### PR TITLE
Update validation for RPC hit reconstruction (backport of #45626, 14_0_X)

### DIFF
--- a/Validation/RPCRecHits/interface/RPCRecHitValid.h
+++ b/Validation/RPCRecHits/interface/RPCRecHitValid.h
@@ -62,17 +62,12 @@ private:
   MEP h_recoMuonBarrel_phi, h_recoMuonOverlap_phi, h_recoMuonEndcap_phi, h_recoMuonNoRPC_phi;
   MEP h_simParticleType, h_simParticleTypeBarrel, h_simParticleTypeEndcap;
 
-  MEP h_refPunchOccupancyBarrel_wheel, h_refPunchOccupancyEndcap_disk, h_refPunchOccupancyBarrel_station;
-  MEP h_refPunchOccupancyBarrel_wheel_station, h_refPunchOccupancyEndcap_disk_ring;
-  MEP h_recPunchOccupancyBarrel_wheel, h_recPunchOccupancyEndcap_disk, h_recPunchOccupancyBarrel_station;
-  MEP h_recPunchOccupancyBarrel_wheel_station, h_recPunchOccupancyEndcap_disk_ring;
-
   MEP h_matchOccupancyBarrel_detId;
   MEP h_matchOccupancyEndcap_detId;
   MEP h_refOccupancyBarrel_detId;
   MEP h_refOccupancyEndcap_detId;
-  MEP h_noiseOccupancyBarrel_detId;
-  MEP h_noiseOccupancyEndcap_detId;
+  MEP h_allOccupancyBarrel_detId;
+  MEP h_allOccupancyEndcap_detId;
   MEP h_rollAreaBarrel_detId;
   MEP h_rollAreaEndcap_detId;
 

--- a/Validation/RPCRecHits/src/RPCRecHitValid.cc
+++ b/Validation/RPCRecHits/src/RPCRecHitValid.cc
@@ -1,4 +1,3 @@
-#include "FWCore/Framework/interface/MakerMacros.h"
 #include "Validation/RPCRecHits/interface/RPCRecHitValid.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -166,85 +165,6 @@ void RPCRecHitValid::bookHistograms(DQMStore::IBooker &booker, edm::Run const &r
   }
   h_eventCount->Fill(3);
 
