### PR TITLE
MTD geometry: update unit tests for default Phase2 scenario definition

### DIFF
--- a/RecoMTD/DetLayers/test/mtd_cfg.py
+++ b/RecoMTD/DetLayers/test/mtd_cfg.py
@@ -1,8 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
+from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
 
-process = cms.Process("GeometryTest",Phase2C17I13M9)
+process = cms.Process("GeometryTest",_PH2_ERA,dd4hep)
 
 process.source = cms.Source("EmptySource")
 
@@ -54,7 +56,7 @@ process.MessageLogger.files.mtdDetLayerGeometry = cms.untracked.PSet(
     threshold = cms.untracked.string('INFO'))
 
 # Choose Tracker Geometry
-process.load("Configuration.Geometry.GeometryExtendedRun4D110Reco_cff")
+process.load("Configuration.Geometry.GeometryDD4hepExtendedRun4DefaultReco_cff")
 process.load("MagneticField.Engine.volumeBasedMagneticField_160812_cfi")
 
 process.Timing = cms.Service("Timing")

--- a/SimG4CMS/Forward/test/python/runMTDSens_DD4hep_cfg.py
+++ b/SimG4CMS/Forward/test/python/runMTDSens_DD4hep_cfg.py
@@ -1,10 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
 from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
-process = cms.Process('G4PrintGeometry',Phase2C17I13M9,dd4hep)
+process = cms.Process('G4PrintGeometry',_PH2_ERA,dd4hep)
 
-process.load('Configuration.Geometry.GeometryDD4hepExtendedRun4D110Reco_cff')
+process.load('Configuration.Geometry.GeometryDD4hepExtendedRun4DefaultReco_cff')
 process.load('FWCore.MessageService.MessageLogger_cfi')
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")

--- a/SimG4CMS/Forward/test/python/runMTDSens_cfg.py
+++ b/SimG4CMS/Forward/test/python/runMTDSens_cfg.py
@@ -1,10 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
-process = cms.Process('G4PrintGeometry',Phase2C17I13M9)
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
 
-process.load('Configuration.Geometry.GeometryExtendedRun4D110Reco_cff')
+process = cms.Process('G4PrintGeometry', _PH2_ERA)
+
 process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.Geometry.GeometryExtendedRun4DefaultReco_cff')
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.MessageLogger.cerr.threshold = cms.untracked.string('INFO')


### PR DESCRIPTION
#### PR description:

Following the recent renaming of Phase2 geometry configurations, and the introduction of a default Phase2 scenario definition, this PR continue the migration of MTD-related unit tests in #46608 , by porting tests in ```SimG4CMS/Forward``` (ideal geometry in G4 model building) and ```RecMTD/DetLayers``` (navigation of tracking geometry needed by reconstruction).
The latter is also moved to use the DD4hep backend.

#### PR validation:

```scram b runtests``` runs successfully.