### PR TITLE
DQM CSCMonitorModule: crash fix for corrupted events with missing ALCT data (14_2_X)

### DIFF
--- a/DQM/CSCMonitorModule/plugins/CSCDQM_EventProcessor_processCSC.cc
+++ b/DQM/CSCMonitorModule/plugins/CSCDQM_EventProcessor_processCSC.cc
@@ -412,12 +412,12 @@ namespace cscdqm {
     /** ALCT Found */
     if (data.nalct()) {
       const CSCALCTHeader* alctHeader = data.alctHeader();
-      int fwVersion = alctHeader->alctFirmwareVersion();
-      int fwRevision = alctHeader->alctFirmwareRevision();
       const CSCALCTTrailer* alctTrailer = data.alctTrailer();
       const CSCAnodeData* alctData = data.alctData();
 
       if (alctHeader && alctTrailer) {
+        int fwVersion = alctHeader->alctFirmwareVersion();
+        int fwRevision = alctHeader->alctFirmwareRevision();
         /** Summary plot for chambers with detected Run3 ALCT firmware */
         if (getEMUHisto(h::EMU_CSC_RUN3_ALCT_FORMAT, mo)) {
           /// ALCT Run3 firmware revision should be > 5


### PR DESCRIPTION
#### PR description:

DQM CSCMonitorModule: crash fix for handling of corrupted events with missing/corrupted ALCT data
Fix for the issue "Segmentation violation in CSCMonitorModule during Express job at T0 #45797 "
https://github.com/cms-sw/cmssw/issues/45797

#### PR validation:

Initial crash was reproduced with original code
After fix was applied the standard CMSSW checks passed 
The fix was tested with provided data sample 
/eos/user/c/cmst0/public/PausedJobs/Run2024G/dqmCSCClient/job_2218360/input/run384963_ls0707_streamExpress_StorageManager.dat
No crashes were observed.
Please advise if backports are needed
