### PR TITLE
[L1] [Clang]Cleanup clang-analyzer warnings

### DIFF
--- a/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixMaxof2.cc
+++ b/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixMaxof2.cc
@@ -33,11 +33,12 @@ void EcalFenixMaxof2::process(
 
   for (unsigned int i = 0; i < output.size(); i++) {
     if (nstrip - 1 == 0) {
-      output[i] = strip_oddmask[0][i] * ((bypasslinout[0][i]) & mask);
+      [[clang::suppress]] output[i] = strip_oddmask[0][i] * ((bypasslinout[0][i]) & mask);
     } else {
       for (int i2strip = 0; i2strip < nstrip - 1; ++i2strip) {
-        sumby2_[i2strip][i] = strip_oddmask[i2strip][i] * ((bypasslinout[i2strip][i]) & mask) +
-                              strip_oddmask[i2strip + 1][i] * ((bypasslinout[i2strip + 1][i]) & mask);
+        [[clang::suppress]] sumby2_[i2strip][i] =
+            strip_oddmask[i2strip][i] * ((bypasslinout[i2strip][i]) & mask) +
+            strip_oddmask[i2strip + 1][i] * ((bypasslinout[i2strip + 1][i]) & mask);
         if (sumby2_[i2strip][i] > output[i]) {
           output[i] = sumby2_[i2strip][i];
         }


### PR DESCRIPTION
This fixes clang static analyzer warnings https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_14_2_X_2024-10-02-1100/el8_amd64_gcc12/build-logs/ and see [report](https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_14_2_X_2024-10-02-1100/el8_amd64_gcc12/llvm-analysis/report-1351c9.html#EndPath) . Looks like it is false positve. First it assumes that `output.size()` is empty at https://github.com/cms-sw/cmssw/blob/master/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixMaxof2.cc#L26 and then it it assumes it is not empty at https://github.com/cms-sw/cmssw/blob/master/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixMaxof2.cc#L34