### PR TITLE
Update `test_MC_*_setup` unit tests

### DIFF
--- a/Configuration/PyReleaseValidation/test/BuildFile.xml
+++ b/Configuration/PyReleaseValidation/test/BuildFile.xml
@@ -13,16 +13,14 @@
     environment variable CMSSW_MC_SETUP_TEST_CATCH_HLT.
 -->
 
-<!-- In CMSSW_13_0_18 the auto:phase1_2023_realistic (pre BPix) is 130X_mcRun3_2023_realistic_postBPix_v1 -->
 <ifarchitecture name="el8_amd64">
   <!-- Run this test for production arch of CMSSW_13_0_19_HLT release only -->
-  <test name="test_MC_23_setup" command="CMSSW_MC_SETUP_TEST_CATCH_HLT=0 ${CMSSW_BASE}/src/Configuration/PyReleaseValidation/test/test_mc_setup/test_MC_setup.sh auto:phase1_2023_realistic Run3_2023 2023v12 CMSSW_13_0_19_HLT 130X_mcRun3_2023_realistic_v13 Realistic25ns13p6TeVEarly2023Collision" />
+  <test name="test_MC_23_setup" command="CMSSW_MC_SETUP_TEST_CATCH_HLT=0 ${CMSSW_BASE}/src/Configuration/PyReleaseValidation/test/test_mc_setup/test_MC_setup.sh auto:phase1_2023_realistic Run3_2023 2023v12 CMSSW_13_0_19_HLT 130X_mcRun3_2023_realistic_HLT_forReMC_v2 Realistic25ns13p6TeVEarly2023Collision" />
 </ifarchitecture>
 
-<!-- In CMSSW_12_4_20 the auto:phase1_2022_realistic (pre EE) is 124X_mcRun3_2022_realistic_v12 -->
 <ifarchitecture name="el8_amd64">
-  <!-- Run this test for production arch of CMSSW_12_4_21_HLT release only -->
-  <test name="test_MC_22_setup" command="test_mc_setup/test_MC_setup.sh auto:phase1_2022_realistic Run3 2022v14 CMSSW_12_4_21_HLT 124X_mcRun3_2022_realistic_v12 Realistic25ns13p6TeVEarly2022Collision" />
+  <!-- Run this test for production arch of CMSSW_12_4_22_HLT release only -->
+  <test name="test_MC_22_setup" command="CMSSW_MC_SETUP_TEST_CATCH_HLT=0 ${CMSSW_BASE}/src/Configuration/PyReleaseValidation/test/test_mc_setup/test_MC_setup.sh auto:phase1_2022_realistic Run3 2022v15 CMSSW_12_4_22_HLT 124X_mcRun3_2022_realistic_HLT_forReMC_v5 Realistic25ns13p6TeVEarly2022Collision" />
 </ifarchitecture>
 
 <!-- 

--- a/Configuration/PyReleaseValidation/test/test_mc_setup/test_MC_setup_reco.sh
+++ b/Configuration/PyReleaseValidation/test/test_mc_setup/test_MC_setup_reco.sh
@@ -9,10 +9,18 @@ era=$3
 
 #export SCRAM_ARCH=$scram_arch
 
-echo '> Running RAW2DIGI,L1Reco,RECO,RECOSIM + PAT steps in ' $release
+echo '> Running RAW2DIGI,L1Reco,RECO,RECOSIM + PAT steps reading input generated in ' $release
+
+# Check if release matches the pattern "CMSSW_12_4_*_HLT"
+if [[ $release == CMSSW_12_4_*_HLT ]]; then
+    echo "Release matches CMSSW_12_4_*_HLT, adding customisation for fixReading_12_4_X_Files"
+    customise_flag="IOPool/Input/fixReading_12_4_X_Files.fixReading_12_4_X_Files, Configuration/DataProcessing/Utils.addMonitoring"
+else
+    customise_flag="Configuration/DataProcessing/Utils.addMonitoring"
+fi
 
 cmsDriver.py  --python_filename reco.py --eventcontent AODSIM \
---customise Configuration/DataProcessing/Utils.addMonitoring \
+--customise $customise_flag \
 --datatier AODSIM --fileout file:step4.root \
 --conditions $conditions --step RAW2DIGI,L1Reco,RECO,RECOSIM \
 --geometry DB:Extended --filein file:step3.root --era $era \


### PR DESCRIPTION
#### PR description:

As discussed in https://github.com/cms-sw/cmssw/issues/45888#issuecomment-2332194431 these unit tests failed to catch an issue when running the reconstruction of data coming out the HLT produced in an earlier release. 
I am updating the tests to use the latest and greatest ingredients as of Oct 18, 2024 (both in terms of releases and GlobalTags) as well as activating catching failures in the HLT step when it's failing in the target release.
Additionally for the RECO step for the 2022 use the customization function `fixReading_12_4_X_Files` as suggested at https://github.com/cms-sw/cmssw/issues/45888#issuecomment-2331984194. 

#### PR validation:

`scram b runtests` runs fine in this package

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but will be backported down to 14.0.X