### PR TITLE
[NANO] Implement a check on the number of scale variation weights in GenWeightsTableProducer

### DIFF
--- a/PhysicsTools/NanoAOD/python/genWeightsTable_cfi.py
+++ b/PhysicsTools/NanoAOD/python/genWeightsTable_cfi.py
@@ -24,6 +24,7 @@ genWeightsTable = cms.EDProducer("GenWeightsTableProducer",
     lheWeightPrecision = cms.int32(14),
     maxPdfWeights = cms.uint32(150),
     keepAllPSWeights = cms.bool(False),
+    allowedNumScaleWeights = cms.vuint32(9),
     debug = cms.untracked.bool(False),
 )
 


### PR DESCRIPTION
#### PR description:

This PR implements a possible mitigation of the LHEScaleSumw issue, as discussed in the [PPD general meeting](https://indico.cern.ch/event/1470301/#6-xpog-remini-renano-discussio) today. Feedback is welcome!

Basically a configurable option `allowedNumScaleWeights` is introduced to `GenWeightsTableProducer`, which can take a list of numbers, and the number of scale variation weights identified by parsing the `initrwgt` header of `LHERunInfoProduct` must match one of the values provided in `allowedNumScaleWeights`, otherwise a `LogicError` is thrown. The default value of `allowedNumScaleWeights` is set to 9 as it is the expected number of scale variations in the standard setup. An empty list for `allowedNumScaleWeights` means any number of scale variation weights is allowed and no check is performed.

This PR also fixes the parsing of certain MadGraph headers where it fails to pick up the central weight, as in some cases the central weight is outside any weight group. This has led to some NanoAOD samples containing only 8 (instead of 9) scale weights.

Related issue: https://github.com/cms-sw/cmssw/issues/43784

#### PR validation:

Passes local tests with:
- [x]  a `normal` MadGraph file with the expected, 9 scale weights: 
     - `/store/mc/Run3Summer22EEMiniAODv4/DYGto2LG-1Jets_MLL-50_PTG-10to50_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/MINIAODSIM/130X_mcRun3_2022_realistic_postEE_v6-v2/30000/0fd00136-3752-4096-8e82-4b6fcd656da4.root`
- [x] a buggy MadGraph file with no PDF/scale weights and missing the`initrwgt` header : 
    - `/store/mc/Run3Summer22EEMiniAODv4/DYGto2LG-1Jets_MLL-50_PTG-10to50_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/MINIAODSIM/130X_mcRun3_2022_realistic_postEE_v6-v2/40000/c22ada93-447e-4db9-bee9-fcb3ab3e7fa9.root`
- [x] another MG file where only 8 scale weights were identified before the change:
    - `/store/mc/RunIISummer20UL16MiniAODAPVv2/TTZ-ZToBB-TTTo2L_TuneCP5_13TeV-amcatnlo-pythia8/MINIAODSIM/106X_mcRun2_asymptotic_preVFP_v11-v2/2560000/02890624-0027-E345-880C-C8372B42C942.root`


#### Update on Nov 19

A large-scale test was performed to check essentially all generator configurations in UL18 and 2022. Basically I took all the samples in GrASP for UL18 and 2022, then group them by the `short name`, and then pick only one sample for each generator suffix (e.g., `madgraphMLM-pythia8`) from the group and run `GenWeightsTableProducer` on one file.

A few modifications (https://github.com/cms-sw/cmssw/pull/46573/commits/c8a0f0b6fd9718d7065e5746228c4a332f7311fa) was made based on the findings from the test:
- Restrict the check to MadGraph samples, and more specifically, MG5 version `2.x.y`. 
   - it was found some PowHeg MiNNLO samples are configured with more scale variations
   - there are few MG samples using MG version 3.x (with pLHE workflow), and the current code cannot parse MG 3.x headers consistently
- Fixed another scenario where the central weight is not identified -- basically if the `mg_reweighting` group appears before the scale variation group.

After these changes, all ~500 sample groups for 2022 passed the test, and only 2 (out of ~1100) sample groups in UL18 still fail (modulo 5-10% failures due to unable to access files via xrootd which are not accounted here):
 -  VH SMEFT:
    - WHJet_HToBB_WToLNu_M-125_TuneCP5_SMEFTsim_topU3l_13TeV-madgraphMLM-pythia8
    - ZHJet_HToBB_ZToLL_M-125_TuneCP5_SMEFTsim_topU3l_13TeV-madgraphMLM-pythia8
    - ZHJet_HToBB_ZToNuNu_M-125_TuneCP5_SMEFTsim_topU3l_13TeV-madgraphMLM-pythia8
    - (it seems these samples are misconfigured with `None = systematics_program`?)
- IDM:
    - IDM_MuMuHH_MA100_MH45_MHp150_TuneCP5_13TeV-madgraph-pythia8
    - IDM_MuMuHH_MA120_MH72_MHp150_TuneCP5_13TeV-madgraph-pythia8
    - IDM_MuMuHH_MA150_MH80_MHp193_TuneCP5_13TeV-madgraph-pythia8
    - (these have `systematics = systematics_program`  but still no scale weights)
