### PR TITLE
Tracking validation updates/improvements

### DIFF
--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -388,10 +388,10 @@ for _eraName, _postfix, _era in _relevantEras:
                    "cutsRecoTracksBtvLike",
                    "cutsRecoTracksAK4PFJets"
                ],
-               doResolutionPlotsForLabels = ["generalTracks", locals()["_generalTracksHp"+_postfix]]  +
-                       locals()["_selectorsByOriginalAlgo"+_postfix] +
-                       ["generalTracksPt09"] +
-               [
+               doResolutionPlotsForLabels = [
+                   "generalTracks",
+                   locals()["_generalTracksHp"+_postfix],
+                   "generalTracksPt09",
                    "cutsRecoTracksBtvLike",
                    "cutsRecoTracksJetCoreRegionalStepByOriginalAlgo"
                ]
@@ -932,6 +932,7 @@ tracksValidationSeedSelectorsTrackingOnly.add(tracksValidationSeedSelectorsPreSp
 # MTV instances
 trackValidatorTrackingOnly = trackValidatorStandalone.clone(
     label = [ x for x in trackValidatorStandalone.label if x != "cutsRecoTracksAK4PFJets"],
+    doResolutionPlotsForLabels = trackValidatorStandalone.doResolutionPlotsForLabels + locals()["_selectorsByOriginalAlgo"+_postfix],
     cores = "highPtJetsForTrk"
  )
 

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -388,12 +388,12 @@ for _eraName, _postfix, _era in _relevantEras:
                    "cutsRecoTracksBtvLike",
                    "cutsRecoTracksAK4PFJets"
                ],
-               doResolutionPlotsForLabels = [
-                   "generalTracks",
-                   locals()["_generalTracksHp"+_postfix],
-                   "generalTracksPt09",
+               doResolutionPlotsForLabels = ["generalTracks", locals()["_generalTracksHp"+_postfix]]  +
+                       locals()["_selectorsByOriginalAlgo"+_postfix] +
+                       ["generalTracksPt09"] +
+               [
                    "cutsRecoTracksBtvLike",
-                   "cutsRecoTracksJetCoreRegionalStepByOriginalAlgo",
+                   "cutsRecoTracksJetCoreRegionalStepByOriginalAlgo"
                ]
     )
     _setForEra(trackValidator.histoProducerAlgoBlock, _eraName, _era, seedingLayerSets=locals()["_seedingLayerSets"+_postfix])
@@ -534,12 +534,12 @@ _trackValidatorSeedingBuilding = trackValidator.clone( # common for built tracks
     dodEdxPlots = False,
     doPVAssociationPlots = False,
     doSimPlots = False,
-    doResolutionPlotsForLabels = ["disabled"],
+    doResolutionPlotsForLabels = ["disabled"]
 )
 trackValidatorBuilding = _trackValidatorSeedingBuilding.clone(
     dirName = "Tracking/TrackBuilding/",
     doMVAPlots = True,
-    doResolutionPlotsForLabels = ['jetCoreRegionalStepTracks'],
+    doResolutionPlotsForLabels = ['jetCoreRegionalStepTracks']
 )
 trackValidatorBuildingPreSplitting = trackValidatorBuilding.clone(
     associators = ["quickTrackAssociatorByHitsPreSplitting"],

--- a/Validation/RecoTrack/python/TrackingParticleSelectionForEfficiency_cfi.py
+++ b/Validation/RecoTrack/python/TrackingParticleSelectionForEfficiency_cfi.py
@@ -22,10 +22,19 @@ TrackingParticleSelectionForEfficiency = cms.PSet(
 def _modifyForPhase1(pset):
     pset.minRapidityTP = -3
     pset.maxRapidityTP = 3
+
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(TrackingParticleSelectionForEfficiency, _modifyForPhase1)
+
+def _modifyForPhase2(pset):
+    pset.minRapidityTP = -4.5
+    pset.maxRapidityTP = 4.5
+
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toModify(TrackingParticleSelectionForEfficiency, minRapidityTP = -4.5, maxRapidityTP = 4.5)
+phase2_tracker.toModify(TrackingParticleSelectionForEfficiency, _modifyForPhase2)
+
+def _modifyForFastSim(pset):
+    pset.stableOnlyTP = True
+
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-fastSim.toModify(TrackingParticleSelectionForEfficiency, stableOnlyTP = True)
-    
+fastSim.toModify(TrackingParticleSelectionForEfficiency, _modifyForFastSim)

--- a/Validation/RecoTrack/python/TrackingParticleSelectionsForEfficiency_cff.py
+++ b/Validation/RecoTrack/python/TrackingParticleSelectionsForEfficiency_cff.py
@@ -1,4 +1,6 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 
 generalTpSelectorBlock = cms.PSet(
     lip = cms.double(30.0),
@@ -21,26 +23,38 @@ generalTpSelectorBlock = cms.PSet(
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toModify(generalTpSelectorBlock, stableOnly = True)
 
-TpSelectorForEfficiencyVsEtaBlock = generalTpSelectorBlock.clone()
-TpSelectorForEfficiencyVsPhiBlock = generalTpSelectorBlock.clone()
-TpSelectorForEfficiencyVsPtBlock = generalTpSelectorBlock.clone(ptMin = 0.050 )
-TpSelectorForEfficiencyVsVTXRBlock = generalTpSelectorBlock.clone(tip = 60.0)
-TpSelectorForEfficiencyVsVTXZBlock = generalTpSelectorBlock.clone()
+generalTpSelectorForEfficiencyBlock = generalTpSelectorBlock.clone() # TP selector block for efficiency (with additional selections)
+
+def _modifyForPhase1Efficiency(pset):
+    pset.tip = 2.5 # beampipe is around 2.0, BPIX1 is at 2.9
+
+phase1Pixel.toModify(generalTpSelectorForEfficiencyBlock, _modifyForPhase1Efficiency)
+
+def _modifyForPhase2Efficiency(pset):
+    pset.minRapidity = -3.5 # within efficient eta range in phase-2
+    pset.maxRapidity = 3.5 # within efficient eta range in phase-2
+    pset.tip = 2.5 # IT1 will be around 3.0 (as in Phase1)
+
+phase2_tracker.toModify(generalTpSelectorForEfficiencyBlock, _modifyForPhase2Efficiency)
+
+TpSelectorForEfficiencyVsEtaBlock = generalTpSelectorForEfficiencyBlock.clone()
+TpSelectorForEfficiencyVsPhiBlock = generalTpSelectorForEfficiencyBlock.clone()
+TpSelectorForEfficiencyVsPtBlock = generalTpSelectorForEfficiencyBlock.clone(ptMin = 0.050 )
+TpSelectorForEfficiencyVsVTXRBlock = generalTpSelectorForEfficiencyBlock.clone(tip = 60.0)
+TpSelectorForEfficiencyVsVTXZBlock = generalTpSelectorForEfficiencyBlock.clone()
 
 def _modifyForPhase1(pset):
     pset.minRapidity = -3
     pset.maxRapidity = 3
     pset.tip = 2.5 # beampipe is around 2.0, BPIX1 is at 2.9
 
-from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-phase1Pixel.toModify(generalTpSelectorBlock, _modifyForPhase1)
-phase1Pixel.toModify(TpSelectorForEfficiencyVsEtaBlock, _modifyForPhase1)
+phase1Pixel.toModify(generalTpSelectorBlock, _modifyForPhase1) # for general TP selector, extend eta to full acceptance
+phase1Pixel.toModify(TpSelectorForEfficiencyVsEtaBlock, _modifyForPhase1) # for efficiency vs eta, also extend eta to full acceptance
 
 def _modifyForPhase2(pset):
     pset.minRapidity = -4.5
     pset.maxRapidity = 4.5
     pset.tip = 2.5 # IT1 will be around 3.0 (as in Phase1)
 
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toModify(generalTpSelectorBlock, _modifyForPhase2)
-phase2_tracker.toModify(TpSelectorForEfficiencyVsEtaBlock, _modifyForPhase2)
+phase2_tracker.toModify(generalTpSelectorBlock, _modifyForPhase2) # for general TP selector, extend eta to full acceptance
+phase2_tracker.toModify(TpSelectorForEfficiencyVsEtaBlock, _modifyForPhase2) # for efficiency vs eta, also extend eta to full acceptance

--- a/Validation/RecoTrack/python/plotting/plotting.py
+++ b/Validation/RecoTrack/python/plotting/plotting.py
@@ -1995,7 +1995,7 @@ class Plot:
             h.SetMarkerStyle(msty)
             h.SetMarkerColor(col)
             h.SetMarkerSize(0.7)
-            h.SetLineColor(1)
+            h.SetLineColor(col)
             h.SetLineWidth(1)
 
         def _styleHist(h, msty, col):

--- a/Validation/RecoTrack/python/plotting/trackingPlots.py
+++ b/Validation/RecoTrack/python/plotting/trackingPlots.py
@@ -1444,11 +1444,11 @@ class Iteration:
         return self._other
 
     def modules(self):
-        return [("ClusterMask", self.clusterMasking()),
-                ("Seeding", self.seeding()),
-                ("Building", self.building()),
+        return [("Cluster Mask", self.clusterMasking()),
+                ("Seed", self.seeding()),
+                ("Build", self.building()),
                 ("Fit", self.fit()),
-                ("Selection", self.selection()),
+                ("Select", self.selection()),
                 ("Other", self.other())]
 
 
@@ -1650,11 +1650,11 @@ def _stepModuleMap():
         return ret
 
     return collections.OrderedDict([
-        ("ClusterMask", getProp("clusterMasking")),
-        ("Seeding", getProp("seeding")),
-        ("Building", getProp("building")),
-        ("Fitting", getProp("fit")),
-        ("Selection", getProp("selection")),
+        ("Cluster Mask", getProp("clusterMasking")),
+        ("Seed", getProp("seeding")),
+        ("Build", getProp("building")),
+        ("Fit", getProp("fit")),
+        ("Select", getProp("selection")),
         ("Other", getProp("other"))
     ])
 
@@ -1877,6 +1877,9 @@ _iteration_reorder = TrackingIterationOrder()
 _time_per_iter_cpu = AggregateBins("iteration", _time_per_event_cpu, _iterModuleMap(), ignoreMissingBins=True, reorder=_iteration_reorder)
 _time_per_iter_real = AggregateBins("iteration", _time_per_event_real, _iterModuleMap(), ignoreMissingBins=True, reorder=_iteration_reorder)
 
+_timing_common = _common.copy()
+_timing_common["xbinlabelsize"] = 17
+_timing_common["xbinlabeloption"] = "d"
 _timing_summaryCPU = PlotGroup("summaryCPU", [
     Plot(_time_per_iter_cpu,
          ytitle="Average CPU time (ms)", title="Average CPU time / event", legendDx=-0.4, **_common),
@@ -1884,9 +1887,9 @@ _timing_summaryCPU = PlotGroup("summaryCPU", [
          ytitle="Fraction", title="", normalizeToUnitArea=True, **_common),
     #
     Plot(AggregateBins("step", _time_per_event_cpu, _stepModuleMap(), ignoreMissingBins=True),
-         ytitle="Average CPU time (ms)", title="Average CPU time / event", **_common),
+         ytitle="Average CPU time (ms)", title="Average CPU time / event", **_timing_common),
     Plot(AggregateBins("step_fraction", _time_per_event_cpu, _stepModuleMap(), ignoreMissingBins=True),
-         ytitle="Fraction", title="", normalizeToUnitArea=True, **_common),
+         ytitle="Fraction", title="", normalizeToUnitArea=True, **_timing_common),
     #
     Plot(TimePerTrackPlot("iteration_track", _time_per_iter_cpu, selectedTracks=False),
          ytitle="Average CPU time / built track (ms)", title="Average CPU time / built track", **_common),
@@ -1901,9 +1904,9 @@ _timing_summaryReal = PlotGroup("summaryReal", [
          ytitle="Fraction", title="", normalizeToUnitArea=True, **_common),
     #
     Plot(AggregateBins("step", _time_per_event_real, _stepModuleMap(), ignoreMissingBins=True),
-         ytitle="Average real time (ms)", title="Average real time / event", **_common),
+         ytitle="Average real time (ms)", title="Average real time / event", **_timing_common),
     Plot(AggregateBins("step_fraction", _time_per_event_real, _stepModuleMap(), ignoreMissingBins=True),
-         ytitle="Fraction", title="", normalizeToUnitArea=True, **_common),
+         ytitle="Fraction", title="", normalizeToUnitArea=True, **_timing_common),
     #
     Plot(TimePerTrackPlot("iteration_track", _time_per_iter_real, selectedTracks=False),
          ytitle="Average real time / built track (ms)", title="Average real time / built track", **_common),
@@ -1911,17 +1914,16 @@ _timing_summaryReal = PlotGroup("summaryReal", [
          ytitle="Average real time / selected track (ms)", title="Average real time / selected HP track by algoMask", **_common),
     ],
 )
-
 _timing_iterationsCPU = PlotGroup("iterationsCPU", [
     Plot(AggregateBins(i.name(), _time_per_event_cpu, collections.OrderedDict(i.modules()), ignoreMissingBins=True),
-         ytitle="Average CPU time (ms)", title=i.name(), **_common)
+         ytitle="Average CPU time (ms)", title=i.name(), **_timing_common)
     for i in _iterations
 ],
                                ncols=4, legend=False
 )
 _timing_iterationsReal = PlotGroup("iterationsReal", [
     Plot(AggregateBins(i.name(), _time_per_event_real, collections.OrderedDict(i.modules()), ignoreMissingBins=True),
-         ytitle="Average real time (ms)", title=i.name(), **_common)
+         ytitle="Average real time (ms)", title=i.name(), **_timing_common)
     for i in _iterations
 ],
                                ncols=4, legend=False


### PR DESCRIPTION
### PR description:

This PR is aimed at updating/improving Multi-Track Validation in terms of style/readability and content.
In particular:
- Line colors are set to the same colors as markers (instead of black), and labels are increased for timing plots.
- Resolution plots are added per iteration, only for tracks `byOriginalAlgo`, to allow for more detailed studies.
- For phase-2, default pseudorapidity range for efficiency plot is increased to |η|<3.5.
- Cut on transverse impact parameter (TIP) is set to the same value for all efficiency plots (but efficiency vs TIP); previously, TIP cut was only updated for efficiency vs  η.

FYI, @kskovpen