### PR TITLE
Global config added for DMR-averaged tool

### DIFF
--- a/Alignment/OfflineValidation/bin/DMRmerge.cc
+++ b/Alignment/OfflineValidation/bin/DMRmerge.cc
@@ -56,6 +56,10 @@ int merge(int argc, char* argv[]) {
   //Read all configure variables and set default for missing keys
   std::string methods = validation.count("methods") ? getVecTokenized(validation, "methods", ",") : "median,rmsNorm";
   std::string curves = validation.count("curves") ? getVecTokenized(validation, "curves", ",") : "plain";
+  std::string moduleFilterFile =
+      validation.count("moduleFilterFile") ? validation.get<std::string>("moduleFilterFile") : "";
+  float maxBadLumiPixel = validation.count("maxBadLumiPixel") ? validation.get<float>("maxBadLumiPixel") : 0.5;
+  float maxBadLumiStrip = validation.count("maxBadLumiStrip") ? validation.get<float>("maxBadLumiStrip") : 7.0;
   std::string rlabel = validation.count("customrighttitle") ? validation.get<std::string>("customrighttitle") : "";
   rlabel = merge_style.count("Rlabel") ? merge_style.get<std::string>("Rlabel") : rlabel;
   std::string cmslabel = merge_style.count("CMSlabel") ? merge_style.get<std::string>("CMSlabel") : "INTERNAL";
@@ -122,7 +126,7 @@ int merge(int argc, char* argv[]) {
   plotter.setOutputDir(main_tree.get<std::string>("output"));
   plotter.useFitForDMRplots(useFit);
   plotter.setTreeBaseDir("TrackHitFilter");
-  plotter.plotDMR(methods, minimum, curves);
+  plotter.plotDMR(methods, minimum, curves, moduleFilterFile, maxBadLumiPixel, maxBadLumiStrip);
   plotter.plotSurfaceShapes("coarse");
   plotter.plotChi2((main_tree.get<std::string>("output") + "/" + "result.root").c_str());
 

--- a/Alignment/OfflineValidation/interface/PlotAlignmentValidation.h
+++ b/Alignment/OfflineValidation/interface/PlotAlignmentValidation.h
@@ -123,12 +123,15 @@ public:
   void plotDMR(const std::string& plotVar = "medianX",
                Int_t minHits = 50,
                const std::string& options = "plain",
-               const std::string& filterName = "");
+               const std::string& filterName = "",
+               Float_t maxBadLumiPixel = 0.5,
+               Float_t maxBadLumiStrip = 7.0);
   /**<
   * plotVar=mean,meanX,meanY,median,rms etc., comma-separated list can be given; 
   * minHits=the minimum hits needed for module to appear in plot; 
   * options="plain" for regular DMR, "split" for inwards/outwards split, "layers" for layerwise DMR, "layer=N" for Nth layer, or combination of the previous (e.g. "split layers")
   * filterName=rootfile containing tree with module ids to be skipped in plotting (to be used for averaged plots or in debugging)
+  * maxBadLumiPixel and maxBadLumiStrip place cuts on maximum luminosity for which module wont be skipped if it does not satisfy condition for guaranteed number of hits
   */
   void plotSurfaceShapes(const std::string& options = "layers", const std::string& variable = "");
   void plotChi2(const char* inputFile);
@@ -169,6 +172,8 @@ public:
     TH1F* h2;
     bool firsthisto;
     std::string filterName;
+    float maxBadLumiPixel;
+    float maxBadLumiStrip;
   };
 
 private:

--- a/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
+++ b/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
@@ -128,6 +128,8 @@ private:
 
     TH1* LocalX;
     TH1* LocalY;
+
+    unsigned int EntriesInt;
   };
 
   // container struct to organize collection of histograms during endJob
@@ -373,7 +375,7 @@ private:
 
   unsigned long long nTracks_;
   const unsigned long long maxTracks_;
-
+  const unsigned int maxEntriesPerModuleForDmr_;
   TrackerValidationVariables avalidator_;
 };
 
