### PR TITLE
[14.1.X] fix HLT online DQM client to cope with PbPb HLT strip collections

### DIFF
--- a/DQM/HLTEvF/python/HLTSiStripMonitoring_cff.py
+++ b/DQM/HLTEvF/python/HLTSiStripMonitoring_cff.py
@@ -178,6 +178,12 @@ hltMeasurementTrackerEvent = cms.EDProducer( "MeasurementTrackerEventProducer",
     measurementTracker = cms.string( "hltESPMeasurementTracker" )
 )
 
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+pp_on_PbPb_run3.toModify(hltMeasurementTrackerEvent,
+                         stripClusterProducer = cms.string( "hltHITrackingSiStripRawToClustersFacilityFullZeroSuppression" ),
+                         pixelClusterProducer = cms.string( "hltSiPixelClustersAfterSplittingPPOnAA" ),
+                         )
+
 #####
 hltESPTrajectoryFitterRK = cms.ESProducer( "KFTrajectoryFitterESProducer",
   appendToDataLabel = cms.string( "" ),
@@ -223,6 +229,9 @@ hltTrackRefitterForSiStripMonitorTrack.MeasurementTrackerEvent = 'hltMeasurement
 hltTrackRefitterForSiStripMonitorTrack.NavigationSchool        = 'navigationSchoolESProducer'
 hltTrackRefitterForSiStripMonitorTrack.src                     = 'hltMergedTracks' # hltIter2Merged
 
+pp_on_PbPb_run3.toModify(hltTrackRefitterForSiStripMonitorTrack,
+                         src = 'hltMergedTracksPPOnAA')
+
 HLTSiStripMonitorTrack.TopFolderName = 'HLT/SiStrip'
 HLTSiStripMonitorTrack.TrackProducer = 'hltTrackRefitterForSiStripMonitorTrack'
 HLTSiStripMonitorTrack.TrackLabel    = ''
@@ -233,6 +242,12 @@ HLTSiStripMonitorTrack.Mod_On        = False
 HLTSiStripMonitorTrack.OffHisto_On   = True
 HLTSiStripMonitorTrack.HistoFlag_On  = False
 HLTSiStripMonitorTrack.TkHistoMap_On = False
+
+pp_on_PbPb_run3.toModify(HLTSiStripMonitorTrack,
+                         Cluster_src = "hltHITrackingSiStripRawToClustersFacilityFullZeroSuppression")
+
+pp_on_PbPb_run3.toModify(HLTSiStripMonitorCluster,
+                         BPTXfilter = dict(l1Algorithms = ['L1_ZeroBias']))
 
 HLTSiStripMonitorClusterAPVgainCalibration = HLTSiStripMonitorCluster.clone()
 from DQM.TrackingMonitorSource.pset4GenericTriggerEventFlag_cfi import *
@@ -260,6 +275,10 @@ HLTSiStripMonitorClusterAPVgainCalibration.BPTXfilter = cms.PSet(
    verbosityLevel = cms.uint32(1)
 )
 HLTSiStripMonitorClusterAPVgainCalibration.TopFolderName = cms.string('HLT/SiStrip/ZeroBias_FirstCollisionAfterAbortGap')
+
+pp_on_PbPb_run3.toModify(HLTSiStripMonitorClusterAPVgainCalibration,
+                         BPTXfilter = dict(hltPaths = ["HLT_HICentrality30100_FirstCollisionAfterAbortGap_v*"]),
+                         TopFolderName = cms.string('HLT/SiStrip/HLT_HICentrality30100_FirstCollisionAfterAbortGap'))
 
 sistripOnlineMonitorHLTsequence = cms.Sequence(
     hltMeasurementTrackerEvent

--- a/DQM/Integration/python/clients/hlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hlt_dqm_sourceclient-live_cfg.py
@@ -1,8 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 
 import sys
-from Configuration.Eras.Era_Run3_cff import Run3
-process = cms.Process("DQM", Run3)
+if 'runkey=hi_run' in sys.argv:
+  from Configuration.Eras.Era_Run3_pp_on_PbPb_approxSiStripClusters_cff import Run3_pp_on_PbPb_approxSiStripClusters
+  process = cms.Process("DQM", Run3_pp_on_PbPb_approxSiStripClusters)
+else:
+  from Configuration.Eras.Era_Run3_cff import Run3
+  process = cms.Process("DQM", Run3)
 
 unitTest = False
 if 'unitTest=True' in sys.argv:

--- a/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_TrackResiduals_cff.py
+++ b/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_TrackResiduals_cff.py
@@ -142,6 +142,10 @@ hltSiPixelPhase1TrackResidualsAnalyzer = DQMEDAnalyzer('SiPixelPhase1TrackResidu
         VertexCut = cms.untracked.bool(True)
 )
 
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+pp_on_PbPb_run3.toModify(hltSiPixelPhase1TrackResidualsAnalyzer,
+                         vertices = 'hltPixelVerticesPPOnAA')
+
 hltSiPixelPhase1TrackResidualsHarvester = DQMEDHarvester("SiPixelPhase1Harvester",
         histograms = hltSiPixelPhase1TrackResidualsConf,
         geometry = hltSiPixelPhase1Geometry


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/46622

#### PR description:

Title says it all, aimed to fix the empty Strip collections at HLT seen in the early 2024 PbPb runs, e.g. [387886](https://cmsoms.cern.ch/cms/runs/report?cms_run=387886)  ([link to DQM](https://cmsweb.cern.ch/dqm/online/start?runnr=387886;dataset=/Global/Online/ALL;sampletype=online_data;filter=all;referencepos=overlay;referenceshow=customise;referencenorm=True;referenceobj1=refobj;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=Everything;size=M;root=HLT/SiStrip/MechanicalView;focus=;zoom=no;))

#### PR validation:

See See https://github.com/cms-sw/cmssw/pull/46622#issuecomment-2466418452.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

verbatim backport of https://github.com/cms-sw/cmssw/pull/46622 to the 2024 PbPb data-taking cycle.