### PR TITLE
[MTD validation]: update and reorganization of MtdTracksValidation

### DIFF
--- a/Validation/MtdValidation/plugins/MtdTracksHarvester.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksHarvester.cc
@@ -30,24 +30,77 @@ private:
   MonitorElement* meBtlEtaEff_;
   MonitorElement* meBtlPhiEff_;
   MonitorElement* meBtlPtEff_;
-  MonitorElement* meEtlEtaEff_[2];
+  MonitorElement* meEtlEtaEff_;
+  MonitorElement* meEtlPhiEff_;
+  MonitorElement* meEtlPtEff_;
+  MonitorElement* meEtlEtaEff2_;
+  MonitorElement* meEtlPhiEff2_;
+  MonitorElement* meEtlPtEff2_;
   MonitorElement* meEtlEtaEffLowPt_[2];
-  MonitorElement* meEtlPhiEff_[2];
-  MonitorElement* meEtlPtEff_[2];
-  MonitorElement* meEtlEtaEff2_[2];
   MonitorElement* meEtlEtaEff2LowPt_[2];
-  MonitorElement* meEtlPhiEff2_[2];
-  MonitorElement* meEtlPtEff2_[2];
-  MonitorElement* meTPPtSelEff_;
-  MonitorElement* meTPEtaSelEff_;
-  MonitorElement* meTPPtMatchEff_;
-  MonitorElement* meTPEtaMatchEff_;
-  MonitorElement* meTPPtMatchEtl2Eff_;
-  MonitorElement* meTPEtaMatchEtl2Eff_;
-  MonitorElement* meTPmtdPtSelEff_;
-  MonitorElement* meTPmtdEtaSelEff_;
-  MonitorElement* meTPmtdPtMatchEff_;
-  MonitorElement* meTPmtdEtaMatchEff_;
+
+  MonitorElement* meBTLTPPtSelEff_;
+  MonitorElement* meBTLTPEtaSelEff_;
+  MonitorElement* meBTLTPPtMatchEff_;
+  MonitorElement* meBTLTPEtaMatchEff_;
+  MonitorElement* meETLTPPtSelEff_;
+  MonitorElement* meETLTPEtaSelEff_;
+  MonitorElement* meETLTPPtMatchEff_;
+  MonitorElement* meETLTPEtaMatchEff_;
+  MonitorElement* meETLTPPtMatchEff2_;
+  MonitorElement* meETLTPEtaMatchEff2_;
+
+  // - BTL track-mtd matching efficiencies
+  MonitorElement* meBTLTPmtdDirectEtaSelEff_;
+  MonitorElement* meBTLTPmtdDirectPtSelEff_;
+  MonitorElement* meBTLTPmtdOtherEtaSelEff_;
+  MonitorElement* meBTLTPmtdOtherPtSelEff_;
+  MonitorElement* meBTLTPnomtdEtaSelEff_;
+  MonitorElement* meBTLTPnomtdPtSelEff_;
+
+  MonitorElement* meBTLTPmtdDirectCorrectAssocEtaMatchEff_;
+  MonitorElement* meBTLTPmtdDirectCorrectAssocPtMatchEff_;
+  MonitorElement* meBTLTPmtdDirectWrongAssocEtaMatchEff_;
+  MonitorElement* meBTLTPmtdDirectWrongAssocPtMatchEff_;
+  MonitorElement* meBTLTPmtdDirectNoAssocEtaMatchEff_;
+  MonitorElement* meBTLTPmtdDirectNoAssocPtMatchEff_;
+
+  MonitorElement* meBTLTPmtdOtherCorrectAssocEtaMatchEff_;
+  MonitorElement* meBTLTPmtdOtherCorrectAssocPtMatchEff_;
+  MonitorElement* meBTLTPmtdOtherWrongAssocEtaMatchEff_;
+  MonitorElement* meBTLTPmtdOtherWrongAssocPtMatchEff_;
+  MonitorElement* meBTLTPmtdOtherNoAssocEtaMatchEff_;
+  MonitorElement* meBTLTPmtdOtherNoAssocPtMatchEff_;
+
+  MonitorElement* meBTLTPnomtdEtaMatchEff_;
+  MonitorElement* meBTLTPnomtdPtMatchEff_;
+
+  // - ETL track-mtd matching efficiencies
+  MonitorElement* meETLTPmtd1EtaSelEff_;
+  MonitorElement* meETLTPmtd1PtSelEff_;
+  MonitorElement* meETLTPmtd2EtaSelEff_;
+  MonitorElement* meETLTPmtd2PtSelEff_;
+  MonitorElement* meETLTPnomtdEtaSelEff_;
+  MonitorElement* meETLTPnomtdPtSelEff_;
+
+  MonitorElement* meETLTPmtd1CorrectAssocEtaMatchEff_;
+  MonitorElement* meETLTPmtd1CorrectAssocPtMatchEff_;
+  MonitorElement* meETLTPmtd1WrongAssocEtaMatchEff_;
+  MonitorElement* meETLTPmtd1WrongAssocPtMatchEff_;
+  MonitorElement* meETLTPmtd1NoAssocEtaMatchEff_;
+  MonitorElement* meETLTPmtd1NoAssocPtMatchEff_;
+
+  MonitorElement* meETLTPmtd2CorrectAssocEtaMatchEff_;
+  MonitorElement* meETLTPmtd2CorrectAssocPtMatchEff_;
+  MonitorElement* meETLTPmtd2WrongAssocEtaMatchEff_;
+  MonitorElement* meETLTPmtd2WrongAssocPtMatchEff_;
+  MonitorElement* meETLTPmtd2NoAssocEtaMatchEff_;
+  MonitorElement* meETLTPmtd2NoAssocPtMatchEff_;
+
+  MonitorElement* meETLTPnomtdEtaMatchEff_;
+  MonitorElement* meETLTPnomtdPtMatchEff_;
+
+  // -
   MonitorElement* meNoTimeFraction_;
   MonitorElement* meExtraPtEff_;
   MonitorElement* meExtraPtEtl2Eff_;
@@ -93,54 +146,111 @@ void MtdTracksHarvester::normalize(MonitorElement* h, double scale) {
 // ------------ endjob tasks ----------------------------
 void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& igetter) {
   // --- Get the monitoring histograms
-  MonitorElement* meBTLTrackEffEtaTot = igetter.get(folder_ + "TrackBTLEffEtaTot");
-  MonitorElement* meBTLTrackEffPhiTot = igetter.get(folder_ + "TrackBTLEffPhiTot");
-  MonitorElement* meBTLTrackEffPtTot = igetter.get(folder_ + "TrackBTLEffPtTot");
-  MonitorElement* meBTLTrackEffEtaMtd = igetter.get(folder_ + "TrackBTLEffEtaMtd");
-  MonitorElement* meBTLTrackEffPhiMtd = igetter.get(folder_ + "TrackBTLEffPhiMtd");
-  MonitorElement* meBTLTrackEffPtMtd = igetter.get(folder_ + "TrackBTLEffPtMtd");
-  MonitorElement* meETLTrackEffEtaTotZneg = igetter.get(folder_ + "TrackETLEffEtaTotZneg");
-  MonitorElement* meETLTrackEffEtaTotLowPt0 = igetter.get(folder_ + "TrackETLEffEtaTotLowPt0");
-  MonitorElement* meETLTrackEffEtaTotLowPt1 = igetter.get(folder_ + "TrackETLEffEtaTotLowPt1");
-  MonitorElement* meETLTrackEffPhiTotZneg = igetter.get(folder_ + "TrackETLEffPhiTotZneg");
-  MonitorElement* meETLTrackEffPtTotZneg = igetter.get(folder_ + "TrackETLEffPtTotZneg");
-  MonitorElement* meETLTrackEffEtaMtdZneg = igetter.get(folder_ + "TrackETLEffEtaMtdZneg");
-  MonitorElement* meETLTrackEffEtaMtdLowPt0 = igetter.get(folder_ + "TrackETLEffEtaMtdLowPt0");
-  MonitorElement* meETLTrackEffEtaMtdLowPt1 = igetter.get(folder_ + "TrackETLEffEtaMtdLowPt1");
-  MonitorElement* meETLTrackEffPhiMtdZneg = igetter.get(folder_ + "TrackETLEffPhiMtdZneg");
-  MonitorElement* meETLTrackEffPtMtdZneg = igetter.get(folder_ + "TrackETLEffPtMtdZneg");
-  MonitorElement* meETLTrackEffEta2MtdZneg = igetter.get(folder_ + "TrackETLEffEta2MtdZneg");
-  MonitorElement* meETLTrackEffEta2MtdLowPt0 = igetter.get(folder_ + "TrackETLEffEta2MtdLowPt0");
-  MonitorElement* meETLTrackEffEta2MtdLowPt1 = igetter.get(folder_ + "TrackETLEffEta2MtdLowPt1");
-  MonitorElement* meETLTrackEffPhi2MtdZneg = igetter.get(folder_ + "TrackETLEffPhi2MtdZneg");
-  MonitorElement* meETLTrackEffPt2MtdZneg = igetter.get(folder_ + "TrackETLEffPt2MtdZneg");
-  MonitorElement* meETLTrackEffEtaTotZpos = igetter.get(folder_ + "TrackETLEffEtaTotZpos");
-  MonitorElement* meETLTrackEffPhiTotZpos = igetter.get(folder_ + "TrackETLEffPhiTotZpos");
-  MonitorElement* meETLTrackEffPtTotZpos = igetter.get(folder_ + "TrackETLEffPtTotZpos");
-  MonitorElement* meETLTrackEffEtaMtdZpos = igetter.get(folder_ + "TrackETLEffEtaMtdZpos");
-  MonitorElement* meETLTrackEffPhiMtdZpos = igetter.get(folder_ + "TrackETLEffPhiMtdZpos");
-  MonitorElement* meETLTrackEffPtMtdZpos = igetter.get(folder_ + "TrackETLEffPtMtdZpos");
-  MonitorElement* meETLTrackEffEta2MtdZpos = igetter.get(folder_ + "TrackETLEffEta2MtdZpos");
-  MonitorElement* meETLTrackEffPhi2MtdZpos = igetter.get(folder_ + "TrackETLEffPhi2MtdZpos");
-  MonitorElement* meETLTrackEffPt2MtdZpos = igetter.get(folder_ + "TrackETLEffPt2MtdZpos");
-  MonitorElement* meTrackPtTot = igetter.get(folder_ + "TrackPtTot");
+  MonitorElement* meBTLTrackEtaTot = igetter.get(folder_ + "TrackBTLEtaTot");
+  MonitorElement* meBTLTrackPhiTot = igetter.get(folder_ + "TrackBTLPhiTot");
+  MonitorElement* meBTLTrackPtTot = igetter.get(folder_ + "TrackBTLPtTot");
+  MonitorElement* meBTLTrackEtaMtd = igetter.get(folder_ + "TrackBTLEtaMtd");
+  MonitorElement* meBTLTrackPhiMtd = igetter.get(folder_ + "TrackBTLPhiMtd");
+  MonitorElement* meBTLTrackPtMtd = igetter.get(folder_ + "TrackBTLPtMtd");
+
+  MonitorElement* meETLTrackEtaTot = igetter.get(folder_ + "TrackETLEtaTot");
+  MonitorElement* meETLTrackPhiTot = igetter.get(folder_ + "TrackETLPhiTot");
+  MonitorElement* meETLTrackPtTot = igetter.get(folder_ + "TrackETLPtTot");
+  MonitorElement* meETLTrackEtaMtd = igetter.get(folder_ + "TrackETLEtaMtd");
+  MonitorElement* meETLTrackPhiMtd = igetter.get(folder_ + "TrackETLPhiMtd");
+  MonitorElement* meETLTrackPtMtd = igetter.get(folder_ + "TrackETLPtMtd");
+  MonitorElement* meETLTrackEta2Mtd = igetter.get(folder_ + "TrackETLEta2Mtd");
+  MonitorElement* meETLTrackPhi2Mtd = igetter.get(folder_ + "TrackETLPhi2Mtd");
+  MonitorElement* meETLTrackPt2Mtd = igetter.get(folder_ + "TrackETLPt2Mtd");
+
+  MonitorElement* meETLTrackEtaTotLowPt0 = igetter.get(folder_ + "TrackETLEtaTotLowPt0");
+  MonitorElement* meETLTrackEtaTotLowPt1 = igetter.get(folder_ + "TrackETLEtaTotLowPt1");
+  MonitorElement* meETLTrackEtaMtdLowPt0 = igetter.get(folder_ + "TrackETLEtaMtdLowPt0");
+  MonitorElement* meETLTrackEtaMtdLowPt1 = igetter.get(folder_ + "TrackETLEtaMtdLowPt1");
+  MonitorElement* meETLTrackEta2MtdLowPt0 = igetter.get(folder_ + "TrackETLEta2MtdLowPt0");
+  MonitorElement* meETLTrackEta2MtdLowPt1 = igetter.get(folder_ + "TrackETLEta2MtdLowPt1");
+
   MonitorElement* meExtraPtMtd = igetter.get(folder_ + "ExtraPtMtd");
   MonitorElement* meExtraPtEtl2Mtd = igetter.get(folder_ + "ExtraPtEtl2Mtd");
-  MonitorElement* meTrackMatchedTPEffPtTot = igetter.get(folder_ + "MatchedTPEffPtTot");
-  MonitorElement* meTrackMatchedTPEffPtTotLV = igetter.get(folder_ + "MatchedTPEffPtTotLV");
-  MonitorElement* meTrackMatchedTPEffPtMtd = igetter.get(folder_ + "MatchedTPEffPtMtd");
-  MonitorElement* meTrackMatchedTPEffPtEtl2Mtd = igetter.get(folder_ + "MatchedTPEffPtEtl2Mtd");
-  MonitorElement* meTrackMatchedTPmtdEffPtTot = igetter.get(folder_ + "MatchedTPmtdEffPtTot");
-  MonitorElement* meTrackMatchedTPmtdEffPtMtd = igetter.get(folder_ + "MatchedTPmtdEffPtMtd");
-  MonitorElement* meTrackEtaTot = igetter.get(folder_ + "TrackEtaTot");
+  MonitorElement* meTrackMatchedTPPtTotLV = igetter.get(folder_ + "MatchedTPPtTotLV");
   MonitorElement* meExtraEtaMtd = igetter.get(folder_ + "ExtraEtaMtd");
   MonitorElement* meExtraEtaEtl2Mtd = igetter.get(folder_ + "ExtraEtaEtl2Mtd");
-  MonitorElement* meTrackMatchedTPEffEtaTot = igetter.get(folder_ + "MatchedTPEffEtaTot");
-  MonitorElement* meTrackMatchedTPEffEtaTotLV = igetter.get(folder_ + "MatchedTPEffEtaTotLV");
-  MonitorElement* meTrackMatchedTPEffEtaMtd = igetter.get(folder_ + "MatchedTPEffEtaMtd");
-  MonitorElement* meTrackMatchedTPEffEtaEtl2Mtd = igetter.get(folder_ + "MatchedTPEffEtaEtl2Mtd");
-  MonitorElement* meTrackMatchedTPmtdEffEtaTot = igetter.get(folder_ + "MatchedTPmtdEffEtaTot");
-  MonitorElement* meTrackMatchedTPmtdEffEtaMtd = igetter.get(folder_ + "MatchedTPmtdEffEtaMtd");
+  MonitorElement* meTrackMatchedTPEtaTotLV = igetter.get(folder_ + "MatchedTPEtaTotLV");
+
+  MonitorElement* meBTLTrackMatchedTPPtTot = igetter.get(folder_ + "BTLTrackMatchedTPPtTot");
+  MonitorElement* meBTLTrackMatchedTPPtMtd = igetter.get(folder_ + "BTLTrackMatchedTPPtMtd");
+  MonitorElement* meBTLTrackMatchedTPEtaTot = igetter.get(folder_ + "BTLTrackMatchedTPEtaTot");
+  MonitorElement* meBTLTrackMatchedTPEtaMtd = igetter.get(folder_ + "BTLTrackMatchedTPEtaMtd");
+  MonitorElement* meETLTrackMatchedTPPtTot = igetter.get(folder_ + "ETLTrackMatchedTPPtTot");
+  MonitorElement* meETLTrackMatchedTPPtMtd = igetter.get(folder_ + "ETLTrackMatchedTPPtMtd");
+  MonitorElement* meETLTrackMatchedTPPt2Mtd = igetter.get(folder_ + "ETLTrackMatchedTPPt2Mtd");
+  MonitorElement* meETLTrackMatchedTPEtaTot = igetter.get(folder_ + "ETLTrackMatchedTPEtaTot");
+  MonitorElement* meETLTrackMatchedTPEtaMtd = igetter.get(folder_ + "ETLTrackMatchedTPEtaMtd");
+  MonitorElement* meETLTrackMatchedTPEta2Mtd = igetter.get(folder_ + "ETLTrackMatchedTPEta2Mtd");
+
+  //
+  MonitorElement* meBTLTrackMatchedTPmtdDirectEta = igetter.get(folder_ + "BTLTrackMatchedTPmtdDirectEta");
+  MonitorElement* meBTLTrackMatchedTPmtdDirectPt = igetter.get(folder_ + "BTLTrackMatchedTPmtdDirectPt");
+  MonitorElement* meBTLTrackMatchedTPmtdOtherEta = igetter.get(folder_ + "BTLTrackMatchedTPmtdOtherEta");
+  MonitorElement* meBTLTrackMatchedTPmtdOtherPt = igetter.get(folder_ + "BTLTrackMatchedTPmtdOtherPt");
+  ;
+  MonitorElement* meBTLTrackMatchedTPnomtdEta = igetter.get(folder_ + "BTLTrackMatchedTPnomtdEta");
+  MonitorElement* meBTLTrackMatchedTPnomtdPt = igetter.get(folder_ + "BTLTrackMatchedTPnomtdPt");
+
+  MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocEta =
+      igetter.get(folder_ + "BTLTrackMatchedTPmtdDirectCorrectAssocEta");
+  MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocPt =
+      igetter.get(folder_ + "BTLTrackMatchedTPmtdDirectCorrectAssocPt");
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocEta =
+      igetter.get(folder_ + "BTLTrackMatchedTPmtdDirectWrongAssocEta");
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocPt =
+      igetter.get(folder_ + "BTLTrackMatchedTPmtdDirectWrongAssocPt");
+  MonitorElement* meBTLTrackMatchedTPmtdDirectNoAssocEta =
+      igetter.get(folder_ + "BTLTrackMatchedTPmtdDirectNoAssocEta");
+  MonitorElement* meBTLTrackMatchedTPmtdDirectNoAssocPt = igetter.get(folder_ + "BTLTrackMatchedTPmtdDirectNoAssocPt");
+
+  MonitorElement* meBTLTrackMatchedTPmtdOtherCorrectAssocEta =
+      igetter.get(folder_ + "BTLTrackMatchedTPmtdOtherCorrectAssocEta");
+  MonitorElement* meBTLTrackMatchedTPmtdOtherCorrectAssocPt =
+      igetter.get(folder_ + "BTLTrackMatchedTPmtdOtherCorrectAssocPt");
+  MonitorElement* meBTLTrackMatchedTPmtdOtherWrongAssocEta =
+      igetter.get(folder_ + "BTLTrackMatchedTPmtdOtherWrongAssocEta");
+  MonitorElement* meBTLTrackMatchedTPmtdOtherWrongAssocPt =
+      igetter.get(folder_ + "BTLTrackMatchedTPmtdOtherWrongAssocPt");
+  MonitorElement* meBTLTrackMatchedTPmtdOtherNoAssocEta = igetter.get(folder_ + "BTLTrackMatchedTPmtdOtherNoAssocEta");
+  MonitorElement* meBTLTrackMatchedTPmtdOtherNoAssocPt = igetter.get(folder_ + "BTLTrackMatchedTPmtdOtherNoAssocPt");
+
+  MonitorElement* meBTLTrackMatchedTPnomtdAssocEta = igetter.get(folder_ + "BTLTrackMatchedTPnomtdAssocEta");
+  MonitorElement* meBTLTrackMatchedTPnomtdAssocPt = igetter.get(folder_ + "BTLTrackMatchedTPnomtdAssocPt");
+
+  MonitorElement* meETLTrackMatchedTPmtd1Eta = igetter.get(folder_ + "ETLTrackMatchedTPmtd1Eta");
+  MonitorElement* meETLTrackMatchedTPmtd1Pt = igetter.get(folder_ + "ETLTrackMatchedTPmtd1Pt");
+  MonitorElement* meETLTrackMatchedTPmtd2Eta = igetter.get(folder_ + "ETLTrackMatchedTPmtd2Eta");
+  MonitorElement* meETLTrackMatchedTPmtd2Pt = igetter.get(folder_ + "ETLTrackMatchedTPmtd2Pt");
+  ;
+  MonitorElement* meETLTrackMatchedTPnomtdEta = igetter.get(folder_ + "ETLTrackMatchedTPnomtdEta");
+  MonitorElement* meETLTrackMatchedTPnomtdPt = igetter.get(folder_ + "ETLTrackMatchedTPnomtdPt");
+
+  MonitorElement* meETLTrackMatchedTPmtd1CorrectAssocEta =
+      igetter.get(folder_ + "ETLTrackMatchedTPmtd1CorrectAssocEta");
+  MonitorElement* meETLTrackMatchedTPmtd1CorrectAssocPt = igetter.get(folder_ + "ETLTrackMatchedTPmtd1CorrectAssocPt");
+  MonitorElement* meETLTrackMatchedTPmtd1WrongAssocEta = igetter.get(folder_ + "ETLTrackMatchedTPmtd1WrongAssocEta");
+  MonitorElement* meETLTrackMatchedTPmtd1WrongAssocPt = igetter.get(folder_ + "ETLTrackMatchedTPmtd1WrongAssocPt");
+  MonitorElement* meETLTrackMatchedTPmtd1NoAssocEta = igetter.get(folder_ + "ETLTrackMatchedTPmtd1NoAssocEta");
+  MonitorElement* meETLTrackMatchedTPmtd1NoAssocPt = igetter.get(folder_ + "ETLTrackMatchedTPmtd1NoAssocPt");
+
+  MonitorElement* meETLTrackMatchedTPmtd2CorrectAssocEta =
+      igetter.get(folder_ + "ETLTrackMatchedTPmtd2CorrectAssocEta");
+  MonitorElement* meETLTrackMatchedTPmtd2CorrectAssocPt = igetter.get(folder_ + "ETLTrackMatchedTPmtd2CorrectAssocPt");
+  MonitorElement* meETLTrackMatchedTPmtd2WrongAssocEta = igetter.get(folder_ + "ETLTrackMatchedTPmtd2WrongAssocEta");
+  MonitorElement* meETLTrackMatchedTPmtd2WrongAssocPt = igetter.get(folder_ + "ETLTrackMatchedTPmtd2WrongAssocPt");
+  MonitorElement* meETLTrackMatchedTPmtd2NoAssocEta = igetter.get(folder_ + "ETLTrackMatchedTPmtd2NoAssocEta");
+  MonitorElement* meETLTrackMatchedTPmtd2NoAssocPt = igetter.get(folder_ + "ETLTrackMatchedTPmtd2NoAssocPt");
+
+  MonitorElement* meETLTrackMatchedTPnomtdAssocEta = igetter.get(folder_ + "ETLTrackMatchedTPnomtdAssocEta");
+  MonitorElement* meETLTrackMatchedTPnomtdAssocPt = igetter.get(folder_ + "ETLTrackMatchedTPnomtdAssocPt");
+
+  //
   MonitorElement* meTrackNumHits = igetter.get(folder_ + "TrackNumHits");
   MonitorElement* meTrackNumHitsNT = igetter.get(folder_ + "TrackNumHitsNT");
   MonitorElement* meExtraPhiAtBTL = igetter.get(folder_ + "ExtraPhiAtBTL");
@@ -149,21 +259,36 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   MonitorElement* meExtraMTDfailExtenderEta = igetter.get(folder_ + "ExtraMTDfailExtenderEta");
   MonitorElement* meExtraMTDfailExtenderPt = igetter.get(folder_ + "ExtraMTDfailExtenderPt");
 
-  if (!meBTLTrackEffEtaTot || !meBTLTrackEffPhiTot || !meBTLTrackEffPtTot || !meBTLTrackEffEtaMtd ||
-      !meBTLTrackEffPhiMtd || !meBTLTrackEffPtMtd || !meETLTrackEffEtaTotZneg || !meETLTrackEffPhiTotZneg ||
-      !meETLTrackEffPtTotZneg || !meETLTrackEffEtaTotLowPt0 || !meETLTrackEffEtaTotLowPt1 || !meETLTrackEffEtaMtdZneg ||
-      !meETLTrackEffEtaMtdLowPt0 || !meETLTrackEffEtaMtdLowPt1 || !meETLTrackEffPhiMtdZneg || !meETLTrackEffPtMtdZneg ||
-      !meETLTrackEffEta2MtdZneg || !meETLTrackEffEta2MtdLowPt0 || !meETLTrackEffEta2MtdLowPt1 ||
-      !meETLTrackEffPhi2MtdZneg || !meETLTrackEffPt2MtdZneg || !meETLTrackEffEtaTotZpos || !meETLTrackEffPhiTotZpos ||
-      !meETLTrackEffPtTotZpos || !meETLTrackEffEtaMtdZpos || !meETLTrackEffPhiMtdZpos || !meETLTrackEffPtMtdZpos ||
-      !meETLTrackEffEta2MtdZpos || !meETLTrackEffPhi2MtdZpos || !meETLTrackEffPt2MtdZpos || !meTrackMatchedTPEffPtTot ||
-      !meTrackMatchedTPEffPtTotLV || !meTrackMatchedTPEffPtMtd || !meTrackMatchedTPEffPtEtl2Mtd ||
-      !meTrackMatchedTPmtdEffPtTot || !meTrackMatchedTPmtdEffPtMtd || !meTrackMatchedTPEffEtaTot ||
-      !meTrackMatchedTPEffEtaTotLV || !meTrackMatchedTPEffEtaMtd || !meTrackMatchedTPEffEtaEtl2Mtd ||
-      !meTrackMatchedTPmtdEffEtaTot || !meTrackMatchedTPmtdEffEtaMtd || !meTrackNumHits || !meTrackNumHitsNT ||
-      !meTrackPtTot || !meTrackEtaTot || !meExtraPtMtd || !meExtraPtEtl2Mtd || !meExtraEtaMtd || !meExtraEtaEtl2Mtd ||
-      !meExtraPhiAtBTL || !meExtraPhiAtBTLmatched || !meExtraBTLeneInCone || !meExtraMTDfailExtenderEta ||
-      !meExtraMTDfailExtenderPt) {
+  if (!meBTLTrackEtaTot || !meBTLTrackPhiTot || !meBTLTrackPtTot || !meBTLTrackEtaMtd || !meBTLTrackPhiMtd ||
+      !meBTLTrackPtMtd || !meETLTrackEtaTot || !meETLTrackPhiTot || !meETLTrackPtTot || !meETLTrackEtaMtd ||
+      !meETLTrackPhiMtd || !meETLTrackPtMtd || !meETLTrackEta2Mtd || !meETLTrackPhi2Mtd || !meETLTrackPt2Mtd ||
+      !meETLTrackEtaTotLowPt0 || !meETLTrackEtaTotLowPt1 || !meETLTrackEtaMtdLowPt0 || !meETLTrackEtaMtdLowPt1 ||
+      !meETLTrackEta2MtdLowPt0 || !meETLTrackEta2MtdLowPt1 || !meTrackMatchedTPPtTotLV || !meTrackMatchedTPEtaTotLV ||
+
+      !meBTLTrackMatchedTPPtTot || !meBTLTrackMatchedTPPtMtd || !meBTLTrackMatchedTPEtaTot ||
+      !meBTLTrackMatchedTPEtaMtd || !meETLTrackMatchedTPPtTot || !meETLTrackMatchedTPPtMtd ||
+      !meETLTrackMatchedTPPt2Mtd || !meETLTrackMatchedTPEtaTot || !meETLTrackMatchedTPEtaMtd ||
+      !meETLTrackMatchedTPEta2Mtd ||
+
+      !meBTLTrackMatchedTPmtdDirectEta || !meBTLTrackMatchedTPmtdDirectPt || !meBTLTrackMatchedTPmtdOtherEta ||
+      !meBTLTrackMatchedTPmtdOtherPt || !meBTLTrackMatchedTPnomtdEta || !meBTLTrackMatchedTPnomtdPt ||
+      !meBTLTrackMatchedTPmtdDirectCorrectAssocEta || !meBTLTrackMatchedTPmtdDirectCorrectAssocPt ||
+      !meBTLTrackMatchedTPmtdDirectWrongAssocEta || !meBTLTrackMatchedTPmtdDirectWrongAssocPt ||
+      !meBTLTrackMatchedTPmtdDirectNoAssocEta || !meBTLTrackMatchedTPmtdDirectNoAssocPt ||
+      !meBTLTrackMatchedTPmtdOtherCorrectAssocEta || !meBTLTrackMatchedTPmtdOtherCorrectAssocPt ||
+      !meBTLTrackMatchedTPmtdOtherWrongAssocEta || !meBTLTrackMatchedTPmtdOtherWrongAssocPt ||
+      !meBTLTrackMatchedTPmtdOtherNoAssocEta || !meBTLTrackMatchedTPmtdOtherNoAssocPt ||
+      !meBTLTrackMatchedTPnomtdAssocEta || !meBTLTrackMatchedTPnomtdAssocPt || !meETLTrackMatchedTPmtd1Eta ||
+      !meETLTrackMatchedTPmtd1Pt || !meETLTrackMatchedTPmtd2Eta || !meETLTrackMatchedTPmtd2Pt ||
+      !meETLTrackMatchedTPnomtdEta || !meETLTrackMatchedTPnomtdPt || !meETLTrackMatchedTPmtd1CorrectAssocEta ||
+      !meETLTrackMatchedTPmtd1CorrectAssocPt || !meETLTrackMatchedTPmtd1WrongAssocEta ||
+      !meETLTrackMatchedTPmtd1WrongAssocPt || !meETLTrackMatchedTPmtd1NoAssocEta || !meETLTrackMatchedTPmtd1NoAssocPt ||
+      !meETLTrackMatchedTPmtd2CorrectAssocEta || !meETLTrackMatchedTPmtd2CorrectAssocPt ||
+      !meETLTrackMatchedTPmtd2WrongAssocEta || !meETLTrackMatchedTPmtd2WrongAssocPt ||
+      !meETLTrackMatchedTPmtd2NoAssocEta || !meETLTrackMatchedTPmtd2NoAssocPt || !meETLTrackMatchedTPnomtdAssocEta ||
+      !meETLTrackMatchedTPnomtdAssocPt || !meTrackNumHits || !meTrackNumHitsNT || !meExtraPtMtd || !meExtraPtEtl2Mtd ||
+      !meExtraEtaMtd || !meExtraEtaEtl2Mtd || !meExtraPhiAtBTL || !meExtraPhiAtBTLmatched || !meExtraBTLeneInCone ||
+      !meExtraMTDfailExtenderEta || !meExtraMTDfailExtenderPt) {
     edm::LogError("MtdTracksHarvester") << "Monitoring histograms not found!" << std::endl;
     return;
   }
@@ -172,270 +297,583 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   ibook.cd(folder_);
   meBtlEtaEff_ = ibook.book1D("BtlEtaEff",
                               " Track Efficiency VS Eta;#eta;Efficiency",
-                              meBTLTrackEffEtaTot->getNbinsX(),
-                              meBTLTrackEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
-                              meBTLTrackEffEtaTot->getTH1()->GetXaxis()->GetXmax());
+                              meBTLTrackEtaTot->getNbinsX(),
+                              meBTLTrackEtaTot->getTH1()->GetXaxis()->GetXmin(),
+                              meBTLTrackEtaTot->getTH1()->GetXaxis()->GetXmax());
   meBtlEtaEff_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meBTLTrackEffEtaMtd, meBTLTrackEffEtaTot, meBtlEtaEff_);
