### PR TITLE
Fix for L1TMuonGlobalParams_PayloadInspector

### DIFF
--- a/CondCore/L1TPlugins/plugins/BuildFile.xml
+++ b/CondCore/L1TPlugins/plugins/BuildFile.xml
@@ -3,3 +3,11 @@
   <use name="CondCore/CondDB"/>
   <use name="CondFormats/L1TObjects"/>
 </library>
+
+<library file="L1TMuonGlobalParams_PayloadInspector.cc" name="L1TMuonGlobalParams_PayloadInspector">
+  <use name="CondCore/Utilities"/>
+  <use name="CondCore/CondDB"/>
+  <use name="CondFormats/L1TObjects"/>
+  <use name="L1Trigger/L1TMuon"/>
+  <use name="FWCore/MessageLogger"/>
+</library>

--- a/CondCore/L1TPlugins/plugins/L1TMuonGlobalParams_PayloadInspector.cc
+++ b/CondCore/L1TPlugins/plugins/L1TMuonGlobalParams_PayloadInspector.cc
@@ -18,7 +18,7 @@
 #include "L1Trigger/L1TMuon/interface/L1TMuonGlobalParamsHelper.h"
 #include "L1Trigger/L1TMuon/interface/L1TMuonGlobalParams_PUBLIC.h"
 
-#include <bitset>
+#include <fmt/format.h>
 
 // include ROOT
 #include "TH1F.h"
@@ -93,13 +93,11 @@ namespace {
         leg.Draw();
         lzero.Draw();
 
-        tl.DrawLatexNDC(
-            0.12,
-            0.85,
-            (fmt::v8::format(
-                 "fwVersion: {}, bx Min, Max: {}, {}", l1tmgph.fwVersion(), payload->bxMin(), payload->bxMax()))
-                .c_str());
-        tl.DrawLatexNDC(0.1, 0.92, (fmt::v8::format("{}, iov: {}", tag.name, IOVsince)).c_str());
+        auto const label_fw =
+            fmt::format("fwVersion: {}, bx Min, Max: {}, {}", l1tmgph.fwVersion(), payload->bxMin(), payload->bxMax());
+        auto const label_tag = fmt::format("{}, iov: {}", tag.name, IOVsince);
+        tl.DrawLatexNDC(0.12, 0.85, label_fw.c_str());
+        tl.DrawLatexNDC(0.10, 0.92, label_tag.c_str());
         tl.DrawLatexNDC(0.07, 0.59, "1");
         tl.DrawLatexNDC(0.07, 0.27, "1");
 


### PR DESCRIPTION
As pointed out in https://github.com/cms-sw/cmssw/pull/45438#issuecomment-2293834884, the code implemented with #45438 had some error that need to be fixed.

I am implementing here the suggestion proposed by @missirol in that comment (tank you!). The updated code was tested with
```
getPayloadData.py --plugin pluginL1TMuonGlobalParams_PayloadInspector --plot plot_L1TMuonGlobalParamsInputBits --tag L1TMuonGlobalParams_Stage2v0_2024_mc_v1 --time_type Run --iovs '{"start_iov": "1", "end_iov" : "1"}' --db Prod --test
```

Now the code builds and produces the following output (as it should):
![c9793dbb-6603-4c1a-95f5-f723aa3248ee](https://github.com/user-attachments/assets/d64c810b-d294-45fd-8727-47564ee0a9ea)
