### PR TITLE
[14.1.X] Extend the topology modes to accommodate different scenarios during the Run2 period

### DIFF
--- a/Geometry/HcalCommonData/data/hcalRecNumbering/2016/v1/hcalRecNumbering.xml
+++ b/Geometry/HcalCommonData/data/hcalRecNumbering/2016/v1/hcalRecNumbering.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<DDDefinition>
+
+<ConstantsSection  label="hcalRecNumbering.xml" eval="true">
+  <Vector name="etagroup" type="numeric" nEntries="29">
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+  </Vector>
+  <Vector name="phigroup" type="numeric" nEntries="29">
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+  </Vector>
+  <Vector name="layerGroupRecEta1" type="numeric" nEntries="19">
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 4, 4
+  </Vector>
+  <Vector name="layerGroupRecEta15" type="numeric" nEntries="19">
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 4, 4
+  </Vector>
+  <Vector name="layerGroupRecEta16" type="numeric" nEntries="19">
+    1, 1, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3
+  </Vector>
+  <Vector name="layerGroupRecEta17" type="numeric" nEntries="19">
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+  </Vector>
+  <Vector name="layerGroupRecEta18" type="numeric" nEntries="19">
+    1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2
+  </Vector>
+  <Vector name="layerGroupRecEta19" type="numeric" nEntries="19">
+    1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2
+  </Vector>
+  <Vector name="layerGroupRecEta27" type="numeric" nEntries="19">
+    1, 1, 1, 1, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3
+  </Vector>
+</ConstantsSection>
+
+<SpecParSection label="hcalRecNumbering.xml" eval="true">
+  <SpecPar name="hcal">
+    <PartSelector path="//HCal"/>
+    <Parameter name="OnlyForHcalRecNumbering" value="HCAL" eval="false"/>
+    <Parameter name="TopologyMode" value="HcalTopologyMode::Run2A" eval="false"/>
+    <Parameter name="TriggerMode"  value="HcalTopologyMode::TriggerMode_2016" eval="false"/>
+  </SpecPar>
+</SpecParSection>
+</DDDefinition>

--- a/Geometry/HcalCommonData/data/hcalRecNumbering/2016a/v1/hcalRecNumbering.xml
+++ b/Geometry/HcalCommonData/data/hcalRecNumbering/2016a/v1/hcalRecNumbering.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<DDDefinition>
+
+<ConstantsSection  label="hcalRecNumbering.xml" eval="true">
+  <Vector name="etagroup" type="numeric" nEntries="29">
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+  </Vector>
+  <Vector name="phigroup" type="numeric" nEntries="29">
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+  </Vector>
+  <Vector name="layerGroupRecEta1" type="numeric" nEntries="19">
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 4, 4
+  </Vector>
+  <Vector name="layerGroupRecEta15" type="numeric" nEntries="19">
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 4, 4
+  </Vector>
+  <Vector name="layerGroupRecEta16" type="numeric" nEntries="19">
+    1, 1, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3
+  </Vector>
+  <Vector name="layerGroupRecEta17" type="numeric" nEntries="19">
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+  </Vector>
+  <Vector name="layerGroupRecEta18" type="numeric" nEntries="19">
+    1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2
+  </Vector>
+  <Vector name="layerGroupRecEta19" type="numeric" nEntries="19">
+    1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2
+  </Vector>
+  <Vector name="layerGroupRecEta27" type="numeric" nEntries="19">
+    1, 1, 1, 1, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3
+  </Vector>
+</ConstantsSection>
+
+<SpecParSection label="hcalRecNumbering.xml" eval="true">
+  <SpecPar name="hcal">
+    <PartSelector path="//HCal"/>
+    <Parameter name="OnlyForHcalRecNumbering" value="HCAL" eval="false"/>
+    <Parameter name="TopologyMode" value="HcalTopologyMode::Run2A" eval="false"/>
+    <Parameter name="TriggerMode"  value="HcalTopologyMode::TriggerMode_2016" eval="false"/>
+  </SpecPar>
+</SpecParSection>
+</DDDefinition>

