### PR TITLE
update PackedCandidate::dzError to return what it should in track parameterization

### DIFF
--- a/DQM/TrackingMonitor/src/PackedCandidateTrackValidator.cc
+++ b/DQM/TrackingMonitor/src/PackedCandidateTrackValidator.cc
@@ -696,7 +696,7 @@ void PackedCandidateTrackValidator::bookHistograms(DQMStore::IBooker& iBooker,
                                   -0.001,
                                   0.001);  // expect equality within precision
   h_diffDszError = iBooker.book1D("diffDszError",
-                                  "(PackedCandidate::dzError() - reco::Track::dszError())/reco::Track",
+                                  "(PackedCandidate::dszError() - reco::Track::dszError())/reco::Track",
                                   40,
                                   -0.001,
                                   0.001);  // ideally, not equal, but for now they are
@@ -950,7 +950,7 @@ void PackedCandidateTrackValidator::analyze(const edm::Event& iEvent, const edm:
         h_diffCovDszDsz, reco::TrackBase::i_dsz, reco::TrackBase::i_dsz, [](double value) { return value * 10000.; });
 
     if (isInRange(diffCovDszDsz.status())) {
-      fillNoFlow(h_diffDszError, diffRelative(pcRef->dzError(), track.dszError()));
+      fillNoFlow(h_diffDszError, diffRelative(pcRef->dszError(), track.dszError()));
       fillNoFlow(h_diffDzError, diffRelative(pcRef->dzError(), track.dzError()));
       fillNoFlow(h_diffTrackDzError, diffRelative(trackPc.dzError(), track.dzError()));
     }

