### PR TITLE
Adding Golden Workflows for 2022 and 2023 Data

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_data_highstats.py
+++ b/Configuration/PyReleaseValidation/python/relval_data_highstats.py
@@ -7,12 +7,12 @@ workflows = Matrix()
 ## Here we define higher (>50k events) stats data workflows
 ## not to be run as default. 150k, 250k, 500k or 1M events each
 
-## 2024
-base_wf_number_2024 = 2024.0
-offset_era = 0.1 # less than 10 eras
-offset_pd = 0.001 # less than 100 pds
+offset_era = 0.1 # less than 10 eras per year
+offset_pd = 0.001 # less than 100 pds per year
 offset_events = 0.0001 # less than 10 event setups (50k,150k,250k,500k)
 
+## 2024
+base_wf_number_2024 = 2024.0
 for e_n,era in enumerate(eras_2024):
     for p_n,pd in enumerate(pds_2024):
         for e_key,evs in event_steps_dict.items():
@@ -25,6 +25,50 @@ for e_n,era in enumerate(eras_2024):
             wf_number = round(wf_number,6)
             step_name = "Run" + pd + era.split("Run")[1] + "_" + e_key
             workflows[wf_number] = ['',[step_name,'HLTDR3_2024','AODNANORUN3_reHLT_2024','HARVESTRUN3_2024']]
+
+## 2023
+base_wf_number_2023 = 2023.0
+for e_n,era in enumerate(eras_2023):
+    for p_n,pd in enumerate(pds_2023):
+        for e_key,evs in event_steps_dict.items():
+            if "10k" == e_key: # already defined in relval_standard
+                continue   
+            wf_number = base_wf_number_2023
+            wf_number = wf_number + offset_era * e_n
+            wf_number = wf_number + offset_pd * p_n
+            wf_number = wf_number + offset_events * evs 
+            wf_number = round(wf_number,6)
+            step_name = "Run" + pd + era.split("Run")[1] + "_" + e_key
+            workflows[wf_number] = ['',[step_name,'HLTDR3_2023','AODNANORUN3_reHLT_2023','HARVESTRUN3_2023']]
+
+
+## 2022
+base_wf_number_2022 = 2022.0
+for e_n,era in enumerate(eras_2022_1):
+    for p_n,pd in enumerate(pds_2022_1):
+        for e_key,evs in event_steps_dict.items():
+            if "10k" == e_key: # already defined in relval_standard
+                continue   
+            wf_number = base_wf_number_2022
+            wf_number = wf_number + offset_era * e_n
+            wf_number = wf_number + offset_pd * p_n
+            wf_number = wf_number + offset_events * evs 
+            wf_number = round(wf_number,6)
+            step_name = "Run" + pd + era.split("Run")[1] + "_" + e_key
+            workflows[wf_number] = ['',[step_name,'HLTDR3_2022','AODNANORUN3_reHLT_2022','HARVESTRUN3_2022']]
+
+for e_n,era in enumerate(eras_2022_2):
+    for p_n,pd in enumerate(pds_2022_2):
+        for e_key,evs in event_steps_dict.items():
+            if "10k" == e_key: # already defined in relval_standard
+                continue   
+            wf_number = base_wf_number_2022
+            wf_number = wf_number + offset_era * (e_n + len(eras_2022_1))
+            wf_number = wf_number + offset_pd * (p_n + len(pds_2022_1))
+            wf_number = wf_number + offset_events * evs 
+            wf_number = round(wf_number,6)
+            step_name = "Run" + pd + era.split("Run")[1] + "_" + e_key
+            workflows[wf_number] = ['',[step_name,'HLTDR3_2022','AODNANORUN3_reHLT_2022','HARVESTRUN3_2022']]
 
 
 

