### PR TITLE
Add dedxLikelihood to 2023 UPC rereco

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
@@ -124,7 +124,7 @@ from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
 from PhysicsTools.PatAlgos.modules import DeDxEstimatorRekeyer
 dedxEstimator = DeDxEstimatorRekeyer()
 from Configuration.Eras.Modifier_run3_egamma_2023_cff import run3_egamma_2023
-(run3_upc & ~run3_egamma_2023).toModify(dedxEstimator, dedxEstimators = ["dedxHarmonic2", "dedxPixelHarmonic2", "dedxPixelLikelihood", "dedxStripLikelihood", "dedxAllLikelihood"])
+run3_upc.toModify(dedxEstimator, dedxEstimators = ["dedxHarmonic2", "dedxPixelHarmonic2", "dedxPixelLikelihood", "dedxStripLikelihood", "dedxAllLikelihood"])
 run3_upc.toReplaceWith(slimmingTask, cms.Task(slimmingTask.copy(), hiPixelTracks, packedPFCandidateTrackChi2, lostTrackChi2, dedxEstimator))
 
 from Configuration.Eras.Modifier_ppRef_2024_cff import ppRef_2024

--- a/RecoTracker/DeDx/python/dedxEstimators_cff.py
+++ b/RecoTracker/DeDx/python/dedxEstimators_cff.py
@@ -116,4 +116,4 @@ dedxPixelLikelihood = dedxAllLikelihood.clone(UseStrip = False, UsePixel = True)
 dedxStripLikelihood = dedxAllLikelihood.clone(UseStrip = True,  UsePixel = False)
 
 from Configuration.Eras.Modifier_run3_egamma_2023_cff import run3_egamma_2023
-(run3_upc & ~run3_egamma_2023).toReplaceWith(doAlldEdXEstimatorsTask, cms.Task(doAlldEdXEstimatorsTask.copy(), dedxHitCalibrator, dedxStripLikelihood, dedxPixelLikelihood, dedxAllLikelihood))
+run3_upc.toReplaceWith(doAlldEdXEstimatorsTask, cms.Task(doAlldEdXEstimatorsTask.copy(), dedxHitCalibrator, dedxStripLikelihood, dedxPixelLikelihood, dedxAllLikelihood))


### PR DESCRIPTION
#### PR description:

This PR adds the dEdx derived using the likelihood fit introduced in https://github.com/cms-sw/cmssw/pull/45016 in the Run3 2023 UPC era for the 2024 re-reconstruction (using 14_1_X) of 2023 HIForward data.

@mandrenguyen 

#### PR validation:

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
To be backported to 14_1_X