### PR TITLE
Update data processing tests generation Tier-0 configurations

### DIFF
--- a/Configuration/DataProcessing/test/RunAlcaHarvesting.py
+++ b/Configuration/DataProcessing/test/RunAlcaHarvesting.py
@@ -140,7 +140,7 @@ if __name__ == '__main__':
         if opt == "--dataset" :
             harvester.dataset = arg
         if opt == "--workflows":
-            harvester.workflows = [ x for x in arg.split(',') if len(x) > 0 ]
+            harvester.workflows = [ x for x in arg.split('+') if len(x) > 0 ]
         if opt == "--alcapromptdataset":
             harvester.alcapromptdataset = arg
 

--- a/Configuration/DataProcessing/test/RunAlcaSkimming.py
+++ b/Configuration/DataProcessing/test/RunAlcaSkimming.py
@@ -124,7 +124,7 @@ python2.4 RunAlcaSkimming.py --scenario=Cosmics --lfn=/store/whatever --skims=Mu
         if opt == "--lfn" :
             skimmer.inputLFN = arg
         if opt == "--skims":
-            skimmer.skims = [ x for x in arg.split(',') if len(x) > 0 ]
+            skimmer.skims = [ x for x in arg.split('+') if len(x) > 0 ]
         if opt == "--global-tag":
             skimmer.globalTag = arg
 

--- a/Configuration/DataProcessing/test/RunExpressProcessing.py
+++ b/Configuration/DataProcessing/test/RunExpressProcessing.py
@@ -160,7 +160,7 @@ Examples:
 
 python RunExpressProcessing.py --scenario cosmics --global-tag GLOBALTAG --lfn /store/whatever --fevt --dqmio --alcarecos=TkAlCosmics0T+SiStripCalZeroBias
 
-python RunExpressProcessing.py --scenario pp --global-tag GLOBALTAG --lfn /store/whatever --daq --fevt --dqmio --alcarecos=TkAlMinBias+SiStripCalZeroBias
+python RunExpressProcessing.py --scenario pp --global-tag GLOBALTAG --lfn /store/whatever --dat --fevt --dqmio --alcarecos=TkAlMinBias+SiStripCalZeroBias
 
 """
     try:

--- a/Configuration/DataProcessing/test/RunExpressProcessing.py
+++ b/Configuration/DataProcessing/test/RunExpressProcessing.py
@@ -31,6 +31,7 @@ class RunExpressProcessing:
         self.inputLFN = None
         self.alcaRecos = None
         self.nThreads = None
+        self.dat = False
 
     def __call__(self):
         if self.scenario == None:
@@ -90,9 +91,11 @@ class RunExpressProcessing:
                 if self.alcaRecos:
                     kwds['skims'] = self.alcaRecos
 
-
             if self.nThreads:
-                kwds['nThreads'] = self.nThreads
+                kwds['nThreads'] = int(self.nThreads)
+
+            if self.dat:
+                kwds['inputSource'] = 'DAT'
 
             process = scenario.expressProcessing(self.globalTag, **kwds)
 
@@ -135,7 +138,7 @@ class RunExpressProcessing:
 
 if __name__ == '__main__':
     valid = ["scenario=", "raw", "reco", "fevt", "dqm", "dqmio", "no-output",
-             "global-tag=", "lfn=", 'alcarecos=', "nThreads="]
+             "global-tag=", "lfn=", "dat", 'alcarecos=', "nThreads="]
     usage = \
 """
 RunExpressProcessing.py <options>
@@ -149,6 +152,7 @@ Where options are:
  --no-output (create config with no output, overrides other settings)
  --global-tag=GlobalTag
  --lfn=/store/input/lfn
+ --dat (to enable streamer files as input)
  --alcarecos=plus_seprated_list
  --nThreads=Number_of_cores_or_Threads_used
 
@@ -156,7 +160,7 @@ Examples:
 
 python RunExpressProcessing.py --scenario cosmics --global-tag GLOBALTAG --lfn /store/whatever --fevt --dqmio --alcarecos=TkAlCosmics0T+SiStripCalZeroBias
 
