### PR TITLE
Adding subGenJets to NanoGEN

### DIFF
--- a/PhysicsTools/NanoAOD/python/nanogen_cff.py
+++ b/PhysicsTools/NanoAOD/python/nanogen_cff.py
@@ -15,6 +15,8 @@ nanoMetadata = cms.EDProducer("UniqueStringProducer",
     )
 )
 
+
+
 nanogenSequence = cms.Sequence(
     nanoMetadata+
     cms.Sequence(particleLevelTask)+
@@ -22,6 +24,7 @@ nanogenSequence = cms.Sequence(
     patJetPartonsNano+
     genJetFlavourAssociation+
     genJetFlavourTable+
+    genSubJetAK8Table+
     genJetAK8Table+
     genJetAK8FlavourAssociation+
     genJetAK8FlavourTable+
@@ -108,7 +111,12 @@ def customizeNanoGEN(process):
     process.genJetAK8Table.src = "ak8GenJetsNoNu"
     process.tauGenJetsForNano.GenParticles = "genParticles"
     process.genVisTaus.srcGenParticles = "genParticles"
-
+    process.load("RecoJets.JetProducers.ak8GenJets_cfi")
+    process.ak8GenJetsNoNuConstituents =  process.ak8GenJetsConstituents.clone(src='ak8GenJetsNoNu')
+    process.ak8GenJetsNoNuSoftDrop = process.ak8GenJetsSoftDrop.clone(src=cms.InputTag('ak8GenJetsNoNuConstituents', 'constituents'))
+    process.genSubJetAK8Table.src = "ak8GenJetsNoNuSoftDrop"
+    process.nanogenSequence.insert(0, process.ak8GenJetsNoNuSoftDrop)
+    process.nanogenSequence.insert(0, process.ak8GenJetsNoNuConstituents)
     # In case customizeNanoGENFromMini has already been called
     process.nanogenSequence.remove(process.mergedGenParticles)
     process.nanogenSequence.remove(process.genIso)


### PR DESCRIPTION
#### PR description:

This PR adds the SubGenJets to NANOGEN.

#### PR validation:

Tested on 13_X and produces the expected collections

SubGenJetAK8_pt 7.87129 1.35149
SubGenJetAK8_eta 7.89604 1.2970
SubGenJetAK8_phi 7.89604 1.2970
SubGenJetAK8_mass 7.92079 1.242
nSubGenJetAK8 7.33168 0.925743



