### PR TITLE
[14.1.X] Update Pixel GPU DQM online client

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1694,7 +1694,8 @@ upgradeWFs['PatatrackPixelOnlyAlpakaValidation'] = PatatrackWorkflow(
         '--customise' : 'HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling',
     },
     harvest = {
-        '-s': 'HARVESTING:@trackingOnlyValidation+@pixelTrackingOnlyDQM'
+        '-s': 'HARVESTING:@trackingOnlyValidation+@pixelTrackingOnlyDQM',
+        '--procModifiers': 'alpakaValidation',
     },
     suffix = 'Patatrack_PixelOnlyAlpaka_Validation',
     offset = 0.403,

--- a/DQM/Integration/python/clients/pixelgpu_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixelgpu_dqm_sourceclient-live_cfg.py
@@ -92,8 +92,8 @@ process.load('DQM.SiPixelHeterogeneous.SiPixelHeterogenousDQM_FirstStep_cff')
 #	Some Settings before Finishing up
 #-------------------------------------
 if process.runType.getRunType() == process.runType.hi_run:
-    process.siPixelPhase1RawDataErrorComparator.pixelErrorSrcGPU = 'hltSiPixelDigisFromSoAPPOnAA'
-    process.siPixelPhase1RawDataErrorComparator.pixelErrorSrcCPU = 'hltSiPixelDigisLegacyPPOnAA'
+    process.siPixelPhase1RawDataErrorComparator.pixelErrorSrcGPU = 'hltSiPixelDigiErrorsPPOnAA'
+    process.siPixelPhase1RawDataErrorComparator.pixelErrorSrcCPU = 'hltSiPixelDigiErrorsPPOnAASerialSync'
 else:
     process.siPixelPhase1RawDataErrorComparator.pixelErrorSrcGPU = 'hltSiPixelDigiErrors'
     process.siPixelPhase1RawDataErrorComparator.pixelErrorSrcCPU = 'hltSiPixelDigiErrorsSerialSync'

--- a/DQM/Integration/python/clients/pixelgpu_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixelgpu_dqm_sourceclient-live_cfg.py
@@ -87,14 +87,20 @@ cmssw			= os.getenv("CMSSW_VERSION").split("_")
 #	Pixel DQM Tasks and Harvesters import
 #-------------------------------------
 process.load('DQM.SiPixelHeterogeneous.SiPixelHeterogenousDQM_FirstStep_cff')
+process.load('DQM.SiPixelHeterogeneous.SiPixelHeterogenousDQMHarvesting_cff')
+process.siPixelTrackComparisonHarvesterAlpaka.topFolderName = cms.string('SiPixelHeterogeneous/PixelTrackCompareGPUvsCPU')
 
 #-------------------------------------
 #	Some Settings before Finishing up
 #-------------------------------------
 if process.runType.getRunType() == process.runType.hi_run:
+    process.siPixelPhase1MonitorRawDataASerial.src = 'hltSiPixelDigiErrorsPPOnAASerialSync'
+    process.siPixelPhase1MonitorRawDataADevice.src = 'hltSiPixelDigiErrorsPPOnAA'
     process.siPixelPhase1RawDataErrorComparator.pixelErrorSrcGPU = 'hltSiPixelDigiErrorsPPOnAA'
     process.siPixelPhase1RawDataErrorComparator.pixelErrorSrcCPU = 'hltSiPixelDigiErrorsPPOnAASerialSync'
 else:
+    process.siPixelPhase1MonitorRawDataASerial.src = 'hltSiPixelDigiErrorsSerialSync'
+    process.siPixelPhase1MonitorRawDataADevice.src = 'hltSiPixelDigiErrors'
     process.siPixelPhase1RawDataErrorComparator.pixelErrorSrcGPU = 'hltSiPixelDigiErrors'
     process.siPixelPhase1RawDataErrorComparator.pixelErrorSrcCPU = 'hltSiPixelDigiErrorsSerialSync'
 #-------------------------------------
@@ -106,7 +112,11 @@ process.dumpPath = cms.Path(process.dump)
 #-------------------------------------
 #	Hcal DQM Tasks/Clients Sequences Definition
 #-------------------------------------
