### PR TITLE
[14_0] Add AXO and CICADA seeds to uGT Timing config and modifies online DQM client era to Run3_2024

### DIFF
--- a/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 import sys
-from Configuration.Eras.Era_Run3_cff import Run3
-process = cms.Process("L1TStage2DQM", Run3)
+from Configuration.Eras.Era_Run3_2024_cff import Run3_2024
+process = cms.Process("L1TStage2DQM", Run3_2024)
 
 unitTest = False
 if 'unitTest=True' in sys.argv:

--- a/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 import sys
-from Configuration.Eras.Era_Run3_cff import Run3
-process = cms.Process("L1TStage2EmulatorDQM", Run3)
+from Configuration.Eras.Era_Run3_2024_cff import Run3_2024
+process = cms.Process("L1TStage2EmulatorDQM", Run3_2024)
 
 unitTest = False
 if 'unitTest=True' in sys.argv:

--- a/DQM/L1TMonitor/python/L1TStage2uGTTiming_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGTTiming_cfi.py
@@ -1,44 +1,65 @@
 import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 
+unprescaledAlgoList = cms.untracked.vstring(
+    "L1_SingleMu22_BMTF",
+    "L1_SingleMu22_OMTF",
+    "L1_SingleMu22_EMTF",
+    "L1_SingleIsoEG28er1p5",
+    "L1_SingleIsoEG32er2p5",
+    "L1_SingleEG40er2p5",
+    "L1_SingleEG60",
+    "L1_SingleTau120er2p1",
+    "L1_SingleJet180",
+    "L1_ETMHF130",
+    "L1_HTT360er",
+    "L1_ETT2000"
+)
+prescaledAlgoList = cms.untracked.vstring(
+    "L1_FirstCollisionInTrain",
+    "L1_LastCollisionInTrain",
+    "L1_IsolatedBunch",
+    "L1_SingleMu0_BMTF",
+    "L1_SingleMu0_OMTF",
+    "L1_SingleMu0_EMTF",
+    "L1_SingleEG10er2p5",
+    "L1_SingleEG15er2p5",
+    "L1_SingleEG26er2p5",
+    "L1_SingleLooseIsoEG28er1p5",
+    "L1_SingleJet35",
+    "L1_SingleJet35er2p5",
+    "L1_SingleJet35_FWD2p5",
+    "L1_ETMHF100",
+    "L1_HTT120er",
+    "L1_ETT1600"
+)
+
+unprescaledAlgoList_2024 = cms.untracked.vstring(unprescaledAlgoList)
+unprescaledAlgoList_2024.extend([
+    "L1_AXO_Nominal",
+    "L1_AXO_VTight",
+    "L1_CICADA_Medium",
+    "L1_CICADA_VTight"
+])
+ 
+prescaledAlgoList_2024 = cms.untracked.vstring(prescaledAlgoList)
+if "L1_ETT1600" in prescaledAlgoList_2024:
+    prescaledAlgoList_2024.remove("L1_ETT1600")
+
 l1tStage2uGTTiming = DQMEDAnalyzer('L1TStage2uGTTiming',
-    l1tStage2uGtSource = cms.InputTag("gtStage2Digis"),    
+    l1tStage2uGtSource = cms.InputTag("gtStage2Digis"),
     monitorDir = cms.untracked.string("L1T/L1TStage2uGT/timing_aux"),
     verbose = cms.untracked.bool(False),
     firstBXInTrainAlgo = cms.untracked.string("L1_FirstCollisionInTrain"),
-    lastBXInTrainAlgo = cms.untracked.string("L1_LastCollisionInTrain"),    
-    isoBXAlgo = cms.untracked.string("L1_IsolatedBunch"),    
-    unprescaledAlgoShortList = cms.untracked.vstring(
-        "L1_SingleMu22_BMTF",
-        "L1_SingleMu22_OMTF",
-        "L1_SingleMu22_EMTF",
-        "L1_SingleIsoEG28er1p5",
-        "L1_SingleIsoEG32er2p5",
-        "L1_SingleEG40er2p5",
-        "L1_SingleEG60",
-        "L1_SingleTau120er2p1",
-        "L1_SingleJet180",
-        "L1_ETMHF130",
-        "L1_HTT360er",
-        "L1_ETT2000"
-    ),
-    prescaledAlgoShortList = cms.untracked.vstring(
-        "L1_FirstCollisionInTrain",
-        "L1_LastCollisionInTrain",
-        "L1_IsolatedBunch",
-        "L1_SingleMu0_BMTF",
-        "L1_SingleMu0_OMTF",
-        "L1_SingleMu0_EMTF",
-        "L1_SingleEG10er2p5",
-        "L1_SingleEG15er2p5",
-        "L1_SingleEG26er2p5",
-        "L1_SingleLooseIsoEG28er1p5",
-        "L1_SingleJet35",
-        "L1_SingleJet35er2p5",
-        "L1_SingleJet35_FWD2p5",
-        "L1_ETMHF100",
-        "L1_HTT120er",
-        "L1_ETT1600"
-    ),
+    lastBXInTrainAlgo = cms.untracked.string("L1_LastCollisionInTrain"),
+    isoBXAlgo = cms.untracked.string("L1_IsolatedBunch"),
+    unprescaledAlgoShortList = unprescaledAlgoList,
+    prescaledAlgoShortList = prescaledAlgoList,
     useAlgoDecision = cms.untracked.string("initial")
+)
+
+from Configuration.Eras.Modifier_run3_2024_L1T_cff import run3_2024_L1T
+run3_2024_L1T.toModify(l1tStage2uGTTiming,
+    unprescaledAlgoShortList = unprescaledAlgoList_2024,
+    prescaledAlgoShortList = prescaledAlgoList_2024
 )


### PR DESCRIPTION
#### PR description:

This PR adds unprescaled AXO and CICADA seeds (L1_AXO_Nominal, L1_AXO_VTight, L1_CICADA_Medium, L1_CICADA_VTight) to unprescaled uGT algo shortlist. This aims to add these seeds to uGT algo accept vs BX plots (L1T Online shift plots 19-20). This PR also modifies the era in the DQM client config files

#### PR validation:

All code compiles and formatting have been applied. Tested locally with 14_0_15.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is a backport of #45242 and #45634.