### PR TITLE
[14.0.X] Update Pixel GPU DQM online client

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1639,7 +1639,8 @@ upgradeWFs['PatatrackPixelOnlyAlpakaValidation'] = PatatrackWorkflow(
         '--customise' : 'HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling',
     },
     harvest = {
-        '-s': 'HARVESTING:@trackingOnlyValidation+@pixelTrackingOnlyDQM'
+        '-s': 'HARVESTING:@trackingOnlyValidation+@pixelTrackingOnlyDQM',
+        '--procModifiers': 'alpakaValidation',
     },
     suffix = 'Patatrack_PixelOnlyAlpaka_Validation',
     offset = 0.403,

--- a/DQM/Integration/python/clients/pixelgpu_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixelgpu_dqm_sourceclient-live_cfg.py
@@ -87,14 +87,20 @@ cmssw			= os.getenv("CMSSW_VERSION").split("_")
 #	Pixel DQM Tasks and Harvesters import
 #-------------------------------------
 process.load('DQM.SiPixelHeterogeneous.SiPixelHeterogenousDQM_FirstStep_cff')
+process.load('DQM.SiPixelHeterogeneous.SiPixelHeterogenousDQMHarvesting_cff')
+process.siPixelTrackComparisonHarvesterAlpaka.topFolderName = cms.string('SiPixelHeterogeneous/PixelTrackCompareGPUvsCPU')
 
 #-------------------------------------
 #	Some Settings before Finishing up
 #-------------------------------------
 if process.runType.getRunType() == process.runType.hi_run:
-    process.siPixelPhase1RawDataErrorComparator.pixelErrorSrcGPU = 'hltSiPixelDigisFromSoAPPOnAA'
-    process.siPixelPhase1RawDataErrorComparator.pixelErrorSrcCPU = 'hltSiPixelDigisLegacyPPOnAA'
+    process.siPixelPhase1MonitorRawDataASerial.src = 'hltSiPixelDigiErrorsPPOnAASerialSync'
+    process.siPixelPhase1MonitorRawDataADevice.src = 'hltSiPixelDigiErrorsPPOnAA'
+    process.siPixelPhase1RawDataErrorComparator.pixelErrorSrcGPU = 'hltSiPixelDigiErrorsPPOnAA'
+    process.siPixelPhase1RawDataErrorComparator.pixelErrorSrcCPU = 'hltSiPixelDigiErrorsPPOnAASerialSync'
 else:
+    process.siPixelPhase1MonitorRawDataASerial.src = 'hltSiPixelDigiErrorsSerialSync'
+    process.siPixelPhase1MonitorRawDataADevice.src = 'hltSiPixelDigiErrors'
     process.siPixelPhase1RawDataErrorComparator.pixelErrorSrcGPU = 'hltSiPixelDigiErrors'
     process.siPixelPhase1RawDataErrorComparator.pixelErrorSrcCPU = 'hltSiPixelDigiErrorsSerialSync'
 #-------------------------------------
@@ -106,7 +112,11 @@ process.dumpPath = cms.Path(process.dump)
 #-------------------------------------
 #	Hcal DQM Tasks/Clients Sequences Definition
 #-------------------------------------
-process.tasksPath = cms.Path(process.siPixelPhase1RawDataErrorComparator)
+process.tasksPath = cms.Path(process.siPixelPhase1MonitorRawDataASerial *
+                             process.siPixelPhase1MonitorRawDataADevice *
+                             process.siPixelPhase1RawDataErrorComparator *
+                             process.siPixelHeterogeneousDQMComparisonHarvestingAlpaka
+                             )
 
 #-------------------------------------
 #	Paths/Sequences Definitions

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareTracks.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareTracks.cc
@@ -11,6 +11,7 @@
 //
 
 // for string manipulations
+#include <algorithm>
 #include <fmt/printf.h>
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Math/interface/deltaR.h"
@@ -94,6 +95,9 @@ private:
   MonitorElement* hnTracks_;
   MonitorElement* hnLooseAndAboveTracks_;
   MonitorElement* hnLooseAndAboveTracks_matched_;
