### PR TITLE
Update ZdcSimpleRecAlgo_Run3.cc

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/src/ZdcSimpleRecAlgo_Run3.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/ZdcSimpleRecAlgo_Run3.cc
@@ -97,7 +97,7 @@ ZDCRecHit ZdcSimpleRecAlgo_Run3::reco0(const QIE10DataFrame& digi,
   double ta = 0;
   double energySOIp1 = 0;
   double ratioSOIp1 = -1.0;
-  double chargeWeightedTime = 0;
+  double chargeWeightedTime = -99.0;
 
   double Allnoise = 0;
   int noiseslices = 0;
@@ -223,9 +223,7 @@ ZDCRecHit ZdcSimpleRecAlgo_Run3::reco0(const QIE10DataFrame& digi,
 
   double tmp_energy = 0;
   double tmp_TSWeightedEnergy = 0;
-  for (int ts = 0; ts < nTs_; ++ts) {
-    if (CurrentTS >= digi_size)
-      continue;
+  for (int ts = 0; ts < digi_size; ++ts) {
     int capid = digi[ts].capid();
 
     // max sure there are no negative values in time calculation
@@ -237,7 +235,8 @@ ZDCRecHit ZdcSimpleRecAlgo_Run3::reco0(const QIE10DataFrame& digi,
     }
   }
 
-  chargeWeightedTime = (tmp_TSWeightedEnergy / tmp_energy - 1) * 25.0;
+  if (tmp_energy > 0)
+    chargeWeightedTime = (tmp_TSWeightedEnergy / tmp_energy - 1) * 25.0;
   auto rh = ZDCRecHit(digi.id(), ampl, time, -99);
   rh.setEnergySOIp1(energySOIp1);
 


### PR DESCRIPTION
#### PR description:

Fixed an issue where if statement checking wrong variable to guard against seg fault. Fixed issue by updating associated for loop condition to be less than `digi_size`. I also updated the `ChargeWeightedTime` to check for potential NAN which will now be set to -99.0

This issue is not critical for 2024 HI data taking. The issue was noticed when running on outdated conditions where the signal Timeslices included 6 which caused the bad if statement to skip the calculation of the `ChargeWeightedTime` variable since the number of samples in the digi is 6. When the conditions are updated for the signal TS to be 2 and the noise TS to be 1, the if statement will be false and ChargeWeightedTime will be calculated correctly. The [for loop](https://github.com/matt2275/cmssw/blob/Fix_ZdcRecAlgo/RecoLocalCalo/HcalRecAlgos/src/ZdcSimpleRecAlgo_Run3.cc#L226) will be unchanged since` nTS_ = digi_size = 6`. There is a small risk of seg fault if nTS_ is updated in [ZdcHitReconstructorRun3](https://github.com/matt2275/cmssw/blob/Fix_ZdcRecAlgo/RecoLocalCalo/HcalRecProducers/plugins/ZdcHitReconstructor_Run3.cc#L220) to be greater than the `digi_size` but that would not occur on global reconstructor, only local running if the user happens to update that value incorrectly. 


#### PR validation:

For testing, I ran on [this script ](https://github.com/hjbossi/ZDCOnlineMonitoring/blob/main/python/run2024ZDCReco.py) where previously, the values of the ChargeWeightedTime were NAN and now are positive floats from 0 to 125 ns. 
