### PR TITLE
MTD Validation: speed up LocalRecoValidation plus other fixes

### DIFF
--- a/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
@@ -503,47 +503,49 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
       double cluLocYSIM = 0.;
       double cluLocZSIM = 0.;
 
-      for (int ihit = 0; ihit < cluster.size(); ++ihit) {
-        int hit_row = cluster.minHitRow() + cluster.hitOffset()[ihit * 2];
-        int hit_col = cluster.minHitCol() + cluster.hitOffset()[ihit * 2 + 1];
+      if (optionalPlots_) {
+        for (int ihit = 0; ihit < cluster.size(); ++ihit) {
+          int hit_row = cluster.minHitRow() + cluster.hitOffset()[ihit * 2];
+          int hit_col = cluster.minHitCol() + cluster.hitOffset()[ihit * 2 + 1];
 
-        // Match the RECO hit to the corresponding SIM hit
-        for (const auto& recHit : *btlRecHitsHandle) {
-          BTLDetId hitId(recHit.id().rawId());
+          // Match the RECO hit to the corresponding SIM hit
+          for (const auto& recHit : *btlRecHitsHandle) {
+            BTLDetId hitId(recHit.id().rawId());
 
-          if (m_btlSimHits.count(hitId.rawId()) == 0)
-            continue;
+            if (m_btlSimHits.count(hitId.rawId()) == 0)
+              continue;
 
-          // Check the hit position
-          if (hitId.mtdSide() != cluId.mtdSide() || hitId.mtdRR() != cluId.mtdRR() || recHit.row() != hit_row ||
-              recHit.column() != hit_col)
-            continue;
+            // Check the hit position
+            if (hitId.mtdSide() != cluId.mtdSide() || hitId.mtdRR() != cluId.mtdRR() || recHit.row() != hit_row ||
+                recHit.column() != hit_col)
+              continue;
 
-          // Check the hit energy and time
-          if (recHit.energy() != cluster.hitENERGY()[ihit] || recHit.time() != cluster.hitTIME()[ihit])
-            continue;
+            // Check the hit energy and time
+            if (recHit.energy() != cluster.hitENERGY()[ihit] || recHit.time() != cluster.hitTIME()[ihit])
+              continue;
 
-          // SIM hit's position in the module reference frame
-          Local3DPoint local_point_sim(convertMmToCm(m_btlSimHits[recHit.id().rawId()].x),
-                                       convertMmToCm(m_btlSimHits[recHit.id().rawId()].y),
-                                       convertMmToCm(m_btlSimHits[recHit.id().rawId()].z));
-          local_point_sim =
-              topo.pixelToModuleLocalPoint(local_point_sim, hitId.row(topo.nrows()), hitId.column(topo.nrows()));
+            // SIM hit's position in the module reference frame
+            Local3DPoint local_point_sim(convertMmToCm(m_btlSimHits[recHit.id().rawId()].x),
+                                         convertMmToCm(m_btlSimHits[recHit.id().rawId()].y),
+                                         convertMmToCm(m_btlSimHits[recHit.id().rawId()].z));
+            local_point_sim =
+                topo.pixelToModuleLocalPoint(local_point_sim, hitId.row(topo.nrows()), hitId.column(topo.nrows()));
 
-          // Calculate the SIM cluster's position in the module reference frame
-          cluLocXSIM += local_point_sim.x() * m_btlSimHits[recHit.id().rawId()].energy;
-          cluLocYSIM += local_point_sim.y() * m_btlSimHits[recHit.id().rawId()].energy;
-          cluLocZSIM += local_point_sim.z() * m_btlSimHits[recHit.id().rawId()].energy;
+            // Calculate the SIM cluster's position in the module reference frame
+            cluLocXSIM += local_point_sim.x() * m_btlSimHits[recHit.id().rawId()].energy;
+            cluLocYSIM += local_point_sim.y() * m_btlSimHits[recHit.id().rawId()].energy;
+            cluLocZSIM += local_point_sim.z() * m_btlSimHits[recHit.id().rawId()].energy;
 
-          // Calculate the SIM cluster energy and time
-          cluEneSIM += m_btlSimHits[recHit.id().rawId()].energy;
-          cluTimeSIM += m_btlSimHits[recHit.id().rawId()].time * m_btlSimHits[recHit.id().rawId()].energy;
+            // Calculate the SIM cluster energy and time
+            cluEneSIM += m_btlSimHits[recHit.id().rawId()].energy;
+            cluTimeSIM += m_btlSimHits[recHit.id().rawId()].time * m_btlSimHits[recHit.id().rawId()].energy;
 
-          break;
+            break;
 
-        }  // recHit loop
+          }  // recHit loop
 
-      }  // ihit loop
+        }  // ihit loop
+      }
 
       // Find the MTDTrackingRecHit corresponding to the cluster
       const MTDTrackingRecHit* comp(nullptr);
@@ -562,41 +564,41 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
       }
 
       // --- Fill the cluster resolution histograms
