### PR TITLE
[14_1_X] Added more ZDC functionality to DQM

### DIFF
--- a/DQM/HcalTasks/interface/ZDCQIE10Task.h
+++ b/DQM/HcalTasks/interface/ZDCQIE10Task.h
@@ -9,24 +9,87 @@
  */
 
 #include "DQM/HcalCommon/interface/ElectronicsMap.h"
+#include "DQM/HcalTasks/interface/DigiTask.h"
+#include "DQM/HcalCommon/interface/DQTask.h"
+#include "DQM/HcalCommon/interface/Utilities.h"
+#include "DQM/HcalCommon/interface/HashFilter.h"
+#include "DQM/HcalCommon/interface/Container1D.h"
+#include "DQM/HcalCommon/interface/Container2D.h"
+#include "DQM/HcalCommon/interface/ContainerProf1D.h"
+#include "DQM/HcalCommon/interface/ContainerProf2D.h"
+#include "DQM/HcalCommon/interface/ContainerSingle1D.h"
+#include "DQM/HcalCommon/interface/ContainerSingle2D.h"
+#include "DQM/HcalCommon/interface/ContainerSingleProf2D.h"
+#include "DQM/HcalCommon/interface/Constants.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class ZDCQIE10Task : public DQMEDAnalyzer {
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+
+#include "CondFormats/L1TObjects/interface/CaloParams.h"
+#include "CondFormats/DataRecord/interface/L1TCaloParamsRcd.h"
+
+#include "DataFormats/L1TCalorimeter/interface/CaloTower.h"
+#include "DataFormats/L1TCalorimeter/interface/CaloCluster.h"
+#include "DataFormats/L1Trigger/interface/EGamma.h"
+#include "DataFormats/L1Trigger/interface/Tau.h"
+#include "DataFormats/L1Trigger/interface/Jet.h"
+#include "DataFormats/L1Trigger/interface/EtSum.h"
+#include "CondFormats/HcalObjects/interface/HcalLongRecoParams.h"
+#include "CondFormats/HcalObjects/interface/HcalLongRecoParam.h"
+
+class ZDCQIE10Task : public hcaldqm::DQTask {
 public:
-  ZDCQIE10Task(edm::ParameterSet const&);
+  ZDCQIE10Task(edm::ParameterSet const &);
   ~ZDCQIE10Task() override {}
 
-  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  //    std::shared_ptr<hcaldqm::Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const &,
+  //							       edm::EventSetup const &) const override;
+  //void globalEndLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) override;
 
 protected:
-  void analyze(edm::Event const&, edm::EventSetup const&) override;
+  void _process(edm::Event const &, edm::EventSetup const &) override;
 
   //	tags
   edm::InputTag _tagQIE10;
+  edm::InputTag sumTag;
   edm::EDGetTokenT<QIE10DigiCollection> _tokQIE10;
+  edm::ESGetToken<HcalDbService, HcalDbRecord> hcalDbServiceToken_;
+  edm::EDGetToken sumToken_;
+  edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> htopoToken_;
+  edm::ESGetToken<HcalLongRecoParams, HcalLongRecoParamsRcd> paramsToken_;
+  //edm::EDGetTokenT<l1t::EtSumBxCollection> sumZDCToken_;
+
+  //emap
+  hcaldqm::electronicsmap::ElectronicsMap _ehashmap;  // online only
 
   //	hcaldqm::Containers
-  std::map<uint32_t, MonitorElement*> _cADC_EChannel;
-  std::map<uint32_t, MonitorElement*> _cADC_vs_TS_EChannel;
+  std::map<uint32_t, MonitorElement *> _cADC_EChannel;
+  std::map<uint32_t, MonitorElement *> _cADC_vs_TS_EChannel;
+  std::map<uint32_t, MonitorElement *> _cDigiSize_Crate;
+  std::map<uint32_t, MonitorElement *> _cDigiSize_FED;
+  std::map<uint32_t, MonitorElement *> _cADC_PM;
+  std::map<uint32_t, MonitorElement *> _cADC_vs_TS_PM;
+  std::map<uint32_t, MonitorElement *> _cOccupancy_FEDuTCA;
+  std::map<uint32_t, MonitorElement *> _cOccupancy_ElectronicsuTCA;
+  std::map<uint32_t, MonitorElement *> _cOccupancy_Crate;
+  std::map<uint32_t, MonitorElement *> _cOccupancy_CrateSlot;
+  std::map<uint32_t, MonitorElement *> _cZDC_SUMS;
+  std::map<uint32_t, MonitorElement *> _cZDC_BXSUMS;
+  std::map<uint32_t, MonitorElement *> _cZDC_BX_EmuSUMS;
+  std::map<uint32_t, MonitorElement *> _cZDC_CapIDS;
+  std::map<uint32_t, MonitorElement *> _cfC_EChannel;
+  std::map<uint32_t, MonitorElement *> _cTDC_EChannel;
+  std::map<uint32_t, MonitorElement *> _cfC_vs_TS_EChannel;
+  std::map<uint32_t, MonitorElement *> _cZDC_HAD_TM;
+  std::map<uint32_t, MonitorElement *> _cZDC_EM_TM;
+
+  std::unique_ptr<HcalLongRecoParams> longRecoParams_;
 };
 
 #endif

--- a/DQM/HcalTasks/interface/ZDCQIE10Task.h
+++ b/DQM/HcalTasks/interface/ZDCQIE10Task.h
@@ -48,9 +48,6 @@ public:
   ~ZDCQIE10Task() override {}
 
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  //    std::shared_ptr<hcaldqm::Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const &,
-  //							       edm::EventSetup const &) const override;
-  //void globalEndLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) override;
 
 protected:
   void _process(edm::Event const &, edm::EventSetup const &) override;
@@ -63,7 +60,6 @@ protected:
   edm::EDGetToken sumToken_;
   edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> htopoToken_;
   edm::ESGetToken<HcalLongRecoParams, HcalLongRecoParamsRcd> paramsToken_;
-  //edm::EDGetTokenT<l1t::EtSumBxCollection> sumZDCToken_;
 
   //emap
   hcaldqm::electronicsmap::ElectronicsMap _ehashmap;  // online only

--- a/DQM/HcalTasks/interface/ZDCQIE10Task.h
+++ b/DQM/HcalTasks/interface/ZDCQIE10Task.h
@@ -9,26 +9,9 @@
  */
 
 #include "DQM/HcalCommon/interface/ElectronicsMap.h"
-#include "DQM/HcalTasks/interface/DigiTask.h"
 #include "DQM/HcalCommon/interface/DQTask.h"
