### PR TITLE
Run3-alca249 Modify calibration macros to use the current IsoTrack calibration

### DIFF
--- a/Calibration/HcalCalibAlgos/macros/CalibCorr.C
+++ b/Calibration/HcalCalibAlgos/macros/CalibCorr.C
@@ -189,7 +189,7 @@ unsigned int truncateId(unsigned int detId, int truncateFlag, bool debug = false
       depth = 1;
     }
   } else if (truncate0 == 9) {
-    //Depths 1 and 2 considered as depth = 1; rest of the depths are kept as it is
+    //Depths 1 and 2 considered as depth = 2; rest of the depths are kept as it is
     if (depth <= 2)
       depth = 2;
   }

--- a/Calibration/HcalCalibAlgos/macros/CalibCorr.C
+++ b/Calibration/HcalCalibAlgos/macros/CalibCorr.C
@@ -34,6 +34,17 @@
 //        double getCorr(entry): Entry # (in the file) dependent correction
 //        bool absent(entry) : if correction factor absent
 //        bool present(entry): or present (relevant for ML motivated)
+//        double getPhiCorr(unsigned int id): correction factor from phi
+//                                            symmery studies
+//        double getPhiCorrs(int run, unsigned int id): era-dependent correction
+//                                            factor from phi symmetry studies
+//      *infile* is the name of the input file
+//      *flag* can have a value between 0:5 specifying the type of correction
+//             5 for run-dependent correctons using results from several phi
+//             symmetry studies; 4 for using results from one phi-symmetry
+//             study; 3 for pileup correction using machine learning method;
+//             2 for overall response corrections; 1 for depth dependence
+//             corrections; 0 for raddam corrections)
 // CalibSelectRBX(rbxFile, debug)
 //      A class for selecting a given set of Read Out Box's and provides
 //        bool isItRBX(detId): if it/they is in the chosen RBXs
@@ -42,12 +53,17 @@
 //      A class for either rejecting duplicate entries or giving depth
 //        dependent weight. flag is 0 for keeping a list of duplicate
 //        emtries; 1 is to keep depth dependent weight for each ieta;
-//        2 is to keep a list of ieta, iphi for channels to be selected.
+//        2 is to keep a list of ieta, iphi for channels to be selected;
+//        3 is to read the gain correction file
 //        bool isDuplicate(entry): if it is a duplicate entry
 //        double getWeight(ieta, depth): get the dependent weight
 //        bool select(int ieta, int iphi): channels to be selected
+//        double getCorr(int run, int ieta, int depth): correction factor
+//        to modify the rechit energy due to change in gain fctor
 // void CalibCorrTest(infile, flag)
 //      Tests a file which contains correction factors used by CalibCorr
+//      if *flag* is >= 0; for negative values it initializes CalibDuplicate
+//      with -flag and *debug* = tue
 // void CalibCorrScale(infile, oufile, scale)
 //      Scales all contents of correction factors by "scale" from "infile"
 //      to "outfile"
@@ -173,13 +189,9 @@ unsigned int truncateId(unsigned int detId, int truncateFlag, bool debug = false
       depth = 1;
     }
   } else if (truncate0 == 9) {
-    //Depths 1 and 2 in HB considered as depth = 1; rest of the depths in HB as depth = 2
-    if (subdet == 1) {
-      if (depth > 1)
-        depth = 2;
-      else
-        depth = 1;
-    }
+    //Depths 1 and 2 considered as depth = 1; rest of the depths are kept as it is
+    if (depth <= 2)
+      depth = 2;
   }
   id = (subdet << 25) | (0x1000000) | ((depth & 0xF) << 20) | ((zside > 0) ? (0x80000 | (ieta << 10)) : (ieta << 10));
   if (debug) {
@@ -591,16 +603,19 @@ public:
   double getCorr(const Long64_t& entry);
   double getTrueCorr(const Long64_t& entry);
   double getPhiCorr(unsigned int id);
+  double getPhiCorrs(int run, unsigned int id);
   bool absent(const Long64_t& entry);
   bool absent() { return (good_ == 0); }
   bool present(const Long64_t& entry);
 
 private:
+  unsigned int runId(const int& run);
   unsigned int readCorrRun(const char* infile);
   unsigned int readCorrDepth(const char* infile);
   unsigned int readCorrResp(const char* infile);
   unsigned int readCorrPU(const char* infile);
   unsigned int readCorrPhi(const char* infile);
+  unsigned int readCorrPhis(const char* infile);
   unsigned int getDetIdHE(int ieta, int iphi, int depth);
   unsigned int getDetId(int subdet, int ieta, int iphi, int depth);
   unsigned int correctDetId(const unsigned int& detId);
@@ -613,6 +628,8 @@ private:
   std::map<Long64_t, double> cfactors_;
   std::vector<int> runlow_;
   std::map<unsigned int, double> corrPhiSym_;
+  std::vector<std::pair<int, int> > runs_, ids_;
+  std::map<std::pair<unsigned int, unsigned int>, double> corrPhiSyms_;
 };
 
 class CalibSelectRBX {
@@ -636,15 +653,22 @@ public:
 
   bool isDuplicate(long entry);
   double getWeight(const unsigned int);
-  bool doCorr() { return ((flag_ == 1) && ok_); }
+  bool doCorr() { return (((flag_ == 1) || (flag_ == 3)) && ok_); }
+  bool doCorr(int flag) { return ((flag_ == flag) && ok_); }
   bool select(int ieta, int iphi);
+  double getCorr(int run, int ieta, int depth);
 
 private:
+  bool readCorrFactor(const char* fName);
+  unsigned int runId(const int& run);
+
   int flag_;
   double debug_, ok_;
   std::vector<Long64_t> entries_;
   std::map<int, std::vector<double> > weights_;
   std::vector<std::pair<int, int> > etaphi_;
+  std::vector<std::pair<int, int> > runs_, ids_;
+  std::map<std::pair<int, int>, std::vector<double> > corrs_;
 };
 
 CalibCorrFactor::CalibCorrFactor(const char* infile, int useScale, double scale, bool etamax, bool marina, bool debug)
@@ -758,6 +782,8 @@ CalibCorr::CalibCorr(const char* infile, int flag, bool debug) : flag_(flag), de
     good_ = readCorrPU(infile);
   else if (flag == 4)
     good_ = readCorrPhi(infile);
+  else if (flag == 5)
+    good_ = readCorrPhis(infile);
   else
     good_ = readCorrRun(infile);
 }
