### PR TITLE
ZDC Phase2 HcalTPChannelParameters update to silence multiple warnings 

### DIFF
--- a/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
@@ -756,7 +756,10 @@ HcalTPChannelParameter HcalDbHardcode::makeHardcodeTPChannelParameter(HcalGeneri
   // mask for channel validity and self trigger information, fine grain
   // bit information and auxiliary words
   uint32_t bitInfo = ((44 << 16) | 30);
-  return HcalTPChannelParameter(fId.rawId(), 0, bitInfo, 0, 0);
+  int auxi2 = 0;
+  if (fId.genericSubdet() == HcalGenericDetId::HcalGenZDC)
+    auxi2 = 50;  // ZDC bunch spacing parameter
+  return HcalTPChannelParameter(fId.rawId(), 0, bitInfo, 0, auxi2);
 }
 
 void HcalDbHardcode::makeHardcodeTPParameters(HcalTPParameters& tppar) const {


### PR DESCRIPTION
#### PR description:

Complementary to Sunanda's just submitted https://github.com/cms-sw/cmssw/pull/46720
Silences [18 warnings at beginRun mentioned earlier by @mmusich](https://github.com/cms-sw/cmssw/pull/46537#discussion_r1844944801) 

#### PR validation:

wf  29634.0 runs without warnings 

