### PR TITLE
Add certificates handling to `G2GainsValidator.py`

### DIFF
--- a/CondCore/SiStripPlugins/scripts/testCompare.sh
+++ b/CondCore/SiStripPlugins/scripts/testCompare.sh
@@ -6,27 +6,25 @@ display_usage() {
 } 
 
 # if less than two arguments supplied, display usage 
-	if [  $# -le 3 ] 
-	then 
-		display_usage
-		exit 1
-	fi 
+if [  $# -le 3 ]
+then
+    display_usage
+    exit 1
+fi
  
 # check whether user had supplied -h or --help . If yes display usage 
-	if [[ ( $# == "--help") ||  $# == "-h" ]] 
-	then 
-		display_usage
-		exit 0
-	fi 
+if [[ ( $# == "--help") ||  $# == "-h" ]]
+then
+    display_usage
+    exit 0
+fi
 
 # Save current working dir so img can be outputted there later
 W_DIR=$(pwd);
-# Set SCRAM architecture var
-SCRAM_ARCH=slc6_amd64_gcc630;
+
 STARTIOV=$2
 ENDIOV=$3
 
-export SCRAM_ARCH;
 source /afs/cern.ch/cms/cmsset_default.sh;
 eval `scram run -sh`;
 # Go back to original working directory

--- a/CondCore/SiStripPlugins/test/BuildFile.xml
+++ b/CondCore/SiStripPlugins/test/BuildFile.xml
@@ -8,3 +8,4 @@
 <use name="CalibTracker/SiStripCommon"/>
 <bin file="testSiStripPayloadInspector.cpp" name="testSiStripPayloadInspector">
 </bin>
+<test name="test_G2GainsValidator" command="test_G2GainsValidator.sh"/>

--- a/CondCore/SiStripPlugins/test/test_G2GainsValidator.sh
+++ b/CondCore/SiStripPlugins/test/test_G2GainsValidator.sh
@@ -2,4 +2,3 @@
 
 function die { echo $1: status $2 ; exit $2; }
 python3 $CMSSW_BASE/src/CondCore/SiStripPlugins/scripts/G2GainsValidator.py  || die "Failure running G2GainsValidator.py" $?
- 

--- a/CondCore/SiStripPlugins/test/test_G2GainsValidator.sh
+++ b/CondCore/SiStripPlugins/test/test_G2GainsValidator.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+function die { echo $1: status $2 ; exit $2; }
+python3 $CMSSW_BASE/src/CondCore/SiStripPlugins/scripts/G2GainsValidator.py  || die "Failure running G2GainsValidator.py" $?
+ 


### PR DESCRIPTION
#### PR description:

The spirit of this PR is similar to https://github.com/cms-sw/cmssw/pull/45779.
This PR adds providing certificates for curl requests done to `https://cmsweb.cern.ch/t0wmadatasvc/prod/` from  `G2GainsValidator.py`. 
The paths to the certificate and the key are meant to be specified in `X509_USER_CERT` and `X509_USER_KEY` and can be automatically fetched by the user (when not available) via the option '-u' or  '--user-mode'.
I am assuming they are available in the cms-bot test environment so I am not going to impose that mode when running tests.
I also profit of the PR to add a dedicated unit test: `test_G2GainsValidator`  

#### PR validation:

`scram b runtests_test_G2GainsValidator` runs fine with this branch.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, to be backported to CMSSW_14_1_X and CMSSW_14_0_X for data-taking operations purposes.