### PR TITLE
[14.1.X] adjust the L1T seeds to be monitored from `L1TStage2uGTTiming` in Run3 PbPb modes

### DIFF
--- a/DQM/L1TMonitor/python/L1TStage2uGTTiming_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGTTiming_cfi.py
@@ -41,10 +41,20 @@ unprescaledAlgoList_2024.extend([
     "L1_CICADA_Medium",
     "L1_CICADA_VTight"
 ])
- 
+
+unprescaledAlgoList_PbPb = cms.untracked.vstring(unprescaledAlgoList)
+unprescaledAlgoList_PbPb.remove("L1_SingleIsoEG28er1p5")
+unprescaledAlgoList_PbPb.remove("L1_SingleTau120er2p1")
+unprescaledAlgoList_PbPb.remove("L1_ETMHF130")
+
 prescaledAlgoList_2024 = cms.untracked.vstring(prescaledAlgoList)
 if "L1_ETT1600" in prescaledAlgoList_2024:
     prescaledAlgoList_2024.remove("L1_ETT1600")
+
+prescaledAlgoList_PbPb = cms.untracked.vstring(prescaledAlgoList)
+prescaledAlgoList_PbPb.remove("L1_SingleLooseIsoEG28er1p5")
+prescaledAlgoList_PbPb.remove("L1_SingleJet35_FWD2p5")
+prescaledAlgoList_PbPb.remove("L1_ETT1600")
 
 l1tStage2uGTTiming = DQMEDAnalyzer('L1TStage2uGTTiming',
     l1tStage2uGtSource = cms.InputTag("gtStage2Digis"),
@@ -63,3 +73,9 @@ stage2L1Trigger_2024.toModify(l1tStage2uGTTiming,
     unprescaledAlgoShortList = unprescaledAlgoList_2024,
     prescaledAlgoShortList = prescaledAlgoList_2024
 )
+
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
+(pp_on_PbPb_run3 | run3_upc).toModify(l1tStage2uGTTiming,
+                                      unprescaledAlgoShortList = unprescaledAlgoList_PbPb,
+                                      prescaledAlgoShortList = prescaledAlgoList_PbPb)


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/46590

#### PR description:

Addresses https://github.com/cms-sw/cmssw/issues/43488#issuecomment-2441471358, by removing from `DQM/L1TMonitor/python/L1TStage2uGTTiming_cfi.py` the monitoring seeds not existing in the Run3 PbPb L1T menus.

#### PR validation:

Run the setup at https://github.com/cms-sw/cmssw/pull/46584#issuecomment-2452936119 with this commit and verified that the noisy warnings are removed.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

verbatim backport of https://github.com/cms-sw/cmssw/pull/46590 to the production cycle of the 2024 PbPb run.
