### PR TITLE
[ANALYSIS] [Clang]Cleanup clang-analyzer warnings

### DIFF
--- a/TopQuarkAnalysis/TopEventProducers/src/TtDilepEvtSolutionMaker.cc
+++ b/TopQuarkAnalysis/TopEventProducers/src/TtDilepEvtSolutionMaker.cc
@@ -157,7 +157,6 @@ void TtDilepEvtSolutionMaker::produce(edm::Event& iEvent, const edm::EventSetup&
     }
     if (ee) {
       if (LepDiffCharge(&(*electrons)[0], &(*electrons)[1])) {
-        leptonFound = true;
         leptonFoundEE = true;
         if (HasPositiveCharge(&(*electrons)[0])) {
           selElectronp = 0;
@@ -169,7 +168,6 @@ void TtDilepEvtSolutionMaker::produce(edm::Event& iEvent, const edm::EventSetup&
       }
     } else if (emu) {
       if (LepDiffCharge(&(*electrons)[0], &(*muons)[0])) {
-        leptonFound = true;
         if (HasPositiveCharge(&(*electrons)[0])) {
           leptonFoundEpMm = true;
           selElectronp = 0;
@@ -182,7 +180,6 @@ void TtDilepEvtSolutionMaker::produce(edm::Event& iEvent, const edm::EventSetup&
       }
     } else if (mumu) {
       if (LepDiffCharge(&(*muons)[0], &(*muons)[1])) {
-        leptonFound = true;
         leptonFoundMM = true;
         if (HasPositiveCharge(&(*muons)[0])) {
           selMuonp = 0;
@@ -305,7 +302,6 @@ void TtDilepEvtSolutionMaker::produce(edm::Event& iEvent, const edm::EventSetup&
   } else if (taus->size() > 1) {
     tautau = true;
     if (LepDiffCharge(&(*taus)[0], &(*taus)[1])) {
-      leptonFound = true;
       leptonFoundTT = true;
       if (HasPositiveCharge(&(*taus)[0])) {
         selTaup = 0;

--- a/TopQuarkAnalysis/TopHitFit/src/CLHEPHitFitTranslator.cc
+++ b/TopQuarkAnalysis/TopHitFit/src/CLHEPHitFitTranslator.cc
@@ -28,6 +28,7 @@ namespace hitfit {
 
   template <>
   LeptonTranslatorBase<CLHEP::HepLorentzVector>::LeptonTranslatorBase() {
+    [[clang::suppress]]
     std::string CMSSW_BASE(std::getenv("CMSSW_BASE"));
     std::string resolution_filename =
         CMSSW_BASE + std::string("/src/TopQuarkAnalysis/TopHitFit/data/exampleElectronResolution.txt");
@@ -37,6 +38,7 @@ namespace hitfit {
 
   template <>
   LeptonTranslatorBase<CLHEP::HepLorentzVector>::LeptonTranslatorBase(const std::string& ifile) {
+    [[clang::suppress]]
     std::string CMSSW_BASE(std::getenv("CMSSW_BASE"));
     std::string resolution_filename;
 
@@ -79,6 +81,7 @@ namespace hitfit {
 
   template <>
   JetTranslatorBase<CLHEP::HepLorentzVector>::JetTranslatorBase() {
+    [[clang::suppress]]
     std::string CMSSW_BASE(std::getenv("CMSSW_BASE"));
     std::string udsc_resolution_filename =
         CMSSW_BASE + std::string("/src/TopQuarkAnalysis/TopHitFit/data/exampleJetResolution.txt");
@@ -91,6 +94,7 @@ namespace hitfit {
 
   template <>
   JetTranslatorBase<CLHEP::HepLorentzVector>::JetTranslatorBase(const std::string& udscFile, const std::string& bFile) {
+    [[clang::suppress]]
     std::string CMSSW_BASE(std::getenv("CMSSW_BASE"));
     std::string udsc_resolution_filename;
     std::string b_resolution_filename;

--- a/TopQuarkAnalysis/TopHitFit/src/PatElectronHitFitTranslator.cc
+++ b/TopQuarkAnalysis/TopHitFit/src/PatElectronHitFitTranslator.cc
@@ -22,6 +22,7 @@ namespace hitfit {
 
   template <>
   LeptonTranslatorBase<pat::Electron>::LeptonTranslatorBase() {
+    [[clang::suppress]]
     std::string CMSSW_BASE(std::getenv("CMSSW_BASE"));
     std::string resolution_filename =
         CMSSW_BASE + std::string("/src/TopQuarkAnalysis/PatHitFit/data/exampleElectronResolution.txt");
@@ -31,6 +32,7 @@ namespace hitfit {
 
   template <>
   LeptonTranslatorBase<pat::Electron>::LeptonTranslatorBase(const std::string& ifile) {
+    [[clang::suppress]]
     std::string CMSSW_BASE(std::getenv("CMSSW_BASE"));
     std::string resolution_filename;
 

--- a/TopQuarkAnalysis/TopHitFit/src/PatJetHitFitTranslator.cc
+++ b/TopQuarkAnalysis/TopHitFit/src/PatJetHitFitTranslator.cc
@@ -19,6 +19,7 @@ namespace hitfit {
 
   template <>
   JetTranslatorBase<pat::Jet>::JetTranslatorBase() {
+    [[clang::suppress]]
     std::string CMSSW_BASE(std::getenv("CMSSW_BASE"));
     std::string resolution_filename =
         CMSSW_BASE + std::string("/src/TopQuarkAnalysis/PatHitFit/data/exampleJetResolution.txt");
@@ -32,6 +33,7 @@ namespace hitfit {
 
   template <>
   JetTranslatorBase<pat::Jet>::JetTranslatorBase(const std::string& udscFile, const std::string& bFile) {
+    [[clang::suppress]]
     std::string CMSSW_BASE(std::getenv("CMSSW_BASE"));
     std::string udscResolution_filename;
     std::string bResolution_filename;
@@ -63,6 +65,7 @@ namespace hitfit {
                                                  const std::string& jetCorrectionLevel,
                                                  double jes,
                                                  double jesB) {
+    [[clang::suppress]]
     std::string CMSSW_BASE(std::getenv("CMSSW_BASE"));
     std::string udscResolution_filename;
     std::string bResolution_filename;

--- a/TopQuarkAnalysis/TopHitFit/src/PatMuonHitFitTranslator.cc
+++ b/TopQuarkAnalysis/TopHitFit/src/PatMuonHitFitTranslator.cc
@@ -21,6 +21,7 @@ namespace hitfit {
 
   template <>
   LeptonTranslatorBase<pat::Muon>::LeptonTranslatorBase() {
+    [[clang::suppress]]
     std::string CMSSW_BASE(std::getenv("CMSSW_BASE"));
     std::string resolution_filename =
         CMSSW_BASE + std::string("/src/TopQuarkAnalysis/PatHitFit/data/exampleMuonResolution.txt");
@@ -30,6 +31,7 @@ namespace hitfit {
 
   template <>
   LeptonTranslatorBase<pat::Muon>::LeptonTranslatorBase(const std::string& ifile) {
+    [[clang::suppress]]
     std::string CMSSW_BASE(std::getenv("CMSSW_BASE"));
     std::string resolution_filename;
 


### PR DESCRIPTION
This fixes clang static analyzer warnings https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_14_2_X_2024-10-02-1100/el8_amd64_gcc12/build-logs/
- remove dead code
- suppress warnings as 
  - code is conditionally used by LogDebug/LogTrace
  - `getenv(std::getenv("CMSSW_BASE"))` in cmssw env should not return nullptr