### PR TITLE
Bugfix for EMTF DQM module

### DIFF
--- a/DQM/L1TMonitor/src/L1TStage2EMTF.cc
+++ b/DQM/L1TMonitor/src/L1TStage2EMTF.cc
@@ -1006,7 +1006,7 @@ void L1TStage2EMTF::analyze(const edm::Event& e, const edm::EventSetup& c) {
         gemChamberPartition[hist_index]->Fill(chamber, Hit->Partition());
         gemHitOccupancy->Fill(chamber_bin(1, 1, chamber), (endcap > 0) ? 1.5 : 0.5);  // follow CSC convention
         //Added plots 07-21-22 ***
-        gemVFATBXPerChamber[chamber - 1][hist_index][layer-1]->Fill(Hit->BX(), vfat);
+        gemVFATBXPerChamber[chamber - 1][hist_index][layer - 1]->Fill(Hit->BX(), vfat);
         //indexed plots by BX 07-21-22
         gemChamberVFATBX[hist_index][Hit->BX() + 3]->Fill(chamber_bin(1, 1, chamber), vfat);
       }

--- a/DQM/L1TMonitor/src/L1TStage2EMTF.cc
+++ b/DQM/L1TMonitor/src/L1TStage2EMTF.cc
@@ -1006,7 +1006,7 @@ void L1TStage2EMTF::analyze(const edm::Event& e, const edm::EventSetup& c) {
         gemChamberPartition[hist_index]->Fill(chamber, Hit->Partition());
         gemHitOccupancy->Fill(chamber_bin(1, 1, chamber), (endcap > 0) ? 1.5 : 0.5);  // follow CSC convention
         //Added plots 07-21-22 ***
-        gemVFATBXPerChamber[chamber - 1][hist_index][layer]->Fill(Hit->BX(), vfat);
+        gemVFATBXPerChamber[chamber - 1][hist_index][layer-1]->Fill(Hit->BX(), vfat);
         //indexed plots by BX 07-21-22
         gemChamberVFATBX[hist_index][Hit->BX() + 3]->Fill(chamber_bin(1, 1, chamber), vfat);
       }


### PR DESCRIPTION
#### PR description:

This PR addresses https://github.com/cms-sw/cmssw/issues/46182 

I verified that GEM layer always takes values 1 or 2 and also verified this with GEM experts. The solution is to subtract 1 from `layer` while filling the histograms. 

#### PR validation:

Validated by running DQM on recent data. The plots are filled correctly for layers 1 and 2 after the fix.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

We can backport this to 14_1_X to fix the problem during the HI run as well.