-python RunExpressProcessing.py --scenario pp --global-tag GLOBALTAG --lfn /store/whatever --fevt --dqmio --alcarecos=TkAlMinBias+SiStripCalZeroBias
+python RunExpressProcessing.py --scenario pp --global-tag GLOBALTAG --lfn /store/whatever --daq --fevt --dqmio --alcarecos=TkAlMinBias+SiStripCalZeroBias
 
 """
     try:
@@ -192,5 +196,7 @@ python RunExpressProcessing.py --scenario pp --global-tag GLOBALTAG --lfn /store
             expressinator.alcaRecos = [ x for x in arg.split('+') if len(x) > 0 ]
         if opt == "--nThreads":
             expressinator.nThreads = arg
+        if opt == "--dat":
+            expressinator.dat = True
 
     expressinator()

--- a/Configuration/DataProcessing/test/RunPromptReco.py
+++ b/Configuration/DataProcessing/test/RunPromptReco.py
@@ -109,7 +109,7 @@ class RunPromptReco:
                     kwds['repacked'] = self.isRepacked
 
                 if self.nThreads:
-                    kwds['nThreads'] = self.nThreads
+                    kwds['nThreads'] = int(self.nThreads)
 
             process = scenario.promptReco(self.globalTag, **kwds)
 

--- a/Configuration/DataProcessing/test/run_CfgTest_10.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest_10.sh
@@ -11,6 +11,6 @@ function die { echo $1: status $2 ;  exit $2; }
 function runTest { echo $1 ; python3 $1 || die "Failure for configuration: $1" $?; }
 
 runTest "${SCRAM_TEST_PATH}/RunExpressProcessing.py --scenario AlCaLumiPixels --global-tag GLOBALTAG --lfn /store/whatever --alcareco AlCaPCCRandom+PromptCalibProdLumiPCC"
-runTest "${SCRAM_TEST_PATH}/RunAlcaSkimming.py --scenario AlCaLumiPixels --lfn=/store/whatever --global-tag GLOBALTAG --skims AlCaPCCRandom,PromptCalibProdLumiPCC"
+runTest "${SCRAM_TEST_PATH}/RunAlcaSkimming.py --scenario AlCaLumiPixels --lfn=/store/whatever --global-tag GLOBALTAG --skims AlCaPCCRandom+PromptCalibProdLumiPCC"
 runTest "${SCRAM_TEST_PATH}/RunAlcaHarvesting.py --scenario AlCaLumiPixels --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG --alcapromptdataset=PromptCalibProdLumiPCC"
 

--- a/Configuration/DataProcessing/test/run_CfgTest_11.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest_11.sh
@@ -11,6 +11,6 @@ function die { echo $1: status $2 ;  exit $2; }
 function runTest { echo $1 ; python3 $1 || die "Failure for configuration: $1" $?; }
 
 runTest "${SCRAM_TEST_PATH}/RunExpressProcessing.py --scenario AlCaLumiPixels_Run3 --global-tag GLOBALTAG --lfn /store/whatever --alcareco AlCaPCCRandom+PromptCalibProdLumiPCC"
-runTest "${SCRAM_TEST_PATH}/RunAlcaSkimming.py --scenario AlCaLumiPixels_Run3 --lfn=/store/whatever --global-tag GLOBALTAG --skims AlCaPCCRandom,PromptCalibProdLumiPCC"
+runTest "${SCRAM_TEST_PATH}/RunAlcaSkimming.py --scenario AlCaLumiPixels_Run3 --lfn=/store/whatever --global-tag GLOBALTAG --skims AlCaPCCRandom+PromptCalibProdLumiPCC"
 runTest "${SCRAM_TEST_PATH}/RunAlcaHarvesting.py --scenario AlCaLumiPixels_Run3 --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG --alcapromptdataset=PromptCalibProdLumiPCC"
 

--- a/Configuration/DataProcessing/test/run_CfgTest_12.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest_12.sh
@@ -14,8 +14,8 @@ declare -a arr=("trackingOnlyEra_Run2_2018" "trackingOnlyEra_Run2_2018_highBetaS
 for scenario in "${arr[@]}"
 do
     runTest "${SCRAM_TEST_PATH}/RunExpressProcessing.py --scenario $scenario --global-tag GLOBALTAG  --lfn /store/whatever  --alcarecos=TkAlMinBias+PromptCalibProdBeamSpotHP"
-    runTest "${SCRAM_TEST_PATH}/RunAlcaSkimming.py --scenario $scenario --lfn /store/whatever --global-tag GLOBALTAG --skims TkAlMinBias,PromptCalibProdBeamSpotHP"
-    runTest "${SCRAM_TEST_PATH}/RunAlcaSkimming.py --scenario $scenario --lfn /store/whatever --global-tag GLOBALTAG --skims TkAlMinBias,PromptCalibProdBeamSpotHPLowPU"
+    runTest "${SCRAM_TEST_PATH}/RunAlcaSkimming.py --scenario $scenario --lfn /store/whatever --global-tag GLOBALTAG --skims TkAlMinBias+PromptCalibProdBeamSpotHP"
+    runTest "${SCRAM_TEST_PATH}/RunAlcaSkimming.py --scenario $scenario --lfn /store/whatever --global-tag GLOBALTAG --skims TkAlMinBias+PromptCalibProdBeamSpotHPLowPU"
     runTest "${SCRAM_TEST_PATH}/RunAlcaHarvesting.py --scenario $scenario --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG --alcapromptdataset=PromptCalibProdBeamSpotHP"
     runTest "${SCRAM_TEST_PATH}/RunAlcaHarvesting.py --scenario $scenario --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG --alcapromptdataset=PromptCalibProdBeamSpotHPLowPU"
 done

--- a/Configuration/DataProcessing/test/run_CfgTest_2.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest_2.sh
@@ -15,6 +15,6 @@ for scenario in "${arr[@]}"
 do
      runTest "${SCRAM_TEST_PATH}/RunExpressProcessing.py --scenario $scenario --global-tag GLOBALTAG --lfn /store/whatever --fevt --dqmio  --alcareco TkAlMinBias+SiStripCalMinBias "
      runTest "${SCRAM_TEST_PATH}/RunVisualizationProcessing.py --scenario $scenario --lfn /store/whatever --global-tag GLOBALTAG --fevt"
-     runTest "${SCRAM_TEST_PATH}/RunAlcaHarvesting.py --scenario $scenario --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG --workflows=BeamSpotByRun,BeamSpotByLumi,SiStripQuality"
+     runTest "${SCRAM_TEST_PATH}/RunAlcaHarvesting.py --scenario $scenario --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG --workflows=BeamSpotByRun+BeamSpotByLumi+SiStripQuality"
 done
 

--- a/Configuration/DataProcessing/test/run_CfgTest_6.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest_6.sh
@@ -13,7 +13,7 @@ function runTest { echo $1 ; python3 $1 || die "Failure for configuration: $1" $
 declare -a arr=("AlCaLumiPixels" "cosmicsEra_Run2_2018" "ppEra_Run2_2018" "ppEra_Run2_2018_highBetaStar" "ppEra_Run2_2018_pp_on_AA" "cosmicsHybridEra_Run2_2018" "cosmicsEra_Run3" "ppEra_Run3" "AlCaLumiPixels_Run3")
 for scenario in "${arr[@]}"
 do
-     runTest "${SCRAM_TEST_PATH}/RunAlcaSkimming.py --scenario $scenario --lfn=/store/whatever --global-tag GLOBALTAG --skims SiStripCalZeroBias,SiStripCalMinBias,PromptCalibProd"
+     runTest "${SCRAM_TEST_PATH}/RunAlcaSkimming.py --scenario $scenario --lfn=/store/whatever --global-tag GLOBALTAG --skims SiStripCalZeroBias+SiStripCalMinBias+PromptCalibProd"
      runTest "${SCRAM_TEST_PATH}/RunDQMHarvesting.py --scenario $scenario --lfn /store/whatever --run 12345 --dataset /A/B/C --global-tag GLOBALTAG"
 done
 

--- a/Configuration/DataProcessing/test/run_CfgTest_7.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest_7.sh
@@ -14,6 +14,7 @@ declare -a arr=("ppEra_Run2_2018" "ppEra_Run2_2018_highBetaStar" "ppEra_Run2_201
 for scenario in "${arr[@]}"
 do
      runTest "${SCRAM_TEST_PATH}/RunPromptReco.py --scenario $scenario --reco --aod --miniaod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"
+     runTest "${SCRAM_TEST_PATH}/RunPromptReco.py --scenario $scenario --reco --aod --miniaod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias --nThreads=8"
      runTest "${SCRAM_TEST_PATH}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias --PhysicsSkim=@SingleMuon"
 done
 

--- a/Configuration/DataProcessing/test/run_CfgTest_9.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest_9.sh
@@ -11,6 +11,8 @@ function die { echo $1: status $2 ;  exit $2; }
 function runTest { echo $1 ; python3 $1 || die "Failure for configuration: $1" $?; }
 
 runTest "${SCRAM_TEST_PATH}/RunExpressProcessing.py --scenario AlCaTestEnable --global-tag GLOBALTAG --lfn /store/whatever --alcareco PromptCalibProdEcalPedestals "
+runTest "${SCRAM_TEST_PATH}/RunExpressProcessing.py --scenario AlCaTestEnable --global-tag GLOBALTAG --lfn /store/whatever --alcareco PromptCalibProdEcalPedestals --dat"
+runTest "${SCRAM_TEST_PATH}/RunExpressProcessing.py --scenario AlCaTestEnable --global-tag GLOBALTAG --lfn /store/whatever --alcareco PromptCalibProdEcalPedestals --nThreads=8"
 runTest "${SCRAM_TEST_PATH}/RunAlcaSkimming.py --scenario AlCaTestEnable --lfn=/store/whatever --global-tag GLOBALTAG --skims PromptCalibProdEcalPedestals"
 runTest "${SCRAM_TEST_PATH}/RunAlcaHarvesting.py --scenario AlCaTestEnable --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG --alcapromptdataset=PromptCalibProdEcalPedestals"
 


### PR DESCRIPTION
#### PR description:

I'm updating T0 test scripts so they are more useful to T0 operators and users. This involves three changes that I'm introducing in  this PR:

- Fix test scripts multi-threading after changes introduced in #43042.
   - Add tests for multi-treading in both scripts
- Allow for Express processing of directly from streamer files, as this is the default mode of operations in Tier-0
   - Add test for this new feature 
- Use '+' as separator for `RunAlcaSkimming.py` and `RunAlcaSkimming.py`, as is already done with the other test scripts
   -  Update related automatic tests.

#### PR validation:

Running `scram b runtests` shows no issues
