### PR TITLE
Remove redundant dictionary definition in DataFormats/HGCRecHit

### DIFF
--- a/DataFormats/HGCRecHit/src/classes_def.xml
+++ b/DataFormats/HGCRecHit/src/classes_def.xml
@@ -23,7 +23,6 @@
   <class name="edm::RefProd<edm::SortedCollection<HGCRecHit,edm::StrictWeakOrdering<HGCRecHit> > >"/>
 
   <class name="edm::Wrapper<std::vector<HGCRecHit>>"/>
-  <class name="edm::Wrapper<HGCRecHitCollection>"/>
  
   <class name="edm::DetSet<HGCRecHit>"/>
   <class name="edm::DetSetVector<HGCRecHit>"/>


### PR DESCRIPTION
#### PR description:

The equivalent `<class name="edm::SortedCollection<HGCRecHit,edm::StrictWeakOrdering<HGCRecHit> >"/>` is already defined above. This duplication was (I'd say accidentally) found in https://github.com/cms-sw/cmssw/pull/45423#issuecomment-2226416814 .

Resolves https://github.com/cms-sw/framework-team/issues/962

#### PR validation:

Code compiles, and the to-be-added `edmDumpClassVersion` succeeds to process the `classes_def.xml` files.