### PR TITLE
Add specialisations of `make_device_view` with a Queue argument

### DIFF
--- a/DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsDevice.h
+++ b/DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsDevice.h
@@ -25,15 +25,13 @@ public:
   template <typename TQueue>
   explicit TrackingRecHitDevice(TQueue queue, uint32_t nHits, int32_t offsetBPIX2, uint32_t const* hitsModuleStart)
       : PortableDeviceCollection<TrackingRecHitLayout<TrackerTraits>, TDev>(nHits, queue), offsetBPIX2_{offsetBPIX2} {
-    const auto device = alpaka::getDev(queue);
-
-    auto start_h = cms::alpakatools::make_device_view(device, hitsModuleStart, TrackerTraits::numberOfModules + 1);
+    auto start_h = cms::alpakatools::make_device_view(queue, hitsModuleStart, TrackerTraits::numberOfModules + 1);
     auto start_d =
-        cms::alpakatools::make_device_view(device, view().hitsModuleStart().data(), TrackerTraits::numberOfModules + 1);
+        cms::alpakatools::make_device_view(queue, view().hitsModuleStart().data(), TrackerTraits::numberOfModules + 1);
     alpaka::memcpy(queue, start_d, start_h);
 
     auto off_h = cms::alpakatools::make_host_view(offsetBPIX2_);
-    auto off_d = cms::alpakatools::make_device_view(device, view().offsetBPIX2());
+    auto off_d = cms::alpakatools::make_device_view(queue, view().offsetBPIX2());
     alpaka::memcpy(queue, off_d, off_h);
   }
 
@@ -47,7 +45,7 @@ public:
   template <typename TQueue>
   void updateFromDevice(TQueue queue) {
     auto off_h = cms::alpakatools::make_host_view(offsetBPIX2_);
-    auto off_d = cms::alpakatools::make_device_view(alpaka::getDev(queue), view().offsetBPIX2());
+    auto off_d = cms::alpakatools::make_device_view(queue, view().offsetBPIX2());
     alpaka::memcpy(queue, off_h, off_d);
   }
 

--- a/EventFilter/EcalRawToDigi/plugins/alpaka/EcalRawToDigiPortable.cc
+++ b/EventFilter/EcalRawToDigi/plugins/alpaka/EcalRawToDigiPortable.cc
@@ -98,8 +98,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     OutputProduct digisDevEE{static_cast<int32_t>(config_.maxChannelsEE), queue};
     // reset the size scalar of the SoA
     // memset takes an alpaka view that is created from the scalar in a view to the device collection
-    auto digiViewEB = cms::alpakatools::make_device_view<uint32_t>(alpaka::getDev(queue), digisDevEB.view().size());
-    auto digiViewEE = cms::alpakatools::make_device_view<uint32_t>(alpaka::getDev(queue), digisDevEE.view().size());
+    auto digiViewEB = cms::alpakatools::make_device_view<uint32_t>(queue, digisDevEB.view().size());
+    auto digiViewEE = cms::alpakatools::make_device_view<uint32_t>(queue, digisDevEE.view().size());
     alpaka::memset(queue, digiViewEB, 0);
     alpaka::memset(queue, digiViewEE, 0);
 

--- a/HeterogeneousCore/AlpakaInterface/README.md
+++ b/HeterogeneousCore/AlpakaInterface/README.md
@@ -4,3 +4,373 @@ This package only depends on the `alpaka` header-only external library, and
 provides the interface used by other packages in CMSSW.
 
 It is safe to be used inside DataFormats packages.
