### PR TITLE
CICADA-Calo Layer 1 Packer

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CICADAPacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CICADAPacker.cc
@@ -16,7 +16,7 @@ namespace l1t {
       uint32_t fourthWord = (cicadaBits & 0x000F) << 28;
       return {firstWord, secondWord, thirdWord, fourthWord};
     }
-    
+
     Blocks CICADAPacker::pack(const edm::Event& event, const PackerTokens* toks) {
       edm::Handle<CICADABxCollection> cicadaScores;
       event.getByToken(static_cast<const CaloLayer1Tokens*>(toks)->getCICADAToken(), cicadaScores);
@@ -27,7 +27,7 @@ namespace l1t {
       //Calo Layer 1 doesn't distinguish between BX's, it just sends the one.
       float cicadaScore = 0.0;
       if (cicadaScores->size(0) != 0) {
-	cicadaScore = cicadaScores->at(0, 0);
+        cicadaScore = cicadaScores->at(0, 0);
       }
       payload = makeCICADAWordsFromScore(cicadaScore);
       payload.push_back(0);
@@ -35,7 +35,7 @@ namespace l1t {
 
       return {Block(0, payload, 0, 0, CTP7)};
     }
-  }
-}
+  }  // namespace stage2
+}  // namespace l1t
 
 DEFINE_L1T_PACKER(l1t::stage2::CICADAPacker);

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CICADAPacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CICADAPacker.cc
@@ -1,0 +1,41 @@
+#include "FWCore/Framework/interface/Event.h"
+#include "EventFilter/L1TRawToDigi/plugins/PackerFactory.h"
+
+#include "CaloLayer1Tokens.h"
+
+#include "CICADAPacker.h"
+
+namespace l1t {
+  namespace stage2 {
+    std::vector<uint32_t> CICADAPacker::makeCICADAWordsFromScore(float score) {
+      //turn the score into an integer to make it a bit easier to work with it bitwise
+      uint32_t cicadaBits = static_cast<uint32_t>(score * 256.f);
+      uint32_t firstWord = (cicadaBits & 0xF000) << 16;
+      uint32_t secondWord = (cicadaBits & 0x0F00) << 20;
+      uint32_t thirdWord = (cicadaBits & 0x00F0) << 24;
+      uint32_t fourthWord = (cicadaBits & 0x000F) << 28;
+      return {firstWord, secondWord, thirdWord, fourthWord};
+    }
+    
+    Blocks CICADAPacker::pack(const edm::Event& event, const PackerTokens* toks) {
+      edm::Handle<CICADABxCollection> cicadaScores;
+      event.getByToken(static_cast<const CaloLayer1Tokens*>(toks)->getCICADAToken(), cicadaScores);
+
+      std::vector<uint32_t> payload;
+
+      //for the purposes of this packer, we really only have to care about the central BX
+      //Calo Layer 1 doesn't distinguish between BX's, it just sends the one.
+      float cicadaScore = 0.0;
+      if (cicadaScores->size(0) != 0) {
+	cicadaScore = cicadaScores->at(0, 0);
+      }
+      payload = makeCICADAWordsFromScore(cicadaScore);
+      payload.push_back(0);
+      payload.push_back(0);
+
+      return {Block(0, payload, 0, 0, CTP7)};
+    }
+  }
+}
+
+DEFINE_L1T_PACKER(l1t::stage2::CICADAPacker);

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CICADAPacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CICADAPacker.h
@@ -13,7 +13,7 @@ namespace l1t {
     private:
       std::vector<uint32_t> makeCICADAWordsFromScore(float);
     };
