### PR TITLE
Fix testAOTTools for non-amd64 arch

### DIFF
--- a/PhysicsTools/TensorFlowAOT/test/testAOTTools.py
+++ b/PhysicsTools/TensorFlowAOT/test/testAOTTools.py
@@ -11,6 +11,7 @@ import subprocess
 import tempfile
 import functools
 import unittest
+import platform
 
 
 this_dir = os.path.dirname(os.path.abspath(__file__))
@@ -42,6 +43,8 @@ class TFAOTTests(unittest.TestCase):
         config_file = os.path.join(m.group(1), "share", "test_models", "simple", "aot_config.yaml")
         self.assertTrue(os.path.exists(config_file))
 
+        arch = "{0}-pc-linux".format(platform.processor())
+
         # run the dev workflow
         # create the test model
         cmd = [
@@ -50,6 +53,7 @@ class TFAOTTests(unittest.TestCase):
             "-o", tmp_dir,
             "--tool-name", "tfaot-model-test",
             "--dev",
+            "--additional-flags=--target_triple=" + arch
         ]
         run_cmd(cmd)
 


### PR DESCRIPTION
#### PR description:

This unit test [fails](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_aarch64_gcc12/CMSSW_14_2_TF_X_2024-10-08-1100/unitTestLogs/PhysicsTools/TensorFlowAOT#/104-104) with the following message:

```
Traceback (most recent call last):
  File "/cvmfs/cms-ib.cern.ch/sw/aarch64/nweek-02858/el8_aarch64_gcc12/cms/cmssw/CMSSW_14_2_TF_X_2024-10-08-1100/external/el8_aarch64_gcc12/bin/saved_model_cli3", line 10, in <module>
    sys.exit(main())
  File "/cvmfs/cms-ib.cern.ch/sw/aarch64/nweek-02858/el8_aarch64_gcc12/external/py3-tensorflow/2.17.0-19f19889e80ed84709258505f8c10b73/lib/python3.9/site-packages/tensorflow/python/tools/saved_model_cli.py", line 1340, in main
    app.run(smcli_main)
  File "/cvmfs/cms-ib.cern.ch/sw/aarch64/nweek-02858/el8_aarch64_gcc12/external/py3-absl-py/2.1.0-62ec116f971a239f4f311c7908bb3abf/lib/python3.9/site-packages/absl/app.py", line 308, in run
    _run_main(main, args)
  File "/cvmfs/cms-ib.cern.ch/sw/aarch64/nweek-02858/el8_aarch64_gcc12/external/py3-absl-py/2.1.0-62ec116f971a239f4f311c7908bb3abf/lib/python3.9/site-packages/absl/app.py", line 254, in _run_main
    sys.exit(main(argv))
  File "/cvmfs/cms-ib.cern.ch/sw/aarch64/nweek-02858/el8_aarch64_gcc12/external/py3-tensorflow/2.17.0-19f19889e80ed84709258505f8c10b73/lib/python3.9/site-packages/tensorflow/python/tools/saved_model_cli.py", line 1338, in smcli_main
    args.func()
  File "/cvmfs/cms-ib.cern.ch/sw/aarch64/nweek-02858/el8_aarch64_gcc12/external/py3-tensorflow/2.17.0-19f19889e80ed84709258505f8c10b73/lib/python3.9/site-packages/tensorflow/python/tools/saved_model_cli.py", line 1140, in aot_compile_cpu
    saved_model_aot_compile.aot_compile_cpu_meta_graph_def(
  File "/cvmfs/cms-ib.cern.ch/sw/aarch64/nweek-02858/el8_aarch64_gcc12/external/py3-tensorflow/2.17.0-19f19889e80ed84709258505f8c10b73/lib/python3.9/site-packages/tensorflow/python/tools/saved_model_aot_compile.py", line 395, in aot_compile_cpu_meta_graph_def
    _pywrap_tfcompile.Compile(
RuntimeError: XLA compilation failed: TargetRegistry::lookupTarget failed: No available targets are compatible with triple "x86_64-pc-linux"
```

I propose to disable this test for non-amd64 arches.

#### PR validation:

Bot tests

