### PR TITLE
[RECONSTRUCTION] [Clang]Cleanup clang-analyzer warnings

### DIFF
--- a/TrackPropagation/RungeKutta/src/RKPropagatorInS.cc
+++ b/TrackPropagation/RungeKutta/src/RKPropagatorInS.cc
@@ -310,7 +310,10 @@ GlobalTrajectoryParameters RKPropagatorInS::gtpFromLocal(const Basic3DVector<flo
   return GlobalTrajectoryParameters(surf.toGlobal(LocalPoint(lpos)), surf.toGlobal(LocalVector(lmom)), ch, theVolume);
 }
 
-RKLocalFieldProvider RKPropagatorInS::fieldProvider() const { return RKLocalFieldProvider(*theVolume); }
+RKLocalFieldProvider RKPropagatorInS::fieldProvider() const {
+  assert(theVolume);
+  return RKLocalFieldProvider(*theVolume);
+}
 
 RKLocalFieldProvider RKPropagatorInS::fieldProvider(const Cylinder& cyl) const {
   return RKLocalFieldProvider(*theVolume, cyl);

--- a/TrackPropagation/SteppingHelixPropagator/src/SteppingHelixPropagator.cc
+++ b/TrackPropagation/SteppingHelixPropagator/src/SteppingHelixPropagator.cc
@@ -336,6 +336,7 @@ SteppingHelixPropagator::Result SteppingHelixPropagator::propagate(StateArray& s
 
   result = SteppingHelixStateInfo::UNDEFINED;
   bool makeNextStep = true;
+  [[clang::suppress]]
   double dStep = defaultStep_;
   PropagationDirection dir, oldDir;
   dir = propagationDirection();
@@ -562,7 +563,6 @@ SteppingHelixPropagator::Result SteppingHelixPropagator::propagate(StateArray& s
         }
       } else {
         //keep this trial point and continue
-        dStep = defaultStep_;
         if (debug_) {
           LogTrace(metname) << std::setprecision(17) << std::setw(20) << std::scientific << "Found branch point in PCA"
                             << std::endl;
@@ -727,10 +727,11 @@ void SteppingHelixPropagator::loadState(SteppingHelixPropagator::StateInfo& svCu
     if (debug_) {
       LogTrace(metname) << std::setprecision(17) << std::setw(20) << std::scientific << "Loaded bfield float: " << bf
                         << " at global float " << gPointNorZ << " double " << svCurrent.r3 << std::endl;
+      [[clang::suppress]]
       LocalPoint lPoint(svCurrent.magVol->toLocal(gPointNorZ));
-      LocalVector lbf = svCurrent.magVol->fieldInTesla(lPoint);
-      LogTrace(metname) << std::setprecision(17) << std::setw(20) << std::scientific << "\t cf in local locF: " << lbf
-                        << " at " << lPoint << std::endl;
+      LogTrace(metname) << std::setprecision(17) << std::setw(20) << std::scientific
+                        << "\t cf in local locF: " << svCurrent.magVol->fieldInTesla(lPoint) << " at " << lPoint
+                        << std::endl;
     }
     svCurrent.bf.set(bf.x(), bf.y(), bf.z());
   } else {
@@ -922,7 +923,6 @@ bool SteppingHelixPropagator::makeAtomStep(SteppingHelixPropagator::StateInfo& s
         double phi2 = phi * phi;
         double phi3 = phi2 * phi;
         double phi4 = phi3 * phi;
-        oneLessCosPhi = phi2 / 2. - phi4 / 24. + phi2 * phi4 / 720.;             // 0.5*phi*phi;//*(1.- phi*phi/12.);
         oneLessCosPhiOPhi = 0.5 * phi - phi3 / 24. + phi2 * phi3 / 720.;         //*(1.- phi*phi/12.);
         phiLessSinPhiOPhi = phi * phi / 6. - phi4 / 120. + phi4 * phi2 / 5040.;  //*(1. - phi*phi/20.);
       } else {

--- a/TrackPropagation/SteppingHelixPropagator/test/SteppingHelixPropagatorAnalyzer.cc
+++ b/TrackPropagation/SteppingHelixPropagator/test/SteppingHelixPropagatorAnalyzer.cc
@@ -359,9 +359,10 @@ void SteppingHelixPropagatorAnalyzer::analyze(const edm::Event& iEvent, const ed
       std::map<double, const GlobalSimHit*>::const_iterator simHitsCI = simHitsByDistance.begin();
       for (; simHitsCI != simHitsByDistance.end(); simHitsCI++) {
         const GlobalSimHit* igHit = simHitsCI->second;
-        const PSimHit* iHit = simHitsCI->second->hit;
 
         if (debug_) {
+          [[clang::suppress]]
+          const PSimHit* iHit = simHitsCI->second->hit;
           LogTrace(metname) << igHit->id.rawId() << " r3L:" << iHit->localPosition() << " r3G:" << igHit->r3
                             << " p3L:" << iHit->momentumAtEntry() << " p3G:" << igHit->p3
                             << " pId:" << iHit->particleType() << " tId:" << iHit->trackId() << std::endl;
@@ -371,7 +372,6 @@ void SteppingHelixPropagatorAnalyzer::analyze(const edm::Event& iEvent, const ed
           LogTrace(metname) << "Will propagate to surface: " << igHit->surf->position() << " "
                             << igHit->surf->rotation() << std::endl;
         }
-        pStatus = 0;
         if (startFromPrevHit_) {
           if (simHitsCI != simHitsByDistance.begin()) {
             std::map<double, const GlobalSimHit*>::const_iterator simHitPrevCI = simHitsCI;


### PR DESCRIPTION
This fixes clang static analyzer warnings https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_14_2_X_2024-10-02-1100/el8_amd64_gcc12/build-logs/

- remove dead code
- suppress warnings as
  - code is conditionally used by LogDebug/LogTrace
