### PR TITLE
[MiniAOD] Remove Flag_METFilters from MiniAOD

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/metFilterPaths_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/metFilterPaths_cff.py
@@ -10,7 +10,6 @@ from RecoMET.METFilters.metFilters_cff import chargedHadronTrackResolutionFilter
 from RecoMET.METFilters.metFilters_cff import BadChargedCandidateFilter, BadPFMuonFilter, BadPFMuonDzFilter #2016 post-ICHEPversion
 from RecoMET.METFilters.metFilters_cff import BadChargedCandidateSummer16Filter, BadPFMuonSummer16Filter #2016 ICHEP version
 from RecoMET.METFilters.metFilters_cff import hfNoisyHitsFilter
-from RecoMET.METFilters.metFilters_cff import metFilters
 
 # individual filters
 Flag_HBHENoiseFilter = cms.Path(HBHENoiseFilterResultProducer * HBHENoiseFilter)
@@ -44,17 +43,13 @@ Flag_trkPOG_manystripclus53X = cms.Path(~manystripclus53X)
 Flag_trkPOG_toomanystripclus53X = cms.Path(~toomanystripclus53X)
 Flag_trkPOG_logErrorTooManyClusters = cms.Path(~logErrorTooManyClusters)
 
-
-# and the summary
-Flag_METFilters = cms.Path(metFilters)
-
 #add your new path here!!
 allMetFilterPaths=['HBHENoiseFilter','HBHENoiseIsoFilter','CSCTightHaloFilter','CSCTightHaloTrkMuUnvetoFilter','CSCTightHalo2015Filter','globalTightHalo2016Filter','globalSuperTightHalo2016Filter','HcalStripHaloFilter','hcalLaserEventFilter','EcalDeadCellTriggerPrimitiveFilter','EcalDeadCellBoundaryEnergyFilter','ecalBadCalibFilter','goodVertices','eeBadScFilter',
                    'ecalLaserCorrFilter','trkPOGFilters','chargedHadronTrackResolutionFilter','muonBadTrackFilter',
                    'BadChargedCandidateFilter','BadPFMuonFilter', 'BadPFMuonDzFilter', 'hfNoisyHitsFilter', 'BadChargedCandidateSummer16Filter','BadPFMuonSummer16Filter',
-                   'trkPOG_manystripclus53X','trkPOG_toomanystripclus53X','trkPOG_logErrorTooManyClusters','METFilters']
+                   'trkPOG_manystripclus53X','trkPOG_toomanystripclus53X','trkPOG_logErrorTooManyClusters']
 
-       
+
 def miniAOD_customizeMETFiltersFastSim(process):
     """Replace some MET filters that don't work in FastSim with trivial bools"""
     for X in 'CSCTightHaloFilter', 'CSCTightHaloTrkMuUnvetoFilter','CSCTightHalo2015Filter','globalTightHalo2016Filter','globalSuperTightHalo2016Filter','HcalStripHaloFilter':

--- a/RecoMET/METFilters/python/metFilters_cff.py
+++ b/RecoMET/METFilters/python/metFilters_cff.py
@@ -93,30 +93,3 @@ from RecoMET.METFilters.BadPFMuonDzFilter_cfi import *
 
 #HF noise filter 
 from RecoMET.METFilters.hfNoisyHitsFilter_cfi import *
-
-metFilters = cms.Sequence(
-    goodVertices *
-    globalSuperTightHalo2016Filter *
-    HBHENoiseFilterResultProducer  *
-    HBHENoiseFilter *
-    HBHENoiseIsoFilter *
-    EcalDeadCellTriggerPrimitiveFilter *  
-    BadPFMuonFilter *
-    BadPFMuonDzFilter *
-    hfNoisyHitsFilter *
-    eeBadScFilter *
-    ecalBadCalibFilter 
-)
-
-from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
-phase2_hgcal.toReplaceWith(metFilters, metFilters.copyAndExclude([
-    HBHENoiseFilterResultProducer, HBHENoiseFilter, HBHENoiseIsoFilter, # No hcalnoise for hgcal
-    eeBadScFilter                                   # No EE
-]))
-
-
-from Configuration.Eras.Modifier_run2_jme_2016_cff import run2_jme_2016
-run2_jme_2016.toReplaceWith(metFilters, metFilters.copyAndExclude([
-    ecalBadCalibFilter, hfNoisyHitsFilter
-]))
-


### PR DESCRIPTION
#### PR description:

This PR removes the `Flag_METFilters` from MiniAOD and also from NanoAOD by virtue that the flag will not be in the input MiniAODs.  The flag is deprecated and has been unsupported by JME for a while now. The recommendation for analyzers ([twiki](https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2)) is to apply the individual noise filter flags. Removing the `Flag_METFilters` flag avoids accidental usage by analyzers with the next MiniAOD and NanoAOD production.

#### PR validation:

- passes the usual runTheMatrix test: `runTheMatrix.py -l limited -i all --ibeos`
- ran workflow `25202.0_TTbar_13`  and had checked that the `Flag_METFilters` branch is not in NanoAOD anymore

