### PR TITLE
Add D98 DD4hep workflow for monitoring the instability

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_2026.py
+++ b/Configuration/PyReleaseValidation/python/relval_2026.py
@@ -62,6 +62,7 @@ numWFIB.extend([prefixDet+234.999])  #premixing combined stage1+stage2 ttbar+PU5
 numWFIB.extend([prefixDet+234.21])   #prodlike PU
 numWFIB.extend([prefixDet+234.9921]) #prodlike premix stage1+stage2
 numWFIB.extend([prefixDet+234.114])  #PU, with 10% OT inefficiency
-
+#
+numWFIB.extend([24834.911]) #D98 XML, to monitor instability of DD4hep
 for numWF in numWFIB:
     workflows[numWF] = _upgrade_workflows[numWF]

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -91,7 +91,7 @@ if __name__ == '__main__':
 
                     # Phase2
                     29634.0,    # RelValTTbar_14TeV                     phase2_realistic_T33        Extended2026D110         (Phase-2 baseline)
-                    24834.911   # Previous DD4hep baseline for monitoring the stability of DD4hep workflow
+                    24834.911,  # Previous DD4hep baseline for monitoring the stability of DD4hep workflow
                     29634.911,  # TTbar_14TeV_TuneCP5                   phase2_realistic_T33        DD4hepExtended2026D110   DD4Hep (HLLHC14TeV BeamSpot) 
                     29834.999,  # RelValTTbar_14TeV (PREMIX)            phase2_realistic_T33        Extended2026D110         AVE_50_BX_25ns_m3p3     
                     29696.0,    # RelValCloseByPGun_CE_E_Front_120um    phase2_realistic_T33        Extended2026D110

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -90,7 +90,8 @@ if __name__ == '__main__':
                     2500.4,     # RelValTTbar_14TeV             NanoAOD from existing MINI
 
                     # Phase2
-                    29634.0,    # RelValTTbar_14TeV                     phase2_realistic_T33        Extended2026D110         (Phase-2 baseline)   
+                    29634.0,    # RelValTTbar_14TeV                     phase2_realistic_T33        Extended2026D110         (Phase-2 baseline)
+                    24834.911   # Previous DD4hep baseline for monitoring the stability of DD4hep workflow
                     29634.911,  # TTbar_14TeV_TuneCP5                   phase2_realistic_T33        DD4hepExtended2026D110   DD4Hep (HLLHC14TeV BeamSpot) 
                     29834.999,  # RelValTTbar_14TeV (PREMIX)            phase2_realistic_T33        Extended2026D110         AVE_50_BX_25ns_m3p3     
                     29696.0,    # RelValCloseByPGun_CE_E_Front_120um    phase2_realistic_T33        Extended2026D110


### PR DESCRIPTION
#### PR description:
Try to get some clue on instability of Phase-2 DD4hep workflow with previous baseline.

#### PR validation:
Job runs.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
No need of backport.