### PR TITLE
Exclude PluginManager cache from MaxMemoryPreload monitoring

### DIFF
--- a/FWCore/PluginManager/src/PauseMaxMemoryPreloadSentry.cc
+++ b/FWCore/PluginManager/src/PauseMaxMemoryPreloadSentry.cc
@@ -1,0 +1,11 @@
+#include "PauseMaxMemoryPreloadSentry.h"
+
+// By default do nothing, but add "hooks" that MaxMemoryPreload can
+// override with LD_PRELOAD
+void pauseMaxMemoryPreload() {}
+void unpauseMaxMemoryPreload() {}
+
+namespace edm {
+  PauseMaxMemoryPreloadSentry::PauseMaxMemoryPreloadSentry() { pauseMaxMemoryPreload(); }
+  PauseMaxMemoryPreloadSentry::~PauseMaxMemoryPreloadSentry() { unpauseMaxMemoryPreload(); }
+}  // namespace edm

--- a/FWCore/PluginManager/src/PauseMaxMemoryPreloadSentry.h
+++ b/FWCore/PluginManager/src/PauseMaxMemoryPreloadSentry.h
@@ -1,0 +1,17 @@
+#ifndef FWCore_PluginManager_src_PauseMaxMemoryPreloadSentry_h
+#define FWCore_PluginManager_src_PauseMaxMemoryPreloadSentry_h
+
+namespace edm {
+  class PauseMaxMemoryPreloadSentry {
+  public:
+    PauseMaxMemoryPreloadSentry();
+    ~PauseMaxMemoryPreloadSentry();
+
+    PauseMaxMemoryPreloadSentry(const PauseMaxMemoryPreloadSentry&) = delete;
+    PauseMaxMemoryPreloadSentry(PauseMaxMemoryPreloadSentry&&) = delete;
+    PauseMaxMemoryPreloadSentry& operator=(const PauseMaxMemoryPreloadSentry&) = delete;
+    PauseMaxMemoryPreloadSentry& operator=(PauseMaxMemoryPreloadSentry&&) = delete;
+  };
+}  // namespace edm
+
+#endif

--- a/FWCore/PluginManager/src/PluginManager.cc
+++ b/FWCore/PluginManager/src/PluginManager.cc
@@ -29,6 +29,8 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
 
+#include "PauseMaxMemoryPreloadSentry.h"
+
 namespace edmplugin {
   //
   // constants, enums and typedefs
@@ -47,6 +49,7 @@ namespace edmplugin {
         throw cms::Exception("PluginMangerCacheProblem")
             << "Unable to open the cache file '" << cacheFile.string() << "'. Please check permissions on file";
       }
+      edm::PauseMaxMemoryPreloadSentry pauseSentry;
       CacheParser::read(file, dir, categoryToInfos);
       return true;
     }

--- a/PerfTools/MaxMemoryPreload/README.md
+++ b/PerfTools/MaxMemoryPreload/README.md
@@ -16,6 +16,33 @@ LD_PRELOAD="libPerfToolsAllocMonitorPreload.so libPerfToolsMaxMemoryPreload.so"
 
 the order is important.
 
+### Pausing the monitoring
+
+It is possible to temporarily pause the monitoring by instrumenting the target application by definining the following functions
+```cpp
+// in some header,
+void pauseMaxMemoryPreload();
+void unpauseMaxMemoryPreload();
+
+// in an implementation source file
+void pauseMaxMemoryPreload() {
+}
+void unpauseMaxMemoryPreload() {
+}
+```
+and then using these in code
+```cpp
+  ...
+  pauseMaxMemoryPreload();
+  // code that should be excluded from the monitoring
+  unpauseMaxMemoryPreload();
+  ...
+```
+
+The trick is that by default these functions are defined in the application, and the functions do nothing. The `libPerfToolsMaxMemoryPreload.so` provides also the same functions that actually pause the data collection, and the LD_PRELOADing makes the application to call the functions within `libPerfToolsMaxMemoryPreload.so`.
+
+It is recommended to not pause the monitoring within a multithreaded section, because that could result in unexpected results, because the pausing setting is global.
+
 ## Reporting
 When the application ends, the monitor will report the following to standard error:
 


### PR DESCRIPTION
#### PR description:

As described in https://github.com/cms-sw/cmssw/issues/46359, developer areas with many checked out packages result in larger "max memory" reported by MaxMemoryPreload AllocMonitor. This additional memory is used by PluginManager cache.

As a simple (albeit a bit hacky) workaround, this PR adds hooks to the MaxMemoryPreload that allow its data collection to be paused, and uses those hooks in PluginManager to paused the data collection during the cache file reading. 

Resolves https://github.com/cms-sw/cmssw/issues/46359
Resolves https://github.com/cms-sw/framework-team/issues/1074

#### PR validation:

Tested the impact with two developer areas of CMSSW_14_2_0_pre2: one with many packages checked out, and one with only two packages (`FWCore/PluginManager` and `PerfTools/MaxMemoryPreload`). The remaining difference in "max memory" was about 1 MB, or 0.05 %.