### PR TITLE
[DQM]L1TOccupancyClient: Bug fix and fixes static analyzer warning

### DIFF
--- a/DQM/L1TMonitorClient/src/L1TOccupancyClient.cc
+++ b/DQM/L1TMonitorClient/src/L1TOccupancyClient.cc
@@ -457,8 +457,11 @@ double L1TOccupancyClient::xySymmetry(const ParameterSet& ps,
       cout << "statsup= " << statsup << ", statslow= " << statslow << endl;
     }
 
-    if (nActualStrips > 0)
+    if (nActualStrips > 0) {
       enoughStats = TMath::MinElement(nActualStrips, maxAvgs.get()) > TMath::Max(statsup, statslow);
+    } else if (verbose_) {
+      cout << "No valid strips found, insufficient statistics." << endl;
+    }
     if (verbose_) {
       cout << "stats: " << TMath::MinElement(nActualStrips, maxAvgs.get())
            << ", statsAvg: " << diffHist->GetEntries() / hservice_->getNBinsHistogram(iTestName)
@@ -541,8 +544,11 @@ double L1TOccupancyClient::xySymmetry(const ParameterSet& ps,
     if (verbose_) {
       cout << "statsup= " << statsup << ", statslow= " << statslow << endl;
     }
-    if (nActualStrips > 0)
+    if (nActualStrips > 0) {
       enoughStats = TMath::MinElement(nActualStrips, maxAvgs.get()) > TMath::Max(statsup, statslow);
+    } else if (verbose_) {
+      cout << "No valid strips found, insufficient statistics." << endl;
+    }
     if (verbose_) {
       cout << "stats: " << TMath::MinElement(nActualStrips, maxAvgs.get())
            << ", statsAvg: " << diffHist->GetEntries() / hservice_->getNBinsHistogram(iTestName)

--- a/DQM/L1TMonitorClient/src/L1TOccupancyClient.cc
+++ b/DQM/L1TMonitorClient/src/L1TOccupancyClient.cc
@@ -418,13 +418,11 @@ double L1TOccupancyClient::xySymmetry(const ParameterSet& ps,
     std::unique_ptr<double[]> maxAvgs(new double[maxBinStrip - upBinStrip + 1]);
 
     int nActualStrips = 0;  //number of strips that are not fully masked
-    for (int i = 0, j = upBinStrip, k = lowBinStrip; j <= maxBinStrip; i++, j++, k--) {
-      double avg1 = getAvrg(diffHist, iTestName, pAxis, nBinsY, j, pAverageMode);
-      double avg2 = getAvrg(diffHist, iTestName, pAxis, nBinsY, k, pAverageMode);
-
+    for (int j = upBinStrip, k = lowBinStrip; j <= maxBinStrip; j++, k--) {
       // Protection for when both strips are masked
       if (!hservice_->isStripMasked(iTestName, j, pAxis) && !hservice_->isStripMasked(iTestName, k, pAxis)) {
-        maxAvgs[i] = TMath::Max(avg1, avg2);
+        maxAvgs[nActualStrips] = TMath::Max(getAvrg(diffHist, iTestName, pAxis, nBinsY, j, pAverageMode),
+                                            getAvrg(diffHist, iTestName, pAxis, nBinsY, k, pAverageMode));
         nActualStrips++;
       }
     }
@@ -459,7 +457,8 @@ double L1TOccupancyClient::xySymmetry(const ParameterSet& ps,
       cout << "statsup= " << statsup << ", statslow= " << statslow << endl;
     }
 
-    enoughStats = TMath::MinElement(nActualStrips, maxAvgs.get()) > TMath::Max(statsup, statslow);
+    if (nActualStrips > 0)
+      enoughStats = TMath::MinElement(nActualStrips, maxAvgs.get()) > TMath::Max(statsup, statslow);
     if (verbose_) {
       cout << "stats: " << TMath::MinElement(nActualStrips, maxAvgs.get())
            << ", statsAvg: " << diffHist->GetEntries() / hservice_->getNBinsHistogram(iTestName)
@@ -507,11 +506,10 @@ double L1TOccupancyClient::xySymmetry(const ParameterSet& ps,
     //do we have enough statistics? Min(Max(strip_i,strip_j))>threshold
     std::unique_ptr<double[]> maxAvgs(new double[maxBinStrip - upBinStrip + 1]);
     int nActualStrips = 0;
-    for (int i = 0, j = upBinStrip, k = lowBinStrip; j <= maxBinStrip; i++, j++, k--) {
-      double avg1 = getAvrg(diffHist, iTestName, pAxis, nBinsX, j, pAverageMode);
-      double avg2 = getAvrg(diffHist, iTestName, pAxis, nBinsX, k, pAverageMode);
+    for (int j = upBinStrip, k = lowBinStrip; j <= maxBinStrip; j++, k--) {
       if (!hservice_->isStripMasked(iTestName, j, pAxis) && !hservice_->isStripMasked(iTestName, k, pAxis)) {
-        maxAvgs[i] = TMath::Max(avg1, avg2);
+        maxAvgs[nActualStrips] = TMath::Max(getAvrg(diffHist, iTestName, pAxis, nBinsX, j, pAverageMode),
+                                            getAvrg(diffHist, iTestName, pAxis, nBinsX, k, pAverageMode));
         nActualStrips++;
       }
     }
@@ -543,7 +541,8 @@ double L1TOccupancyClient::xySymmetry(const ParameterSet& ps,
     if (verbose_) {
       cout << "statsup= " << statsup << ", statslow= " << statslow << endl;
     }
-    enoughStats = TMath::MinElement(nActualStrips, maxAvgs.get()) > TMath::Max(statsup, statslow);
+    if (nActualStrips > 0)
+      enoughStats = TMath::MinElement(nActualStrips, maxAvgs.get()) > TMath::Max(statsup, statslow);
     if (verbose_) {
       cout << "stats: " << TMath::MinElement(nActualStrips, maxAvgs.get())
            << ", statsAvg: " << diffHist->GetEntries() / hservice_->getNBinsHistogram(iTestName)


### PR DESCRIPTION
This PR proposes following changes
- code clean: Call `getAvrg` only when needed
- Bug fix: Fill `maxAvgs` using the correct correct index `nActualStrips`
- Call `TMath::MinElement` only if  `nActualStrips>0` otherwise we have a uninitialize `maxAvgs`. This fixes clang analyzer warning [a]


[a] https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_14_2_X_2024-10-16-1100/el8_amd64_gcc12/llvm-analysis/report-4ed65d.html#EndPath
```
In file included from src/DQM/L1TMonitorClient/src/L1TOccupancyClient.cc:1:
In file included from src/DQM/L1TMonitorClient/interface/L1TOccupancyClient.h:9:
In file included from src/DQMServices/Core/interface/DQMStore.h:4:
In file included from src/DQMServices/Core/interface/MonitorElement.h:15:
In file included from root/6.30.09-c59d6b036f1cbd6988c172ba319259f1/include/TF1.h:36:
  root/6.30.09-c59d6b036f1cbd6988c172ba319259f1/include/TMath.h:961:4: warning: Undefined or garbage value returned to caller [core.uninitialized.UndefReturn]
   961 |    return *std::min_element(a,a+n);
```