### PR TITLE
fix a bunch of failing unit tests after D88 and D92 went missing

### DIFF
--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/defaultInputFiles_cff.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/defaultInputFiles_cff.py
@@ -23,11 +23,11 @@ filesDefaultMC_MinBiasPUPhase2 = cms.untracked.vstring(
 filesDefaultMC_DoubleMuonPUPhase_string = '/store/mc/Phase2Fall22DRMiniAOD/DYJetsToMuMu_M-50_TuneCP5_14TeV-madgraphMLM-pythia8/ALCARECO/TkAlZMuMu-PU200ALCA_TkAlPU200_125X_mcRun4_realistic_v5-v1/60000/9382696c-70fd-4b37-8a0f-24bd02aeda5f.root'
 
 filesDefaultMC_MinBiasPUPhase2RECO = cms.untracked.vstring(
-    '/store/relval/CMSSW_12_5_3/RelValMinBias_14TeV/GEN-SIM-RECO/125X_mcRun4_realistic_v5_2026D88PU-v1/2590000/22e22ae6-a353-4f2e-815e-cc5efee37af9.root',
+    '/store/relval/CMSSW_14_1_0_pre6/RelValMinBias_14TeV/GEN-SIM-RECO/PU_141X_mcRun4_realistic_v1_STD_2026D110_PU-v3/2560000/c22f1cbd-50e3-458e-aba9-b0a327e4c971.root'
 )
 
 filesDefaultMC_TTbarPhase2RECO = cms.untracked.vstring(
-    '/store/relval/CMSSW_12_6_0_pre5/RelValTTbar_14TeV/GEN-SIM-RECO/125X_mcRun4_realistic_v5_2026D88noPU-v1/2590000/57cbe250-487d-4a47-998b-48f9028a0058.root',
+    '/store/relval/CMSSW_14_1_0_pre5/RelValTTbar_14TeV/GEN-SIM-RECO/140X_mcRun4_realistic_v4_STD_2026D110_noPU-v1/2580000/b8c9ef5e-9c45-4c47-aae3-4db1304cd66e.root',
 )
 
 filesDefaultData_JetHTRun2018D = cms.untracked.vstring(

--- a/Alignment/OfflineValidation/test/testPrimaryVertexRelatedValidations_cfg.py
+++ b/Alignment/OfflineValidation/test/testPrimaryVertexRelatedValidations_cfg.py
@@ -34,11 +34,16 @@ _theRefitter = RefitType.COMMON # RefitType.STANDARD (other option not involving
 _theTrackCollection = 'generalTracks' # FIXME: 'ALCARECOTkAlMinBias' once a sample is available
 
 ###################################################################
+# Set default phase-2 settings
+###################################################################
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
+
+###################################################################
 # Set the era
 ###################################################################
 if(options.isPhase2):
-     from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
-     process = cms.Process("Demo",Phase2C17I13M9) 
+     process = cms.Process("Demo", _PH2_ERA)
 else:
      from Configuration.Eras.Era_Run3_cff import Run3
      process = cms.Process("Demo", Run3)
@@ -118,7 +123,7 @@ process.load("RecoVertex.BeamSpotProducer.BeamSpot_cff")
 ####################################################################
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, ('auto:phase2_realistic_T33' if options.isPhase2 else 'auto:phase1_2022_realistic'), '')
+process.GlobalTag = GlobalTag(process.GlobalTag, (_PH2_GLOBAL_TAG if options.isPhase2 else 'auto:phase1_2022_realistic'), '')
 
 if _allFromGT:
      print("############ testPVValidation_cfg.py: msg%-i: All is taken from GT")

--- a/Alignment/OfflineValidation/test/testPrimaryVertexRelatedValidations_cfg.py
+++ b/Alignment/OfflineValidation/test/testPrimaryVertexRelatedValidations_cfg.py
@@ -104,7 +104,7 @@ process.load('Configuration.StandardSequences.MagneticField_cff')
 # Standard loads
 ###################################################################
 if(options.isPhase2):
-     process.load('Configuration.Geometry.GeometryExtended2026D88Reco_cff')
+     process.load('Configuration.Geometry.GeometryExtended2026DefaultReco_cff')
 else:
      process.load("Configuration.Geometry.GeometryRecoDB_cff")
 
@@ -118,7 +118,7 @@ process.load("RecoVertex.BeamSpotProducer.BeamSpot_cff")
 ####################################################################
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, ('auto:phase2_realistic_T21' if options.isPhase2 else 'auto:phase1_2022_realistic'), '')
+process.GlobalTag = GlobalTag(process.GlobalTag, ('auto:phase2_realistic_T33' if options.isPhase2 else 'auto:phase1_2022_realistic'), '')
 
 if _allFromGT:
      print("############ testPVValidation_cfg.py: msg%-i: All is taken from GT")

