### PR TITLE
Improve QTest Pixel DQM (BP to [14_1_X])

### DIFF
--- a/DQM/SiPixelPhase1Config/test/qTests/mean_charge_qualitytest_config.xml
+++ b/DQM/SiPixelPhase1Config/test/qTests/mean_charge_qualitytest_config.xml
@@ -8,7 +8,7 @@
       <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.65</PARAM>
       <PARAM name="warning">0.80</PARAM>
-      <PARAM name="ymin">27500.</PARAM>
+      <PARAM name="ymin">15000.</PARAM>
       <PARAM name="ymax">75000.</PARAM>
     </QTEST>
 
@@ -17,7 +17,7 @@
       <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.65</PARAM>
       <PARAM name="warning">0.80</PARAM>
-      <PARAM name="ymin">27500.</PARAM>
+      <PARAM name="ymin">15000.</PARAM>
       <PARAM name="ymax">75000.</PARAM>
     </QTEST>
 
@@ -26,7 +26,7 @@
       <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.65</PARAM>
       <PARAM name="warning">0.80</PARAM>
-      <PARAM name="ymin">35000.</PARAM>
+      <PARAM name="ymin">15000.</PARAM>
       <PARAM name="ymax">75000.</PARAM>
     </QTEST>
 
@@ -35,7 +35,7 @@
       <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.65</PARAM>
       <PARAM name="warning">0.80</PARAM>
-      <PARAM name="ymin">30000.</PARAM>
+      <PARAM name="ymin">15000.</PARAM>
       <PARAM name="ymax">75000.</PARAM>
     </QTEST>
 
@@ -45,7 +45,7 @@
       <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.75</PARAM>
       <PARAM name="warning">0.90</PARAM>
-      <PARAM name="ymin">35000.</PARAM>
+      <PARAM name="ymin">15000.</PARAM>
       <PARAM name="ymax">75000.</PARAM>
     </QTEST>
 
@@ -54,7 +54,7 @@
       <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">35000.</PARAM>
+      <PARAM name="ymin">15000.</PARAM>
       <PARAM name="ymax">75000.</PARAM>
     </QTEST>
 
@@ -63,7 +63,7 @@
       <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.75</PARAM>
       <PARAM name="warning">0.90</PARAM>
-      <PARAM name="ymin">35000.</PARAM>
+      <PARAM name="ymin">15000.</PARAM>
       <PARAM name="ymax">75000.</PARAM>
     </QTEST>
 
@@ -72,7 +72,7 @@
       <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.75</PARAM>
       <PARAM name="warning">0.90</PARAM>
-      <PARAM name="ymin">25000.</PARAM>
+      <PARAM name="ymin">15000.</PARAM>
       <PARAM name="ymax">75000.</PARAM>
     </QTEST>
 
@@ -82,7 +82,7 @@
       <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">35000.</PARAM>
+      <PARAM name="ymin">15000.</PARAM>
       <PARAM name="ymax">75000.</PARAM>
     </QTEST>
 
@@ -91,7 +91,7 @@
       <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">35000.</PARAM>
+      <PARAM name="ymin">15000.</PARAM>
       <PARAM name="ymax">75000.</PARAM>
     </QTEST>
 
@@ -100,7 +100,7 @@
       <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">35000.</PARAM>
+      <PARAM name="ymin">15000.</PARAM>
       <PARAM name="ymax">75000.</PARAM>
     </QTEST>
 
@@ -109,7 +109,7 @@
       <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">35000.</PARAM>
+      <PARAM name="ymin">15000.</PARAM>
       <PARAM name="ymax">75000.</PARAM>
     </QTEST>
 
@@ -119,7 +119,7 @@
       <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">35000.</PARAM>
+      <PARAM name="ymin">15000.</PARAM>
       <PARAM name="ymax">75000.</PARAM>
     </QTEST>
 
@@ -128,7 +128,7 @@
       <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">35000.</PARAM>
+      <PARAM name="ymin">15000.</PARAM>
       <PARAM name="ymax">75000.</PARAM>
     </QTEST>
 
@@ -137,7 +137,7 @@
       <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">35000.</PARAM>
+      <PARAM name="ymin">15000.</PARAM>
       <PARAM name="ymax">75000.</PARAM>
     </QTEST>
 
