### PR TITLE
initialise `phiBinner` in device-to-host copy of `TrackingRecHitsSoACollection<TrackerTraits>`

### DIFF
--- a/DataFormats/TrackingRecHitSoA/interface/alpaka/TrackingRecHitsSoACollection.h
+++ b/DataFormats/TrackingRecHitSoA/interface/alpaka/TrackingRecHitsSoACollection.h
@@ -41,6 +41,16 @@ namespace cms::alpakatools {
       assert(deviceData.nHits() == hostData.nHits());
       assert(deviceData.offsetBPIX2() == hostData.offsetBPIX2());
 #endif
+      // Update the contents address of the phiBinner histo container after the copy from device happened
+      alpaka::wait(queue);
+      typename TrackingRecHitSoA<TrackerTraits>::PhiBinnerView pbv;
+      pbv.assoc = &(hostData.view().phiBinner());
+      pbv.offSize = -1;
+      pbv.offStorage = nullptr;
+      pbv.contentSize = hostData.nHits();
+      pbv.contentStorage = hostData.view().phiBinnerStorage();
+      hostData.view().phiBinner().initStorage(pbv);
+
       return hostData;
     }
   };


### PR DESCRIPTION
#### PR description:

Originally as https://github.com/missirol/cmssw/commit/62620da84d02d0749868ae6281490b461905c8d2.
This PR is meant as a fix for https://github.com/cms-sw/cmssw/issues/45708. 
Fix to the device-to-host copy of `TrackingRecHitsSoACollection<TrackerTraits>`, in order to initialise the `phiBinner` data member on the host side.
A more complete explanation of the issue is provided by @makortel in https://github.com/cms-sw/cmssw/issues/45708#issuecomment-2294166204

#### PR validation:

Executed the following script:

```bash
#!/bin/bash

[ $# -ge 1 ] || exit 1

hltLabel=hlt
outDir="${1}"

[ ! -d "${outDir}" ] || exit 1

mkdir -p "${outDir}"
cd "${outDir}"

hltGetConfiguration /dev/CMSSW_14_0_0/GRun/V173 \
  --globaltag 140X_dataRun3_HLT_v3 \
  --data \
  --no-prescale \
  --output none \
  --max-events -1 \
  --paths MC_*Tracking* \
  --input root://eoscms.cern.ch//eos/cms/store/group/tsg/STEAM/validations/GPUVsCPU/240814/raw_pickevents.root \
  > "${hltLabel}".py

cat <<@EOF >> "${hltLabel}".py
process.options.numberOfThreads = 1
process.options.numberOfStreams = 0
process.options.wantSummary = True

for foo in ['HLTAnalyzerEndpath', 'dqmOutput', 'MessageLogger']:
    if hasattr(process, foo):
        process.__delattr__(foo)

process.load('FWCore.MessageLogger.MessageLogger_cfi')

#process.options.accelerators = ['cpu']

#process.hltEcalDigisSoA.alpaka.backend = 'serial_sync'
#process.hltEcalUncalibRecHitSoA.alpaka.backend = 'serial_sync'
#process.hltHbheRecoSoA.alpaka.backend = 'serial_sync'
#process.hltParticleFlowRecHitHBHESoA.alpaka.backend = 'serial_sync'
#process.hltParticleFlowClusterHBHESoA.alpaka.backend = 'serial_sync'
#process.hltOnlineBeamSpotDevice.alpaka.backend = 'serial_sync'
#process.hltSiPixelClustersSoA.alpaka.backend = 'serial_sync'
#process.hltSiPixelRecHitsSoA.alpaka.backend = 'serial_sync'
process.hltPixelTracksSoA.alpaka.backend = 'serial_sync'
process.hltPixelVerticesSoA.alpaka.backend = 'serial_sync'
@EOF

CUDA_LAUNCH_BLOCKING=1 \
cmsRun "${hltLabel}".py &> "${hltLabel}".log
```

(originally from @missirol  see https://github.com/cms-sw/cmssw/issues/45708#issue-2468792471- thanks!) and verified that with this patch (*N.B.* only after having run `git cms-checkdeps -a` ) it runs, whereas it failed in a plain `CMSSW_14_0_14_MULTIARCHS`.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but to be backported to `CMSSW_14_0_X` in order to use it for building the 2024 HIon HLT menu (see [CMSHLT-3284](https://its.cern.ch/jira/browse/CMSHLT-3284) for more details).  