### PR TITLE
Update classes inheriting from ROOT::Minuit2::FCNBase to account for changes in ROOTmaster

### DIFF
--- a/OnlineDB/CSCCondDB/interface/CSCThrTurnOnFcn.h
+++ b/OnlineDB/CSCCondDB/interface/CSCThrTurnOnFcn.h
@@ -11,6 +11,10 @@
 
 #include "Minuit2/FCNBase.h"
 #include <vector>
+#include <RVersion.h>
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 33, 1)
+#include <span>
+#endif
 
 class CSCThrTurnOnFcn : public ROOT::Minuit2::FCNBase {
 private:
@@ -39,7 +43,11 @@ public:
   void setNorm(float n) { norm = n; };
 
   /// Provide the chi-squared function for the given data
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 33, 1)
+  double operator()(std::span<const double>) const override;
+#else
   double operator()(const std::vector<double>&) const override;
+#endif
 
   ///@@ What?
   double Up() const override { return 1.; }

--- a/OnlineDB/CSCCondDB/src/CSCFitAFEBThr.cc
+++ b/OnlineDB/CSCCondDB/src/CSCFitAFEBThr.cc
@@ -130,8 +130,12 @@ bool CSCFitAFEBThr::ThresholdNoise(const std::vector<float>& inputx,
   //                                               <<" "<<ery[i]<<std::endl;
 
   /// Fit  as 1D, <=500 iterations, edm=10**-5 (->0.1)
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 33, 1)
+  FunctionMinimum fmin =
+      theFitter->Minimize(*theOBJfun, std::span<double>(parinit), std::span<double>(erparinit), 1, 500, 0.1);
+#else
   FunctionMinimum fmin = theFitter->Minimize(*theOBJfun, parinit, erparinit, 1, 500, 0.1);
-
+#endif
   status = fmin.IsValid();
 
   if (status) {

--- a/OnlineDB/CSCCondDB/src/CSCThrTurnOnFcn.cc
+++ b/OnlineDB/CSCCondDB/src/CSCThrTurnOnFcn.cc
@@ -5,7 +5,11 @@
 #include <vector>
 #include "TMath.h"
 
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 33, 1)
+double CSCThrTurnOnFcn::operator()(std::span<const double> par) const {
+#else
 double CSCThrTurnOnFcn::operator()(const std::vector<double>& par) const {
+#endif
   double x, y, er, fn;
   double N = norm;
   double chi2 = 0.;

--- a/RecoVertex/BeamSpotProducer/interface/BSpdfsFcn.h
+++ b/RecoVertex/BeamSpotProducer/interface/BSpdfsFcn.h
@@ -18,6 +18,10 @@ ________________________________________________________________**/
 
 #include <iostream>
 #include <string>
+#include <RVersion.h>
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 32, 4)
+#include <span>
+#endif
 
 class BSpdfsFcn : public ROOT::Minuit2::FCNBase {
 public:
@@ -26,14 +30,25 @@ public:
   // define pdfs to use
   void SetPDFs(std::string usepdfs) { fusepdfs = usepdfs; }
 
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 33, 1)
+  double operator()(std::span<const double>) const override;
+#else
   double operator()(const std::vector<double>&) const override;
+#endif
   double Up() const override { return 1.; }
 
 private:
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 33, 1)
+  double PDFGauss_d(double z, double d, double sigmad, double phi, std::span<const double> parms) const;
+  double PDFGauss_d_resolution(double z, double d, double phi, double pt, std::span<const double> parms) const;
+
+  double PDFGauss_z(double z, double sigmaz, std::span<const double> parms) const;
+#else
   double PDFGauss_d(double z, double d, double sigmad, double phi, const std::vector<double>& parms) const;
   double PDFGauss_d_resolution(double z, double d, double phi, double pt, const std::vector<double>& parms) const;
 
   double PDFGauss_z(double z, double sigmaz, const std::vector<double>& parms) const;
+#endif
 
   std::string fusepdfs;
   std::vector<BSTrkParameters> fBSvector;

--- a/RecoVertex/BeamSpotProducer/interface/FcnBeamSpotFitPV.h
+++ b/RecoVertex/BeamSpotProducer/interface/FcnBeamSpotFitPV.h
@@ -18,6 +18,8 @@
 #include "Minuit2/FCNBase.h"
 
 #include <vector>
