### PR TITLE
[JME] Set up Pileup Jet ID for AK4 Puppi V18 jets

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -361,7 +361,7 @@ def miniAOD_customizeCommon(process):
     (pp_on_AA).toReplaceWith(
         process.makePatTausTask, _makePatTausTaskWithTauReReco
         )
-    
+
     # Adding puppi jets
     process.load('CommonTools.PileupAlgos.Puppi_cff')
     process.load('RecoJets.JetProducers.ak4PFJets_cfi')
@@ -383,6 +383,10 @@ def miniAOD_customizeCommon(process):
     )
     task.add(process.patJetPuppiCharge)
 
+    ## PUJetID for ak4PFJetsPuppi
+    process.load("RecoJets.JetProducers.PileupJetID_cfi")
+    task.add(process.pileUpJetIDPuppiTask)
+
     def _add_jetsPuppi(process):
         from PhysicsTools.PatAlgos.tools.jetTools import addJetCollection
         noDeepFlavourDiscriminators = [x.value() if isinstance(x, cms.InputTag) else x for x in process.patJets.discriminatorSources 
@@ -394,9 +398,13 @@ def miniAOD_customizeCommon(process):
                      )
 
         process.patJetGenJetMatchPuppi.matched = 'slimmedGenJets'
-    
+
         process.patJetsPuppi.jetChargeSource = cms.InputTag("patJetPuppiCharge")
-    
+
+        ## Store PUJetID variables in patJetsPuppi
+        process.patJetsPuppi.userData.userFloats.src += [cms.InputTag("pileupJetIdPuppi:fullDiscriminant")]
+        process.patJetsPuppi.userData.userInts.src += [cms.InputTag("pileupJetIdPuppi:fullId")]
+
         process.selectedPatJetsPuppi.cut = cms.string("pt > 10")
     
         from PhysicsTools.PatAlgos.slimming.applyDeepBtagging_cff import applyDeepBtagging

