### PR TITLE
HLTTauDQM: support for PatTau ref objects

### DIFF
--- a/DQMOffline/Trigger/interface/HLTTauRefProducer.h
+++ b/DQMOffline/Trigger/interface/HLTTauRefProducer.h
@@ -24,6 +24,7 @@
 #include "DataFormats/TauReco/interface/PFTau.h"
 #include "DataFormats/TauReco/interface/PFTauDiscriminator.h"
 #include "DataFormats/TauReco/interface/TauDiscriminatorContainer.h"
+#include "DataFormats/PatCandidates/interface/Tau.h"
 
 // ELECTRON includes
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
@@ -71,10 +72,12 @@ private:
   edm::EDGetTokenT<reco::PFTauCollection> PFTaus_;
   std::vector<edm::EDGetTokenT<reco::PFTauDiscriminator>> PFTauDis_;
   std::vector<edm::EDGetTokenT<reco::TauDiscriminatorContainer>> PFTauDisCont_;
+  edm::EDGetTokenT<edm::View<pat::Tau>> PATTaus_;
   std::vector<std::string> PFTauDisContWPs_;
   edm::ProcessHistoryID phID_;
   bool doPFTaus_;
   double ptMinPFTau_, etaMinPFTau_, etaMaxPFTau_, phiMinPFTau_, phiMaxPFTau_;
+  std::vector<std::string> discriminatorNames;
 
   edm::EDGetTokenT<reco::GsfElectronCollection> Electrons_;
   bool doElectrons_;

