### PR TITLE
Added displaced muon information to the EMTF emulator DQM

### DIFF
--- a/DQM/L1TMonitor/python/L1TdeStage2EMTF_cff.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2EMTF_cff.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from DQM.L1TMonitor.L1TdeStage2EMTF_cfi import *
 from DQM.L1TMonitor.L1TdeStage2RegionalShower_cfi import *
+from Configuration.Eras.Modifier_run3_2024_L1T_cff import run3_2024_L1T
 
 # List of bins to ignore
 ignoreBinsDeStage2Emtf = [1]
@@ -20,6 +21,12 @@ l1tdeStage2EmtfComp = DQMEDAnalyzer(
     ignoreBadTrackAddress = cms.untracked.bool(True),
     ignoreBin = cms.untracked.vint32(ignoreBinsDeStage2Emtf),
     verbose = cms.untracked.bool(False),
+    hasDisplacementInfo = cms.untracked.bool(False),
+)
+
+run3_2024_L1T.toModify(
+    l1tdeStage2EmtfComp,
+    hasDisplacementInfo = cms.untracked.bool(True) # Linden Burack 7/26/2024
 )
 
 # sequences


### PR DESCRIPTION
#### PR description:

The EMTF emulator DQM will now include the displaced muon pT and dxy information which was added to the EMTF in 2024. The code to make these plots already existed, but an era modifier to set 'hasDisplacementInfo' to true for 2024 Run3 data was necessary to make it appear.

There are two new DQM histograms showing unconstrained muon pT from the hardware and from the emulator.
The errorSummaryDen, errorSummaryNum, and mismatchRatio histograms have two new bins for unconstrained muon pt, and transverse displacement. 

After inclusion of displaced muons, a much higher muon mismatch ratio should be expected because unconstrained muon pT assignment in the emulator slightly differs from the hardware due to fixed point vs floating point models. A normal unconstrained pT mismatch rate is high in the EMTF (~30%).

#### PR validation:

The DQM was successfully run locally on lxplus
dataset='/Muon0/Run2024F-ZMu-PromptReco-v1/RAW-RECO'
run='383449'
runTheMatrix.py -l limited -i all --ibeos: all passed except 1000.0_RunMinBias2011A which has a [known issue](https://github.com/cms-sw/cmssw/issues/44369) when CMSSW is run from eos.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is expected to be backported to 14_0_X so that it can be used in data taking.

@eyigitba