### PR TITLE
[RECONSTRUCTION] Fix syntax in python scripts

### DIFF
--- a/RecoHI/HiEvtPlaneAlgos/test/hievtplaneflat_cfg.py
+++ b/RecoHI/HiEvtPlaneAlgos/test/hievtplaneflat_cfg.py
@@ -56,7 +56,7 @@ process.GlobalTag.toGet.extend([
 
 process.GlobalTag.toGet.extend([
         cms.PSet(record = cms.string("HeavyIonRPRcd"),
-                 tag = cms.string('HeavyIonRPRcd_Hydjet_74x_v02_mc')
+                 tag = cms.string('HeavyIonRPRcd_Hydjet_74x_v02_mc'),
                  connect = cms.untracked.string("frontier://FrontierProd/CMS_COND_PAT_000")
                  )
         ])

--- a/RecoTracker/MkFitCore/standalone/plotting/compareTotals.py
+++ b/RecoTracker/MkFitCore/standalone/plotting/compareTotals.py
@@ -87,7 +87,7 @@ for d in range(0, len(fnames)):
   subrate = []
   
   for subdir in subdirs:
-    print "In subdir %s:"%subdir
+    print("In subdir %s:"%subdir)
     fs[d].cd(subdir)
 
     thiseff_obj  = []
@@ -104,7 +104,7 @@ for d in range(0, len(fnames)):
       obj = key.ReadObj()
       if obj.IsA().InheritsFrom("TH1"):
         h = obj
-        #print "Found TH1 %s"%h.GetName()
+        #print("Found TH1 %s"%h.GetName())
           
         thishist.append(h)
         thishist[nh].Sumw2()
@@ -118,7 +118,7 @@ for d in range(0, len(fnames)):
 
       if obj.IsA().InheritsFrom("TEfficiency"):
         e = obj
-        #print "Found TEfficiency %s"%e.GetName()
+        #print("Found TEfficiency %s"%e.GetName())
         
         thiseff_obj .append(e)
         thiseff_obj[ne].SetLineColor(colors[d])

--- a/RecoTracker/MkFitCore/standalone/plotting/makeBenchmarkPlots.py
+++ b/RecoTracker/MkFitCore/standalone/plotting/makeBenchmarkPlots.py
@@ -26,7 +26,7 @@ def run():
     elif arch == 'SNB' :
         vuvals.append('8int')
     else :
-        print arch,'is not a valid architecture! Exiting...'
+        print(arch,'is not a valid architecture! Exiting...')
         sys.exit(0)
 
     # call the make plots function
@@ -50,7 +50,7 @@ def run():
         nvu = '16int'
         thvals = ['1','2','4','8','16','32','48','64']
     else :
-        print arch,'is not a valid architecture! Exiting...'
+        print(arch,'is not a valid architecture! Exiting...')
         sys.exit(0)
     
     # call the make plots function
@@ -67,11 +67,11 @@ def makeplots(arch,sample,build,vals,nC,text):
     elif build == 'CE'  : pos = 14 
     elif build == 'FV'  : pos = 17
     else :
-        print build,'is not a valid test! Exiting...'
+        print(build,'is not a valid test! Exiting...')
         sys.exit(0)
 
     # time    
-    print arch,sample,build,text
+    print(arch,sample,build,text)
 
     # define tgraphs vs absolute time and speedup
     g_time    = ROOT.TGraphErrors(len(vals)-1)
@@ -98,7 +98,7 @@ def makeplots(arch,sample,build,vals,nC,text):
         if   text is 'VU' : os.system('grep Matriplex log_'+arch+'_'+sample+'_'+build+'_NVU'+val+'_NTH'+nC +'.txt >& log_'+arch+'_'+sample+'_'+build+'_'+text+'.txt')
         elif text is 'TH' : os.system('grep Matriplex log_'+arch+'_'+sample+'_'+build+'_NVU'+nC +'_NTH'+val+'.txt >& log_'+arch+'_'+sample+'_'+build+'_'+text+'.txt')
         else :
-            print 'VU or TH are the only options for extra text! Exiting...'
+            print('VU or TH are the only options for extra text! Exiting...')
             exit
 
         # open temp file, store event times into yvals
@@ -130,7 +130,7 @@ def makeplots(arch,sample,build,vals,nC,text):
             emean = 0
 
         # Printout value for good measure
-        print val,mean,'+/-',emean
+        print(val,mean,'+/-',emean)
 
         # store intrinsics val into separate plot
         if 'int' not in val :

--- a/RecoTracker/MkFitCore/standalone/plotting/makeMEIFBenchmarkPlots.py
+++ b/RecoTracker/MkFitCore/standalone/plotting/makeMEIFBenchmarkPlots.py
@@ -33,7 +33,7 @@ elif arch == 'LNX-S' :
     thvals = ['1','2','4','8','16','32','48','64']
     evvals = ['1','2','4','8','16','32','64']
 else :
-    print arch,"is not a valid architecture! Exiting..."
+    print(arch,"is not a valid architecture! Exiting...")
     sys.exit(0)
 
 # extra text label
@@ -49,7 +49,7 @@ yval0 = array.array('d',[0])
 
 # time    
 for evval in evvals :
-    print arch,sample,build,"nEV:",evval
+    print(arch,sample,build,"nEV:",evval)
     
     # define event float
     ev = float(evval)
@@ -80,7 +80,7 @@ for evval in evvals :
         yval /= nev
 
         # Printout value for good measure
-        print xval,yval
+        print(xval,yval)
 
         # store val
         g_time.SetPoint(point,xval,yval)


### PR DESCRIPTION
#### PR description:

Fix syntax in python scripts:

* Switch to python 3 syntax: `print()`, `except ... as`
* Partial fix for indentation: make all indented line use the same characters for indentation (either spaces or tabs), remove mixing of tabs and spaces
* Add missing braces and commas, fix invalid syntax (`FWLiteEnabler::enable()` should be `ROOT.FWLiteEnabler.enable()`), remove trailing semicolons
* Replaced (potentially unsafe) `exec` with `import_module`

This is a preparation for fixing #46113 . Maybe some of these scripts are not needed anymore and can be removed?

#### PR validation:

Bot tests.