-#include "DQM/HcalCommon/interface/Utilities.h"
-#include "DQM/HcalCommon/interface/HashFilter.h"
-#include "DQM/HcalCommon/interface/Container1D.h"
-#include "DQM/HcalCommon/interface/Container2D.h"
-#include "DQM/HcalCommon/interface/ContainerProf1D.h"
-#include "DQM/HcalCommon/interface/ContainerProf2D.h"
-#include "DQM/HcalCommon/interface/ContainerSingle1D.h"
-#include "DQM/HcalCommon/interface/ContainerSingle2D.h"
-#include "DQM/HcalCommon/interface/ContainerSingleProf2D.h"
-#include "DQM/HcalCommon/interface/Constants.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-#include "FWCore/ServiceRegistry/interface/Service.h"
-#include "CommonTools/UtilAlgos/interface/TFileService.h"
 
 #include "CondFormats/L1TObjects/interface/CaloParams.h"
 #include "CondFormats/DataRecord/interface/L1TCaloParamsRcd.h"

--- a/DQM/HcalTasks/plugins/BuildFile.xml
+++ b/DQM/HcalTasks/plugins/BuildFile.xml
@@ -2,4 +2,5 @@
 <use name="PhysicsTools/ONNXRuntime"/>
 <use name="rootmath"/>
 <use name="DQM/HcalTasks"/>
+<use name="DataFormats/L1Trigger"/>
 <flags EDM_PLUGIN="1"/>

--- a/DQM/HcalTasks/plugins/ZDCQIE10Task.cc
+++ b/DQM/HcalTasks/plugins/ZDCQIE10Task.cc
@@ -1,116 +1,529 @@
-
 #include "DQM/HcalTasks/interface/ZDCQIE10Task.h"
+using namespace std;
+using namespace hcaldqm;
+using namespace hcaldqm::constants;
+using namespace hcaldqm::filter;
 