-  h_refPunchOccupancyBarrel_wheel =
-      booker.book1D("RefPunchOccupancyBarrel_wheel", "RefPunchthrough occupancy", 5, -2.5, 2.5);
-  h_refPunchOccupancyEndcap_disk =
-      booker.book1D("RefPunchOccupancyEndcap_disk", "RefPunchthrough occupancy", 9, -4.5, 4.5);
-  h_refPunchOccupancyBarrel_station =
-      booker.book1D("RefPunchOccupancyBarrel_station", "RefPunchthrough occupancy", 4, 0.5, 4.5);
-  h_recPunchOccupancyBarrel_wheel =
-      booker.book1D("RecPunchOccupancyBarrel_wheel", "Punchthrough recHit occupancy", 5, -2.5, 2.5);
-  h_recPunchOccupancyEndcap_disk =
-      booker.book1D("RecPunchOccupancyEndcap_disk", "Punchthrough recHit occupancy", 9, -4.5, 4.5);
-  h_recPunchOccupancyBarrel_station =
-      booker.book1D("RecPunchOccupancyBarrel_station", "Punchthrough recHit occupancy", 4, 0.5, 4.5);
-
-  h_refPunchOccupancyBarrel_wheel->getTH1()->SetMinimum(0);
-  h_refPunchOccupancyEndcap_disk->getTH1()->SetMinimum(0);
-  h_refPunchOccupancyBarrel_station->getTH1()->SetMinimum(0);
-  h_recPunchOccupancyBarrel_wheel->getTH1()->SetMinimum(0);
-  h_recPunchOccupancyEndcap_disk->getTH1()->SetMinimum(0);
-  h_recPunchOccupancyBarrel_station->getTH1()->SetMinimum(0);
-
-  h_refPunchOccupancyBarrel_wheel_station =
-      booker.book2D("RefPunchOccupancyBarrel_wheel_station", "RefPunchthrough occupancy", 5, -2.5, 2.5, 4, 0.5, 4.5);
-  h_refPunchOccupancyEndcap_disk_ring =
-      booker.book2D("RefPunchOccupancyEndcap_disk_ring", "RefPunchthrough occupancy", 9, -4.5, 4.5, 4, 0.5, 4.5);
-  h_recPunchOccupancyBarrel_wheel_station = booker.book2D(
-      "RecPunchOccupancyBarrel_wheel_station", "Punchthrough recHit occupancy", 5, -2.5, 2.5, 4, 0.5, 4.5);
-  h_recPunchOccupancyEndcap_disk_ring =
-      booker.book2D("RecPunchOccupancyEndcap_disk_ring", "Punchthrough recHit occupancy", 9, -4.5, 4.5, 4, 0.5, 4.5);
-
-  h_refPunchOccupancyBarrel_wheel_station->getTH2F()->SetOption("COLZ");
-  h_refPunchOccupancyEndcap_disk_ring->getTH2F()->SetOption("COLZ");
-  h_recPunchOccupancyBarrel_wheel_station->getTH2F()->SetOption("COLZ");
-  h_recPunchOccupancyEndcap_disk_ring->getTH2F()->SetOption("COLZ");
-
-  h_refPunchOccupancyBarrel_wheel_station->getTH2F()->SetContour(10);
-  h_refPunchOccupancyEndcap_disk_ring->getTH2F()->SetContour(10);
-  h_recPunchOccupancyBarrel_wheel_station->getTH2F()->SetContour(10);
-  h_recPunchOccupancyEndcap_disk_ring->getTH2F()->SetContour(10);
-
-  h_refPunchOccupancyBarrel_wheel_station->getTH2F()->SetStats(false);
-  h_refPunchOccupancyEndcap_disk_ring->getTH2F()->SetStats(false);
-  h_recPunchOccupancyBarrel_wheel_station->getTH2F()->SetStats(false);
-  h_recPunchOccupancyEndcap_disk_ring->getTH2F()->SetStats(false);
-
-  h_refPunchOccupancyBarrel_wheel_station->getTH2F()->SetMinimum(0);
-  h_refPunchOccupancyEndcap_disk_ring->getTH2F()->SetMinimum(0);
-  h_recPunchOccupancyBarrel_wheel_station->getTH2F()->SetMinimum(0);
-  h_recPunchOccupancyEndcap_disk_ring->getTH2F()->SetMinimum(0);
-
-  for (int i = 1; i <= 5; ++i) {
-    TString binLabel = Form("Wheel %d", i - 3);
-    h_refPunchOccupancyBarrel_wheel->getTH1()->GetXaxis()->SetBinLabel(i, binLabel);
-    h_refPunchOccupancyBarrel_wheel_station->getTH2F()->GetXaxis()->SetBinLabel(i, binLabel);
-    h_recPunchOccupancyBarrel_wheel->getTH1()->GetXaxis()->SetBinLabel(i, binLabel);
-    h_recPunchOccupancyBarrel_wheel_station->getTH2F()->GetXaxis()->SetBinLabel(i, binLabel);
-  }
-
-  for (int i = 1; i <= 9; ++i) {
-    TString binLabel = Form("Disk %d", i - 5);
-    h_refPunchOccupancyEndcap_disk->getTH1()->GetXaxis()->SetBinLabel(i, binLabel);
-    h_refPunchOccupancyEndcap_disk_ring->getTH2F()->GetXaxis()->SetBinLabel(i, binLabel);
-    h_recPunchOccupancyEndcap_disk->getTH1()->GetXaxis()->SetBinLabel(i, binLabel);
-    h_recPunchOccupancyEndcap_disk_ring->getTH2F()->GetXaxis()->SetBinLabel(i, binLabel);
-  }
-
-  for (int i = 1; i <= 4; ++i) {
-    TString binLabel = Form("Station %d", i);
-    h_refPunchOccupancyBarrel_station->getTH1()->GetXaxis()->SetBinLabel(i, binLabel);
-    h_refPunchOccupancyBarrel_wheel_station->getTH2F()->GetYaxis()->SetBinLabel(i, binLabel);
-    h_recPunchOccupancyBarrel_station->getTH1()->GetXaxis()->SetBinLabel(i, binLabel);
-    h_recPunchOccupancyBarrel_wheel_station->getTH2F()->GetYaxis()->SetBinLabel(i, binLabel);
-  }
-
-  for (int i = 1; i <= 4; ++i) {
-    TString binLabel = Form("Ring %d", i);
-    h_refPunchOccupancyEndcap_disk_ring->getTH2F()->GetYaxis()->SetBinLabel(i, binLabel);
-    h_recPunchOccupancyEndcap_disk_ring->getTH2F()->GetYaxis()->SetBinLabel(i, binLabel);
-  }
-
   // Book roll-by-roll histograms
   auto rpcGeom = eventSetup.getHandle(rpcGeomTokenInRun_);
 
