### PR TITLE
Update PV settings for Run3 PbPb UPC reco

### DIFF
--- a/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
+++ b/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
@@ -179,3 +179,31 @@ highBetaStar_2018.toModify(offlinePrimaryVertices,
      }
 )
 
+from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
+run3_upc.toModify(offlinePrimaryVertices,
+    TkFilterParameters = dict(
+        algorithm="filterWithThreshold",
+        maxNormalizedChi2 = 80.0,
+        minPixelLayersWithHits = 1,
+        minSiliconLayersWithHits = 3,
+        maxD0Significance = 2.0,
+        maxD0Error = 10.0,
+        maxDzError = 10.0,
+        minPt = 0.0,
+        maxEta = 3.0,
+        trackQuality = "highPurity",
+        numTracksThreshold = cms.int32(3),
+        maxNumTracksThreshold = cms.int32(1000),
+        minPtTight = cms.double(1.0)
+    ),
+    TkClusParameters = cms.PSet(
+        algorithm = cms.string("gap"),
+        TkGapClusParameters = cms.PSet(
+            zSeparation = cms.double(6.0)
+        )
+    ),
+    vertexCollections = {
+        0: dict(chi2cutoff = 4.0, minNdof = -1.1),
+        1: dict(chi2cutoff = 4.0, minNdof = -2.0),
+    }
+)


### PR DESCRIPTION
#### PR description:

This PR updates the primary vertex producer settings used in the Run3 PbPb UPC reconstruction. These settings provide an increase of ~30% (from 57% to 85%) PV reco efficiency for two-track events (e.g. phi -> KK) and a significant reduction of split vertices in gamma+nucleus interactions (e.g. gamma+N -> D).

The details are document in the [google slides](https://docs.google.com/presentation/d/1PYMMci1JINOm2ozrRhgX441PgZDQhklIuTvpSdtvMPQ/edit?usp=sharing).

@mandrenguyen  

#### PR validation:

Tested with 180, 180.1, 181, 181.1 and 142.901

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for: