### PR TITLE
Remove Duplicate RelVals from `relval_highstats.py` and Smaller Queries for `das-up-to-nevents.py`

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixUtil.py
+++ b/Configuration/PyReleaseValidation/python/MatrixUtil.py
@@ -133,9 +133,9 @@ class InputInfo(object):
             command = "dasgoclient %s --query '%s'" % (das_options, self.queries(dataset)[0])
         elif self.skimEvents:
             from os import getenv
-            if getenv("CMSSW_USE_IBEOS","false")=="true": 
+            if getenv("JENKINS_PREFIX") is not None:
                 # to be assured that whatever happens the files are only those at CERN
-                command = "das-up-to-nevents.py -d %s -e %d -s T2_CH_CERN"%(dataset,self.events) 
+                command = "das-up-to-nevents.py -d %s -e %d -pc"%(dataset,self.events)
             else:
                 command = "das-up-to-nevents.py -d %s -e %d"%(dataset,self.events)
         # Run filter on DAS output 

--- a/Configuration/PyReleaseValidation/python/relval_data_highstats.py
+++ b/Configuration/PyReleaseValidation/python/relval_data_highstats.py
@@ -16,7 +16,7 @@ offset_events = 0.0001 # less than 10 event setups (50k,150k,250k,500k)
 for e_n,era in enumerate(eras_2024):
     for p_n,pd in enumerate(pds_2024):
         for e_key,evs in event_steps_dict.items():
-            if "50k" == e_key: # already defined in relval_standard
+            if "10k" == e_key: # already defined in relval_standard
                 continue   
             wf_number = base_wf_number_2024
             wf_number = wf_number + offset_era * e_n

