### PR TITLE
Add support for adding variable-size attributes (std::vector) within objects for NanoAOD

### DIFF
--- a/CommonTools/Utils/interface/TypedStringObjectMethodCaller.h
+++ b/CommonTools/Utils/interface/TypedStringObjectMethodCaller.h
@@ -24,12 +24,13 @@ struct TypedStringObjectMethodCaller {
       }
     } catch (reco::parser::BaseException& e) {
       throw edm::Exception(edm::errors::Configuration)
-        << "MethodChainGrammer parse error:" << reco::parser::baseExceptionWhat(e) << " (char " << e.where - startingFrom << ")\n";
+          << "MethodChainGrammer parse error:" << reco::parser::baseExceptionWhat(e) << " (char "
+          << e.where - startingFrom << ")\n";
     }
   }
 
-  R operator()(const T &t) const {
-    edm::ObjectWithDict o(type_, const_cast<T *>(&t));
+  R operator()(const T& t) const {
+    edm::ObjectWithDict o(type_, const_cast<T*>(&t));
     edm::ObjectWithDict ret = methodchain_->value(o);
     return *static_cast<R*>(ret.address());
   }

--- a/CommonTools/Utils/interface/TypedStringObjectMethodCaller.h
+++ b/CommonTools/Utils/interface/TypedStringObjectMethodCaller.h
@@ -1,0 +1,42 @@
+#ifndef CommonTools_Utils_TypedStringObjectMethodCaller_h
+#define CommonTools_Utils_TypedStringObjectMethodCaller_h
+/* \class TypedStringObjectMethodCaller
+ * 
+ * Object's method (or a chain of methods) caller functor with generic return-type, specified by string expression
+ *
+ */
+
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "CommonTools/Utils/interface/parser/Exception.h"
+#include "CommonTools/Utils/interface/parser/MethodChain.h"
+#include "CommonTools/Utils/interface/parser/MethodChainGrammar.h"
+#include "FWCore/Reflection/interface/ObjectWithDict.h"
+
+template <typename T, typename R, bool DefaultLazyness = false>
+struct TypedStringObjectMethodCaller {
+  TypedStringObjectMethodCaller(const std::string expr, bool lazy = DefaultLazyness) : type_(typeid(T)) {
+    using namespace boost::spirit::classic;
+    reco::parser::MethodChainGrammar grammar(methodchain_, type_, lazy);
+    const char* startingFrom = expr.c_str();
+    try {
+      if (!parse(startingFrom, grammar >> end_p, space_p).full) {
+        throw edm::Exception(edm::errors::Configuration, "failed to parse \"" + expr + "\"");
+      }
+    } catch (reco::parser::BaseException& e) {
+      throw edm::Exception(edm::errors::Configuration)
+        << "MethodChainGrammer parse error:" << reco::parser::baseExceptionWhat(e) << " (char " << e.where - startingFrom << ")\n";
+    }
+  }
+
+  R operator()(const T &t) const {
+    edm::ObjectWithDict o(type_, const_cast<T *>(&t));
+    edm::ObjectWithDict ret = methodchain_->value(o);
+    return *static_cast<R*>(ret.address());
+  }
+
+private:
+  reco::parser::MethodChainPtr methodchain_;
+  edm::TypeWithDict type_;
+};
+
+#endif

--- a/CommonTools/Utils/interface/parser/MethodChain.h
+++ b/CommonTools/Utils/interface/parser/MethodChain.h
@@ -1,0 +1,76 @@
+#ifndef CommonTools_Utils_MethodChain_h
+#define CommonTools_Utils_MethodChain_h
+
+/* \class reco::parser::MethodChain
+ *
+ * Chain of methods
+ * Based on ExpressionBase and ExpressionVar, but remove final conversion to double
+ *
+ */
+
+#include "CommonTools/Utils/interface/parser/MethodInvoker.h"
+#include "CommonTools/Utils/interface/TypeCode.h"
+
+#include <vector>
+#include <oneapi/tbb/concurrent_queue.h>
+
+namespace reco {
+  namespace parser {
+    
+    /// Based on Expression, but its value method returns an edm::ObjectWithDict instead of a double
+    class MethodChainBase {
+    public: // Public Methods
+      virtual ~MethodChainBase() {}
+      virtual edm::ObjectWithDict value(const edm::ObjectWithDict&) const = 0; 
+    };
+    
+    /// Shared ptr to MethodChainBase
+    typedef std::shared_ptr<MethodChainBase> MethodChainPtr;
+
+    /// Evaluate an object's method or datamember (or chain of them)
+    class MethodChain : public MethodChainBase {
+    private:  // Private Data Members
+      std::vector<MethodInvoker> methods_;
+      using Objects = std::vector<std::pair<edm::ObjectWithDict, bool>>;
+      mutable oneapi::tbb::concurrent_queue<Objects> objectsCache_;
+
+    private:  // Private Methods
+      [[nodiscard]] Objects initObjects_() const;
+
+      Objects borrowObjects() const;
+      void returnObjects(Objects&&) const;
+
+    public:  // Public Static Methods
+
+      /// allocate an object to hold the result of a given member (if needed)
+      /// this method is used also from the LazyInvoker code
+      /// returns true if objects returned from this will require a destructor
+      static bool makeStorage(edm::ObjectWithDict& obj, const edm::TypeWithDict& retType);
+
+      /// delete an objecty, if needed
+      /// this method is used also from the LazyInvoker code
+      static void delStorage(edm::ObjectWithDict&);
+
+    public:  // Public Methods
+      MethodChain(const std::vector<MethodInvoker>& methods);
+      MethodChain(const MethodChain&);
+      ~MethodChain();
+      edm::ObjectWithDict value(const edm::ObjectWithDict&) const override;
+    };
+
+    /// Same as MethodChain but with lazy resolution of object methods
+    /// using the dynamic type of the object, and not the one fixed at compile time
+    class LazyMethodChain : public MethodChainBase {
+    private:  // Private Data Members
+      std::vector<LazyInvoker> methods_;
+
+    public:
+      LazyMethodChain(const std::vector<LazyInvoker>& methods);
+      ~LazyMethodChain() override;
+      edm::ObjectWithDict value(const edm::ObjectWithDict&) const override;
+    };
+
+  }  // namespace parser
+}  // namespace reco
+
+#endif  // CommonTools_Utils_MethodChain_h

--- a/CommonTools/Utils/interface/parser/MethodChain.h
+++ b/CommonTools/Utils/interface/parser/MethodChain.h
@@ -16,14 +16,14 @@
 
 namespace reco {
   namespace parser {
-    
+
     /// Based on Expression, but its value method returns an edm::ObjectWithDict instead of a double
     class MethodChainBase {
-    public: // Public Methods
+    public:  // Public Methods
       virtual ~MethodChainBase() {}
-      virtual edm::ObjectWithDict value(const edm::ObjectWithDict&) const = 0; 
+      virtual edm::ObjectWithDict value(const edm::ObjectWithDict&) const = 0;
     };
-    
+
     /// Shared ptr to MethodChainBase
     typedef std::shared_ptr<MethodChainBase> MethodChainPtr;
 
@@ -41,7 +41,6 @@ namespace reco {
       void returnObjects(Objects&&) const;
 
     public:  // Public Static Methods
-
       /// allocate an object to hold the result of a given member (if needed)
       /// this method is used also from the LazyInvoker code
       /// returns true if objects returned from this will require a destructor

--- a/CommonTools/Utils/interface/parser/MethodChainGrammar.h
+++ b/CommonTools/Utils/interface/parser/MethodChainGrammar.h
@@ -25,14 +25,14 @@
 namespace reco {
   namespace parser {
     struct MethodChainGrammar : public boost::spirit::classic::grammar<MethodChainGrammar> {
-      MethodChainPtr *methchain_;
-      bool lazy_; 
+      MethodChainPtr* methchain_;
+      bool lazy_;
       mutable MethodStack methStack;
       mutable LazyMethodStack lazyMethStack;
       mutable MethodArgumentStack methArgStack;
       mutable TypeStack typeStack;
 
-      MethodChainGrammar(MethodChainPtr &methchain, const edm::TypeWithDict& iType, bool lazy = false)
+      MethodChainGrammar(MethodChainPtr& methchain, const edm::TypeWithDict& iType, bool lazy = false)
           : methchain_(&methchain), lazy_(lazy) {
         typeStack.push_back(iType);
       }
@@ -59,10 +59,10 @@ namespace reco {
           metharg = (strict_real_p[methodArg_s]) | (int_p[methodArg_s]) |
                     (ch_p('"') >> *(~ch_p('"')) >> ch_p('"'))[methodArg_s] |
                     (ch_p('\'') >> *(~ch_p('\'')) >> ch_p('\''))[methodArg_s];
-          method = // alnum_p doesn't accept underscores, so we use chset<>; lexeme_d needed to avoid whitespace skipping within method names
-                   (lexeme_d[alpha_p >> *chset<>("a-zA-Z0-9_")] >> ch_p('(') >> metharg >> *(ch_p(',') >> metharg) >>
-                    expectParenthesis(ch_p(')')))[method_s] |
-                   ((lexeme_d[alpha_p >> *chset<>("a-zA-Z0-9_")])[method_s] >> !(ch_p('(') >> ch_p(')')));
+          method =  // alnum_p doesn't accept underscores, so we use chset<>; lexeme_d needed to avoid whitespace skipping within method names
+              (lexeme_d[alpha_p >> *chset<>("a-zA-Z0-9_")] >> ch_p('(') >> metharg >> *(ch_p(',') >> metharg) >>
+               expectParenthesis(ch_p(')')))[method_s] |
+              ((lexeme_d[alpha_p >> *chset<>("a-zA-Z0-9_")])[method_s] >> !(ch_p('(') >> ch_p(')')));
           arrayAccess = (ch_p('[') >> metharg >> *(ch_p(',') >> metharg) >> expectParenthesis(ch_p(']')))[method_s];
           methodchain = (method >> *(arrayAccess | (ch_p('.') >> expect(method))))[methodchain_s];
         }
@@ -70,7 +70,7 @@ namespace reco {
         rule const& start() const { return methodchain; }
       };
     };
-  }
-}
+  }  // namespace parser
+}  // namespace reco
 
 #endif

--- a/CommonTools/Utils/interface/parser/MethodChainGrammar.h
+++ b/CommonTools/Utils/interface/parser/MethodChainGrammar.h
@@ -1,0 +1,76 @@
+#ifndef CommonTools_Utils_MethodChainGrammar_h
+#define CommonTools_Utils_MethodChainGrammar_h
+/* \class MethodChainGrammer
+ *
+ * subset grammar of the full Grammer (CommonTools/Utils/interface/parser/Grammar.h), allowing only a chain of methods 
+ *
+ */
+
+#include "boost/spirit/include/classic_core.hpp"
+#include "boost/spirit/include/classic_grammar_def.hpp"
+#include "boost/spirit/include/classic_chset.hpp"
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Reflection/interface/ObjectWithDict.h"
+#include "CommonTools/Utils/interface/parser/MethodChain.h"
+#include "CommonTools/Utils/interface/parser/MethodChainSetter.h"
+#include "CommonTools/Utils/interface/parser/MethodSetter.h"
+#include "CommonTools/Utils/interface/parser/MethodArgumentSetter.h"
+#include "CommonTools/Utils/interface/parser/MethodInvoker.h"
+#include "CommonTools/Utils/interface/parser/MethodStack.h"
+#include "CommonTools/Utils/interface/parser/TypeStack.h"
+#include "CommonTools/Utils/interface/parser/MethodArgumentStack.h"
+#include "CommonTools/Utils/interface/parser/AnyMethodArgument.h"
+#include "CommonTools/Utils/interface/parser/Exception.h"
+
+namespace reco {
+  namespace parser {
+    struct MethodChainGrammar : public boost::spirit::classic::grammar<MethodChainGrammar> {
+      MethodChainPtr *methchain_;
+      bool lazy_; 
+      mutable MethodStack methStack;
+      mutable LazyMethodStack lazyMethStack;
+      mutable MethodArgumentStack methArgStack;
+      mutable TypeStack typeStack;
+
+      MethodChainGrammar(MethodChainPtr &methchain, const edm::TypeWithDict& iType, bool lazy = false)
+          : methchain_(&methchain), lazy_(lazy) {
+        typeStack.push_back(iType);
+      }
+
+      template <typename ScannerT>
+      struct definition {
+        typedef boost::spirit::classic::rule<ScannerT> rule;
+        rule metharg, method, arrayAccess, methodchain;
+        definition(const MethodChainGrammar& self) {
+          using namespace boost::spirit::classic;
+
+          MethodArgumentSetter methodArg_s(self.methArgStack);
+          MethodSetter method_s(self.methStack, self.lazyMethStack, self.typeStack, self.methArgStack, self.lazy_);
+          MethodChainSetter methodchain_s(*self.methchain_, self.methStack, self.lazyMethStack, self.typeStack);
+
+          BOOST_SPIRIT_DEBUG_RULE(methodchain);
+          BOOST_SPIRIT_DEBUG_RULE(arrayAccess);
+          BOOST_SPIRIT_DEBUG_RULE(method);
+          BOOST_SPIRIT_DEBUG_RULE(metharg);
+
+          boost::spirit::classic::assertion<SyntaxErrors> expectParenthesis(kMissingClosingParenthesis);
+          boost::spirit::classic::assertion<SyntaxErrors> expect(kSyntaxError);
+
+          metharg = (strict_real_p[methodArg_s]) | (int_p[methodArg_s]) |
+                    (ch_p('"') >> *(~ch_p('"')) >> ch_p('"'))[methodArg_s] |
+                    (ch_p('\'') >> *(~ch_p('\'')) >> ch_p('\''))[methodArg_s];
+          method = // alnum_p doesn't accept underscores, so we use chset<>; lexeme_d needed to avoid whitespace skipping within method names
+                   (lexeme_d[alpha_p >> *chset<>("a-zA-Z0-9_")] >> ch_p('(') >> metharg >> *(ch_p(',') >> metharg) >>
+                    expectParenthesis(ch_p(')')))[method_s] |
+                   ((lexeme_d[alpha_p >> *chset<>("a-zA-Z0-9_")])[method_s] >> !(ch_p('(') >> ch_p(')')));
+          arrayAccess = (ch_p('[') >> metharg >> *(ch_p(',') >> metharg) >> expectParenthesis(ch_p(']')))[method_s];
+          methodchain = (method >> *(arrayAccess | (ch_p('.') >> expect(method))))[methodchain_s];
+        }
+
+        rule const& start() const { return methodchain; }
+      };
+    };
+  }
+}
+
+#endif

--- a/CommonTools/Utils/interface/parser/MethodChainSetter.h
+++ b/CommonTools/Utils/interface/parser/MethodChainSetter.h
@@ -1,0 +1,36 @@
+#ifndef CommonTools_Utils_MethodChainSetter_h
+#define CommonTools_Utils_MethodChainSetter_h
+/* \class reco::parser::MethodChainSetter
+ *
+ * Method Chain setter, used to construct MethodChain when parsing with boost::spirit
+ *
+ */
+#include "CommonTools/Utils/interface/parser/MethodChain.h"
+#include "CommonTools/Utils/interface/parser/MethodStack.h"
+#include "CommonTools/Utils/interface/parser/TypeStack.h"
+
+#include <iostream>
+
+namespace reco {
+  namespace parser {
+    struct MethodChainSetter {
+      MethodChainSetter(MethodChainPtr &methchain,
+                        MethodStack &methStack,
+                        LazyMethodStack &lazyMethStack,
+                        TypeStack &typeStack)
+          : methchain_(methchain), methStack_(methStack), lazyMethStack_(lazyMethStack), typeStack_(typeStack) {}
+      void operator()(const char *, const char *) const;
+
+    private:
+      void push(const char *, const char *) const;
+      void lazyPush(const char *, const char *) const;
+
+      MethodChainPtr &methchain_;
+      MethodStack &methStack_;
+      LazyMethodStack &lazyMethStack_;
+      TypeStack &typeStack_;
+    };
+  }  // namespace parser
+}  // namespace reco
+
+#endif

--- a/CommonTools/Utils/src/MethodChain.cc
+++ b/CommonTools/Utils/src/MethodChain.cc
@@ -28,14 +28,9 @@ MethodChain::Objects MethodChain::initObjects_() const {
   return objects;
 }
 
-MethodChain::MethodChain(const vector<MethodInvoker>& methods)
-    : methods_(methods) {
-  returnObjects(initObjects_());
-}
+MethodChain::MethodChain(const vector<MethodInvoker>& methods) : methods_(methods) { returnObjects(initObjects_()); }
 
-MethodChain::MethodChain(const MethodChain& rhs) : methods_(rhs.methods_) {
-  returnObjects(initObjects_());
-}
+MethodChain::MethodChain(const MethodChain& rhs) : methods_(rhs.methods_) { returnObjects(initObjects_()); }
 
 MethodChain::Objects MethodChain::borrowObjects() const {
   Objects objects;

--- a/CommonTools/Utils/src/MethodChain.cc
+++ b/CommonTools/Utils/src/MethodChain.cc
@@ -1,0 +1,127 @@
+#include "CommonTools/Utils/interface/parser/MethodChain.h"
+#include "CommonTools/Utils/interface/parser/MethodInvoker.h"
+
+#include "FWCore/Reflection/interface/ObjectWithDict.h"
+#include "FWCore/Reflection/interface/FunctionWithDict.h"
+#include "FWCore/Reflection/interface/MemberWithDict.h"
+#include "FWCore/Reflection/interface/TypeWithDict.h"
+
+#include <cassert>
+#include <map>
+
+using namespace reco::parser;
+using namespace std;
+
+MethodChain::Objects MethodChain::initObjects_() const {
+  Objects objects(methods_.size(), {edm::ObjectWithDict(), false});
+  assert(objects.size() == methods_.size());
+  auto IO = objects.begin();
+  for (auto const& method : methods_) {
+    if (method.isFunction()) {
+      edm::TypeWithDict retType = method.method().finalReturnType();
+      IO->second = makeStorage(IO->first, retType);
+    } else {
+      *IO = {edm::ObjectWithDict(), false};
+    }
+    ++IO;
+  }
+  return objects;
+}
+
+MethodChain::MethodChain(const vector<MethodInvoker>& methods)
+    : methods_(methods) {
+  returnObjects(initObjects_());
+}
+
+MethodChain::MethodChain(const MethodChain& rhs) : methods_(rhs.methods_) {
+  returnObjects(initObjects_());
+}
+
+MethodChain::Objects MethodChain::borrowObjects() const {
+  Objects objects;
+  if (objectsCache_.try_pop(objects)) {
+    return objects;
+  }
+  return initObjects_();
+}
+
+void MethodChain::returnObjects(Objects&& iOb) const { objectsCache_.push(std::move(iOb)); }
+
+MethodChain::~MethodChain() {
+  Objects objects;
+  while (objectsCache_.try_pop(objects)) {
+    for (auto& o : objects) {
+      delStorage(o.first);
+    }
+  }
+}
+
+void MethodChain::delStorage(edm::ObjectWithDict& obj) {
+  if (!obj.address()) {
+    return;
+  }
+  if (obj.typeOf().isPointer() || obj.typeOf().isReference()) {
+    // just delete a void*, as that's what it was
+    void** p = static_cast<void**>(obj.address());
+    delete p;
+  } else {
+    //std::cout << "Calling Destruct on a " <<
+    //  obj.typeOf().qualifiedName() << std::endl;
+    obj.typeOf().deallocate(obj.address());
+  }
+}
+
+bool MethodChain::makeStorage(edm::ObjectWithDict& obj, const edm::TypeWithDict& retType) {
+  static const edm::TypeWithDict tVoid(edm::TypeWithDict::byName("void"));
+  bool ret = false;
+  if (retType == tVoid) {
+    obj = edm::ObjectWithDict::byType(tVoid);
+  } else if (retType.isPointer() || retType.isReference()) {
+    // in this case, I have to allocate a void*, not an object!
+    obj = edm::ObjectWithDict(retType, new void*);
+  } else {
+    obj = edm::ObjectWithDict(retType, retType.allocate());
+    ret = retType.isClass();
+    //std::cout << "MethodChain: reserved memory at "  << obj.address() <<
+    //  " for a " << retType.qualifiedName() << " returned by " <<
+    //  member.name() << std::endl;
+  }
+  return ret;
+}
+
+edm::ObjectWithDict MethodChain::value(const edm::ObjectWithDict& obj) const {
+  edm::ObjectWithDict val(obj);
+  auto objects = borrowObjects();
+  auto IO = objects.begin();
+  for (auto& m : methods_) {
+    val = m.invoke(val, IO->first);
+    ++IO;
+  }
+  for (auto RI = objects.rbegin(), RE = objects.rend(); RI != RE; ++RI) {
+    if (RI->second) {
+      RI->first.destruct(false);
+    }
+  }
+  returnObjects(std::move(objects));
+  return val;
+}
+
+LazyMethodChain::LazyMethodChain(const std::vector<LazyInvoker>& methods) : methods_(methods) {}
+
+LazyMethodChain::~LazyMethodChain() {}
+
+edm::ObjectWithDict LazyMethodChain::value(const edm::ObjectWithDict& o) const {
+  edm::ObjectWithDict val = o;
+  std::vector<StorageManager> storage;
+  storage.reserve(methods_.size());
+
+  std::vector<LazyInvoker>::const_iterator I = methods_.begin();
+  std::vector<LazyInvoker>::const_iterator E = methods_.end();
+  for (; I < E; ++I) {
+    val = I->invoke(val, storage);
+  }
+  while (not storage.empty()) {
+    storage.pop_back();
+  }
+  return val;
+}

--- a/CommonTools/Utils/src/MethodChainSetter.cc
+++ b/CommonTools/Utils/src/MethodChainSetter.cc
@@ -1,0 +1,30 @@
+#include "CommonTools/Utils/interface/parser/MethodChainSetter.h"
+#include "CommonTools/Utils/interface/parser/MethodChain.h"
+#include "CommonTools/Utils/interface/returnType.h"
+#include "CommonTools/Utils/interface/parser/Exception.h"
+#include <string>
+
+using namespace reco::parser;
+using namespace std;
+
+void MethodChainSetter::operator()(const char *begin, const char *end) const {
+  //std::cerr << "MethodChainSetter: Pushed [" << std::string(begin,end) << "]" << std::endl;
+  if (!methStack_.empty())
+    push(begin, end);
+  else if (!lazyMethStack_.empty())
+    lazyPush(begin, end);
+  else
+    throw Exception(begin) << " Expression didn't parse neither hastily nor lazyly. This must not happen.\n";
+}
+
+void MethodChainSetter::push(const char *begin, const char *end) const {
+  methchain_ = std::shared_ptr<MethodChainBase>(new MethodChain(methStack_));
+  methStack_.clear();
+  typeStack_.resize(1);
+}
+
+void MethodChainSetter::lazyPush(const char *begin, const char *end) const {
+  methchain_ = std::shared_ptr<MethodChainBase>(new LazyMethodChain(lazyMethStack_));
+  lazyMethStack_.clear();
+  typeStack_.resize(1);
+}

--- a/PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h
+++ b/PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h
@@ -14,6 +14,7 @@
 
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 #include "CommonTools/Utils/interface/StringObjectFunction.h"
+#include "CommonTools/Utils/interface/TypedStringObjectMethodCaller.h"
 
 #include <memory>
 #include <vector>
@@ -71,6 +72,55 @@ public:
 protected:
   StringFunctor func_;
   StringFunctor precisionFunc_;
+};
+
+// Collection variables: i.e. variables that is variable-size collection, e.g. std::vector
+template <typename ObjType>
+class CollectionVariable : public VariableBase {
+public:
+  CollectionVariable(const std::string &aname, const edm::ParameterSet &cfg) : VariableBase(aname, cfg) {}
+  virtual std::unique_ptr<std::vector<unsigned int>> getCounts(std::vector<const ObjType *> &selobjs) const = 0;
+  virtual void fill(std::vector<const ObjType *> &selobjs, nanoaod::FlatTable &out) const = 0;
+};
+
+template <typename ObjType, typename CollectionStringFunctor, typename PrecisionStringFunctor, typename ValType>
+class FuncCollectionVariable : public CollectionVariable<ObjType> {
+public:
+  FuncCollectionVariable(const std::string &aname, const edm::ParameterSet &cfg)
+    : CollectionVariable<ObjType>(aname, cfg),
+      func_(cfg.getParameter<std::string>("expr"), cfg.getUntrackedParameter<bool>("lazyEval")),
+      precisionFunc_(cfg.existsAs<std::string>("precision") ? cfg.getParameter<std::string>("precision") : "23",
+                     cfg.getUntrackedParameter<bool>("lazyEval")) {}
+  ~FuncCollectionVariable() override {}
+  
+  std::unique_ptr<std::vector<unsigned int>> getCounts(std::vector<const ObjType *> &selobjs) const override{
+    auto counts = std::make_unique<std::vector<unsigned int>>();
+    for (auto const &obj : selobjs)
+      counts->push_back(func_(*obj).size());
+    return counts;
+  }
+
+  void fill(std::vector<const ObjType *> &selobjs, nanoaod::FlatTable &out) const override {
+    std::vector<ValType> vals;
+    for (unsigned int i = 0; i < selobjs.size(); ++i) {
+      for (ValType val : func_(*selobjs[i])) {
+        if constexpr (std::is_same<ValType, float>()) {
+          if (this->precision_ == -2) {
+            auto prec = precisionFunc_(*selobjs[i]);
+            if (prec > 0) {
+              val = MiniFloatConverter::reduceMantissaToNbitsRounding(val, prec);
+            }
+          }
+        }
+        vals.push_back(val);
+      }
+    }
+    out.template addColumn<ValType>(this->name_, vals, this->doc_, this->precision_);
+  }
+
+protected:
+  CollectionStringFunctor func_; // functor to get collection objects
+  PrecisionStringFunctor precisionFunc_; // functor to get output precision
 };
 
 // External variables: i.e. variables that are not member or methods of the object
@@ -484,6 +534,176 @@ protected:
   typedef TypedValueMapVariable<T, V, StringObjectFunction<V>, uint8_t> UInt8TypedExtVar;
   typedef TypedValueMapVariable<T, V, StringObjectFunction<V>, int16_t> Int16TypedExtVar;
   typedef TypedValueMapVariable<T, V, StringObjectFunction<V>, uint16_t> UInt16TypedExtVar;
+};
+
+template <typename T>
+class SimpleCollectionFlatTableProducer : public SimpleFlatTableProducer<T> {
+public: 
+  SimpleCollectionFlatTableProducer(edm::ParameterSet const &params) : SimpleFlatTableProducer<T>(params) {
+    if (params.existsAs<edm::ParameterSet>("collectionVariables")) {
+      edm::ParameterSet const &collectionVarsPSet = params.getParameter<edm::ParameterSet>("collectionVariables");
+      for (const std::string &coltablename : collectionVarsPSet.getParameterNamesForType<edm::ParameterSet>()) { // tables of variables
+        const auto &coltablePSet = collectionVarsPSet.getParameter<edm::ParameterSet>(coltablename);
+        CollectionVariableTableInfo coltable;
+        coltable.name = coltablePSet.existsAs<std::string>("name") ? coltablePSet.getParameter<std::string>("name") : coltablename; 
+        coltable.doc = coltablePSet.getParameter<std::string>("doc");
+        coltable.useCount = coltablePSet.getParameter<bool>("useCount");
+        coltable.useOffset = coltablePSet.getParameter<bool>("useOffset");
+        const auto &colvarsPSet = coltablePSet.getParameter<edm::ParameterSet>("variables");
+        for (const std::string &colvarname : colvarsPSet.getParameterNamesForType<edm::ParameterSet>()) { // variables
+          const auto &colvarPSet = colvarsPSet.getParameter<edm::ParameterSet>(colvarname);
+          const std::string &type = colvarPSet.getParameter<std::string>("type");
+          if (type == "int")
+            coltable.colvars.push_back(std::make_unique<IntVectorVar>(colvarname, colvarPSet));
+          else if (type == "uint")
+            coltable.colvars.push_back(std::make_unique<UIntVectorVar>(colvarname, colvarPSet));
+          else if (type == "float")
+            coltable.colvars.push_back(std::make_unique<FloatVectorVar>(colvarname, colvarPSet));
+          else if (type == "double")
+            coltable.colvars.push_back(std::make_unique<DoubleVectorVar>(colvarname, colvarPSet));
+          else if (type == "uint8")
+            coltable.colvars.push_back(std::make_unique<UInt8VectorVar>(colvarname, colvarPSet));
+          else if (type == "int16")
+            coltable.colvars.push_back(std::make_unique<Int16VectorVar>(colvarname, colvarPSet));
+          else if (type == "uint16")
+            coltable.colvars.push_back(std::make_unique<UInt16VectorVar>(colvarname, colvarPSet));
+          else
+            throw cms::Exception("Configuration", "unsupported type " + type + " for variable " + colvarname + " in " + coltablename);
+        }
+        this->coltables.push_back(std::move(coltable));
+        edm::stream::EDProducer<>::produces<nanoaod::FlatTable>(coltables.back().name + "Table");
+      }
+    }
+  }
+
+  ~SimpleCollectionFlatTableProducer() override {}
+
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+    edm::ParameterSetDescription desc = SimpleFlatTableProducer<T>::baseDescriptions();
+    edm::ParameterSetDescription colvariable;
+    colvariable.add<std::string>("expr")->setComment("a function to define the content of the branch in the flat table");
+    colvariable.add<std::string>("doc")->setComment("few words of self documentation");
+    colvariable.addUntracked<bool>("lazyEval", false)
+        ->setComment("if true, can use methods of inheriting classes in `expr`. Can cause problems with threading.");
+    colvariable.ifValue(
+        edm::ParameterDescription<std::string>(
+          "type", "int", true, edm::Comment("the c++ type of the branch in the flat table")),
+        edm::allowedValues<std::string>("int", "uint", "float", "double", "uint8", "int16", "uint16"));
+    colvariable.addOptionalNode(
+        edm::ParameterDescription<int>(
+            "precision", true, edm::Comment("the precision with which to store the value in the flat table")) xor
+            edm::ParameterDescription<std::string>(
+                "precision", true, edm::Comment("the precision with which to store the value in the flat table")),
+        false);
+    edm::ParameterSetDescription colvariables;
+    colvariables.setComment("a parameters set to define all variable to fill the flat table");
+    colvariables.addNode(
+        edm::ParameterWildcard<edm::ParameterSetDescription>("*", edm::RequireAtLeastOne, true, colvariable));
+      
+    edm::ParameterSetDescription coltable;
+    coltable.addOptional<std::string>("name")->setComment("name of the branch in the flat table containing flatten collections of variables");
+    coltable.add<std::string>("doc")->setComment("few words description of the table containing flatten collections of variables");
+    coltable.add<bool>("useCount", true)
+        ->setComment("whether to use count for the main table to index table with flatten collections of variables");
+    coltable.add<bool>("useOffset", false)
+        ->setComment("whether to use offset for the main table to index table with flatten collections of variables");
+    coltable.add<edm::ParameterSetDescription>("variables", colvariables);
+
+    edm::ParameterSetDescription coltables;
+    coltables.setComment("a parameters set to define variables to be flatten to fill the table");
+    coltables.addOptionalNode(
+        edm::ParameterWildcard<edm::ParameterSetDescription>("*", edm::RequireZeroOrMore, true, coltable), false);
+    desc.addOptional<edm::ParameterSetDescription>("collectionVariables", coltables);
+
+    descriptions.addWithDefaultLabel(desc);
+  }
+
+  void produce(edm::Event &iEvent, const edm::EventSetup &iSetup) override {
+    // same as SimpleFlatTableProducer
+    edm::Handle<edm::View<T>> prod;
+    iEvent.getByToken(this->src_, prod);
+
+    std::vector<const T *> selobjs;
+    std::vector<edm::Ptr<T>> selptrs;  // for external variables
+    if (prod.isValid() || !(this->skipNonExistingSrc_)) {
+      if (this->singleton_) {
+        assert(prod->size() == 1);
+        selobjs.push_back(&(*prod)[0]);
+        if (!this->extvars_.empty() || !this->typedextvars_.empty())
+          selptrs.emplace_back(prod->ptrAt(0));
+      } else {
+        for (unsigned int i = 0, n = prod->size(); i < n; ++i) {
+          const auto &obj = (*prod)[i];
+          if (this->cut_(obj)) {
+            selobjs.push_back(&obj);
+            if (!this->extvars_.empty() || !this->typedextvars_.empty())
+              selptrs.emplace_back(prod->ptrAt(i));
+          }
+          if (selobjs.size() >= this->maxLen_)
+            break;
+        }
+      }
+    }
+
+    auto out = std::make_unique<nanoaod::FlatTable>(selobjs.size(), this->name_, this->singleton_, this->extension_);
+    for (const auto &var : this->vars_)
+      var->fill(selobjs, *out);
+    for (const auto &var : this->extvars_)
+      var->fill(iEvent, selptrs, *out);
+    for (const auto &var : this->typedextvars_)
+      var->fill(iEvent, selptrs, *out);
+
+    // collection variable tables
+    for (const auto &coltable : this->coltables) {
+      std::unique_ptr<std::vector<unsigned int>> counts = coltable.colvars[0]->getCounts(selobjs);
+      // compute size
+      unsigned int coltablesize = 0;
+      for (auto const &count : *counts)
+        coltablesize += count;
+      // add count branch if requested
+      if (coltable.useCount)
+        out->template addColumn<uint16_t>("n" + coltable.name, *counts, "counts for " + coltable.name);
+      // add offset branch if requested
+      if (coltable.useOffset) {
+        unsigned int offset = 0;
+        std::vector<unsigned int> offsets;
+        for (auto const &count : *counts) {
+          offsets.push_back(offset);
+          offset += count;
+        }
+        out->template addColumn<uint16_t>("o" + coltable.name, offsets, "offsets for " + coltable.name);
+      }
+
+      std::unique_ptr<nanoaod::FlatTable> outcoltable = std::make_unique<nanoaod::FlatTable>(coltablesize, coltable.name, false, false);
+      for (const auto &colvar : coltable.colvars) {
+        colvar->fill(selobjs, *outcoltable);
+      }
+      outcoltable->setDoc(coltable.doc);
+      iEvent.put(std::move(outcoltable), coltable.name + "Table");
+    }
+    
+    // put the main table into the event
+    out->setDoc(this->doc_);
+    iEvent.put(std::move(out));
+  }
+
+protected:
+  typedef FuncCollectionVariable<T, TypedStringObjectMethodCaller<T, std::vector<int32_t>>, StringObjectFunction<T>, int32_t> IntVectorVar;
+  typedef FuncCollectionVariable<T, TypedStringObjectMethodCaller<T, std::vector<uint32_t>>, StringObjectFunction<T>, uint32_t> UIntVectorVar;
+  typedef FuncCollectionVariable<T, TypedStringObjectMethodCaller<T, std::vector<float>>, StringObjectFunction<T>, float> FloatVectorVar;
+  typedef FuncCollectionVariable<T, TypedStringObjectMethodCaller<T, std::vector<double>>, StringObjectFunction<T>, double> DoubleVectorVar;
+  typedef FuncCollectionVariable<T, TypedStringObjectMethodCaller<T, std::vector<uint8_t>>, StringObjectFunction<T>, uint8_t> UInt8VectorVar;
+  typedef FuncCollectionVariable<T, TypedStringObjectMethodCaller<T, std::vector<int16_t>>, StringObjectFunction<T>, int16_t> Int16VectorVar;
+  typedef FuncCollectionVariable<T, TypedStringObjectMethodCaller<T, std::vector<uint16_t>>, StringObjectFunction<T>, uint16_t> UInt16VectorVar;
+
+  struct CollectionVariableTableInfo {
+    std::string name;
+    std::string doc;
+    bool useCount;
+    bool useOffset;
+    std::vector<std::unique_ptr<CollectionVariable<T>>> colvars;
+  };
+  std::vector<CollectionVariableTableInfo> coltables;
 };
 
 template <typename T>

