### PR TITLE
`DisplacedJet_Monitor`: use  `hltIter2MergedForDisplaced` instead of  `hltIter2MergedForBTag` to (as per CMSHLT-3303)

### DIFF
--- a/DQMOffline/Trigger/python/DisplacedJet_Monitor_cff.py
+++ b/DQMOffline/Trigger/python/DisplacedJet_Monitor_cff.py
@@ -6,9 +6,9 @@ from DQMOffline.Trigger.JetMonitor_cfi import hltJetMETmonitoring
 from DQMOffline.Trigger.TrackingMonitoring_cff import * 
 
 DisplacedJetIter2TracksMonitoringHLT = trackingMonHLT.clone(
-    FolderName       = 'HLT/EXO/DisplacedJet/Tracking/iter2MergedForBTag',
-    TrackProducer    = 'hltIter2MergedForBTag',
-    allTrackProducer = 'hltIter2MergedForBTag',
+    FolderName       = 'HLT/EXO/DisplacedJet/Tracking/iter2ForDisplaced',
+    TrackProducer    = 'hltIter2MergedForDisplaced',
+    allTrackProducer = 'hltIter2MergedForDisplaced',
     doEffFromHitPatternVsPU   = False,
     doEffFromHitPatternVsBX   = False,
     doEffFromHitPatternVsLUMI = False


### PR DESCRIPTION
#### PR description:

Title says it all, as per discussion at [CMSHLT-3303](https://its.cern.ch/jira/browse/CMSHLT-3303). 
The collection `hltIter2MergedForDisplaced`  produced at HLT by few displaced object triggers is not monitored by the EXO monitoring setup in `HLTMonitor`. This PR jointly with a HLT menu change foreseen for Aug-5 2024 will restore the monitoring.

#### PR validation:

None, trivial input collection change.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, will be backported to CMSSW_14_0_X for 2024 data-taking operations.
