### PR TITLE
Added Era_Run3_2024 modifier to simOmtfDigis, to use OMTF 2024 config (14_0_X)

### DIFF
--- a/L1Trigger/L1TMuonOverlapPhase1/python/simOmtfDigis_cfi.py
+++ b/L1Trigger/L1TMuonOverlapPhase1/python/simOmtfDigis_cfi.py
@@ -32,3 +32,9 @@ simOmtfDigis = cms.EDProducer("L1TMuonOverlapPhase1TrackProducer",
 
   extrapolFactorsFilename = cms.FileInPath("L1Trigger/L1TMuon/data/omtf_config/ExtrapolationFactors_simple.xml"),
 )
+
+### Era: Run3_2024
+from Configuration.Eras.Modifier_stage2L1Trigger_2024_cff import stage2L1Trigger_2024 
+stage2L1Trigger_2024.toModify(simOmtfDigis, 
+                              configXMLFile = cms.FileInPath("L1Trigger/L1TMuon/data/omtf_config/hwToLogicLayer_0x0009.xml"),
+                              patternsXMLFile = cms.FileInPath("L1Trigger/L1TMuon/data/omtf_config/Patterns_ExtraplMB1nadMB2SimplifiedFP_t17_classProb17_recalib2_minDP0_v3.xml") )


### PR DESCRIPTION
L1Trigger/L1TMuonOverlapPhase1/python/simOmtfDigis_cfi.py: added parameters configXMLFile and patternsXMLFile corresponding to the 2024 OMTF firmware to the stage2L1Trigger_2024 era modifier. This is needed since there are problems with uploading the 2024 OMTF params to the condDB.

The files
L1Trigger/L1TMuon/data/omtf_config/hwToLogicLayer_0x0009.xml
L1Trigger/L1TMuon/data/omtf_config/Patterns_ExtraplMB1nadMB2SimplifiedFP_t17_classProb17_recalib2_minDP0_v3.xml
are in the CMSSW_DATA.

#### PR description:
Up to now, the OMTF emulator configuration parameters were stored in the condDB. The new parameters were uploaded to the condDB with the use of the "manual o2o" procedure. Unfortunately, the knowledge of how to execute this procedure was lost, and despite a few trials, the upload of the OMTF params corresponding to the firmware deployed at P5 in March of 2024 was unsuccessful. Therefore, with this PR, the emulator will be configured from the appropriate XML files, provided the Era Run3_2024 is defined for the job.
This will fix the data-emulator mismatches present in the DQM since the beginning of the 2024 pp run. Besides, will ensure the upcoming 2024 MC production will use the 2024 OMTF algorithm version.

#### PR validation:

The PR was validated by running the L1T DQM on one file from run 385422. The data-to-emulator mismatches for the OMTF are at the level of 0.5%, which is the expected level when the OMTF is properly configured.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is a backport of https://github.com/cms-sw/cmssw/pull/45984.
