### PR TITLE
Fixed CLCT sorting in CSC TP emulator and synchronize the config to the Point-5 data-taking settings

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCUpgradeCathodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCUpgradeCathodeLCTProcessor.h
@@ -42,7 +42,7 @@ private:
       const CSCL1TPLookupTableCCLUT* lookupTable) override;
 
   // mark half-strip zones around pretriggers that happened at the current first_bx
-  void markPreTriggerZone(bool pretrig_zone[CSCConstants::MAX_NUM_HALF_STRIPS_RUN2_TRIGGER]) const;
+  void markPreTriggerZone(int bx, bool pretrig_zone[CSCConstants::MAX_NUM_HALF_STRIPS_RUN2_TRIGGER]) const;
 
   // update the deadzone after finding a pretrigger
   void markBusyZone(const int bx);

--- a/L1Trigger/CSCTriggerPrimitives/python/params/clctParams.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/params/clctParams.py
@@ -44,13 +44,11 @@ clctPhase2 = clctPhase1.clone(
     useDeadTimeZoning = True,
 
     # Width (in #HS) of a fixed dead zone around a key HS:
-    clctStateMachineZone = cms.uint32(4),
+    clctStateMachineZone = cms.uint32(5),
 
     # Pretrigger HS +- clctPretriggerTriggerZone sets the trigger matching zone
     # which defines how far from pretrigger HS the TMB may look for a trigger HS
-    # (it becomes important to do so with localized dead-time zoning):
-    # not implemented yet, 2018-10-18, Tao Huang
-    clctPretriggerTriggerZone = cms.uint32(224),
+    clctPretriggerTriggerZone = cms.uint32(5),
 )
 
 # CLCT threshold still set to 4 for now

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeCathodeLCTProcessor.cc
@@ -192,7 +192,7 @@ std::vector<CSCCLCTDigi> CSCUpgradeCathodeLCTProcessor::findLCTs(
       if (hits_in_time) {
         // first, mark half-strip zones around pretriggers
         // that happened at the current first_bx
-        markPreTriggerZone(pretrig_zone);
+        markPreTriggerZone(first_bx, pretrig_zone);
 
         for (int hstrip = stagger[CSCConstants::KEY_CLCT_LAYER - 1]; hstrip < numHalfStrips_; hstrip++) {
           /* The bend-direction bit pid[0] is ignored (left and right bends have equal quality).
@@ -309,14 +309,14 @@ std::vector<CSCCLCTDigi> CSCUpgradeCathodeLCTProcessor::findLCTs(
 }  // findLCTs -- Phase2 version.
 
 void CSCUpgradeCathodeLCTProcessor::markPreTriggerZone(
-    bool pretrig_zone[CSCConstants::MAX_NUM_HALF_STRIPS_RUN2_TRIGGER]) const {
+    int bx, bool pretrig_zone[CSCConstants::MAX_NUM_HALF_STRIPS_RUN2_TRIGGER]) const {
   // first reset the pretrigger zone (no pretriggers anywhere in this BX
   for (int hstrip = 0; hstrip < CSCConstants::MAX_NUM_HALF_STRIPS_RUN2_TRIGGER; hstrip++) {
     pretrig_zone[hstrip] = false;
   }
   // then set the pretrigger zone according to the ispretrig_ array
   for (int hstrip = 0; hstrip < CSCConstants::MAX_NUM_HALF_STRIPS_RUN2_TRIGGER; hstrip++) {
-    if (ispretrig_[hstrip]) {
+    if (ispretrig_[hstrip] && !busyMap_[hstrip][bx]) {
       int min_hs = hstrip - pretrig_trig_zone_;
       int max_hs = hstrip + pretrig_trig_zone_;
       // set the minimum strip


### PR DESCRIPTION
#### PR description:

1. update the deadtimezone and pretrigger-trigger match
2. update the configuration parameter to synchronize with the setting for data-taking at P5

#### PR validation:

We did test the agreement between OTMB firmware for CSC trigger and CSC TP emulator by injecting simulated muons into OTMB, and finally with these changes and bugfixed firmware, we can achieve a perfect agreement. 

Yumeng@yumeng111 presented the results on CSC weekly meeting:
https://indico.cern.ch/event/1450065/contributions/6105639/attachments/2917647/5120368/otmb_cscmeeting.pdf