### PR TITLE
[14.0.X] `MultiTrajectoryStateAssembler`: protect `removeWrongPz` when average pZ sign is identically 0

### DIFF
--- a/TrackingTools/GsfTools/src/MultiTrajectoryStateAssembler.cc
+++ b/TrackingTools/GsfTools/src/MultiTrajectoryStateAssembler.cc
@@ -190,6 +190,15 @@ void MultiTrajectoryStateAssembler::removeWrongPz() {
   for (auto const &is : theStates)
     meanPz += is.weight() * is.localParameters().pzSign();
   meanPz /= theValidWeightSum;
+
+  // When meanPz=0 it is not possible to check which are the states non agreeing with the average pZ sign
+  if (meanPz == 0.) {
+    edm::LogError("MultiTrajectoryStateAssembler")
+        << " input multistate has average pZ sign == 0. Rejecting!" << std::endl;
+    theStates.clear();
+    return;
+  }
+
   //
   // Now keep only states compatible with the average pz
   //
@@ -197,7 +206,7 @@ void MultiTrajectoryStateAssembler::removeWrongPz() {
   MultiTSOS oldStates(theStates);
   theStates.clear();
   for (auto const &is : oldStates) {
-    if (meanPz * is.localParameters().pzSign() >= 0.) {
+    if (meanPz * is.localParameters().pzSign() > 0.) {
       theValidWeightSum += is.weight();
       theStates.push_back(is);
     } else {


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/45646

#### PR description:

This PR is meant as a fix for the situation that occurred in online HLT operations and lead to https://github.com/cms-sw/cmssw/issues/45639. 
As explained in detailed https://github.com/cms-sw/cmssw/issues/45639#issuecomment-2270661982, in this event, some states have positive pz-sign, and some states have negative pz-sign, which is a problem.
The chain of calls is the following:  `GsfMultiStateUpdator` calls `MultiTrajectoryStateAssembler::combinedState()` , which in turn calls `MultiTrajectoryStateAssembler::prepareCombinedState()`. At this stage, the algo tries to fix the problem by calling `removeWrongPz()`. In most cases `removeWrongPz` will solve the issue.
In one special case , where `meanPz=0`, it will not be able to solve the issue and it will let the charged-flipped states pass which will create the crash later on, where there is another check of pz-sign.
This PR circumvents the issue by explicitly logging an error when this happens, clear the states vector and then do an early return.

#### PR validation:

Tested in `CMSSW_14_0_13_MULTIARCH` + this commit https://github.com/mmusich/cmssw/commit/24d4fd21c58c95ee35d1e840e5ce8aeacc37b4a8 with the reproducer at https://github.com/cms-sw/cmssw/issues/45639#issue-2448433243:

```bash
#!/bin/bash -ex

# CMSSW_14_0_13_MULTIARCHS

hltGetConfiguration run:384069 \
--globaltag 140X_dataRun3_HLT_v3 \
--data \
--no-prescale \
--no-output \
--max-events -1 \
--input '/store/group/tsg/FOG/error_stream_root/run384069/run384069_ls0689_index000033_fu-c2b04-35-01_pid2378323.root,/store/group/tsg/FOG/error_stream_root/run384069/run384069_ls0689_index000067_fu-c2b0
4-35-01_pid2378323.root' > hlt.py

cat <<@EOF >> hlt.py
del process.MessageLogger
process.load('FWCore.MessageService.MessageLogger_cfi')  
process.options.wantSummary = True
process.options.numberOfThreads = 1
process.options.numberOfStreams = 0
@EOF

cmsRun hlt.py &> hlt.log
```

and observed no crash. 

## **N.B.** 
It's worth noting that the crash doesn't appear to start with in `CMSSW_14_0_13` (tout-cout) , so it looks like the `MULTIARCHS` variant (hence `x86-64-v3` micro-architecture) is triggering the problem in the first place, see https://github.com/cms-sw/cmssw/issues/45639#issuecomment-2270869959. 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/45646 for 2024 online HLT data-taking puroposes.
