### PR TITLE
Phase2-hgx359XX Modify Three test scripts to test if the bug-fix for HGCalGeometry Works

### DIFF
--- a/Geometry/HGCalGeometry/src/HGCalGeometry.cc
+++ b/Geometry/HGCalGeometry/src/HGCalGeometry.cc
@@ -237,7 +237,7 @@ GlobalPoint HGCalGeometry::getPosition(const DetId& detid, bool cog, bool debug)
                                         << id.iCell2;
       }
       xy = m_topology.dddConstants().locateCell(
-          id.zSide, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, true, true, cog, debug);
+          id.zSide, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, true, false, cog, debug);
       double xx = id.zSide * xy.first;
       double zz = id.zSide * m_topology.dddConstants().waferZ(id.iLay, true);
       glob = GlobalPoint(xx, xy.second, zz);

--- a/Geometry/HGCalGeometry/src/HGCalGeometry.cc
+++ b/Geometry/HGCalGeometry/src/HGCalGeometry.cc
@@ -237,7 +237,7 @@ GlobalPoint HGCalGeometry::getPosition(const DetId& detid, bool cog, bool debug)
                                         << id.iCell2;
       }
       xy = m_topology.dddConstants().locateCell(
-          id.zSide, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, true, false, cog, debug);
+          id.zSide, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, true, true, cog, debug);
       double xx = id.zSide * xy.first;
       double zz = id.zSide * m_topology.dddConstants().waferZ(id.iLay, true);
       glob = GlobalPoint(xx, xy.second, zz);

--- a/Geometry/HGCalGeometry/test/python/testHGCalGeometryRotCheck_cfg.py
+++ b/Geometry/HGCalGeometry/test/python/testHGCalGeometryRotCheck_cfg.py
@@ -1,8 +1,9 @@
 ###############################################################################
 # Way to use this:
-#   cmsRun testHGCalGeometryRotCheck_cfg.py geometry=D88
+#   cmsRun testHGCalGeometryRotCheck_cfg.py geometry=D110
 #
-#   Options for type D88, D92, D93
+#   Options for type D95, D96, D98, D99, D100, D101, D102, D103, D104, D105,
+#                    D106, D107, D108, D109, D110, D111, D112, D113, D114
 #
 ###############################################################################
 import FWCore.ParameterSet.Config as cms
@@ -13,10 +14,10 @@ import FWCore.ParameterSet.VarParsing as VarParsing
 ### SETUP OPTIONS
 options = VarParsing.VarParsing('standard')
 options.register('geometry',
-                 "D92",
+                 "D110",
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.string,
-                  "type of operations: D88, D92, D93")
+                  "type of operations: D95, D96, D98, D99, D100, D101, D102, D103, D104, D105, D106, D107, D108, D109, D110, D111, D112, D113, D114")
 
 ### get and parse the command line arguments
 options.parseArguments()
@@ -27,12 +28,9 @@ process = cms.Process("HGCalGeometryRotCheck",Phase2C17I13M9)
 
 ####################################################################
 # Use the options
-if (options.geometry == "D88"):
-    process.load('Configuration.Geometry.GeometryExtended2026D88Reco_cff')
-elif (options.geometry == "D93"):
-    process.load('Configuration.Geometry.GeometryExtended2026D93Reco_cff')
-else:
-    process.load('Configuration.Geometry.GeometryExtended2026D92Reco_cff')
+geomFile = "Configuration.Geometry.GeometryExtended2026" + options.geometry + "Reco_cff"
+print("Geometry file: ", geomFile)
+process.load(geomFile)
 
 process.load("SimGeneral.HepPDTESSource.pdt_cfi")
 process.load('Geometry.HGCalGeometry.hgcalGeometryRotCheck_cfi')

--- a/Geometry/HGCalGeometry/test/python/testHGCalGeometryRotTest_cfg.py
+++ b/Geometry/HGCalGeometry/test/python/testHGCalGeometryRotTest_cfg.py
@@ -1,8 +1,9 @@
 ###############################################################################
 # Way to use this:
-#   cmsRun testHGCalGeometryRotTest_cfg.py geometry=D88
+#   cmsRun testHGCalGeometryRotTest_cfg.py geometry=D110
 #
