### PR TITLE
use `ReadPrescalesFromFile=False` in the `GenericTriggerEventFlag` of a bunch of DQM modules

### DIFF
--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
@@ -74,18 +74,19 @@ stage2L1Trigger.toModify(SiStripMonitorClusterBPTX,
                              stage2 = cms.bool(True),
                              l1tAlgBlkInputTag = cms.InputTag("gtStage2Digis"),
                              l1tExtBlkInputTag = cms.InputTag("gtStage2Digis"),
-                             ReadPrescalesFromFile = cms.bool(True)
+                             ReadPrescalesFromFile = cms.bool(False)
                          ),
                          PixelDCSfilter = dict(
                              stage2 = cms.bool(True),
                              l1tAlgBlkInputTag = cms.InputTag("gtStage2Digis"),
                              l1tExtBlkInputTag = cms.InputTag("gtStage2Digis"),
-                             ReadPrescalesFromFile = cms.bool(True)),
+                             ReadPrescalesFromFile = cms.bool(False)
+                         ),
                          StripDCSfilter = dict(
                              stage2 = cms.bool(True),
                              l1tAlgBlkInputTag = cms.InputTag("gtStage2Digis"),
                              l1tExtBlkInputTag = cms.InputTag("gtStage2Digis"),
-                             ReadPrescalesFromFile = cms.bool(True)
+                             ReadPrescalesFromFile = cms.bool(False)
                          )
                         )
 

--- a/DQMOffline/Trigger/python/BPHMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/BPHMonitor_cfi.py
@@ -124,9 +124,10 @@ stage2L1Trigger.toModify(hltBPHmonitoring,
                          numGenericTriggerEventPSet = dict(stage2 = cms.bool(True),
                                                            l1tAlgBlkInputTag = cms.InputTag("gtStage2Digis"),
                                                            l1tExtBlkInputTag = cms.InputTag("gtStage2Digis"),
-                                                           ReadPrescalesFromFile = cms.bool(True)),
+                                                           ReadPrescalesFromFile = cms.bool(False)),
                          denGenericTriggerEventPSet = dict(stage2 = cms.bool(True),
                                                            l1tAlgBlkInputTag = cms.InputTag("gtStage2Digis"),
                                                            l1tExtBlkInputTag = cms.InputTag("gtStage2Digis"),
-                                                           ReadPrescalesFromFile = cms.bool(True)))
+                                                           ReadPrescalesFromFile = cms.bool(False))
+                         )
 

--- a/DQMOffline/Trigger/python/JetMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/JetMonitor_cfi.py
@@ -48,10 +48,11 @@ stage2L1Trigger.toModify(hltJetMETmonitoring,
                          numGenericTriggerEventPSet = dict(stage2 = cms.bool(True),
                                                            l1tAlgBlkInputTag = cms.InputTag("gtStage2Digis"),
                                                            l1tExtBlkInputTag = cms.InputTag("gtStage2Digis"),
-                                                           ReadPrescalesFromFile = cms.bool(True)),
+                                                           ReadPrescalesFromFile = cms.bool(False)),
                          denGenericTriggerEventPSet = dict(stage2 = cms.bool(True),
                                                            l1tAlgBlkInputTag = cms.InputTag("gtStage2Digis"),
                                                            l1tExtBlkInputTag = cms.InputTag("gtStage2Digis"),
-                                                           ReadPrescalesFromFile = cms.bool(True)))
+                                                           ReadPrescalesFromFile = cms.bool(False))
+                         )
 
 

--- a/DQMOffline/Trigger/python/METMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/METMonitor_cfi.py
@@ -46,10 +46,10 @@ stage2L1Trigger.toModify(hltMETmonitoring,
                          numGenericTriggerEventPSet = dict(stage2 = cms.bool(True),
                                                            l1tAlgBlkInputTag = cms.InputTag("gtStage2Digis"),
                                                            l1tExtBlkInputTag = cms.InputTag("gtStage2Digis"),
-                                                           ReadPrescalesFromFile = cms.bool(True)),
+                                                           ReadPrescalesFromFile = cms.bool(False)),
                          denGenericTriggerEventPSet = dict(stage2 = cms.bool(True),
                                                            l1tAlgBlkInputTag = cms.InputTag("gtStage2Digis"),
                                                            l1tExtBlkInputTag = cms.InputTag("gtStage2Digis"),
-                                                           ReadPrescalesFromFile = cms.bool(True)))
+                                                           ReadPrescalesFromFile = cms.bool(False)))
 
 

--- a/DQMOffline/Trigger/python/MuonMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/MuonMonitor_cfi.py
@@ -48,10 +48,11 @@ stage2L1Trigger.toModify(hltMuonmonitoring,
                          numGenericTriggerEventPSet = dict(stage2 = cms.bool(True),
                                                            l1tAlgBlkInputTag = cms.InputTag("gtStage2Digis"),
                                                            l1tExtBlkInputTag = cms.InputTag("gtStage2Digis"),
-                                                           ReadPrescalesFromFile = cms.bool(True)),
+                                                           ReadPrescalesFromFile = cms.bool(False)),
                          denGenericTriggerEventPSet = dict(stage2 = cms.bool(True),
                                                            l1tAlgBlkInputTag = cms.InputTag("gtStage2Digis"),
                                                            l1tExtBlkInputTag = cms.InputTag("gtStage2Digis"),
-                                                           ReadPrescalesFromFile = cms.bool(True)))
+                                                           ReadPrescalesFromFile = cms.bool(False))
+                         )
 
 


### PR DESCRIPTION
#### PR description:

Spinned off from https://github.com/cms-sw/cmssw/issues/46448#issuecomment-2441180113. 
Reading L1T prescales from an 8 years old file looks wrong. Should help mitigating https://github.com/cms-sw/cmssw/issues/46448. 

#### PR validation:

None, other than compiling

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Will be backported to active data-taking cycles if validates OK