### PR TITLE
VarParsing: prevent TypeError for default of int/float/bool list

### DIFF
--- a/FWCore/ParameterSet/python/VarParsing.py
+++ b/FWCore/ParameterSet/python/VarParsing.py
@@ -414,7 +414,7 @@ class VarParsing (object):
             # if it's a list, we only want to use the default if it
             # does exist.
             if (mytype in [VarParsing.varType.bool, VarParsing.varType.int, VarParsing.varType.float] and \
-               default != "") or len (default): # check type to prevent TypeError for bool/int/float defaults
+               default not in ["",[]]) or len (default): # check type to prevent TypeError for bool/int/float defaults
                 self._lists[name].append (default) # known bug: default can be list
         #######################################
         ## Process any additional directives ##

--- a/FWCore/ParameterSet/python/VarParsing.py
+++ b/FWCore/ParameterSet/python/VarParsing.py
@@ -413,8 +413,9 @@ class VarParsing (object):
             self._lists[name] = []
             # if it's a list, we only want to use the default if it
             # does exist.
-            if len (default):
-                self._lists[name].append (default)
+            if (mytype in [VarParsing.varType.bool, VarParsing.varType.int, VarParsing.varType.float] and \
+               default != "") or len (default): # check type to prevent TypeError for bool/int/float defaults
+                self._lists[name].append (default) # known bug: default can be list
         #######################################
         ## Process any additional directives ##
         #######################################

--- a/FWCore/ParameterSet/test/BuildFile.xml
+++ b/FWCore/ParameterSet/test/BuildFile.xml
@@ -15,3 +15,5 @@
 
 <test name="testFWCoreParameterSetEdmConfigDump" command="run_edmConfigDump.sh"/>
 <test name="testFWCoreParameterSetEdmConfigSplit" command="run_edmConfigSplit.sh"/>
+
+<test name="TestFWCoreParameterSetVarParsingList" command="python3 ${LOCALTOP}/src/FWCore/ParameterSet/test/test_varparsing_list.py"/>

--- a/FWCore/ParameterSet/test/test_varparsing_list.py
+++ b/FWCore/ParameterSet/test/test_varparsing_list.py
@@ -2,25 +2,29 @@ import sys
 from FWCore.ParameterSet.VarParsing import VarParsing
 
 def parse(argv):
-  sys.argv = ['test.py','maxEvents=100']+argv # emulate user arguments
+  sys.argv = ['test_varparsing_list.py','maxEvents=100']+argv # emulate user arguments
   opts = VarParsing('standard')
-  def add(n, d, m, t):
-    opts.register(n, d, m, t)
-  add('myInts0',   '',      VarParsing.multiplicity.list, VarParsing.varType.int)
-  add('myInts1',   0,       VarParsing.multiplicity.list, VarParsing.varType.int)
-  add('myInts2',   [0],     VarParsing.multiplicity.list, VarParsing.varType.int)
-  add('myFloats0', '',      VarParsing.multiplicity.list, VarParsing.varType.float)
-  add('myFloats1', 0,       VarParsing.multiplicity.list, VarParsing.varType.float)
-  add('myFloats2', [0],     VarParsing.multiplicity.list, VarParsing.varType.float)
-  add('myBools0',  '',      VarParsing.multiplicity.list, VarParsing.varType.bool)
-  add('myBools1',  True,    VarParsing.multiplicity.list, VarParsing.varType.bool)
-  add('myBools2',  [True],  VarParsing.multiplicity.list, VarParsing.varType.bool)
-  add('myStrs0',   '',      VarParsing.multiplicity.list, VarParsing.varType.string)
-  add('myStrs1',   'foo',   VarParsing.multiplicity.list, VarParsing.varType.string)
-  add('myStrs2',   ['foo'], VarParsing.multiplicity.list, VarParsing.varType.string)
+  opts.register('myInts0',   '',      VarParsing.multiplicity.list, VarParsing.varType.int)
+  opts.register('myInts1',   [],      VarParsing.multiplicity.list, VarParsing.varType.int)
+  opts.register('myInts2',   0,       VarParsing.multiplicity.list, VarParsing.varType.int)
+  opts.register('myInts3',   [0],     VarParsing.multiplicity.list, VarParsing.varType.int)
+  opts.register('myFloats0', '',      VarParsing.multiplicity.list, VarParsing.varType.float)
+  opts.register('myFloats1', [],      VarParsing.multiplicity.list, VarParsing.varType.float)
+  opts.register('myFloats2', 0,       VarParsing.multiplicity.list, VarParsing.varType.float)
+  opts.register('myFloats3', [0],     VarParsing.multiplicity.list, VarParsing.varType.float)
+  opts.register('myBools0',  '',      VarParsing.multiplicity.list, VarParsing.varType.bool)
+  opts.register('myBools1',  [],      VarParsing.multiplicity.list, VarParsing.varType.bool)
+  opts.register('myBools2',  True,    VarParsing.multiplicity.list, VarParsing.varType.bool)
+  opts.register('myBools3',  [True],  VarParsing.multiplicity.list, VarParsing.varType.bool)
+  opts.register('myStrs0',   '',      VarParsing.multiplicity.list, VarParsing.varType.string)
+  opts.register('myStrs1',   [],      VarParsing.multiplicity.list, VarParsing.varType.string)
+  opts.register('myStrs2',   'foo',   VarParsing.multiplicity.list, VarParsing.varType.string)
+  opts.register('myStrs3',   ['foo'], VarParsing.multiplicity.list, VarParsing.varType.string)
+  opts.parseArguments()
+  #print(f">>> Parsed: {sys.argv} -> lists={opts._lists}")
 
 # parse without user arguments
 parse([ ])
 
 # parse with user arguments
