### PR TITLE
Noisy_ElectronSeedProducer_Correction_V1 : plugins part

### DIFF
--- a/DataFormats/EgammaReco/src/ElectronSeed.cc
+++ b/DataFormats/EgammaReco/src/ElectronSeed.cc
@@ -77,8 +77,8 @@ void ElectronSeed::initTwoHitSeed(const unsigned char hitMask) {
   }
   for (size_t hitNr = 0; hitNr < hitInfo_.size(); hitNr++) {
     auto& info = hitInfo_[hitNr];
-    info.setDPhi(std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity());
-    info.setDRZ(std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity());
+    info.setDPhi(std::numeric_limits<float>::max(), std::numeric_limits<float>::max());
+    info.setDRZ(std::numeric_limits<float>::max(), std::numeric_limits<float>::max());
     info.setDet((recHits().begin() + hitNrs[hitNr])->geographicalId(), -1);
   }
 }
@@ -164,10 +164,10 @@ std::vector<ElectronSeed::PMVars> ElectronSeed::createHitInfo(const float dPhi1P
 }
 
 ElectronSeed::PMVars::PMVars()
-    : dRZPos(std::numeric_limits<float>::infinity()),
-      dRZNeg(std::numeric_limits<float>::infinity()),
-      dPhiPos(std::numeric_limits<float>::infinity()),
-      dPhiNeg(std::numeric_limits<float>::infinity()),
+    : dRZPos(std::numeric_limits<float>::max()),
+      dRZNeg(std::numeric_limits<float>::max()),
+      dPhiPos(std::numeric_limits<float>::max()),
+      dPhiNeg(std::numeric_limits<float>::max()),
       detId(0),
       layerOrDiskNr(-1) {}
 


### PR DESCRIPTION
#### PR description:

Finish the transition from infinity() to max()
Description: Solves the problem reported [here](https://github.com/cms-sw/cmssw/issues/45658).
The printouts were triggered because a mixed usage of max() and infinity() 

#### PR validation:

compilation is OK, basics tests (scram b runtests or local tests) are OK too.
runTheMatrix.py -l limited -i all --ibeos tests are fine
41 40 39 34 17 1 1 1 1 1 1 tests passed, 2 0 0 0 0 0 0 0 0 0 0 failed
the 2 errors are DAS error (see runall-report-step123-.log).
runall-report-step123-.logation is OK, basics tests (scram b runtests or local tests) are OK too.
[runall-report-step123-.log](https://github.com/user-attachments/files/17777697/runall-report-step123-.log)

@beaudett