+
+
+## Memory operations
+
+Alpaka buffers represent a multidimensional array in host or device memory.
+Buffers implement a shared ownership model of the the memory they represent,
+similar to an `std::shared_ptr<std::vector<T>>`.
+
+Alpaka views represent a multidimensional array in host or device memory.
+Views _do not_ own the memory, they refer to some pre-existing, underlying
+object; as with raw pointers, the user must guarantee that the memory remains
+valid for as long as the view is used.
+
+This package defines in the `cms::alpakatools` namespace type aliases and helper
+functions to simplify the use of zero-dimensional (scalars) and one-dimensional
+(array) alpaka buffers and views, residing in host and device memory.
+
+
+## Host memory buffers
+
+These type aliases simplify the use of zero-dimensional (scalars) and
+one-dimensional (array) alpaka host buffers:
+
+  - `host_buffer<T>` (where `T` is not an array)
+    represents a single object of type `T`;
+
+  - `host_buffer<T[N]>`
+    represents a one-dimensional buffer of `N` objects of type `T`;
+
+  - `host_buffer<T[]>`
+    represents a one-dimensional buffer of a number of objects of type `T`
+    determined at construction time.
+
+
+### `const` host memory buffers
+
+As for an `std::shared_ptr`, the use of a `const` buffer is not particularly
+usefeful, because one can always make a non-`const` copy that shares ownership
+of the same underlying memory and objects.
+When `const`-only access to a buffer is desired, an `alpaka::ViewConst` adapter
+can be used to provide the required semantics.
+
+These type aliases implement host buffers with `const`-only semantics:
+
+  - `const_host_buffer<T>`;
+  - `const_host_buffer<T[N]>`;
+  - `const_host_buffer<T[]>`.
+
+A `const_host_buffer` can be automatically constructued from a `host_buffer`.
+These are mostly useful as function arguments, to guarantee that the function
+does not make changes to the underlying memory.
+
+
+### Allocating host buffers
+
+These helper functions allocate zero-dimensional (scalars) and one-dimensional
+(array) alpaka buffers in general purpose host memory:
+
+  - `auto make_host_buffer<T>()` (where `T` is not an array)
+    allocates a zero-dimensional buffer holding a single object of type `T`;
+
+  - `auto make_host_buffer<T[N]>()`
+    allocates a one-dimensional buffer holding `N` objects of type `T`;
+
+  - `auto make_host_buffer<T[]>(size)`
+    allocates a one-dimensional buffer holding `size` objects of type `T`.
+
+These function allocate the buffers in general purpose host memory, using
+immediate operations, without any caching.
+
+The memory is not initialised.
+
+
+### Allocating host buffers in device-mapped memory
+
+These helper functions allocate zero-dimensional (scalars) and one-dimensional
+(array) alpaka buffers in device-mapped memory:
+
+  - `auto make_host_buffer<T, Platform>()` (where `T` is not an array)
+    allocates a zero-dimensional buffer holding a single object of type `T`;
+
+  - `auto make_host_buffer<T[N], Platform>()`
+    allocates a one-dimensional buffer holding `N` objects of type `T`;
+
+  - `auto make_host_buffer<T[], Platform>(size)`
+    allocates a one-dimensional buffer holding `size` objects of type `T`.
+
+These functions allocate the buffers in host memory that is pinned and mapped in
+the address space of the devices, using potentially blocking operations, without
+any caching. The memory and objects can be accessed both on the host and on the
+devices.
+
+The memory is not initialised.
+
+On most systems accessing this memory from the device is significantly slower
+than using device global memory, so it is not adviced to use these buffers
+directly in device kernels. A common use case for device-mapped memory is as a
+staging area for copies to and from the devices.
+
+
+### Allocating queue-ordered host buffers in device-mapped memory
+
+These helper functions allocate zero-dimensional (scalars) and one-dimensional
+(array) alpaka queue-ordered buffers in device-mapped memory:
+
+  - `auto make_host_buffer<T>(queue)` (where `T` is not an array)
+    allocates a zero-dimensional buffer holding a single object of type `T`;
+
+  - `auto make_host_buffer<T[N]>(queue)`
+    allocates a one-dimensional buffer holding `N` objects of type `T`;
+
+  - `auto make_host_buffer<T[]>(queue, size)`
+    allocates a one-dimensional buffer holding `size` objects of type `T`.
+
+These functions use queue-ordered, potentially cached, memory allocations.
+Queue-ordered host buffers are available immediately. However, when they go out
+of scope or are destroyed, the buffer memory and the underlying objects are kept
+alive and remain valid until all the operations that have been enqueued in the
+given queue up to that point have completed.
+
+These functions allocate the buffers in host memory that is pinned and mapped in
+the address space of the device associated to the `queue`; the memory and objects
+can be accessed both on the host and on the devices from the same platform as the
+device associated to the `queue`.
+
+These function potentially use caching to reduce the allocation overhead.
+
+The memory is not initialised.
+
+See the previous section for considerations about the use of device-mapped
+memory.
+
+
+## A note about copies and synchronisation
+
+When copying data from a host buffer to a device buffer, _e.g._ with
+```c++
+alpaka::memcpy(queue, device_buffer, host_buffer);
+```
+the copy will run asynchronously along the given `queue`. This means that the
+data can be accessed on the _device_ by any subsequent operation scheduled on
+the same `queue`, like the execution of a kernel, a `memset`, a device-to-device
+copy, _etc_. For example, this:
+```c++
+alpaka::memcpy(queue, device_buffer, host_buffer);
+alpaka::exec(queue, workdivision, kernel{}, device_buffer.data());
+```
+is a safe approach that is commonly used.
+
+However, the _host_ must avoid freeing, modifying or otherwise reusing the
+buffer from which the data is being copied until the operation is complete.
+For example, something like
+```c++
+alpaka::memcpy(queue, a_device_buffer, a_host_buffer);
+std::memset(a_host_buffer.data(), 0x00, size);
+```
+is likely to overwrite part of the buffer while the copy is still ongoing,
+resulting in `a_device_buffer` with incomplete and corrupted contents.
+
+When copying data from a device buffer to a host buffer, _e.g._ with
+```c++
+alpaka::memcpy(queue, a_host_buffer, a_device_buffer);
+```
+the copy will run asynchronously along the given `queue`. This means that the
+data can be accessed on the _host_ by any subsequent operation scheduled on
+the same `queue`, or after an explicit synchronisation.
+A simple approach would be to wait for the copy to be complete:
+```c++
+alpaka::memcpy(queue, a_host_buffer, a_device_buffer);
+alpaka::wait(queue);
+int a_value = *a_host_buffer;
+```
+This has the downside of blocking the host until the copy - and all previously
+enqueued operations - have completed. A more efficient approach is to use an
+`edm::stream::EDProducer<edm::ExternalWork>` or a `stream::SynchronizingEDProducer`,
+with the copy in the `acquire()` method, and the access to the data in the
+`produce()` method:
+```c++
+// data member
+host_buffer<int> a_host_buffer_;
+
+// acquire() runs immediately and submits asynchronous operations to the device
+void acquire(device::Event const& event, device::EventSetup const& setup) {
+  ...
+  alpaka::memcpy(event.queue(), a_host_buffer_, a_device_buffer);
+}
+
+// produce() is scheduled only once all operation in queue have completed
+void produce(device::Event& event, device::EventSetup const& setup) {
+  int a_value = *host_buffer_;
+  ...
+}
+```
+
+
+## Device buffers
+
+These type aliases simplify the use of zero-dimensional (scalars) and
+one-dimensional (array) alpaka device buffers:
+
+  - `device_buffer<Device, T>` (where `T` is not an array)
+    represents a single object of type `T`;
+
+  - `device_buffer<Device, T[N]>`
+    represents a one-dimensional buffer of `N` objects of type `T`;
+
+  - `device_buffer<Device, T[]>`
+    represents a one-dimensional buffer of a number of objects of type `T`
+    determined at construction time.
+
+
+### `const` device memory buffers
+
+As for an `std::shared_ptr`, the use of a `const` buffer is not particularly
+usefeful, because one can always make a non-`const` copy that shares ownership
+of the same underlying memory and objects.
+When `const`-only access to a buffer is desired, an `alpaka::ViewConst` adapter
+can be used to provide the required semantics.
+
+These type aliases implement device buffers with `const`-only semantics:
+
+  - `const_device_buffer<Device, T>`;
+  - `const_device_buffer<Device, T[N]>`;
+  - `const_device_buffer<Device, T[]>`.
+
+A `const_device_buffer` can be automatically constructued from a `device_buffer`.
+These are mostly useful as function arguments, to guarantee that the function
+does not make changes to the underlying memory.
+
+
+### Allocating device buffers
+
+These helper functions allocate zero-dimensional (scalars) and one-dimensional
+(array) alpaka buffers in device global memory:
+
+  - `auto make_device_buffer<T>(device)` (where `T` is not an array)
+    allocates a zero-dimensional buffer holding a single object of type `T` in
+    the global memory of `device`;
+
+  - `auto make_device_buffer<T[N]>(device)`
+    allocates a one-dimensional buffer holding `N` objects of type `T` in the
+    global memory of `device`;
+
+  - `auto make_device_buffer<T[]>(device, size)`
+    allocates a one-dimensional buffer holding `size` objects of type `T` in the
+    global memory of device.
+
+These function allocate the buffers in device global memory, using potentially
+blocking operations, without any caching.
+
+The memory is not initialised.
+
+
+### Allocating queue-ordered device buffers
+
+These helper functions allocate zero-dimensional (scalars) and one-dimensional
+(array) alpaka queue-ordered buffers in device global memory:
+
+  - `auto make_device_buffer<T>(queue)` (where `T` is not an array)
+    allocates a zero-dimensional buffer holding a single object of type `T` in
+    the global memory of `device`;
+
+  - `auto make_device_buffer<T[N]>(queue)`
+    allocates a one-dimensional buffer holding `N` objects of type `T` in the
+    global memory of `device`;
+
+  - `auto make_device_buffer<T[]>(queue, size)`
+    allocates a one-dimensional buffer holding `size` objects of type `T` in the
+    global memory of device.
+
+These functions use queue-ordered memory allocations.
+Queue-ordered device buffers are available once all the operations that have
+been enqueued in the given queue up to that point have completed.
+In a similar manner, when the buffers go out of scope or are destroyed, the
+buffer memory and the underlying objects are kept alive and remain valid until
+all the operations that have been enqueued in the given queue up to that point
+have completed.
+
+These function allocate the buffers in device global memory, potentially using
+caching to reduce the allocation overhead.
+
+The memory is not initialised.
+
+
+## Host memory views
+
+These type aliases simplify the use of zero-dimensional (scalars) and
+one-dimensional (array) alpaka host views:
+
+  - `host_view<T>` (where `T` is not an array)
+    represents a zero-dimensional view over a single object of type `T` in host
+    memory;
+
+  - `host_view<T[N]>`
+    represents a one-dimensional view over `N` objects of type `T` in host
+    memory;
+
+  - `host_view<T[]>`
+    represents a one-dimensional view over a number of objects of type `T` in
+    host memory determined at construction time.
+
+
+## Instantiatig host views
+
+These helper functions instantiate zero-dimensional (scalars) and one-dimensional
+(array) alpaka views over existing objects in host memory:
+
+  - `auto make_host_view<T>(T& data)` (where `T` is not an array)
+    instantiates a zero-dimensional view over the object `data` in host memory;
+
+  - `auto make_host_view<T[N]>(T[N]& data)`
+    instantiates a one-dimensional view over an array `data` in host memory;
+
+  - `auto make_host_view<T[]>(T* data, size)`
+    instantiates a one-dimensional view over an array starting at `data` with
+    `size` elements in host memory;
+
+
+## Device memory views
+
+These type aliases simplify the use of zero-dimensional (scalars) and
+one-dimensional (array) alpaka device views:
+
+  - `device_view<Device, T>` (where `T` is not an array)
+    represents a zero-dimensional view over a single object of type `T` in
+    device global memory;
+
+  - `device_view<Device, T[N]>`
+    represents a one-dimensional view over `N` objects of type `T` in device
+    global memory;
+
+  - `device_view<Device, T[]>`
+    represents a one-dimensional view over a number of objects of type `T` in
+    device global memory determined at construction time.
+
+
+## Instantiatig device views
+
+These helper functions instantiate zero-dimensional (scalars) and one-dimensional
+(array) alpaka views over existing objects in device memory:
+
+  - `auto make_device_view<T>(device, T& data)` (where `T` is not an array)
+    instantiates a zero-dimensional view over the object `data` in device global
+    memory;
+
+  - `auto make_device_view<T[N]>(device, T[N]& data)`
+    instantiates a one-dimensional view over an array `data` in device global
+    memory;
+
+  - `auto make_device_view<T[]>(device, T* data, size)`
+    instantiates a one-dimensional view over an array starting at `data` with
+    `size` elements in device global memory.
+
+The `make_device_view` functions can also accept as a first argument a `queue`
+instead of a `device`:
+
+  - `auto make_device_view<T>(queue, T& data)` (where `T` is not an array)
+    instantiates a zero-dimensional view over the object `data` in device global
+    memory;
+
+  - `auto make_device_view<T[N]>(queue, T[N]& data)`
+    instantiates a one-dimensional view over an array `data` in device global
+    memory;
+
+  - `auto make_device_view<T[]>(queue, T* data, size)`
+    instantiates a one-dimensional view over an array starting at `data` with
+    `size` elements in device global memory.
+
+These functions use the device associated to the given `queue`. These operations
+are otherwise identical to those that take a `device` as their first argument.

