### PR TITLE
[PRO] adding new PPS conditions for 2023

### DIFF
--- a/CalibPPS/ESProducers/python/ctppsOpticalFunctions_non_DB_cff.py
+++ b/CalibPPS/ESProducers/python/ctppsOpticalFunctions_non_DB_cff.py
@@ -87,32 +87,8 @@ optics_2018 = cms.PSet(
 
 ctppsOpticalFunctionsESSource.configuration.append(optics_2018)
 
-optics_2021 = cms.PSet(
-  validityRange = cms.EventRange("1234:1 - 1234:max"), # NB: a fake IOV, this optics was never used for LHC
-
-  opticalFunctions = cms.VPSet(
-    cms.PSet( xangle = cms.double(110.444), fileName = cms.FileInPath("CalibPPS/ESProducers/data/optical_functions/2021/version_pre3/110.444urad.root") ),
-    cms.PSet( xangle = cms.double(184.017), fileName = cms.FileInPath("CalibPPS/ESProducers/data/optical_functions/2021/version_pre3/184.017urad.root") )
-  ),
-
-  scoringPlanes = cms.VPSet(
-    # z in cm
-    cms.PSet( rpId = cms.uint32(2014838784), dirName = cms.string("XRPH_D6L5_B2"), z = cms.double(-21255.0) ),  # RP 003, pixel
-    cms.PSet( rpId = cms.uint32(2056257536), dirName = cms.string("XRPH_A6L5_B2"), z = cms.double(-21507.8) ),  # RP 022, diamond
-    cms.PSet( rpId = cms.uint32(2054160384), dirName = cms.string("XRPH_E6L5_B2"), z = cms.double(-21570.0) ),  # RP 016, diamond
-    cms.PSet( rpId = cms.uint32(2023227392), dirName = cms.string("XRPH_B6L5_B2"), z = cms.double(-21955.0) ),  # RP 023, pixel
-
-    cms.PSet( rpId = cms.uint32(2031616000), dirName = cms.string("XRPH_D6R5_B1"), z = cms.double(+21255.0) ),  # RP 103, pixel
-    cms.PSet( rpId = cms.uint32(2073034752), dirName = cms.string("XRPH_A6R5_B1"), z = cms.double(+21507.8) ),  # RP 122, diamond
-    cms.PSet( rpId = cms.uint32(2070937600), dirName = cms.string("XRPH_E6R5_B1"), z = cms.double(+21570.0) ),  # RP 116, diamond
-    cms.PSet( rpId = cms.uint32(2040004608), dirName = cms.string("XRPH_B6R5_B1"), z = cms.double(+21955.0) ),  # RP 123, pixel
-  )
-)
-
-# NB: do not append the 2021 config - not used for any LHC data
-
 optics_2022 = cms.PSet(
-  validityRange = cms.EventRange("343890:min - 999999:max"),
+  validityRange = cms.EventRange("343890:min - 357101:max"),
 
   opticalFunctions = cms.VPSet(
     cms.PSet( xangle = cms.double(144.974), fileName = cms.FileInPath("CalibPPS/ESProducers/data/optical_functions/2022/version_pre1/144.974urad.root") ),
@@ -132,6 +108,31 @@ optics_2022 = cms.PSet(
     cms.PSet( rpId = cms.uint32(2040004608), dirName = cms.string("XRPH_B6R5_B1"), z = cms.double(+21955.0) ),  # RP 123, pixel
   )
 )
+
+optics_2023 = cms.PSet(
+  validityRange = cms.EventRange("366403:min - 370790:max"),
+
+  opticalFunctions = cms.VPSet(
+    cms.PSet( xangle = cms.double(135.000), fileName = cms.FileInPath("CalibPPS/ESProducers/data/optical_functions/2023/version_pre1/135.000urad_calib.root") ),
+    cms.PSet( xangle = cms.double(144.974), fileName = cms.FileInPath("CalibPPS/ESProducers/data/optical_functions/2023/version_pre1/144.974urad_calib.root") ),
+    cms.PSet( xangle = cms.double(160.000), fileName = cms.FileInPath("CalibPPS/ESProducers/data/optical_functions/2023/version_pre1/160.000urad_calib.root") )
+  ),
+
+  scoringPlanes = cms.VPSet(
+    # z in cm
+    cms.PSet( rpId = cms.uint32(2014838784), dirName = cms.string("XRPH_D6L5_B2"), z = cms.double(-21255.0) ),  # RP 003, pixel
+    cms.PSet( rpId = cms.uint32(2056257536), dirName = cms.string("XRPH_A6L5_B2"), z = cms.double(-21507.8) ),  # RP 022, diamond
+    cms.PSet( rpId = cms.uint32(2054160384), dirName = cms.string("XRPH_E6L5_B2"), z = cms.double(-21570.0) ),  # RP 016, diamond
+    cms.PSet( rpId = cms.uint32(2023227392), dirName = cms.string("XRPH_B6L5_B2"), z = cms.double(-21955.0) ),  # RP 023, pixel
+
+    cms.PSet( rpId = cms.uint32(2031616000), dirName = cms.string("XRPH_D6R5_B1"), z = cms.double(+21255.0) ),  # RP 103, pixel
+    cms.PSet( rpId = cms.uint32(2073034752), dirName = cms.string("XRPH_A6R5_B1"), z = cms.double(+21507.8) ),  # RP 122, diamond
+    cms.PSet( rpId = cms.uint32(2070937600), dirName = cms.string("XRPH_E6R5_B1"), z = cms.double(+21570.0) ),  # RP 116, diamond
+    cms.PSet( rpId = cms.uint32(2040004608), dirName = cms.string("XRPH_B6R5_B1"), z = cms.double(+21955.0) ),  # RP 123, pixel
+  )
+)
+
+ctppsOpticalFunctionsESSource.configuration.append(optics_2023)
 
 ctppsOpticalFunctionsESSource.configuration.append(optics_2022)
 

--- a/CalibPPS/ESProducers/python/ctppsOpticalFunctions_non_DB_cff.py
+++ b/CalibPPS/ESProducers/python/ctppsOpticalFunctions_non_DB_cff.py
@@ -109,6 +109,8 @@ optics_2022 = cms.PSet(
   )
 )
 
+ctppsOpticalFunctionsESSource.configuration.append(optics_2022)
+
 optics_2023 = cms.PSet(
   validityRange = cms.EventRange("366403:min - 370790:max"),
 
@@ -133,8 +135,6 @@ optics_2023 = cms.PSet(
 )
 
 ctppsOpticalFunctionsESSource.configuration.append(optics_2023)
-
-ctppsOpticalFunctionsESSource.configuration.append(optics_2022)
 
 # optics interpolation between crossing angles
 from CalibPPS.ESProducers.ctppsInterpolatedOpticalFunctionsESSource_cfi import *

--- a/Configuration/Eras/python/Era_Run3_2023_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2023_cff.py
@@ -2,5 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Run3_cff import Run3
 from Configuration.Eras.Modifier_run3_egamma_2023_cff import run3_egamma_2023
+from Configuration.Eras.Modifier_ctpps_2022_cff import ctpps_2022
+from Configuration.Eras.Modifier_ctpps_2023_cff import ctpps_2023
 
-Run3_2023 = cms.ModifierChain(Run3, run3_egamma_2023)
+Run3_2023 = cms.ModifierChain(Run3.copyAndExclude([ctpps_2022]), run3_egamma_2023, ctpps_2023)

--- a/Configuration/Eras/python/Modifier_ctpps_2023_cff.py
+++ b/Configuration/Eras/python/Modifier_ctpps_2023_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+ctpps_2023 =  cms.Modifier()
+

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -87,7 +87,7 @@ class Eras (object):
                            'phase2_trigger',
                            'phase2_squarePixels', 'phase2_3DPixels',
                            'trackingLowPU', 'trackingPhase1',
-                           'ctpps', 'ctpps_2016', 'ctpps_2017', 'ctpps_2018', 'ctpps_2022',
+                           'ctpps', 'ctpps_2016', 'ctpps_2017', 'ctpps_2018', 'ctpps_2022', 'ctpps_2023',
                            'trackingPhase2PU140','highBetaStar_2018',
                            'tracker_apv_vfp30_2016', 'pf_badHcalMitigationOff',
                            'run2_nanoAOD_106Xv2',

--- a/SimPPS/Configuration/python/GenPPS_cff.py
+++ b/SimPPS/Configuration/python/GenPPS_cff.py
@@ -15,5 +15,9 @@ PPSTransportTask = cms.Task()
 #from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
 #ctpps_2018.toReplaceWith(PPSTransportTask, cms.Task(LHCTransport))
 
+# on hold until proper conditions in place
 from Configuration.Eras.Modifier_ctpps_2022_cff import ctpps_2022
 ctpps_2022.toReplaceWith(PPSTransportTask, cms.Task(LHCTransport))
+
+from Configuration.Eras.Modifier_ctpps_2023_cff import ctpps_2023
+ctpps_2023.toReplaceWith(PPSTransportTask, cms.Task(LHCTransport))

--- a/SimPPS/Configuration/python/SimPPS_cff.py
+++ b/SimPPS/Configuration/python/SimPPS_cff.py
@@ -23,5 +23,9 @@ ctppsDigiTask = cms.Task()
 #from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
 #ctpps_2018.toReplaceWith(ctppsDigiTask, RPixDetDigitizerTask)
 
+# on hold until proper conditions in place
 from Configuration.Eras.Modifier_ctpps_2022_cff import ctpps_2022
 ctpps_2022.toReplaceWith(ctppsDigiTask, RPixDetDigitizerTask)
+
+from Configuration.Eras.Modifier_ctpps_2023_cff import ctpps_2023
+ctpps_2023.toReplaceWith(ctppsDigiTask, RPixDetDigitizerTask)

--- a/SimPPS/Configuration/python/directSimPPS_cff.py
+++ b/SimPPS/Configuration/python/directSimPPS_cff.py
@@ -48,7 +48,19 @@ def _modify2022(process):
         # replaced by the composite ESSource
         delattr(process, 'ctppsGeometryESModule')
 
+def _modify2023(process):
+    print('Process customised for 2023 PPS era')
+    process.load('SimPPS.DirectSimProducer.simPPS2023_cfi')
+    unshiftVertex(process, 'Realistic25ns13p6TeVEarly2023CollisionVtxSmearingParameters')
+    if hasattr(process, 'generator'):
+        process.generator.energy = process.profile_2023_PostTS1.ctppsLHCInfo.beamEnergy
+    if hasattr(process, 'ctppsGeometryESModule'):
+        # replaced by the composite ESSource
+        delattr(process, 'ctppsGeometryESModule')
+
 modifyConfigurationStandardSequencesFor2016_ = eras.ctpps_2016.makeProcessModifier(_modify2016)
 modifyConfigurationStandardSequencesFor2017_ = eras.ctpps_2017.makeProcessModifier(_modify2017)
 modifyConfigurationStandardSequencesFor2018_ = eras.ctpps_2018.makeProcessModifier(_modify2018)
 modifyConfigurationStandardSequencesFor2022_ = eras.ctpps_2022.makeProcessModifier(_modify2022)
+modifyConfigurationStandardSequencesFor2023_ = eras.ctpps_2023.makeProcessModifier(_modify2023)
+

--- a/SimPPS/DirectSimProducer/python/profiles_2022_cff.py
+++ b/SimPPS/DirectSimProducer/python/profiles_2022_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from SimPPS.DirectSimProducer.profile_base_cff import profile_base as _base
-from CalibPPS.ESProducers.ctppsOpticalFunctions_non_DB_cff import optics_2021 as _optics
+from CalibPPS.ESProducers.ctppsOpticalFunctions_non_DB_cff import optics_2022 as _optics
 
 # base profile settings for 2022
 _base_2022 = _base.clone(

--- a/SimPPS/DirectSimProducer/python/profiles_2023_cff.py
+++ b/SimPPS/DirectSimProducer/python/profiles_2023_cff.py
@@ -1,0 +1,64 @@
+import FWCore.ParameterSet.Config as cms
+from SimPPS.DirectSimProducer.profile_base_cff import profile_base as _base
+from CalibPPS.ESProducers.ctppsOpticalFunctions_non_DB_cff import optics_2023 as _optics
+
+# base profile settings for 2023
+_base_2023 = _base.clone(
+    ctppsOpticalFunctions = _base.ctppsOpticalFunctions.clone(
+        opticalFunctions = _optics.opticalFunctions,
+        scoringPlanes = _optics.scoringPlanes,
+    ),
+    ctppsDirectSimuData = _base.ctppsDirectSimuData.clone(
+        empiricalAperture45 = "1.e3*([xi] - 0.20)",
+        empiricalAperture56 = "1.e3*([xi] - 0.20)"
+    )
+)
+
+profile_2023_PreTS1A = _base_2023.clone(
+    L_int = 1.,
+    ctppsLHCInfo = _base_2023.ctppsLHCInfo.clone(
+        # NB: until a dedicated 2022 distributions are issued, it is OK to use 2021 ones here
+        xangleBetaStarHistogramObject = "2021/h2_betaStar_vs_xangle"
+    ),
+    ctppsRPAlignmentCorrectionsDataXML = _base_2023.ctppsRPAlignmentCorrectionsDataXML.clone(
+        MisalignedFiles = ["Validation/CTPPS/alignment/alignment_2023_PreTS1_366403_367840.xml"],
+        RealFiles = ["Validation/CTPPS/alignment/alignment_2023_PreTS1_366403_367840.xml"]
+    ),
+    ctppsDirectSimuData = _base_2023.ctppsDirectSimuData.clone(
+        timeResolutionDiamonds45 = "0.200",
+        timeResolutionDiamonds56 = "0.200"
+    )
+)
+
+profile_2023_PreTS1B = _base_2023.clone(
+    L_int = 1.,
+    ctppsLHCInfo = _base_2023.ctppsLHCInfo.clone(
+        # NB: until a dedicated 2022 distributions are issued, it is OK to use 2021 ones here
+        xangleBetaStarHistogramObject = "2021/h2_betaStar_vs_xangle"
+    ),
+    ctppsRPAlignmentCorrectionsDataXML = _base_2023.ctppsRPAlignmentCorrectionsDataXML.clone(
+        MisalignedFiles = ["Validation/CTPPS/alignment/alignment_2023_PreTS1_367881_368765.xml"],
+        RealFiles = ["Validation/CTPPS/alignment/alignment_2023_PreTS1_367881_368765.xml"]
+    ),
+    ctppsDirectSimuData = _base_2023.ctppsDirectSimuData.clone(
+        timeResolutionDiamonds45 = "0.200",
+        timeResolutionDiamonds56 = "0.200"
+    )
+)
+
+profile_2023_PostTS1 = _base_2023.clone(
+    L_int = 1.,
+    ctppsLHCInfo = _base_2023.ctppsLHCInfo.clone(
+        # NB: until a dedicated 2022 distributions are issued, it is OK to use 2021 ones here
+        xangleBetaStarHistogramObject = "2021/h2_betaStar_vs_xangle"
+    ),
+    ctppsRPAlignmentCorrectionsDataXML = _base_2023.ctppsRPAlignmentCorrectionsDataXML.clone(
+        MisalignedFiles = ["Validation/CTPPS/alignment/alignment_2023_PostTS1.xml"],
+        RealFiles = ["Validation/CTPPS/alignment/alignment_2023_PostTS1.xml"]
+    ),
+    ctppsDirectSimuData = _base_2023.ctppsDirectSimuData.clone(
+        timeResolutionDiamonds45 = "0.200",
+        timeResolutionDiamonds56 = "0.200"
+    )
+)
+

--- a/SimPPS/DirectSimProducer/python/simPPS2023_cfi.py
+++ b/SimPPS/DirectSimProducer/python/simPPS2023_cfi.py
@@ -1,0 +1,20 @@
+import FWCore.ParameterSet.Config as cms
+from CalibPPS.ESProducers.ctppsCompositeESSource_cfi import ctppsCompositeESSource as _esComp
+from CalibPPS.ESProducers.ppsAssociationCuts_non_DB_cff import use_single_infinite_iov_entry, p2022
+from CalibPPS.ESProducers.ppsAssociationCuts_non_DB_cff import ppsAssociationCutsESSource as _esAssCuts
+from Geometry.VeryForwardGeometry.commons_cff import cloneGeometry
+from SimPPS.DirectSimProducer.profiles_2023_cff import profile_2023_PostTS1, profile_2023_PreTS1A, profile_2023_PreTS1B
+from SimPPS.DirectSimProducer.simPPS2017_cfi import rpIds
+
+ppsAssociationCutsESSource = _esAssCuts.clone()
+use_single_infinite_iov_entry(ppsAssociationCutsESSource, p2022)
+XMLIdealGeometryESSource_CTPPS, _ctppsGeometryESModule = cloneGeometry('Geometry.VeryForwardGeometry.geometryRPFromDD_2022_cfi')
+# not cloning the ctppsGeometryESModule, as it is replaced by the composite ES source
+
+ctppsCompositeESSource = _esComp.clone(
+    generateEveryNEvents = 100,
+    periods = [profile_2023_PostTS1,profile_2023_PreTS1A,profile_2023_PreTS1B],
+    compactViewTag = _ctppsGeometryESModule.compactViewTag,
+    isRun2 = _ctppsGeometryESModule.isRun2
+)
+

--- a/SimPPS/DirectSimProducer/test/test_miniAOD_cfg.py
+++ b/SimPPS/DirectSimProducer/test/test_miniAOD_cfg.py
@@ -1,6 +1,13 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.Eras import eras
-process = cms.Process('PPS', eras.Run2_2018)
+from Configuration.Eras.Modifier_ctpps_directSim_cff import ctpps_directSim
+process = cms.Process('PPS', ctpps_directSim, eras.Run3_2023)
+
+detailedLog=True
+Year="2023"
+Period="PreTS1B"
+Profile="profile_"+Year+"_"+Period
+print(Profile)
 
 process.load('Configuration.StandardSequences.Services_cff')
 process.load('Configuration.EventContent.EventContent_cff')
@@ -17,15 +24,28 @@ process.load('FWCore.MessageService.MessageLogger_cfi')
 process.MessageLogger.cerr.threshold = cms.untracked.string('')
 process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32(100)
 
+if detailedLog:
+  process.MessageLogger = cms.Service("MessageLogger",
+      destinations = cms.untracked.vstring('detailedInfo','cerr'),
+      detailedInfo = cms.untracked.PSet(
+          threshold = cms.untracked.string('INFO') 
+      ),
+      cerr = cms.untracked.PSet(
+          threshold  = cms.untracked.string('WARNING') 
+      )
+  )
+
+# period
+process.ctppsCompositeESSource.periods = [process.profile_2023_PreTS1B]
+
 # global tag
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, '106X_upgrade2018_realistic_v16_L1v1', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, '140X_mcRun3_2024_realistic_v20', '')
 
 # raw data source
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
-        #'/store/mc/RunIISummer20UL16MiniAODAPVv2/GGToMuMu_Pt-25_Elastic_13TeV-lpair/MINIAODSIM/106X_mcRun2_asymptotic_preVFP_v11-v1/280000/3870E880-4A47-7440-B122-C76062D2290F.root',
-        '/store/mc/RunIISummer20UL18MiniAODv2/GGToMuMu_Pt-25_Elastic_13TeV-lpair/MINIAODSIM/106X_upgrade2018_realistic_v16_L1v1-v2/260000/6EC2EE65-77C0-3C43-A51B-7B94FE441894.root',
+        "/store/mc/Run3Summer23DRPremix/GGToMuMu_PT-25_El-El_13p6TeV_lpair/AODSIM/130X_mcRun3_2023_realistic_v14-v2/2560000/94caefe9-1efd-4c9e-99ca-9861a85c11ea.root"
     ),
 )
 
