### PR TITLE
[ALCA] [PY312] String formatting to fix SyntaxWarning

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/python/mpsvalidate/beamerCreator.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/mpsvalidate/beamerCreator.py
@@ -25,16 +25,16 @@ class Out:
         self.text += "\\begin{{frame}}[t]{{{0}}}\n".format(head)
         self.text += text
         self.text += """\\vfill
-                        \\rule{0.9\paperwidth}{1pt}
-                        \insertnavigation{0.89\paperwidth}
+                        \\rule{0.9\\paperwidth}{1pt}
+                        \\insertnavigation{0.89\\paperwidth}
                         \\end{frame}\n"""
                         
     def addSlide_fragile(self, head, text):
         self.text += "\\begin{{frame}}[fragile=singleslide]{{{0}}}\n".format(head)
         self.text += text
         self.text += """\\vfill
-                        \\rule{0.9\paperwidth}{1pt}
-                        \insertnavigation{0.89\paperwidth}
+                        \\rule{0.9\\paperwidth}{1pt}
+                        \\insertnavigation{0.89\\paperwidth}
                         \\end{frame}\n"""
                         
     def add(self, text):
@@ -59,19 +59,19 @@ def create(alignables, pedeDump, additionalData, outputFile, config):
     
     # title page
     if (config.message):
-        text += """\centering
+        text += """\\centering
                     \\vspace*{{4cm}}
-                    \Huge\\bfseries Alignment Validation\par
+                    \\Huge\\bfseries Alignment Validation\\par
                     \\vspace{{2cm}}	
-                    \scshape\huge Alignment Campaign\\\\ {{{0}}}\par
+                    \\scshape\\huge Alignment Campaign\\\\ {{{0}}}\\par
                     \\vfill
-                    \large \\today\par""".format(config.message)
+                    \\large \\today\\par""".format(config.message)
     else:
-        text += """\centering
+        text += """\\centering
                     \\vspace*{4cm}
-                    \Huge\\bfseries Alignment Validation\par
+                    \\Huge\\bfseries Alignment Validation\\par
                     \\vfill
-                    \large \\today\par"""
+                    \\large \\today\\par"""
     out.addSlide("", text)
     
     # table of contents
@@ -79,7 +79,7 @@ def create(alignables, pedeDump, additionalData, outputFile, config):
     out.addSlide("Overview", text)
 
     # general information
-    out.add("\section{General information}")
+    out.add("\\section{General information}")
     text = ""
     if (config.message):
         text = "Project: {{{0}}}\\\\\n".format(config.message)
@@ -91,7 +91,7 @@ def create(alignables, pedeDump, additionalData, outputFile, config):
     
     # alignment_merge.py
     try:
-        out.add("\subsection{Alignment Configuration}")
+        out.add("\\subsection{Alignment Configuration}")
         text = "\\textbf{{PedeSteerer method:}} {{{0}}}\\\\\n".format(
             additionalData.pede_steerer_method)
         text += "\\textbf{{PedeSteerer options:}}\\\\\n"
@@ -105,14 +105,14 @@ def create(alignables, pedeDump, additionalData, outputFile, config):
     
     # table of input files with number of tracks
     if config.showmonitor:
