### PR TITLE
More of the DataProxy to ESProductResolver renaming

### DIFF
--- a/FWCore/Concurrency/scripts/edmStreamStallGrapher.py
+++ b/FWCore/Concurrency/scripts/edmStreamStallGrapher.py
@@ -603,7 +603,7 @@ def plotPerStreamAboveFirstAndPrepareStack(points, allStackTimes, ax, stream, he
             allStackTimes[color].extend(theTS*(nthreads-threadOffset))
 
 #----------------------------------------------
-# The same ES module can have multiple Proxies running concurrently
+# The same ES module can have multiple Resolvers running concurrently
 #   so we need to reference count the names of the active modules
 class RefCountSet(set):
   def __init__(self):

--- a/FWCore/Framework/interface/CallbackBase.h
+++ b/FWCore/Framework/interface/CallbackBase.h
@@ -68,7 +68,7 @@ namespace edm {
     class CallbackBase {
     public:
       CallbackBase(T* iProd, std::shared_ptr<TProduceFunc> iProduceFunc, unsigned int iID, const TDecorator& iDec)
-          : proxyData_{},
+          : resolverData_{},
             producer_(iProd),
             callingContext_(&iProd->description(), iID),
             produceFunction_(std::move(iProduceFunc)),
@@ -127,13 +127,13 @@ namespace edm {
                     try {
                       convertException::wrap([this, &serviceToken, &record, &eventSetupImpl, &produceFunctor] {
                         ESModuleCallingContext const& context = callingContext_;
-                        auto proxies = getTokenIndices();
+                        auto resolvers = getTokenIndices();
                         if (postMayGetResolvers_) {
-                          proxies = &((*postMayGetResolvers_).front());
+                          resolvers = &((*postMayGetResolvers_).front());
                         }
                         TRecord rec;
                         ESParentContext pc{&context};
-                        rec.setImpl(record, transitionID(), proxies, eventSetupImpl, &pc);
+                        rec.setImpl(record, transitionID(), resolvers, eventSetupImpl, &pc);
                         ServiceRegistry::Operate operate(serviceToken.lock());
                         record->activityRegistry()->preESModuleSignal_.emit(record->key(), context);
                         struct EndGuard {
@@ -202,12 +202,12 @@ namespace edm {
 
       template <class DataT>
       void holdOntoPointer(DataT* iData) {
-        proxyData_[produce::find_index<TReturn, DataT>::value] = iData;
+        resolverData_[produce::find_index<TReturn, DataT>::value] = iData;
       }
 
       template <class RemainingContainerT, class DataT, class ProductsT>
       void setData(ProductsT& iProducts) {
-        DataT* temp = reinterpret_cast<DataT*>(proxyData_[produce::find_index<TReturn, DataT>::value]);
+        DataT* temp = reinterpret_cast<DataT*>(resolverData_[produce::find_index<TReturn, DataT>::value]);
         if (nullptr != temp) {
           moveFromTo(iProducts, *temp);
         }
@@ -243,14 +243,14 @@ namespace edm {
 
       void prefetchNeededDataAsync(WaitingTaskHolder task,
                                    EventSetupImpl const* iImpl,
-                                   ESResolverIndex const* proxies,
+                                   ESResolverIndex const* resolvers,
                                    ServiceToken const& token) const noexcept {
         auto recs = producer_->getTokenRecordIndices(id_);
         auto n = producer_->numberOfTokenIndices(id_);
         for (size_t i = 0; i != n; ++i) {
           auto rec = iImpl->findImpl(recs[i]);
           if (rec) {
-            rec->prefetchAsync(task, proxies[i], iImpl, token, ESParentContext{&callingContext_});
+            rec->prefetchAsync(task, resolvers[i], iImpl, token, ESParentContext{&callingContext_});
           }
         }
       }
@@ -264,7 +264,7 @@ namespace edm {
         return static_cast<bool>(postMayGetResolvers_);
       }
 
-      std::array<void*, produce::size<TReturn>::value> proxyData_;
+      std::array<void*, produce::size<TReturn>::value> resolverData_;
       std::optional<std::vector<ESResolverIndex>> postMayGetResolvers_;
       propagate_const<T*> producer_;
       ESModuleCallingContext callingContext_;

--- a/FWCore/Framework/interface/CallbackExternalWork.h
+++ b/FWCore/Framework/interface/CallbackExternalWork.h
@@ -172,13 +172,13 @@ namespace edm {
                         try {
                           convertException::wrap([this, &holder, &serviceToken, &record, &eventSetupImpl] {
                             ESModuleCallingContext const& context = Base::callingContext();
-                            auto proxies = Base::getTokenIndices();
+                            auto resolvers = Base::getTokenIndices();
                             if (Base::postMayGetResolvers()) {
-                              proxies = &((*Base::postMayGetResolvers()).front());
+                              resolvers = &((*Base::postMayGetResolvers()).front());
                             }
                             TRecord rec;
                             edm::ESParentContext pc{&context};
-                            rec.setImpl(record, Base::transitionID(), proxies, eventSetupImpl, &pc);
+                            rec.setImpl(record, Base::transitionID(), resolvers, eventSetupImpl, &pc);
                             ServiceRegistry::Operate operate(serviceToken.lock());
                             record->activityRegistry()->preESModuleAcquireSignal_.emit(record->key(), context);
                             struct EndGuard {

--- a/FWCore/Framework/interface/ESProducer.h
+++ b/FWCore/Framework/interface/ESProducer.h
@@ -16,11 +16,11 @@
   set at run-time instead of compile time can be obtained by inheriting from ESProductResolverFactoryProducer instead.)
 
     If only one algorithm is being encapsulated then the user needs to
-      1) add a method name 'produce' to the class.  The 'produce' takes as its argument a const reference
+      1) add a method named 'produce' to the class.  The 'produce' takes as its argument a const reference
          to the record that is to hold the data item being produced.  If only one data item is being produced,
          the 'produce' method must return either an 'std::unique_ptr' or 'std::shared_ptr' to the object being
          produced.  (The choice depends on if the EventSetup or the ESProducer is managing the lifetime of
-         the object).  If multiple items are being Produced they the 'produce' method must return an
+         the object).  If multiple items are being Produced then the 'produce' method must return an
          ESProducts<> object which holds all of the items.
       2) add 'setWhatProduced(this);' to their classes constructor
 

--- a/FWCore/Framework/interface/ESProductResolver.h
+++ b/FWCore/Framework/interface/ESProductResolver.h
@@ -1,13 +1,13 @@
+// -*- C++ -*-
 #ifndef FWCore_Framework_ESProductResolver_h
 #define FWCore_Framework_ESProductResolver_h
-// -*- C++ -*-
 //
 // Package:     Framework
 // Class  :     ESProductResolver
 //
 /**\class edm::eventsetup::ESProductResolver
 
- Description: Base class for data Proxies held by a EventSetupRecord
+ Description: Base class for product resolvers held by a EventSetupRecord
 
  Usage:
     This class defines the interface used to handle retrieving data from an

--- a/FWCore/Framework/interface/ESProductResolverFactoryProducer.h
+++ b/FWCore/Framework/interface/ESProductResolverFactoryProducer.h
@@ -1,13 +1,13 @@
+// -*- C++ -*-
 #ifndef Framework_ESProductResolverFactoryProducer_h
 #define Framework_ESProductResolverFactoryProducer_h
-// -*- C++ -*-
 //
 // Package:     Framework
 // Class  :     ESProductResolverFactoryProducer
 //
-/**\class ESProductResolverFactoryProducer ESProductResolverFactoryProducer.h FWCore/Framework/interface/ESProductResolverFactoryProducer.h
+/**\class edm::ESProductResolverFactoryProducer
 
- Description: An EventSetup algorithmic Provider that manages Factories of Proxies
+ Description: An EventSetup algorithmic Provider that manages Factories of Resolvers
 
  Usage:
     This class is used when the algorithms in the EventSetup that are to be run on demand are encapsulated
@@ -15,7 +15,7 @@
   directly in the Provider (see ESProducer for such an implemenation).
 
     Users inherit from this class and then call the 'registerFactory' method in their class' constructor
-  in order to get their Proxies registered.  For most users, the already available templated Factory classes
+  in order to get their Resolvers registered.  For most users, the already available templated Factory classes
   should suffice and therefore they should not need to create their own Factories.
 
 Example: register one Factory that creates a resolver that takes no arguments

--- a/FWCore/Framework/interface/ESProductResolverProvider.h
+++ b/FWCore/Framework/interface/ESProductResolverProvider.h
@@ -1,6 +1,6 @@
+// -*- C++ -*-
 #ifndef FWCore_Framework_ESProductResolverProvider_h
 #define FWCore_Framework_ESProductResolverProvider_h
-// -*- C++ -*-
 //
 // Package:     Framework
 // Class  :     ESProductResolverProvider
@@ -22,7 +22,7 @@
     CondDBESSource is the main such class) then the registerResolvers
     function must be overridden. For the same EventSetupRecordKey, the
     vector returned should contain the same DataKeys in the same order for
-    all the different iovIndexes. DataProxies associated with the same
+    all the different iovIndexes. ESProductResolver's associated with the same
     EventSetupRecordKey should have caches that use different memory, but
     other than that they should also be the same.
 
@@ -33,7 +33,7 @@
     All other functions are intended for use by the Framework or tests
     and should not be called in classes derived from ESProductResolverProvider.
     They are primarily used when initializing the EventSetup system
-    so the DataProxies are available for use when needed.
+    so the ESProductResolver's are available for use when needed.
 */
 //
 // Author:      Chris Jones

--- a/FWCore/Framework/interface/ESProductResolverTemplate.h
+++ b/FWCore/Framework/interface/ESProductResolverTemplate.h
@@ -1,13 +1,13 @@
+// -*- C++ -*-
 #ifndef FWCore_Framework_ESProductResolverTemplate_h
 #define FWCore_Framework_ESProductResolverTemplate_h
-// -*- C++ -*-
 //
 // Package:     Framework
 // Class  :     ESProductResolverTemplate
 //
-/**\class ESProductResolverTemplate ESProductResolverTemplate.h FWCore/Framework/interface/ESProductResolverTemplate.h
+/**\class edm::eventsetup::ESProductResolverTemplate
 
- Description: A ESProductResolver base class which allows one to write type-safe proxies
+ Description: A ESProductResolver base class which allows one to write type-safe resolvers
 
               Note that ESProductResolver types that inherit from this are not allowed
               to get data from the EventSetup (they cannot consume anything).

--- a/FWCore/Framework/interface/ESSourceConcurrentProductResolverTemplate.h
+++ b/FWCore/Framework/interface/ESSourceConcurrentProductResolverTemplate.h
@@ -1,13 +1,13 @@
+// -*- C++ -*-
 #ifndef FWCore_Framework_ESSourceConcurrentESProductResolverTemplate_h
 #define FWCore_Framework_ESSourceConcurrentESProductResolverTemplate_h
-// -*- C++ -*-
 //
 // Package:     FWCore/Framework
 // Class  :     ESSourceConcurrentESProductResolverTemplate
 //
-/**\class ESSourceConcurrentESProductResolverTemplate ESSourceConcurrentESProductResolverTemplate.h "FWCore/Framework/interface/ESSourceConcurrentESProductResolverTemplate.h"
+/**\class edm::eventsetup::ESSourceConcurrentESProductResolverTemplate
 
- Description: An ESSource specific ESProductResolver which is type safe and can run concurrently with other DataProxies from the same ESSource.
+ Description: An ESSource specific ESProductResolver which is type safe and can run concurrently with other ESProductResolvers from the same ESSource.
 
  Usage:
     Inherit from this class and override

--- a/FWCore/Framework/interface/ESSourceProductResolverBase.h
+++ b/FWCore/Framework/interface/ESSourceProductResolverBase.h
@@ -1,16 +1,17 @@
+// -*- C++ -*-
 #ifndef FWCore_Framework_ESSourceProductResolverBase_h
 #define FWCore_Framework_ESSourceProductResolverBase_h
-// -*- C++ -*-
 //
 // Package:     FWCore/Framework
 // Class  :     ESSourceProductResolverBase
 //
-/**\class ESSourceProductResolverBase ESSourceProductResolverBase.h "FWCore/Framework/interface/ESSourceProductResolverBase.h"
+/**\class edm::eventsetup::ESSourceProductResolverBase
 
- Description: Base class for DataProxies for ESSources that can be specialized based on concurrency needs
+ Description: Base class for ESProductResolvers for ESSources that can be specialized based on concurrency needs
 
  Usage:
-    The ESSourceProductResolverBase provides the bases for DataProxies needed for ESSources. It allows customization of synchronization needs via the use of template parameters.
+    The ESSourceProductResolverBase provides the bases for ProductResolvers needed for ESSources.
+    It allows customization of synchronization needs via the use of template parameters.
 
     NOTE: if inheriting classes override `void invalidateCache()` they must be sure to call this classes
     implementation as part of the call.

--- a/FWCore/Framework/interface/ESSourceProductResolverConcurrentBase.h
+++ b/FWCore/Framework/interface/ESSourceProductResolverConcurrentBase.h
@@ -1,16 +1,16 @@
+// -*- C++ -*-
 #ifndef FWCore_Framework_ESSourceProductResolverConcurrentBase_h
 #define FWCore_Framework_ESSourceProductResolverConcurrentBase_h
-// -*- C++ -*-
 //
 // Package:     FWCore/Framework
 // Class  :     ESSourceProductResolverConcurrentBase
 //
-/**\class ESSourceProductResolverConcurrentBase ESSourceProductResolverConcurrentBase.h "FWCore/Framework/interface/ESSourceProductResolverConcurrentBase.h"
+/**\class edm::eventsetup::ESSourceProductResolverConcurrentBase
 
- Description: Base class for DataProxies for ESSources that require no synchronization
+ Description: Base class for ESProductResolver for ESSources that require no synchronization
 
  Usage:
-    The ESSourceProductResolverConcurrentBase allows DataProxies from the same ESSource to be called concurrently.
+    The ESSourceProductResolverConcurrentBase allows ESProductResolvers from the same ESSource to be called concurrently.
 
     NOTE: if inheriting classes override `void invalidateCache()` they must be sure to call this classes
     implementation as part of the call.

--- a/FWCore/Framework/interface/ESSourceProductResolverNonConcurrentBase.h
+++ b/FWCore/Framework/interface/ESSourceProductResolverNonConcurrentBase.h
@@ -1,16 +1,16 @@
+// -*- C++ -*-
 #ifndef FWCore_Framework_ESSourceProductResolverNonConcurrentBase_h
 #define FWCore_Framework_ESSourceProductResolverNonConcurrentBase_h
-// -*- C++ -*-
 //
 // Package:     FWCore/Framework
 // Class  :     ESSourceProductResolverNonConcurrentBase
 //
-/**\class ESSourceProductResolverNonConcurrentBase ESSourceProductResolverNonConcurrentBase.h "FWCore/Framework/interface/ESSourceProductResolverNonConcurrentBase.h"
+/**\class edm::eventsetup::ESSourceProductResolverNonConcurrentBase
 
- Description: Base class for DataProxies for ESSources that require synchronization
+ Description: Base class for ESProductResolvers for ESSources that require synchronization
 
  Usage:
-    The ESSourceProductResolverNonConcurrentBase uses a SerialTaskQueue to serialize all DataProxies for the ESSource and a
+    The ESSourceProductResolverNonConcurrentBase uses a SerialTaskQueue to serialize all ESProductResolvers for the ESSource and a
     std::mutex to protect from concurrent calls to a ESProductResolver and the ESSource itself. Such concurrent calls
     can happen if concurrent LuminosityBlocks are being used.
 

--- a/FWCore/Framework/interface/EventSetupProvider.h
+++ b/FWCore/Framework/interface/EventSetupProvider.h
@@ -1,6 +1,6 @@
+// -*- C++ -*-
 #ifndef FWCore_Framework_EventSetupProvider_h
 #define FWCore_Framework_EventSetupProvider_h
-// -*- C++ -*-
 //
 // Package:     Framework
 // Class:      EventSetupProvider
@@ -83,7 +83,7 @@ namespace edm {
 
       void finishConfiguration(NumberOfConcurrentIOVs const&, bool& hasNonconcurrentFinder);
 
-      ///Used when we need to force a Record to reset all its proxies
+      ///Used when we need to force a Record to reset all its resolvers
       void resetRecordPlusDependentRecords(EventSetupRecordKey const&);
 
       ///Used when testing that all code properly updates on IOV changes of all Records

--- a/FWCore/Framework/interface/EventSetupRecord.h
+++ b/FWCore/Framework/interface/EventSetupRecord.h
@@ -16,7 +16,7 @@
  use to get data associated with a record.
 
  This class holds a pointer to an EventSetupRecordImpl class, which
- is the class used to get the DataProxies associated with a given Record.
+ is the class used to get the ESProductResolvers associated with a given Record.
  It also has a pointer to the EventSetupImpl which is used to lookup
  dependent records in DependentRecordImplementation.
 

--- a/FWCore/Framework/interface/EventSetupRecordImpl.h
+++ b/FWCore/Framework/interface/EventSetupRecordImpl.h
@@ -10,17 +10,17 @@
  Description: Base class for all Records in an EventSetup.  Holds data with the same lifetime.
 
  Usage:
-This class contains the Proxies that make up a given Record.  It
+This class contains the Resolvers that make up a given Record.  It
 is designed to be reused time after time, rather than it being
 destroyed and a new one created every time a new Record is
-required.  Proxies can only be added by the EventSetupRecordProvider class which
+required.  Resolvers can only be added by the EventSetupRecordProvider class which
 uses the 'add' function to do this.
 
-When the set of  Proxies for a Records changes, i.e. a
+When the set of  Resolvers for a Records changes, i.e. a
 ESProductResolverProvider is added of removed from the system, then the
-Proxies in a Record need to be changed as appropriate.
+Resolvers in a Record need to be changed as appropriate.
 In this design it was decided the easiest way to achieve this was
-to erase all Proxies in a Record.
+to erase all Resolvers in a Record.
 
 It is important for the management of the Records that each Record
 know the ValidityInterval that represents the time over which its data is valid.
@@ -120,7 +120,7 @@ namespace edm {
 
       // The following member functions should only be used by EventSetupRecordProvider
       bool add(DataKey const& iKey, ESProductResolver* iResolver);
-      void clearProxies();
+      void clearResolvers();
 
       ///Set the cache identifier and validity interval when starting a new IOV
       ///In addition, also notify the ESProductResolver's a new IOV is starting.
@@ -147,8 +147,8 @@ namespace edm {
                                       ComponentDescription const*,
                                       DataKey const&) const;
 
-      void invalidateProxies();
-      void resetIfTransientInProxies();
+      void invalidateResolvers();
+      void resetIfTransientInResolvers();
 
     private:
       void const* getFromResolverAfterPrefetch(ESResolverIndex iResolverIndex,
@@ -164,7 +164,7 @@ namespace edm {
                              std::shared_ptr<ESHandleExceptionFactory>& whyFailedFactory) const {
         DataKey const* dataKey = nullptr;
         assert(iResolverIndex.value() > -1 and
-               iResolverIndex.value() < static_cast<ESResolverIndex::Value_t>(keysForProxies_.size()));
+               iResolverIndex.value() < static_cast<ESResolverIndex::Value_t>(keysForResolvers_.size()));
         void const* pValue = this->getFromResolverAfterPrefetch(iResolverIndex, iTransientAccessOnly, oDesc, dataKey);
         iData = reinterpret_cast<DataT const*>(pValue);
       }
@@ -181,8 +181,8 @@ namespace edm {
       CMS_THREAD_SAFE mutable ValidityInterval validity_;
 
       EventSetupRecordKey key_;
-      std::vector<DataKey> keysForProxies_;
-      std::vector<edm::propagate_const<ESProductResolver*>> proxies_;
+      std::vector<DataKey> keysForResolvers_;
+      std::vector<edm::propagate_const<ESProductResolver*>> resolvers_;
       ActivityRegistry const* activityRegistry_;
       unsigned long long cacheIdentifier_;
       unsigned int iovIndex_;

--- a/FWCore/Framework/interface/EventSetupRecordProvider.h
+++ b/FWCore/Framework/interface/EventSetupRecordProvider.h
@@ -1,6 +1,6 @@
+// -*- C++ -*-
 #ifndef FWCore_Framework_EventSetupRecordProvider_h
 #define FWCore_Framework_EventSetupRecordProvider_h
-// -*- C++ -*-
 //
 // Package:     Framework
 // Class  :     EventSetupRecordProvider
@@ -140,8 +140,8 @@ namespace edm {
          all providers have been added.  An empty map is acceptable. */
       void usePreferred(DataToPreferredProviderMap const&);
 
-      ///This will clear the cache's of all the Proxies so that next time they are called they will run
-      void resetProxies();
+      ///This will clear the cache's of all the Resolvers so that next time they are called they will run
+      void resetResolvers();
 
       std::shared_ptr<EventSetupRecordIntervalFinder const> finder() const { return get_underlying_safe(finder_); }
       std::shared_ptr<EventSetupRecordIntervalFinder>& finder() { return get_underlying_safe(finder_); }
@@ -158,11 +158,11 @@ namespace edm {
       IntervalStatus intervalStatus() const { return intervalStatus_; }
 
     protected:
-      void addProxiesToRecordHelper(edm::propagate_const<std::shared_ptr<ESProductResolverProvider>>& dpp,
-                                    DataToPreferredProviderMap const& mp) {
-        addProxiesToRecord(get_underlying_safe(dpp), mp);
+      void addResolversToRecordHelper(edm::propagate_const<std::shared_ptr<ESProductResolverProvider>>& dpp,
+                                      DataToPreferredProviderMap const& mp) {
+        addResolversToRecord(get_underlying_safe(dpp), mp);
       }
-      void addProxiesToRecord(std::shared_ptr<ESProductResolverProvider>, DataToPreferredProviderMap const&);
+      void addResolversToRecord(std::shared_ptr<ESProductResolverProvider>, DataToPreferredProviderMap const&);
 
       std::shared_ptr<EventSetupRecordIntervalFinder> swapFinder(std::shared_ptr<EventSetupRecordIntervalFinder> iNew) {
         std::swap(iNew, finder());

--- a/FWCore/Framework/src/ESProductResolverProvider.cc
+++ b/FWCore/Framework/src/ESProductResolverProvider.cc
@@ -47,19 +47,19 @@ namespace edm {
     }
 
     void ESProductResolverProvider::KeyedResolvers::insert(
-        std::vector<std::pair<DataKey, std::shared_ptr<ESProductResolver>>>&& proxies,
+        std::vector<std::pair<DataKey, std::shared_ptr<ESProductResolver>>>&& resolvers,
         std::string const& appendToDataLabel) {
       PerRecordInfo& perRecordInfo = productResolverContainer_->perRecordInfos_[recordIndex_];
       if (perRecordInfo.indexToDataKeys_ == kInvalidIndex) {
-        perRecordInfo.nDataKeys_ = proxies.size();
+        perRecordInfo.nDataKeys_ = resolvers.size();
         perRecordInfo.indexToDataKeys_ = productResolverContainer_->dataKeys_.size();
-        for (auto const& it : proxies) {
+        for (auto const& it : resolvers) {
           productResolverContainer_->dataKeys_.push_back(it.first);
         }
       } else {
-        assert(perRecordInfo.nDataKeys_ == proxies.size());
+        assert(perRecordInfo.nDataKeys_ == resolvers.size());
         unsigned index = 0;
-        for (auto const& it : proxies) {
+        for (auto const& it : resolvers) {
           if (appendToDataLabel.empty()) {
             assert(it.first == productResolverContainer_->dataKeys_[perRecordInfo.indexToDataKeys_ + index]);
           } else {
@@ -76,7 +76,7 @@ namespace edm {
       }
       assert(unInitialized());
       productResolversIndex_ = productResolverContainer_->productResolvers_.size();
-      for (auto const& it : proxies) {
+      for (auto const& it : resolvers) {
         productResolverContainer_->productResolvers_.emplace_back(it.second);
       }
     }

--- a/FWCore/Framework/src/EventSetupProvider.cc
+++ b/FWCore/Framework/src/EventSetupProvider.cc
@@ -264,7 +264,7 @@ namespace edm {
       finders_.reset();
 
       //Now handle providers since sources can also be finders and the sources can delay registering
-      // their Records and therefore could delay setting up their Proxies
+      // their Records and therefore could delay setting up their Resolvers
       psetIDToRecordKey_->clear();
       for (auto& productResolverProvider : *dataProviders_) {
         ParameterSetIDHolder psetID(productResolverProvider->description().pid_);
@@ -383,16 +383,16 @@ namespace edm {
 
       dependents.erase(std::unique(dependents.begin(), dependents.end()), dependents.end());
 
-      recProvider->resetProxies();
+      recProvider->resetResolvers();
       for (auto& d : dependents) {
-        d->resetProxies();
+        d->resetResolvers();
       }
     }
 
     void EventSetupProvider::forceCacheClear() {
       for (auto& recProvider : recordProviders_) {
         if (recProvider) {
-          recProvider->resetProxies();
+          recProvider->resetResolvers();
         }
       }
     }

--- a/FWCore/Framework/src/EventSetupRecordProvider.cc
+++ b/FWCore/Framework/src/EventSetupRecordProvider.cc
@@ -98,7 +98,7 @@ namespace edm {
     }
     void EventSetupRecordProvider::usePreferred(const DataToPreferredProviderMap& iMap) {
       using std::placeholders::_1;
-      for_all(providers_, std::bind(&EventSetupRecordProvider::addProxiesToRecordHelper, this, _1, iMap));
+      for_all(providers_, std::bind(&EventSetupRecordProvider::addResolversToRecordHelper, this, _1, iMap));
       if (1 < multipleFinders_->size()) {
         std::shared_ptr<IntersectingIOVRecordIntervalFinder> intFinder =
             make_shared_noexcept_false<IntersectingIOVRecordIntervalFinder>(key_);
@@ -113,8 +113,9 @@ namespace edm {
       multipleFinders_.reset(nullptr);
     }
 
-    void EventSetupRecordProvider::addProxiesToRecord(std::shared_ptr<ESProductResolverProvider> iProvider,
-                                                      const EventSetupRecordProvider::DataToPreferredProviderMap& iMap) {
+    void EventSetupRecordProvider::addResolversToRecord(
+        std::shared_ptr<ESProductResolverProvider> iProvider,
+        const EventSetupRecordProvider::DataToPreferredProviderMap& iMap) {
       typedef ESProductResolverProvider::KeyedResolvers ResolverList;
       typedef EventSetupRecordProvider::DataToPreferredProviderMap PreferredMap;
 
@@ -152,7 +153,7 @@ namespace edm {
       }
     }
 
-    void EventSetupRecordProvider::endIOV(unsigned int iovIndex) { recordImpls_[iovIndex].invalidateProxies(); }
+    void EventSetupRecordProvider::endIOV(unsigned int iovIndex) { recordImpls_[iovIndex].invalidateResolvers(); }
 
     void EventSetupRecordProvider::initializeForNewSyncValue() {
       intervalStatus_ = IntervalStatus::NotInitializedForSyncValue;
@@ -212,11 +213,11 @@ namespace edm {
       return intervalStatus_ != IntervalStatus::Invalid;
     }
 
-    void EventSetupRecordProvider::resetProxies() {
+    void EventSetupRecordProvider::resetResolvers() {
       // Clear out all the ESProductResolver's
       for (auto& recordImplIter : recordImpls_) {
-        recordImplIter.invalidateProxies();
-        recordImplIter.resetIfTransientInProxies();
+        recordImplIter.invalidateResolvers();
+        recordImplIter.resetIfTransientInResolvers();
       }
       // Force a new IOV to start with a new cacheIdentifier
       // on the next eventSetupForInstance call.
@@ -245,10 +246,10 @@ namespace edm {
 
     void EventSetupRecordProvider::resetRecordToResolverPointers(DataToPreferredProviderMap const& iMap) {
       for (auto& recordImplIter : recordImpls_) {
-        recordImplIter.clearProxies();
+        recordImplIter.clearResolvers();
       }
       using std::placeholders::_1;
-      for_all(providers_, std::bind(&EventSetupRecordProvider::addProxiesToRecordHelper, this, _1, iMap));
+      for_all(providers_, std::bind(&EventSetupRecordProvider::addResolversToRecordHelper, this, _1, iMap));
     }
 
     std::set<EventSetupRecordKey> EventSetupRecordProvider::dependentRecords() const { return dependencies(key()); }

--- a/FWCore/Framework/test/dependentrecord_t.cppunit.cc
+++ b/FWCore/Framework/test/dependentrecord_t.cppunit.cc
@@ -761,15 +761,15 @@ namespace {
 
     void prefetch(edm::EventSetupImpl const& iImpl) const {
       auto const& recs = this->esGetTokenRecordIndicesVector(edm::Transition::Event);
-      auto const& proxies = this->esGetTokenIndicesVector(edm::Transition::Event);
-      for (size_t i = 0; i != proxies.size(); ++i) {
+      auto const& resolvers = this->esGetTokenIndicesVector(edm::Transition::Event);
+      for (size_t i = 0; i != resolvers.size(); ++i) {
         auto rec = iImpl.findImpl(recs[i]);
         if (rec) {
           oneapi::tbb::task_group group;
           edm::FinalWaitingTask waitTask{group};
           edm::ServiceToken token;
           rec->prefetchAsync(
-              edm::WaitingTaskHolder(group, &waitTask), proxies[i], &iImpl, token, edm::ESParentContext{});
+              edm::WaitingTaskHolder(group, &waitTask), resolvers[i], &iImpl, token, edm::ESParentContext{});
           waitTask.wait();
         }
       }
@@ -785,15 +785,15 @@ namespace {
 
     void prefetch(edm::EventSetupImpl const& iImpl) const {
       auto const& recs = this->esGetTokenRecordIndicesVector(edm::Transition::Event);
-      auto const& proxies = this->esGetTokenIndicesVector(edm::Transition::Event);
-      for (size_t i = 0; i != proxies.size(); ++i) {
+      auto const& resolvers = this->esGetTokenIndicesVector(edm::Transition::Event);
+      for (size_t i = 0; i != resolvers.size(); ++i) {
         auto rec = iImpl.findImpl(recs[i]);
         if (rec) {
           oneapi::tbb::task_group group;
           edm::FinalWaitingTask waitTask{group};
           edm::ServiceToken token;
           rec->prefetchAsync(
-              edm::WaitingTaskHolder(group, &waitTask), proxies[i], &iImpl, token, edm::ESParentContext{});
+              edm::WaitingTaskHolder(group, &waitTask), resolvers[i], &iImpl, token, edm::ESParentContext{});
           waitTask.wait();
         }
       }

--- a/FWCore/Framework/test/esproducer_t.cppunit.cc
+++ b/FWCore/Framework/test/esproducer_t.cppunit.cc
@@ -53,14 +53,17 @@ namespace {
   struct DummyDataConsumerBase : public edm::EDConsumerBase {
     void prefetch(edm::EventSetupImpl const& iImpl) const {
       auto const& recs = this->esGetTokenRecordIndicesVector(edm::Transition::Event);
-      auto const& proxies = this->esGetTokenIndicesVector(edm::Transition::Event);
-      for (size_t i = 0; i != proxies.size(); ++i) {
+      auto const& resolvers = this->esGetTokenIndicesVector(edm::Transition::Event);
+      for (size_t i = 0; i != resolvers.size(); ++i) {
         auto rec = iImpl.findImpl(recs[i]);
         if (rec) {
           oneapi::tbb::task_group group;
           edm::FinalWaitingTask waitTask{group};
-          rec->prefetchAsync(
-              edm::WaitingTaskHolder(group, &waitTask), proxies[i], &iImpl, edm::ServiceToken{}, edm::ESParentContext{});
+          rec->prefetchAsync(edm::WaitingTaskHolder(group, &waitTask),
+                             resolvers[i],
+                             &iImpl,
+                             edm::ServiceToken{},
+                             edm::ESParentContext{});
           waitTask.wait();
         }
       }

--- a/FWCore/Framework/test/eventsetup_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetup_t.cppunit.cc
@@ -100,7 +100,7 @@ class testEventsetup : public CppUnit::TestFixture {
   CPPUNIT_TEST(introspectionTest);
 
   CPPUNIT_TEST(iovExtensionTest);
-  CPPUNIT_TEST(resetProxiesTest);
+  CPPUNIT_TEST(resetResolversTest);
 
   CPPUNIT_TEST_SUITE_END();
 
@@ -132,7 +132,7 @@ public:
   void introspectionTest();
 
   void iovExtensionTest();
-  void resetProxiesTest();
+  void resetResolversTest();
 
 private:
   edm::propagate_const<std::unique_ptr<edm::ThreadsController>> m_scheduler;
@@ -422,14 +422,14 @@ namespace {
 
     void prefetch(edm::EventSetupImpl const& iImpl) const {
       auto const& recs = this->esGetTokenRecordIndicesVector(edm::Transition::Event);
-      auto const& proxies = this->esGetTokenIndicesVector(edm::Transition::Event);
-      for (size_t i = 0; i != proxies.size(); ++i) {
+      auto const& resolvers = this->esGetTokenIndicesVector(edm::Transition::Event);
+      for (size_t i = 0; i != resolvers.size(); ++i) {
         auto rec = iImpl.findImpl(recs[i]);
         if (rec) {
           oneapi::tbb::task_group group;
           edm::FinalWaitingTask waitTask{group};
           rec->prefetchAsync(
-              WaitingTaskHolder(group, &waitTask), proxies[i], &iImpl, edm::ServiceToken{}, edm::ESParentContext{});
+              WaitingTaskHolder(group, &waitTask), resolvers[i], &iImpl, edm::ServiceToken{}, edm::ESParentContext{});
           waitTask.wait();
         }
       }
@@ -1165,7 +1165,7 @@ void testEventsetup::preferTest() {
 
       EventSetupProvider::PreferredProviderInfo preferInfo;
       EventSetupProvider::RecordToDataMap recordToData;
-      //default means use all proxies
+      //default means use all resolvers
       preferInfo[ComponentDescription("DummyESProductResolverProvider", "", ComponentDescription::unknownID(), false)] =
           recordToData;
       provider.setPreferredProviderInfo(preferInfo);
@@ -1201,7 +1201,7 @@ void testEventsetup::preferTest() {
 
       EventSetupProvider::PreferredProviderInfo preferInfo;
       EventSetupProvider::RecordToDataMap recordToData;
-      //default means use all proxies
+      //default means use all resolvers
       preferInfo[ComponentDescription("DummyESProductResolverProvider", "", ComponentDescription::unknownID(), false)] =
           recordToData;
       provider.setPreferredProviderInfo(preferInfo);
@@ -1370,7 +1370,7 @@ void testEventsetup::iovExtensionTest() {
   }
 }
 
-void testEventsetup::resetProxiesTest() {
+void testEventsetup::resetResolversTest() {
   SynchronousEventSetupsController controller;
   edm::ParameterSet pset = createDummyPset();
   EventSetupProvider& provider = *controller.makeProvider(pset, &activityRegistry);

--- a/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
@@ -189,12 +189,12 @@ namespace {
     explicit DummyDataConsumer(ESInputTag const& iTag) : m_token{esConsumes(iTag)} {}
 
     void prefetch(eventsetup::EventSetupRecordImpl const& iRec) const {
-      auto const& proxies = this->esGetTokenIndicesVector(edm::Transition::Event);
-      for (size_t i = 0; i != proxies.size(); ++i) {
+      auto const& resolvers = this->esGetTokenIndicesVector(edm::Transition::Event);
+      for (size_t i = 0; i != resolvers.size(); ++i) {
         oneapi::tbb::task_group group;
         edm::FinalWaitingTask waitTask{group};
         edm::ServiceToken token;
-        iRec.prefetchAsync(WaitingTaskHolder(group, &waitTask), proxies[i], nullptr, token, edm::ESParentContext{});
+        iRec.prefetchAsync(WaitingTaskHolder(group, &waitTask), resolvers[i], nullptr, token, edm::ESParentContext{});
         waitTask.wait();
       }
     }
@@ -207,12 +207,12 @@ namespace {
         : m_token{esConsumes<>(eventsetup::EventSetupRecordKey::makeKey<DummyRecord>(), iKey)} {}
 
     void prefetch(eventsetup::EventSetupRecordImpl const& iRec) const {
-      auto const& proxies = this->esGetTokenIndicesVector(edm::Transition::Event);
-      for (size_t i = 0; i != proxies.size(); ++i) {
+      auto const& resolvers = this->esGetTokenIndicesVector(edm::Transition::Event);
+      for (size_t i = 0; i != resolvers.size(); ++i) {
         oneapi::tbb::task_group group;
         edm::FinalWaitingTask waitTask{group};
         edm::ServiceToken token;
-        iRec.prefetchAsync(WaitingTaskHolder(group, &waitTask), proxies[i], nullptr, token, edm::ESParentContext{});
+        iRec.prefetchAsync(WaitingTaskHolder(group, &waitTask), resolvers[i], nullptr, token, edm::ESParentContext{});
         waitTask.wait();
       }
     }
@@ -229,7 +229,7 @@ namespace {
     edm::EventSetupImpl& eventSetupImpl_;
     CONSUMER& consumer;
     //we need the DataKeys to stick around since references are being kept to them
-    std::vector<std::pair<edm::eventsetup::DataKey, edm::eventsetup::ESProductResolver*>> proxies;
+    std::vector<std::pair<edm::eventsetup::DataKey, edm::eventsetup::ESProductResolver*>> resolvers;
     // same for ESParentContext
     ESParentContext pc_;
 
@@ -237,12 +237,12 @@ namespace {
                  EventSetupRecordKey const& iKey,
                  EventSetupImpl& iEventSetup,
                  ActivityRegistry* iRegistry,
-                 std::vector<std::pair<edm::eventsetup::DataKey, edm::eventsetup::ESProductResolver*>> iProxies)
+                 std::vector<std::pair<edm::eventsetup::DataKey, edm::eventsetup::ESProductResolver*>> iResolvers)
         : dummyRecordImpl(iKey, iRegistry),
           eventSetupImpl_(iEventSetup),
           consumer(iConsumer),
-          proxies(std::move(iProxies)) {
-      for (auto const& d : proxies) {
+          resolvers(std::move(iResolvers)) {
+      for (auto const& d : resolvers) {
         dummyRecordImpl.add(d.first, d.second);
       }
 
@@ -658,7 +658,7 @@ void testEventsetupRecord::introspectionTest() {
   CPPUNIT_ASSERT(referencedComponents.size() == 4);
   CPPUNIT_ASSERT(find(referencedDataKeys, referencedComponents, workingDataKey4) == &cd4);
 
-  dummyRecordImpl.clearProxies();
+  dummyRecordImpl.clearResolvers();
   dummyRecord.fillRegisteredDataKeys(keys);
   CPPUNIT_ASSERT(0 == keys.size());
 }
@@ -716,7 +716,7 @@ void testEventsetupRecord::resolverResetTest() {
   wdProv->createKeyedResolvers(DummyRecord::keyForClass(), 1);
   dummyProvider->add(wdProv);
 
-  //this causes the proxies to actually be placed in the Record
+  //this causes the resolvers to actually be placed in the Record
   edm::eventsetup::EventSetupRecordProvider::DataToPreferredProviderMap pref;
   dummyProvider->usePreferred(pref);
 
@@ -733,7 +733,7 @@ void testEventsetupRecord::resolverResetTest() {
   CPPUNIT_ASSERT(!workingResolver->invalidateCalled());
   CPPUNIT_ASSERT(!workingResolver->invalidateTransientCalled());
 
-  dummyProvider->resetProxies();
+  dummyProvider->resetResolvers();
   CPPUNIT_ASSERT(workingResolver->invalidateCalled());
   CPPUNIT_ASSERT(workingResolver->invalidateTransientCalled());
   consumer.prefetch(sr.dummyRecordImpl);
@@ -771,7 +771,7 @@ void testEventsetupRecord::transientTest() {
   wdProv->createKeyedResolvers(DummyRecord::keyForClass(), 1);
   dummyProvider->add(wdProv);
 
-  //this causes the proxies to actually be placed in the Record
+  //this causes the resolvers to actually be placed in the Record
   edm::eventsetup::EventSetupRecordProvider::DataToPreferredProviderMap pref;
   dummyProvider->usePreferred(pref);
 
@@ -784,7 +784,7 @@ void testEventsetupRecord::transientTest() {
   CPPUNIT_ASSERT(workingResolver->invalidateCalled() == false);
   CPPUNIT_ASSERT(workingResolver->invalidateTransientCalled() == false);
 
-  nonConstDummyRecordImpl.resetIfTransientInProxies();
+  nonConstDummyRecordImpl.resetIfTransientInResolvers();
   CPPUNIT_ASSERT(workingResolver->invalidateCalled());
   CPPUNIT_ASSERT(workingResolver->invalidateTransientCalled());
 
@@ -797,7 +797,7 @@ void testEventsetupRecord::transientTest() {
 
   hDummy = dummyRecord.getHandleImpl<edm::ESHandle>(token);
   CPPUNIT_ASSERT(&myDummy2 == &(*hDummy));
-  nonConstDummyRecordImpl.resetIfTransientInProxies();
+  nonConstDummyRecordImpl.resetIfTransientInResolvers();
   CPPUNIT_ASSERT(workingResolver->invalidateCalled() == false);
   CPPUNIT_ASSERT(workingResolver->invalidateTransientCalled() == false);
 
@@ -806,13 +806,13 @@ void testEventsetupRecord::transientTest() {
   hDummy = dummyRecord.getHandleImpl<edm::ESHandle>(token);
   hTDummy = dummyRecord.getHandleImpl<edm::ESTransientHandle>(token);
 
-  nonConstDummyRecordImpl.resetIfTransientInProxies();
+  nonConstDummyRecordImpl.resetIfTransientInResolvers();
   CPPUNIT_ASSERT(workingResolver->invalidateCalled() == false);
   CPPUNIT_ASSERT(workingResolver->invalidateTransientCalled() == false);
 
   //Ask for a transient then a non transient to be sure we don't have an ordering problem
   {
-    dummyProvider->resetProxies();
+    dummyProvider->resetResolvers();
     Dummy myDummy3;
     workingResolver->set(&myDummy3);
 
@@ -822,7 +822,7 @@ void testEventsetupRecord::transientTest() {
 
     CPPUNIT_ASSERT(&myDummy3 == &(*hDummy));
     CPPUNIT_ASSERT(&myDummy3 == &(*hTDummy));
-    nonConstDummyRecordImpl.resetIfTransientInProxies();
+    nonConstDummyRecordImpl.resetIfTransientInResolvers();
     CPPUNIT_ASSERT(workingResolver->invalidateCalled() == false);
     CPPUNIT_ASSERT(workingResolver->invalidateTransientCalled() == false);
   }

--- a/FWCore/Framework/test/fullchain_t.cppunit.cc
+++ b/FWCore/Framework/test/fullchain_t.cppunit.cc
@@ -53,14 +53,14 @@ namespace {
 
     void prefetch(edm::EventSetupImpl const& iImpl) const {
       auto const& recs = this->esGetTokenRecordIndicesVector(edm::Transition::Event);
-      auto const& proxies = this->esGetTokenIndicesVector(edm::Transition::Event);
-      for (size_t i = 0; i != proxies.size(); ++i) {
+      auto const& resolvers = this->esGetTokenIndicesVector(edm::Transition::Event);
+      for (size_t i = 0; i != resolvers.size(); ++i) {
         auto rec = iImpl.findImpl(recs[i]);
         if (rec) {
           oneapi::tbb::task_group group;
           edm::FinalWaitingTask waitTask{group};
           rec->prefetchAsync(
-              WaitingTaskHolder(group, &waitTask), proxies[i], &iImpl, edm::ServiceToken{}, edm::ESParentContext{});
+              WaitingTaskHolder(group, &waitTask), resolvers[i], &iImpl, edm::ServiceToken{}, edm::ESParentContext{});
           waitTask.wait();
         }
       }

--- a/FWCore/Integration/plugins/ESTestProducers.cc
+++ b/FWCore/Integration/plugins/ESTestProducers.cc
@@ -316,7 +316,7 @@ namespace edmtest {
   private:
     KeyedResolversVector registerResolvers(const edm::eventsetup::EventSetupRecordKey&, unsigned int iovIndex) override;
 
-    std::vector<std::shared_ptr<TestESProductResolverTemplateJ>> proxies_;
+    std::vector<std::shared_ptr<TestESProductResolverTemplateJ>> resolvers_;
     std::vector<unsigned> expectedCacheIds_;
   };
 
@@ -335,11 +335,11 @@ namespace edmtest {
   edm::eventsetup::ESProductResolverProvider::KeyedResolversVector ESTestESProductResolverProviderJ::registerResolvers(
       const edm::eventsetup::EventSetupRecordKey& iRecord, unsigned int iovIndex) {
     KeyedResolversVector keyedResolversVector;
-    while (iovIndex >= proxies_.size()) {
-      proxies_.push_back(std::make_shared<TestESProductResolverTemplateJ>(&expectedCacheIds_));
+    while (iovIndex >= resolvers_.size()) {
+      resolvers_.push_back(std::make_shared<TestESProductResolverTemplateJ>(&expectedCacheIds_));
     }
     edm::eventsetup::DataKey dataKey(edm::eventsetup::DataKey::makeTypeTag<ESTestDataJ>(), "");
-    keyedResolversVector.emplace_back(dataKey, proxies_[iovIndex]);
+    keyedResolversVector.emplace_back(dataKey, resolvers_[iovIndex]);
     return keyedResolversVector;
   }
 }  // namespace edmtest

--- a/FWCore/TestProcessor/interface/EventSetupTestHelper.h
+++ b/FWCore/TestProcessor/interface/EventSetupTestHelper.h
@@ -1,11 +1,11 @@
+// -*- C++ -*-
 #ifndef FWCore_TestProcessor_EventSetupTestHelper_h
 #define FWCore_TestProcessor_EventSetupTestHelper_h
-// -*- C++ -*-
 //
 // Package:     FWCore/TestProcessor
 // Class  :     EventSetupTestHelper
 //
-/**\class EventSetupTestHelper EventSetupTestHelper.h "EventSetupTestHelper.h"
+/**\class edm::test::EventSetupTestHelper
 
  Description: [one line class summary]
 
@@ -39,7 +39,7 @@ namespace edm {
 
       std::shared_ptr<eventsetup::ESProductResolver> getResolver(unsigned int index);
 
-      void resetAllProxies();
+      void resetAllResolvers();
 
     protected:
       void setIntervalFor(const eventsetup::EventSetupRecordKey&, const IOVSyncValue&, ValidityInterval&) final;
@@ -48,7 +48,7 @@ namespace edm {
 
     private:
       // ---------- member data --------------------------------
-      std::vector<ESProduceEntry> proxies_;
+      std::vector<ESProduceEntry> resolvers_;
     };
   }  // namespace test
 }  // namespace edm

--- a/FWCore/TestProcessor/src/EventSetupTestHelper.cc
+++ b/FWCore/TestProcessor/src/EventSetupTestHelper.cc
@@ -19,10 +19,11 @@
 namespace edm {
   namespace test {
 
-    EventSetupTestHelper::EventSetupTestHelper(std::vector<ESProduceEntry> iProxies) : proxies_{std::move(iProxies)} {
+    EventSetupTestHelper::EventSetupTestHelper(std::vector<ESProduceEntry> iResolvers)
+        : resolvers_{std::move(iResolvers)} {
       //Deal with duplicates
       std::set<eventsetup::EventSetupRecordKey> records;
-      for (auto const& p : proxies_) {
+      for (auto const& p : resolvers_) {
         records.insert(p.recordKey_);
       }
       for (auto const& k : records) {
@@ -34,18 +35,18 @@ namespace edm {
     void EventSetupTestHelper::setIntervalFor(const eventsetup::EventSetupRecordKey&,
                                               const IOVSyncValue& iSync,
                                               ValidityInterval& oIOV) {
-      // Note that we manually invalidate the proxies at the end of every call
+      // Note that we manually invalidate the resolvers at the end of every call
       // to test. And the beginning of the call to test is the only opportunity
       // to reset this data, so we are not relying on the EventSetup system
-      // to manage invalidating the proxies in EventSetupTestHelper. The only
+      // to manage invalidating the resolvers in EventSetupTestHelper. The only
       // reasonable thing to do is return an interval for all time so the EventSetup
-      // system does not invalidate these proxies when it shouldn't. There are two
+      // system does not invalidate these resolvers when it shouldn't. There are two
       // weaknesses to this:
       //
-      //     1. If for the same record type there are DataProxies both managed
+      //     1. If for the same record type there are ESProductResolvers both managed
       //     by this class and also others managed by the EventSetup, then
       //     at IOV boundaries for this record this will fail. The EventSetup
-      //     will invalidate all the proxies for the record after this class
+      //     will invalidate all the resolvers for the record after this class
       //     has set the ones it manages and they will stay invalid when they
       //     are needed.
       //
@@ -59,7 +60,7 @@ namespace edm {
     eventsetup::ESProductResolverProvider::KeyedResolversVector EventSetupTestHelper::registerResolvers(
         const eventsetup::EventSetupRecordKey& iRecordKey, unsigned int iovIndex) {
       KeyedResolversVector keyedResolversVector;
-      for (auto const& p : proxies_) {
+      for (auto const& p : resolvers_) {
         if (p.recordKey_ == iRecordKey) {
           keyedResolversVector.emplace_back(p.dataKey_, p.resolver_);
         }
@@ -68,11 +69,11 @@ namespace edm {
     }
 
     std::shared_ptr<eventsetup::ESProductResolver> EventSetupTestHelper::getResolver(unsigned int iIndex) {
-      return proxies_[iIndex].resolver_;
+      return resolvers_[iIndex].resolver_;
     }
 
-    void EventSetupTestHelper::resetAllProxies() {
-      for (auto const& p : proxies_) {
+    void EventSetupTestHelper::resetAllResolvers() {
+      for (auto const& p : resolvers_) {
         p.resolver_->invalidate();
       }
     }

--- a/FWCore/TestProcessor/src/TestProcessor.cc
+++ b/FWCore/TestProcessor/src/TestProcessor.cc
@@ -212,7 +212,7 @@ namespace edm {
       schedule_->clearCounters();
       if (esHelper_) {
         //We want each test to have its own ES data products
-        esHelper_->resetAllProxies();
+        esHelper_->resetAllResolvers();
       }
       return edm::test::Event(
           principalCache_.eventPrincipal(0), labelOfTestModule_, processConfiguration_->processName(), result);
@@ -246,7 +246,7 @@ namespace edm {
 
       if (esHelper_) {
         //We want each test to have its own ES data products
-        esHelper_->resetAllProxies();
+        esHelper_->resetAllResolvers();
       }
       return edm::test::LuminosityBlock(lumiPrincipal_, labelOfTestModule_, processConfiguration_->processName());
     }
@@ -278,7 +278,7 @@ namespace edm {
       });
       if (esHelper_) {
         //We want each test to have its own ES data products
-        esHelper_->resetAllProxies();
+        esHelper_->resetAllResolvers();
       }
 
       return edm::test::LuminosityBlock(std::move(lumi), labelOfTestModule_, processConfiguration_->processName());
@@ -307,7 +307,7 @@ namespace edm {
       });
       if (esHelper_) {
         //We want each test to have its own ES data products
-        esHelper_->resetAllProxies();
+        esHelper_->resetAllResolvers();
       }
       return edm::test::Run(runPrincipal_, labelOfTestModule_, processConfiguration_->processName());
     }
@@ -335,7 +335,7 @@ namespace edm {
       });
       if (esHelper_) {
         //We want each test to have its own ES data products
-        esHelper_->resetAllProxies();
+        esHelper_->resetAllResolvers();
       }
 
       return edm::test::Run(rp, labelOfTestModule_, processConfiguration_->processName());

--- a/PhysicsTools/CondLiteIO/plugins/FWLiteESRecordWriterAnalyzer.cc
+++ b/PhysicsTools/CondLiteIO/plugins/FWLiteESRecordWriterAnalyzer.cc
@@ -137,7 +137,7 @@ namespace edm {
         return;
       }
       assert(iResolverIndex.value() > -1 and
-             iResolverIndex.value() < static_cast<ESResolverIndex::Value_t>(keysForProxies_.size()));
+             iResolverIndex.value() < static_cast<ESResolverIndex::Value_t>(keysForResolvers_.size()));
       void const* pValue = this->getFromResolverAfterPrefetch(iResolverIndex, iTransientAccessOnly, oDesc, dataKey);
       if (nullptr == pValue) {
         throw cms::Exception("NoDataException")


### PR DESCRIPTION
#### PR description:

In PR #42075, we renamed DataProxy to ESProductResolver. As I was reading through the code for something else, I noticed we had missed some places where the name DataProxy or proxy was still in use and I migrated all that to use ESProductResolver or resolver. This is just renaming so it should not affect behavior. It makes it easier to read this code without mentally context switching between the two names...

At the same time, I made a few other minor cleanup fixes in the files I touched: Doxygen class declarations are now in a namespace, emacs C++ directive is now on the top line (does nothing otherwise), and a few typos in comments fixed.

#### PR validation:

Core unit tests pass.