--- a/Geometry/HcalCommonData/data/hcalRecNumbering/2017/v1/hcalRecNumbering.xml
+++ b/Geometry/HcalCommonData/data/hcalRecNumbering/2017/v1/hcalRecNumbering.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<DDDefinition>
+
+<ConstantsSection  label="hcalRecNumbering.xml" eval="true">
+  <Vector name="etagroup" type="numeric" nEntries="29">
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+  </Vector>
+  <Vector name="phigroup" type="numeric" nEntries="29">
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+  </Vector>
+  <Vector name="layerGroupRecEta1" type="numeric" nEntries="19">
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 4, 4
+  </Vector>
+  <Vector name="layerGroupRecEta15" type="numeric" nEntries="19">
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 4, 4
+  </Vector>
+  <Vector name="layerGroupRecEta16" type="numeric" nEntries="19">
+    1, 1, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3
+  </Vector>
+  <Vector name="layerGroupRecEta17" type="numeric" nEntries="19">
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+  </Vector>
+  <Vector name="layerGroupRecEta18" type="numeric" nEntries="19">
+    1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2
+  </Vector>
+  <Vector name="layerGroupRecEta19" type="numeric" nEntries="19">
+    1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2
+  </Vector>
+  <Vector name="layerGroupRecEta27" type="numeric" nEntries="19">
+    1, 1, 1, 1, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3
+  </Vector>
+</ConstantsSection>
+
+<SpecParSection label="hcalRecNumbering.xml" eval="true">
+  <SpecPar name="hcal">
+    <PartSelector path="//HCal"/>
+    <Parameter name="OnlyForHcalRecNumbering" value="HCAL" eval="false"/>
+    <Parameter name="TopologyMode" value="HcalTopologyMode::Run2B" eval="false"/>
+    <Parameter name="TriggerMode"  value="HcalTopologyMode::TriggerMode_2017plan1" eval="false"/>
+  </SpecPar>
+</SpecParSection>
+</DDDefinition>

--- a/Geometry/HcalCommonData/data/hcalRecNumbering/2018/v1/hcalRecNumbering.xml
+++ b/Geometry/HcalCommonData/data/hcalRecNumbering/2018/v1/hcalRecNumbering.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<DDDefinition>
+
+<ConstantsSection  label="hcalRecNumbering.xml" eval="true">
+  <Vector name="etagroup" type="numeric" nEntries="29">
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+  </Vector>
+  <Vector name="phigroup" type="numeric" nEntries="29">
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+  </Vector>
+  <Vector name="layerGroupRecEta1" type="numeric" nEntries="19">
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 4, 4
+  </Vector>
+  <Vector name="layerGroupRecEta15" type="numeric" nEntries="19">
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 4, 4
+  </Vector>
+  <Vector name="layerGroupRecEta16" type="numeric" nEntries="19">
+    1, 1, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3
+  </Vector>
+  <Vector name="layerGroupRecEta17" type="numeric" nEntries="19">
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+  </Vector>
+  <Vector name="layerGroupRecEta18" type="numeric" nEntries="19">
+    1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2
+  </Vector>
+  <Vector name="layerGroupRecEta19" type="numeric" nEntries="19">
+    1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2
+  </Vector>
+  <Vector name="layerGroupRecEta27" type="numeric" nEntries="19">
+    1, 1, 1, 1, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3
+  </Vector>
+</ConstantsSection>
+
+<SpecParSection label="hcalRecNumbering.xml" eval="true">
+  <SpecPar name="hcal">
+    <PartSelector path="//HCal"/>
+    <Parameter name="OnlyForHcalRecNumbering" value="HCAL" eval="false"/>
+    <Parameter name="TopologyMode" value="HcalTopologyMode::Run2B" eval="false"/>
+    <Parameter name="TriggerMode"  value="HcalTopologyMode::TriggerMode_2018" eval="false"/>
+  </SpecPar>
+</SpecParSection>
+</DDDefinition>

--- a/Geometry/HcalCommonData/data/hcalRecNumbering/2018Plan36/v1/hcalRecNumbering.xml
+++ b/Geometry/HcalCommonData/data/hcalRecNumbering/2018Plan36/v1/hcalRecNumbering.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<DDDefinition>
+
+<ConstantsSection  label="hcalRecNumbering.xml" eval="true">
+  <Vector name="etagroup" type="numeric" nEntries="29">
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+  </Vector>
+  <Vector name="phigroup" type="numeric" nEntries="29">
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+  </Vector>
+  <Vector name="layerGroupRecEta1" type="numeric" nEntries="19">
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 4, 4
+  </Vector>
+  <Vector name="layerGroupRecEta15" type="numeric" nEntries="19">
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 4, 4
+  </Vector>
+  <Vector name="layerGroupRecEta16" type="numeric" nEntries="19">
+    1, 1, 2, 2, 2, 2, 2, 2, 2, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4
+  </Vector>
+  <Vector name="layerGroupRecEta17" type="numeric" nEntries="19">
+    2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3
+  </Vector>
+  <Vector name="layerGroupRecEta18" type="numeric" nEntries="19">
+    1, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5
+  </Vector>
+  <Vector name="layerGroupRecEta19" type="numeric" nEntries="19">
+    1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6
+  </Vector>
+  <Vector name="layerGroupRecEta26" type="numeric" nEntries="19">
+    1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 5, 6, 6, 6, 6, 7, 7, 7, 7
+  </Vector>
+</ConstantsSection>
+
+<SpecParSection label="hcalRecNumbering.xml" eval="true">
+  <SpecPar name="hcal">
+    <PartSelector path="//HCal"/>
+    <Parameter name="OnlyForHcalRecNumbering" value="HCAL" eval="false"/>
+    <Parameter name="TopologyMode" value="HcalTopologyMode::Run2B" eval="false"/>
+    <Parameter name="TriggerMode"  value="HcalTopologyMode::TriggerMode_2018" eval="false"/>
+  </SpecPar>
+</SpecParSection>
+</DDDefinition>

