### PR TITLE
Update 2024 MC realistic GTs in autocond

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -92,9 +92,9 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2024
     'phase1_2024_design'           :    '140X_mcRun3_2024_design_v11',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        :    '140X_mcRun3_2024_realistic_v15',
+    'phase1_2024_realistic'        :    '140X_mcRun3_2024_realistic_v21',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2024, Strip tracker in DECO mode
-    'phase1_2024_cosmics'          :    '140X_mcRun3_2024cosmics_realistic_deco_v13',
+    'phase1_2024_cosmics'          :    '140X_mcRun3_2024cosmics_realistic_deco_v14',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2024, Strip tracker in DECO mode
     'phase1_2024_cosmics_design'   :    '140X_mcRun3_2024cosmics_design_deco_v11',
     # GlobalTag for MC production with realistic conditions for Phase1 2024 detector for Heavy Ion


### PR DESCRIPTION
Update the 2024 MC Gts in autoCond with the following modified conditions:
- PPS conditions, see  https://cms-talk.web.cern.ch/t/final-call-for-run3summer24-mc-conditions-in-140x/41226/3
  - CTPPSOpticsRcd -> PPSOpticalFunctions_2024_v1_mc
  - CTPPSPixelGainCalibrationsRcd -> CTPPSPixelGainCalibrations_v4_mc
- Reco and Sim BeamSpot, see https://cms-talk.web.cern.ch/t/final-call-for-run3summer24-mc-conditions-in-140x/41226/4
  - BeamSpotObjectsRcd -> BeamSpotObjects_Early2024_forMinBias_v1_mc
  - BeamSpotOnlineHLTObjectsRcd -> BeamSpotOnlineObjects_Early2024_forMinBias_v1_mc
  - BeamSpotOnlineLegacyObjectsRcd -> BeamSpotOnlineObjects_Early2024_forMinBias_v1_mc
  - SimBeamSpotObjectsRcd -> SimBeamSpot_Realistic25ns13p6TeVEarly2024CollisionVtxSmearingParameters_v1_mc
- SiStrip Bad Channels, see https://cms-talk.web.cern.ch/t/gt-mc-new-mc-gt-request-for-offline-to-hlt-tracking-performance-in-140x/44332/19
  - SiStripBadChannelRcd -> SiStripBadComponents_realisticMC_for2024_v4_mc
- SiPixel quality reverted back to the pre-FPixIssue conditions, see https://cms-talk.web.cern.ch/t/final-call-for-run3summer24-mc-conditions-in-140x/41226/9
  - SiPixelQualityFromDbRcd,forDigitizer -> SiPixelQuality_forDigitizer_phase1_2024_v5_mc
  - SiPixelQualityFromDbRcd -> SiPixelQuality_phase1_2024_v5_mc

The updated 2024 MC GTs in autoCond are the following:
- [140X_mcRun3_2024_realistic_v21](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/140X_mcRun3_2024_realistic_v21)
- [140X_mcRun3_2024cosmics_realistic_deco_v14](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/140X_mcRun3_2024cosmics_realistic_deco_v14)

And the difference wrt the GTs that were previously in autoCond are the following
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2024_realistic_v15/140X_mcRun3_2024_realistic_v21
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2024cosmics_realistic_deco_v13/140X_mcRun3_2024cosmics_realistic_deco_v14

#### PR validation:

Successfully run on the short matrix