### PR TITLE
[AlCa] Fix Wdangling-reference in PixelBaryCentreAnalyzer

### DIFF
--- a/Alignment/OfflineValidation/plugins/PixelBaryCentreAnalyzer.cc
+++ b/Alignment/OfflineValidation/plugins/PixelBaryCentreAnalyzer.cc
@@ -262,7 +262,7 @@ void PixelBaryCentreAnalyzer::analyze(const edm::Event& iEvent, const edm::Event
 
     // Tracker global position
     const Alignments& globalAlignments = iSetup.getData(gprToken_);
-    const AlignTransform& globalCoordinates = align::DetectorGlobalPosition(globalAlignments, DetId(DetId::Tracker));
+    const AlignTransform globalCoordinates = align::DetectorGlobalPosition(globalAlignments, DetId(DetId::Tracker));
     GlobalVector globalTkPosition(
         globalCoordinates.translation().x(), globalCoordinates.translation().y(), globalCoordinates.translation().z());
 


### PR DESCRIPTION
#### PR description:

Fix Wdangling-reference [reported](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el9_amd64_gcc13/CMSSW_14_2_X_2024-10-18-2300/Alignment/OfflineValidation) by gcc13:

```
src/Alignment/OfflineValidation/plugins/PixelBaryCentreAnalyzer.cc: In member function 'virtual void PixelBaryCentreAnalyzer::analyze(const edm::Event&, const edm::EventSetup&)':
  src/Alignment/OfflineValidation/plugins/PixelBaryCentreAnalyzer.cc:265:27: warning: possibly dangling reference to a temporary [-Wdangling-reference]
   265 |     const AlignTransform& globalCoordinates = align::DetectorGlobalPosition(globalAlignments, DetId(DetId::Tracker));
      |                           ^~~~~~~~~~~~~~~~~
src/Alignment/OfflineValidation/plugins/PixelBaryCentreAnalyzer.cc:265:76: note: the temporary was destroyed at the end of the full expression 'align::DetectorGlobalPosition((* & globalAlignments), DetId(((uint32_t)DetId::Tracker)))'
  265 |     const AlignTransform& globalCoordinates = align::DetectorGlobalPosition(globalAlignments, DetId(DetId::Tracker));
      |                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

`AlignTransform` looks cheap to copy (just a bunch of `double`s).

#### PR validation:

Bot tests