### PR TITLE
Run3-hcx378Y Backport of #46520 to read old ZDC geometry from DB correctly where dense index was not stored

### DIFF
--- a/Geometry/ForwardGeometry/plugins/moduleDB.cc
+++ b/Geometry/ForwardGeometry/plugins/moduleDB.cc
@@ -1,8 +1,12 @@
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DataFormats/HcalDetId/interface/HcalZDCDetId.h"
 #include "Geometry/CaloEventSetup/interface/CaloGeometryDBEP.h"
 #include "Geometry/CaloEventSetup/interface/CaloGeometryDBReader.h"
 #include "Geometry/ForwardGeometry/interface/ZdcGeometry.h"
 #include "Geometry/ForwardGeometry/interface/CaloGeometryDBZdc.h"
 #include "Geometry/ForwardGeometry/interface/CastorGeometry.h"
+
+//#define EDM_ML_DEBUG
 
 template class CaloGeometryDBEP<CastorGeometry, CaloGeometryDBReader>;
 
@@ -18,7 +22,7 @@ CaloGeometryDBEP<ZdcGeometry, CaloGeometryDBReader>::produceAligned(const typena
   TrVec tvec;
   DimVec dvec;
   IVec ivec;
-  IVec dins;
+  std::vector<uint32_t> dins;
 
   const auto& pG = iRecord.get(geometryToken_);
 
@@ -27,91 +31,182 @@ CaloGeometryDBEP<ZdcGeometry, CaloGeometryDBReader>::produceAligned(const typena
   ivec = pG.getIndexes();
   dins = pG.getDenseIndices();
   //*********************************************************************************************
-
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("ZDCGeometry") << "ZDCGeometry sizes " << tvec.size() << ":" << dvec.size() << ":" << ivec.size()
+                                  << ":" << dins.size();
+#endif
   const auto& zdcTopology = iRecord.get(additionalTokens_.topology);
 
   assert(dvec.size() <= ZdcGeometry::k_NumberOfShapes * ZdcGeometry::k_NumberOfParametersPerShape);
   ZdcGeometry* zdcGeometry = new ZdcGeometry(&zdcTopology);
   PtrType ptr(zdcGeometry);
 
-  const unsigned int nTrParm(tvec.size() / zdcTopology.kSizeForDenseIndexing());
+  if (dins.size() > 0) {
+    const unsigned int nTrParm(tvec.size() / zdcTopology.kSizeForDenseIndexing());
 
-  assert(dvec.size() == ZdcGeometry::k_NumberOfShapes * ZdcGeometry::k_NumberOfParametersPerShape);
+    assert(dvec.size() == ZdcGeometry::k_NumberOfShapes * ZdcGeometry::k_NumberOfParametersPerShape);
 
-  ptr->fillDefaultNamedParameters();
+    ptr->fillDefaultNamedParameters();
 
-  ptr->allocateCorners(zdcTopology.kSizeForDenseIndexing());
-  ptr->allocatePar(zdcGeometry->numberOfShapes(), ZdcGeometry::k_NumberOfParametersPerShape);
+    ptr->allocateCorners(zdcTopology.kSizeForDenseIndexing());
+    ptr->allocatePar(zdcGeometry->numberOfShapes(), ZdcGeometry::k_NumberOfParametersPerShape);
+#ifdef EDM_ML_DEBUG
+    edm::LogVerbatim("ZDCGeometry") << "ZDCGeometry:Allocate corners and Par";
+#endif
+    for (unsigned int i(0); i < dins.size(); ++i) {
+      const unsigned int nPerShape(ZdcGeometry::k_NumberOfParametersPerShape);
+      DimVec dims;
+      dims.reserve(nPerShape);
 
-  for (unsigned int i(0); i < dins.size(); ++i) {
-    const unsigned int nPerShape(ZdcGeometry::k_NumberOfParametersPerShape);
-    DimVec dims;
-    dims.reserve(nPerShape);
+      const unsigned int indx(ivec.size() == 1 ? 0 : i);
 
-    const unsigned int indx(ivec.size() == 1 ? 0 : i);
+      DimVec::const_iterator dsrc(dvec.begin() + ivec[indx] * nPerShape);
 
-    DimVec::const_iterator dsrc(dvec.begin() + ivec[indx] * nPerShape);
+      for (unsigned int j(0); j != nPerShape; ++j) {
+        dims.emplace_back(*dsrc);
+        ++dsrc;
+      }
 
-    for (unsigned int j(0); j != nPerShape; ++j) {
-      dims.emplace_back(*dsrc);
-      ++dsrc;
+      const CCGFloat* myParm(CaloCellGeometry::getParmPtr(dims, ptr->parMgr(), ptr->parVecVec()));
+
+      const DetId id(zdcTopology.denseId2detId(dins[i]));
+
+      const unsigned int iGlob(nullptr == globalPtr ? 0 : ZdcGeometry::alignmentTransformIndexGlobal(id));
+
+      assert(nullptr == globalPtr || iGlob < globalPtr->m_align.size());
+
+      const AlignTransform* gt(nullptr == globalPtr ? nullptr : &globalPtr->m_align[iGlob]);
+
+      assert(nullptr == gt || iGlob == ZdcGeometry::alignmentTransformIndexGlobal(DetId(gt->rawId())));
+
+      const unsigned int iLoc(nullptr == alignPtr ? 0 : ZdcGeometry::alignmentTransformIndexLocal(id));
+
+      assert(nullptr == alignPtr || iLoc < alignPtr->m_align.size());
+
+      const AlignTransform* at(nullptr == alignPtr ? nullptr : &alignPtr->m_align[iLoc]);
+
+      assert(nullptr == at || (ZdcGeometry::alignmentTransformIndexLocal(DetId(at->rawId())) == iLoc));
+
+      const CaloGenericDetId gId(id);
+
+      Pt3D lRef;
+      Pt3DVec lc(8, Pt3D(0, 0, 0));
+      zdcGeometry->localCorners(lc, &dims.front(), dins[i], lRef);
+
+      const Pt3D lBck(0.25 * (lc[4] + lc[5] + lc[6] + lc[7]));  // ctr rear  face in local
+      const Pt3D lCor(lc[0]);
+
+      //----------------------------------- create transform from 6 numbers ---
+      const unsigned int jj(i * nTrParm);
+      Tr3D tr;
+      const ROOT::Math::Translation3D tl(tvec[jj], tvec[jj + 1], tvec[jj + 2]);
+      const ROOT::Math::EulerAngles ea(6 == nTrParm ? ROOT::Math::EulerAngles(tvec[jj + 3], tvec[jj + 4], tvec[jj + 5])
+                                                    : ROOT::Math::EulerAngles());
+      const ROOT::Math::Transform3D rt(ea, tl);
+      double xx, xy, xz, dx, yx, yy, yz, dy, zx, zy, zz, dz;
+      rt.GetComponents(xx, xy, xz, dx, yx, yy, yz, dy, zx, zy, zz, dz);
+      tr = Tr3D(CLHEP::HepRep3x3(xx, xy, xz, yx, yy, yz, zx, zy, zz), CLHEP::Hep3Vector(dx, dy, dz));
+
+      // now prepend alignment(s) for final transform
+      const Tr3D atr(nullptr == at ? tr
+                                   : (nullptr == gt ? at->transform() * tr : at->transform() * gt->transform() * tr));
+      //--------------------------------- done making transform  ---------------
+
+      const Pt3D gRef(atr * lRef);
+      const GlobalPoint fCtr(gRef.x(), gRef.y(), gRef.z());
+      const Pt3D gBck(atr * lBck);
+      const GlobalPoint fBck(gBck.x(), gBck.y(), gBck.z());
+      const Pt3D gCor(atr * lCor);
+      const GlobalPoint fCor(gCor.x(), gCor.y(), gCor.z());
+
+      assert(zdcTopology.detId2denseId(id) == dins[i]);
+
+      ptr->newCell(fCtr, fBck, fCor, myParm, id);
+#ifdef EDM_ML_DEBUG
+      edm::LogVerbatim("ZDCGeometry") << "ZDCGeometry Insert cell " << i << ":" << HcalZDCDetId(id);
+#endif
     }
+  } else {
+    const unsigned int nTrParm(tvec.size() / HcalZDCDetId::kSizeForDenseIndexingRun1);
 
-    const CCGFloat* myParm(CaloCellGeometry::getParmPtr(dims, ptr->parMgr(), ptr->parVecVec()));
+    assert(dvec.size() == ZdcGeometry::k_NumberOfShapes * ZdcGeometry::k_NumberOfParametersPerShape);
 
-    const DetId id(zdcTopology.denseId2detId(dins[i]));
+    ptr->fillDefaultNamedParameters();
+    ptr->allocateCorners(HcalZDCDetId::kSizeForDenseIndexingRun1);
+    ptr->allocatePar(zdcGeometry->numberOfShapes(), ZdcGeometry::k_NumberOfParametersPerShape);
+#ifdef EDM_ML_DEBUG
+    edm::LogVerbatim("ZDCGeometry") << "ZDCGeometry:Allocate corners and Par";
+#endif
+    for (unsigned int i(0); i != HcalZDCDetId::kSizeForDenseIndexingRun1; ++i) {
+      const unsigned int nPerShape(ZdcGeometry::k_NumberOfParametersPerShape);
+      DimVec dims;
+      dims.reserve(nPerShape);
 
-    const unsigned int iGlob(nullptr == globalPtr ? 0 : ZdcGeometry::alignmentTransformIndexGlobal(id));
+      const unsigned int indx(ivec.size() == 1 ? 0 : i);
 
-    assert(nullptr == globalPtr || iGlob < globalPtr->m_align.size());
+      DimVec::const_iterator dsrc(dvec.begin() + ivec[indx] * nPerShape);
 
-    const AlignTransform* gt(nullptr == globalPtr ? nullptr : &globalPtr->m_align[iGlob]);
+      for (unsigned int j(0); j != nPerShape; ++j) {
+        dims.emplace_back(*dsrc);
+        ++dsrc;
+      }
 
-    assert(nullptr == gt || iGlob == ZdcGeometry::alignmentTransformIndexGlobal(DetId(gt->rawId())));
+      const CCGFloat* myParm(CaloCellGeometry::getParmPtr(dims, ptr->parMgr(), ptr->parVecVec()));
 
-    const unsigned int iLoc(nullptr == alignPtr ? 0 : ZdcGeometry::alignmentTransformIndexLocal(id));
+      const DetId id(zdcTopology.denseId2detId(i));
 
-    assert(nullptr == alignPtr || iLoc < alignPtr->m_align.size());
+      const unsigned int iGlob(nullptr == globalPtr ? 0 : ZdcGeometry::alignmentTransformIndexGlobal(id));
 
-    const AlignTransform* at(nullptr == alignPtr ? nullptr : &alignPtr->m_align[iLoc]);
+      assert(nullptr == globalPtr || iGlob < globalPtr->m_align.size());
 
-    assert(nullptr == at || (ZdcGeometry::alignmentTransformIndexLocal(DetId(at->rawId())) == iLoc));
+      const AlignTransform* gt(nullptr == globalPtr ? nullptr : &globalPtr->m_align[iGlob]);
 
-    const CaloGenericDetId gId(id);
+      assert(nullptr == gt || iGlob == ZdcGeometry::alignmentTransformIndexGlobal(DetId(gt->rawId())));
 
-    Pt3D lRef;
-    Pt3DVec lc(8, Pt3D(0, 0, 0));
-    zdcGeometry->localCorners(lc, &dims.front(), dins[i], lRef);
+      const unsigned int iLoc(nullptr == alignPtr ? 0 : ZdcGeometry::alignmentTransformIndexLocal(id));
 
-    const Pt3D lBck(0.25 * (lc[4] + lc[5] + lc[6] + lc[7]));  // ctr rear  face in local
-    const Pt3D lCor(lc[0]);
+      assert(nullptr == alignPtr || iLoc < alignPtr->m_align.size());
 
-    //----------------------------------- create transform from 6 numbers ---
-    const unsigned int jj(i * nTrParm);
-    Tr3D tr;
-    const ROOT::Math::Translation3D tl(tvec[jj], tvec[jj + 1], tvec[jj + 2]);
-    const ROOT::Math::EulerAngles ea(6 == nTrParm ? ROOT::Math::EulerAngles(tvec[jj + 3], tvec[jj + 4], tvec[jj + 5])
-                                                  : ROOT::Math::EulerAngles());
-    const ROOT::Math::Transform3D rt(ea, tl);
-    double xx, xy, xz, dx, yx, yy, yz, dy, zx, zy, zz, dz;
-    rt.GetComponents(xx, xy, xz, dx, yx, yy, yz, dy, zx, zy, zz, dz);
-    tr = Tr3D(CLHEP::HepRep3x3(xx, xy, xz, yx, yy, yz, zx, zy, zz), CLHEP::Hep3Vector(dx, dy, dz));
+      const AlignTransform* at(nullptr == alignPtr ? nullptr : &alignPtr->m_align[iLoc]);
 
-    // now prepend alignment(s) for final transform
-    const Tr3D atr(nullptr == at ? tr
-                                 : (nullptr == gt ? at->transform() * tr : at->transform() * gt->transform() * tr));
-    //--------------------------------- done making transform  ---------------
+      assert(nullptr == at || (ZdcGeometry::alignmentTransformIndexLocal(DetId(at->rawId())) == iLoc));
 
-    const Pt3D gRef(atr * lRef);
-    const GlobalPoint fCtr(gRef.x(), gRef.y(), gRef.z());
-    const Pt3D gBck(atr * lBck);
-    const GlobalPoint fBck(gBck.x(), gBck.y(), gBck.z());
-    const Pt3D gCor(atr * lCor);
-    const GlobalPoint fCor(gCor.x(), gCor.y(), gCor.z());
+      const CaloGenericDetId gId(id);
 
-    assert(zdcTopology.detId2denseId(id) == dins[i]);
+      Pt3D lRef;
+      Pt3DVec lc(8, Pt3D(0, 0, 0));
+      zdcGeometry->localCorners(lc, &dims.front(), i, lRef);
+      const Pt3D lBck(0.25 * (lc[4] + lc[5] + lc[6] + lc[7]));  // ctr rear  face in local
+      const Pt3D lCor(lc[0]);
 
-    ptr->newCell(fCtr, fBck, fCor, myParm, id);
+      //----------------------------------- create transform from 6 numbers ---
+      const unsigned int jj(i * nTrParm);
+      Tr3D tr;
+      const ROOT::Math::Translation3D tl(tvec[jj], tvec[jj + 1], tvec[jj + 2]);
+      const ROOT::Math::EulerAngles ea(6 == nTrParm ? ROOT::Math::EulerAngles(tvec[jj + 3], tvec[jj + 4], tvec[jj + 5])
+                                                    : ROOT::Math::EulerAngles());
+      const ROOT::Math::Transform3D rt(ea, tl);
+      double xx, xy, xz, dx, yx, yy, yz, dy, zx, zy, zz, dz;
+      rt.GetComponents(xx, xy, xz, dx, yx, yy, yz, dy, zx, zy, zz, dz);
+      tr = Tr3D(CLHEP::HepRep3x3(xx, xy, xz, yx, yy, yz, zx, zy, zz), CLHEP::Hep3Vector(dx, dy, dz));
+
+      // now prepend alignment(s) for final transform
+      const Tr3D atr(nullptr == at ? tr
+                                   : (nullptr == gt ? at->transform() * tr : at->transform() * gt->transform() * tr));
+      //--------------------------------- done making transform  ---------------
+
+      const Pt3D gRef(atr * lRef);
+      const GlobalPoint fCtr(gRef.x(), gRef.y(), gRef.z());
+      const Pt3D gBck(atr * lBck);
+      const GlobalPoint fBck(gBck.x(), gBck.y(), gBck.z());
+      const Pt3D gCor(atr * lCor);
+      const GlobalPoint fCor(gCor.x(), gCor.y(), gCor.z());
+
+      ptr->newCell(fCtr, fBck, fCor, myParm, id);
+#ifdef EDM_ML_DEBUG
+      edm::LogVerbatim("ZDCGeometry") << "ZDCGeometry Insert cell " << i << ":" << HcalZDCDetId(id);
+#endif
+    }
   }
   ptr->initializeParms();  // initializations; must happen after cells filled
 


### PR DESCRIPTION
#### PR description:

Backport of #46520 to read old ZDC geometry from DB correctly where dense index was not stored

#### PR validation:

Tested with a dedicated script

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #46520