--- a/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalUncalibRecHitProducerPortable.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalUncalibRecHitProducerPortable.cc
@@ -162,9 +162,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     // copy the actual numbers of digis in the collections to host
     auto ebDigisSizeDevConstView =
-        cms::alpakatools::make_device_view<const uint32_t>(alpaka::getDev(queue), ebDigisDev.const_view().size());
+        cms::alpakatools::make_device_view<const uint32_t>(queue, ebDigisDev.const_view().size());
     auto eeDigisSizeDevConstView =
-        cms::alpakatools::make_device_view<const uint32_t>(alpaka::getDev(queue), eeDigisDev.const_view().size());
+        cms::alpakatools::make_device_view<const uint32_t>(queue, eeDigisDev.const_view().size());
     alpaka::memcpy(queue, ebDigisSizeHostBuf_, ebDigisSizeDevConstView);
     alpaka::memcpy(queue, eeDigisSizeHostBuf_, eeDigisSizeDevConstView);
   }
@@ -186,9 +186,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     // reset the size scalar of the SoA
     // memset takes an alpaka view that is created from the scalar in a view to the portable device collection
     auto uncalibRecHitSizeViewEB =
-        cms::alpakatools::make_device_view<uint32_t>(alpaka::getDev(queue), uncalibRecHitsDevEB.view().size());
+        cms::alpakatools::make_device_view<uint32_t>(queue, uncalibRecHitsDevEB.view().size());
     auto uncalibRecHitSizeViewEE =
