### PR TITLE
[LLVM Analyzer] Fix use-after-free warning in VariableComputerTest::VariableComputerTest

### DIFF
--- a/PhysicsTools/UtilAlgos/src/CachingVariable.cc
+++ b/PhysicsTools/UtilAlgos/src/CachingVariable.cc
@@ -53,13 +53,12 @@ VariableComputer::VariableComputer(const CachingVariable::CachingVariableFactory
 }
 
 void VariableComputer::declare(std::string var, edm::ConsumesCollector& iC) {
-  std::string aName = name_ + separator_ + var;
-  ComputedVariable* newVar = new ComputedVariable(method_, aName, arg_.iConfig, this, iC);
   if (iCompute_.find(var) != iCompute_.end()) {
     edm::LogError("VariableComputer") << "redeclaring: " << var << " skipping.";
-    delete newVar;
     return;
   }
+  std::string aName = name_ + separator_ + var;
+  ComputedVariable* newVar = new ComputedVariable(method_, aName, arg_.iConfig, this, iC);
   iCompute_[var] = newVar;
   arg_.m.insert(std::make_pair(aName, newVar));
 }


### PR DESCRIPTION
#### PR description:

LLVM Analyzer reports use-after-free in `VariableComputerTest::VariableComputerTest`, see e.g. [this](https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_14_2_X_2024-09-29-0000/el8_amd64_gcc12/llvm-analysis/report-8d81fe.html#EndPath). The warning looks false-positive. This change will (hopefully) fix it

#### PR validation:

Bot tests
