### PR TITLE
fix Compare / Diff / Ratio by partition plots for SiStrip Payload Inspector plugins

### DIFF
--- a/CondCore/SiStripPlugins/plugins/SiStripNoises_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripNoises_PayloadInspector.cc
@@ -73,21 +73,33 @@ namespace {
     }
   };
 
-  class SiStripNoiseCompareByPartition : public PlotImage<SiStripNoises, MULTI_IOV, 2> {
+  template <int ntags, IOVMultiplicity nIOVs>
+  class SiStripNoiseCompareByPartitionBase : public PlotImage<SiStripNoises, nIOVs, ntags> {
   public:
-    SiStripNoiseCompareByPartition() : PlotImage<SiStripNoises, MULTI_IOV, 2>("SiStrip Compare Noises By Partition") {}
+    SiStripNoiseCompareByPartitionBase()
+        : PlotImage<SiStripNoises, nIOVs, ntags>("SiStrip Compare Noises By Partition") {}
 
     bool fill() override {
       // trick to deal with the multi-ioved tag and two tag case at the same time
       auto theIOVs = PlotBase::getTag<0>().iovs;
       auto tagname1 = PlotBase::getTag<0>().name;
-      auto tag2iovs = PlotBase::getTag<1>().iovs;
-      auto tagname2 = PlotBase::getTag<1>().name;
-      SiStripPI::MetaData firstiov = theIOVs.front();
-      SiStripPI::MetaData lastiov = tag2iovs.front();
+      std::string tagname2{tagname1};
+      auto firstiov = theIOVs.front();
+      SiStripPI::MetaData lastiov;
 
-      std::shared_ptr<SiStripNoises> last_payload = fetchPayload(std::get<1>(lastiov));
-      std::shared_ptr<SiStripNoises> first_payload = fetchPayload(std::get<1>(firstiov));
+      // we don't support (yet) comparison with more than 2 tags
+      assert(this->m_plotAnnotations.ntags < 3);
+
+      if (this->m_plotAnnotations.ntags == 2) {
+        auto tag2iovs = PlotBase::getTag<1>().iovs;
+        tagname2 = PlotBase::getTag<1>().name;
+        lastiov = tag2iovs.front();
+      } else {
+        lastiov = theIOVs.back();
+      }
+
+      std::shared_ptr<SiStripNoises> last_payload = this->fetchPayload(std::get<1>(lastiov));
+      std::shared_ptr<SiStripNoises> first_payload = this->fetchPayload(std::get<1>(firstiov));
 
       SiStripNoiseContainer* l_objContainer = new SiStripNoiseContainer(last_payload, lastiov, tagname1);
       SiStripNoiseContainer* f_objContainer = new SiStripNoiseContainer(first_payload, firstiov, tagname2);
@@ -99,28 +111,42 @@ namespace {
       TCanvas canvas("Partition summary", "partition summary", 1400, 1000);
       l_objContainer->fillByPartition(canvas, 100, 0.1, 10.);
 
-      std::string fileName(m_imageFileName);
+      std::string fileName(this->m_imageFileName);
       canvas.SaveAs(fileName.c_str());
 
       return true;
     }  // fill
   };
 
-  class SiStripNoiseDiffByPartition : public PlotImage<SiStripNoises, MULTI_IOV, 2> {
+  using SiStripNoiseCompareByPartitionSingleTag = SiStripNoiseCompareByPartitionBase<1, MULTI_IOV>;
+  using SiStripNoiseCompareByPartitionTwoTags = SiStripNoiseCompareByPartitionBase<2, SINGLE_IOV>;
+
+  template <int ntags, IOVMultiplicity nIOVs>
+  class SiStripNoiseDiffByPartitionBase : public PlotImage<SiStripNoises, nIOVs, ntags> {
   public:
-    SiStripNoiseDiffByPartition() : PlotImage<SiStripNoises, MULTI_IOV, 2>("SiStrip Diff Noises By Partition") {}
+    SiStripNoiseDiffByPartitionBase() : PlotImage<SiStripNoises, nIOVs, ntags>("SiStrip Diff Noises By Partition") {}
 
     bool fill() override {
       // trick to deal with the multi-ioved tag and two tag case at the same time
       auto theIOVs = PlotBase::getTag<0>().iovs;
       auto tagname1 = PlotBase::getTag<0>().name;
-      auto tag2iovs = PlotBase::getTag<1>().iovs;
-      auto tagname2 = PlotBase::getTag<1>().name;
-      SiStripPI::MetaData firstiov = theIOVs.front();
-      SiStripPI::MetaData lastiov = tag2iovs.front();
+      std::string tagname2{tagname1};
+      auto firstiov = theIOVs.front();
+      SiStripPI::MetaData lastiov;
 
-      std::shared_ptr<SiStripNoises> last_payload = fetchPayload(std::get<1>(lastiov));
-      std::shared_ptr<SiStripNoises> first_payload = fetchPayload(std::get<1>(firstiov));
+      // we don't support (yet) comparison with more than 2 tags
+      assert(this->m_plotAnnotations.ntags < 3);
+
+      if (this->m_plotAnnotations.ntags == 2) {
+        auto tag2iovs = PlotBase::getTag<1>().iovs;
+        tagname2 = PlotBase::getTag<1>().name;
+        lastiov = tag2iovs.front();
+      } else {
+        lastiov = theIOVs.back();
+      }
+
+      std::shared_ptr<SiStripNoises> last_payload = this->fetchPayload(std::get<1>(lastiov));
+      std::shared_ptr<SiStripNoises> first_payload = this->fetchPayload(std::get<1>(firstiov));
 
       SiStripNoiseContainer* l_objContainer = new SiStripNoiseContainer(last_payload, lastiov, tagname1);
       SiStripNoiseContainer* f_objContainer = new SiStripNoiseContainer(first_payload, firstiov, tagname2);
@@ -132,12 +158,15 @@ namespace {
       TCanvas canvas("Partition summary", "partition summary", 1400, 1000);
       l_objContainer->fillByPartition(canvas, 100, -1., 1.);
 
-      std::string fileName(m_imageFileName);
+      std::string fileName(this->m_imageFileName);
       canvas.SaveAs(fileName.c_str());
 
       return true;
     }  // fill
   };
+
+  using SiStripNoiseDiffByPartitionSingleTag = SiStripNoiseDiffByPartitionBase<1, MULTI_IOV>;
+  using SiStripNoiseDiffByPartitionTwoTags = SiStripNoiseDiffByPartitionBase<2, SINGLE_IOV>;
 
   class SiStripNoiseCorrelationByPartition : public PlotImage<SiStripNoises> {
   public:
@@ -1992,8 +2021,10 @@ namespace {
 
 PAYLOAD_INSPECTOR_MODULE(SiStripNoises) {
   PAYLOAD_INSPECTOR_CLASS(SiStripNoiseConsistencyCheck);
-  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseCompareByPartition);
-  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseDiffByPartition);
+  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseCompareByPartitionSingleTag);
+  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseDiffByPartitionSingleTag);
+  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseCompareByPartitionTwoTags);
+  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseDiffByPartitionTwoTags);
   PAYLOAD_INSPECTOR_CLASS(SiStripNoiseCorrelationByPartition);
   PAYLOAD_INSPECTOR_CLASS(SiStripNoisesTest);
   PAYLOAD_INSPECTOR_CLASS(SiStripNoisePerDetId);

--- a/CondCore/SiStripPlugins/scripts/G2GainsValidator.py
+++ b/CondCore/SiStripPlugins/scripts/G2GainsValidator.py
@@ -29,6 +29,7 @@ def getCommandOutput(command):
     err = child.close()
     if err:
         print ('%s failed w/ exit code %d' % (command, err))
+        sys.exit(1)  # This will stop the script immediately with the failure exit code
     return data
 
 ##############################################

--- a/CondCore/SiStripPlugins/scripts/testCompare.sh
+++ b/CondCore/SiStripPlugins/scripts/testCompare.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/bin/bash -e
+
 display_usage() { 
     echo "This script must be run giving the following arguments." 
     echo -e "./testCompare.sh <name of tag> <first IOV> <last IOV> <sqlite file> \n\n"
@@ -6,75 +7,99 @@ display_usage() {
 } 
 
 # if less than two arguments supplied, display usage 
-if [  $# -le 3 ]
-then
+if [  $# -le 3 ]; then
     display_usage
     exit 1
 fi
  
 # check whether user had supplied -h or --help . If yes display usage 
-if [[ ( $# == "--help") ||  $# == "-h" ]]
-then
+if [[ ( "$1" == "--help" ) ||  "$1" == "-h" ]]; then
     display_usage
     exit 0
 fi
 
 # Save current working dir so img can be outputted there later
-W_DIR=$(pwd);
+W_DIR=$(pwd)
 
 STARTIOV=$2
 ENDIOV=$3
 
-source /afs/cern.ch/cms/cmsset_default.sh;
-eval `scram run -sh`;
+source /cvmfs/cms.cern.ch/cmsset_default.sh
+eval "$(scram run -sh)"
+
 # Go back to original working directory
-cd $W_DIR;
+cd "$W_DIR"
 
-plotTypes=(SiStripApvGainsComparatorSingleTag SiStripApvGainsValuesComparatorSingleTag SiStripApvGainsComparatorByRegionSingleTag SiStripApvGainsRatioComparatorByRegionSingleTag SiStripApvGainByPartition)
+plotTypes=(
+    SiStripApvGainsComparatorSingleTag
+    SiStripApvGainsValuesComparatorSingleTag
+    SiStripApvGainsComparatorByRegionSingleTag
+    SiStripApvGainsRatioComparatorByRegionSingleTag
+    SiStripApvGainByPartition
+)
 
-mkdir -p $W_DIR/results_$2-$3
+mkdir -p "$W_DIR/results_$2-$3"
 
-if [ -f *.png ]; then    
+# Remove any existing PNG files
+if ls *.png 1> /dev/null 2>&1; then
     rm *.png
 fi
 
-for i in "${plotTypes[@]}" 
-do
-echo "Making plot ${i}"
-# Run get payload data script
-    getPayloadData.py \
-	--plugin pluginSiStripApvGain_PayloadInspector \
-	--plot plot_${i} \
-	--tag $1 \
-	--time_type Run \
-	--iovs  '{"start_iov": "'$STARTIOV'", "end_iov": "'$ENDIOV'"}' \
-	--db sqlite_file:$4 \
-	--test;
+for i in "${plotTypes[@]}"; do
+    echo "Making plot ${i}"
 
-    mv *.png $W_DIR/results_$2-$3/${i}_$1_$2-$3.png
+    # Run get payload data script
+    getPayloadData.py \
+        --plugin pluginSiStripApvGain_PayloadInspector \
+        --plot plot_${i} \
+        --tag "$1" \
+        --time_type Run \
+        --iovs '{"start_iov": "'$STARTIOV'", "end_iov": "'$ENDIOV'"}' \
+        --db sqlite_file:"$4" \
+        --test
+
+    # Check if the command failed
+    if [ $? -ne 0 ]; then
+        echo "Error in getPayloadData for plot ${i}, exiting..."
+        exit 1
+    fi
+
+    mv *.png "$W_DIR/results_$2-$3/${i}_$1_$2-$3.png"
 done
 
-plotTypes2=(SiStripApvGainCompareByPartition SiStripApvGainDiffByPartition)
+plotTypes2=(
+    SiStripApvGainCompareByPartitionTwoTags
+    SiStripApvGainDiffByPartitionTwoTags
+)
 
-for i in "${plotTypes2[@]}" 
-do
-echo "Making plot ${i}"
-# Run get payload data script
+for i in "${plotTypes2[@]}"; do
+    echo "Making plot ${i}"
+
+    # Run get payload data script
     getPayloadData.py \
-	--plugin pluginSiStripApvGain_PayloadInspector \
-	--plot plot_${i} \
-	--tag $1 \
-	--tagtwo $1 \
-	--time_type Run \
-	--iovs '{"start_iov": "'$STARTIOV'", "end_iov": "'$STARTIOV'"}' \
-	--iovstwo '{"start_iov": "'$ENDIOV'", "end_iov": "'$ENDIOV'"}' \
-	--db sqlite_file:$4 \
-	--test;
+        --plugin pluginSiStripApvGain_PayloadInspector \
+        --plot plot_${i} \
+        --tag "$1" \
+        --tagtwo "$1" \
+        --time_type Run \
+        --iovs '{"start_iov": "'$STARTIOV'", "end_iov": "'$STARTIOV'"}' \
+        --iovstwo '{"start_iov": "'$ENDIOV'", "end_iov": "'$ENDIOV'"}' \
+        --db sqlite_file:"$4" \
+        --test
 
-    mv *.png $W_DIR/results_$2-$3/${i}_$1_$2-$3.png
+    # Check if the command failed
+    if [ $? -ne 0 ]; then
+        echo "Error in getPayloadData for plot ${i}, exiting..."
+        exit 1
+    fi
+
+    mv *.png "$W_DIR/results_$2-$3/${i}_$1_$2-$3.png"
 done
 
-plotTypes3=(SiStripApvGainsAvgDeviationRatioWithPreviousIOVTrackerMap SiStripApvGainsMaxDeviationRatioWithPreviousIOVTrackerMap)
+plotTypes3=(
+    SiStripApvGainsAvgDeviationRatioWithPreviousIOVTrackerMap
+    SiStripApvGainsMaxDeviationRatioWithPreviousIOVTrackerMap
+)
 
 for i in "${plotTypes3[@]}"
 do
@@ -90,8 +115,14 @@ do
 	    --iovs  '{"start_iov": "'$STARTIOV'", "end_iov": "'$ENDIOV'"}' \
 	    --input_params '{"nsigma":"'${j}'"}' \
 	    --db sqlite_file:$4 \
-	    --test;
+	    --test
 
-	mv *.png $W_DIR/results_$2-$3/${i}_${j}sigmas_$1_$2-$3.png
+	# Check if the command failed
+	if [ $? -ne 0 ]; then
+            echo "Error in getPayloadData for plot ${i}, exiting..."
+            exit 1
+	fi
+
+	mv *.png "$W_DIR/results_$2-$3/${i}_${j}sigmas_$1_$2-$3.png"
     done
 done

--- a/CondCore/SiStripPlugins/test/testSiStripPayloadInspector.cpp
+++ b/CondCore/SiStripPlugins/test/testSiStripPayloadInspector.cpp
@@ -70,6 +70,14 @@ int main(int argc, char** argv) {
   histo7.process(connectionString, PI::mk_input(tag, start, end));
   edm::LogPrint("testSiStripPayloadInspector") << histo7.data() << std::endl;
 
+  SiStripApvGainCompareByPartitionSingleTag histoGainByPart;
+  histoGainByPart.process(connectionString, PI::mk_input(tag, start, end));
+  edm::LogPrint("testSiStripPayloadInspector") << histoGainByPart.data() << std::endl;
+
+  SiStripApvGainRatioByPartitionSingleTag histoGainRatioByPart;
+  histoGainRatioByPart.process(connectionString, PI::mk_input(tag, start, end));
+  edm::LogPrint("testSiStripPayloadInspector") << histoGainRatioByPart.data() << std::endl;
+
   // Noise
 
   tag = "SiStripNoise_GR10_v1_hlt";
@@ -100,6 +108,10 @@ int main(int argc, char** argv) {
   histoNoiseCorrelationByPartition.process(connectionString, PI::mk_input(tag, start, start));
   edm::LogPrint("testSiStripPayloadInspector") << histoNoiseCorrelationByPartition.data() << std::endl;
 
+  SiStripNoiseDiffByPartitionSingleTag histoNoiseDiffByPart;
+  histoNoiseDiffByPart.process(connectionString, PI::mk_input(tag, start, end));
+  edm::LogPrint("testSiStripPayloadInspector") << histoNoiseDiffByPart.data() << std::endl;
+
   // Pedestals
 
   tag = "SiStripPedestals_v2_prompt";
@@ -126,6 +138,10 @@ int main(int argc, char** argv) {
   SiStripPedestalCorrelationByPartition histoPedestalCorrelationByPartition;
   histoPedestalCorrelationByPartition.process(connectionString, PI::mk_input(tag, start, start));
   edm::LogPrint("testSiStripPayloadInspector") << histoPedestalCorrelationByPartition.data() << std::endl;
+
+  SiStripPedestalDiffByPartitionSingleTag histoPedDiffByPart;
+  histoPedDiffByPart.process(connectionString, PI::mk_input(tag, start, end));
+  edm::LogPrint("testSiStripPayloadInspector") << histoPedDiffByPart.data() << std::endl;
 
   // Latency
 


### PR DESCRIPTION
#### PR description:

When trying to make some plots related to https://github.com/cms-sw/cmssw/issues/46250 I observed that few of the SiStrip Payload Inspector plots despite being nominally multi-IOV and multi-Tag, e.g.:

https://github.com/cms-sw/cmssw/blob/21636e84e4c3f2016ad6aab147f930e70231810c/CondCore/SiStripPlugins/plugins/SiStripNoises_PayloadInspector.cc#L109

are not allowed to select single IOVs from two different tags from the `cmsDbBrowser` backend, see following screenshots

![Screenshot from 2024-10-12 12-09-07](https://github.com/user-attachments/assets/82525e81-302b-4e34-87c3-0bb39a9261f5)

![Screenshot from 2024-10-12 12-09-17](https://github.com/user-attachments/assets/ce62db2b-9964-4769-9ac1-41768695bc5f)

In absence of a better solution from the `cmsDbBrowser` side, I have split all the affected classes into two versions:
   * one supports a single tag (2 input IOVs) 
   * another one supports two tags (single IOV)
   
I profit of this PR to add these plots in the battery of existing unit tests and to improve the G2 gain validation unit tests.

#### PR validation:

`scram b runtests_testSiStripPayloadInspector` and `scram b runtests_test_G2GainsValidator` run successfully with these updates

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, not to be backported
