### PR TITLE
Fix ClassVersion unit test

### DIFF
--- a/FWCore/Reflection/test/run_checkClassVersion.sh
+++ b/FWCore/Reflection/test/run_checkClassVersion.sh
@@ -3,7 +3,7 @@
 function die { echo Failure $1: status $2 ; exit $2 ; }
 
 XMLPATH=${SCRAM_TEST_PATH}/stubs
-LIBFILE=${LOCALTOP}/lib/${SCRAM_ARCH}/libFWCoreReflectionTestObjects.so
+LIBFILE=libFWCoreReflectionTestObjects.so
 
 edmCheckClassVersion -l ${LIBFILE} -x ${XMLPATH}/classes_def.xml || die "edmCheckClassVersion failed" $?
 

--- a/FWCore/Reflection/test/run_dumpClassVersion.sh
+++ b/FWCore/Reflection/test/run_dumpClassVersion.sh
@@ -3,7 +3,7 @@
 function die { echo Failure $1: status $2 ; exit $2 ; }
 
 XMLPATH=${SCRAM_TEST_PATH}/stubs
-LIBFILE=${LOCALTOP}/lib/${SCRAM_ARCH}/libFWCoreReflectionTestObjects.so
+LIBFILE=libFWCoreReflectionTestObjects.so
 
 edmDumpClassVersion -l ${LIBFILE} -x ${XMLPATH}/classes_def.xml -o dump.json || die "edmDumpClassVersion failed" $?
 diff -u ${SCRAM_TEST_PATH}/dumpClassVersion_reference.json dump.json || die "Unexpected class version dump" $?


### PR DESCRIPTION
Instead of passing full path of `libFWCoreReflectionTestObjects.so` let root load it from LD_LIBRARY_PATH.  This will also allow ROOT to pick the correct multi-arch `libFWCoreReflectionTestObjects.so` library.

This should fix the two failing ClassVersion tests. 