### PR TITLE
[UBSAN][Math] Suppress signed-integer-overflow for approx_exp

### DIFF
--- a/DataFormats/Math/interface/approx_exp.h
+++ b/DataFormats/Math/interface/approx_exp.h
@@ -122,7 +122,11 @@ end;
 
 // valid for -87.3365 < x < 88.7228
 template <int DEGREE>
-constexpr float unsafe_expf_impl(float x) {
+#ifdef CMS_UNDEFINED_SANITIZER
+__attribute__((no_sanitize("signed-integer-overflow")))
+#endif
+constexpr float
+unsafe_expf_impl(float x) {
   using namespace approx_math;
   /* Sollya for the following constants:
      display=hexadecimal;

--- a/DataFormats/Math/interface/approx_exp.h
+++ b/DataFormats/Math/interface/approx_exp.h
@@ -123,6 +123,9 @@ end;
 // valid for -87.3365 < x < 88.7228
 template <int DEGREE>
 #ifdef CMS_UNDEFINED_SANITIZER
+//Supress UBSan runtime error about signed integer overflow: -2147483648 - 1
+//This function is an unsafe implementation of expf and rely on overflow feature
+//Vectorization is affected on x86_64 if change to unsigned int
 __attribute__((no_sanitize("signed-integer-overflow")))
 #endif
 constexpr float


### PR DESCRIPTION
This PR suggests to suppress [a] UBSAN runtime errors. According to https://github.com/cms-sw/cmssw/issues/11753#issuecomment-147696466 this overflow should be considered as feature. This change will suppress the  signed-integer-overflow runtime error coming from `unsafe_expf_impl()` function. 

Note that `CMS_UNDEFINED_SANITIZER` is cpp macro which is only set when we build UBSAN IBs.

FYI @VinInn, let me know if you have any better way to fix/suppress this error

Fixes #46396

[a]
```
136.821/step3:DataFormats/Math/interface/approx_exp.h:154:5: runtime error: signed integer overflow: -2147483648 - 1 cannot be represented in type 'int'
136.821/step3:DataFormats/Math/interface/approx_exp.h:162:32: runtime error: signed integer overflow: 2147483647 + 127 cannot be represented in type 'int'
```