### PR TITLE
[ANALYSIS] [PY312] String formatting to fix SyntaxWarning

### DIFF
--- a/PhysicsTools/Heppy/python/utils/cmsswRelease.py
+++ b/PhysicsTools/Heppy/python/utils/cmsswRelease.py
@@ -20,13 +20,13 @@ def releaseNumber(release = None):
     # first check if this is an integration build
     if release is None:
         release = cmsswRelease()
-    ibrel = re.compile('^CMSSW_(\d+)_(\d+)_X.*$')
+    ibrel = re.compile('^CMSSW_(\\d+)_(\\d+)_X.*$')
     m = ibrel.match(release)
     if m:
         big = int(m.group(1))
         medium = int(m.group(2))
         return big, medium
-    rerel = re.compile('^CMSSW_(\d+)_(\d+)_(\d+)(_\S+)*$')
+    rerel = re.compile('^CMSSW_(\\d+)_(\\d+)_(\\d+)(_\\S+)*$')
     m = rerel.match(release)
     if m is None:
         raise ValueError('malformed release string '+release)
@@ -34,8 +34,8 @@ def releaseNumber(release = None):
     medium = int(m.group(2))
     small = int(m.group(3))
     if m.group(4): # that's either a patch or prerelease
-        prel = re.compile('_pre(\d+)')
-        patch = re.compile('_patch(\d+)')
+        prel = re.compile('_pre(\\d+)')
+        patch = re.compile('_patch(\\d+)')
         pm = prel.match(m.group(4))
         if pm: # prerelease
             pre = int(pm.group(1))

--- a/PhysicsTools/HeppyCore/python/framework/config.py
+++ b/PhysicsTools/HeppyCore/python/framework/config.py
@@ -44,7 +44,7 @@ class CFG(object):
                                           name=self.name)
         varlines = ['\t{var:<15}:   {value}'.format(var=var, value=value) \
                     for var,value in sorted(vars(self.items())) \
-                    if var is not 'name']
+                    if var != 'name']
         all = [ header ]
         all.extend(varlines)
         return '\n'.join( all )

--- a/PhysicsTools/HeppyCore/python/utils/batchmanager.py
+++ b/PhysicsTools/HeppyCore/python/utils/batchmanager.py
@@ -219,7 +219,7 @@ class BatchManager:
             sys.exit(3)
         else:
             for line in ifile:
-                p = re.compile("\s*cp.*\$jobdir\s+(\S+)$");
+                p = re.compile("\\s*cp.*\\$jobdir\\s+(\\S+)$");
                 m=p.match(line)
                 if m:
                     if os.path.isdir( os.path.expandvars(m.group(1)) ):

--- a/PhysicsTools/HeppyCore/python/utils/dataset.py
+++ b/PhysicsTools/HeppyCore/python/utils/dataset.py
@@ -285,7 +285,7 @@ class Dataset( BaseDataset ):
         self.bad_files = {}
         self.good_files = []
 
-        file_mask = castortools.matchingFiles(self.castorDir, '^%s_.*\.txt$' % mask)
+        file_mask = castortools.matchingFiles(self.castorDir, '^%s_.*\\.txt$' % mask)
         if file_mask:
             # here to avoid circular dependency
             from .edmIntegrityCheck import PublishToFileSystem

--- a/PhysicsTools/HeppyCore/python/utils/edmIntegrityCheck.py
+++ b/PhysicsTools/HeppyCore/python/utils/edmIntegrityCheck.py
@@ -63,7 +63,7 @@ class PublishToFileSystem(object):
     
     def get(self, dir):
         """Finds the lastest file and reads it"""
-        reg = '^%s_.*\.txt$' % self.parent
+        reg = '^%s_.*\\.txt$' % self.parent
         files = castortools.matchingFiles(dir, reg)
         files = sorted([ (os.path.basename(f), f) for f in files])
         if not files:
@@ -117,7 +117,7 @@ class IntegrityCheck(object):
         def isCrabFile(name):
             _, fname = os.path.split(name)
             base, _ = os.path.splitext(fname)
-            return re.match(".*_\d+_\d+_\w+$", base) is not None, base
+            return re.match(".*_\\d+_\\d+_\\w+$", base) is not None, base
         def getCrabIndex(base):
             tokens = base.split('_')
             if len(tokens) > 2:

--- a/PhysicsTools/HeppyCore/python/utils/logger.py
+++ b/PhysicsTools/HeppyCore/python/utils/logger.py
@@ -33,7 +33,7 @@ class logger:
             file = castortools.castorToLFN(file)
             
         if castortools.isLFN( file ):
-            tgzPattern = re.compile('.*\.tgz$')
+            tgzPattern = re.compile('.*\\.tgz$')
             m = tgzPattern.match( file )
             if m:
                 return True

--- a/PhysicsTools/HeppyCore/python/utils/production_tasks.py
+++ b/PhysicsTools/HeppyCore/python/utils/production_tasks.py
@@ -240,7 +240,7 @@ class CheckForMask(Task):
 
         report = None
         if (hasattr(self.options,'check') and self.options.check) or not hasattr(self.options,'check'):
-            file_mask = castortools.matchingFiles(dir, '^%s_.*\.txt$' % mask)
+            file_mask = castortools.matchingFiles(dir, '^%s_.*\\.txt$' % mask)
 
             if file_mask:
                 p = PublishToFileSystem(mask)


### PR DESCRIPTION
This should fix the Python 3.12 `SyntaxWarning: invalid escape sequence` warnings. These changes also work for python 3.9 (cmssw default python)