### PR TITLE
update `hcalgpu` online-DQM client (post HCAL-Alpaka port at HLT)

### DIFF
--- a/DQM/Integration/python/clients/hcalgpu_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcalgpu_dqm_sourceclient-live_cfg.py
@@ -108,8 +108,8 @@ process.load('DQM.HcalTasks.HcalQualityTests_cfi')
 #	New Style Modules
 #-------------------------------------
 oldsubsystem = subsystem
-process.hcalGPUComparisonTask.tagHBHE_ref = "hltHbherecoLegacy"
-process.hcalGPUComparisonTask.tagHBHE_target = "hltHbherecoFromGPU"
+process.hcalGPUComparisonTask.tagHBHE_ref = "hltHbherecoSerialSync"
+process.hcalGPUComparisonTask.tagHBHE_target = "hltHbhereco"
 process.hcalGPUComparisonTask.runkeyVal = runType
 process.hcalGPUComparisonTask.runkeyName = runTypeName
 


### PR DESCRIPTION
#### PR description:

This PR updates the names of the collections consumed in the `hcalgpu` online-DQM client according to the content of the latest Run-3 HLT menus, which include the port of the HCAL local reconstruction to Alpaka (see [CMSHLT-3281](https://its.cern.ch/jira/browse/CMSHLT-3281) and links therein). These HLT updates are set to be deployed online next week (Week-31 of 2024); when that happens, the `hcalgpu` client should be updated accordingly, with the change in this PR.

#### PR validation:

None.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

`CMSSW_14_0_X`

Change to one online-DQM client to adapt to the latest HLT menus for 2024 data-taking.
