### PR TITLE
make `V0EventSelector` produce skimmed V0 collections based on their mass 

### DIFF
--- a/DQM/TrackingMonitorSource/plugins/V0EventSelector.cc
+++ b/DQM/TrackingMonitorSource/plugins/V0EventSelector.cc
@@ -2,11 +2,13 @@
 #include <vector>
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/View.h"
+#include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Candidate/interface/VertexCompositeCandidate.h"
 #include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
 
 class V0EventSelector : public edm::stream::EDFilter<> {
 public:
@@ -19,25 +21,45 @@ public:
 private:
   const edm::EDGetTokenT<reco::VertexCompositeCandidateCollection> vccToken_;
   const unsigned int minNumCandidates_;
+  const double massMin_;
+  const double massMax_;
 };
 
 V0EventSelector::V0EventSelector(const edm::ParameterSet& iConfig)
     : vccToken_{consumes<reco::VertexCompositeCandidateCollection>(
           iConfig.getParameter<edm::InputTag>("vertexCompositeCandidates"))},
-      minNumCandidates_{iConfig.getParameter<unsigned int>("minCandidates")} {}
+      minNumCandidates_{iConfig.getParameter<unsigned int>("minCandidates")},
+      massMin_{iConfig.getParameter<double>("massMin")},
+      massMax_{iConfig.getParameter<double>("massMax")} {
+  produces<reco::VertexCompositeCandidateCollection>();
+}
 
 bool V0EventSelector::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::Handle<reco::VertexCompositeCandidateCollection> vccHandle;
   iEvent.getByToken(vccToken_, vccHandle);
 
-  return vccHandle->size() >= minNumCandidates_;
+  auto filteredVCC = std::make_unique<reco::VertexCompositeCandidateCollection>();
+
+  for (const auto& vcc : *vccHandle) {
+    if (vcc.mass() >= massMin_ && vcc.mass() <= massMax_) {
+      filteredVCC->push_back(vcc);
+    }
+  }
+
+  bool pass = filteredVCC->size() >= minNumCandidates_;
+  iEvent.put(std::move(filteredVCC));
+
+  return pass;
 }
 
 void V0EventSelector::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("vertexCompositeCandidates", edm::InputTag("generalV0Candidates:Kshort"));
-  desc.add<unsigned int>("minCandidates", 1);  // Change '1' to your desired minimum number of candidates
+  desc.add<unsigned int>("minCandidates", 1)->setComment("Minimum number of candidates required");
+  desc.add<double>("massMin", 0.0)->setComment("Minimum mass in GeV");
+  desc.add<double>("massMax", std::numeric_limits<double>::max())->setComment("Maximum mass in GeV");
   descriptions.addWithDefaultLabel(desc);
 }
 
+// Define this module as a plug-in
 DEFINE_FWK_MODULE(V0EventSelector);

--- a/DQM/TrackingMonitorSource/python/TrackingDataMCValidation_Standalone_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackingDataMCValidation_Standalone_cff.py
@@ -94,7 +94,7 @@ electronTracks = cms.EDProducer("ZtoEEElectronTrackProducer")
 ttbarEventSelector = cms.EDFilter("ttbarEventSelector")
 ttbarTracks = cms.EDProducer("TtbarTrackProducer")
 
-# Added modules for V0Monitoring
+# Added modules for V0Monitoring (standard)
 KshortMonitor = v0Monitor.clone()
 KshortMonitor.FolderName = "StandaloneTrackMonitor/V0Monitoring/Ks"
 KshortMonitor.v0         = "generalV0Candidates:Kshort"
@@ -108,6 +108,18 @@ LambdaMonitor.v0 = "generalV0Candidates:Lambda"
 LambdaMonitor.histoPSet.massPSet = cms.PSet(nbins = cms.int32(100),
                                             xmin  = cms.double(1.050),
                                             xmax  = cms.double(1.250))
