### PR TITLE
[14.1.X] Miscellaneous fixes for HLT online DQM

### DIFF
--- a/DQM/HLTEvF/python/HLTObjectMonitor_cfi.py
+++ b/DQM/HLTEvF/python/HLTObjectMonitor_cfi.py
@@ -5,10 +5,10 @@ photon_pathName = "HLT_DoublePhoton33_CaloIdL" # "HLT_Photon30_R9Id90_HE10_IsoM"
 photon_moduleName = "hltEG33CaloIdLClusterShapeFilter" # "hltEG30R9Id90HE10IsoMTrackIsoFilter"
 
 muon_pathName = "HLT_IsoMu27"
-muon_moduleName = "hltL3crIsoL1sMu22Or25L1f0L2f10QL3f27QL3trkIsoFiltered0p07" # "hltL3crIsoL1sMu22Or25L1f0L2f10QL3f27QL3trkIsoFiltered0p09"
+muon_moduleName = "hltL3crIsoL1sMu22Or25L1f0L2f10QL3f27QL3trkIsoFiltered" # "hltL3crIsoL1sMu22Or25L1f0L2f10QL3f27QL3trkIsoFiltered0p09"
 
-l2muon_pathName = "HLT_L2Mu10"
-l2muon_moduleName = "hltL2fL1sMu22L1f0L2Filtered10Q"
+l2muon_pathName = "HLT_L2Mu23NoVtx_2Cha"
+l2muon_moduleName = "hltL2fL1sMuORL1f0L2NoVtx23Q2Cha"
 
 l2NoBPTXmuon_pathName = "HLT_L2Mu40_NoVertex_3Sta_NoBPTX3BX" # "HLT_L2Mu10_NoVertex_NoBPTX3BX"
 l2NoBPTXmuon_moduleName = "hltL2fL1sMuOpenNotBptxORNoHaloMu3BXL1f0NoVtxCosmicSeedMeanTimerL2Filtered40Sta3" # "hltL2fL1sMuOpenNotBptxORNoHaloMu3BXL1f0NoVtxCosmicSeedMeanTimerL2Filtered10"
@@ -16,14 +16,14 @@ l2NoBPTXmuon_moduleName = "hltL2fL1sMuOpenNotBptxORNoHaloMu3BXL1f0NoVtxCosmicSee
 electron_pathName = "HLT_Ele38_WPTight_Gsf" # "HLT_Ele23_WPLoose_Gsf"
 electron_moduleName = "hltEle38noerWPTightGsfTrackIsoFilter" # "hltEle23WPLooseGsfTrackIsoFilter"
 
-caloMet_pathName = "HLT_MET60_IsoTrk35_Loose"
-caloMet_moduleName = "hltMET60"
+caloMet_pathName = "HLT_MET105_IsoTrk50"
+caloMet_moduleName = "hltMET105"
 
 pfMet_pathName = "HLT_PFMET120_PFMHT120_IDTight"
 pfMet_moduleName = "hltPFMET120"
 
-jetAk8_pathName = "HLT_AK8PFJet400_TrimMass30" # "HLT_AK8PFJet360_TrimMass30"
-jetAk8_moduleName = "hltAK8SinglePFJet400TrimModMass30" # "hltAK8SinglePFJet360TrimModMass30"
+jetAk8_pathName = "HLT_AK8PFJet400" # "HLT_AK8PFJet360_TrimMass30"
+jetAk8_moduleName = "hltSinglePFJet400AK8" # "hltAK8SinglePFJet360TrimModMass30"
 
 rsq_mr_pathName = "HLT_RsqMR240_Rsq0p09_MR200"
 rsq_mr_moduleName = "hltRsqMR240Rsq0p09MR200"
