### PR TITLE
Fix `SiStripG2GainsValidator`

### DIFF
--- a/CondCore/SiStripPlugins/scripts/SiStripG2GainsValidator
+++ b/CondCore/SiStripPlugins/scripts/SiStripG2GainsValidator
@@ -1,21 +1,13 @@
 #!/usr/bin/env python3
-from __future__ import print_function 
-
 from datetime import datetime
-import ROOT
 import configparser as ConfigParser
-import datetime
-import glob
 import json
-import numpy
 import optparse
 import os
-import re
 import sqlalchemy
 import string
 import subprocess
 import sys
-import time
 import CondCore.Utilities.conddblib as conddb
 
 ##############################################

--- a/CondCore/SiStripPlugins/scripts/SiStripG2GainsValidator
+++ b/CondCore/SiStripPlugins/scripts/SiStripG2GainsValidator
@@ -290,7 +290,7 @@ if __name__ == "__main__":
             for i,theValidationTagSince in enumerate(IOVsToValidate):
 
                 # Construct the conddb_import command, modifying the 'since' value if necessary
-                since_value = FCSR + i if theValidationTagSince < lastG2Payload[0] else theValidationTagSince
+                since_value = HLTFCSR + i if theValidationTagSince < lastG2Payload[0] else theValidationTagSince
                 command = (
                     f'conddb_import -c sqlite_file:toCompare.db '
                     f'-f frontier://FrontierPrep/CMS_CONDITIONS '
@@ -299,13 +299,13 @@ if __name__ == "__main__":
 
                 # Print and execute the conddb_import command
                 if theValidationTagSince < lastG2Payload[0]:
-                    print("The last available IOV in the validation tag is older than the current last express IOV, taking FCSR as a since!")
+                    print("The last available IOV in the validation tag is older than the current last express IOV, taking Express FCSR (HLT) as a since!")
 
                 print(command)
                 getCommandOutput(command)
 
                 # Construct the testCompareSiStripG2Gains.sh command, adjusting the 'since' value similarly
-                since_value = FCSR + i if theValidationTagSince < lastG2Payload[0] else theValidationTagSince
+                since_value = HLTFCSR + i if theValidationTagSince < lastG2Payload[0] else theValidationTagSince
                 command = (
                     f'${{CMSSW_BASE}}/src/CondCore/SiStripPlugins/scripts/testCompareSiStripG2Gains.sh '
                     f'{Tag} {lastG2Payload[0]} {since_value} {current_directory}/toCompare.db'

--- a/CondCore/SiStripPlugins/scripts/SiStripG2GainsValidator
+++ b/CondCore/SiStripPlugins/scripts/SiStripG2GainsValidator
@@ -23,6 +23,7 @@ def getCommandOutput(command):
     if err:
         print ('%s failed w/ exit code %d' % (command, err))
         sys.exit(1)  # This will stop the script immediately with the failure exit code
+    print(data)
     return data
 
 ##############################################

--- a/CondCore/SiStripPlugins/scripts/testCompareSiStripG2Gains.sh
+++ b/CondCore/SiStripPlugins/scripts/testCompareSiStripG2Gains.sh
@@ -24,6 +24,12 @@ W_DIR=$(pwd)
 STARTIOV=$2
 ENDIOV=$3
 
+# Check if ENDIOV is greater than or equal to STARTIOV
+if (( $ENDIOV < $STARTIOV )); then
+    echo "Error: ENDIOV ($ENDIOV) is less than STARTIOV ($STARTIOV). Skipping comparisons"
+    exit 0
+fi
+
 source /cvmfs/cms.cern.ch/cmsset_default.sh
 eval "$(scram run -sh)"
 


### PR DESCRIPTION
#### PR description:

This PR is a simple follow-up to https://github.com/cms-sw/cmssw/pull/46382.
I noticed that the test started failing in `CMSSW_14_2_X_2024-10-16-1100` [log](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc12/CMSSW_14_2_X_2024-10-16-1100/unitTestLogs/CondCore/SiStripPlugins#/), following up to a recent upload to the production SiStrip G2 tag ([cmsTalk](https://cms-talk.web.cern.ch/t/new-sistrip-g2-gain/53441/4)). 
The reasons lies in the fact that after that upload, we're currently in a situation in which the most recent IoV since (386968) in the production tag is more recent that the FCSR at the time of the test (386912). This leads calling the script `testCompareSiStripG2Gains.sh` with time-inverted arguments, which then causes crashes in the calls to the `getPayloadData.py` script.   
I fix this possible pitfall by changing the PCL FCSR to the HLT FCSR which is guaranteed to be >= to any possible upload to the production tag (barring upload mistakes). 
I profit of this PR to remove a few unneeded import statements. 

#### PR validation:

`scram b runtests_test_SiStripG2GainsValidator` run as of Oct 16, 2024 22:30 runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A