### PR TITLE
[L1] Fix syntax in python scripts

### DIFF
--- a/L1Trigger/DTTriggerPhase2/test/macros/compare_groupings_StdToBayes.py
+++ b/L1Trigger/DTTriggerPhase2/test/macros/compare_groupings_StdToBayes.py
@@ -61,7 +61,7 @@ ROOT.gROOT.SetBatch(True)
 ##
 files = ['../../../../DTTriggerPhase2Primitives.root']
 
-print "Number of files: %d" % len(files)
+print("Number of files: %d" % len(files))
 
 events = Events(files)
 
@@ -191,7 +191,7 @@ for frac in [0.25,0.5,0.75,1.00]:
             hTimeRes_MB_q8.append(ROOT.TH1F("hTimeRes_MB_MB%i_MB_Wh%i_MB_q8_MB_%s" %(st, wh, fracname), "", 20, -100, 100.))
 
 
-    print "now save into dictionary"
+    print("now save into dictionary")
     outputDict[fracname] = {}
     for st in range(1,5):
         outputDict[fracname]['hMatchingEff_MB%i'%st] = hMatchingEff[st-1]
@@ -260,7 +260,7 @@ for frac in [0.25,0.5,0.75,1.00]:
         f= open("EventDumpList_StdToBayes.log","w+")
 
     for ev in events:
-        if not count%1000:  print count, events.size()
+        if not count%1000:  print(count, events.size())
         count = count+1
         
         ev.getByLabel(muoBayesLabel, muoBayesHandle)

--- a/L1Trigger/DTTriggerPhase2/test/macros/plotGroupings_StdToBayes.py
+++ b/L1Trigger/DTTriggerPhase2/test/macros/plotGroupings_StdToBayes.py
@@ -54,14 +54,14 @@ for st in ["MB1","MB2","MB3","MB4"]:
 outpath = "../../../../Groupings/"
 if not os.path.exists(outpath):
     os.mkdir(outpath)
-    print "cp /afs/cern.ch/user/n/ntrevisa/public/utils/index.php %s/" %outpath
+    print("cp /afs/cern.ch/user/n/ntrevisa/public/utils/index.php %s/" %outpath)
     os.system("cp /afs/cern.ch/user/n/ntrevisa/public/utils/index.php %s/" %outpath)
 os.system("cp EventDumpList_StdToBayes.log %s/" %outpath)
 
 outpath = outpath + "StdToBayes/"
 if not os.path.exists(outpath):
     os.mkdir(outpath)
-    print "cp /afs/cern.ch/user/n/ntrevisa/public/utils/index.php %s/" %outpath
+    print("cp /afs/cern.ch/user/n/ntrevisa/public/utils/index.php %s/" %outpath)
     os.system("cp /afs/cern.ch/user/n/ntrevisa/public/utils/index.php %s/" %outpath)
 
 


### PR DESCRIPTION
#### PR description:

Fix syntax in python scripts:

* Switch to python 3 syntax: `print()`, `except ... as`
* Partial fix for indentation: make all indented line use the same characters for indentation (either spaces or tabs), remove mixing of tabs and spaces
* Add missing braces and commas, fix invalid syntax (`FWLiteEnabler::enable()` should be `ROOT.FWLiteEnabler.enable()`), remove trailing semicolons
* Replaced (potentially unsafe) `exec` with `import_module`

This is a preparation for fixing #46113 . Maybe some of these scripts are not needed anymore and can be removed?

#### PR validation:

Bot tests.