### PR TITLE
[LLVM Analysis] Fix potential memory leak in ApvAnalysisFactory::constructAuxiliaryApvClasses (pt 2)

### DIFF
--- a/CalibTracker/SiStripAPVAnalysis/src/ApvAnalysisFactory.cc
+++ b/CalibTracker/SiStripAPVAnalysis/src/ApvAnalysisFactory.cc
@@ -119,6 +119,9 @@ void ApvAnalysisFactory::constructAuxiliaryApvClasses(ApvAnalysis* theAPV, uint3
     } else {
       cout << "Sorry Only Median is available for now, Mean and FastLinear are coming soon" << endl;
       delete theCommonMode;
+      delete theMask;
+      delete thePedestal;
+      delete theNoise;
       return;
     }
   } else {


### PR DESCRIPTION
#### PR description:

I have missed [one more report](https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_14_2_X_2024-09-29-0000/el8_amd64_gcc12/llvm-analysis/report-07aa8e.html#EndPath) when preparing #46202. Fixing it.

#### PR validation:

Bot tests.
