### PR TITLE
Protect TauSpinnerTable producer against crash with samples with HTT mixed with other processes

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/TauSpinnerTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/TauSpinnerTableProducer.cc
@@ -24,6 +24,8 @@
 #include "TauSpinner/SimpleParticle.h"
 #include "TauSpinner/tau_reweight_lib.h"
 
+#include <atomic>
+
 class TauSpinnerTableProducer : public edm::one::EDProducer<edm::one::SharedResources> {
 public:
   explicit TauSpinnerTableProducer(const edm::ParameterSet &);
@@ -92,6 +94,9 @@ private:
   const int nonSMN_;
   const double cmsE_;
   const double default_weight_;
+
+  std::atomic<unsigned int> nWarnings{0};
+  static const unsigned int nMaxWarnings = 10;
 };
 
 TauSpinnerTableProducer::TauSpinnerTableProducer(const edm::ParameterSet &config)
@@ -189,7 +194,20 @@ void TauSpinnerTableProducer::produce(edm::Event &event, const edm::EventSetup &
   edm::RefVector<edm::View<reco::GenParticle>> bosons;
   getBosons(bosons, genParts);
   if (bosons.size() !=
-      1) {  // no boson found or more than one found, produce empty table (expected for non HTT samples)
+      1) {  // no boson found or more than one found, produce table with default weights (expected for non HTT samples)
+    if (++nWarnings < nMaxWarnings)
+      edm::LogWarning("TauSpinnerTableProducer::produce")
+          << "Current event has " << bosons.size()
+          << " Higgs bosons while there must be exactly one; table with default weights is produced.\n";
+    // Fill table with default values
+    for (const auto &theta : theta_vec_) {
+      wtTable->addColumnValue<double>(
+          "weight_cp_" + theta.first, default_weight_, "TauSpinner weight for theta_CP = " + theta.first);
+      wtTable->addColumnValue<double>(
+          "weight_cp_" + theta.first + "_alt",
+          default_weight_,
+          "TauSpinner weight for theta_CP = " + theta.first + " (alternative hadronic currents)");
+    }
     event.put(std::move(wtTable));
     return;
   }
@@ -197,7 +215,21 @@ void TauSpinnerTableProducer::produce(edm::Event &event, const edm::EventSetup &
   // Search for taus from boson decay
   reco::GenParticleRefVector taus;
   getTaus(taus, *bosons[0]);
-  if (taus.size() != 2) {  // boson does not decay to tau pair, produce empty table (expected for non HTT samples)
+  if (taus.size() !=
+      2) {  // boson does not decay to tau pair, produce table with default weights (expected for non HTT samples)
+    if (++nWarnings < nMaxWarnings)
+      edm::LogWarning("TauSpinnerTableProducer::produce")
+          << "Current event has " << taus.size()
+          << " taus from boson decay while there must be exactly one pair; table with default weights is produced.\n";
+    // Fill table with default values
+    for (const auto &theta : theta_vec_) {
+      wtTable->addColumnValue<double>(
+          "weight_cp_" + theta.first, default_weight_, "TauSpinner weight for theta_CP = " + theta.first);
+      wtTable->addColumnValue<double>(
+          "weight_cp_" + theta.first + "_alt",
+          default_weight_,
+          "TauSpinner weight for theta_CP = " + theta.first + " (alternative hadronic currents)");
+    }
     event.put(std::move(wtTable));
     return;
   }


### PR DESCRIPTION
#### PR description:

This PR fixes `TauSpinnerTableProducer` (introduced in #45828) against an issue caused by samples with events containing the H->tau,tau (HTT) decay mixed with events without this decay. Examples of such samples were discussed in https://cms-talk.web.cern.ch/t/higgs-in-wz-amcatnlofxfx-samples/55138. 

The nanoAOD production crashes in such samples as the `TauSpinnerTableProducer` produces a non-empty table for events with the HTT decay while empty one for events without it which leads to an inconsistent output across different events which then confuses the output module.

The fix consists of producing tables with default weights for events without HTT ensuring consistency, but for price of producing not needed numbers. To be noted that similar strategy is employed in case of HTXS tables. Overhead due to this should be limited as tables with constant values are efficiently compressed.

#### PR validation:

Validated by processing samples with events containing the HTT decay, without the HTT decay and mixed with and without.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

No backport expected.
