### PR TITLE
Replace CUDA with Alpaka wf in `relval_2026.py`

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_2026.py
+++ b/Configuration/PyReleaseValidation/python/relval_2026.py
@@ -42,8 +42,7 @@ numWFIB.extend([prefixDet+34.911]) #DD4hep XML
 numWFIB.extend([prefixDet+34.702]) #mkFit tracking (initialStep)
 numWFIB.extend([prefixDet+34.5])   #pixelTrackingOnly
 numWFIB.extend([prefixDet+34.9])   #vector hits
-numWFIB.extend([prefixDet+34.501]) #Patatrack local reconstruction on CPU
-numWFIB.extend([prefixDet+34.502]) #Patatrack local reconstruction on GPU
+numWFIB.extend([prefixDet+34.402]) #Alpaka local reconstruction offloaded on device (GPU if available)
 numWFIB.extend([prefixDet+34.21])  #prodlike
 numWFIB.extend([prefixDet+96.0])   #CloseByPGun CE_E_Front_120um
 numWFIB.extend([prefixDet+100.0])  #CloseByPGun CE_H_Coarse_Scint


### PR DESCRIPTION
#### PR description:

This PR proposes to replace the `*.501` and `*.502` wfs with the `*.402` one in Alpaka for Phase2. This would also definitely solve https://github.com/cms-sw/cmssw/issues/45332#issuecomment-2344144773 removing the (deprecated) CUDA wfs.
