### PR TITLE
QTest Tracking Summary DQM (BP to 14_1_X)

### DIFF
--- a/DQM/SiStripMonitorClient/data/sistrip_qualitytest_config_tier0_cosmic.xml
+++ b/DQM/SiStripMonitorClient/data/sistrip_qualitytest_config_tier0_cosmic.xml
@@ -77,7 +77,7 @@
       <PARAM name="useSigma">0</PARAM>
       <PARAM name="useRange">1</PARAM>
       <PARAM name="minEntries">0</PARAM>
-      <PARAM name="xmin">15.0</PARAM>
+      <PARAM name="xmin">10.0</PARAM>
       <PARAM name="xmax">50.0</PARAM>
 </QTEST>
 <QTEST name="MeanWithinExpectedRange:StoNTOB">
@@ -89,7 +89,7 @@
       <PARAM name="useSigma">0</PARAM>
       <PARAM name="useRange">1</PARAM>
       <PARAM name="minEntries">0</PARAM>
-      <PARAM name="xmin">15.0</PARAM>
+      <PARAM name="xmin">10.0</PARAM>
       <PARAM name="xmax">50.0</PARAM>
 </QTEST>
 <QTEST name="MeanWithinExpectedRange:StoNTEC">
@@ -101,7 +101,7 @@
       <PARAM name="useSigma">0</PARAM>
       <PARAM name="useRange">1</PARAM>
       <PARAM name="minEntries">0</PARAM>
-      <PARAM name="xmin">15.0</PARAM>
+      <PARAM name="xmin">10.0</PARAM>
       <PARAM name="xmax">50.0</PARAM>
 </QTEST>
 <QTEST name="MeanWithinExpectedRange:StoNTID">
@@ -113,7 +113,7 @@
       <PARAM name="useSigma">0</PARAM>
       <PARAM name="useRange">1</PARAM>
       <PARAM name="minEntries">0</PARAM>
-      <PARAM name="xmin">15.0</PARAM>
+      <PARAM name="xmin">10.0</PARAM>
       <PARAM name="xmax">50.0</PARAM>
 </QTEST>
 <QTEST name="MeanWithinExpectedRange:TrkRate" activate="true">

--- a/DQM/TrackingMonitorClient/data/tracking_qualitytest_config_tier0_cosmic.xml
+++ b/DQM/TrackingMonitorClient/data/tracking_qualitytest_config_tier0_cosmic.xml
@@ -31,6 +31,30 @@
      <PARAM name="xmin">-1.1</PARAM> 
      <PARAM name="xmax">1.1</PARAM> 
 </QTEST>
+<QTEST name="MeanWithinExpectedRange:SeedNStrip" activate="true">
+     <TYPE>MeanWithinExpected</TYPE>
+      <PARAM name="error">0.05</PARAM>
+      <PARAM name="warning">0.3</PARAM>
+      <PARAM name="mean">1.0</PARAM>
+      <PARAM name="useRMS">0</PARAM>
+      <PARAM name="useSigma">0</PARAM>
+      <PARAM name="useRange">1</PARAM>
+      <PARAM name="minEntries">0</PARAM>
+      <PARAM name="xmin">0.0</PARAM>
+      <PARAM name="xmax">200.0</PARAM>
+</QTEST>
+<QTEST name="MeanWithinExpectedRange:SeedNPixel" activate="true">
+     <TYPE>MeanWithinExpected</TYPE>
+      <PARAM name="error">0.05</PARAM>
+      <PARAM name="warning">0.3</PARAM>
+      <PARAM name="mean">1.0</PARAM>
+      <PARAM name="useRMS">0</PARAM>
+      <PARAM name="useSigma">0</PARAM>
+      <PARAM name="useRange">1</PARAM>
+      <PARAM name="minEntries">0</PARAM>
+      <PARAM name="xmin">0.0</PARAM>
+      <PARAM name="xmax">800.0</PARAM>
+</QTEST>
 
 <LINK name="*TrackParameters/GeneralProperties/NumberOfTracks_CKFTk">
   <TestName activate="true">MeanWithinExpectedRange:TrkRate</TestName>
@@ -43,5 +67,11 @@
 </LINK>
 <LINK name="*TrackParameters/GeneralProperties/FractionOfGoodTracks_CKFTk">
   <TestName activate="true">XrangeWithin:FractionOfGoodTracks</TestName>
+</LINK>
+<LINK name="SiStrip/MechanicalView/NumberOfClustersInStrip">
+  <TestName activate="true">MeanWithinExpectedRange:SeedNStrip</TestName>
+</LINK>
+<LINK name="SiStrip/MechanicalView/NumberOfClustersInPixel">
+  <TestName activate="true">MeanWithinExpectedRange:SeedNPixel</TestName>
 </LINK>
 </TESTSCONFIGURATION>

