### PR TITLE
[GEOMETRY] Fix syntax in python scripts

### DIFF
--- a/Geometry/TrackerCommonData/test/twikiExport.py
+++ b/Geometry/TrackerCommonData/test/twikiExport.py
@@ -206,13 +206,13 @@ def main():
         expandvars(
             "$CMSSW_BASE/src/Geometry/TrackerCommonData/data/Materials/pure_materials.input"
         )
-    )
+    ))
 
     predefinedMaterials.update( readMaterialFile(
         expandvars(
             "$CMSSW_BASE/src/Geometry/TrackerCommonData/data/Materials/mixed_materials.input"
         )
-    )
+    ))
 
     inFile = open(options.inFile,"r")
     inFileContent = inFile.read()


### PR DESCRIPTION
#### PR description:

Fix syntax in python scripts:

* Switch to python 3 syntax: `print()`, `except ... as`
* Partial fix for indentation: make all indented line use the same characters for indentation (either spaces or tabs), remove mixing of tabs and spaces
* Add missing braces and commas, fix invalid syntax (`FWLiteEnabler::enable()` should be `ROOT.FWLiteEnabler.enable()`), remove trailing semicolons
* Replaced (potentially unsafe) `exec` with `import_module`

This is a preparation for fixing #46113 . Maybe some of these scripts are not needed anymore and can be removed?

#### PR validation:

Bot tests.