### PR TITLE
Fix IB test failures due to missing outdated energy correction files

### DIFF
--- a/PhysicsTools/NanoAOD/python/electrons_cff.py
+++ b/PhysicsTools/NanoAOD/python/electrons_cff.py
@@ -172,18 +172,6 @@ run2_egamma_2018.toModify(calibratedPatElectronsNano,
     correctionFile = cms.string("EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2018_29Sep2020_RunFineEtaR9Gain")
 )
 
-run2_miniAOD_80XLegacy.toModify(calibratedPatElectronsNano,
-                                correctionFile = cms.string("EgammaAnalysis/ElectronTools/data/ScalesSmearings/Legacy2016_07Aug2017_FineEtaR9_v3_ele_unc")
-                            )
-
-for modifier in run2_nanoAOD_94XMiniAODv1,run2_nanoAOD_94XMiniAODv2:
-    modifier.toModify(calibratedPatElectronsNano, 
-        correctionFile = cms.string("EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2017_17Nov2017_v1_ele_unc")
-    )
-
-run2_nanoAOD_102Xv1.toModify(calibratedPatElectronsNano,
-    correctionFile = cms.string("EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2018_Step2Closure_CoarseEtaR9Gain_v2")
-)
 ##############################end calibratedPatElectronsNano############################
 
 slimmedElectronsWithUserData = cms.EDProducer("PATElectronUserDataEmbedder",

--- a/PhysicsTools/NanoAOD/python/photons_cff.py
+++ b/PhysicsTools/NanoAOD/python/photons_cff.py
@@ -93,22 +93,6 @@ run2_egamma_2018.toModify(calibratedPatPhotonsNano,
     correctionFile = cms.string("EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2018_29Sep2020_RunFineEtaR9Gain")
 )
 
-run2_nanoAOD_102Xv1.toModify(calibratedPatPhotonsNano,
-    correctionFile = cms.string("EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2018_Step2Closure_CoarseEtaR9Gain_v2")
-)
-
-run2_nanoAOD_94XMiniAODv1.toModify(calibratedPatPhotonsNano,
-    correctionFile = cms.string("EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2017_17Nov2017_v1_ele_unc")
-)
-
-run2_nanoAOD_94XMiniAODv2.toModify(calibratedPatPhotonsNano,
-    correctionFile = cms.string("EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2017_17Nov2017_v1_ele_unc")
-)
-
-run2_miniAOD_80XLegacy.toModify(calibratedPatPhotonsNano,
-    correctionFile = cms.string("EgammaAnalysis/ElectronTools/data/ScalesSmearings/Legacy2016_07Aug2017_FineEtaR9_v3_ele_unc")
-)
-
 slimmedPhotonsWithUserData = cms.EDProducer("PATPhotonUserDataEmbedder",
     src = cms.InputTag("slimmedPhotons"),
     userFloats = cms.PSet(

--- a/RecoEgamma/EgammaTools/python/calibratedEgammas_cff.py
+++ b/RecoEgamma/EgammaTools/python/calibratedEgammas_cff.py
@@ -9,7 +9,7 @@ _correctionFile2018UL        = "EgammaAnalysis/ElectronTools/data/ScalesSmearing
 
 calibratedEgammaSettings = cms.PSet(minEtToCalibrate = cms.double(5.0),
                                     semiDeterministic = cms.bool(True),
-                                    correctionFile = cms.string(_correctionFile2017Nov17),
+                                    correctionFile = cms.string(_correctionFile2017UL),
                                     recHitCollectionEB = cms.InputTag('reducedEcalRecHitsEB'),
                                     recHitCollectionEE = cms.InputTag('reducedEcalRecHitsEE'),
                                     produceCalibratedObjs = cms.bool(True)

--- a/RecoEgamma/EgammaTools/python/calibratedEgammas_cff.py
+++ b/RecoEgamma/EgammaTools/python/calibratedEgammas_cff.py
@@ -30,9 +30,6 @@ from Configuration.Eras.Modifier_run2_egamma_2017_cff import run2_egamma_2017
 from Configuration.Eras.Modifier_run2_egamma_2018_cff import run2_egamma_2018
 (run2_miniAOD_UL & run2_egamma_2018).toModify(calibratedEgammaSettings,correctionFile = _correctionFile2018UL)
 
-from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
-run2_miniAOD_80XLegacy.toModify(calibratedEgammaSettings,correctionFile = _correctionFile2016Legacy)
-
 calibratedEgammaPatSettings = calibratedEgammaSettings.clone(
     recHitCollectionEB = cms.InputTag('reducedEgamma','reducedEBRecHits'),
     recHitCollectionEE = cms.InputTag('reducedEgamma','reducedEERecHits')


### PR DESCRIPTION
#### PR description:

Some of the IB tests still look for the legacy 9_4_X electron & photon energy correction files. The deletion of the outdated correction file in cms-data/EgammaAnalysis-ElectronTools#12 and #46138 caused the IB test failures as the default energy correction file is the legacy one when there is no modifier.

(the master is okay since the legacy workflows were cleaned up in #45240)

So I cherry-picked one of the line changes in #45240 - this should make the default energy correction file the UL version when there is no modifier.

Fix https://github.com/cms-data/EgammaAnalysis-ElectronTools/pull/12#issuecomment-2454167466 and https://github.com/cms-sw/cmssw/pull/46138#issuecomment-2454179806