### PR TITLE
MTD validation: update vertex density plots

### DIFF
--- a/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
+++ b/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
@@ -293,7 +293,6 @@ private:
   const double minProbHeavy_;
   const double trackweightTh_;
   const double mvaTh_;
-  const std::vector<double> lineDensityPar_;
   const reco::RecoToSimCollection* r2s_;
   const reco::SimToRecoCollection* s2r_;
 
@@ -371,7 +370,10 @@ private:
   MonitorElement* meRecVerNumber_;
   MonitorElement* meRecPVZ_;
   MonitorElement* meRecPVT_;
+  MonitorElement* meSimVerNumber_;
   MonitorElement* meSimPVZ_;
+  MonitorElement* meSimPVT_;
+  MonitorElement* meSimPVTvsZ_;
 
   MonitorElement* meVtxTrackMult_;
   MonitorElement* meVtxTrackW_;
@@ -528,7 +530,6 @@ Primary4DVertexValidation::Primary4DVertexValidation(const edm::ParameterSet& iC
       minProbHeavy_(iConfig.getParameter<double>("minProbHeavy")),
       trackweightTh_(iConfig.getParameter<double>("trackweightTh")),
       mvaTh_(iConfig.getParameter<double>("mvaTh")),
-      lineDensityPar_(iConfig.getParameter<std::vector<double>>("lineDensityPar")),
       pdtToken_(esConsumes<HepPDT::ParticleDataTable, edm::DefaultRecord>()) {
   vecPileupSummaryInfoToken_ = consumes<std::vector<PileupSummaryInfo>>(edm::InputTag(std::string("addPileupInfo")));
   trackingParticleCollectionToken_ =
@@ -696,12 +697,13 @@ void Primary4DVertexValidation::bookHistograms(DQMStore::IBooker& ibook,
                    20,
                    0,
                    20);
-  meRecoVtxVsLineDensity_ =
-      ibook.book1D("RecoVtxVsLineDensity", "#Reco vertices/mm/event; line density [#vtx/mm/event]", 160, 0., 4.);
   meRecVerNumber_ = ibook.book1D("RecVerNumber", "RECO Vertex Number: Number of vertices", 50, 0, 250);
-  meRecPVZ_ = ibook.book1D("recPVZ", "Weighted #Rec vertices/mm", 400, -20., 20.);
-  meRecPVT_ = ibook.book1D("recPVT", "#Rec vertices/10 ps", 200, -1., 1.);
-  meSimPVZ_ = ibook.book1D("simPVZ", "Weighted #Sim vertices/mm", 400, -20., 20.);
+  meSimVerNumber_ = ibook.book1D("SimVerNumber", "SIM Vertex Number: Number of vertices", 50, 0, 250);
+  meRecPVZ_ = ibook.book1D("recPVZ", "#Rec vertices/10 mm", 30, -15., 15.);
+  meRecPVT_ = ibook.book1D("recPVT", "#Rec vertices/50 ps", 30, -0.75, 0.75);
+  meSimPVZ_ = ibook.book1D("simPVZ", "#Sim vertices/10 mm", 30, -15., 15.);
+  meSimPVT_ = ibook.book1D("simPVT", "#Sim vertices/50 ps", 30, -0.75, 0.75);
+  meSimPVTvsZ_ = ibook.bookProfile("simPVTvsZ", "PV Time vs Z", 30, -15., 15., 30, -0.75, 0.75);
 
   meVtxTrackMult_ = ibook.book1D("VtxTrackMult", "Log10(Vertex track multiplicity)", 80, 0.5, 2.5);
   meVtxTrackW_ = ibook.book1D("VtxTrackW", "Vertex track weight (all)", 50, 0., 1.);
@@ -2599,23 +2601,14 @@ void Primary4DVertexValidation::analyze(const edm::Event& iEvent, const edm::Eve
   int other_fake = 0;
   int split = 0;
 
-  auto puLineDensity = [&](double z) {
-    // gaussian parameterization of line density vs z, z in cm, parameters in mm
-    double argl = (z * 10. - lineDensityPar_[1]) / lineDensityPar_[2];
-    return lineDensityPar_[0] * exp(-0.5 * argl * argl);
-  };
-
   meRecVerNumber_->Fill(recopv.size());
   for (unsigned int ir = 0; ir < recopv.size(); ir++) {
     if (recopv.at(ir).ndof > selNdof_) {
-      meRecoVtxVsLineDensity_->Fill(puLineDensity(recopv.at(ir).z));
-      meRecPVZ_->Fill(recopv.at(ir).z, 1. / puLineDensity(recopv.at(ir).z));
+      meRecPVZ_->Fill(recopv.at(ir).z);
       if (recopv.at(ir).recVtx->tError() > 0.) {
         meRecPVT_->Fill(recopv.at(ir).recVtx->t());
       }
       LogTrace("Primary4DVertexValidation") << "************* IR: " << ir;
-      LogTrace("Primary4DVertexValidation")
-          << "z: " << recopv.at(ir).z << " corresponding to line density: " << puLineDensity(recopv.at(ir).z);
       LogTrace("Primary4DVertexValidation") << "is_real: " << recopv.at(ir).is_real();
       LogTrace("Primary4DVertexValidation") << "is_fake: " << recopv.at(ir).is_fake();
       LogTrace("Primary4DVertexValidation") << "is_signal: " << recopv.at(ir).is_signal();
@@ -2646,12 +2639,11 @@ void Primary4DVertexValidation::analyze(const edm::Event& iEvent, const edm::Eve
   mePUvsSplitV_->Fill(simpv.size(), split);
 
   // fill vertices histograms here in a new loop
+  meSimVerNumber_->Fill(simpv.size());
   for (unsigned int is = 0; is < simpv.size(); is++) {
-    // protect against particle guns with very displaced vertices
-    if (edm::isNotFinite(1. / puLineDensity(simpv.at(is).z))) {
-      continue;
-    }
-    meSimPVZ_->Fill(simpv.at(is).z, 1. / puLineDensity(simpv.at(is).z));
+    meSimPVZ_->Fill(simpv.at(is).z);
+    meSimPVT_->Fill(simpv.at(is).t * simUnit_);
+    meSimPVTvsZ_->Fill(simpv.at(is).z, simpv.at(is).t * simUnit_);
     if (is == 0 && optionalPlots_) {
       meSimPosInSimOrigCollection_->Fill(simpv.at(is).OriginalIndex);
     }
@@ -2788,14 +2780,6 @@ void Primary4DVertexValidation::fillDescriptions(edm::ConfigurationDescriptions&
   desc.add<double>("trackweightTh", 0.5);
   desc.add<double>("mvaTh", 0.8);
   desc.add<double>("minProbHeavy", 0.75);
-
-  //lineDensity parameters have been obtained by fitting the distribution of the z position of the vertices,
-  //using a 200k single mu ptGun sample (gaussian fit)
-  std::vector<double> lDP;
-  lDP.push_back(1.87);
-  lDP.push_back(0.);
-  lDP.push_back(42.5);
-  desc.add<std::vector<double>>("lineDensityPar", lDP);
   descriptions.add("vertices4DValid", desc);
 }
 


### PR DESCRIPTION
#### PR description:

In the ```Primary4DVertexValidation``` class, a set of plots is devoted to show the true and reconstructed vertex density as a function of space (line density along the beam line in the z coordinate) and time. Previously a parameterization of the simulated HL-LHC beam spot profile in z was used to weight entries, now just simple distributions, scaled by the total number of events to provide the per event density, are filled. The bin numbers have been significantly reduced, to improve the memory footprint of this code.

#### PR validation:

Code compiles, runs and provide the desired plots, showing that the expected beam spot sigma is about 4.29 cm and the corresponding time spread sigma is about 194 ps (on /store/relval/CMSSW_14_2_0_pre2/RelValTTbar_14TeV/GEN-SIM-RECO/PU_141X_mcRun4_realistic_v1_STD_2026D110_PU-v1/2580000/bc39e0cf-b5f9-40ce-9dac-af84dc3e049a.root).

![simpvz](https://github.com/user-attachments/assets/e71dfe49-b164-4708-9121-ea2bc4d0c113)
![simpvt](https://github.com/user-attachments/assets/d9337450-6bab-49c8-a642-8af7a36425f7)

