### PR TITLE
[DQM-L1] [PY312] String formatting to fix SyntaxWarning

### DIFF
--- a/DQMOffline/L1Trigger/python/L1THistDefinitions_cff.py
+++ b/DQMOffline/L1Trigger/python/L1THistDefinitions_cff.py
@@ -24,7 +24,7 @@ histDefinitions = cms.PSet(
     ),
     PHIvsPHI=cms.PSet(
         name=cms.untracked.string('PHIvsPHI'),
-        title=cms.untracked.string('Template for \phi vs \phi histograms'),
+        title=cms.untracked.string('Template for \\phi vs \\phi histograms'),
         nbinsX=cms.untracked.uint32(80),
         xmin=cms.untracked.double(-3.2),
         xmax=cms.untracked.double(3.2),


### PR DESCRIPTION
This should fix the Python 3.12 `SyntaxWarning: invalid escape sequence` warnings. These changes also work for python 3.9 (cmssw default python)