@@ -299,17 +219,17 @@ void RPCRecHitValid::bookHistograms(DQMStore::IBooker &booker, edm::Run const &r
                                              nRPCRollEndcap,
                                              0,
                                              nRPCRollEndcap);
-  h_noiseOccupancyBarrel_detId = booker.book1D(
-      "NoiseOccupancyBarrel_detId", "Noise occupancy;roll index (can be arbitrary)", nRPCRollBarrel, 0, nRPCRollBarrel);
-  h_noiseOccupancyEndcap_detId = booker.book1D(
-      "NoiseOccupancyEndcap_detId", "Noise occupancy;roll index (can be arbitrary)", nRPCRollEndcap, 0, nRPCRollEndcap);
+  h_allOccupancyBarrel_detId = booker.book1D(
+      "OccupancyBarrel_detId", "Occupancy;roll index (can be arbitrary)", nRPCRollBarrel, 0, nRPCRollBarrel);
+  h_allOccupancyEndcap_detId = booker.book1D(
+      "OccupancyEndcap_detId", "Occupancy;roll index (can be arbitrary)", nRPCRollEndcap, 0, nRPCRollEndcap);
 
   h_matchOccupancyBarrel_detId->getTH1()->SetMinimum(0);
   h_matchOccupancyEndcap_detId->getTH1()->SetMinimum(0);
   h_refOccupancyBarrel_detId->getTH1()->SetMinimum(0);
   h_refOccupancyEndcap_detId->getTH1()->SetMinimum(0);
-  h_noiseOccupancyBarrel_detId->getTH1()->SetMinimum(0);
-  h_noiseOccupancyEndcap_detId->getTH1()->SetMinimum(0);
+  h_allOccupancyBarrel_detId->getTH1()->SetMinimum(0);
+  h_allOccupancyEndcap_detId->getTH1()->SetMinimum(0);
 
   h_rollAreaBarrel_detId = booker.bookProfile(
       "RollAreaBarrel_detId", "Roll area;roll index;Area", nRPCRollBarrel, 0., 1. * nRPCRollBarrel, 0., 1e5);
@@ -461,8 +381,6 @@ void RPCRecHitValid::analyze(const edm::Event &event, const edm::EventSetup &eve
         h_simMuonNoRPC_eta->Fill(simParticle->eta());
         h_simMuonNoRPC_phi->Fill(simParticle->phi());
       }
-    } else {
-      pthrSimHits.insert(pthrSimHits.end(), simHitsFromParticle.begin(), simHitsFromParticle.end());
     }
 
     if (hasRPCHit) {
@@ -533,34 +451,6 @@ void RPCRecHitValid::analyze(const edm::Event &event, const edm::EventSetup &eve
     }
   }
 
