### PR TITLE
Improvements to `hltPhase2UpgradeIntegrationTests`

### DIFF
--- a/HLTrigger/Configuration/scripts/hltPhase2UpgradeIntegrationTests
+++ b/HLTrigger/Configuration/scripts/hltPhase2UpgradeIntegrationTests
@@ -28,6 +28,7 @@ def print_help():
     --geometry        : Geometry setting for the CMS process (required)
     --events          : Number of events to process (default: 1)
     --threads         : Number of threads to use (default: 1)
+    --parallelJobs    : Number of parallel cmsRun and hltDiff executions (default: 4)
     --restrictPathsTo : Restrict paths to be run to a user defined subset (e.g. "HLT_Ele*")
     --procModifiers   : Optionally use one (or more) cmssw processModifier
 
@@ -79,6 +80,7 @@ parser.add_argument("--events", type=int, default=10, help="Number of events to 
 parser.add_argument("--parallelJobs", type=int, default=4, help="Number of parallel cmsRun HLT jobs")
 parser.add_argument("--threads", type=int, default=1, help="Number of threads to use")
 parser.add_argument("--restrictPathsTo", nargs='+', default=[], help="List of HLT paths to restrict to")
+parser.add_argument("--cachedInput", default=None, help="Predefined input file to use instead of running TTbar GEN,SIM step")
 parser.add_argument("--procModifiers", default=None, help="Optional process modifier for cmsDriver")  # New argument for procModifiers
 
 # Step 0: Capture the start time and print the start timestamp
@@ -131,14 +133,29 @@ if os.path.exists(output_dir):
 os.makedirs(output_dir)
 
 # Define the cmsDriver.py command to create the base configuration
-base_cmsdriver_command = (
-    f"cmsDriver.py Phase2 -s L1P2GT,HLT:75e33_timing "
-    f"--conditions {global_tag} -n {num_events} --eventcontent FEVTDEBUGHLT "
-    f"--geometry {geometry} --era {era} --filein file:{output_dir}/step1.root --fileout {output_dir}/hlt.root --no_exec "
-    f"--nThreads {num_threads} "
-    f"--customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000 "
-    f'--customise_commands "process.options.wantSummary=True"'
-)
+# If cachedInput is provided, use it as the input for the base cmsDriver command
+if args.cachedInput:
+    print(f"Using cached input file: {args.cachedInput}")
+    base_cmsdriver_command = (
+        f"cmsDriver.py Phase2 -s L1P2GT,HLT:75e33_timing "
+        f"--conditions {global_tag} -n {num_events} --eventcontent FEVTDEBUGHLT "
+        f"--geometry {geometry} --era {era} --filein {args.cachedInput} --fileout {output_dir}/hlt.root --no_exec "
+        f"--mc --nThreads {num_threads} "
+        f"--processName=HLTX "
+        f"--inputCommands='keep *, drop *_hlt*_*_HLT, drop triggerTriggerFilterObjectWithRefs_l1t*_*_HLT' "
+        f"--customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000 "
+        f'--customise_commands "process.options.wantSummary=True"'
+    )
+else:
+    print(f"Using regenerated file from scratch")
+    base_cmsdriver_command = (
+        f"cmsDriver.py Phase2 -s L1P2GT,HLT:75e33_timing "
+        f"--conditions {global_tag} -n {num_events} --eventcontent FEVTDEBUGHLT "
+        f"--geometry {geometry} --era {era} --filein file:{output_dir}/step1.root --fileout {output_dir}/hlt.root --no_exec "
+        f"--nThreads {num_threads} "
+        f"--customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000 "
+        f'--customise_commands "process.options.wantSummary=True"'
+    )
 
 # Add procModifiers if provided
 if proc_modifiers:
@@ -262,8 +279,9 @@ ttbar_command = (
     f"--python_filename {ttbar_config_file}"
 )
 
-print("Running TTbar GEN,SIM step...")
-run_command(ttbar_command, log_file=os.path.join(output_dir, "ttbar_gen_sim.log"))
+if not args.cachedInput:
+    print("Running TTbar GEN,SIM step...")
+    run_command(ttbar_command, log_file=os.path.join(output_dir, "ttbar_gen_sim.log"))
 
 # Directory containing HLT test configurations
 hlt_configs_dir = output_dir

--- a/HLTrigger/Configuration/scripts/hltPhase2UpgradeIntegrationTests
+++ b/HLTrigger/Configuration/scripts/hltPhase2UpgradeIntegrationTests
@@ -31,6 +31,7 @@ def print_help():
     --parallelJobs    : Number of parallel cmsRun and hltDiff executions (default: 4)
     --restrictPathsTo : Restrict paths to be run to a user defined subset (e.g. "HLT_Ele*")
     --procModifiers   : Optionally use one (or more) cmssw processModifier
+    --cachedInput     : Optionally use an existing RAW data file (do not regenerate it from scratch)
 
     Example usage:
     hltPhase2UpgradeIntegrationTests --globaltag auto:phase2_realistic_T33 --geometry Extended2026D110 --events 10 --threads 4
@@ -121,6 +122,10 @@ if restrict_paths_to:
 # Print procModifiers if provided
 if proc_modifiers:
     print(f"Proc Modifiers:       {proc_modifiers}")
+if args.cachedInput:
+    print(f"Using cached input file: {args.cachedInput}")
+else:
+    print(f"Using regenerated GEN-SIM-DIGI-RAW file from scratch")
 print("=" * 40)
 
 # Directory where all test configurations will be stored
@@ -135,7 +140,6 @@ os.makedirs(output_dir)
 # Define the cmsDriver.py command to create the base configuration
 # If cachedInput is provided, use it as the input for the base cmsDriver command
 if args.cachedInput:
-    print(f"Using cached input file: {args.cachedInput}")
     base_cmsdriver_command = (
         f"cmsDriver.py Phase2 -s L1P2GT,HLT:75e33_timing "
         f"--conditions {global_tag} -n {num_events} --eventcontent FEVTDEBUGHLT "
@@ -147,7 +151,6 @@ if args.cachedInput:
         f'--customise_commands "process.options.wantSummary=True"'
     )
 else:
-    print(f"Using regenerated file from scratch")
     base_cmsdriver_command = (
         f"cmsDriver.py Phase2 -s L1P2GT,HLT:75e33_timing "
         f"--conditions {global_tag} -n {num_events} --eventcontent FEVTDEBUGHLT "
@@ -309,7 +312,10 @@ def run_cmsrun(config_file):
     return 0  # Return 0 for success
     
 # Step 8: Loop through all files in hlt_test_configs and run cmsRun on each in parallel
-config_files = [f for f in os.listdir(hlt_configs_dir) if f.endswith(".py") and f.startswith("Phase2_")]
+config_files = [
+    f for f in os.listdir(hlt_configs_dir)
+    if f.endswith(".py") and f.startswith("Phase2_") and f != "Phase2_dump.py"
+]
 print(f"Found {len(config_files)} configuration files in {hlt_configs_dir}.")
 
 # Run cmsRun on all config files in parallel and handle errors


### PR DESCRIPTION
#### PR description:

This PR packages a couple of minor improvements to the `hltPhase2UpgradeIntegrationTests` utility.
   * 228ce134f6b53eb48fa41442378d7952da8c7850 allows usage of cached RAW input data in the test
   * 51874701c3bdeb6e680b19d9904d1c6019fa0ec6 do not run twice the full menu (after having dumped it with `edmConfigDump`)

No regressions are expected, just a small speedup of the execution.

#### PR validation:

Run successfully the following script:

```bash
#!/bin/bash

# Exit the script immediately if any command fails
set -e

# Enable pipefail to propagate the exit status of the entire pipeline
set -o pipefail

# Define the dataset
DATASET="/RelValTTbar_14TeV/CMSSW_14_1_0_pre6-PU_141X_mcRun4_realistic_v1_STD_2026D110_PU-v3/GEN-SIM-DIGI-RAW"

# Fetch the list of files in the dataset
FILES=( $(dasgoclient -query="file dataset=${DATASET}" --limit=-1) )

# Loop through each file in the FILES array and pass it as --cachedInput
for FILE in "${FILES[@]}"; do
  echo "Running HLT test with cached input file: ${FILE}"
  
  hltPhase2UpgradeIntegrationTests \
    --parallelJobs 4 \
    --threads 4 \
    --cachedInput "$FILE" \
    --restrictPathsTo "HLT_IsoMu20_eta2p1_LooseDeepTauPFTauHPS27_eta2p1_CrossL1*"

  # Check if the test failed for a particular file
  if [ $? -ne 0 ]; then
    echo "Error occurred with input file: $FILE"
    exit 1  # Exit the loop if any command fails
  fi
done
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, not to be backported