### PR TITLE
Use constexpr in Wrapper to simplify the conditional code

### DIFF
--- a/DataFormats/Common/interface/Wrapper.h
+++ b/DataFormats/Common/interface/Wrapper.h
@@ -98,48 +98,56 @@ namespace edm {
 
   template <typename T>
   inline std::type_info const& Wrapper<T>::valueTypeInfo_() const {
-    return detail::getValueType<T>()();
+    return detail::getValueType<T>::get();
   }
 
   template <typename T>
   inline std::type_info const& Wrapper<T>::memberTypeInfo_() const {
-    return detail::getMemberType<T>()();
+    return detail::getMemberType<T>::get();
   }
 
   template <typename T>
   inline bool Wrapper<T>::isMergeable_() const {
-    return detail::getHasMergeFunction<T>()();
+    return detail::has_mergeProduct_function_v<T>;
   }
 
   template <typename T>
   inline bool Wrapper<T>::mergeProduct_(WrapperBase const* newProduct) {
     Wrapper<T> const* wrappedNewProduct = dynamic_cast<Wrapper<T> const*>(newProduct);
     assert(wrappedNewProduct != nullptr);
-    return detail::doMergeProduct<T>()(obj, wrappedNewProduct->obj);
+    if constexpr (detail::has_mergeProduct_function_v<T>) {
+      return obj.mergeProduct(wrappedNewProduct->obj);
+    }
+    return true;
   }
 
   template <typename T>
   inline bool Wrapper<T>::hasIsProductEqual_() const {
-    return detail::getHasIsProductEqual<T>()();
+    return detail::has_isProductEqual_function_v<T>;
   }
 
   template <typename T>
   inline bool Wrapper<T>::isProductEqual_(WrapperBase const* newProduct) const {
     Wrapper<T> const* wrappedNewProduct = dynamic_cast<Wrapper<T> const*>(newProduct);
     assert(wrappedNewProduct != nullptr);
-    return detail::doIsProductEqual<T>()(obj, wrappedNewProduct->obj);
+    if constexpr (detail::has_isProductEqual_function_v<T>) {
+      return obj.isProductEqual(wrappedNewProduct->obj);
+    }
+    return true;
   }
 
   template <typename T>
   inline bool Wrapper<T>::hasSwap_() const {
-    return detail::getHasSwapFunction<T>()();
+    return detail::has_swap_function_v<T>;
   }
 
   template <typename T>
   inline void Wrapper<T>::swapProduct_(WrapperBase* newProduct) {
     Wrapper<T>* wrappedNewProduct = dynamic_cast<Wrapper<T>*>(newProduct);
     assert(wrappedNewProduct != nullptr);
-    detail::doSwapProduct<T>()(obj, wrappedNewProduct->obj);
+    if constexpr (detail::has_swap_function_v<T>) {
+      obj.swap(wrappedNewProduct->obj);
+    }
   }
 
   namespace soa {

--- a/DataFormats/Common/interface/WrapperDetail.h
+++ b/DataFormats/Common/interface/WrapperDetail.h
@@ -37,11 +37,11 @@ namespace edm {
     struct getValueType;
     template <typename T>
     struct getValueType<T, true> {
-      std::type_info const& operator()() { return typeid(typename T::value_type); }
+      static constexpr std::type_info const& get() { return typeid(typename T::value_type); }
     };
     template <typename T>
     struct getValueType<T, false> {
-      std::type_info const& operator()() { return typeid(void); }
+      static constexpr std::type_info const& get() { return typeid(void); }
     };
 
     // memberTypeInfo_() will return typeid(T::member_type) if T::member_type is declared and typeid(void) otherwise.
@@ -59,11 +59,11 @@ namespace edm {
     struct getMemberType;
     template <typename T>
     struct getMemberType<T, true> {
-      std::type_info const& operator()() { return typeid(typename T::member_type); }
+      static constexpr std::type_info const& get() { return typeid(typename T::member_type); }
     };
     template <typename T>
     struct getMemberType<T, false> {
-      std::type_info const& operator()() { return typeid(void); }
+      static constexpr std::type_info const& get() { return typeid(void); }
     };
 
     template <typename T>
@@ -73,7 +73,7 @@ namespace edm {
 
     template <typename T>
     struct getMemberType<std::vector<edm::Ptr<T> >, true> {
-      std::type_info const& operator()() { return typeid(T); }
+      static constexpr std::type_info const& get() { return typeid(T); }
     };
 
     template <typename T, typename Deleter>
@@ -83,7 +83,7 @@ namespace edm {
 
     template <typename T, typename Deleter>
     struct getMemberType<std::vector<std::unique_ptr<T, Deleter> >, true> {
-      std::type_info const& operator()() { return typeid(T); }
+      static constexpr std::type_info const& get() { return typeid(T); }
     };
 
     // bool isMergeable_() will return true if T::mergeProduct(T const&) is declared and false otherwise
@@ -101,28 +101,8 @@ namespace edm {
       static constexpr bool value = std::is_same<decltype(has_mergeProduct<T>(nullptr)), yes_tag>::value;
     };
 
-    template <typename T, bool = has_mergeProduct_function<T>::value>
-    struct getHasMergeFunction;
     template <typename T>
-    struct getHasMergeFunction<T, true> {
-      bool operator()() { return true; }
-    };
-    template <typename T>
-    struct getHasMergeFunction<T, false> {
-      bool operator()() { return false; }
-    };
-    template <typename T, bool = has_mergeProduct_function<T>::value>
-    struct doMergeProduct;
-    template <typename T>
-    struct doMergeProduct<T, true> {
-      bool operator()(T& thisProduct, T const& newProduct) { return thisProduct.mergeProduct(newProduct); }
-    };
-    template <typename T>
-    struct doMergeProduct<T, false> {
-      bool operator()(T& thisProduct, T const& newProduct) {
-        return true;  // Should never be called
-      }
-    };
+    inline constexpr bool has_mergeProduct_function_v = has_mergeProduct_function<T>::value;
 
     // bool hasIsProductEqual_() will return true if T::isProductEqual(T const&) const is declared and false otherwise
     // bool isProductEqual _(WrapperBase const*) will call T::isProductEqual(T const&) if it is defined
@@ -138,29 +118,8 @@ namespace edm {
     struct has_isProductEqual_function {
       static constexpr bool value = std::is_same<decltype(has_isProductEqual<T>(nullptr)), yes_tag>::value;
     };
-
-    template <typename T, bool = has_isProductEqual_function<T>::value>
-    struct getHasIsProductEqual;
     template <typename T>
-    struct getHasIsProductEqual<T, true> {
-      bool operator()() { return true; }
-    };
-    template <typename T>
-    struct getHasIsProductEqual<T, false> {
-      bool operator()() { return false; }
-    };
-    template <typename T, bool = has_isProductEqual_function<T>::value>
-    struct doIsProductEqual;
-    template <typename T>
-    struct doIsProductEqual<T, true> {
-      bool operator()(T const& thisProduct, T const& newProduct) { return thisProduct.isProductEqual(newProduct); }
-    };
-    template <typename T>
-    struct doIsProductEqual<T, false> {
-      bool operator()(T const& thisProduct, T const& newProduct) {
-        return true;  // Should never be called
-      }
-    };
+    inline constexpr bool has_isProductEqual_function_v = has_isProductEqual_function<T>::value;
 
     // bool hasSwap_() will return true if T::swap(T&) is declared and false otherwise
     // void swapProduct_() will call T::swap(T&) if it is defined otherwise it does nothing
@@ -177,28 +136,9 @@ namespace edm {
       static constexpr bool value = std::is_same<decltype(has_swap<T>(nullptr)), yes_tag>::value;
     };
 
-    template <typename T, bool = has_swap_function<T>::value>
-    struct getHasSwapFunction;
     template <typename T>
-    struct getHasSwapFunction<T, true> {
-      bool operator()() { return true; }
-    };
-    template <typename T>
-    struct getHasSwapFunction<T, false> {
-      bool operator()() { return false; }
-    };
-    template <typename T, bool = has_swap_function<T>::value>
-    struct doSwapProduct;
-    template <typename T>
-    struct doSwapProduct<T, true> {
-      void operator()(T& thisProduct, T& newProduct) { thisProduct.swap(newProduct); }
-    };
-    template <typename T>
-    struct doSwapProduct<T, false> {
-      void operator()(T&, T&) {
-        return;  // Should never be called
-      }
-    };
+    inline constexpr bool has_swap_function_v = has_swap_function<T>::value;
+
   }  // namespace detail
 }  // namespace edm
 #endif


### PR DESCRIPTION
#### PR description:

Simplify the use of SFINAE related code for Wrapper by using constexpr to allow removal of some of the classes.

#### PR validation:

Code compiles.