### PR TITLE
[UBSAN][PatCandidates/Tau] Reference binding to null pointer

### DIFF
--- a/DataFormats/PatCandidates/src/Tau.cc
+++ b/DataFormats/PatCandidates/src/Tau.cc
@@ -461,7 +461,7 @@ const reco::PFCandidatePtr convertToPFCandidatePtr(const reco::CandidatePtr& ptr
 
 const reco::PFCandidatePtr Tau::leadPFChargedHadrCand() const {
   if (!embeddedLeadPFChargedHadrCand_) {
-    if (pfSpecific_.empty())
+    if (pfSpecific_.empty() || (!pfSpecific().leadPFChargedHadrCand_))
       return reco::PFCandidatePtr();
     else
       return convertToPFCandidatePtr(pfSpecific().leadPFChargedHadrCand_);


### PR DESCRIPTION
This fixes the UBSAN runtime error [a].  I am opening this PR so that @cms-sw/reconstruction-l2 can review it. It could be that right fix might be to find the reason why 
```
pfSpecific_.push_back(pat::tau::TauPFSpecific(*pfTau));
```
at https://github.com/cms-sw/cmssw/blob/master/DataFormats/PatCandidates/src/Tau.cc#L125  did not set `leadPFChargedHadrCand_` properly?

[a]  https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/raw/el8_amd64_gcc12/CMSSW_14_2_UBSAN_X_2024-10-14-2300/pyRelValMatrixLogs/run/141.004_RunNoBPTX2023B/step3_RunNoBPTX2023B.log
```
141.004/step3:DataFormats/Common/interface/Ptr.h:223:13: runtime error: reference binding to null pointer of type 'const struct Candidate'
```