### PR TITLE
Fix HGCAL Geometry - Revert `norot` back to False in `locateCell()` 

### DIFF
--- a/Geometry/HGCalGeometry/src/HGCalGeometry.cc
+++ b/Geometry/HGCalGeometry/src/HGCalGeometry.cc
@@ -237,7 +237,7 @@ GlobalPoint HGCalGeometry::getPosition(const DetId& detid, bool cog, bool debug)
                                         << id.iCell2;
       }
       xy = m_topology.dddConstants().locateCell(
-          id.zSide, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, true, true, cog, debug);
+          id.zSide, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, true, false, cog, debug);
       double xx = id.zSide * xy.first;
       double zz = id.zSide * m_topology.dddConstants().waferZ(id.iLay, true);
       glob = GlobalPoint(xx, xy.second, zz);


### PR DESCRIPTION
This PR aims to fix a problem introduce with #45366, where the `norot` value in one call of `locateCell ` has been flipped to True (thanks @fwyzard for spotting it). 
This caused some problems in the correct position of the DetId on some Layers of HGCAL. We noticed the problem by inspecting some events using Fireworks. 

Visualizing events produced with CMSSW_14_1_0_pre6 with the D99 geometry, with a dump of the Reco geometry done using CMSSW_14_1_0_pre1 (currently impossible to dump the geometry in CMSSW_14_1_0_pre6) we noticed some strange behaviour in the TICL Tracksters reconstruction. In [1] you can see how some of the LayerCluster are rotated with respect to the position of the Rechits. 
Inspecting in more details the problem we decided to dump the position of one of these DetIds in the different releases

```bash
14_1_0_pre6: DetId 2485782895 position  (-63.1768,-51.3877,374.281)  (eta,phi) 2.22995 -2.45874 
14_1_0_pre1: DetId 2485782895 position  (-80.4066,-12.9146,374.281)  (eta,phi) 2.22995 -2.98234 
14_1_0_pre5: DetId 2485782895 position (-80.4066,-12.9146,374.281)  (eta,phi) 2.22995 -2.98234
Fix_14_1_0_pre6: DetId 2485782895  (-80.4066,-12.9146,374.281)  (eta,phi) 2.22995 -2.98234
```

You can clearly see that in 14_1_0_pre6 the detId is rotated by 30 degrees. This is fixed with this PR as you can see in Fix_14_1_0_pre6 . In [2] you can see the event display after the fix

[1]
![image_2024-08-23_12-08-58](https://github.com/user-attachments/assets/2a4a2d1a-fa6f-4032-8c4b-767d1e0baabe)

[2]
![image](https://github.com/user-attachments/assets/55c8fcfd-5bde-4f7d-9b0f-482270c1b083)


@felicepantaleo FYI