### PR TITLE
[RECONSTRUCTION][RISCV] Fix needed for riscv64

### DIFF
--- a/DataFormats/Math/interface/SSEVec.h
+++ b/DataFormats/Math/interface/SSEVec.h
@@ -2,7 +2,7 @@
 #define DataFormat_Math_SSEVec_H
 
 #if !defined(__arm__) && !defined(__aarch64__) && !defined(__MIC__) && !defined(__powerpc64__) && \
-    !defined(__PPC64__) && !defined(__powerpc__) && !defined(__NVCC__)
+    !defined(__PPC64__) && !defined(__powerpc__) && !defined(__NVCC__) && !defined(__riscv)
 #if defined(__GNUC__)
 #include <x86intrin.h>
 #define CMS_USE_SSE

--- a/DataFormats/Math/src/SSEVec.cc
+++ b/DataFormats/Math/src/SSEVec.cc
@@ -1,5 +1,5 @@
 #if !defined(__arm__) && !defined(__aarch64__) && !defined(__MIC__) && !defined(__powerpc64__) && \
-    !defined(__PPC64__) && !defined(__powerpc__)
+    !defined(__PPC64__) && !defined(__powerpc__) && !defined(__riscv)
 #include "DataFormats/Math/interface/SSEVec.h"
 #include "DataFormats/Math/interface/SSERot.h"
 using namespace mathSSE;

--- a/DataFormats/Math/test/rdtscp.h
+++ b/DataFormats/Math/test/rdtscp.h
@@ -2,7 +2,7 @@
 #define RDPSCP_H
 // performance test
 #if !defined(__arm__) && !defined(__aarch64__) && !defined(__powerpc64__) && !defined(__PPC64__) && \
-    !defined(__powerpc__)
+    !defined(__powerpc__) && !defined(__riscv)
 #include <x86intrin.h>
 #include <cpuid.h>
 #ifdef __clang__


### PR DESCRIPTION
This change is needed to build/use `DataFormats/Math` on riscv architecture