@@ -776,9 +802,9 @@ float CalibCorr::getCorr(int run, unsigned int id) {
     if (itr != corrFacResp_.end())
       cfac = itr->second;
   } else if (flag_ == 4) {
-    std::map<unsigned int, double>::iterator itr = corrPhiSym_.find(idx);
-    if (itr != corrPhiSym_.end())
-      cfac = itr->second;
+    cfac = getPhiCorr(idx);
+  } else if (flag_ == 5) {
+    cfac = getPhiCorrs(run, idx);
   } else {
     int ip(-1);
     for (unsigned int k = 0; k < runlow_.size(); ++k) {
@@ -838,6 +864,24 @@ double CalibCorr::getPhiCorr(unsigned int idx) {
     unpackDetId(idx, subdet, zside, ieta, iphi, depth);
     std::cout << "ID " << std::hex << idx << std::dec << " (Sub " << subdet << " eta " << zside * ieta << " phi "
               << iphi << " depth " << depth << ")  Factor " << cfac << std::endl;
+  }
+  return cfac;
+}
+
+double CalibCorr::getPhiCorrs(int run, unsigned int idx) {
+  double cfac(1.0);
+  if (good_ == 0)
+    return cfac;
+  unsigned int runid = runId(run);
+  std::map<std::pair<unsigned int, unsigned int>, double>::iterator itr =
+      corrPhiSyms_.find(std::pair<unsigned int, unsigned int>(runid, idx));
+  if (itr != corrPhiSyms_.end())
+    cfac = itr->second;
+  if (debug_) {
+    int subdet, zside, ieta, iphi, depth;
+    unpackDetId(idx, subdet, zside, ieta, iphi, depth);
+    std::cout << "Run " << run << " ID " << runid << ":" << std::hex << idx << std::dec << " (Sub " << subdet << " eta "
+              << zside * ieta << " phi " << iphi << " depth " << depth << ")  Factor " << cfac << std::endl;
   }
   return cfac;
 }
@@ -1057,6 +1101,82 @@ unsigned int CalibCorr::readCorrPhi(const char* infile) {
   return good;
 }
 
+unsigned int CalibCorr::readCorrPhis(const char* infile0) {
+  std::cout << "Enters readCorrPhis for " << infile0 << std::endl;
+  unsigned int all(0), good(0);
+  std::ifstream fIn(infile0);
+  if (!fIn.good()) {
+    std::cout << "Cannot open file " << infile0 << std::endl;
+  } else {
+    char buffer0[1024];
+    while (fIn.getline(buffer0, 1024)) {
+      std::string bufferString0(buffer0);
+      if (bufferString0.substr(0, 1) == "#") {
+        continue;  //ignore other comments
+      } else {
+        std::vector<std::string> item = splitString(bufferString0);
+        if (item.size() > 2) {
+          int run1 = std::atoi(item[0].c_str());
+          int run2 = std::atoi(item[1].c_str());
+          std::string infile(item[2]);
+          unsigned int runid = runs_.size();
+          runs_.push_back(std::pair<int, int>(run1, run2));
+          std::ifstream fInput(infile.c_str());
+          if (!fInput.good()) {
+            std::cout << "Cannot open file " << infile << std::endl;
+          } else {
+            char buffer[1024];
+            while (fInput.getline(buffer, 1024)) {
+              ++all;
+              std::string bufferString(buffer);
+              if (bufferString.substr(0, 1) == "#") {
+                continue;  //ignore other comments
+              } else {
+                std::vector<std::string> items = splitString(bufferString);
+                if (items.size() < 5) {
+                  std::cout << "Ignore  line: " << buffer << " Size " << items.size();
+                  for (unsigned int k = 0; k < items.size(); ++k)
+                    std::cout << " [" << k << "] : " << items[k];
+                  std::cout << std::endl;
+                } else {
+                  ++good;
+                  int subdet = std::atoi(items[0].c_str());
+                  int ieta = std::atoi(items[1].c_str());
+                  int iphi = std::atoi(items[2].c_str());
+                  int depth = std::atoi(items[3].c_str());
+                  double corrf = std::atof(items[4].c_str());
+                  unsigned int id = packDetId(subdet, ieta, iphi, depth);
+                  corrPhiSyms_[std::pair<int, int>(runid, id)] = corrf;
+                  if (debug_)
+                    std::cout << "ID " << runid << ":" << std::hex << id << std::dec << ":" << id << " (subdet "
+                              << subdet << " eta " << ieta << " phi " << iphi << " depth " << depth << ") "
+                              << corrPhiSym_[id] << std::endl;
+                }
+              }
+            }
+            fInput.close();
+          }
+        }
+      }
+    }
+    fIn.close();
+    std::cout << "Reads total of " << all << " and " << good << " good records of phi-symmetry factors from "
+              << runs_.size() << " files as given in " << infile0 << std::endl;
+  }
+  return good;
+}
+
+unsigned int CalibCorr::runId(const int& run) {
+  unsigned int id(runs_.size());
+  for (unsigned int k = 0; k < runs_.size(); ++k) {
+    if ((run >= runs_[k].first) && (run <= runs_[k].second)) {
+      id = k;
+      break;
+    }
+  }
+  return id;
+}
+
 unsigned int CalibCorr::getDetIdHE(int ieta, int iphi, int depth) { return getDetId(2, ieta, iphi, depth); }
 
 unsigned int CalibCorr::getDetId(int subdet, int ieta, int iphi, int depth) {
@@ -1256,6 +1376,8 @@ CalibDuplicate::CalibDuplicate(const char* fname, int flag, bool debug) : flag_(
           ok_ = true;
       }
     }
+  } else if (flag_ == 3) {
+    ok_ = readCorrFactor(fname);
   } else {
     flag_ = 2;
     if (strcmp(fname, "") != 0) {
@@ -1330,16 +1452,87 @@ bool CalibDuplicate::select(int ieta, int iphi) {
   return flag;
 }
 
+double CalibDuplicate::getCorr(int run, int ieta, int depth) {
+  std::map<std::pair<int, int>, std::vector<double> >::const_iterator itr =
+      corrs_.find(std::pair<int, int>(ieta, depth));
+  double corr(1.0);
+  if (itr != corrs_.end()) {
+    unsigned int irun = runId(run);
+    corr = (itr->second)[irun];
+  }
+  return corr;
+}
+
+bool CalibDuplicate::readCorrFactor(const char* infile) {
+  bool flag(false);
+  std::ifstream fInput(infile);
+  if (!fInput.good()) {
+    std::cout << "CalibDuplicate::readCorrFactor:Cannot open file " << infile << std::endl;
+  } else {
+    int nrun, neta;
+    fInput >> nrun >> neta;
+    int indx, run1, run2;
+    for (int k = 0; k < nrun; ++k) {
+      fInput >> indx >> run1 >> run2;
+      runs_.push_back(std::pair<int, int>(run1, run2));
+    }
+    int eta, depth;
+    double corr;
+    for (int k = 0; k < neta; ++k) {
+      fInput >> eta >> depth;
+      std::vector<double> corrs;
+      for (int i = 0; i < nrun; ++i) {
+        fInput >> corr;
+        corrs.push_back(corr);
+      }
+      corrs_[std::pair<int, int>(eta, depth)] = corrs;
+    }
+    fInput.close();
+    std::cout << "CalibDuplicate::readCorrFactor:Reads information of " << runs_.size() << " runs and " << corrs_.size()
+              << " channels from " << infile << std::endl;
+    flag = true;
+    if (debug_) {
+      for (unsigned int k = 0; k < runs_.size(); ++k)
+        std::cout << "Run range[" << k << "] " << runs_[k].first << ":" << runs_[k].second << std::endl;
+      std::map<std::pair<int, int>, std::vector<double> >::const_iterator itr;
+      for (itr = corrs_.begin(); itr != corrs_.end(); ++itr) {
+        std::cout << "eta:depth [" << (itr->first).first << ":" << (itr->first).second << "]";
+        for (unsigned int i = 0; i < (itr->second).size(); ++i)
+          std::cout << " " << (itr->second)[i];
+        std::cout << std::endl;
+      }
+    }
+  }
+  return flag;
+}
+
+unsigned int CalibDuplicate::runId(const int& run) {
+  unsigned int id(runs_.size());
+  for (unsigned int k = 0; k < runs_.size(); ++k) {
+    if ((run >= runs_[k].first) && (run <= runs_[k].second)) {
+      id = k;
+      break;
+    }
+  }
+  return id;
+}
+
 void CalibCorrTest(const char* infile, int flag) {
-  CalibCorr* c1 = new CalibCorr(infile, flag, true);
-  for (int ieta = 1; ieta < 29; ++ieta) {
-    int subdet = (ieta > 16) ? 2 : 1;
-    int depth = (ieta > 16) ? 2 : 1;
-    unsigned int id1 = ((4 << 28) | ((subdet & 0x7) << 25));
-    id1 |= ((0x1000000) | ((depth & 0xF) << 20) | (ieta << 10) | 1);
-    c1->getCorr(0, id1);
-    id1 |= (0x80000);
-    c1->getCorr(0, id1);
+  if (flag >= 0) {
+    CalibCorr* c1 = new CalibCorr(infile, flag, true);
+    for (int ieta = 1; ieta < 29; ++ieta) {
+      int subdet = (ieta > 16) ? 2 : 1;
+      int depth = (ieta > 16) ? 2 : 1;
+      unsigned int id1 = ((4 << 28) | ((subdet & 0x7) << 25));
+      id1 |= ((0x1000000) | ((depth & 0xF) << 20) | (ieta << 10) | 1);
+      c1->getCorr(0, id1);
+      id1 |= (0x80000);
+      c1->getCorr(0, id1);
+    }
+    delete c1;
+  } else {
+    CalibDuplicate* c1 = new CalibDuplicate(infile, -flag, true);
+    delete c1;
   }
 }
 

--- a/Calibration/HcalCalibAlgos/macros/CalibCorr.C
+++ b/Calibration/HcalCalibAlgos/macros/CalibCorr.C
@@ -34,17 +34,6 @@
 //        double getCorr(entry): Entry # (in the file) dependent correction
 //        bool absent(entry) : if correction factor absent
 //        bool present(entry): or present (relevant for ML motivated)
-//        double getPhiCorr(unsigned int id): correction factor from phi
-//                                            symmery studies
-//        double getPhiCorrs(int run, unsigned int id): era-dependent correction
-//                                            factor from phi symmetry studies
-//      *infile* is the name of the input file
-//      *flag* can have a value between 0:5 specifying the type of correction
-//             5 for run-dependent correctons using results from several phi
-//             symmetry studies; 4 for using results from one phi-symmetry
-//             study; 3 for pileup correction using machine learning method;
-//             2 for overall response corrections; 1 for depth dependence
-//             corrections; 0 for raddam corrections)
 // CalibSelectRBX(rbxFile, debug)
 //      A class for selecting a given set of Read Out Box's and provides
 //        bool isItRBX(detId): if it/they is in the chosen RBXs
@@ -53,17 +42,12 @@
 //      A class for either rejecting duplicate entries or giving depth
 //        dependent weight. flag is 0 for keeping a list of duplicate
 //        emtries; 1 is to keep depth dependent weight for each ieta;
-//        2 is to keep a list of ieta, iphi for channels to be selected;
-//        3 is to read the gain correction file
+//        2 is to keep a list of ieta, iphi for channels to be selected.
 //        bool isDuplicate(entry): if it is a duplicate entry
 //        double getWeight(ieta, depth): get the dependent weight
 //        bool select(int ieta, int iphi): channels to be selected
-//        double getCorr(int run, int ieta, int depth): correction factor
-//        to modify the rechit energy due to change in gain fctor
 // void CalibCorrTest(infile, flag)
 //      Tests a file which contains correction factors used by CalibCorr
-//      if *flag* is >= 0; for negative values it initializes CalibDuplicate
-//      with -flag and *debug* = tue
 // void CalibCorrScale(infile, oufile, scale)
 //      Scales all contents of correction factors by "scale" from "infile"
 //      to "outfile"
@@ -607,19 +591,16 @@ public:
   double getCorr(const Long64_t& entry);
   double getTrueCorr(const Long64_t& entry);
   double getPhiCorr(unsigned int id);
-  double getPhiCorrs(int run, unsigned int id);
   bool absent(const Long64_t& entry);
   bool absent() { return (good_ == 0); }
   bool present(const Long64_t& entry);
 
 private:
-  unsigned int runId(const int& run);
   unsigned int readCorrRun(const char* infile);
   unsigned int readCorrDepth(const char* infile);
   unsigned int readCorrResp(const char* infile);
   unsigned int readCorrPU(const char* infile);
   unsigned int readCorrPhi(const char* infile);
-  unsigned int readCorrPhis(const char* infile);
   unsigned int getDetIdHE(int ieta, int iphi, int depth);
   unsigned int getDetId(int subdet, int ieta, int iphi, int depth);
   unsigned int correctDetId(const unsigned int& detId);
@@ -632,8 +613,6 @@ private:
   std::map<Long64_t, double> cfactors_;
   std::vector<int> runlow_;
   std::map<unsigned int, double> corrPhiSym_;
-  std::vector<std::pair<int, int> > runs_, ids_;
-  std::map<std::pair<unsigned int, unsigned int>, double> corrPhiSyms_;
 };
 
 class CalibSelectRBX {
@@ -657,22 +636,15 @@ public:
 
   bool isDuplicate(long entry);
   double getWeight(const unsigned int);
-  bool doCorr() { return (((flag_ == 1) || (flag_ == 3)) && ok_); }
-  bool doCorr(int flag) { return ((flag_ == flag) && ok_); }
+  bool doCorr() { return ((flag_ == 1) && ok_); }
   bool select(int ieta, int iphi);
-  double getCorr(int run, int ieta, int depth);
 
 private:
-  bool readCorrFactor(const char* fName);
-  unsigned int runId(const int& run);
-
   int flag_;
   double debug_, ok_;
   std::vector<Long64_t> entries_;
   std::map<int, std::vector<double> > weights_;
   std::vector<std::pair<int, int> > etaphi_;
-  std::vector<std::pair<int, int> > runs_, ids_;
-  std::map<std::pair<int, int>, std::vector<double> > corrs_;
 };
 
 CalibCorrFactor::CalibCorrFactor(const char* infile, int useScale, double scale, bool etamax, bool marina, bool debug)
@@ -786,8 +758,6 @@ CalibCorr::CalibCorr(const char* infile, int flag, bool debug) : flag_(flag), de
     good_ = readCorrPU(infile);
   else if (flag == 4)
     good_ = readCorrPhi(infile);
-  else if (flag == 5)
-    good_ = readCorrPhis(infile);
   else
     good_ = readCorrRun(infile);
 }
@@ -806,9 +776,9 @@ float CalibCorr::getCorr(int run, unsigned int id) {
     if (itr != corrFacResp_.end())
       cfac = itr->second;
   } else if (flag_ == 4) {
-    cfac = getPhiCorr(idx);
-  } else if (flag_ == 5) {
-    cfac = getPhiCorrs(run, idx);
+    std::map<unsigned int, double>::iterator itr = corrPhiSym_.find(idx);
+    if (itr != corrPhiSym_.end())
+      cfac = itr->second;
   } else {
     int ip(-1);
     for (unsigned int k = 0; k < runlow_.size(); ++k) {
@@ -868,24 +838,6 @@ double CalibCorr::getPhiCorr(unsigned int idx) {
     unpackDetId(idx, subdet, zside, ieta, iphi, depth);
     std::cout << "ID " << std::hex << idx << std::dec << " (Sub " << subdet << " eta " << zside * ieta << " phi "
               << iphi << " depth " << depth << ")  Factor " << cfac << std::endl;
-  }
-  return cfac;
-}
-
-double CalibCorr::getPhiCorrs(int run, unsigned int idx) {
-  double cfac(1.0);
-  if (good_ == 0)
-    return cfac;
-  unsigned int runid = runId(run);
-  std::map<std::pair<unsigned int, unsigned int>, double>::iterator itr =
-      corrPhiSyms_.find(std::pair<unsigned int, unsigned int>(runid, idx));
-  if (itr != corrPhiSyms_.end())
-    cfac = itr->second;
-  if (debug_) {
-    int subdet, zside, ieta, iphi, depth;
-    unpackDetId(idx, subdet, zside, ieta, iphi, depth);
-    std::cout << "Run " << run << " ID " << runid << ":" << std::hex << idx << std::dec << " (Sub " << subdet << " eta "
-              << zside * ieta << " phi " << iphi << " depth " << depth << ")  Factor " << cfac << std::endl;
   }
   return cfac;
 }
@@ -1105,82 +1057,6 @@ unsigned int CalibCorr::readCorrPhi(const char* infile) {
   return good;
 }
 
-unsigned int CalibCorr::readCorrPhis(const char* infile0) {
-  std::cout << "Enters readCorrPhis for " << infile0 << std::endl;
-  unsigned int all(0), good(0);
-  std::ifstream fIn(infile0);
-  if (!fIn.good()) {
-    std::cout << "Cannot open file " << infile0 << std::endl;
-  } else {
-    char buffer0[1024];
-    while (fIn.getline(buffer0, 1024)) {
-      std::string bufferString0(buffer0);
-      if (bufferString0.substr(0, 1) == "#") {
-        continue;  //ignore other comments
-      } else {
-        std::vector<std::string> item = splitString(bufferString0);
-        if (item.size() > 2) {
-          int run1 = std::atoi(item[0].c_str());
-          int run2 = std::atoi(item[1].c_str());
-          std::string infile(item[2]);
-          unsigned int runid = runs_.size();
-          runs_.push_back(std::pair<int, int>(run1, run2));
-          std::ifstream fInput(infile.c_str());
-          if (!fInput.good()) {
-            std::cout << "Cannot open file " << infile << std::endl;
-          } else {
-            char buffer[1024];
-            while (fInput.getline(buffer, 1024)) {
-              ++all;
-              std::string bufferString(buffer);
-              if (bufferString.substr(0, 1) == "#") {
-                continue;  //ignore other comments
-              } else {
-                std::vector<std::string> items = splitString(bufferString);
-                if (items.size() < 5) {
-                  std::cout << "Ignore  line: " << buffer << " Size " << items.size();
-                  for (unsigned int k = 0; k < items.size(); ++k)
-                    std::cout << " [" << k << "] : " << items[k];
-                  std::cout << std::endl;
-                } else {
-                  ++good;
-                  int subdet = std::atoi(items[0].c_str());
-                  int ieta = std::atoi(items[1].c_str());
-                  int iphi = std::atoi(items[2].c_str());
-                  int depth = std::atoi(items[3].c_str());
-                  double corrf = std::atof(items[4].c_str());
-                  unsigned int id = packDetId(subdet, ieta, iphi, depth);
-                  corrPhiSyms_[std::pair<int, int>(runid, id)] = corrf;
-                  if (debug_)
-                    std::cout << "ID " << runid << ":" << std::hex << id << std::dec << ":" << id << " (subdet "
-                              << subdet << " eta " << ieta << " phi " << iphi << " depth " << depth << ") "
-                              << corrPhiSym_[id] << std::endl;
-                }
-              }
-            }
-            fInput.close();
-          }
-        }
-      }
-    }
-    fIn.close();
-    std::cout << "Reads total of " << all << " and " << good << " good records of phi-symmetry factors from "
-              << runs_.size() << " files as given in " << infile0 << std::endl;
-  }
-  return good;
-}
-
-unsigned int CalibCorr::runId(const int& run) {
-  unsigned int id(runs_.size());
-  for (unsigned int k = 0; k < runs_.size(); ++k) {
-    if ((run >= runs_[k].first) && (run <= runs_[k].second)) {
-      id = k;
-      break;
-    }
-  }
-  return id;
-}
-
 unsigned int CalibCorr::getDetIdHE(int ieta, int iphi, int depth) { return getDetId(2, ieta, iphi, depth); }
 
 unsigned int CalibCorr::getDetId(int subdet, int ieta, int iphi, int depth) {
@@ -1380,8 +1256,6 @@ CalibDuplicate::CalibDuplicate(const char* fname, int flag, bool debug) : flag_(
           ok_ = true;
       }
     }
-  } else if (flag_ == 3) {
-    ok_ = readCorrFactor(fname);
   } else {
     flag_ = 2;
     if (strcmp(fname, "") != 0) {
@@ -1456,87 +1330,16 @@ bool CalibDuplicate::select(int ieta, int iphi) {
   return flag;
 }
 
-double CalibDuplicate::getCorr(int run, int ieta, int depth) {
-  std::map<std::pair<int, int>, std::vector<double> >::const_iterator itr =
-      corrs_.find(std::pair<int, int>(ieta, depth));
-  double corr(1.0);
-  if (itr != corrs_.end()) {
-    unsigned int irun = runId(run);
-    corr = (itr->second)[irun];
-  }
-  return corr;
-}
-
-bool CalibDuplicate::readCorrFactor(const char* infile) {
-  bool flag(false);
-  std::ifstream fInput(infile);
-  if (!fInput.good()) {
-    std::cout << "CalibDuplicate::readCorrFactor:Cannot open file " << infile << std::endl;
-  } else {
-    int nrun, neta;
-    fInput >> nrun >> neta;
-    int indx, run1, run2;
-    for (int k = 0; k < nrun; ++k) {
-      fInput >> indx >> run1 >> run2;
-      runs_.push_back(std::pair<int, int>(run1, run2));
-    }
-    int eta, depth;
-    double corr;
-    for (int k = 0; k < neta; ++k) {
-      fInput >> eta >> depth;
-      std::vector<double> corrs;
-      for (int i = 0; i < nrun; ++i) {
-        fInput >> corr;
-        corrs.push_back(corr);
-      }
-      corrs_[std::pair<int, int>(eta, depth)] = corrs;
-    }
-    fInput.close();
-    std::cout << "CalibDuplicate::readCorrFactor:Reads information of " << runs_.size() << " runs and " << corrs_.size()
-              << " channels from " << infile << std::endl;
-    flag = true;
-    if (debug_) {
-      for (unsigned int k = 0; k < runs_.size(); ++k)
-        std::cout << "Run range[" << k << "] " << runs_[k].first << ":" << runs_[k].second << std::endl;
-      std::map<std::pair<int, int>, std::vector<double> >::const_iterator itr;
-      for (itr = corrs_.begin(); itr != corrs_.end(); ++itr) {
-        std::cout << "eta:depth [" << (itr->first).first << ":" << (itr->first).second << "]";
-        for (unsigned int i = 0; i < (itr->second).size(); ++i)
-          std::cout << " " << (itr->second)[i];
-        std::cout << std::endl;
-      }
-    }
-  }
-  return flag;
-}
-
-unsigned int CalibDuplicate::runId(const int& run) {
-  unsigned int id(runs_.size());
-  for (unsigned int k = 0; k < runs_.size(); ++k) {
-    if ((run >= runs_[k].first) && (run <= runs_[k].second)) {
-      id = k;
-      break;
-    }
-  }
-  return id;
-}
-
 void CalibCorrTest(const char* infile, int flag) {
-  if (flag >= 0) {
-    CalibCorr* c1 = new CalibCorr(infile, flag, true);
-    for (int ieta = 1; ieta < 29; ++ieta) {
-      int subdet = (ieta > 16) ? 2 : 1;
-      int depth = (ieta > 16) ? 2 : 1;
-      unsigned int id1 = ((4 << 28) | ((subdet & 0x7) << 25));
-      id1 |= ((0x1000000) | ((depth & 0xF) << 20) | (ieta << 10) | 1);
-      c1->getCorr(0, id1);
-      id1 |= (0x80000);
-      c1->getCorr(0, id1);
-    }
-    delete c1;
-  } else {
-    CalibDuplicate* c1 = new CalibDuplicate(infile, -flag, true);
-    delete c1;
+  CalibCorr* c1 = new CalibCorr(infile, flag, true);
+  for (int ieta = 1; ieta < 29; ++ieta) {
+    int subdet = (ieta > 16) ? 2 : 1;
+    int depth = (ieta > 16) ? 2 : 1;
+    unsigned int id1 = ((4 << 28) | ((subdet & 0x7) << 25));
+    id1 |= ((0x1000000) | ((depth & 0xF) << 20) | (ieta << 10) | 1);
+    c1->getCorr(0, id1);
+    id1 |= (0x80000);
+    c1->getCorr(0, id1);
   }
 }
 

--- a/Calibration/HcalCalibAlgos/macros/CalibFitPlots.C
+++ b/Calibration/HcalCalibAlgos/macros/CalibFitPlots.C
@@ -269,13 +269,13 @@ const double fitrangeFactor = 1.5;
 struct cfactors {
   int ieta, depth;
   double corrf, dcorr;
-  cfactors(int ie = 0, int dp = 0, double cor = 1, double dc = 0) : ieta(ie), depth(dp), corrf(cor), dcorr(dc){};
+  cfactors(int ie = 0, int dp = 0, double cor = 1, double dc = 0) : ieta(ie), depth(dp), corrf(cor), dcorr(dc) {};
 };
 
 struct results {
   double mean, errmean, width, errwidth;
   results(double v1 = 0, double er1 = 0, double v2 = 0, double er2 = 0)
-      : mean(v1), errmean(er1), width(v2), errwidth(er2){};
+      : mean(v1), errmean(er1), width(v2), errwidth(er2) {};
 };
 
 std::pair<double, double> GetMean(TH1D* hist, double xmin, double xmax, double& rms) {

--- a/Calibration/HcalCalibAlgos/macros/CalibFitPlots.C
+++ b/Calibration/HcalCalibAlgos/macros/CalibFitPlots.C
@@ -87,18 +87,18 @@
 //                      infile4, text4, infile5, text5, prefixF, ratio,
 //                      drawStatBox, nmin, isRealData, year, iformat, save)
 //      Defaults: ratio=false, drawStatBox=true, nmin=100, isRealData=false,
-//                year=2018, iformat=0, save=0
+//                year="2024", iformat=0, save=0
 //
 //  PlotHistCorr2Factors(infile1, text1, infile2, text2, depth, prefixF, ratio,
 //                      drawStatBox, nmin, isRealData, year, iformat, save)
 //      Defaults: ratio=true, drawStatBox=false, nmin=100, isRealData=true,
-//                year=2023, iformat=0, save=0
+//                year="2024", iformat=0, save=0
 //
 //  PlotHistCorrDFactors(infile1, text1, infile2, text2, infile3, text3,
 //                      infile4, text4, infile5, text5, depth, prefixF, ratio,
 //                      drawStatBox, nmin, isRealData, year, iformat, save)
 //      Defaults: ratio=true, drawStatBox=false, nmin=100, isRealData=true,
-//                year=2024, iformat=0, save=0
+//                year="2024", iformat=0, save=0
 //
 //             For plotting correction factors including systematics
 //  PlotHistCorrSys(infilec, conds, text, save)
@@ -166,7 +166,7 @@
 //                    text0, etaMin, etaMax, doFit, isRealData, year, iformat,
 //                    save)
 //      Defaults etaMin = -1, etaMax = -1, doFit = true, isRealData = true,
-//               year = 2022, iformat = 0, save = 0
+//               year = "2024", iformat = 0, save = 0
 //      text0 is a general description common to both sets of corr factors
 //      etaMin < 0 and etaMax > 0 will take ieta range from -etaMax to +etaMax;
 //      etaMin > 0 will select ieta's where |ieta| is greater than etaMin
@@ -219,7 +219,7 @@
 //  scale    (double)       = constant scale factor applied to the factors
 //  ratio    (bool)         = set to show the ratio plot (false)
 //  drawStatBox (bool)      = set to show the statistical box (true)
-//  year     (int)          = Year of data taking (applicable to Data)
+//  year     (char *)       = Year of data taking (applicable to Data)
 //  infilc   (string)       = prefix of the file names of correction factors
 //                            (assumes file name would be the prefix followed
 //                            by _condX.txt where X=0 for the default version
@@ -2583,7 +2583,7 @@ void PlotHistCorrFactors(char* infile1,
                          bool drawStatBox = true,
                          int nmin = 100,
                          bool isRealData = false,
-                         int year = 2018,
+                         const char* year = "2024",
                          int iformat = 0,
                          int save = 0) {
   std::map<int, cfactors> cfacs[5];
@@ -2801,9 +2801,9 @@ void PlotHistCorrFactors(char* infile1,
     txt0->SetFillColor(0);
     char txt[40];
     if (isRealData)
-      sprintf(txt, "CMS Preliminary (%d)", year);
+      sprintf(txt, "CMS Preliminary (%s)", year);
     else
-      sprintf(txt, "CMS Simulation Preliminary (%d)", year);
+      sprintf(txt, "CMS Simulation Preliminary (%s)", year);
     txt0->AddText(txt);
     txt0->Draw("same");
     pad->Update();
@@ -2838,7 +2838,7 @@ void PlotHistCorr2Factors(char* infile1,
                           bool drawStatBox = false,
                           int nmin = 100,
                           bool isRealData = true,
-                          int year = 2023,
+                          const char* year = "2024",
                           int iformat = 0,
                           int save = 0) {
   std::map<int, cfactors> cfacs[5];
@@ -2922,7 +2922,7 @@ void PlotHistCorr2Factors(char* infile1,
         h->GetYaxis()->SetLabelOffset(0.005);
         h->GetYaxis()->SetTitleSize(0.036);
         h->GetYaxis()->SetTitleOffset(1.20);
-        h->GetYaxis()->SetRangeUser(0.50, 1.50);
+        h->GetYaxis()->SetRangeUser(0.80, 1.20);
         hists.push_back(h);
         fitr.push_back(fit);
         htype.push_back(ih);
@@ -2967,7 +2967,7 @@ void PlotHistCorr2Factors(char* infile1,
         h->GetYaxis()->SetTitle("Correction Factor");
         h->GetYaxis()->SetLabelOffset(0.005);
         h->GetYaxis()->SetTitleOffset(1.20);
-        h->GetYaxis()->SetRangeUser(0.5, 1.5);
+        h->GetYaxis()->SetRangeUser(0.8, 1.2);
         hists.push_back(h);
         entries.push_back(nent);
         if (drawStatBox)
@@ -3017,9 +3017,9 @@ void PlotHistCorr2Factors(char* infile1,
     txt0->SetFillColor(0);
     char txt[40];
     if (isRealData)
-      sprintf(txt, "CMS Preliminary (%d)", year);
+      sprintf(txt, "CMS Preliminary (%s)", year);
     else
-      sprintf(txt, "CMS Simulation Preliminary (%d)", year);
+      sprintf(txt, "CMS Simulation Preliminary (%s)", year);
     txt0->AddText(txt);
     txt0->Draw("same");
     pad->Update();
@@ -3060,7 +3060,7 @@ void PlotHistCorrDFactors(char* infile1,
                           bool drawStatBox = false,
                           int nmin = 100,
                           bool isRealData = true,
-                          int year = 2024,
+                          const char* year = "2024",
                           int iformat = 0,
                           int save = 0) {
   std::map<int, cfactors> cfacs[5];
@@ -3169,7 +3169,7 @@ void PlotHistCorrDFactors(char* infile1,
         h->GetYaxis()->SetLabelOffset(0.005);
         h->GetYaxis()->SetTitleSize(0.036);
         h->GetYaxis()->SetTitleOffset(1.20);
-        h->GetYaxis()->SetRangeUser(0.50, 1.50);
+        h->GetYaxis()->SetRangeUser(0.80, 1.20);
         hists.push_back(h);
         fitr.push_back(fit);
         htype.push_back(ih);
@@ -3214,7 +3214,7 @@ void PlotHistCorrDFactors(char* infile1,
         h->GetYaxis()->SetTitle("Correction Factor");
         h->GetYaxis()->SetLabelOffset(0.005);
         h->GetYaxis()->SetTitleOffset(1.20);
-        h->GetYaxis()->SetRangeUser(0.5, 1.5);
+        h->GetYaxis()->SetRangeUser(0.8, 1.2);
         hists.push_back(h);
         entries.push_back(nent);
         if (drawStatBox)
@@ -3264,9 +3264,9 @@ void PlotHistCorrDFactors(char* infile1,
     txt0->SetFillColor(0);
     char txt[40];
     if (isRealData)
-      sprintf(txt, "CMS Preliminary (%d)", year);
+      sprintf(txt, "CMS Preliminary (%s)", year);
     else
-      sprintf(txt, "CMS Simulation Preliminary (%d)", year);
+      sprintf(txt, "CMS Simulation Preliminary (%s)", year);
     txt0->AddText(txt);
     txt0->Draw("same");
     pad->Update();
@@ -4779,7 +4779,7 @@ void PlotHistCorrRatio(char* infile1,
                        int etaMax = -1,
                        bool doFit = true,
                        bool isRealData = true,
-                       int year = 2022,
+                       const char* year = "2024",
                        int iformat = 0,
                        int save = 0) {
   std::map<int, cfactors> cfacs[2];
@@ -4920,9 +4920,9 @@ void PlotHistCorrRatio(char* infile1,
     txt0->SetFillColor(0);
     char txt[40];
     if (isRealData)
-      sprintf(txt, "CMS Preliminary (%d)", year);
+      sprintf(txt, "CMS Preliminary (%s)", year);
     else
-      sprintf(txt, "CMS Simulation Preliminary (%d)", year);
+      sprintf(txt, "CMS Simulation Preliminary (%s)", year);
     txt0->AddText(txt);
     txt0->Draw("same");
     TPaveText* txt2 = new TPaveText(0.65, 0.91, 0.90, 0.96, "blNDC");

--- a/Calibration/HcalCalibAlgos/macros/CalibMain.C
+++ b/Calibration/HcalCalibAlgos/macros/CalibMain.C
@@ -30,7 +30,7 @@
 //
 //  Other parameters for CalibSplit:
 //  <InputFile> <HistogramFile> <Flag> <DirectoryName> <Prefix> <PUcorr>
-//  <Truncate> <Nmax> <pmin> <pmax> <debug>
+//  <Truncate> <Nmax> <pmin> <pmax> <runMin> <runMax> <debug>
 //
 //
 ////////////////////////////////////////////////////////////////////////////////
@@ -371,8 +371,10 @@ int main(Int_t argc, Char_t* argv[]) {
     // CalibSplit
     double pmin = (argc > 10) ? std::atof(argv[10]) : 40.0;
     double pmax = (argc > 11) ? std::atof(argv[11]) : 60.0;
-    bool debug = (argc > 12) ? (std::atoi(argv[12]) > 0) : false;
-    CalibSplit c1(infile, dirname, histfile, pmin, pmax, debug);
+    int runMin = (argc > 12) ? std::atoi(argv[12]) : -1;
+    int runMax = (argc > 13) ? std::atoi(argv[13]) : -1;
+    bool debug = (argc > 14) ? (std::atoi(argv[14]) > 0) : false;
+    CalibSplit c1(infile, dirname, histfile, pmin, pmax, runMin, runMax, debug);
     c1.Loop(nmax);
   }
   return 0;

--- a/Calibration/HcalCalibAlgos/macros/CalibMain.C
+++ b/Calibration/HcalCalibAlgos/macros/CalibMain.C
@@ -30,7 +30,7 @@
 //
 //  Other parameters for CalibSplit:
 //  <InputFile> <HistogramFile> <Flag> <DirectoryName> <Prefix> <PUcorr>
-//  <Truncate> <Nmax> <pmin> <pmax> <runMin> <runMax> <debug>
+//  <Truncate> <Nmax> <pmin> <pmax> <debug>
 //
 //
 ////////////////////////////////////////////////////////////////////////////////
@@ -371,10 +371,8 @@ int main(Int_t argc, Char_t* argv[]) {
     // CalibSplit
     double pmin = (argc > 10) ? std::atof(argv[10]) : 40.0;
     double pmax = (argc > 11) ? std::atof(argv[11]) : 60.0;
-    int runMin = (argc > 12) ? std::atoi(argv[12]) : -1;
-    int runMax = (argc > 13) ? std::atoi(argv[13]) : -1;
-    bool debug = (argc > 14) ? (std::atoi(argv[14]) > 0) : false;
-    CalibSplit c1(infile, dirname, histfile, pmin, pmax, runMin, runMax, debug);
+    bool debug = (argc > 12) ? (std::atoi(argv[12]) > 0) : false;
+    CalibSplit c1(infile, dirname, histfile, pmin, pmax, debug);
     c1.Loop(nmax);
   }
   return 0;

--- a/Calibration/HcalCalibAlgos/macros/CalibMonitor.C
+++ b/Calibration/HcalCalibAlgos/macros/CalibMonitor.C
@@ -27,7 +27,6 @@
 //                               (use "HcalIsoTrkAnalyzer")
 //   dupFileName (char*)       = name of the file containing list of entries
 //                               of duplicate events or depth dependent weights
-//                               or weights coming due to change in gains
 //                               (driven by flag)
 //   comFileName (char*)       = name of the file with list of run and event
 //                               number to be selected
@@ -41,7 +40,7 @@
 //   rcorFileName (char*)      = name of the text file having the correction
 //                               factors as a function of run numbers or depth
 //                               or entry number to be used for raddam/depth/
-//                               pileup/phisym/phisym(s) dependent correction
+//                               pileup/phisym dependent correction
 //                               (default="", no correction)
 //   puCorr (int)              = PU correction to be applied or not: 0 no
 //                               correction; < 0 use eDelta; > 0 rho dependent
@@ -49,18 +48,14 @@
 //   flag (int)                = 8 digit integer (xymlthdo) with control
 //                               information (x=3/2/1/0 for having 1000/500/50/
 //                               100 bins for response distribution in (0:5);
-//                               y=3/2/1/0 containing list of run ranges and
-//                               ieta, depth for gain changes (3): list of
-//                               ieta, iphi of channels to be selected (2);
-//                               list containing depth dependent weights for
-//                               each ieta (1); list of duplicate entries (0)
-//                               in the dupFileName;
+//                               y=2/1/0 containing list of ieta, iphi of
+//                               channels to be selected (2); list containing
+//                               depth dependent weights for each ieta (1);
+//                               list of duplicate entries (0) in dupFileName;
 //                               m=1/0 for (not) making plots for each RBX;
-//                               l=5/4/3/2/1/0 for type of rcorFileName (5
-//                               for run-dependent correctons using results
-//                               from several phi symmetry studies; 4 for
-//                               using results from one phi-symmetry study;
-//                               3 for pileup correction using machine learning
+//                               l=4/3/2/1/0 for type of rcorFileName (4 for
+//                               using results from phi-symmetry; 3 for
+//                               pileup correction using machine learning
 //                               method; 2 for overall response corrections;
 //                               1 for depth dependence corrections;
 //                               0 for raddam corrections);
@@ -1161,13 +1156,8 @@ void CalibMonitor::Loop(Long64_t nmax, bool debug) {
           }
           if ((cFactor_ != nullptr) && (ifDepth_ != 3) && (ifDepth_ > 0))
             cfac *= cFactor_->getCorr(t_Run, (*t_DetIds)[k]);
-          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr(1)))
+          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr()))
             cfac *= cDuplicate_->getWeight((*t_DetIds)[k]);
-          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr(3))) {
-            int subdet, zside, ieta, iphi, depth;
-            unpackDetId((*t_DetIds)[k], subdet, zside, ieta, iphi, depth);
-            cfac *= cDuplicate_->getCorr(t_Run, ieta, depth);
-          }
           eHcal += (cfac * ((*t_HitEnergies)[k]));
           if (debug) {
             int subdet, zside, ieta, iphi, depth;
@@ -1767,13 +1757,8 @@ void CalibMonitor::correctEnergy(double &eHcal, const Long64_t &entry) {
           double cfac = corrFactor_->getCorr(id);
           if ((cFactor_ != 0) && (ifDepth_ != 3) && (ifDepth_ > 0))
             cfac *= cFactor_->getCorr(t_Run, (*t_DetIds1)[idet]);
-          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr(1)))
+          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr()))
             cfac *= cDuplicate_->getWeight((*t_DetIds1)[idet]);
-          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr(3))) {
-            int subdet, zside, ieta, iphi, depth;
-            unpackDetId((*t_DetIds1)[idet], subdet, zside, ieta, iphi, depth);
-            cfac *= cDuplicate_->getCorr(t_Run, ieta, depth);
-          }
           double hitEn = cfac * (*t_HitEnergies1)[idet];
           Etot1 += hitEn;
         }
@@ -1786,13 +1771,8 @@ void CalibMonitor::correctEnergy(double &eHcal, const Long64_t &entry) {
           double cfac = corrFactor_->getCorr(id);
           if ((cFactor_ != 0) && (ifDepth_ != 3) && (ifDepth_ > 0))
             cfac *= cFactor_->getCorr(t_Run, (*t_DetIds3)[idet]);
-          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr(1)))
+          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr()))
             cfac *= cDuplicate_->getWeight((*t_DetIds3)[idet]);
-          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr(3))) {
-            int subdet, zside, ieta, iphi, depth;
-            unpackDetId((*t_DetIds3)[idet], subdet, zside, ieta, iphi, depth);
-            cfac *= cDuplicate_->getCorr(t_Run, ieta, depth);
-          }
           double hitEn = cfac * (*t_HitEnergies3)[idet];
           Etot3 += hitEn;
         }

