### PR TITLE
Downgrade EnergyInDeadEB/EE_FE Warning To Info

### DIFF
--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitWorkerRecover.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitWorkerRecover.cc
@@ -278,7 +278,7 @@ bool EcalRecHitWorkerRecover::run(const edm::Event& evt,
       float tpEt = ecalScale.getTPGInGeV(tp->compressedEt(), tp->id());
       float tpEtThreshEB = logWarningEtThreshold_EB_FE_;
       if (tpEt > tpEtThreshEB) {
-        edm::LogWarning("EnergyInDeadEB_FE") << "TP energy in the dead TT = " << tpEt << " at " << ttDetId;
+        edm::LogInfo("EnergyInDeadEB_FE") << "TP energy in the dead TT = " << tpEt << " at " << ttDetId;
       }
       if (!killDeadChannels_ || recoverEBFE_) {
         // democratic energy sharing
@@ -432,7 +432,7 @@ bool EcalRecHitWorkerRecover::run(const edm::Event& evt,
     float scEt = totE;
     float scEtThreshEE = logWarningEtThreshold_EE_FE_;
     if (scEt > scEtThreshEE) {
-      edm::LogWarning("EnergyInDeadEE_FE") << "TP energy in the dead TT = " << scEt << " at " << sc;
+      edm::LogInfo("EnergyInDeadEE_FE") << "TP energy in the dead TT = " << scEt << " at " << sc;
     }
 
     // assign the energy to the SC crystals


### PR DESCRIPTION
#### PR description:

This PR addresses unnecessary warnings raised in hltEcalRecHit, noted in [#41456](https://github.com/cms-sw/cmssw/issues/41456)  and [#45880](https://github.com/cms-sw/cmssw/issues/45880). These warnings are really just reporting energy calculated from the TP and don't indicate a problem, so they are to be downgraded from `LogWarning` to `LogInfo`.