--- a/RecoJets/JetProducers/python/PileupJetIDCutParams_cfi.py
+++ b/RecoJets/JetProducers/python/PileupJetIDCutParams_cfi.py
@@ -106,6 +106,36 @@ full_106x_UL16_chs_wp = cms.PSet(
 ###########################################################
 full_106x_UL16APV_chs_wp = full_106x_UL16_chs_wp.clone()
 
+###########################################################
+## Working points for the 133X trainig for AK4 Puppi jets
+###########################################################
+full_133x_Winter24_puppiv18_wp = cms.PSet(
+    # 4 Eta Categories  0-2.5 2.5-2.75 2.75-3.0 3.0-5.0
+    # 5 Pt Categories   0-10, 10-20, 20-30, 30-40, 40-50
+
+    #Tight Id
+    Pt010_Tight  = cms.vdouble(-1.00, -1.00,  -1.00,  -1.00),
+    Pt1020_Tight = cms.vdouble(0.038, 0.219, -0.220, -0.254),
+    Pt2030_Tight = cms.vdouble(0.033, 0.060, -0.154, -0.154),
+    Pt3040_Tight = cms.vdouble(0.056, 0.103, -0.159, -0.109),
+    Pt4050_Tight = cms.vdouble(0.043, 0.127, -0.067, -0.059),
+
+    #Medium Id
+    Pt010_Medium  = cms.vdouble(-1.00,  - 1.00,  -1.00,  -1.00),
+    Pt1020_Medium = cms.vdouble(-0.200, -0.068, -0.158, -0.384),
+    Pt2030_Medium = cms.vdouble(-0.109, -0.179, -0.293, -0.322),
+    Pt3040_Medium = cms.vdouble(-0.043, -0.124, -0.259, -0.286),
+    Pt4050_Medium = cms.vdouble(-0.034, -0.071, -0.198, -0.235),
+
+    #Loose Id
+    Pt010_Loose  = cms.vdouble( -1.00,  -1.00,  -1.00,  -1.00),
+    Pt1020_Loose = cms.vdouble(-0.723, -0.392, -0.277, -0.516),
+    Pt2030_Loose = cms.vdouble(-0.548, -0.347, -0.313, -0.489),
+    Pt3040_Loose = cms.vdouble(-0.413, -0.289, -0.322, -0.438),
+    Pt4050_Loose = cms.vdouble(-0.279, -0.219, -0.279, -0.384),
+)
+
+
 #########################################################
 ## Empty cutbased WP for compatibility
 ###########################################################

--- a/RecoJets/JetProducers/python/PileupJetIDParams_cfi.py
+++ b/RecoJets/JetProducers/python/PileupJetIDParams_cfi.py
@@ -167,6 +167,21 @@ for train in full_106x_UL16APV_chs.trainings:
     train.tmvaWeights = train.tmvaWeights.value().replace("UL17", "UL16APV")
 
 ####################################################################################################################
+full_133x_Winter24_puppi_v18_wp = full_106x_UL17_chs.clone(
+    JetIdParams = full_133x_Winter24_puppiv18_wp,
+    trainings = {0: dict(tmvaWeights   = "RecoJets/JetProducers/data/pileupJetId_133X_Winter24_Eta0p0To2p5_puppiV18_BDT.weights.xml.gz",
+                         tmvaVariables = trainingVariables_102X_Eta0To3),
+                 1: dict(tmvaWeights   = "RecoJets/JetProducers/data/pileupJetId_133X_Winter24_Eta2p5To2p75_puppiV18_BDT.weights.xml.gz",
+                         tmvaVariables = trainingVariables_102X_Eta0To3),
+                 2: dict(tmvaWeights   = "RecoJets/JetProducers/data/pileupJetId_133X_Winter24_Eta2p75To3p0_puppiV18_BDT.weights.xml.gz",
+                         tmvaVariables = trainingVariables_102X_Eta0To3),
+                 3: dict(tmvaWeights   = "RecoJets/JetProducers/data/pileupJetId_133X_Winter24_Eta3p0To5p0_puppiV18_BDT.weights.xml.gz",
+                         tmvaVariables = trainingVariables_102X_Eta3To5)
+    }
+)
+
+
+####################################################################################################################
 cutbased = cms.PSet(
     impactParTkThreshold = cms.double(1.),
     cutBased = cms.bool(True),

--- a/RecoJets/JetProducers/python/PileupJetID_cfi.py
+++ b/RecoJets/JetProducers/python/PileupJetID_cfi.py
@@ -52,3 +52,18 @@ pileUpJetIDTask = cms.Task(pileupJetId,
                            pileupJetIdCalculator,
                            pileupJetIdEvaluator
 )
+
+#
+#
+#
+_puppiV18algos_133X_Winter24 = cms.VPSet(full_133x_Winter24_puppi_v18_wp,cutbased)
+
+pileupJetIdPuppi = pileupJetId.clone(
+    jets = "ak4PFJetsPuppi",
+    jec  = "AK4PFPuppi",
+    srcConstituentWeights = "puppi",
+    algos = cms.VPSet(_puppiV18algos_133X_Winter24),
+)
+
+pileUpJetIDPuppiTask = cms.Task(pileupJetIdPuppi)
+


### PR DESCRIPTION
#### PR description:

This PR sets up the Pileup Jet ID for AK4 Puppi V18 jets for MiniAODv5/NanoAODv15 reMini-reNano campaign. The training was performed by by Jihoon Shin (@jshin96) and presented in a JMAR [meeting](https://indico.cern.ch/event/1429230/#3-run3-pileup-jet-id-training). In this PR, the Pileup Jet ID is set up to be calculated at the PAT step and stored for `slimmedJetsPuppi`. A separate PR will soon follow to add the Pileup Jet ID branch for the NANO step.

This PR should be tested with the training weights in this cms-data/RecoJets-JetProducers PR:  https://github.com/cms-data/RecoJets-JetProducers/pull/14

FYI JMAR convenors (@fiemmi @colizz @wajidalikhan)

#### PR validation:

- passes the usual runTheMatrix test: `runTheMatrix.py -l limited -i all --ibeos`
- passes MiniAOD workflows: `runTheMatrix.py -i all --ibeos  -l 2500.021,2500.022,2500.023,2500.024,2500.031,2500.032,2500.033,2500.034`