--- a/Calibration/HcalCalibAlgos/macros/CalibMonitor.C
+++ b/Calibration/HcalCalibAlgos/macros/CalibMonitor.C
@@ -90,7 +90,7 @@
 //                               ignore depth index; (8) in case of HE, depths
 //                               1 and 2 are set to 1, else depth = 2; for HB
 //                               ignore depth index; (9) Assign all depth = 1
-//                               as depth = 2. The digit *d* is used if zside 
+//                               as depth = 2. The digit *d* is used if zside
 //                               is to be ignored (1) or not (0)
 //                               (Default 0)
 //   useGen (bool)             = true/false to use generator level momentum

--- a/Calibration/HcalCalibAlgos/macros/CalibPlotProperties.C
+++ b/Calibration/HcalCalibAlgos/macros/CalibPlotProperties.C
@@ -22,7 +22,7 @@
 //        pLow and pHigh and save the canvases
 //
 // .L CalibPlotProperties.C+g
-//  CalibSplit c1(fname, dirname, outFileName, pmin, pmax, runMin, runMax, debug);
+//  CalibSplit c1(fname, dirname, outFileName, pmin, pmax, debug);
 //  c1.Loop(nentries);
 //
 //        This will split the tree and keep for tacks with momenta between
@@ -36,33 +36,26 @@
 //   dirname (const char*)     = name of the directory where Tree resides
 //                               (use "HcalIsoTrkAnalyzer")
 //   dupFileName (const char*) = name of the file containing list of entries
