### PR TITLE
Fix cross section when using ResonanceDecayFilter

### DIFF
--- a/GeneratorInterface/Core/plugins/GenFilterEfficiencyProducer.cc
+++ b/GeneratorInterface/Core/plugins/GenFilterEfficiencyProducer.cc
@@ -121,7 +121,9 @@ void GenFilterEfficiencyProducer::produce(edm::StreamID, edm::Event& iEvent, con
     return;
   double weight = genEventScale->weight();
 
-  int eventCounterValue = ResonanceDecayFilterCounter::getInstance().getFilterBool() ? ResonanceDecayFilterCounter::getInstance().getEventCounter() : 1;
+  int eventCounterValue = ResonanceDecayFilterCounter::getInstance().getFilterBool()
+                              ? ResonanceDecayFilterCounter::getInstance().getEventCounter()
+                              : 1;
 
   auto sums = luminosityBlockCache(iEvent.getLuminosityBlock().index());
 

--- a/GeneratorInterface/Core/plugins/GenFilterEfficiencyProducer.cc
+++ b/GeneratorInterface/Core/plugins/GenFilterEfficiencyProducer.cc
@@ -135,25 +135,25 @@ void GenFilterEfficiencyProducer::produce(edm::StreamID, edm::Event& iEvent, con
       atomic_sum_double(sums->sumpass_w2_, weight * weight);
 
       atomic_sum_double(sums->sumtotal_w_, weight * eventCounterValue);
-      atomic_sum_double(sums->sumtotal_w2_, weight * weight * eventCounterValue * eventCounterValue);
+      atomic_sum_double(sums->sumtotal_w2_, weight * weight * eventCounterValue);
 
       if (weight > 0) {
         sums->numEventsPassPos_++;
-        sums->numEventsTotalPos_ = sums->numEventsTotalPos_ + eventCounterValue;
+        sums->numEventsTotalPos_++;
       } else {
         sums->numEventsPassNeg_++;
-        sums->numEventsTotalNeg_ = sums->numEventsTotalNeg_ + eventCounterValue;
+        sums->numEventsTotalNeg_++;
       }
 
     } else  // if fail the filter
     {
       atomic_sum_double(sums->sumtotal_w_, weight * eventCounterValue);
-      atomic_sum_double(sums->sumtotal_w2_, weight * weight * eventCounterValue * eventCounterValue);
+      atomic_sum_double(sums->sumtotal_w2_, weight * weight * eventCounterValue);
 
       if (weight > 0)
-        sums->numEventsTotalPos_ = sums->numEventsTotalPos_ + eventCounterValue;
+        sums->numEventsTotalPos_++;
       else
-        sums->numEventsTotalNeg_ = sums->numEventsTotalNeg_ + eventCounterValue;
+        sums->numEventsTotalNeg_++;
     }
     //    std::cout << "Total events = " << numEventsTotal << " passed = " << numEventsPassed << std::endl;
   }

--- a/GeneratorInterface/Core/plugins/GenXSecAnalyzer.cc
+++ b/GeneratorInterface/Core/plugins/GenXSecAnalyzer.cc
@@ -25,6 +25,7 @@
 #include "SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenFilterInfo.h"
 #include "SimDataFormats/GeneratorProducts/interface/LHERunInfoProduct.h"