+  computeEfficiency1D(meBTLTrackEtaMtd, meBTLTrackEtaTot, meBtlEtaEff_);
 
   meBtlPhiEff_ = ibook.book1D("BtlPhiEff",
                               "Track Efficiency VS Phi;#phi [rad];Efficiency",
-                              meBTLTrackEffPhiTot->getNbinsX(),
-                              meBTLTrackEffPhiTot->getTH1()->GetXaxis()->GetXmin(),
-                              meBTLTrackEffPhiTot->getTH1()->GetXaxis()->GetXmax());
+                              meBTLTrackPhiTot->getNbinsX(),
+                              meBTLTrackPhiTot->getTH1()->GetXaxis()->GetXmin(),
+                              meBTLTrackPhiTot->getTH1()->GetXaxis()->GetXmax());
   meBtlPhiEff_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meBTLTrackEffPhiMtd, meBTLTrackEffPhiTot, meBtlPhiEff_);
+  computeEfficiency1D(meBTLTrackPhiMtd, meBTLTrackPhiTot, meBtlPhiEff_);
 
   meBtlPtEff_ = ibook.book1D("BtlPtEff",
                              "Track Efficiency VS Pt;Pt [GeV];Efficiency",
-                             meBTLTrackEffPtTot->getNbinsX(),
-                             meBTLTrackEffPtTot->getTH1()->GetXaxis()->GetXmin(),
-                             meBTLTrackEffPtTot->getTH1()->GetXaxis()->GetXmax());
+                             meBTLTrackPtTot->getNbinsX(),
+                             meBTLTrackPtTot->getTH1()->GetXaxis()->GetXmin(),
+                             meBTLTrackPtTot->getTH1()->GetXaxis()->GetXmax());
   meBtlPtEff_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meBTLTrackEffPtMtd, meBTLTrackEffPtTot, meBtlPtEff_);
+  computeEfficiency1D(meBTLTrackPtMtd, meBTLTrackPtTot, meBtlPtEff_);
 
-  meEtlEtaEff_[0] = ibook.book1D("EtlEtaEffZneg",
-                                 " Track Efficiency VS Eta (-Z);#eta;Efficiency",
-                                 meETLTrackEffEtaTotZneg->getNbinsX(),
-                                 meETLTrackEffEtaTotZneg->getTH1()->GetXaxis()->GetXmin(),
-                                 meETLTrackEffEtaTotZneg->getTH1()->GetXaxis()->GetXmax());
-  meEtlEtaEff_[0]->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meETLTrackEffEtaMtdZneg, meETLTrackEffEtaTotZneg, meEtlEtaEff_[0]);
+  meEtlEtaEff_ = ibook.book1D("EtlEtaEff",
+                              " Track Efficiency VS Eta;#eta;Efficiency",
+                              meETLTrackEtaTot->getNbinsX(),
+                              meETLTrackEtaTot->getTH1()->GetXaxis()->GetXmin(),
+                              meETLTrackEtaTot->getTH1()->GetXaxis()->GetXmax());
+  meEtlEtaEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meETLTrackEtaMtd, meETLTrackEtaTot, meEtlEtaEff_);
 
+  meEtlPhiEff_ = ibook.book1D("EtlPhiEff",
+                              "Track Efficiency VS Phi;#phi [rad];Efficiency",
+                              meETLTrackPhiTot->getNbinsX(),
+                              meETLTrackPhiTot->getTH1()->GetXaxis()->GetXmin(),
+                              meETLTrackPhiTot->getTH1()->GetXaxis()->GetXmax());
+  meEtlPhiEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meETLTrackPhiMtd, meETLTrackPhiTot, meEtlPhiEff_);
+
+  meEtlPtEff_ = ibook.book1D("EtlPtEff",
+                             "Track Efficiency VS Pt;Pt [GeV];Efficiency",
+                             meETLTrackPtTot->getNbinsX(),
+                             meETLTrackPtTot->getTH1()->GetXaxis()->GetXmin(),
+                             meETLTrackPtTot->getTH1()->GetXaxis()->GetXmax());
+  meEtlPtEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meETLTrackPtMtd, meETLTrackPtTot, meEtlPtEff_);
+
+  meEtlEtaEff2_ = ibook.book1D("EtlEtaEff2",
+                               " Track Efficiency VS Eta (2 hits);#eta;Efficiency",
+                               meETLTrackEtaTot->getNbinsX(),
+                               meETLTrackEtaTot->getTH1()->GetXaxis()->GetXmin(),
+                               meETLTrackEtaTot->getTH1()->GetXaxis()->GetXmax());
+  meEtlEtaEff2_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meETLTrackEta2Mtd, meETLTrackEtaTot, meEtlEtaEff2_);
+
+  meEtlPhiEff2_ = ibook.book1D("EtlPhiEff2",
+                               "Track Efficiency VS Phi (2 hits);#phi [rad];Efficiency",
+                               meETLTrackPhiTot->getNbinsX(),
+                               meETLTrackPhiTot->getTH1()->GetXaxis()->GetXmin(),
+                               meETLTrackPhiTot->getTH1()->GetXaxis()->GetXmax());
+  meEtlPhiEff2_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meETLTrackPhi2Mtd, meETLTrackPhiTot, meEtlPhiEff2_);
+
+  meEtlPtEff2_ = ibook.book1D("EtlPtEff2",
+                              "Track Efficiency VS Pt (2 hits);Pt [GeV];Efficiency",
+                              meETLTrackPtTot->getNbinsX(),
+                              meETLTrackPtTot->getTH1()->GetXaxis()->GetXmin(),
+                              meETLTrackPtTot->getTH1()->GetXaxis()->GetXmax());
+  meEtlPtEff2_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meETLTrackPt2Mtd, meETLTrackPtTot, meEtlPtEff2_);
+
+  // low pT
   meEtlEtaEffLowPt_[0] = ibook.book1D("EtlEtaEffLowPt0",
                                       " Track Efficiency VS Eta, 0.2 < pt < 0.45;#eta;Efficiency",
-                                      meETLTrackEffEtaTotLowPt0->getNbinsX(),
-                                      meETLTrackEffEtaTotLowPt0->getTH1()->GetXaxis()->GetXmin(),
-                                      meETLTrackEffEtaTotLowPt0->getTH1()->GetXaxis()->GetXmax());
+                                      meETLTrackEtaTotLowPt0->getNbinsX(),
+                                      meETLTrackEtaTotLowPt0->getTH1()->GetXaxis()->GetXmin(),
+                                      meETLTrackEtaTotLowPt0->getTH1()->GetXaxis()->GetXmax());
   meEtlEtaEffLowPt_[0]->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meETLTrackEffEtaMtdLowPt0, meETLTrackEffEtaTotLowPt0, meEtlEtaEffLowPt_[0]);
-
-  meEtlPhiEff_[0] = ibook.book1D("EtlPhiEffZneg",
-                                 "Track Efficiency VS Phi (-Z);#phi [rad];Efficiency",
-                                 meETLTrackEffPhiTotZneg->getNbinsX(),
-                                 meETLTrackEffPhiTotZneg->getTH1()->GetXaxis()->GetXmin(),
-                                 meETLTrackEffPhiTotZneg->getTH1()->GetXaxis()->GetXmax());
-  meEtlPhiEff_[0]->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meETLTrackEffPhiMtdZneg, meETLTrackEffPhiTotZneg, meEtlPhiEff_[0]);
-
-  meEtlPtEff_[0] = ibook.book1D("EtlPtEffZneg",
-                                "Track Efficiency VS Pt (-Z);Pt [GeV];Efficiency",
-                                meETLTrackEffPtTotZneg->getNbinsX(),
-                                meETLTrackEffPtTotZneg->getTH1()->GetXaxis()->GetXmin(),
-                                meETLTrackEffPtTotZneg->getTH1()->GetXaxis()->GetXmax());
-  meEtlPtEff_[0]->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meETLTrackEffPtMtdZneg, meETLTrackEffPtTotZneg, meEtlPtEff_[0]);
-
-  meEtlEtaEff_[1] = ibook.book1D("EtlEtaEffZpos",
-                                 " Track Efficiency VS Eta (+Z);#eta;Efficiency",
-                                 meETLTrackEffEtaTotZpos->getNbinsX(),
-                                 meETLTrackEffEtaTotZpos->getTH1()->GetXaxis()->GetXmin(),
-                                 meETLTrackEffEtaTotZpos->getTH1()->GetXaxis()->GetXmax());
-  meEtlEtaEff_[1]->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meETLTrackEffEtaMtdZpos, meETLTrackEffEtaTotZpos, meEtlEtaEff_[1]);
+  computeEfficiency1D(meETLTrackEtaMtdLowPt0, meETLTrackEtaTotLowPt0, meEtlEtaEffLowPt_[0]);
 
   meEtlEtaEffLowPt_[1] = ibook.book1D("EtlEtaEffLowPt1",
                                       " Track Efficiency VS Eta, 0.45 < pt < 0.7;#eta;Efficiency",
-                                      meETLTrackEffEtaTotLowPt1->getNbinsX(),
-                                      meETLTrackEffEtaTotLowPt1->getTH1()->GetXaxis()->GetXmin(),
-                                      meETLTrackEffEtaTotLowPt1->getTH1()->GetXaxis()->GetXmax());
+                                      meETLTrackEtaTotLowPt1->getNbinsX(),
+                                      meETLTrackEtaTotLowPt1->getTH1()->GetXaxis()->GetXmin(),
+                                      meETLTrackEtaTotLowPt1->getTH1()->GetXaxis()->GetXmax());
   meEtlEtaEffLowPt_[1]->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meETLTrackEffEtaMtdLowPt1, meETLTrackEffEtaTotLowPt1, meEtlEtaEffLowPt_[1]);
-
-  meEtlPhiEff_[1] = ibook.book1D("EtlPhiEffZpos",
-                                 "Track Efficiency VS Phi (+Z);#phi [rad];Efficiency",
-                                 meETLTrackEffPhiTotZpos->getNbinsX(),
-                                 meETLTrackEffPhiTotZpos->getTH1()->GetXaxis()->GetXmin(),
-                                 meETLTrackEffPhiTotZpos->getTH1()->GetXaxis()->GetXmax());
-  meEtlPhiEff_[1]->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meETLTrackEffPhiMtdZpos, meETLTrackEffPhiTotZpos, meEtlPhiEff_[1]);
-
-  meEtlPtEff_[1] = ibook.book1D("EtlPtEffZpos",
-                                "Track Efficiency VS Pt (+Z);Pt [GeV];Efficiency",
-                                meETLTrackEffPtTotZpos->getNbinsX(),
-                                meETLTrackEffPtTotZpos->getTH1()->GetXaxis()->GetXmin(),
-                                meETLTrackEffPtTotZpos->getTH1()->GetXaxis()->GetXmax());
-  meEtlPtEff_[1]->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meETLTrackEffPtMtdZpos, meETLTrackEffPtTotZpos, meEtlPtEff_[1]);
-
-  meEtlEtaEff2_[0] = ibook.book1D("EtlEtaEff2Zneg",
-                                  " Track Efficiency VS Eta (-Z, 2 hit);#eta;Efficiency",
-                                  meETLTrackEffEtaTotZneg->getNbinsX(),
-                                  meETLTrackEffEtaTotZneg->getTH1()->GetXaxis()->GetXmin(),
-                                  meETLTrackEffEtaTotZneg->getTH1()->GetXaxis()->GetXmax());
-  meEtlEtaEff2_[0]->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meETLTrackEffEta2MtdZneg, meETLTrackEffEtaTotZneg, meEtlEtaEff2_[0]);
+  computeEfficiency1D(meETLTrackEtaMtdLowPt1, meETLTrackEtaTotLowPt1, meEtlEtaEffLowPt_[1]);
 
   meEtlEtaEff2LowPt_[0] = ibook.book1D("EtlEtaEff2LowPt0",
                                        " Track Efficiency VS Eta (2 hits), 0.2 < pt < 0.45;#eta;Efficiency",
-                                       meETLTrackEffEtaTotLowPt0->getNbinsX(),
-                                       meETLTrackEffEtaTotLowPt0->getTH1()->GetXaxis()->GetXmin(),
-                                       meETLTrackEffEtaTotLowPt0->getTH1()->GetXaxis()->GetXmax());
+                                       meETLTrackEtaTotLowPt0->getNbinsX(),
+                                       meETLTrackEtaTotLowPt0->getTH1()->GetXaxis()->GetXmin(),
+                                       meETLTrackEtaTotLowPt0->getTH1()->GetXaxis()->GetXmax());
   meEtlEtaEff2LowPt_[0]->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meETLTrackEffEta2MtdLowPt0, meETLTrackEffEtaTotLowPt0, meEtlEtaEff2LowPt_[0]);
-
-  meEtlPhiEff2_[0] = ibook.book1D("EtlPhiEff2Zneg",
-                                  "Track Efficiency VS Phi (-Z, 2 hits);#phi [rad];Efficiency",
-                                  meETLTrackEffPhiTotZneg->getNbinsX(),
-                                  meETLTrackEffPhiTotZneg->getTH1()->GetXaxis()->GetXmin(),
-                                  meETLTrackEffPhiTotZneg->getTH1()->GetXaxis()->GetXmax());
-  meEtlPhiEff2_[0]->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meETLTrackEffPhi2MtdZneg, meETLTrackEffPhiTotZneg, meEtlPhiEff2_[0]);
-
-  meEtlPtEff2_[0] = ibook.book1D("EtlPtEff2Zneg",
-                                 "Track Efficiency VS Pt (-Z, 2 hits);Pt [GeV];Efficiency",
-                                 meETLTrackEffPtTotZneg->getNbinsX(),
-                                 meETLTrackEffPtTotZneg->getTH1()->GetXaxis()->GetXmin(),
-                                 meETLTrackEffPtTotZneg->getTH1()->GetXaxis()->GetXmax());
-  meEtlPtEff2_[0]->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meETLTrackEffPt2MtdZneg, meETLTrackEffPtTotZneg, meEtlPtEff2_[0]);
-
-  meEtlEtaEff2_[1] = ibook.book1D("EtlEtaEff2Zpos",
-                                  "Track Efficiency VS Eta (+Z, 2 hits);#eta;Efficiency",
-                                  meETLTrackEffEtaTotZpos->getNbinsX(),
-                                  meETLTrackEffEtaTotZpos->getTH1()->GetXaxis()->GetXmin(),
-                                  meETLTrackEffEtaTotZpos->getTH1()->GetXaxis()->GetXmax());
-  meEtlEtaEff2_[1]->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meETLTrackEffEta2MtdZpos, meETLTrackEffEtaTotZpos, meEtlEtaEff2_[1]);
+  computeEfficiency1D(meETLTrackEta2MtdLowPt0, meETLTrackEtaTotLowPt0, meEtlEtaEff2LowPt_[0]);
 
   meEtlEtaEff2LowPt_[1] = ibook.book1D("EtlEtaEff2LowPt1",
                                        " Track Efficiency VS Eta (2 hits), 0.45 < pt < 0.7;#eta;Efficiency",
-                                       meETLTrackEffEtaTotLowPt1->getNbinsX(),
-                                       meETLTrackEffEtaTotLowPt1->getTH1()->GetXaxis()->GetXmin(),
-                                       meETLTrackEffEtaTotLowPt1->getTH1()->GetXaxis()->GetXmax());
+                                       meETLTrackEtaTotLowPt1->getNbinsX(),
+                                       meETLTrackEtaTotLowPt1->getTH1()->GetXaxis()->GetXmin(),
+                                       meETLTrackEtaTotLowPt1->getTH1()->GetXaxis()->GetXmax());
   meEtlEtaEff2LowPt_[1]->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meETLTrackEffEta2MtdLowPt1, meETLTrackEffEtaTotLowPt1, meEtlEtaEff2LowPt_[1]);
-
-  meEtlPhiEff2_[1] = ibook.book1D("EtlPhiEff2Zpos",
-                                  "Track Efficiency VS Phi (+Z, 2 hits);#phi [rad];Efficiency",
-                                  meETLTrackEffPhiTotZpos->getNbinsX(),
-                                  meETLTrackEffPhiTotZpos->getTH1()->GetXaxis()->GetXmin(),
-                                  meETLTrackEffPhiTotZpos->getTH1()->GetXaxis()->GetXmax());
-  meEtlPhiEff2_[1]->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meETLTrackEffPhi2MtdZpos, meETLTrackEffPhiTotZpos, meEtlPhiEff2_[1]);
-
-  meEtlPtEff2_[1] = ibook.book1D("EtlPtEff2Zpos",
-                                 "Track Efficiency VS Pt (+Z, 2 hits);Pt [GeV];Efficiency",
-                                 meETLTrackEffPtTotZpos->getNbinsX(),
-                                 meETLTrackEffPtTotZpos->getTH1()->GetXaxis()->GetXmin(),
-                                 meETLTrackEffPtTotZpos->getTH1()->GetXaxis()->GetXmax());
-  meEtlPtEff2_[1]->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meETLTrackEffPt2MtdZpos, meETLTrackEffPtTotZpos, meEtlPtEff2_[1]);
+  computeEfficiency1D(meETLTrackEta2MtdLowPt1, meETLTrackEtaTotLowPt1, meEtlEtaEff2LowPt_[1]);
 
   meExtraPtEff_ =
       ibook.book1D("ExtraPtEff",
                    "MTD matching efficiency wrt extrapolated track associated to LV VS Pt;Pt [GeV];Efficiency",
-                   meTrackMatchedTPEffPtTotLV->getNbinsX(),
-                   meTrackMatchedTPEffPtTotLV->getTH1()->GetXaxis()->GetXmin(),
-                   meTrackMatchedTPEffPtTotLV->getTH1()->GetXaxis()->GetXmax());
+                   meTrackMatchedTPPtTotLV->getNbinsX(),
+                   meTrackMatchedTPPtTotLV->getTH1()->GetXaxis()->GetXmin(),
+                   meTrackMatchedTPPtTotLV->getTH1()->GetXaxis()->GetXmax());
   meExtraPtEff_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meExtraPtMtd, meTrackMatchedTPEffPtTotLV, meExtraPtEff_);
+  computeEfficiency1D(meExtraPtMtd, meTrackMatchedTPPtTotLV, meExtraPtEff_);
 
   meExtraPtEtl2Eff_ =
       ibook.book1D("ExtraPtEtl2Eff",
                    "MTD matching efficiency (2 ETL) wrt extrapolated track associated to LV VS Pt;Pt [GeV];Efficiency",
-                   meTrackMatchedTPEffPtTotLV->getNbinsX(),
-                   meTrackMatchedTPEffPtTotLV->getTH1()->GetXaxis()->GetXmin(),
-                   meTrackMatchedTPEffPtTotLV->getTH1()->GetXaxis()->GetXmax());
+                   meTrackMatchedTPPtTotLV->getNbinsX(),
+                   meTrackMatchedTPPtTotLV->getTH1()->GetXaxis()->GetXmin(),
+                   meTrackMatchedTPPtTotLV->getTH1()->GetXaxis()->GetXmax());
   meExtraPtEtl2Eff_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meExtraPtEtl2Mtd, meTrackMatchedTPEffPtTotLV, meExtraPtEtl2Eff_);
+  computeEfficiency1D(meExtraPtEtl2Mtd, meTrackMatchedTPPtTotLV, meExtraPtEtl2Eff_);
 
   meExtraEtaEff_ = ibook.book1D("ExtraEtaEff",
                                 "MTD matching efficiency wrt extrapolated track associated to LV VS Eta;Eta;Efficiency",
-                                meTrackMatchedTPEffEtaTotLV->getNbinsX(),
-                                meTrackMatchedTPEffEtaTotLV->getTH1()->GetXaxis()->GetXmin(),
-                                meTrackMatchedTPEffEtaTotLV->getTH1()->GetXaxis()->GetXmax());
+                                meTrackMatchedTPEtaTotLV->getNbinsX(),
+                                meTrackMatchedTPEtaTotLV->getTH1()->GetXaxis()->GetXmin(),
+                                meTrackMatchedTPEtaTotLV->getTH1()->GetXaxis()->GetXmax());
   meExtraEtaEff_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meExtraEtaMtd, meTrackMatchedTPEffEtaTotLV, meExtraEtaEff_);
+  computeEfficiency1D(meExtraEtaMtd, meTrackMatchedTPEtaTotLV, meExtraEtaEff_);
 
   meExtraEtaEtl2Eff_ =
       ibook.book1D("ExtraEtaEtl2Eff",
                    "MTD matching efficiency (2 ETL) wrt extrapolated track associated to LV VS Eta;Eta;Efficiency",
-                   meTrackMatchedTPEffEtaTotLV->getNbinsX(),
-                   meTrackMatchedTPEffEtaTotLV->getTH1()->GetXaxis()->GetXmin(),
-                   meTrackMatchedTPEffEtaTotLV->getTH1()->GetXaxis()->GetXmax());
+                   meTrackMatchedTPEtaTotLV->getNbinsX(),
+                   meTrackMatchedTPEtaTotLV->getTH1()->GetXaxis()->GetXmin(),
+                   meTrackMatchedTPEtaTotLV->getTH1()->GetXaxis()->GetXmax());
   meExtraEtaEtl2Eff_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meExtraEtaEtl2Mtd, meTrackMatchedTPEffEtaTotLV, meExtraEtaEtl2Eff_);
+  computeEfficiency1D(meExtraEtaEtl2Mtd, meTrackMatchedTPEtaTotLV, meExtraEtaEtl2Eff_);
 
-  meTPPtSelEff_ = ibook.book1D("TPPtSelEff",
-                               "Track selected efficiency TP VS Pt;Pt [GeV];Efficiency",
-                               meTrackPtTot->getNbinsX(),
-                               meTrackPtTot->getTH1()->GetXaxis()->GetXmin(),
-                               meTrackPtTot->getTH1()->GetXaxis()->GetXmax());
-  meTPPtSelEff_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meTrackMatchedTPEffPtTot, meTrackPtTot, meTPPtSelEff_);
+  // Efficiency for TP matched tracks
+  meBTLTPPtSelEff_ = ibook.book1D("BTLTPPtSelEff",
+                                  "Track selected efficiency TP VS Pt;Pt [GeV];Efficiency",
+                                  meBTLTrackPtTot->getNbinsX(),
+                                  meBTLTrackPtTot->getTH1()->GetXaxis()->GetXmin(),
+                                  meBTLTrackPtTot->getTH1()->GetXaxis()->GetXmax());
+  meBTLTPPtSelEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meBTLTrackMatchedTPPtTot, meBTLTrackPtTot, meBTLTPPtSelEff_);
 
-  meTPEtaSelEff_ = ibook.book1D("TPEtaSelEff",
-                                "Track selected efficiency TP VS Eta;Eta;Efficiency",
-                                meTrackEtaTot->getNbinsX(),
-                                meTrackEtaTot->getTH1()->GetXaxis()->GetXmin(),
-                                meTrackEtaTot->getTH1()->GetXaxis()->GetXmax());
-  meTPEtaSelEff_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meTrackMatchedTPEffEtaTot, meTrackEtaTot, meTPEtaSelEff_);
+  meBTLTPEtaSelEff_ = ibook.book1D("BTLTPEtaSelEff",
+                                   "Track selected efficiency TP VS Eta;Eta;Efficiency",
+                                   meBTLTrackEtaTot->getNbinsX(),
+                                   meBTLTrackEtaTot->getTH1()->GetXaxis()->GetXmin(),
+                                   meBTLTrackEtaTot->getTH1()->GetXaxis()->GetXmax());
+  meBTLTPEtaSelEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meBTLTrackMatchedTPEtaTot, meBTLTrackEtaTot, meBTLTPEtaSelEff_);
 
-  meTPPtMatchEff_ = ibook.book1D("TPPtMatchEff",
-                                 "Track matched to TP efficiency VS Pt;Pt [GeV];Efficiency",
-                                 meTrackMatchedTPEffPtTot->getNbinsX(),
-                                 meTrackMatchedTPEffPtTot->getTH1()->GetXaxis()->GetXmin(),
-                                 meTrackMatchedTPEffPtTot->getTH1()->GetXaxis()->GetXmax());
-  meTPPtMatchEff_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meTrackMatchedTPEffPtMtd, meTrackMatchedTPEffPtTot, meTPPtMatchEff_);
+  meBTLTPPtMatchEff_ = ibook.book1D("BTLTPPtMatchEff",
+                                    "Track matched to TP efficiency VS Pt;Pt [GeV];Efficiency",
+                                    meBTLTrackMatchedTPPtTot->getNbinsX(),
+                                    meBTLTrackMatchedTPPtTot->getTH1()->GetXaxis()->GetXmin(),
+                                    meBTLTrackMatchedTPPtTot->getTH1()->GetXaxis()->GetXmax());
+  meBTLTPPtMatchEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meBTLTrackMatchedTPPtMtd, meBTLTrackMatchedTPPtTot, meBTLTPPtMatchEff_);
 
-  meTPEtaMatchEff_ = ibook.book1D("TPEtaMatchEff",
-                                  "Track matched to TP efficiency VS Eta;Eta;Efficiency",
-                                  meTrackMatchedTPEffEtaTot->getNbinsX(),
-                                  meTrackMatchedTPEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
-                                  meTrackMatchedTPEffEtaTot->getTH1()->GetXaxis()->GetXmax());
-  meTPEtaMatchEff_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meTrackMatchedTPEffEtaMtd, meTrackMatchedTPEffEtaTot, meTPEtaMatchEff_);
+  meBTLTPEtaMatchEff_ = ibook.book1D("BTLTPEtaMatchEff",
+                                     "Track matched to TP efficiency VS Eta;Eta;Efficiency",
+                                     meBTLTrackMatchedTPEtaTot->getNbinsX(),
+                                     meBTLTrackMatchedTPEtaTot->getTH1()->GetXaxis()->GetXmin(),
+                                     meBTLTrackMatchedTPEtaTot->getTH1()->GetXaxis()->GetXmax());
+  meBTLTPEtaMatchEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meBTLTrackMatchedTPEtaMtd, meBTLTrackMatchedTPEtaTot, meBTLTPEtaMatchEff_);
 
-  meTPPtMatchEtl2Eff_ = ibook.book1D("TPPtMatchEtl2Eff",
-                                     "Track matched to TP efficiency VS Pt, 2 ETL hits;Pt [GeV];Efficiency",
-                                     meTrackMatchedTPEffPtTot->getNbinsX(),
-                                     meTrackMatchedTPEffPtTot->getTH1()->GetXaxis()->GetXmin(),
-                                     meTrackMatchedTPEffPtTot->getTH1()->GetXaxis()->GetXmax());
-  meTPPtMatchEtl2Eff_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meTrackMatchedTPEffPtEtl2Mtd, meTrackMatchedTPEffPtTot, meTPPtMatchEtl2Eff_);
+  meETLTPPtSelEff_ = ibook.book1D("ETLTPPtSelEff",
+                                  "Track selected efficiency TP VS Pt;Pt [GeV];Efficiency",
+                                  meETLTrackPtTot->getNbinsX(),
+                                  meETLTrackPtTot->getTH1()->GetXaxis()->GetXmin(),
+                                  meETLTrackPtTot->getTH1()->GetXaxis()->GetXmax());
+  meETLTPPtSelEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meETLTrackMatchedTPPtTot, meETLTrackPtTot, meETLTPPtSelEff_);
 
-  meTPEtaMatchEtl2Eff_ = ibook.book1D("TPEtaMatchEtl2Eff",
-                                      "Track matched to TP efficiency VS Eta, 2 ETL hits;Eta;Efficiency",
-                                      meTrackMatchedTPEffEtaTot->getNbinsX(),
-                                      meTrackMatchedTPEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
-                                      meTrackMatchedTPEffEtaTot->getTH1()->GetXaxis()->GetXmax());
-  meTPEtaMatchEtl2Eff_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meTrackMatchedTPEffEtaEtl2Mtd, meTrackMatchedTPEffEtaTot, meTPEtaMatchEtl2Eff_);
+  meETLTPEtaSelEff_ = ibook.book1D("ETLTPEtaSelEff",
+                                   "Track selected efficiency TP VS Eta;Eta;Efficiency",
+                                   meETLTrackEtaTot->getNbinsX(),
+                                   meETLTrackEtaTot->getTH1()->GetXaxis()->GetXmin(),
+                                   meETLTrackEtaTot->getTH1()->GetXaxis()->GetXmax());
+  meETLTPEtaSelEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meETLTrackMatchedTPEtaTot, meETLTrackEtaTot, meETLTPEtaSelEff_);
 
-  meTPmtdPtSelEff_ = ibook.book1D("TPmtdPtSelEff",
-                                  "Track selected efficiency TP-mtd hit VS Pt;Pt [GeV];Efficiency",
-                                  meTrackPtTot->getNbinsX(),
-                                  meTrackPtTot->getTH1()->GetXaxis()->GetXmin(),
-                                  meTrackPtTot->getTH1()->GetXaxis()->GetXmax());
-  meTPmtdPtSelEff_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meTrackMatchedTPmtdEffPtTot, meTrackPtTot, meTPmtdPtSelEff_);
+  meETLTPPtMatchEff_ = ibook.book1D("ETLTPPtMatchEff",
+                                    "Track matched to TP efficiency VS Pt;Pt [GeV];Efficiency",
+                                    meETLTrackMatchedTPPtTot->getNbinsX(),
+                                    meETLTrackMatchedTPPtTot->getTH1()->GetXaxis()->GetXmin(),
+                                    meETLTrackMatchedTPPtTot->getTH1()->GetXaxis()->GetXmax());
+  meETLTPPtMatchEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meETLTrackMatchedTPPtMtd, meETLTrackMatchedTPPtTot, meETLTPPtMatchEff_);
 
