### PR TITLE
Fixed energy of R-Hadron cloud in energy deposit model

### DIFF
--- a/SimG4Core/CustomPhysics/src/FullModelHadronicProcess.cc
+++ b/SimG4Core/CustomPhysics/src/FullModelHadronicProcess.cc
@@ -354,10 +354,7 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
   G4LorentzVector p_g_cms = gluinoMomentum;  //gluino in CMS BEFORE collision
   p_g_cms.boost(trafo_full_cms);
 
-  double e = cloud_p4_new.e() + gluinoMomentum.e();
-  if (outgoingRhadron)
-    e += outgoingRhadron->GetPDGMass();
-  G4LorentzVector p4_new(cloud_p4_new.v() + gluinoMomentum.v(), e);
+  G4LorentzVector p4_new(cloud_p4_new.v() + gluinoMomentum.v(), outgoingRhadron->GetPDGMass());
   //  G4cout<<"P4-diff: "<<(p4_new-cloud_p4_new-gluinoMomentum)/GeV<<", magnitude: "
   // <<(p4_new-cloud_p4_new-gluinoMomentum).m()/MeV<<" MeV" <<G4endl;
 


### PR DESCRIPTION
#### PR description:

[A 2015 commit to FullModelHadronicProcess.cc](https://github.com/cms-sw/cmssw/commit/0f7fe9f2e7b0d63c51c023862a2eeb75d9898e1e#diff-d97c0182cf0b0204534930064c29ace096341c2b2a33ede9d1f1aac75be22d91) introduced a bug to the energy deposit model. This bug incorrectly deposited energy values close to the BSM particles mass into the simulated detector. This merge request reverts the energy deposit model to a previously working version from 2015. **This is a work in progress, additional changes are expected to be made.** [Here are slides given to the EXO general group on the topic from November 19th, 2024](https://indico.cern.ch/event/1479107/)

#### PR validation:

`scram b runtests use-ibeos` completed successfully.
`runTheMatrix.py -l limited -i all --ibeos` completed successfully without any failrues.
Below is a comparison of 10,000 identically seeded simulated energy deposits in the ECAL barrel with and without the bug.

<img width="681" alt="Screenshot 2024-11-18 at 1 51 38 PM" src="https://github.com/user-attachments/assets/4a7ccf83-9da9-429a-b8e5-5893ef33296a">

<img width="679" alt="Screenshot 2024-11-18 at 1 52 19 PM" src="https://github.com/user-attachments/assets/4ddd919a-1173-4b32-b872-d932bad5ac38">
