### PR TITLE
Replace buggy UL2016 EGM energy correction files

### DIFF
--- a/PhysicsTools/NanoAOD/python/electrons_cff.py
+++ b/PhysicsTools/NanoAOD/python/electrons_cff.py
@@ -127,12 +127,12 @@ calibratedPatElectronsNano = RecoEgamma.EgammaTools.calibratedEgammas_cff.calibr
 
 (run2_egamma_2016 & tracker_apv_vfp30_2016).toModify(
     calibratedPatElectronsNano,
-    correctionFile = "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2016_UltraLegacy_preVFP_RunFineEtaR9Gain"
+    correctionFile = "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2016_UltraLegacy_preVFP_RunFineEtaR9Gain_v3"
 )
 
 (run2_egamma_2016 & ~tracker_apv_vfp30_2016).toModify(
     calibratedPatElectronsNano,
-    correctionFile = "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2016_UltraLegacy_postVFP_RunFineEtaR9Gain"
+    correctionFile = "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2016_UltraLegacy_postVFP_RunFineEtaR9Gain_v1"
 )
 
 run2_egamma_2017.toModify(

--- a/PhysicsTools/NanoAOD/python/photons_cff.py
+++ b/PhysicsTools/NanoAOD/python/photons_cff.py
@@ -96,18 +96,17 @@ seedGainPho = cms.EDProducer("PhotonSeedGainProducer", src = cms.InputTag("slimm
 import RecoEgamma.EgammaTools.calibratedEgammas_cff
 
 calibratedPatPhotonsNano = RecoEgamma.EgammaTools.calibratedEgammas_cff.calibratedPatPhotons.clone(
-    produceCalibratedObjs = False,
-    correctionFile = cms.string("EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2016_UltraLegacy_preVFP_RunFineEtaR9Gain"),
+    produceCalibratedObjs = False
 )
 
 (run2_egamma_2016 & tracker_apv_vfp30_2016).toModify(
     calibratedPatPhotonsNano,
-    correctionFile = cms.string("EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2016_UltraLegacy_preVFP_RunFineEtaR9Gain")
+    correctionFile = cms.string("EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2016_UltraLegacy_preVFP_RunFineEtaR9Gain_v3")
 )
 
 (run2_egamma_2016 & ~tracker_apv_vfp30_2016).toModify(
     calibratedPatPhotonsNano,
-    correctionFile = cms.string("EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2016_UltraLegacy_postVFP_RunFineEtaR9Gain"),
+    correctionFile = cms.string("EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2016_UltraLegacy_postVFP_RunFineEtaR9Gain_v1"),
 )
 
 run2_egamma_2017.toModify(

--- a/RecoEgamma/EgammaTools/python/calibratedEgammas_cff.py
+++ b/RecoEgamma/EgammaTools/python/calibratedEgammas_cff.py
@@ -2,8 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 _correctionFile2016Legacy    = "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Legacy2016_07Aug2017_FineEtaR9_v3_ele_unc"
 _correctionFile2017Nov17     = "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2017_17Nov2017_v1_ele_unc"
-_correctionFile2016ULpreVFP  = "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2016_UltraLegacy_preVFP_RunFineEtaR9Gain"
-_correctionFile2016ULpostVFP = "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2016_UltraLegacy_postVFP_RunFineEtaR9Gain"
+_correctionFile2016ULpreVFP  = "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2016_UltraLegacy_preVFP_RunFineEtaR9Gain_v3"
+_correctionFile2016ULpostVFP = "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2016_UltraLegacy_postVFP_RunFineEtaR9Gain_v1"
 _correctionFile2017UL        = "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2017_24Feb2020_runEtaR9Gain_v2"
 _correctionFile2018UL        = "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2018_29Sep2020_RunFineEtaR9Gain"
 


### PR DESCRIPTION
#### PR description:

Replacing buggy UL2016 electron & photon energy correction data files, following the [CMS talk thread](https://cms-talk.web.cern.ch/t/issue-with-photons-with-1-5-eta-2-0-specific-to-2016prevfp-ul/44247) and in preparation for the potential Run2 ReMiniAOD-ReNanoAOD campaign future (previously, the latest correction files only existed in the [private repo](https://github.com/jainshilpi/EgammaAnalysis-ElectronTools/tree/ULSSfiles_correctScaleSysMC) - there was an [official prescription](https://twiki.cern.ch/twiki/bin/viewauth/CMS/EgammaUL2016To2018#Scale_and_smearing_corrections_f) to this for UL MiniAODv2, but it sneaked into the NanoAOD and became persistent since the newest data files were never merged to the official repo).

This PR is supposed to be work together with the data file update in cms-data/EgammaAnalysis-ElectronTools#12 (please see the discussion in this PR for more details).


