### PR TITLE
[14_1_X] Era for UPC re-reco of 2016 pPb data

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,7 +24,7 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'                   :    '131X_mcRun2_pA_v3',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'                    :    '140X_dataRun2_v2',
+    'run2_data'                    :    '141X_dataRun2_v2',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_HEfail'             :    '140X_dataRun2_HEfail_v1',
     # GlobalTag for Run2 HI data

--- a/Configuration/Eras/python/Era_Run2_2016_UPC_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2016_UPC_cff.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Eras.Era_Run3_2024_cff import Run3_2024
+from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
 from Configuration.ProcessModifiers.egamma_lowPt_exclusive_cff import egamma_lowPt_exclusive
 from Configuration.Eras.Modifier_highBetaStar_cff import highBetaStar
 from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
 
-Run3_2024_UPC = cms.ModifierChain(Run3_2024, egamma_lowPt_exclusive, highBetaStar, run3_upc)
+Run2_2016_UPC = cms.ModifierChain(Run2_2016, egamma_lowPt_exclusive, highBetaStar, run3_upc)

--- a/Configuration/Eras/python/Era_Run2_2018_highBetaStar_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2018_highBetaStar_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
 from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
-from Configuration.Eras.Modifier_highBetaStar_2018_cff import highBetaStar_2018
+from Configuration.Eras.Modifier_highBetaStar_cff import highBetaStar
 
-Run2_2018_highBetaStar = cms.ModifierChain(Run2_2018.copyAndExclude([trackdnn]), highBetaStar_2018)
+Run2_2018_highBetaStar = cms.ModifierChain(Run2_2018.copyAndExclude([trackdnn]), highBetaStar)

--- a/Configuration/Eras/python/Era_Run3_2023_UPC_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2023_UPC_cff.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Run3_2023_cff import Run3_2023
 from Configuration.ProcessModifiers.egamma_lowPt_exclusive_cff import egamma_lowPt_exclusive
-from Configuration.Eras.Modifier_highBetaStar_2018_cff import highBetaStar_2018
+from Configuration.Eras.Modifier_highBetaStar_cff import highBetaStar
 from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
 
-Run3_2023_UPC = cms.ModifierChain(Run3_2023, egamma_lowPt_exclusive, highBetaStar_2018, run3_upc)
+Run3_2023_UPC = cms.ModifierChain(Run3_2023, egamma_lowPt_exclusive, highBetaStar, run3_upc)

--- a/Configuration/Eras/python/Modifier_highBetaStar_cff.py
+++ b/Configuration/Eras/python/Modifier_highBetaStar_cff.py
@@ -1,4 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 
-highBetaStar_2018 =  cms.Modifier()
+highBetaStar =  cms.Modifier()
 

