### PR TITLE
Fixes for recent raw data format test PR

### DIFF
--- a/DataFormats/Common/test/TestTriggerResultsFormat.sh
+++ b/DataFormats/Common/test/TestTriggerResultsFormat.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -ex
+#!/bin/bash
 
 function die { echo $1: status $2 ;  exit $2; }
 

--- a/DataFormats/Common/test/test_readTriggerResults_cfg.py
+++ b/DataFormats/Common/test/test_readTriggerResults_cfg.py
@@ -15,7 +15,8 @@ process.testReadTriggerResults = cms.EDAnalyzer("TestReadTriggerResults",
 )
 
 process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('testTriggerResults2.root')
+    fileName = cms.untracked.string('testTriggerResults2.root'),
+    fastCloning = cms.untracked.bool(False)
 )
 
 process.path = cms.Path(process.testReadTriggerResults)

--- a/DataFormats/DetId/test/TestVectorDetId.sh
+++ b/DataFormats/DetId/test/TestVectorDetId.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -ex
+#!/bin/bash
 
 function die { echo $1: status $2 ;  exit $2; }
 

--- a/DataFormats/DetId/test/test_readVectorDetId_cfg.py
+++ b/DataFormats/DetId/test/test_readVectorDetId_cfg.py
@@ -11,7 +11,8 @@ process.testReadVectorDetId = cms.EDAnalyzer("TestReadVectorDetId",
 )
 
 process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('testVectorDetId2.root')
+    fileName = cms.untracked.string('testVectorDetId2.root'),
+    fastCloning = cms.untracked.bool(False)
 )
 
 process.path = cms.Path(process.testReadVectorDetId)

--- a/DataFormats/FEDRawData/test/TestFEDRawDataCollectionFormat.sh
+++ b/DataFormats/FEDRawData/test/TestFEDRawDataCollectionFormat.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -ex
+#!/bin/bash
 
 function die { echo $1: status $2 ;  exit $2; }
 

--- a/DataFormats/FEDRawData/test/test_readFEDRawDataCollection_cfg.py
+++ b/DataFormats/FEDRawData/test/test_readFEDRawDataCollection_cfg.py
@@ -13,7 +13,8 @@ process.testReadFEDRawDataCollection = cms.EDAnalyzer("TestReadFEDRawDataCollect
 )
 
 process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('testFEDRawDataCollection2.root')
+    fileName = cms.untracked.string('testFEDRawDataCollection2.root'),
+    fastCloning = cms.untracked.bool(False)
 )
 
 process.path = cms.Path(process.testReadFEDRawDataCollection)

--- a/DataFormats/HLTReco/test/TestTriggerEventFormat.sh
+++ b/DataFormats/HLTReco/test/TestTriggerEventFormat.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -ex
+#!/bin/bash
 
 function die { echo $1: status $2 ;  exit $2; }
 

--- a/DataFormats/HLTReco/test/test_readTriggerEvent_cfg.py
+++ b/DataFormats/HLTReco/test/test_readTriggerEvent_cfg.py
@@ -27,7 +27,8 @@ process.testReadTriggerEvent = cms.EDAnalyzer("TestReadTriggerEvent",
 )
 
 process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('testTriggerEvent2.root')
+    fileName = cms.untracked.string('testTriggerEvent2.root'),
+    fastCloning = cms.untracked.bool(False)
 )
 
 process.path = cms.Path(process.testReadTriggerEvent)

--- a/DataFormats/L1Scouting/test/TestL1ScoutingFormat.sh
+++ b/DataFormats/L1Scouting/test/TestL1ScoutingFormat.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -ex
+#!/bin/bash
 
 function die { echo $1: status $2 ;  exit $2; }
 

--- a/DataFormats/L1Scouting/test/read_L1Scouting_cfg.py
+++ b/DataFormats/L1Scouting/test/read_L1Scouting_cfg.py
@@ -33,7 +33,8 @@ process.l1ScoutingTestAnalyzer = cms.EDAnalyzer("TestReadL1Scouting",
 )
 
 process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('testL1Scouting2.root')
+    fileName = cms.untracked.string('testL1Scouting2.root'),
+    fastCloning = cms.untracked.bool(False)
 )
 
 process.path = cms.Path(process.l1ScoutingTestAnalyzer)