-  meTPmtdEtaSelEff_ = ibook.book1D("TPmtdEtaSelEff",
-                                   "Track selected efficiency TPmtd hit VS Eta;Eta;Efficiency",
-                                   meTrackEtaTot->getNbinsX(),
-                                   meTrackEtaTot->getTH1()->GetXaxis()->GetXmin(),
-                                   meTrackEtaTot->getTH1()->GetXaxis()->GetXmax());
-  meTPmtdEtaSelEff_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meTrackMatchedTPmtdEffEtaTot, meTrackEtaTot, meTPmtdEtaSelEff_);
+  meETLTPEtaMatchEff_ = ibook.book1D("ETLTPEtaMatchEff",
+                                     "Track matched to TP efficiency VS Eta;Eta;Efficiency",
+                                     meETLTrackMatchedTPEtaTot->getNbinsX(),
+                                     meETLTrackMatchedTPEtaTot->getTH1()->GetXaxis()->GetXmin(),
+                                     meETLTrackMatchedTPEtaTot->getTH1()->GetXaxis()->GetXmax());
+  meETLTPEtaMatchEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meETLTrackMatchedTPEtaMtd, meETLTrackMatchedTPEtaTot, meETLTPEtaMatchEff_);
 
-  meTPmtdPtMatchEff_ = ibook.book1D("TPmtdPtMatchEff",
-                                    "Track matched to TP-mtd hit efficiency VS Pt;Pt [GeV];Efficiency",
-                                    meTrackMatchedTPmtdEffPtTot->getNbinsX(),
-                                    meTrackMatchedTPmtdEffPtTot->getTH1()->GetXaxis()->GetXmin(),
-                                    meTrackMatchedTPmtdEffPtTot->getTH1()->GetXaxis()->GetXmax());
-  meTPmtdPtMatchEff_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meTrackMatchedTPmtdEffPtMtd, meTrackMatchedTPmtdEffPtTot, meTPmtdPtMatchEff_);
+  meETLTPPtMatchEff2_ = ibook.book1D("ETLTPPtMatchEff2",
+                                     "Track matched to TP efficiency VS Pt (2 ETL hits);Pt [GeV];Efficiency",
+                                     meETLTrackMatchedTPPtTot->getNbinsX(),
+                                     meETLTrackMatchedTPPtTot->getTH1()->GetXaxis()->GetXmin(),
+                                     meETLTrackMatchedTPPtTot->getTH1()->GetXaxis()->GetXmax());
+  meETLTPPtMatchEff2_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meETLTrackMatchedTPPt2Mtd, meETLTrackMatchedTPPtTot, meETLTPPtMatchEff2_);
 
-  meTPmtdEtaMatchEff_ = ibook.book1D("TPmtdEtaMatchEff",
-                                     "Track matched to TP-mtd hit efficiency VS Eta;Eta;Efficiency",
-                                     meTrackMatchedTPmtdEffEtaTot->getNbinsX(),
-                                     meTrackMatchedTPmtdEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
-                                     meTrackMatchedTPmtdEffEtaTot->getTH1()->GetXaxis()->GetXmax());
-  meTPmtdEtaMatchEff_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meTrackMatchedTPmtdEffEtaMtd, meTrackMatchedTPmtdEffEtaTot, meTPmtdEtaMatchEff_);
+  meETLTPEtaMatchEff2_ = ibook.book1D("ETLTPEtaMatchEff2",
+                                      "Track matched to TP efficiency VS Eta (2 hits);Eta;Efficiency",
+                                      meETLTrackMatchedTPEtaTot->getNbinsX(),
+                                      meETLTrackMatchedTPEtaTot->getTH1()->GetXaxis()->GetXmin(),
+                                      meETLTrackMatchedTPEtaTot->getTH1()->GetXaxis()->GetXmax());
+  meETLTPEtaMatchEff2_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meETLTrackMatchedTPEta2Mtd, meETLTrackMatchedTPEtaTot, meETLTPEtaMatchEff2_);
+
+  // == Track-cluster matching efficiencies based on mc truth
+  // -- BTL
+  meBTLTPmtdDirectEtaSelEff_ = ibook.book1D("BTLTPmtdDirectEtaSelEff",
+                                            "Track selected efficiency TP-mtd hit (direct) VS Eta",
+                                            meBTLTrackEtaTot->getNbinsX(),
+                                            meBTLTrackEtaTot->getTH1()->GetXaxis()->GetXmin(),
+                                            meBTLTrackEtaTot->getTH1()->GetXaxis()->GetXmax());
+  meBTLTPmtdDirectEtaSelEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meBTLTrackMatchedTPmtdDirectEta, meBTLTrackEtaTot, meBTLTPmtdDirectEtaSelEff_);
+
+  meBTLTPmtdDirectPtSelEff_ = ibook.book1D("BTLTPmtdDirectPtSelEff",
+                                           "Track selected efficiency TP-mtd hit (direct) VS Pt",
+                                           meBTLTrackPtTot->getNbinsX(),
+                                           meBTLTrackPtTot->getTH1()->GetXaxis()->GetXmin(),
+                                           meBTLTrackPtTot->getTH1()->GetXaxis()->GetXmax());
+  meBTLTPmtdDirectPtSelEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meBTLTrackMatchedTPmtdDirectPt, meBTLTrackPtTot, meBTLTPmtdDirectPtSelEff_);
+
+  meBTLTPmtdOtherEtaSelEff_ = ibook.book1D("BTLTPmtdOtherEtaSelEff",
+                                           "Track selected efficiency TP-mtd hit (other) VS Eta",
+                                           meBTLTrackEtaTot->getNbinsX(),
+                                           meBTLTrackEtaTot->getTH1()->GetXaxis()->GetXmin(),
+                                           meBTLTrackEtaTot->getTH1()->GetXaxis()->GetXmax());
+  meBTLTPmtdOtherEtaSelEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meBTLTrackMatchedTPmtdOtherEta, meBTLTrackEtaTot, meBTLTPmtdOtherEtaSelEff_);
+
+  meBTLTPmtdOtherPtSelEff_ = ibook.book1D("BTLTPmtdOtherPtSelEff",
+                                          "Track selected efficiency TP-mtd hit (other) VS Pt",
+                                          meBTLTrackPtTot->getNbinsX(),
+                                          meBTLTrackPtTot->getTH1()->GetXaxis()->GetXmin(),
+                                          meBTLTrackPtTot->getTH1()->GetXaxis()->GetXmax());
+  meBTLTPmtdOtherPtSelEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meBTLTrackMatchedTPmtdOtherPt, meBTLTrackPtTot, meBTLTPmtdOtherPtSelEff_);
+
+  meBTLTPnomtdEtaSelEff_ = ibook.book1D("BTLTPnomtdEtaSelEff",
+                                        "Track selected efficiency TP-no mtd hit VS Eta",
+                                        meBTLTrackEtaTot->getNbinsX(),
+                                        meBTLTrackEtaTot->getTH1()->GetXaxis()->GetXmin(),
+                                        meBTLTrackEtaTot->getTH1()->GetXaxis()->GetXmax());
+  meBTLTPnomtdEtaSelEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meBTLTrackMatchedTPnomtdEta, meBTLTrackEtaTot, meBTLTPnomtdEtaSelEff_);
+
+  meBTLTPnomtdPtSelEff_ = ibook.book1D("BTLTPnomtdPtSelEff",
+                                       "Track selected efficiency TP-no mtd hit VS Pt",
+                                       meBTLTrackPtTot->getNbinsX(),
+                                       meBTLTrackPtTot->getTH1()->GetXaxis()->GetXmin(),
+                                       meBTLTrackPtTot->getTH1()->GetXaxis()->GetXmax());
+  meBTLTPnomtdPtSelEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meBTLTrackMatchedTPnomtdPt, meBTLTrackPtTot, meBTLTPnomtdPtSelEff_);
+
+  meBTLTPmtdDirectCorrectAssocEtaMatchEff_ =
+      ibook.book1D("BTLTPmtdDirectCorrectAssocEtaMatchEff",
+                   "Track efficiency TP-mtd hit (direct), correct reco match VS Eta",
+                   meBTLTrackMatchedTPmtdDirectEta->getNbinsX(),
+                   meBTLTrackMatchedTPmtdDirectEta->getTH1()->GetXaxis()->GetXmin(),
+                   meBTLTrackMatchedTPmtdDirectEta->getTH1()->GetXaxis()->GetXmax());
+  meBTLTPmtdDirectCorrectAssocEtaMatchEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meBTLTrackMatchedTPmtdDirectCorrectAssocEta,
+                      meBTLTrackMatchedTPmtdDirectEta,
+                      meBTLTPmtdDirectCorrectAssocEtaMatchEff_);
+
+  meBTLTPmtdDirectCorrectAssocPtMatchEff_ =
+      ibook.book1D("BTLTPmtdDirectCorrectAssocPtMatchEff",
+                   "Track efficiency TP-mtd hit (direct), correct reco match VS Pt",
+                   meBTLTrackMatchedTPmtdDirectPt->getNbinsX(),
+                   meBTLTrackMatchedTPmtdDirectPt->getTH1()->GetXaxis()->GetXmin(),
+                   meBTLTrackMatchedTPmtdDirectPt->getTH1()->GetXaxis()->GetXmax());
+  meBTLTPmtdDirectCorrectAssocPtMatchEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meBTLTrackMatchedTPmtdDirectCorrectAssocPt,
+                      meBTLTrackMatchedTPmtdDirectPt,
+                      meBTLTPmtdDirectCorrectAssocPtMatchEff_);
+
+  meBTLTPmtdDirectWrongAssocEtaMatchEff_ =
+      ibook.book1D("BTLTPmtdDirectWrongAssocEtaMatchEff",
+                   "Track efficiency TP-mtd hit (direct), incorrect reco match VS Eta",
+                   meBTLTrackMatchedTPmtdDirectEta->getNbinsX(),
+                   meBTLTrackMatchedTPmtdDirectEta->getTH1()->GetXaxis()->GetXmin(),
+                   meBTLTrackMatchedTPmtdDirectEta->getTH1()->GetXaxis()->GetXmax());
+  meBTLTPmtdDirectWrongAssocEtaMatchEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meBTLTrackMatchedTPmtdDirectWrongAssocEta,
+                      meBTLTrackMatchedTPmtdDirectEta,
+                      meBTLTPmtdDirectWrongAssocEtaMatchEff_);
+
+  meBTLTPmtdDirectWrongAssocPtMatchEff_ =
+      ibook.book1D("BTLTPmtdDirectWrongAssocPtMatchEff",
+                   "Track efficiency TP-mtd hit (direct), incorrect reco match VS Pt",
+                   meBTLTrackMatchedTPmtdDirectPt->getNbinsX(),
+                   meBTLTrackMatchedTPmtdDirectPt->getTH1()->GetXaxis()->GetXmin(),
+                   meBTLTrackMatchedTPmtdDirectPt->getTH1()->GetXaxis()->GetXmax());
+  meBTLTPmtdDirectWrongAssocPtMatchEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(
+      meBTLTrackMatchedTPmtdDirectWrongAssocPt, meBTLTrackMatchedTPmtdDirectPt, meBTLTPmtdDirectWrongAssocPtMatchEff_);
+
+  meBTLTPmtdDirectNoAssocEtaMatchEff_ = ibook.book1D("BTLTPmtdDirectNoAssocEtaMatchEff",
+                                                     "Track efficiency TP-mtd hit (direct), no reco match VS Eta",
+                                                     meBTLTrackMatchedTPmtdDirectEta->getNbinsX(),
+                                                     meBTLTrackMatchedTPmtdDirectEta->getTH1()->GetXaxis()->GetXmin(),
+                                                     meBTLTrackMatchedTPmtdDirectEta->getTH1()->GetXaxis()->GetXmax());
+  meBTLTPmtdDirectNoAssocEtaMatchEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(
+      meBTLTrackMatchedTPmtdDirectNoAssocEta, meBTLTrackMatchedTPmtdDirectEta, meBTLTPmtdDirectNoAssocEtaMatchEff_);
+
+  meBTLTPmtdDirectNoAssocPtMatchEff_ = ibook.book1D("BTLTPmtdDirectNoAssocPtMatchEff",
+                                                    "Track efficiency TP-mtd hit (direct), no reco match VS Pt",
+                                                    meBTLTrackMatchedTPmtdDirectPt->getNbinsX(),
+                                                    meBTLTrackMatchedTPmtdDirectPt->getTH1()->GetXaxis()->GetXmin(),
+                                                    meBTLTrackMatchedTPmtdDirectPt->getTH1()->GetXaxis()->GetXmax());
+  meBTLTPmtdDirectNoAssocPtMatchEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(
+      meBTLTrackMatchedTPmtdDirectNoAssocPt, meBTLTrackMatchedTPmtdDirectPt, meBTLTPmtdDirectNoAssocPtMatchEff_);
+
+  meBTLTPmtdOtherCorrectAssocEtaMatchEff_ =
+      ibook.book1D("BTLTPmtdOtherCorrectAssocEtaMatchEff",
+                   "Track efficiency TP-mtd hit (other), correct reco match VS Eta",
+                   meBTLTrackMatchedTPmtdOtherEta->getNbinsX(),
+                   meBTLTrackMatchedTPmtdOtherEta->getTH1()->GetXaxis()->GetXmin(),
+                   meBTLTrackMatchedTPmtdOtherEta->getTH1()->GetXaxis()->GetXmax());
+  meBTLTPmtdOtherCorrectAssocEtaMatchEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meBTLTrackMatchedTPmtdOtherCorrectAssocEta,
+                      meBTLTrackMatchedTPmtdOtherEta,
+                      meBTLTPmtdOtherCorrectAssocEtaMatchEff_);
+
+  meBTLTPmtdOtherCorrectAssocPtMatchEff_ = ibook.book1D("BTLTPmtdOtherCorrectAssocPtMatchEff",
+                                                        "Track efficiency TP-mtd hit (other), correct reco match VS Pt",
+                                                        meBTLTrackMatchedTPmtdOtherPt->getNbinsX(),
+                                                        meBTLTrackMatchedTPmtdOtherPt->getTH1()->GetXaxis()->GetXmin(),
+                                                        meBTLTrackMatchedTPmtdOtherPt->getTH1()->GetXaxis()->GetXmax());
+  meBTLTPmtdOtherCorrectAssocPtMatchEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(
+      meBTLTrackMatchedTPmtdOtherCorrectAssocPt, meBTLTrackMatchedTPmtdOtherPt, meBTLTPmtdOtherCorrectAssocPtMatchEff_);
+
+  meBTLTPmtdOtherWrongAssocEtaMatchEff_ =
+      ibook.book1D("BTLTPmtdOtherWrongAssocEtaMatchEff",
+                   "Track efficiency TP-mtd hit (other), incorrect reco match VS Eta",
+                   meBTLTrackMatchedTPmtdOtherEta->getNbinsX(),
+                   meBTLTrackMatchedTPmtdOtherEta->getTH1()->GetXaxis()->GetXmin(),
+                   meBTLTrackMatchedTPmtdOtherEta->getTH1()->GetXaxis()->GetXmax());
+  meBTLTPmtdOtherWrongAssocEtaMatchEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(
+      meBTLTrackMatchedTPmtdOtherWrongAssocEta, meBTLTrackMatchedTPmtdOtherEta, meBTLTPmtdOtherWrongAssocEtaMatchEff_);
+
+  meBTLTPmtdOtherWrongAssocPtMatchEff_ = ibook.book1D("BTLTPmtdOtherWrongAssocPtMatchEff",
+                                                      "Track efficiency TP-mtd hit (other), incorrect reco match VS Pt",
+                                                      meBTLTrackMatchedTPmtdOtherPt->getNbinsX(),
+                                                      meBTLTrackMatchedTPmtdOtherPt->getTH1()->GetXaxis()->GetXmin(),
+                                                      meBTLTrackMatchedTPmtdOtherPt->getTH1()->GetXaxis()->GetXmax());
+  meBTLTPmtdOtherWrongAssocPtMatchEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(
+      meBTLTrackMatchedTPmtdOtherWrongAssocPt, meBTLTrackMatchedTPmtdOtherPt, meBTLTPmtdOtherWrongAssocPtMatchEff_);
+
+  meBTLTPmtdOtherNoAssocEtaMatchEff_ = ibook.book1D("BTLTPmtdOtherNoAssocEtaMatchEff",
+                                                    "Track efficiency TP-mtd hit (other), no reco match VS Eta",
+                                                    meBTLTrackMatchedTPmtdOtherEta->getNbinsX(),
+                                                    meBTLTrackMatchedTPmtdOtherEta->getTH1()->GetXaxis()->GetXmin(),
+                                                    meBTLTrackMatchedTPmtdOtherEta->getTH1()->GetXaxis()->GetXmax());
+  meBTLTPmtdOtherNoAssocEtaMatchEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(
+      meBTLTrackMatchedTPmtdOtherNoAssocEta, meBTLTrackMatchedTPmtdOtherEta, meBTLTPmtdOtherNoAssocEtaMatchEff_);
+
+  meBTLTPmtdOtherNoAssocPtMatchEff_ = ibook.book1D("BTLTPmtdOtherNoAssocPtMatchEff",
+                                                   "Track efficiency TP-mtd hit (other), no reco match VS Pt",
+                                                   meBTLTrackMatchedTPmtdOtherPt->getNbinsX(),
+                                                   meBTLTrackMatchedTPmtdOtherPt->getTH1()->GetXaxis()->GetXmin(),
+                                                   meBTLTrackMatchedTPmtdOtherPt->getTH1()->GetXaxis()->GetXmax());
+  meBTLTPmtdOtherNoAssocPtMatchEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(
+      meBTLTrackMatchedTPmtdOtherNoAssocPt, meBTLTrackMatchedTPmtdOtherPt, meBTLTPmtdOtherNoAssocPtMatchEff_);
+
+  meBTLTPnomtdEtaMatchEff_ = ibook.book1D("BTLTPnomtdEtaMatchEff",
+                                          "Track efficiency TP- no mtd hit, with reco match VS Eta",
+                                          meBTLTrackMatchedTPnomtdEta->getNbinsX(),
+                                          meBTLTrackMatchedTPnomtdEta->getTH1()->GetXaxis()->GetXmin(),
+                                          meBTLTrackMatchedTPnomtdEta->getTH1()->GetXaxis()->GetXmax());
+  meBTLTPnomtdEtaMatchEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meBTLTrackMatchedTPnomtdAssocEta, meBTLTrackMatchedTPnomtdEta, meBTLTPnomtdEtaMatchEff_);
+
+  meBTLTPnomtdPtMatchEff_ = ibook.book1D("BTLTPnomtdPtMatchEff",
+                                         "Track efficiency TP- no mtd hit, with reco match VS Pt",
+                                         meBTLTrackMatchedTPnomtdPt->getNbinsX(),
+                                         meBTLTrackMatchedTPnomtdPt->getTH1()->GetXaxis()->GetXmin(),
+                                         meBTLTrackMatchedTPnomtdPt->getTH1()->GetXaxis()->GetXmax());
+  meBTLTPnomtdPtMatchEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meBTLTrackMatchedTPnomtdAssocPt, meBTLTrackMatchedTPnomtdPt, meBTLTPnomtdPtMatchEff_);
+
+  // -- ETL
+  meETLTPmtd1EtaSelEff_ = ibook.book1D("ETLTPmtd1EtaSelEff",
+                                       "Track selected efficiency TP-mtd hit (>=1 sim hit) VS Eta",
+                                       meETLTrackEtaTot->getNbinsX(),
+                                       meETLTrackEtaTot->getTH1()->GetXaxis()->GetXmin(),
+                                       meETLTrackEtaTot->getTH1()->GetXaxis()->GetXmax());
+  meETLTPmtd1EtaSelEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meETLTrackMatchedTPmtd1Eta, meETLTrackEtaTot, meETLTPmtd1EtaSelEff_);
+
+  meETLTPmtd1PtSelEff_ = ibook.book1D("ETLTPmtd1PtSelEff",
+                                      "Track selected efficiency TP-mtd hit (>=1 sim hit) VS Pt",
+                                      meETLTrackPtTot->getNbinsX(),
+                                      meETLTrackPtTot->getTH1()->GetXaxis()->GetXmin(),
+                                      meETLTrackPtTot->getTH1()->GetXaxis()->GetXmax());
+  meETLTPmtd1PtSelEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meETLTrackMatchedTPmtd1Pt, meETLTrackPtTot, meETLTPmtd1PtSelEff_);
+
+  meETLTPmtd2EtaSelEff_ = ibook.book1D("ETLTPmtd2EtaSelEff",
+                                       "Track selected efficiency TP-mtd hit (2 sim hits) VS Eta",
+                                       meETLTrackEtaTot->getNbinsX(),
+                                       meETLTrackEtaTot->getTH1()->GetXaxis()->GetXmin(),
+                                       meETLTrackEtaTot->getTH1()->GetXaxis()->GetXmax());
+  meETLTPmtd2EtaSelEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meETLTrackMatchedTPmtd2Eta, meETLTrackEtaTot, meETLTPmtd2EtaSelEff_);
+
+  meETLTPmtd2PtSelEff_ = ibook.book1D("ETLTPmtd2PtSelEff",
+                                      "Track selected efficiency TP-mtd hit (2 sim hits) VS Pt",
+                                      meETLTrackPtTot->getNbinsX(),
+                                      meETLTrackPtTot->getTH1()->GetXaxis()->GetXmin(),
+                                      meETLTrackPtTot->getTH1()->GetXaxis()->GetXmax());
+  meETLTPmtd2PtSelEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meETLTrackMatchedTPmtd2Pt, meETLTrackPtTot, meETLTPmtd2PtSelEff_);
+
+  meETLTPnomtdEtaSelEff_ = ibook.book1D("ETLTPnomtdEtaSelEff",
+                                        "Track selected efficiency TP-no mtd hit VS Eta",
+                                        meETLTrackEtaTot->getNbinsX(),
+                                        meETLTrackEtaTot->getTH1()->GetXaxis()->GetXmin(),
+                                        meETLTrackEtaTot->getTH1()->GetXaxis()->GetXmax());
+  meETLTPnomtdEtaSelEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meETLTrackMatchedTPnomtdEta, meETLTrackEtaTot, meETLTPnomtdEtaSelEff_);
+
+  meETLTPnomtdPtSelEff_ = ibook.book1D("ETLTPnomtdPtSelEff",
+                                       "Track selected efficiency TP-no mtd hit VS Pt",
+                                       meETLTrackPtTot->getNbinsX(),
+                                       meETLTrackPtTot->getTH1()->GetXaxis()->GetXmin(),
+                                       meETLTrackPtTot->getTH1()->GetXaxis()->GetXmax());
+  meETLTPnomtdPtSelEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meETLTrackMatchedTPnomtdPt, meETLTrackPtTot, meETLTPnomtdPtSelEff_);
+
+  meETLTPmtd1CorrectAssocEtaMatchEff_ =
+      ibook.book1D("ETLTPmtd1CorrectAssocEtaMatchEff",
+                   "Track efficiency TP-mtd hit (>=1 sim hit), correct reco match VS Eta",
+                   meETLTrackMatchedTPmtd1Eta->getNbinsX(),
+                   meETLTrackMatchedTPmtd1Eta->getTH1()->GetXaxis()->GetXmin(),
+                   meETLTrackMatchedTPmtd1Eta->getTH1()->GetXaxis()->GetXmax());
+  meETLTPmtd1CorrectAssocEtaMatchEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(
+      meETLTrackMatchedTPmtd1CorrectAssocEta, meETLTrackMatchedTPmtd1Eta, meETLTPmtd1CorrectAssocEtaMatchEff_);
+
+  meETLTPmtd1CorrectAssocPtMatchEff_ =
+      ibook.book1D("ETLTPmtd1CorrectAssocPtMatchEff",
+                   "Track efficiency TP-mtd hit (>=1 sim hit), correct reco match VS Pt",
+                   meETLTrackMatchedTPmtd1Pt->getNbinsX(),
+                   meETLTrackMatchedTPmtd1Pt->getTH1()->GetXaxis()->GetXmin(),
+                   meETLTrackMatchedTPmtd1Pt->getTH1()->GetXaxis()->GetXmax());
+  meETLTPmtd1CorrectAssocPtMatchEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(
+      meETLTrackMatchedTPmtd1CorrectAssocPt, meETLTrackMatchedTPmtd1Pt, meETLTPmtd1CorrectAssocPtMatchEff_);
+
+  meETLTPmtd1WrongAssocEtaMatchEff_ =
+      ibook.book1D("ETLTPmtd1WrongAssocEtaMatchEff",
+                   "Track efficiency TP-mtd hit (>=1 sim hit), incorrect reco match VS Eta",
+                   meETLTrackMatchedTPmtd1Eta->getNbinsX(),
+                   meETLTrackMatchedTPmtd1Eta->getTH1()->GetXaxis()->GetXmin(),
+                   meETLTrackMatchedTPmtd1Eta->getTH1()->GetXaxis()->GetXmax());
+  meETLTPmtd1WrongAssocEtaMatchEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(
+      meETLTrackMatchedTPmtd1WrongAssocEta, meETLTrackMatchedTPmtd1Eta, meETLTPmtd1WrongAssocEtaMatchEff_);
+
+  meETLTPmtd1WrongAssocPtMatchEff_ =
+      ibook.book1D("ETLTPmtd1WrongAssocPtMatchEff",
+                   "Track efficiency TP-mtd hit (>=1 sim hit), incorrect reco match VS Pt",
+                   meETLTrackMatchedTPmtd1Pt->getNbinsX(),
+                   meETLTrackMatchedTPmtd1Pt->getTH1()->GetXaxis()->GetXmin(),
+                   meETLTrackMatchedTPmtd1Pt->getTH1()->GetXaxis()->GetXmax());
+  meETLTPmtd1WrongAssocPtMatchEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meETLTrackMatchedTPmtd1WrongAssocPt, meETLTrackMatchedTPmtd1Pt, meETLTPmtd1WrongAssocPtMatchEff_);
+
+  meETLTPmtd1NoAssocEtaMatchEff_ = ibook.book1D("ETLTPmtd1NoAssocEtaMatchEff",
+                                                "Track efficiency TP-mtd hit (>=1 sim hit), no reco match VS Eta",
+                                                meETLTrackMatchedTPmtd1Eta->getNbinsX(),
+                                                meETLTrackMatchedTPmtd1Eta->getTH1()->GetXaxis()->GetXmin(),
+                                                meETLTrackMatchedTPmtd1Eta->getTH1()->GetXaxis()->GetXmax());
+  meETLTPmtd1NoAssocEtaMatchEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meETLTrackMatchedTPmtd1NoAssocEta, meETLTrackMatchedTPmtd1Eta, meETLTPmtd1NoAssocEtaMatchEff_);
+
+  meETLTPmtd1NoAssocPtMatchEff_ = ibook.book1D("ETLTPmtd1NoAssocPtMatchEff",
+                                               "Track efficiency TP-mtd hit (>=1 sim hit), no reco match VS Pt",
+                                               meETLTrackMatchedTPmtd1Pt->getNbinsX(),
+                                               meETLTrackMatchedTPmtd1Pt->getTH1()->GetXaxis()->GetXmin(),
+                                               meETLTrackMatchedTPmtd1Pt->getTH1()->GetXaxis()->GetXmax());
+  meETLTPmtd1NoAssocPtMatchEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meETLTrackMatchedTPmtd1NoAssocPt, meETLTrackMatchedTPmtd1Pt, meETLTPmtd1NoAssocPtMatchEff_);
+
+  meETLTPmtd2CorrectAssocEtaMatchEff_ =
+      ibook.book1D("ETLTPmtd2CorrectAssocEtaMatchEff",
+                   "Track efficiency TP-mtd hit (2 sim hits), correct reco match VS Eta",
+                   meETLTrackMatchedTPmtd2Eta->getNbinsX(),
+                   meETLTrackMatchedTPmtd2Eta->getTH1()->GetXaxis()->GetXmin(),
+                   meETLTrackMatchedTPmtd2Eta->getTH1()->GetXaxis()->GetXmax());
+  meETLTPmtd2CorrectAssocEtaMatchEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(
+      meETLTrackMatchedTPmtd2CorrectAssocEta, meETLTrackMatchedTPmtd2Eta, meETLTPmtd2CorrectAssocEtaMatchEff_);
+
+  meETLTPmtd2CorrectAssocPtMatchEff_ =
+      ibook.book1D("ETLTPmtd2CorrectAssocPtMatchEff",
+                   "Track efficiency TP-mtd hit (2 sim hits), correct reco match VS Pt",
+                   meETLTrackMatchedTPmtd2Pt->getNbinsX(),
+                   meETLTrackMatchedTPmtd2Pt->getTH1()->GetXaxis()->GetXmin(),
+                   meETLTrackMatchedTPmtd2Pt->getTH1()->GetXaxis()->GetXmax());
+  meETLTPmtd2CorrectAssocPtMatchEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(
+      meETLTrackMatchedTPmtd2CorrectAssocPt, meETLTrackMatchedTPmtd2Pt, meETLTPmtd2CorrectAssocPtMatchEff_);
+
+  meETLTPmtd2WrongAssocEtaMatchEff_ =
+      ibook.book1D("ETLTPmtd2WrongAssocEtaMatchEff",
+                   "Track efficiency TP-mtd hit (2 sim hits), incorrect reco match VS Eta",
+                   meETLTrackMatchedTPmtd2Eta->getNbinsX(),
+                   meETLTrackMatchedTPmtd2Eta->getTH1()->GetXaxis()->GetXmin(),
+                   meETLTrackMatchedTPmtd2Eta->getTH1()->GetXaxis()->GetXmax());
+  meETLTPmtd2WrongAssocEtaMatchEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(
+      meETLTrackMatchedTPmtd2WrongAssocEta, meETLTrackMatchedTPmtd2Eta, meETLTPmtd2WrongAssocEtaMatchEff_);
+
+  meETLTPmtd2WrongAssocPtMatchEff_ =
+      ibook.book1D("ETLTPmtd2WrongAssocPtMatchEff",
+                   "Track efficiency TP-mtd hit (2 sim hits), incorrect reco match VS Pt",
+                   meETLTrackMatchedTPmtd2Pt->getNbinsX(),
+                   meETLTrackMatchedTPmtd2Pt->getTH1()->GetXaxis()->GetXmin(),
+                   meETLTrackMatchedTPmtd2Pt->getTH1()->GetXaxis()->GetXmax());
+  meETLTPmtd2WrongAssocPtMatchEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meETLTrackMatchedTPmtd2WrongAssocPt, meETLTrackMatchedTPmtd2Pt, meETLTPmtd2WrongAssocPtMatchEff_);
+
+  meETLTPmtd2NoAssocEtaMatchEff_ = ibook.book1D("ETLTPmtd2NoAssocEtaMatchEff",
+                                                "Track efficiency TP-mtd hit (2 sim hits), no reco match VS Eta",
+                                                meETLTrackMatchedTPmtd2Eta->getNbinsX(),
+                                                meETLTrackMatchedTPmtd2Eta->getTH1()->GetXaxis()->GetXmin(),
+                                                meETLTrackMatchedTPmtd2Eta->getTH1()->GetXaxis()->GetXmax());
+  meETLTPmtd2NoAssocEtaMatchEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meETLTrackMatchedTPmtd2NoAssocEta, meETLTrackMatchedTPmtd2Eta, meETLTPmtd2NoAssocEtaMatchEff_);
+
+  meETLTPmtd2NoAssocPtMatchEff_ = ibook.book1D("ETLTPmtd2NoAssocPtMatchEff",
+                                               "Track efficiency TP-mtd hit (2 sim hits), no reco match VS Pt",
+                                               meETLTrackMatchedTPmtd2Pt->getNbinsX(),
+                                               meETLTrackMatchedTPmtd2Pt->getTH1()->GetXaxis()->GetXmin(),
+                                               meETLTrackMatchedTPmtd2Pt->getTH1()->GetXaxis()->GetXmax());
+  meETLTPmtd2NoAssocPtMatchEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meETLTrackMatchedTPmtd2NoAssocPt, meETLTrackMatchedTPmtd2Pt, meETLTPmtd2NoAssocPtMatchEff_);
+
+  meETLTPnomtdEtaMatchEff_ = ibook.book1D("ETLTPnomtdEtaMatchEff",
+                                          "Track efficiency TP- no mtd hit, with reco match VS Eta",
+                                          meETLTrackMatchedTPnomtdEta->getNbinsX(),
+                                          meETLTrackMatchedTPnomtdEta->getTH1()->GetXaxis()->GetXmin(),
+                                          meETLTrackMatchedTPnomtdEta->getTH1()->GetXaxis()->GetXmax());
+  meETLTPnomtdEtaMatchEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meETLTrackMatchedTPnomtdAssocEta, meETLTrackMatchedTPnomtdEta, meETLTPnomtdEtaMatchEff_);
+
+  meETLTPnomtdPtMatchEff_ = ibook.book1D("ETLTPnomtdPtMatchEff",
+                                         "Track efficiency TP- no mtd hit, with reco match VS Pt",
+                                         meETLTrackMatchedTPnomtdPt->getNbinsX(),
+                                         meETLTrackMatchedTPnomtdPt->getTH1()->GetXaxis()->GetXmin(),
+                                         meETLTrackMatchedTPnomtdPt->getTH1()->GetXaxis()->GetXmax());
+  meETLTPnomtdPtMatchEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meETLTrackMatchedTPnomtdAssocPt, meETLTrackMatchedTPnomtdPt, meETLTPnomtdPtMatchEff_);
 
   meNoTimeFraction_ = ibook.book1D("NoTimeFraction",
                                    "Fraction of tracks with MTD hits and no time associated; Num. of hits",
@@ -448,15 +886,15 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   meBtlEtaEff_->getTH1()->SetMinimum(0.);
   meBtlPhiEff_->getTH1()->SetMinimum(0.);
   meBtlPtEff_->getTH1()->SetMinimum(0.);
+  meEtlEtaEff_->getTH1()->SetMinimum(0.);
+  meEtlPhiEff_->getTH1()->SetMinimum(0.);
+  meEtlPtEff_->getTH1()->SetMinimum(0.);
+  meEtlEtaEff2_->getTH1()->SetMinimum(0.);
+  meEtlPhiEff2_->getTH1()->SetMinimum(0.);
+  meEtlPtEff2_->getTH1()->SetMinimum(0.);
   for (int i = 0; i < 2; i++) {
-    meEtlEtaEff_[i]->getTH1()->SetMinimum(0.);
     meEtlEtaEffLowPt_[i]->getTH1()->SetMinimum(0.);
-    meEtlPhiEff_[i]->getTH1()->SetMinimum(0.);
-    meEtlPtEff_[i]->getTH1()->SetMinimum(0.);
-    meEtlEtaEff2_[i]->getTH1()->SetMinimum(0.);
     meEtlEtaEff2LowPt_[i]->getTH1()->SetMinimum(0.);
-    meEtlPhiEff2_[i]->getTH1()->SetMinimum(0.);
-    meEtlPtEff2_[i]->getTH1()->SetMinimum(0.);
   }
 
   meExtraPhiAtBTLEff_ = ibook.book1D("ExtraPhiAtBTLEff",
@@ -472,20 +910,20 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   meExtraMTDfailExtenderEtaEff_ =
       ibook.book1D("ExtraMTDfailExtenderEtaEff",
                    "Track associated to LV extrapolated at MTD surface no extender efficiency VS Eta;Eta;Efficiency",
-                   meTrackMatchedTPEffEtaTotLV->getNbinsX(),
-                   meTrackMatchedTPEffEtaTotLV->getTH1()->GetXaxis()->GetXmin(),
-                   meTrackMatchedTPEffEtaTotLV->getTH1()->GetXaxis()->GetXmax());
+                   meTrackMatchedTPEtaTotLV->getNbinsX(),
+                   meTrackMatchedTPEtaTotLV->getTH1()->GetXaxis()->GetXmin(),
+                   meTrackMatchedTPEtaTotLV->getTH1()->GetXaxis()->GetXmax());
   meExtraMTDfailExtenderEtaEff_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meExtraMTDfailExtenderEta, meTrackMatchedTPEffEtaTotLV, meExtraMTDfailExtenderEtaEff_);
