### PR TITLE
Remove duplicate dictionary definition in DataFormats/L1Trigger

### DIFF
--- a/DataFormats/L1Trigger/src/classes_def.xml
+++ b/DataFormats/L1Trigger/src/classes_def.xml
@@ -55,7 +55,6 @@
   </class>
   <class name="std::vector<l1t::TkTripletWord>"/>
   <class name="edm::Wrapper<std::vector<l1t::TkTripletWord> >"/>
-  <class name="edm::Wrapper<l1t::TkTripletWordCollection>"/>
 
   <class name="l1t::EGamma" ClassVersion="14">
    <version ClassVersion="14" checksum="1235149790"/>


### PR DESCRIPTION

#### PR description:

The `l1t::TkTripletWordCollection` is a type alias for `std::vector<l1t::TkTripletWord>` whose dictionary is defined two lines above. Found with https://github.com/cms-sw/cmssw/pull/45423#issuecomment-2226416814

Resolves https://github.com/cms-sw/framework-team/issues/964

#### PR validation:

Code compiles, and the to-be-added `edmDumpClassVersion` succeeds to process the `classes_def.xml` files.