### PR TITLE
Fix "Called C++ object pointer is null" in DDCoreToDDXMLOutput::position

### DIFF
--- a/DetectorDescription/OfflineDBLoader/src/DDCoreToDDXMLOutput.cc
+++ b/DetectorDescription/OfflineDBLoader/src/DDCoreToDDXMLOutput.cc
@@ -784,25 +784,27 @@ void DDCoreToDDXMLOutput::position(const TGeoVolume& parent,
   xos << "<rChild name=\"" << childVolName << "\"/>" << std::endl;
 
   const auto matrix = child.GetMatrix();
-  if (matrix != nullptr && !matrix->IsIdentity()) {
-    auto rot = matrix->GetRotationMatrix();
-    if (cms::rotation_utils::rotHash(rot) != cms::rotation_utils::identityHash) {
-      std::string rotNameStr = cms::rotation_utils::rotName(rot, context);
-      if (rotNameStr == "NULL") {
-        rotNameStr = child.GetName();  // Phys vol name
-        rotNameStr += parent.GetName();
-        cms::DDNamespace nameSpace(context);
-        cms::rotation_utils::addRotWithNewName(nameSpace, rotNameStr, rot);
+  if (matrix != nullptr) {
+    if (!matrix->IsIdentity()) {
+      auto rot = matrix->GetRotationMatrix();
+      if (cms::rotation_utils::rotHash(rot) != cms::rotation_utils::identityHash) {
+        std::string rotNameStr = cms::rotation_utils::rotName(rot, context);
+        if (rotNameStr == "NULL") {
+          rotNameStr = child.GetName();  // Phys vol name
+          rotNameStr += parent.GetName();
+          cms::DDNamespace nameSpace(context);
+          cms::rotation_utils::addRotWithNewName(nameSpace, rotNameStr, rot);
+        }
+        xos << "<rRotation name=\"" << rotNameStr << "\"/>" << std::endl;
       }
-      xos << "<rRotation name=\"" << rotNameStr << "\"/>" << std::endl;
     }
+    auto trans = matrix->GetTranslation();
+    using namespace cms_rounding;
+    xos << "<Translation x=\"" << roundIfNear0(trans[0]) << "*mm\"";
+    xos << " y=\"" << roundIfNear0(trans[1]) << "*mm\"";
+    xos << " z=\"" << roundIfNear0(trans[2]) << "*mm\"";
+    xos << "/>" << std::endl;
   }
-  auto trans = matrix->GetTranslation();
-  using namespace cms_rounding;
-  xos << "<Translation x=\"" << roundIfNear0(trans[0]) << "*mm\"";
-  xos << " y=\"" << roundIfNear0(trans[1]) << "*mm\"";
-  xos << " z=\"" << roundIfNear0(trans[2]) << "*mm\"";
-  xos << "/>" << std::endl;
   xos << "</PosPart>" << std::endl;
 }
 


### PR DESCRIPTION
#### PR description:

LLVM Analyzer [reports](https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_14_2_X_2024-09-16-1100/el8_amd64_gcc12/llvm-analysis/report-bdaf3e.html#EndPath) "Called C++ object pointer is null" in `DDCoreToDDXMLOutput::position`. This PR protects from this.

#### PR validation:

Bot tests