### PR TITLE
[LLVM analyzer] Assigned value is garbage or undefined in L1GctInternEtSum.cc

### DIFF
--- a/DataFormats/L1GlobalCaloTrigger/src/L1GctInternEtSum.cc
+++ b/DataFormats/L1GlobalCaloTrigger/src/L1GctInternEtSum.cc
@@ -1,7 +1,7 @@
 #include "DataFormats/L1GlobalCaloTrigger/interface/L1GctInternEtSum.h"
 #include <cstdint>
 
-L1GctInternEtSum::L1GctInternEtSum() {}
+L1GctInternEtSum::L1GctInternEtSum() : data_(0) {}
 
 /// construct from individual quantities
 L1GctInternEtSum::L1GctInternEtSum(uint16_t capBlock, uint16_t capIndex, int16_t bx, uint32_t et, uint8_t oflow)


### PR DESCRIPTION
#### PR description:

LLVM [reports](https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_14_2_X_2024-09-16-1100/el8_amd64_gcc12/llvm-analysis/report-9eca1d.html#EndPath) that `data_` is used uninitialized [here](https://github.com/cms-sw/cmssw/blob/master/DataFormats/L1GlobalCaloTrigger/src/L1GctInternEtSum.cc#L144). 

#### PR validation:

Bot tests