### PR TITLE
fix `InputTag` in `SimL1EmulatorRepack_uGT_cff.py`

### DIFF
--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_uGT_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_uGT_cff.py
@@ -30,7 +30,7 @@ simGtStage2Digis.TauInputTag        = "unpackGtStage2:Tau"
 simGtStage2Digis.JetInputTag        = "unpackGtStage2:Jet"
 simGtStage2Digis.EtSumInputTag      = "unpackGtStage2:EtSum"
 simGtStage2Digis.EtSumZdcInputTag   = "unpackGtStage2:EtSumZDC"
-simGtStage2Digis.CICADAScoreInputTag = "unpackGtStage2:CICADAScore"
+simGtStage2Digis.CICADAInputTag     = "unpackGtStage2:CICADAScore"
 simGtStage2Digis.ExtInputTag        = "unpackGtStage2" # as in default
 
 


### PR DESCRIPTION
#### PR description:

While trying to run the following script [1] in `CMSSW_14_2_X` I got the following error:

```
----- Begin Fatal Exception 04-Nov-2024 15:06:01 CET-----------------------
An exception of category 'ConfigFileReadError' occurred while
   [0] Processing the python configuration file named hlt.py
Exception Message:
 unknown python problem occurred.
TypeError: CICADAScoreInputTag does not already exist, so it can only be set to a CMS python configuration type

At:
  /cvmfs/cms-ib.cern.ch/sw/x86_64/week0/el9_amd64_gcc12/cms/cmssw/CMSSW_14_2_X_2024-11-03-0000/src/FWCore/ParameterSet/python/Mixins.py(319): __raiseBadSetAttr
  /cvmfs/cms-ib.cern.ch/sw/x86_64/week0/el9_amd64_gcc12/cms/cmssw/CMSSW_14_2_X_2024-11-03-0000/src/FWCore/ParameterSet/python/Mixins.py(244): __addParameter
  /cvmfs/cms-ib.cern.ch/sw/x86_64/week0/el9_amd64_gcc12/cms/cmssw/CMSSW_14_2_X_2024-11-03-0000/src/FWCore/ParameterSet/python/Mixins.py(285): __setattr__
  /cvmfs/cms-ib.cern.ch/sw/x86_64/week0/el9_amd64_gcc12/cms/cmssw/CMSSW_14_2_X_2024-11-03-0000/src/Configuration/StandardSequences/python/SimL1EmulatorRepack_uGT_cff.py(33): <module>
  <frozen importlib._bootstrap>(228): _call_with_frames_removed
  <frozen importlib._bootstrap_external>(850): exec_module
  <frozen importlib._bootstrap>(695): _load_unlocked
  <frozen importlib._bootstrap>(986): _find_and_load_unlocked
  <frozen importlib._bootstrap>(1007): _find_and_load
  /cvmfs/cms-ib.cern.ch/sw/x86_64/week0/el9_amd64_gcc12/cms/cmssw/CMSSW_14_2_X_2024-11-03-0000/src/FWCore/ParameterSet/python/Config.py(762): load
  /cvmfs/cms-ib.cern.ch/sw/x86_64/week0/el9_amd64_gcc12/cms/cmssw/CMSSW_14_2_X_2024-11-03-0000/src/HLTrigger/Configuration/python/CustomConfigs.py(178): L1REPACK
  hlt.py(31207): <module>

----- End Fatal Exception -------------------------------------------------
```

This apparently is caused by PR https://github.com/cms-sw/cmssw/pull/45826. 
This PR tries to fix the issue.

#### PR validation:

Run the script in `CMSSW_14_2_X_2024-11-03-0000` + this PR and the crash is overcome.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not needed as https://github.com/cms-sw/cmssw/pull/45826/ was not backported.

----
[1]

<details>
  <summary>Click me</summary>
  
```bash
#!/bin/bash -ex

voms-proxy-init -voms cms

hltGetConfiguration /dev/CMSSW_14_1_0/HIon/V42 \
		    --max-events 10 \
		    --no-prescale \
		    --no-output \
		    --data \
		    --input /store/hidata/HIRun2023A/HIZeroBias0/RAW/v1/000/375/703/00000/03000cf7-c12e-467f-9388-8d106e0ec320.root \
		    --globaltag 141X_dataRun3_HLT_v1 \
		    --eras Run3 \
		    --l1-emulator uGT --l1 L1Menu_CollisionsHeavyIons2024_v1_0_5_xml \
		    --customise HLTrigger/Configuration/CustomConfigs.customiseL1THLTforHIonRepackedRAW --open > hlt.py

cmsRun hlt.py >& hlt.log
```
</details>