### PR TITLE
[GCC13] Avoid Wdangling-reference warning in HcalTPGCoderULUT.cc

### DIFF
--- a/CalibCalorimetry/HcalTPGEventSetup/src/HcalTPGCoderULUT.cc
+++ b/CalibCalorimetry/HcalTPGEventSetup/src/HcalTPGCoderULUT.cc
@@ -160,7 +160,8 @@ HcalTPGCoderULUT::ReturnType HcalTPGCoderULUT::produce(const HcalTPGRecord& iRec
   auto host = holder_.makeOrGet([]() { return new HostType; });
 
   const auto& topo = iRecord.get(topoToken_);
-  const auto& delay = iRecord.getRecord<HcalDbRecord>().get(delayToken_);
+  const auto& delayRcd = iRecord.getRecord<HcalDbRecord>();
+  const auto& delay = delayRcd.get(delayToken_);
   if (read_Ascii_ || read_XML_) {
     buildCoder(&topo, &delay, host.get());
   } else {


### PR DESCRIPTION
#### PR description:

In GCC13 IB, the compiler emits the following warning:

```
src/CalibCalorimetry/HcalTPGEventSetup/src/HcalTPGCoderULUT.cc: In member function 'HcalTPGCoderULUT::ReturnType HcalTPGCoderULUT::produce(const HcalTPGRecord&)':
  src/CalibCalorimetry/HcalTPGEventSetup/src/HcalTPGCoderULUT.cc:163:15: warning: possibly dangling reference to a temporary [-Wdangling-reference]
   163 |   const auto& delay = iRecord.getRecord<HcalDbRecord>().get(delayToken_);
      |               ^~~~~
src/CalibCalorimetry/HcalTPGEventSetup/src/HcalTPGCoderULUT.cc:163:60: note: the temporary was destroyed at the end of the full expression 'edm::eventsetup::DependentRecordImplementation<RecordT, ListT>::getRecord() const [with DepRecordT = HcalDbRecord; RecordT = HcalTPGRecord; ListT = edm::mpl::Vector<HcalRecNumberingRecord, IdealGeometryRecord, HcalDbRecord>]().HcalDbRecord::<anonymous>.edm::eventsetup::DependentRecordImplementation<HcalDbRecord, edm::mpl::Vector<HcalRecNumberingRecord, IdealGeometryRecord, HcalPedestalsRcd, HcalPedestalWidthsRcd, HcalGainsRcd, HcalGainWidthsRcd, HcalQIEDataRcd, HcalQIETypesRcd, HcalChannelQualityRcd, HcalZSThresholdsRcd, HcalRespCorrsRcd, HcalL1TriggerObjectsRcd, HcalElectronicsMapRcd, HcalTimeCorrsRcd, HcalLUTCorrsRcd, HcalPFCorrsRcd, HcalFrontEndMapRcd, HcalSiPMCharacteristicsRcd, HcalSiPMParametersRcd, HcalTPParametersRcd, HcalTPChannelParametersRcd, HcalLutMetadataRcd, HcalMCParamsRcd, HcalRecoParamsRcd, HcalTimeSlewRecord> >::get<HcalTimeSlew, HcalTimeSlewRecord>(((HcalTPGCoderULUT*)this)->HcalTPGCoderULUT::delayToken_)'
  163 |   const auto& delay = iRecord.getRecord<HcalDbRecord>().get(delayToken_);
      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
```

#### PR validation:

Bot tests
