### PR TITLE
Move `pair<LocalVector,LocalVector> and pair<LocalPoint,LocalPoint>` dictionaries to `DataFormats/GeometryVector`

### DIFF
--- a/AnalysisDataFormats/TrackInfo/src/classes_def.xml
+++ b/AnalysisDataFormats/TrackInfo/src/classes_def.xml
@@ -1,6 +1,4 @@
 <lcgdict>
-  <class name="std::pair<LocalVector,LocalVector>"/>
-  <class name="std::pair<LocalPoint,LocalPoint>"/>
   <class name="reco::TrackingRecHitInfo" ClassVersion="11">
    <version ClassVersion="11" checksum="803167075"/>
    <version ClassVersion="10" checksum="2470257581"/>

--- a/DataFormats/GeometryVector/src/classes.h
+++ b/DataFormats/GeometryVector/src/classes.h
@@ -1,15 +1,9 @@
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/GeometryVector/interface/Phi.h"
-namespace {
-  Geom::Phi<double, Geom::MinusPiToPi> dummy;
-  Geom::Phi<float, Geom::MinusPiToPi> dummy1;
-}  // namespace
-
 #include "DataFormats/GeometryVector/interface/Basic3DVector.h"
-//
-
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
+#include "DataFormats/GeometryVector/interface/LocalVector.h"
 #include "DataFormats/GeometryVector/interface/Point2DBase.h"
 #include "DataFormats/GeometryVector/interface/Point3DBase.h"
 #include "DataFormats/GeometryVector/interface/LocalTag.h"

--- a/DataFormats/GeometryVector/src/classes_def.xml
+++ b/DataFormats/GeometryVector/src/classes_def.xml
@@ -126,4 +126,7 @@
    <version ClassVersion="11" checksum="2722543385"/>
    <version ClassVersion="10" checksum="3537126144"/>
   </class>
+
+  <class name="std::pair<Vector3DBase<float,LocalTag>,Vector3DBase<float,LocalTag>>"/>
+  <class name="std::pair<Point3DBase<float,LocalTag>,Point3DBase<float,LocalTag>>"/>
 </lcgdict>


### PR DESCRIPTION
#### PR description:

`DataFormats/GeometryVector` is the right place as it defines the `Vector3DBase` and `Point3DBase` class templates. Found with https://github.com/cms-sw/cmssw/pull/45423#issuecomment-2226416814.

Resolves https://github.com/cms-sw/framework-team/issues/967

#### PR validation:

Code compiles, and the to-be-added `edmDumpClassVersion` succeeds to process the `classes_def.xml` files.
