### PR TITLE
Skip non-leaf GeomDets when dumping fireworks geometry

### DIFF
--- a/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
+++ b/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
@@ -402,7 +402,7 @@ void FWRecoGeometryESProducer::addPixelBarrelGeometry(FWRecoGeometry& fwRecoGeom
        ++it) {
     const GeomDet* det = *it;
 
-    if (det) {
+    if (det and det->isLeaf()) {
       DetId detid = det->geographicalId();
       unsigned int rawid = detid.rawId();
       unsigned int current = insert_id(rawid, fwRecoGeometry);


### PR DESCRIPTION
#### PR description:

This is an attempt to fix the problem seen trying to dump the phase2 geometry from CMSSW_14_1_0_pre6.

#### PR validation:

I ran 
```
cmsRun $CMSSW_RELEASE_BASE/src/Fireworks/Geometry/python/dumpRecoGeometry_cfg.py tag=2026 version=D110
```

and it finished successfully.