### PR TITLE
Move "hybrid" tau production from nano to mini step

### DIFF
--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -250,8 +250,8 @@ def nanoAOD_customizeCommon(process):
 
     nanoAOD_tau_switch = cms.PSet(
         idsToAdd = cms.vstring(),
-        addUParTInfo = cms.bool(True),
-        addPNet = cms.bool(True)
+        addUParTInfo = cms.bool(False),
+        addPNet = cms.bool(False)
     )
     (run2_nanoAOD_106Xv2 | run3_nanoAOD_122).toModify(
         nanoAOD_tau_switch, idsToAdd = ["deepTau2018v2p5"]
@@ -259,10 +259,16 @@ def nanoAOD_customizeCommon(process):
         process, lambda p : nanoAOD_addTauIds(p, nanoAOD_tau_switch.idsToAdd.value())
     )
     
-    # Don't add Unified Tagger for PUPPI jets for Run 2 (as different PUPPI tune
-    # and base jet algorithm) or early Run 3 eras
+    # Add Unified Tagger for CHS jets (PNet) for Run 2 and early Run 3 eras,
+    # but don't add Unified Tagger for PUPPI jets (as different PUPPI tune
+    # and base jet algorithm)
     (run3_nanoAOD_122 | run3_nanoAOD_124 | run2_nanoAOD_106Xv2).toModify(
-        nanoAOD_tau_switch, addUParTInfo = False
+        nanoAOD_tau_switch, addPNet = True
+    )
+    # Add Unified Taggers for Run 3 pre 142X (pre v15) era (Unified taggers 
+    # are already added to slimmedTaus in miniAOD for newer eras)
+    run3_nanoAOD_pre142X.toModify(
+        nanoAOD_tau_switch, addPNet = True, addUParTInfo = True
     )
     
     # Add Unified Tagger For CHS Jets (PNet 2023)

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -476,6 +476,101 @@ def miniAOD_customizeCommon(process):
     process.load("RecoEgamma.EgammaTools.slimmedEgammaHGC_cff")
     phase2_hgcal.toModify(task, func=lambda t: t.add(process.slimmedEgammaHGCTask))
 
