### PR TITLE
Run3-alca248A Modify the macro to accommodate some requirements for obtaining calibration constants of HCAL

### DIFF
--- a/Calibration/HcalCalibAlgos/macros/CalibMain.C
+++ b/Calibration/HcalCalibAlgos/macros/CalibMain.C
@@ -30,7 +30,7 @@
 //
 //  Other parameters for CalibSplit:
 //  <InputFile> <HistogramFile> <Flag> <DirectoryName> <Prefix> <PUcorr>
-//  <Truncate> <Nmax> <pmin> <pmax> <debug>
+//  <Truncate> <Nmax> <pmin> <pmax> <runMin> <runMax> <debug>
 //
 //
 ////////////////////////////////////////////////////////////////////////////////
@@ -371,8 +371,10 @@ int main(Int_t argc, Char_t* argv[]) {
     // CalibSplit
     double pmin = (argc > 10) ? std::atof(argv[10]) : 40.0;
     double pmax = (argc > 11) ? std::atof(argv[11]) : 60.0;
-    bool debug = (argc > 12) ? (std::atoi(argv[12]) > 0) : false;
-    CalibSplit c1(infile, dirname, histfile, pmin, pmax, debug);
+    int runMin = (argc > 12) ? std::atoi(argv[12]) : -1;
+    int runMax = (argc > 13) ? std::atoi(argv[13]) : -1;
+    bool debug = (argc > 14) ? (std::atoi(argv[14]) > 0) : false;
+    CalibSplit c1(infile, dirname, histfile, pmin, pmax, runMin, runMax, debug);
     c1.Loop(nmax);
   }
   return 0;

--- a/Calibration/HcalCalibAlgos/macros/CalibPlotProperties.C
+++ b/Calibration/HcalCalibAlgos/macros/CalibPlotProperties.C
@@ -1814,8 +1814,8 @@ public:
              const std::string &outFileName,
              double pmin = 40.0,
              double pmax = 60.0,
-	     int runMin = -1,
-	     int runMax = -1,
+             int runMin = -1,
+             int runMax = -1,
              bool debug = false);
   virtual ~CalibSplit();
   virtual Int_t Cut(Long64_t entry);
@@ -1839,7 +1839,14 @@ private:
   TTree *outputTree_;
 };
 
-CalibSplit::CalibSplit(const char *fname, const std::string &dirnm, const std::string &outFileName, double pmin, double pmax, int runMin, int runMax, bool debug)
+CalibSplit::CalibSplit(const char *fname,
+                       const std::string &dirnm,
+                       const std::string &outFileName,
+                       double pmin,
+                       double pmax,
+                       int runMin,
+                       int runMax,
+                       bool debug)
     : fname_(fname),
       dirnm_(dirnm),
       outFileName_(outFileName),
@@ -2085,7 +2092,7 @@ void CalibSplit::Loop(Long64_t nentries) {
     bool select = ((t_p >= pmin_) && (t_p < pmax_));
     if (select && checkRun_) {
       if ((t_Run < runMin_) || (t_Run > runMax_))
-	select = false;
+        select = false;
     }
     if (!select) {
       ++reject;


### PR DESCRIPTION
#### PR description:

Modify the macro to accommodate some requirements for obtaining calibration constants of HCAL

#### PR validation:

Use the modified macros to obtain the latest calibration constants for HCAL

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special