--- a/DQM/TrackingMonitorClient/python/TrackingClientConfig_Tier0_Cosmic_cff.py
+++ b/DQM/TrackingMonitorClient/python/TrackingClientConfig_Tier0_Cosmic_cff.py
@@ -22,6 +22,16 @@ trackingOfflineAnalyser = DQMEDHarvester("TrackingOfflineDQM",
              dir        = cms.string("TrackParameters/HitProperties"),
              name       = cms.string("NumberOfRecHitsPerTrack_"),
          ),
+         cms.PSet(
+             QT         = cms.string("SeedNStrip"),
+             dir        = cms.string("SiStrip/MechanicalView"),
+             name       = cms.string("NumberOfClustersInStrip"),
+         ),
+         cms.PSet(
+             QT         = cms.string("SeedNPixel"),
+             dir        = cms.string("SiStrip/MechanicalView"),
+             name       = cms.string("NumberOfClustersInPixel"),
+         )
     ),
     TrackingLSQualityPSets = cms.VPSet(
          cms.PSet(

--- a/DQM/TrackingMonitorClient/src/TrackingQualityChecker.cc
+++ b/DQM/TrackingMonitorClient/src/TrackingQualityChecker.cc
@@ -304,6 +304,10 @@ void TrackingQualityChecker::fillTrackingStatus(DQMStore::IBooker& ibooker, DQMS
     std::string MEname = it->second.HistoName;
 
     std::vector<MonitorElement*> tmpMEvec = igetter.getContents(ibooker.pwd() + "/" + localMEdirpath);
+    //SeedNStrip and SeedNPixel DQM plots are in SiStrip folder (not inside Tracking folder)
+    if (it->first == "SeedNStrip" or it->first == "SeedNPixel") {
+      tmpMEvec = igetter.getContents(localMEdirpath);
+    }
     if (verbose_)
       edm::LogInfo("TrackingQualityChecker") << "fillTrackingStatus tmpMEvec: " << tmpMEvec.size() << std::endl;
     MonitorElement* me = nullptr;
@@ -410,6 +414,7 @@ void TrackingQualityChecker::fillTrackingStatus(DQMStore::IBooker& ibooker, DQMS
                   << "fillTrackingStatus qt_reports: " << qt_reports.size() << std::endl;
             // loop on possible QTs
             for (auto iQT : qt_reports) {
+              tmp_status = 0;  // reset status
               tmp_status += iQT->getQTresult();
               if (verbose_)
                 edm::LogInfo("TrackingQualityChecker") << "fillTrackingStatus iQT: " << iQT->getQRName() << std::endl;


### PR DESCRIPTION
#### PR description:

Offline DQM GUI for Cosmics runs: 

- add two QTests in Tracking Summary to monitor Number of Clusters in Pixel and Strip (warning: 800 and 200, hard cut limit: 1000 and 300)
  - motivation of this change: https://cms-talk.web.cern.ch/t/significant-reduction-in-the-number-of-cosmics-tracks/48672
  - recent PR to increase of limit on Number of Pixel Clusters: #46283 
- change S/N minimum value: lower from 15 to 10 (TIB L1, TID and TEC 7/8/9 mean S/N is close to 15, due to radiation damage)
 
#### PR validation:

DQM plots production:

- cmsDriver.py step1 -s RAW2DIGI,L1Reco,RECO,DQM -n 1000 --eventcontent DQM --datatier DQMIO --conditions 140X_dataRun3_Prompt_v4  --filein file:/eos/cms/store/data/Run2024G/Cosmics/RAW/v1/000/385/054/00000/01253f11-88ba-4d33-8cc8-545c2a8b8d65.root  --scenario cosmics --data --no_exec --python_filename=runFirst.py --era Run3_2024 

- cmsRun runFirst.py 

QTest execution on DQM plots:

- cmsDriver.py step3_DT1_1 -s HARVESTING:dqmHarvesting --filein file:step1_RAW2DIGI_L1Reco_RECO_DQM.root --filetype DQM --scenario cosmics --data --no_exec --conditions 140X_dataRun3_Prompt_v4 --python_filename=runSecond.py --era Run3_2024 

- cmsRun runSecond.py 

Results checked in [private Offline QUI](http://prova1234.cern.ch:8080/dqm/offline/ ) (to access need lxplus tunneling):

[385054](https://tinyurl.com/yrv29t6k )

#### About backport:

This is a Backport to 14_1_X of PR #46532