--- a/PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h
+++ b/PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h
@@ -87,13 +87,13 @@ template <typename ObjType, typename CollectionStringFunctor, typename Precision
 class FuncCollectionVariable : public CollectionVariable<ObjType> {
 public:
   FuncCollectionVariable(const std::string &aname, const edm::ParameterSet &cfg)
-    : CollectionVariable<ObjType>(aname, cfg),
-      func_(cfg.getParameter<std::string>("expr"), cfg.getUntrackedParameter<bool>("lazyEval")),
-      precisionFunc_(cfg.existsAs<std::string>("precision") ? cfg.getParameter<std::string>("precision") : "23",
-                     cfg.getUntrackedParameter<bool>("lazyEval")) {}
+      : CollectionVariable<ObjType>(aname, cfg),
+        func_(cfg.getParameter<std::string>("expr"), cfg.getUntrackedParameter<bool>("lazyEval")),
+        precisionFunc_(cfg.existsAs<std::string>("precision") ? cfg.getParameter<std::string>("precision") : "23",
+                       cfg.getUntrackedParameter<bool>("lazyEval")) {}
   ~FuncCollectionVariable() override {}
-  
-  std::unique_ptr<std::vector<unsigned int>> getCounts(std::vector<const ObjType *> &selobjs) const override{
+
+  std::unique_ptr<std::vector<unsigned int>> getCounts(std::vector<const ObjType *> &selobjs) const override {
     auto counts = std::make_unique<std::vector<unsigned int>>();
     for (auto const &obj : selobjs)
       counts->push_back(func_(*obj).size());
@@ -119,8 +119,8 @@ public:
   }
 
 protected:
-  CollectionStringFunctor func_; // functor to get collection objects
-  PrecisionStringFunctor precisionFunc_; // functor to get output precision
+  CollectionStringFunctor func_;          // functor to get collection objects
+  PrecisionStringFunctor precisionFunc_;  // functor to get output precision
 };
 
 // External variables: i.e. variables that are not member or methods of the object
@@ -538,19 +538,21 @@ protected:
 
 template <typename T>
 class SimpleCollectionFlatTableProducer : public SimpleFlatTableProducer<T> {
-public: 
+public:
   SimpleCollectionFlatTableProducer(edm::ParameterSet const &params) : SimpleFlatTableProducer<T>(params) {
     if (params.existsAs<edm::ParameterSet>("collectionVariables")) {
       edm::ParameterSet const &collectionVarsPSet = params.getParameter<edm::ParameterSet>("collectionVariables");
-      for (const std::string &coltablename : collectionVarsPSet.getParameterNamesForType<edm::ParameterSet>()) { // tables of variables
+      for (const std::string &coltablename :
+           collectionVarsPSet.getParameterNamesForType<edm::ParameterSet>()) {  // tables of variables
         const auto &coltablePSet = collectionVarsPSet.getParameter<edm::ParameterSet>(coltablename);
         CollectionVariableTableInfo coltable;
-        coltable.name = coltablePSet.existsAs<std::string>("name") ? coltablePSet.getParameter<std::string>("name") : coltablename; 
+        coltable.name =
+            coltablePSet.existsAs<std::string>("name") ? coltablePSet.getParameter<std::string>("name") : coltablename;
         coltable.doc = coltablePSet.getParameter<std::string>("doc");
         coltable.useCount = coltablePSet.getParameter<bool>("useCount");
         coltable.useOffset = coltablePSet.getParameter<bool>("useOffset");
         const auto &colvarsPSet = coltablePSet.getParameter<edm::ParameterSet>("variables");
-        for (const std::string &colvarname : colvarsPSet.getParameterNamesForType<edm::ParameterSet>()) { // variables
+        for (const std::string &colvarname : colvarsPSet.getParameterNamesForType<edm::ParameterSet>()) {  // variables
           const auto &colvarPSet = colvarsPSet.getParameter<edm::ParameterSet>(colvarname);
           const std::string &type = colvarPSet.getParameter<std::string>("type");
           if (type == "int")
@@ -568,7 +570,8 @@ public:
           else if (type == "uint16")
             coltable.colvars.push_back(std::make_unique<UInt16VectorVar>(colvarname, colvarPSet));
           else
-            throw cms::Exception("Configuration", "unsupported type " + type + " for variable " + colvarname + " in " + coltablename);
+            throw cms::Exception("Configuration",
+                                 "unsupported type " + type + " for variable " + colvarname + " in " + coltablename);
         }
         this->coltables.push_back(std::move(coltable));
         edm::stream::EDProducer<>::produces<nanoaod::FlatTable>(coltables.back().name + "Table");
@@ -581,14 +584,14 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
     edm::ParameterSetDescription desc = SimpleFlatTableProducer<T>::baseDescriptions();
     edm::ParameterSetDescription colvariable;
-    colvariable.add<std::string>("expr")->setComment("a function to define the content of the branch in the flat table");
+    colvariable.add<std::string>("expr")->setComment(
+        "a function to define the content of the branch in the flat table");
     colvariable.add<std::string>("doc")->setComment("few words of self documentation");
     colvariable.addUntracked<bool>("lazyEval", false)
         ->setComment("if true, can use methods of inheriting classes in `expr`. Can cause problems with threading.");
-    colvariable.ifValue(
-        edm::ParameterDescription<std::string>(
-          "type", "int", true, edm::Comment("the c++ type of the branch in the flat table")),
-        edm::allowedValues<std::string>("int", "uint", "float", "double", "uint8", "int16", "uint16"));
+    colvariable.ifValue(edm::ParameterDescription<std::string>(
+                            "type", "int", true, edm::Comment("the c++ type of the branch in the flat table")),
+                        edm::allowedValues<std::string>("int", "uint", "float", "double", "uint8", "int16", "uint16"));
     colvariable.addOptionalNode(
         edm::ParameterDescription<int>(
             "precision", true, edm::Comment("the precision with which to store the value in the flat table")) xor
@@ -599,10 +602,12 @@ public:
     colvariables.setComment("a parameters set to define all variable to fill the flat table");
     colvariables.addNode(
         edm::ParameterWildcard<edm::ParameterSetDescription>("*", edm::RequireAtLeastOne, true, colvariable));
-      
+
     edm::ParameterSetDescription coltable;
-    coltable.addOptional<std::string>("name")->setComment("name of the branch in the flat table containing flatten collections of variables");
-    coltable.add<std::string>("doc")->setComment("few words description of the table containing flatten collections of variables");
+    coltable.addOptional<std::string>("name")->setComment(
+        "name of the branch in the flat table containing flatten collections of variables");
+    coltable.add<std::string>("doc")->setComment(
+        "few words description of the table containing flatten collections of variables");
     coltable.add<bool>("useCount", true)
         ->setComment("whether to use count for the main table to index table with flatten collections of variables");
     coltable.add<bool>("useOffset", false)
@@ -674,27 +679,32 @@ public:
         out->template addColumn<uint16_t>("o" + coltable.name, offsets, "offsets for " + coltable.name);
       }
 
-      std::unique_ptr<nanoaod::FlatTable> outcoltable = std::make_unique<nanoaod::FlatTable>(coltablesize, coltable.name, false, false);
+      std::unique_ptr<nanoaod::FlatTable> outcoltable =
+          std::make_unique<nanoaod::FlatTable>(coltablesize, coltable.name, false, false);
       for (const auto &colvar : coltable.colvars) {
         colvar->fill(selobjs, *outcoltable);
       }
       outcoltable->setDoc(coltable.doc);
       iEvent.put(std::move(outcoltable), coltable.name + "Table");
     }
-    
+
     // put the main table into the event
     out->setDoc(this->doc_);
     iEvent.put(std::move(out));
   }
 
 protected:
-  typedef FuncCollectionVariable<T, TypedStringObjectMethodCaller<T, std::vector<int32_t>>, StringObjectFunction<T>, int32_t> IntVectorVar;
-  typedef FuncCollectionVariable<T, TypedStringObjectMethodCaller<T, std::vector<uint32_t>>, StringObjectFunction<T>, uint32_t> UIntVectorVar;
-  typedef FuncCollectionVariable<T, TypedStringObjectMethodCaller<T, std::vector<float>>, StringObjectFunction<T>, float> FloatVectorVar;
-  typedef FuncCollectionVariable<T, TypedStringObjectMethodCaller<T, std::vector<double>>, StringObjectFunction<T>, double> DoubleVectorVar;
-  typedef FuncCollectionVariable<T, TypedStringObjectMethodCaller<T, std::vector<uint8_t>>, StringObjectFunction<T>, uint8_t> UInt8VectorVar;
-  typedef FuncCollectionVariable<T, TypedStringObjectMethodCaller<T, std::vector<int16_t>>, StringObjectFunction<T>, int16_t> Int16VectorVar;
-  typedef FuncCollectionVariable<T, TypedStringObjectMethodCaller<T, std::vector<uint16_t>>, StringObjectFunction<T>, uint16_t> UInt16VectorVar;
+  template <typename R>
+  using VectorVar =
+      FuncCollectionVariable<T, TypedStringObjectMethodCaller<T, std::vector<R>>, StringObjectFunction<T>, R>;
+
+  using IntVectorVar = VectorVar<int32_t>;
+  using UIntVectorVar = VectorVar<uint32_t>;
+  using FloatVectorVar = VectorVar<float>;
+  using DoubleVectorVar = VectorVar<double>;
+  using UInt8VectorVar = VectorVar<uint8_t>;
+  using Int16VectorVar = VectorVar<int16_t>;
+  using UInt16VectorVar = VectorVar<uint16_t>;
 
   struct CollectionVariableTableInfo {
     std::string name;

--- a/PhysicsTools/NanoAOD/plugins/SimpleFlatTableProducerPlugins.cc
+++ b/PhysicsTools/NanoAOD/plugins/SimpleFlatTableProducerPlugins.cc
@@ -3,6 +3,8 @@
 #include "DataFormats/Candidate/interface/Candidate.h"
 typedef SimpleFlatTableProducer<reco::Candidate> SimpleCandidateFlatTableProducer;
 
+typedef SimpleCollectionFlatTableProducer<reco::Candidate> SimpleCandidateCollectionFlatTableProducer;
+
 #include "DataFormats/TrackReco/interface/Track.h"
 typedef SimpleFlatTableProducer<reco::Track> SimpleTrackFlatTableProducer;
 
@@ -50,6 +52,7 @@ typedef EventSingletonSimpleFlatTableProducer<reco::BeamSpot> SimpleBeamspotFlat
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(SimpleCandidateFlatTableProducer);
+DEFINE_FWK_MODULE(SimpleCandidateCollectionFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleTrackFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleSuperclusterFlatTableProducer);
 DEFINE_FWK_MODULE(SimplePFJetFlatTableProducer);


### PR DESCRIPTION
#### PR description:

Add support for adding variable-size attributes (std::vector) within objects for NanoAOD. Presented at [XPOG meeting on 13.11.2024](https://indico.cern.ch/event/1478217/#3-support-for-variable-size-va). In addition, after the presentation, lazy evaluation functionality has been added.

Tested mainly in context of ScoutingNano, but this functionality is generic and can be useful for any custom NanoAOD. Hence, we decided to make this PR with only variable-size attributes support in NanoAOD. For usage in ScoutingNano, we will prepare another PR later after discussion with scouting group.

#### PR validation:

Tested with ScoutingNano (for ScoutingMuon and ScoutingElectron) with workflow 2500.227(RelValTTbar/2024/MINIAODSIM) and 2500.237 (ScoutingPFRun3/2024D/HLTSCOUT) as presented in the slide.

For lazy evaluation, test with workflow 2500.237 by setting ScoutingMuon's hitPattern variable with ```lazyEval=True```. The output step2.root looks the same as output step2.root when setting ```lazyEval=False```.

Pass all tests when running: ```scram b runtests use-ibeos```
```
Pass    0s ... CommonTools/Utils/ExprEvalPopen_t
Pass   12s ... CommonTools/Utils/ExpressionEvaluatorUnitTest
Pass    7s ... CommonTools/Utils/testCommonToolsUtil
Pass    3s ... CommonTools/Utils/testCommonToolsUtilThreaded
Pass    0s ... CommonTools/Utils/testDynArray
Pass   17s ... CommonTools/Utils/testExpressionEvaluator
Pass   15s ... PhysicsTools/NanoAOD/testPhysicsToolsNanoAODTP
>> Test sequence completed for CMSSW CMSSW_14_2_0_pre3
```

When running ```runTheMatrix.py -l limited -i all --ibeos```, some workflows failed due to file open errors. Tested 3 times and got the similar file open errors.
```
45 41 39 35 17 1 1 1 1 1 1 tests passed, 1 3 0 0 0 0 0 0 0 0 0 failed
```
Failed workflows are:
- failed at step-0: ```312.0``` 
- failed at step-1: ```25202.0, 14234.0, 250202.181```
which are all due to file open errors.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is not a backport and there is no plan for a backport.
