### PR TITLE
Improve constructor for PhotonIsolationCalculator

### DIFF
--- a/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
@@ -426,14 +426,13 @@ GEDPhotonProducer::GEDPhotonProducer(const edm::ParameterSet& config, const Cach
 
   //moved from beginRun to here, I dont see how this could cause harm as its just reading in the exactly same parameters each run
   if (!recoStep_.isFinal()) {
-    photonIsoCalculator_ = std::make_unique<PhotonIsolationCalculator>();
     edm::ParameterSet isolationSumsCalculatorSet = config.getParameter<edm::ParameterSet>("isolationSumsCalculatorSet");
-    photonIsoCalculator_->setup(isolationSumsCalculatorSet,
-                                flagsexclEB_,
-                                flagsexclEE_,
-                                severitiesexclEB_,
-                                severitiesexclEE_,
-                                consumesCollector());
+    photonIsoCalculator_ = std::make_unique<PhotonIsolationCalculator>(isolationSumsCalculatorSet,
+                                                                       flagsexclEB_,
+                                                                       flagsexclEE_,
+                                                                       severitiesexclEB_,
+                                                                       severitiesexclEE_,
+                                                                       consumesCollector());
     edm::ParameterSet mipVariableSet = config.getParameter<edm::ParameterSet>("mipVariableSet");
     photonMIPHaloTagger_ = std::make_unique<PhotonMIPHaloTagger>(mipVariableSet, consumesCollector());
   }

--- a/RecoEgamma/EgammaPhotonProducers/src/PhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/PhotonProducer.cc
@@ -125,6 +125,20 @@ DEFINE_FWK_MODULE(PhotonProducer);
 PhotonProducer::PhotonProducer(const edm::ParameterSet& config)
     : caloGeomToken_(esConsumes()),
       topologyToken_(esConsumes()),
+      flagsexclEB_{StringToEnumValue<EcalRecHit::Flags>(
+          config.getParameter<std::vector<std::string>>("RecHitFlagToBeExcludedEB"))},
+      flagsexclEE_{StringToEnumValue<EcalRecHit::Flags>(
+          config.getParameter<std::vector<std::string>>("RecHitFlagToBeExcludedEE"))},
+      severitiesexclEB_{StringToEnumValue<EcalSeverityLevel::SeverityLevel>(
+          config.getParameter<std::vector<std::string>>("RecHitSeverityToBeExcludedEB"))},
+      severitiesexclEE_{StringToEnumValue<EcalSeverityLevel::SeverityLevel>(
+          config.getParameter<std::vector<std::string>>("RecHitSeverityToBeExcludedEE"))},
+      photonIsolationCalculator_(config.getParameter<edm::ParameterSet>("isolationSumsCalculatorSet"),
+                                 flagsexclEB_,
+                                 flagsexclEE_,
+                                 severitiesexclEB_,
+                                 severitiesexclEE_,
+                                 consumesCollector()),
       photonMIPHaloTagger_(config.getParameter<edm::ParameterSet>("mipVariableSet"), consumesCollector()),
       photonEnergyCorrector_(config, consumesCollector()) {
   // use configuration file to setup input/output collection names
@@ -153,28 +167,6 @@ PhotonProducer::PhotonProducer(const edm::ParameterSet& config)
   if (cutsFromDB_) {
     hcalCutsToken_ = esConsumes<HcalPFCuts, HcalPFCutsRcd>(edm::ESInputTag("", "withTopo"));
   }
-
-  //AA
-  //Flags and Severities to be excluded from photon calculations
-  const std::vector<std::string> flagnamesEB =
-      config.getParameter<std::vector<std::string>>("RecHitFlagToBeExcludedEB");
-
-  const std::vector<std::string> flagnamesEE =
-      config.getParameter<std::vector<std::string>>("RecHitFlagToBeExcludedEE");
-
-  flagsexclEB_ = StringToEnumValue<EcalRecHit::Flags>(flagnamesEB);
-
-  flagsexclEE_ = StringToEnumValue<EcalRecHit::Flags>(flagnamesEE);
-
-  const std::vector<std::string> severitynamesEB =
-      config.getParameter<std::vector<std::string>>("RecHitSeverityToBeExcludedEB");
-
-  severitiesexclEB_ = StringToEnumValue<EcalSeverityLevel::SeverityLevel>(severitynamesEB);
-
-  const std::vector<std::string> severitynamesEE =
-      config.getParameter<std::vector<std::string>>("RecHitSeverityToBeExcludedEE");
-
-  severitiesexclEE_ = StringToEnumValue<EcalSeverityLevel::SeverityLevel>(severitynamesEE);
 
   ElectronHcalHelper::Configuration cfgCone, cfgBc;
   cfgCone.hOverEConeSize = hOverEConeSize_;
@@ -244,10 +236,6 @@ PhotonProducer::PhotonProducer(const edm::ParameterSet& config)
   preselCutValuesEndcap_.push_back(config.getParameter<double>("trackPtSumHollowConeEndcap"));
   preselCutValuesEndcap_.push_back(config.getParameter<double>("sigmaIetaIetaCutEndcap"));
   //
-
-  edm::ParameterSet isolationSumsCalculatorSet = config.getParameter<edm::ParameterSet>("isolationSumsCalculatorSet");
-  photonIsolationCalculator_.setup(
-      isolationSumsCalculatorSet, flagsexclEB_, flagsexclEE_, severitiesexclEB_, severitiesexclEE_, consumesCollector());
 
   // Register the product
   produces<reco::PhotonCollection>(PhotonCollection_);

--- a/RecoEgamma/PhotonIdentification/interface/PhotonIsolationCalculator.h
+++ b/RecoEgamma/PhotonIdentification/interface/PhotonIsolationCalculator.h
@@ -32,16 +32,14 @@ class EcalSeverityLevelAlgoRcd;
 
 class PhotonIsolationCalculator {
 public:
-  PhotonIsolationCalculator() {}
+  PhotonIsolationCalculator(const edm::ParameterSet& conf,
+                            std::vector<int> const& flagsEB_,
+                            std::vector<int> const& flagsEE_,
+                            std::vector<int> const& severitiesEB_,
+                            std::vector<int> const& severitiesEE_,
+                            edm::ConsumesCollector&& iC);
 
-  ~PhotonIsolationCalculator() {}
-
-  void setup(const edm::ParameterSet& conf,
-             std::vector<int> const& flagsEB_,
-             std::vector<int> const& flagsEE_,
-             std::vector<int> const& severitiesEB_,
-             std::vector<int> const& severitiesEE_,
-             edm::ConsumesCollector&& iC);
+  ~PhotonIsolationCalculator() = default;
 
   void calculate(const reco::Photon*,
                  const edm::Event&,

--- a/RecoEgamma/PhotonIdentification/src/PhotonIsolationCalculator.cc
+++ b/RecoEgamma/PhotonIdentification/src/PhotonIsolationCalculator.cc
@@ -26,12 +26,12 @@
 
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgoRcd.h"
 
-void PhotonIsolationCalculator::setup(const edm::ParameterSet& conf,
-                                      std::vector<int> const& flagsEB,
-                                      std::vector<int> const& flagsEE,
-                                      std::vector<int> const& severitiesEB,
-                                      std::vector<int> const& severitiesEE,
-                                      edm::ConsumesCollector&& iC) {
+PhotonIsolationCalculator::PhotonIsolationCalculator(const edm::ParameterSet& conf,
+                                                     std::vector<int> const& flagsEB,
+                                                     std::vector<int> const& flagsEE,
+                                                     std::vector<int> const& severitiesEB,
+                                                     std::vector<int> const& severitiesEE,
+                                                     edm::ConsumesCollector&& iC) {
   trackInputTag_ = iC.consumes<reco::TrackCollection>(conf.getParameter<edm::InputTag>("trackProducer"));
   beamSpotProducerTag_ = iC.consumes<reco::BeamSpot>(conf.getParameter<edm::InputTag>("beamSpotProducer"));
   barrelecalCollection_ =


### PR DESCRIPTION
#### PR description:

It is in general better to use a constructor rather than a setup method.

#### PR validation:

Compiles.