### PR TITLE
Add 2024 HI eras to reco processing configuation

### DIFF
--- a/Configuration/DataProcessing/python/Impl/ppEra_Run3_2024_UPC.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run3_2024_UPC.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""
+_ppEra_Run3_2024_UPC_
+Scenario supporting UPC collisions for 2024
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Era_Run3_2024_UPC_cff import Run3_2024_UPC
+
+from Configuration.DataProcessing.Impl.pp import pp
+
+class ppEra_Run3_2024_UPC(pp):
+    def __init__(self):
+        pp.__init__(self)
+        self.recoSeq=''
+        self.cbSc='pp'
+        self.eras=Run3_2024_UPC
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_2024_UPC' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_2024_UPC' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_2024_UPC' ]
+    """
+    _ppEra_Run3_2024_UPC_
+    Implement configuration building for data processing for proton
+    collision data taking for Run3_2024
+    """

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run3_2024_ppRef.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run3_2024_ppRef.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""
+_ppEra_Run3_2024_ppRef_
+Scenario supporting ppRef collisions for 2024
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Era_Run3_2024_ppRef_cff import Run3_2024_ppRef
+
+from Configuration.DataProcessing.Impl.pp import pp
+
+class ppEra_Run3_2024_ppRef(pp):
+    def __init__(self):
+        pp.__init__(self)
+        self.recoSeq=''
+        self.cbSc='pp'
+        self.eras=Run3_2024_ppRef
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_2024_ppRef' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_2024_ppRef' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_2024_ppRef' ]
+    """
+    _ppEra_Run3_2024_ppRef_
+    Implement configuration building for data processing for proton
+    collision data taking for Run3_2024
+    """

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run3_pp_on_PbPb_2024.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run3_pp_on_PbPb_2024.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""
+_ppEra_Run3_pp_on_PbPb_2024_
+
+Scenario supporting heavy ions collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Era_Run3_pp_on_PbPb_2024_cff import Run3_pp_on_PbPb_2024
+
+from Configuration.DataProcessing.Impl.pp import pp
+
+class ppEra_Run3_pp_on_PbPb_2024(pp):
+    def __init__(self):
+        pp.__init__(self)
+        self.recoSeq=''
+        self.cbSc='pp'
+        self.isRepacked=True
+        self.eras=Run3_pp_on_PbPb_2024
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb_2024' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb_2024' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb_2024' ]
+    """
+    _ppEra_Run3_pp_on_PbPb_2024_
+
+    Implement configuration building for data processing for pp-like processing of HI
+    collision data taking for Run3
+
+    """

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2024.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2024.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""
+_ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2024_
+
+Scenario supporting heavy ions collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+from Configuration.Eras.Era_Run3_pp_on_PbPb_approxSiStripClusters_2024_cff import Run3_pp_on_PbPb_approxSiStripClusters_2024
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.DataProcessing.Impl.pp import pp
+
+class ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2024(pp):
+    def __init__(self):
+        pp.__init__(self)
+        self.recoSeq=''
+        self.cbSc='pp'
+        self.isRepacked=True
+        self.eras=Run3_pp_on_PbPb_approxSiStripClusters_2024
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb_approxSiStripClusters_2024' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb_approxSiStripClusters_2024' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb_approxSiStripClusters_2024' ]
+
+    """
+    _ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2024_
+
+    Implement configuration building for data processing for pp-like processing of HI
+    collision data taking for Run3 with approxSiStripClusters (rawprime format)
+
+    """

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -126,6 +126,18 @@ def customisePostEra_Run3_pp_on_PbPb_approxSiStripClusters_2023(process):
     customisePostEra_Run3_pp_on_PbPb_2023(process)
     return process
 
+def customisePostEra_Run3_pp_on_PbPb_2024(process):
+    customisePostEra_Run3_2024(process)
+    return process
+
+def customisePostEra_Run3_pp_on_PbPb_approxSiStripClusters_2024(process):
+    customisePostEra_Run3_pp_on_PbPb_2024(process)
+    return process
+
+def customisePostEra_Run3_2024_UPC(process):
+    customisePostEra_Run3_2024(process)
+    return process
+
 ##############################################################################
 def customisePPData(process):
     #deprecated process= customiseCommon(process)

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -138,6 +138,10 @@ def customisePostEra_Run3_2024_UPC(process):
     customisePostEra_Run3_2024(process)
     return process
 
+def customisePostEra_Run3_2024_ppRef(process):
+    customisePostEra_Run3_2024(process)
+    return process
+
 ##############################################################################
 def customisePPData(process):
     #deprecated process= customiseCommon(process)

--- a/Configuration/DataProcessing/test/run_CfgTest_5.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest_5.sh
@@ -10,7 +10,7 @@ function die { echo $1: status $2 ;  exit $2; }
 
 function runTest { echo $1 ; python3 $1 || die "Failure for configuration: $1" $?; }
 