-  // Loop over punch-through simHits, fill histograms which does not need
-  // associations
-  for (const auto &simHit : pthrSimHits) {
-    const RPCDetId detId = static_cast<const RPCDetId>(simHit->detUnitId());
-    const RPCRoll *roll = dynamic_cast<const RPCRoll *>(rpcGeom->roll(detId()));
-
-    const int region = roll->id().region();
-    const int ring = roll->id().ring();
-    // const int sector = roll->id().sector();
-    const int station = roll->id().station();
-    // const int layer = roll->id().layer();
-    // const int subSector = roll->id().subsector();
-
-    if (region == 0) {
-      ++nRefHitBarrel;
-      h_refPunchOccupancyBarrel_wheel->Fill(ring);
-      h_refPunchOccupancyBarrel_station->Fill(station);
-      h_refPunchOccupancyBarrel_wheel_station->Fill(ring, station);
-
-      h_refOccupancyBarrel_detId->Fill(detIdToIndexMapBarrel_[simHit->detUnitId()]);
-    } else {
-      ++nRefHitEndcap;
-      h_refPunchOccupancyEndcap_disk->Fill(region * station);
-      h_refPunchOccupancyEndcap_disk_ring->Fill(region * station, ring);
-
-      h_refOccupancyEndcap_detId->Fill(detIdToIndexMapEndcap_[simHit->detUnitId()]);
-    }
-  }
   h_.nRefHitBarrel->Fill(nRefHitBarrel);
   h_.nRefHitEndcap->Fill(nRefHitEndcap);
 
@@ -592,6 +482,8 @@ void RPCRecHitValid::analyze(const edm::Event &event, const edm::EventSetup &eve
       h_.recHitOccupancyBarrel_station->Fill(station);
       h_.recHitOccupancyBarrel_wheel_station->Fill(ring, station);
 
+      h_allOccupancyBarrel_detId->Fill(detIdToIndexMapBarrel_[detId.rawId()]);
+
       h_.timeBarrel->Fill(time);
     } else {
       ++nRecHitEndcap;
@@ -599,6 +491,8 @@ void RPCRecHitValid::analyze(const edm::Event &event, const edm::EventSetup &eve
       h_.clusterSizeEndcap->Fill(recHitIter->clusterSize());
       h_.recHitOccupancyEndcap_disk->Fill(region * station);
       h_.recHitOccupancyEndcap_disk_ring->Fill(region * station, ring);
+
+      h_allOccupancyEndcap_detId->Fill(detIdToIndexMapEndcap_[detId.rawId()]);
 
       h_.timeEndcap->Fill(time);
     }
@@ -766,96 +660,8 @@ void RPCRecHitValid::analyze(const edm::Event &event, const edm::EventSetup &eve
     }
   }
 
