### PR TITLE
Update electron Prompt MVA weights for Run 3

### DIFF
--- a/PhysicsTools/NanoAOD/python/electrons_cff.py
+++ b/PhysicsTools/NanoAOD/python/electrons_cff.py
@@ -266,7 +266,7 @@ finalElectrons = cms.EDFilter("PATElectronRefSelector",
 ################################################electronPROMPTMVA#####################
 electronPROMPTMVA= cms.EDProducer("EleBaseMVAValueMapProducer",
     src = cms.InputTag("linkedObjects","electrons"),
-    weightFile =  cms.FileInPath("PhysicsTools/NanoAOD/data/el_BDTG_2017.weights.xml"),
+    weightFile =  cms.FileInPath("PhysicsTools/NanoAOD/data/"),
     name = cms.string("electronPROMPTMVA"),
     backend = cms.string("TMVA"),
     isClassifier = cms.bool(True),


### PR DESCRIPTION
#### PR description:

The electron PromptMVA weights in NanoAOD are old and inadequate for Run 3. We are updating them after a retraining.

#### PR validation:

This is a place-holder PR for the moment, with no actual update of the MVA weights - it is there not to forget that this has to happen before October 30th to end up in NanoAOD v15.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

No backport needed.

@cms-sw/egamma-pog-l2 @SanghyunKo @cochando @Raffaella07 @AlbertoBelvedere @Cvico 