### PR TITLE
[14.1.X] Fix DQM config test: Increase number of sequence to test

### DIFF
--- a/DQMOffline/Configuration/test/BuildFile.xml
+++ b/DQMOffline/Configuration/test/BuildFile.xml
@@ -4,12 +4,12 @@
 <test name="GetTestDQMOfflineConfigurationFile" command="edmCopyUtil ${INFILE} $(LOCALTOP)/tmp/"/>
 
 <!-- To make the tests run in parallel, we chunk up the work into arbitrary sets of 10 sequences. -->
-<test name="TestDQMOfflineConfiguration" command="runtests.sh   ${step_value} ${value} file://${LOCALTOP}/tmp/${INFILE_NAME}" for="0,320,10">
+<test name="TestDQMOfflineConfiguration" command="runtests.sh   ${step_value} ${value} file://${LOCALTOP}/tmp/${INFILE_NAME}" for="0,329,10">
   <flags PRE_TEST="GetTestDQMOfflineConfigurationFile"/>
 </test>
 
 <!-- To make sure we actually got all sequences, the last check checks that there are no sequences beyond the last test -->
 <!-- This might need to updated when the number of distinct sequences grows, add more rows above and change the number here. -->
-<test name="TestDQMOfflineConfigurationGotAll" command="runrest.sh file://${LOCALTOP}/tmp/${INFILE_NAME} 320">
+<test name="TestDQMOfflineConfigurationGotAll" command="runrest.sh file://${LOCALTOP}/tmp/${INFILE_NAME} 329">
   <flags PRE_TEST="GetTestDQMOfflineConfigurationFile"/>
 </test>


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/46334

#### PR description:

This should fix the failing DQM configuration tests (report [a]). This PR proposes to adjust the number of DQM sequences
From original PR discussion:

> Currently we have 321 sequences returned by `cmsswSequenceInfo.py --runTheMatrix --steps DQM,VALIDATION` which should be processed by `TestDQMOfflineConfiguration_NN` unit tests and `TestDQMOfflineConfigurationGotAll` should not process any sequences (otherwise it should fail).
> I could have set this number to 321 but I decided to set it to 329 so that if new extra sequences are added then they can be processed by `TestDQMOfflineConfiguration_NN` untill we hit 330 sequences

#### PR validation:

`scram b runtests_TestDQMOfflineConfigurationGotAll` runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

verbatim backport of https://github.com/cms-sw/cmssw/pull/46334 to CMSSW_14_1_X

[a] https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/el8_amd64_gcc12/www/wed/14.1-wed-23/CMSSW_14_1_X_2024-10-16-2300?utests