### PR TITLE
Removing Muon POG DQM sequence from Express pipeline - backport to 14_0_X

### DIFF
--- a/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
@@ -115,7 +115,7 @@ DQMOffline_SecondStep_PrePOG = cms.Sequence( DQMOffline_SecondStepTracking *
 
 
 DQMOffline_SecondStep_PrePOG_Express = cms.Sequence( DQMOffline_SecondStepTracking *
-                                             DQMOffline_SecondStepMUO *
+                                             #DQMOffline_SecondStepMUO *
                                              #DQMOffline_SecondStepEGamma *
                                              DQMOffline_SecondStepTrigger *
                                              DQMOffline_SecondStepBTag *

--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -158,7 +158,7 @@ DQMOfflinePrePOG = cms.Sequence( DQMOfflineTracking *
 
 
 DQMOfflinePrePOGExpress = cms.Sequence( DQMOfflineTracking *
-                                 DQMOfflineMUO *
+                                 #DQMOfflineMUO *
                                  #DQMOfflineJetMET *
                                  #DQMOfflineEGamma *
                                  DQMOfflineTrigger *


### PR DESCRIPTION
#### PR description:

Removing Muon POG DQM sequence from Express pipeline to reduce memory load at T0.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #46293
