### PR TITLE
[Core] Mark cms::Exception and edm::Exception functions that throw exceptions as noreturn

### DIFF
--- a/FWCore/Utilities/interface/EDMException.h
+++ b/FWCore/Utilities/interface/EDMException.h
@@ -103,18 +103,18 @@ namespace edm {
 
     static const std::string& codeToString(Code);
 
-    static void throwThis(Code category,
-                          char const* message0 = "",
-                          char const* message1 = "",
-                          char const* message2 = "",
-                          char const* message3 = "",
-                          char const* message4 = "");
-    static void throwThis(Code category, char const* message0, int intVal, char const* message2 = "");
+    [[noreturn]] static void throwThis(Code category,
+                                       char const* message0 = "",
+                                       char const* message1 = "",
+                                       char const* message2 = "",
+                                       char const* message3 = "",
+                                       char const* message4 = "");
+    [[noreturn]] static void throwThis(Code category, char const* message0, int intVal, char const* message2 = "");
 
     Exception* clone() const override;
 
   private:
-    void rethrow() override;
+    [[noreturn]] void rethrow() override;
     int returnCode_() const override;
 
     Code category_;

--- a/FWCore/Utilities/interface/Exception.h
+++ b/FWCore/Utilities/interface/Exception.h
@@ -80,7 +80,7 @@ namespace cms {
     std::list<std::string> const& additionalInfo() const;
     int returnCode() const;
 
-    [[noreturn]] void raise() { rethrow(); }
+    void raise() { rethrow(); }
 
     void append(Exception const& another);
     void append(std::string const& more_information);

--- a/FWCore/Utilities/interface/Exception.h
+++ b/FWCore/Utilities/interface/Exception.h
@@ -80,7 +80,7 @@ namespace cms {
     std::list<std::string> const& additionalInfo() const;
     int returnCode() const;
 
-    void raise() { rethrow(); }
+    [[noreturn]] void raise() { rethrow(); }
 
     void append(Exception const& another);
     void append(std::string const& more_information);
@@ -132,7 +132,7 @@ namespace cms {
 
   private:
     void init(std::string const& message);
-    virtual void rethrow();
+    [[noreturn]] virtual void rethrow();
     virtual int returnCode_() const;
 
     // data members

--- a/FWCore/Utilities/interface/ExceptionCollector.h
+++ b/FWCore/Utilities/interface/ExceptionCollector.h
@@ -35,7 +35,7 @@ namespace edm {
     ExceptionCollector(std::string const& initialMessage);
     ~ExceptionCollector();
     bool hasThrown() const;
-    [[noreturn]] void rethrow() const;
+    void rethrow() const;
     void call(std::function<void(void)>);
     void addException(cms::Exception const& exception);
 

--- a/FWCore/Utilities/interface/ExceptionCollector.h
+++ b/FWCore/Utilities/interface/ExceptionCollector.h
@@ -35,7 +35,7 @@ namespace edm {
     ExceptionCollector(std::string const& initialMessage);
     ~ExceptionCollector();
     bool hasThrown() const;
-    void rethrow() const;
+    [[noreturn]] void rethrow() const;
     void call(std::function<void(void)>);
     void addException(cms::Exception const& exception);
 


### PR DESCRIPTION
#### PR description:

This should hopefully solve LLVM analyzer warnings like this: [link](https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_14_2_X_2024-10-13-0000/el8_amd64_gcc12/llvm-analysis/report-8c63da.html#EndPath)

#### PR validation:

Bot tests
