### PR TITLE
Pass pointer to EgammaRecHitIsolation::getEtSum

### DIFF
--- a/DQMOffline/Trigger/src/EgHLTOffHelper.cc
+++ b/DQMOffline/Trigger/src/EgHLTOffHelper.cc
@@ -309,7 +309,7 @@ void OffHelper::fillIsolData(const reco::GsfElectron& ele, OffEle::IsolData& iso
   } else
     isolData.hltTrksPho = 0.;
   if (calHLTEmIsol_)
-    isolData.hltEm = ecalIsolAlgoEB.getEtSum(&ele, *thresholds) + ecalIsolAlgoEE.getEtSum(&ele, *thresholds);
+    isolData.hltEm = ecalIsolAlgoEB.getEtSum(&ele, thresholds) + ecalIsolAlgoEE.getEtSum(&ele, thresholds);
   else
     isolData.hltEm = 0.;
 }
@@ -475,7 +475,7 @@ void OffHelper::fillIsolData(const reco::Photon& pho, OffPho::IsolData& isolData
   } else
     isolData.hltTrks = 0.;
   if (calHLTEmIsol_)
-    isolData.hltEm = ecalIsolAlgoEB.getEtSum(&pho, *thresholds) + ecalIsolAlgoEE.getEtSum(&pho, *thresholds);
+    isolData.hltEm = ecalIsolAlgoEB.getEtSum(&pho, thresholds) + ecalIsolAlgoEE.getEtSum(&pho, thresholds);
   else
     isolData.hltEm = 0.;
 }

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -1181,11 +1181,11 @@ void GsfElectronAlgo::createElectron(reco::GsfElectronCollection& electrons,
       dr04.hcalRecHitSumEtBc[id] = eventData.hadIsolation04Bc.getHcalEtSumBc(&ele, id + 1, hcalCuts);
     }
 
-    dr03.ecalRecHitSumEt = eventData.ecalBarrelIsol03.getEtSum(&ele, thresholds);
-    dr03.ecalRecHitSumEt += eventData.ecalEndcapIsol03.getEtSum(&ele, thresholds);
+    dr03.ecalRecHitSumEt = eventData.ecalBarrelIsol03.getEtSum(&ele, &thresholds);
+    dr03.ecalRecHitSumEt += eventData.ecalEndcapIsol03.getEtSum(&ele, &thresholds);
 
-    dr04.ecalRecHitSumEt = eventData.ecalBarrelIsol04.getEtSum(&ele, thresholds);
-    dr04.ecalRecHitSumEt += eventData.ecalEndcapIsol04.getEtSum(&ele, thresholds);
+    dr04.ecalRecHitSumEt = eventData.ecalBarrelIsol04.getEtSum(&ele, &thresholds);
+    dr04.ecalRecHitSumEt += eventData.ecalEndcapIsol04.getEtSum(&ele, &thresholds);
   }
 
   dr03.pre7DepthHcal = false;

--- a/RecoEgamma/EgammaIsolationAlgos/interface/EgammaRecHitIsolation.h
+++ b/RecoEgamma/EgammaIsolationAlgos/interface/EgammaRecHitIsolation.h
@@ -38,18 +38,18 @@ public:
                         const EcalSeverityLevelAlgo*,
                         DetId::Detector detector);
 
-  double getEtSum(const reco::Candidate* emObject, EcalPFRecHitThresholds const& thresholds) const {
-    return getSum_(emObject, true, &thresholds);
+  double getEtSum(const reco::Candidate* emObject, EcalPFRecHitThresholds const* thresholds) const {
+    return getSum_(emObject, true, thresholds);
   }
-  double getEnergySum(const reco::Candidate* emObject, EcalPFRecHitThresholds const& thresholds) const {
-    return getSum_(emObject, false, &thresholds);
+  double getEnergySum(const reco::Candidate* emObject, EcalPFRecHitThresholds const* thresholds) const {
+    return getSum_(emObject, false, thresholds);
   }
 
-  double getEtSum(const reco::SuperCluster* emObject, EcalPFRecHitThresholds const& thresholds) const {
-    return getSum_(emObject, true, &thresholds);
+  double getEtSum(const reco::SuperCluster* emObject, EcalPFRecHitThresholds const* thresholds) const {
+    return getSum_(emObject, true, thresholds);
   }
-  double getEnergySum(const reco::SuperCluster* emObject, EcalPFRecHitThresholds const& thresholds) const {
-    return getSum_(emObject, false, &thresholds);
+  double getEnergySum(const reco::SuperCluster* emObject, EcalPFRecHitThresholds const* thresholds) const {
+    return getSum_(emObject, false, thresholds);
   }
 
   void setUseNumCrystals(bool b = true) { useNumCrystals_ = b; }

--- a/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackCandidateProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackCandidateProducer.cc
@@ -406,7 +406,7 @@ void ConversionTrackCandidateProducer::buildCollections(bool isBarrel,
       ecalIso.doSeverityChecks(&ecalRecHits, severitiesexclEE_);
     }
 
-    double ecalIsolation = ecalIso.getEtSum(sc, *thresholds);
+    double ecalIsolation = ecalIso.getEtSum(sc, thresholds);
     if (ecalIsolation > ecalIsoCut_offset_ + ecalIsoCut_slope_ * scEt)
       continue;
 

--- a/RecoEgamma/PhotonIdentification/src/PhotonIsolationCalculator.cc
+++ b/RecoEgamma/PhotonIdentification/src/PhotonIsolationCalculator.cc
@@ -515,7 +515,7 @@ double PhotonIsolationCalculator::calculateEcalRecHitIso(const reco::Photon* pho
   phoIsoEB.setUseNumCrystals(useNumXtals);
   phoIsoEB.doSeverityChecks(ecalhitsCollEB.product(), severityExclEB_);
   phoIsoEB.doFlagChecks(flagsEB_);
-  double ecalIsolEB = phoIsoEB.getEtSum(photon, thresholds);
+  double ecalIsolEB = phoIsoEB.getEtSum(photon, &thresholds);
 
   EgammaRecHitIsolation phoIsoEE(
       RCone, RConeInner, etaSlice, etMin, eMin, geoHandle, *rechitsCollectionEE_, sevLevel, DetId::Ecal);
@@ -525,7 +525,7 @@ double PhotonIsolationCalculator::calculateEcalRecHitIso(const reco::Photon* pho
   phoIsoEE.doSeverityChecks(ecalhitsCollEE.product(), severityExclEE_);
   phoIsoEE.doFlagChecks(flagsEE_);
 
-  double ecalIsolEE = phoIsoEE.getEtSum(photon, thresholds);
+  double ecalIsolEE = phoIsoEE.getEtSum(photon, &thresholds);
   //  delete phoIso;
   double ecalIsol = ecalIsolEB + ecalIsolEE;
 


### PR DESCRIPTION

#### PR description:

The reference was having its address taken and then passed to an internal function which checked for null. UBSAN reported that some calling code of getEtSum was dereferencing a nullptr to pass to the routine.

C++ says references can never be assigned to a nullptr and the compiler/optimizer are allowed to use that. Therefore the internal routine being called CAN have the check for nullptr ignored which can lead to incorrect execution. Only by having getEtSum also take an address rather than a reference can the code be guaranteed to be what was expected.

#### PR validation:

Code compiles.