### PR TITLE
[14_1_X] o2oRun_SiStripDCS email warning fix

### DIFF
--- a/CondTools/SiStrip/scripts/o2oRun_SiStripDCS.py
+++ b/CondTools/SiStrip/scripts/o2oRun_SiStripDCS.py
@@ -56,7 +56,7 @@ def summary(args, is_ok, logfile):
     debugLabel = '[TEST] ' if args.debug else ''
     with open(logfile, 'rb') as log:
         helper.send_mail(subject='%sDCS O2O Failure: %s' % (debugLabel, args.jobname),
-                 message=log.read(),
+                 message=str(log.read()),
                  send_to=args.mail_log_to,
                  send_from=args.mail_from)
 


### PR DESCRIPTION
#### PR description:

Backport of https://github.com/cms-sw/cmssw/pull/45977

This fixes an error encountered when testing moving `SiStripDetVOff_prompt` O2O from CMSSW_11_0_1 to 14_0_15_patch1. A copy of `SiStripDetVOff_prompt` - `SiStripDetVOff_prompt_test` was run for the tests and when it was failing it was trying to send a warning email which caused an exception. The exception's cause is providing a `bytes` object where `str` was expected.

#### PR validation:

Tested by running `SiStripDetVOff_prompt_test` on CMSSW_14_0_15_patch1 with local changes (this PR's fix). The O2O was failing when testing providing the certificate for T0 API access (see https://github.com/cms-sw/cmssw/pull/45779) - setting TIER0_API_URL=https://cmsweb-preprod.cern.ch/t0wmadatasvc/prod/ (which requires the cert) but not setting X509_USER_CERT. An O2O failure in this test scenario is expected (no cert provided) but it shouldn't cause an error with the email warning and this PR fixes the email error.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of https://github.com/cms-sw/cmssw/pull/45977
 
FYI @p-masterson @perrotta @PonIlya 