### PR TITLE
[14_1_X] ZDC Reconstruction Bug Fixes

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/src/ZdcSimpleRecAlgo_Run3.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/ZdcSimpleRecAlgo_Run3.cc
@@ -231,22 +231,23 @@ ZDCRecHit ZdcSimpleRecAlgo_Run3::reco0(const QIE10DataFrame& digi,
     ta *= calibs.respcorrgain(capid);  // fC --> GeV
     if (ta > 0) {
       tmp_energy += ta;
-      tmp_TSWeightedEnergy += (ts + 1) * ta;
+      tmp_TSWeightedEnergy += (ts)*ta;
     }
   }
 
   if (tmp_energy > 0)
-    chargeWeightedTime = (tmp_TSWeightedEnergy / tmp_energy - 1) * 25.0;
+    chargeWeightedTime = (tmp_TSWeightedEnergy / tmp_energy) * 25.0;
   auto rh = ZDCRecHit(digi.id(), ampl, time, -99);
   rh.setEnergySOIp1(energySOIp1);
 
   if (maxI >= 0 && maxI < tool.size()) {
     float tmp_tdctime = 0;
+    int le_tdc = digi[maxI].le_tdc();
     // TDC error codes will be 60=-1, 61 = -2, 62 = -3, 63 = -4
-    if (digi[maxI].le_tdc() >= 60)
-      tmp_tdctime = -1 * (digi[maxI].le_tdc() - 59);
+    if (le_tdc >= 60)
+      tmp_tdctime = -1 * (le_tdc - 59);
     else
-      tmp_tdctime = maxI * 25. + (digi[maxI].le_tdc() / 2);
+      tmp_tdctime = maxI * 25. + (le_tdc / 2.0);
     rh.setTDCtime(tmp_tdctime);
   }
 

--- a/RecoLocalCalo/HcalRecProducers/plugins/ZdcHitReconstructor_Run3.cc
+++ b/RecoLocalCalo/HcalRecProducers/plugins/ZdcHitReconstructor_Run3.cc
@@ -18,10 +18,9 @@
 
 #include <vector>
 namespace zdchelper {
-  void setZDCSaturation(ZDCRecHit rh, QIE10DataFrame& digi, int maxValue) {
-    for (auto it = digi.begin(); it != digi.end(); it++) {
-      QIE10DataFrame::Sample sample = QIE10DataFrame::Sample(*it);
-      if (sample.adc() >= maxValue) {
+  void setZDCSaturation(ZDCRecHit& rh, QIE10DataFrame& digi, int maxValue) {
+    for (int i = 0; i < digi.samples(); i++) {
+      if (digi[i].adc() >= maxValue) {
         rh.setFlagField(1, HcalCaloFlagLabels::ADCSaturationBit);
         break;
       }
@@ -30,7 +29,6 @@ namespace zdchelper {
 
 }  // namespace zdchelper
 
-/*  Zdc Hit reconstructor allows for CaloRecHits with status words */
 ZdcHitReconstructor_Run3::ZdcHitReconstructor_Run3(edm::ParameterSet const& conf)
 
     : reco_(conf.getParameter<int>("recoMethod")),
@@ -227,7 +225,7 @@ void ZdcHitReconstructor_Run3::fillDescriptions(edm::ConfigurationDescriptions& 
                                       {
                                           1,
                                       });
-  desc.add<bool>("setSaturationFlags", false);
+  desc.add<bool>("setSaturationFlags", true);
   {
     edm::ParameterSetDescription psd0;
     psd0.add<int>("maxADCvalue", 255);


### PR DESCRIPTION
#### PR description:
Backport of https://github.com/cms-sw/cmssw/pull/46429

Bug Fixes:
ZdcSimpleRecAlgo_Run3.cc:
Simplified the formula for ChargeWeightedTime.
Fixed issue with integer division with TdcTime and updated code only call digi.le_tcd() once.

ZdcHitReconstruction_Run3.cc:
Fixed issue with setZdcSaturation where the saturation was always 1 due to incorrect method to iterate over QIE10 digis.  Updated setSaturationFlags to true.


#### PR validation:

Tested on CMSSW_14_1_3 with runTheMatrix.py -l 142 -e --ibeos and passed all steps