### PR TITLE
Fix small typo in `makePileupJSON.py`: `runNumber` → `run`

### DIFF
--- a/RecoLuminosity/LumiDB/scripts/makePileupJSON.py
+++ b/RecoLuminosity/LumiDB/scripts/makePileupJSON.py
@@ -134,7 +134,7 @@ if __name__ == '__main__':
             mean_pileup = bunch_del_lumi * parameters.orbitLength / parameters.lumiSectionLength
             if mean_pileup > 100:
                 print("mean number of pileup events > 100 for run %d, lum %d : m %f l %f" % \
-                      (runNumber, lumi_section, mean_pileup, bunch_del_lumi))
+                      (run, lumi_section, mean_pileup, bunch_del_lumi))
                 #print "mean number of pileup events for lum %d: m %f idx %d l %f" % (lumi_section, mean_pileup, bxid, bunch_rec_lumi)
 
             total_int2 += bunch_rec_lumi*(mean_pileup-mean_int)*(mean_pileup-mean_int)

--- a/RecoLuminosity/LumiDB/scripts/pileupCalc.py
+++ b/RecoLuminosity/LumiDB/scripts/pileupCalc.py
@@ -62,7 +62,7 @@ class EquidistantBinning(object):
     def width(self):
         return (self.xMax-self.xMin)/self.num
     def find(self, x):
-        return np.floor((x-self.xMin)*self.num/(self.xMax-self.xMin)).astype(np.int)
+        return np.floor((x-self.xMin)*self.num/(self.xMax-self.xMin)).astype(int)
 
 Sqrt2 = np.sqrt(2)
 


### PR DESCRIPTION
This PR fixes small typo in https://github.com/cms-sw/cmssw/blob/master/RecoLuminosity/LumiDB/scripts/makePileupJSON.py.

Run number is introduced as just `run`:
https://github.com/cms-sw/cmssw/blob/c312b85e0474fb1c058f8e2c8e0aadcf6b69c30d/RecoLuminosity/LumiDB/scripts/makePileupJSON.py#L57-L73
But later `runNumber` is used:
https://github.com/cms-sw/cmssw/blob/c312b85e0474fb1c058f8e2c8e0aadcf6b69c30d/RecoLuminosity/LumiDB/scripts/makePileupJSON.py#L132-L138

This led to the following error when computing PU profile for 2024, following instructions from [this "PileupJSONFileforData" TWiki](https://twiki.cern.ch/twiki/bin/view/CMS/PileupJSONFileforData#Creating_the_pileup_files):
```shell
$ makePileupJSON.py lumi_DCSONLY.csv pileup_JSON.txt I get this error:
...
Processing <...>/lumi_DCSONLY.csv with all BX
Traceback (most recent call last):
  File "/cvmfs/cms.cern.ch/el9_amd64_gcc12/cms/cmssw/CMSSW_14_1_0_pre4/bin/el9_amd64_gcc12/makePileupJSON.py", line 137, in <module>
    (runNumber, lumi_section, mean_pileup, bunch_del_lumi))
NameError: name 'runNumber' is not defined
```