### PR TITLE
Use C++ concepts in ReturnArgumentTypes

### DIFF
--- a/FWCore/Framework/interface/es_impl/ReturnArgumentTypes.h
+++ b/FWCore/Framework/interface/es_impl/ReturnArgumentTypes.h
@@ -46,17 +46,19 @@ namespace edm {
 
     //////////
 
-    template <typename F, typename = void>
+    template <typename F>
     struct ReturnArgumentTypes;
 
     template <typename F>
-    struct ReturnArgumentTypes<F, std::enable_if_t<std::is_class_v<F>>> {
+      requires std::is_class_v<F>
+    struct ReturnArgumentTypes<F> {
       using argument_type = typename ReturnArgumentTypesImpl<decltype(&F::operator())>::argument_type;
       using return_type = typename ReturnArgumentTypesImpl<decltype(&F::operator())>::return_type;
     };
 
     template <typename F>
-    struct ReturnArgumentTypes<F, std::enable_if_t<std::is_pointer_v<F>>> {
+      requires std::is_pointer_v<F>
+    struct ReturnArgumentTypes<F> {
       using argument_type = typename ReturnArgumentTypesImpl<F>::argument_type;
       using return_type = typename ReturnArgumentTypesImpl<F>::return_type;
     };


### PR DESCRIPTION
#### PR description:

Used to constrain the allowed types that can be used for function like types.

#### PR validation:

Code compiles.