### PR TITLE
Synchronize L1T L1TReEmulFromRAW and Repack_Full configurations

### DIFF
--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_Full_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_Full_cff.py
@@ -90,8 +90,10 @@ simCscTriggerPrimitiveDigis.CSCComparatorDigiProducer = 'unpackCSC:MuonCSCCompar
 simCscTriggerPrimitiveDigis.CSCWireDigiProducer       = 'unpackCSC:MuonCSCWireDigi'
 
 simTwinMuxDigis.RPC_Source         = 'unpackRPCTwinMux'
-simTwinMuxDigis.DTDigi_Source      = "unpackTwinMux:PhIn"
-simTwinMuxDigis.DTThetaDigi_Source = "unpackTwinMux:ThIn"
+#simTwinMuxDigis.DTDigi_Source      = "unpackTwinMux:PhIn"
+#simTwinMuxDigis.DTThetaDigi_Source = "unpackTwinMux:ThIn" #technically correct, but L1 emulation does not seem to favor this?
+simTwinMuxDigis.DTDigi_Source = 'simDtTriggerPrimitiveDigis'
+simTwinMuxDigis.DTThetaDigi_Source = 'simDtTriggerPrimitiveDigis'
 
 (stage2L1Trigger & run3_GEM).toModify(simMuonGEMPadDigis,
     InputCollection = 'unpackGEM'
@@ -105,7 +107,8 @@ for b in cutlist:
 # -----------------------------------------------------------
 
 # BMTF
-simBmtfDigis.DTDigi_Source       = "simTwinMuxDigis"
+#simBmtfDigis.DTDigi_Source =     = "simTwinMuxDigis" #used previously, but removed in favor of rem-emul favored unpacked inputs
+simBmtfDigis.DTDigi_Source       = "unpackBmtf"
 simBmtfDigis.DTDigi_Theta_Source = "unpackBmtf"
 
 # OMTF
@@ -123,6 +126,10 @@ stage2L1Trigger_2017.toModify(simOmtfDigis,
 # EMTF
 simEmtfDigis.CSCInput            = "unpackEmtf"
 simEmtfDigis.RPCInput            = 'unpackRPC'
+simEmtfDigis.CPPFInput           = cms.InputTag('unpackEmtf')
+simEmtfDigis.GEMEnable           = cms.bool(False)
+simEmtfDigis.GEMInput            = cms.InputTag('unpackGEM')
+simEmtfDigis.CPPFEnable          = cms.bool(True)
 
 # Calo Layer-1
 simCaloStage2Layer1Digis.ecalToken = 'unpackEcal:EcalTriggerPrimitives'


### PR DESCRIPTION
#### PR description:

This PR is designed to synchronize the L1T favored re-emulation customization: https://github.com/cms-sw/cmssw/blob/master/L1Trigger/Configuration/python/customiseReEmul.py

and the Repack_Full configuration: https://github.com/cms-sw/cmssw/blob/master/Configuration/StandardSequences/python/SimL1EmulatorRepack_Full_cff.py

No substantive changes are expected from this

@eyigitba FYI

#### PR validation:

PR tests for repacks will be checked

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not a backport