### PR TITLE
Make ClusterSummary possible to turn off warning

### DIFF
--- a/DPGAnalysis/SiStripTools/plugins/MultiplicityAlgorithms.cc
+++ b/DPGAnalysis/SiStripTools/plugins/MultiplicityAlgorithms.cc
@@ -6,13 +6,15 @@ ClusterSummarySingleMultiplicity::ClusterSummarySingleMultiplicity(const edm::Pa
                                                                    edm::ConsumesCollector&& iC)
     : m_subdetenum((ClusterSummary::CMSTracker)iConfig.getParameter<int>("subDetEnum")),
       m_varenum((ClusterSummary::VariablePlacement)iConfig.getParameter<int>("varEnum")),
-      m_collection(iC.consumes<ClusterSummary>(iConfig.getParameter<edm::InputTag>("clusterSummaryCollection"))) {}
+      m_collection(iC.consumes<ClusterSummary>(iConfig.getParameter<edm::InputTag>("clusterSummaryCollection"))),
+      m_warn(iConfig.getUntrackedParameter<bool>("warnIfModuleMissing", true)) {}
 
 ClusterSummarySingleMultiplicity::ClusterSummarySingleMultiplicity(const edm::ParameterSet& iConfig,
                                                                    edm::ConsumesCollector& iC)
     : m_subdetenum((ClusterSummary::CMSTracker)iConfig.getParameter<int>("subDetEnum")),
       m_varenum((ClusterSummary::VariablePlacement)iConfig.getParameter<int>("varEnum")),
-      m_collection(iC.consumes<ClusterSummary>(iConfig.getParameter<edm::InputTag>("clusterSummaryCollection"))) {}
+      m_collection(iC.consumes<ClusterSummary>(iConfig.getParameter<edm::InputTag>("clusterSummaryCollection"))),
+      m_warn(iConfig.getUntrackedParameter<bool>("warnIfModuleMissing", true)) {}
 
 ClusterSummarySingleMultiplicity::value_t ClusterSummarySingleMultiplicity::getEvent(
     const edm::Event& iEvent, const edm::EventSetup& iSetup) const {
@@ -23,13 +25,13 @@ ClusterSummarySingleMultiplicity::value_t ClusterSummarySingleMultiplicity::getE
 
   switch (m_varenum) {
     case ClusterSummary::NCLUSTERS:
-      mult = int(clustsumm->getNClus(m_subdetenum));
+      mult = int(clustsumm->getNClus(m_subdetenum, m_warn));
       break;
     case ClusterSummary::CLUSTERSIZE:
-      mult = int(clustsumm->getClusSize(m_subdetenum));
+      mult = int(clustsumm->getClusSize(m_subdetenum, m_warn));
       break;
     case ClusterSummary::CLUSTERCHARGE:
-      mult = int(clustsumm->getClusCharge(m_subdetenum));
+      mult = int(clustsumm->getClusCharge(m_subdetenum, m_warn));
       break;
     default:
       mult = -1;

--- a/DPGAnalysis/SiStripTools/plugins/MultiplicityAlgorithms.h
+++ b/DPGAnalysis/SiStripTools/plugins/MultiplicityAlgorithms.h
@@ -42,6 +42,7 @@ namespace sistriptools::algorithm {
     ClusterSummary::CMSTracker m_subdetenum;
     ClusterSummary::VariablePlacement m_varenum;
     edm::EDGetTokenT<ClusterSummary> m_collection;
+    bool m_warn;
   };
 
   template <class T>

--- a/DataFormats/TrackerCommon/interface/ClusterSummary.h
+++ b/DataFormats/TrackerCommon/interface/ClusterSummary.h
@@ -106,16 +106,16 @@ public:
   int getClusSizeByIndex(const int mod) const { return clusSize.at(mod); }
   float getClusChargeByIndex(const int mod) const { return clusCharge.at(mod); }
 
-  int getNClus(const CMSTracker mod) const {
-    int pos = getModuleLocation(mod);
+  int getNClus(const CMSTracker mod, bool warn = true) const {
+    int pos = getModuleLocation(mod, warn);
     return pos < 0 ? 0. : nClus[pos];
   }
-  int getClusSize(const CMSTracker mod) const {
-    int pos = getModuleLocation(mod);
+  int getClusSize(const CMSTracker mod, bool warn = true) const {
+    int pos = getModuleLocation(mod, warn);
     return pos < 0 ? 0. : clusSize[pos];
   }
-  float getClusCharge(const CMSTracker mod) const {
-    int pos = getModuleLocation(mod);
+  float getClusCharge(const CMSTracker mod, bool warn = true) const {
+    int pos = getModuleLocation(mod, warn);
     return pos < 0 ? 0. : clusCharge[pos];
   }
 
@@ -127,9 +127,15 @@ public:
   void addClusSizeByIndex(const int mod, const int val) { clusSize.at(mod) += val; }
   void addClusChargeByIndex(const int mod, const float val) { clusCharge.at(mod) += val; }
 
-  void addNClus(const CMSTracker mod, const int val) { nClus.at(getModuleLocation(mod)) += val; }
-  void addClusSize(const CMSTracker mod, const int val) { clusSize.at(getModuleLocation(mod)) += val; }
-  void addClusCharge(const CMSTracker mod, const float val) { clusCharge.at(getModuleLocation(mod)) += val; }
+  void addNClus(const CMSTracker mod, const int val, bool warn = true) {
+    nClus.at(getModuleLocation(mod, warn)) += val;
+  }
+  void addClusSize(const CMSTracker mod, const int val, bool warn = true) {
+    clusSize.at(getModuleLocation(mod, warn)) += val;
+  }
+  void addClusCharge(const CMSTracker mod, const float val, bool warn = true) {
+    clusCharge.at(getModuleLocation(mod, warn)) += val;
+  }
 
   const std::vector<int>& getModules() const { return modules; }
   // Return the location of desired module within modules_. If warn is set to true, a warnign will be outputed in case no module was found


### PR DESCRIPTION

#### PR description:

Can turn on warning via PSet of code using ClusterSummary.
Large warning storm happened while testing with Neutrino beam jobs.

#### PR validation:

Code compiles. Ran a small test job and the unnecessary warnings are gone.