### PR TITLE
[Backport 14.1.X] Refine RPCDigis Validation histograms

### DIFF
--- a/Validation/MuonRPCDigis/interface/RPCDigiValid.h
+++ b/Validation/MuonRPCDigis/interface/RPCDigiValid.h
@@ -45,6 +45,7 @@ private:
   MonitorElement *hBxDisc_4Min_;
 
   // Timing information
+  bool isDigiTimeAvailable_;
   MonitorElement *hDigiTimeAll_, *hDigiTime_, *hDigiTimeIRPC_, *hDigiTimeNoIRPC_;
 
   // Multiplicity plots

--- a/Validation/MuonRPCDigis/python/validationMuonRPCDigis_cfi.py
+++ b/Validation/MuonRPCDigis/python/validationMuonRPCDigis_cfi.py
@@ -9,10 +9,7 @@ validationMuonRPCDigis = DQMEDAnalyzer('RPCDigiValid',
     simHitTag = cms.untracked.InputTag("g4SimHits", "MuonRPCHits"),
 
     # Flag to turn on/off timing plots
-    digiTime = cms.untracked.bool(False),
-
-    # Name of the root file which will contain the histos
-    outputFile = cms.untracked.string('')
+    digiTime = cms.untracked.bool(False)
 )
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim

--- a/Validation/MuonRPCDigis/python/validationMuonRPCDigis_cfi.py
+++ b/Validation/MuonRPCDigis/python/validationMuonRPCDigis_cfi.py
@@ -8,9 +8,15 @@ validationMuonRPCDigis = DQMEDAnalyzer('RPCDigiValid',
     # Tag for simulated hits event data retrieval
     simHitTag = cms.untracked.InputTag("g4SimHits", "MuonRPCHits"),
 
+    # Flag to turn on/off timing plots
+    digiTime = cms.untracked.bool(False),
+
     # Name of the root file which will contain the histos
     outputFile = cms.untracked.string('')
 )
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toModify(validationMuonRPCDigis, simHitTag = "MuonSimHits:MuonRPCHits")
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(validationMuonRPCDigis, digiTime = True)

--- a/Validation/MuonRPCDigis/src/RPCDigiValid.cc
+++ b/Validation/MuonRPCDigis/src/RPCDigiValid.cc
@@ -201,6 +201,7 @@ void RPCDigiValid::bookHistograms(DQMStore::IBooker &booker, edm::Run const &run
 
   // RZ plot
   hRZ_ = booker.book2D("RZ", "R-Z view;Z (cm);R (cm)", nbinsZ, -maxZ, maxZ, nbinsR, minR, maxR);
+  hRZ_->setOption("colz");
 
   // XY plots
   hXY_Barrel_ = booker.book2D("XY_Barrel", "X-Y view of Barrel", nbinsXY, -maxXY, maxXY, nbinsXY, -maxXY, maxXY);
@@ -211,6 +212,8 @@ void RPCDigiValid::bookHistograms(DQMStore::IBooker &booker, edm::Run const &run
     const std::string meTitleN = fmt::format("X-Y view of Endcap{:+1d};X (cm);Y (cm)", -disk);
     hXY_Endcap_[disk] = booker.book2D(meNameP, meTitleP, nbinsXY, -maxXY, maxXY, nbinsXY, -maxXY, maxXY);
     hXY_Endcap_[-disk] = booker.book2D(meNameN, meTitleN, nbinsXY, -maxXY, maxXY, nbinsXY, -maxXY, maxXY);
+    hXY_Endcap_[disk]->setOption("colz");
+    hXY_Endcap_[-disk]->setOption("colz");
   }
 
   // Z-phi plots
@@ -218,6 +221,7 @@ void RPCDigiValid::bookHistograms(DQMStore::IBooker &booker, edm::Run const &run
     const std::string meName = fmt::format("ZPhi_Layer{:1d}", layer);
     const std::string meTitle = fmt::format("Z-#phi view of Layer{:1d};Z (cm);#phi (degree)", layer);
     hZPhi_[layer] = booker.book2D(meName, meTitle, nbinsBarrelZ, -maxBarrelZ, maxBarrelZ, nbinsPhi, -180, 180);
+    hZPhi_[layer]->setOption("colz");
   }
 
   // Strip profile
@@ -267,9 +271,7 @@ void RPCDigiValid::bookHistograms(DQMStore::IBooker &booker, edm::Run const &run
     hResEndcapDisks_[-disk] = booker.book1D(meNameN, meTitleN, 100, -8, 8);
   }
 
-  for (int ring = 1; ring <= 3; ++ring) {
-    const std::string meName = fmt::format("Residual_Endcap_Ring{:1d}", ring);
-    const std::string meTitle = fmt::format("Residual of Endcap Ring{:1d};dx (cm)", ring);
-    hResEndcapRings_[ring] = booker.book1D(meName, meTitle, 100, -8, 8);
-  }
+  hResEndcapRings_[1] = booker.book1D("Residual_Endcap_Ring1", "Residual of Endcap Ring1;dx (cm)", 100, -12, 12);
+  hResEndcapRings_[2] = booker.book1D("Residual_Endcap_Ring2", "Residual of Endcap Ring2;dx (cm)", 100, -8, 8);
+  hResEndcapRings_[3] = booker.book1D("Residual_Endcap_Ring3", "Residual of Endcap Ring3;dx (cm)", 100, -8, 8);
 }

