### PR TITLE
Two Small Changes Related to ZDC LUTs

### DIFF
--- a/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
+++ b/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
@@ -652,7 +652,7 @@ void HcaluLUTTPGCoder::update(const HcalDbService& conditions) {
           lut[adc] = 0;
           lut_ootpu[adc] = 0;
         } else {
-          if ((adc2fC(adc) - ped) < (pedWidth * 5.)) {
+          if ((adc2fC(adc) - ped) < pedWidth) {
             lut[adc] = 0;
             lut_ootpu[adc] = 0;
           } else {

--- a/CaloOnlineTools/HcalOnlineDb/src/HcalLutManager.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/HcalLutManager.cc
@@ -1754,6 +1754,8 @@ std::map<int, std::shared_ptr<LutXml>> HcalLutManager::getZdcLutXml(const HcalTP
         _cfg.topbottom = 1;
       else if (row->topbottom.find('b') != std::string::npos)
         _cfg.topbottom = 0;
+      else if (row->topbottom.find('u') != std::string::npos)
+        _cfg.topbottom = 2;
       else
         edm::LogWarning("HcalLutManager") << "fpga out of range...";
 


### PR DESCRIPTION
#### PR description:

In consultation with ZDC software expert @hjbossi and fellow HCAL trigger expert @Michael-Krohn.

First change in `HcaluLUTTPGCoder`
* When determining zeroing for the ZDC LUT, 1 pedestal width shall be used in the calculation on L655, rather than 5 pedestal widths.

Second change in `HcalLutManager`
* When generating the ZDC LUT XML, an additional `else if` case is added for topbottom FPGA label corresponding to `u`.

#### PR validation:

Only the first change to the `HcaluLUTTPGCoder` will result in some small changes to emulated ZDC trigger primitives. The second change to `HcalLutManager` only affects the generation of ZDC LUT XML files.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR will be backported to 14_1_X (#46346).
