### PR TITLE
skip bad channels in `PFRecHitProducerKernelConstruct<T>::applyCuts`

### DIFF
--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/CalorimeterDefinitions.h
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/CalorimeterDefinitions.h
@@ -111,7 +111,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::particleFlowRecHitProducer {
       if (subdet == HcalEndcap)
         return detId2denseIdHE(detId);
 
-      printf("invalid detId: %u\n", detId);
+      printf("invalid Hcal detId: %u\n", detId);
       return kInvalidDenseId;
     }
   };
@@ -197,7 +197,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::particleFlowRecHitProducer {
       if (subdet == EcalEndcap)
         return Barrel::kSize + Endcap::denseIndex(detId);
 
-      printf("invalid detId: %u\n", detId);
+      printf("invalid Ecal detId: %u\n", detId);
       return kInvalidDenseId;
     }
 

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitProducerKernel.dev.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitProducerKernel.dev.cc
@@ -59,8 +59,19 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     const uint32_t detId = rh.detId();
     const uint32_t depth = HCAL::getDepth(detId);
     const uint32_t subdet = getSubdet(detId);
+
+    // skip bad channels
+    if (rh.chi2() < 0)
+      return false;
+
     if (topology.cutsFromDB()) {
-      threshold = topology.noiseThreshold()[HCAL::detId2denseId(detId)];
+      const auto& denseId = HCAL::detId2denseId(detId);
+      if (denseId != HCAL::kInvalidDenseId) {
+        threshold = topology.noiseThreshold()[denseId];
+      } else {
+        printf("Encountered invalid denseId for detId %u (subdetector %u)!", detId, subdet);
+        return false;
+      }
     } else {
       if (subdet == HcalBarrel) {
         threshold = params.energyThresholds()[depth - 1];


### PR DESCRIPTION
#### PR description:

This PR is a simple fix for https://github.com/cms-sw/cmssw/issues/45595 and implements the suggestion at https://github.com/cms-sw/cmssw/issues/45595#issuecomment-2259266422
Skips bad channels in `PFRecHitProducerKernelConstruct<T>::applyCuts`
- as implemented in `HcalRecHitSoAToLegacy`
- also check `denseId` validity before retrieving  the corresponding PF threshold

#### PR validation:

Run successfully the reproducer script at https://github.com/cms-sw/cmssw/issues/45595#issuecomment-2259202142.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, we might backported it if accepted. In that case we'll need an urgent patch on to of `CMSSW_14_0_13`
