### PR TITLE
[14_1] Fix memory leak issues in Calo Layer 1 UCT Infrastructure

### DIFF
--- a/L1Trigger/L1TCaloLayer1/plugins/L1TCaloLayer1.cc
+++ b/L1Trigger/L1TCaloLayer1/plugins/L1TCaloLayer1.cc
@@ -74,16 +74,16 @@ private:
   edm::EDPutTokenT<L1CaloRegionCollection> regionPutToken;
   const L1TCaloLayer1FetchLUTsTokens lutsTokens;
 
-  std::vector<std::array<std::array<std::array<uint32_t, nEtBins>, nCalSideBins>, nCalEtaBins> > ecalLUT;
-  std::vector<std::array<std::array<std::array<uint32_t, nEtBins>, nCalSideBins>, nCalEtaBins> > hcalLUT;
-  std::vector<std::array<std::array<uint32_t, nEtBins>, nHfEtaBins> > hfLUT;
+  std::vector<std::array<std::array<std::array<uint32_t, nEtBins>, nCalSideBins>, nCalEtaBins>> ecalLUT;
+  std::vector<std::array<std::array<std::array<uint32_t, nEtBins>, nCalSideBins>, nCalEtaBins>> hcalLUT;
+  std::vector<std::array<std::array<uint32_t, nEtBins>, nHfEtaBins>> hfLUT;
   std::vector<unsigned long long int> hcalFBLUT;
 
   std::vector<unsigned int> ePhiMap;
   std::vector<unsigned int> hPhiMap;
   std::vector<unsigned int> hfPhiMap;
 
-  std::vector<UCTTower*> twrList;
+  std::vector<std::shared_ptr<UCTTower>> twrList;
 
   bool useLSB;
   bool useCalib;
