### PR TITLE
Add possibility for a `CopyToHost::postCopy()` operation

### DIFF
--- a/DataFormats/PortableTestObjects/interface/TestProductWithPtr.h
+++ b/DataFormats/PortableTestObjects/interface/TestProductWithPtr.h
@@ -1,0 +1,48 @@
+#ifndef DataFormats_PortableTest_interface_TestProductWithPtr_h
+#define DataFormats_PortableTest_interface_TestProductWithPtr_h
+
+#include "DataFormats/Portable/interface/PortableCollection.h"
+#include "DataFormats/SoATemplate/interface/SoACommon.h"
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+#include "DataFormats/SoATemplate/interface/SoAView.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/CopyToHost.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/CopyToDevice.h"
+
+#include <alpaka/alpaka.hpp>
+
+/**
+ * This data product is part of a test for CopyToHost::postCopy()
+ * (i.e. updating a data product after the device-to-host copy). For
+ * any practical purposes the indirection to 'buffer' array via the
+ * 'ptr' pointer scalar is completely unnecessary. Do not take this
+ * case as an example for good design of a data product.
+ */
+namespace portabletest {
+  GENERATE_SOA_LAYOUT(TestSoALayoutWithPtr, SOA_COLUMN(int, buffer), SOA_SCALAR(int*, ptr));
+  using TestSoAWithPtr = TestSoALayoutWithPtr<>;
+
+  template <typename TDev>
+  using TestProductWithPtr = PortableCollection<TestSoAWithPtr, TDev>;
+
+  ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE void setPtrInTestProductWithPtr(TestSoAWithPtr::View view) {
+    view.ptr() = &view.buffer(0);
+  }
+}  // namespace portabletest
+
+namespace cms::alpakatools {
+  template <typename TDev>
+  struct CopyToHost<PortableDeviceCollection<portabletest::TestSoAWithPtr, TDev>> {
+    template <typename TQueue>
+    static auto copyAsync(TQueue& queue, PortableDeviceCollection<portabletest::TestSoAWithPtr, TDev> const& src) {
+      PortableHostCollection<portabletest::TestSoAWithPtr> dst(src->metadata().size(), queue);
+      alpaka::memcpy(queue, dst.buffer(), src.buffer());
+      return dst;
+    }
+
+    static void postCopy(PortableHostCollection<portabletest::TestSoAWithPtr>& dst) {
+      portabletest::setPtrInTestProductWithPtr(dst.view());
+    }
+  };
+}  // namespace cms::alpakatools
+
+#endif

--- a/DataFormats/PortableTestObjects/src/alpaka/classes_cuda.h
+++ b/DataFormats/PortableTestObjects/src/alpaka/classes_cuda.h
@@ -1,5 +1,10 @@
+// these first to make sure they get included before any SoA header
+#include <Eigen/Core>
+#include <Eigen/Dense>
+
 #include "DataFormats/Common/interface/DeviceProduct.h"
 #include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/PortableTestObjects/interface/TestProductWithPtr.h"
 #include "DataFormats/PortableTestObjects/interface/TestSoA.h"
 #include "DataFormats/PortableTestObjects/interface/TestStruct.h"
 #include "DataFormats/PortableTestObjects/interface/alpaka/TestDeviceCollection.h"

--- a/DataFormats/PortableTestObjects/src/alpaka/classes_cuda_def.xml
+++ b/DataFormats/PortableTestObjects/src/alpaka/classes_cuda_def.xml
@@ -14,4 +14,8 @@
   <class name="alpaka_cuda_async::portabletest::TestDeviceMultiCollection3" persistent="false"/>
   <class name="edm::DeviceProduct<alpaka_cuda_async::portabletest::TestDeviceMultiCollection3>" persistent="false"/>
   <class name="edm::Wrapper<edm::DeviceProduct<alpaka_cuda_async::portabletest::TestDeviceMultiCollection3>>" persistent="false"/>
+
+  <class name="portabletest::TestProductWithPtr<alpaka_cuda_async::Device>"/>
+  <class name="edm::DeviceProduct<portabletest::TestProductWithPtr<alpaka_cuda_async::Device>>"/>
+  <class name="edm::Wrapper<edm::DeviceProduct<portabletest::TestProductWithPtr<alpaka_cuda_async::Device>>>" persistent="false"/>
 </lcgdict>

