### PR TITLE
Add `fillDescriptions` to modules used in cosmics HLT reco

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -48,6 +48,14 @@ def customiseForOffline(process):
 
     return process
 
+def customiseForXXXX(process):
+    for prod in producers_by_type(process, 'CtfSpecialSeedGenerator'):
+        if hasattr(prod, "DontCountDetsAboveNClusters"):
+            value = prod.DontCountDetsAboveNClusters.value()
+            delattr(prod, "DontCountDetsAboveNClusters")
+            # Replace it with cms.uint32
+            prod.DontCountDetsAboveNClusters = cms.uint32(value)
+    return process
 
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
@@ -57,4 +65,6 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
 
+    process = customiseForXXXX(process)
+    
     return process

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -48,13 +48,20 @@ def customiseForOffline(process):
 
     return process
 
-def customiseForXXXX(process):
+def customiseHLTFor46647(process):
     for prod in producers_by_type(process, 'CtfSpecialSeedGenerator'):
         if hasattr(prod, "DontCountDetsAboveNClusters"):
             value = prod.DontCountDetsAboveNClusters.value()
             delattr(prod, "DontCountDetsAboveNClusters")
             # Replace it with cms.uint32
             prod.DontCountDetsAboveNClusters = cms.uint32(value)
+
+        for prod in producers_by_type(process, 'SeedCombiner'):
+            if hasattr(prod, "PairCollection"):
+                delattr(prod, "PairCollection")
+            if hasattr(prod, "TripletCollection"):
+                delattr(prod, "TripletCollection")
+
     return process
 
 # CMSSW version specific customizations
@@ -65,6 +72,6 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
 
-    process = customiseForXXXX(process)
+    process = customiseHLTFor46647(process)
     
     return process

--- a/RecoTracker/Configuration/python/RecoTrackerP5_cff.py
+++ b/RecoTracker/Configuration/python/RecoTrackerP5_cff.py
@@ -20,10 +20,7 @@ from RecoTracker.SpecialSeedGenerators.SimpleCosmicBONSeeder_cff import *
 from RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cff import *
 combinedP5SeedsForCTF = RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cfi.globalCombinedSeeds.clone(
     seedCollections   = ['combinatorialcosmicseedfinderP5',
-	                 'simpleCosmicBONSeeds'],
-    #backward compatibility 2.2/3.1
-    PairCollection    = cms.InputTag('combinatorialcosmicseedfinderP5'),
-    TripletCollection = cms.InputTag('simpleCosmicBONSeeds')
+	                 'simpleCosmicBONSeeds']
 )
 
 from RecoTracker.CkfPattern.CkfTrackCandidatesP5_cff import *

--- a/RecoTracker/SpecialSeedGenerators/interface/CtfSpecialSeedGenerator.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/CtfSpecialSeedGenerator.h
@@ -6,11 +6,13 @@
  *  from combinations of hits in pairs of strip layers 
  */
 //FWK
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 //DataFormats
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
@@ -42,13 +44,14 @@ public:
   typedef TrajectoryStateOnSurface TSOS;
 
   CtfSpecialSeedGenerator(const edm::ParameterSet& conf);
-
-  ~CtfSpecialSeedGenerator() override;  //{};
+  ~CtfSpecialSeedGenerator() override = default;
 
   void beginRun(edm::Run const&, edm::EventSetup const&) override;
   void endRun(edm::Run const&, edm::EventSetup const&) override;
 
   void produce(edm::Event& e, const edm::EventSetup& c) override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
   bool run(const edm::EventSetup& c, const edm::Event& e, TrajectorySeedCollection& output);

--- a/RecoTracker/TkSeedGenerator/plugins/SeedCombiner.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedCombiner.cc
@@ -43,8 +43,6 @@ SeedCombiner::SeedCombiner(const edm::ParameterSet& cfg) {
   }
 }
 
-SeedCombiner::~SeedCombiner() {}
-
 void SeedCombiner::produce(edm::Event& ev, const edm::EventSetup& es) {
   // Read inputs, and count total seeds
   size_t ninputs = inputCollections_.size();
@@ -84,4 +82,11 @@ void SeedCombiner::produce(edm::Event& ev, const edm::EventSetup& es) {
 
   // Save result into the event
   ev.put(std::move(result));
+}
+
+void SeedCombiner::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<std::vector<edm::InputTag> >("seedCollections", {});
+  desc.addOptional<std::vector<edm::InputTag> >("clusterRemovalInfos", {});
+  descriptions.addWithDefaultLabel(desc);
 }

--- a/RecoTracker/TkSeedGenerator/plugins/SeedCombiner.h
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedCombiner.h
@@ -2,9 +2,11 @@
 #define RecoTracker_TkSeedGenerator_SeedCombiner_H
 
 #include <vector>
-#include "FWCore/Framework/interface/stream/EDProducer.h"
-#include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 #include "DataFormats/TrackerRecHit2D/interface/ClusterRemovalInfo.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Utilities/interface/Visibility.h"
 
@@ -17,7 +19,9 @@ namespace edm {
 class dso_hidden SeedCombiner : public edm::stream::EDProducer<> {
 public:
   SeedCombiner(const edm::ParameterSet& cfg);
-  ~SeedCombiner() override;
+  ~SeedCombiner() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
   void produce(edm::Event& ev, const edm::EventSetup& es) override;
 

--- a/RecoTracker/TkSeedGenerator/src/ClusterChecker.cc
+++ b/RecoTracker/TkSeedGenerator/src/ClusterChecker.cc
@@ -37,6 +37,7 @@ void ClusterChecker::fillDescriptions(edm::ParameterSetDescription& desc) {
   desc.add<edm::InputTag>("PixelClusterCollectionLabel", edm::InputTag("siPixelClusters"));
   desc.add<std::string>("cut",
                         "strip < 400000 && pixel < 40000 && (strip < 50000 + 10*pixel) && (pixel < 5000 + 0.1*strip)");
+  desc.add<uint32_t>("DontCountDetsAboveNClusters", 0);
 }
 
 ClusterChecker::~ClusterChecker() {}


### PR DESCRIPTION
#### PR description:

When deep-importing a new path in confDB I noticed the following recurring warning messages:

```
Modules (4):
  -> hltCombinatorialcosmicseedfinderP5 [CtfSpecialSeedGenerator] CHANGED
       PSet UpperScintillatorParameters [REMOVED]
       PSet LowerScintillatorParameters [REMOVED]
       untracked uint32 DontCountDetsAboveNClusters = 20 [REMOVED]
  -> hltCombinedP5SeedsForCTF [SeedCombiner] CHANGED
       untracked InputTag PairCollection = hltCombinatorialcosmicseedfinderP5 [REMOVED]
       untracked InputTag TripletCollection = hltSimpleCosmicBONSeeds [REMOVED]
```

Upon inspection of the modules, I gathered that most of these are incorrect, in the sense that the confDB parsing is expecting some parameters that either of the wrong type or are not needed.
To fix the issue I propose to:
   * introduce a `fillDescriptions` method for `CtfSpecialSeedGenerator` and introduce a customization for the wrong parameters in the HLT menu.
   * introduce a `fillDescriptions` method for `SeedCombiner`, clean up configuration in `RecoTrackerP5_cff` and customize HLT menu

#### PR validation:

Run successfully with this branch:
   * `runTheMatrix.py -l 7.3` (cosmics reco)
   * `addOnTests.py`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A