### PR TITLE
[14.1.X] `AlcaPCCEventProducer` configuration to save per ROC data 

### DIFF
--- a/Calibration/LumiAlCaRecoProducers/plugins/AlcaPCCEventProducer.cc
+++ b/Calibration/LumiAlCaRecoProducers/plugins/AlcaPCCEventProducer.cc
@@ -37,8 +37,8 @@ public:
 
 private:
   const edm::InputTag pixelClusterLabel_;
-  const std::string trigstring_;      //specifies the trigger Rand or ZeroBias
-  const bool savePerROCInfo_;  // save per ROC data (important for the special fills)
+  const std::string trigstring_;  //specifies the trigger Rand or ZeroBias
+  const bool savePerROCInfo_;     // save per ROC data (important for the special fills)
   const edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > pixelToken_;
 
   static constexpr int rowsperroc = 52;

--- a/Calibration/LumiAlCaRecoProducers/plugins/AlcaPCCEventProducer.cc
+++ b/Calibration/LumiAlCaRecoProducers/plugins/AlcaPCCEventProducer.cc
@@ -37,7 +37,8 @@ public:
 
 private:
   const edm::InputTag pixelClusterLabel_;
-  const std::string trigstring_;  //specifies the trigger Rand or ZeroBias
+  const std::string trigstring_;      //specifies the trigger Rand or ZeroBias
+  const bool savePerROCInfo_;  // save per ROC data (important for the special fills)
   const edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > pixelToken_;
 
   static constexpr int rowsperroc = 52;
@@ -49,6 +50,7 @@ private:
 AlcaPCCEventProducer::AlcaPCCEventProducer(const edm::ParameterSet& iConfig)
     : pixelClusterLabel_(iConfig.getParameter<edm::InputTag>("pixelClusterLabel")),
       trigstring_(iConfig.getUntrackedParameter<std::string>("trigstring", "alcaPCCEvent")),
+      savePerROCInfo_(iConfig.getParameter<bool>("savePerROCInfo")),
       pixelToken_(consumes<edmNew::DetSetVector<SiPixelCluster> >(pixelClusterLabel_)) {
   produces<reco::PixelClusterCountsInEvent, edm::Transition::Event>(trigstring_);
 }
@@ -71,19 +73,21 @@ void AlcaPCCEventProducer::produce(edm::StreamID id, edm::Event& iEvent, edm::Ev
     }
     DetId detId = mod.id();
 
-    // Iterate over Clusters in module to fill per ROC histogram
-    for (auto const& cluster : mod) {
-      for (int i = 0; i < cluster.size(); ++i) {
-        const auto pix = cluster.pixel(i);
-        // TODO: add roc threshold to config if(di.adc > fRocThreshold_) {
-        if (pix.adc > 0) {
-          int irow = pix.x / rowsperroc; /* constant column direction is along x-axis */
-          int icol = pix.y / colsperroc; /* constant row direction is along y-axis */
-          /* generate the folling roc index that is going to map with ROC id as
-          8  9  10 11 12 13 14 15
-          0  1  2  3  4  5  6  7 */
-          int key = icol + irow * nROCcolumns;
-          thePCCob->incrementRoc(((detId << 7) + key), 1);
+    if (savePerROCInfo_) {
+      // Iterate over Clusters in module to fill per ROC histogram
+      for (auto const& cluster : mod) {
+        for (int i = 0; i < cluster.size(); ++i) {
+          const auto pix = cluster.pixel(i);
+          // TODO: add roc threshold to config if(di.adc > fRocThreshold_) {
+          if (pix.adc > 0) {
+            int irow = pix.x / rowsperroc; /* constant column direction is along x-axis */
+            int icol = pix.y / colsperroc; /* constant row direction is along y-axis */
+            /* generate the folling roc index that is going to map with ROC id as
+            8  9  10 11 12 13 14 15
+            0  1  2  3  4  5  6  7 */
+            int key = icol + irow * nROCcolumns;
+            thePCCob->incrementRoc(((detId << 7) + key), 1);
+          }
         }
       }
     }
@@ -101,6 +105,7 @@ void AlcaPCCEventProducer::fillDescriptions(edm::ConfigurationDescriptions& desc
   edm::ParameterSetDescription evtParamDesc;
   evtParamDesc.add<edm::InputTag>("pixelClusterLabel", edm::InputTag("siPixelClustersForLumi"));
   evtParamDesc.addUntracked<std::string>("trigstring", "alcaPCCEvent");
+  evtParamDesc.add<bool>("savePerROCInfo", true);
   descriptions.add("alcaPCCEventProducer", evtParamDesc);
 }
 


### PR DESCRIPTION
 backport of https://github.com/cms-sw/cmssw/pull/46231

#### PR description:

A minor change to the `AlcaPCCEventProducer`

The proposed modification would enable external configuration of the producer. This would allow us to specify, via a menu, whether we want to save pixel data at per-module or per-ROC granularity.

This feature is particularly important for special fills where we have high-rate zero-bias streams for AlcaLumi. The proposed change could reduce event size by a factor of ~7 under these conditions compared to the current implementation. It is essential to have this feature for successful pp-Ref and HI vdM fills planned in the next weeks.

However, per-ROC information is critical for physics, as it helps us understand instabilities and non-linearities within individual modules, and we wish to continue recording this data. More details are given in the [talk](https://indico.cern.ch/event/1358674/contributions/5725781/attachments/2775100/4836057/PCC_Active_Masking_Dec_19_2023.pdf) by B. Kronheim and C. Palmer.

This PR is related to https://github.com/cms-sw/cmssw/pull/29069 https://github.com/cms-sw/cmssw/pull/44996

#### PR validation:

See master PR

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/46231 for PPref and HIon 2024 run data-taking purposes
