### PR TITLE
Removing clang warning in EgammaHLTPixelMatchVarProducer

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTPixelMatchVarProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTPixelMatchVarProducer.cc
@@ -41,7 +41,24 @@ namespace {
       int layerOffset = 3;
       if (seed.subDet(hitNr) == PixelSubdetector::PixelEndcap)
         layerOffset += 4;
-      int layerBit = 0x1 << layerOffset << seed.layerOrDiskNr(hitNr);
+
+      int layerOrDiskNr = seed.layerOrDiskNr(hitNr);
+      if (layerOrDiskNr == 0 || layerOrDiskNr > 4) {
+        if (layerOrDiskNr == std::numeric_limits<int>::max()) {
+          throw cms::Exception("LogicError")
+              << " in " << __FILE__ << " " << __LINE__ << "layerOrDiskNr of hit " << hitNr << " is " << layerOrDiskNr
+              << " which is equal to numeric_limits::max which implies it was not filled correctly\n. While this is "
+                 "valid for the matching variables as it can signal the failure to find a postive or negative seed "
+                 "trajector, it is not valid for the layer number as that is always known.\nThus there is a logic "
+                 "error in the code or possible corupt data";
+        } else {
+          throw cms::Exception("InvalidData")
+              << " in " << __FILE__ << " " << __LINE__ << "layerOrDiskNr of hit " << hitNr << " is " << layerOrDiskNr
+              << " and is not in the range of 1<=x<=4 which implies a new pixel detector (the current one has only 4 "
+                 "layers numbered 1-4) or corrupt data\n";
+        }
+      }
+      int layerBit = 0x1 << layerOffset << layerOrDiskNr;
       info |= layerBit;
 
       int nrLayersAlongTrajShifted = seed.nrLayersAlongTraj() << 12;

--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTPixelMatchVarProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTPixelMatchVarProducer.cc
@@ -50,7 +50,7 @@ namespace {
               << " which is equal to numeric_limits::max which implies it was not filled correctly.\nWhile this is "
                  "valid for the matching variables as it can signal the failure to find a postive or negative seed "
                  "trajectory,\nit is not valid for the layer number as that is always known.\nThus there is a logic "
-                 "error in the code or possible corupt data";
+                 "error in the code or possible corrupt data";
         } else {
           throw cms::Exception("InvalidData") << "The layerOrDiskNr of hitnr " << hitNr << " is " << layerOrDiskNr
                                               << " and is not in the range of 1<=x<=4 which implies a new pixel "

--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTPixelMatchVarProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTPixelMatchVarProducer.cc
@@ -46,16 +46,16 @@ namespace {
       if (layerOrDiskNr == 0 || layerOrDiskNr > 4) {
         if (layerOrDiskNr == std::numeric_limits<int>::max()) {
           throw cms::Exception("LogicError")
-              << " in " << __FILE__ << " " << __LINE__ << "layerOrDiskNr of hit " << hitNr << " is " << layerOrDiskNr
-              << " which is equal to numeric_limits::max which implies it was not filled correctly\n. While this is "
+              << "The layerOrDiskNr of hitnr " << hitNr << " is " << layerOrDiskNr
+              << " which is equal to numeric_limits::max which implies it was not filled correctly.\nWhile this is "
                  "valid for the matching variables as it can signal the failure to find a postive or negative seed "
-                 "trajector, it is not valid for the layer number as that is always known.\nThus there is a logic "
+                 "trajectory,\nit is not valid for the layer number as that is always known.\nThus there is a logic "
                  "error in the code or possible corupt data";
         } else {
-          throw cms::Exception("InvalidData")
-              << " in " << __FILE__ << " " << __LINE__ << "layerOrDiskNr of hit " << hitNr << " is " << layerOrDiskNr
-              << " and is not in the range of 1<=x<=4 which implies a new pixel detector (the current one has only 4 "
-                 "layers numbered 1-4) or corrupt data\n";
+          throw cms::Exception("InvalidData") << "The layerOrDiskNr of hitnr " << hitNr << " is " << layerOrDiskNr
+                                              << " and is not in the range of 1<=x<=4 which implies a new pixel "
+                                                 "detector\nthis code does not support as the current one has only 4 "
+                                                 "layers numbered 1-4 or corrupt data\n";
         }
       }
       int layerBit = 0x1 << layerOffset << layerOrDiskNr;


### PR DESCRIPTION
#### PR description:

This PR fixes the clang warning reported in https://github.com/cms-sw/cmssw/pull/46319

The warning was harmless but in looking at the code, figured would make it a bit more robust against bad data (and if we ever added a new pixel layer unlikely that it is)

So the code now explicitly verfies that the value is in range and throws an exception if caused. I also strongly suspect but did not prove 100% that numeric_limits::max is an invalid value for this specific quanity and put that as an exception as well.  I'm running over a bunch of data to verify this (about 20k HLTPhysics events and will try to run on an EGamma file)

Finally it should be noted that this code is only run if productsToWrite  = 2 which is only done for debugging when we wish to dump the values of this producer for studies. So it doesnt normally run in the HLT and I dont believe there is any workflow that runs this code. 
 
So this should be a zero output change. As this code does not run normally and when it does run the data should always pass these checks. 
 
#### PR validation:

Runs as expected on my local machine based on HLT timing data. Will run on E/gamma data later with productsToWrite=2 later.

