### PR TITLE
[FWLite] Protect against version branch not existing in NANOAOD MetaData tree.

### DIFF
--- a/FWCore/FWLite/src/BranchMapReader.cc
+++ b/FWCore/FWLite/src/BranchMapReader.cc
@@ -595,6 +595,9 @@ namespace fwlite {
     edm::FileFormatVersion v;
     edm::FileFormatVersion* pV = &v;
     TBranch* bVer = metaDataTree->GetBranch(edm::poolNames::fileFormatVersionBranchName().c_str());
+    if (nullptr == bVer) {
+      return 0;
+    }
     bVer->SetAddress(&pV);
     bVer->GetEntry(0);
     fileVersion_ = v.value();


### PR DESCRIPTION
Opening a NANOAOD file succeeds in getting the MetaData tree but then there is no version branch in there, only process-history. This protection avoids a crash when opening a NANOAOD file.