-ZDCQIE10Task::ZDCQIE10Task(edm::ParameterSet const& ps) {
-  //	tags
+ZDCQIE10Task::ZDCQIE10Task(edm::ParameterSet const& ps)
+
+    : DQTask(ps), hcalDbServiceToken_(esConsumes<HcalDbService, HcalDbRecord, edm::Transition::BeginRun>()) {
+  //tags
   _tagQIE10 = ps.getUntrackedParameter<edm::InputTag>("tagQIE10", edm::InputTag("hcalDigis", "ZDC"));
   _tokQIE10 = consumes<QIE10DigiCollection>(_tagQIE10);
+
+  //const edm::EDGetTokenT<l1t::EtSumBxCollection> sumZDCToken_;
+
+  sumTag = ps.getUntrackedParameter<edm::InputTag>("etSumTag", edm::InputTag("etSumZdcProducer", ""));
+  //sumTag = ps.getParameter<edm::InputTag>("etSumTag");
+  sumToken_ = consumes<l1t::EtSumBxCollection>(sumTag);
+  //sumZDCToken_ = consumes<l1t::EtSumBxCollection>(ps.getUntrackedParameter<edm::InputTag>("sumZDCToken"));
+
+  htopoToken_ = esConsumes<HcalTopology, HcalRecNumberingRecord>();
+  paramsToken_ = esConsumes<HcalLongRecoParams, HcalLongRecoParamsRcd>();
 }
 
 /* virtual */ void ZDCQIE10Task::bookHistograms(DQMStore::IBooker& ib, edm::Run const& r, edm::EventSetup const& es) {
+  DQTask::bookHistograms(ib, r, es);
   ib.cd();
+  edm::ESHandle<HcalDbService> dbs = es.getHandle(hcalDbServiceToken_);
+  _emap = dbs->getHcalMapping();
+  // Book LED calibration channels from emap
+  std::vector<HcalElectronicsId> eids = _emap->allElectronicsId();
+  _ehashmap.initialize(_emap, electronicsmap::fD2EHashMap);
+
+  //    BOOK HISTOGRAMS
+  std::string histoname;
+  histoname = "Crate28";
+  ib.setCurrentFolder("Hcal/ZDCQIE10Task/DigiSize");
+  _cDigiSize_Crate[0] = ib.book1DD(histoname.c_str(), histoname.c_str(), 21, -0.5, 20.5);
+  _cDigiSize_Crate[0]->setAxisTitle("DigiSize", 1);
+  _cDigiSize_Crate[0]->setAxisTitle("N", 2);
+
+  histoname = "FED1136";
+  ib.setCurrentFolder("Hcal/ZDCQIE10Task/DigiSize");
+  _cDigiSize_FED[0] = ib.book1DD(histoname.c_str(), histoname.c_str(), 21, -0.5, 20.5);
+  _cDigiSize_FED[0]->setAxisTitle("DigiSize", 1);
+  _cDigiSize_FED[0]->setAxisTitle("N", 2);
+
+  histoname = "ZDCM";
+  ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC");
+  _cADC_PM[0] = ib.book1DD(histoname.c_str(), histoname.c_str(), 256, 0, 256);
+  _cADC_PM[0]->setAxisTitle("ADC", 1);
+  _cADC_PM[0]->setAxisTitle("N", 2);
+
+  histoname = "ZDCP";
+  ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC");
+  _cADC_PM[1] = ib.book1DD(histoname.c_str(), histoname.c_str(), 256, 0, 256);
+  _cADC_PM[1]->setAxisTitle("ADC", 1);
+  _cADC_PM[1]->setAxisTitle("N", 2);
+
+  histoname = "ZDCM";
+  ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADCvsTS");
+  _cADC_vs_TS_PM[0] = ib.book2DD(histoname.c_str(), histoname.c_str(), 6, 0, 6, 256, 0, 256);
+  _cADC_vs_TS_PM[0]->setAxisTitle("TS", 1);
+  _cADC_vs_TS_PM[0]->setAxisTitle("ADC", 2);
+
+  histoname = "ZDCP";
+  ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADCvsTS");
+  _cADC_vs_TS_PM[1] = ib.book2DD(histoname.c_str(), histoname.c_str(), 6, 0, 6, 256, 0, 256);
+  _cADC_vs_TS_PM[1]->setAxisTitle("TS", 1);
+  _cADC_vs_TS_PM[1]->setAxisTitle("ADC", 2);
+
+  histoname = "Crate28";
+  ib.setCurrentFolder("Hcal/ZDCQIE10Task/Occupancy/Crate");
+  _cOccupancy_Crate[0] = ib.book2DD(histoname.c_str(), histoname.c_str(), 12, 0, 12, 144, 0, 144);
+  _cOccupancy_Crate[0]->setAxisTitle("SlotuTCA", 1);
+  _cOccupancy_Crate[0]->setAxisTitle("FiberuTCAFiberCh", 2);
+
+  histoname = "Crate28S3";
+  ib.setCurrentFolder("Hcal/ZDCQIE10Task/Occupancy/CrateSlote");
+  _cOccupancy_CrateSlot[0] = ib.book2DD(histoname.c_str(), histoname.c_str(), 24, 0, 24, 6, 0, 6);
+  _cOccupancy_CrateSlot[0]->setAxisTitle("SlotuTCA", 1);
+  _cOccupancy_CrateSlot[0]->setAxisTitle("FiberCh", 2);
+
+  histoname = "uTCA_for_FED1136";
+  ib.setCurrentFolder("Hcal/ZDCQIE10Task/Occupancy/Electronics");
+  _cOccupancy_ElectronicsuTCA[0] = ib.book1DD(histoname.c_str(), histoname.c_str(), 12, 0, 12);
+  _cOccupancy_ElectronicsuTCA[0]->setAxisTitle("N", 1);
+  _cOccupancy_ElectronicsuTCA[0]->setAxisTitle("SlotuTCA", 1);
+
+  histoname = "ZDCP_Sum";
+  ib.setCurrentFolder("Hcal/ZDCQIE10Task/Sums");
+  _cZDC_SUMS[1] = ib.book1DD(histoname.c_str(), histoname.c_str(), 100, -1, 5000);
+  _cZDC_SUMS[1]->setAxisTitle("GeV", 1);
+  _cZDC_SUMS[1]->setAxisTitle("N", 2);
+
+  histoname = "ZDCM_Sum";
+  ib.setCurrentFolder("Hcal/ZDCQIE10Task/Sums");
+  _cZDC_SUMS[0] = ib.book1DD(histoname.c_str(), histoname.c_str(), 100, -1, 5000);
+  _cZDC_SUMS[0]->setAxisTitle("GeV", 1);
+  _cZDC_SUMS[0]->setAxisTitle("N", 2);
+
+  histoname = "ZDCM_SumBX";
+  ib.setCurrentFolder("Hcal/ZDCQIE10Task/Sums");
+  _cZDC_BXSUMS[0] = ib.book1DD(histoname.c_str(), histoname.c_str(), 3500, 0, 3500);
+  _cZDC_BXSUMS[0]->setAxisTitle("globalBX", 1);
+  _cZDC_BXSUMS[0]->setAxisTitle("GeV", 2);
+
+  histoname = "ZDCP_SumBX";
+  ib.setCurrentFolder("Hcal/ZDCQIE10Task/Sums");
+  _cZDC_BXSUMS[1] = ib.book1DD(histoname.c_str(), histoname.c_str(), 3500, 0, 3500);
+  _cZDC_BXSUMS[1]->setAxisTitle("globalBX", 1);
+  _cZDC_BXSUMS[1]->setAxisTitle("GeV", 2);
+
+  histoname = "ZDCM_EmuSumBX";
+  ib.setCurrentFolder("Hcal/ZDCQIE10Task/Sums");
+  _cZDC_BX_EmuSUMS[0] = ib.book1DD(histoname.c_str(), histoname.c_str(), 3500, 0, 3500);
+  _cZDC_BX_EmuSUMS[0]->setAxisTitle("globalBX", 1);
+  _cZDC_BX_EmuSUMS[0]->setAxisTitle("0-255 weighted output", 2);
+
+  histoname = "ZDCP_EmuSumBX";
+  ib.setCurrentFolder("Hcal/ZDCQIE10Task/Sums");
+  _cZDC_BX_EmuSUMS[1] = ib.book1DD(histoname.c_str(), histoname.c_str(), 3500, 0, 3500);
+  _cZDC_BX_EmuSUMS[1]->setAxisTitle("globalBX", 1);
+  _cZDC_BX_EmuSUMS[1]->setAxisTitle("0-255 weighted output", 2);
+
+  histoname = "CapIDs";
+  ib.setCurrentFolder("Hcal/ZDCQIE10Task");
+  _cZDC_CapIDS[0] = ib.book1DD(histoname.c_str(), histoname.c_str(), 4, 0, 4);
+  _cZDC_CapIDS[0]->setAxisTitle("CapID", 1);
+  _cZDC_CapIDS[0]->setAxisTitle("N", 2);
+
+  histoname = "EM_M_Timings";
+  ib.setCurrentFolder("Hcal/ZDCQIE10Task");
+  _cZDC_EM_TM[0] = ib.book1DD(histoname.c_str(), histoname.c_str(), 10, 1, 11);
+  _cZDC_EM_TM[0]->setAxisTitle("Channel", 1);
+  _cZDC_EM_TM[0]->setAxisTitle("N", 2);
+  _cZDC_EM_TM[0]->setBinLabel(1, "EM_M_1 good timing");
+  _cZDC_EM_TM[0]->setBinLabel(2, "EM_M_1 bad timing");
+  _cZDC_EM_TM[0]->setBinLabel(3, "EM_M_2 good timing");
+  _cZDC_EM_TM[0]->setBinLabel(4, "EM_M_2 bad timing");
+  _cZDC_EM_TM[0]->setBinLabel(5, "EM_M_3 good timing");
+  _cZDC_EM_TM[0]->setBinLabel(6, "EM_M_3 bad timing");
+  _cZDC_EM_TM[0]->setBinLabel(7, "EM_M_4 good timing");
+  _cZDC_EM_TM[0]->setBinLabel(8, "EM_M_4 bad timing");
+  _cZDC_EM_TM[0]->setBinLabel(9, "EM_M_5 good timing");
+  _cZDC_EM_TM[0]->setBinLabel(10, "EM_M_5 bad timing");
+
+  histoname = "EM_P_Timings";
+  ib.setCurrentFolder("Hcal/ZDCQIE10Task");
+  _cZDC_EM_TM[1] = ib.book1DD(histoname.c_str(), histoname.c_str(), 10, 1, 11);
+  _cZDC_EM_TM[1]->setAxisTitle("Channel", 1);
+  _cZDC_EM_TM[1]->setAxisTitle("N", 2);
+  _cZDC_EM_TM[1]->setBinLabel(1, "EM_P_1 good timing");
+  _cZDC_EM_TM[1]->setBinLabel(2, "EM_P_1 bad timing");
+  _cZDC_EM_TM[1]->setBinLabel(3, "EM_P_2 good timing");
+  _cZDC_EM_TM[1]->setBinLabel(4, "EM_P_2 bad timing");
+  _cZDC_EM_TM[1]->setBinLabel(5, "EM_P_3 good timing");
+  _cZDC_EM_TM[1]->setBinLabel(6, "EM_P_3 bad timing");
+  _cZDC_EM_TM[1]->setBinLabel(7, "EM_P_4 good timing");
+  _cZDC_EM_TM[1]->setBinLabel(8, "EM_P_4 bad timing");
+  _cZDC_EM_TM[1]->setBinLabel(9, "EM_P_5 good timing");
+  _cZDC_EM_TM[1]->setBinLabel(10, "EM_P_5 bad timing");
+
+  histoname = "HAD_M_Timings";
+  ib.setCurrentFolder("Hcal/ZDCQIE10Task");
+  _cZDC_HAD_TM[0] = ib.book1DD(histoname.c_str(), histoname.c_str(), 8, 1, 9);
+  _cZDC_HAD_TM[0]->setAxisTitle("Channel", 1);
+  _cZDC_HAD_TM[0]->setAxisTitle("N", 2);
+  _cZDC_HAD_TM[0]->setBinLabel(1, "HAD_M_1 good timing");
+  _cZDC_HAD_TM[0]->setBinLabel(2, "HAD_M_1 bad timing");
+  _cZDC_HAD_TM[0]->setBinLabel(3, "HAD_M_2 good timing");
+  _cZDC_HAD_TM[0]->setBinLabel(4, "HAD_M_2 bad timing");
+  _cZDC_HAD_TM[0]->setBinLabel(5, "HAD_M_3 good timing");
+  _cZDC_HAD_TM[0]->setBinLabel(6, "HAD_M_3 bad timing");
+  _cZDC_HAD_TM[0]->setBinLabel(7, "HAD_M_4 good timing");
+  _cZDC_HAD_TM[0]->setBinLabel(8, "HAD_M_4 bad timing");
+
+  histoname = "HAD_P_Timings";
+  ib.setCurrentFolder("Hcal/ZDCQIE10Task");
+  _cZDC_HAD_TM[1] = ib.book1DD(histoname.c_str(), histoname.c_str(), 8, 1, 9);
+  _cZDC_HAD_TM[1]->setAxisTitle("Channel", 1);
+  _cZDC_HAD_TM[1]->setAxisTitle("N", 2);
+  _cZDC_HAD_TM[1]->setBinLabel(1, "HAD_P_1 good timing");
+  _cZDC_HAD_TM[1]->setBinLabel(2, "HAD_P_1 bad timing");
+  _cZDC_HAD_TM[1]->setBinLabel(3, "HAD_P_2 good timing");
+  _cZDC_HAD_TM[1]->setBinLabel(4, "HAD_P_2 bad timing");
+  _cZDC_HAD_TM[1]->setBinLabel(5, "HAD_P_3 good timing");
+  _cZDC_HAD_TM[1]->setBinLabel(6, "HAD_P_3 bad timing");
+  _cZDC_HAD_TM[1]->setBinLabel(7, "HAD_P_4 good timing");
+  _cZDC_HAD_TM[1]->setBinLabel(8, "HAD_P_4 bad timing");
 
   //book histos per channel
-  std::string histoname;
+  //std::string histoname;
   for (int channel = 1; channel < 6; channel++) {
     // EM Pos
     HcalZDCDetId didp(HcalZDCDetId::EM, true, channel);
-    histoname = "EM_P_" + std::to_string(channel) + "_1";
+
+    histoname = "EM_P_" + std::to_string(channel);
     ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_perChannel");
     _cADC_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 256, 0, 256);
     _cADC_EChannel[didp()]->setAxisTitle("ADC", 1);
     _cADC_EChannel[didp()]->setAxisTitle("N", 2);
     ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_vs_TS_perChannel");
-    _cADC_vs_TS_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 10, 0, 10);
+    _cADC_vs_TS_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 6, 0, 6);
     _cADC_vs_TS_EChannel[didp()]->setAxisTitle("TS", 1);
     _cADC_vs_TS_EChannel[didp()]->setAxisTitle("sum ADC", 2);
 
