### PR TITLE
Fix duplication of TrigObj in nanoAOD

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/TriggerObjectTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/TriggerObjectTableProducer.cc
@@ -167,7 +167,7 @@ void TriggerObjectTableProducer::produce(edm::Event &iEvent, const edm::EventSet
     for (unsigned int j = 0; j < i; ++j) {
       const auto &obj2 = *selected[j].first;
       const auto &sel2 = *selected[j].second;
-      if (sel.id == sel2.id && abs(obj.pt() - obj2.pt()) < 1e-6 && deltaR2(obj, obj2) < 1e-6) {
+      if (sel.id == sel2.id && deltaR2(obj, obj2) < 1e-6) {
         selected_bits[sel.id][&obj2] |= selected_bits[sel.id][&obj];  //Keep filters from all the objects
         selected.erase(selected.begin() + i);
         i--;


### PR DESCRIPTION
#### PR description:

Remove the pT matching requirement in the TrigObj self-cleaning to allow objects with slightly different pT enter the cleaning. 

This PR is made after observing that most of the muons with pT>100 GeV are duplicated, or tripled, as TrigObj. This occurs because of the redundant reconstruction for Muons above 100 GeV (highPtTkMu, MuCascade, ...). 

This issue was presented in the following [XPOG meeting](https://indico.cern.ch/event/1450394/contributions/6106083/attachments/2921241/5127468/XPOG_Muon_Sept24.pdf), where this solution was proposed.

As a further check, we tested other objects that may be affected by this change (possible duplicates):

- Muons (Main target)
- Tau
- FatJet
- HT
- MHT

Alternatively, if this solution affect in any negative way other objects than Muons, we propose to modify the IF condition such that the pT matching is bypass only for Muon IDs