--- a/DataFormats/PortableTestObjects/src/alpaka/classes_rocm.h
+++ b/DataFormats/PortableTestObjects/src/alpaka/classes_rocm.h
@@ -1,5 +1,10 @@
+// these first to make sure they get included before any SoA header
+#include <Eigen/Core>
+#include <Eigen/Dense>
+
 #include "DataFormats/Common/interface/DeviceProduct.h"
 #include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/PortableTestObjects/interface/TestProductWithPtr.h"
 #include "DataFormats/PortableTestObjects/interface/TestSoA.h"
 #include "DataFormats/PortableTestObjects/interface/TestStruct.h"
 #include "DataFormats/PortableTestObjects/interface/alpaka/TestDeviceCollection.h"

--- a/DataFormats/PortableTestObjects/src/alpaka/classes_rocm_def.xml
+++ b/DataFormats/PortableTestObjects/src/alpaka/classes_rocm_def.xml
@@ -14,4 +14,8 @@
   <class name="alpaka_rocm_async::portabletest::TestDeviceMultiCollection3" persistent="false"/>
   <class name="edm::DeviceProduct<alpaka_rocm_async::portabletest::TestDeviceMultiCollection3>" persistent="false"/>
   <class name="edm::Wrapper<edm::DeviceProduct<alpaka_rocm_async::portabletest::TestDeviceMultiCollection3>>" persistent="false"/>
+
+  <class name="portabletest::TestProductWithPtr<alpaka_rocm_async::Device>"/>
+  <class name="edm::DeviceProduct<portabletest::TestProductWithPtr<alpaka_rocm_async::Device>>"/>
+  <class name="edm::Wrapper<edm::DeviceProduct<portabletest::TestProductWithPtr<alpaka_rocm_async::Device>>>" persistent="false"/>
 </lcgdict>

--- a/DataFormats/PortableTestObjects/src/classes.h
+++ b/DataFormats/PortableTestObjects/src/classes.h
@@ -1,5 +1,10 @@
+// these first to make sure they get included before any SoA header
+#include <Eigen/Core>
+#include <Eigen/Dense>
+
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/PortableTestObjects/interface/TestHostCollection.h"
 #include "DataFormats/PortableTestObjects/interface/TestHostObject.h"
+#include "DataFormats/PortableTestObjects/interface/TestProductWithPtr.h"
 #include "DataFormats/PortableTestObjects/interface/TestSoA.h"
 #include "DataFormats/PortableTestObjects/interface/TestStruct.h"

--- a/DataFormats/PortableTestObjects/src/classes_def.xml
+++ b/DataFormats/PortableTestObjects/src/classes_def.xml
@@ -39,4 +39,7 @@
   <class name="portabletest::TestHostMultiCollection3"/>
 
   <class name="edm::Wrapper<portabletest::TestHostMultiCollection3>" splitLevel="0"/>
+
+  <class name="portabletest::TestProductWithPtr<alpaka_common::DevHost>"/>
+  <class name="edm::Wrapper<portabletest::TestProductWithPtr<alpaka_common::DevHost>>" persistent="false"/>
 </lcgdict>

--- a/HeterogeneousCore/AlpakaCore/interface/alpaka/ProducerBase.h
+++ b/HeterogeneousCore/AlpakaCore/interface/alpaka/ProducerBase.h
@@ -17,18 +17,8 @@
 
 #include <memory>
 #include <tuple>
-#include <type_traits>
-#include <utility>
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
-  namespace detail {
-    template <typename, typename Arg, typename = void>
-    struct hasPostCopy : std::false_type {};
-
-    template <typename T, typename Arg>
-    struct hasPostCopy<T, Arg, std::void_t<decltype(T::postCopy(std::declval<Arg&>()))>> : std::true_type {};
-  }  // namespace detail
-
   template <typename Producer, edm::Transition Tr>
   class ProducerBaseAdaptor;
 