--- a/Alignment/TrackerAlignment/test/Misalignments/createRandomlyMisalignedGeometry_Phase2_cfg.py
+++ b/Alignment/TrackerAlignment/test/Misalignments/createRandomlyMisalignedGeometry_Phase2_cfg.py
@@ -46,7 +46,7 @@ process.MessageLogger.cout = cms.untracked.PSet(
 ###################################################################
 # Ideal geometry producer and standard includes
 ###################################################################
-process.load('Configuration.Geometry.GeometryExtended2026D88Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2026DefaultReco_cff')
 process.trackerGeometry.applyAlignment = True
 
 ###################################################################
@@ -54,7 +54,7 @@ process.trackerGeometry.applyAlignment = True
 ###################################################################
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T21', '') # using realistic Phase 2 geom
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T33', '') # using realistic Phase 2 geom
 print("Using global tag:", process.GlobalTag.globaltag.value())
 
 ###################################################################

--- a/Alignment/TrackerAlignment/test/Misalignments/createRandomlyMisalignedGeometry_Phase2_cfg.py
+++ b/Alignment/TrackerAlignment/test/Misalignments/createRandomlyMisalignedGeometry_Phase2_cfg.py
@@ -3,7 +3,9 @@ import FWCore.ParameterSet.Config as cms
 import FWCore.ParameterSet.VarParsing as VarParsing
 import copy, sys, os
 
-process = cms.Process("Misaligner")
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+GLOBAL_TAG, ERA = _settings.get_era_and_conditions("2026D107")  # this should really be _settings.DEFAULT_VERSION :(
+process = cms.Process("Misaligner", ERA)
 
 ###################################################################
 # Setup 'standard' options
@@ -46,7 +48,7 @@ process.MessageLogger.cout = cms.untracked.PSet(
 ###################################################################
 # Ideal geometry producer and standard includes
 ###################################################################
-process.load('Configuration.Geometry.GeometryExtended2026DefaultReco_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D107Reco_cff')
 process.trackerGeometry.applyAlignment = True
 
 ###################################################################
@@ -54,7 +56,8 @@ process.trackerGeometry.applyAlignment = True
 ###################################################################
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T33', '') # using realistic Phase 2 geom
+#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T25', '') # using realistic Phase 2 geom
+process.GlobalTag = GlobalTag(process.GlobalTag, GLOBAL_TAG, '') # using realistic Phase 2 geom
 print("Using global tag:", process.GlobalTag.globaltag.value())
 
 ###################################################################

--- a/CondTools/SiPhase2Tracker/test/SiPhase2BadStripChannelBuilder_cfg.py
+++ b/CondTools/SiPhase2Tracker/test/SiPhase2BadStripChannelBuilder_cfg.py
@@ -17,13 +17,13 @@ process.RandomNumberGeneratorService.prod = cms.PSet(
     engineName = cms.untracked.string('TRandom3')
 )
 
-## specify detector D88, as the geometry is needed (will take tracker T24)
-process.load("Configuration.Geometry.GeometryExtended2026D88_cff")
-process.load('Configuration.Geometry.GeometryExtended2026D88Reco_cff')
+## specify detector D110, as the geometry is needed (will take tracker T35)
+process.load("Configuration.Geometry.GeometryExtended2026Default_cff")
+process.load('Configuration.Geometry.GeometryExtended2026DefaultReco_cff')
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T21', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T33', '')
 
 ###################################################################
 # Messages
@@ -61,10 +61,10 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
         authenticationPath = cms.untracked.string('')
     ),
     timetype = cms.untracked.string('runnumber'),
-    connect = cms.string('sqlite_file:SiStripBadStripPhase2_T21_v0.db'),
+    connect = cms.string('sqlite_file:SiStripBadStripPhase2_T33_v0.db'),
     toPut = cms.VPSet(cms.PSet(
         record = cms.string('SiStripBadStripRcd'),
-        tag = cms.string('SiStripBadStripPhase2_T21')
+        tag = cms.string('SiStripBadStripPhase2_T33')
     ))
 )
 

