### PR TITLE
add few more default geometry tests in `Geometry/TrackerGeometryBuilder`

### DIFF
--- a/Geometry/TrackerGeometryBuilder/test/python/testPhase2TrackerHierarchy_cfg.py
+++ b/Geometry/TrackerGeometryBuilder/test/python/testPhase2TrackerHierarchy_cfg.py
@@ -1,0 +1,43 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+###################################################################
+# Setup 'standard' options
+###################################################################
+options = VarParsing.VarParsing()
+options.register('Scenario',
+                 _settings.DEFAULT_VERSION, # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.string, # string, int, or float
+                 "geometry version to use: 2026DXXX")
+options.parseArguments()
+
+###################################################################
+# get Global Tag and ERA
+###################################################################
+GLOBAL_TAG, ERA = _settings.get_era_and_conditions(options.Scenario)
+
+process = cms.Process("GeometryTest",ERA)
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+
+# Choose Tracker Geometry
+if(options.Scenario == _settings.DEFAULT_VERSION):
+    print("Loading default scenario: ", _settings.DEFAULT_VERSION)
+    process.load('Configuration.Geometry.GeometryExtended2026DefaultReco_cff')
+else:
+    process.load('Configuration.Geometry.GeometryExtended'+options.Scenario+'Reco_cff')
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+process.prod = cms.EDAnalyzer("GeoHierarchy",
+    fromDDD = cms.bool(True)
+)
+
+process.load("Alignment.CommonAlignmentProducer.FakeAlignmentSource_cfi")
+process.preferFakeAlign = cms.ESPrefer("FakeAlignmentSource") 
+
+process.p1 = cms.Path(process.prod)

--- a/Geometry/TrackerGeometryBuilder/test/python/testTrackerModuleInfoDD4hep_cfg.py
+++ b/Geometry/TrackerGeometryBuilder/test/python/testTrackerModuleInfoDD4hep_cfg.py
@@ -1,12 +1,33 @@
 import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
 
-from Configuration.Eras.Era_Run3_dd4hep_cff import Run3_dd4hep
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+###################################################################
+# Setup 'standard' options
+###################################################################
+options = VarParsing.VarParsing()
+options.register('Scenario',
+                 _settings.DEFAULT_VERSION, # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.string, # string, int, or float
+                 "geometry version to use: 2026DXXX")
+options.parseArguments()
 
-process = cms.Process("GeometryTest", Run3_dd4hep)
+###################################################################
+# get Global Tag and ERA
+###################################################################
+GLOBAL_TAG, ERA = _settings.get_era_and_conditions(options.Scenario)
+
+from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
+process = cms.Process("GeometryTest", ERA, dd4hep)
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 
 # Choose Tracker Geometry
-process.load('Configuration.Geometry.GeometryDD4hepExtended2026D100Reco_cff')
+if(options.Scenario == _settings.DEFAULT_VERSION):
+    print("Loading default scenario: ", _settings.DEFAULT_VERSION)
+    process.load('Configuration.Geometry.GeometryDD4hepExtended2026DefaultReco_cff')
+else:
+    process.load('Configuration.Geometry.GeometryDD4hepExtended'+options.Scenario+'Reco_cff')
 
 process.TrackerGeometricDetESModule = cms.ESProducer( "TrackerGeometricDetESModule",
                                                       fromDDD = cms.bool( False ),

--- a/Geometry/TrackerGeometryBuilder/test/python/testTrackerModuleInfoDDD_cfg.py
+++ b/Geometry/TrackerGeometryBuilder/test/python/testTrackerModuleInfoDDD_cfg.py
@@ -1,11 +1,34 @@
 import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
 
-process = cms.Process("GeometryTest")
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+###################################################################
+# Setup 'standard' options
+###################################################################
+options = VarParsing.VarParsing()
+options.register('Scenario',
+                 _settings.DEFAULT_VERSION, # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.string, # string, int, or float
+                 "geometry version to use: 2026DXXX")
+options.parseArguments()
+
+###################################################################
+# get Global Tag and ERA
+###################################################################
+GLOBAL_TAG, ERA = _settings.get_era_and_conditions(options.Scenario)
+
+process = cms.Process("GeometryTest",ERA)
 # empty input service, fire 10 events
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 
 # Choose Tracker Geometry
-process.load('Configuration.Geometry.GeometryExtended2026D100_cff')
+if(options.Scenario == _settings.DEFAULT_VERSION):
+    print("Loading default scenario: ", _settings.DEFAULT_VERSION)
+    process.load('Configuration.Geometry.GeometryExtended2026Default_cff')
+else:
+    process.load('Configuration.Geometry.GeometryExtended'+options.Scenario+'_cff')
+
 process.load('Geometry.CommonTopologies.globalTrackingGeometry_cfi')
 process.load('Geometry.TrackerGeometryBuilder.trackerParameters_cfi')
 process.load('Geometry.TrackerNumberingBuilder.trackerTopology_cfi')


### PR DESCRIPTION
#### PR description:

Title says it all, goes in the same direction as of https://github.com/cms-sw/cmssw/pull/45810, https://github.com/cms-sw/cmssw/pull/45796, https://github.com/cms-sw/cmssw/pull/45775 and https://github.com/cms-sw/cmssw/pull/45764
Use the default 2026 sim and reco geometries to test the tracker geometry with `ModuleInfo` and `GeoHierarchy`

#### PR validation:

`scram b runtests_GeometryTrackerGeometryBuilderTestDriver` runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A