### PR TITLE
[UBSAN][L1/CSCTriggerPrimitives] avoid large shift exponent

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
@@ -686,7 +686,7 @@ bool CSCAnodeLCTProcessor::patternDetection(
                 // find at what bx did pulse on this wire&layer start
                 // use hit_pesrist constraint on how far back we can go
                 int first_bx_layer = first_bx[key_wire] + drift_delay;
-                for (unsigned int dbx = 0; dbx < hit_persist; dbx++) {
+                for (unsigned int dbx = 0; (dbx < hit_persist) && (first_bx_layer > 0); dbx++) {
                   if (pulse_.isOneShotHighAtBX(i_layer, this_wire, first_bx_layer - 1)) {
                     first_bx_layer--;
                   } else


### PR DESCRIPTION
This PR proposes an extra check to avoid large shift exponent. As explained in #46406 , for `first_bx_layer=0` the shift exponent `first_bx_layer-1` is too large. 

Fixes #46406