-//                               of duplicate events or depth dependent weights
-//                               or weights coming due to change in gains
-//                               (driven by flag)
+//                               of duplicate events
 //   prefix (std::string)      = String to be added to the name of histogram
 //                               (usually a 4 character string; default="")
 //   corrFileName (const char*)= name of the text file having the correction
 //                               factors to be used (default="", no corr.)
 //   rcorFileName (const char*)= name of the text file having the correction
 //                               factors as a function of run numbers or depth
-//                               to be used for raddam/depth/pileup/phisym/
-//                               phisym(s) dependent correction
-//                               (default="", no corr.)
+//                               to be used for raddam/depth/pileup/phisym
+//                               dependent correction  (default="", no corr.)
 //   puCorr (int)              = PU correction to be applied or not: 0 no
 //                               correction; < 0 use eDelta; > 0 rho dependent
 //                               correction (-8)
 //   flag (int)                = 7 digit integer (ymlthdo) with control
-//                               information (y=3/2/1/0 containing list of
-//                               run ranges and ieta, depth for gain changes
-//                               (3): list of ieta, iphi of channels to be
-//                               selected (2); list containing depth dependent
-//                               weights for each ieta (1); list of duplicate
-//                               entries (0) in the dupFileName;
-//                               m=0/1 for controlling creation of depth
-//                               depedendent histograms;
-//                               l=5/4/3/2/1/0 for type of rcorFileName ((5
-//                               for run-dependent correctons using results
-//                               from several phi symmetry studies; 4 for
+//                               information (y=2/1/0 containing list of
+//                               ieta, iphi of channels to be selected (2);
+//                               list containing depth dependent weights for
+//                               each ieta (1); list of duplicate entries
+//                               (0) in dupFileName; m=0/1 for controlling
+//                               creation of depth depedendent histograms;
+//                               l=4/3/2/1/0 for type of rcorFileName (4 for
 //                               using results from phi-symmetry; 3 for
 //                               pileup correction using machine learning
 //                               method; 2 for overall response corrections;
