### PR TITLE
Backport of ZDC Emulation Fix.

### DIFF
--- a/L1Trigger/L1TZDC/plugins/L1TZDCProducer.cc
+++ b/L1Trigger/L1TZDC/plugins/L1TZDCProducer.cc
@@ -125,7 +125,7 @@ void L1TZDCProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
       for (int ibx = 0; ibx < nSamples; ibx++) {
         if (ibx >= nPresamples + bxFirst_ && ibx <= nPresamples + bxLast_) {
           HcalTriggerPrimitiveSample hcalTpSample = hcalTp.sample(ibx);
-          int ietIn = hcalTpSample.compressedEt();
+          int ietIn = hcalTpSample.raw();
 
           l1t::EtSum tempEt = l1t::EtSum();
           tempEt.setHwPt(ietIn);


### PR DESCRIPTION
#### PR description:

This PR is a fix for the ZDC L1 emulation. Previously, the Et Sums were "compressed" to a value of 0 to 255, which is typical for the HCAL setup. However for the ZDC Et Sums, we would like the Et sums to go from 0 to 1023 in order to be consistent with what is included in the firmware. As the ZDC 1n OR trigger threshold is 16, this compression is not noticeable in the ZDC trigger rates, or emulated sums when focusing on lower values. However, when considering higher values this issue becomes clear.

#### PR validation:

This was tested using 10,000 events, using a replay of 2023 data using 14_1_X [see slides](https://www.dropbox.com/scl/fi/aw4it4ghzlp6lf2ohrfz7/HBossi_HINDailyRunMeeting_10242024.pdf?rlkey=exu2r50kvynzq0jgq3meiikda&dl=0).

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This  PR is a backport of https://github.com/cms-sw/cmssw/pull/46500

