### PR TITLE
[LLVM Analyzer] Avoid storing pointer to a temporary string's internal buffer in SiPixelFakeGenErrorDBObjectESSource::produce and SiPixelTemplateDBObjectReader::analyze 

### DIFF
--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeGenErrorDBObjectESSource.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeGenErrorDBObjectESSource.cc
@@ -23,7 +23,6 @@ std::unique_ptr<SiPixelGenErrorDBObject> SiPixelFakeGenErrorDBObjectESSource::pr
   SiPixelGenErrorDBObject* obj = new SiPixelGenErrorDBObject;
 
   // Local variables
-  const char* tempfile;
   int m;
 
   // Set the number of GenErrors to be passed to the dbobject
@@ -35,9 +34,7 @@ std::unique_ptr<SiPixelGenErrorDBObject> SiPixelFakeGenErrorDBObjectESSource::pr
   //  open the GenError file(s)
   for (m = 0; m < obj->numOfTempl(); ++m) {
     edm::FileInPath file(GenErrorCalibrations_[m].c_str());
-    tempfile = (file.fullPath()).c_str();
-
-    std::ifstream in_file(tempfile, std::ios::in);
+    std::ifstream in_file(file.fullPath(), std::ios::in);
 
     if (in_file.is_open()) {
       edm::LogInfo("SiPixelFakeGenErrorDBObjectESSource")
@@ -84,7 +81,7 @@ std::unique_ptr<SiPixelGenErrorDBObject> SiPixelFakeGenErrorDBObjectESSource::pr
       in_file.close();
     } else {
       // If file didn't open, report this
-      edm::LogError("SiPixeFakelGenErrorDBObjectESSource") << "Error opening File" << tempfile << std::endl;
+      edm::LogError("SiPixeFakelGenErrorDBObjectESSource") << "Error opening File" << file.fullPath() << std::endl;
     }
   }
 

--- a/CondTools/SiPixel/plugins/SiPixelTemplateDBObjectReader.cc
+++ b/CondTools/SiPixel/plugins/SiPixelTemplateDBObjectReader.cc
@@ -114,7 +114,6 @@ void SiPixelTemplateDBObjectReader::analyze(const edm::Event& iEvent, const edm:
     edm::LogPrint("SiPixelTemplateDBObjectReader") << std::endl;
 
     //local variables
-    const char* tempfile;
     int numOfTempl = dbobject.numOfTempl();
     int index = 0;
     float tempnum = 0, diff = 0;
@@ -139,8 +138,7 @@ void SiPixelTemplateDBObjectReader::analyze(const edm::Event& iEvent, const edm:
            << std::right << dbobject.sVector()[index] << ".out" << std::ends;
 
       edm::FileInPath file(tout.str());
-      tempfile = (file.fullPath()).c_str();
-      std::ifstream in_file(tempfile, std::ios::in);
+      std::ifstream in_file(file.fullPath(), std::ios::in);
 
       if (in_file.is_open()) {
         //Removes header in textfile from diff


### PR DESCRIPTION
#### PR description:

LLVM report: [link](https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_14_2_X_2024-09-29-0000/el8_amd64_gcc12/llvm-analysis/report-1b271a.html#EndPath)

#### PR validation:

Bot tests
