### PR TITLE
Fix bug affecting label in exception message

### DIFF
--- a/FWCore/Framework/interface/EventSetupRecord.h
+++ b/FWCore/Framework/interface/EventSetupRecord.h
@@ -206,9 +206,9 @@ namespace edm {
       template <template <typename> typename H, typename T, typename R>
       H<T> noResolverHandle(ESGetToken<T, R> const& iToken) const {
         auto const key = this->key();
-        auto name = iToken.name();
-        return H<T>{makeESHandleExceptionFactory([key, name] {
-          NoProductResolverException<T> ex(key, DataKey{DataKey::makeTypeTag<T>(), name});
+        auto productLabel = iToken.productLabel();
+        return H<T>{makeESHandleExceptionFactory([key, productLabel] {
+          NoProductResolverException<T> ex(key, DataKey{DataKey::makeTypeTag<T>(), productLabel});
           return std::make_exception_ptr(ex);
         })};
       }

--- a/FWCore/Framework/src/EDConsumerBase.cc
+++ b/FWCore/Framework/src/EDConsumerBase.cc
@@ -186,10 +186,11 @@ void EDConsumerBase::updateLookup(eventsetup::ESRecordsToProductResolverIndices 
   }
 }
 
-ESTokenIndex EDConsumerBase::recordESConsumes(Transition iTrans,
-                                              eventsetup::EventSetupRecordKey const& iRecord,
-                                              eventsetup::heterocontainer::HCTypeTag const& iDataType,
-                                              edm::ESInputTag const& iTag) {
+std::tuple<ESTokenIndex, char const*> EDConsumerBase::recordESConsumes(
+    Transition iTrans,
+    eventsetup::EventSetupRecordKey const& iRecord,
+    eventsetup::heterocontainer::HCTypeTag const& iDataType,
+    edm::ESInputTag const& iTag) {
   if (frozen_) {
     throwESConsumesCallAfterFrozen(iRecord, iDataType, iTag);
   }
@@ -218,7 +219,8 @@ ESTokenIndex EDConsumerBase::recordESConsumes(Transition iTrans,
   auto indexForToken = esItemsToGetFromTransition_[static_cast<unsigned int>(iTrans)].size();
   esItemsToGetFromTransition_[static_cast<unsigned int>(iTrans)].emplace_back(-1 * (index + 1));
   esRecordsToGetFromTransition_[static_cast<unsigned int>(iTrans)].emplace_back();
-  return ESTokenIndex{static_cast<ESTokenIndex::Value_t>(indexForToken)};
+  return {ESTokenIndex{static_cast<ESTokenIndex::Value_t>(indexForToken)},
+          m_esTokenInfo.get<kESLookupInfo>(index).m_key.name().value()};
 }
 
 //
@@ -589,8 +591,4 @@ std::vector<ConsumesInfo> EDConsumerBase::consumesInfo() const {
                         itInfo->m_index.skipCurrentProcess());
   }
   return result;
-}
-
-const char* EDConsumerBase::labelFor(ESTokenIndex iIndex) const {
-  return m_esTokenInfo.get<kESLookupInfo>(iIndex.value()).m_key.name().value();
 }

--- a/FWCore/Utilities/interface/ESGetToken.h
+++ b/FWCore/Utilities/interface/ESGetToken.h
@@ -75,11 +75,11 @@ namespace edm {
     static constexpr ESTokenIndex invalidIndex() noexcept { return ESTokenIndex{std::numeric_limits<int>::max()}; }
 
   private:
-    explicit constexpr ESGetToken(unsigned int transitionID, ESTokenIndex index, char const* label) noexcept
-        : m_label{label}, m_transitionID{transitionID}, m_index{index} {}
+    explicit constexpr ESGetToken(unsigned int transitionID, ESTokenIndex index, char const* productLabel) noexcept
+        : m_productLabel{productLabel}, m_transitionID{transitionID}, m_index{index} {}
 
-    constexpr char const* name() const noexcept { return m_label; }
-    char const* m_label{nullptr};
+    constexpr char const* productLabel() const noexcept { return m_productLabel; }
+    char const* m_productLabel{nullptr};
     unsigned int m_transitionID{std::numeric_limits<unsigned int>::max()};
     ESTokenIndex m_index{std::numeric_limits<int>::max()};
   };


### PR DESCRIPTION
#### PR description:

Fix a bug that affects the content of an exception message printed when the EventSetup system cannot find an ESProducer or ESSource to produce data requested by a module. This bug should not affect anything when an exception does not occur.

I noticed this problem as I was working on nearby code. It was not reported by a user.

Also I modified some names to more consistently use ```ProductLabel``` instead of various other terms used for the same thing in code directly related to the bug.

The bug was caused by using an index into the container esItemsToGetFromTransition_ to access an element of the container m_esTokenInfo. Under certain circumstances this can cause the wrong product label to print in the error message.

#### PR validation:

Existing unit tests pass.

