### PR TITLE
New mvaTTH weights for Run 3

### DIFF
--- a/PhysicsTools/NanoAOD/python/electrons_cff.py
+++ b/PhysicsTools/NanoAOD/python/electrons_cff.py
@@ -308,7 +308,7 @@ run2_egamma_2016.toModify(
     variables = _legacy_electron_BDT_variable
 )
 
-(run2_egamma_2016 | run2_egamma_2018).toModify(
+(run2_egamma_2017 | run2_egamma_2018).toModify(
     electronPROMPTMVA,
     weightFile = "PhysicsTools/NanoAOD/data/el_BDTG_2017.weights.xml",
     variables = _legacy_electron_BDT_variable

--- a/PhysicsTools/NanoAOD/python/electrons_cff.py
+++ b/PhysicsTools/NanoAOD/python/electrons_cff.py
@@ -273,7 +273,7 @@ electronPROMPTMVA= cms.EDProducer("EleBaseMVAValueMapProducer",
     variables = cms.VPSet(
         cms.PSet( name = cms.string("LepGood_pt"), expr = cms.string("pt")),
         cms.PSet( name = cms.string("LepGood_eta"), expr = cms.string("eta")),
-        cms.PSet( name = cms.string("LepGood_pfRelIso03_all"), expr = cms.string("(pfIsolationR03().sumChargedHadronPt + max(pfIsolationR03().sumNeutralHadronEt + pfIsolationR03().sumPhotonEt - pfIsolationR03().sumPUPt/2,0.0))/pt")),
+        cms.PSet( name = cms.string("LepGood_pfRelIso03_all"), expr = cms.string("userFloat('PFIsoAll')/pt")),
         cms.PSet( name = cms.string("LepGood_miniRelIsoCharged"), expr = cms.string("userFloat('miniIsoChg_Fall17V2')/pt")),
         cms.PSet( name = cms.string("LepGood_miniRelIsoNeutral"), expr = cms.string("(userFloat('miniIsoAll_Fall17V2')-userFloat('miniIsoChg_Fall17V2'))/pt")),
         cms.PSet( name = cms.string("LepGood_jetNDauChargedMVASel"), expr = cms.string("?userCand('jetForLepJetVar').isNonnull()?userFloat('jetNDauChargedMVASel'):0")),

--- a/PhysicsTools/NanoAOD/python/electrons_cff.py
+++ b/PhysicsTools/NanoAOD/python/electrons_cff.py
@@ -266,11 +266,28 @@ finalElectrons = cms.EDFilter("PATElectronRefSelector",
 ################################################electronPROMPTMVA#####################
 electronPROMPTMVA= cms.EDProducer("EleBaseMVAValueMapProducer",
     src = cms.InputTag("linkedObjects","electrons"),
-    weightFile =  cms.FileInPath("PhysicsTools/NanoAOD/data/el_BDTG_2017.weights.xml"),
+    weightFile =  cms.FileInPath("PhysicsTools/NanoAOD/data/el_BDTG_2022.weights.xml"),
     name = cms.string("electronPROMPTMVA"),
     backend = cms.string("TMVA"),
     isClassifier = cms.bool(True),
     variables = cms.VPSet(
+        cms.PSet( name = cms.string("LepGood_pt"), expr = cms.string("pt")),
+        cms.PSet( name = cms.string("LepGood_eta"), expr = cms.string("eta")),
+        cms.PSet( name = cms.string("LepGood_pfRelIso03_all"), expr = cms.string("(pfIsolationR03().sumChargedHadronPt + max(pfIsolationR03().sumNeutralHadronEt + pfIsolationR03().sumPhotonEt - pfIsolationR03().sumPUPt/2,0.0))/pt")),
+        cms.PSet( name = cms.string("LepGood_miniRelIsoCharged"), expr = cms.string("userFloat('miniIsoChg_Fall17V2')/pt")),
+        cms.PSet( name = cms.string("LepGood_miniRelIsoNeutral"), expr = cms.string("(userFloat('miniIsoAll_Fall17V2')-userFloat('miniIsoChg_Fall17V2'))/pt")),
+        cms.PSet( name = cms.string("LepGood_jetNDauChargedMVASel"), expr = cms.string("?userCand('jetForLepJetVar').isNonnull()?userFloat('jetNDauChargedMVASel'):0")),
+        cms.PSet( name = cms.string("LepGood_jetPtRelv2"), expr = cms.string("?userCand('jetForLepJetVar').isNonnull()?userFloat('ptRel'):0")),
+        cms.PSet( name = cms.string("LepGood_jetDF"), expr = cms.string("?userCand('jetForLepJetVar').isNonnull()?max(userCand('jetForLepJetVar').bDiscriminator('pfDeepFlavourJetTags:probbb')+userCand('jetForLepJetVar').bDiscriminator('pfDeepFlavourJetTags:probb')+userCand('jetForLepJetVar').bDiscriminator('pfDeepFlavourJetTags:problepb'),0.0):0.0")),
+        cms.PSet( name = cms.string("LepGood_jetPtRatio"), expr = cms.string("?userCand('jetForLepJetVar').isNonnull()?min(userFloat('ptRatio'),1.5):1.0/(1.0+userFloat('PFIsoAll04_Fall17V2')/pt)")),
+        cms.PSet( name = cms.string("LepGood_sip3d"), expr = cms.string("abs(dB('PV3D')/edB('PV3D'))")),
+        cms.PSet( name = cms.string("LepGood_dxy"), expr = cms.string("log(abs(dB('PV2D')))")),
+        cms.PSet( name = cms.string("LepGood_dz"), expr = cms.string("log(abs(dB('PVDZ')))")),
+        cms.PSet( name = cms.string("LepGood_mvaIso"), expr = cms.string("userFloat('mvaIso')")),
+    )
+)
+
+_legacy_electron_BDT_variable = cms.VPSet(
         cms.PSet( name = cms.string("LepGood_pt"), expr = cms.string("pt")),
         cms.PSet( name = cms.string("LepGood_eta"), expr = cms.string("eta")),
         cms.PSet( name = cms.string("LepGood_jetNDauChargedMVASel"), expr = cms.string("?userCand('jetForLepJetVar').isNonnull()?userFloat('jetNDauChargedMVASel'):0")),
@@ -283,11 +300,18 @@ electronPROMPTMVA= cms.EDProducer("EleBaseMVAValueMapProducer",
         cms.PSet( name = cms.string("LepGood_sip3d"), expr = cms.string("abs(dB('PV3D')/edB('PV3D'))")),
         cms.PSet( name = cms.string("LepGood_dz"), expr = cms.string("log(abs(dB('PVDZ')))")),
         cms.PSet( name = cms.string("LepGood_mvaFall17V2noIso"), expr = cms.string("userFloat('mvaNoIso_Fall17V2')")),
-    )
 )
+
 run2_egamma_2016.toModify(
     electronPROMPTMVA,
     weightFile = "PhysicsTools/NanoAOD/data/el_BDTG_2016.weights.xml",
+    variables = _legacy_electron_BDT_variable
+)
+
+(run2_egamma_2016 | run2_egamma_2018).toModify(
+    electronPROMPTMVA,
+    weightFile = "PhysicsTools/NanoAOD/data/el_BDTG_2017.weights.xml",
+    variables = _legacy_electron_BDT_variable
 )
 ################################################electronPROMPTMVA end#####################
 


### PR DESCRIPTION
#### PR description:
## Brief description
Dear reviewers,

This PR is to introduce the newest training of the Electron mvaTTH in CMSSW. The training has been performed following what was done already done for Run 2, but using Run 3 MC samples for training and validation.

## Context of the PR
The goal for this new training is to be used as a substitute of the current mvaTTH **only in Run 3 MC production**. That is: for Run 2 we still need to keep the current mvaTTH implementation.

## What this PR includes
**This change should only affect Run 3 production**.  How the mva is evaluated changes a little bit with respect to the previous version: mainly the order in which the variables are parsed to TMVA and also we have added a new additional variable which is `LepGood_pfRelIso03_all`. 

## IMPORTANT REMARK
The training has been done considering a MiniAOD that has a buggy mvaNoISO variable. Instead of considering the buggy variable, the training has been done with mvaISO (and so it reflects in the config file, the last input variable to the MVA is mvaISO). This will change in the future most likely.

## Validation
I've performed a local test running a simple `cmsRun` script to see that the mva is loaded and nanoAOD is in fact produced. Below is  the cmsDriver I've used (in a cmssw-el8 container):

`cmsDriver.py  --python_filename GEN-Run3Summer23NanoAODv12-00146_1_cfg.py --eventcontent NANOEDMAODSIM --customise Configuration/DataProcessing/Utils.addMonitoring --datatier NANOAODSIM --fileout file:GEN-Run3Summer23NanoAODv12-00146.root --conditions 130X_mcRun3_2023_realistic_v14 --step NANO --scenario pp --filein "dbs:/WZto3LNu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v1/MINIAODSIM" --era Run3_2023 --no_exec --mc -n 1
`
Below  there's also a plot comparing the performance of this training vs the current one.
![image](https://github.com/user-attachments/assets/ae3a5a52-3a20-4eb2-8703-438e7465e95d)

## Other comments
Please let me know if the proposal is reasonable, and if there's anything else I can do for testing. I'm adding the L2 electron conveners @RSalvatico @afiqaize so they can follow up the PR as well. Feel free to add any other electron convener. I'm also tagging the placeholder PR that Riccardo prepare in the links below (I prefered creating a new one).

## Linked PRs
- This is the link for the PR that includes the weights in CMS-data: [pull19](https://github.com/cms-data/PhysicsTools-NanoAOD/pull/19).
- Placeholder PR: https://github.com/cms-sw/cmssw/pull/46316