### PR TITLE
[14_0_X] Adding GEM onlineDQM trigger primitive plots

### DIFF
--- a/DQM/GEM/interface/GEMDQMBase.h
+++ b/DQM/GEM/interface/GEMDQMBase.h
@@ -557,8 +557,15 @@ protected:
   virtual int ProcessWithMEMap3(BookingHelper &bh, ME3IdsKey key) { return 0; };              // must be overrided
   virtual int ProcessWithMEMap4(BookingHelper &bh, ME4IdsKey key) { return 0; };              // must be overrided
   virtual int ProcessWithMEMap5(BookingHelper &bh, ME5IdsKey key) { return 0; };              // must be overrided
-  virtual int ProcessWithMEMap4WithChamber(BookingHelper &bh, ME4IdsKey key) { return 0; };   // must be overrided
-  virtual int ProcessWithMEMap5WithChamber(BookingHelper &bh, ME5IdsKey key) { return 0; };   // must be overrided
+  /********************/
+  virtual int ProcessWithMEMap2WithChamber(BookingHelper &bh, ME3IdsKey key) { return 0; };
+  /*********************/
+  /********************/
+  virtual int ProcessWithMEMap2WithEtaCh(BookingHelper &bh, ME4IdsKey key) { return 0; };
+  /*********************/
+
+  virtual int ProcessWithMEMap4WithChamber(BookingHelper &bh, ME4IdsKey key) { return 0; };  // must be overrided
+  virtual int ProcessWithMEMap5WithChamber(BookingHelper &bh, ME5IdsKey key) { return 0; };  // must be overrided
 
   int keyToRegion(ME2IdsKey key) { return std::get<0>(key); };
   int keyToRegion(ME3IdsKey key) { return std::get<0>(key); };
@@ -575,6 +582,9 @@ protected:
   int keyToModule(ME5IdsKey key) { return std::get<3>(key); };
   int keyToChamber(ME4IdsKey key) { return std::get<3>(key); };
   int keyToChamber(ME5IdsKey key) { return std::get<4>(key); };
+  /**********/
+  int keyToChamber(ME3IdsKey key) { return std::get<2>(key); };
+  /*************/
   int keyToIEta(ME4IdsKey key) { return std::get<3>(key); };
   int keyToIEta(ME5IdsKey key) { return std::get<4>(key); };
 
@@ -614,6 +624,7 @@ protected:
   inline Float_t restrictAngle(const Float_t fTheta, const Float_t fStart);
   inline std::string getNameDirLayer(ME3IdsKey key3);
   inline std::string getNameDirLayer(ME4IdsKey key4);
+  inline std::string getNameDirChamber(ME4IdsKey key4);
 
   const GEMGeometry *GEMGeometry_;
   edm::ESGetToken<GEMGeometry, MuonGeometryRecord> geomToken_;
@@ -624,6 +635,12 @@ protected:
   std::map<ME2IdsKey, bool> MEMap2Check_;
   std::map<ME3IdsKey, bool> MEMap2WithEtaCheck_;
   std::map<ME3IdsKey, bool> MEMap2AbsReWithEtaCheck_;
+  /************/
+  std::map<ME3IdsKey, bool> MEMap2WithChCheck_;
+  /************/
+  /************/
+  std::map<ME4IdsKey, bool> MEMap2WithEtaChCheck_;
+  /************/
   std::map<ME3IdsKey, bool> MEMap3Check_;
   std::map<ME4IdsKey, bool> MEMap4Check_;
   std::map<ME4IdsKey, bool> MEMap4WithChCheck_;
@@ -744,4 +761,10 @@ inline std::string GEMDQMBase::getNameDirLayer(ME4IdsKey key4) {
   return std::string(Form("GE%i1-%c-L%i", nStation, cRegion, nLayer));
 }
 
+inline std::string GEMDQMBase::getNameDirChamber(ME4IdsKey key4) {
+  auto nStation = keyToStation(key4);
+  char cRegion = (keyToRegion(key4) > 0 ? 'P' : 'M');
+  auto nChamber = keyToChamber(key4);
+  return std::string(Form("GE%i1-%c-Ch%i", nStation, cRegion, nChamber));
+}
 #endif  // DQM_GEM_INTERFACE_GEMDQMBase_h

