### PR TITLE
Update the run3_data GT in autoCond to the version intended for the 2022, 2023, 2024CDE rereco

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -37,8 +37,8 @@ autoCond = {
     'run3_data_express'            :    '141X_dataRun3_Express_frozen_v3',
     # GlobalTag for Run3 data relvals (prompt GT): same as 141X_dataRun3_Prompt_v3 but with snapshot at 2024-09-12 11:03:32 (UTC)
     'run3_data_prompt'             :    '141X_dataRun3_Prompt_frozen_v3',
-    # GlobalTag for Run3 offline data reprocessing - snapshot at 2024-10-01 13:57:41 (UTC)
-    'run3_data'                    :    '140X_dataRun3_v14',
+    # GlobalTag for Run3 offline data reprocessing - snapshot at 2024-10-16 18:21:05 (UTC)
+    'run3_data'                    :    '140X_dataRun3_v16',
     # GlobalTag for Run3 offline data reprocessing with Prompt GT, currently for 2022FG - snapshot at 2024-02-12 12:00:00 (UTC)
     'run3_data_PromptAnalysis'     :    '140X_dataRun3_PromptAnalysis_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)


### PR DESCRIPTION
#### PR description:

Update the run3_data GT in autoCond to [140X_dataRun3_v16](https://cms-conddb.cern.ch/cmsDbBrowser/search/Prod/140X_dataRun3_v16), supposed to be the final GT for the 2024CDE re-reco.

Differences with respect to the previous such GT in autoCond are [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_dataRun3_v14/140X_dataRun3_v16). In particular:
- Update EcalIntercalibConstants (https://cms-talk.web.cern.ch/t/call-for-conditions-re-reco-of-2024-eras-c-d-e/42331/16)
- Update ESIntercalibConstants (https://cms-talk.web.cern.ch/t/call-for-conditions-re-reco-of-2024-eras-c-d-e/42331/19), also for 2022 data
- Update ECAL alignment (https://cms-talk.web.cern.ch/t/call-for-conditions-re-reco-of-2024-eras-c-d-e/42331/17)
- Update DT/CSC alignment (https://cms-talk.web.cern.ch/t/muonalignment-run3-rereco-tags/53484), also for the 2022 and 2023 data
- Add GEMRecoGeometry, GEMAlignmentRcd, GEMAlignmentErrorExtended https://cms-talk.web.cern.ch/t/muonalignment-run3-rereco-tags/53484/2
- Pick up lastest append to DTTtrig_V07_offline (https://cms-talk.web.cern.ch/t/call-for-conditions-re-reco-of-2024-eras-c-d-e/42331/20)

Backports to CMSSW_14_1_X and CMSSW_14_0_X will be also provided