### PR TITLE
Minuit2::FCNBase: fix for root 6.32

### DIFF
--- a/RecoVertex/BeamSpotProducer/interface/BSpdfsFcn.h
+++ b/RecoVertex/BeamSpotProducer/interface/BSpdfsFcn.h
@@ -19,7 +19,7 @@ ________________________________________________________________**/
 #include <iostream>
 #include <string>
 #include <RVersion.h>
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 32, 4)
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 33, 1)
 #include <span>
 #endif
 

--- a/RecoVertex/BeamSpotProducer/interface/FcnBeamSpotFitPV.h
+++ b/RecoVertex/BeamSpotProducer/interface/FcnBeamSpotFitPV.h
@@ -31,7 +31,7 @@ public:
   // deltaFcn for definition of the uncertainty
   double Up() const override { return errorDef_; }
   // -2lnL value based on vector of parameters
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 32, 4)
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 33, 1)
   double operator()(std::span<const double>) const override;
 #else
   double operator()(const std::vector<double>&) const override;

--- a/RecoVertex/BeamSpotProducer/src/BSpdfsFcn.cc
+++ b/RecoVertex/BeamSpotProducer/src/BSpdfsFcn.cc
@@ -20,7 +20,7 @@ ________________________________________________________________**/
 #endif
 
 //______________________________________________________________________
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 32, 4)
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 33, 1)
 double BSpdfsFcn::PDFGauss_d(double z, double d, double sigmad, double phi, std::span<const double> parms) const {
 #else
 double BSpdfsFcn::PDFGauss_d(double z, double d, double sigmad, double phi, const std::vector<double>& parms) const {
@@ -42,7 +42,7 @@ double BSpdfsFcn::PDFGauss_d(double z, double d, double sigmad, double phi, cons
 }
 
 //______________________________________________________________________
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 32, 4)
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 33, 1)
 double BSpdfsFcn::PDFGauss_d_resolution(double z, double d, double phi, double pt, std::span<const double> parms) const {
 #else
 double BSpdfsFcn::PDFGauss_d_resolution(
@@ -68,7 +68,7 @@ double BSpdfsFcn::PDFGauss_d_resolution(
 }
 
 //______________________________________________________________________
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 32, 4)
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 33, 1)
 double BSpdfsFcn::PDFGauss_z(double z, double sigmaz, std::span<const double> parms) const {
 #else
 double BSpdfsFcn::PDFGauss_z(double z, double sigmaz, const std::vector<double>& parms) const {
@@ -89,7 +89,7 @@ double BSpdfsFcn::PDFGauss_z(double z, double sigmaz, const std::vector<double>&
 }
 
 //______________________________________________________________________
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 32, 4)
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 33, 1)
 double BSpdfsFcn::operator()(const std::span<const double> params) const {
 #else
 double BSpdfsFcn::operator()(const std::vector<double>& params) const {


### PR DESCRIPTION
This fixes a typo in #45965 . The root version which has the `Minuit2::FCNBase` interface change is ROOT 6.33 while #45965 has mistakenly applied the change for ROOT 6.32. This should fix the ROOT 6.32 build errors https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_14_2_ROOT632_X_2024-09-13-2300/RecoVertex/BeamSpotProducer
```
In file included from src/RecoVertex/BeamSpotProducer/src/FcnBeamSpotFitPV.cc:1:
  src/RecoVertex/BeamSpotProducer/interface/FcnBeamSpotFitPV.h:35:10: error: 'double FcnBeamSpotFitPV::operator()(std::span<const double>) const' marked 'override', but does not override
    35 |   double operator()(std::span<const double>) const override;
      |          ^~~~~~~~
  src/RecoVertex/BeamSpotProducer/src/BSpdfsFcn.cc:24:8: error: no declaration matches 'double BSpdfsFcn::PDFGauss_d(double, double, double, double, std::span<const double>) const'
    24 | double BSpdfsFcn::PDFGauss_d(double z, double d, double sigmad, double phi, std::span<const double> parms) const {
      |        ^~~~~~~~~
In file included from src/RecoVertex/BeamSpotProducer/src/BSpdfsFcn.cc:13:
src/RecoVertex/BeamSpotProducer/interface/BSpdfsFcn.h:47:10: note: candidate is: 'double BSpdfsFcn::PDFGauss_d(double, double, double, double, const std::vector<double>&) const'
   47 |   double PDFGauss_d(double z, double d, double sigmad, double phi, const std::vector<double>& parms) const;
      |          ^~~~~~~~~~
src/RecoVertex/BeamSpotProducer/interface/BSpdfsFcn.h:26:7: note: 'class BSpdfsFcn' defined here
   26 | class BSpdfsFcn : public ROOT::Minuit2::FCNBase {
      |       ^~~~~~~~~
  src/RecoVertex/BeamSpotProducer/src/BSpdfsFcn.cc:46:8: error: no declaration matches 'double BSpdfsFcn::PDFGauss_d_resolution(double, double, double, double, std::span<const double>) const'
    46 | double BSpdfsFcn::PDFGauss_d_resolution(double z, double d, double phi, double pt, std::span<const double> parms) const {
      |        ^~~~~~~~~
src/RecoVertex/BeamSpotProducer/interface/BSpdfsFcn.h:48:10: note: candidate is: 'double BSpdfsFcn::PDFGauss_d_resolution(double, double, double, double, const std::vector<double>&) const'
   48 |   double PDFGauss_d_resolution(double z, double d, double phi, double pt, const std::vector<double>& parms) const;
      |          ^~~~~~~~~~~~~~~~~~~~~
src/RecoVertex/BeamSpotProducer/interface/BSpdfsFcn.h:26:7: note: 'class BSpdfsFcn' defined here
   26 | class BSpdfsFcn : public ROOT::Minuit2::FCNBase {
      |       ^~~~~~~~~

```