### PR TITLE
[ALCA] Fix syntax in python scripts

### DIFF
--- a/Alignment/OfflineValidation/scripts/createIOVlist.py
+++ b/Alignment/OfflineValidation/scripts/createIOVlist.py
@@ -27,7 +27,7 @@ def parser():
 
 ##Called in fillJson function in parallel
 def getFileInfo(filename):
-    print "Processing: {}".format(filename)
+    print("Processing: {}".format(filename))
 
     ##Get file info
     try:
@@ -37,7 +37,7 @@ def getFileInfo(filename):
 
     ##File not at CERN
     except:
-        print "Not at CERN {}".format(filename)
+        print("Not at CERN {}".format(filename))
         runInfo = filename
 
     return runInfo
@@ -52,7 +52,7 @@ def getFileList(dataset):
     ##Find files in dataset
     dbs = DbsApi('https://cmsweb.cern.ch/dbs/prod/global/DBSReader')
 
-    print "Processing: {}".format(dataset)
+    print("Processing: {}".format(dataset))
     sites = subprocess.check_output(["dasgoclient", "--query", "site dataset={}".format(dataset)]).split()
 
     if "T2_CH_CERN" in sites:
@@ -68,7 +68,7 @@ def getFileList(dataset):
                 emptyfiles.append(filename)
 
     else:
-        print "Not at CERN {}".format(dataset)
+        print("Not at CERN {}".format(dataset))
 
     return filelist, emptyfiles, nEvents
 

--- a/CalibCalorimetry/CaloMiscalibTools/test/make_ecal_miscaplibration.py
+++ b/CalibCalorimetry/CaloMiscalibTools/test/make_ecal_miscaplibration.py
@@ -152,11 +152,11 @@ for zindex in (-1,1):
             miscal_fac=miscalib(lumi,endcap,zindex,etaindex,phiindex,1)
             # create line:
             if endcap==0:
-	       if zindex==-1:
+               if zindex==-1:
                   line='        <Cell eta_index="'+str(-etaindex)+'" phi_index="'+str(phiindex)+'" scale_factor="'+str(miscal_fac)+'"/>\n'
                   xmlfile.write(line)
                   count=count+1
-	       else:
+               else:
                   line='        <Cell eta_index="'+str(+etaindex)+'" phi_index="'+str(phiindex)+'" scale_factor="'+str(miscal_fac)+'"/>\n'
                   xmlfile.write(line)
                   count=count+1

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisModules/data/EcnaSystemPythonModuleInsert_2.py
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisModules/data/EcnaSystemPythonModuleInsert_2.py
@@ -24,4 +24,5 @@ process.myCnaPackage = cms.EDAnalyzer("EcnaAnalyzer",
                                       #-------------- Getting Digis
                                       EBdigiCollection = cms.string("ebDigis"),
                                       EEdigiCollection = cms.string("eeDigis"),
+)
 #-------------- EcnaSystemPythoModuleInsert_2 / end

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisModules/data/EcnaSystemPythonModuleInsert_2_data.py
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisModules/data/EcnaSystemPythonModuleInsert_2_data.py
@@ -23,5 +23,6 @@ process.myCnaPackage = cms.EDAnalyzer("EcnaAnalyzer",
                                       #-------------- Getting Digis
                                       EBdigiCollection = cms.string("ebDigis"),
                                       EEdigiCollection = cms.string("eeDigis"),
+)
 #-------------- EcnaSystemPythoModuleInsert_2 _data/ end
 

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisModules/data/EcnaSystemPythonModuleInsert_2_simul.py
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisModules/data/EcnaSystemPythonModuleInsert_2_simul.py
@@ -24,4 +24,5 @@ process.myCnaPackage = cms.EDAnalyzer("EcnaAnalyzer",
                                       #-------------- Getting Digis
                                       EBdigiCollection = cms.string("ebDigis"),
                                       EEdigiCollection = cms.string("eeDigis"),
+)
 #-------------- EcnaSystemPythoModuleInsert_2 _simul/ end

--- a/CalibTracker/SiStripChannelGain/test/7TeVData/automatic_RunOnCalibTree.py
+++ b/CalibTracker/SiStripChannelGain/test/7TeVData/automatic_RunOnCalibTree.py
@@ -208,10 +208,10 @@ if(lastRun<=0):lastRun = lastGoodRun
 
 print("RunRange=[" + str(firstRun) + "," + str(lastRun) + "] --> NEvents=" + str(NTotalEvents/1000)+"K")
 
-if(automatic==True and NTotalEvents<2e6):	#ask at least 2M events to perform the calibration
-	print('Not Enough events to run the calibration')
+if(automatic==True and NTotalEvents<2e6): #ask at least 2M events to perform the calibration
+        print('Not Enough events to run the calibration')
         os.system('echo "Gain calibration postponed" | mail -s "Gain calibration postponed ('+str(firstRun)+' to '+str(lastRun)+') NEvents=' + str(NTotalEvents/1000)+'K" ' + mail)
-	exit(0);
+        exit(0)
 
 name = "Run_"+str(firstRun)+"_to_"+str(lastRun)
 if len(calMode)>0:  name = name+"_"+calMode

--- a/CalibTracker/SiStripChannelGain/test/7TeVData/dataCert.py
+++ b/CalibTracker/SiStripChannelGain/test/7TeVData/dataCert.py
@@ -16,8 +16,8 @@ def splitByTag(line,tags=["td","th"]):
     for tag in tags:
       posTag=line.find("<"+tag,pos)
       if posTag<firstTagPos and posTag>-1:
-	firstTag=tag
-	firstTagPos=posTag
+        firstTag=tag
+        firstTagPos=posTag
     if not firstTag:
       break
     tag=firstTag

--- a/CalibTracker/SiStripChannelGain/test/CodeExample/computeGain_cfg_OnBatch.py
+++ b/CalibTracker/SiStripChannelGain/test/CodeExample/computeGain_cfg_OnBatch.py
@@ -7,21 +7,21 @@ import os
 import sys
 
 Input_ConfigFile = "computeGain_cfg.py"
-					# The name of your config file
-					# where you have to replace the OutputAdresse by XXX_OUTPUT_XXX
-					# and the Number of Events by XXX_NEVENTS_XXX
-					# and the Number of Event to skip is XXX_SKIPEVENT_XXX
+                                        # The name of your config file
+                                        # where you have to replace the OutputAdresse by XXX_OUTPUT_XXX
+                                        # and the Number of Events by XXX_NEVENTS_XXX
+                                        # and the Number of Event to skip is XXX_SKIPEVENT_XXX
 Input_CffFile    = "InputFiles_cff.py"
 Input_CffN       = 1
 
 
 Output_RootFile = "SST_MERGE_GAIN" # The name of your output file  (will replace XXX_OUTPUT_XXX)
 
-Job_NEvents = -1			# Number of Events by job (will replace XXX_NEVENTS_XXX)
-Job_Start   = 0 			# The Index of your first job
-Job_End     = 1				# The Index of your last  job
-Job_SEvents = 0				# Event that you want to skip
-					# The first event will be Job_SEvents+1
+Job_NEvents = -1                        # Number of Events by job (will replace XXX_NEVENTS_XXX)
+Job_Start   = 0                         # The Index of your first job
+Job_End     = 1                                # The Index of your last  job
+Job_SEvents = 0                                # Event that you want to skip
+                                        # The first event will be Job_SEvents+1
 
 FarmDirectory = "FARM"
 QUEUE         = "cmscaf1nd"
@@ -30,48 +30,48 @@ QUEUE         = "cmscaf1nd"
 
 def CreateTheConfigFile(PATH,CONFIG_FILE,NEVENTS,OUTPUTFILE,INPUTFILE,INDEX):
 
-	config_file=open(CONFIG_FILE,'r')
-	config_txt   = config_file.read()               # Read all data
-	config_file.close()
-	newconfig_path = PATH + "/"+FarmDirectory+"/InputFile/%04i_" % INDEX
+        config_file=open(CONFIG_FILE,'r')
+        config_txt   = config_file.read()               # Read all data
+        config_file.close()
+        newconfig_path = PATH + "/"+FarmDirectory+"/InputFile/%04i_" % INDEX
         newconfig_path = newconfig_path + Output_RootFile + "_cfg.py"
 
-	mylogo1 = "#  -----------------------------------------------\n"
-	mylogo2 = "# |   cfg modified by the LaunchOnFarm Script     |\n"
-	mylogo3 = "# |   Created by Loic Quertenmont                 |\n"
-	mylogo4 = "# |   Loic.quertenmont@cern.ch                    |\n"
-	mylogo5 = "#  -----------------------------------------------\n\n\n\n"
-	config_txt = mylogo1 + mylogo2 + mylogo3 + mylogo4 + mylogo5 + config_txt
+        mylogo1 = "#  -----------------------------------------------\n"
+        mylogo2 = "# |   cfg modified by the LaunchOnFarm Script     |\n"
+        mylogo3 = "# |   Created by Loic Quertenmont                 |\n"
+        mylogo4 = "# |   Loic.quertenmont@cern.ch                    |\n"
+        mylogo5 = "#  -----------------------------------------------\n\n\n\n"
+        config_txt = mylogo1 + mylogo2 + mylogo3 + mylogo4 + mylogo5 + config_txt
 
-	i=0
-	while i < len(config_txt) :
-		if config_txt[i:i+15]=='XXX_NEVENTS_XXX':
-			Skip = INDEX*NEVENTS+Job_SEvents
-			MaxEvent = NEVENTS
-			print("job #%d" %INDEX + "\t\tNumber of Events fixed to \t\t%d"%MaxEvent)
-			newconfig_file=open(newconfig_path,'w')
-			newconfig_file.write("%s" % config_txt[0:i])
-			newconfig_file.write("%d" % MaxEvent)
-			newconfig_file.write("%s" % config_txt[i+15:len(config_txt)])
-			newconfig_file.close()
-			newconfig_file=open(newconfig_path,'r')
-			config_txt   = newconfig_file.read()
-			newconfig_file.close()
-			i = 0
-		if config_txt[i:i+14]=='XXX_OUTPUT_XXX':
-			print("job #%d" %INDEX + "\tOutput file fixed to\t\t%s"%OUTPUTFILE)
-			newconfig_file=open(newconfig_path,'w')
-			newconfig_file.write("%s" % config_txt[0:i])
-			newconfig_file.write("%s"% OUTPUTFILE)
-			newconfig_file.write("_%04i.root" % INDEX)
-			newconfig_file.write("%s" % config_txt[i+14:len(config_txt)])
-			newconfig_file.close()
-			newconfig_file=open(newconfig_path,'r')
-			config_txt   = newconfig_file.read()
-			newconfig_file.close()
-			i = 0
+        i=0
+        while i < len(config_txt) :
+                if config_txt[i:i+15]=='XXX_NEVENTS_XXX':
+                        Skip = INDEX*NEVENTS+Job_SEvents
+                        MaxEvent = NEVENTS
+                        print("job #%d" %INDEX + "\t\tNumber of Events fixed to \t\t%d"%MaxEvent)
+                        newconfig_file=open(newconfig_path,'w')
+                        newconfig_file.write("%s" % config_txt[0:i])
+                        newconfig_file.write("%d" % MaxEvent)
+                        newconfig_file.write("%s" % config_txt[i+15:len(config_txt)])
+                        newconfig_file.close()
+                        newconfig_file=open(newconfig_path,'r')
+                        config_txt   = newconfig_file.read()
+                        newconfig_file.close()
+                        i = 0
+                if config_txt[i:i+14]=='XXX_OUTPUT_XXX':
+                        print("job #%d" %INDEX + "\tOutput file fixed to\t\t%s"%OUTPUTFILE)
+                        newconfig_file=open(newconfig_path,'w')
+                        newconfig_file.write("%s" % config_txt[0:i])
+                        newconfig_file.write("%s"% OUTPUTFILE)
+                        newconfig_file.write("_%04i.root" % INDEX)
+                        newconfig_file.write("%s" % config_txt[i+14:len(config_txt)])
+                        newconfig_file.close()
+                        newconfig_file=open(newconfig_path,'r')
+                        config_txt   = newconfig_file.read()
+                        newconfig_file.close()
+                        i = 0
                 if config_txt[i:i+17]=='XXX_SKIPEVENT_XXX':
-			Skip = INDEX*NEVENTS+Job_SEvents
+                        Skip = INDEX*NEVENTS+Job_SEvents
                         print("job #%d" %INDEX + "\tNumber of Event to skip is fixed to\t\t%i"%Skip)
                         newconfig_file=open(newconfig_path,'w')
                         newconfig_file.write("%s" % config_txt[0:i])
@@ -118,30 +118,30 @@ def CreateTheConfigFile(PATH,CONFIG_FILE,NEVENTS,OUTPUTFILE,INPUTFILE,INDEX):
 
 
 
-		i = i+1
+                i = i+1
 
 def GetInputFiles(PATH,INPUT_FILE,NEVENTS,OUTPUTFILE,INDEX):
 
         config_file=open(INPUT_FILE,'r')
         config_txt = ""
-	i=0
+        i=0
         iMin = (INDEX+0)*Input_CffN
-	iMax = (INDEX+1)*Input_CffN-1
+        iMax = (INDEX+1)*Input_CffN-1
         for line in config_file:
 #                if(line[0:1]!='\''):
-#			continue
+#                        continue
 
                 if( (i>=iMin) and (i<=iMax) ):
-			config_txt = config_txt + line
+                        config_txt = config_txt + line
                 i = i+1
 
         if(iMax>=i):
-		return 0
+                return 0
         config_file.close()
 
 
         if(config_txt[len(config_txt)-2:len(config_txt)-1]==','):
-		config_txt = config_txt[0:len(config_txt)-2]
+                config_txt = config_txt[0:len(config_txt)-2]
         newconfig_path = PATH + "/"+FarmDirectory+"/InputFile/%04i_" % INDEX
         newconfig_path = newconfig_path + Output_RootFile + "_cff.py"
 
@@ -150,37 +150,37 @@ def GetInputFiles(PATH,INPUT_FILE,NEVENTS,OUTPUTFILE,INDEX):
 
 
 def CreateTheShellFile(PATH,INDEX):
-	shell_path = "./"+FarmDirectory+"/InputFile/%04i_" % INDEX
+        shell_path = "./"+FarmDirectory+"/InputFile/%04i_" % INDEX
         shell_path = shell_path + Output_RootFile + ".sh"
 
         cfg_path = PATH + "/" + FarmDirectory + "/InputFile/%04i_" % INDEX
         cfg_path = cfg_path + Output_RootFile + "_cfg.py"
 
