### PR TITLE
Bug fix: initialization of genJetMatch token in appropriate place [14_1_X]

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATTauHybridProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTauHybridProducer.cc
@@ -75,11 +75,11 @@ PATTauHybridProducer::PATTauHybridProducer(const edm::ParameterSet& cfg)
       utagJetScoreNames_.push_back(name);
     if (UtagPtCorrName_.find(':') != std::string::npos)
       UtagPtCorrName_ = UtagPtCorrName_.substr(UtagPtCorrName_.find(':') + 1);
-    // GenJet matching
-    if (addGenJetMatch_) {
-      genJetMatchToken_ =
-          consumes<edm::Association<reco::GenJetCollection>>(cfg.getParameter<edm::InputTag>("genJetMatch"));
-    }
+  }
+  // GenJet matching
+  if (addGenJetMatch_) {
+    genJetMatchToken_ =
+        consumes<edm::Association<reco::GenJetCollection>>(cfg.getParameter<edm::InputTag>("genJetMatch"));
   }
 
   produces<std::vector<pat::Tau>>();


### PR DESCRIPTION
#### PR description:

As title says: this PR moves initialization of the `genJetMatchToken` to a correct place which fixes a bug.
This bug have not manifested until now as gen-matching is not used in central workflows.

#### PR validation:

Validated in a custom workflow with and without enabling gen-matching.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #45802.