### PR TITLE
fix packing of muon-shower objects for L1-uGT FED [`14_0_X`]

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonPacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonPacker.cc
@@ -9,7 +9,7 @@ namespace l1t {
       GMTOutputObjectMap gmtObjMap;
       std::pair<int, int> muonBx = getMuons(gmtObjMap, event, static_cast<const CommonTokens*>(toks)->getMuonToken());
       std::pair<int, int> muonShowerBx{0, 0};
-      if ((fedId_ == 1402 && fwId_ >= 0x7000000) || (fedId_ == 1404 && fwId_ >= 0x00010f01)) {
+      if (MuonRawDigiTranslator::isFwVersionWithShowers(fedId_, fwId_)) {
         muonShowerBx = getMuonShowers(gmtObjMap, event, static_cast<const CommonTokens*>(toks)->getMuonShowerToken());
       }
 

--- a/L1Trigger/L1TMuon/interface/MuonRawDigiTranslator.h
+++ b/L1Trigger/L1TMuon/interface/MuonRawDigiTranslator.h
@@ -18,6 +18,7 @@ namespace l1t {
                          int muInBx);
     static void fillMuon(Muon& mu, uint32_t raw_data_spare, uint64_t dataword, int fed, int fw, int muInBx);
     static void fillIntermediateMuon(Muon& mu, uint32_t raw_data_00_31, uint32_t raw_data_32_63, int fw);
+    static bool isFwVersionWithShowers(int fedId, int fwId);
     static bool showerFired(uint32_t shower_word, int fedId, int fwId);
     static void generatePackedMuonDataWords(const Muon& mu,
                                             uint32_t& raw_data_spare,

--- a/L1Trigger/L1TMuon/src/MuonRawDigiTranslator.cc
+++ b/L1Trigger/L1TMuon/src/MuonRawDigiTranslator.cc
@@ -262,9 +262,13 @@ void l1t::MuonRawDigiTranslator::generate64bitDataWord(
   dataword = (((uint64_t)msw) << 32) + lsw;
 }
 
+bool l1t::MuonRawDigiTranslator::isFwVersionWithShowers(int fedId, int fwId) {
+  return ((fedId == kUgmtFedId && fwId >= kUgmtFwVersionFirstWithShowers) ||
+          (fedId == kUgtFedId && fwId >= kUgtFwVersionFirstWithShowers));
+}
+
 bool l1t::MuonRawDigiTranslator::showerFired(uint32_t shower_word, int fedId, int fwId) {
-  if ((fedId == kUgmtFedId && fwId >= kUgmtFwVersionFirstWithShowers) ||
-      (fedId == kUgtFedId && fwId >= kUgtFwVersionFirstWithShowers)) {
+  if (isFwVersionWithShowers(fedId, fwId)) {
     return ((shower_word >> showerShift_) & 1) == 1;
   }
   return false;
@@ -274,8 +278,7 @@ std::array<std::array<uint32_t, 4>, 2> l1t::MuonRawDigiTranslator::getPackedShow
                                                                                             const int fedId,
                                                                                             const int fwId) {
   std::array<std::array<uint32_t, 4>, 2> res{};
-  if ((fedId == kUgmtFedId && fwId >= kUgmtFwVersionFirstWithShowers) ||
-      (fedId == kUgtFedId && fwId >= kUgtFwVersionFirstWithShowers)) {
+  if (isFwVersionWithShowers(fedId, fwId)) {
     res.at(0).at(0) = shower.isOneNominalInTime() ? (1 << showerShift_) : 0;
     res.at(0).at(1) = shower.isOneTightInTime() ? (1 << showerShift_) : 0;
   }


### PR DESCRIPTION
backport of #45519

#### PR description:

From the description of #45519:

>This PR applies the fix in #40822 to `MuonPacker.cc`. Right now, when `L1REPACK` is used to re-emulate L1T, [`gtStage2Raw`](https://github.com/cms-sw/cmssw/blob/0cbc4b00b1664496105480e9f561a29ba7c9a68b/EventFilter/L1TRawToDigi/python/gtStage2Raw_cfi.py#L3) is used to pack the L1-uGT data, `gtStage2Raw.FwId` equals `0x1150`, and `MuonPacker::getMuonShowers` is not executed because the check touched by this PR fails (b/c `0x1150 < 0x10f01`). This PR fixes the check in `MuonPacker.cc`, and moves it to a static function in `MuonRawDigiTranslator` for easier maintenance.

#### PR validation:

None.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

#45519

Bugfix which may be relevant for trigger studies in the 2024-pp production release (not necessary for online operations, in my understanding).