--- a/DataFormats/L1ScoutingRawData/test/TestSDSRawDataCollectionFormat.sh
+++ b/DataFormats/L1ScoutingRawData/test/TestSDSRawDataCollectionFormat.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -ex
+#!/bin/bash
 
 function die { echo $1: status $2 ;  exit $2; }
 

--- a/DataFormats/L1ScoutingRawData/test/read_SDSRawDataCollection_cfg.py
+++ b/DataFormats/L1ScoutingRawData/test/read_SDSRawDataCollection_cfg.py
@@ -13,7 +13,8 @@ process.testReadSDSDRawDataCollection = cms.EDAnalyzer("TestReadSDSRawDataCollec
 )
 
 process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('testSDSRawDataCollection2.root')
+    fileName = cms.untracked.string('testSDSRawDataCollection2.root'),
+    fastCloning = cms.untracked.bool(False)
 )
 
 process.path = cms.Path(process.testReadSDSDRawDataCollection)

--- a/DataFormats/L1TGlobal/test/TestGlobalObjectMapRecordFormat.sh
+++ b/DataFormats/L1TGlobal/test/TestGlobalObjectMapRecordFormat.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -ex
+#!/bin/bash
 
 function die { echo $1: status $2 ;  exit $2; }
 

--- a/DataFormats/L1TGlobal/test/test_readGlobalObjectMapRecord_cfg.py
+++ b/DataFormats/L1TGlobal/test/test_readGlobalObjectMapRecord_cfg.py
@@ -24,7 +24,8 @@ process.testReadGlobalObjectMapRecord = cms.EDAnalyzer("TestReadGlobalObjectMapR
 )
 
 process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('testGlobalObjectMapRecord2.root')
+    fileName = cms.untracked.string('testGlobalObjectMapRecord2.root'),
+    fastCloning = cms.untracked.bool(False)
 )
 
 process.path = cms.Path(process.testReadGlobalObjectMapRecord)

--- a/DataFormats/Scouting/test/TestRun2ScoutingFormats.sh
+++ b/DataFormats/Scouting/test/TestRun2ScoutingFormats.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -ex
+#!/bin/bash
 
 function die { echo $1: status $2 ;  exit $2; }
 

--- a/DataFormats/Scouting/test/TestRun3ScoutingFormats.sh
+++ b/DataFormats/Scouting/test/TestRun3ScoutingFormats.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -ex
+#!/bin/bash
 
 function die { echo $1: status $2 ;  exit $2; }
 
@@ -65,13 +65,15 @@ cmsRun ${LOCAL_TEST_DIR}/test_readRun3Scouting_cfg.py || die "Failure using test
 # one took the time to investigate that). When reading that file
 # the Service named "FixMissingStreamerInfos" needs to be used.
 
-oldFiles="testRun3Scouting_v3_v5_v3_v4_v5_v3_v5_v3_v3_CMSSW_12_4_0_split_99.root testRun3Scouting_v3_v5_v3_v4_v5_v3_v5_v3_v3_CMSSW_12_4_0_split_0.root"
-for file in $oldFiles; do
-  inputfile=$(edmFileInPath DataFormats/Scouting/data/$file) || die "Failure edmFileInPath DataFormats/Scouting/data/$file" $?
-  argsPassedToPython="--inputFile $inputfile --outputFileName testRun3Scouting2_CMSSW_12_4_0.root --electronVersion 5 --photonVersion 5 --vertexVersion 3"
-  cmsRun ${LOCAL_TEST_DIR}/test_readRun3Scouting_cfg.py $argsPassedToPython || die "Failed to read old file $file" $?
-done
+file=testRun3Scouting_v3_v5_v3_v4_v5_v3_v5_v3_v3_CMSSW_12_4_0_split_99.root
+inputfile=$(edmFileInPath DataFormats/Scouting/data/$file) || die "Failure edmFileInPath DataFormats/Scouting/data/$file" $?
+argsPassedToPython="--inputFile $inputfile --outputFileName testRun3Scouting2_CMSSW_12_4_0.root --electronVersion 5 --photonVersion 5 --vertexVersion 3"
+cmsRun ${LOCAL_TEST_DIR}/test_readRun3Scouting_cfg.py $argsPassedToPython || die "Failed to read old file $file" $?
 
