### PR TITLE
[UBSAN]Initialize data member to fix runtime error from ubsan

### DIFF
--- a/L1Trigger/L1TCaloLayer1/src/UCTRegion.cc
+++ b/L1Trigger/L1TCaloLayer1/src/UCTRegion.cc
@@ -72,6 +72,7 @@ UCTRegion::UCTRegion(const UCTRegion& otherRegion)
     : crate(otherRegion.crate),
       card(otherRegion.card),
       region(otherRegion.region),
+      negativeEta(otherRegion.negativeEta),
       towers(otherRegion.towers),
       regionSummary(otherRegion.regionSummary),
       fwVersion(otherRegion.fwVersion) {}


### PR DESCRIPTION
This should fix the [runtime errors](https://cmssdt.cern.ch/SDT/jenkins-artifacts/ubsan_logs/CMSSW_14_2_X_2024-11-06-2300/logs/e5/e5af0780548ce2438448a44c8148f037/log) [a] reported by UBSAN relvals. 

[a] https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/raw/el8_amd64_gcc12/CMSSW_14_2_UBSAN_X_2024-11-06-2300/pyRelValMatrixLogs/run/10001.0_SingleElectronPt10+2017/step2_SingleElectronPt10+2017.log
```
src/L1Trigger/L1TCaloLayer1/src/UCTRegion.hh:94:45: runtime error: load of value 90, which is not a valid value for type 'bool'
    #0 0x145a8b4ea487 in UCTRegion::isNegativeEta() const src/L1Trigger/L1TCaloLayer1/src/UCTRegion.hh:94
    #1 0x145a8b4ea487 in UCTSummaryCard::processRegion(std::pair<int, unsigned int>) src/L1Trigger/L1TCaloLayer1/src/UCTSummaryCard.cc:221
    #2 0x145a8b5a53fd in UCTSummaryCard::process() src/L1Trigger/L1TCaloLayer1/src/UCTSummaryCard.cc:87
    #3 0x145a8bb48812 in L1TCaloSummary<ap_uint<10>, ap_ufixed<16, 8, (ap_q_mode)4, (ap_o_mode)0, 0> >::produce(edm::Event&, edm::EventSetup const&) src/L1Trigger/L1TCaloLayer1/plugins/L1TCaloSummary.cc:275
    #4 0x145b8e4d9423 in edm::stream::EDProducerAdaptorBase::doEvent(edm::EventTransitionInfo const&, edm::ActivityRegistry*, edm::ModuleCallingContext const*) src/FWCore/Framework/src/stream/EDProducerAdaptorBase.cc:83
```
