### PR TITLE
Add ByLS DQM plots for ES [14_1_X]

### DIFF
--- a/DQM/EcalPreshowerMonitorModule/interface/ESIntegrityTask.h
+++ b/DQM/EcalPreshowerMonitorModule/interface/ESIntegrityTask.h
@@ -9,12 +9,12 @@
 #include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 
-struct ESLSCache {
+struct ESIntLSCache {
   int ievtLS_;
-  int DIErrorsLS_[2][2][40][40];
+  int DIErrorsByLS_[2][2][40][40];
 };
 
-class ESIntegrityTask : public DQMOneEDAnalyzer<edm::LuminosityBlockCache<ESLSCache>> {
+class ESIntegrityTask : public DQMOneEDAnalyzer<edm::LuminosityBlockCache<ESIntLSCache>> {
 public:
   ESIntegrityTask(const edm::ParameterSet& ps);
   ~ESIntegrityTask() override {}
@@ -32,8 +32,8 @@ protected:
   void dqmEndRun(const edm::Run& r, const edm::EventSetup& c) override;
 
   /// Begin Lumi
-  std::shared_ptr<ESLSCache> globalBeginLuminosityBlock(const edm::LuminosityBlock& lumi,
-                                                        const edm::EventSetup& c) const override;
+  std::shared_ptr<ESIntLSCache> globalBeginLuminosityBlock(const edm::LuminosityBlock& lumi,
+                                                           const edm::EventSetup& c) const override;
 
   /// End Lumi
   void globalEndLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup& c) override;
@@ -52,20 +52,25 @@ private:
   MonitorElement* meGain_;
   MonitorElement* meFED_;
   MonitorElement* meSLinkCRCErr_;
+  MonitorElement* meSLinkCRCErrByLS_;
   MonitorElement* meDCCErr_;
   MonitorElement* meDCCCRCErr_;
+  MonitorElement* meDCCCRCErrByLS_;
   MonitorElement* meOptoRX_;
   MonitorElement* meOptoBC_;
+  MonitorElement* meOptoBCByLS_;
   MonitorElement* meFiberBadStatus_;
   MonitorElement* meFiberErrCode_;
+  MonitorElement* meFiberErrCodeByLS_;
   MonitorElement* meFiberOff_;
+  MonitorElement* meFiberOffByLS_;
   MonitorElement* meEVDR_;
   MonitorElement* meKF1_;
   MonitorElement* meKF2_;
   MonitorElement* meKBC_;
   MonitorElement* meKEC_;
   MonitorElement* meDIErrors_[2][2];
-  MonitorElement* meDIErrorsLS_[2][2];
+  MonitorElement* meDIErrorsByLS_[2][2];
   MonitorElement* meDIFraction_;
 
   edm::FileInPath lookup_;

--- a/DQM/EcalPreshowerMonitorModule/interface/ESOccupancyTask.h
+++ b/DQM/EcalPreshowerMonitorModule/interface/ESOccupancyTask.h
@@ -7,21 +7,33 @@
 
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 
-class ESOccupancyTask : public DQMOneEDAnalyzer<> {
+struct ESOccLSCache {
+  int ievtLS_;
+};
+
+class ESOccupancyTask : public DQMOneEDAnalyzer<edm::LuminosityBlockCache<ESOccLSCache>> {
 public:
   ESOccupancyTask(const edm::ParameterSet& ps);
   ~ESOccupancyTask() override {}
 
-private:
+protected:
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
+  /// Begin Lumi
+  std::shared_ptr<ESOccLSCache> globalBeginLuminosityBlock(const edm::LuminosityBlock& lumi,
+                                                           const edm::EventSetup& c) const override;
+  /// End Lumi
+  void globalEndLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup& c) override;
+
+private:
   // ----------member data ---------------------------
   edm::EDGetTokenT<ESRecHitCollection> rechittoken_;
   std::string prefixME_;
 
   MonitorElement* hRecOCC_[2][2];
   MonitorElement* hSelOCC_[2][2];
+  MonitorElement* hSelOCCByLS_[2][2];
   MonitorElement* hRecNHit_[2][2];
   MonitorElement* hEnDensity_[2][2];
   MonitorElement* hSelEnDensity_[2][2];

--- a/DQM/EcalPreshowerMonitorModule/interface/ESRawDataTask.h
+++ b/DQM/EcalPreshowerMonitorModule/interface/ESRawDataTask.h
@@ -9,8 +9,13 @@
 
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 
-class ESRawDataTask : public DQMEDAnalyzer {
+struct ESRawLSCache {
+  int ievtLS_;
+};
+
+class ESRawDataTask : public DQMOneEDAnalyzer<edm::LuminosityBlockCache<ESRawLSCache>> {
 public:
   ESRawDataTask(const edm::ParameterSet& ps);
   ~ESRawDataTask() override {}
@@ -22,6 +27,12 @@ protected:
   /// Setup
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
 
+  /// Begin Lumi
+  std::shared_ptr<ESRawLSCache> globalBeginLuminosityBlock(const edm::LuminosityBlock& lumi,
+                                                           const edm::EventSetup& c) const override;
+  /// End Lumi
+  void globalEndLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup& c) override;
+
 private:
   int ievt_;
 
@@ -30,10 +41,12 @@ private:
   edm::EDGetTokenT<ESRawDataCollection> dccCollections_;
   edm::EDGetTokenT<FEDRawDataCollection> FEDRawDataCollection_;
 
-  //MonitorElement* meRunNumberErrors_;
   MonitorElement* meL1ADCCErrors_;
+  MonitorElement* meL1ADCCErrorsByLS_;
   MonitorElement* meBXDCCErrors_;
+  MonitorElement* meBXDCCErrorsByLS_;
   MonitorElement* meOrbitNumberDCCErrors_;
+  MonitorElement* meOrbitNumberDCCErrorsByLS_;
   MonitorElement* meL1ADiff_;
   MonitorElement* meBXDiff_;
   MonitorElement* meOrbitNumberDiff_;

--- a/DQM/EcalPreshowerMonitorModule/python/ESIntegrityTask_cfi.py
+++ b/DQM/EcalPreshowerMonitorModule/python/ESIntegrityTask_cfi.py
@@ -7,6 +7,6 @@ ecalPreshowerIntegrityTask = DQMEDAnalyzer('ESIntegrityTask',
                                             ESDCCCollections = cms.InputTag("ecalPreshowerDigis"),
                                             ESKChipCollections = cms.InputTag("ecalPreshowerDigis"),
                                             OutputFile = cms.untracked.string(""),
-                                            DoLumiAnalysis = cms.bool(False)
+                                            DoLumiAnalysis = cms.bool(True)
                                             )
 


### PR DESCRIPTION
#### PR description:

This PR adds plots in EcalPreshower (ES) DQM : lumi-section (LS) based DQM plots in the new category of "ByLumiSection" ES DQM.

Full list of ES DQM plots added in the new ByLS plots is as follows:
```
EcalPreshower>ESIntegrityTask:
- Fiber error code
- Fiber off
- Integrity error
- ES OptoRX BC mismatch
- ES Slink CRC errors

EcalPreshower>ESOccupancyTask:
- ES occupancy with selected hits

EcalPreshower>ESRawDataTask:
- ES Orbit number DCC errors
- ES BX DCC errors
- ES L1A DCC errors 
```

#### PR validation:

PR is validated by running the ES online DQM configuration and verifying the plots on a test DQM GUI. 

<img width="1436" alt="ES_ByLS_DQM" src="https://github.com/user-attachments/assets/d800194f-b2ae-457b-b4f6-fcf6c8fdc94b">

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is the backport to `14_1_X`. Master PR is #46348 and backports to `14_0_X` is made in #46349