### PR TITLE
Add standalone unit test for DQM/TrackingMonitorSource plugins

### DIFF
--- a/DQM/TrackingMonitorSource/plugins/StandaloneTrackMonitor.cc
+++ b/DQM/TrackingMonitorSource/plugins/StandaloneTrackMonitor.cc
@@ -387,11 +387,11 @@ void StandaloneTrackMonitor::fillDescriptions(edm::ConfigurationDescriptions& de
   desc.addUntracked<bool>("haveAllHistograms", false);
   desc.addUntracked<std::string>("puScaleFactorFile", "PileupScaleFactor.root");
   desc.addUntracked<std::string>("trackScaleFactorFile", "PileupScaleFactor.root");
-  desc.addUntracked<std::vector<std::string> >("MVAProducers");
-  desc.addUntracked<edm::InputTag>("TrackProducerForMVA");
+  desc.addUntracked<std::vector<std::string> >("MVAProducers", {"initialStepClassifier1", "initialStepClassifier2"});
+  desc.addUntracked<edm::InputTag>("TrackProducerForMVA", edm::InputTag("initialStepTracks"));
 
-  desc.addUntracked<edm::InputTag>("TCProducer");
-  desc.addUntracked<std::string>("AlgoName");
+  desc.addUntracked<edm::InputTag>("TCProducer", edm::InputTag("initialStepTrackCandidates"));
+  desc.addUntracked<std::string>("AlgoName", "GenTk");
   desc.addUntracked<bool>("verbose", false);
 
   {
@@ -1315,7 +1315,8 @@ void StandaloneTrackMonitor::analyze(edm::Event const& iEvent, edm::EventSetup c
   edm::Handle<reco::VertexCollection> vertexColl;
   iEvent.getByToken(vertexToken_, vertexColl);
   if (!vertexColl.isValid()) {
-    edm::LogError("DqmTrackStudy") << "Error! Failed to get reco::Vertex Collection, " << vertexTag_;
+    edm::LogError("StandaloneTrackMonitor") << "Error! Failed to get reco::Vertex Collection, " << vertexTag_;
+    return;
   }
   if (vertexColl->empty()) {
     edm::LogError("StandalonaTrackMonitor") << "No good vertex in the event!!" << std::endl;
@@ -1326,14 +1327,18 @@ void StandaloneTrackMonitor::analyze(edm::Event const& iEvent, edm::EventSetup c
   // Beam spot
   edm::Handle<reco::BeamSpot> beamSpot;
   iEvent.getByToken(bsToken_, beamSpot);
-  if (!beamSpot.isValid())
+  if (!beamSpot.isValid()) {
     edm::LogError("StandalonaTrackMonitor") << "Beamspot for input tag: " << bsTag_ << " not found!!";
+    return;
+  }
 
   // Track collection
   edm::Handle<reco::TrackCollection> tracks;
   iEvent.getByToken(trackToken_, tracks);
-  if (!tracks.isValid())
+  if (!tracks.isValid()) {
     edm::LogError("StandalonaTrackMonitor") << "TrackCollection for input tag: " << trackTag_ << " not found!!";
+    return;
+  }
 
   // Access PU information
   double wfac = 1.0;  // for data

--- a/DQM/TrackingMonitorSource/plugins/TrackMultiplicityFilter.cc
+++ b/DQM/TrackingMonitorSource/plugins/TrackMultiplicityFilter.cc
@@ -62,6 +62,13 @@ bool TrackMultiplicityFilter::filter(edm::StreamID iStream, edm::Event& iEvent, 
   bool pass = false;
   edm::Handle<reco::TrackCollection> tracks;
   iEvent.getByToken(tracksToken_, tracks);
+
+  if (!tracks.isValid()) {
+    edm::LogError("TrackMultiplicityFilter")
+        << "Error >> Failed to get TrackMultiplicityFilter for label: " << tracksTag_;
+    return false;
+  }
+
   double count = std::count_if(tracks->begin(), tracks->end(), selector_);
   pass = (count >= nmin_);
 

--- a/DQM/TrackingMonitorSource/plugins/TtbarTrackProducer.cc
+++ b/DQM/TrackingMonitorSource/plugins/TtbarTrackProducer.cc
@@ -250,16 +250,19 @@ void TtbarTrackProducer::produce(edm::StreamID streamID, edm::Event& iEvent, edm
 
   edm::Handle<reco::JetTagCollection> bTagHandle;
   iEvent.getByToken(bjetsToken_, bTagHandle);
-  const reco::JetTagCollection& bTags = *(bTagHandle.product());
-  std::vector<TLorentzVector> list_bjets;
 
-  if (!bTags.empty()) {
-    for (unsigned bj = 0; bj != bTags.size(); ++bj) {
-      TLorentzVector lv_bjets;
-      lv_bjets.SetPtEtaPhiE(
-          bTags[bj].first->pt(), bTags[bj].first->eta(), bTags[bj].first->phi(), bTags[bj].first->energy());
-      if (bTags[bj].second > btagFactor_)
-        list_bjets.push_back(lv_bjets);
+  if (bTagHandle.isValid()) {
+    const reco::JetTagCollection& bTags = *(bTagHandle.product());
+    std::vector<TLorentzVector> list_bjets;
+
+    if (!bTags.empty()) {
+      for (unsigned bj = 0; bj != bTags.size(); ++bj) {
+        TLorentzVector lv_bjets;
+        lv_bjets.SetPtEtaPhiE(
+            bTags[bj].first->pt(), bTags[bj].first->eta(), bTags[bj].first->phi(), bTags[bj].first->energy());
+        if (bTags[bj].second > btagFactor_)
+          list_bjets.push_back(lv_bjets);
+      }
     }
   }
 

--- a/DQM/TrackingMonitorSource/plugins/V0EventSelector.cc
+++ b/DQM/TrackingMonitorSource/plugins/V0EventSelector.cc
@@ -37,8 +37,13 @@ V0EventSelector::V0EventSelector(const edm::ParameterSet& iConfig)
 bool V0EventSelector::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::Handle<reco::VertexCompositeCandidateCollection> vccHandle;
   iEvent.getByToken(vccToken_, vccHandle);
-
   auto filteredVCC = std::make_unique<reco::VertexCompositeCandidateCollection>();
+
+  // early return if the input collection is empty
+  if (!vccHandle.isValid()) {
+    iEvent.put(std::move(filteredVCC));
+    return false;
+  }
 
   for (const auto& vcc : *vccHandle) {
     if (vcc.mass() >= massMin_ && vcc.mass() <= massMax_) {

--- a/DQM/TrackingMonitorSource/plugins/ZEEDetails.cc
+++ b/DQM/TrackingMonitorSource/plugins/ZEEDetails.cc
@@ -230,7 +230,7 @@ void ZEEDetails::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
       if (beamSpot.isValid()) {
         trkd0 = -(trk->dxy(beamSpot->position()));
       } else {
-        edm::LogError("ElectronTrackProducer") << "Error >> Failed to get BeamSpot for label: " << bsTag_;
+        edm::LogError("ZEEDetails") << "Error >> Failed to get BeamSpot for label: " << bsTag_;
       }
       if (std::fabs(trkd0) >= maxD0_)
         continue;
@@ -261,16 +261,17 @@ void ZEEDetails::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
       finalelectrons.push_back(ele);
     }
   } else {
-    edm::LogError("ElectronTrackProducer") << "Error >> Failed to get ElectronCollection for label: " << electronTag_;
+    edm::LogError("ZEEDetails") << "Error >> Failed to get ElectronCollection for label: " << electronTag_;
   }
 
   edm::Handle<reco::VertexCollection> vertexColl;
   iEvent.getByToken(vertexToken_, vertexColl);
   if (!vertexColl.isValid()) {
-    edm::LogError("DqmTrackStudy") << "Error! Failed to get reco::Vertex Collection, " << vertexTag_;
+    edm::LogError("ZEEDetails") << "Error! Failed to get reco::Vertex Collection, " << vertexTag_;
+    return;
   }
   if (vertexColl->empty()) {
-    edm::LogError("DqmTrackStudy") << "No good vertex in the event!!";
+    edm::LogError("ZEEDetails") << "No good vertex in the event!!";
     return;
   }
 
@@ -294,7 +295,7 @@ void ZEEDetails::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
         }
       }
     } else
-      edm::LogError("DqmTrackStudy") << "PUSummary for input tag: " << puSummaryTag_ << " not found!!";
+      edm::LogError("ZEEDetails") << "PUSummary for input tag: " << puSummaryTag_ << " not found!!";
   }
 
   for (unsigned int I = 0; I != finalelectrons.size(); I++) {

--- a/DQM/TrackingMonitorSource/test/BuildFile.xml
+++ b/DQM/TrackingMonitorSource/test/BuildFile.xml
@@ -1,2 +1,8 @@
 <test name="testTrackingDATAMC" command="testTrackingDATAMC.sh"/>
 <test name="testTrackingResolution" command="testTrackingResolution.sh"/>
+<environment>
+  <bin file="testTrackingDQMAnalyzers.cc" name="testTrackingDQMAnalyzers">
+    <use name="FWCore/TestProcessor"/>
+    <use name="catch2"/>
+  </bin>
+</environment>

--- a/DQM/TrackingMonitorSource/test/testTrackingDQMAnalyzers.cc
+++ b/DQM/TrackingMonitorSource/test/testTrackingDQMAnalyzers.cc
@@ -1,0 +1,165 @@
+#include "FWCore/TestProcessor/interface/TestProcessor.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+// Function to run the catch2 tests
+//___________________________________________________________________________________________
+void runTestForAnalyzer(const std::string& baseConfig, const std::string& analyzerName) {
+  edm::test::TestProcessor::Config config{baseConfig};
+
+  SECTION(analyzerName + " base configuration is OK") { REQUIRE_NOTHROW(edm::test::TestProcessor(config)); }
+
+  SECTION(analyzerName + " No Runs data") {
+    edm::test::TestProcessor tester(config);
+    REQUIRE_NOTHROW(tester.testWithNoRuns());
+  }
+
+  SECTION(analyzerName + " beginJob and endJob only") {
+    edm::test::TestProcessor tester(config);
+    REQUIRE_NOTHROW(tester.testBeginAndEndJobOnly());
+  }
+
+  SECTION("No event data") {
+    edm::test::TestProcessor tester(config);
+    REQUIRE_NOTHROW(tester.test());
+  }
+
+  SECTION("Run with no LuminosityBlocks") {
+    edm::test::TestProcessor tester(config);
+    REQUIRE_NOTHROW(tester.testRunWithNoLuminosityBlocks());
+  }
+
+  SECTION("LuminosityBlock with no Events") {
+    edm::test::TestProcessor tester(config);
+    REQUIRE_NOTHROW(tester.testLuminosityBlockWithNoEvents());
+  }
+}
+
+// Function to generate base configuration string
+//___________________________________________________________________________________________
+std::string generateBaseConfig(const std::string& analyzerName, const std::string& rootFileName) {
+  // Define a raw string literal
+  constexpr const char* rawString = R"_(from FWCore.TestProcessor.TestProcess import *
+process = TestProcess()
+process.load("MagneticField.Engine.uniformMagneticField_cfi")
+process.load("Configuration.Geometry.GeometryExtended2024Reco_cff")
+process.load("Alignment.CommonAlignmentProducer.FakeAlignmentSource_cfi")
+from DQM.TrackingMonitorSource.{}_cfi import {}
+process.trackAnalyzer = {}
+process.moduleToTest(process.trackAnalyzer)
+process.add_(cms.Service('DQMStore'))
+process.add_(cms.Service('MessageLogger'))
+process.add_(cms.Service('JobReportService'))
+process.add_(cms.Service('TFileService',fileName=cms.string('{}')))
+    )_";
+
+  // Format the raw string literal using fmt::format
+  return fmt::format(rawString, analyzerName, analyzerName, analyzerName, rootFileName);
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("ShortenedTrackResolution tests", "[ShortenedTrackResolution]") {
+  const std::string baseConfig = generateBaseConfig("shortenedTrackResolution", "test1.root");
+  runTestForAnalyzer(baseConfig, "ShortenedTrackResolution");
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("StandaloneTrackMonitor tests", "[StandaloneTrackMonitor]") {
+  const std::string baseConfig = generateBaseConfig("standaloneTrackMonitorDefault", "test2.root");
+  runTestForAnalyzer(baseConfig, "StandaloneTrackMonitor");
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("AlcaRecoTrackSelector tests", "[AlcaRecoTrackSelector]") {
+  const std::string baseConfig = generateBaseConfig("alcaRecoTrackSelector", "tes3.root");
+  runTestForAnalyzer(baseConfig, "AlcaRecoTrackSelector");
+}
+
+//___________________________________________________________________________________________
+//TEST_CASE("HltPathSelector tests", "[HltPathSelector]") {
+//  const std::string baseConfig = generateBaseConfig("hltPathSelector", "test_hltPathSelector.root");
+//  runTestForAnalyzer(baseConfig, "HltPathSelector");
+//}
+
+//___________________________________________________________________________________________
+TEST_CASE("TrackMultiplicityFilter tests", "[TrackMultiplicityFilter]") {
+  const std::string baseConfig = generateBaseConfig("trackMultiplicityFilter", "test_trackMultiplicityFilter.root");
+  runTestForAnalyzer(baseConfig, "TrackMultiplicityFilter");
+}
+
+//___________________________________________________________________________________________
+//TEST_CASE("TrackToTrackComparisonHists tests", "[TrackToTrackComparisonHists]") {
+//  const std::string baseConfig = generateBaseConfig("trackToTrackComparisonHists", "test_trackToTrackComparisonHists.root");
+//  runTestForAnalyzer(baseConfig, "TrackToTrackComparisonHists");
+//}
+
+//___________________________________________________________________________________________
+TEST_CASE("TrackTypeMonitor tests", "[TrackTypeMonitor]") {
+  const std::string baseConfig = generateBaseConfig("trackTypeMonitor", "test_trackTypeMonitor.root");
+  runTestForAnalyzer(baseConfig, "TrackTypeMonitor");
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("TtbarEventSelector tests", "[TtbarEventSelector]") {
+  const std::string baseConfig = generateBaseConfig("ttbarEventSelector", "test_ttbarEventSelector.root");
+  runTestForAnalyzer(baseConfig, "TtbarEventSelector");
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("TtbarTrackProducer tests", "[TtbarTrackProducer]") {
+  const std::string baseConfig = generateBaseConfig("ttbarTrackProducer", "test_ttbarTrackProducer.root");
+  runTestForAnalyzer(baseConfig, "TtbarTrackProducer");
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("V0EventSelector tests", "[V0EventSelector]") {
+  const std::string baseConfig = generateBaseConfig("v0EventSelector", "test_v0EventSelector.root");
+  runTestForAnalyzer(baseConfig, "V0EventSelector");
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("V0VertexTrackProducer tests", "[V0VertexTrackProducer]") {
+  const std::string baseConfig = generateBaseConfig("v0VertexTrackProducer", "test_v0VertexTrackProducer.root");
+  runTestForAnalyzer(baseConfig, "V0VertexTrackProducer");
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("WtoLNuSelector tests", "[WtoLNuSelector]") {
+  const std::string baseConfig = generateBaseConfig("wtoLNuSelector", "test_wtoLNuSelector.root");
+  runTestForAnalyzer(baseConfig, "WtoLNuSelector");
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("ZeeDetails tests", "[ZeeDetails]") {
+  const std::string baseConfig = generateBaseConfig("zeeDetails", "test_zeeDetails.root");
+  runTestForAnalyzer(baseConfig, "ZeeDetails");
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("ZtoEEElectronTrackProducer tests", "[ZtoEEElectronTrackProducer]") {
+  const std::string baseConfig =
+      generateBaseConfig("ztoEEElectronTrackProducer", "test_ztoEEElectronTrackProducer.root");
+  runTestForAnalyzer(baseConfig, "ZtoEEElectronTrackProducer");
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("ZtoEEEventSelector tests", "[ZtoEEEventSelector]") {
+  const std::string baseConfig = generateBaseConfig("ztoEEEventSelector", "test_ztoEEEventSelector.root");
+  runTestForAnalyzer(baseConfig, "ZtoEEEventSelector");
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("ZtoMMEventSelector tests", "[ZtoMMEventSelector]") {
+  const std::string baseConfig = generateBaseConfig("ztoMMEventSelector", "test_ztoMMEventSelector.root");
+  runTestForAnalyzer(baseConfig, "ZtoMMEventSelector");
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("ZtoMMMuonTrackProducer tests", "[ZtoMMMuonTrackProducer]") {
+  const std::string baseConfig = generateBaseConfig("ztoMMMuonTrackProducer", "test_ztoMMMuonTrackProducer.root");
+  runTestForAnalyzer(baseConfig, "ZtoMMMuonTrackProducer");
+}


### PR DESCRIPTION
#### PR description:

Title says it all:
   * https://github.com/cms-sw/cmssw/pull/46187/commits/27a84e6d0e17a2a75e0c94d2bbceaeb7321ebae3 add missing `fillDescription` parameters and place early returns in case of missing input data in various plugins
   * https://github.com/cms-sw/cmssw/pull/46187/commits/dcf5859c3860b34c7a05205592ab42b56fd1ef05 add `catch2` based tests for various plugins in the package

#### PR validation:

`scram b runtests_testTrackingDQMAnalyzers` runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, might be backported
