### PR TITLE
Remove unused L1TCaloSummary DQM sequences causing issues with HCAL.

### DIFF
--- a/DQM/L1TMonitor/python/L1TCaloLayer1Summary_cff.py
+++ b/DQM/L1TMonitor/python/L1TCaloLayer1Summary_cff.py
@@ -1,16 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 from L1Trigger.Configuration.CaloTriggerPrimitives_cff import *
-simEcalTriggerPrimitiveDigis.Label = 'ecalDigis'
-simHcalTriggerPrimitiveDigis.inputLabel = cms.VInputTag(
-    cms.InputTag('hcalDigis'),
-    cms.InputTag('hcalDigis')
-)
-simHcalTriggerPrimitiveDigis.inputUpgradeLabel = cms.VInputTag(
-            cms.InputTag('hcalDigis'),
-            cms.InputTag('hcalDigis')
-)
-
 from L1Trigger.L1TCaloLayer1.simCaloStage2Layer1Summary_cfi import *
 from L1Trigger.L1TCaloLayer1.simCaloStage2Layer1Digis_cfi import *
 from DQM.L1TMonitor.L1TCaloLayer1Summary_cfi import *
@@ -19,4 +9,4 @@ simCaloStage2Layer1Summary.caloLayer1Regions = cms.InputTag("caloLayer1Digis", "
 simCaloStage2Layer1Digis.ecalToken = cms.InputTag("ecalDigis", "EcalTriggerPrimitives")
 simCaloStage2Layer1Digis.hcalToken = cms.InputTag("hcalDigis", "")
 
-l1tCaloLayer1SummarySeq = cms.Sequence(simEcalTriggerPrimitiveDigis * simHcalTriggerPrimitiveDigis * simCaloStage2Layer1Digis * simCaloStage2Layer1Summary * l1tCaloLayer1Summary)
+l1tCaloLayer1SummarySeq = cms.Sequence(simCaloStage2Layer1Digis * simCaloStage2Layer1Summary * l1tCaloLayer1Summary)

--- a/DQM/L1TMonitor/python/L1TCaloLayer1Summary_cff.py
+++ b/DQM/L1TMonitor/python/L1TCaloLayer1Summary_cff.py
@@ -5,8 +5,12 @@ from L1Trigger.L1TCaloLayer1.simCaloStage2Layer1Summary_cfi import *
 from L1Trigger.L1TCaloLayer1.simCaloStage2Layer1Digis_cfi import *
 from DQM.L1TMonitor.L1TCaloLayer1Summary_cfi import *
 
-simCaloStage2Layer1Summary.caloLayer1Regions = cms.InputTag("caloLayer1Digis", "")
-simCaloStage2Layer1Digis.ecalToken = cms.InputTag("ecalDigis", "EcalTriggerPrimitives")
-simCaloStage2Layer1Digis.hcalToken = cms.InputTag("hcalDigis", "")
+dqmSimCaloStage2Layer1Summary = simCaloStage2Layer1Summary.clone(
+    caloLayer1Regions = cms.InputTag("caloLayer1Digis", ""),
+)
+dqmSimCaloStage2Layer1Digis = simCaloStage2Layer1Digis.clone(
+    ecalToken = cms.InputTag("ecalDigis", "EcalTriggerPrimitives"),
+    hcalToken = cms.InputTag("hcalDigis", "")
+)
 
-l1tCaloLayer1SummarySeq = cms.Sequence(simCaloStage2Layer1Digis * simCaloStage2Layer1Summary * l1tCaloLayer1Summary)
+l1tCaloLayer1SummarySeq = cms.Sequence(dqmSimCaloStage2Layer1Digis * dqmSimCaloStage2Layer1Summary * l1tCaloLayer1Summary)

--- a/DQM/L1TMonitor/python/L1TCaloLayer1Summary_cff.py
+++ b/DQM/L1TMonitor/python/L1TCaloLayer1Summary_cff.py
@@ -6,7 +6,8 @@ from L1Trigger.L1TCaloLayer1.simCaloStage2Layer1Digis_cfi import *
 from DQM.L1TMonitor.L1TCaloLayer1Summary_cfi import *
 
 dqmSimCaloStage2Layer1Summary = simCaloStage2Layer1Summary.clone(
-    caloLayer1Regions = cms.InputTag("caloLayer1Digis", ""),
+    caloLayer1Regions = "caloLayer1Digis",
+    backupRegionToken = 'dqmSimCaloStage2Layer1Digis',
 )
 dqmSimCaloStage2Layer1Digis = simCaloStage2Layer1Digis.clone(
     ecalToken = cms.InputTag("ecalDigis", "EcalTriggerPrimitives"),

--- a/DQM/L1TMonitor/python/L1TCaloLayer1Summary_cfi.py
+++ b/DQM/L1TMonitor/python/L1TCaloLayer1Summary_cfi.py
@@ -3,7 +3,7 @@ from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 
 l1tCaloLayer1Summary = DQMEDAnalyzer("L1TCaloLayer1Summary",
     caloLayer1CICADAScore = cms.InputTag("caloLayer1Digis", "CICADAScore"),
-    gtCICADAScore = cms.InputTag("gtTestcrateStage2Digis", "CICADAScore"),
+    gtCICADAScore = cms.InputTag("gtStage2Digis", "CICADAScore"),
     simCICADAScore = cms.InputTag("simCaloStage2Layer1Summary", "CICADAScore"),
     caloLayer1Regions = cms.InputTag("caloLayer1Digis", ""),
     simRegions = cms.InputTag("simCaloStage2Layer1Digis", ""),

--- a/DQM/L1TMonitor/python/L1TCaloLayer1Summary_cfi.py
+++ b/DQM/L1TMonitor/python/L1TCaloLayer1Summary_cfi.py
@@ -4,9 +4,9 @@ from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 l1tCaloLayer1Summary = DQMEDAnalyzer("L1TCaloLayer1Summary",
     caloLayer1CICADAScore = cms.InputTag("caloLayer1Digis", "CICADAScore"),
     gtCICADAScore = cms.InputTag("gtStage2Digis", "CICADAScore"),
-    simCICADAScore = cms.InputTag("simCaloStage2Layer1Summary", "CICADAScore"),
+    simCICADAScore = cms.InputTag("dqmSimCaloStage2Layer1Summary", "CICADAScore"),
     caloLayer1Regions = cms.InputTag("caloLayer1Digis", ""),
-    simRegions = cms.InputTag("simCaloStage2Layer1Digis", ""),
+    simRegions = cms.InputTag("dqmSimCaloStage2Layer1Digis", ""),
     fedRawDataLabel  = cms.InputTag("rawDataCollector"),
     histFolder = cms.string('L1T/L1TCaloLayer1Summary')
 )

--- a/L1Trigger/L1TCaloLayer1/plugins/L1TCaloSummary.cc
+++ b/L1Trigger/L1TCaloLayer1/plugins/L1TCaloSummary.cc
@@ -143,7 +143,8 @@ L1TCaloSummary<INPUT, OUTPUT>::L1TCaloSummary(const edm::ParameterSet& iConfig)
       verbose(iConfig.getParameter<bool>("verbose")),
       fwVersion(iConfig.getParameter<int>("firmwareVersion")),
       regionToken(consumes<L1CaloRegionCollection>(iConfig.getParameter<edm::InputTag>("caloLayer1Regions"))),
-      backupRegionToken(consumes<L1CaloRegionCollection>(edm::InputTag("simCaloStage2Layer1Digis"))),
+      //backupRegionToken(consumes<L1CaloRegionCollection>(edm::InputTag("simCaloStage2Layer1Digis"))),
+      backupRegionToken(consumes<L1CaloRegionCollection>(iConfig.getParameter<edm::InputTag>("backupRegionToken"))),
       loader(hls4mlEmulator::ModelLoader(iConfig.getParameter<string>("CICADAModelVersion"))),
       overwriteWithTestPatterns(iConfig.getParameter<bool>("useTestPatterns")),
       testPatterns(iConfig.getParameter<std::vector<edm::ParameterSet>>("testPatterns")) {

--- a/L1Trigger/L1TCaloLayer1/python/simCaloStage2Layer1Summary_cfi.py
+++ b/L1Trigger/L1TCaloLayer1/python/simCaloStage2Layer1Summary_cfi.py
@@ -53,5 +53,6 @@ simCaloStage2Layer1Summary = cms.EDProducer('L1TCaloSummary_CICADA_vXp1p2',
     CICADAModelVersion = cms.string("CICADAModel_v2p1p2"),
     useTestPatterns = cms.bool(False),
     testPatterns = standardCICADATestPatterns,
-    caloLayer1Regions = cms.InputTag("simCaloStage2Layer1Digis", "")
+    caloLayer1Regions = cms.InputTag("simCaloStage2Layer1Digis", ""),
+    backupRegionToken = cms.InputTag("simCaloStage2Layer1Digis", "")
 )


### PR DESCRIPTION
### PR description:

This PR removes two unused sequences in the CICADA DQM that were potentially causing duplicate TPs seen in HCAL tests. No DQM changes are expected as a result of this change.

Also changes Calo Summary DQM configuration to use GT digis instead of test crate digis, which is more correct.

@missirol FYI
@JHiltbrand Also FYI, but could I ask you to see if you can rerun the test you were looking at with this PR and see if this resolves the issue please?

### PR validation:

Changed HCAL workflow was run-again to make sure that the sequence does not crash.

### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not a backport, but may need backporting to online/offline DQM releases.