-  // Find Non-muon hits
-  for (RecHitIter recHitIter = recHitHandle->begin(); recHitIter != recHitHandle->end(); ++recHitIter) {
-    const RPCDetId detId = static_cast<const RPCDetId>(recHitIter->rpcId());
-    const RPCRoll *roll = dynamic_cast<const RPCRoll *>(rpcGeom->roll(detId));
-
-    const int region = roll->id().region();
-    const int ring = roll->id().ring();
-    // const int sector = roll->id().sector();
-    const int station = roll->id().station();
-    // const int layer = roll->id().layer();
-    // const int subsector = roll->id().subsector();
-
-    bool matched = false;
-    for (const auto &match : simToRecHitMap) {
-      if (recHitIter == match.second) {
-        matched = true;
-        break;
-      }
-    }
-
-    if (!matched) {
-      int nPunchMatched = 0;
-      // Check if this recHit came from non-muon simHit
-      for (const auto &simHit : pthrSimHits) {
-        const int absSimHitPType = abs(simHit->particleType());
-        if (absSimHitPType == 13)
-          continue;
-
-        const RPCDetId simDetId = static_cast<const RPCDetId>(simHit->detUnitId());
-        if (simDetId == detId)
-          ++nPunchMatched;
-      }
-
-      if (nPunchMatched > 0) {
-        if (region == 0) {
-          h_recPunchOccupancyBarrel_wheel->Fill(ring);
-          h_recPunchOccupancyBarrel_station->Fill(station);
-          h_recPunchOccupancyBarrel_wheel_station->Fill(ring, station);
-        } else {
-          h_recPunchOccupancyEndcap_disk->Fill(region * station);
-          h_recPunchOccupancyEndcap_disk_ring->Fill(region * station, ring);
-        }
-      }
-    }
-  }
-
-  // Find noise recHits : RecHits without SimHit match
-  for (RecHitIter recHitIter = recHitHandle->begin(); recHitIter != recHitHandle->end(); ++recHitIter) {
-    const RPCDetId recDetId = static_cast<const RPCDetId>(recHitIter->rpcId());
-    const RPCRoll *roll = dynamic_cast<const RPCRoll *>(rpcGeom->roll(recDetId));
-
-    const int region = roll->id().region();
-    //    const int ring = roll->id().ring(); // UNUSED VARIABLE
-    // const int sector = roll->id().sector();
-    //    const int station = roll->id().station(); // UNUSED VARIABLE
-    // const int layer = roll->id().layer();
-    // const int subsector = roll->id().subsector();
-
-    const double recX = recHitIter->localPosition().x();
-    const double recErrX = sqrt(recHitIter->localPositionError().xx());
-
-    bool matched = false;
-    for (SimHitIter simHitIter = simHitHandle->begin(); simHitIter != simHitHandle->end(); ++simHitIter) {
-      const RPCDetId simDetId = static_cast<const RPCDetId>(simHitIter->detUnitId());
-      const RPCRoll *simRoll = dynamic_cast<const RPCRoll *>(rpcGeom->roll(simDetId));
-      if (!simRoll)
-        continue;
-
-      if (simDetId != recDetId)
-        continue;
-
-      const double simX = simHitIter->localPosition().x();
-      const double dX = fabs(recX - simX);
-
-      if (dX / recErrX < 5) {
-        matched = true;
-        break;
-      }
-    }
-
-    if (!matched) {
-      if (region == 0) {
-        h_noiseOccupancyBarrel_detId->Fill(detIdToIndexMapBarrel_[recDetId.rawId()]);
-      } else {
-        h_noiseOccupancyEndcap_detId->Fill(detIdToIndexMapEndcap_[recDetId.rawId()]);
-      }
-    }
-  }
-
   h_eventCount->Fill(2);
 }
 
+#include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(RPCRecHitValid);

--- a/Validation/RPCRecHits/src/RPCRecHitValidClient.cc
+++ b/Validation/RPCRecHits/src/RPCRecHitValidClient.cc
@@ -19,18 +19,6 @@ void RPCRecHitValidClient::dqmEndJob(DQMStore::IBooker &booker, DQMStore::IGette
       booker.book1D("RollEfficiencyBarrel_eff", "Roll efficiency in Barrel;Efficiency [%]", 50 + 2, -2, 100 + 2);
   MEP me_rollEfficiencyEndcap_eff =
       booker.book1D("RollEfficiencyEndcap_eff", "Roll efficiency in Endcap;Efficiency [%]", 50 + 2, -2, 100 + 2);
-  MEP me_rollEfficiencyStatCutOffBarrel_eff =
-      booker.book1D("RollEfficiencyCutOffBarrel_eff",
-                    "Roll efficiency in Barrel without low stat chamber;Efficiency [%]",
-                    50 + 2,
-                    -2,
-                    100 + 2);
-  MEP me_rollEfficiencyStatCutOffEndcap_eff =
-      booker.book1D("RollEfficiencyCutOffEndcap_eff",
-                    "Roll efficiency in Endcap without low stat chamber;Efficiency [%]",
-                    50 + 2,
-                    -2,
-                    100 + 2);
 
   const double maxNoise = 1e-7;
   MEP me_rollNoiseBarrel_noise = booker.book1D("RollNoiseBarrel_noise",
@@ -60,8 +48,6 @@ void RPCRecHitValidClient::dqmEndJob(DQMStore::IBooker &booker, DQMStore::IGette
       const double eff = nRef ? nRec / nRef * 100 : -1;
 
       me_rollEfficiencyBarrel_eff->Fill(eff);
-      if (nRef >= 20)
-        me_rollEfficiencyStatCutOffBarrel_eff->Fill(eff);
     }
   }
 
@@ -76,17 +62,15 @@ void RPCRecHitValidClient::dqmEndJob(DQMStore::IBooker &booker, DQMStore::IGette
       const double eff = nRef ? nRec / nRef * 100 : -1;
 
       me_rollEfficiencyEndcap_eff->Fill(eff);
-      if (nRef >= 20)
-        me_rollEfficiencyStatCutOffEndcap_eff->Fill(eff);
     }
   }
 
   MEP me_eventCount = getter.get(subDir_ + "/Occupancy/EventCount");
   const double nEvent = me_eventCount ? me_eventCount->getTH1()->GetBinContent(1) : 1;
