### PR TITLE
Fix BS of HLLHC GenOnly workflow

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -4363,6 +4363,9 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                 }
     if beamspot is not None: upgradeStepDict['Gen'][k]['--beamspot']=beamspot
 
+    upgradeStepDict['GenHLBeamSpot'][k] = merge([{'--conditions' : gt+'_13TeV'}, upgradeStepDict['Gen'][k]])
+    upgradeStepDict['GenHLBeamSpot14'][k] = merge([{}, upgradeStepDict['Gen'][k]])
+    
     upgradeStepDict['GenSim'][k]= {'-s' : 'GEN,SIM',
                                        '-n' : 10,
                                        '--conditions' : gt,

--- a/Configuration/PyReleaseValidation/python/relval_upgrade.py
+++ b/Configuration/PyReleaseValidation/python/relval_upgrade.py
@@ -44,6 +44,9 @@ for year in upgradeKeys:
                             step = 'GenSimHLBeamSpotHGCALCloseBy'
                     stepMaker = makeStepNameSim
                 elif 'Gen' in step:
+                    if 'HLBeamSpot' in step:
+                        if '14TeV' in frag:
+                            step = 'GenHLBeamSpot14'
                     stepMaker = makeStepNameSim
                 
                 if 'HARVEST' in step: hasHarvest = True

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -203,6 +203,8 @@ class UpgradeWorkflow_baseline(UpgradeWorkflow):
 upgradeWFs['baseline'] = UpgradeWorkflow_baseline(
     steps =  [
         'Gen',
+        'GenHLBeamSpot',
+        'GenHLBeamSpot14',
         'Sim',
         'GenSim',
         'GenSimHLBeamSpot',
@@ -3172,18 +3174,18 @@ upgradeProperties[2026] = {
     },
     '2026D110GenOnly' : {
         'Geom' : 'Extended2026D110',
-        'Beamspot' : 'HLLHC',
+        'BeamSpot' : 'DBrealisticHLLHC',
         'GT' : 'auto:phase2_realistic_T33',
         'Era' : 'Phase2C17I13M9',
-        'ScenToRun' : ['Gen'],
+        'ScenToRun' : ['GenHLBeamSpot'],
     },
     '2026D110SimOnGen' : {
         'Geom' : 'Extended2026D110',
         'HLTmenu': '@relval2026',
-        'Beamspot' : 'HLLHC',
+        'BeamSpot' : 'DBrealisticHLLHC',
         'GT' : 'auto:phase2_realistic_T33',
         'Era' : 'Phase2C17I13M9',
-        'ScenToRun' : ['Gen','Sim','DigiTrigger','RecoGlobal', 'HARVESTGlobal', 'ALCAPhase2'],
+        'ScenToRun' : ['GenHLBeamSpot','Sim','DigiTrigger','RecoGlobal', 'HARVESTGlobal', 'ALCAPhase2'],
     },
     '2026D115' : {
         'Geom' : 'Extended2026D115',


### PR DESCRIPTION
#### PR description:
Fix the bug discussed in https://github.com/cms-sw/cmssw/pull/45005/files#r1712680623
Note that `'Sim'`-only step for HLLHC workflow should also be fixed if 13TeV is used. Currently, I will keep as is, as we normally use 14 TeV.

#### PR validation:
Dump and check the config of 13TeV and 14TeV HLLHC workflows:
- `runTheMatrix.py --what upgrade -l 31624.0 --wm init`
- `runTheMatrix.py --what upgrade -l 31634.0 --wm init`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
No need of backport
