### PR TITLE
Allowing Cluster Splitting with HLT Vertices

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -670,6 +670,12 @@ FEVTDEBUGHLTEventContent.outputCommands.append('keep *_*_MergedTrackTruth_*')
 FEVTDEBUGHLTEventContent.outputCommands.append('keep *_*_StripDigiSimLink_*')
 FEVTDEBUGHLTEventContent.outputCommands.append('keep *_*_PixelDigiSimLink_*')
 
+from Configuration.ProcessModifiers.hltClusterSplitting_cff import hltClusterSplitting
+hltClusterSplitting.toModify(FEVTDEBUGHLTEventContent,
+                              outputCommands = FEVTDEBUGHLTEventContent.outputCommands+[
+                                  'keep *_hltPixelVertices_*_*'
+                              ])
+
 approxSiStripClusters.toModify(FEVTDEBUGHLTEventContent,
                               outputCommands = FEVTDEBUGHLTEventContent.outputCommands+[
                                   'keep *_hltSiStripClusters2ApproxClusters_*_*',

--- a/Configuration/ProcessModifiers/python/hltClusterSplitting_cff.py
+++ b/Configuration/ProcessModifiers/python/hltClusterSplitting_cff.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+# This modifier enables
+# - saving pixel vertices at HLT;
+# - using those vertices in input for the cluster splitting and ak4CaloJets;
+
+hltClusterSplitting =  cms.Modifier()
+

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -2552,6 +2552,72 @@ upgradeWFs['JetCore'] = UpgradeWorkflow_JetCore(
     offset = 0.19002,
 )
 
+class UpgradeWorkflow_SplittingFromHLT(UpgradeWorkflow):
+    def setup_(self, step, stepName, stepDict, k, properties):
+        stepDict[stepName][k] = merge([{'--procModifiers': 'hltClusterSplitting'}, stepDict[step][k]])
+    def condition(self, fragment, stepList, key, hasHarvest):
+        return '2025' in key and fragment=="TTbar_14TeV"
+
+upgradeWFs['SplittingFromHLT'] = UpgradeWorkflow_SplittingFromHLT(
+    steps = [
+        'DigiTrigger',
+        'Digi',
+        'HLTOnly',
+        'RecoLocal',
+        'Reco',
+        'RecoFakeHLT',
+        'RecoGlobal',
+    ],
+    PU = [
+        'DigiTrigger',
+        'Digi',
+        'HLTOnly',
+        'RecoLocal',
+        'Reco',
+        'RecoFakeHLT',
+        'RecoGlobal',
+    ],
+    suffix = '_SplittingFromHLT',
+    offset = 0.19003,
+)
+
+class UpgradeWorkflow_SplittingProdLike(UpgradeWorkflow_ProdLike):
+    def __init__(self, suffix, offset,steps, PU):
+        super(UpgradeWorkflow_SplittingProdLike, self).__init__(steps, PU, suffix, offset)
+
+    def setup_(self, step, stepName, stepDict, k, properties):
+        # copy steps, then apply specializations
+        stepDict[stepName][k] = merge([{'--procModifiers': 'hltClusterSplitting'}, stepDict[step][k]])
+
+    def condition(self, fragment, stepList, key, hasHarvest):
+        return '2025' in key and fragment=="TTbar_14TeV"
+
+upgradeWFs['SplittingFromHLTProdLike'] = UpgradeWorkflow_SplittingProdLike(
+    steps = [
+    ],
+    PU = [
+        'GenSimHLBeamSpot14',
+        'Digi',
+        'DigiTrigger',
+        'HLTOnly',
+        'Reco',
+        'RecoFakeHLT',
+        'RecoGlobal',
+        'RecoNano',
+        'RecoNanoFakeHLT',
+        'HARVEST',
+        'HARVESTFakeHLT',
+        'HARVESTGlobal',
+        'HARVESTNano',
+        'HARVESTNanoFakeHLT',
+        'MiniAOD',
+        'ALCA',
+        'Nano',
+    ],
+    suffix = '_SplittingFromHLTProdLike',
+    offset = 0.1900321,
+)
+
 #
 # Simulates Bias Rail in Phase-2 OT PS modules and X% random bad Strips
 # in PS-s and SS sensors

--- a/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
@@ -221,6 +221,12 @@ ak4CaloJetsForTrkPreSplitting = ak4CaloJetsForTrk.clone(
     src    = 'caloTowerForTrkPreSplitting',
     srcPVs = 'firstStepPrimaryVerticesPreSplitting'
 )
+
+from Configuration.ProcessModifiers.hltClusterSplitting_cff import hltClusterSplitting
+hltClusterSplitting.toModify(ak4CaloJetsForTrkPreSplitting,
+    srcPVs = 'hltPixelVertices'
+)
+
 jetsForCoreTrackingPreSplitting = jetsForCoreTracking.clone(
     src    = 'ak4CaloJetsForTrkPreSplitting'
 )
@@ -232,6 +238,8 @@ siPixelClusters = jetCoreClusterSplitter.clone(
     vertices      = 'firstStepPrimaryVerticesPreSplitting',
     cores         = 'jetsForCoreTrackingPreSplitting'
 )
+
+
 
 # Final sequence
 from RecoLocalTracker.SiPixelRecHits.SiPixelRecHits_cfi import siPixelRecHits
@@ -254,6 +262,21 @@ InitialStepPreSplittingTask = cms.Task(trackerClusterCheckPreSplitting,
                                        siPixelRecHits,
                                        MeasurementTrackerEvent,
                                        siPixelClusterShapeCache)
+
+hltClusterSplitting.toModify(siPixelClusters,
+    vertices = cms.InputTag("hltPixelVertices") 
+)
+
+InitialStepPreSplittingFromHLTTask = cms.Task(
+                                       caloTowerForTrkPreSplitting,
+                                       ak4CaloJetsForTrkPreSplitting,
+                                       jetsForCoreTrackingPreSplitting,
+                                       siPixelClusters,
+                                       siPixelRecHits,
+                                       MeasurementTrackerEvent,
+                                       siPixelClusterShapeCache)
+hltClusterSplitting.toReplaceWith(InitialStepPreSplittingTask, InitialStepPreSplittingFromHLTTask)
+
 InitialStepPreSplitting = cms.Sequence(InitialStepPreSplittingTask)
 _InitialStepPreSplittingTask_trackingPhase1 = InitialStepPreSplittingTask.copy()
 _InitialStepPreSplittingTask_trackingPhase1.replace(initialStepHitTripletsPreSplitting, cms.Task(initialStepHitTripletsPreSplitting,initialStepHitQuadrupletsPreSplitting))

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -20,6 +20,7 @@ from CommonTools.RecoAlgos.recoChargedRefCandidateToTrackRefProducer_cfi import 
 import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 import RecoTracker.IterativeTracking.iterativeTkUtils as _utils
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
+from Configuration.ProcessModifiers.hltClusterSplitting_cff import hltClusterSplitting
 
 ### First define the stuff for the standard validation sequence
 ## Track selectors
@@ -47,8 +48,8 @@ _removeForFastSimSeedProducers =["initialStepSeedsPreSplitting",
                                  "displacedRegionalStepSeeds",
                                  "muonSeededSeedsInOut",
                                  "muonSeededSeedsOutIn"]
-
 _seedProducers_fastSim = [ x for x in _seedProducers if x not in _removeForFastSimSeedProducers]
+_seedProducers_hltSplit = [ x for x in _seedProducers if x not in ["initialStepSeedsPreSplitting"]]
 
 _removeForFastTrackProducers = ["initialStepTracksPreSplitting",
                                 "jetCoreRegionalStepTracks",
@@ -56,6 +57,7 @@ _removeForFastTrackProducers = ["initialStepTracksPreSplitting",
                                 "muonSeededTracksInOut",
                                 "muonSeededTracksOutIn"]
 _trackProducers_fastSim = [ x for x in _trackProducers if x not in _removeForFastTrackProducers]
+_trackProducers_hltSplit = [ x for x in _trackProducers if x not in ["initialStepTracksPreSplitting"]]
 
 def _algoToSelector(algo):
     sel = ""
@@ -813,6 +815,10 @@ fastSim.toReplaceWith(tracksValidation, tracksValidation.copyAndExclude([
     trackValidatorGsfTracks,
 ]))
 
+hltClusterSplitting.toReplaceWith(tracksValidation, tracksValidation.copyAndExclude([
+    trackValidatorBuildingPreSplitting,
+]))
+
 ### Then define stuff for standalone mode (i.e. MTV with RECO+DIGI input)
 
 # Select by originalAlgo and algoMask
@@ -1016,6 +1022,12 @@ fastSim.toReplaceWith(trackValidatorsTrackingOnly, trackValidatorsTrackingOnly.c
     trackValidatorConversionTrackingOnly,
     trackValidatorBHadronTrackingOnly
 ]))
+
+hltClusterSplitting.toReplaceWith(trackValidatorsTrackingOnly, trackValidatorsTrackingOnly.copyAndExclude([
+    trackValidatorBuildingPreSplitting,
+    trackValidatorSeedingPreSplittingTrackingOnly,
+]))
+
 tracksValidationTrackingOnly = cms.Sequence(
     trackValidatorsTrackingOnly,
     tracksPreValidationTrackingOnly,


### PR DESCRIPTION
#### PR description:

This PR proposes the introduction of a new process modifier `hltClusterSplitting` that:
- enables to write the `hltPixelVertices` in `FEVTDEBUGHLTEventContent`;
  - one could test also just the `hltTrimmedPixelVertices` that are just 1-2 for Run3 HLT;
- uses those vertices for the `ak4CaloJetsForTrkPreSplitting` and the cluster splitter;
  -  these producers actually use only the coordinates so the content to be stored could be actually slimmed down to be just a collection of floats;   
- removes the `InitialStepPreSplitting` iteration from iterative tracking.

Running on 14_2_0_pre2 RelVals with Run3 PU:

- [TTbar (400 events)](https://adiflori.web.cern.ch/adiflori/hlt_cluster_splitting/ttbar_plots/);
- [QCD_Pt15To7000_Flat (500 events)](https://adiflori.web.cern.ch/adiflori/hlt_cluster_splitting/qcd_plots/);

the tracking performance seems untouched. 

![Screenshot 2024-11-13 alle 16 58 14](https://github.com/user-attachments/assets/3a4c738d-07e9-4a89-b86f-ef2e0eeba183)


I don't know how much this would be useful for Run3, but it may be interesting to check it for Phase2. For Run3 I've measured (roughly)[ a speedup of 1.5-2%](https://adiflori.web.cern.ch/adiflori/hlt_cluster_splitting/circles/web/piechart.php?local=false&dataset=reference_ttbar_pu&resource=time_real&colours=default&groups=packages&show_labels=true&threshold=0) on a TTbar Run3 PU 2025 conditions sample.

I took the chance also to add a specific wf with offset `.19003` (to be aligned to the other cluster splitting related wfs) and a `ProdLike` version with `.1900321`.

#### PR validation:

`runTheMatrix.py -w upgrade -l 17434.19003,17434.1900321`
