### PR TITLE
[BTV] Disable pT cut for AK4 Puppi ParticleNet and UParT taggers inference

### DIFF
--- a/RecoBTag/FeatureTools/plugins/ParticleNetFeatureEvaluator.cc
+++ b/RecoBTag/FeatureTools/plugins/ParticleNetFeatureEvaluator.cc
@@ -64,6 +64,7 @@ private:
   const double max_eta_for_taus_;
   const bool include_neutrals_;
   const bool flip_ip_sign_;
+  const bool fallback_puppi_weight_;
   bool use_puppi_value_map_;
   const double max_sip3dsig_for_flip_;
 
@@ -267,6 +268,7 @@ ParticleNetFeatureEvaluator::ParticleNetFeatureEvaluator(const edm::ParameterSet
       max_eta_for_taus_(iConfig.getParameter<double>("max_eta_for_taus")),
       include_neutrals_(iConfig.getParameter<bool>("include_neutrals")),
       flip_ip_sign_(iConfig.getParameter<bool>("flip_ip_sign")),
+      fallback_puppi_weight_(iConfig.getParameter<bool>("fallback_puppi_weight")),
       use_puppi_value_map_(false),
       max_sip3dsig_for_flip_(iConfig.getParameter<double>("max_sip3dsig_for_flip")),
       muon_token_(consumes<pat::MuonCollection>(iConfig.getParameter<edm::InputTag>("muons"))),
@@ -306,6 +308,7 @@ void ParticleNetFeatureEvaluator::fillDescriptions(edm::ConfigurationDescription
   desc.add<double>("max_eta_for_taus", 2.5);
   desc.add<bool>("include_neutrals", true);
   desc.add<bool>("flip_ip_sign", false);
+  desc.add<bool>("fallback_puppi_weight", false);
   desc.add<double>("max_sip3dsig_for_flip", 99999);
   desc.add<edm::InputTag>("vertices", edm::InputTag("offlineSlimmedPrimaryVertices"));
   desc.add<edm::InputTag>("secondary_vertices", edm::InputTag("slimmedSecondaryVertices"));
@@ -428,6 +431,9 @@ void ParticleNetFeatureEvaluator::fillParticleFeatures(DeepBoostedJetFeatures &f
   // track builder
   TrackInfoBuilder trackinfo(track_builder_);
 
+  //Save puppi weight for selected constituents in this map
+  std::map<const pat::PackedCandidate *, float> map_pc2puppiweight;
+
   // make list of pf-candidates to be considered
   std::vector<const pat::PackedCandidate *> daughters;
   for (const auto &dau : jet.daughterPtrVector()) {
@@ -443,6 +449,16 @@ void ParticleNetFeatureEvaluator::fillParticleFeatures(DeepBoostedJetFeatures &f
       continue;
     // filling daughters
     daughters.push_back(cand);
+
+    float puppiw = 1.;
+    if (use_puppi_value_map_){
+      puppiw = (*puppi_value_map_)[dau];
+    }
+    else if (!fallback_puppi_weight_) {
+      throw edm::Exception(edm::errors::InvalidReference, "PUPPI value map missing")
+          << "use fallback_puppi_weight option to use " << puppiw << " for cand as default";
+    }
+    map_pc2puppiweight[cand] = puppiw;
   }
 
   // sort by original pt (not Puppi-weighted)
@@ -501,7 +517,7 @@ void ParticleNetFeatureEvaluator::fillParticleFeatures(DeepBoostedJetFeatures &f
     fts.fill("jet_pfcand_frompv", cand->fromPV());
     fts.fill("jet_pfcand_dz", ip_sign * (std::isnan(cand->dz(pv_ass_pos)) ? 0 : cand->dz(pv_ass_pos)));
     fts.fill("jet_pfcand_dxy", ip_sign * (std::isnan(cand->dxy(pv_ass_pos)) ? 0 : cand->dxy(pv_ass_pos)));
-    fts.fill("jet_pfcand_puppiw", cand->puppiWeight());
+    fts.fill("jet_pfcand_puppiw", map_pc2puppiweight[cand]);
     fts.fill("jet_pfcand_nlostinnerhits", cand->lostInnerHits());
     fts.fill("jet_pfcand_nhits", cand->numberOfHits());
     fts.fill("jet_pfcand_npixhits", cand->numberOfPixelHits());

--- a/RecoBTag/FeatureTools/plugins/ParticleNetFeatureEvaluator.cc
+++ b/RecoBTag/FeatureTools/plugins/ParticleNetFeatureEvaluator.cc
@@ -283,7 +283,7 @@ ParticleNetFeatureEvaluator::ParticleNetFeatureEvaluator(const edm::ParameterSet
       pfcand_token_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("pf_candidates"))),
       track_builder_token_(
           esConsumes<TransientTrackBuilder, TransientTrackRecord>(edm::ESInputTag("", "TransientTrackBuilder"))) {
-  const auto& puppi_value_map_tag = iConfig.getParameter<edm::InputTag>("puppi_value_map");
+  const auto &puppi_value_map_tag = iConfig.getParameter<edm::InputTag>("puppi_value_map");
   if (!puppi_value_map_tag.label().empty()) {
     puppi_value_map_token_ = consumes<edm::ValueMap<float>>(puppi_value_map_tag);
     use_puppi_value_map_ = true;
@@ -451,10 +451,9 @@ void ParticleNetFeatureEvaluator::fillParticleFeatures(DeepBoostedJetFeatures &f
     daughters.push_back(cand);
 
     float puppiw = 1.;
-    if (use_puppi_value_map_){
+    if (use_puppi_value_map_) {
       puppiw = (*puppi_value_map_)[dau];
-    }
-    else if (!fallback_puppi_weight_) {
+    } else if (!fallback_puppi_weight_) {
       throw edm::Exception(edm::errors::InvalidReference, "PUPPI value map missing")
           << "use fallback_puppi_weight option to use " << puppiw << " for cand as default";
     }

--- a/RecoBTag/FeatureTools/plugins/UnifiedParticleTransformerAK4TagInfoProducer.cc
+++ b/RecoBTag/FeatureTools/plugins/UnifiedParticleTransformerAK4TagInfoProducer.cc
@@ -171,7 +171,7 @@ void UnifiedParticleTransformerAK4TagInfoProducer::fillDescriptions(edm::Configu
   desc.add<bool>("fallback_puppi_weight", false);
   desc.add<bool>("fallback_vertex_association", false);
   desc.add<bool>("is_weighted_jet", false);
-  desc.add<double>("min_jet_pt", 15.0);
+  desc.add<double>("min_jet_pt",  0.0);
   desc.add<double>("max_jet_eta", 2.5);
   descriptions.add("pfUnifiedParticleTransformerAK4TagInfos", desc);
 }
@@ -225,10 +225,10 @@ void UnifiedParticleTransformerAK4TagInfoProducer::produce(edm::Event& iEvent, c
 
     // reco jet reference (use as much as possible)
     const auto& jet = jets->at(jet_n);
-    if (jet.pt() < 15.0) {
+    if (jet.pt() < min_jet_pt_) {
       features.is_filled = false;
     }
-    if (std::abs(jet.eta()) > 2.5) {
+    if (std::abs(jet.eta()) > max_jet_eta_) {
       features.is_filled = false;
     }
     // dynamical casting to pointers, null if not possible

--- a/RecoBTag/FeatureTools/plugins/UnifiedParticleTransformerAK4TagInfoProducer.cc
+++ b/RecoBTag/FeatureTools/plugins/UnifiedParticleTransformerAK4TagInfoProducer.cc
@@ -171,7 +171,7 @@ void UnifiedParticleTransformerAK4TagInfoProducer::fillDescriptions(edm::Configu
   desc.add<bool>("fallback_puppi_weight", false);
   desc.add<bool>("fallback_vertex_association", false);
   desc.add<bool>("is_weighted_jet", false);
-  desc.add<double>("min_jet_pt",  0.0);
+  desc.add<double>("min_jet_pt", 0.0);
   desc.add<double>("max_jet_eta", 2.5);
   descriptions.add("pfUnifiedParticleTransformerAK4TagInfos", desc);
 }

--- a/RecoBTag/ONNXRuntime/python/pfParticleNetFromMiniAODAK4_cff.py
+++ b/RecoBTag/ONNXRuntime/python/pfParticleNetFromMiniAODAK4_cff.py
@@ -26,7 +26,7 @@ pfParticleNetFromMiniAODAK4CHSForwardTagInfos = ParticleNetFeatureEvaluator.clon
 pfParticleNetFromMiniAODAK4PuppiCentralTagInfos = ParticleNetFeatureEvaluator.clone(
     jets = "slimmedJetsPuppi",
     jet_radius = 0.4,
-    min_jet_pt = 15,
+    min_jet_pt = 0.,
     min_jet_eta = 0.,
     max_jet_eta = 2.5,
 )
@@ -34,9 +34,9 @@ pfParticleNetFromMiniAODAK4PuppiCentralTagInfos = ParticleNetFeatureEvaluator.cl
 pfParticleNetFromMiniAODAK4PuppiForwardTagInfos = ParticleNetFeatureEvaluator.clone(
     jets = "slimmedJetsPuppi",
     jet_radius = 0.4,
-    min_jet_pt = 15,
+    min_jet_pt = 0.,
     min_jet_eta = 2.5,
-    max_jet_eta = 4.7,
+    max_jet_eta = 5.0,
 )
 
 


### PR DESCRIPTION
#### PR description:

This PR makes several changes related to BTV:

- Lower jet pT cut to 0 for AK4 Puppi ParticleNet and UParT jet taggers. The jet abs(eta) range for ParticleNet is also extended to 5. This is to ensure that the taggers provide pT regression values for low pt jets. Very small timing impact on PAT step ([XPOG 4/9](https://indico.cern.ch/event/1450394/#11-jme-pt-threshold-for-pt-reg)). 
- Remove hardcoded jet pT and eta selection in `UnifiedParticleTransformerAK4TagInfoProducer.cc`.
- Puppi weight is now retrieved from ValueMap in `ParticleNetFeatureEvaluator.cc`.
- Simplify setup of `packedpuppi` module in `setupBTagging()` function.

#### PR validation:

- passes the usual runTheMatrix test: `runTheMatrix.py -l limited -i all --ibeos`
- passes MiniAOD workflows: `runTheMatrix.py -i all --ibeos  -l 2500.021,2500.022,2500.023,2500.024,2500.031,2500.032,2500.033,2500.034`


