### PR TITLE
Dependency cleanup for big simulation plugin

### DIFF
--- a/BigProducts/Simulation/BuildFile.xml
+++ b/BigProducts/Simulation/BuildFile.xml
@@ -29,7 +29,6 @@
 <use name="Validation/EcalHits"/>
 <use name="Validation/Geometry"/>
 <use name="Validation/HcalHits"/>
-<use name="Validation/HGCalValidation"/>
 <use name="geant4static"/>
 <use name="g4hepemstatic"/>
 <flags DROP_DEP="geant4core"/>

--- a/CondFormats/EcalObjects/BuildFile.xml
+++ b/CondFormats/EcalObjects/BuildFile.xml
@@ -11,7 +11,11 @@
 <use name="boost_serialization"/>
 <use name="rootmath"/>
 <use name="clhep"/>
-<use name="cuda"/>
+<iftool name="cuda">
+  <use name="cuda"/>
+<else/>
+  <flags SKIP_FILES="%GPU.cc"/>
+</iftool>
 <use name="HeterogeneousCore/AlpakaInterface"/>
 <flags ALPAKA_BACKENDS="!serial"/>
 <export>

--- a/CondFormats/HGCalObjects/BuildFile.xml
+++ b/CondFormats/HGCalObjects/BuildFile.xml
@@ -7,7 +7,11 @@
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>
 <use name="HeterogeneousCore/AlpakaInterface"/>
-<use name="HeterogeneousCore/CUDACore"/>
+<iftool name="cuda">
+  <use name="HeterogeneousCore/CUDACore"/>
+<else/>
+  <flags SKIP_FILES="T_EventSetup_HeterogeneousHGCalHEFCellPositionsConditions.cc"/>
+</iftool>
 <flags ALPAKA_BACKENDS="1"/>
 <export>
   <lib name="1"/>

--- a/CondFormats/HcalObjects/BuildFile.xml
+++ b/CondFormats/HcalObjects/BuildFile.xml
@@ -10,8 +10,12 @@
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>
 <use name="Geometry/CaloTopology"/>
-<use name="HeterogeneousCore/CUDACore"/>
-<use name="HeterogeneousCore/CUDAUtilities"/>
+<iftool name="cuda">
+  <use name="HeterogeneousCore/CUDACore"/>
+  <use name="HeterogeneousCore/CUDAUtilities"/>
+<else/>
+  <flags SKIP_FILES="%GPU.cc"/>
+</iftool>
 <use name="HeterogeneousCore/AlpakaCore"/>
 <use name="HeterogeneousCore/AlpakaInterface"/>
 <flags ALPAKA_BACKENDS="1"/>

--- a/Validation/HGCalValidation/BuildFile.xml
+++ b/Validation/HGCalValidation/BuildFile.xml
@@ -8,7 +8,6 @@
 <use name="SimDataFormats/CaloAnalysis"/>
 <use name="RecoLocalCalo/HGCalRecAlgos"/>
 <use name="RecoLocalCalo/HGCalRecProducers"/>
-<use name="geant4core"/>
 <use name="clhep"/>
 <use name="hepmc"/>
 <export>

--- a/Validation/HGCalValidation/plugins/BuildFile.xml
+++ b/Validation/HGCalValidation/plugins/BuildFile.xml
@@ -26,7 +26,6 @@
 <use name="SimG4CMS/Calo"/>
 <use name="RecoLocalCalo/HGCalRecAlgos"/>
 <use name="Validation/HGCalValidation"/>
-<use name="geant4core"/>
 <use name="dd4hep"/>
 <use name="clhep"/>
 <use name="hepmc"/>

--- a/Validation/HGCalValidation/test/BuildFile.xml
+++ b/Validation/HGCalValidation/test/BuildFile.xml
@@ -9,7 +9,6 @@
 <use name="SimDataFormats/CaloTest"/>
 <use name="SimG4CMS/Calo"/>
 <use name="RecoLocalCalo/HGCalRecAlgos"/>
-<use name="geant4core"/>
 <use name="clhep"/>
 <use name="hepmc"/>
 <flags EDM_PLUGIN="1"/>


### PR DESCRIPTION
This PR proposes to 
- If cuda is not available for cmssw then
  - `CondFormats/EcalObjects CondFormats/HcalObjects`: Do not build `*GPU.cc`
  - `CondFormats/HGCalObjects: Do not build `HeterogeneousHGCalHEFCellPositionsConditions.cc`
- Remove used `geant4core` dependency from `Validation/HGCalValidation`
- Drop  `Validation/HGCalValidation` (which now does not depend on `geant4`) from `Simulation` big plugin

These changes should allow to build buig Simulation plugin for Riscv 64