### PR TITLE
Validation/RecoEgamma Phase2 vertex_pt correction

### DIFF
--- a/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.cc
@@ -83,6 +83,8 @@ ElectronMcSignalValidatorMiniAOD::ElectronMcSignalValidatorMiniAOD(const edm::Pa
   h1_recEleNum = nullptr;
 
   h1_ele_vertexPt = nullptr;
+  h1_ele_vertexPt_EB = nullptr;
+  h1_ele_vertexPt_EE = nullptr;
   h1_ele_vertexEta = nullptr;
   h1_ele_vertexPt_nocut = nullptr;
 
@@ -143,6 +145,10 @@ void ElectronMcSignalValidatorMiniAOD::bookHistograms(DQMStore::IBooker& iBooker
   setBookPrefix("h_ele");
   h1_ele_vertexPt =
       bookH1withSumw2(iBooker, "vertexPt", "ele transverse momentum", pt_nbin, 0., pt_max, "p_{T vertex} (GeV/c)");
+  h1_ele_vertexPt_EB = bookH1withSumw2(
+      iBooker, "vertexPt_EB", "ele transverse momentum barrel", pt_nbin, 0., pt_max, "p_{T vertex} (GeV/c)");
+  h1_ele_vertexPt_EE = bookH1withSumw2(
+      iBooker, "vertexPt_EE", "ele transverse momentum endcaps", pt_nbin, 0., pt_max, "p_{T vertex} (GeV/c)");
   h1_ele_vertexEta = bookH1withSumw2(iBooker, "vertexEta", "ele momentum eta", eta_nbin, eta_min, eta_max, "#eta");
   h1_ele_vertexPt_nocut =
       bookH1withSumw2(iBooker, "vertexPt_nocut", "pT of prunned electrons", pt_nbin, 0., 20., "p_{T vertex} (GeV/c)");
@@ -430,7 +436,7 @@ void ElectronMcSignalValidatorMiniAOD::analyze(const edm::Event& iEvent, const e
       << "Treating event " << iEvent.id() << " with " << electrons_endcaps.product()->size()
       << " multi slimmed electrons";
 
-  h1_recEleNum->Fill((*electrons).size());
+  //h1_recEleNum->Fill((*electrons).size());
 
   //===============================================
   // all rec electrons
@@ -445,11 +451,14 @@ void ElectronMcSignalValidatorMiniAOD::analyze(const edm::Event& iEvent, const e
   // get a vector with EB  & EE
   //===============================================
   std::vector<pat::Electron> localCollection;
+  std::vector<pat::Electron> localCollection_EB;
+  std::vector<pat::Electron> localCollection_EE;
 
   // looking for EB
   for (el1 = electrons->begin(); el1 != electrons->end(); el1++) {
     if (el1->isEB()) {
       localCollection.push_back(*el1);
+      localCollection_EB.push_back(*el1);
     }
   }
 
@@ -457,8 +466,10 @@ void ElectronMcSignalValidatorMiniAOD::analyze(const edm::Event& iEvent, const e
   for (el1 = electrons_endcaps->begin(); el1 != electrons_endcaps->end(); el1++) {
     if (el1->isEE()) {
       localCollection.push_back(*el1);
+      localCollection_EE.push_back(*el1);
     }
   }
+  h1_recEleNum->Fill((localCollection).size());
 
   for (el3 = localCollection.begin(); el3 != localCollection.end(); el3++) {
     for (el4 = el3 + 1; el4 != localCollection.end(); el4++) {
@@ -543,6 +554,11 @@ void ElectronMcSignalValidatorMiniAOD::analyze(const edm::Event& iEvent, const e
 
       // electron related distributions
       h1_ele_vertexPt->Fill(bestGsfElectron.pt());
+      if (isEBflag) {
+        h1_ele_vertexPt_EB->Fill(bestGsfElectron.pt());
+      } else if (isEEflag) {
+        h1_ele_vertexPt_EE->Fill(bestGsfElectron.pt());
+      }
       h1_ele_vertexEta->Fill(bestGsfElectron.eta());
       if ((bestGsfElectron.scSigmaIEtaIEta() == 0.) && (bestGsfElectron.fbrem() == 0.))
         h1_ele_vertexPt_nocut->Fill(bestGsfElectron.pt());

--- a/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.h
+++ b/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.h
@@ -91,6 +91,8 @@ private:
   MonitorElement *h1_recEleNum;
 
   MonitorElement *h1_ele_vertexPt;
+  MonitorElement *h1_ele_vertexPt_EB;
+  MonitorElement *h1_ele_vertexPt_EE;
   MonitorElement *h1_ele_vertexEta;
   MonitorElement *h1_ele_vertexPt_nocut;
 

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
@@ -273,6 +273,8 @@ ElectronMcSignalValidator::ElectronMcSignalValidator(const edm::ParameterSet &co
   h2_ele_chargeVsPt = nullptr;
   h1_ele_vertexP = nullptr;
   h1_ele_vertexPt = nullptr;
+  h1_ele_vertexPt_EB = nullptr;
+  h1_ele_vertexPt_EE = nullptr;
   h1_ele_vertexPt_nocut = nullptr;
   h1_ele_Et = nullptr;
   h2_ele_vertexPtVsEta = nullptr;
@@ -1093,6 +1095,10 @@ void ElectronMcSignalValidator::bookHistograms(DQMStore::IBooker &iBooker, edm::
   h1_ele_vertexP = bookH1withSumw2(iBooker, "vertexP", "ele momentum", p_nbin, 0., p_max, "p_{vertex} (GeV/c)");
   h1_ele_vertexPt =
       bookH1withSumw2(iBooker, "vertexPt", "ele transverse momentum", pt_nbin, 0., pt_max, "p_{T vertex} (GeV/c)");
+  h1_ele_vertexPt_EB = bookH1withSumw2(
+      iBooker, "vertexPt_EB", "ele transverse momentum barrel", pt_nbin, 0., pt_max, "p_{T vertex} (GeV/c)");
+  h1_ele_vertexPt_EE = bookH1withSumw2(
+      iBooker, "vertexPt_EE", "ele transverse momentum endcaps", pt_nbin, 0., pt_max, "p_{T vertex} (GeV/c)");
   h1_ele_vertexPt_nocut = bookH1withSumw2(
       iBooker, "vertexPt_nocut", "pT of prunned electrons", pt_nbin, 0., pt_max, "p_{T vertex} (GeV/c)");
   h1_ele_Et = bookH1withSumw2(iBooker, "Et", "ele ecal E_{T}", pt_nbin, 0., pt_max, "E_{T} (GeV)");
@@ -3305,11 +3311,14 @@ void ElectronMcSignalValidator::analyze(const edm::Event &iEvent, const edm::Eve
   // get a vector with EB & EE
   //===============================================
   std::vector<reco::GsfElectron> localCollection;
+  std::vector<reco::GsfElectron> localCollection_EB;
+  std::vector<reco::GsfElectron> localCollection_EE;
 
   // looking for EB
   for (gsfIter = gsfElectrons->begin(); gsfIter != gsfElectrons->end(); gsfIter++) {
     if (gsfIter->isEB()) {
       localCollection.push_back(*gsfIter);
+      localCollection_EB.push_back(*gsfIter);
     }
   }
 
@@ -3317,6 +3326,7 @@ void ElectronMcSignalValidator::analyze(const edm::Event &iEvent, const edm::Eve
   for (gsfIter = gsfElectronsEndcaps->begin(); gsfIter != gsfElectronsEndcaps->end(); gsfIter++) {
     if (gsfIter->isEE()) {
       localCollection.push_back(*gsfIter);
+      localCollection_EE.push_back(*gsfIter);
     }
   }
 
@@ -3669,6 +3679,11 @@ void ElectronMcSignalValidator::analyze(const edm::Event &iEvent, const edm::Eve
       continue;
 
     // electron related distributions
+    if (isEBflag) {
+      h1_ele_vertexPt_EB->Fill(bestGsfElectron.pt());
+    } else if (isEEflag) {
+      h1_ele_vertexPt_EE->Fill(bestGsfElectron.pt());
+    }
     h1_ele_charge->Fill(bestGsfElectron.charge());
     h2_ele_chargeVsEta->Fill(bestGsfElectron.eta(), bestGsfElectron.charge());
     h2_ele_chargeVsPhi->Fill(bestGsfElectron.phi(), bestGsfElectron.charge());

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.h
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.h
@@ -230,6 +230,8 @@ private:
   MonitorElement *h2_ele_chargeVsPt;
   MonitorElement *h1_ele_vertexP;
   MonitorElement *h1_ele_vertexPt;
+  MonitorElement *h1_ele_vertexPt_EB;
+  MonitorElement *h1_ele_vertexPt_EE;
   MonitorElement *h1_ele_vertexPt_nocut;
   MonitorElement *h1_ele_Et;
   MonitorElement *h2_ele_vertexPtVsEta;

--- a/Validation/RecoEgamma/python/ElectronMcSignalValidatorMiniAOD_cfi.py
+++ b/Validation/RecoEgamma/python/ElectronMcSignalValidatorMiniAOD_cfi.py
@@ -48,7 +48,7 @@ electronMcSignalValidatorMiniAOD = DQMEDAnalyzer('ElectronMcSignalValidatorMiniA
     DeltaR=cms.double(0.05),
     MaxAbsEta=cms.double(2.5),
     MatchingID=cms.vint32(11, -11),
-    MatchingMotherID=cms.vint32(23, 24, -24, 32),
+    MatchingMotherID=cms.vint32(23, 24, -24, 32, 990),
     histosCfg=cms.PSet(electronMcSignalHistosCfg),
     isolationCfg=cms.PSet(electronPFIsolationCfg),
 )
@@ -64,5 +64,6 @@ phase2_hgcal.toModify(
         Nbineta2D=60,
         Etamin=-3.0,
         Etamax=3.0,
+        NbinELE = 100, ELE_min = -0.5, ELE_max = 99.5,
     ),
 )

--- a/Validation/RecoEgamma/test/ElectronMcSignalPostValidationMiniAOD_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalPostValidationMiniAOD_cfg.py
@@ -42,7 +42,7 @@ process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load('Configuration.EventContent.EventContent_cff')
 process.load('SimGeneral.MixingModule.mixNoPU_cfi')
-process.load('Configuration.Geometry.GeometryExtended2026D76Reco_cff')
+#process.load('Configuration.Geometry.GeometryExtended2026D76Reco_cff')
 process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.StandardSequences.DQMSaverAtRunEnd_cff')
 process.load('Configuration.StandardSequences.Harvesting_cff')
@@ -51,7 +51,7 @@ process.load('Configuration.StandardSequences.Harvesting_cff')
 from DQMServices.Components.DQMStoreStats_cfi import *
 dqmStoreStats.runOnEndJob = cms.untracked.bool(True)
 
-process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1))
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(-1))
 
 print('= inputPostFile : %s' % os.environ['inputPostFile'])
 localFileInput = os.environ['inputPostFile']#.replace(".root", "_a.root") #
@@ -64,14 +64,12 @@ process.electronMcSignalPostValidatorMiniAOD.OutputFolderName = cms.string("Egam
 
 from Configuration.AlCa.autoCond import autoCond
 #process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']#+'::All'
-process.GlobalTag.globaltag = '122X_mcRun4_realistic_v1'
-#process.GlobalTag.globaltag = '113X_mcRun4_realistic_v4'
-#process.GlobalTag.globaltag = '93X_mc2017_realistic_v1'
+#process.GlobalTag.globaltag = '122X_mcRun4_realistic_v1'
 
 rel = os.environ['DD_SAMPLE']
 part1 = os.environ['DD_RELEASE']
 part2 = os.environ['TEST_GLOBAL_TAG']
-process.dqmSaver.workflow = '/' + rel + '/' + part1 + '-' + part2 + '/RECO'
+process.dqmSaver.workflow = '/' + rel + '/' + part1 + '-' + part2 + '/miniAOD'
 process.dqmsave_step = cms.Path(process.DQMSaver)
 
 process.p = cms.Path(process.EDMtoME * process.electronMcSignalPostValidatorMiniAOD * process.dqmStoreStats)

--- a/Validation/RecoEgamma/test/ElectronMcSignalPostValidation_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalPostValidation_cfg.py
@@ -40,7 +40,7 @@ process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load('Configuration.EventContent.EventContent_cff')
 process.load('SimGeneral.MixingModule.mixNoPU_cfi')
-process.load('Configuration.Geometry.GeometryExtended2026D76Reco_cff')
+#process.load('Configuration.Geometry.GeometryExtended2026D76Reco_cff')
 process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.StandardSequences.DQMSaverAtRunEnd_cff')
 process.load('Configuration.StandardSequences.Harvesting_cff')
@@ -48,7 +48,7 @@ process.load('Configuration.StandardSequences.Harvesting_cff')
 from DQMServices.Components.DQMStoreStats_cfi import *
 dqmStoreStats.runOnEndJob = cms.untracked.bool(True)
 
-process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1))
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(-1))
 
 localFileInput = os.environ['inputPostFile']#.replace(".root", "_a.root") #
 # Source
@@ -61,9 +61,6 @@ process.electronMcSignalPostValidator.OutputFolderName = cms.string("EgammaV/Ele
 from Configuration.AlCa.autoCond import autoCond
 #process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']#+'::All'
 #process.GlobalTag.globaltag = '125X_mcRun3_2022_realistic_v3'
-#process.GlobalTag.globaltag = '125X_mcRun4_realistic_v2_2026D88noPU' # no more needed
-#process.GlobalTag.globaltag = '93X_mc2017_realistic_v1'
-#process.GlobalTag.globaltag = '92X_upgrade2017_realistic_v10'
 
 rel = os.environ['DD_SAMPLE']
 part1 = os.environ['DD_RELEASE']

--- a/Validation/RecoEgamma/test/ElectronMcSignalValidationMiniAOD_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalValidationMiniAOD_cfg.py
@@ -29,11 +29,10 @@ else:
     from Configuration.Eras.Era_Phase2_cff import Phase2
     process = cms.Process('electronValidation',Phase2)
 
-#process.options = cms.untracked.PSet( )
-
 process.DQMStore = cms.Service("DQMStore")
 process.load("DQMServices.Components.DQMStoreStats_cfi")
 from DQMServices.Components.DQMStoreStats_cfi import *
+
 dqmStoreStats.runOnEndJob = cms.untracked.bool(True)
 
 print("reading files ...")
@@ -43,7 +42,9 @@ process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(max_number))
 data = os.environ['data']
 flist = dd.getCMSdata(data)
 print(flist)
-process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring(*flist))
+process.source = cms.Source("PoolSource",
+    #eventsToProcess = cms.untracked.VEventRange('1:38-1:40'),
+    fileNames = cms.untracked.vstring(*flist))
 
 #process.source = cms.Source ("PoolSource",
 #eventsToProcess = cms.untracked.VEventRange('1:2682-1:2682'),
@@ -76,9 +77,7 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 from Configuration.AlCa.autoCond import autoCond
 #process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']#+'::All'
-process.GlobalTag.globaltag = '122X_mcRun4_realistic_v1'
-#process.GlobalTag.globaltag = '113X_mcRun4_realistic_v4'
-#process.GlobalTag.globaltag = '93X_mc2017_realistic_v1'
+#process.GlobalTag.globaltag = '122X_mcRun4_realistic_v1'
 
 # FOR DATA REDONE FROM RAW, ONE MUST HIDE IsoFromDeps
 # CONFIGURATION
@@ -109,6 +108,7 @@ process.electronMcSignalValidatorMiniAOD.OutputFolderName = cms.string("EgammaV/
 #process.p = cms.Path(process.ElectronIsolation * process.electronMcSignalValidatorMiniAOD * process.MEtoEDMConverter ) # * process.dqmStoreStats
 #process.p = cms.Path(process.electronMcSignalValidatorMiniAOD * process.MEtoEDMConverter * process.dqmStoreStats)
 process.p = cms.Path( process.miniAODElectronIsolation * process.ElectronIsolation * process.electronMcSignalValidatorMiniAOD * process.MEtoEDMConverter ) #  process.printContent *
+
 process.outpath = cms.EndPath(
 process.EDM,
 )

--- a/Validation/RecoEgamma/test/ElectronMcSignalValidationPt1000_gedGsfElectrons_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalValidationPt1000_gedGsfElectrons_cfg.py
@@ -76,10 +76,7 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 from Configuration.AlCa.autoCond import autoCond
 #process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']#+'::All'
-process.GlobalTag.globaltag = '122X_mcRun4_realistic_v1'
-#process.GlobalTag.globaltag = '93X_upgrade2023_realistic_v2'
-#process.GlobalTag.globaltag = '93X_upgrade2023_realistic_v0'
-#process.GlobalTag.globaltag = '93X_mc2017_realistic_v1'
+#process.GlobalTag.globaltag = '122X_mcRun4_realistic_v1'
 
 # FOR DATA REDONE FROM RAW, ONE MUST HIDE IsoFromDeps
 # CONFIGURATION

--- a/Validation/RecoEgamma/test/ElectronMcSignalValidation_gedGsfElectrons_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalValidation_gedGsfElectrons_cfg.py
@@ -35,6 +35,7 @@ from DQMServices.Components.DQMStoreStats_cfi import *
 
 dqmStoreStats.runOnEndJob = cms.untracked.bool(True)
 
+print("reading files ...")
 # max_skipped = 165
 max_number = -1  # 10 # number of events
 process.maxEvents = cms.untracked.PSet(input=cms.untracked.int32(max_number))
@@ -43,7 +44,10 @@ process.maxEvents = cms.untracked.PSet(input=cms.untracked.int32(max_number))
 data = os.environ['data']
 flist = dd.getCMSdata(data)
 print(flist)
-process.source = cms.Source("PoolSource", fileNames=cms.untracked.vstring(*flist))
+process.source = cms.Source("PoolSource",
+    #eventsToProcess = cms.untracked.VEventRange('1:38-1:40'),
+    fileNames=cms.untracked.vstring(*flist)
+)
 
 # process.source = cms.Source ("PoolSource", fileNames = cms.untracked.vstring(),secondaryFileNames = cms.untracked.vstring()) # std value
 # process.source.fileNames.extend(dd.search())  # to be commented for local run only
@@ -78,11 +82,6 @@ from Configuration.AlCa.autoCond import autoCond
 
 # process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG'] + '::All'
 #process.GlobalTag.globaltag = '120X_mcRun3_2021_realistic_v1'
-#process.GlobalTag.globaltag = '125X_mcRun3_2022_realistic_v3'
-#process.GlobalTag.globaltag = '125X_mcRun4_realistic_v2_2026D88noPU' # no more needed
-# process.GlobalTag.globaltag = '113X_mcRun3_2021_realistic_v4'
-# process.GlobalTag.globaltag = '93X_mc2017_realistic_v1'
-# process.GlobalTag.globaltag = '92X_upgrade2017_realistic_v10'
 
 # FOR DATA REDONE FROM RAW, ONE MUST HIDE IsoFromDeps
 # CONFIGURATION
@@ -103,7 +102,8 @@ process.electronMcSignalValidator.InputFolderName = cms.string("EgammaV/Electron
 process.electronMcSignalValidator.OutputFolderName = cms.string("EgammaV/ElectronMcSignalValidator")
 
 # process.p = cms.Path(process.electronIsoFromDeps * process.electronMcSignalValidator * process.MEtoEDMConverter * process.dqmStoreStats)
-process.p = cms.Path(process.electronMcSignalValidator * process.MEtoEDMConverter * process.dqmStoreStats)
+#process.p = cms.Path(process.electronMcSignalValidator * process.MEtoEDMConverter * process.dqmStoreStats)
+process.p = cms.Path(process.electronMcSignalValidator * process.MEtoEDMConverter)
 
 process.outpath = cms.EndPath(
     process.EDM,

--- a/Validation/RecoEgamma/test/electronValidationCheck_Env.py
+++ b/Validation/RecoEgamma/test/electronValidationCheck_Env.py
@@ -8,8 +8,12 @@ import os, sys
 class env:
     def checkSample(self):
         if ('DD_SAMPLE' not in os.environ) or (os.environ['DD_SAMPLE'] == ''):
-            if (len(sys.argv) > 2):  # no else part since if sample does not exist, we had quit previously
-                sampleName = str(sys.argv[2])
+            print('no existing sample name')
+            print('nb of element : ', len(sys.argv))
+            print('0 : ', sys.argv[0])
+            print('1 : ', sys.argv[1])
+            if (len(sys.argv) > 1):  # no else part since if sample does not exist, we had quit previously
+                sampleName = str(sys.argv[1])
                 os.environ['DD_SAMPLE'] = 'RelVal' + sampleName
                 print('Sample name:', sampleName, ' - ', os.environ['DD_SAMPLE'])
             else:
@@ -17,6 +21,8 @@ class env:
                 print('no sample name, quit')
                 print('====================')
                 quit()
+        else:
+            print('Existing Sample name:', sampleName, ' - ', os.environ['DD_SAMPLE'])
 
     def beginTag(self):
         beginTag = 'Phase2'
@@ -25,17 +31,13 @@ class env:
 
     def dd_tier(self):
         dd_tier = 'GEN-SIM-RECO'
-        #dd_tier = 'MINIAODSIM'
+        dd_tier = 'MINIAODSIM'
         return dd_tier
 
     def tag_startup(self):
         #tag_startup = '125X_mcRun3_2022_realistic_v3'
-        tag_startup = '125X_mcRun4_realistic_v2_2026D88noPU'
+        tag_startup = '140X_mcRun4_realistic_v4_STD_2026D110_noPU'
         # tag_startup = '113X_mcRun3_2021_realistic_v7'
-        # tag_startup = '93X_upgrade2023_realistic_v2_2023D17PU140'
-        # tag_startup = '93X_upgrade2023_realistic_v0_D17PU200'
-        # tag_startup = '92X_upgrade2023_realistic_v2_2023D17noPU'
-        # tag_startup = '93X_upgrade2023_realistic_v0_D17PU200'
         return tag_startup
 
     def data_version(self):
@@ -87,6 +89,8 @@ class env:
         os.environ['data'] = '/' + os.environ['DD_SAMPLE'] + '/' + os.environ['DD_RELEASE'] + '-' + os.environ[
             'DD_COND'] + '/' + os.environ['DD_TIER']
         os.environ['outputFile'] = 'electronHistos.' + os.environ['DD_SAMPLE_OUT'] + '_gedGsfE.root'
+        if (os.environ['DD_TIER'] == 'MINIAODSIM'):
+            os.environ['outputFile'] = 'electronHistos.' + os.environ['DD_SAMPLE_OUT'] + '_miniAOD.root'
         if ('inputPostFile' not in os.environ) or (os.environ['inputPostFile'] == ''):
             print('inputPostFile : %s' % os.environ['outputFile'])
             os.environ['inputPostFile'] = os.environ['outputFile']


### PR DESCRIPTION
#### PR description:

Adding two plots to better monitor the selection of electrons done at the miniAOD level
we can see the effect before : 
![Capture d’écran du 2024-07-30 14-31-33](https://github.com/user-attachments/assets/6fb9fa53-35e2-4a44-a8cf-fc4e2f496b88)

and after the correction : 
![Capture d’écran du 2024-07-30 14-32-02](https://github.com/user-attachments/assets/9ea74549-f511-4383-bedb-8ffbe6063453)

Tests have been made also for RECO and did not show any change.
The files into the Validation/RecoEgamma/test folder are only for local tests

#### PR validation:

compilation is OK, basics tests (scram b runtests or local tests) are OK too.

runTheMatrix.py -l limited -i all --ibeos tests are fine
47 46 45 36 19 1 1 1 1 1 1 tests passed, 0 0 0 0 0 0 0 0 0 0 0 failed
[runall-report-step123-.log](https://github.com/user-attachments/files/16428018/runall-report-step123-.log)

@beaudett 