### PR TITLE
Add L1TCaloLayer1Summary and necessary changes to emulator

### DIFF
--- a/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
@@ -178,6 +178,29 @@ process.schedule = cms.Schedule(
 )
 
 #--------------------------------------------------
+# L1T Emulator
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+process.load('L1Trigger.Configuration.SimL1Emulator_cff')
+process.load('L1Trigger.Configuration.CaloTriggerPrimitives_cff')
+process.load('EventFilter.L1TXRawToDigi.caloLayer1Stage2Digis_cfi')
+process.load('SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cff')
+process.load('CalibCalorimetry.CaloTPG.CaloTPGTranscoder_cfi')
+
+from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
+associatePatAlgosToolsTask(process)
+
+from L1Trigger.Configuration.customiseReEmul import L1TReEmulFromRAW
+process = L1TReEmulFromRAW(process)
+
+process.simCaloStage2Layer1Summary.caloLayer1Regions = cms.InputTag("caloLayer1Digis", "")
+
+#--------------------------------------------------
 # Process Customizations
 
 from DQM.Integration.config.online_customizations_cfi import *

--- a/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
@@ -178,29 +178,6 @@ process.schedule = cms.Schedule(
 )
 
 #--------------------------------------------------
-# L1T Emulator
-process.load('Configuration.StandardSequences.Services_cff')
-process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
-process.load('FWCore.MessageService.MessageLogger_cfi')
-process.load('Configuration.EventContent.EventContent_cff')
-process.load('Configuration.StandardSequences.MagneticField_cff')
-process.load('Configuration.StandardSequences.EndOfProcess_cff')
-process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
-process.load('L1Trigger.Configuration.SimL1Emulator_cff')
-process.load('L1Trigger.Configuration.CaloTriggerPrimitives_cff')
-process.load('EventFilter.L1TXRawToDigi.caloLayer1Stage2Digis_cfi')
-process.load('SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cff')
-process.load('CalibCalorimetry.CaloTPG.CaloTPGTranscoder_cfi')
-
-from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
-associatePatAlgosToolsTask(process)
-
-from L1Trigger.Configuration.customiseReEmul import L1TReEmulFromRAW
-process = L1TReEmulFromRAW(process)
-
-process.simCaloStage2Layer1Summary.caloLayer1Regions = cms.InputTag("caloLayer1Digis", "")
-
-#--------------------------------------------------
 # Process Customizations
 
 from DQM.Integration.config.online_customizations_cfi import *

--- a/DQM/L1TMonitor/interface/L1TCaloLayer1Summary.h
+++ b/DQM/L1TMonitor/interface/L1TCaloLayer1Summary.h
@@ -1,0 +1,73 @@
+// -*- C++ -*-
+//
+// Package:    L1TMonitor/L1TCaloLayer1Summary
+// Class:      L1TCaloLayer1Summary
+//
+/**\class L1TCaloLayer1Summary L1TCaloLayer1Summary.cc Demo/L1TCaloLayer1Summary/plugins/L1TCaloLayer1Summary.cc
+
+ Description: DQM Analyzer for CaloLayer1 regions and CICADAScore
+
+ Implementation:
+     This module uses emulator sequence for CaloLayer1.
+*/
+//
+// Original Author:  Max Zhao <max.zhao@princeton.edu>
+//         Created:  31 Jul 2024
+//
+//
+
+// system include files
+#include <memory>
+#include <string>
+
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include "DataFormats/L1CaloTrigger/interface/CICADA.h"
+#include "DataFormats/L1CaloTrigger/interface/L1CaloCollections.h"
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
+#include "EventFilter/L1TXRawToDigi/interface/UCTDAQRawData.h"
+#include "EventFilter/L1TXRawToDigi/interface/UCTAMCRawData.h"
+
+class L1TCaloLayer1Summary : public DQMEDAnalyzer {
+public:
+  explicit L1TCaloLayer1Summary(const edm::ParameterSet&);
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override;
+
+  // ----------member data ---------------------------
+  edm::EDGetTokenT<l1t::CICADABxCollection> caloLayer1CICADAScoreToken_;
+  edm::EDGetTokenT<l1t::CICADABxCollection> gtCICADAScoreToken_;
+  edm::EDGetTokenT<l1t::CICADABxCollection> simCICADAScoreToken_;
+  edm::EDGetTokenT<L1CaloRegionCollection> caloLayer1RegionsToken_;
+  edm::EDGetTokenT<L1CaloRegionCollection> simRegionsToken_;
+  edm::EDGetTokenT<FEDRawDataCollection> fedRawData_;
+
+  dqm::reco::MonitorElement* histoCaloLayer1CICADAScore;
+  dqm::reco::MonitorElement* histoGtCICADAScore;
+  dqm::reco::MonitorElement* histoSimCICADAScore;
+  dqm::reco::MonitorElement* histoCaloMinusSim;
+  dqm::reco::MonitorElement* histoCaloMinusGt;
+  dqm::reco::MonitorElement* histoSlot7MinusDaqBxid;
+  dqm::reco::MonitorElement* histoCaloRegions;
+  dqm::reco::MonitorElement* histoSimRegions;
+  dqm::reco::MonitorElement* histoCaloMinusSimRegions;
+
+  std::string histFolder_;
+};

--- a/DQM/L1TMonitor/interface/L1TCaloLayer1Summary.h
+++ b/DQM/L1TMonitor/interface/L1TCaloLayer1Summary.h
@@ -40,6 +40,7 @@
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "EventFilter/L1TXRawToDigi/interface/UCTDAQRawData.h"
 #include "EventFilter/L1TXRawToDigi/interface/UCTAMCRawData.h"
