### PR TITLE
[14.1.X] migrate calotowers creation code  to use `EcalPFRecHitThresholds`

### DIFF
--- a/RecoLocalCalo/CaloTowersCreator/python/calotowermaker_cfi.py
+++ b/RecoLocalCalo/CaloTowersCreator/python/calotowermaker_cfi.py
@@ -149,8 +149,9 @@ calotowermaker = cms.EDProducer("CaloTowersCreator",
     HcalPhase = cms.int32(0),
 
 # Read HBHE thresholds from Global Tag
-    usePFThresholdsFromDB = cms.bool(False)
-    
+    usePFThresholdsFromDB = cms.bool(False),
+# Read ECAL thresholds from Global Tag
+    EcalRecHitThresh = cms.bool(False)
 )
 
 from Configuration.Eras.Modifier_run2_HE_2018_cff import run2_HE_2018

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
@@ -353,7 +353,10 @@ CaloTowersCreationAlgo::CaloTowersCreationAlgo(double EBthreshold,
   // nalgo=N;
 }
 
-void CaloTowersCreationAlgo::setThresFromDB(const HcalPFCuts* cuts) { hcalCuts = cuts; }
+void CaloTowersCreationAlgo::setThresFromDB(const EcalPFRecHitThresholds* EcalCuts, const HcalPFCuts* HcalCuts) {
+  ecalCuts = EcalCuts;
+  hcalCuts = HcalCuts;
+}
 
 void CaloTowersCreationAlgo::setGeometry(const CaloTowerTopology* cttopo,
                                          const CaloTowerConstituentsMap* ctmap,
@@ -629,7 +632,7 @@ void CaloTowersCreationAlgo::assignHitHcal(const CaloRecHit* recHit) {
       tower28.E_outer += e28;
       tower29.E_outer += e29;
     }  // not a "bad" hit
-  }    // end of special case
+  }  // end of special case
 
   else {
     HcalDetId hcalDetId(detId);
@@ -1253,14 +1256,22 @@ void CaloTowersCreationAlgo::getThresholdAndWeight(const DetId& detId, double& t
 
     EcalSubdetector subdet = (EcalSubdetector)(detId.subdetId());
     if (subdet == EcalBarrel) {
-      threshold = theEBthreshold;
+      if (ecalCuts == nullptr) {  // this means that ecalRecHitThresh_ is false
+        threshold = theEBthreshold;
+      } else {
+        threshold = (*ecalCuts)[detId];
+      }
       weight = theEBweight;
       if (weight <= 0.) {
         ROOT::Math::Interpolator my(theEBGrid, theEBWeights, ROOT::Math::Interpolation::kAKIMA);
         weight = my.Eval(theEBEScale);
       }
     } else if (subdet == EcalEndcap) {
-      threshold = theEEthreshold;
+      if (ecalCuts == nullptr) {
+        threshold = theEEthreshold;
+      } else {
+        threshold = (*ecalCuts)[detId];
+      }
       weight = theEEweight;
       if (weight <= 0.) {
         ROOT::Math::Interpolator my(theEEGrid, theEEWeights, ROOT::Math::Interpolation::kAKIMA);

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.h
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.h
@@ -30,6 +30,8 @@
 #include "CondFormats/DataRecord/interface/HcalPFCutsRcd.h"
 #include "CondTools/Hcal/interface/HcalPFCutsHandler.h"
 
+#include "CondFormats/EcalObjects/interface/EcalPFRecHitThresholds.h"
+
 class CaloTowerTopology;
 class HcalTopology;
 class CaloGeometry;
@@ -162,7 +164,7 @@ public:
                    const HcalTopology* htopo,
                    const CaloGeometry* geo);
 
-  void setThresFromDB(const HcalPFCuts* cuts);
+  void setThresFromDB(const EcalPFRecHitThresholds* EcalCuts, const HcalPFCuts* HcalCuts);
   // pass the containers of channels status from the event record (stored in DB)
   // these are called in  CaloTowersCreator
   void setHcalChStatusFromDB(const HcalChannelQuality* s) { theHcalChStatus = s; }
@@ -322,6 +324,7 @@ private:
   double theHOEScale;
   double theHF1EScale;
   double theHF2EScale;
+  const EcalPFRecHitThresholds* ecalCuts;
   const HcalPFCuts* hcalCuts;
   const CaloTowerTopology* theTowerTopology;
   const HcalTopology* theHcalTopology;


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/45803

#### PR description:

This PR is the ECAL equivalent of https://github.com/cms-sw/cmssw/pull/43329. 
While our final aim is to fully deprecate calotowers, there is no clear ETA for that. Several POGs still use calotowers, specially at HLT. So, to ensure that correct HCAL thresholds are used in making calotowers, the safest way is to use the thresholds from GT.
That is what is done in this PR. 
This PR was sparked by the observation that at the HLT we are using the following configuration:

```python
EBThreshold = cms.double( 0.07 )
EEThreshold = cms.double( 0.3 )
```

which looks exceedingly low given that 0.3 GeV threshold in EE for all crystals is too small threshold to mitigate the noise in EE.
There are crystals in EE where the threshold is order of 10 GeV (reaching up to ~50 GeV or maybe even higher these days).
Indeed inspecting the last IOV of the `EcalPFRecHitThresholdsRcd` associated tag at HLT,

```
$ conddb list 140X_dataRun3_HLT_v3 | grep EcalPFRecHitThresholdsRcd
[2024-08-26 10:47:34,394] INFO: Connecting to pro [frontier://PromptProd/cms_conditions]
EcalPFRecHitThresholdsRcd                               -                                                 EcalPFRecHitThresholds_2018_v1_hlt                               

$ conddb list EcalPFRecHitThresholds_2018_v1_hlt
[2024-08-26 10:47:48,292] INFO: Connecting to pro [frontier://PromptProd/cms_conditions]
[2024-08-26 10:47:48,471] INFO: Listing with a limit of 500 IOVs, starting from the highest since. If you need to see more, please increase the limit of returned results.
Since: Run   Insertion Time       Payload                                   Object Type                      
-----------  -------------------  ----------------------------------------  ------------------------------   
1            2018-03-28 14:25:39  9f22e391bcdcabe1f9f13608961bbed938c8a05c  EcalCondObjectContainer<float>   
337349       2020-09-24 08:42:44  f965e090d8749785f3d9c290bb08f247b90bd9fe  EcalCondObjectContainer<float>   
347532       2022-02-10 10:03:50  6bf33ca11214dec349a05af31b1f4af8526ffb30  EcalCondObjectContainer<float>   
 
$ conddb dump 6bf33ca11214dec349a05af31b1f4af8526ffb30 > dump.xml 
```

I see rather large thresholds especially in EE:

![Screenshot from 2024-08-26 10-46-58](https://github.com/user-attachments/assets/78be4105-e178-4c66-9fc4-082bae68656a)

This PR allows to change the logic of the code to use the `EcalPFRecHitThresholds` from GT instead of the fixed values.
The new parameter `EcalRecHitThresh` is set to false, such that this PR is technically a no-op.

#### PR validation:

Validation was purely technical: `runTheMatrix.py - l limited --ibeos`.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is a verbatim backport of https://github.com/cms-sw/cmssw/pull/45803 to the 2024 PRef and HIon data-taking release (CMSSW_14_1_X). TSG is aiming to deploy this + a new version of the HLT JECs for that run.