### PR TITLE
Fix Wdangling-reference (probably after merging #46200)

### DIFF
--- a/CalibPPS/ESProducers/plugins/CTPPSCompositeESSource.cc
+++ b/CalibPPS/ESProducers/plugins/CTPPSCompositeESSource.cc
@@ -322,9 +322,8 @@ void CTPPSCompositeESSource::buildOptics(const edm::ParameterSet &profile, Profi
   std::vector<FileInfo> fileInfo;
 
   for (const auto &pset : ctppsOpticalFunctions.getParameter<std::vector<edm::ParameterSet>>("opticalFunctions")) {
-    const double &xangle = pset.getParameter<double>("xangle");
-    const std::string &fileName = pset.getParameter<edm::FileInPath>("fileName").fullPath();
-    fileInfo.push_back({xangle, fileName});
+    fileInfo.emplace_back(pset.getParameter<double>("xangle"),
+                          pset.getParameter<edm::FileInPath>("fileName").fullPath());
   }
 
   struct RPInfo {
@@ -335,11 +334,8 @@ void CTPPSCompositeESSource::buildOptics(const edm::ParameterSet &profile, Profi
   std::unordered_map<unsigned int, RPInfo> rpInfo;
 
   for (const auto &pset : ctppsOpticalFunctions.getParameter<std::vector<edm::ParameterSet>>("scoringPlanes")) {
-    const unsigned int rpId = pset.getParameter<unsigned int>("rpId");
-    const std::string dirName = pset.getParameter<std::string>("dirName");
-    const double z = pset.getParameter<double>("z");
-    const RPInfo entry = {dirName, z};
-    rpInfo.emplace(rpId, entry);
+    rpInfo.emplace(pset.getParameter<unsigned int>("rpId"),
+                   RPInfo{pset.getParameter<std::string>("dirName"), pset.getParameter<double>("z")});
   }
 
   for (const auto &fi : fileInfo) {
@@ -412,11 +408,10 @@ void CTPPSCompositeESSource::buildLHCInfo(const edm::ParameterSet &profile, Prof
     for (int y = 1; y <= h_xangle_beta_star->GetNbinsY(); ++y) {
       const double w = h_xangle_beta_star->GetBinContent(h_xangle_beta_star->GetBin(x, y)) / sum;
       if (w > 0.) {
-        pData.xangleBetaStarBins.push_back(
-            {cw,
-             cw + w,
-             std::pair<double, double>(h_xangle_beta_star->GetXaxis()->GetBinCenter(x),
-                                       h_xangle_beta_star->GetYaxis()->GetBinCenter(y))});
+        pData.xangleBetaStarBins.emplace_back(cw,
+                                              cw + w,
+                                              std::make_pair(h_xangle_beta_star->GetXaxis()->GetBinCenter(x),
+                                                             h_xangle_beta_star->GetYaxis()->GetBinCenter(y)));
         cw += w;
       }
     }

--- a/CalibPPS/ESProducers/plugins/CTPPSOpticalFunctionsESSource.cc
+++ b/CalibPPS/ESProducers/plugins/CTPPSOpticalFunctionsESSource.cc
@@ -62,18 +62,14 @@ CTPPSOpticalFunctionsESSource::CTPPSOpticalFunctionsESSource(const edm::Paramete
 
     std::vector<FileInfo> fileInfo;
     for (const auto &pset : entry_pset.getParameter<std::vector<edm::ParameterSet>>("opticalFunctions")) {
-      const double &xangle = pset.getParameter<double>("xangle");
-      const std::string &fileName = pset.getParameter<edm::FileInPath>("fileName").fullPath();
-      fileInfo.push_back({xangle, fileName});
+      fileInfo.emplace_back(pset.getParameter<double>("xangle"),
+                            pset.getParameter<edm::FileInPath>("fileName").fullPath());
     }
 
     std::unordered_map<unsigned int, RPInfo> rpInfo;
     for (const auto &pset : entry_pset.getParameter<std::vector<edm::ParameterSet>>("scoringPlanes")) {
-      const unsigned int rpId = pset.getParameter<unsigned int>("rpId");
-      const std::string dirName = pset.getParameter<std::string>("dirName");
-      const double z = pset.getParameter<double>("z");
-      const RPInfo entry = {dirName, z};
-      rpInfo.emplace(rpId, entry);
+      rpInfo.emplace(pset.getParameter<unsigned int>("rpId"),
+                     RPInfo{pset.getParameter<std::string>("dirName"), pset.getParameter<double>("z")});
     }
 
     m_entries.push_back({validityRange, fileInfo, rpInfo});

--- a/HeterogeneousCore/SonicTriton/src/TritonClient.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonClient.cc
@@ -98,7 +98,7 @@ TritonClient::TritonClient(const edm::ParameterSet& params, const std::string& d
   //get fixed parameters from local config
   inference::ModelConfig localModelConfig;
   {
-    const std::string& localModelConfigPath(params.getParameter<edm::FileInPath>("modelConfigPath").fullPath());
+    const std::string localModelConfigPath(params.getParameter<edm::FileInPath>("modelConfigPath").fullPath());
     int fileDescriptor = open(localModelConfigPath.c_str(), O_RDONLY);
     if (fileDescriptor < 0)
       throw TritonException("LocalFailure")


### PR DESCRIPTION
#### PR description:

gcc13 warns about storing reference to temporary:

```
>> Compiling edm plugin src/CalibPPS/ESProducers/plugins/PPSTimingCalibrationLUTESSource.cc
(...)
src/CalibPPS/ESProducers/plugins/CTPPSOpticalFunctionsESSource.cc: In constructor 'CTPPSOpticalFunctionsESSource::CTPPSOpticalFunctionsESSource(const edm::ParameterSet&)':
  src/CalibPPS/ESProducers/plugins/CTPPSOpticalFunctionsESSource.cc:66:26: warning: possibly dangling reference to a temporary [-Wdangling-reference]
    66 |       const std::string &fileName = pset.getParameter<edm::FileInPath>("fileName").fullPath();
      |                          ^~~~~~~~
src/CalibPPS/ESProducers/plugins/CTPPSOpticalFunctionsESSource.cc:66:92: note: the temporary was destroyed at the end of the full expression 'edm::ParameterSet::getParameter(const char*) const [with T = edm::FileInPath](((const char*)"fileName")).edm::FileInPath::fullPath()'
   66 |       const std::string &fileName = pset.getParameter<edm::FileInPath>("fileName").fullPath();
      |                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
>> Compiling edm plugin src/CalibPPS/ESProducers/plugins/PrintTotemDAQMapping.cc
(...)
src/CalibPPS/ESProducers/plugins/CTPPSCompositeESSource.cc: In member function 'void CTPPSCompositeESSource::buildOptics(const edm::ParameterSet&, ProfileData&)':
  src/CalibPPS/ESProducers/plugins/CTPPSCompositeESSource.cc:326:24: warning: possibly dangling reference to a temporary [-Wdangling-reference]
   326 |     const std::string &fileName = pset.getParameter<edm::FileInPath>("fileName").fullPath();
      |                        ^~~~~~~~
src/CalibPPS/ESProducers/plugins/CTPPSCompositeESSource.cc:326:90: note: the temporary was destroyed at the end of the full expression 'edm::ParameterSet::getParameter(const char*) const [with T = edm::FileInPath](((const char*)"fileName")).edm::FileInPath::fullPath()'
  326 |     const std::string &fileName = pset.getParameter<edm::FileInPath>("fileName").fullPath();
      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
```

```
src/HeterogeneousCore/SonicTriton/src/TritonClient.cc: In constructor 'TritonClient::TritonClient(const edm::ParameterSet&, const std::string&)':
  src/HeterogeneousCore/SonicTriton/src/TritonClient.cc:101:24: warning: possibly dangling reference to a temporary [-Wdangling-reference]
   101 |     const std::string& localModelConfigPath(params.getParameter<edm::FileInPath>("modelConfigPath").fullPath());
      |                        ^~~~~~~~~~~~~~~~~~~~
src/HeterogeneousCore/SonicTriton/src/TritonClient.cc:101:109: note: the temporary was destroyed at the end of the full expression 'edm::ParameterSet::getParameter(const char*) const [with T = edm::FileInPath](((const char*)"modelConfigPath")).edm::FileInPath::fullPath()'
  101 |     const std::string& localModelConfigPath(params.getParameter<edm::FileInPath>("modelConfigPath").fullPath());
      |                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
```

#### PR validation:

Please test