### PR TITLE
Fix NaNs From 0 Divisions in `DAClusterizerInZ_vect.cc`

### DIFF
--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
@@ -504,6 +504,8 @@ bool DAClusterizerInZ_vect::merge(vertex_t& y, track_t& tks, double& beta) const
 
     if (rho > 0) {
       y.zvtx[k] = (y.rho[k] * y.zvtx[k] + y.rho[k + 1] * y.zvtx[k + 1]) / rho;
+      if (not edm::isFinite(y.zvtx[k]))
+        y.zvtx[k] = 0.5 * (y.zvtx[k] + y.zvtx[k + 1]);
     } else {
       y.zvtx[k] = 0.5 * (y.zvtx[k] + y.zvtx[k + 1]);
     }
@@ -663,7 +665,7 @@ bool DAClusterizerInZ_vect::split(const double beta, track_t& tks, vertex_t& y, 
   std::vector<std::pair<double, unsigned int>> critical;
   for (unsigned int k = 0; k < nv; k++) {
     double Tc = 2 * y.swE[k] / y.sw[k];
-    if (beta * Tc > threshold) {
+    if (edm::isFinite(Tc) and beta * Tc > threshold) {
       critical.push_back(make_pair(Tc, k));
     }
   }
@@ -746,6 +748,10 @@ bool DAClusterizerInZ_vect::split(const double beta, track_t& tks, vertex_t& y, 
       split = true;
       double pk1 = p1 * y.rho[k] / (p1 + p2);
       double pk2 = p2 * y.rho[k] / (p1 + p2);
+
+      if (not(edm::isFinite(pk1) and edm::isFinite(pk2)))
+        continue;
+
       y.zvtx[k] = z2;
       y.rho[k] = pk2;
       y.insertItem(k, z1, pk1, tks);


### PR DESCRIPTION
#### PR description:

This PR is a follow-up of and may replace https://github.com/cms-sw/cmssw/pull/45528.

Quoting @smuzaffar 
> Many relvals are failing for aarch64 IB due to nan being pass to std::stable_sort (see https://github.com/cms-sw/cmssw/issues/45464 ). This PR fixes few divide by 0 in DAClusterizerInZ_vect.cc to avoid generating nan.

The proposal is to check for finiteness (with `edm::isFinite` due to https://github.com/cms-sw/cmssw/pull/45528#issuecomment-2276108018) for the denominator of a series of ratios exploding to NaN.
