### PR TITLE
o2oRun_SiStripDCS email warning fix

### DIFF
--- a/CondTools/SiStrip/scripts/o2oRun_SiStripDCS.py
+++ b/CondTools/SiStrip/scripts/o2oRun_SiStripDCS.py
@@ -56,7 +56,7 @@ def summary(args, is_ok, logfile):
     debugLabel = '[TEST] ' if args.debug else ''
     with open(logfile, 'rb') as log:
         helper.send_mail(subject='%sDCS O2O Failure: %s' % (debugLabel, args.jobname),
-                 message=log.read(),
+                 message=str(log.read()),
                  send_to=args.mail_log_to,
                  send_from=args.mail_from)
 


### PR DESCRIPTION
#### PR description:

This fixes an error encountered when testing moving `SiStripDetVOff_prompt` O2O from CMSSW_11_0_1 to 14_0_15_patch1. A copy of `SiStripDetVOff_prompt` - `SiStripDetVOff_prompt_test` was run for the tests and when it was failing it was trying to send a warning email which caused an exception. The exception's cause is providing a `bytes` object where `str` was expected.

#### PR validation:

Tested by running `SiStripDetVOff_prompt_test` on CMSSW_14_0_15_patch1 with local changes (this PR's fix). The O2O was failing when testing providing the certificate for T0 API access (see https://github.com/cms-sw/cmssw/pull/45779) - setting TIER0_API_URL=https://cmsweb-preprod.cern.ch/t0wmadatasvc/prod/ (which requires the cert) but not setting X509_USER_CERT. An O2O failure in this test scenario is expected (no cert provided) but it shouldn't cause an error with the email warning and this PR fixes the email error.

The error was:
```
[ERROR] O2OJob SiStripDetVOff_prompt_test FAILED!
Traceback (most recent call last):
  File "/cvmfs/cms.cern.ch/slc7_amd64_gcc12/cms/cmssw/CMSSW_14_0_15/bin/slc7_amd64_gcc12/o2oRun_SiStripDCS.py", line 104, in <module>
    sys.exit(main())
  File "/cvmfs/cms.cern.ch/slc7_amd64_gcc12/cms/cmssw/CMSSW_14_0_15/bin/slc7_amd64_gcc12/o2oRun_SiStripDCS.py", line 93, in main
    summary(args, is_ok, logfile)
  File "/cvmfs/cms.cern.ch/slc7_amd64_gcc12/cms/cmssw/CMSSW_14_0_15/bin/slc7_amd64_gcc12/o2oRun_SiStripDCS.py", line 58, in summary
    helper.send_mail(subject='%sDCS O2O Failure: %s' % (debugLabel, args.jobname),
  File "/cvmfs/cms.cern.ch/slc7_amd64_gcc12/cms/cmssw-patch/CMSSW_14_0_15_patch1/src/CondTools/SiStrip/python/o2o_helper.py", line 137, in send_mail
    msg.attach(MIMEText(message))
  File "/cvmfs/cms.cern.ch/slc7_amd64_gcc12/external/python3/3.9.14-4612d00f9f0430a19291545f1e47b4a4/lib/python3.9/email/mime/text.py", line 34, in __init__
    _text.encode('us-ascii')
AttributeError: 'bytes' object has no attribute 'encode'
```

After the fix the expected certificate-related failure was:
```
WARNING: No certificate provided for Tier0 access\n[2024-09-11 14:57:50,316] ERROR: ValueError for firstConditionSafeRun from Tier-0 Expecting value: line 1 column 1 (char 0) \n[2024-09-11 14:57:50,319] ERROR: Changes rolled back.\n[2024-09-11 14:57:50,319] ERROR: Error setting up Tier-0 data service: Invalid firstConditionSafeRun from Tier-0\n'
[2024-09-11 14:57:50,385] INFO: @@@Upload return code = -1@@@
Traceback (most recent call last):
  File "/data/O2O/cmssw/CMSSW_14_0_15_patch1/bin/slc7_amd64_gcc12/SiStripDCSPopCon.py", line 113, in <module>
    main()
  File "/data/O2O/cmssw/CMSSW_14_0_15_patch1/bin/slc7_amd64_gcc12/SiStripDCSPopCon.py", line 106, in main
    runjob(args)
  File "/data/O2O/cmssw/CMSSW_14_0_15_patch1/bin/slc7_amd64_gcc12/SiStripDCSPopCon.py", line 58, in runjob
    f(dbFile=output_db, inputTag=args.inputTag, destTags=args.destTags, destDb=args.destDb, since=None,
  File "/data/O2O/cmssw/CMSSW_14_0_15_patch1/src/CondTools/SiStrip/python/o2o_helper.py", line 128, in copy_payload
    raise RuntimeError('Upload FAILED!')
RuntimeError: Upload FAILED!
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

We need backports to 14_0_X and 14_1_X
PRs:
https://github.com/cms-sw/cmssw/pull/45978
https://github.com/cms-sw/cmssw/pull/45979
 
FYI @p-masterson @perrotta @PonIlya 