+  computeEfficiency1D(meExtraMTDfailExtenderEta, meTrackMatchedTPEtaTotLV, meExtraMTDfailExtenderEtaEff_);
 
   meExtraMTDfailExtenderPtEff_ = ibook.book1D(
       "ExtraMTDfailExtenderPtEff",
       "Track associated to LV extrapolated at MTD surface no extender efficiency VS Pt;Pt [GeV];Efficiency",
-      meTrackMatchedTPEffPtTotLV->getNbinsX(),
-      meTrackMatchedTPEffPtTotLV->getTH1()->GetXaxis()->GetXmin(),
-      meTrackMatchedTPEffPtTotLV->getTH1()->GetXaxis()->GetXmax());
+      meTrackMatchedTPPtTotLV->getNbinsX(),
+      meTrackMatchedTPPtTotLV->getTH1()->GetXaxis()->GetXmin(),
+      meTrackMatchedTPPtTotLV->getTH1()->GetXaxis()->GetXmax());
   meExtraMTDfailExtenderPtEff_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meExtraMTDfailExtenderPt, meTrackMatchedTPEffPtTotLV, meExtraMTDfailExtenderPtEff_);
+  computeEfficiency1D(meExtraMTDfailExtenderPt, meTrackMatchedTPPtTotLV, meExtraMTDfailExtenderPtEff_);
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ----------

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -54,6 +54,8 @@
 #include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementError.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementPoint.h"
 #include "DataFormats/FTLRecHit/interface/FTLRecHitCollections.h"
+#include "DataFormats/FTLRecHit/interface/FTLClusterCollections.h"
+#include "DataFormats/TrackerRecHit2D/interface/MTDTrackingRecHit.h"
 
 #include "DataFormats/Common/interface/OneToMany.h"
 #include "DataFormats/Common/interface/AssociationMap.h"
@@ -64,6 +66,9 @@
 #include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 #include "SimDataFormats/Associations/interface/MtdSimLayerClusterToTPAssociatorBaseImpl.h"
+#include "SimDataFormats/CaloAnalysis/interface/MtdSimLayerCluster.h"
+#include "SimDataFormats/Associations/interface/MtdRecoClusterToSimLayerClusterAssociationMap.h"
+#include "SimDataFormats/Associations/interface/MtdSimLayerClusterToRecoClusterAssociationMap.h"
 
 #include "CLHEP/Units/PhysicalConstants.h"
 #include "MTDHit.h"
@@ -101,9 +106,22 @@ private:
 
   bool isETL(const double eta) const { return (std::abs(eta) > trackMinEtlEta_) && (std::abs(eta) < trackMaxEtlEta_); }
 
+  void fillTrackClusterMatchingHistograms(MonitorElement* me1,
+                                          MonitorElement* me2,
+                                          MonitorElement* me3,
+                                          MonitorElement* me4,
+                                          MonitorElement* me5,
+                                          float var1,
+                                          float var2,
+                                          float var3,
+                                          float var4,
+                                          float var5,
+                                          bool flag);
+
   // ------------ member data ------------
 
   const std::string folder_;
+  const bool optionalPlots_;
   const float trackMaxPt_;
   const float trackMaxBtlEta_;
   const float trackMinEtlEta_;
@@ -122,7 +140,6 @@ private:
   static constexpr double cluDRradius_ = 0.05;  // to cluster rechits around extrapolated track
 
   const reco::RecoToSimCollection* r2s_;
-  const reco::SimToRecoCollection* s2r_;
 
   edm::EDGetTokenT<reco::TrackCollection> GenRecTrackToken_;
   edm::EDGetTokenT<reco::TrackCollection> RecTrackToken_;
@@ -131,8 +148,12 @@ private:
   edm::EDGetTokenT<reco::SimToRecoCollection> simToRecoAssociationToken_;
   edm::EDGetTokenT<reco::RecoToSimCollection> recoToSimAssociationToken_;
   edm::EDGetTokenT<reco::TPToSimCollectionMtd> tp2SimAssociationMapToken_;
+  edm::EDGetTokenT<MtdRecoClusterToSimLayerClusterAssociationMap> r2sAssociationMapToken_;
+
   edm::EDGetTokenT<FTLRecHitCollection> btlRecHitsToken_;
   edm::EDGetTokenT<FTLRecHitCollection> etlRecHitsToken_;
+  edm::EDGetTokenT<FTLClusterCollection> btlRecCluToken_;
+  edm::EDGetTokenT<FTLClusterCollection> etlRecCluToken_;
 
   edm::EDGetTokenT<edm::ValueMap<int>> trackAssocToken_;
   edm::EDGetTokenT<edm::ValueMap<float>> pathLengthToken_;
@@ -158,28 +179,40 @@ private:
   edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> builderToken_;
 
   MonitorElement* meBTLTrackRPTime_;
-  MonitorElement* meBTLTrackEffEtaTot_;
-  MonitorElement* meBTLTrackEffPhiTot_;
-  MonitorElement* meBTLTrackEffPtTot_;
-  MonitorElement* meBTLTrackEffEtaMtd_;
-  MonitorElement* meBTLTrackEffPhiMtd_;
-  MonitorElement* meBTLTrackEffPtMtd_;
+  MonitorElement* meBTLTrackEtaTot_;
+  MonitorElement* meBTLTrackPhiTot_;
+  MonitorElement* meBTLTrackPtTot_;
+  MonitorElement* meBTLTrackEtaMtd_;
+  MonitorElement* meBTLTrackPhiMtd_;
+  MonitorElement* meBTLTrackPtMtd_;
   MonitorElement* meBTLTrackPtRes_;
 
   MonitorElement* meETLTrackRPTime_;
-  MonitorElement* meETLTrackEffEtaTot_[2];
-  MonitorElement* meETLTrackEffEtaTotLowPt_[2];
-  MonitorElement* meETLTrackEffPhiTot_[2];
-  MonitorElement* meETLTrackEffPtTot_[2];
-  MonitorElement* meETLTrackEffEtaMtd_[2];
-  MonitorElement* meETLTrackEffEtaMtdLowPt_[2];
-  MonitorElement* meETLTrackEffEta2MtdLowPt_[2];
-  MonitorElement* meETLTrackEffPhiMtd_[2];
-  MonitorElement* meETLTrackEffPtMtd_[2];
-  MonitorElement* meETLTrackEffEta2Mtd_[2];
-  MonitorElement* meETLTrackEffPhi2Mtd_[2];
-  MonitorElement* meETLTrackEffPt2Mtd_[2];
+  MonitorElement* meETLTrackEtaTot_;
+  MonitorElement* meETLTrackPhiTot_;
+  MonitorElement* meETLTrackPtTot_;
+  MonitorElement* meETLTrackEtaMtd_;
+  MonitorElement* meETLTrackPhiMtd_;
+  MonitorElement* meETLTrackPtMtd_;
+  MonitorElement* meETLTrackEta2Mtd_;
+  MonitorElement* meETLTrackPhi2Mtd_;
+  MonitorElement* meETLTrackPt2Mtd_;
   MonitorElement* meETLTrackPtRes_;
+
+  MonitorElement* meETLTrackEtaTotLowPt_[2];
+  MonitorElement* meETLTrackEtaMtdLowPt_[2];
+  MonitorElement* meETLTrackEta2MtdLowPt_[2];
+
+  MonitorElement* meBTLTrackMatchedTPEtaTot_;
+  MonitorElement* meBTLTrackMatchedTPPtTot_;
+  MonitorElement* meBTLTrackMatchedTPEtaMtd_;
+  MonitorElement* meBTLTrackMatchedTPPtMtd_;
+  MonitorElement* meETLTrackMatchedTPEtaTot_;
+  MonitorElement* meETLTrackMatchedTPPtTot_;
+  MonitorElement* meETLTrackMatchedTPEtaMtd_;
+  MonitorElement* meETLTrackMatchedTPPtMtd_;
+  MonitorElement* meETLTrackMatchedTPEta2Mtd_;
+  MonitorElement* meETLTrackMatchedTPPt2Mtd_;
 
   MonitorElement* meTracktmtd_;
   MonitorElement* meTrackt0Src_;
@@ -197,10 +230,6 @@ private:
 
   MonitorElement* meTrackSigmaTof_[3];
   MonitorElement* meTrackSigmaTofvsP_[3];
-
-  MonitorElement* meTrackPtTot_;
-  MonitorElement* meExtraPtMtd_;
-  MonitorElement* meExtraPtEtl2Mtd_;
 
   MonitorElement* meBTLTrackMatchedTPPtResMtd_;
   MonitorElement* meETLTrackMatchedTPPtResMtd_;
@@ -221,36 +250,132 @@ private:
   MonitorElement* meETLTrackMatchedTPDPtvsPtMtd_;
   MonitorElement* meETLTrackMatchedTP2DPtvsPtMtd_;
 
-  MonitorElement* meTrackMatchedTPEffPtTot_;
-  MonitorElement* meTrackMatchedTPEffPtTotLV_;
-  MonitorElement* meTrackMatchedTPEffPtMtd_;
-  MonitorElement* meTrackMatchedTPEffPtEtl2Mtd_;
-  MonitorElement* meTrackMatchedTPmtdEffPtTot_;
-  MonitorElement* meTrackMatchedTPmtdEffPtMtd_;
-  MonitorElement* meTrackEtaTot_;
-  MonitorElement* meExtraEtaMtd_;
-  MonitorElement* meExtraEtaEtl2Mtd_;
-  MonitorElement* meTrackMatchedTPEffEtaTot_;
-  MonitorElement* meTrackMatchedTPEffEtaTotLV_;
-  MonitorElement* meTrackMatchedTPEffEtaMtd_;
-  MonitorElement* meTrackMatchedTPEffEtaEtl2Mtd_;
-  MonitorElement* meTrackMatchedTPmtdEffEtaTot_;
-  MonitorElement* meTrackMatchedTPmtdEffEtaMtd_;
   MonitorElement* meTrackResTot_;
   MonitorElement* meTrackPullTot_;
   MonitorElement* meTrackResTotvsMVAQual_;
   MonitorElement* meTrackPullTotvsMVAQual_;
 
+  MonitorElement* meTrackMatchedTPPtTotLV_;
+  MonitorElement* meTrackMatchedTPEtaTotLV_;
+  MonitorElement* meExtraPtMtd_;
+  MonitorElement* meExtraPtEtl2Mtd_;
+  MonitorElement* meExtraEtaMtd_;
+  MonitorElement* meExtraEtaEtl2Mtd_;
   MonitorElement* meExtraPhiAtBTL_;
   MonitorElement* meExtraPhiAtBTLmatched_;
   MonitorElement* meExtraBTLeneInCone_;
   MonitorElement* meExtraMTDfailExtenderEta_;
   MonitorElement* meExtraMTDfailExtenderPt_;
+  
+  // ====== Trak-cluster matching based on MC truth
+  // - BTL TPmtd Direct, TPmtd Other, TPnomtd
+  MonitorElement* meBTLTrackMatchedTPmtdDirectEta_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectPt_;
+
+  MonitorElement* meBTLTrackMatchedTPmtdOtherEta_;
+  MonitorElement* meBTLTrackMatchedTPmtdOtherPt_;
+
+  MonitorElement* meBTLTrackMatchedTPnomtdEta_;
+  MonitorElement* meBTLTrackMatchedTPnomtdPt_;
+
+  // - BTL TPmtd Direct hits: correct, wrong, missing association in MTD
+  MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocEta_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocPt_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocMVAQual_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocTimeRes_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocTimePull_;
+
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocEta_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocPt_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocMVAQual_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTimeRes_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTimePull_;
+
+  MonitorElement* meBTLTrackMatchedTPmtdDirectNoAssocEta_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectNoAssocPt_;
+
+  // - BTL TPmtd "other" hits: correct, wrong, missing association in MTD
+  MonitorElement* meBTLTrackMatchedTPmtdOtherCorrectAssocEta_;
+  MonitorElement* meBTLTrackMatchedTPmtdOtherCorrectAssocPt_;
+  MonitorElement* meBTLTrackMatchedTPmtdOtherCorrectAssocMVAQual_;
+  MonitorElement* meBTLTrackMatchedTPmtdOtherCorrectAssocTimeRes_;
+  MonitorElement* meBTLTrackMatchedTPmtdOtherCorrectAssocTimePull_;
+
+  MonitorElement* meBTLTrackMatchedTPmtdOtherWrongAssocEta_;
+  MonitorElement* meBTLTrackMatchedTPmtdOtherWrongAssocPt_;
+  MonitorElement* meBTLTrackMatchedTPmtdOtherWrongAssocMVAQual_;
+  MonitorElement* meBTLTrackMatchedTPmtdOtherWrongAssocTimeRes_;
+  MonitorElement* meBTLTrackMatchedTPmtdOtherWrongAssocTimePull_;
+
+  MonitorElement* meBTLTrackMatchedTPmtdOtherNoAssocEta_;
+  MonitorElement* meBTLTrackMatchedTPmtdOtherNoAssocPt_;
+
+  // - BTL TPnomtd but a reco cluster is associated
+  MonitorElement* meBTLTrackMatchedTPnomtdAssocEta_;
+  MonitorElement* meBTLTrackMatchedTPnomtdAssocPt_;
+  MonitorElement* meBTLTrackMatchedTPnomtdAssocMVAQual_;
+  MonitorElement* meBTLTrackMatchedTPnomtdAssocTimeRes_;
+  MonitorElement* meBTLTrackMatchedTPnomtdAssocTimePull_;
+
+   // - ETL: one, two o no sim hits
+  MonitorElement* meETLTrackMatchedTPmtd1Eta_;  // -- sim hit in >=1 etl disk
+  MonitorElement* meETLTrackMatchedTPmtd1Pt_;
+  MonitorElement* meETLTrackMatchedTPmtd2Eta_;  // -- sim hits in 2 etl disks
+  MonitorElement* meETLTrackMatchedTPmtd2Pt_;
+  MonitorElement* meETLTrackMatchedTPnomtdEta_;  // -- no sim hits in etl
+  MonitorElement* meETLTrackMatchedTPnomtdPt_;
+  
+  // - ETL >=1 sim hit: each correct, at least one wrong, each sim hit missing reco association
+  MonitorElement* meETLTrackMatchedTPmtd1CorrectAssocEta_;
+  MonitorElement* meETLTrackMatchedTPmtd1CorrectAssocPt_;
+  MonitorElement* meETLTrackMatchedTPmtd1CorrectAssocMVAQual_;
+  MonitorElement* meETLTrackMatchedTPmtd1CorrectAssocTimeRes_;
+  MonitorElement* meETLTrackMatchedTPmtd1CorrectAssocTimePull_;
+
+  MonitorElement* meETLTrackMatchedTPmtd1WrongAssocEta_;
+  MonitorElement* meETLTrackMatchedTPmtd1WrongAssocPt_;
+  MonitorElement* meETLTrackMatchedTPmtd1WrongAssocMVAQual_;
+  MonitorElement* meETLTrackMatchedTPmtd1WrongAssocTimeRes_;
+  MonitorElement* meETLTrackMatchedTPmtd1WrongAssocTimePull_;
+
+  MonitorElement* meETLTrackMatchedTPmtd1NoAssocEta_;
+  MonitorElement* meETLTrackMatchedTPmtd1NoAssocPt_;
+  MonitorElement* meETLTrackMatchedTPmtd1NoAssocMVAQual_;
+  MonitorElement* meETLTrackMatchedTPmtd1NoAssocTimeRes_;
+  MonitorElement* meETLTrackMatchedTPmtd1NoAssocTimePull_;
+
+  // - ETL - 2 sim hits: both correct, at least one wrong or one missing, both missing reco association
+  MonitorElement* meETLTrackMatchedTPmtd2CorrectAssocEta_;
+  MonitorElement* meETLTrackMatchedTPmtd2CorrectAssocPt_;
+  MonitorElement* meETLTrackMatchedTPmtd2CorrectAssocMVAQual_;
+  MonitorElement* meETLTrackMatchedTPmtd2CorrectAssocTimeRes_;
+  MonitorElement* meETLTrackMatchedTPmtd2CorrectAssocTimePull_;
+
+  MonitorElement* meETLTrackMatchedTPmtd2WrongAssocEta_;
+  MonitorElement* meETLTrackMatchedTPmtd2WrongAssocPt_;
+  MonitorElement* meETLTrackMatchedTPmtd2WrongAssocMVAQual_;
+  MonitorElement* meETLTrackMatchedTPmtd2WrongAssocTimeRes_;
+  MonitorElement* meETLTrackMatchedTPmtd2WrongAssocTimePull_;
+
+  MonitorElement* meETLTrackMatchedTPmtd2NoAssocEta_;
+  MonitorElement* meETLTrackMatchedTPmtd2NoAssocPt_;
+  MonitorElement* meETLTrackMatchedTPmtd2NoAssocMVAQual_;
+  MonitorElement* meETLTrackMatchedTPmtd2NoAssocTimeRes_;
+  MonitorElement* meETLTrackMatchedTPmtd2NoAssocTimePull_;
+
+  // - ETL - no sim hits, but reco hit associated to the track
+  MonitorElement* meETLTrackMatchedTPnomtdAssocEta_;
+  MonitorElement* meETLTrackMatchedTPnomtdAssocPt_;
+  MonitorElement* meETLTrackMatchedTPnomtdAssocMVAQual_;
+  MonitorElement* meETLTrackMatchedTPnomtdAssocTimeRes_;
+  MonitorElement* meETLTrackMatchedTPnomtdAssocTimePull_;
+
 };
 
 // ------------ constructor and destructor --------------
 MtdTracksValidation::MtdTracksValidation(const edm::ParameterSet& iConfig)
     : folder_(iConfig.getParameter<std::string>("folder")),
+      optionalPlots_(iConfig.getParameter<bool>("optionalPlots")),
       trackMaxPt_(iConfig.getParameter<double>("trackMaximumPt")),
       trackMaxBtlEta_(iConfig.getParameter<double>("trackMaximumBtlEta")),
       trackMinEtlEta_(iConfig.getParameter<double>("trackMinimumEtlEta")),
@@ -265,8 +390,12 @@ MtdTracksValidation::MtdTracksValidation(const edm::ParameterSet& iConfig)
       consumes<reco::RecoToSimCollection>(iConfig.getParameter<edm::InputTag>("TPtoRecoTrackAssoc"));
   tp2SimAssociationMapToken_ =
       consumes<reco::TPToSimCollectionMtd>(iConfig.getParameter<edm::InputTag>("tp2SimAssociationMapTag"));
+  r2sAssociationMapToken_ = consumes<MtdRecoClusterToSimLayerClusterAssociationMap>(
+      iConfig.getParameter<edm::InputTag>("r2sAssociationMapTag"));
   btlRecHitsToken_ = consumes<FTLRecHitCollection>(iConfig.getParameter<edm::InputTag>("btlRecHits"));
   etlRecHitsToken_ = consumes<FTLRecHitCollection>(iConfig.getParameter<edm::InputTag>("etlRecHits"));
+  btlRecCluToken_ = consumes<FTLClusterCollection>(iConfig.getParameter<edm::InputTag>("recCluTagBTL"));
+  etlRecCluToken_ = consumes<FTLClusterCollection>(iConfig.getParameter<edm::InputTag>("recCluTagETL"));
   trackAssocToken_ = consumes<edm::ValueMap<int>>(iConfig.getParameter<edm::InputTag>("trackAssocSrc"));
   pathLengthToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("pathLengthSrc"));
   tmtdToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("tmtd"));
@@ -300,12 +429,16 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
 
   auto GenRecTrackHandle = makeValid(iEvent.getHandle(GenRecTrackToken_));
 
+  auto btlRecCluHandle = makeValid(iEvent.getHandle(btlRecCluToken_));
+  auto etlRecCluHandle = makeValid(iEvent.getHandle(etlRecCluToken_));
+  
   std::unordered_map<uint32_t, MTDHit> m_btlHits;
   std::unordered_map<uint32_t, MTDHit> m_etlHits;
   std::unordered_map<uint32_t, std::set<unsigned long int>> m_btlTrkPerCell;
   std::unordered_map<uint32_t, std::set<unsigned long int>> m_etlTrkPerCell;
   const auto& tp2SimAssociationMap = iEvent.get(tp2SimAssociationMapToken_);
-
+  const auto& r2sAssociationMap = iEvent.get(r2sAssociationMapToken_);
+ 
   const auto& tMtd = iEvent.get(tmtdToken_);
   const auto& SigmatMtd = iEvent.get(SigmatmtdToken_);
   const auto& t0Src = iEvent.get(t0SrcToken_);
@@ -321,9 +454,6 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
   const auto& trackAssoc = iEvent.get(trackAssocToken_);
   const auto& pathLength = iEvent.get(pathLengthToken_);
   const auto& outermostHitPosition = iEvent.get(outermostHitPositionToken_);
-
-  auto simToRecoH = makeValid(iEvent.getHandle(simToRecoAssociationToken_));
-  s2r_ = simToRecoH.product();
 
   auto recoToSimH = makeValid(iEvent.getHandle(recoToSimAssociationToken_));
   r2s_ = recoToSimH.product();
@@ -345,6 +475,8 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
 
     bool isBTL = false;
     bool isETL = false;
+    bool ETLdisc1 = false;
+    bool ETLdisc2 = false;
     bool twoETLdiscs = false;
     bool noCrack = std::abs(trackGen.eta()) < trackMaxBtlEta_ || std::abs(trackGen.eta()) > trackMinEtlEta_;
 
@@ -373,12 +505,17 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
       meTrackSigmaTofvsP_[2]->Fill(trackGen.p(), SigmaTofP[trackref] * 1e3);
 
       meTrackPathLenghtvsEta_->Fill(std::abs(trackGen.eta()), pathLength[trackref]);
-
+      bool MTDEtlZnegD1 = false;
+      bool MTDEtlZnegD2 = false;
+      bool MTDEtlZposD1 = false;
+      bool MTDEtlZposD2 = false;
+      std::vector<edm::Ref<edmNew::DetSetVector<FTLCluster>, FTLCluster>> recoClustersRefs;
+      
       if (std::abs(trackGen.eta()) < trackMaxBtlEta_) {
         // --- all BTL tracks (with and without hit in MTD) ---
-        meBTLTrackEffEtaTot_->Fill(trackGen.eta());
-        meBTLTrackEffPhiTot_->Fill(trackGen.phi());
-        meBTLTrackEffPtTot_->Fill(trackGen.pt());
+        meBTLTrackEtaTot_->Fill(std::abs(trackGen.eta()));
+        meBTLTrackPhiTot_->Fill(trackGen.phi());
+        meBTLTrackPtTot_->Fill(trackGen.pt());
 
         bool MTDBtl = false;
         int numMTDBtlvalidhits = 0;
@@ -389,6 +526,12 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
           if ((Hit.det() == 6) && (Hit.subdetId() == 1) && (Hit.mtdSubDetector() == 1)) {
             MTDBtl = true;
             numMTDBtlvalidhits++;
+	    const auto* mtdhit = static_cast<const MTDTrackingRecHit*>(hit);
+            const auto& hitCluster = mtdhit->mtdCluster();
+            if (hitCluster.size() != 0) {
+              auto recoClusterRef = edmNew::makeRefTo(btlRecCluHandle, &hitCluster);
+              recoClustersRefs.push_back(recoClusterRef);
+            }
           }
         }
         meTrackNumHits_->Fill(numMTDBtlvalidhits);
@@ -396,9 +539,9 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
         // --- keeping only tracks with last hit in MTD ---
         if (MTDBtl == true) {
           isBTL = true;
-          meBTLTrackEffEtaMtd_->Fill(trackGen.eta());
-          meBTLTrackEffPhiMtd_->Fill(trackGen.phi());
-          meBTLTrackEffPtMtd_->Fill(trackGen.pt());
+          meBTLTrackEtaMtd_->Fill(std::abs(trackGen.eta()));
+          meBTLTrackPhiMtd_->Fill(trackGen.phi());
+          meBTLTrackPtMtd_->Fill(trackGen.pt());
           meBTLTrackRPTime_->Fill(track.t0());
           meBTLTrackPtRes_->Fill((trackGen.pt() - track.pt()) / trackGen.pt());
         }
