### PR TITLE
[ROOT6] Disable NanoAODRNuple plugin

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/BuildFile.xml
+++ b/PhysicsTools/NanoAOD/plugins/BuildFile.xml
@@ -37,8 +37,9 @@
   <use name="roottmva"/>
   <flags EDM_PLUGIN="1"/>
 </library>
+<!-- Disable RNuple plugin: https://github.com/cms-sw/cmsdist/pull/9451#issuecomment-2393861542
 <library file="rntuple/*.cc" name="PhysicsToolsNanoAODRNuplePlugins">
   <use name="rootntuple"/>
   <flags EDM_PLUGIN="1"/>
 </library>
-
+-->


### PR DESCRIPTION
This PR disables RNuple plugin to get root master changes in ROOT6 IBs. See https://github.com/cms-sw/cmsdist/pull/9451 for details