-declare -a arr=("AlCaLumiPixels" "AlCaTestEnable" "cosmicsEra_Run2_2018" "hcalnzsEra_Run2_2018" "ppEra_Run2_2018" "hcalnzsEra_Run2_2018_highBetaStar" "hcalnzsEra_Run2_2018_pp_on_AA" "ppEra_Run2_2018_highBetaStar" "ppEra_Run2_2018_pp_on_AA" "cosmicsHybridEra_Run2_2018" "cosmicsEra_Run3" "hcalnzsEra_Run3" "ppEra_Run3" "AlCaLumiPixels_Run3" "AlCaPhiSymEcal_Nano" "AlCaPPS_Run3" "ppEra_Run3_pp_on_PbPb" "hcalnzsEra_Run3_pp_on_PbPb" "ppEra_Run3_pp_on_PbPb_approxSiStripClusters" "ppEra_Run3_2023" "ppEra_Run3_pp_on_PbPb_2023" "ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2023" "ppEra_Run3_2024")
+declare -a arr=("AlCaLumiPixels" "AlCaTestEnable" "cosmicsEra_Run2_2018" "hcalnzsEra_Run2_2018" "ppEra_Run2_2018" "hcalnzsEra_Run2_2018_highBetaStar" "hcalnzsEra_Run2_2018_pp_on_AA" "ppEra_Run2_2018_highBetaStar" "ppEra_Run2_2018_pp_on_AA" "cosmicsHybridEra_Run2_2018" "cosmicsEra_Run3" "hcalnzsEra_Run3" "ppEra_Run3" "AlCaLumiPixels_Run3" "AlCaPhiSymEcal_Nano" "AlCaPPS_Run3" "ppEra_Run3_pp_on_PbPb" "hcalnzsEra_Run3_pp_on_PbPb" "ppEra_Run3_pp_on_PbPb_approxSiStripClusters" "ppEra_Run3_2023" "ppEra_Run3_pp_on_PbPb_2023" "ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2023" "ppEra_Run3_2024" "ppEra_Run3_pp_on_PbPb_2024" "ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2024" "ppEra_Run3_2024_UPC")
 for scenario in "${arr[@]}"
 do
      runTest "${SCRAM_TEST_PATH}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"

--- a/Configuration/DataProcessing/test/run_CfgTest_5.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest_5.sh
@@ -10,7 +10,7 @@ function die { echo $1: status $2 ;  exit $2; }
 
 function runTest { echo $1 ; python3 $1 || die "Failure for configuration: $1" $?; }
 
-declare -a arr=("AlCaLumiPixels" "AlCaTestEnable" "cosmicsEra_Run2_2018" "hcalnzsEra_Run2_2018" "ppEra_Run2_2018" "hcalnzsEra_Run2_2018_highBetaStar" "hcalnzsEra_Run2_2018_pp_on_AA" "ppEra_Run2_2018_highBetaStar" "ppEra_Run2_2018_pp_on_AA" "cosmicsHybridEra_Run2_2018" "cosmicsEra_Run3" "hcalnzsEra_Run3" "ppEra_Run3" "AlCaLumiPixels_Run3" "AlCaPhiSymEcal_Nano" "AlCaPPS_Run3" "ppEra_Run3_pp_on_PbPb" "hcalnzsEra_Run3_pp_on_PbPb" "ppEra_Run3_pp_on_PbPb_approxSiStripClusters" "ppEra_Run3_2023" "ppEra_Run3_pp_on_PbPb_2023" "ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2023" "ppEra_Run3_2024" "ppEra_Run3_pp_on_PbPb_2024" "ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2024" "ppEra_Run3_2024_UPC")
+declare -a arr=("AlCaLumiPixels" "AlCaTestEnable" "cosmicsEra_Run2_2018" "hcalnzsEra_Run2_2018" "ppEra_Run2_2018" "hcalnzsEra_Run2_2018_highBetaStar" "hcalnzsEra_Run2_2018_pp_on_AA" "ppEra_Run2_2018_highBetaStar" "ppEra_Run2_2018_pp_on_AA" "cosmicsHybridEra_Run2_2018" "cosmicsEra_Run3" "hcalnzsEra_Run3" "ppEra_Run3" "AlCaLumiPixels_Run3" "AlCaPhiSymEcal_Nano" "AlCaPPS_Run3" "ppEra_Run3_pp_on_PbPb" "hcalnzsEra_Run3_pp_on_PbPb" "ppEra_Run3_pp_on_PbPb_approxSiStripClusters" "ppEra_Run3_2023" "ppEra_Run3_pp_on_PbPb_2023" "ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2023" "ppEra_Run3_2024" "ppEra_Run3_pp_on_PbPb_2024" "ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2024" "ppEra_Run3_2024_UPC" "ppEra_Run3_2024_ppRef")
 for scenario in "${arr[@]}"
 do
      runTest "${SCRAM_TEST_PATH}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"


### PR DESCRIPTION
#### PR description:

New HI eras for this year's data taking run have to be included in Prompt reco configs run at the T0

#### PR validation:

compiles

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

will have to be backported to 14_0_X
