### PR TITLE
Implement a test for the `copyFromDense` and `copyToDense` utilities

### DIFF
--- a/DataFormats/TrackSoA/test/BuildFile.xml
+++ b/DataFormats/TrackSoA/test/BuildFile.xml
@@ -1,5 +1,12 @@
 <use name="eigen"/>
+
 <bin file="alpaka/TrackSoAHeterogeneous_test.cc alpaka/TrackSoAHeterogeneous_test.dev.cc" name="TrackSoAHeterogeneousAlpaka_test">
+  <use name="alpaka"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+<flags ALPAKA_BACKENDS="1"/>
+</bin>
+
+<bin file="alpaka/TrajectoryStateSoA_t.cc alpaka/TrajectoryStateSoA_t.dev.cc" name="TrajectoryStateSoA_t">
   <use name="alpaka"/>
   <use name="HeterogeneousCore/AlpakaInterface"/>
 <flags ALPAKA_BACKENDS="1"/>

--- a/DataFormats/TrackSoA/test/alpaka/TrajectoryStateSoA_t.cc
+++ b/DataFormats/TrackSoA/test/alpaka/TrajectoryStateSoA_t.cc
@@ -1,0 +1,52 @@
+/* Simple test for the copyFromDense and copyToDense utilities from DataFormats/TrackSoA/interface/alpaka/TrackUtilities.h .
+ *
+ * Creates an instance of TracksSoACollection<pixelTopology::Phase1> (automatically allocates memory on device),
+ * passes the view of the SoA data to the kernel that:
+ *   - fill the SoA with covariance data;
+ *   - copy the covariance data to the dense representation, and back to the matrix representation;
+ *   - verify that the data is copied back and forth correctly.
+ */
+
+#include <cstdlib>
+#include <iostream>
+
+#include <alpaka/alpaka.hpp>
+
+#include "DataFormats/TrackSoA/interface/TracksSoA.h"
+#include "DataFormats/TrackSoA/interface/alpaka/TracksSoACollection.h"
+#include "FWCore/Utilities/interface/stringize.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/devices.h"
+
+#include "TrajectoryStateSoA_t.h"
+
+// Each test binary is built for a single Alpaka backend.
+using namespace ALPAKA_ACCELERATOR_NAMESPACE;
+
+int main() {
+  // Get the list of devices on the current platform.
+  auto const& devices = cms::alpakatools::devices<Platform>();
+  if (devices.empty()) {
+    std::cerr << "No devices available for the " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE) " backend, "
+      "the test will be skipped.\n";
+    exit(EXIT_FAILURE);
+  }
+
+  // Run the test on each device.
+  for (const auto& device : devices) {
+    Queue queue(device);
+
+    // Inner scope to deallocate memory before destroying the stream.
+    {
+      TracksSoACollection<pixelTopology::Phase1> tracks_d(queue);
+
+      test::testTrackSoA<pixelTopology::Phase1>(queue, tracks_d.view());
+
+      // Wait for the tests to complete.
+      alpaka::wait(queue);
+    }
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/DataFormats/TrackSoA/test/alpaka/TrajectoryStateSoA_t.dev.cc
+++ b/DataFormats/TrackSoA/test/alpaka/TrajectoryStateSoA_t.dev.cc
@@ -1,0 +1,75 @@
+#include <Eigen/Dense>
+
+#include "DataFormats/TrackSoA/interface/TracksSoA.h"
+#include "DataFormats/TrackSoA/interface/alpaka/TrackUtilities.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
+
+#include "TrajectoryStateSoA_t.h"
+
+using Vector5d = Eigen::Matrix<double, 5, 1>;
+using Matrix5d = Eigen::Matrix<double, 5, 5>;
+
+using namespace cms::alpakatools;
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE::test {
+
+  namespace {
+
+    ALPAKA_FN_ACC Matrix5d buildCovariance(Vector5d const& e) {
+      Matrix5d cov;
+      for (int i = 0; i < 5; ++i)
+        cov(i, i) = e(i) * e(i);
+      for (int i = 0; i < 5; ++i) {
+        for (int j = 0; j < i; ++j) {
+          // this makes the matrix positive defined
+          double v = 0.3 * std::sqrt(cov(i, i) * cov(j, j));
+          cov(i, j) = (i + j) % 2 ? -0.4 * v : 0.1 * v;
+          cov(j, i) = cov(i, j);
+        }
+      }
+      return cov;
+    }
+
+    template <typename TrackerTraits>
+    struct TestTrackSoA {
+      using Utils = TracksUtilities<TrackerTraits>;
+
+      ALPAKA_FN_ACC void operator()(Acc1D const& acc, reco::TrackSoAView<TrackerTraits> tracks) const {
+        Vector5d par0;
+        par0 << 0.2, 0.1, 3.5, 0.8, 0.1;
+        Vector5d e0;
+        e0 << 0.01, 0.01, 0.035, -0.03, -0.01;
+        Matrix5d cov0 = buildCovariance(e0);
+
+        for (auto i : uniform_elements(acc, tracks.metadata().size())) {
+          Utils::copyFromDense(tracks, par0, cov0, i);
+          Vector5d par1;
+          Matrix5d cov1;
+          Utils::copyToDense(tracks, par1, cov1, i);
+          Vector5d deltaV = par1 - par0;
+          Matrix5d deltaM = cov1 - cov0;
+          for (int j = 0; j < 5; ++j) {
+            ALPAKA_ASSERT(std::abs(deltaV(j)) < 1.e-5);
+            for (int k = j; k < 5; ++k) {
+              ALPAKA_ASSERT(cov0(k, j) == cov0(j, k));
+              ALPAKA_ASSERT(cov1(k, j) == cov1(j, k));
+              ALPAKA_ASSERT(std::abs(deltaM(k, j)) < 1.e-5);
+            }
+          }
+        }
+      }
+    };
+
+  }  // namespace
+
+  template <typename TrackerTraits>
+  void testTrackSoA(Queue& queue, reco::TrackSoAView<TrackerTraits>& tracks) {
+    auto grid = make_workdiv<Acc1D>(1, 64);
+    alpaka::exec<Acc1D>(queue, grid, TestTrackSoA<TrackerTraits>{}, tracks);
+  }
+
+  template void testTrackSoA<pixelTopology::Phase1>(Queue& queue, reco::TrackSoAView<pixelTopology::Phase1>& tracks);
+  template void testTrackSoA<pixelTopology::Phase2>(Queue& queue, reco::TrackSoAView<pixelTopology::Phase2>& tracks);
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::test

--- a/DataFormats/TrackSoA/test/alpaka/TrajectoryStateSoA_t.h
+++ b/DataFormats/TrackSoA/test/alpaka/TrajectoryStateSoA_t.h
@@ -1,0 +1,15 @@
+#ifndef DataFormats_TrackSoA_test_alpaka_TrajectoryStateSoA_t_h
+#define DataFormats_TrackSoA_test_alpaka_TrajectoryStateSoA_t_h
+
+#include "DataFormats/TrackSoA/interface/TracksSoA.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE::test {
+
+  template <typename TrackerTraits>
+  void testTrackSoA(Queue& queue, reco::TrackSoAView<TrackerTraits>& tracks);
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::test
+
+#endif  // DataFormats_TrackSoA_test_alpaka_TrajectoryStateSoA_t_h


### PR DESCRIPTION
#### PR description:

Reimplement `CUDADataFormats/Track/test/TrajectoryStateSOA_t.h` using the alpaka-based data structures and utilities.

Implement a simple test for the copyFromDense and copyToDense utilities from `DataFormats/TrackSoA/interface/alpaka/TrackUtilities.h`.

Creates an instance of `TracksSoACollectionPhase1` (automatically allocates memory on device), passes the view of the SoA data to the kernel that:
  - fill the SoA with covariance data;
  - copy the covariance data to the dense representation, and back to the matrix representation;
  - verify that the data is copied back and forth correctly.


#### PR validation:

The new test runs successfully on the serial and CUDA backend.