### PR TITLE
Fix `CopyToDevice` for `PortableHostMultiCollection` and New Test

### DIFF
--- a/DataFormats/Portable/interface/PortableCollection.h
+++ b/DataFormats/Portable/interface/PortableCollection.h
@@ -77,12 +77,12 @@ namespace cms::alpakatools {
     }
   };
 
-  template <typename TDev, typename T0, typename... Args>
-  struct CopyToDevice<PortableHostMultiCollection<TDev, T0, Args...>> {
+  template <typename T0, typename... Args>
+  struct CopyToDevice<PortableHostMultiCollection<T0, Args...>> {
     template <typename TQueue>
-    static auto copyAsync(TQueue& queue, PortableHostMultiCollection<TDev, T0, Args...> const& srcData) {
+    static auto copyAsync(TQueue& queue, PortableHostMultiCollection<T0, Args...> const& srcData) {
       using TDevice = typename alpaka::trait::DevType<TQueue>::type;
-      PortableDeviceMultiCollection<TDev, T0, Args...> dstData(srcData.sizes(), queue);
+      PortableDeviceMultiCollection<TDevice, T0, Args...> dstData(srcData.sizes(), queue);
       alpaka::memcpy(queue, dstData.buffer(), srcData.buffer());
       return dstData;
     }

--- a/HeterogeneousCore/AlpakaTest/interface/AlpakaESTestData.h
+++ b/HeterogeneousCore/AlpakaTest/interface/AlpakaESTestData.h
@@ -14,6 +14,8 @@ namespace cms::alpakatest {
   using AlpakaESTestDataCHost = PortableHostCollection<AlpakaESTestSoAC>;
   using AlpakaESTestDataDHost = PortableHostCollection<AlpakaESTestSoAD>;
 
+  using AlpakaESTestDataACMultiHost = PortableHostMultiCollection<AlpakaESTestSoAA, AlpakaESTestSoAC>;
+
   // Template-over-device model
   template <typename TDev>
   class AlpakaESTestDataB {

--- a/HeterogeneousCore/AlpakaTest/interface/alpaka/AlpakaESTestData.h
+++ b/HeterogeneousCore/AlpakaTest/interface/alpaka/AlpakaESTestData.h
@@ -20,6 +20,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   using AlpakaESTestDataEHost = cms::alpakatest::AlpakaESTestDataEHost;
   using AlpakaESTestDataEDevice = cms::alpakatest::AlpakaESTestDataE<Device>;
+
+  using AlpakaESTestDataACMultiHost = cms::alpakatest::AlpakaESTestDataACMultiHost;
+  using AlpakaESTestDataACMultiDevice =
+      PortableMultiCollection<Device, cms::alpakatest::AlpakaESTestSoAA, cms::alpakatest::AlpakaESTestSoAC>;
+
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE
 
 // check that the portable device collections for the host device are the same as the portable host collections
@@ -27,5 +32,6 @@ ASSERT_DEVICE_MATCHES_HOST_COLLECTION(AlpakaESTestDataADevice, cms::alpakatest::
 ASSERT_DEVICE_MATCHES_HOST_COLLECTION(AlpakaESTestDataCDevice, cms::alpakatest::AlpakaESTestDataCHost);
 ASSERT_DEVICE_MATCHES_HOST_COLLECTION(AlpakaESTestDataDDevice, cms::alpakatest::AlpakaESTestDataDHost);
 ASSERT_DEVICE_MATCHES_HOST_COLLECTION(AlpakaESTestDataEDevice, cms::alpakatest::AlpakaESTestDataEHost);
+ASSERT_DEVICE_MATCHES_HOST_COLLECTION(AlpakaESTestDataACMultiDevice, ::cms::alpakatest::AlpakaESTestDataACMultiHost);
 
 #endif  // HeterogeneousCore_AlpakaTest_interface_alpaka_AlpakaESTestData_h

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaESProducerAMulti.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaESProducerAMulti.cc
@@ -1,0 +1,60 @@
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/ESProducer.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/ModuleFactory.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/host.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+#include "HeterogeneousCore/AlpakaTest/interface/AlpakaESTestRecords.h"
+#include "HeterogeneousCore/AlpakaTest/interface/AlpakaESTestSoA.h"
+#include "HeterogeneousCore/AlpakaTest/interface/ESTestData.h"
+#include "HeterogeneousCore/AlpakaTest/interface/alpaka/AlpakaESTestData.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+  /**
+   * This class is the equivalent of TesAlpakaESProducerA.cc
+   * for PortableHostMultiCollection. It consumes a standard
+   * host ESProduct and converts the data into PortableHostMultiCollection, and
+   * implicitly transfers the data product to device
+   */
+  class TestAlpakaESProducerAMulti : public ESProducer {
+  public:
+    TestAlpakaESProducerAMulti(edm::ParameterSet const& iConfig) : ESProducer(iConfig) {
+      auto cc = setWhatProduced(this);
+      token_ = cc.consumes();
+    }
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+      descriptions.addWithDefaultLabel(desc);
+    }
+
+    std::optional<AlpakaESTestDataACMultiHost> produce(AlpakaESTestRecordA const& iRecord) {
+      auto const& input = iRecord.get(token_);
+
+      int const sizeA = 10;
+      int const sizeC = 100;
+      // TODO: pinned allocation?
+      // TODO: cached allocation?
+      AlpakaESTestDataACMultiHost product({{sizeA, sizeC}}, cms::alpakatools::host());
+      auto viewA = product.view<
+          cms::alpakatest::AlpakaESTestSoAA>();  // this template is not really needed as this is fhe first layout
+      auto viewC = product.view<cms::alpakatest::AlpakaESTestSoAC>();
+
+      for (int i = 0; i < sizeA; ++i) {
+        viewA[i].z() = input.value() - i;
+      }
+
+      for (int i = 0; i < sizeC; ++i) {
+        viewC[i].x() = input.value() + i;
+      }
+
+      return product;
+    }
+
+  private:
+    edm::ESGetToken<cms::alpakatest::ESTestDataA, AlpakaESTestRecordA> token_;
+  };
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+DEFINE_FWK_EVENTSETUP_ALPAKA_MODULE(TestAlpakaESProducerAMulti);

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaGlobalProducer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaGlobalProducer.cc
@@ -22,6 +22,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   public:
     TestAlpakaGlobalProducer(edm::ParameterSet const& config)
         : esToken_(esConsumes(config.getParameter<edm::ESInputTag>("eventSetupSource"))),
+          esMultiToken_(esConsumes(config.getParameter<edm::ESInputTag>("eventSetupSourceMulti"))),
           deviceToken_{produces()},
           deviceTokenMulti2_{produces()},
           deviceTokenMulti3_{produces()},
@@ -34,6 +35,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     void produce(edm::StreamID, device::Event& iEvent, device::EventSetup const& iSetup) const override {
       [[maybe_unused]] auto const& esData = iSetup.getData(esToken_);
+      [[maybe_unused]] auto const& esMultiData = iSetup.getData(esMultiToken_);
 
       portabletest::TestDeviceCollection deviceProduct{size_, iEvent.queue()};
       portabletest::TestDeviceMultiCollection2 deviceProductMulti2{{{size_, size2_}}, iEvent.queue()};
@@ -52,6 +54,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
       edm::ParameterSetDescription desc;
       desc.add("eventSetupSource", edm::ESInputTag{});
+      desc.add("eventSetupSourceMulti", edm::ESInputTag{});
 
       edm::ParameterSetDescription psetSize;
       psetSize.add<int32_t>("alpaka_serial_sync");
@@ -64,6 +67,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   private:
     const device::ESGetToken<AlpakaESTestDataADevice, AlpakaESTestRecordA> esToken_;
+    const device::ESGetToken<AlpakaESTestDataACMultiDevice, AlpakaESTestRecordA> esMultiToken_;
     const device::EDPutToken<portabletest::TestDeviceCollection> deviceToken_;
     const device::EDPutToken<portabletest::TestDeviceMultiCollection2> deviceTokenMulti2_;
     const device::EDPutToken<portabletest::TestDeviceMultiCollection3> deviceTokenMulti3_;

--- a/HeterogeneousCore/AlpakaTest/src/ES_AlpakaESTestData.cc
+++ b/HeterogeneousCore/AlpakaTest/src/ES_AlpakaESTestData.cc
@@ -5,6 +5,7 @@
 TYPELOOKUP_DATA_REG(cms::alpakatest::AlpakaESTestDataAHost);
 TYPELOOKUP_DATA_REG(cms::alpakatest::AlpakaESTestDataCHost);
 TYPELOOKUP_DATA_REG(cms::alpakatest::AlpakaESTestDataDHost);
+TYPELOOKUP_DATA_REG(cms::alpakatest::AlpakaESTestDataACMultiHost);
 
 // Template-over-device model
 TYPELOOKUP_DATA_REG(cms::alpakatest::AlpakaESTestDataB<alpaka_common::DevHost>);

--- a/HeterogeneousCore/AlpakaTest/src/alpaka/ES_AlpakaESTestData.cc
+++ b/HeterogeneousCore/AlpakaTest/src/alpaka/ES_AlpakaESTestData.cc
@@ -5,6 +5,7 @@
 TYPELOOKUP_ALPAKA_DATA_REG(AlpakaESTestDataADevice);
 TYPELOOKUP_ALPAKA_DATA_REG(AlpakaESTestDataCDevice);
 TYPELOOKUP_ALPAKA_DATA_REG(AlpakaESTestDataDDevice);
+TYPELOOKUP_ALPAKA_DATA_REG(AlpakaESTestDataACMultiDevice);
 
 // Template-over-device model
 #include "HeterogeneousCore/AlpakaTest/interface/AlpakaESTestData.h"

--- a/HeterogeneousCore/AlpakaTest/test/testAlpakaModules_cfg.py
+++ b/HeterogeneousCore/AlpakaTest/test/testAlpakaModules_cfg.py
@@ -59,11 +59,16 @@ process.alpakaESProducerNull = cms.ESProducer("TestAlpakaESProducerNull@alpaka",
     appendToDataLabel = cms.string("null"),
 )
 
+# PortableMultiCollection
+from HeterogeneousCore.AlpakaTest.testAlpakaESProducerAMulti_cfi import testAlpakaESProducerAMulti 
+
 process.intProduct = cms.EDProducer("IntProducer", ivalue = cms.int32(42))
+process.alpakaESProducerAMulti = testAlpakaESProducerAMulti.clone(appendToDataLabel = cms.string("appendedLabel"))
 
 from HeterogeneousCore.AlpakaTest.testAlpakaGlobalProducer_cfi import testAlpakaGlobalProducer
 process.alpakaGlobalProducer = testAlpakaGlobalProducer.clone(
     eventSetupSource = cms.ESInputTag("alpakaESProducerA", "appendedLabel"),
+    eventSetupSourceMulti = cms.ESInputTag("alpakaESProducerAMulti", "appendedLabel"),
     size = dict(
         alpaka_serial_sync = 10,
         alpaka_cuda_async = 20,
@@ -146,7 +151,7 @@ process.alpakaNullESConsumer = cms.EDProducer("TestAlpakaGlobalProducerNullES@al
 if args.processAcceleratorBackend != "":
     process.ProcessAcceleratorAlpaka.setBackend(args.processAcceleratorBackend)
 if args.moduleBackend != "":
-    for name in ["ESProducerA", "ESProducerB", "ESProducerC", "ESProducerD", "ESProducerE",
+    for name in ["ESProducerA", "ESProducerB", "ESProducerC", "ESProducerD", "ESProducerE", "ESProducerAMulti",
                  "ESProducerNull",
                  "GlobalProducer", "GlobalProducerE",
                  "StreamProducer", "StreamInstanceProducer",


### PR DESCRIPTION
#### PR description:

This PR proposes a small fix for the `CopyToDevice` function for `PortableHostMultiCollection` and the addition of a new test to exercise the copy (in the form of an `ESProduct` based on a `PortableHostMultiCollection` to be copied to device).

#### PR validation:

`scram b runtests` runs.
