### PR TITLE
Add offline cuts to PbPb UPC monopole skim

### DIFF
--- a/Configuration/Skimming/python/PbPb_UPC_Monopole_cff.py
+++ b/Configuration/Skimming/python/PbPb_UPC_Monopole_cff.py
@@ -7,9 +7,12 @@ hltUPCMonopole.HLTPaths = ["HLT_HIUPC_MinPixelThrust0p8_MaxPixelCluster10000_v*"
 hltUPCMonopole.throw = False
 hltUPCMonopole.andOr = True
 
+from HLTrigger.special.hltPixelActivityFilter_cfi import hltPixelActivityFilter as _hltPixelActivityFilter
+hltPixelActivityFilterMinClusters40 = _hltPixelActivityFilter.clone(inputTag = "siPixelClusters", minClusters = 40)
+
 from Configuration.Skimming.PDWG_EXOMONOPOLE_cff import EXOMonopoleSkimContent
 upcMonopoleSkimContent = EXOMonopoleSkimContent.clone()
 upcMonopoleSkimContent.outputCommands.append('keep FEDRawDataCollection_rawDataRepacker_*_*')
 
 # UPC monopole skim sequence
-upcMonopoleSkimSequence = cms.Sequence(hltUPCMonopole)
+upcMonopoleSkimSequence = cms.Sequence(hltUPCMonopole * hltPixelActivityFilterMinClusters40)


### PR DESCRIPTION
#### PR description:

This PR adds an additional selection on the number of pixel clusters in the PbPb UPC monopole skim, which reduces the number of events by a factor of 4.

@mandrenguyen 

#### PR validation:


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 14_1_X