+    histoname = "EM_P_" + std::to_string(channel);
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/fC_perChannel");
+    _cfC_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 100, 0, 8000);
+    _cfC_EChannel[didp()]->setAxisTitle("fC", 1);
+    _cfC_EChannel[didp()]->setAxisTitle("N", 2);
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/fC_vs_TS_perChannel");
+    _cfC_vs_TS_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 6, 0, 6);
+    _cfC_vs_TS_EChannel[didp()]->setAxisTitle("TS", 1);
+    _cfC_vs_TS_EChannel[didp()]->setAxisTitle("sum fC", 2);
+
+    histoname = "EM_P_" + std::to_string(channel);
+    _cTDC_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 50, 1, 50);
+    _cTDC_EChannel[didp()]->setAxisTitle("TDC", 1);
+    _cTDC_EChannel[didp()]->setAxisTitle("N", 2);
+
     // EM Minus
     HcalZDCDetId didm(HcalZDCDetId::EM, false, channel);
-    histoname = "EM_M_" + std::to_string(channel) + "_1";
+
+    histoname = "EM_M_" + std::to_string(channel);
     ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_perChannel");
     _cADC_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 256, 0, 256);
     _cADC_EChannel[didm()]->setAxisTitle("ADC", 1);
     _cADC_EChannel[didm()]->setAxisTitle("N", 2);
     ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_vs_TS_perChannel");
-    _cADC_vs_TS_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 10, 0, 10);
+    _cADC_vs_TS_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 6, 0, 6);
     _cADC_vs_TS_EChannel[didm()]->setAxisTitle("TS", 1);
     _cADC_vs_TS_EChannel[didm()]->setAxisTitle("sum ADC", 2);
+
+    histoname = "EM_M_" + std::to_string(channel);
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/fC_perChannel");
+    _cfC_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 100, 0, 8000);
+    _cfC_EChannel[didm()]->setAxisTitle("fC", 1);
+    _cfC_EChannel[didm()]->setAxisTitle("N", 2);
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/fC_vs_TS_perChannel");
+    _cfC_vs_TS_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 6, 0, 6);
+    _cfC_vs_TS_EChannel[didm()]->setAxisTitle("TS", 1);
+    _cfC_vs_TS_EChannel[didm()]->setAxisTitle("sum fC", 2);
+
+    histoname = "EM_M_" + std::to_string(channel);
+    _cTDC_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 50, 1, 50);
+    _cTDC_EChannel[didm()]->setAxisTitle("TDC", 1);
+    _cTDC_EChannel[didm()]->setAxisTitle("N", 2);
   }
 
   for (int channel = 1; channel < 5; channel++) {
     // HAD Pos
     HcalZDCDetId didp(HcalZDCDetId::HAD, true, channel);
-    histoname = "HAD_P_" + std::to_string(channel) + "_" + std::to_string(channel + 2);
+
+    histoname = "HAD_P_" + std::to_string(channel);
     ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_perChannel");
     _cADC_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 256, 0, 256);
     _cADC_EChannel[didp()]->setAxisTitle("ADC", 1);
     _cADC_EChannel[didp()]->setAxisTitle("N", 2);
     ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_vs_TS_perChannel");
-    _cADC_vs_TS_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 10, 0, 10);
+    _cADC_vs_TS_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 6, 0, 6);
     _cADC_vs_TS_EChannel[didp()]->setAxisTitle("TS", 1);
     _cADC_vs_TS_EChannel[didp()]->setAxisTitle("sum ADC", 2);
 
