### PR TITLE
Update/fix SimBeamSpot tag in the 2023 HI MC GT

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -88,7 +88,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2023, Strip tracker in DECO mode
     'phase1_2023_cosmics_design'   :    '140X_mcRun3_2023cosmics_design_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2023 detector for Heavy Ion
-    'phase1_2023_realistic_hi'     :    '140X_mcRun3_2023_realistic_HI_v3',
+    'phase1_2023_realistic_hi'     :    '140X_mcRun3_2023_realistic_HI_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2024
     'phase1_2024_design'           :    '140X_mcRun3_2024_design_v11',
     # GlobalTag for MC production with realistic conditions for Phase1 2024


### PR DESCRIPTION
#### PR description:

This PR fixes the update in autoCond for the `phase1_2023_realistic_hi` GT which was not included in #45346

The following GT has been updated by including the updated SimBeamSpot (only the 141X GT is updated in autoCond for this release):

[140X_mcRun3_2023_realistic_HI_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/140X_mcRun3_2023_realistic_HI_v4)

Differences with the previous HI MC GTs in autoCond:

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2023_realistic_HI_v3/140X_mcRun3_2023_realistic_HI_v4

#### PR validation:

This was already tested in CMSSW_14_0_X, where the correct 2023 HI GT was included in autoCond (see https://github.com/cms-sw/cmssw/pull/45347)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

No backport needed, because https://github.com/cms-sw/cmssw/pull/45347 already makes the correct assignment in 140X