### PR TITLE
[13_0_X_HLT] set bypassVersionCheck default to True again

### DIFF
--- a/Configuration/DataProcessing/python/Merge.py
+++ b/Configuration/DataProcessing/python/Merge.py
@@ -41,7 +41,7 @@ def mergeProcess(*inputFiles, **options):
     dropDQM = options.get("drop_dqm", False)
     newDQMIO = options.get("newDQMIO", False)
     mergeNANO = options.get("mergeNANO", False)
-    bypassVersionCheck = options.get("bypassVersionCheck", False)
+    bypassVersionCheck = options.get("bypassVersionCheck", True)
     #  //
     # // build process
     #//

--- a/Configuration/DataProcessing/test/RunMerge.py
+++ b/Configuration/DataProcessing/test/RunMerge.py
@@ -24,7 +24,7 @@ class RunMerge:
         self.inputFiles = []
         self.newDQMIO = False
         self.mergeNANO = False
-        self.bypassVersionCheck = False
+        self.bypassVersionCheck = True
         
 
     def __call__(self):


### PR DESCRIPTION
as in [#9054](https://github.com/dmwm/WMCore/issues/9054) to be able to process HLT in older release in MC production the merge step needs to be bypassing the version check.

this is solely for 13_0 HLT branch for the purpose of MC production

in the long run, we'll have to find a better way to handle this at the production tool level, instead of having to patch the release like this