### PR TITLE
2025 Wfs Skeleton and Updates to Data Wfs (2024,2023,2022)

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -101,6 +101,19 @@ autoCond = {
     'phase1_2024_realistic_hi'     :    '141X_mcRun3_2024_realistic_HI_v8',
     # GlobalTag for MC production with realistic conditions for Phase1 2024 detector for ppRef5TeV
     'phase1_2024_realistic_ppRef5TeV'     :    '141X_mcRun3_2024_realistic_ppRef5TeV_v5',
+
+    ### 2025 conditions copy of 2024 conditions on 17/10/2024
+    ### to be updated when 2025 conditions come
+    # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2025
+    'phase1_2025_design'           :    '140X_mcRun3_2025_design_v11',
+    # GlobalTag for MC production with realistic conditions for Phase1 2025
+    'phase1_2025_realistic'        :    '140X_mcRun3_2025_realistic_v25',
+    # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2025, Strip tracker in DECO mode
+    'phase1_2025_cosmics'          :    '140X_mcRun3_2025cosmics_realistic_deco_v14',
+    # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2025, Strip tracker in DECO mode
+    'phase1_2025_cosmics_design'   :    '140X_mcRun3_2025cosmics_design_deco_v11',
+    ################
+
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             :    '141X_mcRun4_realistic_v3'
 }

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -101,19 +101,10 @@ autoCond = {
     'phase1_2024_realistic_hi'     :    '141X_mcRun3_2024_realistic_HI_v8',
     # GlobalTag for MC production with realistic conditions for Phase1 2024 detector for ppRef5TeV
     'phase1_2024_realistic_ppRef5TeV'     :    '141X_mcRun3_2024_realistic_ppRef5TeV_v5',
-
-    ### 2025 conditions copy of 2024 conditions on 17/10/2024
-    ### to be updated when 2025 conditions come
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2025
-    'phase1_2025_design'           :    '140X_mcRun3_2025_design_v11',
-    # GlobalTag for MC production with realistic conditions for Phase1 2025
-    'phase1_2025_realistic'        :    '140X_mcRun3_2025_realistic_v25',
-    # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2025, Strip tracker in DECO mode
-    'phase1_2025_cosmics'          :    '140X_mcRun3_2025cosmics_realistic_deco_v14',
-    # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2025, Strip tracker in DECO mode
-    'phase1_2025_cosmics_design'   :    '140X_mcRun3_2025cosmics_design_deco_v11',
-    ################
-
+    'phase1_2025_design'           :    '140X_mcRun3_2024_design_v11',
+    # GlobalTag for MC production with realistic conditions for Phase1 2024
+    'phase1_2025_realistic'        :    '142X_mcRun3_2025_realistic_v1',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             :    '141X_mcRun4_realistic_v3'
 }

