### PR TITLE
explicitly link pythia6_pdfdummy where needed

### DIFF
--- a/GeneratorInterface/GenExtensions/bin/BuildFile.xml
+++ b/GeneratorInterface/GenExtensions/bin/BuildFile.xml
@@ -1,5 +1,6 @@
 <library file="BCVEGPY/*.F,BCVEGPY/*.f" name="GeneratorInterfaceBCVEGPY">
   <use name="pythia6"/>
+  <use name="pythia6_pdfdummy"/>
   <use name="f77compiler"/>
 </library>
 


### PR DESCRIPTION
This change along with https://github.com/cms-sw/cmsdist/pull/9514 should properly link lhapdf library for ASNEEDED IBs. Currently pythia6 tool also link `pythia6_pdfdummy` library which provides the `pdfset` symbol. For ASNEEDED IBs, complier decided to not link ` lhapdf` as the needed `pdfset` symbol was available via  `pythia6_pdfdummy`. cmsdist PR moves `pythia6_pdfdummy` in to a separate tool file which is then only linked where it is needed.

Fixes #45747