### PR TITLE
Fix crash in DeDxEstimatorRekeyer

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/DeDxEstimatorRekeyer.cc
+++ b/PhysicsTools/PatAlgos/plugins/DeDxEstimatorRekeyer.cc
@@ -120,8 +120,10 @@ void DeDxEstimatorRekeyer::produce(edm::StreamID, edm::Event& iEvent, const edm:
   for (const auto& h : pcTrkMap) {
     std::vector<int> indices(h.first->size(), -1);
     for (const auto& p : h.second) {
-      indices[p.first.key()] = resultdedxHitColl->size();
       const auto& dedxHit = dedxHitAss[p.second];
+      if (dedxHit.isNull())
+        continue;
+      indices[p.first.key()] = resultdedxHitColl->size();
       resultdedxHitColl->emplace_back(*dedxHit);
       momenta.emplace_back(dedxHitMom[dedxHit]);
     }


### PR DESCRIPTION
#### PR description:

This PR fixes the issue reported in https://github.com/cms-sw/cmssw/issues/46307

#### PR validation:

Tested by running over the crashing HIForward event reported by T0.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport to be made for 14_1_X
