### PR TITLE
[GCC13] Avoid Wdangling-reference warning in CalibTracker submodules

### DIFF
--- a/CalibTracker/SiStripCommon/plugins/TkDetMapESProducer.cc
+++ b/CalibTracker/SiStripCommon/plugins/TkDetMapESProducer.cc
@@ -294,7 +294,8 @@ namespace {
 }  // namespace
 
 std::unique_ptr<TkDetMap> TkDetMapESProducer::produce(const TrackerTopologyRcd& tTopoRcd) {
-  const auto& geomDet = tTopoRcd.getRecord<IdealGeometryRecord>().get(geomDetToken_);
+  const auto& geomDetRcd = tTopoRcd.getRecord<IdealGeometryRecord>();
+  const auto& geomDet = geomDetRcd.get(geomDetToken_);
   const auto TkDetIdList = TrackerGeometryUtils::getSiStripDetIds(geomDet);
 
   const auto& tTopo = tTopoRcd.get(tTopoToken_);

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripBackPlaneCorrectionFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripBackPlaneCorrectionFakeESSource.cc
@@ -65,7 +65,8 @@ SiStripBackPlaneCorrectionFakeESSource::ReturnType SiStripBackPlaneCorrectionFak
     const SiStripBackPlaneCorrectionRcd& iRecord) {
   using namespace edm::es;
 
-  const auto& geomDet = iRecord.getRecord<TrackerTopologyRcd>().get(m_geomDetToken);
+  const auto& geomDetRcd = iRecord.getRecord<TrackerTopologyRcd>();
+  const auto& geomDet = geomDetRcd.get(m_geomDetToken);
   const auto& tTopo = iRecord.get(m_tTopoToken);
 
   auto backPlaneCorrection = std::make_unique<SiStripBackPlaneCorrection>();

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripHashedDetIdFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripHashedDetIdFakeESSource.cc
@@ -31,7 +31,8 @@ std::unique_ptr<SiStripHashedDetId> SiStripHashedDetIdFakeESSource::produce(cons
   edm::LogVerbatim("HashedDetId") << "[SiStripHashedDetIdFakeESSource::" << __func__ << "]"
                                   << " Building \"fake\" hashed DetId map from IdealGeometry";
 
-  const auto& geomDet = record.getRecord<TrackerDigiGeometryRecord>().get(geomDetToken_);
+  const auto& geomDetRcd = record.getRecord<TrackerDigiGeometryRecord>();
+  const auto& geomDet = geomDetRcd.get(geomDetToken_);
 
   const std::vector<uint32_t> dets = TrackerGeometryUtils::getSiStripDetIds(geomDet);
   edm::LogVerbatim("HashedDetId") << "[SiStripHashedDetIdFakeESSource::" << __func__ << "]"

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripLorentzAngleFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripLorentzAngleFakeESSource.cc
@@ -183,7 +183,8 @@ SiStripLorentzAngleFakeESSource::ReturnType SiStripLorentzAngleFakeESSource::pro
     const SiStripLorentzAngleRcd& iRecord) {
   using namespace edm::es;
 
-  const auto& geomDet = iRecord.getRecord<TrackerTopologyRcd>().get(m_geomDetToken);
+  const auto& geomDetRcd = iRecord.getRecord<TrackerTopologyRcd>();
+  const auto& geomDet = geomDetRcd.get(m_geomDetToken);
   const auto& tTopo = iRecord.get(m_tTopoToken);
 
   auto lorentzAngle = std::make_unique<SiStripLorentzAngle>();

--- a/CalibTracker/SiStripQuality/plugins/SiStripQualityHotStripIdentifier.cc
+++ b/CalibTracker/SiStripQuality/plugins/SiStripQualityHotStripIdentifier.cc
@@ -167,7 +167,8 @@ void SiStripQualityHotStripIdentifier::resetHistos() {
 void SiStripQualityHotStripIdentifier::bookHistos() {
   edm::LogInfo("SiStripQualityHotStripIdentifier") << " [SiStripQualityHotStripIdentifier::bookHistos] " << std::endl;
   char hname[1024];
-  for (const auto& it : SiStripDetInfoFileReader::read(fp_.fullPath()).getAllData()) {
+  const auto info = SiStripDetInfoFileReader::read(fp_.fullPath());
+  for (const auto& it : info.getAllData()) {
     sprintf(hname, "h_%d", it.first);
     auto ref = ClusterPositionHistoMap.find(it.first);
     if (ref == ClusterPositionHistoMap.end()) {

--- a/CalibTracker/SiStripQuality/plugins/SiStripQualityHotStripIdentifier.cc
+++ b/CalibTracker/SiStripQuality/plugins/SiStripQualityHotStripIdentifier.cc
@@ -167,7 +167,7 @@ void SiStripQualityHotStripIdentifier::resetHistos() {
 void SiStripQualityHotStripIdentifier::bookHistos() {
   edm::LogInfo("SiStripQualityHotStripIdentifier") << " [SiStripQualityHotStripIdentifier::bookHistos] " << std::endl;
   char hname[1024];
-  const auto info = SiStripDetInfoFileReader::read(fp_.fullPath());
+  const SiStripDetInfo& info = SiStripDetInfoFileReader::read(fp_.fullPath());
   for (const auto& it : info.getAllData()) {
     sprintf(hname, "h_%d", it.first);
     auto ref = ClusterPositionHistoMap.find(it.first);


### PR DESCRIPTION
#### PR description:

In GCC13 IBs, the following warnings are emitted:

```
src/CalibTracker/SiStripCommon/plugins/TkDetMapESProducer.cc: In member function 'std::unique_ptr<TkDetMap> TkDetMapESProducer::produce(const TrackerTopologyRcd&)':
  src/CalibTracker/SiStripCommon/plugins/TkDetMapESProducer.cc:297:15: warning: possibly dangling reference to a temporary [-Wdangling-reference]
   297 |   const auto& geomDet = tTopoRcd.getRecord<IdealGeometryRecord>().get(geomDetToken_);
      |               ^~~~~~~
src/CalibTracker/SiStripCommon/plugins/TkDetMapESProducer.cc:297:70: note: the temporary was destroyed at the end of the full expression 'edm::eventsetup::DependentRecordImplementation<RecordT, ListT>::getRecord() const [with DepRecordT = IdealGeometryRecord; RecordT = TrackerTopologyRcd; ListT = edm::mpl::Vector<IdealGeometryRecord, PTrackerParametersRcd>]().IdealGeometryRecord::<anonymous>.edm::eventsetup::DependentRecordImplementation<IdealGeometryRecord, edm::mpl::Vector<GeometryFileRcd> >::<anonymous>.edm::eventsetup::EventSetupRecordImplementation<IdealGeometryRecord>::get<GeometricDet>(((TkDetMapESProducer*)this)->TkDetMapESProducer::geomDetToken_)'
  297 |   const auto& geomDet = tTopoRcd.getRecord<IdealGeometryRecord>().get(geomDetToken_);
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
	  
src/CalibTracker/SiStripESProducers/plugins/fake/SiStripBackPlaneCorrectionFakeESSource.cc: In member function 'SiStripBackPlaneCorrectionFakeESSource::ReturnType SiStripBackPlaneCorrectionFakeESSource::produce(const SiStripBackPlaneCorrectionRcd&)':
  src/CalibTracker/SiStripESProducers/plugins/fake/SiStripBackPlaneCorrectionFakeESSource.cc:68:15: warning: possibly dangling reference to a temporary [-Wdangling-reference]
    68 |   const auto& geomDet = iRecord.getRecord<TrackerTopologyRcd>().get(m_geomDetToken);
      |               ^~~~~~~
src/CalibTracker/SiStripESProducers/plugins/fake/SiStripBackPlaneCorrectionFakeESSource.cc:68:68: note: the temporary was destroyed at the end of the full expression 'edm::eventsetup::DependentRecordImplementation<RecordT, ListT>::getRecord() const [with DepRecordT = TrackerTopologyRcd; RecordT = SiStripBackPlaneCorrectionRcd; ListT = edm::mpl::Vector<TrackerTopologyRcd>]().TrackerTopologyRcd::<anonymous>.edm::eventsetup::DependentRecordImplementation<TrackerTopologyRcd, edm::mpl::Vector<IdealGeometryRecord, PTrackerParametersRcd> >::get<GeometricDet, IdealGeometryRecord>(((SiStripBackPlaneCorrectionFakeESSource*)this)->SiStripBackPlaneCorrectionFakeESSource::m_geomDetToken)'
   68 |   const auto& geomDet = iRecord.getRecord<TrackerTopologyRcd>().get(m_geomDetToken);
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~

src/CalibTracker/SiStripESProducers/plugins/fake/SiStripHashedDetIdFakeESSource.cc: In member function 'virtual std::unique_ptr<SiStripHashedDetId> SiStripHashedDetIdFakeESSource::produce(const SiStripHashedDetIdRcd&)':
  src/CalibTracker/SiStripESProducers/plugins/fake/SiStripHashedDetIdFakeESSource.cc:34:15: warning: possibly dangling reference to a temporary [-Wdangling-reference]
    34 |   const auto& geomDet = record.getRecord<TrackerDigiGeometryRecord>().get(geomDetToken_);
      |               ^~~~~~~
src/CalibTracker/SiStripESProducers/plugins/fake/SiStripHashedDetIdFakeESSource.cc:34:74: note: the temporary was destroyed at the end of the full expression 'edm::eventsetup::DependentRecordImplementation<RecordT, ListT>::getRecord() const [with DepRecordT = TrackerDigiGeometryRecord; RecordT = SiStripHashedDetIdRcd; ListT = edm::mpl::Vector<TrackerDigiGeometryRecord>]().TrackerDigiGeometryRecord::<anonymous>.edm::eventsetup::DependentRecordImplementation<TrackerDigiGeometryRecord, edm::mpl::Vector<IdealGeometryRecord, TrackerAlignmentRcd, TrackerAlignmentErrorExtendedRcd, TrackerSurfaceDeformationRcd, GlobalPositionRcd, TrackerTopologyRcd, PTrackerParametersRcd, PTrackerAdditionalParametersPerDetRcd> >::get<GeometricDet, IdealGeometryRecord>(((SiStripHashedDetIdFakeESSource*)this)->SiStripHashedDetIdFakeESSource::geomDetToken_)'
   34 |   const auto& geomDet = record.getRecord<TrackerDigiGeometryRecord>().get(geomDetToken_);
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
src/CalibTracker/SiStripESProducers/plugins/fake/SiStripLorentzAngleFakeESSource.cc: In member function 'SiStripLorentzAngleFakeESSource::ReturnType SiStripLorentzAngleFakeESSource::produce(const SiStripLorentzAngleRcd&)':
  src/CalibTracker/SiStripESProducers/plugins/fake/SiStripLorentzAngleFakeESSource.cc:186:15: warning: possibly dangling reference to a temporary [-Wdangling-reference]
   186 |   const auto& geomDet = iRecord.getRecord<TrackerTopologyRcd>().get(m_geomDetToken);
      |               ^~~~~~~
src/CalibTracker/SiStripESProducers/plugins/fake/SiStripLorentzAngleFakeESSource.cc:186:68: note: the temporary was destroyed at the end of the full expression 'edm::eventsetup::DependentRecordImplementation<RecordT, ListT>::getRecord() const [with DepRecordT = TrackerTopologyRcd; RecordT = SiStripLorentzAngleRcd; ListT = edm::mpl::Vector<TrackerTopologyRcd>]().TrackerTopologyRcd::<anonymous>.edm::eventsetup::DependentRecordImplementation<TrackerTopologyRcd, edm::mpl::Vector<IdealGeometryRecord, PTrackerParametersRcd> >::get<GeometricDet, IdealGeometryRecord>(((SiStripLorentzAngleFakeESSource*)this)->SiStripLorentzAngleFakeESSource::m_geomDetToken)'
  186 |   const auto& geomDet = iRecord.getRecord<TrackerTopologyRcd>().get(m_geomDetToken);
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
	  
src/CalibTracker/SiStripQuality/plugins/SiStripQualityHotStripIdentifier.cc: In member function 'void SiStripQualityHotStripIdentifier::bookHistos()':
  src/CalibTracker/SiStripQuality/plugins/SiStripQualityHotStripIdentifier.cc:170:83: warning: possibly dangling reference to a temporary [-Wdangling-reference]
   170 |   for (const auto& it : SiStripDetInfoFileReader::read(fp_.fullPath()).getAllData()) {
      |                                                                                   ^
src/CalibTracker/SiStripQuality/plugins/SiStripQualityHotStripIdentifier.cc:170:82: note: the temporary was destroyed at the end of the full expression 'SiStripDetInfoFileReader::read(std::string)().SiStripDetInfo::getAllData()'
  170 |   for (const auto& it : SiStripDetInfoFileReader::read(fp_.fullPath()).getAllData()) {
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
```

#### PR validation:

Bot tests
