### PR TITLE
Avoid extra memory use in CaloSubdetectorGeometry

### DIFF
--- a/Geometry/CaloGeometry/interface/CaloCellGeometryMayOwnPtr.h
+++ b/Geometry/CaloGeometry/interface/CaloCellGeometryMayOwnPtr.h
@@ -1,0 +1,86 @@
+#ifndef Geometry_CaloGeometry_CaloCellGeometryMayOwnPtr_h
+#define Geometry_CaloGeometry_CaloCellGeometryMayOwnPtr_h
+// -*- C++ -*-
+//
+// Package:     Geometry/CaloGeometry
+// Class  :     CaloCellGeometryMayOwnPtr
+//
+/**\class CaloCellGeometryMayOwnPtr CaloCellGeometryMayOwnPtr.h "Geometry/CaloGeometry/interface/CaloCellGeometryMayOwnPtr.h"
+
+ Description: Type to hold pointer to CaloCellGeometry with possible ownership
+
+ Usage:
+    Used to either have single ownership or no ownership of the CaloCellGeometry
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Wed, 23 Oct 2024 19:50:05 GMT
+//
+
+// system include files
+#include <memory>
+
+// user include files
+#include "Geometry/CaloGeometry/interface/CaloCellGeometryPtr.h"
+#include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
+
+// forward declarations
+
+class CaloCellGeometryMayOwnPtr {
+public:
+  explicit CaloCellGeometryMayOwnPtr(CaloCellGeometry const* iPtr, bool iOwn) noexcept : ptr_{iPtr}, own_{iOwn} {}
+  explicit CaloCellGeometryMayOwnPtr(std::unique_ptr<CaloCellGeometry const> iPtr) noexcept
+      : ptr_{iPtr.release()}, own_{true} {}
+  explicit CaloCellGeometryMayOwnPtr(CaloCellGeometryPtr const& iPtr) noexcept : ptr_{iPtr.get()}, own_{false} {}
+
+  ~CaloCellGeometryMayOwnPtr() noexcept {
+    if (own_) {
+      delete ptr_;
+    }
+  }
+  CaloCellGeometryMayOwnPtr() noexcept = default;
+  CaloCellGeometryMayOwnPtr(const CaloCellGeometryMayOwnPtr&) noexcept = delete;
+  CaloCellGeometryMayOwnPtr(CaloCellGeometryMayOwnPtr&& iPtr) noexcept : ptr_{iPtr.ptr_}, own_{iPtr.own_} {
+    iPtr.ptr_ = nullptr;
+    iPtr.own_ = false;
+  }
+  CaloCellGeometryMayOwnPtr& operator=(CaloCellGeometryMayOwnPtr const&) noexcept = delete;
+  CaloCellGeometryMayOwnPtr& operator=(CaloCellGeometryMayOwnPtr&& iPtr) noexcept {
+    if (own_) {
+      delete ptr_;
+    }
+    ptr_ = iPtr.ptr_;
+    own_ = iPtr.own_;
+    iPtr.ptr_ = nullptr;
+    iPtr.own_ = false;
+    return *this;
+  }
+
+  CaloCellGeometry const* operator->() const { return ptr_; }
+  CaloCellGeometry const* get() const { return ptr_; }
+  CaloCellGeometry const& operator*() const { return *ptr_; }
+
+  operator CaloCellGeometry const*() const { return ptr_; }
+
+  //transfers ownership to a shared_ptr
+  std::shared_ptr<CaloCellGeometry const> releaseToShared() {
+    auto p = ptr_;
+    ptr_ = nullptr;
+    if (own_) {
+      own_ = false;
+      return std::shared_ptr<CaloCellGeometry const>(p);
+    }
+    return std::shared_ptr<CaloCellGeometry const>(p, no_delete());
+  }
+
+private:
+  struct no_delete {
+    void operator()(const void*) {}
+  };
+
+  const CaloCellGeometry* ptr_ = nullptr;
+  bool own_ = false;
+};
+
+#endif

--- a/Geometry/CaloGeometry/interface/CaloCellGeometryPtr.h
+++ b/Geometry/CaloGeometry/interface/CaloCellGeometryPtr.h
@@ -1,0 +1,47 @@
+#ifndef Geometry_CaloGeometry_CaloCellGeometryPtr_h
+#define Geometry_CaloGeometry_CaloCellGeometryPtr_h
+// -*- C++ -*-
+//
+// Package:     Geometry/CaloGeometry
+// Class  :     CaloCellGeometryPtr
+//
+/**\class CaloCellGeometryPtr CaloCellGeometryPtr.h "Geometry/CaloGeometry/interface/CaloCellGeometryPtr.h"
+
+ Description: Type to hold pointer to CaloCellGeometry
+
+ Usage:
+    Used to express that the CaloCellGeometry is owned elsewhere
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Wed, 23 Oct 2024 18:47:22 GMT
+//
+
+// system include files
+
+// user include files
+
+// forward declarations
+class CaloCellGeometry;
+
+class CaloCellGeometryPtr {
+public:
+  explicit CaloCellGeometryPtr(CaloCellGeometry const* iPtr) noexcept : ptr_{iPtr} {}
+  CaloCellGeometryPtr() noexcept = default;
+  CaloCellGeometryPtr(const CaloCellGeometryPtr&) noexcept = default;
+  CaloCellGeometryPtr(CaloCellGeometryPtr&&) noexcept = default;
+  CaloCellGeometryPtr& operator=(CaloCellGeometryPtr const&) noexcept = default;
+  CaloCellGeometryPtr& operator=(CaloCellGeometryPtr&&) noexcept = default;
+
+  CaloCellGeometry const* operator->() const { return ptr_; }
+  CaloCellGeometry const* get() const { return ptr_; }
+  CaloCellGeometry const& operator*() const { return *ptr_; }
+
+  operator CaloCellGeometry const*() const { return ptr_; }
+
+private:
+  const CaloCellGeometry* ptr_ = nullptr;
+};
+
+#endif

--- a/Geometry/CaloGeometry/interface/CaloGeometry.h
+++ b/Geometry/CaloGeometry/interface/CaloGeometry.h
@@ -3,11 +3,10 @@
 
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
-#include <memory>
+#include "Geometry/CaloGeometry/interface/CaloCellGeometryMayOwnPtr.h"
 #include <vector>
 
 class CaloSubdetectorGeometry;
-class CaloCellGeometry;
 
 /** \class CaloGeometry
       
@@ -29,7 +28,7 @@ public:
   GlobalPoint getPosition(const DetId& id) const;
 
   /// Get the cell geometry of a given detector id
-  std::shared_ptr<const CaloCellGeometry> getGeometry(const DetId& id) const;
+  CaloCellGeometryMayOwnPtr getGeometry(const DetId& id) const;
 
   /// Get the list of all valid detector ids
   std::vector<DetId> getValidDetIds() const;

--- a/Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h
+++ b/Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h
@@ -11,6 +11,8 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
+#include "Geometry/CaloGeometry/interface/CaloCellGeometryPtr.h"
+#include "Geometry/CaloGeometry/interface/CaloCellGeometryMayOwnPtr.h"
 #include "DataFormats/Math/interface/deltaR.h"
 
 /** \class CaloSubdetectorGeometry
@@ -35,6 +37,9 @@ public:
   typedef std::vector<unsigned int> IVec;
   typedef std::vector<CCGFloat> DimVec;
 
+  using CellPtr = CaloCellGeometryPtr;
+  using CellMayOwnPtr = CaloCellGeometryMayOwnPtr;
+
   CaloSubdetectorGeometry();
 
   /// The base class DOES assume that it owns the CaloCellGeometry objects
@@ -54,7 +59,7 @@ public:
   virtual bool present(const DetId& id) const;
 
   /// Get the cell geometry of a given detector id.  Should return false if not found.
-  virtual std::shared_ptr<const CaloCellGeometry> getGeometry(const DetId& id) const;
+  virtual CellMayOwnPtr getGeometry(const DetId& id) const;
 
   /** \brief Get a list of valid detector ids (for the given subdetector)
       \note The implementation in this class is relevant for SubdetectorGeometries which handle only
@@ -108,8 +113,8 @@ protected:
   virtual unsigned int indexFor(const DetId& id) const;
   virtual unsigned int sizeForDenseIndex(const DetId& id) const;
 
-  virtual const CaloCellGeometry* getGeometryRawPtr(uint32_t index) const = 0;
-  virtual std::shared_ptr<const CaloCellGeometry> cellGeomPtr(uint32_t index) const;
+  virtual CellPtr getGeometryRawPtr(uint32_t index) const = 0;
+  virtual CellPtr cellGeomPtr(uint32_t index) const;
 
   ParVecVec m_parVecVec;
 

--- a/Geometry/CaloGeometry/src/CaloGeometry.cc
+++ b/Geometry/CaloGeometry/src/CaloGeometry.cc
@@ -57,13 +57,13 @@ GlobalPoint CaloGeometry::getPosition(const DetId& id) const {
   }
 }
 
-std::shared_ptr<const CaloCellGeometry> CaloGeometry::getGeometry(const DetId& id) const {
+CaloCellGeometryMayOwnPtr CaloGeometry::getGeometry(const DetId& id) const {
   const CaloSubdetectorGeometry* geom = getSubdetectorGeometry(id);
   if (geom) {
     auto cell = geom->getGeometry(id);
     return cell;
   } else {
-    return std::shared_ptr<const CaloCellGeometry>();
+    return CaloCellGeometryMayOwnPtr();
   }
 }
 

--- a/Geometry/CaloGeometry/test/BuildFile.xml
+++ b/Geometry/CaloGeometry/test/BuildFile.xml
@@ -1,2 +1,6 @@
 <bin name="TestRounding" file="testRounding.cpp">
 </bin>
+<bin name="TestGeometryCaloGeometryCatch" file="*catch2.cc">
+  <use name="Geometry/CaloGeometry"/>
+  <use name="catch2"/>
+</bin>

--- a/Geometry/CaloGeometry/test/calocellgeometryptr_catch2.cc
+++ b/Geometry/CaloGeometry/test/calocellgeometryptr_catch2.cc
@@ -1,0 +1,268 @@
+// -*- C++ -*-
+//
+// Package:     Geometry/CaloGeometry
+// Class  :     calocellgeometryptr_catch2
+//
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Christopher Jones
+//         Created:  Thu, 24 Oct 2024 17:35:52 GMT
+//
+
+// system include files
+
+// user include files
+#include "Geometry/CaloGeometry/interface/CaloCellGeometryPtr.h"
+#include "Geometry/CaloGeometry/interface/CaloCellGeometryMayOwnPtr.h"
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+namespace {
+  class DummyCell : public CaloCellGeometry {
+  public:
+    DummyCell() { ++nLive; }
+    ~DummyCell() { --nLive; }
+    DummyCell(DummyCell const&) = delete;
+    DummyCell(DummyCell&&) = delete;
+    DummyCell& operator=(DummyCell const&) = delete;
+    DummyCell& operator=(DummyCell&&) = delete;
+
+    void vocalCorners(Pt3DVec& vec, const CCGFloat* pv, Pt3D& ref) const final {}
+    void initCorners(CornersVec&) final {}
+
+    static int nLive;
+  };
+  int DummyCell::nLive = 0;
+}  // namespace
+
+TEST_CASE("Test CaloCellGeometryPtr", "[CaloCellGeometryPtr]") {
+  SECTION("Default Constructor") {
+    CaloCellGeometryPtr ptr;
+    CHECK(ptr.get() == nullptr);
+    CHECK(static_cast<CaloCellGeometry const*>(ptr) == nullptr);
+  }
+  SECTION("Pointer Constructor") {
+    {
+      DummyCell dummy;
+      REQUIRE(DummyCell::nLive == 1);
+
+      {
+        CaloCellGeometryPtr ptr(&dummy);
+        CHECK(ptr.get() == &dummy);
+        CHECK(static_cast<CaloCellGeometry const*>(ptr) == &dummy);
+        CHECK(ptr.operator->() == &dummy);
+        CHECK(&(*ptr) == &dummy);
+      }
+      REQUIRE(DummyCell::nLive == 1);
+    }
+    REQUIRE(DummyCell::nLive == 0);
+  }
+}
+
+TEST_CASE("Test CaloCellGeometryMayOwnPtr", "[CaloCellGeometryPtr]") {
+  SECTION("Default Constructed") {
+    CaloCellGeometryMayOwnPtr ptr;
+    CHECK(ptr.get() == nullptr);
+    CHECK(static_cast<CaloCellGeometry const*>(ptr) == nullptr);
+    CHECK(ptr.releaseToShared().get() == nullptr);
+  }
+  SECTION("From CaloCellGeometryPtr") {
+    {
+      DummyCell dummy;
+      REQUIRE(DummyCell::nLive == 1);
+      CaloCellGeometryPtr p(&dummy);
+      {
+        CaloCellGeometryMayOwnPtr ptr(p);
+        CHECK(ptr.get() == &dummy);
+        CHECK(static_cast<CaloCellGeometry const*>(ptr) == &dummy);
+        CHECK(ptr.operator->() == &dummy);
+        CHECK(&(*ptr) == &dummy);
+      }
+      REQUIRE(DummyCell::nLive == 1);
+      SECTION("releaseToShared") {
+        {
+          CaloCellGeometryMayOwnPtr ptr(p);
+          CHECK(ptr.releaseToShared().get() == &dummy);
+          REQUIRE(DummyCell::nLive == 1);
+          CHECK(ptr.get() == nullptr);
+        }
+        REQUIRE(DummyCell::nLive == 1);
+      }
+    }
+    REQUIRE(DummyCell::nLive == 0);
+  }
+
+  SECTION("From unique_ptr") {
+    {
+      auto dummy = std::make_unique<DummyCell>();
+      auto dummyAddress = dummy.get();
+      REQUIRE(DummyCell::nLive == 1);
+      {
+        CaloCellGeometryMayOwnPtr ptr(std::move(dummy));
+        CHECK(ptr.get() == dummyAddress);
+        CHECK(static_cast<CaloCellGeometry const*>(ptr) == dummyAddress);
+        CHECK(ptr.operator->() == dummyAddress);
+        CHECK(&(*ptr) == dummyAddress);
+      }
+      REQUIRE(DummyCell::nLive == 0);
+      SECTION("releaseToShared") {
+        {
+          auto dummy = std::make_unique<DummyCell>();
+          auto dummyAddress = dummy.get();
+          REQUIRE(DummyCell::nLive == 1);
+          CaloCellGeometryMayOwnPtr ptr(std::move(dummy));
+          CHECK(ptr.releaseToShared().get() == dummyAddress);
+          REQUIRE(DummyCell::nLive == 0);
+          CHECK(ptr.get() == nullptr);
+        }
+      }
+    }
+  }
+
+  SECTION("move constructor") {
+    SECTION("non-owning") {
+      DummyCell dummy;
+      REQUIRE(DummyCell::nLive == 1);
+      CaloCellGeometryPtr p(&dummy);
+      {
+        CaloCellGeometryMayOwnPtr from(p);
+        {
+          CaloCellGeometryMayOwnPtr ptr(std::move(from));
+          CHECK(from.get() == nullptr);
+          CHECK(ptr.get() == &dummy);
+          CHECK(static_cast<CaloCellGeometry const*>(ptr) == &dummy);
+          CHECK(ptr.operator->() == &dummy);
+          CHECK(&(*ptr) == &dummy);
+          REQUIRE(DummyCell::nLive == 1);
+        }
+        REQUIRE(DummyCell::nLive == 1);
+      }
+      REQUIRE(DummyCell::nLive == 1);
+    }
+    SECTION("owning") {
+      auto dummy = std::make_unique<DummyCell>();
+      auto dummyAddress = dummy.get();
+      REQUIRE(DummyCell::nLive == 1);
+      {
+        CaloCellGeometryMayOwnPtr from(std::move(dummy));
+        {
+          CaloCellGeometryMayOwnPtr ptr(std::move(from));
+          CHECK(from.get() == nullptr);
+          CHECK(ptr.get() == dummyAddress);
+          CHECK(static_cast<CaloCellGeometry const*>(ptr) == dummyAddress);
+          CHECK(ptr.operator->() == dummyAddress);
+          CHECK(&(*ptr) == dummyAddress);
+        }
+        REQUIRE(DummyCell::nLive == 0);
+      }
+    }
+  }
+
+  SECTION("move assignment") {
+    SECTION("from non-owning") {
+      DummyCell oldDummy;
+      CaloCellGeometryPtr p(&oldDummy);
+      REQUIRE(DummyCell::nLive == 1);
+      SECTION("to non-owning") {
+        DummyCell dummy;
+        REQUIRE(DummyCell::nLive == 2);
+        {
+          CaloCellGeometryMayOwnPtr ptr(p);
+          CaloCellGeometryPtr p(&dummy);
+          {
+            CaloCellGeometryMayOwnPtr from(p);
+            {
+              ptr = std::move(from);
+              CHECK(from.get() == nullptr);
+              CHECK(ptr.get() == &dummy);
+              CHECK(static_cast<CaloCellGeometry const*>(ptr) == &dummy);
+              CHECK(ptr.operator->() == &dummy);
+              CHECK(&(*ptr) == &dummy);
+            }
+            REQUIRE(DummyCell::nLive == 2);
+          }
+          REQUIRE(DummyCell::nLive == 2);
+        }
+        REQUIRE(DummyCell::nLive == 2);
+      }
+      SECTION("to owning") {
+        {
+          CaloCellGeometryMayOwnPtr ptr(p);
+          auto dummy = std::make_unique<DummyCell>();
+          auto dummyAddress = dummy.get();
+          REQUIRE(DummyCell::nLive == 2);
+          {
+            CaloCellGeometryMayOwnPtr from(std::move(dummy));
+            {
+              ptr = std::move(from);
+              CHECK(from.get() == nullptr);
+              CHECK(ptr.get() == dummyAddress);
+              CHECK(static_cast<CaloCellGeometry const*>(ptr) == dummyAddress);
+              CHECK(ptr.operator->() == dummyAddress);
+              CHECK(&(*ptr) == dummyAddress);
+            }
+          }
+          REQUIRE(DummyCell::nLive == 2);
+        }
+        REQUIRE(DummyCell::nLive == 1);
+      }
+    }
+  }
+
+  SECTION("move assignment") {
+    SECTION("from owning") {
+      SECTION("to non-owning") {
+        auto oldDummy = std::make_unique<DummyCell>();
+        REQUIRE(DummyCell::nLive == 1);
+        DummyCell dummy;
+        REQUIRE(DummyCell::nLive == 2);
+        {
+          CaloCellGeometryMayOwnPtr ptr(std::move(oldDummy));
+          CaloCellGeometryPtr p(&dummy);
+          {
+            CaloCellGeometryMayOwnPtr from(p);
+            {
+              REQUIRE(DummyCell::nLive == 2);
+              ptr = std::move(from);
+              REQUIRE(DummyCell::nLive == 1);
+              CHECK(from.get() == nullptr);
+              CHECK(ptr.get() == &dummy);
+              CHECK(static_cast<CaloCellGeometry const*>(ptr) == &dummy);
+              CHECK(ptr.operator->() == &dummy);
+              CHECK(&(*ptr) == &dummy);
+            }
+          }
+          REQUIRE(DummyCell::nLive == 1);
+        }
+        REQUIRE(DummyCell::nLive == 1);
+      }
+      SECTION("to owning") {
+        REQUIRE(DummyCell::nLive == 0);
+        {
+          auto oldDummy = std::make_unique<DummyCell>();
+          REQUIRE(DummyCell::nLive == 1);
+          CaloCellGeometryMayOwnPtr ptr(std::move(oldDummy));
+          auto dummy = std::make_unique<DummyCell>();
+          auto dummyAddress = dummy.get();
+          REQUIRE(DummyCell::nLive == 2);
+          {
+            CaloCellGeometryMayOwnPtr from(std::move(dummy));
+            {
+              REQUIRE(DummyCell::nLive == 2);
+              ptr = std::move(from);
+              REQUIRE(DummyCell::nLive == 1);
+              CHECK(from.get() == nullptr);
+              CHECK(ptr.get() == dummyAddress);
+              CHECK(static_cast<CaloCellGeometry const*>(ptr) == dummyAddress);
+              CHECK(ptr.operator->() == dummyAddress);
+              CHECK(&(*ptr) == dummyAddress);
+            }
+          }
+          REQUIRE(DummyCell::nLive == 1);
+        }
+        REQUIRE(DummyCell::nLive == 0);
+      }
+    }
+  }
+}

--- a/Geometry/EcalAlgo/interface/EcalBarrelGeometry.h
+++ b/Geometry/EcalAlgo/interface/EcalBarrelGeometry.h
@@ -102,7 +102,7 @@ public:
 
 protected:
   // Modify the RawPtr class
-  const CaloCellGeometry* getGeometryRawPtr(uint32_t index) const override;
+  CaloCellGeometryPtr getGeometryRawPtr(uint32_t index) const override;
 
 private:
   /** number of crystals in eta direction */

