### PR TITLE
Updating phase2_realistic to point to 141X_mcRun4_realistic_v2 [141X Backport]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -102,7 +102,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2024 detector for ppRef5TeV
     'phase1_2024_realistic_ppRef5TeV'     :    '141X_mcRun3_2024_realistic_ppRef5TeV_v4',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             :    '141X_mcRun4_realistic_v1'
+    'phase2_realistic'             :    '141X_mcRun4_realistic_v2'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:

A backport of https://github.com/cms-sw/cmssw/pull/46264. This PR updates the GT pointed to by phase2_realistic, from 141X_mcRun4_realistic_v1 to 141X_mcRun4_realistic_v2. This follows the [new GT created yesterday](https://cms-talk.web.cern.ch/t/mc-request-for-updates-to-the-phase2-realistic-gt/51430).

#### PR validation:

Validation was done in CMSSW_14_2_X_2024-10-02-2300 for the original PR.