### PR TITLE
Alpaka Pixel: Write `nTracks=0` When No Track Stored

### DIFF
--- a/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGenerator.cc
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGenerator.cc
@@ -300,9 +300,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     TrackSoA tracks(queue);
 
     // Don't bother if less than 2 this
-    if (hits_d.view().metadata().size() < 2)
+    if (hits_d.view().metadata().size() < 2) {
+      const auto device = alpaka::getDev(queue);
+      auto ntracks_d = cms::alpakatools::make_device_view(device, tracks.view().nTracks());
+      alpaka::memset(queue, ntracks_d, 0);
       return tracks;
-
+    }
     GPUKernels kernels(m_params, hits_d.view().metadata().size(), hits_d.offsetBPIX2(), queue);
 
     kernels.buildDoublets(hits_d.view(), hits_d.offsetBPIX2(), queue);


### PR DESCRIPTION
#### PR description:

This PR proposes a small fix in order to avoid  the [ loop on the track SoA done by `vertexFinder`](https://github.com/cms-sw/cmssw/blob/master/RecoTracker/PixelVertexFinding/plugins/alpaka/vertexFinder.dev.cc#L41) when no track is actually stored.

solves https://github.com/cms-sw/cmssw/issues/45871

#### PR validation:

`runTheMatrix.py -w upgrade -l 12461.402` does not crash.