### PR TITLE
[Do not merge] Workaround for Tier0 API access missing certificate

### DIFF
--- a/CondCore/SiStripPlugins/scripts/G2GainsValidator.py
+++ b/CondCore/SiStripPlugins/scripts/G2GainsValidator.py
@@ -33,21 +33,30 @@ def getCommandOutput(command):
 ##############################################
 def getFCSR():
 ##############################################
-    out = subprocess.check_output(["curl", "-k", "-s", "https://cmsweb.cern.ch/t0wmadatasvc/prod/firstconditionsaferun"])
+    # temporary solution accessing URL that is not requiring a certificate but it is
+    # planed to be dicomissioned in 7 days after 20.08.2024
+    # should be reverted to https://cmsweb.cern.ch/t0wmadatasvc/prod/ and fixed to use a certificate
+    out = subprocess.check_output(["curl", "-k", "-s", "https://cmsweb-prod.cern.ch/t0wmadatasvc/prod/firstconditionsaferun"])
     response = json.loads(out)["result"][0]
     return int(response)
 
 ##############################################
 def getPromptGT():
 ##############################################
-    out = subprocess.check_output(["curl", "-k", "-s", "https://cmsweb.cern.ch/t0wmadatasvc/prod/reco_config"])
+    # temporary solution accessing URL that is not requiring a certificate but it is
+    # planed to be dicomissioned in 7 days after 20.08.2024
+    # should be reverted to https://cmsweb.cern.ch/t0wmadatasvc/prod/ and fixed to use a certificate
+    out = subprocess.check_output(["curl", "-k", "-s", "https://cmsweb-prod.cern.ch/t0wmadatasvc/prod/reco_config"])
     response = json.loads(out)["result"][0]['global_tag']
     return response
 
 ##############################################
 def getExpressGT():
 ##############################################
-    out = subprocess.check_output(["curl", "-k", "-s", "https://cmsweb.cern.ch/t0wmadatasvc/prod/express_config"])
+    # temporary solution accessing URL that is not requiring a certificate but it is
+    # planed to be dicomissioned in 7 days after 20.08.2024
+    # should be reverted to https://cmsweb.cern.ch/t0wmadatasvc/prod/ and fixed to use a certificate
+    out = subprocess.check_output(["curl", "-k", "-s", "https://cmsweb-prod.cern.ch/t0wmadatasvc/prod/express_config"])
     response = json.loads(out)["result"][0]['global_tag']
     return response
 

--- a/CondCore/Utilities/python/tier0.py
+++ b/CondCore/Utilities/python/tier0.py
@@ -11,7 +11,10 @@ import subprocess
 
 import pycurl
 
-tier0Url = 'https://cmsweb.cern.ch/t0wmadatasvc/prod/'
+# temporary solution accessing URL that is not requiring a certificate but it is
+# planed to be dicomissioned in 7 days after 20.08.2024
+# should be reverted to https://cmsweb.cern.ch/t0wmadatasvc/prod/ and fixed to use a certificate
+tier0Url = 'https://cmsweb-prod.cern.ch/t0wmadatasvc/prod/'
 
 class Tier0Error(Exception):
     '''Tier0 exception.

--- a/DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py
+++ b/DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py
@@ -24,7 +24,10 @@ import subprocess
 import sys
 import time
 
-tier0Url = 'https://cmsweb.cern.ch/t0wmadatasvc/prod/'
+# temporary solution accessing URL that is not requiring a certificate but it is
+# planed to be dicomissioned in 7 days after 20.08.2024
+# should be reverted to https://cmsweb.cern.ch/t0wmadatasvc/prod/ and fixed to use a certificate
+tier0Url = 'https://cmsweb-prod.cern.ch/t0wmadatasvc/prod/'
 
 class Tier0Error(Exception):
     '''Tier0 exception.


### PR DESCRIPTION
After migration of CMSWEB "https://cmsweb.cern.ch/t0wmadatasvc/prod/" requires a certificate. This change caused failures of EcalLaser_prompt_run3 O2O jobs. This is a workaround changing the URL to  'https://cmsweb-prod.cern.ch/t0wmadatasvc/prod/' which is running the pre-migration version not requiring the certificate. It is only a temporary solution as the pre-migration version is going to be decommissioned after 7 days from the migration which took place on 20.08.2024

The EcalLaser_prompt_run3 are using the URL "CondCore/Utilities/python/tier0.py". We didn't notice the impact of the other occurrences of this URL changed in this PR.

This is not meant to be merged. We are currently working with @PonIlya on a proper solution using the old URL and providing the certificate.