### PR TITLE
Remove legacy L1T digis dependencies in Online DQM

### DIFF
--- a/DQM/DTMonitorModule/python/dt_dqm_sourceclient_common_cff.py
+++ b/DQM/DTMonitorModule/python/dt_dqm_sourceclient_common_cff.py
@@ -20,6 +20,9 @@ gtDigis = EventFilter.L1GlobalTriggerRawToDigi.l1GtUnpack_cfi.l1GtUnpack.clone(
    DaqGtInputTag = 'rawDataCollector'
 )
 
+from EventFilter.L1TRawToDigi.gtStage2Digis_cfi import gtStage2Digis
+gtStage2Digis.InputLabel = 'rawDataCollector'
+
 # Scalers info
 from EventFilter.ScalersRawToDigi.ScalersRawToDigi_cfi import *
 scalersRawToDigi.scalersInputTag = 'rawDataCollector'
@@ -122,3 +125,6 @@ dtDQMCalib = cms.Sequence(dtTPmonitor + dtTPTriggerMonitor + dtTPmonitorTest + d
 # sequence to be run on physics events (includes filters, reco and DQM)
 dtDQMPhysSequence = cms.Sequence(dtScalerInfoMonitor + gtDigis + reco + dtDQMTask + dtDQMTest)
 
+from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+dtDQMPhysSequenceStage2 = cms.Sequence(dtScalerInfoMonitor + gtStage2Digis + reco + dtDQMTask + dtDQMTest)
+stage2L1Trigger.toReplaceWith(dtDQMPhysSequence,dtDQMPhysSequenceStage2)

--- a/DQM/EcalMonitorTasks/python/ClusterTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/ClusterTask_cfi.py
@@ -498,4 +498,3 @@ ecalClusterTask = cms.untracked.PSet(
         )
     )
 )
-