-process.tasksPath = cms.Path(process.siPixelPhase1RawDataErrorComparator)
+process.tasksPath = cms.Path(process.siPixelPhase1MonitorRawDataASerial *
+                             process.siPixelPhase1MonitorRawDataADevice *
+                             process.siPixelPhase1RawDataErrorComparator *
+                             process.siPixelHeterogeneousDQMComparisonHarvestingAlpaka
+                             )
 
 #-------------------------------------
 #	Paths/Sequences Definitions

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareTrackSoA.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareTrackSoA.cc
@@ -95,6 +95,7 @@ private:
   MonitorElement* hChi2VsPhi_;
   MonitorElement* hChi2VsEta_;
   MonitorElement* hpt_;
+  MonitorElement* hCurvature_;
   MonitorElement* hptLogLog_;
   MonitorElement* heta_;
   MonitorElement* hphi_;
@@ -110,10 +111,10 @@ private:
   MonitorElement* htipdiffMatched_;
 
   //for matching eff vs region: derive the ratio at harvesting
-  MonitorElement* hpt_eta_tkAllCPU_;
-  MonitorElement* hpt_eta_tkAllCPUMatched_;
-  MonitorElement* hphi_z_tkAllCPU_;
-  MonitorElement* hphi_z_tkAllCPUMatched_;
+  MonitorElement* hpt_eta_tkAllRef_;
+  MonitorElement* hpt_eta_tkAllRefMatched_;
+  MonitorElement* hphi_z_tkAllRef_;
+  MonitorElement* hphi_z_tkAllRefMatched_;
 };
 
 //
@@ -187,6 +188,7 @@ void SiPixelCompareTrackSoA<T>::analyze(const edm::Event& iEvent, const edm::Eve
     float phiCPU = helper::phi(tsoaCPU.view(), it);
     float zipCPU = helper::zip(tsoaCPU.view(), it);
     float tipCPU = helper::tip(tsoaCPU.view(), it);
+    auto qCPU = helper::charge(tsoaCPU.view(), it);
 
     if (!(ptCPU > 0.))
       continue;
@@ -211,17 +213,18 @@ void SiPixelCompareTrackSoA<T>::analyze(const edm::Event& iEvent, const edm::Eve
       }
     }
 
-    hpt_eta_tkAllCPU_->Fill(etaCPU, ptCPU);  //all CPU tk
-    hphi_z_tkAllCPU_->Fill(phiCPU, zipCPU);
+    hpt_eta_tkAllRef_->Fill(etaCPU, ptCPU);  //all CPU tk
+    hphi_z_tkAllRef_->Fill(phiCPU, zipCPU);
     if (closestTkidx == notFound)
       continue;
     nLooseAndAboveTracksCPU_matchedGPU++;
 
     hchi2_->Fill(tsoaCPU.view()[it].chi2(), tsoaGPU.view()[closestTkidx].chi2());
-    hCharge_->Fill(helper::charge(tsoaCPU.view(), it), helper::charge(tsoaGPU.view(), closestTkidx));
+    hCharge_->Fill(qCPU, helper::charge(tsoaGPU.view(), closestTkidx));
     hnHits_->Fill(helper::nHits(tsoaCPU.view(), it), helper::nHits(tsoaGPU.view(), closestTkidx));
     hnLayers_->Fill(tsoaCPU.view()[it].nLayers(), tsoaGPU.view()[closestTkidx].nLayers());
     hpt_->Fill(ptCPU, tsoaGPU.view()[closestTkidx].pt());
+    hCurvature_->Fill(qCPU / ptCPU, helper::charge(tsoaGPU.view(), closestTkidx) / tsoaGPU.view()[closestTkidx].pt());
     hptLogLog_->Fill(ptCPU, tsoaGPU.view()[closestTkidx].pt());
     heta_->Fill(etaCPU, tsoaGPU.view()[closestTkidx].eta());
     hphi_->Fill(phiCPU, helper::phi(tsoaGPU.view(), closestTkidx));
