### PR TITLE
DQM: restore Muon POG sequence (and CSC Monitor), revert #46293

### DIFF
--- a/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
@@ -115,7 +115,7 @@ DQMOffline_SecondStep_PrePOG = cms.Sequence( DQMOffline_SecondStepTracking *
 
 
 DQMOffline_SecondStep_PrePOG_Express = cms.Sequence( DQMOffline_SecondStepTracking *
-                                             #DQMOffline_SecondStepMUO *
+                                             DQMOffline_SecondStepMUO *
                                              #DQMOffline_SecondStepEGamma *
                                              DQMOffline_SecondStepTrigger *
                                              DQMOffline_SecondStepBTag *

--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -158,7 +158,7 @@ DQMOfflinePrePOG = cms.Sequence( DQMOfflineTracking *
 
 
 DQMOfflinePrePOGExpress = cms.Sequence( DQMOfflineTracking *
-                                 #DQMOfflineMUO *
+                                 DQMOfflineMUO *
                                  #DQMOfflineJetMET *
                                  #DQMOfflineEGamma *
                                  DQMOfflineTrigger *


### PR DESCRIPTION
#### PR description:

#46293 has involuntarily removed CSC Monitor DQM output while trying to reduce the memory footprint of DQM harvesting by switching off apparently not crucial muon POG output. This PR simply restores the previous situation to prevent the loss of CSC information, while preparing a better alternative solution

#### PR validation:

Trivial revert to the previous situation of the affected sequences.