### PR TITLE
Extend lowPt egamma modifier to conversions

### DIFF
--- a/RecoEgamma/EgammaPhotonProducers/python/allConversions_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/allConversions_cfi.py
@@ -66,3 +66,5 @@ from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 phase2_hgcal.toModify( allConversions, bypassPreselGsf = False )
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toModify(allConversions, src = 'gsfGeneralConversionTrackMerger')
+from Configuration.ProcessModifiers.egamma_lowPt_exclusive_cff import egamma_lowPt_exclusive
+egamma_lowPt_exclusive.toModify(allConversions, minSCEt = 1.0)

--- a/RecoEgamma/EgammaPhotonProducers/python/conversionTrackCandidates_cff.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/conversionTrackCandidates_cff.py
@@ -12,3 +12,6 @@ conversionTrackCandidates.RecHitSeverityToBeExcludedEB = cleanedHybridSuperClust
 conversionTrackCandidates.RecHitFlagToBeExcludedEE = multi5x5BasicClustersCleaned.RecHitFlagToBeExcluded
 conversionTrackCandidates.RecHitSeverityToBeExcludedEE = cleanedHybridSuperClusters.RecHitSeverityToBeExcluded
 conversionTrackCandidates.TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('TrajectoryBuilderForConversions'))
+
+from Configuration.ProcessModifiers.egamma_lowPt_exclusive_cff import egamma_lowPt_exclusive
+egamma_lowPt_exclusive.toModify(conversionTrackCandidates, minSCEt = 1.0, bcEtCut = 0.5)

--- a/RecoEgamma/EgammaPhotonProducers/python/reducedEgamma_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/reducedEgamma_cfi.py
@@ -88,3 +88,6 @@ run2_miniAOD_pp_on_AA_103X.toModify(
     photonsPFValMap = "pfEGammaToCandidateRemapperCleaned:photons",
     gsfElectronsPFValMap = "pfEGammaToCandidateRemapperCleaned:electrons"
 )
+
+from Configuration.ProcessModifiers.egamma_lowPt_exclusive_cff import egamma_lowPt_exclusive
+egamma_lowPt_exclusive.toModify(reducedEgamma, keepPfSuperclusterPtMin = 1.0, keepPhotons = "", slimRelinkPhotons = "", relinkPhotons = "", relinkGsfElectrons = "")


### PR DESCRIPTION
#### PR description:

This PR extends the egamma lowPt modifier (used in the UPC reconstruction) to conversions, lowering the super cluster ET threshold to 1.0 GeV for conversions as done for photons and electrons. In addition, it also reduce the thresholds of reducedEgamma collection used in MiniAOD to keep the low pT egamma objects.

@mandrenguyen 


#### PR validation:

runTheMatrix.py -l 180,180.1,181,181.1

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 14_1_X
