### PR TITLE
[GCC13][AlCa] Avoid Wdangling-reference in SiPhase2OuterTrackerFakeLorentzAngleESSource

### DIFF
--- a/CalibTracker/SiPhase2TrackerESProducers/plugins/SiPhase2OuterTrackerFakeLorentzAngleESSource.cc
+++ b/CalibTracker/SiPhase2TrackerESProducers/plugins/SiPhase2OuterTrackerFakeLorentzAngleESSource.cc
@@ -69,13 +69,15 @@ namespace fakeOTLA {
 
 std::unique_ptr<SiPhase2OuterTrackerLorentzAngle> SiPhase2OuterTrackerFakeLorentzAngleESSource::produceOTLA(
     const SiPhase2OuterTrackerLorentzAngleRcd& rcd) {
-  const auto& geomDet = rcd.getRecord<TrackerTopologyRcd>().get(m_geomDetToken);
+  const auto& geomDetRcd = rcd.getRecord<TrackerTopologyRcd>();
+  const auto& geomDet = geomDetRcd.get(m_geomDetToken);
   return fakeOTLA::produceRecord<SiPhase2OuterTrackerLorentzAngle>(LAvalue_, geomDet);
 }
 
 std::unique_ptr<SiPhase2OuterTrackerLorentzAngle> SiPhase2OuterTrackerFakeLorentzAngleESSource::produceOTSimLA(
     const SiPhase2OuterTrackerLorentzAngleSimRcd& rcd) {
-  const auto& geomDet = rcd.getRecord<TrackerTopologyRcd>().get(m_geomDetToken);
+  const auto& geomDetRcd = rcd.getRecord<TrackerTopologyRcd>();
+  const auto& geomDet = geomDetRcd.get(m_geomDetToken);
   return fakeOTLA::produceRecord<SiPhase2OuterTrackerLorentzAngle>(LAvalue_, geomDet);
 }
 

--- a/CalibTracker/SiPhase2TrackerESProducers/plugins/SiPhase2OuterTrackerFakeLorentzAngleESSource.cc
+++ b/CalibTracker/SiPhase2TrackerESProducers/plugins/SiPhase2OuterTrackerFakeLorentzAngleESSource.cc
@@ -75,8 +75,7 @@ std::unique_ptr<SiPhase2OuterTrackerLorentzAngle> SiPhase2OuterTrackerFakeLorent
 
 std::unique_ptr<SiPhase2OuterTrackerLorentzAngle> SiPhase2OuterTrackerFakeLorentzAngleESSource::produceOTSimLA(
     const SiPhase2OuterTrackerLorentzAngleSimRcd& rcd) {
-  const auto& geomDetRcd = rcd.getRecord<TrackerTopologyRcd>();
-  const auto& geomDet = geomDetRcd.get(m_geomDetToken);
+  const auto& geomDet = rcd.get(m_geomDetToken);
   return fakeOTLA::produceRecord<SiPhase2OuterTrackerLorentzAngle>(LAvalue_, geomDet);
 }
 

--- a/CalibTracker/SiPhase2TrackerESProducers/plugins/SiPhase2OuterTrackerFakeLorentzAngleESSource.cc
+++ b/CalibTracker/SiPhase2TrackerESProducers/plugins/SiPhase2OuterTrackerFakeLorentzAngleESSource.cc
@@ -69,8 +69,7 @@ namespace fakeOTLA {
 
 std::unique_ptr<SiPhase2OuterTrackerLorentzAngle> SiPhase2OuterTrackerFakeLorentzAngleESSource::produceOTLA(
     const SiPhase2OuterTrackerLorentzAngleRcd& rcd) {
-  const auto& geomDetRcd = rcd.getRecord<TrackerTopologyRcd>();
-  const auto& geomDet = geomDetRcd.get(m_geomDetToken);
+  const auto& geomDet = rcd.get(m_geomDetToken);
   return fakeOTLA::produceRecord<SiPhase2OuterTrackerLorentzAngle>(LAvalue_, geomDet);
 }
 

--- a/CondFormats/DataRecord/interface/SiPhase2OuterTrackerCondDataRecords.h
+++ b/CondFormats/DataRecord/interface/SiPhase2OuterTrackerCondDataRecords.h
@@ -4,15 +4,18 @@
 #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "FWCore/Utilities/interface/mplVector.h"
 
 /*Record associated to SiPhase2OuterTrackerLorentzAngle Object: the SimRcd is used in simulation only*/
 class SiPhase2OuterTrackerLorentzAngleRcd
     : public edm::eventsetup::DependentRecordImplementation<SiPhase2OuterTrackerLorentzAngleRcd,
-                                                            edm::mpl::Vector<TrackerTopologyRcd> > {};
+                                                            edm::mpl::Vector<IdealGeometryRecord, TrackerTopologyRcd> > {
+};
 class SiPhase2OuterTrackerLorentzAngleSimRcd
     : public edm::eventsetup::DependentRecordImplementation<SiPhase2OuterTrackerLorentzAngleSimRcd,
-                                                            edm::mpl::Vector<TrackerTopologyRcd> > {};
+                                                            edm::mpl::Vector<IdealGeometryRecord, TrackerTopologyRcd> > {
+};
 /*Record associated to SiStripBadStrip Object:*/
 class SiPhase2OuterTrackerBadStripRcd : public edm::eventsetup::DependentRecordImplementation<
                                             SiPhase2OuterTrackerBadStripRcd,


### PR DESCRIPTION
#### PR description:

In GCC13 IB, complier complains about dangling reference to a temporary:

```
src/CalibTracker/SiPhase2TrackerESProducers/plugins/SiPhase2OuterTrackerFakeLorentzAngleESSource.cc: In member function 'virtual std::unique_ptr<SiPhase2OuterTrackerLorentzAngle> SiPhase2OuterTrackerFakeLorentzAngleESSource::produceOTLA(const SiPhase2OuterTrackerLorentzAngleRcd&)':
  src/CalibTracker/SiPhase2TrackerESProducers/plugins/SiPhase2OuterTrackerFakeLorentzAngleESSource.cc:72:15: warning: possibly dangling reference to a temporary [-Wdangling-reference]
    72 |   const auto& geomDet = rcd.getRecord<TrackerTopologyRcd>().get(m_geomDetToken);
      |               ^~~~~~~
src/CalibTracker/SiPhase2TrackerESProducers/plugins/SiPhase2OuterTrackerFakeLorentzAngleESSource.cc:72:64: note: the temporary was destroyed at the end of the full expression 'edm::eventsetup::DependentRecordImplementation<RecordT, ListT>::getRecord() const [with DepRecordT = TrackerTopologyRcd; RecordT = SiPhase2OuterTrackerLorentzAngleRcd; ListT = edm::mpl::Vector<TrackerTopologyRcd>]().TrackerTopologyRcd::<anonymous>.edm::eventsetup::DependentRecordImplementation<TrackerTopologyRcd, edm::mpl::Vector<IdealGeometryRecord, PTrackerParametersRcd> >::get<GeometricDet, IdealGeometryRecord>(((SiPhase2OuterTrackerFakeLorentzAngleESSource*)this)->SiPhase2OuterTrackerFakeLorentzAngleESSource::m_geomDetToken)'
   72 |   const auto& geomDet = rcd.getRecord<TrackerTopologyRcd>().get(m_geomDetToken);
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
src/CalibTracker/SiPhase2TrackerESProducers/plugins/SiPhase2OuterTrackerFakeLorentzAngleESSource.cc: In member function 'virtual std::unique_ptr<SiPhase2OuterTrackerLorentzAngle> SiPhase2OuterTrackerFakeLorentzAngleESSource::produceOTSimLA(const SiPhase2OuterTrackerLorentzAngleSimRcd&)':
  src/CalibTracker/SiPhase2TrackerESProducers/plugins/SiPhase2OuterTrackerFakeLorentzAngleESSource.cc:78:15: warning: possibly dangling reference to a temporary [-Wdangling-reference]
    78 |   const auto& geomDet = rcd.getRecord<TrackerTopologyRcd>().get(m_geomDetToken);
      |               ^~~~~~~
src/CalibTracker/SiPhase2TrackerESProducers/plugins/SiPhase2OuterTrackerFakeLorentzAngleESSource.cc:78:64: note: the temporary was destroyed at the end of the full expression 'edm::eventsetup::DependentRecordImplementation<RecordT, ListT>::getRecord() const [with DepRecordT = TrackerTopologyRcd; RecordT = SiPhase2OuterTrackerLorentzAngleSimRcd; ListT = edm::mpl::Vector<TrackerTopologyRcd>]().TrackerTopologyRcd::<anonymous>.edm::eventsetup::DependentRecordImplementation<TrackerTopologyRcd, edm::mpl::Vector<IdealGeometryRecord, PTrackerParametersRcd> >::get<GeometricDet, IdealGeometryRecord>(((SiPhase2OuterTrackerFakeLorentzAngleESSource*)this)->SiPhase2OuterTrackerFakeLorentzAngleESSource::m_geomDetToken)'
   78 |   const auto& geomDet = rcd.getRecord<TrackerTopologyRcd>().get(m_geomDetToken);
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
```

Previously this warning was fixed by removing reference. However I think `geomDet` is not cheap to copy, so I opted for explicitly storing result of `getRecord` call.

#### PR validation:

Bot tests