### PR TITLE
[14.1.X] fix minimum of the di-muon mass window in the Z→μμ validation tool

### DIFF
--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/Zmumu_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/Zmumu_cfg.py
@@ -144,7 +144,7 @@ from Alignment.OfflineValidation.diMuonValidation_cfi import diMuonValidation as
 process.DiMuonMassValidation = _diMuonValidation.clone(
     TkTag = 'TrackRefitter',
     # mu mu mass
-    Pair_mass_min   = 80.,
+    Pair_mass_min   = 60.,
     Pair_mass_max   = 120.,
     Pair_mass_nbins = 80,
     Pair_etaminpos  = -2.4,


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/46134

#### PR description:

It was recently noticed that the default mass window range in the python configuration of the `ZMuMu` validation tool was in the range [80-120] GeV.
Restricting the mass fits in this asymmetric region around the Z mass peak ends up biasing the output fit parameters, as illustrated e.g. this plot:

![Screenshot from 2024-09-26 15-40-41](https://github.com/user-attachments/assets/9a4b6172-391c-4fe8-b987-5449b00a2943)

This in turn created some unphysical features in the distribution of the invariant mass peak position as a function of the muon kinematic that are used to validate the various alignments. 
The goal of this PR is to allow the fit to cover the whole region [60-120] GeV as default value in the all-in-one tool configuration, as already done in the `fillDescriptions` method of the plugin, see:

https://github.com/cms-sw/cmssw/blob/3914bc83b3f9a0e3613f34c94bed4ec84f4b4cfe/Alignment/OfflineValidation/plugins/DiMuonValidation.cc#L380-L381

#### PR validation:

The tool was run in the vanilla release and the newly proposed defaults.

| Default | This PR |
| ----------- | ----------- |
| ![image](https://github.com/user-attachments/assets/1036e0ef-e21b-4b4f-8a32-a9e1090ba9bf)  | ![image](https://github.com/user-attachments/assets/3e90c030-dba3-4e25-a0dc-d26f66262370) |

as it can be seen unphysical bin by bin oscillations are removed.  

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

verbatim backport of https://github.com/cms-sw/cmssw/pull/46134 to CMSSW_14_0_X