### PR TITLE
[UBSAN][L1] Fix read out of bounds issue

### DIFF
--- a/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h
+++ b/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h
@@ -1251,10 +1251,10 @@ inline p2eg::clusterInfo p2eg::getBremsValuesNeg(p2eg::crystal tempX[p2eg::CRYST
   }
 
   // Read the energies of the input crystal tempX into the slightly larger array temp, with an offset so temp is tempX
-  // except shifted in +1 in eta and +7 in phi
+  // except shifted in +1 in eta and +4 in phi
   for (int i = 0; i < (p2eg::CRYSTAL_IN_ETA); i++) {
     for (int j = 0; j < (p2eg::CRYSTAL_IN_PHI - 1); j++) {
-      temp[i + 1][j + 7] = tempX[i][j].energy;
+      temp[i + 1][j + 4] = tempX[i][j].energy;
     }
   }
 
@@ -1264,33 +1264,31 @@ inline p2eg::clusterInfo p2eg::getBremsValuesNeg(p2eg::crystal tempX[p2eg::CRYST
 
   // Loop over the shifted array, and at the original location of the seed (seed_eta1/seed_phi1),
   // read a 3 (eta) x 5 (phi) rectangle of crystals where the original location of the seed is in the bottom left corner
-  for (int j = 0; j < p2eg::CRYSTAL_IN_ETA; j++) {
-    if (j == seed_eta1) {
-      for (int k = 0; k < p2eg::CRYSTAL_IN_PHI; k++) {
-        if (k == seed_phi1) {
-          // Same eta as the seed, read next five crystals in phi
-          phi0eta[0] = temp[j][k];
-          phi1eta[0] = temp[j][k + 1];
-          phi2eta[0] = temp[j][k + 2];
-          phi3eta[0] = temp[j][k + 3];
-          phi4eta[0] = temp[j][k + 4];
+  if (seed_eta1 < p2eg::CRYSTAL_IN_ETA) {
+    if (seed_phi1 < p2eg::CRYSTAL_IN_PHI) {
+      int j = seed_eta1;
+      int k = seed_phi1;
 
-          // +1 eta from the seed, read next five crystals in phi
-          phi0eta[1] = temp[j + 1][k];
-          phi1eta[1] = temp[j + 1][k + 1];
-          phi2eta[1] = temp[j + 1][k + 2];
-          phi3eta[1] = temp[j + 1][k + 3];
-          phi4eta[1] = temp[j + 1][k + 4];
+      // Same eta as the seed, read next five crystals in phi
+      phi0eta[0] = temp[j][k];
+      phi1eta[0] = temp[j][k + 1];
+      phi2eta[0] = temp[j][k + 2];
+      phi3eta[0] = temp[j][k + 3];
+      phi4eta[0] = temp[j][k + 4];
 
-          // +2 eta from the seed, read next five crystals in phi
-          phi0eta[2] = temp[j + 2][k];
-          phi1eta[2] = temp[j + 2][k + 1];
-          phi2eta[2] = temp[j + 2][k + 2];
-          phi3eta[2] = temp[j + 2][k + 3];
-          phi4eta[2] = temp[j + 2][k + 4];
-          continue;
-        }
-      }
+      // +1 eta from the seed, read next five crystals in phi
+      phi0eta[1] = temp[j + 1][k];
+      phi1eta[1] = temp[j + 1][k + 1];
+      phi2eta[1] = temp[j + 1][k + 2];
+      phi3eta[1] = temp[j + 1][k + 3];
+      phi4eta[1] = temp[j + 1][k + 4];
+
+      // +2 eta from the seed, read next five crystals in phi
+      phi0eta[2] = temp[j + 2][k];
+      phi1eta[2] = temp[j + 2][k + 1];
+      phi2eta[2] = temp[j + 2][k + 2];
+      phi3eta[2] = temp[j + 2][k + 3];
+      phi4eta[2] = temp[j + 2][k + 4];
     }
   }
 
@@ -1339,48 +1337,45 @@ inline p2eg::clusterInfo p2eg::getClusterValues(p2eg::crystal tempX[p2eg::CRYSTA
   // now we are in the left bottom corner
   // Loop over the shifted array, and at the original location of the seed (seed_eta1/seed_phi1),
   // read a 5 (eta) x 5 (phi) rectangle of crystals where the original location of the seed is in the bottom left corner
-  for (int j = 0; j < p2eg::CRYSTAL_IN_ETA; j++) {
-    if (j == seed_eta1) {
-      for (int k = 0; k < p2eg::CRYSTAL_IN_PHI; k++) {
-        if (k == seed_phi1) {
-          // Same eta as the seed, read next five crystals in phi
-          phi0eta[0] = temp[j][k];
-          phi1eta[0] = temp[j][k + 1];
-          phi2eta[0] = temp[j][k + 2];
-          phi3eta[0] = temp[j][k + 3];
-          phi4eta[0] = temp[j][k + 4];
+  if (seed_eta1 < p2eg::CRYSTAL_IN_ETA) {
+    if (seed_phi1 < p2eg::CRYSTAL_IN_PHI) {
+      int j = seed_eta1;
+      int k = seed_phi1;
 
-          // +1 eta from the seed, read next five crystals in phi
-          phi0eta[1] = temp[j + 1][k];
-          phi1eta[1] = temp[j + 1][k + 1];
-          phi2eta[1] = temp[j + 1][k + 2];
-          phi3eta[1] = temp[j + 1][k + 3];
-          phi4eta[1] = temp[j + 1][k + 4];
+      // Same eta as the seed, read next five crystals in phi
+      phi0eta[0] = temp[j][k];
+      phi1eta[0] = temp[j][k + 1];
+      phi2eta[0] = temp[j][k + 2];
+      phi3eta[0] = temp[j][k + 3];
+      phi4eta[0] = temp[j][k + 4];
 
-          // +2 eta from the seed, read next five crystals in phi
-          phi0eta[2] = temp[j + 2][k];
-          phi1eta[2] = temp[j + 2][k + 1];
-          phi2eta[2] = temp[j + 2][k + 2];
-          phi3eta[2] = temp[j + 2][k + 3];
-          phi4eta[2] = temp[j + 2][k + 4];
+      // +1 eta from the seed, read next five crystals in phi
+      phi0eta[1] = temp[j + 1][k];
+      phi1eta[1] = temp[j + 1][k + 1];
+      phi2eta[1] = temp[j + 1][k + 2];
+      phi3eta[1] = temp[j + 1][k + 3];
+      phi4eta[1] = temp[j + 1][k + 4];
 
-          // +3 eta from the seed, read next five crystals in phi
-          phi0eta[3] = temp[j + 3][k];
-          phi1eta[3] = temp[j + 3][k + 1];
-          phi2eta[3] = temp[j + 3][k + 2];
-          phi3eta[3] = temp[j + 3][k + 3];
-          phi4eta[3] = temp[j + 3][k + 4];
+      // +2 eta from the seed, read next five crystals in phi
+      phi0eta[2] = temp[j + 2][k];
+      phi1eta[2] = temp[j + 2][k + 1];
+      phi2eta[2] = temp[j + 2][k + 2];
+      phi3eta[2] = temp[j + 2][k + 3];
+      phi4eta[2] = temp[j + 2][k + 4];
 
-          // +4 eta from the seed, read next five crystals in phi
-          phi0eta[4] = temp[j + 4][k];
-          phi1eta[4] = temp[j + 4][k + 1];
-          phi2eta[4] = temp[j + 4][k + 2];
-          phi3eta[4] = temp[j + 4][k + 3];
-          phi4eta[4] = temp[j + 4][k + 4];
+      // +3 eta from the seed, read next five crystals in phi
+      phi0eta[3] = temp[j + 3][k];
+      phi1eta[3] = temp[j + 3][k + 1];
+      phi2eta[3] = temp[j + 3][k + 2];
+      phi3eta[3] = temp[j + 3][k + 3];
+      phi4eta[3] = temp[j + 3][k + 4];
 
-          continue;
-        }
-      }
+      // +4 eta from the seed, read next five crystals in phi
+      phi0eta[4] = temp[j + 4][k];
+      phi1eta[4] = temp[j + 4][k + 1];
+      phi2eta[4] = temp[j + 4][k + 2];
+      phi3eta[4] = temp[j + 4][k + 3];
+      phi4eta[4] = temp[j + 4][k + 4];
     }
   }
 


### PR DESCRIPTION
This should fix the UBSAN error like [a]. There are few issues with this code
- It allocates a temp ` ap_uint<12> temp[p2eg::CRYSTAL_IN_ETA + 2][p2eg::CRYSTAL_IN_PHI + 4];` but then assign value to  `temp[CRYSTAL_IN_ETA + 1][CRYSTAL_IN_PHI + 7]`. 
- Loop https://github.com/cms-sw/cmssw/blob/master/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h#L1267-L1295 only reads values for `seed eta and phi` so I think there is no need to loop over every item
- Same as loop https://github.com/cms-sw/cmssw/blob/master/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h#L1342-L1385. 
- Todo: Finally we only read temp memory for `seed eta and phi` + some offset. So we do not need to allocate `temp[p2eg::CRYSTAL_IN_ETA + 2][p2eg::CRYSTAL_IN_PHI + 4];` a smaller memory just to hold the values for  `seed eta and phi` + some offset should be enough.

I am opening this PR but would like @cms-sw/l1-l2  to review this code and may be propose a batter change



[a]  https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/raw/el8_amd64_gcc12/CMSSW_14_2_UBSAN_X_2024-10-11-2300/pyRelValMatrixLogs/run/23634.0_TTbar_14TeV+2026D95/step2_TTbar_14TeV+2026D95.log
```
src/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h:1257:24: runtime error: index 25 out of bounds for type 'ap_uint [24]'
    #0 0x14e16aba5450 in p2eg::getBremsValuesNeg(p2eg::crystal (*) [20], ap_uint<5>, ap_uint<5>) src/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h:1257
    #1 0x14e16abedbad in p2eg::getClusterFromRegion3x4(p2eg::crystal (*) [20]) src/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h:1441
    #2 0x14e16aa9cd7c in Phase2L1CaloEGammaEmulator::produce(edm::Event&, edm::EventSetup const&) src/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloEGammaEmulator.cc:337
```