-      if (cluTimeSIM > 0. && cluEneSIM > 0.) {
-        cluTimeSIM /= cluEneSIM;
+      if (optionalPlots_) {
+        if (cluTimeSIM > 0. && cluEneSIM > 0.) {
+          cluTimeSIM /= cluEneSIM;
 
-        Local3DPoint cluLocalPosSIM(cluLocXSIM / cluEneSIM, cluLocYSIM / cluEneSIM, cluLocZSIM / cluEneSIM);
-        const auto& cluGlobalPosSIM = genericDet->toGlobal(cluLocalPosSIM);
+          Local3DPoint cluLocalPosSIM(cluLocXSIM / cluEneSIM, cluLocYSIM / cluEneSIM, cluLocZSIM / cluEneSIM);
+          const auto& cluGlobalPosSIM = genericDet->toGlobal(cluLocalPosSIM);
 
-        float time_res = cluster.time() - cluTimeSIM;
-        float energy_res = cluster.energy() - cluEneSIM;
-        meCluTimeRes_->Fill(time_res);
-        meCluEnergyRes_->Fill(energy_res);
+          float time_res = cluster.time() - cluTimeSIM;
+          float energy_res = cluster.energy() - cluEneSIM;
+          meCluTimeRes_->Fill(time_res);
+          meCluEnergyRes_->Fill(energy_res);
 
-        float rho_res = global_point.perp() - cluGlobalPosSIM.perp();
-        float phi_res = global_point.phi() - cluGlobalPosSIM.phi();
+          float rho_res = global_point.perp() - cluGlobalPosSIM.perp();
+          float phi_res = global_point.phi() - cluGlobalPosSIM.phi();
 
-        meCluRhoRes_->Fill(rho_res);
-        meCluPhiRes_->Fill(phi_res);
+          meCluRhoRes_->Fill(rho_res);
+          meCluPhiRes_->Fill(phi_res);
 
-        float xlocal_res = local_point.x() - cluLocalPosSIM.x();
-        float ylocal_res = local_point.y() - cluLocalPosSIM.y();
+          float xlocal_res = local_point.x() - cluLocalPosSIM.x();
+          float ylocal_res = local_point.y() - cluLocalPosSIM.y();
 
-        float z_res = global_point.z() - cluGlobalPosSIM.z();
+          float z_res = global_point.z() - cluGlobalPosSIM.z();
 
-        meCluZRes_->Fill(z_res);
+          meCluZRes_->Fill(z_res);
 
-        if (matchClu && comp != nullptr) {
-          meCluLocalXRes_->Fill(xlocal_res);
+          if (matchClu && comp != nullptr) {
+            meCluLocalXRes_->Fill(xlocal_res);
 
-          if (global_point.z() > 0) {
-            meCluLocalYResZGlobPlus_->Fill(ylocal_res);
-            meCluLocalYPullZGlobPlus_->Fill(ylocal_res / std::sqrt(comp->localPositionError().yy()));
-          } else {
-            meCluLocalYResZGlobMinus_->Fill(ylocal_res);
-            meCluLocalYPullZGlobMinus_->Fill(ylocal_res / std::sqrt(comp->localPositionError().yy()));
-          }
-          if (optionalPlots_) {
+            if (global_point.z() > 0) {
+              meCluLocalYResZGlobPlus_->Fill(ylocal_res);
+              meCluLocalYPullZGlobPlus_->Fill(ylocal_res / std::sqrt(comp->localPositionError().yy()));
+            } else {
+              meCluLocalYResZGlobMinus_->Fill(ylocal_res);
+              meCluLocalYPullZGlobMinus_->Fill(ylocal_res / std::sqrt(comp->localPositionError().yy()));
+            }
             if (cluster.size() == 1) {  // single-crystal clusters
               meCluSingCrystalLocalYRes_->Fill(ylocal_res);
               if (global_point.z() > 0) {
@@ -638,26 +640,25 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
             meCluYXLocal_->Fill(local_point.x(), local_point.y());
             meCluYXLocalSim_->Fill(cluLocalPosSIM.x(), cluLocalPosSIM.y());
 
-          }  //end of optional plots
+            meCluLocalXPull_->Fill(xlocal_res / std::sqrt(comp->localPositionError().xx()));
+            meCluZPull_->Fill(z_res / std::sqrt(comp->globalPositionError().czz()));
+            meCluXLocalErr_->Fill(std::sqrt(comp->localPositionError().xx()));
+            meCluYLocalErr_->Fill(std::sqrt(comp->localPositionError().yy()));
+          }
 
-          meCluLocalXPull_->Fill(xlocal_res / std::sqrt(comp->localPositionError().xx()));
-          meCluZPull_->Fill(z_res / std::sqrt(comp->globalPositionError().czz()));
-          meCluXLocalErr_->Fill(std::sqrt(comp->localPositionError().xx()));
-          meCluYLocalErr_->Fill(std::sqrt(comp->localPositionError().yy()));
+          meCluEnergyvsEta_->Fill(std::abs(cluGlobalPosSIM.eta()), cluster.energy());
+          meCluHitsvsEta_->Fill(std::abs(cluGlobalPosSIM.eta()), cluster.size());
+
+          meCluTResvsEta_->Fill(std::abs(cluGlobalPosSIM.eta()), time_res);
+          meCluTResvsE_->Fill(cluEneSIM, time_res);
+
+          meCluTPullvsEta_->Fill(std::abs(cluGlobalPosSIM.eta()), time_res / cluster.timeError());
+          meCluTPullvsE_->Fill(cluEneSIM, time_res / cluster.timeError());
+
+        }  // if ( cluTimeSIM > 0. &&  cluEneSIM > 0. )
+        else {
+          meUnmatchedCluEnergy_->Fill(std::log10(cluster.energy()));
         }
-
-        meCluEnergyvsEta_->Fill(std::abs(cluGlobalPosSIM.eta()), cluster.energy());
-        meCluHitsvsEta_->Fill(std::abs(cluGlobalPosSIM.eta()), cluster.size());
-
-        meCluTResvsEta_->Fill(std::abs(cluGlobalPosSIM.eta()), time_res);
-        meCluTResvsE_->Fill(cluEneSIM, time_res);
-
-        meCluTPullvsEta_->Fill(std::abs(cluGlobalPosSIM.eta()), time_res / cluster.timeError());
-        meCluTPullvsE_->Fill(cluEneSIM, time_res / cluster.timeError());
-
-      }  // if ( cluTimeSIM > 0. &&  cluEneSIM > 0. )
-      else {
-        meUnmatchedCluEnergy_->Fill(std::log10(cluster.energy()));
       }
 
       // --- Fill the cluster resolution histograms using MtdSimLayerClusters as mtd truth
@@ -837,94 +838,95 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
   meNevents_->Fill(0.5);
 
   // --- Loop over the BTL Uncalibrated RECO hits
-  auto btlUncalibRecHitsHandle = makeValid(iEvent.getHandle(btlUncalibRecHitsToken_));
+  if (optionalPlots_) {
+    auto btlUncalibRecHitsHandle = makeValid(iEvent.getHandle(btlUncalibRecHitsToken_));
+    for (const auto& uRecHit : *btlUncalibRecHitsHandle) {
+      BTLDetId detId = uRecHit.id();
 
-  for (const auto& uRecHit : *btlUncalibRecHitsHandle) {
-    BTLDetId detId = uRecHit.id();
+      // --- Skip UncalibratedRecHits not matched to SimHits
+      if (m_btlSimHits.count(detId.rawId()) != 1)
+        continue;
 
-    // --- Skip UncalibratedRecHits not matched to SimHits
-    if (m_btlSimHits.count(detId.rawId()) != 1)
-      continue;
+      // --- Combine the information from the left and right BTL cell sides
 
-    // --- Combine the information from the left and right BTL cell sides
+      float nHits = 0.;
+      float hit_amplitude = 0.;
+      float hit_time = 0.;
 
-    float nHits = 0.;
-    float hit_amplitude = 0.;
-    float hit_time = 0.;
+      // left side:
+      if (uRecHit.amplitude().first > 0.) {
+        hit_amplitude += uRecHit.amplitude().first;
+        hit_time += uRecHit.time().first;
+        nHits += 1.;
+      }
+      // right side:
+      if (uRecHit.amplitude().second > 0.) {
+        hit_amplitude += uRecHit.amplitude().second;
+        hit_time += uRecHit.time().second;
+        nHits += 1.;
+      }
 
-    // left side:
-    if (uRecHit.amplitude().first > 0.) {
-      hit_amplitude += uRecHit.amplitude().first;
-      hit_time += uRecHit.time().first;
-      nHits += 1.;
-    }
-    // right side:
-    if (uRecHit.amplitude().second > 0.) {
-      hit_amplitude += uRecHit.amplitude().second;
-      hit_time += uRecHit.time().second;
-      nHits += 1.;
-    }
+      hit_amplitude /= nHits;
+      hit_time /= nHits;
 
-    hit_amplitude /= nHits;
-    hit_time /= nHits;
+      // --- Fill the histograms
 
-    // --- Fill the histograms
+      if (hit_amplitude < hitMinAmplitude_)
+        continue;
 
-    if (hit_amplitude < hitMinAmplitude_)
-      continue;
+      meUncEneRVsX_->Fill(uRecHit.position(), uRecHit.amplitude().first - hit_amplitude);
+      meUncEneLVsX_->Fill(uRecHit.position(), uRecHit.amplitude().second - hit_amplitude);
 
-    meUncEneRVsX_->Fill(uRecHit.position(), uRecHit.amplitude().first - hit_amplitude);
-    meUncEneLVsX_->Fill(uRecHit.position(), uRecHit.amplitude().second - hit_amplitude);
+      meUncTimeRVsX_->Fill(uRecHit.position(), uRecHit.time().first - hit_time);
+      meUncTimeLVsX_->Fill(uRecHit.position(), uRecHit.time().second - hit_time);
 
-    meUncTimeRVsX_->Fill(uRecHit.position(), uRecHit.time().first - hit_time);
-    meUncTimeLVsX_->Fill(uRecHit.position(), uRecHit.time().second - hit_time);
+      if (uncalibRecHitsPlots_) {
+        DetId geoId = detId.geographicalId(MTDTopologyMode::crysLayoutFromTopoMode(topology->getMTDTopologyMode()));
+        const MTDGeomDet* thedet = geom->idToDet(geoId);
+        if (thedet == nullptr)
+          throw cms::Exception("BtlLocalRecoValidation") << "GeographicalID: " << std::hex << geoId.rawId() << " ("
+                                                         << detId.rawId() << ") is invalid!" << std::dec << std::endl;
+        const ProxyMTDTopology& topoproxy = static_cast<const ProxyMTDTopology&>(thedet->topology());
+        const RectangularMTDTopology& topo = static_cast<const RectangularMTDTopology&>(topoproxy.specificTopology());
 
-    if (uncalibRecHitsPlots_) {
-      DetId geoId = detId.geographicalId(MTDTopologyMode::crysLayoutFromTopoMode(topology->getMTDTopologyMode()));
-      const MTDGeomDet* thedet = geom->idToDet(geoId);
-      if (thedet == nullptr)
-        throw cms::Exception("BtlLocalRecoValidation") << "GeographicalID: " << std::hex << geoId.rawId() << " ("
-                                                       << detId.rawId() << ") is invalid!" << std::dec << std::endl;
-      const ProxyMTDTopology& topoproxy = static_cast<const ProxyMTDTopology&>(thedet->topology());
-      const RectangularMTDTopology& topo = static_cast<const RectangularMTDTopology&>(topoproxy.specificTopology());
+        Local3DPoint local_point(0., 0., 0.);
+        local_point = topo.pixelToModuleLocalPoint(local_point, detId.row(topo.nrows()), detId.column(topo.nrows()));
+        const auto& global_point = thedet->toGlobal(local_point);
 
-      Local3DPoint local_point(0., 0., 0.);
-      local_point = topo.pixelToModuleLocalPoint(local_point, detId.row(topo.nrows()), detId.column(topo.nrows()));
-      const auto& global_point = thedet->toGlobal(local_point);
+        float time_res = hit_time - m_btlSimHits[detId.rawId()].time;
 
-      float time_res = hit_time - m_btlSimHits[detId.rawId()].time;
+        // amplitude histograms
 
-      // amplitude histograms
+        int qBin = (int)(hit_amplitude / binWidthQ_);
+        if (qBin > nBinsQ_ - 1)
+          qBin = nBinsQ_ - 1;
 
-      int qBin = (int)(hit_amplitude / binWidthQ_);
-      if (qBin > nBinsQ_ - 1)
-        qBin = nBinsQ_ - 1;
+        meTimeResQ_[qBin]->Fill(time_res);
 
-      meTimeResQ_[qBin]->Fill(time_res);
+        int etaBin = 0;
+        for (int ibin = 1; ibin < nBinsQEta_; ++ibin)
+          if (fabs(global_point.eta()) >= binsQEta_[ibin] && fabs(global_point.eta()) < binsQEta_[ibin + 1])
+            etaBin = ibin;
 
-      int etaBin = 0;
-      for (int ibin = 1; ibin < nBinsQEta_; ++ibin)
-        if (fabs(global_point.eta()) >= binsQEta_[ibin] && fabs(global_point.eta()) < binsQEta_[ibin + 1])
-          etaBin = ibin;
+        meTimeResQvsEta_[qBin][etaBin]->Fill(time_res);
 
-      meTimeResQvsEta_[qBin][etaBin]->Fill(time_res);
+        // eta histograms
 
-      // eta histograms
+        etaBin = (int)(fabs(global_point.eta()) / binWidthEta_);
+        if (etaBin > nBinsEta_ - 1)
+          etaBin = nBinsEta_ - 1;
 
-      etaBin = (int)(fabs(global_point.eta()) / binWidthEta_);
-      if (etaBin > nBinsEta_ - 1)
-        etaBin = nBinsEta_ - 1;
+        meTimeResEta_[etaBin]->Fill(time_res);
 
-      meTimeResEta_[etaBin]->Fill(time_res);
+        qBin = 0;
+        for (int ibin = 1; ibin < nBinsEtaQ_; ++ibin)
+          if (hit_amplitude >= binsEtaQ_[ibin] && hit_amplitude < binsEtaQ_[ibin + 1])
+            qBin = ibin;
 
-      qBin = 0;
-      for (int ibin = 1; ibin < nBinsEtaQ_; ++ibin)
-        if (hit_amplitude >= binsEtaQ_[ibin] && hit_amplitude < binsEtaQ_[ibin + 1])
-          qBin = ibin;
-
-      meTimeResEtavsQ_[etaBin][qBin]->Fill(time_res);
-    }
-  }  // uRecHit loop}
+        meTimeResEtavsQ_[etaBin][qBin]->Fill(time_res);
+      }
+    }  // uRecHit loop}
+  }
 }
 
 // ------------ method for histogram booking ------------
@@ -1028,59 +1030,63 @@ void BtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
   meCluHits_ = ibook.book1D("BtlCluHitNumber", "BTL hits per cluster; Cluster size", 10, 0, 10);
   meCluZvsPhi_ = ibook.book2D(
       "BtlOccupancy", "BTL cluster Z vs #phi;Z_{RECO} [cm]; #phi_{RECO} [rad]", 144, -260., 260., 50, -3.2, 3.2);
-  meCluEnergyvsEta_ = ibook.bookProfile(
-      "BtlCluEnergyVsEta", "BTL cluster energy vs #eta; |#eta_{RECO}|; E_{RECO} [cm]", 30, 0., 1.55, 0., 20., "S");
-  meCluHitsvsEta_ = ibook.bookProfile(
-      "BtlCluHitsVsEta", "BTL hits per cluster vs #eta; |#eta_{RECO}|;Cluster size", 30, 0., 1.55, 0., 10., "S");
 
-  meCluTimeRes_ = ibook.book1D("BtlCluTimeRes", "BTL cluster time resolution;T_{RECO}-T_{SIM} [ns]", 100, -0.5, 0.5);
-  meCluEnergyRes_ =
-      ibook.book1D("BtlCluEnergyRes", "BTL cluster energy resolution;E_{RECO}-E_{SIM} [MeV]", 100, -0.5, 0.5);
-  meCluTResvsE_ = ibook.bookProfile("BtlCluTResvsE",
-                                    "BTL cluster time resolution vs E;E_{SIM} [MeV];(T_{RECO}-T_{SIM}) [ns]",
-                                    20,
-                                    0.,
-                                    20.,
-                                    -0.5,
-                                    0.5,
-                                    "S");
-  meCluTResvsEta_ = ibook.bookProfile("BtlCluTResvsEta",
-                                      "BTL cluster time resolution vs #eta;|#eta_{RECO}|;(T_{RECO}-T_{SIM}) [ns]",
-                                      30,
-                                      0,
-                                      1.55,
+  if (optionalPlots_) {
+    meCluEnergyvsEta_ = ibook.bookProfile(
+        "BtlCluEnergyVsEta", "BTL cluster energy vs #eta; |#eta_{RECO}|; E_{RECO} [cm]", 30, 0., 1.55, 0., 20., "S");
+    meCluHitsvsEta_ = ibook.bookProfile(
+        "BtlCluHitsVsEta", "BTL hits per cluster vs #eta; |#eta_{RECO}|;Cluster size", 30, 0., 1.55, 0., 10., "S");
+
+    meCluTimeRes_ = ibook.book1D("BtlCluTimeRes", "BTL cluster time resolution;T_{RECO}-T_{SIM} [ns]", 100, -0.5, 0.5);
+    meCluEnergyRes_ =
+        ibook.book1D("BtlCluEnergyRes", "BTL cluster energy resolution;E_{RECO}-E_{SIM} [MeV]", 100, -0.5, 0.5);
+    meCluTResvsE_ = ibook.bookProfile("BtlCluTResvsE",
+                                      "BTL cluster time resolution vs E;E_{SIM} [MeV];(T_{RECO}-T_{SIM}) [ns]",
+                                      20,
+                                      0.,
+                                      20.,
                                       -0.5,
                                       0.5,
                                       "S");
-  meCluTPullvsE_ = ibook.bookProfile("BtlCluTPullvsE",
-                                     "BTL cluster time pull vs E;E_{SIM} [MeV];(T_{RECO}-T_{SIM})/#sigma_{T_{RECO}}",
-                                     20,
-                                     0.,
-                                     20.,
-                                     -5.,
-                                     5.,
-                                     "S");
-  meCluTPullvsEta_ =
-      ibook.bookProfile("BtlCluTPullvsEta",
-                        "BTL cluster time pull vs #eta;|#eta_{RECO}|;(T_{RECO}-T_{SIM})/#sigma_{T_{RECO}}",
-                        30,
-                        0,
-                        1.55,
-                        -5.,
-                        5.,
-                        "S");
-  meCluRhoRes_ =
-      ibook.book1D("BtlCluRhoRes", "BTL cluster #rho resolution;#rho_{RECO}-#rho_{SIM} [cm]", 100, -0.5, 0.5);
-  meCluPhiRes_ =
-      ibook.book1D("BtlCluPhiRes", "BTL cluster #phi resolution;#phi_{RECO}-#phi_{SIM} [rad]", 100, -0.03, 0.03);
-  meCluZRes_ = ibook.book1D("BtlCluZRes", "BTL cluster Z resolution;Z_{RECO}-Z_{SIM} [cm]", 100, -0.2, 0.2);
-  meCluLocalXRes_ =
-      ibook.book1D("BtlCluLocalXRes", "BTL cluster local X resolution;X_{RECO}-X_{SIM} [cm]", 100, -3.1, 3.1);
-  meCluLocalYResZGlobPlus_ = ibook.book1D(
-      "BtlCluLocalYResZGlobPlus", "BTL cluster local Y resolution (glob Z > 0);Y_{RECO}-Y_{SIM} [cm]", 100, -0.2, 0.2);
-  meCluLocalYResZGlobMinus_ = ibook.book1D(
-      "BtlCluLocalYResZGlobMinus", "BTL cluster local Y resolution (glob Z < 0);Y_{RECO}-Y_{SIM} [cm]", 100, -0.2, 0.2);
-  if (optionalPlots_) {
+    meCluTResvsEta_ = ibook.bookProfile("BtlCluTResvsEta",
+                                        "BTL cluster time resolution vs #eta;|#eta_{RECO}|;(T_{RECO}-T_{SIM}) [ns]",
+                                        30,
+                                        0,
+                                        1.55,
+                                        -0.5,
+                                        0.5,
+                                        "S");
+    meCluTPullvsE_ = ibook.bookProfile("BtlCluTPullvsE",
+                                       "BTL cluster time pull vs E;E_{SIM} [MeV];(T_{RECO}-T_{SIM})/#sigma_{T_{RECO}}",
+                                       20,
+                                       0.,
+                                       20.,
+                                       -5.,
+                                       5.,
+                                       "S");
+    meCluTPullvsEta_ =
+        ibook.bookProfile("BtlCluTPullvsEta",
+                          "BTL cluster time pull vs #eta;|#eta_{RECO}|;(T_{RECO}-T_{SIM})/#sigma_{T_{RECO}}",
+                          30,
+                          0,
+                          1.55,
+                          -5.,
+                          5.,
+                          "S");
+    meCluRhoRes_ =
+        ibook.book1D("BtlCluRhoRes", "BTL cluster #rho resolution;#rho_{RECO}-#rho_{SIM} [cm]", 100, -0.5, 0.5);
+    meCluPhiRes_ =
+        ibook.book1D("BtlCluPhiRes", "BTL cluster #phi resolution;#phi_{RECO}-#phi_{SIM} [rad]", 100, -0.03, 0.03);
+    meCluZRes_ = ibook.book1D("BtlCluZRes", "BTL cluster Z resolution;Z_{RECO}-Z_{SIM} [cm]", 100, -0.2, 0.2);
+    meCluLocalXRes_ =
+        ibook.book1D("BtlCluLocalXRes", "BTL cluster local X resolution;X_{RECO}-X_{SIM} [cm]", 100, -3.1, 3.1);
+    meCluLocalYResZGlobPlus_ = ibook.book1D(
+        "BtlCluLocalYResZGlobPlus", "BTL cluster local Y resolution (glob Z > 0);Y_{RECO}-Y_{SIM} [cm]", 100, -0.2, 0.2);
+    meCluLocalYResZGlobMinus_ = ibook.book1D("BtlCluLocalYResZGlobMinus",
+                                             "BTL cluster local Y resolution (glob Z < 0);Y_{RECO}-Y_{SIM} [cm]",
+                                             100,
+                                             -0.2,
+                                             0.2);
     meCluSingCrystalLocalYRes_ =
         ibook.book1D("BtlCluSingCrystalLocalYRes",
                      "BTL cluster local Y resolution (single Crystal clusters);Y_{RECO}-Y_{SIM} [cm]",
@@ -1151,22 +1157,24 @@ void BtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
                      100,
                      -0.2,
                      0.2);
-  }
-  meCluLocalYPullZGlobPlus_ = ibook.book1D(
-      "BtlCluLocalYPullZGlobPlus", "BTL cluster local Y pull (glob Z > 0);Y_{RECO}-Y_{SIM}/sigmaY_[RECO]", 100, -5., 5.);
-  meCluLocalYPullZGlobMinus_ = ibook.book1D("BtlCluLocalYPullZGlobMinus",
-                                            "BTL cluster local Y pull (glob Z < 0);Y_{RECO}-Y_{SIM}/sigmaY_[RECO]",
-                                            100,
-                                            -5.,
-                                            5.);
 
-  meCluLocalXPull_ =
-      ibook.book1D("BtlCluLocalXPull", "BTL cluster local X pull;X_{RECO}-X_{SIM}/sigmaX_[RECO]", 100, -5., 5.);
+    meCluLocalYPullZGlobPlus_ = ibook.book1D("BtlCluLocalYPullZGlobPlus",
+                                             "BTL cluster local Y pull (glob Z > 0);Y_{RECO}-Y_{SIM}/sigmaY_[RECO]",
+                                             100,
+                                             -5.,
+                                             5.);
+    meCluLocalYPullZGlobMinus_ = ibook.book1D("BtlCluLocalYPullZGlobMinus",
+                                              "BTL cluster local Y pull (glob Z < 0);Y_{RECO}-Y_{SIM}/sigmaY_[RECO]",
+                                              100,
+                                              -5.,
+                                              5.);
 
-  meCluZPull_ = ibook.book1D("BtlCluZPull", "BTL cluster Z pull;Z_{RECO}-Z_{SIM}/sigmaZ_[RECO]", 100, -5., 5.);
-  meCluXLocalErr_ = ibook.book1D("BtlCluXLocalErr", "BTL cluster X local error;sigmaX_{RECO,loc} [cm]", 20, 0., 2.);
-  meCluYLocalErr_ = ibook.book1D("BtlCluYLocalErr", "BTL cluster Y local error;sigmaY_{RECO,loc} [cm]", 20, 0., 0.4);
-  if (optionalPlots_) {
+    meCluLocalXPull_ =
+        ibook.book1D("BtlCluLocalXPull", "BTL cluster local X pull;X_{RECO}-X_{SIM}/sigmaX_[RECO]", 100, -5., 5.);
+
+    meCluZPull_ = ibook.book1D("BtlCluZPull", "BTL cluster Z pull;Z_{RECO}-Z_{SIM}/sigmaZ_[RECO]", 100, -5., 5.);
+    meCluXLocalErr_ = ibook.book1D("BtlCluXLocalErr", "BTL cluster X local error;sigmaX_{RECO,loc} [cm]", 20, 0., 2.);
+    meCluYLocalErr_ = ibook.book1D("BtlCluYLocalErr", "BTL cluster Y local error;sigmaY_{RECO,loc} [cm]", 20, 0., 0.4);
     meCluYXLocal_ = ibook.book2D("BtlCluYXLocal",
                                  "BTL cluster local Y vs X;X^{local}_{RECO} [cm];Y^{local}_{RECO} [cm]",
                                  200,
@@ -1183,6 +1191,8 @@ void BtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
                                     200,
                                     -2.8,
                                     2.8);
+    meUnmatchedCluEnergy_ =
+        ibook.book1D("BtlUnmatchedCluEnergy", "BTL unmatched cluster log10(energy);log10(E_{RECO} [MeV])", 5, -3, 2);
   }
 
   // with MtdSimLayerCluster as truth
@@ -1590,75 +1600,74 @@ void BtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
                      2.8);
   }
 
-  ///
-
-  meUnmatchedCluEnergy_ =
-      ibook.book1D("BtlUnmatchedCluEnergy", "BTL unmatched cluster log10(energy);log10(E_{RECO} [MeV])", 5, -3, 2);
-
   // --- UncalibratedRecHits histograms
 
-  meUncEneLVsX_ = ibook.bookProfile("BTLUncEneLVsX",
-                                    "BTL uncalibrated hit amplitude left - average vs X;X [cm];Delta(Q_{left}) [pC]",
-                                    20,
-                                    -5.,
-                                    5.,
-                                    -640.,
-                                    640.,
-                                    "S");
-  meUncEneRVsX_ = ibook.bookProfile("BTLUncEneRVsX",
-                                    "BTL uncalibrated hit amplitude right - average vs X;X [cm];Delta(Q_{right}) [pC]",
-                                    20,
-                                    -5.,
-                                    5.,
-                                    -640.,
-                                    640.,
-                                    "S");
+  if (optionalPlots_) {
+    meUncEneLVsX_ = ibook.bookProfile("BTLUncEneLVsX",
+                                      "BTL uncalibrated hit amplitude left - average vs X;X [cm];Delta(Q_{left}) [pC]",
+                                      20,
+                                      -5.,
+                                      5.,
+                                      -640.,
+                                      640.,
+                                      "S");
+    meUncEneRVsX_ =
+        ibook.bookProfile("BTLUncEneRVsX",
+                          "BTL uncalibrated hit amplitude right - average vs X;X [cm];Delta(Q_{right}) [pC]",
+                          20,
+                          -5.,
+                          5.,
+                          -640.,
+                          640.,
+                          "S");
 
-  meUncTimeLVsX_ = ibook.bookProfile("BTLUncTimeLVsX",
-                                     "BTL uncalibrated hit time left - average vs X;X [cm];Delta(T_{left}) [MeV]",
-                                     20,
-                                     -5.,
-                                     5.,
-                                     -25.,
-                                     25.,
-                                     "S");
-  meUncTimeRVsX_ = ibook.bookProfile("BTLUncTimeRVsX",
-                                     "BTL uncalibrated hit time right - average vs X;X [cm];Delta(T_{right}) [MeV]",
-                                     20,
-                                     -5.,
-                                     5.,
-                                     -25.,
-                                     25.,
-                                     "S");
+    meUncTimeLVsX_ = ibook.bookProfile("BTLUncTimeLVsX",
+                                       "BTL uncalibrated hit time left - average vs X;X [cm];Delta(T_{left}) [MeV]",
+                                       20,
+                                       -5.,
+                                       5.,
+                                       -25.,
+                                       25.,
+                                       "S");
+    meUncTimeRVsX_ = ibook.bookProfile("BTLUncTimeRVsX",
+                                       "BTL uncalibrated hit time right - average vs X;X [cm];Delta(T_{right}) [MeV]",
+                                       20,
+                                       -5.,
+                                       5.,
+                                       -25.,
+                                       25.,
+                                       "S");
+    if (uncalibRecHitsPlots_) {
+      for (unsigned int ihistoQ = 0; ihistoQ < nBinsQ_; ++ihistoQ) {
+        std::string hname = Form("TimeResQ_%d", ihistoQ);
+        std::string htitle = Form("BTL time resolution (Q bin = %d);T_{RECO} - T_{SIM} [ns]", ihistoQ);
+        meTimeResQ_[ihistoQ] = ibook.book1D(hname, htitle, 200, -0.3, 0.7);
 
-  if (uncalibRecHitsPlots_) {
-    for (unsigned int ihistoQ = 0; ihistoQ < nBinsQ_; ++ihistoQ) {
-      std::string hname = Form("TimeResQ_%d", ihistoQ);
-      std::string htitle = Form("BTL time resolution (Q bin = %d);T_{RECO} - T_{SIM} [ns]", ihistoQ);
-      meTimeResQ_[ihistoQ] = ibook.book1D(hname, htitle, 200, -0.3, 0.7);
+        for (unsigned int ihistoEta = 0; ihistoEta < nBinsQEta_; ++ihistoEta) {
+          hname = Form("TimeResQvsEta_%d_%d", ihistoQ, ihistoEta);
+          htitle =
+              Form("BTL time resolution (Q bin = %d, |#eta| bin = %d);T_{RECO} - T_{SIM} [ns]", ihistoQ, ihistoEta);
+          meTimeResQvsEta_[ihistoQ][ihistoEta] = ibook.book1D(hname, htitle, 200, -0.3, 0.7);
 
-      for (unsigned int ihistoEta = 0; ihistoEta < nBinsQEta_; ++ihistoEta) {
-        hname = Form("TimeResQvsEta_%d_%d", ihistoQ, ihistoEta);
-        htitle = Form("BTL time resolution (Q bin = %d, |#eta| bin = %d);T_{RECO} - T_{SIM} [ns]", ihistoQ, ihistoEta);
-        meTimeResQvsEta_[ihistoQ][ihistoEta] = ibook.book1D(hname, htitle, 200, -0.3, 0.7);
-
-      }  // ihistoEta loop
-
-    }  // ihistoQ loop
-
-    for (unsigned int ihistoEta = 0; ihistoEta < nBinsEta_; ++ihistoEta) {
-      std::string hname = Form("TimeResEta_%d", ihistoEta);
-      std::string htitle = Form("BTL time resolution (|#eta| bin = %d);T_{RECO} - T_{SIM} [ns]", ihistoEta);
-      meTimeResEta_[ihistoEta] = ibook.book1D(hname, htitle, 200, -0.3, 0.7);
-
-      for (unsigned int ihistoQ = 0; ihistoQ < nBinsEtaQ_; ++ihistoQ) {
-        hname = Form("TimeResEtavsQ_%d_%d", ihistoEta, ihistoQ);
-        htitle = Form("BTL time resolution (|#eta| bin = %d, Q bin = %d);T_{RECO} - T_{SIM} [ns]", ihistoEta, ihistoQ);
-        meTimeResEtavsQ_[ihistoEta][ihistoQ] = ibook.book1D(hname, htitle, 200, -0.3, 0.7);
+        }  // ihistoEta loop
 
       }  // ihistoQ loop
 
-    }  // ihistoEta loop
+      for (unsigned int ihistoEta = 0; ihistoEta < nBinsEta_; ++ihistoEta) {
+        std::string hname = Form("TimeResEta_%d", ihistoEta);
+        std::string htitle = Form("BTL time resolution (|#eta| bin = %d);T_{RECO} - T_{SIM} [ns]", ihistoEta);
+        meTimeResEta_[ihistoEta] = ibook.book1D(hname, htitle, 200, -0.3, 0.7);
+
+        for (unsigned int ihistoQ = 0; ihistoQ < nBinsEtaQ_; ++ihistoQ) {
+          hname = Form("TimeResEtavsQ_%d_%d", ihistoEta, ihistoQ);
+          htitle =
+              Form("BTL time resolution (|#eta| bin = %d, Q bin = %d);T_{RECO} - T_{SIM} [ns]", ihistoEta, ihistoQ);
+          meTimeResEtavsQ_[ihistoEta][ihistoQ] = ibook.book1D(hname, htitle, 200, -0.3, 0.7);
+
+        }  // ihistoQ loop
+
+      }  // ihistoEta loop
+    }
   }
 }
 

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -410,55 +410,58 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
       double cluLocYSIM = 0.;
       double cluLocZSIM = 0.;
 
-      for (int ihit = 0; ihit < cluster.size(); ++ihit) {
-        int hit_row = cluster.minHitRow() + cluster.hitOffset()[ihit * 2];
-        int hit_col = cluster.minHitCol() + cluster.hitOffset()[ihit * 2 + 1];
+      if (optionalPlots_) {
+        for (int ihit = 0; ihit < cluster.size(); ++ihit) {
+          int hit_row = cluster.minHitRow() + cluster.hitOffset()[ihit * 2];
+          int hit_col = cluster.minHitCol() + cluster.hitOffset()[ihit * 2 + 1];
 
-        // Match the RECO hit to the corresponding SIM hit
-        for (const auto& recHit : *etlRecHitsHandle) {
-          ETLDetId detId(recHit.id().rawId());
+          // Match the RECO hit to the corresponding SIM hit
+          for (const auto& recHit : *etlRecHitsHandle) {
+            ETLDetId detId(recHit.id().rawId());
 
-          DetId geoId = detId.geographicalId();
-          const MTDGeomDet* thedet = geom->idToDet(geoId);
-          const ProxyMTDTopology& topoproxy = static_cast<const ProxyMTDTopology&>(thedet->topology());
-          const RectangularMTDTopology& topo = static_cast<const RectangularMTDTopology&>(topoproxy.specificTopology());
+            DetId geoId = detId.geographicalId();
+            const MTDGeomDet* thedet = geom->idToDet(geoId);
+            const ProxyMTDTopology& topoproxy = static_cast<const ProxyMTDTopology&>(thedet->topology());
+            const RectangularMTDTopology& topo =
+                static_cast<const RectangularMTDTopology&>(topoproxy.specificTopology());
 
-          Local3DPoint local_point(topo.localX(recHit.row()), topo.localY(recHit.column()), 0.);
+            Local3DPoint local_point(topo.localX(recHit.row()), topo.localY(recHit.column()), 0.);
 
-          std::pair<uint8_t, uint8_t> pixel = geomUtil.pixelInModule(detId, local_point);
-          mtd_digitizer::MTDCellId pixelId(detId.rawId(), pixel.first, pixel.second);
+            std::pair<uint8_t, uint8_t> pixel = geomUtil.pixelInModule(detId, local_point);
+            mtd_digitizer::MTDCellId pixelId(detId.rawId(), pixel.first, pixel.second);
 
-          if (m_etlSimHits[idet].count(pixelId) == 0)
-            continue;
+            if (m_etlSimHits[idet].count(pixelId) == 0)
+              continue;
 
-          // Check the hit position
-          if (detId.zside() != cluId.zside() || detId.mtdRR() != cluId.mtdRR() || detId.module() != cluId.module() ||
-              recHit.row() != hit_row || recHit.column() != hit_col)
-            continue;
+            // Check the hit position
+            if (detId.zside() != cluId.zside() || detId.mtdRR() != cluId.mtdRR() || detId.module() != cluId.module() ||
+                recHit.row() != hit_row || recHit.column() != hit_col)
+              continue;
 
-          // Check the hit time
-          if (recHit.time() != cluster.hitTIME()[ihit])
-            continue;
+            // Check the hit time
+            if (recHit.time() != cluster.hitTIME()[ihit])
+              continue;
 
-          // SIM hit's position in the module reference frame
-          Local3DPoint local_point_sim(convertMmToCm(m_etlSimHits[idet][pixelId].x),
-                                       convertMmToCm(m_etlSimHits[idet][pixelId].y),
-                                       convertMmToCm(m_etlSimHits[idet][pixelId].z));
+            // SIM hit's position in the module reference frame
+            Local3DPoint local_point_sim(convertMmToCm(m_etlSimHits[idet][pixelId].x),
+                                         convertMmToCm(m_etlSimHits[idet][pixelId].y),
+                                         convertMmToCm(m_etlSimHits[idet][pixelId].z));
 
-          // Calculate the SIM cluster's position in the module reference frame
-          cluLocXSIM += local_point_sim.x() * m_etlSimHits[idet][pixelId].energy;
-          cluLocYSIM += local_point_sim.y() * m_etlSimHits[idet][pixelId].energy;
-          cluLocZSIM += local_point_sim.z() * m_etlSimHits[idet][pixelId].energy;
+            // Calculate the SIM cluster's position in the module reference frame
+            cluLocXSIM += local_point_sim.x() * m_etlSimHits[idet][pixelId].energy;
+            cluLocYSIM += local_point_sim.y() * m_etlSimHits[idet][pixelId].energy;
+            cluLocZSIM += local_point_sim.z() * m_etlSimHits[idet][pixelId].energy;
 
-          // Calculate the SIM cluster energy and time
-          cluEneSIM += m_etlSimHits[idet][pixelId].energy;
-          cluTimeSIM += m_etlSimHits[idet][pixelId].time * m_etlSimHits[idet][pixelId].energy;
+            // Calculate the SIM cluster energy and time
+            cluEneSIM += m_etlSimHits[idet][pixelId].energy;
+            cluTimeSIM += m_etlSimHits[idet][pixelId].time * m_etlSimHits[idet][pixelId].energy;
 
-          break;
+            break;
 
-        }  // recHit loop
+          }  // recHit loop
 
-      }  // ihit loop
+        }  // ihit loop
+      }
 
       // Find the MTDTrackingRecHit corresponding to the cluster
       MTDTrackingRecHit* comp(nullptr);
@@ -478,37 +481,37 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
 
       // --- Fill the cluster resolution histograms
       int iside = (cluId.zside() == -1 ? 0 : 1);
-      if (cluTimeSIM > 0. && cluEneSIM > 0.) {
-        cluTimeSIM /= cluEneSIM;
+      if (optionalPlots_) {
+        if (cluTimeSIM > 0. && cluEneSIM > 0.) {
+          cluTimeSIM /= cluEneSIM;
 
-        Local3DPoint cluLocalPosSIM(cluLocXSIM / cluEneSIM, cluLocYSIM / cluEneSIM, cluLocZSIM / cluEneSIM);
-        const auto& cluGlobalPosSIM = genericDet->toGlobal(cluLocalPosSIM);
+          Local3DPoint cluLocalPosSIM(cluLocXSIM / cluEneSIM, cluLocYSIM / cluEneSIM, cluLocZSIM / cluEneSIM);
+          const auto& cluGlobalPosSIM = genericDet->toGlobal(cluLocalPosSIM);
 
-        float time_res = cluster.time() - cluTimeSIM;
-        float x_res = global_point.x() - cluGlobalPosSIM.x();
-        float y_res = global_point.y() - cluGlobalPosSIM.y();
-        float z_res = global_point.z() - cluGlobalPosSIM.z();
+          float time_res = cluster.time() - cluTimeSIM;
+          float x_res = global_point.x() - cluGlobalPosSIM.x();
+          float y_res = global_point.y() - cluGlobalPosSIM.y();
+          float z_res = global_point.z() - cluGlobalPosSIM.z();
 
-        meCluTimeRes_[iside]->Fill(time_res);
-        meCluXRes_[iside]->Fill(x_res);
-        meCluYRes_[iside]->Fill(y_res);
-        meCluZRes_[iside]->Fill(z_res);
+          meCluTimeRes_[iside]->Fill(time_res);
+          meCluXRes_[iside]->Fill(x_res);
+          meCluYRes_[iside]->Fill(y_res);
+          meCluZRes_[iside]->Fill(z_res);
 
-        meCluTPullvsEta_[iside]->Fill(cluGlobalPosSIM.eta(), time_res / cluster.timeError());
-        meCluTPullvsE_[iside]->Fill(cluEneSIM, time_res / cluster.timeError());
+          meCluTPullvsEta_[iside]->Fill(cluGlobalPosSIM.eta(), time_res / cluster.timeError());
+          meCluTPullvsE_[iside]->Fill(cluEneSIM, time_res / cluster.timeError());
 
-        if (matchClu && comp != nullptr) {
-          meCluXPull_[iside]->Fill(x_res / std::sqrt(comp->globalPositionError().cxx()));
-          meCluYPull_[iside]->Fill(y_res / std::sqrt(comp->globalPositionError().cyy()));
-          meCluXLocalErr_[iside]->Fill(std::sqrt(comp->localPositionError().xx()));
-          meCluYLocalErr_[iside]->Fill(std::sqrt(comp->localPositionError().yy()));
-        }
-        if (optionalPlots_) {
+          if (matchClu && comp != nullptr) {
+            meCluXPull_[iside]->Fill(x_res / std::sqrt(comp->globalPositionError().cxx()));
+            meCluYPull_[iside]->Fill(y_res / std::sqrt(comp->globalPositionError().cyy()));
+            meCluXLocalErr_[iside]->Fill(std::sqrt(comp->localPositionError().xx()));
+            meCluYLocalErr_[iside]->Fill(std::sqrt(comp->localPositionError().yy()));
+          }
           meCluYXLocal_[iside]->Fill(local_point.x(), local_point.y());
           meCluYXLocalSim_[iside]->Fill(cluLocalPosSIM.x(), cluLocalPosSIM.y());
-        }
 
-      }  // if ( cluTimeSIM > 0. &&  cluEneSIM > 0. )
+        }  // if ( cluTimeSIM > 0. &&  cluEneSIM > 0. )
+      }
 
       // --- Fill the cluster resolution histograms using MtdSimLayerClusters as mtd truth
       edm::Ref<edmNew::DetSetVector<FTLCluster>, FTLCluster> clusterRef = edmNew::makeRefTo(etlRecCluHandle, &cluster);
@@ -553,60 +556,62 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
   }  // DetSetClu loop
 
   // --- Loop over the ETL Uncalibrated RECO hits
-  if (uncalibRecHitsPlots_) {
-    auto etlUncalibRecHitsHandle = makeValid(iEvent.getHandle(etlUncalibRecHitsToken_));
+  if (optionalPlots_) {
+    if (uncalibRecHitsPlots_) {
+      auto etlUncalibRecHitsHandle = makeValid(iEvent.getHandle(etlUncalibRecHitsToken_));
 
-    for (const auto& uRecHit : *etlUncalibRecHitsHandle) {
-      ETLDetId detId = uRecHit.id();
-      int idet = detId.zside() + detId.nDisc();
+      for (const auto& uRecHit : *etlUncalibRecHitsHandle) {
+        ETLDetId detId = uRecHit.id();
+        int idet = detId.zside() + detId.nDisc();
 
-      DetId geoId = detId.geographicalId();
-      const MTDGeomDet* thedet = geom->idToDet(geoId);
-      const ProxyMTDTopology& topoproxy = static_cast<const ProxyMTDTopology&>(thedet->topology());
-      const RectangularMTDTopology& topo = static_cast<const RectangularMTDTopology&>(topoproxy.specificTopology());
+        DetId geoId = detId.geographicalId();
+        const MTDGeomDet* thedet = geom->idToDet(geoId);
+        const ProxyMTDTopology& topoproxy = static_cast<const ProxyMTDTopology&>(thedet->topology());
+        const RectangularMTDTopology& topo = static_cast<const RectangularMTDTopology&>(topoproxy.specificTopology());
 
-      Local3DPoint local_point(topo.localX(uRecHit.row()), topo.localY(uRecHit.column()), 0.);
-      const auto& global_point = thedet->toGlobal(local_point);
+        Local3DPoint local_point(topo.localX(uRecHit.row()), topo.localY(uRecHit.column()), 0.);
+        const auto& global_point = thedet->toGlobal(local_point);
 
-      std::pair<uint8_t, uint8_t> pixel = geomUtil.pixelInModule(detId, local_point);
-      mtd_digitizer::MTDCellId pixelId(detId.rawId(), pixel.first, pixel.second);
+        std::pair<uint8_t, uint8_t> pixel = geomUtil.pixelInModule(detId, local_point);
+        mtd_digitizer::MTDCellId pixelId(detId.rawId(), pixel.first, pixel.second);
 
-      // --- Skip UncalibratedRecHits not matched to SimHits
-      if (m_etlSimHits[idet].count(pixelId) == 0)
-        continue;
+        // --- Skip UncalibratedRecHits not matched to SimHits
+        if (m_etlSimHits[idet].count(pixelId) == 0)
+          continue;
 
-      if (thedet == nullptr)
-        throw cms::Exception("EtlLocalRecoValidation") << "GeographicalID: " << std::hex << geoId.rawId() << " ("
-                                                       << detId.rawId() << ") is invalid!" << std::dec << std::endl;
+        if (thedet == nullptr)
+          throw cms::Exception("EtlLocalRecoValidation") << "GeographicalID: " << std::hex << geoId.rawId() << " ("
+                                                         << detId.rawId() << ") is invalid!" << std::dec << std::endl;
 
-      // --- Fill the histograms
+        // --- Fill the histograms
 
-      if (uRecHit.amplitude().first < hitMinAmplitude_)
-        continue;
+        if (uRecHit.amplitude().first < hitMinAmplitude_)
+          continue;
 
-      float time_res = uRecHit.time().first - m_etlSimHits[idet][pixelId].time;
+        float time_res = uRecHit.time().first - m_etlSimHits[idet][pixelId].time;
 
-      int iside = (detId.zside() == -1 ? 0 : 1);
+        int iside = (detId.zside() == -1 ? 0 : 1);
 
-      // amplitude histograms
+        // amplitude histograms
 
-      int totBin = (int)(uRecHit.amplitude().first / binWidthTot_);
-      if (totBin > nBinsTot_ - 1)
-        totBin = nBinsTot_ - 1;
+        int totBin = (int)(uRecHit.amplitude().first / binWidthTot_);
+        if (totBin > nBinsTot_ - 1)
+          totBin = nBinsTot_ - 1;
 
-      meTimeResTot_[iside][totBin]->Fill(time_res);
+        meTimeResTot_[iside][totBin]->Fill(time_res);
 
-      // eta histograms
+        // eta histograms
 
-      int etaBin = (int)((fabs(global_point.eta()) - etaMin_) / binWidthEta_);
-      if (etaBin < 0)
-        etaBin = 0;
-      else if (etaBin > nBinsEta_ - 1)
-        etaBin = nBinsEta_ - 1;
+        int etaBin = (int)((fabs(global_point.eta()) - etaMin_) / binWidthEta_);
+        if (etaBin < 0)
+          etaBin = 0;
+        else if (etaBin > nBinsEta_ - 1)
+          etaBin = nBinsEta_ - 1;
 
-      meTimeResEta_[iside][etaBin]->Fill(time_res);
+        meTimeResEta_[iside][etaBin]->Fill(time_res);
 
-    }  // uRecHit loop
+      }  // uRecHit loop
+    }
   }
 }
 
@@ -743,6 +748,7 @@ void EtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
   meHitEta_[2] = ibook.book1D(
       "EtlHitEtaZposD1", "ETL RECO hits #eta (+Z, Single(topo1D)/First(topo2D) Disk);#eta_{RECO}", 100, 1.56, 3.2);
   meHitEta_[3] = ibook.book1D("EtlHitEtaZposD2", "ETL RECO hits #eta (+Z, Second Disk);#eta_{RECO}", 100, 1.56, 3.2);
+
   meTimeRes_ = ibook.book1D("EtlTimeRes", "ETL time resolution;T_{RECO}-T_{SIM}", 100, -0.5, 0.5);
   meHitTvsPhi_[0] = ibook.bookProfile(
       "EtlHitTvsPhiZnegD1",
@@ -855,72 +861,77 @@ void EtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
       "EtlCluHitNumberZposD1", "ETL hits per cluster (+Z, Single(topo1D)/First(topo2D) Disk);Cluster size", 5, 0, 5);
   meCluHits_[3] = ibook.book1D("EtlCluHitNumberZposD2", "ETL hits per cluster (+Z, Second Disk);Cluster size", 5, 0, 5);
 
-  meCluTimeRes_[0] =
-      ibook.book1D("EtlCluTimeResZneg", "ETL cluster time resolution (-Z);T_{RECO}-T_{SIM} [ns]", 100, -0.5, 0.5);
-  meCluTimeRes_[1] =
-      ibook.book1D("EtlCluTimeResZpos", "ETL cluster time resolution (+Z);T_{RECO}-T_{SIM} [MeV]", 100, -0.5, 0.5);
-
-  meCluTPullvsE_[0] =
-      ibook.bookProfile("EtlCluTPullvsEZneg",
-                        "ETL cluster time pull vs E (-Z);E_{SIM} [MeV];(T_{RECO}-T_{SIM})/#sigma_{T_{RECO}}",
-                        25,
-                        0.,
-                        0.5,
-                        -5.,
-                        5.,
-                        "S");
-  meCluTPullvsE_[1] =
-      ibook.bookProfile("EtlCluTPullvsEZpos",
-                        "ETL cluster time pull vs E (+Z);E_{SIM} [MeV];(T_{RECO}-T_{SIM})/#sigma_{T_{RECO}}",
-                        25,
-                        0.,
-                        0.5,
-                        -5.,
-                        5.,
-                        "S");
-  meCluTPullvsEta_[0] =
-      ibook.bookProfile("EtlCluTPullvsEtaZneg",
-                        "ETL cluster time pull vs #eta (-Z);|#eta_{RECO}|;(T_{RECO}-T_{SIM})/#sigma_{T_{RECO}}",
-                        30,
-                        -3.,
-                        -1.65,
-                        -5.,
-                        5.,
-                        "S");
-  meCluTPullvsEta_[1] =
-      ibook.bookProfile("EtlCluTPullvsEtaZpos",
-                        "ETL cluster time pull vs #eta (+Z);|#eta_{RECO}|;(T_{RECO}-T_{SIM})/#sigma_{T_{RECO}}",
-                        30,
-                        1.65,
-                        3.,
-                        -5.,
-                        5.,
-                        "S");
-  meCluXRes_[0] = ibook.book1D("EtlCluXResZneg", "ETL cluster X resolution (-Z);X_{RECO}-X_{SIM} [cm]", 100, -0.1, 0.1);
-  meCluXRes_[1] = ibook.book1D("EtlCluXResZpos", "ETL cluster X resolution (+Z);X_{RECO}-X_{SIM} [cm]", 100, -0.1, 0.1);
-  meCluYRes_[0] = ibook.book1D("EtlCluYResZneg", "ETL cluster Y resolution (-Z);Y_{RECO}-Y_{SIM} [cm]", 100, -0.1, 0.1);
-  meCluYRes_[1] = ibook.book1D("EtlCluYResZpos", "ETL cluster Y resolution (+Z);Y_{RECO}-Y_{SIM} [cm]", 100, -0.1, 0.1);
-  meCluZRes_[0] =
-      ibook.book1D("EtlCluZResZneg", "ETL cluster Z resolution (-Z);Z_{RECO}-Z_{SIM} [cm]", 100, -0.003, 0.003);
-  meCluZRes_[1] =
-      ibook.book1D("EtlCluZResZpos", "ETL cluster Z resolution (+Z);Z_{RECO}-Z_{SIM} [cm]", 100, -0.003, 0.003);
-  meCluXPull_[0] =
-      ibook.book1D("EtlCluXPullZneg", "ETL cluster X pull (-Z);X_{RECO}-X_{SIM}/sigmaX_[RECO] [cm]", 100, -5., 5.);
-  meCluXPull_[1] =
-      ibook.book1D("EtlCluXPullZpos", "ETL cluster X pull (+Z);X_{RECO}-X_{SIM}/sigmaX_[RECO] [cm]", 100, -5., 5.);
-  meCluYPull_[0] =
-      ibook.book1D("EtlCluYPullZneg", "ETL cluster Y pull (-Z);Y_{RECO}-Y_{SIM}/sigmaY_[RECO] [cm]", 100, -5., 5.);
-  meCluYPull_[1] =
-      ibook.book1D("EtlCluYPullZpos", "ETL cluster Y pull (+Z);Y_{RECO}-Y_{SIM}/sigmaY_[RECO] [cm]", 100, -5., 5.);
-  meCluXLocalErr_[0] =
-      ibook.book1D("EtlCluXLocalErrNeg", "ETL cluster X local error (-Z);sigmaX_{RECO,loc} [cm]", 50, 0., 0.2);
-  meCluXLocalErr_[1] =
-      ibook.book1D("EtlCluXLocalErrPos", "ETL cluster X local error (+Z);sigmaX_{RECO,loc} [cm]", 50, 0., 0.2);
-  meCluYLocalErr_[0] =
-      ibook.book1D("EtlCluYLocalErrNeg", "ETL cluster Y local error (-Z);sigmaY_{RECO,loc} [cm]", 50., 0., 0.2);
-  meCluYLocalErr_[1] =
-      ibook.book1D("EtlCluYLocalErrPos", "ETL cluster Y local error (+Z);sigmaY_{RECO,loc} [cm]", 50, 0., 0.2);
   if (optionalPlots_) {
+    meCluTimeRes_[0] =
+        ibook.book1D("EtlCluTimeResZneg", "ETL cluster time resolution (-Z);T_{RECO}-T_{SIM} [ns]", 100, -0.5, 0.5);
+    meCluTimeRes_[1] =
+        ibook.book1D("EtlCluTimeResZpos", "ETL cluster time resolution (+Z);T_{RECO}-T_{SIM} [MeV]", 100, -0.5, 0.5);
+
+    meCluTPullvsE_[0] =
+        ibook.bookProfile("EtlCluTPullvsEZneg",
+                          "ETL cluster time pull vs E (-Z);E_{SIM} [MeV];(T_{RECO}-T_{SIM})/#sigma_{T_{RECO}}",
+                          25,
+                          0.,
+                          0.5,
+                          -5.,
+                          5.,
+                          "S");
+    meCluTPullvsE_[1] =
+        ibook.bookProfile("EtlCluTPullvsEZpos",
+                          "ETL cluster time pull vs E (+Z);E_{SIM} [MeV];(T_{RECO}-T_{SIM})/#sigma_{T_{RECO}}",
+                          25,
+                          0.,
+                          0.5,
+                          -5.,
+                          5.,
+                          "S");
+    meCluTPullvsEta_[0] =
+        ibook.bookProfile("EtlCluTPullvsEtaZneg",
+                          "ETL cluster time pull vs #eta (-Z);|#eta_{RECO}|;(T_{RECO}-T_{SIM})/#sigma_{T_{RECO}}",
+                          30,
+                          -3.,
+                          -1.65,
+                          -5.,
+                          5.,
+                          "S");
+    meCluTPullvsEta_[1] =
+        ibook.bookProfile("EtlCluTPullvsEtaZpos",
+                          "ETL cluster time pull vs #eta (+Z);|#eta_{RECO}|;(T_{RECO}-T_{SIM})/#sigma_{T_{RECO}}",
+                          30,
+                          1.65,
+                          3.,
+                          -5.,
+                          5.,
+                          "S");
+    meCluXRes_[0] =
+        ibook.book1D("EtlCluXResZneg", "ETL cluster X resolution (-Z);X_{RECO}-X_{SIM} [cm]", 100, -0.1, 0.1);
+    meCluXRes_[1] =
+        ibook.book1D("EtlCluXResZpos", "ETL cluster X resolution (+Z);X_{RECO}-X_{SIM} [cm]", 100, -0.1, 0.1);
+    meCluYRes_[0] =
+        ibook.book1D("EtlCluYResZneg", "ETL cluster Y resolution (-Z);Y_{RECO}-Y_{SIM} [cm]", 100, -0.1, 0.1);
+    meCluYRes_[1] =
+        ibook.book1D("EtlCluYResZpos", "ETL cluster Y resolution (+Z);Y_{RECO}-Y_{SIM} [cm]", 100, -0.1, 0.1);
+    meCluZRes_[0] =
+        ibook.book1D("EtlCluZResZneg", "ETL cluster Z resolution (-Z);Z_{RECO}-Z_{SIM} [cm]", 100, -0.003, 0.003);
+    meCluZRes_[1] =
+        ibook.book1D("EtlCluZResZpos", "ETL cluster Z resolution (+Z);Z_{RECO}-Z_{SIM} [cm]", 100, -0.003, 0.003);
+    meCluXPull_[0] =
+        ibook.book1D("EtlCluXPullZneg", "ETL cluster X pull (-Z);X_{RECO}-X_{SIM}/sigmaX_[RECO] [cm]", 100, -5., 5.);
+    meCluXPull_[1] =
+        ibook.book1D("EtlCluXPullZpos", "ETL cluster X pull (+Z);X_{RECO}-X_{SIM}/sigmaX_[RECO] [cm]", 100, -5., 5.);
+    meCluYPull_[0] =
+        ibook.book1D("EtlCluYPullZneg", "ETL cluster Y pull (-Z);Y_{RECO}-Y_{SIM}/sigmaY_[RECO] [cm]", 100, -5., 5.);
+    meCluYPull_[1] =
+        ibook.book1D("EtlCluYPullZpos", "ETL cluster Y pull (+Z);Y_{RECO}-Y_{SIM}/sigmaY_[RECO] [cm]", 100, -5., 5.);
+    meCluXLocalErr_[0] =
+        ibook.book1D("EtlCluXLocalErrNeg", "ETL cluster X local error (-Z);sigmaX_{RECO,loc} [cm]", 50, 0., 0.2);
+    meCluXLocalErr_[1] =
+        ibook.book1D("EtlCluXLocalErrPos", "ETL cluster X local error (+Z);sigmaX_{RECO,loc} [cm]", 50, 0., 0.2);
+    meCluYLocalErr_[0] =
+        ibook.book1D("EtlCluYLocalErrNeg", "ETL cluster Y local error (-Z);sigmaY_{RECO,loc} [cm]", 50., 0., 0.2);
+    meCluYLocalErr_[1] =
+        ibook.book1D("EtlCluYLocalErrPos", "ETL cluster Y local error (+Z);sigmaY_{RECO,loc} [cm]", 50, 0., 0.2);
+
     meCluOccupancy_[0] =
         ibook.book2D("EtlCluOccupancyZnegD1",
                      "ETL cluster X vs Y (-Z, Single(topo1D)/First(topo2D) Disk);X_{RECO} [cm]; Y_{RECO} [cm]",
@@ -1112,24 +1123,26 @@ void EtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
 
   // --- UncalibratedRecHits histograms
 
-  if (uncalibRecHitsPlots_) {
-    const std::string det_name[2] = {"ETL-", "ETL+"};
-    for (unsigned int iside = 0; iside < 2; ++iside) {
-      for (unsigned int ihistoTot = 0; ihistoTot < nBinsTot_; ++ihistoTot) {
-        std::string hname = Form("TimeResTot_%d_%d", iside, ihistoTot);
-        std::string htitle =
-            Form("%s time resolution (Tot bin = %d);T_{RECO} - T_{SIM} [ns]", det_name[iside].data(), ihistoTot);
-        meTimeResTot_[iside][ihistoTot] = ibook.book1D(hname, htitle, 200, -0.5, 0.5);
+  if (optionalPlots_) {
+    if (uncalibRecHitsPlots_) {
+      const std::string det_name[2] = {"ETL-", "ETL+"};
+      for (unsigned int iside = 0; iside < 2; ++iside) {
+        for (unsigned int ihistoTot = 0; ihistoTot < nBinsTot_; ++ihistoTot) {
+          std::string hname = Form("TimeResTot_%d_%d", iside, ihistoTot);
+          std::string htitle =
+              Form("%s time resolution (Tot bin = %d);T_{RECO} - T_{SIM} [ns]", det_name[iside].data(), ihistoTot);
+          meTimeResTot_[iside][ihistoTot] = ibook.book1D(hname, htitle, 200, -0.5, 0.5);
 
-      }  // ihistoTot loop
+        }  // ihistoTot loop
 
-      for (unsigned int ihistoEta = 0; ihistoEta < nBinsEta_; ++ihistoEta) {
-        std::string hname = Form("TimeResEta_%d_%d", iside, ihistoEta);
-        std::string htitle =
-            Form("%s time resolution (|#eta| bin = %d);T_{RECO} - T_{SIM} [ns]", det_name[iside].data(), ihistoEta);
-        meTimeResEta_[iside][ihistoEta] = ibook.book1D(hname, htitle, 200, -0.5, 0.5);
+        for (unsigned int ihistoEta = 0; ihistoEta < nBinsEta_; ++ihistoEta) {
+          std::string hname = Form("TimeResEta_%d_%d", iside, ihistoEta);
+          std::string htitle =
+              Form("%s time resolution (|#eta| bin = %d);T_{RECO} - T_{SIM} [ns]", det_name[iside].data(), ihistoEta);
+          meTimeResEta_[iside][ihistoEta] = ibook.book1D(hname, htitle, 200, -0.5, 0.5);
 
-      }  // ihistoEta loop
+        }  // ihistoEta loop
+      }
     }
   }
 }

--- a/Validation/MtdValidation/plugins/MtdTracksHarvester.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksHarvester.cc
@@ -325,18 +325,18 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   meExtraPtEff_ =
       ibook.book1D("ExtraPtEff",
                    "MTD matching efficiency wrt extrapolated track associated to LV VS Pt;Pt [GeV];Efficiency",
-                   meTrackMatchedTPEffEtaTotLV->getNbinsX(),
-                   meTrackMatchedTPEffEtaTotLV->getTH1()->GetXaxis()->GetXmin(),
-                   meTrackMatchedTPEffEtaTotLV->getTH1()->GetXaxis()->GetXmax());
+                   meTrackMatchedTPEffPtTotLV->getNbinsX(),
+                   meTrackMatchedTPEffPtTotLV->getTH1()->GetXaxis()->GetXmin(),
+                   meTrackMatchedTPEffPtTotLV->getTH1()->GetXaxis()->GetXmax());
   meExtraPtEff_->getTH1()->SetMinimum(0.);
   computeEfficiency1D(meExtraPtMtd, meTrackMatchedTPEffPtTotLV, meExtraPtEff_);
 
   meExtraPtEtl2Eff_ =
       ibook.book1D("ExtraPtEtl2Eff",
                    "MTD matching efficiency (2 ETL) wrt extrapolated track associated to LV VS Pt;Pt [GeV];Efficiency",
-                   meTrackMatchedTPEffEtaTotLV->getNbinsX(),
-                   meTrackMatchedTPEffEtaTotLV->getTH1()->GetXaxis()->GetXmin(),
-                   meTrackMatchedTPEffEtaTotLV->getTH1()->GetXaxis()->GetXmax());
+                   meTrackMatchedTPEffPtTotLV->getNbinsX(),
+                   meTrackMatchedTPEffPtTotLV->getTH1()->GetXaxis()->GetXmin(),
+                   meTrackMatchedTPEffPtTotLV->getTH1()->GetXaxis()->GetXmax());
   meExtraPtEtl2Eff_->getTH1()->SetMinimum(0.);
   computeEfficiency1D(meExtraPtEtl2Mtd, meTrackMatchedTPEffPtTotLV, meExtraPtEtl2Eff_);
 

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -641,7 +641,7 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
         }  // time res and time pull
 
       }  // TP matching
-    }    // trkRecSel
+    }  // trkRecSel
 
     // ETL tracks with low pt (0.2 < Pt [GeV] < 0.7)
     if (trkRecSelLowPt(trackGen)) {

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -1253,12 +1253,10 @@ void MtdTracksValidation::fillDescriptions(edm::ConfigurationDescriptions& descr
   desc.add<edm::InputTag>("trackMVAQual", edm::InputTag("mtdTrackQualityMVA:mtdQualMVA"));
   desc.add<edm::InputTag>("outermostHitPositionSrc",
                           edm::InputTag("trackExtenderWithMTD:generalTrackOutermostHitPosition"));
-  desc.add<double>("trackMinimumPt", 0.7);  // [GeV]
   desc.add<double>("trackMaximumPt", 12.);  // [GeV]
   desc.add<double>("trackMaximumBtlEta", 1.5);
   desc.add<double>("trackMinimumEtlEta", 1.6);
   desc.add<double>("trackMaximumEtlEta", 3.);
-  desc.addUntracked<bool>("optionalPlots", true);
 
   descriptions.add("mtdTracksValid", desc);
 }

--- a/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
+++ b/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
@@ -659,10 +659,10 @@ void Primary4DVertexValidation::bookHistograms(DQMStore::IBooker& ibook,
                    50,
                    -0.5,
                    0.5);
-  meTimeRes_ = ibook.book1D("TimeRes", "t_{rec} - t_{sim} ;t_{rec} - t_{sim} [ns] ", 40, -0.2, 0.2);
+  meTimeRes_ = ibook.book1D("TimeRes", "t_{rec} - t_{sim} ;t_{rec} - t_{sim} [ns] ", 100, -0.2, 0.2);
   meTimePull_ = ibook.book1D("TimePull", "Pull; t_{rec} - t_{sim}/#sigma_{t rec}", 100, -10., 10.);
   meTimeSignalRes_ =
-      ibook.book1D("TimeSignalRes", "t_{rec} - t_{sim} for signal ;t_{rec} - t_{sim} [ns] ", 40, -0.2, 0.2);
+      ibook.book1D("TimeSignalRes", "t_{rec} - t_{sim} for signal ;t_{rec} - t_{sim} [ns] ", 50, -0.1, 0.1);
   meTimeSignalPull_ =
       ibook.book1D("TimeSignalPull", "Pull for signal; t_{rec} - t_{sim}/#sigma_{t rec}", 100, -10., 10.);
   mePUvsRealV_ =

--- a/Validation/MtdValidation/test/mtdHarvesting_cfg.py
+++ b/Validation/MtdValidation/test/mtdHarvesting_cfg.py
@@ -8,7 +8,7 @@ process.load('Configuration.StandardSequences.Services_cff')
 process.load('Configuration.StandardSequences.EDMtoMEAtRunEnd_cff')
 process.load('SimGeneral.MixingModule.mixNoPU_cfi')
 
-process.load("Configuration.Geometry.GeometryExtended2026D98Reco_cff")
+process.load("Configuration.Geometry.GeometryExtended2026D110Reco_cff")
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 


### PR DESCRIPTION
PR description:
This PR sets as optional cluster resolution histograms using SIM hits associated to the cluster as mtd truth (instead of MtdSimLayerClusters), in ETL and BTL LocalRecoValidation.
With this update, a reduced time consumption is achieved (tested with TimeMemorySummary on TTbarPU):
- btlLocalRecoValid, from ~1.34s to ~0.05s
- etlLocalRecoValid, from ~18.83s to ~0.05s
Furthermore, ExtraPtEff and ExtraPtEtl2Eff histogram range were updated in MtdTracksHarvester.cc (to fix an issue introduced with PR #45457) and mtdHarvesting_cfg.py was moved to D110 scenario.
Finally, some unused parameters were removed from MtdTracksValidation.cc and vertex time resolution ranges and binning were updated.

PR validation:
The updated validation code has been tested in the CMSSW_14_2_0_pre1 release with the workflows: 
- 29634.0_TTbar_14TeV+2026D110
- 29834.0_TTbar_14TeV+2026D110PU
The new code produces histograms compatible to the current validation.