-        cms::alpakatools::make_device_view<uint32_t>(alpaka::getDev(queue), uncalibRecHitsDevEE.view().size());
+        cms::alpakatools::make_device_view<uint32_t>(queue, uncalibRecHitsDevEE.view().size());
     alpaka::memset(queue, uncalibRecHitSizeViewEB, 0);
     alpaka::memset(queue, uncalibRecHitSizeViewEE, 0);
 

--- a/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalLayerClustersAlgoWrapper.dev.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalLayerClustersAlgoWrapper.dev.cc
@@ -26,16 +26,15 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         queue, dc, kappa, outlierDeltaFactor, false);
 
     // Initialize output memory to 0
-    auto delta = cms::alpakatools::make_device_view<float>(alpaka::getDev(queue), outputs.delta(), size);
+    auto delta = cms::alpakatools::make_device_view<float>(queue, outputs.delta(), size);
     alpaka::memset(queue, delta, 0x0);
-    auto rho = cms::alpakatools::make_device_view<float>(alpaka::getDev(queue), outputs.rho(), size);
+    auto rho = cms::alpakatools::make_device_view<float>(queue, outputs.rho(), size);
     alpaka::memset(queue, rho, 0x0);
-    auto nearestHigher =
-        cms::alpakatools::make_device_view<unsigned int>(alpaka::getDev(queue), outputs.nearestHigher(), size);
+    auto nearestHigher = cms::alpakatools::make_device_view<unsigned int>(queue, outputs.nearestHigher(), size);
     alpaka::memset(queue, nearestHigher, 0x0);
