### PR TITLE
[14_1_X] Update sourceFile of beamspotdip DQM client

### DIFF
--- a/DQM/Integration/python/clients/beamspotdip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamspotdip_dqm_sourceclient-live_cfg.py
@@ -48,6 +48,9 @@ process.GlobalTag.toGet = cms.VPSet(
 process.load("DQM.BeamMonitor.BeamSpotDipServer_cff")
 
 process.beamSpotDipServer.verbose = cms.untracked.bool(True)
+process.beamSpotDipServer.sourceFile  = cms.untracked.string(
+    "/nfshome0/dqmpro/BeamMonitorDQM/BeamFitResultsForDIP.txt"
+)
 
 # process customizations included here
 from DQM.Integration.config.online_customizations_cfi import *


### PR DESCRIPTION
#### PR description:
Verbatim backport of https://github.com/cms-sw/cmssw/pull/46613

Original PR description:
> This PR updates the `beamspotdip` client (which publishes the online BeamSpot values to DIP and OMS) to read the BeamSpot result not from `BeamFitResults.txt`, which is produced by the `beamhlt` client, but from `BeamFitResultsForDIP.txt`, which is produced by the `onlinebeammonitor` and is the result of the arbitration between the beamspot values produced by the `beam` and `beamhlt` clients.
> 
> This fix should ideally solve cases where the `beamhlt` client is not running/not producing a valid result, as it happened this morning during the first 2024 HI StableBeams (see the empy BeamSpot plots in https://cmsoms.cern.ch/cms/fills/report?cms_fill=10329).


#### PR validation:
Code compiles, to be tested in online DQM at P5.

#### Backport
backport of https://github.com/cms-sw/cmssw/pull/46613