### PR TITLE
Fix ordering of modules in HLT_TriMu_10_5_5_DZ_FromL1TkMuon path.

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_TriMu_10_5_5_DZ_FromL1TkMuon_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_TriMu_10_5_5_DZ_FromL1TkMuon_cfi.py
@@ -9,14 +9,9 @@ from ..sequences.HLTHgcalLocalRecoSequence_cfi import *
 from ..sequences.HLTDoLocalHcalSequence_cfi import *
 from ..sequences.HLTDoFullUnpackingEgammaEcalSequence_cfi import *
 from ..sequences.HLTFastJetForEgammaSequence_cfi import *
-from ..sequences.HLTIter0Phase2L3FromL1TkSequence_cfi import *
-from ..sequences.HLTIter2Phase2L3FromL1TkSequence_cfi import *
 from ..sequences.HLTPfClusteringHBHEHFSequence_cfi import *
-from ..sequences.HLTPhase2L3FromL1TkSequence_cfi import *
-from ..sequences.HLTPhase2L3OISequence_cfi import *
-from ..sequences.HLTPhase2L3MuonsSequence_cfi import *
-from ..sequences.HLTL2MuonsFromL1TkSequence_cfi import *
 from ..sequences.HLTPFClusteringForEgammaUnseededSequence_cfi import *
+from ..sequences.HLTMuonsSequence_cfi import *
 from ..modules.hltPhase2PixelFitterByHelixProjections_cfi import *
 from ..modules.hltPhase2PixelTrackFilterByKinematics_cfi import *
 from ..modules.hltL3fL1TkTripleMu533L31055DZFiltered0p2_cfi import *
@@ -31,16 +26,11 @@ HLT_TriMu_10_5_5_DZ_FromL1TkMuon = cms.Path(HLTBeginSequence
     +HLTRawToDigiSequence
     +HLTItLocalRecoSequence
     +HLTOtLocalRecoSequence
-    +HLTL2MuonsFromL1TkSequence
-    +HLTPhase2L3MuonsSequence
-    +hltL3fL1TkTripleMu533PreFiltered555
-    +hltL3fL1TkTripleMu533L3Filtered1055
-    +HLTPhase2L3FromL1TkSequence
     +hltPhase2PixelFitterByHelixProjections
     +hltPhase2PixelTrackFilterByKinematics
-    +HLTIter0Phase2L3FromL1TkSequence
-    +HLTIter2Phase2L3FromL1TkSequence
-    +HLTPhase2L3OISequence
+    +HLTMuonsSequence
+    +hltL3fL1TkTripleMu533PreFiltered555
+    +hltL3fL1TkTripleMu533L3Filtered1055
     +hltL3fL1TkTripleMu533L31055DZFiltered0p2
     +HLTEndSequence)
 #


### PR DESCRIPTION
#### PR description:

The ordering of the modules as currently defined in this path is severely buggy and will result in an unrunnable schedule if this path is the only one scheduled. Once again, this problem surfaced while using the new L1T menu in 14_2_0_pre1, but the scheduling problem has been there for a while but has gone unnoticed so far.

#### PR validation:

It was tested running an ad-hoc menu with only the HLT_TriMu_10_5_5_DZ_FromL1TkMuon path. Runs w/o errors.