@@ -234,8 +237,8 @@ void SiPixelCompareTrackSoA<T>::analyze(const edm::Event& iEvent, const edm::Eve
     hphidiffMatched_->Fill(reco::deltaPhi(phiCPU, helper::phi(tsoaGPU.view(), closestTkidx)));
     hzdiffMatched_->Fill(zipCPU - helper::zip(tsoaGPU.view(), closestTkidx));
     htipdiffMatched_->Fill(tipCPU - helper::tip(tsoaGPU.view(), closestTkidx));
-    hpt_eta_tkAllCPUMatched_->Fill(etaCPU, tsoaCPU.view()[it].pt());  //matched to gpu
-    hphi_z_tkAllCPUMatched_->Fill(etaCPU, zipCPU);
+    hpt_eta_tkAllRefMatched_->Fill(etaCPU, tsoaCPU.view()[it].pt());  //matched to gpu
+    hphi_z_tkAllRefMatched_->Fill(etaCPU, zipCPU);
   }
   hnTracks_->Fill(nTracksCPU, nTracksGPU);
   hnLooseAndAboveTracks_->Fill(nLooseAndAboveTracksCPU, nLooseAndAboveTracksGPU);
@@ -273,24 +276,25 @@ void SiPixelCompareTrackSoA<T>::bookHistograms(DQMStore::IBooker& iBook,
   hCharge_ = iBook.book2I("charge",fmt::sprintf("%s;CPU;GPU",toRep),3, -1.5, 1.5, 3, -1.5, 1.5);
 
   hpt_ = iBook.book2I("pt", "Track (quality #geq loose) p_{T} [GeV];CPU;GPU", 200, 0., 200., 200, 0., 200.);
+  hCurvature_ = iBook.book2I("curvature", "Track (quality #geq loose) q/p_{T} [GeV^{-1}];CPU;GPU",  60,- 3., 3., 60, -3., 3. );
   hptLogLog_ = make2DIfLog(iBook, true, true, "ptLogLog", "Track (quality #geq loose) p_{T} [GeV];CPU;GPU", 200, log10(0.5), log10(200.), 200, log10(0.5), log10(200.));
   heta_ = iBook.book2I("eta", "Track (quality #geq loose) #eta;CPU;GPU", 30, -3., 3., 30, -3., 3.);
   hphi_ = iBook.book2I("phi", "Track (quality #geq loose) #phi;CPU;GPU", 30, -M_PI, M_PI, 30, -M_PI, M_PI);
   hz_ = iBook.book2I("z", "Track (quality #geq loose) z [cm];CPU;GPU", 30, -30., 30., 30, -30., 30.);
   htip_ = iBook.book2I("tip", "Track (quality #geq loose) TIP [cm];CPU;GPU", 100, -0.5, 0.5, 100, -0.5, 0.5);
   //1D difference plots
-  hptdiffMatched_ = iBook.book1D("ptdiffmatched", " p_{T} diff [GeV] between matched tracks; #Delta p_{T} [GeV]", 60, -30., 30.);
-  hCurvdiffMatched_ = iBook.book1D("curvdiffmatched", "q/p_{T} diff [GeV] between matched tracks; #Delta q/p_{T} [GeV]", 60, -30., 30.);
-  hetadiffMatched_ = iBook.book1D("etadiffmatched", " #eta diff between matched tracks; #Delta #eta", 160, -0.04 ,0.04);
-  hphidiffMatched_ = iBook.book1D("phidiffmatched", " #phi diff between matched tracks; #Delta #phi",  160, -0.04 ,0.04);
-  hzdiffMatched_ = iBook.book1D("zdiffmatched", " z diff between matched tracks; #Delta z [cm]", 300, -1.5, 1.5);
-  htipdiffMatched_ = iBook.book1D("tipdiffmatched", " TIP diff between matched tracks; #Delta TIP [cm]", 300, -1.5, 1.5);
+  hptdiffMatched_ = iBook.book1D("ptdiffmatched", " p_{T} diff [GeV] between matched tracks; #Delta p_{T} [GeV]", 61, -30.5, 30.5);
+  hCurvdiffMatched_ = iBook.book1D("curvdiffmatched", "q/p_{T} diff [GeV^{-1}] between matched tracks; #Delta q/p_{T} [GeV^{-1}]", 61, -3.05, 3.05);
+  hetadiffMatched_ = iBook.book1D("etadiffmatched", " #eta diff between matched tracks; #Delta #eta", 161, -0.045 ,0.045);
+  hphidiffMatched_ = iBook.book1D("phidiffmatched", " #phi diff between matched tracks; #Delta #phi",  161, -0.045 ,0.045);
+  hzdiffMatched_ = iBook.book1D("zdiffmatched", " z diff between matched tracks; #Delta z [cm]", 301, -1.55, 1.55);
+  htipdiffMatched_ = iBook.book1D("tipdiffmatched", " TIP diff between matched tracks; #Delta TIP [cm]", 301, -1.55, 1.55);
   //2D plots for eff
-  hpt_eta_tkAllCPU_ = iBook.book2I("ptetatrkAllCPU", "Track (quality #geq loose) on CPU; #eta; p_{T} [GeV];", 30, -M_PI, M_PI, 200, 0., 200.);
-  hpt_eta_tkAllCPUMatched_ = iBook.book2I("ptetatrkAllCPUmatched", "Track (quality #geq loose) on CPU matched to GPU track; #eta; p_{T} [GeV];", 30, -M_PI, M_PI, 200, 0., 200.);
+  hpt_eta_tkAllRef_ = iBook.book2I("ptetatrkAllReference", "Track (quality #geq loose) on CPU; #eta; p_{T} [GeV];", 30, -M_PI, M_PI, 200, 0., 200.);
+  hpt_eta_tkAllRefMatched_ = iBook.book2I("ptetatrkAllReferencematched", "Track (quality #geq loose) on CPU matched to GPU track; #eta; p_{T} [GeV];", 30, -M_PI, M_PI, 200, 0., 200.);
 
-  hphi_z_tkAllCPU_ = iBook.book2I("phiztrkAllCPU", "Track (quality #geq loose) on CPU; #phi; z [cm];",  30, -M_PI, M_PI, 30, -30., 30.);
-  hphi_z_tkAllCPUMatched_ = iBook.book2I("phiztrkAllCPUmatched", "Track (quality #geq loose) on CPU; #phi; z [cm];", 30, -M_PI, M_PI, 30, -30., 30.);
+  hphi_z_tkAllRef_ = iBook.book2I("phiztrkAllReference", "Track (quality #geq loose) on CPU; #phi; z [cm];",  30, -M_PI, M_PI, 30, -30., 30.);
+  hphi_z_tkAllRefMatched_ = iBook.book2I("phiztrkAllReferencematched", "Track (quality #geq loose) on CPU; #phi; z [cm];", 30, -M_PI, M_PI, 30, -30., 30.);
 
 }
 
