### PR TITLE
[SIM] Fixed compilation warning with the new Geant4 11.3

### DIFF
--- a/SimG4Core/Geometry/src/CMSG4CheckOverlap.cc
+++ b/SimG4Core/Geometry/src/CMSG4CheckOverlap.cc
@@ -121,11 +121,11 @@ void CMSG4CheckOverlap::makeReportForMaterials(std::ofstream& fout) {
        << "\n";
   fout << "ElementsDump:"
        << "\n";
-  G4ElementTable* elmtab = G4Element::GetElementTable();
+  const auto elmtab = G4Element::GetElementTable();
   fout << *elmtab;
   fout << "====================================================================="
        << "\n";
-  G4MaterialTable* mattab = G4Material::GetMaterialTable();
+  const auto mattab = G4Material::GetMaterialTable();
   fout << "MaterialsDump:"
        << "\n";
   //fout << *mattab << "\n";


### PR DESCRIPTION
#### PR description:
There is the compilation warning with the new Geant4 11.3. This fix is also useful for previous Geant4 version. No change in any WF is expected.



#### PR validation:
private


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for: NO

