### PR TITLE
Introduce era modifier run3_nanoAOD_pre142X

### DIFF
--- a/Configuration/Eras/python/Modifier_run3_nanoAOD_pre142X_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_nanoAOD_pre142X_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+run3_nanoAOD_pre142X = cms.Modifier()

--- a/Configuration/PyReleaseValidation/python/relval_nano.py
+++ b/Configuration/PyReleaseValidation/python/relval_nano.py
@@ -148,7 +148,7 @@ steps['NANO_data_UL18reMINI'] = merge([{'--era': 'Run2_2018',
 steps['TTbarMINIAOD13.0'] = {'INPUT': InputInfo(
     location='STD', dataSet='/TTtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v2/MINIAODSIM')}
 
-steps['NANO_mc13.0'] = merge([{'--era': 'Run3', '--conditions': 'auto:phase1_2023_realistic'},
+steps['NANO_mc13.0'] = merge([{'--era': 'Run3,run3_nanoAOD_pre142X', '--conditions': 'auto:phase1_2023_realistic'},
                               _NANO_mc])
 
 
@@ -160,7 +160,7 @@ steps['ScoutingPFRun32022RAW13.0'] = {'INPUT': InputInfo(
     dataSet='/ScoutingPFRun3/Run2022D-v1/RAW', label='2022D', events=100000, location='STD', ls=Run2022D)}
 
 
-steps['NANO_data13.0'] = merge([{'--era': 'Run3', '--conditions': 'auto:run3_data'},
+steps['NANO_data13.0'] = merge([{'--era': 'Run3,run3_nanoAOD_pre142X', '--conditions': 'auto:run3_data'},
                                 _NANO_data])
 
 steps['NANO_data13.0_prompt'] = merge([{'-s': 'NANO:@Prompt,DQM:@nanoAODDQM', '-n': '1000'},
@@ -176,7 +176,7 @@ steps['scoutingNANO_data13.0'] = merge([{'-s': 'NANO:@Scout'},
 steps['TTbarMINIAOD14.0'] = {'INPUT': InputInfo(
     location='STD', dataSet='/RelValTTbar_14TeV/CMSSW_14_0_0-PU_140X_mcRun3_2024_realistic_v3_STD_2024_PU-v2/MINIAODSIM')}
 
-steps['NANO_mc14.0'] = merge([{'--era': 'Run3', '--conditions': 'auto:phase1_2024_realistic'},
+steps['NANO_mc14.0'] = merge([{'--era': 'Run3,run3_nanoAOD_pre142X', '--conditions': 'auto:phase1_2024_realistic'},
                               _NANO_mc])
 
 steps['muPOGNANO_mc14.0'] = merge([{'-s': 'NANO:@MUPOG,DQM:@nanoAODDQM', '-n': '1000'},
@@ -217,7 +217,7 @@ steps['ZeroBias2024RAW14.0'] = {'INPUT': InputInfo(location='STD', ls=lumis_Run2
 steps['TestEnablesEcalHcal2024RAW14.0'] = {'INPUT': InputInfo(location='STD', ls={383173: [[151, 162]]},
                                                               dataSet='/TestEnablesEcalHcal/Run2024F-Express-v1/RAW')}
 
-steps['NANO_data14.0'] = merge([{'--era': 'Run3_2024', '--conditions': 'auto:run3_data_prompt'},
+steps['NANO_data14.0'] = merge([{'--era': 'Run3_2024,run3_nanoAOD_pre142X', '--conditions': 'auto:run3_data_prompt'},
                                 _NANO_data])
 
 steps['NANO_data14.0_prompt'] = merge([{'-s': 'NANO:@Prompt,DQM:@nanoAODDQM', '-n': '1000'},

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -91,7 +91,7 @@ class Eras (object):
                            'trackingPhase2PU140','highBetaStar_2018',
                            'tracker_apv_vfp30_2016', 'pf_badHcalMitigationOff',
                            'run2_nanoAOD_106Xv2',
-                           'run3_nanoAOD_122', 'run3_nanoAOD_124',
+                           'run3_nanoAOD_122', 'run3_nanoAOD_124', 'run3_nanoAOD_pre142X',
                            'run3_ecal_devel',
                            'run3_upc',
                            'hcalHardcodeConditions', 'hcalSkipPacker',

--- a/PhysicsTools/NanoAOD/python/nano_eras_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_eras_cff.py
@@ -19,6 +19,7 @@ from Configuration.Eras.Modifier_tracker_apv_vfp30_2016_cff import tracker_apv_v
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 from Configuration.Eras.Modifier_run3_nanoAOD_122_cff import run3_nanoAOD_122
 from Configuration.Eras.Modifier_run3_nanoAOD_124_cff import run3_nanoAOD_124
+from Configuration.Eras.Modifier_run3_nanoAOD_pre142X_cff import run3_nanoAOD_pre142X
 from Configuration.Eras.Modifier_run3_jme_Winter22runsBCDEprompt_cff import run3_jme_Winter22runsBCDEprompt
 
 run2_nanoAOD_ANY = (


### PR DESCRIPTION
#### PR description:

This PR introduces a new era modifier, `run3_nanoAOD_pre142X`, for running the NANO step from pre-14_2_X Run3 MiniAODs (e.g., 13_0_X and 14_0_X). This will allow for developments that move some sequences/products from the NANO step to the MINI step.

This resolves https://github.com/cms-sw/cmssw/issues/46038.

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

`runTheMatrix.py -w nano --ibeos -l 2500.101,2500.111,2500.201,2500.211`