### PR TITLE
Adding HTXS variables to nanoAOD for on-the-fly 1.3 categorisation

### DIFF
--- a/GeneratorInterface/RivetInterface/src/HiggsTemplateCrossSections.cc
+++ b/GeneratorInterface/RivetInterface/src/HiggsTemplateCrossSections.cc
@@ -302,6 +302,27 @@ namespace Rivet {
       cat.jets25 = jets.jetsByPt(Cuts::pT > 25.0);
       cat.jets30 = jets.jetsByPt(Cuts::pT > 30.0);
 
+      // Temporary fix: add variables to perform STXS 1.3 classification with nanoAOD on-the-fly
+      // Vector-boson pt for VH production modes
+      if (isVH(prodMode)) {
+          cat.V_pt = cat.V.pt();
+      } else {
+          cat.V_pt = -999;
+      }
+      // Dijet variables using jets30 collection
+      if (cat.jets30.size() >= 2){
+        cat.Mjj = (cat.jets30[0].mom() + cat.jets30[1].mom()).mass();
+        cat.ptHjj = (cat.jets30[0].mom() + cat.jets30[1].mom() + cat.higgs.momentum()).pt();
+        cat.dPhijj = cat.jets30[0].mom().phi()-cat.jets30[1].mom().phi();
+        // Return phi angle in the interval [-PI,PI)
+        if (cat.dPhijj >= Rivet::pi) cat.dPhijj -= 2*Rivet::pi;
+        else if (cat.dPhijj < -1*Rivet::pi) cat.dPhijj += 2*Rivet::pi;
+      } else {
+        cat.Mjj = -999;
+        cat.ptHjj = -999;
+        cat.dPhijj = -999;
+      }
+
       // check that four mometum sum of all stable particles satisfies momentum consevation
       /*
       if ( sum.pt()>0.1 )

--- a/GeneratorInterface/RivetInterface/src/HiggsTemplateCrossSections.cc
+++ b/GeneratorInterface/RivetInterface/src/HiggsTemplateCrossSections.cc
@@ -305,18 +305,20 @@ namespace Rivet {
       // Temporary fix: add variables to perform STXS 1.3 classification with nanoAOD on-the-fly
       // Vector-boson pt for VH production modes
       if (isVH(prodMode)) {
-          cat.V_pt = cat.V.pt();
+        cat.V_pt = cat.V.pt();
       } else {
-          cat.V_pt = -999;
+        cat.V_pt = -999;
       }
       // Dijet variables using jets30 collection
-      if (cat.jets30.size() >= 2){
+      if (cat.jets30.size() >= 2) {
         cat.Mjj = (cat.jets30[0].mom() + cat.jets30[1].mom()).mass();
         cat.ptHjj = (cat.jets30[0].mom() + cat.jets30[1].mom() + cat.higgs.momentum()).pt();
-        cat.dPhijj = cat.jets30[0].mom().phi()-cat.jets30[1].mom().phi();
+        cat.dPhijj = cat.jets30[0].mom().phi() - cat.jets30[1].mom().phi();
         // Return phi angle in the interval [-PI,PI)
-        if (cat.dPhijj >= Rivet::pi) cat.dPhijj -= 2*Rivet::pi;
-        else if (cat.dPhijj < -1*Rivet::pi) cat.dPhijj += 2*Rivet::pi;
+        if (cat.dPhijj >= Rivet::pi)
+          cat.dPhijj -= 2 * Rivet::pi;
+        else if (cat.dPhijj < -1 * Rivet::pi)
+          cat.dPhijj += 2 * Rivet::pi;
       } else {
         cat.Mjj = -999;
         cat.ptHjj = -999;

--- a/PhysicsTools/NanoAOD/python/particlelevel_cff.py
+++ b/PhysicsTools/NanoAOD/python/particlelevel_cff.py
@@ -116,6 +116,11 @@ HTXSCategoryTable = simpleHTXSFlatTableProducer.clone(
         Higgs_y = Var("higgs.Rapidity()",float, doc="rapidity of the Higgs boson as identified in HTXS", precision=12),
         njets30 = Var("jets30.size()","uint8", doc="number of jets with pt>30 GeV as identified in HTXS"),
         njets25 = Var("jets25.size()","uint8", doc="number of jets with pt>25 GeV as identified in HTXS"),
+        # Temporary fix: add variables to perform STXS 1.3 classification with nanoAOD on-the-fly
+        V_pt = Var("V_pt",float, doc="pt of the vector boson as identified in HTXS", precision=14),
+        Mjj = Var("Mjj",float, doc="invariant mass of the dijet (pt>30) system as identified in HTXS", precision=14),
+        ptHjj = Var("ptHjj",float, doc="pt of the dijet(pt>30)-plus-higgs system as identified in HTXS", precision=14),
+        dPhijj = Var("dPhijj",float, doc="DeltaPhi between jets (pt>30) in dijet system as identified in HTXS", precision=12),
    )
 )
 

--- a/SimDataFormats/HTXS/interface/HiggsTemplateCrossSections.h
+++ b/SimDataFormats/HTXS/interface/HiggsTemplateCrossSections.h
@@ -540,6 +540,11 @@ namespace HTXS {
     HTXS::Stage1_2_Fine::Category stage1_2_fine_cat_pTjet30GeV;
     // Flag for Z->vv decay mode (needed to split QQ2ZH and GG2ZH)
     bool isZ2vvDecay = false;
+    // Temporary fix: add variables to perform STXS 1.3 classification with nanoAOD on-the-fly
+    double V_pt;
+    double Mjj;
+    double ptHjj;
+    double dPhijj;
     // Error code :: classification was succesful or some error occured
     HTXS::ErrorCode errorCode;
   };
@@ -567,6 +572,11 @@ namespace HTXS {
     cat.stage1_2_fine_cat_pTjet25GeV = htxs_cat_rivet.stage1_2_fine_cat_pTjet25GeV;
     cat.stage1_2_fine_cat_pTjet30GeV = htxs_cat_rivet.stage1_2_fine_cat_pTjet30GeV;
     cat.isZ2vvDecay = htxs_cat_rivet.isZ2vvDecay;
+    // Temporary fix: add variables to perform STXS 1.3 classification with nanoAOD on-the-fly
+    cat.V_pt = htxs_cat_rivet.V_pt;
+    cat.Mjj = htxs_cat_rivet.Mjj;
+    cat.ptHjj = htxs_cat_rivet.ptHjj;
+    cat.dPhijj = htxs_cat_rivet.dPhijj;
     return cat;
   }
 
@@ -766,6 +776,11 @@ namespace Rivet {
     HTXS::Stage1_2_Fine::Category stage1_2_fine_cat_pTjet30GeV;
     /// Flag to distiguish the Z->vv and Z->l+l- decay modes
     bool isZ2vvDecay = false;
+    // Temporary fix: add variables to perform STXS 1.3 classification with nanoAOD on-the-fly
+    double V_pt;
+    double Mjj;
+    double ptHjj;
+    double dPhijj;
     /// Error code: Whether classification was succesful or some error occured
     HTXS::ErrorCode errorCode;
   };


### PR DESCRIPTION
#### PR description:

Temporary fix to HTXS classification Rivet to enable (planned) STXS 1.3 categorisation on-the-fly using nanoAOD. This will avoid a re-nano campaign of Higgs boson signal MC for STXS Run 3 analyses. Added four new variables to nanoAOD output:
* `HTXS_V_pt`: vector-boson transverse momentum for VH production mode events with precision=14. Default value of -999 for non-VH events.
* `HTXS_Mjj`: dijet invariant mass for events with at-least two jets (pT>30 GeV), with precision=14. Default value of -999 for events without a valid dijet system.
* `HTXS_ptHjj`: transverse momentum of dijet-plus-higgs system for events with at-least two jets (pT>30 GeV), with precision=14. Default value of -999 for events without a valid dijet system.
* `HTXS_dPhijj`: delta-phi between two jets in dijet system for events with at-least two jets (pT>30 GeV), with precision=12. Variables is defined in range [-PI,PI). Default value of -999 for events without a valid dijet system.

With these variables in nanoAOD, we can re-categorise Higgs signal events into the proposed STXS 1.3 bins. The latest slides documenting the 1.3 binning scheme can be found [here](https://indico.cern.ch/event/1424812/contributions/5992689/attachments/2873998/5032645/STXS_1.3_v4.pdf).

#### PR validation:

Tested in `CMSSW_13_3_1_patch1` as used for nanoAOD v13 production.

Ran cmsDriver.py command to privately produce nanoAOD for four main production modes. For example ggH:
```
cmsDriver.py  --python_filename ggH_cfg.py --eventcontent NANOAODSIM --customise Configuration/DataProcessing/Utils.addMonitoring --datatier NANOAODSIM --fileout file:ggH.root --conditions 133X_mcRun3_2022_realistic_postEE_ForNanov13_v1 --step NANO --scenario pp --filein "dbs:/GluGluHtoGG_M-125_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM" --era Run3 --no_exec --mc -n -200
```

Checked outputs for 200 events in each production mode to confirm that the four new variables match for the STXS 1.2 identifier (`HTXS_stage1_2_cat_pTjet30GeV`).

#### PR backport

This PR will need to be backported into the release cycles which are used for nanoAOD production:
* v13: `CMSSW_13_3_1_patch1`
* v14: `CMSSW_14_0_6_patch1`
