### PR TITLE
[VISUALIZATION] [RISCV] Fix needed for riscv64

### DIFF
--- a/Fireworks/Core/interface/FWDisplayProperties.h
+++ b/Fireworks/Core/interface/FWDisplayProperties.h
@@ -63,7 +63,6 @@ public:
 
   /** Notice that transparency in root is in the range [0, 100] */
   void setTransparency(Char_t transparency) {
-    transparency = transparency < 0 ? 0 : transparency;
     transparency = transparency > 100 ? 100 : transparency;
     m_transparency = transparency;
   }


### PR DESCRIPTION
While building for `riscv64`, fireworks failed complaining that `transparency = transparency < 0 ? 0 : transparency;` is always false as `Char_t transparency` can not be less than zero.