@@ -124,7 +114,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
             },
             [](auto tplPtr) {
               auto& productOnHost = std::get<0>(*tplPtr);
-              if constexpr (detail::hasPostCopy<CopyT, decltype(productOnHost)>::value) {
+              if constexpr (requires { CopyT::postCopy(productOnHost); }) {
                 CopyT::postCopy(productOnHost);
               }
               return std::move(productOnHost);

--- a/HeterogeneousCore/AlpakaInterface/interface/CopyToHost.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/CopyToHost.h
@@ -28,6 +28,29 @@ namespace cms::alpakatools {
    * queue. The ExampleDeviceProduct and ExampleHostProduct can be the
    * same type, if they internally are able to handle the memory
    * allocation difference between host and device.
+   *
+   * Data products that contain pointers to memory elsewhere in the
+   * data product need those pointers to be updated after the copy
+   * from device-to-host completes. While such data structures are
+   * generally discouraged, such an update of the data product can be
+   * implemented (without any additional synchronization) with an
+   * optional postCopy() static member function in the CopyToHost
+   * specialization. The postCopy() is called for the host-side data
+   * product after the copy operations enqueued in the copyAsync()
+   * have finished. Following the example above, the expected
+   * signature is
+   * \code
+   * template <>
+   * struct CopyToHost<ExampleDeviceProduct> {
+   *   // copyAsync() definition from above
+   *
+   *   static void postCopy(ExampleHostProduct& obj) {
+   *     // modify obj
+   *     // any modifications must be such that the postCopy() can be
+   *     // skipped when the obj originates from the host (i.e. on CPU backends)
+   *   }
+   * };
+   * \endcode
    */
   template <typename TDeviceData>
   struct CopyToHost;

--- a/HeterogeneousCore/AlpakaTest/plugins/TestAlpakaAnalyzerProductWithPtr.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/TestAlpakaAnalyzerProductWithPtr.cc
@@ -1,0 +1,47 @@
+#include "DataFormats/PortableTestObjects/interface/TestProductWithPtr.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+/**
+ * This class is part of testing CopyToHost<T>::postCopy().
+ */
+class TestAlpakaAnalyzerProductWithPtr : public edm::global::EDAnalyzer<> {
+public:
+  TestAlpakaAnalyzerProductWithPtr(edm::ParameterSet const& iConfig)
+      : token_(consumes(iConfig.getParameter<edm::InputTag>("src"))) {}
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<edm::InputTag>("src");
+    descriptions.addDefault(desc);
+  }
+
+  void analyze(edm::StreamID, edm::Event const& iEvent, edm::EventSetup const&) const override {
+    auto const& prod = iEvent.get(token_);
+    auto view = prod.view();
+    for (int i = 0; i < view.metadata().size(); ++i) {
+      auto const expected = i * 2 + 1;
+      if (expected != view.ptr()[i]) {
+        throw cms::Exception("Assert") << "Expected " << expected << " got " << view.ptr()[i];
+      }
+      if (view.buffer(i) != view.ptr()[i]) {
+        throw cms::Exception("Assert") << "Buffer has " << view.buffer(i) << " via pointer " << view.ptr()[i];
+      }
+    }
+  }
+
+private:
+  edm::EDGetTokenT<portabletest::TestProductWithPtr<alpaka_common::DevHost>> token_;
+};
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(TestAlpakaAnalyzerProductWithPtr);

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaGlobalProducerWithPtr.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaGlobalProducerWithPtr.cc
@@ -1,0 +1,41 @@
+#include "DataFormats/PortableTestObjects/interface/TestProductWithPtr.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/global/EDProducer.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/EDPutToken.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/ESGetToken.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaTest/interface/AlpakaESTestRecords.h"
+#include "HeterogeneousCore/AlpakaTest/interface/alpaka/AlpakaESTestData.h"
+
+#include "testPtrAlgoAsync.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+  /**
+   * This class is part of testing CopyToHost<T>::postCopy().
+   */
+  class TestAlpakaGlobalProducerWithPtr : public global::EDProducer<> {
+  public:
+    TestAlpakaGlobalProducerWithPtr(edm::ParameterSet const& config)
+        : token_{produces()}, size_{config.getParameter<int>("size")} {}
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+      desc.add<int>("size");
+      descriptions.addWithDefaultLabel(desc);
+    }
+
+    void produce(edm::StreamID, device::Event& iEvent, device::EventSetup const& iSetup) const override {
+      iEvent.emplace(token_, testPtrAlgoAsync(iEvent.queue(), size_));
+    }
+
+  private:
+    const device::EDPutToken<portabletest::TestProductWithPtr<Device>> token_;
+    const int32_t size_;
+  };
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/MakerMacros.h"
+DEFINE_FWK_ALPAKA_MODULE(TestAlpakaGlobalProducerWithPtr);

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/testPtrAlgoAsync.dev.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/testPtrAlgoAsync.dev.cc
@@ -1,0 +1,29 @@
+#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
+
+#include "testPtrAlgoAsync.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+  portabletest::TestProductWithPtr<Device> testPtrAlgoAsync(Queue& queue, int size) {
+    portabletest::TestProductWithPtr<Device> ret{size, queue};
+    using View = portabletest::TestProductWithPtr<Device>::View;
+    alpaka::exec<Acc1D>(
+        queue,
+        cms::alpakatools::make_workdiv<Acc1D>(1, 1),
+        [] ALPAKA_FN_ACC(Acc1D const& acc, View view) {
+          if (cms::alpakatools::once_per_grid(acc)) {
+            portabletest::setPtrInTestProductWithPtr(view);
+          }
+        },
+        ret.view());
+    alpaka::exec<Acc1D>(
+        queue,
+        cms::alpakatools::make_workdiv<Acc1D>(1, size),
+        [] ALPAKA_FN_ACC(Acc1D const& acc, View view) {
+          for (auto i : cms::alpakatools::uniform_elements(acc)) {
+            view.ptr()[i] = 2 * i + 1;
+          }
+        },
+        ret.view());
+    return ret;
+  }
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/testPtrAlgoAsync.h
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/testPtrAlgoAsync.h
@@ -1,0 +1,11 @@
+#ifndef HeterogeneousCore_AlpakaTest_plugins_alpaka_testPtrAlgo_h
+#define HeterogeneousCore_AlpakaTest_plugins_alpaka_testPtrAlgo_h
+
+#include "DataFormats/PortableTestObjects/interface/TestProductWithPtr.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+  portabletest::TestProductWithPtr<Device> testPtrAlgoAsync(Queue& queue, int size);
+}
+
+#endif

