### PR TITLE
Add usePCACleaning to CLUE3DHighStep_cff and fix HFNose seeded region

### DIFF
--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
@@ -204,7 +204,7 @@ void PatternRecognitionbyCA<TILES>::filter(std::vector<Trackster> &output,
     }
   }
   output.reserve(selectedTrackstersIds.size());
-  bool isRegionalIter = (input.regions[0].index != -1);
+  bool isRegionalIter = !input.regions.empty() && (input.regions[0].index != -1);
   for (unsigned i = 0; i < selectedTrackstersIds.size(); ++i) {
     const auto &t = inTracksters[selectedTrackstersIds[i]];
     if (isRegionalIter) {

--- a/RecoHGCal/TICL/python/CLUE3DHighStep_cff.py
+++ b/RecoHGCal/TICL/python/CLUE3DHighStep_cff.py
@@ -65,6 +65,7 @@ ticlTrackstersCLUE3DHigh = _trackstersProducer.clone(
 
 from Configuration.ProcessModifiers.ticl_v5_cff import ticl_v5
 ticl_v5.toModify(ticlTrackstersCLUE3DHigh.pluginPatternRecognitionByCLUE3D, computeLocalTime = cms.bool(True))
+ticl_v5.toModify(ticlTrackstersCLUE3DHigh.pluginPatternRecognitionByCLUE3D, usePCACleaning = cms.bool(True))
 ticl_v5.toModify(ticlTrackstersCLUE3DHigh.inferenceAlgo, type = cms.string('TracksterInferenceByDNN'))
 
 ticlCLUE3DHighStepTask = cms.Task(ticlSeedingGlobal


### PR DESCRIPTION
This PR updates the HFNose module in PatternRecognitionbyCA to protect it from events without seeding regions and adds usePCACleaning to CLUE3DHighStep_cff.

It fixes the issue found in [PR #45821](https://github.com/cms-sw/cmssw/pull/45821) and should be tested with D115, workflow 32034.0.

Tagging @felicepantaleo @waredjeb @hatakeyamak