### PR TITLE
Introduce `SiStripNoisesGetAllChecker`

### DIFF
--- a/CondTools/SiStrip/plugins/SiStripNoisesGetAllChecker.cc
+++ b/CondTools/SiStrip/plugins/SiStripNoisesGetAllChecker.cc
@@ -1,0 +1,108 @@
+#include "CondFormats/DataRecord/interface/SiStripNoisesRcd.h"
+#include "CondFormats/SiStripObjects/interface/SiStripNoises.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/CommonTopologies/interface/StripTopology.h"
+#include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+
+#include <iostream>
+#include <exception>
+
+class SiStripNoisesGetAllChecker : public edm::one::EDAnalyzer<> {
+public:
+  explicit SiStripNoisesGetAllChecker(const edm::ParameterSet&);
+  ~SiStripNoisesGetAllChecker() override = default;
+
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+private:
+  const edm::ESGetToken<SiStripNoises, SiStripNoisesRcd> noisesToken_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tkGeomToken_;
+  void checkModuleNoise(const SiStripNoises&, const uint32_t detID, uint16_t maxNStrips);
+};
+
+SiStripNoisesGetAllChecker::SiStripNoisesGetAllChecker(const edm::ParameterSet&)
+    : noisesToken_(esConsumes()), tkGeomToken_(esConsumes()) {}
+
+void SiStripNoisesGetAllChecker::analyze(const edm::Event&, const edm::EventSetup& iSetup) {
+  const auto& siStripNoises = iSetup.getData(noisesToken_);
+
+  const auto& tkGeom = &iSetup.getData(tkGeomToken_);
+  const auto& tkDets = tkGeom->dets();
+
+  edm::LogInfo("SiStripNoisesGetAllChecker") << "Starting to loop over all SiStrip modules...";
+
+  // Get all DetIDs associated with SiStripNoises
+  std::vector<uint32_t> detIDs;
+  siStripNoises.getDetIds(detIDs);
+
+  size_t exceptionCounts{0};
+  for (const auto& detID : detIDs) {
+    uint16_t maxNStrips{0};
+    auto det = std::find_if(tkDets.begin(), tkDets.end(), [detID](auto& elem) -> bool {
+      return (elem->geographicalId().rawId() == detID);
+    });
+    const StripTopology& p = dynamic_cast<const StripGeomDetUnit*>(*det)->specificTopology();
+    maxNStrips = p.nstrips();
+
+    try {
+      checkModuleNoise(siStripNoises, detID, maxNStrips);
+    } catch (const std::exception& e) {
+      // Increment the exception counter if checkModuleNoise itself throws an exception
+      edm::LogError("SiStripNoisesGetAllChecker")
+          << "Exception in checkModuleNoise for detID " << detID << ": " << e.what();
+      ++exceptionCounts;
+    } catch (...) {
+      edm::LogError("SiStripNoisesGetAllChecker") << "Unknown exception in checkModuleNoise for detID " << detID;
+      ++exceptionCounts;
+    }
+  }
+
+  std::ostringstream message;
+
+  // Define the box width
+  const int boxWidth = 50;
+
+  message << "\n"
+          << std::string(boxWidth, '*') << "\n"
+          << "* " << std::setw(boxWidth - 4) << std::left << "SiStripNoisesGetAllChecker Summary"
+          << " *\n"
+          << std::string(boxWidth, '*') << "\n"
+          << "* " << std::setw(boxWidth - 4) << std::left
+          << ("Completed loop over " + std::to_string(detIDs.size()) + " SiStrip modules.") << " *\n"
+          << "* " << std::setw(boxWidth - 4) << std::left
+          << ("Encountered " + std::to_string(exceptionCounts) + " exceptions.") << " *\n"
+          << std::string(boxWidth, '*');
+
+  edm::LogSystem("SiStripNoisesGetAllChecker") << message.str();
+}
+
+void SiStripNoisesGetAllChecker::checkModuleNoise(const SiStripNoises& siStripNoises,
+                                                  const uint32_t detID,
+                                                  uint16_t maxNStrips) {
+  try {
+    SiStripNoises::Range detNoiseRange = siStripNoises.getRange(detID);
+    std::vector<float> noises;
+    noises.resize(maxNStrips);
+    siStripNoises.allNoises(noises, detNoiseRange);
+    edm::LogInfo("SiStripNoisesGetAllChecker") << "Successfully processed detID: " << detID;
+  } catch (const std::exception& e) {
+    edm::LogError("SiStripNoisesGetAllChecker") << "Exception caught for detID " << detID << ": " << e.what();
+    throw;  // Re-throw the exception to allow the outer loop to handle it
+  } catch (...) {
+    edm::LogError("SiStripNoisesGetAllChecker") << "Unknown exception caught for detID " << detID;
+    throw;  // Re-throw the unknown exception
+  }
+}
+
+// Define this as a plug-in
+DEFINE_FWK_MODULE(SiStripNoisesGetAllChecker);

--- a/CondTools/SiStrip/test/SiStripNoisesGetAllChecker_cfg.py
+++ b/CondTools/SiStrip/test/SiStripNoisesGetAllChecker_cfg.py
@@ -1,0 +1,40 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+process = cms.Process("TestSiStripNoises")
+
+options = VarParsing.VarParsing("analysis")
+
+options.register ('globalTag',
+                  "141X_dataRun3_HLT_v1",
+                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                  VarParsing.VarParsing.varType.string,         # string, int, or float
+                  "GlobalTag")
+
+options.register ('runNumber',
+                  375440,
+                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                  VarParsing.VarParsing.varType.int,            # string, int, or float
+                  "run number")
+
+options.parseArguments()
+
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.maxEvents = cms.untracked.PSet(input=cms.untracked.int32(1))
+
+process.source = cms.Source("EmptySource",
+                            firstRun = cms.untracked.uint32(options.runNumber),
+                            numberEventsInRun = cms.untracked.uint32(1),
+                            )
+
+process.load("Configuration.Geometry.GeometryRecoDB_cff") # Ideal geometry and interface 
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag,options.globalTag, '')
+
+print("Using Global Tag:", process.GlobalTag.globaltag._value)
+
+process.SiStripNoisesGetAllChecker = cms.EDAnalyzer("SiStripNoisesGetAllChecker")
+
+process.p = cms.Path(process.SiStripNoisesGetAllChecker)

--- a/CondTools/SiStrip/test/testBuildersReaders.sh
+++ b/CondTools/SiStrip/test/testBuildersReaders.sh
@@ -53,6 +53,15 @@ done
 
 echo -e " Done with the miscalibrators \n\n"
 
+## do the checkers
+for entry in "${SCRAM_TEST_PATH}/"SiStrip*Checker_cfg.py
+do
+  echo "===== Test \"cmsRun $entry \" ===="
+  (cmsRun $entry) || die "Failure using cmsRun $entry" $?
+done
+
+echo -e " Done with the checkers \n\n"
+
 ## do the scaler
 
 # copy all the necessary conditions in order to run the miscalibration tool


### PR DESCRIPTION
#### PR description:

The goal of this PR is to add a utility plugin `SiStripNoisesGetAllChecker`, which is meant to check that `SiStripNoise` is available for all strips defined within the module geometric boundaries.
This class was useful in the debugging of https://github.com/cms-sw/cmssw/issues/43078.

#### PR validation:

Relies on the unit tests of the package ` scram b runtests_testCondToolsSiStripBuildersReaders` runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A