### PR TITLE
Update new timing seeds for HI

### DIFF
--- a/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
@@ -127,6 +127,8 @@ if process.runType.getRunType() == process.runType.cosmic_run:
 if process.runType.getRunType() == process.runType.hi_run:
     process.hltFatEventFilter.HLTPaths.append('HLT_HIPhysics_v*')
     rawDataRepackerLabel = 'rawDataRepacker'
+    process.l1tStage2uGTTiming.firstBXInTrainAlgo=cms.untracked.string("L1_FirstBunchInTrain_50ns")
+    process.l1tStage2uGTTiming.lastBXInTrainAlgo=cms.untracked.string("L1_LastBunchInTrain_50ns")
     process.onlineMetaDataDigis.onlineMetaDataInputLabel = rawDataRepackerLabel
     process.onlineMetaDataRawToDigi.onlineMetaDataInputLabel = rawDataRepackerLabel
     process.castorDigis.InputLabel = rawDataRepackerLabel


### PR DESCRIPTION
#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->
  - There is an issue with the DQM timing plot not being properly drawn during the HI run ([DQMGUI](https://cmsweb.cern.ch/dqm/online/start?runnr=375703;dataset=/Global/Online/ALL;sampletype=online_data;filter=all;referencepos=overlay;referenceshow=customise;referencenorm=True;referenceobj1=refobj;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=Shift;size=M;root=00%20Shift/L1T;focus=;zoom=no), Run 375703, Plots 19-22)
  - Change the L1 seeds used for drawing the timing plot to L1 seeds that correspond to the 50 ns bunch spacing of the HI run
