### PR TITLE
fix retry logic for triton client

### DIFF
--- a/HeterogeneousCore/SonicTriton/interface/TritonClient.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonClient.h
@@ -3,6 +3,7 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ServiceRegistry/interface/ServiceToken.h"
 #include "HeterogeneousCore/SonicCore/interface/SonicClient.h"
 #include "HeterogeneousCore/SonicTriton/interface/TritonData.h"
 #include "HeterogeneousCore/SonicTriton/interface/TritonService.h"
@@ -86,6 +87,7 @@ protected:
   std::unique_ptr<triton::client::InferenceServerGrpcClient> client_;
   //stores timeout, model name and version
   std::vector<triton::client::InferOptions> options_;
+  edm::ServiceToken token_;
 
 private:
   friend TritonInputData;


### PR DESCRIPTION
#### PR description:

On retry the client was trying to access the TritonService through the ServiceRegistry. However, the thread calling the evalute method did not have the appropriate context setup to allow this. We now save the ServiceToken when the client is created, so the appropriate context can be setup before accessing the service.


#### PR validation:

We tested this at NERSC where we are seeing `GOAWAY` responses from our nginx ingress. This logic successfully retries the failed requests. 