-	shell_file=open(shell_path,'w')
-	shell_file.write("#! /bin/sh\n")
-	shell_file.write("#  ----------------------------------------------- \n")
-	shell_file.write("# |   Script created by the LaunchOnFarm Script   |\n")
-	shell_file.write("# |   Created by Loic Quertenmont                 |\n")
-	shell_file.write("# |   Loic.quertenmont@cern.ch                    |\n")
-	shell_file.write("#  ----------------------------------------------- \n\n\n\n")
+        shell_file=open(shell_path,'w')
+        shell_file.write("#! /bin/sh\n")
+        shell_file.write("#  ----------------------------------------------- \n")
+        shell_file.write("# |   Script created by the LaunchOnFarm Script   |\n")
+        shell_file.write("# |   Created by Loic Quertenmont                 |\n")
+        shell_file.write("# |   Loic.quertenmont@cern.ch                    |\n")
+        shell_file.write("#  ----------------------------------------------- \n\n\n\n")
         shell_file.write("%s" % "cd " + PATH + "/" + FarmDirectory + "\n")
-	shell_file.write("%s\n" % "eval `scramv1 runtime -sh`")
+        shell_file.write("%s\n" % "eval `scramv1 runtime -sh`")
 #        shell_file.write("%s\n" % "export STAGE_SVCCLASS=cmscaf")
 #        shell_file.write("%s\n" % "export STAGER_TRACE=3")
         shell_file.write("%s" % "cmsRun " + cfg_path +"\n")
-	shell_file.close()
-	chmod_path = "chmod 777 "+shell_path
-	os.system(chmod_path)
+        shell_file.close()
+        chmod_path = "chmod 777 "+shell_path
+        os.system(chmod_path)
 
 
-path = os.getcwd() 	#Get the current path
+path = os.getcwd()         #Get the current path
 os.system('mkdir '+FarmDirectory)
 os.system('mkdir '+FarmDirectory+'/RootFiles')
 os.system('mkdir '+FarmDirectory+'/Log')
 os.system('mkdir '+FarmDirectory+'/InputFile')
 
 for i in range(Job_Start,Job_End):
-	print('Submitting job number %d' %i)
+        print('Submitting job number %d' %i)
 
         input_path = FarmDirectory + ".InputFile.%04i_" % i
         input_path = input_path + Output_RootFile + "_cff.py"
@@ -189,18 +189,18 @@ for i in range(Job_Start,Job_End):
 #        if( GetInputFiles(path,Input_CffFile,Job_NEvents,path+"/"+FarmDirectory+"/RootFiles/"+Output_RootFile,i) == 0)
 #               print('error during the _cfg.py file creation --> are you sure InputFile_cff.py contains enough lines? \n')
 #               continue
-		
+                
         
-#	cff_created = 0
+#        cff_created = 0
 #        if(len(Input_CffFile)>3):
-#		cff_created = CreateTheInputFile(path,Input_CffFile,Job_NEvents,path+"/"+FarmDirectory+"/RootFiles/"+Output_RootFile,i)
+#                cff_created = CreateTheInputFile(path,Input_CffFile,Job_NEvents,path+"/"+FarmDirectory+"/RootFiles/"+Output_RootFile,i)
 #        if(cff_created==0):
 #                print('error during the cff file creation --> are you sure it contains enough lines? \n')
-#		continue
-	CreateTheConfigFile(path,Input_ConfigFile,Job_NEvents,path+"/"+FarmDirectory+"/RootFiles/"+Output_RootFile,input_path,i)
-	CreateTheShellFile(path,i)
+#                continue
+        CreateTheConfigFile(path,Input_ConfigFile,Job_NEvents,path+"/"+FarmDirectory+"/RootFiles/"+Output_RootFile,input_path,i)
+        CreateTheShellFile(path,i)
 
-	condor_path = "./"+FarmDirectory+"/InputFile/%04i_" % i
+        condor_path = "./"+FarmDirectory+"/InputFile/%04i_" % i
         condor_path = condor_path + Output_RootFile + ".cmd"
 
         shell_path = path + "/" + FarmDirectory + "/InputFile/%04i_" % i
@@ -214,9 +214,9 @@ for i in range(Job_Start,Job_End):
 #        batchSubmit = "bsub -q" + QUEUE + " -J" + JobName  + "'" + shell_path + " 0 ele'"
 #        batchSubmit = "bsub -q " + QUEUE + " -J " + JobName  + " -oo " + OutputPath + " -eo " + OutputPath + " '" + shell_path + " 0 ele'"
         batchSubmit = "bsub -q " + QUEUE + " -J " + JobName  + " '" + shell_path + " 0 ele'"
-	os.system (batchSubmit)
+        os.system (batchSubmit)
         
-	print('\n')
+        print('\n')
 NJobs = Job_End - Job_Start
 print("\n\n")
 print("\t\t\t%i Jobs submitted by the LaunchOnFarm script" % NJobs)

--- a/CalibTracker/SiStripChannelGain/test/CodeExample/produceCalibrationTree_cfg_OnBatch.py
+++ b/CalibTracker/SiStripChannelGain/test/CodeExample/produceCalibrationTree_cfg_OnBatch.py
@@ -7,21 +7,21 @@ import os
 import sys
 
 Input_ConfigFile = "produceCalibrationTree_cfg.py"
-					# The name of your config file
-					# where you have to replace the OutputAdresse by XXX_OUTPUT_XXX
-					# and the Number of Events by XXX_NEVENTS_XXX
-					# and the Number of Event to skip is XXX_SKIPEVENT_XXX
+                                        # The name of your config file
+                                        # where you have to replace the OutputAdresse by XXX_OUTPUT_XXX
+                                        # and the Number of Events by XXX_NEVENTS_XXX
+                                        # and the Number of Event to skip is XXX_SKIPEVENT_XXX
 Input_CffFile    = "InputFiles_cff.py"
 Input_CffN       = 1
 
 
 Output_RootFile = "SST_PART_GAIN" # The name of your output file  (will replace XXX_OUTPUT_XXX)
 
-Job_NEvents = -1			# Number of Events by job (will replace XXX_NEVENTS_XXX)
-Job_Start   = 0 			# The Index of your first job
-Job_End     = 115			# The Index of your last  job
-Job_SEvents = 0				# Event that you want to skip
-					# The first event will be Job_SEvents+1
+Job_NEvents = -1                        # Number of Events by job (will replace XXX_NEVENTS_XXX)
+Job_Start   = 0                         # The Index of your first job
+Job_End     = 115                        # The Index of your last  job
+Job_SEvents = 0                                # Event that you want to skip
+                                        # The first event will be Job_SEvents+1
 
 FarmDirectory = "FARM"
 QUEUE         = "cmscaf1nh"
@@ -30,48 +30,48 @@ QUEUE         = "cmscaf1nh"
 
 def CreateTheConfigFile(PATH,CONFIG_FILE,NEVENTS,OUTPUTFILE,INPUTFILE,INDEX):
 
-	config_file=open(CONFIG_FILE,'r')
-	config_txt   = config_file.read()               # Read all data
-	config_file.close()
-	newconfig_path = PATH + "/"+FarmDirectory+"/InputFile/%04i_" % INDEX
+        config_file=open(CONFIG_FILE,'r')
+        config_txt   = config_file.read()               # Read all data
+        config_file.close()
+        newconfig_path = PATH + "/"+FarmDirectory+"/InputFile/%04i_" % INDEX
         newconfig_path = newconfig_path + Output_RootFile + "_cfg.py"
 
-	mylogo1 = "#  -----------------------------------------------\n"
-	mylogo2 = "# |   cfg modified by the LaunchOnFarm Script     |\n"
-	mylogo3 = "# |   Created by Loic Quertenmont                 |\n"
-	mylogo4 = "# |   Loic.quertenmont@cern.ch                    |\n"
-	mylogo5 = "#  -----------------------------------------------\n\n\n\n"
-	config_txt = mylogo1 + mylogo2 + mylogo3 + mylogo4 + mylogo5 + config_txt
+        mylogo1 = "#  -----------------------------------------------\n"
+        mylogo2 = "# |   cfg modified by the LaunchOnFarm Script     |\n"
+        mylogo3 = "# |   Created by Loic Quertenmont                 |\n"
+        mylogo4 = "# |   Loic.quertenmont@cern.ch                    |\n"
+        mylogo5 = "#  -----------------------------------------------\n\n\n\n"
+        config_txt = mylogo1 + mylogo2 + mylogo3 + mylogo4 + mylogo5 + config_txt
 
-	i=0
-	while i < len(config_txt) :
-		if config_txt[i:i+15]=='XXX_NEVENTS_XXX':
-			Skip = INDEX*NEVENTS+Job_SEvents
-			MaxEvent = NEVENTS
-			print("job #%d" %INDEX + "\t\tNumber of Events fixed to \t\t%d"%MaxEvent)
-			newconfig_file=open(newconfig_path,'w')
-			newconfig_file.write("%s" % config_txt[0:i])
-			newconfig_file.write("%d" % MaxEvent)
-			newconfig_file.write("%s" % config_txt[i+15:len(config_txt)])
-			newconfig_file.close()
-			newconfig_file=open(newconfig_path,'r')
-			config_txt   = newconfig_file.read()
-			newconfig_file.close()
-			i = 0
-		if config_txt[i:i+14]=='XXX_OUTPUT_XXX':
-			print("job #%d" %INDEX + "\tOutput file fixed to\t\t%s"%OUTPUTFILE)
-			newconfig_file=open(newconfig_path,'w')
-			newconfig_file.write("%s" % config_txt[0:i])
-			newconfig_file.write("%s"% OUTPUTFILE)
-			newconfig_file.write("_%04i.root" % INDEX)
-			newconfig_file.write("%s" % config_txt[i+14:len(config_txt)])
-			newconfig_file.close()
-			newconfig_file=open(newconfig_path,'r')
-			config_txt   = newconfig_file.read()
-			newconfig_file.close()
-			i = 0
+        i=0
+        while i < len(config_txt) :
+                if config_txt[i:i+15]=='XXX_NEVENTS_XXX':
+                        Skip = INDEX*NEVENTS+Job_SEvents
+                        MaxEvent = NEVENTS
+                        print("job #%d" %INDEX + "\t\tNumber of Events fixed to \t\t%d"%MaxEvent)
+                        newconfig_file=open(newconfig_path,'w')
+                        newconfig_file.write("%s" % config_txt[0:i])
+                        newconfig_file.write("%d" % MaxEvent)
+                        newconfig_file.write("%s" % config_txt[i+15:len(config_txt)])
+                        newconfig_file.close()
+                        newconfig_file=open(newconfig_path,'r')
+                        config_txt   = newconfig_file.read()
+                        newconfig_file.close()
+                        i = 0
+                if config_txt[i:i+14]=='XXX_OUTPUT_XXX':
+                        print("job #%d" %INDEX + "\tOutput file fixed to\t\t%s"%OUTPUTFILE)
+                        newconfig_file=open(newconfig_path,'w')
+                        newconfig_file.write("%s" % config_txt[0:i])
+                        newconfig_file.write("%s"% OUTPUTFILE)
+                        newconfig_file.write("_%04i.root" % INDEX)
+                        newconfig_file.write("%s" % config_txt[i+14:len(config_txt)])
+                        newconfig_file.close()
+                        newconfig_file=open(newconfig_path,'r')
+                        config_txt   = newconfig_file.read()
+                        newconfig_file.close()
+                        i = 0
                 if config_txt[i:i+17]=='XXX_SKIPEVENT_XXX':
-			Skip = INDEX*NEVENTS+Job_SEvents
+                        Skip = INDEX*NEVENTS+Job_SEvents
                         print("job #%d" %INDEX + "\tNumber of Event to skip is fixed to\t\t%i"%Skip)
                         newconfig_file=open(newconfig_path,'w')
                         newconfig_file.write("%s" % config_txt[0:i])
@@ -106,30 +106,30 @@ def CreateTheConfigFile(PATH,CONFIG_FILE,NEVENTS,OUTPUTFILE,INPUTFILE,INDEX):
 
 
 
-		i = i+1
+                i = i+1
 
 def GetInputFiles(PATH,INPUT_FILE,NEVENTS,OUTPUTFILE,INDEX):
 
         config_file=open(INPUT_FILE,'r')
         config_txt = ""
-	i=0
+        i=0
         iMin = (INDEX+0)*Input_CffN
-	iMax = (INDEX+1)*Input_CffN-1
+        iMax = (INDEX+1)*Input_CffN-1
         for line in config_file:
 #                if(line[0:1]!='\''):
-#			continue
+#                        continue
 
                 if( (i>=iMin) and (i<=iMax) ):
-			config_txt = config_txt + line
+                        config_txt = config_txt + line
                 i = i+1
 
         if(iMax>=i):
-		return 0
+                return 0
         config_file.close()
 
 
         if(config_txt[len(config_txt)-2:len(config_txt)-1]==','):
-		config_txt = config_txt[0:len(config_txt)-2]
+                config_txt = config_txt[0:len(config_txt)-2]
         newconfig_path = PATH + "/"+FarmDirectory+"/InputFile/%04i_" % INDEX
         newconfig_path = newconfig_path + Output_RootFile + "_cff.py"
 
@@ -138,37 +138,37 @@ def GetInputFiles(PATH,INPUT_FILE,NEVENTS,OUTPUTFILE,INDEX):
 
 
 def CreateTheShellFile(PATH,INDEX):
-	shell_path = "./"+FarmDirectory+"/InputFile/%04i_" % INDEX
+        shell_path = "./"+FarmDirectory+"/InputFile/%04i_" % INDEX
         shell_path = shell_path + Output_RootFile + ".sh"
 
         cfg_path = PATH + "/" + FarmDirectory + "/InputFile/%04i_" % INDEX
         cfg_path = cfg_path + Output_RootFile + "_cfg.py"
 
-	shell_file=open(shell_path,'w')
-	shell_file.write("#! /bin/sh\n")
-	shell_file.write("#  ----------------------------------------------- \n")
-	shell_file.write("# |   Script created by the LaunchOnFarm Script   |\n")
-	shell_file.write("# |   Created by Loic Quertenmont                 |\n")
-	shell_file.write("# |   Loic.quertenmont@cern.ch                    |\n")
-	shell_file.write("#  ----------------------------------------------- \n\n\n\n")
+        shell_file=open(shell_path,'w')
+        shell_file.write("#! /bin/sh\n")
+        shell_file.write("#  ----------------------------------------------- \n")
+        shell_file.write("# |   Script created by the LaunchOnFarm Script   |\n")
+        shell_file.write("# |   Created by Loic Quertenmont                 |\n")
+        shell_file.write("# |   Loic.quertenmont@cern.ch                    |\n")
+        shell_file.write("#  ----------------------------------------------- \n\n\n\n")
         shell_file.write("%s" % "cd " + PATH + "/" + FarmDirectory + "\n")
