### PR TITLE
better automatic handling of default 2026 geometry

### DIFF
--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026DefaultReco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026DefaultReco_cff.py
@@ -1,3 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.Geometry.defaultPhase2ConditionsEra_cff import DEFAULT_VERSION
 
-from Configuration.Geometry.GeometryDD4hepExtended2026D110Reco_cff import *
+reco_dd4hep_geometry_import_stmt = f"from Configuration.Geometry.GeometryDD4hepExtended{DEFAULT_VERSION}Reco_cff import *"
+exec(reco_dd4hep_geometry_import_stmt)

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026Default_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026Default_cff.py
@@ -1,3 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.Geometry.defaultPhase2ConditionsEra_cff import DEFAULT_VERSION
 
-from Configuration.Geometry.GeometryDD4hepExtended2026D110_cff import *
+dd4hep_geometry_import_stmt = f"from Configuration.Geometry.GeometryDD4hepExtended{DEFAULT_VERSION}_cff import *"
+exec(dd4hep_geometry_import_stmt)

--- a/Configuration/Geometry/python/GeometryExtended2026DefaultReco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026DefaultReco_cff.py
@@ -1,3 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.Geometry.defaultPhase2ConditionsEra_cff import DEFAULT_VERSION
 
-from Configuration.Geometry.GeometryExtended2026D110Reco_cff import *
+reco_geometry_import_stmt = f"from Configuration.Geometry.GeometryExtended{DEFAULT_VERSION}Reco_cff import *"
+exec(reco_geometry_import_stmt)

--- a/Configuration/Geometry/python/GeometryExtended2026Default_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026Default_cff.py
@@ -1,3 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.Geometry.defaultPhase2ConditionsEra_cff import DEFAULT_VERSION
 
-from Configuration.Geometry.GeometryExtended2026D110_cff import *
+geometry_import_stmt = f"from Configuration.Geometry.GeometryExtended{DEFAULT_VERSION}_cff import *"
+exec(geometry_import_stmt)


### PR DESCRIPTION
#### PR description:

This is a follow-up to https://github.com/cms-sw/cmssw/pull/45764, in order to enforce that the the "default" 2026 geometry is taken from one unique place (in this case: `Configuration/Geometry/python/defaultPhase2ConditionsEra_cff.py`).

#### PR validation:

Checked out the following packages 
```
git cms-addpkg Geometry/TrackerGeometryBuilder/ SimTracker/TrackerMaterialAnalysis RecoTracker/MkFit SLHCUpgradeSimulations/Geometry Alignment/OfflineValidation
```

 in which the default geometry is used and check that all the unit tests run fine with: `scram b runtests`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A