+    #-- Produce a "hybrid" tau collection combining HPS-reconstructed taus with tau-tagged jets
+    # Run it at the end of customisation to ensure that jets sequences with unified taggers are already defined
+    def _addUTagToTaus(process, task,
+                       storePNetCHSjets = False,
+                       storeUParTPUPPIjets = False,
+                       addGenJet = False):
+        if not (storePNetCHSjets or storeUParTPUPPIjets): return process
+        noUpdatedTauName = 'slimmedTausNoUTag'
+        updatedTauName = ''
+        addToProcessAndTask(noUpdatedTauName, process.slimmedTaus.clone(), process, task)
+        process.pfParticleNetFromMiniAODAK4CHSCentralTagInfosSlimmedDeepFlavour.taus = noUpdatedTauName
+        process.pfParticleNetFromMiniAODAK4PuppiCentralTagInfosSlimmedPuppiWithDeepTags.taus = noUpdatedTauName
+        process.pfParticleNetFromMiniAODAK4PuppiForwardTagInfosSlimmedPuppiWithDeepTags.taus = noUpdatedTauName
+        from PhysicsTools.PatAlgos.patTauHybridProducer_cfi import patTauHybridProducer
+        if storePNetCHSjets:
+            jetCollection = 'slimmedJets'
+            TagName = 'pfParticleNetFromMiniAODAK4CHSCentralJetTags'
+            tag_prefix = 'byUTagCHS'
+            updatedTauName = 'slimmedTausWithUTagCHS'
+            # PNet tagger used for CHS jets
+            from RecoBTag.ONNXRuntime.pfParticleNetFromMiniAODAK4_cff import pfParticleNetFromMiniAODAK4CHSCentralJetTags
+            Discriminators = [TagName+":"+tag for tag in pfParticleNetFromMiniAODAK4CHSCentralJetTags.flav_names.value()]
+            # Define "hybridTau" producer
+            setattr(process, updatedTauName,
+                    patTauHybridProducer.clone(
+                        src = noUpdatedTauName,
+                        jetSource = jetCollection,
+                        dRMax = 0.4,
+                        jetPtMin = 15,
+                        jetEtaMax = 2.5,
+                        UTagLabel = TagName,
+                        UTagScoreNames = Discriminators,
+                        tagPrefix = tag_prefix,
+                        tauScoreMin = -1,
+                        vsJetMin = 0.05,
+                        checkTauScoreIsBest = False,
+                        chargeAssignmentProbMin = 0.2,
+                        addGenJetMatch = addGenJet,
+                        genJetMatch = ''
+                    ))
+            if addGenJet:
+                addToProcessAndTask('tauGenJetMatchCHSJet',
+                                    process.tauGenJetMatch.clone(src = jetCollection),
+                                    process, task)
+                getattr(process,updatedTauName).genJetMatch = 'tauGenJetMatchCHSJet'
+            if storeUParTPUPPIjets: task.add(getattr(process,updatedTauName))
+        if storeUParTPUPPIjets:
+            jetCollection = 'slimmedJetsPuppi'
+            TagName = 'pfUnifiedParticleTransformerAK4JetTags'
+            tag_prefix = 'byUTagPUPPI'
+            updatedTauName = 'slimmedTausWithUTagPUPPI' if not storePNetCHSjets else 'slimmedTausWithUTagCHSAndUTagPUPPI'
+            # Unified ParT Tagger used for PUPPI jets
+            from RecoBTag.ONNXRuntime.pfUnifiedParticleTransformerAK4JetTags_cfi import pfUnifiedParticleTransformerAK4JetTags
+            Discriminators = [TagName+":"+tag for tag in pfUnifiedParticleTransformerAK4JetTags.flav_names.value()]
+            # Define "hybridTau" producer
+            setattr(process, updatedTauName,
+                    patTauHybridProducer.clone(
+                        src = noUpdatedTauName if not storePNetCHSjets else 'slimmedTausWithUTagCHS',
+                        jetSource = jetCollection,
+                        dRMax = 0.4,
+                        jetPtMin = 15,
+                        jetEtaMax = 2.5,
+                        UTagLabel = TagName,
+                        UTagScoreNames = Discriminators,
+                        tagPrefix = tag_prefix,
+                        tauScoreMin = -1,
+                        vsJetMin = 0.05,
+                        checkTauScoreIsBest = False,
+                        chargeAssignmentProbMin = 0.2,
+                        addGenJetMatch = addGenJet,
+                        genJetMatch = ''
+                    ))
+            if addGenJet:
+                addToProcessAndTask('tauGenJetMatchPUPPIJet',
+                                    process.tauGenJetMatch.clone(src = jetCollection),
+                                    process, task)
+                getattr(process,updatedTauName).genJetMatch = 'tauGenJetMatchPUPPIJet'
+        #add "hybridTau" producer to pat-task and replace slimmedTaus
+        delattr(process, 'slimmedTaus')
+        process.slimmedTaus = getattr(process, updatedTauName).clone()
+        task.add(process.slimmedTaus)
+        return process
+
+    _uTagToTaus_switches = cms.PSet(
+        storePNetCHSjets = cms.bool(True),
+        storeUParTPUPPIjets = cms.bool(True),
+        addGenJet = cms.bool(True)
+    )
+    pp_on_AA.toModify(_uTagToTaus_switches, storePNetCHSjets=False, storeUParTPUPPIjets=False)
+    _addUTagToTaus(process, task,
+                   storePNetCHSjets = _uTagToTaus_switches.storePNetCHSjets.value(),
+                   storeUParTPUPPIjets = _uTagToTaus_switches.storePNetCHSjets.value(),
+                   addGenJet = _uTagToTaus_switches.addGenJet.value()
+    )
+
     # L1 pre-firing weights for 2016, 2017, and 2018
     from Configuration.Eras.Modifier_run2_L1prefiring_cff import run2_L1prefiring
     from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
@@ -557,6 +652,21 @@ def miniAOD_customizeOutput(out):
 def miniAOD_customizeData(process):
     from PhysicsTools.PatAlgos.tools.coreTools import runOnData
     runOnData( process, outputModules = [] )
