### PR TITLE
add a phase-2 D110 relval workflow running the HLT timing menu, up to step2

### DIFF
--- a/Configuration/PyReleaseValidation/README.md
+++ b/Configuration/PyReleaseValidation/README.md
@@ -82,7 +82,7 @@ The offsets currently in use are:
 * 0.633: ECAL phase2 Trigger Primitive
 * 0.634: ECAL phase2 Trigger Primitive + component-method based digis
 * 0.635: ECAL phase2 Trigger Primitive + component-method based finely-sampled waveforms
-* 0.75: Phase-2 HLT
+* 0.75: Phase-2 HLT Timing menu
 * 0.91: Track DNN modifier
 * 0.97: Premixing stage1
 * 0.98: Premixing stage2

--- a/Configuration/PyReleaseValidation/python/relval_2026.py
+++ b/Configuration/PyReleaseValidation/python/relval_2026.py
@@ -48,6 +48,7 @@ numWFIB.extend([prefixDet+34.21])  #prodlike
 numWFIB.extend([prefixDet+96.0])   #CloseByPGun CE_E_Front_120um
 numWFIB.extend([prefixDet+100.0])  #CloseByPGun CE_H_Coarse_Scint
 numWFIB.extend([prefixDet+61.0])   #Nu Gun
+numWFIB.extend([prefixDet+34.75])  #Timing menu
 #numWFIB.extend([prefixDet+151.85]) #Heavy ion reconstruction
 #Default Phase-2 Det PU
 numWFIB.extend([prefixDet+261.97])   #premixing stage1 (NuGun+PU)

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1935,30 +1935,37 @@ upgradeWFs['ProdLikePU180'] = UpgradeWorkflow_ProdLikeRunningPU(
     fixedPU = 180,
 )
 
-class UpgradeWorkflow_HLT75e33(UpgradeWorkflow):
+class UpgradeWorkflow_HLT75e33Timing(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):
-        if 'HARVEST' in step:
-            stepDict[stepName][k] = merge([{'--filein':'file:step3_inDQM.root'}, stepDict[step][k]])
+        # skip RECO, ALCA and HARVEST
+        if ('ALCA' in step) or ('Reco' in step) or ('HARVEST' in step) or ('HLT' in step):
+            stepDict[stepName][k] = None
+        elif 'DigiTrigger' in step:
+            stepDict[stepName][k] = merge([{'-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:75e33_timing'}, stepDict[step][k]])
         else:
             stepDict[stepName][k] = merge([stepDict[step][k]])
     def condition(self, fragment, stepList, key, hasHarvest):
         return fragment=="TTbar_14TeV" and '2026' in key
-upgradeWFs['HLT75e33'] = UpgradeWorkflow_HLT75e33(
+upgradeWFs['HLTTiming75e33'] = UpgradeWorkflow_HLT75e33Timing(
     steps = [
-        'GenSimHLBeamSpot14',
-        'DigiTrigger',
+        'Reco',
         'RecoGlobal',
-        'HLT75e33',
+        'RecoNano',
+        'DigiTrigger',
+        'ALCA',
+        'ALCAPhase2',
         'HARVESTGlobal',
     ],
     PU = [
-        'GenSimHLBeamSpot14',
-        'DigiTrigger',
+        'Reco',
         'RecoGlobal',
-        'HLT75e33',
-        'HARVESTGlobal',
+        'RecoNano',
+        'DigiTrigger',
+        'ALCA',
+        'ALCAPhase2',
+        'HARVESTGlobal'
     ],
-    suffix = '_HLT75e33',
+    suffix = '_HLT75e33Timing',
     offset = 0.75,
 )
 

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -97,7 +97,7 @@ if __name__ == '__main__':
                     29696.0,    # RelValCloseByPGun_CE_E_Front_120um    phase2_realistic_T33        Extended2026D110
                     29700.0,    # RelValCloseByPGun_CE_H_Coarse_Scint   phase2_realistic_T33        Extended2026D110  
                     #23234.0,   # Need new workflow with HFNose
-                    
+                    29634.75,   # RelValTTbar_14TeV                     phase2_realistic_T33        Extended2026D110         (Phase-2 baseline -  but using timing menu, and only up to step 2)
 
                     ###### pp Data
                     ## Run1


### PR DESCRIPTION
#### PR description:

Title say is all: introduce a phase-2 D110-based relval workflow running the HLT timing menu, up to step2 (in order to be fast) and included in the limited matrix. This is done in order to spot whenever the phase-2 HLT timing menu configuration gets broken.

#### PR validation:

`runTheMatrix.py --what upgrade -l 29634.75 -t 4 -j 8` runs fine, when this branch is tested in conjunction with https://github.com/cms-sw/cmssw/pull/45768.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A