### PR TITLE
[14_1_X] Fix `maxHitsInModule` for `SiPixelRecHitFromSoAAlpaka`

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitFromSoAAlpaka.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitFromSoAAlpaka.cc
@@ -100,7 +100,7 @@ void SiPixelRecHitFromSoAAlpaka<TrackerTraits>::produce(edm::StreamID streamID,
 
   auto const hclusters = iEvent.getHandle(clusterToken_);
 
-  constexpr uint32_t maxHitsInModule = pixelClustering::maxHitsInModule();
+  constexpr uint32_t maxHitsInModule = TrackerTraits::maxHitsInModule;
 
   int numberOfDetUnits = 0;
   int numberOfClusters = 0;


### PR DESCRIPTION
#### PR description:

Backport of https://github.com/cms-sw/cmssw/pull/46686 for HIon data taking. 

Solves https://github.com/cms-sw/cmssw/issues/46656
