### PR TITLE
Update a few GTs in autoCond - CMSSW_14_0_X

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -33,12 +33,12 @@ autoCond = {
     'run2_hlt_relval'              :    '140X_dataRun2_HLT_relval_v1',
     # GlobalTag for Run3 HLT: identical to the online GT - 140X_dataRun3_HLT_v3 with snapshot at 2024-02-29 18:52:29 (UTC)
     'run3_hlt'                     :    '140X_dataRun3_HLT_frozen_v3',
-    # GlobalTag for Run3 data relvals (express GT) - 140X_dataRun3_Express_v1 but snapshot at 2024-01-20 12:00:00 (UTC)
-    'run3_data_express'            :    '140X_dataRun3_Express_frozen_v1',
-    # GlobalTag for Run3 data relvals (prompt GT) - 140X_dataRun3_Prompt_v3 but snapshot at 2024-05-31 09:09:12 (UTC)
-    'run3_data_prompt'             :    '140X_dataRun3_Prompt_frozen_v3',
-    # GlobalTag for Run3 offline data reprocessing - snapshot at 2024-09-04 16:25:09 (UTC)
-    'run3_data'                    :    '140X_dataRun3_v9',
+    # GlobalTag for Run3 data relvals (express GT) - 140X_dataRun3_Express_v3 but with snapshot at 2024-06-12 09:01:43
+    'run3_data_express'            :    '140X_dataRun3_Express_frozen_v2',
+    # GlobalTag for Run3 data relvals (prompt GT) - 140X_dataRun3_Prompt_v4 but with snapshot at 2024-09-25 14:18:52
+    'run3_data_prompt'             :    '140X_dataRun3_Prompt_frozen_v4',
+    # GlobalTag for Run3 offline data reprocessing - snapshot at 2024-09-25 12:44:01 (UTC)
+    'run3_data'                    :    '140X_dataRun3_v13',
     # GlobalTag for Run3 offline data reprocessing with Prompt GT, currently for 2022FG - snapshot at 2024-02-12 12:00:00 (UTC)
     'run3_data_PromptAnalysis'     :    '140X_dataRun3_PromptAnalysis_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
@@ -66,7 +66,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2022
     'phase1_2022_design'           :    '140X_mcRun3_2022_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2022
-    'phase1_2022_realistic'        :    '140X_mcRun3_2022_realistic_v3',
+    'phase1_2022_realistic'        :    '140X_mcRun3_2022_realistic_v9',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 post-EE+ leak
     'phase1_2022_realistic_postEE' :    '140X_mcRun3_2022_realistic_postEE_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2022, Strip tracker in DECO mode
@@ -78,7 +78,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2023
     'phase1_2023_design'           :    '140X_mcRun3_2023_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        :    '140X_mcRun3_2023_realistic_v3',
+    'phase1_2023_realistic'        :    '140X_mcRun3_2023_realistic_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 postBPix issue 2023
     'phase1_2023_realistic_postBPix'  : '140X_mcRun3_2023_realistic_postBPix_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 preBPix 2023, Strip tracker in DECO mode
@@ -92,7 +92,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2024
     'phase1_2024_design'           :    '140X_mcRun3_2024_design_v11',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        :    '140X_mcRun3_2024_realistic_v15',
+    'phase1_2024_realistic'        :    '140X_mcRun3_2024_realistic_v24',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2024, Strip tracker in DECO mode
     'phase1_2024_cosmics'          :    '140X_mcRun3_2024cosmics_realistic_deco_v13',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2024, Strip tracker in DECO mode


### PR DESCRIPTION
#### PR description:

The following GTs had been updated in autoCond:

- `run3_data_express` to [140X_dataRun3_Express_frozen_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/140X_dataRun3_Express_frozen_v2), which is a copy of 140X_dataRun3_Express_v3 but with snapshot at 2024-06-12 09:01:43, see [diff](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_dataRun3_Express_v1/140X_dataRun3_Express_v3) between 140X_dataRun3_Express_v1 and 140X_dataRun3_Express_v3

- `run3_data_prompt` to [140X_dataRun3_Prompt_frozen_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/140X_dataRun3_Prompt_frozen_v4), which is a copy of 140X_dataRun3_Prompt_v4 but with snapshot at 2024-09-25 14:18:52, see [diff](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_dataRun3_Prompt_v3/140X_dataRun3_Prompt_v4) between 140X_dataRun3_Prompt_v3 and 140X_dataRun3_Prompt_v4

- `run3_data` to [140X_dataRun3_v13](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/140X_dataRun3_v13) ([diff](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_dataRun3_v13/140X_dataRun3_v9) wrt previous _v9), see [cmsTalk](https://cms-talk.web.cern.ch/t/call-for-conditions-re-reco-of-2024-eras-c-d-e/42331/13)

- `phase1_2022_realistic` to [140X_mcRun3_2022_realistic_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/140X_mcRun3_2022_realistic_v9) ([diff](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2022_realistic_v9/140X_mcRun3_2022_realistic_v3) wrt previous _v3), see [cmsTalk](https://cms-talk.web.cern.ch/t/call-for-conditions-full-2022-2023-data-rereco-and-mc-production-in-140x/32887/39)

- `phase1_2023_realistic` to [140X_mcRun3_2023_realistic_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/140X_mcRun3_2023_realistic_v6) ([diff](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2023_realistic_v6/140X_mcRun3_2023_realistic_v3) wrt previous _v3), see [cmsTalk](https://cms-talk.web.cern.ch/t/call-for-conditions-full-2022-2023-data-rereco-and-mc-production-in-140x/32887/39)

- `phase1_2024_realistic` to [140X_mcRun3_2024_realistic_v24](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/140X_mcRun3_2024_realistic_v24) ([diff](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2024_realistic_v21/140X_mcRun3_2024_realistic_v24) wrt previous _v21), see [cmsTalk](https://cms-talk.web.cern.ch/t/final-call-for-run3summer24-mc-conditions-in-140x/41226)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported 

Backport of  #46124