--- a/Geometry/HcalCommonData/data/hcalRecNumbering/2019/v1/hcalRecNumbering.xml
+++ b/Geometry/HcalCommonData/data/hcalRecNumbering/2019/v1/hcalRecNumbering.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<DDDefinition>
+
+<ConstantsSection  label="hcalRecNumbering.xml" eval="true">
+  <Vector name="etagroup" type="numeric" nEntries="29">
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+  </Vector>
+  <Vector name="phigroup" type="numeric" nEntries="29">
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+  </Vector>
+  <Vector name="layerGroupRecEta1" type="numeric" nEntries="19">
+    1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4
+  </Vector>
+  <Vector name="layerGroupRecEta16" type="numeric" nEntries="19">
+    1, 1, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4
+  </Vector>
+  <Vector name="layerGroupRecEta17" type="numeric" nEntries="19">
+    2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3
+  </Vector>
+  <Vector name="layerGroupRecEta18" type="numeric" nEntries="19">
+    1, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5
+  </Vector>
+  <Vector name="layerGroupRecEta19" type="numeric" nEntries="19">
+    1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6
+  </Vector>
+  <Vector name="layerGroupRecEta26" type="numeric" nEntries="19">
+    1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 5, 6, 6, 6, 6, 7, 7, 7, 7
+  </Vector>
+</ConstantsSection>
+
+<SpecParSection label="hcalRecNumbering.xml" eval="true">
+  <SpecPar name="hcal">
+    <PartSelector path="//HCal"/>
+    <Parameter name="OnlyForHcalRecNumbering" value="HCAL" eval="false"/>
+    <Parameter name="TopologyMode" value="HcalTopologyMode::Run2C" eval="false"/>
+    <Parameter name="TriggerMode"  value="HcalTopologyMode::TriggerMode_2021" eval="false"/>
+  </SpecPar>
+</SpecParSection>
+
+</DDDefinition>

--- a/Geometry/HcalCommonData/data/hcalRecNumbering/2021/v3/hcalRecNumbering.xml
+++ b/Geometry/HcalCommonData/data/hcalRecNumbering/2021/v3/hcalRecNumbering.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<DDDefinition>
+
+<ConstantsSection  label="hcalRecNumbering.xml" eval="true">
+  <Vector name="etagroup" type="numeric" nEntries="29">
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+  </Vector>
+  <Vector name="phigroup" type="numeric" nEntries="29">
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+  </Vector>
+  <Vector name="layerGroupRecEta1" type="numeric" nEntries="19">
+    1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4
+  </Vector>
+  <Vector name="layerGroupRecEta16" type="numeric" nEntries="19">
+    1, 1, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4
+  </Vector>
+  <Vector name="layerGroupRecEta17" type="numeric" nEntries="19">
+    2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3
+  </Vector>
+  <Vector name="layerGroupRecEta18" type="numeric" nEntries="19">
+    1, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5
+  </Vector>
+  <Vector name="layerGroupRecEta19" type="numeric" nEntries="19">
+    1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6
+  </Vector>
+  <Vector name="layerGroupRecEta26" type="numeric" nEntries="19">
+    1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 5, 6, 6, 6, 6, 7, 7, 7, 7
+  </Vector>
+</ConstantsSection>
+
+<SpecParSection label="hcalRecNumbering.xml" eval="true">
+  <SpecPar name="hcal">
+    <PartSelector path="//HBS.*"/>
+    <PartSelector path="//HTS.*"/>
+    <PartSelector path="//HES.*"/>
+    <PartSelector path="//HVQX"/>
+    <Parameter name="OnlyForHcalRecNumbering" value="HCAL" eval="false"/>
+    <Parameter name="TopologyMode" value="HcalTopologyMode::Run2C" eval="false"/>
+    <Parameter name="TriggerMode"  value="HcalTopologyMode::TriggerMode_2021" eval="false"/>
+  </SpecPar>
+</SpecParSection>
+
+</DDDefinition>


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/46351


#### PR description:

Extend the topology modes to accommodate different scenarios during the Run2 period

#### PR validation:

Use the runTheMatrix test workflows

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

verbatim backport of https://github.com/cms-sw/cmssw/pull/46351 to fix issues reported at https://github.com/cms-sw/cmssw/pull/46468#discussion_r1821963646