### PR TITLE
[UBSAN] Initialize PerigeeTrajectoryError::weightIsAvailable

### DIFF
--- a/TrackingTools/TrajectoryParametrization/interface/PerigeeTrajectoryError.h
+++ b/TrackingTools/TrajectoryParametrization/interface/PerigeeTrajectoryError.h
@@ -13,7 +13,7 @@
 
 class PerigeeTrajectoryError {
 public:
-  PerigeeTrajectoryError() {}
+  PerigeeTrajectoryError() : weightIsAvailable(false) {}
   // ~PerigeeTrajectoryError() {}
 
   /*


### PR DESCRIPTION
Initialize PerigeeTrajectoryError::weightIsAvailable for default constructor. This should fix  UBSAN runtime errors [a]

[a] https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/raw/el8_amd64_gcc12/CMSSW_14_2_UBSAN_X_2024-10-11-2300/pyRelValMatrixLogs/run/13234.0_TTbar_14TeV+2021FS/step2_TTbar_14TeV+2021FS.log
```
TrackingTools/TrajectoryParametrization/interface/PerigeeTrajectoryError.h:14:7: runtime error: load of value 124, which is not a valid value for type 'bool'
```

```
TrackingTools/TrajectoryState/interface/TrajectoryStateClosestToPoint.h:18:7: runtime error: load of value 58, which is not a valid value for type 'bool'

```