--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -559,13 +559,16 @@ workflows[142.0] = ['',['RunHIPhysicsRawPrime2023A','HLTDR3_HI2023ARawprime','RE
 workflows[142.901] = ['',['RunUPC2023','RECODR3_2024_UPC','HARVESTDPROMPTR3']]
 workflows[142.902] = ['',['RunUPC2023','RECODR3_2024_HIN','HARVESTDPROMPTR3']]
 
-## 2024 Data Workflows 
+##################################################################
+### Golden Data Wfs
 # for a limited set of eras and PDs not to overflow the IB matrices
-#
-base_wf_number_2024 = 2024.0
-offset_era = 0.1 # less than 10 eras
-offset_pd = 0.001 # less than 100 pds
+# the full set in relval_data_highstats.py
 
+offset_era = 0.1 # less than 10 eras per year
+offset_pd = 0.001 # less than 100 pds per year
+
+# 2024
+base_wf_number_2024 = 2024.0
 for e_n,era in enumerate(['Run2024D','Run2024C']):
     for p_n,pd in enumerate(['JetMET0','ZeroBias']):
         wf_number = base_wf_number_2024
@@ -575,6 +578,31 @@ for e_n,era in enumerate(['Run2024D','Run2024C']):
         wf_number = round(wf_number,6)
         step_name = "Run" + pd + era.split("Run")[1] + "_10k"
         workflows[wf_number] = ['',[step_name,'HLTDR3_2024','AODNANORUN3_reHLT_2024','HARVESTRUN3_2024']]
+
+# 2023
+base_wf_number_2023 = 2023.0
+for e_n,era in enumerate(['Run2023C', 'Run2023D']):
+    for p_n,pd in enumerate(['MuonEG','DisplacedJet']):
+        wf_number = base_wf_number_2023
+        wf_number = wf_number + offset_era * e_n
+        wf_number = wf_number + offset_pd * p_n
+        wf_number = wf_number + 0.0001 * 0.01
+        wf_number = round(wf_number,6)
+        step_name = "Run" + pd + era.split("Run")[1] + "_10k"
+        workflows[wf_number] = ['',[step_name,'HLTDR3_2023','AODNANORUN3_reHLT_2023','HARVESTRUN3_2023']]
+
+# 2022
+base_wf_number_2022 = 2022.0
+for e_n,era in enumerate(['Run2022B', 'Run2022C']):
+    for p_n,pd in enumerate(['JetHT','EGamma']):
+        wf_number = base_wf_number_2022
+        wf_number = wf_number + offset_era * e_n
+        wf_number = wf_number + offset_pd * p_n
+        wf_number = wf_number + 0.0001 * 0.01 
+        wf_number = round(wf_number,6)
+        step_name = "Run" + pd + era.split("Run")[1] + "_10k"
+        workflows[wf_number] = ['',[step_name,'HLTDR3_2022','AODNANORUN3_reHLT_2022','HARVESTRUN3_2022']]
+##################################################################
 
 ### fastsim ###
 workflows[5.1] = ['TTbarFS', ['TTbarFS','HARVESTFS']]

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -634,13 +634,14 @@ steps['RunUPC2023']={'INPUT':InputInfo(dataSet='/HIForward1/HIRun2023A-v1/RAW',l
 RunHI2023={375491: [[100, 100]]}
 steps['RunHIPhysicsRawPrime2023A']={'INPUT':InputInfo(dataSet='/HIPhysicsRawPrime0/HIRun2023A-v1/RAW',label='HI2023A',events=100000,location='STD', ls=RunHI2023)}
 
-### Golden Data Wfs
-# reading good runs directly from the latest golden json 
+##################################################################
+### Golden Data Steps
+# Reading good runs directly from the latest golden json 
 # in https://cms-service-dqmdc.web.cern.ch/CAF/certification/
-# or (if available) 
+# or (if available) from eos. the number of events limits 
+# the files used as input
 
 ###2024 
-# number of events limits the files used as input
 
 pds_2024  = ['BTagMu', 'DisplacedJet', 'EGamma0', 'HcalNZS', 'JetMET0', 'Muon0', 'MuonEG', 'NoBPTX', 'ParkingDoubleMuonLowMass0', 'ParkingHH', 'ParkingLLP', 'ParkingSingleMuon0', 'ParkingVBF0', 'Tau', 'ZeroBias']
 eras_2024 = ['Run2024B', 'Run2024C', 'Run2024D', 'Run2024E', 'Run2024F']
@@ -650,6 +651,44 @@ for era in eras_2024:
         for e_key,evs in event_steps_dict.items():
             step_name = "Run" + pd + era.split("Run")[1] + "_" + e_key
             steps[step_name] = {'INPUT':InputInfo(dataSet=dataset,label=era.split("Run")[1],events=int(evs*1e6), skimEvents=True, location='STD')}
+
+###2023 
+
+pds_2023  = ['BTagMu', 'DisplacedJet', 'EGamma0', 'HcalNZS', 'JetMET0', 'Muon0', 'MuonEG', 'NoBPTX', 'ParkingDoubleElectronLowMass', 'ParkingDoubleMuonLowMass0', 'Tau', 'ZeroBias']
+eras_2023 = ['Run2023B', 'Run2023C', 'Run2023D']
+# 'MinimumBias' is excluded since apprently no Golden run for /MinimumBias/Run2023{B,C,D}-v1/RAW 
+for era in eras_2023:
+    for pd in pds_2023:
+        dataset = "/" + pd + "/" + era + "-v1/RAW"
+        for e_key,evs in event_steps_dict.items():
+            step_name = "Run" + pd + era.split("Run")[1] + "_" + e_key
+            steps[step_name] = {'INPUT':InputInfo(dataSet=dataset,label=era.split("Run")[1],events=int(evs*1e6), skimEvents=True, location='STD')}
+
+###2022 
+
+pds_2022_1  = ['BTagMu', 'DisplacedJet', 'DoubleMuon', 'SingleMuon', 'EGamma', 'HcalNZS', 'JetHT', 'MET', 'MinimumBias', 'MuonEG', 'NoBPTX', 'Tau', 'ZeroBias']
+eras_2022_1 = ['Run2022B', 'Run2022C']
+for era in eras_2022_1:
+    for pd in pds_2022_1:
+        dataset = "/" + pd + "/" + era + "-v1/RAW"
+        for e_key,evs in event_steps_dict.items():
+            step_name = "Run" + pd + era.split("Run")[1] + "_" + e_key
+            steps[step_name] = {'INPUT':InputInfo(dataSet=dataset,label=era.split("Run")[1],events=int(evs*1e6), skimEvents=True, location='STD')}
+
+# PD names changed during the year (!)
+pds_2022_2  = ['BTagMu', 'DisplacedJet', 'Muon', 'EGamma', 'HcalNZS', 'JetMET', 'MuonEG', 'NoBPTX', 'Tau', 'ZeroBias']
+# Note: 'MinimumBias' is excluded since apprently no Golden run for /MinimumBias/Run2022{D,E}-v1/RAW 
+eras_2022_2 = ['Run2022D', 'Run2022E']
+
+for era in eras_2022_2:
+    for pd in pds_2022_2:
+        dataset = "/" + pd + "/" + era + "-v1/RAW"
+        for e_key,evs in event_steps_dict.items():
+            step_name = "Run" + pd + era.split("Run")[1] + "_" + e_key
+            steps[step_name] = {'INPUT':InputInfo(dataSet=dataset,label=era.split("Run")[1],events=int(evs*1e6), skimEvents=True, location='STD')}
+
+
+##################################################################
 
 # Highstat HLTPhysics
 Run2015DHS=selectedLS([258712,258713,258714,258741,258742,258745,258749,258750,259626,259637,259683,259685,259686,259721,259809,259810,259818,259820,259821,259822,259862,259890,259891])


### PR DESCRIPTION
#### PR description:

Following the setup introduced in https://github.com/cms-sw/cmssw/pull/45055 for 2024 data wfs, this PR proposes to add also the equivalent set of workflows for 2022 and 2023 data. As in the parent PR a smaller set of wfs is added to `relval_standard.py` just to keep testing the machinery in the IBs, while the higher stats wfs are in `relval_data_highstats.py`.

#### PR validation:

E.g. `runTheMatrix.py -w data -l 2022.000005, 2023.001005`.