### PR TITLE
[14.0.X] `TrackingRecHitsSoACollection`: early return `hostData` in `CopyHost::copyAsync()` when there aren't hits

### DIFF
--- a/DataFormats/TrackingRecHitSoA/interface/alpaka/TrackingRecHitsSoACollection.h
+++ b/DataFormats/TrackingRecHitSoA/interface/alpaka/TrackingRecHitsSoACollection.h
@@ -34,6 +34,16 @@ namespace cms::alpakatools {
     template <typename TQueue>
     static auto copyAsync(TQueue& queue, TrackingRecHitDevice<TrackerTraits, TDevice> const& deviceData) {
       TrackingRecHitHost<TrackerTraits> hostData(queue, deviceData.view().metadata().size());
+
+      // Don't bother if zero hits
+      if (deviceData.view().metadata().size() == 0) {
+        std::memset(hostData.buffer().data(),
+                    0,
+                    alpaka::getExtentProduct(hostData.buffer()) *
+                        sizeof(alpaka::Elem<typename TrackingRecHitHost<TrackerTraits>::Buffer>));
+        return hostData;
+      }
+
       alpaka::memcpy(queue, hostData.buffer(), deviceData.buffer());
 #ifdef GPU_DEBUG
       printf("TrackingRecHitsSoACollection: I'm copying to host.\n");

--- a/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGenerator.cc
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGenerator.cc
@@ -299,6 +299,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     TrackSoA tracks(queue);
 
+    // Don't bother if less than 2 this
+    if (hits_d.view().metadata().size() < 2)
+      return tracks;
+
     GPUKernels kernels(m_params, hits_d.view().metadata().size(), hits_d.offsetBPIX2(), queue);
 
     kernels.buildDoublets(hits_d.view(), hits_d.offsetBPIX2(), queue);


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/45837

#### PR description:

This PR is meant as a fix for https://github.com/cms-sw/cmssw/issues/45834, and builds on top of the earlier fix  https://github.com/cms-sw/cmssw/pull/45744 or issue https://github.com/cms-sw/cmssw/issues/45708.
In a nutshell, `CopyHost::copyAsync()` returns before the `alpaka::memcpy` call in `TrackingRecHitsSoACollection` if the `size()` of the input `deviceData` is null (i.e. there are no input hits).
Additionally protect `CAHitNtupletGenerator` by returning before launching kernels when there are less than 2 hits.

#### PR validation:

Multiple tests have been performed with this branch:

I tested successfully (on `lxplus8-gpu`):
   * the script at https://github.com/cms-sw/cmssw/issues/45834#issue-2494223656 (standard FOG-like tests for pp)
   * the script at https://github.com/cms-sw/cmssw/issues/45708#issue-2468792471 (hybrid GPU+CPU menu, `HIon`-like)
   * `runTheMatrix.py --what upgrade -l 12861.402`  
   
Additionally, following the example at https://github.com/cms-sw/cmssw/issues/45834#issuecomment-2317801292 I  I feed the "alpaka-migrated" menu from [CMSHLT-3284](https://its.cern.ch/jira/browse/CMSHLT-3284) into the relval machinery via:

```bash
cmsrel CMSSW_14_0_15
cd CMSSW_14_0_15/src
cmsenv
git cms-addpkg HLTrigger/Configuration
git cms-addpkg Configuration/PyReleaseValidation
hltGetConfiguration /users/soohwan/HLT_140X/Alpaka/HIonV173/V10 \
   --globaltag auto:phase1_2024_realistic \
   --mc \
   --unprescale \
   --cff > "${CMSSW_BASE}"/src/HLTrigger/Configuration/python/HLT_User_cff.py
scram b -j 20   
```

and then apply the following patch:

```diff
diff --git a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
index 8a70a74aa0c..f9dc0a0397f 100644
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -2865,7 +2865,7 @@ upgradeProperties[2017] = {
     '2022HI' : {
         'Geom' : 'DB:Extended',
         'GT':'auto:phase1_2022_realistic_hi',
-        'HLTmenu': '@fake2',
+        'HLTmenu': 'User',
         'Era':'Run3_pp_on_PbPb',
         'BeamSpot': 'DBrealistic',
         'ScenToRun' : ['GenSim','Digi','RecoNano','HARVESTNano','ALCA'],
@@ -2873,7 +2873,7 @@ upgradeProperties[2017] = {
     '2022HIRP' : {
         'Geom' : 'DB:Extended',
         'GT':'auto:phase1_2022_realistic_hi',
-        'HLTmenu': '@fake2',
+        'HLTmenu': 'User',
         'Era':'Run3_pp_on_PbPb_approxSiStripClusters',
         'BeamSpot': 'DBrealistic',
         'ScenToRun' : ['GenSim','Digi','RecoNano','HARVESTNano','ALCA'],
@@ -2881,7 +2881,7 @@ upgradeProperties[2017] = {
     '2023HI' : {
         'Geom' : 'DB:Extended',
         'GT':'auto:phase1_2023_realistic_hi',
-        'HLTmenu': '@fake2',
+        'HLTmenu': 'User',
         'Era':'Run3_pp_on_PbPb',
         'BeamSpot': 'DBrealistic',
         'ScenToRun' : ['GenSim','Digi','RecoNano','HARVESTNano','ALCA'],
@@ -2889,7 +2889,7 @@ upgradeProperties[2017] = {
     '2023HIRP' : {
         'Geom' : 'DB:Extended',
         'GT':'auto:phase1_2023_realistic_hi',
-        'HLTmenu': '@fake2',
+        'HLTmenu': 'User',
         'Era':'Run3_pp_on_PbPb_approxSiStripClusters',
         'BeamSpot': 'DBrealistic',
         'ScenToRun' : ['GenSim','Digi','RecoNano','HARVESTNano','ALCA'],
```

in a release that I have prepared with this and then finally run:
   * `runTheMatrix.py --what upgrade -l 15261.0 --maxSteps 2` (neutrino gun input)
   * `runTheMatrix.py --what upgrade -l 15224.0 --maxSteps 2` (TTbar input)

Both tests run fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of https://github.com/cms-sw/cmssw/pull/45837 to CMSSW_14_0_X for data-taking purposes.