### PR TITLE
Improve plotting utilities to generate Tracker maps given user input

### DIFF
--- a/DQM/TrackerRemapper/bin/printPixelLayersDisksMap.cc
+++ b/DQM/TrackerRemapper/bin/printPixelLayersDisksMap.cc
@@ -1,5 +1,6 @@
 #include "DQM/TrackerRemapper/interface/Phase1PixelMaps.h"
-#include <cstdlib>
+#include <cstdint>  // For uint32_t
+#include <cstdlib>  // For std::exit
 #include <fstream>
 #include <iostream>
 #include <numeric>  // std::accumulate
@@ -10,21 +11,45 @@
 #include "TCanvas.h"
 #include "TStyle.h"
 
+void showHelp() {
+  std::cout << "Usage: \n"
+            << "  --input-file <filename>       Specify the input file\n"
+            << "  --h or --help                 Show this help message\n"
+            << "  <detid>                       Provide DetId (list of DetIds)\n";
+}
+
 int main(int argc, char* argv[]) {
   std::string inputFile;
   std::vector<std::pair<uint32_t, float>> detidValues;
 
+  // If no arguments are passed or --h/--help is passed, show the help message
+  if (argc == 1) {
+    showHelp();
+    return 0;
+  }
+
   // Parse command line arguments
   for (int i = 1; i < argc; ++i) {
-    if (std::string(argv[i]) == "--input-file" && i + 1 < argc) {
+    std::string arg = argv[i];
+
+    if (arg == "--h" || arg == "--help") {
+      showHelp();
+      return 0;  // Exit after displaying help
+    } else if (arg == "--input-file" && i + 1 < argc) {
       gStyle->SetPalette(kRainbow);
       gStyle->SetNumberContours(256);
       inputFile = argv[++i];
     } else {
       gStyle->SetPalette(1);
       // Treat as DetId list if no --input-file is provided
-      uint32_t detid = std::stoul(argv[i]);
-      detidValues.emplace_back(detid, 1.0);  // Default value is 1.0
+      try {
+        uint32_t detid = std::stoul(arg);
+        detidValues.emplace_back(detid, 1.0);  // Default value is 1.0
+      } catch (const std::invalid_argument&) {
+        std::cerr << "Invalid DetId: " << arg << "\n";
+        showHelp();
+        return 1;
+      }
     }
   }
 

--- a/DQM/TrackerRemapper/bin/printPixelLayersDisksMap.cc
+++ b/DQM/TrackerRemapper/bin/printPixelLayersDisksMap.cc
@@ -11,8 +11,9 @@
 #include "TCanvas.h"
 #include "TStyle.h"
 
-void showHelp() {
-  std::cout << "Usage: \n"
+void showHelp(const std::string& scriptName) {
+  std::cout << "Usage: " << scriptName << " [options] <detid>\n"
+            << "Options:\n"
             << "  --input-file <filename>       Specify the input file\n"
             << "  --h or --help                 Show this help message\n"
             << "  <detid>                       Provide DetId (list of DetIds)\n";
@@ -24,7 +25,7 @@ int main(int argc, char* argv[]) {
 
   // If no arguments are passed or --h/--help is passed, show the help message
   if (argc == 1) {
-    showHelp();
+    showHelp(argv[0]);
     return 0;
   }
 
@@ -33,7 +34,7 @@ int main(int argc, char* argv[]) {
     std::string arg = argv[i];
 
     if (arg == "--h" || arg == "--help") {
-      showHelp();
+      showHelp(argv[0]);
       return 0;  // Exit after displaying help
     } else if (arg == "--input-file" && i + 1 < argc) {
       gStyle->SetPalette(kRainbow);
@@ -47,7 +48,7 @@ int main(int argc, char* argv[]) {
         detidValues.emplace_back(detid, 1.0);  // Default value is 1.0
       } catch (const std::invalid_argument&) {
         std::cerr << "Invalid DetId: " << arg << "\n";
-        showHelp();
+        showHelp(argv[0]);
         return 1;
       }
     }

--- a/DQM/TrackerRemapper/bin/printPixelROCsMap.cc
+++ b/DQM/TrackerRemapper/bin/printPixelROCsMap.cc
@@ -1,6 +1,7 @@
 #include "DQM/TrackerRemapper/interface/Phase1PixelROCMaps.h"
 #include <bitset>
-#include <cstdlib>
+#include <cstdint>  // for uint32_t
+#include <cstdlib>  // for std::exit
 #include <fstream>
 #include <iostream>
 #include <numeric>  // std::accumulate
@@ -11,27 +12,47 @@
 #include "TCanvas.h"
 #include "TStyle.h"
 
+void showHelp() {
+  std::cout << "Usage: \n"
+            << "  --input-file <filename>       Specify the input file\n"
+            << "  --input-ROCs <filename>       Specify the input ROCs file\n"
+            << "  --h or --help                 Show this help message\n"
+            << "  <detid>                       Provide DetId (list of DetIds)\n";
+}
+
 int main(int argc, char* argv[]) {
   std::string inputFile;
   std::string inputROCsFile;
   std::vector<std::pair<uint32_t, float>> detidValues;
   std::vector<std::pair<uint32_t, std::bitset<16>>> detidRocs;
 
+  // If no arguments are passed or --h/--help is passed, show the help message
+  if (argc == 1) {
+    showHelp();
+    return 0;
+  }
+
   // Parse command line arguments
   for (int i = 1; i < argc; ++i) {
-    if (std::string(argv[i]) == "--input-file" && i + 1 < argc) {
-      gStyle->SetPalette(kRainbow);
-      gStyle->SetNumberContours(256);
+    std::string arg = argv[i];
+
+    if (arg == "--h" || arg == "--help") {
+      showHelp();
+      return 0;  // Exit after displaying help
+    } else if (arg == "--input-file" && i + 1 < argc) {
       inputFile = argv[++i];
-    } else if (std::string(argv[i]) == "--input-ROCs" && i + 1 < argc) {
-      gStyle->SetPalette(kRainBow);
-      gStyle->SetNumberContours(256);
+    } else if (arg == "--input-ROCs" && i + 1 < argc) {
       inputROCsFile = argv[++i];
     } else {
-      gStyle->SetPalette(1);
-      // Treat as DetId list if no --input-file is provided
-      uint32_t detid = std::stoul(argv[i]);
-      detidValues.emplace_back(detid, 1.0);  // Default value is 1.0
+      // Assume it's a DetId, convert to uint32_t
+      try {
+        uint32_t detid = std::stoul(arg);
+        detidValues.emplace_back(detid, 1.0);  // Default value is 1.0
+      } catch (const std::invalid_argument&) {
+        std::cerr << "Invalid argument: " << arg << "\n";
+        showHelp();
+        return 1;
+      }
     }
   }
 

--- a/DQM/TrackerRemapper/bin/printPixelROCsMap.cc
+++ b/DQM/TrackerRemapper/bin/printPixelROCsMap.cc
@@ -12,8 +12,8 @@
 #include "TCanvas.h"
 #include "TStyle.h"
 
-void showHelp() {
-  std::cout << "Usage: \n"
+void showHelp(const std::string& scriptName) {
+  std::cout << "Usage: " << scriptName << " [options] <detid>\n"
             << "  --input-file <filename>       Specify the input file\n"
             << "  --input-ROCs <filename>       Specify the input ROCs file\n"
             << "  --h or --help                 Show this help message\n"
@@ -28,7 +28,7 @@ int main(int argc, char* argv[]) {
 
   // If no arguments are passed or --h/--help is passed, show the help message
   if (argc == 1) {
-    showHelp();
+    showHelp(argv[0]);
     return 0;
   }
 
@@ -37,7 +37,7 @@ int main(int argc, char* argv[]) {
     std::string arg = argv[i];
 
     if (arg == "--h" || arg == "--help") {
-      showHelp();
+      showHelp(argv[0]);
       return 0;  // Exit after displaying help
     } else if (arg == "--input-file" && i + 1 < argc) {
       inputFile = argv[++i];
@@ -50,7 +50,7 @@ int main(int argc, char* argv[]) {
         detidValues.emplace_back(detid, 1.0);  // Default value is 1.0
       } catch (const std::invalid_argument&) {
         std::cerr << "Invalid argument: " << arg << "\n";
-        showHelp();
+        showHelp(argv[0]);
         return 1;
       }
     }

--- a/DQM/TrackerRemapper/bin/printPixelTrackerMap.cc
+++ b/DQM/TrackerRemapper/bin/printPixelTrackerMap.cc
@@ -11,8 +11,8 @@
 #include "TCanvas.h"
 #include "TStyle.h"
 
-void showHelp() {
-  std::cout << "Usage: \n"
+void showHelp(const std::string& scriptName) {
+  std::cout << "Usage: " << scriptName << " [options] <detid>\n"
             << "  --input-file <filename>       Specify the input file\n"
             << "  --h or --help                 Show this help message\n"
             << "  <detid>                       Provide DetId (list of DetIds)\n";
@@ -24,7 +24,7 @@ int main(int argc, char* argv[]) {
 
   // If no arguments are passed or --h/--help is passed, show the help message
   if (argc == 1) {
-    showHelp();
+    showHelp(argv[0]);
     return 0;
   }
 
@@ -33,7 +33,7 @@ int main(int argc, char* argv[]) {
     std::string arg = argv[i];
 
     if (arg == "--h" || arg == "--help") {
-      showHelp();
+      showHelp(argv[0]);
       return 0;  // Exit after displaying help
     } else if (arg == "--input-file" && i + 1 < argc) {
       gStyle->SetPalette(kRainbow);
@@ -47,7 +47,7 @@ int main(int argc, char* argv[]) {
         detidValues.emplace_back(detid, 1.0);  // Default value is 1.0
       } catch (const std::invalid_argument&) {
         std::cerr << "Invalid DetId: " << arg << "\n";
-        showHelp();
+        showHelp(argv[0]);
         return 1;
       }
     }

--- a/DQM/TrackerRemapper/bin/printPixelTrackerMap.cc
+++ b/DQM/TrackerRemapper/bin/printPixelTrackerMap.cc
@@ -1,5 +1,6 @@
 #include "DQM/TrackerRemapper/interface/Phase1PixelSummaryMap.h"
-#include <cstdlib>
+#include <cstdint>  // For uint32_t
+#include <cstdlib>  // For std::exit
 #include <fstream>
 #include <iostream>
 #include <numeric>  // std::accumulate
@@ -10,21 +11,45 @@
 #include "TCanvas.h"
 #include "TStyle.h"
 
+void showHelp() {
+  std::cout << "Usage: \n"
+            << "  --input-file <filename>       Specify the input file\n"
+            << "  --h or --help                 Show this help message\n"
+            << "  <detid>                       Provide DetId (list of DetIds)\n";
+}
+
 int main(int argc, char* argv[]) {
   std::string inputFile;
   std::vector<std::pair<uint32_t, float>> detidValues;
 
+  // If no arguments are passed or --h/--help is passed, show the help message
+  if (argc == 1) {
+    showHelp();
+    return 0;
+  }
+
   // Parse command line arguments
   for (int i = 1; i < argc; ++i) {
-    if (std::string(argv[i]) == "--input-file" && i + 1 < argc) {
+    std::string arg = argv[i];
+
+    if (arg == "--h" || arg == "--help") {
+      showHelp();
+      return 0;  // Exit after displaying help
+    } else if (arg == "--input-file" && i + 1 < argc) {
       gStyle->SetPalette(kRainbow);
       gStyle->SetNumberContours(256);
       inputFile = argv[++i];
     } else {
       gStyle->SetPalette(1);
       // Treat as DetId list if no --input-file is provided
-      uint32_t detid = std::stoul(argv[i]);
-      detidValues.emplace_back(detid, 1.0);  // Default value is 1.0
+      try {
+        uint32_t detid = std::stoul(arg);
+        detidValues.emplace_back(detid, 1.0);  // Default value is 1.0
+      } catch (const std::invalid_argument&) {
+        std::cerr << "Invalid DetId: " << arg << "\n";
+        showHelp();
+        return 1;
+      }
     }
   }
 

--- a/DQM/TrackerRemapper/bin/printStripTrackerMap.cc
+++ b/DQM/TrackerRemapper/bin/printStripTrackerMap.cc
@@ -11,8 +11,8 @@
 #include "TCanvas.h"
 #include "TStyle.h"
 
-void showHelp() {
-  std::cout << "Usage: \n"
+void showHelp(const std::string& scriptName) {
+  std::cout << "Usage: " << scriptName << " [options] <detid>\n"
             << "  --input-file <filename>       Specify the input file\n"
             << "  --h or --help                 Show this help message\n"
             << "  <detid>                       Provide DetId (list of DetIds)\n";
@@ -24,7 +24,7 @@ int main(int argc, char* argv[]) {
 
   // If no arguments are passed or --h/--help is passed, show the help message
   if (argc == 1) {
-    showHelp();
+    showHelp(argv[0]);
     return 0;
   }
 
@@ -33,7 +33,7 @@ int main(int argc, char* argv[]) {
     std::string arg = argv[i];
 
     if (arg == "--h" || arg == "--help") {
-      showHelp();
+      showHelp(argv[0]);
       return 0;  // Exit after displaying help
     } else if (arg == "--input-file" && i + 1 < argc) {
       gStyle->SetPalette(kRainbow);
@@ -47,7 +47,7 @@ int main(int argc, char* argv[]) {
         detidValues.emplace_back(detid, 1.0);  // Default value is 1.0
       } catch (const std::invalid_argument&) {
         std::cerr << "Invalid DetId: " << arg << "\n";
-        showHelp();
+        showHelp(argv[0]);
         return 1;
       }
     }

--- a/DQM/TrackerRemapper/bin/printStripTrackerMap.cc
+++ b/DQM/TrackerRemapper/bin/printStripTrackerMap.cc
@@ -1,5 +1,6 @@
 #include "DQM/TrackerRemapper/interface/SiStripTkMaps.h"
-#include <cstdlib>
+#include <cstdint>  // For uint32_t
+#include <cstdlib>  // For std::exit
 #include <fstream>
 #include <iostream>
 #include <numeric>  // std::accumulate
@@ -10,21 +11,45 @@
 #include "TCanvas.h"
 #include "TStyle.h"
 
+void showHelp() {
+  std::cout << "Usage: \n"
+            << "  --input-file <filename>       Specify the input file\n"
+            << "  --h or --help                 Show this help message\n"
+            << "  <detid>                       Provide DetId (list of DetIds)\n";
+}
+
 int main(int argc, char* argv[]) {
   std::string inputFile;
   std::vector<std::pair<uint32_t, float>> detidValues;
 
+  // If no arguments are passed or --h/--help is passed, show the help message
+  if (argc == 1) {
+    showHelp();
+    return 0;
+  }
+
   // Parse command line arguments
   for (int i = 1; i < argc; ++i) {
-    if (std::string(argv[i]) == "--input-file" && i + 1 < argc) {
+    std::string arg = argv[i];
+
+    if (arg == "--h" || arg == "--help") {
+      showHelp();
+      return 0;  // Exit after displaying help
+    } else if (arg == "--input-file" && i + 1 < argc) {
       gStyle->SetPalette(kRainbow);
       gStyle->SetNumberContours(256);
       inputFile = argv[++i];
     } else {
       gStyle->SetPalette(1);
       // Treat as DetId list if no --input-file is provided
-      uint32_t detid = std::stoul(argv[i]);
-      detidValues.emplace_back(detid, 1.0);  // Default value is 1.0
+      try {
+        uint32_t detid = std::stoul(arg);
+        detidValues.emplace_back(detid, 1.0);  // Default value is 1.0
+      } catch (const std::invalid_argument&) {
+        std::cerr << "Invalid DetId: " << arg << "\n";
+        showHelp();
+        return 1;
+      }
     }
   }
 

--- a/DQM/TrackerRemapper/test/BuildFile.xml
+++ b/DQM/TrackerRemapper/test/BuildFile.xml
@@ -7,3 +7,5 @@
   <use name="root"/>
   <use name="catch2"/>
 </bin>
+
+<test name="testPrintTkMaps" command="testPrintTkMaps.sh"/>

--- a/DQM/TrackerRemapper/test/testPrintTkMaps.sh
+++ b/DQM/TrackerRemapper/test/testPrintTkMaps.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+function die { echo $1: status $2; exit $2; }
+
+echo -e "Testing help functions"
+printPixelLayersDisksMap --help  || die 'failed running printPixelLayersDisksMap --help' $?
+printPixelROCsMap --help || die 'failed running printPixelROCsMap --help' $?
+printPixelTrackerMap --help || die 'failed running printPixelTrackerMap --help' $?
+printStripTrackerMap --help || die 'failed running printStripTrackerMap --help' $?
+echo -e "\n"
+testPixelFile=$CMSSW_RELEASE_BASE/src/SLHCUpgradeSimulations/Geometry/data/PhaseI/PixelSkimmedGeometry_phase1.txt
+# Store the first 50 elements of the first column in a variable
+testPixelDetids=$(head -n 50 "$testPixelFile" | cut -d ' ' -f 1 | paste -sd ' ' -)
+
+echo "Using the following pixel DetIds:" $testPixelDetids
+echo -e "\n"
+echo -e "==== Testing printPixelLayersDisksMap"
+printPixelLayersDisksMap --input-file $testPixelFile || die 'failed printPixelLayersDisksMap --input-file'
+printPixelLayersDisksMap $testPixelDetids || die 'failed printPixelLayersDisksMap $testPixelDetids'
+echo -e "\n"
+echo -e "==== Testing printPixelROCsMap"
+printPixelROCsMap --input-file $testPixelFile || die 'failed printPixelROCsMap --input-file'
+printPixelROCsMap $testPixelDetids || die 'failed printPixelROCsMap $testPixelDetids'
+echo -e "\n"
+echo -e "==== Testing printPixelTrackerMap"
+printPixelTrackerMap --input-file $testPixelFile || die 'failed printPixelTrackerMap --input-file'
+printPixelTrackerMap $testPixelDetids || die 'failed printPixelTrackerMap $testPixelDetids'
+echo -e "\n"
+testStripFile=$CMSSW_RELEASE_BASE/src/CalibTracker/SiStripCommon/data/SiStripDetInfo.dat
+# Store the first 50 elements of the first column in a variable
+testStripDetids=$(head -n 50 "$testStripFile" | cut -d ' ' -f 1 | paste -sd ' ' -)
+
+echo "Using the following strip DetIds:" $testStripDetids
+echo -e "\n"
+echo -e "==== Testing printStripTrackerMap"
+printStripTrackerMap --input-file $testStripFile || die 'failed printStripTrackerMap --input-file'
+printStripTrackerMap $testStripDetids || die 'failed printStripTrackerMap $testPixelDetids'

--- a/DQM/TrackerRemapper/test/testPrintTkMaps.sh
+++ b/DQM/TrackerRemapper/test/testPrintTkMaps.sh
@@ -14,16 +14,19 @@ testPixelDetids=$(head -n 50 "$testPixelFile" | cut -d ' ' -f 1 | paste -sd ' ' 
 echo "Using the following pixel DetIds:" $testPixelDetids
 echo -e "\n"
 echo -e "==== Testing printPixelLayersDisksMap"
-printPixelLayersDisksMap --input-file $testPixelFile || die 'failed printPixelLayersDisksMap --input-file'
-printPixelLayersDisksMap $testPixelDetids || die 'failed printPixelLayersDisksMap $testPixelDetids'
+printPixelLayersDisksMap --input-file $testPixelFile || die 'failed printPixelLayersDisksMap --input-file' $?
+printPixelLayersDisksMap $testPixelDetids || die 'failed printPixelLayersDisksMap $testPixelDetids' $?
 echo -e "\n"
 echo -e "==== Testing printPixelROCsMap"
-printPixelROCsMap --input-file $testPixelFile || die 'failed printPixelROCsMap --input-file'
-printPixelROCsMap $testPixelDetids || die 'failed printPixelROCsMap $testPixelDetids'
+printPixelROCsMap --input-file $testPixelFile || die 'failed printPixelROCsMap --input-file' $?
+printPixelROCsMap $testPixelDetids || die 'failed printPixelROCsMap $testPixelDetids' $?
+printPixelROCsMap $testPixelDetids --region barrel || die 'failed printPixelROCsMap $testPixelDetids --barrel' $?
+printPixelROCsMap $testPixelDetids --region forward || die 'failed printPixelROCsMap $testPixelDetids --forward' $?
+printPixelROCsMap $testPixelDetids --region full || die 'failed printPixelROCsMap $testPixelDetids --full' $?
 echo -e "\n"
 echo -e "==== Testing printPixelTrackerMap"
-printPixelTrackerMap --input-file $testPixelFile || die 'failed printPixelTrackerMap --input-file'
-printPixelTrackerMap $testPixelDetids || die 'failed printPixelTrackerMap $testPixelDetids'
+printPixelTrackerMap --input-file $testPixelFile || die 'failed printPixelTrackerMap --input-file' $?
+printPixelTrackerMap $testPixelDetids || die 'failed printPixelTrackerMap $testPixelDetids' $?
 echo -e "\n"
 testStripFile=$CMSSW_RELEASE_BASE/src/CalibTracker/SiStripCommon/data/SiStripDetInfo.dat
 # Store the first 50 elements of the first column in a variable
@@ -32,5 +35,5 @@ testStripDetids=$(head -n 50 "$testStripFile" | cut -d ' ' -f 1 | paste -sd ' ' 
 echo "Using the following strip DetIds:" $testStripDetids
 echo -e "\n"
 echo -e "==== Testing printStripTrackerMap"
-printStripTrackerMap --input-file $testStripFile || die 'failed printStripTrackerMap --input-file'
-printStripTrackerMap $testStripDetids || die 'failed printStripTrackerMap $testPixelDetids'
+printStripTrackerMap --input-file $testStripFile || die 'failed printStripTrackerMap --input-file' $?
+printStripTrackerMap $testStripDetids || die 'failed printStripTrackerMap $testPixelDetids' $?


### PR DESCRIPTION
#### PR description:

This PR is a quick follow-up to https://github.com/cms-sw/cmssw/pull/45795, in which few improvements are added to the tools to generate Tracker maps given user input introduced there:
   * f47039b168c7084cfc9c08bba14323b706fb06c1 adds help functions to `printPixelROCsMap`, `printPixelTrackerMap`, `printPixelLayersDisksMap` and `printStripTrackerMap`
   * 2931551ccc0a2d1aae903080b5cd82970b56097d adds unit tests (`testPrintTkMaps`)
   * 8c91a071efd51965c5c5879ee545dafb64bf5e40 improves `printPixelROCsMap` to accept full, barrel and forward drawing options
  
#### PR validation:

`scram b runtests_testPrintTkMaps` runs fine.

Example map obtained collecting the bad ROCs for [run-386872](https://cmsoms.cern.ch/cms/runs/report?cms_run=386872) in which ROCs 7 and 15 disabled on the Layer1 modules for the full run (see e.g.  [here](https://indico.cern.ch/event/1455577/contributions/6186152/attachments/2949810/5184828/TkDQM_L1_thresholds_Oct24.pdf#page=12) and [here](https://tinyurl.com/29wrmg82)).

![Phase1PixelROCMap_barrel](https://github.com/user-attachments/assets/a2b0be1f-81bf-4965-9957-fcdfce9a6b1b)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A