### PR TITLE
MTD Validation: exclude electron isolation module from the official MTD validation sequence

### DIFF
--- a/Validation/Configuration/python/mtdSimValid_cff.py
+++ b/Validation/Configuration/python/mtdSimValid_cff.py
@@ -20,9 +20,8 @@ from Validation.MtdValidation.etlSimHitsValid_cfi import etlSimHitsValid
 from Validation.MtdValidation.etlDigiHitsValid_cfi import etlDigiHitsValid
 from Validation.MtdValidation.mtdTracksValid_cfi import mtdTracksValid
 from Validation.MtdValidation.vertices4DValid_cfi import vertices4DValid
-from Validation.MtdValidation.mtdEleIsoValid_cfi import mtdEleIsoValid
 
 mtdSimValid  = cms.Sequence(btlSimHitsValid  + etlSimHitsValid )
 mtdDigiValid = cms.Sequence(btlDigiHitsValid + etlDigiHitsValid)
-mtdRecoValid = cms.Sequence(mtdAssociationProducers + btlLocalRecoValid  + etlLocalRecoValid + mtdTracksValid + vertices4DValid + mtdEleIsoValid)
+mtdRecoValid = cms.Sequence(mtdAssociationProducers + btlLocalRecoValid  + etlLocalRecoValid + mtdTracksValid + vertices4DValid)
 

--- a/Validation/MtdValidation/python/MtdPostProcessor_cff.py
+++ b/Validation/MtdValidation/python/MtdPostProcessor_cff.py
@@ -3,7 +3,6 @@ import FWCore.ParameterSet.Config as cms
 from Validation.MtdValidation.btlSimHitsPostProcessor_cfi import btlSimHitsPostProcessor
 from Validation.MtdValidation.btlLocalRecoPostProcessor_cfi import btlLocalRecoPostProcessor
 from Validation.MtdValidation.MtdTracksPostProcessor_cfi import MtdTracksPostProcessor
-from Validation.MtdValidation.MtdEleIsoPostProcessor_cfi import MtdEleIsoPostProcessor
 from Validation.MtdValidation.Primary4DVertexPostProcessor_cfi import Primary4DVertexPostProcessor
 
-mtdValidationPostProcessor = cms.Sequence(btlSimHitsPostProcessor + btlLocalRecoPostProcessor + MtdTracksPostProcessor + MtdEleIsoPostProcessor + Primary4DVertexPostProcessor)
+mtdValidationPostProcessor = cms.Sequence(btlSimHitsPostProcessor + btlLocalRecoPostProcessor + MtdTracksPostProcessor + Primary4DVertexPostProcessor)


### PR DESCRIPTION
#### PR description:

The MTD electron isolation validation module is removed from the official MTD validation sequence, since it is of limited use for the time being in regular validation. The code is kept in the private test validation configuration for dedicated studies, but it does nto need to be run at any test.

#### PR validation:

Code tested to remove the desired module in CMSSW_14_1_X_2024-08-01-1100