### PR TITLE
Modification to move ZDC trigger spacing to TP channel parameters conditions.

### DIFF
--- a/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
+++ b/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
@@ -32,7 +32,6 @@ class HcalDbService;
 class HcaluLUTTPGCoder : public HcalTPGCoder {
 public:
   static const float lsb_;
-  static const float zdc_lsb_;
 
   HcaluLUTTPGCoder();
   HcaluLUTTPGCoder(const HcalTopology* topo, const HcalTimeSlew* delay);


### PR DESCRIPTION
#### PR description:
This PR takes a parameter hard-coded in the HCAL LUT generation for the ZDC and replaces it with a second auxiliary parameter from the HCAL TP Channel Parameters conditions. This is in order to change the granularity of the ZDC trigger decision (currently set to 1 count = 50 GeV) in coordination with ZDC gain changes set forth by changing the operating voltage. Whenever the conditions are updated to modify this parameter, this will also require a modification of the L1 menu. Therefore this PR will need to be carefully synchronized for deployment. 

#### PR validation:
This PR was tested locally on 2024 HI data taken with spurious collisions over the weekend. 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

 This PR is intended for HI data-taking and will require backport to CMSSW_14_1_X. 

Tagging @mandrenguyen , @JHiltbrand, and @Michael-Krohn.