### PR TITLE
[14.1.X] Minimal bugfix on the missing lumifilter for the MTS validation.

### DIFF
--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/MTS_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/MTS_cfg.py
@@ -66,6 +66,7 @@ if "goodlumi" in config["validation"]:
 
 else:
      goodLumiSecs = cms.untracked.VLuminosityBlockRange()
+process.source.lumisToProcess = goodLumiSecs
 
 ###################################################################
 # Runs and events


### PR DESCRIPTION
Backport of [#46256](https://github.com/cms-sw/cmssw/pull/46256)

#### PR description:
While the list of good lumisections to process was picked up from the global All-in-one config, it was forgotten to pass it to the local python config. This is a patch that ensures we don't need to apply fix manually. No public results were affected. 

#### PR validation:
runtests, code-checks, code-format

@henriettepetersen 
