### PR TITLE
Bugfix in simulation of scintillator noise at startup

### DIFF
--- a/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
@@ -240,7 +240,7 @@ def HGCal_setRealisticStartupNoise(process):
       (for instance turning on the 0th  bit turns off the impact of fluence in Si)
     """
     process=HGCal_setRealisticNoiseSi(process,byDose=True,byDoseAlgo=1)
-    process=HGCal_setRealisticNoiseSci(process,byDose=True,byDoseAlgo=2+8+16,referenceIdark=0.125,referenceXtalk=0.01)
+    process=HGCal_setRealisticNoiseSci(process,byDose=True,byDoseAlgo=2+16+32,byDoseFactor=0,referenceIdark=0.125,referenceXtalk=0.01)
     return process
 
 def HGCal_setRealisticStartupNoise_fixedSiPMTileAreasAndSN(process,targetSN=7,referenceXtalk=-1,ignorePedestal=False):


### PR DESCRIPTION
#### PR description:
This PR fixes a bug in the settings for the simulation of the noise in the HGCal scintillator region for the startup scenario. The scaling of the noise by the dose factor was not being turned off for the startup scenario. The bug was discovered after looking at hits and occupancies in the scintillator region [1]. The fix was validated by comparing samples produced with the new settings and samples produced with the old settings but with the flags to ignore the effect of dose and fluence. The results were shown to agree, validating the new settings. 

[1] https://indico.cern.ch/event/1413991/#9-occupancy-studies-in-the-sip
