### PR TITLE
Introduce support for cluster splitting and JetCore iteration in Phase-2 track reconstruction

### DIFF
--- a/Configuration/ProcessModifiers/python/jetCoreInPhase2_cff.py
+++ b/Configuration/ProcessModifiers/python/jetCoreInPhase2_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+jetCoreInPhase2 = cms.Modifier()

--- a/Configuration/ProcessModifiers/python/splitClustersInPhase2Pixel_cff.py
+++ b/Configuration/ProcessModifiers/python/splitClustersInPhase2Pixel_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+splitClustersInPhase2Pixel = cms.Modifier()

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -2415,6 +2415,52 @@ upgradeWFs['Aging3000'].suffix = 'Aging3000'
 upgradeWFs['Aging3000'].offset = 0.103
 upgradeWFs['Aging3000'].lumi = '3000'
 
+class UpgradeWorkflow_PixelClusterSplitting(UpgradeWorkflow):
+    def setup_(self, step, stepName, stepDict, k, properties):
+        stepDict[stepName][k] = merge([{'--procModifiers': 'splitClustersInPhase2Pixel'}, stepDict[step][k]])
+    def condition(self, fragment, stepList, key, hasHarvest):
+        return '2026' in key
+
+upgradeWFs['PixelClusterSplitting'] = UpgradeWorkflow_PixelClusterSplitting(
+    steps = [
+        'RecoLocal',
+        'Reco',
+        'RecoFakeHLT',
+        'RecoGlobal',
+    ],
+    PU = [
+        'RecoLocal',
+        'Reco',
+        'RecoFakeHLT',
+        'RecoGlobal',
+    ],
+    suffix = '_ClusterSplittingInPixel',
+    offset = 0.19001,
+)
+
+class UpgradeWorkflow_JetCore(UpgradeWorkflow):
+    def setup_(self, step, stepName, stepDict, k, properties):
+        stepDict[stepName][k] = merge([{'--procModifiers': 'splitClustersInPhase2Pixel,jetCoreInPhase2'}, stepDict[step][k]])
+    def condition(self, fragment, stepList, key, hasHarvest):
+        return '2026' in key
+
+upgradeWFs['JetCore'] = UpgradeWorkflow_JetCore(
+    steps = [
+        'RecoLocal',
+        'Reco',
+        'RecoFakeHLT',
+        'RecoGlobal',
+    ],
+    PU = [
+        'RecoLocal',
+        'Reco',
+        'RecoFakeHLT',
+        'RecoGlobal',
+    ],
+    suffix = '_JetCore',
+    offset = 0.19002,
+)
+
 #
 # Simulates Bias Rail in Phase-2 OT PS modules and X% random bad Strips
 # in PS-s and SS sensors

--- a/RecoLocalTracker/SubCollectionProducers/python/jetCoreClusterSplitter_cfi.py
+++ b/RecoLocalTracker/SubCollectionProducers/python/jetCoreClusterSplitter_cfi.py
@@ -14,6 +14,11 @@ jetCoreClusterSplitter = cms.EDProducer("JetCoreClusterSplitter",
            fractionalWidth  = cms.double(0.4),
            chargePerUnit  = cms.double(2000),
            centralMIPCharge  = cms.double(26000),
+           expSizeXAtLorentzAngleIncidence = cms.double(1.5),
+           expSizeXDeltaPerTanAlpha = cms.double(0.0),
+           expSizeYAtNormalIncidence = cms.double(1.3),
+           tanLorentzAngle = cms.double(0.0), # doesn't really matter if expSizeXDeltaPerTanAlpha == 0
+           tanLorentzAngleBarrelLayer1 = cms.double(0.0),
 	
 
     )

--- a/RecoLocalTracker/SubCollectionProducers/src/JetCoreClusterSplitter.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/JetCoreClusterSplitter.cc
@@ -1,7 +1,9 @@
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -12,8 +14,11 @@
 #include "RecoLocalTracker/Records/interface/TkPixelCPERecord.h"
 
 #include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
+#include "Geometry/CommonTopologies/interface/PixelTopology.h"
 #include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
 #include "DataFormats/GeometryVector/interface/VectorUtil.h"
