### PR TITLE
New Tests PR Tests for HIN 2023 and 2024

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -4392,6 +4392,10 @@ defaultDataSets['2026D96']='CMSSW_13_1_0_pre1-130X_mcRun4_realistic_v2_2026D96no
 defaultDataSets['2026D98']='CMSSW_13_2_0_pre1-131X_mcRun4_realistic_v5_2026D98noPU-v'
 defaultDataSets['2026D110']='CMSSW_14_1_0_pre5-140X_mcRun4_realistic_v4_RegeneratedGS_2026D110_noPU-v'
 
+## HIN
+defaultDataSets['2023HIN']='CCMSSW_14_1_0-PU_140X_mcRun3_2023_realistic_HI_v4_STD_2023HIN_PU-v'
+defaultDataSets['2024HIN']='CMSSW_14_1_0-PU_141X_mcRun3_2024_realistic_HI_v5_STD_2024HIN_PU-v'
+
 puDataSets = {}
 for key, value in defaultDataSets.items(): puDataSets[key+'PU'] = value
 defaultDataSets.update(puDataSets)

--- a/Configuration/PyReleaseValidation/scripts/README.md
+++ b/Configuration/PyReleaseValidation/scripts/README.md
@@ -389,3 +389,5 @@ And Heavy Ion workflows:
 |  	|  	|  	|  	|  	|  	
 | 158.01 	| RelValHydjetQ_B12_5020GeV_2018_ppReco (reMINIAOD) | phase1_2018_realistic_hi 	| Run2_2018_pp_on_AA 	| (HI MC with pp-like reco) 	|  	  	
 | 312.0 	| Pyquen_ZeemumuJets_pt10_2760GeV 	|  phase1_2022_realistic_hi	| Run3_pp_on_PbPb 	| PU = HiMixGEN 	|  
+| 322.0 	| Pyquen_ZeemumuJets_pt10_5362GeV_2023 	|  phase1_2023_realistic_hi	| Run3_pp_on_PbPb_2023 	| PU = HiMixGEN 	|  
+| 332.0 	| Pyquen_ZeemumuJets_pt10_5362GeV_2024 	|  phase1_2024_realistic_hi	| Run3_pp_on_PbPb_2024 	| PU = HiMixGEN 	|  

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -129,8 +129,10 @@ if __name__ == '__main__':
                     # Run2   
                     140.56,    # HIRun2018A HIHardProbes                    Run2_2018_pp_on_AA 
                     ## MC
-                    312.0,     # Pyquen_ZeemumuJets_pt10_2760GeV            PU : HiMixGEN 
-
+                    # Run3
+                    312.0,     # Pyquen_ZeemumuJets_pt10_2760GeV            2022    PU : HiMixGEN
+                    322.0,     # Pyquen_ZeemumuJets_pt10_5362GeV_2023       2023    PU : HiMixGEN
+                    332.0,     # Pyquen_ZeemumuJets_pt10_5362GeV_2024       2024    PU : HiMixGEN
                      ],
         'jetmc': [5.1, 13, 15, 25, 38, 39], #MC
         'metmc' : [5.1, 15, 25, 37, 38, 39], #MC


### PR DESCRIPTION
#### PR description:

This PR proposes:
- the addition of two HIN MC workflows for PR tests for 2023 and 2024 conditions;
- the addition of default input datasets for `HIN2023` and `HIN2024` conditions.

#### PR validation:

Tests run.

I think a backport to `14_1_X` would be useful.