### PR TITLE
[14_1_X] Replace CUDA with Alpaka wf in `relval_2026.py`

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_2026.py
+++ b/Configuration/PyReleaseValidation/python/relval_2026.py
@@ -42,8 +42,7 @@ numWFIB.extend([prefixDet+34.911]) #DD4hep XML
 numWFIB.extend([prefixDet+34.702]) #mkFit tracking (initialStep)
 numWFIB.extend([prefixDet+34.5])   #pixelTrackingOnly
 numWFIB.extend([prefixDet+34.9])   #vector hits
-numWFIB.extend([prefixDet+34.501]) #Patatrack local reconstruction on CPU
-numWFIB.extend([prefixDet+34.502]) #Patatrack local reconstruction on GPU
+numWFIB.extend([prefixDet+34.402]) # Alpaka reconstruction on Device (if available)
 numWFIB.extend([prefixDet+34.21])  #prodlike
 numWFIB.extend([prefixDet+96.0])   #CloseByPGun CE_E_Front_120um
 numWFIB.extend([prefixDet+100.0])  #CloseByPGun CE_H_Coarse_Scint


### PR DESCRIPTION
#### PR description:

Backport of https://github.com/cms-sw/cmssw/pull/45980. Fixes the [IB failures for `14_1_0_X`](https://cmssdt.cern.ch/SDT/html/cmssdt-ib/#/relVal/CMSSW_14_1/2024-09-17-2300?selectedArchs=el8_aarch64_gcc12&selectedFlavors=X&selectedStatus=failed). 
