### PR TITLE
Add plotting utilities to generate Tracker maps given user input

### DIFF
--- a/DQM/TrackerRemapper/bin/BuildFile.xml
+++ b/DQM/TrackerRemapper/bin/BuildFile.xml
@@ -8,3 +8,4 @@
 <bin name="printPixelTrackerMap" file="printPixelTrackerMap.cc" />
 <bin name="printPixelROCsMap" file="printPixelROCsMap.cc" />
 <bin name="printPixelLayersDisksMap" file="printPixelLayersDisksMap.cc" />
+<bin name="printStripTrackerMap" file="printStripTrackerMap.cc" />

--- a/DQM/TrackerRemapper/bin/BuildFile.xml
+++ b/DQM/TrackerRemapper/bin/BuildFile.xml
@@ -6,3 +6,4 @@
 <use name="rootmath"/>
 <lib name="stdc++fs" />
 <bin name="printPixelTrackerMap" file="printPixelTrackerMap.cc" />
+<bin name="printPixelROCsMap" file="printPixelROCsMap.cc" />

--- a/DQM/TrackerRemapper/bin/BuildFile.xml
+++ b/DQM/TrackerRemapper/bin/BuildFile.xml
@@ -1,0 +1,8 @@
+<flags CXXFLAGS="-g -O3 -lASImage -lMultiProc" />
+<use name="DQM/TrackerRemapper"/>
+<use name="fmt"/>
+<use name="rootcore"/>
+<use name="rootgraphics"/>
+<use name="rootmath"/>
+<lib name="stdc++fs" />
+<bin name="printPixelTrackerMap" file="printPixelTrackerMap.cc" />

--- a/DQM/TrackerRemapper/bin/BuildFile.xml
+++ b/DQM/TrackerRemapper/bin/BuildFile.xml
@@ -7,3 +7,4 @@
 <lib name="stdc++fs" />
 <bin name="printPixelTrackerMap" file="printPixelTrackerMap.cc" />
 <bin name="printPixelROCsMap" file="printPixelROCsMap.cc" />
+<bin name="printPixelLayersDisksMap" file="printPixelLayersDisksMap.cc" />

--- a/DQM/TrackerRemapper/bin/printPixelLayersDisksMap.cc
+++ b/DQM/TrackerRemapper/bin/printPixelLayersDisksMap.cc
@@ -1,0 +1,69 @@
+#include "DQM/TrackerRemapper/interface/Phase1PixelMaps.h"
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <numeric>  // std::accumulate
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "TCanvas.h"
+#include "TStyle.h"
+
+int main(int argc, char* argv[]) {
+  std::string inputFile;
+  std::vector<std::pair<uint32_t, float>> detidValues;
+
+  // Parse command line arguments
+  for (int i = 1; i < argc; ++i) {
+    if (std::string(argv[i]) == "--input-file" && i + 1 < argc) {
+      gStyle->SetPalette(kRainbow);
+      gStyle->SetNumberContours(256);
+      inputFile = argv[++i];
+    } else {
+      gStyle->SetPalette(1);
+      // Treat as DetId list if no --input-file is provided
+      uint32_t detid = std::stoul(argv[i]);
+      detidValues.emplace_back(detid, 1.0);  // Default value is 1.0
+    }
+  }
+
+  // If --input-file is provided, read from file
+  if (!inputFile.empty()) {
+    std::ifstream file(inputFile);
+    if (!file) {
+      std::cerr << "Error: Unable to open input file " << inputFile << std::endl;
+      return 1;
+    }
+
+    std::string line;
+    while (std::getline(file, line)) {
+      std::istringstream iss(line);
+      uint32_t detid;
+      float value = 1.0;  // Default value
+
+      iss >> detid;
+      if (iss >> value) {  // If a second column exists, read it as value
+        detidValues.emplace_back(detid, value);
+      } else {
+        detidValues.emplace_back(detid, 1.0);
+      }
+    }
+  }
+
+  // Create the map and fill it
+  Phase1PixelMaps theMap("COLZ0A L");  // needed to not show the axis
+  TCanvas c = TCanvas("c", "c", 1200, 800);
+  theMap.book("mytest", "Marked modules", "input values");
+  for (const auto& [detid, value] : detidValues) {
+    theMap.fill("mytest", detid, value);
+  }
+
+  theMap.beautifyAllHistograms();
+  theMap.drawSummaryMaps("mytest", c);
+  c.SaveAs("Phase1PixelMaps_Summary.png");
+
+  std::cout << "Filled tracker map with " << detidValues.size() << " detids." << std::endl;
+
+  return 0;
+}