-parse(['myInts1=0,1','myBools1=True,False','myStrs1=foo,bar','myStrs2=foo,bar'])
+parse(['myInts1=0,1,-1','myFloats1=3.14,0,0.0,-1.0','myBools1=True,False','myStrs1=foo,bar'])

--- a/FWCore/ParameterSet/test/test_varparsing_list.py
+++ b/FWCore/ParameterSet/test/test_varparsing_list.py
@@ -1,0 +1,26 @@
+import sys
+from FWCore.ParameterSet.VarParsing import VarParsing
+
+def parse(argv):
+  sys.argv = ['test.py','maxEvents=100']+argv # emulate user arguments
+  opts = VarParsing('standard')
+  def add(n, d, m, t):
+    opts.register(n, d, m, t)
+  add('myInts0',   '',      VarParsing.multiplicity.list, VarParsing.varType.int)
+  add('myInts1',   0,       VarParsing.multiplicity.list, VarParsing.varType.int)
+  add('myInts2',   [0],     VarParsing.multiplicity.list, VarParsing.varType.int)
+  add('myFloats0', '',      VarParsing.multiplicity.list, VarParsing.varType.float)
+  add('myFloats1', 0,       VarParsing.multiplicity.list, VarParsing.varType.float)
+  add('myFloats2', [0],     VarParsing.multiplicity.list, VarParsing.varType.float)
+  add('myBools0',  '',      VarParsing.multiplicity.list, VarParsing.varType.bool)
+  add('myBools1',  True,    VarParsing.multiplicity.list, VarParsing.varType.bool)
+  add('myBools2',  [True],  VarParsing.multiplicity.list, VarParsing.varType.bool)
+  add('myStrs0',   '',      VarParsing.multiplicity.list, VarParsing.varType.string)
+  add('myStrs1',   'foo',   VarParsing.multiplicity.list, VarParsing.varType.string)
+  add('myStrs2',   ['foo'], VarParsing.multiplicity.list, VarParsing.varType.string)
+
+# parse without user arguments
+parse([ ])
+
+# parse with user arguments
+parse(['myInts1=0,1','myBools1=True,False','myStrs1=foo,bar','myStrs2=foo,bar'])


### PR DESCRIPTION
## PR description:

This PR patches the handling of defaults in `FWCore.ParameterSet.VarParsing` to prevent a `TypeError` for the case of an int/float/bool type in combination with `VarParsing.multiplicity.list`, where the default is a single int/float/bool value. This bug was described in https://github.com/cms-sw/cmssw/issues/44630:

Note:
* In order to prevent interfering with any workflows that might rely on the behavior of "list of list" defaults, this PR only prevents the `TypeError` with an if statement:
https://github.com/IzaakWN/cmssw/blob/dbd4367723a9bcc29fcf308f2902896c2aabbc6e/FWCore/ParameterSet/python/VarParsing.py#L413-L418
* This means that if a user wants to use as default a list of multiple int/float/bool values, they will still get a list of lists of those values, same as for strings... E.g., `[0,1]` → `[[0,1]]`.

```python
opts = VarParsing('standard')

opts.register('myInts0`,  0,  VarParsing.multiplicity.list, VarParsing.varType.int) 
# before this PR: causes TypeError because len(int)
# after this PR: yields list of (single) integer [0] as default

