### PR TITLE
Updating phase2_realistic to point to 141X_mcRun4_realistic_v2

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -102,7 +102,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2024 detector for ppRef5TeV
     'phase1_2024_realistic_ppRef5TeV'     :    '141X_mcRun3_2024_realistic_ppRef5TeV_v4',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             :    '141X_mcRun4_realistic_v1'
+    'phase2_realistic'             :    '141X_mcRun4_realistic_v2'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:

This PR updates the GT pointed to by `phase2_realistic`, from `141X_mcRun4_realistic_v1` to `141X_mcRun4_realistic_v2`. This follows the [new GT created yesterday](https://cms-talk.web.cern.ch/t/mc-request-for-updates-to-the-phase2-realistic-gt/51430).

#### PR validation:

When running the [L1TrackNtupleMaker](https://github.com/cms-sw/cmssw/blob/CMSSW_14_2_X_2024-10-04-1100/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py) over Spring24 samples and [re-running the track trigger](https://github.com/cms-sw/cmssw/blob/CMSSW_14_2_X_2024-10-04-1100/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py#L242): previously (with `141X_mcRun4_realistic_v1`) we would get an error of type:
`Size mismatch between geometry (size=43600) and alignments (size=43708)`
After switching to `141X_mcRun4_realistic_v2`, there is no error, and we can run over the files again.