+#include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 
 class L1TCaloLayer1Summary : public DQMEDAnalyzer {
 public:

--- a/DQM/L1TMonitor/plugins/SealModule.cc
+++ b/DQM/L1TMonitor/plugins/SealModule.cc
@@ -27,6 +27,9 @@ DEFINE_FWK_MODULE(L1TGMT);
 #include "DQM/L1TMonitor/interface/L1TStage2CaloLayer1.h"
 DEFINE_FWK_MODULE(L1TStage2CaloLayer1);
 
+#include "DQM/L1TMonitor/interface/L1TCaloLayer1Summary.h"
+DEFINE_FWK_MODULE(L1TCaloLayer1Summary);
+
 #include "DQM/L1TMonitor/interface/L1TStage2CaloLayer2.h"
 DEFINE_FWK_MODULE(L1TStage2CaloLayer2);
 

--- a/DQM/L1TMonitor/python/L1TCaloLayer1Summary_cff.py
+++ b/DQM/L1TMonitor/python/L1TCaloLayer1Summary_cff.py
@@ -1,10 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
-from Configuration.Eras.Modifier_stage2L1Trigger_2017_cff import stage2L1Trigger_2017
-from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
-
-from L1Trigger.Configuration.SimL1Emulator_cff import *
 from L1Trigger.Configuration.CaloTriggerPrimitives_cff import *
 simEcalTriggerPrimitiveDigis.Label = 'ecalDigis'
 simHcalTriggerPrimitiveDigis.inputLabel = cms.VInputTag(
@@ -15,95 +10,13 @@ simHcalTriggerPrimitiveDigis.inputUpgradeLabel = cms.VInputTag(
             cms.InputTag('hcalDigis'),
             cms.InputTag('hcalDigis')
 )
-simDtTriggerPrimitiveDigis.digiTag = cms.InputTag("muonDTDigis")
-simCscTriggerPrimitiveDigis.CSCComparatorDigiProducer = cms.InputTag( 'muonCSCDigis', 'MuonCSCComparatorDigi')
-simCscTriggerPrimitiveDigis.CSCWireDigiProducer       = cms.InputTag( 'muonCSCDigis', 'MuonCSCWireDigi' )  
-L1TReEmul = cms.Sequence(simEcalTriggerPrimitiveDigis * simHcalTriggerPrimitiveDigis * SimL1Emulator)
 
-from L1Trigger.L1TCaloLayer1.simCaloStage2Layer1Summary_cfi import simCaloStage2Layer1Summary as _simCaloStage2Layer1Summary
-cicadaEmulFromDigis = _simCaloStage2Layer1Summary.clone(caloLayer1Regions = cms.InputTag("caloLayer1Digis", ""))
-L1TReEmul.replace(simCaloStage2Layer1Summary, cicadaEmulFromDigis)
+from L1Trigger.L1TCaloLayer1.simCaloStage2Layer1Summary_cfi import *
+from L1Trigger.L1TCaloLayer1.simCaloStage2Layer1Digis_cfi import *
+from DQM.L1TMonitor.L1TCaloLayer1Summary_cfi import *
 
-# TwinMux
-stage2L1Trigger.toModify(simTwinMuxDigis,
-    RPC_Source         = 'rpcTwinMuxRawToDigi',
-    DTDigi_Source      = 'twinMuxStage2Digis:PhIn',
-    DTThetaDigi_Source = 'twinMuxStage2Digis:ThIn'
-)
-# BMTF
-stage2L1Trigger.toModify(simBmtfDigis,
-DTDigi_Source         = "simTwinMuxDigis",
-DTDigi_Theta_Source   = "bmtfDigis"
-)
-# KBMTF
-stage2L1Trigger.toModify(simKBmtfStubs,
-srcPhi       = 'simTwinMuxDigis',
-srcTheta     = 'bmtfDigis'
-)
-# OMTF
-stage2L1Trigger.toModify(simOmtfDigis,
-    srcRPC  = 'muonRPCDigis',
-    srcCSC  = 'csctfDigis',
-    srcDTPh = 'bmtfDigis',
-    srcDTTh = 'bmtfDigis'
-)
-# EMTF
-stage2L1Trigger.toModify(simEmtfDigis,
-    CSCInput = 'emtfStage2Digis',
-    RPCInput = 'muonRPCDigis'
-)
-# Calo Layer1
-stage2L1Trigger.toModify(simCaloStage2Layer1Digis,
-    ecalToken = 'ecalDigis:EcalTriggerPrimitives',
-    hcalToken = 'hcalDigis:'
-)
+simCaloStage2Layer1Summary.caloLayer1Regions = cms.InputTag("caloLayer1Digis", "")
+simCaloStage2Layer1Digis.ecalToken = cms.InputTag("ecalDigis", "EcalTriggerPrimitives")
+simCaloStage2Layer1Digis.hcalToken = cms.InputTag("hcalDigis", "")
 
-(~stage2L1Trigger).toModify(simRctDigis,
-    ecalDigis = ['ecalDigis:EcalTriggerPrimitives'],
-    hcalDigis = ['hcalDigis:']
-)
-(~stage2L1Trigger).toModify(simRpcTriggerDigis, label = 'muonRPCDigis')
-
-# if not hasattr(process, 'L1TReEmulPath'):
-#     process.L1TReEmulPath = cms.Path(process.L1TReEmul)    
-#     process.schedule.append(process.L1TReEmulPath)
-
-stage2L1Trigger_2017.toModify(simOmtfDigis,
-    srcRPC   = 'omtfStage2Digis',
-    srcCSC   = 'omtfStage2Digis',
-    srcDTPh  = 'omtfStage2Digis',
-    srcDTTh  = 'omtfStage2Digis'
-)
-
-stage2L1Trigger.toModify(simEmtfDigis,
-    CSCInput  = cms.InputTag('emtfStage2Digis'),
-    RPCInput  = cms.InputTag('muonRPCDigis'),
-    CPPFInput = cms.InputTag('emtfStage2Digis'),
-    GEMEnable = cms.bool(False),
-    GEMInput  = cms.InputTag('muonGEMPadDigis'),
-    CPPFEnable = cms.bool(True), # Use CPPF-emulated clustered RPC hits from CPPF as the RPC hits
-)
-
-run3_GEM.toModify(simMuonGEMPadDigis,
-    InputCollection         = 'muonGEMDigis',
-)
-
-run3_GEM.toModify(simTwinMuxDigis,
-    RPC_Source         = 'rpcTwinMuxRawToDigi',
-    DTDigi_Source      = 'simDtTriggerPrimitiveDigis',
-    DTThetaDigi_Source = 'simDtTriggerPrimitiveDigis'
-)
-
-run3_GEM.toModify(simKBmtfStubs,
-    srcPhi   = 'bmtfDigis',
-    srcTheta = 'bmtfDigis'
-)
-
-run3_GEM.toModify(simBmtfDigis,
-    DTDigi_Source       = 'bmtfDigis',
-    DTDigi_Theta_Source = 'bmtfDigis'
-)
-
-from DQM.L1TMonitor.L1TCaloLayer1Summary_cfi import l1tCaloLayer1Summary as _l1tCaloLayer1Summary
-l1tCaloLayer1Summary = _l1tCaloLayer1Summary.clone(simCICADAScore = cms.InputTag("cicadaEmulFromDigis", "CICADAScore"))
-l1tCaloLayer1SummarySeq = cms.Sequence(L1TReEmul * l1tCaloLayer1Summary)
+l1tCaloLayer1SummarySeq = cms.Sequence(simEcalTriggerPrimitiveDigis * simHcalTriggerPrimitiveDigis * simCaloStage2Layer1Digis * simCaloStage2Layer1Summary * l1tCaloLayer1Summary)

--- a/DQM/L1TMonitor/python/L1TCaloLayer1Summary_cff.py
+++ b/DQM/L1TMonitor/python/L1TCaloLayer1Summary_cff.py
@@ -1,0 +1,109 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+from Configuration.Eras.Modifier_stage2L1Trigger_2017_cff import stage2L1Trigger_2017
+from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
+
+from L1Trigger.Configuration.SimL1Emulator_cff import *
+from L1Trigger.Configuration.CaloTriggerPrimitives_cff import *
+simEcalTriggerPrimitiveDigis.Label = 'ecalDigis'
+simHcalTriggerPrimitiveDigis.inputLabel = cms.VInputTag(
+    cms.InputTag('hcalDigis'),
+    cms.InputTag('hcalDigis')
+)
+simHcalTriggerPrimitiveDigis.inputUpgradeLabel = cms.VInputTag(
+            cms.InputTag('hcalDigis'),
+            cms.InputTag('hcalDigis')
+)
+simDtTriggerPrimitiveDigis.digiTag = cms.InputTag("muonDTDigis")
+simCscTriggerPrimitiveDigis.CSCComparatorDigiProducer = cms.InputTag( 'muonCSCDigis', 'MuonCSCComparatorDigi')
+simCscTriggerPrimitiveDigis.CSCWireDigiProducer       = cms.InputTag( 'muonCSCDigis', 'MuonCSCWireDigi' )  
+L1TReEmul = cms.Sequence(simEcalTriggerPrimitiveDigis * simHcalTriggerPrimitiveDigis * SimL1Emulator)
+
+from L1Trigger.L1TCaloLayer1.simCaloStage2Layer1Summary_cfi import simCaloStage2Layer1Summary as _simCaloStage2Layer1Summary
+cicadaEmulFromDigis = _simCaloStage2Layer1Summary.clone(caloLayer1Regions = cms.InputTag("caloLayer1Digis", ""))
+L1TReEmul.replace(simCaloStage2Layer1Summary, cicadaEmulFromDigis)
+
+# TwinMux
+stage2L1Trigger.toModify(simTwinMuxDigis,
+    RPC_Source         = 'rpcTwinMuxRawToDigi',
+    DTDigi_Source      = 'twinMuxStage2Digis:PhIn',
+    DTThetaDigi_Source = 'twinMuxStage2Digis:ThIn'
+)
+# BMTF
+stage2L1Trigger.toModify(simBmtfDigis,
+DTDigi_Source         = "simTwinMuxDigis",
+DTDigi_Theta_Source   = "bmtfDigis"
+)
+# KBMTF
+stage2L1Trigger.toModify(simKBmtfStubs,
+srcPhi       = 'simTwinMuxDigis',
+srcTheta     = 'bmtfDigis'
+)
+# OMTF
+stage2L1Trigger.toModify(simOmtfDigis,
+    srcRPC  = 'muonRPCDigis',
+    srcCSC  = 'csctfDigis',
+    srcDTPh = 'bmtfDigis',
+    srcDTTh = 'bmtfDigis'
+)
+# EMTF
+stage2L1Trigger.toModify(simEmtfDigis,
+    CSCInput = 'emtfStage2Digis',
+    RPCInput = 'muonRPCDigis'
+)
+# Calo Layer1
+stage2L1Trigger.toModify(simCaloStage2Layer1Digis,
+    ecalToken = 'ecalDigis:EcalTriggerPrimitives',
+    hcalToken = 'hcalDigis:'
+)
+
+(~stage2L1Trigger).toModify(simRctDigis,
+    ecalDigis = ['ecalDigis:EcalTriggerPrimitives'],
+    hcalDigis = ['hcalDigis:']
+)
+(~stage2L1Trigger).toModify(simRpcTriggerDigis, label = 'muonRPCDigis')
+
+# if not hasattr(process, 'L1TReEmulPath'):
+#     process.L1TReEmulPath = cms.Path(process.L1TReEmul)    
+#     process.schedule.append(process.L1TReEmulPath)
+
+stage2L1Trigger_2017.toModify(simOmtfDigis,
+    srcRPC   = 'omtfStage2Digis',
+    srcCSC   = 'omtfStage2Digis',
+    srcDTPh  = 'omtfStage2Digis',
+    srcDTTh  = 'omtfStage2Digis'
+)
+
+stage2L1Trigger.toModify(simEmtfDigis,
+    CSCInput  = cms.InputTag('emtfStage2Digis'),
+    RPCInput  = cms.InputTag('muonRPCDigis'),
+    CPPFInput = cms.InputTag('emtfStage2Digis'),
+    GEMEnable = cms.bool(False),
+    GEMInput  = cms.InputTag('muonGEMPadDigis'),
+    CPPFEnable = cms.bool(True), # Use CPPF-emulated clustered RPC hits from CPPF as the RPC hits
+)
+
+run3_GEM.toModify(simMuonGEMPadDigis,
+    InputCollection         = 'muonGEMDigis',
+)
+
+run3_GEM.toModify(simTwinMuxDigis,
+    RPC_Source         = 'rpcTwinMuxRawToDigi',
+    DTDigi_Source      = 'simDtTriggerPrimitiveDigis',
+    DTThetaDigi_Source = 'simDtTriggerPrimitiveDigis'
+)
+
+run3_GEM.toModify(simKBmtfStubs,
+    srcPhi   = 'bmtfDigis',
+    srcTheta = 'bmtfDigis'
+)
+
+run3_GEM.toModify(simBmtfDigis,
+    DTDigi_Source       = 'bmtfDigis',
+    DTDigi_Theta_Source = 'bmtfDigis'
+)
+
+from DQM.L1TMonitor.L1TCaloLayer1Summary_cfi import l1tCaloLayer1Summary as _l1tCaloLayer1Summary
+l1tCaloLayer1Summary = _l1tCaloLayer1Summary.clone(simCICADAScore = cms.InputTag("cicadaEmulFromDigis", "CICADAScore"))
+l1tCaloLayer1SummarySeq = cms.Sequence(L1TReEmul * l1tCaloLayer1Summary)

--- a/DQM/L1TMonitor/python/L1TCaloLayer1Summary_cfi.py
+++ b/DQM/L1TMonitor/python/L1TCaloLayer1Summary_cfi.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+
+l1tCaloLayer1Summary = DQMEDAnalyzer("L1TCaloLayer1Summary",
+    caloLayer1CICADAScore = cms.InputTag("caloLayer1Digis", "CICADAScore"),
+    gtCICADAScore = cms.InputTag("gtTestcrateStage2Digis", "CICADAScore"),
+    simCICADAScore = cms.InputTag("simCaloStage2Layer1Summary", "CICADAScore"),
+    caloLayer1Regions = cms.InputTag("caloLayer1Digis", ""),
+    simRegions = cms.InputTag("simCaloStage2Layer1Digis", ""),
+    fedRawDataLabel  = cms.InputTag("rawDataCollector"),
+    histFolder = cms.string('L1T/L1TCaloLayer1Summary')
+)

--- a/DQM/L1TMonitor/python/L1TStage2_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2_cff.py
@@ -9,6 +9,9 @@ from DQM.L1TMonitor.L1TStage2CaloLayer1_cfi import *
 # CaloLayer2
 from DQM.L1TMonitor.L1TStage2CaloLayer2_cfi import *
 
+# CaloLayer1Summary
+from DQM.L1TMonitor.L1TCaloLayer1Summary_cfi import *
+
 # BMTF
 from DQM.L1TMonitor.L1TStage2BMTF_cff import *
 
@@ -47,7 +50,8 @@ l1tStage2OnlineDQM = cms.Sequence(
     l1tStage2RegionalShower +  
     l1tStage2uGMTOnlineDQMSeq +
     l1tObjectsTiming +
-    l1tStage2uGTOnlineDQMSeq
+    l1tStage2uGTOnlineDQMSeq +
+    l1tCaloLayer1Summary
 )
 
 # sequence to run only for validation events

--- a/DQM/L1TMonitor/python/L1TStage2_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2_cff.py
@@ -10,7 +10,7 @@ from DQM.L1TMonitor.L1TStage2CaloLayer1_cfi import *
 from DQM.L1TMonitor.L1TStage2CaloLayer2_cfi import *
 
 # CaloLayer1Summary
-from DQM.L1TMonitor.L1TCaloLayer1Summary_cfi import *
+from DQM.L1TMonitor.L1TCaloLayer1Summary_cff import *
 
 # BMTF
 from DQM.L1TMonitor.L1TStage2BMTF_cff import *
@@ -51,7 +51,7 @@ l1tStage2OnlineDQM = cms.Sequence(
     l1tStage2uGMTOnlineDQMSeq +
     l1tObjectsTiming +
     l1tStage2uGTOnlineDQMSeq +
-    l1tCaloLayer1Summary
+    l1tCaloLayer1SummarySeq
 )
 
 # sequence to run only for validation events

--- a/DQM/L1TMonitor/src/L1TCaloLayer1Summary.cc
+++ b/DQM/L1TMonitor/src/L1TCaloLayer1Summary.cc
@@ -45,8 +45,17 @@ void L1TCaloLayer1Summary::analyze(const edm::Event& iEvent, const edm::EventSet
   }
   int matrixSize = maxEtaIdx + 1;
 
-  bool foundMatrix[2][matrixSize][matrixSize] = {};
-  int etMatrix[2][matrixSize][matrixSize] = {};
+  bool foundMatrix[2][matrixSize][matrixSize];
+  int etMatrix[2][matrixSize][matrixSize];
+  for (int i = 0; i < 2; i++) {
+    for (int j = 0; j < matrixSize; j++) {
+      for (int k = 0; k < matrixSize; k++) {
+        foundMatrix[i][j][k] = false;
+        etMatrix[i][j][k] = 0;
+      }
+    }
+  }
+
   for (int iRegion = 0; iRegion < nRegions; iRegion++) {
     L1CaloRegion cRegion = caloLayer1Regions[iRegion];
     L1CaloRegion sRegion = simRegions[iRegion];

--- a/DQM/L1TMonitor/src/L1TCaloLayer1Summary.cc
+++ b/DQM/L1TMonitor/src/L1TCaloLayer1Summary.cc
@@ -9,8 +9,7 @@ L1TCaloLayer1Summary::L1TCaloLayer1Summary(const edm::ParameterSet& iConfig)
           consumes<L1CaloRegionCollection>(iConfig.getParameter<edm::InputTag>("caloLayer1Regions"))),
       simRegionsToken_(consumes<L1CaloRegionCollection>(iConfig.getParameter<edm::InputTag>("simRegions"))),
       fedRawData_(consumes<FEDRawDataCollection>(iConfig.getParameter<edm::InputTag>("fedRawDataLabel"))),
-      histFolder_(iConfig.getParameter<std::string>("histFolder")) {
-}
+      histFolder_(iConfig.getParameter<std::string>("histFolder")) {}
 
 // ------------ method called for each event  ------------
 void L1TCaloLayer1Summary::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {

--- a/DQM/L1TMonitor/src/L1TCaloLayer1Summary.cc
+++ b/DQM/L1TMonitor/src/L1TCaloLayer1Summary.cc
@@ -1,14 +1,15 @@
 #include "DQM/L1TMonitor/interface/L1TCaloLayer1Summary.h"
 
 L1TCaloLayer1Summary::L1TCaloLayer1Summary(const edm::ParameterSet& iConfig)
-    : caloLayer1CICADAScoreToken_(consumes<l1t::CICADABxCollection>(iConfig.getParameter<edm::InputTag>("caloLayer1CICADAScore"))),
-    gtCICADAScoreToken_(consumes<l1t::CICADABxCollection>(iConfig.getParameter<edm::InputTag>("gtCICADAScore"))),
-    simCICADAScoreToken_(consumes<l1t::CICADABxCollection>(iConfig.getParameter<edm::InputTag>("simCICADAScore"))),
-    caloLayer1RegionsToken_(consumes<L1CaloRegionCollection>(iConfig.getParameter<edm::InputTag>("caloLayer1Regions"))),
-    simRegionsToken_(consumes<L1CaloRegionCollection>(iConfig.getParameter<edm::InputTag>("simRegions"))),
-    fedRawData_(consumes<FEDRawDataCollection>(iConfig.getParameter<edm::InputTag>("fedRawDataLabel"))),
-    histFolder_(iConfig.getParameter<std::string>("histFolder")) {
-}
+    : caloLayer1CICADAScoreToken_(
+          consumes<l1t::CICADABxCollection>(iConfig.getParameter<edm::InputTag>("caloLayer1CICADAScore"))),
+      gtCICADAScoreToken_(consumes<l1t::CICADABxCollection>(iConfig.getParameter<edm::InputTag>("gtCICADAScore"))),
+      simCICADAScoreToken_(consumes<l1t::CICADABxCollection>(iConfig.getParameter<edm::InputTag>("simCICADAScore"))),
+      caloLayer1RegionsToken_(
+          consumes<L1CaloRegionCollection>(iConfig.getParameter<edm::InputTag>("caloLayer1Regions"))),
+      simRegionsToken_(consumes<L1CaloRegionCollection>(iConfig.getParameter<edm::InputTag>("simRegions"))),
+      fedRawData_(consumes<FEDRawDataCollection>(iConfig.getParameter<edm::InputTag>("fedRawDataLabel"))),
+      histFolder_(iConfig.getParameter<std::string>("histFolder")) {}
 
 // ------------ method called for each event  ------------
 void L1TCaloLayer1Summary::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
@@ -88,16 +89,18 @@ void L1TCaloLayer1Summary::bookHistograms(DQMStore::IBooker& ibooker, edm::Run c
   histoSlot7MinusDaqBxid = ibooker.book1D("slot7BXID", "Slot 7- DAQ BXID", 50, -20, 20);
 
   ibooker.setCurrentFolder(histFolder_ + "/CICADAScore");
-  histoCaloLayer1CICADAScore = ibooker.book1D("caloLayer1CICADAScore" , "CaloLayer1 CICADAScore" , 50 , 0 , 200 );
-  histoGtCICADAScore = ibooker.book1D("gtCICADAScore" , "GT CICADAScore at BX0" , 50 , 0 , 200 );
-  histoCaloMinusGt = ibooker.book1D("caloMinusGtCICADAScore" , "CaloLayer1 - GT CICADAScore at BX0", 50, -50, 50);
-  histoSimCICADAScore = ibooker.book1D("simCaloLayer1CICADAScore" , "simCaloLayer1 CICADAScore" , 50 , 0 , 200 );
-  histoCaloMinusSim = ibooker.book1D("caloMinusSimCICADAScore" , "CaloLayer1 - simCaloLayer1 CICADAScore", 50, -50, 50);
+  histoCaloLayer1CICADAScore = ibooker.book1D("caloLayer1CICADAScore", "CaloLayer1 CICADAScore", 50, 0, 200);
+  histoGtCICADAScore = ibooker.book1D("gtCICADAScore", "GT CICADAScore at BX0", 50, 0, 200);
+  histoCaloMinusGt = ibooker.book1D("caloMinusGtCICADAScore", "CaloLayer1 - GT CICADAScore at BX0", 50, -50, 50);
+  histoSimCICADAScore = ibooker.book1D("simCaloLayer1CICADAScore", "simCaloLayer1 CICADAScore", 50, 0, 200);
+  histoCaloMinusSim = ibooker.book1D("caloMinusSimCICADAScore", "CaloLayer1 - simCaloLayer1 CICADAScore", 50, -50, 50);
 
   ibooker.setCurrentFolder(histFolder_ + "/Regions");
-  histoCaloMinusSimRegions = ibooker.book2D("caloMinusSumRegions", "CaloLayer1 - simCaloLayer1 Regions;Region;ET", 252, -0.5, 252.5, 100, -400, 400);
+  histoCaloMinusSimRegions = ibooker.book2D(
+      "caloMinusSumRegions", "CaloLayer1 - simCaloLayer1 Regions;Region;ET", 252, -0.5, 252.5, 100, -400, 400);
   histoCaloRegions = ibooker.book2D("caloLayer1Regions", "CaloLayer1 Regions;Region;ET", 252, -0.5, 252.5, 100, 0, 800);
-  histoSimRegions = ibooker.book2D("simCaloLayer1Regions", "simCaloLayer1 Regions;Region;ET", 252, -0.5, 252.5, 100, 0, 800);
+  histoSimRegions =
+      ibooker.book2D("simCaloLayer1Regions", "simCaloLayer1 Regions;Region;ET", 252, -0.5, 252.5, 100, 0, 800);
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------

--- a/DQM/L1TMonitor/src/L1TCaloLayer1Summary.cc
+++ b/DQM/L1TMonitor/src/L1TCaloLayer1Summary.cc
@@ -102,15 +102,30 @@ void L1TCaloLayer1Summary::bookHistograms(DQMStore::IBooker& ibooker, edm::Run c
   histoCaloLayer1CICADAScore = ibooker.book1D("caloLayer1CICADAScore", "CaloLayer1 CICADAScore", 50, 0, 200);
   histoGtCICADAScore = ibooker.book1D("gtCICADAScore", "GT CICADAScore at BX0", 50, 0, 200);
   histoCaloMinusGt = ibooker.book1D("caloMinusGtCICADAScore", "CaloLayer1 - GT CICADAScore at BX0", 50, -50, 50);
-  histoSimCICADAScore = ibooker.book1D("simCaloLayer1CICADAScore", "simCaloLayer1 CICADAScore", 50, 0, 200);
-  histoCaloMinusSim = ibooker.book1D("caloMinusSimCICADAScore", "CaloLayer1 - simCaloLayer1 CICADAScore", 50, -50, 50);
+  histoSimCICADAScore =
+      ibooker.book1D("simCaloLayer1CICADAScore", "simCaloLayer1 CICADAScore (input: DAQ regions)", 50, 0, 200);
+  histoCaloMinusSim = ibooker.book1D(
+      "caloMinusSimCICADAScore", "CaloLayer1 - simCaloLayer1 (input: DAQ regions) CICADAScore", 50, -50, 50);
 
   ibooker.setCurrentFolder(histFolder_ + "/Regions");
-  histoCaloMinusSimRegions = ibooker.book2D(
-      "caloMinusSumRegions", "CaloLayer1 - simCaloLayer1 Regions;Region;ET", 252, -0.5, 252.5, 100, -400, 400);
+  histoCaloMinusSimRegions =
+      ibooker.book2D("caloMinusSumRegions",
+                     "CaloLayer1 - simCaloLayer1 (input: DAQ trigger primatives) Regions;Region;ET Difference",
+                     252,
+                     -0.5,
+                     252.5,
+                     100,
+                     -400,
+                     400);
   histoCaloRegions = ibooker.book2D("caloLayer1Regions", "CaloLayer1 Regions;Region;ET", 252, -0.5, 252.5, 100, 0, 800);
-  histoSimRegions =
-      ibooker.book2D("simCaloLayer1Regions", "simCaloLayer1 Regions;Region;ET", 252, -0.5, 252.5, 100, 0, 800);
+  histoSimRegions = ibooker.book2D("simCaloLayer1Regions",
+                                   "simCaloLayer1 Regions (input: DAQ trigger primatives);Region;ET",
+                                   252,
+                                   -0.5,
+                                   252.5,
+                                   100,
+                                   0,
+                                   800);
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------

--- a/DQM/L1TMonitor/src/L1TCaloLayer1Summary.cc
+++ b/DQM/L1TMonitor/src/L1TCaloLayer1Summary.cc
@@ -1,0 +1,119 @@
+#include "DQM/L1TMonitor/interface/L1TCaloLayer1Summary.h"
+
+L1TCaloLayer1Summary::L1TCaloLayer1Summary(const edm::ParameterSet& iConfig)
+    : caloLayer1CICADAScoreToken_(consumes<l1t::CICADABxCollection>(iConfig.getParameter<edm::InputTag>("caloLayer1CICADAScore"))),
+    gtCICADAScoreToken_(consumes<l1t::CICADABxCollection>(iConfig.getParameter<edm::InputTag>("gtCICADAScore"))),
+    simCICADAScoreToken_(consumes<l1t::CICADABxCollection>(iConfig.getParameter<edm::InputTag>("simCICADAScore"))),
+    caloLayer1RegionsToken_(consumes<L1CaloRegionCollection>(iConfig.getParameter<edm::InputTag>("caloLayer1Regions"))),
+    simRegionsToken_(consumes<L1CaloRegionCollection>(iConfig.getParameter<edm::InputTag>("simRegions"))),
+    fedRawData_(consumes<FEDRawDataCollection>(iConfig.getParameter<edm::InputTag>("fedRawDataLabel"))),
+    histFolder_(iConfig.getParameter<std::string>("histFolder")) {
+}
+
+// ------------ method called for each event  ------------
+void L1TCaloLayer1Summary::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  edm::Handle<FEDRawDataCollection> fedRawDataCollection;
+  iEvent.getByToken(fedRawData_, fedRawDataCollection);
+  if (fedRawDataCollection.isValid()) {
+    for (int iFed = 1354; iFed < 1360; iFed += 2) {
+      const FEDRawData& fedRawData = fedRawDataCollection->FEDData(iFed);
+      if (fedRawData.size() == 0) {
+        continue;
+      }
+      const uint64_t* fedRawDataArray = (const uint64_t*)fedRawData.data();
+      UCTDAQRawData daqData(fedRawDataArray);
+
+      if (daqData.nAMCs() == 7) {
+        UCTAMCRawData amcSlot7(daqData.amcPayload(3));
+        if (amcSlot7.amcNo() != 7) {
+          std::cout << "Wrong AMC No: " << amcSlot7.amcNo() << std::endl;
+        } else {
+          histoSlot7MinusDaqBxid->Fill(amcSlot7.BXID() - daqData.BXID());
+        }
+      }
+    }
+  }
+
+  L1CaloRegionCollection caloLayer1Regions = iEvent.get(caloLayer1RegionsToken_);
+  L1CaloRegionCollection simRegions = iEvent.get(simRegionsToken_);
+
+  bool foundMatrix[2][18][18] = {};
+  int etMatrix[2][18][18] = {};
+
+  int nRegions = caloLayer1Regions.size();
+  for (int iRegion = 0; iRegion < nRegions; iRegion++) {
+    L1CaloRegion cRegion = caloLayer1Regions[iRegion];
+    L1CaloRegion sRegion = simRegions[iRegion];
+
+    foundMatrix[0][cRegion.gctEta()][cRegion.gctPhi()] = true;
+    etMatrix[0][cRegion.gctEta()][cRegion.gctPhi()] = cRegion.et();
+    foundMatrix[1][sRegion.gctEta()][sRegion.gctPhi()] = true;
+    etMatrix[1][sRegion.gctEta()][sRegion.gctPhi()] = sRegion.et();
+  }
+  int iRegion = 0;
+  for (int iEta = 0; iEta < 18; iEta++) {
+    for (int iPhi = 0; iPhi < 18; iPhi++) {
+      if (foundMatrix[0][iEta][iPhi] && foundMatrix[1][iEta][iPhi]) {
+        histoCaloRegions->Fill(iRegion, etMatrix[0][iEta][iPhi]);
+        histoSimRegions->Fill(iRegion, etMatrix[1][iEta][iPhi]);
+        histoCaloMinusSimRegions->Fill(iRegion, etMatrix[0][iEta][iPhi] - etMatrix[1][iEta][iPhi]);
+        iRegion++;
+      }
+    }
+  }
+
+  float caloCICADAScore = iEvent.get(caloLayer1CICADAScoreToken_)[0];
+  auto gtCICADAScores = iEvent.get(gtCICADAScoreToken_);
+  float simCICADAScore = iEvent.get(simCICADAScoreToken_)[0];
+
+  histoSimCICADAScore->Fill(simCICADAScore);
+  histoCaloMinusSim->Fill(caloCICADAScore - simCICADAScore);
+
+  uint32_t bx0Idx;
+  if (gtCICADAScores.size() == 30) {
+    bx0Idx = 12;
+  } else if (gtCICADAScores.size() == 5) {
+    bx0Idx = 2;
+  } else {
+    bx0Idx = 2;
+  }
+
+  histoCaloLayer1CICADAScore->Fill(caloCICADAScore);
+  histoGtCICADAScore->Fill(gtCICADAScores[bx0Idx]);
+  histoCaloMinusGt->Fill(gtCICADAScores[bx0Idx] - caloCICADAScore);
+}
+
+void L1TCaloLayer1Summary::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, edm::EventSetup const&) {
+  ibooker.setCurrentFolder(histFolder_);
+  histoSlot7MinusDaqBxid = ibooker.book1D("slot7BXID", "Slot 7- DAQ BXID", 50, -20, 20);
+
+  ibooker.setCurrentFolder(histFolder_ + "/CICADAScore");
+  histoCaloLayer1CICADAScore = ibooker.book1D("caloLayer1CICADAScore" , "CaloLayer1 CICADAScore" , 50 , 0 , 200 );
+  histoGtCICADAScore = ibooker.book1D("gtCICADAScore" , "GT CICADAScore at BX0" , 50 , 0 , 200 );
+  histoCaloMinusGt = ibooker.book1D("caloMinusGtCICADAScore" , "CaloLayer1 - GT CICADAScore at BX0", 50, -50, 50);
+  histoSimCICADAScore = ibooker.book1D("simCaloLayer1CICADAScore" , "simCaloLayer1 CICADAScore" , 50 , 0 , 200 );
+  histoCaloMinusSim = ibooker.book1D("caloMinusSimCICADAScore" , "CaloLayer1 - simCaloLayer1 CICADAScore", 50, -50, 50);
+
+  ibooker.setCurrentFolder(histFolder_ + "/Regions");
+  histoCaloMinusSimRegions = ibooker.book2D("caloMinusSumRegions", "CaloLayer1 - simCaloLayer1 Regions;Region;ET", 252, -0.5, 252.5, 100, -400, 400);
+  histoCaloRegions = ibooker.book2D("caloLayer1Regions", "CaloLayer1 Regions;Region;ET", 252, -0.5, 252.5, 100, 0, 800);
+  histoSimRegions = ibooker.book2D("simCaloLayer1Regions", "simCaloLayer1 Regions;Region;ET", 252, -0.5, 252.5, 100, 0, 800);
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void L1TCaloLayer1Summary::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+
+  //Specify that only 'tracks' is allowed
+  //To use, remove the default given above and uncomment below
+  //edm::ParameterSetDescription desc;
+  //desc.addUntracked<edm::InputTag>("tracks", edm::InputTag("ctfWithMaterialTracks"));
+  //descriptions.addWithDefaultLabel(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(L1TCaloLayer1Summary);

--- a/L1Trigger/L1TCaloLayer1/plugins/L1TCaloSummary.cc
+++ b/L1Trigger/L1TCaloLayer1/plugins/L1TCaloSummary.cc
@@ -107,6 +107,7 @@ private:
   int fwVersion;
 
   edm::EDGetTokenT<L1CaloRegionCollection> regionToken;
+  edm::EDGetTokenT<L1CaloRegionCollection> backupRegionToken;
 
   UCTLayer1* layer1;
 
@@ -142,6 +143,7 @@ L1TCaloSummary<INPUT, OUTPUT>::L1TCaloSummary(const edm::ParameterSet& iConfig)
       verbose(iConfig.getParameter<bool>("verbose")),
       fwVersion(iConfig.getParameter<int>("firmwareVersion")),
       regionToken(consumes<L1CaloRegionCollection>(iConfig.getParameter<edm::InputTag>("caloLayer1Regions"))),
+      backupRegionToken(consumes<L1CaloRegionCollection>(edm::InputTag("simCaloStage2Layer1Digis"))),
       loader(hls4mlEmulator::ModelLoader(iConfig.getParameter<string>("CICADAModelVersion"))),
       overwriteWithTestPatterns(iConfig.getParameter<bool>("useTestPatterns")),
       testPatterns(iConfig.getParameter<std::vector<edm::ParameterSet>>("testPatterns")) {
@@ -198,6 +200,12 @@ void L1TCaloSummary<INPUT, OUTPUT>::produce(edm::Event& iEvent, const edm::Event
   if (!iEvent.getByToken(regionToken, regionCollection))
     edm::LogError("L1TCaloSummary") << "UCT: Failed to get regions from region collection!";
   iEvent.getByToken(regionToken, regionCollection);
+
+  if (regionCollection->size() == 0) {
+    iEvent.getByToken(backupRegionToken, regionCollection);
+    edm::LogWarning("L1TCaloSummary") << "Switched to emulated regions since data regions was empty.\n";
+  }
+
   //Model input
   //This is done as a flat vector input, but future versions may involve 2D input
   //This will have to be handled later

--- a/L1Trigger/L1TCaloLayer1/plugins/L1TCaloSummary.cc
+++ b/L1Trigger/L1TCaloLayer1/plugins/L1TCaloSummary.cc
@@ -141,7 +141,7 @@ L1TCaloSummary<INPUT, OUTPUT>::L1TCaloSummary(const edm::ParameterSet& iConfig)
       boostedJetPtFactor(iConfig.getParameter<double>("boostedJetPtFactor")),
       verbose(iConfig.getParameter<bool>("verbose")),
       fwVersion(iConfig.getParameter<int>("firmwareVersion")),
-      regionToken(consumes<L1CaloRegionCollection>(edm::InputTag("simCaloStage2Layer1Digis"))),
+      regionToken(consumes<L1CaloRegionCollection>(iConfig.getParameter<edm::InputTag>("caloLayer1Regions"))),
       loader(hls4mlEmulator::ModelLoader(iConfig.getParameter<string>("CICADAModelVersion"))),
       overwriteWithTestPatterns(iConfig.getParameter<bool>("useTestPatterns")),
       testPatterns(iConfig.getParameter<std::vector<edm::ParameterSet>>("testPatterns")) {

--- a/L1Trigger/L1TCaloLayer1/python/simCaloStage2Layer1Summary_cfi.py
+++ b/L1Trigger/L1TCaloLayer1/python/simCaloStage2Layer1Summary_cfi.py
@@ -52,5 +52,6 @@ simCaloStage2Layer1Summary = cms.EDProducer('L1TCaloSummary_CICADA_vXp1p2',
     firmwareVersion = cms.int32(1),
     CICADAModelVersion = cms.string("CICADAModel_v2p1p2"),
     useTestPatterns = cms.bool(False),
-    testPatterns = standardCICADATestPatterns
+    testPatterns = standardCICADATestPatterns,
+    caloLayer1Regions = cms.InputTag("simCaloStage2Layer1Digis", "")
 )


### PR DESCRIPTION
#### PR description:

New DQM Analyzer for L1T Calorimeter Layer 1. Generates plots for CaloLayer1 Regions and CICADA Score, comparing DAQ data to emulator output. Also makes necessary changes to the CICADA emulator to allow for configurable source for regions.

#### PR validation:

Validated locally on CMSSW_14_1_0_pre5, running DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py modified for testing on lxplus. Also validated for online running in online DQM playback test.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is meant for future backporting to CMSSW_14_0_12 for online running.
