### PR TITLE
Fixes mismatches between emulator and fw on CDC dimuon seed

### DIFF
--- a/L1Trigger/L1TGlobal/interface/GlobalBoard.h
+++ b/L1Trigger/L1TGlobal/interface/GlobalBoard.h
@@ -84,7 +84,9 @@ namespace l1t {
     void receiveMuonObjectData(const edm::Event&,
                                const edm::EDGetTokenT<BXVector<l1t::Muon>>&,
                                const bool receiveMu,
-                               const int nrL1Mu);
+                               const int nrL1Mu,
+                               const std::vector<l1t::Muon>* muonVec_bxm2,
+                               const std::vector<l1t::Muon>* muonVec_bxm1);
 
     void receiveMuonShowerObjectData(const edm::Event&,
                                      const edm::EDGetTokenT<BXVector<l1t::MuonShower>>&,

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
@@ -266,6 +266,10 @@ L1TGlobalProducer::L1TGlobalProducer(const edm::ParameterSet& parSet)
 
   m_currentLumi = 0;
 
+  //
+  std::vector<l1t::Muon> muonVec_bxm2;
+  std::vector<l1t::Muon> muonVec_bxm1;
+
   // Set default, initial, dummy prescale factor table
   std::vector<std::vector<double>> temp_prescaleTable;
 
@@ -641,7 +645,7 @@ void L1TGlobalProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSet
                                   receiveEtSumsZdc,
                                   receiveCICADA);
 
-  m_uGtBrd->receiveMuonObjectData(iEvent, m_muInputToken, receiveMu, m_nrL1Mu);
+  m_uGtBrd->receiveMuonObjectData(iEvent, m_muInputToken, receiveMu, m_nrL1Mu, &muonVec_bxm2, &muonVec_bxm1);
 
   if (m_useMuonShowers)
     m_uGtBrd->receiveMuonShowerObjectData(iEvent, m_muShowerInputToken, receiveMuShower, m_nrL1MuShower);
@@ -700,6 +704,13 @@ void L1TGlobalProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSet
 
   }  //End Loop over Bx
 
+  muonVec_bxm2 = muonVec_bxm1;
+  muonVec_bxm1.clear();
+  for (std::vector<const l1t::Muon*>::const_iterator iMu = (*(m_uGtBrd->getCandL1Mu())).begin(0);
+       iMu != (*(m_uGtBrd->getCandL1Mu())).end(0);
+       ++iMu) {
+    muonVec_bxm1.push_back(**iMu);
+  }
   // Add explicit reset of Board
   m_uGtBrd->reset();
 

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.h
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.h
@@ -202,6 +202,10 @@ private:
 
   //switch to save axo scores in global board
   bool m_produceAXOL1TLScore;
+
+  //vectors to store muon data for previous relative bx crossings
+  std::vector<l1t::Muon> muonVec_bxm2;
+  std::vector<l1t::Muon> muonVec_bxm1;
 };
 
 #endif  // L1TGlobalProducer_h

