### PR TITLE
Fix for nalphabits == 0

### DIFF
--- a/L1Trigger/TrackFindingTracklet/src/Stub.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Stub.cc
@@ -57,7 +57,7 @@ Stub::Stub(L1TStub& stub, Settings const& settings, Globals& globals) : settings
   int newphi = phibits.to_ulong();
 
   int newalpha = alphabits.to_ulong();
-  if (newalpha >= (1 << (nalphabits - 1)))
+  if (nalphabits > 0 && newalpha >= (1 << (nalphabits - 1)))
     newalpha = newalpha - (1 << nalphabits);
 
   l1tstub_ = &stub;


### PR DESCRIPTION
#### PR description:

This PR fixes the runtime error seen in recent UBSAN IBs that was reported in #46403.

The fix is to add a short circuit to the offending conditional, so that when `nalphabits` is zero, the negative bit shift is never evaluated. This has no effect on the end results because `newalpha` is never used when `nalphabits` is zero.

Fixes #46403

#### PR validation:

I was able to reproduce the runtime error reported in #46403 within the 23634.0 workflow, and after adding this short circuit, the same workflow gives no error.

@tomalin 