### PR TITLE
make `AlcaBeamMonitor` hoard less memory

### DIFF
--- a/DQM/BeamMonitor/plugins/AlcaBeamMonitor.h
+++ b/DQM/BeamMonitor/plugins/AlcaBeamMonitor.h
@@ -8,8 +8,11 @@
  */
 // C++
 #include <map>
+#include <array>
 #include <vector>
 #include <string>
+#include <utility>
+
 // CMS
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -28,8 +31,23 @@ class BeamFitter;
 class PVFitter;
 
 namespace alcabeammonitor {
+
+  struct pvPosAndErr {
+    // Array of pairs: (value, error) for x, y, z
+    std::array<std::pair<double, double>, 3> data;
+
+    // Constructor initializes the array with values and errors from a reco::Vertex
+    pvPosAndErr(const reco::Vertex& vertex)
+        : data{{{vertex.x(), vertex.xError()}, {vertex.y(), vertex.yError()}, {vertex.z(), vertex.zError()}}} {}
+
+    // Accessor functions that return pairs (value, error) directly
+    std::pair<double, double> xWithError() const { return data[0]; }
+    std::pair<double, double> yWithError() const { return data[1]; }
+    std::pair<double, double> zWithError() const { return data[2]; }
+  };
+
   struct BeamSpotInfo {
-    std::vector<reco::VertexCollection> vertices_;
+    std::vector<std::vector<pvPosAndErr>> vertices_;
     typedef std::map<std::string, reco::BeamSpot> BeamSpotContainer;
     BeamSpotContainer beamSpotMap_;
   };


### PR DESCRIPTION
#### PR description:

This PR is meant to partially address https://github.com/cms-sw/cmssw/issues/42995 by means of storing the vertex position and errors for the vertices of interest in a dedicated `struct` within `BeamSpotInfo`  instead of copying the raw `reco::Vertex` objects directly in it. 

#### PR validation:

`cmssw` compiles, will be tested in PR tests.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but will be backported to (at least) 14.1.X if successful. 