### PR TITLE
Run3-alca250 Change thresholds of ECAL energy to make compatible calibrations with Jet-MET studies

### DIFF
--- a/Calibration/HcalAlCaRecoProducers/plugins/AlCaHcalIsotrkProducer.cc
+++ b/Calibration/HcalAlCaRecoProducers/plugins/AlCaHcalIsotrkProducer.cc
@@ -405,7 +405,7 @@ void AlCaHcalIsotrkProducer::fillDescriptions(edm::ConfigurationDescriptions& de
   desc.add<double>("coneRadiusMIP3", 20.0);
   desc.add<double>("coneRadiusMIP4", 22.0);
   desc.add<double>("coneRadiusMIP5", 24.0);
-  desc.add<double>("maximumEcalEnergy", 2.0);
+  desc.add<double>("maximumEcalEnergy", 10.0);
   // following 4 parameters are for isolation cuts and described in the code
   desc.add<double>("maxTrackP", 8.0);
   desc.add<double>("slopeTrackP", 0.05090504066);

--- a/Calibration/HcalAlCaRecoProducers/plugins/AlCaIsoTracksProducer.cc
+++ b/Calibration/HcalAlCaRecoProducers/plugins/AlCaIsoTracksProducer.cc
@@ -278,7 +278,7 @@ void AlCaIsoTracksProducer::fillDescriptions(edm::ConfigurationDescriptions& des
   desc.add<double>("minimumTrackP", 20.0);
   // signal zone in ECAL and MIP energy cutoff
   desc.add<double>("coneRadiusMIP", 14.0);
-  desc.add<double>("maximumEcalEnergy", 2.0);
+  desc.add<double>("maximumEcalEnergy", 10.0);
   // following 3 parameters are for isolation cuts and described in the code
   desc.add<double>("maxTrackP", 8.0);
   desc.add<double>("slopeTrackP", 0.05090504066);


### PR DESCRIPTION
#### PR description:

Change thresholds of ECAL energy to make compatible calibrations with Jet-MET studies

#### PR validation:

Checked this using scripts in the test directory of Calibration/HcalAlCaRecoProducers

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special