### PR TITLE
Add LogWarning in OnlineBeamSpotESProducer::checkSingleBS

### DIFF
--- a/RecoVertex/BeamSpotProducer/plugins/BeamSpotOnlineProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/BeamSpotOnlineProducer.cc
@@ -105,7 +105,7 @@ void BeamSpotOnlineProducer::produce(Event& iEvent, const EventSetup& iSetup) {
     auto const& spotDB = iSetup.getData(beamTransientToken_);
     if (spotDB.beamType() != 2) {
       if (shoutMODE && beamTransientRcdESWatcher_.check(iSetup)) {
-        edm::LogWarning("BeamSpotFromDB")
+        edm::LogWarning("BeamSpotOnlineProducer")
             << "Online Beam Spot producer falls back to DB value because the ESProducer returned a fake beamspot ";
       }
       fallBackToDB = true;
@@ -181,7 +181,7 @@ void BeamSpotOnlineProducer::produce(Event& iEvent, const EventSetup& iSetup) {
       if (spotOnline.x() == 0 && spotOnline.y() == 0 && spotOnline.z() == 0 && spotOnline.width_x() == 0 &&
           spotOnline.width_y() == 0) {
         if (shoutMODE) {
-          edm::LogWarning("BeamSpotFromDB")
+          edm::LogWarning("BeamSpotOnlineProducer")
               << "Online Beam Spot producer falls back to DB value because the scaler values are zero ";
         }
         fallBackToDB = true;
@@ -189,7 +189,7 @@ void BeamSpotOnlineProducer::produce(Event& iEvent, const EventSetup& iSetup) {
       double r2 = spotOnline.x() * spotOnline.x() + spotOnline.y() * spotOnline.y();
       if (std::abs(spotOnline.z()) >= theMaxZ || r2 >= theMaxR2) {
         if (shoutMODE) {
-          edm::LogError("BeamSpotFromDB")
+          edm::LogError("BeamSpotOnlineProducer")
               << "Online Beam Spot producer falls back to DB value because the scaler values are too big to be true :"
               << spotOnline.x() << " " << spotOnline.y() << " " << spotOnline.z();
         }

--- a/RecoVertex/BeamSpotProducer/plugins/OnlineBeamSpotESProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/OnlineBeamSpotESProducer.cc
@@ -145,6 +145,8 @@ const BeamSpotOnlineObjects* OnlineBeamSpotESProducer::checkSingleBS(const BeamS
   if (diffBStime1 < limitTime && isGoodBS(bs1)) {
     return bs1;
   } else {
+    edm::LogWarning("OnlineBeamSpotESProducer") << "Defaulting to fake (fallback to PCL) because the only payload "
+                                                   "is either too old or does not pass the fit sanity checks";
     return nullptr;
   }
 }
@@ -179,7 +181,7 @@ std::shared_ptr<const BeamSpotObjects> OnlineBeamSpotESProducer::produce(const B
     return std::shared_ptr<const BeamSpotObjects>(best, edm::do_nothing_deleter());
   }
   edm::LogWarning("OnlineBeamSpotESProducer")
-      << "None of the Online BeamSpots in the ES is suitable, \n returning a fake one(fallback to PCL).";
+      << "None of the Online BeamSpots in the ES is suitable, \n returning a fake one (fallback to PCL).";
   return std::shared_ptr<const BeamSpotObjects>(&fakeBS_, edm::do_nothing_deleter());
 }
 


### PR DESCRIPTION
#### PR description:
Title says it all.
Minor improvement to add a` LogWarning` (which was forgotten in the past implementation of the class) in case we fall back to PCL in the `checkSingleBS` method of `OnlineBeamSpotESProducer`.

#### PR validation:
Code compiles.

#### Backport:
Not a backport, no backport needed.