### PR TITLE
[DQM] Modify DQMGUI upload test to only run in automated environments

### DIFF
--- a/DQMServices/Demo/test/test_dqmgui_upload.sh
+++ b/DQMServices/Demo/test/test_dqmgui_upload.sh
@@ -7,12 +7,44 @@
 set -x
 set -e
 
+force=0
+
+function usage() {
+    echo "Usage: $0 [--help] [--force]"
+}
+
+# Parse args, if any.
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+    --force)
+        force=1
+        shift
+        ;;
+    --help)
+        usage
+        exit 0
+        ;;
+    *)
+        echo "Unknown parameter passed: $1"
+        usage
+        exit 1
+        ;;
+    esac
+done
+
+# Don't run the test unless it's run by the bot for PRs or IBs.
+# The user may force it by adding --force
+if [ -z "$CMSBOT_CI_TESTS" ] && [ "$force" -ne 1 ]; then
+    echo "Non-automated test environment, skipping test."
+    exit 0
+fi
+
 DEV_DQMGUI_URL="https://cmsweb.cern.ch/dqm/dev"
 # Create a unique fake "Era", so that different executions of this test
 # produce differently named files. This is required, because this test might pass
 # if it's checking a file that was successfully uploaded during a previous
 # instance of the same test.
-UNIQUE_ERA_ID=$(date -u +%Y%m%d%M%S%N)
+UNIQUE_ERA_ID=$(date -u +%Y%m%d%H%M%S%N)
 OLD_FILENAME=DQM_V0001_R000000001__Harvesting__DQMTests__DQMIO.root
 NEW_FILENAME=${OLD_FILENAME/DQMTests/DQMTests${UNIQUE_ERA_ID}}
 


### PR DESCRIPTION
#### PR description:

After @smuzaffar's recommendation, modify `TestDQMGUIUpload` to only run for PRs and IBs, and not for local testing, when the `DQMServices/Demo` package is checked out. The test checks for the `CMSBOT_CI_TESTS` env var, or a `--force` argument, to override the variable.

Also fix the timestamp of the renamed file to include the hour, which was missing before, it will help with debugging.

A `--help` argument to print the script's usage is also added.

See also: #46682

#### PR validation:

Tested on LXPLUS. DQMGUI dev is currently unavailable for full testing.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport.
