### PR TITLE
HcalZDCDetId fix for Run3 [CMSSW_14_0_X]

### DIFF
--- a/DataFormats/HcalDetId/interface/HcalZDCDetId.h
+++ b/DataFormats/HcalDetId/interface/HcalZDCDetId.h
@@ -24,7 +24,7 @@
 class HcalZDCDetId : public DetId {
 public:
   static constexpr uint32_t kZDCChannelMask1 = 0xF;
-  static constexpr uint32_t kZDCChannelMask2 = 0x7F;
+  static constexpr uint32_t kZDCChannelMask2 = 0x3F;
   static constexpr uint32_t kZDCSectionMask = 0x3;
   static constexpr uint32_t kZDCSectionOffset = 4;
   static constexpr uint32_t kZDCZsideMask = 0x40;


### PR DESCRIPTION
#### PR description:

Fix of a bug in Run3 update of the HcalZDCDetId https://github.com/cms-sw/cmssw/pull/43200
which prevented a proper serialization of the conditions for newly added Run3-specific ZDC readouts (RPD)

backport of #45033 (from @abdoulline)

#### PR validation:

Merged in CMSSW_14_1_X (and now also CMSSW_14_2_X) since a while