### PR TITLE
Another workaround for -O3 ASAN compilation issue in CTPPSProtonReconstructionPlotter

### DIFF
--- a/Validation/CTPPS/plugins/CTPPSProtonReconstructionPlotter.cc
+++ b/Validation/CTPPS/plugins/CTPPSProtonReconstructionPlotter.cc
@@ -624,7 +624,10 @@ void CTPPSProtonReconstructionPlotter::analyze(const edm::Event &event, const ed
 
   // make multi-RP-reco plots
   for (const auto &proton : *hRecoProtonsMultiRP) {
-    CTPPSDetId rpId((*proton.contributingLocalTracks().begin())->rpId());
+    // workaround for https://github.com/cms-sw/cmssw/issues/44931#issuecomment-2142898754
+    const auto &pcLTiter = *proton.contributingLocalTracks().begin();
+    assert(pcLTiter.isNonnull());
+    CTPPSDetId rpId(pcLTiter->rpId());
     unsigned int armId = rpId.arm();
 
     const bool n1f1 = (armTrackCounter_N[armId] == 1 && armTrackCounter_F[armId] == 1);


### PR DESCRIPTION
#### PR description:

Build of CMSSW_14_1_ASAN_X_2024-08-21-2300 failed with
```
In file included from src/DataFormats/Common/interface/RefVector.h:18,
                 from src/DataFormats/ProtonReco/interface/ForwardProton.h:14,
                 from src/Validation/CTPPS/plugins/CTPPSProtonReconstructionPlotter.cc:20:
In member function 'edm::RefVectorIterator<C, T, F>::reference edm::RefVectorIterator<C, T, F>::operator*() const [with C = std::vector<CTPPSLocalTrackLite>; T = CTPPSLocalTrackLite; F = edm::refhelper::FindUsingAdvance<std::vector<CTPPSLocalTrackLite>, CTPPSLocalTrackLite>]',
    inlined from 'virtual void CTPPSProtonReconstructionPlotter::analyze(const edm::Event&, const edm::EventSetup&)' at src/Validation/CTPPS/plugins/CTPPSProtonReconstructionPlotter.cc:627:22:
  src/DataFormats/Common/interface/RefVectorIterator.h:49:39: error: 'this' pointer is null [-Werror=nonnull]
    49 |       return (*nestedRefVector_)[iter_];
      |                                       ^
src/DataFormats/Common/interface/RefVector.h: In member function 'virtual void CTPPSProtonReconstructionPlotter::analyze(const edm::Event&, const edm::EventSetup&)':
src/DataFormats/Common/interface/RefVector.h:70:22: note: in a call to non-static member function 'const edm::RefVector<C, T, F>::value_type edm::RefVector<C, T, F>::operator[](size_type) const [with C = edm::RefVector<std::vector<CTPPSLocalTrackLite> >; T = CTPPSLocalTrackLite; F = edm::refhelper::FindRefVectorUsingAdvance<edm::RefVector<std::vector<CTPPSLocalTrackLite> > >]'
   70 |     value_type const operator[](size_type idx) const {
      |                      ^~~~~~~~
In member function 'edm::RefVectorIterator<C, T, F>::reference edm::RefVectorIterator<C, T, F>::operator*() const [with C = std::vector<CTPPSLocalTrackLite>; T = CTPPSLocalTrackLite; F = edm::refhelper::FindUsingAdvance<std::vector<CTPPSLocalTrackLite>, CTPPSLocalTrackLite>]',
    inlined from 'virtual void CTPPSProtonReconstructionPlotter::analyze(const edm::Event&, const edm::EventSetup&)' at src/Validation/CTPPS/plugins/CTPPSProtonReconstructionPlotter.cc:725:24:
  src/DataFormats/Common/interface/RefVectorIterator.h:49:39: error: 'this' pointer is null [-Werror=nonnull]
    49 |       return (*nestedRefVector_)[iter_];
      |                                       ^
src/DataFormats/Common/interface/RefVector.h: In member function 'virtual void CTPPSProtonReconstructionPlotter::analyze(const edm::Event&, const edm::EventSetup&)':
src/DataFormats/Common/interface/RefVector.h:70:22: note: in a call to non-static member function 'const edm::RefVector<C, T, F>::value_type edm::RefVector<C, T, F>::operator[](size_type) const [with C = edm::RefVector<std::vector<CTPPSLocalTrackLite> >; T = CTPPSLocalTrackLite; F = edm::refhelper::FindRefVectorUsingAdvance<edm::RefVector<std::vector<CTPPSLocalTrackLite> > >]'
   70 |     value_type const operator[](size_type idx) const {
      |                      ^~~~~~~~
cc1plus: some warnings being treated as errors
```

which is the same error as noted in https://github.com/cms-sw/cmssw/issues/44931#issuecomment-2134850535 and worked around in https://github.com/cms-sw/cmssw/issues/44931#issuecomment-2176186031 and https://github.com/cms-sw/cmssw/pull/45304. This PR applies the same workaround to other part in this code.

Resolves https://github.com/cms-sw/framework-team/issues/1004

#### PR validation:

Code compiles in CMSSW_14_1_ASAN_X_2024-08-21-2300