### PR TITLE
Fix "Called C++ object pointer is null" in ApvAnalysisFactory::constructAuxiliaryApvClasses

### DIFF
--- a/CalibTracker/SiStripAPVAnalysis/src/ApvAnalysisFactory.cc
+++ b/CalibTracker/SiStripAPVAnalysis/src/ApvAnalysisFactory.cc
@@ -121,7 +121,7 @@ void ApvAnalysisFactory::constructAuxiliaryApvClasses(ApvAnalysis* theAPV, uint3
       return;
     }
   } else {
-    cout << "ApvAnalysisFactory: algorithm " << theAlgorithmType_ << " not supported" << endl:
+    cout << "ApvAnalysisFactory: algorithm " << theAlgorithmType_ << " not supported" << endl;
     return;
   }
 

--- a/CalibTracker/SiStripAPVAnalysis/src/ApvAnalysisFactory.cc
+++ b/CalibTracker/SiStripAPVAnalysis/src/ApvAnalysisFactory.cc
@@ -121,6 +121,7 @@ void ApvAnalysisFactory::constructAuxiliaryApvClasses(ApvAnalysis* theAPV, uint3
       return;
     }
   } else {
+    cout << "ApvAnalysisFactory: algorithm " << theAlgorithmType_ << " not supported" << endl:
     return;
   }
 

--- a/CalibTracker/SiStripAPVAnalysis/src/ApvAnalysisFactory.cc
+++ b/CalibTracker/SiStripAPVAnalysis/src/ApvAnalysisFactory.cc
@@ -118,7 +118,10 @@ void ApvAnalysisFactory::constructAuxiliaryApvClasses(ApvAnalysis* theAPV, uint3
       theCM = new MedianCommonModeCalculator();
     } else {
       cout << "Sorry Only Median is available for now, Mean and FastLinear are coming soon" << endl;
+      return;
     }
+  } else {
+    return;
   }
 
   if (theCommonMode)


### PR DESCRIPTION
#### PR description:

LLVM analyzer [reports](https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_14_2_X_2024-09-16-1100/el8_amd64_gcc12/llvm-analysis/report-818127.html#EndPath) "Called C++ object pointer is null" in `ApvAnalysisFactory::constructAuxiliaryApvClasses`. This PR adds early return statements to avoid this.

#### PR validation:

Bot tests