### PR TITLE
Fix warning in MeasurementDet.h

### DIFF
--- a/TrackingTools/MeasurementDet/interface/MeasurementDet.h
+++ b/TrackingTools/MeasurementDet/interface/MeasurementDet.h
@@ -62,12 +62,13 @@ public:
     measurements(stateOnThisDet, est, data, tmps);
     std::vector<TrajectoryMeasurement> result;
     result.reserve(tmps.size());
-    int index[tmps.size()];
+    int* index = new int[tmps.size()];
     tmps.sortIndex(index);
     for (std::size_t i = 0; i != tmps.size(); ++i) {
       auto j = index[i];
       result.emplace_back(stateOnThisDet, std::move(tmps.hits[j]), tmps.distances[j]);
     }
+    delete[] index;
     return result;
   }
 


### PR DESCRIPTION
#### PR description:

Fix compilation warning:

```
>> Building LCG reflex dict from header file src/RecoTracker/MeasurementDet/src/classes.h
<...>
In file included from input_line_7:67:
In file included from src/RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h:14:
In file included from src/RecoTracker/MeasurementDet/interface/MeasurementTracker.h:4:
In file included from src/TrackingTools/MeasurementDet/interface/MeasurementDetSystem.h:5:
In file included from src/TrackingTools/MeasurementDet/interface/MeasurementDetWithData.h:4:
  src/TrackingTools/MeasurementDet/interface/MeasurementDet.h:65:15: warning: variable length arrays in C++ are a Clang extension [-Wvla-cxx-extension]
     int index[tmps.size()];
              ^~~~~~~~~~~
src/TrackingTools/MeasurementDet/interface/MeasurementDet.h:65:20: note: non-constexpr function 'size' cannot be used in a constant expression
    int index[tmps.size()];
                   ^
src/TrackingTools/MeasurementDet/interface/TempMeasurements.h:20:17: note: declared here
    std::size_t size() const { return hits.size(); }
                ^
```

#### PR validation:

Bot tests