-	shell_file.write("%s\n" % "eval `scramv1 runtime -sh`")
+        shell_file.write("%s\n" % "eval `scramv1 runtime -sh`")
 #        shell_file.write("%s\n" % "export STAGE_SVCCLASS=cmscaf")
 #        shell_file.write("%s\n" % "export STAGER_TRACE=3")
         shell_file.write("%s" % "cmsRun " + cfg_path +"\n")
-	shell_file.close()
-	chmod_path = "chmod 777 "+shell_path
-	os.system(chmod_path)
+        shell_file.close()
+        chmod_path = "chmod 777 "+shell_path
+        os.system(chmod_path)
 
 
-path = os.getcwd() 	#Get the current path
+path = os.getcwd()         #Get the current path
 os.system('mkdir '+FarmDirectory)
 os.system('mkdir '+FarmDirectory+'/RootFiles')
 os.system('mkdir '+FarmDirectory+'/Log')
 os.system('mkdir '+FarmDirectory+'/InputFile')
 
 for i in range(Job_Start,Job_End):
-	print('Submitting job number %d' %i)
+        print('Submitting job number %d' %i)
 
         input_path = FarmDirectory + ".InputFile.%04i_" % i
         input_path = input_path + Output_RootFile + "_cff.py"
@@ -177,18 +177,18 @@ for i in range(Job_Start,Job_End):
 #        if( GetInputFiles(path,Input_CffFile,Job_NEvents,path+"/"+FarmDirectory+"/RootFiles/"+Output_RootFile,i) == 0)
 #               print('error during the _cfg.py file creation --> are you sure InputFile_cff.py contains enough lines? \n')
 #               continue
-		
+                
         
-#	cff_created = 0
+#        cff_created = 0
 #        if(len(Input_CffFile)>3):
-#		cff_created = CreateTheInputFile(path,Input_CffFile,Job_NEvents,path+"/"+FarmDirectory+"/RootFiles/"+Output_RootFile,i)
+#                cff_created = CreateTheInputFile(path,Input_CffFile,Job_NEvents,path+"/"+FarmDirectory+"/RootFiles/"+Output_RootFile,i)
 #        if(cff_created==0):
 #                print('error during the cff file creation --> are you sure it contains enough lines? \n')
-#		continue
-	CreateTheConfigFile(path,Input_ConfigFile,Job_NEvents,path+"/"+FarmDirectory+"/RootFiles/"+Output_RootFile,input_path,i)
-	CreateTheShellFile(path,i)
+#                continue
+        CreateTheConfigFile(path,Input_ConfigFile,Job_NEvents,path+"/"+FarmDirectory+"/RootFiles/"+Output_RootFile,input_path,i)
+        CreateTheShellFile(path,i)
 
-	condor_path = "./"+FarmDirectory+"/InputFile/%04i_" % i
+        condor_path = "./"+FarmDirectory+"/InputFile/%04i_" % i
         condor_path = condor_path + Output_RootFile + ".cmd"
 
         shell_path = path + "/" + FarmDirectory + "/InputFile/%04i_" % i
@@ -202,9 +202,9 @@ for i in range(Job_Start,Job_End):
 #        batchSubmit = "bsub -q" + QUEUE + " -J" + JobName  + "'" + shell_path + " 0 ele'"
 #        batchSubmit = "bsub -q " + QUEUE + " -J " + JobName  + " -oo " + OutputPath + " -eo " + OutputPath + " '" + shell_path + " 0 ele'"
         batchSubmit = "bsub -q " + QUEUE + " -J " + JobName  + " '" + shell_path + " 0 ele'"
-	os.system (batchSubmit)
+        os.system (batchSubmit)
         
-	print('\n')
+        print('\n')
 NJobs = Job_End - Job_Start
 print("\n\n")
 print("\t\t\t%i Jobs submitted by the LaunchOnFarm script" % NJobs)

--- a/CalibTracker/SiStripChannelGain/test/Cosmic_B38/MergeOnBatch.py
+++ b/CalibTracker/SiStripChannelGain/test/Cosmic_B38/MergeOnBatch.py
@@ -7,18 +7,18 @@ import os
 import sys
 
 Input_ConfigFile = "MergeJob_cfg.py"
-					# The name of your config file
-					# where you have to replace the OutputAdresse by XXX_OUTPUT_XXX
-					# and the Number of Events by XXX_NEVENTS_XXX
-					# and the Number of Event to skip is XXX_SKIPEVENT_XXX
+                                        # The name of your config file
+                                        # where you have to replace the OutputAdresse by XXX_OUTPUT_XXX
+                                        # and the Number of Events by XXX_NEVENTS_XXX
+                                        # and the Number of Event to skip is XXX_SKIPEVENT_XXX
 
 Output_RootFile = "MERGE" # The name of your output file  (will replace XXX_OUTPUT_XXX)
 
-Job_NEvents = 10000			# Number of Events by job (will replace XXX_NEVENTS_XXX)
-Job_Start   = 0 			# The Index of your first job
-Job_End     = 1				# The Index of your last  job
-Job_SEvents = 0				# Event that you want to skip
-					# The first event will be Job_SEvents+1
+Job_NEvents = 10000                        # Number of Events by job (will replace XXX_NEVENTS_XXX)
+Job_Start   = 0                         # The Index of your first job
+Job_End     = 1                                # The Index of your last  job
+Job_SEvents = 0                                # Event that you want to skip
+                                        # The first event will be Job_SEvents+1
 
 FarmDirectory = "FARM_Merge"
 QUEUE         = "cmscaf"
@@ -26,48 +26,48 @@ QUEUE         = "cmscaf"
 
 def CreateTheConfigFile(PATH,CONFIG_FILE,NEVENTS,OUTPUTFILE,INDEX):
 
-	config_file=open(CONFIG_FILE,'r')
-	config_txt   = config_file.read()               # Read all data
-	config_file.close()
-	newconfig_path = PATH + "/"+FarmDirectory+"/InputFile/%04i_" % INDEX
+        config_file=open(CONFIG_FILE,'r')
+        config_txt   = config_file.read()               # Read all data
+        config_file.close()
+        newconfig_path = PATH + "/"+FarmDirectory+"/InputFile/%04i_" % INDEX
         newconfig_path = newconfig_path + Output_RootFile + ".cfg"
 
-	mylogo1 = "#  -----------------------------------------------\n"
-	mylogo2 = "# |   cfg modified by the LaunchOnFarm Script     |\n"
-	mylogo3 = "# |   Created by Loic Quertenmont                 |\n"
-	mylogo4 = "# |   Loic.quertenmont@cern.ch                    |\n"
-	mylogo5 = "#  -----------------------------------------------\n\n\n\n"
-	config_txt = mylogo1 + mylogo2 + mylogo3 + mylogo4 + mylogo5 + config_txt
+        mylogo1 = "#  -----------------------------------------------\n"
+        mylogo2 = "# |   cfg modified by the LaunchOnFarm Script     |\n"
+        mylogo3 = "# |   Created by Loic Quertenmont                 |\n"
+        mylogo4 = "# |   Loic.quertenmont@cern.ch                    |\n"
+        mylogo5 = "#  -----------------------------------------------\n\n\n\n"
+        config_txt = mylogo1 + mylogo2 + mylogo3 + mylogo4 + mylogo5 + config_txt
 
-	i=0
-	while i < len(config_txt) :
-		if config_txt[i:i+15]=='XXX_NEVENTS_XXX':
-			Skip = INDEX*NEVENTS+Job_SEvents
-			MaxEvent = NEVENTS
-			print("job #%d" %INDEX + "\t\tNumber of Events fixed to \t\t%d"%MaxEvent)
-			newconfig_file=open(newconfig_path,'w')
-			newconfig_file.write("%s" % config_txt[0:i])
-			newconfig_file.write("%d" % MaxEvent)
-			newconfig_file.write("%s" % config_txt[i+15:len(config_txt)])
-			newconfig_file.close()
-			newconfig_file=open(newconfig_path,'r')
-			config_txt   = newconfig_file.read()
-			newconfig_file.close()
-			i = 0
-		if config_txt[i:i+14]=='XXX_OUTPUT_XXX':
-			print("job #%d" %INDEX + "\tOutput file fixed to\t\t%s"%OUTPUTFILE)
-			newconfig_file=open(newconfig_path,'w')
-			newconfig_file.write("%s" % config_txt[0:i])
-			newconfig_file.write("%s"% OUTPUTFILE)
-			newconfig_file.write("_%04i.root" % INDEX)
-			newconfig_file.write("%s" % config_txt[i+14:len(config_txt)])
-			newconfig_file.close()
-			newconfig_file=open(newconfig_path,'r')
-			config_txt   = newconfig_file.read()
-			newconfig_file.close()
-			i = 0
+        i=0
+        while i < len(config_txt) :
+                if config_txt[i:i+15]=='XXX_NEVENTS_XXX':
+                        Skip = INDEX*NEVENTS+Job_SEvents
+                        MaxEvent = NEVENTS
+                        print("job #%d" %INDEX + "\t\tNumber of Events fixed to \t\t%d"%MaxEvent)
+                        newconfig_file=open(newconfig_path,'w')
+                        newconfig_file.write("%s" % config_txt[0:i])
+                        newconfig_file.write("%d" % MaxEvent)
+                        newconfig_file.write("%s" % config_txt[i+15:len(config_txt)])
+                        newconfig_file.close()
+                        newconfig_file=open(newconfig_path,'r')
+                        config_txt   = newconfig_file.read()
+                        newconfig_file.close()
+                        i = 0
+                if config_txt[i:i+14]=='XXX_OUTPUT_XXX':
+                        print("job #%d" %INDEX + "\tOutput file fixed to\t\t%s"%OUTPUTFILE)
+                        newconfig_file=open(newconfig_path,'w')
+                        newconfig_file.write("%s" % config_txt[0:i])
+                        newconfig_file.write("%s"% OUTPUTFILE)
+                        newconfig_file.write("_%04i.root" % INDEX)
+                        newconfig_file.write("%s" % config_txt[i+14:len(config_txt)])
+                        newconfig_file.close()
+                        newconfig_file=open(newconfig_path,'r')
+                        config_txt   = newconfig_file.read()
+                        newconfig_file.close()
+                        i = 0
                 if config_txt[i:i+17]=='XXX_SKIPEVENT_XXX':
-			Skip = INDEX*NEVENTS+Job_SEvents
+                        Skip = INDEX*NEVENTS+Job_SEvents
                         print("job #%d" %INDEX + "\tNumber of Event to skip is fixed to\t\t%i"%Skip)
                         newconfig_file=open(newconfig_path,'w')
                         newconfig_file.write("%s" % config_txt[0:i])
@@ -90,43 +90,43 @@ def CreateTheConfigFile(PATH,CONFIG_FILE,NEVENTS,OUTPUTFILE,INDEX):
                         i = 0
 
 
-		i = i+1
+                i = i+1
 
 def CreateTheShellFile(PATH,INDEX):
-	shell_path = "./"+FarmDirectory+"/InputFile/%04i_" % INDEX
+        shell_path = "./"+FarmDirectory+"/InputFile/%04i_" % INDEX
         shell_path = shell_path + Output_RootFile + ".sh"
 
         cfg_path = PATH + "/" + FarmDirectory + "/InputFile/%04i_" % INDEX
         cfg_path = cfg_path + Output_RootFile + ".cfg"
 
-	shell_file=open(shell_path,'w')
-	shell_file.write("#! /bin/sh\n")
-	shell_file.write("#  ----------------------------------------------- \n")
-	shell_file.write("# |   Script created by the LaunchOnFarm Script   |\n")
-	shell_file.write("# |   Created by Loic Quertenmont                 |\n")
-	shell_file.write("# |   Loic.quertenmont@cern.ch                    |\n")
-	shell_file.write("#  ----------------------------------------------- \n\n\n\n")
+        shell_file=open(shell_path,'w')
+        shell_file.write("#! /bin/sh\n")
+        shell_file.write("#  ----------------------------------------------- \n")
+        shell_file.write("# |   Script created by the LaunchOnFarm Script   |\n")
+        shell_file.write("# |   Created by Loic Quertenmont                 |\n")
+        shell_file.write("# |   Loic.quertenmont@cern.ch                    |\n")
+        shell_file.write("#  ----------------------------------------------- \n\n\n\n")
         shell_file.write("%s" % "cd " + PATH + "/" + FarmDirectory + "\n")
-	shell_file.write("%s\n" % "eval `scramv1 runtime -sh`")
+        shell_file.write("%s\n" % "eval `scramv1 runtime -sh`")
         shell_file.write("%s" % "cmsRun " + cfg_path +"\n")
-	shell_file.close()
-	chmod_path = "chmod 777 "+shell_path
-	os.system(chmod_path)
+        shell_file.close()
+        chmod_path = "chmod 777 "+shell_path
+        os.system(chmod_path)
 
 
-path = os.getcwd() 	#Get the current path
+path = os.getcwd()         #Get the current path
 os.system('mkdir '+FarmDirectory)
 os.system('mkdir '+FarmDirectory+'/RootFiles')
 os.system('mkdir '+FarmDirectory+'/Log')
 os.system('mkdir '+FarmDirectory+'/InputFile')
 
 for i in range(Job_Start,Job_End):
-	print('Submitting job number %d' %i)
+        print('Submitting job number %d' %i)
 
-	CreateTheConfigFile(path,Input_ConfigFile,Job_NEvents,path+"/"+FarmDirectory+"/RootFiles/"+Output_RootFile,i)
-	CreateTheShellFile(path,i)
+        CreateTheConfigFile(path,Input_ConfigFile,Job_NEvents,path+"/"+FarmDirectory+"/RootFiles/"+Output_RootFile,i)
+        CreateTheShellFile(path,i)
 
-	condor_path = "./"+FarmDirectory+"/InputFile/%04i_" % i
+        condor_path = "./"+FarmDirectory+"/InputFile/%04i_" % i
         condor_path = condor_path + Output_RootFile + ".cmd"
 
         shell_path = path + "/" + FarmDirectory + "/InputFile/%04i_" % i
@@ -144,11 +144,11 @@ for i in range(Job_Start,Job_End):
 #        batchSubmit = "bsub -q" + QUEUE + " -J" + JobName  + "'" + shell_path + " 0 ele'"
 #        batchSubmit = "bsub -q " + QUEUE + " -J " + JobName  + " -oo " + OutputPath + " -eo " + OutputPath + " '" + shell_path + " 0 ele'"
         batchSubmit = "bsub -q " + QUEUE + " -J " + JobName  + " '" + shell_path + " 0 ele'"
-	os.system (batchSubmit)
+        os.system (batchSubmit)
         os.system(cdPath)
 
         
-	print('\n')
+        print('\n')
 NJobs = Job_End - Job_Start
 print("\n\n")
 print("\t\t\t%i Jobs submitted by the LaunchOnFarm script" % NJobs)

