### PR TITLE
Improvements for `SubmitPVsplit` unit test

### DIFF
--- a/Alignment/OfflineValidation/scripts/submitPVResolutionJobs.py
+++ b/Alignment/OfflineValidation/scripts/submitPVResolutionJobs.py
@@ -302,11 +302,11 @@ def main():
     runs.sort()
     print("\n\n Will run on the following runs: \n",runs)
 
-    if(not os.path.exists("cfg")):
-        os.system("mkdir cfg")
-        os.system("mkdir BASH")
-        os.system("mkdir harvest")
-        os.system("mkdir out")
+    # List of directories to create
+    directories = ["cfg", "BASH", "harvest", "out"]
+
+    for directory in directories:
+        os.makedirs(directory, exist_ok=True)
 
     cwd = os.getcwd()
     bashdir = os.path.join(cwd,"BASH")
@@ -412,10 +412,25 @@ def main():
                 key = key.split(":", 1)[1]
                 print("dealing with",key)
 
-            os.system("cp "+input_CMSSW_BASE+"/src/Alignment/OfflineValidation/test/PrimaryVertexResolution_templ_cfg.py ./cfg/PrimaryVertexResolution_"+key+"_"+run+"_cfg.py")
-            os.system("sed -i 's|XXX_FILES_XXX|"+listOfFiles+"|g' "+cwd+"/cfg/PrimaryVertexResolution_"+key+"_"+run+"_cfg.py")
-            os.system("sed -i 's|XXX_RUN_XXX|"+run+"|g' "+cwd+"/cfg/PrimaryVertexResolution_"+key+"_"+run+"_cfg.py")
-            os.system("sed -i 's|YYY_KEY_YYY|"+key+"|g' "+cwd+"/cfg/PrimaryVertexResolution_"+key+"_"+run+"_cfg.py")
+            # Paths and variables
+            template_file = os.path.join(input_CMSSW_BASE, "src/Alignment/OfflineValidation/test/PrimaryVertexResolution_templ_cfg.py")
+            output_file = f"./cfg/PrimaryVertexResolution_{key}_{run}_cfg.py"
+
+            # Copy the template file to the destination
+            shutil.copy(template_file, output_file)
+
+            # Read and replace placeholders in the copied file
+            with open(output_file, 'r') as file:
+                content = file.read()
+
+            # Replace placeholders with actual values
+            content = content.replace("XXX_FILES_XXX", listOfFiles)
+            content = content.replace("XXX_RUN_XXX", run)
+            content = content.replace("YYY_KEY_YYY", key)
+
+            # Write the modified content back to the file
+            with open(output_file, 'w') as file:
+                file.write(content)
 
             scriptFileName = os.path.join(bashdir,"batchHarvester_"+key+"_"+str(count-1)+".sh")
             scriptFile = open(scriptFileName,'w')

--- a/Alignment/OfflineValidation/scripts/submitPVResolutionJobs.py
+++ b/Alignment/OfflineValidation/scripts/submitPVResolutionJobs.py
@@ -210,7 +210,9 @@ fi
 cd $LXBATCH_DIR 
 cp -pr {CFGDIR}/PrimaryVertexResolution_{KEY}_{runindex}_cfg.py .
 cmsRun PrimaryVertexResolution_{KEY}_{runindex}_cfg.py TrackCollection={TRKS} GlobalTag={GT} lumi={LUMITORUN} {REC} {EXT} >& log_{KEY}_run{runindex}.out
-ls -lh . 
+# Print the contents of the current directory using $PWD and echo
+echo "Contents of the current directory ($PWD):"
+echo "$(ls -lh "$PWD")"
 """.format(CMSSW_BASE_DIR=theCMSSW_BASE,
            CFGDIR=cfgdir,
            runindex=runindex,

--- a/Alignment/OfflineValidation/test/testingScripts/test_unitSubmitPVsplit.sh
+++ b/Alignment/OfflineValidation/test/testingScripts/test_unitSubmitPVsplit.sh
@@ -30,5 +30,17 @@ cd "${testdir}/testExecution" || exit 1
 # Execute the script and handle errors
 $PWD/"${scriptName}" || die "Failure running PVSplit script" $?
 
-# Dump to screen the content of the log file
-cat log*.out
+# Dump to screen the content of the log file(s) with clear headers
+log_files=(log*.out)
+if [[ ${#log_files[@]} -gt 0 ]]; then
+    echo "Displaying content of log files:"
+    for log_file in "${log_files[@]}"; do
+        echo "========================================"
+        echo "Content of $log_file:"
+        echo "========================================"
+        cat "$log_file"
+        echo # Add an extra blank line for separation
+    done
+else
+    echo "No log files found matching 'log*.out'."
+fi

--- a/Alignment/OfflineValidation/test/testingScripts/test_unitSubmitPVsplit.sh
+++ b/Alignment/OfflineValidation/test/testingScripts/test_unitSubmitPVsplit.sh
@@ -11,12 +11,13 @@ echo -e "\n\n TESTING Primary Vertex Split script execution ..."
 scriptName="batchHarvester_Prompt_0.sh"
 
 # Create directory if it doesn't exist
-mkdir -p "./testExecution"
+testdir=$PWD
+mkdir ${testdir}/"testExecution"
 
 # Check if the script exists and is a regular file
-if [ -f "./BASH/${scriptName}" ]; then
+if [ -f "${testdir}/BASH/${scriptName}" ]; then
     # Copy script to the test execution directory
-    cp -pr "./BASH/${scriptName}" "./testExecution/"
+    cp "${testdir}/BASH/${scriptName}" "${testdir}/testExecution/"
 else
     # Emit a warning if the script doesn't exist or is not a regular file
     echo "Warning: Script '${scriptName}' not found or is not a regular file. Skipping excution of further tests."
@@ -24,10 +25,10 @@ else
 fi
 
 # Change directory to the test execution directory
-cd "./testExecution" || exit 1
+cd "${testdir}/testExecution" || exit 1
 
 # Execute the script and handle errors
-./"${scriptName}" || die "Failure running PVSplit script" $?
+$PWD/"${scriptName}" || die "Failure running PVSplit script" $?
 
 # Dump to screen the content of the log file
 cat log*.out


### PR DESCRIPTION
#### PR description:

This PR is an attempt to solve part of issue https://github.com/cms-sw/cmssw/issues/45751 related to the `SubmitPVsplit` unit test (see also IB [logs](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc12/CMSSW_14_2_ASAN_X_2024-11-15-2300/unitTestLogs/Alignment/OfflineValidation#/23237-23237)). 

#### PR validation:

   * `scram b runtests_SubmitPVsplit` runs regularly in `CMSSW_14_2_X_2024-11-17-0000`
   * `scram b runtests_SubmitPVsplit` runs regularly in `CMSSW_14_2_ASAN_X_2024-11-15-2300` without residuals mentions of `LeakSanitizer` on `cmsdev40`, albeit it also did run to completion before the changes, thus I cannot be full certain this is a complete fix.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A