### PR TITLE
Having Upgrade Matrix Failing for Duplicate Suffixes

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixUtil.py
+++ b/Configuration/PyReleaseValidation/python/MatrixUtil.py
@@ -266,4 +266,8 @@ def genvalid(fragment,d,suffix='all',fi='',dataSet=''):
     c['cfg']=fragment
     return c
 
-
+def check_dups(input):
+    seen = set()
+    dups = set(x for x in input if x in seen or seen.add(x))
+    
+    return dups

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1,6 +1,6 @@
 from copy import copy, deepcopy
 from collections import OrderedDict
-from .MatrixUtil import merge, Kby, Mby
+from .MatrixUtil import merge, Kby, Mby, check_dups
 import re
 
 U2000by1={'--relval': '2000,1'}
@@ -2819,12 +2819,17 @@ upgradeWFs['SonicTriton'] = UpgradeWorkflow_SonicTriton(
     offset = 0.9001,
 )
 
-# check for duplicate offsets
-offsets = [specialWF.offset for specialType,specialWF in upgradeWFs.items()]
-seen = set()
-dups = set(x for x in offsets if x in seen or seen.add(x))
+# check for duplicates in offsets or suffixes
+offsets  = [specialWF.offset for specialType,specialWF in upgradeWFs.items()]
+suffixes = [specialWF.suffix for specialType,specialWF in upgradeWFs.items()]
+
+dups = check_dups(offsets)
 if len(dups)>0:
     raise ValueError("Duplicate special workflow offsets not allowed: "+','.join([str(x) for x in dups]))
+
+dups = check_dups(suffixes)
+if len(dups)>0:
+    raise ValueError("Duplicate special workflow suffixes not allowed: "+','.join([str(x) for x in dups]))
 
 upgradeProperties = {}
 


### PR DESCRIPTION
#### PR description:

This PR proposes to have the upgrade matrix building fail if duplicate suffixes for workflows are found. Currently it fails only if duplicate offsets are found and if, by error, we have two workflows with the same suffix it silently overwrites the first one with the second. 

~As is the PR should cause a failure just to prove the mechanism is working.~
 
#### PR validation:

`runTheMatrix -n -w upgrade` ~fails.~ runs.