### PR TITLE
HCAL DQM Online Histogram for Bad Quality Events

### DIFF
--- a/DQM/HcalTasks/data/HcalQualityTests.xml
+++ b/DQM/HcalTasks/data/HcalQualityTests.xml
@@ -30,4 +30,20 @@
   <LINK name="*Hcal/DigiTask/CapID/CapID_BadvsLS*">
     <TestName activate="true">BadCapIDThreshold</TestName>
   </LINK>
+  <QTEST name="BadQualityThreshold">
+    <TYPE>ContentsWithinExpected</TYPE>
+      <PARAM name="error">1.0</PARAM>
+      <PARAM name="warning">1.0</PARAM>
+      <PARAM name="minMean">-1.0</PARAM>
+      <PARAM name="maxMean">0.0</PARAM>
+      <PARAM name="minRMS">0.0</PARAM>
+      <PARAM name="maxRMS">0.0</PARAM>
+      <PARAM name="toleranceMean">-1.0</PARAM>
+      <PARAM name="minEntries">0</PARAM>
+      <PARAM name="useEmptyBins">1</PARAM>
+  </QTEST>
+  <LINK name="*Hcal/RawTask/BadQ_FEDvsLSmod60/BadQ_FEDvsLS*">
+    <TestName activate="true">BadQualityThreshold</TestName>
+  </LINK>
+
 </TESTSCONFIGURATION>

--- a/DQM/HcalTasks/data/HcalQualityTests.xml
+++ b/DQM/HcalTasks/data/HcalQualityTests.xml
@@ -42,7 +42,7 @@
       <PARAM name="minEntries">0</PARAM>
       <PARAM name="useEmptyBins">1</PARAM>
   </QTEST>
-  <LINK name="*Hcal/RawTask/BadQ_FEDvsLSmod60/BadQ_FEDvsLS*">
+  <LINK name="*Hcal/RawTask/BadQ_FEDvsLSmod10/BadQ_FEDvsLS*">
     <TestName activate="true">BadQualityThreshold</TestName>
   </LINK>
 

--- a/DQM/HcalTasks/interface/DigiTask.h
+++ b/DQM/HcalTasks/interface/DigiTask.h
@@ -168,8 +168,7 @@ protected:
   hcaldqm::Container1D _cCapidMinusBXmod4_SubdetPM;
   hcaldqm::ContainerSingle2D _cCapidMinusBXmod4_CrateSlotuTCA[4];  // CrateSlot 2D histograms for each (capid-BX)%4
   hcaldqm::ContainerSingle2D _cCapid_BadvsFEDvsLS;
-  hcaldqm::ContainerSingle2D
-      _cCapid_BadvsFEDvsLSmod60;  // Same as _cCapid_BadvsFEDvsLS, but only for last 50 LSes (for sound alarm turning off when problem goes away)
+  hcaldqm::ContainerSingle2D _cCapid_BadvsFEDvsLSmod10;  // Same as _cCapid_BadvsFEDvsLS, but only for last 50 LSes (for sound alarm turning off when problem goes away)
 
   //	#events counters
   MonitorElement *meNumEvents1LS;  // to transfer the #events to harvesting

--- a/DQM/HcalTasks/interface/DigiTask.h
+++ b/DQM/HcalTasks/interface/DigiTask.h
@@ -168,7 +168,8 @@ protected:
   hcaldqm::Container1D _cCapidMinusBXmod4_SubdetPM;
   hcaldqm::ContainerSingle2D _cCapidMinusBXmod4_CrateSlotuTCA[4];  // CrateSlot 2D histograms for each (capid-BX)%4
   hcaldqm::ContainerSingle2D _cCapid_BadvsFEDvsLS;
