### PR TITLE
[14_1_X] Backport of #45820: Change ScoutingNano event content

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/SimpleScoutingFlatTableProducerPlugins.cc
+++ b/PhysicsTools/NanoAOD/plugins/SimpleScoutingFlatTableProducerPlugins.cc
@@ -15,9 +15,13 @@ typedef SimpleFlatTableProducer<Run3ScoutingElectron> SimpleRun3ScoutingElectron
 #include "DataFormats/Scouting/interface/Run3ScoutingTrack.h"
 typedef SimpleFlatTableProducer<Run3ScoutingTrack> SimpleRun3ScoutingTrackFlatTableProducer;
 
+#include "DataFormats/Scouting/interface/Run3ScoutingPFJet.h"
+typedef SimpleFlatTableProducer<Run3ScoutingPFJet> SimpleRun3ScoutingPFJetFlatTableProducer;
+
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(SimpleRun3ScoutingVertexFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleRun3ScoutingPhotonFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleRun3ScoutingMuonFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleRun3ScoutingElectronFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleRun3ScoutingTrackFlatTableProducer);
+DEFINE_FWK_MODULE(SimpleRun3ScoutingPFJetFlatTableProducer);

--- a/PhysicsTools/NanoAOD/python/custom_run3scouting_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_run3scouting_cff.py
@@ -10,7 +10,6 @@ from PhysicsTools.PatAlgos.slimming.slimmedPatTrigger_cfi import slimmedPatTrigg
 
 # common tasks
 particleTask = cms.Task(scoutingPFCands)
-particleTableTask = cms.Task(particleScoutingTable)
 ak4JetTableTask = cms.Task(ak4ScoutingJets,ak4ScoutingJetParticleNetJetTagInfos,ak4ScoutingJetParticleNetJetTags,ak4ScoutingJetTable)
 ak8JetTableTask = cms.Task(ak8ScoutingJets,ak8ScoutingJetsSoftDrop,ak8ScoutingJetsSoftDropMass,ak8ScoutingJetEcfNbeta1,ak8ScoutingJetNjettiness,ak8ScoutingJetParticleNetJetTagInfos,ak8ScoutingJetParticleNetJetTags,ak8ScoutingJetParticleNetMassRegressionJetTags,ak8ScoutingJetTable)
 
