### PR TITLE
Initialize all member data in CaloSD constructor

### DIFF
--- a/SimG4CMS/Calo/interface/CaloSD.h
+++ b/SimG4CMS/Calo/interface/CaloSD.h
@@ -175,7 +175,7 @@ private:
 
   bool ignoreTrackID;
   bool isParameterized;
-  bool ignoreReject;
+  bool ignoreReject = false;
   bool useMap;  // use map for comparison of ID
   bool corrTOFBeam;
 
@@ -197,7 +197,7 @@ private:
   std::unordered_map<unsigned int, unsigned int> boundaryCrossingParentMap_;
   std::vector<std::unique_ptr<CaloG4Hit>> reusehit[2];
   std::vector<Detector> fineDetectors_;
-  bool doFineCaloThisStep_;
+  bool doFineCaloThisStep_ = false;
 };
 
 #endif  // SimG4CMS_CaloSD_h


### PR DESCRIPTION
#### PR description:

UBSAN warned that the value for doFineCaloThisStep_ was begin read before it was set.

The warning was
```
SimG4CMS/Calo/src/CaloSD.cc:667:8: runtime error: load of value 95, which is not a valid value for type 'bool'
```

#### PR validation:
Code compiles.