### PR TITLE
possibility of configuring the OMTF emulator directly from XMLs (14_0_X)

### DIFF
--- a/L1Trigger/L1TMuonOverlapPhase1/interface/Omtf/OMTFReconstruction.h
+++ b/L1Trigger/L1TMuonOverlapPhase1/interface/Omtf/OMTFReconstruction.h
@@ -67,6 +67,8 @@ protected:
   int bxMin, bxMax;
 
   ///OMTF objects
+  //omtfParams are created only if they are read from the xml file in beginRun(). If the params goes from eventSetup, omtfParams are null
+  unique_ptr<L1TMuonOverlapParams> omtfParams;
   unique_ptr<OMTFConfiguration> omtfConfig;
 
   unique_ptr<OMTFinputMaker> inputMaker;

--- a/L1Trigger/L1TMuonOverlapPhase1/src/Omtf/OMTFProcessor.cc
+++ b/L1Trigger/L1TMuonOverlapPhase1/src/Omtf/OMTFProcessor.cc
@@ -95,7 +95,6 @@ void OMTFProcessor<GoldenPatternType>::init(const edm::ParameterSet& edmCfg, edm
 
   edm::LogVerbatim("OMTFReconstruction") << "useFloatingPointExtrapolation " << useFloatingPointExtrapolation
                                          << std::endl;
-  edm::LogVerbatim("OMTFReconstruction") << "extrapolFactorsFilename " << extrapolFactorsFilename << std::endl;
 }
 
 template <class GoldenPatternType>
@@ -294,7 +293,6 @@ std::vector<l1t::RegionalMuonCand> OMTFProcessor<GoldenPatternType>::getFinalcan
     //check if it matters if it needs to be here as well
     trackAddr[1] = myCand->getRefLayer();
     trackAddr[2] = myCand->getDisc();
