### PR TITLE
Remove empty `classes_def` files from `Cond{Core,Tools}Utilities`

### DIFF
--- a/CondCore/Utilities/src/classes.h
+++ b/CondCore/Utilities/src/classes.h
@@ -1,5 +1,0 @@
-#include <iostream>
-
-namespace CondCore_Utilities {
-  struct dictionary {};
-}  // namespace CondCore_Utilities

--- a/CondCore/Utilities/src/classes_def.xml
+++ b/CondCore/Utilities/src/classes_def.xml
@@ -1,2 +1,0 @@
-<lcgdict>
-</lcgdict>   

--- a/CondTools/Utilities/test/classes_def.xml
+++ b/CondTools/Utilities/test/classes_def.xml
@@ -1,2 +1,0 @@
- <lcgdict>
-</lcgdict>   


### PR DESCRIPTION
#### PR description:

`duplicateReflexLibrarySearch.py` was indicating these files "did not have the proper information", and upon closer look, they are effectively empty, and can thus be removed.

Resolves https://github.com/cms-sw/framework-team/issues/970

#### PR validation:

Code compiles.