@@ -145,8 +138,6 @@
 //   outFileName (std::string)= name of the file containing saved tree
 //   pmin (double)            = minimum track momentum (40.0)
 //   pmax (double)            = maximum track momentum (60.0)
-//   runMin (int)             = minimum run number (-1) | if -1, no check on
-//   runMax (int)             = maximum run number (-1) | run number not done
 //   debug (bool)             = debug flag (false)
 //////////////////////////////////////////////////////////////////////////////
 #include <TROOT.h>
@@ -927,13 +918,8 @@ void CalibPlotProperties::Loop(Long64_t nentries) {
           double cfac = corrFactor_->getCorr(id);
           if ((cFactor_ != 0) && (ifDepth_ != 3) && (ifDepth_ > 0))
             cfac *= cFactor_->getCorr(t_Run, (*t_DetIds)[k]);
-          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr(1)))
+          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr()))
             cfac *= cDuplicate_->getWeight((*t_DetIds)[k]);
-          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr(3))) {
-            int subdet, zside, ieta, iphi, depth;
-            unpackDetId((*t_DetIds)[k], subdet, zside, ieta, iphi, depth);
-            cfac *= cDuplicate_->getCorr(t_Run, ieta, depth);
-          }
           eHcal += (cfac * ((*t_HitEnergies)[k]));
           if (debug) {
             int subdet, zside, ieta, iphi, depth;
@@ -1027,13 +1013,8 @@ void CalibPlotProperties::Loop(Long64_t nentries) {
                 double cfac = corrFactor_->getCorr(id);
                 if ((cFactor_ != 0) && (ifDepth_ != 3) && (ifDepth_ > 0))
                   cfac *= cFactor_->getCorr(t_Run, (*t_DetIds)[k]);
-                if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr(1)))
+                if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr()))
                   cfac *= cDuplicate_->getWeight((*t_DetIds)[k]);