+  MonitorElement* hDeltaNTracks_;
+  MonitorElement* hDeltaNLooseAndAboveTracks_;
+  MonitorElement* hDeltaNLooseAndAboveTracks_matched_;
   MonitorElement* hnHits_;
   MonitorElement* hnHitsVsPhi_;
   MonitorElement* hnHitsVsEta_;
@@ -105,6 +109,7 @@ private:
   MonitorElement* hChi2VsPhi_;
   MonitorElement* hChi2VsEta_;
   MonitorElement* hpt_;
+  MonitorElement* hCurvature_;
   MonitorElement* hptLogLog_;
   MonitorElement* heta_;
   MonitorElement* hphi_;
@@ -200,6 +205,7 @@ void SiPixelCompareTracks<T>::analyzeSeparate(U tokenRef, V tokenTar, const edm:
     float phiRef = reco::phi(tsoaRef.view(), it);
     float zipRef = reco::zip(tsoaRef.view(), it);
     float tipRef = reco::tip(tsoaRef.view(), it);
+    auto qRef = reco::charge(tsoaRef.view(), it);
 
     if (!(ptRef > 0.))
       continue;
@@ -231,17 +237,18 @@ void SiPixelCompareTracks<T>::analyzeSeparate(U tokenRef, V tokenTar, const edm:
     nLooseAndAboveTracksRef_matchedTar++;
 
     hchi2_->Fill(tsoaRef.view()[it].chi2(), tsoaTar.view()[closestTkidx].chi2());
-    hCharge_->Fill(reco::charge(tsoaRef.view(), it), reco::charge(tsoaTar.view(), closestTkidx));
+    hCharge_->Fill(qRef, reco::charge(tsoaTar.view(), closestTkidx));
     hnHits_->Fill(helper::nHits(tsoaRef.view(), it), helper::nHits(tsoaTar.view(), closestTkidx));
     hnLayers_->Fill(tsoaRef.view()[it].nLayers(), tsoaTar.view()[closestTkidx].nLayers());
     hpt_->Fill(ptRef, tsoaTar.view()[closestTkidx].pt());
+    hCurvature_->Fill(qRef / ptRef, reco::charge(tsoaTar.view(), closestTkidx) / tsoaTar.view()[closestTkidx].pt());
     hptLogLog_->Fill(ptRef, tsoaTar.view()[closestTkidx].pt());
     heta_->Fill(etaRef, tsoaTar.view()[closestTkidx].eta());
     hphi_->Fill(phiRef, reco::phi(tsoaTar.view(), closestTkidx));
     hz_->Fill(zipRef, reco::zip(tsoaTar.view(), closestTkidx));
     htip_->Fill(tipRef, reco::tip(tsoaTar.view(), closestTkidx));
     hptdiffMatched_->Fill(ptRef - tsoaTar.view()[closestTkidx].pt());
-    hCurvdiffMatched_->Fill((reco::charge(tsoaRef.view(), it) / tsoaRef.view()[it].pt()) -
+    hCurvdiffMatched_->Fill(qRef / ptRef -
                             (reco::charge(tsoaTar.view(), closestTkidx) / tsoaTar.view()[closestTkidx].pt()));
     hetadiffMatched_->Fill(etaRef - tsoaTar.view()[closestTkidx].eta());
     hphidiffMatched_->Fill(reco::deltaPhi(phiRef, reco::phi(tsoaTar.view(), closestTkidx)));
@@ -250,9 +257,23 @@ void SiPixelCompareTracks<T>::analyzeSeparate(U tokenRef, V tokenTar, const edm:
     hpt_eta_tkAllRefMatched_->Fill(etaRef, tsoaRef.view()[it].pt());  //matched to gpu
     hphi_z_tkAllRefMatched_->Fill(etaRef, zipRef);
   }
-  hnTracks_->Fill(nTracksRef, nTracksTar);
-  hnLooseAndAboveTracks_->Fill(nLooseAndAboveTracksRef, nLooseAndAboveTracksTar);
-  hnLooseAndAboveTracks_matched_->Fill(nLooseAndAboveTracksRef, nLooseAndAboveTracksRef_matchedTar);
+
+  // Define a lambda function for filling the histograms
+  auto fillHistogram = [](auto& histogram, auto xValue, auto yValue) { histogram->Fill(xValue, yValue); };
+
+  // Define a lambda for filling delta histograms
+  auto fillDeltaHistogram = [](auto& histogram, int cpuValue, int gpuValue) {
+    histogram->Fill(std::min(cpuValue, 1000), std::clamp(gpuValue - cpuValue, -100, 100));
+  };
+
+  // Fill the histograms
+  fillHistogram(hnTracks_, nTracksRef, nTracksTar);
+  fillHistogram(hnLooseAndAboveTracks_, nLooseAndAboveTracksRef, nLooseAndAboveTracksTar);
+  fillHistogram(hnLooseAndAboveTracks_matched_, nLooseAndAboveTracksRef, nLooseAndAboveTracksRef_matchedTar);
+
+  fillDeltaHistogram(hDeltaNTracks_, nTracksRef, nTracksTar);
+  fillDeltaHistogram(hDeltaNLooseAndAboveTracks_, nLooseAndAboveTracksRef, nLooseAndAboveTracksTar);
+  fillDeltaHistogram(hDeltaNLooseAndAboveTracks_matched_, nLooseAndAboveTracksRef, nLooseAndAboveTracksRef_matchedTar);
 }
 
 //
@@ -275,13 +296,44 @@ void SiPixelCompareTracks<T>::bookHistograms(DQMStore::IBooker& iBook,
   iBook.cd();
   iBook.setCurrentFolder(topFolderName_);
 
-  // clang-format off
+  // Define a helper function for booking histograms
   std::string toRep = "Number of tracks";
+  auto bookTracksTH2I = [&](const std::string& name,
+                            const std::string& title,
+                            int xBins,
+                            double xMin,
+                            double xMax,
+                            int yBins,
+                            double yMin,
+                            double yMax) {
+    return iBook.book2I(name, fmt::sprintf(title, toRep), xBins, xMin, xMax, yBins, yMin, yMax);
+  };
+
+  // Define common parameters for different histogram types
+  constexpr int xBins = 501;
+  constexpr double xMin = -0.5;
+  constexpr double xMax = 1001.5;
+
+  constexpr int dXBins = 1001;
+  constexpr double dXMin = -0.5;
+  constexpr double dXMax = 1000.5;
+
+  constexpr int dYBins = 201;
+  constexpr double dYMin = -100.5;
+  constexpr double dYMax = 100.5;
+
   // FIXME: all the 2D correlation plots are quite heavy in terms of memory consumption, so a as soon as DQM supports THnSparse
   // these should be moved to a less resource consuming format
-  hnTracks_ = iBook.book2I("nTracks", fmt::sprintf("%s per event; Reference; Target",toRep), 501, -0.5, 500.5, 501, -0.5, 500.5);
-  hnLooseAndAboveTracks_ = iBook.book2I("nLooseAndAboveTracks", fmt::sprintf("%s (quality #geq loose) per event; Reference; Target",toRep), 501, -0.5, 500.5, 501, -0.5, 500.5);
-  hnLooseAndAboveTracks_matched_ = iBook.book2I("nLooseAndAboveTracks_matched", fmt::sprintf("%s (quality #geq loose) per event; Reference; Target",toRep), 501, -0.5, 500.5, 501, -0.5, 500.5);
+
+  // Book histograms using the helper function
+  // clang-format off
+  hnTracks_ = bookTracksTH2I("nTracks", "%s per event; Reference; Target", xBins, xMin, xMax, xBins, xMin, xMax);
+  hnLooseAndAboveTracks_ = bookTracksTH2I("nLooseAndAboveTracks", "%s (quality #geq loose) per event; Reference; Target", xBins, xMin, xMax, xBins, xMin, xMax);
+  hnLooseAndAboveTracks_matched_ = bookTracksTH2I("nLooseAndAboveTracks_matched", "%s (quality #geq loose) per event; Reference; Target", xBins, xMin, xMax, xBins, xMin, xMax);
+
+  hDeltaNTracks_ = bookTracksTH2I("deltaNTracks", "%s per event; Reference; Target - Reference", dXBins, dXMin, dXMax, dYBins, dYMin, dYMax);
+  hDeltaNLooseAndAboveTracks_ = bookTracksTH2I("deltaNLooseAndAboveTracks", "%s (quality #geq loose) per event; Reference; Target - Reference", dXBins, dXMin, dXMax, dYBins, dYMin, dYMax);
+  hDeltaNLooseAndAboveTracks_matched_ = bookTracksTH2I("deltaNLooseAndAboveTracks_matched", "%s (quality #geq loose) per event; Reference; Target - Reference", dXBins, dXMin, dXMax, dYBins, dYMin, dYMax);
 
   toRep = "Number of all RecHits per track (quality #geq loose)";
   hnHits_ = iBook.book2I("nRecHits", fmt::sprintf("%s;Reference;Target",toRep), 15, -0.5, 14.5, 15, -0.5, 14.5);
@@ -296,18 +348,20 @@ void SiPixelCompareTracks<T>::bookHistograms(DQMStore::IBooker& iBook,
   hCharge_ = iBook.book2I("charge",fmt::sprintf("%s;Reference;Target",toRep),3, -1.5, 1.5, 3, -1.5, 1.5);
 
   hpt_ = iBook.book2I("pt", "Track (quality #geq loose) p_{T} [GeV];Reference;Target", 200, 0., 200., 200, 0., 200.);
+  hCurvature_ = iBook.book2I("curvature", "Track (quality #geq loose) q/p_{T} [GeV^{-1}];Reference;Target",  60,- 3., 3., 60, -3., 3. );
   hptLogLog_ = make2DIfLog(iBook, true, true, "ptLogLog", "Track (quality #geq loose) p_{T} [GeV];Reference;Target", 200, log10(0.5), log10(200.), 200, log10(0.5), log10(200.));
   heta_ = iBook.book2I("eta", "Track (quality #geq loose) #eta;Reference;Target", 30, -3., 3., 30, -3., 3.);
   hphi_ = iBook.book2I("phi", "Track (quality #geq loose) #phi;Reference;Target", 30, -M_PI, M_PI, 30, -M_PI, M_PI);
   hz_ = iBook.book2I("z", "Track (quality #geq loose) z [cm];Reference;Target", 30, -30., 30., 30, -30., 30.);
   htip_ = iBook.book2I("tip", "Track (quality #geq loose) TIP [cm];Reference;Target", 100, -0.5, 0.5, 100, -0.5, 0.5);
+
   //1D difference plots
-  hptdiffMatched_ = iBook.book1D("ptdiffmatched", " p_{T} diff [GeV] between matched tracks; #Delta p_{T} [GeV]", 60, -30., 30.);
-  hCurvdiffMatched_ = iBook.book1D("curvdiffmatched", "q/p_{T} diff [GeV] between matched tracks; #Delta q/p_{T} [GeV]", 60, -30., 30.);
-  hetadiffMatched_ = iBook.book1D("etadiffmatched", " #eta diff between matched tracks; #Delta #eta", 160, -0.04 ,0.04);
-  hphidiffMatched_ = iBook.book1D("phidiffmatched", " #phi diff between matched tracks; #Delta #phi",  160, -0.04 ,0.04);
-  hzdiffMatched_ = iBook.book1D("zdiffmatched", " z diff between matched tracks; #Delta z [cm]", 300, -1.5, 1.5);
-  htipdiffMatched_ = iBook.book1D("tipdiffmatched", " TIP diff between matched tracks; #Delta TIP [cm]", 300, -1.5, 1.5);
+  hptdiffMatched_ = iBook.book1D("ptdiffmatched", " p_{T} diff [GeV] between matched tracks; #Delta p_{T} [GeV]", 61, -30.5, 30.5);
+  hCurvdiffMatched_ = iBook.book1D("curvdiffmatched", "q/p_{T} diff [GeV^{-1}] between matched tracks; #Delta q/p_{T} [GeV^{-1}]", 61, -3.05, 3.05);
+  hetadiffMatched_ = iBook.book1D("etadiffmatched", " #eta diff between matched tracks; #Delta #eta", 161, -0.045 ,0.045);
+  hphidiffMatched_ = iBook.book1D("phidiffmatched", " #phi diff between matched tracks; #Delta #phi",  161, -0.045 ,0.045);
+  hzdiffMatched_ = iBook.book1D("zdiffmatched", " z diff between matched tracks; #Delta z [cm]", 301, -1.55, 1.55);
+  htipdiffMatched_ = iBook.book1D("tipdiffmatched", " TIP diff between matched tracks; #Delta TIP [cm]", 301, -1.55, 1.55);
   //2D plots for eff
   hpt_eta_tkAllRef_ = iBook.book2I("ptetatrkAllReference", "Track (quality #geq loose) on Reference; #eta; p_{T} [GeV];", 30, -M_PI, M_PI, 200, 0., 200.);
   hpt_eta_tkAllRefMatched_ = iBook.book2I("ptetatrkAllReferencematched", "Track (quality #geq loose) on Reference matched to Target track; #eta; p_{T} [GeV];", 30, -M_PI, M_PI, 200, 0., 200.);
@@ -326,7 +380,7 @@ void SiPixelCompareTracks<T>::fillDescriptions(edm::ConfigurationDescriptions& d
   desc.add<std::string>("topFolderName", "SiPixelHeterogeneous/PixelTrackCompareDeviceVSHost");
   desc.add<bool>("useQualityCut", true);
   desc.add<std::string>("minQuality", "loose");
-  desc.add<double>("deltaR2cut", 0.04);
+  desc.add<double>("deltaR2cut", 0.02 * 0.02)->setComment("deltaR2 cut between track on device and host");
   descriptions.addWithDefaultLabel(desc);
 }
 

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorTrackSoA.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorTrackSoA.cc
@@ -52,6 +52,7 @@ private:
   MonitorElement* hChi2VsPhi;
   MonitorElement* hChi2VsEta;
   MonitorElement* hpt;
+  MonitorElement* hCurvature;
   MonitorElement* heta;
   MonitorElement* hphi;
   MonitorElement* hz;
@@ -112,6 +113,7 @@ void SiPixelMonitorTrackSoA<T>::analyze(const edm::Event& iEvent, const edm::Eve
     float zip = helper::zip(tsoa.const_view(), it);
     float eta = tsoa.view()[it].eta();
     float tip = helper::tip(tsoa.const_view(), it);
+    auto charge = helper::charge(tsoa.const_view(), it);
 
     hchi2->Fill(chi2);
     hChi2VsPhi->Fill(phi, chi2);
@@ -123,6 +125,7 @@ void SiPixelMonitorTrackSoA<T>::analyze(const edm::Event& iEvent, const edm::Eve
     hnLayersVsPhi->Fill(phi, nLayers);
     hnLayersVsEta->Fill(eta, nLayers);
     hpt->Fill(pt);
+    hCurvature->Fill(charge / pt);
     heta->Fill(eta);
     hphi->Fill(phi);
     hz->Fill(zip);
@@ -145,8 +148,8 @@ void SiPixelMonitorTrackSoA<T>::bookHistograms(DQMStore::IBooker& iBook,
 
   // clang-format off
   std::string toRep = "Number of tracks";
-  hnTracks = iBook.book1D("nTracks", fmt::sprintf(";%s per event;#events",toRep), 1001, -0.5, 1000.5);
-  hnLooseAndAboveTracks = iBook.book1D("nLooseAndAboveTracks", fmt::sprintf(";%s (quality #geq loose) per event;#events",toRep), 1001, -0.5, 1000.5);
+  hnTracks = iBook.book1D("nTracks", fmt::sprintf(";%s per event;#events",toRep), 1001, -0.5, 2001.5);
+  hnLooseAndAboveTracks = iBook.book1D("nLooseAndAboveTracks", fmt::sprintf(";%s (quality #geq loose) per event;#events",toRep), 1001, -0.5, 2001.5);
 
   toRep = "Number of all RecHits per track (quality #geq loose)";
   hnHits = iBook.book1D("nRecHits", fmt::sprintf(";%s;#tracks",toRep), 15, -0.5, 14.5);
@@ -165,6 +168,7 @@ void SiPixelMonitorTrackSoA<T>::bookHistograms(DQMStore::IBooker& iBook,
   // clang-format on
 
   hpt = iBook.book1D("pt", ";Track (quality #geq loose) p_{T} [GeV];#tracks", 200, 0., 200.);
+  hCurvature = iBook.book1D("curvature", ";Track (quality #geq loose) q/p_{T} [GeV^{-1}];#tracks", 100, -3., 3.);
   heta = iBook.book1D("eta", ";Track (quality #geq loose) #eta;#tracks", 30, -3., 3.);
   hphi = iBook.book1D("phi", ";Track (quality #geq loose) #phi;#tracks", 30, -M_PI, M_PI);
   hz = iBook.book1D("z", ";Track (quality #geq loose) z [cm];#tracks", 30, -30., 30.);

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorTrackSoAAlpaka.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorTrackSoAAlpaka.cc
@@ -52,6 +52,7 @@ private:
   MonitorElement* hChi2VsPhi;
   MonitorElement* hChi2VsEta;
   MonitorElement* hpt;
+  MonitorElement* hCurvature;
   MonitorElement* heta;
   MonitorElement* hphi;
   MonitorElement* hz;
@@ -112,6 +113,7 @@ void SiPixelMonitorTrackSoAAlpaka<T>::analyze(const edm::Event& iEvent, const ed
     float zip = tsoa.view()[it].state()(4);
     float eta = tsoa.view()[it].eta();
     float tip = tsoa.view()[it].state()(1);
+    auto charge = reco::charge(tsoa.view(), it);
 
     hchi2->Fill(chi2);
     hChi2VsPhi->Fill(phi, chi2);
@@ -123,6 +125,7 @@ void SiPixelMonitorTrackSoAAlpaka<T>::analyze(const edm::Event& iEvent, const ed
     hnLayersVsPhi->Fill(phi, nLayers);
     hnLayersVsEta->Fill(eta, nLayers);
     hpt->Fill(pt);
+    hCurvature->Fill(charge / pt);
     heta->Fill(eta);
     hphi->Fill(phi);
     hz->Fill(zip);
@@ -145,8 +148,8 @@ void SiPixelMonitorTrackSoAAlpaka<T>::bookHistograms(DQMStore::IBooker& iBook,
 
   // clang-format off
 std::string toRep = "Number of tracks";
-hnTracks = iBook.book1D("nTracks", fmt::format(";{} per event;#events",toRep), 1001, -0.5, 1000.5);
-hnLooseAndAboveTracks = iBook.book1D("nLooseAndAboveTracks", fmt::format(";{} (quality #geq loose) per event;#events",toRep), 1001, -0.5, 1000.5);
+hnTracks = iBook.book1D("nTracks", fmt::format(";{} per event;#events",toRep), 1001, -0.5, 2001.5);
+hnLooseAndAboveTracks = iBook.book1D("nLooseAndAboveTracks", fmt::format(";{} (quality #geq loose) per event;#events",toRep), 1001, -0.5, 2001.5);
 
 toRep = "Number of all RecHits per track (quality #geq loose)";
 hnHits = iBook.book1D("nRecHits", fmt::format(";{};#tracks",toRep), 15, -0.5, 14.5);
@@ -165,6 +168,7 @@ hChi2VsEta = iBook.bookProfile("nChi2ndofVsEta", fmt::format("{} vs track #eta;T
   // clang-format on
 
   hpt = iBook.book1D("pt", ";Track (quality #geq loose) p_{T} [GeV];#tracks", 200, 0., 200.);
+  hCurvature = iBook.book1D("curvature", ";Track (quality #geq loose) q/p_{T} [GeV^{-1}];#tracks", 100, -3., 3.);
   heta = iBook.book1D("eta", ";Track (quality #geq loose) #eta;#tracks", 30, -3., 3.);
   hphi = iBook.book1D("phi", ";Track (quality #geq loose) #phi;#tracks", 30, -M_PI, M_PI);
   hz = iBook.book1D("z", ";Track (quality #geq loose) z [cm];#tracks", 30, -30., 30.);

--- a/DQM/SiPixelHeterogeneous/python/SiPixelHeterogenousDQMHarvesting_cff.py
+++ b/DQM/SiPixelHeterogeneous/python/SiPixelHeterogenousDQMHarvesting_cff.py
@@ -2,19 +2,30 @@ import FWCore.ParameterSet.Config as cms
 siPixelHeterogeneousDQMHarvesting = cms.Sequence() # empty sequence if not both CPU and GPU recos are run
 
 from DQM.SiPixelPhase1Common.SiPixelPhase1RawData_cfi import *
-from DQM.SiPixelHeterogeneous.SiPixelHeterogenousDQM_FirstStep_cff import SiPixelPhase1RawDataConfForCPU,SiPixelPhase1RawDataConfForGPU
+from DQM.SiPixelHeterogeneous.SiPixelHeterogenousDQM_FirstStep_cff import SiPixelPhase1RawDataConfForCPU,SiPixelPhase1RawDataConfForGPU,SiPixelPhase1RawDataConfForSerial,SiPixelPhase1RawDataConfForDevice
 
+# CUDA code
 siPixelPhase1RawDataHarvesterCPU = SiPixelPhase1RawDataHarvester.clone(histograms = SiPixelPhase1RawDataConfForCPU)
 siPixelPhase1RawDataHarvesterGPU = SiPixelPhase1RawDataHarvester.clone(histograms = SiPixelPhase1RawDataConfForGPU)
 
+# alpaka code
+siPixelPhase1RawDataHarvesterSerial = SiPixelPhase1RawDataHarvester.clone(histograms = SiPixelPhase1RawDataConfForSerial)
+siPixelPhase1RawDataHarvesterDevice = SiPixelPhase1RawDataHarvester.clone(histograms = SiPixelPhase1RawDataConfForDevice)
+
 from DQM.SiPixelHeterogeneous.siPixelTrackComparisonHarvester_cfi import *
+siPixelTrackComparisonHarvesterAlpaka = siPixelTrackComparisonHarvester.clone(topFolderName = cms.string('SiPixelHeterogeneous/PixelTrackCompareDeviceVSHost'))
 
 siPixelHeterogeneousDQMComparisonHarvesting = cms.Sequence(siPixelPhase1RawDataHarvesterCPU *
                                                            siPixelPhase1RawDataHarvesterGPU *
                                                            siPixelTrackComparisonHarvester )
 
+siPixelHeterogeneousDQMComparisonHarvestingAlpaka = cms.Sequence(siPixelPhase1RawDataHarvesterSerial *
+                                                                 siPixelPhase1RawDataHarvesterDevice *
+                                                                 siPixelTrackComparisonHarvesterAlpaka )
+
 # add the harvester in case of the validation modifier is active
 from Configuration.ProcessModifiers.gpuValidationPixel_cff import gpuValidationPixel
 gpuValidationPixel.toReplaceWith(siPixelHeterogeneousDQMHarvesting,siPixelHeterogeneousDQMComparisonHarvesting)
 
-
+from Configuration.ProcessModifiers.alpakaValidationPixel_cff import alpakaValidationPixel
+(alpakaValidationPixel & ~gpuValidationPixel).toReplaceWith(siPixelHeterogeneousDQMHarvesting,siPixelHeterogeneousDQMComparisonHarvestingAlpaka)


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/45666

#### PR description:

This PR performs few simple updates of the pixel GPU DQM online client:
  * fix the pixel digi error collection names for the HIon menu ([CMSHLT-3284](https://its.cern.ch/jira/browse/CMSHLT-3284))
  * add pixel heterogeneous harvesting sequence for alpaka
  * update `pixelgpu_dqm_sourceclient-live` to add raw data input monitoring and track harvesting
  * add 2D scatter plot for track curvature and change matching deltaR from 0.2 to 0.02
  *  improvements to SoA track monitoring plugins
  *  add `alpakaValidation` modifier to .403 harvesting steps

#### PR validation:

`scram b runtests_TestDQMOnlineClient-pixelgpu_dqm_sourceclient` runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/45666 for 2024 data-taking purposes.