### PR TITLE
Remove the use of `hls` external from Calibration/HcalAlCaRecoProducers as unnecessary

### DIFF
--- a/Calibration/HcalAlCaRecoProducers/plugins/BuildFile.xml
+++ b/Calibration/HcalAlCaRecoProducers/plugins/BuildFile.xml
@@ -26,7 +26,6 @@
 <use name="TrackPropagation/SteppingHelixPropagator"/>
 <use name="rootphysics"/>
 <use name="boost"/>
-<use name="hls"/>
 <use name="clhep"/>
 <use name="root"/>
 <library file="*.cc" name="CalibrationHcalAlCaRecoProducersPlugins">


### PR DESCRIPTION
#### PR description:

Came up while looking what packages use `hls`.

Resolves https://github.com/cms-sw/framework-team/issues/1077

#### PR validation:

Code compiles