### PR TITLE
Update a few GTs in autoCond

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -37,8 +37,8 @@ autoCond = {
     'run3_data_express'            :    '141X_dataRun3_Express_frozen_v3',
     # GlobalTag for Run3 data relvals (prompt GT): same as 141X_dataRun3_Prompt_v3 but with snapshot at 2024-09-12 11:03:32 (UTC)
     'run3_data_prompt'             :    '141X_dataRun3_Prompt_frozen_v3',
-    # GlobalTag for Run3 offline data reprocessing - snapshot at 2024-10-16 18:21:05 (UTC)
-    'run3_data'                    :    '140X_dataRun3_v16',
+    # GlobalTag for Run3 offline data reprocessing - snapshot at 2024-11-12 07:39:42 (UTC)
+    'run3_data'                    :    '140X_dataRun3_v17',
     # GlobalTag for Run3 offline data reprocessing with Prompt GT, currently for 2022FG - snapshot at 2024-02-12 12:00:00 (UTC)
     'run3_data_PromptAnalysis'     :    '140X_dataRun3_PromptAnalysis_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
@@ -66,7 +66,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2022
     'phase1_2022_design'           :    '140X_mcRun3_2022_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2022
-    'phase1_2022_realistic'        :    '140X_mcRun3_2022_realistic_v11',
+    'phase1_2022_realistic'        :    '140X_mcRun3_2022_realistic_v12',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 post-EE+ leak
     'phase1_2022_realistic_postEE' :    '140X_mcRun3_2022_realistic_postEE_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2022, Strip tracker in DECO mode
@@ -78,7 +78,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2023
     'phase1_2023_design'           :    '140X_mcRun3_2023_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        :    '140X_mcRun3_2023_realistic_v7',
+    'phase1_2023_realistic'        :    '140X_mcRun3_2023_realistic_v9',
     # GlobalTag for MC production with realistic conditions for Phase1 postBPix issue 2023
     'phase1_2023_realistic_postBPix'  : '140X_mcRun3_2023_realistic_postBPix_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 preBPix 2023, Strip tracker in DECO mode


### PR DESCRIPTION
The following GTs were updated in autoCond to the latest version available for them in the DB.

- GlobalTag for Run3 offline data reprocessing, 'run3_data':  
  -  [140X_dataRun3_v17](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/140X_dataRun3_v17) ([diff](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_dataRun3_v17/140X_dataRun3_v16) wrt previous version v16)
  - Fix HCal Pedestals and Gains to solve the issue reported in [gitlab](https://gitlab.cern.ch/cms-ppd/event-performance/ep-coordination/-/issues/5#note_8640560), see [cmsTalk](https://cms-talk.web.cern.ch/t/call-for-conditions-re-reco-of-2024-eras-c-d-e/42331/23)
- GlobalTag for MC production with realistic conditions for Phase1 2022, 'phase1_2022_realistic':
  - [140X_mcRun3_2022_realistic_v12](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/140X_mcRun3_2022_realistic_v12) ([diff](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2022_realistic_v11/140X_mcRun3_2022_realistic_v12) wrt previous version v11)
  - Update the muon alignment as for [cmsTalk](https://cms-talk.web.cern.ch/t/call-for-conditions-full-2022-2023-data-rereco-and-mc-production-in-140x/32887/53) 
- GlobalTag for MC production with realistic conditions for Phase1 2023, 'phase1_2023_realistic':
  - [140X_mcRun3_2023_realistic_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/140X_mcRun3_2023_realistic_v9) ([diff](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2023_realistic_v7/140X_mcRun3_2023_realistic_v9) wrt previous version v7)
  - Update the muon alignment as for [cmsTalk](https://cms-talk.web.cern.ch/t/call-for-conditions-full-2022-2023-data-rereco-and-mc-production-in-140x/32887/52) 
  - Update the SiPixelStatus tags as for [cmsTalk](https://cms-talk.web.cern.ch/t/call-for-conditions-full-2022-2023-data-rereco-and-mc-production-in-140x/32887/51)

To be backported in 14_1_X and 14_0_X