### PR TITLE
Add runtime allocation of PF rechit fraction SoA

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -48,6 +48,16 @@ def customiseForOffline(process):
 
     return process
 
+def customizeHLTfor46135(process):
+    """Remove pfRecHitFractionAllocation from PFClusterSoAProducer config"""
+    for producer in producers_by_type(process, "PFClusterSoAProducer@alpaka"):
+        if hasattr(producer, 'pfRecHitFractionAllocation'):
+            delattr(producer, 'pfRecHitFractionAllocation')
+    for producer in producers_by_type(process, "alpaka_serial_sync::PFClusterSoAProducer"):
+        if hasattr(producer, 'pfRecHitFractionAllocation'):
+            delattr(producer, 'pfRecHitFractionAllocation')
+    return process
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
@@ -55,5 +65,7 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
 
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
+
+    process = customizeHLTfor46135(process)
 
     return process

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducer.cc
@@ -8,7 +8,7 @@
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Utilities/interface/StreamID.h"
-#include "HeterogeneousCore/AlpakaCore/interface/alpaka/stream/EDProducer.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/stream/SynchronizingEDProducer.h"
 #include "HeterogeneousCore/CUDACore/interface/JobConfigurationGPURecord.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/PFCPositionCalculatorBase.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/alpaka/PFClusterParamsDeviceCollection.h"
@@ -16,7 +16,7 @@
 #include "RecoParticleFlow/PFRecHitProducer/interface/PFRecHitTopologyRecord.h"
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
-  class PFClusterSoAProducer : public stream::EDProducer<> {
+  class PFClusterSoAProducer : public stream::SynchronizingEDProducer<> {
   public:
     PFClusterSoAProducer(edm::ParameterSet const& config)
         : pfClusParamsToken(esConsumes(config.getParameter<edm::ESInputTag>("pfClusterParams"))),
@@ -24,8 +24,35 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           inputPFRecHitSoA_Token_{consumes(config.getParameter<edm::InputTag>("pfRecHits"))},
           outputPFClusterSoA_Token_{produces()},
           outputPFRHFractionSoA_Token_{produces()},
-          synchronise_(config.getParameter<bool>("synchronise")),
-          pfRecHitFractionAllocation_(config.getParameter<int>("pfRecHitFractionAllocation")) {}
+          num_rhf_{cms::alpakatools::make_host_buffer<uint32_t, Platform>()},
+          synchronise_(config.getParameter<bool>("synchronise")) {}
+
+    void acquire(device::Event const& event, device::EventSetup const& setup) override {
+      const reco::PFClusterParamsDeviceCollection& params = setup.getData(pfClusParamsToken);
+      const reco::PFRecHitHCALTopologyDeviceCollection& topology = setup.getData(topologyToken_);
+      const reco::PFRecHitHostCollection& pfRecHits = event.get(inputPFRecHitSoA_Token_);
+      int nRH = 0;
+      if (pfRecHits->metadata().size() != 0)
+        nRH = pfRecHits->size();
+
+      pfClusteringVars_ = std::make_optional<reco::PFClusteringVarsDeviceCollection>(nRH, event.queue());
+      pfClusteringEdgeVars_ = std::make_optional<reco::PFClusteringEdgeVarsDeviceCollection>(nRH * 8, event.queue());
+      pfClusters_ = std::make_optional<reco::PFClusterDeviceCollection>(nRH, event.queue());
+
+      *num_rhf_ = 0;
+
+      if (nRH != 0) {
+        PFClusterProducerKernel kernel(event.queue(), pfRecHits);
+        kernel.step1(event.queue(),
+                     params,
+                     topology,
+                     *pfClusteringVars_,
+                     *pfClusteringEdgeVars_,
+                     pfRecHits,
+                     *pfClusters_,
+                     num_rhf_.data());
+      }
+    }
 
     void produce(device::Event& event, device::EventSetup const& setup) override {
       const reco::PFClusterParamsDeviceCollection& params = setup.getData(pfClusParamsToken);
@@ -35,28 +62,26 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       if (pfRecHits->metadata().size() != 0)
         nRH = pfRecHits->size();
 
-      reco::PFClusteringVarsDeviceCollection pfClusteringVars{nRH, event.queue()};
-      reco::PFClusteringEdgeVarsDeviceCollection pfClusteringEdgeVars{(nRH * 8), event.queue()};
-      reco::PFClusterDeviceCollection pfClusters{nRH, event.queue()};
-      reco::PFRecHitFractionDeviceCollection pfrhFractions{nRH * pfRecHitFractionAllocation_, event.queue()};
-
       if (nRH != 0) {
+        pfrhFractions_ = std::make_optional<reco::PFRecHitFractionDeviceCollection>(*num_rhf_.data(), event.queue());
         PFClusterProducerKernel kernel(event.queue(), pfRecHits);
-        kernel.execute(event.queue(),
-                       params,
-                       topology,
-                       pfClusteringVars,
-                       pfClusteringEdgeVars,
-                       pfRecHits,
-                       pfClusters,
-                       pfrhFractions);
+        kernel.step2(event.queue(),
+                     params,
+                     topology,
+                     *pfClusteringVars_,
+                     *pfClusteringEdgeVars_,
+                     pfRecHits,
+                     *pfClusters_,
+                     *pfrhFractions_);
+      } else {
+        pfrhFractions_ = std::make_optional<reco::PFRecHitFractionDeviceCollection>(0, event.queue());
       }
 
       if (synchronise_)
         alpaka::wait(event.queue());
 
-      event.emplace(outputPFClusterSoA_Token_, std::move(pfClusters));
-      event.emplace(outputPFRHFractionSoA_Token_, std::move(pfrhFractions));
+      event.emplace(outputPFClusterSoA_Token_, std::move(*pfClusters_));
+      event.emplace(outputPFRHFractionSoA_Token_, std::move(*pfrhFractions_));
     }
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -65,7 +90,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       desc.add<edm::ESInputTag>("pfClusterParams", edm::ESInputTag(""));
       desc.add<edm::ESInputTag>("topology", edm::ESInputTag(""));
       desc.add<bool>("synchronise", false);
-      desc.add<int>("pfRecHitFractionAllocation", 120);
       descriptions.addWithDefaultLabel(desc);
     }
 
@@ -75,8 +99,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     const edm::EDGetTokenT<reco::PFRecHitHostCollection> inputPFRecHitSoA_Token_;
     const device::EDPutToken<reco::PFClusterDeviceCollection> outputPFClusterSoA_Token_;
     const device::EDPutToken<reco::PFRecHitFractionDeviceCollection> outputPFRHFractionSoA_Token_;
+    cms::alpakatools::host_buffer<uint32_t> num_rhf_;
+    std::optional<reco::PFClusteringVarsDeviceCollection> pfClusteringVars_;
+    std::optional<reco::PFClusteringEdgeVarsDeviceCollection> pfClusteringEdgeVars_;
+    std::optional<reco::PFClusterDeviceCollection> pfClusters_;
+    std::optional<reco::PFRecHitFractionDeviceCollection> pfrhFractions_;
     const bool synchronise_;
-    const int pfRecHitFractionAllocation_;
   };
 
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducerKernel.dev.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducerKernel.dev.cc
@@ -1090,7 +1090,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                   const reco::PFRecHitHCALTopologyDeviceCollection::ConstView topology,
                                   const reco::PFRecHitHostCollection::ConstView pfRecHits,
                                   reco::PFClusterDeviceCollection::View clusterView,