+#include "GeneratorInterface/Pythia8Interface/interface/ResonanceDecayFilterCounter.h"
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
@@ -332,8 +333,9 @@ void GenXSecAnalyzer::globalEndRun(edm::Run const &iRun, edm::EventSetup const &
   double thisGenFilterErr = 0;
 
   if (runC->filterOnlyEffRun_.sumWeights2() > 0) {
-    thisGenFilterEff = runC->filterOnlyEffRun_.filterEfficiency(hepidwtup_);
-    thisGenFilterErr = runC->filterOnlyEffRun_.filterEfficiencyError(hepidwtup_);
+    int input_genfilter_efficiency = ResonanceDecayFilterCounter::getInstance().getFilterBool() ? 1 : hepidwtup_.load();
+    thisGenFilterEff = runC->filterOnlyEffRun_.filterEfficiency(input_genfilter_efficiency);
+    thisGenFilterErr = runC->filterOnlyEffRun_.filterEfficiencyError(input_genfilter_efficiency);
     if (thisGenFilterEff < 0) {
       thisGenFilterEff = 1;
       thisGenFilterErr = 0;

--- a/GeneratorInterface/Pythia8Interface/interface/ResonanceDecayFilterCounter.h
+++ b/GeneratorInterface/Pythia8Interface/interface/ResonanceDecayFilterCounter.h
@@ -1,5 +1,5 @@
-#ifndef RESONANCE_DECAY_FILTER_COUNTER_H
-#define RESONANCE_DECAY_FILTER_COUNTER_H
+#ifndef GeneratorInterface_Pythia8Interface_ResonanceDecayFilterCounter_h
+#define GeneratorInterface_Pythia8Interface_ResonanceDecayFilterCounter_h
 
 class ResonanceDecayFilterCounter {
 public:
@@ -8,21 +8,13 @@ public:
     return instance;
   }
 
-  void setEventCounter(int eventCounter) {
-    eventCounter_ = eventCounter;
-  }
+  void setEventCounter(int eventCounter) { eventCounter_ = eventCounter; }
 
-  void setFilterBool(bool filterBool) {
-    filterBool_ = filterBool;
-  }
+  void setFilterBool(bool filterBool) { filterBool_ = filterBool; }
 
-  int getEventCounter() const {
-    return eventCounter_;
-  }
+  int getEventCounter() const { return eventCounter_; }
 
-  bool getFilterBool() const {
-    return filterBool_;
-  }
+  bool getFilterBool() const { return filterBool_; }
 
 private:
   ResonanceDecayFilterCounter() : eventCounter_(0), filterBool_(false) {}
@@ -30,4 +22,4 @@ private:
   bool filterBool_;
 };
 
-#endif // RESONANCE_DECAY_FILTER_COUNTER_H
+#endif  // GeneratorInterface_Pythia8Interface_ResonanceDecayFilterCounter_h

--- a/GeneratorInterface/Pythia8Interface/interface/ResonanceDecayFilterCounter.h
+++ b/GeneratorInterface/Pythia8Interface/interface/ResonanceDecayFilterCounter.h
@@ -12,10 +12,6 @@ public:
     eventCounter_ = eventCounter;
   }
 
-  void setTotalCounter(int totalCounter) {
-    totalCounter_ = totalCounter;
-  }
-
   void setFilterBool(bool filterBool) {
     filterBool_ = filterBool;
   }
@@ -24,18 +20,13 @@ public:
     return eventCounter_;
   }
 
-  int getTotalCounter() const {
-    return totalCounter_;
-  }
-
   bool getFilterBool() const {
     return filterBool_;
   }
 
 private:
-  ResonanceDecayFilterCounter() : eventCounter_(0), totalCounter_(0), filterBool_(false) {}
+  ResonanceDecayFilterCounter() : eventCounter_(0), filterBool_(false) {}
   int eventCounter_;
-  int totalCounter_;
   bool filterBool_;
 };
 

--- a/GeneratorInterface/Pythia8Interface/interface/ResonanceDecayFilterCounter.h
+++ b/GeneratorInterface/Pythia8Interface/interface/ResonanceDecayFilterCounter.h
@@ -1,0 +1,42 @@
+#ifndef RESONANCE_DECAY_FILTER_COUNTER_H
+#define RESONANCE_DECAY_FILTER_COUNTER_H
+
+class ResonanceDecayFilterCounter {
+public:
+  static ResonanceDecayFilterCounter& getInstance() {
+    static ResonanceDecayFilterCounter instance;
+    return instance;
+  }
+
+  void setEventCounter(int eventCounter) {
+    eventCounter_ = eventCounter;
+  }
+
+  void setTotalCounter(int totalCounter) {
+    totalCounter_ = totalCounter;
+  }
+
+  void setFilterBool(bool filterBool) {
+    filterBool_ = filterBool;
+  }
+
+  int getEventCounter() const {
+    return eventCounter_;
+  }
+
+  int getTotalCounter() const {
+    return totalCounter_;
+  }
+
+  bool getFilterBool() const {
+    return filterBool_;
+  }
+
+private:
+  ResonanceDecayFilterCounter() : eventCounter_(0), totalCounter_(0), filterBool_(false) {}
+  int eventCounter_;
+  int totalCounter_;
+  bool filterBool_;
+};
+
+#endif // RESONANCE_DECAY_FILTER_COUNTER_H

--- a/GeneratorInterface/Pythia8Interface/interface/ResonanceDecayFilterHook.h
+++ b/GeneratorInterface/Pythia8Interface/interface/ResonanceDecayFilterHook.h
@@ -21,6 +21,7 @@ public:
 private:
   bool filter_;
   bool exclusive_;