+    histoname = "HAD_P_" + std::to_string(channel);
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/fC_perChannel");
+    _cfC_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 100, 0, 8000);
+    _cfC_EChannel[didp()]->setAxisTitle("fC", 1);
+    _cfC_EChannel[didp()]->setAxisTitle("N", 2);
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/fC_vs_TS_perChannel");
+    _cfC_vs_TS_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 6, 0, 6);
+    _cfC_vs_TS_EChannel[didp()]->setAxisTitle("TS", 1);
+    _cfC_vs_TS_EChannel[didp()]->setAxisTitle("sum fC", 2);
+
+    histoname = "HAD_P_" + std::to_string(channel);
+    _cTDC_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 50, 1, 50);
+    _cTDC_EChannel[didp()]->setAxisTitle("TDC", 1);
+    _cTDC_EChannel[didp()]->setAxisTitle("N", 2);
+
     // HAD Minus
     HcalZDCDetId didm(HcalZDCDetId::HAD, false, channel);
-    histoname = "HAD_M_" + std::to_string(channel) + "_" + std::to_string(channel + 2);
+
+    histoname = "HAD_M_" + std::to_string(channel);
     ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_perChannel");
     _cADC_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 256, 0, 256);
     _cADC_EChannel[didm()]->setAxisTitle("ADC", 1);
     _cADC_EChannel[didm()]->setAxisTitle("N", 2);
     ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_vs_TS_perChannel");
-    _cADC_vs_TS_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 10, 0, 10);
+    _cADC_vs_TS_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 6, 0, 6);
     _cADC_vs_TS_EChannel[didm()]->setAxisTitle("TS", 1);
     _cADC_vs_TS_EChannel[didm()]->setAxisTitle("sum ADC", 2);
+
+    histoname = "HAD_M_" + std::to_string(channel);
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/fC_perChannel");
+    _cfC_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 100, 0, 8000);
+    _cfC_EChannel[didm()]->setAxisTitle("fC", 1);
+    _cfC_EChannel[didm()]->setAxisTitle("N", 2);
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/fC_vs_TS_perChannel");
+    _cfC_vs_TS_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 6, 0, 6);
+    _cfC_vs_TS_EChannel[didm()]->setAxisTitle("TS", 1);
+    _cfC_vs_TS_EChannel[didm()]->setAxisTitle("sum fC", 2);
+
+    histoname = "HAD_M_" + std::to_string(channel);
+    _cTDC_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 50, 1, 50);
+    _cTDC_EChannel[didm()]->setAxisTitle("TDC", 1);
+    _cTDC_EChannel[didm()]->setAxisTitle("N", 2);
   }
 
   for (int channel = 1; channel < 17; channel++) {
     // RPD Pos
     HcalZDCDetId didp(HcalZDCDetId::RPD, true, channel);
-    histoname = "RPD_P_" + std::to_string(channel) + "_2";
+
+    histoname = "RPD_P_" + std::to_string(channel);
     ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_perChannel");
     _cADC_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 256, 0, 256);
     _cADC_EChannel[didp()]->setAxisTitle("ADC", 1);
     _cADC_EChannel[didp()]->setAxisTitle("N", 2);
     ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_vs_TS_perChannel");
-    _cADC_vs_TS_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 10, 0, 10);
+    _cADC_vs_TS_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 6, 0, 6);
     _cADC_vs_TS_EChannel[didp()]->setAxisTitle("TS", 1);
     _cADC_vs_TS_EChannel[didp()]->setAxisTitle("sum ADC", 2);
 
+    histoname = "RPD_P_" + std::to_string(channel);
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/fC_perChannel");
+    _cfC_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 100, 0, 8000);
+    _cfC_EChannel[didp()]->setAxisTitle("fC", 1);
+    _cfC_EChannel[didp()]->setAxisTitle("N", 2);
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/fC_vs_TS_perChannel");
+    _cfC_vs_TS_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 6, 0, 6);
+    _cfC_vs_TS_EChannel[didp()]->setAxisTitle("TS", 1);
+    _cfC_vs_TS_EChannel[didp()]->setAxisTitle("sum fC", 2);
+
+    histoname = "RPD_P_" + std::to_string(channel);
+    _cTDC_EChannel[didp()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 50, 1, 50);
+    _cTDC_EChannel[didp()]->setAxisTitle("TDC", 1);
+    _cTDC_EChannel[didp()]->setAxisTitle("N", 2);
+
     // RPD Minus
     HcalZDCDetId didm(HcalZDCDetId::RPD, false, channel);
-    histoname = "RPD_M_" + std::to_string(channel) + "_2";
+    histoname = "RPD_M_" + std::to_string(channel);
+
     ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_perChannel");
     _cADC_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 256, 0, 256);
     _cADC_EChannel[didm()]->setAxisTitle("ADC", 1);
     _cADC_EChannel[didm()]->setAxisTitle("N", 2);
     ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_vs_TS_perChannel");
-    _cADC_vs_TS_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 10, 0, 10);
+    _cADC_vs_TS_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 6, 0, 6);
     _cADC_vs_TS_EChannel[didm()]->setAxisTitle("TS", 1);
     _cADC_vs_TS_EChannel[didm()]->setAxisTitle("sum ADC", 2);
+
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/fC_perChannel");
+    _cfC_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 100, 0, 8000);
+    _cfC_EChannel[didm()]->setAxisTitle("fC", 1);
+    _cfC_EChannel[didm()]->setAxisTitle("N", 2);
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/fC_vs_TS_perChannel");
+    _cfC_vs_TS_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 6, 0, 6);
+    _cfC_vs_TS_EChannel[didm()]->setAxisTitle("TS", 1);
+    _cfC_vs_TS_EChannel[didm()]->setAxisTitle("sum fC", 2);
+
+    histoname = "RPD_M_" + std::to_string(channel);
+    _cTDC_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 50, 1, 50);
+    _cTDC_EChannel[didm()]->setAxisTitle("TDC", 1);
+    _cTDC_EChannel[didm()]->setAxisTitle("N", 2);
   }
 }
 