+
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
@@ -25,6 +30,7 @@
 
 class JetCoreClusterSplitter : public edm::stream::EDProducer<> {
 public:
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   JetCoreClusterSplitter(const edm::ParameterSet& iConfig);
   ~JetCoreClusterSplitter() override;
   void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
@@ -49,11 +55,17 @@ private:
 
   edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> const tTrackingGeom_;
   edm::ESGetToken<PixelClusterParameterEstimator, TkPixelCPERecord> const tCPE_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> const tTrackerTopo_;
 
   bool verbose;
   double ptMin_;
   double deltaR_;
   double chargeFracMin_;
+  float expSizeXAtLorentzAngleIncidence_;
+  float expSizeXDeltaPerTanAlpha_;
+  float expSizeYAtNormalIncidence_;
+  float tanLorentzAngle_;
+  float tanLorentzAngleBarrelLayer1_;
   edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster>> pixelClusters_;
   edm::EDGetTokenT<reco::VertexCollection> vertices_;
   edm::EDGetTokenT<edm::View<reco::Candidate>> cores_;
@@ -64,13 +76,45 @@ private:
   double centralMIPCharge_;
 };
 
+void JetCoreClusterSplitter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+
+  desc.add<std::string>("pixelCPE", "PixelCPEGeneric");
+  desc.add<bool>("verbose", false);
+  desc.add<double>("ptMin", 200.0);
+  desc.add<double>("deltaRmax", 0.05);
+  desc.add<double>("chargeFractionMin", 2.0);
+  desc.add<edm::InputTag>("pixelClusters", edm::InputTag("siPixelCluster"));
+  desc.add<edm::InputTag>("vertices", edm::InputTag("offlinePrimaryVertices"));
+  desc.add<edm::InputTag>("cores", edm::InputTag("ak5CaloJets"));
+  desc.add<double>("forceXError", 100.0);
+  desc.add<double>("forceYError", 150.0);
+  desc.add<double>("fractionalWidth", 0.4);
+  desc.add<double>("chargePerUnit", 2000.0);
+  desc.add<double>("centralMIPCharge", 26e3);
+
+  desc.add<double>("expSizeXAtLorentzAngleIncidence", 1.5);
+  desc.add<double>("expSizeXDeltaPerTanAlpha", 0.0);
+  desc.add<double>("expSizeYAtNormalIncidence", 1.3);
+  desc.add<double>("tanLorentzAngle", 0.0);
+  desc.add<double>("tanLorentzAngleBarrelLayer1", 0.0);
+
+  descriptions.addWithDefaultLabel(desc);
+}
+
 JetCoreClusterSplitter::JetCoreClusterSplitter(const edm::ParameterSet& iConfig)
     : tTrackingGeom_(esConsumes()),
       tCPE_(esConsumes(edm::ESInputTag("", iConfig.getParameter<std::string>("pixelCPE")))),
+      tTrackerTopo_(esConsumes()),
       verbose(iConfig.getParameter<bool>("verbose")),
       ptMin_(iConfig.getParameter<double>("ptMin")),
       deltaR_(iConfig.getParameter<double>("deltaRmax")),
       chargeFracMin_(iConfig.getParameter<double>("chargeFractionMin")),
+      expSizeXAtLorentzAngleIncidence_(iConfig.getParameter<double>("expSizeXAtLorentzAngleIncidence")),
+      expSizeXDeltaPerTanAlpha_(iConfig.getParameter<double>("expSizeXDeltaPerTanAlpha")),
+      expSizeYAtNormalIncidence_(iConfig.getParameter<double>("expSizeYAtNormalIncidence")),
+      tanLorentzAngle_(iConfig.getParameter<double>("tanLorentzAngle")),
+      tanLorentzAngleBarrelLayer1_(iConfig.getParameter<double>("tanLorentzAngleBarrelLayer1")),
       pixelClusters_(
           consumes<edmNew::DetSetVector<SiPixelCluster>>(iConfig.getParameter<edm::InputTag>("pixelClusters"))),
       vertices_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertices"))),
@@ -92,6 +136,7 @@ bool SortPixels(const SiPixelCluster::Pixel& i, const SiPixelCluster::Pixel& j) 
 void JetCoreClusterSplitter::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
   const auto& geometry = &iSetup.getData(tTrackingGeom_);
+  const auto& topology = &iSetup.getData(tTrackerTopo_);
 
   Handle<edmNew::DetSetVector<SiPixelCluster>> inputPixelClusters;
   iEvent.getByToken(pixelClusters_, inputPixelClusters);
