### PR TITLE
Replace usleep with std::this_thread::sleep_for

### DIFF
--- a/FWCore/Concurrency/README.md
+++ b/FWCore/Concurrency/README.md
@@ -167,10 +167,11 @@ Example: protecting `std::cout` so printouts do not intertwine.
 ```C++
   edm::SerialTaskQueue queue;
   
+  using namespace std::chrono_literals;
   oneapi::tbb::task_group group;
   for(int i=0; i<3; ++i) {
     group.run([&queue, &group] {
-      usleep(1000);
+      std::this_thread::sleep_for(1000us);
       queue.push(group1, [i](){
         std::cout <<"loop 1"<<i<<"\n";
       });
@@ -179,7 +180,7 @@ Example: protecting `std::cout` so printouts do not intertwine.
   
   for(int i=0; i<6; ++i) {
     group.run([&queue, &group] {
-      usleep(1500);
+      std::this_thread::sleep_for(1500us);
       queue.push(group1, [i](){
         std::cout <<"loop 2"<<i<<"\n";
       });

--- a/FWCore/Concurrency/test/limitedtaskqueue_t.cppunit.cpp
+++ b/FWCore/Concurrency/test/limitedtaskqueue_t.cppunit.cpp
@@ -8,7 +8,7 @@
 #include <iostream>
 
 #include <cppunit/extensions/HelperMacros.h>
-#include <unistd.h>
+#include <chrono>
 #include <memory>
 #include <atomic>
 #include "oneapi/tbb/task_arena.h"
@@ -32,6 +32,7 @@ public:
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(LimitedTaskQueue_test);
+using namespace std::chrono_literals;
 
 void LimitedTaskQueue_test::testPush() {
   {
@@ -44,19 +45,19 @@ void LimitedTaskQueue_test::testPush() {
 
       queue.push(group, [&count, &waitingTasks] {
         CPPUNIT_ASSERT(count++ == 0);
-        usleep(10);
+        std::this_thread::sleep_for(10us);
         --waitingTasks;
       });
 
       queue.push(group, [&count, &waitingTasks] {
         CPPUNIT_ASSERT(count++ == 1);
-        usleep(10);
+        std::this_thread::sleep_for(10us);
         --waitingTasks;
       });
 
       queue.push(group, [&count, &waitingTasks] {
         CPPUNIT_ASSERT(count++ == 2);
-        usleep(10);
+        std::this_thread::sleep_for(10us);
         --waitingTasks;
       });
 
@@ -78,21 +79,21 @@ void LimitedTaskQueue_test::testPush() {
 
       queue.push(group, [&count, &waitingTasks] {
         CPPUNIT_ASSERT(count++ < kMax);
-        usleep(10);
+        std::this_thread::sleep_for(10us);
         --count;
         --waitingTasks;
       });
 
       queue.push(group, [&count, &waitingTasks] {
         CPPUNIT_ASSERT(count++ < kMax);
-        usleep(10);
+        std::this_thread::sleep_for(10us);
         --count;
         --waitingTasks;
       });
 
       queue.push(group, [&count, &waitingTasks] {
         CPPUNIT_ASSERT(count++ < kMax);
-        usleep(10);
+        std::this_thread::sleep_for(10us);
         --count;
         --waitingTasks;
       });
@@ -148,7 +149,7 @@ void LimitedTaskQueue_test::testPause() {
         }
         --waitingTasks;
       });
-      usleep(100);
+      std::this_thread::sleep_for(100us);
       //can't do == since the queue may not have processed the first task yet
       CPPUNIT_ASSERT(2 >= count);
       while (not resumerSet) {

--- a/FWCore/Concurrency/test/serialtaskqueue_t.cppunit.cpp
+++ b/FWCore/Concurrency/test/serialtaskqueue_t.cppunit.cpp
@@ -8,7 +8,7 @@
 #include <iostream>
 
 #include <cppunit/extensions/HelperMacros.h>
-#include <unistd.h>
+#include <chrono>
 #include <memory>
 #include <atomic>
 #include "oneapi/tbb/task_arena.h"
@@ -32,6 +32,7 @@ public:
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(SerialTaskQueue_test);
+using namespace std::chrono_literals;
 
 void SerialTaskQueue_test::testPush() {
   std::atomic<unsigned int> count{0};
@@ -43,19 +44,19 @@ void SerialTaskQueue_test::testPush() {
 
     queue.push(group, [&count, &waitingTasks] {
       CPPUNIT_ASSERT(count++ == 0);
-      usleep(10);
+      std::this_thread::sleep_for(10us);
       --waitingTasks;
     });
 
     queue.push(group, [&count, &waitingTasks] {
       CPPUNIT_ASSERT(count++ == 1);
-      usleep(10);
+      std::this_thread::sleep_for(10us);
       --waitingTasks;
     });
 
     queue.push(group, [&count, &waitingTasks] {
       CPPUNIT_ASSERT(count++ == 2);
-      usleep(10);
+      std::this_thread::sleep_for(10us);
       --waitingTasks;
     });
 
@@ -80,7 +81,7 @@ void SerialTaskQueue_test::testPause() {
         CPPUNIT_ASSERT(count++ == 0);
         --waitingTasks;
       });
-      usleep(1000);
+      std::this_thread::sleep_for(1000us);
       CPPUNIT_ASSERT(0 == count);
       queue.resume();
       do {
@@ -106,7 +107,7 @@ void SerialTaskQueue_test::testPause() {
         CPPUNIT_ASSERT(count++ == 3);
         --waitingTasks;
       });
-      usleep(100);
+      std::this_thread::sleep_for(100us);
       //can't do == since the queue may not have processed the first task yet
       CPPUNIT_ASSERT(2 >= count);
       queue.resume();

--- a/FWCore/Concurrency/test/serialtaskqueuechain_t.cppunit.cpp
+++ b/FWCore/Concurrency/test/serialtaskqueuechain_t.cppunit.cpp
@@ -8,7 +8,7 @@
 #include <iostream>
 
 #include <cppunit/extensions/HelperMacros.h>
-#include <unistd.h>
+#include <chrono>
 #include <memory>
 #include <atomic>
 #include <thread>
@@ -32,6 +32,7 @@ public:
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(SerialTaskQueueChain_test);
+using namespace std::chrono_literals;
 
 void SerialTaskQueueChain_test::testPush() {
   std::atomic<unsigned int> count{0};
@@ -44,19 +45,19 @@ void SerialTaskQueueChain_test::testPush() {
     std::atomic<int> waiting{3};
     chain.push(group, [&count, &waiting] {
       CPPUNIT_ASSERT(count++ == 0);
-      usleep(10);
+      std::this_thread::sleep_for(10us);
       --waiting;
     });
 
     chain.push(group, [&count, &waiting] {
       CPPUNIT_ASSERT(count++ == 1);
-      usleep(10);
+      std::this_thread::sleep_for(10us);
       --waiting;
     });
 
     chain.push(group, [&count, &waiting] {
       CPPUNIT_ASSERT(count++ == 2);
-      usleep(10);
+      std::this_thread::sleep_for(10us);
       --waiting;
     });
 
@@ -80,19 +81,19 @@ void SerialTaskQueueChain_test::testPushOne() {
 
     chain.push(group, [&count, &waiting] {
       CPPUNIT_ASSERT(count++ == 0);
-      usleep(10);
+      std::this_thread::sleep_for(10us);
       --waiting;
     });
 
     chain.push(group, [&count, &waiting] {
       CPPUNIT_ASSERT(count++ == 1);
-      usleep(10);
+      std::this_thread::sleep_for(10us);
       --waiting;
     });
 
     chain.push(group, [&count, &waiting] {
       CPPUNIT_ASSERT(count++ == 2);
-      usleep(10);
+      std::this_thread::sleep_for(10us);
       --waiting;
     });
 

--- a/FWCore/Concurrency/test/waitingtasklist_t.cppunit.cpp
+++ b/FWCore/Concurrency/test/waitingtasklist_t.cppunit.cpp
@@ -8,7 +8,7 @@
 #include <iostream>
 
 #include <cppunit/extensions/HelperMacros.h>
-#include <unistd.h>
+#include <chrono>
 #include <memory>
 #include <atomic>
 #include <thread>
@@ -66,6 +66,7 @@ namespace {
   };
 
 }  // namespace
+using namespace std::chrono_literals;
 
 void WaitingTaskList_test::addThenDone() {
   std::atomic<bool> called{false};
@@ -79,7 +80,7 @@ void WaitingTaskList_test::addThenDone() {
     oneapi::tbb::task_group group;
     waitList.add(edm::WaitingTaskHolder(group, t));
 
-    usleep(10);
+    std::this_thread::sleep_for(10us);
     CPPUNIT_ASSERT(false == called);
 
     waitList.doneWaiting(std::exception_ptr{});
@@ -100,7 +101,7 @@ void WaitingTaskList_test::addThenDone() {
 
     waitList.add(edm::WaitingTaskHolder(group, t));
 
-    usleep(10);
+    std::this_thread::sleep_for(10us);
     CPPUNIT_ASSERT(false == called);
 
     waitList.doneWaiting(std::exception_ptr{});
@@ -142,7 +143,7 @@ void WaitingTaskList_test::addThenDoneFailed() {
 
     waitList.add(edm::WaitingTaskHolder(group, t));
 
-    usleep(10);
+    std::this_thread::sleep_for(10us);
     CPPUNIT_ASSERT(false == called);
 
     waitList.doneWaiting(std::make_exception_ptr(std::string("failed")));

--- a/FWCore/Framework/test/stubs/TestStreamAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/TestStreamAnalyzers.cc
@@ -13,6 +13,7 @@ for testing purposes only.
 #include <tuple>
 #include <unistd.h>
 #include <vector>
+#include <chrono>
 
 #include "FWCore/Framework/interface/CacheHandle.h"
 #include "FWCore/Framework/interface/stream/EDAnalyzer.h"
@@ -570,7 +571,7 @@ namespace edmtest {
         }
         // Force events to be processed concurrently
         if (sleepTime_ > 0) {
-          usleep(sleepTime_);
+          std::this_thread::sleep_for(std::chrono::microseconds(sleepTime_));
         }
       }
 
@@ -721,7 +722,7 @@ namespace edmtest {
 
         // Force events to be processed concurrently
         if (testGlobalCache->sleepTime_ > 0) {
-          usleep(testGlobalCache->sleepTime_);
+          std::this_thread::sleep_for(std::chrono::microseconds(testGlobalCache->sleepTime_));
         }
       }
 

--- a/FWCore/Framework/test/stubs/TestStreamFilters.cc
+++ b/FWCore/Framework/test/stubs/TestStreamFilters.cc
@@ -14,6 +14,7 @@ for testing purposes only.
 #include <tuple>
 #include <unistd.h>
 #include <vector>
+#include <chrono>
 
 #include "FWCore/Framework/interface/CacheHandle.h"
 #include "FWCore/Framework/interface/stream/EDFilter.h"
@@ -931,7 +932,7 @@ namespace edmtest {
         }
         // Force events to be processed concurrently
         if (sleepTime_ > 0) {
-          usleep(sleepTime_);
+          std::this_thread::sleep_for(std::chrono::microseconds(sleepTime_));
         }
         return true;
       }
@@ -1083,7 +1084,7 @@ namespace edmtest {
 
         // Force events to be processed concurrently
         if (testGlobalCache->sleepTime_ > 0) {
-          usleep(testGlobalCache->sleepTime_);
+          std::this_thread::sleep_for(std::chrono::microseconds(testGlobalCache->sleepTime_));
         }
         return true;
       }

--- a/FWCore/Framework/test/stubs/TestStreamProducers.cc
+++ b/FWCore/Framework/test/stubs/TestStreamProducers.cc
@@ -14,6 +14,7 @@ for testing purposes only.
 #include <tuple>
 #include <unistd.h>
 #include <vector>
+#include <chrono>
 
 #include "FWCore/Framework/interface/CacheHandle.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
@@ -975,7 +976,7 @@ namespace edmtest {
         }
         // Force events to be processed concurrently
         if (sleepTime_ > 0) {
-          usleep(sleepTime_);
+          std::this_thread::sleep_for(std::chrono::microseconds(sleepTime_));
         }
       }
 
@@ -1126,7 +1127,7 @@ namespace edmtest {
 
         // Force events to be processed concurrently
         if (testGlobalCache->sleepTime_ > 0) {
-          usleep(testGlobalCache->sleepTime_);
+          std::this_thread::sleep_for(std::chrono::microseconds(testGlobalCache->sleepTime_));
         }
       }
 

--- a/FWCore/Framework/test/stubs/TestTBBTasksAnalyzer.cc
+++ b/FWCore/Framework/test/stubs/TestTBBTasksAnalyzer.cc
@@ -19,7 +19,7 @@
 // system include files
 #include <memory>
 #include <atomic>
-#include <unistd.h>
+#include <chrono>
 #include "oneapi/tbb/task_group.h"
 #include "oneapi/tbb/task_arena.h"
 
@@ -108,7 +108,7 @@ unsigned int TestTBBTasksAnalyzer::startTasks(unsigned int iNTasks, unsigned int
           break;
         }
       }
-      usleep(m_usecondsToSleep);
+      std::this_thread::sleep_for(std::chrono::microseconds(m_usecondsToSleep));
       --(count);
     });
   }

--- a/FWCore/Framework/test/stubs/ToyIntProducers.cc
+++ b/FWCore/Framework/test/stubs/ToyIntProducers.cc
@@ -32,7 +32,7 @@ Toy EDProducers of Ints for testing purposes only.
 #include <cassert>
 #include <string>
 #include <vector>
-#include <unistd.h>
+#include <chrono>
 
 namespace edmtest {
 
@@ -790,7 +790,7 @@ namespace edmtest {
       // in multi-threaded processes. Otherwise, the modules are so
       // fast it is hard to tell whether a module finishes before the
       // the Framework starts the next module.
-      usleep(sleepTime_);
+      std::this_thread::sleep_for(std::chrono::microseconds(sleepTime_));
     }
     processBlock.emplace(bpbToken_, value_);
   }
@@ -799,7 +799,7 @@ namespace edmtest {
       check(processBlock.get(epbGet_), epbExpect_);
     }
     if (sleepTime_ > 0) {
-      usleep(sleepTime_);
+      std::this_thread::sleep_for(std::chrono::microseconds(sleepTime_));
     }
     processBlock.emplace(epbToken_, value_);
   }
@@ -808,7 +808,7 @@ namespace edmtest {
       check(processBlock.get(aipbGet_), aipbExpect_);
     }
     if (sleepTime_ > 0) {
-      usleep(sleepTime_);
+      std::this_thread::sleep_for(std::chrono::microseconds(sleepTime_));
     }
   }
   void NonEventIntProducer::globalBeginRunProduce(edm::Run& r, edm::EventSetup const&) const {
@@ -816,7 +816,7 @@ namespace edmtest {
       check(r.get(brGet_), brExpect_);
     }
     if (sleepTime_ > 0) {
-      usleep(sleepTime_);
+      std::this_thread::sleep_for(std::chrono::microseconds(sleepTime_));
     }
     r.emplace(brToken_, value_);
   }
@@ -825,7 +825,7 @@ namespace edmtest {
       check(r.get(erGet_), erExpect_);
     }
     if (sleepTime_ > 0) {
-      usleep(sleepTime_);
+      std::this_thread::sleep_for(std::chrono::microseconds(sleepTime_));
     }
     r.emplace(erToken_, value_);
   }
@@ -834,7 +834,7 @@ namespace edmtest {
       check(l.get(blGet_), blExpect_);
     }
     if (sleepTime_ > 0) {
-      usleep(sleepTime_);
+      std::this_thread::sleep_for(std::chrono::microseconds(sleepTime_));
     }
     l.emplace(blToken_, value_);
   }
@@ -843,7 +843,7 @@ namespace edmtest {
       check(l.get(elGet_), elExpect_);
     }
     if (sleepTime_ > 0) {
-      usleep(sleepTime_);
+      std::this_thread::sleep_for(std::chrono::microseconds(sleepTime_));
     }
     l.emplace(elToken_, value_);
   }

--- a/FWCore/Integration/bin/interprocess.cc
+++ b/FWCore/Integration/bin/interprocess.cc
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <string>
 #include <thread>
+#include <chrono>
 
 #include "FWCore/TestProcessor/interface/TestProcessor.h"
 #include "DataFormats/TestObjects/interface/ToyProducts.h"
@@ -184,7 +185,7 @@ int main(int argc, char* argv[]) {
 
             serializer.serialize(value);
             std::cerr << uniqueID << " process: " << value.size() << " " << counter << std::endl;
-            //usleep(10000000);
+            //std::this_thread::sleep_for(std::chrono::microseconds(10000000));
             break;
           }
           case edm::Transition::EndLuminosityBlock: {

--- a/FWCore/Integration/bin/interprocess_random.cc
+++ b/FWCore/Integration/bin/interprocess_random.cc
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <string>
 #include <thread>
+#include <chrono>
 
 #include "FWCore/TestProcessor/interface/TestProcessor.h"
 #include "DataFormats/TestObjects/interface/ToyProducts.h"
@@ -178,7 +179,7 @@ int main(int argc, char* argv[]) {
 
             serializer.serialize(toSend);
             std::cerr << uniqueID << " process: " << toSend.first.value << " " << counter << std::endl;
-            //usleep(10000000);
+            //std::this_thread::sleep_for(std::chrono::microseconds(10000000));
             break;
           }
           default: {

--- a/FWCore/Integration/plugins/AcquireIntESProducer.cc
+++ b/FWCore/Integration/plugins/AcquireIntESProducer.cc
@@ -29,8 +29,8 @@
 
 #include <memory>
 #include <optional>
-#include <unistd.h>
 #include <vector>
+#include <chrono>
 
 namespace {
   constexpr int kAcquireTestValue = 11;
@@ -42,6 +42,7 @@ namespace {
 
 namespace edmtest {
 
+  using namespace std::chrono_literals;
   class AcquireIntESProducer : public edm::ESProducerExternalWork {
   public:
     AcquireIntESProducer(edm::ParameterSet const&);
@@ -108,13 +109,13 @@ namespace edmtest {
 
     setWhatAcquiredProducedWithLambda(
         [this](ESTestRecordI const& record, edm::WaitingTaskWithArenaHolder holder) {
-          usleep(200000);
+          std::this_thread::sleep_for(200ms);
           auto returnValue = std::make_unique<TestValue>(kAcquireTestValueUniquePtr1);
           lambdaUniqueTestPointers_[record.iovIndex()] = returnValue.get();
           return returnValue;
         },
         [this](ESTestRecordI const& record, auto testValue) {
-          usleep(200000);
+          std::this_thread::sleep_for(200ms);
           if (testValue.get() != lambdaUniqueTestPointers_[record.iovIndex()]) {
             throw cms::Exception("TestFailure") << "AcquireIntESProducer::<lambda produceUniquePtr>"
                                                 << " unexpected value passed in as argument";
@@ -125,7 +126,7 @@ namespace edmtest {
 
     setWhatAcquiredProducedWithLambda(
         [this](ESTestRecordI const& record, edm::WaitingTaskWithArenaHolder holder) {
-          usleep(200000);
+          std::this_thread::sleep_for(200ms);
           std::vector<TestValue> testVector;
           testVector.push_back(kAcquireTestValueOptional1);
           auto returnValue = std::make_optional<std::vector<TestValue>>(std::move(testVector));
@@ -133,7 +134,7 @@ namespace edmtest {
           return returnValue;
         },
         [this](ESTestRecordI const& record, std::optional<std::vector<TestValue>> testValue) {
-          usleep(200000);
+          std::this_thread::sleep_for(200ms);
           if (&testValue.value()[0] != lambdaOptionalTestPointers_[record.iovIndex()]) {
             throw cms::Exception("TestFailure") << "AcquireIntESProducer::<lambda produceOptional>"
                                                 << " unexpected value passed in as argument";
@@ -164,7 +165,7 @@ namespace edmtest {
   }
 
   int AcquireIntESProducer::acquire(ESTestRecordI const& record, edm::WaitingTaskWithArenaHolder holder) {
-    usleep(200000);
+    std::this_thread::sleep_for(200ms);
 
     test_acquire::Cache& iovCache = caches_[record.iovIndex()];
     iovCache.retrieved().clear();
@@ -199,7 +200,7 @@ namespace edmtest {
   }
 
   std::unique_ptr<ESTestDataI> AcquireIntESProducer::produce(ESTestRecordI const& record, int valueReturnedByAcquire) {
-    usleep(200000);
+    std::this_thread::sleep_for(200ms);
 
     if (valueReturnedByAcquire != kAcquireTestValue) {
       throw cms::Exception("TestFailure") << "AcquireIntESProducer::produce"
@@ -229,7 +230,7 @@ namespace edmtest {
 
   std::unique_ptr<AcquireIntESProducer::TestValue> AcquireIntESProducer::acquireUniquePtr(
       ESTestRecordI const& record, edm::WaitingTaskWithArenaHolder holder) {
-    usleep(200000);
+    std::this_thread::sleep_for(200ms);
     auto returnValue = std::make_unique<TestValue>(kAcquireTestValueUniquePtr1);
     uniqueTestPointers_[record.iovIndex()] = returnValue.get();
     return returnValue;
@@ -237,7 +238,7 @@ namespace edmtest {
 
   std::unique_ptr<ESTestDataI> AcquireIntESProducer::produceUniquePtr(ESTestRecordI const& record,
                                                                       std::unique_ptr<TestValue> testValue) {
-    usleep(200000);
+    std::this_thread::sleep_for(200ms);
     if (testValue.get() != uniqueTestPointers_[record.iovIndex()]) {
       throw cms::Exception("TestFailure") << "AcquireIntESProducer::produceUniquePtr"
                                           << " unexpected value passed in as argument";
@@ -247,7 +248,7 @@ namespace edmtest {
 
   std::optional<std::vector<AcquireIntESProducer::TestValue>> AcquireIntESProducer::acquireOptional(
       ESTestRecordI const& record, edm::WaitingTaskWithArenaHolder holder) {
-    usleep(200000);
+    std::this_thread::sleep_for(200ms);
     std::vector<TestValue> testVector;
     testVector.push_back(kAcquireTestValueOptional1);
     auto returnValue = std::make_optional<std::vector<TestValue>>(std::move(testVector));
@@ -257,7 +258,7 @@ namespace edmtest {
 
   std::unique_ptr<ESTestDataI> AcquireIntESProducer::produceOptional(ESTestRecordI const& record,
                                                                      std::optional<std::vector<TestValue>> testValue) {
-    usleep(200000);
+    std::this_thread::sleep_for(200ms);
     if (&testValue.value()[0] != optionalTestPointers_[record.iovIndex()]) {
       throw cms::Exception("TestFailure") << "AcquireIntESProducer::produceOptional"
                                           << " unexpected value passed in as argument";

--- a/FWCore/Integration/plugins/AcquireIntProducer.cc
+++ b/FWCore/Integration/plugins/AcquireIntProducer.cc
@@ -20,7 +20,7 @@ namespace edm {
 }
 
 namespace edmtest {
-
+  using namespace std::chrono_literals;
   class AcquireIntProducer : public edm::global::EDProducer<edm::ExternalWork, edm::StreamCache<test_acquire::Cache>> {
   public:
     explicit AcquireIntProducer(edm::ParameterSet const& pset);
@@ -77,7 +77,7 @@ namespace edmtest {
                                    edm::Event const& event,
                                    edm::EventSetup const&,
                                    edm::WaitingTaskWithArenaHolder holder) const {
-    usleep(1000000);
+    std::this_thread::sleep_for(1s);
 
     test_acquire::Cache* streamCacheData = streamCache(streamID);
     streamCacheData->retrieved().clear();
@@ -91,7 +91,7 @@ namespace edmtest {
   }
 
   void AcquireIntProducer::produce(edm::StreamID streamID, edm::Event& event, edm::EventSetup const&) const {
-    usleep(1000000);
+    std::this_thread::sleep_for(1s);
 
     int sum = 0;
     for (auto v : streamCache(streamID)->processed()) {

--- a/FWCore/Integration/plugins/SourceWithWaits.cc
+++ b/FWCore/Integration/plugins/SourceWithWaits.cc
@@ -7,7 +7,7 @@
 //         Created:  12 October 2023
 
 // This source allows configuring both a time per lumi section
-// and events per lumi. Calls to usleep are inserted in the
+// and events per lumi. Calls to std::this_thread::sleep_for are inserted in the
 // getNextItemType function in the amount
 //
 //   (time per lumi) / (events per lumi + 1)
@@ -115,15 +115,13 @@ namespace edmtest {
   }
 
   edm::InputSource::ItemTypeInfo SourceWithWaits::getNextItemType() {
-    constexpr unsigned int secondsToMicroseconds = 1000000;
-
     if (startedNewRun_) {
-      usleep(secondsToMicroseconds * sleepAfterStartOfRun_);
+      std::this_thread::sleep_for(std::chrono::duration<double>(sleepAfterStartOfRun_));
       startedNewRun_ = false;
     }
 
     if (lastEventOfLumi_ || noEventsInLumi_) {
-      usleep(secondsToMicroseconds * timePerLumi_ / (eventsPerLumi_[currentLumi_ - 1] + 1));
+      std::this_thread::sleep_for(std::chrono::duration<double>(timePerLumi_ / (eventsPerLumi_[currentLumi_ - 1] + 1)));
       lastEventOfLumi_ = false;
       noEventsInLumi_ = false;
     }
@@ -193,8 +191,7 @@ namespace edmtest {
     }
     // Handle events in the current lumi
     else if (eventInCurrentLumi_ < eventsPerLumi_[currentLumi_ - 1] && lumisPerRun_ != 0) {
-      // note the argument to usleep is microseconds, timePerLumi_ is in seconds
-      usleep(secondsToMicroseconds * timePerLumi_ / (eventsPerLumi_[currentLumi_ - 1] + 1));
+      std::this_thread::sleep_for(std::chrono::duration<double>(timePerLumi_ / (eventsPerLumi_[currentLumi_ - 1] + 1)));
       ++eventInCurrentLumi_;
       ++currentEvent_;
       if (eventInCurrentLumi_ == eventsPerLumi_[currentLumi_ - 1]) {

--- a/FWCore/Integration/plugins/TransformAsyncIntProducer.cc
+++ b/FWCore/Integration/plugins/TransformAsyncIntProducer.cc
@@ -5,6 +5,7 @@
 #include "FWCore/Utilities/interface/Exception.h"
 
 #include <thread>
+#include <chrono>
 namespace edmtest {
   class TransformAsyncIntProducer : public edm::global::EDProducer<edm::Transformer> {
   public:
@@ -27,7 +28,8 @@ namespace edmtest {
               throw cms::Exception("TransformShouldNotBeCalled");
             }
             WorkCache ret;
-            ret.thread_ = std::make_shared<std::thread>([iTask] { usleep(100000); });
+            using namespace std::chrono_literals;
+            ret.thread_ = std::make_shared<std::thread>([iTask] { std::this_thread::sleep_for(100ms); });
             ret.value_ = IntProduct(iFrom.value + offset);
             return ret;
           },

--- a/FWCore/Integration/plugins/TransformAsyncIntStreamProducer.cc
+++ b/FWCore/Integration/plugins/TransformAsyncIntStreamProducer.cc
@@ -5,6 +5,7 @@
 #include "FWCore/Utilities/interface/Exception.h"
 
 #include <thread>
+#include <chrono>
 namespace edmtest {
   class TransformAsyncIntStreamProducer : public edm::stream::EDProducer<edm::Transformer> {
   public:
@@ -26,7 +27,8 @@ namespace edmtest {
               throw cms::Exception("TransformShouldNotBeCalled");
             }
             WorkCache ret;
-            ret.thread_ = std::make_shared<std::thread>([iTask] { usleep(100000); });
+            using namespace std::chrono_literals;
+            ret.thread_ = std::make_shared<std::thread>([iTask] { std::this_thread::sleep_for(100ms); });
             ret.value_ = IntProduct(iFrom.value + offset);
             return ret;
           },

--- a/FWCore/Modules/src/TimeStudyModules.cc
+++ b/FWCore/Modules/src/TimeStudyModules.cc
@@ -11,12 +11,12 @@
 //
 
 // system include files
-#include <unistd.h>
 #include <vector>
 #include <thread>
 #include <atomic>
 #include <condition_variable>
 #include <mutex>
+#include <chrono>
 
 // user include files
 #include "FWCore/Framework/interface/global/EDProducer.h"
@@ -60,7 +60,7 @@ namespace timestudy {
           (void)e.getHandle(t);
         }
         //Event number minimum value is 1
-        usleep(eventTimes_[(e.id().event() - 1) % eventTimes_.size()]);
+        std::this_thread::sleep_for(std::chrono::microseconds(eventTimes_[(e.id().event() - 1) % eventTimes_.size()]));
       }
 
       static void fillDescription(edm::ParameterSetDescription& desc) {
@@ -248,15 +248,15 @@ namespace timestudy {
           if (v[1] > longestTime) {
             longestTime = v[1];
           }
-          usleep(v[0]);
+          std::this_thread::sleep_for(std::chrono::microseconds(v[0]));
         }
         //simulate running external device
-        usleep(longestTime);
+        std::this_thread::sleep_for(std::chrono::microseconds(longestTime));
 
         //simulate copying data back
         for (auto i : streamsToProcess) {
           auto const& v = waitTimesPerStream_[i];
-          usleep(v[2]);
+          std::this_thread::sleep_for(std::chrono::microseconds(v[2]));
           waitingTaskPerStream_[i].doneWaiting(std::exception_ptr());
         }
       }

--- a/FWCore/Sources/src/IDGeneratorSourceBase.cc
+++ b/FWCore/Sources/src/IDGeneratorSourceBase.cc
@@ -2,6 +2,7 @@
 ----------------------------------------------------------------------*/
 
 #include <cerrno>
+#include <chrono>
 
 #include "DataFormats/Provenance/interface/LuminosityBlockAuxiliary.h"
 #include "DataFormats/Provenance/interface/RunAuxiliary.h"
@@ -149,7 +150,7 @@ namespace edm {
     EventID oldEventID = eventID_;
     advanceToNext(eventID_, presentTime_);
     if (eventCreationDelay_ > 0) {
-      usleep(eventCreationDelay_);
+      std::this_thread::sleep_for(std::chrono::microseconds(eventCreationDelay_));
     }
     size_t index = fileIndex();
     bool another = setRunAndEventInfo(eventID_, presentTime_, eType_);

--- a/IOMC/RandomEngine/test/TestRandomNumberServiceGlobal.cc
+++ b/IOMC/RandomEngine/test/TestRandomNumberServiceGlobal.cc
@@ -80,7 +80,7 @@ the text file containing the states.
 #include <mutex>
 #include <sstream>
 #include <string>
-#include <unistd.h>
+#include <chrono>
 
 namespace {
   std::mutex write_mutex;
@@ -188,7 +188,8 @@ void TestRandomNumberServiceGlobal::analyze(edm::StreamID streamID,
                                             edm::EventSetup const&) const {
   // Add some sleep to encourage all the streams to get events to process.
   if (nStreams_ > 1) {
-    usleep(25000);
+    using namespace std::chrono_literals;
+    std::this_thread::sleep_for(25ms);
   }
 
   if (dump_) {


### PR DESCRIPTION
#### PR description:

POSIX has deprecated the use of usleep

This was pointed out by the 'flaw finder' on the IB page.

#### PR validation:

code compiles.