### PR TITLE
Improve ScoutingNano integration with autoNano

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_nano.py
+++ b/Configuration/PyReleaseValidation/python/relval_nano.py
@@ -200,6 +200,9 @@ steps['jmeNANO_rePuppi_mc14.0'] = merge([{'-s': 'NANO:@JMErePuppi ', '-n': '1000
 steps['scoutingNANO_mc14.0'] = merge([{'-s': 'NANO:@Scout'},
                                       steps['NANO_mc14.0']])
 
+steps['scoutingNANO_withPrompt_mc14.0'] = merge([{'-s': 'NANO:@Prompt+@Scout'},
+                                                 steps['NANO_mc14.0']])
+
 # 14.0 workflows -- data
 lumis_Run2024D = {380306: [[28, 273]]}
 steps['MuonEG2024MINIAOD14.0'] = {'INPUT': InputInfo(location='STD', ls=lumis_Run2024D,
@@ -207,6 +210,9 @@ steps['MuonEG2024MINIAOD14.0'] = {'INPUT': InputInfo(location='STD', ls=lumis_Ru
 
 steps['ScoutingPFRun32024RAW14.0'] = {'INPUT': InputInfo(location='STD', ls=lumis_Run2024D,
                                                          dataSet='/ScoutingPFRun3/Run2024D-v1/HLTSCOUT')}
+
+steps['ScoutingPFMonitor2024MINIAOD14.0'] = {'INPUT': InputInfo(location='STD', ls=lumis_Run2024D,
+                                                                dataSet='/ScoutingPFMonitor/Run2024D-PromptReco-v1/MINIAOD')}
 
 steps['ZMuSkim2024RAWRECO14.0'] = {'INPUT': InputInfo(location='STD', ls=lumis_Run2024D,
                                                       dataSet='/Muon0/Run2024D-ZMu-PromptReco-v1/RAW-RECO')}
@@ -243,6 +249,9 @@ steps['jmeNANO_rePuppi_data14.0'] = merge([{'-s': 'NANO:@JMErePuppi', '-n': '100
 
 steps['scoutingNANO_data14.0'] = merge([{'-s': 'NANO:@Scout'},
                                         steps['NANO_data14.0']])
+
+steps['scoutingNANO_withPrompt_data14.0'] = merge([{'-s': 'NANO:@Prompt+@Scout', '--customise_commands': '"process.options.TryToContinue = cms.untracked.vstring(\'ProductNotFound\')"'},
+                                                   steps['NANO_data14.0']])
 
 # DPG custom NANO
 steps['muDPGNANO_data14.0'] = merge([{'-s': 'RAW2DIGI,NANO:@MUDPG', '-n': '100'},
@@ -336,6 +345,7 @@ workflows[_wfn()] = ['jmeNANOmc140X', ['TTbarMINIAOD14.0', 'jmeNANO_mc14.0']]
 workflows[_wfn()] = ['jmeNANOrePuppimc140X', ['TTbarMINIAOD14.0', 'jmeNANO_rePuppi_mc14.0']]
 workflows[_wfn()] = ['lepTrackInfoNANOmc140X', ['TTbarMINIAOD14.0', 'lepTrackInfoNANO_mc14.0']]
 workflows[_wfn()] = ['ScoutingNANOmc140X', ['TTbarMINIAOD14.0', 'scoutingNANO_mc14.0']]
+workflows[_wfn()] = ['ScoutingNANOwithPromptmc140X', ['TTbarMINIAOD14.0', 'scoutingNANO_withPrompt_mc14.0']]
 
 # POG/PAG custom NANOs, data
 _wfn.subnext()
@@ -346,6 +356,7 @@ workflows[_wfn()] = ['jmeNANOdata140Xrun3', ['MuonEG2024MINIAOD14.0', 'jmeNANO_d
 workflows[_wfn()] = ['jmeNANOrePuppidata140Xrun3', ['MuonEG2024MINIAOD14.0', 'jmeNANO_rePuppi_data14.0']]
 workflows[_wfn()] = ['lepTrackInfoNANOdata140Xrun3', ['MuonEG2024MINIAOD14.0', 'lepTrackInfoNANO_data14.0']]
 workflows[_wfn()] = ['ScoutingNANOdata140Xrun3', ['ScoutingPFRun32024RAW14.0', 'scoutingNANO_data14.0']]
+workflows[_wfn()] = ['ScoutingNANOwithPromptdata140Xrun3', ['ScoutingPFMonitor2024MINIAOD14.0', 'scoutingNANO_withPrompt_data14.0']]
 
 # DPG custom NANOs, data
 _wfn.subnext()

--- a/Configuration/PyReleaseValidation/python/relval_nano.py
+++ b/Configuration/PyReleaseValidation/python/relval_nano.py
@@ -250,7 +250,10 @@ steps['jmeNANO_rePuppi_data14.0'] = merge([{'-s': 'NANO:@JMErePuppi', '-n': '100
 steps['scoutingNANO_data14.0'] = merge([{'-s': 'NANO:@Scout'},
                                         steps['NANO_data14.0']])
 
-steps['scoutingNANO_withPrompt_data14.0'] = merge([{'-s': 'NANO:@Prompt+@Scout', '--customise_commands': '"process.options.TryToContinue = cms.untracked.vstring(\'ProductNotFound\')"'},
+# Process.options.TryToContinue = cms.untracked.vstring(\'ProductNotFound\') is needed here because some events in ScoutingPFMonitor in 2024 do not contain scouting objects.
+# This should be fixed in 2025 (https://its.cern.ch/jira/browse/CMSHLT-3331) so customise_commands won't be needed for 2025 workflow.
+steps['scoutingNANO_withPrompt_data14.0'] = merge([{'-s': 'NANO:@Prompt+@Scout', 
+                                                   '--customise_commands': '"process.options.TryToContinue = cms.untracked.vstring(\'ProductNotFound\')"'},
                                                    steps['NANO_data14.0']])
 
 # DPG custom NANO

--- a/PhysicsTools/NanoAOD/python/autoNANO.py
+++ b/PhysicsTools/NanoAOD/python/autoNANO.py
@@ -34,8 +34,8 @@ autoNANO = {
     # Scouting nano
     'Scout' : {'sequence': 'PhysicsTools/NanoAOD/custom_run3scouting_cff.scoutingNanoSequence',
                'customize': 'PhysicsTools/NanoAOD/custom_run3scouting_cff.customiseScoutingNano'},
-    'ScoutFromMini' : {'sequence': 'PhysicsTools/NanoAOD/custom_run3scouting_cff.scoutingNanoSequence',
-                       'customize': 'PhysicsTools/NanoAOD/custom_run3scouting_cff.customiseScoutingNanoFromMini'},
+    'ScoutFromMini' : {'sequence': '@Scout',
+                       'customize': '@Scout+PhysicsTools/NanoAOD/custom_run3scouting_cff.customiseScoutingNanoFromMini'},
     # JME nano
     'JME': {'sequence': '@PHYS',
             'customize': '@PHYS+PhysicsTools/NanoAOD/custom_jme_cff.PrepJMECustomNanoAOD'},

--- a/PhysicsTools/NanoAOD/python/autoNANO.py
+++ b/PhysicsTools/NanoAOD/python/autoNANO.py
@@ -31,8 +31,11 @@ autoNANO = {
     # L1 flavours: add tables through customize, supposed to be combined with PHYS
     'L1': {'customize': 'PhysicsTools/NanoAOD/l1trig_cff.nanoL1TrigObjCustomize'},
     'L1FULL': {'customize': 'PhysicsTools/NanoAOD/l1trig_cff.nanoL1TrigObjCustomizeFull'},
-    # scouting nano
-    'Scout': {'sequence': 'PhysicsTools/NanoAOD/custom_run3scouting_cff'},
+    # Scouting nano
+    'Scout' : {'sequence': 'PhysicsTools/NanoAOD/custom_run3scouting_cff.scoutingNanoSequence',
+               'customize': 'PhysicsTools/NanoAOD/custom_run3scouting_cff.customiseScoutingNano'},
+    'ScoutFromMini' : {'sequence': 'PhysicsTools/NanoAOD/custom_run3scouting_cff.scoutingNanoSequence',
+                       'customize': 'PhysicsTools/NanoAOD/custom_run3scouting_cff.customiseScoutingNanoFromMini'},
     # JME nano
     'JME': {'sequence': '@PHYS',
             'customize': '@PHYS+PhysicsTools/NanoAOD/custom_jme_cff.PrepJMECustomNanoAOD'},

--- a/PhysicsTools/NanoAOD/python/custom_run3scouting_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_run3scouting_cff.py
@@ -141,10 +141,15 @@ def customiseScoutingNano(process):
     
     return process
 
-def customiseScoutingNanoFromMini(process):
-    # normal customise for ScoutingNano
-    process = customiseScoutingNano(process)
+#####################
+### Customisation ###
+#####################
+# these function are designed to be used with --customise flag in cmsDriver.py
+# e.g. --customise PhysicsTools/NanoAOD/python/custom_run3scouting_cff.addScoutingPFCandidate
 
+# reconfigure for running with ScoutingPFMonitor/MiniAOD inputs alone
+# should be used with default customiseScoutingNano
+def customiseScoutingNanoFromMini(process):
     # remove L1TRawToDigi
     process.scoutingTriggerSequence.remove(process.L1TRawToDigi)
 
@@ -162,12 +167,6 @@ def customiseScoutingNanoFromMini(process):
     process.l1EtSumScoutingTable.src = cms.InputTag("caloStage2Digis", "EtSum")
 
     return process
-
-#####################
-### Customisation ###
-#####################
-# these function are designed to be used with --customise flag in cmsDriver.py
-# e.g. --customise PhysicsTools/NanoAOD/python/custom_run3scouting_cff.addScoutingPFCandidate
 
 def addScoutingTrack(process):
     process.scoutingNanoSequence.associate(cms.Task(scoutingTrackTable))

--- a/PhysicsTools/NanoAOD/python/custom_run3scouting_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_run3scouting_cff.py
@@ -1,62 +1,184 @@
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.NanoAOD.run3scouting_cff import *
-from PhysicsTools.NanoAOD.globals_cff import puTable
-from PhysicsTools.NanoAOD.triggerObjects_cff import unpackedPatTrigger, triggerObjectTable, l1bits
 from L1Trigger.Configuration.L1TRawToDigi_cff import *
 from EventFilter.L1TRawToDigi.gtStage2Digis_cfi import gtStage2Digis
-from PhysicsTools.PatAlgos.triggerLayer1.triggerProducer_cfi import patTrigger
-from PhysicsTools.PatAlgos.slimming.selectedPatTrigger_cfi import selectedPatTrigger
-from PhysicsTools.PatAlgos.slimming.slimmedPatTrigger_cfi import slimmedPatTrigger
+from PhysicsTools.NanoAOD.triggerObjects_cff import l1bits
+from PhysicsTools.NanoAOD.globals_cff import puTable
 
-# common tasks
-particleTask = cms.Task(scoutingPFCands)
-ak4JetTableTask = cms.Task(ak4ScoutingJets,ak4ScoutingJetParticleNetJetTagInfos,ak4ScoutingJetParticleNetJetTags,ak4ScoutingJetTable)
-ak8JetTableTask = cms.Task(ak8ScoutingJets,ak8ScoutingJetsSoftDrop,ak8ScoutingJetsSoftDropMass,ak8ScoutingJetEcfNbeta1,ak8ScoutingJetNjettiness,ak8ScoutingJetParticleNetJetTagInfos,ak8ScoutingJetParticleNetJetTags,ak8ScoutingJetParticleNetMassRegressionJetTags,ak8ScoutingJetTable)
+############################
+### Sub Task Definitions ###
+############################
 
-muonScoutingTableTask = cms.Task(muonScoutingTable)
-displacedvertexScoutingTableTask = cms.Task(displacedvertexScoutingTable)
+# Task contains all dependent tasks
+# ExtensionTask must be run on top of another Task
 
-# from 2024, there are two scouting muon collections
+#############################
+# Scouting Original Objects #
+#############################
+
+# Scouting Muon
+scoutingMuonTableTask = cms.Task(scoutingMuonTable)
+scoutingMuonDisplacedVertexTableTask = cms.Task(scoutingMuonDisplacedVertexTable)
+
+# from 2024, there are two muon collections
 from Configuration.Eras.Modifier_run3_scouting_nanoAOD_post2023_cff import run3_scouting_nanoAOD_post2023
-run3_scouting_nanoAOD_post2023.toReplaceWith(muonScoutingTableTask, cms.Task(muonVtxScoutingTable, muonNoVtxScoutingTable))\
-    .toReplaceWith(displacedvertexScoutingTableTask, cms.Task(displacedvertexVtxScoutingTable, displacedvertexNoVtxScoutingTable))
+run3_scouting_nanoAOD_post2023.toReplaceWith(scoutingMuonTableTask, cms.Task(scoutingMuonVtxTable, scoutingMuonNoVtxTable))\
+    .toReplaceWith(scoutingMuonDisplacedVertexTableTask, cms.Task(scoutingMuonVtxDisplacedVertexTable, scoutingMuonNoVtxDisplacedVertexTable))
+
+# other collections are directly from original Run3Scouting objects, so unnessary to define tasks
+
+############################
+# Scouting Derived Objects #
+############################
+
+scoutingPFCandidateTask = cms.Task(scoutingPFCandidate, scoutingPFCandidateTable)
+scoutingPFJetReclusterTask = cms.Task(
+    scoutingPFCandidate, # translate to reco::PFCandidate, used as input
+    scoutingPFJetRecluster, # jet clustering
+    scoutingPFJetReclusterParticleNetJetTagInfos, scoutingPFJetReclusterParticleNetJetTags, # jet tagging
+    scoutingPFJetReclusterTable
+)
+scoutingPFJetReclusterMatchGenExtensionTask = cms.Task(
+    scoutingPFJetReclusterMatchGen, # gen jet matching
+    scoutingPFJetReclusterMatchGenExtensionTable
+)
+
+scoutingFatPFJetReclusterTask = cms.Task(
+    scoutingPFCandidate, # translate to reco::PFCandidate, used as input
+    scoutingFatPFJetRecluster, # jet clustering
+    scoutingFatPFJetReclusterParticleNetJetTagInfos, scoutingFatPFJetReclusterParticleNetJetTags, # jet tagging
+    scoutingFatPFJetReclusterSoftDrop, scoutingFatPFJetReclusterSoftDropMass, # softdrop mass
+    scoutingFatPFJetReclusterParticleNetJetTagInfos, scoutingFatPFJetReclusterParticleNetMassRegressionJetTags, # regressed mass
+    scoutingFatPFJetReclusterEcfNbeta1, scoutingFatPFJetReclusterNjettiness, # substructure variables
+    scoutingFatPFJetReclusterTable
+)
+scoutingFatPFJetReclusterMatchGenExtensionTask = cms.Task(
+    scoutingFatPFJetReclusterMatchGen, # gen jet matching
+    scoutingFatPFJetReclusterMatchGenExtensionTable
+)
+
+############################
+# Trigger Bits and Objects #
+############################
 
 ## L1 decisions
 gtStage2DigisScouting = gtStage2Digis.clone(InputLabel="hltFEDSelectorL1")
-l1bitsScouting = l1bits.clone(src="gtStage2DigisScouting")
+l1bitsScouting = l1bits.clone(src="gtStage2DigisScouting") 
 
 ## L1 objects
 from PhysicsTools.NanoAOD.l1trig_cff import *
-l1MuScoutingTable = l1MuTable.clone(src=cms.InputTag("gtStage2DigisScouting","Muon"))
-l1JetScoutingTable = l1JetTable.clone(src=cms.InputTag("gtStage2DigisScouting","Jet"))
-l1EGScoutingTable = l1EGTable.clone(src=cms.InputTag("gtStage2DigisScouting","EGamma"))
-l1TauScoutingTable = l1TauTable.clone(src=cms.InputTag("gtStage2DigisScouting","Tau"))
-l1EtSumScoutingTable = l1EtSumTable.clone(src=cms.InputTag("gtStage2DigisScouting","EtSum"))
+l1MuScoutingTable = l1MuTable.clone(src=cms.InputTag("gtStage2DigisScouting", "Muon"))
+l1EGScoutingTable = l1EGTable.clone(src=cms.InputTag("gtStage2DigisScouting", "EGamma"))
+l1TauScoutingTable = l1TauTable.clone(src=cms.InputTag("gtStage2DigisScouting", "Tau"))
+l1JetScoutingTable = l1JetTable.clone(src=cms.InputTag("gtStage2DigisScouting", "Jet"))
+l1EtSumScoutingTable = l1EtSumTable.clone(src=cms.InputTag("gtStage2DigisScouting", "EtSum"))
 
-#reduce the variables to the core variables as only these are available in gtStage2Digis
-l1EGScoutingTable.variables = cms.PSet(l1EGReducedVars)
+# reduce the variables to the core variables as only these are available in gtStage2Digis
 l1MuScoutingTable.variables = cms.PSet(l1MuonReducedVars)
-l1JetScoutingTable.variables = cms.PSet(l1JetReducedVars)
+l1EGScoutingTable.variables = cms.PSet(l1EGReducedVars)
 l1TauScoutingTable.variables = cms.PSet(l1TauReducedVars)
+l1JetScoutingTable.variables = cms.PSet(l1JetReducedVars)
 l1EtSumScoutingTable.variables = cms.PSet(l1EtSumReducedVars)
 
-triggerTask = cms.Task(
-    gtStage2DigisScouting, l1bitsScouting,
-    l1MuScoutingTable, l1EGScoutingTable, l1TauScoutingTable, l1JetScoutingTable, l1EtSumScoutingTable, 
-)
-triggerSequence = cms.Sequence(L1TRawToDigi+cms.Sequence(triggerTask))
+##############################
+### Main Tasks Definitions ###
+##############################
 
-# MC tasks
-genJetTask = cms.Task(ak4ScoutingJetMatchGen,ak4ScoutingJetExtTable,ak8ScoutingJetMatchGen,ak8ScoutingJetExtTable)
-puTask = cms.Task(puTable)
+# default configuration for ScoutingNano common for both data and MC
+def prepareScoutingNanoTaskCommon():
+    # Scouting original objects
+    # all scouting objects are saved except PF Candidate and Track
+    scoutingNanoTaskCommon = cms.Task()
+    scoutingNanoTaskCommon.add(scoutingMuonTableTask, scoutingMuonDisplacedVertexTableTask)
+    scoutingNanoTaskCommon.add(scoutingElectronTable)
+    scoutingNanoTaskCommon.add(scoutingPhotonTable)
+    scoutingNanoTaskCommon.add(scoutingPrimaryVertexTable)
+    scoutingNanoTaskCommon.add(scoutingPFJetTable)
+    scoutingNanoTaskCommon.add(scoutingMETTable, scoutingRhoTable)
+    
+    # Scouting derived objects
+    scoutingNanoTaskCommon.add(scoutingPFJetReclusterTask)
+    scoutingNanoTaskCommon.add(scoutingFatPFJetReclusterTask)
 
-nanoTableTaskCommon = cms.Task(photonScoutingTable,muonScoutingTableTask,electronScoutingTable,primaryvertexScoutingTable,displacedvertexScoutingTableTask,jetScoutingTable,rhoScoutingTable,metScoutingTable,particleTask,ak4JetTableTask,ak8JetTableTask)
+    return scoutingNanoTaskCommon
 
-nanoSequenceCommon = cms.Sequence(triggerSequence,nanoTableTaskCommon)
+# tasks related to trigger bits and objects
+def prepareScoutingTriggerTask():
+    scoutingTriggerTask = cms.Task(gtStage2DigisScouting, l1bitsScouting)
+    scoutingTriggerTask.add(cms.Task(l1MuScoutingTable, l1EGScoutingTable, l1TauScoutingTable, l1JetScoutingTable, l1EtSumScoutingTable))
+    return scoutingTriggerTask
 
-nanoSequence = cms.Sequence(nanoSequenceCommon)
+# additional tasks for running on MC
+def prepareScoutingNanoTaskMC():
+    scoutingNanoTaskMC = cms.Task()
+    scoutingNanoTaskMC.add(scoutingPFJetReclusterMatchGenExtensionTask)
+    scoutingNanoTaskMC.add(scoutingFatPFJetReclusterMatchGenExtensionTask)
 
-nanoSequenceMC = cms.Sequence(nanoSequenceCommon + cms.Sequence(cms.Task(genJetTask,puTask)))
+    scoutingNanoTaskMC.add(puTable)
+    return scoutingNanoTaskMC
 
-def nanoAOD_customizeCommon(process):
+# Common tasks added to main scoutingNanoSequence
+scoutingNanoTaskCommon = prepareScoutingNanoTaskCommon()
+scoutingNanoSequence = cms.Sequence(scoutingNanoTaskCommon)
+
+# Specific tasks which will be added to sequence during customization
+scoutingTriggerTask = prepareScoutingTriggerTask()
+scoutingTriggerSequence = cms.Sequence(L1TRawToDigi+cms.Sequence(scoutingTriggerTask))
+scoutingNanoTaskMC = prepareScoutingNanoTaskMC()
+
+def customiseScoutingNano(process):
+    # if running with standard NanoAOD, triggerSequence is already added
+    # if running standalone, triggerSequence need to be added
+    if not ((hasattr(process, "nanoSequence") and process.schedule.contains(process.nanoSequence))
+            or hasattr(process, "nanoSequenceMC") and process.schedule.contains(process.nanoSequenceMC)):
+        process.trigger_step = cms.Path(process.scoutingTriggerSequence)
+        process.schedule.extend([process.trigger_step])
+
+    # specific tasks when running on MC
+    runOnMC = hasattr(process,"NANOEDMAODSIMoutput") or hasattr(process,"NANOAODSIMoutput")
+    if runOnMC:
+        process.scoutingNanoSequence.associate(scoutingNanoTaskMC)
+    
+    return process
+
+def customiseScoutingNanoFromMini(process):
+    # normal customise for ScoutingNano
+    process = customiseScoutingNano(process)
+
+    # remove L1TRawToDigi
+    process.scoutingTriggerSequence.remove(process.L1TRawToDigi)
+
+    # remove gtStage2Digis since they are already run for Mini
+    process.scoutingTriggerTask.remove(process.gtStage2DigisScouting)
+
+    # change src for l1 bits
+    process.l1bitsScouting.src = cms.InputTag("gtStage2Digis")
+
+    # change src for l1 objects
+    process.l1MuScoutingTable.src = cms.InputTag("gmtStage2Digis", "Muon")
+    process.l1EGScoutingTable.src = cms.InputTag("caloStage2Digis", "EGamma")
+    process.l1TauScoutingTable.src = cms.InputTag("caloStage2Digis", "Tau")
+    process.l1JetScoutingTable.src = cms.InputTag("caloStage2Digis", "Jet")
+    process.l1EtSumScoutingTable.src = cms.InputTag("caloStage2Digis", "EtSum")
+
+    return process
+
+#####################
+### Customisation ###
+#####################
+# these function are designed to be used with --customise flag in cmsDriver.py
+# e.g. --customise PhysicsTools/NanoAOD/python/custom_run3scouting_cff.addScoutingPFCandidate
+
+def addScoutingTrack(process):
+    process.scoutingNanoSequence.associate(cms.Task(scoutingTrackTable))
+    return process
+
+def addScoutingParticle(process):
+    # original PF candidate without post-processing
+    process.scoutingNanoSequence.associate(cms.Task(scoutingParticleTable))
+    return process
+
+def addScoutingPFCandidate(process):
+    # PF candidate after translation to reco::PFCandidate
+    process.scoutingNanoSequence.associate(scoutingPFCandidateTask)
     return process

--- a/PhysicsTools/NanoAOD/python/run3scouting_cff.py
+++ b/PhysicsTools/NanoAOD/python/run3scouting_cff.py
@@ -2,217 +2,296 @@ import FWCore.ParameterSet.Config as cms
 from  PhysicsTools.NanoAOD.common_cff import *
 from PhysicsTools.NanoAOD.simpleCandidateFlatTableProducer_cfi import simpleCandidateFlatTableProducer
 
-################
-# Scouting photons, electrons, muons, tracks, primary vertices, displaced vertices, jets (clustered at HLT), rho and MET
+#####################################
+##### Scouting Original Objects #####
+#####################################
+# objects directly from Run3Scouting* formats
 
-photonScoutingTable = cms.EDProducer("SimpleRun3ScoutingPhotonFlatTableProducer",
-     src = cms.InputTag("hltScoutingEgammaPacker"),
-     cut = cms.string(""),
-     name = cms.string("ScoutingPhoton"),
-     doc  = cms.string("Photon scouting information"),
-     singleton = cms.bool(False),
-     extension = cms.bool(False),
-     variables = cms.PSet(
-         pt = Var('pt', 'float', precision=10, doc='super-cluster (SC) pt'),
-         eta = Var('eta', 'float', precision=10, doc='SC eta'),
-         phi = Var('phi', 'float', precision=10, doc='SC phi'),
-         m = Var('m', 'float', precision=10, doc='SC mass'),
-         sigmaIetaIeta = Var('sigmaIetaIeta', 'float', precision=10, doc='sigmaIetaIeta of the SC, calculated with full 5x5 region, noise cleaned'),
-         hOverE = Var('hOverE', 'float', precision=10, doc='Energy in HCAL / Energy in ECAL'),
-         ecalIso = Var('ecalIso', 'float', precision=10, doc='Isolation of SC in the ECAL'),
-         hcalIso = Var('hcalIso', 'float', precision=10, doc='Isolation of SC in the HCAL'),
-         r9 = Var('r9', 'float', precision=10, doc='Photon SC r9 as defined in https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideEgammaShowerShape'),
-         sMin = Var('sMin', 'float', precision=10, doc='minor moment of the SC shower shape'),
-         sMaj = Var('sMaj', 'float', precision=10, doc='major moment of the SC shower shape'),
-         seedId = Var('seedId', 'int', doc='ECAL ID of the SC seed'),
-     )
+# Scouting Muon
+# https://github.com/cms-sw/cmssw/blob/CMSSW_14_0_X/DataFormats/Scouting/interface/Run3ScoutingMuon.h
+
+scoutingMuonTable = cms.EDProducer("SimpleRun3ScoutingMuonFlatTableProducer",
+    src = cms.InputTag("hltScoutingMuonPacker"),
+    cut = cms.string(""),
+    name = cms.string("ScoutingMuon"),
+    doc  = cms.string("Scouting Muon"),
+    singleton = cms.bool(False),
+    extension = cms.bool(False),
+    variables = cms.PSet(
+        pt = Var('pt', 'float', precision=10, doc='pt'),
+        eta = Var('eta', 'float', precision=10, doc='eta'),
+        phi = Var('phi', 'float', precision=10, doc='phi'),
+        m = Var('m', 'float', precision=10, doc='mass'),
+        type = Var('type', 'int', doc='type of muon'),
+        charge = Var('charge', 'int', doc='track charge'),
+        normchi2 = Var('normalizedChi2', 'float', precision=10, doc='normalized chi squared'),
+        ecalIso = Var('ecalIso', 'float', precision=10, doc='PF ECAL isolation'),
+        hcalIso = Var('hcalIso', 'float', precision=10, doc='PF HCAL isolation'),
+        trackIso = Var('trackIso', 'float', precision=10, doc='track isolation'),
+        nValidStandAloneMuonHits = Var('nValidStandAloneMuonHits', 'int', doc='number of valid standalone muon hits'),
+        nStandAloneMuonMatchedStations = Var('nStandAloneMuonMatchedStations', 'int', doc='number of muon stations with valid hits'),
+        nValidRecoMuonHits = Var('nValidRecoMuonHits', 'int', doc='number of valid reco muon hits'),
+        nRecoMuonChambers = Var('nRecoMuonChambers', 'int', doc='number of reco muon chambers'),
+        nRecoMuonChambersCSCorDT = Var('nRecoMuonChambersCSCorDT', 'int', doc='number of reco muon chambers CSC or DT'),
+        nRecoMuonMatches = Var('nRecoMuonMatches', 'int', doc='number of reco muon matches'),
+        nRecoMuonMatchedStations = Var('nRecoMuonMatchedStations', 'int', doc='number of reco muon matched stations'),
+        nRecoMuonExpectedMatchedStations = Var('nRecoMuonExpectedMatchedStations', 'int', doc='number of reco muon expected matched stations'),
+        recoMuonStationMask = Var('recoMuonStationMask', 'int', doc='reco muon station mask'),
+        nRecoMuonMatchedRPCLayers = Var('nRecoMuonMatchedRPCLayers', 'int', doc='number of reco muon matched RPC layers'),
+        recoMuonRPClayerMask = Var('recoMuonRPClayerMask', 'int', doc='reco muon RPC layer mask'),
+        nValidPixelHits = Var('nValidPixelHits', 'int', doc='number of valid pixel hits'),
+        nValidStripHits = Var('nValidStripHits', 'int', doc='number of valid strip hits'),
+        nPixelLayersWithMeasurement = Var('nPixelLayersWithMeasurement', 'int', doc='number of pixel layers with measurement'),
+        nTrackerLayersWithMeasurement = Var('nTrackerLayersWithMeasurement', 'int', doc='number of tracker layer with measurements'),
+        trk_chi2 = Var('trk_chi2', 'float', precision=10, doc='track chi squared'),
+        trk_ndof = Var('trk_ndof', 'float', precision=10, doc='track number of degrees of freedom'),
+        trk_dxy = Var('trk_dxy', 'float', precision=10, doc='track dxy'),
+        trk_dz = Var('trk_dz', 'float', precision=10, doc='track dz'),
+        trk_qoverp = Var('trk_qoverp', 'float', precision=10, doc='track qoverp'),
+        trk_lambda = Var('trk_lambda', 'float', precision=10, doc='track lambda'),
+        trk_pt = Var('trk_pt', 'float', precision=10, doc='track pt'),
+        trk_phi = Var('trk_phi', 'float', precision=10, doc='track phi'),
+        trk_eta = Var('trk_eta', 'float', precision=10, doc='track eta'),
+        trk_dxyError = Var('trk_dxyError', 'float', precision=10, doc='track dxyError'),
+        trk_dzError = Var('trk_dzError', 'float', precision=10, doc='tracl dzError'),
+        trk_qoverpError = Var('trk_qoverpError', 'float', precision=10, doc='track qoverpError'),
+        trk_lambdaError = Var('trk_lambdaError', 'float', precision=10, doc='track lambdaError'),
+        trk_phiError = Var('trk_phiError', 'float', precision=10, doc='track phiError'),
+        trk_dsz = Var('trk_dsz', 'float', precision=10, doc='track dsz'),
+        trk_dszError = Var('trk_dszError', 'float', precision=10, doc='track dszError'),
+        trk_qoverp_lambda_cov = Var('trk_qoverp_lambda_cov', 'float', precision=10, doc='track qoverp lambda covariance ((0,1) element of covariance matrix)'),
+        trk_qoverp_phi_cov = Var('trk_qoverp_phi_cov', 'float', precision=10, doc='track qoverp phi covariance ((0,2) element of covariance matrix)'),
+        trk_qoverp_dxy_cov = Var('trk_qoverp_dxy_cov', 'float', precision=10, doc='track qoverp dxy covariance ((0,3) element of covariance matrix)'),
+        trk_qoverp_dsz_cov = Var('trk_qoverp_dsz_cov', 'float', precision=10, doc='track qoverp dsz covariance ((0,4) element of covariance matrix)'),
+        trk_lambda_phi_cov = Var('trk_lambda_phi_cov', 'float', precision=10, doc='track lambda phi covariance ((1,2) element of covariance matrix)'),
+        trk_lambda_dxy_cov = Var('trk_lambda_dxy_cov', 'float', precision=10, doc='track lambda dxy covariance ((1,3) element of covariance matrix)'),
+        trk_lambda_dsz_cov = Var('trk_lambda_dsz_cov', 'float', precision=10, doc='track lambda dsz covariance ((1,4) element of covariance matrix)'),
+        trk_phi_dxy_cov = Var('trk_phi_dxy_cov', 'float', precision=10, doc='track phi dxy covariance ((2,3) element of covariance matrix)'),
+        trk_phi_dsz_cov = Var('trk_phi_dsz_cov', 'float', precision=10, doc='track phi dsz covariance ((2,4) element of covariance matrix)'),
+        trk_dxy_dsz_cov = Var('trk_dxy_dsz_cov', 'float', precision=10, doc='track dxy dsz covariance ((3,4) element of covariance matrix)'),
+        trk_vx = Var('trk_vx', 'float', precision=10, doc='track vx'),
+        trk_vy = Var('trk_vy', 'float', precision=10, doc='track vy'),
+        trk_vz = Var('trk_vz', 'float', precision=10, doc='track vz'),
+    ),
 )
 
-electronScoutingTable = cms.EDProducer("SimpleRun3ScoutingElectronFlatTableProducer",
-     src = cms.InputTag("hltScoutingEgammaPacker"),
-     cut = cms.string(""),
-     name = cms.string("ScoutingElectron"),
-     doc  = cms.string("Electron scouting information"),
-     singleton = cms.bool(False),
-     extension = cms.bool(False),
-     variables = cms.PSet(
-         pt = Var('pt', 'float', precision=10, doc='super-cluster (SC) pt'),
-         eta = Var('eta', 'float', precision=10, doc='SC eta'),
-         phi = Var('phi', 'float', precision=10, doc='SC phi'),
-         m = Var('m', 'float', precision=10, doc='SC mass'),
-         dEtaIn = Var('dEtaIn', 'float', precision=10, doc='#Delta#eta(SC seed, track pixel seed)'),
-         dPhiIn = Var('dPhiIn', 'float', precision=10, doc='#Delta#phi(SC seed, track pixel seed)'),
-         sigmaIetaIeta = Var('sigmaIetaIeta', 'float', precision=10, doc='sigmaIetaIeta of the SC, calculated with full 5x5 region, noise cleaned'),
-         hOverE = Var('hOverE', 'float', precision=10, doc='Energy in HCAL / Energy in ECAL'),
-         ooEMOop = Var('ooEMOop', 'float', precision=10, doc='1/E(SC) - 1/p(track momentum)'),
-         missingHits = Var('missingHits', 'int', doc='missing hits in the tracker'),
-         ecalIso = Var('ecalIso', 'float', precision=10, doc='Isolation of SC in the ECAL'),
-         hcalIso = Var('hcalIso', 'float', precision=10, doc='Isolation of SC in the HCAL'),
-         trackIso = Var('trackIso', 'float', precision=10, doc='Isolation of electron track in the tracker'),
-         r9 = Var('r9', 'float', precision=10, doc='ELectron SC r9 as defined in https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideEgammaShowerShape'),
-         sMin = Var('sMin', 'float', precision=10, doc='minor moment of the SC shower shape'),
-         sMaj = Var('sMaj', 'float', precision=10, doc='major moment of the SC shower shape'),
-         seedId = Var('seedId', 'int', doc='ECAL ID of the SC seed'),
-     )
+# Scouting Displaced Vertex (Muon)
+# https://github.com/cms-sw/cmssw/blob/CMSSW_14_0_X/DataFormats/Scouting/interface/Run3ScoutingVertex.h
+
+scoutingMuonDisplacedVertexTable = cms.EDProducer("SimpleRun3ScoutingVertexFlatTableProducer",
+    src = cms.InputTag("hltScoutingMuonPacker","displacedVtx"),
+    cut = cms.string(""),
+    name = cms.string("ScoutingMuonDisplacedVertex"),
+    doc  = cms.string("Scouting Muon Displaced Vertex"),
+    singleton = cms.bool(False),
+    extension = cms.bool(False),
+    variables = cms.PSet(
+        x = Var('x', 'float', precision=10, doc='position x coordinate'),
+        y = Var('y', 'float', precision=10, doc='position y coordinate'),
+        z = Var('z', 'float', precision=10, doc='position z coordinate'),
+        xError = Var('xError', 'float', precision=10, doc='x error'),
+        yError = Var('yError', 'float', precision=10, doc='y error'),
+        zError = Var('zError', 'float', precision=10, doc='z error'),
+        tracksSize = Var('tracksSize', 'int', doc='number of tracks'),
+        chi2 = Var('chi2', 'float', precision=10, doc='chi squared'),
+        ndof = Var('ndof', 'int', doc='number of degrees of freedom'),
+        isValidVtx = Var('isValidVtx', 'bool', doc='is valid'),
+    ),
 )
 
-muonScoutingTable = cms.EDProducer("SimpleRun3ScoutingMuonFlatTableProducer",
-     src = cms.InputTag("hltScoutingMuonPacker"),
-     cut = cms.string(""),
-     name = cms.string("ScoutingMuon"),
-     doc  = cms.string("Muon scouting information"),
-     singleton = cms.bool(False),
-     extension = cms.bool(False),
-     variables = cms.PSet(
-         pt = Var('pt', 'float', precision=10, doc='pt'),
-         eta = Var('eta', 'float', precision=10, doc='eta'),
-         phi = Var('phi', 'float', precision=10, doc='phi'),
-         m = Var('m', 'float', precision=10, doc='mass'),
-         type = Var('type', 'int', doc='type of muon'),
-         charge = Var('charge', 'int', doc='track charge'),
-         normchi2 = Var('normalizedChi2', 'float', precision=10, doc='normalized chi squared'),
-         ecalIso = Var('ecalIso', 'float', precision=10, doc='PF ECAL isolation'),
-         hcalIso = Var('hcalIso', 'float', precision=10, doc='PF HCAL isolation'),
-         trackIso = Var('trackIso', 'float', precision=10, doc='track isolation'),
-         nValidStandAloneMuonHits = Var('nValidStandAloneMuonHits', 'int', doc='number of valid standalone muon hits'),
-         nStandAloneMuonMatchedStations = Var('nStandAloneMuonMatchedStations', 'int', doc='number of muon stations with valid hits'),
-         nValidRecoMuonHits = Var('nValidRecoMuonHits', 'int', doc='number of valid reco muon hits'),
-         nRecoMuonChambers = Var('nRecoMuonChambers', 'int', doc='number of reco muon chambers'),
-         nRecoMuonChambersCSCorDT = Var('nRecoMuonChambersCSCorDT', 'int', doc='number of reco muon chambers CSC or DT'),
-         nRecoMuonMatches = Var('nRecoMuonMatches', 'int', doc='number of reco muon matches'),
-         nRecoMuonMatchedStations = Var('nRecoMuonMatchedStations', 'int', doc='number of reco muon matched stations'),
-         nRecoMuonExpectedMatchedStations = Var('nRecoMuonExpectedMatchedStations', 'int', doc='number of reco muon expected matched stations'),
-         recoMuonStationMask = Var('recoMuonStationMask', 'int', doc='reco muon station mask'),
-         nRecoMuonMatchedRPCLayers = Var('nRecoMuonMatchedRPCLayers', 'int', doc='number of reco muon matched RPC layers'),
-         recoMuonRPClayerMask = Var('recoMuonRPClayerMask', 'int', doc='reco muon RPC layer mask'),
-         nValidPixelHits = Var('nValidPixelHits', 'int', doc='number of valid pixel hits'),
-         nValidStripHits = Var('nValidStripHits', 'int', doc='number of valid strip hits'),
-         nPixelLayersWithMeasurement = Var('nPixelLayersWithMeasurement', 'int', doc='number of pixel layers with measurement'),
-         nTrackerLayersWithMeasurement = Var('nTrackerLayersWithMeasurement', 'int', doc='number of tracker layer with measurements'),
-         trk_chi2 = Var('trk_chi2', 'float', precision=10, doc='track chi squared'),
-         trk_ndof = Var('trk_ndof', 'float', precision=10, doc='track number of degrees of freedom'),
-         trk_dxy = Var('trk_dxy', 'float', precision=10, doc='track dxy'),
-         trk_dz = Var('trk_dz', 'float', precision=10, doc='track dz'),
-         trk_qoverp = Var('trk_qoverp', 'float', precision=10, doc='track qoverp'),
-         trk_lambda = Var('trk_lambda', 'float', precision=10, doc='track lambda'),
-         trk_pt = Var('trk_pt', 'float', precision=10, doc='track pt'),
-         trk_phi = Var('trk_phi', 'float', precision=10, doc='track phi'),
-         trk_eta = Var('trk_eta', 'float', precision=10, doc='track eta'),
-         trk_dxyError = Var('trk_dxyError', 'float', precision=10, doc='track dxyError'),
-         trk_dzError = Var('trk_dzError', 'float', precision=10, doc='tracl dzError'),
-         trk_qoverpError = Var('trk_qoverpError', 'float', precision=10, doc='track qoverpError'),
-         trk_lambdaError = Var('trk_lambdaError', 'float', precision=10, doc='track lambdaError'),
-         trk_phiError = Var('trk_phiError', 'float', precision=10, doc='track phiError'),
-         trk_dsz = Var('trk_dsz', 'float', precision=10, doc='track dsz'),
-         trk_dszError = Var('trk_dszError', 'float', precision=10, doc='track dszError'),
-         trk_qoverp_lambda_cov = Var('trk_qoverp_lambda_cov', 'float', precision=10, doc='track qoverp lambda covariance ((0,1) element of covariance matrix)'),
-         trk_qoverp_phi_cov = Var('trk_qoverp_phi_cov', 'float', precision=10, doc='track qoverp phi covariance ((0,2) element of covariance matrix)'),
-         trk_qoverp_dxy_cov = Var('trk_qoverp_dxy_cov', 'float', precision=10, doc='track qoverp dxy covariance ((0,3) element of covariance matrix)'),
-         trk_qoverp_dsz_cov = Var('trk_qoverp_dsz_cov', 'float', precision=10, doc='track qoverp dsz covariance ((0,4) element of covariance matrix)'),
-         trk_lambda_phi_cov = Var('trk_lambda_phi_cov', 'float', precision=10, doc='track lambda phi covariance ((1,2) element of covariance matrix)'),
-         trk_lambda_dxy_cov = Var('trk_lambda_dxy_cov', 'float', precision=10, doc='track lambda dxy covariance ((1,3) element of covariance matrix)'),
-         trk_lambda_dsz_cov = Var('trk_lambda_dsz_cov', 'float', precision=10, doc='track lambda dsz covariance ((1,4) element of covariance matrix)'),
-         trk_phi_dxy_cov = Var('trk_phi_dxy_cov', 'float', precision=10, doc='track phi dxy covariance ((2,3) element of covariance matrix)'),
-         trk_phi_dsz_cov = Var('trk_phi_dsz_cov', 'float', precision=10, doc='track phi dsz covariance ((2,4) element of covariance matrix)'),
-         trk_dxy_dsz_cov = Var('trk_dxy_dsz_cov', 'float', precision=10, doc='track dxy dsz covariance ((3,4) element of covariance matrix)'),
-         trk_vx = Var('trk_vx', 'float', precision=10, doc='track vx'),
-         trk_vy = Var('trk_vy', 'float', precision=10, doc='track vy'),
-         trk_vz = Var('trk_vz', 'float', precision=10, doc='track vz'),
-     )
+
+# from 2024, there are two scouting muon collections
+
+# muonVtx
+scoutingMuonVtxTable = scoutingMuonTable.clone(
+    src = cms.InputTag("hltScoutingMuonPackerVtx"),
+    name = cms.string("ScoutingMuonVtx"),
+    doc  = cms.string("Scouting Muon Vtx"),
+)
+scoutingMuonVtxDisplacedVertexTable = scoutingMuonDisplacedVertexTable.clone(
+    src = cms.InputTag("hltScoutingMuonPackerVtx", "displacedVtx"),
+    name = cms.string("ScoutingMuonVtxDisplacedVertex"),
+    doc  = cms.string("Scouting Muon Vtx DisplacedVertex"),
 )
 
-trackScoutingTable = cms.EDProducer("SimpleRun3ScoutingTrackFlatTableProducer",
-     src = cms.InputTag("hltScoutingTrackPacker"),
-     cut = cms.string(""),
-     name = cms.string("ScoutingTrack"),
-     doc  = cms.string("Track scouting information"),
-     singleton = cms.bool(False),
-     extension = cms.bool(False),
-     variables = cms.PSet(
-         pt = Var('tk_pt', 'float', precision=10, doc='pt'),
-         eta = Var('tk_eta', 'float', precision=10, doc='eta'),
-         phi = Var('tk_phi', 'float', precision=10, doc='phi'),
-         chi2 = Var('tk_chi2', 'float', precision=10, doc='chi squared'),
-         ndof = Var('tk_ndof', 'float', precision=10, doc='number of degrees of freedom'),
-         charge = Var('tk_charge', 'int', doc='charge'),
-         dxy = Var('tk_dxy', 'float', precision=10, doc='dxy'),
-         dz = Var('tk_dz', 'float', precision=10, doc='dz'),
-         nValidPixelHits = Var('tk_nValidPixelHits', 'int', doc='number of valid pixel hits'),
-         nValidStripHits = Var('tk_nValidStripHits', 'int', doc='number of valid strip hits'),
-         nTrackerLayersWithMeasurement = Var('tk_nTrackerLayersWithMeasurement', 'int', doc='number of tracker layers with measurements'),
-         qoverp = Var('tk_qoverp', 'float', precision=10, doc='qoverp'),
-         lambda_ = Var('tk_lambda', 'float', precision=10, doc='lambda'),
-         dxyError = Var('tk_dxy_Error', 'float', precision=10, doc='dxyError'),
-         dzError = Var('tk_dz_Error', 'float', precision=10, doc='dzError'),
-         qoverpError = Var('tk_qoverp_Error', 'float', precision=10, doc='qoverpError'),
-         lambdaError = Var('tk_lambda_Error', 'float', precision=10, doc='lambdaError'),
-         phiError = Var('tk_phi_Error', 'float', precision=10, doc='phiError'),
-         dsz = Var('tk_dsz', 'float', precision=10, doc='dsz'),
-         dszError = Var('tk_dsz_Error', 'float', precision=10, doc='dszError'),
-         qoverp_lambda_cov = Var('tk_qoverp_lambda_cov', 'float', precision=10, doc='qoverp lambda covariance ((0,1) element of covariance matrix)'),
-         qoverp_phi_cov = Var('tk_qoverp_phi_cov', 'float', precision=10, doc='qoverp phi covariance ((0,2) element of covariance matrix)'),
-         qoverp_dxy_cov = Var('tk_qoverp_dxy_cov', 'float', precision=10, doc='qoverp dxy covariance ((0,3) element of covariance matrix)'),
-         qoverp_dsz_cov = Var('tk_qoverp_dsz_cov', 'float', precision=10, doc='qoverp dsz covariance ((0,4) element of covariance matrix)'),
-         lambda_phi_cov = Var('tk_lambda_phi_cov', 'float', precision=10, doc='lambda phi covariance ((1,2) element of covariance matrix)'),
-         lambda_dxy_cov = Var('tk_lambda_dxy_cov', 'float', precision=10, doc='lambda dxy covariance ((1,3) element of covariance matrix)'),
-         lambda_dsz_cov = Var('tk_lambda_dsz_cov', 'float', precision=10, doc='lambd dsz covariance ((1,4) element of covariance matrix)'),
-         phi_dxy_cov = Var('tk_phi_dxy_cov', 'float', precision=10, doc='phi dxy covariance ((2,3) element of covariance matrix)'),
-         phi_dsz_cov = Var('tk_phi_dsz_cov', 'float', precision=10, doc='phi dsz covariance ((2,4) element of covariance matrix)'),
-         dxy_dsz_cov = Var('tk_dxy_dsz_cov', 'float', precision=10, doc='dxy dsz covariance ((3,4) element of covariance matrix)'),
-         vtxInd = Var('tk_vtxInd', 'int', doc='vertex index'),
-         vx = Var('tk_vx', 'float', precision=10, doc='vx'),
-         vy = Var('tk_vy', 'float', precision=10, doc='vy'),
-         vz = Var('tk_vz', 'float', precision=10, doc='vz'),
-     )
+# muonNoVtx
+scoutingMuonNoVtxTable = scoutingMuonTable.clone(
+    src = cms.InputTag("hltScoutingMuonPackerNoVtx"),
+    name = cms.string("ScoutingMuonNoVtx"),
+    doc  = cms.string("Scouting Muon NoVtx"),
+)
+scoutingMuonNoVtxDisplacedVertexTable = scoutingMuonDisplacedVertexTable.clone(
+    src = cms.InputTag("hltScoutingMuonPackerNoVtx", "displacedVtx"),
+    name = cms.string("ScoutingMuonNoVtxDisplacedVertex"),
+    doc  = cms.string("Scouting Muon NoVtx DisplacedVertex"),
 )
 
-primaryvertexScoutingTable = cms.EDProducer("SimpleRun3ScoutingVertexFlatTableProducer",
-     src = cms.InputTag("hltScoutingPrimaryVertexPacker", "primaryVtx"),
-     cut = cms.string(""),
-     name = cms.string("ScoutingPrimaryVertex"),
-     doc  = cms.string("PrimaryVertex scouting information"),
-     singleton = cms.bool(False),
-     extension = cms.bool(False),
-     variables = cms.PSet(
-         x = Var('x', 'float', precision=10, doc='position x coordinate'),
-         y = Var('y', 'float', precision=10, doc='position y coordinate'),
-         z = Var('z', 'float', precision=10, doc='position z coordinate'),
-         xError = Var('xError', 'float', precision=10, doc='x error'),
-         yError = Var('yError', 'float', precision=10, doc='y error'),
-         zError = Var('zError', 'float', precision=10, doc='z error'),
-         tracksSize = Var('tracksSize', 'int', doc='number of tracks'),
-         chi2 = Var('chi2', 'float', precision=10, doc='chi squared'),
-         ndof = Var('ndof', 'int', doc='number of degrees of freedom'),
-         isValidVtx = Var('isValidVtx', 'bool', doc='is valid'),
-     )
+# Scouting Electron
+# https://github.com/cms-sw/cmssw/blob/CMSSW_14_0_X/DataFormats/Scouting/interface/Run3ScoutingElectron.h
+
+scoutingElectronTable = cms.EDProducer("SimpleRun3ScoutingElectronFlatTableProducer",
+    src = cms.InputTag("hltScoutingEgammaPacker"),
+    cut = cms.string(""),
+    name = cms.string("ScoutingElectron"),
+    doc  = cms.string("Scouting Electron"),
+    singleton = cms.bool(False),
+    extension = cms.bool(False),
+    variables = cms.PSet(
+        pt = Var('pt', 'float', precision=10, doc='super-cluster (SC) pt'),
+        eta = Var('eta', 'float', precision=10, doc='SC eta'),
+        phi = Var('phi', 'float', precision=10, doc='SC phi'),
+        m = Var('m', 'float', precision=10, doc='SC mass'),
+        dEtaIn = Var('dEtaIn', 'float', precision=10, doc='#Delta#eta(SC seed, track pixel seed)'),
+        dPhiIn = Var('dPhiIn', 'float', precision=10, doc='#Delta#phi(SC seed, track pixel seed)'),
+        sigmaIetaIeta = Var('sigmaIetaIeta', 'float', precision=10, doc='sigmaIetaIeta of the SC, calculated with full 5x5 region, noise cleaned'),
+        hOverE = Var('hOverE', 'float', precision=10, doc='Energy in HCAL / Energy in ECAL'),
+        ooEMOop = Var('ooEMOop', 'float', precision=10, doc='1/E(SC) - 1/p(track momentum)'),
+        missingHits = Var('missingHits', 'int', doc='missing hits in the tracker'),
+        ecalIso = Var('ecalIso', 'float', precision=10, doc='Isolation of SC in the ECAL'),
+        hcalIso = Var('hcalIso', 'float', precision=10, doc='Isolation of SC in the HCAL'),
+        trackIso = Var('trackIso', 'float', precision=10, doc='Isolation of electron track in the tracker'),
+        r9 = Var('r9', 'float', precision=10, doc='ELectron SC r9 as defined in https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideEgammaShowerShape'),
+        sMin = Var('sMin', 'float', precision=10, doc='minor moment of the SC shower shape'),
+        sMaj = Var('sMaj', 'float', precision=10, doc='major moment of the SC shower shape'),
+        seedId = Var('seedId', 'int', doc='ECAL ID of the SC seed'),
+    ),
 )
 
-displacedvertexScoutingTable = cms.EDProducer("SimpleRun3ScoutingVertexFlatTableProducer",
-     src = cms.InputTag("hltScoutingMuonPacker","displacedVtx"),
-     cut = cms.string(""),
-     name = cms.string("ScoutingDisplacedVertex"),
-     doc  = cms.string("DisplacedVertex scouting information"),
-     singleton = cms.bool(False),
-     extension = cms.bool(False),
-     variables = cms.PSet(
-         x = Var('x', 'float', precision=10, doc='position x coordinate'),
-         y = Var('y', 'float', precision=10, doc='position y coordinate'),
-         z = Var('z', 'float', precision=10, doc='position z coordinate'),
-         xError = Var('xError', 'float', precision=10, doc='x error'),
-         yError = Var('yError', 'float', precision=10, doc='y error'),
-         zError = Var('zError', 'float', precision=10, doc='z error'),
-         tracksSize = Var('tracksSize', 'int', doc='number of tracks'),
-         chi2 = Var('chi2', 'float', precision=10, doc='chi squared'),
-         ndof = Var('ndof', 'int', doc='number of degrees of freedom'),
-         isValidVtx = Var('isValidVtx', 'bool', doc='is valid'),
-     )
+# Scouting Photon
+# https://github.com/cms-sw/cmssw/blob/CMSSW_14_0_X/DataFormats/Scouting/interface/Run3ScoutingPhoton.h
+
+scoutingPhotonTable = cms.EDProducer("SimpleRun3ScoutingPhotonFlatTableProducer",
+    src = cms.InputTag("hltScoutingEgammaPacker"),
+    cut = cms.string(""),
+    name = cms.string("ScoutingPhoton"),
+    doc  = cms.string("Scouting Photon"),
+    singleton = cms.bool(False),
+    extension = cms.bool(False),
+    variables = cms.PSet(
+        pt = Var('pt', 'float', precision=10, doc='super-cluster (SC) pt'),
+        eta = Var('eta', 'float', precision=10, doc='SC eta'),
+        phi = Var('phi', 'float', precision=10, doc='SC phi'),
+        m = Var('m', 'float', precision=10, doc='SC mass'),
+        sigmaIetaIeta = Var('sigmaIetaIeta', 'float', precision=10, doc='sigmaIetaIeta of the SC, calculated with full 5x5 region, noise cleaned'),
+        hOverE = Var('hOverE', 'float', precision=10, doc='Energy in HCAL / Energy in ECAL'),
+        ecalIso = Var('ecalIso', 'float', precision=10, doc='Isolation of SC in the ECAL'),
+        hcalIso = Var('hcalIso', 'float', precision=10, doc='Isolation of SC in the HCAL'),
+        trkIso = Var('trkIso', 'float', precision=10, doc='Isolation of track in the tracker'),
+        r9 = Var('r9', 'float', precision=10, doc='Photon SC r9 as defined in https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideEgammaShowerShape'),
+        sMin = Var('sMin', 'float', precision=10, doc='minor moment of the SC shower shape'),
+        sMaj = Var('sMaj', 'float', precision=10, doc='major moment of the SC shower shape'),
+        seedId = Var('seedId', 'int', doc='ECAL ID of the SC seed'),
+    ),
 )
 
-jetScoutingTable = cms.EDProducer("SimpleRun3ScoutingPFJetFlatTableProducer",
+# Scouting Track
+# https://github.com/cms-sw/cmssw/blob/CMSSW_14_0_X/DataFormats/Scouting/interface/Run3ScoutingTrack.h
+
+scoutingTrackTable = cms.EDProducer("SimpleRun3ScoutingTrackFlatTableProducer",
+    src = cms.InputTag("hltScoutingTrackPacker"),
+    cut = cms.string(""),
+    name = cms.string("ScoutingTrack"),
+    doc  = cms.string("Scouting Track"),
+    singleton = cms.bool(False),
+    extension = cms.bool(False),
+    variables = cms.PSet(
+        pt = Var('tk_pt', 'float', precision=10, doc='pt'),
+        eta = Var('tk_eta', 'float', precision=10, doc='eta'),
+        phi = Var('tk_phi', 'float', precision=10, doc='phi'),
+        chi2 = Var('tk_chi2', 'float', precision=10, doc='chi squared'),
+        ndof = Var('tk_ndof', 'float', precision=10, doc='number of degrees of freedom'),
+        charge = Var('tk_charge', 'int', doc='charge'),
+        dxy = Var('tk_dxy', 'float', precision=10, doc='dxy'),
+        dz = Var('tk_dz', 'float', precision=10, doc='dz'),
+        nValidPixelHits = Var('tk_nValidPixelHits', 'int', doc='number of valid pixel hits'),
+        nValidStripHits = Var('tk_nValidStripHits', 'int', doc='number of valid strip hits'),
+        nTrackerLayersWithMeasurement = Var('tk_nTrackerLayersWithMeasurement', 'int', doc='number of tracker layers with measurements'),
+        qoverp = Var('tk_qoverp', 'float', precision=10, doc='qoverp'),
+        lambda_ = Var('tk_lambda', 'float', precision=10, doc='lambda'),
+        dxyError = Var('tk_dxy_Error', 'float', precision=10, doc='dxyError'),
+        dzError = Var('tk_dz_Error', 'float', precision=10, doc='dzError'),
+        qoverpError = Var('tk_qoverp_Error', 'float', precision=10, doc='qoverpError'),
+        lambdaError = Var('tk_lambda_Error', 'float', precision=10, doc='lambdaError'),
+        phiError = Var('tk_phi_Error', 'float', precision=10, doc='phiError'),
+        dsz = Var('tk_dsz', 'float', precision=10, doc='dsz'),
+        dszError = Var('tk_dsz_Error', 'float', precision=10, doc='dszError'),
+        qoverp_lambda_cov = Var('tk_qoverp_lambda_cov', 'float', precision=10, doc='qoverp lambda covariance ((0,1) element of covariance matrix)'),
+        qoverp_phi_cov = Var('tk_qoverp_phi_cov', 'float', precision=10, doc='qoverp phi covariance ((0,2) element of covariance matrix)'),
+        qoverp_dxy_cov = Var('tk_qoverp_dxy_cov', 'float', precision=10, doc='qoverp dxy covariance ((0,3) element of covariance matrix)'),
+        qoverp_dsz_cov = Var('tk_qoverp_dsz_cov', 'float', precision=10, doc='qoverp dsz covariance ((0,4) element of covariance matrix)'),
+        lambda_phi_cov = Var('tk_lambda_phi_cov', 'float', precision=10, doc='lambda phi covariance ((1,2) element of covariance matrix)'),
+        lambda_dxy_cov = Var('tk_lambda_dxy_cov', 'float', precision=10, doc='lambda dxy covariance ((1,3) element of covariance matrix)'),
+        lambda_dsz_cov = Var('tk_lambda_dsz_cov', 'float', precision=10, doc='lambd dsz covariance ((1,4) element of covariance matrix)'),
+        phi_dxy_cov = Var('tk_phi_dxy_cov', 'float', precision=10, doc='phi dxy covariance ((2,3) element of covariance matrix)'),
+        phi_dsz_cov = Var('tk_phi_dsz_cov', 'float', precision=10, doc='phi dsz covariance ((2,4) element of covariance matrix)'),
+        dxy_dsz_cov = Var('tk_dxy_dsz_cov', 'float', precision=10, doc='dxy dsz covariance ((3,4) element of covariance matrix)'),
+        vtxInd = Var('tk_vtxInd', 'int', doc='vertex index'),
+        vx = Var('tk_vx', 'float', precision=10, doc='vx'),
+        vy = Var('tk_vy', 'float', precision=10, doc='vy'),
+        vz = Var('tk_vz', 'float', precision=10, doc='vz'),
+    ),
+)
+
+# Scouting Primary Vertex
+# https://github.com/cms-sw/cmssw/blob/CMSSW_14_0_X/DataFormats/Scouting/interface/Run3ScoutingVertex.h
+
+scoutingPrimaryVertexTable = cms.EDProducer("SimpleRun3ScoutingVertexFlatTableProducer",
+    src = cms.InputTag("hltScoutingPrimaryVertexPacker", "primaryVtx"),
+    cut = cms.string(""),
+    name = cms.string("ScoutingPrimaryVertex"),
+    doc  = cms.string("Scouting Primary Vertex"),
+    singleton = cms.bool(False),
+    extension = cms.bool(False),
+    variables = cms.PSet(
+        x = Var('x', 'float', precision=10, doc='position x coordinate'),
+        y = Var('y', 'float', precision=10, doc='position y coordinate'),
+        z = Var('z', 'float', precision=10, doc='position z coordinate'),
+        xError = Var('xError', 'float', precision=10, doc='x error'),
+        yError = Var('yError', 'float', precision=10, doc='y error'),
+        zError = Var('zError', 'float', precision=10, doc='z error'),
+        tracksSize = Var('tracksSize', 'int', doc='number of tracks'),
+        chi2 = Var('chi2', 'float', precision=10, doc='chi squared'),
+        ndof = Var('ndof', 'int', doc='number of degrees of freedom'),
+        isValidVtx = Var('isValidVtx', 'bool', doc='is valid'),
+    ),
+)
+
+# Scouting Particle (PF candidate)
+# https://github.com/cms-sw/cmssw/blob/CMSSW_14_0_X/DataFormats/Scouting/interface/Run3ScoutingParticle.h
+
+scoutingParticleTable = cms.EDProducer("SimpleRun3ScoutingParticleFlatTableProducer",
+    src = cms.InputTag("hltScoutingPFPacker"),
+    name = cms.string("ScoutingParticle"),
+    cut = cms.string(""),
+    doc = cms.string("Scouting Particle"),
+    singleton = cms.bool(False),
+    extension = cms.bool(False),
+    variables = cms.PSet(
+        P3Vars,
+        pdgId = Var("pdgId", int, doc="PDG code assigned by the event reconstruction (not by MC truth)"),
+        vertex = Var("vertex()", int, doc="vertex index"),
+        normchi2 = Var("normchi2()", float, doc="normalized chi squared of best track"),
+        dz = Var("dz()", float, doc="dz of best track"),
+        dxy = Var("dxy()", float, doc="dxy of best track"),
+        dzsig = Var("dzsig()", float, doc="dzsig of best track"),
+        dxysig = Var("dxysig()", float, doc="dxysig of best track"),
+        lostInnerHits = Var("lostInnerHits()", "uint8", doc="lostInnerHits of best track"),
+        quality = Var("quality()", "uint8", doc="quality of best track"),
+        trk_pt = Var("trk_pt()", "float", doc="pt of best track"),
+        trk_eta = Var("trk_eta()", "float", doc="eta of best track"),
+        trk_phi = Var("trk_phi()", "float", doc="phi of best track"),
+        relative_trk_vars = Var("relative_trk_vars()", "bool", doc="relative_trk_vars"),
+    ),
+)
+
+# Scouting PFJet
+# https://github.com/cms-sw/cmssw/blob/CMSSW_14_0_X/DataFormats/Scouting/interface/Run3ScoutingPFJet.h
+
+scoutingPFJetTable = cms.EDProducer("SimpleRun3ScoutingPFJetFlatTableProducer",
     src = cms.InputTag("hltScoutingPFPacker"),
     cut = cms.string(""),
     name = cms.string("ScoutingPFJet"),
-    doc  = cms.string("PFJet scouting information"),
+    doc  = cms.string("Scouting PFJet"),
     singleton = cms.bool(False),
     extension = cms.bool(False),
     variables = cms.PSet(
@@ -231,327 +310,349 @@ jetScoutingTable = cms.EDProducer("SimpleRun3ScoutingPFJetFlatTableProducer",
         photonMultiplicity = Var('photonMultiplicity', 'int', doc='number of photons in the jet'),
         electronMultiplicity = Var('electronMultiplicity', 'int', doc='number of electrons in the jet'),
         muonMultiplicity = Var('muonMultiplicity', 'int', doc='number of muons in the jet'),
-        HFHadronMultiplicity = Var('HFHadronMultiplicity', 'int', doc='number of HF hadronic particles in the jet'),
-        HFEMMultiplicity = Var('HFEMMultiplicity', 'int', doc='number of HF electromagnetic particles in the jet'),
+        HFHadronMultiplicity = Var('HFHadronMultiplicity', 'int', doc='number of hadronic particles in the jet in HF'),
+        HFEMMultiplicity = Var('HFEMMultiplicity', 'int', doc='number of electromagnetic particles in the jet in HF'),
         HOEnergy = Var('HOEnergy', 'float', precision=10, doc='hadronic energy in HO'),
-    )
+    ),
 )
 
-rhoScoutingTable = cms.EDProducer("GlobalVariablesTableProducer",
-    name = cms.string(""),
-    variables = cms.PSet(
-        ScoutingRho = ExtVar( cms.InputTag("hltScoutingPFPacker", "rho"), "double", doc = "rho from all scouting PF Candidates, used e.g. for JECs" ),
-    )
-)
-
-metScoutingTable = cms.EDProducer("GlobalVariablesTableProducer",
+# Scouting MET
+scoutingMETTable = cms.EDProducer("GlobalVariablesTableProducer",
     name = cms.string("ScoutingMET"),
     variables = cms.PSet(
         pt = ExtVar( cms.InputTag("hltScoutingPFPacker", "pfMetPt"), "double", doc = "scouting MET pt"),
         phi = ExtVar( cms.InputTag("hltScoutingPFPacker", "pfMetPhi"), "double", doc = "scouting MET phi"),
-    )
-)
-
-# from 2024, there are two scouting muon collections
-
-# muonVtx
-muonVtxScoutingTable = muonScoutingTable.clone(
-    src = cms.InputTag("hltScoutingMuonPackerVtx"),
-    name = cms.string("ScoutingMuonVtx"),
-    doc  = cms.string("Scouting Muon Vtx information"),
-)
-displacedvertexVtxScoutingTable = displacedvertexScoutingTable.clone(
-    src = cms.InputTag("hltScoutingMuonPackerVtx", "displacedVtx"),
-    name = cms.string("ScoutingMuonVtxDisplacedVertex"),
-    doc  = cms.string("Scouting Muon Vtx DisplacedVertex information"),
-)
-
-# muonNoVtx
-muonNoVtxScoutingTable = muonScoutingTable.clone(
-    src = cms.InputTag("hltScoutingMuonPackerNoVtx"),
-    name = cms.string("ScoutingMuonNoVtx"),
-    doc  = cms.string("Scouting Muon NoVtx information"),
-)
-displacedvertexNoVtxScoutingTable = displacedvertexScoutingTable.clone(
-    src = cms.InputTag("hltScoutingMuonPackerNoVtx", "displacedVtx"),
-    name = cms.string("ScoutingMuonNoVtxDisplacedVertex"),
-    doc  = cms.string("Scouting Muon NoVtx DisplacedVertex information"),
-)
-
-################
-# Scouting particles
-
-scoutingPFCands = cms.EDProducer(
-     "Run3ScoutingParticleToRecoPFCandidateProducer",
-     scoutingparticle=cms.InputTag("hltScoutingPFPacker"),
-)
-
-particleScoutingTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
-    src = cms.InputTag("scoutingPFCands"),
-    name = cms.string("ScoutingParticle"),
-    cut = cms.string(""),
-    doc = cms.string("ScoutingParticle"),
-    singleton = cms.bool(False),
-    extension = cms.bool(False), # this is the main table
-    externalVariables = cms.PSet(
-       vertexIndex = ExtVar(cms.InputTag("scoutingPFCands", "vertexIndex"), int, doc="vertex index"),
-       trkNormchi2 = ExtVar(cms.InputTag("scoutingPFCands", "normchi2"), float, doc="normalized chi squared of best track", precision=6),
-       trkDz = ExtVar(cms.InputTag("scoutingPFCands", "dz"), float, doc="dz of best track", precision=6),
-       trkDxy = ExtVar(cms.InputTag("scoutingPFCands", "dxy"), float, doc="dxy of best track", precision=6),
-       trkDzsig = ExtVar(cms.InputTag("scoutingPFCands", "dzsig"), float, doc="dzsig of best track", precision=6),
-       trkDxysig = ExtVar(cms.InputTag("scoutingPFCands", "dxysig"), float, doc="dxysig of best track", precision=6),
-       trkLostInnerHits = ExtVar(cms.InputTag("scoutingPFCands", "lostInnerHits"), int, doc="lostInnerHits of best track"),
-       trkQuality = ExtVar(cms.InputTag("scoutingPFCands", "quality"), int, doc="quality of best track"),
-       trkPt = ExtVar(cms.InputTag("scoutingPFCands", "trkPt"), float, doc="pt of best track", precision=6),
-       trkEta = ExtVar(cms.InputTag("scoutingPFCands", "trkEta"), float, doc="eta of best track", precision=6),
-       trkPhi = ExtVar(cms.InputTag("scoutingPFCands", "trkPhi"), float, doc="phi of best track", precision=6),
     ),
+)
+
+# Scouting Rho
+scoutingRhoTable = cms.EDProducer("GlobalVariablesTableProducer",
+    name = cms.string("ScoutingRho"),
     variables = cms.PSet(
-       CandVars,
+        fixedGridRhoFastjetAll = ExtVar(cms.InputTag("hltScoutingPFPacker", "rho"), "double", doc = "rho from all scouting PF Candidates, used e.g. for JECs" ),
     ),
-  )
+)
 
-################
-# Scouting AK4 jets
+####################################
+##### Scouting Derived Objects #####
+####################################
+# objects built from scouting objects, e.g. reclustered jets
+
+#########################
+# Scouting PF Candidate #
+#########################
+# translation from Run3ScoutingParticle to reco::PFCandidate
+# used as input for standard algorithm, e.g. jet clustering
+
+scoutingPFCandidate = cms.EDProducer("Run3ScoutingParticleToRecoPFCandidateProducer",
+    scoutingparticle = cms.InputTag("hltScoutingPFPacker"),
+    CHS = cms.bool(False),
+)
+
+# this table is similar to scoutingParticleTable
+# except if relative_trk_vars is true, PF candidate variables will be already added to PF candidate's track variables
+scoutingPFCandidateTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
+    src = cms.InputTag("scoutingPFCandidate"),
+    name = cms.string("ScoutingPFCandidate"),
+    cut = cms.string(""),
+    doc = cms.string("Scouting Candidate"),
+    singleton = cms.bool(False),
+    extension = cms.bool(False),
+    variables = cms.PSet(
+        CandVars,
+    ),
+    externalVariables = cms.PSet(
+        vertexIndex = ExtVar(cms.InputTag("scoutingPFCandidate", "vertexIndex"), int, doc="vertex index"),
+        trkNormchi2 = ExtVar(cms.InputTag("scoutingPFCandidate", "normchi2"), float, doc="normalized chi squared of best track", precision=6),
+        trkDz = ExtVar(cms.InputTag("scoutingPFCandidate", "dz"), float, doc="dz of best track", precision=6),
+        trkDxy = ExtVar(cms.InputTag("scoutingPFCandidate", "dxy"), float, doc="dxy of best track", precision=6),
+        trkDzsig = ExtVar(cms.InputTag("scoutingPFCandidate", "dzsig"), float, doc="dzsig of best track", precision=6),
+        trkDxysig = ExtVar(cms.InputTag("scoutingPFCandidate", "dxysig"), float, doc="dxysig of best track", precision=6),
+        trkLostInnerHits = ExtVar(cms.InputTag("scoutingPFCandidate", "lostInnerHits"), int, doc="lostInnerHits of best track"),
+        trkQuality = ExtVar(cms.InputTag("scoutingPFCandidate", "quality"), int, doc="quality of best track"),
+        trkPt = ExtVar(cms.InputTag("scoutingPFCandidate", "trkPt"), float, doc="pt of best track", precision=6),
+        trkEta = ExtVar(cms.InputTag("scoutingPFCandidate", "trkEta"), float, doc="eta of best track", precision=6),
+        trkPhi = ExtVar(cms.InputTag("scoutingPFCandidate", "trkPhi"), float, doc="phi of best track", precision=6),
+    ),
+)
+
+#########################
+# AK4 PFJet Reclustered #
+#########################
+# AK4 jets from reclustering PF candidates
+
+# AK4 jet clustering
 
 from RecoJets.JetProducers.ak4PFJets_cfi import ak4PFJets
-ak4ScoutingJets = ak4PFJets.clone(
-     src = ("scoutingPFCands"),
-     jetPtMin = 20,
+scoutingPFJetRecluster = ak4PFJets.clone(
+    src = ("scoutingPFCandidate"),
+    jetPtMin = 20,
 )
 
-ak4ScoutingJetParticleNetJetTagInfos = cms.EDProducer("DeepBoostedJetTagInfoProducer",
-      jet_radius = cms.double( 0.4 ),
-      min_jet_pt = cms.double( 5.0 ),
-      max_jet_eta = cms.double( 2.5 ),
-      min_pt_for_track_properties = cms.double( 0.95 ),
-      min_pt_for_pfcandidates = cms.double( 0.1 ),
-      use_puppiP4 = cms.bool( False ),
-      include_neutrals = cms.bool( True ),
-      sort_by_sip2dsig = cms.bool( False ),
-      min_puppi_wgt = cms.double( -1.0 ),
-      flip_ip_sign = cms.bool( False ),
-      sip3dSigMax = cms.double( -1.0 ),
-      use_hlt_features = cms.bool( False ),
-      pf_candidates = cms.InputTag( "scoutingPFCands" ),
-      jets = cms.InputTag( "ak4ScoutingJets" ),
-      puppi_value_map = cms.InputTag( "" ),
-      use_scouting_features = cms.bool( True ),
-      normchi2_value_map = cms.InputTag("scoutingPFCands", "normchi2"),
-      dz_value_map = cms.InputTag("scoutingPFCands", "dz"),
-      dxy_value_map = cms.InputTag("scoutingPFCands", "dxy"),
-      dzsig_value_map = cms.InputTag("scoutingPFCands", "dzsig"),
-      dxysig_value_map = cms.InputTag("scoutingPFCands", "dxysig"),
-      lostInnerHits_value_map = cms.InputTag("scoutingPFCands", "lostInnerHits"),
-      quality_value_map = cms.InputTag("scoutingPFCands", "quality"),
-      trkPt_value_map = cms.InputTag("scoutingPFCands", "trkPt"),
-      trkEta_value_map = cms.InputTag("scoutingPFCands", "trkEta"),
-      trkPhi_value_map = cms.InputTag("scoutingPFCands", "trkPhi"),
+# AK4 jet tagging 
+
+scoutingPFJetReclusterParticleNetJetTagInfos = cms.EDProducer("DeepBoostedJetTagInfoProducer",
+    jet_radius = cms.double(0.4),
+    min_jet_pt = cms.double(5.0),
+    max_jet_eta = cms.double(2.5),
+    min_pt_for_track_properties = cms.double(0.95),
+    min_pt_for_pfcandidates = cms.double(0.1),
+    use_puppiP4 = cms.bool(False),
+    include_neutrals = cms.bool(True),
+    sort_by_sip2dsig = cms.bool(False),
+    min_puppi_wgt = cms.double(-1.0),
+    flip_ip_sign = cms.bool(False),
+    sip3dSigMax = cms.double(-1.0),
+    use_hlt_features = cms.bool(False),
+    pf_candidates = cms.InputTag("scoutingPFCandidate"),
+    jets = cms.InputTag("scoutingPFJetRecluster"),
+    puppi_value_map = cms.InputTag(""),
+    use_scouting_features = cms.bool(True),
+    normchi2_value_map = cms.InputTag("scoutingPFCandidate", "normchi2"),
+    dz_value_map = cms.InputTag("scoutingPFCandidate", "dz"),
+    dxy_value_map = cms.InputTag("scoutingPFCandidate", "dxy"),
+    dzsig_value_map = cms.InputTag("scoutingPFCandidate", "dzsig"),
+    dxysig_value_map = cms.InputTag("scoutingPFCandidate", "dxysig"),
+    lostInnerHits_value_map = cms.InputTag("scoutingPFCandidate", "lostInnerHits"),
+    quality_value_map = cms.InputTag("scoutingPFCandidate", "quality"),
+    trkPt_value_map = cms.InputTag("scoutingPFCandidate", "trkPt"),
+    trkEta_value_map = cms.InputTag("scoutingPFCandidate", "trkEta"),
+    trkPhi_value_map = cms.InputTag("scoutingPFCandidate", "trkPhi"),
 )
 
 from RecoBTag.ONNXRuntime.boostedJetONNXJetTagsProducer_cfi import boostedJetONNXJetTagsProducer
-
-ak4ScoutingJetParticleNetJetTags = cms.EDProducer("BoostedJetONNXJetTagsProducer",
-      jets = cms.InputTag("ak4ScoutingJets"),
-      produceValueMap = cms.untracked.bool(True),
-      src = cms.InputTag("ak4ScoutingJetParticleNetJetTagInfos"),
-      preprocess_json = cms.string("RecoBTag/Combined/data/Run3Scouting/ParticleNetAK4/V00/preprocess.json"),
-      model_path = cms.FileInPath("RecoBTag/Combined/data/Run3Scouting/ParticleNetAK4/V00/particle-net.onnx"),
-      flav_names = cms.vstring(["probb", "probbb","probc", "probcc", "probuds", "probg", "probundef"]),
-      debugMode = cms.untracked.bool(False),
+scoutingPFJetReclusterParticleNetJetTags = cms.EDProducer("BoostedJetONNXJetTagsProducer",
+    jets = cms.InputTag("scoutingPFJetRecluster"),
+    produceValueMap = cms.untracked.bool(True),
+    src = cms.InputTag("scoutingPFJetReclusterParticleNetJetTagInfos"),
+    preprocess_json = cms.string("RecoBTag/Combined/data/Run3Scouting/ParticleNetAK4/V00/preprocess.json"),
+    model_path = cms.FileInPath("RecoBTag/Combined/data/Run3Scouting/ParticleNetAK4/V00/particle-net.onnx"),
+    flav_names = cms.vstring(["probb", "probbb","probc", "probcc", "probuds", "probg", "probundef"]),
+    debugMode = cms.untracked.bool(False),
 )
 
-ak4ScoutingJetTable = cms.EDProducer("SimplePFJetFlatTableProducer",
-      src = cms.InputTag("ak4ScoutingJets"),
-      name = cms.string("ScoutingPFJetRecluster"),
-      cut = cms.string(""),
-      doc = cms.string("ak4 jets from re-clustering scouting PF candidates"),
-      singleton = cms.bool(False),
-      extension = cms.bool(False), # this is the main table
-      externalVariables = cms.PSet(
-         particleNet_prob_b = ExtVar(cms.InputTag('ak4ScoutingJetParticleNetJetTags:probb'), float, doc="ParticleNet probability of b", precision=10),
-         particleNet_prob_bb = ExtVar(cms.InputTag('ak4ScoutingJetParticleNetJetTags:probbb'), float, doc="ParticleNet probability of bb", precision=10),
-         particleNet_prob_c = ExtVar(cms.InputTag('ak4ScoutingJetParticleNetJetTags:probc'), float, doc="ParticleNet probability of c", precision=10),
-         particleNet_prob_cc = ExtVar(cms.InputTag('ak4ScoutingJetParticleNetJetTags:probcc'), float, doc="ParticleNet probability of cc", precision=10),
-         particleNet_prob_uds = ExtVar(cms.InputTag('ak4ScoutingJetParticleNetJetTags:probuds'), float, doc="particlenet probability of uds", precision=10),
-         particleNet_prob_g = ExtVar(cms.InputTag('ak4ScoutingJetParticleNetJetTags:probg'), float, doc="ParticleNet probability of g", precision=10),
-         particleNet_prob_undef = ExtVar(cms.InputTag('ak4ScoutingJetParticleNetJetTags:probundef'), float, doc="ParticleNet probability of undef", precision=10),
-      ),
-      variables = cms.PSet(
-         P4Vars,
-         area = Var("jetArea()", float, doc="jet catchment area, for JECs",precision=10),
-         chHEF = Var("chargedHadronEnergy()/(chargedHadronEnergy()+neutralHadronEnergy()+photonEnergy()+electronEnergy()+muonEnergy())", float, doc="charged Hadron Energy Fraction", precision= 6),
-         neHEF = Var("neutralHadronEnergy()/(chargedHadronEnergy()+neutralHadronEnergy()+photonEnergy()+electronEnergy()+muonEnergy())", float, doc="neutral Hadron Energy Fraction", precision= 6),
-         chEmEF = Var("(electronEnergy()+muonEnergy())/(chargedHadronEnergy()+neutralHadronEnergy()+photonEnergy()+electronEnergy()+muonEnergy())", float, doc="charged Electromagnetic Energy Fraction", precision= 6),
-         neEmEF = Var("(photonEnergy())/(chargedHadronEnergy()+neutralHadronEnergy()+photonEnergy()+electronEnergy()+muonEnergy())", float, doc="neutral Electromagnetic Energy Fraction", precision= 6),
-         muEF = Var("(muonEnergy())/(chargedHadronEnergy()+neutralHadronEnergy()+photonEnergy()+electronEnergy()+muonEnergy())", float, doc="muon Energy Fraction", precision= 6),
-         nCh = Var("chargedHadronMultiplicity()", int, doc="number of charged hadrons in the jet"),
-         nNh = Var("neutralHadronMultiplicity()", int, doc="number of neutral hadrons in the jet"),
-         nMuons = Var("muonMultiplicity()", int, doc="number of muons in the jet"),
-         nElectrons = Var("electronMultiplicity()", int, doc="number of electrons in the jet"),
-         nPhotons = Var("photonMultiplicity()", int, doc="number of photons in the jet"),
-         nConstituents = Var("numberOfDaughters()", "uint8", doc="number of particles in the jet")
-      ),
+# output AK4 jet to nanoaod::flattable
+
+scoutingPFJetReclusterTable = cms.EDProducer("SimplePFJetFlatTableProducer",
+    src = cms.InputTag("scoutingPFJetRecluster"),
+    name = cms.string("ScoutingPFJetRecluster"),
+    cut = cms.string(""),
+    doc = cms.string("ak4 jet from reclustering scouting PF candidates"),
+    singleton = cms.bool(False),
+    extension = cms.bool(False),
+    variables = cms.PSet(
+        P4Vars,
+        area = Var("jetArea()", float, doc="jet catchment area, for JECs",precision=10),
+        # energy fractions
+        chHEF = Var("chargedHadronEnergyFraction()", float, doc="charged Hadron Energy Fraction", precision= 6),
+        neHEF = Var("neutralHadronEnergyFraction()", float, doc="neutral Hadron Energy Fraction", precision= 6),
+        chEmEF = Var("chargedEmEnergyFraction()", float, doc="charged Electromagnetic Energy Fraction", precision= 6),
+        neEmEF = Var("neutralEmEnergyFraction()", float, doc="neutral Electromagnetic Energy Fraction", precision= 6),
+        muEF = Var("muonEnergyFraction()", float, doc="muon Energy Fraction", precision= 6),
+        hfHEF = Var("HFHadronEnergyFraction()",float,doc="hadronic Energy Fraction in HF",precision= 6),
+        hfEmEF = Var("HFEMEnergyFraction()",float,doc="electromagnetic Energy Fraction in HF",precision= 6),
+        # multiplicities
+        nCh = Var("chargedHadronMultiplicity()", int, doc="number of charged hadrons in the jet"),
+        nNh = Var("neutralHadronMultiplicity()", int, doc="number of neutral hadrons in the jet"),
+        nMuons = Var("muonMultiplicity()", int, doc="number of muons in the jet"),
+        nElectrons = Var("electronMultiplicity()", int, doc="number of electrons in the jet"),
+        nPhotons = Var("photonMultiplicity()", int, doc="number of photons in the jet"),
+        nConstituents = Var("numberOfDaughters()", "uint8", doc="number of particles in the jet")
+    ),
+    externalVariables = cms.PSet(
+        # jet tagging probabilities
+        particleNet_prob_b = ExtVar(cms.InputTag("scoutingPFJetReclusterParticleNetJetTags:probb"), float, doc="ParticleNet probability of b", precision=10),
+        particleNet_prob_bb = ExtVar(cms.InputTag("scoutingPFJetReclusterParticleNetJetTags:probbb"), float, doc="ParticleNet probability of bb", precision=10),
+        particleNet_prob_c = ExtVar(cms.InputTag("scoutingPFJetReclusterParticleNetJetTags:probc"), float, doc="ParticleNet probability of c", precision=10),
+        particleNet_prob_cc = ExtVar(cms.InputTag("scoutingPFJetReclusterParticleNetJetTags:probcc"), float, doc="ParticleNet probability of cc", precision=10),
+        particleNet_prob_uds = ExtVar(cms.InputTag("scoutingPFJetReclusterParticleNetJetTags:probuds"), float, doc="particlenet probability of uds", precision=10),
+        particleNet_prob_g = ExtVar(cms.InputTag("scoutingPFJetReclusterParticleNetJetTags:probg"), float, doc="ParticleNet probability of g", precision=10),
+        particleNet_prob_undef = ExtVar(cms.InputTag("scoutingPFJetReclusterParticleNetJetTags:probundef"), float, doc="ParticleNet probability of undef", precision=10),
+    ),
 )
 
-ak4ScoutingJetMatchGen = cms.EDProducer("RecoJetToGenJetDeltaRValueMapProducer",
-      src = cms.InputTag("ak4ScoutingJets"),
-      matched = cms.InputTag("slimmedGenJets"),
-      distMax = cms.double(0.4),
-      value = cms.string("index"),
-  )
+# AK4 gen jet matching (only for MC)
 
-ak4ScoutingJetExtTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
-      src = cms.InputTag("ak4ScoutingJets"),
-      name = cms.string("ScoutingPFJetRecluster"),
-      cut = cms.string(""),
-      singleton = cms.bool(False),
-      extension = cms.bool(True),
-      externalVariables = cms.PSet(
-         genJetIdx = ExtVar(cms.InputTag("ak4ScoutingJetMatchGen"), int, doc="gen jet idx"),
-      ),
-      variables = cms.PSet(),
-  )
-
-################
-# Scouting AK8 jets
-
-ak8ScoutingJets = ak4PFJets.clone(
-     src = ("scoutingPFCands"),
-     rParam   = 0.8,
-     jetPtMin = 170.0,
+scoutingPFJetReclusterMatchGen = cms.EDProducer("RecoJetToGenJetDeltaRValueMapProducer",
+    src = cms.InputTag("scoutingPFJetRecluster"),
+    matched = cms.InputTag("slimmedGenJets"),
+    distMax = cms.double(0.4),
+    value = cms.string("index"),
 )
 
-ak8ScoutingJetsSoftDrop = ak4PFJets.clone(
-     src = ("scoutingPFCands"),
-     rParam   = 0.8,
-     jetPtMin = 170.0,
-     useSoftDrop = cms.bool(True),
-     zcut = cms.double(0.1),
-     beta = cms.double(0.0),
-     R0   = cms.double(0.8),
-     useExplicitGhosts = cms.bool(True),
-     writeCompound = cms.bool(True),
-     jetCollInstanceName=cms.string("SubJets"),
-  )
+scoutingPFJetReclusterMatchGenExtensionTable = cms.EDProducer("SimplePFJetFlatTableProducer",
+    src = cms.InputTag("scoutingPFJetRecluster"),
+    name = cms.string("ScoutingPFJetRecluster"),
+    cut = cms.string(""),
+    singleton = cms.bool(False),
+    extension = cms.bool(True),
+    variables = cms.PSet(),
+    externalVariables = cms.PSet(
+        genJetIdx = ExtVar(cms.InputTag("scoutingPFJetReclusterMatchGen"), int, doc="gen jet idx"),
+    ),
+)
 
-ak8ScoutingJetsSoftDropMass = cms.EDProducer("RecoJetDeltaRValueMapProducer",
-     src = cms.InputTag("ak8ScoutingJets"),
-     matched = cms.InputTag("ak8ScoutingJetsSoftDrop"),
-     distMax = cms.double(0.8),
-     value = cms.string('mass')
-  )
+#########################
+# AK8 PFJet Reclustered #
+#########################
+
+# AK8 jet clustering
+
+scoutingFatPFJetRecluster = ak4PFJets.clone(
+    src = ("scoutingPFCandidate"),
+    rParam   = 0.8,
+    jetPtMin = 170.0,
+)
+
+# AK8 jet tagging
+
+scoutingFatPFJetReclusterParticleNetJetTagInfos = cms.EDProducer("DeepBoostedJetTagInfoProducer",
+    jet_radius = cms.double(0.8),
+    min_jet_pt = cms.double(50),
+    max_jet_eta = cms.double(2.5),
+    min_pt_for_track_properties = cms.double(0.95),
+    min_pt_for_pfcandidates = cms.double(0.1),
+    use_puppiP4 = cms.bool(False),
+    include_neutrals = cms.bool(True),
+    sort_by_sip2dsig = cms.bool(False),
+    min_puppi_wgt = cms.double(-1.0),
+    flip_ip_sign = cms.bool(False),
+    sip3dSigMax = cms.double(-1.0),
+    use_hlt_features = cms.bool(False),
+    pf_candidates = cms.InputTag("scoutingPFCandidate"),
+    jets = cms.InputTag("scoutingFatPFJetRecluster"),
+    puppi_value_map = cms.InputTag(""),
+    use_scouting_features = cms.bool(True),
+    normchi2_value_map = cms.InputTag("scoutingPFCandidate", "normchi2"),
+    dz_value_map = cms.InputTag("scoutingPFCandidate", "dz"),
+    dxy_value_map = cms.InputTag("scoutingPFCandidate", "dxy"),
+    dzsig_value_map = cms.InputTag("scoutingPFCandidate", "dzsig"),
+    dxysig_value_map = cms.InputTag("scoutingPFCandidate", "dxysig"),
+    lostInnerHits_value_map = cms.InputTag("scoutingPFCandidate", "lostInnerHits"),
+    quality_value_map = cms.InputTag("scoutingPFCandidate", "quality"),
+    trkPt_value_map = cms.InputTag("scoutingPFCandidate", "trkPt"),
+    trkEta_value_map = cms.InputTag("scoutingPFCandidate", "trkEta"),
+    trkPhi_value_map = cms.InputTag("scoutingPFCandidate", "trkPhi"),
+)
+
+from RecoBTag.ONNXRuntime.boostedJetONNXJetTagsProducer_cfi import boostedJetONNXJetTagsProducer
+scoutingFatPFJetReclusterParticleNetJetTags = cms.EDProducer("BoostedJetONNXJetTagsProducer",
+    jets = cms.InputTag("scoutingFatPFJetRecluster"),
+    produceValueMap = cms.untracked.bool(True),
+    src = cms.InputTag("scoutingFatPFJetReclusterParticleNetJetTagInfos"),
+    preprocess_json = cms.string("RecoBTag/Combined/data/Run3Scouting/ParticleNetAK8/General/V00/preprocess.json"),
+    model_path = cms.FileInPath("RecoBTag/Combined/data/Run3Scouting/ParticleNetAK8/General/V00/particle-net.onnx"),
+    flav_names = cms.vstring(["probQCDall", "probHbb","probHcc", "probHqq"]),
+    debugMode = cms.untracked.bool(False),
+)
+
+# AK8 jet softdrop mass
+
+scoutingFatPFJetReclusterSoftDrop = ak4PFJets.clone(
+    src = ("scoutingPFCandidate"),
+    rParam   = 0.8,
+    jetPtMin = 170.0,
+    useSoftDrop = cms.bool(True),
+    zcut = cms.double(0.1),
+    beta = cms.double(0.0),
+    R0   = cms.double(0.8),
+    useExplicitGhosts = cms.bool(True),
+    writeCompound = cms.bool(True),
+    jetCollInstanceName=cms.string("SubJets"),
+)
+
+scoutingFatPFJetReclusterSoftDropMass = cms.EDProducer("RecoJetDeltaRValueMapProducer",
+    src = cms.InputTag("scoutingFatPFJetRecluster"),
+    matched = cms.InputTag("scoutingFatPFJetReclusterSoftDrop"),
+    distMax = cms.double(0.8),
+    value = cms.string("mass")
+)
+
+# AK8 jet regressed mass
+
+scoutingFatPFJetReclusterParticleNetMassRegressionJetTags = cms.EDProducer("BoostedJetONNXJetTagsProducer",
+    jets = cms.InputTag("scoutingFatPFJetRecluster"),
+    produceValueMap = cms.untracked.bool(True),
+    src = cms.InputTag("scoutingFatPFJetReclusterParticleNetJetTagInfos"),
+    preprocess_json = cms.string("RecoBTag/Combined/data/Run3Scouting/ParticleNetAK8/MassRegression/V00/preprocess.json"),
+    model_path = cms.FileInPath("RecoBTag/Combined/data/Run3Scouting/ParticleNetAK8/MassRegression/V00/particle-net.onnx"),
+    flav_names = cms.vstring(["mass"]),
+    debugMode = cms.untracked.bool(False),
+)
+
+# AK8 jet substructure variables 
 
 from RecoJets.JetProducers.ECF_cff import ecfNbeta1
-ak8ScoutingJetEcfNbeta1 = ecfNbeta1.clone(src = cms.InputTag("ak8ScoutingJets"), srcWeights="")
+scoutingFatPFJetReclusterEcfNbeta1 = ecfNbeta1.clone(src = cms.InputTag("scoutingFatPFJetRecluster"), srcWeights="")
 
 from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
-ak8ScoutingJetNjettiness = Njettiness.clone(src = cms.InputTag("ak8ScoutingJets"), srcWeights="")
+scoutingFatPFJetReclusterNjettiness = Njettiness.clone(src = cms.InputTag("scoutingFatPFJetRecluster"), srcWeights="")
 
-ak8ScoutingJetParticleNetJetTagInfos = cms.EDProducer("DeepBoostedJetTagInfoProducer",
-      jet_radius = cms.double( 0.8 ),
-      min_jet_pt = cms.double( 50 ),
-      max_jet_eta = cms.double( 2.5 ),
-      min_pt_for_track_properties = cms.double( 0.95 ),
-      min_pt_for_pfcandidates = cms.double( 0.1 ),
-      use_puppiP4 = cms.bool( False ),
-      include_neutrals = cms.bool( True ),
-      sort_by_sip2dsig = cms.bool( False ),
-      min_puppi_wgt = cms.double( -1.0 ),
-      flip_ip_sign = cms.bool( False ),
-      sip3dSigMax = cms.double( -1.0 ),
-      use_hlt_features = cms.bool( False ),
-      pf_candidates = cms.InputTag( "scoutingPFCands" ),
-      jets = cms.InputTag( "ak8ScoutingJets" ),
-      puppi_value_map = cms.InputTag( "" ),
-      use_scouting_features = cms.bool( True ),
-      normchi2_value_map = cms.InputTag("scoutingPFCands", "normchi2"),
-      dz_value_map = cms.InputTag("scoutingPFCands", "dz"),
-      dxy_value_map = cms.InputTag("scoutingPFCands", "dxy"),
-      dzsig_value_map = cms.InputTag("scoutingPFCands", "dzsig"),
-      dxysig_value_map = cms.InputTag("scoutingPFCands", "dxysig"),
-      lostInnerHits_value_map = cms.InputTag("scoutingPFCands", "lostInnerHits"),
-      quality_value_map = cms.InputTag("scoutingPFCands", "quality"),
-      trkPt_value_map = cms.InputTag("scoutingPFCands", "trkPt"),
-      trkEta_value_map = cms.InputTag("scoutingPFCands", "trkEta"),
-      trkPhi_value_map = cms.InputTag("scoutingPFCands", "trkPhi"),
-  )
+# output AK8 jet to nanoaod::flattable
 
-from RecoBTag.ONNXRuntime.boostedJetONNXJetTagsProducer_cfi import boostedJetONNXJetTagsProducer
-ak8ScoutingJetParticleNetJetTags = cms.EDProducer("BoostedJetONNXJetTagsProducer",
-      jets = cms.InputTag("ak8ScoutingJets"),
-      produceValueMap = cms.untracked.bool(True),
-      src = cms.InputTag("ak8ScoutingJetParticleNetJetTagInfos"),
-      preprocess_json = cms.string("RecoBTag/Combined/data/Run3Scouting/ParticleNetAK8/General/V00/preprocess.json"),
-      model_path = cms.FileInPath("RecoBTag/Combined/data/Run3Scouting/ParticleNetAK8/General/V00/particle-net.onnx"),
-      flav_names = cms.vstring([ "probQCDall", "probHbb", "probHcc", "probHqq"]),
-      debugMode = cms.untracked.bool(False),
-  )
+scoutingFatPFJetReclusterTable = cms.EDProducer("SimplePFJetFlatTableProducer",
+    src = cms.InputTag("scoutingFatPFJetRecluster"),
+    name = cms.string("ScoutingFatPFJetRecluster"),
+    cut = cms.string(""),
+    doc = cms.string("ak8 jet from re-clustering scouting PF Candidates"),
+    singleton = cms.bool(False),
+    extension = cms.bool(False),
+    variables = cms.PSet(
+        P4Vars,
+        area = Var("jetArea()", float, doc="jet catchment area, for JECs",precision=10),
+        # energy fractions
+        chHEF = Var("chargedHadronEnergyFraction()", float, doc="charged Hadron Energy Fraction", precision= 6),
+        neHEF = Var("neutralHadronEnergyFraction()", float, doc="neutral Hadron Energy Fraction", precision= 6),
+        chEmEF = Var("chargedEmEnergyFraction()", float, doc="charged Electromagnetic Energy Fraction", precision= 6),
+        neEmEF = Var("neutralEmEnergyFraction()", float, doc="neutral Electromagnetic Energy Fraction", precision= 6),
+        muEF = Var("muonEnergyFraction()", float, doc="muon Energy Fraction", precision= 6),
+        hfHEF = Var("HFHadronEnergyFraction()",float,doc="hadronic Energy Fraction in HF",precision= 6),
+        hfEmEF = Var("HFEMEnergyFraction()",float,doc="electromagnetic Energy Fraction in HF",precision= 6),
+        # multiplicities
+        nCh = Var("chargedHadronMultiplicity()", int, doc="number of charged hadrons in the jet"),
+        nNh = Var("neutralHadronMultiplicity()", int, doc="number of neutral hadrons in the jet"),
+        nMuons = Var("muonMultiplicity()", int, doc="number of muons in the jet"),
+        nElectrons = Var("electronMultiplicity()", int, doc="number of electrons in the jet"),
+        nPhotons = Var("photonMultiplicity()", int, doc="number of photons in the jet"),
+        nConstituents = Var("numberOfDaughters()", "uint8", doc="number of particles in the jet")
+    ),
+    externalVariables = cms.PSet(
+        # jet tagging probabilities
+        particleNet_prob_QCD = ExtVar(cms.InputTag("scoutingFatPFJetReclusterParticleNetJetTags:probQCDall"), float, doc="ParticleNet probability of QCD", precision=10),
+        particleNet_prob_Hbb = ExtVar(cms.InputTag("scoutingFatPFJetReclusterParticleNetJetTags:probHbb"), float, doc="ParticleNet probability of Hbb", precision=10),
+        particleNet_prob_Hcc = ExtVar(cms.InputTag("scoutingFatPFJetReclusterParticleNetJetTags:probHcc"), float, doc="ParticleNet probability of Hcc", precision=10),
+        particleNet_prob_Hqq = ExtVar(cms.InputTag("scoutingFatPFJetReclusterParticleNetJetTags:probHqq"), float, doc="ParticleNet probability of Hqq", precision=10),
+        # softdrop mass
+        msoftdrop = ExtVar(cms.InputTag("scoutingFatPFJetReclusterSoftDropMass"), float, doc="Softdrop mass", precision=10),
+        # regressed mass
+        particleNet_mass = ExtVar(cms.InputTag("scoutingFatPFJetReclusterParticleNetMassRegressionJetTags:mass"), float, doc="ParticleNet regressed mass", precision=10),
+        # substructure variables    
+        n2b1 = ExtVar(cms.InputTag("scoutingFatPFJetReclusterEcfNbeta1:ecfN2"), float, doc="N2 with beta=1", precision=10),
+        n3b1 = ExtVar(cms.InputTag("scoutingFatPFJetReclusterEcfNbeta1:ecfN3"), float, doc="N3 with beta=1", precision=10),
+        tau1 = ExtVar(cms.InputTag("scoutingFatPFJetReclusterNjettiness:tau1"), float, doc="Nsubjettiness (1 axis)", precision=10),
+        tau2 = ExtVar(cms.InputTag("scoutingFatPFJetReclusterNjettiness:tau2"), float, doc="Nsubjettiness (2 axis)", precision=10),
+        tau3 = ExtVar(cms.InputTag("scoutingFatPFJetReclusterNjettiness:tau3"), float, doc="Nsubjettiness (3 axis)", precision=10),
+        tau4 = ExtVar(cms.InputTag("scoutingFatPFJetReclusterNjettiness:tau4"), float, doc="Nsubjettiness (4 axis)", precision=10),
+    ),
+)
 
-ak8ScoutingJetParticleNetMassRegressionJetTags = cms.EDProducer("BoostedJetONNXJetTagsProducer",
-      jets = cms.InputTag("ak8ScoutingJets"),
-      produceValueMap = cms.untracked.bool(True),
-      src = cms.InputTag("ak8ScoutingJetParticleNetJetTagInfos"),
-      preprocess_json = cms.string("RecoBTag/Combined/data/Run3Scouting/ParticleNetAK8/MassRegression/V00/preprocess.json"),
-      model_path = cms.FileInPath("RecoBTag/Combined/data/Run3Scouting/ParticleNetAK8/MassRegression/V00/particle-net.onnx"),
-      flav_names = cms.vstring(["mass"]),
-      debugMode = cms.untracked.bool(False),
-  )
+# AK8 gen jet matching (only for MC)
 
-ak8ScoutingJetTable = cms.EDProducer("SimplePFJetFlatTableProducer",
-      src = cms.InputTag("ak8ScoutingJets"),
-      name = cms.string("ScoutingFatPFJetRecluster"),
-      cut = cms.string(""),
-      doc = cms.string("ak8 jets from re-clustering scouting PF candidates"),
-      singleton = cms.bool(False),
-      extension = cms.bool(False), # this is the main table
-      externalVariables = cms.PSet(
-         #genJetAK8Idx = ExtVar(cms.InputTag("ak8ScoutingJetMatchGen"), int, doc="gen jet idx"),
-         msoftdrop = ExtVar(cms.InputTag('ak8ScoutingJetsSoftDropMass'), float, doc="Softdrop mass", precision=10),
-         n2b1 = ExtVar(cms.InputTag('ak8ScoutingJetEcfNbeta1:ecfN2'), float, doc="N2 with beta=1", precision=10),
-         n3b1 = ExtVar(cms.InputTag('ak8ScoutingJetEcfNbeta1:ecfN3'), float, doc="N3 with beta=1", precision=10),
-         tau1 = ExtVar(cms.InputTag('ak8ScoutingJetNjettiness:tau1'), float, doc="Nsubjettiness (1 axis)", precision=10),
-         tau2 = ExtVar(cms.InputTag('ak8ScoutingJetNjettiness:tau2'), float, doc="Nsubjettiness (2 axis)", precision=10),
-         tau3 = ExtVar(cms.InputTag('ak8ScoutingJetNjettiness:tau3'), float, doc="Nsubjettiness (3 axis)", precision=10),
-         tau4 = ExtVar(cms.InputTag('ak8ScoutingJetNjettiness:tau4'), float, doc="Nsubjettiness (4 axis)", precision=10),
-         particleNet_mass = ExtVar(cms.InputTag('ak8ScoutingJetParticleNetMassRegressionJetTags:mass'), float, doc="ParticleNet regressed mass", precision=10),
-         particleNet_prob_QCD = ExtVar(cms.InputTag('ak8ScoutingJetParticleNetJetTags:probQCDall'), float, doc="ParticleNet probability of QCD", precision=10),
-         particleNet_prob_Hbb = ExtVar(cms.InputTag('ak8ScoutingJetParticleNetJetTags:probHbb'), float, doc="ParticleNet probability of Hbb", precision=10),
-         particleNet_prob_Hcc = ExtVar(cms.InputTag('ak8ScoutingJetParticleNetJetTags:probHcc'), float, doc="ParticleNet probability of Hcc", precision=10),
-         particleNet_prob_Hqq = ExtVar(cms.InputTag('ak8ScoutingJetParticleNetJetTags:probHqq'), float, doc="ParticleNet probability of Hqq", precision=10),
-      ),
-      variables = cms.PSet(
-         P4Vars,
-         area = Var("jetArea()", float, doc="jet catchment area, for JECs",precision=10),
-         chHEF = Var("chargedHadronEnergy()/(chargedHadronEnergy()+neutralHadronEnergy()+photonEnergy()+electronEnergy()+muonEnergy())", float, doc="charged Hadron Energy Fraction", precision= 6),
-         neHEF = Var("neutralHadronEnergy()/(chargedHadronEnergy()+neutralHadronEnergy()+photonEnergy()+electronEnergy()+muonEnergy())", float, doc="neutral Hadron Energy Fraction", precision= 6),
-         chEmEF = Var("(electronEnergy()+muonEnergy())/(chargedHadronEnergy()+neutralHadronEnergy()+photonEnergy()+electronEnergy()+muonEnergy())", float, doc="charged Electromagnetic Energy Fraction", precision= 6),
-         neEmEF = Var("(photonEnergy())/(chargedHadronEnergy()+neutralHadronEnergy()+photonEnergy()+electronEnergy()+muonEnergy())", float, doc="neutral Electromagnetic Energy Fraction", precision= 6),
-         muEF = Var("(muonEnergy())/(chargedHadronEnergy()+neutralHadronEnergy()+photonEnergy()+electronEnergy()+muonEnergy())", float, doc="muon Energy Fraction", precision= 6),
-         nCh = Var("chargedHadronMultiplicity()", int, doc="number of charged hadrons in the jet"),
-         nNh = Var("neutralHadronMultiplicity()", int, doc="number of neutral hadrons in the jet"),
-         nMuons = Var("muonMultiplicity()", int, doc="number of muons in the jet"),
-         nElectrons = Var("electronMultiplicity()", int, doc="number of electrons in the jet"),
-         nPhotons = Var("photonMultiplicity()", int, doc="number of photons in the jet"),
-         nConstituents = Var("numberOfDaughters()", "uint8", doc="number of particles in the jet")
-      ),
-  )
+scoutingFatPFJetReclusterMatchGen = cms.EDProducer("RecoJetToGenJetDeltaRValueMapProducer",
+    src = cms.InputTag("scoutingFatPFJetRecluster"),
+    matched = cms.InputTag("slimmedGenJetsAK8"),
+    distMax = cms.double(0.8),
+    value = cms.string("index"),
+)
 
-ak8ScoutingJetMatchGen = cms.EDProducer("RecoJetToGenJetDeltaRValueMapProducer",
-      src = cms.InputTag("ak8ScoutingJets"),
-      matched = cms.InputTag("slimmedGenJetsAK8"),
-      distMax = cms.double(0.8),
-      value = cms.string("index"),
-  )
-
-ak8ScoutingJetExtTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
-      src = cms.InputTag("ak8ScoutingJets"),
-      name = cms.string("ScoutingFatPFJetRecluster"),
-      cut = cms.string(""),
-      singleton = cms.bool(False),
-      extension = cms.bool(True),
-      externalVariables = cms.PSet(
-         genJetAK8Idx = ExtVar(cms.InputTag("ak8ScoutingJetMatchGen"), int, doc="gen jet idx"),
-      ),
-      variables = cms.PSet(),
-  )
+scoutingFatPFJetReclusterMatchGenExtensionTable = cms.EDProducer("SimplePFJetFlatTableProducer",
+    src = cms.InputTag("scoutingFatPFJetRecluster"),
+    name = cms.string("ScoutingFatPFJetRecluster"),
+    cut = cms.string(""),
+    singleton = cms.bool(False),
+    extension = cms.bool(True),
+    variables = cms.PSet(),
+    externalVariables = cms.PSet(
+        genJetAK8Idx = ExtVar(cms.InputTag("scoutingFatPFJetReclusterMatchGen"), int, doc="gen jet idx"),
+    ),
+)


### PR DESCRIPTION
#### PR description:

This PR improves ScoutingNano integration with autoNano. This mainly concerns using ScoutingNano flavour in combination with other nano flavours. The primary use case is in scouting vs offline object comparison studies using ScoutingPFMonitor datasets. Currently, ScoutingNano configuration replaces ```nanoSequence``` which is also used in standard nano, making combining ScoutingNano with standard NanoAOD unclear and difficult. While there exist recipes to compose scouting+standard, they are not intuitive and do not use the autoNano functionalities. Hence, this PR implements changes to allow combining scouting+standard with autoNano. This is achieved by creating new ```scoutingNanoSequence``` in the configuration file and not altering standard ```nanoSequence```. For combining scouting+standard, both ```scoutingNanoSequence``` and ```nanoSequence``` will be scheduled on different paths to run. Additionally, in principle, ScoutingNano will be able to combine with other nano flavours in autoNano as well.

The changes also aims to better integrate with T0 processing workflow to prepare for scouting+standard NanoAOD production for ScoutingPFMonitor dataset in the future.

In addition, we use this opportunity to also
- Apply general code clean up.
- Implement customise functions for use with ```cmsDriver.py --customise```:
   - add back scouting tracks and PF candidates after they were dropped in the previous PR for private production
- Reclustered jets use already-implemented energy fractions as opposed to recalculation as expressed in SimplePFJetFlatTable producer.

An accompanying documentation for this change is also available [1]. Examples using autoNano are provided and checked.

#### PR validation:

Pass all tests from ```scram b runtests use-ibeos```
```
Creating test log file logs/el9_amd64_gcc12/testing.log
>> Created tmp/el9_amd64_gcc12/das_client/dasgoclient
Pass   51s ... Configuration/Applications/TestConfigurationApplicationsConfigBuilder
>> Creating project symlinks
Pass   13s ... PhysicsTools/NanoAOD/testPhysicsToolsNanoAODTP
>> Test sequence completed for CMSSW CMSSW_14_2_0_pre1
```
Pass all tests from ```runTheMatrix.py -l limited -i all --ibeos```
```
44 43 41 36 19 1 1 1 1 1 1 tests passed, 0 0 0 0 0 0 0 0 0 0 0 failed
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is not a backport and there is currently no plan for a backport.

[1] https://codimd.web.cern.ch/s/_sVpKamo5