--- a/DQM/TrackerRemapper/bin/printPixelROCsMap.cc
+++ b/DQM/TrackerRemapper/bin/printPixelROCsMap.cc
@@ -1,0 +1,107 @@
+#include "DQM/TrackerRemapper/interface/Phase1PixelROCMaps.h"
+#include <bitset>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <numeric>  // std::accumulate
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "TCanvas.h"
+#include "TStyle.h"
+
+int main(int argc, char* argv[]) {
+  std::string inputFile;
+  std::string inputROCsFile;
+  std::vector<std::pair<uint32_t, float>> detidValues;
+  std::vector<std::pair<uint32_t, std::bitset<16>>> detidRocs;
+
+  // Parse command line arguments
+  for (int i = 1; i < argc; ++i) {
+    if (std::string(argv[i]) == "--input-file" && i + 1 < argc) {
+      gStyle->SetPalette(kRainbow);
+      gStyle->SetNumberContours(256);
+      inputFile = argv[++i];
+    } else if (std::string(argv[i]) == "--input-ROCs" && i + 1 < argc) {
+      gStyle->SetPalette(kRainBow);
+      gStyle->SetNumberContours(256);
+      inputROCsFile = argv[++i];
+    } else {
+      gStyle->SetPalette(1);
+      // Treat as DetId list if no --input-file is provided
+      uint32_t detid = std::stoul(argv[i]);
+      detidValues.emplace_back(detid, 1.0);  // Default value is 1.0
+    }
+  }
+
+  // If --input-file is provided, read from file
+  if (!inputFile.empty()) {
+    std::ifstream file(inputFile);
+    if (!file) {
+      std::cerr << "Error: Unable to open input file " << inputFile << std::endl;
+      return 1;
+    }
+
+    std::string line;
+    while (std::getline(file, line)) {
+      std::istringstream iss(line);
+      uint32_t detid;
+      float value = 1.0;  // Default value
+
+      iss >> detid;
+      if (iss >> value) {  // If a second column exists, read it as value
+        detidValues.emplace_back(detid, value);
+      } else {
+        detidValues.emplace_back(detid, 1.0);
+      }
+    }
+  }
+
+  // If --input-ROCs is provided, read from file
+  if (!inputROCsFile.empty()) {
+    std::ifstream file(inputROCsFile);
+    if (!file) {
+      std::cerr << "Error: Unable to open input ROCs file " << inputROCsFile << std::endl;
+      return 1;
+    }
+
+    std::string line;
+    while (std::getline(file, line)) {
+      std::istringstream iss(line);
+      uint32_t detid;
+      std::string rocBits;
+      iss >> detid >> rocBits;
+
+      if (rocBits.length() == 16) {
+        std::bitset<16> rocs(rocBits);
+        detidRocs.emplace_back(detid, rocs);
+      } else {
+        std::cerr << "Error: Invalid ROC bits string for detid " << detid << std::endl;
+        return 1;
+      }
+    }
+  }
+
+  // Create the map and fill it
+  Phase1PixelROCMaps theMap("");
+
+  // Fill with detidValues if --input-file or command line DetIds are used
+  for (const auto& [detid, value] : detidValues) {
+    theMap.fillWholeModule(detid, value);
+  }
+
+  // Fill with detidRocs if --input-ROCs is used
+  for (const auto& [detid, rocs] : detidRocs) {
+    theMap.fillSelectedRocs(detid, rocs, 1.0);  // Default value 1.0
+  }
+
+  // Draw and save the map
+  TCanvas canvas("Summary", "Summary", 1200, 1600);
+  theMap.drawMaps(canvas, "Marked Pixel ROCs");
+  canvas.SaveAs("Phase1PixelROCMap.png");
+
+  std::cout << "Filled Phase1 Pixel ROC map with " << detidValues.size() + detidRocs.size() << " detids." << std::endl;
+
+  return 0;
+}

--- a/DQM/TrackerRemapper/bin/printPixelTrackerMap.cc
+++ b/DQM/TrackerRemapper/bin/printPixelTrackerMap.cc
@@ -1,50 +1,69 @@
 #include "DQM/TrackerRemapper/interface/Phase1PixelSummaryMap.h"
+#include <cstdlib>
+#include <fstream>
 #include <iostream>
 #include <numeric>  // std::accumulate
