### PR TITLE
protect `SiStripTkMaps` in case of empty inputs, also test for it in unit tests

### DIFF
--- a/DQM/TrackerRemapper/src/SiStripTkMaps.cc
+++ b/DQM/TrackerRemapper/src/SiStripTkMaps.cc
@@ -96,12 +96,14 @@ void SiStripTkMaps::drawMap(TCanvas& canvas, std::string option) {
   }
 
   // Adjust the color palette
-  double minValue = *std::min_element(m_values.begin(), m_values.end());
-  double maxValue = *std::max_element(m_values.begin(), m_values.end());
+  if (!m_values.empty()) {
+    double minValue = *std::min_element(m_values.begin(), m_values.end());
+    double maxValue = *std::max_element(m_values.begin(), m_values.end());
 
-  // Setting a palette that skips the color for the emptyBinValue
-  m_trackerMap->SetMinimum(minValue);  // Set min to the smallest valid value
-  m_trackerMap->SetMaximum(maxValue);  // Set max to the largest valid value
+    // Setting a palette that skips the color for the emptyBinValue
+    m_trackerMap->SetMinimum(minValue);  // Set min to the smallest valid value
+    m_trackerMap->SetMaximum(maxValue);  // Set max to the largest valid value
+  }
 
   canvas.cd();
   adjustCanvasMargins(canvas.cd(), tmargin_, bmargin_, lmargin_, rmargin_);
@@ -307,8 +309,8 @@ void SiStripTkMaps::readVertices(double& minx, double& maxx, double& miny, doubl
           }
           ++iy;
         }  // else
-      }    // else
-    }      // loop on entries
+      }  // else
+    }  // loop on entries
 
     if (isPixel) {
       continue;

--- a/DQM/TrackerRemapper/test/test_catch2_SiStripTkMaps.cc
+++ b/DQM/TrackerRemapper/test/test_catch2_SiStripTkMaps.cc
@@ -26,4 +26,13 @@ TEST_CASE("SiStripTkMaps testing", "[SiStripTkMaps]") {
     std::cout << "SiStripTkMaps filled " << filledIds.size() << " DetIds" << std::endl;
     REQUIRE(filledIds.size() == count);
   }
+  //_____________________________________________________________
+  SECTION("Check empty SiStripTkMaps") {
+    SiStripTkMaps theMap("COLZA L");
+    theMap.bookMap("testing SiStripTkMaps", "counts");
+    TCanvas c = TCanvas("c", "c");
+    theMap.drawMap(c, "");
+    c.SaveAs("SiStripsEmptyTkMaps.png");
+    REQUIRE(true);
+  }
 }


### PR DESCRIPTION
#### PR description:

https://github.com/cms-sw/cmssw/issues/45952 exposed a fragility in `SiStripTkMaps` when there is no actual input in it. The failing unit test was fixed via https://github.com/cms-sw/cmssw/pull/45954, but the possibility to generate a segmentation fault when not filling the map remains. This is fixed in this PR. 
To demonstrate the viability I add a section to the `catch2` unit tests for this use case.

#### PR validation:

`scram b runtests` runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A