### PR TITLE
Rework Muon candidate selection in few tracker ALCARECO  

### DIFF
--- a/Alignment/CommonAlignmentProducer/plugins/AlignmentGoodIdMuonSelector.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/AlignmentGoodIdMuonSelector.cc
@@ -1,0 +1,127 @@
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+
+class AlignmentGoodIdMuonSelector : public edm::global::EDFilter<> {
+public:
+  explicit AlignmentGoodIdMuonSelector(const edm::ParameterSet&);
+  ~AlignmentGoodIdMuonSelector() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+
+  const edm::EDGetTokenT<reco::MuonCollection> muonToken_;
+  const double maxEta_;
+  const double maxChi2_;
+  const int minMuonHits_;
+  const int minMatches_;
+  const bool requireGlobal_;
+  const bool requireTracker_;
+  const bool filterEvents_;  // flag to control event filtering behavior
+
+  // Secondary selection parameters (e.g., for Phase 2)
+  const bool useSecondarySelection_;
+  const double secondaryEtaLow_;
+  const double secondaryEtaHigh_;
+  const int secondaryMinMatches_;
+  const bool requireTrackerForSecondary_;
+};
+
+void AlignmentGoodIdMuonSelector::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("src", edm::InputTag("muons"))->setComment("Input muon collection");
+  desc.add<double>("maxEta", 2.5)->setComment("|eta| cut");
+  desc.add<double>("maxChi2", 20.)->setComment("max chi2 of the global tags");
+  desc.add<int>("minMuonHits", 0.)->setComment("minimum number of valid muon hits");
+  desc.add<int>("minMatches", 1.)->setComment("minimum number of matches");
+  desc.add<bool>("requireGlobal", true)->setComment("is global muons");
+  desc.add<bool>("requireTracker", true)->setComment("is tracker muon");
+  desc.add<bool>("useSecondarySelection", false)->setComment("secondary selection");
+  desc.add<double>("secondaryEtaLow", 2.3)->setComment("min eta cut (secondary)");
+  desc.add<double>("secondaryEtaHigh", 3.0)->setComment("max eta cut (secondary)");
+  desc.add<int>("secondaryMinMatches", 0.)->setComment("minimum number of matches (secondary)");
+  desc.add<bool>("secondaryRequireTracker", true)->setComment("is tracker muon (secondary)");
+  desc.add<bool>("filter", true)->setComment("retain event only if non empty collection");
+  descriptions.addWithDefaultLabel(desc);
+}
+
+AlignmentGoodIdMuonSelector::AlignmentGoodIdMuonSelector(const edm::ParameterSet& iConfig)
+    : muonToken_(consumes<reco::MuonCollection>(iConfig.getParameter<edm::InputTag>("src"))),
+      maxEta_(iConfig.getParameter<double>("maxEta")),
+      maxChi2_(iConfig.getParameter<double>("maxChi2")),
+      minMuonHits_(iConfig.getParameter<int>("minMuonHits")),
+      minMatches_(iConfig.getParameter<int>("minMatches")),
+      requireGlobal_(iConfig.getParameter<bool>("requireGlobal")),
+      requireTracker_(iConfig.getParameter<bool>("requireTracker")),
+      filterEvents_(iConfig.getParameter<bool>("filter")),
+
+      // Secondary selection
+      useSecondarySelection_(iConfig.getParameter<bool>("useSecondarySelection")),
+      secondaryEtaLow_(iConfig.getParameter<double>("secondaryEtaLow")),
+      secondaryEtaHigh_(iConfig.getParameter<double>("secondaryEtaHigh")),
+      secondaryMinMatches_(iConfig.getParameter<int>("secondaryMinMatches")),
+      requireTrackerForSecondary_(iConfig.getParameter<bool>("secondaryRequireTracker")) {
+  produces<reco::MuonCollection>();
+}
+
+bool AlignmentGoodIdMuonSelector::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup&) const {
+  edm::Handle<reco::MuonCollection> muons;
+  iEvent.getByToken(muonToken_, muons);
+
+  auto selectedMuons = std::make_unique<reco::MuonCollection>();
+
+  for (const auto& muon : *muons) {
+    bool passPrimarySelection = true;
+
+    // Check if globalTrack() is valid before using it
+    if (requireGlobal_) {
+      if (!muon.isGlobalMuon() || muon.globalTrack().isNull()) {
+        passPrimarySelection = false;
+      } else {
+        // Only access properties if the global track is valid
+        if (muon.globalTrack()->hitPattern().numberOfValidMuonHits() <= minMuonHits_)
+          passPrimarySelection = false;
+        if (muon.globalTrack()->normalizedChi2() >= maxChi2_)
+          passPrimarySelection = false;
+      }
+    }
+
+    if (requireTracker_ && !muon.isTrackerMuon())
+      passPrimarySelection = false;
+    if (muon.numberOfMatches() <= minMatches_)
+      passPrimarySelection = false;
+    if (std::abs(muon.eta()) >= maxEta_)
+      passPrimarySelection = false;
+
+    bool passSecondarySelection = false;
+    if (useSecondarySelection_) {
+      if (std::abs(muon.eta()) > secondaryEtaLow_ && std::abs(muon.eta()) < secondaryEtaHigh_ &&
+          muon.numberOfMatches() >= secondaryMinMatches_ && (!requireTrackerForSecondary_ || muon.isTrackerMuon())) {
+        passSecondarySelection = true;
+      }
+    }
+
+    if (passPrimarySelection || passSecondarySelection) {
+      selectedMuons->push_back(muon);
+    }
+  }
+
+  const bool passEvent = !selectedMuons->empty();
+  iEvent.put(std::move(selectedMuons));
+
+  // Decide if the event should pass based on filterEvents_ flag
+  return filterEvents_ ? passEvent : true;
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(AlignmentGoodIdMuonSelector);

--- a/Alignment/CommonAlignmentProducer/plugins/AlignmentRelCombIsoMuonSelector.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/AlignmentRelCombIsoMuonSelector.cc
@@ -1,0 +1,75 @@
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+
+class AlignmentRelCombIsoMuonSelector : public edm::global::EDFilter<> {
+public:
+  explicit AlignmentRelCombIsoMuonSelector(const edm::ParameterSet&);
+  ~AlignmentRelCombIsoMuonSelector() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+
+  edm::EDGetTokenT<reco::MuonCollection> muonToken_;
+  const double relCombIsoCut_;
+  const bool useTrackerOnlyIsolation_;  // New flag for tracker-only isolation
+  const bool filterEvents_;
+};
+
+void AlignmentRelCombIsoMuonSelector::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("src", edm::InputTag("muons"))->setComment("Input muon collection");
+  desc.add<double>("relCombIsoCut", 0.15)->setComment("cut on the relative combined isolation");
+  desc.add<bool>("useTrackerOnlyIsolation", false)->setComment("use only tracker isolation");
+  desc.add<bool>("filter", true);
+  descriptions.addWithDefaultLabel(desc);
+}
+
+AlignmentRelCombIsoMuonSelector::AlignmentRelCombIsoMuonSelector(const edm::ParameterSet& iConfig)
+    : muonToken_(consumes<reco::MuonCollection>(iConfig.getParameter<edm::InputTag>("src"))),
+      relCombIsoCut_(iConfig.getParameter<double>("relCombIsoCut")),
+      useTrackerOnlyIsolation_(iConfig.getParameter<bool>("useTrackerOnlyIsolation")),
+      filterEvents_(iConfig.getParameter<bool>("filter")) {
+  produces<reco::MuonCollection>();
+}
+
+bool AlignmentRelCombIsoMuonSelector::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup&) const {
+  edm::Handle<reco::MuonCollection> muons;
+  iEvent.getByToken(muonToken_, muons);
+
+  auto selectedMuons = std::make_unique<reco::MuonCollection>();
+
+  for (const auto& muon : *muons) {
+    double relCombIso;
+    if (useTrackerOnlyIsolation_) {
+      // Tracker-only isolation
+      relCombIso = muon.isolationR03().sumPt / muon.pt();
+    } else {
+      // Full combined isolation
+      relCombIso = (muon.isolationR03().sumPt + muon.isolationR03().emEt + muon.isolationR03().hadEt) / muon.pt();
+    }
+
+    if (relCombIso < relCombIsoCut_) {
+      selectedMuons->push_back(muon);
+    }
+  }
+
+  const bool passEvent = !selectedMuons->empty();
+  iEvent.put(std::move(selectedMuons));
+
+  // Apply the filter flag logic
+  return filterEvents_ ? passEvent : true;
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(AlignmentRelCombIsoMuonSelector);

--- a/Alignment/CommonAlignmentProducer/plugins/BuildFile.xml
+++ b/Alignment/CommonAlignmentProducer/plugins/BuildFile.xml
@@ -57,3 +57,8 @@
   <use name="HLTrigger/HLTcore"/>
   <flags EDM_PLUGIN="1"/>
 </library>
+
+<library file="Alignment*MuonSelector.cc" name="AlignmentCommonAlignmentProducerSelector">
+  <use name="DataFormats/MuonReco"/>
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlDiMuonAndVertex_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlDiMuonAndVertex_cff.py
@@ -3,13 +3,12 @@ import FWCore.ParameterSet.Config as cms
 ##################################################################
 # Exact same configuration as TkAlZMuMu: extract mumu pairs
 #################################################################
+from Alignment.CommonAlignmentProducer.TkAlMuonSelectors_cfi import *
 import Alignment.CommonAlignmentProducer.ALCARECOTkAlZMuMu_cff as confALCARECOTkAlZMuMu
 ALCARECOTkAlDiMuonHLT = confALCARECOTkAlZMuMu.ALCARECOTkAlZMuMuHLT.clone()
 ALCARECOTkAlDiMuonDCSFilter = confALCARECOTkAlZMuMu.ALCARECOTkAlZMuMuDCSFilter.clone()
-ALCARECOTkAlDiMuonGoodMuons = confALCARECOTkAlZMuMu.ALCARECOTkAlZMuMuGoodMuons.clone()
-ALCARECOTkAlDiMuonRelCombIsoMuons = confALCARECOTkAlZMuMu.ALCARECOTkAlZMuMuRelCombIsoMuons.clone(src = 'ALCARECOTkAlDiMuonGoodMuons')
 ALCARECOTkAlDiMuon = confALCARECOTkAlZMuMu.ALCARECOTkAlZMuMu.clone()
-ALCARECOTkAlDiMuon.GlobalSelector.muonSource = 'ALCARECOTkAlDiMuonRelCombIsoMuons'
+ALCARECOTkAlDiMuon.GlobalSelector.muonSource = 'TkAlRelCombIsoMuonSelector'
 
 ##################################################################
 # Tracks from the selected vertex
@@ -31,8 +30,7 @@ TkAlDiMuonAndVertexGenMuonSelector = cms.EDFilter("GenParticleSelector",
 #################################################################
 seqALCARECOTkAlDiMuonAndVertex = cms.Sequence(ALCARECOTkAlDiMuonHLT+
                                               ALCARECOTkAlDiMuonDCSFilter+
-                                              ALCARECOTkAlDiMuonGoodMuons+
-                                              ALCARECOTkAlDiMuonRelCombIsoMuons+
+                                              seqALCARECOTkAlRelCombIsoMuons+
                                               ALCARECOTkAlDiMuon+
                                               ALCARECOTkAlDiMuonVertexTracks+
                                               TkAlDiMuonAndVertexGenMuonSelector)

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMuonIsolated_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMuonIsolated_cff.py
@@ -21,11 +21,7 @@ ALCARECOTkAlMuonIsolatedDCSFilter = DPGAnalysis.Skims.skim_detstatus_cfi.dcsstat
     DebugOn      = cms.untracked.bool(False)
 )
 
-import Alignment.CommonAlignmentProducer.TkAlMuonSelectors_cfi
-ALCARECOTkAlMuonIsolatedGoodMuons = Alignment.CommonAlignmentProducer.TkAlMuonSelectors_cfi.TkAlGoodIdMuonSelector.clone()
-ALCARECOTkAlMuonIsolatedRelCombIsoMuons = Alignment.CommonAlignmentProducer.TkAlMuonSelectors_cfi.TkAlRelCombIsoMuonSelector.clone(
-    src = 'ALCARECOTkAlMuonIsolatedGoodMuons'
-)
+from Alignment.CommonAlignmentProducer.TkAlMuonSelectors_cfi import *
 
 import Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi
 ALCARECOTkAlMuonIsolated = Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi.AlignmentTrackSelector.clone(
@@ -37,7 +33,7 @@ ALCARECOTkAlMuonIsolated = Alignment.CommonAlignmentProducer.AlignmentTrackSelec
     nHitMin = 0
 )
 
-ALCARECOTkAlMuonIsolated.GlobalSelector.muonSource = 'ALCARECOTkAlMuonIsolatedRelCombIsoMuons'
+ALCARECOTkAlMuonIsolated.GlobalSelector.muonSource = 'TkAlRelCombIsoMuonSelector'
 # Isolation is shifted to the muon preselection, and then applied intrinsically if applyGlobalMuonFilter = True
 ALCARECOTkAlMuonIsolated.GlobalSelector.applyIsolationtest = False
 ALCARECOTkAlMuonIsolated.GlobalSelector.minJetDeltaR = 0.1
@@ -47,8 +43,10 @@ ALCARECOTkAlMuonIsolated.TwoBodyDecaySelector.applyMassrangeFilter = False
 ALCARECOTkAlMuonIsolated.TwoBodyDecaySelector.applyChargeFilter = False
 ALCARECOTkAlMuonIsolated.TwoBodyDecaySelector.applyAcoplanarityFilter = False
 
-seqALCARECOTkAlMuonIsolated = cms.Sequence(ALCARECOTkAlMuonIsolatedHLT+ALCARECOTkAlMuonIsolatedDCSFilter+ALCARECOTkAlMuonIsolatedGoodMuons+ALCARECOTkAlMuonIsolatedRelCombIsoMuons+ALCARECOTkAlMuonIsolated)
-
+seqALCARECOTkAlMuonIsolated = cms.Sequence(ALCARECOTkAlMuonIsolatedHLT+
+                                           ALCARECOTkAlMuonIsolatedDCSFilter+
+                                           seqALCARECOTkAlRelCombIsoMuons+
+                                           ALCARECOTkAlMuonIsolated)
 
 ## customizations for the pp_on_AA eras
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMu_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMu_cff.py
@@ -23,11 +23,7 @@ ALCARECOTkAlUpsilonMuMuDCSFilter = DPGAnalysis.Skims.skim_detstatus_cfi.dcsstatu
 
 import Alignment.CommonAlignmentProducer.TkAlMuonSelectors_cfi
 ALCARECOTkAlUpsilonMuMuGoodMuons = Alignment.CommonAlignmentProducer.TkAlMuonSelectors_cfi.TkAlGoodIdMuonSelector.clone()
-ALCARECOTkAlUpsilonMuMuRelCombIsoMuons = Alignment.CommonAlignmentProducer.TkAlMuonSelectors_cfi.TkAlRelCombIsoMuonSelector.clone(
-    src = 'ALCARECOTkAlUpsilonMuMuGoodMuons',
-    cut = '(isolationR03().sumPt + isolationR03().emEt + isolationR03().hadEt)/pt  < 0.3'
-
-)
+ALCARECOTkAlUpsilonMuMuRelCombIsoMuons = Alignment.CommonAlignmentProducer.TkAlMuonSelectors_cfi.TkAlRelCombIsoMuonSelector.clone(src = 'ALCARECOTkAlUpsilonMuMuGoodMuons')
 
 import Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi
 ALCARECOTkAlUpsilonMuMu = Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi.AlignmentTrackSelector.clone()

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMuPA_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMuPA_cff.py
@@ -9,7 +9,7 @@ ALCARECOTkAlZMuMuPAHLT = ALCARECOTkAlZMuMuHLT.clone(
 
 ALCARECOTkAlZMuMuPADCSFilter = ALCARECOTkAlZMuMuDCSFilter.clone()
 
-ALCARECOTkAlZMuMuPAGoodMuons = ALCARECOTkAlZMuMuGoodMuons.clone()
+ALCARECOTkAlZMuMuPAGoodMuons = TkAlGoodIdMuonSelector.clone()
 
 ALCARECOTkAlZMuMuPA = ALCARECOTkAlZMuMu.clone(
      src = 'generalTracks'
@@ -18,6 +18,6 @@ ALCARECOTkAlZMuMuPA.GlobalSelector.muonSource = 'ALCARECOTkAlZMuMuPAGoodMuons'
 
 seqALCARECOTkAlZMuMuPA = cms.Sequence(ALCARECOTkAlZMuMuPAHLT
                                       +ALCARECOTkAlZMuMuPADCSFilter
-                                      +ALCARECOTkAlZMuMuPAGoodMuons
+                                      +TkAlGoodIdMuonSelector
                                       +ALCARECOTkAlZMuMuPA
                                       )

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMu_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMu_cff.py
@@ -21,11 +21,8 @@ ALCARECOTkAlZMuMuDCSFilter = DPGAnalysis.Skims.skim_detstatus_cfi.dcsstatus.clon
     DebugOn      = cms.untracked.bool(False)
 )
 
-import Alignment.CommonAlignmentProducer.TkAlMuonSelectors_cfi
-ALCARECOTkAlZMuMuGoodMuons = Alignment.CommonAlignmentProducer.TkAlMuonSelectors_cfi.TkAlGoodIdMuonSelector.clone()
-ALCARECOTkAlZMuMuRelCombIsoMuons = Alignment.CommonAlignmentProducer.TkAlMuonSelectors_cfi.TkAlRelCombIsoMuonSelector.clone(
-    src = 'ALCARECOTkAlZMuMuGoodMuons'
-)
+## standard muon selection
+from Alignment.CommonAlignmentProducer.TkAlMuonSelectors_cfi import *
 
 import Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi
 ALCARECOTkAlZMuMu = Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi.AlignmentTrackSelector.clone()
@@ -37,7 +34,7 @@ ALCARECOTkAlZMuMu.etaMin = -3.5
 ALCARECOTkAlZMuMu.etaMax = 3.5
 ALCARECOTkAlZMuMu.nHitMin = 0
 
-ALCARECOTkAlZMuMu.GlobalSelector.muonSource = 'ALCARECOTkAlZMuMuRelCombIsoMuons'
+ALCARECOTkAlZMuMu.GlobalSelector.muonSource = 'TkAlRelCombIsoMuonSelector'
 # Isolation is shifted to the muon preselection, and then applied intrinsically if applyGlobalMuonFilter = True
 ALCARECOTkAlZMuMu.GlobalSelector.applyIsolationtest = False
 ALCARECOTkAlZMuMu.GlobalSelector.applyGlobalMuonFilter = True
@@ -58,7 +55,11 @@ TkAlZMuMuGenMuonSelector = cms.EDFilter("GenParticleSelector",
                                         filter = cms.bool(False),
                                         throwOnMissing = cms.untracked.bool(False))
 
-seqALCARECOTkAlZMuMu = cms.Sequence(ALCARECOTkAlZMuMuHLT+ALCARECOTkAlZMuMuDCSFilter+ALCARECOTkAlZMuMuGoodMuons+ALCARECOTkAlZMuMuRelCombIsoMuons+ALCARECOTkAlZMuMu+TkAlZMuMuGenMuonSelector)
+seqALCARECOTkAlZMuMu = cms.Sequence(ALCARECOTkAlZMuMuHLT+
+                                    ALCARECOTkAlZMuMuDCSFilter+
+                                    seqALCARECOTkAlRelCombIsoMuons+
+                                    ALCARECOTkAlZMuMu+
+                                    TkAlZMuMuGenMuonSelector)
 
 ## customizations for the pp_on_AA eras
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017

--- a/Alignment/CommonAlignmentProducer/python/TkAlMuonSelectors_cfi.py
+++ b/Alignment/CommonAlignmentProducer/python/TkAlMuonSelectors_cfi.py
@@ -1,31 +1,48 @@
 import FWCore.ParameterSet.Config as cms
 
-TkAlGoodIdMuonSelector = cms.EDFilter("MuonSelector",
-    src = cms.InputTag('muons'),
-    cut = cms.string('isGlobalMuon &'
-                     'isTrackerMuon &'
-                     'numberOfMatches > 1 &'
-                     'globalTrack.hitPattern.numberOfValidMuonHits > 0 &'
-                     'abs(eta) < 2.5 &'
-                     'globalTrack.normalizedChi2 < 20.'),
-    filter = cms.bool(True)
-)
+# original selection:
+# 'isGlobalMuon & isTrackerMuon & numberOfMatches > 1 & globalTrack.hitPattern.numberOfValidMuonHits > 0
+#  & abs(eta) < 2.5 & globalTrack.normalizedChi2 < 20.'
 
-TkAlRelCombIsoMuonSelector = cms.EDFilter("MuonSelector",
-    src = cms.InputTag(''),
-    cut = cms.string('(isolationR03().sumPt + isolationR03().emEt + isolationR03().hadEt)/pt  < 0.15'),
-    filter = cms.bool(True)
-)
+from Alignment.CommonAlignmentProducer.alignmentGoodIdMuonSelector_cfi import alignmentGoodIdMuonSelector
+TkAlGoodIdMuonSelector = alignmentGoodIdMuonSelector.clone(src = 'muons',
+                                                           requireGlobal = True,
+                                                           requireTracker = True,
+                                                           minMatches = 1,
+                                                           minMuonHits = 0,
+                                                           maxEta = 2.5,
+                                                           maxChi2 = 20,
+                                                           filter = True)
+# original selection:
+# '(isolationR03().sumPt + isolationR03().emEt + isolationR03().hadEt)/pt  < 0.15'
+
+from Alignment.CommonAlignmentProducer.alignmentRelCombIsoMuonSelector_cfi import alignmentRelCombIsoMuonSelector
+TkAlRelCombIsoMuonSelector = alignmentRelCombIsoMuonSelector.clone(src = cms.InputTag('TkAlGoodIdMuonSelector'),
+                                                                   filter = True,
+                                                                   relCombIsoCut = 0.15,
+                                                                   useTrackerOnlyIsolation = False)
+
+# Define a common sequence to be imported in ALCARECOs
+seqALCARECOTkAlRelCombIsoMuons = cms.Sequence(TkAlGoodIdMuonSelector+TkAlRelCombIsoMuonSelector)
 
 ## FIXME: these are needed for ALCARECO production in CMSSW_14_0_X
 ## to avoid loosing in efficiency. To be reviewed after muon reco is fixed
 
+# original selection:
+# '(isGlobalMuon & isTrackerMuon & numberOfMatches > 1 & globalTrack.hitPattern.numberOfValidMuonHits > 0
+#  & abs(eta) < 2.5 & globalTrack.normalizedChi2 < 20.) || (abs(eta) > 2.3 & abs(eta) < 3.0 & numberOfMatches >= 0 & isTrackerMuon)'
+
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 phase2_common.toModify(TkAlGoodIdMuonSelector,
-                       cut = '(abs(eta) < 2.5 & isGlobalMuon & isTrackerMuon & numberOfMatches > 1 & globalTrack.hitPattern.numberOfValidMuonHits > 0 &  globalTrack.normalizedChi2 < 20.) ||'  # regular selection
-                       '(abs(eta) > 2.3 & abs(eta) < 3.0 & numberOfMatches >= 0 & isTrackerMuon)'   # to recover GE0 tracks
-                       )
+                       useSecondarySelection = True, # to recover tracks passing through GE0
+                       secondaryEtaLow = 2.3,
+                       secondaryEtaHigh = 3,
+                       secondaryMinMatches = 0,
+                       secondaryRequireTracker = True)
+
+# original selection:
+# '(isolationR03().sumPt)/pt < 0.1'
 
 phase2_common.toModify(TkAlRelCombIsoMuonSelector,
-                       cut = '(isolationR03().sumPt)/pt < 0.1' # only tracker isolation
-                       )
+                       relCombIsoCut = 0.10,
+                       useTrackerOnlyIsolation = True)  # only tracker isolation

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalSingleMuonTight_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalSingleMuonTight_cff.py
@@ -24,11 +24,7 @@ ALCARECOSiPixelCalSingleMuonTightDCSFilter = DPGAnalysis.Skims.skim_detstatus_cf
 ##################################################################
 # Isolated muons Track selector
 ##################################################################