@@ -140,7 +140,7 @@ L1TCaloLayer1::L1TCaloLayer1(const edm::ParameterSet& iConfig)
     for (uint32_t crd = 0; crd < cards.size(); crd++) {
       vector<UCTRegion*> regions = cards[crd]->getRegions();
       for (uint32_t rgn = 0; rgn < regions.size(); rgn++) {
-        vector<UCTTower*> towers = regions[rgn]->getTowers();
+        vector<std::shared_ptr<UCTTower>> towers = regions[rgn]->getTowers();
         for (uint32_t twr = 0; twr < towers.size(); twr++) {
           twrList.push_back(towers[twr]);
         }
@@ -150,7 +150,7 @@ L1TCaloLayer1::L1TCaloLayer1(const edm::ParameterSet& iConfig)
 
   // This sort corresponds to the sort condition on
   // the output CaloTowerBxCollection
-  std::sort(twrList.begin(), twrList.end(), [](UCTTower* a, UCTTower* b) {
+  std::sort(twrList.begin(), twrList.end(), [](std::shared_ptr<UCTTower> a, std::shared_ptr<UCTTower> b) {
     return CaloTools::caloTowerHash(a->caloEta(), a->caloPhi()) < CaloTools::caloTowerHash(b->caloEta(), b->caloPhi());
   });
 }

--- a/L1Trigger/L1TCaloLayer1/plugins/L1TCaloSummary.cc
+++ b/L1Trigger/L1TCaloLayer1/plugins/L1TCaloSummary.cc
@@ -194,8 +194,8 @@ void L1TCaloSummary<INPUT, OUTPUT>::produce(edm::Event& iEvent, const edm::Event
   // of size 7*2. Indices are mapped in UCTSummaryCard accordingly.
   UCTSummaryCard summaryCard =
       UCTSummaryCard(&pumLUT, jetSeed, tauSeed, tauIsolationFactor, eGammaSeed, eGammaIsolationFactor);
-  std::vector<UCTRegion*> inputRegions;
-  inputRegions.clear();
+  std::vector<UCTRegion> inputRegions;
+  inputRegions.reserve(252);  // 252 calorimeter regions. 18 phi * 14 eta
   edm::Handle<std::vector<L1CaloRegion>> regionCollection;
   if (!iEvent.getByToken(regionToken, regionCollection))
     edm::LogError("L1TCaloSummary") << "UCT: Failed to get regions from region collection!";
@@ -221,8 +221,8 @@ void L1TCaloSummary<INPUT, OUTPUT>::produce(edm::Event& iEvent, const edm::Event
     uint32_t crate = g.getCrate(t.first, t.second);
     uint32_t card = g.getCard(t.first, t.second);
     uint32_t region = g.getRegion(absCaloEta, absCaloPhi);
-    UCTRegion* test = new UCTRegion(crate, card, negativeEta, region, fwVersion);
-    test->setRegionSummary(i.raw());
+    UCTRegion test = UCTRegion(crate, card, negativeEta, region, fwVersion);
+    test.setRegionSummary(i.raw());
     inputRegions.push_back(test);
     //This *should* fill the tensor in the proper order to be fed to the anomaly model
     //We take 4 off of the GCT eta/iEta.
@@ -281,9 +281,10 @@ void L1TCaloSummary<INPUT, OUTPUT>::produce(edm::Event& iEvent, const edm::Event
   double phi = -999.;
   double mass = 0;
 
-  std::list<UCTObject*> boostedJetObjs = summaryCard.getBoostedJetObjs();
-  for (std::list<UCTObject*>::const_iterator i = boostedJetObjs.begin(); i != boostedJetObjs.end(); i++) {
-    const UCTObject* object = *i;
+  std::list<std::shared_ptr<UCTObject>> boostedJetObjs = summaryCard.getBoostedJetObjs();
+  for (std::list<std::shared_ptr<UCTObject>>::const_iterator i = boostedJetObjs.begin(); i != boostedJetObjs.end();
+       i++) {
+    const std::shared_ptr<UCTObject> object = *i;
     pt = ((double)object->et()) * caloScaleFactor * boostedJetPtFactor;
     eta = g.getUCTTowerEta(object->iEta());
     phi = g.getUCTTowerPhi(object->iPhi());

--- a/L1Trigger/L1TCaloLayer1/src/UCTLayer1.cc
+++ b/L1Trigger/L1TCaloLayer1/src/UCTLayer1.cc
@@ -62,7 +62,7 @@ const UCTRegion* UCTLayer1::getRegion(int regionEtaIndex, uint32_t regionPhiInde
   return region;
 }
 
-const UCTTower* UCTLayer1::getTower(int caloEta, int caloPhi) const {
+const std::shared_ptr<UCTTower> UCTLayer1::getTower(int caloEta, int caloPhi) const {
   if (caloPhi < 0) {
     LOG_ERROR << "UCT::getTower - Negative caloPhi is unacceptable -- bailing" << std::endl;
     exit(1);
@@ -71,7 +71,7 @@ const UCTTower* UCTLayer1::getTower(int caloEta, int caloPhi) const {
   UCTTowerIndex twr = UCTTowerIndex(caloEta, caloPhi);
   const UCTRegionIndex rgn = g.getUCTRegionIndex(twr);
   const UCTRegion* region = getRegion(rgn);
-  const UCTTower* tower = region->getTower(twr);
+  const std::shared_ptr<UCTTower> tower = region->getTower(twr);
   return tower;
 }
 

--- a/L1Trigger/L1TCaloLayer1/src/UCTLayer1.hh
+++ b/L1Trigger/L1TCaloLayer1/src/UCTLayer1.hh
@@ -2,6 +2,7 @@
 #define UCTLayer1_hh
 
 #include <vector>
+#include <memory>
 
 class UCTCrate;
 class UCTRegion;
@@ -36,7 +37,7 @@ public:
 
   std::vector<UCTCrate*>& getCrates() { return crates; }
   const UCTRegion* getRegion(UCTRegionIndex r) const { return getRegion(r.first, r.second); }
-  const UCTTower* getTower(UCTTowerIndex t) const { return getTower(t.first, t.second); }
+  const std::shared_ptr<UCTTower> getTower(UCTTowerIndex t) const { return getTower(t.first, t.second); }
 
   // To zero out event in case of selective tower filling
   bool clearEvent();
@@ -58,7 +59,7 @@ private:
   // Helper functions
 
   const UCTRegion* getRegion(int regionEtaIndex, uint32_t regionPhiIndex) const;
-  const UCTTower* getTower(int caloEtaIndex, int caloPhiIndex) const;
+  const std::shared_ptr<UCTTower> getTower(int caloEtaIndex, int caloPhiIndex) const;
 
   //Private data
 

--- a/L1Trigger/L1TCaloLayer1/src/UCTRegion.hh
+++ b/L1Trigger/L1TCaloLayer1/src/UCTRegion.hh
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <iostream>
+#include <memory>
 
 #include "UCTTower.hh"
 
@@ -30,19 +31,19 @@ public:
 
   UCTRegion() = delete;
 
-  // No copy constructor is needed
-
-  UCTRegion(const UCTRegion&) = delete;
+  //copy constructor helps gettting around some memory leakage
+  // and ownership problems in the summary card emulation
+  UCTRegion(const UCTRegion&);
 
   // No equality operator is needed
 
   const UCTRegion& operator=(const UCTRegion&) = delete;
 
-  virtual ~UCTRegion();
+  virtual ~UCTRegion() = default;
 
   // To setData for towers before processing
 
-  const std::vector<UCTTower*>& getTowers() { return towers; }
+  const std::vector<std::shared_ptr<UCTTower>>& getTowers() { return towers; }
 
   // To process event
 
@@ -92,14 +93,14 @@ public:
 
   const bool isNegativeEta() const { return negativeEta; }
 
-  const UCTTower* getTower(UCTTowerIndex t) const { return getTower(t.first, t.second); }
+  const std::shared_ptr<UCTTower> getTower(UCTTowerIndex t) const { return getTower(t.first, t.second); }
 
   friend std::ostream& operator<<(std::ostream&, const UCTRegion&);
 
 protected:
   // Helper functions
 
-  const UCTTower* getTower(uint32_t caloEta, uint32_t caloPhi) const;
+  const std::shared_ptr<UCTTower> getTower(uint32_t caloEta, uint32_t caloPhi) const;
 
   // Region location definition
 
@@ -110,7 +111,7 @@ protected:
 
   // Owned region level data
 
-  std::vector<UCTTower*> towers;
+  std::vector<std::shared_ptr<UCTTower>> towers;
 
   uint32_t regionSummary;
 

--- a/L1Trigger/L1TCaloLayer1/src/UCTSummaryCard.hh
+++ b/L1Trigger/L1TCaloLayer1/src/UCTSummaryCard.hh
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <list>
+#include <memory>
 
 #include "UCTGeometryExtended.hh"
 
@@ -12,7 +13,7 @@ class UCTRegion;
 
 class UCTSummaryCard {
 public:
-  UCTSummaryCard(const std::vector<std::vector<std::vector<uint32_t> > >* l,
+  UCTSummaryCard(const std::vector<std::vector<std::vector<uint32_t>>>* l,
                  uint32_t jetSeedIn = 10,
                  uint32_t tauSeedIn = 10,
                  double tauIsolationFactorIn = 0.3,
@@ -27,7 +28,7 @@ public:
 
   const UCTSummaryCard& operator=(const UCTSummaryCard&) = delete;
 
-  virtual ~UCTSummaryCard();
+  virtual ~UCTSummaryCard() = default;
 
   // To set up event data before processing
 
@@ -38,24 +39,24 @@ public:
   bool clearEvent();
   bool clearRegions();
   bool setRegionData(
-      std::vector<UCTRegion*> inputRegions);  // Use when the region collection is available and no direct access to TPGs
+      std::vector<UCTRegion> inputRegions);  // Use when the region collection is available and no direct access to TPGs
   bool process();
 
   // Access to data
 
-  const std::list<UCTObject*>& getEMObjs() { return emObjs; }
-  const std::list<UCTObject*>& getIsoEMObjs() { return isoEMObjs; }
-  const std::list<UCTObject*>& getTauObjs() { return tauObjs; }
-  const std::list<UCTObject*>& getIsoTauObjs() { return isoTauObjs; }
-  const std::list<UCTObject*>& getCentralJetObjs() { return centralJetObjs; }
-  const std::list<UCTObject*>& getForwardJetObjs() { return forwardJetObjs; }
-  const std::list<UCTObject*>& getBoostedJetObjs() { return boostedJetObjs; }
+  const std::list<std::shared_ptr<UCTObject>>& getEMObjs() { return emObjs; }
+  const std::list<std::shared_ptr<UCTObject>>& getIsoEMObjs() { return isoEMObjs; }
+  const std::list<std::shared_ptr<UCTObject>>& getTauObjs() { return tauObjs; }
+  const std::list<std::shared_ptr<UCTObject>>& getIsoTauObjs() { return isoTauObjs; }
+  const std::list<std::shared_ptr<UCTObject>>& getCentralJetObjs() { return centralJetObjs; }
+  const std::list<std::shared_ptr<UCTObject>>& getForwardJetObjs() { return forwardJetObjs; }
+  const std::list<std::shared_ptr<UCTObject>>& getBoostedJetObjs() { return boostedJetObjs; }
 
-  const UCTObject* getET() { return ET; }
-  const UCTObject* getMET() { return MET; }
+  const std::shared_ptr<UCTObject> getET() { return ET; }
+  const std::shared_ptr<UCTObject> getMET() { return MET; }
 
-  const UCTObject* getHT() { return HT; }
-  const UCTObject* getMHT() { return MHT; }
+  const std::shared_ptr<UCTObject> getHT() { return HT; }
+  const std::shared_ptr<UCTObject> getMHT() { return MHT; }
 
   void print();
 
@@ -67,7 +68,7 @@ private:
   // Parameters specified at constructor level
 
   //  const UCTLayer1 *uctLayer1;
-  const std::vector<std::vector<std::vector<uint32_t> > >* pumLUT;
+  const std::vector<std::vector<std::vector<uint32_t>>>* pumLUT;
   uint32_t jetSeed;
   uint32_t tauSeed;
   double tauIsolationFactor;
@@ -76,25 +77,25 @@ private:
 
   // Owned card level data
 
-  std::vector<UCTRegion*> regions;
+  std::vector<UCTRegion> regions;
 
   double sinPhi[73];  // Make one extra so caloPhi : 1-72 can be used as index directly
   double cosPhi[73];
 
-  std::list<UCTObject*> emObjs;
-  std::list<UCTObject*> isoEMObjs;
-  std::list<UCTObject*> tauObjs;
-  std::list<UCTObject*> isoTauObjs;
-  std::list<UCTObject*> centralJetObjs;
-  std::list<UCTObject*> forwardJetObjs;
-  std::list<UCTObject*> boostedJetObjs;
+  std::list<std::shared_ptr<UCTObject>> emObjs;
+  std::list<std::shared_ptr<UCTObject>> isoEMObjs;
+  std::list<std::shared_ptr<UCTObject>> tauObjs;
+  std::list<std::shared_ptr<UCTObject>> isoTauObjs;
+  std::list<std::shared_ptr<UCTObject>> centralJetObjs;
+  std::list<std::shared_ptr<UCTObject>> forwardJetObjs;
+  std::list<std::shared_ptr<UCTObject>> boostedJetObjs;
 
-  UCTObject* ET;
-  UCTObject* MET;
+  std::shared_ptr<UCTObject> ET;
+  std::shared_ptr<UCTObject> MET;
 
-  UCTObject* HT;
-  UCTObject* MHT;
-
+  std::shared_ptr<UCTObject> HT;
+  std::shared_ptr<UCTObject> MHT;
+  
   uint32_t cardSummary;
 
   // Pileup subtraction LUT based on multiplicity of regions > threshold

--- a/L1Trigger/L1TCaloLayer1/src/UCTSummaryCard.hh
+++ b/L1Trigger/L1TCaloLayer1/src/UCTSummaryCard.hh
@@ -95,7 +95,7 @@ private:
 
   std::shared_ptr<UCTObject> HT;
   std::shared_ptr<UCTObject> MHT;
-  
+
   uint32_t cardSummary;
 
   // Pileup subtraction LUT based on multiplicity of regions > threshold

--- a/L1Trigger/L1TCaloLayer1/test/testUCTLayer1.cpp
+++ b/L1Trigger/L1TCaloLayer1/test/testUCTLayer1.cpp
@@ -57,7 +57,7 @@ void print(UCTLayer1& uct) {
         if (regions[rgn]->et() > 0) {
           int hitEta = regions[rgn]->hitCaloEta();
           int hitPhi = regions[rgn]->hitCaloPhi();
-          vector<UCTTower*> towers = regions[rgn]->getTowers();
+          std::vector<std::shared_ptr<UCTTower>> towers = regions[rgn]->getTowers();
           for (uint32_t twr = 0; twr < towers.size(); twr++) {
             if (towers[twr]->caloPhi() == hitPhi && towers[twr]->caloEta() == hitEta) {
               std::cout << "*";

--- a/L1Trigger/L1TCaloLayer1/test/testUCTLayer1.cpp
+++ b/L1Trigger/L1TCaloLayer1/test/testUCTLayer1.cpp
@@ -57,7 +57,7 @@ void print(UCTLayer1& uct) {
         if (regions[rgn]->et() > 0) {
           int hitEta = regions[rgn]->hitCaloEta();
           int hitPhi = regions[rgn]->hitCaloPhi();
-          std::vector<std::shared_ptr<UCTTower>> towers = regions[rgn]->getTowers();
+	  auto const& towers = regions[rgn]->getTowers();
           for (uint32_t twr = 0; twr < towers.size(); twr++) {
             if (towers[twr]->caloPhi() == hitPhi && towers[twr]->caloEta() == hitEta) {
               std::cout << "*";

--- a/L1Trigger/L1TCaloLayer1/test/testUCTLayer1.cpp
+++ b/L1Trigger/L1TCaloLayer1/test/testUCTLayer1.cpp
@@ -57,7 +57,7 @@ void print(UCTLayer1& uct) {
         if (regions[rgn]->et() > 0) {
           int hitEta = regions[rgn]->hitCaloEta();
           int hitPhi = regions[rgn]->hitCaloPhi();
-	  auto const& towers = regions[rgn]->getTowers();
+          auto const& towers = regions[rgn]->getTowers();
           for (uint32_t twr = 0; twr < towers.size(); twr++) {
             if (towers[twr]->caloPhi() == hitPhi && towers[twr]->caloEta() == hitEta) {
               std::cout << "*";

--- a/L1Trigger/L1TCaloLayer1/test/testUCTLayer1HF.cpp
+++ b/L1Trigger/L1TCaloLayer1/test/testUCTLayer1HF.cpp
@@ -56,7 +56,7 @@ void print(UCTLayer1& uct) {
     for (uint32_t crd = 0; crd < cards.size(); crd++) {
       vector<UCTRegion*> regions = cards[crd]->getRegions();
       for (uint32_t rgn = 0; rgn < regions.size(); rgn++) {
-        vector<std::shared_ptr<UCTTower>> towers = regions[rgn]->getTowers();
+	auto const& towers = regions[rgn]->getTowers();
         for (uint32_t twr = 0; twr < towers.size(); twr++) {
           if (towers[twr]->et() != 0)
             std::cout << *towers[twr] << std::endl;

--- a/L1Trigger/L1TCaloLayer1/test/testUCTLayer1HF.cpp
+++ b/L1Trigger/L1TCaloLayer1/test/testUCTLayer1HF.cpp
@@ -56,7 +56,7 @@ void print(UCTLayer1& uct) {
     for (uint32_t crd = 0; crd < cards.size(); crd++) {
       vector<UCTRegion*> regions = cards[crd]->getRegions();
       for (uint32_t rgn = 0; rgn < regions.size(); rgn++) {
-        vector<UCTTower*> towers = regions[rgn]->getTowers();
+        vector<std::shared_ptr<UCTTower>> towers = regions[rgn]->getTowers();
         for (uint32_t twr = 0; twr < towers.size(); twr++) {
           if (towers[twr]->et() != 0)
             std::cout << *towers[twr] << std::endl;

--- a/L1Trigger/L1TCaloLayer1/test/testUCTLayer1HF.cpp
+++ b/L1Trigger/L1TCaloLayer1/test/testUCTLayer1HF.cpp
@@ -56,7 +56,7 @@ void print(UCTLayer1& uct) {
     for (uint32_t crd = 0; crd < cards.size(); crd++) {
       vector<UCTRegion*> regions = cards[crd]->getRegions();
       for (uint32_t rgn = 0; rgn < regions.size(); rgn++) {
-	auto const& towers = regions[rgn]->getTowers();
+        auto const& towers = regions[rgn]->getTowers();
         for (uint32_t twr = 0; twr < towers.size(); twr++) {
           if (towers[twr]->et() != 0)
             std::cout << *towers[twr] << std::endl;


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/46543

#### PR description:

Taken from previous PR

> This PR should handle some of the worst offending pointer issues and memory leak problems in https://github.com/cms-sw/cmssw/issues/46526. This swaps a lot of Calo Layer 1 Infrastructure pointers over to std::shared_ptr's to try and avoid memory leak issues. Summary card regions are now stored as the objects themselves, instead of pointers to them (That decision may not be directly necessary? It makes sense to me, and there is a spot where pointers to these things are used internally, and nullptrs are possible but checked against)
> 
> This is just a first pass, but a larger fix of all of this infrastructure with smart pointers should be considered.

@mmusich @mandrenguyen FYI

#### PR validation:

All code compiles and has had code formatting applied. Bot tests.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is a backport to 14_1 of https://github.com/cms-sw/cmssw/pull/46543 for purposes of PbPb prompt reconstruction fixes