### PR TITLE
Update run3_data GT in autoCond from 140X_dataRun3_v4 to 140X_dataRun3_v9 [14_1_X]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -37,9 +37,9 @@ autoCond = {
     'run3_data_express'            :    '141X_dataRun3_Express_frozen_v2',
     # GlobalTag for Run3 data relvals (prompt GT) - 140X_dataRun3_Prompt_v3 (+ the the SecondaryDataset TriggerBits tag and the DeDxCalibrationRcd for HI) but snapshot at 2024_06_12 13:47:20 (UTC)
     'run3_data_prompt'             :    '141X_dataRun3_Prompt_frozen_v1',
-    # GlobalTag for Run3 offline data reprocessing - snapshot at 2024-02-07 16:38:59 (UTC)
-    'run3_data'                    :    '140X_dataRun3_v4',
-    # GlobalTag for Run3 offline data reprocessing with Prompt GT, currenlty for 2022FG - snapshot at 2024-02-12 12:00:00 (UTC)
+    # GlobalTag for Run3 offline data reprocessing - snapshot at 2024-09-04 16:25:09 (UTC)
+    'run3_data'                    :    '140X_dataRun3_v9',
+    # GlobalTag for Run3 offline data reprocessing with Prompt GT, currently for 2022FG - snapshot at 2024-02-12 12:00:00 (UTC)
     'run3_data_PromptAnalysis'     :    '140X_dataRun3_PromptAnalysis_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           :    '131X_mc2017_design_v3',


### PR DESCRIPTION
#### PR description:

This pull request upgrades the versioned GT for the dataRun3 in autoCond from 140X_dataRun3_v4 to [140X_dataRun3_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/140X_dataRun3_v9).

The updates included in the various intermediate GT versions are the following:

- 140X_dataRun3_v4 to 140X_dataRun3_v5, [diff](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_dataRun3_v4/140X_dataRun3_v5)
Preliminary GT for Run3 2022 and 2023 ReReco in 140X (See details for the call and updates in https://cms-talk.web.cern.ch/t/call-for-conditions-full-2022-2023-data-rereco-and-mc-production-in-140x/32887/24)

- 140X_dataRun3_v5 to 140X_dataRun3_v6, [diff](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_dataRun3_v5/140X_dataRun3_v6)
Updated GT with SiPixel and TkAl conditions for 2022-2023 ReReco in 140X (See details in https://cms-talk.web.cern.ch/t/call-for-conditions-full-2022-2023-data-rereco-and-mc-production-in-140x/32887/26)

- 140X_dataRun3_v6 to 140X_dataRun3_v7, [diff](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_dataRun3_v6/140X_dataRun3_v7)
Copy of 140X_dataRun3_v6 but with the snapshot time now accommodating the GEM alignment 2024 conditions appended in the offline GT as well (See https://cms-talk.web.cern.ch/t/gt-mc-data-update-of-2024-geomtery-conditions-and-gem-alignment-for-data-and-mc/36739/3)

- 140X_dataRun3_v7 to 140X_dataRun3_v8, [diff](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_dataRun3_v7/140X_dataRun3_v8)
Update the PPS geometry tag as of https://cms-talk.web.cern.ch/t/offline-new-pps-geometry-tag/45399 and the PPSDiamondTimingCalibration tag as of https://cms-talk.web.cern.ch/t/offline-new-ppsdiamondtimingcalibration-tag-added-to-140x-datarun3-queue-and-141x-datarun3-queue/46057

- 140X_dataRun3_v8 to 140X_dataRun3_v9, [diff](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_dataRun3_v8/140X_dataRun3_v9)
Add the updated beamspot for the 2022-23 re-reco, as requested in https://cms-talk.web.cern.ch/t/call-for-conditions-full-2022-2023-data-rereco-and-mc-production-in-140x/32887/31

It is intended that the updates integrated for the Run3 2022 and 2023 ReReco in 140X are not yet the final ones. But it is worth including the current status in autoCond nonetheless, so that it can be kept tested in the IBs.


#### PR validation:

Tested in master

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #45879
