### PR TITLE
Fix overloaded-virtual warnings in RecoBTag and RecoVertex

### DIFF
--- a/RecoBTag/SecondaryVertex/interface/CombinedSVSoftLeptonComputer.h
+++ b/RecoBTag/SecondaryVertex/interface/CombinedSVSoftLeptonComputer.h
@@ -25,6 +25,7 @@ public:
 
 private:
   bool SoftLeptonFlip;
+  using CombinedSVComputer::operator();
 };
 
 inline double CombinedSVSoftLeptonComputer::flipSoftLeptonValue(double value) const {

--- a/RecoVertex/VertexTools/interface/Lms3d.h
+++ b/RecoVertex/VertexTools/interface/Lms3d.h
@@ -12,6 +12,9 @@
 class Lms3d : public ModeFinder3d {
 public:
   virtual GlobalPoint operator()(std::vector<GlobalPoint>& values) const;
+
+private:
+  virtual GlobalPoint operator()(const std::vector<PointAndDistance>&) const = 0;
 };
 
 #endif


### PR DESCRIPTION
#### PR description:

Fix compliation warnings emitted in GCC13 IB [1](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el9_amd64_gcc13/CMSSW_14_1_X_2024-08-16-2300/RecoBTag/CTagging), [2](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el9_amd64_gcc13/CMSSW_14_1_X_2024-08-16-2300/RecoBTag/SecondaryVertex), [3](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el9_amd64_gcc13/CMSSW_14_1_X_2024-08-16-2300/RecoVertex/VertexTools):

```
In file included from src/RecoBTag/SecondaryVertex/interface/CombinedSVSoftLeptonComputer.h:12,
                 from src/RecoBTag/CTagging/interface/CharmTagger.h:8,
                 from src/RecoBTag/CTagging/plugins/CTaggerESProducer.cc:5:
  src/RecoBTag/SecondaryVertex/interface/CombinedSVComputer.h:45:37: warning: 'virtual reco::TaggingVariableList CombinedSVComputer::operator()(const reco::CandIPTagInfo&, const reco::CandSecondaryVertexTagInfo&) const' was hidden [-Woverloaded-virtual=]
    45 |   virtual reco::TaggingVariableList operator()(const reco::CandIPTagInfo &ipInfo,
      |                                     ^~~~~~~~
src/RecoBTag/SecondaryVertex/interface/CombinedSVSoftLeptonComputer.h:21:29: note:   by 'CombinedSVSoftLeptonComputer::operator()(const IPTI&, const SVTI&, const reco::CandSoftLeptonTagInfo&, const reco::CandSoftLeptonTagInfo&) const'
   21 |   reco::TaggingVariableList operator()(const IPTI &ipInfo,
      |                             ^~~~~~~~
  src/RecoBTag/SecondaryVertex/interface/CombinedSVComputer.h:43:37: warning: 'virtual reco::TaggingVariableList CombinedSVComputer::operator()(const reco::TrackIPTagInfo&, const reco::SecondaryVertexTagInfo&) const' was hidden [-Woverloaded-virtual=]
    43 |   virtual reco::TaggingVariableList operator()(const reco::TrackIPTagInfo &ipInfo,
      |                                     ^~~~~~~~
src/RecoBTag/SecondaryVertex/interface/CombinedSVSoftLeptonComputer.h:21:29: note:   by 'CombinedSVSoftLeptonComputer::operator()(const IPTI&, const SVTI&, const reco::CandSoftLeptonTagInfo&, const reco::CandSoftLeptonTagInfo&) const'
   21 |   reco::TaggingVariableList operator()(const IPTI &ipInfo,
      |                             ^~~~~~~~
```

```
In file included from src/RecoVertex/VertexTools/interface/Lms3d.h:4,
                 from src/RecoVertex/VertexTools/src/Lms3d.cc:2:
  src/RecoVertex/VertexTools/interface/ModeFinder3d.h:17:23: warning: 'virtual GlobalPoint ModeFinder3d::operator()(const std::vector<std::pair<Point3DBase<float, GlobalTag>, float> >&) const' was hidden [-Woverloaded-virtual=]
    17 |   virtual GlobalPoint operator()(const std::vector<PointAndDistance>&) const = 0;
      |                       ^~~~~~~~
src/RecoVertex/VertexTools/interface/Lms3d.h:14:23: note:   by 'virtual GlobalPoint Lms3d::operator()(std::vector<Point3DBase<float, GlobalTag> >&) const'
   14 |   virtual GlobalPoint operator()(std::vector<GlobalPoint>& values) const;
      |                       ^~~~~~~~```

```

#### PR validation:

Bot tests