### PR TITLE
[Phase 2 L1T] fixing ASAN errors in Phase2L1CaloJetEmulator

### DIFF
--- a/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloJetEmulator.cc
+++ b/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloJetEmulator.cc
@@ -710,7 +710,7 @@ float Phase2L1CaloJetEmulator::get_jet_pt_calibration(const float& jet_pt, const
       pt_index++;
     }
     calib = calibrationsBarrel[eta_index][pt_index];
-  }                         // end Barrel
+  }  // end Barrel
   else if (abs_eta <= 3.0)  // HGCal
   {
     // Start loop checking 2nd value
@@ -726,7 +726,7 @@ float Phase2L1CaloJetEmulator::get_jet_pt_calibration(const float& jet_pt, const
       pt_index++;
     }
     calib = calibrationsHGCal[eta_index][pt_index];
-  }     // end HGCal
+  }  // end HGCal
   else  // HF
   {
     // Start loop checking 2nd value
@@ -773,7 +773,7 @@ float Phase2L1CaloJetEmulator::get_tau_pt_calibration(const float& tau_pt, const
       pt_index++;
     }
     calib = tauPtCalibrationsBarrel[eta_index][pt_index];
-  }                         // end Barrel
+  }  // end Barrel
   else if (abs_eta <= 3.0)  // HGCal
   {
     // Start loop checking 2nd value

--- a/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloJetEmulator.cc
+++ b/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloJetEmulator.cc
@@ -395,10 +395,17 @@ void Phase2L1CaloJetEmulator::produce(edm::Event& iEvent, const edm::EventSetup&
       hfTowers[2 * ieta + 1][iphi] = et / 8;
       hfTowers[2 * ieta][iphi + 1] = et / 8;
       hfTowers[2 * ieta + 1][iphi + 1] = et / 8;
-      hfTowers[2 * ieta][iphi + 2] = et / 8;
-      hfTowers[2 * ieta + 1][iphi + 2] = et / 8;
-      hfTowers[2 * ieta][iphi + 3] = et / 8;
-      hfTowers[2 * ieta + 1][iphi + 3] = et / 8;
+      if (iphi + 2 == nHfPhi) {
+        hfTowers[2 * ieta][0] = et / 8;
+        hfTowers[2 * ieta + 1][0] = et / 8;
+        hfTowers[2 * ieta][1] = et / 8;
+        hfTowers[2 * ieta + 1][1] = et / 8;
+      } else {
+        hfTowers[2 * ieta][iphi + 2] = et / 8;
+        hfTowers[2 * ieta + 1][iphi + 2] = et / 8;
+        hfTowers[2 * ieta][iphi + 3] = et / 8;
+        hfTowers[2 * ieta + 1][iphi + 3] = et / 8;
+      }
     } else if ((ieta >= 2 && ieta < nHfEta - 2) && iphi % 2 == 0) {
       hfTowers[2 * ieta][iphi] = et / 4;
       hfTowers[2 * ieta + 1][iphi] = et / 4;


### PR DESCRIPTION
#### PR description:

Fixing the error discussed in https://github.com/cms-sw/cmssw/pull/45540

#### PR validation:

Ran local checks using the following instructions:
```
scram p CMSSW_14_2_ASAN_X_2024-09-04-2300
cd CMSSW_14_2_ASAN_X_2024-09-04-2300
cmsenv
runTheMatrix.py -i all -l 25634.0 -t 4 --ibeos
```
#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport
