### PR TITLE
Update Run3 data, Run3 2024 pp MC, Run3 2024 ppRef5TeV MC GTs in autoCond

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -37,8 +37,8 @@ autoCond = {
     'run3_data_express'            :    '141X_dataRun3_Express_frozen_v3',
     # GlobalTag for Run3 data relvals (prompt GT): same as 141X_dataRun3_Prompt_v3 but with snapshot at 2024-09-12 11:03:32 (UTC)
     'run3_data_prompt'             :    '141X_dataRun3_Prompt_frozen_v3',
-    # GlobalTag for Run3 offline data reprocessing - snapshot at 2024-09-25 12:44:01 (UTC)
-    'run3_data'                    :    '140X_dataRun3_v13',
+    # GlobalTag for Run3 offline data reprocessing - snapshot at 2024-10-01 13:57:41 (UTC)
+    'run3_data'                    :    '140X_dataRun3_v14',
     # GlobalTag for Run3 offline data reprocessing with Prompt GT, currently for 2022FG - snapshot at 2024-02-12 12:00:00 (UTC)
     'run3_data_PromptAnalysis'     :    '140X_dataRun3_PromptAnalysis_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
@@ -92,7 +92,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2024
     'phase1_2024_design'           :    '140X_mcRun3_2024_design_v11',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        :    '140X_mcRun3_2024_realistic_v24',
+    'phase1_2024_realistic'        :    '140X_mcRun3_2024_realistic_v25',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2024, Strip tracker in DECO mode
     'phase1_2024_cosmics'          :    '140X_mcRun3_2024cosmics_realistic_deco_v14',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2024, Strip tracker in DECO mode
@@ -100,7 +100,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2024 detector for Heavy Ion
     'phase1_2024_realistic_hi'     :    '141X_mcRun3_2024_realistic_HI_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2024 detector for ppRef5TeV
-    'phase1_2024_realistic_ppRef5TeV'     :    '141X_mcRun3_2024_realistic_ppRef5TeV_v3',
+    'phase1_2024_realistic_ppRef5TeV'     :    '141X_mcRun3_2024_realistic_ppRef5TeV_v4',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             :    '141X_mcRun4_realistic_v1'
 }


### PR DESCRIPTION
#### PR description:

The following GTs are updated in autoCond:

- `run3_data` -> [140X_dataRun3_v14](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/140X_dataRun3_v14) (see the [diff wrt _v13](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_dataRun3_v13/140X_dataRun3_v14))
  - Allow the 2024 payloads (IOV range 378983 to 383705) appended to the CTPPSRPAlignment tag, see https://cms-talk.web.cern.ch/t/call-for-conditions-re-reco-of-2024-eras-c-d-e/42331/14 
 
- `phase1_2024_realistic `-> [140X_mcRun3_2024_realistic_v25](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/140X_mcRun3_2024_realistic_v25) (see the [diff wrt _v24](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2024_realistic_v24/140X_mcRun3_2024_realistic_v25))
  - Include the DT and CSC alignments plus a set of GEM tags, see https://cms-talk.web.cern.ch/t/final-call-for-run3summer24-mc-conditions-in-140x/41226/15

- `phase1_2024_realistic_ppRef5TeV` ->[141X_mcRun3_2024_realistic_ppRef5TeV_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/141X_mcRun3_2024_realistic_ppRef5TeV_v4) (see the [diff wrt _v3](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/141X_mcRun3_2024_realistic_ppRef5TeV_v3/141X_mcRun3_2024_realistic_ppRef5TeV_v4))
  - Include the DT and CSC alignments plus a set of GEM tags, see https://cms-talk.web.cern.ch/t/final-call-for-run3summer24-mc-conditions-in-140x/41226/15 (i.e. synchronize with 140X_mcRun3_2024_realistic_v25, see [diff wrt 140X_mcRun3_2024_realistic_v25](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/141X_mcRun3_2024_realistic_ppRef5TeV_v4/140X_mcRun3_2024_realistic_v25))


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backports for CMSSW_14_0_X and CMSSW_14_1_X will be prepared