### PR TITLE
[L1] Fix syntax in python scripts

### DIFF
--- a/L1Trigger/L1TGEM/test/runGEMPadDigiReader_cfg.py
+++ b/L1Trigger/L1TGEM/test/runGEMPadDigiReader_cfg.py
@@ -20,7 +20,7 @@ process.source = cms.Source("PoolSource",
     )
 )
 
-process.dumper = cms.EDAnalyzer("GEMPadDigiReader"
+process.dumper = cms.EDAnalyzer("GEMPadDigiReader",
     gemDigiToken = cms.InputTag("simMuonGEMDigis"),
     gemPadToken = cms.InputTag("simMuonGEMPadDigis")
 )

--- a/L1Trigger/L1TMuonEndCap/test/tools/make_coordlut_MC.py
+++ b/L1Trigger/L1TMuonEndCap/test/tools/make_coordlut_MC.py
@@ -8,7 +8,7 @@ process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
-print "Using GlobalTag: %s" % process.GlobalTag.globaltag.value()
+print("Using GlobalTag: %s" % process.GlobalTag.globaltag.value())
 
 # Fake alignment is/should be ideal geometry
 # ==========================================

--- a/L1Trigger/L1TMuonEndCap/test/tools/make_coordlut_data.py
+++ b/L1Trigger/L1TMuonEndCap/test/tools/make_coordlut_data.py
@@ -10,7 +10,7 @@ process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, '102X_dataRun2_Sep2018Rereco_v1')
-print "Using GlobalTag: %s" % process.GlobalTag.globaltag.value()
+print("Using GlobalTag: %s" % process.GlobalTag.globaltag.value())
 
 process.source = cms.Source("EmptyIOVSource",
     timetype = cms.string('runnumber'),

--- a/L1Trigger/L1TMuonOverlapPhase1/test/expert/omtf/runMuonOverlapDataDump.py
+++ b/L1Trigger/L1TMuonOverlapPhase1/test/expert/omtf/runMuonOverlapDataDump.py
@@ -68,7 +68,7 @@ path = '/eos/user/a/akalinow/Data/SingleMu/9_3_14_FullEta_v2/' #new sample, but 
 #path = '/afs/cern.ch/work/k/kbunkow/public/data/SingleMuFullEta/721_FullEta_v4/'
 
 onlyfiles = [f for f in listdir(path) if isfile(join(path, f))]
-#print onlyfiles
+#print(onlyfiles)
 
 filesNameLike = sys.argv[1]
 #chosenFiles = ['file://' + path + f for f in onlyfiles if (('_p_10_' in f) or ('_m_10_' in f))]
@@ -76,7 +76,7 @@ filesNameLike = sys.argv[1]
 #chosenFiles = ['file://' + path + f for f in onlyfiles if (re.match('.*_._p_10.*', f))]
 #chosenFiles = ['file://' + path + f for f in onlyfiles if ((filesNameLike in f))]
 
-#print onlyfiles
+#print(onlyfiles)
 
 chosenFiles = []
 
@@ -90,7 +90,7 @@ if filesNameLike == 'allPt' :
                 for f in onlyfiles:
                    #if (( '_' + str(ptCode) + sign + '_' + str(i) + '_') in f): #TODO for 721_FullEta_v4/
                    if (( '_' + str(ptCode) + sign + '_' + str(i) + ".") in f):  #TODO for 9_3_14_FullEta_v2
-                        #print f
+                        #print(f)
                         chosenFiles.append('file://' + path + f) 
                         selFilesPerPtBin += 1
                 if(selFilesPerPtBin >= filesPerPtBin):
@@ -101,16 +101,16 @@ else :
         for f in onlyfiles:
             if (( filesNameLike + '_' + str(i) + '_') in f):  #TODO for 721_FullEta_v4/
             #if (( filesNameLike + '_' + str(i) + '.') in f): #TODO for 9_3_14_FullEta_v2
-                print f
+                print(f)
                 chosenFiles.append('file://' + path + f) 
          
 
-print "chosenFiles"
+print("chosenFiles")
 for chFile in chosenFiles:
-    print chFile
+    print(chFile)
 
 if len(chosenFiles) == 0 :
-    print "no files selected!!!!!!!!!!!!!!!"
+    print("no files selected!!!!!!!!!!!!!!!")
     exit
 
 firstEv = 0#40000

--- a/L1Trigger/L1TTwinMux/test/runUnpEmuTwinMux.py
+++ b/L1Trigger/L1TTwinMux/test/runUnpEmuTwinMux.py
@@ -109,7 +109,7 @@ process.L1TMuonSeq = cms.Sequence(process.RPCTwinMuxRawToDigi
 
 process.L1TMuonPath = cms.Path(process.L1TMuonSeq)
 
- process.out = cms.OutputModule("PoolOutputModule", 
+process.out = cms.OutputModule("PoolOutputModule", 
      outputCommands = cms.untracked.vstring(
          'drop *',
          #'keep *CSC*_*_*_*',
@@ -121,9 +121,9 @@ process.L1TMuonPath = cms.Path(process.L1TMuonSeq)
          'keep *_*TwinMux*_*_*',
          'keep *_*Bmtf*_*_*',
          'keep GenEventInfoProduct_generator_*_*'),
- 
-   fileName = cms.untracked.string("l1ttwinmux.root")
- )
+
+     fileName = cms.untracked.string("l1ttwinmux.root")
+)
 
 process.output_step = cms.EndPath(process.out)
 process.schedule = cms.Schedule(process.L1TMuonPath)

--- a/L1Trigger/VertexFinder/test/vertexFinder_cfg.py
+++ b/L1Trigger/VertexFinder/test/vertexFinder_cfg.py
@@ -39,7 +39,7 @@ if options.l1Tracks.count(':') != 1:
     raise RuntimeError("Value for 'l1Tracks' command-line argument (= '{}') should contain one colon".format(options.l1Tracks))
 
 l1TracksTag = cms.InputTag(options.l1Tracks.split(':')[0], options.l1Tracks.split(':')[1])
-print "  INPUT TRACK COLLECTION = {0}  {1}".format(*options.l1Tracks.split(':')) 
+print("  INPUT TRACK COLLECTION = {0}  {1}".format(*options.l1Tracks.split(':')) )
     
 
 process.options   = cms.untracked.PSet( wantSummary = cms.untracked.bool(False) )

--- a/L1Trigger/VertexFinder/test/vertexNTupler_cfg.py
+++ b/L1Trigger/VertexFinder/test/vertexNTupler_cfg.py
@@ -56,7 +56,7 @@ if options.l1Tracks.count(':') != 1:
     raise RuntimeError("Value for 'l1Tracks' command-line argument (= '{}') should contain one colon".format(options.l1Tracks))
 
 l1TracksTag = cms.InputTag(options.l1Tracks.split(':')[0], options.l1Tracks.split(':')[1])
-print "Input Track Collection = {0}  {1}".format(*options.l1Tracks.split(':')) 
+print("Input Track Collection = {0}  {1}".format(*options.l1Tracks.split(':')))
 
 
 # PART 2: SETUP MAIN CMSSW PROCESS 
@@ -128,11 +128,11 @@ if options.runVariations:
                 for l in range(7):
                     seedTrackPt = 2.0 + float(l) * 0.5
 
-                    print
-                    print "dist       =", dist
-                    print "minPt      =", minPt
-                    print "minDensity =", minDensity
-                    print "seedTrkPt  =", seedTrackPt
+                    print()
+                    print("dist       =", dist)
+                    print("minPt      =", minPt)
+                    print("minDensity =", minDensity)
+                    print("seedTrkPt  =", seedTrackPt)
 
                     producer = process.l1tVertexProducer.clone()
                     producer.VertexReconstruction.VertexDistance = cms.double(dist)
@@ -142,16 +142,16 @@ if options.runVariations:
 
                     producerName = 'VertexProducerDBSCANDist{0}minPt{1}minDensity{2}seedTrackPt{3}'.format(dist, minPt, minDensity, seedTrackPt)
                     producerName = producerName.replace(".","p")
-                    print "producer name =", producerName
+                    print("producer name =", producerName)
                     setattr(process, producerName, producer)
                     producerNames += [producerName]
                     process.l1tVertexNTupler.extraVertexDescriptions += ['DBSCAN(dist={0},minPt={1},minDensity={2},seedTrackPt{3})'.format(dist, minPt, minDensity, seedTrackPt)]
                     process.l1tVertexNTupler.extraVertexInputTags.append( cms.InputTag(producerName, 'L1Vertices'))
                     producerSum += producer
 
-print "Total number of producers =", len(additionalProducerAlgorithms)+1
-print "  Producers = [{0}]".format(producerSum.dumpSequenceConfig().replace('&',', '))
-print "  Algorithms = [fastHisto, {0}]".format(', '.join(additionalProducerAlgorithms))
+print("Total number of producers =", len(additionalProducerAlgorithms)+1)
+print("  Producers = [{0}]".format(producerSum.dumpSequenceConfig().replace('&',', ')))
+print("  Algorithms = [fastHisto, {0}]".format(', '.join(additionalProducerAlgorithms)))
 
 # PART 4: UTILITIES
 
@@ -177,5 +177,5 @@ process.p = cms.Path(producerSum + process.l1tTPStubValueMapProducer + process.l
 
 # DUMP AND EXIT
 if options.dump:
-    print process.dumpPython()
+    print(process.dumpPython())
     sys.exit(0)


### PR DESCRIPTION
#### PR description:

Fix syntax in python scripts:

* Switch to python 3 syntax: `print()`, `except ... as`
* Partial fix for indentation: make all indented line use the same characters for indentation (either spaces or tabs), remove mixing of tabs and spaces
* Add missing braces and commas, fix invalid syntax (`FWLiteEnabler::enable()` should be `ROOT.FWLiteEnabler.enable()`), remove trailing semicolons
* Replaced (potentially unsafe) `exec` with `import_module`

This is a preparation for fixing #46113 . Maybe some of these scripts are not needed anymore and can be removed?

#### PR validation:

Bot tests.