### PR TITLE
[MillePede] Add optional geometry parameter to `setup()` for dynamic loading of geometries

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/python/alignmentsetup/GeneralSetup.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/alignmentsetup/GeneralSetup.py
@@ -1,29 +1,54 @@
 from __future__ import print_function
-def setup(process, global_tag, zero_tesla = False):
+import re
+
+def setup(process, global_tag, zero_tesla=False, geometry=""):
     """General setup of an alignment process.
 
     Arguments:
     - `process`: cms.Process object
     - `global_tag`: global tag to be used
     - `zero_tesla`: if 'True' the B-field map for 0T is enforced
+    - `geometry`: geometry to be used (default is an empty string for the standard geometry)
     """
 
     # MessageLogger for convenient output
     # --------------------------------------------------------------------------
     process.load('Alignment.MillePedeAlignmentAlgorithm.alignmentsetup.myMessageLogger_cff')
 
-    # Load the conditions
+    # Load the magnetic field configuration
     # --------------------------------------------------------------------------
     if zero_tesla:
-        # actually only needed for 0T MC samples, but does not harm for 0T data:
+        # For 0T MC samples or data
         process.load("Configuration.StandardSequences.MagneticField_0T_cff")
     else:
         process.load('Configuration.StandardSequences.MagneticField_cff')
-    process.load('Configuration.Geometry.GeometryRecoDB_cff')
+
+    # Load the geometry
+    # --------------------------------------------------------------------------
+    if geometry == "":
+        # Default geometry
+        print(f"Using Geometry from DB")
+        process.load('Configuration.Geometry.GeometryRecoDB_cff')
+    else:
+        # Check if the geometry string matches the format "Extended<X>", e.g. Extended2026D110
+        if re.match(r"^Extended\w+$", geometry):
+            # Dynamically load the specified geometry
+            geometry_module = f"Configuration.Geometry.Geometry{geometry}Reco_cff"
+            try:
+                process.load(geometry_module)
+                print(f"Using Geometry: {geometry_module}")
+            except Exception as e:
+                print(f"Error: Unable to load the geometry module '{geometry_module}'.\n{e}")
+                raise
+        else:
+            raise ValueError(f"Invalid geometry format: '{geometry}'. Expected format is 'Extended<X>'.")
+
+    # Load the conditions (GlobalTag)
+    # --------------------------------------------------------------------------
     process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 
     from Configuration.AlCa.GlobalTag import GlobalTag
     process.GlobalTag = GlobalTag(process.GlobalTag, global_tag)
     print("Using Global Tag:", process.GlobalTag.globaltag._value)
 
-    return process # not required because the cms.Process is modified in place
+    return process  # Not required since the cms.Process object is modified in place

--- a/Alignment/MillePedeAlignmentAlgorithm/templates/alignment_config.ini
+++ b/Alignment/MillePedeAlignmentAlgorithm/templates/alignment_config.ini
@@ -52,6 +52,8 @@ pedeMem        = 32000
 datasetdir     = /afs/cern.ch/cms/CAF/CMSALCA/ALCA_TRACKERALIGN/MP/MPproduction/datasetfiles
 configTemplate = universalConfigTemplate.py
 globaltag      = auto:run2_data
+;# empty string defaults to geometry from DB
+recogeometry   =
 ;# set this to the run from where you want to start
 FirstRunForStartGeometry = 0
 

--- a/Alignment/MillePedeAlignmentAlgorithm/templates/universalConfigTemplate.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/templates/universalConfigTemplate.py
@@ -34,10 +34,6 @@
 #        process.AlignmentProducer.algoConfig.TrajectoryFactory.ParticleProperties.PrimaryWidth = ...
 #        if primaryWidth<=0.0 it has no effect at all.
 
-
-import FWCore.ParameterSet.Config as cms
-process = cms.Process("Alignment")
-
 ################################################################################
 # Variables edited by mps_alisetup.py. Used in functions below.
 # You can change them manually as well.
