### PR TITLE
[140X backport] MTD geometry: fix BTL numbering scheme for scenario v3

### DIFF
--- a/Geometry/MTDCommonData/src/BTLNumberingScheme.cc
+++ b/Geometry/MTDCommonData/src/BTLNumberingScheme.cc
@@ -26,6 +26,10 @@ uint32_t BTLNumberingScheme::getUnitID(const MTDBaseNumber& baseNumber) const {
     }
   }
 
+#ifdef EDM_ML_DEBUG
+  LogDebug("MTDGeom") << "BTLNumberingScheme::getUnitID(): isDD4hep " << isDD4hepOK;
+#endif
+
   auto bareBaseName = [&](std::string_view name) {
     size_t ipos = name.rfind('_');
     return (isDD4hepOK) ? name.substr(0, ipos) : name;
@@ -117,7 +121,11 @@ uint32_t BTLNumberingScheme::getUnitID(const MTDBaseNumber& baseNumber) const {
         modCopy = negModCopy[modCopy - 1];
       }
 
-      bool isV2(baseNumber.getLevelName(0).back() != 'l');
+      bool isV2(bareBaseName(baseNumber.getLevelName(0)).back() != 'l');
+
+#ifdef EDM_ML_DEBUG
+      LogDebug("MTDGeom") << "BTLNumberingScheme::getUnitID(): isV2 " << isV2;
+#endif
 
       if (isV2) {
         // V2: the type is embedded in crystal name
@@ -204,7 +212,11 @@ uint32_t BTLNumberingScheme::getUnitID(const MTDBaseNumber& baseNumber) const {
       modCopy = negModCopy[modCopy - 1];
     }
 
-    bool isV2(baseNumber.getLevelName(0).back() != 'e');
+    bool isV2(bareBaseName(baseNumber.getLevelName(0)).back() != 'e');
+
+#ifdef EDM_ML_DEBUG
+    LogDebug("MTDGeom") << "BTLNumberingScheme::getUnitID(): isV2 " << isV2;
+#endif
 
     if (isV2) {
       // V2: the type is embedded in crystal name


### PR DESCRIPTION
#### PR description:

Partial backport of #45211 to allow a smooth processing of geometries with BTL secanrio v3 also on DD4hep. This PR addresses the porblem reported by @srimanob in https://github.com/cms-sw/cmssw/pull/45513#issuecomment-2241080815 .

#### PR validation:

Workflow 29634.911 runs without any warning in CMSSW_14_0_X_2024-07-29-1100 .