### PR TITLE
[GENERATORS] [PY312] String formatting to fix SyntaxWarning

### DIFF
--- a/Configuration/Generator/python/QCD_Pt-20toInf_MuEnrichedPt15_TuneCUETP8M1_13TeV_pythia8_cff.py
+++ b/Configuration/Generator/python/QCD_Pt-20toInf_MuEnrichedPt15_TuneCUETP8M1_13TeV_pythia8_cff.py
@@ -48,8 +48,8 @@ mugenfilter = cms.EDFilter("MCSmartSingleParticleFilter",
 
 
 configurationMetadata = cms.untracked.PSet(
-    version = cms.untracked.string('\$Revision$'),
-    name = cms.untracked.string('\$Source$'),
+    version = cms.untracked.string('\\$Revision$'),
+    name = cms.untracked.string('\\$Source$'),
     annotation = cms.untracked.string('QCD dijet production, pThat > 20 GeV, with INCLUSIVE muon preselection (pt(mu) > 15 GeV), 13 TeV, TuneCUETP8M1')
 )
 

--- a/Configuration/Generator/python/QCD_Pt-20toInf_MuEnrichedPt15_TuneCUETP8M1_14TeV_pythia8_cff.py
+++ b/Configuration/Generator/python/QCD_Pt-20toInf_MuEnrichedPt15_TuneCUETP8M1_14TeV_pythia8_cff.py
@@ -48,8 +48,8 @@ mugenfilter = cms.EDFilter("MCSmartSingleParticleFilter",
 
 
 configurationMetadata = cms.untracked.PSet(
-    version = cms.untracked.string('\$Revision$'),
-    name = cms.untracked.string('\$Source$'),
+    version = cms.untracked.string('\\$Revision$'),
+    name = cms.untracked.string('\\$Source$'),
     annotation = cms.untracked.string('QCD dijet production, pThat > 20 GeV, with INCLUSIVE muon preselection (pt(mu) > 15 GeV), 13 TeV, TuneCUETP8M1')
 )
 

--- a/Configuration/Generator/python/QCD_Pt20toInf_MuEnrichedPt15_14TeV_TuneCP5_cff.py
+++ b/Configuration/Generator/python/QCD_Pt20toInf_MuEnrichedPt15_14TeV_TuneCP5_cff.py
@@ -48,8 +48,8 @@ mugenfilter = cms.EDFilter("MCSmartSingleParticleFilter",
 
 
 configurationMetadata = cms.untracked.PSet(
-    version = cms.untracked.string('\$Revision$'),
-    name = cms.untracked.string('\$Source$'),
+    version = cms.untracked.string('\\$Revision$'),
+    name = cms.untracked.string('\\$Source$'),
     annotation = cms.untracked.string('QCD dijet production, pThat > 20 GeV, with INCLUSIVE muon preselection (pt(mu) > 15 GeV), 13 TeV, TuneCUETP8M1')
 )
 


### PR DESCRIPTION
This should fix the Python 3.12 `SyntaxWarning: invalid escape sequence` warnings. These changes also work for python 3.9 (cmssw default python)