### PR TITLE
Increase threshold of max number of pixel clusters for cosmic tracking

### DIFF
--- a/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForCosmics_cfi.py
+++ b/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForCosmics_cfi.py
@@ -109,7 +109,7 @@ combinatorialcosmicseedfinder = cms.EDProducer("CtfSpecialSeedGenerator",
     ClusterCollectionLabel = cms.InputTag("siStripClusters"),
     MaxNumberOfStripClusters = cms.uint32(300),
     PixelClusterCollectionLabel = cms.InputTag("siPixelClusters"),
-    MaxNumberOfPixelClusters = cms.uint32(300),
+    MaxNumberOfPixelClusters = cms.uint32(1000),
     requireBOFF = cms.bool(False),
     maxSeeds = cms.int32(10000),
 )

--- a/RecoTracker/SpecialSeedGenerators/python/CosmicSeed_cfi.py
+++ b/RecoTracker/SpecialSeedGenerators/python/CosmicSeed_cfi.py
@@ -17,7 +17,7 @@ cosmicseedfinder = cms.EDProducer("CosmicSeedGenerator",
     DontCountDetsAboveNClusters = cms.uint32(20),
     originRadius = cms.double(150.0),
     ClusterCollectionLabel = cms.InputTag("siStripClusters"),
-    MaxNumberOfPixelClusters = cms.uint32(300),
+    MaxNumberOfPixelClusters = cms.uint32(1000),
     PixelClusterCollectionLabel = cms.InputTag("siPixelClusters"),
     originHalfLength = cms.double(90.0),
     #***top-bottom

--- a/RecoTracker/SpecialSeedGenerators/python/SimpleCosmicBONSeeder_cfi.py
+++ b/RecoTracker/SpecialSeedGenerators/python/SimpleCosmicBONSeeder_cfi.py
@@ -39,7 +39,7 @@ simpleCosmicBONSeeds = cms.EDProducer("SimpleCosmicBONSeeder",
             MaxNumberOfStripClusters = cms.uint32(300),
             ClusterCollectionLabel = cms.InputTag("siStripClusters"),
             DontCountDetsAboveNClusters = cms.uint32(20),  # if N > 0, ignore in total the dets with more than N clusters
-            MaxNumberOfPixelClusters = cms.uint32(300),
+            MaxNumberOfPixelClusters = cms.uint32(1000),
             PixelClusterCollectionLabel = cms.InputTag("siPixelClusters")
     ),
     maxTriplets = cms.int32(50000),


### PR DESCRIPTION
#### PR description:
The rate of cosmic tracks have dropped since ERA G, see latest [slides](https://indico.cern.ch/event/1455576/#37-update-on-drop-in-cosmic-ra). After performing several tests, Tracker DPG concluded that it was related to the cut that is imposed for number of max. pixel clusters per event in Cosmic tracking, see [slides](https://indico.cern.ch/event/1455576/contributions/6165164/attachments/2940845/5166520/241004_Cosmic_rate.pdf). The average number of clusters in pixel has steadily increased and reaching ```300```(default value till now) is roughly correlated in time with the rate drop. We are increasing the threshold to ```1000``` in the configs for Cosmic tracking.

#### If this PR is a backport please specify the original PR and why you need to backport that PR.
Not a backport. Backport will be done for 14_0_X.