### PR TITLE
[14_1_X] Backport of modifications to make ZDC trigger spacing configurable with TP channel parameters. 

### DIFF
--- a/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
+++ b/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
@@ -32,7 +32,6 @@ class HcalDbService;
 class HcaluLUTTPGCoder : public HcalTPGCoder {
 public:
   static const float lsb_;
-  static const float zdc_lsb_;
 
   HcaluLUTTPGCoder();
   HcaluLUTTPGCoder(const HcalTopology* topo, const HcalTimeSlew* delay);

--- a/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
+++ b/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
@@ -2,6 +2,7 @@
 #include <fstream>
 #include <cmath>
 #include <string>
+#include <algorithm>
 #include "CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h"
 #include "CalibFormats/HcalObjects/interface/HcalCoderDb.h"
 #include "CalibFormats/HcalObjects/interface/HcalCalibrations.h"
@@ -29,7 +30,6 @@
 #include "CalibCalorimetry/HcalTPGAlgos/interface/LutXml.h"
 
 const float HcaluLUTTPGCoder::lsb_ = 1. / 16;
-const float HcaluLUTTPGCoder::zdc_lsb_ = 50.;
 
 const int HcaluLUTTPGCoder::QIE8_LUT_BITMASK;
 const int HcaluLUTTPGCoder::QIE10_LUT_BITMASK;
@@ -275,10 +275,10 @@ void HcaluLUTTPGCoder::update(const char* filename, bool appendMSB) {
             } else
               inputLUT_[lutId][adc] = lutFromFile[i][adc];
           }  // for adc
-        }    // for depth
-      }      // for iphi
-    }        // for ieta
-  }          // for nCol
+        }  // for depth
+      }  // for iphi
+    }  // for ieta
+  }  // for nCol
 }
 
 void HcaluLUTTPGCoder::updateXML(const char* filename) {
@@ -595,10 +595,21 @@ void HcaluLUTTPGCoder::update(const HcalDbService& conditions) {
       const HcalLutMetadatum* meta = metadata->getValues(cell);
 
       auto tpParam = conditions.getHcalTPChannelParameter(cell, false);
-      int weight = tpParam->getauxi1();
+      const int weight = tpParam->getauxi1();
+      int factorGeVPerCount = tpParam->getauxi2();
+      if (factorGeVPerCount == 0) {
+        edm::LogWarning("HcaluLUTTPGCoder")
+            << "WARNING: ZDC trigger spacing factor, taken from auxi2 field of HCALTPChannelParameters for the cell "
+               "with (zside, section, channel) =  ("
+            << cell.zside() << " , " << cell.section() << " , " << cell.channel()
+            << ") is set to the "
+               "default value of 0, which is an incompatible value for a spacing factor. Setting the value to 50 and "
+               "continuing.";
+        factorGeVPerCount = 50;
+      }
 
-      int lutId = getLUTId(cell);
-      int lutId_ootpu = lutId + sizeZDC_;
+      const int lutId = getLUTId(cell);
+      const int lutId_ootpu = lutId + sizeZDC_;
       Lut& lut = inputLUT_[lutId];
       Lut& lut_ootpu = inputLUT_[lutId_ootpu];
       float ped = 0;
@@ -656,9 +667,9 @@ void HcaluLUTTPGCoder::update(const HcalDbService& conditions) {
             lut[adc] = 0;
             lut_ootpu[adc] = 0;
           } else {
-            lut[adc] = std::min(std::max(0, int((adc2fC(adc) - ped) * gain * rcalib / zdc_lsb_)), MASK);
-            lut_ootpu[adc] =
-                std::min(std::max(0, int((adc2fC(adc) - ped) * gain * rcalib * weight / (zdc_lsb_ * 256))), MASK);
+            auto lut_term = (adc2fC(adc) - ped) * gain * rcalib / factorGeVPerCount;
+            lut[adc] = std::clamp(int(lut_term), 0, MASK);
+            lut_ootpu[adc] = std::clamp(int(lut_term * weight / 256), 0, MASK);
           }
         }
       }


### PR DESCRIPTION
#### PR description:

This PR takes a parameter hard-coded in the HCAL LUT generation for the ZDC and replaces it with a second auxiliary parameter from the HCAL TP Channel Parameters conditions. This is in order to change the granularity of the ZDC trigger decision (currently set to 1 count = 50 GeV) in coordination with ZDC gain changes set forth by changing the operating voltage. Whenever the conditions are updated to modify this parameter, this will also require a modification of the L1 menu. Therefore this PR will need to be carefully synchronized for deployment.

#### PR validation:

This PR was tested locally on 2024 HI data taken with spurious collisions over the weekend.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is a backport of https://github.com/cms-sw/cmssw/pull/46537 and is meant for CMSSW_14_1_X and is intended for HI data-taking. 