--- a/DQM/GEM/interface/GEMPadDigiClusterSource.h
+++ b/DQM/GEM/interface/GEMPadDigiClusterSource.h
@@ -1,0 +1,78 @@
+#ifndef DQM_GEM_INTERFACE_GEMPadDigiClusterSource_h
+#define DQM_GEM_INTERFACE_GEMPadDigiClusterSource_h
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+#include "Validation/MuonGEMHits/interface/GEMValidationUtils.h"
+
+#include "DataFormats/GEMDigi/interface/GEMDigiCollection.h"
+#include "DataFormats/GEMDigi/interface/GEMPadDigiCluster.h"
+#include "DataFormats/GEMDigi/interface/GEMPadDigiClusterCollection.h"
+#include "DataFormats/Scalers/interface/LumiScalers.h"
+
+#include "DQM/GEM/interface/GEMDQMBase.h"
+
+#include <string>
+
+//----------------------------------------------------------------------------------------------------
+
+class GEMPadDigiClusterSource : public GEMDQMBase {
+public:
+  explicit GEMPadDigiClusterSource(const edm::ParameterSet& cfg);
+  ~GEMPadDigiClusterSource() override{};
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+protected:
+  void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override{};
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
+  void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
+
+private:
+  int ProcessWithMEMap2WithEta(BookingHelper& bh, ME3IdsKey key) override;
+  int ProcessWithMEMap2(BookingHelper& bh, ME2IdsKey key) override;
+  int ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) override;
+
+  int ProcessWithMEMap2WithChamber(BookingHelper& bh, ME3IdsKey key) override;
+
+  //int ProcessWithMEMap2WithEtaCh(BookingHelper& bh, ME4IdsKey key) override;
+
+  int ProcessWithMEMap4WithChamber(BookingHelper& bh, ME4IdsKey key) override;
+
+  const static int nNumBitDigiOcc_ = 16384;
+
+  edm::EDGetToken tagPadDigiCluster_;
+
+  edm::EDGetTokenT<LumiScalersCollection> lumiScalers_;
+
+  MEMap3Inf mapPadDiffPerCh_;
+  MEMap3Inf mapBXDiffPerCh_;
+  MEMap3Inf mapPadBXDiffPerCh_;
+
+  MEMap4Inf mapPadBXDiffPerEtaCh_;
+  MEMap4Inf mapPadDigiOccPerCh_;
+  MEMap4Inf mapPadBxPerCh_;
+  MEMap4Inf mapPadCLSPerCh_;
+  MEMap4Inf mapPadDiffPerEtaCh_;
+  MEMap4Inf mapBXMidPerCh_;
+  MEMap4Inf mapBXCLSPerCh_;
+  std::string strFolderMain_;
+
+  Int_t nBXMin_, nBXMax_;
+  Int_t nCLSMax_, nClusterSizeBinNum_;
+  Float_t fRadiusMin_;
+  Float_t fRadiusMax_;
+};
+
+#endif  // DQM_GEM_INTERFACE_GEMDigiSource_h

