### PR TITLE
[SIMULATION] Fix syntax in python scripts

### DIFF
--- a/SimCalorimetry/HcalSimAlgos/test/HcalDigitizerTest_cfg.py
+++ b/SimCalorimetry/HcalSimAlgos/test/HcalDigitizerTest_cfg.py
@@ -17,7 +17,7 @@ process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
 )
 
-process.hcalDigitizerTest = cms.EDAnalyzer("HcalDigitizerTest".,
+process.hcalDigitizerTest = cms.EDAnalyzer("HcalDigitizerTest",
     useHBUpgrade = ref_hardcode.useHBUpgrade,
     useHEUpgrade = ref_hardcode.useHEUpgrade,
     useHFUpgrade = ref_hardcode.useHFUpgrade,

--- a/SimG4CMS/Calo/test/python/minbias2026_cfg.py
+++ b/SimG4CMS/Calo/test/python/minbias2026_cfg.py
@@ -31,7 +31,7 @@ if (options.type == "V18"):
 elif (options.type == "V17Shift"):
     geomFile = "Geometry.HGCalCommonData.testHGCal" + options.type + "Reco_cff"
 elif (options.type == "V17"):
-    geomFile = "Configuration.Geometry.GeometryExtended2026D110Reco_cffelse:
+    geomFile = "Configuration.Geometry.GeometryExtended2026D110Reco_cff"
 else:
     geomFile = "Configuration.Geometry.GeometryExtended2026D100Reco_cff"
 

--- a/SimG4CMS/HcalTestBeam/test/python/run_tb06_all_cfg.py
+++ b/SimG4CMS/HcalTestBeam/test/python/run_tb06_all_cfg.py
@@ -8,13 +8,13 @@ import os, sys
 VERSION = os.environ.get('CMSSW_VERSION')
 if VERSION is None:
 	print('''No environment CMSSW_VERSION''')
-        sys.exit()
+	sys.exit()
 
 if len(sys.argv) < 5:
 	print('Usage: python run.py PhysList Particle Fhcal VAR')
 	print('Example: python run.py FTFP_BERT pi- 106.5 RR')
 	sys.exit()
-else:	
+else:
 	phys = sys.argv[1]
 	part = sys.argv[2]
 	hcal = sys.argv[3]

--- a/SimGeneral/HepPDTESSource/test/ParticleCheck.py
+++ b/SimGeneral/HepPDTESSource/test/ParticleCheck.py
@@ -121,10 +121,10 @@ for record in G4msg:
                 decaytable=False
                 ParticleInfoDict.update({'G4 Decay Table':decaytable})
         elif record[0:5]=='%MSG ': #Notice the space
-            #print 'G4 message ended'
+            #print('G4 message ended')
             G4cout=False
     if record[0:13]=='%MSG-i G4cout':
-        #print 'G4 message started'
+        #print('G4 message started')
         G4cout=True 
 import os
 import math
@@ -135,7 +135,7 @@ for record in open(os.environ.data['CMSSW_RELEASE_BASE']+'/src/SimGeneral/HepPDT
         pass
     else:
         tokens = record.split()
-        #print tokens
+        #print(tokens)
         if len(tokens)==6: #There is an empty line at the end of the file
             #Note the different conventions (Particle names are different, charge is reported in units of 1/3e originally in HepPDT, lifetime expressed in ctau in cm)
             HepPdtTable.update({tokens[1]:{'Particle Name':tokens[1],'PDG ID':int(tokens[0]),'Charge [e]': float(tokens[2])/3, 'Mass [GeV/c2]':float(tokens[3]), 'ctau [mm]':float(tokens[5])}})
@@ -144,31 +144,31 @@ for record in open(os.environ.data['CMSSW_RELEASE_BASE']+'/src/SimGeneral/HepPDT
 #A few consistency checks on the dictionaries
 #G4ParticleTables
 #Quick and dirty removal of empty first element of G4ParticleTable ('':{}) should really fix the code, but for now it's OK...
-print 'Popping the first empty element of G4ParticleTable: %s '%G4ParticleTable.pop('')
-print 'G4ParticleTable contains ',len(G4ParticleTable),'elements'
-print 'G4ParticleTablePDG contains ',len(G4ParticleTablePDG),'elements'
+print('Popping the first empty element of G4ParticleTable: %s '%G4ParticleTable.pop(''))
+print('G4ParticleTable contains ',len(G4ParticleTable),'elements')
+print('G4ParticleTablePDG contains ',len(G4ParticleTablePDG),'elements')
 if len(G4ParticleTable)>len(G4ParticleTablePDG):
-    print "The following values were in the G4ParticleTable dictionary but not in the G4ParticleTablePDG one (multiple entries with different names but the same PDG code):"
+    print("The following values were in the G4ParticleTable dictionary but not in the G4ParticleTablePDG one (multiple entries with different names but the same PDG code):")
     for value in G4ParticleTable.values():
         if value not in G4ParticleTablePDG.values():
-            print value
+            print(value)
 elif len(G4ParticleTablePDG)>len(G4ParticleTable):
-    print "The following values were in the G4ParticleTablePDG dictionary but not in the G4ParticleTable one (multiple entries with different PDG codes but the same Particle Name):"
+    print("The following values were in the G4ParticleTablePDG dictionary but not in the G4ParticleTable one (multiple entries with different PDG codes but the same Particle Name):")
     for value in G4ParticleTablePDG.values():
         if value not in G4ParticleTable.values():
-            print value
-print 'HepPdtTable contains ',len(HepPdtTable),'elements'
-print 'HepPdtTablePDG contains ',len(HepPdtTablePDG),'elements'
+            print(value)
+print('HepPdtTable contains ',len(HepPdtTable),'elements')
+print('HepPdtTablePDG contains ',len(HepPdtTablePDG),'elements')
 if len(HepPdtTable)>len(HepPdtTablePDG):
-    print "The following values were in the HepPdtTable dictionary but not in the HepPdtTablePDG one (multiple entries with different names but the same PDG code):"
+    print("The following values were in the HepPdtTable dictionary but not in the HepPdtTablePDG one (multiple entries with different names but the same PDG code):")
     for value in HepPdtTable.values():
         if value not in HepPdtTablePDG.values():
-            print value
+            print(value)
 elif len(HepPdtTablePDG)>len(HepPdtTable):
-    print "The following values were in the HepPdtTablePDG dictionary but not in the HepPdtTable one (multiple entries with different PDG codes but the same Particle Name):"
+    print("The following values were in the HepPdtTablePDG dictionary but not in the HepPdtTable one (multiple entries with different PDG codes but the same Particle Name):")
     for value in HepPdtTablePDG.values():
         if value not in HepPdtTable.values():
-            print value
+            print(value)
 
 #Comparison via dictionaries!
         
@@ -209,7 +209,7 @@ for pdgcode in HepPdtTablePDG.keys():
         #Check that G4 has decay tables for particles with ctau>10 mm:
         if G4ParticleTablePDG[pdgcode]['ctau [mm]']>10.0 or HepPdtTablePDG[pdgcode]['ctau [mm]']>10.0:
             if not G4ParticleTablePDG[pdgcode]['G4 Decay Table']:
-                print "****Uh Oh No G4 Decay Table for ", G4ParticleTablePDG[pdgcode]['Particle Name']
+                print("****Uh Oh No G4 Decay Table for ", G4ParticleTablePDG[pdgcode]['Particle Name'])
             else:
                 WriteOutHtml(MatchingPDGDecayFileHtml,[pdgcode,HepPdtTablePDG[pdgcode]['Particle Name'],G4ParticleTablePDG[pdgcode]['Particle Name'],HepPdtTablePDG[pdgcode]['ctau [mm]'],G4ParticleTablePDG[pdgcode]['ctau [mm]'],HepPdtTablePDG[pdgcode]['Mass [GeV/c2]'],G4ParticleTablePDG[pdgcode]['Mass [GeV/c2]'],G4ParticleTablePDG[pdgcode]['G4 Decay Table']])
         #Since we are here also compare ctaus
@@ -234,14 +234,14 @@ for pdgcode in HepPdtTablePDG.keys():
             MassDiff=HepPdtTablePDG[pdgcode]['Mass [GeV/c2]']-G4ParticleTablePDG[pdgcode]['Mass [GeV/c2]']
             MassDiffPercent=math.fabs(MassDiff/HepPdtTablePDG[pdgcode]['Mass [GeV/c2]']*100)
             MassDiffPercentList+=[(abs(MassDiffPercent),pdgcode,MassDiff,MassDiffPercent)]
-            print pdgcode,HepPdtTablePDG[pdgcode]['Particle Name'],G4ParticleTablePDG[pdgcode]['Particle Name'],' Mass:',HepPdtTablePDG[pdgcode]['Mass [GeV/c2]'],' Mass:',G4ParticleTablePDG[pdgcode]['Mass [GeV/c2]'],MassDiff,MassDiffPercent
+            print(pdgcode,HepPdtTablePDG[pdgcode]['Particle Name'],G4ParticleTablePDG[pdgcode]['Particle Name'],' Mass:',HepPdtTablePDG[pdgcode]['Mass [GeV/c2]'],' Mass:',G4ParticleTablePDG[pdgcode]['Mass [GeV/c2]'],MassDiff,MassDiffPercent)
             #WriteOutHtml(MatchingPDGMassFileHtml,[pdgcode,HepPdtTablePDG[pdgcode]['Particle Name'],G4ParticleTablePDG[pdgcode]['Particle Name'],HepPdtTablePDG[pdgcode]['Mass [GeV/c2]'],G4ParticleTablePDG[pdgcode]['Mass [GeV/c2]'],MassDiff,MassDiffPercent])
         else:
             #Save the PDG code and Mass matching particles Particle Name in MatchingPDGMass list
             MatchingPDGMass+=[HepPdtTablePDG[pdgcode]['Particle Name']]
         #Check Charge
         if HepPdtTablePDG[pdgcode]['Charge [e]']!=G4ParticleTablePDG[pdgcode]['Charge [e]']:
-            print pdgcode,HepPdtTablePDG[pdgcode]['Particle Name'],G4ParticleTablePDG[pdgcode]['Particle Name'],' Charge [e]:',HepPdtTablePDG[pdgcode]['Charge [e]'],' Charge [e]:',G4ParticleTablePDG[pdgcode]['Charge [e]']
+            print(pdgcode,HepPdtTablePDG[pdgcode]['Particle Name'],G4ParticleTablePDG[pdgcode]['Particle Name'],' Charge [e]:',HepPdtTablePDG[pdgcode]['Charge [e]'],' Charge [e]:',G4ParticleTablePDG[pdgcode]['Charge [e]'])
             WriteOutHtml(MatchingPDGChargeFileHtml,[pdgcode,HepPdtTablePDG[pdgcode]['Particle Name'],G4ParticleTablePDG[pdgcode]['Particle Name'],HepPdtTablePDG[pdgcode]['Charge [e]'],G4ParticleTablePDG[pdgcode]['Charge [e]']])
     else:
         #########################################################################################
@@ -261,7 +261,7 @@ for element in MassDiffPercentList:
     MassDiff=element[2]
     MassDiffPercent=element[3]
     WriteOutHtml(MatchingPDGMassSortedFileHtml,[pdgcode,HepPdtTablePDG[pdgcode]['Particle Name'],G4ParticleTablePDG[pdgcode]['Particle Name'],HepPdtTablePDG[pdgcode]['Mass [GeV/c2]'],G4ParticleTablePDG[pdgcode]['Mass [GeV/c2]'],MassDiff,MassDiffPercent,G4ParticleTablePDG[pdgcode]['ctau [mm]']])
-#    print element[0],element[1]
+#    print(element[0],element[1])
 
 MatchingPDGctauSortedFileHtml=open('MatchingPDGctauSorted.html','w')
 MatchingPDGctauSortedFileHtml.writelines(['<html>\n','<body>\n','<table align="center", border=2>\n'])


### PR DESCRIPTION
#### PR description:

Fix syntax in python scripts:

* Switch to python 3 syntax: `print()`, `except ... as`
* Partial fix for indentation: make all indented line use the same characters for indentation (either spaces or tabs), remove mixing of tabs and spaces
* Add missing braces and commas, fix invalid syntax (`FWLiteEnabler::enable()` should be `ROOT.FWLiteEnabler.enable()`), remove trailing semicolons
* Replaced (potentially unsafe) `exec` with `import_module`

This is a preparation for fixing #46113 . Maybe some of these scripts are not needed anymore and can be removed?

#### PR validation:

Bot tests.