### PR TITLE
Fix d0 bug

### DIFF
--- a/DataFormats/L1TrackTrigger/src/TTTrack_TrackWord.cc
+++ b/DataFormats/L1TrackTrigger/src/TTTrack_TrackWord.cc
@@ -72,7 +72,7 @@ void TTTrack_TrackWord::setTrackWord(unsigned int valid,
   float rPhi = localPhi(momentum.phi(), sector);  // this needs to be phi relative to the center of the sector
   float rTanl = momentum.z() / momentum.perp();
   float rZ0 = POCA.z();
-  float rD0 = POCA.x()*sin(momentum.phi()) - POCA.y()*cos(momentum.phi());
+  float rD0 = POCA.x() * sin(momentum.phi()) - POCA.y() * cos(momentum.phi());
 
   // bin and convert to integers
   valid_t valid_ = valid;

--- a/DataFormats/L1TrackTrigger/src/TTTrack_TrackWord.cc
+++ b/DataFormats/L1TrackTrigger/src/TTTrack_TrackWord.cc
@@ -72,7 +72,7 @@ void TTTrack_TrackWord::setTrackWord(unsigned int valid,
   float rPhi = localPhi(momentum.phi(), sector);  // this needs to be phi relative to the center of the sector
   float rTanl = momentum.z() / momentum.perp();
   float rZ0 = POCA.z();
-  float rD0 = POCA.perp();
+  float rD0 = POCA.x()*sin(momentum.phi()) - POCA.y()*cos(momentum.phi());
 
   // bin and convert to integers
   valid_t valid_ = valid;


### PR DESCRIPTION
#### PR description:

The calculation of the variable rd0 inside TTTrack_TrackWord::setTrackWord() was incorrect. It has now been fixed. As a result, TTTrack::d0() and TTTrack::getD0() return identical values for the track impact parameter, aside from the small loss of resolution in the latter function caused by the d0 being digitized and then undigitized again.

This bug was pointed out by Ryan Mccarthy @ryanm124 .