### PR TITLE
[ClangAna][HcalHits] Remove dead code; suppress false-positive warnings

### DIFF
--- a/Validation/HcalHits/plugins/HcalSimHitCheck.cc
+++ b/Validation/HcalHits/plugins/HcalSimHitCheck.cc
@@ -533,6 +533,7 @@ void HcalSimHitCheck::analyzeHits(std::vector<PCaloHit> &hits) {
 
   for (int i = 0; i < ieta_bins_HB; i++) {
     for (int j = 0; j < iphi_bins; j++) {
+      [[clang::suppress]]
       if (HBEneMap[i][j] != 0) {
         meHBEneSum_->Fill(HBEneMap[i][j]);
         meHBEneSum_vs_ieta_->Fill((i - eta_offset_HB), HBEneMap[i][j]);
@@ -543,6 +544,7 @@ void HcalSimHitCheck::analyzeHits(std::vector<PCaloHit> &hits) {
 
   for (int i = 0; i < ieta_bins_HE; i++) {
     for (int j = 0; j < iphi_bins; j++) {
+      [[clang::suppress]]
       if (HEEneMap[i][j] != 0) {
         meHEEneSum_->Fill(HEEneMap[i][j]);
         meHEEneSum_vs_ieta_->Fill((i - eta_offset_HE), HEEneMap[i][j]);
@@ -553,6 +555,7 @@ void HcalSimHitCheck::analyzeHits(std::vector<PCaloHit> &hits) {
 
   for (int i = 0; i < ieta_bins_HO; i++) {
     for (int j = 0; j < iphi_bins; j++) {
+      [[clang::suppress]]
       if (HOEneMap[i][j] != 0) {
         meHOEneSum_->Fill(HOEneMap[i][j]);
         meHOEneSum_vs_ieta_->Fill((i - eta_offset_HO), HOEneMap[i][j]);
@@ -563,6 +566,7 @@ void HcalSimHitCheck::analyzeHits(std::vector<PCaloHit> &hits) {
 
   for (int i = 0; i < ieta_bins_HF; i++) {
     for (int j = 0; j < iphi_bins; j++) {
+      [[clang::suppress]]
       if (HFEneMap[i][j] != 0) {
         meHFEneSum_->Fill(HFEneMap[i][j]);
         meHFEneSum_vs_ieta_->Fill((i - eta_offset_HF), HFEneMap[i][j]);

--- a/Validation/HcalHits/plugins/HcalSimHitStudy.cc
+++ b/Validation/HcalHits/plugins/HcalSimHitStudy.cc
@@ -482,6 +482,7 @@ void HcalSimHitStudy::analyzeHits(std::vector<PCaloHit> &hits) {
 
   for (int i = 0; i < ieta_bins_HB; i++) {
     for (int j = 0; j < iphi_bins; j++) {
+      [[clang::suppress]]
       if (HBEneMap[i][j] != 0) {
         meHBEneSum_->Fill(HBEneMap[i][j]);
         meHBEneSum_vs_ieta_->Fill((i - eta_offset_HB), HBEneMap[i][j]);
@@ -492,6 +493,7 @@ void HcalSimHitStudy::analyzeHits(std::vector<PCaloHit> &hits) {
 
   for (int i = 0; i < ieta_bins_HE; i++) {
     for (int j = 0; j < iphi_bins; j++) {
+      [[clang::suppress]]
       if (HEEneMap[i][j] != 0) {
         meHEEneSum_->Fill(HEEneMap[i][j]);
         meHEEneSum_vs_ieta_->Fill((i - eta_offset_HE), HEEneMap[i][j]);
@@ -502,6 +504,7 @@ void HcalSimHitStudy::analyzeHits(std::vector<PCaloHit> &hits) {
 
   for (int i = 0; i < ieta_bins_HO; i++) {
     for (int j = 0; j < iphi_bins; j++) {
+      [[clang::suppress]]
       if (HOEneMap[i][j] != 0) {
         meHOEneSum_->Fill(HOEneMap[i][j]);
         meHOEneSum_vs_ieta_->Fill((i - eta_offset_HO), HOEneMap[i][j]);
@@ -512,6 +515,7 @@ void HcalSimHitStudy::analyzeHits(std::vector<PCaloHit> &hits) {
 
   for (int i = 0; i < ieta_bins_HF; i++) {
     for (int j = 0; j < iphi_bins; j++) {
+      [[clang::suppress]]
       if (HFEneMap[i][j] != 0) {
         meHFEneSum_->Fill(HFEneMap[i][j]);
         meHFEneSum_vs_ieta_->Fill((i - eta_offset_HF), HFEneMap[i][j]);

--- a/Validation/HcalHits/src/HcalSimHitsValidation.cc
+++ b/Validation/HcalHits/src/HcalSimHitsValidation.cc
@@ -42,11 +42,11 @@ void HcalSimHitsValidation::bookHistograms(DQMStore::IBooker &ib, edm::Run const
   // Get Phi segmentation from geometry, use the max phi number so that all iphi
   // values are included.
 
-  int NphiMax = hcons_->getNPhi(0);
+  //int NphiMax = hcons_->getNPhi(0);
 
-  NphiMax = (hcons_->getNPhi(1) > NphiMax ? hcons_->getNPhi(1) : NphiMax);
-  NphiMax = (hcons_->getNPhi(2) > NphiMax ? hcons_->getNPhi(2) : NphiMax);
-  NphiMax = (hcons_->getNPhi(3) > NphiMax ? hcons_->getNPhi(3) : NphiMax);
+  //NphiMax = (hcons_->getNPhi(1) > NphiMax ? hcons_->getNPhi(1) : NphiMax);
+  //NphiMax = (hcons_->getNPhi(2) > NphiMax ? hcons_->getNPhi(2) : NphiMax);
+  //NphiMax = (hcons_->getNPhi(3) > NphiMax ? hcons_->getNPhi(3) : NphiMax);
 
   // Center the iphi bins on the integers
   // float iphi_min = 0.5;

--- a/Validation/HcalHits/src/SimG4HcalValidation.cc
+++ b/Validation/HcalHits/src/SimG4HcalValidation.cc
@@ -271,8 +271,7 @@ void SimG4HcalValidation::update(const BeginOfEvent *evt) {
   // Cache reset
   clear();
 
-  int iev = (*evt)()->GetEventID();
-  LogDebug("ValidHcal") << "SimG4HcalValidation: =====> Begin of event = " << iev;
+  LogDebug("ValidHcal") << "SimG4HcalValidation: =====> Begin of event = " << (*evt)()->GetEventID();
 }
 
 //=================================================================== each STEP
@@ -591,10 +590,10 @@ void SimG4HcalValidation::jetAnalysis(PHcalValidInfoJets &product) {
 
     double ecal_collect = 0.;  // collect Ecal energy in the cone
     if (!hcalOnly) {
-      ecal_collect = clus_itr->collectEcalEnergyR();
+      [[clang::suppress]] ecal_collect = clus_itr->collectEcalEnergyR();
     } else {
       collectEnergyRdir(etac, phic);
-      ecal_collect = een;
+      [[clang::suppress]] ecal_collect = een;
     }
     LogDebug("ValidHcal") << " JetAnalysis ===> ecal_collect  = " << ecal_collect;
 
@@ -735,17 +734,14 @@ void SimG4HcalValidation::fetchHits(PHcalValidInfoLayer &product) {
     double phi = (*k1)->phi();
     int lay = ((unitID >> 15) & 31) + 1;
     int subdet = (unitID >> 20) & 15;
-    int zside = (unitID >> 14) & 1;
-    int ieta = (unitID >> 7) & 127;
-    int iphi = (unitID) & 127;
 
     // All hits in cache
     product.fillHits(nHits, lay, subdet, eta, phi, ehit, t);
     nHits++;
 
     LogDebug("ValidHcal") << "SimG4HcalValidation::fetchHits:Hit " << nHits << " " << i << " ID 0x" << std::hex
-                          << unitID << "   det " << std::dec << subdet << " " << lay << " " << zside << " " << ieta
-                          << " " << iphi << " Time " << t << " E " << ehit;
+                          << unitID << "   det " << std::dec << subdet << " " << lay << " " << ((unitID >> 14) & 1)
+                          << " " << ((unitID >> 7) & 127) << " " << ((unitID) & 127) << " Time " << t << " E " << ehit;
 
     i += jump;
     k1 += jump;

--- a/Validation/HcalHits/src/SimHitsValidationHcal.cc
+++ b/Validation/HcalHits/src/SimHitsValidationHcal.cc
@@ -37,22 +37,22 @@ void SimHitsValidationHcal::bookHistograms(DQMStore::IBooker &ib, edm::Run const
   float iphi_max = NphiMax + 0.5;
   int iphi_bins = (int)(iphi_max - iphi_min);
 
-  int iEtaHBMax = hcons->getEtaRange(0).second;
-  int iEtaHEMax = std::max(hcons->getEtaRange(1).second, 1);
-  int iEtaHFMax = hcons->getEtaRange(2).second;
-  int iEtaHOMax = hcons->getEtaRange(3).second;
+  //int iEtaHBMax = hcons->getEtaRange(0).second;
+  //int iEtaHEMax = std::max(hcons->getEtaRange(1).second, 1);
+  //int iEtaHFMax = hcons->getEtaRange(2).second;
+  //int iEtaHOMax = hcons->getEtaRange(3).second;
 
   // Retain classic behavior, all plots have same ieta range.
   // Comment out	code to	allow each subdetector to have its on range
 
-  int iEtaMax = (iEtaHBMax > iEtaHEMax ? iEtaHBMax : iEtaHEMax);
-  iEtaMax = (iEtaMax > iEtaHFMax ? iEtaMax : iEtaHFMax);
-  iEtaMax = (iEtaMax > iEtaHOMax ? iEtaMax : iEtaHOMax);
+  //int iEtaMax = (iEtaHBMax > iEtaHEMax ? iEtaHBMax : iEtaHEMax);
+  //iEtaMax = (iEtaMax > iEtaHFMax ? iEtaMax : iEtaHFMax);
+  //iEtaMax = (iEtaMax > iEtaHOMax ? iEtaMax : iEtaHOMax);
 
-  iEtaHBMax = iEtaMax;
-  iEtaHEMax = iEtaMax;
-  iEtaHFMax = iEtaMax;
-  iEtaHOMax = iEtaMax;
+  //iEtaHBMax = iEtaMax;
+  //iEtaHEMax = iEtaMax;
+  //iEtaHFMax = iEtaMax;
+  //iEtaHOMax = iEtaMax;
 
   // Give an empty bin around the subdet ieta range to make it clear that all
   // ieta rings have been included float ieta_min_HB = -iEtaHBMax - 1.5; float


### PR DESCRIPTION
This fixes the clang-analyzer warnings for [Validation/HcalHits](https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_14_2_X_2024-10-02-1100/el8_amd64_gcc12/build-logs/Validation/HcalHits/log.html ) package. It remove some dead code which was only used in commented-out section. There were few false positive reports which are suppressed via `[[clang::suppress]]` 