### PR TITLE
update a vertex smearing parameters for 2024 pp ref MC

### DIFF
--- a/Configuration/StandardSequences/python/VtxSmeared.py
+++ b/Configuration/StandardSequences/python/VtxSmeared.py
@@ -73,6 +73,7 @@ VtxSmeared = {
     'Nominal2022PbPbCollision' : 'IOMC.EventVertexGenerators.VtxSmearedNominal2022PbPbCollision_cfi',
     'Realistic2022PbPbCollision' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic2022PbPbCollision_cfi',
     'Realistic2023PbPbCollision' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic2023PbPbCollision_cfi',
+    'Realistic2024ppRefCollision' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic2024ppRefCollision_cfi',
 }
 VtxSmearedDefaultKey='Realistic50ns13TeVCollision'
 VtxSmearedHIDefaultKey='RealisticPbPbCollision2018'

--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -1071,6 +1071,19 @@ Realistic2023PbPbCollisionVtxSmearingParameters = cms.PSet(
     Z0 = cms.double(0.3064731)
 )
 
+# From 2024 ppRef data run 387590-387721
+Realistic2024ppRefCollisionVtxSmearingParameters = cms.PSet(
+    Phi = cms.double(0.0),
+    BetaStar = cms.double(310),
+    Emittance = cms.double(8.636e-08),
+    Alpha = cms.double(0.0),
+    SigmaZ = cms.double(5.82376),
+    TimeOffset = cms.double(0.0),
+    X0 = cms.double(0.0244619),
+    Y0 = cms.double(-0.0169181),
+    Z0 = cms.double(0.3513597)
+)
+
 # Parameters for HL-LHC operation at 13TeV
 HLLHCVtxSmearingParameters = cms.PSet(
     MeanXIncm = cms.double(0.),

--- a/IOMC/EventVertexGenerators/python/VtxSmearedRealistic2024ppRefCollision_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedRealistic2024ppRefCollision_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Realistic2024ppRefCollisionVtxSmearingParameters,VtxSmearedCommon
+VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
+    Realistic2024ppRefCollisionVtxSmearingParameters,
+    VtxSmearedCommon
+)


### PR DESCRIPTION
#### PR description:
- This PR adds a vertex smearing for 2024 pp ref MC. Beamspot position derived from runs 387590 to 387721, barycentre location provided by Tracker Alignment Group ([cmsTalk](https://cms-talk.web.cern.ch/t/bpix-barycentre-values-for-the-2024-pp-ref-mc/59947/))
<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation: 
- This PR has been modeled after a similar PR from 2022 and 2023: [2022 PR link](https://github.com/cms-sw/cmssw/pull/40496), [2023 PR link](https://github.com/cms-sw/cmssw/pull/43217)

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for: 
- We will need a backport for 14_1_X 

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

<!-- Please delete the text above after you verified all points of the checklist  -->
