### PR TITLE
Update a few MC Gts in autoCond to the latest version available on 14/10/2024 - CMSSW_14_1_X

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -66,7 +66,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2022
     'phase1_2022_design'           :    '140X_mcRun3_2022_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2022
-    'phase1_2022_realistic'        :    '140X_mcRun3_2022_realistic_v9',
+    'phase1_2022_realistic'        :    '140X_mcRun3_2022_realistic_v11',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 post-EE+ leak
     'phase1_2022_realistic_postEE' :    '140X_mcRun3_2022_realistic_postEE_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2022, Strip tracker in DECO mode
@@ -78,7 +78,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2023
     'phase1_2023_design'           :    '140X_mcRun3_2023_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        :    '140X_mcRun3_2023_realistic_v6',
+    'phase1_2023_realistic'        :    '140X_mcRun3_2023_realistic_v7',
     # GlobalTag for MC production with realistic conditions for Phase1 postBPix issue 2023
     'phase1_2023_realistic_postBPix'  : '140X_mcRun3_2023_realistic_postBPix_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 preBPix 2023, Strip tracker in DECO mode
@@ -92,17 +92,17 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2024
     'phase1_2024_design'           :    '140X_mcRun3_2024_design_v11',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        :    '140X_mcRun3_2024_realistic_v25',
+    'phase1_2024_realistic'        :    '140X_mcRun3_2024_realistic_v26',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2024, Strip tracker in DECO mode
     'phase1_2024_cosmics'          :    '140X_mcRun3_2024cosmics_realistic_deco_v14',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2024, Strip tracker in DECO mode
     'phase1_2024_cosmics_design'   :    '140X_mcRun3_2024cosmics_design_deco_v11',
     # GlobalTag for MC production with realistic conditions for Phase1 2024 detector for Heavy Ion
-    'phase1_2024_realistic_hi'     :    '141X_mcRun3_2024_realistic_HI_v5',
+    'phase1_2024_realistic_hi'     :    '141X_mcRun3_2024_realistic_HI_v8',
     # GlobalTag for MC production with realistic conditions for Phase1 2024 detector for ppRef5TeV
-    'phase1_2024_realistic_ppRef5TeV'     :    '141X_mcRun3_2024_realistic_ppRef5TeV_v4',
+    'phase1_2024_realistic_ppRef5TeV'     :    '141X_mcRun3_2024_realistic_ppRef5TeV_v5',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             :    '141X_mcRun4_realistic_v2'
+    'phase2_realistic'             :    '141X_mcRun4_realistic_v3'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:

The following GTs are updated in autoCond (in some cases they are not yet the final ones, but they can be tested as such in the IBs).

- `phase1_2022_realistic` : [140X_mcRun3_2022_realistic_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/140X_mcRun3_2022_realistic_v10)
  - Difference with previous version in confDB (v9) is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2022_realistic_v11/140X_mcRun3_2022_realistic_v9) and it comprises:
     - Update Tracker alignment (same as the one for the 2023 MC, as for https://cms-talk.web.cern.ch/t/call-for-conditions-full-2022-2023-data-rereco-and-mc-production-in-140x/32887/41) and the corresponding BeamSpot (see https://cms-talk.web.cern.ch/t/call-for-conditions-full-2022-2023-data-rereco-and-mc-production-in-140x/32887/45)
     - Update (fix) the SiStripBadComponents tag as for https://cms-talk.web.cern.ch/t/call-for-conditions-full-2022-2023-data-rereco-and-mc-production-in-140x/32887/47
- `phase1_2023_realistic`: [140X_mcRun3_2023_realistic_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/140X_mcRun3_2023_realistic_v7)
   - Difference with previous version in confDB (v6) is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2023_realistic_v7/140X_mcRun3_2023_realistic_v6) and it comprises:
      - Update the SiStripBadComponents tag as for https://cms-talk.web.cern.ch/t/call-for-conditions-full-2022-2023-data-rereco-and-mc-production-in-140x/32887/47
- `phase1_2024_realistic`: [140X_mcRun3_2024_realistic_v26](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/140X_mcRun3_2024_realistic_v26)
   - Difference with previous version in confDB (v25) is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2024_realistic_v26/140X_mcRun3_2024_realistic_v25) and it comprises:
      - Fix the `EcalLaserAPDPNRatios_2024_outliers_cleaned_3sigma_mc` with the correct `EcalLasrtAPDPNRatiosRcd` (while it had been previously wrongly uploaded in the `EcalLaserAPDPNRatiosMCRcd`)
- `phase1_2024_realistic_hi`: [141X_mcRun3_2024_realistic_HI_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/141X_mcRun3_2024_realistic_HI_v8)
   - Difference with previous version in confDB (v5) is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/141X_mcRun3_2024_realistic_HI_v8/141X_mcRun3_2024_realistic_HI_v5) and it comprises:
      - Update L1T menu to L1Menu_CollisionsHeavyIons2024_v1_0_5_xml, see https://cms-talk.web.cern.ch/t/gt-mc-update-of-l1t-menu-v1-0-0-in-pbpb-mc-gt-for-14-1-x/51295/13
      - Update tags to synchronize with the pp ref MC, see https://cms-talk.web.cern.ch/t/gt-mc-update-of-l1t-menu-v1-0-0-in-pbpb-mc-gt-for-14-1-x/51295/8
- `phase1_2024_realistic_ppRef5TeV`: [141X_mcRun3_2024_realistic_ppRef5TeV_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/141X_mcRun3_2024_realistic_ppRef5TeV_v5)
   - Difference with previous version in confDB (v4) is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/141X_mcRun3_2024_realistic_ppRef5TeV_v5/141X_mcRun3_2024_realistic_ppRef5TeV_v4) and it comprises:
      - Fix the `EcalLaserAPDPNRatios_2024_outliers_cleaned_3sigma_mc` with the correct `EcalLasrtAPDPNRatiosRcd` (while it had been previously wrongly uploaded in the `EcalLaserAPDPNRatiosMCRcd`)
- `phase2_realistic`: [141X_mcRun4_realistic_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/141X_mcRun4_realistic_v3)
   - Difference with previous version in confDB (v2) is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/141X_mcRun4_realistic_v3/141X_mcRun4_realistic_v2) and it comprises:
      - Remove geometry tags to address a reported source of confusion caused by geometry mismatch crashes due to Phase 1 ideal simulation / reconstruction geometry present in the Phase 2 GTs, see https://cms-talk.web.cern.ch/t/mc-request-for-updates-to-the-phase2-realistic-gt/51430/6

Backport of #46379