-                if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr(3))) {
-                  int subdet, zside, ieta, iphi, depth;
-                  unpackDetId((*t_DetIds)[k], subdet, zside, ieta, iphi, depth);
-                  cfac *= cDuplicate_->getCorr(t_Run, ieta, depth);
-                }
                 double ener = cfac * (*t_HitEnergies)[k];
                 if (corrPU_)
                   correctEnergy(ener);
@@ -1261,13 +1242,8 @@ void CalibPlotProperties::correctEnergy(double &eHcal) {
           double cfac = corrFactor_->getCorr(id);
           if ((cFactor_ != 0) && (ifDepth_ != 3) && (ifDepth_ > 0))
             cfac *= cFactor_->getCorr(t_Run, (*t_DetIds1)[idet]);
-          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr(1)))
+          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr()))
             cfac *= cDuplicate_->getWeight((*t_DetIds1)[idet]);
-          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr(3))) {
-            int subdet, zside, ieta, iphi, depth;
-            unpackDetId((*t_DetIds1)[idet], subdet, zside, ieta, iphi, depth);
-            cfac *= cDuplicate_->getCorr(t_Run, ieta, depth);
-          }
           double hitEn = cfac * (*t_HitEnergies1)[idet];
           Etot1 += hitEn;
         }
@@ -1280,13 +1256,8 @@ void CalibPlotProperties::correctEnergy(double &eHcal) {
           double cfac = corrFactor_->getCorr(id);
           if ((cFactor_ != 0) && (ifDepth_ != 3) && (ifDepth_ > 0))
             cfac *= cFactor_->getCorr(t_Run, (*t_DetIds3)[idet]);
-          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr(1)))
+          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr()))
             cfac *= cDuplicate_->getWeight((*t_DetIds)[idet]);
-          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr(3))) {
-            int subdet, zside, ieta, iphi, depth;
-            unpackDetId((*t_DetIds3)[idet], subdet, zside, ieta, iphi, depth);
-            cfac *= cDuplicate_->getCorr(t_Run, ieta, depth);
-          }
           double hitEn = cfac * (*t_HitEnergies3)[idet];
           Etot3 += hitEn;
         }
@@ -1841,8 +1812,6 @@ public:
              const std::string &outFileName,
              double pmin = 40.0,
              double pmax = 60.0,
-             int runMin = -1,
-             int runMax = -1,
              bool debug = false);
   virtual ~CalibSplit();
   virtual Int_t Cut(Long64_t entry);
@@ -1858,34 +1827,23 @@ public:
 private:
   const std::string fname_, dirnm_, outFileName_;
   const double pmin_, pmax_;
-  const int runMin_, runMax_;
   const bool debug_;
-  bool checkRun_;
   TFile *outputFile_;
   TDirectoryFile *outputDir_;
   TTree *outputTree_;
 };
 
-CalibSplit::CalibSplit(const char *fname,
-                       const std::string &dirnm,
-                       const std::string &outFileName,
-                       double pmin,
-                       double pmax,
-                       int runMin,
-                       int runMax,
-                       bool debug)
+CalibSplit::CalibSplit(
+    const char *fname, const std::string &dirnm, const std::string &outFileName, double pmin, double pmax, bool debug)
     : fname_(fname),
       dirnm_(dirnm),
       outFileName_(outFileName),
       pmin_(pmin),
       pmax_(pmax),