-        out.add("\subsection{Datasets with tracks}")
+        out.add("\\subsection{Datasets with tracks}")
         text = """\\begin{table}[h]
-            \centering
-            \caption{Datasets with tracks}
+            \\centering
+            \\caption{Datasets with tracks}
             \\begin{tabular}{ccc}
-            \hline
+            \\hline
             Dataset & Number of used tracks & Weight \\\\
-            \hline \n"""
+            \\hline \n"""
         try:
             for monitor in mpsv_classes.MonitorData.monitors:
                 text += "{0} & {1} & {2}\\\\\n".format(monitor.name, monitor.ntracks,
@@ -120,15 +120,15 @@ def create(alignables, pedeDump, additionalData, outputFile, config):
         except Exception as e:
             logger.error("data not found - {0} {1}".format(type(e), e))
         if (pedeDump.nrec):
-            text += "\hline\nNumber of records & {0}\\\\\n".format(pedeDump.nrec)
-        text += """\hline
-                  \end{tabular}\n
-                  \end{table}\n"""
+            text += "\\hline\nNumber of records & {0}\\\\\n".format(pedeDump.nrec)
+        text += """\\hline
+                  \\end{tabular}\n
+                  \\end{table}\n"""
         text += "The information in this table is based on the monitor root files. Note that the number of tracks which where used in the pede step can differ from this table.\n"
         out.addSlide("Datasets with tracks", text)
 
     # pede.dump.gz
-    out.add("\subsection{Pede monitoring information}")
+    out.add("\\subsection{Pede monitoring information}")
     try:
         if (pedeDump.sumValue != 0):
             text = r"\begin{{align*}}Sum(Chi^2)/Sum(Ndf) &= {0}\\ &= {1}\end{{align*}}".format(
@@ -149,20 +149,20 @@ def create(alignables, pedeDump, additionalData, outputFile, config):
         logger.error("data not found - {0} {1}".format(type(e), e))
         
     # Parameter plots
-    out.add("\section{Parameter plots}")
+    out.add("\\section{Parameter plots}")
     
     # high level Structures
-    out.add("\subsection{High-level parameters}")
+    out.add("\\subsection{High-level parameters}")
     big = [x for x in config.outputList if (x.plottype == "big")]
 
     for i in big:
-        text = "\includegraphics[height=0.85\\textheight]{{{0}/plots/pdf/{1}.pdf}}\n".format(
+        text = "\\includegraphics[height=0.85\\textheight]{{{0}/plots/pdf/{1}.pdf}}\n".format(
             config.outputPath, i.filename)
 
         out.addSlide("High-level parameters", text)
 
     # time (IOV) dependent plots
-    out.add("\subsection{High-level parameters versus time (IOV)}")
+    out.add("\\subsection{High-level parameters versus time (IOV)}")
     time = [x for x in config.outputList if (x.plottype == "time")]
 
     if time:
@@ -172,13 +172,13 @@ def create(alignables, pedeDump, additionalData, outputFile, config):
                 text = "\\framesubtitle{{{0}}}\n".format(structure)
                 if any([x.filename for x in time if (x.parameter == mode and x.name == structure)]):
                     filename = [x.filename for x in time if (x.parameter == mode and x.name == structure)][0]
-                    text += "\includegraphics[height=0.85\\textheight]{{{0}/plots/pdf/{1}.pdf}}\n".format(
+                    text += "\\includegraphics[height=0.85\\textheight]{{{0}/plots/pdf/{1}.pdf}}\n".format(
                         config.outputPath, filename)
 
                 out.addSlide("High-level parameters versus time (IOV)", text)
 
     # hole modules
-    out.add("\subsection{Module-level parameters}")
+    out.add("\\subsection{Module-level parameters}")
     # check if there are module plots
     if any(x for x in config.outputList if (x.plottype == "mod" and x.number == "")):
 
@@ -201,7 +201,7 @@ def create(alignables, pedeDump, additionalData, outputFile, config):
                     # check if plot there is a plot in this mode
                     if module:
                         text = "\\framesubtitle{{{0}}}\n".format(moduleName)
-                        text += "\includegraphics[height=0.85\\textheight]{{{0}/plots/pdf/{1}.pdf}}\n".format(
+                        text += "\\includegraphics[height=0.85\\textheight]{{{0}/plots/pdf/{1}.pdf}}\n".format(
                             config.outputPath, module[0].filename)
 
                         out.addSlide("Module-level parameters", text)
@@ -210,16 +210,16 @@ def create(alignables, pedeDump, additionalData, outputFile, config):
                         for plot in moduleSub:
                             text = "\\framesubtitle{{{0}}}\n".format(
                                 moduleName)
-                            text += "\includegraphics[height=0.85\\textheight]{{{0}/plots/pdf/{1}.pdf}}\n".format(
+                            text += "\\includegraphics[height=0.85\\textheight]{{{0}/plots/pdf/{1}.pdf}}\n".format(
                                 config.outputPath, plot.filename)
 
                             out.addSlide("Module-level parameters", text)
 
     # plot taken from the millePedeMonitor_merge.root file
-    out.add("\section{Monitor plots}")
+    out.add("\\section{Monitor plots}")
     for plot in [x for x in config.outputList if x.plottype == "monitor"]:
         text = "\\framesubtitle{{{0}}}\n".format(plot.name)
-        text += "\includegraphics[height=0.85\\textheight]{{{0}/plots/pdf/{1}.pdf}}\n".format(
+        text += "\\includegraphics[height=0.85\\textheight]{{{0}/plots/pdf/{1}.pdf}}\n".format(
             config.outputPath, plot.filename)
         out.addSlide("Monitor", text)
 

--- a/Alignment/MillePedeAlignmentAlgorithm/python/mpsvalidate/dumpparser.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/mpsvalidate/dumpparser.py
@@ -79,17 +79,17 @@ def parse(path, config):
 
         # nrec number of records
         if (" = number of records" in line):
-            number = list(map(int, re.findall("\d+", dumpFile[i])))
+            number = list(map(int, re.findall("\\d+", dumpFile[i])))
             pedeDump.nrec = number[0]
 
         # ntgb total number of parameters
         if (" = total number of parameters" in line):
-            number = list(map(int, re.findall("\d+", dumpFile[i])))
+            number = list(map(int, re.findall("\\d+", dumpFile[i])))
             pedeDump.ntgb = number[0]
 
         # nvgb number of variable parameters
         if (" = number of variable parameters" in line):
-            number = list(map(int, re.findall("\d+", dumpFile[i])))
+            number = list(map(int, re.findall("\\d+", dumpFile[i])))
             pedeDump.nvgb = number[0]
 
     return pedeDump

--- a/Alignment/MillePedeAlignmentAlgorithm/python/mpsvalidate/pdfCreator.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/mpsvalidate/pdfCreator.py
@@ -34,30 +34,30 @@ def create(alignables, pedeDump, additionalData, outputFile, config):
     # title page
     if (config.message):
         out += """\\begin{{titlepage}}
