### PR TITLE
Run3-hcx373 Correct the HcalTopology class for 2 new geometry modes

### DIFF
--- a/CondTools/Geometry/test/calogeometry2026writer.py
+++ b/CondTools/Geometry/test/calogeometry2026writer.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("CaloGeometryWriter")
+from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
+process = cms.Process("CaloGeometryWriter",Phase2C17I13M9)
 process.load('CondCore.CondDB.CondDB_cfi')
 process.load('Configuration.Geometry.GeometryExtended2026D110_cff')
 process.load('Geometry.CaloEventSetup.CaloGeometry2026DBWriter_cfi')

--- a/CondTools/Geometry/test/calogeometry2026writer.py
+++ b/CondTools/Geometry/test/calogeometry2026writer.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("CaloGeometryWriter")
 process.load('CondCore.CondDB.CondDB_cfi')
-process.load('Configuration.Geometry.GeometryExtended2026D41_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D110_cff')
 process.load('Geometry.CaloEventSetup.CaloGeometry2026DBWriter_cfi')
 process.load('CondTools.Geometry.HcalParametersWriter_cff')
 

--- a/Geometry/CaloTopology/interface/HcalTopology.h
+++ b/Geometry/CaloTopology/interface/HcalTopology.h
@@ -229,7 +229,10 @@ private:
   static constexpr int kHBhalf = 1296, kHEhalf = 1296, kHOhalf = 1080, kHFhalf = 864, kHThalf = 2088, kZDChalf = 11,
                        kCASTORhalf = 224, kCALIBhalf = 693, kHThalfPhase1 = 2520,
                        kHcalhalf = kHBhalf + kHEhalf + kHOhalf + kHFhalf;
+  static constexpr int kHBhalfPostLS2 = 4536, kHEhalfPostLS2 = 3384, kHFhalfPostLS2 = 1728;
+  static constexpr int kHcalhalfPostLS2 = kHBhalfPostLS2 + kHEhalfPostLS2 + kHOhalf + kHFhalfPostLS2;
   static constexpr int kSizeForDenseIndexingPreLS1 = 2 * kHcalhalf;
+  static constexpr int kSizeForDenseIndexingPostLS2 = 2 * kHcalhalfPostLS2;
   static constexpr int kHBSizePreLS1 = 2 * kHBhalf;
   static constexpr int kHESizePreLS1 = 2 * kHEhalf;
   static constexpr int kHOSizePreLS1 = 2 * kHOhalf;
@@ -237,6 +240,9 @@ private:
   static constexpr int kHTSizePreLS1 = 2 * kHThalf;
   static constexpr int kHTSizePhase1 = 2 * kHThalfPhase1;
   static constexpr int kCALIBSizePreLS1 = 2 * kCALIBhalf;
+  static constexpr int kHBSizePostLS2 = 2 * kHBhalfPostLS2;
+  static constexpr int kHESizePostLS2 = 2 * kHEhalfPostLS2;
+  static constexpr int kHFSizePostLS2 = 2 * kHFhalfPostLS2;
   static constexpr int minMaxDepth_ = 4;
   static constexpr unsigned int minPhi_ = 1, maxPhi_ = 72;
   static constexpr unsigned int kOffCalibHB_ = 0;

--- a/Geometry/CaloTopology/interface/HcalTopology.h
+++ b/Geometry/CaloTopology/interface/HcalTopology.h
@@ -171,6 +171,8 @@ public:
   HcalDetId idBack(const HcalDetId& id) const { return hcons_->idBack(id); }
 
 private:
+  bool phase1() const { return ((mode_ == HcalTopologyMode::LHC) || (mode_ == HcalTopologyMode::Run3)); }
+  bool phase2() const { return ((mode_ == HcalTopologyMode::SLHC) || (mode_ == HcalTopologyMode::Run4)); }
   /** Get the neighbors of the given cell with higher absolute ieta */
   int incAIEta(const HcalDetId& id, HcalDetId neighbors[2]) const;
   /** Get the neighbors of the given cell with lower absolute ieta */

