### PR TITLE
Fix unlabeled case in mayConsumes EventSetup

### DIFF
--- a/FWCore/Framework/src/ESRecordsToProductResolverIndices.cc
+++ b/FWCore/Framework/src/ESRecordsToProductResolverIndices.cc
@@ -115,10 +115,12 @@ namespace edm::eventsetup {
         }
       } else {
         foundFirstIndex = true;
-        returnValue.emplace_back(
-            keyIndex - beginIndex,
-            dataKeys_[keyIndex].name().value(),
-            components_[keyIndex] ? std::string_view(components_[keyIndex]->label_) : std::string_view());
+        returnValue.emplace_back(keyIndex - beginIndex,
+                                 dataKeys_[keyIndex].name().value(),
+                                 components_[keyIndex] ? components_[keyIndex]->label_.empty()
+                                                             ? std::string_view(components_[keyIndex]->type_)
+                                                             : std::string_view(components_[keyIndex]->label_)
+                                                       : std::string_view());
       }
       ++keyIndex;
     }


### PR DESCRIPTION
#### PR description:

Fix the EventSetup feature called setMayConsumes in the corner case where the module is configured "unlabeled" and setMayConsumes requires a specific module label. There is nothing using using this corner case at the present time so I do not think this should change the behavior of anything, but the original intent was that this feature should work properly in this case.

#### PR validation:

Extended the setMayConsumes unit test to cover this case.