+    # hybrid taus
+    print('removing MC dependencies for hybrid taus')
+    modulesToDel = []
+    for postfix in ['','WithUTagCHS','WithUTagPUPPI','WithUTagCHSAndUTagPUPPI']:
+        if hasattr(process,'slimmedTaus'+postfix):
+            hybridTau = getattr(process,'slimmedTaus'+postfix)
+            if hasattr(hybridTau,'addGenJetMatch'):
+                hybridTau.addGenJetMatch = False
+                genJetModule = hybridTau.genJetMatch.getModuleLabel()
+                if not genJetModule in modulesToDel:
+                    modulesToDel.append(genJetModule)
+                hybridTau.genJetMatch = ''
+    for module in modulesToDel:
+        if hasattr(process,module): delattr(process,module)
+
     process.load("RecoPPS.Local.ctppsLocalTrackLiteProducer_cff")
     process.load("RecoPPS.ProtonReconstruction.ctppsProtons_cff")
     process.load("Geometry.VeryForwardGeometry.geometryRPFromDB_cfi")

--- a/TauAnalysis/MCEmbeddingTools/test/run_2016postVFPUL_workflow_tests.sh
+++ b/TauAnalysis/MCEmbeddingTools/test/run_2016postVFPUL_workflow_tests.sh
@@ -119,7 +119,7 @@ cmsDriver.py \
     --step NANO \
     --data \
     --conditions auto:run2_data \
-    --era Run2_2016,run2_nanoAOD_106Xv2 \
+    --era Run2_2016 \
     --eventcontent NANOAODSIM \
     --datatier NANOAODSIM \
     --customise TauAnalysis/MCEmbeddingTools/customisers.customiseNanoAOD \

--- a/TauAnalysis/MCEmbeddingTools/test/run_2016preVFPUL_workflow_tests.sh
+++ b/TauAnalysis/MCEmbeddingTools/test/run_2016preVFPUL_workflow_tests.sh
@@ -119,7 +119,7 @@ cmsDriver.py \
     --step NANO \
     --data \
     --conditions auto:run2_data \
-    --era Run2_2016_HIPM,run2_nanoAOD_106Xv2 \
+    --era Run2_2016_HIPM \
     --eventcontent NANOAODSIM \
     --datatier NANOAODSIM \
     --customise TauAnalysis/MCEmbeddingTools/customisers.customiseNanoAOD \

--- a/TauAnalysis/MCEmbeddingTools/test/run_2017UL_workflow_tests.sh
+++ b/TauAnalysis/MCEmbeddingTools/test/run_2017UL_workflow_tests.sh
@@ -119,7 +119,7 @@ cmsDriver.py \
     --step NANO \
     --data \
     --conditions auto:run2_data \
-    --era Run2_2017,run2_nanoAOD_106Xv2 \
+    --era Run2_2017 \
     --eventcontent NANOAODSIM \
     --datatier NANOAODSIM \
     --customise TauAnalysis/MCEmbeddingTools/customisers.customiseNanoAOD \

--- a/TauAnalysis/MCEmbeddingTools/test/run_2018UL_workflow_tests.sh
+++ b/TauAnalysis/MCEmbeddingTools/test/run_2018UL_workflow_tests.sh
@@ -119,7 +119,7 @@ cmsDriver.py \
     --step NANO \
     --data \
     --conditions auto:run2_data \
-    --era Run2_2018,run2_nanoAOD_106Xv2 \
+    --era Run2_2018 \
     --eventcontent NANOAODSIM \
     --datatier NANOAODSIM \
     --customise TauAnalysis/MCEmbeddingTools/customisers.customiseNanoAOD \

--- a/Validation/RecoTau/src/TauValidationMiniAOD.cc
+++ b/Validation/RecoTau/src/TauValidationMiniAOD.cc
@@ -621,7 +621,8 @@ void TauValidationMiniAOD::analyze(const edm::Event &iEvent, const edm::EventSet
         string currentDiscriminator = it.getParameter<string>("discriminator");
         double selectionCut = it.getParameter<double>("selectionCut");
         summaryMap.find("Den")->second->Fill(j);
-        if (matchedTau->tauID(currentDiscriminator) >= selectionCut)
+        if (matchedTau->isTauIDAvailable(currentDiscriminator) &&
+            matchedTau->tauID(currentDiscriminator) >= selectionCut)
           summaryMap.find("Num")->second->Fill(j);
         j = j + 1;
       }