-    auto clusterIndex = cms::alpakatools::make_device_view<int>(alpaka::getDev(queue), outputs.clusterIndex(), size);
+    auto clusterIndex = cms::alpakatools::make_device_view<int>(queue, outputs.clusterIndex(), size);
     alpaka::memset(queue, clusterIndex, kInvalidClusterByte);
-    auto isSeed = cms::alpakatools::make_device_view<uint8_t>(alpaka::getDev(queue), outputs.isSeed(), size);
+    auto isSeed = cms::alpakatools::make_device_view<uint8_t>(queue, outputs.isSeed(), size);
     alpaka::memset(queue, isSeed, 0x0);
 
     algoStandalone.makeClustersCMSSW(size,

--- a/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalLayerClustersSoAAlgoWrapper.dev.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalLayerClustersSoAAlgoWrapper.dev.cc
@@ -76,8 +76,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
             clusterEnergy = (clusterSeed == kInvalidIndex) ? 0.f : input_rechits_soa[clusterSeed].weight();
           }
         }  // CAS
-      }    // uniform_elements
-    }      // operator()
+      }  // uniform_elements
+    }  // operator()
   };
 
   // Real Kernel position
@@ -115,7 +115,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         alpaka::atomicAdd(acc, &outputs[cluster_index].y(), input_rechits_soa[hit_index].dim2() * Wi);
         alpaka::atomicAdd(acc, &outputs_service[cluster_index].total_weight_log(), Wi);
       }  // uniform_elements