-/* virtual */ void ZDCQIE10Task::analyze(edm::Event const& e, edm::EventSetup const&) {
+/* virtual */
+void ZDCQIE10Task::_process(edm::Event const& e, edm::EventSetup const& es) {
+  const HcalTopology& htopo = es.getData(htopoToken_);
+  const HcalLongRecoParams& p = es.getData(paramsToken_);
+  longRecoParams_ = std::make_unique<HcalLongRecoParams>(p);
+  longRecoParams_->setTopo(&htopo);
+
+  int bx = e.bunchCrossing();
+
+  edm::Handle<BXVector<l1t::EtSum> > sums;
+  e.getByToken(sumToken_, sums);
+
+  int startBX = sums->getFirstBX();
+
+  for (int ibx = startBX; ibx <= sums->getLastBX(); ++ibx) {
+    for (auto itr = sums->begin(ibx); itr != sums->end(ibx); ++itr) {
+      l1t::EtSum::EtSumType type = itr->getType();
+
+      if (type == l1t::EtSum::EtSumType::kZDCP) {
+        if (ibx == 0)
+          _cZDC_BX_EmuSUMS[1]->Fill(bx, itr->hwPt());
+      }
+      if (type == l1t::EtSum::EtSumType::kZDCM) {
+        if (ibx == 0)
+          _cZDC_BX_EmuSUMS[0]->Fill(bx, itr->hwPt());
+      }
+    }
+  }
+
   edm::Handle<QIE10DigiCollection> digis;
   if (!e.getByToken(_tokQIE10, digis))
     edm::LogError("Collection QIE10DigiCollection for ZDC isn't available" + _tagQIE10.label() + " " +
                   _tagQIE10.instance());
 
+  double HADM_sum = 0, HADP_sum = 0, EMM_sum = 0, EMP_sum = 0;
+  double HADM_tot_sum = 0, HADP_tot_sum = 0, EMM_tot_sum = 0, EMP_tot_sum = 0;
+
   for (auto it = digis->begin(); it != digis->end(); it++) {
     const QIE10DataFrame digi = static_cast<const QIE10DataFrame>(*it);
+
     HcalZDCDetId const& did = digi.detid();
 
+    uint32_t rawid = _ehashmap.lookup(did);
+    if (rawid == 0) {
+      continue;
+    }
+    HcalElectronicsId const& eid(rawid);
+
+    _cDigiSize_Crate[0]->Fill(digi.samples());
+
+    if (_ptype != fOffline) {  // hidefed2crate
+
+      _cDigiSize_FED[0]->Fill(digi.samples());
+
+      _cOccupancy_ElectronicsuTCA[0]->Fill(eid.slot());
+    }
+    if (_ptype == fOnline || _ptype == fLocal) {
+      _cOccupancy_Crate[0]->Fill(eid.slot(), eid.fiberIndex());
+      _cOccupancy_CrateSlot[0]->Fill(eid.slot(), eid.fiberChanId());
+    }
+
+    double sample_ZDCm_TS1 = 0, sample_ZDCp_TS1 = 0, sample_ZDCm_TS2 = 0, sample_ZDCp_TS2 = 0;
+    double sample[2][6] = {{0}};
+
     for (int i = 0; i < digi.samples(); i++) {
+      // ZDC Plus
+      if (did.zside() > 0) {
+        _cADC_PM[1]->Fill(digi[i].adc());
+        _cADC_vs_TS_PM[1]->Fill(i, digi[i].adc());
+        sample[1][i] = constants::adc2fC[digi[i].adc()];
+        if (i == 1) {
+          sample_ZDCp_TS1 = constants::adc2fC[digi[i].adc()];
+        }
+        if (i == 2) {
+          sample_ZDCp_TS2 = constants::adc2fC[digi[i].adc()];
+        }
+
+      }
+      // ZDC Minus
+      else {
+        _cADC_PM[0]->Fill(digi[i].adc());
+        _cADC_vs_TS_PM[0]->Fill(i, digi[i].adc());
+        sample[0][i] = constants::adc2fC[digi[i].adc()];
+        if (i == 1) {
+          sample_ZDCm_TS1 = constants::adc2fC[digi[i].adc()];
+        }
+        if (i == 2) {
+          sample_ZDCm_TS2 = constants::adc2fC[digi[i].adc()];
+        }
+      }
+
       // iter over all samples
       if (_cADC_EChannel.find(did()) != _cADC_EChannel.end()) {
         _cADC_EChannel[did()]->Fill(digi[i].adc());
+        _cfC_EChannel[did()]->Fill(constants::adc2fC[digi[i].adc()]);
+        _cTDC_EChannel[did()]->Fill(digi[i].le_tdc());
       }
       if (_cADC_vs_TS_EChannel.find(did()) != _cADC_vs_TS_EChannel.end()) {
         _cADC_vs_TS_EChannel[did()]->Fill(i, digi[i].adc());
+        _cfC_vs_TS_EChannel[did()]->Fill(i, constants::adc2fC[digi[i].adc()]);
+      }
+      _cZDC_CapIDS[0]->Fill(digi[i].capid());
+    }
+
+    if (did.section() == 1) {
+      if ((did.channel() > 0) && (did.channel() < 6)) {
+        EMM_sum += (sample_ZDCm_TS2 - sample_ZDCm_TS1);
+        EMP_sum += (sample_ZDCp_TS2 - sample_ZDCp_TS1);
+        for (int k = 0; k < 6; k++) {
+          EMP_tot_sum += sample[1][k];
+          EMM_tot_sum += sample[0][k];
+        }
+        if (did.zside() == -1) {
+          if (sample[0][2] > (0.0 * EMM_tot_sum)) {
+            _cZDC_EM_TM[0]->Fill((did.channel() * 2) - 1);
+          } else {
+            _cZDC_EM_TM[0]->Fill((did.channel() * 2));
+          }
+        }
+        if (did.zside() == 1) {
+          if (sample[1][2] > (0.0 * EMP_tot_sum)) {
+            _cZDC_EM_TM[1]->Fill((did.channel() * 2) - 1);
+          } else {
+            _cZDC_EM_TM[1]->Fill((did.channel() * 2));
+          }
+        }
+      }
+    }
+    if (did.section() == 2) {
+      if ((did.channel() > 0) && (did.channel() < 5)) {
+        HADP_sum += (sample_ZDCp_TS2 - sample_ZDCp_TS1);
+        HADM_sum += (sample_ZDCm_TS2 - sample_ZDCm_TS1);
+        for (int k = 0; k < 6; k++) {
+          HADP_tot_sum += sample[1][k];
+          HADM_tot_sum += sample[0][k];
+        }
+        if (did.zside() == -1) {
+          if (sample[0][2] > (0.0 * HADM_tot_sum)) {
+            _cZDC_HAD_TM[0]->Fill((did.channel() * 2) - 1);
+          } else {
+            _cZDC_HAD_TM[0]->Fill((did.channel() * 2));
+          }
+        }
+        if (did.zside() == 1) {
+          if (sample[1][2] > (0.0 * HADP_tot_sum)) {
+            _cZDC_HAD_TM[1]->Fill((did.channel() * 2) - 1);
+          } else {
+            _cZDC_HAD_TM[1]->Fill((did.channel() * 2));
+          }
+        }
       }
     }
   }
+
+  // Hardcoded callibrations currently
+  _cZDC_SUMS[0]->Fill(((EMM_sum * 0.1) + HADM_sum) * 0.5031);
+  _cZDC_SUMS[1]->Fill(((EMP_sum * 0.12) + HADP_sum) * 0.9397);
+  _cZDC_BXSUMS[0]->Fill(bx, ((EMM_sum * 0.1) + HADM_sum) * 0.5031);
+  _cZDC_BXSUMS[1]->Fill(bx, ((EMP_sum * 0.12) + HADP_sum) * 0.9397);
 }
 
 DEFINE_FWK_MODULE(ZDCQIE10Task);

--- a/DQM/HcalTasks/plugins/ZDCQIE10Task.cc
+++ b/DQM/HcalTasks/plugins/ZDCQIE10Task.cc
@@ -11,12 +11,8 @@ ZDCQIE10Task::ZDCQIE10Task(edm::ParameterSet const& ps)
   _tagQIE10 = ps.getUntrackedParameter<edm::InputTag>("tagQIE10", edm::InputTag("hcalDigis", "ZDC"));
   _tokQIE10 = consumes<QIE10DigiCollection>(_tagQIE10);
 
-  //const edm::EDGetTokenT<l1t::EtSumBxCollection> sumZDCToken_;
-
   sumTag = ps.getUntrackedParameter<edm::InputTag>("etSumTag", edm::InputTag("etSumZdcProducer", ""));
-  //sumTag = ps.getParameter<edm::InputTag>("etSumTag");
   sumToken_ = consumes<l1t::EtSumBxCollection>(sumTag);
-  //sumZDCToken_ = consumes<l1t::EtSumBxCollection>(ps.getUntrackedParameter<edm::InputTag>("sumZDCToken"));
 
   htopoToken_ = esConsumes<HcalTopology, HcalRecNumberingRecord>();
   paramsToken_ = esConsumes<HcalLongRecoParams, HcalLongRecoParamsRcd>();

--- a/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
@@ -124,7 +124,7 @@ process.emulTPDigisNoTDCCut = process.emulTPDigis.clone(
 	TDCMaskHF = cms.uint64(0xFFFFFFFFFFFFFFFF)
      )
 )
