### PR TITLE
static-analyzer: treat relative file names as local CMS files

### DIFF
--- a/Utilities/StaticAnalyzers/src/CmsSupport.cpp
+++ b/Utilities/StaticAnalyzers/src/CmsSupport.cpp
@@ -38,6 +38,8 @@ bool clangcms::support::isCmsLocalFile(const char *file) {
     if (LocalDir != nullptr)
       DirLen = strlen(LocalDir);
   }
+  if (strncmp(file, "src/", 4) == 0)
+    return true;
   if ((DirLen == 0) || (strncmp(file, LocalDir, DirLen) != 0) || (strncmp(&file[DirLen], "/src/", 5) != 0))
     return false;
   return true;


### PR DESCRIPTION
Static analyzer was relaying on the fact that all files compiled have full path(e.g `$CMSSW_BASE/src/package/file.ext`) but scram now uses relative path (e.g.  `src/package/file.ext` ) for portable `PGO` profiles. This PR fixes this issue and treat all files name started with `src/` as local CMS files.