@@ -489,6 +491,7 @@ TrackerOfflineValidation::TrackerOfflineValidation(const edm::ParameterSet& iCon
       chargeCut_(parSet_.getParameter<int>("chargeCut")),
       nTracks_(0),
       maxTracks_(parSet_.getParameter<unsigned long long>("maxTracks")),
+      maxEntriesPerModuleForDmr_(parSet_.getParameter<unsigned int>("maxEntriesPerModuleForDmr")),
       avalidator_(iConfig, consumesCollector()) {
   usesResource(TFileService::kSharedResource);
 }
@@ -509,6 +512,7 @@ void TrackerOfflineValidation::fillDescriptions(edm::ConfigurationDescriptions& 
   desc.add<std::string>("moduleDirectoryInOutput", {});
   desc.add<int>("chargeCut", 0);
   desc.add<unsigned long long>("maxTracks", 0);
+  desc.add<unsigned int>("maxEntriesPerModuleForDmr", 0);
 
   // fill in the residuals details
   std::vector<std::string> listOfResidualsPSets = {"TH1XResPixelModules",
@@ -1325,6 +1329,9 @@ void TrackerOfflineValidation::analyze(const edm::Event& iEvent, const edm::Even
 
         if (moduleLevelProfiles_ && itH->inside) {
           float tgalpha = tan(itH->localAlpha);
+          histStruct.EntriesInt = histStruct.LocalX->GetEntries();
+          if (maxEntriesPerModuleForDmr_ > 0 && histStruct.EntriesInt >= maxEntriesPerModuleForDmr_)
+            continue;
           if (fabs(tgalpha) != 0) {
             histStruct.LocalX->Fill(itH->localXnorm, tgalpha * tgalpha);
             histStruct.LocalY->Fill(itH->localYnorm, tgalpha * tgalpha);

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/DMR.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/DMR.py
@@ -245,7 +245,17 @@ def DMR(config, validationDir):
                 elif isDataMerged[mergeName] == 1: 
                     mergesDATA.append(mergeName)
                 else:
-                    mergesMC.append(mergeName) 
+                    mergesMC.append(mergeName)
+                if "moduleFilterFile" not in config["validations"]["DMR"]["merge"][mergeName]:
+                    raise Exception("Value for 'moduleFilterFile' is required for the 'merge' step if the 'averaged' step is requested.")
+                if "maxBadLumiPixel" not in config["validations"]["DMR"]["merge"][mergeName]:
+                    print("WARNING: Default value for the 'maxBadLumiPixel' is used.")
+                if "maxBadLumiStrip" not in config["validations"]["DMR"]["merge"][mergeName]:
+                    print("WARNING: Default value for the 'maxBadLumiStrip' is used.")
+                #Validate single step within merge step
+                for singleName in config["validations"]["DMR"]["merge"][mergeName]['singles']:
+                    if "maxEntriesPerModuleForDmr" not in config["validations"]["DMR"]["single"][singleName]:
+                        raise Exception("Value for 'maxEntriesPerModuleForDmr' is required for the 'single' step if the 'averaged' step is requested.")
 
             lumiPerRun = []
             lumiPerIoV = []

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/DMR_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/DMR_cfg.py
@@ -156,6 +156,7 @@ process.TrackerOfflineValidation = _trackerOfflineValidation.clone(
     useFit                    = False,
     useOverflowForRMS         = False,
     maxTracks                 = config["validation"].get("maxtracks", 1),
+    maxEntriesPerModuleForDmr = config["validation"].get("maxEntriesPerModuleForDmr", 0),
     chargeCut                 = config["validation"].get("chargecut", 0),
 
     # Normalized X Residuals, normal local coordinates (Strip)

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/DMRplotter.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/DMRplotter.py
@@ -607,8 +607,9 @@ class DMRplotter:
                     elif obj['type'] == "DATA":
                         obj['hist'].SetMarkerColor(self.args['colors'][self.args['objects'].index(objName)])
                         obj['hist'].SetLineColor(self.args['colors'][self.args['objects'].index(objName)])
+                        obj['hist'].SetLineWidth(3)
                         obj['hist'].SetMarkerStyle(self.args['styles'][self.args['objects'].index(objName)])
-                        obj['hist'].SetMarkerSize(1.5)  
+                        obj['hist'].SetMarkerSize(1.5) 
 
         #set general style for DMRs
         tStyle = ROOT.TStyle("StyleCMS","Style CMS")

--- a/Alignment/OfflineValidation/src/PlotAlignmentValidation.cc
+++ b/Alignment/OfflineValidation/src/PlotAlignmentValidation.cc
@@ -687,7 +687,9 @@ void PlotAlignmentValidation::plotSS(const std::string& options, const std::stri
 void PlotAlignmentValidation::plotDMR(const std::string& variable,
                                       Int_t minHits,
                                       const std::string& options,
-                                      const std::string& filterName) {
+                                      const std::string& filterName,
+                                      Float_t maxBadLumiPixel,
+                                      Float_t maxBadLumiStrip) {
   // If several, comma-separated values are given in 'variable',
   // call plotDMR with each value separately.
   // If a comma is found, the string is divided to two.
@@ -696,8 +698,8 @@ void PlotAlignmentValidation::plotDMR(const std::string& variable,
   if (findres != std::string::npos) {
     std::string substring1 = variable.substr(0, findres);
     std::string substring2 = variable.substr(findres + 1, std::string::npos);
-    plotDMR(substring1, minHits, options, filterName);
-    plotDMR(substring2, minHits, options, filterName);
+    plotDMR(substring1, minHits, options, filterName, maxBadLumiPixel, maxBadLumiStrip);
+    plotDMR(substring2, minHits, options, filterName, maxBadLumiPixel, maxBadLumiStrip);
     return;
   }
 
@@ -705,8 +707,8 @@ void PlotAlignmentValidation::plotDMR(const std::string& variable,
   // X and Y added, respectively
   if (variable == "mean" || variable == "median" || variable == "meanNorm" || variable == "rms" ||
       variable == "rmsNorm") {
-    plotDMR(variable + "X", minHits, options, filterName);
-    plotDMR(variable + "Y", minHits, options, filterName);
+    plotDMR(variable + "X", minHits, options, filterName, maxBadLumiPixel, maxBadLumiStrip);
+    plotDMR(variable + "Y", minHits, options, filterName, maxBadLumiPixel, maxBadLumiStrip);
     return;
   }
 
@@ -761,6 +763,8 @@ void PlotAlignmentValidation::plotDMR(const std::string& variable,
   plotinfo.plotPlain = plotPlain;
   plotinfo.plotLayers = plotLayers;
   plotinfo.filterName = filterName;
+  plotinfo.maxBadLumiPixel = maxBadLumiPixel;
+  plotinfo.maxBadLumiStrip = maxBadLumiStrip;
 
   // width in cm
   // for DMRS, use 100 bins in range +-10 um, bin width 0.2um
@@ -825,6 +829,33 @@ void PlotAlignmentValidation::plotDMR(const std::string& variable,
   }
   //Begin loop on structures
   for (int i = 1; i <= 6; ++i) {
+    // Preferred binning in case of averaged DMR disributions
+    if (!plotinfo.filterName.empty()) {
+      if (i == 1 || i == 2) {
+        if (variable == "medianX") {
+          if (plotSplits) {
+            plotinfo.nbins = 50;
+          } else {
+            plotinfo.nbins = 50;
+          }
+        } else if (variable == "medianY") {
+          if (plotSplits) {
+            plotinfo.nbins = 50;
+          } else {
+            plotinfo.nbins = 25;
+          }
+        }
+      } else if (i == 3 || i == 4 || i == 5 || i == 6) {
+        if (variable == "medianX" || variable == "medianY") {
+          if (plotSplits) {
+            plotinfo.nbins = 50;
+          } else {
+            plotinfo.nbins = 25;
+          }
+        }
+      }
+    }
+
     // Skip strip detectors if plotting any "Y" variable
     if (i != 1 && i != 2 && variable.length() > 0 && variable[variable.length() - 1] == 'Y') {
       continue;
@@ -2068,6 +2099,12 @@ void PlotAlignmentValidation::plotDMRHistogram(PlotAlignmentValidation::DMRPlotI
       }
     }
   } else {
+    plotinfo.vars->getTree()->Draw(
+        plotVariable.c_str(), selection.c_str(), "goff");  //dummy to get the histogram structure
+    if (gDirectory)
+      gDirectory->GetObject(histoname.Data(), h);
+    h->Reset();
+    std::cout << "Module filter enabled." << std::endl;
     TTreeReader reader(plotinfo.vars->getTree());
     TTreeReaderValue<Float_t> varToPlot(reader, plotinfo.variable.c_str());
     TTreeReaderValue<unsigned int> _entries(reader, "entries");
@@ -2084,9 +2121,11 @@ void PlotAlignmentValidation::plotDMRHistogram(PlotAlignmentValidation::DMRPlotI
     TTreeReaderValue<int> _bad_id(readerBad, "id");
     TTreeReaderValue<double> _bad_lumi(readerBad, "lumi");
 
-    //Record which modules were used
+    //Record which modules were or were not used
     std::ofstream fUsedModules;
+    std::ofstream fNotUsedModules;
     fUsedModules.open("usedModules.txt", std::ios::out | std::ios::app);
+    fNotUsedModules.open("notUsedModules.txt", std::ios::out | std::ios::app);
 
     //Filter on modules by hand together with base selection
     for (uint i = 0; i < plotinfo.vars->getTree()->GetEntries(); i++) {
@@ -2113,19 +2152,21 @@ void PlotAlignmentValidation::plotDMRHistogram(PlotAlignmentValidation::DMRPlotI
         readerBad.SetEntry(ibad);
         //if (*_valid == 0) {continue;} //only modules that failed 0 times are OK = very strict
         if (subdet == "BPIX" || subdet == "FPIX") {
-          if (*_bad_lumi <= 2.0)
+          if (*_bad_lumi <= plotinfo.maxBadLumiPixel)
             continue;
         } else {
-          if (*_bad_lumi <= 7.0)
+          if (*_bad_lumi <= plotinfo.maxBadLumiStrip)
             continue;
         }
-        //modules that misbehave for less than 2/fb are OK = mild strict
+        //modules that misbehave for less than XYZ are OK = mild strict
         if (*_moduleId == uint(*_bad_id))
           isBadModule = true;
       }
 
-      if (isBadModule)
+      if (isBadModule) {
+        fNotUsedModules << *_moduleId << "\n";
         continue;
+      }
       fUsedModules << *_moduleId << "\n";
       if (h) {
         h->Fill(*varToPlot);
@@ -2134,6 +2175,7 @@ void PlotAlignmentValidation::plotDMRHistogram(PlotAlignmentValidation::DMRPlotI
 
     //Finalize
     fUsedModules.close();
+    fNotUsedModules.close();
     fBadModules->Close();
     if (h) {
       h->SetName(histoname.Data());

--- a/Alignment/OfflineValidation/test/unit_test.json
+++ b/Alignment/OfflineValidation/test/unit_test.json
@@ -106,7 +106,8 @@
                       "vertexcollection": "offlinePrimaryVertices",
                       "magneticfield": "true",
                       "maxevents": "1",
-                      "maxtracks": "1"
+                      "maxtracks": "1",
+		      "maxEntriesPerModuleForDmr":100
                  }
              },
              "merge": {
@@ -117,7 +118,10 @@
                       "singles": ["TestSingleMC"],
                       "usefit": "true",
                       "minimum": "15",
-                      "customrighttitle": "IOV"
+                      "customrighttitle": "IOV",
+		      "moduleFilterFile": "",
+                      "maxBadLumiPixel": 0.5,
+                      "maxBadLumiStrip": 7.0
                  }
              },
              "trends": {

--- a/Alignment/OfflineValidation/test/unit_test.yaml
+++ b/Alignment/OfflineValidation/test/unit_test.yaml
@@ -96,6 +96,7 @@ validations:
                 magneticfield: true
                 maxevents: 1
                 maxtracks: 1
+                maxEntriesPerModuleForDmr: 100
 
         merge:
             TestMergeMC:
@@ -106,6 +107,9 @@ validations:
                 - plain
                 - split
                 customrighttitle: IOV
+                moduleFilterFile: ""
+                maxBadLumiPixel: 0.5
+                maxBadLumiStrip: 7.0
                 legendoptions:
                 - mean
                 - rms


### PR DESCRIPTION
TkAlignment all-in-one tool receives the new global config options to be specified for the DMR averaged validation tool:
maxEntriesPerModuleForDmr: specifies an exact amount of hits per module for a fair comparison between MC and data (default 0 = this option is ignored)
moduleFilterFile: TTree with module IDs that do not satisfy maxEntriesPerModuleForDmr for a given range of IOVs (default is an empty string = ignore filtering)
maxBadLumiPixel: mark Pixel (Phase1) module as OK if it does not satisfy maxEntriesPerModuleForDmr for less than this integrated lumi (default 0.5/fb)
maxBadLumiStrip: mark Strip (Phase1) module as OK if it does not satisfy maxEntriesPerModuleForDmr for less than this integrated lumi (default 7.0/fb)

#### PR validation:
Code checks. Code format. Unit tests done. 