-process.HcalTPGCoderULUT.LUTGenerationMode = True
+process.HcalTPGCoderULUT.LUTGenerationMode = False
 
 # For sent-received comparison
 process.load("L1Trigger.Configuration.L1TRawToDigi_cff")

--- a/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
@@ -33,7 +33,7 @@ if 'unitTest=True' in sys.argv:
 from DQM.Integration.config.online_customizations_cfi import *
 if useOfflineGT:
         process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-        process.GlobalTag.globaltag = '141X_dataRun3_Prompt_Candidate_2024_10_08_09_42_50'
+        process.GlobalTag.globaltag = autoCond['run3_data_prompt']
 else:
 	process.load('DQM.Integration.config.FrontierCondition_GT_cfi')
 
@@ -59,11 +59,11 @@ process.dqmSaverPB.runNumber = options.runNumber
 process = customise(process)
 process.DQMStore.verbose = 0
 
-'''
+
 if not unitTest and not useFileInput :
   if not options.BeamSplashRun :
     process.source.minEventsPerLumi = 100
-'''
+
 #-------------------------------------
 #	CMSSW/Hcal non-DQM Related Module import
 #-------------------------------------
@@ -253,10 +253,6 @@ process.options = cms.untracked.PSet(
 		)
 )
 process.options.wantSummary = True
-
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(-1)
-    )
 
 # tracer
 #process.Tracer = cms.Service("Tracer")

--- a/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
@@ -32,10 +32,11 @@ if 'unitTest=True' in sys.argv:
 #-------------------------------------
 from DQM.Integration.config.online_customizations_cfi import *
 if useOfflineGT:
-	process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-	process.GlobalTag.globaltag = autoCond['run3_data_prompt'] 
+        process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+        process.GlobalTag.globaltag = '141X_dataRun3_Prompt_Candidate_2024_10_08_09_42_50'
 else:
 	process.load('DQM.Integration.config.FrontierCondition_GT_cfi')
+
 if unitTest:
 	process.load("DQM.Integration.config.unittestinputsource_cfi")
 	from DQM.Integration.config.unittestinputsource_cfi import options
@@ -57,10 +58,12 @@ process.dqmSaverPB.tag = subsystem
 process.dqmSaverPB.runNumber = options.runNumber
 process = customise(process)
 process.DQMStore.verbose = 0
+
+'''
 if not unitTest and not useFileInput :
   if not options.BeamSplashRun :
     process.source.minEventsPerLumi = 100
-
+'''
 #-------------------------------------
 #	CMSSW/Hcal non-DQM Related Module import
 #-------------------------------------
@@ -94,17 +97,24 @@ if isHeavyIon:
 	process.castorDigis.InputLabel = rawTag
 
 process.emulTPDigis = process.simHcalTriggerPrimitiveDigis.clone(
-   inputLabel = ["hcalDigis", 'hcalDigis'],
+   inputLabel = cms.VInputTag("hcalDigis", "hcalDigis:ZDC"),
    FrontEndFormatError = True,
    FG_threshold = 2,
    InputTagFEDRaw = rawTag,
    upgradeHF = True,
    upgradeHE = True,
    upgradeHB = True,
-   inputUpgradeLabel = ["hcalDigis", "hcalDigis"],
+   inputUpgradeLabel = cms.VInputTag("hcalDigis", "hcalDigis:ZDC"),
    # Enable ZS on emulated TPs, to match what is done in data
    RunZS = True,
    ZS_threshold = 0
+)
+
+#inserting zdc emulator after tp digis
+process.etSumZdcProducer = cms.EDProducer('L1TZDCProducer',
+                                          hcalTPDigis = cms.InputTag("emulTPDigis"),
+                                          bxFirst = cms.int32(-2),
+                                          bxLast = cms.int32(3)
 )
 
 process.hcalDigis.InputLabel = rawTag
@@ -114,7 +124,7 @@ process.emulTPDigisNoTDCCut = process.emulTPDigis.clone(
 	TDCMaskHF = cms.uint64(0xFFFFFFFFFFFFFFFF)
      )
 )
-process.HcalTPGCoderULUT.LUTGenerationMode = False
+process.HcalTPGCoderULUT.LUTGenerationMode = True
 
 # For sent-received comparison
 process.load("L1Trigger.Configuration.L1TRawToDigi_cff")
@@ -134,7 +144,7 @@ if isHeavyIon:
 	process.rpcTwinMuxRawToDigi.inputTag = "rawDataRepacker"
 	process.rpcCPPFRawToDigi.inputTag = "rawDataRepacker"
 
