### PR TITLE
Era modifier updated from Run3 to Run3_2024 in dqm client configs

### DIFF
--- a/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 import sys
-from Configuration.Eras.Era_Run3_cff import Run3
-process = cms.Process("L1TStage2DQM", Run3)
+from Configuration.Eras.Era_Run3_2024_cff import Run3_2024
+process = cms.Process("L1TStage2DQM", Run3_2024)
 
 unitTest = False
 if 'unitTest=True' in sys.argv:

--- a/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 import sys
-from Configuration.Eras.Era_Run3_cff import Run3
-process = cms.Process("L1TStage2EmulatorDQM", Run3)
+from Configuration.Eras.Era_Run3_2024_cff import Run3_2024
+process = cms.Process("L1TStage2EmulatorDQM", Run3_2024)
 
 unitTest = False
 if 'unitTest=True' in sys.argv:


### PR DESCRIPTION
#### PR description:

This PR modifies the era in the DQM client config files to fix the data emulator mismatches seen in BMTF Muon quality plots.

#### PR validation:

Code quality check performed. Changes under test with DQM Online streamers
