### PR TITLE
Use internal reference counting in CaloCellGeometry

### DIFF
--- a/DataFormats/ParticleFlowReco/interface/PFRecHit.h
+++ b/DataFormats/ParticleFlowReco/interface/PFRecHit.h
@@ -17,6 +17,7 @@
 #include "DataFormats/Common/interface/RefToBase.h"
 
 #include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
+#include "Geometry/CaloGeometry/interface/CaloCellGeometryMayOwnPtr.h"
 
 namespace reco {
 
@@ -50,11 +51,8 @@ namespace reco {
     /// default constructor. Sets energy and position to zero
     PFRecHit() {}
 
-    PFRecHit(std::shared_ptr<const CaloCellGeometry> caloCell,
-             unsigned int detId,
-             PFLayer::Layer layer,
-             float energy,
-             uint32_t flags = 0)
+    PFRecHit(
+        CaloCellGeometryMayOwnPtr caloCell, unsigned int detId, PFLayer::Layer layer, float energy, uint32_t flags = 0)
         : caloCell_(std::move(caloCell)), detId_(detId), layer_(layer), energy_(energy), flags_(flags) {}
 
     /// copy
@@ -139,7 +137,7 @@ namespace reco {
     Neighbours buildNeighbours(unsigned int n) const { return Neighbours(neighbours_.data(), n); }
 
     /// cell geometry
-    std::shared_ptr<const CaloCellGeometry> caloCell_ = nullptr;
+    CaloCellGeometryMayOwnPtr caloCell_;
 
     ///cell detid
     unsigned int detId_ = 0;

--- a/Geometry/CaloGeometry/interface/IdealZPrism.h
+++ b/Geometry/CaloGeometry/interface/IdealZPrism.h
@@ -57,12 +57,8 @@ public:
 
   void vocalCorners(Pt3DVec& vec, const CCGFloat* pv, Pt3D& ref) const override;
 
-  // corrected geom for PF
-  std::shared_ptr<const IdealZPrism> forPF() const {
-    static const auto do_not_delete = [](const void*) {};
-    auto cell = std::shared_ptr<const IdealZPrism>(m_geoForPF.get(), do_not_delete);
-    return cell;
-  }
+  // corrected geom for PF. memory is owned by this object and not transfered to caller.
+  const IdealZPrism* forPF() const { return m_geoForPF.get(); }
 
 private:
   void initCorners(CornersVec&) override;

--- a/RecoParticleFlow/PFClusterProducer/interface/PFEcalBarrelRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFEcalBarrelRecHitCreator.h
@@ -75,7 +75,7 @@ public:
           throw cms::Exception("PFEcalBarrelRecHitCreator") << "detid " << detid.rawId() << "not found in geometry";
         }
 
-        out->emplace_back(thisCell.releaseToShared(), detid.rawId(), PFLayer::ECAL_BARREL, energy, flags);
+        out->emplace_back(std::move(thisCell), detid.rawId(), PFLayer::ECAL_BARREL, energy, flags);
       }
       auto& rh = out->back();
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFEcalEndcapRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFEcalEndcapRecHitCreator.h
@@ -77,7 +77,7 @@ public:
           throw cms::Exception("PFEcalEndcapRecHitCreator") << "detid " << detid.rawId() << "not found in geometry";
         }
 
-        out->emplace_back(thisCell.releaseToShared(), detid.rawId(), PFLayer::ECAL_ENDCAP, energy);
+        out->emplace_back(std::move(thisCell), detid.rawId(), PFLayer::ECAL_ENDCAP, energy);
       }
       auto& rh = out->back();
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHBHERecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHBHERecHitCreator.h
@@ -69,7 +69,7 @@ public:
         continue;
       }
 
-      reco::PFRecHit rh(thisCell.releaseToShared(), detid.rawId(), layer, energy);
+      reco::PFRecHit rh(std::move(thisCell), detid.rawId(), layer, energy);
       rh.setTime(time);  //Mike: This we will use later
       rh.setDepth(depth);
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHFRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHFRecHitCreator.h
@@ -63,7 +63,7 @@ public:
       auto thisCellTemp = hcalGeo->getGeometry(detid);
       auto zp = dynamic_cast<IdealZPrism const*>(thisCellTemp.get());
       assert(zp);
