### PR TITLE
Update in autoCond 141X data and MC GTs for HI, and also synchronize them with the updated 140X ones - CMSSW_14_1_X

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -31,12 +31,12 @@ autoCond = {
     'run2_data_promptlike_hi'      :    '140X_dataRun2_PromptLike_HI_v1',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              :    '140X_dataRun2_HLT_relval_v1',
-    # GlobalTag for Run3 HLT: identical the online GT - 140X_dataRun3_HLT_v1 with snapshot at 2024-06-13 14:22:43 (UTC)
+    # GlobalTag for Run3 HLT: identical the online GT 140X_dataRun3_HLT_v3 with snapshot at 2024-06-13 14:22:43 (UTC)
     'run3_hlt'                     :    '141X_dataRun3_HLT_frozen_v1',
-    # GlobalTag for Run3 data relvals (express GT) - 140X_dataRun3_Express_v2 (+ the new LHCInfoPer*_duringFill tags) but snapshot at 2024-06-13 15:13:03 (UTC)
-    'run3_data_express'            :    '141X_dataRun3_Express_frozen_v2',
-    # GlobalTag for Run3 data relvals (prompt GT) - 140X_dataRun3_Prompt_v3 (+ the the SecondaryDataset TriggerBits tag and the DeDxCalibrationRcd for HI) but snapshot at 2024_06_12 13:47:20 (UTC)
-    'run3_data_prompt'             :    '141X_dataRun3_Prompt_frozen_v1',
+    # GlobalTag for Run3 data relvals (express GT): same as 141X_dataRun3_Express_v2 but with snapshot at 2024-09-12 10:35:04 (UTC)
+    'run3_data_express'            :    '141X_dataRun3_Express_frozen_v3',
+    # GlobalTag for Run3 data relvals (prompt GT): same as 141X_dataRun3_Prompt_v3 but with snapshot at 2024-09-12 11:03:32 (UTC)
+    'run3_data_prompt'             :    '141X_dataRun3_Prompt_frozen_v3',
     # GlobalTag for Run3 offline data reprocessing - snapshot at 2024-09-04 16:25:09 (UTC)
     'run3_data'                    :    '140X_dataRun3_v9',
     # GlobalTag for Run3 offline data reprocessing with Prompt GT, currently for 2022FG - snapshot at 2024-02-12 12:00:00 (UTC)
@@ -98,7 +98,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2024, Strip tracker in DECO mode
     'phase1_2024_cosmics_design'   :    '140X_mcRun3_2024cosmics_design_deco_v11',
     # GlobalTag for MC production with realistic conditions for Phase1 2024 detector for Heavy Ion
-    'phase1_2024_realistic_hi'     :    '141X_mcRun3_2024_realistic_HI_v4',
+    'phase1_2024_realistic_hi'     :    '141X_mcRun3_2024_realistic_HI_v5',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             :    '141X_mcRun4_realistic_v1'
 }


### PR DESCRIPTION
#### PR description:

This PR updates in autoCond the 141X GTs for 2024 HI data taking and MC, with the latest requests submitted to AlCa.
Moreover, all those GTs had been updated taking into account all updates implemented in the corresponding GTs and not yet ported to the 141X ones.

These are the corresponding GT changes

- [141X_dataRun3_HLT_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/141X_dataRun3_HLT_v1) is already identical to 143X_dataRun3_HLT_v3, see [diff](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/141X_dataRun3_HLT_v1/140X_dataRun3_HLT_v3) 
  - (Not modified in autoCond, and therefore listed here only for completeness)

- [141X_dataRun3_Express_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/141X_dataRun3_Express_v3) adds, on top of 141X_dataRun3_Express_v2, see [diff](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/141X_dataRun3_Express_v3/141X_dataRun3_Express_v2):
  - The new LHCInfoPer*_duringFill tags (details for the request and validation in https://cms-talk.web.cern.ch/t/full-track-validation-hlt-express-prompt-update-of-pps-conditions-for-2024-data-taking/36747)
  - (The frozen version in autoCond was already up to date with the LHCInfo tag, only the snapshot time has changed in it, with current snapshot at 2024-09-12 10:35:04)
  - It is synchronized with 140X_dataRun3_Express_v3, with the additional (see [diff](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/141X_dataRun3_Express_v3/140X_dataRun3_Express_v3)) light-by-light egamma tags (GBRDWrapperRcd with several different labels) that were originally requested for HI prompt 132X GTs in https://cms-talk.web.cern.ch/t/gt-offline-prompt-request-for-new-run3-hi-prompt-gt-in-13-2-x-with-light-by-light-egamma-regression-collections/32023
 
- [141X_dataRun3_Prompt_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/141X_dataRun3_Prompt_v3) adds, on top of 140X_dataRun3_Prompt_v4, see [diff](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/141X_dataRun3_Prompt_v3/140X_dataRun3_Prompt_v4):
  - The light-by-light egamma tags (GBRDWrapperRcd with several different labels) that were originally requested for HI prompt 132X GTs in https://cms-talk.web.cern.ch/t/gt-offline-prompt-request-for-new-run3-hi-prompt-gt-in-13-2-x-with-light-by-light-egamma-regression-collections/32023
  - The DeDx calibration as requested in https://cms-talk.web.cern.ch/t/gt-mc-prompt-update-of-dedxcalibration-for-hi-upc/45324
  - (Frozen version: same as 141X_dataRun3_Prompt_v3 but with snapshot at 2024-09-12 11:03:32)

- [141X_mcRun3_2024_realistic_HI_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/141X_mcRun3_2024_realistic_HI_v53) adds on top of 141X_mcRun3_2024_realistic_HI_v4 (already in autoCond), see [diff](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/141X_mcRun3_2024_realistic_HI_v5/141X_mcRun3_2024_realistic_HI_v4): 
  - The DeDx calibration as requested in https://cms-talk.web.cern.ch/t/gt-mc-prompt-update-of-dedxcalibration-for-hi-upc/45324

For completeness, let me report here also the GT prepared for 2024ppRef5TeV, which is not (yet) in autoCond, and therefore does not affect this PR:

- [141X_mcRun3_2024_realistic_ppRef5TeV_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/141X_mcRun3_2024_realistic_ppRef5TeV_v2) is based on the latest 140X_mcRun3_2024_realistic_v22 GT with the following additions, see [diff](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/141X_mcRun3_2024_realistic_ppRef5TeV_v1/140X_mcRun3_2024_realistic_v22):
  - The DeDx calibration as requested in https://cms-talk.web.cern.ch/t/gt-mc-prompt-update-of-dedxcalibration-for-hi-upc/45324
  - The new L1T menu specific for ppRef in 2024 as requested in https://cms-talk.web.cern.ch/t/gt-mc-update-of-l1t-menu-in-ppref-mc-gt-for-14-1-x/48077

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #45990 in CMSSW_14_1_X
