### PR TITLE
Fixing track HT for phase2

### DIFF
--- a/L1Trigger/L1TTrackMatch/plugins/L1TkHTMissEmulatorProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TkHTMissEmulatorProducer.cc
@@ -9,7 +9,6 @@
 // Update: George Karathanasis, CU Boulder
 //         2/4/2024
 
-
 // system include files
 #include <memory>
 #include <numeric>

--- a/L1Trigger/L1TTrackMatch/plugins/L1TkHTMissEmulatorProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TkHTMissEmulatorProducer.cc
@@ -6,6 +6,9 @@
 
 // Original Author:  Hardik Routray
 //         Created:  Mon, 11 Oct 2021
+// Update: George Karathanasis, CU Boulder
+//         2/4/2024
+
 
 // system include files
 #include <memory>
@@ -138,6 +141,8 @@ void L1TkHTMissEmulatorProducer::produce(edm::Event& iEvent, const edm::EventSet
     //float tmp_jet_et_ = jetIter->pt();  // FIXME Get Et from the emulated jets
     float tmp_jet_pt_ = jetIter->pt();
 
+    bool tmp_jet_isDisplaced_ = jetIter->dispflag();
+
     l1tmhtemu::pt_t tmp_jet_pt =
         l1tmhtemu::digitizeSignedValue<l1tmhtemu::pt_t>(jetIter->pt(), l1tmhtemu::kInternalPtWidth, l1tmhtemu::kStepPt);
     l1tmhtemu::eta_t tmp_jet_eta = l1tmhtemu::digitizeSignedValue<l1tmhtemu::eta_t>(
@@ -203,6 +208,8 @@ void L1TkHTMissEmulatorProducer::produce(edm::Event& iEvent, const edm::EventSet
     if (tmp_jet_nt < minNtracksLowPt_ && tmp_jet_pt > 200)
       continue;
     if (tmp_jet_nt < minNtracksHighPt_ && tmp_jet_pt > 400)
+      continue;
+    if (displaced_ && !tmp_jet_isDisplaced_)
       continue;
 
     if (debug_) {


### PR DESCRIPTION
Hello,

During the review we saw a bug in the HT calculation for the phase 2 l1t  gtt. We fixed it in the l1t offline and now I am propagating it to the central. Is just a flag to take displaced tracks when we want the displaced HT

Best,
George