### PR TITLE
Use C++ concepts for edm::Ptr

### DIFF
--- a/DataFormats/Common/interface/Ptr.h
+++ b/DataFormats/Common/interface/Ptr.h
@@ -109,7 +109,8 @@ namespace edm {
     Ptr() : core_(), key_(key_traits<key_type>::value) {}
 
     template <typename U>
-    Ptr(Ptr<U> const& iOther, std::enable_if_t<std::is_base_of<T, U>::value>* = nullptr)
+      requires std::is_base_of_v<T, U>
+    Ptr(Ptr<U> const& iOther)
         : core_(iOther.id(),
                 (iOther.hasProductCache() ? static_cast<T const*>(iOther.get()) : static_cast<T const*>(nullptr)),
                 iOther.productGetter(),
@@ -123,7 +124,8 @@ namespace edm {
     }
 
     template <typename U>
-    explicit Ptr(Ptr<U> const& iOther, std::enable_if_t<std::is_base_of<U, T>::value>* = nullptr)
+      requires std::is_base_of_v<U, T>
+    explicit Ptr(Ptr<U> const& iOther)
         : core_(iOther.id(), dynamic_cast<T const*>(iOther.get()), nullptr, iOther.isTransient()), key_(iOther.key()) {}
 
     /// Destructor

--- a/DataFormats/Common/test/ptr_t.cppunit.cc
+++ b/DataFormats/Common/test/ptr_t.cppunit.cc
@@ -207,6 +207,9 @@ void testPtr::constructTest() {
     CPPUNIT_ASSERT(dummy2Ptr.key() == copyPtr.key());
     CPPUNIT_ASSERT(dummy2Ptr.get() == static_cast<const Dummy*>(dummy2Ptr.get()));
 
+    Ptr<Dummy> copyCtrPtr(copyPtr);
+    CPPUNIT_ASSERT(copyPtr.key() == copyCtrPtr.key());
+
     Ptr<Dummy> movePtr(std::move(copyPtr));
     CPPUNIT_ASSERT(dummy2Ptr.key() == movePtr.key());
   }


### PR DESCRIPTION
#### PR description:

Used to improve handling of constructors for edm::Ptr's related to other types.

#### PR validation:

The code compiles and the relevant unit test passes.