### PR TITLE
improve graphical rendering of `AlCaRecoTriggerBits_PayloadInspector` pots

### DIFF
--- a/CondCore/HLTPlugins/plugins/AlCaRecoTriggerBits_PayloadInspector.cc
+++ b/CondCore/HLTPlugins/plugins/AlCaRecoTriggerBits_PayloadInspector.cc
@@ -3,13 +3,15 @@
 #include "CondCore/CondDB/interface/Time.h"
 #include "CondFormats/HLTObjects/interface/AlCaRecoTriggerBits.h"
 
-#include <fmt/printf.h>
-#include <memory>
-#include <sstream>
-#include <iostream>
 #include "TCanvas.h"
 #include "TLatex.h"
 #include "TLine.h"
+#include <fmt/printf.h>
+#include <iostream>
+#include <memory>
+#include <cmath>
+#include <numeric>
+#include <sstream>
 
 namespace {
 
@@ -22,106 +24,133 @@ namespace {
   public:
     AlCaRecoTriggerBits_Display() : PlotImage<AlCaRecoTriggerBits, SINGLE_IOV>("Table of AlCaRecoTriggerBits") {}
 
+    using TriggerMap = std::map<std::string, std::string>;
+
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
       auto iov = tag.iovs.front();
+      std::string IOVsince = std::to_string(std::get<0>(iov));
+      auto tagname = tag.name;
       std::shared_ptr<AlCaRecoTriggerBits> payload = fetchPayload(std::get<1>(iov));
 
-      std::string IOVsince = std::to_string(std::get<0>(iov));
+      if (payload.get()) {
+        const TriggerMap &triggerMap = payload->m_alcarecoToTrig;
 
-      // Get map of strings to concatenated list of names of HLT paths:
-      typedef std::map<std::string, std::string> TriggerMap;
-      const TriggerMap &triggerMap = payload->m_alcarecoToTrig;
+        // pre-compute how many time we break the line
+        const int totalCarriageReturns = calculateTotalCarriageReturns(payload);
+        LogDebug("AlCaRecoTriggerBits_Display") << "Total number of carriage returns: " << totalCarriageReturns;
 
-      unsigned int mapsize = triggerMap.size();
-      float pitch = 1. / (mapsize * 1.1);
+        // Dynamically calculate the pitch and canvas height
+        float pitch = 1.0 / (totalCarriageReturns + 2.0);  // Adjusted pitch for better spacing
 
-      float y, x1, x2;
-      std::vector<float> y_x1, y_x2, y_line;
-      std::vector<std::string> s_x1, s_x2, s_x3;
+        float y = 1.0;
+        float x1 = 0.02, x2 = x1 + 0.25;
+        std::vector<float> y_x1, y_x2, y_line;
+        std::vector<std::string> s_x1, s_x2;
 
-      // starting table at y=1.0 (top of the canvas)
-      // first column is at 0.02, second column at 0.32 NDC
-      y = 1.0;
-      x1 = 0.02;
-      x2 = x1 + 0.30;
-
-      y -= pitch;
-      y_x1.push_back(y);
-      s_x1.push_back("#scale[1.2]{Key}");
-      y_x2.push_back(y);
-      s_x2.push_back("#scale[1.2]{tag: " + tag.name + " in IOV: " + IOVsince + "}");
-
-      y -= pitch / 2.;
-      y_line.push_back(y);
-
-      for (const auto &element : triggerMap) {
+        // Header row setup
         y -= pitch;
         y_x1.push_back(y);
-        s_x1.push_back(element.first);
+        s_x1.push_back("#scale[1.2]{Key}");
+        y_x2.push_back(y);
+        s_x2.push_back("#scale[1.2]{tag: " + tagname + " in IOV: " + IOVsince + "}");
 
-        std::vector<std::string> output;
-        std::string toAppend = "";
-        const std::vector<std::string> paths = payload->decompose(element.second);
-        for (unsigned int iPath = 0; iPath < paths.size(); ++iPath) {
-          // if the line to be added has less than 60 chars append to current
-          if ((toAppend + paths[iPath]).length() < 60) {
-            toAppend += paths[iPath] + ";";
-          } else {
-            // else if the line exceeds 60 chars, dump in the vector and resume from scratch
-            output.push_back(toAppend);
-            toAppend.clear();
-            toAppend += paths[iPath] + ";";
+        y -= pitch / 2.0;
+        y_line.push_back(y);
+
+        // Populate rows with data from the trigger map
+        for (const auto &element : triggerMap) {
+          y -= pitch;
+          y_x1.push_back(y);
+          s_x1.push_back(element.first);
+          std::vector<std::string> output;
+
+          std::string toAppend = "";
+          const std::vector<std::string> paths = payload->decompose(element.second);
+          for (unsigned int iPath = 0; iPath < paths.size(); ++iPath) {
+            if ((toAppend + paths[iPath]).length() < 80) {  // Wider lines
+              toAppend += paths[iPath] + ";";
+            } else {
+              output.push_back(toAppend);
+              toAppend.clear();
+              toAppend += paths[iPath] + ";";
+            }
+            if (iPath == paths.size() - 1)
+              output.push_back(toAppend);
           }
-          // if it's the last, dump it
-          if (iPath == paths.size() - 1)
-            output.push_back(toAppend);
+
+          for (unsigned int br = 0; br < output.size(); br++) {
+            y_x2.push_back(y);
+            s_x2.push_back("#color[2]{" + output[br] + "}");
+            if (br != output.size() - 1)
+              y -= pitch;
+          }
+
+          y_line.push_back(y - (pitch / 2.0));
         }
 
-        for (unsigned int br = 0; br < output.size(); br++) {
-          y_x2.push_back(y);
-          s_x2.push_back("#color[2]{" + output[br] + "}");
-          if (br != output.size() - 1)
-            y -= pitch;
+        // Dynamically calculate the pitch and canvas height
+        float canvasHeight = std::max(800.0f, totalCarriageReturns * 30.0f);  // Adjust canvas height based on entries
+        TCanvas canvas("AlCaRecoTriggerBits", "AlCaRecoTriggerBits", 2000, static_cast<int>(canvasHeight));
+
+        TLatex l;
+        l.SetTextAlign(12);
+        float textSize = std::clamp(pitch, 0.015f, 0.035f);
+        l.SetTextSize(textSize);
+
+        // Draw the columns
+        int totalPitches = 0;
+        canvas.cd();
+        for (unsigned int i = 0; i < y_x1.size(); i++) {
+          l.DrawLatexNDC(x1, y_x1[i], s_x1[i].c_str());
+          if (i != 0) {
+            LogDebug("AlCaRecoTriggerBits_Display")
+                << "x1:" << x1 << " y_x1[" << std::setw(2) << i << "]: " << y_x1[i]
+                << " Delta = " << std::ceil((y_x1[i - 1] - y_x1[i]) / pitch) << " pitches " << s_x1[i].c_str();
+            totalPitches += std::ceil((y_x1[i - 1] - y_x1[i]) / pitch);
+          }
         }
 
-        y_line.push_back(y - (pitch / 2.));
+        LogDebug("AlCaRecoTriggerBits_Display") << "We've gone down by " << totalPitches << "pitches ";
+
+        for (unsigned int i = 0; i < y_x2.size(); i++) {
+          l.DrawLatexNDC(x2, y_x2[i], s_x2[i].c_str());
+        }
+
+        // Draw lines for row separation
+        TLine lines[y_line.size()];
+        for (unsigned int i = 0; i < y_line.size(); i++) {
+          lines[i] = TLine(gPad->GetUxmin(), y_line[i], gPad->GetUxmax(), y_line[i]);
+          lines[i].SetLineWidth(1);
+          lines[i].SetLineStyle(9);
+          lines[i].SetLineColor(2);
+          lines[i].Draw("same");
+        }
+
+        canvas.SaveAs(m_imageFileName.c_str());
       }
-
-      TCanvas canvas("AlCaRecoTriggerBits", "AlCaRecoTriggerBits", 2000, std::max(y_x1.size(), y_x2.size()) * 40);
-      TLatex l;
-      // Draw the columns titles
-      l.SetTextAlign(12);
-
-      float newpitch = 1 / (std::max(y_x1.size(), y_x2.size()) * 1.1);
-      float factor = newpitch / pitch;
-      l.SetTextSize(newpitch - 0.002);
-      canvas.cd();
-      for (unsigned int i = 0; i < y_x1.size(); i++) {
-        l.DrawLatexNDC(x1, 1 - (1 - y_x1[i]) * factor, s_x1[i].c_str());
-      }
-
-      for (unsigned int i = 0; i < y_x2.size(); i++) {
-        l.DrawLatexNDC(x2, 1 - (1 - y_x2[i]) * factor, s_x2[i].c_str());
-      }
-
-      canvas.cd();
-      canvas.Update();
-
-      TLine lines[y_line.size()];
-      unsigned int iL = 0;
-      for (const auto &line : y_line) {
-        lines[iL] = TLine(gPad->GetUxmin(), 1 - (1 - line) * factor, gPad->GetUxmax(), 1 - (1 - line) * factor);
-        lines[iL].SetLineWidth(1);
-        lines[iL].SetLineStyle(9);
-        lines[iL].SetLineColor(2);
-        lines[iL].Draw("same");
-        iL++;
-      }
-
-      std::string fileName(m_imageFileName);
-      canvas.SaveAs(fileName.c_str());
       return true;
+    }
+
+  private:
+    int calculateTotalCarriageReturns(std::shared_ptr<AlCaRecoTriggerBits> payload) {
+      int totalCarriageReturns = 0;
+      const TriggerMap &triggerMap = payload->m_alcarecoToTrig;
+
+      for (const auto &element : triggerMap) {
+        const auto &paths = payload->decompose(element.second);
+        int lineLength = 0;
+
+        for (const auto &path : paths) {
+          lineLength += path.length() + 1;  // +1 for the semicolon
+          if (lineLength >= 80) {
+            totalCarriageReturns++;
+            lineLength = path.length() + 1;  // Reset for the next line segment
+          }
+        }
+        totalCarriageReturns++;  // Count the initial line for each element
+      }
+      return totalCarriageReturns;
     }
   };
 


### PR DESCRIPTION
#### PR description:

The goal of this PR as the title mentions is to improve the graphical appearance of the `AlCaRecoTriggerBits_PayloadInspector` output plots. 
No regressions are expected in any workflow.

#### PR validation:

Tested with the following script:

```bash
#!/bin/bash -ex

getPayloadData.py \
    --plugin pluginAlCaRecoTriggerBits_PayloadInspector \
    --plot plot_AlCaRecoTriggerBits_Display \
    --tag AlCaRecoHLTpaths8e29_5e33_v9_prompt \
    --input_params "{}" \
    --time_type Run \
    --iovs '{"start_iov": "352189", "end_iov": "352189"}' \
    --db Prod \
    --test;
```

I attach the output of the plot with this branch in comparison with a plain `CMSSW_14_2_X_2024-10-31-2300`

| This PR  |  Original |
| ------------- | ------------- |
| ![this_pr](https://github.com/user-attachments/assets/56b994ec-4a67-4c9a-a57f-5f19a6bacd71) | ![CMSSW_14_2_X_2024-10-31-2300](https://github.com/user-attachments/assets/d08340a8-b7d1-49b1-98a2-9d941209ce17) |

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A