@@ -303,7 +307,7 @@ void SiPixelCompareTrackSoA<T>::fillDescriptions(edm::ConfigurationDescriptions&
   desc.add<std::string>("topFolderName", "SiPixelHeterogeneous/PixelTrackCompareGPUvsCPU");
   desc.add<bool>("useQualityCut", true);
   desc.add<std::string>("minQuality", "loose");
-  desc.add<double>("deltaR2cut", 0.04);
+  desc.add<double>("deltaR2cut", 0.02 * 0.02)->setComment("deltaR2 cut between track on CPU and GPU");
   descriptions.addWithDefaultLabel(desc);
 }
 

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareTracks.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareTracks.cc
@@ -299,7 +299,7 @@ void SiPixelCompareTracks<T>::bookHistograms(DQMStore::IBooker& iBook,
   hCharge_ = iBook.book2I("charge",fmt::sprintf("%s;Reference;Target",toRep),3, -1.5, 1.5, 3, -1.5, 1.5);
 
   hpt_ = iBook.book2I("pt", "Track (quality #geq loose) p_{T} [GeV];Reference;Target", 200, 0., 200., 200, 0., 200.);
-  hCurvature_ = iBook.book2I("curvature", "Track (quality #geq loose) q/p_{T} [GeV^{-1}];Reference;Target",  60,- 30, 30., 60, -30, 30 );
+  hCurvature_ = iBook.book2I("curvature", "Track (quality #geq loose) q/p_{T} [GeV^{-1}];Reference;Target",  60,- 3., 3., 60, -3., 3. );
   hptLogLog_ = make2DIfLog(iBook, true, true, "ptLogLog", "Track (quality #geq loose) p_{T} [GeV];Reference;Target", 200, log10(0.5), log10(200.), 200, log10(0.5), log10(200.));
   heta_ = iBook.book2I("eta", "Track (quality #geq loose) #eta;Reference;Target", 30, -3., 3., 30, -3., 3.);
   hphi_ = iBook.book2I("phi", "Track (quality #geq loose) #phi;Reference;Target", 30, -M_PI, M_PI, 30, -M_PI, M_PI);
@@ -308,7 +308,7 @@ void SiPixelCompareTracks<T>::bookHistograms(DQMStore::IBooker& iBook,
 
   //1D difference plots
   hptdiffMatched_ = iBook.book1D("ptdiffmatched", " p_{T} diff [GeV] between matched tracks; #Delta p_{T} [GeV]", 61, -30.5, 30.5);
-  hCurvdiffMatched_ = iBook.book1D("curvdiffmatched", "q/p_{T} diff [GeV] between matched tracks; #Delta q/p_{T} [GeV]", 61, -30.5, 30.5);
+  hCurvdiffMatched_ = iBook.book1D("curvdiffmatched", "q/p_{T} diff [GeV^{-1}] between matched tracks; #Delta q/p_{T} [GeV^{-1}]", 61, -3.05, 3.05);
   hetadiffMatched_ = iBook.book1D("etadiffmatched", " #eta diff between matched tracks; #Delta #eta", 161, -0.045 ,0.045);
   hphidiffMatched_ = iBook.book1D("phidiffmatched", " #phi diff between matched tracks; #Delta #phi",  161, -0.045 ,0.045);
   hzdiffMatched_ = iBook.book1D("zdiffmatched", " z diff between matched tracks; #Delta z [cm]", 301, -1.55, 1.55);

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorTrackSoA.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorTrackSoA.cc
@@ -148,8 +148,8 @@ void SiPixelMonitorTrackSoA<T>::bookHistograms(DQMStore::IBooker& iBook,
 
   // clang-format off
   std::string toRep = "Number of tracks";
-  hnTracks = iBook.book1D("nTracks", fmt::sprintf(";%s per event;#events",toRep), 1001, -0.5, 1000.5);
-  hnLooseAndAboveTracks = iBook.book1D("nLooseAndAboveTracks", fmt::sprintf(";%s (quality #geq loose) per event;#events",toRep), 1001, -0.5, 1000.5);
+  hnTracks = iBook.book1D("nTracks", fmt::sprintf(";%s per event;#events",toRep), 1001, -0.5, 2001.5);
+  hnLooseAndAboveTracks = iBook.book1D("nLooseAndAboveTracks", fmt::sprintf(";%s (quality #geq loose) per event;#events",toRep), 1001, -0.5, 2001.5);
 
   toRep = "Number of all RecHits per track (quality #geq loose)";
   hnHits = iBook.book1D("nRecHits", fmt::sprintf(";%s;#tracks",toRep), 15, -0.5, 14.5);

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorTrackSoA.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorTrackSoA.cc
@@ -52,6 +52,7 @@ private:
   MonitorElement* hChi2VsPhi;
   MonitorElement* hChi2VsEta;
   MonitorElement* hpt;
+  MonitorElement* hCurvature;
   MonitorElement* heta;
   MonitorElement* hphi;
   MonitorElement* hz;
@@ -112,6 +113,7 @@ void SiPixelMonitorTrackSoA<T>::analyze(const edm::Event& iEvent, const edm::Eve
     float zip = helper::zip(tsoa.const_view(), it);
     float eta = tsoa.view()[it].eta();
     float tip = helper::tip(tsoa.const_view(), it);
+    auto charge = helper::charge(tsoa.const_view(), it);
 
     hchi2->Fill(chi2);
     hChi2VsPhi->Fill(phi, chi2);
@@ -123,6 +125,7 @@ void SiPixelMonitorTrackSoA<T>::analyze(const edm::Event& iEvent, const edm::Eve
     hnLayersVsPhi->Fill(phi, nLayers);
     hnLayersVsEta->Fill(eta, nLayers);
     hpt->Fill(pt);
+    hCurvature->Fill(charge / pt);
     heta->Fill(eta);
     hphi->Fill(phi);
     hz->Fill(zip);
@@ -165,6 +168,7 @@ void SiPixelMonitorTrackSoA<T>::bookHistograms(DQMStore::IBooker& iBook,
   // clang-format on
 
   hpt = iBook.book1D("pt", ";Track (quality #geq loose) p_{T} [GeV];#tracks", 200, 0., 200.);
+  hCurvature = iBook.book1D("curvature", ";Track (quality #geq loose) q/p_{T} [GeV^{-1}];#tracks", 100, -3., 3.);
   heta = iBook.book1D("eta", ";Track (quality #geq loose) #eta;#tracks", 30, -3., 3.);
   hphi = iBook.book1D("phi", ";Track (quality #geq loose) #phi;#tracks", 30, -M_PI, M_PI);
   hz = iBook.book1D("z", ";Track (quality #geq loose) z [cm];#tracks", 30, -30., 30.);

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorTrackSoAAlpaka.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorTrackSoAAlpaka.cc
@@ -52,6 +52,7 @@ private:
   MonitorElement* hChi2VsPhi;
   MonitorElement* hChi2VsEta;
   MonitorElement* hpt;
+  MonitorElement* hCurvature;
   MonitorElement* heta;
   MonitorElement* hphi;
   MonitorElement* hz;
@@ -112,6 +113,7 @@ void SiPixelMonitorTrackSoAAlpaka<T>::analyze(const edm::Event& iEvent, const ed
     float zip = tsoa.view()[it].state()(4);
     float eta = tsoa.view()[it].eta();
     float tip = tsoa.view()[it].state()(1);
+    auto charge = reco::charge(tsoa.view(), it);
 
     hchi2->Fill(chi2);
     hChi2VsPhi->Fill(phi, chi2);
@@ -123,6 +125,7 @@ void SiPixelMonitorTrackSoAAlpaka<T>::analyze(const edm::Event& iEvent, const ed
     hnLayersVsPhi->Fill(phi, nLayers);
     hnLayersVsEta->Fill(eta, nLayers);
     hpt->Fill(pt);
+    hCurvature->Fill(charge / pt);
     heta->Fill(eta);
     hphi->Fill(phi);
     hz->Fill(zip);
@@ -165,6 +168,7 @@ hChi2VsEta = iBook.bookProfile("nChi2ndofVsEta", fmt::format("{} vs track #eta;T
   // clang-format on
 
   hpt = iBook.book1D("pt", ";Track (quality #geq loose) p_{T} [GeV];#tracks", 200, 0., 200.);
+  hCurvature = iBook.book1D("curvature", ";Track (quality #geq loose) q/p_{T} [GeV^{-1}];#tracks", 100, -3., 3.);
   heta = iBook.book1D("eta", ";Track (quality #geq loose) #eta;#tracks", 30, -3., 3.);
   hphi = iBook.book1D("phi", ";Track (quality #geq loose) #phi;#tracks", 30, -M_PI, M_PI);
   hz = iBook.book1D("z", ";Track (quality #geq loose) z [cm];#tracks", 30, -30., 30.);

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorTrackSoAAlpaka.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorTrackSoAAlpaka.cc
@@ -148,8 +148,8 @@ void SiPixelMonitorTrackSoAAlpaka<T>::bookHistograms(DQMStore::IBooker& iBook,
 
   // clang-format off
 std::string toRep = "Number of tracks";
-hnTracks = iBook.book1D("nTracks", fmt::format(";{} per event;#events",toRep), 1001, -0.5, 1000.5);
-hnLooseAndAboveTracks = iBook.book1D("nLooseAndAboveTracks", fmt::format(";{} (quality #geq loose) per event;#events",toRep), 1001, -0.5, 1000.5);
+hnTracks = iBook.book1D("nTracks", fmt::format(";{} per event;#events",toRep), 1001, -0.5, 2001.5);
+hnLooseAndAboveTracks = iBook.book1D("nLooseAndAboveTracks", fmt::format(";{} (quality #geq loose) per event;#events",toRep), 1001, -0.5, 2001.5);
 
 toRep = "Number of all RecHits per track (quality #geq loose)";
 hnHits = iBook.book1D("nRecHits", fmt::format(";{};#tracks",toRep), 15, -0.5, 14.5);

--- a/DQM/SiPixelHeterogeneous/python/SiPixelHeterogenousDQMHarvesting_cff.py
+++ b/DQM/SiPixelHeterogeneous/python/SiPixelHeterogenousDQMHarvesting_cff.py
@@ -2,19 +2,30 @@ import FWCore.ParameterSet.Config as cms
 siPixelHeterogeneousDQMHarvesting = cms.Sequence() # empty sequence if not both CPU and GPU recos are run
 
 from DQM.SiPixelPhase1Common.SiPixelPhase1RawData_cfi import *
-from DQM.SiPixelHeterogeneous.SiPixelHeterogenousDQM_FirstStep_cff import SiPixelPhase1RawDataConfForCPU,SiPixelPhase1RawDataConfForGPU
+from DQM.SiPixelHeterogeneous.SiPixelHeterogenousDQM_FirstStep_cff import SiPixelPhase1RawDataConfForCPU,SiPixelPhase1RawDataConfForGPU,SiPixelPhase1RawDataConfForSerial,SiPixelPhase1RawDataConfForDevice
 
+# CUDA code
 siPixelPhase1RawDataHarvesterCPU = SiPixelPhase1RawDataHarvester.clone(histograms = SiPixelPhase1RawDataConfForCPU)
 siPixelPhase1RawDataHarvesterGPU = SiPixelPhase1RawDataHarvester.clone(histograms = SiPixelPhase1RawDataConfForGPU)
 
+# alpaka code
+siPixelPhase1RawDataHarvesterSerial = SiPixelPhase1RawDataHarvester.clone(histograms = SiPixelPhase1RawDataConfForSerial)
+siPixelPhase1RawDataHarvesterDevice = SiPixelPhase1RawDataHarvester.clone(histograms = SiPixelPhase1RawDataConfForDevice)
+
 from DQM.SiPixelHeterogeneous.siPixelTrackComparisonHarvester_cfi import *
+siPixelTrackComparisonHarvesterAlpaka = siPixelTrackComparisonHarvester.clone(topFolderName = cms.string('SiPixelHeterogeneous/PixelTrackCompareDeviceVSHost'))
 
 siPixelHeterogeneousDQMComparisonHarvesting = cms.Sequence(siPixelPhase1RawDataHarvesterCPU *
                                                            siPixelPhase1RawDataHarvesterGPU *
                                                            siPixelTrackComparisonHarvester )
 
+siPixelHeterogeneousDQMComparisonHarvestingAlpaka = cms.Sequence(siPixelPhase1RawDataHarvesterSerial *
+                                                                 siPixelPhase1RawDataHarvesterDevice *
+                                                                 siPixelTrackComparisonHarvesterAlpaka )
+
 # add the harvester in case of the validation modifier is active
 from Configuration.ProcessModifiers.gpuValidationPixel_cff import gpuValidationPixel
 gpuValidationPixel.toReplaceWith(siPixelHeterogeneousDQMHarvesting,siPixelHeterogeneousDQMComparisonHarvesting)
 
-
+from Configuration.ProcessModifiers.alpakaValidationPixel_cff import alpakaValidationPixel
+(alpakaValidationPixel & ~gpuValidationPixel).toReplaceWith(siPixelHeterogeneousDQMHarvesting,siPixelHeterogeneousDQMComparisonHarvestingAlpaka)


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/45666

#### PR description:

This PR performs few simple updates of the pixel GPU DQM online client:
  * fix the pixel digi error collection names for the HIon menu ([CMSHLT-3284](https://its.cern.ch/jira/browse/CMSHLT-3284))
  * add pixel heterogeneous harvesting sequence for alpaka
  * update `pixelgpu_dqm_sourceclient-live` to add raw data input monitoring and track harvesting
  * add 2D scatter plot for track curvature and change matching deltaR from 0.2 to 0.02
  *  improvements to SoA track monitoring plugins
  *  add `alpakaValidation` modifier to .403 harvesting steps

#### PR validation:

`scram b runtests_TestDQMOnlineClient-pixelgpu_dqm_sourceclient` runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of https://github.com/cms-sw/cmssw/pull/45666 for 2024 HIon data-taking operations