-      runMin_(runMin),
-      runMax_(runMax),
       debug_(debug),
       outputFile_(nullptr),
       outputDir_(nullptr),
       outputTree_(nullptr) {
-  checkRun_ = ((runMin_ < 0) || (runMax_ < 0)) ? false : true;
   char treeName[400];
   sprintf(treeName, "%s/CalibTree", dirnm.c_str());
   TChain *chain = new TChain(treeName);
@@ -2117,10 +2075,6 @@ void CalibSplit::Loop(Long64_t nentries) {
       std::cout << "Entry " << jentry << " Run " << t_Run << " Event " << t_Event << std::endl;
     ++kount;
     bool select = ((t_p >= pmin_) && (t_p < pmax_));
-    if (select && checkRun_) {
-      if ((t_Run < runMin_) || (t_Run > runMax_))
-        select = false;
-    }
     if (!select) {
       ++reject;
       if (debug_)

--- a/Calibration/HcalCalibAlgos/macros/CalibPlotProperties.C
+++ b/Calibration/HcalCalibAlgos/macros/CalibPlotProperties.C
@@ -90,7 +90,7 @@
 //                               ignore depth index; (8) in case of HE, depths
 //                               1 and 2 are set to 1, else depth = 2; for HB
 //                               ignore depth index; (9) Assign all depth = 1
-//                               as depth = 2. The digit *d* is used if zside 
+//                               as depth = 2. The digit *d* is used if zside
 //                               is to be ignored (1) or not (0)
 //                               (Default 0)
 //   useGen (bool)             = true/false to use generator level momentum

--- a/Calibration/HcalCalibAlgos/macros/CalibPlotProperties.C
+++ b/Calibration/HcalCalibAlgos/macros/CalibPlotProperties.C
@@ -22,7 +22,7 @@
 //        pLow and pHigh and save the canvases
 //
 // .L CalibPlotProperties.C+g
-//  CalibSplit c1(fname, dirname, outFileName, pmin, pmax, debug);
+//  CalibSplit c1(fname, dirname, outFileName, pmin, pmax, runMin, runMax, debug);
 //  c1.Loop(nentries);
 //
 //        This will split the tree and keep for tacks with momenta between
@@ -36,26 +36,33 @@
 //   dirname (const char*)     = name of the directory where Tree resides
 //                               (use "HcalIsoTrkAnalyzer")
 //   dupFileName (const char*) = name of the file containing list of entries
-//                               of duplicate events
+//                               of duplicate events or depth dependent weights
+//                               or weights coming due to change in gains
+//                               (driven by flag)
 //   prefix (std::string)      = String to be added to the name of histogram
 //                               (usually a 4 character string; default="")
 //   corrFileName (const char*)= name of the text file having the correction
 //                               factors to be used (default="", no corr.)
 //   rcorFileName (const char*)= name of the text file having the correction
 //                               factors as a function of run numbers or depth
-//                               to be used for raddam/depth/pileup/phisym
-//                               dependent correction  (default="", no corr.)
+//                               to be used for raddam/depth/pileup/phisym/
+//                               phisym(s) dependent correction
+//                               (default="", no corr.)
 //   puCorr (int)              = PU correction to be applied or not: 0 no
 //                               correction; < 0 use eDelta; > 0 rho dependent
 //                               correction (-8)
 //   flag (int)                = 7 digit integer (ymlthdo) with control
-//                               information (y=2/1/0 containing list of
-//                               ieta, iphi of channels to be selected (2);
-//                               list containing depth dependent weights for
-//                               each ieta (1); list of duplicate entries
-//                               (0) in dupFileName; m=0/1 for controlling
-//                               creation of depth depedendent histograms;
-//                               l=4/3/2/1/0 for type of rcorFileName (4 for
+//                               information (y=3/2/1/0 containing list of
+//                               run ranges and ieta, depth for gain changes
+//                               (3): list of ieta, iphi of channels to be
+//                               selected (2); list containing depth dependent
+//                               weights for each ieta (1); list of duplicate
+//                               entries (0) in the dupFileName;
+//                               m=0/1 for controlling creation of depth
+//                               depedendent histograms;
+//                               l=5/4/3/2/1/0 for type of rcorFileName ((5
+//                               for run-dependent correctons using results
+//                               from several phi symmetry studies; 4 for
 //                               using results from phi-symmetry; 3 for
 //                               pileup correction using machine learning
 //                               method; 2 for overall response corrections;
@@ -69,19 +76,22 @@
 //                               o =0/1/2 for tight / loose / flexible
 //                               selection). Default = 101111
 //   isRealData (bool)         = true/false for data/MC (default true)
-//   truncateFlag    (int)     = Flag to treat different depths differently (0)
-//                               both depths of ieta 15, 16 of HB as depth 1 (1)
-//                               all depths as depth 1 (2), ignore all depth
-//                               index in HE (depth index set 1) (3); ignore
-//                               depth index in HB (depth index set 1) (4); all
-//                               all depths in HB and HE with values > 1 as
-//                               depth 2 (5); for depth = 1 and 2, depth = 1,
-//                               else depth = 2 (6); in case of HB, depths 1
-//                               and 2 are set to 1, else depth = 2; for HE
-//                               ignore depth index (7); in case of HE, depths 1
-//                               and 2 are set to 1, else depth =2; for HB
-//                               ignore depth index (8); ignore depth index for
-//                               depth > 1 in HB and all depth index for HE (9).
+//   truncateFlag    (int)     = A two digit flag (dr) with the default value 0.
+//                               The digit *r* is used to treat depth values:
+//                               (0) treat each depth independently; (1) all
+//                               depths of ieta 15, 16 of HB as depth 1; (2)
+//                               all depths in HB and HE as depth 1; (3) ignore
+//                               depth index in HE (depth index set to 1); (4)
+//                               ignore depth index in HB (depth index set 1);
+//                               (5) all depths in HB and HE with values > 1
+//                               as depth 2; (6) for depth = 1 and 2, depth =
+//                               1, else depth = 2; (7) in case of HB, depths
+//                               1 and 2 are set to 1, else depth = 2; for HE
+//                               ignore depth index; (8) in case of HE, depths
+//                               1 and 2 are set to 1, else depth = 2; for HB
+//                               ignore depth index; (9) Assign all depth = 1
+//                               as depth = 2. The digit *d* is used if zside 
+//                               is to be ignored (1) or not (0)
 //                               (Default 0)
 //   useGen (bool)             = true/false to use generator level momentum
 //                               or reconstruction level momentum (def false)
@@ -138,6 +148,8 @@
 //   outFileName (std::string)= name of the file containing saved tree
 //   pmin (double)            = minimum track momentum (40.0)
 //   pmax (double)            = maximum track momentum (60.0)
+//   runMin (int)             = minimum run number (-1) | if -1, no check on
+//   runMax (int)             = maximum run number (-1) | run number not done
 //   debug (bool)             = debug flag (false)
 //////////////////////////////////////////////////////////////////////////////
 #include <TROOT.h>
@@ -918,8 +930,13 @@ void CalibPlotProperties::Loop(Long64_t nentries) {
           double cfac = corrFactor_->getCorr(id);
           if ((cFactor_ != 0) && (ifDepth_ != 3) && (ifDepth_ > 0))
             cfac *= cFactor_->getCorr(t_Run, (*t_DetIds)[k]);
-          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr()))
+          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr(1)))
             cfac *= cDuplicate_->getWeight((*t_DetIds)[k]);
+          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr(3))) {
+            int subdet, zside, ieta, iphi, depth;
+            unpackDetId((*t_DetIds)[k], subdet, zside, ieta, iphi, depth);
+            cfac *= cDuplicate_->getCorr(t_Run, ieta, depth);
+          }
           eHcal += (cfac * ((*t_HitEnergies)[k]));
           if (debug) {
             int subdet, zside, ieta, iphi, depth;
@@ -1013,8 +1030,13 @@ void CalibPlotProperties::Loop(Long64_t nentries) {
                 double cfac = corrFactor_->getCorr(id);
                 if ((cFactor_ != 0) && (ifDepth_ != 3) && (ifDepth_ > 0))
                   cfac *= cFactor_->getCorr(t_Run, (*t_DetIds)[k]);
-                if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr()))
+                if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr(1)))
                   cfac *= cDuplicate_->getWeight((*t_DetIds)[k]);
+                if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr(3))) {
+                  int subdet, zside, ieta, iphi, depth;
+                  unpackDetId((*t_DetIds)[k], subdet, zside, ieta, iphi, depth);
+                  cfac *= cDuplicate_->getCorr(t_Run, ieta, depth);
+                }
                 double ener = cfac * (*t_HitEnergies)[k];
                 if (corrPU_)
                   correctEnergy(ener);
@@ -1242,8 +1264,13 @@ void CalibPlotProperties::correctEnergy(double &eHcal) {
           double cfac = corrFactor_->getCorr(id);
           if ((cFactor_ != 0) && (ifDepth_ != 3) && (ifDepth_ > 0))
             cfac *= cFactor_->getCorr(t_Run, (*t_DetIds1)[idet]);
-          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr()))
+          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr(1)))
             cfac *= cDuplicate_->getWeight((*t_DetIds1)[idet]);
+          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr(3))) {
+            int subdet, zside, ieta, iphi, depth;
+            unpackDetId((*t_DetIds1)[idet], subdet, zside, ieta, iphi, depth);
+            cfac *= cDuplicate_->getCorr(t_Run, ieta, depth);
+          }
           double hitEn = cfac * (*t_HitEnergies1)[idet];
           Etot1 += hitEn;
         }
@@ -1256,8 +1283,13 @@ void CalibPlotProperties::correctEnergy(double &eHcal) {
           double cfac = corrFactor_->getCorr(id);
           if ((cFactor_ != 0) && (ifDepth_ != 3) && (ifDepth_ > 0))
             cfac *= cFactor_->getCorr(t_Run, (*t_DetIds3)[idet]);
-          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr()))
+          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr(1)))
             cfac *= cDuplicate_->getWeight((*t_DetIds)[idet]);
+          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr(3))) {
+            int subdet, zside, ieta, iphi, depth;
+            unpackDetId((*t_DetIds3)[idet], subdet, zside, ieta, iphi, depth);
+            cfac *= cDuplicate_->getCorr(t_Run, ieta, depth);
+          }
           double hitEn = cfac * (*t_HitEnergies3)[idet];
           Etot3 += hitEn;
         }
@@ -1812,6 +1844,8 @@ public:
              const std::string &outFileName,
              double pmin = 40.0,
              double pmax = 60.0,
+             int runMin = -1,
+             int runMax = -1,
              bool debug = false);
   virtual ~CalibSplit();
   virtual Int_t Cut(Long64_t entry);
@@ -1827,23 +1861,34 @@ public:
 private:
   const std::string fname_, dirnm_, outFileName_;
   const double pmin_, pmax_;
+  const int runMin_, runMax_;
   const bool debug_;
+  bool checkRun_;
   TFile *outputFile_;
   TDirectoryFile *outputDir_;
   TTree *outputTree_;
 };
 
-CalibSplit::CalibSplit(
-    const char *fname, const std::string &dirnm, const std::string &outFileName, double pmin, double pmax, bool debug)
+CalibSplit::CalibSplit(const char *fname,
+                       const std::string &dirnm,
+                       const std::string &outFileName,
+                       double pmin,
+                       double pmax,
+                       int runMin,
+                       int runMax,
+                       bool debug)
     : fname_(fname),
       dirnm_(dirnm),
       outFileName_(outFileName),
       pmin_(pmin),
       pmax_(pmax),