-      auto thisCell = zp->forPF();
+      CaloCellGeometryPtr thisCell{zp->forPF()};
 
       // find rechit geometry
       if (!thisCell) {
@@ -74,7 +74,7 @@ public:
 
       PFLayer::Layer layer = depth == 1 ? PFLayer::HF_EM : PFLayer::HF_HAD;
 
-      reco::PFRecHit rh(thisCell, detid.rawId(), layer, energy);
+      reco::PFRecHit rh(CaloCellGeometryMayOwnPtr(thisCell), detid.rawId(), layer, energy);
       rh.setTime(time);
       rh.setDepth(depth);
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHGCalRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHGCalRecHitCreator.h
@@ -71,7 +71,7 @@ public:
         continue;
       }
 
-      reco::PFRecHit rh(thisCell.releaseToShared(), detid.rawId(), Layer, energy);
+      reco::PFRecHit rh(std::move(thisCell), detid.rawId(), Layer, energy);
 
       bool rcleaned = false;
       bool keep = true;

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHcalRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHcalRecHitCreator.h
@@ -69,7 +69,7 @@ public:
         continue;
       }
 
-      reco::PFRecHit rh(thisCell.releaseToShared(), detid.rawId(), Layer, energy);
+      reco::PFRecHit rh(std::move(thisCell), detid.rawId(), Layer, energy);
       rh.setTime(time);  //Mike: This we will use later
       rh.setDepth(depth);
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFPSRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFPSRecHitCreator.h
@@ -70,7 +70,7 @@ public:
         continue;
       }
 
-      out->emplace_back(thisCell.releaseToShared(), detid.rawId(), layer, energy);
+      out->emplace_back(std::move(thisCell), detid.rawId(), layer, energy);
       auto& rh = out->back();
       rh.setDepth(detid.plane());
       rh.setTime(erh.time());

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFBadHcalPseudoClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFBadHcalPseudoClusterProducer.cc
@@ -133,7 +133,7 @@ void PFBadHcalPseudoClusterProducer::init(const EventSetup& iSetup) {
     // make a PF RecHit
     auto thisCell = (barrel ? hbGeom : heGeom)->getGeometry(id);
     const GlobalPoint& pos = thisCell->getPosition();
-    badAreasRH_.emplace_back(thisCell.releaseToShared(), id(), layer, dummyEnergy);
+    badAreasRH_.emplace_back(std::move(thisCell), id(), layer, dummyEnergy);
     // make a PF cluster (but can't add the rechit, as for that I need an edm::Ref)
     badAreasC_.emplace_back(layer, dummyEnergy, pos.x(), pos.y(), pos.z());
     badAreasC_.back().setFlags(reco::CaloCluster::badHcalMarker);

--- a/RecoParticleFlow/PFRecHitProducer/plugins/LegacyPFRecHitProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/LegacyPFRecHitProducer.cc
@@ -58,11 +58,11 @@ void LegacyPFRecHitProducer::produce(edm::Event& event, const edm::EventSetup& s
   if (alpakaPfRecHits.metadata().size() != 0) {
     out.reserve(alpakaPfRecHits.size());
     for (size_t i = 0; i < alpakaPfRecHits.size(); i++) {
-      reco::PFRecHit& pfrh = out.emplace_back(
-          caloGeo_.at(alpakaPfRecHits[i].layer())->getGeometry(alpakaPfRecHits[i].detId()).releaseToShared(),
-          alpakaPfRecHits[i].detId(),
-          alpakaPfRecHits[i].layer(),
-          alpakaPfRecHits[i].energy());
+      reco::PFRecHit& pfrh =
+          out.emplace_back(caloGeo_.at(alpakaPfRecHits[i].layer())->getGeometry(alpakaPfRecHits[i].detId()),
+                           alpakaPfRecHits[i].detId(),
+                           alpakaPfRecHits[i].layer(),
+                           alpakaPfRecHits[i].energy());
       pfrh.setTime(alpakaPfRecHits[i].time());
       pfrh.setDepth(alpakaPfRecHits[i].depth());
 


### PR DESCRIPTION
#### PR description:

This removes the need for std::shared_ptr in PFRecHit and should reduce memory usage.

#### PR validation:

Code compiles. Ran workflow 141.046 and it worked fine.