### PR TITLE
[UBSAN][L1]Properly initialize data members

### DIFF
--- a/L1Trigger/TrackFindingTracklet/src/MatchEngineUnit.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchEngineUnit.cc
@@ -9,15 +9,22 @@ MatchEngineUnit::MatchEngineUnit(const Settings& settings,
                                  bool barrel,
                                  unsigned int layerdisk,
                                  const TrackletLUT& luttable)
-    : settings_(settings), luttable_(luttable), candmatches_(3) {
-  idle_ = true;
-  print_ = false;
+    : settings_(settings),
+      isPSseed_(false),
+      idle_(true),
+      almostfullsave_(false),
+      luttable_(luttable),
+      isPSseed__(false),
+      isPSseed___(false),
+      isPSseed____(false),
+      good__(false),
+      good___(false),
+      good____(false),
+      candmatches_(3),
+      print_(false) {
   imeu_ = -1;
   barrel_ = barrel;
   layerdisk_ = layerdisk;
-  good__ = false;
-  good___ = false;
-  good____ = false;
   ir2smin_ = 0;
   if (layerdisk_ >= N_LAYER) {
     double rmin2s = (layerdisk_ < N_LAYER + 2) ? settings_.rDSSinner(0) : settings_.rDSSouter(0);

--- a/L1Trigger/TrackFindingTracklet/src/TrackletEngineUnit.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletEngineUnit.cc
@@ -15,8 +15,14 @@ TrackletEngineUnit::TrackletEngineUnit(const Settings* const settings,
                                        const TrackletLUT* pttableinnernew,
                                        const TrackletLUT* pttableouternew,
                                        VMStubsTEMemory* outervmstubs)
-    : settings_(settings), pttableinnernew_(pttableinnernew), pttableouternew_(pttableouternew), candpairs_(3) {
-  idle_ = true;
+    : settings_(settings),
+      nearfull_(false),
+      idle_(true),
+      pttableinnernew_(pttableinnernew),
+      pttableouternew_(pttableouternew),
+      goodpair_(false),
+      goodpair__(false),
+      candpairs_(3) {
   nbitsfinephi_ = nbitsfinephi;
   layerdisk2_ = layerdisk2;
   layerdisk1_ = layerdisk1;


### PR DESCRIPTION
This should fix the UBSAN runtime errors [a]


[a] https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/raw/el8_amd64_gcc12/CMSSW_14_2_UBSAN_X_2024-11-15-2300/pyRelValMatrixLogs/run/23634.0_TTbar_14TeV+Run4D95/step2_TTbar_14TeV+Run4D95.log
```
23634.0/step2:L1Trigger/TrackFindingTracklet/interface/TrackletEngineUnit.h:28:9: runtime error: load of value 155, which is not a valid value for type 'bool'
23634.0/step2:L1Trigger/TrackFindingTracklet/interface/TrackletEngineUnit.h:28:9: runtime error: load of value 80, which is not a valid value for type 'bool'
23634.0/step2:L1Trigger/TrackFindingTracklet/interface/TrackletEngineUnit.h:28:9: runtime error: load of value 194, which is not a valid value for type 'bool'
```
```
23634.0/step2:L1Trigger/TrackFindingTracklet/interface/MatchEngineUnit.h:28:9: runtime error: load of value 9, which is not a valid value for type 'bool'
23634.0/step2:L1Trigger/TrackFindingTracklet/interface/MatchEngineUnit.h:28:9: runtime error: load of value 155, which is not a valid value for type 'bool'
23634.0/step2:L1Trigger/TrackFindingTracklet/interface/MatchEngineUnit.h:28:9: runtime error: load of value 208, which is not a valid value for type 'bool'
```