opts.register('myInts1`, [0],  VarParsing.multiplicity.list, VarParsing.varType.int)
# works because len(list)
# yields list of list [[0]] as default

opts.register('myInts2', [0,1],  VarParsing.multiplicity.list, VarParsing.varType.int)
# works because len(list)
# yields list of list [[0,1]] as default
```

Tagging: @makortel


## PR validation:

I setup CMSSW as follows:
```bash
source $VO_CMS_SW_DIR/cmsset_default.sh
export SCRAM_ARCH="el9_amd64_gcc12"
CMSSW="CMSSW_14_1_0_pre6"
cmsrel $CMSSW -n ${CMSSW}_varpars
cd ${CMSSW}_varpars/src && cmsenv
git cms-addpkg FWCore/ParameterSet
```

To test the behavior, I used this reproducible snippet in the `python3` command line:
```python
import sys
from FWCore.ParameterSet.VarParsing import VarParsing

def parse(argv):
  print(f">>> Parsing {argv!r}...")
  sys.argv = ['test.py','maxEvents=100']+argv
  opts = VarParsing('standard')
  print(">>> Register...")
  def add(*args,**kwargs):
    try:
      print(f">>>   {args!r}, {kwargs!r}...")
      opts.register(*args,**kwargs)
    except Exception as err:
      print(f">>>   => {err!r}")
  add('myInts0',  '',      VarParsing.multiplicity.list, VarParsing.varType.int) # works because len(str)
  add('myInts1',  0,       VarParsing.multiplicity.list, VarParsing.varType.int) # ERROR because len(int)
  add('myInts2',  [0],     VarParsing.multiplicity.list, VarParsing.varType.int) # works because len(list)
  add('myBools0', '',      VarParsing.multiplicity.list, VarParsing.varType.bool) # works because len(str)
  add('myBools1', True,    VarParsing.multiplicity.list, VarParsing.varType.bool) # ERROR because len(bool)
  add('myBools2', [True],  VarParsing.multiplicity.list, VarParsing.varType.bool) # works because len(list)
  add('myStrs0',  '',      VarParsing.multiplicity.list, VarParsing.varType.string) # works because len(str)
  add('myStrs1',  'foo',   VarParsing.multiplicity.list, VarParsing.varType.string) # works because len(str)
  add('myStrs2',  ['foo'], VarParsing.multiplicity.list, VarParsing.varType.string) # works because len(list)
  opts.parseArguments()
  print(f">>> Parsed:")
  for var in opts._lists:
    if var.startswith('my'):
      print(f">>>   {var:6s} = {getattr(opts,var)!r}")

parse([ ])
parse(['myInts1=0,1','myBools1=True,False','myStrs1=foo,bar','myStrs2=foo,bar'])
```

Before the changes, there are `TypeErrors`:
```python
>>> parse([ ])
>>> Parsing []...
>>> Register...
>>>   ('myInts0', '', 'multiplicity_list', '_int'), {}...
>>>   ('myInts1', 0, 'multiplicity_list', '_int'), {}...
>>>   => TypeError("object of type 'int' has no len()")
>>>   ('myInts2', [0], 'multiplicity_list', '_int'), {}...
>>>   ('myBools0', '', 'multiplicity_list', '_bool'), {}...
>>>   ('myBools1', True, 'multiplicity_list', '_bool'), {}...
>>>   => TypeError("object of type 'bool' has no len()")
>>>   ('myBools2', [True], 'multiplicity_list', '_bool'), {}...
>>>   ('myStrs0', '', 'multiplicity_list', '_string'), {}...
>>>   ('myStrs1', 'foo', 'multiplicity_list', '_string'), {}...
>>>   ('myStrs2', ['foo'], 'multiplicity_list', '_string'), {}...
>>> Parsed:
>>>   myInts0 = []
>>>   myInts1 = []
>>>   myInts2 = [[0]]
>>>   myBools0 = []
>>>   myBools1 = []
>>>   myBools2 = [[True]]
>>>   myStrs0 = []
>>>   myStrs1 = ['foo']
>>>   myStrs2 = [['foo']]
>>> parse(['myInts1=0,1','myBools1=True,False','myStrs1=foo,bar','myStrs2=foo,bar'])
>>> Parsing ['myInts1=0,1', 'myBools1=True,False', 'myStrs1=foo,bar', 'myStrs2=foo,bar']...
>>> Register...
>>>   ('myInts0', '', 'multiplicity_list', '_int'), {}...
>>>   ('myInts1', 0, 'multiplicity_list', '_int'), {}...
>>>   => TypeError("object of type 'int' has no len()")
>>>   ('myInts2', [0], 'multiplicity_list', '_int'), {}...
>>>   ('myBools0', '', 'multiplicity_list', '_bool'), {}...
>>>   ('myBools1', True, 'multiplicity_list', '_bool'), {}...
>>>   => TypeError("object of type 'bool' has no len()")
>>>   ('myBools2', [True], 'multiplicity_list', '_bool'), {}...
>>>   ('myStrs0', '', 'multiplicity_list', '_string'), {}...
>>>   ('myStrs1', 'foo', 'multiplicity_list', '_string'), {}...
>>>   ('myStrs2', ['foo'], 'multiplicity_list', '_string'), {}...
>>> Parsed:
>>>   myInts0 = []
>>>   myInts1 = [0, 1]
>>>   myInts2 = [[0]]
>>>   myBools0 = []
>>>   myBools1 = [True, False]
>>>   myBools2 = [[True]]
>>>   myStrs0 = []
>>>   myStrs1 = ['foo', 'bar']
>>>   myStrs2 = ['foo', 'bar']
```

After the changes, the `TypeErrors` are gone, and the single defaults are stored as a list of int/float/bool:
```python
>>> parse([ ])
>>> Parsing []...
>>> Register...
>>>   ('myInts0', '', 'multiplicity_list', '_int'), {}...
>>>   ('myInts1', 0, 'multiplicity_list', '_int'), {}...
>>>   ('myInts2', [0], 'multiplicity_list', '_int'), {}...
>>>   ('myBools0', '', 'multiplicity_list', '_bool'), {}...
>>>   ('myBools1', True, 'multiplicity_list', '_bool'), {}...
>>>   ('myBools2', [True], 'multiplicity_list', '_bool'), {}...
>>>   ('myStrs0', '', 'multiplicity_list', '_string'), {}...
>>>   ('myStrs1', 'foo', 'multiplicity_list', '_string'), {}...
>>>   ('myStrs2', ['foo'], 'multiplicity_list', '_string'), {}...
>>> Parsed:
>>>   myInts0 = []
>>>   myInts1 = [0]
>>>   myInts2 = [[0]]
>>>   myBools0 = []
>>>   myBools1 = [True]
>>>   myBools2 = [[True]]
>>>   myStrs0 = []
>>>   myStrs1 = ['foo']
>>>   myStrs2 = [['foo']]
>>> parse(['myInts1=0,1','myBools1=True,False','myStrs1=foo,bar','myStrs2=foo,bar'])
>>> Parsing ['myInts1=0,1', 'myBools1=True,False', 'myStrs1=foo,bar', 'myStrs2=foo,bar']...
>>> Register...
>>>   ('myInts0', '', 'multiplicity_list', '_int'), {}...
>>>   ('myInts1', 0, 'multiplicity_list', '_int'), {}...
>>>   ('myInts2', [0], 'multiplicity_list', '_int'), {}...
>>>   ('myBools0', '', 'multiplicity_list', '_bool'), {}...
>>>   ('myBools1', True, 'multiplicity_list', '_bool'), {}...
>>>   ('myBools2', [True], 'multiplicity_list', '_bool'), {}...
>>>   ('myStrs0', '', 'multiplicity_list', '_string'), {}...
>>>   ('myStrs1', 'foo', 'multiplicity_list', '_string'), {}...
>>>   ('myStrs2', ['foo'], 'multiplicity_list', '_string'), {}...
>>> Parsed:
>>>   myInts0 = []
>>>   myInts1 = [0, 1]
>>>   myInts2 = [[0]]
>>>   myBools0 = []
>>>   myBools1 = [True, False]
>>>   myBools2 = [[True]]
>>>   myStrs0 = []
>>>   myStrs1 = ['foo', 'bar']
>>>   myStrs2 = ['foo', 'bar']
```

## PR tests

Following https://cms-sw.github.io/PRWorkflow.html, I did:
```
scram b distclean 
git cms-checkdeps -a -A # adds 17 other packages..
scram b -j 8
scram b runtests
```
As `VarParsing` is used by many python configuration scripts, `git cms-checkdeps -a -A ` will add 17 additional packages. Not all test are successful, but I checked the same tests fail in a CMSSW project without any changes. As far as I can tell the failures do not come from my side. I assume no workflow contains an exception for the `TypeError` above.