-    }    // operator()
+    }  // operator()
   };
 
   // Besides the final position, add also the DetId of the seed of each cluster
@@ -144,7 +144,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         }
         outputs[cluster_index].z() = input_rechits_soa[max_energy_index].dim3();
       }  // uniform_elements
-    }    // operator()
+    }  // operator()
   };
 
   void HGCalLayerClustersSoAAlgoWrapper::run(Queue& queue,
@@ -155,29 +155,25 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                              const HGCalSoARecHitsExtraDeviceCollection::ConstView input_clusters_soa,
                                              HGCalSoAClustersDeviceCollection::View outputs,
                                              HGCalSoAClustersExtraDeviceCollection::View outputs_service) const {
-    auto x = cms::alpakatools::make_device_view<float>(alpaka::getDev(queue), outputs.x(), size);
+    auto x = cms::alpakatools::make_device_view<float>(queue, outputs.x(), size);
     alpaka::memset(queue, x, 0x0);
-    auto y = cms::alpakatools::make_device_view<float>(alpaka::getDev(queue), outputs.y(), size);
+    auto y = cms::alpakatools::make_device_view<float>(queue, outputs.y(), size);
     alpaka::memset(queue, y, 0x0);
-    auto z = cms::alpakatools::make_device_view<float>(alpaka::getDev(queue), outputs.z(), size);
+    auto z = cms::alpakatools::make_device_view<float>(queue, outputs.z(), size);
     alpaka::memset(queue, z, 0x0);
-    auto seed = cms::alpakatools::make_device_view<int>(alpaka::getDev(queue), outputs.seed(), size);
+    auto seed = cms::alpakatools::make_device_view<int>(queue, outputs.seed(), size);
     alpaka::memset(queue, seed, 0x0);
-    auto energy = cms::alpakatools::make_device_view<float>(alpaka::getDev(queue), outputs.energy(), size);
+    auto energy = cms::alpakatools::make_device_view<float>(queue, outputs.energy(), size);
     alpaka::memset(queue, energy, 0x0);
-    auto cells = cms::alpakatools::make_device_view<int>(alpaka::getDev(queue), outputs.cells(), size);
+    auto cells = cms::alpakatools::make_device_view<int>(queue, outputs.cells(), size);
     alpaka::memset(queue, cells, 0x0);
-    auto total_weight =
-        cms::alpakatools::make_device_view<float>(alpaka::getDev(queue), outputs_service.total_weight(), size);
+    auto total_weight = cms::alpakatools::make_device_view<float>(queue, outputs_service.total_weight(), size);
     alpaka::memset(queue, total_weight, 0x0);
-    auto total_weight_log =
-        cms::alpakatools::make_device_view<float>(alpaka::getDev(queue), outputs_service.total_weight_log(), size);
+    auto total_weight_log = cms::alpakatools::make_device_view<float>(queue, outputs_service.total_weight_log(), size);
     alpaka::memset(queue, total_weight_log, 0x0);
-    auto maxEnergyValue =
-        cms::alpakatools::make_device_view<float>(alpaka::getDev(queue), outputs_service.maxEnergyValue(), size);
+    auto maxEnergyValue = cms::alpakatools::make_device_view<float>(queue, outputs_service.maxEnergyValue(), size);
     alpaka::memset(queue, maxEnergyValue, 0x0);
-    auto maxEnergyIndex =
-        cms::alpakatools::make_device_view<int>(alpaka::getDev(queue), outputs_service.maxEnergyIndex(), size);
+    auto maxEnergyIndex = cms::alpakatools::make_device_view<int>(queue, outputs_service.maxEnergyIndex(), size);
     alpaka::memset(queue, maxEnergyIndex, kInvalidIndexByte);
 
     // use 64 items per group (this value is arbitrary, but it's a reasonable starting point)

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.dev.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.dev.cc
@@ -74,7 +74,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
             slopeCol = 1;
             rowOffset = 2 * ::pixelDetails::numRowsInRoc - 1;
             colOffset = (rocIdInDetUnit - 8) * ::pixelDetails::numColsInRoc;
-          }       // if roc
+          }  // if roc
         } else {  // +Z side: 4 non-flipped modules oriented like 'pppp', but all 8 in layer1
           if (rocIdInDetUnit < 8) {
             slopeRow = -1;
@@ -426,7 +426,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         }  // end of stride on grid
 
       }  // end of Raw to Digi kernel operator()
