### PR TITLE
Revert changes made in BTV DQM with #45577

### DIFF
--- a/DQMOffline/RecoB/python/bTagCommon_cff.py
+++ b/DQMOffline/RecoB/python/bTagCommon_cff.py
@@ -40,13 +40,13 @@ bTagCommonBlock = cms.PSet(
         cms.PSet(
             bTagTrackIPAnalysisBlock,
             type = cms.string('CandIP'),
-            label = cms.InputTag("pfImpactParameterTagInfosPuppi"),
+            label = cms.InputTag("pfImpactParameterTagInfos"),
             folder = cms.string("IPTag")
         ),
 
         cms.PSet(
             bTagProbabilityAnalysisBlock,
-            label = cms.InputTag("pfJetProbabilityBJetTagsPuppi"),
+            label = cms.InputTag("pfJetProbabilityBJetTags"),
             folder = cms.string("JP")
         ),
 

--- a/DQMOffline/RecoB/python/dqmAnalyzer_cff.py
+++ b/DQMOffline/RecoB/python/dqmAnalyzer_cff.py
@@ -62,27 +62,6 @@ bTagPlotsMC = cms.Sequence(bTagValidation)
                                       doJEC=False
 )
 
-from Configuration.Eras.Modifier_fastSim_cff import fastSim
-fastSim.toModify(myak4JetFlavourInfos,
-    jets = "ak4PFJetsCHS",
-    weights = None
-).toModify(newpatJetGenJetMatch,
-   src = "ak4PFJetsCHS",
-).toModify(bTagValidation.tagConfig[0],
-   label = "pfImpactParameterTagInfos"
-).toModify(bTagValidation.tagConfig[1],
-   label = "pfJetProbabilityBJetTags"
-)
-
-from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
-pp_on_PbPb_run3.toModify(newpatJetGenJetMatch,
-           src = "akCs4PFJets",
-).toModify(bTagValidation.tagConfig[0],
-           label = "pfImpactParameterTagInfos"
-).toModify(bTagValidation.tagConfig[1],
-           label = "pfJetProbabilityBJetTags"
-)
-
 #to run on fullsim in the validation sequence, all histograms produced in the dqmoffline sequence
 bTagValidationNoall = bTagValidation.clone(flavPlots="bcl")
 bTagPlotsMCbcl = cms.Sequence(bTagValidationNoall)

--- a/DQMOffline/RecoB/python/dqmAnalyzer_cff.py
+++ b/DQMOffline/RecoB/python/dqmAnalyzer_cff.py
@@ -21,8 +21,7 @@ from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 from PhysicsTools.JetMCAlgos.HadronAndPartonSelector_cfi import selectedHadronsAndPartons
 from PhysicsTools.JetMCAlgos.AK4PFJetsMCFlavourInfos_cfi import ak4JetFlavourInfos
 myak4JetFlavourInfos = ak4JetFlavourInfos.clone(
-    jets = "ak4PFJetsPuppi",
-    weights = cms.InputTag("puppi"),
+    jets = "ak4PFJetsCHS",
     partons = "selectedHadronsAndPartons:algorithmicPartons",
     hadronFlavourHasPriority = True
     )
@@ -36,7 +35,7 @@ ak4GenJetsForPUid = cms.EDFilter("GenJetSelector",
 #do reco gen - reco matching
 from PhysicsTools.PatAlgos.mcMatchLayer0.jetMatch_cfi import patJetGenJetMatch
 newpatJetGenJetMatch = patJetGenJetMatch.clone(
-    src = "ak4PFJetsPuppi",
+    src = "ak4PFJetsCHS",
     matched = "ak4GenJetsForPUid",
     maxDeltaR = 0.25,
     resolveAmbiguities = True


### PR DESCRIPTION
#### PR description:

This PR fixes the failing RelVal tests (as raised here https://github.com/cms-sw/cmssw/pull/45577#issuecomment-2304706322) by reverting the changes made in #45577.  After closing inspection while preparing this PR, I think the AK4 CHS to Puppi switch needs to be discussed again for this particular BTV DQM / Validation since no b-tagging variables are set up to be computed at RECO level for AK4 Puppi jets (@cms-sw/btv-pog-l2).

#### PR validation:

- passes the usual runTheMatrix test: `runTheMatrix.py -l limited -i all --ibeos`
- passes the failing RelVal tests: `runTheMatrix.py -i all --ibeos -l 11.0,158.0,158.1,158.2,158.3,158.5,281.0,300.0,301.0,302.0,1311.0`