### PR TITLE
[DB] Fix syntax in python scripts

### DIFF
--- a/CondCore/EcalPlugins/test/inspectPed.py
+++ b/CondCore/EcalPlugins/test/inspectPed.py
@@ -1,7 +1,7 @@
 #
 # I should write a decent test of the python binding...
 #
-import sys, DLFCN
+import sys, DLFCN, importlib
 sys.setdlopenflags(DLFCN.RTLD_GLOBAL+DLFCN.RTLD_LAZY)
 
 from pluginCondDBPyInterface import *
@@ -27,13 +27,13 @@ vf = VFloat()
 for tag in tags.split() :
     try :
         log = db.lastLogEntry(tag)
-        print log.getState()
+        print(log.getState())
         iov = inspect.Iov(db,tag)
-        print iov.list()
-#        print iov.summaries()
-#        print iov.trend("",[0,2,12])
+        print(iov.list())
+#        print(iov.summaries())
+#        print(iov.trend("",[0,2,12]))
     except RuntimeError :
-        print " no iov? in", tag
+        print(" no iov? in", tag)
 
 
 iov=0
@@ -50,11 +50,11 @@ for key in what.keys():
 
 
 iov = inspect.Iov(db,tag)
-print iov.trend(ans)
+print(iov.trend(ans))
 ans = {'how': 'all', 'quantity': 'mean_x3', 'which' : []}
-print iov.trend(an)
+print(iov.trend(ans))
 ans = {'how': 'singleChannel', 'quantity': 'mean_x6', 'which' : [0,200,1200]}
-print iov.trend(ans)
+print(iov.trend(ans))
 
 
 
@@ -64,7 +64,7 @@ print iov.trend(ans)
 token = log.payloadToken
 
 p = inspect.PayLoad(db,token)
-print p
+print(p)
 
 p=0
 
@@ -83,21 +83,21 @@ iov.trend("",[0,2,12])
 
 o = iovInspector.PayLoad(db,log.payloadToken)
 
-        exec('import '+db.moduleName(tag)+' as Plug')   
-        iov = db.iov(tag)
-        log = db.lastLogEntry(tag)
-        print tag, iov.size(), log.execmessage, log.exectime, log.payloadIdx 
-        vi = VInt()
-        vi.append(0)
-        vi.append(2)
-        vi.append(12)
-        ex = Plug.Extractor("",vi)
-        for elem in iov.elements :
-            p = Plug.Object(elem)
-            print elem.since(), elem.till(),p.summary()
-            p.extract(ex)
-            for v in ex.values() :
-                print v
+Plug = importlib.import_module(db.moduleName(tag))
+iov = db.iov(tag)
+log = db.lastLogEntry(tag)
+print(tag, iov.size(), log.execmessage, log.exectime, log.payloadIdx )
+vi = VInt()
+vi.append(0)
+vi.append(2)
+vi.append(12)
+ex = Plug.Extractor("",vi)
+for elem in iov.elements :
+    p = Plug.Object(elem)
+    print(elem.since(), elem.till(),p.summary())
+    p.extract(ex)
+    for v in ex.values() :
+        print(v)
 
 
 token = '[DB=00000000-0000-0000-0000-000000000000][CNT=EcalPedestalsRcd][CLID=75E7B995-8233-097B-FD4A-31AEC6A040C8][TECH=00000B01][OID=0000000C-00000114]'

--- a/CondCore/PopCon/test/inspect.py
+++ b/CondCore/PopCon/test/inspect.py
@@ -24,28 +24,28 @@ vf = VFloat()
 for tag in tags.split() :
     try :
         log = db.lastLogEntry(tag)
-        print log.getState()
+        print(log.getState())
         iov = inspect.Iov(db,tag)
-        print iov.list()
-#        print iov.summaries()
-#        print iov.trend("",[0,2,12])
+        print(iov.list())
+#        print(iov.summaries())
+#        print(iov.trend("",[0,2,12]))
     except RuntimeError :
-        print " no iov? in", tag
+        print(" no iov? in", tag)
 
 
 iov=0
 
 tag='Example_tag2'
 what = inspect.extractorWhat(db,tag)
-print what
+print(what)
 
 ans = {'which':[0,2,12],'quantity':[0]}
 iov = inspect.Iov(db,tag)
-print iov.trend(ans)
+print(iov.trend(ans))
 ans = {'which':[0,2,12],'quantity':[1]}
-print iov.trend(ans)
+print(iov.trend(ans))
 ans = {'which':[0,2,12],'quantity':[0,1]}
-print iov.trend(ans)
+print(iov.trend(ans))
 
 
 
@@ -55,7 +55,7 @@ print iov.trend(ans)
 token = log.payloadToken
 
 p = inspect.PayLoad(db,token)
-print p
+print(p)
 
 p=0
 
@@ -74,21 +74,21 @@ iov.trend("",[0,2,12])
 
 o = iovInspector.PayLoad(db,log.payloadToken)
 