-import Alignment.CommonAlignmentProducer.TkAlMuonSelectors_cfi
-ALCARECOSiPixelCalSingleMuonTightGoodMuons = Alignment.CommonAlignmentProducer.TkAlMuonSelectors_cfi.TkAlGoodIdMuonSelector.clone()
-ALCARECOSiPixelCalSingleMuonTightRelCombIsoMuons = Alignment.CommonAlignmentProducer.TkAlMuonSelectors_cfi.TkAlRelCombIsoMuonSelector.clone(
-    src = 'ALCARECOSiPixelCalSingleMuonTightGoodMuons'
-)
+from Alignment.CommonAlignmentProducer.TkAlMuonSelectors_cfi import *
 
 ##################################################################
 # Basic Track selection
@@ -46,7 +42,7 @@ ALCARECOSiPixelCalSingleMuonTight = Alignment.CommonAlignmentProducer.AlignmentT
 ##################################################################
 # Muon selection
 ##################################################################
-ALCARECOSiPixelCalSingleMuonTight.GlobalSelector.muonSource = 'ALCARECOSiPixelCalSingleMuonTightRelCombIsoMuons'
+ALCARECOSiPixelCalSingleMuonTight.GlobalSelector.muonSource = 'TkAlRelCombIsoMuonSelector'
 # Isolation is shifted to the muon preselection, and then applied intrinsically if applyGlobalMuonFilter = True
 ALCARECOSiPixelCalSingleMuonTight.GlobalSelector.applyIsolationtest = False
 ALCARECOSiPixelCalSingleMuonTight.GlobalSelector.minJetDeltaR = 0.1