--- a/Geometry/CaloTopology/src/HcalTopology.cc
+++ b/Geometry/CaloTopology/src/HcalTopology.cc
@@ -195,7 +195,7 @@ HcalTopology::HcalTopology(HcalTopologyMode::Mode mode,
       HFSize_(kHFSizePreLS1),
       HTSize_(kHTSizePreLS1),
       CALIBSize_(kCALIBSizePreLS1),
-      numberOfShapes_(phase2() ? 500 : 87) {
+      numberOfShapes_((mode_ == HcalTopologyMode::LHC) ? 87 : 500) {
   if (mode_ == HcalTopologyMode::LHC) {
     topoVersion_ = 0;         //DL
     HBSize_ = kHBSizePreLS1;  // qie-per-fiber * fiber/rm * rm/rbx * rbx/barrel * barrel/hcal

--- a/Geometry/CaloTopology/src/HcalTopology.cc
+++ b/Geometry/CaloTopology/src/HcalTopology.cc
@@ -72,15 +72,7 @@ HcalTopology::HcalTopology(const HcalDDDRecConstants* hcons, const bool mergePos
     HFSize_ = kHFSizePreLS1;  // ieta * iphi * depth * 2
     CALIBSize_ = kCALIBSizePreLS1;
     numberOfShapes_ = 87;
-  } else if (mode_ == HcalTopologyMode::Run3) {
-    topoVersion_ = 10;
-    HBSize_ = kHBSizePostLS2;
-    HESize_ = kHESizePostLS2;
-    HOSize_ = kHOSizePreLS1;  // ieta * iphi * 2
-    HFSize_ = kHFSizePostLS2;
-    CALIBSize_ = kOffCalibHFX_;
-    numberOfShapes_ = (maxPhiHE_ > 72) ? 1200 : 500;
-  } else if (phase2()) {  // need to know more eventually
+  } else {  // need to know more eventually
     topoVersion_ = 10;
     HBSize_ = nEtaHB_ * IPHI_MAX * maxDepthHB_ * 2;
     HESize_ = nEtaHE_ * maxPhiHE_ * maxDepthHE_ * 2;
@@ -210,14 +202,7 @@ HcalTopology::HcalTopology(HcalTopologyMode::Mode mode,
     HESize_ = kHESizePreLS1;  // qie-per-fiber * fiber/rm * rm/rbx * rbx/endcap * endcap/hcal
     HOSize_ = kHOSizePreLS1;  // ieta * iphi * 2
     HFSize_ = kHFSizePreLS1;  // phi * eta * depth * pm
-  } else if (mode_ == HcalTopologyMode::Run3) {
-    topoVersion_ = 10;
-    HBSize_ = kHBSizePostLS2;
-    HESize_ = kHESizePostLS2;
-    HOSize_ = kHOSizePreLS1;  // ieta * iphi * 2
-    HFSize_ = kHFSizePostLS2;
-    CALIBSize_ = kOffCalibHFX_;
-  } else if (phase2()) {  // need to know more eventually
+  } else {  // need to know more eventually
     HBSize_ = maxDepthHB * 16 * IPHI_MAX * 2;
     HESize_ = maxDepthHE * (29 - 16 + 1) * maxPhiHE_ * 2;
     HOSize_ = 15 * IPHI_MAX * 2;                // ieta * iphi * 2

--- a/Geometry/CaloTopology/src/HcalTopology.cc
+++ b/Geometry/CaloTopology/src/HcalTopology.cc
@@ -890,12 +890,12 @@ bool HcalTopology::incrementDepth(HcalDetId& detId) const {
       subdet = HcalEndcap;
       if (phase2() || (mode_ == HcalTopologyMode::H2HE))
         depth = hcons_->getDepthEta16(2, iphi, zside);
-    } else if ((subdet == HcalEndcap) && (etaRing == lastHERing() - 1) && phase2()) {
+    } else if ((subdet == HcalEndcap) && (etaRing == lastHERing() - 1) && !phase2()) {
       // guard ring HF29 is behind HE 28
       subdet = HcalForward;
       (ieta > 0) ? ++ieta : --ieta;
       depth = 1;
-    } else if ((subdet == HcalEndcap) && (etaRing == lastHERing()) && phase2()) {
+    } else if ((subdet == HcalEndcap) && (etaRing == lastHERing()) && !phase2()) {
       // split cells go to bigger granularity.  Ring 29 -> 28
       (ieta > 0) ? --ieta : ++ieta;
     } else {
@@ -929,7 +929,7 @@ bool HcalTopology::decrementDepth(HcalDetId& detId) const {
       }
     }
   } else if ((subdet == HcalEndcap) && (etaRing == lastHERing()) && (depth == hcons_->getDepthEta29(iphi, zside, 0)) &&
-             phase2()) {
+             !phase2()) {
     (ieta > 0) ? --ieta : ++ieta;
   } else if (depth <= 0) {
     if (subdet == HcalForward && etaRing == firstHFRing()) {

--- a/Geometry/CaloTopology/src/HcalTopology.cc
+++ b/Geometry/CaloTopology/src/HcalTopology.cc
@@ -217,7 +217,7 @@ HcalTopology::HcalTopology(HcalTopologyMode::Mode mode,
     HOSize_ = kHOSizePreLS1;  // ieta * iphi * 2
     HFSize_ = kHFSizePostLS2;
     CALIBSize_ = kOffCalibHFX_;
-  } else if (phase2()) {      // need to know more eventually
+  } else if (phase2()) {  // need to know more eventually
     HBSize_ = maxDepthHB * 16 * IPHI_MAX * 2;
     HESize_ = maxDepthHE * (29 - 16 + 1) * maxPhiHE_ * 2;
     HOSize_ = 15 * IPHI_MAX * 2;                // ieta * iphi * 2

--- a/Geometry/CaloTopology/src/HcalTopology.cc
+++ b/Geometry/CaloTopology/src/HcalTopology.cc
@@ -195,8 +195,7 @@ HcalTopology::HcalTopology(HcalTopologyMode::Mode mode,
       HFSize_(kHFSizePreLS1),
       HTSize_(kHTSizePreLS1),
       CALIBSize_(kCALIBSizePreLS1),
-      numberOfShapes_(
-          ((mode == HcalTopologyMode::SLHC) || (mode_ == HcalTopologyMode::Run4)) ? 500 : 87) {
+      numberOfShapes_(((mode == HcalTopologyMode::SLHC) || (mode_ == HcalTopologyMode::Run4)) ? 500 : 87) {
   if ((mode_ == HcalTopologyMode::LHC) || (mode_ == HcalTopologyMode::Run3)) {
     topoVersion_ = 0;         //DL
     HBSize_ = kHBSizePreLS1;  // qie-per-fiber * fiber/rm * rm/rbx * rbx/barrel * barrel/hcal
@@ -1134,7 +1133,9 @@ std::pair<double, double> HcalTopology::etaRange(HcalSubdetector subdet, int ket
         return std::pair<double, double>(etaTableHF[ii], etaTableHF[ii + 1]);
     }
   } else {
-    int ietal = (((mode_ == HcalTopologyMode::LHC) || (mode_ == HcalTopologyMode::Run3)) && ieta == lastHERing_ - 1) ? (ieta + 1) : ieta;
+    int ietal = (((mode_ == HcalTopologyMode::LHC) || (mode_ == HcalTopologyMode::Run3)) && ieta == lastHERing_ - 1)
+                    ? (ieta + 1)
+                    : ieta;
     if ((ietal < (int)(etaTable.size())) && (ieta > 0))
       return std::pair<double, double>(etaTable[ieta - 1], etaTable[ietal]);
   }

--- a/Geometry/CaloTopology/src/HcalTopology.cc
+++ b/Geometry/CaloTopology/src/HcalTopology.cc
@@ -64,7 +64,7 @@ HcalTopology::HcalTopology(const HcalDDDRecConstants* hcons, const bool mergePos
   } else {
     nEtaHE_ = (lastHERing_ - firstHERing_ + 1);
   }
-  if ((mode_ == HcalTopologyMode::LHC) || (mode_ == HcalTopologyMode::Run3)) {
+  if (phase1()) {
     topoVersion_ = 0;         //DL
     HBSize_ = kHBSizePreLS1;  // qie-per-fiber * fiber/rm * rm/rbx * rbx/barrel * barrel/hcal
     HESize_ = kHESizePreLS1;  // qie-per-fiber * fiber/rm * rm/rbx * rbx/endcap * endcap/hcal
@@ -72,7 +72,7 @@ HcalTopology::HcalTopology(const HcalDDDRecConstants* hcons, const bool mergePos
     HFSize_ = kHFSizePreLS1;  // ieta * iphi * depth * 2
     CALIBSize_ = kCALIBSizePreLS1;
     numberOfShapes_ = 87;
-  } else if ((mode_ == HcalTopologyMode::SLHC) || (mode_ == HcalTopologyMode::Run4)) {  // need to know more eventually
+  } else if (phase2()) {  // need to know more eventually
     topoVersion_ = 10;
     HBSize_ = nEtaHB_ * IPHI_MAX * maxDepthHB_ * 2;
     HESize_ = nEtaHE_ * maxPhiHE_ * maxDepthHE_ * 2;
@@ -195,14 +195,14 @@ HcalTopology::HcalTopology(HcalTopologyMode::Mode mode,
       HFSize_(kHFSizePreLS1),
       HTSize_(kHTSizePreLS1),
       CALIBSize_(kCALIBSizePreLS1),
-      numberOfShapes_(((mode == HcalTopologyMode::SLHC) || (mode_ == HcalTopologyMode::Run4)) ? 500 : 87) {
-  if ((mode_ == HcalTopologyMode::LHC) || (mode_ == HcalTopologyMode::Run3)) {
+      numberOfShapes_(phase2() ? 500 : 87) {
+  if (phase1()) {
     topoVersion_ = 0;         //DL
     HBSize_ = kHBSizePreLS1;  // qie-per-fiber * fiber/rm * rm/rbx * rbx/barrel * barrel/hcal
     HESize_ = kHESizePreLS1;  // qie-per-fiber * fiber/rm * rm/rbx * rbx/endcap * endcap/hcal
     HOSize_ = kHOSizePreLS1;  // ieta * iphi * 2
     HFSize_ = kHFSizePreLS1;  // phi * eta * depth * pm
-  } else if ((mode_ == HcalTopologyMode::SLHC) || (mode_ == HcalTopologyMode::Run4)) {  // need to know more eventually
+  } else if (phase2()) {  // need to know more eventually
     HBSize_ = maxDepthHB * 16 * IPHI_MAX * 2;
     HESize_ = maxDepthHE * (29 - 16 + 1) * maxPhiHE_ * 2;
     HOSize_ = 15 * IPHI_MAX * 2;                // ieta * iphi * 2
@@ -567,7 +567,7 @@ bool HcalTopology::validRaw(const HcalDetId& id) const {
 
   if (ok) {
     if (subdet == HcalBarrel) {
-      if ((mode_ == HcalTopologyMode::SLHC) || (mode_ == HcalTopologyMode::H2HE) || (mode_ == HcalTopologyMode::Run4)) {
+      if (phase2() || (mode_ == HcalTopologyMode::H2HE)) {
         if ((aieta > lastHBRing()) || (depth > hcons_->getMaxDepth(0, aieta, iphi, zside)) ||
             (depth < hcons_->getMinDepth(0, aieta, iphi, zside)))
           ok = false;
@@ -576,7 +576,7 @@ bool HcalTopology::validRaw(const HcalDetId& id) const {
           ok = false;
       }
     } else if (subdet == HcalEndcap) {
-      if ((mode_ == HcalTopologyMode::SLHC) || (mode_ == HcalTopologyMode::H2HE) || (mode_ == HcalTopologyMode::Run4)) {
+      if (phase2() || (mode_ == HcalTopologyMode::H2HE)) {
         if ((depth > hcons_->getMaxDepth(1, aieta, iphi, zside)) ||
             (depth < hcons_->getMinDepth(1, aieta, iphi, zside)) || (aieta < firstHERing()) || (aieta > lastHERing())) {
           ok = false;
@@ -817,7 +817,7 @@ int HcalTopology::decAIEta(const HcalDetId& id, HcalDetId neighbors[2]) const {
 void HcalTopology::depthBinInformation(
     HcalSubdetector subdet, int etaRing, int iphi, int zside, int& nDepthBins, int& startingBin) const {
   if (subdet == HcalBarrel) {
-    if ((mode_ == HcalTopologyMode::SLHC) || (mode_ == HcalTopologyMode::H2HE) || (mode_ == HcalTopologyMode::Run4)) {
+    if (phase2() || (mode_ == HcalTopologyMode::H2HE)) {
       startingBin = hcons_->getMinDepth(0, etaRing, iphi, zside);
       if (etaRing == lastHBRing()) {
         nDepthBins = hcons_->getDepthEta16(1, iphi, zside) - startingBin + 1;
@@ -834,7 +834,7 @@ void HcalTopology::depthBinInformation(
       }
     }
   } else if (subdet == HcalEndcap) {
-    if ((mode_ == HcalTopologyMode::SLHC) || (mode_ == HcalTopologyMode::H2HE) || (mode_ == HcalTopologyMode::Run4)) {
+    if (phase2() || (mode_ == HcalTopologyMode::H2HE)) {
       if (etaRing == firstHERing()) {
         startingBin = hcons_->getDepthEta16(2, iphi, zside);
       } else {
@@ -888,16 +888,14 @@ bool HcalTopology::incrementDepth(HcalDetId& detId) const {
     } else if (subdet == HcalBarrel && etaRing == lastHBRing()) {
       // overlap
       subdet = HcalEndcap;
-      if ((mode_ == HcalTopologyMode::SLHC) || (mode_ == HcalTopologyMode::H2HE) || (mode_ == HcalTopologyMode::Run4))
+      if (phase2() || (mode_ == HcalTopologyMode::H2HE))
         depth = hcons_->getDepthEta16(2, iphi, zside);
-    } else if ((subdet == HcalEndcap) && (etaRing == lastHERing() - 1) && (mode_ != HcalTopologyMode::SLHC) &&
-               (mode_ != HcalTopologyMode::Run4)) {
+    } else if ((subdet == HcalEndcap) && (etaRing == lastHERing() - 1) && phase2()) {
       // guard ring HF29 is behind HE 28
       subdet = HcalForward;
       (ieta > 0) ? ++ieta : --ieta;
       depth = 1;
-    } else if ((subdet == HcalEndcap) && (etaRing == lastHERing()) && (mode_ != HcalTopologyMode::SLHC) &&
-               (mode_ != HcalTopologyMode::Run4)) {
+    } else if ((subdet == HcalEndcap) && (etaRing == lastHERing()) && phase2()) {
       // split cells go to bigger granularity.  Ring 29 -> 28
       (ieta > 0) ? --ieta : ++ieta;
     } else {
@@ -931,7 +929,7 @@ bool HcalTopology::decrementDepth(HcalDetId& detId) const {
       }
     }
   } else if ((subdet == HcalEndcap) && (etaRing == lastHERing()) && (depth == hcons_->getDepthEta29(iphi, zside, 0)) &&
-             (mode_ != HcalTopologyMode::SLHC) && (mode_ != HcalTopologyMode::Run4)) {
+             phase2()) {
     (ieta > 0) ? --ieta : ++ieta;
   } else if (depth <= 0) {
     if (subdet == HcalForward && etaRing == firstHFRing()) {
@@ -1133,9 +1131,7 @@ std::pair<double, double> HcalTopology::etaRange(HcalSubdetector subdet, int ket
         return std::pair<double, double>(etaTableHF[ii], etaTableHF[ii + 1]);
     }
   } else {
-    int ietal = (((mode_ == HcalTopologyMode::LHC) || (mode_ == HcalTopologyMode::Run3)) && ieta == lastHERing_ - 1)
-                    ? (ieta + 1)
-                    : ieta;
+    int ietal = (phase1() && ieta == lastHERing_ - 1) ? (ieta + 1) : ieta;
     if ((ietal < (int)(etaTable.size())) && (ieta > 0))
       return std::pair<double, double>(etaTable[ieta - 1], etaTable[ietal]);
   }

--- a/Geometry/CaloTopology/src/HcalTopology.cc
+++ b/Geometry/CaloTopology/src/HcalTopology.cc
@@ -64,7 +64,7 @@ HcalTopology::HcalTopology(const HcalDDDRecConstants* hcons, const bool mergePos
   } else {
     nEtaHE_ = (lastHERing_ - firstHERing_ + 1);
   }
-  if (mode_ == HcalTopologyMode::LHC) {
+  if ((mode_ == HcalTopologyMode::LHC) || (mode_ == HcalTopologyMode::Run3)) {
     topoVersion_ = 0;         //DL
     HBSize_ = kHBSizePreLS1;  // qie-per-fiber * fiber/rm * rm/rbx * rbx/barrel * barrel/hcal
     HESize_ = kHESizePreLS1;  // qie-per-fiber * fiber/rm * rm/rbx * rbx/endcap * endcap/hcal
@@ -72,7 +72,7 @@ HcalTopology::HcalTopology(const HcalDDDRecConstants* hcons, const bool mergePos
     HFSize_ = kHFSizePreLS1;  // ieta * iphi * depth * 2
     CALIBSize_ = kCALIBSizePreLS1;
     numberOfShapes_ = 87;
-  } else if (mode_ == HcalTopologyMode::SLHC) {  // need to know more eventually
+  } else if ((mode_ == HcalTopologyMode::SLHC) || (mode_ == HcalTopologyMode::Run4)) {  // need to know more eventually
     topoVersion_ = 10;
     HBSize_ = nEtaHB_ * IPHI_MAX * maxDepthHB_ * 2;
     HESize_ = nEtaHE_ * maxPhiHE_ * maxDepthHE_ * 2;
@@ -196,17 +196,14 @@ HcalTopology::HcalTopology(HcalTopologyMode::Mode mode,
       HTSize_(kHTSizePreLS1),
       CALIBSize_(kCALIBSizePreLS1),
       numberOfShapes_(
-          ((mode == HcalTopologyMode::SLHC) || (mode_ == HcalTopologyMode::Run3) || (mode_ == HcalTopologyMode::Run4))
-              ? 500
-              : 87) {
-  if (mode_ == HcalTopologyMode::LHC) {
+          ((mode == HcalTopologyMode::SLHC) || (mode_ == HcalTopologyMode::Run4)) ? 500 : 87) {
+  if ((mode_ == HcalTopologyMode::LHC) || (mode_ == HcalTopologyMode::Run3)) {
     topoVersion_ = 0;         //DL
     HBSize_ = kHBSizePreLS1;  // qie-per-fiber * fiber/rm * rm/rbx * rbx/barrel * barrel/hcal
     HESize_ = kHESizePreLS1;  // qie-per-fiber * fiber/rm * rm/rbx * rbx/endcap * endcap/hcal
     HOSize_ = kHOSizePreLS1;  // ieta * iphi * 2
     HFSize_ = kHFSizePreLS1;  // phi * eta * depth * pm
-  } else if ((mode_ == HcalTopologyMode::SLHC) || (mode_ == HcalTopologyMode::Run3) ||
-             (mode_ == HcalTopologyMode::Run4)) {  // need to know more eventually
+  } else if ((mode_ == HcalTopologyMode::SLHC) || (mode_ == HcalTopologyMode::Run4)) {  // need to know more eventually
     HBSize_ = maxDepthHB * 16 * IPHI_MAX * 2;
     HESize_ = maxDepthHE * (29 - 16 + 1) * maxPhiHE_ * 2;
     HOSize_ = 15 * IPHI_MAX * 2;                // ieta * iphi * 2
@@ -571,8 +568,7 @@ bool HcalTopology::validRaw(const HcalDetId& id) const {
 
   if (ok) {
     if (subdet == HcalBarrel) {
-      if ((mode_ == HcalTopologyMode::SLHC) || (mode_ == HcalTopologyMode::H2HE) || (mode_ == HcalTopologyMode::Run3) ||
-          (mode_ == HcalTopologyMode::Run4)) {
+      if ((mode_ == HcalTopologyMode::SLHC) || (mode_ == HcalTopologyMode::H2HE) || (mode_ == HcalTopologyMode::Run4)) {
         if ((aieta > lastHBRing()) || (depth > hcons_->getMaxDepth(0, aieta, iphi, zside)) ||
             (depth < hcons_->getMinDepth(0, aieta, iphi, zside)))
           ok = false;
@@ -581,8 +577,7 @@ bool HcalTopology::validRaw(const HcalDetId& id) const {
           ok = false;
       }
     } else if (subdet == HcalEndcap) {
-      if ((mode_ == HcalTopologyMode::SLHC) || (mode_ == HcalTopologyMode::H2HE) || (mode_ == HcalTopologyMode::Run3) ||
-          (mode_ == HcalTopologyMode::Run4)) {
+      if ((mode_ == HcalTopologyMode::SLHC) || (mode_ == HcalTopologyMode::H2HE) || (mode_ == HcalTopologyMode::Run4)) {
         if ((depth > hcons_->getMaxDepth(1, aieta, iphi, zside)) ||
             (depth < hcons_->getMinDepth(1, aieta, iphi, zside)) || (aieta < firstHERing()) || (aieta > lastHERing())) {
           ok = false;
@@ -823,8 +818,7 @@ int HcalTopology::decAIEta(const HcalDetId& id, HcalDetId neighbors[2]) const {
 void HcalTopology::depthBinInformation(
     HcalSubdetector subdet, int etaRing, int iphi, int zside, int& nDepthBins, int& startingBin) const {
   if (subdet == HcalBarrel) {
-    if ((mode_ == HcalTopologyMode::SLHC) || (mode_ == HcalTopologyMode::H2HE) || (mode_ == HcalTopologyMode::Run3) ||
-        (mode_ == HcalTopologyMode::Run4)) {
+    if ((mode_ == HcalTopologyMode::SLHC) || (mode_ == HcalTopologyMode::H2HE) || (mode_ == HcalTopologyMode::Run4)) {
       startingBin = hcons_->getMinDepth(0, etaRing, iphi, zside);
       if (etaRing == lastHBRing()) {
         nDepthBins = hcons_->getDepthEta16(1, iphi, zside) - startingBin + 1;
@@ -841,8 +835,7 @@ void HcalTopology::depthBinInformation(
       }
     }
   } else if (subdet == HcalEndcap) {
-    if ((mode_ == HcalTopologyMode::SLHC) || (mode_ == HcalTopologyMode::H2HE) || (mode_ == HcalTopologyMode::Run3) ||
-        (mode_ == HcalTopologyMode::Run4)) {
+    if ((mode_ == HcalTopologyMode::SLHC) || (mode_ == HcalTopologyMode::H2HE) || (mode_ == HcalTopologyMode::Run4)) {
       if (etaRing == firstHERing()) {
         startingBin = hcons_->getDepthEta16(2, iphi, zside);
       } else {
@@ -896,17 +889,16 @@ bool HcalTopology::incrementDepth(HcalDetId& detId) const {
     } else if (subdet == HcalBarrel && etaRing == lastHBRing()) {
       // overlap
       subdet = HcalEndcap;
-      if ((mode_ == HcalTopologyMode::SLHC) || (mode_ == HcalTopologyMode::H2HE) || (mode_ == HcalTopologyMode::Run3) ||
-          (mode_ == HcalTopologyMode::Run4))
+      if ((mode_ == HcalTopologyMode::SLHC) || (mode_ == HcalTopologyMode::H2HE) || (mode_ == HcalTopologyMode::Run4))
         depth = hcons_->getDepthEta16(2, iphi, zside);
     } else if ((subdet == HcalEndcap) && (etaRing == lastHERing() - 1) && (mode_ != HcalTopologyMode::SLHC) &&
-               (mode_ != HcalTopologyMode::Run3) && (mode_ != HcalTopologyMode::Run4)) {
+               (mode_ != HcalTopologyMode::Run4)) {
       // guard ring HF29 is behind HE 28
       subdet = HcalForward;
       (ieta > 0) ? ++ieta : --ieta;
       depth = 1;
     } else if ((subdet == HcalEndcap) && (etaRing == lastHERing()) && (mode_ != HcalTopologyMode::SLHC) &&
-               (mode_ != HcalTopologyMode::Run3) && (mode_ != HcalTopologyMode::Run4)) {
+               (mode_ != HcalTopologyMode::Run4)) {
       // split cells go to bigger granularity.  Ring 29 -> 28
       (ieta > 0) ? --ieta : ++ieta;
     } else {
@@ -940,8 +932,7 @@ bool HcalTopology::decrementDepth(HcalDetId& detId) const {
       }
     }
   } else if ((subdet == HcalEndcap) && (etaRing == lastHERing()) && (depth == hcons_->getDepthEta29(iphi, zside, 0)) &&
-             (mode_ != HcalTopologyMode::SLHC) && (mode_ != HcalTopologyMode::Run3) &&
-             (mode_ != HcalTopologyMode::Run4)) {
+             (mode_ != HcalTopologyMode::SLHC) && (mode_ != HcalTopologyMode::Run4)) {
     (ieta > 0) ? --ieta : ++ieta;
   } else if (depth <= 0) {
     if (subdet == HcalForward && etaRing == firstHFRing()) {
@@ -1143,7 +1134,7 @@ std::pair<double, double> HcalTopology::etaRange(HcalSubdetector subdet, int ket
         return std::pair<double, double>(etaTableHF[ii], etaTableHF[ii + 1]);
     }
   } else {
-    int ietal = (mode_ == HcalTopologyMode::LHC && ieta == lastHERing_ - 1) ? (ieta + 1) : ieta;
+    int ietal = (((mode_ == HcalTopologyMode::LHC) || (mode_ == HcalTopologyMode::Run3)) && ieta == lastHERing_ - 1) ? (ieta + 1) : ieta;
     if ((ietal < (int)(etaTable.size())) && (ieta > 0))
       return std::pair<double, double>(etaTable[ieta - 1], etaTable[ietal]);
   }

--- a/Geometry/CaloTopology/src/HcalTopology.cc
+++ b/Geometry/CaloTopology/src/HcalTopology.cc
@@ -64,7 +64,7 @@ HcalTopology::HcalTopology(const HcalDDDRecConstants* hcons, const bool mergePos
   } else {
     nEtaHE_ = (lastHERing_ - firstHERing_ + 1);
   }
-  if (phase1()) {
+  if (mode_ == HcalTopologyMode::LHC) {
     topoVersion_ = 0;         //DL
     HBSize_ = kHBSizePreLS1;  // qie-per-fiber * fiber/rm * rm/rbx * rbx/barrel * barrel/hcal
     HESize_ = kHESizePreLS1;  // qie-per-fiber * fiber/rm * rm/rbx * rbx/endcap * endcap/hcal
@@ -72,6 +72,14 @@ HcalTopology::HcalTopology(const HcalDDDRecConstants* hcons, const bool mergePos
     HFSize_ = kHFSizePreLS1;  // ieta * iphi * depth * 2
     CALIBSize_ = kCALIBSizePreLS1;
     numberOfShapes_ = 87;
+  } else if (mode_ == HcalTopologyMode::Run3) {
+    topoVersion_ = 10;
+    HBSize_ = kHBSizePostLS2;
+    HESize_ = kHESizePostLS2;
+    HOSize_ = kHOSizePreLS1;  // ieta * iphi * 2
+    HFSize_ = kHFSizePostLS2;
+    CALIBSize_ = kOffCalibHFX_;
+    numberOfShapes_ = (maxPhiHE_ > 72) ? 1200 : 500;
   } else if (phase2()) {  // need to know more eventually
     topoVersion_ = 10;
     HBSize_ = nEtaHB_ * IPHI_MAX * maxDepthHB_ * 2;
@@ -196,12 +204,19 @@ HcalTopology::HcalTopology(HcalTopologyMode::Mode mode,
       HTSize_(kHTSizePreLS1),
       CALIBSize_(kCALIBSizePreLS1),
       numberOfShapes_(phase2() ? 500 : 87) {
-  if (phase1()) {
+  if (mode_ == HcalTopologyMode::LHC) {
     topoVersion_ = 0;         //DL
     HBSize_ = kHBSizePreLS1;  // qie-per-fiber * fiber/rm * rm/rbx * rbx/barrel * barrel/hcal
     HESize_ = kHESizePreLS1;  // qie-per-fiber * fiber/rm * rm/rbx * rbx/endcap * endcap/hcal
     HOSize_ = kHOSizePreLS1;  // ieta * iphi * 2
     HFSize_ = kHFSizePreLS1;  // phi * eta * depth * pm
+  } else if (mode_ == HcalTopologyMode::Run3) {
+    topoVersion_ = 10;
+    HBSize_ = kHBSizePostLS2;
+    HESize_ = kHESizePostLS2;
+    HOSize_ = kHOSizePreLS1;  // ieta * iphi * 2
+    HFSize_ = kHFSizePostLS2;
+    CALIBSize_ = kOffCalibHFX_;
   } else if (phase2()) {      // need to know more eventually
     HBSize_ = maxDepthHB * 16 * IPHI_MAX * 2;
     HESize_ = maxDepthHE * (29 - 16 + 1) * maxPhiHE_ * 2;

--- a/Geometry/CaloTopology/src/HcalTopology.cc
+++ b/Geometry/CaloTopology/src/HcalTopology.cc
@@ -202,7 +202,7 @@ HcalTopology::HcalTopology(HcalTopologyMode::Mode mode,
     HESize_ = kHESizePreLS1;  // qie-per-fiber * fiber/rm * rm/rbx * rbx/endcap * endcap/hcal
     HOSize_ = kHOSizePreLS1;  // ieta * iphi * 2
     HFSize_ = kHFSizePreLS1;  // phi * eta * depth * pm
-  } else {  // need to know more eventually
+  } else {                    // need to know more eventually
     HBSize_ = maxDepthHB * 16 * IPHI_MAX * 2;
     HESize_ = maxDepthHE * (29 - 16 + 1) * maxPhiHE_ * 2;
     HOSize_ = 15 * IPHI_MAX * 2;                // ieta * iphi * 2

--- a/Geometry/CaloTopology/src/HcalTopology.cc
+++ b/Geometry/CaloTopology/src/HcalTopology.cc
@@ -202,7 +202,7 @@ HcalTopology::HcalTopology(HcalTopologyMode::Mode mode,
     HESize_ = kHESizePreLS1;  // qie-per-fiber * fiber/rm * rm/rbx * rbx/endcap * endcap/hcal
     HOSize_ = kHOSizePreLS1;  // ieta * iphi * 2
     HFSize_ = kHFSizePreLS1;  // phi * eta * depth * pm
-  } else if (phase2()) {  // need to know more eventually
+  } else if (phase2()) {      // need to know more eventually
     HBSize_ = maxDepthHB * 16 * IPHI_MAX * 2;
     HESize_ = maxDepthHE * (29 - 16 + 1) * maxPhiHE_ * 2;
     HOSize_ = 15 * IPHI_MAX * 2;                // ieta * iphi * 2


### PR DESCRIPTION
#### PR description:

Correct the HcalTopology class for 2 new geometry modes. Geometry mode is used to specify the detector scenario. LHC was the fixed version of the legacy detector. New modes are defined to specify the current situation with new ZDC assignment with the RPD detector (Run3) and the Phase2 setup (Run4) with no HE detector. It will be expanded in future to mark when HF DetIds were enlarged (2016), HE started expansion (2017) and HB had several depths (post LS2). Some of this is reflected in this version of HcalTopology. The usage of the modes was not correctly interpreted in the earlier version of the HcalTopology code.

#### PR validation:

Use the runTheMatrix test workflows

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport to 14_1_X using #46309