### PR TITLE
Removed unnecessary xz dependency from GeneratorProducts

### DIFF
--- a/SimDataFormats/GeneratorProducts/BuildFile.xml
+++ b/SimDataFormats/GeneratorProducts/BuildFile.xml
@@ -3,7 +3,6 @@
 <use name="DataFormats/Common"/>
 <use name="hepmc"/>
 <use name="hepmc3"/>
-<use name="xz"/>
 <use name="roothistmatrix"/>
 <export>
   <lib name="1"/>


### PR DESCRIPTION
#### PR description:

The dependency is not needed for compiling or linking.

#### PR validation:

Code compiles and links.