### PR TITLE
Decrease error threshold for BadCapIDThreshold QTest

### DIFF
--- a/DQM/HcalTasks/data/HcalQualityTests.xml
+++ b/DQM/HcalTasks/data/HcalQualityTests.xml
@@ -17,7 +17,7 @@
 
   <QTEST name="BadCapIDThreshold">
     <TYPE>ContentsWithinExpected</TYPE>
-      <PARAM name="error">1.0</PARAM>
+      <PARAM name="error">0.999</PARAM>
       <PARAM name="warning">1.0</PARAM>
       <PARAM name="minMean">-1.0</PARAM>
       <PARAM name="maxMean">0.0</PARAM>
@@ -27,7 +27,8 @@
       <PARAM name="minEntries">0</PARAM>
       <PARAM name="useEmptyBins">1</PARAM>
   </QTEST>
-  <LINK name="*Hcal/DigiTask/CapID/CapID_BadvsLS*">
+  <LINK name="*CapID_BadvsLSmod60*">
     <TestName activate="true">BadCapIDThreshold</TestName>
   </LINK>
 </TESTSCONFIGURATION>
+


### PR DESCRIPTION
#### PR description:

As discussed with @DennRoy, This PR decreases the `error` threshold of the Hcal `BadCapIDThreshold` QTest, i.e., makes the test more tolerant to errors, allowing the up to any 3 bins to fail the test for the whole plot (which translates to ~99.9% error threshold for 60x42 bins that the plot contains). 

A backport will also be created, to patch the DQM production CMSSW deployment.



