### PR TITLE
Electron hlt filter bits mod

### DIFF
--- a/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
+++ b/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
@@ -60,8 +60,9 @@ triggerObjectTable = triggerObjectTableProducer.clone(
             skipObjectsNotPassingQualityBits = cms.bool(True),
             qualityBits = cms.VPSet(
                 mksel("filter('*CaloIdLTrackIdLIsoVL*TrackIso*Filter')","CaloIdL_TrackIdL_IsoVL"),
-                mksel("filter('hltEle*WPTight*TrackIsoFilter*')","1e (WPTight)"),
+                mksel("filter('hltEle*WPTight*TrackIsoFilter*')","1e (WPTight with possibile contribution from Xtriggers besides singleElectron)"),
                 mksel("filter('hltEle*WPLoose*TrackIsoFilter')","1e (WPLoose)"),
+                mksel("filter('hltEle30WPTightGsfTrackIsoFilter')","1e (HLT30WPTightGSfTrackIso)"),
                 mksel("filter('*OverlapFilter*IsoEle*PFTau*')","OverlapFilter PFTau"),
                 mksel("filter('hltEle*Ele*CaloIdLTrackIdLIsoVLTrackIsoLeg1Filter')","2e (Leg 1)"),
                 mksel("filter('hltEle*Ele*CaloIdLTrackIdLIsoVLTrackIsoLeg2Filter')","2e (Leg 2)"),

--- a/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
+++ b/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
@@ -62,7 +62,6 @@ triggerObjectTable = triggerObjectTableProducer.clone(
                 mksel("filter('*CaloIdLTrackIdLIsoVL*TrackIso*Filter')","CaloIdL_TrackIdL_IsoVL"),
                 mksel("filter('hltEle*WPTight*TrackIsoFilter*')","1e (WPTight with possibile contribution from Xtriggers besides singleElectron)"),
                 mksel("filter('hltEle*WPLoose*TrackIsoFilter')","1e (WPLoose)"),
-                mksel("filter('hltEle30WPTightGsfTrackIsoFilter')","1e (HLT30WPTightGSfTrackIso)"),
                 mksel("filter('*OverlapFilter*IsoEle*PFTau*')","OverlapFilter PFTau"),
                 mksel("filter('hltEle*Ele*CaloIdLTrackIdLIsoVLTrackIsoLeg1Filter')","2e (Leg 1)"),
                 mksel("filter('hltEle*Ele*CaloIdLTrackIdLIsoVLTrackIsoLeg2Filter')","2e (Leg 2)"),
@@ -77,7 +76,8 @@ triggerObjectTable = triggerObjectTableProducer.clone(
                 mksel(["hltEG175HEFilter","hltEG200HEFilter"],"1e (Photon175_OR_Photon200)"),
                 mksel("filter('hltEle*CaloIdLMWPMS2Filter')","2e (CaloIdL_MW seeded)"),
                 mksel("filter('hltDiEle*CaloIdLMWPMS2UnseededFilter')","2e (CaloIdL_MW unseeded)"),
-                mksel("filter('hlt*OverlapFilterIsoEle*ETau*PNet*Tau*')", "1e-1tau PNet")
+                mksel("filter('hlt*OverlapFilterIsoEle*ETau*PNet*Tau*')", "1e-1tau PNet"),
+                mksel("filter('hltEle30WPTightGsfTrackIsoFilter')","1e (HLT30WPTightGSfTrackIso)")
                 )
         ),
         Photon = cms.PSet(


### PR DESCRIPTION
#### PR description:

This PR is being made to correctly assign the filterbit "HLT30WPTightGSfTrackIso" to the electron trigger objects.
In current versio, we have a filter bit "WPTight" including "WPTight" & "TrackIsoFilter" in the similar line, however this is more generic and have contribution from cross-triggers along with the single electron triger of interest. 
Thus it is very important for EGM to have this additional filterbits(being included via this PR) to have the proper filterbit corresponding to the lowest pT, unprescaled, single electron trigger.  

#### PR validation:
- This PR just adds one filterbit to the electron trigger objects 
- Checked with : runTheMatrix.py -l 12846.0
- The test passed and the results are as expected

Backportation is not needed for this PR.