--- a/Configuration/PyReleaseValidation/python/relval_highstats.py
+++ b/Configuration/PyReleaseValidation/python/relval_highstats.py
@@ -86,29 +86,3 @@ workflows[13992502]=['',['TTbar_13_HS','DIGIUP15_PU25HS','RECOUP15_PU25HS','HARV
 workflows[134.99601] = ['',['RunJetHT2015HLHS','HLTDR2_25ns','RECODR2_25nsreHLT_HIPM','HARVESTDR2']]
 workflows[134.99602] = ['',['RunZeroBias2015HLHS','HLTDR2_25ns','RECODR2_25nsreHLT_HIPM','HARVESTDR2']]
 workflows[134.99603] = ['',['RunSingleMu2015HLHS','HLTDR2_25ns','RECODR2_25nsreHLT_HIPM','HARVESTDR2']]
-
-
-
-## 2024 Data Higher Stats Workflows
-## with 150k, 250k, 500k or 1M events each
-
-base_wf_number_2024 = 2024.0
-offset_era = 0.1 # less than 10 eras
-offset_pd = 0.001 # less than 100 pds
-offset_events = 0.0001 # less than 10 event setups (50k,150k,250k,500k)
-
-for e_n,era in enumerate(eras_2024):
-    for p_n,pd in enumerate(pds_2024):
-        for e_key,evs in event_steps_dict.items():
-            if "50k" in e_key: # already defined in relval_standard
-                continue   
-            wf_number = base_wf_number_2024
-            wf_number = wf_number + offset_era * e_n
-            wf_number = wf_number + offset_pd * p_n
-            wf_number = wf_number + offset_events * evs 
-            wf_number = round(wf_number,6)
-            step_name = "Run" + pd + era.split("Run")[1] + "_" + e_key
-            workflows[wf_number] = ['',[step_name,'HLTDR3_2024','AODNANORUN3_reHLT_2024','HARVESTRUN3_2024']]
-
-
-

--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -559,19 +559,21 @@ workflows[142.0] = ['',['RunHIPhysicsRawPrime2023A','HLTDR3_HI2023ARawprime','RE
 workflows[142.901] = ['',['RunUPC2023','RECODR3_2024_UPC','HARVESTDPROMPTR3']]
 workflows[142.902] = ['',['RunUPC2023','RECODR3_2024_HIN','HARVESTDPROMPTR3']]
 
-## 2024 Data Workflows
+## 2024 Data Workflows 
+# for a limited set of eras and PDs not to overflow the IB matrices
+#
 base_wf_number_2024 = 2024.0
 offset_era = 0.1 # less than 10 eras
 offset_pd = 0.001 # less than 100 pds
 
-for e_n,era in enumerate(eras_2024):
-    for p_n,pd in enumerate(pds_2024):
+for e_n,era in enumerate(['Run2024D','Run2024C']):
+    for p_n,pd in enumerate(['JetMET0','ZeroBias']):
         wf_number = base_wf_number_2024
         wf_number = wf_number + offset_era * e_n
         wf_number = wf_number + offset_pd * p_n
-        wf_number = wf_number + 0.0001 * 0.05 
+        wf_number = wf_number + 0.0001 * 0.01 
         wf_number = round(wf_number,6)
-        step_name = "Run" + pd + era.split("Run")[1] + "_50k"
+        step_name = "Run" + pd + era.split("Run")[1] + "_10k"
         workflows[wf_number] = ['',[step_name,'HLTDR3_2024','AODNANORUN3_reHLT_2024','HARVESTRUN3_2024']]
 
 ### fastsim ###

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -45,8 +45,8 @@ step1Up2024HiProdDefaults = merge ([{'--conditions':'auto:phase1_2024_realistic_
 steps = Steps()
 
 #### Event to runs
-event_steps = [0.05,0.15,0.25,0.5,1] #in millions
-event_steps_k = ["50k","150k","250k","500k","1M"]
+event_steps = [0.01,0.05,0.15,0.25,0.5,1] #in millions
+event_steps_k = ["10k","50k","150k","250k","500k","1M"]
 event_steps_dict = dict(zip(event_steps_k,event_steps))
 #### Production test section ####
 steps['ProdMinBias']=merge([{'cfg':'MinBias_8TeV_pythia8_TuneCUETP8M1_cff','--relval':'9000,300'},step1Defaults])


### PR DESCRIPTION
#### PR description:

This PR proposes few things:

1. to remove the duplicate RelVals in `relval_highstats.py` already added in `relval_data_highstats.py` by https://github.com/cms-sw/cmssw/pull/45055. Without this `runTheMatrix.py -w data,highstats -n`  complains about duplicates:

```
==> duplicate name found for  2024.4141_RunZeroBias2024F_1M
    keeping  :  (2024.4141, 'RunZeroBias2024F_1M', [<Configuration.PyReleaseValidation.MatrixUtil.InputInfo object at 0x7f2bcc55d700>, 'cmsDriver.py step2  --process reHLT -s L1REPACK:Full,HLT:@relval2024 --conditions auto:run3_hlt_relval --data  --eventcontent FEVTDEBUGHLT --datatier FEVTDEBUGHLT --era Run3_2024', 'cmsDriver.py step3  --conditions auto:run3_data_prompt_relval -s RAW2DIGI,L1Reco,RECO,PAT,NANO,DQM:@standardDQM+@miniAODDQM+@nanoAODDQM --datatier AOD,MINIAOD,NANOAOD,DQMIO --eventcontent AOD,MINIAOD,NANOEDMAOD,DQM --data  --process reRECO --scenario pp --era Run3 --customise Configuration/DataProcessing/RecoTLR.customisePostEra_Run3 --hltProcess reHLT', 'cmsDriver.py step4  -s HARVESTING:@standardDQM+@miniAODDQM+@nanoAODDQM --conditions auto:run3_data --data  --filetype DQM --scenario pp --era Run3'], ['RunZeroBias2024F_1M', 'HLTDR3_2024', 'AODNANORUN3_reHLT_2024', 'HARVESTRUN3_2024'])
    ignoring :  (2024.4141, 'RunZeroBias2024F_1M', [<Configuration.PyReleaseValidation.MatrixUtil.InputInfo object at 0x7f2bcc55d700>, 'cmsDriver.py step2  --process reHLT -s L1REPACK:Full,HLT:@relval2024 --conditions auto:run3_hlt_relval --data  --eventcontent FEVTDEBUGHLT --datatier FEVTDEBUGHLT --era Run3_2024', 'cmsDriver.py step3  --conditions auto:run3_data_prompt_relval -s RAW2DIGI,L1Reco,RECO,PAT,NANO,DQM:@standardDQM+@miniAODDQM+@nanoAODDQM --datatier AOD,MINIAOD,NANOAOD,DQMIO --eventcontent AOD,MINIAOD,NANOEDMAOD,DQM --data  --process reRECO --scenario pp --era Run3 --customise Configuration/DataProcessing/RecoTLR.customisePostEra_Run3 --hltProcess reHLT', 'cmsDriver.py step4  -s HARVESTING:@standardDQM+@miniAODDQM+@nanoAODDQM --conditions auto:run3_data --data  --filetype DQM --scenario pp --era Run3'], ['RunZeroBias2024F_1M', 'HLTDR3_2024', 'AODNANORUN3_reHLT_2024', 'HARVESTRUN3_2024'])
````

2. adjusted `das-up-to-nevents.py` to run DAS queries run per run up to the number of events requested in order to have smaller queries to be cached by cms-bot. This should fix the DAS query failures observed in latest tests.
 
3. moving most of the 2024 data wfs from `relval_standard.py` to `relval_data_highstats.py` so that they don't get run in the IBs (since it's not really needed). This reduce the 2024 wfs to be run in an IB from 75 to 4.
#### PR validation:

`runTheMatrix.py -w data,highstats -n` 

does not complain about duplicates anymore.
