### PR TITLE
Add support for ROCm 6.x (14.0.x)

### DIFF
--- a/HeterogeneousCore/ROCmServices/plugins/ROCmService.cc
+++ b/HeterogeneousCore/ROCmServices/plugins/ROCmService.cc
@@ -6,7 +6,12 @@
 #include <vector>
 
 #include <hip/hip_runtime.h>
+#if HIP_VERSION_MAJOR >= 6
+// the location of rocm_version.h changed in HIP/ROCm 6.0
+#include <rocm-core/rocm_version.h>
+#else
 #include <rocm_version.h>
+#endif  // HIP_VERSION_MAJOR
 #include <rocm_smi/rocm_smi.h>
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"


### PR DESCRIPTION
#### PR description:

ROCm 6.0 moved `rocm_version.h` to `rocm-core/rocm_version.h`.

This change is useful for testing the impact of more recent ROCm versions on the HLT performance.

#### PR validation:

Tested on AMD MI300X GPUs with ROCm 6.2.2.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #44824.