### PR TITLE
add unit tests for `SiPhase2OTFakeLorentzAngleESSource`

### DIFF
--- a/CondTools/SiPhase2Tracker/test/SiPhase2OuterTrackerLorentzAngleReader_cfg.py
+++ b/CondTools/SiPhase2Tracker/test/SiPhase2OuterTrackerLorentzAngleReader_cfg.py
@@ -1,7 +1,22 @@
 #! /usr/bin/env cmsRun
 # Author: Marco Musich (October 2021)
 import FWCore.ParameterSet.Config as cms
-process = cms.Process("TEST")
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+###################################################################
+# Set default phase-2 settings
+###################################################################
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
+
+process = cms.Process("TEST",_PH2_ERA)
+options = VarParsing.VarParsing('analysis')
+options.register('fromESSource',
+                 False, # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.bool,
+                 "Populate SiPhase2OuterTrackerLorentzAngleRcd from the ESSource")
+options.parseArguments()
 
 ###################################################################
 # Messages
@@ -20,6 +35,7 @@ process.MessageLogger.cout = cms.untracked.PSet(
                                    ),                                                      
   SiPhase2OuterTrackerLorentzAngleReader = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
   SiPhase2OuterTrackerLorentzAngle = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
+  SiPhase2OuterTrackerFakeLorentzAngleESSource =  cms.untracked.PSet( limit = cms.untracked.int32(-1))
 )
 
 ###################################################################
@@ -36,22 +52,38 @@ process.source = cms.Source("EmptyIOVSource",
 ###################################################################
 # Input data
 ###################################################################
-tag = 'SiPhase2OuterTrackerLorentzAngle_T33'
-suffix = 'v0'
-inFile = tag+'_'+suffix+'.db'
-inDB = 'sqlite_file:'+inFile
+if(options.fromESSource):
+    process.load("Configuration.Geometry.GeometryExtended2026Default_cff")
+    process.load('Configuration.Geometry.GeometryExtended2026DefaultReco_cff')
+    process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+    from Configuration.AlCa.GlobalTag import GlobalTag
+    process.GlobalTag = GlobalTag(process.GlobalTag, _PH2_GLOBAL_TAG, '')
 
-process.load("CondCore.CondDB.CondDB_cfi")
-# input database (in this case the local sqlite file)
-process.CondDB.connect = inDB
+    # process.SiPhase2OTFakeLorentzAngleESSource = cms.ESSource('SiPhase2OuterTrackerFakeLorentzAngleESSource',
+    #                                                           LAValue = cms.double(0.014),
+    #                                                           recordName = cms.string("LorentzAngle"))
+    # process.es_prefer_fake_LA = cms.ESPrefer("SiPhase2OuterTrackerFakeLorentzAngleESSource","SiPhase2OTFakeLorentzAngleESSource")
 
-process.PoolDBESSource = cms.ESSource("PoolDBESSource",
-                                      process.CondDB,
-                                      DumpStat=cms.untracked.bool(True),
-                                      toGet = cms.VPSet(cms.PSet(record = cms.string("SiPhase2OuterTrackerLorentzAngleRcd"),
-                                                                 tag = cms.string(tag))
-                                                       )
-                                      )
+    from CalibTracker.SiPhase2TrackerESProducers.SiPhase2OuterTrackerFakeLorentzAngleESSource_cfi import SiPhase2OTFakeLorentzAngleESSource
+    process.mySiPhase2OTFakeLorentzAngleESSource =  SiPhase2OTFakeLorentzAngleESSource.clone(LAValue = cms.double(0.14))
+    process.es_prefer_fake_LA = cms.ESPrefer("SiPhase2OuterTrackerFakeLorentzAngleESSource","mySiPhase2OTFakeLorentzAngleESSource")
+else:
+    tag = 'SiPhase2OuterTrackerLorentzAngle_T33'
+    suffix = 'v0'
+    inFile = tag+'_'+suffix+'.db'
+    inDB = 'sqlite_file:'+inFile
+
+    process.load("CondCore.CondDB.CondDB_cfi")
+    # input database (in this case the local sqlite file)
+    process.CondDB.connect = inDB
+
+    process.PoolDBESSource = cms.ESSource("PoolDBESSource",
+                                          process.CondDB,
+                                          DumpStat=cms.untracked.bool(True),
+                                          toGet = cms.VPSet(cms.PSet(record = cms.string("SiPhase2OuterTrackerLorentzAngleRcd"),
+                                                                     tag = cms.string(tag))
+                                                            )
+                                          )
 
 ###################################################################
 # check the ES data getter

--- a/CondTools/SiPhase2Tracker/test/test_CondToolsSiPhase2Tracker.sh
+++ b/CondTools/SiPhase2Tracker/test/test_CondToolsSiPhase2Tracker.sh
@@ -7,12 +7,13 @@ printf "testing writing Phase2 Outer Tracker Lorentz Angle \n\n"
 ## need to be in order (don't read before writing)
 cmsRun ${TEST_DIR}/SiPhase2OuterTrackerLorentzAngleWriter_cfg.py || die "Failure running SiPhase2OuterTrackerLorentzAngleWriter_cfg.py " $?
 cmsRun ${TEST_DIR}/SiPhase2OuterTrackerLorentzAngleReader_cfg.py || die "Failure running SiPhase2OuterTrackerLorentzAngleReader_cfg.py " $?
+cmsRun ${TEST_DIR}/SiPhase2OuterTrackerLorentzAngleReader_cfg.py fromESSource=True || die "Failure running SiPhase2OuterTrackerLorentzAngleReader_cfg.py fromESSource=True" $?
 
 printf "testing writing Phase2 Outer Tracker Bad Strips \n\n"
 ## need to be in order (don't read before writing)
 cmsRun ${TEST_DIR}/SiPhase2BadStripChannelBuilder_cfg.py algorithm=1 || die "Failure running SiPhase2BadStripChannelBuilder_cfg.py (naive)" $?
-cmsRun ${TEST_DIR}/SiPhase2BadStripChannelBuilder_cfg.py algorithm=1 || die "Failure running SiPhase2BadStripChannelBuilder_cfg.py (random)" $?
-cmsRun ${TEST_DIR}/SiPhase2BadStripChannelReader_cfg.py  || die "Failure running SiPhase2BadStripChannelReader_cfg.py" $?
+cmsRun ${TEST_DIR}/SiPhase2BadStripChannelBuilder_cfg.py algorithm=2 || die "Failure running SiPhase2BadStripChannelBuilder_cfg.py (random)" $?
+cmsRun ${TEST_DIR}/SiPhase2BadStripChannelReader_cfg.py || die "Failure running SiPhase2BadStripChannelReader_cfg.py" $?
 cmsRun ${TEST_DIR}/SiPhase2BadStripChannelReader_cfg.py fromESSource=True || die "Failure running SiPhase2BadStripChannelReader_cfg.py fromESSource=True" $?
 
 printf "testing writing Phase2 Tracker Cabling Map (test) \n\n"


### PR DESCRIPTION
#### PR description:

PR https://github.com/cms-sw/cmssw/pull/45730 made me realize that we lack dedicated unit tests for  `SiPhase2OTFakeLorentzAngleESSource`. This PR adds them as part of `test_CondToolsSiPhase2Tracker`. 

#### PR validation:

`scram b runtests_test_CondToolsSiPhase2Tracker` runs fine with this branch.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A