### PR TITLE
use `rawDataRepacker` in presence of `hi_run` run class in a bunch of DQM online clients

### DIFF
--- a/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
@@ -164,6 +164,7 @@ if process.runType.getRunType() == process.runType.hi_run:
     process.selfFatEventFilter.rawInput = rawDataRepackerLabel
     process.rpcTwinMuxRawToDigi.inputTag = rawDataRepackerLabel
     process.rpcCPPFRawToDigi.inputTag = rawDataRepackerLabel
+    process.rpcunpacker.InputLabel = rawDataRepackerLabel
 
 #--------------------------------------------------
 # L1T Emulator Online DQM Schedule

--- a/DQM/Integration/python/clients/mutracking_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/mutracking_dqm_sourceclient-live_cfg.py
@@ -2,9 +2,12 @@ from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
 import sys
-from Configuration.Eras.Era_Run2_2018_pp_on_AA_cff import Run2_2018_pp_on_AA
-from Configuration.Eras.Era_Run3_cff import Run3
-process = cms.Process("MUTRKDQM", Run3)
+if 'runkey=hi_run' in sys.argv:
+  from Configuration.Eras.Era_Run3_pp_on_PbPb_approxSiStripClusters_cff import Run3_pp_on_PbPb_approxSiStripClusters
+  process = cms.Process("MUTRKDQM", Run3_pp_on_PbPb_approxSiStripClusters)
+else:
+  from Configuration.Eras.Era_Run3_cff import Run3
+  process = cms.Process("MUTRKDQM", Run3)
 
 live=True
 unitTest=False
@@ -13,7 +16,6 @@ if 'unitTest=True' in sys.argv:
     unitTest=True
 
 offlineTesting=not live
-
 
 #----------------------------
 #### Event Source
@@ -101,9 +103,22 @@ elif(offlineTesting):
     from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
     process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run3_data', '')
 
+### HEAVY ION SETTING
+if process.runType.getRunType() == process.runType.hi_run:
+    rawDataRepackerLabel = 'rawDataRepacker'
+    process.muonCSCDigis.InputObjects = rawDataRepackerLabel
+    process.muonDTDigis.inputLabel = rawDataRepackerLabel
+    process.muonRPCDigis.InputLabel = rawDataRepackerLabel
+    process.muonGEMDigis.InputLabel = rawDataRepackerLabel
+    process.twinMuxStage2Digis.DTTM7_FED_Source = rawDataRepackerLabel
+    process.bmtfDigis.InputLabel = rawDataRepackerLabel
+    process.omtfStage2Digis.inputLabel = rawDataRepackerLabel
+    process.emtfStage2Digis.InputLabel = rawDataRepackerLabel
+    process.gmtStage2Digis.InputLabel = rawDataRepackerLabel
+    process.rpcTwinMuxRawToDigi.inputTag = rawDataRepackerLabel
+    process.rpcCPPFRawToDigi.inputTag = rawDataRepackerLabel
 
-
-#------------------------------------                                                                                              
+#------------------------------------
 # Cosmic muons reconstruction modules
 #------------------------------------
 

--- a/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
@@ -108,16 +108,19 @@ process.load("DPGAnalysis.SiStripTools.apvcyclephaseproducerfroml1tsDB_cfi")
 process.load("EventFilter.SiPixelRawToDigi.SiPixelRawToDigi_cfi")
 process.siPixelDigis.cpu.IncludeErrors = True
 
-if (process.runType.getRunType() == process.runType.hi_run):    
-    #--------------------------------
-    # Heavy Ion Configuration Changes
-    #--------------------------------
-    process.siPixelDigis.cpu.InputLabel = "rawDataRepacker"
-    process.siStripDigis.ProductLabel   = "rawDataRepacker"
-    process.scalersRawToDigi.scalersInputTag = "rawDataRepacker"
+if (process.runType.getRunType() == process.runType.hi_run):
+  rawDataRepackerLabel = 'rawDataRepacker'
+  #--------------------------------
+  # Heavy Ion Configuration Changes
+  #--------------------------------
+  process.siPixelDigis.cpu.InputLabel = rawDataRepackerLabel
+  process.siStripDigis.ProductLabel   = rawDataRepackerLabel
+  process.scalersRawToDigi.scalersInputTag = rawDataRepackerLabel
+  process.tcdsDigis.InputLabel = rawDataRepackerLabel
 else :
-    process.siPixelDigis.cpu.InputLabel = "rawDataCollector"
-    process.siStripDigis.ProductLabel     = cms.InputTag("rawDataCollector") 
+  rawDataCollectorLabel = 'rawDataCollector'
+  process.siPixelDigis.cpu.InputLabel = rawDataCollectorLabel
+  process.siStripDigis.ProductLabel = rawDataCollectorLabel
 
 ## Collision Reconstruction
 process.load("Configuration.StandardSequences.RawToDigi_Data_cff")

--- a/DQM/Integration/python/clients/sistrip_approx_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/sistrip_approx_dqm_sourceclient-live_cfg.py
@@ -196,6 +196,7 @@ if process.runType.getRunType() == process.runType.hi_run:
     process.scalersRawToDigi.scalersInputTag = rawDataRepackerLabel
     process.siPixelDigis.cpu.InputLabel = rawDataRepackerLabel
     process.siStripDigis.ProductLabel = rawDataRepackerLabel
+    process.tcdsDigis.InputLabel = rawDataRepackerLabel
 
     if ((process.runType.getRunType() == process.runType.hi_run) and live):
         process.source.SelectEvents = [

--- a/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
@@ -547,6 +547,7 @@ if process.runType.getRunType() == process.runType.hi_run:
     process.siPixelDigis.cpu.InputLabel = rawDataRepackerLabel
     process.siStripDigis.ProductLabel = rawDataRepackerLabel
     process.siStripFEDMonitor.RawDataTag = rawDataRepackerLabel
+    process.tcdsDigis.InputLabel = rawDataRepackerLabel
 
     if ((process.runType.getRunType() == process.runType.hi_run) and live):
         process.source.SelectEvents = [


### PR DESCRIPTION
#### PR description:

Title says it all, for HIon run (i.e `hi_run` run class), use the `FEDRawDataCollection_rawDataRepacker_*_*` input collection instead of   `FEDRawDataCollection_rawDataCollector_*_*` as a second step to avoid keeping it around in the stream `HIDQM` after the initial effort at https://github.com/cms-sw/cmssw/pull/43120.
This PR targets to continue the work in that direction (see also discussion at [CMSHLT-3306](https://its.cern.ch/jira/browse/CMSHLT-3306)).    

#### PR validation:

I generated some input streamer files using the recipe at https://github.com/cms-data/DQM-Integration/blob/main/README.md and then run over files generated in such a way with: 
```
cmsRun DQM/Integration/python/clients/[*]_dqm_sourceclient-live_cfg.py runInputDir=. runNumber=362321 runkey=hi_run scanOnce=True datafnPosition=4
```
All clients touched in this PR run correctly.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, will be backported to 14.0.X.