-    trackAddr[3] = myCand->getGpResultUnconstr().getPdfSumUnconstr();
     if (candidate.hwPt() > 0 || candidate.hwPtUnconstrained() > 0) {
       candidate.setTrackAddress(trackAddr);
       candidate.setTFIdentifiers(iProcessor, mtfType);
@@ -909,8 +907,8 @@ void OMTFProcessor<GoldenPatternType>::loadExtrapolFactors(const std::string& fi
       int iLayer = lutNode.second.get<int>("<xmlattr>.Layer");
       std::string keyType = lutNode.second.get<std::string>("<xmlattr>.KeyType");
 
-      edm::LogVerbatim("OMTFReconstruction")
-          << "iRefLayer " << iRefLayer << " iLayer " << iLayer << " keyType " << keyType << std::endl;
+      LogTrace("OMTFReconstruction") << "iRefLayer " << iRefLayer << " iLayer " << iLayer << " keyType " << keyType
+                                     << std::endl;
 
       auto& valueNodes = lutNode.second;
       for (boost::property_tree::ptree::value_type& valueNode : valueNodes) {
@@ -918,7 +916,7 @@ void OMTFProcessor<GoldenPatternType>::loadExtrapolFactors(const std::string& fi
           int key = valueNode.second.get<int>("<xmlattr>.key");
           float value = valueNode.second.get<float>("<xmlattr>.value");
           extrapolFactors.at(iRefLayer).at(iLayer)[key] = value;
-          edm::LogVerbatim("OMTFReconstruction") << "key " << key << " value " << value << std::endl;
+          LogTrace("OMTFReconstruction") << "key " << key << " value " << value << std::endl;
         }
       }
     }

--- a/L1Trigger/L1TMuonOverlapPhase1/src/Omtf/OMTFReconstruction.cc
+++ b/L1Trigger/L1TMuonOverlapPhase1/src/Omtf/OMTFReconstruction.cc
@@ -64,8 +64,6 @@ void OMTFReconstruction::beginRun(edm::Run const& run,
                                   const MuonGeometryTokens& muonGeometryTokens,
                                   const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord>& magneticFieldEsToken,
                                   const edm::ESGetToken<Propagator, TrackingComponentsRecord>& propagatorEsToken) {
-  const L1TMuonOverlapParams* omtfParams = nullptr;
-
   std::string processorType = "OMTFProcessor";  //GoldenPatternWithStat GoldenPattern
   if (edmParameterSet.exists("processorType")) {
     processorType = edmParameterSet.getParameter<std::string>("processorType");
@@ -73,22 +71,29 @@ void OMTFReconstruction::beginRun(edm::Run const& run,
 
   bool buildPatternsFromXml = (edmParameterSet.exists("patternsXMLFile") || edmParameterSet.exists("patternsXMLFiles"));
 
+  bool readConfigFromXml = edmParameterSet.exists("configXMLFile");
+
+  if (buildPatternsFromXml != readConfigFromXml)
+    throw cms::Exception(
+        "OMTFReconstruction::beginRun: buildPatternsFromXml != readConfigFromXml -  both patternsXMLFiles and "
+        "configXMLFile should be defined (or not) for the simOmtDigis or simOmtfPhase2Digis");
+
   edm::LogVerbatim("OMTFReconstruction") << "OMTFReconstruction::beginRun " << run.id()
                                          << " buildPatternsFromXml: " << buildPatternsFromXml << std::endl;
 
   //if the buildPatternsFromXml == false - we are making the omtfConfig and omtfProc for every run,
   //as the configuration my change between the runs,
-  //if buildPatternsFromXml == true - we assume the the entire configuration comes from phyton,
-  //so we do it only for the first run
-  if (omtfProc == nullptr || buildPatternsFromXml == false) {
+  if (buildPatternsFromXml == false) {
     if (omtfParamsRecordWatcher.check(eventSetup)) {
       edm::LogVerbatim("OMTFReconstruction") << "retrieving omtfParams from EventSetup" << std::endl;
 
-      omtfParams = &(eventSetup.getData(omtfParamsEsToken));
-      if (!omtfParams) {
-        edm::LogError("OMTFReconstruction") << "Could not retrieve parameters from Event Setup" << std::endl;
+      const L1TMuonOverlapParams* omtfParamsFromES = &(eventSetup.getData(omtfParamsEsToken));
+      if (!omtfParamsFromES) {
+        edm::LogError("OMTFReconstruction") << "Could not retrieve omtfParams from Event Setup" << std::endl;
+        throw cms::Exception("OMTFReconstruction::beginRun: Could not retrieve omtfParams from Event Setup");
       }
-      omtfConfig->configure(omtfParams);
+
+      omtfConfig->configure(omtfParamsFromES);
 
       //the parameters can be overwritten from the python config
       omtfConfig->configureFromEdmParameterSet(edmParameterSet);
@@ -96,19 +101,45 @@ void OMTFReconstruction::beginRun(edm::Run const& run,
       inputMaker->initialize(edmParameterSet, eventSetup, muonGeometryTokens);
 
       //patterns from the edm::EventSetup are reloaded every beginRun
-      if (buildPatternsFromXml == false) {
-        edm::LogVerbatim("OMTFReconstruction") << "getting patterns from EventSetup" << std::endl;
-        if (processorType == "OMTFProcessor") {
-          omtfProc = std::make_unique<OMTFProcessor<GoldenPattern> >(
-              omtfConfig.get(), edmParameterSet, eventSetup, omtfParams);
-          omtfProc->printInfo();
-        }
+      //therefore OMTFProcessor is re-created here
+      edm::LogVerbatim("OMTFReconstruction") << "getting patterns from EventSetup" << std::endl;
+      if (processorType == "OMTFProcessor") {
+        omtfProc = std::make_unique<OMTFProcessor<GoldenPattern> >(
+            omtfConfig.get(), edmParameterSet, eventSetup, omtfParamsFromES);
+        omtfProc->printInfo();
       }
     }
   }
 
-  //if we read the patterns directly from the xml, we do it only once, at the beginning of the first run, not every run
+  //if buildPatternsFromXml == true - the entire configuration (patterns and hwToLogicLayer) comes from phyton,
+  //so we read it only once, at the beginning of the first run, not every run
   if (omtfProc == nullptr && buildPatternsFromXml) {
+    std::string fName = edmParameterSet.getParameter<edm::FileInPath>("configXMLFile").fullPath();
+
+    edm::LogVerbatim("OMTFReconstruction")
+        << "OMTFReconstruction::beginRun - reading config from file: " << fName << std::endl;
+
+    XMLConfigReader xmlConfigReader;
+    xmlConfigReader.setConfigFile(fName);
+
+    omtfParams.reset(new L1TMuonOverlapParams());
+    xmlConfigReader.readConfig(omtfParams.get());
+
+    //getPatternsVersion() parses the entire patterns xml - si it is very inefficient
+    //moreover, PatternsVersion is not used anywhere
+    //Therefore we we dont use xmlPatternReader.getPatternsVersion(); but set patternsVersion to 0
+    unsigned int patternsVersion = 0;
+    unsigned int fwVersion = omtfParams->fwVersion();
+    omtfParams->setFwVersion((fwVersion << 16) + patternsVersion);
+
+    omtfConfig->configure(omtfParams.get());
+
+    //the parameters can be overwritten from the python config
+    omtfConfig->configureFromEdmParameterSet(edmParameterSet);
+
+    inputMaker->initialize(edmParameterSet, eventSetup, muonGeometryTokens);
+
+    //reading patterns from the xml----------------------------------------------------------
     std::vector<std::string> patternsXMLFiles;
 
     if (edmParameterSet.exists("patternsXMLFile")) {
@@ -122,8 +153,6 @@ void OMTFReconstruction::beginRun(edm::Run const& run,
     for (auto& patternsXMLFile : patternsXMLFiles)
       edm::LogVerbatim("OMTFReconstruction") << "reading patterns from " << patternsXMLFile << std::endl;
 
-    XMLConfigReader xmlReader;
-
     std::string patternType = "GoldenPattern";  //GoldenPatternWithStat GoldenPattern
     if (edmParameterSet.exists("patternType")) {
       patternType = edmParameterSet.getParameter<std::string>("patternType");
@@ -136,15 +165,14 @@ void OMTFReconstruction::beginRun(edm::Run const& run,
               omtfConfig.get(),
               edmParameterSet,
               eventSetup,
-              xmlReader.readPatterns<GoldenPattern>(*omtfParams, patternsXMLFiles, false));
+              xmlConfigReader.readPatterns<GoldenPattern>(*omtfParams, patternsXMLFiles, false));
         } else {  //in principle should not happen
           throw cms::Exception("OMTFReconstruction::beginRun: omtfParams is nullptr");
         }
       }
 
-      edm::LogVerbatim("OMTFReconstruction")
-          << "OMTFProcessor constructed. processorType " << processorType << ". GoldenPattern type: " << patternType
-          << " nProcessors " << omtfConfig->nProcessors() << std::endl;
+      edm::LogVerbatim("OMTFReconstruction") << "OMTFProcessor constructed. processorType " << processorType
+                                             << ". GoldenPattern type: " << patternType << std::endl;
     } else if (patternType == "GoldenPatternWithStat") {
       //pattern generation is only possible if the processor is constructed only once per job
       //PatternGenerator modifies the patterns!!!
@@ -154,7 +182,7 @@ void OMTFReconstruction::beginRun(edm::Run const& run,
               omtfConfig.get(),
               edmParameterSet,
               eventSetup,
-              xmlReader.readPatterns<GoldenPatternWithStat>(*omtfParams, patternsXMLFiles, false));
+              xmlConfigReader.readPatterns<GoldenPatternWithStat>(*omtfParams, patternsXMLFiles, false));
         } else {  //in principle should not happen
           throw cms::Exception("OMTFReconstruction::beginRun: omtfParams is nullptr");
         }
@@ -205,7 +233,7 @@ void OMTFReconstruction::addObservers(
       if (edmParameterSet.getParameter<bool>("eventCaptureDebug")) {
         observers.emplace_back(std::make_unique<EventCapture>(
             edmParameterSet, omtfConfig.get(), candidateSimMuonMatcher, muonGeometryTokens
-            //, &(omtfProcGoldenPat->getPatterns() )
+            //&(omtfProcGoldenPat->getPatterns() ),
             //watch out, will crash if the proc is re-constructed from the DB after L1TMuonOverlapParamsRcd change
             ));
       }
@@ -228,7 +256,7 @@ void OMTFReconstruction::addObservers(
       if (edmParameterSet.getParameter<bool>("eventCaptureDebug")) {
         observers.emplace_back(std::make_unique<EventCapture>(
             edmParameterSet, omtfConfig.get(), candidateSimMuonMatcher, muonGeometryTokens
-            //&(omtfProcGoldenPat->getPatterns() )
+            //&(omtfProcGoldenPat->getPatterns() ),
             //watch out, will crash if the proc is re-constructed from the DB after L1TMuonOverlapParamsRcd change
             ));
       }


### PR DESCRIPTION
#### PR description:

This PR adds the possibility of configuring the OMTF emulator directly from the config XML, without using the L1TMuonOverlapPhase1ParamsESProducer.

#### PR validation:

The PR was validated by running the L1T DQM on one file from run 385422. 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is a backport of https://github.com/cms-sw/cmssw/pull/45032 
Only the files from the L1TMuonOverlapPhase1 folder are backported, as L1TMuonOverlapPhase2 is not included in the CMSSW_14_0_X.
This PR will be followed by the backport of https://github.com/cms-sw/cmssw/pull/45984

This PR and the backport of https://github.com/cms-sw/cmssw/pull/45984 will ensure that the OMTF emulator will be configured from the XML files corresponding to the 2024 OMTF algorithm version that was deployed at CSM on 19th March 2024, provided the Era Run3_2024 is defined for the job.
This will fix the data-emulator mismatches present in the DQM since the beginning of the 2024 pp run. Besides, will ensure the upcoming 2024 MC production will use the 2024 OMTF algorithm version.

#### Details of changes:

OMTFReconstruction.h and OMTFReconstruction.cc
The possibility of configuring the OMTF emulator directly from the config XML is added. When both patternsXMLFile and configXMLFile are given from the python config of the simOmtfDigis or simOmtfPhase2Digis, the L1TMuonOverlapParams are read directly from these files, and the L1TMuonOverlapPhase1ParamsESProducer is not needed. Otherwise, the L1TMuonOverlapParams are obtained from the eventSetup (so from the DB, or from the L1TMuonOverlapPhase1ParamsESProducer - if it is defined).

L1Trigger/L1TMuonOverlapPhase1/src/Omtf/OMTFProcessor.cc line
trackAddr[3] = myCand->getGpResultUnconstr().getPdfSumUnconstr(); is removed, as uGMT expects 3 entries in the TrackAddress (when there were 4, uGMT was generating a warning).
