### PR TITLE
make `test_dumpRecoGeometry` run faster

### DIFF
--- a/Fireworks/Geometry/python/dumpRecoGeometry_cfg.py
+++ b/Fireworks/Geometry/python/dumpRecoGeometry_cfg.py
@@ -220,7 +220,7 @@ recoGeoLoad(options.tag,properties)
 
 if ( options.tgeo == True):
     if (options.out == defaultOutputFileName ):
-        options.out = "cmsTGeoRecoGeom-" +  str(options.tag) + ".root"
+       options.out = "cmsTGeoRecoGeom-" + str(options.tag) + (f"_{options.version}" if options.version else "") + ".root"
     process.add_(cms.ESProducer("FWTGeoRecoGeometryESProducer",
                  Tracker = cms.untracked.bool(options.tracker),
                  Muon = cms.untracked.bool(options.muon),
@@ -232,7 +232,7 @@ if ( options.tgeo == True):
                               )
 else:
     if (options.out == defaultOutputFileName ):
-        options.out = "cmsRecoGeom-" +  str(options.tag) + ".root"
+       options.out = "cmsRecoGeom-" + str(options.tag) + (f"_{options.version}" if options.version else "") + ".root"
     process.add_(cms.ESProducer("FWRecoGeometryESProducer",
                  Tracker = cms.untracked.bool(options.tracker),
                  Muon = cms.untracked.bool(options.muon),

--- a/Fireworks/Geometry/test/BuildFile.xml
+++ b/Fireworks/Geometry/test/BuildFile.xml
@@ -1,1 +1,7 @@
-<test name="test_dumpRecoGeometry" command="test_dumpRecoGeometry.sh"/>
+<!-- Possible choices are "Run1" "2015" "2017" "2021" "2026" -->
+<test name="test_dumpRecoGeometry_Run1" command="test_dumpRecoGeometry.sh Run1"/>
+<test name="test_dumpRecoGeometry_2015" command="test_dumpRecoGeometry.sh 2015"/>
+<test name="test_dumpRecoGeometry_2017" command="test_dumpRecoGeometry.sh 2017"/>
+<!-- currently commented as it crashes at runtime -->
+<!-- <test name="test_dumpRecoGeometry_2021" command="test_dumpRecoGeometry.sh 2021"/> -->
+<test name="test_dumpRecoGeometry_2026" command="test_dumpRecoGeometry.sh 2026"/>


### PR DESCRIPTION
#### PR description:

The `test_dumpRecoGeometry` test script runs many `cmsRun` jobs and can time out in PR tests (see e.g. https://github.com/cms-sw/cmssw/pull/45999#issuecomment-2353723360). 
The script is refactored such that some of  these jobs can run in parallel.
   * one job per "year" (`Run1` `2015` `2017` `2026`)
   * the `2026` case (as it has an internal nested loop which is the most consuming part of the test) is run with 4 parallel `cmsRun` executions.

This resolves https://github.com/cms-sw/cmssw/issues/46053

#### PR validation:

`scram b runtests` runs successfully:

```console
>> Local Products Rules ..... started
>> Local Products Rules ..... done
>> Creating project symlinks
Creating test log file logs/el9_amd64_gcc12/testing.log
Pass    7s ... Fireworks/Geometry/test_dumpRecoGeometry_2015
Pass   10s ... Fireworks/Geometry/test_dumpRecoGeometry_2017
Pass  177s ... Fireworks/Geometry/test_dumpRecoGeometry_2026
Pass    6s ... Fireworks/Geometry/test_dumpRecoGeometry_Run1
>> Test sequence completed for CMSSW CMSSW_14_2_X_2024-09-19-2300
```

in about 3 and $1/2$ minutes, whereas before this PR it took around 10 minutes to complete.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A