### PR TITLE
[L1] [PY312] String formatting to fix SyntaxWarning

### DIFF
--- a/EventFilter/L1TXRawToDigi/python/util/rrapi.py
+++ b/EventFilter/L1TXRawToDigi/python/util/rrapi.py
@@ -27,7 +27,7 @@ class RRApiError(Exception):
                     m = re.search("<pre>(.*)", line)
                     if m != None:
                         self.stack = m.group(1)
-                        m = re.search("^.+\.([^\.]+: .*)$", self.stack)
+                        m = re.search("^.+\\.([^\\.]+: .*)$", self.stack)
                         if m != None:
                             self.message = m.group(1)
                         else:

--- a/L1Trigger/L1TCalorimeter/python/studyJets.py
+++ b/L1Trigger/L1TCalorimeter/python/studyJets.py
@@ -52,7 +52,7 @@ def getJetProperties(jetSeed,etaFwd,etaCen):
 
 def printJetProperties(etaRange):
 
-    print("Size  \  eta\t", end=' ')
+    print("Size  \\  eta\t", end=' ')
     for seedEta in etaRange:
         if(seedEta<29):
             print(str(seedEta)+"\t\t", end=' ')


### PR DESCRIPTION
This should fix the Python 3.12 `SyntaxWarning: invalid escape sequence` warnings. These changes also work for python 3.9 (cmssw default python)