### PR TITLE
CICADA L1TTtuples Data Format Update

### DIFF
--- a/L1Trigger/L1TNtuples/plugins/L1CaloSummaryTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1CaloSummaryTreeProducer.cc
@@ -21,6 +21,7 @@
 
 #include "DataFormats/L1CaloTrigger/interface/L1CaloCollections.h"
 #include "DataFormats/L1CaloTrigger/interface/L1CaloRegion.h"
+#include "DataFormats/L1CaloTrigger/interface/CICADA.h"
 
 class L1CaloSummaryTreeProducer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
@@ -36,14 +37,14 @@ public:
   L1Analysis::L1AnalysisCaloSummaryDataFormat* caloSummaryData_;
 
 private:
-  const edm::EDGetTokenT<float> scoreToken_;
+  const edm::EDGetTokenT<l1t::CICADABxCollection> scoreToken_;
   const edm::EDGetTokenT<L1CaloRegionCollection> regionToken_;
   edm::Service<TFileService> fs_;
   TTree* tree_;
 };
 
 L1CaloSummaryTreeProducer::L1CaloSummaryTreeProducer(const edm::ParameterSet& iConfig)
-    : scoreToken_(consumes<float>(iConfig.getUntrackedParameter<edm::InputTag>("scoreToken"))),
+  : scoreToken_(consumes<l1t::CICADABxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("scoreToken"))),
       regionToken_(consumes<L1CaloRegionCollection>(iConfig.getUntrackedParameter<edm::InputTag>("regionToken"))) {
   usesResource(TFileService::kSharedResource);
   tree_ = fs_->make<TTree>("L1CaloSummaryTree", "L1CaloSummaryTree");
@@ -67,10 +68,10 @@ void L1CaloSummaryTreeProducer::analyze(const edm::Event& iEvent, const edm::Eve
     edm::LogWarning("L1Ntuple") << "Could not find region regions. CICADA model input will not be filled";
   }
 
-  edm::Handle<float> score;
+  edm::Handle<l1t::CICADABxCollection> score;
   iEvent.getByToken(scoreToken_, score);
   if (score.isValid())
-    caloSummaryData_->CICADAScore = *score;
+    caloSummaryData_->CICADAScore = score->at(0, 0);
   else
     edm::LogWarning("L1Ntuple") << "Could not find a proper CICADA score. CICADA score will not be filled.";
 

--- a/L1Trigger/L1TNtuples/plugins/L1CaloSummaryTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1CaloSummaryTreeProducer.cc
@@ -44,7 +44,7 @@ private:
 };
 
 L1CaloSummaryTreeProducer::L1CaloSummaryTreeProducer(const edm::ParameterSet& iConfig)
-  : scoreToken_(consumes<l1t::CICADABxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("scoreToken"))),
+    : scoreToken_(consumes<l1t::CICADABxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("scoreToken"))),
       regionToken_(consumes<L1CaloRegionCollection>(iConfig.getUntrackedParameter<edm::InputTag>("regionToken"))) {
   usesResource(TFileService::kSharedResource);
   tree_ = fs_->make<TTree>("L1CaloSummaryTree", "L1CaloSummaryTree");


### PR DESCRIPTION
#### PR description:

This PR changes the CICADA data format in the L1T Ntuples collection to be the correct data format (BX vector) introduced with the unpacker changes. These changes are non-urgent.

#### PR validation:

This PR has been tested to compile, have formatting applied, and appropriately produce the ntuples in L1 ReEmulation

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not a backport and is not expected to be backported
