### PR TITLE
Add ECAL DCC desync DQM trend plots and update the DQM threshold for Integrity summary

### DIFF
--- a/DQM/EcalMonitorClient/python/IntegrityClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/IntegrityClient_cfi.py
@@ -27,7 +27,7 @@ ecalIntegrityClient = cms.untracked.PSet(
             kind = cms.untracked.string('TH2F'),
             otype = cms.untracked.string('Ecal3P'),
             btype = cms.untracked.string('Crystal'),
-            description = cms.untracked.string('Summary of the data integrity. A channel is red if more than ' + str(errFractionThreshold) + ' of its entries have integrity errors.')
+            description = cms.untracked.string('Summary of the data integrity. A channel is red if more than ' + str(errFractionThreshold) + ' of its entries have integrity errors. Also, an entire SuperModule can show red if more than 0.01 of its entries have DCC-SRP or DCC-TCC Desync errors.')
         ),
         Quality = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sIntegrityClient/%(prefix)sIT data integrity quality %(sm)s'),

--- a/DQM/EcalMonitorClient/src/IntegrityClient.cc
+++ b/DQM/EcalMonitorClient/src/IntegrityClient.cc
@@ -123,15 +123,20 @@ namespace ecaldqm {
       }
     }
 
-    // Quality check: set an entire FED to BAD if "any" DCC-SRP or DCC-TCC mismatch errors are detected
+    // Quality check: set an entire FED to BAD if "any" DCC-SRP or DCC-TCC mismatch errors are detected AND the number of events affected by the DCC-SRP or DCC-TCC mismatch errors is more than 1% of the events analyzed in the run
     // Fill mismatch statistics
     MESet const& sBXSRP(sources_.at("BXSRP"));
     MESet const& sBXTCC(sources_.at("BXTCC"));
     std::vector<bool> hasMismatchDCC(nDCC, false);
     for (unsigned iDCC(0); iDCC < nDCC; ++iDCC) {
-      if (sBXSRP.getBinContent(getEcalDQMSetupObjects(), iDCC + 1) > 50. ||
-          sBXTCC.getBinContent(getEcalDQMSetupObjects(), iDCC + 1) > 50.)  // "any" => 50
-        hasMismatchDCC[iDCC] = true;
+      int nBXSRPdesync = sBXSRP.getBinContent(getEcalDQMSetupObjects(), iDCC + 1);
+      int nBXTCCdesync = sBXTCC.getBinContent(getEcalDQMSetupObjects(), iDCC + 1);
+
+      if (nBXSRPdesync > 50. || nBXTCCdesync > 50.)  { // "any" => 50
+        if (nBXSRPdesync > int(0.01 * processedEvents) || nBXTCCdesync > int(0.01 * processedEvents)) { // check if the events with DCC-SRP or DCC-TCC desyncs for the given DCC is more than 1% of the events analyzed
+          hasMismatchDCC[iDCC] = true;
+        }
+      }
     }
     // Analyze mismatch statistics
     for (MESet::iterator qsItr(meQualitySummary.beginChannel(GetElectronicsMap()));

--- a/DQM/EcalMonitorTasks/python/RawDataTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/RawDataTask_cfi.py
@@ -49,6 +49,34 @@ statuses = [
 
 ecalRawDataTask = cms.untracked.PSet(
     MEs = cms.untracked.PSet(
+        TrendBXTCC = cms.untracked.PSet(
+            path = cms.untracked.string('Ecal/Trends/RawDataTask number of %(prefix)sRDT bunch crossing TCC errors'),
+            kind = cms.untracked.string('TH1F'),
+            otype = cms.untracked.string('Ecal2P'),
+            btype = cms.untracked.string('Trend'),
+            description = cms.untracked.string('Trend of the number of bunch crossing value mismatches between DCC and TCC.')
+        ),
+        TrendL1ATCC = cms.untracked.PSet(
+            path = cms.untracked.string('Ecal/Trends/RawDataTask number of %(prefix)sRDT L1A TCC errors'),
+            kind = cms.untracked.string('TH1F'),
+            otype = cms.untracked.string('Ecal2P'),
+            btype = cms.untracked.string('Trend'),
+            description = cms.untracked.string('Trend of the number of L1A value mismatches between DCC and TCC.')
+        ),
+        TrendBXSRP = cms.untracked.PSet(
+            path = cms.untracked.string('Ecal/Trends/RawDataTask number of %(prefix)sRDT bunch crossing SRP errors'),
+            kind = cms.untracked.string('TH1F'),
+            otype = cms.untracked.string('Ecal2P'),
+            btype = cms.untracked.string('Trend'),
+            description = cms.untracked.string('Trend of the number of bunch crossing value mismatches between DCC and SRP.')
+        ),
+        TrendL1ASRP = cms.untracked.PSet(
+            path = cms.untracked.string('Ecal/Trends/RawDataTask number of %(prefix)sRDT L1A SRP errors'),
+            kind = cms.untracked.string('TH1F'),
+            otype = cms.untracked.string('Ecal2P'),
+            btype = cms.untracked.string('Trend'),
+            description = cms.untracked.string('Trend of the number of L1A value mismatches between DCC and SRP.')
+        ),
         BXSRP = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sRawDataTask/%(prefix)sRDT bunch crossing SRP errors'),
             kind = cms.untracked.string('TH1F'),

--- a/DQM/EcalMonitorTasks/src/RawDataTask.cc
+++ b/DQM/EcalMonitorTasks/src/RawDataTask.cc
@@ -88,6 +88,10 @@ namespace ecaldqm {
     MESet& meBXSRP(MEs_.at("BXSRP"));
     MESet& meL1ASRP(MEs_.at("L1ASRP"));
     MESet& meTrendNSyncErrors(MEs_.at("L1ATCC"));
+    MESet& meTrendBXTCC(MEs_.at("TrendBXTCC"));
+    MESet& meTrendL1ATCC(MEs_.at("TrendL1ATCC"));
+    MESet& meTrendBXSRP(MEs_.at("TrendBXSRP"));
+    MESet& meTrendL1ASRP(MEs_.at("TrendL1ASRP"));
     MESet& meEventTypePreCalib(MEs_.at("EventTypePreCalib"));
     MESet& meEventTypeCalib(MEs_.at("EventTypeCalib"));
     MESet& meEventTypePostCalib(MEs_.at("EventTypePostCalib"));
@@ -214,29 +218,53 @@ namespace ecaldqm {
       if (tccBx.size() == 4) {  // EB uses tccBx[0]; EE uses all
         if (dccId <= kEEmHigh + 1 || dccId >= kEEpLow + 1) {
           for (int iTCC(0); iTCC < 4; iTCC++) {
-            if (tccBx[iTCC] != dccBX && tccBx[iTCC] != -1 && dccBX != -1)
+            if (tccBx[iTCC] != dccBX && tccBx[iTCC] != -1 && dccBX != -1) {
               meBXTCC.fill(getEcalDQMSetupObjects(), dccId);
+              meTrendBXTCC.fill(getEcalDQMSetupObjects(), EcalEndcap, double(timestamp_.iLumi), 1);
+            }
 
-            if (tccL1[iTCC] != dccL1AShort && tccL1[iTCC] != -1 && dccL1AShort != 0)
+            if (tccL1[iTCC] != dccL1AShort && tccL1[iTCC] != -1 && dccL1AShort != 0) {
               meL1ATCC.fill(getEcalDQMSetupObjects(), dccId);
+              meTrendL1ATCC.fill(getEcalDQMSetupObjects(), EcalEndcap, double(timestamp_.iLumi), 1);
+            }
           }
         } else {
-          if (tccBx[0] != dccBX && tccBx[0] != -1 && dccBX != -1)
+          if (tccBx[0] != dccBX && tccBx[0] != -1 && dccBX != -1) {
             meBXTCC.fill(getEcalDQMSetupObjects(), dccId);
+            meTrendBXTCC.fill(getEcalDQMSetupObjects(), EcalBarrel, double(timestamp_.iLumi), 1);
+          }
 
-          if (tccL1[0] != dccL1AShort && tccL1[0] != -1 && dccL1AShort != 0)
+          if (tccL1[0] != dccL1AShort && tccL1[0] != -1 && dccL1AShort != 0) {
             meL1ATCC.fill(getEcalDQMSetupObjects(), dccId);
+            meTrendL1ATCC.fill(getEcalDQMSetupObjects(), EcalBarrel, double(timestamp_.iLumi), 1);
+          }
         }
       }
 
       short srpBx(dcchItr->getSRPBx());
       short srpL1(dcchItr->getSRPLv1());
 
-      if (srpBx != dccBX && srpBx != -1 && dccBX != -1)
+      if (srpBx != dccBX && srpBx != -1 && dccBX != -1) {
         meBXSRP.fill(getEcalDQMSetupObjects(), dccId);
 
-      if (srpL1 != dccL1AShort && srpL1 != -1 && dccL1AShort != 0)
+        if (dccId <= kEEmHigh + 1 || dccId >= kEEpLow + 1) { // EE
+          meTrendBXSRP.fill(getEcalDQMSetupObjects(), EcalEndcap, double(timestamp_.iLumi), 1);
+        }
+        else { // EB
+          meTrendBXSRP.fill(getEcalDQMSetupObjects(), EcalBarrel, double(timestamp_.iLumi), 1);
+        }
+      }
+
+      if (srpL1 != dccL1AShort && srpL1 != -1 && dccL1AShort != 0) {
         meL1ASRP.fill(getEcalDQMSetupObjects(), dccId);
+
+        if (dccId <= kEEmHigh + 1 || dccId >= kEEpLow + 1) { // EE
+          meTrendL1ASRP.fill(getEcalDQMSetupObjects(), EcalEndcap, double(timestamp_.iLumi), 1);
+        }
+        else { // EB
+          meTrendL1ASRP.fill(getEcalDQMSetupObjects(), EcalBarrel, double(timestamp_.iLumi), 1);
+        }
+      }
 
       const int calibBX(3490);
 


### PR DESCRIPTION
#### PR description:

This PR includes two changes related to ECAL DQM:
[1] Adding the ECAL DQM plots for the trend of DCC-SRP and DCC-TCC desync in ECAL DQM (in `Layout/01 Raw Data` and `Layout/11 Trend`).
[2] Update the DQM threshold for the integrity summary for ECAL supermodule, such that if more than 1% of the supermodule has DCC-SRP or DCC-TCC desync errors it is flagged as bad (previous threshold: more than 50 desync errors).

#### PR validation:

PR is validated by running the ECAL online DQM configuration and verifying the plots on a test DQM GUI.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is a Master PR. Backports are made to `14_0_13` in the PR #45761. 