--- a/DQM/EcalMonitorTasks/src/ClusterTask.cc
+++ b/DQM/EcalMonitorTasks/src/ClusterTask.cc
@@ -81,6 +81,13 @@ namespace ecaldqm {
 
     edm::Handle<L1GlobalTriggerReadoutRecord> l1GTHndl;
     _evt.getByToken(L1GlobalTriggerReadoutRecordToken_, l1GTHndl);
+
+    if (!l1GTHndl.isValid()) {
+      edm::LogError("L1GlobalTriggerReadoutRecord")
+          << "Failed to retrieve L1GlobalTriggerReadoutRecord from the Event!";
+      return;  // Exit the function early if the handle is invalid
+    }
+
     DecisionWord const& dWord(l1GTHndl->decisionWord());
 
     //Ecal

--- a/DQM/Integration/python/clients/dt4ml_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/dt4ml_dqm_sourceclient-live_cfg.py
@@ -88,6 +88,7 @@ process.dtDQMPathPhys = cms.Path(process.unpackers + process.dqmmodules + proces
 process.twinMuxStage2Digis.DTTM7_FED_Source = "rawDataCollector"
 process.dtunpacker.inputLabel = "rawDataCollector"
 process.gtDigis.DaqGtInputTag = "rawDataCollector"
+process.gtStage2Digis.InputLabel = "rawDataCollector"
 process.scalersRawToDigi.scalersInputTag = "rawDataCollector"
 
 print("Running with run type = ", process.runType.getRunType())
@@ -117,6 +118,7 @@ if (process.runType.getRunType() == process.runType.hi_run):
     process.twinMuxStage2Digis.DTTM7_FED_Source = "rawDataRepacker"
     process.dtunpacker.inputLabel = "rawDataRepacker"
     process.gtDigis.DaqGtInputTag = "rawDataRepacker"
+    process.gtStage2Digis.InputLabel = "rawDataCollector"
     process.scalersRawToDigi.scalersInputTag = "rawDataRepacker"
     
     process.dtDigiMonitor.ResetCycle = 9999

--- a/DQM/Integration/python/clients/dt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/dt_dqm_sourceclient-live_cfg.py
@@ -46,7 +46,7 @@ if not unitTest:
 
 # DT reco and DQM sequences
 process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
-process.load("Configuration/StandardSequences/MagneticField_cff")
+process.load("Configuration.StandardSequences.MagneticField_cff")
 process.load("DQM.DTMonitorModule.dt_dqm_sourceclient_common_cff")
 #---- for P5 (online) DB access
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
@@ -69,6 +69,7 @@ process.dtDQMPathPhys = cms.Path(process.unpackers + process.dqmmodules + proces
 process.twinMuxStage2Digis.DTTM7_FED_Source = "rawDataCollector"
 process.dtunpacker.inputLabel = "rawDataCollector"
 process.gtDigis.DaqGtInputTag = "rawDataCollector"
+process.gtStage2Digis.InputLabel = "rawDataCollector"
 process.scalersRawToDigi.scalersInputTag = "rawDataCollector"
 
 print("Running with run type = ", process.runType.getRunType())
@@ -97,11 +98,9 @@ if (process.runType.getRunType() == process.runType.hi_run):
     process.twinMuxStage2Digis.DTTM7_FED_Source = "rawDataRepacker"
     process.dtunpacker.inputLabel = "rawDataRepacker"
     process.gtDigis.DaqGtInputTag = "rawDataRepacker"
+    process.gtStage2Digis.InputLabel = "rawDataRepacker"
     process.scalersRawToDigi.scalersInputTag = "rawDataRepacker"
-    
     process.dtDigiMonitor.ResetCycle = 9999
-
-
 
 ### process customizations included here
 from DQM.Integration.config.online_customizations_cfi import *

--- a/DQM/Integration/python/clients/ecal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ecal_dqm_sourceclient-live_cfg.py
@@ -164,7 +164,7 @@ process.ecalMonitorTask.workerParameters.OccupancyTask.params.lumiCheck = True
 ### Sequences ###
 
 process.ecalPreRecoSequence = cms.Sequence(process.bunchSpacingProducer + process.ecalDigis)
-process.ecalRecoSequence = cms.Sequence((process.ecalMultiFitUncalibRecHit+process.ecalDetIdToBeRecovered+process.ecalRecHit)+(process.simEcalTriggerPrimitiveDigis+process.gtDigis)+(process.hybridClusteringSequence+process.multi5x5ClusteringSequence))
+process.ecalRecoSequence = cms.Sequence((process.ecalMultiFitUncalibRecHit+process.ecalDetIdToBeRecovered+process.ecalRecHit)+(process.simEcalTriggerPrimitiveDigis+process.gtStage2Digis)+(process.hybridClusteringSequence+process.multi5x5ClusteringSequence))
 process.multi5x5ClusteringSequence = cms.Sequence(process.multi5x5BasicClustersCleaned+process.multi5x5SuperClustersCleaned+process.multi5x5BasicClustersUncleaned+process.multi5x5SuperClustersUncleaned+process.multi5x5SuperClusters)
 process.hybridClusteringSequence = cms.Sequence(process.cleanedHybridSuperClusters+process.uncleanedHybridSuperClusters+process.hybridSuperClusters+process.correctedHybridSuperClusters+process.uncleanedOnlyCorrectedHybridSuperClusters)
 

--- a/DQMOffline/Trigger/python/SiStrip_OfflineMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/SiStrip_OfflineMonitoring_cff.py
@@ -32,29 +32,52 @@ HLTSiStripMonitorCluster.TH1StripNoise2ApvCycle.globalswitchon  = cms.bool(False
 HLTSiStripMonitorCluster.TH1StripNoise3ApvCycle.globalswitchon  = cms.bool(False)
 
 HLTSiStripMonitorCluster.BPTXfilter = cms.PSet(
-        andOr         = cms.bool( False ),
-            dbLabel       = cms.string("SiStripDQMTrigger"),
-            l1Algorithms = cms.vstring( 'L1Tech_BPTX_plus_AND_minus.v0', 'L1_ZeroBias' ),
-            andOrL1       = cms.bool( True ),
-            errorReplyL1  = cms.bool( True ),
-            l1BeforeMask  = cms.bool( True ) # specifies, if the L1 algorithm decision should be read as before (true) or after (false) masking is applied.
-        )
+    andOr         = cms.bool( False ),
+    dbLabel       = cms.string("SiStripDQMTrigger"),
+    l1Algorithms = cms.vstring( 'L1Tech_BPTX_plus_AND_minus.v0', 'L1_ZeroBias' ),
+    andOrL1       = cms.bool( True ),
+    errorReplyL1  = cms.bool( True ),
+    l1BeforeMask  = cms.bool( True ) # specifies, if the L1 algorithm decision should be read as before (true) or after (false) masking is applied.
+)
 HLTSiStripMonitorCluster.PixelDCSfilter = cms.PSet(
-        andOr         = cms.bool( False ),
-            dcsInputTag   = cms.InputTag( "scalersRawToDigi" ),
-            dcsRecordInputTag = cms.InputTag("onlineMetaDataDigis"),
-            dcsPartitions = cms.vint32 ( 28, 29),
-            andOrDcs      = cms.bool( False ),
-            errorReplyDcs = cms.bool( True ),
-        )
+    andOr         = cms.bool( False ),
+    dcsInputTag   = cms.InputTag( "scalersRawToDigi" ),
+    dcsRecordInputTag = cms.InputTag("onlineMetaDataDigis"),
+    dcsPartitions = cms.vint32 ( 28, 29),
+    andOrDcs      = cms.bool( False ),
+    errorReplyDcs = cms.bool( True ),
+)
 HLTSiStripMonitorCluster.StripDCSfilter = cms.PSet(
-        andOr         = cms.bool( False ),
-            dcsInputTag   = cms.InputTag( "scalersRawToDigi" ),
-            dcsRecordInputTag = cms.InputTag("onlineMetaDataDigis"),
-            dcsPartitions = cms.vint32 ( 24, 25, 26, 27 ),
-            andOrDcs      = cms.bool( False ),
-            errorReplyDcs = cms.bool( True ),
-        )
+    andOr         = cms.bool( False ),
+    dcsInputTag   = cms.InputTag( "scalersRawToDigi" ),
+    dcsRecordInputTag = cms.InputTag("onlineMetaDataDigis"),
+    dcsPartitions = cms.vint32 ( 24, 25, 26, 27 ),
+    andOrDcs      = cms.bool( False ),
+    errorReplyDcs = cms.bool( True ),
+)
+
+from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+stage2L1Trigger.toModify(HLTSiStripMonitorCluster, 
+                        BPTXfilter = dict(
+                             stage2 = cms.bool(True),
+                             l1tAlgBlkInputTag = cms.InputTag("gtStage2Digis"),
+                             l1tExtBlkInputTag = cms.InputTag("gtStage2Digis"),
+                             ReadPrescalesFromFile = cms.bool(False)
+                         ),
+                         PixelDCSfilter = dict(
+                             stage2 = cms.bool(True),
+                             l1tAlgBlkInputTag = cms.InputTag("gtStage2Digis"),
+                             l1tExtBlkInputTag = cms.InputTag("gtStage2Digis"),
+                             ReadPrescalesFromFile = cms.bool(False)
+                         ),
+                         StripDCSfilter = dict(
+                             stage2 = cms.bool(True),
+                             l1tAlgBlkInputTag = cms.InputTag("gtStage2Digis"),
+                             l1tExtBlkInputTag = cms.InputTag("gtStage2Digis"),
+                             ReadPrescalesFromFile = cms.bool(False)
+                         )
+                         )
+
 HLTSiStripMonitorCluster.TH2CStripVsCpixel = cms.PSet(
         Nbinsx = cms.int32(200),
         xmin   = cms.double(-0.5),
@@ -74,6 +97,7 @@ HLTSiStripMonitorCluster.TH1NClusStrip = cms.PSet(
         xmax = cms.double(99999.5),
         xmin = cms.double(-0.5)
     )
+
 hltESPPixelCPETemplateReco = cms.ESProducer( "PixelCPETemplateRecoESProducer",
   LoadTemplatesFromDB = cms.bool( True ),
   ComponentName = cms.string( "hltESPPixelCPETemplateReco" ),


### PR DESCRIPTION
#### PR description:

In the ticket [CMSALCAFAST-94](https://its.cern.ch/jira/browse/CMSALCAFAST-94), while testing a new Global Tag candidate meant for a general cleaning of unused / previous runs unmaintained records, few online DQM clients (`dt4ml`, `dt`, `ecal`, and `hlt`) encountered issues and failed.
The reason of these failures was analyzed as unnecessary dependencies of the current DQM clients on the legacy L1T digis.
This is fixed / worked around in this PR.
   * 9b3afd7e478fd1ec4b0b66f876e1188754feab27 removes the dependency in `HLTSiStripMonitorCluster` by means of re-configuring the few instances of `GenericTriggerEventFlag` class to use the stage 2 gt digis in presence of the `stage2L1Trigger` modifier.
   * 8c7fd9b32506c8450f6734d9201da13714317043 replaces the legacy gt digis with the stage2 ones in presence of the `stage2L1Trigger` modifier
   * fe46246e44fbac0a69747078acf9ac64a72d68e1 works around the fact that the `DQM/EcalMonitorTasks/src/ClusterTask.cc` natively doesn't support the stage2 L1T setup but requires products from the legacy L1T (this is followed up also at https://github.com/cms-sw/cmssw/issues/46715) 

#### PR validation:

The following commands work with this branch,

```
scram b runtests_TestDQMOnlineClient-hlt_dqm_sourceclient use-ibeos
scram b runtests_TestDQMOnlineClient-dt_dqm_sourceclient use-ibeos
scram b runtests_TestDQMOnlineClient-dt4ml_dqm_sourceclient use-ibeos
scram b runtests_TestDQMOnlineClient-ecal_dqm_sourceclient use-ibeos
```

when tested by using the Global Tag proposed at  [CMSALCAFAST-94](https://its.cern.ch/jira/browse/CMSALCAFAST-94).

```diff
diff --git a/DQM/Integration/python/config/FrontierCondition_GT_cfi.py b/DQM/Integration/python/config/FrontierCondition_GT_cfi.py
index 5845afa34bb..a91ce205422 100644
--- a/DQM/Integration/python/config/FrontierCondition_GT_cfi.py
+++ b/DQM/Integration/python/config/FrontierCondition_GT_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import *
 from Configuration.AlCa.autoCond import autoCond
-GlobalTag.globaltag = autoCond['run3_hlt']
+GlobalTag.globaltag = "141X_dataRun3_HLT_Candidate_2024_11_15_CleaningOfRecords"  #autoCond['run3_hlt']
 
 #############################################
 #
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A