### PR TITLE
Release memory earlier in PFBlockProducer

### DIFF
--- a/CommonTools/RecoAlgos/interface/KDTreeLinkerAlgo.h
+++ b/CommonTools/RecoAlgos/interface/KDTreeLinkerAlgo.h
@@ -63,9 +63,12 @@ struct KDTreeNodes {
   void clear() {
     for (auto &dim : dims) {
       dim.clear();
+      dim.shrink_to_fit();
     }
     right.clear();
+    right.shrink_to_fit();
     data.clear();
+    data.shrink_to_fit();
     poolSize = -1;
     poolPos = -1;
   }

--- a/RecoParticleFlow/PFProducer/src/PFBlockAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFBlockAlgo.cc
@@ -209,6 +209,7 @@ reco::PFBlockCollection PFBlockAlgo::findBlocks() {
   }
 
   elements_.clear();
+  elements_.shrink_to_fit();
 
   return blocks;
 }


### PR DESCRIPTION
#### PR description:

Using an experimental AllocMonitor service showed that PFBlockProducer was holding additional memory between events which was often then resized.

#### PR validation:

A simple test using step3 of workflow 1330.0 showed that per event memory retention was eliminated.