--- a/DQM/GEM/plugins/GEMPadDigiClusterSource.cc
+++ b/DQM/GEM/plugins/GEMPadDigiClusterSource.cc
@@ -1,0 +1,194 @@
+#include "DQM/GEM/interface/GEMPadDigiClusterSource.h"
+
+using namespace std;
+using namespace edm;
+
+GEMPadDigiClusterSource::GEMPadDigiClusterSource(const edm::ParameterSet& cfg) : GEMDQMBase(cfg) {
+  tagPadDigiCluster_ =
+      consumes<GEMPadDigiClusterCollection>(cfg.getParameter<edm::InputTag>("padDigiClusterInputLabel"));
+  lumiScalers_ = consumes<LumiScalersCollection>(
+      cfg.getUntrackedParameter<edm::InputTag>("lumiCollection", edm::InputTag("scalersRawToDigi")));
+  nBXMin_ = cfg.getParameter<int>("bxMin");
+  nBXMax_ = cfg.getParameter<int>("bxMax");
+  nCLSMax_ = cfg.getParameter<int>("clsMax");
+  nClusterSizeBinNum_ = cfg.getParameter<int>("ClusterSizeBinNum");
+}
+
+void GEMPadDigiClusterSource::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("padDigiClusterInputLabel", edm::InputTag("muonCSCDigis", "MuonGEMPadDigiCluster"));
+  desc.addUntracked<std::string>("runType", "online");
+  desc.addUntracked<std::string>("logCategory", "GEMPadDigiClusterSource");
+  desc.add<int>("bxMin", -15);
+  desc.add<int>("bxMax", 15);
+  desc.add<int>("clsMax", 9);
+  desc.add<int>("ClusterSizeBinNum", 9);
+  descriptions.add("GEMPadDigiClusterSource", desc);
+}
+
+void GEMPadDigiClusterSource::bookHistograms(DQMStore::IBooker& ibooker,
+                                             edm::Run const&,
+                                             edm::EventSetup const& iSetup) {
+  initGeometry(iSetup);
+  if (GEMGeometry_ == nullptr)
+    return;
+  loadChambers();
+
+  strFolderMain_ = "GEM/PadDigiCluster";
+
+  fRadiusMin_ = 120.0;
+  fRadiusMax_ = 250.0;
+
+  mapPadBXDiffPerCh_ = MEMap3Inf(this,
+                                 "delta_pad_bx",
+                                 "Difference of Trigger Primitive Pad Number and BX ",
+                                 81,
+                                 -40 - 0.5,
+                                 40 + 0.5,
+                                 21,
+                                 -10 - 0.5,
+                                 10 + 0.5,
+                                 "Lay1 - Lay2 cluster central pad",
+                                 "Lay1 - Lay2 cluster BX");
+  mapPadDiffPerCh_ = MEMap3Inf(this,
+                               "delta_pad",
+                               "Difference of Trigger Primitive Pad Number ",
+                               81,
+                               -40 - 0.5,
+                               40 + 0.5,
+                               "Lay1 - Lay2 cluster central pad");
+  mapBXDiffPerCh_ = MEMap3Inf(
+      this, "delta_bx", "Difference of Trigger Primitive BX ", 21, -10 - 0.5, 10 + 0.5, "Lay1 - Lay2 cluster BX");
+
+  mapBXCLSPerCh_ = MEMap4Inf(this, "bx", " Trigger Primitive Cluster BX ", 14, -0.5, 13.5, "Bunch crossing");
+  mapPadDigiOccPerCh_ =
+      MEMap4Inf(this, "occ", "Trigger Primitive Occupancy ", 1, -0.5, 1.5, 1, 0.5, 1.5, "Pad number", "i#eta");
+  mapPadBxPerCh_ = MEMap4Inf(this,
+                             "pad",
+                             "Trigger Primitive Pad Number and BX ",
+                             1536,
+                             0.5,
+                             1536.5,
+                             15,
+                             -0.5,
+                             15 - 0.5,
+                             "Pad number",
+                             "Cluster BX");
+  mapPadCLSPerCh_ =
+      MEMap4Inf(this, "cls", "Trigger Primitive Cluster Size ", 9, 0.5, 9 + 0.5, 1, 0.5, 1.5, "Cluster Size", "i#eta");
+
+  ibooker.cd();
+  ibooker.setCurrentFolder(strFolderMain_);
+  GenerateMEPerChamber(ibooker);
+}
+
+int GEMPadDigiClusterSource::ProcessWithMEMap2(BookingHelper& bh, ME2IdsKey key) { return 0; }
+
+int GEMPadDigiClusterSource::ProcessWithMEMap2WithEta(BookingHelper& bh, ME3IdsKey key) { return 0; }
+
+int GEMPadDigiClusterSource::ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) { return 0; }
+int GEMPadDigiClusterSource::ProcessWithMEMap2WithChamber(BookingHelper& bh, ME3IdsKey key) {
+  bh.getBooker()->setCurrentFolder(strFolderMain_ + "/pad_bx_difference");
+  mapPadBXDiffPerCh_.bookND(bh, key);
+  bh.getBooker()->setCurrentFolder(strFolderMain_);
+
+  bh.getBooker()->setCurrentFolder(strFolderMain_ + "/pad_difference");
+  mapPadDiffPerCh_.bookND(bh, key);
+  bh.getBooker()->setCurrentFolder(strFolderMain_);
+
+  bh.getBooker()->setCurrentFolder(strFolderMain_ + "/bx_difference");
+  mapBXDiffPerCh_.bookND(bh, key);
+  bh.getBooker()->setCurrentFolder(strFolderMain_);
+
+  return 0;
+}
+
+int GEMPadDigiClusterSource::ProcessWithMEMap4WithChamber(BookingHelper& bh, ME4IdsKey key) {
+  ME3IdsKey key3 = key4Tokey3(key);
+  MEStationInfo& stationInfo = mapStationInfo_[key3];
+
+  bh.getBooker()->setCurrentFolder(strFolderMain_ + "/occupancy_" + getNameDirLayer(key3));
+
+  int nNumVFATPerEta = stationInfo.nMaxVFAT_ / stationInfo.nNumEtaPartitions_;
+  int nNumCh = stationInfo.nNumDigi_;
+
+  mapPadDigiOccPerCh_.SetBinConfX(nNumCh * nNumVFATPerEta / 2, -0.5);
+  mapPadDigiOccPerCh_.SetBinConfY(stationInfo.nNumEtaPartitions_);
+  mapPadDigiOccPerCh_.bookND(bh, key);
+  mapPadDigiOccPerCh_.SetLabelForIEta(key, 2);
+
+  bh.getBooker()->setCurrentFolder(strFolderMain_ + "/pads in time_" + getNameDirLayer(key3));
+  mapPadBxPerCh_.SetBinConfX(nNumCh * nNumVFATPerEta * stationInfo.nNumEtaPartitions_ / 2, -0.5);
+  mapPadBxPerCh_.bookND(bh, key);
+
+  bh.getBooker()->setCurrentFolder(strFolderMain_ + "/cluster size_" + getNameDirLayer(key3));
+
+  mapPadCLSPerCh_.SetBinConfY(stationInfo.nNumEtaPartitions_);
+  mapPadCLSPerCh_.bookND(bh, key);
+  mapPadCLSPerCh_.SetLabelForIEta(key, 2);
+
+  bh.getBooker()->setCurrentFolder(strFolderMain_ + "/bx_cluster_" + getNameDirLayer(key3));
+  mapBXCLSPerCh_.bookND(bh, key);
+  bh.getBooker()->setCurrentFolder(strFolderMain_);
+  return 0;
+}
+
+void GEMPadDigiClusterSource::analyze(edm::Event const& event, edm::EventSetup const& eventSetup) {
+  edm::Handle<GEMPadDigiClusterCollection> gemPadDigiClusters;
+  event.getByToken(this->tagPadDigiCluster_, gemPadDigiClusters);
+  edm::Handle<LumiScalersCollection> lumiScalers;
+  event.getByToken(lumiScalers_, lumiScalers);
+
+  int med_pad1, med_pad2;
+
+  for (auto it = gemPadDigiClusters->begin(); it != gemPadDigiClusters->end(); it++) {
+    auto range = gemPadDigiClusters->get((*it).first);
+
+    for (auto cluster = range.first; cluster != range.second; cluster++) {
+      if (cluster->isValid()) {
+        ME4IdsKey key4Ch{
+            ((*it).first).region(), ((*it).first).station(), ((*it).first).layer(), ((*it).first).chamber()};
+        ME3IdsKey key3Ch{((*it).first).region(), ((*it).first).station(), ((*it).first).chamber()};
+
+        //Plot the bx of each cluster.
+        mapBXCLSPerCh_.Fill(key4Ch, cluster->bx());
+
+        //Plot the size of clusters for each chamber and layer
+        Int_t nCLS = cluster->pads().size();
+        Int_t nCLSCutOff = std::min(nCLS, nCLSMax_);
+        mapPadCLSPerCh_.Fill(key4Ch, nCLSCutOff, ((*it).first).roll());
+
+        //Plot of pad and bx diff of two layers per chamer.
+        med_pad1 = floor((cluster->pads().front() + cluster->pads().front() + cluster->pads().size() - 1) / 2);
+        for (auto it2 = gemPadDigiClusters->begin(); it2 != gemPadDigiClusters->end(); it2++) {
+          auto range2 = gemPadDigiClusters->get((*it2).first);
+
+          for (auto cluster2 = range2.first; cluster2 != range2.second; cluster2++) {
+            if (cluster2->isValid()) {
+              med_pad2 = floor((cluster2->pads().front() + cluster2->pads().front() + cluster2->pads().size() - 1) / 2);
+
+              if (((*it).first).chamber() == ((*it2).first).chamber() &&
+                  ((*it).first).station() == ((*it2).first).station() &&
+                  ((*it).first).region() == ((*it2).first).region() && ((*it).first).layer() == 1 &&
+                  ((*it2).first).layer() == 2) {
+                if (abs(med_pad1 - med_pad2) <= 40 && abs(((*it).first).roll() - ((*it2).first).roll()) <= 1) {
+                  mapPadBXDiffPerCh_.Fill(key3Ch, med_pad1 - med_pad2, cluster->bx() - cluster2->bx());
+                  mapPadDiffPerCh_.Fill(key3Ch, med_pad1 - med_pad2);
+                  mapBXDiffPerCh_.Fill(key3Ch, cluster->bx() - cluster2->bx());
+                }
+              }
+            }
+          }
+        }
+
+        for (auto pad = cluster->pads().front(); pad < (cluster->pads().front() + cluster->pads().size()); pad++) {
+          //Plot of pad and bx for each chamber and layer
+          mapPadDigiOccPerCh_.Fill(key4Ch, pad, ((*it).first).roll());
+          mapPadBxPerCh_.Fill(key4Ch, pad + (192 * (8 - ((*it).first).roll())), cluster->bx());
+        }
+      }
+    }
+  }
+}
+
+DEFINE_FWK_MODULE(GEMPadDigiClusterSource);

