### PR TITLE
[GCC13] Avoid Wdangling-reference warning in CaloTPGTranscoderULUTs

### DIFF
--- a/CalibCalorimetry/CaloTPG/plugins/CaloTPGTranscoderULUTs.cc
+++ b/CalibCalorimetry/CaloTPG/plugins/CaloTPGTranscoderULUTs.cc
@@ -155,7 +155,8 @@ CaloTPGTranscoderULUTs::ReturnType CaloTPGTranscoderULUTs::produce(const CaloTPG
 
   const auto& lutMetadata = iRecord.get(lutMetadataToken);
   const auto& theTrigTowerGeometry = iRecord.get(theTrigTowerGeometryToken);
-  const auto& topo = iRecord.getRecord<HcalLutMetadataRcd>().get(topoToken);
+  const auto& topoRecord = iRecord.getRecord<HcalLutMetadataRcd>();
+  const auto& topo = topoRecord.get(topoToken);
 
   HcalLutMetadata fullLut{lutMetadata};
   fullLut.setTopo(&topo);


### PR DESCRIPTION
#### PR description:

In GCC13 IB, compiler warns about a potentially dangling reference to a temporary:

```
  src/CalibCalorimetry/CaloTPG/plugins/CaloTPGTranscoderULUTs.cc:158:15: warning: possibly dangling reference to a temporary [-Wdangling-reference]
   158 |   const auto& topo = iRecord.getRecord<HcalLutMetadataRcd>().get(topoToken);
      |               ^~~~
src/CalibCalorimetry/CaloTPG/plugins/CaloTPGTranscoderULUTs.cc:158:65: note: the temporary was destroyed at the end of the full expression 'edm::eventsetup::DependentRecordImplementation<RecordT, ListT>::getRecord() const [with DepRecordT = HcalLutMetadataRcd; RecordT = CaloTPGRecord; ListT = edm::mpl::Vector<HcalLutMetadataRcd, CaloGeometryRecord>]().HcalLutMetadataRcd::<anonymous>.edm::eventsetup::DependentRecordImplementation<HcalLutMetadataRcd, edm::mpl::Vector<HcalRecNumberingRecord, IdealGeometryRecord> >::get<HcalTopology, HcalRecNumberingRecord>(((CaloTPGTranscoderULUTs*)this)->CaloTPGTranscoderULUTs::topoToken)'
  158 |   const auto& topo = iRecord.getRecord<HcalLutMetadataRcd>().get(topoToken);
      |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
```

Similar issues in the past were fixed by removing refence. I'm not sure if `topo` is cheap to copy, so I made the code explicitly store the result of getRecord.

#### PR validation:

Bot tests