### PR TITLE
Remove empty `classes_def` file from `DPGAnalysis/HcalNanoAOD`

### DIFF
--- a/DPGAnalysis/HcalNanoAOD/src/classes_def.xml
+++ b/DPGAnalysis/HcalNanoAOD/src/classes_def.xml
@@ -1,3 +1,0 @@
-<lcgdict>
-    <!--<class name="hcalnano::HcalChannelInfo" persistent="false"/>-->
-</lcgdict>


### PR DESCRIPTION
#### PR description:

`duplicateReflexLibrarySearch.py` was indicating this file "did not have the proper information", and upon closer look, they are effectively empty, and can thus be removed.

Resolves https://github.com/cms-sw/framework-team/issues/971

#### PR validation:

Code compiles.