--- a/DQM/GEM/python/GEMDQM_cff.py
+++ b/DQM/GEM/python/GEMDQM_cff.py
@@ -4,9 +4,11 @@ from DQM.GEM.GEMDigiSource_cfi import *
 from DQM.GEM.GEMRecHitSource_cfi import *
 from DQM.GEM.GEMDAQStatusSource_cfi import *
 from DQM.GEM.GEMDQMHarvester_cfi import *
+from DQM.GEM.GEMPadDigiClusterSource_cfi import *
 
 GEMDQM = cms.Sequence(
   GEMDigiSource
+  *GEMPadDigiClusterSource
   *GEMRecHitSource
   *GEMDAQStatusSource
   +GEMDQMHarvester

--- a/DQM/GEM/src/GEMDQMBase.cc
+++ b/DQM/GEM/src/GEMDQMBase.cc
@@ -199,11 +199,19 @@ int GEMDQMBase::GenerateMEPerChamber(DQMStore::IBooker& ibooker) {
   MEMap5Check_.clear();
   MEMap2WithEtaCheck_.clear();
   MEMap2AbsReWithEtaCheck_.clear();
+
+  MEMap2WithChCheck_.clear();
+
   MEMap4WithChCheck_.clear();
   MEMap5WithChCheck_.clear();
+
+  MEMap2WithEtaChCheck_.clear();
   for (auto gid : listChamberId_) {
     ME2IdsKey key2{gid.region(), gid.station()};
     ME3IdsKey key3{gid.region(), gid.station(), gid.layer()};
+    /*******************/
+    ME3IdsKey key2WithChamber{gid.region(), gid.station(), gid.chamber()};
+    /******************/
     const auto num_mod = mapStationInfo_[key3].nNumModules_;
     for (int module_number = 1; module_number <= num_mod; module_number++) {
       ME4IdsKey key4{gid.region(), gid.station(), gid.layer(), module_number};
@@ -215,6 +223,16 @@ int GEMDQMBase::GenerateMEPerChamber(DQMStore::IBooker& ibooker) {
         BookingHelper bh2(ibooker, strSuffixName, strSuffixTitle);
         ProcessWithMEMap2(bh2, key2);
         MEMap2Check_[key2] = true;
+      }
+      if (!MEMap2WithChCheck_[key2WithChamber]) {
+        Int_t nCh = gid.chamber();
+        //Int_t nLa = gid.layer();
+        char cLS = (nCh % 2 == 0 ? 'L' : 'S');  // FIXME: Is it general enough?
+        auto strSuffixName = GEMUtils::getSuffixName(key2) + Form("-%02i-%c", nCh, cLS);
+        auto strSuffixTitle = GEMUtils::getSuffixTitle(key2) + Form("-%02i-%c", nCh, cLS);
+        BookingHelper bh2Ch(ibooker, strSuffixName, strSuffixTitle);
+        ProcessWithMEMap2WithChamber(bh2Ch, key2WithChamber);
+        MEMap2WithChCheck_[key2WithChamber] = true;
       }
       if (!MEMap3Check_[key3]) {
         auto strSuffixName = GEMUtils::getSuffixName(key3);
@@ -261,6 +279,9 @@ int GEMDQMBase::GenerateMEPerChamber(DQMStore::IBooker& ibooker) {
       for (auto iEta : mapEtaPartition_[gid]) {
         GEMDetId eId = iEta->id();
         ME5IdsKey key5{gid.region(), gid.station(), gid.layer(), module_number, eId.ieta()};
+        /*******************/
+        ME4IdsKey key2WithEtaCh{gid.region(), gid.station(), eId.ieta(), gid.chamber()};
+        /******************/
         ME3IdsKey key2WithEta{gid.region(), gid.station(), eId.ieta()};
         ME3IdsKey key2AbsReWithEta{std::abs(gid.region()), gid.station(), eId.ieta()};
         if (!MEMap5Check_[key5]) {
@@ -269,6 +290,16 @@ int GEMDQMBase::GenerateMEPerChamber(DQMStore::IBooker& ibooker) {
           BookingHelper bh5(ibooker, strSuffixName, strSuffixTitle);
           ProcessWithMEMap5(bh5, key5);
           MEMap5Check_[key5] = true;
+        }
+        if (!MEMap2WithEtaChCheck_[key2WithEtaCh]) {
+          Int_t nCh = gid.chamber();
+          //Int_t nLa = gid.layer();
+          char cLS = (nCh % 2 == 0 ? 'L' : 'S');
+          auto strSuffixName = GEMUtils::getSuffixName(key2) + Form("-%02i-%c-E%02i", nCh, cLS, eId.ieta());
+          auto strSuffixTitle = GEMUtils::getSuffixTitle(key2) + Form("-%02i-%c-E%02i", nCh, cLS, eId.ieta());
+          BookingHelper bh4(ibooker, strSuffixName, strSuffixTitle);
+          ProcessWithMEMap2WithEtaCh(bh4, key2WithEtaCh);
+          MEMap2WithEtaChCheck_[key2WithEtaCh] = true;
         }
         if (!MEMap2WithEtaCheck_[key2WithEta]) {
           auto strSuffixName = GEMUtils::getSuffixName(key2) + Form("-E%02i", eId.ieta());

--- a/DQM/Integration/python/clients/gem_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/gem_dqm_sourceclient-live_cfg.py
@@ -27,6 +27,7 @@ process.dqmSaverPB.runNumber = options.runNumber
 
 process.load("DQMServices.Components.DQMProvInfo_cfi")
 
+
 process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
 process.load("Configuration.StandardSequences.Reconstruction_cff")
 process.load('RecoLocalMuon.GEMCSCSegment.gemcscSegments_cff')
@@ -46,6 +47,7 @@ process.gemRecHits.ge21Off = cms.bool(False)
 process.GEMDigiSource.runType = "online"
 process.GEMRecHitSource.runType = "online"
 process.GEMDAQStatusSource.runType = "online"
+process.GEMPadDigiClusterSource.runType = "online"
 
 # from csc_dqm_sourceclient-live_cfg.py
 process.CSCGeometryESModule.useGangedStripsInME1a = False


### PR DESCRIPTION
#### PR description:

In this PR, GEM onlineDQM plots for trigger primitive have been implemented.

This is a backport of #45489 to 14_0_X.

#### PR validation:

Tests are done with cmsRun $CMSSW_BASE/src/DQM/Integration/python/clients/gem_dqm_sourceclient-live_cfg.py unitTest=True runNumber=379866 dataset=/ExpressPhysics/Run2024C-Express-v1/FEVT minLumi=20 maxLumi=30 eventsPerLumi=50000 and runTheMatrix.py -l limited -i all --ibeos since it makes effects on P5.

@jshlee @watson-ij @quark2 @hcai0520 @giovanni-mocellin