### PR TITLE
Update the time resoultion of GEM Digitization

### DIFF
--- a/SimMuon/GEMDigitizer/plugins/GEMDigiProducer.cc
+++ b/SimMuon/GEMDigitizer/plugins/GEMDigiProducer.cc
@@ -84,7 +84,7 @@ void GEMDigiProducer::fillDescriptions(edm::ConfigurationDescriptions& descripti
   desc.add<std::string>("mixLabel", "mix");
 
   desc.add<double>("signalPropagationSpeed", 0.66);
-  desc.add<double>("timeResolution", 18.);
+  desc.add<double>("timeResolution", 10.);
   desc.add<double>("timeJitter", 1.0);
   desc.add<double>("averageShapingTime", 50.0);
   desc.add<double>("averageEfficiency", 0.98);


### PR DESCRIPTION
#### PR description:

##### Update on GEM Digitization simulation

- Changing the time resolution of GEMDigi to the more realistic value
- <https://indico.cern.ch/event/1471927/contributions/6197521/attachments/2959308/5210343/ME0_P2UG_Review.pdf> 
: Page 26 and 27

#### PR validation:

- The code format has applied with `scram build code-format` and tested with `scram build code-checks`
- The branch has tested with the following command
```
runTheMatrix.py -w upgrade -l 3211.0
```
