### PR TITLE
Add new user-configurable parameter in BSOnlineFromOfflineConverter

### DIFF
--- a/CondTools/BeamSpot/test/BeamSpotOnlineFromOfflineConverter_cfg.py
+++ b/CondTools/BeamSpot/test/BeamSpotOnlineFromOfflineConverter_cfg.py
@@ -39,12 +39,19 @@ options.register('startLumi',
                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
                  VarParsing.VarParsing.varType.int, # string, int, or float
                  "IOV Start Lumi")
+options.register('maxIOVtoProcess',
+                 999, # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.int, # string, int, or float
+                 "max number of IOVs (events) to process")
 options.parseArguments()
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.FwkReport.reportEvery = 100000 # do not clog output with IO
 
-process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(999))
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(options.maxIOVtoProcess)
+)
 
 ####################################################################
 # Empty source 
@@ -53,7 +60,7 @@ process.source = cms.Source("EmptySource",
                             firstRun = cms.untracked.uint32(options.startRun),                  
                             firstLuminosityBlock = cms.untracked.uint32(options.startLumi),     
                             numberEventsInLuminosityBlock = cms.untracked.uint32(1),            
-                            numberEventsInRun = cms.untracked.uint32(999))
+                            numberEventsInRun = cms.untracked.uint32(options.maxIOVtoProcess))
 
 ####################################################################
 # Connect to conditions DB


### PR DESCRIPTION
#### PR description:
Minor improvement to the `BeamSpotOnlineFromOfflineConverter_cfg.py` script.
Upon request of TkAl team, in this PR I'm adding a new user-configurable parameter (`maxIOVtoProcess`) so that the conversion from offline to online Beamspot objects can be more easily handled also for tags with a large number of IOVs.

#### PR validation:
This script is not run in any production environment, but only run manually by experts.
Tested on a private `db` file (provided by TkAl team) with 2517 IOVs:
- Default value (999 IOVs)
  ```
  cmsRun BeamSpotOnlineFromOfflineConverter_cfg.py inputTag=BSoffline inputFile=BSoffline.db outputTag=BSonline_default startRun=387607
  conddb --db test_BSonline_default.db --noLimit list BSonline_default
  ```
  Resulted in 999 BeamSpotOnline IOVs as expected
- Limit to 10 IOVs
  ```
  cmsRun BeamSpotOnlineFromOfflineConverter_cfg.py inputTag=BSoffline inputFile=BSoffline.db outputTag=BSonline_10iov startRun=387607 maxIOVtoProcess=10
  conddb --db test_BSonline_10iov.db --noLimit list BSonline_10iov
  ```
  Resulted in 10 BeamSpotOnline IOVs as expected
- Limit to 2520 IOVs
  ```
  cmsRun BeamSpotOnlineFromOfflineConverter_cfg.py inputTag=BSoffline inputFile=BSoffline.db outputTag=BSonline_2520iov startRun=387607 maxIOVtoProcess=2520
  conddb --db test_BSonline_2520iov.db --noLimit list BSonline_2520iov
  ```
  Resulted in 2517 BeamSpotOnline IOVs as expected


#### Backport:
Not a backport.
@TomasKello please let me know if you think it would be useful to have this also in the current data-taking release, and I can backport it to 14_1_X.