--- a/CalibTracker/SiStripChannelGain/test/Cosmic_B38/launchOnBatch.py
+++ b/CalibTracker/SiStripChannelGain/test/Cosmic_B38/launchOnBatch.py
@@ -7,21 +7,21 @@ import os
 import sys
 
 Input_ConfigFile = "MultiJob_cfg.py"
-					# The name of your config file
-					# where you have to replace the OutputAdresse by XXX_OUTPUT_XXX
-					# and the Number of Events by XXX_NEVENTS_XXX
-					# and the Number of Event to skip is XXX_SKIPEVENT_XXX
+                                        # The name of your config file
+                                        # where you have to replace the OutputAdresse by XXX_OUTPUT_XXX
+                                        # and the Number of Events by XXX_NEVENTS_XXX
+                                        # and the Number of Event to skip is XXX_SKIPEVENT_XXX
 Input_CffFile    = "InputFiles_cff.py"
 Input_CffN       = 1
 
 
 Output_RootFile = "ALCA" # The name of your output file  (will replace XXX_OUTPUT_XXX)
 
-Job_NEvents = -1			# Number of Events by job (will replace XXX_NEVENTS_XXX)
-Job_Start   = 0 			# The Index of your first job
-Job_End     = 115			# The Index of your last  job
-Job_SEvents = 0				# Event that you want to skip
-					# The first event will be Job_SEvents+1
+Job_NEvents = -1                        # Number of Events by job (will replace XXX_NEVENTS_XXX)
+Job_Start   = 0                         # The Index of your first job
+Job_End     = 115                        # The Index of your last  job
+Job_SEvents = 0                                # Event that you want to skip
+                                        # The first event will be Job_SEvents+1
 
 FarmDirectory = "FARM"
 QUEUE         = "cmscaf"
@@ -30,48 +30,48 @@ QUEUE         = "cmscaf"
 
 def CreateTheConfigFile(PATH,CONFIG_FILE,NEVENTS,OUTPUTFILE,INPUTFILE,INDEX):
 
-	config_file=open(CONFIG_FILE,'r')
-	config_txt   = config_file.read()               # Read all data
-	config_file.close()
-	newconfig_path = PATH + "/"+FarmDirectory+"/InputFile/%04i_" % INDEX
+        config_file=open(CONFIG_FILE,'r')
+        config_txt   = config_file.read()               # Read all data
+        config_file.close()
+        newconfig_path = PATH + "/"+FarmDirectory+"/InputFile/%04i_" % INDEX
         newconfig_path = newconfig_path + Output_RootFile + "_cfg.py"
 
-	mylogo1 = "#  -----------------------------------------------\n"
-	mylogo2 = "# |   cfg modified by the LaunchOnFarm Script     |\n"
-	mylogo3 = "# |   Created by Loic Quertenmont                 |\n"
-	mylogo4 = "# |   Loic.quertenmont@cern.ch                    |\n"
-	mylogo5 = "#  -----------------------------------------------\n\n\n\n"
-	config_txt = mylogo1 + mylogo2 + mylogo3 + mylogo4 + mylogo5 + config_txt
+        mylogo1 = "#  -----------------------------------------------\n"
+        mylogo2 = "# |   cfg modified by the LaunchOnFarm Script     |\n"
+        mylogo3 = "# |   Created by Loic Quertenmont                 |\n"
+        mylogo4 = "# |   Loic.quertenmont@cern.ch                    |\n"
+        mylogo5 = "#  -----------------------------------------------\n\n\n\n"
+        config_txt = mylogo1 + mylogo2 + mylogo3 + mylogo4 + mylogo5 + config_txt
 
-	i=0
-	while i < len(config_txt) :
-		if config_txt[i:i+15]=='XXX_NEVENTS_XXX':
-			Skip = INDEX*NEVENTS+Job_SEvents
-			MaxEvent = NEVENTS
-			print("job #%d" %INDEX + "\t\tNumber of Events fixed to \t\t%d"%MaxEvent)
-			newconfig_file=open(newconfig_path,'w')
-			newconfig_file.write("%s" % config_txt[0:i])
-			newconfig_file.write("%d" % MaxEvent)
-			newconfig_file.write("%s" % config_txt[i+15:len(config_txt)])
-			newconfig_file.close()
-			newconfig_file=open(newconfig_path,'r')
-			config_txt   = newconfig_file.read()
-			newconfig_file.close()
-			i = 0
-		if config_txt[i:i+14]=='XXX_OUTPUT_XXX':
-			print("job #%d" %INDEX + "\tOutput file fixed to\t\t%s"%OUTPUTFILE)
-			newconfig_file=open(newconfig_path,'w')
-			newconfig_file.write("%s" % config_txt[0:i])
-			newconfig_file.write("%s"% OUTPUTFILE)
-			newconfig_file.write("_%04i.root" % INDEX)
-			newconfig_file.write("%s" % config_txt[i+14:len(config_txt)])
-			newconfig_file.close()
-			newconfig_file=open(newconfig_path,'r')
-			config_txt   = newconfig_file.read()
-			newconfig_file.close()
-			i = 0
+        i=0
+        while i < len(config_txt) :
+                if config_txt[i:i+15]=='XXX_NEVENTS_XXX':
+                        Skip = INDEX*NEVENTS+Job_SEvents
+                        MaxEvent = NEVENTS
+                        print("job #%d" %INDEX + "\t\tNumber of Events fixed to \t\t%d"%MaxEvent)
+                        newconfig_file=open(newconfig_path,'w')
+                        newconfig_file.write("%s" % config_txt[0:i])
+                        newconfig_file.write("%d" % MaxEvent)
+                        newconfig_file.write("%s" % config_txt[i+15:len(config_txt)])
+                        newconfig_file.close()
+                        newconfig_file=open(newconfig_path,'r')
+                        config_txt   = newconfig_file.read()
+                        newconfig_file.close()
+                        i = 0
+                if config_txt[i:i+14]=='XXX_OUTPUT_XXX':
+                        print("job #%d" %INDEX + "\tOutput file fixed to\t\t%s"%OUTPUTFILE)
+                        newconfig_file=open(newconfig_path,'w')
+                        newconfig_file.write("%s" % config_txt[0:i])
+                        newconfig_file.write("%s"% OUTPUTFILE)
+                        newconfig_file.write("_%04i.root" % INDEX)
+                        newconfig_file.write("%s" % config_txt[i+14:len(config_txt)])
+                        newconfig_file.close()
+                        newconfig_file=open(newconfig_path,'r')
+                        config_txt   = newconfig_file.read()
+                        newconfig_file.close()
+                        i = 0
                 if config_txt[i:i+17]=='XXX_SKIPEVENT_XXX':
-			Skip = INDEX*NEVENTS+Job_SEvents
+                        Skip = INDEX*NEVENTS+Job_SEvents
                         print("job #%d" %INDEX + "\tNumber of Event to skip is fixed to\t\t%i"%Skip)
                         newconfig_file=open(newconfig_path,'w')
                         newconfig_file.write("%s" % config_txt[0:i])
@@ -106,30 +106,30 @@ def CreateTheConfigFile(PATH,CONFIG_FILE,NEVENTS,OUTPUTFILE,INPUTFILE,INDEX):
 
 
 
-		i = i+1
+                i = i+1
 
 def GetInputFiles(PATH,INPUT_FILE,NEVENTS,OUTPUTFILE,INDEX):
 
         config_file=open(INPUT_FILE,'r')
         config_txt = ""
-	i=0
+        i=0
         iMin = (INDEX+0)*Input_CffN
-	iMax = (INDEX+1)*Input_CffN-1
+        iMax = (INDEX+1)*Input_CffN-1
         for line in config_file:
                 if(line[0:1]!='\''):
-			continue
+                        continue
 
                 if( (i>=iMin) and (i<=iMax) ):
-			config_txt = config_txt + line
+                        config_txt = config_txt + line
                 i = i+1
 
         if(iMax>=i):
-		return 0
+                return 0
         config_file.close()
 
 
         if(config_txt[len(config_txt)-2:len(config_txt)-1]==','):
-		config_txt = config_txt[0:len(config_txt)-2]
+                config_txt = config_txt[0:len(config_txt)-2]
         newconfig_path = PATH + "/"+FarmDirectory+"/InputFile/%04i_" % INDEX
         newconfig_path = newconfig_path + Output_RootFile + "_cff.py"
 
@@ -138,37 +138,37 @@ def GetInputFiles(PATH,INPUT_FILE,NEVENTS,OUTPUTFILE,INDEX):
 
 
 def CreateTheShellFile(PATH,INDEX):
-	shell_path = "./"+FarmDirectory+"/InputFile/%04i_" % INDEX
+        shell_path = "./"+FarmDirectory+"/InputFile/%04i_" % INDEX
         shell_path = shell_path + Output_RootFile + ".sh"
 
         cfg_path = PATH + "/" + FarmDirectory + "/InputFile/%04i_" % INDEX
         cfg_path = cfg_path + Output_RootFile + "_cfg.py"
 
-	shell_file=open(shell_path,'w')
-	shell_file.write("#! /bin/sh\n")
-	shell_file.write("#  ----------------------------------------------- \n")
-	shell_file.write("# |   Script created by the LaunchOnFarm Script   |\n")
-	shell_file.write("# |   Created by Loic Quertenmont                 |\n")
-	shell_file.write("# |   Loic.quertenmont@cern.ch                    |\n")
-	shell_file.write("#  ----------------------------------------------- \n\n\n\n")
+        shell_file=open(shell_path,'w')
+        shell_file.write("#! /bin/sh\n")
+        shell_file.write("#  ----------------------------------------------- \n")
+        shell_file.write("# |   Script created by the LaunchOnFarm Script   |\n")
+        shell_file.write("# |   Created by Loic Quertenmont                 |\n")
+        shell_file.write("# |   Loic.quertenmont@cern.ch                    |\n")
+        shell_file.write("#  ----------------------------------------------- \n\n\n\n")
         shell_file.write("%s" % "cd " + PATH + "/" + FarmDirectory + "\n")
-	shell_file.write("%s\n" % "eval `scramv1 runtime -sh`")
+        shell_file.write("%s\n" % "eval `scramv1 runtime -sh`")
 #        shell_file.write("%s\n" % "export STAGE_SVCCLASS=cmscaf")
 #        shell_file.write("%s\n" % "export STAGER_TRACE=3")
         shell_file.write("%s" % "cmsRun " + cfg_path +"\n")
-	shell_file.close()
-	chmod_path = "chmod 777 "+shell_path
-	os.system(chmod_path)
+        shell_file.close()
+        chmod_path = "chmod 777 "+shell_path
+        os.system(chmod_path)
 
 
-path = os.getcwd() 	#Get the current path
+path = os.getcwd()         #Get the current path
 os.system('mkdir '+FarmDirectory)
 os.system('mkdir '+FarmDirectory+'/RootFiles')
 os.system('mkdir '+FarmDirectory+'/Log')
 os.system('mkdir '+FarmDirectory+'/InputFile')
 
 for i in range(Job_Start,Job_End):
-	print('Submitting job number %d' %i)
+        print('Submitting job number %d' %i)
 
         input_path = FarmDirectory + ".InputFile.%04i_" % i
         input_path = input_path + Output_RootFile + "_cff.py"
@@ -177,18 +177,18 @@ for i in range(Job_Start,Job_End):
 #        if( GetInputFiles(path,Input_CffFile,Job_NEvents,path+"/"+FarmDirectory+"/RootFiles/"+Output_RootFile,i) == 0)
 #               print('error during the _cfg.py file creation --> are you sure InputFile_cff.py contains enough lines? \n')
 #               continue
-		
+                
         
-#	cff_created = 0
+#        cff_created = 0
 #        if(len(Input_CffFile)>3):
-#		cff_created = CreateTheInputFile(path,Input_CffFile,Job_NEvents,path+"/"+FarmDirectory+"/RootFiles/"+Output_RootFile,i)
+#                cff_created = CreateTheInputFile(path,Input_CffFile,Job_NEvents,path+"/"+FarmDirectory+"/RootFiles/"+Output_RootFile,i)
 #        if(cff_created==0):
 #                print('error during the cff file creation --> are you sure it contains enough lines? \n')
-#		continue
-	CreateTheConfigFile(path,Input_ConfigFile,Job_NEvents,path+"/"+FarmDirectory+"/RootFiles/"+Output_RootFile,input_path,i)
-	CreateTheShellFile(path,i)
+#                continue
+        CreateTheConfigFile(path,Input_ConfigFile,Job_NEvents,path+"/"+FarmDirectory+"/RootFiles/"+Output_RootFile,input_path,i)
+        CreateTheShellFile(path,i)
 
-	condor_path = "./"+FarmDirectory+"/InputFile/%04i_" % i
+        condor_path = "./"+FarmDirectory+"/InputFile/%04i_" % i
         condor_path = condor_path + Output_RootFile + ".cmd"
 
         shell_path = path + "/" + FarmDirectory + "/InputFile/%04i_" % i
@@ -202,9 +202,9 @@ for i in range(Job_Start,Job_End):
 #        batchSubmit = "bsub -q" + QUEUE + " -J" + JobName  + "'" + shell_path + " 0 ele'"
 #        batchSubmit = "bsub -q " + QUEUE + " -J " + JobName  + " -oo " + OutputPath + " -eo " + OutputPath + " '" + shell_path + " 0 ele'"
         batchSubmit = "bsub -q " + QUEUE + " -J " + JobName  + " '" + shell_path + " 0 ele'"
-	os.system (batchSubmit)
+        os.system (batchSubmit)
         
-	print('\n')
+        print('\n')
 NJobs = Job_End - Job_Start
 print("\n\n")
 print("\t\t\t%i Jobs submitted by the LaunchOnFarm script" % NJobs)

--- a/CalibTracker/SiStripChannelGain/test/Cosmic_B38/onFarm_MergeJob_cfg.py
+++ b/CalibTracker/SiStripChannelGain/test/Cosmic_B38/onFarm_MergeJob_cfg.py
@@ -31,39 +31,39 @@ QUEUE         = "cmscaf"
 
 def CreateTheConfigFile(CONFIG_FILE,NEVENTS,OUTPUTFILE,INDEX):
 
-	config_file=open(CONFIG_FILE,'r')
-	config_txt   = config_file.read()               # Read all data
-	config_file.close()
-	newconfig_path = "./"+FarmDirectory+"/InputFile/%04i_" % INDEX
+        config_file=open(CONFIG_FILE,'r')
+        config_txt   = config_file.read()               # Read all data
+        config_file.close()
+        newconfig_path = "./"+FarmDirectory+"/InputFile/%04i_" % INDEX
         newconfig_path = newconfig_path + JobName + "_cfg.py"
 
