### PR TITLE
another apptainer workaround

### DIFF
--- a/HeterogeneousCore/SonicTriton/scripts/cmsTriton
+++ b/HeterogeneousCore/SonicTriton/scripts/cmsTriton
@@ -313,6 +313,9 @@ start_apptainer(){
 		fi
 	fi
 
+    # workaround for https://github.com/apptainer/apptainer/issues/2164
+    unset DBUS_SESSION_BUS_ADDRESS
+
 	# start instance
 	# need to bind /cvmfs for above symlinks to work inside container
 	# --underlay: workaround for https://github.com/apptainer/apptainer/issues/2167


### PR DESCRIPTION
#### PR description:

Another apptainer issue has appeared when starting the local Triton fallback server for el7 CMSSW (when running on el9 host OS). The symptom is:
```
INFO:    Disabling cgroups because systemd is unavailable
ERROR:   container cleanup failed: no instance found with name triton_server_instance_CPU_ee4479ae-3b48-43cb-8cb6-2524794d089e
FATAL:   container creation failed: while applying cgroups config: while creating cgroup manager: systemd not running on this host, cannot use systemd cgroups manager
```

This is not the exact same message as in https://github.com/apptainer/apptainer/issues/2164, but the same workaround applies.

#### PR validation:

Unit tests now pass.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Will be backported to 14_0_X to fix the same issue.