-                                  reco::PFRecHitFractionDeviceCollection::View fracView,
                                   uint32_t* __restrict__ nSeeds) const {
       const int nRH = pfRecHits.size();
 
@@ -1199,7 +1198,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                   const reco::PFRecHitHostCollection::ConstView pfRecHits,
                                   reco::PFClusteringVarsDeviceCollection::View pfClusteringVars,
                                   reco::PFClusterDeviceCollection::View clusterView,
-                                  uint32_t* __restrict__ nSeeds) const {
+                                  uint32_t* __restrict__ nSeeds,
+                                  uint32_t* __restrict__ num_rhf_) const {
       const int nRH = pfRecHits.size();
       int& totalSeedOffset = alpaka::declareSharedVar<int, __COUNTER__>(acc);
       int& totalSeedFracOffset = alpaka::declareSharedVar<int, __COUNTER__>(acc);
@@ -1302,6 +1302,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         pfClusteringVars.pcrhFracSize() = totalSeedFracOffset;
         pfClusteringVars.nRHFracs() = totalSeedFracOffset;
         clusterView.nRHFracs() = totalSeedFracOffset;
+        *num_rhf_ = totalSeedFracOffset;
         clusterView.nSeeds() = *nSeeds;
         clusterView.nTopos() = pfClusteringVars.nTopos();
 
@@ -1467,14 +1468,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     alpaka::memset(queue, nSeeds, 0x00);  // Reset nSeeds
   }
 
