### PR TITLE
Fix typo: fixes testPrintTkMaps unit test

### DIFF
--- a/DQM/TrackerRemapper/test/testPrintTkMaps.sh
+++ b/DQM/TrackerRemapper/test/testPrintTkMaps.sh
@@ -8,7 +8,7 @@ printPixelTrackerMap --help || die 'failed running printPixelTrackerMap --help' 
 printStripTrackerMap --help || die 'failed running printStripTrackerMap --help' $?
 echo -e "\n"
 testPixelFile=$CMSSW_BASE/src/SLHCUpgradeSimulations/Geometry/data/PhaseI/PixelSkimmedGeometry_phase1.txt
-[ -e $testPixelFile} ] || testPixelFile=$CMSSW_RELEASE_BASE/src/SLHCUpgradeSimulations/Geometry/data/PhaseI/PixelSkimmedGeometry_phase1.txt
+[ -e $testPixelFile ] || testPixelFile=$CMSSW_RELEASE_BASE/src/SLHCUpgradeSimulations/Geometry/data/PhaseI/PixelSkimmedGeometry_phase1.txt
 # Store the first 50 elements of the first column in a variable
 testPixelDetids=$(head -n 50 "$testPixelFile" | cut -d ' ' -f 1 | paste -sd ' ' -)
 


### PR DESCRIPTION
This PR fixes a typo which went in via https://github.com/cms-sw/cmssw/pull/46561. Without this PR tests fail when cmssw is build in full mode e.g. https://github.com/cms-sw/cmsdist/pull/9509#issuecomment-2463602897

I have tested this change locally and now it properly read the local data file if available otherwise fall back to release area data file