### PR TITLE
[ANALYSIS] Fix syntax in python scripts

### DIFF
--- a/EgammaAnalysis/ElectronTools/test/run_CorrectECALIsolation_cfg.py
+++ b/EgammaAnalysis/ElectronTools/test/run_CorrectECALIsolation_cfg.py
@@ -18,11 +18,10 @@ process.source = cms.Source("PoolSource",
     )
 
 process.correctEcalIso = cms.EDAnalyzer("CorrectECALIsolation",
-                                        
                                         # input collections
                                         Electrons = cms.InputTag('gsfElectrons'),
                                         isData = cms.bool(True)
-
+)
 process.p = cms.Path(process.correctEcalIso)
 
 


### PR DESCRIPTION
#### PR description:

Fix syntax in python scripts:

* Switch to python 3 syntax: `print()`, `except ... as`
* Partial fix for indentation: make all indented line use the same characters for indentation (either spaces or tabs), remove mixing of tabs and spaces
* Add missing braces and commas, fix invalid syntax (`FWLiteEnabler::enable()` should be `ROOT.FWLiteEnabler.enable()`), remove trailing semicolons
* Replaced (potentially unsafe) `exec` with `import_module`

This is a preparation for fixing #46113 . Maybe some of these scripts are not needed anymore and can be removed?

#### PR validation:

Bot tests.