+  bool matching_;
   bool eMuAsEquivalent_;
   bool eMuTauAsEquivalent_;
   bool allNuAsEquivalent_;
@@ -30,7 +31,10 @@ private:
   unsigned long int counter_event_;
   std::set<int> mothers_;
   std::vector<int> daughters_;
+  std::vector<int> matchedDecays_;
 
   std::map<int, int> requestedDaughters_;
   std::map<int, int> observedDaughters_;
+  std::multiset<std::pair<int, int>> requestedDecays_;
+  std::multiset<std::pair<int, int>> remainingDecays_;
 };

--- a/GeneratorInterface/Pythia8Interface/interface/ResonanceDecayFilterHook.h
+++ b/GeneratorInterface/Pythia8Interface/interface/ResonanceDecayFilterHook.h
@@ -13,7 +13,7 @@ public:
   bool canVetoResonanceDecays() override { return true; }
   bool doVetoResonanceDecays(Pythia8::Event& process) override { return checkVetoResonanceDecays(process); }
   bool checkVetoResonanceDecays(const Pythia8::Event& process);
-  unsigned long int returnEventCounter() {return counter_event_;};
+  unsigned long int returnEventCounter() { return counter_event_; };
   void resetEventCounter();
 
   //--------------------------------------------------------------------------

--- a/GeneratorInterface/Pythia8Interface/interface/ResonanceDecayFilterHook.h
+++ b/GeneratorInterface/Pythia8Interface/interface/ResonanceDecayFilterHook.h
@@ -9,6 +9,7 @@ public:
 
   //--------------------------------------------------------------------------
 
+  int idCat(int id);
   bool initAfterBeams() override;
   bool canVetoResonanceDecays() override { return true; }
   bool doVetoResonanceDecays(Pythia8::Event& process) override { return checkVetoResonanceDecays(process); }
@@ -31,7 +32,7 @@ private:
   unsigned long int counter_event_;
   std::set<int> mothers_;
   std::vector<int> daughters_;
-  std::vector<int> matchedDecays_;
+  std::vector<std::string> matchedDecays_;
 
   std::map<int, int> requestedDaughters_;
   std::map<int, int> observedDaughters_;

--- a/GeneratorInterface/Pythia8Interface/interface/ResonanceDecayFilterHook.h
+++ b/GeneratorInterface/Pythia8Interface/interface/ResonanceDecayFilterHook.h
@@ -13,6 +13,9 @@ public:
   bool canVetoResonanceDecays() override { return true; }
   bool doVetoResonanceDecays(Pythia8::Event& process) override { return checkVetoResonanceDecays(process); }
   bool checkVetoResonanceDecays(const Pythia8::Event& process);
+  unsigned long int returnEventCounter() {return counter_event_;};
+  unsigned long int returnTotalCounter() {return counter_total_;};
+  void resetEventCounter();
 
   //--------------------------------------------------------------------------
 
@@ -25,6 +28,8 @@ private:
   bool udscAsEquivalent_;
   bool udscbAsEquivalent_;
   bool wzAsEquivalent_;
+  unsigned long int counter_event_;
+  unsigned long int counter_total_;
   std::set<int> mothers_;
   std::vector<int> daughters_;
 

--- a/GeneratorInterface/Pythia8Interface/interface/ResonanceDecayFilterHook.h
+++ b/GeneratorInterface/Pythia8Interface/interface/ResonanceDecayFilterHook.h
@@ -14,7 +14,6 @@ public:
   bool doVetoResonanceDecays(Pythia8::Event& process) override { return checkVetoResonanceDecays(process); }
   bool checkVetoResonanceDecays(const Pythia8::Event& process);
   unsigned long int returnEventCounter() {return counter_event_;};
-  unsigned long int returnTotalCounter() {return counter_total_;};
   void resetEventCounter();
 
   //--------------------------------------------------------------------------
@@ -29,7 +28,6 @@ private:
   bool udscbAsEquivalent_;
   bool wzAsEquivalent_;
   unsigned long int counter_event_;
-  unsigned long int counter_total_;
   std::set<int> mothers_;
   std::vector<int> daughters_;
 

--- a/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
@@ -41,6 +41,7 @@ using namespace Pythia8;
 
 //decay filter hook
 #include "GeneratorInterface/Pythia8Interface/interface/ResonanceDecayFilterHook.h"
