### PR TITLE
Fix sorting index for lost tracks in UnifiedParticleTransformer producer

### DIFF
--- a/RecoBTag/FeatureTools/plugins/UnifiedParticleTransformerAK4TagInfoProducer.cc
+++ b/RecoBTag/FeatureTools/plugins/UnifiedParticleTransformerAK4TagInfoProducer.cc
@@ -79,6 +79,7 @@ private:
   const double jet_radius_;
   const double min_candidate_pt_;
   const bool flip_;
+  const bool fix_lt_sorting_;
 
   const edm::EDGetTokenT<edm::View<reco::Jet>> jet_token_;
   const edm::EDGetTokenT<VertexCollection> vtx_token_;
@@ -108,6 +109,7 @@ UnifiedParticleTransformerAK4TagInfoProducer::UnifiedParticleTransformerAK4TagIn
     : jet_radius_(iConfig.getParameter<double>("jet_radius")),
       min_candidate_pt_(iConfig.getParameter<double>("min_candidate_pt")),
       flip_(iConfig.getParameter<bool>("flip")),
+      fix_lt_sorting_(iConfig.getParameter<bool>("fix_lt_sorting")),
       jet_token_(consumes<edm::View<reco::Jet>>(iConfig.getParameter<edm::InputTag>("jets"))),
       vtx_token_(consumes<VertexCollection>(iConfig.getParameter<edm::InputTag>("vertices"))),
       lt_token_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("losttracks"))),
@@ -154,6 +156,7 @@ void UnifiedParticleTransformerAK4TagInfoProducer::fillDescriptions(edm::Configu
   desc.add<double>("jet_radius", 0.4);
   desc.add<double>("min_candidate_pt", 0.10);
   desc.add<bool>("flip", false);
+  desc.add<bool>("fix_lt_sorting", false);
   desc.add<edm::InputTag>("vertices", edm::InputTag("offlinePrimaryVertices"));
   desc.add<edm::InputTag>("losttracks", edm::InputTag("lostTracks"));
   desc.add<edm::InputTag>("puppi_value_map", edm::InputTag("puppi"));
@@ -312,7 +315,7 @@ void UnifiedParticleTransformerAK4TagInfoProducer::produce(edm::Event& iEvent, c
           float drminpfcandsv = btagbtvdeep::mindrsvpfcand(svs_unsorted, PackedCandidate_);
           float distminpfcandsv = 0;
 
-          size_t entry = lt_sortedindices.at(lt_sorted[i].get());
+          size_t entry = lt_sortedindices.at(fix_lt_sorting_ ? lt_sorted[i].get() : i);
           // get cached track info
           auto& trackinfo = lt_trackinfos.emplace(i, track_builder).first->second;
           trackinfo.buildTrackInfo(PackedCandidate_, jet_dir, jet_ref_track_dir, pv);

--- a/RecoBTag/FeatureTools/plugins/UnifiedParticleTransformerAK4TagInfoProducer.cc
+++ b/RecoBTag/FeatureTools/plugins/UnifiedParticleTransformerAK4TagInfoProducer.cc
@@ -312,7 +312,7 @@ void UnifiedParticleTransformerAK4TagInfoProducer::produce(edm::Event& iEvent, c
           float drminpfcandsv = btagbtvdeep::mindrsvpfcand(svs_unsorted, PackedCandidate_);
           float distminpfcandsv = 0;
 
-          size_t entry = lt_sortedindices.at(i);
+          size_t entry = lt_sortedindices.at(lt_sorted[i].get());
           // get cached track info
           auto& trackinfo = lt_trackinfos.emplace(i, track_builder).first->second;
           trackinfo.buildTrackInfo(PackedCandidate_, jet_dir, jet_ref_track_dir, pv);


### PR DESCRIPTION
#### PR description:

This PR fixes an issue found in the UnifiedParticleTransformer producer, that relates to the index used to access the sorting list of lost tracks. The indices of the lt_sortedindices vector correspond to the indices of the original collection (e.g. LTs collection), however in the second for loop, the lt_sortedindices is accessed using the index of the lt_sorted vector (which has been trimmed and is smaller than the LTs collection). To get back the correct index to access the elements of the lt_sortedindices one should use the "get()" function from the lt_sorted vector, which returns the index of the LTs collection.

@SWuchterl @DickyChant

#### PR validation:

Tested locally by comparing the features produced by the CMSSW producer to those used by the b-hive inference.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
