### PR TITLE
[CORE] [RISCV] Fix needed for riscv64

### DIFF
--- a/FWCore/Services/plugins/CPU.cc
+++ b/FWCore/Services/plugins/CPU.cc
@@ -28,6 +28,8 @@
 #include "cpu_features/cpuinfo_aarch64.h"
 #elif defined(CPU_FEATURES_ARCH_PPC)
 #include "cpu_features/cpuinfo_ppc.h"
+#elif defined(CPU_FEATURES_ARCH_RISCV)
+#include "cpu_features/cpuinfo_riscv.h"
 #endif
 
 #include <cstdlib>
@@ -253,6 +255,9 @@ namespace edm {
 #elif defined(CPU_FEATURES_ARCH_PPC)
       const auto strings{GetPPCPlatformStrings()};
       model = strings.machine;
+#elif defined(CPU_FEATURES_ARCH_RISCV)
+      const auto info{GetRiscvInfo()};
+      model = fmt::format("riscv64 {} {}", info.vendor, info.uarch);
 #endif
       return model;
     }

--- a/FWCore/Utilities/interface/HRRealTime.h
+++ b/FWCore/Utilities/interface/HRRealTime.h
@@ -76,6 +76,12 @@ namespace edm {
       __asm__ __volatile__("isb; mrs %0, cntvct_el0" : "=r"(ret));
       return ret;
     }
+#elif defined(__riscv) && __riscv_xlen == 64
+    static __inline__ unsigned long long rdtsc(void) {
+      unsigned long long cycles;
+      asm volatile("rdcycle %0" : "=r"(cycles));
+      return cycles;
+    }
 #else
 #error The file FWCore/Utilities/interface/HRRealTime.h needs to be set up for your CPU type.
 #endif


### PR DESCRIPTION
These changes are needed to build `FWCore` on `riscv64` architecture. @makortel , `GetRiscvInfo()` returns [a] structure. Let me know if we should include something form `RiscvFeatures` too.



[a] https://github.com/google/cpu_features/blob/main/include/cpuinfo_riscv.h#L44-L48
```
typedef struct {
  RiscvFeatures features;
  char uarch[64];   // 0 terminated string
  char vendor[64];  // 0 terminated string
} RiscvInfo;
```