--- a/CondTools/SiPhase2Tracker/test/SiPhase2BadStripChannelBuilder_cfg.py
+++ b/CondTools/SiPhase2Tracker/test/SiPhase2BadStripChannelBuilder_cfg.py
@@ -1,6 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("ICALIB")
+###################################################################
+# Set default phase-2 settings
+###################################################################
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
+
+process = cms.Process("ICALIB", _PH2_ERA)
 import FWCore.ParameterSet.VarParsing as VarParsing
 
 options = VarParsing.VarParsing('analysis')
@@ -17,13 +23,13 @@ process.RandomNumberGeneratorService.prod = cms.PSet(
     engineName = cms.untracked.string('TRandom3')
 )
 
-## specify detector D110, as the geometry is needed (will take tracker T35)
+## specify the default phase2 detector
 process.load("Configuration.Geometry.GeometryExtended2026Default_cff")
 process.load('Configuration.Geometry.GeometryExtended2026DefaultReco_cff')
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T33', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, _PH2_GLOBAL_TAG, '')
 
 ###################################################################
 # Messages

--- a/CondTools/SiPhase2Tracker/test/SiPhase2BadStripChannelReader_cfg.py
+++ b/CondTools/SiPhase2Tracker/test/SiPhase2BadStripChannelReader_cfg.py
@@ -3,7 +3,13 @@
 import FWCore.ParameterSet.Config as cms
 import FWCore.ParameterSet.VarParsing as VarParsing
 