--- a/Validation/MuonRPCDigis/src/RPCDigiValid.cc
+++ b/Validation/MuonRPCDigis/src/RPCDigiValid.cc
@@ -209,6 +209,7 @@ void RPCDigiValid::bookHistograms(DQMStore::IBooker &booker, edm::Run const &run
 
   // XY plots
   hXY_Barrel_ = booker.book2D("XY_Barrel", "X-Y view of Barrel", nbinsXY, -maxXY, maxXY, nbinsXY, -maxXY, maxXY);
+  hXY_Barrel_->setOption("colz");
   for (int disk = 1; disk <= 4; ++disk) {
     const std::string meNameP = fmt::format("XY_Endcap_p{:1d}", disk);
     const std::string meNameN = fmt::format("XY_Endcap_m{:1d}", disk);

--- a/Validation/MuonRPCDigis/src/RPCDigiValid.cc
+++ b/Validation/MuonRPCDigis/src/RPCDigiValid.cc
@@ -124,7 +124,7 @@ void RPCDigiValid::analyze(const Event &event, const EventSetup &eventSetup) {
       }
 
       // Fill timing information
-      if ( isDigiTimeAvailable_ ) {
+      if (isDigiTimeAvailable_) {
         const double digiTime = digiIt->hasTime() ? digiIt->time() : digiIt->bx() * 25;
         hDigiTimeAll_->Fill(digiTime);
         if (digiIt->hasTime()) {
@@ -241,7 +241,7 @@ void RPCDigiValid::bookHistograms(DQMStore::IBooker &booker, edm::Run const &run
   hBxDisc_4Min_ = booker.book1D("BxDisc_4Min", "BxDisc_4Min", 20, -10., 10.);
 
   // Timing informations
-  if ( isDigiTimeAvailable_ ) {
+  if (isDigiTimeAvailable_) {
     hDigiTimeAll_ =
         booker.book1D("DigiTimeAll", "Digi time including present electronics;Digi time (ns)", 100, -12.5, 12.5);
     hDigiTime_ = booker.book1D("DigiTime", "Digi time only with timing information;Digi time (ns)", 100, -12.5, 12.5);


### PR DESCRIPTION
#### PR description:
This is a backport of #45702 to 14.1.X release cycle, which is also a follow-up PR of #45029.

#### PR validation:

- `runTheMatrix.py -l 12434.0` OK
- `scram b code-checks` OK
- `scram b code-format` OK

(already tested with the CMSSW_14_1_0_pre6, wf 13034.0, 12434.0 and 29634.0  in the original PR)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is a backport of #45702, which was originally proposed for 14.1.X but it eventually went to 14.2.X cycle.
We'd like to have the same set of validation plots across the releases in the further relval campaigns.

@mileva @mrcthiel