### PR TITLE
Fix "Called C++ object pointer is null in JetResolution::parameterEtaEval"

### DIFF
--- a/CondFormats/JetMETObjects/src/JetResolution.cc
+++ b/CondFormats/JetMETObjects/src/JetResolution.cc
@@ -179,9 +179,12 @@ double JetResolution::parameterEtaEval(const std::string& parameterName, float e
     break;
   }
 
-  if (!func)
+  if (!func) {
     edm::LogError("ParameterNotFound") << "JetResolution::parameterEtaEval(): no parameter \"" << parameterName
                                        << "\" found" << std::endl;
+    throw cms::Exception("JetResolution")
+        << "JetResolution::parameterEtaEval(): no parameter \"" << parameterName << "\" found\n";
+  }
 
   std::vector<float> etas;
   etas.push_back(eta);


### PR DESCRIPTION
#### PR description:

Fixes #46071

#### PR validation:

Bot tests