### PR TITLE
[14_0_X] Tier0Handler: add maxTime, improve cert warning

### DIFF
--- a/CondCore/Utilities/scripts/conddb
+++ b/CondCore/Utilities/scripts/conddb
@@ -706,12 +706,13 @@ def _get_hlt_fcsr( session, timeType ):
 
 def _get_prompt_fcsr( session, timeType ):
     tier0timeout = 5
+    tier0maxtime = 60
     tier0retries = 3 
     tier0retryPeriod = 5
     tier0proxy = None
     try:
         t0DataSvc = Tier0Handler( tier0Url,
-                                  tier0timeout, tier0retries, tier0retryPeriod,
+                                  tier0timeout, tier0maxtime, tier0retries, tier0retryPeriod,
                                   tier0proxy, False )
         try:
             fcsr = t0DataSvc.getFirstSafeRun()


### PR DESCRIPTION
#### PR description:

Before this PR Tier0Handler was running a `curl` command using only the `--connect-timeout` flag which sets the timeout for connecting. If the connection is established but the server takes forever to respond, the command waits indefinitely. To avoid hung-up processes maxTime argument was added to `Tier0Handler` setting the `--max-time` flag. This flag sets the maximum time for the whole `curl` command.

`Tier0Handler` is used in the `conddb` command and the maxTime was set to 60 s, the connection timeout was left at 1 s.

Also, extends the warning information when the certificates are not provided with information about the `X509_USER_CERT` and  `X509_USER_KEY` env variables.

This is a follow-up to https://github.com/cms-sw/cmssw/pull/45779

#### PR validation:

Tested by running `python3 tier0.py` which is running the test for it and by running `conddb showFSCR` (for the latter `scram b` is needed beforehand).

The proper functionality of `--connect-timeout` and `--max-time` in `Tier0Handler` was tested by changing the T0 API URL using the `TIER0_API_URL` env variable to:
* `http://localhost:8099/` and running `nc -kl 8099` to test being able to connect but never receiving a response
* `https://example.com:81/` to test the connection timeout

#### Backport
Backport of https://github.com/cms-sw/cmssw/pull/45943 to 14_0_X
 
FYI @perrotta @francescobrivio @PonIlya 