@@ -38,8 +58,13 @@ process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService
     ppsDirectProtonSimulation = cms.PSet(initialSeed = cms.untracked.uint32(4981))
 )
 
-from SimPPS.DirectSimProducer.matching_cff import matchDirectSimOutputsMiniAOD
-matchDirectSimOutputsMiniAOD(process)
+from SimPPS.DirectSimProducer.matching_cff import matchDirectSimOutputsAOD
+matchDirectSimOutputsAOD(process)
+
+if detailedLog:
+  print('Verbosity of DirectSimProducer = '+str(process.ppsDirectProtonSimulation.verbosity))
+  process.ppsDirectProtonSimulation.verbosity = cms.untracked.uint32(1)
+  print('beamEnergy from profile = '+str(process.profile_2023_PreTS1B.ctppsLHCInfo.beamEnergy))
 
 process.p = cms.Path(
     process.directSimPPS
@@ -48,8 +73,14 @@ process.p = cms.Path(
 
 # output configuration
 from RecoPPS.Configuration.RecoCTPPS_EventContent_cff import RecoCTPPSAOD
+RecoCTPPSAOD.outputCommands.extend(cms.untracked.vstring(
+    'keep *_genPUProtons_*_*',
+    'keep *_genParticles_*_*'
+    )
+)
+
 process.output = cms.OutputModule('PoolOutputModule',
-    fileName = cms.untracked.string('file:output.root'),
+    fileName = cms.untracked.string('file:output'+'_'+Year+'_'+Period+'.root'),
     outputCommands = RecoCTPPSAOD.outputCommands
 )
 

--- a/Validation/CTPPS/alignment/alignment_2023_PostTS1.xml
+++ b/Validation/CTPPS/alignment/alignment_2023_PostTS1.xml
@@ -1,0 +1,21 @@
+<!-- 
+     Shifts in um, rotations in mrad.
+
+For more details see RPAlignmentCorrections::LoadXMLFile in
+TotemAlignment/RPDataFormats/src/RPAlignmentCorrectionsSequence.cc
+<iov first="369873" last="370890">
+ -->
+<xml DocumentType="AlignmentDescription">
+        <!--  pixel, RP   3  -->
+        <rp id="2014838784" sh_x=" -599.29" sh_y=" 1936.20" sh_z=" +0.000" rot_x=" +0.000" rot_y=" +0.000" rot_z=" +0.000"/>
+        <!--  diamond, RP   16  -->
+        <rp id="2054160384" sh_x=" 0.00" sh_y=" 0.00" sh_z=" +0.000" rot_x=" +0.000" rot_y=" +0.000" rot_z=" +0.000"/>
+        <!--  pixel, RP   23  -->
+        <rp id="2023227392" sh_x=" 150.06" sh_y=" 2141.96" sh_z=" +0.000" rot_x=" +0.000" rot_y=" +0.000" rot_z=" +0.000"/>
+        <!--  pixel, RP   103  -->
+        <rp id="2031616000" sh_x=" 76.95" sh_y=" 574.67" sh_z=" +0.000" rot_x=" +0.000" rot_y=" +0.000" rot_z=" +0.000"/>
+        <!--  diamond, RP   116  -->
+        <rp id="2070937600" sh_x=" 0.00" sh_y=" 0.00" sh_z=" +0.000" rot_x=" +0.000" rot_y=" +0.000" rot_z=" +0.000"/>
+        <!--  pixel, RP   123  -->
+        <rp id="2040004608" sh_x=" 136.90" sh_y=" 2019.47" sh_z=" +0.000" rot_x=" +0.000" rot_y=" +0.000" rot_z=" +0.000"/>
+</xml>

--- a/Validation/CTPPS/alignment/alignment_2023_PreTS1_366403_367840.xml
+++ b/Validation/CTPPS/alignment/alignment_2023_PreTS1_366403_367840.xml
@@ -1,0 +1,21 @@
+<!-- 
+     Shifts in um, rotations in mrad.
+
+For more details see RPAlignmentCorrections::LoadXMLFile in
+TotemAlignment/RPDataFormats/src/RPAlignmentCorrectionsSequence.cc
+<iov first="366403" last="367840">
+ -->
+<xml DocumentType="AlignmentDescription">
+        <!--  pixel, RP   3  -->
+        <rp id="2014838784" sh_x=" -923.95" sh_y=" 3099.22" sh_z=" +0.000" rot_x=" +0.000" rot_y=" +0.000" rot_z=" +0.000"/>
+        <!--  diamond, RP   16  -->
+        <rp id="2054160384" sh_x=" 0.00" sh_y=" 0.00" sh_z=" +0.000" rot_x=" +0.000" rot_y=" +0.000" rot_z=" +0.000"/>
+        <!--  pixel, RP   23  -->
+        <rp id="2023227392" sh_x=" -159.96" sh_y=" 3470.95" sh_z=" +0.000" rot_x=" +0.000" rot_y=" +0.000" rot_z=" +0.000"/>
+        <!--  pixel, RP   103  -->
+        <rp id="2031616000" sh_x=" -166.21" sh_y=" 1654.16" sh_z=" +0.000" rot_x=" +0.000" rot_y=" +0.000" rot_z=" +0.000"/>
+        <!--  diamond, RP   116  -->
+        <rp id="2070937600" sh_x=" 0.00" sh_y=" 0.00" sh_z=" +0.000" rot_x=" +0.000" rot_y=" +0.000" rot_z=" +0.000"/>
+        <!--  pixel, RP   123  -->
+        <rp id="2040004608" sh_x=" 70.34" sh_y=" 2856.93" sh_z=" +0.000" rot_x=" +0.000" rot_y=" +0.000" rot_z=" +0.000"/>
+</xml>

--- a/Validation/CTPPS/alignment/alignment_2023_PreTS1_367881_368765.xml
+++ b/Validation/CTPPS/alignment/alignment_2023_PreTS1_367881_368765.xml
@@ -1,0 +1,21 @@
+<!-- 
+     Shifts in um, rotations in mrad.
+
+For more details see RPAlignmentCorrections::LoadXMLFile in
+TotemAlignment/RPDataFormats/src/RPAlignmentCorrectionsSequence.cc
+<iov first="367881" last="368765">
+ -->
+<xml DocumentType="AlignmentDescription">
+        <!--  pixel, RP   3  -->
+        <rp id="2014838784" sh_x=" -846.88" sh_y=" 2448.57" sh_z=" +0.000" rot_x=" +0.000" rot_y=" +0.000" rot_z=" +0.000"/>
+        <!--  diamond, RP   16  -->
+        <rp id="2054160384" sh_x=" 0.00" sh_y=" 0.00" sh_z=" +0.000" rot_x=" +0.000" rot_y=" +0.000" rot_z=" +0.000"/>
+        <!--  pixel, RP   23  -->
+        <rp id="2023227392" sh_x=" -105.83" sh_y=" 2856.95" sh_z=" +0.000" rot_x=" +0.000" rot_y=" +0.000" rot_z=" +0.000"/>
+        <!--  pixel, RP   103  -->
+        <rp id="2031616000" sh_x=" -178.29" sh_y=" 1151.84" sh_z=" +0.000" rot_x=" +0.000" rot_y=" +0.000" rot_z=" +0.000"/>
+        <!--  diamond, RP   116  -->
+        <rp id="2070937600" sh_x=" 0.00" sh_y=" 0.00" sh_z=" +0.000" rot_x=" +0.000" rot_y=" +0.000" rot_z=" +0.000"/>
+        <!--  pixel, RP   123  -->
+        <rp id="2040004608" sh_x=" -33.06" sh_y=" 2497.08" sh_z=" +0.000" rot_x=" +0.000" rot_y=" +0.000" rot_z=" +0.000"/>
+</xml>


### PR DESCRIPTION
This PR is meant to introduce the latest PPS conditions for 2023 for the PPS fast simulation (Direct Simulation).

PPS direct simulation with 2023 conditions show the expected agreement in proton reconstruction based on the gen v recpo comparison.

![Gen_vs_Reco_2023](https://github.com/user-attachments/assets/797c6374-4a8f-4c5b-9793-709df80e1c1f)

Not a back-port; a new PR is going to be submitted meant for 14.1 since that was the release for 2023 data-taking.

PR passed unittests and runTheMatrix 44 43 41 36 19 1 1 1 1 1 1 tests passed, 0 0 0 0 0 0 0 0 0 0 0 failed

FYI @fabferro @AndreaBellora @forthommel 