@@ -46,9 +42,20 @@ setupGlobaltag        = "placeholder_globaltag"
 setupCollection       = "placeholder_collection"
 setupCosmicsDecoMode  = False
 setupCosmicsZeroTesla = False
+setupRecoGeometry     = "placeholder_recogeometry"
 setupPrimaryWidth     = -1.0
 setupJson             = "placeholder_json"
 setupRunStartGeometry = -1
+
+import FWCore.ParameterSet.Config as cms
+if not setupRecoGeometry:  # empty string defaults to DB
+    from Configuration.Eras.Era_Run3_cff import Run3
+    process = cms.Process("Alignment", Run3)
+else:
+    import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+    # need to remove "Extended from the setupRecoGeometry because of defaultPhase2ConditionsEra interface"
+    _PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(setupRecoGeometry.replace("Extended", ""))
+    process = cms.Process("Alignment",_PH2_ERA)
 
 ################################################################################
 # Variables edited by MPS (mps_setup and mps_merge). Be careful.
@@ -69,7 +76,7 @@ readFiles = cms.untracked.vstring()
 # General setup
 # ------------------------------------------------------------------------------
 import Alignment.MillePedeAlignmentAlgorithm.alignmentsetup.GeneralSetup as generalSetup
-generalSetup.setup(process, setupGlobaltag, setupCosmicsZeroTesla)
+generalSetup.setup(process, setupGlobaltag, setupCosmicsZeroTesla, setupRecoGeometry)
 
 
 ################################################################################

--- a/Alignment/MillePedeAlignmentAlgorithm/test/test_mille.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/test/test_mille.py
@@ -26,6 +26,7 @@ setupCollection = "ALCARECOTkAlZMuMu"
 setupCosmicsDecoMode  = False
 setupCosmicsZeroTesla = False
 setupPrimaryWidth     = -1.0
+setupRecoGeometry     = "" # empty string defaults to DB
 setupJson = ""
 setupRunStartGeometry = 362350
 
@@ -53,7 +54,7 @@ readFiles.extend([
 # General setup
 # ------------------------------------------------------------------------------
 import Alignment.MillePedeAlignmentAlgorithm.alignmentsetup.GeneralSetup as generalSetup
-generalSetup.setup(process, setupGlobaltag, setupCosmicsZeroTesla)
+generalSetup.setup(process, setupGlobaltag, setupCosmicsZeroTesla, setupRecoGeometry)
 
 ################################################################################
 # setup alignment producer

--- a/Alignment/MillePedeAlignmentAlgorithm/test/test_pede.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/test/test_pede.py
@@ -11,6 +11,7 @@ setupCollection = "ALCARECOTkAlCosmicsCosmicTF0T"
 setupCosmicsDecoMode = True
 setupCosmicsZeroTesla = False
 setupPrimaryWidth     = -1.0
+setupRecoGeometry     = "" # empty string defaults to DB
 setupJson             = "placeholder_json"
 setupRunStartGeometry = 348908
 
@@ -35,7 +36,7 @@ readFiles.extend([
 # General setup
 # ------------------------------------------------------------------------------
 import Alignment.MillePedeAlignmentAlgorithm.alignmentsetup.GeneralSetup as generalSetup
-generalSetup.setup(process, setupGlobaltag, setupCosmicsZeroTesla)
+generalSetup.setup(process, setupGlobaltag, setupCosmicsZeroTesla, setupRecoGeometry)
 
 ################################################################################
 # setup alignment producer


### PR DESCRIPTION
#### PR description:

For Phase-2 style alignment campaigns, one needs to load the geometry from XML and not from DB.
In this PR I add an optional geometry parameter to the `setup()` fuction for dynamic loading of geometries:

- Added the 'geometry' parameter to the setup function
- Loads default geometry if the parameter is not provided
- Dynamically loads geometry modules based on the 'Extended<X>' format
- Includes error handling for invalid formats or loading failures

#### PR validation:

`scram b runtests use-ibeos` runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, to be backported.