--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -559,6 +559,9 @@ workflows[142.0] = ['',['RunHIPhysicsRawPrime2023A','HLTDR3_HI2023ARawprime','RE
 workflows[142.901] = ['',['RunUPC2023','RECODR3_2024_UPC','HARVESTDPROMPTR3']]
 workflows[142.902] = ['',['RunUPC2023','RECODR3_2024_HIN','HARVESTDPROMPTR3']]
 
+### run2-2016 (2024 PA UPC rereco data)
+workflows[142.903] = ['',['RunUPC2016PA','RECODR2_2016_UPC','HARVEST2016']]
+
 ## 2024 Data Workflows 
 # for a limited set of eras and PDs not to overflow the IB matrices
 #

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -306,6 +306,10 @@ steps['RunMuOnia2016H']={'INPUT':InputInfo(dataSet='/MuOnia/Run2016H-v1/RAW',lab
 steps['RunJetHT2016H_reminiaod']={'INPUT':InputInfo(dataSet='/JetHT/Run2016H-18Apr2017-v1/AOD',label='2016Hrmaod',events=100000,location='STD', ls=Run2016H)}
 steps['RunJetHT2016H_reminiaodUL']={'INPUT':InputInfo(dataSet='/JetHT/Run2016H-21Feb2020_UL2016-v1/AOD',label='2016HrmaodUL',events=100000,location='STD', ls=Run2016H)}
 
+#### run2 2016 PA UPC ####
+Run2016UPCPA={286051: [[98,98]]}
+steps['RunUPC2016PA']={'INPUT':InputInfo(dataSet='/PAForward/PARun2016C-v1/RAW',label='upcPA2016',events=10000,location='STD',ls=Run2016UPCPA)}
+
 #### run2 2017B ####
 Run2017BlowPU={297227: [[1, 45]]}
 Run2017B={297557: [[8, 167]]}
@@ -2733,6 +2737,7 @@ steps['RECODR3_reHLT_2023']=merge([{'--conditions':'auto:run3_data_prompt_relval
 steps['RECODR3_reHLT_2023B']=merge([{'--conditions':'auto:run3_data_prompt_relval', '--hltProcess':'reHLT'},steps['RECODR3']])
 steps['RECODR3_reHLT_2024']=merge([{'--conditions':'auto:run3_data_prompt_relval', '--hltProcess':'reHLT'},steps['RECODR3']])
 
+steps['RECODR2_2016_UPC']=merge([{'--conditions':'auto:run2_data', '--era':'Run2_2016_UPC', '-s':'RAW2DIGI,L1Reco,RECO,DQM:@commonFakeHLT+@standardDQMFakeHLT', '--repacked':''},steps['RECODR2_2016']])
 steps['RECODR3_2023_HIN']=merge([{'--conditions':'auto:run3_data_prompt', '-s':'RAW2DIGI,L1Reco,RECO,DQM:@commonFakeHLT+@standardDQMFakeHLT', '--repacked':'', '-n':1000},steps['RECODR3_2023']])
 steps['RECODR3_2023_UPC']=merge([{'--era':'Run3_2023_UPC'},steps['RECODR3_2023_HIN']])
 steps['RECODR3_2024_HIN']=merge([{'--conditions':'auto:run3_data_prompt', '-s':'RAW2DIGI,L1Reco,RECO,DQM:@commonFakeHLT+@standardDQMFakeHLT', '--repacked':'', '-n':1000},steps['RECODR3_2024']])

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -20,6 +20,7 @@ class Eras (object):
                  'Run2_2016_HIPM',
                  'Run2_2016_trackingLowPU',
                  'Run2_2016_pA',
+                 'Run2_2016_UPC',
                  'Run2_2017',
                  'Run2_2017_noMkFit',
                  'Run2_2017_FastSim', #new modifier for Phase1 FastSim, skips the muon GEM sequence
@@ -88,7 +89,7 @@ class Eras (object):
                            'phase2_squarePixels', 'phase2_3DPixels',
                            'trackingLowPU', 'trackingPhase1',
                            'ctpps', 'ctpps_2016', 'ctpps_2017', 'ctpps_2018', 'ctpps_2022',
-                           'trackingPhase2PU140','highBetaStar_2018',
+                           'trackingPhase2PU140','highBetaStar',
                            'tracker_apv_vfp30_2016', 'pf_badHcalMitigationOff',
                            'run2_nanoAOD_106Xv2',
                            'run3_nanoAOD_122', 'run3_nanoAOD_124',

--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -187,7 +187,7 @@ from RecoHI.HiTracking.HILowPtConformalPixelTracks_cfi import *
 from RecoHI.HiCentralityAlgos.HiCentrality_cfi import hiCentrality
 from RecoHI.HiCentralityAlgos.HiClusterCompatibility_cfi import hiClusterCompatibility
 _highlevelreco_HITask = highlevelrecoTask.copy()
-_highlevelreco_HITask.add(hiConformalPixelTracksTaskPhase1)
+_highlevelreco_HITask.add(hiConformalPixelTracksTask)
 _highlevelreco_HITask.add(hiCentrality)
 _highlevelreco_HITask.add(hiClusterCompatibility)
 (pp_on_XeXe_2017 | pp_on_AA | run3_upc).toReplaceWith(highlevelrecoTask, _highlevelreco_HITask)

--- a/RecoHI/HiTracking/python/HILowPtConformalPixelTracks_cfi.py
+++ b/RecoHI/HiTracking/python/HILowPtConformalPixelTracks_cfi.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
+from RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi import PixelLayerTriplets
 from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _hitPairEDProducer
 from RecoTracker.PixelSeeding.pixelTripletHLTEDProducer_cfi import pixelTripletHLTEDProducer as _pixelTripletHLTEDProducer
 from RecoTracker.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
@@ -123,6 +124,7 @@ phase1Pixel.toModify(hiConformalPixelTracks,
 
 hiConformalPixelTracksTask = cms.Task(
     hiTrackingRegionWithVertex ,
+    PixelLayerTriplets ,
     hiConformalPixelTracksHitDoublets ,
     hiConformalPixelTracksHitTriplets ,
     pixelFitterByConformalMappingAndLine ,
@@ -216,8 +218,10 @@ pixelNtupletFit.toReplaceWith(hiConformalPixelTracksTaskPhase1, cms.Task(
     hiConformalPixelTracksTaskPhase1.copy()
 ))
 
-hiConformalPixelTracksSequencePhase1 = cms.Sequence(hiConformalPixelTracksTaskPhase1)
+phase1Pixel.toReplaceWith(hiConformalPixelTracksTask, hiConformalPixelTracksTaskPhase1)
 
 from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
 run3_upc.toModify(hiConformalPixelTracksPhase1TrackingRegions.RegionPSet, ptMin = 0.05)
 run3_upc.toModify(hiConformalPixelTracksPhase1Filter, ptMin = 0.05)
+run3_upc.toModify(hiTrackingRegionWithVertex.RegionPSet, VertexCollection = "offlinePrimaryVertices", ptMin = 0.05)
+run3_upc.toModify(hiConformalPixelFilter, VertexCollection = "offlinePrimaryVertices", ptMin = 0.05)

--- a/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
@@ -51,8 +51,8 @@ from RecoTracker.TkTrackingRegions.globalTrackingRegionWithVertices_cff import g
                 )
                                                                       )
 )
-from Configuration.Eras.Modifier_highBetaStar_2018_cff import highBetaStar_2018
-highBetaStar_2018.toModify(detachedQuadStepTrackingRegions,RegionPSet = dict(ptMin = 0.05))
+from Configuration.Eras.Modifier_highBetaStar_cff import highBetaStar
+highBetaStar.toModify(detachedQuadStepTrackingRegions,RegionPSet = dict(ptMin = 0.05))
 
 
 # seeding
@@ -80,7 +80,7 @@ detachedQuadStepHitQuadruplets = _caHitQuadrupletEDProducer.clone(
     CAThetaCut           = 0.0011,
     CAPhiCut             = 0,
 )
-highBetaStar_2018.toModify(detachedQuadStepHitQuadruplets,CAThetaCut = 0.0022,CAPhiCut = 0.1)
+highBetaStar.toModify(detachedQuadStepHitQuadruplets,CAThetaCut = 0.0022,CAPhiCut = 0.1)
 
 from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer_cff import seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer as _seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer
 detachedQuadStepSeeds = _seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer.clone(
@@ -256,7 +256,7 @@ trackdnn.toReplaceWith(detachedQuadStep, trackTfClassifier.clone(
 ))
 
 
-highBetaStar_2018.toModify(detachedQuadStep,qualityCuts = [-0.7,0.0,0.5])
+highBetaStar.toModify(detachedQuadStep,qualityCuts = [-0.7,0.0,0.5])
 
 (pp_on_AA & trackdnn).toModify(detachedQuadStep, qualityCuts =  [-0.63, 0.5, 0.94] )
 

--- a/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
@@ -65,8 +65,8 @@ from RecoTracker.TkTrackingRegions.globalTrackingRegionWithVertices_cff import g
                     originRadius = 1.5)
                 )
 )
-from Configuration.Eras.Modifier_highBetaStar_2018_cff import highBetaStar_2018
-highBetaStar_2018.toModify(detachedTripletStepTrackingRegions, RegionPSet = dict(ptMin = 0.05))
+from Configuration.Eras.Modifier_highBetaStar_cff import highBetaStar
+highBetaStar.toModify(detachedTripletStepTrackingRegions, RegionPSet = dict(ptMin = 0.05))
 
 # seeding
 from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _hitPairEDProducer
@@ -109,7 +109,7 @@ trackingPhase1.toReplaceWith(detachedTripletStepHitTriplets, _caHitTripletEDProd
     CAPhiCut             = 0,
     CAHardPtCut          = 0.2,
 ))
-highBetaStar_2018.toModify(detachedTripletStepHitTriplets,CAThetaCut = 0.002,CAPhiCut = 0.1,CAHardPtCut = 0)
+(highBetaStar & trackingPhase1).toModify(detachedTripletStepHitTriplets,CAThetaCut = 0.002,CAPhiCut = 0.1,CAHardPtCut = 0)
 
 import FastSimulation.Tracking.TrajectorySeedProducer_cfi
 _fastSim_detachedTripletStepSeeds = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.clone(
@@ -303,7 +303,7 @@ trackdnn.toReplaceWith(detachedTripletStep, trackTfClassifier.clone(
 
 (pp_on_AA & trackdnn).toModify(detachedTripletStep, qualityCuts =  [-0.32, 0.5, 0.98] )
 
-highBetaStar_2018.toModify(detachedTripletStep,qualityCuts = [-0.5,0.0,0.5])
+(highBetaStar & trackingPhase1).toModify(detachedTripletStep,qualityCuts = [-0.5,0.0,0.5])
 
 # For LowPU
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -81,8 +81,8 @@ from RecoTracker.TkTrackingRegions.globalTrackingRegionWithVertices_cff import g
                 )
                                                                       )
 )
-from Configuration.Eras.Modifier_highBetaStar_2018_cff import highBetaStar_2018
-highBetaStar_2018.toModify(highPtTripletStepTrackingRegions,RegionPSet = dict(
+from Configuration.Eras.Modifier_highBetaStar_cff import highBetaStar
+highBetaStar.toModify(highPtTripletStepTrackingRegions,RegionPSet = dict(
      ptMin        = 0.05,
      originRadius = 0.2
 ))
@@ -116,7 +116,7 @@ highPtTripletStepHitTriplets = _caHitTripletEDProducer.clone(
 )
 
 trackingPhase2PU140.toModify(highPtTripletStepHitTriplets,CAThetaCut = 0.003,CAPhiCut = 0.06,CAHardPtCut = 0.5)
-highBetaStar_2018.toModify(highPtTripletStepHitTriplets,CAThetaCut = 0.008,CAPhiCut = 0.14,CAHardPtCut = 0)
+highBetaStar.toModify(highPtTripletStepHitTriplets,CAThetaCut = 0.008,CAPhiCut = 0.14,CAHardPtCut = 0)
 
 from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsEDProducer_cff import seedCreatorFromRegionConsecutiveHitsEDProducer as _seedCreatorFromRegionConsecutiveHitsEDProducer
 highPtTripletStepSeeds = _seedCreatorFromRegionConsecutiveHitsEDProducer.clone(
@@ -153,7 +153,7 @@ highPtTripletStepTrajectoryFilterBase = _highPtTripletStepTrajectoryFilterBase.c
 trackingPhase2PU140.toReplaceWith(highPtTripletStepTrajectoryFilterBase, _highPtTripletStepTrajectoryFilterBase)
 
 (pp_on_XeXe_2017 | pp_on_AA).toModify(highPtTripletStepTrajectoryFilterBase, minPt=0.7)
-highBetaStar_2018.toModify(highPtTripletStepTrajectoryFilterBase, minPt=0.05)
+highBetaStar.toModify(highPtTripletStepTrajectoryFilterBase, minPt=0.05)
 
 highPtTripletStepTrajectoryFilter = _TrajectoryFilter_cff.CompositeTrajectoryFilter_block.clone(
     filters = [cms.PSet(refToPSet_ = cms.string('highPtTripletStepTrajectoryFilterBase'))]
@@ -171,7 +171,7 @@ highPtTripletStepTrajectoryFilterInOut = highPtTripletStepTrajectoryFilterBase.c
     strictSeedExtension = False, # allow inactive
     pixelSeedExtension  = False,
 )
-highBetaStar_2018.toModify(highPtTripletStepTrajectoryFilterInOut, minPt=0.05)
+highBetaStar.toModify(highPtTripletStepTrajectoryFilterInOut, minPt=0.05)
 
 import RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi
 highPtTripletStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi.Chi2ChargeMeasurementEstimator.clone(
@@ -299,7 +299,7 @@ trackdnn.toReplaceWith(highPtTripletStep, trackTfClassifier.clone(
     src = 'highPtTripletStepTracks',
     qualityCuts = qualityCutDictionary.HighPtTripletStep.value()
 ))
-highBetaStar_2018.toModify(highPtTripletStep,qualityCuts = [-0.2,0.3,0.4])
+highBetaStar.toModify(highPtTripletStep,qualityCuts = [-0.2,0.3,0.4])
 
 fastSim.toModify(highPtTripletStep,vertices = 'firstStepPrimaryVerticesBeforeMixing')
 

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -36,8 +36,8 @@ initialStepTrackingRegions = _globalTrackingRegionFromBeamSpot.clone(RegionPSet 
 ))
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
 trackingPhase1.toModify(initialStepTrackingRegions, RegionPSet = dict(ptMin = 0.5))
-from Configuration.Eras.Modifier_highBetaStar_2018_cff import highBetaStar_2018
-highBetaStar_2018.toModify(initialStepTrackingRegions,RegionPSet = dict(
+from Configuration.Eras.Modifier_highBetaStar_cff import highBetaStar
+highBetaStar.toModify(initialStepTrackingRegions,RegionPSet = dict(
      ptMin        = 0.05,
      originRadius = 0.2
 ))
@@ -78,7 +78,7 @@ _initialStepCAHitQuadruplets = _caHitQuadrupletEDProducer.clone(
     CAThetaCut           = 0.0012,
     CAPhiCut             = 0.2,
 )
-highBetaStar_2018.toModify(_initialStepCAHitQuadruplets,
+highBetaStar.toModify(_initialStepCAHitQuadruplets,
     CAThetaCut = 0.0024,
     CAPhiCut   = 0.4
 )
@@ -154,7 +154,7 @@ _tracker_apv_vfp30_2016.toModify(initialStepTrajectoryFilterBase, maxCCCLostHits
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 (pp_on_XeXe_2017 | pp_on_AA).toModify(initialStepTrajectoryFilterBase, minPt=0.6)
-highBetaStar_2018.toModify(initialStepTrajectoryFilterBase, minPt = 0.05)
+highBetaStar.toModify(initialStepTrajectoryFilterBase, minPt = 0.05)
 
 initialStepTrajectoryFilterInOut = initialStepTrajectoryFilterBase.clone(
     minimumNumberOfHits = 4,

--- a/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
@@ -42,8 +42,8 @@ from RecoTracker.TkTrackingRegions.globalTrackingRegionWithVertices_cff import g
                     originRadius = 0.02 )
                 )
 )
-from Configuration.Eras.Modifier_highBetaStar_2018_cff import highBetaStar_2018
-highBetaStar_2018.toModify(lowPtQuadStepTrackingRegions,RegionPSet = dict(
+from Configuration.Eras.Modifier_highBetaStar_cff import highBetaStar
+highBetaStar.toModify(lowPtQuadStepTrackingRegions,RegionPSet = dict(
      ptMin        = 0.05,
      originRadius = 0.2, )
 )
@@ -76,7 +76,7 @@ lowPtQuadStepHitQuadruplets = _caHitQuadrupletEDProducer.clone(
     CAPhiCut             = 0.3,
 )
 trackingPhase2PU140.toModify(lowPtQuadStepHitQuadruplets,CAThetaCut = 0.0015,CAPhiCut = 0.25)
-highBetaStar_2018.toModify(lowPtQuadStepHitQuadruplets,CAThetaCut = 0.0034,CAPhiCut = 0.6)
+highBetaStar.toModify(lowPtQuadStepHitQuadruplets,CAThetaCut = 0.0034,CAPhiCut = 0.6)
 
 from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsEDProducer_cff import seedCreatorFromRegionConsecutiveHitsEDProducer as _seedCreatorFromRegionConsecutiveHitsEDProducer
 lowPtQuadStepSeeds = _seedCreatorFromRegionConsecutiveHitsEDProducer.clone(
@@ -244,7 +244,7 @@ trackdnn.toReplaceWith(lowPtQuadStep, trackTfClassifier.clone(
     src = 'lowPtQuadStepTracks',
     qualityCuts = qualityCutDictionary.LowPtQuadStep.value()
 ))
-highBetaStar_2018.toModify(lowPtQuadStep,qualityCuts = [-0.9,-0.35,-0.15])
+highBetaStar.toModify(lowPtQuadStep,qualityCuts = [-0.9,-0.35,-0.15])
 fastSim.toModify(lowPtQuadStep,vertices = 'firstStepPrimaryVerticesBeforeMixing')
 
 ((~trackingMkFitLowPtQuadStep) & trackdnn).toModify(lowPtQuadStep, mva = dict(tfDnnLabel  = 'trackSelectionTf_CKF'),

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -75,8 +75,8 @@ from RecoTracker.TkTrackingRegions.globalTrackingRegionWithVertices_cff import g
                     originRadius  = 0.02 )
                )
 )
-from Configuration.Eras.Modifier_highBetaStar_2018_cff import highBetaStar_2018
-highBetaStar_2018.toModify(lowPtTripletStepTrackingRegions,RegionPSet = dict(
+from Configuration.Eras.Modifier_highBetaStar_cff import highBetaStar
+highBetaStar.toModify(lowPtTripletStepTrackingRegions,RegionPSet = dict(
      ptMin        = 0.05,
      originRadius = 0.2 )
 )
@@ -130,7 +130,7 @@ trackingPhase2PU140.toReplaceWith(lowPtTripletStepHitTriplets, _caHitTripletEDPr
     CAThetaCut           = 0.002,
     CAPhiCut             = 0.05 )
 )
-highBetaStar_2018.toModify(lowPtTripletStepHitTriplets,CAThetaCut = 0.004,CAPhiCut = 0.1)
+(highBetaStar & trackingPhase1).toModify(lowPtTripletStepHitTriplets,CAThetaCut = 0.004,CAPhiCut = 0.1)
  
 import FastSimulation.Tracking.TrajectorySeedProducer_cfi
 from FastSimulation.Tracking.SeedingMigration import _hitSetProducerToFactoryPSet
@@ -323,7 +323,7 @@ trackdnn.toReplaceWith(lowPtTripletStep, trackTfClassifier.clone(
     src = 'lowPtTripletStepTracks',
     qualityCuts = qualityCutDictionary.LowPtTripletStep.value()
 ))
-highBetaStar_2018.toModify(lowPtTripletStep,qualityCuts = [-0.7,-0.3,-0.1])
+highBetaStar.toModify(lowPtTripletStep,qualityCuts = [-0.7,-0.3,-0.1])
 
 fastSim.toModify(lowPtTripletStep, vertices = 'firstStepPrimaryVerticesBeforeMixing')
 

--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -75,8 +75,8 @@ trackingLowPU.toModify(mixedTripletStepSeedLayersA,
     ],
     TEC = dict(clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny')),
 )
-from Configuration.Eras.Modifier_highBetaStar_2018_cff import highBetaStar_2018
-highBetaStar_2018.toModify(mixedTripletStepSeedLayersA,
+from Configuration.Eras.Modifier_highBetaStar_cff import highBetaStar
+highBetaStar.toModify(mixedTripletStepSeedLayersA,
     layerList = [
         'BPix1+BPix2+BPix3',
         'BPix1+FPix1_pos+FPix2_pos','BPix1+FPix1_neg+FPix2_neg',
@@ -95,7 +95,7 @@ _mixedTripletStepTrackingRegionsCommon = _globalTrackingRegionFromBeamSpotFixedZ
     originRadius     = 1.5
 ))
 trackingLowPU.toModify(_mixedTripletStepTrackingRegionsCommon, RegionPSet = dict(originHalfLength = 10.0))
-highBetaStar_2018.toModify(_mixedTripletStepTrackingRegionsCommon,RegionPSet = dict(
+highBetaStar.toModify(_mixedTripletStepTrackingRegionsCommon,RegionPSet = dict(
      ptMin        = 0.05,
      originRadius = 0.2
 ))
@@ -195,7 +195,7 @@ mixedTripletStepTrackingRegionsB = _mixedTripletStepTrackingRegionsCommon.clone(
                     ptMin      = 0.6,)
                 )
 )
-highBetaStar_2018.toReplaceWith(mixedTripletStepTrackingRegionsB, _mixedTripletStepTrackingRegionsCommon.clone())
+highBetaStar.toReplaceWith(mixedTripletStepTrackingRegionsB, _mixedTripletStepTrackingRegionsCommon.clone())
 
 # seeding
 mixedTripletStepHitDoubletsB = mixedTripletStepHitDoubletsA.clone(
@@ -226,7 +226,7 @@ _mixedTripletStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.Trajec
     minimumNumberOfHits = 3,
     minPt               = 0.1
 )
-highBetaStar_2018.toModify(_mixedTripletStepTrajectoryFilterBase,minPt = 0.05)
+highBetaStar.toModify(_mixedTripletStepTrajectoryFilterBase,minPt = 0.05)
 
 mixedTripletStepTrajectoryFilter = _mixedTripletStepTrajectoryFilterBase.clone(
     constantValueForLostHitsFractionFilter = 1.4,
@@ -248,7 +248,7 @@ mixedTripletStepPropagator = TrackingTools.MaterialEffects.MaterialPropagator_cf
 trackingParabolicMf.toModify(mixedTripletStepPropagator, SimpleMagneticField = 'ParabolicMf')
 for e in [pp_on_XeXe_2017, pp_on_AA]:
     e.toModify(mixedTripletStepPropagator, ptMin=0.4)
-highBetaStar_2018.toModify(mixedTripletStepPropagator,ptMin = 0.05)
+highBetaStar.toModify(mixedTripletStepPropagator,ptMin = 0.05)
 
 import TrackingTools.MaterialEffects.OppositeMaterialPropagator_cfi
 mixedTripletStepPropagatorOpposite = TrackingTools.MaterialEffects.OppositeMaterialPropagator_cfi.OppositeMaterialPropagator.clone(
@@ -259,7 +259,7 @@ mixedTripletStepPropagatorOpposite = TrackingTools.MaterialEffects.OppositeMater
 trackingParabolicMf.toModify(mixedTripletStepPropagatorOpposite, SimpleMagneticField = 'ParabolicMf')
 for e in [pp_on_XeXe_2017, pp_on_AA]:
     e.toModify(mixedTripletStepPropagatorOpposite, ptMin=0.4)
-highBetaStar_2018.toModify(mixedTripletStepPropagatorOpposite,ptMin = 0.05)
+highBetaStar.toModify(mixedTripletStepPropagatorOpposite,ptMin = 0.05)
 
 import RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi
 mixedTripletStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator_cfi.Chi2ChargeMeasurementEstimator.clone(
@@ -388,7 +388,8 @@ trackdnn.toReplaceWith(mixedTripletStep, trackTfClassifier.clone(
 ))
 (trackdnn & fastSim).toModify(mixedTripletStep,vertices = 'firstStepPrimaryVerticesBeforeMixing')
 
-highBetaStar_2018.toModify(mixedTripletStep,qualityCuts = [-0.7,0.0,0.5])
+(highBetaStar & trackingPhase1).toModify(mixedTripletStep,qualityCuts = [-0.7,0.0,0.5])
+(highBetaStar & ~trackingPhase1).toModify(mixedTripletStepClassifier1,qualityCuts = [-0.7,0.0,0.5])
 pp_on_AA.toModify(mixedTripletStep, qualityCuts = [-0.5,0.0,0.9])
 
 # For LowPU

--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -86,14 +86,14 @@ _region_Phase1 = dict(
 )
 trackingPhase1.toModify(pixelPairStepTrackingRegions, RegionPSet=_region_Phase1)
 trackingPhase2PU140.toModify(pixelPairStepTrackingRegions, RegionPSet=_region_Phase1)
-from Configuration.Eras.Modifier_highBetaStar_2018_cff import highBetaStar_2018
-highBetaStar_2018.toModify(pixelPairStepTrackingRegions,RegionPSet = dict(
+from Configuration.Eras.Modifier_highBetaStar_cff import highBetaStar
+highBetaStar.toModify(pixelPairStepTrackingRegions,RegionPSet = dict(
      ptMin        = 0.05,
      originRadius = 0.2,
      fixedError   = 4.
 ))
 from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
-(highBetaStar_2018 & run3_upc).toModify(pixelPairStepTrackingRegions,RegionPSet = dict(originRadius = 0.015))
+(highBetaStar & run3_upc).toModify(pixelPairStepTrackingRegions,RegionPSet = dict(originRadius = 0.015))
 fastSim.toModify(pixelPairStepTrackingRegions, RegionPSet=dict(VertexCollection = 'firstStepPrimaryVerticesBeforeMixing'))
 
 # SEEDS
@@ -173,7 +173,7 @@ pixelPairStepTrackingRegionsSeedLayersB = _pixelInactiveAreaTrackingRegionsAndSe
     ),
     ignoreSingleFPixPanelModules = True,
 )
-highBetaStar_2018.toModify(pixelPairStepTrackingRegionsSeedLayersB,RegionPSet = dict(
+highBetaStar.toModify(pixelPairStepTrackingRegionsSeedLayersB,RegionPSet = dict(
      ptMin        = 0.05,
      originRadius = 0.2,
 ))
@@ -231,7 +231,7 @@ trackingPhase2PU140.toReplaceWith(pixelPairStepTrajectoryFilterBase, _pixelPairS
     maxLostHitsFraction = 1./10.,
     constantValueForLostHitsFractionFilter = 0.701,
 ))
-highBetaStar_2018.toModify(pixelPairStepTrajectoryFilterBase, minPt = 0.05)
+highBetaStar.toModify(pixelPairStepTrajectoryFilterBase, minPt = 0.05)
 
 import RecoTracker.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi
 pixelPairStepTrajectoryFilterShape = RecoTracker.PixelLowPtUtilities.StripSubClusterShapeTrajectoryFilter_cfi.StripSubClusterShapeTrajectoryFilterTIX12.clone()
@@ -272,7 +272,7 @@ _tracker_apv_vfp30_2016.toModify(pixelPairStepChi2Est,
 trackingLowPU.toModify(pixelPairStepChi2Est,
     clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny'),
 )
-highBetaStar_2018.toModify(pixelPairStepChi2Est, MaxChi2 = 30)
+highBetaStar.toModify(pixelPairStepChi2Est, MaxChi2 = 30)
 
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
@@ -383,7 +383,7 @@ trackdnn.toReplaceWith(pixelPairStep, trackTfClassifier.clone(
     qualityCuts=qualityCutDictionary.PixelPairStep.value()
 ))
 
-highBetaStar_2018.toModify(pixelPairStep,qualityCuts = [-0.95,0.0,0.3])
+highBetaStar.toModify(pixelPairStep,qualityCuts = [-0.95,0.0,0.3])
 pp_on_AA.toModify(pixelPairStep, qualityCuts = [0.85, 0.95, 0.98])
 fastSim.toModify(pixelPairStep, vertices = 'firstStepPrimaryVerticesBeforeMixing')
 

--- a/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
+++ b/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
@@ -87,8 +87,8 @@ from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
          )
 )
 
-from Configuration.Eras.Modifier_highBetaStar_2018_cff import highBetaStar_2018
-highBetaStar_2018.toModify(offlinePrimaryVertices,
+from Configuration.Eras.Modifier_highBetaStar_cff import highBetaStar
+highBetaStar.toModify(offlinePrimaryVertices,
     TkClusParameters = dict(
         TkDAClusParameters = dict(
             Tmin = 4.0,
@@ -162,8 +162,7 @@ from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
                )
 )
 
-from Configuration.Eras.Modifier_highBetaStar_2018_cff import highBetaStar_2018
-highBetaStar_2018.toModify(offlinePrimaryVertices,
+highBetaStar.toModify(offlinePrimaryVertices,
      TkFilterParameters = dict(
          maxNormalizedChi2 = 80.0,
          minPixelLayersWithHits = 1,


### PR DESCRIPTION
#### PR description:

Backport of https://github.com/cms-sw/cmssw/pull/46087

#### PR validation:

Tested using the relvals 180,180.1,181,181.1,141.901,142.901,142.903

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for: