### PR TITLE
Use C++ concepts in Token classes

### DIFF
--- a/FWCore/Utilities/interface/EDGetToken.h
+++ b/FWCore/Utilities/interface/EDGetToken.h
@@ -81,9 +81,11 @@ namespace edm {
     constexpr EDGetTokenT& operator=(EDGetTokenT<T>&&) noexcept = default;
 
     template <typename ADAPTER>
+      requires requires(ADAPTER&& a) { a.template consumes<T>(); }
     constexpr explicit EDGetTokenT(ADAPTER&& iAdapter) : EDGetTokenT(iAdapter.template consumes<T>()) {}
 
     template <typename ADAPTER>
+      requires requires(ADAPTER&& a) { a.template consumes<T>(); }
     constexpr EDGetTokenT& operator=(ADAPTER&& iAdapter) {
       EDGetTokenT<T> temp(iAdapter.template consumes<T>());
       m_value = temp.m_value;
@@ -91,14 +93,6 @@ namespace edm {
       return *this;
     }
 
-    //Needed to avoid EDGetTokenT(ADAPTER&&) from being called instead
-    // when we can use C++20 concepts we can avoid the problem using a constraint
-    constexpr EDGetTokenT(EDGetTokenT<T>& iOther) noexcept : m_value{iOther.m_value} {}
-    constexpr EDGetTokenT(const EDGetTokenT<T>&& iOther) noexcept : m_value{iOther.m_value} {}
-
-    constexpr EDGetTokenT& operator=(EDGetTokenT<T>& iOther) {
-      return (*this = const_cast<const EDGetTokenT<T>&>(iOther));
-    }
     // ---------- const member functions ---------------------
     constexpr unsigned int index() const noexcept { return m_value; }
     constexpr bool isUninitialized() const noexcept { return m_value == s_uninitializedValue; }

--- a/FWCore/Utilities/interface/EDPutToken.h
+++ b/FWCore/Utilities/interface/EDPutToken.h
@@ -75,19 +75,16 @@ namespace edm {
 
     constexpr EDPutTokenT(const EDPutTokenT<T>&) noexcept = default;
     constexpr EDPutTokenT(EDPutTokenT<T>&&) noexcept = default;
-    constexpr EDPutTokenT(EDPutTokenT<T>& iToken) noexcept : EDPutTokenT(const_cast<EDPutTokenT<T> const&>(iToken)) {}
 
     template <typename ADAPTER>
+      requires requires(ADAPTER&& a) { a.template produces<T>(); }
     constexpr explicit EDPutTokenT(ADAPTER&& iAdapter) noexcept : EDPutTokenT(iAdapter.template produces<T>()) {}
 
     constexpr EDPutTokenT& operator=(const EDPutTokenT<T>&) noexcept = default;
     constexpr EDPutTokenT& operator=(EDPutTokenT<T>&&) noexcept = default;
-    constexpr EDPutTokenT& operator=(EDPutTokenT<T>& iOther) noexcept {
-      m_value = iOther.m_value;
-      return *this;
-    }
 
     template <typename ADAPTER>
+      requires requires(ADAPTER&& a) { a.template produces<T>(); }
     constexpr EDPutTokenT& operator=(ADAPTER&& iAdapter) noexcept {
       EDPutTokenT<T> temp(iAdapter.template produces<T>());
       m_value = temp.m_value;

--- a/FWCore/Utilities/interface/ESGetToken.h
+++ b/FWCore/Utilities/interface/ESGetToken.h
@@ -49,23 +49,14 @@ namespace edm {
     constexpr ESGetToken<ESProduct, ESRecord>& operator=(ESGetToken<ESProduct, ESRecord> const&) noexcept = default;
 
     template <typename ADAPTER>
+      requires requires(ADAPTER&& a) { a.template consumes<ESProduct, ESRecord>(); }
     constexpr explicit ESGetToken(ADAPTER&& iAdapter) : ESGetToken(iAdapter.template consumes<ESProduct, ESRecord>()) {}
 
     template <typename ADAPTER>
+      requires requires(ADAPTER&& a) { a.template consumes<ESProduct, ESRecord>(); }
     constexpr ESGetToken<ESProduct, ESRecord>& operator=(ADAPTER&& iAdapter) {
       ESGetToken<ESProduct, ESRecord> temp(std::forward<ADAPTER>(iAdapter));
       return (*this = std::move(temp));
-    }
-
-    //protect against templated version being a better match
-    constexpr ESGetToken(ESGetToken<ESProduct, ESRecord>& iOther)
-        : ESGetToken(const_cast<const ESGetToken<ESProduct, ESRecord>&>(iOther)) {}
-    constexpr ESGetToken<ESProduct, ESRecord>& operator=(ESGetToken<ESProduct, ESRecord>& iOther) noexcept {
-      return (*this = const_cast<ESGetToken<ESProduct, ESRecord> const&>(iOther));
-    }
-    constexpr ESGetToken(ESGetToken<ESProduct, ESRecord> const&& iOther) : ESGetToken(iOther) {}
-    constexpr ESGetToken<ESProduct, ESRecord>& operator=(ESGetToken<ESProduct, ESRecord> const&& iOther) noexcept {
-      return (*this = iOther);
     }
 
     constexpr unsigned int transitionID() const noexcept { return m_transitionID; }


### PR DESCRIPTION
#### PR description:

The use of concepts allows the default copy/operator= methods to properly handle non-const arguments without having the template being a better match.

#### PR validation:

Code compiles.