### PR TITLE
Fix 'Assigned value is garbage or undefined' warning from llvm-analyzer in EcalTBHodoscopeRecInfoAlgo

### DIFF
--- a/RecoTBCalo/EcalTBHodoscopeReconstructor/src/EcalTBHodoscopeRecInfoAlgo.cc
+++ b/RecoTBCalo/EcalTBHodoscopeReconstructor/src/EcalTBHodoscopeRecInfoAlgo.cc
@@ -93,9 +93,9 @@ void EcalTBHodoscopeRecInfoAlgo::fitLine(float& x,
 
 EcalTBHodoscopeRecInfo EcalTBHodoscopeRecInfoAlgo::reconstruct(const EcalTBHodoscopeRawInfo& hodoscopeRawInfo) const {
   // Reset Hodo data
-  float x, y = -100.0;
-  float xSlope, ySlope = 0.0;
-  float xQuality, yQuality = -100.0;
+  float x = -100.0, y = -100.0;
+  float xSlope = 0.0, ySlope = 0.0;
+  float xQuality = -100.0, yQuality = -100.0;
 
   int nclus[4];
   std::vector<int> xclus[4];


### PR DESCRIPTION
#### PR description:

Log: [link](https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_14_2_X_2024-09-16-1100/el8_amd64_gcc12/llvm-analysis/report-1f05cf.html#EndPath)

#### PR validation:

Bot tests