### PR TITLE
[14.0.X] instrument `fitVertices` to output more information when failing assert (issue cms-sw/cmssw#44923)

### DIFF
--- a/RecoTracker/PixelVertexFinding/plugins/alpaka/fitVertices.h
+++ b/RecoTracker/PixelVertexFinding/plugins/alpaka/fitVertices.h
@@ -74,7 +74,19 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::vertexFinder {
     alpaka::syncBlockThreads(acc);
     // reuse nn
     for (auto i : cms::alpakatools::uniform_elements(acc, foundClusters)) {
-      ALPAKA_ASSERT_ACC(wv[i] > 0.f);
+      bool const wv_cond = (wv[i] > 0.f);
+      if (not wv_cond) {
+        printf("ERROR: wv[%d] (%f) > 0.f failed\n", i, wv[i]);
+        // printing info on tracks associated to this vertex
+        for (auto trk_i = 0u; trk_i < nt; ++trk_i) {
+          if (iv[trk_i] != int(i)) {
+            continue;
+          }
+          printf("   iv[%d]=%d zt[%d]=%f ezt2[%d]=%f\n", trk_i, iv[trk_i], trk_i, zt[trk_i], trk_i, ezt2[trk_i]);
+        }
+        ALPAKA_ASSERT_ACC(false);
+      }
+
       zv[i] /= wv[i];
       nn[i] = -1;  // ndof
     }


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/45630

#### PR description:

Title says it all, as per https://github.com/cms-sw/cmssw/issues/44923#issuecomment-2267853936

#### PR validation:

`cmssw` compiles

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of  https://github.com/cms-sw/cmssw/pull/45630 for 2024 data-taking operations.