### PR TITLE
[LLVM Analyzer][DB] Fix dead assignment in FEConfigLUTGroupDat

### DIFF
--- a/OnlineDB/EcalCondDB/src/FEConfigLUTGroupDat.cc
+++ b/OnlineDB/EcalCondDB/src/FEConfigLUTGroupDat.cc
@@ -127,8 +127,7 @@ void FEConfigLUTGroupDat::fetchData(map<EcalLogicID, FEConfigLUTGroupDat>* fillM
 
     int nrows = 1024;
 
-    int igold = -1;
-    int ig = igold;
+    int ig = -1;
 
     while (rset->next()) {
       ig = rset->getInt(1);


### PR DESCRIPTION
#### PR description:

`igold` is never used.

#### PR validation:

Bot tests