--- a/HeterogeneousCore/AlpakaTest/test/BuildFile.xml
+++ b/HeterogeneousCore/AlpakaTest/test/BuildFile.xml
@@ -14,6 +14,12 @@
   <use name="rocm"/>
 </test>
 
+<test name="testHeterogeneousCoreAlpakaTestCopyOfPtr" command="cmsRun ${LOCALTOP}/src/HeterogeneousCore/AlpakaTest/test/testAlpakaModulesCopyOfPtr_cfg.py">
+  <!-- dependence and flag only to trigger the unit test for each Alpaka backend -->
+  <use name="alpaka"/>
+  <flags ALPAKA_BACKENDS="1"/>
+</test>
+
 <bin name="alpakaTestPrintAnswer" file="alpaka/printAnswer.cpp">
   <use name="HeterogeneousCore/AlpakaInterface"/>
   <use name='HeterogeneousCore/AlpakaTest'/>

--- a/HeterogeneousCore/AlpakaTest/test/testAlpakaModulesCopyOfPtr_cfg.py
+++ b/HeterogeneousCore/AlpakaTest/test/testAlpakaModulesCopyOfPtr_cfg.py
@@ -1,0 +1,22 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('TEST')
+
+process.source = cms.Source('EmptySource')
+
+process.maxEvents.input = 3
+
+process.load('Configuration.StandardSequences.Accelerators_cff')
+process.load('HeterogeneousCore.AlpakaCore.ProcessAcceleratorAlpaka_cfi')
+
+process.producer = cms.EDProducer('TestAlpakaGlobalProducerWithPtr@alpaka',
+    size = cms.int32(32)
+)
+process.analyzer = cms.EDAnalyzer('TestAlpakaAnalyzerProductWithPtr',
+    src = cms.InputTag('producer')
+)
+
+process.p = cms.Path(
+    process.producer
+    + process.analyzer
+)


### PR DESCRIPTION
#### PR description:

Following https://github.com/cms-sw/cmssw/issues/45708#issuecomment-2294166204 this PR adds the possibility for a `CopyToHost<T>::postCopy()` function, that is called by the implicit data product device-to-host copy operation after the copy has finished (but only if the `postCopy()` function is defined). This facility allows data products that need to be updated after a `memcpy()` (e.g. because they have pointers to itself) to be used without blocking synchronization calls in `CopyToHost::copyAsync()`. I expect (hope) we will ever have only at most few such data products.

The first commit has a C++17 SFINAE -based solution for checking if the `CopyToHost<T>::postCopy()` exists (that can be backported to 14_0_X), and the second commit replaces that with C++20 concepts-based solution.

Resolves https://github.com/cms-sw/framework-team/issues/989

#### PR validation:

Added unit test runs on CPU-only and NVIDIA GPU nodes.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

~~To be backported to 14_1_X, and to 14_0_X (first commit only).~~ Following https://github.com/cms-sw/cmssw/issues/45708#issuecomment-2324539478 not to be backported.