### PR TITLE
Remove a potential memory leak in Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.cc

### DIFF
--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.cc
@@ -608,7 +608,8 @@ void GEMGeometryBuilder::buildRegions(GEMGeometry& theGeometry,
         if (foundSuperChamber) {
           station->add(ring);
           theGeometry.add(ring);
-        }
+        } else
+          delete ring;
       }
       if (!foundSuperChamber) {
 #ifdef EDM_ML_DEBUG


### PR DESCRIPTION
Remove a potential memory leak that was pointed out by the static analyzer.

Tested not crashing on a few relevant workflows. No changes are expected whatsoever.