### PR TITLE
use eigen3 header instead of tf third_party/eigen3

### DIFF
--- a/PhysicsTools/TensorFlowAOT/interface/Wrapper.h
+++ b/PhysicsTools/TensorFlowAOT/interface/Wrapper.h
@@ -12,7 +12,7 @@
 
 #include "tensorflow/compiler/tf2xla/xla_compiled_cpu_function.h"
 #include "tensorflow/core/platform/types.h"
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
+#include "eigen3/unsupported/Eigen/CXX11/Tensor"
 
 #include "FWCore/Utilities/interface/Exception.h"
 


### PR DESCRIPTION
This change allows to pick up eigen3 header from our distribution of eigen instead of tensorflow/third_party/eigen3. This is needed for TF 2.16 but should work for old versions of TF too. This should be test with https://github.com/cms-sw/cmsdist/pull/9360 and should be merged only after https://github.com/cms-sw/cmsdist/pull/9360 is in IB.

[a] https://github.com/cms-sw/cmsdist/pull/9241#issuecomment-2286578371
```
>> Compiling  src/PhysicsTools/TensorFlowAOT/src/Wrapper.cc
In file included from src/PhysicsTools/TensorFlowAOT/src/Wrapper.cc:10:
src/PhysicsTools/TensorFlowAOT/interface/Wrapper.h:15:10: fatal error: third_party/eigen3/unsupported/Eigen/CXX11/Tensor: No such file or directory
   15 | #include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
```