### PR TITLE
[14_0_X] Reject badly measured tracks with very high values of `qoverpError` before trying to reconstruct displaced vertices

### DIFF
--- a/RecoParticleFlow/PFTracking/interface/PFDisplacedVertexCandidateFinder.h
+++ b/RecoParticleFlow/PFTracking/interface/PFDisplacedVertexCandidateFinder.h
@@ -47,6 +47,7 @@ public:
     pt_min_ = ps_trk.getParameter<double>("pt_min");
     pt_min_prim_ = ps_trk.getParameter<double>("pt_min_prim");
     dxy_ = ps_trk.getParameter<double>("dxy");
+    qoverpError_max_ = ps_trk.getParameter<double>("qoverpError_max");
   }
 
   /// sets debug printout flag
@@ -137,7 +138,8 @@ private:
 
   double pt_min_prim_;
   double dxy_;
-
+  double qoverpError_max_;
+  
   /// Max number of expected vertexCandidates in the event
   /// Used to allocate the memory and avoid multiple copy
   unsigned vertexCandidatesSize_;

--- a/RecoParticleFlow/PFTracking/python/particleFlowDisplacedVertexCandidate_cfi.py
+++ b/RecoParticleFlow/PFTracking/python/particleFlowDisplacedVertexCandidate_cfi.py
@@ -39,7 +39,7 @@ particleFlowDisplacedVertexCandidate = cms.EDProducer("PFDisplacedVertexCandidat
     # PFDisplacedVertex timing
         pt_min_prim = cms.double(.8),
         dxy = cms.double(.2),
-        
+        qoverpError_max =cms.double(1.0e+7)
     )                                                     
                                    
 )

--- a/RecoParticleFlow/PFTracking/src/PFDisplacedVertexCandidateFinder.cc
+++ b/RecoParticleFlow/PFTracking/src/PFDisplacedVertexCandidateFinder.cc
@@ -314,10 +314,11 @@ bool PFDisplacedVertexCandidateFinder::goodPtResolution(const TrackBaseRef& trac
   double dxy = trackref->dxy(pvtx_);
 
   double pt_error = dpt / pt * 100;
+  double qoverpError = trackref->qoverpError();
 
   LogDebug("PFDisplacedVertexCandidateFinder")
       << " PFDisplacedVertexFinder: PFrecTrack->Track Pt= " << pt << " dPt/Pt = " << pt_error << "% nChi2 = " << nChi2;
-  if (nChi2 > nChi2_max_ || pt < pt_min_) {
+  if (nChi2 > nChi2_max_ || pt < pt_min_ || qoverpError > qoverpError_max_) {
     LogDebug("PFDisplacedVertexCandidateFinder") << " PFBlockAlgo: skip badly measured or low pt track"
                                                  << " nChi2_cut = " << 5 << " pt_cut = " << 0.2;
     return false;


### PR DESCRIPTION
#### PR description:

An attempt to solve this issue https://github.com/cms-sw/cmssw/issues/45520. 
Backport of https://github.com/cms-sw/cmssw/pull/45536, however, verbatim backport was not possible due to other changes introduced only in 14_1_X via https://github.com/cms-sw/cmssw/pull/45212

#### PR validation:

Checked with following workflows:
`12846.0_ZEE_14+2024` and `141.044_RunJetMET2023D`