-  hcaldqm::ContainerSingle2D _cCapid_BadvsFEDvsLSmod10;  // Same as _cCapid_BadvsFEDvsLS, but only for last 50 LSes (for sound alarm turning off when problem goes away)
+  hcaldqm::ContainerSingle2D
+      _cCapid_BadvsFEDvsLSmod10;  // Same as _cCapid_BadvsFEDvsLS, but only for last 50 LSes (for sound alarm turning off when problem goes away)
 
   //	#events counters
   MonitorElement *meNumEvents1LS;  // to transfer the #events to harvesting

--- a/DQM/HcalTasks/interface/RawTask.h
+++ b/DQM/HcalTasks/interface/RawTask.h
@@ -77,7 +77,7 @@ protected:
 
   hcaldqm::Container2D _cSummaryvsLS_FED;          // online only
   hcaldqm::ContainerSingle2D _cSummaryvsLS;        // online only
-  hcaldqm::ContainerSingle2D _cBadQ_FEDvsLSmod60;  // online only
+  hcaldqm::ContainerSingle2D _cBadQ_FEDvsLSmod10;  // online only
 };
 
 #endif

--- a/DQM/HcalTasks/interface/RawTask.h
+++ b/DQM/HcalTasks/interface/RawTask.h
@@ -51,7 +51,7 @@ protected:
   //	physics vs calib processing switch
   bool _calibProcessing;
   int _thresh_calib_nbadq;
-
+  int _NBadQEvent;
   //	vector of HcalElectronicsId for FEDs
   std::vector<uint32_t> _vhashFEDs;
 
@@ -75,8 +75,9 @@ protected:
   hcaldqm::Container2D _cOrnMsm_ElectronicsuTCA;
   hcaldqm::ContainerXXX<uint32_t> _xEvnMsmLS, _xBcnMsmLS, _xOrnMsmLS, _xBadQLS;
 
-  hcaldqm::Container2D _cSummaryvsLS_FED;    // online only
-  hcaldqm::ContainerSingle2D _cSummaryvsLS;  // online only
+  hcaldqm::Container2D _cSummaryvsLS_FED;          // online only
+  hcaldqm::ContainerSingle2D _cSummaryvsLS;        // online only
+  hcaldqm::ContainerSingle2D _cBadQ_FEDvsLSmod60;  // online only
 };
 
 #endif

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -459,9 +459,9 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
                                       new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
                                       0);
 
