### PR TITLE
run G2GainsValidator.py in user-mode

### DIFF
--- a/CondCore/SiStripPlugins/test/test_G2GainsValidator.sh
+++ b/CondCore/SiStripPlugins/test/test_G2GainsValidator.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 function die { echo $1: status $2 ; exit $2; }
-python3 $CMSSW_BASE/src/CondCore/SiStripPlugins/scripts/G2GainsValidator.py  || die "Failure running G2GainsValidator.py" $?
+python3 $CMSSW_BASE/src/CondCore/SiStripPlugins/scripts/G2GainsValidator.py --user-mode || die "Failure running G2GainsValidator.py" $?


### PR DESCRIPTION
This PR proposes to run `G2GainsValidator.py` with `--user-mode` option which will use the user cert/key from `~/.globus`
Fixes https://github.com/cms-sw/cmssw/issues/46177