-  }
-}
+  }  // namespace stage2
+}  // namespace l1t
 
 #endif

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CICADAPacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CICADAPacker.h
@@ -1,0 +1,19 @@
+#ifndef L1T_PACKER_STAGE2_CICADAPACKER_H
+#define L1T_PACKER_STAGE2_CICADAPACKER_H
+
+#include "EventFilter/L1TRawToDigi/interface/Packer.h"
+#include "CaloLayer1Tokens.h"
+
+namespace l1t {
+  namespace stage2 {
+    class CICADAPacker : public Packer {
+    public:
+      Blocks pack(const edm::Event&, const PackerTokens*) override;
+
+    private:
+      std::vector<uint32_t> makeCICADAWordsFromScore(float);
+    };
+  }
+}
+
+#endif

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Setup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Setup.cc
@@ -19,6 +19,7 @@ namespace l1t {
       desc.addOptional<edm::InputTag>("ecalDigis");
       desc.addOptional<edm::InputTag>("hcalDigis");
       desc.addOptional<edm::InputTag>("caloRegions");
+      desc.addOptional<edm::InputTag>("CICADAScore");
     }
 
     PackerMap CaloLayer1Setup::getPackers(int fed, unsigned int fw) {
@@ -37,6 +38,8 @@ namespace l1t {
         res[{2, 15}] = {PackerFactory::get()->make("stage2::CaloLayer1Packer")};
         res[{3, 16}] = {PackerFactory::get()->make("stage2::CaloLayer1Packer")};
         res[{5, 17}] = {PackerFactory::get()->make("stage2::CaloLayer1Packer")};
+        // CICADA board
+        res[{7, 0}] = {PackerFactory::get()->make("stage2::CICADAPacker")};
         res[{8, 0}] = {PackerFactory::get()->make("stage2::CaloLayer1Packer")};
         res[{9, 1}] = {PackerFactory::get()->make("stage2::CaloLayer1Packer")};
         res[{11, 2}] = {PackerFactory::get()->make("stage2::CaloLayer1Packer")};

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Tokens.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Tokens.cc
@@ -10,10 +10,12 @@ namespace l1t {
       auto ecalTag = cfg.getParameter<edm::InputTag>("ecalDigis");
       auto hcalTag = cfg.getParameter<edm::InputTag>("hcalDigis");
       auto regionTag = cfg.getParameter<edm::InputTag>("caloRegions");
+      auto cicadaTag = cfg.getParameter<edm::InputTag>("CICADAScore");
 
       ecalDigiToken_ = cc.consumes<EcalTrigPrimDigiCollection>(ecalTag);
       hcalDigiToken_ = cc.consumes<HcalTrigPrimDigiCollection>(hcalTag);
       caloRegionToken_ = cc.consumes<L1CaloRegionCollection>(regionTag);
+      cicadaToken_ = cc.consumes<CICADABxCollection>(cicadaTag);
     }
   }  // namespace stage2
 }  // namespace l1t

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Tokens.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Tokens.h
@@ -6,6 +6,7 @@
 #include "DataFormats/L1CaloTrigger/interface/L1CaloCollections.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "EventFilter/L1TRawToDigi/interface/PackerTokens.h"
+#include "DataFormats/L1CaloTrigger/interface/CICADA.h"
 
 namespace l1t {
   namespace stage2 {
@@ -16,11 +17,13 @@ namespace l1t {
       inline const edm::EDGetTokenT<EcalTrigPrimDigiCollection>& getEcalDigiToken() const { return ecalDigiToken_; };
       inline const edm::EDGetTokenT<HcalTrigPrimDigiCollection>& getHcalDigiToken() const { return hcalDigiToken_; };
       inline const edm::EDGetTokenT<L1CaloRegionCollection>& getCaloRegionToken() const { return caloRegionToken_; };
+      inline const edm::EDGetTokenT<CICADABxCollection>& getCICADAToken() const { return cicadaToken_; };
 
     private:
       edm::EDGetTokenT<EcalTrigPrimDigiCollection> ecalDigiToken_;
       edm::EDGetTokenT<HcalTrigPrimDigiCollection> hcalDigiToken_;
       edm::EDGetTokenT<L1CaloRegionCollection> caloRegionToken_;
+      edm::EDGetTokenT<CICADABxCollection> cicadaToken_;
     };
   }  // namespace stage2
 }  // namespace l1t

--- a/EventFilter/L1TRawToDigi/python/caloLayer1Raw_cfi.py
+++ b/EventFilter/L1TRawToDigi/python/caloLayer1Raw_cfi.py
@@ -6,6 +6,7 @@ caloLayer1RawFed1354 = cms.EDProducer(
     ecalDigis = cms.InputTag("simEcalTriggerPrimitiveDigis"),
     hcalDigis = cms.InputTag("simHcalTriggerPrimitiveDigis"),
     caloRegions = cms.InputTag("simCaloStage2Layer1Digis"),
+    CICADAScore = cms.InputTag("simCaloStage2Layer1Summary", "CICADAScore"),
     FedId = cms.int32(1354),
     FWId = cms.uint32(0x12345678),
     lenSlinkHeader = cms.untracked.int32(8),


### PR DESCRIPTION
#### PR description:

This PR adds a packer for the CICADA data as transmitted by the Calo Layer 1 system. This should be the counterpart to the Calo Layer 1 Unpacker added as a part of https://github.com/cms-sw/cmssw/pull/45293.

@slaurila @eyigitba FYI.

#### PR validation:

All code compiles and has had formatting appllied. The DIGI2RAW step has been checked on MC, and the packer is called appropriately, and produces the expected output for input scores:

![image](https://github.com/user-attachments/assets/44028347-d5ce-428d-8ad1-86bb2550f00e)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not a backport, but will likely require backports all the way to CMSSW_14_0.