### PR TITLE
[GCC13] Avoid Wdangling-reference in HcalChannelPropertiesEP

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/plugins/HcalChannelPropertiesEP.cc
+++ b/RecoLocalCalo/HcalRecAlgos/plugins/HcalChannelPropertiesEP.cc
@@ -53,8 +53,10 @@ public:
   inline ~HcalChannelPropertiesEP() override {}
 
   ReturnType1 produce1(const HcalChannelPropertiesAuxRecord& rcd) {
-    const HcalTopology& htopo = rcd.getRecord<HcalRecNumberingRecord>().get(topoToken_);
-    const HcalRecoParams& params = rcd.getRecord<HcalRecoParamsRcd>().get(paramsToken_);
+    const auto& htopoRecord = rcd.getRecord<HcalRecNumberingRecord>();
+    const HcalTopology& htopo = htopoRecord.get(topoToken_);
+    const auto& paramsRecord = rcd.getRecord<HcalRecoParamsRcd>();
+    const HcalRecoParams& params = paramsRecord.get(paramsToken_);
 
     ReturnType1 prod = std::make_unique<HcalRecoParams>(params);
     prod->setTopo(&htopo);
@@ -72,10 +74,14 @@ public:
     // Retrieve various event setup records and data products
     const HcalDbRecord& dbRecord = rcd.getRecord<HcalDbRecord>();
     const HcalDbService& cond = dbRecord.get(condToken_);
-    const HcalRecoParams& params = rcd.getRecord<HcalChannelPropertiesAuxRecord>().get(myParamsToken_);
-    const HcalSeverityLevelComputer& severity = rcd.getRecord<HcalSeverityLevelComputerRcd>().get(sevToken_);
-    const HcalChannelQuality& qual = dbRecord.getRecord<HcalChannelQualityRcd>().get(qualToken_);
-    const CaloGeometry& geom = rcd.getRecord<CaloGeometryRecord>().get(geomToken_);
+    const auto& paramsRecord = rcd.getRecord<HcalChannelPropertiesAuxRecord>();
+    const HcalRecoParams& params = paramsRecord.get(myParamsToken_);
+    const auto& severityRecord = rcd.getRecord<HcalSeverityLevelComputerRcd>();
+    const HcalSeverityLevelComputer& severity = severityRecord.get(sevToken_);
+    const auto& qualRecord = dbRecord.getRecord<HcalChannelQualityRcd>();
+    const HcalChannelQuality& qual = qualRecord.get(qualToken_);
+    const auto& geomRecord = rcd.getRecord<CaloGeometryRecord>();
+    const CaloGeometry& geom = geomRecord.get(geomToken_);
 
     // HcalTopology is taken from "params" created by the "produce1" method
     const HcalTopology& htopo(*params.topo());


### PR DESCRIPTION
#### PR description:

In GCC13 IB the following warnings are emitted:

```
src/RecoLocalCalo/HcalRecAlgos/plugins/HcalChannelPropertiesEP.cc: In member function 'HcalChannelPropertiesEP::ReturnType1 HcalChannelPropertiesEP::produce1(const HcalChannelPropertiesAuxRecord&)':
  src/RecoLocalCalo/HcalRecAlgos/plugins/HcalChannelPropertiesEP.cc:56:25: warning: possibly dangling reference to a temporary [-Wdangling-reference]
    56 |     const HcalTopology& htopo = rcd.getRecord<HcalRecNumberingRecord>().get(topoToken_);
      |                         ^~~~~
src/RecoLocalCalo/HcalRecAlgos/plugins/HcalChannelPropertiesEP.cc:56:76: note: the temporary was destroyed at the end of the full expression 'edm::eventsetup::DependentRecordImplementation<RecordT, ListT>::getRecord() const [with DepRecordT = HcalRecNumberingRecord; RecordT = HcalChannelPropertiesAuxRecord; ListT = edm::mpl::Vector<HcalRecNumberingRecord, HcalRecoParamsRcd>]().HcalRecNumberingRecord::<anonymous>.edm::eventsetup::DependentRecordImplementation<HcalRecNumberingRecord, edm::mpl::Vector<IdealGeometryRecord, HcalParametersRcd, HcalSimNumberingRecord> >::<anonymous>.edm::eventsetup::EventSetupRecordImplementation<HcalRecNumberingRecord>::get<HcalTopology>(((HcalChannelPropertiesEP*)this)->HcalChannelPropertiesEP::topoToken_)'
   56 |     const HcalTopology& htopo = rcd.getRecord<HcalRecNumberingRecord>().get(topoToken_);
      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
  src/RecoLocalCalo/HcalRecAlgos/plugins/HcalChannelPropertiesEP.cc:57:27: warning: possibly dangling reference to a temporary [-Wdangling-reference]
    57 |     const HcalRecoParams& params = rcd.getRecord<HcalRecoParamsRcd>().get(paramsToken_);
      |                           ^~~~~~
src/RecoLocalCalo/HcalRecAlgos/plugins/HcalChannelPropertiesEP.cc:57:74: note: the temporary was destroyed at the end of the full expression 'edm::eventsetup::DependentRecordImplementation<RecordT, ListT>::getRecord() const [with DepRecordT = HcalRecoParamsRcd; RecordT = HcalChannelPropertiesAuxRecord; ListT = edm::mpl::Vector<HcalRecNumberingRecord, HcalRecoParamsRcd>]().HcalRecoParamsRcd::<anonymous>.edm::eventsetup::DependentRecordImplementation<HcalRecoParamsRcd, edm::mpl::Vector<HcalRecNumberingRecord, IdealGeometryRecord> >::<anonymous>.edm::eventsetup::EventSetupRecordImplementation<HcalRecoParamsRcd>::get<HcalRecoParams>(((HcalChannelPropertiesEP*)this)->HcalChannelPropertiesEP::paramsToken_)'
   57 |     const HcalRecoParams& params = rcd.getRecord<HcalRecoParamsRcd>().get(paramsToken_);
      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
src/RecoLocalCalo/HcalRecAlgos/plugins/HcalChannelPropertiesEP.cc: In member function 'HcalChannelPropertiesEP::ReturnType2 HcalChannelPropertiesEP::produce2(const HcalChannelPropertiesRecord&)':
  src/RecoLocalCalo/HcalRecAlgos/plugins/HcalChannelPropertiesEP.cc:75:27: warning: possibly dangling reference to a temporary [-Wdangling-reference]
    75 |     const HcalRecoParams& params = rcd.getRecord<HcalChannelPropertiesAuxRecord>().get(myParamsToken_);
      |                           ^~~~~~
src/RecoLocalCalo/HcalRecAlgos/plugins/HcalChannelPropertiesEP.cc:75:87: note: the temporary was destroyed at the end of the full expression 'edm::eventsetup::DependentRecordImplementation<RecordT, ListT>::getRecord() const [with DepRecordT = HcalChannelPropertiesAuxRecord; RecordT = HcalChannelPropertiesRecord; ListT = edm::mpl::Vector<CaloGeometryRecord, HcalDbRecord, HcalSeverityLevelComputerRcd, HcalChannelPropertiesAuxRecord>]().HcalChannelPropertiesAuxRecord::<anonymous>.edm::eventsetup::DependentRecordImplementation<HcalChannelPropertiesAuxRecord, edm::mpl::Vector<HcalRecNumberingRecord, HcalRecoParamsRcd> >::<anonymous>.edm::eventsetup::EventSetupRecordImplementation<HcalChannelPropertiesAuxRecord>::get<HcalRecoParams>(((HcalChannelPropertiesEP*)this)->HcalChannelPropertiesEP::myParamsToken_)'
   75 |     const HcalRecoParams& params = rcd.getRecord<HcalChannelPropertiesAuxRecord>().get(myParamsToken_);
      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
  src/RecoLocalCalo/HcalRecAlgos/plugins/HcalChannelPropertiesEP.cc:76:38: warning: possibly dangling reference to a temporary [-Wdangling-reference]
    76 |     const HcalSeverityLevelComputer& severity = rcd.getRecord<HcalSeverityLevelComputerRcd>().get(sevToken_);
      |                                      ^~~~~~~~
src/RecoLocalCalo/HcalRecAlgos/plugins/HcalChannelPropertiesEP.cc:76:98: note: the temporary was destroyed at the end of the full expression 'edm::eventsetup::DependentRecordImplementation<RecordT, ListT>::getRecord() const [with DepRecordT = HcalSeverityLevelComputerRcd; RecordT = HcalChannelPropertiesRecord; ListT = edm::mpl::Vector<CaloGeometryRecord, HcalDbRecord, HcalSeverityLevelComputerRcd, HcalChannelPropertiesAuxRecord>]().HcalSeverityLevelComputerRcd::<anonymous>.edm::eventsetup::EventSetupRecordImplementation<HcalSeverityLevelComputerRcd>::get<HcalSeverityLevelComputer>(((HcalChannelPropertiesEP*)this)->HcalChannelPropertiesEP::sevToken_)'
   76 |     const HcalSeverityLevelComputer& severity = rcd.getRecord<HcalSeverityLevelComputerRcd>().get(sevToken_);
      |                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
  src/RecoLocalCalo/HcalRecAlgos/plugins/HcalChannelPropertiesEP.cc:77:31: warning: possibly dangling reference to a temporary [-Wdangling-reference]
    77 |     const HcalChannelQuality& qual = dbRecord.getRecord<HcalChannelQualityRcd>().get(qualToken_);
      |                               ^~~~
src/RecoLocalCalo/HcalRecAlgos/plugins/HcalChannelPropertiesEP.cc:77:85: note: the temporary was destroyed at the end of the full expression 'edm::eventsetup::DependentRecordImplementation<RecordT, ListT>::getRecord() const [with DepRecordT = HcalChannelQualityRcd; RecordT = HcalDbRecord; ListT = edm::mpl::Vector<HcalRecNumberingRecord, IdealGeometryRecord, HcalPedestalsRcd, HcalPedestalWidthsRcd, HcalGainsRcd, HcalGainWidthsRcd, HcalQIEDataRcd, HcalQIETypesRcd, HcalChannelQualityRcd, HcalZSThresholdsRcd, HcalRespCorrsRcd, HcalL1TriggerObjectsRcd, HcalElectronicsMapRcd, HcalTimeCorrsRcd, HcalLUTCorrsRcd, HcalPFCorrsRcd, HcalFrontEndMapRcd, HcalSiPMCharacteristicsRcd, HcalSiPMParametersRcd, HcalTPParametersRcd, HcalTPChannelParametersRcd, HcalLutMetadataRcd, HcalMCParamsRcd, HcalRecoParamsRcd, HcalTimeSlewRecord>]().HcalChannelQualityRcd::<anonymous>.edm::eventsetup::DependentRecordImplementation<HcalChannelQualityRcd, edm::mpl::Vector<HcalRecNumberingRecord, IdealGeometryRecord> >::<anonymous>.edm::eventsetup::EventSetupRecordImplementation<HcalChannelQualityRcd>::get<HcalChannelQuality>(((HcalChannelPropertiesEP*)this)->HcalChannelPropertiesEP::qualToken_)'
   77 |     const HcalChannelQuality& qual = dbRecord.getRecord<HcalChannelQualityRcd>().get(qualToken_);
      |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
  src/RecoLocalCalo/HcalRecAlgos/plugins/HcalChannelPropertiesEP.cc:78:25: warning: possibly dangling reference to a temporary [-Wdangling-reference]
    78 |     const CaloGeometry& geom = rcd.getRecord<CaloGeometryRecord>().get(geomToken_);
      |                         ^~~~
src/RecoLocalCalo/HcalRecAlgos/plugins/HcalChannelPropertiesEP.cc:78:71: note: the temporary was destroyed at the end of the full expression 'edm::eventsetup::DependentRecordImplementation<RecordT, ListT>::getRecord() const [with DepRecordT = CaloGeometryRecord; RecordT = HcalChannelPropertiesRecord; ListT = edm::mpl::Vector<CaloGeometryRecord, HcalDbRecord, HcalSeverityLevelComputerRcd, HcalChannelPropertiesAuxRecord>]().CaloGeometryRecord::<anonymous>.edm::eventsetup::DependentRecordImplementation<CaloGeometryRecord, edm::mpl::Vector<IdealGeometryRecord, EcalBarrelGeometryRecord, EcalEndcapGeometryRecord, EcalPreshowerGeometryRecord, HcalParametersRcd, HcalSimNumberingRecord, HcalRecNumberingRecord, HcalGeometryRecord, HGCalGeometryRecord, CaloTowerGeometryRecord, CastorGeometryRecord, ZDCGeometryRecord> >::<anonymous>.edm::eventsetup::EventSetupRecordImplementation<CaloGeometryRecord>::get<CaloGeometry>(((HcalChannelPropertiesEP*)this)->HcalChannelPropertiesEP::geomToken_)'
   78 |     const CaloGeometry& geom = rcd.getRecord<CaloGeometryRecord>().get(geomToken_);
      |                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
```
#### PR validation:

Bot tests

