### PR TITLE
Support lumi-weighted input files for the TkAl Primary Vertex Validation plotting

### DIFF
--- a/Alignment/OfflineValidation/macros/FitPVResiduals.C
+++ b/Alignment/OfflineValidation/macros/FitPVResiduals.C
@@ -657,12 +657,38 @@ void FitPVResiduals(TString namesandlabels,
     timer.Continue();
   }
 
+  // Lambda function to determine the effective number of entries
+  auto getEffectiveEntries = [](TH1 *hist) -> double {
+    if (!hist) {
+      std::cerr << "Invalid histogram pointer!" << std::endl;
+      return 0.;
+    }
+
+    double entries = hist->GetEntries() / hist->GetNbinsX();
+
+    // Check if the histogram was hadded (entries != 1 indicates potential hadding)
+    if (entries != 1) {
+      // If the sum of weights is not equal to effective entries, it suggests that the histogram was weighted
+      if (hist->GetSumOfWeights() != hist->GetEffectiveEntries()) {
+        entries = 1.;  // Assuming overall sum of weights is 1 (lumi-weighted histograms)
+      }
+    }
+
+    if (isDebugMode) {
+      std::cout << "name:" << hist->GetName() << " bins:" << hist->GetNbinsX() << " sumW:" << hist->GetSumOfWeights()
+                << " effective entries:" << hist->GetEffectiveEntries() << " returned entries:" << entries << std::endl;
+    }
+
+    return entries;
+  };
+
   for (Int_t i = 0; i < nFiles_; i++) {
     fins[i]->cd("PVValidation/EventFeatures/");
 
     if (gDirectory->GetListOfKeys()->Contains("etaMax")) {
       gDirectory->GetObject("etaMax", theEtaHistos[i]);
-      theEtaMax_[i] = theEtaHistos[i]->GetBinContent(1) / theEtaHistos[i]->GetEntries();
+      double entries = getEffectiveEntries(theEtaHistos[i]);
+      theEtaMax_[i] = theEtaHistos[i]->GetBinContent(1) / entries;
       std::cout << "File n. " << i << " has theEtaMax[" << i << "] = " << theEtaMax_[i] << std::endl;
     } else {
       theEtaMax_[i] = 2.5;
@@ -671,7 +697,8 @@ void FitPVResiduals(TString namesandlabels,
 
     if (gDirectory->GetListOfKeys()->Contains("nbins")) {
       gDirectory->GetObject("nbins", thebinsHistos[i]);
-      theNBINS[i] = thebinsHistos[i]->GetBinContent(1) / thebinsHistos[i]->GetEntries();
+      double entries = getEffectiveEntries(thebinsHistos[i]);
+      theNBINS[i] = thebinsHistos[i]->GetBinContent(1) / entries;
       std::cout << "File n. " << i << " has theNBINS[" << i << "] = " << theNBINS[i] << std::endl;
     } else {
       theNBINS[i] = 48.;
@@ -680,7 +707,8 @@ void FitPVResiduals(TString namesandlabels,
 
     if (gDirectory->GetListOfKeys()->Contains("nladders")) {
       gDirectory->GetObject("nladders", theLaddersHistos[i]);
-      theLadders[i] = theLaddersHistos[i]->GetBinContent(1) / theLaddersHistos[i]->GetEntries();
+      double entries = getEffectiveEntries(theLaddersHistos[i]);
+      theLadders[i] = theLaddersHistos[i]->GetBinContent(1) / entries;
       std::cout << "File n. " << i << " has theNLadders[" << i << "] = " << theLadders[i] << std::endl;
     } else {
       theLadders[i] = -1.;
@@ -689,7 +717,8 @@ void FitPVResiduals(TString namesandlabels,
 
     if (gDirectory->GetListOfKeys()->Contains("nModZ")) {
       gDirectory->GetObject("nModZ", theModZHistos[i]);
-      theModZ[i] = theModZHistos[i]->GetBinContent(1) / theModZHistos[i]->GetEntries();
+      double entries = getEffectiveEntries(theModZHistos[i]);
+      theModZ[i] = theModZHistos[i]->GetBinContent(1) / entries;
       std::cout << "File n. " << i << " has theNModZ[" << i << "] = " << theModZ[i] << std::endl;
     } else {
       theModZ[i] = -1.;
@@ -698,10 +727,10 @@ void FitPVResiduals(TString namesandlabels,
 
     if (gDirectory->GetListOfKeys()->Contains("pTinfo")) {
       gDirectory->GetObject("pTinfo", thePtInfoHistos[i]);
-      thePTBINS[i] = thePtInfoHistos[i]->GetBinContent(1) * 3. / thePtInfoHistos[i]->GetEntries();
-      ;
-      thePtMin[i] = thePtInfoHistos[i]->GetBinContent(2) * 3. / thePtInfoHistos[i]->GetEntries();
-      thePtMax[i] = thePtInfoHistos[i]->GetBinContent(3) * 3. / thePtInfoHistos[i]->GetEntries();
+      double entries = getEffectiveEntries(thePtInfoHistos[i]);
+      thePTBINS[i] = thePtInfoHistos[i]->GetBinContent(1) / entries;
+      thePtMin[i] = thePtInfoHistos[i]->GetBinContent(2) / entries;
+      thePtMax[i] = thePtInfoHistos[i]->GetBinContent(3) / entries;
       std::cout << "File n. " << i << " has thePTBINS[" << i << "] = " << thePTBINS[i] << " pT min:  " << thePtMin[i]
                 << " pT max: " << thePtMax[i] << std::endl;
     } else {
@@ -727,7 +756,7 @@ void FitPVResiduals(TString namesandlabels,
     gDirectory->GetObject("h_probeRefitVSigXY", dxySigRefit[i]);
     gDirectory->GetObject("h_probeRefitVSigZ", dzSigRefit[i]);
 
-    for (Int_t j = 0; j < theNBINS[i]; j++) {
+    for (Int_t j = 0; j < Int_t(theNBINS[i]); j++) {
       if (stdres) {
         // DCA absolute residuals
 
@@ -757,7 +786,7 @@ void FitPVResiduals(TString namesandlabels,
         // double differential residuals
 
         if (do2DMaps) {
-          for (Int_t k = 0; k < theNBINS[i]; k++) {
+          for (Int_t k = 0; k < Int_t(theNBINS[i]); k++) {
             // absolute residuals
             fins[i]->cd("PVValidation/Abs_DoubleDiffResiduals/");
             gDirectory->GetObject(Form("histo_dxy_eta_plot%i_phi_plot%i", j, k), dxyMapResiduals[i][j][k]);
@@ -792,7 +821,7 @@ void FitPVResiduals(TString namesandlabels,
 
         // double differential residuals
         if (do2DMaps) {
-          for (Int_t k = 0; k < theNBINS[i]; k++) {
+          for (Int_t k = 0; k < Int_t(theNBINS[i]); k++) {
             // absolute residuals
             fins[i]->cd("PVValidation/Abs_DoubleDiffResiduals");
             gDirectory->GetObject(Form("PVValidation/Abs_DoubleDiffResiduals/histo_dxy_eta_plot%i_phi_plot%i", j, k),
@@ -815,7 +844,7 @@ void FitPVResiduals(TString namesandlabels,
 
     // residuals vs pT
 
-    for (Int_t l = 0; l < thePTBINS[i] - 1; l++) {
+    for (Int_t l = 0; l < Int_t(thePTBINS[i] - 1); l++) {
       dxyPtResiduals[i][l] = (TH1F *)fins[i]->Get(Form("PVValidation/Abs_Transv_pT_Residuals/histo_dxy_pT_plot%i", l));
       dzPtResiduals[i][l] = (TH1F *)fins[i]->Get(Form("PVValidation/Abs_Long_pT_Residuals/histo_dz_pT_plot%i", l));
 


### PR DESCRIPTION
#### PR description:

The title tells it all. It was recently realized that some of the plots that were made public in [CMS-DP-2024-071](https://twiki.cern.ch/twiki/bin/view/CMSPublic/TkAlignmentPerformanceRun3Reprocessing) are affected by a bug in the computation of the error bars.
Upon further investigation an issue was found with the error bars in this particular set of plots ([primary vertex run averaged](https://twiki.cern.ch/twiki/bin/view/CMSPublic/TkAlignmentPerformanceRun3Reprocessing#Primary_vertex_validation_Averag)): in general we use a likelihood gaussian fit to account for empty bins when we look at run by run primary vertex validation during operations which can happen relatively frequently in single runs. However, this is not appropriate for weighted inputs (as is the case for lumi-averaging) and here one should use a least squares fit. 
This PR provides some changes to plotting macro `FitPVResiduals` such that it auto-detects if the input file is lumi-weighted or a regular single run file and then acts accordingly in the fit procedure.
Some preliminary commit (86e2e0d073610be6b1fa2f8fd1d1b1874cf98fa3) was needed in order to make the fetching of the validation "metadata" agnostic on the type of input file (before this PR this was dealt with by using a separate and different code).

#### PR validation:

I've run this branch with and without the commit acb0ab0ddcb937aaab58d320d0918a5f46e665a7. 
Without the changes I get plot with exaggerated error bars e.g:

![image](https://github.com/user-attachments/assets/079a928f-f176-49a1-8844-b6fb83fa7216)

while, when using the commit I get much more reasonable error bars:

![image](https://github.com/user-attachments/assets/0d8a395b-c636-4dd6-b953-775b4b90d300)

In addition I have also tested the single run (unweighted case) to make sure there are no changes, and none are observe (see [this](https://marcomusich.web.cern.ch/TestPVValidation/single/mods/) vs [that](https://marcomusich.web.cern.ch/TestPVValidation/single/vanilla/)).

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A

Cc:
@henriettepetersen @TomasKello 