### PR TITLE
rename modifier `run3_2024_L1T` to `stage2L1Trigger_2024`

### DIFF
--- a/Configuration/Eras/python/Era_Run3_2024_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2024_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Run3_cff import Run3
-from Configuration.Eras.Modifier_run3_2024_L1T_cff import run3_2024_L1T
+from Configuration.Eras.Modifier_stage2L1Trigger_2024_cff import stage2L1Trigger_2024
 from Configuration.Eras.Modifier_run3_scouting_nanoAOD_post2023_cff import run3_scouting_nanoAOD_post2023
 
-Run3_2024 = cms.ModifierChain(Run3, run3_2024_L1T, run3_scouting_nanoAOD_post2023)
+Run3_2024 = cms.ModifierChain(Run3, stage2L1Trigger_2024, run3_scouting_nanoAOD_post2023)

--- a/Configuration/Eras/python/Modifier_stage2L1Trigger_2024_cff.py
+++ b/Configuration/Eras/python/Modifier_stage2L1Trigger_2024_cff.py
@@ -1,3 +1,3 @@
 import FWCore.ParameterSet.Config as cms
 
-run3_2024_L1T = cms.Modifier()
+stage2L1Trigger_2024 = cms.Modifier()

--- a/DQM/L1TMonitor/python/L1TStage2uGTTiming_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGTTiming_cfi.py
@@ -58,8 +58,8 @@ l1tStage2uGTTiming = DQMEDAnalyzer('L1TStage2uGTTiming',
     useAlgoDecision = cms.untracked.string("initial")
 )
 
-from Configuration.Eras.Modifier_run3_2024_L1T_cff import run3_2024_L1T
-run3_2024_L1T.toModify(l1tStage2uGTTiming,
+from Configuration.Eras.Modifier_stage2L1Trigger_2024_cff import stage2L1Trigger_2024
+stage2L1Trigger_2024.toModify(l1tStage2uGTTiming,
     unprescaledAlgoShortList = unprescaledAlgoList_2024,
     prescaledAlgoShortList = prescaledAlgoList_2024
 )

--- a/DQM/L1TMonitor/python/L1TdeStage2EMTF_cff.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2EMTF_cff.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from DQM.L1TMonitor.L1TdeStage2EMTF_cfi import *
 from DQM.L1TMonitor.L1TdeStage2RegionalShower_cfi import *
-from Configuration.Eras.Modifier_run3_2024_L1T_cff import run3_2024_L1T
+from Configuration.Eras.Modifier_stage2L1Trigger_2024_cff import stage2L1Trigger_2024
 
 # List of bins to ignore
 ignoreBinsDeStage2Emtf = [1]
@@ -24,7 +24,7 @@ l1tdeStage2EmtfComp = DQMEDAnalyzer(
     hasDisplacementInfo = cms.untracked.bool(False),
 )
 
-run3_2024_L1T.toModify(
+stage2L1Trigger_2024.toModify(
     l1tdeStage2EmtfComp,
     hasDisplacementInfo = cms.untracked.bool(True) # Linden Burack 7/26/2024
 )

--- a/L1Trigger/L1TMuonBarrel/python/simKBmtfDigis_cfi.py
+++ b/L1Trigger/L1TMuonBarrel/python/simKBmtfDigis_cfi.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.Eras.Modifier_run3_2024_L1T_cff import run3_2024_L1T
+from Configuration.Eras.Modifier_stage2L1Trigger_2024_cff import stage2L1Trigger_2024
 
 bmtfKalmanTrackingSettings = cms.PSet(
     verbose = cms.bool(False),  # 
@@ -51,11 +51,11 @@ bmtfKalmanTrackingSettings = cms.PSet(
 
     useNewQualityCalculation = cms.bool(False),
 )
-run3_2024_L1T.toModify(
-    bmtfKalmanTrackingSettings,
-    useNewQualityCalculation = cms.bool(True),
-)
 
+stage2L1Trigger_2024.toModify(
+    bmtfKalmanTrackingSettings,
+    useNewQualityCalculation = True,
+)
 
 simKBmtfDigis = cms.EDProducer("L1TMuonBarrelKalmanTrackProducer",
     src = cms.InputTag("simKBmtfStubs"),


### PR DESCRIPTION
#### PR description:

This PR suggests to rename the modifier introduced in #45352, in order to use a name that's consistent with other existing modifiers specific to the Stage-2 L1 Trigger, see
https://github.com/cms-sw/cmssw/blob/7320a6bb38b604b8c69c7e1ee57539fe71a53b9e/Configuration/Eras/python/Modifier_stage2L1Trigger_2017_cff.py
https://github.com/cms-sw/cmssw/blob/7320a6bb38b604b8c69c7e1ee57539fe71a53b9e/Configuration/Eras/python/Modifier_stage2L1Trigger_2018_cff.py
https://github.com/cms-sw/cmssw/blob/7320a6bb38b604b8c69c7e1ee57539fe71a53b9e/Configuration/Eras/python/Modifier_stage2L1Trigger_2021_cff.py

#### PR validation:

None.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

Will be backported down to `CMSSW_14_0_X`.