-        exec('import '+db.moduleName(tag)+' as Plug')   
-        iov = db.iov(tag)
-        log = db.lastLogEntry(tag)
-        print tag, iov.size(), log.execmessage, log.exectime, log.payloadIdx 
-        vi = VInt()
-        vi.append(0)
-        vi.append(2)
-        vi.append(12)
-        ex = Plug.Extractor("",vi)
-        for elem in iov.elements :
-            p = Plug.Object(elem)
-            print elem.since(), elem.till(),p.summary()
-            p.extract(ex)
-            for v in ex.values() :
-                print v
+exec('import '+db.moduleName(tag)+' as Plug')   
+iov = db.iov(tag)
+log = db.lastLogEntry(tag)
+print(tag, iov.size(), log.execmessage, log.exectime, log.payloadIdx )
+vi = VInt()
+vi.append(0)
+vi.append(2)
+vi.append(12)
+ex = Plug.Extractor("",vi)
+for elem in iov.elements :
+    p = Plug.Object(elem)
+    print(elem.since(), elem.till(),p.summary())
+    p.extract(ex)
+    for v in ex.values() :
+        print(v)
 
 
 token = '[DB=00000000-0000-0000-0000-000000000000][CNT=EcalPedestalsRcd][CLID=75E7B995-8233-097B-FD4A-31AEC6A040C8][TECH=00000B01][OID=0000000C-00000114]'

--- a/CondTools/Geometry/test/hgcalgeometrywriter.py
+++ b/CondTools/Geometry/test/hgcalgeometrywriter.py
@@ -28,8 +28,9 @@ process.HGCalHEParametersWriter = cms.EDAnalyzer("PHGCalParametersDBBuilder",
 process.HGCalHEScParametersWriter = cms.EDAnalyzer("PHGCalParametersDBBuilder",
                                                    Name = cms.untracked.string("HGCalHEScintillatorSensitive"),
                                                    NameW = cms.untracked.string("HGCalWafer"),
-                                                   NameC = cms.untracked.string("HGCalCell")),
-                                                 NameT = cms.untracked.string("HGCal")
+                                                   NameC = cms.untracked.string("HGCalCell"),
+                                                   NameT = cms.untracked.string("HGCal")
+)
 
 process.CondDB.timetype = cms.untracked.string('runnumber')
 process.CondDB.connect = cms.string('sqlite_file:myfile.db')

--- a/CondTools/Hcal/test/dumpHcalDcsMap_cfg.py
+++ b/CondTools/Hcal/test/dumpHcalDcsMap_cfg.py
@@ -43,12 +43,12 @@ process.source = cms.Source("EmptySource",
 )
 
 
-process.es_pool = cms.ESSource("PoolDBESSource",
-     process.CondDBSetup,
-     timetype = cms.string('runnumber'),
-     connect = cms.string('sqlite_file:testExample.db'),
-     authenticationMethod = cms.untracked.uint32(0),
-     toGet = cms.VPSet(
+#process.es_pool = cms.ESSource("PoolDBESSource",
+#     process.CondDBSetup,
+#     timetype = cms.string('runnumber'),
+#     connect = cms.string('sqlite_file:testExample.db'),
+#     authenticationMethod = cms.untracked.uint32(0),
+#     toGet = cms.VPSet(
 #        cms.PSet(
 #            record = cms.string('HcalPedestalsRcd'),
 #            tag = cms.string('hcal_pedestals_fC_v6_mc')

--- a/CondTools/RPC/test/writeRPCEMap2DB.py
+++ b/CondTools/RPC/test/writeRPCEMap2DB.py
@@ -1,4 +1,4 @@
-mport FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("Write2DB")
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/SiPixel/test/SiPixelTemplateDBObjectReader_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelTemplateDBObjectReader_cfg.py
@@ -34,17 +34,17 @@ testGlobalTag = False
 options.parseArguments()
 
 MagFieldValue = 10.*options.MagField #code needs it in deciTesla
-print '\nMagField = %f deciTesla \n'%(MagFieldValue)
+print('\nMagField = %f deciTesla \n'%(MagFieldValue))
 version = options.Version
-print'\nVersion = %s \n'%(version)
+print('\nVersion = %s \n'%(version))
 magfieldstrsplit = str(options.MagField).split('.')
 MagFieldString = magfieldstrsplit[0]
 if len(magfieldstrsplit)>1 :
 	MagFieldString+=magfieldstrsplit[1]
 
 template_base = 'SiPixelTemplateDBObject_'+MagFieldString+'T_'+options.Year+'_v'+version
-print "Testing sqlite file: "+template_base+".db"
-print "                tag: "+template_base
+print("Testing sqlite file: "+template_base+".db")
+print("                tag: "+template_base)
 
 
 from Configuration.StandardSequences.Eras import eras


### PR DESCRIPTION
#### PR description:

Fix syntax in python scripts:

* Switch to python 3 syntax: `print()`, `except ... as`
* Partial fix for indentation: make all indented line use the same characters for indentation (either spaces or tabs), remove mixing of tabs and spaces
* Add missing braces and commas, fix invalid syntax (`FWLiteEnabler::enable()` should be `ROOT.FWLiteEnabler.enable()`), remove trailing semicolons
* Replaced (potentially unsafe) `exec` with `import_module`

This is a preparation for fixing #46113 . Maybe some of these scripts are not needed anymore and can be removed?

#### PR validation:

Bot tests.