-      _cCapid_BadvsFEDvsLSmod60.initialize(_name,
+      _cCapid_BadvsFEDvsLSmod10.initialize(_name,
                                            "CapID",
-                                           new hcaldqm::quantity::LumiSection(60),
+                                           new hcaldqm::quantity::LumiSection(10),
                                            new hcaldqm::quantity::FEDQuantity(vFEDs),
                                            new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
                                            0);
@@ -658,7 +658,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
   _cCapidMinusBXmod4_SubdetPM.book(ib, _emap, _subsystem);
   if (_ptype == fOnline) {
     _cCapid_BadvsFEDvsLS.book(ib, _subsystem, "BadvsLS");
-    _cCapid_BadvsFEDvsLSmod60.book(ib, _subsystem, "BadvsLSmod60");
+    _cCapid_BadvsFEDvsLSmod10.book(ib, _subsystem, "BadvsLSmod10");
   }
   for (int i = 0; i < 4; ++i) {
     constexpr unsigned int kSize = 32;
@@ -787,10 +787,10 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
   _xQuality = lumiCache->xQuality;
 
   if (_ptype == fOnline &&
-      lumiCache->EvtCntLS == 1) {  // Reset the bin for _cCapid_BadvsFEDvsLSmod60 at the beginning of each new LS
+      lumiCache->EvtCntLS == 1) {  // Reset the bin for _cCapid_BadvsFEDvsLSmod10 at the beginning of each new LS
     for (std::vector<uint32_t>::const_iterator it = _vhashFEDs.begin(); it != _vhashFEDs.end(); ++it) {
       HcalElectronicsId eid = HcalElectronicsId(*it);
-      _cCapid_BadvsFEDvsLSmod60.setBinContent(eid, _currentLS % 60, 0);
+      _cCapid_BadvsFEDvsLSmod10.setBinContent(eid, _currentLS % 10, 0);
     }
   }
 
@@ -898,7 +898,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
       if (!good_capidmbx) {
         _xBadCapid.get(eid)++;
         _cCapid_BadvsFEDvsLS.fill(eid, _currentLS);
-        _cCapid_BadvsFEDvsLSmod60.fill(eid, _currentLS % 60);
+        _cCapid_BadvsFEDvsLSmod10.fill(eid, _currentLS % 10);
       }
       if (!eid.isVMEid()) {
         _cCapidMinusBXmod4_CrateSlotuTCA[this_capidmbx].fill(eid);
@@ -1091,7 +1091,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
       if (!good_capidmbx) {
         _xBadCapid.get(eid)++;
         _cCapid_BadvsFEDvsLS.fill(eid, _currentLS);
-        _cCapid_BadvsFEDvsLSmod60.fill(eid, _currentLS % 60);
+        _cCapid_BadvsFEDvsLSmod10.fill(eid, _currentLS % 10);
       }
       if (!eid.isVMEid()) {
         _cCapidMinusBXmod4_CrateSlotuTCA[this_capidmbx].fill(eid);
@@ -1256,7 +1256,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
         if (!good_capidmbx) {
           _xBadCapid.get(eid)++;
           _cCapid_BadvsFEDvsLS.fill(eid, _currentLS);
-          _cCapid_BadvsFEDvsLSmod60.fill(eid, _currentLS % 60);
+          _cCapid_BadvsFEDvsLSmod10.fill(eid, _currentLS % 10);
         }
         if (!eid.isVMEid()) {
           _cCapidMinusBXmod4_CrateSlotuTCA[this_capidmbx].fill(eid);

--- a/DQM/HcalTasks/plugins/RawTask.cc
+++ b/DQM/HcalTasks/plugins/RawTask.cc
@@ -18,6 +18,7 @@ RawTask::RawTask(edm::ParameterSet const& ps)
   _vflags[fBcnMsm] = flag::Flag("BcnMsm");
   _vflags[fBadQ] = flag::Flag("BadQ");
   _vflags[fOrnMsm] = flag::Flag("OrnMsm");
+  _NBadQEvent = 0;
 }
 
 /* virtual */ void RawTask::bookHistograms(DQMStore::IBooker& ib, edm::Run const& r, edm::EventSetup const& es) {
@@ -131,6 +132,12 @@ RawTask::RawTask(edm::ParameterSet const& ps)
                                new hcaldqm::quantity::FEDQuantity(vFEDs),
                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fState),
                                0);
+      _cBadQ_FEDvsLSmod60.initialize(_name,
+                                     "BadQ_FEDvsLSmod60",
+                                     new hcaldqm::quantity::LumiSection(60),
+                                     new hcaldqm::quantity::FEDQuantity(vFEDs),
+                                     new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                     0);
       //	FED Size vs LS
       _cDataSizevsLS_FED.initialize(_name,
                                     "DataSizevsLS",
@@ -166,6 +173,7 @@ RawTask::RawTask(edm::ParameterSet const& ps)
     _xBadQLS.book(_emap);
     _cSummaryvsLS_FED.book(ib, _emap, _subsystem);
     _cSummaryvsLS.book(ib, _subsystem);
+    _cBadQ_FEDvsLSmod60.book(ib, _subsystem);
     _cDataSizevsLS_FED.book(ib, _emap, _subsystem);
   }
 
@@ -224,6 +232,12 @@ RawTask::RawTask(edm::ParameterSet const& ps)
   //	TODO: Include for Online Calibration Channels marked as bad
   //	a comment below is left on purpose!
   //_cBadQualityvsBX.fill(bx, creport->badQualityDigis());
+  int Nbadq = creport->badQualityDigis();
+  if (lumiCache->EvtCntLS == 1)
+    _NBadQEvent = 0;  // Reset at the beginning of each new LS
+  if (Nbadq > 0)
+    _NBadQEvent++;
+  //std::cout << " Nbadq  "<<  Nbadq   << " NBadQEvent  " <<_NBadQEvent<< std::endl;
   for (std::vector<DetId>::const_iterator it = creport->bad_quality_begin(); it != creport->bad_quality_end(); ++it) {
     //	skip non HCAL det ids
     if (!HcalGenericDetId(*it).isHcalDetId())
@@ -242,7 +256,9 @@ RawTask::RawTask(edm::ParameterSet const& ps)
     _cBadQuality_depth.fill(HcalDetId(*it));
     //	ONLINE ONLY!
     if (_ptype == fOnline)
+      //Number of BadQualityDigis
       _xBadQLS.get(eid)++;
+    //std::cout << " event _xBadQLS "<<  double(_xBadQLS.get(eid)) << std::endl;
     if (_ptype != fOffline) {  // hidefed2crate
       if (!eid.isVMEid()) {
         if (_filter_FEDsuTCA.filter(eid))
@@ -393,13 +409,15 @@ std::shared_ptr<hcaldqm::Cache> RawTask::globalBeginLuminosityBlock(edm::Luminos
   for (std::vector<uint32_t>::const_iterator it = _vhashFEDs.begin(); it != _vhashFEDs.end(); ++it) {
     flag::Flag fSum("RAW");
     HcalElectronicsId eid = HcalElectronicsId(*it);
-
+    int fed = hcaldqm::utilities::crate2fed(eid.crateId(), eid.slot());
     std::vector<uint32_t>::const_iterator cit = std::find(_vcdaqEids.begin(), _vcdaqEids.end(), *it);
     if (cit == _vcdaqEids.end()) {
       // not @cDAQ
       for (uint32_t iflag = 0; iflag < _vflags.size(); iflag++)
         _cSummaryvsLS_FED.setBinContent(eid, _currentLS, int(iflag), int(flag::fNCDAQ));
       _cSummaryvsLS.setBinContent(eid, _currentLS, int(flag::fNCDAQ));
+      if (!hcaldqm::utilities::isFEDHO(eid) && fed != 1136)
+        _cBadQ_FEDvsLSmod60.setBinContent(eid, _currentLS % 60, int(flag::fNCDAQ));
       continue;
     }
 
@@ -419,9 +437,13 @@ std::shared_ptr<hcaldqm::Cache> RawTask::globalBeginLuminosityBlock(edm::Luminos
         _vflags[fOrnMsm]._state = flag::fGOOD;
       if (double(_xBadQLS.get(eid)) > double(12 * _evsPerLS))
         _vflags[fBadQ]._state = flag::fBAD;
-      else if (_xBadQLS.get(eid) > 0)
+      //else if (_xBadQLS.get(eid) > 0){
+      // Following line added due to https://gitlab.cern.ch/cmshcal/docs/-/issues/233
+      // BadQ > (5%) of number of events in this LS.
+      else if (double(_xBadQLS.get(eid)) > 0 && double(_NBadQEvent) > double(0.05 * _evsPerLS)) {
         _vflags[fBadQ]._state = flag::fPROBLEMATIC;
-      else
+
+      } else
         _vflags[fBadQ]._state = flag::fGOOD;
     }
 
@@ -431,6 +453,12 @@ std::shared_ptr<hcaldqm::Cache> RawTask::globalBeginLuminosityBlock(edm::Luminos
     //	- reset each flag right after using it
     for (std::vector<flag::Flag>::iterator ft = _vflags.begin(); ft != _vflags.end(); ++ft) {
       _cSummaryvsLS_FED.setBinContent(eid, _currentLS, int(iflag), ft->_state);
+
+      if (ft->_name == "BadQ") {
+        if (!hcaldqm::utilities::isFEDHO(eid) && fed != 1136 && ft->_state != 3) {
+          _cBadQ_FEDvsLSmod60.setBinContent(eid, _currentLS % 60, (double(_NBadQEvent) / double(_evsPerLS)) * 100);
+        }
+      }
       fSum += (*ft);
       iflag++;
 

--- a/DQM/HcalTasks/plugins/RawTask.cc
+++ b/DQM/HcalTasks/plugins/RawTask.cc
@@ -132,9 +132,9 @@ RawTask::RawTask(edm::ParameterSet const& ps)
                                new hcaldqm::quantity::FEDQuantity(vFEDs),
                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fState),
                                0);
-      _cBadQ_FEDvsLSmod60.initialize(_name,
-                                     "BadQ_FEDvsLSmod60",
-                                     new hcaldqm::quantity::LumiSection(60),
+      _cBadQ_FEDvsLSmod10.initialize(_name,
+                                     "BadQ_FEDvsLSmod10",
+                                     new hcaldqm::quantity::LumiSection(10),
                                      new hcaldqm::quantity::FEDQuantity(vFEDs),
                                      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
                                      0);
@@ -173,7 +173,7 @@ RawTask::RawTask(edm::ParameterSet const& ps)
     _xBadQLS.book(_emap);
     _cSummaryvsLS_FED.book(ib, _emap, _subsystem);
     _cSummaryvsLS.book(ib, _subsystem);
-    _cBadQ_FEDvsLSmod60.book(ib, _subsystem);
+    _cBadQ_FEDvsLSmod10.book(ib, _subsystem);
     _cDataSizevsLS_FED.book(ib, _emap, _subsystem);
   }
 
@@ -417,7 +417,7 @@ std::shared_ptr<hcaldqm::Cache> RawTask::globalBeginLuminosityBlock(edm::Luminos
         _cSummaryvsLS_FED.setBinContent(eid, _currentLS, int(iflag), int(flag::fNCDAQ));
       _cSummaryvsLS.setBinContent(eid, _currentLS, int(flag::fNCDAQ));
       if (!hcaldqm::utilities::isFEDHO(eid) && fed != 1136)
-        _cBadQ_FEDvsLSmod60.setBinContent(eid, _currentLS % 60, int(flag::fNCDAQ));
+        _cBadQ_FEDvsLSmod10.setBinContent(eid, _currentLS % 10, int(flag::fNCDAQ));
       continue;
     }
 
@@ -456,7 +456,7 @@ std::shared_ptr<hcaldqm::Cache> RawTask::globalBeginLuminosityBlock(edm::Luminos
 
       if (ft->_name == "BadQ") {
         if (!hcaldqm::utilities::isFEDHO(eid) && fed != 1136 && ft->_state != 3) {
-          _cBadQ_FEDvsLSmod60.setBinContent(eid, _currentLS % 60, (double(_NBadQEvent) / double(_evsPerLS)) * 100);
+          _cBadQ_FEDvsLSmod10.setBinContent(eid, _currentLS % 10, (double(_NBadQEvent) / double(_evsPerLS)) * 100);
         }
       }
       fSum += (*ft);


### PR DESCRIPTION
#### PR description:
  - We have added a histogram to Online HCAL DQM by implementing the required changes in the CMSSW_14_1_0_pre3 [1] release.
 - We set up the GUI on the dqmfu-c2b02-46-01 machine by following the instructions provided in [0].
   [0]: https://github.com/cms-DQM/dqmgui_prod_deployment/wiki/Deployment-at-Point-5
   [1]: https://github.com/cms-sw/cmssw/blob/master/DQM/HcalTasks/plugins/RawTask.cc

 - A new histogram will be appeared in 00_Shift/Errors
 - There is a gitlab issue https://gitlab.cern.ch/cmshcal/docs/-/issues/233.
#### PR validation:
<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->
- All the PR validation checks and the runTheMatrix test are done. 

- This PR is not a back port.
- All points of checklist is done.