-    };   // end of Raw to Digi struct
+    };  // end of Raw to Digi struct
 
     template <typename TrackerTraits>
     struct FillHitsModuleStart {
@@ -515,7 +515,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 #endif
 
       }  // end of FillHitsModuleStart kernel operator()
-    };   // end of FillHitsModuleStart struct
+    };  // end of FillHitsModuleStart struct
 
     // Interface to outside
     template <typename TrackerTraits>
@@ -639,8 +639,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         alpaka::exec<Acc1D>(
             queue, workDiv, CountModules<TrackerTraits>{}, digis_d->view(), clusters_d->view(), wordCounter);
 
-        auto moduleStartFirstElement =
-            cms::alpakatools::make_device_view(alpaka::getDev(queue), clusters_d->view().moduleStart(), 1u);
+        auto moduleStartFirstElement = cms::alpakatools::make_device_view(queue, clusters_d->view().moduleStart(), 1u);
         alpaka::memcpy(queue, nModules_Clusters_h, moduleStartFirstElement);
 
         const auto elementsPerBlockFindClus = FindClus<TrackerTraits>::maxElementsPerBlock;
@@ -676,13 +675,13 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         alpaka::exec<Acc1D>(queue, workDivOneBlock, FillHitsModuleStart<TrackerTraits>{}, clusters_d->view());
 
         // last element holds the number of all clusters
-        const auto clusModuleStartLastElement = cms::alpakatools::make_device_view(
-            alpaka::getDev(queue), clusters_d->const_view().clusModuleStart() + numberOfModules, 1u);
+        const auto clusModuleStartLastElement =
+            cms::alpakatools::make_device_view(queue, clusters_d->const_view().clusModuleStart() + numberOfModules, 1u);
         constexpr int startBPIX2 = TrackerTraits::layerStart[1];
 
         // element startBPIX2 hold the number of clusters until BPIX2