--- a/L1Trigger/L1TGlobal/src/GlobalBoard.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalBoard.cc
@@ -376,7 +376,9 @@ void l1t::GlobalBoard::receiveCaloObjectData(const edm::Event& iEvent,
 void l1t::GlobalBoard::receiveMuonObjectData(const edm::Event& iEvent,
                                              const edm::EDGetTokenT<BXVector<l1t::Muon>>& muInputToken,
                                              const bool receiveMu,
-                                             const int nrL1Mu) {
+                                             const int nrL1Mu,
+                                             const std::vector<l1t::Muon>* muonVec_bxm2,
+                                             const std::vector<l1t::Muon>* muonVec_bxm1) {
   if (m_verbosity) {
     LogDebug("L1TGlobal") << "\n**** GlobalBoard receiving muon data = ";
     //<< "\n     from input tag " << muInputTag << "\n"
@@ -403,16 +405,45 @@ void l1t::GlobalBoard::receiveMuonObjectData(const edm::Event& iEvent,
 
         //Loop over Muons in this bx
         int nObj = 0;
-        for (std::vector<l1t::Muon>::const_iterator mu = muonData->begin(i); mu != muonData->end(i); ++mu) {
-          if (nObj < nrL1Mu) {
-            (*m_candL1Mu).push_back(i, &(*mu));
-          } else {
-            edm::LogWarning("L1TGlobal") << " Too many Muons (" << nObj << ") for uGT Configuration maxMu =" << nrL1Mu;
-          }
+        if (i == -2) {
+          for (std::vector<l1t::Muon>::const_iterator mu = muonVec_bxm2->begin(); mu != muonVec_bxm2->end(); ++mu) {
+            if (nObj < nrL1Mu) {
+              (*m_candL1Mu).push_back(i, &(*mu));
+            } else {
+              edm::LogWarning("L1TGlobal")
+                  << " Too many Muons (" << nObj << ") for uGT Configuration maxMu =" << nrL1Mu;
+            }
 
-          LogDebug("L1TGlobal") << "Muon  Pt " << mu->hwPt() << " EtaAtVtx  " << mu->hwEtaAtVtx() << " PhiAtVtx "
-                                << mu->hwPhiAtVtx() << "  Qual " << mu->hwQual() << "  Iso " << mu->hwIso();
-          nObj++;
+            LogDebug("L1TGlobal") << "Muon  Pt " << mu->hwPt() << " EtaAtVtx  " << mu->hwEtaAtVtx() << " PhiAtVtx "
+                                  << mu->hwPhiAtVtx() << "  Qual " << mu->hwQual() << "  Iso " << mu->hwIso();
+            nObj++;
+          }
+        } else if (i == -1) {
+          for (std::vector<l1t::Muon>::const_iterator mu = muonVec_bxm1->begin(); mu != muonVec_bxm1->end(); ++mu) {
+            if (nObj < nrL1Mu) {
+              (*m_candL1Mu).push_back(i, &(*mu));
+            } else {
+              edm::LogWarning("L1TGlobal")
+                  << " Too many Muons (" << nObj << ") for uGT Configuration maxMu =" << nrL1Mu;
+            }
+
+            LogDebug("L1TGlobal") << "Muon  Pt " << mu->hwPt() << " EtaAtVtx  " << mu->hwEtaAtVtx() << " PhiAtVtx "
+                                  << mu->hwPhiAtVtx() << "  Qual " << mu->hwQual() << "  Iso " << mu->hwIso();
+            nObj++;
+          }
+        } else {
+          for (std::vector<l1t::Muon>::const_iterator mu = muonData->begin(i); mu != muonData->end(i); ++mu) {
+            if (nObj < nrL1Mu) {
+              (*m_candL1Mu).push_back(i, &(*mu));
+            } else {
+              edm::LogWarning("L1TGlobal")
+                  << " Too many Muons (" << nObj << ") for uGT Configuration maxMu =" << nrL1Mu;
+            }
+
+            LogDebug("L1TGlobal") << "Muon  Pt " << mu->hwPt() << " EtaAtVtx  " << mu->hwEtaAtVtx() << " PhiAtVtx "
+                                  << mu->hwPhiAtVtx() << "  Qual " << mu->hwQual() << "  Iso " << mu->hwIso();
+            nObj++;
+          }
         }  //end loop over muons in bx
       }  //end loop over bx
     }  //end if over valid muon data


### PR DESCRIPTION
#### PR description:

Corrects mismatches between emulator and firmware from L1_CDC_SingleMu_3_er1p2_TOP120_DPHI2p618_3p142
This particular algorithm requires muon information from the current bunch crossing and the previous bunch crossing, this fix stores the previous bunch crossings in vectors so that the emulator can continue to access this muon data to check the conditions of this algorithm.

No changes are expected in the output.
This PR does not rely on any other PRs or externals.

#### PR validation:

Performed runTheMatrix with -l 11634.0, passed 5 out of 5 tests.
Test vector code was in agreement with firmware.
Changes were checked against "scram build code-format" to ensure they followed CMS Naming, Coding and Style Rules.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not a backport