+
+# Added modules for V0Monitoring (for restricted mass candidates)
+SelectedKshortMonitor = KshortMonitor.clone(
+    FolderName = "StandaloneTrackMonitor/V0Monitoring/SelectedKs",
+    v0         = "KShortEventSelector"
+)
+
+SelectedLambdaMonitor = LambdaMonitor.clone(
+    FolderName = "StandaloneTrackMonitor/V0Monitoring/SelectedLambda",
+    v0         = "LambdaEventSelector"
+)
+
 ##################
 # For MinBias
 ##################
@@ -171,7 +183,7 @@ standaloneValidationK0s = cms.Sequence(
     * KShortEventSelector
     * KshortTracks
     * standaloneTrackMonitorK0
-    * KshortMonitor)
+    * SelectedKshortMonitor)
 
 standaloneValidationK0sMC = cms.Sequence(
     hltPathFilter
@@ -179,7 +191,7 @@ standaloneValidationK0sMC = cms.Sequence(
     * KShortEventSelector
     * KshortTracks
     * standaloneTrackMonitorK0MC
-    * KshortMonitor)
+    * SelectedKshortMonitor)
 
 standaloneValidationLambdas = cms.Sequence(
     hltPathFilter
@@ -187,7 +199,7 @@ standaloneValidationLambdas = cms.Sequence(
     * LambdaEventSelector
     * LambdaTracks
     * standaloneTrackMonitorLambda
-    * LambdaMonitor)
+    * SelectedLambdaMonitor)
 
 standaloneValidationLambdasMC = cms.Sequence(
     hltPathFilter
@@ -195,7 +207,7 @@ standaloneValidationLambdasMC = cms.Sequence(
     * LambdaEventSelector
     * LambdaTracks
     * standaloneTrackMonitorLambdaMC
-    * LambdaMonitor)
+    * SelectedLambdaMonitor)
 
 ##################
 # For ZtoEE

--- a/DQM/TrackingMonitorSource/python/V0Selections_cfi.py
+++ b/DQM/TrackingMonitorSource/python/V0Selections_cfi.py
@@ -1,12 +1,21 @@
 from DQM.TrackingMonitorSource.v0EventSelector_cfi import *
 from DQM.TrackingMonitorSource.v0VertexTrackProducer_cfi import *
 
-KShortEventSelector = v0EventSelector.clone()
-LambdaEventSelector = v0EventSelector.clone(
-    vertexCompositeCandidates = "generalV0Candidates:Lambda"  
+KShortEventSelector = v0EventSelector.clone(
+    vertexCompositeCandidates = "generalV0Candidates:Kshort",
+    massMin = 0.47,
+    massMax = 0.52,
 )
 
-KshortTracks = v0VertexTrackProducer.clone()
+LambdaEventSelector = v0EventSelector.clone(
+    vertexCompositeCandidates = "generalV0Candidates:Lambda",
+    massMin = 1.11,
+    massMax = 1.128
+)
+
+KshortTracks = v0VertexTrackProducer.clone(
+    vertexCompositeCandidates = "KShortEventSelector"
+)
 LambdaTracks = v0VertexTrackProducer.clone(
-    vertexCompositeCandidates = "generalV0Candidates:Lambda"
+    vertexCompositeCandidates = "LambdaEventSelector"
 )


### PR DESCRIPTION
#### PR description:

Title says it all, it was suggested to modify `V0EventSelector` in order to produce skimmed V0 collections based on their mass, to enhance the purity in terms of strange origin of the tracks analyzed via `StandaloneTrackMonitor`, based on the results shown [here](https://dbruschi.web.cern.ch/TrackingPOG_sorted/2024_physics_production/K0s/) and [here](https://dbruschi.web.cern.ch/TrackingPOG_sorted/2024_physics_production/Lambdas/).
This update concerns only the Tracking Data/MC validation suite and is of no consequence on any DQM production sequence run in online or offline DQM.

#### PR validation:

Relies on the existing unit tests of this package: `scram b runtests_testTrackingDATAMC`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, might be backported later on for convenience