### PR TITLE
Add a `zeroInitialise()` method to portable objects and collections

### DIFF
--- a/DataFormats/Portable/interface/PortableDeviceCollection.h
+++ b/DataFormats/Portable/interface/PortableDeviceCollection.h
@@ -70,6 +70,12 @@ public:
   ConstBuffer buffer() const { return *buffer_; }
   ConstBuffer const_buffer() const { return *buffer_; }
 
+  // erases the data in the Buffer by writing zeros (bytes containing '\0') to it
+  template <typename TQueue, typename = std::enable_if_t<alpaka::isQueue<TQueue>>>
+  void zeroInitialise(TQueue&& queue) {
+    alpaka::memset(std::forward<TQueue>(queue), *buffer_, 0x00);
+  }
+
 private:
   std::optional<Buffer> buffer_;  //!
   Layout layout_;                 //
@@ -275,7 +281,13 @@ public:
   ConstBuffer buffer() const { return *buffer_; }
   ConstBuffer const_buffer() const { return *buffer_; }
 
-  // Extract the sizes array
+  // erases the data in the Buffer by writing zeros (bytes containing '\0') to it
+  template <typename TQueue, typename = std::enable_if_t<alpaka::isQueue<TQueue>>>
+  void zeroInitialise(TQueue&& queue) {
+    alpaka::memset(std::forward<TQueue>(queue), *buffer_, 0x00);
+  }
+
+  // extract the sizes array
   SizesArray sizes() const {
     SizesArray ret;
     portablecollection::constexpr_for<0, members_>([&](auto i) { ret[i] = get<i>().layout_.metadata().size(); });

--- a/DataFormats/Portable/interface/PortableDeviceObject.h
+++ b/DataFormats/Portable/interface/PortableDeviceObject.h
@@ -50,9 +50,11 @@ public:
   // access the product
   Product& value() { return *buffer_->data(); }
   Product const& value() const { return *buffer_->data(); }
+  Product const& const_value() const { return *buffer_->data(); }
 
   Product* data() { return buffer_->data(); }
   Product const* data() const { return buffer_->data(); }
+  Product const* const_data() const { return buffer_->data(); }
 
   Product& operator*() { return *buffer_->data(); }
   Product const& operator*() const { return *buffer_->data(); }
@@ -64,6 +66,12 @@ public:
   Buffer buffer() { return *buffer_; }
   ConstBuffer buffer() const { return *buffer_; }
   ConstBuffer const_buffer() const { return *buffer_; }
+
+  // erases the data in the Buffer by writing zeros (bytes containing '\0') to it
+  template <typename TQueue, typename = std::enable_if_t<alpaka::isQueue<TQueue>>>
+  void zeroInitialise(TQueue&& queue) {
+    alpaka::memset(std::forward<TQueue>(queue), *buffer_, 0x00);
+  }
 
 private:
   std::optional<Buffer> buffer_;

--- a/DataFormats/Portable/interface/PortableHostCollection.h
+++ b/DataFormats/Portable/interface/PortableHostCollection.h
@@ -69,6 +69,16 @@ public:
   ConstBuffer buffer() const { return *buffer_; }
   ConstBuffer const_buffer() const { return *buffer_; }
 
+  // erases the data in the Buffer by writing zeros (bytes containing '\0') to it
+  void zeroInitialise() {
+    std::memset(std::data(*buffer_), 0x00, alpaka::getExtentProduct(*buffer_) * sizeof(std::byte));
+  }
+
+  template <typename TQueue, typename = std::enable_if_t<alpaka::isQueue<TQueue>>>
+  void zeroInitialise(TQueue&& queue) {
+    alpaka::memset(std::forward<TQueue>(queue), *buffer_, 0x00);
+  }
+
   // part of the ROOT read streamer
   static void ROOTReadStreamer(PortableHostCollection* newObj, Layout& layout) {
     // destroy the default-constructed collection
@@ -278,12 +288,23 @@ public:
   ConstBuffer buffer() const { return *buffer_; }
   ConstBuffer const_buffer() const { return *buffer_; }
 
-  // Extract the sizes array
+  // erases the data in the Buffer by writing zeros (bytes containing '\0') to it
+  void zeroInitialise() {
+    std::memset(std::data(*buffer_), 0x00, alpaka::getExtentProduct(*buffer_) * sizeof(std::byte));
+  }
+
+  template <typename TQueue, typename = std::enable_if_t<alpaka::isQueue<TQueue>>>
+  void zeroInitialise(TQueue&& queue) {
+    alpaka::memset(std::forward<TQueue>(queue), *buffer_, 0x00);
+  }
+
+  // extract the sizes array
   SizesArray sizes() const {
     SizesArray ret;
     portablecollection::constexpr_for<0, members_>([&](auto i) { ret[i] = get<i>().layout_.metadata().size(); });
     return ret;
   }
+
   // part of the ROOT read streamer
   static void ROOTReadStreamer(PortableHostMultiCollection* newObj, Implementation& onfileImpl) {
     newObj->~PortableHostMultiCollection();

--- a/DataFormats/Portable/interface/PortableHostObject.h
+++ b/DataFormats/Portable/interface/PortableHostObject.h
@@ -48,9 +48,11 @@ public:
   // access the product
   Product& value() { return *product_; }
   Product const& value() const { return *product_; }
+  Product const& const_value() const { return *product_; }
 
   Product* data() { return product_; }
   Product const* data() const { return product_; }
+  Product const* const_data() const { return product_; }
 
   Product& operator*() { return *product_; }
   Product const& operator*() const { return *product_; }
@@ -62,6 +64,16 @@ public:
   Buffer buffer() { return *buffer_; }
   ConstBuffer buffer() const { return *buffer_; }
   ConstBuffer const_buffer() const { return *buffer_; }
+
+  // erases the data in the Buffer by writing zeros (bytes containing '\0') to it
+  void zeroInitialise() {
+    std::memset(std::data(*buffer_), 0x00, alpaka::getExtentProduct(*buffer_) * sizeof(std::byte));
+  }
+
+  template <typename TQueue, typename = std::enable_if_t<alpaka::isQueue<TQueue>>>
+  void zeroInitialise(TQueue&& queue) {
+    alpaka::memset(std::forward<TQueue>(queue), *buffer_, 0x00);
+  }
 
   // part of the ROOT read streamer
   static void ROOTReadStreamer(PortableHostObject* newObj, Product& product) {

--- a/DataFormats/PortableTestObjects/test/TestSoA.cc
+++ b/DataFormats/PortableTestObjects/test/TestSoA.cc
@@ -1,6 +1,7 @@
 // A minimal test to ensure that
 //   - portabletest::TestSoA can be compiled
 //   - portabletest::TestHostCollection can be allocated
+//   - portabletest::TestHostCollection can be erased
 //   - view-based element access works
 
 #include "DataFormats/PortableTestObjects/interface/TestHostCollection.h"
@@ -13,6 +14,8 @@ int main() {
 
   const portabletest::Matrix matrix{{1, 2, 3, 4, 5, 6}, {2, 4, 6, 8, 10, 12}, {3, 6, 9, 12, 15, 18}};
   const portabletest::Array flags = {{6, 4, 2, 0}};
+
+  collection.zeroInitialise();
 
   collection.view().r() = 1.;
 

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlgo.h
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlgo.h
@@ -26,6 +26,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     void fillMulti2(Queue& queue, portabletest::TestDeviceMultiCollection2& collection, double xvalue = 0.) const;
     void fillMulti3(Queue& queue, portabletest::TestDeviceMultiCollection3& collection, double xvalue = 0.) const;
+
+    void checkZero(Queue& queue, portabletest::TestDeviceCollection const& collection) const;
+    void checkZero(Queue& queue, portabletest::TestDeviceMultiCollection2 const& collection) const;
+    void checkZero(Queue& queue, portabletest::TestDeviceMultiCollection3 const& collection) const;
+    void checkZero(Queue& queue, portabletest::TestDeviceObject const& object) const;
   };
 
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaProducer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaProducer.cc
@@ -30,18 +30,23 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     void produce(edm::StreamID sid, device::Event& event, device::EventSetup const&) const override {
       // run the algorithm, potentially asynchronously
       portabletest::TestDeviceCollection deviceCollection{size_, event.queue()};
+      deviceCollection.zeroInitialise(event.queue());
+      algo_.checkZero(event.queue(), deviceCollection);
       algo_.fill(event.queue(), deviceCollection);
 
       portabletest::TestDeviceObject deviceObject{event.queue()};
+      deviceObject.zeroInitialise(event.queue());
+      algo_.checkZero(event.queue(), deviceObject);
       algo_.fillObject(event.queue(), deviceObject, 5., 12., 13., 42);
 
-      portabletest::TestDeviceCollection deviceProduct{size_, event.queue()};
-      algo_.fill(event.queue(), deviceProduct);
-
       portabletest::TestDeviceMultiCollection2 deviceMultiProduct2{{{size_, size2_}}, event.queue()};
+      deviceMultiProduct2.zeroInitialise(event.queue());
+      algo_.checkZero(event.queue(), deviceMultiProduct2);
       algo_.fillMulti2(event.queue(), deviceMultiProduct2);
 
       portabletest::TestDeviceMultiCollection3 deviceMultiProduct3{{{size_, size2_, size3_}}, event.queue()};
+      deviceMultiProduct3.zeroInitialise(event.queue());
+      algo_.checkZero(event.queue(), deviceMultiProduct3);
       algo_.fillMulti3(event.queue(), deviceMultiProduct3);
 
       // put the asynchronous products into the event without waiting


### PR DESCRIPTION
#### PR description:

Add a `zeroInitialise()` method to the `PortableObject` and `PortableCollection` templates that erases the data in the `Buffer` by writing zeros (bytes containing `'\0'`) to it:

  - on the host, `zeroInitialise()` can be called without arguments to execute immediately, or with a queue to be run asynchronously;

  - on the device, `zeroInitialise()` requires a queue and can only be run asynchronously.

Extend the tests in `DataFormats/PortableTestObjects` and `HeterogeneousCore/AlpakaTest` to validate the new functionality. 

#### PR validation:

The update unit tests pass on CPU and NVIDIA GPUs.