--- a/Geometry/EcalAlgo/interface/EcalEndcapGeometry.h
+++ b/Geometry/EcalAlgo/interface/EcalEndcapGeometry.h
@@ -96,7 +96,7 @@ public:
 
 protected:
   // Modify the RawPtr class
-  const CaloCellGeometry* getGeometryRawPtr(uint32_t index) const override;
+  CaloCellGeometryPtr getGeometryRawPtr(uint32_t index) const override;
 
 private:
   static int myPhi(int i) {

--- a/Geometry/EcalAlgo/interface/EcalPreshowerGeometry.h
+++ b/Geometry/EcalAlgo/interface/EcalPreshowerGeometry.h
@@ -88,7 +88,7 @@ public:
 
 protected:
   // Modify the RawPtr class
-  const CaloCellGeometry* getGeometryRawPtr(uint32_t index) const override;
+  CaloCellGeometryPtr getGeometryRawPtr(uint32_t index) const override;
 
 private:
   const CCGFloat m_xWidWaf;

--- a/Geometry/EcalAlgo/src/EcalBarrelGeometry.cc
+++ b/Geometry/EcalAlgo/src/EcalBarrelGeometry.cc
@@ -432,10 +432,10 @@ CCGFloat EcalBarrelGeometry::avgRadiusXYFrontFaceCenter() const {
   return m_radius;
 }
 
-const CaloCellGeometry* EcalBarrelGeometry::getGeometryRawPtr(uint32_t index) const {
+CaloCellGeometryPtr EcalBarrelGeometry::getGeometryRawPtr(uint32_t index) const {
   // Modify the RawPtr class
-  const CaloCellGeometry* cell(&m_cellVec[index]);
-  return (m_cellVec.size() < index || nullptr == cell->param() ? nullptr : cell);
+  return CaloCellGeometryPtr(m_cellVec.size() <= index || nullptr == m_cellVec[index].param() ? nullptr
+                                                                                              : &m_cellVec[index]);
 }
 
 bool EcalBarrelGeometry::present(const DetId& id) const {

--- a/Geometry/EcalAlgo/src/EcalEndcapGeometry.cc
+++ b/Geometry/EcalAlgo/src/EcalEndcapGeometry.cc
@@ -447,10 +447,9 @@ CCGFloat EcalEndcapGeometry::avgAbsZFrontFaceCenter() const {
   return m_avgZ;
 }
 
-const CaloCellGeometry* EcalEndcapGeometry::getGeometryRawPtr(uint32_t index) const {
-  // Modify the RawPtr class
-  const CaloCellGeometry* cell(&m_cellVec[index]);
-  return (m_cellVec.size() < index || nullptr == cell->param() ? nullptr : cell);
+CaloCellGeometryPtr EcalEndcapGeometry::getGeometryRawPtr(uint32_t index) const {
+  return CaloCellGeometryPtr(m_cellVec.size() <= index || nullptr == m_cellVec[index].param() ? nullptr
+                                                                                              : &m_cellVec[index]);
 }
 
 bool EcalEndcapGeometry::present(const DetId& id) const {

--- a/Geometry/EcalAlgo/src/EcalPreshowerGeometry.cc
+++ b/Geometry/EcalAlgo/src/EcalPreshowerGeometry.cc
@@ -209,8 +209,7 @@ void EcalPreshowerGeometry::newCell(const GlobalPoint& f1,
 #endif
 }
 
-const CaloCellGeometry* EcalPreshowerGeometry::getGeometryRawPtr(uint32_t index) const {
-  // Modify the RawPtr class
-  const CaloCellGeometry* cell(&m_cellVec[index]);
-  return (m_cellVec.size() < index || nullptr == cell->param() ? nullptr : cell);
+CaloCellGeometryPtr EcalPreshowerGeometry::getGeometryRawPtr(uint32_t index) const {
+  return CaloCellGeometryPtr(m_cellVec.size() <= index || nullptr == m_cellVec[index].param() ? nullptr
+                                                                                              : &m_cellVec[index]);
 }

--- a/Geometry/EcalAlgo/test/EcalBarrelCellParameterDump.cc
+++ b/Geometry/EcalAlgo/test/EcalBarrelCellParameterDump.cc
@@ -42,7 +42,7 @@ void EcalBarrelCellParameterDump::analyze(const edm::Event& /*iEvent*/, const ed
   int nall(0);
   for (auto id : ids) {
     ++nall;
-    std::shared_ptr<const CaloCellGeometry> geom = ecalGeom->getGeometry(id);
+    auto geom = ecalGeom->getGeometry(id);
     EBDetId ebid(id.rawId());
 
     std::ostringstream st1;

--- a/Geometry/EcalAlgo/test/EcalEndcapCellParameterDump.cc
+++ b/Geometry/EcalAlgo/test/EcalEndcapCellParameterDump.cc
@@ -41,7 +41,7 @@ void EcalEndcapCellParameterDump::analyze(const edm::Event& /*iEvent*/, const ed
   int nall(0);
   for (auto id : ids) {
     ++nall;
-    std::shared_ptr<const CaloCellGeometry> geom = ecalGeom->getGeometry(id);
+    auto geom = ecalGeom->getGeometry(id);
     EEDetId ebid(id.rawId());
 
     std::ostringstream st1;

--- a/Geometry/EcalTestBeam/interface/EcalTBHodoscopeGeometry.h
+++ b/Geometry/EcalTestBeam/interface/EcalTBHodoscopeGeometry.h
@@ -35,7 +35,7 @@ public:
 
 protected:
   // Modify the RawPtr class
-  const CaloCellGeometry* getGeometryRawPtr(uint32_t index) const override;
+  CaloCellGeometryPtr getGeometryRawPtr(uint32_t index) const override;
 
 private:
   struct fibre_pos {

--- a/Geometry/EcalTestBeam/src/EcalTBHodoscopeGeometry.cc
+++ b/Geometry/EcalTestBeam/src/EcalTBHodoscopeGeometry.cc
@@ -338,8 +338,8 @@ std::vector<int> EcalTBHodoscopeGeometry::getFiredFibresInPlane(float xtr, int p
   return firedFibres;
 }
 
-const CaloCellGeometry* EcalTBHodoscopeGeometry::getGeometryRawPtr(uint32_t index) const {
+CaloCellGeometryPtr EcalTBHodoscopeGeometry::getGeometryRawPtr(uint32_t index) const {
   // Modify the RawPtr class
-  const CaloCellGeometry* cell(&m_cellVec[index]);
-  return (m_cellVec.size() < index || nullptr == cell->param() ? nullptr : cell);
+  return CaloCellGeometryPtr(m_cellVec.size() <= index || nullptr == m_cellVec[index].param() ? nullptr
+                                                                                              : &m_cellVec[index]);
 }

--- a/Geometry/ForwardGeometry/interface/CastorGeometry.h
+++ b/Geometry/ForwardGeometry/interface/CastorGeometry.h
@@ -63,12 +63,10 @@ public:
 
 protected:
   // Modify the RawPtr class
-  const CaloCellGeometry* getGeometryRawPtr(uint32_t index) const override;
+  CaloCellGeometryPtr getGeometryRawPtr(uint32_t index) const override;
 
 private:
   const CastorTopology* theTopology;
-  mutable DetId::Detector lastReqDet_;
-  mutable int lastReqSubdet_;
   bool m_ownsTopology;
 
   CellVec m_cellVec;

--- a/Geometry/ForwardGeometry/interface/ZdcGeometry.h
+++ b/Geometry/ForwardGeometry/interface/ZdcGeometry.h
@@ -67,7 +67,7 @@ protected:
   unsigned int indexFor(const DetId& id) const override { return theTopology->detId2DenseIndex(id); }
 
   // Modify the RawPtr class
-  const CaloCellGeometry* getGeometryRawPtr(uint32_t index) const override;
+  CaloCellGeometryPtr getGeometryRawPtr(uint32_t index) const override;
 
 private:
   const ZdcTopology* theTopology;

--- a/Geometry/ForwardGeometry/src/CastorGeometry.cc
+++ b/Geometry/ForwardGeometry/src/CastorGeometry.cc
@@ -10,18 +10,10 @@ typedef CaloCellGeometry::Pt3D Pt3D;
 typedef CaloCellGeometry::Pt3DVec Pt3DVec;
 
 CastorGeometry::CastorGeometry()
-    : theTopology(new CastorTopology),
-      lastReqDet_(DetId::Detector(0)),
-      lastReqSubdet_(0),
-      m_ownsTopology(true),
-      m_cellVec(k_NumberOfCellsForCorners) {}
+    : theTopology(new CastorTopology), m_ownsTopology(true), m_cellVec(k_NumberOfCellsForCorners) {}
 
 CastorGeometry::CastorGeometry(const CastorTopology* topology)
-    : theTopology(topology),
-      lastReqDet_(DetId::Detector(0)),
-      lastReqSubdet_(0),
-      m_ownsTopology(false),
-      m_cellVec(k_NumberOfCellsForCorners) {}
+    : theTopology(topology), m_ownsTopology(false), m_cellVec(k_NumberOfCellsForCorners) {}
 
 CastorGeometry::~CastorGeometry() {
   if (m_ownsTopology)
@@ -72,8 +64,8 @@ void CastorGeometry::newCell(const GlobalPoint& f1,
   addValidID(detId);
 }
 
-const CaloCellGeometry* CastorGeometry::getGeometryRawPtr(uint32_t index) const {
+CaloCellGeometryPtr CastorGeometry::getGeometryRawPtr(uint32_t index) const {
   // Modify the RawPtr class
-  const CaloCellGeometry* cell(&m_cellVec[index]);
-  return (m_cellVec.size() < index || nullptr == cell->param() ? nullptr : cell);
+  return CaloCellGeometryPtr(m_cellVec.size() <= index || nullptr == m_cellVec[index].param() ? nullptr
+                                                                                              : &m_cellVec[index]);
 }

--- a/Geometry/ForwardGeometry/src/ZdcGeometry.cc
+++ b/Geometry/ForwardGeometry/src/ZdcGeometry.cc
@@ -91,12 +91,12 @@ void ZdcGeometry::newCell(const GlobalPoint& f1,
   addValidID(detId);
 }
 
-const CaloCellGeometry* ZdcGeometry::getGeometryRawPtr(uint32_t index) const {
+CaloCellGeometryPtr ZdcGeometry::getGeometryRawPtr(uint32_t index) const {
   // Modify the RawPtr class
-  if (m_cellVec.size() < index)
-    return nullptr;
+  if (m_cellVec.size() <= index)
+    return CaloCellGeometryPtr();
   const CaloCellGeometry* cell(&m_cellVec[index]);
-  return (((cell == nullptr) || (nullptr == cell->param())) ? nullptr : cell);
+  return CaloCellGeometryPtr(((cell == nullptr) || (nullptr == cell->param())) ? nullptr : cell);
 }
 
 void ZdcGeometry::getSummary(CaloSubdetectorGeometry::TrVec& tVec,
@@ -115,7 +115,7 @@ void ZdcGeometry::getSummary(CaloSubdetectorGeometry::TrVec& tVec,
 
   for (uint32_t i(0); i != m_validIds.size(); ++i) {
     Tr3D tr;
-    std::shared_ptr<const CaloCellGeometry> ptr(cellGeomPtr(i));
+    auto ptr = cellGeomPtr(i);
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("ZDCGeom") << "ZDCGeometry:Summary " << i << ":" << HcalZDCDetId::kSizeForDenseIndexingRun1
                                 << " Pointer " << ptr << ":" << (nullptr != ptr);

--- a/Geometry/HGCalGeometry/interface/HGCalGeometry.h
+++ b/Geometry/HGCalGeometry/interface/HGCalGeometry.h
@@ -61,7 +61,7 @@ public:
                const DetId& detId) override;
 
   /// Get the cell geometry of a given detector id.  Should return false if not found.
-  std::shared_ptr<const CaloCellGeometry> getGeometry(const DetId& id) const override;
+  CaloCellGeometryMayOwnPtr getGeometry(const DetId& id) const override;
 
   bool present(const DetId& id) const override;
 
@@ -119,9 +119,9 @@ protected:
   unsigned int sizeForDenseIndex() const;
 
   // Modify the RawPtr class
-  const CaloCellGeometry* getGeometryRawPtr(uint32_t index) const override;
+  CaloCellGeometryPtr getGeometryRawPtr(uint32_t index) const override;
 
-  std::shared_ptr<const CaloCellGeometry> cellGeomPtr(uint32_t index) const override;
+  CaloCellGeometryPtr cellGeomPtr(uint32_t index) const override;
 
   void addValidID(const DetId& id);
   unsigned int getClosestCellIndex(const GlobalPoint& r) const;
@@ -129,7 +129,7 @@ protected:
 private:
   template <class T>
   unsigned int getClosestCellIndex(const GlobalPoint& r, const std::vector<T>& vec) const;
-  std::shared_ptr<const CaloCellGeometry> cellGeomPtr(uint32_t index, const GlobalPoint& p) const;
+  CaloCellGeometryMayOwnPtr cellGeomPtr(uint32_t index, const GlobalPoint& p) const;
   DetId getGeometryDetId(DetId detId) const;
 
   static constexpr double k_half = 0.5;

--- a/Geometry/HGCalGeometry/interface/HGCalTBGeometry.h
+++ b/Geometry/HGCalGeometry/interface/HGCalTBGeometry.h
@@ -59,7 +59,7 @@ public:
                const DetId& detId) override;
 
   /// Get the cell geometry of a given detector id.  Should return false if not found.
-  std::shared_ptr<const CaloCellGeometry> getGeometry(const DetId& id) const override;
+  CaloCellGeometryMayOwnPtr getGeometry(const DetId& id) const override;
 
   bool present(const DetId& id) const override;
 
@@ -115,9 +115,9 @@ protected:
   unsigned int sizeForDenseIndex() const;
 
   // Modify the RawPtr class
-  const CaloCellGeometry* getGeometryRawPtr(uint32_t index) const override;
+  CaloCellGeometryPtr getGeometryRawPtr(uint32_t index) const override;
 
-  std::shared_ptr<const CaloCellGeometry> cellGeomPtr(uint32_t index) const override;
+  CaloCellGeometryPtr cellGeomPtr(uint32_t index) const override;
 
   void addValidID(const DetId& id);
   unsigned int getClosestCellIndex(const GlobalPoint& r) const;
@@ -125,7 +125,7 @@ protected:
 private:
   template <class T>
   unsigned int getClosestCellIndex(const GlobalPoint& r, const std::vector<T>& vec) const;
-  std::shared_ptr<const CaloCellGeometry> cellGeomPtr(uint32_t index, const GlobalPoint& p) const;
+  CaloCellGeometryMayOwnPtr cellGeomPtr(uint32_t index, const GlobalPoint& p) const;
   DetId getGeometryDetId(DetId detId) const;
 
   static constexpr double k_half = 0.5;

--- a/Geometry/HcalTowerAlgo/interface/CaloTowerGeometry.h
+++ b/Geometry/HcalTowerAlgo/interface/CaloTowerGeometry.h
@@ -51,8 +51,8 @@ public:
                const CCGFloat* parm,
                const DetId& detId) override;
 
-  std::shared_ptr<const CaloCellGeometry> getGeometry(const DetId& id) const override {
-    return cellGeomPtr(m_cttopo->denseIndex(id));
+  CaloCellGeometryMayOwnPtr getGeometry(const DetId& id) const override {
+    return CaloCellGeometryMayOwnPtr(cellGeomPtr(m_cttopo->denseIndex(id)));
   }
 
   void getSummary(CaloSubdetectorGeometry::TrVec& trVector,
@@ -65,7 +65,7 @@ protected:
   unsigned int sizeForDenseIndex(const DetId& id) const override { return m_cttopo->sizeForDenseIndexing(); }
 
   // Modify the RawPtr class
-  const CaloCellGeometry* getGeometryRawPtr(uint32_t index) const override;
+  CaloCellGeometryPtr getGeometryRawPtr(uint32_t index) const override;
 
 private:
   const CaloTowerTopology* m_cttopo;

--- a/Geometry/HcalTowerAlgo/interface/HcalDDDGeometry.h
+++ b/Geometry/HcalTowerAlgo/interface/HcalDDDGeometry.h
@@ -41,7 +41,7 @@ public:
 
 protected:
   // Modify the RawPtr class
-  const CaloCellGeometry* getGeometryRawPtr(uint32_t index) const override;
+  CaloCellGeometryPtr getGeometryRawPtr(uint32_t index) const override;
 
 private:
   void newCellImpl(

--- a/Geometry/HcalTowerAlgo/interface/HcalGeometry.h
+++ b/Geometry/HcalTowerAlgo/interface/HcalGeometry.h
@@ -49,7 +49,7 @@ public:
 
   const std::vector<DetId>& getValidDetIds(DetId::Detector det = DetId::Detector(0), int subdet = 0) const override;
 
-  std::shared_ptr<const CaloCellGeometry> getGeometry(const DetId& id) const override;
+  CaloCellGeometryMayOwnPtr getGeometry(const DetId& id) const override;
 
   DetId getClosestCell(const GlobalPoint& r) const override;
   DetId getClosestCell(const GlobalPoint& r, bool ignoreCorrect) const;
@@ -115,13 +115,11 @@ protected:
   unsigned int sizeForDenseIndex(const DetId& id) const override { return m_topology.ncells(); }
 
   // Modify the RawPtr class
-  const CaloCellGeometry* getGeometryRawPtr(uint32_t index) const override;
+  CaloCellGeometryPtr getGeometryRawPtr(uint32_t index) const override;
 
 private:
   // Base clas for getting geometry
-  std::shared_ptr<const CaloCellGeometry> getGeometryBase(const DetId& id) const {
-    return cellGeomPtr(m_topology.detId2denseId(id));
-  }
+  CaloCellGeometryPtr getGeometryBase(const DetId& id) const { return cellGeomPtr(m_topology.detId2denseId(id)); }
 
   //returns din
   unsigned int newCellImpl(

--- a/Geometry/HcalTowerAlgo/src/CaloTowerGeometry.cc
+++ b/Geometry/HcalTowerAlgo/src/CaloTowerGeometry.cc
@@ -52,10 +52,10 @@ void CaloTowerGeometry::newCell(
   m_dins.emplace_back(di);
 }
 
-const CaloCellGeometry* CaloTowerGeometry::getGeometryRawPtr(uint32_t index) const {
+CaloCellGeometryPtr CaloTowerGeometry::getGeometryRawPtr(uint32_t index) const {
   // Modify the RawPtr class
-  const CaloCellGeometry* cell(&m_cellVec[index]);
-  return (m_cellVec.size() < index || nullptr == cell->param() ? nullptr : cell);
+  return CaloCellGeometryPtr(m_cellVec.size() <= index || nullptr == m_cellVec[index].param() ? nullptr
+                                                                                              : &m_cellVec[index]);
 }
 
 void CaloTowerGeometry::getSummary(CaloSubdetectorGeometry::TrVec& tVec,

--- a/Geometry/HcalTowerAlgo/src/HcalDDDGeometry.cc
+++ b/Geometry/HcalTowerAlgo/src/HcalDDDGeometry.cc
@@ -184,7 +184,7 @@ void HcalDDDGeometry::newCellFast(
   m_validIds.emplace_back(detId);
 }
 
-const CaloCellGeometry* HcalDDDGeometry::getGeometryRawPtr(uint32_t din) const {
+CaloCellGeometryPtr HcalDDDGeometry::getGeometryRawPtr(uint32_t din) const {
   // Modify the RawPtr class
   const CaloCellGeometry* cell(nullptr);
   if (m_hbCellVec.size() > din) {
@@ -200,7 +200,7 @@ const CaloCellGeometry* HcalDDDGeometry::getGeometryRawPtr(uint32_t din) const {
     cell = (&m_hfCellVec[ind]);
   }
 
-  return ((nullptr == cell || nullptr == cell->param()) ? nullptr : cell);
+  return CaloCellGeometryPtr((nullptr == cell || nullptr == cell->param()) ? nullptr : cell);
 }
 
 void HcalDDDGeometry::increaseReserve(unsigned int extra) { m_validIds.reserve(m_validIds.size() + extra); }

--- a/Geometry/HcalTowerAlgo/test/HcalCellParameterDump.cc
+++ b/Geometry/HcalTowerAlgo/test/HcalCellParameterDump.cc
@@ -52,7 +52,7 @@ void HcalCellParameterDump::analyze(const edm::Event& /*iEvent*/, const edm::Eve
   int nall(0);
   for (auto id : ids) {
     ++nall;
-    std::shared_ptr<const CaloCellGeometry> geom = hcalGeom->getGeometry(id);
+    auto geom = hcalGeom->getGeometry(id);
     edm::LogVerbatim("HCalGeom") << "[" << nall << "] " << HcalDetId(id) << " Reference " << std::setprecision(4)
                                  << geom->getPosition() << " Back " << geom->getBackPoint() << " [r,eta,phi] ("
                                  << geom->rhoPos() << ", " << geom->etaPos() << ":" << geom->etaSpan() << ", "

--- a/RecoEcal/EgammaCoreTools/src/EcalClustersGraph.cc
+++ b/RecoEcal/EgammaCoreTools/src/EcalClustersGraph.cc
@@ -256,7 +256,7 @@ std::pair<double, double> EcalClustersGraph::computeCovariances(const CaloCluste
   double denominator = cluster->energy();
   double clEta = cluster->position().eta();
   double clPhi = cluster->position().phi();
-  std::shared_ptr<const CaloCellGeometry> this_cell;
+  CaloCellGeometryMayOwnPtr this_cell;
   EcalRecHitCollection::const_iterator rHit;
 
   const std::vector<std::pair<DetId, float>>& detId = cluster->hitsAndFractions();

--- a/RecoEgamma/EgammaTools/plugins/DRNCorrectionProducerT.cc
+++ b/RecoEgamma/EgammaTools/plugins/DRNCorrectionProducerT.cc
@@ -255,7 +255,7 @@ void DRNCorrectionProducerT<T>::acquire(edm::Event const& iEvent, edm::EventSetu
    * Fill input tensors by iterating over particles...
    */
   int64_t partNum = 0;
-  std::shared_ptr<const CaloCellGeometry> geom;
+  CaloCellGeometryMayOwnPtr geom;
   for (auto& part : *particles_) {
     const reco::SuperClusterRef& sc = part.superCluster();
 

--- a/RecoMET/METAlgorithms/src/EcalHaloAlgo.cc
+++ b/RecoMET/METAlgorithms/src/EcalHaloAlgo.cc
@@ -68,7 +68,7 @@ EcalHaloData EcalHaloAlgo::Calculate(const CaloGeometry& TheCaloGeometry,
     // Get EB geometry
     const CaloSubdetectorGeometry* TheSubGeometry = TheCaloGeometry.getSubdetectorGeometry(DetId::Ecal, 1);
     EBDetId EcalID(id.rawId());
-    auto cell = (TheSubGeometry) ? (TheSubGeometry->getGeometry(id)) : nullptr;
+    auto cell = (TheSubGeometry) ? (TheSubGeometry->getGeometry(id)) : decltype(TheSubGeometry->getGeometry(id))();
 
     if (cell) {
       // GlobalPoint globalpos = cell->getPosition();

--- a/RecoParticleFlow/PFClusterProducer/interface/PFEcalBarrelRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFEcalBarrelRecHitCreator.h
@@ -67,15 +67,16 @@ public:
       auto flags = erh.flagsBits();
       bool hi = (useSrF ? isHighInterest(detid) : true);
 
-      const auto thisCell = ecalGeo->getGeometry(detid);
+      {
+        auto thisCell = ecalGeo->getGeometry(detid);
 
-      // find rechit geometry
-      if (!thisCell) {
-        throw cms::Exception("PFEcalBarrelRecHitCreator") << "detid " << detid.rawId() << "not found in geometry";
+        // find rechit geometry
+        if (!thisCell) {
+          throw cms::Exception("PFEcalBarrelRecHitCreator") << "detid " << detid.rawId() << "not found in geometry";
+        }
+
+        out->emplace_back(thisCell.releaseToShared(), detid.rawId(), PFLayer::ECAL_BARREL, energy, flags);
       }
-
-      out->emplace_back(thisCell, detid.rawId(), PFLayer::ECAL_BARREL, energy, flags);
-
       auto& rh = out->back();
 
       bool rcleaned = false;

--- a/RecoParticleFlow/PFClusterProducer/interface/PFEcalEndcapRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFEcalEndcapRecHitCreator.h
@@ -69,15 +69,16 @@ public:
 
       bool hi = (useSrF ? isHighInterest(detid) : true);
 
-      std::shared_ptr<const CaloCellGeometry> thisCell = ecalGeo->getGeometry(detid);
+      {
+        auto thisCell = ecalGeo->getGeometry(detid);
 
-      // find rechit geometry
-      if (!thisCell) {
-        throw cms::Exception("PFEcalEndcapRecHitCreator") << "detid " << detid.rawId() << "not found in geometry";
+        // find rechit geometry
+        if (!thisCell) {
+          throw cms::Exception("PFEcalEndcapRecHitCreator") << "detid " << detid.rawId() << "not found in geometry";
+        }
+
+        out->emplace_back(thisCell.releaseToShared(), detid.rawId(), PFLayer::ECAL_ENDCAP, energy);
       }
-
-      out->emplace_back(thisCell, detid.rawId(), PFLayer::ECAL_ENDCAP, energy);
-
       auto& rh = out->back();
 
       bool rcleaned = false;

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHBHERecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHBHERecHitCreator.h
@@ -46,7 +46,7 @@ public:
       auto time = erh.time();
       auto depth = detid.depth();
 
-      std::shared_ptr<const CaloCellGeometry> thisCell = nullptr;
+      CaloCellGeometryMayOwnPtr thisCell;
       PFLayer::Layer layer = PFLayer::HCAL_BARREL1;
       switch (esd) {
         case HcalBarrel:
@@ -69,7 +69,7 @@ public:
         continue;
       }
 
-      reco::PFRecHit rh(thisCell, detid.rawId(), layer, energy);
+      reco::PFRecHit rh(thisCell.releaseToShared(), detid.rawId(), layer, energy);
       rh.setTime(time);  //Mike: This we will use later
       rh.setDepth(depth);
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHFRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHFRecHitCreator.h
@@ -60,10 +60,10 @@ public:
       auto energy = erh.energy();
       auto time = erh.time();
 
-      std::shared_ptr<const CaloCellGeometry> thisCell = hcalGeo->getGeometry(detid);
-      auto zp = dynamic_cast<IdealZPrism const*>(thisCell.get());
+      auto thisCellTemp = hcalGeo->getGeometry(detid);
+      auto zp = dynamic_cast<IdealZPrism const*>(thisCellTemp.get());
       assert(zp);
-      thisCell = zp->forPF();
+      auto thisCell = zp->forPF();
 
       // find rechit geometry
       if (!thisCell) {

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHGCalRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHGCalRecHitCreator.h
@@ -71,7 +71,7 @@ public:
         continue;
       }
 
-      reco::PFRecHit rh(thisCell, detid.rawId(), Layer, energy);
+      reco::PFRecHit rh(thisCell.releaseToShared(), detid.rawId(), Layer, energy);
 
       bool rcleaned = false;
       bool keep = true;

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHcalRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHcalRecHitCreator.h
@@ -69,7 +69,7 @@ public:
         continue;
       }
 
-      reco::PFRecHit rh(thisCell, detid.rawId(), Layer, energy);
+      reco::PFRecHit rh(thisCell.releaseToShared(), detid.rawId(), Layer, energy);
       rh.setTime(time);  //Mike: This we will use later
       rh.setDepth(depth);
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFPSRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFPSRecHitCreator.h
@@ -70,7 +70,7 @@ public:
         continue;
       }
 
-      out->emplace_back(thisCell, detid.rawId(), layer, energy);
+      out->emplace_back(thisCell.releaseToShared(), detid.rawId(), layer, energy);
       auto& rh = out->back();
       rh.setDepth(detid.plane());
       rh.setTime(erh.time());

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFBadHcalPseudoClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFBadHcalPseudoClusterProducer.cc
@@ -131,9 +131,9 @@ void PFBadHcalPseudoClusterProducer::init(const EventSetup& iSetup) {
       continue;
     PFLayer::Layer layer = (barrel ? PFLayer::HCAL_BARREL1 : PFLayer::HCAL_ENDCAP);
     // make a PF RecHit
-    std::shared_ptr<const CaloCellGeometry> thisCell = (barrel ? hbGeom : heGeom)->getGeometry(id);
+    auto thisCell = (barrel ? hbGeom : heGeom)->getGeometry(id);
     const GlobalPoint& pos = thisCell->getPosition();
-    badAreasRH_.emplace_back(thisCell, id(), layer, dummyEnergy);
+    badAreasRH_.emplace_back(thisCell.releaseToShared(), id(), layer, dummyEnergy);
     // make a PF cluster (but can't add the rechit, as for that I need an edm::Ref)
     badAreasC_.emplace_back(layer, dummyEnergy, pos.x(), pos.y(), pos.z());
     badAreasC_.back().setFlags(reco::CaloCluster::badHcalMarker);

--- a/RecoParticleFlow/PFRecHitProducer/plugins/LegacyPFRecHitProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/LegacyPFRecHitProducer.cc
@@ -58,11 +58,11 @@ void LegacyPFRecHitProducer::produce(edm::Event& event, const edm::EventSetup& s
   if (alpakaPfRecHits.metadata().size() != 0) {
     out.reserve(alpakaPfRecHits.size());
     for (size_t i = 0; i < alpakaPfRecHits.size(); i++) {
-      reco::PFRecHit& pfrh =
-          out.emplace_back(caloGeo_.at(alpakaPfRecHits[i].layer())->getGeometry(alpakaPfRecHits[i].detId()),
-                           alpakaPfRecHits[i].detId(),
-                           alpakaPfRecHits[i].layer(),
-                           alpakaPfRecHits[i].energy());
+      reco::PFRecHit& pfrh = out.emplace_back(
+          caloGeo_.at(alpakaPfRecHits[i].layer())->getGeometry(alpakaPfRecHits[i].detId()).releaseToShared(),
+          alpakaPfRecHits[i].detId(),
+          alpakaPfRecHits[i].layer(),
+          alpakaPfRecHits[i].energy());
       pfrh.setTime(alpakaPfRecHits[i].time());
       pfrh.setDepth(alpakaPfRecHits[i].depth());
 


### PR DESCRIPTION
#### PR description:

- Created CaloCellGeometry*Ptr classes for controlling access to cells held or created by Calo geometry classes
- PFRecHit still holds a std::shared_ptr as ROOT requires the class to have a working copy constructor.
- Fixed possible out of bounds reads on containers where index is identical to the size of the container.

This was based on the issue #46433

#### PR validation:
Code compiles. New unit test passes.