-        const auto bpix2ClusterStart = cms::alpakatools::make_device_view(
-            alpaka::getDev(queue), clusters_d->const_view().clusModuleStart() + startBPIX2, 1u);
+        const auto bpix2ClusterStart =
+            cms::alpakatools::make_device_view(queue, clusters_d->const_view().clusModuleStart() + startBPIX2, 1u);
         auto nModules_Clusters_h_1 = cms::alpakatools::make_host_view(nModules_Clusters_h.data() + 1, 1u);
         alpaka::memcpy(queue, nModules_Clusters_h_1, clusModuleStartLastElement);
 
@@ -728,8 +727,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       alpaka::exec<Acc1D>(
           queue, workDiv, CountModules<pixelTopology::Phase2>{}, digis_view, clusters_d->view(), numDigis);
 
-      auto moduleStartFirstElement =
-          cms::alpakatools::make_device_view(alpaka::getDev(queue), clusters_d->view().moduleStart(), 1u);
+      auto moduleStartFirstElement = cms::alpakatools::make_device_view(queue, clusters_d->view().moduleStart(), 1u);
       alpaka::memcpy(queue, nModules_Clusters_h, moduleStartFirstElement);
 
       const auto elementsPerBlockFindClus = FindClus<TrackerTraits>::maxElementsPerBlock;
@@ -765,12 +763,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       alpaka::exec<Acc1D>(queue, workDivOneBlock, FillHitsModuleStart<TrackerTraits>{}, clusters_d->view());
 
       // last element holds the number of all clusters
-      const auto clusModuleStartLastElement = cms::alpakatools::make_device_view(
-          alpaka::getDev(queue), clusters_d->const_view().clusModuleStart() + numberOfModules, 1u);
+      const auto clusModuleStartLastElement =
+          cms::alpakatools::make_device_view(queue, clusters_d->const_view().clusModuleStart() + numberOfModules, 1u);
       constexpr int startBPIX2 = pixelTopology::Phase2::layerStart[1];
       // element startBPIX2 hold the number of clusters until BPIX2
-      const auto bpix2ClusterStart = cms::alpakatools::make_device_view(
-          alpaka::getDev(queue), clusters_d->const_view().clusModuleStart() + startBPIX2, 1u);
+      const auto bpix2ClusterStart =
+          cms::alpakatools::make_device_view(queue, clusters_d->const_view().clusModuleStart() + startBPIX2, 1u);
       auto nModules_Clusters_h_1 = cms::alpakatools::make_host_view(nModules_Clusters_h.data() + 1, 1u);
       alpaka::memcpy(queue, nModules_Clusters_h_1, clusModuleStartLastElement);
 

--- a/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGeneratorKernels.dev.cc
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGeneratorKernels.dev.cc
@@ -66,8 +66,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
             cms::alpakatools::make_device_buffer<cms::alpakatools::AtomicPairCounter::DoubleWord[]>(queue, 3u)},
         device_hitTuple_apc_{reinterpret_cast<cms::alpakatools::AtomicPairCounter *>(device_storage_.data())},
         device_hitToTuple_apc_{reinterpret_cast<cms::alpakatools::AtomicPairCounter *>(device_storage_.data() + 1)},
-        device_nCells_{cms::alpakatools::make_device_view(alpaka::getDev(queue),
-                                                          *reinterpret_cast<uint32_t *>(device_storage_.data() + 2))} {
+        device_nCells_{
+            cms::alpakatools::make_device_view(queue, *reinterpret_cast<uint32_t *>(device_storage_.data() + 2))} {
 #ifdef GPU_DEBUG
     std::cout << "Allocation for tuple building. N hits " << nhits << std::endl;
 #endif


### PR DESCRIPTION
#### PR description:

Add specialisations of `make_device_view` with a `Queue` argument instead of a `Device`.

These functions are only for convenience: their behaviour is identical to those taking a `Device`.


#### PR validation:

None.