### PR TITLE
Remove run3_nanoAOD_122 & 124 modifiers

### DIFF
--- a/Configuration/Eras/python/Modifier_run3_nanoAOD_122_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_nanoAOD_122_cff.py
@@ -1,3 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-run3_nanoAOD_122 = cms.Modifier()

--- a/Configuration/Eras/python/Modifier_run3_nanoAOD_124_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_nanoAOD_124_cff.py
@@ -1,3 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-run3_nanoAOD_124 = cms.Modifier()

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -91,7 +91,7 @@ class Eras (object):
                            'trackingPhase2PU140','highBetaStar_2018',
                            'tracker_apv_vfp30_2016', 'pf_badHcalMitigationOff',
                            'run2_nanoAOD_106Xv2',
-                           'run3_nanoAOD_122', 'run3_nanoAOD_124', 'run3_nanoAOD_pre142X',
+                           'run3_nanoAOD_pre142X',
                            'run3_ecal_devel',
                            'run3_upc',
                            'hcalHardcodeConditions', 'hcalSkipPacker',

--- a/PhysicsTools/NanoAOD/python/boostedTaus_cff.py
+++ b/PhysicsTools/NanoAOD/python/boostedTaus_cff.py
@@ -95,12 +95,3 @@ boostedTauMCTable = tauMCTable.clone(
 boostedTauTask = cms.Task(finalBoostedTaus)
 boostedTauTablesTask = cms.Task(boostedTauTable)
 boostedTauMCTask = cms.Task(boostedTausMCMatchLepTauForTable,boostedTausMCMatchHadTauForTable,boostedTauMCTable)
-
-#remove boosted tau from previous eras
-(run3_nanoAOD_122).toReplaceWith(
-    boostedTauTask,cms.Task()
-).toReplaceWith(
-    boostedTauTablesTask,cms.Task()
-).toReplaceWith(
-    boostedTauMCTask,cms.Task()
-)

--- a/PhysicsTools/NanoAOD/python/custom_btv_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_btv_cff.py
@@ -496,17 +496,6 @@ def add_BTV(process,  addAK4=False, addAK8=False, scheme="btvSF"):
                 get_ParticleNetAK4_outputs(),
                 #get_ParticleTransformerAK4_outputs(),# removed in 2024
             ))
