### PR TITLE
`HLTRegionalEcalResonanceFilter`: put output collections in the event also if the filter fails

### DIFF
--- a/HLTrigger/special/plugins/HLTRegionalEcalResonanceFilter.cc
+++ b/HLTrigger/special/plugins/HLTRegionalEcalResonanceFilter.cc
@@ -555,9 +555,6 @@ bool HLTRegionalEcalResonanceFilter::filter(edm::Event &iEvent, const edm::Event
   //Put selected information in the event
   int ee_collsize = selEERecHitCollection->size();
 
-  if (eb_collsize < 2 && ee_collsize < 2)
-    return false;
-
   ////Now put into events selected rechits.
   if (doSelBarrel_) {
     iEvent.put(std::move(selEBRecHitCollection), BarrelHits_);
@@ -569,7 +566,7 @@ bool HLTRegionalEcalResonanceFilter::filter(edm::Event &iEvent, const edm::Event
     }
   }
 
-  return true;
+  return (eb_collsize > 1 or ee_collsize > 1);
 }
 
 void HLTRegionalEcalResonanceFilter::doSelection(


### PR DESCRIPTION
#### PR description:

In the JIRA ticket [CMSHLT-3397](https://its.cern.ch/jira/browse/CMSHLT-3379?focusedId=6588727&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-6588727) it was discussed that when running a script (akin to this one) [1] one gets the following crash:

```
----- Begin Fatal Exception 04-Nov-2024 15:28:03 CET-----------------------
An exception of category 'ProductNotFound' occurred while
   [0] Processing  Event run: 375703 lumi: 746 event: 821822396 stream: 1
   [1] Running path 'AlCa_EcalPi0EEonlyForHI_v13'
   [2] Calling method for module EcalRecalibRecHitProducer/'hltAlCaPi0EEUncalibrator'
Exception Message:
Principal::getByToken: Found zero products matching all criteria
Looking for type: edm::SortedCollection<EcalRecHit,edm::StrictWeakOrdering<EcalRecHit> >
Looking for module label: hltAlCaPi0RecHitsFilterEEonlyRegional
Looking for productInstanceName: pi0EcalRecHitsEE

   Additional Info:
      [a] If you wish to continue processing events after a ProductNotFound exception,
add "TryToContinue = cms.untracked.vstring('ProductNotFound')" to the "options" PSet in the configuration.

----- End Fatal Exception -------------------------------------------------
```

The reason has been traced to the fact that when running in "open"  mode if there aren't hits  and one of the upstream filters fails the output collections will not be created, but the processing will continue because the filter decision got ignored.
For instance [here](https://github.com/cms-sw/cmssw/blob/master/HLTrigger/special/plugins/HLTRegionalEcalResonanceFilter.cc#L559) the filter `HLTRegionalEcalResonanceFilter` returns false without putting the products in the event, but the filter decision being ignored, the processing will continue regardless leading to the missing products downstream. This could be fixed in the cmssw code, but it's not a showstopper for production. 
The solution proposed here, for instance, entails putting the collections in the event before the return false statement in case there are not enough rechits in the collection.

#### PR validation:

Re-run the script in description and didn't get any crash.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A

---
[1]

<details>
  <summary>Click me</summary>
  
```bash
#!/bin/bash -ex

voms-proxy-init -voms cms

hltGetConfiguration /dev/CMSSW_14_1_0/HIon/V42 \
		    --max-events 10 \
		    --no-prescale \
		    --no-output \
		    --data \
		    --input /store/hidata/HIRun2023A/HIZeroBias0/RAW/v1/000/375/703/00000/03000cf7-c12e-467f-9388-8d106e0ec320.root \
		    --globaltag 141X_dataRun3_HLT_v1 \
		    --eras Run3 \
		    --l1-emulator uGT --l1 L1Menu_CollisionsHeavyIons2024_v1_0_5_xml \
		    --customise HLTrigger/Configuration/CustomConfigs.customiseL1THLTforHIonRepackedRAW --open > hlt.py

cmsRun hlt.py >& hlt.log
```
</details>