### PR TITLE
[HCAL-DQM] New plot BadQualityEvents vs all LS and changes of alarm threshold for CapID and BadQEvents for CMSSW_14_1_X

### DIFF
--- a/DQM/HcalTasks/data/HcalQualityTests.xml
+++ b/DQM/HcalTasks/data/HcalQualityTests.xml
@@ -17,8 +17,8 @@
 
   <QTEST name="BadCapIDThreshold">
     <TYPE>ContentsWithinExpected</TYPE>
-      <PARAM name="error">1.0</PARAM>
-      <PARAM name="warning">1.0</PARAM>
+      <PARAM name="error">0.994</PARAM>
+      <PARAM name="warning">0.994</PARAM>
       <PARAM name="minMean">-1.0</PARAM>
       <PARAM name="maxMean">0.0</PARAM>
       <PARAM name="minRMS">0.0</PARAM>
@@ -32,8 +32,8 @@
   </LINK>
   <QTEST name="BadQualityThreshold">
     <TYPE>ContentsWithinExpected</TYPE>
-      <PARAM name="error">1.0</PARAM>
-      <PARAM name="warning">1.0</PARAM>
+      <PARAM name="error">0.994</PARAM>
+      <PARAM name="warning">0.994</PARAM>
       <PARAM name="minMean">-1.0</PARAM>
       <PARAM name="maxMean">0.0</PARAM>
       <PARAM name="minRMS">0.0</PARAM>

--- a/DQM/HcalTasks/interface/RawTask.h
+++ b/DQM/HcalTasks/interface/RawTask.h
@@ -78,6 +78,7 @@ protected:
   hcaldqm::Container2D _cSummaryvsLS_FED;          // online only
   hcaldqm::ContainerSingle2D _cSummaryvsLS;        // online only
   hcaldqm::ContainerSingle2D _cBadQ_FEDvsLSmod10;  // online only
+  hcaldqm::ContainerSingle2D _cBadQ_FEDvsLS;  // online only   
 };
 
 #endif

--- a/DQM/HcalTasks/plugins/RawTask.cc
+++ b/DQM/HcalTasks/plugins/RawTask.cc
@@ -132,6 +132,12 @@ RawTask::RawTask(edm::ParameterSet const& ps)
                                new hcaldqm::quantity::FEDQuantity(vFEDs),
                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fState),
                                0);
+      _cBadQ_FEDvsLS.initialize(_name,
+                               "BadQ_FEDvsLS",
+			       new hcaldqm::quantity::LumiSectionCoarse(_maxLS, 10), 	
+                               new hcaldqm::quantity::FEDQuantity(vFEDs),
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                               0);
       _cBadQ_FEDvsLSmod10.initialize(_name,
                                      "BadQ_FEDvsLSmod10",
                                      new hcaldqm::quantity::LumiSection(10),
@@ -174,6 +180,7 @@ RawTask::RawTask(edm::ParameterSet const& ps)
     _cSummaryvsLS_FED.book(ib, _emap, _subsystem);
     _cSummaryvsLS.book(ib, _subsystem);
     _cBadQ_FEDvsLSmod10.book(ib, _subsystem);
+    _cBadQ_FEDvsLS.book(ib, _subsystem);
     _cDataSizevsLS_FED.book(ib, _emap, _subsystem);
   }
 
@@ -226,12 +233,19 @@ RawTask::RawTask(edm::ParameterSet const& ps)
       return;
   }
 
+  if (_ptype == fOnline && lumiCache->EvtCntLS == 1) {  // Reset the bin for  _cBadQ_FEDvsLSmod10 at the beginning of each new LS
+      for (std::vector<uint32_t>::const_iterator it = _vhashFEDs.begin(); it != _vhashFEDs.end(); ++it) {
+	  HcalElectronicsId eid = HcalElectronicsId(*it);
+	  _cBadQ_FEDvsLSmod10.setBinContent(eid, _currentLS % 10, 0);
+      }
+  }
   int nn = 0;
   //	loop thru and fill the detIds with bad quality
   //	NOTE: Calibration Channels are skipped!
   //	TODO: Include for Online Calibration Channels marked as bad
   //	a comment below is left on purpose!
   //_cBadQualityvsBX.fill(bx, creport->badQualityDigis());
+  
   int Nbadq = creport->badQualityDigis();
   if (lumiCache->EvtCntLS == 1)
     _NBadQEvent = 0;  // Reset at the beginning of each new LS
@@ -416,8 +430,6 @@ std::shared_ptr<hcaldqm::Cache> RawTask::globalBeginLuminosityBlock(edm::Luminos
       for (uint32_t iflag = 0; iflag < _vflags.size(); iflag++)
         _cSummaryvsLS_FED.setBinContent(eid, _currentLS, int(iflag), int(flag::fNCDAQ));
       _cSummaryvsLS.setBinContent(eid, _currentLS, int(flag::fNCDAQ));
-      if (!hcaldqm::utilities::isFEDHO(eid) && fed != 1136)
-        _cBadQ_FEDvsLSmod10.setBinContent(eid, _currentLS % 10, int(flag::fNCDAQ));
       continue;
     }
 
@@ -437,12 +449,8 @@ std::shared_ptr<hcaldqm::Cache> RawTask::globalBeginLuminosityBlock(edm::Luminos
         _vflags[fOrnMsm]._state = flag::fGOOD;
       if (double(_xBadQLS.get(eid)) > double(12 * _evsPerLS))
         _vflags[fBadQ]._state = flag::fBAD;
-      //else if (_xBadQLS.get(eid) > 0){
-      // Following line added due to https://gitlab.cern.ch/cmshcal/docs/-/issues/233
-      // BadQ > (5%) of number of events in this LS.
-      else if (double(_xBadQLS.get(eid)) > 0 && double(_NBadQEvent) > double(0.05 * _evsPerLS)) {
+      else if (_xBadQLS.get(eid) > 0){
         _vflags[fBadQ]._state = flag::fPROBLEMATIC;
-
       } else
         _vflags[fBadQ]._state = flag::fGOOD;
     }
@@ -454,9 +462,11 @@ std::shared_ptr<hcaldqm::Cache> RawTask::globalBeginLuminosityBlock(edm::Luminos
     for (std::vector<flag::Flag>::iterator ft = _vflags.begin(); ft != _vflags.end(); ++ft) {
       _cSummaryvsLS_FED.setBinContent(eid, _currentLS, int(iflag), ft->_state);
 
-      if (ft->_name == "BadQ") {
+      // Following line added due to https://gitlab.cern.ch/cmshcal/docs/-/issues/233                                                                                                               // BadQ > (5%) of number of events in this LS. 
+      if (ft->_name == "BadQ" && (double(_xBadQLS.get(eid)) > 0 && double(_NBadQEvent) > double(0.05 * _evsPerLS))) {
         if (!hcaldqm::utilities::isFEDHO(eid) && fed != 1136 && ft->_state != 3) {
           _cBadQ_FEDvsLSmod10.setBinContent(eid, _currentLS % 10, (double(_NBadQEvent) / double(_evsPerLS)) * 100);
+	  _cBadQ_FEDvsLS.setBinContent(eid, _currentLS, (double(_NBadQEvent) / double(_evsPerLS)) * 100);
         }
       }
       fSum += (*ft);


### PR DESCRIPTION
#### PR description:
  - A new plot BadQualityEvents vs all LS is added, 
  - Changes of error and warning alarm thresholds from 1 to 0.994 for both CapID and BadQEvents
 
#### PR validation:

<!-- runTheMatrix test is done

#### This is not a backport PR.