@@ -91,8 +87,7 @@ trackDistances = TrackDistanceValueMap.TrackDistanceValueMapProducer.clone(muonT
 seqALCARECOSiPixelCalSingleMuonTight = cms.Sequence(offlineBeamSpot+
                                                     ALCARECOSiPixelCalSingleMuonTightHLTFilter+
                                                     ALCARECOSiPixelCalSingleMuonTightDCSFilter+
-                                                    ALCARECOSiPixelCalSingleMuonTightGoodMuons+
-                                                    ALCARECOSiPixelCalSingleMuonTightRelCombIsoMuons+
+                                                    seqALCARECOTkAlRelCombIsoMuons+
                                                     ALCARECOSiPixelCalSingleMuonTight+
                                                     trackDistances +
                                                     ALCARECOSiPixelCalSingleMuonTightOffTrackClusters)


### PR DESCRIPTION
#### PR description:

This PR is a partial response to https://github.com/cms-sw/cmssw/issues/46493.
In https://github.com/cms-sw/cmssw/issues/46493#issuecomment-2432672540 it was suggested to replace few of the `MuonSelector` (`ObjectSelectorBase<SingleElementCollectionSelector<edm::View<reco::Muon>, ...> `) instances with modules that express the structure of the selection in C++ code instead, as this would allow to reduce the memory footprint in Run 3 prompt reco jobs for `Muon*` PDs.
This is implemented in commits 8e3de6568ee2a4d2b6141d8463689274fd12e0a0 and 2d97abd56f34981d62e260bcc10725662379cd41 that introduce ad-hoc classes `AlignmentGoodIdMuonSelector` and `AlignmentRelCombIsoMuonSelector` for this purpose.
Additionally in https://github.com/cms-sw/cmssw/issues/46493#issuecomment-2432744958 it was suggested that the duplication of selection identical modules configuration has both memory and runtime cost. This is addressed at 8e49f10451877c56f6cf1def481603198b840914 by introducing a new common sequence `seqALCARECOTkAlRelCombIsoMuons` that ulimately takes in input a `reco::MuonCollection` (with label `muons`) and returns a skimmed `reco::MuonCollection` called `TkAlRelCombIsoMuonSelector` which is then used to feed the rest of the selection chain.

#### PR validation:

```
runTheMatrix.py -l 1001.0,1001.2,1001.3,1001.4,1002.4
```
runs. 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A