@@ -111,6 +156,13 @@ void JetCoreClusterSplitter::produce(edm::Event& iEvent, const edm::EventSetup& 
     edmNew::DetSetVector<SiPixelCluster>::FastFiller filler(*output, detIt->id());
     const edmNew::DetSet<SiPixelCluster>& detset = *detIt;
     const GeomDet* det = geometry->idToDet(detset.id());
+    float pitchX, pitchY;
+    std::tie(pitchX, pitchY) = static_cast<const PixelTopology&>(det->topology()).pitch();
+    float thickness = det->surface().bounds().thickness();
+    float tanLorentzAngle = tanLorentzAngle_;
+    if (DetId(detset.id()).subdetId() == 1 /* px barrel */ && topology->pxbLayer(detset.id()) == 1) {
+      tanLorentzAngle = tanLorentzAngleBarrelLayer1_;
+    }
     for (auto cluster = detset.begin(); cluster != detset.end(); cluster++) {
       const SiPixelCluster& aCluster = *cluster;
       bool hasBeenSplit = false;
@@ -126,18 +178,18 @@ void JetCoreClusterSplitter::produce(edm::Event& iEvent, const edm::EventSetup& 
           if (Geom::deltaR(jetDir, clusterDir) < deltaR_) {
             // check if the cluster has to be splitted
 
-            bool isEndCap = (std::abs(cPos.z()) > 30.f);  // FIXME: check detID instead!
-            float jetZOverRho = jet.momentum().Z() / jet.momentum().Rho();
-            if (isEndCap)
-              jetZOverRho = jet.momentum().Rho() / jet.momentum().Z();
-            float expSizeY = std::sqrt((1.3f * 1.3f) + (1.9f * 1.9f) * jetZOverRho * jetZOverRho);
+            LocalVector jetDirLocal = det->surface().toLocal(jetDir);
+            float jetTanAlpha = jetDirLocal.x() / jetDirLocal.z();
+            float jetTanBeta = jetDirLocal.y() / jetDirLocal.z();
+            float jetZOverRho = std::sqrt(jetTanAlpha * jetTanAlpha + jetTanBeta * jetTanBeta);
+            float expSizeX = expSizeXAtLorentzAngleIncidence_ +
+                             std::abs(expSizeXDeltaPerTanAlpha_ * (jetTanAlpha - tanLorentzAngle));
+            float expSizeY = std::sqrt((expSizeYAtNormalIncidence_ * expSizeYAtNormalIncidence_) +
+                                       thickness * thickness / (pitchY * pitchY) * jetTanBeta * jetTanBeta);
+            if (expSizeX < 1.f)
+              expSizeX = 1.f;
             if (expSizeY < 1.f)
               expSizeY = 1.f;
-            float expSizeX = 1.5f;
-            if (isEndCap) {
-              expSizeX = expSizeY;
-              expSizeY = 1.5f;
-            }  // in endcap col/rows are switched
             float expCharge = std::sqrt(1.08f + jetZOverRho * jetZOverRho) * centralMIPCharge_;
 
             if (aCluster.charge() > expCharge * chargeFracMin_ &&
@@ -163,8 +215,10 @@ void JetCoreClusterSplitter::produce(edm::Event& iEvent, const edm::EventSetup& 
         if (shouldBeSplit) {
           // blowup the error if we failed to split a splittable cluster (does
           // it ever happen)
-          c.setSplitClusterErrorX(c.sizeX() * (100.f / 3.f));  // this is not really blowing up .. TODO: tune
-          c.setSplitClusterErrorY(c.sizeY() * (150.f / 3.f));
+          const float fromCentiToMicro = 1e4;
+          c.setSplitClusterErrorX(c.sizeX() *
+                                  (pitchX * fromCentiToMicro / 3.f));  // this is not really blowing up .. TODO: tune
+          c.setSplitClusterErrorY(c.sizeY() * (pitchY * fromCentiToMicro / 3.f));
         }
         filler.push_back(c);
         std::push_heap(filler.begin(), filler.end(), [](SiPixelCluster const& cl1, SiPixelCluster const& cl2) {

--- a/RecoTracker/FinalTrackSelectors/python/earlyGeneralTracks_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/earlyGeneralTracks_cfi.py
@@ -87,21 +87,23 @@ from RecoTracker.FinalTrackSelectors.trackListMerger_cfi import trackListMerger 
 trackingPhase2PU140.toReplaceWith(earlyGeneralTracks, _trackListMerger.clone(
     TrackProducers =['initialStepTracks',
                      'highPtTripletStepTracks',
+                     'jetCoreRegionalStepTracks',
                      'lowPtQuadStepTracks',
                      'lowPtTripletStepTracks',
                      'detachedQuadStepTracks',
                      'pixelPairStepTracks',
                     ],
-    hasSelector = [1,1,1,1,1,1],
-    indivShareFrac = [1.0,0.16,0.095,0.09,0.09,0.09],
+    hasSelector = [1,1,1,1,1,1,1],
+    indivShareFrac = [1.0,0.16,1.0,0.095,0.09,0.09,0.09],
     selectedTrackQuals = ['initialStepSelector:initialStep',
                           'highPtTripletStepSelector:highPtTripletStep',
+                          'jetCoreRegionalStepSelector:jetCoreRegionalStep',
                           'lowPtQuadStepSelector:lowPtQuadStep',
                           'lowPtTripletStepSelector:lowPtTripletStep',
                           'detachedQuadStep',
                           'pixelPairStepSelector:pixelPairStep',
                           ],
-    setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1,2,3,4,5), pQual=cms.bool(True) ) 
+    setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1,2,3,4,5,6), pQual=cms.bool(True) )
 	),
     copyExtras = True,
     makeReKeyedSeeds = cms.untracked.bool(False)

--- a/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
@@ -23,6 +23,10 @@ from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 trackingPhase1.toModify(initialStepSeedLayersPreSplitting,
     layerList = RecoTracker.TkSeedingLayers.PixelLayerQuadruplets_cfi.PixelLayerQuadruplets.layerList.value()
 )
+from Configuration.ProcessModifiers.splitClustersInPhase2Pixel_cff import splitClustersInPhase2Pixel
+splitClustersInPhase2Pixel.toModify(initialStepSeedLayersPreSplitting,
+    layerList = RecoTracker.TkSeedingLayers.PixelLayerQuadruplets_cfi.PixelLayerQuadruplets.layerList.value()
+)
 
 # TrackingRegion
 from RecoTracker.TkTrackingRegions.globalTrackingRegionFromBeamSpot_cfi import globalTrackingRegionFromBeamSpot as _globalTrackingRegionFromBeamSpot
@@ -32,6 +36,7 @@ initialStepTrackingRegionsPreSplitting = _globalTrackingRegionFromBeamSpot.clone
     nSigmaZ      = 4.0
 ))
 trackingPhase1.toModify(initialStepTrackingRegionsPreSplitting, RegionPSet = dict(ptMin = 0.5))
+splitClustersInPhase2Pixel.toModify(initialStepTrackingRegionsPreSplitting, RegionPSet = dict(ptMin = 0.6,originRadius = 0.03))
 
 # seeding
 from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _hitPairEDProducer
@@ -54,6 +59,7 @@ initialStepHitTripletsPreSplitting = _pixelTripletHLTEDProducer.clone(
 )
 from RecoTracker.PixelSeeding.caHitQuadrupletEDProducer_cfi import caHitQuadrupletEDProducer as _caHitQuadrupletEDProducer
 trackingPhase1.toModify(initialStepHitDoubletsPreSplitting, layerPairs = [0,1,2]) # layer pairs (0,1), (1,2), (2,3)
+splitClustersInPhase2Pixel.toModify(initialStepHitDoubletsPreSplitting, layerPairs = [0,1,2]) # layer pairs (0,1), (1,2), (2,3)
 initialStepHitQuadrupletsPreSplitting = _caHitQuadrupletEDProducer.clone(
     doublets = 'initialStepHitDoubletsPreSplitting',
     extraHitRPhitolerance = initialStepHitTripletsPreSplitting.extraHitRPhitolerance,
@@ -68,21 +74,29 @@ initialStepHitQuadrupletsPreSplitting = _caHitQuadrupletEDProducer.clone(
     CAThetaCut           = 0.0012,
     CAPhiCut             = 0.2,
 )
+splitClustersInPhase2Pixel.toModify(initialStepHitQuadrupletsPreSplitting,
+    CAThetaCut = 0.0010,
+    CAPhiCut   = 0.175,
+)
 from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsEDProducer_cff import seedCreatorFromRegionConsecutiveHitsEDProducer as _seedCreatorFromRegionConsecutiveHitsEDProducer
 initialStepSeedsPreSplitting = _seedCreatorFromRegionConsecutiveHitsEDProducer.clone(
     seedingHitSets = 'initialStepHitTripletsPreSplitting',
 )
 trackingPhase1.toModify(initialStepSeedsPreSplitting, seedingHitSets = 'initialStepHitQuadrupletsPreSplitting')
+splitClustersInPhase2Pixel.toModify(initialStepSeedsPreSplitting, seedingHitSets = 'initialStepHitQuadrupletsPreSplitting')
 
 
 # building
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
-initialStepTrajectoryFilterBasePreSplitting = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+_initialStepTrajectoryFilterBasePreSplitting = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
     minimumNumberOfHits = 4,
     minPt               = 0.2,
+)
+initialStepTrajectoryFilterBasePreSplitting = _initialStepTrajectoryFilterBasePreSplitting.clone(
     maxCCCLostHits      = 0,
     minGoodStripCharge  = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
 )
+splitClustersInPhase2Pixel.toReplaceWith(initialStepTrajectoryFilterBasePreSplitting, _initialStepTrajectoryFilterBasePreSplitting)
 from Configuration.Eras.Modifier_tracker_apv_vfp30_2016_cff import tracker_apv_vfp30_2016
 _tracker_apv_vfp30_2016.toModify(initialStepTrajectoryFilterBasePreSplitting, maxCCCLostHits = 2)
 import RecoTracker.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi
@@ -93,6 +107,10 @@ initialStepTrajectoryFilterPreSplitting = cms.PSet(
         cms.PSet( refToPSet_ = cms.string('initialStepTrajectoryFilterBasePreSplitting')),
         cms.PSet( refToPSet_ = cms.string('initialStepTrajectoryFilterShapePreSplitting'))),
 )
+splitClustersInPhase2Pixel.toReplaceWith(initialStepTrajectoryFilterPreSplitting, TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+    minimumNumberOfHits = 3,
+    minPt               = 0.2
+))
 
 import RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi
 initialStepChi2EstPreSplitting = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi.Chi2ChargeMeasurementEstimator.clone(
@@ -103,6 +121,9 @@ initialStepChi2EstPreSplitting = RecoTracker.MeasurementDet.Chi2ChargeMeasuremen
 )
 _tracker_apv_vfp30_2016.toModify(initialStepChi2EstPreSplitting,
     clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny')
+)
+splitClustersInPhase2Pixel.toModify(initialStepChi2EstPreSplitting,
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutNone'),
 )
 
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
@@ -237,6 +258,9 @@ InitialStepPreSplitting = cms.Sequence(InitialStepPreSplittingTask)
 _InitialStepPreSplittingTask_trackingPhase1 = InitialStepPreSplittingTask.copy()
 _InitialStepPreSplittingTask_trackingPhase1.replace(initialStepHitTripletsPreSplitting, cms.Task(initialStepHitTripletsPreSplitting,initialStepHitQuadrupletsPreSplitting))
 trackingPhase1.toReplaceWith(InitialStepPreSplittingTask, _InitialStepPreSplittingTask_trackingPhase1.copyAndExclude([initialStepHitTripletsPreSplitting]))
+_InitialStepPreSplittingTask_trackingPhase2PU140 = InitialStepPreSplittingTask.copy()
+_InitialStepPreSplittingTask_trackingPhase2PU140.replace(initialStepHitTripletsPreSplitting, cms.Task(initialStepHitTripletsPreSplitting,initialStepHitQuadrupletsPreSplitting))
+splitClustersInPhase2Pixel.toReplaceWith(InitialStepPreSplittingTask, _InitialStepPreSplittingTask_trackingPhase2PU140.copyAndExclude([initialStepHitTripletsPreSplitting]))
 
 from Configuration.ProcessModifiers.trackingMkFitCommon_cff import trackingMkFitCommon
 _InitialStepPreSplittingTask_trackingMkFitCommon = InitialStepPreSplittingTask.copy()
@@ -265,12 +289,23 @@ from RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizer_cfi import siPixelCl
 from Configuration.Eras.Modifier_trackingLowPU_cff import trackingLowPU
 trackingLowPU.toReplaceWith(siPixelClusters, _siPixelClusters)
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
-trackingPhase2PU140.toReplaceWith(siPixelClusters, _siPixelClusters)
-_InitialStepPreSplittingTask_LowPU_Phase2PU140 = cms.Task(
+(trackingPhase2PU140 & ~splitClustersInPhase2Pixel).toReplaceWith(siPixelClusters, _siPixelClusters)
+_InitialStepPreSplittingTask_LowPU = cms.Task(
     siPixelClusters ,
     siPixelRecHits ,
     MeasurementTrackerEvent ,
     siPixelClusterShapeCache
 )
-trackingLowPU.toReplaceWith(InitialStepPreSplittingTask, _InitialStepPreSplittingTask_LowPU_Phase2PU140)
-trackingPhase2PU140.toReplaceWith(InitialStepPreSplittingTask, _InitialStepPreSplittingTask_LowPU_Phase2PU140)
+trackingLowPU.toReplaceWith(InitialStepPreSplittingTask, _InitialStepPreSplittingTask_LowPU)
+(trackingPhase2PU140 & ~splitClustersInPhase2Pixel).toReplaceWith(InitialStepPreSplittingTask, _InitialStepPreSplittingTask_LowPU)
+splitClustersInPhase2Pixel.toModify(siPixelClusters,
+    centralMIPCharge  = cms.double(12000),
+    expSizeXAtLorentzAngleIncidence = cms.double(1.5),
+    expSizeXDeltaPerTanAlpha = cms.double(5.2),
+    expSizeYAtNormalIncidence = cms.double(2.3),
+    tanLorentzAngle = cms.double(-0.21),
+    tanLorentzAngleBarrelLayer1 = cms.double(0.0),
+    chargeFractionMin = cms.double(2.0),
+    forceXError = cms.double(25.0),
+    forceYError = cms.double(100.0),
+)

--- a/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
+++ b/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
@@ -63,6 +63,10 @@ _iterations_trackingPhase2PU140 = [
 ]
 from Configuration.ProcessModifiers.vectorHits_cff import vectorHits
 vectorHits.toModify(_iterations_trackingPhase2PU140, func=lambda x: x.append('PixelLessStep'))
+
+from Configuration.ProcessModifiers.jetCoreInPhase2_cff import jetCoreInPhase2
+jetCoreInPhase2.toModify(_iterations_trackingPhase2PU140, func=lambda x: x.append('JetCoreRegionalStep'))
+
 _iterations_muonSeeded = [
     "MuonSeededStepInOut",
     "MuonSeededStepOutIn",


### PR DESCRIPTION
#### PR description:

This PR introduces the support for cluster splitting and a JetCore iteration in the Phase-2 track reconstruction, while keeping both of them disabled by default.

The effect of this PR on the Phase-1 and Phase-2 reconstruction (resource utilization & tracking performance) are summarized in this presentation at the Tracking POG meeting: https://indico.cern.ch/event/1428996/#38-integration-of-jetcore-for
Information about the tuning of the cluster splitting parameters for Phase-2 in this other presentation: https://indico.cern.ch/event/1396796/#30-jetcore-and-cluster-splitti

Some details about this PR:
- The `JetCoreClusterSplitter` in `RecoLocalTracker/SubCollectionProducers` has been modified to support the features of the Phase-2 Inner Tracker (geometry and 3D sensors in TBPX layer 1). No worsening of the tracking performance in the Phase-1 reconstruction was observed following these changes ([validation plots here](https://cernbox.cern.ch/s/IRM9k1zOHcS79ZD)).
- Two process modifiers have been introduced:
  - `splitClustersInPhase2Pixel`, enabling an `InitialStepPreSplitting` to produce a collection of split clusters for use in the `InitialStep`;
  - `jetCoreInPhase2`, enabling the JetCore iteration in the Phase-2 Tracking.
- Two workflow offsets have been added:
  - `0.19001` activates the `splitClustersInPhase2Pixel` process modifier;
  - `0.19002` activates both the `splitClustersInPhase2Pixel` and the `jetCoreInPhase2` modifiers.

#### PR validation:

- Compiles fine after `git cms-checkdeps -a -A`.
- `export CMS_PATH=/cvmfs/cms-ib.cern.ch/ ; export SITECONFIG_PATH=/cvmfs/cms-ib.cern.ch/SITECONF/local/ ; scram b runtests`: no failing test.
- `runTheMatrix.py -l limited -i all --ibeos`: no failing test.
- Tested with step 3 on RelVals from DAS (`TTBar_14TeV` + PU and `QCD_FlatPt_15_3000HS_14` without PU), runs to completion.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not a backport, and no backport is needed.