### PR TITLE
Additional tracks filter for vertices (minimum no. strip hits)

### DIFF
--- a/RecoVertex/PrimaryVertexProducer/interface/TrackFilterForPVFinding.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/TrackFilterForPVFinding.h
@@ -26,7 +26,7 @@ public:
 private:
   float maxD0Sig_, minPt_, maxEta_;
   float maxD0Error_, maxDzError_;
-  int minSiLayers_, minPxLayers_;
+  int minSiLayers_, minPxLayers_, minStripHits_;
   float maxNormChi2_;
   reco::TrackBase::TrackQuality quality_;
 };

--- a/RecoVertex/PrimaryVertexProducer/src/TrackFilterForPVFinding.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/TrackFilterForPVFinding.cc
@@ -10,6 +10,7 @@ TrackFilterForPVFinding::TrackFilterForPVFinding(const edm::ParameterSet& conf) 
   maxNormChi2_ = conf.getParameter<double>("maxNormalizedChi2");
   minSiLayers_ = conf.getParameter<int>("minSiliconLayersWithHits");
   minPxLayers_ = conf.getParameter<int>("minPixelLayersWithHits");
+  minStripHits_ = conf.getParameter<int>("minValidStripHits");
 
   // the next few lines are taken from RecoBTag/SecondaryVertex/interface/TrackSelector.h"
   std::string qualityClass = conf.getParameter<std::string>("trackQuality");
@@ -33,8 +34,9 @@ bool TrackFilterForPVFinding::operator()(const reco::TransientTrack& tk) const {
   bool nPxLayCut = tk.hitPattern().pixelLayersWithMeasurement() >= minPxLayers_;
   bool nSiLayCut = tk.hitPattern().trackerLayersWithMeasurement() >= minSiLayers_;
   bool trackQualityCut = (quality_ == reco::TrackBase::undefQuality) || tk.track().quality(quality_);
+  bool nStripHitsCut = tk.hitPattern().numberOfValidStripHits() >= minStripHits_;
 
-  return IPSigCut && pTCut && etaCut && normChi2Cut && nPxLayCut && nSiLayCut && trackQualityCut;
+  return IPSigCut && pTCut && etaCut && normChi2Cut && nPxLayCut && nSiLayCut && trackQualityCut && nStripHitsCut;
 }
 
 // select the vector of tracks that pass the filter cuts
@@ -72,4 +74,5 @@ void TrackFilterForPVFinding::fillPSetDescription(edm::ParameterSetDescription& 
   desc.add<std::string>("trackQuality", "any");
   desc.add<int>("minPixelLayersWithHits", 2);
   desc.add<int>("minSiliconLayersWithHits", 5);
+  desc.add<int>("minValidStripHits", 0);
 }


### PR DESCRIPTION
#### PR description:

This PR is for adding the cut in minimum valid strip hits for filtering tracks in PV fits. 
Application for phase2 HLT PUPPI performance with trimmed tracks. (tagging HLT Upgrade conveners: @rovere @VourMa )

#### PR validation:

Compiles and runs with unit tests `scram b runtests`.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

will need backport for `CMSSW_14_1_X` for HLT phase2 menu development.
