### PR TITLE
Increase field width in MessageLogger Summary

### DIFF
--- a/FWCore/MessageService/src/ELstatistics.cc
+++ b/FWCore/MessageService/src/ELstatistics.cc
@@ -248,10 +248,10 @@ namespace edm {
         //
         if (n == 0) {
           s << "\n";
-          s << " type     category        sev         module            "
-               "   subroutine          count    total\n"
-            << " ---- -------------------- -- --------------------- "
-               "---------------------  -----    -----\n";
+          s << " type     category        sev          module           "
+               "     subroutine         count   total\n"
+            << " ---- -------------------- -- ------------------------- "
+               "---------------------   -----   -----\n";
         }
         // -----  Emit detailed message information:
         //

--- a/FWCore/MessageService/src/ELstatistics.cc
+++ b/FWCore/MessageService/src/ELstatistics.cc
@@ -248,16 +248,16 @@ namespace edm {
         //
         if (n == 0) {
           s << "\n";
-          s << " type     category        sev    module        "
-               "subroutine        count    total\n"
-            << " ---- -------------------- -- ---------------- "
-               "----------------  -----    -----\n";
+          s << " type     category        sev         module            "
+               "   subroutine          count    total\n"
+            << " ---- -------------------- -- --------------------- "
+               "---------------------  -----    -----\n";
         }
         // -----  Emit detailed message information:
         //
         s << right << std::setw(5) << ++n << ' ' << left << std::setw(20) << (*i).first.id.substr(0, 20) << ' ' << left
-          << std::setw(2) << (*i).first.severity.getSymbol() << ' ' << left << std::setw(16)
-          << (*i).first.module.substr(0, 16) << ' ' << left << std::setw(16) << (*i).first.subroutine.substr(0, 16)
+          << std::setw(2) << (*i).first.severity.getSymbol() << ' ' << left << std::setw(25)
+          << (*i).first.module.substr(0, 25) << ' ' << left << std::setw(21) << (*i).first.subroutine.substr(0, 21)
           << right << std::setw(7) << (*i).second.n << left << std::setw(1) << ((*i).second.ignoredFlag ? '*' : ' ')
           << right << std::setw(8) << (*i).second.aggregateN << '\n';
         ftnote = ftnote || (*i).second.ignoredFlag;

--- a/FWCore/MessageService/test/unit_test_outputs/infos.log
+++ b/FWCore/MessageService/test/unit_test_outputs/infos.log
@@ -37,12 +37,12 @@ Test of std::setprecision(p): Pi with precision 12 is 3.14159265359
 
 MessageLogger Summary
 
- type     category        sev    module        subroutine        count    total
- ---- -------------------- -- ---------------- ----------------  -----    -----
-    1 cat_B                -i UnitTestClient_G                      10*      10
-    2 FwkReport            -f AfterSource                            1        1
-    3 cat_A                -w UnitTestClient_G                       1        1
-    4 cat_C                -w UnitTestClient_G                      15*      15
+ type     category        sev          module                subroutine         count   total
+ ---- -------------------- -- ------------------------- ---------------------   -----   -----
+    1 cat_B                -i UnitTestClient_G:sendSome                           10*      10
+    2 FwkReport            -f AfterSource                                          1        1
+    3 cat_A                -w UnitTestClient_G:sendSome                            1        1
+    4 cat_C                -w UnitTestClient_G:sendSome                           15*      15
 
 * Some occurrences of this message were suppressed in all logs, due to limits.
 

--- a/FWCore/MessageService/test/unit_test_outputs/u16_errors.mmlog
+++ b/FWCore/MessageService/test/unit_test_outputs/u16_errors.mmlog
@@ -15,10 +15,10 @@ LogError was used to send this other message
 
 MessageLogger Summary
 
- type     category        sev    module        subroutine        count    total
- ---- -------------------- -- ---------------- ----------------  -----    -----
-    1 cat_A                -e UnitTestClient_A                       2        2
-    2 cat_B                -e UnitTestClient_A                       2        2
+ type     category        sev          module                subroutine         count   total
+ ---- -------------------- -- ------------------------- ---------------------   -----   -----
+    1 cat_A                -e UnitTestClient_Ad:sendSom                            2        2
+    2 cat_B                -e UnitTestClient_Ad:sendSom                            2        2
 
  type    category    Examples: run/evt        run/evt          run/evt
  ---- -------------------- ---------------- ---------------- ----------------

--- a/FWCore/MessageService/test/unit_test_outputs/u16_statistics.mslog
+++ b/FWCore/MessageService/test/unit_test_outputs/u16_statistics.mslog
@@ -3,12 +3,12 @@
 
 MessageLogger Summary
 
- type     category        sev    module        subroutine        count    total
- ---- -------------------- -- ---------------- ----------------  -----    -----
-    1 cat_A                -w UnitTestClient_A                       2        2
-    2 cat_B                -w UnitTestClient_A                       2        2
-    3 cat_A                -e UnitTestClient_A                       2        2
-    4 cat_B                -e UnitTestClient_A                       2        2
+ type     category        sev          module                subroutine         count   total
+ ---- -------------------- -- ------------------------- ---------------------   -----   -----
+    1 cat_A                -w UnitTestClient_Ad:sendSom                            2        2
+    2 cat_B                -w UnitTestClient_Ad:sendSom                            2        2
+    3 cat_A                -e UnitTestClient_Ad:sendSom                            2        2
+    4 cat_B                -e UnitTestClient_Ad:sendSom                            2        2
 
  type    category    Examples: run/evt        run/evt          run/evt
  ---- -------------------- ---------------- ---------------- ----------------

--- a/FWCore/MessageService/test/unit_test_outputs/u17_all.log
+++ b/FWCore/MessageService/test/unit_test_outputs/u17_all.log
@@ -71,11 +71,11 @@ LogSystem: 9
 
 MessageLogger Summary
 
- type     category        sev    module        subroutine        count    total
- ---- -------------------- -- ---------------- ----------------  -----    -----
-    1 FwkReport            -f AfterSource                            2        2
-    2 cat_P                -w UnitTestClient_K                      20*      20
-    3 cat_S                -s UnitTestClient_K                      20       20
+ type     category        sev          module                subroutine         count   total
+ ---- -------------------- -- ------------------------- ---------------------   -----   -----
+    1 FwkReport            -f AfterSource                                          2        2
+    2 cat_P                -w UnitTestClient_K:sendSome                           20*      20
+    3 cat_S                -s UnitTestClient_K:sendSome                           20       20
 
 * Some occurrences of this message were suppressed in all logs, due to limits.
 

--- a/FWCore/MessageService/test/unit_test_outputs/u20_cerr.log
+++ b/FWCore/MessageService/test/unit_test_outputs/u20_cerr.log
@@ -52,10 +52,10 @@ Test of std::setprecision(p): Pi with precision 12 is 3.14159265359
 
 MessageLogger Summary
 
- type     category        sev    module        subroutine        count    total
- ---- -------------------- -- ---------------- ----------------  -----    -----
-    1 cat_A                -w UnitTestClient_G                       1        1
-    2 cat_C                -w UnitTestClient_G                      15       15
+ type     category        sev          module                subroutine         count   total
+ ---- -------------------- -- ------------------------- ---------------------   -----   -----
+    1 cat_A                -w UnitTestClient_G:sendSome                            1        1
+    2 cat_C                -w UnitTestClient_G:sendSome                           15       15
 
  type    category    Examples: run/evt        run/evt          run/evt
  ---- -------------------- ---------------- ---------------- ----------------

--- a/FWCore/MessageService/test/unit_test_outputs/u23_infos.log
+++ b/FWCore/MessageService/test/unit_test_outputs/u23_infos.log
@@ -58,15 +58,15 @@ Q2 trace with identifier 23
 
 MessageLogger Summary
 
- type     category        sev    module        subroutine        count    total
- ---- -------------------- -- ---------------- ----------------  -----    -----
-    1 cat_A                -i UTC_Q1:ssm_1a                          1        1
-    2 cat_A                -i UTC_Q1:ssm_1b                          1        1
-    3 cat_A                -i UTC_Q1:ssm_1c                          1        1
-    4 cat_A                -i UTC_Q2:ssm_2a                          1        1
-    5 cat_A                -i UTC_Q2:ssm_2b                          1        1
-    6 cat_A                -i UTC_Q2:ssm_2c                          1        1
-    7 FwkReport            -f AfterSource                            1        1
+ type     category        sev          module                subroutine         count   total
+ ---- -------------------- -- ------------------------- ---------------------   -----   -----
+    1 cat_A                -i UTC_Q1:ssm_1a                                        1        1
+    2 cat_A                -i UTC_Q1:ssm_1b                                        1        1
+    3 cat_A                -i UTC_Q1:ssm_1c                                        1        1
+    4 cat_A                -i UTC_Q2:ssm_2a                                        1        1
+    5 cat_A                -i UTC_Q2:ssm_2b                                        1        1
+    6 cat_A                -i UTC_Q2:ssm_2c                                        1        1
+    7 FwkReport            -f AfterSource                                          1        1
     8 timer                -i   <Any Module>   <Any Function>        6        6
     9 trace                -i   <Any Module>   <Any Function>        6        6
 

--- a/FWCore/MessageService/test/unit_test_outputs/u25_only.log
+++ b/FWCore/MessageService/test/unit_test_outputs/u25_only.log
@@ -94,11 +94,11 @@ B 6146
 
 MessageLogger Summary
 
- type     category        sev    module        subroutine        count    total
- ---- -------------------- -- ---------------- ----------------  -----    -----
-    1 FwkReport            -f AfterSource                            1        1
-    2 cat_A                -e UnitTestClient_R                   10000*   10000
-    3 cat_B                -e UnitTestClient_R                   10000*   10000
+ type     category        sev          module                subroutine         count   total
+ ---- -------------------- -- ------------------------- ---------------------   -----   -----
+    1 FwkReport            -f AfterSource                                          1        1
+    2 cat_A                -e UnitTestClient_R:sendSome                        10000*   10000
+    3 cat_B                -e UnitTestClient_R:sendSome                        10000*   10000
 
 * Some occurrences of this message were suppressed in all logs, due to limits.
 

--- a/FWCore/MessageService/test/unit_test_outputs/u27_infos.log
+++ b/FWCore/MessageService/test/unit_test_outputs/u27_infos.log
@@ -58,15 +58,15 @@ Q2 trace with identifier 23
 
 MessageLogger Summary
 
- type     category        sev    module        subroutine        count    total
- ---- -------------------- -- ---------------- ----------------  -----    -----
-    1 cat_A                -i UTC_Q1:ssm_1a                          1        1
-    2 cat_A                -i UTC_Q1:ssm_1b                          1        1
-    3 cat_A                -i UTC_Q1:ssm_1c                          1        1
-    4 cat_A                -i UTC_Q2:ssm_2a                          1        1
-    5 cat_A                -i UTC_Q2:ssm_2b                          1        1
-    6 cat_A                -i UTC_Q2:ssm_2c                          1        1
-    7 FwkReport            -f AfterSource                            1        1
+ type     category        sev          module                subroutine         count   total
+ ---- -------------------- -- ------------------------- ---------------------   -----   -----
+    1 cat_A                -i UTC_Q1:ssm_1a                                        1        1
+    2 cat_A                -i UTC_Q1:ssm_1b                                        1        1
+    3 cat_A                -i UTC_Q1:ssm_1c                                        1        1
+    4 cat_A                -i UTC_Q2:ssm_2a                                        1        1
+    5 cat_A                -i UTC_Q2:ssm_2b                                        1        1
+    6 cat_A                -i UTC_Q2:ssm_2c                                        1        1
+    7 FwkReport            -f AfterSource                                          1        1
     8 timer                -i   <Any Module>   <Any Function>        6        6
     9 trace                -i   <Any Module>   <Any Function>        6        6
 

--- a/FWCore/MessageService/test/unit_test_outputs/u28_output.log
+++ b/FWCore/MessageService/test/unit_test_outputs/u28_output.log
@@ -69,12 +69,12 @@ LogInfo was used to send this other message
 
 MessageLogger Summary
 
- type     category        sev    module        subroutine        count    total
- ---- -------------------- -- ---------------- ----------------  -----    -----
-    1 cat_A                -w UnitTestClient_A                       3        3
-    2 cat_B                -w UnitTestClient_A                       3        3
-    3 cat_A                -e UnitTestClient_A                       3        3
-    4 cat_B                -e UnitTestClient_A                       3        3
+ type     category        sev          module                subroutine         count   total
+ ---- -------------------- -- ------------------------- ---------------------   -----   -----
+    1 cat_A                -w UnitTestClient_A:sendSome                            3        3
+    2 cat_B                -w UnitTestClient_A:sendSome                            3        3
+    3 cat_A                -e UnitTestClient_A:sendSome                            3        3
+    4 cat_B                -e UnitTestClient_A:sendSome                            3        3
 
  type    category    Examples: run/evt        run/evt          run/evt
  ---- -------------------- ---------------- ---------------- ----------------

--- a/FWCore/MessageService/test/unit_test_outputs/u31_infos.log
+++ b/FWCore/MessageService/test/unit_test_outputs/u31_infos.log
@@ -979,30 +979,30 @@ Category timer   Module UTC_T2:ssm_2c   Severity Error   Count 1
 
 MessageLogger Summary
 
- type     category        sev    module        subroutine        count    total
- ---- -------------------- -- ---------------- ----------------  -----    -----
-    1 summary              -i UTC_T2:ssm_2a                          4        4
-    2 summary              -i UTC_T2:ssm_2b                          4        4
-    3 summary              -i UTC_T2:ssm_2c                          4        4
-    4 FwkReport            -f AfterSource                           16       16
-    5 cat_A                -w UTC_T1:ssm_1a                         16       16
-    6 cat_A                -w UTC_T1:ssm_1b                         16       16
-    7 cat_A                -w UTC_T1:ssm_1c                         16       16
-    8 cat_A                -w UTC_T2:ssm_2a                         16       16
-    9 cat_A                -w UTC_T2:ssm_2b                         16       16
-   10 cat_A                -w UTC_T2:ssm_2c                         16       16
-   11 cat_A                -e UTC_T1:ssm_1a                         16       16
-   12 cat_A                -e UTC_T1:ssm_1b                         16       16
-   13 cat_A                -e UTC_T1:ssm_1c                         16       16
-   14 cat_A                -e UTC_T2:ssm_2a                         16       16
-   15 cat_A                -e UTC_T2:ssm_2b                         16       16
-   16 cat_A                -e UTC_T2:ssm_2c                         16       16
-   17 timer                -e UTC_T1:ssm_1a                         16       16
-   18 timer                -e UTC_T1:ssm_1b                         16       16
-   19 timer                -e UTC_T1:ssm_1c                         16       16
-   20 timer                -e UTC_T2:ssm_2a                         16       16
-   21 timer                -e UTC_T2:ssm_2b                         16       16
-   22 timer                -e UTC_T2:ssm_2c                         16       16
+ type     category        sev          module                subroutine         count   total
+ ---- -------------------- -- ------------------------- ---------------------   -----   -----
+    1 summary              -i UTC_T2:ssm_2a                                        4        4
+    2 summary              -i UTC_T2:ssm_2b                                        4        4
+    3 summary              -i UTC_T2:ssm_2c                                        4        4
+    4 FwkReport            -f AfterSource                                         16       16
+    5 cat_A                -w UTC_T1:ssm_1a                                       16       16
+    6 cat_A                -w UTC_T1:ssm_1b                                       16       16
+    7 cat_A                -w UTC_T1:ssm_1c                                       16       16
+    8 cat_A                -w UTC_T2:ssm_2a                                       16       16
+    9 cat_A                -w UTC_T2:ssm_2b                                       16       16
+   10 cat_A                -w UTC_T2:ssm_2c                                       16       16
+   11 cat_A                -e UTC_T1:ssm_1a                                       16       16
+   12 cat_A                -e UTC_T1:ssm_1b                                       16       16
+   13 cat_A                -e UTC_T1:ssm_1c                                       16       16
+   14 cat_A                -e UTC_T2:ssm_2a                                       16       16
+   15 cat_A                -e UTC_T2:ssm_2b                                       16       16
+   16 cat_A                -e UTC_T2:ssm_2c                                       16       16
+   17 timer                -e UTC_T1:ssm_1a                                       16       16
+   18 timer                -e UTC_T1:ssm_1b                                       16       16
+   19 timer                -e UTC_T1:ssm_1c                                       16       16
+   20 timer                -e UTC_T2:ssm_2a                                       16       16
+   21 timer                -e UTC_T2:ssm_2b                                       16       16
+   22 timer                -e UTC_T2:ssm_2c                                       16       16
 
  type    category    Examples: run/evt        run/evt          run/evt
  ---- -------------------- ---------------- ---------------- ----------------

--- a/FWCore/MessageService/test/unit_test_outputs/u33_all.log
+++ b/FWCore/MessageService/test/unit_test_outputs/u33_all.log
@@ -119,36 +119,36 @@ T1 endProcessBlock info with identifier 12 event 2
 
 MessageLogger Summary
 
- type     category        sev    module        subroutine        count    total
- ---- -------------------- -- ---------------- ----------------  -----    -----
-    1 cat_A                -i UTC_V1:ssm_1a                          2        2
-    2 cat_A                -i UTC_V1:ssm_1b                          2        2
-    3 cat_A                -i UTC_V2:ssm_2b                          2        2
-    4 cat_BPB              -i UTC_V1:ssm_1a@be                       1        1
-    5 cat_BPB              -i UTC_V1:ssm_1b@be                       1        1
-    6 cat_BR               -i UTC_V1:ssm_1a@be                       1        1
-    7 cat_BR               -i UTC_V1:ssm_1b@be                       1        1
-    8 cat_EPB              -i UTC_V1:ssm_1a@en                       1        1
-    9 cat_EPB              -i UTC_V1:ssm_1b@en                       1        1
-   10 FwkReport            -f AfterSource                            2        2
-   11 cat_A                -w UTC_V1:ssm_1a                          2        2
-   12 cat_A                -w UTC_V1:ssm_1b                          2        2
-   13 cat_A                -w UTC_V2:ssm_2a                          2        2
-   14 cat_A                -w UTC_V2:ssm_2b                          2        2
-   15 cat_BJ               -w UTC_V1:ssm_1a@be                       1        1
-   16 cat_BJ               -w UTC_V1:ssm_1b@be                       1        1
-   17 cat_BL               -w UTC_V1:ssm_1a@be                       1        1
-   18 cat_BL               -w UTC_V1:ssm_1b@be                       1        1
-   19 TestMessageLogger    -e PreBeginProcessB                       1        1
-   20 TestMessageLogger    -e PreEndProcessBlo                       1        1
-   21 TestMessageLogger    -e PreGlobalBeginLu                       1        1
-   22 TestMessageLogger    -e PreGlobalBeginRu                       1        1
-   23 TestMessageLogger    -e PreGlobalEndLumi                       1        1
-   24 TestMessageLogger    -e PreGlobalEndRun                        1        1
-   25 cat_A                -e UTC_V1:ssm_1a                          2        2
-   26 cat_A                -e UTC_V1:ssm_1b                          2        2
-   27 cat_A                -e UTC_V2:ssm_2a                          2        2
-   28 cat_A                -e UTC_V2:ssm_2b                          2        2
+ type     category        sev          module                subroutine         count   total
+ ---- -------------------- -- ------------------------- ---------------------   -----   -----
+    1 cat_A                -i UTC_V1:ssm_1a                                        2        2
+    2 cat_A                -i UTC_V1:ssm_1b                                        2        2
+    3 cat_A                -i UTC_V2:ssm_2b                                        2        2
+    4 cat_BPB              -i UTC_V1:ssm_1a@beginProces                            1        1
+    5 cat_BPB              -i UTC_V1:ssm_1b@beginProces                            1        1
+    6 cat_BR               -i UTC_V1:ssm_1a@beginRun                               1        1
+    7 cat_BR               -i UTC_V1:ssm_1b@beginRun                               1        1
+    8 cat_EPB              -i UTC_V1:ssm_1a@endProcessB                            1        1
+    9 cat_EPB              -i UTC_V1:ssm_1b@endProcessB                            1        1
+   10 FwkReport            -f AfterSource                                          2        2
+   11 cat_A                -w UTC_V1:ssm_1a                                        2        2
+   12 cat_A                -w UTC_V1:ssm_1b                                        2        2
+   13 cat_A                -w UTC_V2:ssm_2a                                        2        2
+   14 cat_A                -w UTC_V2:ssm_2b                                        2        2
+   15 cat_BJ               -w UTC_V1:ssm_1a@beginJob                               1        1
+   16 cat_BJ               -w UTC_V1:ssm_1b@beginJob                               1        1
+   17 cat_BL               -w UTC_V1:ssm_1a@beginLumi                              1        1
+   18 cat_BL               -w UTC_V1:ssm_1b@beginLumi                              1        1
+   19 TestMessageLogger    -e PreBeginProcessBlock                                 1        1
+   20 TestMessageLogger    -e PreEndProcessBlock                                   1        1
+   21 TestMessageLogger    -e PreGlobalBeginLumi                                   1        1
+   22 TestMessageLogger    -e PreGlobalBeginRun                                    1        1
+   23 TestMessageLogger    -e PreGlobalEndLumi                                     1        1
+   24 TestMessageLogger    -e PreGlobalEndRun                                      1        1
+   25 cat_A                -e UTC_V1:ssm_1a                                        2        2
+   26 cat_A                -e UTC_V1:ssm_1b                                        2        2
+   27 cat_A                -e UTC_V2:ssm_2a                                        2        2
+   28 cat_A                -e UTC_V2:ssm_2b                                        2        2
 
  type    category    Examples: run/evt        run/evt          run/evt
  ---- -------------------- ---------------- ---------------- ----------------

--- a/FWCore/MessageService/test/unit_test_outputs/u33d_all.log
+++ b/FWCore/MessageService/test/unit_test_outputs/u33d_all.log
@@ -104,30 +104,30 @@ T1 analyze info with identifier 22 event 1
 
 MessageLogger Summary
 
- type     category        sev    module        subroutine        count    total
- ---- -------------------- -- ---------------- ----------------  -----    -----
-    1 cat_A                -d UTC_Vd1:ssm_1b                         2        2
-    2 cat_BJ               -d UTC_Vd1:ssm_1b@b                       1        1
-    3 cat_BJ               -d UTC_Vd1:ssm_1b@b                       1        1
-    4 cat_BL               -d UTC_Vd1:ssm_1b@b                       1        1
-    5 cat_A                -i UTC_Vd1:ssm_1a                         2        2
-    6 cat_A                -i UTC_Vd1:ssm_1b                         2        2
-    7 cat_A                -i UTC_Vd2:ssm_2b                         2        2
-    8 cat_BR               -i UTC_Vd1:ssm_1a@b                       1        1
-    9 cat_BR               -i UTC_Vd1:ssm_1b@b                       1        1
-   10 FwkReport            -f AfterSource                            2        2
-   11 cat_A                -w UTC_Vd1:ssm_1a                         2        2
-   12 cat_A                -w UTC_Vd1:ssm_1b                         2        2
-   13 cat_A                -w UTC_Vd2:ssm_2a                         2        2
-   14 cat_A                -w UTC_Vd2:ssm_2b                         2        2
-   15 cat_BJ               -w UTC_Vd1:ssm_1a@b                       1        1
-   16 cat_BJ               -w UTC_Vd1:ssm_1b@b                       1        1
-   17 cat_BL               -w UTC_Vd1:ssm_1a@b                       1        1
-   18 cat_BL               -w UTC_Vd1:ssm_1b@b                       1        1
-   19 cat_A                -e UTC_Vd1:ssm_1a                         2        2
-   20 cat_A                -e UTC_Vd1:ssm_1b                         2        2
-   21 cat_A                -e UTC_Vd2:ssm_2a                         2        2
-   22 cat_A                -e UTC_Vd2:ssm_2b                         2        2
+ type     category        sev          module                subroutine         count   total
+ ---- -------------------- -- ------------------------- ---------------------   -----   -----
+    1 cat_A                -d UTC_Vd1:ssm_1b                                       2        2
+    2 cat_BJ               -d UTC_Vd1:ssm_1b@beginJob                              1        1
+    3 cat_BJ               -d UTC_Vd1:ssm_1b@beginRun                              1        1
+    4 cat_BL               -d UTC_Vd1:ssm_1b@beginLumi                             1        1
+    5 cat_A                -i UTC_Vd1:ssm_1a                                       2        2
+    6 cat_A                -i UTC_Vd1:ssm_1b                                       2        2
+    7 cat_A                -i UTC_Vd2:ssm_2b                                       2        2
+    8 cat_BR               -i UTC_Vd1:ssm_1a@beginRun                              1        1
+    9 cat_BR               -i UTC_Vd1:ssm_1b@beginRun                              1        1
+   10 FwkReport            -f AfterSource                                          2        2
+   11 cat_A                -w UTC_Vd1:ssm_1a                                       2        2
+   12 cat_A                -w UTC_Vd1:ssm_1b                                       2        2
+   13 cat_A                -w UTC_Vd2:ssm_2a                                       2        2
+   14 cat_A                -w UTC_Vd2:ssm_2b                                       2        2
+   15 cat_BJ               -w UTC_Vd1:ssm_1a@beginJob                              1        1
+   16 cat_BJ               -w UTC_Vd1:ssm_1b@beginJob                              1        1
+   17 cat_BL               -w UTC_Vd1:ssm_1a@beginLumi                             1        1
+   18 cat_BL               -w UTC_Vd1:ssm_1b@beginLumi                             1        1
+   19 cat_A                -e UTC_Vd1:ssm_1a                                       2        2
+   20 cat_A                -e UTC_Vd1:ssm_1b                                       2        2
+   21 cat_A                -e UTC_Vd2:ssm_2a                                       2        2
+   22 cat_A                -e UTC_Vd2:ssm_2b                                       2        2
 
  type    category    Examples: run/evt        run/evt          run/evt
  ---- -------------------- ---------------- ---------------- ----------------

--- a/FWCore/MessageService/test/unit_test_outputs/u3_statistics.log
+++ b/FWCore/MessageService/test/unit_test_outputs/u3_statistics.log
@@ -3,16 +3,16 @@
 
 MessageLogger Summary
 
- type     category        sev    module        subroutine        count    total
- ---- -------------------- -- ---------------- ----------------  -----    -----
-    1 FwkTest              -i UnitTestClient_A                       3*       3
-    2 cat_A                -i UnitTestClient_A                       3        3
-    3 cat_B                -i UnitTestClient_A                       3        3
-    4 FwkReport            -f AfterSource                            3        3
-    5 cat_A                -w UnitTestClient_A                       3        3
-    6 cat_B                -w UnitTestClient_A                       3        3
-    7 cat_A                -e UnitTestClient_A                       3        3
-    8 cat_B                -e UnitTestClient_A                       3        3
+ type     category        sev          module                subroutine         count   total
+ ---- -------------------- -- ------------------------- ---------------------   -----   -----
+    1 FwkTest              -i UnitTestClient_A:sendSome                            3*       3
+    2 cat_A                -i UnitTestClient_A:sendSome                            3        3
+    3 cat_B                -i UnitTestClient_A:sendSome                            3        3
+    4 FwkReport            -f AfterSource                                          3        3
+    5 cat_A                -w UnitTestClient_A:sendSome                            3        3
+    6 cat_B                -w UnitTestClient_A:sendSome                            3        3
+    7 cat_A                -e UnitTestClient_A:sendSome                            3        3
+    8 cat_B                -e UnitTestClient_A:sendSome                            3        3
 
 * Some occurrences of this message were suppressed in all logs, due to limits.
 

--- a/FWCore/MessageService/test/unit_test_outputs/u4_another.log
+++ b/FWCore/MessageService/test/unit_test_outputs/u4_another.log
@@ -3,16 +3,16 @@
 
 MessageLogger Summary
 
- type     category        sev    module        subroutine        count    total
- ---- -------------------- -- ---------------- ----------------  -----    -----
-    1 FwkTest              -i UnitTestClient_A                       3*       3
-    2 cat_A                -i UnitTestClient_A                       3*       3
-    3 cat_B                -i UnitTestClient_A                       3*       3
-    4 FwkReport            -f AfterSource                            3*       3
-    5 cat_A                -w UnitTestClient_A                       3*       3
-    6 cat_B                -w UnitTestClient_A                       3*       3
-    7 cat_A                -e UnitTestClient_A                       3        3
-    8 cat_B                -e UnitTestClient_A                       3        3
+ type     category        sev          module                subroutine         count   total
+ ---- -------------------- -- ------------------------- ---------------------   -----   -----
+    1 FwkTest              -i UnitTestClient_A:sendSome                            3*       3
+    2 cat_A                -i UnitTestClient_A:sendSome                            3*       3
+    3 cat_B                -i UnitTestClient_A:sendSome                            3*       3
+    4 FwkReport            -f AfterSource                                          3*       3
+    5 cat_A                -w UnitTestClient_A:sendSome                            3*       3
+    6 cat_B                -w UnitTestClient_A:sendSome                            3*       3
+    7 cat_A                -e UnitTestClient_A:sendSome                            3        3
+    8 cat_B                -e UnitTestClient_A:sendSome                            3        3
 
 * Some occurrences of this message were suppressed in all logs, due to limits.
 

--- a/FWCore/MessageService/test/unit_test_outputs/u4_errors.log
+++ b/FWCore/MessageService/test/unit_test_outputs/u4_errors.log
@@ -21,10 +21,10 @@ LogError was used to send this other message
 
 MessageLogger Summary
 
- type     category        sev    module        subroutine        count    total
- ---- -------------------- -- ---------------- ----------------  -----    -----
-    1 cat_A                -e UnitTestClient_A                       3        3
-    2 cat_B                -e UnitTestClient_A                       3        3
+ type     category        sev          module                subroutine         count   total
+ ---- -------------------- -- ------------------------- ---------------------   -----   -----
+    1 cat_A                -e UnitTestClient_A:sendSome                            3        3
+    2 cat_B                -e UnitTestClient_A:sendSome                            3        3
 
  type    category    Examples: run/evt        run/evt          run/evt
  ---- -------------------- ---------------- ---------------- ----------------

--- a/FWCore/MessageService/test/unit_test_outputs/u4_statistics.log
+++ b/FWCore/MessageService/test/unit_test_outputs/u4_statistics.log
@@ -3,12 +3,12 @@
 
 MessageLogger Summary
 
- type     category        sev    module        subroutine        count    total
- ---- -------------------- -- ---------------- ----------------  -----    -----
-    1 cat_A                -w UnitTestClient_A                       3*       3
-    2 cat_B                -w UnitTestClient_A                       3*       3
-    3 cat_A                -e UnitTestClient_A                       3        3
-    4 cat_B                -e UnitTestClient_A                       3        3
+ type     category        sev          module                subroutine         count   total
+ ---- -------------------- -- ------------------------- ---------------------   -----   -----
+    1 cat_A                -w UnitTestClient_A:sendSome                            3*       3
+    2 cat_B                -w UnitTestClient_A:sendSome                            3*       3
+    3 cat_A                -e UnitTestClient_A:sendSome                            3        3
+    4 cat_B                -e UnitTestClient_A:sendSome                            3        3
 
 * Some occurrences of this message were suppressed in all logs, due to limits.
 

--- a/FWCore/MessageService/test/unit_test_outputs/u5_default.log
+++ b/FWCore/MessageService/test/unit_test_outputs/u5_default.log
@@ -3,11 +3,11 @@
 
 MessageLogger Summary
 
- type     category        sev    module        subroutine        count    total
- ---- -------------------- -- ---------------- ----------------  -----    -----
-    1 FwkReport            -f AfterSource                            1*       1
-    2 cat_A                -e UnitTestClient_B                       1        1
-    3 cat_B                -e UnitTestClient_B                       1        1
+ type     category        sev          module                subroutine         count   total
+ ---- -------------------- -- ------------------------- ---------------------   -----   -----
+    1 FwkReport            -f AfterSource                                          1*       1
+    2 cat_A                -e UnitTestClient_B:sendSome                            1        1
+    3 cat_B                -e UnitTestClient_B:sendSome                            1        1
 
 * Some occurrences of this message were suppressed in all logs, due to limits.
 
@@ -28,11 +28,11 @@ dropped waiting message count 0
 
 MessageLogger Summary
 
- type     category        sev    module        subroutine        count    total
- ---- -------------------- -- ---------------- ----------------  -----    -----
-    1 FwkReport            -f AfterSource                            2*       2
-    2 cat_A                -e UnitTestClient_B                       3        3
-    3 cat_B                -e UnitTestClient_B                       2        2
+ type     category        sev          module                subroutine         count   total
+ ---- -------------------- -- ------------------------- ---------------------   -----   -----
+    1 FwkReport            -f AfterSource                                          2*       2
+    2 cat_A                -e UnitTestClient_B:sendSome                            3        3
+    3 cat_B                -e UnitTestClient_B:sendSome                            2        2
 
 * Some occurrences of this message were suppressed in all logs, due to limits.
 
@@ -53,11 +53,11 @@ dropped waiting message count 0
 
 MessageLogger Summary
 
- type     category        sev    module        subroutine        count    total
- ---- -------------------- -- ---------------- ----------------  -----    -----
-    1 FwkReport            -f AfterSource                            3*       3
-    2 cat_A                -e UnitTestClient_B                       6        6
-    3 cat_B                -e UnitTestClient_B                       3        3
+ type     category        sev          module                subroutine         count   total
+ ---- -------------------- -- ------------------------- ---------------------   -----   -----
+    1 FwkReport            -f AfterSource                                          3*       3
+    2 cat_A                -e UnitTestClient_B:sendSome                            6        6
+    3 cat_B                -e UnitTestClient_B:sendSome                            3        3
 
 * Some occurrences of this message were suppressed in all logs, due to limits.
 
@@ -78,11 +78,11 @@ dropped waiting message count 0
 
 MessageLogger Summary
 
- type     category        sev    module        subroutine        count    total
- ---- -------------------- -- ---------------- ----------------  -----    -----
-    1 FwkReport            -f AfterSource                            3*       3
-    2 cat_A                -e UnitTestClient_B                       6        6
-    3 cat_B                -e UnitTestClient_B                       3        3
+ type     category        sev          module                subroutine         count   total
+ ---- -------------------- -- ------------------------- ---------------------   -----   -----
+    1 FwkReport            -f AfterSource                                          3*       3
+    2 cat_A                -e UnitTestClient_B:sendSome                            6        6
+    3 cat_B                -e UnitTestClient_B:sendSome                            3        3
 
 * Some occurrences of this message were suppressed in all logs, due to limits.
 

--- a/FWCore/MessageService/test/unit_test_outputs/u5_noreset.log
+++ b/FWCore/MessageService/test/unit_test_outputs/u5_noreset.log
@@ -3,11 +3,11 @@
 
 MessageLogger Summary
 
- type     category        sev    module        subroutine        count    total
- ---- -------------------- -- ---------------- ----------------  -----    -----
-    1 FwkReport            -f AfterSource                            1*       1
-    2 cat_A                -e UnitTestClient_B                       1        1
-    3 cat_B                -e UnitTestClient_B                       1        1
+ type     category        sev          module                subroutine         count   total
+ ---- -------------------- -- ------------------------- ---------------------   -----   -----
+    1 FwkReport            -f AfterSource                                          1*       1
+    2 cat_A                -e UnitTestClient_B:sendSome                            1        1
+    3 cat_B                -e UnitTestClient_B:sendSome                            1        1
 
 * Some occurrences of this message were suppressed in all logs, due to limits.
 
@@ -28,11 +28,11 @@ dropped waiting message count 0
 
 MessageLogger Summary
 
- type     category        sev    module        subroutine        count    total
- ---- -------------------- -- ---------------- ----------------  -----    -----
-    1 FwkReport            -f AfterSource                            2*       2
-    2 cat_A                -e UnitTestClient_B                       3        3
-    3 cat_B                -e UnitTestClient_B                       2        2
+ type     category        sev          module                subroutine         count   total
+ ---- -------------------- -- ------------------------- ---------------------   -----   -----
+    1 FwkReport            -f AfterSource                                          2*       2
+    2 cat_A                -e UnitTestClient_B:sendSome                            3        3
+    3 cat_B                -e UnitTestClient_B:sendSome                            2        2
 
 * Some occurrences of this message were suppressed in all logs, due to limits.
 
@@ -53,11 +53,11 @@ dropped waiting message count 0
 
 MessageLogger Summary
 
- type     category        sev    module        subroutine        count    total
- ---- -------------------- -- ---------------- ----------------  -----    -----
-    1 FwkReport            -f AfterSource                            3*       3
-    2 cat_A                -e UnitTestClient_B                       6        6
-    3 cat_B                -e UnitTestClient_B                       3        3
+ type     category        sev          module                subroutine         count   total
+ ---- -------------------- -- ------------------------- ---------------------   -----   -----
+    1 FwkReport            -f AfterSource                                          3*       3
+    2 cat_A                -e UnitTestClient_B:sendSome                            6        6
+    3 cat_B                -e UnitTestClient_B:sendSome                            3        3
 
 * Some occurrences of this message were suppressed in all logs, due to limits.
 
@@ -78,11 +78,11 @@ dropped waiting message count 0
 
 MessageLogger Summary
 
- type     category        sev    module        subroutine        count    total
- ---- -------------------- -- ---------------- ----------------  -----    -----
-    1 FwkReport            -f AfterSource                            3*       3
-    2 cat_A                -e UnitTestClient_B                       6        6
-    3 cat_B                -e UnitTestClient_B                       3        3
+ type     category        sev          module                subroutine         count   total
+ ---- -------------------- -- ------------------------- ---------------------   -----   -----
+    1 FwkReport            -f AfterSource                                          3*       3
+    2 cat_A                -e UnitTestClient_B:sendSome                            6        6
+    3 cat_B                -e UnitTestClient_B:sendSome                            3        3
 
 * Some occurrences of this message were suppressed in all logs, due to limits.
 

--- a/FWCore/MessageService/test/unit_test_outputs/u5_reset.log
+++ b/FWCore/MessageService/test/unit_test_outputs/u5_reset.log
@@ -3,11 +3,11 @@
 
 MessageLogger Summary
 
- type     category        sev    module        subroutine        count    total
- ---- -------------------- -- ---------------- ----------------  -----    -----
-    1 FwkReport            -f AfterSource                            1*       1
-    2 cat_A                -e UnitTestClient_B                       1        1
-    3 cat_B                -e UnitTestClient_B                       1        1
+ type     category        sev          module                subroutine         count   total
+ ---- -------------------- -- ------------------------- ---------------------   -----   -----
+    1 FwkReport            -f AfterSource                                          1*       1
+    2 cat_A                -e UnitTestClient_B:sendSome                            1        1
+    3 cat_B                -e UnitTestClient_B:sendSome                            1        1
 
 * Some occurrences of this message were suppressed in all logs, due to limits.
 
@@ -28,11 +28,11 @@ dropped waiting message count 0
 
 MessageLogger Summary
 
- type     category        sev    module        subroutine        count    total
- ---- -------------------- -- ---------------- ----------------  -----    -----
-    1 FwkReport            -f AfterSource                            1*       1
-    2 cat_A                -e UnitTestClient_B                       2        2
-    3 cat_B                -e UnitTestClient_B                       1        1
+ type     category        sev          module                subroutine         count   total
+ ---- -------------------- -- ------------------------- ---------------------   -----   -----
+    1 FwkReport            -f AfterSource                                          1*       1
+    2 cat_A                -e UnitTestClient_B:sendSome                            2        2
+    3 cat_B                -e UnitTestClient_B:sendSome                            1        1
 
 * Some occurrences of this message were suppressed in all logs, due to limits.
 
@@ -53,11 +53,11 @@ dropped waiting message count 0
 
 MessageLogger Summary
 
- type     category        sev    module        subroutine        count    total
- ---- -------------------- -- ---------------- ----------------  -----    -----
-    1 FwkReport            -f AfterSource                            1*       1
-    2 cat_A                -e UnitTestClient_B                       3        3
-    3 cat_B                -e UnitTestClient_B                       1        1
+ type     category        sev          module                subroutine         count   total
+ ---- -------------------- -- ------------------------- ---------------------   -----   -----
+    1 FwkReport            -f AfterSource                                          1*       1
+    2 cat_A                -e UnitTestClient_B:sendSome                            3        3
+    3 cat_B                -e UnitTestClient_B:sendSome                            1        1
 
 * Some occurrences of this message were suppressed in all logs, due to limits.
 

--- a/FWCore/MessageService/test/unit_test_outputs/warnings.log
+++ b/FWCore/MessageService/test/unit_test_outputs/warnings.log
@@ -24,10 +24,10 @@ Test of std::setprecision(p): Pi with precision 12 is 3.14159265359
 
 MessageLogger Summary
 
- type     category        sev    module        subroutine        count    total
- ---- -------------------- -- ---------------- ----------------  -----    -----
-    1 cat_A                -w UnitTestClient_G                       1        1
-    2 cat_C                -w UnitTestClient_G                      15*      15
+ type     category        sev          module                subroutine         count   total
+ ---- -------------------- -- ------------------------- ---------------------   -----   -----
+    1 cat_A                -w UnitTestClient_G:sendSome                            1        1
+    2 cat_C                -w UnitTestClient_G:sendSome                           15*      15
 
 * Some occurrences of this message were suppressed in all logs, due to limits.
 


### PR DESCRIPTION
#### PR description:

In the "MessageLogger Summary" at the end of a CMSSW job, particularly if one sets the MessageLogger printout level to INFO, so messages for many modules are printed out, one sees that strings corresponding to the names of the "modules" and "subroutines" are often so heavily truncated that it's not possible to identify them.

This PR increases the width of the "module" field from 16 to 25 letters and of the "subroutine" field from 16 to 21 letters. Although this doesn't eliminate truncation, it reduces it enough that most of the modules can be identified in the summary. The PR also adjusts the columns heading positions of the MessageLogger Summary to match the increased field widths.

This is a small code change, but will obviously affect many CMSSW jobs.