### PR TITLE
Thread safe caching of module info in HLTConfigData

### DIFF
--- a/HLTrigger/HLTcore/interface/HLTConfigProvider.h
+++ b/HLTrigger/HLTcore/interface/HLTConfigProvider.h
@@ -102,10 +102,10 @@ public:
   }
 
   /// C++ class name of module
-  const std::string moduleType(const std::string& module) const { return hltConfigData_->moduleType(module); }
+  const std::string& moduleType(const std::string& module) const { return hltConfigData_->moduleType(module); }
 
   /// C++ base class name of module
-  const std::string moduleEDMType(const std::string& module) const { return hltConfigData_->moduleEDMType(module); }
+  const std::string& moduleEDMType(const std::string& module) const { return hltConfigData_->moduleEDMType(module); }
 
   /// ParameterSet of process
   const edm::ParameterSet& processPSet() const { return hltConfigData_->processPSet(); }

--- a/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.cc
@@ -748,7 +748,7 @@ void PATTriggerProducer::produce(Event& iEvent, const EventSetup& iSetup) {
         const trigger::Vids& types = handleTriggerEvent->filterIds(iF);  // not cached
         TriggerFilter triggerFilter(nameFilter);
         // set filter type
-        const std::string typeFilter(hltConfig.moduleType(nameFilter));
+        const std::string& typeFilter(hltConfig.moduleType(nameFilter));
         triggerFilter.setType(typeFilter);
         triggerFilter.setSaveTags(hltConfig.saveTags(nameFilter));
         // set keys and trigger object types of used objects


### PR DESCRIPTION
#### PR description:

Excessive numbers of allocations per event were seen from users of this code.

#### PR validation:

Using step3 of workflow 12861.0 and the ModuleAllocMonitor the number of allocations per event measured from a module using this code went from 155k to 37k. This was tested using 8 threads.