### PR TITLE
[14.0.X] L1T DQM: Combined backport of cms-sw/cmssw#45242 and cms-sw/cmssw#45634

### DIFF
--- a/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 import sys
-from Configuration.Eras.Era_Run3_cff import Run3
-process = cms.Process("L1TStage2DQM", Run3)
+from Configuration.Eras.Era_Run3_2024_cff import Run3_2024
+process = cms.Process("L1TStage2DQM", Run3_2024)
 
 unitTest = False
 if 'unitTest=True' in sys.argv:

--- a/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 import sys
-from Configuration.Eras.Era_Run3_cff import Run3
-process = cms.Process("L1TStage2EmulatorDQM", Run3)
+from Configuration.Eras.Era_Run3_2024_cff import Run3_2024
+process = cms.Process("L1TStage2EmulatorDQM", Run3_2024)
 
 unitTest = False
 if 'unitTest=True' in sys.argv:

--- a/DQM/L1TMonitor/python/L1TStage2uGTTiming_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGTTiming_cfi.py
@@ -20,7 +20,9 @@ l1tStage2uGTTiming = DQMEDAnalyzer('L1TStage2uGTTiming',
         "L1_SingleJet180",
         "L1_ETMHF130",
         "L1_HTT360er",
-        "L1_ETT2000"
+        "L1_ETT2000",
+        "L1_AXO_Nominal",
+        "L1_AXO_VTight"
     ),
     prescaledAlgoShortList = cms.untracked.vstring(
         "L1_FirstCollisionInTrain",

--- a/DQM/L1TMonitor/python/L1TStage2uGTTiming_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGTTiming_cfi.py
@@ -1,46 +1,61 @@
 import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 
+unprescaledAlgoList = cms.untracked.vstring(
+    "L1_SingleMu22_BMTF",
+    "L1_SingleMu22_OMTF",
+    "L1_SingleMu22_EMTF",
+    "L1_SingleIsoEG28er1p5",
+    "L1_SingleIsoEG32er2p5",
+    "L1_SingleEG40er2p5",
+    "L1_SingleEG60",
+    "L1_SingleTau120er2p1",
+    "L1_SingleJet180",
+    "L1_ETMHF130",
+    "L1_HTT360er",
+    "L1_ETT2000"
+)
+prescaledAlgoList = cms.untracked.vstring(
+    "L1_FirstCollisionInTrain",
+    "L1_LastCollisionInTrain",
+    "L1_IsolatedBunch",
+    "L1_SingleMu0_BMTF",
+    "L1_SingleMu0_OMTF",
+    "L1_SingleMu0_EMTF",
+    "L1_SingleEG10er2p5",
+    "L1_SingleEG15er2p5",
+    "L1_SingleEG26er2p5",
+    "L1_SingleLooseIsoEG28er1p5",
+    "L1_SingleJet35",
+    "L1_SingleJet35er2p5",
+    "L1_SingleJet35_FWD2p5",
+    "L1_ETMHF100",
+    "L1_HTT120er",
+    "L1_ETT1600"
+)
+
+unprescaledAlgoList_2024 = unprescaledAlgoList
+unprescaledAlgoList_2024.append("L1_AXO_Nominal")
+unprescaledAlgoList_2024.append("L1_AXO_VTight")
+unprescaledAlgoList_2024.append("L1_CICADA_Medium")
+unprescaledAlgoList_2024.append("L1_CICADA_VTight")
+prescaledAlgoList_2024 = prescaledAlgoList
+prescaledAlgoList_2024.remove("L1_ETT1600")
+
 l1tStage2uGTTiming = DQMEDAnalyzer('L1TStage2uGTTiming',
-    l1tStage2uGtSource = cms.InputTag("gtStage2Digis"),    
+    l1tStage2uGtSource = cms.InputTag("gtStage2Digis"),
     monitorDir = cms.untracked.string("L1T/L1TStage2uGT/timing_aux"),
     verbose = cms.untracked.bool(False),
     firstBXInTrainAlgo = cms.untracked.string("L1_FirstCollisionInTrain"),
-    lastBXInTrainAlgo = cms.untracked.string("L1_LastCollisionInTrain"),    
-    isoBXAlgo = cms.untracked.string("L1_IsolatedBunch"),    
-    unprescaledAlgoShortList = cms.untracked.vstring(
-        "L1_SingleMu22_BMTF",
-        "L1_SingleMu22_OMTF",
-        "L1_SingleMu22_EMTF",
-        "L1_SingleIsoEG28er1p5",
-        "L1_SingleIsoEG32er2p5",
-        "L1_SingleEG40er2p5",
-        "L1_SingleEG60",
-        "L1_SingleTau120er2p1",
-        "L1_SingleJet180",
-        "L1_ETMHF130",
-        "L1_HTT360er",
-        "L1_ETT2000",
-        "L1_AXO_Nominal",
-        "L1_AXO_VTight"
-    ),
-    prescaledAlgoShortList = cms.untracked.vstring(
-        "L1_FirstCollisionInTrain",
-        "L1_LastCollisionInTrain",
-        "L1_IsolatedBunch",
-        "L1_SingleMu0_BMTF",
-        "L1_SingleMu0_OMTF",
-        "L1_SingleMu0_EMTF",
-        "L1_SingleEG10er2p5",
-        "L1_SingleEG15er2p5",
-        "L1_SingleEG26er2p5",
-        "L1_SingleLooseIsoEG28er1p5",
-        "L1_SingleJet35",
-        "L1_SingleJet35er2p5",
-        "L1_SingleJet35_FWD2p5",
-        "L1_ETMHF100",
-        "L1_HTT120er",
-        "L1_ETT1600"
-    ),
+    lastBXInTrainAlgo = cms.untracked.string("L1_LastCollisionInTrain"),
+    isoBXAlgo = cms.untracked.string("L1_IsolatedBunch"),
+    unprescaledAlgoShortList = unprescaledAlgoList,
+    prescaledAlgoShortList = prescaledAlgoList,
     useAlgoDecision = cms.untracked.string("initial")
+)
+
+from Configuration.Eras.Modifier_run3_2024_L1T_cff import run3_2024_L1T
+run3_2024_L1T.toModify(l1tStage2uGTTiming,
+    unprescaledAlgoShortList = unprescaledAlgoList_2024,
+    prescaledAlgoShortList = prescaledAlgoList_2024
 )

--- a/DQM/L1TMonitor/python/L1TStage2uGTTiming_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGTTiming_cfi.py
@@ -34,13 +34,17 @@ prescaledAlgoList = cms.untracked.vstring(
     "L1_ETT1600"
 )
 
-unprescaledAlgoList_2024 = unprescaledAlgoList
-unprescaledAlgoList_2024.append("L1_AXO_Nominal")
-unprescaledAlgoList_2024.append("L1_AXO_VTight")
-unprescaledAlgoList_2024.append("L1_CICADA_Medium")
-unprescaledAlgoList_2024.append("L1_CICADA_VTight")
-prescaledAlgoList_2024 = prescaledAlgoList
-prescaledAlgoList_2024.remove("L1_ETT1600")
+unprescaledAlgoList_2024 = cms.untracked.vstring(unprescaledAlgoList)
+unprescaledAlgoList_2024.extend([
+    "L1_AXO_Nominal",
+    "L1_AXO_VTight",
+    "L1_CICADA_Medium",
+    "L1_CICADA_VTight"
+])
+ 
+prescaledAlgoList_2024 = cms.untracked.vstring(prescaledAlgoList)
+if "L1_ETT1600" in prescaledAlgoList_2024:
+    prescaledAlgoList_2024.remove("L1_ETT1600")
 
 l1tStage2uGTTiming = DQMEDAnalyzer('L1TStage2uGTTiming',
     l1tStage2uGtSource = cms.InputTag("gtStage2Digis"),


### PR DESCRIPTION
#### PR description:

Combined backport https://github.com/cms-sw/cmssw/pull/45242 and https://github.com/cms-sw/cmssw/pull/45634:
   * Two Unprescaled AXO seeds, `L1_AXO_Nominal` and `L1_AXO_VTight`, added to unprescaled uGT algo shortlist. This aims to add these seeds to uGT algo accept vs BX plots (L1T Online shift plots 19-20).
   * modifies the era in the DQM client config files to fix the data emulator mismatches seen in BMTF Muon quality plots.

#### PR validation:

Tests at P5 OK: https://github.com/cms-sw/cmssw/pull/45242#issuecomment-2304369160

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of backport https://github.com/cms-sw/cmssw/pull/45242 and https://github.com/cms-sw/cmssw/pull/45634 for data-taking operations.