### PR TITLE
Use repacked raw for 2024 UPC processing

### DIFF
--- a/Configuration/DataProcessing/python/Impl/ppEra_Run3_2024_UPC.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run3_2024_UPC.py
@@ -18,6 +18,7 @@ class ppEra_Run3_2024_UPC(pp):
         pp.__init__(self)
         self.recoSeq=''
         self.cbSc='pp'
+        self.isRepacked=True
         self.eras=Run3_2024_UPC
         self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_2024_UPC' ]
         self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_2024_UPC' ]


### PR DESCRIPTION
#### PR description:

HI data replay is failing because I forget to use the "repacked" raw data format for the UPC era:
https://github.com/cms-sw/cmssw/issues/46186
This PR fixes that

#### PR validation:

none.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Will need a 14_1_X backport