@@ -25,7 +24,6 @@ run3_scouting_nanoAOD_post2023.toReplaceWith(muonScoutingTableTask, cms.Task(muo
 ## L1 decisions
 gtStage2DigisScouting = gtStage2Digis.clone(InputLabel="hltFEDSelectorL1")
 l1bitsScouting = l1bits.clone(src="gtStage2DigisScouting")
-patTriggerScouting = patTrigger.clone(l1tAlgBlkInputTag="gtStage2DigisScouting",l1tExtBlkInputTag="gtStage2DigisScouting")
 
 ## L1 objects
 from PhysicsTools.NanoAOD.l1trig_cff import *
@@ -42,22 +40,17 @@ l1JetScoutingTable.variables = cms.PSet(l1JetReducedVars)
 l1TauScoutingTable.variables = cms.PSet(l1TauReducedVars)
 l1EtSumScoutingTable.variables = cms.PSet(l1EtSumReducedVars)
 
-selectedPatTriggerScouting = selectedPatTrigger.clone(src="patTriggerScouting")
-slimmedPatTriggerScouting = slimmedPatTrigger.clone(src="selectedPatTriggerScouting")
-unpackedPatTriggerScouting = unpackedPatTrigger.clone(patTriggerObjectsStandAlone="slimmedPatTriggerScouting")
-triggerObjectTableScouting = triggerObjectTable.clone(src="unpackedPatTriggerScouting")
-
 triggerTask = cms.Task(
-    gtStage2DigisScouting, l1MuScoutingTable, l1EGScoutingTable, l1TauScoutingTable, l1JetScoutingTable, l1EtSumScoutingTable, 
-    unpackedPatTriggerScouting,triggerObjectTableScouting,l1bitsScouting
+    gtStage2DigisScouting, l1bitsScouting,
+    l1MuScoutingTable, l1EGScoutingTable, l1TauScoutingTable, l1JetScoutingTable, l1EtSumScoutingTable, 
 )
-triggerSequence = cms.Sequence(L1TRawToDigi+patTriggerScouting+selectedPatTriggerScouting+slimmedPatTriggerScouting+cms.Sequence(triggerTask))
+triggerSequence = cms.Sequence(L1TRawToDigi+cms.Sequence(triggerTask))
 
 # MC tasks
 genJetTask = cms.Task(ak4ScoutingJetMatchGen,ak4ScoutingJetExtTable,ak8ScoutingJetMatchGen,ak8ScoutingJetExtTable)
 puTask = cms.Task(puTable)
 
-nanoTableTaskCommon = cms.Task(photonScoutingTable,muonScoutingTableTask,electronScoutingTable,trackScoutingTable,primaryvertexScoutingTable,displacedvertexScoutingTableTask,rhoScoutingTable,metScoutingTable,particleTask,particleTableTask,ak4JetTableTask,ak8JetTableTask)
+nanoTableTaskCommon = cms.Task(photonScoutingTable,muonScoutingTableTask,electronScoutingTable,primaryvertexScoutingTable,displacedvertexScoutingTableTask,jetScoutingTable,rhoScoutingTable,metScoutingTable,particleTask,ak4JetTableTask,ak8JetTableTask)
 
 nanoSequenceCommon = cms.Sequence(triggerSequence,nanoTableTaskCommon)
 

--- a/PhysicsTools/NanoAOD/python/run3scouting_cff.py
+++ b/PhysicsTools/NanoAOD/python/run3scouting_cff.py
@@ -3,7 +3,7 @@ from  PhysicsTools.NanoAOD.common_cff import *
 from PhysicsTools.NanoAOD.simpleCandidateFlatTableProducer_cfi import simpleCandidateFlatTableProducer
 
 ################
-# Scouting photons, electrons, muons, tracks, primary vertices, displaced vertices, rho and MET
+# Scouting photons, electrons, muons, tracks, primary vertices, displaced vertices, jets (clustered at HLT), rho and MET
 
 photonScoutingTable = cms.EDProducer("SimpleRun3ScoutingPhotonFlatTableProducer",
      src = cms.InputTag("hltScoutingEgammaPacker"),
@@ -141,7 +141,7 @@ trackScoutingTable = cms.EDProducer("SimpleRun3ScoutingTrackFlatTableProducer",
          nValidStripHits = Var('tk_nValidStripHits', 'int', doc='number of valid strip hits'),
          nTrackerLayersWithMeasurement = Var('tk_nTrackerLayersWithMeasurement', 'int', doc='number of tracker layers with measurements'),
          qoverp = Var('tk_qoverp', 'float', precision=10, doc='qoverp'),
-         _lambda = Var('tk_lambda', 'float', precision=10, doc='lambda'),
+         lambda_ = Var('tk_lambda', 'float', precision=10, doc='lambda'),
          dxyError = Var('tk_dxy_Error', 'float', precision=10, doc='dxyError'),
          dzError = Var('tk_dz_Error', 'float', precision=10, doc='dzError'),
          qoverpError = Var('tk_qoverp_Error', 'float', precision=10, doc='qoverpError'),
@@ -206,6 +206,35 @@ displacedvertexScoutingTable = cms.EDProducer("SimpleRun3ScoutingVertexFlatTable
          ndof = Var('ndof', 'int', doc='number of degrees of freedom'),
          isValidVtx = Var('isValidVtx', 'bool', doc='is valid'),
      )
+)
+
+jetScoutingTable = cms.EDProducer("SimpleRun3ScoutingPFJetFlatTableProducer",
+    src = cms.InputTag("hltScoutingPFPacker"),
+    cut = cms.string(""),
+    name = cms.string("ScoutingPFJet"),
+    doc  = cms.string("PFJet scouting information"),
+    singleton = cms.bool(False),
+    extension = cms.bool(False),
+    variables = cms.PSet(
+        P3Vars,
+        m = Var('m', 'float', precision=10, doc='mass'),
+        jetArea = Var('jetArea', 'float', precision=10, doc='jet area'),
+        chargedHadronEnergy = Var('chargedHadronEnergy', 'float', precision=10, doc='charged hadron energy'),
+        neutralHadronEnergy = Var('neutralHadronEnergy', 'float', precision=10, doc='neutral hadron energy'),
+        photonEnergy = Var('photonEnergy', 'float', precision=10, doc='photon energy'),
+        electronEnergy = Var('electronEnergy', 'float', precision=10, doc='electron energy'),
+        muonEnergy = Var('muonEnergy', 'float', precision=10, doc='muon energy'),
+        HFHadronEnergy = Var('HFHadronEnergy', 'float', precision=10, doc='hadronic energy in HF'),
+        HFEMEnergy = Var('HFEMEnergy', 'float', precision=10, doc='electromagnetic energy in HF'),
+        chargedHadronMultiplicity = Var('chargedHadronMultiplicity', 'int', doc='number of charged hadrons in the jet'),
+        neutralHadronMultiplicity = Var('neutralHadronMultiplicity', 'int', doc='number of neutral hadrons in the jet'),
+        photonMultiplicity = Var('photonMultiplicity', 'int', doc='number of photons in the jet'),
+        electronMultiplicity = Var('electronMultiplicity', 'int', doc='number of electrons in the jet'),
+        muonMultiplicity = Var('muonMultiplicity', 'int', doc='number of muons in the jet'),
+        HFHadronMultiplicity = Var('HFHadronMultiplicity', 'int', doc='number of HF hadronic particles in the jet'),
+        HFEMMultiplicity = Var('HFEMMultiplicity', 'int', doc='number of HF electromagnetic particles in the jet'),
+        HOEnergy = Var('HOEnergy', 'float', precision=10, doc='hadronic energy in HO'),
+    )
 )
 
 rhoScoutingTable = cms.EDProducer("GlobalVariablesTableProducer",
@@ -334,9 +363,9 @@ ak4ScoutingJetParticleNetJetTags = cms.EDProducer("BoostedJetONNXJetTagsProducer
 
 ak4ScoutingJetTable = cms.EDProducer("SimplePFJetFlatTableProducer",
       src = cms.InputTag("ak4ScoutingJets"),
-      name = cms.string("ScoutingJet"),
+      name = cms.string("ScoutingCHSJetRecluster"),
       cut = cms.string(""),
-      doc = cms.string("ScoutingJet"),
+      doc = cms.string("ak4 jets from re-clustering scouting PF candidates with CHS applied"),
       singleton = cms.bool(False),
       extension = cms.bool(False), # this is the main table
       externalVariables = cms.PSet(
@@ -344,7 +373,7 @@ ak4ScoutingJetTable = cms.EDProducer("SimplePFJetFlatTableProducer",
          particleNet_prob_bb = ExtVar(cms.InputTag('ak4ScoutingJetParticleNetJetTags:probbb'), float, doc="ParticleNet probability of bb", precision=10),
          particleNet_prob_c = ExtVar(cms.InputTag('ak4ScoutingJetParticleNetJetTags:probc'), float, doc="ParticleNet probability of c", precision=10),
          particleNet_prob_cc = ExtVar(cms.InputTag('ak4ScoutingJetParticleNetJetTags:probcc'), float, doc="ParticleNet probability of cc", precision=10),
-         particlenet_prob_uds = ExtVar(cms.InputTag('ak4ScoutingJetParticleNetJetTags:probuds'), float, doc="particlenet probability of uds", precision=10),
+         particleNet_prob_uds = ExtVar(cms.InputTag('ak4ScoutingJetParticleNetJetTags:probuds'), float, doc="particlenet probability of uds", precision=10),
          particleNet_prob_g = ExtVar(cms.InputTag('ak4ScoutingJetParticleNetJetTags:probg'), float, doc="ParticleNet probability of g", precision=10),
          particleNet_prob_undef = ExtVar(cms.InputTag('ak4ScoutingJetParticleNetJetTags:probundef'), float, doc="ParticleNet probability of undef", precision=10),
       ),
@@ -374,7 +403,7 @@ ak4ScoutingJetMatchGen = cms.EDProducer("RecoJetToGenJetDeltaRValueMapProducer",
 
 ak4ScoutingJetExtTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
       src = cms.InputTag("ak4ScoutingJets"),
-      name = cms.string("ScoutingJet"),
+      name = cms.string("ScoutingCHSJetRecluster"),
       cut = cms.string(""),
       singleton = cms.bool(False),
       extension = cms.bool(True),
@@ -455,7 +484,7 @@ ak8ScoutingJetParticleNetJetTags = cms.EDProducer("BoostedJetONNXJetTagsProducer
       src = cms.InputTag("ak8ScoutingJetParticleNetJetTagInfos"),
       preprocess_json = cms.string("RecoBTag/Combined/data/Run3Scouting/ParticleNetAK8/General/V00/preprocess.json"),
       model_path = cms.FileInPath("RecoBTag/Combined/data/Run3Scouting/ParticleNetAK8/General/V00/particle-net.onnx"),
-      flav_names = cms.vstring(["probHbb", "probHcc","probHqq", "probQCDall"]),
+      flav_names = cms.vstring([ "probQCDall", "probHbb", "probHcc", "probHqq"]),
       debugMode = cms.untracked.bool(False),
   )
 
@@ -471,9 +500,9 @@ ak8ScoutingJetParticleNetMassRegressionJetTags = cms.EDProducer("BoostedJetONNXJ
 
 ak8ScoutingJetTable = cms.EDProducer("SimplePFJetFlatTableProducer",
       src = cms.InputTag("ak8ScoutingJets"),
-      name = cms.string("ScoutingFatJet"),
+      name = cms.string("ScoutingFatCHSJetRecluster"),
       cut = cms.string(""),
-      doc = cms.string("ScoutingFatJet"),
+      doc = cms.string("ak8 jets from re-clustering scouting PF candidates with CHS applied"),
       singleton = cms.bool(False),
       extension = cms.bool(False), # this is the main table
       externalVariables = cms.PSet(
@@ -486,10 +515,10 @@ ak8ScoutingJetTable = cms.EDProducer("SimplePFJetFlatTableProducer",
          tau3 = ExtVar(cms.InputTag('ak8ScoutingJetNjettiness:tau3'), float, doc="Nsubjettiness (3 axis)", precision=10),
          tau4 = ExtVar(cms.InputTag('ak8ScoutingJetNjettiness:tau4'), float, doc="Nsubjettiness (4 axis)", precision=10),
          particleNet_mass = ExtVar(cms.InputTag('ak8ScoutingJetParticleNetMassRegressionJetTags:mass'), float, doc="ParticleNet regressed mass", precision=10),
+         particleNet_prob_QCD = ExtVar(cms.InputTag('ak8ScoutingJetParticleNetJetTags:probQCDall'), float, doc="ParticleNet probability of QCD", precision=10),
          particleNet_prob_Hbb = ExtVar(cms.InputTag('ak8ScoutingJetParticleNetJetTags:probHbb'), float, doc="ParticleNet probability of Hbb", precision=10),
          particleNet_prob_Hcc = ExtVar(cms.InputTag('ak8ScoutingJetParticleNetJetTags:probHcc'), float, doc="ParticleNet probability of Hcc", precision=10),
          particleNet_prob_Hqq = ExtVar(cms.InputTag('ak8ScoutingJetParticleNetJetTags:probHqq'), float, doc="ParticleNet probability of Hqq", precision=10),
-         particleNet_prob_QCD = ExtVar(cms.InputTag('ak8ScoutingJetParticleNetJetTags:probQCDall'), float, doc="ParticleNet probability of QCD", precision=10),
       ),
       variables = cms.PSet(
          P4Vars,
@@ -517,7 +546,7 @@ ak8ScoutingJetMatchGen = cms.EDProducer("RecoJetToGenJetDeltaRValueMapProducer",
 
 ak8ScoutingJetExtTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
       src = cms.InputTag("ak8ScoutingJets"),
-      name = cms.string("ScoutingFatJet"),
+      name = cms.string("ScoutingFatCHSJetRecluster"),
       cut = cms.string(""),
       singleton = cms.bool(False),
       extension = cms.bool(True),

--- a/PhysicsTools/NanoAOD/python/run3scouting_cff.py
+++ b/PhysicsTools/NanoAOD/python/run3scouting_cff.py
@@ -363,9 +363,9 @@ ak4ScoutingJetParticleNetJetTags = cms.EDProducer("BoostedJetONNXJetTagsProducer
 
 ak4ScoutingJetTable = cms.EDProducer("SimplePFJetFlatTableProducer",
       src = cms.InputTag("ak4ScoutingJets"),
-      name = cms.string("ScoutingCHSJetRecluster"),
+      name = cms.string("ScoutingPFJetRecluster"),
       cut = cms.string(""),
-      doc = cms.string("ak4 jets from re-clustering scouting PF candidates with CHS applied"),
+      doc = cms.string("ak4 jets from re-clustering scouting PF candidates"),
       singleton = cms.bool(False),
       extension = cms.bool(False), # this is the main table
       externalVariables = cms.PSet(
@@ -403,7 +403,7 @@ ak4ScoutingJetMatchGen = cms.EDProducer("RecoJetToGenJetDeltaRValueMapProducer",
 
 ak4ScoutingJetExtTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
       src = cms.InputTag("ak4ScoutingJets"),
-      name = cms.string("ScoutingCHSJetRecluster"),
+      name = cms.string("ScoutingPFJetRecluster"),
       cut = cms.string(""),
       singleton = cms.bool(False),
       extension = cms.bool(True),
@@ -500,9 +500,9 @@ ak8ScoutingJetParticleNetMassRegressionJetTags = cms.EDProducer("BoostedJetONNXJ
 
 ak8ScoutingJetTable = cms.EDProducer("SimplePFJetFlatTableProducer",
       src = cms.InputTag("ak8ScoutingJets"),
-      name = cms.string("ScoutingFatCHSJetRecluster"),
+      name = cms.string("ScoutingFatPFJetRecluster"),
       cut = cms.string(""),
-      doc = cms.string("ak8 jets from re-clustering scouting PF candidates with CHS applied"),
+      doc = cms.string("ak8 jets from re-clustering scouting PF candidates"),
       singleton = cms.bool(False),
       extension = cms.bool(False), # this is the main table
       externalVariables = cms.PSet(
@@ -546,7 +546,7 @@ ak8ScoutingJetMatchGen = cms.EDProducer("RecoJetToGenJetDeltaRValueMapProducer",
 
 ak8ScoutingJetExtTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
       src = cms.InputTag("ak8ScoutingJets"),
-      name = cms.string("ScoutingFatCHSJetRecluster"),
+      name = cms.string("ScoutingFatPFJetRecluster"),
       cut = cms.string(""),
       singleton = cms.bool(False),
       extension = cms.bool(True),


### PR DESCRIPTION
#### PR description:

Backport of https://github.com/cms-sw/cmssw/pull/45820 from 14_2_X to allow tests for ScoutingNano central production at T0 with 14_1_X release. This backport is also intended to keep release consistent because backport of https://github.com/cms-sw/cmssw/pull/44970/, https://github.com/cms-sw/cmssw/pull/45820 to 14_0_X will follow for actual data-taking release, so we eventually have https://github.com/cms-sw/cmssw/pull/44970/, https://github.com/cms-sw/cmssw/pull/45820 in subsequent releases from 14_0_X.

Note: https://github.com/cms-sw/cmssw/pull/44970/ was originally merged to 14_1_X, so we don't need backport for that PR for 14_1_X.

The original PR changes ScoutingNano event content by dropping PF candidates, dropping tracks, adding PFJet clustered at HLT, removing tasks related to TrigObj table, and additional minor changes. The final event size is <2 kB/event for default ScoutingNano configuration, containing only scouting objects without offline objects and without gen info (MC).

#### PR validation:

Standard tests ```scram b runtests``` and ```runTheMatrix.py -l limited -i all --ibeos``` passed when validating https://github.com/cms-sw/cmssw/pull/45820.  ScoutingNano event size report comparison was done in [1]. Original PR tests confirm that these size reports and also observe event size reduced by ~85%.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is a backport of https://github.com/cms-sw/cmssw/pull/45820 to CMSSW 14_1_X release.

[1] https://indico.cern.ch/event/1441452/#preview:5119073
