### PR TITLE
[14_1_X] Remove tensorflow::setLogging() as thread-unsafe

### DIFF
--- a/DQM/DTMonitorClient/src/DTOccupancyTestML.cc
+++ b/DQM/DTMonitorClient/src/DTOccupancyTestML.cc
@@ -125,7 +125,6 @@ void DTOccupancyTestML::dqmEndLuminosityBlock(DQMStore::IBooker& ibooker,
   vector<const DTChamber*> chambers = muonGeom->chambers();
 
   // Load graph
-  tensorflow::setLogging("3");
   edm::FileInPath modelFilePath("DQM/DTMonitorClient/data/occupancy_cnn_v1.pb");
   tensorflow::GraphDef* graphDef = tensorflow::loadGraphDef(modelFilePath.fullPath());
 

--- a/L1Trigger/L1CaloTrigger/plugins/L1NNCaloTauEmulator.cc
+++ b/L1Trigger/L1CaloTrigger/plugins/L1NNCaloTauEmulator.cc
@@ -717,7 +717,6 @@ void L1NNCaloTauEmulator::produce(edm::Event& iEvent, const edm::EventSetup& eSe
   }  // End while loop of barrel TowerClusters creation
 
   // Barrel TauMinator application
-  tensorflow::setLogging("2");
   int batchSize_CB = (int)(Nclusters_CB);
   tensorflow::TensorShape imageShape_CB({batchSize_CB, IEta_dim, IPhi_dim, 2});
   tensorflow::TensorShape positionShape_CB({batchSize_CB, 2});

--- a/L1Trigger/L1CaloTrigger/plugins/L1NNCaloTauProducer.cc
+++ b/L1Trigger/L1CaloTrigger/plugins/L1NNCaloTauProducer.cc
@@ -582,7 +582,6 @@ void L1NNCaloTauProducer::produce(edm::Event& iEvent, const edm::EventSetup& eSe
   }  // End while loop of endcap TowerClusters creation
 
   // Barrel TauMinator application
-  tensorflow::setLogging("2");
   int batchSize_CB = (int)(l1TowerClustersNxM_CB.size());
   tensorflow::TensorShape imageShape_CB({batchSize_CB, IEta_dim, IPhi_dim, 2});
   tensorflow::TensorShape positionShape_CB({batchSize_CB, 2});

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorAutoEncoderImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorAutoEncoderImpl.cc
@@ -61,8 +61,6 @@ HGCalConcentratorAutoEncoderImpl::HGCalConcentratorAutoEncoderImpl(const edm::Pa
     }
   }
 
-  tensorflow::setLogging("0");
-
   for (const auto& modelFilePset : modelFilePaths_) {
     std::string encoderPath = modelFilePset.getParameter<edm::FileInPath>("encoderModelFile").fullPath();
     std::string decoderPath = modelFilePset.getParameter<edm::FileInPath>("decoderModelFile").fullPath();

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1NNTauProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1NNTauProducer.cc
@@ -81,7 +81,6 @@ L1NNTauProducer::L1NNTauProducer(const edm::ParameterSet& cfg, const tensorflow:
 }
 
 std::unique_ptr<tensorflow::SessionCache> L1NNTauProducer::initializeGlobalCache(const edm::ParameterSet& cfg) {
-  tensorflow::setLogging("3");
   std::string graphPath = edm::FileInPath(cfg.getParameter<std::string>("NNFileName")).fullPath();
   return std::make_unique<tensorflow::SessionCache>(graphPath);
 }

--- a/PhysicsTools/TensorFlow/interface/TensorFlow.h
+++ b/PhysicsTools/TensorFlow/interface/TensorFlow.h
@@ -57,9 +57,6 @@ namespace tensorflow {
     Backend getBackend() const { return _backend; };
   };
 
-  // set the tensorflow log level
-  void setLogging(const std::string& level = "3");
-
   // loads a meta graph definition saved at exportDir using the SavedModel interface for a tag and
   // predefined options
   // transfers ownership

--- a/PhysicsTools/TensorFlow/src/TensorFlow.cc
+++ b/PhysicsTools/TensorFlow/src/TensorFlow.cc
@@ -87,16 +87,6 @@ namespace tensorflow {
     }
   }
 
