### PR TITLE
fix `SiStripLatency` methods when object is empty

### DIFF
--- a/CondFormats/SiStripObjects/src/SiStripLatency.cc
+++ b/CondFormats/SiStripObjects/src/SiStripLatency.cc
@@ -77,6 +77,9 @@ std::pair<uint16_t, uint16_t> SiStripLatency::latencyAndMode(const uint32_t detI
 }
 
 uint16_t SiStripLatency::singleLatency() const {
+  if (latencies_.empty()) {
+    return 255;
+  }
   if (latencies_.size() == 1) {
     return latencies_[0].latency;
   }
@@ -94,6 +97,9 @@ uint16_t SiStripLatency::singleLatency() const {
 }
 
 uint16_t SiStripLatency::singleMode() const {
+  if (latencies_.empty()) {
+    return 0;
+  }
   if (latencies_.size() == 1) {
     return latencies_[0].mode;
   }

--- a/CondFormats/SiStripObjects/test/BuildFile.xml
+++ b/CondFormats/SiStripObjects/test/BuildFile.xml
@@ -9,6 +9,10 @@
 <bin file="testSerializationSiStripObjects.cpp">
 </bin>
 
-<bin file="test_catch2_*.cpp" name="test_catch2_SiStripBadStrip_Phase2">
+<bin file="test_catch2_main.cpp,test_catch2_SiStripBadStripForPhase2.cpp" name="test_catch2_SiStripBadStrip_Phase2">
+  <use name="catch2"/>
+</bin>
+
+<bin file="test_catch2_main.cpp,test_catch2_SiStripLatency.cpp" name="test_catch2_SiStripLatency">
   <use name="catch2"/>
 </bin>

--- a/CondFormats/SiStripObjects/test/test_catch2_SiStripLatency.cpp
+++ b/CondFormats/SiStripObjects/test/test_catch2_SiStripLatency.cpp
@@ -1,0 +1,38 @@
+#include <sstream>
+#include "catch.hpp"
+#include <iostream>
+#include <iomanip>  // std::setw
+
+// Include the headers for SiStripLatency and TrackerTopology
+#include "CondFormats/SiStripObjects/interface/SiStripLatency.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+// Test case to check the SiStripLatency::printSummary and printDebug
+TEST_CASE("SiStripLatency basic test", "[SiStripLatency]") {
+  // Step 1: Create an empty SiStripLatency object
+  SiStripLatency latency;
+
+  // Step 2: Create a mock or dummy TrackerTopology object
+  TrackerTopology* trackerTopo = nullptr;  // Assuming null for now (replace with actual initialization if needed)
+
+  // Step 3: Create a stringstream to capture the output
+  std::stringstream ssSummary;
+  std::stringstream ssDebug;
+
+  // Step 4: Call printSummary and printDebug on the SiStripLatency object
+  try {
+    latency.printSummary(ssSummary, trackerTopo);
+    latency.printDebug(ssDebug, trackerTopo);
+  } catch (const cms::Exception& e) {
+    FAIL("Exception caught during printSummary or printDebug: " << e.what());
+  }
+
+  // Step 5: Optional - Check the output
+  REQUIRE(!ssSummary.str().empty());  // Ensure the summary output is not empty
+  REQUIRE(!ssDebug.str().empty());    // Ensure the debug output is not empty
+
+  // Print outputs for manual inspection
+  std::cout << "Summary Output:\n" << ssSummary.str() << std::endl;
+  std::cout << "Debug Output:\n" << ssDebug.str() << std::endl;
+}


### PR DESCRIPTION
#### PR description:

During the SiStrip DAQ O2O tests performed on [23-09-2024](https://cms-conddb.cern.ch/cmsDbBrowser/logs/O2O_logs/Prod/2024-09-22/2024-09-30/SiStrip/1) in order to update the release `CMSSW_14_0_16` (to allow for the cmsweb migration, see details [here](https://indico.cern.ch/event/1451586/contributions/6146763/attachments/2932960/5150937/23.09.24%20AlCa%20meeting.pdf)), few O2O tests failed with a segmentation fault:

```
Thread 1 (Thread 0x7f6c4e300640 (LWP 745397) "cmsRun"):
#0  0x00007f6c4f0cf0e1 in poll () from /lib64/libc.so.6
#1  0x00007f6c4a8e643f in full_read.constprop () from /opt/offline/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_16/lib/el8_amd64_gcc12/pluginFWCoreServicesPlugins.so
#2  0x00007f6c4a89b4bc in edm::service::InitRootHandlers::stacktraceFromThread() () from /opt/offline/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_16/lib/el8_amd64_gcc12/pluginFWCoreServicesPlugins.so
#3  0x00007f6c4a89b640 in sig_dostack_then_abort () from /opt/offline/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_16/lib/el8_amd64_gcc12/pluginFWCoreServicesPlugins.so
#4  <signal handler called>
#5  0x00007f6c435d7e67 in SiStripLatency::singleMode() const () from /opt/offline/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_16/lib/el8_amd64_gcc12/libCondFormatsSiStripObjects.so
#6  0x00007f6c435d819e in SiStripLatency::singleReadOutMode() const () from /opt/offline/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_16/lib/el8_amd64_gcc12/libCondFormatsSiStripObjects.so
#7  0x00007f6c435d86d9 in SiStripLatency::printSummary(std::__cxx11::basic_stringstream<char, std::char_traits<char>, std::allocator<char> >&, TrackerTopology const*) const () from /opt/offline/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_16/lib/el8_amd64_gcc12/libCondFormatsSiStripObjects.so
#8  0x00007f6c43922a41 in SiStripCondObjBuilderFromDb::buildFECRelatedObjects(SiStripConfigDb*, std::vector<std::pair<unsigned int, std::vector<std::pair<unsigned int, FedChannelConnection>, std::allocator<std::pair<unsigned int, FedChannelConnection> > > >, std::allocator<std::pair<unsigned int, std::vector<std::pair<unsigned int, FedChannelConnection>, std::allocator<std::pair<unsigned int, FedChannelConnection> > > > > > const&) () from /opt/offline/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_16/lib/el8_amd64_gcc12/libOnlineDBSiStripESSources.so
#9  0x00007f6c43929940 in SiStripCondObjBuilderFromDb::buildCondObj() () from /opt/offline/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_16/lib/el8_amd64_gcc12/libOnlineDBSiStripESSources.so
#10 0x00007f6c12e9fef5 in SiStripCondObjBuilderFromDb::getValue(SiStripBadStrip*&) [clone .constprop.0] () from /opt/offline/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_16/lib/el8_amd64_gcc12/pluginOnlineDBSiStripO2OPlugins.so
#11 0x00007f6c12e97b2a in SiStripPayloadHandler<SiStripBadStrip>::analyze(edm::Event const&, edm::EventSetup const&) () from /opt/offline/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_16/lib/el8_amd64_gcc12/pluginOnlineDBSiStripO2OPlugins.so
#12 0x00007f6c51b12762 in edm::one::EDAnalyzerBase::doEvent(edm::EventTransitionInfo const&, edm::ActivityRegistry*, edm::ModuleCallingContext const*) () from /opt/offline/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_16/lib/el8_amd64_gcc12/libFWCoreFramework.so
#13 0x00007f6c51afdd9e in edm::WorkerT<edm::one::EDAnalyzerBase>::implDo(edm::EventTransitionInfo const&, edm::ModuleCallingContext const*) () from /opt/offline/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_16/lib/el8_amd64_gcc12/libFWCoreFramework.so
#14 0x00007f6c51a8f639 in std::__exception_ptr::exception_ptr edm::Worker::runModuleAfterAsyncPrefetch<edm::OccurrenceTraits<edm::EventPrincipal, (edm::BranchActionType)1> >(std::__exception_ptr::exception_ptr, edm::OccurrenceTraits<edm::EventPrincipal, (edm::BranchActionType)1>::TransitionInfoType const&, edm::StreamID, edm::ParentContext const&, edm::OccurrenceTraits<edm::EventPrincipal, (edm::BranchActionType)1>::Context const*) () from /opt/offline/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_16/lib/el8_amd64_gcc12/libFWCoreFramework.so
#15 0x00007f6c51a9070f in edm::SerialTaskQueue::QueuedTask<edm::SerialTaskQueueChain::push<edm::Worker::RunModuleTask<edm::OccurrenceTraits<edm::EventPrincipal, (edm::BranchActionType)1> >::execute()::{lambda()#1}&>(tbb::detail::d1::task_group&, edm::Worker::RunModuleTask<edm::OccurrenceTraits<edm::EventPrincipal, (edm::BranchActionType)1> >::execute()::{lambda()#1}&)::{lambda()#1}>::execute() () from /opt/offline/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_16/lib/el8_amd64_gcc12/libFWCoreFramework.so
#16 0x00007f6c51c43650 in tbb::detail::d1::function_task<edm::SerialTaskQueue::spawn(edm::SerialTaskQueue::TaskBase&)::{lambda()#1}>::execute(tbb::detail::d1::execution_data&) () from /opt/offline/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_16/lib/el8_amd64_gcc12/libFWCoreConcurrency.so
#17 0x00007f6c50249281 in tbb::detail::r1::task_dispatcher::local_wait_for_all<false, tbb::detail::r1::external_waiter> (waiter=..., t=<optimized out>, this=0x7f6c4ccdfe00) at /data/cmsbld/jenkins/workspace/auto-builds/CMSSW_14_1_0_pre1-el8_amd64_gcc12/build/CMSSW_14_1_0_pre1-build/BUILD/el8_amd64_gcc12/external/tbb/v2021.9.0-c3903c50b52342174dbd3a52854a6e6d/tbb-v2021.9.0/src/tbb/task_dispatcher.h:322
#18 tbb::detail::r1::task_dispatcher::local_wait_for_all<tbb::detail::r1::external_waiter> (waiter=..., t=<optimized out>, this=0x7f6c4ccdfe00) at /data/cmsbld/jenkins/workspace/auto-builds/CMSSW_14_1_0_pre1-el8_amd64_gcc12/build/CMSSW_14_1_0_pre1-build/BUILD/el8_amd64_gcc12/external/tbb/v2021.9.0-c3903c50b52342174dbd3a52854a6e6d/tbb-v2021.9.0/src/tbb/task_dispatcher.h:458
#19 tbb::detail::r1::task_dispatcher::execute_and_wait (t=<optimized out>, wait_ctx=..., w_ctx=...) at /data/cmsbld/jenkins/workspace/auto-builds/CMSSW_14_1_0_pre1-el8_amd64_gcc12/build/CMSSW_14_1_0_pre1-build/BUILD/el8_amd64_gcc12/external/tbb/v2021.9.0-c3903c50b52342174dbd3a52854a6e6d/tbb-v2021.9.0/src/tbb/task_dispatcher.cpp:168
#20 0x00007f6c51a12cfb in edm::FinalWaitingTask::wait() () from /opt/offline/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_16/lib/el8_amd64_gcc12/libFWCoreFramework.so
#21 0x00007f6c51a1c66a in edm::EventProcessor::processRuns() () from /opt/offline/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_16/lib/el8_amd64_gcc12/libFWCoreFramework.so
#22 0x00007f6c51a1cbc1 in edm::EventProcessor::runToCompletion() () from /opt/offline/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_16/lib/el8_amd64_gcc12/libFWCoreFramework.so
#23 0x00000000004074ef in tbb::detail::d1::task_arena_function<main::{lambda()#1}::operator()() const::{lambda()#1}, void>::operator()() const ()
#24 0x00007f6c502359ad in tbb::detail::r1::task_arena_impl::execute (ta=..., d=...) at /data/cmsbld/jenkins/workspace/auto-builds/CMSSW_14_1_0_pre1-el8_amd64_gcc12/build/CMSSW_14_1_0_pre1-build/BUILD/el8_amd64_gcc12/external/tbb/v2021.9.0-c3903c50b52342174dbd3a52854a6e6d/tbb-v2021.9.0/src/tbb/arena.cpp:688
#25 0x0000000000408ed2 in main::{lambda()#1}::operator()() const ()
#26 0x000000000040517c in main ()
```

While these tests have been issued with a wrong (empty) input list of configuration lines, it would be nicer if they end more gracefully than with a segmentation fault. 
The issue is traced to the fact that the methods `SiStripLatency::singleLatency()` and `SiStripLatency::singleMode()` try to access the first element of the `latencies_` member vector, while it wasn't filled, ending in a segmentation violation.
The issue is reproducible, when trying to execute the unit test introduced in this PR without the fix-up.

#### PR validation:

Relies on the new unit test: `scram b runtest_test_catch2_SiStripLatency` runs fine

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A