### PR TITLE
[Backport 140X] DQM: restore Muon POG sequence (and CSC Monitor), revert #46298

### DIFF
--- a/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
@@ -115,7 +115,7 @@ DQMOffline_SecondStep_PrePOG = cms.Sequence( DQMOffline_SecondStepTracking *
 
 
 DQMOffline_SecondStep_PrePOG_Express = cms.Sequence( DQMOffline_SecondStepTracking *
-                                             #DQMOffline_SecondStepMUO *
+                                             DQMOffline_SecondStepMUO *
                                              #DQMOffline_SecondStepEGamma *
                                              DQMOffline_SecondStepTrigger *
                                              DQMOffline_SecondStepBTag *

--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -158,7 +158,7 @@ DQMOfflinePrePOG = cms.Sequence( DQMOfflineTracking *
 
 
 DQMOfflinePrePOGExpress = cms.Sequence( DQMOfflineTracking *
-                                 #DQMOfflineMUO *
+                                 DQMOfflineMUO *
                                  #DQMOfflineJetMET *
                                  #DQMOfflineEGamma *
                                  DQMOfflineTrigger *


### PR DESCRIPTION
#### PR description:

Effective backport of #46293 to 140X

#### PR validation:

Simple revert of previous to previously running code.