### PR TITLE
[14_1_X] Fix issue with ZdcSimpleRecAlgo_Run3.cc 

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/src/ZdcSimpleRecAlgo_Run3.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/ZdcSimpleRecAlgo_Run3.cc
@@ -103,7 +103,7 @@ ZDCRecHit ZdcSimpleRecAlgo_Run3::reco0(const QIE10DataFrame& digi,
   int noiseslices = 0;
   int CurrentTS = 0;
   double noise = 0;
-  int digi_size = digi.size();
+  int digi_size = digi.samples();
   HcalZDCDetId cell = digi.id();
   int zdcsection = cell.section();
 
@@ -165,7 +165,6 @@ ZDCRecHit ZdcSimpleRecAlgo_Run3::reco0(const QIE10DataFrame& digi,
   // determine energy if using Template Fit method
   if (correctionMethod_.at(zdcsection) == 1 && templateFitValid_.at(zdcsection)) {
     double energy = 0;
-    int digi_size = digi.size();
     for (int iv = 0; iv < nTs_; iv++) {
       int capid = digi[iv].capid();
       float ped = effPeds.getValue(capid);


### PR DESCRIPTION
#### PR description:

Fixed issue where digi size was determined by QIE8 method instead of QIE10 method. Issue was raised [here ](https://github.com/cms-sw/cmssw/pull/45407#issuecomment-2317624819)

#### PR validation:

Did the following **runthematrix** :

runTheMatrix.py -l 142 -e --ibeos

This job previously failed before the fix was implemented 