@@ -146,7 +146,7 @@
       <PARAM name="useEmptyBins">0</PARAM>
       <PARAM name="error">0.85</PARAM>
       <PARAM name="warning">0.95</PARAM>
-      <PARAM name="ymin">35000.</PARAM>
+      <PARAM name="ymin">15000.</PARAM>
       <PARAM name="ymax">75000.</PARAM>
     </QTEST>
 
@@ -158,7 +158,7 @@
         <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">20000.</PARAM>
+        <PARAM name="ymin">15000.</PARAM>
         <PARAM name="ymax">50000.</PARAM>
       </QTEST>
 
@@ -167,7 +167,7 @@
         <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">20000.</PARAM>
+        <PARAM name="ymin">15000.</PARAM>
         <PARAM name="ymax">50000.</PARAM>
       </QTEST>
 
@@ -176,7 +176,7 @@
         <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">20000.</PARAM>
+        <PARAM name="ymin">15000.</PARAM>
         <PARAM name="ymax">50000.</PARAM>
       </QTEST>
 
@@ -186,7 +186,7 @@
         <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">20000.</PARAM>
+        <PARAM name="ymin">15000.</PARAM>
         <PARAM name="ymax">50000.</PARAM>
       </QTEST>
 
@@ -195,7 +195,7 @@
         <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">25000.</PARAM>
+        <PARAM name="ymin">15000.</PARAM>
         <PARAM name="ymax">50000.</PARAM>
       </QTEST>
 
@@ -204,7 +204,7 @@
         <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">25000.</PARAM>
+        <PARAM name="ymin">15000.</PARAM>
         <PARAM name="ymax">50000.</PARAM>
       </QTEST>
 
@@ -216,7 +216,7 @@
         <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">20000.</PARAM>
+        <PARAM name="ymin">15000.</PARAM>
         <PARAM name="ymax">50000.</PARAM>
       </QTEST>
 
@@ -225,7 +225,7 @@
         <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">20000.</PARAM>
+        <PARAM name="ymin">15000.</PARAM>
         <PARAM name="ymax">50000.</PARAM>
       </QTEST>
 
@@ -234,7 +234,7 @@
         <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">20000.</PARAM>
+        <PARAM name="ymin">15000.</PARAM>
         <PARAM name="ymax">50000.</PARAM>
       </QTEST>
 
@@ -244,7 +244,7 @@
         <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">25000.</PARAM>
+        <PARAM name="ymin">15000.</PARAM>
         <PARAM name="ymax">50000.</PARAM>
       </QTEST>
 
@@ -253,7 +253,7 @@
         <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">25000.</PARAM>
+        <PARAM name="ymin">15000.</PARAM>
         <PARAM name="ymax">50000.</PARAM>
       </QTEST>
 
@@ -262,7 +262,7 @@
         <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">25000.</PARAM>
+        <PARAM name="ymin">15000.</PARAM>
         <PARAM name="ymax">50000.</PARAM>
       </QTEST>
 
@@ -274,7 +274,7 @@
         <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">20000.</PARAM>
+        <PARAM name="ymin">15000.</PARAM>
         <PARAM name="ymax">50000.</PARAM>
       </QTEST>
 
@@ -283,7 +283,7 @@
         <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">20000.</PARAM>
+        <PARAM name="ymin">15000.</PARAM>
         <PARAM name="ymax">50000.</PARAM>
       </QTEST>
 
@@ -292,7 +292,7 @@
         <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">20000.</PARAM>
+        <PARAM name="ymin">15000.</PARAM>
         <PARAM name="ymax">50000.</PARAM>
       </QTEST>
 
@@ -302,7 +302,7 @@
         <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">25000.</PARAM>
+        <PARAM name="ymin">15000.</PARAM>
         <PARAM name="ymax">50000.</PARAM>
       </QTEST>
 
@@ -311,7 +311,7 @@
         <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">25000.</PARAM>
+        <PARAM name="ymin">15000.</PARAM>
         <PARAM name="ymax">50000.</PARAM>
       </QTEST>
 
@@ -320,7 +320,7 @@
         <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">25000.</PARAM>
+        <PARAM name="ymin">15000.</PARAM>
         <PARAM name="ymax">50000.</PARAM>
       </QTEST>
 
@@ -332,7 +332,7 @@
         <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">20000.</PARAM>
+        <PARAM name="ymin">15000.</PARAM>
         <PARAM name="ymax">50000.</PARAM>
       </QTEST>
 
