### PR TITLE
[13_2_X] Fix sorting index for lost tracks in UnifiedParticleTransformer producer

### DIFF
--- a/RecoBTag/FeatureTools/plugins/UnifiedParticleTransformerAK4TagInfoProducer.cc
+++ b/RecoBTag/FeatureTools/plugins/UnifiedParticleTransformerAK4TagInfoProducer.cc
@@ -312,7 +312,7 @@ void UnifiedParticleTransformerAK4TagInfoProducer::produce(edm::Event& iEvent, c
           float drminpfcandsv = btagbtvdeep::mindrsvpfcand(svs_unsorted, PackedCandidate_);
           float distminpfcandsv = 0;
 
-          size_t entry = lt_sortedindices.at(i);
+          size_t entry = lt_sortedindices.at(lt_sorted[i].get());
           // get cached track info
           auto& trackinfo = lt_trackinfos.emplace(i, track_builder).first->second;
           trackinfo.buildTrackInfo(PackedCandidate_, jet_dir, jet_ref_track_dir, pv);


### PR DESCRIPTION
#### PR description:

Partial backport of https://github.com/cms-sw/cmssw/pull/45689. Since the UParT is not consumed by default in 13_2_X and no models have being trained in this release, I backported the bug fix directly.

@SWuchterl @DickyChant @mandrenguyen 

#### PR validation:

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
