### PR TITLE
[UBSAN]Suppess -ve shift error for ReduceMantissaToNbitsRounding

### DIFF
--- a/DataFormats/Math/interface/libminifloat.h
+++ b/DataFormats/Math/interface/libminifloat.h
@@ -51,6 +51,10 @@ public:
 
   class ReduceMantissaToNbitsRounding {
   public:
+#ifdef CMS_UNDEFINED_SANITIZER
+    //Supress UBSan runtime error about -ve shift. This happens when bits==23
+    __attribute__((no_sanitize("shift")))
+#endif
     ReduceMantissaToNbitsRounding(int bits)
         : shift(23 - bits), mask((0xFFFFFFFF >> (shift)) << (shift)), test(1 << (shift - 1)), maxn((1 << bits) - 2) {
       assert(bits <= 23);  // "max mantissa size is 23 bits"


### PR DESCRIPTION
This PR suggests to suppress the `-ve shift exponent` runtime error from DataFormats/Math/interface/libminifloat.h [a] . 
There is discussion at https://github.com/cms-sw/cmssw/issues/29564 to improve `ReduceMantissaToNbitsRounding` so may be if we follow that direction then change in this PR is not needed.

[a] https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/raw/el8_amd64_gcc12/CMSSW_14_2_UBSAN_X_2024-10-25-2300/pyRelValMatrixLogs/run/139.005_AlCaPhiSym2021/step3_AlCaPhiSym2021.log
```
src/DataFormats/Math/interface/libminifloat.h:61:78: runtime error: shift exponent -1 is negative
    #0 0x7fc173925d59 in MiniFloatConverter::ReduceMantissaToNbitsRounding::ReduceMantissaToNbitsRounding(int) src/DataFormats/Math/interface/libminifloat.h:61
    #1 0x7fc1739cfe6d in void MiniFloatConverter::reduceMantissaToNbitsRounding<__gnu_cxx::__normal_iterator<float*, std::vector<float, std::allocator<float> > >, __gnu_cxx::__normal_iterator<float*, std::vector<float, std::allocator<float> > > >(int, __gnu_cxx::__normal_iterator<float*, std::vector<float, std::allocator<float> > >, __gnu_cxx::__normal_iterator<float*, std::vector<float, std::allocator<float> > >, __gnu_cxx::__normal_iterator<float*, std::vector<float, std::allocator<float> > >) src/DataFormats/Math/interface/libminifloat.h:96
    #2 0x7fc1739cfe6d in void nanoaod::flatTableHelper::MaybeMantissaReduce<float>::bulk<edm::Span<__gnu_cxx::__normal_iterator<float*, std::vector<float, std::allocator<float> > > > >(edm::Span<__gnu_cxx::__normal_iterator<float*, std::vector<float, std::allocator<float> > > >&&) const src/DataFormats/NanoAOD/interface/FlatTable.h:33
    #3 0x7fc1739cfe6d in void nanoaod::FlatTable::addColumn<float, std::vector<float, std::allocator<float> > >(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<float, std::allocator<float> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int) src/DataFormats/NanoAOD/interface/FlatTable.h:127
    #4 0x7fc1739d4fb8 in FuncVariable<EcalPhiSymRecHit, StringObjectFunction<EcalPhiSymRecHit, false>, float>::fill(std::vector<EcalPhiSymRecHit const*, std::allocator<EcalPhiSymRecHit const*> >&, nanoaod::FlatTable&) const src/PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h:68
    #5 0x7fc1739b40b1 in RunSimpleFlatTableProducer<EcalPhiSymRecHit, std::vector<EcalPhiSymRecHit, std::allocator<EcalPhiSymRecHit> > >::fillTable(edm::Run const&, edm::Handle<std::vector<EcalPhiSymRecHit, std::allocator<EcalPhiSymRecHit> > > const&) const src/PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h:862
    #6 0x7fc1739e63f4 in SimpleFlatTableProducerBaseRun<EcalPhiSymRecHit, std::vector<EcalPhiSymRecHit, std::allocator<EcalPhiSymRecHit> > >::endRunProduce(edm::Run&, edm::EventSetup const&) src/PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h:799
```