### PR TITLE
Add UPC monopole skim for 2024 PbPb

### DIFF
--- a/Configuration/Skimming/python/PbPb_UPC_Monopole_cff.py
+++ b/Configuration/Skimming/python/PbPb_UPC_Monopole_cff.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+# HLT UPC pixel thrust trigger
+import HLTrigger.HLTfilters.hltHighLevel_cfi
+hltUPCMonopole = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone()
+hltUPCMonopole.HLTPaths = ["HLT_HIUPC_MinPixelThrust0p8_MaxPixelCluster10000_v*"]
+hltUPCMonopole.throw = False
+hltUPCMonopole.andOr = True
+
+from Configuration.Skimming.PDWG_EXOMONOPOLE_cff import EXOMonopoleSkimContent
+upcMonopoleSkimContent = EXOMonopoleSkimContent.clone()
+upcMonopoleSkimContent.outputCommands.append('keep FEDRawDataCollection_rawDataRepacker_*_*')
+
+# UPC monopole skim sequence
+upcMonopoleSkimSequence = cms.Sequence(hltUPCMonopole)

--- a/Configuration/Skimming/python/Skims_PbPb_cff.py
+++ b/Configuration/Skimming/python/Skims_PbPb_cff.py
@@ -62,4 +62,17 @@ SKIMStreamPbPbZMu = cms.FilteredStream(
     dataTier = cms.untracked.string('RAW-RECO')
     )
 
-#####################      
+#####################
+
+from Configuration.Skimming.PbPb_UPC_Monopole_cff import *
+upcMonopoleSkimPath = cms.Path( upcMonopoleSkimSequence )
+SKIMStreamUPCMonopole = cms.FilteredStream(
+    responsible = 'HI PAG',
+    name = 'UPCMonopole',
+    paths = (upcMonopoleSkimPath),
+    content = upcMonopoleSkimContent.outputCommands,
+    selectEvents = cms.untracked.PSet(),
+    dataTier = cms.untracked.string('USER')
+    )
+
+#####################

--- a/Configuration/Skimming/python/autoSkim.py
+++ b/Configuration/Skimming/python/autoSkim.py
@@ -40,6 +40,10 @@ autoSkim = {
  #'SingleMuon': 'LogError+LogErrorMonitor',
 }
 
+# For 2024 PbPb skims
+for i_split in range(20):
+    autoSkim[f'HIForward{i_split}'] = 'UPCMonopole+LogError+LogErrorMonitor'
+
 # For 2023 PbPb skims
 for i_split in range(32):
     autoSkim[f'HIPhysicsRawPrime{i_split}'] = 'PbPbEMu+PbPbZEE+PbPbZMM+LogError+LogErrorMonitor'


### PR DESCRIPTION
#### PR description:

This PR adds a new skim for UPC monopoles to be used on the 2024 PbPb HIForward PDs.

@mandrenguyen 

#### PR validation:

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 14_1_X