### PR TITLE
Checks eta windows from the L1Trigger menu to ensure minimum <= maximum

### DIFF
--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
@@ -1234,7 +1234,13 @@ bool l1t::TriggerMenuParser::parseMuon(L1TUtmCondition condMu, unsigned int chip
 
         case esCutType::Eta: {
           if (etaWindows.size() < 5) {
-            etaWindows.push_back({cut.getMinimum().index, cut.getMaximum().index});
+            if ((cut.getMinimum().index <= cut.getMaximum().index) ^
+                ((cut.getMinimum().index <= 255) ^ (cut.getMaximum().index <= 255))) {
+              etaWindows.push_back({cut.getMinimum().index, cut.getMaximum().index});
+            } else {
+              edm::LogError("TriggerMenuParser")
+                  << "Invalid Eta Window for muon-condition (" << name << ")" << std::endl;
+            }
           } else {
             edm::LogError("TriggerMenuParser")
                 << "Too Many Eta Cuts for muon-condition (" << particle << ")" << std::endl;
@@ -1465,7 +1471,12 @@ bool l1t::TriggerMenuParser::parseMuonCorr(const L1TUtmObject* corrMu, unsigned 
 
       case esCutType::Eta: {
         if (etaWindows.size() < 5) {
-          etaWindows.push_back({cut.getMinimum().index, cut.getMaximum().index});
+          if ((cut.getMinimum().index <= cut.getMaximum().index) ^
+              ((cut.getMinimum().index <= 255) ^ (cut.getMaximum().index <= 255))) {
+            etaWindows.push_back({cut.getMinimum().index, cut.getMaximum().index});
+          } else {
+            edm::LogError("TriggerMenuParser") << "Invalid Eta Window for muon-condition (" << name << ")" << std::endl;
+          }
         } else {
           edm::LogError("TriggerMenuParser")
               << "Too Many Eta Cuts for muon-condition (" << particle << ")" << std::endl;
@@ -1838,7 +1849,13 @@ bool l1t::TriggerMenuParser::parseCalo(L1TUtmCondition condCalo, unsigned int ch
           break;
         case esCutType::Eta: {
           if (etaWindows.size() < 5) {
-            etaWindows.push_back({cut.getMinimum().index, cut.getMaximum().index});
+            if ((cut.getMinimum().index <= cut.getMaximum().index) ^
+                ((cut.getMinimum().index <= 127) ^ (cut.getMaximum().index <= 127))) {
+              etaWindows.push_back({cut.getMinimum().index, cut.getMaximum().index});
+            } else {
+              edm::LogError("TriggerMenuParser")
+                  << "Invalid Eta Window for calo-conditioni (" << name << ")" << std::endl;
+            }
           } else {
             edm::LogError("TriggerMenuParser")
                 << "Too Many Eta Cuts for calo-condition (" << particle << ")" << std::endl;
@@ -2065,7 +2082,12 @@ bool l1t::TriggerMenuParser::parseCaloCorr(const L1TUtmObject* corrCalo, unsigne
         break;
       case esCutType::Eta: {
         if (etaWindows.size() < 5) {
-          etaWindows.push_back({cut.getMinimum().index, cut.getMaximum().index});
+          if ((cut.getMinimum().index <= cut.getMaximum().index) ^
+              ((cut.getMinimum().index <= 127) ^ (cut.getMaximum().index <= 127))) {
+            etaWindows.push_back({cut.getMinimum().index, cut.getMaximum().index});
+          } else {
+            edm::LogError("TriggerMenuParser") << "Invalid Eta Window for calo-condition (" << name << ")" << std::endl;
+          }
         } else {
           edm::LogError("TriggerMenuParser")
               << "Too Many Eta Cuts for calo-condition (" << particle << ")" << std::endl;


### PR DESCRIPTION
#### PR description:

Checks the eta windows as they are read in from the menu to ensure that the lower bound is in fact less than or equal to the upper bound. If the lower bound is larger than the upper bound, prevents this eta window from being used as a condition and propagates an error message.
When testing menu L1Menu_Collisions2024_v1_0_0 mismatches where found between firmware and emulator for displaced dimuon seeds (as discussed in this JIRA ticket: [https://its.cern.ch/jira/browse/CMSLITDPG-1221](https://its.cern.ch/jira/browse/CMSLITDPG-1221)), it was eventually discovered that the source of the mismatches was an eta window where the minimum and maximum values had been switched. This PR should help ensure that in the event that this happens again it can be caught and rectified far more quickly.

No changes to the output are expected.
This PR does not depend on any other PRs or externals.
<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

Performed runTheMatrix with -l 11634.0, passed 5 out of 5 tests.
Test vector code was in agreement with firmware for both the original menu with the faulty eta cuts, and for an updated menu with corrected eta cuts.

Changes were checked against "scram build code-format" to ensure they followed CMS Naming, Coding and Style Rules.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not a backport.