### PR TITLE
[14.1.X] add `ClusterShapeHitFilterESProducer_cfi` to `dedxEstimators_Cosmics_cff` as it's now requested by `DeDxHitInfoProducer`

### DIFF
--- a/RecoTracker/DeDx/python/dedxEstimators_Cosmics_cff.py
+++ b/RecoTracker/DeDx/python/dedxEstimators_Cosmics_cff.py
@@ -3,6 +3,8 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoTracker.DeDx.dedxEstimators_cff import *
 
+from RecoTracker.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
+
 dedxHitInfoCTF     = dedxHitInfo.clone( tracks = "ctfWithMaterialTracksP5")
 
 dedxTruncated40CTF = dedxTruncated40.clone( tracks = "ctfWithMaterialTracksP5")


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/46563

#### PR description:

Simple fix for https://github.com/cms-sw/cmssw/issues/46553

#### PR validation:

```
cmsRun DQM/Integration/python/clients/visualization-live-secondInstance_cfg.py runInputDir=/eos/user/d/dpapagia/data outputBaseDir=./output runNumber=387552 runkey=cosmic_run
```

runs fine (streamers courtesy of @nothingface0)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/46563 to `CMSSW_14_1_X` for 2024 HIon data-taking operations.
