### PR TITLE
Fix Alpaka Harvesting for Phase2

### DIFF
--- a/DQM/SiPixelHeterogeneous/python/SiPixelHeterogenousDQMHarvesting_cff.py
+++ b/DQM/SiPixelHeterogeneous/python/SiPixelHeterogenousDQMHarvesting_cff.py
@@ -23,6 +23,12 @@ siPixelHeterogeneousDQMComparisonHarvestingAlpaka = cms.Sequence(siPixelPhase1Ra
                                                                  siPixelPhase1RawDataHarvesterDevice *
                                                                  siPixelTrackComparisonHarvesterAlpaka )
 
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+_siPixelHeterogeneousDQMComparisonHarvestingAlpakaPhase2 = cms.Sequence(siPixelTrackComparisonHarvesterAlpaka )
+
+phase2_tracker.toReplaceWith(siPixelHeterogeneousDQMComparisonHarvestingAlpaka,_siPixelHeterogeneousDQMComparisonHarvestingAlpakaPhase2)
+
+
 # add the harvester in case of the validation modifier is active
 from Configuration.ProcessModifiers.gpuValidationPixel_cff import gpuValidationPixel
 gpuValidationPixel.toReplaceWith(siPixelHeterogeneousDQMHarvesting,siPixelHeterogeneousDQMComparisonHarvesting)


### PR DESCRIPTION
#### PR description:

In the [latest IBs we have a couple of failures for Phase2 `*.403` wfs](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc12/CMSSW_14_2_GPU_X_2024-09-08-2300/pyRelValMatrixLogs/run/29634.403_TTbar_14TeV+2026D110_Patatrack_PixelOnlyAlpaka_Validation/step4_TTbar_14TeV+2026D110_Patatrack_PixelOnlyAlpaka_Validation.log#/) due to the fact that the heterogenous harvesting step tries to run the RAW data harvester (serial and device). This PR proposes a small change to fix that.

#### PR validation:

`runTheMatrix.py -w upgrade -l 29634.403` runs