### PR TITLE
[AlCa] Fix clang static analyzer warnings about dead assignments

### DIFF
--- a/Alignment/CommonAlignment/src/Utilities.cc
+++ b/Alignment/CommonAlignment/src/Utilities.cc
@@ -62,7 +62,7 @@ align::PositionType align::motherPosition(const std::vector<const PositionType*>
 
   Scalar inv = 1. / static_cast<Scalar>(nDau);
 
-  return PositionType(posX *= inv, posY *= inv, posZ *= inv);
+  return PositionType(posX * inv, posY * inv, posZ * inv);
 }
 
 align::RotationType align::diffRot(const GlobalVectors& current, const GlobalVectors& nominal) {

--- a/Alignment/MuonAlignment/src/MuonAlignmentInputXML.cc
+++ b/Alignment/MuonAlignment/src/MuonAlignmentInputXML.cc
@@ -625,7 +625,7 @@ Alignable *MuonAlignmentInputXML::getCSCnode(align::StructureType structureType,
     }
   } else {
     int endcap, station, ring, chamber, layer;
-    endcap = station = ring = chamber = layer = 1;
+    station = ring = chamber = layer = 1;
 
     DOMAttr *node_endcap = node->getAttributeNode(str_endcap);
     if (node_endcap == nullptr)
@@ -717,7 +717,7 @@ Alignable *MuonAlignmentInputXML::getGEMnode(align::StructureType structureType,
     }
   } else {
     int endcap, station, ring, superChamber;
-    endcap = station = ring = superChamber = 1;
+    station = ring = superChamber = 1;
 
     DOMAttr *node_endcap = node->getAttributeNode(str_endcap);
     if (node_endcap == nullptr)


### PR DESCRIPTION
#### PR description:

See logs here: [1](https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_14_2_X_2024-09-14-1100/el8_amd64_gcc12/build-logs/Alignment/CommonAlignment/log.html), [2](https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_14_2_X_2024-09-14-1100/el8_amd64_gcc12/build-logs/Alignment/MuonAlignment/log.html)

#### PR validation:

Bot tests