--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -773,11 +773,13 @@ namespace pat {
     /// dz  with respect to another point
     virtual float dz(const Point &p) const;
 
-    /// uncertainty on dz
-    float dzError() const override {
+    /// uncertainty on dsz; directly from covariance
+    float dszError() const {
       maybeUnpackCovariance();
       return sqrt((*m_.load())(4, 4));
     }
+    /// uncertainty on dz; depends on momentum
+    float dzError() const override { return dszError() * p() / pt(); }
     /// uncertainty on dxy
     float dxyError() const override {
       maybeUnpackCovariance();
@@ -976,13 +978,13 @@ namespace pat {
 
     struct PackedCovariance {
       PackedCovariance()
-          : dxydxy(0), dxydz(0), dzdz(0), dlambdadz(0), dphidxy(0), dptdpt(0), detadeta(0), dphidphi(0) {}
+          : dxydxy(0), dxydsz(0), dszdsz(0), dlambdadsz(0), dphidxy(0), dptdpt(0), detadeta(0), dphidphi(0) {}
       // 3D IP covariance
       uint16_t dxydxy;
-      uint16_t dxydz;
-      uint16_t dzdz;
+      uint16_t dxydsz;
+      uint16_t dszdsz;
       // other IP relevant elements
-      uint16_t dlambdadz;
+      uint16_t dlambdadsz;
       uint16_t dphidxy;
       // other diag elements
       uint16_t dptdpt;

--- a/DataFormats/PatCandidates/src/PackedCandidate.cc
+++ b/DataFormats/PatCandidates/src/PackedCandidate.cc
@@ -87,9 +87,9 @@ void pat::PackedCandidate::packCovariance(const reco::TrackBase::CovarianceMatri
   packedCovariance_.detadeta = packCovarianceElement(m, 1, 1);
   packedCovariance_.dphidphi = packCovarianceElement(m, 2, 2);
   packedCovariance_.dxydxy = packCovarianceElement(m, 3, 3);
-  packedCovariance_.dzdz = packCovarianceElement(m, 4, 4);
-  packedCovariance_.dxydz = packCovarianceElement(m, 3, 4);
-  packedCovariance_.dlambdadz = packCovarianceElement(m, 1, 4);
+  packedCovariance_.dszdsz = packCovarianceElement(m, 4, 4);
+  packedCovariance_.dxydsz = packCovarianceElement(m, 3, 4);
+  packedCovariance_.dlambdadsz = packCovarianceElement(m, 1, 4);
   packedCovariance_.dphidxy = packCovarianceElement(m, 2, 3);
   // unpack afterwards
   if (unpackAfterwards)
@@ -108,9 +108,9 @@ void pat::PackedCandidate::unpackCovariance() const {
     unpackCovarianceElement(*m, packedCovariance_.detadeta, 1, 1);
     unpackCovarianceElement(*m, packedCovariance_.dphidphi, 2, 2);
     unpackCovarianceElement(*m, packedCovariance_.dxydxy, 3, 3);
-    unpackCovarianceElement(*m, packedCovariance_.dzdz, 4, 4);
-    unpackCovarianceElement(*m, packedCovariance_.dxydz, 3, 4);
-    unpackCovarianceElement(*m, packedCovariance_.dlambdadz, 1, 4);
+    unpackCovarianceElement(*m, packedCovariance_.dszdsz, 4, 4);
+    unpackCovarianceElement(*m, packedCovariance_.dxydsz, 3, 4);
+    unpackCovarianceElement(*m, packedCovariance_.dlambdadsz, 1, 4);
     unpackCovarianceElement(*m, packedCovariance_.dphidxy, 2, 3);
 
     reco::TrackBase::CovarianceMatrix *expected = nullptr;

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -332,9 +332,19 @@
   <class name="pat::Conversion"  ClassVersion="11">
    <version ClassVersion="11" checksum="1239840459"/>
   </class>
-  <class name="pat::PackedCandidate::PackedCovariance" ClassVersion="3">
+  <class name="pat::PackedCandidate::PackedCovariance" ClassVersion="4">
+   <version ClassVersion="4" checksum="2490965287"/>
    <version ClassVersion="3" checksum="3320406063"/>
   </class>
+  <ioread sourceClass="pat::PackedCandidate::PackedCovariance" source="int16_t dxydz;int16_t dzdz;int16_t dlambdadz;" version="[-3]" targetClass="pat::PackedCandidate::PackedCovariance"
+         target="dxydsz,dszdsz,dlambdadsz" embed="false">
+	<![CDATA[
+	 dxydsz = onfile.dxydz;
+	 dszdsz = onfile.dzdz;
+	 dlambdadsz = onfile.dlambdadz;
+	]]>
+   </ioread>
+
   <class name="pat::PackedCandidate" ClassVersion="35">
    <version ClassVersion="35" checksum="2065846728"/>
    <version ClassVersion="34" checksum="3953181632"/>
@@ -399,10 +409,10 @@
    target="packedCovariance_" embed="false" >
    <![CDATA[
             packedCovariance_.dxydxy = onfile.packedCovarianceDxyDxy_;
-            packedCovariance_.dxydz = onfile.packedCovarianceDxyDz_;
-	    packedCovariance_.dzdz = onfile.packedCovarianceDzDz_;
-	    packedCovariance_.dlambdadz = onfile.packedCovarianceDlambdaDz_;
-	    packedCovariance_.dphidxy = onfile.packedCovarianceDphiDxy_;
+            packedCovariance_.dxydsz = onfile.packedCovarianceDxyDz_;
+            packedCovariance_.dszdsz = onfile.packedCovarianceDzDz_;
+            packedCovariance_.dlambdadsz = onfile.packedCovarianceDlambdaDz_;
+            packedCovariance_.dphidxy = onfile.packedCovarianceDphiDxy_;
             packedCovariance_.dptdpt = onfile.packedCovarianceDptDpt_;
             packedCovariance_.detadeta = onfile.packedCovarianceDetaDeta_;
             packedCovariance_.dphidphi = onfile.packedCovarianceDphiDphi_;

--- a/RecoBTag/FeatureTools/plugins/DeepBoostedJetTagInfoProducer.cc
+++ b/RecoBTag/FeatureTools/plugins/DeepBoostedJetTagInfoProducer.cc
@@ -708,7 +708,8 @@ void DeepBoostedJetTagInfoProducer::fillParticleFeatures(DeepBoostedJetFeatures 
           fts.fill("pfcand_isNeutralHad", std::abs(packed_cand->pdgId()) == 130);
           fts.fill("pfcand_dz", ip_sign * packed_cand->dz());
           fts.fill("pfcand_dxy", ip_sign * packed_cand->dxy());
-          fts.fill("pfcand_dzsig", track ? ip_sign * packed_cand->dz() / packed_cand->dzError() : 0);
+          // FIXME: old behavior dzError returned dszError; update after retraining to actual significance
+          fts.fill("pfcand_dzsig", track ? ip_sign * packed_cand->dz() / packed_cand->dszError() : 0);
           fts.fill("pfcand_dxysig", track ? ip_sign * packed_cand->dxy() / packed_cand->dxyError() : 0);
 
         }
@@ -920,7 +921,8 @@ void DeepBoostedJetTagInfoProducer::fillParticleFeatures(DeepBoostedJetFeatures 
         fts.fill("pfcand_mask", 1);
 
         if (track) {
-          fts.fill("jet_pfcand_dzsig", fabs(candidate.dz(pv_ass_pos)) / candidate.dzError());
+          // FIXME: old behavior dzError returned dszError; update after retraining to actual significance
+          fts.fill("jet_pfcand_dzsig", fabs(candidate.dz(pv_ass_pos)) / candidate.dszError());
           fts.fill("jet_pfcand_dxysig", fabs(candidate.dxy(pv_ass_pos)) / candidate.dxyError());
           fts.fill("jet_pfcand_track_chi2", track->normalizedChi2());
           fts.fill("jet_pfcand_track_qual", track->qualityMask());

--- a/RecoBTag/FeatureTools/plugins/ParticleNetFeatureEvaluator.cc
+++ b/RecoBTag/FeatureTools/plugins/ParticleNetFeatureEvaluator.cc
@@ -514,9 +514,11 @@ void ParticleNetFeatureEvaluator::fillParticleFeatures(DeepBoostedJetFeatures &f
     fts.fill("pfcand_mask", 1);
 
     if (track) {
-      fts.fill(
-          "jet_pfcand_dzsig",
-          std::isnan(fabs(cand->dz(pv_ass_pos)) / cand->dzError()) ? 0 : fabs(cand->dz(pv_ass_pos)) / cand->dzError());
+      // FIXME: old behavior dzError returned dszError; update after retraining to actual significance
+      fts.fill("jet_pfcand_dzsig",
+               std::isnan(fabs(cand->dz(pv_ass_pos)) / cand->dszError())
+                   ? 0
+                   : fabs(cand->dz(pv_ass_pos)) / cand->dszError());
       fts.fill("jet_pfcand_dxysig",
                std::isnan(fabs(cand->dxy(pv_ass_pos)) / cand->dxyError())
                    ? 0
@@ -788,10 +790,11 @@ void ParticleNetFeatureEvaluator::fillLostTrackFeatures(DeepBoostedJetFeatures &
                std::isnan(fabs(ltrack.dxy(pv_ass_pos)) / ltrack.dxyError())
                    ? 0
                    : fabs(ltrack.dxy(pv_ass_pos)) / ltrack.dxyError());
+      // FIXME: old behavior dzError returned dszError; update after retraining to actual significance
       fts.fill("jet_losttrack_dzsig",
-               std::isnan(fabs(ltrack.dz(pv_ass_pos)) / ltrack.dzError())
+               std::isnan(fabs(ltrack.dz(pv_ass_pos)) / ltrack.dszError())
                    ? 0
-                   : fabs(ltrack.dz(pv_ass_pos)) / ltrack.dzError());
+                   : fabs(ltrack.dz(pv_ass_pos)) / ltrack.dszError());
 
       reco::TransientTrack transientTrack = track_builder_->build(*track);
       Measurement1D meas_ip3d = IPTools::signedImpactParameter3D(transientTrack, jet_ref_track_dir, *pv_).second;

--- a/RecoBTag/FeatureTools/src/ChargedCandidateConverter.cc
+++ b/RecoBTag/FeatureTools/src/ChargedCandidateConverter.cc
@@ -42,7 +42,8 @@ namespace btagbtvdeep {
     c_pf_features.dxy = catch_infs(c_pf->dxy());
     c_pf_features.dz = catch_infs(c_pf->dz());
     c_pf_features.dxysig = c_pf->bestTrack() ? catch_infs(c_pf->dxy() / c_pf->dxyError()) : 0;
-    c_pf_features.dzsig = c_pf->bestTrack() ? catch_infs(c_pf->dz() / c_pf->dzError()) : 0;
+    // FIXME: old behavior dzError returned dszError; update after retraining to actual significance
+    c_pf_features.dzsig = c_pf->bestTrack() ? catch_infs(c_pf->dz() / c_pf->dszError()) : 0;
 
     float pdgid_;
     if (abs(c_pf->pdgId()) == 11 and c_pf->charge() != 0) {

--- a/RecoTauTag/RecoTau/interface/DeepTauIdBase.h
+++ b/RecoTauTag/RecoTau/interface/DeepTauIdBase.h
@@ -521,7 +521,9 @@ namespace {
              cand.dzError() > 0;
     }
     inline auto getTauDZSigValid(const pat::PackedCandidate& cand) {
-      return cand.hasTrackDetails() && std::isnormal(cand.dz()) && std::isnormal(cand.dzError()) && cand.dzError() > 0;
+      // FIXME: old behavior dzError returned dszError; update after retraining to actual significance
+      return cand.hasTrackDetails() && std::isnormal(cand.dz()) && std::isnormal(cand.dszError()) &&
+             cand.dszError() > 0;
     }
     inline auto getTauDxy(const reco::PFCandidate& cand) { return cand.bestTrack()->dxy(); }
     inline auto getTauDxy(const pat::PackedCandidate& cand) { return cand.dxy(); }
@@ -1361,7 +1363,15 @@ protected:
       get(dnn::tau_dz) = sp.scale(tau_dz, tauInputs_indices_[dnn::tau_dz]);
       get(dnn::tau_dz_sig_valid) =
           sp.scale(candFunc::getTauDZSigValid(*leadChargedHadrCand), tauInputs_indices_[dnn::tau_dz_sig_valid]);
-      const double dzError = hasTrackDetails ? leadChargedHadrCand->dzError() : -999.;
+      // FIXME: old behavior dzError returned dszError; update after retraining to actual significance
+      double dzError;
+      if (hasTrackDetails) {
+        if constexpr (std::is_same_v<CandidateCastType, pat::PackedCandidate>)
+          dzError = leadChargedHadrCand->dszError();
+        else
+          dzError = leadChargedHadrCand->dzError();
+      } else
+        dzError = -999.;
       get(dnn::tau_dz_sig) = sp.scale(std::abs(tau_dz) / dzError, tauInputs_indices_[dnn::tau_dz_sig]);
     }
     get(dnn::tau_flightLength_x) =
@@ -1509,8 +1519,14 @@ protected:
         get(dnn::pfCand_ele_dxy_sig) = sp.scale(std::abs(candFunc::getTauDxy(ele_cand)) / ele_cand.dxyError(),
                                                 dnn::pfCand_ele_dxy_sig - PFe_index_offset);
         get(dnn::pfCand_ele_dz) = sp.scale(candFunc::getTauDz(ele_cand), dnn::pfCand_ele_dz - PFe_index_offset);
-        get(dnn::pfCand_ele_dz_sig) = sp.scale(std::abs(candFunc::getTauDz(ele_cand)) / ele_cand.dzError(),
-                                               dnn::pfCand_ele_dz_sig - PFe_index_offset);
+        // FIXME: old behavior dzError returned dszError; update after retraining to actual significance
+        float dzError;
+        if constexpr (std::is_same_v<CandidateCastType, pat::PackedCandidate>)
+          dzError = ele_cand.dszError();
+        else
+          dzError = ele_cand.dzError();
+        get(dnn::pfCand_ele_dz_sig) =
+            sp.scale(std::abs(candFunc::getTauDz(ele_cand)) / dzError, dnn::pfCand_ele_dz_sig - PFe_index_offset);
         get(dnn::pfCand_ele_track_chi2_ndof) =
             candFunc::getPseudoTrack(ele_cand).ndof() > 0
                 ? sp.scale(candFunc::getPseudoTrack(ele_cand).chi2() / candFunc::getPseudoTrack(ele_cand).ndof(),
@@ -1579,9 +1595,14 @@ protected:
                      dnn::pfCand_gamma_dxy_sig - PFg_index_offset);
         get(dnn::pfCand_gamma_dz + fill_index_offset_PFg) =
             sp.scale(candFunc::getTauDz(gamma_cand), dnn::pfCand_gamma_dz - PFg_index_offset);
+        // FIXME: old behavior dzError returned dszError; update after retraining to actual significance
+        float dzError;
+        if constexpr (std::is_same_v<CandidateCastType, pat::PackedCandidate>)
+          dzError = gamma_cand.dszError();
+        else
+          dzError = gamma_cand.dzError();
         get(dnn::pfCand_gamma_dz_sig + fill_index_offset_PFg) =
-            sp.scale(std::abs(candFunc::getTauDz(gamma_cand)) / gamma_cand.dzError(),
-                     dnn::pfCand_gamma_dz_sig - PFg_index_offset);
+            sp.scale(std::abs(candFunc::getTauDz(gamma_cand)) / dzError, dnn::pfCand_gamma_dz_sig - PFg_index_offset);
         get(dnn::pfCand_gamma_track_chi2_ndof + fill_index_offset_PFg) =
             candFunc::getPseudoTrack(gamma_cand).ndof() > 0
                 ? sp.scale(candFunc::getPseudoTrack(gamma_cand).chi2() / candFunc::getPseudoTrack(gamma_cand).ndof(),
@@ -1784,8 +1805,14 @@ protected:
         get(dnn::pfCand_muon_dxy_sig) = sp.scale(std::abs(candFunc::getTauDxy(muon_cand)) / muon_cand.dxyError(),
                                                  dnn::pfCand_muon_dxy_sig - PFmu_index_offset);
         get(dnn::pfCand_muon_dz) = sp.scale(candFunc::getTauDz(muon_cand), dnn::pfCand_muon_dz - PFmu_index_offset);
-        get(dnn::pfCand_muon_dz_sig) = sp.scale(std::abs(candFunc::getTauDz(muon_cand)) / muon_cand.dzError(),
-                                                dnn::pfCand_muon_dz_sig - PFmu_index_offset);
+        // FIXME: old behavior dzError returned dszError; update after retraining to actual significance
+        float dzError;
+        if constexpr (std::is_same_v<CandidateCastType, pat::PackedCandidate>)
+          dzError = muon_cand.dszError();
+        else
+          dzError = muon_cand.dzError();
+        get(dnn::pfCand_muon_dz_sig) =
+            sp.scale(std::abs(candFunc::getTauDz(muon_cand)) / dzError, dnn::pfCand_muon_dz_sig - PFmu_index_offset);
         get(dnn::pfCand_muon_track_chi2_ndof) =
             candFunc::getPseudoTrack(muon_cand).ndof() > 0
                 ? sp.scale(candFunc::getPseudoTrack(muon_cand).chi2() / candFunc::getPseudoTrack(muon_cand).ndof(),
@@ -1951,8 +1978,14 @@ protected:
         get(dnn::pfCand_chHad_dxy_sig) = sp.scale(std::abs(candFunc::getTauDxy(chH_cand)) / chH_cand.dxyError(),
                                                   dnn::pfCand_chHad_dxy_sig - PFchH_index_offset);
         get(dnn::pfCand_chHad_dz) = sp.scale(candFunc::getTauDz(chH_cand), dnn::pfCand_chHad_dz - PFchH_index_offset);
-        get(dnn::pfCand_chHad_dz_sig) = sp.scale(std::abs(candFunc::getTauDz(chH_cand)) / chH_cand.dzError(),
-                                                 dnn::pfCand_chHad_dz_sig - PFchH_index_offset);
+        // FIXME: old behavior dzError returned dszError; update after retraining to actual significance
+        float dzError;
+        if constexpr (std::is_same_v<CandidateCastType, pat::PackedCandidate>)
+          dzError = chH_cand.dszError();
+        else
+          dzError = chH_cand.dzError();
+        get(dnn::pfCand_chHad_dz_sig) =
+            sp.scale(std::abs(candFunc::getTauDz(chH_cand)) / dzError, dnn::pfCand_chHad_dz_sig - PFchH_index_offset);
         get(dnn::pfCand_chHad_track_chi2_ndof) =
             candFunc::getPseudoTrack(chH_cand).ndof() > 0
                 ? sp.scale(candFunc::getPseudoTrack(chH_cand).chi2() / candFunc::getPseudoTrack(chH_cand).ndof(),


### PR DESCRIPTION
in response to #45598 

prior to this PR `PackedCandidate` saved had a mis-named covariance element `dz` instead of `dsz`

Details of all track parameters from TrackBase.h:
https://github.com/cms-sw/cmssw/blob/fd00eb29f71ae9d94759a5bb2305cd63ff3f415a/DataFormats/TrackReco/interface/TrackBase.h#L19-L25

This PR updates the naming and corrects the returned value in `PackedCandidate::dzError`.
For convenience, `dszError` is also kept available.

I checked dependencies using the short matrix tests and initially throwing in the `PackedCandidate::dzError`. This revealed dependencies in `PATIsolatedTrackProducer`, `PackedCandidateTrackValidator`, and ML b and tau taggers.

The tracking-related parts affected by the change:
- `PATIsolatedTrackProducer::produce` and `IsolatedTrack` will now have a value saved in `dzError` matching the meaning.
    - using the same short matrix check with a throw in `IsolatedTrack::dzError` I did not detect anything using this method in the matrix tests.
- DQM/TrackingMonitor/src/PackedCandidateTrackValidator.cc :  `diffDszError` which compares `Track::dszError` should still match the candidate by now using directly `dszError` and `diffDzError` should match as well

This PR keeps ML b and tau taggers behavior unchanged, to keep values consistent with the training.
 @cms-sw/btv-pog-l2 @cms-sw/tau-pog-l2 

