### PR TITLE
Sort Phase 2 L1T GT trigger paths

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1574,7 +1574,7 @@ class ConfigBuilder(object):
                 if objType == cms.Path:
                     triggerPaths.append(objName)
         
-        triggerScheduleList = [getattr(self.process, name) for name in triggerPaths] #get the actual paths to put in the schedule
+        triggerScheduleList = [getattr(self.process, name) for name in sorted(triggerPaths)] #get the actual paths to put in the schedule
         self.schedule.extend(triggerScheduleList) #put them in the schedule for later
     
     # create the L1 GT step


### PR DESCRIPTION
### PR description:

Possible solution to broken path ordering hashes for nominally same menus. Should fix issues stated here: https://github.com/cms-sw/cmssw/pull/41808#discussion_r1790210428.

This PR simply sorts the names of the trigger paths that get added to the schedule to be in alphabetical order.

@fwyzard @rovere @haarigerharald

### PR validation:

Bot testing

### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not a backport, but may need backporting to MC campaign releases?