### PR TITLE
[JMENano] Setup Pileup Jet ID for reclustered AK4 Puppi jets

### DIFF
--- a/PhysicsTools/NanoAOD/python/custom_jme_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_jme_cff.py
@@ -676,7 +676,7 @@ def ReclusterAK4PuppiJets(proc, recoJA, runOnMC):
   )
   proc.jetPuppiTask.add(getattr(proc, pileupJetIdName))
   proc.updatedJetsPuppiWithUserData.userFloats.puIdDisc = cms.InputTag(pileupJetIdName+':fullDiscriminant')
-  proc.jetPuppiTable.variables.puIdDisc.expr = "userFloat('puIdDisc')"
+  proc.jetPuppiTable.variables.puIdDisc = Var("userFloat('puIdDisc')", float, doc="Pileup ID BDT discriminant with 133X Winter24 PuppiV18 training",precision=10)
 
 
   #

--- a/PhysicsTools/NanoAOD/python/custom_jme_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_jme_cff.py
@@ -662,9 +662,26 @@ def ReclusterAK4PuppiJets(proc, recoJA, runOnMC):
   proc.jetPuppiTable.variables.phoMultiplicity   = PFJETVARS.phoMultiplicity
 
   #
+  # Add Pileup Jet ID for Puppi jets
+  #
+  from RecoJets.JetProducers.PileupJetID_cfi import pileupJetIdPuppi
+  pileupJetIdName = "pileupJetId{}".format(jetName)
+  setattr(proc, pileupJetIdName, pileupJetIdPuppi.clone(
+      jets = "updatedJetsPuppi",
+      srcConstituentWeights = "packedpuppi",
+      vertexes  = "offlineSlimmedPrimaryVertices",
+      inputIsCorrected=True,
+      applyJec=False
+    )
+  )
+  proc.jetPuppiTask.add(getattr(proc, pileupJetIdName))
+  proc.updatedJetsPuppiWithUserData.userFloats.puIdDisc = cms.InputTag(pileupJetIdName+':fullDiscriminant')
+  proc.jetPuppiTable.variables.puIdDisc.expr = "userFloat('puIdDisc')"
+
+
+  #
   # Add variables for pileup jet ID studies.
   #
-
   proc = AddPileUpJetIDVars(proc,
     jetName = jetName,
     jetSrc = "updatedJetsPuppi",


### PR DESCRIPTION
#### PR description:

Following up on PR #46191, this PR sets up the Pileup Jet ID for reclustered AK4 Puppi jets in JMENano. This should also address the failed RelVals workflows as reported in Issue #46221.

#### PR validation:

- passes the failed JMENano workflows: `runTheMatrix.py -i all --ibeos -l 10224.15,11024.15,11634.15,25202.15`


