### PR TITLE
make `AlcaPCCEventProducer` a global module

### DIFF
--- a/Calibration/LumiAlCaRecoProducers/plugins/AlcaPCCEventProducer.cc
+++ b/Calibration/LumiAlCaRecoProducers/plugins/AlcaPCCEventProducer.cc
@@ -1,80 +1,66 @@
 /**_________________________________________________________________
 class:   AlcaPCCEventProducer.cc
 
-
-
 authors: Sam Higginbotham (shigginb@cern.ch), Chris Palmer (capalmer@cern.ch), Attila Radl (attila.radl@cern.ch)
-
 ________________________________________________________________**/
 
 // C++ standard
 #include <string>
 
 // CMS
-#include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/Luminosity/interface/PixelClusterCountsInEvent.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
+#include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/EDGetToken.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 #include "TMath.h"
 
 //The class
-class AlcaPCCEventProducer : public edm::stream::EDProducer<> {
+class AlcaPCCEventProducer : public edm::global::EDProducer<> {
 public:
   explicit AlcaPCCEventProducer(const edm::ParameterSet&);
-  ~AlcaPCCEventProducer() override;
+  ~AlcaPCCEventProducer() override = default;
+  void produce(edm::StreamID id, edm::Event& e, edm::EventSetup const& c) const final;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+  const edm::InputTag pixelClusterLabel_;
+  const std::string trigstring_;  //specifies the trigger Rand or ZeroBias
+  const edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > pixelToken_;
 
-  edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > pixelToken;
-  edm::InputTag fPixelClusterLabel;
-
-  std::string trigstring_;  //specifies the trigger Rand or ZeroBias
-  int countEvt_;            //counter
-  int countLumi_;           //counter
-
-  const int rowsperroc = 52;
-  const int colsperroc = 80;
-  const int nROCcolumns = 8;
-
-  std::unique_ptr<reco::PixelClusterCountsInEvent> thePCCob;
+  static constexpr int rowsperroc = 52;
+  static constexpr int colsperroc = 80;
+  static constexpr int nROCcolumns = 8;
 };
 
 //--------------------------------------------------------------------------------------------------
-AlcaPCCEventProducer::AlcaPCCEventProducer(const edm::ParameterSet& iConfig) {
-  fPixelClusterLabel = iConfig.getParameter<edm::InputTag>("pixelClusterLabel");
-  trigstring_ = iConfig.getUntrackedParameter<std::string>("trigstring", "alcaPCCEvent");
+AlcaPCCEventProducer::AlcaPCCEventProducer(const edm::ParameterSet& iConfig)
+    : pixelClusterLabel_(iConfig.getParameter<edm::InputTag>("pixelClusterLabel")),
+      trigstring_(iConfig.getUntrackedParameter<std::string>("trigstring", "alcaPCCEvent")),
+      pixelToken_(consumes<edmNew::DetSetVector<SiPixelCluster> >(pixelClusterLabel_)) {
   produces<reco::PixelClusterCountsInEvent, edm::Transition::Event>(trigstring_);
-  pixelToken = consumes<edmNew::DetSetVector<SiPixelCluster> >(fPixelClusterLabel);
 }
 
 //--------------------------------------------------------------------------------------------------
-AlcaPCCEventProducer::~AlcaPCCEventProducer() {}
-
-//--------------------------------------------------------------------------------------------------
-void AlcaPCCEventProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  countEvt_++;
-  thePCCob = std::make_unique<reco::PixelClusterCountsInEvent>();
-
+void AlcaPCCEventProducer::produce(edm::StreamID id, edm::Event& iEvent, edm::EventSetup const& iSetup) const {
+  std::unique_ptr<reco::PixelClusterCountsInEvent> thePCCob = std::make_unique<reco::PixelClusterCountsInEvent>();
   unsigned int bx = iEvent.bunchCrossing();
 
   //Looping over the clusters and adding the counts up
   edm::Handle<edmNew::DetSetVector<SiPixelCluster> > hClusterColl;
-  iEvent.getByToken(pixelToken, hClusterColl);
+  iEvent.getByToken(pixelToken_, hClusterColl);
 
   const edmNew::DetSetVector<SiPixelCluster>& clustColl = *(hClusterColl.product());
   // ----------------------------------------------------------------------


### PR DESCRIPTION
#### PR description:

I casually stumbled on this module while looking at resource consumption in the HLT menu. I am wondering if we could make it a `global` module.  I profit of the PR to clean-up a bit the naming of variables and const correctness of data-members.

#### PR validation:

`cmssw` compiles

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A