+#include "GeneratorInterface/Pythia8Interface/interface/ResonanceDecayFilterCounter.h"
 
 //decay filter hook
 #include "GeneratorInterface/Pythia8Interface/interface/PTFilterHook.h"
@@ -531,6 +532,7 @@ bool Pythia8Hadronizer::initializeForInternalPartons() {
   }
 
   bool resonanceDecayFilter = fMasterGen->settings.flag("ResonanceDecayFilter:filter");
+  ResonanceDecayFilterCounter::getInstance().setFilterBool(resonanceDecayFilter);
   if (resonanceDecayFilter) {
     fResonanceDecayFilterHook.reset(new ResonanceDecayFilterHook);
     (fUserHooksVector->hooks).push_back(fResonanceDecayFilterHook);
@@ -698,6 +700,7 @@ bool Pythia8Hadronizer::initializeForExternalPartons() {
   }
 
   bool resonanceDecayFilter = fMasterGen->settings.flag("ResonanceDecayFilter:filter");
+  ResonanceDecayFilterCounter::getInstance().setFilterBool(resonanceDecayFilter);
   if (resonanceDecayFilter) {
     fResonanceDecayFilterHook.reset(new ResonanceDecayFilterHook);
     (fUserHooksVector->hooks).push_back(fResonanceDecayFilterHook);
@@ -781,6 +784,16 @@ void Pythia8Hadronizer::statistics() {
   xsec *= 1.0e9;                              // translate to pb (CMS/Gen "convention" as of May 2009)
   double err = fMasterGen->info.sigmaErr();   // cross section err in mb
   err *= 1.0e9;                               // translate to pb (CMS/Gen "convention" as of May 2009)
+  if (fMasterGen->settings.flag("ResonanceDecayFilter:filter")) {
+    double ResonanceDecayFilterEff = (double) fMasterGen->info.getCounter(4) / (double) fResonanceDecayFilterHook->returnTotalCounter();
+    double ResonanceDecayFilterErr = sqrt((1 - ResonanceDecayFilterEff) * ResonanceDecayFilterEff / (double) fResonanceDecayFilterHook->returnTotalCounter());
+    edm::LogPrint("Pythia8Interface") << "\n *-------  PYTHIA Resonance Decay Filter Statistics  --------------------*";
+    edm::LogPrint("Pythia8Interface") << "   Number of tried events:            " << fMasterGen->info.getCounter(4);
+    edm::LogPrint("Pythia8Interface") << "   Number of accepted events:         " << fResonanceDecayFilterHook->returnTotalCounter();
+    edm::LogPrint("Pythia8Interface") << "   Resonance Decay Filter Efficiency: " << std::scientific << std::setprecision(3) 
+                                      << ResonanceDecayFilterEff << " +- " << ResonanceDecayFilterErr;
+    edm::LogPrint("Pythia8Interface") << " *-------  End PYTHIA Resonance Decay Filter Statistics  ----------------*";
+  }
   runInfo().setInternalXSec(GenRunInfoProduct::XSec(xsec, err));
 }
 
@@ -969,6 +982,14 @@ bool Pythia8Hadronizer::hadronize() {
       double wgt = fMasterGen->info.weight(i);
       event()->weights().push_back(wgt);
     }
+  }
+
+  if (fMasterGen->settings.flag("ResonanceDecayFilter:filter")) {
+    int eventCounterValue = fResonanceDecayFilterHook->returnEventCounter();
+    int totalCounterValue = fResonanceDecayFilterHook->returnTotalCounter();
+    ResonanceDecayFilterCounter::getInstance().setEventCounter(eventCounterValue);
+    ResonanceDecayFilterCounter::getInstance().setTotalCounter(totalCounterValue);
+    fResonanceDecayFilterHook->resetEventCounter();
   }
 
   return true;

--- a/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
@@ -784,16 +784,6 @@ void Pythia8Hadronizer::statistics() {
   xsec *= 1.0e9;                              // translate to pb (CMS/Gen "convention" as of May 2009)
   double err = fMasterGen->info.sigmaErr();   // cross section err in mb
   err *= 1.0e9;                               // translate to pb (CMS/Gen "convention" as of May 2009)
-  if (fMasterGen->settings.flag("ResonanceDecayFilter:filter")) {
-    double ResonanceDecayFilterEff = (double) fMasterGen->info.getCounter(4) / (double) fResonanceDecayFilterHook->returnTotalCounter();
-    double ResonanceDecayFilterErr = sqrt((1 - ResonanceDecayFilterEff) * ResonanceDecayFilterEff / (double) fResonanceDecayFilterHook->returnTotalCounter());
-    edm::LogPrint("Pythia8Interface") << "\n *-------  PYTHIA Resonance Decay Filter Statistics  --------------------*";
-    edm::LogPrint("Pythia8Interface") << "   Number of tried events:            " << fMasterGen->info.getCounter(4);
-    edm::LogPrint("Pythia8Interface") << "   Number of accepted events:         " << fResonanceDecayFilterHook->returnTotalCounter();
-    edm::LogPrint("Pythia8Interface") << "   Resonance Decay Filter Efficiency: " << std::scientific << std::setprecision(3) 
-                                      << ResonanceDecayFilterEff << " +- " << ResonanceDecayFilterErr;
-    edm::LogPrint("Pythia8Interface") << " *-------  End PYTHIA Resonance Decay Filter Statistics  ----------------*";
-  }
   runInfo().setInternalXSec(GenRunInfoProduct::XSec(xsec, err));
 }
 
@@ -986,9 +976,7 @@ bool Pythia8Hadronizer::hadronize() {
 
   if (fMasterGen->settings.flag("ResonanceDecayFilter:filter")) {
     int eventCounterValue = fResonanceDecayFilterHook->returnEventCounter();
-    int totalCounterValue = fResonanceDecayFilterHook->returnTotalCounter();
     ResonanceDecayFilterCounter::getInstance().setEventCounter(eventCounterValue);
-    ResonanceDecayFilterCounter::getInstance().setTotalCounter(totalCounterValue);
     fResonanceDecayFilterHook->resetEventCounter();
   }
 

--- a/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
@@ -274,8 +274,8 @@ Pythia8Hadronizer::Pythia8Hadronizer(const edm::ParameterSet &params)
   if (params.exists("reweightGen")) {
     edm::LogInfo("Pythia8Interface") << "Start setup for reweightGen";
     edm::ParameterSet rgParams = params.getParameter<edm::ParameterSet>("reweightGen");
-    fReweightUserHook.reset(
-        new PtHatReweightUserHook(rgParams.getParameter<double>("pTRef"), rgParams.getParameter<double>("power")));
+    fReweightUserHook = std::make_shared<PtHatReweightUserHook>(rgParams.getParameter<double>("pTRef"),
+                                                                rgParams.getParameter<double>("power"));
     edm::LogInfo("Pythia8Interface") << "End setup for reweightGen";
   }
   if (params.exists("reweightGenEmp")) {
@@ -291,23 +291,23 @@ Pythia8Hadronizer::Pythia8Hadronizer(const edm::ParameterSet &params)
   if (params.exists("reweightGenRap")) {
     edm::LogInfo("Pythia8Interface") << "Start setup for reweightGenRap";
     edm::ParameterSet rgrParams = params.getParameter<edm::ParameterSet>("reweightGenRap");
-    fReweightRapUserHook.reset(new RapReweightUserHook(rgrParams.getParameter<std::string>("yLabSigmaFunc"),
-                                                       rgrParams.getParameter<double>("yLabPower"),
-                                                       rgrParams.getParameter<std::string>("yCMSigmaFunc"),
-                                                       rgrParams.getParameter<double>("yCMPower"),
-                                                       rgrParams.getParameter<double>("pTHatMin"),
-                                                       rgrParams.getParameter<double>("pTHatMax")));
+    fReweightRapUserHook = std::make_shared<RapReweightUserHook>(rgrParams.getParameter<std::string>("yLabSigmaFunc"),
+                                                                 rgrParams.getParameter<double>("yLabPower"),
+                                                                 rgrParams.getParameter<std::string>("yCMSigmaFunc"),
+                                                                 rgrParams.getParameter<double>("yCMPower"),
+                                                                 rgrParams.getParameter<double>("pTHatMin"),
+                                                                 rgrParams.getParameter<double>("pTHatMax"));
     edm::LogInfo("Pythia8Interface") << "End setup for reweightGenRap";
   }
   if (params.exists("reweightGenPtHatRap")) {
     edm::LogInfo("Pythia8Interface") << "Start setup for reweightGenPtHatRap";
     edm::ParameterSet rgrParams = params.getParameter<edm::ParameterSet>("reweightGenPtHatRap");
-    fReweightPtHatRapUserHook.reset(new PtHatRapReweightUserHook(rgrParams.getParameter<std::string>("yLabSigmaFunc"),
-                                                                 rgrParams.getParameter<double>("yLabPower"),
-                                                                 rgrParams.getParameter<std::string>("yCMSigmaFunc"),
-                                                                 rgrParams.getParameter<double>("yCMPower"),
-                                                                 rgrParams.getParameter<double>("pTHatMin"),
-                                                                 rgrParams.getParameter<double>("pTHatMax")));
+    fReweightPtHatRapUserHook = std::make_shared<PtHatRapReweightUserHook>(rgrParams.getParameter<std::string>("yLabSigmaFunc"),
+                                                                           rgrParams.getParameter<double>("yLabPower"),
+                                                                           rgrParams.getParameter<std::string>("yCMSigmaFunc"),
+                                                                           rgrParams.getParameter<double>("yCMPower"),
+                                                                           rgrParams.getParameter<double>("pTHatMin"),
+                                                                           rgrParams.getParameter<double>("pTHatMax"));
     edm::LogInfo("Pythia8Interface") << "End setup for reweightGenPtHatRap";
   }
 
@@ -360,17 +360,17 @@ Pythia8Hadronizer::Pythia8Hadronizer(const edm::ParameterSet &params)
     EV1_nFinalMode = 0;
     if (params.exists("EV1_nFinalMode"))
       EV1_nFinalMode = params.getParameter<int>("EV1_nFinalMode");
-    fEmissionVetoHook1.reset(new EmissionVetoHook1(EV1_nFinal,
-                                                   EV1_vetoOn,
-                                                   EV1_maxVetoCount,
-                                                   EV1_pThardMode,
-                                                   EV1_pTempMode,
-                                                   EV1_emittedMode,
-                                                   EV1_pTdefMode,
-                                                   EV1_MPIvetoOn,
-                                                   EV1_QEDvetoMode,
-                                                   EV1_nFinalMode,
-                                                   0));
+    fEmissionVetoHook1 = std::make_shared<EmissionVetoHook1>(EV1_nFinal,
+                                                             EV1_vetoOn,
+                                                             EV1_maxVetoCount,
+                                                             EV1_pThardMode,
+                                                             EV1_pTempMode,
+                                                             EV1_emittedMode,
+                                                             EV1_pTdefMode,
+                                                             EV1_MPIvetoOn,
+                                                             EV1_QEDvetoMode,
+                                                             EV1_nFinalMode,
+                                                             0);
   }
 
   if (params.exists("UserCustomization")) {

--- a/GeneratorInterface/Pythia8Interface/src/Py8HMC3InterfaceBase.cc
+++ b/GeneratorInterface/Pythia8Interface/src/Py8HMC3InterfaceBase.cc
@@ -91,7 +91,7 @@ namespace gen {
     fMasterGen->settings.addFlag("ResonanceDecayFilter:wzAsEquivalent", false);
     fMasterGen->settings.addMVec("ResonanceDecayFilter:mothers", std::vector<int>(), false, false, 0, 0);
     fMasterGen->settings.addMVec("ResonanceDecayFilter:daughters", std::vector<int>(), false, false, 0, 0);
-    fMasterGen->settings.addMVec("ResonanceDecayFilter:matchedDecays", std::vector<int>(), false, false, 0, 0);
+    fMasterGen->settings.addWVec("ResonanceDecayFilter:matchedDecays", std::vector<std::string>());
 
     //add settings for PT filter
     fMasterGen->settings.addFlag("PTFilter:filter", false);

--- a/GeneratorInterface/Pythia8Interface/src/Py8HMC3InterfaceBase.cc
+++ b/GeneratorInterface/Pythia8Interface/src/Py8HMC3InterfaceBase.cc
@@ -82,6 +82,7 @@ namespace gen {
     //add settings for resonance decay filter
     fMasterGen->settings.addFlag("ResonanceDecayFilter:filter", false);
     fMasterGen->settings.addFlag("ResonanceDecayFilter:exclusive", false);
+    fMasterGen->settings.addFlag("ResonanceDecayFilter:matching", false);
     fMasterGen->settings.addFlag("ResonanceDecayFilter:eMuAsEquivalent", false);
     fMasterGen->settings.addFlag("ResonanceDecayFilter:eMuTauAsEquivalent", false);
     fMasterGen->settings.addFlag("ResonanceDecayFilter:allNuAsEquivalent", false);
@@ -90,6 +91,7 @@ namespace gen {
     fMasterGen->settings.addFlag("ResonanceDecayFilter:wzAsEquivalent", false);
     fMasterGen->settings.addMVec("ResonanceDecayFilter:mothers", std::vector<int>(), false, false, 0, 0);
     fMasterGen->settings.addMVec("ResonanceDecayFilter:daughters", std::vector<int>(), false, false, 0, 0);
+    fMasterGen->settings.addMVec("ResonanceDecayFilter:matchedDecays", std::vector<int>(), false, false, 0, 0);
 
     //add settings for PT filter
     fMasterGen->settings.addFlag("PTFilter:filter", false);

--- a/GeneratorInterface/Pythia8Interface/src/Py8InterfaceBase.cc
+++ b/GeneratorInterface/Pythia8Interface/src/Py8InterfaceBase.cc
@@ -93,6 +93,7 @@ namespace gen {
     //add settings for resonance decay filter
     fMasterGen->settings.addFlag("ResonanceDecayFilter:filter", false);
     fMasterGen->settings.addFlag("ResonanceDecayFilter:exclusive", false);
+    fMasterGen->settings.addFlag("ResonanceDecayFilter:matching", false);
     fMasterGen->settings.addFlag("ResonanceDecayFilter:eMuAsEquivalent", false);
     fMasterGen->settings.addFlag("ResonanceDecayFilter:eMuTauAsEquivalent", false);
     fMasterGen->settings.addFlag("ResonanceDecayFilter:allNuAsEquivalent", false);
@@ -101,6 +102,7 @@ namespace gen {
     fMasterGen->settings.addFlag("ResonanceDecayFilter:wzAsEquivalent", false);
     fMasterGen->settings.addMVec("ResonanceDecayFilter:mothers", std::vector<int>(), false, false, 0, 0);
     fMasterGen->settings.addMVec("ResonanceDecayFilter:daughters", std::vector<int>(), false, false, 0, 0);
+    fMasterGen->settings.addMVec("ResonanceDecayFilter:matchedDecays", std::vector<int>(), false, false, 0, 0);
 
     //add settings for PT filter
     fMasterGen->settings.addFlag("PTFilter:filter", false);

--- a/GeneratorInterface/Pythia8Interface/src/Py8InterfaceBase.cc
+++ b/GeneratorInterface/Pythia8Interface/src/Py8InterfaceBase.cc
@@ -102,7 +102,7 @@ namespace gen {
     fMasterGen->settings.addFlag("ResonanceDecayFilter:wzAsEquivalent", false);
     fMasterGen->settings.addMVec("ResonanceDecayFilter:mothers", std::vector<int>(), false, false, 0, 0);
     fMasterGen->settings.addMVec("ResonanceDecayFilter:daughters", std::vector<int>(), false, false, 0, 0);
-    fMasterGen->settings.addMVec("ResonanceDecayFilter:matchedDecays", std::vector<int>(), false, false, 0, 0);
+    fMasterGen->settings.addWVec("ResonanceDecayFilter:matchedDecays", std::vector<std::string>());
 
     //add settings for PT filter
     fMasterGen->settings.addFlag("PTFilter:filter", false);

--- a/GeneratorInterface/Pythia8Interface/src/ResonanceDecayFilterHook.cc
+++ b/GeneratorInterface/Pythia8Interface/src/ResonanceDecayFilterHook.cc
@@ -122,6 +122,4 @@ bool ResonanceDecayFilterHook::checkVetoResonanceDecays(const Event &process) {
   return false;
 }
 
-void ResonanceDecayFilterHook::resetEventCounter() {
-  counter_event_ = 0;
-}
+void ResonanceDecayFilterHook::resetEventCounter() { counter_event_ = 0; }

--- a/GeneratorInterface/Pythia8Interface/src/ResonanceDecayFilterHook.cc
+++ b/GeneratorInterface/Pythia8Interface/src/ResonanceDecayFilterHook.cc
@@ -6,7 +6,6 @@ using namespace Pythia8;
 //--------------------------------------------------------------------------
 bool ResonanceDecayFilterHook::initAfterBeams() {
   counter_event_ = 0;
-  counter_total_ = 0;
   filter_ = settingsPtr->flag("ResonanceDecayFilter:filter");
   exclusive_ = settingsPtr->flag("ResonanceDecayFilter:exclusive");
   eMuAsEquivalent_ = settingsPtr->flag("ResonanceDecayFilter:eMuAsEquivalent");
@@ -56,7 +55,6 @@ bool ResonanceDecayFilterHook::checkVetoResonanceDecays(const Event &process) {
 
   //count the number of times hook is called.
   counter_event_++;
-  counter_total_++;
 
   observedDaughters_.clear();
 

--- a/GeneratorInterface/Pythia8Interface/src/ResonanceDecayFilterHook.cc
+++ b/GeneratorInterface/Pythia8Interface/src/ResonanceDecayFilterHook.cc
@@ -5,6 +5,8 @@ using namespace Pythia8;
 
 //--------------------------------------------------------------------------
 bool ResonanceDecayFilterHook::initAfterBeams() {
+  counter_event_ = 0;
+  counter_total_ = 0;
   filter_ = settingsPtr->flag("ResonanceDecayFilter:filter");
   exclusive_ = settingsPtr->flag("ResonanceDecayFilter:exclusive");
   eMuAsEquivalent_ = settingsPtr->flag("ResonanceDecayFilter:eMuAsEquivalent");
@@ -51,6 +53,10 @@ bool ResonanceDecayFilterHook::initAfterBeams() {
 bool ResonanceDecayFilterHook::checkVetoResonanceDecays(const Event &process) {
   if (!filter_)
     return false;
+
+  //count the number of times hook is called.
+  counter_event_++;
+  counter_total_++;
 
   observedDaughters_.clear();
 
@@ -116,4 +122,8 @@ bool ResonanceDecayFilterHook::checkVetoResonanceDecays(const Event &process) {
 
   //all criteria satisfied, don't veto
   return false;
+}
+
+void ResonanceDecayFilterHook::resetEventCounter() {
+  counter_event_ = 0;
 }


### PR DESCRIPTION
#### PR description:

This pull request proposes a solution to the issue outlined in https://gitlab.cern.ch/cms-gen/gen_tasklist/-/issues/9. The ResonanceDecayFilter was not correctly accounting for the total number of tried events, leading to an incorrect cross section calculation (as the branching ratio was omitted). To address this, I introduced a counter in ResonanceDecayFilterHook.h to track the number of events vetoed by the filter, along with a function to reset the counter after each event. This data is then passed from Pythia8Hadronizer.cc to GenFilterEfficiencyProducer.cc using an object of the class ResonanceDecayFilterCounter I created.

The counter is applied only to the weight counts and not to the event counts, as requested by PDMV, to ensure the event-level GenFilter efficiency excludes the ResonanceDecayFilter information. This exclusion allows PDMV to accurately determine the number of LHE events required to generate a specific number of Gen events.

Additionally, I introduced the input_genfilter_efficiency variable in GenXsecAnalyzer.cc to ensure that when the ResonanceDecayFilter is enabled, the filter efficiency is always calculated using weight counts (where the filter information is stored) instead of event counts. This adjustment ensures consistent efficiency calculations for both LO and NLO processes and includes the filter’s contribution.

Expected changes to the output are as follows:
1. In the GenFilter luminosity block of the final root file, the sumtotal_w and sumtotal_w2 values now incorporate the ResonanceDecayFilter information, reflecting the true total number of tried events.
2. In GenXsecAnalyzer.cc, the "Filter efficiency (taking into account weights)" now includes this filter’s contribution, which accounts for the branching ratio. Consequently, the final cross section and equivalent luminosity are calculated correctly, incorporating the branching ratio.

#### PR validation:

To verify the correctness of the cross section calculation, I used the LO Radion_GF_HH_M300_narrow gridpack (as referenced in https://gitlab.cern.ch/cms-gen/gen_tasklist/-/issues/9) and a simple NLO ttbar custom gridpack that I generated for testing. In both cases, the resulting cross section was calculated correctly.

I also performed the checks outlined in https://cms-sw.github.io/PRWorkflow.html. Specifically, I executed the runTheMatrix suite of tests, which resulted in four errors in the following workflows:

312.0 Pyquen ZeemumuJets_pt10 2760GeV_2022 (Step0-FAILED)
25202.0 TTbar_13 (Step1-FAILED)
14234.0 TTbar_14TeV+2023FSPU (Step1-FAILED)
250202.181 TTbar13TeVPUppmx2018 (Step1-FAILED)

Each of these failures was due to "No such file or directory" errors caused by missing .root files. To investigate further, I ran the same runTheMatrix tests using an unmodified version of CMSSW_14_2_0_pre3 and observed identical errors. This strongly indicates that the issues are unrelated to my modifications.

Additionally, I adhered to the coding and style guidelines by running the commands scram build code-checks (which reported no diagnostics) and scram build code-format.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not a backport.
