### PR TITLE
[MiniAOD] Set Muon ID flags for PackedCandidates regardless of trackRef 

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -323,9 +323,6 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event &iEvent,
       // these things are always for the CKF track
       outPtrP->back().setTrackHighPurity(cand.trackRef().isNonnull() &&
                                          cand.trackRef()->quality(reco::Track::highPurity));
-      if (cand.muonRef().isNonnull()) {
-        outPtrP->back().setMuonID(cand.muonRef()->isStandAloneMuon(), cand.muonRef()->isGlobalMuon());
-      }
     } else {
       if (!PVs->empty()) {
         PV = reco::VertexRef(PVs, 0);
@@ -336,6 +333,12 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event &iEvent,
           cand.polarP4(), PVpos, cand.pt(), cand.eta(), cand.phi(), cand.pdgId(), PVRefProd, PV.key()));
       outPtrP->back().setAssociationQuality(
           pat::PackedCandidate::PVAssociationQuality(pat::PackedCandidate::UsedInFitTight));
+    }
+
+    // Set Muon ID flags
+
+    if (cand.muonRef().isNonnull()) {
+      outPtrP->back().setMuonID(cand.muonRef()->isStandAloneMuon(), cand.muonRef()->isGlobalMuon());
     }
 
     // neutrals and isolated charged hadrons


### PR DESCRIPTION
#### PR description:

This PR addresses issue #45814. The muon ID flags should be set regardless if the `reco::PFCandidate` has a trackRef or not. Type-1 MET correction will be more consistent between jets with `reco::PFCandidate` as its constituents and jets with `pat::packedCandidate` constituents.

#### PR validation:

- passes the usual runTheMatrix test: `runTheMatrix.py -i all --ibeos -l limited`
- passes MiniAOD workflows: `runTheMatrix.py -i all --ibeos  -l 2500.021,2500.022,2500.023,2500.024,2500.031,2500.032,2500.033,2500.034`