### PR TITLE
[14_1_X] Update the egamma regression for 2023 UPC PbPb rereco and the corresponding GTs in autoCond

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -38,7 +38,7 @@ autoCond = {
     # GlobalTag for Run3 data relvals (prompt GT): same as 141X_dataRun3_Prompt_v3 but with snapshot at 2024-09-12 11:03:32 (UTC)
     'run3_data_prompt'             :    '141X_dataRun3_Prompt_frozen_v3',
     # GlobalTag for Run3 offline data reprocessing - snapshot at 2024-11-12 07:39:42 (UTC) 
-    'run3_data'                    :    '140X_dataRun3_v17',
+    'run3_data'                    :    '141X_dataRun3_v4',
     # GlobalTag for Run3 offline data reprocessing with Prompt GT, currently for 2022FG - snapshot at 2024-02-12 12:00:00 (UTC)
     'run3_data_PromptAnalysis'     :    '140X_dataRun3_PromptAnalysis_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
@@ -88,7 +88,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2023, Strip tracker in DECO mode
     'phase1_2023_cosmics_design'   :    '140X_mcRun3_2023cosmics_design_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2023 detector for Heavy Ion
-    'phase1_2023_realistic_hi'     :    '141X_mcRun3_2023_realistic_HI_v3',
+    'phase1_2023_realistic_hi'     :    '141X_mcRun3_2023_realistic_HI_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2024
     'phase1_2024_design'           :    '140X_mcRun3_2024_design_v11',
     # GlobalTag for MC production with realistic conditions for Phase1 2024

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2739,7 +2739,7 @@ steps['RECODR3_reHLT_2024']=merge([{'--conditions':'auto:run3_data_prompt_relval
 
 steps['RECODR2_2016_UPC']=merge([{'--conditions':'auto:run2_data', '--era':'Run2_2016_UPC', '-s':'RAW2DIGI,L1Reco,RECO,DQM:@commonFakeHLT+@standardDQMFakeHLT', '--repacked':''},steps['RECODR2_2016']])
 steps['RECODR3_2023_HIN']=merge([{'--conditions':'auto:run3_data_prompt', '-s':'RAW2DIGI,L1Reco,RECO,DQM:@commonFakeHLT+@standardDQMFakeHLT', '--repacked':'', '-n':1000},steps['RECODR3_2023']])
-steps['RECODR3_2023_UPC']=merge([{'--era':'Run3_2023_UPC'},steps['RECODR3_2023_HIN']])
+steps['RECODR3_2023_UPC']=merge([{'--conditions':'auto:run3_data', '--era':'Run3_2023_UPC'},steps['RECODR3_2023_HIN']])
 steps['RECODR3_2024_HIN']=merge([{'--conditions':'auto:run3_data_prompt', '-s':'RAW2DIGI,L1Reco,RECO,DQM:@commonFakeHLT+@standardDQMFakeHLT', '--repacked':'', '-n':1000},steps['RECODR3_2024']])
 steps['RECODR3_2024_UPC']=merge([{'--era':'Run3_2024_UPC'},steps['RECODR3_2024_HIN']])
 

--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
@@ -28,3 +28,9 @@ egamma_lowPt_exclusive.toModify(particleFlowSuperClusterECAL,
                                 thresh_PFClusterSeedBarrel = 0.5,
                                 thresh_PFClusterSeedEndcap = 0.5)
 
+from Configuration.Eras.Era_Run3_2023_UPC_cff import Run3_2023_UPC
+(egamma_lowPt_exclusive & Run3_2023_UPC).toModify(particleFlowSuperClusterECAL, regressionConfig = dict(
+    regressionKeyEB  = 'pfscecal_ebCorrection_offline_v2',
+    uncertaintyKeyEB = 'pfscecal_ebUncertainty_offline_v2',
+    regressionKeyEE  = 'pfscecal_eeCorrection_offline_v2',
+    uncertaintyKeyEE = 'pfscecal_eeUncertainty_offline_v2'))

--- a/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectrons_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectrons_cfi.py
@@ -39,6 +39,41 @@ lowPtRegressionModifier = regressionModifier106XUL.clone(
     ),
 )
 
+from RecoEgamma.EgammaTools.regressionModifier_cfi import regressionModifier103XLowPtPho
+_lowPtRegressionModifierUPC = regressionModifier103XLowPtPho.clone(
+    eleRegs = dict(
+        ecalOnlyMean = dict(
+            ebLowEtForestName = ":lowPtElectron_eb_ecalOnly_1To20_0p2To2_mean",
+            ebHighEtForestName = ":lowPtElectron_eb_ecalOnly_1To20_0p2To2_mean",
+            eeLowEtForestName = ":lowPtElectron_ee_ecalOnly_1To20_0p2To2_mean",
+            eeHighEtForestName = ":lowPtElectron_ee_ecalOnly_1To20_0p2To2_mean",
+            ),
+        ecalOnlySigma = dict(
+            ebLowEtForestName = ":lowPtElectron_eb_ecalOnly_1To20_0p0002To0p5_sigma",
+            ebHighEtForestName = ":lowPtElectron_eb_ecalOnly_1To20_0p0002To0p5_sigma",
+            eeLowEtForestName = ":lowPtElectron_ee_ecalOnly_1To20_0p0002To0p5_sigma",
+            eeHighEtForestName = ":lowPtElectron_ee_ecalOnly_1To20_0p0002To0p5_sigma",
+            ),
+        epComb = dict(
+            ecalTrkRegressionConfig = dict(
+                ebLowEtForestName = ":lowPtElectron_eb_ecalTrk_1To20_0p2To2_mean",
+                ebHighEtForestName = ":lowPtElectron_eb_ecalTrk_1To20_0p2To2_mean",
+                eeLowEtForestName = ":lowPtElectron_ee_ecalTrk_1To20_0p2To2_mean",
+                eeHighEtForestName = ":lowPtElectron_ee_ecalTrk_1To20_0p2To2_mean",
+                ),
+            ecalTrkRegressionUncertConfig = dict(
+                ebLowEtForestName = ":lowPtElectron_eb_ecalTrk_1To20_0p0002To0p5_sigma",
+                ebHighEtForestName = ":lowPtElectron_eb_ecalTrk_1To20_0p0002To0p5_sigma",
+                eeLowEtForestName = ":lowPtElectron_ee_ecalTrk_1To20_0p0002To0p5_sigma",
+                eeHighEtForestName = ":lowPtElectron_ee_ecalTrk_1To20_0p0002To0p5_sigma",
+                ),
+        )
+    ),
+)
+from Configuration.Eras.Era_Run3_2023_UPC_cff import Run3_2023_UPC
+from Configuration.ProcessModifiers.egamma_lowPt_exclusive_cff import egamma_lowPt_exclusive
+(egamma_lowPt_exclusive & Run3_2023_UPC).toReplaceWith(lowPtRegressionModifier,_lowPtRegressionModifierUPC)
+
 from RecoEgamma.EgammaElectronProducers.lowPtGsfElectronFinalizer_cfi import lowPtGsfElectronFinalizer
 lowPtGsfElectrons = lowPtGsfElectronFinalizer.clone(
     previousGsfElectronsTag = "lowPtGsfElectronsPreRegression",

--- a/RecoEgamma/EgammaTools/python/regressionModifier_cfi.py
+++ b/RecoEgamma/EgammaTools/python/regressionModifier_cfi.py
@@ -266,5 +266,22 @@ regressionModifierRun3 = regressionModifierRun2.clone(
 from Configuration.Eras.Modifier_run3_egamma_cff import run3_egamma
 run3_egamma.toReplaceWith(regressionModifier,regressionModifierRun3)
 
+from Configuration.Eras.Era_Run3_2023_UPC_cff import Run3_2023_UPC
+from Configuration.Eras.Modifier_run3_egamma_2023_cff import run3_egamma_2023
+(run3_egamma_2023 & Run3_2023_UPC).toModify(regressionModifier103XLowPtPho,
+    eleRegs = dict(
+        ecalOnlyMean = dict(
+            rangeMinHighEt = 0.2,
+            rangeMaxHighEt = 2.0
+        )
+    ),
+    phoRegs = dict(
+        ecalOnlyMean = dict(
+            rangeMinHighEt = 0.2,
+            rangeMaxHighEt = 2.0
+        )
+    )
+)
+
 from Configuration.ProcessModifiers.egamma_lowPt_exclusive_cff import egamma_lowPt_exclusive
 egamma_lowPt_exclusive.toReplaceWith(regressionModifier,regressionModifier103XLowPtPho)


### PR DESCRIPTION
#### PR description:

Backport of https://github.com/cms-sw/cmssw/pull/46562

The data and HI MC Gts are updated in autoCond to take the new regressions into account:
- New run3_data GT:
  - [141X_dataRun3_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/141X_dataRun3_v4) (see [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_dataRun3_v7/141X_dataRun3_v4) the diff wrt previous 140X_dataRun3_v17)
- New phase1_2023_realistic_hi GT:
  - [141X_mcRun3_2023_realistic_HI_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/141X_mcRun3_2023_realistic_HI_v4) (see [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/141X_mcRun3_2023_realistic_HI_v3/141X_mcRun3_2023_realistic_HI_v4) the diff wrt previous 141X_mcRun3_2023_realistic_HI_v3)

@mandrenguyen 
