### PR TITLE
Disable testTorchSimpleDnn for non-amd64 architectures

### DIFF
--- a/PhysicsTools/PyTorch/test/BuildFile.xml
+++ b/PhysicsTools/PyTorch/test/BuildFile.xml
@@ -1,10 +1,12 @@
 <use name="python_tools"/>
 
-<bin name="testTorchSimpleDnn" file="testRunner.cc,testTorchSimpleDnn.cc">
-  <use name="pytorch"/>
-  <use name="boost_filesystem"/>
-  <use name="cppunit"/>
-</bin>
+<ifarch value="x86_64">
+  <bin name="testTorchSimpleDnn" file="testRunner.cc,testTorchSimpleDnn.cc">
+    <use name="pytorch"/>
+    <use name="boost_filesystem"/>
+    <use name="cppunit"/>
+  </bin>
+</ifarch>
 
 <iftool name="cuda">
   <bin name="testTorchSimpleDnnCUDA" file="testRunner.cc,testTorchSimpleDnnCUDA.cc">


### PR DESCRIPTION
#### PR description:

Disable testTorchSimpleDnn for non-amd64 architectures to fix test failing for aarch IBs: [log](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_aarch64_gcc12/CMSSW_14_1_X_2024-08-11-0000/unitTestLogs/PhysicsTools/PyTorch#/53-53)

```
Running .cmd: apptainer exec -B /pool/condor/dir_1590998/jenkins/workspace/ib-run-qa/CMSSW_14_1_X_2024-08-11-0000  /cvmfs/unpacked.cern.ch/registry.hub.docker.com/cmsml/cmsml:3.11  python /pool/condor/dir_1590998/jenkins/workspace/ib-run-qa/CMSSW_14_1_X_2024-08-11-0000/src/PhysicsTools/PyTorch/test/create_simple_dnn.py /pool/condor/dir_1590998/jenkins/workspace/ib-run-qa/CMSSW_14_1_X_2024-08-11-0000/test/el8_aarch64_gcc12/ac19-74b6-90a1-cdc3
FATAL:   image targets 'amd64', cannot run on 'arm64'
```

#### PR validation:

Bot tests