### PR TITLE
Fix beamspot in PATElectronProducer

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
@@ -536,6 +536,13 @@ void PATElectronProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
     // This is needed by the IPTools methods from the tracking group
     trackBuilder = iSetup.getHandle(trackBuilderToken_);
 
+    if (beamSpotHandle.isValid()) {
+      beamSpot = *beamSpotHandle;
+      beamSpotIsValid = true;
+    } else {
+      edm::LogError("DataNotAvailable") << "No beam spot available from EventSetup, not adding high level selection \n";
+    }
+
     if (pvHandle.isValid() && !pvHandle->empty()) {
       primaryVertex = pvHandle->at(0);
       primaryVertexIsValid = true;


### PR DESCRIPTION
#### PR description:

There are two related bugs in the PATElectronProducer:

1. The variable beamSpot
https://github.com/cms-sw/cmssw/blob/4a85623cb932d794ab5e136e7c15518baeb53988/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc#L523
is initialized but never set to the actual collection of BeamSpot. Nevertheless, it is used throughout the code. As a result, the BS2D and BS3D variables (impact parameters wrt the beamspot)
https://github.com/cms-sw/cmssw/blob/4a85623cb932d794ab5e136e7c15518baeb53988/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc#L1427
are essentially trash. For example, before the fix `gsfTrack->dxy(beamspot)` tends to be a very large number wrt the equivalent for muons.

2. There is no check on the validity of the beamspot, so
https://github.com/cms-sw/cmssw/blob/4a85623cb932d794ab5e136e7c15518baeb53988/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc#L524
is never set to `true`. As a result, the BS3D error
https://github.com/cms-sw/cmssw/blob/4a85623cb932d794ab5e136e7c15518baeb53988/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc#L1435
is always `-1.0`.

This PR fixes 1. and 2.

#### PR validation:

I ran several workflows and saw reasonable values for the impact parameters wrt the beamspot.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

It does not need a backport if future re-minis are going to happen with CMSSW >= 142X (probably the case?).

FYI @afiqaize @cochando @SanghyunKo 