### PR TITLE
[XPOG] [PY312] String formatting to fix SyntaxWarning

### DIFF
--- a/PhysicsTools/NanoAODTools/python/postprocessing/framework/datamodel.py
+++ b/PhysicsTools/NanoAODTools/python/postprocessing/framework/datamodel.py
@@ -44,9 +44,9 @@ class Event:
             # remove useless warning about EvalInstance()
             import warnings
             warnings.filterwarnings(action='ignore', category=RuntimeWarning,
-                                    message='creating converter for unknown type "const char\*\*"$')
+                                    message='creating converter for unknown type "const char\\*\\*"$')
             warnings.filterwarnings(action='ignore', category=RuntimeWarning,
-                                    message='creating converter for unknown type "const char\*\[\]"$')
+                                    message='creating converter for unknown type "const char\\*\\[\\]"$')
         if expr not in self._tree._exprs:
             formula = ROOT.TTreeFormula(expr, expr, self._tree)
             if formula.IsInteger():


### PR DESCRIPTION
This should fix the Python 3.12 `SyntaxWarning: invalid escape sequence` warnings. These changes also work for python 3.9 (cmssw default python)