### PR TITLE
Add L1Ntuple customisation for MiniAOD

### DIFF
--- a/L1Trigger/L1TNtuples/python/L1NtupleMINI_cff.py
+++ b/L1Trigger/L1TNtuples/python/L1NtupleMINI_cff.py
@@ -1,0 +1,20 @@
+import FWCore.ParameterSet.Config as cms
+
+from L1Trigger.L1TNtuples.l1EventTree_cfi import *
+from L1Trigger.L1TNtuples.l1UpgradeTree_cfi import *
+from L1Trigger.L1TNtuples.l1uGTTree_cfi import *
+from L1Trigger.L1TNtuples.l1uGTTestcrateTree_cfi import *
+
+# use L1 objects from unpacked uGT output
+l1UpgradeTree.egToken = cms.untracked.InputTag("caloStage2Digis","EGamma")
+l1UpgradeTree.tauTokens = cms.untracked.VInputTag(cms.InputTag("caloStage2Digis","Tau"))
+l1UpgradeTree.jetToken = cms.untracked.InputTag("caloStage2Digis","Jet")
+l1UpgradeTree.muonToken = cms.untracked.InputTag("gmtStage2Digis","Muon")
+l1UpgradeTree.sumToken = cms.untracked.InputTag("caloStage2Digis","EtSum")
+
+L1NtupleMINI = cms.Sequence(
+  l1EventTree
+  +l1UpgradeTree
+#   +l1uGTTestcrateTree
+  +l1uGTTree
+)

--- a/L1Trigger/L1TNtuples/python/customiseL1Ntuple.py
+++ b/L1Trigger/L1TNtuples/python/customiseL1Ntuple.py
@@ -99,6 +99,19 @@ def L1NtupleNanoDST(process):
 
     return process
 
+def L1NtupleMINI(process):
+
+    L1NtupleTFileOut(process)
+
+    process.load('L1Trigger.L1TNtuples.L1NtupleMINI_cff')
+    process.l1ntuplenano = cms.Path(
+        process.L1NtupleMINI
+    )
+    process.schedule.append(process.l1ntuplenano)
+
+    return process
+
+
 def L1NtupleNANO(process):
 
     L1NtupleTFileOut(process)


### PR DESCRIPTION
#### PR description:

This adds a customisation for the L1Ntupler to run on MiniAOD files, similar to this PR https://github.com/cms-sw/cmssw/pull/45440 for `NanoDST/L1Accept`.

Since MiniAOD stores only the unpacked objects, only the corresponding trees are created:
```
BXVector<GlobalAlgBlk>                "gtStage2Digis"             ""                "RECO"    
BXVector<GlobalExtBlk>                "gtStage2Digis"             ""                "RECO"    
BXVector<GlobalExtBlk>                "simGtExtUnprefireable"     ""                "RECO"    
BXVector<l1t::EGamma>                 "caloStage2Digis"           "EGamma"          "RECO"    
BXVector<l1t::EtSum>                  "caloStage2Digis"           "EtSum"           "RECO"    
BXVector<l1t::Jet>                    "caloStage2Digis"           "Jet"             "RECO"    
BXVector<l1t::Muon>                   "gmtStage2Digis"            "Muon"            "RECO"    
BXVector<l1t::Tau>                    "caloStage2Digis"           "Tau"             "RECO"    
```


#### PR validation:

Used this cmsDriver in `CMSSW_14_1_0_pre5`:

```
cmsDriver.py l1Ntuple -s NANO,USER:L1Trigger/L1TNtuples/L1NtupleMINI_cff.L1NtupleMINI \ 
-n 10000 --eventcontent NANOAOD --era=Run3 --data --conditions=140X_dataRun3_Prompt_v2 \
--customise=L1Trigger/L1TNtuples/customiseL1Ntuple.L1NtupleMINI,PhysicsTools/NanoAOD/l1trig_cff.nanoL1TrigObjCustomizeFull --filein file:/eos/cms/tier0/store/data/Run2024F/JetMET1/MINIAOD/PromptReco-v1/000/383/447/00000/0326688d-c840-43a9-96a7-98ff241fb155.root
```

Which produced L1 menu ntuples and Nano with the same content of L1 objects.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

No backport planned.

FYI @caruta @eyigitba @slaurila @RobertJWard