-process = cms.Process("TEST")
+###################################################################
+# Set default phase-2 settings
+###################################################################
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
+
+process = cms.Process("TEST", _PH2_ERA)
 options = VarParsing.VarParsing('analysis')
 options.register('fromESSource',
                  False, # default value
@@ -52,7 +58,7 @@ if(options.fromESSource):
     process.load('Configuration.Geometry.GeometryExtended2026DefaultReco_cff')
     process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
     from Configuration.AlCa.GlobalTag import GlobalTag
-    process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T33', '')
+    process.GlobalTag = GlobalTag(process.GlobalTag, _PH2_GLOBAL_TAG, '')
     #process.load("SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff") # already included
     #process.SiPhase2OTFakeBadStripsESSource.printDebug = cms.untracked.bool(True)    # this makes it verbose 
     process.SiPhase2OTFakeBadStripsESSource.badComponentsFraction = cms.double(0.05)   # bad components fraction is 5%

--- a/CondTools/SiPhase2Tracker/test/SiPhase2BadStripChannelReader_cfg.py
+++ b/CondTools/SiPhase2Tracker/test/SiPhase2BadStripChannelReader_cfg.py
@@ -48,16 +48,16 @@ process.source = cms.Source("EmptyIOVSource",
 # Input data
 ###################################################################
 if(options.fromESSource): 
-    process.load("Configuration.Geometry.GeometryExtended2026D88_cff")
-    process.load('Configuration.Geometry.GeometryExtended2026D88Reco_cff')
+    process.load("Configuration.Geometry.GeometryExtended2026Default_cff")
+    process.load('Configuration.Geometry.GeometryExtended2026DefaultReco_cff')
     process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
     from Configuration.AlCa.GlobalTag import GlobalTag
-    process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T21', '')
+    process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T33', '')
     #process.load("SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff") # already included
     #process.SiPhase2OTFakeBadStripsESSource.printDebug = cms.untracked.bool(True)    # this makes it verbose 
     process.SiPhase2OTFakeBadStripsESSource.badComponentsFraction = cms.double(0.05)   # bad components fraction is 5%
 else:
-    tag = 'SiStripBadStripPhase2_T21'
+    tag = 'SiStripBadStripPhase2_T33'
     suffix = 'v0'
     inFile = tag+'_'+suffix+'.db'
     inDB = 'sqlite_file:'+inFile

--- a/CondTools/SiPhase2Tracker/test/SiPhase2OuterTrackerLorentzAngleReader_cfg.py
+++ b/CondTools/SiPhase2Tracker/test/SiPhase2OuterTrackerLorentzAngleReader_cfg.py
@@ -36,7 +36,7 @@ process.source = cms.Source("EmptyIOVSource",
 ###################################################################
 # Input data
 ###################################################################
-tag = 'SiPhase2OuterTrackerLorentzAngle_T21'
+tag = 'SiPhase2OuterTrackerLorentzAngle_T33'
 suffix = 'v0'
 inFile = tag+'_'+suffix+'.db'
 inDB = 'sqlite_file:'+inFile
@@ -58,7 +58,7 @@ process.PoolDBESSource = cms.ESSource("PoolDBESSource",
 ###################################################################
 process.get = cms.EDAnalyzer("EventSetupRecordDataGetter",
     toGet = cms.VPSet(cms.PSet(
-        record = cms.string(' SiPhase2OuterTrackerLorentzAngleRcd'),
+        record = cms.string('SiPhase2OuterTrackerLorentzAngleRcd'),
         data = cms.vstring('SiPhase2OuterTrackerLorentzAngle')
     )),
     verbose = cms.untracked.bool(True)

--- a/CondTools/SiPhase2Tracker/test/SiPhase2OuterTrackerLorentzAngleWriter_cfg.py
+++ b/CondTools/SiPhase2Tracker/test/SiPhase2OuterTrackerLorentzAngleWriter_cfg.py
@@ -25,7 +25,7 @@ process.MessageLogger.cout = cms.untracked.PSet(
   SiPhase2OuterTrackerLorentzAngle = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
 )
 
-tag = 'SiPhase2OuterTrackerLorentzAngle_T21'
+tag = 'SiPhase2OuterTrackerLorentzAngle_T33'
 suffix = 'v0'
 outfile = tag+'_'+suffix+'.db'
 outdb = 'sqlite_file:'+outfile
@@ -38,12 +38,12 @@ if os.path.exists(outfile):
 process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect = cms.string(outdb)
 
-process.load('Configuration.Geometry.GeometryExtended2026D88Reco_cff')
-process.load('Configuration.Geometry.GeometryExtended2026D88_cff')
+process.load('Configuration.Geometry.GeometryExtended2026DefaultReco_cff')
+process.load('Configuration.Geometry.GeometryExtended2026Default_cff')
 
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T21')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T33')
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/SiPhase2Tracker/test/SiPhase2OuterTrackerLorentzAngleWriter_cfg.py
+++ b/CondTools/SiPhase2Tracker/test/SiPhase2OuterTrackerLorentzAngleWriter_cfg.py
@@ -3,8 +3,14 @@
 from __future__ import print_function
 import os, shlex, shutil, getpass
 
+###################################################################
+# Set default phase-2 settings
+###################################################################
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
+
 import FWCore.ParameterSet.Config as cms
-process = cms.Process("TEST")
+process = cms.Process("TEST", _PH2_ERA)
 
 ###################################################################
 # Messages
@@ -43,7 +49,7 @@ process.load('Configuration.Geometry.GeometryExtended2026Default_cff')
 
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T33')
+process.GlobalTag = GlobalTag(process.GlobalTag, _PH2_GLOBAL_TAG)
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026DefaultReco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026DefaultReco_cff.py
@@ -1,3 +1,3 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Geometry.GeometryDD4hepExtended2026D98Reco_cff import *
+from Configuration.Geometry.GeometryDD4hepExtended2026D110Reco_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026Default_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026Default_cff.py
@@ -1,3 +1,3 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Geometry.GeometryDD4hepExtended2026D98_cff import *
+from Configuration.Geometry.GeometryDD4hepExtended2026D110_cff import *

--- a/Configuration/Geometry/python/GeometryExtended2026DefaultReco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026DefaultReco_cff.py
@@ -1,3 +1,3 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Geometry.GeometryExtended2026D98Reco_cff import *
+from Configuration.Geometry.GeometryExtended2026D110Reco_cff import *

--- a/Configuration/Geometry/python/GeometryExtended2026Default_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026Default_cff.py
@@ -1,3 +1,3 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Geometry.GeometryExtended2026D98_cff import *
+from Configuration.Geometry.GeometryExtended2026D110_cff import *

--- a/Configuration/Geometry/python/defaultPhase2ConditionsEra_cff.py
+++ b/Configuration/Geometry/python/defaultPhase2ConditionsEra_cff.py
@@ -1,0 +1,37 @@
+from Configuration.PyReleaseValidation.upgradeWorkflowComponents import upgradeProperties as properties
+from Configuration.AlCa.autoCond import autoCond
+from Configuration.StandardSequences.Eras import eras
+
+DEFAULT_VERSION = "2026D110"
+
+def get_era_and_conditions(version_key):
+    """Retrieve the era and global tag for a given version key.
+
+    Args:
+        version_key (str): The version key to look up.
+
+    Returns:
+        tuple: A tuple containing the global tag and era object.
+
+    Raises:
+        KeyError: If the version key or global tag is not found.
+    """
+    # Ensure the version key exists in the properties for 2026
+    if version_key not in properties[2026]:
+        raise KeyError(f"Version key '{version_key}' not found in properties[2026].")
+
+    # Retrieve the global tag key
+    global_tag_key = properties[2026][version_key]['GT']
+    print(f"Global tag key from properties: {global_tag_key}")
+
+    # Validate the existence of the global tag in autoCond
+    global_tag_name = global_tag_key.replace("auto:", "")
+    if global_tag_name not in autoCond:
+        raise KeyError(f"Global tag key '{global_tag_key}' not found in autoCond.")
+
+    # Retrieve the era key and get the corresponding era object
+    era_key = properties[2026][version_key]['Era']
+    print(f"Constructed era key from properties: {era_key}")
+    era = getattr(eras, era_key)
+
+    return global_tag_key, era

--- a/Geometry/TrackerGeometryBuilder/src/PixelTopologyMap.cc
+++ b/Geometry/TrackerGeometryBuilder/src/PixelTopologyMap.cc
@@ -26,6 +26,10 @@ void PixelTopologyMap::buildTopologyMaps() {
   for (auto det : m_trackerGeom->detsPXB()) {
     const PixelGeomDetUnit* pixelDet = dynamic_cast<const PixelGeomDetUnit*>(det);
 
+    // discard dets that are not a geomDetUnit
+    if (!pixelDet)
+      continue;
+
     const auto& layer = m_trackerTopo->pxbLayer(pixelDet->geographicalId());
     const auto& ladder = m_trackerTopo->pxbLadder(pixelDet->geographicalId());
     const auto& module = m_trackerTopo->pxbModule(pixelDet->geographicalId());
@@ -55,6 +59,10 @@ void PixelTopologyMap::buildTopologyMaps() {
 
   for (auto det : m_trackerGeom->detsPXF()) {
     const PixelGeomDetUnit* pixelDet = dynamic_cast<const PixelGeomDetUnit*>(det);
+
+    // discard dets that are not a geomDetUnit
+    if (!pixelDet)
+      continue;
 
     const auto& disk = m_trackerTopo->pxfDisk(pixelDet->geographicalId());
     const auto& blade = m_trackerTopo->pxfBlade(pixelDet->geographicalId());

--- a/Geometry/TrackerGeometryBuilder/test/python/testPixelTopologyMapTest_cfg.py
+++ b/Geometry/TrackerGeometryBuilder/test/python/testPixelTopologyMapTest_cfg.py
@@ -1,6 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 import FWCore.ParameterSet.VarParsing as VarParsing
 
+###################################################################
+# Set default phase-2 settings
+###################################################################
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
+
 process = cms.Process("TopologyAnalysis")
 options = VarParsing.VarParsing("analysis")
 
@@ -17,6 +23,12 @@ options.register ('runNumber',
                   "run number")
 
 options.parseArguments()
+
+if 'phase2' in options.globalTag:
+    if options.globalTag != _PH2_GLOBAL_TAG:
+        raise KeyError(
+            f"Global tag key given in input ('{options.globalTag}') mismatches the default ('{_PH2_GLOBAL_TAG}')."
+        )
 
 ###################################################################
 # Message logger service

--- a/Geometry/TrackerGeometryBuilder/test/python/testPixelTopologyMapTest_cfg.py
+++ b/Geometry/TrackerGeometryBuilder/test/python/testPixelTopologyMapTest_cfg.py
@@ -30,8 +30,8 @@ process.MessageLogger.cerr.FwkReport.reportEvery = 1
 process.load("Configuration.StandardSequences.Services_cff")
 
 if 'phase2' in options.globalTag:
-    process.load("Configuration.Geometry.GeometryExtended2026D92_cff")
-    process.load("Configuration.Geometry.GeometryExtended2026D92Reco_cff")
+    process.load("Configuration.Geometry.GeometryExtended2026Default_cff")
+    process.load("Configuration.Geometry.GeometryExtended2026DefaultReco_cff")
 else:
     process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 

--- a/Geometry/TrackerGeometryBuilder/test/runTest.sh
+++ b/Geometry/TrackerGeometryBuilder/test/runTest.sh
@@ -20,7 +20,7 @@ do
 done
 
 cmsRun ${SCRAM_TEST_PATH}/python/testPixelTopologyMapTest_cfg.py runNumber=300000  || die "Failure using cmsRun testPixelTopologyMapTest_cfg.py runNumber=300000" $?
-cmsRun ${SCRAM_TEST_PATH}/python/testPixelTopologyMapTest_cfg.py globalTag=auto:phase2_realistic_T21  || die "Failure using cmsRun testPixelTopologyMapTest_cfg.py globalTag=auto:phase2_realistic_T21" $?
+cmsRun ${SCRAM_TEST_PATH}/python/testPixelTopologyMapTest_cfg.py globalTag=auto:phase2_realistic_T33  || die "Failure using cmsRun testPixelTopologyMapTest_cfg.py globalTag=auto:phase2_realistic_T33" $?
 
 FILE1=trackerParametersDD4hep.log
 FILE2=trackerParametersDDD.log

--- a/RecoTracker/MkFit/test/dumpMkFitGeometryPhase2.py
+++ b/RecoTracker/MkFit/test/dumpMkFitGeometryPhase2.py
@@ -10,12 +10,12 @@ process = cms.Process('DUMP',Phase2C17I13M9,trackingMkFit)
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
 process.load('FWCore.MessageService.MessageLogger_cfi')
-process.load('Configuration.Geometry.GeometryExtended2026D88Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2026DefaultReco_cff')
 process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.StandardSequences.Reconstruction_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, "auto:phase2_realistic_T21", '')
+process.GlobalTag = GlobalTag(process.GlobalTag, "auto:phase2_realistic_T33", '')
 
 process.MessageLogger.cerr.threshold = "INFO"
 process.MessageLogger.cerr.MkFitGeometryESProducer = dict(limit=-1)

--- a/RecoTracker/MkFit/test/dumpMkFitGeometryPhase2.py
+++ b/RecoTracker/MkFit/test/dumpMkFitGeometryPhase2.py
@@ -1,11 +1,16 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
 # from Configuration.ProcessModifiers.trackingMkFit_cff import trackingMkFit
 from Configuration.ProcessModifiers.trackingMkFitCommon_cff import trackingMkFitCommon
 trackingMkFit = cms.ModifierChain(trackingMkFitCommon)
 
-process = cms.Process('DUMP',Phase2C17I13M9,trackingMkFit)
+###################################################################
+# Set default phase-2 settings
+###################################################################
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
+
+process = cms.Process('DUMP', _PH2_ERA, trackingMkFit)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
@@ -15,7 +20,7 @@ process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.StandardSequences.Reconstruction_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, "auto:phase2_realistic_T33", '')
+process.GlobalTag = GlobalTag(process.GlobalTag, _PH2_GLOBAL_TAG, '')
 
 process.MessageLogger.cerr.threshold = "INFO"
 process.MessageLogger.cerr.MkFitGeometryESProducer = dict(limit=-1)

--- a/SLHCUpgradeSimulations/Geometry/test/phase2_digi_reco_pixelntuple_cfg.py
+++ b/SLHCUpgradeSimulations/Geometry/test/phase2_digi_reco_pixelntuple_cfg.py
@@ -1,8 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 
+###################################################################
+# Set default phase-2 settings
+###################################################################
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
 
-from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
-process = cms.Process('USER',Phase2C17I13M9)
+process = cms.Process('USER', _PH2_ERA)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
@@ -95,7 +99,7 @@ process.mix.digitizers = cms.PSet(process.theDigitizersValid)
 # They need pixel RecHits where the charge is stored with high-granularity and large dinamic range
 
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T33', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, _PH2_GLOBAL_TAG, '')
 
 # Path and EndPath definitions
 process.digitisation_step = cms.Path(process.pdigi_valid)

--- a/SLHCUpgradeSimulations/Geometry/test/phase2_digi_reco_pixelntuple_cfg.py
+++ b/SLHCUpgradeSimulations/Geometry/test/phase2_digi_reco_pixelntuple_cfg.py
@@ -11,7 +11,7 @@ process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load('Configuration.EventContent.EventContent_cff')
 process.load('SimGeneral.MixingModule.mixNoPU_cfi')
 #process.load('SimGeneral.MixingModule.mix_POISSON_average_cfi')
-process.load('Configuration.Geometry.GeometryExtended2026D88Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2026DefaultReco_cff')
 process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.StandardSequences.Digi_cff')
 process.load('Configuration.StandardSequences.SimL1Emulator_cff')
@@ -29,7 +29,7 @@ process.maxEvents = cms.untracked.PSet(
 
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
-        '/store/relval/CMSSW_12_3_0_pre6/RelValSingleMuPt10/GEN-SIM/123X_mcRun4_realistic_v8_2026D88noPU-v1/10000/a7e6521e-e026-447b-8bf9-38a09e97916f.root'
+        '/store/relval/CMSSW_14_1_0_pre5/RelValSingleMuPt10/GEN-SIM/140X_mcRun4_realistic_v4_RegeneratedGS_2026D110_noPU-v1/2580000/48116a2e-e383-4b89-a20e-c72fe2f8473d.root'
     )
 )
 
@@ -95,7 +95,7 @@ process.mix.digitizers = cms.PSet(process.theDigitizersValid)
 # They need pixel RecHits where the charge is stored with high-granularity and large dinamic range
 
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T21', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T33', '')
 
 # Path and EndPath definitions
 process.digitisation_step = cms.Path(process.pdigi_valid)

--- a/SLHCUpgradeSimulations/Geometry/test/writeFile_phase2_cfg.py
+++ b/SLHCUpgradeSimulations/Geometry/test/writeFile_phase2_cfg.py
@@ -2,13 +2,13 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("ICALIB")
 process.load("Configuration.StandardSequences.Services_cff")
-process.load('Configuration.Geometry.GeometryExtended2026D92Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2026DefaultReco_cff')
 
 process.trackerGeometry.applyAlignment = cms.bool(False)
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T21', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T33', '')
 
 process.source = cms.Source("EmptyIOVSource",
     firstValue = cms.uint64(1),
@@ -28,7 +28,7 @@ process.prodstrip = cms.EDAnalyzer("SiStripDetInfoFileWriter",
 )
 
 process.prodpixel = cms.EDAnalyzer("SiPixelDetInfoFileWriter",
-    FilePath = cms.untracked.string('PixelSkimmedGeometry_GeometryExtended2026Tilted_D49.txt'),
+    FilePath = cms.untracked.string('PixelSkimmedGeometry_GeometryExtended2026Tilted_D110.txt'),
     WriteROCInfo = cms.untracked.bool(True)
 )
 

--- a/SLHCUpgradeSimulations/Geometry/test/writeFile_phase2_cfg.py
+++ b/SLHCUpgradeSimulations/Geometry/test/writeFile_phase2_cfg.py
@@ -1,6 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("ICALIB")
+###################################################################
+# Set default phase-2 settings
+###################################################################
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
+
+process = cms.Process("ICALIB",_PH2_ERA)
 process.load("Configuration.StandardSequences.Services_cff")
 process.load('Configuration.Geometry.GeometryExtended2026DefaultReco_cff')
 
@@ -8,7 +14,7 @@ process.trackerGeometry.applyAlignment = cms.bool(False)
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T33', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, _PH2_GLOBAL_TAG, '')
 
 process.source = cms.Source("EmptyIOVSource",
     firstValue = cms.uint64(1),
@@ -28,7 +34,7 @@ process.prodstrip = cms.EDAnalyzer("SiStripDetInfoFileWriter",
 )
 
 process.prodpixel = cms.EDAnalyzer("SiPixelDetInfoFileWriter",
-    FilePath = cms.untracked.string('PixelSkimmedGeometry_GeometryExtended2026Tilted_D110.txt'),
+    FilePath = cms.untracked.string('PixelSkimmedGeometry_GeometryExtended2026Tilted_Default.txt'),
     WriteROCInfo = cms.untracked.bool(True)
 )
 

--- a/SimTracker/TrackerMaterialAnalysis/test/listIds_PhaseII.py
+++ b/SimTracker/TrackerMaterialAnalysis/test/listIds_PhaseII.py
@@ -20,9 +20,9 @@ options.parseArguments()
 if options.fromDB :
    process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
    from Configuration.AlCa.GlobalTag import GlobalTag
-   process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T21', '')
+   process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T33', '')
 else:
-   process.load('Configuration.Geometry.GeometryExtended2026D92Reco_cff')
+   process.load('Configuration.Geometry.GeometryExtended2026DefaultReco_cff')
    process.trackerGeometry.applyAlignment = False # needed to avoid to pass the Global Position Record
 
 process.load('FWCore.MessageService.MessageLogger_cfi')

--- a/SimTracker/TrackerMaterialAnalysis/test/listIds_PhaseII.py
+++ b/SimTracker/TrackerMaterialAnalysis/test/listIds_PhaseII.py
@@ -4,7 +4,13 @@
 import FWCore.ParameterSet.Config as cms
 from FWCore.ParameterSet.VarParsing import VarParsing
 
-process = cms.Process("MaterialAnalyser")
+###################################################################
+# Set default phase-2 settings
+###################################################################
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
+
+process = cms.Process("MaterialAnalyser",_PH2_ERA)
 
 options = VarParsing('analysis')
 
@@ -20,7 +26,7 @@ options.parseArguments()
 if options.fromDB :
    process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
    from Configuration.AlCa.GlobalTag import GlobalTag
-   process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T33', '')
+   process.GlobalTag = GlobalTag(process.GlobalTag, _PH2_GLOBAL_TAG, '')
 else:
    process.load('Configuration.Geometry.GeometryExtended2026DefaultReco_cff')
    process.trackerGeometry.applyAlignment = False # needed to avoid to pass the Global Position Record

--- a/SimTracker/TrackerMaterialAnalysis/test/trackingMaterialAnalyser_ForPhaseII.py
+++ b/SimTracker/TrackerMaterialAnalysis/test/trackingMaterialAnalyser_ForPhaseII.py
@@ -1,10 +1,16 @@
 #! /usr/bin/env cmsRun
 # cmsRun trackingMaterialAnalyser fromDB=False
 
+###################################################################
+# Set default phase-2 settings
+###################################################################
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
+
 import FWCore.ParameterSet.Config as cms
 from FWCore.ParameterSet.VarParsing import VarParsing
 
-process = cms.Process("MaterialAnalyser")
+process = cms.Process("MaterialAnalyser",_PH2_ERA)
 
 options = VarParsing('analysis')
 
@@ -20,7 +26,7 @@ options.parseArguments()
 if options.fromDB :
    process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
    from Configuration.AlCa.GlobalTag import GlobalTag
-   process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T33', '')
+   process.GlobalTag = GlobalTag(process.GlobalTag, _PH2_GLOBAL_TAG, '')
 else:
    process.load('Configuration.Geometry.GeometryExtended2026DefaultReco_cff')
 

--- a/SimTracker/TrackerMaterialAnalysis/test/trackingMaterialAnalyser_ForPhaseII.py
+++ b/SimTracker/TrackerMaterialAnalysis/test/trackingMaterialAnalyser_ForPhaseII.py
@@ -20,9 +20,9 @@ options.parseArguments()
 if options.fromDB :
    process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
    from Configuration.AlCa.GlobalTag import GlobalTag
-   process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T21', '')
+   process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T33', '')
 else:
-   process.load('Configuration.Geometry.GeometryExtended2026D92Reco_cff')
+   process.load('Configuration.Geometry.GeometryExtended2026DefaultReco_cff')
 
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.MessageLogger.files.LogTrackingMaterialAnalysis = dict()

--- a/SimTracker/TrackerMaterialAnalysis/test/trackingMaterialProducer10GeVNeutrino_ForPhaseII.py
+++ b/SimTracker/TrackerMaterialAnalysis/test/trackingMaterialProducer10GeVNeutrino_ForPhaseII.py
@@ -5,8 +5,13 @@
 import FWCore.ParameterSet.Config as cms
 from FWCore.ParameterSet.VarParsing import VarParsing
 
-from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
-process = cms.Process("Geometry",phase2_common)
+###################################################################
+# Set default phase-2 settings
+###################################################################
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
+
+process = cms.Process("Geometry",_PH2_ERA)
 
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.MessageLogger.files.debugTrackingMaterialProducer = dict()
@@ -51,7 +56,7 @@ options.parseArguments()
 if options.fromDB :
    process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
    from Configuration.AlCa.GlobalTag import GlobalTag
-   process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T33', '')
+   process.GlobalTag = GlobalTag(process.GlobalTag, _PH2_GLOBAL_TAG, '')
 else:
    process.load('Configuration.Geometry.GeometryExtended2026DefaultReco_cff')
 

--- a/SimTracker/TrackerMaterialAnalysis/test/trackingMaterialProducer10GeVNeutrino_ForPhaseII.py
+++ b/SimTracker/TrackerMaterialAnalysis/test/trackingMaterialProducer10GeVNeutrino_ForPhaseII.py
@@ -51,9 +51,9 @@ options.parseArguments()
 if options.fromDB :
    process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
    from Configuration.AlCa.GlobalTag import GlobalTag
-   process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T21', '')
+   process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T33', '')
 else:
-   process.load('Configuration.Geometry.GeometryExtended2026D92Reco_cff')
+   process.load('Configuration.Geometry.GeometryExtended2026DefaultReco_cff')
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(options.nEvents)

--- a/Validation/Geometry/test/genHGCalPlots.sh
+++ b/Validation/Geometry/test/genHGCalPlots.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 
-geom=Extended2026D92
+geom=Extended2026D110
 VGEO_DIR=${CMSSW_BASE}/src/Validation/Geometry/test
 TEST_DIR=.
 


### PR DESCRIPTION
#### PR description:

Title says it all, in partial response to https://github.com/cms-sw/cmssw/pull/45370#issuecomment-2301200925. 

#### PR validation:

Most of the tests now run correctly: `scram b runtests` of the changed packages.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A
Cc: @srimanob 
