### PR TITLE
[GCC13][AlCa] Avoid storing reference to a temporary object

### DIFF
--- a/Alignment/OfflineValidation/plugins/PixelBaryCentreAnalyzer.cc
+++ b/Alignment/OfflineValidation/plugins/PixelBaryCentreAnalyzer.cc
@@ -259,7 +259,7 @@ void PixelBaryCentreAnalyzer::analyze(const edm::Event& iEvent, const edm::Event
     const SiPixelQuality* badPixelInfo = &iSetup.getData(siPixelQualityToken_);
 
     // Tracker global position
-    const AlignTransform& glbCoord = align::DetectorGlobalPosition(iSetup.getData(gprToken_), DetId(DetId::Tracker));
+    const AlignTransform glbCoord = align::DetectorGlobalPosition(iSetup.getData(gprToken_), DetId(DetId::Tracker));
 
     // Convert AlignTransform::Translation to GlobalVector using the appropriate constructor
     GlobalVector globalTkPosition(glbCoord.translation().x(), glbCoord.translation().y(), glbCoord.translation().z());


### PR DESCRIPTION
#### PR description:

In GCC13 IBs, compiler warns about "possibly dangling reference to a temporary":

```
src/Alignment/OfflineValidation/plugins/PixelBaryCentreAnalyzer.cc: In member function 'virtual void PixelBaryCentreAnalyzer::analyze(const edm::Event&, const edm::EventSetup&)':
  src/Alignment/OfflineValidation/plugins/PixelBaryCentreAnalyzer.cc:262:27: warning: possibly dangling reference to a temporary [-Wdangling-reference]
   262 |     const AlignTransform& glbCoord = align::DetectorGlobalPosition(iSetup.getData(gprToken_), DetId(DetId::Tracker));
      |                           ^~~~~~~~
src/Alignment/OfflineValidation/plugins/PixelBaryCentreAnalyzer.cc:262:67: note: the temporary was destroyed at the end of the full expression 'align::DetectorGlobalPosition((* &(& iSetup)->edm::EventSetup::getData<Alignments, GlobalPositionRcd>(((PixelBaryCentreAnalyzer*)this)->PixelBaryCentreAnalyzer::gprToken_)), DetId(((uint32_t)DetId::Tracker)))'
  262 |     const AlignTransform& glbCoord = align::DetectorGlobalPosition(iSetup.getData(gprToken_), DetId(DetId::Tracker));
      |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

A similar warning was fixed by getting rid of rerference, and since AlignTransform looks cheap to copy I followed the same approach.

#### PR validation:

Bot tests.