--- a/Configuration/HLT/python/autoHLT.py
+++ b/Configuration/HLT/python/autoHLT.py
@@ -12,7 +12,7 @@ autoHLT = {
   'relval2018' : 'Fake2',
   'relval2022' : 'Fake2',
   'relval2023' : 'Fake2',
-  'relval2024' : 'GRun',
+  'relval2024' : 'Fake2',
   'relval2025' : 'GRun',
   'relval2026' : '75e33',
   'test'       : 'GRun',

--- a/Configuration/HLT/python/autoHLT.py
+++ b/Configuration/HLT/python/autoHLT.py
@@ -13,6 +13,7 @@ autoHLT = {
   'relval2022' : 'Fake2',
   'relval2023' : 'Fake2',
   'relval2024' : 'GRun',
+  'relval2025' : 'GRun',
   'relval2026' : '75e33',
   'test'       : 'GRun',
 }

--- a/Configuration/PyReleaseValidation/python/relval_2017.py
+++ b/Configuration/PyReleaseValidation/python/relval_2017.py
@@ -54,6 +54,7 @@ from Configuration.PyReleaseValidation.relval_upgrade import workflows as _upgra
 #        (TTbar FastSim, TTbar FastSim PU, MinBiasFS for mixing))
 #        (ZEE)
 #        (Nu Gun)
+#   2025 (TTbar, TTbar PU)
 
 numWFIB = [10001.0,10002.0,10003.0,10004.0,10005.0,10006.0,10007.0,10008.0,10009.0,10059.0,10071.0,
            10042.0,10024.0,10025.0,10026.0,10023.0,10224.0,10225.0,10424.0,
@@ -101,7 +102,9 @@ numWFIB = [10001.0,10002.0,10003.0,10004.0,10005.0,10006.0,10007.0,10008.0,10009
            12834.402, 12834.412,
            16434.0, 16634.0, 16440.303,
            12846.0,
-           12861.0]
+           12861.0,
+           # 2025
+           16834.0, 17034.0,]
 
 for numWF in numWFIB:
     if not numWF in _upgrade_workflows:

--- a/Configuration/PyReleaseValidation/python/relval_data_highstats.py
+++ b/Configuration/PyReleaseValidation/python/relval_data_highstats.py
@@ -12,51 +12,57 @@ offset_pd = 0.001 # less than 100 pds per year
 offset_events = 0.0001 # less than 10 event setups (50k,150k,250k,500k)
 
 ## 2024
-base_wf_number_2024 = 2024.0
+base_wf = 2024.0
 for e_n,era in enumerate(eras_2024):
     for p_n,pd in enumerate(pds_2024):
         for e_key,evs in event_steps_dict.items():
             if "10k" == e_key: # already defined in relval_standard
                 continue   
-            wf_number = base_wf_number_2024
+            wf_number = base_wf
             wf_number = wf_number + offset_era * e_n
             wf_number = wf_number + offset_pd * p_n
             wf_number = wf_number + offset_events * evs 
             wf_number = round(wf_number,6)
-            step_name = "Run" + pd + era.split("Run")[1] + "_" + e_key
-            workflows[wf_number] = ['',[step_name,'HLTDR3_2024','AODNANORUN3_reHLT_2024','HARVESTRUN3_2024']]
+            step_name = "Run" + pd + era.split("Run")[1] + "_10k"
+            y = str(base_wf)
+            suff = "ZB_" if "ZeroBias" in step_name else ""
+            workflows[wf_number] = ['',[step_name,'HLTDR3_' + y,'RECONANORUN3_' + suff + 'reHLT_'+y,'HARVESTRUN3_' + suff + y]]
 
 ## 2023
-base_wf_number_2023 = 2023.0
+base_wf = 2023.0
 for e_n,era in enumerate(eras_2023):
     for p_n,pd in enumerate(pds_2023):
         for e_key,evs in event_steps_dict.items():
             if "10k" == e_key: # already defined in relval_standard
                 continue   
-            wf_number = base_wf_number_2023
+            wf_number = base_wf
             wf_number = wf_number + offset_era * e_n
             wf_number = wf_number + offset_pd * p_n
             wf_number = wf_number + offset_events * evs 
             wf_number = round(wf_number,6)
-            step_name = "Run" + pd + era.split("Run")[1] + "_" + e_key
-            workflows[wf_number] = ['',[step_name,'HLTDR3_2023','AODNANORUN3_reHLT_2023','HARVESTRUN3_2023']]
-
+            step_name = "Run" + pd + era.split("Run")[1] + "_10k"
+            y = str(base_wf) + "B" if "2023B" in era else str(base_wf)
+            suff = "ZB_" if "ZeroBias" in step_name else ""
+            workflows[wf_number] = ['',[step_name,'HLTDR3_' + y,'RECONANORUN3_' + suff + 'reHLT_'+y,'HARVESTRUN3_' + suff + y]]
 
 ## 2022
-base_wf_number_2022 = 2022.0
+base_wf = 2022.0
 for e_n,era in enumerate(eras_2022_1):
     for p_n,pd in enumerate(pds_2022_1):
         for e_key,evs in event_steps_dict.items():
             if "10k" == e_key: # already defined in relval_standard
                 continue   
-            wf_number = base_wf_number_2022
+            wf_number = base_wf
             wf_number = wf_number + offset_era * e_n
             wf_number = wf_number + offset_pd * p_n
-            wf_number = wf_number + offset_events * evs 
+            wf_number = wf_number + offset_events * evs
             wf_number = round(wf_number,6)
-            step_name = "Run" + pd + era.split("Run")[1] + "_" + e_key
-            workflows[wf_number] = ['',[step_name,'HLTDR3_2022','AODNANORUN3_reHLT_2022','HARVESTRUN3_2022']]
+            step_name = "Run" + pd + era.split("Run")[1] + "_10k"
+            y = str(base_wf)
+            suff = "ZB_" if "ZeroBias" in step_name else ""
+            workflows[wf_number] = ['',[step_name,'HLTDR3_' + y,'RECONANORUN3_' + suff + 'reHLT_'+y,'HARVESTRUN3_' + suff + y]]
 
+# PD names changed during 2022
 for e_n,era in enumerate(eras_2022_2):
     for p_n,pd in enumerate(pds_2022_2):
         for e_key,evs in event_steps_dict.items():
@@ -68,7 +74,6 @@ for e_n,era in enumerate(eras_2022_2):
             wf_number = wf_number + offset_events * evs 
             wf_number = round(wf_number,6)
             step_name = "Run" + pd + era.split("Run")[1] + "_" + e_key
-            workflows[wf_number] = ['',[step_name,'HLTDR3_2022','AODNANORUN3_reHLT_2022','HARVESTRUN3_2022']]
-
-
-
+            y = str(base_wf)
+            suff = "ZB_" if "ZeroBias" in step_name else ""
+            workflows[wf_number] = ['',[step_name,'HLTDR3_' + y,'RECONANORUN3_' + suff + 'reHLT_'+y,'HARVESTRUN3_' + suff + y]] 

--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -571,40 +571,48 @@ offset_era = 0.1 # less than 10 eras per year
 offset_pd = 0.001 # less than 100 pds per year
 
 # 2024
-base_wf_number_2024 = 2024.0
+base_wf = 2024
 for e_n,era in enumerate(['Run2024B','Run2024C','Run2024D','Run2024E']):
-    for p_n,pd in enumerate(['ZeroBias','BTagMu','JetMET0','RunDisplacedJet']):
-        wf_number = base_wf_number_2024
+    for p_n,pd in enumerate(['ZeroBias','BTagMu','JetMET0','DisplacedJet']):
+        wf_number = base_wf
         wf_number = wf_number + offset_era * e_n
         wf_number = wf_number + offset_pd * p_n
         wf_number = wf_number + 0.0001 * 0.01 
         wf_number = round(wf_number,6)
         step_name = "Run" + pd + era.split("Run")[1] + "_10k"
-        workflows[wf_number] = ['',[step_name,'HLTDR3_2024','AODNANORUN3_reHLT_2024','HARVESTRUN3_2024']]
-
+        y = str(base_wf)
+        suff = "ZB_" if "ZeroBias" in step_name else ""
+        workflows[wf_number] = ['',[step_name,'HLTDR3_' + y,'RECONANORUN3_' + suff + 'reHLT_'+y,'HARVESTRUN3_' + suff + y]]
+     
 # 2023
-base_wf_number_2023 = 2023.0
+base_wf = 2023
 for e_n,era in enumerate(['Run2023D']):
     for p_n,pd in enumerate(['MuonEG','DisplacedJet','ZeroBias']):
-        wf_number = base_wf_number_2023
+        wf_number = base_wf
         wf_number = wf_number + offset_era * e_n
         wf_number = wf_number + offset_pd * p_n
         wf_number = wf_number + 0.0001 * 0.01
         wf_number = round(wf_number,6)
         step_name = "Run" + pd + era.split("Run")[1] + "_10k"
-        workflows[wf_number] = ['',[step_name,'HLTDR3_2023','AODNANORUN3_reHLT_2023','HARVESTRUN3_2023']]
+        y = str(base_wf) + "B" if "2023B" in era else str(base_wf)
+        suff = "ZB_" if "ZeroBias" in step_name else ""
+        workflows[wf_number] = ['',[step_name,'HLTDR3_' + y,'RECONANORUN3_' + suff + 'reHLT_'+y,'HARVESTRUN3_' + suff + y]]
+        
 
 # 2022
-base_wf_number_2022 = 2022.0
+base_wf = 2022
 for e_n,era in enumerate(['Run2022C']):
     for p_n,pd in enumerate(['JetHT','EGamma','ZeroBias']):
-        wf_number = base_wf_number_2022
+        wf_number = base_wf
         wf_number = wf_number + offset_era * e_n
         wf_number = wf_number + offset_pd * p_n
         wf_number = wf_number + 0.0001 * 0.01 
         wf_number = round(wf_number,6)
         step_name = "Run" + pd + era.split("Run")[1] + "_10k"
-        workflows[wf_number] = ['',[step_name,'HLTDR3_2022','AODNANORUN3_reHLT_2022','HARVESTRUN3_2022']]
+        y = str(base_wf)
+        suff = "ZB_" if "ZeroBias" in step_name else ""
+        workflows[wf_number] = ['',[step_name,'HLTDR3_' + y,'RECONANORUN3_' + suff + 'reHLT_'+y,'HARVESTRUN3_' + suff + y]]
+
 ##################################################################
 
 ### fastsim ###

--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -572,8 +572,8 @@ offset_pd = 0.001 # less than 100 pds per year
 
 # 2024
 base_wf_number_2024 = 2024.0
-for e_n,era in enumerate(['Run2024D','Run2024C']):
-    for p_n,pd in enumerate(['JetMET0','ZeroBias']):
+for e_n,era in enumerate(['Run2024B','Run2024C','Run2024D','Run2024E']):
+    for p_n,pd in enumerate(['ZeroBias','BTagMu','JetMET0','RunDisplacedJet']):
         wf_number = base_wf_number_2024
         wf_number = wf_number + offset_era * e_n
         wf_number = wf_number + offset_pd * p_n
@@ -584,8 +584,8 @@ for e_n,era in enumerate(['Run2024D','Run2024C']):
 
 # 2023
 base_wf_number_2023 = 2023.0
-for e_n,era in enumerate(['Run2023C', 'Run2023D']):
-    for p_n,pd in enumerate(['MuonEG','DisplacedJet']):
+for e_n,era in enumerate(['Run2023D']):
+    for p_n,pd in enumerate(['MuonEG','DisplacedJet','ZeroBias']):
         wf_number = base_wf_number_2023
         wf_number = wf_number + offset_era * e_n
         wf_number = wf_number + offset_pd * p_n
@@ -596,8 +596,8 @@ for e_n,era in enumerate(['Run2023C', 'Run2023D']):
 
 # 2022
 base_wf_number_2022 = 2022.0
-for e_n,era in enumerate(['Run2022B', 'Run2022C']):
-    for p_n,pd in enumerate(['JetHT','EGamma']):
+for e_n,era in enumerate(['Run2022C']):
+    for p_n,pd in enumerate(['JetHT','EGamma','ZeroBias']):
         wf_number = base_wf_number_2022
         wf_number = wf_number + offset_era * e_n
         wf_number = wf_number + offset_pd * p_n

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2235,11 +2235,11 @@ hltKey2023='relval2023' # currently points to Fake2
 hltKey2024='relval2024' # currently points to Fake2
 hltKey2025='relval2025' # currently points to GRUN (hacky solution to keep running GRun on real data)
 
-steps['HLTDR3_2023']=merge( [ {'-s':'L1REPACK:Full,HLT:@%s'%hltKey2024,},{'--conditions':'auto:run3_hlt_relval'},{'--era' : 'Run3_2023'},steps['HLTD'] ] )
+steps['HLTDR3_2023']=merge( [ {'-s':'L1REPACK:Full,HLT:@%s'%hltKey2023,},{'--conditions':'auto:run3_hlt_relval'},{'--era' : 'Run3_2023'},steps['HLTD'] ] )
 
-steps['HLTDR3_2023B']=merge( [ {'-s':'L1REPACK:Full,HLT:@%s'%hltKey2024,},{'--conditions':'auto:run3_hlt_relval'},{'--era' : 'Run3'},steps['HLTD'] ] )
+steps['HLTDR3_2023B']=merge( [ {'-s':'L1REPACK:Full,HLT:@%s'%hltKey2023,},{'--conditions':'auto:run3_hlt_relval'},{'--era' : 'Run3'},steps['HLTD'] ] )
 
-steps['HLTDR3_2024']=merge( [ {'-s':'L1REPACK:Full,HLT:@%s'%hltKey2024,},{'--conditions':'auto:run3_hlt_relval'},{'--era' : 'Run3_2024'},steps['HLTD'] ] )
+steps['HLTDR3_2024']=merge( [ {'-s':'L1REPACK:Full,HLT:@%s'%hltKey2025,},{'--conditions':'auto:run3_hlt_relval'},{'--era' : 'Run3_2024'},steps['HLTD'] ] )
 
 steps['HLTDR3_HI2023ARawprime']=merge([{'-s':'L1REPACK:Full,HLT:HIon'},
                                        {'--conditions':'auto:run3_hlt_HIon'},
@@ -3132,17 +3132,19 @@ steps['RECOCOSMRUN3_reHLT_2022']=merge([{'--scenario':'cosmics','-s':'RAW2DIGI,L
 
 steps['AODNANORUN3_reHLT_2022']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,NANO,DQM:@standardDQMFakeHLT+@miniAODDQM+@nanoAODDQM','--datatier':'AOD,MINIAOD,NANOAOD,DQMIO','--eventcontent':'AOD,MINIAOD,NANOEDMAOD,DQM'},steps['RECODR3_reHLT_2022']])
 
-steps['RECONANORUN3_reHLT_2023']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,NANO,DQM:@standardDQM+@miniAODDQM+@nanoAODDQM','--datatier':'RECO,MINIAOD,NANOAOD,DQMIO','--eventcontent':'RECO,MINIAOD,NANOEDMAOD,DQM'},steps['RECODR3_reHLT_2023']])
+steps['RECONANORUN3_reHLT_2023']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,NANO,DQM:@standardDQMFakeHLT+@miniAODDQM+@nanoAODDQM','--datatier':'RECO,MINIAOD,NANOAOD,DQMIO','--eventcontent':'RECO,MINIAOD,NANOEDMAOD,DQM'},steps['RECODR3_reHLT_2023']])
 steps['RECONANORUN3_reHLT_2023B']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,NANO,DQM:@standardDQM+@miniAODDQM+@nanoAODDQM','--datatier':'RECO,MINIAOD,NANOAOD,DQMIO','--eventcontent':'RECO,MINIAOD,NANOEDMAOD,DQM'},steps['RECODR3_reHLT_2023B']])
-steps['RECONANORUN3_ZB_reHLT_2023B']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,NANO,DQM:@rerecoZeroBias+@miniAODDQM+@nanoAODDQM'},steps['RECONANORUN3_reHLT_2023B']])
-steps['RECONANORUN3_ZB_reHLT_2023']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,NANO,DQM:@rerecoZeroBias+@miniAODDQM+@nanoAODDQM'},steps['RECONANORUN3_reHLT_2023']])
+steps['RECONANORUN3_ZB_reHLT_2023B']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,NANO,DQM:@rerecoZeroBiasFakeHLT+@miniAODDQM+@nanoAODDQM'},steps['RECONANORUN3_reHLT_2023B']])
+steps['RECONANORUN3_ZB_reHLT_2023']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,NANO,DQM:@rerecoZeroBiasFakeHLT+@miniAODDQM+@nanoAODDQM'},steps['RECONANORUN3_reHLT_2023']])
 steps['RECOCOSMRUN3_reHLT_2023']=merge([{'--scenario':'cosmics','-s':'RAW2DIGI,L1Reco,RECO,DQM','--datatier':'RECO,DQMIO','--eventcontent':'RECO,DQM'},steps['RECONANORUN3_reHLT_2023']])
 
-steps['AODNANORUN3_reHLT_2023']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,NANO,DQM:@standardDQM+@miniAODDQM+@nanoAODDQM','--datatier':'AOD,MINIAOD,NANOAOD,DQMIO','--eventcontent':'AOD,MINIAOD,NANOEDMAOD,DQM'},steps['RECODR3_reHLT_2023']])
-steps['AODNANORUN3_reHLT_2023B']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,NANO,DQM:@standardDQM+@miniAODDQM+@nanoAODDQM','--datatier':'AOD,MINIAOD,NANOAOD,DQMIO','--eventcontent':'AOD,MINIAOD,NANOEDMAOD,DQM'},steps['RECODR3_reHLT_2023B']])
+steps['AODNANORUN3_reHLT_2023']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,NANO,DQM:@standardDQMFakeHLT+@miniAODDQM+@nanoAODDQM','--datatier':'AOD,MINIAOD,NANOAOD,DQMIO','--eventcontent':'AOD,MINIAOD,NANOEDMAOD,DQM'},steps['RECODR3_reHLT_2023']])
+steps['AODNANORUN3_reHLT_2023B']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,NANO,DQM:@standardDQMFakeHLT+@miniAODDQM+@nanoAODDQM','--datatier':'AOD,MINIAOD,NANOAOD,DQMIO','--eventcontent':'AOD,MINIAOD,NANOEDMAOD,DQM'},steps['RECODR3_reHLT_2023B']])
 
 steps['RECOHIRUN3_reHLT_2023']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,DQM:@standardDQM','--datatier':'RECO,MINIAOD,DQMIO','--eventcontent':'RECO,MINIAOD,DQM','--era':'Run3_pp_on_PbPb_approxSiStripClusters_2023','--conditions':'auto:run3_data_HIon'},steps['RECODR3_reHLT_2023']])
 
+steps['RECONANORUN3_reHLT_2024']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,NANO,DQM:@standardDQM+@miniAODDQM+@nanoAODDQM','--datatier':'RECO,MINIAOD,NANOAOD,DQMIO','--eventcontent':'RECO,MINIAOD,NANOEDMAOD,DQM'},steps['RECODR3_reHLT_2024']])
+steps['RECONANORUN3_ZB_reHLT_2024']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,NANO,DQM:@rerecoZeroBias+@miniAODDQM+@nanoAODDQM'},steps['RECONANORUN3_reHLT_2024']])
 steps['AODNANORUN3_reHLT_2024']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,NANO,DQM:@standardDQM+@miniAODDQM+@nanoAODDQM','--datatier':'AOD,MINIAOD,NANOAOD,DQMIO','--eventcontent':'AOD,MINIAOD,NANOEDMAOD,DQM'},steps['RECODR3_reHLT_2024']])
 
 # patatrack validation in data
@@ -3874,19 +3876,22 @@ steps['HARVESTDRUN3']={'-s':'HARVESTING:@standardDQMFakeHLT+@miniAODDQM+@nanoAOD
 
 steps['HARVESTPROMPTRUN3']=merge([{'--data':'', '-s':'HARVESTING:@allForPrompt','--era':'Run3'},steps['HARVESTDRUN3']])
 
-
+# 2022
 steps['HARVESTRUN3_2022']=merge([{'--data':'', '-s':'HARVESTING:@standardDQMFakeHLT+@miniAODDQM+@nanoAODDQM','--era':'Run3'},steps['HARVESTDRUN3']])
 steps['HARVESTRUN3_ZB_2022']=merge([{'--data':'', '-s':'HARVESTING:@rerecoZeroBiasFakeHLT+@miniAODDQM+@nanoAODDQM','--era':'Run3'},steps['HARVESTDRUN3']])
 steps['HARVESTRUN3_COS_2022']=merge([{'--data':'', '--scenario':'cosmics', '--era':'Run3', '-s':'HARVESTING:dqmHarvesting'},steps['HARVESTDRUN3']])
-steps['HARVESTRUN3_2023']=merge([{'--era':'Run3_2023', '-s':'HARVESTING:@standardDQM+@miniAODDQM+@nanoAODDQM'},steps['HARVESTRUN3_2022']])
-steps['HARVESTRUN3_2023B']=merge([{'--era':'Run3', '-s':'HARVESTING:@standardDQM+@miniAODDQM+@nanoAODDQM'},steps['HARVESTRUN3_2022']])
-steps['HARVESTRUN3_2024']=merge([{'--era':'Run3', '-s':'HARVESTING:@standardDQM+@miniAODDQM+@nanoAODDQM'},steps['HARVESTDRUN3']])
+# 2023
+steps['HARVESTRUN3_2023']=merge([{'--era':'Run3_2023', '-s':'HARVESTING:@standardDQMFakeHLT+@miniAODDQM+@nanoAODDQM'},steps['HARVESTRUN3_2022']])
+steps['HARVESTRUN3_2023B']=merge([{'--era':'Run3', '-s':'HARVESTING:@standardDQMFakeHLT+@miniAODDQM+@nanoAODDQM'},steps['HARVESTRUN3_2022']])
+steps['HARVESTRUN3_ZB_2023B']=merge([{'--era':'Run3', '-s':'HARVESTING:@rerecoZeroBiasFakeHLT+@miniAODDQM+@nanoAODDQM'},steps['HARVESTRUN3_2022']])
+steps['HARVESTRUN3_ZB_2023']=merge([{'--era':'Run3_2023', '-s':'HARVESTING:@rerecoZeroBiasFakeHLT+@miniAODDQM+@nanoAODDQM'},steps['HARVESTRUN3_2023']])
+steps['HARVESTRUN3_COS_2023']=merge([{'--scenario':'cosmics', '--era':'Run3_2023', '-s':'HARVESTING:dqmHarvesting'},steps['HARVESTRUN3_2022']])
+# 2024
+steps['HARVESTRUN3_ZB_2024']=merge([{'--era':'Run3_2024', '-s':'HARVESTING:@rerecoZeroBias+@miniAODDQM+@nanoAODDQM'},steps['HARVESTDRUN3']])
+steps['HARVESTRUN3_2024']=merge([{'--era':'Run3_2024', '-s':'HARVESTING:@standardDQM+@miniAODDQM+@nanoAODDQM'},steps['HARVESTDRUN3']])
 
 steps['HARVESTRUN3_HI2023A']=merge([{'--era':'Run3_pp_on_PbPb_approxSiStripClusters_2023', '-s':'HARVESTING:@standardDQM+@miniAODDQM'},steps['HARVESTRUN3_2022']])
 
-steps['HARVESTRUN3_ZB_2023B']=merge([{'--era':'Run3', '-s':'HARVESTING:@rerecoZeroBias+@miniAODDQM+@nanoAODDQM'},steps['HARVESTRUN3_2022']])
-steps['HARVESTRUN3_ZB_2023']=merge([{'--era':'Run3_2023', '-s':'HARVESTING:@rerecoZeroBias+@miniAODDQM+@nanoAODDQM'},steps['HARVESTRUN3_2022']])
-steps['HARVESTRUN3_COS_2023']=merge([{'--scenario':'cosmics', '--era':'Run3_2023', '-s':'HARVESTING:dqmHarvesting'},steps['HARVESTRUN3_2022']])
 steps['HARVESTRUN3_pixelTrackingOnly'] = merge([ {'-s':'HARVESTING:@pixelTrackingOnlyDQM'}, steps['HARVESTRUN3_2023']])
 steps['HARVESTRUN3_pixelTrackingOnlyGPUValidation'] = merge([ {'--procModifiers':'gpuValidation'}, steps['HARVESTRUN3_pixelTrackingOnly']])
 steps['HARVESTRUN3_ECALOnly'] = merge([ {'-s':'HARVESTING:@ecal'}, steps['HARVESTRUN3_2023']])

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -4379,9 +4379,10 @@ defaultDataSets['2021Design']='CMSSW_12_5_0_pre4-124X_mcRun3_2022_design_v7_desi
 defaultDataSets['2021FS']='CMSSW_12_4_13-124X_mcRun3_2022_realistic_v12_2021_FastSim-v'
 defaultDataSets['2023']='CMSSW_13_0_10-130X_mcRun3_2023_realistic_withEarly2023BS_v1_2023-v'
 defaultDataSets['2023FS']='CMSSW_13_0_11-130X_mcRun3_2023_realistic_withEarly2023BS_v1_FastSim-v'
-defaultDataSets['2024']='CMSSW_14_0_0_pre3-140X_mcRun3_2024_realistic_v1_STD_2024_noPU-v'
-defaultDataSets['2024HLTOnDigi']='CMSSW_14_0_0_pre3-140X_mcRun3_2024_realistic_v1_STD_2024_noPU-v'
-defaultDataSets["2024SimOnGen"] = 'CMSSW_14_0_0_pre3-140X_mcRun3_2024_realistic_v1_STD_2024_noPU-v'
+defaultDataSets['2024']='CMSSW_14_1_0_pre7-140X_mcRun3_2024_realistic_v21_STD_RegeneratedGS_2024_noPU-v'
+defaultDataSets['2025']='CMSSW_14_1_0_pre7-140X_mcRun3_2024_realistic_v21_STD_RegeneratedGS_2024_noPU-v'
+defaultDataSets['2024HLTOnDigi'] = defaultDataSets["2024SimOnGen"] = defaultDataSets['2024']
+defaultDataSets["2025HLTOnDigi"] = defaultDataSets["2025SimOnGen"] = defaultDataSets['2025']
 defaultDataSets['2024FS']='CMSSW_13_0_11-130X_mcRun3_2023_realistic_withEarly2023BS_v1_FastSim-v' #To replace with new dataset
 defaultDataSets['2026D49']='CMSSW_12_0_0_pre4-113X_mcRun4_realistic_v7_2026D49noPU-v'
 defaultDataSets['2026D76']='CMSSW_12_0_0_pre4-113X_mcRun4_realistic_v7_2026D76noPU-v'

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2232,8 +2232,9 @@ hltKey2022='relval2022'
 steps['HLTDR3_2022']=merge( [ {'-s':'L1REPACK:Full,HLT:@%s'%hltKey2022,},{'--conditions':'auto:run3_hlt_relval'},{'--era' : 'Run3'},steps['HLTD'] ] )
 
 hltKey2023='relval2023' # currently points to Fake2
+hltKey2024='relval2024' # currently points to Fake2
+hltKey2025='relval2025' # currently points to GRUN (hacky solution to keep running GRun on real data)
 
-hltKey2024='relval2024' # currently points to GRUN (hacky solution to keep running GRun on real data)
 steps['HLTDR3_2023']=merge( [ {'-s':'L1REPACK:Full,HLT:@%s'%hltKey2024,},{'--conditions':'auto:run3_hlt_relval'},{'--era' : 'Run3_2023'},steps['HLTD'] ] )
 
 steps['HLTDR3_2023B']=merge( [ {'-s':'L1REPACK:Full,HLT:@%s'%hltKey2024,},{'--conditions':'auto:run3_hlt_relval'},{'--era' : 'Run3'},steps['HLTD'] ] )
@@ -2772,8 +2773,8 @@ steps['RECODR3_2023']=merge([{'--era':'Run3_2023'},steps['RECODR3']])
 steps['RECODR3_2024']=merge([{'--era':'Run3_2024'},steps['RECODR3']])
 
 steps['RECODR3_reHLT_2022']=merge([{'--conditions':'auto:run3_data_relval', '--hltProcess':'reHLT'},steps['RECODR3']])
-steps['RECODR3_reHLT_2023']=merge([{'--conditions':'auto:run3_data_prompt_relval', '--hltProcess':'reHLT'},steps['RECODR3_2023']])
-steps['RECODR3_reHLT_2023B']=merge([{'--conditions':'auto:run3_data_prompt_relval', '--hltProcess':'reHLT'},steps['RECODR3']])
+steps['RECODR3_reHLT_2023']=merge([{'--conditions':'auto:run3_data_relval', '--hltProcess':'reHLT'},steps['RECODR3_2023']])
+steps['RECODR3_reHLT_2023B']=merge([{'--conditions':'auto:run3_data_relval', '--hltProcess':'reHLT'},steps['RECODR3']])
 steps['RECODR3_reHLT_2024']=merge([{'--conditions':'auto:run3_data_prompt_relval', '--hltProcess':'reHLT'},steps['RECODR3']])
 
 steps['RECODR2_2016_UPC']=merge([{'--conditions':'auto:run2_data', '--era':'Run2_2016_UPC', '-s':'RAW2DIGI,L1Reco,RECO,DQM:@commonFakeHLT+@standardDQMFakeHLT', '--repacked':''},steps['RECODR2_2016']])

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -444,8 +444,8 @@ class UpgradeWorkflow_trackingMkFit(UpgradeWorkflowTracking):
     def setup__(self, step, stepName, stepDict, k, properties):
         if ('Digi' in step and 'NoHLT' not in step) or ('HLTOnly' in step): stepDict[stepName][k] = merge([self.step2, stepDict[step][k]])
         if 'Reco' in step: stepDict[stepName][k] = merge([self.step3, stepDict[step][k]])
-    def condition_(self, fragment, stepList, key, hasHarvest):
-        return ('2017' in key or '2021' in key or '2023' in key or '2024' in key) and ('FS' not in key)
+    def condition_(self, fragment, stepList, key, hasHarvest):     
+        return any(y in key for y in ['2017','2021','2023','2024','2025']) and ('FS' not in key)
 upgradeWFs['trackingMkFit'] = UpgradeWorkflow_trackingMkFit(
     steps = [
         'Digi',
@@ -498,7 +498,7 @@ class UpgradeWorkflow_seedingDeepCore(UpgradeWorkflow):
             stepDict[stepName][k] = None
         elif 'Reco' in step or 'HARVEST' in step: stepDict[stepName][k] = merge([{'--procModifiers': 'seedingDeepCore'}, stepDict[step][k]])
     def condition(self, fragment, stepList, key, hasHarvest):
-        result = (fragment=="QCD_Pt_1800_2400_14" or fragment=="TTbar_14TeV" ) and ('2021' in key or '2024' in key) and hasHarvest
+        result = (fragment=="QCD_Pt_1800_2400_14" or fragment=="TTbar_14TeV" ) and any(y in key for y in ['2021','2024','2025']) and hasHarvest
         return result
 upgradeWFs['seedingDeepCore'] = UpgradeWorkflow_seedingDeepCore(
     steps = [
@@ -534,7 +534,7 @@ class UpgradeWorkflow_displacedRegional(UpgradeWorkflowTracking):
     def setup__(self, step, stepName, stepDict, k, properties):
         if 'Reco' in step: stepDict[stepName][k] = merge([self.step3, stepDict[step][k]])
     def condition_(self, fragment, stepList, key, hasHarvest):
-        return ('2021' in key or '2023' in key or '2024' in key)
+        return any(y in key for y in ['2021','2023','2024','2025'])
 upgradeWFs['displacedRegional'] = UpgradeWorkflow_displacedRegional(
     steps = [
         'Reco',
@@ -612,12 +612,8 @@ class UpgradeWorkflow_weightedVertex(UpgradeWorkflow):
 
     def condition(self, fragment, stepList, key, hasHarvest):
         # select only a subset of the workflows
-        selected = [
-            ('2021' in key and fragment == "TTbar_14TeV" and 'FS' not in key),
-            ('2024' in key and fragment == "TTbar_14TeV"),
-            ('2026' in key and fragment == "TTbar_14TeV")
-        ]
-        result = any(selected) and hasHarvest
+        selected = (fragment == "TTbar_14TeV") and ('FS' not in key) and hasHarvest
+        result =  selected and any(y in key for y in ['2021','2024','2025','2026'])
 
         return result
 
@@ -940,7 +936,7 @@ class PatatrackWorkflow(UpgradeWorkflow):
 
     def condition(self, fragment, stepList, key, hasHarvest):
         # select only a subset of the workflows
-        years = ['2021','2023','2024','2026']
+        years = ['2021','2023','2024','2025','2026']
         fragments = ["TTbar_14","ZMM_14","ZEE_14","ZTT_14","NuGun","SingleMu","QCD_Pt15To7000_Flat"]
         selected = [
             (any(y in key for y in years) and ('FS' not in key) and any( f in fragment for f in fragments)),
@@ -1847,7 +1843,8 @@ class UpgradeWorkflow_ProdLike(UpgradeWorkflow):
         elif 'Nano'==step:
             stepDict[stepName][k] = merge([{'--filein':'file:step4.root','-s':'NANO','--datatier':'NANOAODSIM','--eventcontent':'NANOEDMAODSIM'}, stepDict[step][k]])
     def condition(self, fragment, stepList, key, hasHarvest):
-        return fragment=="TTbar_14TeV" and ('2026' in key or '2021' in key or '2023' in key or '2024' in key)
+        years = ['2021','2023','2024','2025','2026']
+        return fragment=="TTbar_14TeV" and any(y in key for y in years)
 upgradeWFs['ProdLike'] = UpgradeWorkflow_ProdLike(
     steps = [
         'GenSimHLBeamSpot14',
@@ -2681,7 +2678,7 @@ class UpgradeWorkflowPremix(UpgradeWorkflow):
     def condition(self, fragment, stepList, key, hasHarvest):
         if not 'PU' in key:
             return False
-        if not any(y in key for y in ['2021', '2023', '2024', '2026']):
+        if not any(y in key for y in ['2021', '2023', '2024', '2025', '2026']):
             return False
         if self.suffix.endswith("S1"):
             return "NuGun" in fragment
@@ -3149,7 +3146,7 @@ upgradeProperties[2017] = {
         'HLTmenu': '@relval2024',
         'Era' : 'Run3_2024',
         'BeamSpot': 'DBrealistic',
-        'ScenToRun' : ['GenSim','Digi','RecoNano','HARVESTNano','ALCA'],
+        'ScenToRun' : ['GenSim','Digi','RecoNanoFakeHLT','HARVESTNanoFakeHLT','ALCA'],
     },
     '2024HLTOnDigi' : {
         'Geom' : 'DB:Extended',
@@ -3157,7 +3154,7 @@ upgradeProperties[2017] = {
         'HLTmenu': '@relval2024',
         'Era' : 'Run3',
         'BeamSpot': 'DBrealistic',
-        'ScenToRun' : ['GenSim','DigiNoHLT','HLTOnly','RecoNano','HARVESTNano','ALCA'],
+        'ScenToRun' : ['GenSim','DigiNoHLT','HLTOnly','RecoNanoFakeHLT','HARVESTNanoFakeHLT','ALCA'],
     },
     '2021FS' : {
         'Geom' : 'DB:Extended',
@@ -3228,7 +3225,7 @@ upgradeProperties[2017] = {
         'HLTmenu': '@relval2024',
         'Era' : 'Run3',
         'BeamSpot': 'DBrealistic',
-        'ScenToRun' : ['Gen','Sim','Digi','RecoNano','HARVESTNano','ALCA'],
+        'ScenToRun' : ['Gen','Sim','Digi','RecoNanoFakeHLT','HARVESTNanoFakeHLT','ALCA'],
     },
     '2024FS' : {
         'Geom' : 'DB:Extended',

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -42,6 +42,12 @@ upgradeKeys[2017] = [
     '2024SimOnGen',
     '2024FS',
     '2024FSPU',
+    '2025',
+    '2025PU',
+    '2025HLTOnDigi',
+    '2025HLTOnDigiPU',
+    '2025SimOnGen',
+    '2025GenOnly',
 ]
 
 upgradeKeys[2026] = [
@@ -180,9 +186,11 @@ upgradeWFs = OrderedDict()
 
 class UpgradeWorkflow_baseline(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):
+  
         cust=properties.get('Custom', None)
         era=properties.get('Era', None)
         modifier=properties.get('ProcessModifier',None)
+
         if cust is not None: stepDict[stepName][k]['--customise']=cust
         if era is not None:
             stepDict[stepName][k]['--era']=era
@@ -2961,7 +2969,8 @@ upgradeWFs['DD4hepDB'].allowReuse = False
 class UpgradeWorkflow_DDDDB(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):
         the_era = stepDict[step][k]['--era']
-        if 'Run3' in the_era and '2023' not in the_era and '2024' not in the_era and 'Fast' not in the_era and "Pb" not in the_era:
+        exclude = ['2025','2024','2023','Fast','Pb']
+        if 'Run3' in the_era and not any(e in the_era for e in exclude):
             # retain any other eras
             tmp_eras = the_era.split(',')
             tmp_eras[tmp_eras.index("Run3")] = 'Run3_DDD'
@@ -3229,6 +3238,39 @@ upgradeProperties[2017] = {
         'BeamSpot': 'DBrealistic',
         'ScenToRun' : ['Gen','FastSimRun3','HARVESTFastRun3'],
     },
+    '2025' : {
+        'Geom' : 'DB:Extended',
+        'GT' : 'auto:phase1_2025_realistic',
+        'HLTmenu': '@relval2025',
+        'Era' : 'Run3_2025',
+        'BeamSpot': 'DBrealistic',
+        'ScenToRun' : ['GenSim','Digi','RecoNano','HARVESTNano','ALCA'],
+    },
+    '2025HLTOnDigi' : {
+        'Geom' : 'DB:Extended',
+        'GT' : 'auto:phase1_2025_realistic',
+        'HLTmenu': '@relval2025',
+        'Era' : 'Run3_2025',
+        'BeamSpot': 'DBrealistic',
+        'ScenToRun' : ['GenSim','DigiNoHLT','HLTOnly','RecoNano','HARVESTNano','ALCA'],
+    },
+    '2025GenOnly' : {
+        'Geom' : 'DB:Extended',
+        'GT' : 'auto:phase1_2025_realistic',
+        'HLTmenu': '@relval2025',
+        'Era' : 'Run3_2025',
+        'BeamSpot': 'DBrealistic',
+        'ScenToRun' : ['Gen'],
+    },
+    '2025SimOnGen' : {
+        'Geom' : 'DB:Extended',
+        'GT' : 'auto:phase1_2025_realistic',
+        'HLTmenu': '@relval2025',
+        'Era' : 'Run3_2025',
+        'BeamSpot': 'DBrealistic',
+        'ScenToRun' : ['Gen','Sim','Digi','RecoNano','HARVESTNano','ALCA'],
+    },
+    
 }
 
 # standard PU sequences

--- a/Configuration/PyReleaseValidation/scripts/README.md
+++ b/Configuration/PyReleaseValidation/scripts/README.md
@@ -321,10 +321,12 @@ MC workflows for pp collisions:
 | 11634.0 	| TTbar_14TeV 	| phase1_2022_realistic 	| Run3 	|  	|  	
 | 13234.0 	| RelValTTbar_14TeV 	| phase1_2022_realistic 	| Run3_FastSim 	| *FastSim*  |  	
 | 12434.0 	| RelValTTbar_14TeV 	| phase1_2023_realistic 	| Run3_2023 	|  	|  	
-| 12834.0 	| RelValTTbar_14TeV 	| phase1_2023_realistic 	| Run3_2024 	|  	| 
+| 12834.0 	| RelValTTbar_14TeV 	| phase1_2024_realistic 	| Run3_2024 	|  	| 
 | 12846.0 	| RelValZEE_14 	| phase1_2023_realistic 	| Run3_2024 	|  	|  	
-| 13034.0 	| RelValTTbar_14TeV 	| phase1_2023_realistic 	| Run3_2024 	|  Run3_Flat55To75_PoissonOOTPU 	|  	
-| 12834.7 	| RelValTTbar_14TeV 	| phase1_2023_realistic 	| Run3_2024 	| mkFit 	|  	
+| 13034.0 	| RelValTTbar_14TeV 	| phase1_2024_realistic 	| Run3_2024 	|  Run3_Flat55To75_PoissonOOTPU 	|  	
+| 12834.7 	| RelValTTbar_14TeV 	| phase1_2024_realistic 	| Run3_2024 	| mkFit 	|  	
+| 12834.0 	| RelValTTbar_14TeV 	| phase1_2024_realistic 	| Run3_2024 	|  	| 
+| 16834.0 	| RelValTTbar_14TeV 	| phase1_2025_realistic 	| Run3_2025 	|  	| 
 | 14034.0 	| RelValTTbar_14TeV 	| phase1_2023_realistic 	| Run3_2023_FastSim 	|  	*FastSim* |  	
 | 14234.0 	| RelValTTbar_14TeV 	| phase1_2023_realistic 	| Run3_2023_FastSim 	| *FastSim*  Run3_Flat55To75_PoissonOOTPU 	|  	
 | 2500.201 	| RelValTTbar_14TeV 	| phase1_2022_realistic 	| Run3 	| NanoAOD from existing MINI 	|  	

--- a/Configuration/PyReleaseValidation/scripts/README.md
+++ b/Configuration/PyReleaseValidation/scripts/README.md
@@ -367,14 +367,12 @@ pp Data reRECO workflows:
 | 2021 	|  	|  	|  	|  	|  	
 | 139.001 	| Run2021 	MinimumBias 	| run3_hlt_relval 	| Run3 	| HLT@relval2022 (Commissioning2021) |	
 | 2022 	|  	|  	|  	|  	|  	
-| 140.023 	| Run2022B ZeroBias 	|  	run3_hlt_relval |  	Run3 |  	HLT:@relval2022 |  	
-| 140.043 	| Run2022C ZeroBias 	|  	run3_hlt_relval |  	Run3 |  	HLT:@relval2022 |  	
-| 140.063 	| Run2022D ZeroBias 	|  	run3_hlt_relval |  	Run3 |  	HLT:@relval2022 |  	
-| 2023 	|  	|  	|  	|  	|  	
-| 141.044 	| Run2023D JetMET0 	| run3_hlt_relval 	| Run3_2023 	| HLT@relval2024 	|  
-| 141.042 	| Run2023D ZeroBias 	| run3_hlt_relval 	| Run3_2023 	| HLT@relval2024 	|  	
-| 141.046 	| Run2023D EGamma0 	| run3_hlt_relval 	| Run3_2023 	| HLT@relval2024 	|  	
-
+| 2022.222005 	| Run2022D ZeroBias 	|  	run3_hlt_relval + run3_data_relval |  	Run3 |  	HLT:@relval2022 |  	
+| 2023.211005 	| Run2023D ZeroBias 	|  	run3_hlt_relval + run3_data_relval|  	Run3_2023 |  	HLT:@relval2023 | 
+| 2024.014005 	| Run2024B ZeroBias 	|  	run3_hlt_relval + run3_data_prompt_relval|  	Run3_2024 |  	HLT:@relval2023 |  
+| 2024.100005 	| Run2024C BTagMu 	|  	run3_hlt_relval + run3_data_prompt_relval|  	Run3_2024 |  	HLT:@relval2025 |  
+| 2024.204005 	| Run2024D JetMET0 	|  	run3_hlt_relval + run3_data_prompt_relval|  	Run3_2024 |  	HLT:@relval2025 |  
+| 2024.301005 	| Run2024E RunDisplacedJet 	|  	run3_hlt_relval + run3_data_prompt_relval|  	Run3_2024 |  	HLT:@relval2025 |  
 
 And Heavy Ion workflows:
 

--- a/Configuration/PyReleaseValidation/scripts/README.md
+++ b/Configuration/PyReleaseValidation/scripts/README.md
@@ -367,12 +367,14 @@ pp Data reRECO workflows:
 | 2021 	|  	|  	|  	|  	|  	
 | 139.001 	| Run2021 	MinimumBias 	| run3_hlt_relval 	| Run3 	| HLT@relval2022 (Commissioning2021) |	
 | 2022 	|  	|  	|  	|  	|  	
-| 2022.222005 	| Run2022D ZeroBias 	|  	run3_hlt_relval + run3_data_relval |  	Run3 |  	HLT:@relval2022 |  	
-| 2023.211005 	| Run2023D ZeroBias 	|  	run3_hlt_relval + run3_data_relval|  	Run3_2023 |  	HLT:@relval2023 | 
-| 2024.014005 	| Run2024B ZeroBias 	|  	run3_hlt_relval + run3_data_prompt_relval|  	Run3_2024 |  	HLT:@relval2023 |  
-| 2024.100005 	| Run2024C BTagMu 	|  	run3_hlt_relval + run3_data_prompt_relval|  	Run3_2024 |  	HLT:@relval2025 |  
-| 2024.204005 	| Run2024D JetMET0 	|  	run3_hlt_relval + run3_data_prompt_relval|  	Run3_2024 |  	HLT:@relval2025 |  
-| 2024.301005 	| Run2024E RunDisplacedJet 	|  	run3_hlt_relval + run3_data_prompt_relval|  	Run3_2024 |  	HLT:@relval2025 |  
+| 2022.002001 	| Run2022D ZeroBias 	|  	run3_hlt_relval + run3_data_relval |  	Run3 |  	HLT:@relval2022 | 
+| 2022.000001 	| Run2022D JetHT 	|  	run3_hlt_relval + run3_data_relval |  	Run3 |  	HLT:@relval2022 |  	
+| 2023.002001 	| Run2023D ZeroBias 	|  	run3_hlt_relval + run3_data_relval|  	Run3_2023 |  	HLT:@relval2023 | 
+| 2023.000001 	| Run2023D MuonEG 	|  	run3_hlt_relval + run3_data_relval|  	Run3_2023 |  	HLT:@relval2023 | 
+| 2024.000001 	| Run2024B ZeroBias 	|  	run3_hlt_relval + run3_data_prompt_relval|  	Run3_2024 |  	HLT:@relval2023 |  
+| 2024.101001 	| Run2024C BTagMu 	|  	run3_hlt_relval + run3_data_prompt_relval|  	Run3_2024 |  	HLT:@relval2025 |  
+| 2024.202001 	| Run2024D JetMET0 	|  	run3_hlt_relval + run3_data_prompt_relval|  	Run3_2024 |  	HLT:@relval2025 |  
+| 2024.303001 	| Run2024E RunDisplacedJet 	|  	run3_hlt_relval + run3_data_prompt_relval|  	Run3_2024 |  	HLT:@relval2025 |  
 
 And Heavy Ion workflows:
 

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -85,6 +85,7 @@ if __name__ == '__main__':
                     12846.0,    # RelValZEE_13                  2024
                     13034.0,    # RelValTTbar_14TeV             2024 PU = Run3_Flat55To75_PoissonOOTPU
                     12834.7,    # RelValTTbar_14TeV             2024 mkFit
+                    16834.0,    # RelValTTbar_14TeV             2025
                     14034.0,    # RelValTTbar_14TeV             Run3_2023_FastSim 
                     14234.0,    # RelValTTbar_14TeV             Run3_2023_FastSim   PU = Run3_Flat55To75_PoissonOOTPU
                     2500.201,   # RelValTTbar_14TeV             NanoAOD from existing MINI

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -116,24 +116,24 @@ if __name__ == '__main__':
                     139.001,    # Run2021  MinimumBias                  Commissioning2021   
                     
                     # 2022
-                    140.023,    # Run2022B ZeroBias 
-                    140.043,    # Run2022C ZeroBias 
-                    140.063,    # Run2022D ZeroBias 
+                    2022.222005,    # Run2022C ZeroBias
 
                     # 2023
-                    141.044,    # Run2023D JetMET0
-                    141.042,    # Run2023D ZeroBias
-                    141.046,    # Run2023D EGamma0
+                    2023.211005,    # Run2023D ZeroBias
 
+                    # 2024
+                    2024.014005,      # Run2024B ZeroBias
+                    2024.100005,      # Run2024C BTagMu 
+                    2024.204005,      # Run2024D JetMET0
+                    2024.301005,      # Run2024E RunDisplacedJet
+                    
                     ###### Heavy Ions
                     ## Data
                     # Run2   
                     140.56,    # HIRun2018A HIHardProbes                    Run2_2018_pp_on_AA 
                     ## MC
-                    # Run3
-                    312.0,     # Pyquen_ZeemumuJets_pt10_2760GeV            2022    PU : HiMixGEN
-                    322.0,     # Pyquen_ZeemumuJets_pt10_5362GeV_2023       2023    PU : HiMixGEN
-                    332.0,     # Pyquen_ZeemumuJets_pt10_5362GeV_2024       2024    PU : HiMixGEN
+                    312.0,     # Pyquen_ZeemumuJets_pt10_2760GeV            PU : HiMixGEN 
+
                      ],
         'jetmc': [5.1, 13, 15, 25, 38, 39], #MC
         'metmc' : [5.1, 15, 25, 37, 38, 39], #MC

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -116,16 +116,18 @@ if __name__ == '__main__':
                     139.001,    # Run2021  MinimumBias                  Commissioning2021   
                     
                     # 2022
-                    2022.222005,    # Run2022C ZeroBias
+                    2022.002001,    # Run2022C ZeroBias
+                    2022.000001,    # Run2022C JetHT
 
                     # 2023
-                    2023.211005,    # Run2023D ZeroBias
+                    2023.002001,    # Run2023D ZeroBias
+                    2023.002001,    # Run2023D MuonEG
 
                     # 2024
-                    2024.014005,      # Run2024B ZeroBias
-                    2024.100005,      # Run2024C BTagMu 
-                    2024.204005,      # Run2024D JetMET0
-                    2024.301005,      # Run2024E RunDisplacedJet
+                    2024.000001,      # Run2024B ZeroBias
+                    2024.101001,      # Run2024C BTagMu 
+                    2024.202001,      # Run2024D JetMET0
+                    2024.303001,      # Run2024E DisplacedJet
                     
                     ###### Heavy Ions
                     ## Data


### PR DESCRIPTION
#### PR description:

This PR proposes the addition of 2025 wfs to the matrix. For the moment they are a copy of what we run currently for 2024 with the idea that once 2025 parameters (conditions, HLT) come  we will simply need to fill the dummy ones (keeping them in sync one with the other). Here I add also:

- `@relval2025` pointing to `GRun`;
- `auto:phase1_2025_*` symbolic GTs;

The era is `Era_2025` that for now is simply a copy of `Era_2024`. A TTbar 2025 noPU wf is added to the limited matrix to be tested with PRs.

The rationale is that I would like to avoid (with some anticipation) that we fall again in a situation such as https://github.com/cms-sw/cmssw/issues/44028 or https://github.com/cms-sw/cmssw/issues/41410. 

Additional changes:
- 2023 data wfs GT moved to the offline one (`auto:run3_data_relval`);
- 2024 data wfs added to the PR tests reducing the number of 2022,2023 wfs;
- small fixes for `ZeroBias` 2024 wfs to have the RECO datatier produced for them (as it was in 2023 and 2022) and to run the proper DQM sequence.
- 2024 HLT moved to `relval2025` to keep `GRun` tested;
- `relval_2024` moved to `Fake2`;
- 2023 data wfs HLT moved to `relval_2023` (`Fake2`);

#### PR validation:

New wfs run.