@@ -230,8 +230,8 @@ hltObjectMonitor = DQMEDAnalyzer('HLTObjectMonitor',
         Xmax = cms.double(200)
         ),   
     tauPt = cms.PSet(
-        pathName = cms.string("HLT_IsoMu24_eta2p1_MediumChargedIsoPFTau35_Trk1_eta2p1_Reg_CrossL1"), # HLT_DoubleMediumIsoPFTau40_Trk1_eta2p1_Reg"),
-        moduleName = cms.string("hltOverlapFilterIsoMu24MediumChargedIsoPFTau35MonitoringReg"), #hltDoublePFTau40TrackPt1MediumIsolationDz02Reg"),
+        pathName = cms.string("HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS35_L2NN_eta2p1_CrossL1"), # HLT_DoubleMediumIsoPFTau40_Trk1_eta2p1_Reg"),
+        moduleName = cms.string("hltHpsOverlapFilterIsoMu24MediumDitauWPDeepTauPFTau35Monitoring"), #hltDoublePFTau40TrackPt1MediumIsolationDz02Reg"),
         axisLabel = cms.string("tau p_{T} [GeV]"),
         plotLabel = cms.string("Tau_pT"),
         mainWorkspace = cms.bool(True),
@@ -240,7 +240,7 @@ hltObjectMonitor = DQMEDAnalyzer('HLTObjectMonitor',
         Xmax = cms.double(350)
         ),
     diMuonLowMass = cms.PSet(
-        pathName = cms.string("HLT_DoubleMu4_3_Jpsi_Displaced"),
+        pathName = cms.string("HLT_DoubleMu4_3_Jpsi"),
         moduleName = cms.string("hltDisplacedmumuFilterDoubleMu43Jpsi"),
         plotLabel = cms.string("Dimuon_LowMass"),
         axisLabel = cms.string("di-muon low mass [GeV]"),
@@ -290,7 +290,7 @@ hltObjectMonitor = DQMEDAnalyzer('HLTObjectMonitor',
         Xmax = cms.double(3.4)
         ),
     caloHtPt = cms.PSet(
-        pathName = cms.string("HLT_HT650_DisplacedDijet80_Inclusive"),
+        pathName = cms.string("HLT_HT650_DisplacedDijet60_Inclusive"),
         moduleName = cms.string("hltHT650"),
         plotLabel = cms.string("CaloHT_pT"),
         axisLabel = cms.string("calo HT p_{T} [GeV]"),
@@ -300,8 +300,8 @@ hltObjectMonitor = DQMEDAnalyzer('HLTObjectMonitor',
         Xmax = cms.double(2000)
         ),
     pfHtPt = cms.PSet(
-        pathName = cms.string("HLT_PFHT750_4JetPt50"),
-        moduleName = cms.string("hltPF4JetPt50HT750"),
+        pathName = cms.string("HLT_PFHT780"),
+        moduleName = cms.string("hltPFHT780Jet30"),
         plotLabel = cms.string("PFHT_pT"),
         axisLabel = cms.string("PF HT p_{T} [GeV]"),
         mainWorkspace = cms.bool(True),
@@ -375,9 +375,9 @@ hltObjectMonitor = DQMEDAnalyzer('HLTObjectMonitor',
         ),
     diMuonMass = cms.PSet(
         pathName = cms.string("HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ"),
-        moduleName = cms.string("hltDiMuonGlb17Glb8RelTrkIsoFiltered0p4"), #hltDiMuonGlb17Glb8RelTrkIsoFiltered0p4DzFiltered0p2"),
+        moduleName = cms.string("hltDiMuon178RelTrkIsoVVLFilteredDzFiltered0p2"), #hltDiMuonGlb17Glb8RelTrkIsoFiltered0p4DzFiltered0p2"),
         pathName_OR = cms.string("HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ"),
-        moduleName_OR = cms.string("hltDiMuonGlb17Glb8RelTrkIsoFiltered0p4"), # hltDiMuonGlb17Trk8RelTrkIsoFiltered0p4DzFiltered0p2"),
+        moduleName_OR = cms.string("hltDiMuon178RelTrkIsoVVLFilteredDzFiltered0p2"), # hltDiMuonGlb17Trk8RelTrkIsoFiltered0p4DzFiltered0p2"),
         plotLabel = cms.string("diMuon_Mass"),
         axisLabel = cms.string("dimuon mass [GeV]"),
         mainWorkspace = cms.bool(True),
@@ -426,8 +426,8 @@ hltObjectMonitor = DQMEDAnalyzer('HLTObjectMonitor',
         Xmax = cms.double(160)
         ),
     muonDxy = cms.PSet(
-        pathName = cms.string("HLT_DoubleMu18NoFiltersNoVtx"),
-        moduleName = cms.string("hltL3fDimuonL1f0L2NVf10L3NoFiltersNoVtxFiltered18"),
+        pathName = cms.string("HLT_DoubleMu43NoFiltersNoVtx"),
+        moduleName = cms.string("hltL3fDimuonL1f0L2NVf16L3NoFiltersNoVtxFiltered43"),
         plotLabel = cms.string("Muon_dxy"),
         axisLabel = cms.string("muon d_{xy} [mm]"),
         mainWorkspace = cms.bool(True),

--- a/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_TrackCluster_cff.py
+++ b/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_TrackCluster_cff.py
@@ -426,7 +426,7 @@ from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 hltSiPixelPhase1TrackClustersAnalyzer = DQMEDAnalyzer('SiPixelPhase1TrackClusters',
         VertexCut  = cms.untracked.bool(False),
         clusters   = cms.InputTag("hltSiPixelClusters"),
-        tracks     = cms.InputTag("hltrefittedForPixelDQM"), 
+        tracks     = cms.InputTag("hltTrackRefitterForPixelDQM"),
         clusterShapeCache = cms.InputTag("hltSiPixelClusterShapeCache"),
         vertices = cms.InputTag(""),
         histograms = hltSiPixelPhase1TrackClustersConf,

--- a/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_TrackResiduals_cff.py
+++ b/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_TrackResiduals_cff.py
@@ -134,8 +134,8 @@ hltSiPixelPhase1TrackResidualsConf = cms.VPSet(
 
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 hltSiPixelPhase1TrackResidualsAnalyzer = DQMEDAnalyzer('SiPixelPhase1TrackResiduals',
-        trajectoryInput = cms.string("hltrefittedForPixelDQM"),
-        Tracks        = cms.InputTag("hltrefittedForPixelDQM"),
+        trajectoryInput = cms.string("hltTrackRefitterForPixelDQM"),
+        Tracks        = cms.InputTag("hltTrackRefitterForPixelDQM"),
         vertices = cms.InputTag("hltPixelVertices"),
         histograms = hltSiPixelPhase1TrackResidualsConf,
         geometry = hltSiPixelPhase1Geometry,

--- a/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_cff.py
@@ -13,16 +13,17 @@ from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
 pp_on_PbPb_run3.toModify(hltSiPixelClusterShapeCache,
                          src =  "hltSiPixelClustersAfterSplittingPPOnAA")
 
-hltrefittedForPixelDQM = refittedForPixelDQM.clone(src ='hltMergedTracks',
-                                                   TTRHBuilder = 'WithTrackAngle') # no templates at HLT
+hltTrackRefitterForPixelDQM = refittedForPixelDQM.clone(src                     = "hltMergedTracks",
+                                                        beamSpot                = "hltOnlineBeamSpot",
+                                                        TTRHBuilder             = 'hltESPTTRHBWithTrackAngle') # no template at HLT
 
-pp_on_PbPb_run3.toModify(hltrefittedForPixelDQM,
+pp_on_PbPb_run3.toModify(hltTrackRefitterForPixelDQM,
                          src ='hltMergedTracksPPOnAA')
 
 sipixelMonitorHLTsequence = cms.Sequence(
     hltSiPixelClusterShapeCache
     + hltSiPixelPhase1ClustersAnalyzer
-    + hltrefittedForPixelDQM
+    + hltTrackRefitterForPixelDQM
     + hltSiPixelPhase1TrackClustersAnalyzer
     + hltSiPixelPhase1TrackResidualsAnalyzer,
     cms.Task(SiPixelTemplateStoreESProducer)


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/46245

#### PR description:

This PR bundles together a couple of fixes for the HLT online DQM:
   * I noticed looking at the [Pixel residuals @HLT plots](https://cmsweb.cern.ch/dqm/online/start?runnr=386554;dataset=/Global/Online/ALL;sampletype=online_data;filter=all;referencepos=overlay;referenceshow=customise;referencenorm=True;referenceobj1=refobj;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=Everything;size=M;root=HLT/Pixel/Tracks/PXBarrel;focus=;zoom=no;) in recent runs that they were empty. Looking at the [dqm-square log](https://cmsweb.cern.ch/dqm/dqm-square/api?what=get_logs&id=dqm-source-state-run386554-hostdqmfu-c2b03-45-01-pid2856735&db=production) for that run, I also saw a bunch of errors of the type:
   ```
   %MSG-w TrackProducerBase:  TrackRefitter:hltrefittedForPixelDQM  03-Oct-2024 22:56:25 CEST Run: 386554 Event: 2607599
 BeamSpot is not valid
%MSG
%MSG-e TrackRefitter:  TrackRefitter:hltrefittedForPixelDQM  03-Oct-2024 22:56:25 CEST Run: 386554 Event: 2607599
 BeamSpot is (0,0,0), it is probably because is not valid in the event
%MSG
   ```
   I believe the issue is that the current `hltrefittedForPixelDQM` instance clones the one used for offline (`refittedForPixelDQM`) which ultimately clones the template with the offline parameters:
   
   https://github.com/cms-sw/cmssw/blob/180e6a5c307a65a434208d7d55abda866eb9094e/RecoTracker/TrackProducer/python/TrackRefitter_cfi.py#L5
   
   * secondly, also looking at the [HLT quick collection](https://cmsweb.cern.ch/dqm/online/start?runnr=386554;dataset=/Global/Online/ALL;sampletype=online_data;filter=all;referencepos=overlay;referenceshow=customise;referencenorm=True;referenceobj1=refobj;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=HLT;size=M;root=Quick%20collection;focus=;zoom=no;) many of the plots are empty, I believe due the usage of deprecated trigger paths in input 
   
The two issues are addressed at 97a6d8eb0688b8767c8cb58fc1426f22cc33535f and 45dee8103f1b45e52d60e914fe0a603e2db34f34 respectively. 

#### PR validation:

See results of the DQM playback in the master version: https://github.com/cms-sw/cmssw/pull/46245#issuecomment-2393625771

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of #46245 to CMSSW_14_0_X for 2024 data-taking operations.