### PR TITLE
[14_0_X] Mark `ScopedContextAcquire` destructor as `noexcept(false)`

### DIFF
--- a/HeterogeneousCore/CUDACore/interface/ScopedContext.h
+++ b/HeterogeneousCore/CUDACore/interface/ScopedContext.h
@@ -120,7 +120,7 @@ namespace cms {
                                     ContextState& state)
           : ScopedContextGetterBase(data), holderHelper_{std::move(waitingTaskHolder)}, contextState_{&state} {}
 
-      ~ScopedContextAcquire();
+      ~ScopedContextAcquire() noexcept(false);
 
       template <typename F>
       void pushNextTask(F&& f) {

--- a/HeterogeneousCore/CUDACore/src/ScopedContext.cc
+++ b/HeterogeneousCore/CUDACore/src/ScopedContext.cc
@@ -68,7 +68,7 @@ namespace cms::cuda {
 
   ////////////////////
 
-  ScopedContextAcquire::~ScopedContextAcquire() {
+  ScopedContextAcquire::~ScopedContextAcquire() noexcept(false) {
     holderHelper_.enqueueCallback(device(), stream());
     if (contextState_) {
       contextState_->set(device(), streamPtr());


### PR DESCRIPTION
#### PR description:

This destructor can throw an exception that is wanted to be propagated upwards in the stack, even with the risk of double exceptions (and those leading to `std::terminate()`). See https://github.com/cms-sw/cmssw/issues/45555#issuecomment-2251058216 for more context.

#### PR validation:

None beyond https://github.com/cms-sw/cmssw/pull/45560

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of https://github.com/cms-sw/cmssw/pull/45560