-  void setLogging(const std::string& level) {
-    /*
-     * 0 = all messages are logged (default behavior)
-     * 1 = INFO messages are not printed
-     * 2 = INFO and WARNING messages are not printed
-     * 3 = INFO, WARNING, and ERROR messages are not printed
-     */
-    setenv("TF_CPP_MIN_LOG_LEVEL", level.c_str(), 0);
-  }
-
   MetaGraphDef* loadMetaGraphDef(const std::string& exportDir, const std::string& tag) {
     Options default_options{};
     return loadMetaGraphDef(exportDir, tag, default_options);

--- a/PhysicsTools/TensorFlow/test/testConstSessionCUDA.cc
+++ b/PhysicsTools/TensorFlow/test/testConstSessionCUDA.cc
@@ -54,7 +54,6 @@ process.add_(cms.Service('CUDAService'))
 
   // load the graph
   std::string pbFile = dataPath_ + "/constantgraph.pb";
-  tensorflow::setLogging();
   tensorflow::Options options{backend};
 
   tensorflow::GraphDef* graphDef = tensorflow::loadGraphDef(pbFile);

--- a/PhysicsTools/TensorFlow/test/testGraphLoadingCUDA.cc
+++ b/PhysicsTools/TensorFlow/test/testGraphLoadingCUDA.cc
@@ -54,7 +54,6 @@ process.add_(cms.Service('CUDAService'))
 
   // load the graph
   std::string pbFile = dataPath_ + "/constantgraph.pb";
-  tensorflow::setLogging();
   tensorflow::Options options{backend};
   tensorflow::GraphDef* graphDef = tensorflow::loadGraphDef(pbFile);
   CPPUNIT_ASSERT(graphDef != nullptr);

--- a/PhysicsTools/TensorFlow/test/testHelloWorld.cc
+++ b/PhysicsTools/TensorFlow/test/testHelloWorld.cc
@@ -37,7 +37,6 @@ void testHelloWorld::test() {
   // object to load and run the graph / session
   tensorflow::Status status;
   tensorflow::Options options{backend};
-  tensorflow::setLogging();
   tensorflow::RunOptions runOptions;
   tensorflow::SavedModelBundle bundle;
 

--- a/PhysicsTools/TensorFlow/test/testHelloWorldCUDA.cc
+++ b/PhysicsTools/TensorFlow/test/testHelloWorldCUDA.cc
@@ -57,7 +57,6 @@ process.add_(cms.Service('CUDAService'))
   // object to load and run the graph / session
   tensorflow::Status status;
   tensorflow::Options options{backend};
-  tensorflow::setLogging("0");
   tensorflow::RunOptions runOptions;
   tensorflow::SavedModelBundle bundle;
 

--- a/PhysicsTools/TensorFlow/test/testMetaGraphLoadingCUDA.cc
+++ b/PhysicsTools/TensorFlow/test/testMetaGraphLoadingCUDA.cc
@@ -54,7 +54,6 @@ process.add_(cms.Service('CUDAService'))
 
   // load the graph
   std::string exportDir = dataPath_ + "/simplegraph";
-  tensorflow::setLogging();
   tensorflow::Options options{backend};
   tensorflow::MetaGraphDef* metaGraphDef = tensorflow::loadMetaGraphDef(exportDir);
   CPPUNIT_ASSERT(metaGraphDef != nullptr);

--- a/PhysicsTools/TensorFlow/test/testSessionCacheCUDA.cc
+++ b/PhysicsTools/TensorFlow/test/testSessionCacheCUDA.cc
@@ -53,7 +53,6 @@ process.add_(cms.Service('CUDAService'))
 
   // load the graph and the session
   std::string pbFile = dataPath_ + "/constantgraph.pb";
-  tensorflow::setLogging();
   tensorflow::Options options{backend};
 
   // load the graph and the session

--- a/PhysicsTools/TensorFlow/test/testThreadPoolsCUDA.cc
+++ b/PhysicsTools/TensorFlow/test/testThreadPoolsCUDA.cc
@@ -60,7 +60,6 @@ process.add_(cms.Service('CUDAService'))
 
   // load the graph
   std::string pbFile = dataPath_ + "/constantgraph.pb";
-  tensorflow::setLogging();
   tensorflow::GraphDef* graphDef = tensorflow::loadGraphDef(pbFile);
   CPPUNIT_ASSERT(graphDef != nullptr);
 

--- a/PhysicsTools/TensorFlow/test/testVisibleDevicesCUDA.cc
+++ b/PhysicsTools/TensorFlow/test/testVisibleDevicesCUDA.cc
@@ -55,11 +55,9 @@ process.add_(cms.Service('CUDAService'))
   std::cout << "Testing CUDA backend" << std::endl;
   tensorflow::Backend backend = tensorflow::Backend::cuda;
   tensorflow::Options options{backend};
-  tensorflow::setLogging("0");
 
   // load the graph
   std::string pbFile = dataPath_ + "/constantgraph.pb";
-  tensorflow::setLogging();
   tensorflow::GraphDef* graphDef = tensorflow::loadGraphDef(pbFile);
   CPPUNIT_ASSERT(graphDef != nullptr);
 

--- a/RecoEcal/EgammaCoreTools/src/DeepSCGraphEvaluation.cc
+++ b/RecoEcal/EgammaCoreTools/src/DeepSCGraphEvaluation.cc
@@ -28,7 +28,6 @@ const std::vector<std::string> DeepSCGraphEvaluation::availableWindowInputs = {
 const std::vector<std::string> DeepSCGraphEvaluation::availableHitsInputs = {"ieta", "iphi", "iz", "en_withfrac"};
 
 DeepSCGraphEvaluation::DeepSCGraphEvaluation(const DeepSCConfiguration& cfg) : cfg_(cfg) {
-  tensorflow::setLogging("0");
   // Init TF graph and session objects
   initTensorFlowGraphAndSession();
   // Init scaler configs

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForOIDNN.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForOIDNN.cc
@@ -208,7 +208,6 @@ TSGForOIDNN::TSGForOIDNN(const edm::ParameterSet& iConfig)
   if (getStrategyFromDNN_) {
     edm::FileInPath dnnMetadataPath(dnnMetadataPath_);
     pt::read_json(dnnMetadataPath.fullPath(), metadata_);
-    tensorflow::setLogging("3");
 
     if (useRegressor_) {
       // use regressor

--- a/RecoTauTag/HLTProducers/src/L2TauTagNNProducer.cc
+++ b/RecoTauTag/HLTProducers/src/L2TauTagNNProducer.cc
@@ -234,8 +234,6 @@ std::unique_ptr<L2TauNNProducerCacheData> L2TauNNProducer::initializeGlobalCache
   cacheData->graphDef = tensorflow::loadGraphDef(graphPath);
   cacheData->session = tensorflow::createSession(cacheData->graphDef);
 
-  tensorflow::setLogging("2");
-
   boost::property_tree::ptree loadPtreeRoot;
   auto const normalizationDict = edm::FileInPath(cfg.getParameter<std::string>("normalizationDict")).fullPath();
   boost::property_tree::read_json(normalizationDict, loadPtreeRoot);

--- a/RecoTauTag/HLTProducers/src/L2TauTagNNProducerAlpaka.cc
+++ b/RecoTauTag/HLTProducers/src/L2TauTagNNProducerAlpaka.cc
@@ -233,8 +233,6 @@ std::unique_ptr<L2TauNNProducerAlpakaCacheData> L2TauNNProducerAlpaka::initializ
   cacheData->graphDef = tensorflow::loadGraphDef(graphPath);
   cacheData->session = tensorflow::createSession(cacheData->graphDef);
 
-  tensorflow::setLogging("2");
-
   boost::property_tree::ptree loadPtreeRoot;
   auto const normalizationDict = edm::FileInPath(cfg.getParameter<std::string>("normalizationDict")).fullPath();
   boost::property_tree::read_json(normalizationDict, loadPtreeRoot);


### PR DESCRIPTION
#### PR description:

Backport of https://github.com/cms-sw/cmssw/pull/46065

#### PR validation:

None beyond https://github.com/cms-sw/cmssw/pull/46065

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of https://github.com/cms-sw/cmssw/pull/46065 (following request in https://github.com/cms-sw/cmssw/pull/46065#issuecomment-2363258207)