-  MEP me_noiseOccupancyBarrel_detId = getter.get(subDir_ + "/Occupancy/NoiseOccupancyBarrel_detId");
+  MEP me_allOccupancyBarrel_detId = getter.get(subDir_ + "/Occupancy/OccupancyBarrel_detId");
   MEP me_rollAreaBarrel_detId = getter.get(subDir_ + "/Occupancy/RollAreaBarrel_detId");
-  if (me_noiseOccupancyBarrel_detId and me_rollAreaBarrel_detId) {
-    TH1 *h_noiseOccupancyBarrel_detId = me_noiseOccupancyBarrel_detId->getTH1();
+  if (me_allOccupancyBarrel_detId and me_rollAreaBarrel_detId) {
+    TH1 *h_noiseOccupancyBarrel_detId = me_allOccupancyBarrel_detId->getTH1();
     TH1 *h_rollAreaBarrel_detId = me_rollAreaBarrel_detId->getTH1();
 
     for (int bin = 1, nBin = h_noiseOccupancyBarrel_detId->GetNbinsX(); bin <= nBin; ++bin) {
@@ -100,10 +84,10 @@ void RPCRecHitValidClient::dqmEndJob(DQMStore::IBooker &booker, DQMStore::IGette
     }
   }
 
-  MEP me_noiseOccupancyEndcap_detId = getter.get(subDir_ + "/Occupancy/NoiseOccupancyEndcap_detId");
+  MEP me_allOccupancyEndcap_detId = getter.get(subDir_ + "/Occupancy/OccupancyEndcap_detId");
   MEP me_rollAreaEndcap_detId = getter.get(subDir_ + "/Occupancy/RollAreaEndcap_detId");
-  if (me_noiseOccupancyEndcap_detId and me_rollAreaEndcap_detId) {
-    TH1 *h_noiseOccupancyEndcap_detId = me_noiseOccupancyEndcap_detId->getTH1();
+  if (me_allOccupancyEndcap_detId and me_rollAreaEndcap_detId) {
+    TH1 *h_noiseOccupancyEndcap_detId = me_allOccupancyEndcap_detId->getTH1();
     TH1 *h_rollAreaEndcap_detId = me_rollAreaEndcap_detId->getTH1();
 
     for (int bin = 1, nBin = h_noiseOccupancyEndcap_detId->GetNbinsX(); bin <= nBin; ++bin) {


### PR DESCRIPTION
#### PR description:
This PR drops plots that are no longer used in the release validation procedure for RPC hit reconstruction. The PR also simplifies the directory path where plots related to RPC hit reconstruction are stored.

@jhgoh @mileva @mrcthiel

#### PR validation:
The changes were reviewed in [the last RPC DPG meeting](https://indico.cern.ch/event/1443185/#1-updates-on-validation-sw-for). The PR has been tested with `runTheMatrix.py -w upgrade -l 12811.0` with `CMSSW_14_0_X_2024-08-12-2300`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
This PR is a backport of #45626. This backport aims to improve upcoming RPC relval tasks.