### PR TITLE
adding xrootd lhe producer for run2 campaign cmssw

### DIFF
--- a/GeneratorInterface/LHEInterface/data/run_generic_tarball_xrootd.sh
+++ b/GeneratorInterface/LHEInterface/data/run_generic_tarball_xrootd.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -e
+
+echo "   ______________________________________     "
+
+if [ $# -lt 1 ]; then
+    echo "%MSG-ExternalLHEProducer-subprocess ERROR in external process. The gridpack path must be passed as an argument"
+fi
+if [[ $1 != "root://"* ]]; then
+    echo "%MSG-ExternalLHEProducer-subprocess ERROR in external process. Path must have format root://<xrd_path>/<path>"
+    exit 1
+fi 
+
+xrd_path=$1
+gridpack=$(basename $xrd_path)
+
+if [ -e $gridpack ]; then
+    echo "%MSG-ExternalLHEProducer-subprocess WARNING: File $gridpack already exists, it will be overwritten."
+    rm $gridpack
+fi
+
+echo "%MSG-ExternalLHEProducer-subprocess INFO: Copying gridpack $xrd_path locally using xrootd"
+xrdcp $xrd_path .
+
+path=`pwd`/$gridpack
+generic_script=$(dirname ${0})/run_generic_tarball_cvmfs.sh 
+. $generic_script $path ${@:2}
+


### PR DESCRIPTION
#### PR description:

There is no change in output.
This additional script just lets gridpacks to be placed in xrootd reachable area and be used for LHE production.

Backporting this from 4 year old PR https://github.com/cms-sw/cmssw/pull/31911
CMSSW_10_X_Y was missing this and I find this useful for private sample production as it is Run2 CMSSW