-                    \centering
+                    \\centering
                     \\vspace*{{4cm}}
-                    \Huge\\bfseries Alignment Validation\par
+                    \\Huge\\bfseries Alignment Validation\\par
                     \\vspace{{2cm}}	
-                    \scshape\huge Alignment Campaign\\\\ {{{0}}}\par
+                    \\scshape\\huge Alignment Campaign\\\\ {{{0}}}\\par
                     \\vfill
-                    \large \\today\par
+                    \\large \\today\\par
                     \\end{{titlepage}}
                     \\tableofcontents
                     \\newpage""".format(config.message)
     else:
         out += """\\begin{titlepage}
-                    \centering
+                    \\centering
                     \\vspace*{4cm}
-                    \Huge\\bfseries Alignment Validation\par
+                    \\Huge\\bfseries Alignment Validation\\par
                     \\vfill
-                    \large \\today\par
+                    \\large \\today\\par
                     \\end{titlepage}
                     \\tableofcontents
                     \\newpage"""
 
     # general information
 
-    out += "\section{{General information}}\n"
+    out += "\\section{{General information}}\n"
 
     if (config.message):
         out += "Project: {{{0}}}\\\\\n".format(config.message)
@@ -68,7 +68,7 @@ def create(alignables, pedeDump, additionalData, outputFile, config):
 
     # alignment_merge.py
     try:
-        out += "\subsection{Alignment Configuration}\n"
+        out += "\\subsection{Alignment Configuration}\n"
         out += "\\textbf{{PedeSteerer method:}} {{{0}}}\\\\\n".format(
             additionalData.pede_steerer_method)
         out += "\\textbf{{PedeSteerer options:}}\\\\\n"
@@ -97,30 +97,30 @@ def create(alignables, pedeDump, additionalData, outputFile, config):
 
     # table of input files with number of tracks
     if config.showmonitor:
-        out += "\subsection{Datasets with tracks}\n"
+        out += "\\subsection{Datasets with tracks}\n"
         out += """\\begin{table}[h]
-            \centering
-            \caption{Datasets with tracks}
+            \\centering
+            \\caption{Datasets with tracks}
             \\begin{tabular}{ccc}
-            \hline
+            \\hline
             Dataset & Number of used tracks & Weight \\\\
-            \hline \n"""
+            \\hline \n"""
         for monitor in mpsv_classes.MonitorData.monitors:
             out += "{0} & {1} & {2}\\\\\n".format(monitor.name, monitor.ntracks,
                                                   monitor.weight if monitor.weight != None else "--")
         try:
             if (pedeDump.nrec):
-                out += "\hline\nNumber of records & {0}\\\\\n".format(pedeDump.nrec)
+                out += "\\hline\nNumber of records & {0}\\\\\n".format(pedeDump.nrec)
         except Exception as e:
             logger.error("data not found - {0} {1}".format(type(e), e))
-        out += """\hline
-                  \end{tabular}\n
-                  \end{table}\n"""
+        out += """\\hline
+                  \\end{tabular}\n
+                  \\end{table}\n"""
         out += "The information in this table is based on the monitor root files. Note that the number of tracks which where used in the pede step can differ from this table.\n"
     try:
         # pede.dump.gz
         if config.showdump:
-            out += "\subsection{{Pede monitoring information}}\n"
+            out += "\\subsection{{Pede monitoring information}}\n"
             if (pedeDump.sumValue != 0):
                 out += r"\begin{{align*}}Sum(Chi^2)/Sum(Ndf) &= {0}\\ &= {1}\end{{align*}}".format(
                     pedeDump.sumSteps, pedeDump.sumValue)
