### PR TITLE
Add CICADA Regions and Score to AOD and MINIAOD formats

### DIFF
--- a/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
+++ b/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
@@ -100,6 +100,20 @@ L1TriggerFEVTDEBUG = cms.PSet(
 )
 
 
+def _appendCICADAInformation(obj):
+    cicadaDataRegions = [
+        # unpacked/data CICADA input/output
+        'keep L1CaloRegions_caloLayer1Digis_*_*',
+        'keep *_caloLayer1Digis_CICADAScore_*',
+    ]
+    obj.outputCommands += cicadaDataRegions
+# Make CICADA available in AOD and miniAOD from 2024 on
+from Configuration.Eras.Modifier_run3_2024_L1T_cff import run3_2024_L1T
+run3_2024_L1T.toModify(L1TriggerAOD, func=_appendCICADAInformation)
+from PhysicsTools.PatAlgos.slimming.MicroEventContent_cff import MicroEventContent, MicroEventContentMC
+run3_2024_L1T.toModify(MicroEventContent, func=_appendCICADAInformation)
+run3_2024_L1T.toModify(MicroEventContentMC, func=_appendCICADAInformation)
+
 def _appendStage2Digis(obj):
     l1Stage2Digis = [
         'keep *_gtStage2Digis_*_*',

--- a/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
+++ b/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
@@ -108,11 +108,11 @@ def _appendCICADAInformation(obj):
     ]
     obj.outputCommands += cicadaDataRegions
 # Make CICADA available in AOD and miniAOD from 2024 on
-from Configuration.Eras.Modifier_run3_2024_L1T_cff import run3_2024_L1T
-run3_2024_L1T.toModify(L1TriggerAOD, func=_appendCICADAInformation)
+from Configuration.Eras.Modifier_stage2L1Trigger_2024_cff import stage2L1Trigger_2024
+stage2L1Trigger_2024.toModify(L1TriggerAOD, func=_appendCICADAInformation)
 from PhysicsTools.PatAlgos.slimming.MicroEventContent_cff import MicroEventContent, MicroEventContentMC
-run3_2024_L1T.toModify(MicroEventContent, func=_appendCICADAInformation)
-run3_2024_L1T.toModify(MicroEventContentMC, func=_appendCICADAInformation)
+stage2L1Trigger_2024.toModify(MicroEventContent, func=_appendCICADAInformation)
+stage2L1Trigger_2024.toModify(MicroEventContentMC, func=_appendCICADAInformation)
 
 def _appendStage2Digis(obj):
     l1Stage2Digis = [


### PR DESCRIPTION
#### PR description:

By request of the CICADA team, this PR adds CICADA input collections (Calo Layer 1 regions, an `L1CaloRegionCollection`) and CICADA output collections (A bx vector of scores, a `CICADABxCollection`) to AOD and MINIAOD for Data and MC, for easier studying of the physics potential of the new trigger. 

As of right now, inputs to any emulation are only available in the RAW data format, which is undesirable on disk at most sites. These changes will make studying triggers based on these inputs much more possible, and datasets much likelier on disk without special requests, or lots of occupied disk space.

#### PR validation:

Contents of produced Data and MC, MiniAOD and AOD formats have been checked to see that they contained the desired input and output collections.

the EDM Event Size tool was used to check the size added to both formats on O(1000) Data events, and O(100) MC events.

For Data AOD:
| Collection | Uncompressed Size (Bytes/Event) | Compressed Size (Bytes/Event) |
|---------------|-----------------------------------------------|--------------------------------------------|
| Regions    |  5881.13                                         | 366.643                                       |
| Score        | 62.2346                                          | 3.993                                           |

For Data MiniAOD:
| Collection | Uncompressed Size (Bytes/Event) | Compressed Size (Bytes/Event) |
|---------------|-----------------------------------------------|--------------------------------------------|
| Regions    |  5817.43                                         | 25.187                                       |
| Score        | 67.4772                                          | 2,141                                           |

For MC AOD:
| Collection | Uncompressed Size (Bytes/Event) | Compressed Size (Bytes/Event) |
|---------------|-----------------------------------------------|--------------------------------------------|
| Regions    |  5875.26                                         | 588.96                                       |
| Score        | 140.54                                          | 110.14                                           |

For MC MiniAOD
| Collection | Uncompressed Size (Bytes/Event) | Compressed Size (Bytes/Event) |
|---------------|-----------------------------------------------|--------------------------------------------|
| Regions    |  5901.34                                         | 772.37                                       |
| Score        | 71.64                                          | 28.14                                           |

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not a backport and will not require backporting as of right now.