-	mylogo1 = "#  -----------------------------------------------\n"
-	mylogo2 = "# |   cfg modified by the LaunchOnFarm Script     |\n"
-	mylogo3 = "# |   Created by Loic Quertenmont                 |\n"
-	mylogo4 = "# |   Loic.quertenmont@cern.ch                    |\n"
-	mylogo5 = "#  -----------------------------------------------\n\n\n\n"
-	config_txt = mylogo1 + mylogo2 + mylogo3 + mylogo4 + mylogo5 + config_txt
+        mylogo1 = "#  -----------------------------------------------\n"
+        mylogo2 = "# |   cfg modified by the LaunchOnFarm Script     |\n"
+        mylogo3 = "# |   Created by Loic Quertenmont                 |\n"
+        mylogo4 = "# |   Loic.quertenmont@cern.ch                    |\n"
+        mylogo5 = "#  -----------------------------------------------\n\n\n\n"
+        config_txt = mylogo1 + mylogo2 + mylogo3 + mylogo4 + mylogo5 + config_txt
 
         newconfig_file=open(newconfig_path,'w')
         newconfig_file.write("%s" % config_txt)
         newconfig_file.close()
 
 
-	i=0  
-	while i < len(config_txt) :
-		if config_txt[i:i+15]=='XXX_NEVENTS_XXX':
-			Skip = INDEX*NEVENTS+Job_SEvents
-			MaxEvent = NEVENTS
-			print("job #%d" %INDEX + "\t\tNumber of Events fixed to \t\t%d"%MaxEvent)
-			newconfig_file=open(newconfig_path,'w')
-			newconfig_file.write("%s" % config_txt[0:i])
-			newconfig_file.write("%d" % MaxEvent)
-			newconfig_file.write("%s" % config_txt[i+15:len(config_txt)])
-			newconfig_file.close()
-			newconfig_file=open(newconfig_path,'r')
-			config_txt   = newconfig_file.read()
-			newconfig_file.close()
-			i = 0
+        i=0  
+        while i < len(config_txt) :
+                if config_txt[i:i+15]=='XXX_NEVENTS_XXX':
+                        Skip = INDEX*NEVENTS+Job_SEvents
+                        MaxEvent = NEVENTS
+                        print("job #%d" %INDEX + "\t\tNumber of Events fixed to \t\t%d"%MaxEvent)
+                        newconfig_file=open(newconfig_path,'w')
+                        newconfig_file.write("%s" % config_txt[0:i])
+                        newconfig_file.write("%d" % MaxEvent)
+                        newconfig_file.write("%s" % config_txt[i+15:len(config_txt)])
+                        newconfig_file.close()
+                        newconfig_file=open(newconfig_path,'r')
+                        config_txt   = newconfig_file.read()
+                        newconfig_file.close()
+                        i = 0
                 if config_txt[i:i+12]=='XXX_SEED_XXX':
                         Skip = INDEX*NEVENTS+Job_SEvents
                         seed = Job_Seed + INDEX
@@ -77,19 +77,19 @@ def CreateTheConfigFile(CONFIG_FILE,NEVENTS,OUTPUTFILE,INDEX):
                         config_txt   = newconfig_file.read()
                         newconfig_file.close()
                         i = 0
-		if config_txt[i:i+14]=='XXX_OUTPUT_XXX':
-			print("job #%d" %INDEX + "\tOutput file fixed to\t\t%s"%OUTPUTFILE)
-			newconfig_file=open(newconfig_path,'w')
-			newconfig_file.write("%s" % config_txt[0:i])
-			newconfig_file.write("%s"% OUTPUTFILE)
-			newconfig_file.write("%s" % config_txt[i+14:len(config_txt)])
-			newconfig_file.close()
-			newconfig_file=open(newconfig_path,'r')
-			config_txt   = newconfig_file.read()
-			newconfig_file.close()
-			i = 0
+                if config_txt[i:i+14]=='XXX_OUTPUT_XXX':
+                        print("job #%d" %INDEX + "\tOutput file fixed to\t\t%s"%OUTPUTFILE)
+                        newconfig_file=open(newconfig_path,'w')
+                        newconfig_file.write("%s" % config_txt[0:i])
+                        newconfig_file.write("%s"% OUTPUTFILE)
+                        newconfig_file.write("%s" % config_txt[i+14:len(config_txt)])
+                        newconfig_file.close()
+                        newconfig_file=open(newconfig_path,'r')
+                        config_txt   = newconfig_file.read()
+                        newconfig_file.close()
+                        i = 0
                 if config_txt[i:i+17]=='XXX_SKIPEVENT_XXX':
-			Skip = INDEX*NEVENTS+Job_SEvents
+                        Skip = INDEX*NEVENTS+Job_SEvents
                         print("job #%d" %INDEX + "\tNumber of Event to skip is fixed to\t\t%i"%Skip)
                         newconfig_file=open(newconfig_path,'w')
                         newconfig_file.write("%s" % config_txt[0:i])
@@ -121,10 +121,10 @@ def CreateTheConfigFile(CONFIG_FILE,NEVENTS,OUTPUTFILE,INDEX):
                         newconfig_file.close()
                         i = 0
 
-		i = i+1
+                i = i+1
 
 def CreateTheShellFile(INITDIR,INDEX):
-	shell_path = "./"+FarmDirectory+"/InputFile/%04i_" % INDEX
+        shell_path = "./"+FarmDirectory+"/InputFile/%04i_" % INDEX
         shell_path = shell_path + JobName + ".sh"
 
         cfg_path = INITDIR+"/"+FarmDirectory+"/InputFile/%04i_" % INDEX
@@ -132,44 +132,44 @@ def CreateTheShellFile(INITDIR,INDEX):
 
         TxtIndex = "%04i" % INDEX  
 
-	shell_file=open(shell_path,'w')
-	shell_file.write("#! /bin/sh\n")
-	shell_file.write("#  ----------------------------------------------- \n")
-	shell_file.write("# |   Script created by the LaunchOnFarm Script   |\n")
-	shell_file.write("# |   Created by Loic Quertenmont                 |\n")
-	shell_file.write("# |   Loic.quertenmont@cern.ch                    |\n")
-	shell_file.write("#  ----------------------------------------------- \n\n\n\n")
-#	shell_file.write("%s\n" % "export SCRAM_ARCH=slc4_ia32_gcc345")
+        shell_file=open(shell_path,'w')
+        shell_file.write("#! /bin/sh\n")
+        shell_file.write("#  ----------------------------------------------- \n")
+        shell_file.write("# |   Script created by the LaunchOnFarm Script   |\n")
+        shell_file.write("# |   Created by Loic Quertenmont                 |\n")
+        shell_file.write("# |   Loic.quertenmont@cern.ch                    |\n")
+        shell_file.write("#  ----------------------------------------------- \n\n\n\n")
+#        shell_file.write("%s\n" % "export SCRAM_ARCH=slc4_ia32_gcc345")
 #        shell_file.write("%s\n" % "export BUILD_ARCH=slc4_ia32_gcc345")
 #        shell_file.write("%s\n" % "export VO_CMS_SW_DIR=/nfs/soft/cms")
-#	shell_file.write("%s\n" % "source /nfs/soft/cms/cmsset_default.sh")
-	shell_file.write("cd " + path + "\n")
-	shell_file.write("%s\n" % "eval `scramv1 runtime -sh`")
-	shell_file.write("%s\n" % "cd -")
+#        shell_file.write("%s\n" % "source /nfs/soft/cms/cmsset_default.sh")
+        shell_file.write("cd " + path + "\n")
+        shell_file.write("%s\n" % "eval `scramv1 runtime -sh`")
+        shell_file.write("%s\n" % "cd -")
         shell_file.write("%s" % "cmsRun " + cfg_path +"\n\n\n")
         shell_file.write("mv %s* " % JobName)
 #        shell_file.write("mv * ")
         shell_file.write("%s/" % path)
         shell_file.write("%s/.\n" % Output_Path)
-	shell_file.close()
-	chmod_path = "chmod 777 "+shell_path
-	os.system(chmod_path)
+        shell_file.close()
+        chmod_path = "chmod 777 "+shell_path
+        os.system(chmod_path)
 
 
-path = os.getcwd() 	#Get the current path
+path = os.getcwd()         #Get the current path
 if os.path.isdir(FarmDirectory) == False:
-	os.system('mkdir '+FarmDirectory)
-	os.system('mkdir '+FarmDirectory+'/Outputs')
-	os.system('mkdir '+FarmDirectory+'/Log')
-	os.system('mkdir '+FarmDirectory+'/InputFile')
+        os.system('mkdir '+FarmDirectory)
+        os.system('mkdir '+FarmDirectory+'/Outputs')
+        os.system('mkdir '+FarmDirectory+'/Log')
+        os.system('mkdir '+FarmDirectory+'/InputFile')
 
 for i in range(Job_Start,Job_End):
-	print('Submitting job number %d' %i)
+        print('Submitting job number %d' %i)
 
-	CreateTheConfigFile(Input_ConfigFile,Job_NEvents,JobName,i)
-	CreateTheShellFile(path,i)
+        CreateTheConfigFile(Input_ConfigFile,Job_NEvents,JobName,i)
+        CreateTheShellFile(path,i)
 
-	condor_path = path + "/"+FarmDirectory+"/InputFile/%04i_" % i
+        condor_path = path + "/"+FarmDirectory+"/InputFile/%04i_" % i
         condor_path = condor_path + JobName + ".cmd"
 
         shell_path = path + "/"+FarmDirectory + "/InputFile/%04i_" % i
@@ -184,7 +184,7 @@ for i in range(Job_Start,Job_End):
         batchSubmit = "bsub -q " + QUEUE + " -J " + JobName  + " '" + shell_path + " 0 ele'"
         os.system (batchSubmit)
 
-	print('\n')
+        print('\n')
 NJobs = Job_End - Job_Start
 print("\n\n")
 print("\t\t\t%i Jobs submitted by the LaunchOnFarm script" % NJobs)

--- a/CalibTracker/SiStripChannelGain/test/Cosmic_B38/onFarm_MultiJob_cfg.py
+++ b/CalibTracker/SiStripChannelGain/test/Cosmic_B38/onFarm_MultiJob_cfg.py
@@ -31,39 +31,39 @@ QUEUE         = "cmscaf"
 
 def CreateTheConfigFile(CONFIG_FILE,NEVENTS,OUTPUTFILE,INDEX):
 
-	config_file=open(CONFIG_FILE,'r')
-	config_txt   = config_file.read()               # Read all data
-	config_file.close()
-	newconfig_path = "./"+FarmDirectory+"/InputFile/%04i_" % INDEX
+        config_file=open(CONFIG_FILE,'r')
+        config_txt   = config_file.read()               # Read all data
+        config_file.close()
+        newconfig_path = "./"+FarmDirectory+"/InputFile/%04i_" % INDEX
         newconfig_path = newconfig_path + JobName + "_cfg.py"
 
-	mylogo1 = "#  -----------------------------------------------\n"
-	mylogo2 = "# |   cfg modified by the LaunchOnFarm Script     |\n"
-	mylogo3 = "# |   Created by Loic Quertenmont                 |\n"
-	mylogo4 = "# |   Loic.quertenmont@cern.ch                    |\n"
-	mylogo5 = "#  -----------------------------------------------\n\n\n\n"
-	config_txt = mylogo1 + mylogo2 + mylogo3 + mylogo4 + mylogo5 + config_txt
+        mylogo1 = "#  -----------------------------------------------\n"
+        mylogo2 = "# |   cfg modified by the LaunchOnFarm Script     |\n"
+        mylogo3 = "# |   Created by Loic Quertenmont                 |\n"
+        mylogo4 = "# |   Loic.quertenmont@cern.ch                    |\n"
+        mylogo5 = "#  -----------------------------------------------\n\n\n\n"
+        config_txt = mylogo1 + mylogo2 + mylogo3 + mylogo4 + mylogo5 + config_txt
 
         newconfig_file=open(newconfig_path,'w')
         newconfig_file.write("%s" % config_txt)
         newconfig_file.close()
 
 
-	i=0  
-	while i < len(config_txt) :
-		if config_txt[i:i+15]=='XXX_NEVENTS_XXX':
-			Skip = INDEX*NEVENTS+Job_SEvents
-			MaxEvent = NEVENTS
-			print("job #%d" %INDEX + "\t\tNumber of Events fixed to \t\t%d"%MaxEvent)
-			newconfig_file=open(newconfig_path,'w')
-			newconfig_file.write("%s" % config_txt[0:i])
-			newconfig_file.write("%d" % MaxEvent)
-			newconfig_file.write("%s" % config_txt[i+15:len(config_txt)])
-			newconfig_file.close()
-			newconfig_file=open(newconfig_path,'r')
-			config_txt   = newconfig_file.read()
-			newconfig_file.close()
-			i = 0
+        i=0  
+        while i < len(config_txt) :
+                if config_txt[i:i+15]=='XXX_NEVENTS_XXX':
+                        Skip = INDEX*NEVENTS+Job_SEvents
+                        MaxEvent = NEVENTS
+                        print("job #%d" %INDEX + "\t\tNumber of Events fixed to \t\t%d"%MaxEvent)
+                        newconfig_file=open(newconfig_path,'w')
+                        newconfig_file.write("%s" % config_txt[0:i])
+                        newconfig_file.write("%d" % MaxEvent)
+                        newconfig_file.write("%s" % config_txt[i+15:len(config_txt)])
+                        newconfig_file.close()
+                        newconfig_file=open(newconfig_path,'r')
+                        config_txt   = newconfig_file.read()
+                        newconfig_file.close()
+                        i = 0
                 if config_txt[i:i+12]=='XXX_SEED_XXX':
                         Skip = INDEX*NEVENTS+Job_SEvents
                         seed = Job_Seed + INDEX
@@ -77,19 +77,19 @@ def CreateTheConfigFile(CONFIG_FILE,NEVENTS,OUTPUTFILE,INDEX):
                         config_txt   = newconfig_file.read()
                         newconfig_file.close()
                         i = 0
-		if config_txt[i:i+14]=='XXX_OUTPUT_XXX':
-			print("job #%d" %INDEX + "\tOutput file fixed to\t\t%s"%OUTPUTFILE)
-			newconfig_file=open(newconfig_path,'w')
-			newconfig_file.write("%s" % config_txt[0:i])
-			newconfig_file.write("%s"% OUTPUTFILE)
-			newconfig_file.write("%s" % config_txt[i+14:len(config_txt)])
-			newconfig_file.close()
-			newconfig_file=open(newconfig_path,'r')
-			config_txt   = newconfig_file.read()
-			newconfig_file.close()
-			i = 0
+                if config_txt[i:i+14]=='XXX_OUTPUT_XXX':
+                        print("job #%d" %INDEX + "\tOutput file fixed to\t\t%s"%OUTPUTFILE)
+                        newconfig_file=open(newconfig_path,'w')
+                        newconfig_file.write("%s" % config_txt[0:i])
+                        newconfig_file.write("%s"% OUTPUTFILE)
+                        newconfig_file.write("%s" % config_txt[i+14:len(config_txt)])
+                        newconfig_file.close()
+                        newconfig_file=open(newconfig_path,'r')
+                        config_txt   = newconfig_file.read()
+                        newconfig_file.close()
+                        i = 0
                 if config_txt[i:i+17]=='XXX_SKIPEVENT_XXX':