-
-        # disable the ParT branches in default jetPuppi table
-        from PhysicsTools.NanoAOD.nano_eras_cff import run3_nanoAOD_122, run3_nanoAOD_124
-        (run3_nanoAOD_122 | run3_nanoAOD_124).toModify(
-            process.jetPuppiTable.variables,
-            btagRobustParTAK4B = None,
-            btagRobustParTAK4CvL = None,
-            btagRobustParTAK4CvB = None,
-            btagRobustParTAK4QG = None,
-        )
-    
     
          # from Run3 onwards, always set storeAK4Truth to True for MC
         process.customAK4ConstituentsForDeepJetTable = cms.EDProducer("PatJetDeepJetTableProducer",

--- a/PhysicsTools/NanoAOD/python/globals_cff.py
+++ b/PhysicsTools/NanoAOD/python/globals_cff.py
@@ -37,7 +37,7 @@ puTable = cms.EDProducer("NPUTablesProducer",
         zbins = cms.vdouble( [0.0,1.7,2.6,3.0,3.5,4.2,5.2,6.0,7.5,9.0,12.0] ),
         savePtHatMax = cms.bool(True),
 )
-(run2_nanoAOD_ANY | run3_nanoAOD_122 | run3_nanoAOD_124).toModify(
+(run2_nanoAOD_ANY).toModify(
     puTable, savePtHatMax=False
 )
 

--- a/PhysicsTools/NanoAOD/python/jetsAK4_CHS_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_CHS_cff.py
@@ -170,24 +170,6 @@ run2_nanoAOD_ANY.toModify(
     hfEmEF = None
 )
 
-(run3_nanoAOD_122 | run3_nanoAOD_124).toModify(
-    jetTable.variables,
-    # New ParticleNet trainings are not available in MiniAOD until Run3 13X
-    btagPNetB = None,
-    btagPNetCvL = None,
-    btagPNetCvB = None,
-    btagPNetQvG = None,
-    btagPNetTauVJet = None,
-    PNetRegPtRawCorr = None,
-    PNetRegPtRawCorrNeutrino = None,
-    PNetRegPtRawRes = None,
-    # Remove for V11 and earlier Run3 versions
-    chMultiplicity = None,
-    neMultiplicity = None,
-    hfHEF = None,
-    hfEmEF = None
-)
-
 bjetNN = cms.EDProducer("BJetEnergyRegressionMVA",
     backend = cms.string("ONNX"),
     batch_eval = cms.bool(True),

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -117,24 +117,6 @@ run2_nanoAOD_ANY.toModify(
     btagDeepCvB = Var("?bDiscriminator('pfDeepCSVJetTags:probc')>=0?bDiscriminator('pfDeepCSVJetTags:probc')/(bDiscriminator('pfDeepCSVJetTags:probc')+bDiscriminator('pfDeepCSVJetTags:probb')+bDiscriminator('pfDeepCSVJetTags:probbb')):-1",float,doc="DeepCSV c vs b+bb discriminator",precision=10)
 )
 
-(run3_nanoAOD_122 | run3_nanoAOD_124).toModify(
-    jetPuppiTable.variables,
-    # New ParticleNet trainings are not available in MiniAOD until Run3 13X
-    btagPNetB = None,
-    btagPNetCvL = None,
-    btagPNetCvB = None,
-    btagPNetQvG = None,
-    btagPNetTauVJet = None,
-    PNetRegPtRawCorr = None,
-    PNetRegPtRawCorrNeutrino = None,
-    PNetRegPtRawRes = None,
-    # Remove for V11 and earlier Run3 versions
-    chMultiplicity = None,
-    neMultiplicity = None,
-    hfHEF = None,
-    hfEmEF = None
-)
-
 run3_nanoAOD_pre142X.toModify(
     jetPuppiTable.variables,
     puIdDisc = None,

--- a/PhysicsTools/NanoAOD/python/jetsAK8_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK8_cff.py
@@ -115,33 +115,8 @@ run2_nanoAOD_ANY.toModify(
     neEmEF = None,
     muEF = None
 )
-(run3_nanoAOD_122 | run3_nanoAOD_124).toModify(
-    fatJetTable.variables,
-    # New ParticleNet trainings are not available in MiniAOD until Run3 13X
-    particleNet_QCD = None,
-    particleNet_QCD2HF = None,
-    particleNet_QCD1HF = None,
-    particleNet_QCD0HF = None,
-    particleNet_massCorr = None,
-    particleNet_XbbVsQCD = None,
-    particleNet_XccVsQCD = None,
-    particleNet_XqqVsQCD = None,
-    particleNet_XggVsQCD = None,
-    particleNet_XttVsQCD = None,
-    particleNet_XtmVsQCD = None,
-    particleNet_XteVsQCD = None,
-    particleNet_WVsQCD = None,
-    # Remove for V11 and earlier versions
-    chMultiplicity = None,
-    neMultiplicity = None,
-    chHEF = None,
-    neHEF = None,
-    chEmEF = None,
-    neEmEF = None,
-    muEF = None
-)
 
-(run2_nanoAOD_106Xv2 | run3_nanoAOD_122 | run3_nanoAOD_124).toModify(
+(run2_nanoAOD_106Xv2).toModify(
     fatJetTable.variables,
     # Restore taggers that were decommisionned for Run-3
     btagDeepB = Var("?(bDiscriminator('pfDeepCSVJetTags:probb')+bDiscriminator('pfDeepCSVJetTags:probbb'))>=0?bDiscriminator('pfDeepCSVJetTags:probb')+bDiscriminator('pfDeepCSVJetTags:probbb'):-1",float,doc="DeepCSV b+bb tag discriminator",precision=10),
@@ -264,7 +239,7 @@ run2_nanoAOD_ANY.toModify(
     btagCSVV2 = Var("bDiscriminator('pfCombinedInclusiveSecondaryVertexV2BJetTags')",float,doc=" pfCombinedInclusiveSecondaryVertexV2 b-tag discriminator (aka CSVV2)",precision=10)
 )
 
-(run2_nanoAOD_106Xv2 | run3_nanoAOD_122 | run3_nanoAOD_124).toModify(
+(run2_nanoAOD_106Xv2).toModify(
     subJetTable.variables,
     area = None,
 )

--- a/PhysicsTools/NanoAOD/python/nanoDQM_cff.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cff.py
@@ -188,20 +188,6 @@ _FatJet_Run2_plots.extend([
     Plot1D('particleNetLegacy_QCD', 'particleNetLegacy_QCD', 20, 0, 1, 'ParticleNet Legacy Run-2 QCD score'),
 ])
 
-_FatJet_EarlyRun3_plots = cms.VPSet()
-for plot in _FatJet_Run2_plots:
-    if 'particleNet_' not in plot.name.value() and 'btagCSVV2' not in plot.name.value() \
-    and 'Multiplicity' not in plot.name.value() and 'EF' not in plot.name.value():
-        _FatJet_EarlyRun3_plots.append(plot)
-_FatJet_EarlyRun3_plots.extend([
-    Plot1D('btagDeepB', 'btagDeepB', 20, -1, 1, 'Deep B+BB btag discriminator'),
-    Plot1D('btagHbb', 'btagHbb', 20, -1, 1, 'Higgs to BB tagger discriminator'),
-    Plot1D('btagCMVA', 'btagCMVA', 20, -1, 1, 'CMVA V2 btag discriminator'),
-    Plot1D('btagDDBvLV2', 'btagDDBvLV2', 20, 0, 1, 'DeepDoubleX V2(mass-decorrelated) discriminator for H(Z)->bb vs QCD'),
-    Plot1D('btagDDCvBV2', 'btagDDCvBV2', 20, 0, 1, 'DeepDoubleX V2 (mass-decorrelated) discriminator for H(Z)->cc vs H(Z)->bb'),
-    Plot1D('btagDDCvLV2', 'btagDDCvLV2', 20, 0, 1, 'DeepDoubleX V2 (mass-decorrelated) discriminator for H(Z)->cc vs QCD'),
-])
-
 _Jet_Run2_plots = cms.VPSet()
 for plot in nanoDQM.vplots.Jet.plots:
     _Jet_Run2_plots.append(plot)
@@ -215,13 +201,6 @@ _Jet_Run2_plots.extend([
     Plot1D('btagDeepCvB', 'btagDeepCvB', 20, -1, 1, 'DeepCSV c vs b+bb discriminator'),
     Plot1D('btagDeepCvL', 'btagDeepCvL', 20, -1, 1, 'DeepCSV c vs udsg discriminator')
 ])
-
-_Jet_EarlyRun3_plots = cms.VPSet()
-for plot in nanoDQM.vplots.Jet.plots:
-    if 'PNet' not in plot.name.value() and 'Multiplicity' not in plot.name.value() \
-    and 'hfHEF' not in plot.name.value() and 'hfEmEF' not in plot.name.value():
-        _Jet_EarlyRun3_plots.append(plot)
-
 _Jet_pre142X_plots = cms.VPSet()
 for plot in nanoDQM.vplots.Jet.plots:
     if 'puIdDisc' not in plot.name.value():
@@ -233,10 +212,6 @@ for plot in nanoDQM.vplots.SubJet.plots:
 _SubJet_Run2_plots.extend([
     Plot1D('btagCSVV2', 'btagCSVV2', 20, -1, 1, ' pfCombinedInclusiveSecondaryVertexV2 b-tag discriminator (aka CSVV2)'),
 ])
-_SubJet_EarlyRun3_plots = cms.VPSet()
-for plot in nanoDQM.vplots.SubJet.plots:
-    if 'area' not in plot.name.value():
-        _SubJet_EarlyRun3_plots.append(plot)
 
 _SubJet_pre142X_plots = cms.VPSet()
 for plot in nanoDQM.vplots.SubJet.plots:
@@ -256,18 +231,6 @@ run2_nanoAOD_ANY.toModify(
     nanoDQM.vplots.SubJet,
     plots = _SubJet_Run2_plots
 )
-
-(run3_nanoAOD_122 | run3_nanoAOD_124).toModify(
-    nanoDQM.vplots.FatJet,
-    plots = _FatJet_EarlyRun3_plots
-).toModify(
-    nanoDQM.vplots.Jet,
-    plots = _Jet_EarlyRun3_plots
-).toModify(
-    nanoDQM.vplots.SubJet,
-    plots = _SubJet_EarlyRun3_plots
-)
-
 run3_nanoAOD_pre142X.toModify(
     nanoDQM.vplots.Jet,
     plots = _Jet_pre142X_plots
@@ -281,7 +244,7 @@ for plot in nanoDQM.vplots.Pileup.plots:
     if 'pthatmax' not in plot.name.value():
         _Pileup_pre13X_plots.append(plot)
 
-(run2_nanoAOD_ANY | run3_nanoAOD_122 | run3_nanoAOD_124).toModify(
+(run2_nanoAOD_ANY).toModify(
     nanoDQM.vplots.Pileup,
     plots = _Pileup_pre13X_plots
 )

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -51,11 +51,6 @@ run2_nanoAOD_ANY.toModify(
     linkedObjects, jets="finalJets"
 )
 
-# boosted taus don't exist in 122X MINI
-run3_nanoAOD_122.toModify(
-    linkedObjects, boostedTaus=None,
-)
-
 from PhysicsTools.NanoAOD.lhcInfoProducer_cfi import lhcInfoProducer
 lhcInfoTable = lhcInfoProducer.clone()
 (~run3_common).toModify(
@@ -214,13 +209,6 @@ def nanoAOD_customizeCommon(process):
         nanoAOD_addUnifiedParTAK4Tag_switch=True,
     )
   
-    # enable rerun of PNet for CHS jets for early run3 eras
-    # (it is rerun for run2 within jet tasks while is not needed for newer
-    # run3 eras as it is present in miniAOD)
-    (run3_nanoAOD_122 | run3_nanoAOD_124).toModify(
-        nanoAOD_addDeepInfoAK4CHS_switch, nanoAOD_addParticleNet_switch = True
-    )
-    
     # This function is defined in jetsAK4_Puppi_cff.py
     process = nanoAOD_addDeepInfoAK4(process,
         addParticleNet=nanoAOD_addDeepInfoAK4_switch.nanoAOD_addParticleNet_switch,
@@ -253,7 +241,7 @@ def nanoAOD_customizeCommon(process):
         addUParTInfo = cms.bool(True),
         addPNet = cms.bool(True)
     )
-    (run2_nanoAOD_106Xv2 | run3_nanoAOD_122).toModify(
+    (run2_nanoAOD_106Xv2).toModify(
         nanoAOD_tau_switch, idsToAdd = ["deepTau2018v2p5"]
     ).toModify(
         process, lambda p : nanoAOD_addTauIds(p, nanoAOD_tau_switch.idsToAdd.value())
@@ -261,7 +249,7 @@ def nanoAOD_customizeCommon(process):
     
     # Don't add Unified Tagger for PUPPI jets for Run 2 (as different PUPPI tune
     # and base jet algorithm) or early Run 3 eras
-    (run3_nanoAOD_122 | run3_nanoAOD_124 | run2_nanoAOD_106Xv2).toModify(
+    (run2_nanoAOD_106Xv2).toModify(
         nanoAOD_tau_switch, addUParTInfo = False
     )
     

--- a/PhysicsTools/NanoAOD/python/nano_eras_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_eras_cff.py
@@ -17,8 +17,6 @@ from Configuration.Eras.Modifier_run2_nanoAOD_106Xv2_cff import run2_nanoAOD_106
 from Configuration.Eras.Modifier_tracker_apv_vfp30_2016_cff import tracker_apv_vfp30_2016
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
-from Configuration.Eras.Modifier_run3_nanoAOD_122_cff import run3_nanoAOD_122
-from Configuration.Eras.Modifier_run3_nanoAOD_124_cff import run3_nanoAOD_124
 from Configuration.Eras.Modifier_run3_nanoAOD_pre142X_cff import run3_nanoAOD_pre142X
 from Configuration.Eras.Modifier_run3_jme_Winter22runsBCDEprompt_cff import run3_jme_Winter22runsBCDEprompt
 

--- a/PhysicsTools/NanoAOD/python/taus_cff.py
+++ b/PhysicsTools/NanoAOD/python/taus_cff.py
@@ -1,6 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.NanoAOD.common_cff import *
-from PhysicsTools.NanoAOD.nano_eras_cff import run3_nanoAOD_124
 from PhysicsTools.NanoAOD.simpleCandidateFlatTableProducer_cfi import simpleCandidateFlatTableProducer
 from PhysicsTools.NanoAOD.simpleGenParticleFlatTableProducer_cfi import simpleGenParticleFlatTableProducer
 from PhysicsTools.NanoAOD.simplePATTauFlatTableProducer_cfi import simplePATTauFlatTableProducer
@@ -19,11 +18,6 @@ from RecoTauTag.RecoTau.tauIdWPsDefs import WORKING_POINTS_v2p5
 finalTaus = cms.EDFilter("PATTauRefSelector",
     src = cms.InputTag("slimmedTaus"),
     cut = cms.string("pt > 18 && ((tauID('decayModeFindingNewDMs') > 0.5 && (tauID('byLooseCombinedIsolationDeltaBetaCorr3Hits') || (tauID('chargedIsoPtSumdR03')+max(0.,tauID('neutralIsoPtSumdR03')-0.072*tauID('puCorrPtSum'))<2.5) || tauID('byVVVLooseDeepTau2018v2p5VSjet'))) || (?isTauIDAvailable('byUTagCHSVSjetraw')?tauID('byUTagCHSVSjetraw'):-1) > {} || (?isTauIDAvailable('byUTagPUPPIVSjetraw')?tauID('byUTagPUPPIVSjetraw'):-1) > {})".format(0.05, 0.05))
-)
-
-run3_nanoAOD_124.toModify(
-    finalTaus,
-    cut = cms.string("pt > 18 && ((tauID('decayModeFindingNewDMs') > 0.5 && (tauID('byLooseCombinedIsolationDeltaBetaCorr3Hits') || (tauID('chargedIsoPtSumdR03')+max(0.,tauID('neutralIsoPtSumdR03')-0.072*tauID('puCorrPtSum'))<2.5) || (tauID('byDeepTau2018v2p5VSjetraw') > {}))) || (?isTauIDAvailable('byUTagCHSVSjetraw')?tauID('byUTagCHSVSjetraw'):-1) > {} || (?isTauIDAvailable('byUTagPUPPIVSjetraw')?tauID('byUTagPUPPIVSjetraw'):-1) > {})".format(WORKING_POINTS_v2p5["jet"]["VVVLoose"], 0.05, 0.05))
 )
 
 ##################### Tables for final output and docs ##########################
@@ -136,22 +130,6 @@ _variablesMiniV2 = cms.PSet(
 )
 
 tauTable.variables = _variablesMiniV2
-
-run3_nanoAOD_124.toModify(
-    tauTable.variables,
-    idDeepTau2018v2p5VSe = _tauIdWPMask("byDeepTau2018v2p5VSeraw",
-                 choices=("VVVLoose","VVLoose","VLoose","Loose","Medium","Tight","VTight","VVTight"),
-                 doc="byDeepTau2018v2p5VSe ID working points (deepTau2018v2p5)",
-                 from_raw=True, wp_thrs=WORKING_POINTS_v2p5["e"]),
-    idDeepTau2018v2p5VSmu = _tauIdWPMask("byDeepTau2018v2p5VSmuraw",
-                 choices=("VLoose", "Loose", "Medium", "Tight"),
-                 doc="byDeepTau2018v2p5VSmu ID working points (deepTau2018v2p5)",
-                 from_raw=True, wp_thrs=WORKING_POINTS_v2p5["mu"]),
-    idDeepTau2018v2p5VSjet = _tauIdWPMask("byDeepTau2018v2p5VSjetraw",
-                 choices=("VVVLoose","VVLoose","VLoose","Loose","Medium","Tight","VTight","VVTight"),
-                 doc="byDeepTau2018v2p5VSjet ID working points (deepTau2018v2p5)",
-                 from_raw=True, wp_thrs=WORKING_POINTS_v2p5["jet"])
-)
 
 tauSignalCands = patTauSignalCandidatesProducer.clone(
     src = tauTable.src,


### PR DESCRIPTION
#### PR description:

This PR removes the outdated `run3_nanoAOD_122` and `run3_nanoAOD_124` era modifiers.

#### PR validation:

`runTheMatrix.py -w nano --ibeos -l 2500.101,2500.111,2500.201,2500.211,2500.024`