@@ -145,7 +145,7 @@ def create(alignables, pedeDump, additionalData, outputFile, config):
                     out += line + "\n"
                     out += "\\end{verbatim}\n"
 
-            out += "\section{{Parameter plots}}\n"
+            out += "\\section{{Parameter plots}}\n"
     except Exception as e:
         logger.error("data not found - {0} {1}".format(type(e), e))
 
@@ -154,9 +154,9 @@ def create(alignables, pedeDump, additionalData, outputFile, config):
         big = [x for x in config.outputList if (x.plottype == "big")]
 
         if big:
-            out += "\subsection{{High-level parameters}}\n"
+            out += "\\subsection{{High-level parameters}}\n"
             for i in big:
-                out += "\includegraphics[width=\linewidth]{{{0}/plots/pdf/{1}.pdf}}\n".format(
+                out += "\\includegraphics[width=\\linewidth]{{{0}/plots/pdf/{1}.pdf}}\n".format(
                     config.outputPath, i.filename)
 
     # time (IOV) dependent plots
@@ -164,28 +164,28 @@ def create(alignables, pedeDump, additionalData, outputFile, config):
         time = [x for x in config.outputList if (x.plottype == "time")]
 
         if time:
-            out += "\subsection{{High-level parameters versus time (IOV)}}\n"
+            out += "\\subsection{{High-level parameters versus time (IOV)}}\n"
             # get list with names of the structures
             for structure in [x.name for x in time if x.parameter == "xyz"]:
-                out += "\subsubsection{{{0}}}\n".format(structure)
+                out += "\\subsubsection{{{0}}}\n".format(structure)
                 for mode in ["xyz", "rot"]:
                     if any([x.filename for x in time if (x.parameter == mode and x.name == structure)]):
                         filename = [x.filename for x in time if (x.parameter == mode and x.name == structure)][0]
-                        out += "\includegraphics[width=\linewidth]{{{0}/plots/pdf/{1}.pdf}}\n".format(
+                        out += "\\includegraphics[width=\\linewidth]{{{0}/plots/pdf/{1}.pdf}}\n".format(
                             config.outputPath, filename)
 
     # hole modules
     if config.showmodule:
         # check if there are module plots
         if any(x for x in config.outputList if (x.plottype == "mod" and x.number == "")):
-            out += "\subsection{{Module-level parameters}}\n"
+            out += "\\subsection{{Module-level parameters}}\n"
 
             # loop over all structures
             for moduleName in [x.name for x in alignables.structures]:
 
                 # check if there is a plot for this module
                 if any(x for x in config.outputList if (x.plottype == "mod" and x.number == "" and x.name == moduleName)):
-                    out += "\subsubsection{{{0}}}\n".format(moduleName)
+                    out += "\\subsubsection{{{0}}}\n".format(moduleName)
                     # loop over modes
                     for mode in ["xyz", "rot", "dist"]:
 
@@ -198,26 +198,26 @@ def create(alignables, pedeDump, additionalData, outputFile, config):
 
                         # check if plot there is a plot in this mode
                         if module:
-                            out += "\includegraphics[width=\linewidth]{{{0}/plots/pdf/{1}.pdf}}\n".format(
+                            out += "\\includegraphics[width=\\linewidth]{{{0}/plots/pdf/{1}.pdf}}\n".format(
                                 config.outputPath, module[0].filename)
                             if config.showsubmodule:
                                 # loop over submodules
                                 for plot in moduleSub:
-                                    out += "\includegraphics[width=\linewidth]{{{0}/plots/pdf/{1}.pdf}}\n".format(
+                                    out += "\\includegraphics[width=\\linewidth]{{{0}/plots/pdf/{1}.pdf}}\n".format(
                                         config.outputPath, plot.filename)
 
     # plot taken from the millePedeMonitor_merge.root file
     if config.showmonitor:
         if any(x for x in config.outputList if x.plottype == "monitor"):
-            out += "\section{{Monitor plots}}\n"
+            out += "\\section{{Monitor plots}}\n"
 
             lastdataset = ""
             for plot in [x for x in config.outputList if x.plottype == "monitor"]:
                 # all plots of a dataset together in one section
                 if (lastdataset != plot.name):
-                    out += "\subsection{{{0}}}\n".format(plot.name)
+                    out += "\\subsection{{{0}}}\n".format(plot.name)
                 lastdataset = plot.name
-                out += "\includegraphics[width=\linewidth]{{{0}/plots/pdf/{1}.pdf}}\n".format(
+                out += "\\includegraphics[width=\\linewidth]{{{0}/plots/pdf/{1}.pdf}}\n".format(
                     config.outputPath, plot.filename)
 
     data = data.substitute(out=out)

--- a/Alignment/MuonAlignment/python/geometryDiffVisualization.py
+++ b/Alignment/MuonAlignment/python/geometryDiffVisualization.py
@@ -86,7 +86,7 @@ def draw_wheel(geom1, geom2, wheel, filename, length_factor=100., angle_factor=1
             zdiff = length_factor * (geom1.dt[wheel, station, sector].z - geom2.dt[wheel, station, sector].z) * signConventions["DT", wheel, station, sector][2]
             phiydiff = -angle_factor * (geom1.dt[wheel, station, sector].phiy - geom2.dt[wheel, station, sector].phiy) * signConventions["DT", wheel, station, sector][1]
 
-            m = re.search("translate\(([0-9\.\-\+eE]+),\s([0-9\.\-\+eE]+)\)\srotate\(([0-9\.\-\+eE]+)\)",svgitem["transform"])
+            m = re.search("translate\\(([0-9\\.\\-\\+eE]+),\\s([0-9\\.\\-\\+eE]+)\\)\\srotate\\(([0-9\\.\\-\\+eE]+)\\)",svgitem["transform"])
 
             tx = float(m.group(1))
             ty = float(m.group(2))

--- a/Alignment/MuonAlignment/python/svgfig.py
+++ b/Alignment/MuonAlignment/python/svgfig.py
@@ -80,8 +80,8 @@ class SVG:
 
   SVG in Python
 
-  >>> svg = SVG("g", SVG("rect", x=1, y=1, width=2, height=2), \ 
-  ...                SVG("rect", x=3, y=3, width=2, height=2), \ 
+  >>> svg = SVG("g", SVG("rect", x=1, y=1, width=2, height=2), \\ 
+  ...                SVG("rect", x=3, y=3, width=2, height=2), \\ 
   ...           id="mygroup", fill="blue")
 
   Sub-elements and attributes may be accessed through tree-indexing:
@@ -96,7 +96,7 @@ class SVG:
 
   Iteration is depth-first:
 
-  >>> svg = SVG("g", SVG("g", SVG("line", x1=0, y1=0, x2=1, y2=1)), \
+  >>> svg = SVG("g", SVG("g", SVG("line", x1=0, y1=0, x2=1, y2=1)), \\
   ...                SVG("text", SVG("tspan", "hello again")))
   ... 
   >>> for ti, s in svg:
@@ -419,7 +419,7 @@ class SVG:
     """
     fileName = self.interpret_fileName(fileName)
 
-    if compresslevel != None or re.search("\.svgz$", fileName, re.I) or re.search("\.gz$", fileName, re.I):
+    if compresslevel != None or re.search("\\.svgz$", fileName, re.I) or re.search("\\.gz$", fileName, re.I):
       import gzip
       if compresslevel == None:
         f = gzip.GzipFile(fileName, "w")
@@ -511,7 +511,7 @@ def canvas_outline(*sub, **attr):
   """Same as canvas(), but draws an outline around the drawable area,
   so that you know how close your image is to the edges."""
   svg = canvas(*sub, **attr)
-  match = re.match("[, \t]*([0-9e.+\-]+)[, \t]+([0-9e.+\-]+)[, \t]+([0-9e.+\-]+)[, \t]+([0-9e.+\-]+)[, \t]*", svg["viewBox"])
+  match = re.match("[, \t]*([0-9e.+\\-]+)[, \t]+([0-9e.+\\-]+)[, \t]+([0-9e.+\\-]+)[, \t]+([0-9e.+\\-]+)[, \t]*", svg["viewBox"])
   if match == None: raise ValueError("canvas viewBox is incorrectly formatted")
   x, y, width, height = [float(x) for x in match.groups()]
   svg.prepend(SVG("rect", x=x, y=y, width=width, height=height, stroke="none", fill="cornsilk"))
@@ -558,7 +558,7 @@ def load_stream(stream):
     def __init__(self):
       self.stack = []
       self.output = None
-      self.all_whitespace = re.compile("^\s*$")
+      self.all_whitespace = re.compile("^\\s*$")
 
     def startElement(self, name, attr):
       s = SVG(name)


### PR DESCRIPTION
This should fix the Python 3.12 `SyntaxWarning: invalid escape sequence` warnings. These changes also work for python 3.9 (cmssw default python)