### PR TITLE
[14_0_X] Decrease error threshold for BadCapIDThreshold QTest

### DIFF
--- a/DQM/HcalTasks/data/HcalQualityTests.xml
+++ b/DQM/HcalTasks/data/HcalQualityTests.xml
@@ -17,7 +17,7 @@
 
   <QTEST name="BadCapIDThreshold">
     <TYPE>ContentsWithinExpected</TYPE>
-      <PARAM name="error">1.0</PARAM>
+      <PARAM name="error">0.999</PARAM>
       <PARAM name="warning">1.0</PARAM>
       <PARAM name="minMean">-1.0</PARAM>
       <PARAM name="maxMean">0.0</PARAM>
@@ -27,7 +27,7 @@
       <PARAM name="minEntries">0</PARAM>
       <PARAM name="useEmptyBins">1</PARAM>
   </QTEST>
-  <LINK name="*Hcal/DigiTask/CapID/CapID_BadvsLS*">
+  <LINK name="*CapID_BadvsLSmod60*">
     <TestName activate="true">BadCapIDThreshold</TestName>
   </LINK>
 </TESTSCONFIGURATION>


### PR DESCRIPTION
#### PR description:

As discussed with @DennRoy, This PR decreases the error threshold of the Hcal `BadCapIDThreshold` QTest, i.e., makes the test more tolerant to errors, allowing the up to any 3 bins to fail the test for the whole plot (which translates to ~99.9% error threshold for 60x42 bins that the plot contains).

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

backport of #45602