@@ -409,23 +552,11 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
 
       else {
         // --- all ETL tracks (with and without hit in MTD) ---
-        if ((trackGen.eta() < -trackMinEtlEta_) && (trackGen.eta() > -trackMaxEtlEta_)) {
-          meETLTrackEffEtaTot_[0]->Fill(trackGen.eta());
-          meETLTrackEffPhiTot_[0]->Fill(trackGen.phi());
-          meETLTrackEffPtTot_[0]->Fill(trackGen.pt());
-        }
-
-        if ((trackGen.eta() > trackMinEtlEta_) && (trackGen.eta() < trackMaxEtlEta_)) {
-          meETLTrackEffEtaTot_[1]->Fill(trackGen.eta());
-          meETLTrackEffPhiTot_[1]->Fill(trackGen.phi());
-          meETLTrackEffPtTot_[1]->Fill(trackGen.pt());
-        }
-
-        bool MTDEtlZnegD1 = false;
-        bool MTDEtlZnegD2 = false;
-        bool MTDEtlZposD1 = false;
-        bool MTDEtlZposD2 = false;
-        int numMTDEtlvalidhits = 0;
+	meETLTrackEtaTot_->Fill(std::abs(trackGen.eta()));
+        meETLTrackPhiTot_->Fill(trackGen.phi());
+        meETLTrackPtTot_->Fill(trackGen.pt());
+	
+	int numMTDEtlvalidhits = 0;
         for (const auto hit : track.recHits()) {
           if (hit->isValid() == false)
             continue;
@@ -433,6 +564,13 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
           if ((Hit.det() == 6) && (Hit.subdetId() == 1) && (Hit.mtdSubDetector() == 2)) {
             isETL = true;
             ETLDetId ETLHit = hit->geographicalId();
+
+	    const auto* mtdhit = static_cast<const MTDTrackingRecHit*>(hit);
+            const auto& hitCluster = mtdhit->mtdCluster();
+            if (hitCluster.size() != 0) {
+              auto recoClusterRef = edmNew::makeRefTo(etlRecCluHandle, &hitCluster);
+              recoClustersRefs.push_back(recoClusterRef);
+            }
 
             if ((ETLHit.zside() == -1) && (ETLHit.nDisc() == 1)) {
               MTDEtlZnegD1 = true;
@@ -466,30 +604,18 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
         }
 
         // --- keeping only tracks with last hit in MTD ---
-        if ((trackGen.eta() < -trackMinEtlEta_) && (trackGen.eta() > -trackMaxEtlEta_)) {
-          twoETLdiscs = (MTDEtlZnegD1 == true) && (MTDEtlZnegD2 == true);
-          if ((MTDEtlZnegD1 == true) || (MTDEtlZnegD2 == true)) {
-            meETLTrackEffEtaMtd_[0]->Fill(trackGen.eta());
-            meETLTrackEffPhiMtd_[0]->Fill(trackGen.phi());
-            meETLTrackEffPtMtd_[0]->Fill(trackGen.pt());
-            if (twoETLdiscs) {
-              meETLTrackEffEta2Mtd_[0]->Fill(trackGen.eta());
-              meETLTrackEffPhi2Mtd_[0]->Fill(trackGen.phi());
-              meETLTrackEffPt2Mtd_[0]->Fill(trackGen.pt());
-            }
-          }
-        }
-        if ((trackGen.eta() > trackMinEtlEta_) && (trackGen.eta() < trackMaxEtlEta_)) {
-          twoETLdiscs = (MTDEtlZposD1 == true) && (MTDEtlZposD2 == true);
-          if ((MTDEtlZposD1 == true) || (MTDEtlZposD2 == true)) {
-            meETLTrackEffEtaMtd_[1]->Fill(trackGen.eta());
-            meETLTrackEffPhiMtd_[1]->Fill(trackGen.phi());
-            meETLTrackEffPtMtd_[1]->Fill(trackGen.pt());
-            if (twoETLdiscs) {
-              meETLTrackEffEta2Mtd_[1]->Fill(trackGen.eta());
-              meETLTrackEffPhi2Mtd_[1]->Fill(trackGen.phi());
-              meETLTrackEffPt2Mtd_[1]->Fill(trackGen.pt());
-            }
+	ETLdisc1 = (MTDEtlZnegD1 || MTDEtlZposD1);
+        ETLdisc2 = (MTDEtlZnegD2 || MTDEtlZposD2);
+        twoETLdiscs =
+	  ((MTDEtlZnegD1 == true) && (MTDEtlZnegD2 == true)) || ((MTDEtlZposD1 == true) && (MTDEtlZposD2 == true));
+        if (ETLdisc1 || ETLdisc2) {
+          meETLTrackEtaMtd_->Fill(std::abs(trackGen.eta()));
+          meETLTrackPhiMtd_->Fill(trackGen.phi());
+          meETLTrackPtMtd_->Fill(trackGen.pt());
+          if (twoETLdiscs) {
+            meETLTrackEta2Mtd_->Fill(std::abs(trackGen.eta()));
+            meETLTrackPhi2Mtd_->Fill(trackGen.phi());
+            meETLTrackPt2Mtd_->Fill(trackGen.pt());
           }
         }
       }
@@ -503,90 +629,392 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
                                       << trackGen.eta() << " BTL " << isBTL << " ETL " << isETL << " 2disks "
                                       << twoETLdiscs;
 
-      // TrackingParticle based matching
-
+      // == TrackingParticle based matching
       const reco::TrackBaseRef trkrefb(trackref);
       auto tp_info = getMatchedTP(trkrefb);
-
-      meTrackPtTot_->Fill(trackGen.pt());
-      meTrackEtaTot_->Fill(std::abs(trackGen.eta()));
       if (tp_info != nullptr && trkTPSelAll(**tp_info)) {
-        if (trackGen.pt() < trackMaxPt_) {
+	// -- pT resolution plots
+        if (optionalPlots_) {
+	  if (trackGen.pt() < trackMaxPt_) {
+	    if (isBTL) {
+	      meBTLTrackMatchedTPPtResMtd_->Fill(std::abs(track.pt() - (*tp_info)->pt()) /
+						 std::abs(trackGen.pt() - (*tp_info)->pt()));
+	      meBTLTrackMatchedTPPtRatioGen_->Fill(trackGen.pt() / (*tp_info)->pt());
+	      meBTLTrackMatchedTPPtRatioMtd_->Fill(track.pt() / (*tp_info)->pt());
+	      meBTLTrackMatchedTPPtResvsPtMtd_->Fill(
+						     (*tp_info)->pt(), std::abs(track.pt() - (*tp_info)->pt()) / std::abs(trackGen.pt() - (*tp_info)->pt()));
+	      meBTLTrackMatchedTPDPtvsPtGen_->Fill((*tp_info)->pt(),
+						   (trackGen.pt() - (*tp_info)->pt()) / (*tp_info)->pt());
+	      meBTLTrackMatchedTPDPtvsPtMtd_->Fill((*tp_info)->pt(), (track.pt() - (*tp_info)->pt()) / (*tp_info)->pt());
+	    }
+	    if (isETL && !twoETLdiscs && (std::abs(trackGen.eta()) > trackMinEtlEta_) &&
+		(std::abs(trackGen.eta()) < trackMaxEtlEta_)) {
+	      meETLTrackMatchedTPPtResMtd_->Fill(std::abs(track.pt() - (*tp_info)->pt()) /
+						 std::abs(trackGen.pt() - (*tp_info)->pt()));
+	      meETLTrackMatchedTPPtRatioGen_->Fill(trackGen.pt() / (*tp_info)->pt());
+	      meETLTrackMatchedTPPtRatioMtd_->Fill(track.pt() / (*tp_info)->pt());
+	      meETLTrackMatchedTPPtResvsPtMtd_->Fill(
+						     (*tp_info)->pt(), std::abs(track.pt() - (*tp_info)->pt()) / std::abs(trackGen.pt() - (*tp_info)->pt()));
+	      meETLTrackMatchedTPDPtvsPtGen_->Fill((*tp_info)->pt(),
+						   (trackGen.pt() - (*tp_info)->pt()) / ((*tp_info)->pt()));
+	      meETLTrackMatchedTPDPtvsPtMtd_->Fill((*tp_info)->pt(),
+						   (track.pt() - (*tp_info)->pt()) / ((*tp_info)->pt()));
+	    }
+	    if (isETL && twoETLdiscs) {
+	      meETLTrackMatchedTP2PtResMtd_->Fill(std::abs(track.pt() - (*tp_info)->pt()) /
+						  std::abs(trackGen.pt() - (*tp_info)->pt()));
+	      meETLTrackMatchedTP2PtRatioGen_->Fill(trackGen.pt() / (*tp_info)->pt());
+	      meETLTrackMatchedTP2PtRatioMtd_->Fill(track.pt() / (*tp_info)->pt());
+	      meETLTrackMatchedTP2PtResvsPtMtd_->Fill(
+						      (*tp_info)->pt(), std::abs(track.pt() - (*tp_info)->pt()) / std::abs(trackGen.pt() - (*tp_info)->pt()));
+	      meETLTrackMatchedTP2DPtvsPtGen_->Fill((*tp_info)->pt(),
+						    (trackGen.pt() - (*tp_info)->pt()) / ((*tp_info)->pt()));
+	      meETLTrackMatchedTP2DPtvsPtMtd_->Fill((*tp_info)->pt(),
+						    (track.pt() - (*tp_info)->pt()) / ((*tp_info)->pt()));
+	    }
+	  }
+	}
+
+
+	// -- Track matched to TP: all and with last hit in MTD                                                                                                                                                   
+        if (std::abs(trackGen.eta()) < trackMaxBtlEta_) {
+          meBTLTrackMatchedTPEtaTot_->Fill(std::abs(trackGen.eta()));
+          meBTLTrackMatchedTPPtTot_->Fill(trackGen.pt());
           if (isBTL) {
-            meBTLTrackMatchedTPPtResMtd_->Fill(std::abs(track.pt() - (*tp_info)->pt()) /
-                                               std::abs(trackGen.pt() - (*tp_info)->pt()));
-            meBTLTrackMatchedTPPtRatioGen_->Fill(trackGen.pt() / (*tp_info)->pt());
-            meBTLTrackMatchedTPPtRatioMtd_->Fill(track.pt() / (*tp_info)->pt());
-            meBTLTrackMatchedTPPtResvsPtMtd_->Fill(
-                (*tp_info)->pt(), std::abs(track.pt() - (*tp_info)->pt()) / std::abs(trackGen.pt() - (*tp_info)->pt()));
-            meBTLTrackMatchedTPDPtvsPtGen_->Fill((*tp_info)->pt(),
-                                                 (trackGen.pt() - (*tp_info)->pt()) / (*tp_info)->pt());
-            meBTLTrackMatchedTPDPtvsPtMtd_->Fill((*tp_info)->pt(), (track.pt() - (*tp_info)->pt()) / (*tp_info)->pt());
+            meBTLTrackMatchedTPEtaMtd_->Fill(std::abs(trackGen.eta()));
+            meBTLTrackMatchedTPPtMtd_->Fill(trackGen.pt());
           }
-          if (isETL && !twoETLdiscs && (std::abs(trackGen.eta()) > trackMinEtlEta_) &&
-              (std::abs(trackGen.eta()) < trackMaxEtlEta_)) {
-            meETLTrackMatchedTPPtResMtd_->Fill(std::abs(track.pt() - (*tp_info)->pt()) /
-                                               std::abs(trackGen.pt() - (*tp_info)->pt()));
-            meETLTrackMatchedTPPtRatioGen_->Fill(trackGen.pt() / (*tp_info)->pt());
-            meETLTrackMatchedTPPtRatioMtd_->Fill(track.pt() / (*tp_info)->pt());
-            meETLTrackMatchedTPPtResvsPtMtd_->Fill(
-                (*tp_info)->pt(), std::abs(track.pt() - (*tp_info)->pt()) / std::abs(trackGen.pt() - (*tp_info)->pt()));
-            meETLTrackMatchedTPDPtvsPtGen_->Fill((*tp_info)->pt(),
-                                                 (trackGen.pt() - (*tp_info)->pt()) / ((*tp_info)->pt()));
-            meETLTrackMatchedTPDPtvsPtMtd_->Fill((*tp_info)->pt(),
-                                                 (track.pt() - (*tp_info)->pt()) / ((*tp_info)->pt()));
-          }
-          if (isETL && twoETLdiscs) {
-            meETLTrackMatchedTP2PtResMtd_->Fill(std::abs(track.pt() - (*tp_info)->pt()) /
-                                                std::abs(trackGen.pt() - (*tp_info)->pt()));
-            meETLTrackMatchedTP2PtRatioGen_->Fill(trackGen.pt() / (*tp_info)->pt());
-            meETLTrackMatchedTP2PtRatioMtd_->Fill(track.pt() / (*tp_info)->pt());
-            meETLTrackMatchedTP2PtResvsPtMtd_->Fill(
-                (*tp_info)->pt(), std::abs(track.pt() - (*tp_info)->pt()) / std::abs(trackGen.pt() - (*tp_info)->pt()));
-            meETLTrackMatchedTP2DPtvsPtGen_->Fill((*tp_info)->pt(),
-                                                  (trackGen.pt() - (*tp_info)->pt()) / ((*tp_info)->pt()));
-            meETLTrackMatchedTP2DPtvsPtMtd_->Fill((*tp_info)->pt(),
-                                                  (track.pt() - (*tp_info)->pt()) / ((*tp_info)->pt()));
-          }
-        }
-        auto simClustersRefs = tp2SimAssociationMap.find(*tp_info);
-        const bool withMTD = (simClustersRefs != tp2SimAssociationMap.end());
-        if (noCrack) {
-          meTrackMatchedTPEffPtTot_->Fill(trackGen.pt());
-          if (trkTPSelLV(**tp_info)) {
-            meTrackMatchedTPEffPtTotLV_->Fill(trackGen.pt());
-          }
-          if (withMTD) {
-            meTrackMatchedTPmtdEffPtTot_->Fill(trackGen.pt());
-          }
-        }
-        meTrackMatchedTPEffEtaTot_->Fill(std::abs(trackGen.eta()));
-        if (trkTPSelLV(**tp_info)) {
-          meTrackMatchedTPEffEtaTotLV_->Fill(std::abs(trackGen.eta()));
-        }
-        if (withMTD) {
-          meTrackMatchedTPmtdEffEtaTot_->Fill(std::abs(trackGen.eta()));
-        }
-        if (isBTL || isETL) {
-          if (noCrack) {
-            meTrackMatchedTPEffPtMtd_->Fill(trackGen.pt());
-            if (isBTL || twoETLdiscs) {
-              meTrackMatchedTPEffPtEtl2Mtd_->Fill(trackGen.pt());
+        } else {
+          meETLTrackMatchedTPEtaTot_->Fill(std::abs(trackGen.eta()));
+          meETLTrackMatchedTPPtTot_->Fill(trackGen.pt());
+          if (isETL) {
+            meETLTrackMatchedTPEtaMtd_->Fill(std::abs(trackGen.eta()));
+            meETLTrackMatchedTPPtMtd_->Fill(trackGen.pt());
+            if (twoETLdiscs) {
+              meETLTrackMatchedTPEta2Mtd_->Fill(std::abs(trackGen.eta()));
+              meETLTrackMatchedTPPt2Mtd_->Fill(trackGen.pt());
             }
-            if (withMTD) {
-              meTrackMatchedTPmtdEffPtMtd_->Fill(trackGen.pt());
-            }
-          }
-          meTrackMatchedTPEffEtaMtd_->Fill(std::abs(trackGen.eta()));
-          if (isBTL || twoETLdiscs) {
-            meTrackMatchedTPEffEtaEtl2Mtd_->Fill(std::abs(trackGen.eta()));
-          }
-          if (withMTD) {
-            meTrackMatchedTPmtdEffEtaMtd_->Fill(std::abs(trackGen.eta()));
           }
         }
 
-        // time pull and detailed extrapolation check only on tracks associated to TP from signal event
+        if (noCrack) {
+          if (trkTPSelLV(**tp_info)) {
+            meTrackMatchedTPEtaTotLV_->Fill(std::abs(trackGen.eta()));
+            meTrackMatchedTPPtTotLV_->Fill(trackGen.pt());
+          }
+        }
+
+	bool hasTime = false;
+        double tsim = (*tp_info)->parentVertex()->position().t() * simUnit_;
+        double dT(-9999.);
+        double pullT(-9999.);
+        if (Sigmat0Safe[trackref] != -1.) {
+          dT = t0Safe[trackref] - tsim;
+          pullT = dT / Sigmat0Safe[trackref];
+          hasTime = true;
+        }
+
+ // ==  MC truth matching                                                                                                                                                                                  
+        bool isTPmtdDirectBTL = false, isTPmtdOtherBTL = false, isTPmtdDirectCorrectBTL = false,
+             isTPmtdOtherCorrectBTL = false, isTPmtdETLD1 = false, isTPmtdETLD2 = false, isTPmtdCorrectETLD1 = false,
+             isTPmtdCorrectETLD2 = false;
+
+        auto simClustersRefsIt = tp2SimAssociationMap.find(*tp_info);
+        const bool withMTD = (simClustersRefsIt != tp2SimAssociationMap.end());
+
+        // If there is a mtdSimLayerCluster from the tracking particle
+        if (withMTD) {
+          // -- Get the refs to MtdSimLayerClusters associated to the TP
+          std::vector<edm::Ref<MtdSimLayerClusterCollection>> simClustersRefs;
+          for (const auto& ref : simClustersRefsIt->val) {
+            simClustersRefs.push_back(ref);
+            MTDDetId mtddetid = ref->detIds_and_rows().front().first;
+            if (mtddetid.mtdSubDetector() == 2) {
+              ETLDetId detid(mtddetid.rawId());
+              if (detid.nDisc() == 1)
+                isTPmtdETLD1 = true;
+              if (detid.nDisc() == 2)
+                isTPmtdETLD2 = true;
+            }
+          }
+
+	  // === BTL
+          // -- Sort BTL sim clusters by time
+          std::vector<edm::Ref<MtdSimLayerClusterCollection>>::iterator directSimClusIt;
+          if (std::abs(trackGen.eta()) < trackMaxBtlEta_ && !simClustersRefs.empty()) {
+            std::sort(simClustersRefs.begin(), simClustersRefs.end(), [](const auto& a, const auto& b) {
+              return a->simLCTime() < b->simLCTime();
+								      });
+            // Find the first direct hit in time
+            directSimClusIt = std::find_if(simClustersRefs.begin(), simClustersRefs.end(), [](const auto& simCluster) {
+              return simCluster->trackIdOffset() == 0;
+            });
+            // Check if TP has direct or other sim cluster for BTL
+            for (const auto& simClusterRef : simClustersRefs) {
+              if (directSimClusIt != simClustersRefs.end() && simClusterRef == *directSimClusIt) {
+                isTPmtdDirectBTL = true;
+              } else if (simClusterRef->trackIdOffset() != 0) {
+                isTPmtdOtherBTL = true;
+              }
+            }
+          }
+
+	  // ==  Check if the track-cluster association is correct: Track->RecoClus->SimClus == Track->TP->SimClus
+          for (const auto& recClusterRef : recoClustersRefs) {
+            if (recClusterRef.isNonnull()) {
+              auto itp = r2sAssociationMap.equal_range(recClusterRef);
+              if (itp.first != itp.second) {
+                auto& simClustersRefs_RecoMatch = (*itp.first).second;
+
+                for (const auto& simClusterRef_RecoMatch : simClustersRefs_RecoMatch) {
+                  // Check if simClusterRef_RecoMatch  exists in SimClusters
+                  auto simClusterIt =
+                      std::find(simClustersRefs.begin(), simClustersRefs.end(), simClusterRef_RecoMatch);
+
+                  // SimCluster found in SimClusters
+                  if (simClusterIt != simClustersRefs.end()) {
+                    if (isBTL) {
+                      if (directSimClusIt != simClustersRefs.end() && simClusterRef_RecoMatch == *directSimClusIt) {
+                        isTPmtdDirectCorrectBTL = true;
+                      } else if (simClusterRef_RecoMatch->trackIdOffset() != 0) {
+                        isTPmtdOtherCorrectBTL = true;
+                      }
+                    }
+                    if (isETL) {
+                      MTDDetId mtddetid = (*simClusterIt)->detIds_and_rows().front().first;
+                      ETLDetId detid(mtddetid.rawId());
+                      if (detid.nDisc() == 1)
+                        isTPmtdCorrectETLD1 = true;
+                      if (detid.nDisc() == 2)
+                        isTPmtdCorrectETLD2 = true;
+                    }
+                  }
+                }
+              }
+            }
+          }  /// end loop over reco clusters associated to this track.
+	  
+	  // == BTL
+          if (std::abs(trackGen.eta()) < trackMaxBtlEta_) {
+            // -- Track matched to TP with sim hit in MTD
+            if (isTPmtdDirectBTL) {
+              meBTLTrackMatchedTPmtdDirectEta_->Fill(std::abs(trackGen.eta()));
+              meBTLTrackMatchedTPmtdDirectPt_->Fill(trackGen.pt());
+            } else if (isTPmtdOtherBTL) {
+              meBTLTrackMatchedTPmtdOtherEta_->Fill(std::abs(trackGen.eta()));
+              meBTLTrackMatchedTPmtdOtherPt_->Fill(trackGen.pt());
+            }
+            //-- Track matched to TP with sim hit in MTD, with associated reco cluster
+            if (isBTL) {
+              if (isTPmtdDirectBTL) {
+                // -- Track matched to TP with sim hit (direct), correctly associated reco cluster
+                if (isTPmtdDirectCorrectBTL) {
+                  fillTrackClusterMatchingHistograms(meBTLTrackMatchedTPmtdDirectCorrectAssocEta_,
+                                                     meBTLTrackMatchedTPmtdDirectCorrectAssocPt_,
+                                                     meBTLTrackMatchedTPmtdDirectCorrectAssocMVAQual_,
+                                                     meBTLTrackMatchedTPmtdDirectCorrectAssocTimeRes_,
+                                                     meBTLTrackMatchedTPmtdDirectCorrectAssocTimePull_,
+                                                     std::abs(trackGen.eta()),
+                                                     trackGen.pt(),
+                                                     mtdQualMVA[trackref],
+                                                     dT,
+                                                     pullT,
+                                                     hasTime);
+                }
+                // -- Track matched to TP with sim hit (direct), incorrectly associated reco cluster
+		else {
+                  fillTrackClusterMatchingHistograms(meBTLTrackMatchedTPmtdDirectWrongAssocEta_,
+                                                     meBTLTrackMatchedTPmtdDirectWrongAssocPt_,
+                                                     meBTLTrackMatchedTPmtdDirectWrongAssocMVAQual_,
+                                                     meBTLTrackMatchedTPmtdDirectWrongAssocTimeRes_,
+                                                     meBTLTrackMatchedTPmtdDirectWrongAssocTimePull_,
+                                                     std::abs(trackGen.eta()),
+                                                     trackGen.pt(),
+                                                     mtdQualMVA[trackref],
+                                                     dT,
+                                                     pullT,
+                                                     hasTime);
+                }
+              }
+              // -- Track matched to TP with sim hit (other), correctly associated reco cluster
+	       else if (isTPmtdOtherBTL) {
+                if (isTPmtdOtherCorrectBTL) {
+                  fillTrackClusterMatchingHistograms(meBTLTrackMatchedTPmtdOtherCorrectAssocEta_,
+                                                     meBTLTrackMatchedTPmtdOtherCorrectAssocPt_,
+                                                     meBTLTrackMatchedTPmtdOtherCorrectAssocMVAQual_,
+                                                     meBTLTrackMatchedTPmtdOtherCorrectAssocTimeRes_,
+                                                     meBTLTrackMatchedTPmtdOtherCorrectAssocTimePull_,
+                                                     std::abs(trackGen.eta()),
+                                                     trackGen.pt(),
+                                                     mtdQualMVA[trackref],
+                                                     dT,
+                                                     pullT,
+                                                     hasTime);
+                }
+                // -- Track matched to TP with sim hit (other), incorrectly associated reco cluster
+                else {
+                  fillTrackClusterMatchingHistograms(meBTLTrackMatchedTPmtdOtherWrongAssocEta_,
+                                                     meBTLTrackMatchedTPmtdOtherWrongAssocPt_,
+                                                     meBTLTrackMatchedTPmtdOtherWrongAssocMVAQual_,
+                                                     meBTLTrackMatchedTPmtdOtherWrongAssocTimeRes_,
+                                                     meBTLTrackMatchedTPmtdOtherWrongAssocTimePull_,
+                                                     std::abs(trackGen.eta()),
+                                                     trackGen.pt(),
+                                                     mtdQualMVA[trackref],
+                                                     dT,
+                                                     pullT,
+                                                     hasTime);
+                }
+              }
+            }
+            // -- Track matched to TP with sim hit in MTD, missing associated reco cluster
+	     else {
+              if (isTPmtdDirectBTL) {
+                meBTLTrackMatchedTPmtdDirectNoAssocEta_->Fill(std::abs(trackGen.eta()));
+                meBTLTrackMatchedTPmtdDirectNoAssocPt_->Fill(trackGen.pt());
+              } else if (isTPmtdOtherBTL) {
+                meBTLTrackMatchedTPmtdOtherNoAssocEta_->Fill(std::abs(trackGen.eta()));
+                meBTLTrackMatchedTPmtdOtherNoAssocPt_->Fill(trackGen.pt());
+              }
+            }
+	  }  // == end BTL
+	  // == ETL
+          else {
+            // -- Track matched to TP with sim hit in one etl layer
+            if (isTPmtdETLD1 || isTPmtdETLD2) {  // at least one hit (D1 or D2 or both)
+              meETLTrackMatchedTPmtd1Eta_->Fill(std::abs(trackGen.eta()));
+              meETLTrackMatchedTPmtd1Pt_->Fill(trackGen.pt());
+            }
+            // -- Track matched to TP with sim hits in both etl layers (D1 and D2)
+            if (isTPmtdETLD1 && isTPmtdETLD2) {
+              meETLTrackMatchedTPmtd2Eta_->Fill(std::abs(trackGen.eta()));
+              meETLTrackMatchedTPmtd2Pt_->Fill(trackGen.pt());
+            }
+            if (isETL) {
+              // -- Track matched to TP with sim hit in >=1 etl layer
+              if (isTPmtdETLD1 || isTPmtdETLD2) {
+                // - each hit is correctly associated to the track
+                if ((isTPmtdETLD1 && !isTPmtdETLD2 && ETLdisc1 && isTPmtdCorrectETLD1) ||
+                    (isTPmtdETLD2 && !isTPmtdETLD1 && ETLdisc2 && isTPmtdCorrectETLD2) ||
+                    (isTPmtdETLD1 && isTPmtdETLD2 && ETLdisc1 && ETLdisc2 && isTPmtdCorrectETLD1 &&
+                     isTPmtdCorrectETLD2)) {
+                  fillTrackClusterMatchingHistograms(meETLTrackMatchedTPmtd1CorrectAssocEta_,
+                                                     meETLTrackMatchedTPmtd1CorrectAssocPt_,
+                                                     meETLTrackMatchedTPmtd1CorrectAssocMVAQual_,
+                                                     meETLTrackMatchedTPmtd1CorrectAssocTimeRes_,
+                                                     meETLTrackMatchedTPmtd1CorrectAssocTimePull_,
+                                                     std::abs(trackGen.eta()),
+                                                     trackGen.pt(),
+                                                     mtdQualMVA[trackref],
+                                                     dT,
+                                                     pullT,
+                                                     hasTime);
+                }
+                // - at least one reco hit is incorrectly associated or, if two sim hits, one reco hit is missing
+		else if ((isTPmtdETLD1 && !isTPmtdCorrectETLD1) || (isTPmtdETLD2 && !isTPmtdCorrectETLD2)) {
+                  fillTrackClusterMatchingHistograms(meETLTrackMatchedTPmtd1WrongAssocEta_,
+                                                     meETLTrackMatchedTPmtd1WrongAssocPt_,
+                                                     meETLTrackMatchedTPmtd1WrongAssocMVAQual_,
+                                                     meETLTrackMatchedTPmtd1WrongAssocTimeRes_,
+                                                     meETLTrackMatchedTPmtd1WrongAssocTimePull_,
+                                                     std::abs(trackGen.eta()),
+                                                     trackGen.pt(),
+                                                     mtdQualMVA[trackref],
+                                                     dT,
+                                                     pullT,
+                                                     hasTime);
+                }
+              }
+	      // -- Track matched to TP with sim hits in both etl layers (D1 and D2)
+              if (isTPmtdETLD1 && isTPmtdETLD2) {
+                // - each hit correctly associated to the track
+                if (ETLdisc1 && ETLdisc2 && isTPmtdCorrectETLD1 && isTPmtdCorrectETLD2) {
+                  fillTrackClusterMatchingHistograms(meETLTrackMatchedTPmtd2CorrectAssocEta_,
+                                                     meETLTrackMatchedTPmtd2CorrectAssocPt_,
+                                                     meETLTrackMatchedTPmtd2CorrectAssocMVAQual_,
+                                                     meETLTrackMatchedTPmtd2CorrectAssocTimeRes_,
+                                                     meETLTrackMatchedTPmtd2CorrectAssocTimePull_,
+                                                     std::abs(trackGen.eta()),
+                                                     trackGen.pt(),
+                                                     mtdQualMVA[trackref],
+                                                     dT,
+                                                     pullT,
+                                                     hasTime);
+                }
+                // - at least one reco hit incorrectly associated or one hit missing
+		else if ((ETLdisc1 || ETLdisc2) && (!isTPmtdCorrectETLD1 || !isTPmtdCorrectETLD2)) {
+                  fillTrackClusterMatchingHistograms(meETLTrackMatchedTPmtd2WrongAssocEta_,
+                                                     meETLTrackMatchedTPmtd2WrongAssocPt_,
+                                                     meETLTrackMatchedTPmtd2WrongAssocMVAQual_,
+                                                     meETLTrackMatchedTPmtd2WrongAssocTimeRes_,
+                                                     meETLTrackMatchedTPmtd2WrongAssocTimePull_,
+                                                     std::abs(trackGen.eta()),
+                                                     trackGen.pt(),
+                                                     mtdQualMVA[trackref],
+                                                     dT,
+                                                     pullT,
+                                                     hasTime);
+                }
+              }
+            }
+            // -- Missing association with reco hits in MTD
+	    else {
+              // -- Track matched to TP with sim hit in >=1 etl layers, no reco hits associated to the track
+	      if (isTPmtdETLD1 || isTPmtdETLD2) {
+                meETLTrackMatchedTPmtd1NoAssocEta_->Fill(std::abs(trackGen.eta()));
+                meETLTrackMatchedTPmtd1NoAssocPt_->Fill(trackGen.pt());
+              }
+              // -- Track matched to TP with sim hit in 2 etl layers, no reco hits associated to the track
+              if (isTPmtdETLD1 && isTPmtdETLD2) {
+                meETLTrackMatchedTPmtd2NoAssocEta_->Fill(std::abs(trackGen.eta()));
+                meETLTrackMatchedTPmtd2NoAssocPt_->Fill(trackGen.pt());
+              }
+            }
+          }  // == end ETL
+	}  // --- end "withMTD" 
+
+	// - Track matched to TP without sim hit in MTD, but with reco cluster associated
+        // - BTL
+        if (std::abs(trackGen.eta()) < trackMaxBtlEta_) {
+          if (!isTPmtdDirectBTL && !isTPmtdOtherBTL) {
+            meBTLTrackMatchedTPnomtdEta_->Fill(std::abs(trackGen.eta()));
+            meBTLTrackMatchedTPnomtdPt_->Fill(trackGen.pt());
+            if (isBTL) {
+              fillTrackClusterMatchingHistograms(meBTLTrackMatchedTPnomtdAssocEta_,
+                                                 meBTLTrackMatchedTPnomtdAssocPt_,
+                                                 meBTLTrackMatchedTPnomtdAssocMVAQual_,
+                                                 meBTLTrackMatchedTPnomtdAssocTimeRes_,
+                                                 meBTLTrackMatchedTPnomtdAssocTimePull_,
+                                                 std::abs(trackGen.eta()),
+                                                 trackGen.pt(),
+                                                 mtdQualMVA[trackref],
+                                                 dT,
+                                                 pullT,
+                                                 hasTime);
+            }
+          }
+        }
+	// - ETL
+        else if (!isTPmtdETLD1 && !isTPmtdETLD2) {
+          meETLTrackMatchedTPnomtdEta_->Fill(std::abs(trackGen.eta()));
+          meETLTrackMatchedTPnomtdPt_->Fill(trackGen.pt());
+          if (isETL) {
+            fillTrackClusterMatchingHistograms(meETLTrackMatchedTPnomtdAssocEta_,
+                                               meETLTrackMatchedTPnomtdAssocPt_,
+                                               meETLTrackMatchedTPnomtdAssocMVAQual_,
+                                               meETLTrackMatchedTPnomtdAssocTimeRes_,
+                                               meETLTrackMatchedTPnomtdAssocTimePull_,
+                                               std::abs(trackGen.eta()),
+                                               trackGen.pt(),
+                                               mtdQualMVA[trackref],
+                                               dT,
+                                               pullT,
+                                               hasTime);
+          }
+        }
+
+	
+        // == Time pull and detailed extrapolation check only on tracks associated to TP from signal event
         if (!trkTPSelLV(**tp_info)) {
           continue;
         }
@@ -626,20 +1054,14 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
         }  // detailed extrapolation check
 
         // time res and time pull
-        double tsim = (*tp_info)->parentVertex()->position().t() * simUnit_;
-        double dT(-9999.);
-        double pullT(-9999.);
-        if (Sigmat0Safe[trackref] != -1.) {
-          dT = t0Safe[trackref] - tsim;
-          pullT = dT / Sigmat0Safe[trackref];
-          if (isBTL || isETL) {
+	if (Sigmat0Safe[trackref] != -1.) {
+	  if (isBTL || isETL) {
             meTrackResTot_->Fill(dT);
             meTrackPullTot_->Fill(pullT);
             meTrackResTotvsMVAQual_->Fill(mtdQualMVA[trackref], dT);
             meTrackPullTotvsMVAQual_->Fill(mtdQualMVA[trackref], pullT);
           }
         }  // time res and time pull
-
       }  // TP matching
     }  // trkRecSel
 
@@ -647,9 +1069,9 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
     if (trkRecSelLowPt(trackGen)) {
       if ((std::abs(trackGen.eta()) > trackMinEtlEta_) && (std::abs(trackGen.eta()) < trackMaxEtlEta_)) {
         if (trackGen.pt() < 0.45) {
-          meETLTrackEffEtaTotLowPt_[0]->Fill(std::abs(trackGen.eta()));
+          meETLTrackEtaTotLowPt_[0]->Fill(std::abs(trackGen.eta()));
         } else {
-          meETLTrackEffEtaTotLowPt_[1]->Fill(std::abs(trackGen.eta()));
+          meETLTrackEtaTotLowPt_[1]->Fill(std::abs(trackGen.eta()));
         }
       }
       bool MTDEtlZnegD1 = false;
@@ -685,16 +1107,16 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
       }
       if (isETL && (std::abs(trackGen.eta()) > trackMinEtlEta_) && (std::abs(trackGen.eta()) < trackMaxEtlEta_)) {
         if (trackGen.pt() < 0.45) {
-          meETLTrackEffEtaMtdLowPt_[0]->Fill(std::abs(trackGen.eta()));
+          meETLTrackEtaMtdLowPt_[0]->Fill(std::abs(trackGen.eta()));
         } else {
-          meETLTrackEffEtaMtdLowPt_[1]->Fill(std::abs(trackGen.eta()));
+          meETLTrackEtaMtdLowPt_[1]->Fill(std::abs(trackGen.eta()));
         }
       }
       if (isETL && twoETLdiscs) {
         if (trackGen.pt() < 0.45) {
-          meETLTrackEffEta2MtdLowPt_[0]->Fill(std::abs(trackGen.eta()));
+          meETLTrackEta2MtdLowPt_[0]->Fill(std::abs(trackGen.eta()));
         } else {
-          meETLTrackEffEta2MtdLowPt_[1]->Fill(std::abs(trackGen.eta()));
+          meETLTrackEta2MtdLowPt_[1]->Fill(std::abs(trackGen.eta()));
         }
       }
     }  // trkRecSelLowPt
@@ -895,59 +1317,41 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
 
   // histogram booking
   meBTLTrackRPTime_ = ibook.book1D("TrackBTLRPTime", "Track t0 with respect to R.P.;t0 [ns]", 100, -1, 3);
-  meBTLTrackEffEtaTot_ = ibook.book1D("TrackBTLEffEtaTot", "Eta of tracks (Tot);#eta_{RECO}", 100, -1.6, 1.6);
-  meBTLTrackEffPhiTot_ = ibook.book1D("TrackBTLEffPhiTot", "Phi of tracks (Tot);#phi_{RECO} [rad]", 100, -3.2, 3.2);
-  meBTLTrackEffPtTot_ = ibook.book1D("TrackBTLEffPtTot", "Pt of tracks (Tot);pt_{RECO} [GeV]", 50, 0, 10);
-  meBTLTrackEffEtaMtd_ = ibook.book1D("TrackBTLEffEtaMtd", "Eta of tracks (Mtd);#eta_{RECO}", 100, -1.6, 1.6);
-  meBTLTrackEffPhiMtd_ = ibook.book1D("TrackBTLEffPhiMtd", "Phi of tracks (Mtd);#phi_{RECO} [rad]", 100, -3.2, 3.2);
-  meBTLTrackEffPtMtd_ = ibook.book1D("TrackBTLEffPtMtd", "Pt of tracks (Mtd);pt_{RECO} [GeV]", 50, 0, 10);
+  meBTLTrackEtaTot_ = ibook.book1D("TrackBTLEtaTot", "Eta of tracks (Tot);#eta_{RECO}", 30, 0., 1.5);
+  meBTLTrackPhiTot_ = ibook.book1D("TrackBTLPhiTot", "Phi of tracks (Tot);#phi_{RECO} [rad]", 100, -3.2, 3.2);
+  meBTLTrackPtTot_ = ibook.book1D("TrackBTLPtTot", "Pt of tracks (Tot);pt_{RECO} [GeV]", 50, 0, 10);
+  meBTLTrackEtaMtd_ = ibook.book1D("TrackBTLEtaMtd", "Eta of tracks (Mtd);#eta_{RECO}", 30, 0., 1.5);
+  meBTLTrackPhiMtd_ = ibook.book1D("TrackBTLPhiMtd", "Phi of tracks (Mtd);#phi_{RECO} [rad]", 100, -3.2, 3.2);
+  meBTLTrackPtMtd_ = ibook.book1D("TrackBTLPtMtd", "Pt of tracks (Mtd);pt_{RECO} [GeV]", 50, 0, 10);
   meBTLTrackPtRes_ =
       ibook.book1D("TrackBTLPtRes", "Track pT resolution  ;pT_{Gentrack}-pT_{MTDtrack}/pT_{Gentrack} ", 100, -0.1, 0.1);
   meETLTrackRPTime_ = ibook.book1D("TrackETLRPTime", "Track t0 with respect to R.P.;t0 [ns]", 100, -1, 3);
-  meETLTrackEffEtaTot_[0] =
-      ibook.book1D("TrackETLEffEtaTotZneg", "Eta of tracks (Tot) (-Z);#eta_{RECO}", 100, -3.2, -1.4);
-  meETLTrackEffEtaTot_[1] =
-      ibook.book1D("TrackETLEffEtaTotZpos", "Eta of tracks (Tot) (+Z);#eta_{RECO}", 100, 1.4, 3.2);
-  meETLTrackEffEtaTotLowPt_[0] =
-      ibook.book1D("TrackETLEffEtaTotLowPt0", "Eta of tracks, 0.2 < pt < 0.45 (Tot);#eta_{RECO}", 100, 1.4, 3.2);
-  meETLTrackEffEtaTotLowPt_[1] =
-      ibook.book1D("TrackETLEffEtaTotLowPt1", "Eta of tracks, 0.45 < pt < 0.7 (Tot);#eta_{RECO}", 100, 1.4, 3.2);
-  meETLTrackEffPhiTot_[0] =
-      ibook.book1D("TrackETLEffPhiTotZneg", "Phi of tracks (Tot) (-Z);#phi_{RECO} [rad]", 100, -3.2, 3.2);
-  meETLTrackEffPhiTot_[1] =
-      ibook.book1D("TrackETLEffPhiTotZpos", "Phi of tracks (Tot) (+Z);#phi_{RECO} [rad]", 100, -3.2, 3.2);
-  meETLTrackEffPtTot_[0] = ibook.book1D("TrackETLEffPtTotZneg", "Pt of tracks (Tot) (-Z);pt_{RECO} [GeV]", 50, 0, 10);
-  meETLTrackEffPtTot_[1] = ibook.book1D("TrackETLEffPtTotZpos", "Pt of tracks (Tot) (+Z);pt_{RECO} [GeV]", 50, 0, 10);
-  meETLTrackEffEtaMtd_[0] =
-      ibook.book1D("TrackETLEffEtaMtdZneg", "Eta of tracks (Mtd) (-Z);#eta_{RECO}", 100, -3.2, -1.4);
-  meETLTrackEffEtaMtd_[1] =
-      ibook.book1D("TrackETLEffEtaMtdZpos", "Eta of tracks (Mtd) (+Z);#eta_{RECO}", 100, 1.4, 3.2);
-  meETLTrackEffEtaMtdLowPt_[0] =
-      ibook.book1D("TrackETLEffEtaMtdLowPt0", "Eta of tracks, 0.2 < pt < 0.45 (Mtd);#eta_{RECO}", 100, 1.4, 3.2);
-  meETLTrackEffEtaMtdLowPt_[1] =
-      ibook.book1D("TrackETLEffEtaMtdLowPt1", "Eta of tracks, 0.45 < pt < 0.7 (Mtd);#eta_{RECO}", 100, 1.4, 3.2);
-  meETLTrackEffEta2MtdLowPt_[0] =
-      ibook.book1D("TrackETLEffEta2MtdLowPt0", "Eta of tracks, 0.2 < pt < 0.45 (Mtd 2 hit);#eta_{RECO}", 100, 1.4, 3.2);
-  meETLTrackEffEta2MtdLowPt_[1] =
-      ibook.book1D("TrackETLEffEta2MtdLowPt1", "Eta of tracks, 0.45 < pt < 0.7 (Mtd 2 hit);#eta_{RECO}", 100, 1.4, 3.2);
-  meETLTrackEffPhiMtd_[0] =
-      ibook.book1D("TrackETLEffPhiMtdZneg", "Phi of tracks (Mtd) (-Z);#phi_{RECO} [rad]", 100, -3.2, 3.2);
-  meETLTrackEffPhiMtd_[1] =
-      ibook.book1D("TrackETLEffPhiMtdZpos", "Phi of tracks (Mtd) (+Z);#phi_{RECO} [rad]", 100, -3.2, 3.2);
-  meETLTrackEffPtMtd_[0] = ibook.book1D("TrackETLEffPtMtdZneg", "Pt of tracks (Mtd) (-Z);pt_{RECO} [GeV]", 50, 0, 10);
-  meETLTrackEffPtMtd_[1] = ibook.book1D("TrackETLEffPtMtdZpos", "Pt of tracks (Mtd) (+Z);pt_{RECO} [GeV]", 50, 0, 10);
-  meETLTrackEffEta2Mtd_[0] =
-      ibook.book1D("TrackETLEffEta2MtdZneg", "Eta of tracks (Mtd 2 hit) (-Z);#eta_{RECO}", 100, -3.2, -1.4);
-  meETLTrackEffEta2Mtd_[1] =
-      ibook.book1D("TrackETLEffEta2MtdZpos", "Eta of tracks (Mtd 2 hit) (+Z);#eta_{RECO}", 100, 1.4, 3.2);
-  meETLTrackEffPhi2Mtd_[0] =
-      ibook.book1D("TrackETLEffPhi2MtdZneg", "Phi of tracks (Mtd 2 hit) (-Z);#phi_{RECO} [rad]", 100, -3.2, 3.2);
-  meETLTrackEffPhi2Mtd_[1] =
-      ibook.book1D("TrackETLEffPhi2MtdZpos", "Phi of tracks (Mtd 2 hit) (+Z);#phi_{RECO} [rad]", 100, -3.2, 3.2);
-  meETLTrackEffPt2Mtd_[0] =
-      ibook.book1D("TrackETLEffPt2MtdZneg", "Pt of tracks (Mtd 2 hit) (-Z);pt_{RECO} [GeV]", 50, 0, 10);
-  meETLTrackEffPt2Mtd_[1] =
-      ibook.book1D("TrackETLEffPt2MtdZpos", "Pt of tracks (Mtd 2 hit) (+Z);pt_{RECO} [GeV]", 50, 0, 10);
+  meETLTrackEtaTot_ = ibook.book1D("TrackETLEtaTot", "Eta of tracks (Tot);#eta_{RECO}", 30, 1.5, 3.0);
+  meETLTrackPhiTot_ = ibook.book1D("TrackETLPhiTot", "Phi of tracks (Tot);#phi_{RECO} [rad]", 100, -3.2, 3.2);
+  meETLTrackPhiTot_ = ibook.book1D("TrackETLPhiTot", "Phi of tracks (Tot);#phi_{RECO} [rad]", 100, -3.2, 3.2);
+  meETLTrackPtTot_ = ibook.book1D("TrackETLPtTot", "Pt of tracks (Tot);pt_{RECO} [GeV]", 50, 0, 10);
+
+  meETLTrackEtaTotLowPt_[0] =
+      ibook.book1D("TrackETLEtaTotLowPt0", "Eta of tracks, 0.2 < pt < 0.45 (Tot);#eta_{RECO}", 30, 1.5, 3.0);
+  meETLTrackEtaTotLowPt_[1] =
+      ibook.book1D("TrackETLEtaTotLowPt1", "Eta of tracks, 0.45 < pt < 0.7 (Tot);#eta_{RECO}", 30, 1.5, 3.0);
+
+  meETLTrackEtaMtd_ = ibook.book1D("TrackETLEtaMtd", "Eta of tracks (Mtd);#eta_{RECO}", 30, 1.5, 3.0);
+  meETLTrackEtaMtdLowPt_[0] =
+      ibook.book1D("TrackETLEtaMtdLowPt0", "Eta of tracks, 0.2 < pt < 0.45 (Mtd);#eta_{RECO}", 30, 1.5, 3.0);
+  meETLTrackEtaMtdLowPt_[1] =
+      ibook.book1D("TrackETLEtaMtdLowPt1", "Eta of tracks, 0.45 < pt < 0.7 (Mtd);#eta_{RECO}", 30, 1.5, 3.0);
+  meETLTrackEta2MtdLowPt_[0] =
+      ibook.book1D("TrackETLEta2MtdLowPt0", "Eta of tracks, 0.2 < pt < 0.45 (Mtd 2 hit);#eta_{RECO}", 30, 1.5, 3.0);
+  meETLTrackEta2MtdLowPt_[1] =
+      ibook.book1D("TrackETLEta2MtdLowPt1", "Eta of tracks, 0.45 < pt < 0.7 (Mtd 2 hit);#eta_{RECO}", 30, 1.5, 3.0);
+
+  meETLTrackPhiMtd_ = ibook.book1D("TrackETLPhiMtd", "Phi of tracks (Mtd);#phi_{RECO} [rad]", 100, -3.2, 3.2);
+  meETLTrackPtMtd_ = ibook.book1D("TrackETLPtMtd", "Pt of tracks (Mtd);pt_{RECO} [GeV]", 50, 0, 10);
+  meETLTrackEta2Mtd_ = ibook.book1D("TrackETLEta2Mtd", "Eta of tracks (Mtd 2 hit);#eta_{RECO}", 30, 1.5, 3.0);
+  meETLTrackPhi2Mtd_ = ibook.book1D("TrackETLPhi2Mtd", "Phi of tracks (Mtd 2 hit);#phi_{RECO} [rad]", 100, -3.2, 3.2);
+  meETLTrackPt2Mtd_ = ibook.book1D("TrackETLPt2Mtd", "Pt of tracks (Mtd 2 hit);pt_{RECO} [GeV]", 50, 0, 10);
+
   meETLTrackPtRes_ =
       ibook.book1D("TrackETLPtRes", "Track pT resolution;pT_{Gentrack}-pT_{MTDtrack}/pT_{Gentrack} ", 100, -0.1, 0.1);
 
@@ -1010,165 +1414,167 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
                                    110,
                                    0.,
                                    11.);
-
-  meTrackPtTot_ = ibook.book1D("TrackPtTot", "Pt of tracks ; track pt [GeV] ", 110, 0., 11.);
-  meTrackMatchedTPEffPtTot_ =
-      ibook.book1D("MatchedTPEffPtTot", "Pt of tracks matched to TP; track pt [GeV] ", 110, 0., 11.);
-  meTrackMatchedTPEffPtTotLV_ =
-      ibook.book1D("MatchedTPEffPtTotLV", "Pt of tracks associated to LV matched to TP; track pt [GeV] ", 110, 0., 11.);
-  meTrackMatchedTPEffPtMtd_ =
-      ibook.book1D("MatchedTPEffPtMtd", "Pt of tracks matched to TP with time; track pt [GeV] ", 110, 0., 11.);
-  meTrackMatchedTPEffPtEtl2Mtd_ = ibook.book1D(
-      "MatchedTPEffPtEtl2Mtd", "Pt of tracks matched to TP with time, 2 ETL hits; track pt [GeV] ", 110, 0., 11.);
-
-  meBTLTrackMatchedTPPtResMtd_ = ibook.book1D(
-      "TrackMatchedTPBTLPtResMtd",
-      "Pt resolution of tracks matched to TP-BTL hit  ;|pT_{MTDtrack}-pT_{truth}|/|pT_{Gentrack}-pT_{truth}| ",
-      100,
-      0.,
-      4.);
-  meETLTrackMatchedTPPtResMtd_ = ibook.book1D(
-      "TrackMatchedTPETLPtResMtd",
-      "Pt resolution of tracks matched to TP-ETL hit  ;|pT_{MTDtrack}-pT_{truth}|/|pT_{Gentrack}-pT_{truth}| ",
-      100,
-      0.,
-      4.);
-  meETLTrackMatchedTP2PtResMtd_ = ibook.book1D(
-      "TrackMatchedTPETL2PtResMtd",
-      "Pt resolution of tracks matched to TP-ETL 2hits  ;|pT_{MTDtrack}-pT_{truth}|/|pT_{Gentrack}-pT_{truth}| ",
-      100,
-      0.,
-      4.);
-  meBTLTrackMatchedTPPtRatioGen_ = ibook.book1D(
-      "TrackMatchedTPBTLPtRatioGen", "Pt ratio of Gentracks (BTL)  ;pT_{Gentrack}/pT_{truth} ", 100, 0.9, 1.1);
-  meETLTrackMatchedTPPtRatioGen_ = ibook.book1D(
-      "TrackMatchedTPETLPtRatioGen", "Pt ratio of Gentracks (ETL 1hit)  ;pT_{Gentrack}/pT_{truth} ", 100, 0.9, 1.1);
-  meETLTrackMatchedTP2PtRatioGen_ = ibook.book1D(
-      "TrackMatchedTPETL2PtRatioGen", "Pt ratio of Gentracks (ETL 2hits)  ;pT_{Gentrack}/pT_{truth} ", 100, 0.9, 1.1);
-  meBTLTrackMatchedTPPtRatioMtd_ = ibook.book1D("TrackMatchedTPBTLPtRatioMtd",
-                                                "Pt ratio of tracks matched to TP-BTL hit  ;pT_{MTDtrack}/pT_{truth} ",
-                                                100,
-                                                0.9,
-                                                1.1);
-  meETLTrackMatchedTPPtRatioMtd_ = ibook.book1D("TrackMatchedTPETLPtRatioMtd",
-                                                "Pt ratio of tracks matched to TP-ETL hit  ;pT_{MTDtrack}/pT_{truth} ",
-                                                100,
-                                                0.9,
-                                                1.1);
-  meETLTrackMatchedTP2PtRatioMtd_ =
-      ibook.book1D("TrackMatchedTPETL2PtRatioMtd",
-                   "Pt ratio of tracks matched to TP-ETL 2hits  ;pT_{MTDtrack}/pT_{truth} ",
-                   100,
-                   0.9,
-                   1.1);
-  meBTLTrackMatchedTPPtResvsPtMtd_ = ibook.bookProfile("TrackMatchedTPBTLPtResvsPtMtd",
-                                                       "Pt resolution of tracks matched to TP-BTL hit vs Pt;pT_{truth} "
-                                                       "[GeV];|pT_{MTDtrack}-pT_{truth}|/|pT_{Gentrack}-pT_{truth}| ",
-                                                       20,
-                                                       0.7,
-                                                       10.,
-                                                       0.,
-                                                       4.,
-                                                       "s");
-  meETLTrackMatchedTPPtResvsPtMtd_ = ibook.bookProfile("TrackMatchedTPETLPtResvsPtMtd",
-                                                       "Pt resolution of tracks matched to TP-ETL hit vs Pt;pT_{truth} "
-                                                       "[GeV];|pT_{MTDtrack}-pT_{truth}|/|pT_{Gentrack}-pT_{truth}| ",
-                                                       20,
-                                                       0.7,
-                                                       10.,
-                                                       0.,
-                                                       4.,
-                                                       "s");
-  meETLTrackMatchedTP2PtResvsPtMtd_ =
-      ibook.bookProfile("TrackMatchedTPETL2PtResvsPtMtd",
-                        "Pt resolution of tracks matched to TP-ETL 2hits Pt pT;pT_{truth} "
-                        "[GeV];|pT_{MTDtrack}-pT_{truth}|/|pT_{Gentrack}-pT_{truth}| ",
-                        20,
-                        0.7,
-                        10.,
-                        0.,
-                        4.,
-                        "s");
-  meBTLTrackMatchedTPDPtvsPtGen_ = ibook.bookProfile(
-      "TrackMatchedTPBTLDPtvsPtGen",
-      "Pt relative difference of Gentracks (BTL) vs Pt;pT_{truth} [GeV];pT_{Gentrack}-pT_{truth}/pT_{truth} ",
-      20,
-      0.7,
-      10.,
-      -0.1,
-      0.1,
-      "s");
-  meETLTrackMatchedTPDPtvsPtGen_ = ibook.bookProfile(
-      "TrackMatchedTPETLDPtvsPtGen",
-      "Pt relative difference of Gentracks (ETL 1hit) vs Pt;pT_{truth} [GeV];pT_{Gentrack}-pT_{truth}/pT_{truth} ",
-      20,
-      0.7,
-      10.,
-      -0.1,
-      0.1,
-      "s");
-  meETLTrackMatchedTP2DPtvsPtGen_ = ibook.bookProfile(
-      "TrackMatchedTPETL2DPtvsPtGen",
-      "Pt relative difference  of Gentracks (ETL 2hits) vs Pt;pT_{truth} [GeV];pT_{Gentrack}-pT_{truth}/pT_{truth} ",
-      20,
-      0.7,
-      10.,
-      -0.1,
-      0.1,
-      "s");
-  meBTLTrackMatchedTPDPtvsPtMtd_ = ibook.bookProfile("TrackMatchedTPBTLDPtvsPtMtd",
-                                                     "Pt relative difference of tracks matched to TP-BTL hits vs "
-                                                     "Pt;pT_{truth} [GeV];pT_{MTDtrack}-pT_{truth}/pT_{truth} ",
-                                                     20,
-                                                     0.7,
-                                                     10.,
-                                                     -0.1,
-                                                     0.1,
-                                                     "s");
-  meETLTrackMatchedTPDPtvsPtMtd_ = ibook.bookProfile("TrackMatchedTPETLDPtvsPtMtd",
-                                                     "Pt relative difference of tracks matched to TP-ETL hits vs "
-                                                     "Pt;pT_{truth} [GeV];pT_{MTDtrack}-pT_{truth}/pT_{truth} ",
-                                                     20,
-                                                     0.7,
-                                                     10.,
-                                                     -0.1,
-                                                     0.1,
-                                                     "s");
-  meETLTrackMatchedTP2DPtvsPtMtd_ = ibook.bookProfile("TrackMatchedTPETL2DPtvsPtMtd",
-                                                      "Pt relative difference of tracks matched to TP-ETL 2hits vs "
-                                                      "Pt;pT_{truth} [GeV];pT_{MTDtrack}-pT_{truth}/pT_{truth} ",
-                                                      20,
-                                                      0.7,
-                                                      10.,
-                                                      -0.1,
-                                                      0.1,
-                                                      "s");
-
-  meTrackMatchedTPmtdEffPtTot_ =
-      ibook.book1D("MatchedTPmtdEffPtTot", "Pt of tracks matched to TP-mtd hit; track pt [GeV] ", 110, 0., 11.);
-  meTrackMatchedTPmtdEffPtMtd_ = ibook.book1D(
-      "MatchedTPmtdEffPtMtd", "Pt of tracks matched to TP-mtd hit with time; track pt [GeV] ", 110, 0., 11.);
-
   meExtraEtaMtd_ =
       ibook.book1D("ExtraEtaMtd", "Eta of tracks associated to LV extrapolated to hits; track eta ", 66, 0., 3.3);
   meExtraEtaEtl2Mtd_ = ibook.book1D(
       "ExtraEtaEtl2Mtd", "Eta of tracks associated to LV extrapolated to hits, 2 ETL layers; track eta ", 66, 0., 3.3);
+  meTrackMatchedTPEtaTotLV_ =
+      ibook.book1D("MatchedTPEtaTotLV", "Eta of tracks associated to LV matched to TP; track eta ", 66, 0., 3.3);
+  meTrackMatchedTPPtTotLV_ =
+      ibook.book1D("MatchedTPPtTotLV", "Pt of tracks associated to LV matched to TP; track pt [GeV] ", 110, 0., 11.);
 
-  meTrackEtaTot_ = ibook.book1D("TrackEtaTot", "Eta of tracks ; track eta ", 66, 0., 3.3);
-  meTrackMatchedTPEffEtaTot_ =
-      ibook.book1D("MatchedTPEffEtaTot", "Eta of tracks matched to TP; track eta ", 66, 0., 3.3);
-  meTrackMatchedTPEffEtaTotLV_ =
-      ibook.book1D("MatchedTPEffEtaTotLV", "Eta of tracks associated to LV matched to TP; track eta ", 66, 0., 3.3);
-  meTrackMatchedTPEffEtaMtd_ =
-      ibook.book1D("MatchedTPEffEtaMtd", "Eta of tracks matched to TP with time; track eta ", 66, 0., 3.3);
-  meTrackMatchedTPEffEtaEtl2Mtd_ = ibook.book1D(
-      "MatchedTPEffEtaEtl2Mtd", "Eta of tracks matched to TP with time, 2 ETL hits; track eta ", 66, 0., 3.3);
+  
+  meBTLTrackMatchedTPEtaTot_ =
+      ibook.book1D("BTLTrackMatchedTPEtaTot", "Eta of tracks matched to TP; track eta ", 30, 0., 1.5);
+  meBTLTrackMatchedTPEtaMtd_ =
+      ibook.book1D("BTLTrackMatchedTPEtaMtd", "Eta of tracks matched to TP with time; track eta ", 30, 0., 1.5);
+  meBTLTrackMatchedTPPtTot_ =
+      ibook.book1D("BTLTrackMatchedTPPtTot", "Pt of tracks matched to TP; track pt [GeV] ", 50, 0., 10.);
+  meBTLTrackMatchedTPPtMtd_ =
+      ibook.book1D("BTLTrackMatchedTPPtMtd", "Pt of tracks matched to TP with time; track pt [GeV] ", 50, 0., 10.);
+  meETLTrackMatchedTPEtaTot_ =
+      ibook.book1D("ETLTrackMatchedTPEtaTot", "Eta of tracks matched to TP; track eta ", 30, 1.5, 3.0);
+  meETLTrackMatchedTPEtaMtd_ = ibook.book1D(
+      "ETLTrackMatchedTPEtaMtd", "Eta of tracks matched to TP with time (>=1 ETL hit); track eta ", 30, 1.5, 3.0);
+  meETLTrackMatchedTPEta2Mtd_ = ibook.book1D(
+      "ETLTrackMatchedTPEta2Mtd", "Eta of tracks matched to TP with time (2 ETL hits); track eta ", 30, 1.5, 3.0);
+  meETLTrackMatchedTPPtTot_ =
+      ibook.book1D("ETLTrackMatchedTPPtTot", "Pt of tracks matched to TP; track pt [GeV] ", 50, 0., 10.);
+  meETLTrackMatchedTPPtMtd_ = ibook.book1D(
+      "ETLTrackMatchedTPPtMtd", "Pt of tracks matched to TP with time (>=1 ETL hit); track pt [GeV] ", 50, 0., 10.);
+  meETLTrackMatchedTPPt2Mtd_ = ibook.book1D(
+      "ETLTrackMatchedTPPt2Mtd", "Pt of tracks matched to TP with time (2 ETL hits); track pt [GeV] ", 50, 0., 10.);
 
-  meTrackMatchedTPmtdEffEtaTot_ =
-      ibook.book1D("MatchedTPmtdEffEtaTot", "Eta of tracks matched to TP-mtd hit; track eta ", 66, 0., 3.3);
-  meTrackMatchedTPmtdEffEtaMtd_ =
-      ibook.book1D("MatchedTPmtdEffEtaMtd", "Eta of tracks matched to TP-mtd hit with time; track eta ", 66, 0., 3.3);
-
+  
+  if (optionalPlots_) {
+    meBTLTrackMatchedTPPtResMtd_ = ibook.book1D(
+        "TrackMatchedTPBTLPtResMtd",
+        "Pt resolution of tracks matched to TP-BTL hit  ;|pT_{MTDtrack}-pT_{truth}|/|pT_{Gentrack}-pT_{truth}| ",
+        100,
+        0.,
+        4.);
+    meETLTrackMatchedTPPtResMtd_ = ibook.book1D(
+        "TrackMatchedTPETLPtResMtd",
+        "Pt resolution of tracks matched to TP-ETL hit  ;|pT_{MTDtrack}-pT_{truth}|/|pT_{Gentrack}-pT_{truth}| ",
+        100,
+        0.,
+        4.);
+    meETLTrackMatchedTP2PtResMtd_ = ibook.book1D(
+        "TrackMatchedTPETL2PtResMtd",
+        "Pt resolution of tracks matched to TP-ETL 2hits  ;|pT_{MTDtrack}-pT_{truth}|/|pT_{Gentrack}-pT_{truth}| ",
+        100,
+        0.,
+        4.);
+    meBTLTrackMatchedTPPtRatioGen_ = ibook.book1D(
+        "TrackMatchedTPBTLPtRatioGen", "Pt ratio of Gentracks (BTL)  ;pT_{Gentrack}/pT_{truth} ", 100, 0.9, 1.1);
+    meETLTrackMatchedTPPtRatioGen_ = ibook.book1D(
+        "TrackMatchedTPETLPtRatioGen", "Pt ratio of Gentracks (ETL 1hit)  ;pT_{Gentrack}/pT_{truth} ", 100, 0.9, 1.1);
+    meETLTrackMatchedTP2PtRatioGen_ = ibook.book1D(
+        "TrackMatchedTPETL2PtRatioGen", "Pt ratio of Gentracks (ETL 2hits)  ;pT_{Gentrack}/pT_{truth} ", 100, 0.9, 1.1);
+    meBTLTrackMatchedTPPtRatioMtd_ =
+        ibook.book1D("TrackMatchedTPBTLPtRatioMtd",
+                     "Pt ratio of tracks matched to TP-BTL hit  ;pT_{MTDtrack}/pT_{truth} ",
+                     100,
+                     0.9,
+                     1.1);
+    meETLTrackMatchedTPPtRatioMtd_ =
+        ibook.book1D("TrackMatchedTPETLPtRatioMtd",
+                     "Pt ratio of tracks matched to TP-ETL hit  ;pT_{MTDtrack}/pT_{truth} ",
+                     100,
+                     0.9,
+                     1.1);
+    meETLTrackMatchedTP2PtRatioMtd_ =
+        ibook.book1D("TrackMatchedTPETL2PtRatioMtd",
+                     "Pt ratio of tracks matched to TP-ETL 2hits  ;pT_{MTDtrack}/pT_{truth} ",
+                     100,
+                     0.9,
+                     1.1);
+  meBTLTrackMatchedTPPtResvsPtMtd_ =
+        ibook.bookProfile("TrackMatchedTPBTLPtResvsPtMtd",
+                          "Pt resolution of tracks matched to TP-BTL hit vs Pt;pT_{truth} "
+                          "[GeV];|pT_{MTDtrack}-pT_{truth}|/|pT_{Gentrack}-pT_{truth}| ",
+                          20,
+                          0.7,
+                          10.,
+                          0.,
+                          4.,
+                          "s");
+    meETLTrackMatchedTPPtResvsPtMtd_ =
+        ibook.bookProfile("TrackMatchedTPETLPtResvsPtMtd",
+                          "Pt resolution of tracks matched to TP-ETL hit vs Pt;pT_{truth} "
+                          "[GeV];|pT_{MTDtrack}-pT_{truth}|/|pT_{Gentrack}-pT_{truth}| ",
+                          20,
+                          0.7,
+                          10.,
+                          0.,
+                          4.,
+                          "s");
+    meETLTrackMatchedTP2PtResvsPtMtd_ =
+        ibook.bookProfile("TrackMatchedTPETL2PtResvsPtMtd",
+                        "Pt resolution of tracks matched to TP-ETL 2hits Pt pT;pT_{truth} "
+                          "[GeV];|pT_{MTDtrack}-pT_{truth}|/|pT_{Gentrack}-pT_{truth}| ",
+                          20,
+                          0.7,
+                          10.,
+                          0.,
+                          4.,
+                          "s");
+   meBTLTrackMatchedTPDPtvsPtGen_ = ibook.bookProfile(
+        "TrackMatchedTPBTLDPtvsPtGen",
+        "Pt relative difference of Gentracks (BTL) vs Pt;pT_{truth} [GeV];pT_{Gentrack}-pT_{truth}/pT_{truth} ",
+        20,
+        0.7,
+        10.,
+        -0.1,
+        0.1,
+        "s");
+    meETLTrackMatchedTPDPtvsPtGen_ = ibook.bookProfile(
+        "TrackMatchedTPETLDPtvsPtGen",
+        "Pt relative difference of Gentracks (ETL 1hit) vs Pt;pT_{truth} [GeV];pT_{Gentrack}-pT_{truth}/pT_{truth} ",
+        20,
+        0.7,
+        10.,
+        -0.1,
+        0.1,
+        "s");
+    meETLTrackMatchedTP2DPtvsPtGen_ = ibook.bookProfile(
+        "TrackMatchedTPETL2DPtvsPtGen",
+        "Pt relative difference  of Gentracks (ETL 2hits) vs Pt;pT_{truth} [GeV];pT_{Gentrack}-pT_{truth}/pT_{truth} ",
+        20,
+        0.7,
+        10.,
+        -0.1,
+        0.1,
+        "s");
+    meBTLTrackMatchedTPDPtvsPtMtd_ = ibook.bookProfile("TrackMatchedTPBTLDPtvsPtMtd",
+                                                       "Pt relative difference of tracks matched to TP-BTL hits vs "
+                                                       "Pt;pT_{truth} [GeV];pT_{MTDtrack}-pT_{truth}/pT_{truth} ",
+                                                       20,
+                                                       0.7,
+                                                       10.,
+                                                       -0.1,
+                                                       0.1,
+                                                       "s");
+    meETLTrackMatchedTPDPtvsPtMtd_ = ibook.bookProfile("TrackMatchedTPETLDPtvsPtMtd",
+                                                       "Pt relative difference of tracks matched to TP-ETL hits vs "
+                                                       "Pt;pT_{truth} [GeV];pT_{MTDtrack}-pT_{truth}/pT_{truth} ",
+                                                       20,
+                                                       0.7,
+                                                       10.,
+                                                       -0.1,
+                                                       0.1,
+                                                       "s");
+    meETLTrackMatchedTP2DPtvsPtMtd_ = ibook.bookProfile("TrackMatchedTPETL2DPtvsPtMtd",
+                                                        "Pt relative difference of tracks matched to TP-ETL 2hits vs "
+                                                        "Pt;pT_{truth} [GeV];pT_{MTDtrack}-pT_{truth}/pT_{truth} ",
+                                                        20,
+                                                        0.7,
+                                                        10.,
+                                                        -0.1,
+                                                        0.1,
+                                                        "s");
+  } // end optional plots
+ 
   meTrackResTot_ = ibook.book1D(
       "TrackRes", "t_{rec} - t_{sim} for LV associated tracks matched to TP; t_{rec} - t_{sim} [ns] ", 120, -0.15, 0.15);
   meTrackPullTot_ = ibook.book1D(
@@ -1219,6 +1625,436 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
       110,
       0.,
       11.);
+
+  // Book the histograms for track-hit matching based on MC truth
+  meBTLTrackMatchedTPmtdDirectEta_ =
+      ibook.book1D("BTLTrackMatchedTPmtdDirectEta",
+                   "Eta of tracks matched to TP with sim hit in MTD (direct);#eta_{RECO}",
+                   30,
+                   0.,
+                   1.5);
+  meBTLTrackMatchedTPmtdDirectPt_ =
+      ibook.book1D("BTLTrackMatchedTPmtdDirectPt",
+                   "Pt of tracks matched to TP with sim hit in MTD (direct); track pt [GeV]",
+                   50,
+                   0.,
+                   10.);
+
+  meBTLTrackMatchedTPmtdOtherEta_ = ibook.book1D("BTLTrackMatchedTPmtdOtherEta",
+                                                 "Eta of tracks matched to TP with sim hit in MTD (other);#eta_{RECO}",
+                                                 30,
+                                                 0.,
+                                                 1.5);
+  meBTLTrackMatchedTPmtdOtherPt_ =
+      ibook.book1D("BTLTrackMatchedTPmtdOtherPt",
+                   "Pt of tracks matched to TP with sim hit in MTD (other); track pt [GeV]",
+                   50,
+                   0.,
+                   10.);
+
+  meBTLTrackMatchedTPnomtdEta_ = ibook.book1D(
+      "BTLTrackMatchedTPnomtdEta", "Eta of tracks matched to TP w/o sim hit in MTD;#eta_{RECO}", 30, 0., 1.5);
+  meBTLTrackMatchedTPnomtdPt_ = ibook.book1D(
+      "BTLTrackMatchedTPnomtdPt", "Pt of tracks matched to TP w/o sim hit in MTD; track pt [GeV]", 50, 0., 10.);
+
+  meBTLTrackMatchedTPmtdDirectCorrectAssocEta_ = ibook.book1D(
+      "BTLTrackMatchedTPmtdDirectCorrectAssocEta",
+      "Eta of tracks matched to TP with sim hit in MTD (direct), correct track-MTD association;#eta_{RECO}",
+      30,
+      0.,
+      1.5);
+  meBTLTrackMatchedTPmtdDirectCorrectAssocPt_ = ibook.book1D(
+      "BTLTrackMatchedTPmtdDirectCorrectAssocPt",
+      "Pt of tracks matched to TP with sim hit in MTD (direct) - correct track-MTD association;track pt [GeV]",
+      50,
+      0.,
+      10.);
+  meBTLTrackMatchedTPmtdDirectCorrectAssocMVAQual_ = ibook.book1D(
+      "BTLTrackMatchedTPmtdDirectCorrectAssocMVAQual",
+      "MVA of tracks matched to TP with sim hit in MTD (direct) - correct track-MTD association; MVA score",
+      100,
+      -1.,
+      1.);
+  meBTLTrackMatchedTPmtdDirectCorrectAssocTimeRes_ =
+      ibook.book1D("BTLTrackMatchedTPmtdDirectCorrectAssocTimeRes",
+                   "Time resolution of tracks matched to TP with sim hit in MTD (direct) - correct track-MTD "
+                   "association; t_{rec} - t_{sim} [ns] ",
+                   120,
+                   -0.15,
+                   0.15);
+  meBTLTrackMatchedTPmtdDirectCorrectAssocTimePull_ =
+      ibook.book1D("BTLTrackMatchedTPmtdDirectCorrectAssocTimePull",
+                   "Time pull of tracks matched to TP with sim hit in MTD (direct) - correct track-MTD association; "
+                   "(t_{rec}-t_{sim})/#sigma_{t}",
+                   50,
+                   -5.,
+                   5.);
+
+   meBTLTrackMatchedTPmtdDirectWrongAssocEta_ =
+      ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocEta",
+                   "Eta of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association;#eta_{RECO}",
+                   30,
+                   0.,
+                   1.5);
+  meBTLTrackMatchedTPmtdDirectWrongAssocPt_ = ibook.book1D(
+      "BTLTrackMatchedTPmtdDirectWrongAssocPt",
+      "Pt of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association;track pt [GeV]",
+      50,
+      0.,
+      10.);
+  meBTLTrackMatchedTPmtdDirectWrongAssocMVAQual_ =
+      ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocMVAQual",
+                   "MVA of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; MVA score",
+                   100,
+                   -1.,
+                   1.);
+  meBTLTrackMatchedTPmtdDirectWrongAssocTimeRes_ =
+      ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocTimeRes",
+                   "Time resolution of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD "
+                   "association; t_{rec} - t_{sim} [ns] ",
+                   120,
+                   -0.15,
+                   0.15);
+  meBTLTrackMatchedTPmtdDirectWrongAssocTimePull_ =
+      ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocTimePull",
+                   "Time pull of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; "
+                   "(t_{rec}-t_{sim})/#sigma_{t}",
+                   50,
+                   -5.,
+                   5.);
+
+  meBTLTrackMatchedTPmtdDirectNoAssocEta_ =
+      ibook.book1D("BTLTrackMatchedTPmtdDirectNoAssocEta",
+                   "Eta of tracks matched to TP with sim hit in MTD (direct) - no track-MTD association;#eta_{RECO}",
+                   30,
+                   0.,
+                   1.5);
+  meBTLTrackMatchedTPmtdDirectNoAssocPt_ =
+      ibook.book1D("BTLTrackMatchedTPmtdDirectNoAssocPt",
+                   "Pt of tracks matched to TP with sim hit in MTD (direct) - no track-MTD association;track pt [GeV]",
+                   50,
+                   0.,
+                   10.);
+
+  meBTLTrackMatchedTPmtdOtherCorrectAssocEta_ = ibook.book1D(
+      "BTLTrackMatchedTPmtdOtherCorrectAssocEta",
+      "Eta of tracks matched to TP with sim hit in MTD (direct), correct track-MTD association;#eta_{RECO}",
+      30,
+      0.,
+      1.5);
+  meBTLTrackMatchedTPmtdOtherCorrectAssocPt_ = ibook.book1D(
+      "BTLTrackMatchedTPmtdOtherCorrectAssocPt",
+      "Pt of tracks matched to TP with sim hit in MTD (direct) - correct track-MTD association;track pt [GeV]",
+      50,
+      0.,
+      10.);
+  meBTLTrackMatchedTPmtdOtherCorrectAssocMVAQual_ = ibook.book1D(
+      "BTLTrackMatchedTPmtdOtherCorrectAssocMVAQual",
+      "MVA of tracks matched to TP with sim hit in MTD (direct) - correct track-MTD association; MVA score",
+      100,
+      -1.,
+      1.);
+  meBTLTrackMatchedTPmtdOtherCorrectAssocTimeRes_ =
+      ibook.book1D("BTLTrackMatchedTPmtdOtherCorrectAssocTimeRes",
+                   "Time resolution of tracks matched to TP with sim hit in MTD (direct) - correct track-MTD "
+                   "association; t_{rec} - t_{sim} [ns] ",
+                   120,
+                   -0.15,
+                   0.15);
+  meBTLTrackMatchedTPmtdOtherCorrectAssocTimePull_ =
+      ibook.book1D("BTLTrackMatchedTPmtdOtherCorrectAssocTimePull",
+                   "Time pull of tracks matched to TP with sim hit in MTD (direct) - correct track-MTD association; "
+                   "(t_{rec}-t_{sim})/#sigma_{t}",
+                   50,
+                   -5.,
+                   5.);
+
+  meBTLTrackMatchedTPmtdOtherWrongAssocEta_ =
+      ibook.book1D("BTLTrackMatchedTPmtdOtherWrongAssocEta",
+                   "Eta of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association;#eta_{RECO}",
+                   30,
+                   0.,
+                   1.5);
+  meBTLTrackMatchedTPmtdOtherWrongAssocPt_ = ibook.book1D(
+      "BTLTrackMatchedTPmtdOtherWrongAssocPt",
+      "Pt of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association;track pt [GeV]",
+      50,
+      0.,
+      10.);
+  meBTLTrackMatchedTPmtdOtherWrongAssocMVAQual_ =
+      ibook.book1D("BTLTrackMatchedTPmtdOtherWrongAssocMVAQual",
+                   "MVA of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; MVA score",
+                   100,
+                   -1.,
+                   1.);
+  meBTLTrackMatchedTPmtdOtherWrongAssocTimeRes_ =
+      ibook.book1D("BTLTrackMatchedTPmtdOtherWrongAssocTimeRes",
+                   "Time resolution of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD "
+                   "association; t_{rec} - t_{sim} [ns] ",
+                   120,
+                   -0.15,
+                   0.15);
+  meBTLTrackMatchedTPmtdOtherWrongAssocTimePull_ =
+      ibook.book1D("BTLTrackMatchedTPmtdOtherWrongAssocTimePull",
+                   "Time pull of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; "
+                   "(t_{rec}-t_{sim})/#sigma_{t}",
+                   50,
+                   -5.,
+                   5.);
+
+  meBTLTrackMatchedTPmtdOtherNoAssocEta_ =
+      ibook.book1D("BTLTrackMatchedTPmtdOtherNoAssocEta",
+                   "Eta of tracks matched to TP with sim hit in MTD (direct) - no track-MTD association;#eta_{RECO}",
+                   30,
+                   0.,
+                   1.5);
+  meBTLTrackMatchedTPmtdOtherNoAssocPt_ =
+      ibook.book1D("BTLTrackMatchedTPmtdOtherNoAssocPt",
+                   "Pt of tracks matched to TP with sim hit in MTD (direct) - no track-MTD association;track pt [GeV]",
+                   50,
+                   0.,
+                   10.);
+  
+  meBTLTrackMatchedTPnomtdAssocEta_ =
+      ibook.book1D("BTLTrackMatchedTPnomtdAssocEta",
+                   "Eta of tracks matched to TP w/o sim hit in MTD, with associated reco cluster;#eta_{RECO}",
+                   30,
+                   0.,
+                   1.5);
+  meBTLTrackMatchedTPnomtdAssocPt_ =
+      ibook.book1D("BTLTrackMatchedTPnomtdAssocPt",
+                   "Pt of tracks matched to TP w/o sim hit in MTD, with associated reco cluster;track pt [GeV]",
+                   50,
+                   0.,
+                   10.);
+  meBTLTrackMatchedTPnomtdAssocMVAQual_ =
+      ibook.book1D("BTLTrackMatchedTPnomtdAssocMVAQual",
+                   "MVA of tracks matched to TP w/o sim hit in MTD, with associated reco cluster; MVA score",
+                   100,
+                   -1.,
+                   1.);
+  meBTLTrackMatchedTPnomtdAssocTimeRes_ = ibook.book1D("BTLTrackMatchedTPnomtdAssocTimeRes",
+                                                       "Time resolution of tracks matched to TP w/o sim hit in MTD, "
+                                                       "with associated reco cluster; t_{rec} - t_{sim} [ns] ",
+                                                       120,
+                                                       -0.15,
+                                                       0.15);
+  meBTLTrackMatchedTPnomtdAssocTimePull_ = ibook.book1D("BTLTrackMatchedTPnomtdAssocTimePull",
+                                                        "Time pull of tracks matched to TP w/o sim hit in MTD, with "
+                                                        "associated reco cluster; (t_{rec}-t_{sim})/#sigma_{t}",
+                                                        50,
+                                                        -5.,
+                                                        5.);
+
+
+  meETLTrackMatchedTPmtd1Eta_ = ibook.book1D("ETLTrackMatchedTPmtd1Eta",
+                                             "Eta of tracks matched to TP with sim hit in MTD (>= 1 hit);#eta_{RECO}",
+                                             30,
+                                             1.5,
+                                             3.0);
+  meETLTrackMatchedTPmtd1Pt_ = ibook.book1D("ETLTrackMatchedTPmtd1Pt",
+                                            "Pt of tracks matched to TP with sim hit in MTD (>= 1 hit); track pt [GeV]",
+                                            50,
+                                            0.,
+                                            10.);
+
+  meETLTrackMatchedTPmtd2Eta_ = ibook.book1D(
+      "ETLTrackMatchedTPmtd2Eta", "Eta of tracks matched to TP with sim hit in MTD (2 hits);#eta_{RECO}", 30, 1.5, 3.0);
+  meETLTrackMatchedTPmtd2Pt_ = ibook.book1D(
+      "ETLTrackMatchedTPmtd2Pt", "Pt of tracks matched to TP with sim hit in MTD (2 hits); track pt [GeV]", 50, 0., 10.);
+
+  meETLTrackMatchedTPnomtdEta_ = ibook.book1D(
+      "ETLTrackMatchedTPnomtdEta", "Eta of tracks matched to TP w/o sim hit in MTD;#eta_{RECO}", 30, 1.5, 3.0);
+  meETLTrackMatchedTPnomtdPt_ = ibook.book1D(
+      "ETLTrackMatchedTPnomtdPt", "Pt of tracks matched to TP w/o sim hit in MTD; track pt [GeV]", 50, 0., 10.);
+
+    meETLTrackMatchedTPmtd1CorrectAssocEta_ = ibook.book1D(
+      "ETLTrackMatchedTPmtd1CorrectAssocEta",
+      "Eta of tracks matched to TP with sim hit in MTD (>= 1 hit), correct track-MTD association;#eta_{RECO}",
+      30,
+      1.5,
+      3.0);
+  meETLTrackMatchedTPmtd1CorrectAssocPt_ = ibook.book1D(
+      "ETLTrackMatchedTPmtd1CorrectAssocPt",
+      "Pt of tracks matched to TP with sim hit in MTD (>= 1 hit) - correct track-MTD association;track pt [GeV]",
+      50,
+      0.,
+      10.);
+  meETLTrackMatchedTPmtd1CorrectAssocMVAQual_ = ibook.book1D(
+      "ETLTrackMatchedTPmtd1CorrectAssocMVAQual",
+      "MVA of tracks matched to TP with sim hit in MTD (>= 1 hit) - correct track-MTD association; MVA score",
+      100,
+      -1.,
+      1.);
+  meETLTrackMatchedTPmtd1CorrectAssocTimeRes_ =
+      ibook.book1D("ETLTrackMatchedTPmtd1CorrectAssocTimeRes",
+                   "Time resolution of tracks matched to TP with sim hit in MTD (>= 1 hit) - correct track-MTD "
+                   "association; t_{rec} - t_{sim} [ns] ",
+                   120,
+                   -0.15,
+                   0.15);
+  meETLTrackMatchedTPmtd1CorrectAssocTimePull_ =
+      ibook.book1D("ETLTrackMatchedTPmtd1CorrectAssocTimePull",
+                   "Time pull of tracks matched to TP with sim hit in MTD (>= 1 hit) - correct track-MTD association; "
+                   "(t_{rec}-t_{sim})/#sigma_{t}",
+                   50,
+                   -5.,
+                   5.);
+
+  meETLTrackMatchedTPmtd2CorrectAssocEta_ = ibook.book1D(
+      "ETLTrackMatchedTPmtd2CorrectAssocEta",
+      "Eta of tracks matched to TP with sim hit in MTD (2 hits), correct track-MTD association;#eta_{RECO}",
+      30,
+      1.5,
+      3.0);
+  meETLTrackMatchedTPmtd2CorrectAssocPt_ = ibook.book1D(
+      "ETLTrackMatchedTPmtd2CorrectAssocPt",
+      "Pt of tracks matched to TP with sim hit in MTD (2 hits) - correct track-MTD association;track pt [GeV]",
+      50,
+      0.,
+      10.);
+  meETLTrackMatchedTPmtd2CorrectAssocMVAQual_ = ibook.book1D(
+      "ETLTrackMatchedTPmtd2CorrectAssocMVAQual",
+      "MVA of tracks matched to TP with sim hit in MTD (2 hits) - correct track-MTD association; MVA score",
+      100,
+      -1.,
+      1.);
+  meETLTrackMatchedTPmtd2CorrectAssocTimeRes_ =
+      ibook.book1D("ETLTrackMatchedTPmtd2CorrectAssocTimeRes",
+                   "Time resolution of tracks matched to TP with sim hit in MTD (2 hits) - correct track-MTD "
+                   "association; t_{rec} - t_{sim} [ns] ",
+                   120,
+                   -0.15,
+                   0.15);
+  meETLTrackMatchedTPmtd2CorrectAssocTimePull_ =
+      ibook.book1D("ETLTrackMatchedTPmtd2CorrectAssocTimePull",
+                   "Time pull of tracks matched to TP with sim hit in MTD (2 hits) - correct track-MTD association; "
+                   "(t_{rec}-t_{sim})/#sigma_{t}",
+                   50,
+                   -5.,
+                   5.);
+
+   meETLTrackMatchedTPmtd1WrongAssocEta_ = ibook.book1D(
+      "ETLTrackMatchedTPmtd1WrongAssocEta",
+      "Eta of tracks matched to TP with sim hit in MTD (>= 1 hit), wrong track-MTD association;#eta_{RECO}",
+      30,
+      1.5,
+      3.0);
+  meETLTrackMatchedTPmtd1WrongAssocPt_ = ibook.book1D(
+      "ETLTrackMatchedTPmtd1WrongAssocPt",
+      "Pt of tracks matched to TP with sim hit in MTD (>= 1 hit) - wrong track-MTD association;track pt [GeV]",
+      50,
+      0.,
+      10.);
+ meETLTrackMatchedTPmtd1WrongAssocMVAQual_ = ibook.book1D(
+      "ETLTrackMatchedTPmtd1WrongAssocMVAQual",
+      "MVA of tracks matched to TP with sim hit in MTD (>= 1 hit) - wrong track-MTD association; MVA score",
+      100,
+      -1.,
+      1.);
+  meETLTrackMatchedTPmtd1WrongAssocTimeRes_ =
+      ibook.book1D("ETLTrackMatchedTPmtd1WrongAssocTimeRes",
+                   "Time resolution of tracks matched to TP with sim hit in MTD (>= 1 hit) - wrong track-MTD "
+                   "association; t_{rec} - t_{sim} [ns] ",
+                   120,
+                   -0.15,
+                   0.15);
+  meETLTrackMatchedTPmtd1WrongAssocTimePull_ =
+      ibook.book1D("ETLTrackMatchedTPmtd1WrongAssocTimePull",
+                   "Time pull of tracks matched to TP with sim hit in MTD (>= 1 hit) - wrong track-MTD association; "
+                   "(t_{rec}-t_{sim})/#sigma_{t}",
+                   50,
+                   -5.,
+                   5.);
+
+   meETLTrackMatchedTPmtd2WrongAssocEta_ =
+      ibook.book1D("ETLTrackMatchedTPmtd2WrongAssocEta",
+                   "Eta of tracks matched to TP with sim hit in MTD (2 hits), wrong track-MTD association;#eta_{RECO}",
+                   30,
+                   1.5,
+                   3.0);
+  meETLTrackMatchedTPmtd2WrongAssocPt_ = ibook.book1D(
+      "ETLTrackMatchedTPmtd2WrongAssocPt",
+      "Pt of tracks matched to TP with sim hit in MTD (2 hits) - wrong track-MTD association;track pt [GeV]",
+      50,
+      0.,
+      10.);
+  meETLTrackMatchedTPmtd2WrongAssocMVAQual_ =
+      ibook.book1D("ETLTrackMatchedTPmtd2WrongAssocMVAQual",
+                   "MVA of tracks matched to TP with sim hit in MTD (2 hits) - wrong track-MTD association; MVA score",
+                   100,
+                   -1.,
+                   1.);
+  meETLTrackMatchedTPmtd2WrongAssocTimeRes_ =
+      ibook.book1D("ETLTrackMatchedTPmtd2WrongAssocTimeRes",
+                   "Time resolution of tracks matched to TP with sim hit in MTD (2 hits) - wrong track-MTD "
+                   "association; t_{rec} - t_{sim} [ns] ",
+                   120,
+                   -0.15,
+                   0.15);
+  meETLTrackMatchedTPmtd2WrongAssocTimePull_ =
+      ibook.book1D("ETLTrackMatchedTPmtd2WrongAssocTimePull",
+                   "Time pull of tracks matched to TP with sim hit in MTD (2 hits) - wrong track-MTD association; "
+                   "(t_{rec}-t_{sim})/#sigma_{t}",
+                   50,
+                   -5.,
+                   5.);
+
+  meETLTrackMatchedTPmtd1NoAssocEta_ = ibook.book1D(
+      "ETLTrackMatchedTPmtd1NoAssocEta",
+      "Eta of tracks matched to TP with sim hit in MTD (>= 1 hit), missing track-MTD association;#eta_{RECO}",
+      30,
+      1.5,
+      3.0);
+  meETLTrackMatchedTPmtd1NoAssocPt_ = ibook.book1D(
+      "ETLTrackMatchedTPmtd1NoAssocPt",
+      "Pt of tracks matched to TP with sim hit in MTD (>= 1 hit) - missing track-MTD association;track pt [GeV]",
+      50,
+      0.,
+      10.);
+
+  meETLTrackMatchedTPmtd2NoAssocEta_ = ibook.book1D(
+      "ETLTrackMatchedTPmtd2NoAssocEta",
+      "Eta of tracks matched to TP with sim hit in MTD (2 hits), missing track-MTD association;#eta_{RECO}",
+      30,
+      1.5,
+      3.0);
+  meETLTrackMatchedTPmtd2NoAssocPt_ = ibook.book1D(
+      "ETLTrackMatchedTPmtd2NoAssocPt",
+      "Pt of tracks matched to TP with sim hit in MTD (2 hits) - missing track-MTD association;track pt [GeV]",
+      50,
+      0.,
+      10.);
+ meETLTrackMatchedTPnomtdAssocEta_ =
+      ibook.book1D("ETLTrackMatchedTPnomtdAssocEta",
+                   "Eta of tracks matched to TP w/o sim hit in MTD, with associated reco cluster;#eta_{RECO}",
+                   30,
+                   1.5,
+                   3.0);
+  meETLTrackMatchedTPnomtdAssocPt_ =
+      ibook.book1D("ETLTrackMatchedTPnomtdAssocPt",
+                   "Pt of tracks matched to TP w/o sim hit in MTD, with associated reco cluster;track pt [GeV]",
+                   50,
+                   0.,
+                   10.);
+  meETLTrackMatchedTPnomtdAssocMVAQual_ =
+      ibook.book1D("ETLTrackMatchedTPnomtdAssocMVAQual",
+                   "MVA of tracks matched to TP w/o sim hit in MTD, with associated reco cluster; MVA score",
+                   100,
+                   -1.,
+                   1.);
+  meETLTrackMatchedTPnomtdAssocTimeRes_ = ibook.book1D("ETLTrackMatchedTPnomtdAssocTimeRes",
+                                                       "Time resolution of tracks matched to TP w/o sim hit in MTD, "
+                                                       "with associated reco cluster; t_{rec} - t_{sim} [ns] ",
+                                                       120,
+                                                       -0.15,
+                                                       0.15);
+  meETLTrackMatchedTPnomtdAssocTimePull_ = ibook.book1D("ETLTrackMatchedTPnomtdAssocTimePull",
+                                                        "Time pull of tracks matched to TP w/o sim hit in MTD, with "
+                                                        "associated reco cluster; (t_{rec}-t_{sim})/#sigma_{t}",
+                                                        50,
+                                                        -5.,
+                                                        5.);
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
@@ -1227,6 +2063,7 @@ void MtdTracksValidation::fillDescriptions(edm::ConfigurationDescriptions& descr
   edm::ParameterSetDescription desc;
 
   desc.add<std::string>("folder", "MTD/Tracks");
+  desc.add<bool>("optionalPlots", false);
   desc.add<edm::InputTag>("inputTagG", edm::InputTag("generalTracks"));
   desc.add<edm::InputTag>("inputTagT", edm::InputTag("trackExtenderWithMTD"));
   desc.add<edm::InputTag>("inputTagV", edm::InputTag("offlinePrimaryVertices4D"));
@@ -1234,8 +2071,11 @@ void MtdTracksValidation::fillDescriptions(edm::ConfigurationDescriptions& descr
   desc.add<edm::InputTag>("SimTag", edm::InputTag("mix", "MergedTrackTruth"));
   desc.add<edm::InputTag>("TPtoRecoTrackAssoc", edm::InputTag("trackingParticleRecoTrackAsssociation"));
   desc.add<edm::InputTag>("tp2SimAssociationMapTag", edm::InputTag("mtdSimLayerClusterToTPAssociation"));
+  desc.add<edm::InputTag>("r2sAssociationMapTag", edm::InputTag("mtdRecoClusterToSimLayerClusterAssociation"));
   desc.add<edm::InputTag>("btlRecHits", edm::InputTag("mtdRecHits", "FTLBarrel"));
   desc.add<edm::InputTag>("etlRecHits", edm::InputTag("mtdRecHits", "FTLEndcap"));
+  desc.add<edm::InputTag>("recCluTagBTL", edm::InputTag("mtdClusters", "FTLBarrel"));
+  desc.add<edm::InputTag>("recCluTagETL", edm::InputTag("mtdClusters", "FTLEndcap"));
   desc.add<edm::InputTag>("tmtd", edm::InputTag("trackExtenderWithMTD:generalTracktmtd"));
   desc.add<edm::InputTag>("sigmatmtd", edm::InputTag("trackExtenderWithMTD:generalTracksigmatmtd"));
   desc.add<edm::InputTag>("t0Src", edm::InputTag("trackExtenderWithMTD:generalTrackt0"));
@@ -1307,6 +2147,26 @@ const edm::Ref<std::vector<TrackingParticle>>* MtdTracksValidation::getMatchedTP
 
   // reco track not matched to any TP from vertex
   return nullptr;
+}
+
+void MtdTracksValidation::fillTrackClusterMatchingHistograms(MonitorElement* me1,
+                                                             MonitorElement* me2,
+                                                             MonitorElement* me3,
+                                                             MonitorElement* me4,
+                                                             MonitorElement* me5,
+                                                             float var1,
+                                                             float var2,
+                                                             float var3,
+                                                             float var4,
+                                                             float var5,
+                                                             bool flag) {
+  me1->Fill(var1);
+  me2->Fill(var2);
+  if (flag) {
+    me3->Fill(var3);
+    me4->Fill(var4);
+    me5->Fill(var5);
+  }
 }
 
 DEFINE_FWK_MODULE(MtdTracksValidation);

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -266,7 +266,7 @@ private:
   MonitorElement* meExtraBTLeneInCone_;
   MonitorElement* meExtraMTDfailExtenderEta_;
   MonitorElement* meExtraMTDfailExtenderPt_;
-  
+
   // ====== Trak-cluster matching based on MC truth
   // - BTL TPmtd Direct, TPmtd Other, TPnomtd
   MonitorElement* meBTLTrackMatchedTPmtdDirectEta_;
@@ -317,14 +317,14 @@ private:
   MonitorElement* meBTLTrackMatchedTPnomtdAssocTimeRes_;
   MonitorElement* meBTLTrackMatchedTPnomtdAssocTimePull_;
 
-   // - ETL: one, two o no sim hits
+  // - ETL: one, two o no sim hits
   MonitorElement* meETLTrackMatchedTPmtd1Eta_;  // -- sim hit in >=1 etl disk
   MonitorElement* meETLTrackMatchedTPmtd1Pt_;
   MonitorElement* meETLTrackMatchedTPmtd2Eta_;  // -- sim hits in 2 etl disks
   MonitorElement* meETLTrackMatchedTPmtd2Pt_;
   MonitorElement* meETLTrackMatchedTPnomtdEta_;  // -- no sim hits in etl
   MonitorElement* meETLTrackMatchedTPnomtdPt_;
-  
+
   // - ETL >=1 sim hit: each correct, at least one wrong, each sim hit missing reco association
   MonitorElement* meETLTrackMatchedTPmtd1CorrectAssocEta_;
   MonitorElement* meETLTrackMatchedTPmtd1CorrectAssocPt_;
@@ -369,7 +369,6 @@ private:
   MonitorElement* meETLTrackMatchedTPnomtdAssocMVAQual_;
   MonitorElement* meETLTrackMatchedTPnomtdAssocTimeRes_;
   MonitorElement* meETLTrackMatchedTPnomtdAssocTimePull_;
-
 };
 
 // ------------ constructor and destructor --------------
@@ -431,14 +430,14 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
 
   auto btlRecCluHandle = makeValid(iEvent.getHandle(btlRecCluToken_));
   auto etlRecCluHandle = makeValid(iEvent.getHandle(etlRecCluToken_));
-  
+
   std::unordered_map<uint32_t, MTDHit> m_btlHits;
   std::unordered_map<uint32_t, MTDHit> m_etlHits;
   std::unordered_map<uint32_t, std::set<unsigned long int>> m_btlTrkPerCell;
   std::unordered_map<uint32_t, std::set<unsigned long int>> m_etlTrkPerCell;
   const auto& tp2SimAssociationMap = iEvent.get(tp2SimAssociationMapToken_);
   const auto& r2sAssociationMap = iEvent.get(r2sAssociationMapToken_);
- 
+
   const auto& tMtd = iEvent.get(tmtdToken_);
   const auto& SigmatMtd = iEvent.get(SigmatmtdToken_);
   const auto& t0Src = iEvent.get(t0SrcToken_);
@@ -510,7 +509,7 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
       bool MTDEtlZposD1 = false;
       bool MTDEtlZposD2 = false;
       std::vector<edm::Ref<edmNew::DetSetVector<FTLCluster>, FTLCluster>> recoClustersRefs;
-      
+
       if (std::abs(trackGen.eta()) < trackMaxBtlEta_) {
         // --- all BTL tracks (with and without hit in MTD) ---
         meBTLTrackEtaTot_->Fill(std::abs(trackGen.eta()));
@@ -526,7 +525,7 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
           if ((Hit.det() == 6) && (Hit.subdetId() == 1) && (Hit.mtdSubDetector() == 1)) {
             MTDBtl = true;
             numMTDBtlvalidhits++;
-	    const auto* mtdhit = static_cast<const MTDTrackingRecHit*>(hit);
+            const auto* mtdhit = static_cast<const MTDTrackingRecHit*>(hit);
             const auto& hitCluster = mtdhit->mtdCluster();
             if (hitCluster.size() != 0) {
               auto recoClusterRef = edmNew::makeRefTo(btlRecCluHandle, &hitCluster);
@@ -552,11 +551,11 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
 
       else {
         // --- all ETL tracks (with and without hit in MTD) ---
-	meETLTrackEtaTot_->Fill(std::abs(trackGen.eta()));
+        meETLTrackEtaTot_->Fill(std::abs(trackGen.eta()));
         meETLTrackPhiTot_->Fill(trackGen.phi());
         meETLTrackPtTot_->Fill(trackGen.pt());
-	
-	int numMTDEtlvalidhits = 0;
+
+        int numMTDEtlvalidhits = 0;
         for (const auto hit : track.recHits()) {
           if (hit->isValid() == false)
             continue;
@@ -565,7 +564,7 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
             isETL = true;
             ETLDetId ETLHit = hit->geographicalId();
 
-	    const auto* mtdhit = static_cast<const MTDTrackingRecHit*>(hit);
+            const auto* mtdhit = static_cast<const MTDTrackingRecHit*>(hit);
             const auto& hitCluster = mtdhit->mtdCluster();
             if (hitCluster.size() != 0) {
               auto recoClusterRef = edmNew::makeRefTo(etlRecCluHandle, &hitCluster);
@@ -604,10 +603,10 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
         }
 
         // --- keeping only tracks with last hit in MTD ---
-	ETLdisc1 = (MTDEtlZnegD1 || MTDEtlZposD1);
+        ETLdisc1 = (MTDEtlZnegD1 || MTDEtlZposD1);
         ETLdisc2 = (MTDEtlZnegD2 || MTDEtlZposD2);
         twoETLdiscs =
-	  ((MTDEtlZnegD1 == true) && (MTDEtlZnegD2 == true)) || ((MTDEtlZposD1 == true) && (MTDEtlZposD2 == true));
+            ((MTDEtlZnegD1 == true) && (MTDEtlZnegD2 == true)) || ((MTDEtlZposD1 == true) && (MTDEtlZposD2 == true));
         if (ETLdisc1 || ETLdisc2) {
           meETLTrackEtaMtd_->Fill(std::abs(trackGen.eta()));
           meETLTrackPhiMtd_->Fill(trackGen.phi());
@@ -633,50 +632,53 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
       const reco::TrackBaseRef trkrefb(trackref);
       auto tp_info = getMatchedTP(trkrefb);
       if (tp_info != nullptr && trkTPSelAll(**tp_info)) {
-	// -- pT resolution plots
+        // -- pT resolution plots
         if (optionalPlots_) {
-	  if (trackGen.pt() < trackMaxPt_) {
-	    if (isBTL) {
-	      meBTLTrackMatchedTPPtResMtd_->Fill(std::abs(track.pt() - (*tp_info)->pt()) /
-						 std::abs(trackGen.pt() - (*tp_info)->pt()));
-	      meBTLTrackMatchedTPPtRatioGen_->Fill(trackGen.pt() / (*tp_info)->pt());
-	      meBTLTrackMatchedTPPtRatioMtd_->Fill(track.pt() / (*tp_info)->pt());
-	      meBTLTrackMatchedTPPtResvsPtMtd_->Fill(
-						     (*tp_info)->pt(), std::abs(track.pt() - (*tp_info)->pt()) / std::abs(trackGen.pt() - (*tp_info)->pt()));
-	      meBTLTrackMatchedTPDPtvsPtGen_->Fill((*tp_info)->pt(),
-						   (trackGen.pt() - (*tp_info)->pt()) / (*tp_info)->pt());
-	      meBTLTrackMatchedTPDPtvsPtMtd_->Fill((*tp_info)->pt(), (track.pt() - (*tp_info)->pt()) / (*tp_info)->pt());
-	    }
-	    if (isETL && !twoETLdiscs && (std::abs(trackGen.eta()) > trackMinEtlEta_) &&
-		(std::abs(trackGen.eta()) < trackMaxEtlEta_)) {
-	      meETLTrackMatchedTPPtResMtd_->Fill(std::abs(track.pt() - (*tp_info)->pt()) /
-						 std::abs(trackGen.pt() - (*tp_info)->pt()));
-	      meETLTrackMatchedTPPtRatioGen_->Fill(trackGen.pt() / (*tp_info)->pt());
-	      meETLTrackMatchedTPPtRatioMtd_->Fill(track.pt() / (*tp_info)->pt());
-	      meETLTrackMatchedTPPtResvsPtMtd_->Fill(
-						     (*tp_info)->pt(), std::abs(track.pt() - (*tp_info)->pt()) / std::abs(trackGen.pt() - (*tp_info)->pt()));
-	      meETLTrackMatchedTPDPtvsPtGen_->Fill((*tp_info)->pt(),
-						   (trackGen.pt() - (*tp_info)->pt()) / ((*tp_info)->pt()));
-	      meETLTrackMatchedTPDPtvsPtMtd_->Fill((*tp_info)->pt(),
-						   (track.pt() - (*tp_info)->pt()) / ((*tp_info)->pt()));
-	    }
-	    if (isETL && twoETLdiscs) {
-	      meETLTrackMatchedTP2PtResMtd_->Fill(std::abs(track.pt() - (*tp_info)->pt()) /
-						  std::abs(trackGen.pt() - (*tp_info)->pt()));
-	      meETLTrackMatchedTP2PtRatioGen_->Fill(trackGen.pt() / (*tp_info)->pt());
-	      meETLTrackMatchedTP2PtRatioMtd_->Fill(track.pt() / (*tp_info)->pt());
-	      meETLTrackMatchedTP2PtResvsPtMtd_->Fill(
-						      (*tp_info)->pt(), std::abs(track.pt() - (*tp_info)->pt()) / std::abs(trackGen.pt() - (*tp_info)->pt()));
-	      meETLTrackMatchedTP2DPtvsPtGen_->Fill((*tp_info)->pt(),
-						    (trackGen.pt() - (*tp_info)->pt()) / ((*tp_info)->pt()));
-	      meETLTrackMatchedTP2DPtvsPtMtd_->Fill((*tp_info)->pt(),
-						    (track.pt() - (*tp_info)->pt()) / ((*tp_info)->pt()));
-	    }
-	  }
-	}
+          if (trackGen.pt() < trackMaxPt_) {
+            if (isBTL) {
+              meBTLTrackMatchedTPPtResMtd_->Fill(std::abs(track.pt() - (*tp_info)->pt()) /
+                                                 std::abs(trackGen.pt() - (*tp_info)->pt()));
+              meBTLTrackMatchedTPPtRatioGen_->Fill(trackGen.pt() / (*tp_info)->pt());
+              meBTLTrackMatchedTPPtRatioMtd_->Fill(track.pt() / (*tp_info)->pt());
+              meBTLTrackMatchedTPPtResvsPtMtd_->Fill(
+                  (*tp_info)->pt(),
+                  std::abs(track.pt() - (*tp_info)->pt()) / std::abs(trackGen.pt() - (*tp_info)->pt()));
+              meBTLTrackMatchedTPDPtvsPtGen_->Fill((*tp_info)->pt(),
+                                                   (trackGen.pt() - (*tp_info)->pt()) / (*tp_info)->pt());
+              meBTLTrackMatchedTPDPtvsPtMtd_->Fill((*tp_info)->pt(),
+                                                   (track.pt() - (*tp_info)->pt()) / (*tp_info)->pt());
+            }
+            if (isETL && !twoETLdiscs && (std::abs(trackGen.eta()) > trackMinEtlEta_) &&
+                (std::abs(trackGen.eta()) < trackMaxEtlEta_)) {
+              meETLTrackMatchedTPPtResMtd_->Fill(std::abs(track.pt() - (*tp_info)->pt()) /
+                                                 std::abs(trackGen.pt() - (*tp_info)->pt()));
+              meETLTrackMatchedTPPtRatioGen_->Fill(trackGen.pt() / (*tp_info)->pt());
+              meETLTrackMatchedTPPtRatioMtd_->Fill(track.pt() / (*tp_info)->pt());
+              meETLTrackMatchedTPPtResvsPtMtd_->Fill(
+                  (*tp_info)->pt(),
+                  std::abs(track.pt() - (*tp_info)->pt()) / std::abs(trackGen.pt() - (*tp_info)->pt()));
+              meETLTrackMatchedTPDPtvsPtGen_->Fill((*tp_info)->pt(),
+                                                   (trackGen.pt() - (*tp_info)->pt()) / ((*tp_info)->pt()));
+              meETLTrackMatchedTPDPtvsPtMtd_->Fill((*tp_info)->pt(),
+                                                   (track.pt() - (*tp_info)->pt()) / ((*tp_info)->pt()));
+            }
+            if (isETL && twoETLdiscs) {
+              meETLTrackMatchedTP2PtResMtd_->Fill(std::abs(track.pt() - (*tp_info)->pt()) /
+                                                  std::abs(trackGen.pt() - (*tp_info)->pt()));
+              meETLTrackMatchedTP2PtRatioGen_->Fill(trackGen.pt() / (*tp_info)->pt());
+              meETLTrackMatchedTP2PtRatioMtd_->Fill(track.pt() / (*tp_info)->pt());
+              meETLTrackMatchedTP2PtResvsPtMtd_->Fill(
+                  (*tp_info)->pt(),
+                  std::abs(track.pt() - (*tp_info)->pt()) / std::abs(trackGen.pt() - (*tp_info)->pt()));
+              meETLTrackMatchedTP2DPtvsPtGen_->Fill((*tp_info)->pt(),
+                                                    (trackGen.pt() - (*tp_info)->pt()) / ((*tp_info)->pt()));
+              meETLTrackMatchedTP2DPtvsPtMtd_->Fill((*tp_info)->pt(),
+                                                    (track.pt() - (*tp_info)->pt()) / ((*tp_info)->pt()));
+            }
+          }
+        }
 
-
-	// -- Track matched to TP: all and with last hit in MTD                                                                                                                                                   
+        // -- Track matched to TP: all and with last hit in MTD
         if (std::abs(trackGen.eta()) < trackMaxBtlEta_) {
           meBTLTrackMatchedTPEtaTot_->Fill(std::abs(trackGen.eta()));
           meBTLTrackMatchedTPPtTot_->Fill(trackGen.pt());
@@ -704,7 +706,7 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
           }
         }
 
-	bool hasTime = false;
+        bool hasTime = false;
         double tsim = (*tp_info)->parentVertex()->position().t() * simUnit_;
         double dT(-9999.);
         double pullT(-9999.);
@@ -714,7 +716,7 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
           hasTime = true;
         }
 
- // ==  MC truth matching                                                                                                                                                                                  
+        // ==  MC truth matching
         bool isTPmtdDirectBTL = false, isTPmtdOtherBTL = false, isTPmtdDirectCorrectBTL = false,
              isTPmtdOtherCorrectBTL = false, isTPmtdETLD1 = false, isTPmtdETLD2 = false, isTPmtdCorrectETLD1 = false,
              isTPmtdCorrectETLD2 = false;
@@ -738,13 +740,13 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
             }
           }
 
-	  // === BTL
+          // === BTL
           // -- Sort BTL sim clusters by time
           std::vector<edm::Ref<MtdSimLayerClusterCollection>>::iterator directSimClusIt;
           if (std::abs(trackGen.eta()) < trackMaxBtlEta_ && !simClustersRefs.empty()) {
             std::sort(simClustersRefs.begin(), simClustersRefs.end(), [](const auto& a, const auto& b) {
               return a->simLCTime() < b->simLCTime();
-								      });
+            });
             // Find the first direct hit in time
             directSimClusIt = std::find_if(simClustersRefs.begin(), simClustersRefs.end(), [](const auto& simCluster) {
               return simCluster->trackIdOffset() == 0;
@@ -759,7 +761,7 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
             }
           }
 
-	  // ==  Check if the track-cluster association is correct: Track->RecoClus->SimClus == Track->TP->SimClus
+          // ==  Check if the track-cluster association is correct: Track->RecoClus->SimClus == Track->TP->SimClus
           for (const auto& recClusterRef : recoClustersRefs) {
             if (recClusterRef.isNonnull()) {
               auto itp = r2sAssociationMap.equal_range(recClusterRef);
@@ -793,8 +795,8 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
               }
             }
           }  /// end loop over reco clusters associated to this track.
-	  
-	  // == BTL
+
+          // == BTL
           if (std::abs(trackGen.eta()) < trackMaxBtlEta_) {
             // -- Track matched to TP with sim hit in MTD
             if (isTPmtdDirectBTL) {
@@ -822,7 +824,7 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
                                                      hasTime);
                 }
                 // -- Track matched to TP with sim hit (direct), incorrectly associated reco cluster
-		else {
+                else {
                   fillTrackClusterMatchingHistograms(meBTLTrackMatchedTPmtdDirectWrongAssocEta_,
                                                      meBTLTrackMatchedTPmtdDirectWrongAssocPt_,
                                                      meBTLTrackMatchedTPmtdDirectWrongAssocMVAQual_,
@@ -837,7 +839,7 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
                 }
               }
               // -- Track matched to TP with sim hit (other), correctly associated reco cluster
-	       else if (isTPmtdOtherBTL) {
+              else if (isTPmtdOtherBTL) {
                 if (isTPmtdOtherCorrectBTL) {
                   fillTrackClusterMatchingHistograms(meBTLTrackMatchedTPmtdOtherCorrectAssocEta_,
                                                      meBTLTrackMatchedTPmtdOtherCorrectAssocPt_,
@@ -868,7 +870,7 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
               }
             }
             // -- Track matched to TP with sim hit in MTD, missing associated reco cluster
-	     else {
+            else {
               if (isTPmtdDirectBTL) {
                 meBTLTrackMatchedTPmtdDirectNoAssocEta_->Fill(std::abs(trackGen.eta()));
                 meBTLTrackMatchedTPmtdDirectNoAssocPt_->Fill(trackGen.pt());
@@ -877,8 +879,8 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
                 meBTLTrackMatchedTPmtdOtherNoAssocPt_->Fill(trackGen.pt());
               }
             }
-	  }  // == end BTL
-	  // == ETL
+          }  // == end BTL
+          // == ETL
           else {
             // -- Track matched to TP with sim hit in one etl layer
             if (isTPmtdETLD1 || isTPmtdETLD2) {  // at least one hit (D1 or D2 or both)
@@ -911,7 +913,7 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
                                                      hasTime);
                 }
                 // - at least one reco hit is incorrectly associated or, if two sim hits, one reco hit is missing
-		else if ((isTPmtdETLD1 && !isTPmtdCorrectETLD1) || (isTPmtdETLD2 && !isTPmtdCorrectETLD2)) {
+                else if ((isTPmtdETLD1 && !isTPmtdCorrectETLD1) || (isTPmtdETLD2 && !isTPmtdCorrectETLD2)) {
                   fillTrackClusterMatchingHistograms(meETLTrackMatchedTPmtd1WrongAssocEta_,
                                                      meETLTrackMatchedTPmtd1WrongAssocPt_,
                                                      meETLTrackMatchedTPmtd1WrongAssocMVAQual_,
@@ -925,7 +927,7 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
                                                      hasTime);
                 }
               }
-	      // -- Track matched to TP with sim hits in both etl layers (D1 and D2)
+              // -- Track matched to TP with sim hits in both etl layers (D1 and D2)
               if (isTPmtdETLD1 && isTPmtdETLD2) {
                 // - each hit correctly associated to the track
                 if (ETLdisc1 && ETLdisc2 && isTPmtdCorrectETLD1 && isTPmtdCorrectETLD2) {
@@ -942,7 +944,7 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
                                                      hasTime);
                 }
                 // - at least one reco hit incorrectly associated or one hit missing
-		else if ((ETLdisc1 || ETLdisc2) && (!isTPmtdCorrectETLD1 || !isTPmtdCorrectETLD2)) {
+                else if ((ETLdisc1 || ETLdisc2) && (!isTPmtdCorrectETLD1 || !isTPmtdCorrectETLD2)) {
                   fillTrackClusterMatchingHistograms(meETLTrackMatchedTPmtd2WrongAssocEta_,
                                                      meETLTrackMatchedTPmtd2WrongAssocPt_,
                                                      meETLTrackMatchedTPmtd2WrongAssocMVAQual_,
@@ -958,9 +960,9 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
               }
             }
             // -- Missing association with reco hits in MTD
-	    else {
+            else {
               // -- Track matched to TP with sim hit in >=1 etl layers, no reco hits associated to the track
-	      if (isTPmtdETLD1 || isTPmtdETLD2) {
+              if (isTPmtdETLD1 || isTPmtdETLD2) {
                 meETLTrackMatchedTPmtd1NoAssocEta_->Fill(std::abs(trackGen.eta()));
                 meETLTrackMatchedTPmtd1NoAssocPt_->Fill(trackGen.pt());
               }
@@ -971,9 +973,9 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
               }
             }
           }  // == end ETL
-	}  // --- end "withMTD" 
+        }  // --- end "withMTD"
 
-	// - Track matched to TP without sim hit in MTD, but with reco cluster associated
+        // - Track matched to TP without sim hit in MTD, but with reco cluster associated
         // - BTL
         if (std::abs(trackGen.eta()) < trackMaxBtlEta_) {
           if (!isTPmtdDirectBTL && !isTPmtdOtherBTL) {
@@ -994,7 +996,7 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
             }
           }
         }
-	// - ETL
+        // - ETL
         else if (!isTPmtdETLD1 && !isTPmtdETLD2) {
           meETLTrackMatchedTPnomtdEta_->Fill(std::abs(trackGen.eta()));
           meETLTrackMatchedTPnomtdPt_->Fill(trackGen.pt());
@@ -1013,7 +1015,6 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
           }
         }
 