--- a/DQMOffline/Trigger/plugins/HLTTauRefProducer.cc
+++ b/DQMOffline/Trigger/plugins/HLTTauRefProducer.cc
@@ -31,7 +31,7 @@ HLTTauRefProducer::HLTTauRefProducer(const edm::ParameterSet& iConfig) {
   {
     auto const& pfTau = iConfig.getUntrackedParameter<edm::ParameterSet>("PFTaus");
     PFTaus_ = consumes<reco::PFTauCollection>(pfTau.getUntrackedParameter<InputTag>("PFTauProducer", InputTag()));
-    PATTaus_ = consumes<edm::View<pat::Tau>>(pfTau.getUntrackedParameter<InputTag>("PFTauProducer", InputTag()));
+    PATTaus_ = consumes<edm::View<pat::Tau>>(pfTau.getUntrackedParameter<InputTag>("PatTauProducer", InputTag()));
     auto discs = pfTau.getUntrackedParameter<vector<InputTag>>("PFTauDiscriminators");
     auto discConts = pfTau.getUntrackedParameter<vector<InputTag>>("PFTauDiscriminatorContainers");
     PFTauDisContWPs_ = pfTau.getUntrackedParameter<vector<std::string>>("PFTauDiscriminatorContainerWPs");

--- a/DQMOffline/Trigger/plugins/HLTTauRefProducer.cc
+++ b/DQMOffline/Trigger/plugins/HLTTauRefProducer.cc
@@ -30,7 +30,8 @@ HLTTauRefProducer::HLTTauRefProducer(const edm::ParameterSet& iConfig) {
   //One Parameter Set per Collection
   {
     auto const& pfTau = iConfig.getUntrackedParameter<edm::ParameterSet>("PFTaus");
-    PFTaus_ = consumes<reco::PFTauCollection>(pfTau.getUntrackedParameter<InputTag>("PFTauProducer"));
+    PFTaus_ = consumes<reco::PFTauCollection>(pfTau.getUntrackedParameter<InputTag>("PFTauProducer", InputTag()));
+    PATTaus_ = consumes<edm::View<pat::Tau>>(pfTau.getUntrackedParameter<InputTag>("PFTauProducer", InputTag()));
     auto discs = pfTau.getUntrackedParameter<vector<InputTag>>("PFTauDiscriminators");
     auto discConts = pfTau.getUntrackedParameter<vector<InputTag>>("PFTauDiscriminatorContainers");
     PFTauDisContWPs_ = pfTau.getUntrackedParameter<vector<std::string>>("PFTauDiscriminatorContainerWPs");
@@ -39,6 +40,7 @@ HLTTauRefProducer::HLTTauRefProducer(const edm::ParameterSet& iConfig) {
                                                "PFTauDiscriminatorContainerWPs must have the same number of entries!\n";
     for (auto const& tag : discs) {
       PFTauDis_.push_back(consumes<reco::PFTauDiscriminator>(tag));
+      discriminatorNames.push_back(tag.label());
     }
     for (auto const& tag : discConts) {
       PFTauDisCont_.push_back(consumes<reco::TauDiscriminatorContainer>(tag));
@@ -138,85 +140,101 @@ void HLTTauRefProducer::produce(edm::StreamID iID, edm::Event& iEvent, edm::Even
 void HLTTauRefProducer::doPFTaus(edm::StreamID iID, edm::Event& iEvent) const {
   auto product_PFTaus = make_unique<LorentzVectorCollection>();
 
-  edm::Handle<PFTauCollection> pftaus;
-  if (iEvent.getByToken(PFTaus_, pftaus)) {
-    // Retrieve ID container indices if config history changes, in particular for the first event.
-    if (streamCache(iID)->first != iEvent.processHistoryID()) {
-      streamCache(iID)->first = iEvent.processHistoryID();
-      streamCache(iID)->second.resize(PFTauDisContWPs_.size());
-      for (size_t i = 0; i < PFTauDisCont_.size(); ++i) {
-        auto const aHandle = iEvent.getHandle(PFTauDisCont_[i]);
-        auto const aProv = aHandle.provenance();
-        if (aProv == nullptr)
-          aHandle.whyFailed()->raise();
-        const auto& psetsFromProvenance = edm::parameterSet(aProv->stable(), iEvent.processHistory());
-        if (psetsFromProvenance.exists("workingPoints")) {
-          auto const idlist = psetsFromProvenance.getParameter<std::vector<std::string>>("workingPoints");
-          bool found = false;
-          for (size_t j = 0; j < idlist.size(); ++j) {
-            if (PFTauDisContWPs_[i] == idlist[j]) {
-              found = true;
-              streamCache(iID)->second[i] = j;
-            }
-          }
-          if (!found)
-            throw cms::Exception("Configuration")
-                << "HLTTauRefProducer: Requested working point '" << PFTauDisContWPs_[i] << "' not found!\n";
-        } else if (psetsFromProvenance.exists("IDWPdefinitions")) {
-          auto const idlist = psetsFromProvenance.getParameter<std::vector<edm::ParameterSet>>("IDWPdefinitions");
-          bool found = false;
-          for (size_t j = 0; j < idlist.size(); ++j) {
-            if (PFTauDisContWPs_[i] == idlist[j].getParameter<std::string>("IDname")) {
-              found = true;
-              streamCache(iID)->second[i] = j;
-            }
-          }
-          if (!found)
-            throw cms::Exception("Configuration")
-                << "HLTTauRefProducer: Requested working point '" << PFTauDisContWPs_[i] << "' not found!\n";
-        } else
-          throw cms::Exception("Configuration")
-              << "HLTTauRefProducer: No suitable ID list found in provenace config!\n";
+  edm::Handle<edm::View<pat::Tau>> pattaus;
+  if (iEvent.getByToken(PATTaus_, pattaus)) {
+    bool passAll{true};
+    for (unsigned int i = 0; i < pattaus->size(); ++i) {
+      auto const& tau = (*pattaus)[i];
+      if (tau.pt() > ptMinPFTau_ && tau.eta() > etaMinPFTau_ && tau.eta() < etaMaxPFTau_ && tau.phi() > phiMinPFTau_ &&
+          tau.phi() < phiMaxPFTau_) {
+        for (auto const& discriminatorName : discriminatorNames) {
+          passAll = passAll && tau.tauID(discriminatorName);
+        }
       }
+      if (passAll)
+        product_PFTaus->emplace_back(tau.px(), tau.py(), tau.pz(), tau.energy());
     }
-    for (unsigned int i = 0; i < pftaus->size(); ++i) {
-      auto const& pftau = (*pftaus)[i];
-      if (pftau.pt() > ptMinPFTau_ && pftau.eta() > etaMinPFTau_ && pftau.eta() < etaMaxPFTau_ &&
-          pftau.phi() > phiMinPFTau_ && pftau.phi() < phiMaxPFTau_) {
-        reco::PFTauRef thePFTau{pftaus, i};
-        bool passAll{true};
+  } else {
+    edm::Handle<PFTauCollection> pftaus;
+    if (iEvent.getByToken(PFTaus_, pftaus)) {
+      // Retrieve ID container indices if config history changes, in particular for the first event.
+      if (streamCache(iID)->first != iEvent.processHistoryID()) {
+        streamCache(iID)->first = iEvent.processHistoryID();
+        streamCache(iID)->second.resize(PFTauDisContWPs_.size());
+        for (size_t i = 0; i < PFTauDisCont_.size(); ++i) {
+          auto const aHandle = iEvent.getHandle(PFTauDisCont_[i]);
+          auto const aProv = aHandle.provenance();
+          if (aProv == nullptr)
+            aHandle.whyFailed()->raise();
+          const auto& psetsFromProvenance = edm::parameterSet(aProv->stable(), iEvent.processHistory());
+          if (psetsFromProvenance.exists("workingPoints")) {
+            auto const idlist = psetsFromProvenance.getParameter<std::vector<std::string>>("workingPoints");
+            bool found = false;
+            for (size_t j = 0; j < idlist.size(); ++j) {
+              if (PFTauDisContWPs_[i] == idlist[j]) {
+                found = true;
+                streamCache(iID)->second[i] = j;
+              }
+            }
+            if (!found)
+              throw cms::Exception("Configuration")
+                  << "HLTTauRefProducer: Requested working point '" << PFTauDisContWPs_[i] << "' not found!\n";
+          } else if (psetsFromProvenance.exists("IDWPdefinitions")) {
+            auto const idlist = psetsFromProvenance.getParameter<std::vector<edm::ParameterSet>>("IDWPdefinitions");
+            bool found = false;
+            for (size_t j = 0; j < idlist.size(); ++j) {
+              if (PFTauDisContWPs_[i] == idlist[j].getParameter<std::string>("IDname")) {
+                found = true;
+                streamCache(iID)->second[i] = j;
+              }
+            }
+            if (!found)
+              throw cms::Exception("Configuration")
+                  << "HLTTauRefProducer: Requested working point '" << PFTauDisContWPs_[i] << "' not found!\n";
+          } else
+            throw cms::Exception("Configuration")
+                << "HLTTauRefProducer: No suitable ID list found in provenace config!\n";
+        }
+      }
+      for (unsigned int i = 0; i < pftaus->size(); ++i) {
+        auto const& pftau = (*pftaus)[i];
+        if (pftau.pt() > ptMinPFTau_ && pftau.eta() > etaMinPFTau_ && pftau.eta() < etaMaxPFTau_ &&
+            pftau.phi() > phiMinPFTau_ && pftau.phi() < phiMaxPFTau_) {
+          reco::PFTauRef thePFTau{pftaus, i};
+          bool passAll{true};
 
-        for (auto const& token : PFTauDis_) {
-          edm::Handle<reco::PFTauDiscriminator> pftaudis;
-          if (iEvent.getByToken(token, pftaudis)) {
-            if ((*pftaudis)[thePFTau] < 0.5) {
+          for (auto const& token : PFTauDis_) {
+            edm::Handle<reco::PFTauDiscriminator> pftaudis;
+            if (iEvent.getByToken(token, pftaudis)) {
+              if ((*pftaudis)[thePFTau] < 0.5) {
+                passAll = false;
+                break;
+              }
+            } else {
               passAll = false;
               break;
             }
-          } else {
-            passAll = false;
-            break;
           }
-        }
 
-        int idx = 0;
-        for (auto const& token : PFTauDisCont_) {
-          edm::Handle<reco::TauDiscriminatorContainer> pftaudis;
-          if (iEvent.getByToken(token, pftaudis)) {
-            //WP vector not filled if prediscriminator in RecoTauDiscriminator failed.
-            if ((*pftaudis)[thePFTau].workingPoints.empty() ||
-                !(*pftaudis)[thePFTau].workingPoints.at(streamCache(iID)->second[idx])) {
+          int idx = 0;
+          for (auto const& token : PFTauDisCont_) {
+            edm::Handle<reco::TauDiscriminatorContainer> pftaudis;
+            if (iEvent.getByToken(token, pftaudis)) {
+              //WP vector not filled if prediscriminator in RecoTauDiscriminator failed.
+              if ((*pftaudis)[thePFTau].workingPoints.empty() ||
+                  !(*pftaudis)[thePFTau].workingPoints.at(streamCache(iID)->second[idx])) {
+                passAll = false;
+                break;
+              }
+            } else {
               passAll = false;
               break;
             }
-          } else {
-            passAll = false;
-            break;
+            idx++;
           }
-          idx++;
-        }
-        if (passAll) {
-          product_PFTaus->emplace_back(pftau.px(), pftau.py(), pftau.pz(), pftau.energy());
+          if (passAll) {
+            product_PFTaus->emplace_back(pftau.px(), pftau.py(), pftau.pz(), pftau.energy());
+          }
         }
       }
     }

--- a/DQMOffline/Trigger/python/HLTTauDQMOfflineTauProducer_cfi.py
+++ b/DQMOffline/Trigger/python/HLTTauDQMOfflineTauProducer_cfi.py
@@ -1,0 +1,12 @@
+from PhysicsTools.PatAlgos.producersLayer1.tauProducer_cfi import *
+patTaus.addGenMatch      = cms.bool(False)
+patTaus.embedGenMatch    = cms.bool(False)
+patTaus.addGenJetMatch   = cms.bool(False)
+patTaus.embedGenJetMatch = cms.bool(False)
+
+from Configuration.StandardSequences.MagneticField_cff import *
+
+patAlgosToolsTask = cms.Task()
+patAlgosToolsTask.add(patTaus)
+
+HLTTauDQMOfflineTauProducer = cms.Sequence(patAlgosToolsTask)

--- a/DQMOffline/Trigger/python/HLTTauDQMOffline_cff.py
+++ b/DQMOffline/Trigger/python/HLTTauDQMOffline_cff.py
@@ -5,9 +5,14 @@ from DQMOffline.Trigger.HLTTauPostProcessor_cfi import *
 from DQMOffline.Trigger.HLTTauQualityTester_cfi import *
 from DQMOffline.Trigger.HLTTauCertifier_cfi import *
 
-HLTTauDQMOffline = cms.Sequence(TauRefProducer
+from DQMOffline.Trigger.HLTTauDQMOfflineTauProducer_cfi import *
+
+
+HLTTauDQMOffline = cms.Sequence(HLTTauDQMOfflineTauProducer+TauRefProducer+TauRefProducerLowPurity
                                 +hltTauOfflineMonitor_PFTaus
+                                +hltTauOfflineMonitor_PFTausLowPurity
                                 +hltTauOfflineMonitor_PNetTaus
+                                +hltTauOfflineMonitor_PNetTausLowPurity
                                 +hltTauOfflineMonitor_Inclusive
                                 +hltTauOfflineMonitor_TagAndProbe
                                 )

--- a/DQMOffline/Trigger/python/HLTTauDQMOffline_cfi.py
+++ b/DQMOffline/Trigger/python/HLTTauDQMOffline_cfi.py
@@ -20,7 +20,7 @@ TauRefProducer = cms.EDProducer("HLTTauRefProducer",
                             phiMin = cms.untracked.double(-3.15),
                             phiMax = cms.untracked.double(3.15),
                             #PFTauProducer = cms.untracked.InputTag("hpsPFTauProducer")
-                            PFTauProducer = cms.untracked.InputTag("patTaus")
+                            PatTauProducer = cms.untracked.InputTag("patTaus")
                             ),
                     Electrons = cms.untracked.PSet(
                             ElectronCollection = cms.untracked.InputTag("gedGsfElectrons"),
@@ -87,7 +87,7 @@ TauRefProducerLowPurity = TauRefProducer.clone(
         phiMin = cms.untracked.double(-3.15),
         phiMax = cms.untracked.double(3.15),
         #PFTauProducer = cms.untracked.InputTag("hpsPFTauProducer")
-        PFTauProducer = cms.untracked.InputTag("patTaus")
+        PatTauProducer = cms.untracked.InputTag("patTaus")
     )
 )
 

--- a/DQMOffline/Trigger/python/HLTTauDQMOffline_cfi.py
+++ b/DQMOffline/Trigger/python/HLTTauDQMOffline_cfi.py
@@ -9,7 +9,9 @@ TauRefProducer = cms.EDProducer("HLTTauRefProducer",
                             PFTauDiscriminatorContainers  = cms.untracked.VInputTag(),
                             PFTauDiscriminatorContainerWPs  = cms.untracked.vstring(),
                             PFTauDiscriminators = cms.untracked.VInputTag(
-                                    cms.InputTag("hpsPFTauDiscriminationByDecayModeFinding")
+                                #cms.InputTag("hpsPFTauDiscriminationByDecayModeFinding")
+                                cms.InputTag("decayModeFindingNewDMs"),
+                                cms.InputTag("byMediumCombinedIsolationDeltaBetaCorr3Hits")
                             ),
                             doPFTaus = cms.untracked.bool(True),
                             ptMin = cms.untracked.double(15.0),
@@ -17,7 +19,8 @@ TauRefProducer = cms.EDProducer("HLTTauRefProducer",
                             etaMax = cms.untracked.double(2.5),
                             phiMin = cms.untracked.double(-3.15),
                             phiMax = cms.untracked.double(3.15),
-                            PFTauProducer = cms.untracked.InputTag("hpsPFTauProducer")
+                            #PFTauProducer = cms.untracked.InputTag("hpsPFTauProducer")
+                            PFTauProducer = cms.untracked.InputTag("patTaus")
                             ),
                     Electrons = cms.untracked.PSet(
                             ElectronCollection = cms.untracked.InputTag("gedGsfElectrons"),
@@ -69,6 +72,24 @@ TauRefProducer = cms.EDProducer("HLTTauRefProducer",
                     PhiMin = cms.untracked.double(-3.15),
                     PhiMax = cms.untracked.double(3.15)
                   )
+
+TauRefProducerLowPurity = TauRefProducer.clone(
+    PFTaus = cms.untracked.PSet(
+        PFTauDiscriminatorContainers  = cms.untracked.VInputTag(),
+        PFTauDiscriminatorContainerWPs  = cms.untracked.vstring(),
+        PFTauDiscriminators = cms.untracked.VInputTag(
+            cms.InputTag("decayModeFindingNewDMs"),
+        ),
+        doPFTaus = cms.untracked.bool(True),
+        ptMin = cms.untracked.double(15.0),
+        etaMin = cms.untracked.double(-2.5),
+        etaMax = cms.untracked.double(2.5),
+        phiMin = cms.untracked.double(-3.15),
+        phiMax = cms.untracked.double(3.15),
+        #PFTauProducer = cms.untracked.InputTag("hpsPFTauProducer")
+        PFTauProducer = cms.untracked.InputTag("patTaus")
+    )
+)
 
 #----------------------------------MONITORS--------------------------------------------------------------------------
 kEverything = 0
@@ -127,6 +148,36 @@ hltTauOfflineMonitor_Inclusive = hltTauOfflineMonitor_PFTaus.clone(
         doMatching            = cms.untracked.bool(False),
         matchFilters          = cms.untracked.VPSet(),
     )
+)
+
+hltTauOfflineMonitor_PFTausLowPurity = hltTauOfflineMonitor_PFTaus.clone(
+    DQMBaseFolder = cms.untracked.string("HLT/TAU/PFTausLowPurity"),
+    Matching = cms.PSet(
+        doMatching            = cms.untracked.bool(True),
+        matchFilters          = cms.untracked.VPSet(
+                                    cms.untracked.PSet(
+                                        FilterName        = cms.untracked.InputTag("TauRefProducerLowPurity","PFTaus"),
+                                        matchObjectID     = cms.untracked.int32(15),
+                                    ),
+                                    cms.untracked.PSet(
+                                        FilterName        = cms.untracked.InputTag("TauRefProducerLowPurity","Electrons"),
+                                        matchObjectID     = cms.untracked.int32(11),
+                                    ),
+                                    cms.untracked.PSet(
+                                        FilterName        = cms.untracked.InputTag("TauRefProducerLowPurity","Muons"),
+                                        matchObjectID     = cms.untracked.int32(13),
+                                    ),
+                                    cms.untracked.PSet(
+                                        FilterName        = cms.untracked.InputTag("TauRefProducerLowPurity","MET"),
+                                        matchObjectID     = cms.untracked.int32(0),
+                                    ),
+                                ),
+    ),
+)
+
+hltTauOfflineMonitor_PNetTausLowPurity = hltTauOfflineMonitor_PFTausLowPurity.clone(
+    DQMBaseFolder = cms.untracked.string("HLT/TAU/PNetTausLowPurity"),
+    Paths = cms.untracked.string("PNetTauh")
 )
 
 def TriggerSelectionParameters(hltpaths):

--- a/DQMOffline/Trigger/python/HLTTauPostProcessor_cfi.py
+++ b/DQMOffline/Trigger/python/HLTTauPostProcessor_cfi.py
@@ -77,9 +77,14 @@ def makePFTauAnalyzer(monitorModule):
 (HLTTauPostAnalysisPNetTaus, HLTTauPostAnalysisPNetTaus2) = makePFTauAnalyzer(hltTauOfflineMonitor_PNetTaus)
 (HLTTauPostAnalysisTP, HLTTauPostAnalysisTP2) = makePFTauAnalyzer(hltTauOfflineMonitor_TagAndProbe)
 
+(HLTTauPostAnalysisPFTausLowPurity, HLTTauPostAnalysisPFTausLowPurity2) = makePFTauAnalyzer(hltTauOfflineMonitor_PFTausLowPurity)
+(HLTTauPostAnalysisPNetTausLowPurity, HLTTauPostAnalysisPNetTausLowPurity2) = makePFTauAnalyzer(hltTauOfflineMonitor_PNetTausLowPurity)
+
 HLTTauPostSeq = cms.Sequence(
     HLTTauPostAnalysisInclusive+HLTTauPostAnalysisInclusive2+
     HLTTauPostAnalysisPFTaus+HLTTauPostAnalysisPFTaus2+
+    HLTTauPostAnalysisPFTausLowPurity+HLTTauPostAnalysisPFTausLowPurity2+
     HLTTauPostAnalysisPNetTaus+HLTTauPostAnalysisPNetTaus2+
+    HLTTauPostAnalysisPNetTausLowPurity+HLTTauPostAnalysisPNetTausLowPurity2+
     HLTTauPostAnalysisTP+HLTTauPostAnalysisTP2
 )

--- a/PhysicsTools/PatAlgos/plugins/PATTauProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTauProducer.cc
@@ -287,9 +287,7 @@ void PATTauProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
 
   // Get the collection of taus from the event
   edm::Handle<edm::View<reco::BaseTau>> anyTaus;
-  try {
-    iEvent.getByToken(baseTauToken_, anyTaus);
-  } catch (const edm::Exception& e) {
+  if (!iEvent.getByToken(baseTauToken_, anyTaus)) {
     edm::LogWarning("DataSource") << "WARNING! No Tau collection found. This missing input will not block the job. "
                                      "Instead, an empty tau collection is being be produced.";
     auto patTaus = std::make_unique<std::vector<Tau>>();


### PR DESCRIPTION
#### PR description:

Added a creation of pat taus and using them as offline reference objects. That way we can have tau discriminators available, and better offline tau reference object selection.

The DQM plots contain now two sets, one with default medium working point tau against jet selection, and another with decayModeFinding only. The latter plots are named with string 'LowPurity'.

As the offline tau selection changes, expecting differences between new and old plots, however, old plots and new low purity plots should be identical.
