### PR TITLE
Fix `maxHitsInModule` for `SiPixelRecHitFromSoAAlpaka`

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitFromSoAAlpaka.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitFromSoAAlpaka.cc
@@ -100,7 +100,7 @@ void SiPixelRecHitFromSoAAlpaka<TrackerTraits>::produce(edm::StreamID streamID,
 
   auto const hclusters = iEvent.getHandle(clusterToken_);
 
-  constexpr uint32_t maxHitsInModule = pixelClustering::maxHitsInModule();
+  constexpr uint32_t maxHitsInModule = TrackerTraits::maxHitsInModule;
 
   int numberOfDetUnits = 0;
   int numberOfClusters = 0;


### PR DESCRIPTION
#### PR description:

Small fix for `SiPixelRecHitFromSoAAlpaka` that uses the obsolete `pixelClustering::maxHitsInModule()` to limit the number of hits in a module. It should be `TrackerTraits::maxHitsInModule`.  The backport to `14_1_X` will fix https://github.com/cms-sw/cmssw/issues/46656. 

#### PR validation:

`*.402` wfs for HI conditions