@@ -341,7 +341,7 @@
         <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">20000.</PARAM>
+        <PARAM name="ymin">15000.</PARAM>
         <PARAM name="ymax">50000.</PARAM>
       </QTEST>
 
@@ -350,7 +350,7 @@
         <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">20000.</PARAM>
+        <PARAM name="ymin">15000.</PARAM>
         <PARAM name="ymax">50000.</PARAM>
       </QTEST>
 
@@ -360,7 +360,7 @@
         <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">25000.</PARAM>
+        <PARAM name="ymin">15000.</PARAM>
         <PARAM name="ymax">50000.</PARAM>
       </QTEST>
 
@@ -369,7 +369,7 @@
         <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">25000.</PARAM>
+        <PARAM name="ymin">15000.</PARAM>
         <PARAM name="ymax">50000.</PARAM>
       </QTEST>
 
@@ -378,7 +378,7 @@
         <PARAM name="useEmptyBins">0</PARAM>
         <PARAM name="error">0.85</PARAM>
         <PARAM name="warning">0.95</PARAM>
-        <PARAM name="ymin">25000.</PARAM>
+        <PARAM name="ymin">15000.</PARAM>
         <PARAM name="ymax">50000.</PARAM>
       </QTEST>
 

--- a/DQM/SiPixelPhase1Config/test/qTests/mean_size_qualitytest_config.xml
+++ b/DQM/SiPixelPhase1Config/test/qTests/mean_size_qualitytest_config.xml
@@ -9,7 +9,7 @@
       <PARAM name="error">0.65</PARAM>
       <PARAM name="warning">0.80</PARAM>
       <PARAM name="ymin">1.5</PARAM>
-      <PARAM name="ymax">6.</PARAM>
+      <PARAM name="ymax">7.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_1__Shell_mO:mean_size" activate="true">
@@ -18,7 +18,7 @@
       <PARAM name="error">0.65</PARAM>
       <PARAM name="warning">0.80</PARAM>
       <PARAM name="ymin">1.5</PARAM>
-      <PARAM name="ymax">6.</PARAM>
+      <PARAM name="ymax">7.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_1__Shell_pI:mean_size" activate="true">
@@ -27,7 +27,7 @@
       <PARAM name="error">0.65</PARAM>
       <PARAM name="warning">0.80</PARAM>
       <PARAM name="ymin">1.5</PARAM>
-      <PARAM name="ymax">6.</PARAM>
+      <PARAM name="ymax">7.</PARAM>
     </QTEST>
 
     <QTEST name="Yrange:PXLayer_1__Shell_pO:mean_size" activate="true">
@@ -36,7 +36,7 @@
       <PARAM name="error">0.65</PARAM>
       <PARAM name="warning">0.80</PARAM>
       <PARAM name="ymin">1.5</PARAM>
-      <PARAM name="ymax">6.</PARAM>
+      <PARAM name="ymax">7.</PARAM>
     </QTEST>
 
     <!-- PXLAYER 2 -->


### PR DESCRIPTION
#### PR description:

Changes to Pixel DQM Quality Test

1) L1 cluster size:
Issue: HI runs from 2023 and early 2024 pp runs had cluster size > 6 (outside allowed range)
GUI plot: https://tinyurl.com/2ccppw6k
GUI summary: https://tinyurl.com/2dysgbhe
Details: [slides 5-6-7](https://indico.cern.ch/event/1396784/contributions/5918599/attachments/2842621/4969340/DQM_OnCall_Apr24.pdf)
Change: increase error threshold for the QTest from 6 to 7 (L1 mean cluster size)

2) Cluster charge (BPix and FPix):
Issue: 2024 pp runs have cluster charge close to error threshold (values established 5 years ago, during Run 2)
GUI plot: https://tinyurl.com/22n2bwvv
GUI summary: https://tinyurl.com/2xn3uu59
Details: [slides 2-3-4](https://indico.cern.ch/event/1396792/contributions/6092611/attachments/2912142/5109601/Cluster_Charge_16August-2024.pdf)
Change: reduce error threshold to 15k electrons (BPix and FPix mean cluster charge)

#### PR validation:

Simple change to config numerical values: no validation done

#### About backport
This is a backport to 14_1_X of https://github.com/cms-sw/cmssw/pull/45840