### PR TITLE
[PY312] Fix SyntaxWarning in conddb

### DIFF
--- a/CondCore/Utilities/scripts/conddb
+++ b/CondCore/Utilities/scripts/conddb
@@ -411,7 +411,7 @@ def _strip_colors(args, string):
     if args.nocolors:
         return string
 
-    return re.sub('\x1b\\[[;\d]*[A-Za-z]', '', string)
+    return re.sub('\x1b\\[[;\\d]*[A-Za-z]', '', string)
 
 
 def _ljust_colors(args, string, width, fillchar=' '):

--- a/CondCore/Utilities/scripts/conddb
+++ b/CondCore/Utilities/scripts/conddb
@@ -411,7 +411,7 @@ def _strip_colors(args, string):
     if args.nocolors:
         return string
 
-    return re.sub('\x1b\[[;\d]*[A-Za-z]', '', string)
+    return re.sub('\x1b\\[[;\d]*[A-Za-z]', '', string)
 
 
 def _ljust_colors(args, string, width, fillchar=' '):


### PR DESCRIPTION
#### PR description:

Python 3.12 emits warnings about invalid escape sequences. This PR fixes it. The code is valid for older Python versions as well.

#### PR validation:

Bot tests