### PR TITLE
Btag-OfflineDQM-CHS-To_PUPPI

### DIFF
--- a/DQMOffline/RecoB/python/bTagCommon_cff.py
+++ b/DQMOffline/RecoB/python/bTagCommon_cff.py
@@ -40,13 +40,13 @@ bTagCommonBlock = cms.PSet(
         cms.PSet(
             bTagTrackIPAnalysisBlock,
             type = cms.string('CandIP'),
-            label = cms.InputTag("pfImpactParameterTagInfos"),
+            label = cms.InputTag("pfImpactParameterTagInfosPuppi"),
             folder = cms.string("IPTag")
         ),
 
         cms.PSet(
             bTagProbabilityAnalysisBlock,
-            label = cms.InputTag("pfJetProbabilityBJetTags"),
+            label = cms.InputTag("pfJetProbabilityBJetTagsPuppi"),
             folder = cms.string("JP")
         ),
 

--- a/DQMOffline/RecoB/python/dqmAnalyzer_cff.py
+++ b/DQMOffline/RecoB/python/dqmAnalyzer_cff.py
@@ -21,7 +21,8 @@ from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 from PhysicsTools.JetMCAlgos.HadronAndPartonSelector_cfi import selectedHadronsAndPartons
 from PhysicsTools.JetMCAlgos.AK4PFJetsMCFlavourInfos_cfi import ak4JetFlavourInfos
 myak4JetFlavourInfos = ak4JetFlavourInfos.clone(
-    jets = "ak4PFJetsCHS",
+    jets = "ak4PFJetsPuppi",
+    weights = cms.InputTag("puppi"),
     partons = "selectedHadronsAndPartons:algorithmicPartons",
     hadronFlavourHasPriority = True
     )
@@ -35,7 +36,7 @@ ak4GenJetsForPUid = cms.EDFilter("GenJetSelector",
 #do reco gen - reco matching
 from PhysicsTools.PatAlgos.mcMatchLayer0.jetMatch_cfi import patJetGenJetMatch
 newpatJetGenJetMatch = patJetGenJetMatch.clone(
-    src = "ak4PFJetsCHS",
+    src = "ak4PFJetsPuppi",
     matched = "ak4GenJetsForPUid",
     maxDeltaR = 0.25,
     resolveAmbiguities = True

--- a/DQMOffline/RecoB/python/dqmAnalyzer_cff.py
+++ b/DQMOffline/RecoB/python/dqmAnalyzer_cff.py
@@ -62,6 +62,27 @@ bTagPlotsMC = cms.Sequence(bTagValidation)
                                       doJEC=False
 )
 
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+fastSim.toModify(myak4JetFlavourInfos,
+    jets = "ak4PFJetsCHS",
+    weights = None
+).toModify(newpatJetGenJetMatch,
+   src = "ak4PFJetsCHS",
+).toModify(bTagValidation.tagConfig[0],
+   label = "pfImpactParameterTagInfos"
+).toModify(bTagValidation.tagConfig[1],
+   label = "pfJetProbabilityBJetTags"
+)
+
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+pp_on_PbPb_run3.toModify(newpatJetGenJetMatch,
+           src = "akCs4PFJets",
+).toModify(bTagValidation.tagConfig[0],
+           label = "pfImpactParameterTagInfos"
+).toModify(bTagValidation.tagConfig[1],
+           label = "pfJetProbabilityBJetTags"
+)
+
 #to run on fullsim in the validation sequence, all histograms produced in the dqmoffline sequence
 bTagValidationNoall = bTagValidation.clone(flavPlots="bcl")
 bTagPlotsMCbcl = cms.Sequence(bTagValidationNoall)


### PR DESCRIPTION
#### PR description:
With this proposed change the Btag OfflineDQM configs have been changed to run with the PUPPI jet collection as input instead of CHS. 

#### PR validation:
```runTheMatrix.py -l 12834.0 -i all --ibeos``` runs successfully (TTbar dataset is used for validation) with the implemented changes. 