-# Exclude the laser FEDs. They contaminate the QIE10/11 digi collections. 
+# Exclude the laser FEDs. They contaminate the QIE10/11 digi collections.
 #from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
 #run2_HCAL_2017.toModify(process.hcalDigis, FEDs=[724,725,726,727,728,729,730,731,1100,1101,1102,1103,1104,1105,1106,1107,1108,1109,1110,1111,1112,1113,1114,1115,1116,1117,1118,1119,1120,1121,1122,1123])
 
@@ -192,6 +202,7 @@ process.tasksPath = cms.Path(
 		+process.fcdTask
 		#+process.qie11Task
 		#ZDC to be removed after 2018 PbPb run
+		+process.etSumZdcProducer
 		+process.zdcQIE10Task
 		+process.hcalMLTask
 )
@@ -242,6 +253,10 @@ process.options = cms.untracked.PSet(
 		)
 )
 process.options.wantSummary = True
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+    )
 
 # tracer
 #process.Tracer = cms.Service("Tracer")


### PR DESCRIPTION
Code reformatted, emulator updates, and histogram title change

#### PR description:

This is a backport to CMSSW_14_1_X of existing PR here: https://github.com/cms-sw/cmssw/pull/45948

The PR adds to the DQM for ZDC specific histograms, via ZDCQIE10Task

The backport is updated relative to the main PR, mostly fixing build issue, retitling some histograms, and updating python such that emulated ZDC sums fill. It is also rebased to 14_1_X for the backport.

#### PR validation:

PR is tested in CMSSW_14_1_X_2024-10-15-2300, after running a merge-topic to incorporate the PR into a fresh area
scram b ran successfully, validating the build

Following test command produces the expected output:
```
cmsRun DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py inputFiles=/eos/cms/store/group/dpg_hcal/comm_hcal/PFG/backup_raw/HIHLTPhysics-HIRun2023A-RAW-v1-375754.root runkey=hi_run
```
under the upload directory. Inspected histograms inside the DQM file appear reasonable for ZDC sums.

In addition, the following set of commands are run
scram b runtests
scram build code-checks
scram build code-format

code-checks revealed no issues, code-format suggestions were adopted. runtests had multiple failures, detailed below - however, every failure existed already with runtests in a fresh area of CMSSW_14_1_X_2024-10-15-2300 with the same packages checked out (before merge-topic), so it is unclear it is the result of the PR

```
>> Local Products Rules ..... started
>> Local Products Rules ..... done
Creating test log file logs/el9_amd64_gcc12/testing.log
Fail   26s ... DQM/Integration/TestDQMOnlineClient-beam_dqm_sourceclient
Pass   38s ... DQM/Integration/TestDQMOnlineClient-beamhlt_dqm_sourceclient
Fail    6s ... DQM/Integration/TestDQMOnlineClient-beampixel_dqm_sourceclient
Fail   49s ... DQM/Integration/TestDQMOnlineClient-csc_dqm_sourceclient
Fail    7s ... DQM/Integration/TestDQMOnlineClient-ctpps_dqm_sourceclient
Fail    6s ... DQM/Integration/TestDQMOnlineClient-dt4ml_dqm_sourceclient
Fail    6s ... DQM/Integration/TestDQMOnlineClient-dt_dqm_sourceclient
Fail    6s ... DQM/Integration/TestDQMOnlineClient-ecal_dqm_sourceclient
Pass   17s ... DQM/Integration/TestDQMOnlineClient-ecalgpu_dqm_sourceclient
Fail    7s ... DQM/Integration/TestDQMOnlineClient-es_dqm_sourceclient
Fail    6s ... DQM/Integration/TestDQMOnlineClient-fed_dqm_sourceclient
Fail    7s ... DQM/Integration/TestDQMOnlineClient-gem_dqm_sourceclient
Fail    6s ... DQM/Integration/TestDQMOnlineClient-hcal_dqm_sourceclient
Pass   10s ... DQM/Integration/TestDQMOnlineClient-hcalgpu_dqm_sourceclient
Fail    6s ... DQM/Integration/TestDQMOnlineClient-hcalreco_dqm_sourceclient
Fail    6s ... DQM/Integration/TestDQMOnlineClient-hlt_dqm_clientPB
Fail    6s ... DQM/Integration/TestDQMOnlineClient-hlt_dqm_sourceclient
Fail    5s ... DQM/Integration/TestDQMOnlineClient-info_dqm_sourceclient
Fail    6s ... DQM/Integration/TestDQMOnlineClient-l1tstage2_dqm_sourceclient
Fail    6s ... DQM/Integration/TestDQMOnlineClient-l1tstage2emulator_dqm_sourceclient
Fail    6s ... DQM/Integration/TestDQMOnlineClient-mutracking_dqm_sourceclient
Pass    9s ... DQM/Integration/TestDQMOnlineClient-onlinebeammonitor_dqm_sourceclient
Pass    7s ... DQM/Integration/TestDQMOnlineClient-pfgpu_dqm_sourceclient
Fail    6s ... DQM/Integration/TestDQMOnlineClient-pixel_dqm_sourceclient
Pass   10s ... DQM/Integration/TestDQMOnlineClient-pixelgpu_dqm_sourceclient
Fail    5s ... DQM/Integration/TestDQMOnlineClient-pixellumi_dqm_sourceclient
Fail    6s ... DQM/Integration/TestDQMOnlineClient-rpc_dqm_sourceclient
Fail    5s ... DQM/Integration/TestDQMOnlineClient-scal_dqm_sourceclient
Pass   33s ... DQM/Integration/TestDQMOnlineClient-sistrip_approx_dqm_sourceclient
Fail    6s ... DQM/Integration/TestDQMOnlineClient-sistrip_dqm_sourceclient
Fail    6s ... DQM/Integration/TestDQMOnlineClient-visualization
Fail    6s ... DQM/Integration/TestDQMOnlineClient-visualization_secondInstance
Pass  172s ... DQM/Integration/TestDQMOnlineClients-compilation_commissioning_run
Pass  142s ... DQM/Integration/TestDQMOnlineClients-compilation_cosmic_run
Pass  145s ... DQM/Integration/TestDQMOnlineClients-compilation_cosmic_run_stage1
Pass  155s ... DQM/Integration/TestDQMOnlineClients-compilation_hi_run
Pass  152s ... DQM/Integration/TestDQMOnlineClients-compilation_hpu_run
Pass  149s ... DQM/Integration/TestDQMOnlineClients-compilation_pp_run
Pass  131s ... DQM/Integration/TestDQMOnlineClients-compilation_pp_run_stage1
>> Test sequence completed for CMSSW CMSSW_14_1_X_2024-10-15-2300
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

As mentioned above, PR is a backport (with modification) of https://github.com/cms-sw/cmssw/pull/45948, intended for CMSSW_14_1_X

One note - close inspection of the changes to the python file would be welcome - the changes were made as part of testing the full package but unclear to me all should be incorporated into the branch as is. Guidance appreciated.

@hjbossi @mandrenguyen 