### PR TITLE
Minor updates to AlpakaCore README

### DIFF
--- a/HeterogeneousCore/AlpakaCore/README.md
+++ b/HeterogeneousCore/AlpakaCore/README.md
@@ -199,7 +199,7 @@ For concrete examples see code in [`HeterogeneousCore/AlpakaTest`](../../Heterog
 
 ### EDProducer
 
-This example shows a mixture of behavior from test code in [`HeterogeneousCore/AlpakaTest/plugins/alpaka/`](HeterogeneousCore/AlpakaTest/plugins/alpaka/)
+This example shows a mixture of behavior from test code in [`HeterogeneousCore/AlpakaTest/plugins/alpaka/`](../../HeterogeneousCore/AlpakaTest/plugins/alpaka/)
 ```cpp
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/EDGetToken.h"
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/EDPutToken.h"
@@ -314,7 +314,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
       // fill the hostProduct from hostInput
 
-      return std::move(hostProduct);
+      return hostProduct;
     }
 
   private:
@@ -359,7 +359,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       algo_.fill(iRecord.queue(), deviceInput, deviceProduct);
 
       // return the product without waiting
-      return std::move(deviceProduct);
+      return deviceProduct;
     }
 
   private:


### PR DESCRIPTION
#### PR description:

The use of `return std::move(...)` in the ESProducer examples caught my eye, as the use of `std::move()` there has usually resulted in "pessimizing move" warnings (can't remember if from compiler or from clang-tidy). None of the test code in `HeterogeneousCore/AlpakaTest` uses `std::move()` in conjunction with `return`, so I think it is good to remove it from the example.

This also fixes one link.

Resolves https://github.com/cms-sw/framework-team/issues/1091

#### PR validation:

None