-			Skip = INDEX*NEVENTS+Job_SEvents
+                        Skip = INDEX*NEVENTS+Job_SEvents
                         print("job #%d" %INDEX + "\tNumber of Event to skip is fixed to\t\t%i"%Skip)
                         newconfig_file=open(newconfig_path,'w')
                         newconfig_file.write("%s" % config_txt[0:i])
@@ -121,10 +121,10 @@ def CreateTheConfigFile(CONFIG_FILE,NEVENTS,OUTPUTFILE,INDEX):
                         newconfig_file.close()
                         i = 0
 
-		i = i+1
+                i = i+1
 
 def CreateTheShellFile(INITDIR,INDEX):
-	shell_path = "./"+FarmDirectory+"/InputFile/%04i_" % INDEX
+        shell_path = "./"+FarmDirectory+"/InputFile/%04i_" % INDEX
         shell_path = shell_path + JobName + ".sh"
 
         cfg_path = INITDIR+"/"+FarmDirectory+"/InputFile/%04i_" % INDEX
@@ -132,44 +132,44 @@ def CreateTheShellFile(INITDIR,INDEX):
 
         TxtIndex = "%04i" % INDEX  
 
-	shell_file=open(shell_path,'w')
-	shell_file.write("#! /bin/sh\n")
-	shell_file.write("#  ----------------------------------------------- \n")
-	shell_file.write("# |   Script created by the LaunchOnFarm Script   |\n")
-	shell_file.write("# |   Created by Loic Quertenmont                 |\n")
-	shell_file.write("# |   Loic.quertenmont@cern.ch                    |\n")
-	shell_file.write("#  ----------------------------------------------- \n\n\n\n")
-#	shell_file.write("%s\n" % "export SCRAM_ARCH=slc4_ia32_gcc345")
+        shell_file=open(shell_path,'w')
+        shell_file.write("#! /bin/sh\n")
+        shell_file.write("#  ----------------------------------------------- \n")
+        shell_file.write("# |   Script created by the LaunchOnFarm Script   |\n")
+        shell_file.write("# |   Created by Loic Quertenmont                 |\n")
+        shell_file.write("# |   Loic.quertenmont@cern.ch                    |\n")
+        shell_file.write("#  ----------------------------------------------- \n\n\n\n")
+#        shell_file.write("%s\n" % "export SCRAM_ARCH=slc4_ia32_gcc345")
 #        shell_file.write("%s\n" % "export BUILD_ARCH=slc4_ia32_gcc345")
 #        shell_file.write("%s\n" % "export VO_CMS_SW_DIR=/nfs/soft/cms")
-#	shell_file.write("%s\n" % "source /nfs/soft/cms/cmsset_default.sh")
-	shell_file.write("cd " + path + "\n")
-	shell_file.write("%s\n" % "eval `scramv1 runtime -sh`")
-	shell_file.write("%s\n" % "cd -")
+#        shell_file.write("%s\n" % "source /nfs/soft/cms/cmsset_default.sh")
+        shell_file.write("cd " + path + "\n")
+        shell_file.write("%s\n" % "eval `scramv1 runtime -sh`")
+        shell_file.write("%s\n" % "cd -")
         shell_file.write("%s" % "cmsRun " + cfg_path +"\n\n\n")
         shell_file.write("mv %s* " % JobName)
 #        shell_file.write("mv * ")
         shell_file.write("%s/" % path)
         shell_file.write("%s/.\n" % Output_Path)
-	shell_file.close()
-	chmod_path = "chmod 777 "+shell_path
-	os.system(chmod_path)
+        shell_file.close()
+        chmod_path = "chmod 777 "+shell_path
+        os.system(chmod_path)
 
 
-path = os.getcwd() 	#Get the current path
+path = os.getcwd()         #Get the current path
 if os.path.isdir(FarmDirectory) == False:
-	os.system('mkdir '+FarmDirectory)
-	os.system('mkdir '+FarmDirectory+'/Outputs')
-	os.system('mkdir '+FarmDirectory+'/Log')
-	os.system('mkdir '+FarmDirectory+'/InputFile')
+        os.system('mkdir '+FarmDirectory)
+        os.system('mkdir '+FarmDirectory+'/Outputs')
+        os.system('mkdir '+FarmDirectory+'/Log')
+        os.system('mkdir '+FarmDirectory+'/InputFile')
 
 for i in range(Job_Start,Job_End):
-	print('Submitting job number %d' %i)
+        print('Submitting job number %d' %i)
 
-	CreateTheConfigFile(Input_ConfigFile,Job_NEvents,JobName,i)
-	CreateTheShellFile(path,i)
+        CreateTheConfigFile(Input_ConfigFile,Job_NEvents,JobName,i)
+        CreateTheShellFile(path,i)
 
-	condor_path = path + "/"+FarmDirectory+"/InputFile/%04i_" % i
+        condor_path = path + "/"+FarmDirectory+"/InputFile/%04i_" % i
         condor_path = condor_path + JobName + ".cmd"
 
         shell_path = path + "/"+FarmDirectory + "/InputFile/%04i_" % i
@@ -184,7 +184,7 @@ for i in range(Job_Start,Job_End):
         batchSubmit = "bsub -q " + QUEUE + " -J " + JobName  + " '" + shell_path + " 0 ele'"
         os.system (batchSubmit)
 
-	print('\n')
+        print('\n')
 NJobs = Job_End - Job_Start
 print("\n\n")
 print("\t\t\t%i Jobs submitted by the LaunchOnFarm script" % NJobs)

--- a/CalibTracker/SiStripDCS/test/MakeTkMaps.py
+++ b/CalibTracker/SiStripDCS/test/MakeTkMaps.py
@@ -69,10 +69,10 @@ def ProduceTkMapVoltageInputFiles(workdir=os.getcwd()): #Setting the dir by defa
 		LVDict={}
 		HVDict={}
 		for line in logfile:
-		    if "OFF" in line: #All the interesting lines contain "OFF" by definition 
-		        (detid,HV,LV)=line.split()
-			LVDict.update({detid:LV})
-			HVDict.update({detid:HV})
+			if "OFF" in line: #All the interesting lines contain "OFF" by definition 
+				(detid,HV,LV)=line.split()
+				LVDict.update({detid:LV})
+				HVDict.update({detid:HV})
 	
 		#Handle the LV/HV files:
 		for detid in StripDetIDAlias.keys():
@@ -101,17 +101,17 @@ def runcmd(command):
 	Function that uses subprocess.Popen to run commands, it returns the exit code of the command. 
 	"""
 	try:
-	    process  = subprocess.Popen(command,shell=True,stdout=subprocess.PIPE,stderr=subprocess.STDOUT)
-	    pid=process.pid
-	    exitstat= process.wait()
-	    cmdout   = process.stdout.read()
-	    exitstat = process.returncode
+		process  = subprocess.Popen(command,shell=True,stdout=subprocess.PIPE,stderr=subprocess.STDOUT)
+		pid=process.pid
+		exitstat= process.wait()
+		cmdout   = process.stdout.read()
+		exitstat = process.returncode
 	except OSError as detail:
-	    print("Race condition in subprocess.Popen has robbed us of the exit code of the %s process (PID %s).Assume it failed!\n %s\n"%(command,pid,detail))
-	    exitstat=999
+		print("Race condition in subprocess.Popen has robbed us of the exit code of the %s process (PID %s).Assume it failed!\n %s\n"%(command,pid,detail))
+		exitstat=999
 	if exitstat == None:
-	    print("Something strange is going on! Exit code was None for command %s: check if it really ran!"%command)
-	    exitstat=0
+		print("Something strange is going on! Exit code was None for command %s: check if it really ran!"%command)
+		exitstat=0
 	return exitstat
 
 def CreateTkVoltageMapsCfgs(workdir=os.getcwd()): #Default to current working directory (could pass HV/LV list)
@@ -121,7 +121,7 @@ def CreateTkVoltageMapsCfgs(workdir=os.getcwd()): #Default to current working di
 	"""
 	#Use HV log files to loop... could use also LV logs...
 	HVLogs=[x for x in os.listdir(workdir) if x.startswith("HV") and "FROM" in x and x.endswith(".log")]
-	
+
 	#Open the file to use as template
 	TkMapCreatorTemplateFile=open(os.path.join(os.getenv("CMSSW_BASE"),"src/CalibTracker/SiStripDCS/test","TkVoltageMapCreator_cfg.py"),"r")
 	TkMapCreatorTemplateContent=TkMapCreatorTemplateFile.readlines()
@@ -130,7 +130,7 @@ def CreateTkVoltageMapsCfgs(workdir=os.getcwd()): #Default to current working di
 	for HVlog in HVLogs:
 		#Use full path since workdir could be different than current working dir:
 		HVlog=os.path.join(workdir,HVlog)
-	        #Check if the corresponding LV log is there!
+		#Check if the corresponding LV log is there!
 		LVlog=os.path.join(workdir,HVlog.replace("HV","LV"))
 		if not os.path.exists(LVlog):
 			print("ARGH! Missing LV file for file %s"%HVlog)
@@ -149,7 +149,7 @@ def CreateTkVoltageMapsCfgs(workdir=os.getcwd()): #Default to current working di
 				line='\tHVTkMapName = cms.string("%s")\n'%HVlog.replace(".log",".png")
 			TkMapCfg.write(line)
 		TkMapCfg.close()
-	        
+
 	TkMapCreatorTemplateFile.close()
 	return TkMapCfgFilenames
 
@@ -168,7 +168,7 @@ def CreateTkVoltageMaps(workdir=os.getcwd()): #Default to current working direct
 		if exitstat != 0:
 			print("Uh-Oh!")
 			print("Command %s FAILED!"%cmsRunCmd)
-			
+
 #Could put in a def main...
 
 #Create the TkVoltageMapCreator input files in the test dir below:

--- a/CalibTracker/SiStripDCS/test/UltimateCFG_cfg.py
+++ b/CalibTracker/SiStripDCS/test/UltimateCFG_cfg.py
@@ -133,7 +133,7 @@ process.SiStripDetVOffBuilder = cms.Service(
     ExcludedDetIdListFile = cms.string('CalibTracker/SiStripCommon/data/ExcludedSiStripDetInfo.dat'),
 
     # Threshold to consider an HV channel on
-    HighVoltageOnThreshold = cms.double(0.97)
+    HighVoltageOnThreshold = cms.double(0.97),
 
     # Leave empty if you want to use the db
     PsuDetIdMapFile = cms.string("CalibTracker/SiStripDCS/data/PsuDetIdMap.dat")

--- a/CalibTracker/SiStripHitResolution/test/SiStripHitResol_testULcosmics.py
+++ b/CalibTracker/SiStripHitResolution/test/SiStripHitResol_testULcosmics.py
@@ -11,13 +11,13 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data', '')
 UL = 1
 
 if UL == 0:
-        InputTagName = "ALCARECOSiStripCalCosmics"
+	InputTagName = "ALCARECOSiStripCalCosmics"
 	
-  	OutputRootFile = "hitresol_ALCARECO.root"
+	OutputRootFile = "hitresol_ALCARECO.root"
 
 	fileNames=cms.untracked.vstring("file:/eos/cms/store/data/Run2018C/Cosmics/ALCARECO/SiStripCalCosmics-UL18-v1/40000/C88E7B45-E0DA-0742-B622-25C2C9E0AC58.root",
 					"file:/eos/cms/store/data/Run2018C/Cosmics/ALCARECO/SiStripCalCosmics-UL18-v1/40000/08894276-BD9E-454E-96A9-8E30BE93C0C7.root",
-				 	"file:/eos/cms/store/data/Run2018C/Cosmics/ALCARECO/SiStripCalCosmics-UL18-v1/40000/FEA63E84-13F5-3246-BF7D-D7F4C257D419.root",
+					"file:/eos/cms/store/data/Run2018C/Cosmics/ALCARECO/SiStripCalCosmics-UL18-v1/40000/FEA63E84-13F5-3246-BF7D-D7F4C257D419.root",
 					"file:/eos/cms/store/data/Run2018C/Cosmics/ALCARECO/SiStripCalCosmics-UL18-v1/230000/09A05CD3-7D70-B141-870D-DE3BA2E58D96.root",
 					"file:/eos/cms/store/data/Run2018C/Cosmics/ALCARECO/SiStripCalCosmics-UL18-v1/230000/47887C90-18C4-4B4D-86A3-70E6004E2076.root",
 					"file:/eos/cms/store/data/Run2018C/Cosmics/ALCARECO/SiStripCalCosmics-UL18-v1/230000/B481DEBC-037D-1D4D-A767-38FE8A49F8E6.root",
@@ -56,35 +56,35 @@ else:
 	OutputRootFile = "hitresol_ALCARECO_UL.root"
 
 	fileNames=cms.untracked.vstring("file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/F3F28561-1B7E-0444-810D-A119929B4896.root",
-    				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/80508514-FC4F-5E48-84BD-A84EF28EEAE3.root",
-    				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/86DB491C-55E8-9C45-A748-632065719E7B.root",
-    				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/7D9F8691-6521-5247-88A8-97A9FD11EBB6.root",
-    				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280002/2185F94D-CE60-4541-A174-281FEC1217F6.root",
-    				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/5196D8AE-F413-4344-B14D-40CEB7B57736.root",
-   				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/478C4A87-9779-4043-8EF1-5F0938FC9715.root",
-    				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280002/77E53E14-7349-7C4D-926E-0F7151278A53.root",
-    				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280002/5425331D-22AC-AC4D-A057-F031396B712B.root",
-    			     	        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/F05C07EA-AFA7-184C-8E88-7D1D0B6754FA.root",
-    				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/B559B4C1-A0EE-3444-B54E-0B6BD74E9C81.root",
-    				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/8DCD5AED-9053-0649-AF55-6FC644C84A26.root",
-    				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/232BDB85-A055-0641-BF22-28FF482621F5.root",
-    				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/76328DC5-3778-5E4B-BEC1-B1FCD8305D3C.root",
-    				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280001/A26F1C97-DF47-0248-8176-5EA46DC7083F.root",
-    				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/9831870B-57EF-4745-A70A-488A5E2D16FD.root",
-    			  	        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/BC20D7BE-13C7-CD46-9748-09D79AEED760.root",
-    				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/EE51D346-A691-8744-8541-9B028E4BE5C0.root",
-    				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280002/001B8CC6-BBE5-174A-9D83-4126F609020F.root",
-    				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/9393F683-B456-414C-9494-A54BB8E60963.root",
-    				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/F3D0305D-CBB9-4946-8B86-CD0E97B947DC.root",
-    				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/4091B173-B4B9-6648-8474-B10500EB15F4.root",
-    				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/03F44D76-2079-C34C-8E5B-5214B22FE2DC.root",
-    				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280002/4688663E-2C2A-5D43-A0A6-7B1F3FDE7352.root",
-    				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/98DAF8BF-CA7D-1C4D-A6CD-7ACF1441F03D.root",
-    				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/9F86DA7C-1650-214B-A07E-1081DC1A3229.root",
-    			 	        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280002/1D650158-4FD2-7345-9BC5-5995B61D9E95.root",
-    				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/3FEA0EC7-0301-364A-A356-D5223D970579.root",
-    				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/2CB86DCB-22E4-8245-9477-886B8C553D5E.root",
-    				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/F5BBBBCF-2EC7-F54D-8A9C-A557B12F77C1.root")
+				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/80508514-FC4F-5E48-84BD-A84EF28EEAE3.root",
+				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/86DB491C-55E8-9C45-A748-632065719E7B.root",
+				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/7D9F8691-6521-5247-88A8-97A9FD11EBB6.root",
+				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280002/2185F94D-CE60-4541-A174-281FEC1217F6.root",
+				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/5196D8AE-F413-4344-B14D-40CEB7B57736.root",
+				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/478C4A87-9779-4043-8EF1-5F0938FC9715.root",
+				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280002/77E53E14-7349-7C4D-926E-0F7151278A53.root",
+				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280002/5425331D-22AC-AC4D-A057-F031396B712B.root",
+				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/F05C07EA-AFA7-184C-8E88-7D1D0B6754FA.root",
+				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/B559B4C1-A0EE-3444-B54E-0B6BD74E9C81.root",
+				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/8DCD5AED-9053-0649-AF55-6FC644C84A26.root",
+				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/232BDB85-A055-0641-BF22-28FF482621F5.root",
+				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/76328DC5-3778-5E4B-BEC1-B1FCD8305D3C.root",
+				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280001/A26F1C97-DF47-0248-8176-5EA46DC7083F.root",
+				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/9831870B-57EF-4745-A70A-488A5E2D16FD.root",
+				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/BC20D7BE-13C7-CD46-9748-09D79AEED760.root",
+				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/EE51D346-A691-8744-8541-9B028E4BE5C0.root",
+				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280002/001B8CC6-BBE5-174A-9D83-4126F609020F.root",
+				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/9393F683-B456-414C-9494-A54BB8E60963.root",
+				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/F3D0305D-CBB9-4946-8B86-CD0E97B947DC.root",
+				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/4091B173-B4B9-6648-8474-B10500EB15F4.root",
+				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/03F44D76-2079-C34C-8E5B-5214B22FE2DC.root",
+				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280002/4688663E-2C2A-5D43-A0A6-7B1F3FDE7352.root",
+				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/98DAF8BF-CA7D-1C4D-A6CD-7ACF1441F03D.root",
+				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/9F86DA7C-1650-214B-A07E-1081DC1A3229.root",
+				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280002/1D650158-4FD2-7345-9BC5-5995B61D9E95.root",
+				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/3FEA0EC7-0301-364A-A356-D5223D970579.root",
+				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/2CB86DCB-22E4-8245-9477-886B8C553D5E.root",
+				        "file:/eos/cms/store/data/Run2018D/ZeroBias/ALCARECO/SiStripCalMinBias-12Nov2019_UL2018-v3/280000/F5BBBBCF-2EC7-F54D-8A9C-A557B12F77C1.root")
 
 
 process.source = cms.Source("PoolSource", fileNames=fileNames)
@@ -102,7 +102,7 @@ process.anResol.combinatorialTracks = cms.InputTag("refitTracks")
 process.anResol.trajectories = cms.InputTag("refitTracks")
 
 process.TFileService = cms.Service("TFileService",
-        fileName = cms.string(OutputRootFile)  
+	fileName = cms.string(OutputRootFile)
 )
 
 process.allPath = cms.Path(process.MeasurementTrackerEvent*process.offlineBeamSpot*process.refitTracks*process.hitresol)

--- a/Calibration/EcalAlCaRecoProducers/test/nPU_mc.py
+++ b/Calibration/EcalAlCaRecoProducers/test/nPU_mc.py
@@ -7,7 +7,7 @@ from PhysicsTools.PythonAnalysis import *
 
 #print_options.set_float_precision(4)
 gSystem.Load("libFWCoreFWLite.so")
-FWLiteEnabler::enable()
+ROOT.FWLiteEnabler.enable()
 
 #import EcalDetId
 #from DataFormats.EcalDetId import *
@@ -1452,7 +1452,7 @@ file=[
 ]
 
 events = Events (file)
-print file
+print(file)
 handlePupInfo = Handle('std::vector< PileupSummaryInfo >')
 puTAG = 'addPileupInfo'
 
@@ -1476,7 +1476,7 @@ for event in events:
 #        continue
     event_counter+=1
     event.getByLabel(puTAG, handlePupInfo)
-    #    print file_format, file, electronTAG        
+    #    print(file_format, file, electronTAG)
     PupInfo = handlePupInfo.product()
     #std::vector<PileupSummaryInfo>::const_iterator PVI;
     for PVI in PupInfo:
@@ -1487,7 +1487,7 @@ for event in events:
 
 obsPU.SaveAs('mcPU_obs.root')
 truePU.SaveAs('mcPU_true.root')
-print event_counter
+print(event_counter)
 
 
 

--- a/Calibration/EcalAlCaRecoProducers/test/reRecoValidation.py
+++ b/Calibration/EcalAlCaRecoProducers/test/reRecoValidation.py
@@ -7,7 +7,7 @@ from PhysicsTools.PythonAnalysis import *
 
 #print_options.set_float_precision(4)
 gSystem.Load("libFWCoreFWLite.so")
-FWLiteEnabler::enable()
+ROOT.FWLiteEnabler.enable()
 
 #import EcalDetId
 #from DataFormats.EcalDetId import *
@@ -52,22 +52,22 @@ event_counter=0
 
 for arg in sys.argv:
     if(arg=='AOD'):
-        print "AOD"
+        print("AOD")
         file="/tmp/"+os.environ["USER"]+"/rereco30Nov-AOD.root"
         file_format="AOD"
         break
     elif(arg=='AlcaFromAOD'):
-        print "AlcaFromAOD"
+        print("AlcaFromAOD")
         file="/tmp/"+os.environ["USER"]+"/AlcarecoFromAOD.root"
         file_format="AlcaFromAOD"
         break
     elif(arg=='AlcaFromAOD-recalib'):
-        print "AlcaFromAOD-recalib"
+        print("AlcaFromAOD-recalib")
         file="/tmp/"+os.environ["USER"]+"/AlcarecoFromAOD-recalib.root"
         file_format="AlcaFromAOD_Recalib"
         break
     elif(arg=='sandbox'):
-        print 'sandbox'
+        print('sandbox')
         #        file="/tmp/"+os.environ["USER"]+"/sandbox.root"
         #        file="/tmp/"+os.environ["USER"]+"/alcaRecoSkim-2.root"
         file="./scratch/sandbox.root"
@@ -76,7 +76,7 @@ for arg in sys.argv:
 #sandbox"
         break
     elif(arg=='sandboxRereco'):
-        print 'sandbox recalib'
+        print('sandbox recalib')
 
         
         #file="/tmp/"+os.environ["USER"]+"/SANDBOX/sandboxRereco.root"
@@ -85,18 +85,18 @@ for arg in sys.argv:
         file_format="sandboxRecalib"
         break
     elif(arg=='RECO'):
-        print 'RECO'
+        print('RECO')
         file="root://eoscms//eos/cms/store/data/Run2012A/DoubleElectron/RECO/PromptReco-v1/000/193/336/BC442450-7997-E111-8177-003048D3C90E.root"
         #        file="/tmp/"+os.environ["USER"]+"/SANDBOX/RAW-RECO.root"
         file_format="RECO"
         break
     elif(arg=='MC'):
-        print 'MC'
+        print('MC')
         file="/tmp/"+os.environ["USER"]+"/MC-AODSIM.root"
         file_format="AOD"
         break
     elif(arg=='ALCARECO'):
-        print 'ALCARECO'
+        print('ALCARECO')
         file="alcaSkimSandbox_numEvent10000.root"
 #        file="alcaSkimSandbox.root"
         file_format="ALCARECO"
@@ -132,7 +132,7 @@ for arg in sys.argv:
 #file='/tmp/shervin/alcaRecoSkim-1.root'
 #file='/tmp/shervin/myAlcaRecoSkim.root'
 
-print file
+print(file)
 events = Events (file)
 
 handleElectrons = Handle('std::vector<reco::GsfElectron>')
@@ -184,18 +184,18 @@ EBrecHitmap_ele2 = TH2F("EBrecHitmap_ele2", "EBrecHitmap_ele2",
                    171,-85,85,
                    360,0,360)
 
-print file_format, file, electronTAG, processName, maxEvents
+print(file_format, file, electronTAG, processName, maxEvents)
 
-print "run    lumi  event     isEB    energy     eSC  rawESC    e5x5    E_ES, etaEle, phiEle, etaSC, phiSC, clustersSize, nRecHits"
+print("run    lumi  event     isEB    energy     eSC  rawESC    e5x5    E_ES, etaEle, phiEle, etaSC, phiSC, clustersSize, nRecHits")
 for event in events:
 
 #    if(event_counter % 100):
-#        print "[STATUS] event ", event_counter
+#        print("[STATUS] event ", event_counter)
         
     if(maxEvents > 0 and event_counter > maxEvents):
         break
     if(eventListPrint==True):
-        print event.eventAuxiliary().run(), event.eventAuxiliary().luminosityBlock(), event.eventAuxiliary().event()
+        print(event.eventAuxiliary().run(), event.eventAuxiliary().luminosityBlock(), event.eventAuxiliary().event())
         continue
     #if(event.eventAuxiliary.run()== 145351895):
     if lumi > 0 and int(event.eventAuxiliary().luminosityBlock()) != lumi :
@@ -207,7 +207,7 @@ for event in events:
 
         #    event.getByLabel(electronTAG, "", processName, handleElectrons)
     event.getByLabel(electronTAG, handleElectrons)
-    #    print file_format, file, electronTAG        
+    #    print(file_format, file, electronTAG        )
     electrons = handleElectrons.product()
 
 
@@ -215,7 +215,7 @@ for event in events:
         event.getByLabel("reducedEcalRecHitsEB", "", processName, handleRecHitsEB)
         event.getByLabel("reducedEcalRecHitsEE", "", processName, handleRecHitsEE)
         event.getByLabel("reducedEcalRecHitsES", "", processName, handleRecHitsES)
-#        print "##############", 
+#        print("##############", )
         #        rhoTAG=edm.InputTag()
         #        rhoTAG=("kt6PFJets","rho","RECO")
 #        event.getByLabel("kt6PFJets","rho","RECO",handleRhoFastJet)
@@ -237,12 +237,12 @@ for event in events:
 #    else:
         
     
-#    print "Num of electrons: ",len(electrons)
+#    print("Num of electrons: ",len(electrons))
     if(len(electrons)>=2):
      ele_counter=0
      for electron in electrons:
         if(not electron.ecalDrivenSeed()): 
-            print "trackerDriven",
+            print("trackerDriven",)
 #            sys.exit(0)
         electron.superCluster().energy()
 
@@ -252,8 +252,8 @@ for event in events:
         #            for ESrecHit in ESrecHits:
         #                if(eventNumber >0):
         #                    esrecHit = ESDetId(ESrecHit.id().rawId())
-        #                    print ESrecHit.id()(), esrecHit.strip(), esrecHit.six(), esrecHit.siy(), esrecHit.plane()
-        print "------------------------------"
+        #                    print(ESrecHit.id()(), esrecHit.strip(), esrecHit.six(), esrecHit.siy(), esrecHit.plane())
+        print("------------------------------")
         if(not file_format=="sandbox"):
          if(electron.isEB()):
              recHits = handleRecHitsEB.product()
@@ -271,7 +271,7 @@ for event in events:
                          elif(ele_counter==1):
                              EBrecHitmap_ele2.Fill(EBrecHit.ieta(), EBrecHit.iphi(), recHit.energy());
                          
-                     print recHit.id()(), EBrecHit.ieta(), EBrecHit.iphi(), recHit.energy(), recHit.checkFlag(0)
+                     print(recHit.id()(), EBrecHit.ieta(), EBrecHit.iphi(), recHit.energy(), recHit.checkFlag(0))
                  else:
                      EErecHit = EEDetId(recHit.id().rawId())
                      if(allRecHits):
@@ -279,7 +279,7 @@ for event in events:
                              EErecHitmap_ele1.Fill(EErecHit.ix(), EErecHit.iy(), recHit.energy());
                          elif(ele_counter==1):
                              EErecHitmap_ele2.Fill(EErecHit.ix(), EErecHit.iy(), recHit.energy());
-                     print recHit.id()(), EErecHit.ix(), EErecHit.iy(), recHit.energy()
+                     print(recHit.id()(), EErecHit.ix(), EErecHit.iy(), recHit.energy())
  
          hits = electron.superCluster().hitsAndFractions() 
          nRecHitsSC=0
@@ -293,7 +293,7 @@ for event in events:
                              EBrecHitmap_ele1.Fill(EBrecHit.ieta(), EBrecHit.iphi(), hit.second*electron.superCluster().energy());
                          elif(ele_counter==1):
                              EBrecHitmap_ele2.Fill(EBrecHit.ieta(), EBrecHit.iphi(), hit.second*electron.superCluster().energy());
-                     print "SC", (hit.first).rawId(), (hit.first)(), EBrecHit.ieta(), EBrecHit.iphi(),  EBrecHit.tower().iTT(), EBrecHit.ism(), EBrecHit.im()
+                     print("SC", (hit.first).rawId(), (hit.first)(), EBrecHit.ieta(), EBrecHit.iphi(),  EBrecHit.tower().iTT(), EBrecHit.ism(), EBrecHit.im())
                  else:
                      EErecHit = EEDetId(hit.first.rawId())
                      if(not allRecHits):
@@ -302,19 +302,19 @@ for event in events:
                          elif(ele_counter==1):
                              EErecHitmap_ele2.Fill(EErecHit.ix(), EErecHit.iy(), recHit.energy());
  
- #                print "SC ", (hit.first)()
+ #                print("SC ", (hit.first)())
             
-        print event.eventAuxiliary().run(), event.eventAuxiliary().luminosityBlock(), event.eventAuxiliary().event(),
-        print "isEB=",electron.isEB(),
-        print '{0:7.3f} {1:7.3f} {2:7.3f} {3:7.3f} {4:7.3f}'.format(electron.energy(), electron.superCluster().energy(), electron.superCluster().rawEnergy(), electron.e5x5(), electron.superCluster().preshowerEnergy()),
-        print '{0:6.3f} {1:6.3f} {2:6.3f} {3:6.3f}'.format(electron.eta(), electron.phi(), electron.superCluster().eta(), electron.superCluster().phi()),
-        print electron.superCluster().clustersSize(), nRecHits, nRecHitsSC
+        print(event.eventAuxiliary().run(), event.eventAuxiliary().luminosityBlock(), event.eventAuxiliary().event(),)
+        print("isEB=",electron.isEB(),)
+        print('{0:7.3f} {1:7.3f} {2:7.3f} {3:7.3f} {4:7.3f}'.format(electron.energy(), electron.superCluster().energy(), electron.superCluster().rawEnergy(), electron.e5x5(), electron.superCluster().preshowerEnergy()),)
+        print('{0:6.3f} {1:6.3f} {2:6.3f} {3:6.3f}'.format(electron.eta(), electron.phi(), electron.superCluster().eta(), electron.superCluster().phi()),)
+        print(electron.superCluster().clustersSize(), nRecHits, nRecHitsSC)
         ele_counter+=1
         
         
     event_counter+=1
 
-print event_counter
+print(event_counter)
 
 # setting maps to -999
 gStyle.SetPaintTextFormat("1.1f")

--- a/Calibration/EcalAlCaRecoProducers/test/recHitsValidation.py
+++ b/Calibration/EcalAlCaRecoProducers/test/recHitsValidation.py
@@ -7,7 +7,7 @@ from PhysicsTools.PythonAnalysis import *
 
 #print_options.set_float_precision(4)
 gSystem.Load("libFWCoreFWLite.so")
-FWLiteEnabler::enable()
+ROOT.FWLiteEnabler.enable()
 
 #import EcalDetId
 #from DataFormats.EcalDetId import *
@@ -77,42 +77,42 @@ event_counter=0
 
 for arg in sys.argv:
     if (arg=='testAlca1'):
-        print "testAlca1"
+        print("testAlca1")
         file="/tmp/"+os.environ["USER"]+"/testAlca1.root"
         file_format = "AlcaFromAOD"
         break
     elif(arg=='testAlca2'):
-        print 'testAlca2'
+        print('testAlca2')
         file="/tmp/"+os.environ["USER"]+"/testAlca2.root"
         file_format = "AlcaFromAOD_Recalib"
         break
     elif(arg=='testAlca3'):
-        print 'testAlca3'
+        print('testAlca3')
         file="/tmp/"+os.environ["USER"]+"/testAlca3.root"
         file_format = "AlcaFromAOD_Recalib"
         break
     elif(arg=='testAlca4'):
-        print 'testAlca4'
+        print('testAlca4')
         file="/tmp/"+os.environ["USER"]+"/testAlca4.root"
         file_format = "AlcaFromAOD_Recalib"
         break
     elif(arg=='AOD'):
-        print "AOD"
+        print("AOD")
         file="/tmp/"+os.environ["USER"]+"/rereco30Nov-AOD.root"
         file_format="AOD"
         break
     elif(arg=='AlcaFromAOD'):
-        print "AlcaFromAOD"
+        print("AlcaFromAOD")
         file="/tmp/"+os.environ["USER"]+"/AlcarecoFromAOD.root"
         file_format="AlcaFromAOD"
         break
     elif(arg=='AlcaFromAOD-recalib'):
-        print "AlcaFromAOD-recalib"
+        print("AlcaFromAOD-recalib")
         file="/tmp/"+os.environ["USER"]+"/AlcarecoFromAOD-recalib.root"
         file_format="AlcaFromAOD_Recalib"
         break
     elif(arg=='sandbox'):
-        print 'sandbox'
+        print('sandbox')
         #        file="/tmp/"+os.environ["USER"]+"/sandbox.root"
         #        file="/tmp/"+os.environ["USER"]+"/alcaRecoSkim-2.root"
         file="/tmp/"+os.environ["USER"]+"/alcaSkimSandbox.root"
@@ -121,7 +121,7 @@ for arg in sys.argv:
 #sandbox"
         break
     elif(arg=='sandboxRecalib'):
-        print 'sandbox recalib'
+        print('sandbox recalib')
 #        file="/tmp/"+os.environ["USER"]+"/Test-RecalibSandbox-GT_IC_LC.root"
 #        file="/tmp/"+os.environ["USER"]+"/SandboxReReco-noADCtoGeV.root"
         file="/tmp/"+os.environ["USER"]+"/SandboxReReco.root"
@@ -132,7 +132,7 @@ for arg in sys.argv:
         
         break
     elif(arg=='RECO'):
-        print 'RECO'
+        print('RECO')
         file="/tmp/"+os.environ["USER"]+"/SANDBOX/RAW-RECO.root"
         file_format="RECO"
         break
@@ -143,7 +143,7 @@ for arg in sys.argv:
 
 
 events = Events (file)
-print file
+print(file)
 handleElectrons = Handle('std::vector<reco::GsfElectron>')
 handleRecHitsEB = Handle('edm::SortedCollection<EcalRecHit,edm::StrictWeakOrdering<EcalRecHit> >')
 handleRecHitsEE = Handle('edm::SortedCollection<EcalRecHit,edm::StrictWeakOrdering<EcalRecHit> >')
@@ -198,9 +198,9 @@ EBrecHitmap_ele2 = TH2F("EBrecHitmap_ele2", "EBrecHitmap_ele2",
                    171,-85,85,
                    360,0,360)
 
-print file_format, file, electronTAG, processName, maxEvents
+print(file_format, file, electronTAG, processName, maxEvents)
 
-print "run\tlumi, event, energy, eSC, rawESC, e5x5, E_ES, etaEle, phiEle, etaSC, phiSC, clustersSize, nRecHits"
+print("run\tlumi, event, energy, eSC, rawESC, e5x5, E_ES, etaEle, phiEle, etaSC, phiSC, clustersSize, nRecHits")
 for event in events:
 
     if(maxEvents > 0 and event_counter > maxEvents):
@@ -214,7 +214,7 @@ for event in events:
 
         #    event.getByLabel(electronTAG, "", processName, handleElectrons)
     event.getByLabel(electronTAG, handleElectrons)
-    #    print file_format, file, electronTAG        
+    #    print(file_format, file, electronTAG        )
     electrons = handleElectrons.product()
 
     #    event.getByLabel("reducedEcalRecHitsEB", "", processName, handleRecHitsEB)
@@ -242,19 +242,19 @@ for event in events:
            for recHit in recHits_RECO:
                nRecHits_RECO=nRecHits_RECO+1
 #                if(recHit.checkFlag(EcalRecHit.kTowerRecovered)):
-#                   print recHit.id().rawId()
+#                   print(recHit.id().rawId())
        
            nRecHits_ALCASKIM=0
            for recHit in recHits_ALCASKIM:
                nRecHits_ALCASKIM=nRecHits_ALCASKIM+1
                #               if(recHit.checkFlag(EcalRecHit.kTowerRecovered)):
-               print recHit.id().rawId(), recHit.checkFlag(EcalRecHit.kTowerRecovered)
+               print(recHit.id().rawId(), recHit.checkFlag(EcalRecHit.kTowerRecovered))
                
            if(nRecHits_ALCASKIM != nRecHits_RECO):
-               print nRecHits_RECO, nRecHits_ALCASKIM
-               print recHits_RECO
-               print "------------------------------"
-               print recHits_ALCASKIM
+               print(nRecHits_RECO, nRecHits_ALCASKIM)
+               print(recHits_RECO)
+               print("------------------------------")
+               print(recHits_ALCASKIM)
     else:
        for electron in electrons:
            if(abs(electron.eta()) < 1.4442):
@@ -266,9 +266,9 @@ for event in events:
            for recHit in recHits_ALCARECO:
                nRecHits_ALCARECO=nRecHits_ALCARECO+1
                #               if(recHit.checkFlag(EcalRecHit.kTowerRecovered)):
-               print recHit.id().rawId(), recHit.checkFlag(EcalRecHit.kTowerRecovered)
+               print(recHit.id().rawId(), recHit.checkFlag(EcalRecHit.kTowerRecovered))
                
-print event_counter
+print(event_counter)
 
 
 

--- a/Calibration/LumiAlCaRecoProducers/test/PCC_Random_Event_cfg.py
+++ b/Calibration/LumiAlCaRecoProducers/test/PCC_Random_Event_cfg.py
@@ -109,11 +109,10 @@ process.pathALCARECOLumiPixels = cms.Path(process.seqALCARECOLumiPixels)
 process.ALCARECOStreamPromptCalibProdOutPath = cms.EndPath(process.ALCARECOStreamPromptCalibProdPCC)
 
 process.MessageLogger = cms.Service("MessageLogger",
-        default = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        optionalPSet = cms.untracked.bool(True)
+    default = cms.untracked.PSet(
+        limit = cms.untracked.int32(0)
     ),
+    optionalPSet = cms.untracked.bool(True),
     categories = cms.untracked.vstring('FwkJob', 
         'FwkReport', 
         'FwkSummary', 
@@ -159,9 +158,9 @@ process.MessageLogger = cms.Service("MessageLogger",
     debugs = cms.untracked.PSet(
         placeholder = cms.untracked.bool(True)
     ),
-    default = cms.untracked.PSet(
-
-    ),
+#    default = cms.untracked.PSet(
+#
+#    ),
     destinations = cms.untracked.vstring('warnings', 
         'errors', 
         'infos', 

--- a/MuonAnalysis/MomentumScaleCalibration/test/Macros/RunAllChecks.py
+++ b/MuonAnalysis/MomentumScaleCalibration/test/Macros/RunAllChecks.py
@@ -13,7 +13,7 @@ def arguments(comp, resType = "Z", firstFile = "0", secondFile = "1") :
     elif( comp == "PhiMinus" ) :
         name = "phiMinus"
     else :
-        print "Error"
+        print("Error")
         return ""
     if( resType == "Z" ) :
         fitType = "2"
@@ -33,7 +33,7 @@ massProbablityName = "Z"
 macrosDir = os.popen("echo $CMSSW_BASE", "r").read().strip()
 macrosDir += "/src/MuonAnalysis/MomentumScaleCalibration/test/Macros/"
 
-print macrosDir+"Run.C"
+print(macrosDir+"Run.C")
 
 # Mass vs pt, eta, phi
 # --------------------

--- a/MuonAnalysis/MomentumScaleCalibration/test/Macros/TreeProduction/MakeTrees.py
+++ b/MuonAnalysis/MomentumScaleCalibration/test/Macros/TreeProduction/MakeTrees.py
@@ -48,7 +48,7 @@ class ThreadUrl(threading.Thread):
       inputFileName = data[0].split()[-1]
       num = str(data[1])
       outputFileName = data[3]
-      print "input file name = ", inputFileName, " output file name = ", outputFileName
+      print("input file name = ", inputFileName, " output file name = ", outputFileName)
       templateCfg = open("MuScleFit_template_cfg.py").read()
       templateCfg = templateCfg.replace("INPUTFILENAME", "rfio:"+filesDir+inputFileName).replace("OUTPUTTREENAME", outputFileName)
       cfgName = "MuScleFitTree_cfg_"+num+".py"
@@ -57,7 +57,7 @@ class ThreadUrl(threading.Thread):
       cfg.close()
 
       # Run the cmssw job
-      print "cd "+CMSSWDir+"; eval `scramv1 r -sh`; cd -; cmsRun "+cfgName
+      print("cd "+CMSSWDir+"; eval `scramv1 r -sh`; cd -; cmsRun "+cfgName)
       os.system("cd "+CMSSWDir+"; eval `scramv1 r -sh`; cd -; cmsRun "+cfgName)
       os.system("mv "+cfgName+" processedCfgs")
 
@@ -111,4 +111,4 @@ def main(numberOfThreads):
 # Run the jobs withTotalNumberOfThreads threads
 start = time.time()
 main(TotalNumberOfThreads)
-print "Elapsed Time: %s" % (time.time() - start)
+print("Elapsed Time: %s" % (time.time() - start))

--- a/MuonAnalysis/MomentumScaleCalibration/test/MuScleFitGenFilter_cfg.py
+++ b/MuonAnalysis/MomentumScaleCalibration/test/MuScleFitGenFilter_cfg.py
@@ -212,7 +212,7 @@ process.looper = cms.Looper(
 
 
     # Only used when reading events from a root tree
-    MaxEventsFromRootTree = cms.int32(-1)
+    MaxEventsFromRootTree = cms.int32(-1),
 
     # Specify a file if you want to read events from a root tree in a local file.
     # In this case the input source should be an empty source with 0 events.

--- a/MuonAnalysis/MomentumScaleCalibration/test/PrepareErrors.py
+++ b/MuonAnalysis/MomentumScaleCalibration/test/PrepareErrors.py
@@ -47,8 +47,8 @@ for i in range(len(value)):
     errorParameters += prepend+"1"
     prepend = ", "
 
-print "values = ", values
-print "errors = ", errors
+print("values = ", values)
+print("errors = ", errors)
     
 cfgFile = open("ErrorsPropagationAnalyzer_cfg.py", 'r')
 outputCfgFile = open("Errors_cfg.py", 'w')
@@ -63,4 +63,4 @@ for line in cfgFile:
         outputCfgFile.write(line.replace("ErrorFactors = cms.vint32(),", "ErrorFactors = cms.vint32("+errorParameters+"),"))
     else:
         outputCfgFile.write( line )
-    # print line
+    # print(line)

--- a/MuonAnalysis/MomentumScaleCalibration/test/PrepareParameters.py
+++ b/MuonAnalysis/MomentumScaleCalibration/test/PrepareParameters.py
@@ -38,7 +38,7 @@ for i in range(len(value)):
     errorParameters += prepend+"1"
     prepend = ", "
 
-print values
+print(values)
     
 cfgFile = open("template_MuScleFit_cfg.py", 'r')
 outputCfgFile = open("MuScleFit_cfg.py", 'w')
@@ -49,4 +49,4 @@ for line in cfgFile:
         outputCfgFile.write(line.replace("parResol = cms.vdouble(),","parResol = cms.vdouble("+values+"),"))
     else:
         outputCfgFile.write( line )
-    # print line
+    # print(line)


### PR DESCRIPTION
#### PR description:

Fix syntax in python scripts:

* Switch to python 3 syntax: `print()`, `except ... as`
* Partial fix for indentation: make all indented line use the same characters for indentation (either spaces or tabs), remove mixing of tabs and spaces
* Add missing braces and commas, fix invalid syntax (`FWLiteEnabler::enable()` should be `ROOT.FWLiteEnabler.enable()`), remove trailing semicolons

This is a preparation for fixing https://github.com/cms-sw/cmssw/issues/46113 . Maybe some of these scripts are not needed anymore and can be removed?

#### PR validation:

Bot tests. 
