### PR TITLE
Replace patterns with explicit class names in CondFormats `classes_def.xml`

### DIFF
--- a/CondFormats/CastorObjects/src/classes_def.xml
+++ b/CondFormats/CastorObjects/src/classes_def.xml
@@ -44,7 +44,31 @@
  <class name="std::vector<CastorSaturationCorr>"/>
  <class name="CastorSaturationCorrs"/>
 
- <class pattern="*CastorCondObjectContainer*">
+ <class name="CastorCondObjectContainer<CastorCalibrationQIECoder>">
+  <field name="CASTORcontainer" mapping="blob" />
+ </class>
+ <class name="CastorCondObjectContainer<CastorChannelStatus>">
+  <field name="CASTORcontainer" mapping="blob" />
+ </class>
+ <class name="CastorCondObjectContainer<CastorGain>">
+  <field name="CASTORcontainer" mapping="blob" />
+ </class>
+ <class name="CastorCondObjectContainer<CastorGainWidth>">
+  <field name="CASTORcontainer" mapping="blob" />
+ </class>
+ <class name="CastorCondObjectContainer<CastorPedestal>">
+  <field name="CASTORcontainer" mapping="blob" />
+ </class>
+ <class name="CastorCondObjectContainer<CastorPedestalWidth>">
+  <field name="CASTORcontainer" mapping="blob" />
+ </class>
+ <class name="CastorCondObjectContainer<CastorQIECoder>">
+  <field name="CASTORcontainer" mapping="blob" />
+ </class>
+ <class name="CastorCondObjectContainer<CastorRecoParam>">
+  <field name="CASTORcontainer" mapping="blob" />
+ </class>
+ <class name="CastorCondObjectContainer<CastorSaturationCorr>">
   <field name="CASTORcontainer" mapping="blob" />
  </class>
 </lcgdict>   

--- a/CondFormats/SiPixelObjects/src/classes_def.xml
+++ b/CondFormats/SiPixelObjects/src/classes_def.xml
@@ -77,8 +77,14 @@
   <class name="SiPixelQualityProbabilities::probabilityVec"/>
   <class name="std::map<unsigned int,SiPixelQualityProbabilities::probabilityVec>"/>
 
-  <class pattern="PixelDCSObject<*>"/> 
-  <class pattern="PixelDCSObject<*>::Item"/> 
-  <class pattern="PixelDCSObject<*>::Type"/> 
+  <class name="CaenChannel"/>
+  <class name="PixelDCSObject<CaenChannel>"/>
+  <class name="PixelDCSObject<CaenChannel>::Item"/>
+
+  <class name="PixelDCSObject<bool>"/>
+  <class name="PixelDCSObject<bool>::Item"/>
+
+  <class name="PixelDCSObject<float>"/>
+  <class name="PixelDCSObject<float>::Item"/>
 
 </lcgdict>   


### PR DESCRIPTION
#### PR description:

This PR is part of series to replace the last remaining uses class pattern elements in `classes_def.xml` with explicit class names.

Resolves https://github.com/cms-sw/framework-team/issues/978

#### PR validation:

Code compiles, and the generated `.rootmap` files are identical.