### PR TITLE
ECAL PayloadInspector : bug correction

### DIFF
--- a/CondCore/EcalPlugins/plugins/EcalSimComponentShape_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalSimComponentShape_PayloadInspector.cc
@@ -46,7 +46,7 @@ namespace {
           profiles.push_back(new TProfile(nameBuffer, "", EBnbins[iShape], 0, EBxmaxs[iShape]));
           for (int s = 0; s < EBnbins[iShape]; s++) {
             double val = EBshape[s];
-            profiles[iShape]->Fill(s, val);
+            profiles[iShape]->Fill(s * time, val);
           }
           ++iShape;
         }

--- a/CondCore/EcalPlugins/plugins/EcalSimPulseShape_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalSimPulseShape_PayloadInspector.cc
@@ -55,15 +55,15 @@ namespace {
         apd = new TProfile("APDshape", "", APDnbin, 0, APDxmax);
         for (int s = 0; s < EBnbin; s++) {
           double val = EBshape[s];
-          barrel->Fill(s, val);
+          barrel->Fill(s * time, val);
         }
         for (int s = 0; s < EEnbin; s++) {
           double val = EEshape[s];
-          endcap->Fill(s, val);
+          endcap->Fill(s * time, val);
         }
         for (int s = 0; s < APDnbin; s++) {
           double val = APDshape[s];
-          apd->Fill(s, val);
+          apd->Fill(s * time, val);
         }
       }  // if payload.get()
       else


### PR DESCRIPTION
#### PR description:
ECAL PayloadInspector :  in EcalSimComponentShape_PayloadInspector.cc and EcalSimPulseShape_PayloadInspector.cc, the time_interval between successive points was not taken into account, leading to wrong pulse shape plots in case of time_interval <> 1 ns.

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

./getPayloadData.py --plugin pluginEcalSimPulseShape_PayloadInspector --plot plot_EcalSimPulseShapeProfile --tag EcalSimPulseShapePhaseI --time_type Run --iovs '{"start_iov": "1", "end_iov": "1"}' --db Prod --test

./getPayloadData.py --plugin pluginEcalSimPulseShape_PayloadInspector --plot plot_EcalSimPulseShapeProfile --tag EcalSimPulseShapePhaseII --time_type Run --iovs '{"start_iov": "1", "end_iov": "1"}' --db Prod --test

./getPayloadData.py --plugin pluginEcalSimComponentShape_PayloadInspector --plot plot_EcalSimComponentShapeProfile --tag EcalSimComponentShape_PhaseI --time_type Run --iovs '{"start_iov": "1", "end_iov": "1"}' --db Prod --test

./getPayloadData.py --plugin pluginEcalSimComponentShape_PayloadInspector --plot plot_EcalSimComponentShapeProfile --tag EcalSimComponentShape_PhaseII --time_type Run --iovs '{"start_iov": "1", "end_iov": "1"}' --db Prod --test

give the correct plots, for Phase I and Phase II..