-  void PFClusterProducerKernel::execute(Queue& queue,
-                                        const reco::PFClusterParamsDeviceCollection& params,
-                                        const reco::PFRecHitHCALTopologyDeviceCollection& topology,
-                                        reco::PFClusteringVarsDeviceCollection& pfClusteringVars,
-                                        reco::PFClusteringEdgeVarsDeviceCollection& pfClusteringEdgeVars,
-                                        const reco::PFRecHitHostCollection& pfRecHits,
-                                        reco::PFClusterDeviceCollection& pfClusters,
-                                        reco::PFRecHitFractionDeviceCollection& pfrhFractions) {
+  void PFClusterProducerKernel::step1(Queue& queue,
+                                      const reco::PFClusterParamsDeviceCollection& params,
+                                      const reco::PFRecHitHCALTopologyDeviceCollection& topology,
+                                      reco::PFClusteringVarsDeviceCollection& pfClusteringVars,
+                                      reco::PFClusteringEdgeVarsDeviceCollection& pfClusteringEdgeVars,
+                                      const reco::PFRecHitHostCollection& pfRecHits,
+                                      reco::PFClusterDeviceCollection& pfClusters,
+                                      uint32_t* __restrict__ num_rhf_) {
     const int nRH = pfRecHits->size();
     const int threadsPerBlock = 256;
     const int blocks = divide_up_by(nRH, threadsPerBlock);
@@ -1488,7 +1489,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                         topology.view(),
                         pfRecHits.view(),
                         pfClusters.view(),
-                        pfrhFractions.view(),
                         nSeeds.data());
     // prepareTopoInputs
     alpaka::exec<Acc1D>(queue,
@@ -1524,7 +1524,19 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                         pfRecHits.view(),
                         pfClusteringVars.view(),
                         pfClusters.view(),
-                        nSeeds.data());
+                        nSeeds.data(),
+                        num_rhf_);
+  }
+
+  void PFClusterProducerKernel::step2(Queue& queue,
+                                      const reco::PFClusterParamsDeviceCollection& params,
+                                      const reco::PFRecHitHCALTopologyDeviceCollection& topology,
+                                      reco::PFClusteringVarsDeviceCollection& pfClusteringVars,
+                                      reco::PFClusteringEdgeVarsDeviceCollection& pfClusteringEdgeVars,
+                                      const reco::PFRecHitHostCollection& pfRecHits,
+                                      reco::PFClusterDeviceCollection& pfClusters,
+                                      reco::PFRecHitFractionDeviceCollection& pfrhFractions) {
+    const int nRH = pfRecHits->size();
 
     // fillRhfIndex
     alpaka::exec<Acc2D>(queue,

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducerKernel.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducerKernel.h
@@ -4,7 +4,6 @@
 #include "DataFormats/ParticleFlowReco/interface/alpaka/PFRecHitDeviceCollection.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitHostCollection.h"
 #include "DataFormats/ParticleFlowReco/interface/alpaka/PFClusterDeviceCollection.h"
-#include "DataFormats/ParticleFlowReco/interface/PFClusterHostCollection.h"
 #include "DataFormats/ParticleFlowReco/interface/alpaka/PFRecHitFractionDeviceCollection.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/alpaka/PFClusterParamsDeviceCollection.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/alpaka/PFClusteringVarsDeviceCollection.h"
@@ -40,23 +39,23 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   public:
     PFClusterProducerKernel(Queue& queue, const reco::PFRecHitHostCollection& pfRecHits);
 
-    void step1(Queue& queue,
-               const reco::PFClusterParamsDeviceCollection& params,
-               const reco::PFRecHitHCALTopologyDeviceCollection& topology,
-               reco::PFClusteringVarsDeviceCollection& pfClusteringVars,
-               reco::PFClusteringEdgeVarsDeviceCollection& pfClusteringEdgeVars,
-               const reco::PFRecHitHostCollection& pfRecHits,
-               reco::PFClusterDeviceCollection& pfClusters,
-               uint32_t* __restrict__ num_rhf_);
+    void seedTopoAndContract(Queue& queue,
+                             const reco::PFClusterParamsDeviceCollection& params,
+                             const reco::PFRecHitHCALTopologyDeviceCollection& topology,
+                             reco::PFClusteringVarsDeviceCollection& pfClusteringVars,
+                             reco::PFClusteringEdgeVarsDeviceCollection& pfClusteringEdgeVars,
+                             const reco::PFRecHitHostCollection& pfRecHits,
+                             reco::PFClusterDeviceCollection& pfClusters,
+                             uint32_t* __restrict__ nRHF);
 
-    void step2(Queue& queue,
-               const reco::PFClusterParamsDeviceCollection& params,
-               const reco::PFRecHitHCALTopologyDeviceCollection& topology,
-               reco::PFClusteringVarsDeviceCollection& pfClusteringVars,
-               reco::PFClusteringEdgeVarsDeviceCollection& pfClusteringEdgeVars,
-               const reco::PFRecHitHostCollection& pfRecHits,
-               reco::PFClusterDeviceCollection& pfClusters,
-               reco::PFRecHitFractionDeviceCollection& pfrhFractions);
+    void cluster(Queue& queue,
+                 const reco::PFClusterParamsDeviceCollection& params,
+                 const reco::PFRecHitHCALTopologyDeviceCollection& topology,
+                 reco::PFClusteringVarsDeviceCollection& pfClusteringVars,
+                 reco::PFClusteringEdgeVarsDeviceCollection& pfClusteringEdgeVars,
+                 const reco::PFRecHitHostCollection& pfRecHits,
+                 reco::PFClusterDeviceCollection& pfClusters,
+                 reco::PFRecHitFractionDeviceCollection& pfrhFractions);
 
   private:
     cms::alpakatools::device_buffer<Device, uint32_t> nSeeds;

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducerKernel.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducerKernel.h
@@ -4,6 +4,7 @@
 #include "DataFormats/ParticleFlowReco/interface/alpaka/PFRecHitDeviceCollection.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitHostCollection.h"
 #include "DataFormats/ParticleFlowReco/interface/alpaka/PFClusterDeviceCollection.h"
+#include "DataFormats/ParticleFlowReco/interface/PFClusterHostCollection.h"
 #include "DataFormats/ParticleFlowReco/interface/alpaka/PFRecHitFractionDeviceCollection.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/alpaka/PFClusterParamsDeviceCollection.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/alpaka/PFClusteringVarsDeviceCollection.h"
@@ -39,14 +40,23 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   public:
     PFClusterProducerKernel(Queue& queue, const reco::PFRecHitHostCollection& pfRecHits);
 
-    void execute(Queue& queue,
-                 const reco::PFClusterParamsDeviceCollection& params,
-                 const reco::PFRecHitHCALTopologyDeviceCollection& topology,
-                 reco::PFClusteringVarsDeviceCollection& pfClusteringVars,
-                 reco::PFClusteringEdgeVarsDeviceCollection& pfClusteringEdgeVars,
-                 const reco::PFRecHitHostCollection& pfRecHits,
-                 reco::PFClusterDeviceCollection& pfClusters,
-                 reco::PFRecHitFractionDeviceCollection& pfrhFractions);
+    void step1(Queue& queue,
+               const reco::PFClusterParamsDeviceCollection& params,
+               const reco::PFRecHitHCALTopologyDeviceCollection& topology,
+               reco::PFClusteringVarsDeviceCollection& pfClusteringVars,
+               reco::PFClusteringEdgeVarsDeviceCollection& pfClusteringEdgeVars,
+               const reco::PFRecHitHostCollection& pfRecHits,
+               reco::PFClusterDeviceCollection& pfClusters,
+               uint32_t* __restrict__ num_rhf_);
+
+    void step2(Queue& queue,
+               const reco::PFClusterParamsDeviceCollection& params,
+               const reco::PFRecHitHCALTopologyDeviceCollection& topology,
+               reco::PFClusteringVarsDeviceCollection& pfClusteringVars,
+               reco::PFClusteringEdgeVarsDeviceCollection& pfClusteringEdgeVars,
+               const reco::PFRecHitHostCollection& pfRecHits,
+               reco::PFClusterDeviceCollection& pfClusters,
+               reco::PFRecHitFractionDeviceCollection& pfrhFractions);
 
   private:
     cms::alpakatools::device_buffer<Device, uint32_t> nSeeds;


### PR DESCRIPTION
#### PR description:

This PR is made to address crashes of the type in https://github.com/cms-sw/cmssw/issues/45477 and https://github.com/cms-sw/cmssw/issues/44634. It provides runtime allocation of the PF RecHit Fraction SoA to minimize memory usage and avoid crashes when the allocation needed was not a reasonable multiple of the number of PF RecHits. This change is made in a way which does not touch the configuration, and therefore is transparent to the HLT menu.

#### PR validation:

PR physics performance was validated using the matrix workflow `12434.423` and checking output Legacy CPU vs GPU comparisons. The event throughput was tested on a HLT test machine with the following results:

```
Running 3 times over 6300 events with 8 jobs, each with 32 threads, 32 streams and 1 GPUs

Reference: 565.8 ±   0.3 ev/s

This PR: 564.7 ±   1.3 ev/s
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport.

@fwyzard @waredjeb 