### PR TITLE
Fix mask production for empty seeding region

### DIFF
--- a/RecoHGCal/TICL/plugins/TrackstersProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersProducer.cc
@@ -202,21 +202,20 @@ void TrackstersProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
       inferenceAlgo_->runInference(*initialResult);
       myAlgo_->filter(*result, *initialResult, input, seedToTrackstersAssociation);
     }
-    // Now update the global mask and put it into the event
-    output_mask->reserve(original_layerclusters_mask.size());
-    // Copy over the previous state
-    std::copy(std::begin(original_layerclusters_mask),
-              std::end(original_layerclusters_mask),
-              std::back_inserter(*output_mask));
+  }
+  // Now update the global mask and put it into the event
+  output_mask->reserve(original_layerclusters_mask.size());
+  // Copy over the previous state
+  std::copy(
+      std::begin(original_layerclusters_mask), std::end(original_layerclusters_mask), std::back_inserter(*output_mask));
 
-    for (auto& trackster : *result) {
-      trackster.setIteration(iterIndex_);
-      // Mask the used elements, accordingly
-      for (auto const v : trackster.vertices()) {
-        // TODO(rovere): for the moment we mask the layer cluster completely. In
-        // the future, properly compute the fraction of usage.
-        (*output_mask)[v] = 0.;
-      }
+  for (auto& trackster : *result) {
+    trackster.setIteration(iterIndex_);
+    // Mask the used elements, accordingly
+    for (auto const v : trackster.vertices()) {
+      // TODO(rovere): for the moment we mask the layer cluster completely. In
+      // the future, properly compute the fraction of usage.
+      (*output_mask)[v] = 0.;
     }
   }
 


### PR DESCRIPTION
This PR fixes  https://github.com/cms-sw/cmssw/issues/46698  for wf with HFNose in the Geometry.

- Moved mask update logic outside the conditional block that checks for seeding regions to ensure it is always executed, regardless of whether seeding regions are available.
- The mask is updated correctly even when no tracksters are produced.
