### PR TITLE
Fix HLTPhoton187L1SeededSequence

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTPhoton187L1SeededSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTPhoton187L1SeededSequence_cfi.py
@@ -27,5 +27,6 @@ HLTPhoton187L1SeededSequence = cms.Sequence(HLTL1Sequence
                                             +hltEgammaHGCALIDVarsL1Seeded
                                             +hltPhoton187HgcalHEL1SeededFilter
                                             +HLTEGammaDoLocalHcalSequence
+                                            +hltEgammaHoverEL1Seeded
                                             +HLTFastJetForEgammaSequence
                                             +hltPhoton187HEL1SeededFilter)


### PR DESCRIPTION
The sequence `HLTPhoton187L1SeededSequence` was missing a producer, namely `hltEgammaHoverEL1Seeded`. It is not clear why the bug has never been discovered previously. The suspicion is that with the previous L1T Menu (the one before the 2024 AR), this path was reusing the results of the missing producer from other EGamma paths.

