### PR TITLE
[ML][Clang]clang-analyzer, initialize memory and add protection against

### DIFF
--- a/PhysicsTools/MVAComputer/src/ProcMLP.cc
+++ b/PhysicsTools/MVAComputer/src/ProcMLP.cc
@@ -19,6 +19,7 @@
 #include <iterator>
 #include <vector>
 #include <cmath>
+#include <cassert>
 
 #include "FWCore/Utilities/interface/Exception.h"
 
@@ -100,7 +101,7 @@ namespace {  // anonymous
   }
 
   void ProcMLP::eval(ValueIterator iter, unsigned int n) const {
-    double *tmp = (double *)alloca(2 * maxTmp * sizeof(double));
+    double *tmp = (double *)calloc(2 * maxTmp, sizeof(double));
     bool flip = false;
 
     for (double *pos = tmp; iter; iter++, pos++)
@@ -108,6 +109,7 @@ namespace {  // anonymous
 
     double *output = nullptr;
     for (std::vector<Layer>::const_iterator layer = layers.begin(); layer != layers.end(); layer++, flip = !flip) {
+      assert(maxTmp >= layer->inputs);
       const double *input = &tmp[flip ? maxTmp : 0];
       output = &tmp[flip ? 0 : maxTmp];
       std::vector<double>::const_iterator coeff = layer->coeffs.begin();
@@ -123,6 +125,7 @@ namespace {  // anonymous
 
     for (const double *pos = &tmp[flip ? maxTmp : 0]; pos < output; pos++)
       iter(*pos);
+    free(tmp);
   }
 
   std::vector<double> ProcMLP::deriv(ValueIterator iter, unsigned int n) const {


### PR DESCRIPTION
This change fixes [clang-analyzer warning](https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_14_2_X_2024-10-09-2300/el8_amd64_gcc12/build-logs/PhysicsTools/MVAComputer/log.html) with complete report at this [link](https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_14_2_X_2024-10-09-2300/el8_amd64_gcc12/llvm-analysis/report-d98050.html#EndPath) . It is true that we [only initialize](https://github.com/cms-sw/cmssw/blob/master/PhysicsTools/MVAComputer/src/ProcMLP.cc#L106-L107) the `tmp` memory for first `iter`number of items. 

This Pr replaces `alloca` with `calloc` which should initialize the memory to `0` and also adds protection to make sure that `maxTmp` is greater than the layer's inputs (otherwise `input[j]` can access out of range memory)


```
  src/PhysicsTools/MVAComputer/src/ProcMLP.cc:117:27: warning: The left operand of '*' is a garbage value [core.UndefinedBinaryOperatorResult]
   117 |           sum += input[j] * *coeff++;
```
