### PR TITLE
Removing Muon POG DQM sequence from express, with fix for CSC monitoring

### DIFF
--- a/DQM/CSCMonitorModule/python/csc_dqm_sourceclient_offline_cff.py
+++ b/DQM/CSCMonitorModule/python/csc_dqm_sourceclient_offline_cff.py
@@ -4,5 +4,8 @@ from DQM.CSCMonitorModule.csc_dqm_sourceclient_offline_cfi import *
 
 from DQMOffline.MuonDPG.cscTnPEfficiencyTask_cfi import *
 
+from DQMOffline.Muon.CSCMonitor_cfi import cscMonitor
+
 cscSources = cms.Sequence(dqmCSCClient + 
-                          cscTnPEfficiencyMonitor)
+                          cscTnPEfficiencyMonitor+
+                          cscMonitor)

--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -129,7 +129,8 @@ DQMOfflineTracking = cms.Sequence( TrackingDQMSourceTier0 *
                                    DQMOfflineVertex *
                                    materialDumperAnalyzer )
 
-DQMOfflineMUO = cms.Sequence(muonMonitors)
+DQMOfflineMUO = cms.Sequence(muonMonitors
+                             *cscMonitor)
 muonRecoAnalyzer.doMVA =         cms.bool( True )
 muonRecoAnalyzer_miniAOD.doMVA = cms.bool( True )
 
@@ -158,7 +159,7 @@ DQMOfflinePrePOG = cms.Sequence( DQMOfflineTracking *
 
 
 DQMOfflinePrePOGExpress = cms.Sequence( DQMOfflineTracking *
-                                 DQMOfflineMUO *
+                                 #DQMOfflineMUO *
                                  #DQMOfflineJetMET *
                                  #DQMOfflineEGamma *
                                  DQMOfflineTrigger *

--- a/DQMOffline/Muon/python/muonMonitors_cff.py
+++ b/DQMOffline/Muon/python/muonMonitors_cff.py
@@ -23,7 +23,6 @@ dqmInfoMuons = DQMEDAnalyzer('DQMEventInfo',
 muonTrackAnalyzers = cms.Sequence(MonitorTrackSTAMuons*MonitorTrackGLBMuons*MonitorTrackINNMuons)
 
 muonMonitors = cms.Sequence(muonTrackAnalyzers*
-                            cscMonitor*
                             muonAnalyzer*
                             muonIdDQM*
                             dqmInfoMuons*


### PR DESCRIPTION
#### PR description:

Moving `cscMonitor` module from `muonMonitors` to `cscSources`, enabling the removal of the `DQMOfflineMUO` DQM sequence from Express without loosing the `CSCOfflineMonitor` folder.

#### PR validation:

Validated using the following drivers:

`cmsDriver.py step2 --conditions 140X_dataRun3_Express_v3 --data --datatier RECO,DQMIO --era Run3_2024 --eventcontent RECO,DQM --filein /store/express/Run2024I/ExpressPhysics/FEVT/Express-v2/000/386/814/00000/fa7e3b68-1bb0-4173-a047-271497361731.root --fileout file:step2_modified.root --nStreams 2 --nThreads 8 --no_exec --number 10 --process RECODQM --python_filename step2_modified_cfg.py --scenario pp --step RAW2DIGI,L1Reco,RECO,DQM:@standardDQMExpress`

`cmsDriver.py step3 --conditions 140X_dataRun3_Express_v3 --data --era Run3_2024 --filein file:step2_modified_inDQM.root --fileout file:step3_modified.root --filetype DQM --nStreams 2 --no_exec --number 10 --python_filename step_3_modified_cfg.py --scenario pp --step HARVESTING:@standardDQMExpress`

Plus `RunTheMatrix.py`.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Will backport to 14_1_X