+#include <span>
+#include <RVersion.h>
 
 class FcnBeamSpotFitPV : public ROOT::Minuit2::FCNBase {
 public:
@@ -29,7 +31,11 @@ public:
   // deltaFcn for definition of the uncertainty
   double Up() const override { return errorDef_; }
   // -2lnL value based on vector of parameters
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 32, 4)
+  double operator()(std::span<const double>) const override;
+#else
   double operator()(const std::vector<double>&) const override;
+#endif
   // vertex count used for the fit (after selection)
   unsigned int nrOfVerticesUsed() const;
 

--- a/RecoVertex/BeamSpotProducer/src/BSpdfsFcn.cc
+++ b/RecoVertex/BeamSpotProducer/src/BSpdfsFcn.cc
@@ -15,9 +15,16 @@ ________________________________________________________________**/
 
 #include <cmath>
 #include <vector>
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 33, 1)
+#include <span>
+#endif
 
 //______________________________________________________________________
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 32, 4)
+double BSpdfsFcn::PDFGauss_d(double z, double d, double sigmad, double phi, std::span<const double> parms) const {
+#else
 double BSpdfsFcn::PDFGauss_d(double z, double d, double sigmad, double phi, const std::vector<double>& parms) const {
+#endif
   //---------------------------------------------------------------------------
   //  PDF for d0 distribution. This PDF is a simple gaussian in the
   //  beam reference frame.
@@ -35,8 +42,12 @@ double BSpdfsFcn::PDFGauss_d(double z, double d, double sigmad, double phi, cons
 }
 
 //______________________________________________________________________
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 32, 4)
+double BSpdfsFcn::PDFGauss_d_resolution(double z, double d, double phi, double pt, std::span<const double> parms) const {
+#else
 double BSpdfsFcn::PDFGauss_d_resolution(
     double z, double d, double phi, double pt, const std::vector<double>& parms) const {
+#endif
   //---------------------------------------------------------------------------
   //  PDF for d0 distribution. This PDF is a simple gaussian in the
   //  beam reference frame. The IP resolution is parametrize by a linear
@@ -57,7 +68,12 @@ double BSpdfsFcn::PDFGauss_d_resolution(
 }
 
 //______________________________________________________________________
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 32, 4)
+double BSpdfsFcn::PDFGauss_z(double z, double sigmaz, std::span<const double> parms) const {
+#else
 double BSpdfsFcn::PDFGauss_z(double z, double sigmaz, const std::vector<double>& parms) const {
+#endif
+
   //---------------------------------------------------------------------------
   //  PDF for z-vertex distribution. This distribution
   // is parametrized by a simple normalized gaussian distribution.
@@ -73,7 +89,11 @@ double BSpdfsFcn::PDFGauss_z(double z, double sigmaz, const std::vector<double>&
 }
 
 //______________________________________________________________________
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 32, 4)
+double BSpdfsFcn::operator()(const std::span<const double> params) const {
+#else
 double BSpdfsFcn::operator()(const std::vector<double>& params) const {
+#endif
   double f = 0.0;
 
   //std::cout << "fusepdfs=" << fusepdfs << " params.size="<<params.size() << std::endl;

--- a/RecoVertex/BeamSpotProducer/src/FcnBeamSpotFitPV.cc
+++ b/RecoVertex/BeamSpotProducer/src/FcnBeamSpotFitPV.cc
@@ -51,7 +51,11 @@ unsigned int FcnBeamSpotFitPV::nrOfVerticesUsed() const {
   return nVtx;
 }
 
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 33, 1)
+double FcnBeamSpotFitPV::operator()(std::span<const double> pars) const {
+#else
 double FcnBeamSpotFitPV::operator()(const std::vector<double>& pars) const {
+#endif
   //
   // fit parameters
   //


### PR DESCRIPTION
#### PR description:

ROOT::Minuit2::FCNBase  interface changed in https://github.com/root-project/root/commit/63636f6aeb39cfca7d99850b5b8f56802de563fa:

> **[Minuit2] Use std::span instead of std::vector const& for parameters**
> 
> Use `std::span` instead of `std::vector const&` for function parameters
> in Minuit2.
> 
> The motivation is that `std::span` is more general. If the function
> takes a `std::vector const&`, the inputs are forced to be allocated on
> the heap. So if one wants to call functions with constant size or even
> scalar input, that would cause a large overhead.
> 
> This overhead can be avoided when generalizing with `std::span`.
> 
> The standalone Minuit2 build files were also changed to consider the
> `std::span` backport to C++17 that is already in ROOT.
> 

This PR updates classes that inherit from it.

#### PR validation:

Bot tests. 
