### PR TITLE
[UBSAN][VirtualJetProducer]Avoid creating vector of size zero for jet=1

### DIFF
--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
@@ -685,7 +685,7 @@ void VirtualJetProducer::writeJets(edm::Event& iEvent, edm::EventSetup const& iS
   if (!fjJets_.empty()) {
     // Distance between jet centers and overlap area -- for disk-based area calculation
     using RIJ = std::pair<double, double>;
-    std::vector<RIJ> rijStorage(fjJets_.size() * (fjJets_.size() / 2));
+    std::vector<RIJ> rijStorage(fjJets_.size() == 1 ? 1 : fjJets_.size() * (fjJets_.size() >> 1));
     std::vector<RIJ*> rij(fjJets_.size());
     unsigned int k = 0;
     for (unsigned int ijet = 0; ijet < fjJets_.size(); ++ijet) {


### PR DESCRIPTION
This fixes the issue https://github.com/cms-sw/cmssw/issues/44998
The change makes sure that we do not create (and reference) vector of zero size. This will avoid the runtime error [a]. 

Note that this might not be the correct fix, may be this section of code needs different treatment for `fjJets==1`

[a] https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc12/CMSSW_14_2_UBSAN_X_2024-10-30-2300/pyRelValMatrixLogs/run/136.759_RunDoubleEG2016E/step3_RunDoubleEG2016E.log#/185-185
```
gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/stl_vector.h:1124:34: runtime error: reference binding to null pointer of type 'struct value_type'


```