### PR TITLE
New Inputs for D110 And Enabling HIN Phase2 Wf

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_2026.py
+++ b/Configuration/PyReleaseValidation/python/relval_2026.py
@@ -48,7 +48,7 @@ numWFIB.extend([prefixDet+96.0])   #CloseByPGun CE_E_Front_120um
 numWFIB.extend([prefixDet+100.0])  #CloseByPGun CE_H_Coarse_Scint
 numWFIB.extend([prefixDet+61.0])   #Nu Gun
 numWFIB.extend([prefixDet+34.75])  #Timing menu
-#numWFIB.extend([prefixDet+151.85]) #Heavy ion reconstruction
+numWFIB.extend([prefixDet+151.85]) #Heavy ion reconstruction
 #Default Phase-2 Det PU
 numWFIB.extend([prefixDet+261.97])   #premixing stage1 (NuGun+PU)
 numWFIB.extend([prefixDet+234.99])   #premixing combined stage1+stage2 ttbar+PU200

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -4385,7 +4385,7 @@ defaultDataSets['2026D88']='CMSSW_12_3_0_pre5-123X_mcRun4_realistic_v4_2026D88no
 defaultDataSets['2026D95']='CMSSW_13_1_0_pre1-130X_mcRun4_realistic_v2_2026D95noPU-v'
 defaultDataSets['2026D96']='CMSSW_13_1_0_pre1-130X_mcRun4_realistic_v2_2026D96noPU-v'
 defaultDataSets['2026D98']='CMSSW_13_2_0_pre1-131X_mcRun4_realistic_v5_2026D98noPU-v'
-defaultDataSets['2026D110']='CMSSW_14_1_0_pre5-140X_mcRun4_realistic_v4_RegeneratedGS_2026D110_noPU-v'
+defaultDataSets['2026D110']='CMSSW_14_1_0-141X_mcRun4_realistic_v1_STD_RegeneratedGS_2026D110_noPU-v'
 
 puDataSets = {}
 for key, value in defaultDataSets.items(): puDataSets[key+'PU'] = value


### PR DESCRIPTION
#### PR description:

This PR proposes to update the default inputs for D110 wfs to a newer set of `GEN-SIM` (produced in `14_1_0`) and to enable the wfs for HIN Phase2.

#### PR validation:

New inputs works fine.