### PR TITLE
Use C++ concepts for InputProcessBlockCacheImpl

### DIFF
--- a/FWCore/Framework/interface/InputProcessBlockCacheImpl.h
+++ b/FWCore/Framework/interface/InputProcessBlockCacheImpl.h
@@ -81,13 +81,12 @@ namespace edm {
       InputProcessBlockCacheImpl& operator=(InputProcessBlockCacheImpl const&) = delete;
 
       template <std::size_t I>
-      typename std::enable_if<I == sizeof...(CacheTypes), void>::type fillTuple(std::tuple<CacheHandle<CacheTypes>...>&,
-                                                                                Event const&) const {}
+        requires requires { requires I == sizeof...(CacheTypes); }
+      void fillTuple(std::tuple<CacheHandle<CacheTypes>...>&, Event const&) const {}
 
       template <std::size_t I>
-          typename std::enable_if <
-          I<sizeof...(CacheTypes), void>::type fillTuple(std::tuple<CacheHandle<CacheTypes>...>& cacheHandles,
-                                                         Event const& event) const {
+        requires requires { requires I < sizeof...(CacheTypes); }
+      void fillTuple(std::tuple<CacheHandle<CacheTypes>...>& cacheHandles, Event const& event) const {
         unsigned int index = eventProcessBlockIndex(event, processNames_[I]);
 
         // If the branch associated with the token was passed to registerProcessBlockCacheFiller


### PR DESCRIPTION
#### PR description:

Switched from SFINAE to concepts to enforce the type requirements.

#### PR validation:

Code compiles. Test using compiler explorer show the mechanism works as expected.