### PR TITLE
Handle setting module parameters from a dict or PSet

### DIFF
--- a/FWCore/ParameterSet/python/Mixins.py
+++ b/FWCore/ParameterSet/python/Mixins.py
@@ -174,15 +174,7 @@ class _Parameterizable(object):
         self.__dict__['_Parameterizable__validator'] = None
         """The named arguments are the 'parameters' which are added as 'python attributes' to the object"""
         if len(arg) != 0:
-            #raise ValueError("unnamed arguments are not allowed. Please use the syntax 'name = value' when assigning arguments.")
-            for block in arg:
-                # Allow __PSet for testing
-                if type(block).__name__ not in ["PSet", "__PSet", "dict"]:
-                    raise ValueError("Only PSets can be passed as unnamed argument blocks.  This is a "+type(block).__name__)
-                if isinstance(block,dict):
-                    kargs = block
-                else:
-                    self.__setParameters(block.parameters_())
+            self.__setParametersFromArg(*arg)
         self.__setParameters(kargs)
         self._isModified = False
         
@@ -258,6 +250,15 @@ class _Parameterizable(object):
         self.__dict__[name]=value
         self.__parameterNames.append(name)
         self._isModified = True
+    def __setParametersFromArg(self, *arg):
+        for block in arg:
+            # Allow __PSet for testing
+            if type(block).__name__ not in ["PSet", "__PSet", "dict"]:
+                raise ValueError("Only PSets can be passed as unnamed argument blocks.  This is a "+type(block).__name__)
+            if isinstance(block,dict):
+                self.__setParameters(block)
+            else:
+                self.__setParameters(block.parameters_())
 
     def __setParameters(self,parameters):
         v = None
@@ -290,6 +291,19 @@ class _Parameterizable(object):
             else:
                 self.__dict__[name].setValue(value)
             self._isModified = True
+    def update_(self, d):
+        """"Takes a PSet or dict and adds the entries as parameters. Already existing parameters will be overwritten.
+        """
+        if type(d).__name__ not in ["PSet", "__PSet", "dict"]:
+            raise ValueError("Only PSets or dicts can be passed to update_.  This is a "+type(d).__name__)
+        if isinstance(d,dict):
+            for k,v in d.items():
+                setattr(self, k, v)
+        else:
+            for k,v in d.parameters_().items():
+                setattr(self,k,v)
+
+
 
     def isFrozen(self) -> bool:
         return self._isFrozen
@@ -828,6 +842,29 @@ if __name__ == "__main__":
             self.assertEqual(b.a.value(), 1)
             self.assertEqual(b.b.value(), 2)
             self.assertRaises(ValueError, lambda: __Test("MyType", __PSet(a=__TestType(1)), __PSet(a=__TestType(2))))
+            c = __Test("MyType", dict(a=__TestType(1)), dict(b=__TestType(2)))
+            self.assertEqual(c.a.value(), 1)
+            self.assertEqual(c.b.value(), 2)
+            self.assertRaises(ValueError, lambda: __Test("MyType", dict(a=__TestType(1)), dict(a=__TestType(2))))
+        def testUpdate_(self):
+            class __Test(_TypedParameterizable):
+                pass
+            class __TestType(_SimpleParameterTypeBase):
+                def _isValid(self,value):
+                    return True
+            class __PSet(_ParameterTypeBase,_Parameterizable):
+                def __init__(self,*arg,**args):
+                    #need to call the inits separately
+                    _ParameterTypeBase.__init__(self)
+                    _Parameterizable.__init__(self,*arg,**args)
+            a = __Test("MyType", a = __TestType(1))
+            a.update_(dict(b=__TestType(2)))
+            self.assertEqual(a.a.value(), 1)
+            self.assertEqual(a.b.value(), 2)
+            a.update_(dict(a=3))
+            self.assertEqual(a.a.value(), 3)
+            a.update_(__PSet(a=__TestType(5)))
+            self.assertEqual(a.a.value(), 5)
 
         def testCopy(self):
             class __Test(_TypedParameterizable):

--- a/FWCore/ParameterSet/python/Mixins.py
+++ b/FWCore/ParameterSet/python/Mixins.py
@@ -296,12 +296,10 @@ class _Parameterizable(object):
         """
         if type(d).__name__ not in ["PSet", "__PSet", "dict"]:
             raise ValueError("Only PSets or dicts can be passed to update_.  This is a "+type(d).__name__)
-        if isinstance(d,dict):
-            for k,v in d.items():
+
+        items = d.items() if isinstance(d, dict) else d.parameters_().items()
+        for k,v in items:
                 setattr(self, k, v)
-        else:
-            for k,v in d.parameters_().items():
-                setattr(self,k,v)
 
 
 
@@ -865,6 +863,7 @@ if __name__ == "__main__":
             self.assertEqual(a.a.value(), 3)
             a.update_(__PSet(a=__TestType(5)))
             self.assertEqual(a.a.value(), 5)
+            self.assertRaises(TypeError, lambda: a.update_(dict(c=6)))
 
         def testCopy(self):
             class __Test(_TypedParameterizable):

--- a/FWCore/ParameterSet/python/ModulesProxy.py
+++ b/FWCore/ParameterSet/python/ModulesProxy.py
@@ -7,10 +7,10 @@ class _ModuleProxy (object):
         self._package = package
         self._name = name
         self._caller = None
-    def __call__(self,**kwargs):
+    def __call__(self,*arg, **kwargs):
         if not self._caller:
             self._caller = getattr(importlib.import_module(self._package+'.'+self._name),self._name)
-        return self._caller(**kwargs)
+        return self._caller(*arg, **kwargs)
 
 
 def _setupProxies(fullName:str):

--- a/FWCore/ParameterSet/src/ConfigurationDescriptions.cc
+++ b/FWCore/ParameterSet/src/ConfigurationDescriptions.cc
@@ -191,7 +191,7 @@ namespace edm {
     }
     outFile << "import FWCore.ParameterSet.Config as cms\n\n";
     outFile << "def " << pluginName
-            << "(**kwargs):\n"
+            << "(*args, **kwargs):\n"
                "  mod = cms."
             << baseType_ << "('" << pluginName_ << "'";
 
@@ -201,8 +201,9 @@ namespace edm {
     iDesc.writeCfi(outFile, startWithComma, indentation, ops);
 
     outFile << ")\n"
-               "  for k,v in kwargs.items():\n"
-               "    setattr(mod, k, v)\n"
+               "  for a in args:\n"
+               "    mod.update_(a)\n"
+               "  mod.update_(kwargs)\n"
                "  return mod\n";
 
     outFile.close();


### PR DESCRIPTION
#### PR description:

- added update_ method to _Parameterizable to match behavior of dict.update
- can now pass a dict or PSet to new module initialization syntax to match behavior of old syntax.

#### PR validation:

Code compiles. New unit tests pass. Ran the new initialization syntax using a PSet by hand and it worked.