### PR TITLE
[PDMV-UPGRADE] [PY312] String formatting to fix SyntaxWarning

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -395,7 +395,7 @@ class MatrixInjector(object):
                                     chainDict['nowmTasklist'][-1]['EventsPerLumi'] = ns[1]
                                     #overwrite EventsPerLumi if numberEventsInLuminosityBlock is set in cmsDriver
                                     if 'numberEventsInLuminosityBlock' in s[2][index]:
-                                        nEventsInLuminosityBlock = re.findall('process.source.numberEventsInLuminosityBlock=cms.untracked.uint32\(([ 0-9 ]*)\)', s[2][index],re.DOTALL)
+                                        nEventsInLuminosityBlock = re.findall('process.source.numberEventsInLuminosityBlock=cms.untracked.uint32\\(([ 0-9 ]*)\\)', s[2][index],re.DOTALL)
                                         if nEventsInLuminosityBlock[-1].isdigit() and int(nEventsInLuminosityBlock[-1]) < ns[1]:
                                             chainDict['nowmTasklist'][-1]['EventsPerLumi'] = int(nEventsInLuminosityBlock[-1])
                                     if(self.numberEventsInLuminosityBlock > 0 and self.numberEventsInLuminosityBlock <= ns[1]):

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -2544,7 +2544,7 @@ class UpgradeWorkflowPremix(UpgradeWorkflow):
             d = merge([stepDict[self.getStepName(step)][k]])
             if "--filein" in d:
                 filein = d["--filein"]
-                m = re.search("step(?P<ind>\d+)_", filein)
+                m = re.search("step(?P<ind>\\d+)_", filein)
                 if m:
                     d["--filein"] = filein.replace(m.group(), "step%d_"%(int(m.group("ind"))+1))
             stepDict[stepName][k] = d


### PR DESCRIPTION
This should fix the Python 3.12 `SyntaxWarning: invalid escape sequence` warnings. These changes also work for python 3.9 (cmssw default python)