### PR TITLE
Replace deprecated constants for compression level

### DIFF
--- a/IOPool/Output/src/RootOutputFile.cc
+++ b/IOPool/Output/src/RootOutputFile.cc
@@ -125,13 +125,13 @@ namespace edm {
     }
 
     if (om_->compressionAlgorithm() == std::string("ZLIB")) {
-      filePtr_->SetCompressionAlgorithm(ROOT::kZLIB);
+      filePtr_->SetCompressionAlgorithm(ROOT::RCompressionSetting::EAlgorithm::kZLIB);
     } else if (om_->compressionAlgorithm() == std::string("LZMA")) {
-      filePtr_->SetCompressionAlgorithm(ROOT::kLZMA);
+      filePtr_->SetCompressionAlgorithm(ROOT::RCompressionSetting::EAlgorithm::kLZMA);
     } else if (om_->compressionAlgorithm() == std::string("ZSTD")) {
-      filePtr_->SetCompressionAlgorithm(ROOT::kZSTD);
+      filePtr_->SetCompressionAlgorithm(ROOT::RCompressionSetting::EAlgorithm::kZSTD);
     } else if (om_->compressionAlgorithm() == std::string("LZ4")) {
-      filePtr_->SetCompressionAlgorithm(ROOT::kLZ4);
+      filePtr_->SetCompressionAlgorithm(ROOT::RCompressionSetting::EAlgorithm::kLZ4);
     } else {
       throw Exception(errors::Configuration)
           << "PoolOutputModule configured with unknown compression algorithm '" << om_->compressionAlgorithm() << "'\n"

--- a/PhysicsTools/NanoAOD/plugins/NanoAODOutputModule.cc
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODOutputModule.cc
@@ -299,13 +299,13 @@ void NanoAODOutputModule::openFile(edm::FileBlock const&) {
                                    std::vector<std::string>());
 
   if (m_compressionAlgorithm == std::string("ZLIB")) {
-    m_file->SetCompressionAlgorithm(ROOT::kZLIB);
+    m_file->SetCompressionAlgorithm(ROOT::RCompressionSetting::EAlgorithm::kZLIB);
   } else if (m_compressionAlgorithm == std::string("LZMA")) {
-    m_file->SetCompressionAlgorithm(ROOT::kLZMA);
+    m_file->SetCompressionAlgorithm(ROOT::RCompressionSetting::EAlgorithm::kLZMA);
   } else if (m_compressionAlgorithm == std::string("ZSTD")) {
-    m_file->SetCompressionAlgorithm(ROOT::kZSTD);
+    m_file->SetCompressionAlgorithm(ROOT::RCompressionSetting::EAlgorithm::kZSTD);
   } else if (m_compressionAlgorithm == std::string("LZ4")) {
-    m_file->SetCompressionAlgorithm(ROOT::kLZ4);
+    m_file->SetCompressionAlgorithm(ROOT::RCompressionSetting::EAlgorithm::kLZ4);
   } else {
     throw cms::Exception("Configuration")
         << "NanoAODOutputModule configured with unknown compression algorithm '" << m_compressionAlgorithm << "'\n"

--- a/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTupleOutputModule.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTupleOutputModule.cc
@@ -161,9 +161,9 @@ void NanoAODRNTupleOutputModule::openFile(edm::FileBlock const&) {
                                    std::vector<std::string>());
 
   if (m_compressionAlgorithm == "ZLIB") {
-    m_file->SetCompressionAlgorithm(ROOT::kZLIB);
+    m_file->SetCompressionAlgorithm(ROOT::RCompressionSetting::EAlgorithm::kZLIB);
   } else if (m_compressionAlgorithm == "LZMA") {
-    m_file->SetCompressionAlgorithm(ROOT::kLZMA);
+    m_file->SetCompressionAlgorithm(ROOT::RCompressionSetting::EAlgorithm::kLZMA);
   } else {
     throw cms::Exception("Configuration")
         << "NanoAODOutputModule configured with unknown compression algorithm '" << m_compressionAlgorithm << "'\n"

--- a/PhysicsTools/NanoAODTools/python/postprocessing/framework/postprocessor.py
+++ b/PhysicsTools/NanoAODTools/python/postprocessing/framework/postprocessor.py
@@ -105,11 +105,11 @@ class PostProcessor:
                 (algo, level) = self.compression.split(":")
                 compressionLevel = int(level)
                 if algo == "LZMA":
-                    compressionAlgo = ROOT.ROOT.kLZMA
+                    compressionAlgo = ROOT.RCompressionSetting.EAlgorithm.kLZMA
                 elif algo == "ZLIB":
-                    compressionAlgo = ROOT.ROOT.kZLIB
+                    compressionAlgo = ROOT.RCompressionSetting.EAlgorithm.kZLIB
                 elif algo == "LZ4":
-                    compressionAlgo = ROOT.ROOT.kLZ4
+                    compressionAlgo = ROOT.RCompressionSetting.EAlgorithm.kLZ4
                 else:
                     raise RuntimeError("Unsupported compression %s" % algo)
             else:


### PR DESCRIPTION
#### PR description:

Deprecated for a long time, removed in 6.36 [commit](https://github.com/root-project/root/commit/439a26c914e3d8f26bb7864fb38b103a99d45a05). The change _should_ be backwards-compatible.

The kZLIB constant is also mentioned in PhysicsTools/NanoAODTools/python/postprocessing/framework/postprocessor.py, may need to be updated as well.

#### PR validation:

Bot tests