+file=testRun3Scouting_v3_v5_v3_v4_v5_v3_v5_v3_v3_CMSSW_12_4_0_split_0.root
+inputfile=$(edmFileInPath DataFormats/Scouting/data/$file) || die "Failure edmFileInPath DataFormats/Scouting/data/$file" $?
+argsPassedToPython="--inputFile $inputfile --outputFileName testRun3Scouting2_CMSSW_12_4_0.root --electronVersion 5 --photonVersion 5 --vertexVersion 3 --fixStreamerInfo"
+cmsRun ${LOCAL_TEST_DIR}/test_readRun3Scouting_cfg.py $argsPassedToPython || die "Failed to read old file $file" $?
 
 oldFiles="testRun3Scouting_v3_v6_v3_v4_v5_v3_v5_v3_v3_CMSSW_13_0_3_split_99.root testRun3Scouting_v3_v6_v3_v4_v5_v3_v5_v3_v3_CMSSW_13_0_3_split_0.root"
 for file in $oldFiles; do

--- a/DataFormats/Scouting/test/test_readRun2Scouting_cfg.py
+++ b/DataFormats/Scouting/test/test_readRun2Scouting_cfg.py
@@ -90,7 +90,8 @@ process.testReadRun2Scouting = cms.EDAnalyzer("TestReadRun2Scouting",
 )
 
 process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string(args.outputFileName)
+    fileName = cms.untracked.string(args.outputFileName),
+    fastCloning = cms.untracked.bool(False)
 )
 
 process.path = cms.Path(process.testReadRun2Scouting)

--- a/DataFormats/Scouting/test/test_readRun3Scouting_cfg.py
+++ b/DataFormats/Scouting/test/test_readRun3Scouting_cfg.py
@@ -15,8 +15,9 @@ args = parser.parse_args()
 
 process = cms.Process("READ")
 
-process = fixReading_12_4_X_Files(process)
-print("FixingStreamerInfos")
+if args.fixStreamerInfo:
+    process = fixReading_12_4_X_Files(process)
+    print("FixingStreamerInfos")
 
 process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring("file:"+args.inputFile))
 
@@ -113,7 +114,8 @@ process.testReadRun3Scouting = cms.EDAnalyzer("TestReadRun3Scouting",
 )
 
 process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string(args.outputFileName)
+    fileName = cms.untracked.string(args.outputFileName),
+    fastCloning = cms.untracked.bool(False)
 )
 
 process.path = cms.Path(process.testReadRun3Scouting)

--- a/DataFormats/SiStripCluster/test/TestSiStripApproximateClusterCollection.sh
+++ b/DataFormats/SiStripCluster/test/TestSiStripApproximateClusterCollection.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -ex
+#!/bin/bash
 
 function die { echo $1: status $2 ;  exit $2; }
 

--- a/DataFormats/SiStripCluster/test/test_readSiStripApproximateClusterCollection_cfg.py
+++ b/DataFormats/SiStripCluster/test/test_readSiStripApproximateClusterCollection_cfg.py
@@ -11,7 +11,8 @@ process.testReadSiStripApproximateClusterCollection = cms.EDAnalyzer("TestReadSi
 )
 
 process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('testSiStripApproximateClusterCollection2.root')
+    fileName = cms.untracked.string('testSiStripApproximateClusterCollection2.root'),
+    fastCloning = cms.untracked.bool(False)
 )
 
 process.path = cms.Path(process.testReadSiStripApproximateClusterCollection)


### PR DESCRIPTION
#### PR description:

This is related to recent PR #46044 which added split level 0 input files to some raw data format unit tests. A function that  causes some StreamerInfo's to be explicitly loaded was being run for all the Run3Scouting tests, but the original intent was to only do that in the one case where it was necessary, in the split level 0 CMSSW_12_4_0 case. With this PR the unit tests behave as intended. This explicit load is related to the ROOT bug that affected releases 12_4_0 and 13_0_0 (see #43175).

I also noticed the new split level 0 tests were fast cloning. Although the read EDAnalyzer does the primary test, we get some extra test coverage by running the output module. With fast cloning the schema evolution is not run for the output module. This PR explicitly turns off fast cloning.

I also removed the "-ex" argument (top line in the shell scripts) to make the output less verbose.

This only affects the raw data format unit tests. It does not affect the actual data formats, any code run in production, or any other tests.

#### PR validation:

The affected unit tests pass.