+      runMin_(runMin),
+      runMax_(runMax),
       debug_(debug),
       outputFile_(nullptr),
       outputDir_(nullptr),
       outputTree_(nullptr) {
+  checkRun_ = ((runMin_ < 0) || (runMax_ < 0)) ? false : true;
   char treeName[400];
   sprintf(treeName, "%s/CalibTree", dirnm.c_str());
   TChain *chain = new TChain(treeName);
@@ -2075,6 +2120,10 @@ void CalibSplit::Loop(Long64_t nentries) {
       std::cout << "Entry " << jentry << " Run " << t_Run << " Event " << t_Event << std::endl;
     ++kount;
     bool select = ((t_p >= pmin_) && (t_p < pmax_));
+    if (select && checkRun_) {
+      if ((t_Run < runMin_) || (t_Run > runMax_))
+        select = false;
+    }
     if (!select) {
       ++reject;
       if (debug_)

--- a/Calibration/HcalCalibAlgos/macros/CalibTree.C
+++ b/Calibration/HcalCalibAlgos/macros/CalibTree.C
@@ -60,13 +60,12 @@
 //                              (5) all depths in HB and HE with values > 1
 //                              as depth 2; (6) for depth = 1 and 2, depth =
 //                              1, else depth = 2; (7) in case of HB, depths
-//                              1 and 2 are set to 1, else depth =2; for HE
+//                              1 and 2 are set to 1, else depth = 2; for HE
 //                              ignore depth index; (8) in case of HE, depths
-//                              1 and 2 are set to 1, else depth =2; for HB
-//                              ignore depth index; (9) Ignore depth index for
-//                              depth > 1 in HB and all depth index for HE.
-//                              The digit *d* is used if zside is to be
-//                              ignored (1) or not (0)
+//                              1 and 2 are set to 1, else depth = 2; for HB
+//                              ignore depth index; (9) Assign all depth = 1
+//                              as depth = 2. The digit *d* is used if zside 
+//                              is to be ignored (1) or not (0)
 //                              (Default 0)
 //  maxIter         (int)     = number of iterations (30)
 //  drForm          (int)     = type of threshold/dupFileName/rcorFileName (hdr)
@@ -74,11 +73,13 @@
 //                              (1) for depth dependent corrections; (2) for
 //                              RespCorr corrections; (3) use machine learning
 //                              method for pileup correction; (4) use results
-//                              from phi-symmetry.
+//                              from phi-symmetry; (5) use reults from several
+//                              phi-symmetry studies drive by run numeber.
 //                              For dupFileName d: (0) contains list of
 //                              duplicate entries; (1) depth dependent weights;
 //                              (2) list of  (ieta, iphi) of channels to be
-//                              selected.
+//                              selected; (3) list of run ranges and for each
+//                              range, ieta, depth where gain has changed.
 //                              For threshold h: the format for threshold
 //                              application, 0: no threshold; 1: 2022 prompt
 //                              data; 2: 2022 reco data; 3: 2023 prompt data.
@@ -858,8 +859,13 @@ Double_t CalibTree::Loop(int loop,
                 hitEn = (*t_HitEnergies)[idet];
               if ((rcorForm_ != 3) && (rcorForm_ >= 0) && (cFactor_))
                 hitEn *= cFactor_->getCorr(t_Run, id);
-              if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr()))
+              if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr(1)))
                 hitEn *= cDuplicate_->getWeight(id);
+              if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr(3))) {
+                int subdet, zside, ieta, iphi, depth;
+                unpackDetId((*t_DetIds)[idet], subdet, zside, ieta, iphi, depth);
+                hitEn *= cDuplicate_->getCorr(t_Run, ieta, depth);
+              }
               double Wi = evWt * hitEn / en.Etot;
               double Fac = (inverse) ? (en.ehcal / (pmom - t_eMipDR)) : ((pmom - t_eMipDR) / en.ehcal);
               double Fac2 = Wi * Fac * Fac;
@@ -1480,8 +1486,13 @@ CalibTree::energyCalor CalibTree::energyHcal(double pmom, const Long64_t &entry,
           hitEn = (*t_HitEnergies)[idet];
         if ((rcorForm_ != 3) && (rcorForm_ >= 0) && (cFactor_))
           hitEn *= cFactor_->getCorr(t_Run, id);
-        if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr()))
+        if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr(1)))
           hitEn *= cDuplicate_->getWeight(id);
+        if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr(3))) {
+          int subdet, zside, ieta, iphi, depth;
+          unpackDetId((*t_DetIds)[idet], subdet, zside, ieta, iphi, depth);
+          hitEn *= cDuplicate_->getCorr(t_Run, ieta, depth);
+        }
         etot += hitEn;
         etot2 += ((*t_HitEnergies)[idet]);
       }
@@ -1502,8 +1513,13 @@ CalibTree::energyCalor CalibTree::energyHcal(double pmom, const Long64_t &entry,
             hitEn = (*t_HitEnergies1)[idet];
           if ((rcorForm_ != 3) && (rcorForm_ >= 0) && (cFactor_))
             hitEn *= cFactor_->getCorr(t_Run, id);
-          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr()))
+          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr(1)))
             hitEn *= cDuplicate_->getWeight(id);
+          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr(3))) {
+            int subdet, zside, ieta, iphi, depth;
+            unpackDetId((*t_DetIds1)[idet], subdet, zside, ieta, iphi, depth);
+            hitEn *= cDuplicate_->getCorr(t_Run, ieta, depth);
+          }
           etot1 += hitEn;
         }
       }
@@ -1520,8 +1536,13 @@ CalibTree::energyCalor CalibTree::energyHcal(double pmom, const Long64_t &entry,
             hitEn = (*t_HitEnergies3)[idet];
           if ((rcorForm_ != 3) && (rcorForm_ >= 0) && (cFactor_))
             hitEn *= cFactor_->getCorr(t_Run, id);
-          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr()))
+          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr(3)))
             hitEn *= cDuplicate_->getWeight(id);
+          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr(3))) {
+            int subdet, zside, ieta, iphi, depth;
+            unpackDetId((*t_DetIds3)[idet], subdet, zside, ieta, iphi, depth);
+            hitEn *= cDuplicate_->getCorr(t_Run, ieta, depth);
+          }
           etot3 += hitEn;
         }
       }

--- a/Calibration/HcalCalibAlgos/macros/CalibTree.C
+++ b/Calibration/HcalCalibAlgos/macros/CalibTree.C
@@ -74,13 +74,11 @@
 //                              (1) for depth dependent corrections; (2) for
 //                              RespCorr corrections; (3) use machine learning
 //                              method for pileup correction; (4) use results
-//                              from phi-symmetry; (5) use reults from several
-//                              phi-symmetry studies drive by run numeber.
+//                              from phi-symmetry.
 //                              For dupFileName d: (0) contains list of
 //                              duplicate entries; (1) depth dependent weights;
 //                              (2) list of  (ieta, iphi) of channels to be
-//                              selected; (3) list of run ranges and for each
-//                              range, ieta, depth where gain has changed.
+//                              selected.
 //                              For threshold h: the format for threshold
 //                              application, 0: no threshold; 1: 2022 prompt
 //                              data; 2: 2022 reco data; 3: 2023 prompt data.
@@ -860,13 +858,8 @@ Double_t CalibTree::Loop(int loop,
                 hitEn = (*t_HitEnergies)[idet];
               if ((rcorForm_ != 3) && (rcorForm_ >= 0) && (cFactor_))
                 hitEn *= cFactor_->getCorr(t_Run, id);
-              if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr(1)))
+              if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr()))
                 hitEn *= cDuplicate_->getWeight(id);
-              if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr(3))) {
-                int subdet, zside, ieta, iphi, depth;
-                unpackDetId((*t_DetIds)[idet], subdet, zside, ieta, iphi, depth);
-                hitEn *= cDuplicate_->getCorr(t_Run, ieta, depth);
-              }
               double Wi = evWt * hitEn / en.Etot;
               double Fac = (inverse) ? (en.ehcal / (pmom - t_eMipDR)) : ((pmom - t_eMipDR) / en.ehcal);
               double Fac2 = Wi * Fac * Fac;
@@ -1487,13 +1480,8 @@ CalibTree::energyCalor CalibTree::energyHcal(double pmom, const Long64_t &entry,
           hitEn = (*t_HitEnergies)[idet];
         if ((rcorForm_ != 3) && (rcorForm_ >= 0) && (cFactor_))
           hitEn *= cFactor_->getCorr(t_Run, id);
-        if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr(1)))
+        if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr()))
           hitEn *= cDuplicate_->getWeight(id);
-        if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr(3))) {
-          int subdet, zside, ieta, iphi, depth;
-          unpackDetId((*t_DetIds)[idet], subdet, zside, ieta, iphi, depth);
-          hitEn *= cDuplicate_->getCorr(t_Run, ieta, depth);
-        }
         etot += hitEn;
         etot2 += ((*t_HitEnergies)[idet]);
       }
@@ -1514,13 +1502,8 @@ CalibTree::energyCalor CalibTree::energyHcal(double pmom, const Long64_t &entry,
             hitEn = (*t_HitEnergies1)[idet];
           if ((rcorForm_ != 3) && (rcorForm_ >= 0) && (cFactor_))
             hitEn *= cFactor_->getCorr(t_Run, id);
-          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr(1)))
+          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr()))
             hitEn *= cDuplicate_->getWeight(id);
-          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr(3))) {
-            int subdet, zside, ieta, iphi, depth;
-            unpackDetId((*t_DetIds1)[idet], subdet, zside, ieta, iphi, depth);
-            hitEn *= cDuplicate_->getCorr(t_Run, ieta, depth);
-          }
           etot1 += hitEn;
         }
       }
@@ -1537,13 +1520,8 @@ CalibTree::energyCalor CalibTree::energyHcal(double pmom, const Long64_t &entry,
             hitEn = (*t_HitEnergies3)[idet];
           if ((rcorForm_ != 3) && (rcorForm_ >= 0) && (cFactor_))
             hitEn *= cFactor_->getCorr(t_Run, id);
-          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr(3)))
+          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr()))
             hitEn *= cDuplicate_->getWeight(id);
-          if ((cDuplicate_ != nullptr) && (cDuplicate_->doCorr(3))) {
-            int subdet, zside, ieta, iphi, depth;
-            unpackDetId((*t_DetIds3)[idet], subdet, zside, ieta, iphi, depth);
-            hitEn *= cDuplicate_->getCorr(t_Run, ieta, depth);
-          }
           etot3 += hitEn;
         }
       }

--- a/Calibration/HcalCalibAlgos/macros/CalibTree.C
+++ b/Calibration/HcalCalibAlgos/macros/CalibTree.C
@@ -64,7 +64,7 @@
 //                              ignore depth index; (8) in case of HE, depths
 //                              1 and 2 are set to 1, else depth = 2; for HB
 //                              ignore depth index; (9) Assign all depth = 1
-//                              as depth = 2. The digit *d* is used if zside 
+//                              as depth = 2. The digit *d* is used if zside
 //                              is to be ignored (1) or not (0)
 //                              (Default 0)
 //  maxIter         (int)     = number of iterations (30)


### PR DESCRIPTION
#### PR description:

Modify calibration macros to use the current IsoTrack calibration. We introduce a new mode (truncate flag 9) in place of its earlier implementation. We have a new depth-dependent IsoTrack calibration where parameters for depth = 1 and 2 are kept the same 

#### PR validation:

Use the macros for the current IsoTrack analysis

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special