### PR TITLE
change tune names for auto-bkg production

### DIFF
--- a/Configuration/Generator/python/MCTunesRun3ECM13p6TeV/PythiaCP1DownSettings_cfi.py
+++ b/Configuration/Generator/python/MCTunesRun3ECM13p6TeV/PythiaCP1DownSettings_cfi.py
@@ -1,15 +1,15 @@
 import FWCore.ParameterSet.Config as cms
 
-pythia8CP1TuneUpSettingsBlock = cms.PSet(
-    pythia8CP1TuneUpSettings = cms.vstring(
+pythia8CP1DownSettingsBlock = cms.PSet(
+    pythia8CP1DownSettings = cms.vstring(
         'Tune:pp 14',
 	'Tune:ee 7',
 	'MultipartonInteractions:bProfile=2',
         'MultipartonInteractions:ecmPow=0.154',
-        'MultipartonInteractions:pT0Ref=2.3',
-        'MultipartonInteractions:coreRadius=0.5832',
-        'MultipartonInteractions:coreFraction=0.5064',
-        'ColourReconnection:range=8.305',
+        'MultipartonInteractions:pT0Ref=2.4',
+        'MultipartonInteractions:coreRadius=0.5962',
+        'MultipartonInteractions:coreFraction=0.3902',
+        'ColourReconnection:range=8.5'
 	'SigmaTotal:zeroAXB=off',
 	'SpaceShower:rapidityOrder=off',
         'SigmaTotal:mode = 0',

--- a/Configuration/Generator/python/MCTunesRun3ECM13p6TeV/PythiaCP1UpSettings_cfi.py
+++ b/Configuration/Generator/python/MCTunesRun3ECM13p6TeV/PythiaCP1UpSettings_cfi.py
@@ -1,15 +1,15 @@
 import FWCore.ParameterSet.Config as cms
 
-pythia8CP1TuneDownSettingsBlock = cms.PSet(
-    pythia8CP1TuneDownSettings = cms.vstring(
+pythia8CP1UpSettingsBlock = cms.PSet(
+    pythia8CP1UpSettings = cms.vstring(
         'Tune:pp 14',
 	'Tune:ee 7',
 	'MultipartonInteractions:bProfile=2',
         'MultipartonInteractions:ecmPow=0.154',
-        'MultipartonInteractions:pT0Ref=2.4',
-        'MultipartonInteractions:coreRadius=0.5962',
-        'MultipartonInteractions:coreFraction=0.3902',
-        'ColourReconnection:range=8.5'
+        'MultipartonInteractions:pT0Ref=2.3',
+        'MultipartonInteractions:coreRadius=0.5832',
+        'MultipartonInteractions:coreFraction=0.5064',
+        'ColourReconnection:range=8.305',
 	'SigmaTotal:zeroAXB=off',
 	'SpaceShower:rapidityOrder=off',
         'SigmaTotal:mode = 0',

--- a/Configuration/Generator/python/MCTunesRun3ECM13p6TeV/PythiaCP2DownSettings_cfi.py
+++ b/Configuration/Generator/python/MCTunesRun3ECM13p6TeV/PythiaCP2DownSettings_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-pythia8CP2TuneDownSettingsBlock = cms.PSet(
-    pythia8CP2TuneDownSettings = cms.vstring(
+pythia8CP2DownSettingsBlock = cms.PSet(
+    pythia8CP2DownSettings = cms.vstring(
 	'Tune:pp 14',
 	'Tune:ee 7',
 	'MultipartonInteractions:bProfile=2',

--- a/Configuration/Generator/python/MCTunesRun3ECM13p6TeV/PythiaCP2UpSettings_cfi.py
+++ b/Configuration/Generator/python/MCTunesRun3ECM13p6TeV/PythiaCP2UpSettings_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-pythia8CP2TuneUpSettingsBlock = cms.PSet(
-    pythia8CP2TuneUpSettings = cms.vstring(
+pythia8CP2UpSettingsBlock = cms.PSet(
+    pythia8CP2UpSettings = cms.vstring(
 	'Tune:pp 14',
 	'Tune:ee 7',
 	'MultipartonInteractions:bProfile=2',

--- a/Configuration/Generator/python/MCTunesRun3ECM13p6TeV/PythiaCP3DownSettings_cfi.py
+++ b/Configuration/Generator/python/MCTunesRun3ECM13p6TeV/PythiaCP3DownSettings_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-pythia8CP3TuneDownSettingsBlock = cms.PSet(
-    pythia8CP3TuneDownSettings = cms.vstring(
+pythia8CP3DownSettingsBlock = cms.PSet(
+    pythia8CP3DownSettings = cms.vstring(
     'Tune:pp 14',
     'Tune:ee 7',	
     'MultipartonInteractions:bProfile=2',

--- a/Configuration/Generator/python/MCTunesRun3ECM13p6TeV/PythiaCP3UpSettings_cfi.py
+++ b/Configuration/Generator/python/MCTunesRun3ECM13p6TeV/PythiaCP3UpSettings_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-pythia8CP3TuneUpSettingsBlock = cms.PSet(
-    pythia8CP3TuneUpSettings = cms.vstring(
+pythia8CP3UpSettingsBlock = cms.PSet(
+    pythia8CP3UpSettings = cms.vstring(
     'Tune:pp 14',
     'Tune:ee 7',	
     'MultipartonInteractions:bProfile=2',

--- a/Configuration/Generator/python/MCTunesRun3ECM13p6TeV/PythiaCP4DownSettings_cfi.py
+++ b/Configuration/Generator/python/MCTunesRun3ECM13p6TeV/PythiaCP4DownSettings_cfi.py
@@ -1,15 +1,15 @@
 import FWCore.ParameterSet.Config as cms
 
-pythia8CP4TuneUpSettingsBlock = cms.PSet(
-    pythia8CP4TuneUpSettings = cms.vstring(
+pythia8CP4DownSettingsBlock = cms.PSet(
+    pythia8CP4DownSettings = cms.vstring(
     'Tune:pp 14',
     'Tune:ee 7',
     'MultipartonInteractions:bProfile=2',
-    'MultipartonInteractions:pT0Ref=1.482',
+    'MultipartonInteractions:pT0Ref=1.538',
     'MultipartonInteractions:ecmPow=0.02012',
-    'MultipartonInteractions:coreFraction=0.3598',
-    'MultipartonInteractions:coreRadius=0.5752',
-    'ColourReconnection:range=7.93',
+    'MultipartonInteractions:coreFraction=0.3266',
+    'MultipartonInteractions:coreRadius=0.5718',
+    'ColourReconnection:range=6.881',
     'SigmaTotal:zeroAXB=off', 
     'SpaceShower:alphaSorder=2',
     'SpaceShower:alphaSvalue=0.118',

--- a/Configuration/Generator/python/MCTunesRun3ECM13p6TeV/PythiaCP4UpSettings_cfi.py
+++ b/Configuration/Generator/python/MCTunesRun3ECM13p6TeV/PythiaCP4UpSettings_cfi.py
@@ -1,15 +1,15 @@
 import FWCore.ParameterSet.Config as cms
 
-pythia8CP4TuneDownSettingsBlock = cms.PSet(
-    pythia8CP4TuneDownSettings = cms.vstring(
+pythia8CP4UpSettingsBlock = cms.PSet(
+    pythia8CP4UpSettings = cms.vstring(
     'Tune:pp 14',
     'Tune:ee 7',
     'MultipartonInteractions:bProfile=2',
-    'MultipartonInteractions:pT0Ref=1.538',
+    'MultipartonInteractions:pT0Ref=1.482',
     'MultipartonInteractions:ecmPow=0.02012',
-    'MultipartonInteractions:coreFraction=0.3266',
-    'MultipartonInteractions:coreRadius=0.5718',
-    'ColourReconnection:range=6.881',
+    'MultipartonInteractions:coreFraction=0.3598',
+    'MultipartonInteractions:coreRadius=0.5752',
+    'ColourReconnection:range=7.93',
     'SigmaTotal:zeroAXB=off', 
     'SpaceShower:alphaSorder=2',
     'SpaceShower:alphaSvalue=0.118',

--- a/Configuration/Generator/python/MCTunesRun3ECM13p6TeV/PythiaCP5CR1Settings_cfi.py
+++ b/Configuration/Generator/python/MCTunesRun3ECM13p6TeV/PythiaCP5CR1Settings_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-pythia8CP5CR1TuneSettingsBlock = cms.PSet(
-    pythia8CP5CR1TuneSettings = cms.vstring(
+pythia8CP5CR1SettingsBlock = cms.PSet(
+    pythia8CP5CR1Settings = cms.vstring(
 	'Tune:pp 14',
 	'Tune:ee 7',
 	'MultipartonInteractions:alphaSvalue=0.118',

--- a/Configuration/Generator/python/MCTunesRun3ECM13p6TeV/PythiaCP5CR2Settings_cfi.py
+++ b/Configuration/Generator/python/MCTunesRun3ECM13p6TeV/PythiaCP5CR2Settings_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-pythia8CP5CR2TuneSettingsBlock = cms.PSet(
-    pythia8CP5CR2TuneSettings = cms.vstring(
+pythia8CP5CR2SettingsBlock = cms.PSet(
+    pythia8CP5CR2Settings = cms.vstring(
 	'Tune:pp 14',
 	'Tune:ee 7',
 	'MultipartonInteractions:bProfile=2',

--- a/Configuration/Generator/python/MCTunesRun3ECM13p6TeV/PythiaCP5DownSettings_cfi.py
+++ b/Configuration/Generator/python/MCTunesRun3ECM13p6TeV/PythiaCP5DownSettings_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-pythia8CP5TuneDownSettingsBlock = cms.PSet(
-    pythia8CP5TuneDownSettings = cms.vstring(
+pythia8CP5DownSettingsBlock = cms.PSet(
+    pythia8CP5DownSettings = cms.vstring(
     'Tune:pp 14',
         'Tune:ee 7',
         'MultipartonInteractions:ecmPow=0.03344',

--- a/Configuration/Generator/python/MCTunesRun3ECM13p6TeV/PythiaCP5UpSettings_cfi.py
+++ b/Configuration/Generator/python/MCTunesRun3ECM13p6TeV/PythiaCP5UpSettings_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-pythia8CP5TuneUpSettingsBlock = cms.PSet(
-    pythia8CP5TuneUpSettings = cms.vstring(
+pythia8CP5UpSettingsBlock = cms.PSet(
+    pythia8CP5UpSettings = cms.vstring(
     'Tune:pp 14',
         'Tune:ee 7',
         'MultipartonInteractions:ecmPow=0.03344',


### PR DESCRIPTION
#### PR description:

Nothing changes except the names for underlying event tune variations, e.g. changing `CP5TuneUp` to `CP5Up`.

Continuation of two previous old PRs
https://github.com/cms-sw/cmssw/pull/38502
https://github.com/cms-sw/cmssw/pull/38358

#### PR validation:

I don't think there is any runthematrix/relval relevant tests available in the list [1] (there is no `CP5Up` or `CP5Down` in the workflows).
[1] https://github.com/cms-sw/cmssw/blob/master/Configuration/PyReleaseValidation/python/relval_extendedgen.py

Later once we have 22 & 23 rereco campaigns and 24 production campaign fully set up, it needs to be backported.

@agrohsje @cvico @sunilUIET @menglu21 @lviliani @bbilin @DickyChant