### PR TITLE
Fix for `L1TMuonGlobalParams_PayloadInspector`

### DIFF
--- a/CondCore/L1TPlugins/plugins/BuildFile.xml
+++ b/CondCore/L1TPlugins/plugins/BuildFile.xml
@@ -3,3 +3,11 @@
   <use name="CondCore/CondDB"/>
   <use name="CondFormats/L1TObjects"/>
 </library>
+
+<library file="L1TMuonGlobalParams_PayloadInspector.cc" name="L1TMuonGlobalParams_PayloadInspector">
+  <use name="CondCore/Utilities"/>
+  <use name="CondCore/CondDB"/>
+  <use name="CondFormats/L1TObjects"/>
+  <use name="L1Trigger/L1TMuon"/>
+  <use name="FWCore/MessageLogger"/>
+</library>

--- a/CondCore/L1TPlugins/plugins/L1TMuonGlobalParams_PayloadInspector.cc
+++ b/CondCore/L1TPlugins/plugins/L1TMuonGlobalParams_PayloadInspector.cc
@@ -18,7 +18,7 @@
 #include "L1Trigger/L1TMuon/interface/L1TMuonGlobalParamsHelper.h"
 #include "L1Trigger/L1TMuon/interface/L1TMuonGlobalParams_PUBLIC.h"
 
-#include <bitset>
+#include <fmt/format.h>
 
 // include ROOT
 #include "TH1F.h"
@@ -93,13 +93,11 @@ namespace {
         leg.Draw();
         lzero.Draw();
 
-        tl.DrawLatexNDC(
-            0.12,
-            0.85,
-            (fmt::v8::format(
-                 "fwVersion: {}, bx Min, Max: {}, {}", l1tmgph.fwVersion(), payload->bxMin(), payload->bxMax()))
-                .c_str());
-        tl.DrawLatexNDC(0.1, 0.92, (fmt::v8::format("{}, iov: {}", tag.name, IOVsince)).c_str());
+        auto const label_fw =
+            fmt::format("fwVersion: {}, bx Min, Max: {}, {}", l1tmgph.fwVersion(), payload->bxMin(), payload->bxMax());
+        auto const label_tag = fmt::format("{}, iov: {}", tag.name, IOVsince);
+        tl.DrawLatexNDC(0.12, 0.85, label_fw.c_str());
+        tl.DrawLatexNDC(0.10, 0.92, label_tag.c_str());
         tl.DrawLatexNDC(0.07, 0.59, "1");
         tl.DrawLatexNDC(0.07, 0.27, "1");
 

--- a/CondCore/L1TPlugins/test/BuildFile.xml
+++ b/CondCore/L1TPlugins/test/BuildFile.xml
@@ -1,4 +1,5 @@
 <use name="CondCore/Utilities"/>
 <use name="FWCore/PluginManager"/>
+<use name="L1Trigger/L1TMuon"/>
 <bin file="testL1TObjectsPayloadInspector.cpp" name="testL1TObjectsPayloadInspector">
 </bin>

--- a/CondCore/L1TPlugins/test/testL1TObjectsPayloadInspector.cpp
+++ b/CondCore/L1TPlugins/test/testL1TObjectsPayloadInspector.cpp
@@ -2,6 +2,7 @@
 #include <sstream>
 #include "CondCore/Utilities/interface/PayloadInspector.h"
 #include "CondCore/L1TPlugins/plugins/L1TUtmTriggerMenu_PayloadInspector.cc"
+#include "CondCore/L1TPlugins/plugins/L1TMuonGlobalParams_PayloadInspector.cc"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
@@ -59,7 +60,12 @@ int main(int argc, char** argv) {
   test5.process(connectionString, PI::mk_input(tag, start, end, tag2, start, end));
   edm::LogPrint("testL1TObjectsPayloadInspector") << test5.data() << std::endl;
 
-  edm::LogPrint("testL1TObjectsPayloadInspector") << "## Exercising  L1TGlobalPrescalesVetos tests" << std::endl;
+  edm::LogPrint("testL1TObjectsPayloadInspector") << "## Exercising L1TMuonGlobalParams_ tests" << std::endl;
+
+  L1TMuonGlobalParamsInputBits test6;
+  tag = "L1TMuonGlobalParams_Stage2v0_2024_mc_v1";
+  test6.process(connectionString, PI::mk_input(tag, start, end));
+  edm::LogPrint("testL1TObjectsPayloadInspector") << test6.data() << std::endl;
 
   Py_Finalize();
 }

--- a/CondCore/L1TPlugins/test/testL1TPI.sh
+++ b/CondCore/L1TPlugins/test/testL1TPI.sh
@@ -86,3 +86,15 @@ getPayloadData.py \
 
 mv *.png $W_DIR/results/L1TUtmTriggerMenu_CompareConditionsTwoTags.png
 
+####################
+# Test L1TMuonGlobalParams input bits
+####################
+getPayloadData.py \
+    --plugin pluginL1TMuonGlobalParams_PayloadInspector \
+    --plot plot_L1TMuonGlobalParamsInputBits \
+    --tag L1TMuonGlobalParams_Stage2v0_2024_mc_v1 \
+    --time_type Run --iovs '{"start_iov": "1", "end_iov" : "1"}' \
+    --db Prod \
+    --test;
+
+mv *.png $W_DIR/results/L1TMuonGlobalParams_InputBits.png


### PR DESCRIPTION
#### PR description:

As pointed out in https://github.com/cms-sw/cmssw/pull/45438#issuecomment-2293834884, the code implemented with https://github.com/cms-sw/cmssw/pull/45438 had some error that need to be fixed.

#### PR validation:

Relies on the augmented unit tests at `CondCore/L1TPlugins/test/testL1TObjectsPayloadInspector.cpp`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A