### PR TITLE
[UBSAN][TrajectoryState] properly initialize data member

### DIFF
--- a/TrackingTools/TrajectoryState/interface/BasicTrajectoryState.h
+++ b/TrackingTools/TrajectoryState/interface/BasicTrajectoryState.h
@@ -73,7 +73,7 @@ public:
 
 public:
   // default constructor : to make root happy
-  BasicTrajectoryState() : theValid(false), theWeight(0) {}
+  BasicTrajectoryState() : theLocalParametersValid(false), theValid(false), theWeight(0) {}
 
   /// construct invalid trajectory state (without parameters)
   explicit BasicTrajectoryState(const SurfaceType& aSurface);

--- a/TrackingTools/TrajectoryState/src/TrajectoryStateClosestToPoint.cc
+++ b/TrackingTools/TrajectoryState/src/TrajectoryStateClosestToPoint.cc
@@ -4,7 +4,7 @@
 // Private constructor
 
 TrajectoryStateClosestToPoint::TrajectoryStateClosestToPoint(const FTS& originalFTS, const GlobalPoint& referencePoint)
-    : theFTS(originalFTS), theRefPoint(referencePoint), valid(true), theFTSavailable(true) {
+    : theFTS(originalFTS), theRefPoint(referencePoint), valid(true), theFTSavailable(true), errorIsAvailable(false) {
   auto params = PerigeeConversions::ftsToPerigeeParameters(originalFTS, referencePoint, thePt);
   if (not params) {
     valid = false;
@@ -15,8 +15,6 @@ TrajectoryStateClosestToPoint::TrajectoryStateClosestToPoint(const FTS& original
   if (theFTS.hasError()) {
     thePerigeeError = PerigeeConversions::ftsToPerigeeError(originalFTS);
     errorIsAvailable = true;
-  } else {
-    errorIsAvailable = false;
   }
   theField = &(originalFTS.parameters().magneticField());
 }


### PR DESCRIPTION
This change should fix the UBSAN runtime error [a]


[a] 
- https://cmssdt.cern.ch/SDT/jenkins-artifacts/ubsan_logs/CMSSW_14_2_X_2024-10-21-2300/logs/89/89ceaa990b8b9736fe71304cfab8e664/log
- https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc12/CMSSW_14_2_UBSAN_X_2024-10-21-2300/pyRelValMatrixLogs/run/136.75_RunJetHT2016D/step3_RunJetHT2016D.log#/
```
136.75/step3:TrackingTools/TrajectoryState/interface/TrajectoryStateClosestToPoint.h:18:7: runtime error: load of value 17, which is not a valid value for type 'bool'
140.109/step3:TrackingTools/TrajectoryState/interface/TrajectoryStateClosestToPoint.h:18:7: runtime error: load of value 48, which is not a valid value for type 'bool'
141.033/step3:TrackingTools/TrajectoryState/interface/TrajectoryStateClosestToPoint.h:18:7: runtime error: load of value 213, which is not a valid value for type 'bool'
141.102/step3:TrackingTools/TrajectoryState/interface/TrajectoryStateClosestToPoint.h:18:7: runtime error: load of value 236, which is not a valid value for type 'bool'
```