### PR TITLE
[LLVM Analyzer] Avoid storing pointer to a temporary string's internal buffer in SiPixelTemplateDBObjectReader::analyze

### DIFF
--- a/CondTools/SiPixel/plugins/SiPixelTemplateDBObjectReader.cc
+++ b/CondTools/SiPixel/plugins/SiPixelTemplateDBObjectReader.cc
@@ -114,7 +114,6 @@ void SiPixelTemplateDBObjectReader::analyze(const edm::Event& iEvent, const edm:
     edm::LogPrint("SiPixelTemplateDBObjectReader") << std::endl;
 
     //local variables
-    const char* tempfile;
     int numOfTempl = dbobject.numOfTempl();
     int index = 0;
     float tempnum = 0, diff = 0;
@@ -139,8 +138,8 @@ void SiPixelTemplateDBObjectReader::analyze(const edm::Event& iEvent, const edm:
            << std::right << dbobject.sVector()[index] << ".out" << std::ends;
 
       edm::FileInPath file(tout.str());
-      tempfile = (file.fullPath()).c_str();
-      std::ifstream in_file(tempfile, std::ios::in);
+      std::string tempfile = file.fullPath();
+      std::ifstream in_file(tempfile.c_str(), std::ios::in);
 
       if (in_file.is_open()) {
         //Removes header in textfile from diff


### PR DESCRIPTION
#### PR description:

LLVM reports `use-after-free` error in `SiPixelTemplateDBObjectReader::analyze`: [link](https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_14_2_X_2024-09-29-0000/el8_amd64_gcc12/llvm-analysis/report-0bb855.html#EndPath)

#### PR validation:

Bot tests