@@ -631,7 +632,8 @@ void TauValidationMiniAOD::analyze(const edm::Event &iEvent, const edm::EventSet
       if (extensionName_.compare(qcd) == 0 || extensionName_.compare(real_data) == 0 ||
           extensionName_.compare(ztt) == 0) {
         // vsJet/tight
-        if (matchedTau->tauID("byTightDeepTau2018v2p5VSjet") >= 0.5) {
+        if (matchedTau->isTauIDAvailable("byTightDeepTau2018v2p5VSjet") &&
+            matchedTau->tauID("byTightDeepTau2018v2p5VSjet") >= 0.5) {
           ptTightvsJetMap.find("")->second->Fill(matchedTau->pt());
           etaTightvsJetMap.find("")->second->Fill(matchedTau->eta());
           phiTightvsJetMap.find("")->second->Fill(matchedTau->phi());
@@ -639,7 +641,8 @@ void TauValidationMiniAOD::analyze(const edm::Event &iEvent, const edm::EventSet
           puTightvsJetMap.find("")->second->Fill(pvHandle->size());
         }
         // vsJet/medium
-        if (matchedTau->tauID("byMediumDeepTau2018v2p5VSjet") >= 0.5) {
+        if (matchedTau->isTauIDAvailable("byMediumDeepTau2018v2p5VSjet") &&
+            matchedTau->tauID("byMediumDeepTau2018v2p5VSjet") >= 0.5) {
           ptMediumvsJetMap.find("")->second->Fill(matchedTau->pt());
           etaMediumvsJetMap.find("")->second->Fill(matchedTau->eta());
           phiMediumvsJetMap.find("")->second->Fill(matchedTau->phi());
@@ -647,7 +650,8 @@ void TauValidationMiniAOD::analyze(const edm::Event &iEvent, const edm::EventSet
           puMediumvsJetMap.find("")->second->Fill(pvHandle->size());
         }
         // vsJet/loose
-        if (matchedTau->tauID("byLooseDeepTau2018v2p5VSjet") >= 0.5) {
+        if (matchedTau->isTauIDAvailable("byLooseDeepTau2018v2p5VSjet") &&
+            matchedTau->tauID("byLooseDeepTau2018v2p5VSjet") >= 0.5) {
           ptLoosevsJetMap.find("")->second->Fill(matchedTau->pt());
           etaLoosevsJetMap.find("")->second->Fill(matchedTau->eta());
           phiLoosevsJetMap.find("")->second->Fill(matchedTau->phi());
@@ -659,7 +663,8 @@ void TauValidationMiniAOD::analyze(const edm::Event &iEvent, const edm::EventSet
       if (extensionName_.compare(real_eledata) == 0 || extensionName_.compare(zee) == 0 ||
           extensionName_.compare(ztt) == 0) {
         // vsEle/tight
-        if (matchedTau->tauID("byTightDeepTau2018v2p5VSe") >= 0.5) {
+        if (matchedTau->isTauIDAvailable("byTightDeepTau2018v2p5VSe") &&
+            matchedTau->tauID("byTightDeepTau2018v2p5VSe") >= 0.5) {
           ptTightvsEleMap.find("")->second->Fill(matchedTau->pt());
           etaTightvsEleMap.find("")->second->Fill(matchedTau->eta());
           phiTightvsEleMap.find("")->second->Fill(matchedTau->phi());
@@ -667,7 +672,8 @@ void TauValidationMiniAOD::analyze(const edm::Event &iEvent, const edm::EventSet
           puTightvsEleMap.find("")->second->Fill(pvHandle->size());
         }
         // vsEle/medium
-        if (matchedTau->tauID("byMediumDeepTau2018v2p5VSe") >= 0.5) {
+        if (matchedTau->isTauIDAvailable("byMediumDeepTau2018v2p5VSe") &&
+            matchedTau->tauID("byMediumDeepTau2018v2p5VSe") >= 0.5) {
           ptMediumvsEleMap.find("")->second->Fill(matchedTau->pt());
           etaMediumvsEleMap.find("")->second->Fill(matchedTau->eta());
           phiMediumvsEleMap.find("")->second->Fill(matchedTau->phi());
@@ -675,7 +681,8 @@ void TauValidationMiniAOD::analyze(const edm::Event &iEvent, const edm::EventSet
           puMediumvsEleMap.find("")->second->Fill(pvHandle->size());
         }
         // vsEle/loose
-        if (matchedTau->tauID("byLooseDeepTau2018v2p5VSe") >= 0.5) {
+        if (matchedTau->isTauIDAvailable("byLooseDeepTau2018v2p5VSe") &&
+            matchedTau->tauID("byLooseDeepTau2018v2p5VSe") >= 0.5) {
           ptLoosevsEleMap.find("")->second->Fill(matchedTau->pt());
           etaLoosevsEleMap.find("")->second->Fill(matchedTau->eta());
           phiLoosevsEleMap.find("")->second->Fill(matchedTau->phi());
@@ -687,7 +694,8 @@ void TauValidationMiniAOD::analyze(const edm::Event &iEvent, const edm::EventSet
       if (extensionName_.compare(real_mudata) == 0 || extensionName_.compare(zmm) == 0 ||
           extensionName_.compare(ztt) == 0) {
         // vsMuo/tight
-        if (matchedTau->tauID("byTightDeepTau2018v2p5VSmu") >= 0.5) {
+        if (matchedTau->isTauIDAvailable("byTightDeepTau2018v2p5VSmu") &&
+            matchedTau->tauID("byTightDeepTau2018v2p5VSmu") >= 0.5) {
           ptTightvsMuoMap.find("")->second->Fill(matchedTau->pt());
           etaTightvsMuoMap.find("")->second->Fill(matchedTau->eta());
           phiTightvsMuoMap.find("")->second->Fill(matchedTau->phi());
@@ -695,7 +703,8 @@ void TauValidationMiniAOD::analyze(const edm::Event &iEvent, const edm::EventSet
           puTightvsMuoMap.find("")->second->Fill(pvHandle->size());
         }
         // vsMuo/medium
-        if (matchedTau->tauID("byMediumDeepTau2018v2p5VSmu") >= 0.5) {
+        if (matchedTau->isTauIDAvailable("byMediumDeepTau2018v2p5VSmu") &&
+            matchedTau->tauID("byMediumDeepTau2018v2p5VSmu") >= 0.5) {
           ptMediumvsMuoMap.find("")->second->Fill(matchedTau->pt());
           etaMediumvsMuoMap.find("")->second->Fill(matchedTau->eta());
           phiMediumvsMuoMap.find("")->second->Fill(matchedTau->phi());
@@ -703,7 +712,8 @@ void TauValidationMiniAOD::analyze(const edm::Event &iEvent, const edm::EventSet
           puMediumvsMuoMap.find("")->second->Fill(pvHandle->size());
         }
         // vsMuo/loose
-        if (matchedTau->tauID("byLooseDeepTau2018v2p5VSmu") >= 0.5) {
+        if (matchedTau->isTauIDAvailable("byLooseDeepTau2018v2p5VSmu") &&
+            matchedTau->tauID("byLooseDeepTau2018v2p5VSmu") >= 0.5) {
           ptLoosevsMuoMap.find("")->second->Fill(matchedTau->pt());
           etaLoosevsMuoMap.find("")->second->Fill(matchedTau->eta());
           phiLoosevsMuoMap.find("")->second->Fill(matchedTau->phi());


### PR DESCRIPTION
#### PR description:

This PR moves production of hybrid-taus, i.e. collection of tau candidates reconstructed by the HPS algorithm and jet tagged by unified jet taggers as tau-like but not reconstructed by HPS, from nanoAOD to miniAOD step. This movement unfies tau information available in both mini and nano data tiers. 

#### PR validation:

Tested with custom re-mini+nano and with nano workflows.
Matrix tests (limited) successful.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport is not planned.
