### PR TITLE
[13_2_X] Change path of RobustParTAK4.onnx as in RecoBTag-Combined V01-25-00

### DIFF
--- a/RecoBTag/ONNXRuntime/plugins/ParticleTransformerAK4ONNXJetTagsProducer.cc
+++ b/RecoBTag/ONNXRuntime/plugins/ParticleTransformerAK4ONNXJetTagsProducer.cc
@@ -84,7 +84,7 @@ void ParticleTransformerAK4ONNXJetTagsProducer::fillDescriptions(edm::Configurat
   desc.add<edm::InputTag>("src", edm::InputTag("pfParticleTransformerAK4TagInfos"));
   desc.add<std::vector<std::string>>("input_names", {"input_1", "input_2", "input_3", "input_4", "input_5", "input_6"});
   desc.add<edm::FileInPath>("model_path",
-                            edm::FileInPath("RecoBTag/Combined/data/RobustParTAK4/PUPPI/V00/RobustParTAK4.onnx"));
+                            edm::FileInPath("RecoBTag/Combined/data/RobustParTAK4/PUPPI/V00/modelfile/model.onnx"));
   desc.add<std::vector<std::string>>("output_names", {"softmax"});
   desc.add<std::vector<std::string>>(
       "flav_names", std::vector<std::string>{"probb", "probbb", "problepb", "probc", "probuds", "probg"});


### PR DESCRIPTION
#### PR description:

This PR changes the path to the RobustParTAK4.onnx as present in RecoBTag-Combined V01-25-00 and changed by PR https://github.com/cms-sw/cmssw/pull/45579 . It should fix the issue seen in https://github.com/cms-sw/cmsdist/pull/9506#issuecomment-2469986060 .

@mandrenguyen 

#### PR validation:

To be tested with https://github.com/cms-sw/cmsdist/pull/9506

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
