### PR TITLE
[Do not merge] Fix for asneeded IBs, force link pythia6/lhapdf libs

### DIFF
--- a/GeneratorInterface/HydjetInterface/BuildFile.xml
+++ b/GeneratorInterface/HydjetInterface/BuildFile.xml
@@ -8,6 +8,7 @@
 <use   name="f77compiler"/>
 <use   name="hydjet"/>
 <use name="hepmc"/>
+<flags REM_LDFLAGS="-Wl,--as-needed"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/GeneratorInterface/HydjetInterface/plugins/BuildFile.xml
+++ b/GeneratorInterface/HydjetInterface/plugins/BuildFile.xml
@@ -1,5 +1,6 @@
 <use name="GeneratorInterface/HydjetInterface"/>
 <use name="pydata"/>
+<flags REM_LDFLAGS="-Wl,--as-needed"/>
 <library file="*.cc" name="GeneratorInterfaceHydjetInterfacePlugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/GeneratorInterface/PyquenInterface/BuildFile.xml
+++ b/GeneratorInterface/PyquenInterface/BuildFile.xml
@@ -10,6 +10,7 @@
 <use name="GeneratorInterface/ExternalDecays"/>
 <use name="pyquen"/>
 <use name="hepmc"/>
+<flags REM_LDFLAGS="-Wl,--as-needed"/>
 <export>
   <lib name="1"/>
 </export>

--- a/GeneratorInterface/PyquenInterface/plugins/BuildFile.xml
+++ b/GeneratorInterface/PyquenInterface/plugins/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags REM_LDFLAGS="-Wl,--as-needed"/>
 <use name="GeneratorInterface/PyquenInterface"/>
 <use name="pydata"/>
 <library file="*.cc" name="GeneratorInterfacePyquenInterfacePlugins">

--- a/GeneratorInterface/Pythia6Interface/BuildFile.xml
+++ b/GeneratorInterface/Pythia6Interface/BuildFile.xml
@@ -4,6 +4,7 @@
 <use name="pythia6"/>
 <use name="f77compiler"/>
 <use name="hepmc"/>
+<flags REM_LDFLAGS="-Wl,--as-needed"/>
 <export>
   <lib name="1"/>
 </export>

--- a/GeneratorInterface/Pythia6Interface/plugins/BuildFile.xml
+++ b/GeneratorInterface/Pythia6Interface/plugins/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags REM_LDFLAGS="-Wl,--as-needed"/>
 <use name="GeneratorInterface/Pythia6Interface"/>
 <architecture name="osx">
   <use name="pydata"/>


### PR DESCRIPTION
Some Relvals are failing in [CMSSW_14_2_ASNEEDED_X](https://cmssdt.cern.ch/SDT/html/cmssdt-ib/#/relVal/CMSSW_14_2/2024-11-11-1100?selectedArchs=el8_amd64_gcc12&selectedFlavors=ASNEEDED_X&selectedStatus=failed) IBs. Running these relfals locally print error like [a]. This PR makes sure that LHAPDF/pythia6 libs are linked and loaded at runtime. These libs provide the PDFSET symbol.

explicitly linking the Pyquen/Hydjet/Pythia6 allowed to run all the failing workflows
```
1143.201_HydjetQ_B12_5362GeV_2024 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Tue Nov 12 11:26:24 2024-date Tue Nov 12 11:23:03 2024; exit: 0 0 0 0
143.202_HydjetQ_MinBias_5362GeV_2024 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Tue Nov 12 11:26:27 2024-date Tue Nov 12 11:23:03 2024; exit: 0 0 0 0 0
148.0_HydjetQ_MinBias_XeXe_5442GeV_2017 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Tue Nov 12 11:26:20 2024-date Tue Nov 12 11:23:04 2024; exit: 0 0 0 0
43.201_HydjetQ_B12_5362GeV_2024 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Tue Nov 12 11:26:24 2024-date Tue Nov 12 11:23:03 2024; exit: 0 0 0 0
331.0_Pyquen_DiJet_pt80to120_5362GeV_2024 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Tue Nov 12 11:31:37 2024-date Tue Nov 12 11:26:43 2024; exit: 0 0 0 0
332.0_Pyquen_ZeemumuJets_pt10_5362GeV_2024 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Tue Nov 12 11:31:21 2024-date Tue Nov 12 11:26:47 2024; exit: 0 0 0 0
574.0_HydjetQ_B12_5020GeV_2018_ExtGen Step0-PASSED Step1-PASSED  - time date Tue Nov 12 11:27:26 2024-date Tue Nov 12 11:26:51 2024; exit: 0 0
577.0_Pyquen_ZeemumuJets_pt10_2760GeV_ExtGen Step0-PASSED Step1-PASSED  - time date Tue Nov 12 11:27:20 2024-date Tue Nov 12 11:26:54 2024; exit: 0 0
29 29 27 26 12 3 tests passed, 0 0 0 0 0 0 failed
```

[a]
```
1****************** PYINIT: initialization of PYTHIA routines *****************
 Error: you did not link PDFLIB correctly.
 Dummy routine PDFSET in PYTHIA file called instead.
 Execution stopped!

     PYSTOP called with code:    5
```