### PR TITLE
fix `SiStripBadStrip_PayloadInspector` after merging of cms-sw/cmssw#45795

### DIFF
--- a/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
@@ -214,11 +214,8 @@ namespace {
       std::string titleMap =
           "Fraction of bad Strips per module, IOV: " + theIOVsince + " (tag:#color[2]{" + tagname + "})";
 
-      SiStripTkMaps myMap("COLZA0 L");
+      SiStripTkMaps myMap("COLZ0 AL");
       myMap.bookMap(titleMap, "Fraction of bad Strips per module");
-
-      SiStripTkMaps ghost("AL");
-      ghost.bookMap(titleMap, "");
 
       std::vector<uint32_t> detid;
       payload->getDetIds(detid);
@@ -249,7 +246,6 @@ namespace {
       std::string fileName(m_imageFileName);
       TCanvas canvas("Bad Components fraction", "bad components fraction");
       myMap.drawMap(canvas, "");
-      ghost.drawMap(canvas, "same");
       canvas.SaveAs(fileName.c_str());
 
       return true;


### PR DESCRIPTION
fixes https://github.com/cms-sw/cmssw/issues/45952

#### PR description:

Title says it all, after #45795 was merged (in particular commit https://github.com/cms-sw/cmssw/pull/45795/commits/68c2b44cbe7b4a28d40b5d8a1662119f41b4f140), it's not needed anymore to draw an empty "ghost" map as a background when some of the `SiStripTkMap` bins are empty.

#### PR validation:

`scram b runtests_testSiStripPayloadInspector` runs fine with this change.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A