### PR TITLE
[GCC13] Avoid Wdangling-reference in GenericTriggerEventFlag

### DIFF
--- a/CommonTools/TriggerUtils/src/GenericTriggerEventFlag.cc
+++ b/CommonTools/TriggerUtils/src/GenericTriggerEventFlag.cc
@@ -210,7 +210,8 @@ void GenericTriggerEventFlag::initRun(const edm::Run& run, const edm::EventSetup
         algoNames.push_back(ip.first);
     } else {
       l1Gt_->getL1GtRunCache(run, setup, useL1EventSetup, useL1GtTriggerMenuLite);
-      L1GtTriggerMenu const& l1GtTriggerMenu = setup.get<L1GtTriggerMenuRcd>().get(l1GtTriggerMenuToken_);
+	  const auto& l1GtTriggerMenuRcd = setup.get<L1GtTriggerMenuRcd>();
+      L1GtTriggerMenu const& l1GtTriggerMenu = l1GtTriggerMenuRcd.get(l1GtTriggerMenuToken_);
 
       const AlgorithmMap& l1GtPhys(l1GtTriggerMenu.gtAlgorithmMap());
       for (CItAlgo iAlgo = l1GtPhys.begin(); iAlgo != l1GtPhys.end(); ++iAlgo) {

--- a/CommonTools/TriggerUtils/src/GenericTriggerEventFlag.cc
+++ b/CommonTools/TriggerUtils/src/GenericTriggerEventFlag.cc
@@ -210,7 +210,7 @@ void GenericTriggerEventFlag::initRun(const edm::Run& run, const edm::EventSetup
         algoNames.push_back(ip.first);
     } else {
       l1Gt_->getL1GtRunCache(run, setup, useL1EventSetup, useL1GtTriggerMenuLite);
-	  const auto& l1GtTriggerMenuRcd = setup.get<L1GtTriggerMenuRcd>();
+      const auto& l1GtTriggerMenuRcd = setup.get<L1GtTriggerMenuRcd>();
       L1GtTriggerMenu const& l1GtTriggerMenu = l1GtTriggerMenuRcd.get(l1GtTriggerMenuToken_);
 
       const AlgorithmMap& l1GtPhys(l1GtTriggerMenu.gtAlgorithmMap());


### PR DESCRIPTION
#### PR description:

In GCC13 IB, the following warning is emitted:

```
src/CommonTools/TriggerUtils/src/GenericTriggerEventFlag.cc: In member function 'void GenericTriggerEventFlag::initRun(const edm::Run&, const edm::EventSetup&)':
  src/CommonTools/TriggerUtils/src/GenericTriggerEventFlag.cc:213:30: warning: possibly dangling reference to a temporary [-Wdangling-reference]
   213 |       L1GtTriggerMenu const& l1GtTriggerMenu = setup.get<L1GtTriggerMenuRcd>().get(l1GtTriggerMenuToken_);
      |                              ^~~~~~~~~~~~~~~
src/CommonTools/TriggerUtils/src/GenericTriggerEventFlag.cc:213:83: note: the temporary was destroyed at the end of the full expression 'edm::EventSetup::get() const [with T = L1GtTriggerMenuRcd]().L1GtTriggerMenuRcd::<anonymous>.edm::eventsetup::DependentRecordImplementation<L1GtTriggerMenuRcd, edm::mpl::Vector<L1GtStableParametersRcd, L1TriggerKeyListRcd, L1TriggerKeyRcd> >::<anonymous>.edm::eventsetup::EventSetupRecordImplementation<L1GtTriggerMenuRcd>::get<L1GtTriggerMenu>(((GenericTriggerEventFlag*)this)->GenericTriggerEventFlag::l1GtTriggerMenuToken_)'
  213 |       L1GtTriggerMenu const& l1GtTriggerMenu = setup.get<L1GtTriggerMenuRcd>().get(l1GtTriggerMenuToken_);
      |                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
```

#### PR validation:

Bot tests