-	
         // == Time pull and detailed extrapolation check only on tracks associated to TP from signal event
         if (!trkTPSelLV(**tp_info)) {
           continue;
@@ -1054,8 +1055,8 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
         }  // detailed extrapolation check
 
         // time res and time pull
-	if (Sigmat0Safe[trackref] != -1.) {
-	  if (isBTL || isETL) {
+        if (Sigmat0Safe[trackref] != -1.) {
+          if (isBTL || isETL) {
             meTrackResTot_->Fill(dT);
             meTrackPullTot_->Fill(pullT);
             meTrackResTotvsMVAQual_->Fill(mtdQualMVA[trackref], dT);
@@ -1423,7 +1424,6 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
   meTrackMatchedTPPtTotLV_ =
       ibook.book1D("MatchedTPPtTotLV", "Pt of tracks associated to LV matched to TP; track pt [GeV] ", 110, 0., 11.);
 
-  
   meBTLTrackMatchedTPEtaTot_ =
       ibook.book1D("BTLTrackMatchedTPEtaTot", "Eta of tracks matched to TP; track eta ", 30, 0., 1.5);
   meBTLTrackMatchedTPEtaMtd_ =
@@ -1445,7 +1445,6 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
   meETLTrackMatchedTPPt2Mtd_ = ibook.book1D(
       "ETLTrackMatchedTPPt2Mtd", "Pt of tracks matched to TP with time (2 ETL hits); track pt [GeV] ", 50, 0., 10.);
 
-  
   if (optionalPlots_) {
     meBTLTrackMatchedTPPtResMtd_ = ibook.book1D(
         "TrackMatchedTPBTLPtResMtd",
@@ -1489,7 +1488,7 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
                      100,
                      0.9,
                      1.1);
-  meBTLTrackMatchedTPPtResvsPtMtd_ =
+    meBTLTrackMatchedTPPtResvsPtMtd_ =
         ibook.bookProfile("TrackMatchedTPBTLPtResvsPtMtd",
                           "Pt resolution of tracks matched to TP-BTL hit vs Pt;pT_{truth} "
                           "[GeV];|pT_{MTDtrack}-pT_{truth}|/|pT_{Gentrack}-pT_{truth}| ",
@@ -1511,7 +1510,7 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
                           "s");
     meETLTrackMatchedTP2PtResvsPtMtd_ =
         ibook.bookProfile("TrackMatchedTPETL2PtResvsPtMtd",
-                        "Pt resolution of tracks matched to TP-ETL 2hits Pt pT;pT_{truth} "
+                          "Pt resolution of tracks matched to TP-ETL 2hits Pt pT;pT_{truth} "
                           "[GeV];|pT_{MTDtrack}-pT_{truth}|/|pT_{Gentrack}-pT_{truth}| ",
                           20,
                           0.7,
@@ -1519,7 +1518,7 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
                           0.,
                           4.,
                           "s");
-   meBTLTrackMatchedTPDPtvsPtGen_ = ibook.bookProfile(
+    meBTLTrackMatchedTPDPtvsPtGen_ = ibook.bookProfile(
         "TrackMatchedTPBTLDPtvsPtGen",
         "Pt relative difference of Gentracks (BTL) vs Pt;pT_{truth} [GeV];pT_{Gentrack}-pT_{truth}/pT_{truth} ",
         20,
@@ -1573,8 +1572,8 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
                                                         -0.1,
                                                         0.1,
                                                         "s");
-  } // end optional plots
- 
+  }  // end optional plots
+
   meTrackResTot_ = ibook.book1D(
       "TrackRes", "t_{rec} - t_{sim} for LV associated tracks matched to TP; t_{rec} - t_{sim} [ns] ", 120, -0.15, 0.15);
   meTrackPullTot_ = ibook.book1D(
@@ -1690,7 +1689,7 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
                    -5.,
                    5.);
 
-   meBTLTrackMatchedTPmtdDirectWrongAssocEta_ =
+  meBTLTrackMatchedTPmtdDirectWrongAssocEta_ =
       ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocEta",
                    "Eta of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association;#eta_{RECO}",
                    30,
@@ -1814,7 +1813,7 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
                    50,
                    0.,
                    10.);
-  
+
   meBTLTrackMatchedTPnomtdAssocEta_ =
       ibook.book1D("BTLTrackMatchedTPnomtdAssocEta",
                    "Eta of tracks matched to TP w/o sim hit in MTD, with associated reco cluster;#eta_{RECO}",
@@ -1846,7 +1845,6 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
                                                         -5.,
                                                         5.);
 
-
   meETLTrackMatchedTPmtd1Eta_ = ibook.book1D("ETLTrackMatchedTPmtd1Eta",
                                              "Eta of tracks matched to TP with sim hit in MTD (>= 1 hit);#eta_{RECO}",
                                              30,
@@ -1868,7 +1866,7 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
   meETLTrackMatchedTPnomtdPt_ = ibook.book1D(
       "ETLTrackMatchedTPnomtdPt", "Pt of tracks matched to TP w/o sim hit in MTD; track pt [GeV]", 50, 0., 10.);
 
-    meETLTrackMatchedTPmtd1CorrectAssocEta_ = ibook.book1D(
+  meETLTrackMatchedTPmtd1CorrectAssocEta_ = ibook.book1D(
       "ETLTrackMatchedTPmtd1CorrectAssocEta",
       "Eta of tracks matched to TP with sim hit in MTD (>= 1 hit), correct track-MTD association;#eta_{RECO}",
       30,
@@ -1934,7 +1932,7 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
                    -5.,
                    5.);
 
-   meETLTrackMatchedTPmtd1WrongAssocEta_ = ibook.book1D(
+  meETLTrackMatchedTPmtd1WrongAssocEta_ = ibook.book1D(
       "ETLTrackMatchedTPmtd1WrongAssocEta",
       "Eta of tracks matched to TP with sim hit in MTD (>= 1 hit), wrong track-MTD association;#eta_{RECO}",
       30,
@@ -1946,7 +1944,7 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
       50,
       0.,
       10.);
- meETLTrackMatchedTPmtd1WrongAssocMVAQual_ = ibook.book1D(
+  meETLTrackMatchedTPmtd1WrongAssocMVAQual_ = ibook.book1D(
       "ETLTrackMatchedTPmtd1WrongAssocMVAQual",
       "MVA of tracks matched to TP with sim hit in MTD (>= 1 hit) - wrong track-MTD association; MVA score",
       100,
@@ -1967,7 +1965,7 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
                    -5.,
                    5.);
 
-   meETLTrackMatchedTPmtd2WrongAssocEta_ =
+  meETLTrackMatchedTPmtd2WrongAssocEta_ =
       ibook.book1D("ETLTrackMatchedTPmtd2WrongAssocEta",
                    "Eta of tracks matched to TP with sim hit in MTD (2 hits), wrong track-MTD association;#eta_{RECO}",
                    30,
@@ -2025,7 +2023,7 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
       50,
       0.,
       10.);
- meETLTrackMatchedTPnomtdAssocEta_ =
+  meETLTrackMatchedTPnomtdAssocEta_ =
       ibook.book1D("ETLTrackMatchedTPnomtdAssocEta",
                    "Eta of tracks matched to TP w/o sim hit in MTD, with associated reco cluster;#eta_{RECO}",
                    30,


### PR DESCRIPTION
#### PR description:
This PR provides an update of the MtdTracksValidation class, including
- the addition of new histograms and track-MTD hit efficiency plots based on recent studies made by  P. Solanki for different MTD sim hit categories (see for example:https://indico.cern.ch/event/1458405/#8-track-mtd-cluster-matching-s)
- a redefinition of some histogram ranges and binning optimisation

#### PR validation:
Code compiles, runs and produces the desired plots. It was tested on the following samples:
- SingleMuPt10: /store/relval/CMSSW_14_2_0_pre2/RelValSingleMuPt10/GEN-SIM-RECO/141X_mcRun4_realistic_v1_STD_RegeneratedGS_2026D110_noPU-v1/2580000/f3bc2ac7-6d7f-4fd5-ab55-a10c375be68e.root
- MinBias: /store/relval/CMSSW_14_2_0_pre2/RelValMinBias_14TeV/GEN-SIM-RECO/141X_mcRun4_realistic_v1_STD_RegeneratedGS_2026D110_noPU-v1/2580000/ed421aa3-3974-4c13-8318-39034e4b96be.root