-#include <iostream>
-#include <vector>
 #include <sstream>
 #include <string>
+#include <vector>
 
 #include "TCanvas.h"
 #include "TStyle.h"
 
 int main(int argc, char* argv[]) {
-  gStyle->SetPalette(1);
-  // Check if detids are provided as command line arguments
-  if (argc < 2) {
-    std::cerr << "Usage: " << argv[0] << " detid1 detid2 detid3 ..." << std::endl;
-    return 1;
+  std::string inputFile;
+  std::vector<std::pair<uint32_t, float>> detidValues;
+
+  // Parse command line arguments
+  for (int i = 1; i < argc; ++i) {
+    if (std::string(argv[i]) == "--input-file" && i + 1 < argc) {
+      gStyle->SetPalette(kRainbow);
+      gStyle->SetNumberContours(256);
+      inputFile = argv[++i];
+    } else {
+      gStyle->SetPalette(1);
+      // Treat as DetId list if no --input-file is provided
+      uint32_t detid = std::stoul(argv[i]);
+      detidValues.emplace_back(detid, 1.0);  // Default value is 1.0
+    }
   }
 
-  // Convert command line arguments to a vector of uint32_t detids
-  std::vector<uint32_t> detids;
-  for (int i = 1; i < argc; ++i) {
-    uint32_t detid;
-    std::stringstream ss(argv[i]);
-    if (!(ss >> detid)) {
-      std::cerr << "Error: Invalid detid: " << argv[i] << std::endl;
+  // If --input-file is provided, read from file
+  if (!inputFile.empty()) {
+    std::ifstream file(inputFile);
+    if (!file) {
+      std::cerr << "Error: Unable to open input file " << inputFile << std::endl;
       return 1;
     }
-    detids.push_back(detid);
+
+    std::string line;
+    while (std::getline(file, line)) {
+      std::istringstream iss(line);
+      uint32_t detid;
+      float value = 1.0;  // Default value
+
+      iss >> detid;
+      if (iss >> value) {  // If a second column exists, read it as value
+        detidValues.emplace_back(detid, value);
+      } else {
+        detidValues.emplace_back(detid, 1.0);
+      }
+    }
   }
 
-  // Create the Phase1PixelSummaryMap object
-  Phase1PixelSummaryMap theMap("colz", "Marked Pixel Modules", "");
-  
-  // Create the tracker base map
+  // Create the map and fill it
+  Phase1PixelSummaryMap theMap("colz", "Marked Pixel Modules", "input values");
   theMap.createTrackerBaseMap();
 
-  // Fill the tracker map with provided detids
-  for (const auto& detid : detids) {
-    theMap.fillTrackerMap(detid, 1.0);
+  for (const auto& [detid, value] : detidValues) {
+    theMap.fillTrackerMap(detid, value);
   }
 
   TCanvas c = TCanvas("c", "c", 3000, 2000);
   theMap.printTrackerMap(c);
   c.SaveAs("Phase1PixelSummaryMap.png");
 
-  std::cout << "Filled tracker map with " << detids.size() << " detids." << std::endl;
+  std::cout << "Filled tracker map with " << detidValues.size() << " detids." << std::endl;
 
   return 0;
 }

--- a/DQM/TrackerRemapper/bin/printPixelTrackerMap.cc
+++ b/DQM/TrackerRemapper/bin/printPixelTrackerMap.cc
@@ -1,0 +1,50 @@
+#include "DQM/TrackerRemapper/interface/Phase1PixelSummaryMap.h"
+#include <iostream>
+#include <numeric>  // std::accumulate
+#include <iostream>
+#include <vector>
+#include <sstream>
+#include <string>
+
+#include "TCanvas.h"
+#include "TStyle.h"
+
+int main(int argc, char* argv[]) {
+  gStyle->SetPalette(1);
+  // Check if detids are provided as command line arguments
+  if (argc < 2) {
+    std::cerr << "Usage: " << argv[0] << " detid1 detid2 detid3 ..." << std::endl;
+    return 1;
+  }
+
+  // Convert command line arguments to a vector of uint32_t detids
+  std::vector<uint32_t> detids;
+  for (int i = 1; i < argc; ++i) {
+    uint32_t detid;
+    std::stringstream ss(argv[i]);
+    if (!(ss >> detid)) {
+      std::cerr << "Error: Invalid detid: " << argv[i] << std::endl;
+      return 1;
+    }
+    detids.push_back(detid);
+  }
+
+  // Create the Phase1PixelSummaryMap object
+  Phase1PixelSummaryMap theMap("colz", "Marked Pixel Modules", "");
+  
+  // Create the tracker base map
+  theMap.createTrackerBaseMap();
+
+  // Fill the tracker map with provided detids
+  for (const auto& detid : detids) {
+    theMap.fillTrackerMap(detid, 1.0);
+  }
+
+  TCanvas c = TCanvas("c", "c", 3000, 2000);
+  theMap.printTrackerMap(c);
+  c.SaveAs("Phase1PixelSummaryMap.png");
+
+  std::cout << "Filled tracker map with " << detids.size() << " detids." << std::endl;
+
+  return 0;
+}

--- a/DQM/TrackerRemapper/bin/printStripTrackerMap.cc
+++ b/DQM/TrackerRemapper/bin/printStripTrackerMap.cc
@@ -1,0 +1,79 @@
+#include "DQM/TrackerRemapper/interface/SiStripTkMaps.h"
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <numeric>  // std::accumulate
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "TCanvas.h"
+#include "TStyle.h"
+
+int main(int argc, char* argv[]) {
+  std::string inputFile;
+  std::vector<std::pair<uint32_t, float>> detidValues;
+
+  // Parse command line arguments
+  for (int i = 1; i < argc; ++i) {
+    if (std::string(argv[i]) == "--input-file" && i + 1 < argc) {
+      gStyle->SetPalette(kRainbow);
+      gStyle->SetNumberContours(256);
+      inputFile = argv[++i];
+    } else {
+      gStyle->SetPalette(1);
+      // Treat as DetId list if no --input-file is provided
+      uint32_t detid = std::stoul(argv[i]);
+      detidValues.emplace_back(detid, 1.0);  // Default value is 1.0
+    }
+  }
+
+  // If --input-file is provided, read from file
+  if (!inputFile.empty()) {
+    std::ifstream file(inputFile);
+    if (!file) {
+      std::cerr << "Error: Unable to open input file " << inputFile << std::endl;
+      return 1;
+    }
+
+    std::string line;
+    while (std::getline(file, line)) {
+      std::istringstream iss(line);
+      uint32_t detid;
+      float value = 1.0;  // Default value
+
+      iss >> detid;
+      if (iss >> value) {  // If a second column exists, read it as value
+        detidValues.emplace_back(detid, value);
+      } else {
+        detidValues.emplace_back(detid, 1.0);
+      }
+    }
+  }
+
+  // Create the map and fill it
+  SiStripTkMaps theMap("COLZ0 AL");
+  theMap.bookMap("Strip Tracker Map of Marked modules", "input values");
+
+  for (const auto& [detid, value] : detidValues) {
+    theMap.fill(detid, value);
+  }
+
+  // Check if all values are the same using a lambda function
+  bool allSame = std::all_of(detidValues.begin(), detidValues.end(), [&](const std::pair<uint32_t, float>& p) {
+    return p.second == detidValues[0].second;
+  });
+
+  TCanvas c = TCanvas("c", "c");
+  theMap.drawMap(c, "");
+
+  // adjust the z-axis scale
+  if (allSame)
+    theMap.setZAxisRange(0., detidValues[0].second);
+
+  c.SaveAs("SiStripsTkMaps.png");
+
+  std::cout << "Filled tracker map with " << detidValues.size() << " detids." << std::endl;
+
+  return 0;
+}


### PR DESCRIPTION
#### PR description:

Title says it all. Useful when debugging conditions and or local reconstruction issues.
Supports two modes:
   * `printPixelTrackerMap detid1 detid2 detid3 ...`
   * `printPixelTrackerMap --input-file input.txt`


#### PR validation:

Run the script with a [user generated list](https://github.com/user-attachments/files/16740445/output3.txt) and obtained the following map:

![Phase1PixelSummaryMap](https://github.com/user-attachments/assets/273961d8-5e72-4c52-983b-ce82a2f13a6b)

Or:

```console
 cut -d' ' -f1 $CMSSW_RELEASE_BASE/src/CalibTracker/SiStripCommon/data/SiStripDetInfo.dat | shuf -n 5000 | paste -sd ' ' - | xargs printStripTrackerMap
 ```

generates:

![SiStripsTkMaps](https://github.com/user-attachments/assets/014b0978-b8d8-45ca-9e80-617a8fc94e06)


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A