### PR TITLE
Mark dictionaries defined in OnlineDB/EcalCondDB as transient

### DIFF
--- a/OnlineDB/EcalCondDB/src/classes_def.xml
+++ b/OnlineDB/EcalCondDB/src/classes_def.xml
@@ -1,5 +1,6 @@
+
 <lcgdict>
-  <class name="RunIOV"/>
-  <class name="RunTag"/>
-  <class name="EcalCondDBInterface"/>
+  <class name="RunIOV" persistent="false"/>
+  <class name="RunTag" persistent="false"/>
+  <class name="EcalCondDBInterface" persistent="false"/>
 </lcgdict>


### PR DESCRIPTION
#### PR description:

The `OnlineDB/EcalCondDB` package is not a data format package, and from the history (https://github.com/cms-sw/cmssw/pull/29240) it seems the dictionaries were added in order to use them in PyROOT scripts. Found in https://github.com/cms-sw/cmssw/pull/45423#issuecomment-2226416814

Resolves https://github.com/cms-sw/framework-team/issues/960

#### PR validation:

Code compiles, and the to-be-added `edmDumpClassVersion` succeeds to process the `classes_def.xml`.