### PR TITLE
[phase2] add missing ESProducers to timing menu for running alpaka tracking

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33_timing_cff.py
+++ b/HLTrigger/Configuration/python/HLT_75e33_timing_cff.py
@@ -97,6 +97,10 @@ fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPKFTrajectorySm
 
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/trackdnn_source_cfi")
 
+fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPPixelCPEFastParams_cfi")
+fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPSiPixelCablingSoA_cfi")
+fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPSiPixelGainCalibrationForHLTSoA_cfi")
+
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_AK4PFPuppiJet520_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_Diphoton30_23_IsoCaloId_L1Seeded_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_DoubleEle23_12_Iso_L1Seeded_cfi")


### PR DESCRIPTION
#### PR description:

Following https://github.com/cms-sw/cmssw/pull/45508/ , this PR adds three missing ESProducers to the timing menu of phase2 needed to run patatrack tracking with alpaka.

#### PR validation:
I have run the timing menu locally on lxplus, [circles](https://lguzzi.web.cern.ch/lguzzi/circles/web/piechart.php?local=false&dataset=Phase2_fullMenu_alpakaTracking_12sept2024&resource=time_thread&colours=default&groups=hlt&show_labels=true&threshold=0) looks ok

```bash
cmsDriver.py Phase2 -s L1P2GT,HLT:75e33_timing --processName=HLTX \
  --conditions auto:phase2_realistic_T33 \
  --geometry Extended2026D110 \
  --era Phase2C17I13M9 \
  --eventcontent FEVTDEBUGHLT \
  --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000 \
  --filein file:output_Phase2_reL1T.root \
  --inputCommands='keep *, drop *_hlt*_*_HLT, drop triggerTriggerFilterObjectWithRefs_l1t*_*_HLT' \
  --mc --procModifiers alpaka \
  -n 100 --nThreads 1 --output={} 
```

 
#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
not a backport 
