### PR TITLE
[14.1.X] Miscellaneous backports to `DQM/TrackingMonitorSource`

### DIFF
--- a/DQM/TrackingMonitorSource/plugins/StandaloneTrackMonitor.cc
+++ b/DQM/TrackingMonitorSource/plugins/StandaloneTrackMonitor.cc
@@ -387,11 +387,11 @@ void StandaloneTrackMonitor::fillDescriptions(edm::ConfigurationDescriptions& de
   desc.addUntracked<bool>("haveAllHistograms", false);
   desc.addUntracked<std::string>("puScaleFactorFile", "PileupScaleFactor.root");
   desc.addUntracked<std::string>("trackScaleFactorFile", "PileupScaleFactor.root");
-  desc.addUntracked<std::vector<std::string> >("MVAProducers");
-  desc.addUntracked<edm::InputTag>("TrackProducerForMVA");
+  desc.addUntracked<std::vector<std::string> >("MVAProducers", {"initialStepClassifier1", "initialStepClassifier2"});
+  desc.addUntracked<edm::InputTag>("TrackProducerForMVA", edm::InputTag("initialStepTracks"));
 
-  desc.addUntracked<edm::InputTag>("TCProducer");
-  desc.addUntracked<std::string>("AlgoName");
+  desc.addUntracked<edm::InputTag>("TCProducer", edm::InputTag("initialStepTrackCandidates"));
+  desc.addUntracked<std::string>("AlgoName", "GenTk");
   desc.addUntracked<bool>("verbose", false);
 
   {
@@ -1315,7 +1315,8 @@ void StandaloneTrackMonitor::analyze(edm::Event const& iEvent, edm::EventSetup c
   edm::Handle<reco::VertexCollection> vertexColl;
   iEvent.getByToken(vertexToken_, vertexColl);
   if (!vertexColl.isValid()) {
-    edm::LogError("DqmTrackStudy") << "Error! Failed to get reco::Vertex Collection, " << vertexTag_;
+    edm::LogError("StandaloneTrackMonitor") << "Error! Failed to get reco::Vertex Collection, " << vertexTag_;
+    return;
   }
   if (vertexColl->empty()) {
     edm::LogError("StandalonaTrackMonitor") << "No good vertex in the event!!" << std::endl;
@@ -1326,14 +1327,18 @@ void StandaloneTrackMonitor::analyze(edm::Event const& iEvent, edm::EventSetup c
   // Beam spot
   edm::Handle<reco::BeamSpot> beamSpot;
   iEvent.getByToken(bsToken_, beamSpot);
-  if (!beamSpot.isValid())
+  if (!beamSpot.isValid()) {
     edm::LogError("StandalonaTrackMonitor") << "Beamspot for input tag: " << bsTag_ << " not found!!";
+    return;
+  }
 
   // Track collection
   edm::Handle<reco::TrackCollection> tracks;
   iEvent.getByToken(trackToken_, tracks);
-  if (!tracks.isValid())
+  if (!tracks.isValid()) {
     edm::LogError("StandalonaTrackMonitor") << "TrackCollection for input tag: " << trackTag_ << " not found!!";
+    return;
+  }
 
   // Access PU information
   double wfac = 1.0;  // for data

--- a/DQM/TrackingMonitorSource/plugins/TrackMultiplicityFilter.cc
+++ b/DQM/TrackingMonitorSource/plugins/TrackMultiplicityFilter.cc
@@ -62,6 +62,13 @@ bool TrackMultiplicityFilter::filter(edm::StreamID iStream, edm::Event& iEvent, 
   bool pass = false;
   edm::Handle<reco::TrackCollection> tracks;
   iEvent.getByToken(tracksToken_, tracks);
+
+  if (!tracks.isValid()) {
+    edm::LogError("TrackMultiplicityFilter")
+        << "Error >> Failed to get TrackMultiplicityFilter for label: " << tracksTag_;
+    return false;
+  }
+
   double count = std::count_if(tracks->begin(), tracks->end(), selector_);
   pass = (count >= nmin_);
 

--- a/DQM/TrackingMonitorSource/plugins/TtbarTrackProducer.cc
+++ b/DQM/TrackingMonitorSource/plugins/TtbarTrackProducer.cc
@@ -250,16 +250,19 @@ void TtbarTrackProducer::produce(edm::StreamID streamID, edm::Event& iEvent, edm
 
   edm::Handle<reco::JetTagCollection> bTagHandle;
   iEvent.getByToken(bjetsToken_, bTagHandle);
-  const reco::JetTagCollection& bTags = *(bTagHandle.product());
-  std::vector<TLorentzVector> list_bjets;
 
-  if (!bTags.empty()) {
-    for (unsigned bj = 0; bj != bTags.size(); ++bj) {
-      TLorentzVector lv_bjets;
-      lv_bjets.SetPtEtaPhiE(
-          bTags[bj].first->pt(), bTags[bj].first->eta(), bTags[bj].first->phi(), bTags[bj].first->energy());
-      if (bTags[bj].second > btagFactor_)
-        list_bjets.push_back(lv_bjets);
+  if (bTagHandle.isValid()) {
+    const reco::JetTagCollection& bTags = *(bTagHandle.product());
+    std::vector<TLorentzVector> list_bjets;
+
+    if (!bTags.empty()) {
+      for (unsigned bj = 0; bj != bTags.size(); ++bj) {
+        TLorentzVector lv_bjets;
+        lv_bjets.SetPtEtaPhiE(
+            bTags[bj].first->pt(), bTags[bj].first->eta(), bTags[bj].first->phi(), bTags[bj].first->energy());
+        if (bTags[bj].second > btagFactor_)
+          list_bjets.push_back(lv_bjets);
+      }
     }
   }
 

--- a/DQM/TrackingMonitorSource/plugins/V0EventSelector.cc
+++ b/DQM/TrackingMonitorSource/plugins/V0EventSelector.cc
@@ -2,11 +2,13 @@
 #include <vector>
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/View.h"
+#include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Candidate/interface/VertexCompositeCandidate.h"
 #include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
 
 class V0EventSelector : public edm::stream::EDFilter<> {
 public:
@@ -19,25 +21,45 @@ public:
 private:
   const edm::EDGetTokenT<reco::VertexCompositeCandidateCollection> vccToken_;
   const unsigned int minNumCandidates_;
+  const double massMin_;
+  const double massMax_;
 };
 
 V0EventSelector::V0EventSelector(const edm::ParameterSet& iConfig)
     : vccToken_{consumes<reco::VertexCompositeCandidateCollection>(
           iConfig.getParameter<edm::InputTag>("vertexCompositeCandidates"))},
-      minNumCandidates_{iConfig.getParameter<unsigned int>("minCandidates")} {}
+      minNumCandidates_{iConfig.getParameter<unsigned int>("minCandidates")},
+      massMin_{iConfig.getParameter<double>("massMin")},
+      massMax_{iConfig.getParameter<double>("massMax")} {
+  produces<reco::VertexCompositeCandidateCollection>();
+}
 
 bool V0EventSelector::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::Handle<reco::VertexCompositeCandidateCollection> vccHandle;
   iEvent.getByToken(vccToken_, vccHandle);
 
-  return vccHandle->size() >= minNumCandidates_;
+  auto filteredVCC = std::make_unique<reco::VertexCompositeCandidateCollection>();
+
+  for (const auto& vcc : *vccHandle) {
+    if (vcc.mass() >= massMin_ && vcc.mass() <= massMax_) {
+      filteredVCC->push_back(vcc);
+    }
+  }
+
+  bool pass = filteredVCC->size() >= minNumCandidates_;
+  iEvent.put(std::move(filteredVCC));
+
+  return pass;
 }
 
 void V0EventSelector::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("vertexCompositeCandidates", edm::InputTag("generalV0Candidates:Kshort"));
-  desc.add<unsigned int>("minCandidates", 1);  // Change '1' to your desired minimum number of candidates
+  desc.add<unsigned int>("minCandidates", 1)->setComment("Minimum number of candidates required");
+  desc.add<double>("massMin", 0.0)->setComment("Minimum mass in GeV");
+  desc.add<double>("massMax", std::numeric_limits<double>::max())->setComment("Maximum mass in GeV");
   descriptions.addWithDefaultLabel(desc);
 }
 
+// Define this module as a plug-in
 DEFINE_FWK_MODULE(V0EventSelector);

--- a/DQM/TrackingMonitorSource/plugins/V0EventSelector.cc
+++ b/DQM/TrackingMonitorSource/plugins/V0EventSelector.cc
@@ -37,8 +37,13 @@ V0EventSelector::V0EventSelector(const edm::ParameterSet& iConfig)
 bool V0EventSelector::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::Handle<reco::VertexCompositeCandidateCollection> vccHandle;
   iEvent.getByToken(vccToken_, vccHandle);
-
   auto filteredVCC = std::make_unique<reco::VertexCompositeCandidateCollection>();
+
+  // early return if the input collection is empty
+  if (!vccHandle.isValid()) {
+    iEvent.put(std::move(filteredVCC));
+    return false;
+  }
 
   for (const auto& vcc : *vccHandle) {
     if (vcc.mass() >= massMin_ && vcc.mass() <= massMax_) {

--- a/DQM/TrackingMonitorSource/plugins/ZEEDetails.cc
+++ b/DQM/TrackingMonitorSource/plugins/ZEEDetails.cc
@@ -230,7 +230,7 @@ void ZEEDetails::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
       if (beamSpot.isValid()) {
         trkd0 = -(trk->dxy(beamSpot->position()));
       } else {
-        edm::LogError("ElectronTrackProducer") << "Error >> Failed to get BeamSpot for label: " << bsTag_;
+        edm::LogError("ZEEDetails") << "Error >> Failed to get BeamSpot for label: " << bsTag_;
       }
       if (std::fabs(trkd0) >= maxD0_)
         continue;
@@ -261,16 +261,17 @@ void ZEEDetails::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
       finalelectrons.push_back(ele);
     }
   } else {
-    edm::LogError("ElectronTrackProducer") << "Error >> Failed to get ElectronCollection for label: " << electronTag_;
+    edm::LogError("ZEEDetails") << "Error >> Failed to get ElectronCollection for label: " << electronTag_;
   }
 
   edm::Handle<reco::VertexCollection> vertexColl;
   iEvent.getByToken(vertexToken_, vertexColl);
   if (!vertexColl.isValid()) {
-    edm::LogError("DqmTrackStudy") << "Error! Failed to get reco::Vertex Collection, " << vertexTag_;
+    edm::LogError("ZEEDetails") << "Error! Failed to get reco::Vertex Collection, " << vertexTag_;
+    return;
   }
   if (vertexColl->empty()) {
-    edm::LogError("DqmTrackStudy") << "No good vertex in the event!!";
+    edm::LogError("ZEEDetails") << "No good vertex in the event!!";
     return;
   }
 
@@ -294,7 +295,7 @@ void ZEEDetails::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
         }
       }
     } else
-      edm::LogError("DqmTrackStudy") << "PUSummary for input tag: " << puSummaryTag_ << " not found!!";
+      edm::LogError("ZEEDetails") << "PUSummary for input tag: " << puSummaryTag_ << " not found!!";
   }
 
   for (unsigned int I = 0; I != finalelectrons.size(); I++) {

--- a/DQM/TrackingMonitorSource/python/TrackingDataMCValidation_Standalone_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackingDataMCValidation_Standalone_cff.py
@@ -94,7 +94,7 @@ electronTracks = cms.EDProducer("ZtoEEElectronTrackProducer")
 ttbarEventSelector = cms.EDFilter("ttbarEventSelector")
 ttbarTracks = cms.EDProducer("TtbarTrackProducer")
 
-# Added modules for V0Monitoring
+# Added modules for V0Monitoring (standard)
 KshortMonitor = v0Monitor.clone()
 KshortMonitor.FolderName = "StandaloneTrackMonitor/V0Monitoring/Ks"
 KshortMonitor.v0         = "generalV0Candidates:Kshort"
@@ -108,6 +108,18 @@ LambdaMonitor.v0 = "generalV0Candidates:Lambda"
 LambdaMonitor.histoPSet.massPSet = cms.PSet(nbins = cms.int32(100),
                                             xmin  = cms.double(1.050),
                                             xmax  = cms.double(1.250))
+
+# Added modules for V0Monitoring (for restricted mass candidates)
+SelectedKshortMonitor = KshortMonitor.clone(
+    FolderName = "StandaloneTrackMonitor/V0Monitoring/SelectedKs",
+    v0         = "KShortEventSelector"
+)
+
+SelectedLambdaMonitor = LambdaMonitor.clone(
+    FolderName = "StandaloneTrackMonitor/V0Monitoring/SelectedLambda",
+    v0         = "LambdaEventSelector"
+)
+
 ##################
 # For MinBias
 ##################
@@ -171,7 +183,7 @@ standaloneValidationK0s = cms.Sequence(
     * KShortEventSelector
     * KshortTracks
     * standaloneTrackMonitorK0
-    * KshortMonitor)
+    * SelectedKshortMonitor)
 
 standaloneValidationK0sMC = cms.Sequence(
     hltPathFilter
@@ -179,7 +191,7 @@ standaloneValidationK0sMC = cms.Sequence(
     * KShortEventSelector
     * KshortTracks
     * standaloneTrackMonitorK0MC
-    * KshortMonitor)
+    * SelectedKshortMonitor)
 
 standaloneValidationLambdas = cms.Sequence(
     hltPathFilter
@@ -187,7 +199,7 @@ standaloneValidationLambdas = cms.Sequence(
     * LambdaEventSelector
     * LambdaTracks
     * standaloneTrackMonitorLambda
-    * LambdaMonitor)
+    * SelectedLambdaMonitor)
 
 standaloneValidationLambdasMC = cms.Sequence(
     hltPathFilter
@@ -195,7 +207,7 @@ standaloneValidationLambdasMC = cms.Sequence(
     * LambdaEventSelector
     * LambdaTracks
     * standaloneTrackMonitorLambdaMC
-    * LambdaMonitor)
+    * SelectedLambdaMonitor)
 
 ##################
 # For ZtoEE

--- a/DQM/TrackingMonitorSource/python/V0Selections_cfi.py
+++ b/DQM/TrackingMonitorSource/python/V0Selections_cfi.py
@@ -1,12 +1,21 @@
 from DQM.TrackingMonitorSource.v0EventSelector_cfi import *
 from DQM.TrackingMonitorSource.v0VertexTrackProducer_cfi import *
 
-KShortEventSelector = v0EventSelector.clone()
-LambdaEventSelector = v0EventSelector.clone(
-    vertexCompositeCandidates = "generalV0Candidates:Lambda"  
+KShortEventSelector = v0EventSelector.clone(
+    vertexCompositeCandidates = "generalV0Candidates:Kshort",
+    massMin = 0.47,
+    massMax = 0.52,
 )
 
-KshortTracks = v0VertexTrackProducer.clone()
+LambdaEventSelector = v0EventSelector.clone(
+    vertexCompositeCandidates = "generalV0Candidates:Lambda",
+    massMin = 1.11,
+    massMax = 1.128
+)
+
+KshortTracks = v0VertexTrackProducer.clone(
+    vertexCompositeCandidates = "KShortEventSelector"
+)
 LambdaTracks = v0VertexTrackProducer.clone(
-    vertexCompositeCandidates = "generalV0Candidates:Lambda"
+    vertexCompositeCandidates = "LambdaEventSelector"
 )

--- a/DQM/TrackingMonitorSource/test/BuildFile.xml
+++ b/DQM/TrackingMonitorSource/test/BuildFile.xml
@@ -1,2 +1,8 @@
 <test name="testTrackingDATAMC" command="testTrackingDATAMC.sh"/>
 <test name="testTrackingResolution" command="testTrackingResolution.sh"/>
+<environment>
+  <bin file="testTrackingDQMAnalyzers.cc" name="testTrackingDQMAnalyzers">
+    <use name="FWCore/TestProcessor"/>
+    <use name="catch2"/>
+  </bin>
+</environment>

--- a/DQM/TrackingMonitorSource/test/testTrackingDQMAnalyzers.cc
+++ b/DQM/TrackingMonitorSource/test/testTrackingDQMAnalyzers.cc
@@ -1,0 +1,165 @@
+#include "FWCore/TestProcessor/interface/TestProcessor.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+// Function to run the catch2 tests
+//___________________________________________________________________________________________
+void runTestForAnalyzer(const std::string& baseConfig, const std::string& analyzerName) {
+  edm::test::TestProcessor::Config config{baseConfig};
+
+  SECTION(analyzerName + " base configuration is OK") { REQUIRE_NOTHROW(edm::test::TestProcessor(config)); }
+
+  SECTION(analyzerName + " No Runs data") {
+    edm::test::TestProcessor tester(config);
+    REQUIRE_NOTHROW(tester.testWithNoRuns());
+  }
+
+  SECTION(analyzerName + " beginJob and endJob only") {
+    edm::test::TestProcessor tester(config);
+    REQUIRE_NOTHROW(tester.testBeginAndEndJobOnly());
+  }
+
+  SECTION("No event data") {
+    edm::test::TestProcessor tester(config);
+    REQUIRE_NOTHROW(tester.test());
+  }
+
+  SECTION("Run with no LuminosityBlocks") {
+    edm::test::TestProcessor tester(config);
+    REQUIRE_NOTHROW(tester.testRunWithNoLuminosityBlocks());
+  }
+
+  SECTION("LuminosityBlock with no Events") {
+    edm::test::TestProcessor tester(config);
+    REQUIRE_NOTHROW(tester.testLuminosityBlockWithNoEvents());
+  }
+}
+
+// Function to generate base configuration string
+//___________________________________________________________________________________________
+std::string generateBaseConfig(const std::string& analyzerName, const std::string& rootFileName) {
+  // Define a raw string literal
+  constexpr const char* rawString = R"_(from FWCore.TestProcessor.TestProcess import *
+process = TestProcess()
+process.load("MagneticField.Engine.uniformMagneticField_cfi")
+process.load("Configuration.Geometry.GeometryExtended2024Reco_cff")
+process.load("Alignment.CommonAlignmentProducer.FakeAlignmentSource_cfi")
+from DQM.TrackingMonitorSource.{}_cfi import {}
+process.trackAnalyzer = {}
+process.moduleToTest(process.trackAnalyzer)
+process.add_(cms.Service('DQMStore'))
+process.add_(cms.Service('MessageLogger'))
+process.add_(cms.Service('JobReportService'))
+process.add_(cms.Service('TFileService',fileName=cms.string('{}')))
+    )_";
+
+  // Format the raw string literal using fmt::format
+  return fmt::format(rawString, analyzerName, analyzerName, analyzerName, rootFileName);
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("ShortenedTrackResolution tests", "[ShortenedTrackResolution]") {
+  const std::string baseConfig = generateBaseConfig("shortenedTrackResolution", "test1.root");
+  runTestForAnalyzer(baseConfig, "ShortenedTrackResolution");
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("StandaloneTrackMonitor tests", "[StandaloneTrackMonitor]") {
+  const std::string baseConfig = generateBaseConfig("standaloneTrackMonitorDefault", "test2.root");
+  runTestForAnalyzer(baseConfig, "StandaloneTrackMonitor");
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("AlcaRecoTrackSelector tests", "[AlcaRecoTrackSelector]") {
+  const std::string baseConfig = generateBaseConfig("alcaRecoTrackSelector", "tes3.root");
+  runTestForAnalyzer(baseConfig, "AlcaRecoTrackSelector");
+}
+
+//___________________________________________________________________________________________
+//TEST_CASE("HltPathSelector tests", "[HltPathSelector]") {
+//  const std::string baseConfig = generateBaseConfig("hltPathSelector", "test_hltPathSelector.root");
+//  runTestForAnalyzer(baseConfig, "HltPathSelector");
+//}
+
+//___________________________________________________________________________________________
+TEST_CASE("TrackMultiplicityFilter tests", "[TrackMultiplicityFilter]") {
+  const std::string baseConfig = generateBaseConfig("trackMultiplicityFilter", "test_trackMultiplicityFilter.root");
+  runTestForAnalyzer(baseConfig, "TrackMultiplicityFilter");
+}
+
+//___________________________________________________________________________________________
+//TEST_CASE("TrackToTrackComparisonHists tests", "[TrackToTrackComparisonHists]") {
+//  const std::string baseConfig = generateBaseConfig("trackToTrackComparisonHists", "test_trackToTrackComparisonHists.root");
+//  runTestForAnalyzer(baseConfig, "TrackToTrackComparisonHists");
+//}
+
+//___________________________________________________________________________________________
+TEST_CASE("TrackTypeMonitor tests", "[TrackTypeMonitor]") {
+  const std::string baseConfig = generateBaseConfig("trackTypeMonitor", "test_trackTypeMonitor.root");
+  runTestForAnalyzer(baseConfig, "TrackTypeMonitor");
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("TtbarEventSelector tests", "[TtbarEventSelector]") {
+  const std::string baseConfig = generateBaseConfig("ttbarEventSelector", "test_ttbarEventSelector.root");
+  runTestForAnalyzer(baseConfig, "TtbarEventSelector");
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("TtbarTrackProducer tests", "[TtbarTrackProducer]") {
+  const std::string baseConfig = generateBaseConfig("ttbarTrackProducer", "test_ttbarTrackProducer.root");
+  runTestForAnalyzer(baseConfig, "TtbarTrackProducer");
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("V0EventSelector tests", "[V0EventSelector]") {
+  const std::string baseConfig = generateBaseConfig("v0EventSelector", "test_v0EventSelector.root");
+  runTestForAnalyzer(baseConfig, "V0EventSelector");
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("V0VertexTrackProducer tests", "[V0VertexTrackProducer]") {
+  const std::string baseConfig = generateBaseConfig("v0VertexTrackProducer", "test_v0VertexTrackProducer.root");
+  runTestForAnalyzer(baseConfig, "V0VertexTrackProducer");
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("WtoLNuSelector tests", "[WtoLNuSelector]") {
+  const std::string baseConfig = generateBaseConfig("wtoLNuSelector", "test_wtoLNuSelector.root");
+  runTestForAnalyzer(baseConfig, "WtoLNuSelector");
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("ZeeDetails tests", "[ZeeDetails]") {
+  const std::string baseConfig = generateBaseConfig("zeeDetails", "test_zeeDetails.root");
+  runTestForAnalyzer(baseConfig, "ZeeDetails");
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("ZtoEEElectronTrackProducer tests", "[ZtoEEElectronTrackProducer]") {
+  const std::string baseConfig =
+      generateBaseConfig("ztoEEElectronTrackProducer", "test_ztoEEElectronTrackProducer.root");
+  runTestForAnalyzer(baseConfig, "ZtoEEElectronTrackProducer");
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("ZtoEEEventSelector tests", "[ZtoEEEventSelector]") {
+  const std::string baseConfig = generateBaseConfig("ztoEEEventSelector", "test_ztoEEEventSelector.root");
+  runTestForAnalyzer(baseConfig, "ZtoEEEventSelector");
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("ZtoMMEventSelector tests", "[ZtoMMEventSelector]") {
+  const std::string baseConfig = generateBaseConfig("ztoMMEventSelector", "test_ztoMMEventSelector.root");
+  runTestForAnalyzer(baseConfig, "ZtoMMEventSelector");
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("ZtoMMMuonTrackProducer tests", "[ZtoMMMuonTrackProducer]") {
+  const std::string baseConfig = generateBaseConfig("ztoMMMuonTrackProducer", "test_ztoMMMuonTrackProducer.root");
+  runTestForAnalyzer(baseConfig, "ZtoMMMuonTrackProducer");
+}


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/46005 
backport of https://github.com/cms-sw/cmssw/pull/46187

#### PR description:

   * 41e92bba26cb065216ec737e623cf39b291bb643 make `V0EventSelector` produce skimmed V0 collections based on their mass. It was suggested to modify `V0EventSelector` in order to produce skimmed V0 collections based on their mass, to enhance the purity in terms of strange origin of the tracks analyzed via `StandaloneTrackMonitor`, based on the results shown [here](https://dbruschi.web.cern.ch/TrackingPOG_sorted/2024_physics_production/K0s/) and [here](https://dbruschi.web.cern.ch/TrackingPOG_sorted/2024_physics_production/Lambdas/).
   * 199548dfdc867040529a6e9364abdaf9d743801a add missing `fillDescription` parameters and place early returns in case of missing input data in various plugins
   * 514a64cae279aa91cfb6b836f4a57b0a0b5afd76 add `catch2` based tests for various plugins in the package

This update concerns only the Tracking Data/MC validation suite and is of no consequence on any DQM production sequence run in online or offline DQM.

#### PR validation:

Relies on the unit tests of this package: (existing) `scram b runtests_testTrackingDATAMC` and (newly added) `scram b runtests_testTrackingDQMAnalyzers`  both run fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backports of https://github.com/cms-sw/cmssw/pull/46005 and https://github.com/cms-sw/cmssw/pull/46187