### PR TITLE
Removed unnecessary VDT dependency in Geometry/CommonTopologies

### DIFF
--- a/Geometry/CommonTopologies/BuildFile.xml
+++ b/Geometry/CommonTopologies/BuildFile.xml
@@ -4,7 +4,6 @@
 <use name="DataFormats/GeometrySurface"/>
 <use name="DataFormats/DetId"/>
 <use name="FWCore/Utilities"/>
-<use name="vdt_headers"/>
 <export>
   <lib name="1"/>
 </export>

--- a/Geometry/CommonTopologies/src/TkRadialStripTopology.cc
+++ b/Geometry/CommonTopologies/src/TkRadialStripTopology.cc
@@ -6,8 +6,6 @@
 #include <algorithm>
 #include <cassert>
 
-#include <vdt/vdtMath.h>
-
 #ifdef MATH_STS
 #include <iostream>
 #endif


### PR DESCRIPTION
#### PR description:

Working on a minimal code subset for MiniAOD reading found this dependency.

#### PR validation:

Code compiles.