### PR TITLE
Updating phase2_realistic to point to 140X_mcRun4_realistic_v5 [140X Backport]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -98,7 +98,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2024, Strip tracker in DECO mode
     'phase1_2024_cosmics_design'   :    '140X_mcRun3_2024cosmics_design_deco_v11',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             :    '140X_mcRun4_realistic_v3'
+    'phase2_realistic'             :    '140X_mcRun4_realistic_v5'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:

A ~backport of https://github.com/cms-sw/cmssw/pull/46264 but with the correct GT for 140X. This PR updates the GT pointed to by phase2_realistic, from 140X_mcRun4_realistic_v3 to 140X_mcRun4_realistic_v5. This follows the [new GT created yesterday](https://cms-talk.web.cern.ch/t/mc-request-for-updates-to-the-phase2-realistic-gt/51430).

#### PR validation:

Validation was done in CMSSW_14_2_X_2024-10-02-2300 for the original PR.