-#   Options for type D88, D92, D93
+#   Options for type D95, D96, D98, D99, D100, D101, D102, D103, D104, D105,
+#                    D106, D107, D108, D109, D110, D111, D112, D113, D114
 #
 ###############################################################################
 import FWCore.ParameterSet.Config as cms
@@ -13,10 +14,10 @@ import FWCore.ParameterSet.VarParsing as VarParsing
 ### SETUP OPTIONS
 options = VarParsing.VarParsing('standard')
 options.register('geometry',
-                 "D92",
+                 "D110",
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.string,
-                  "type of operations: D88, D92, D93")
+                  "type of operations: D95, D96, D98, D99, D100, D101, D102, D103, D104, D105, D106, D107, D108, D109, D110, D111, D112, D113, D114")
 
 ### get and parse the command line arguments
 options.parseArguments()
@@ -27,12 +28,9 @@ process = cms.Process("HGCalGeometryRotCheck",Phase2C17I13M9)
 
 ####################################################################
 # Use the options
-if (options.geometry == "D88"):
-    process.load('Configuration.Geometry.GeometryExtended2026D88Reco_cff')
-elif (options.geometry == "D93"):
-    process.load('Configuration.Geometry.GeometryExtended2026D93Reco_cff')
-else:
-    process.load('Configuration.Geometry.GeometryExtended2026D92Reco_cff')
+geomFile = "Configuration.Geometry.GeometryExtended2026" + options.geometry + "Reco_cff"
+print("Geometry file: ", geomFile)
+process.load(geomFile)
 
 process.load("SimGeneral.HepPDTESSource.pdt_cfi")
 process.load('Geometry.HGCalGeometry.hgcalGeometryRotTest_cfi')

--- a/Geometry/HGCalGeometry/test/python/testHGCalGeometry_cfg.py
+++ b/Geometry/HGCalGeometry/test/python/testHGCalGeometry_cfg.py
@@ -2,7 +2,7 @@
 # Way to use this:
 #   cmsRun testHGCalHGCalGeometry_cfg.py geometry=V17
 #
-#   Options for geometry V16, V17
+#   Options for geometry V16, V17, V18
 #
 ###############################################################################
 import FWCore.ParameterSet.Config as cms
@@ -16,7 +16,7 @@ options.register('geometry',
                  "V17",
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.string,
-                  "geometry of operations: V16, V17")
+                  "geometry of operations: V16, V17, V18")
 
 ### get and parse the command line arguments
 options.parseArguments()
@@ -26,16 +26,13 @@ print(options)
 ####################################################################
 # Use the options
 
-if (options.geometry == "V16"):
-    from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
-    process = cms.Process('HGCHGCalGeometry',Phase2C17I13M9)
-    process.load("Geometry.HGCalCommonData.testHGCalV16XML_cfi")
-    process.load("Geometry.HGCalCommonData.hgcalV15ParametersInitialization_cfi")
-else:
-    from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
-    process = cms.Process('HGCHGCalGeometry',Phase2C17I13M9)
-    process.load("Geometry.HGCalCommonData.testHGCalV17XML_cfi")
-    process.load("Geometry.HGCalCommonData.hgcalV15ParametersInitialization_cfi")
+from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
+process = cms.Process('HGCHGCalGeometry',Phase2C17I13M9)
+geomFile = "Geometry.HGCalCommonData.testHGCal" + options.geometry + "XML_cfi"
+print("Geometry file: ", geomFile)
+process.load(geomFile)
+process.load("Geometry.HGCalCommonData.hgcalParametersInitialization_cfi")
+process.load("Geometry.HGCalCommonData.hgcalNumberingInitialization_cfi")
 
 process.load("SimGeneral.HepPDTESSource.pdt_cfi")
 process.load("Geometry.HGCalCommonData.hgcalNumberingInitialization_cfi")


### PR DESCRIPTION
#### PR description:

Revert the false flag in the appropriate place in HGCalGeometry and has been tested for V17 geometry. Thanks to Andrea Bocci and the HGCal Reco team.

After making this PR,  I see there is already PR #45782 which has made the same change in the HGCalGeometry code. So I am removing the fix in this code, but the test codes can remain

#### PR validation:

Tested using the cfg files in Geometry/HGCalGeometry/test/python

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to CMSSW_18_1_X