### PR TITLE
Avoid allocations in ParentageID

### DIFF
--- a/DataFormats/Provenance/interface/CompactHash.h
+++ b/DataFormats/Provenance/interface/CompactHash.h
@@ -1,0 +1,163 @@
+#ifndef DataFormats_Provenance_CompactHash_h
+#define DataFormats_Provenance_CompactHash_h
+
+#include <string_view>
+#include <array>
+#include <functional>
+
+namespace cms {
+  class Digest;
+}
+
+namespace edm {
+
+  namespace detail {
+    // This string is the 16-byte, non-printable version.
+    std::array<unsigned char, 16> const& InvalidCompactHash();
+  }  // namespace detail
+
+  namespace compact_hash_detail {
+    using value_type = std::array<unsigned char, 16>;
+    void toString_(std::string& result, value_type const& hash);
+    void toDigest_(cms::Digest& digest, value_type const& hash);
+    std::ostream& print_(std::ostream& os, value_type const& hash);
+    bool isValid_(value_type const& hash);
+    size_t smallHash_(value_type const& hash);
+    value_type fromHex_(std::string_view);
+    void throwIfIllFormed(std::string_view v);
+  }  // namespace compact_hash_detail
+
+  template <int I>
+  class CompactHash {
+  public:
+    typedef compact_hash_detail::value_type value_type;
+
+    CompactHash();
+    explicit CompactHash(value_type const& v);
+    explicit CompactHash(std::string_view v);
+
+    CompactHash(CompactHash<I> const&) = default;
+    CompactHash<I>& operator=(CompactHash<I> const& iRHS) = default;
+
+    CompactHash(CompactHash<I>&&) = default;
+    CompactHash<I>& operator=(CompactHash<I>&&) = default;
+
+    void reset();
+
+    // For now, just check the most basic: a default constructed
+    // ParameterSetID is not valid. This is very crude: we are
+    // assuming that nobody created a ParameterSetID from an empty
+    // string, nor from any string that is not a valid string
+    // representation of an MD5 checksum.
+    bool isValid() const;
+
+    bool operator<(CompactHash<I> const& other) const;
+    bool operator>(CompactHash<I> const& other) const;
+    bool operator==(CompactHash<I> const& other) const;
+    bool operator!=(CompactHash<I> const& other) const;
+    std::ostream& print(std::ostream& os) const;
+    void toString(std::string& result) const;
+    void toDigest(cms::Digest& digest) const;
+
+    // Return the 16-byte (non-printable) string form.
+    value_type const& compactForm() const;
+
+    ///returns a short hash which can be used with hashing containers
+    size_t smallHash() const;
+
+    //Used by ROOT storage
+    // CMS_CLASS_VERSION(3) // This macro is not defined here, so expand it.
+    static short Class_Version() { return 3; }
+
+  private:
+    template <typename Op>
+    bool compareUsing(CompactHash<I> const& iOther, Op op) const {
+      return op(this->hash_, iOther.hash_);
+    }
+
+    value_type hash_;
+  };
+
+  //--------------------------------------------------------------------
+  //
+  // Implementation details follow...
+  //--------------------------------------------------------------------
+
+  template <int I>
+  inline CompactHash<I>::CompactHash() : hash_(detail::InvalidCompactHash()) {}
+
+  template <int I>
+  inline CompactHash<I>::CompactHash(value_type const& v) : hash_(v) {}
+
+  template <int I>
+  inline CompactHash<I>::CompactHash(std::string_view v) {
+    if (v.size() == 32) {
+      hash_ = compact_hash_detail::fromHex_(v);
+    } else {
+      compact_hash_detail::throwIfIllFormed(v);
+      std::copy(v.begin(), v.end(), hash_.begin());
+    }
+  }
+
+  template <int I>
+  inline void CompactHash<I>::reset() {
+    hash_ = detail::InvalidCompactHash();
+  }
+
+  template <int I>
+  inline bool CompactHash<I>::isValid() const {
+    return compact_hash_detail::isValid_(hash_);
+  }
+
+  template <int I>
+  inline bool CompactHash<I>::operator<(CompactHash<I> const& other) const {
+    return this->compareUsing(other, std::less<value_type>());
+  }
+
+  template <int I>
+  inline bool CompactHash<I>::operator>(CompactHash<I> const& other) const {
+    return this->compareUsing(other, std::greater<value_type>());
+  }
+
+  template <int I>
+  inline bool CompactHash<I>::operator==(CompactHash<I> const& other) const {
+    return this->compareUsing(other, std::equal_to<value_type>());
+  }
+
+  template <int I>
+  inline bool CompactHash<I>::operator!=(CompactHash<I> const& other) const {
+    return this->compareUsing(other, std::not_equal_to<value_type>());
+  }
+
+  template <int I>
+  inline std::ostream& CompactHash<I>::print(std::ostream& os) const {
+    return compact_hash_detail::print_(os, hash_);
+  }
+
+  template <int I>
+  inline void CompactHash<I>::toString(std::string& result) const {
+    compact_hash_detail::toString_(result, hash_);
+  }
+
+  template <int I>
+  inline void CompactHash<I>::toDigest(cms::Digest& digest) const {
+    compact_hash_detail::toDigest_(digest, hash_);
+  }
+
+  template <int I>
+  inline typename CompactHash<I>::value_type const& CompactHash<I>::compactForm() const {
+    return hash_;
+  }
+
+  template <int I>
+  inline size_t CompactHash<I>::smallHash() const {
+    return compact_hash_detail::smallHash_(hash_);
+  }
+
+  template <int I>
+  inline std::ostream& operator<<(std::ostream& os, CompactHash<I> const& h) {
+    return h.print(os);
+  }
+
+}  // namespace edm
+#endif

--- a/DataFormats/Provenance/interface/ParentageID.h
+++ b/DataFormats/Provenance/interface/ParentageID.h
@@ -2,10 +2,13 @@
 #define DataFormats_Provenance_ParentageID_h
 
 #include "DataFormats/Provenance/interface/HashedTypes.h"
+#include "DataFormats/Provenance/interface/CompactHash.h"
 #include "DataFormats/Provenance/interface/Hash.h"
 
 namespace edm {
-  typedef Hash<ParentageType> ParentageID;
-}
+  using ParentageID = CompactHash<ParentageType>;
+
+  using StoredParentageID = Hash<ParentageType>;
+}  // namespace edm
 
 #endif

--- a/DataFormats/Provenance/interface/ProductProvenance.h
+++ b/DataFormats/Provenance/interface/ProductProvenance.h
@@ -39,8 +39,7 @@ namespace edm {
     ParentageID const& parentageID() const { return parentageID_; }
     Parentage const& parentage() const;
 
-    void set(ParentageID id) { parentageID_ = std::move(id); }
-    ParentageID moveParentageID() { return std::move(parentageID_); }
+    void set(ParentageID const& id) { parentageID_ = id; }
 
   private:
     BranchID branchID_;

--- a/DataFormats/Provenance/interface/ProductProvenanceLookup.h
+++ b/DataFormats/Provenance/interface/ProductProvenanceLookup.h
@@ -33,7 +33,7 @@ namespace edm {
     ProductProvenanceLookup& operator=(ProductProvenanceLookup const&) = delete;
 
     ProductProvenance const* branchIDToProvenance(BranchID const& bid) const;
-    void insertIntoSet(ProductProvenance provenanceProduct) const;
+    void insertIntoSet(ProductProvenance const& provenanceProduct) const;
     ProductProvenance const* branchIDToProvenanceForProducedOnly(BranchID const& bid) const;
 
     void update(edm::ProductRegistry const&);
@@ -78,8 +78,8 @@ namespace edm {
 
       bool isParentageSet() const noexcept { return isParentageSet_.load(std::memory_order_acquire); }
 
-      void threadsafe_set(ParentageID id) const {
-        provenance_.set(std::move(id));
+      void threadsafe_set(ParentageID const& id) const {
+        provenance_.set(id);
         isParentageSet_.store(true, std::memory_order_release);
       }
 

--- a/DataFormats/Provenance/src/CompactHash.cc
+++ b/DataFormats/Provenance/src/CompactHash.cc
@@ -1,0 +1,71 @@
+#include "DataFormats/Provenance/interface/CompactHash.h"
+#include "FWCore/Utilities/interface/Algorithms.h"
+#include "FWCore/Utilities/interface/Digest.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+
+#include <functional>
+#include <cassert>
+
+namespace {
+  std::array<unsigned char, 16> convert(std::string const& v) {
+    assert(v.size() == 16);
+    std::array<unsigned char, 16> retValue;
+    std::copy(v.begin(), v.end(), retValue.begin());
+    return retValue;
+  }
+}  // namespace
+namespace edm {
+  namespace detail {
+    // This string is the 16-byte, non-printable version.
+    std::array<unsigned char, 16> const& InvalidCompactHash() {
+      static std::array<unsigned char, 16> const invalid = convert(cms::MD5Result().compactForm());
+      return invalid;
+    }
+  }  // namespace detail
+
+  namespace compact_hash_detail {
+    size_t smallHash_(value_type const& hash) {
+      //NOTE: In future we could try to xor the first 8bytes into the second 8bytes of the string to make the hash
+      std::hash<std::string_view> h;
+      return h(std::string_view(reinterpret_cast<const char*>(hash.data()), hash.size()));
+    }
+
+    std::array<unsigned char, 16> fromHex_(std::string_view v) {
+      cms::MD5Result temp;
+      temp.fromHexifiedString(std::string(v));
+      auto hash = temp.compactForm();
+      std::array<unsigned char, 16> ret;
+      std::copy(hash.begin(), hash.end(), ret.begin());
+      return ret;
+    }
+
+    bool isValid_(value_type const& hash) { return hash != detail::InvalidCompactHash(); }
+
+    void throwIfIllFormed(std::string_view v) {
+      // Fixup not needed here.
+      if (v.size() != 16) {
+        throw Exception(errors::LogicError) << "Ill-formed CompactHash instance. "
+                                            << "A string_view of size " << v.size() << " passed to constructor.";
+      }
+    }
+
+    void toString_(std::string& result, value_type const& hash) {
+      cms::MD5Result temp;
+      copy_all(hash, temp.bytes.begin());
+      result += temp.toString();
+    }
+
+    void toDigest_(cms::Digest& digest, value_type const& hash) {
+      cms::MD5Result temp;
+      copy_all(hash, temp.bytes.begin());
+      digest.append(temp.toString());
+    }
+
+    std::ostream& print_(std::ostream& os, value_type const& hash) {
+      cms::MD5Result temp;
+      copy_all(hash, temp.bytes.begin());
+      os << temp.toString();
+      return os;
+    }
+  }  // namespace compact_hash_detail
+}  // namespace edm

--- a/DataFormats/Provenance/src/CompactHash.cc
+++ b/DataFormats/Provenance/src/CompactHash.cc
@@ -32,7 +32,7 @@ namespace edm {
 
     std::array<unsigned char, 16> fromHex_(std::string_view v) {
       cms::MD5Result temp;
-      temp.fromHexifiedString(std::string(v));
+      temp.fromHexifiedString(v);
       auto hash = temp.compactForm();
       std::array<unsigned char, 16> ret;
       std::copy(hash.begin(), hash.end(), ret.begin());

--- a/DataFormats/Provenance/src/ProductProvenanceLookup.cc
+++ b/DataFormats/Provenance/src/ProductProvenanceLookup.cc
@@ -39,7 +39,7 @@ namespace edm {
     setupEntryInfoSet(iReg);
   }
 
-  void ProductProvenanceLookup::insertIntoSet(ProductProvenance entryInfo) const {
+  void ProductProvenanceLookup::insertIntoSet(ProductProvenance const& entryInfo) const {
     //NOTE:do not read provenance here because we only need the full
     // provenance when someone tries to access it not when doing the insert
     // doing the delay saves 20% of time when doing an analysis job
@@ -53,7 +53,7 @@ namespace edm {
       throw edm::Exception(edm::errors::LogicError) << "ProductProvenanceLookup::insertIntoSet passed a BranchID "
                                                     << entryInfo.branchID().id() << " that has not been pre-registered";
     }
-    itFound->threadsafe_set(entryInfo.moveParentageID());
+    itFound->threadsafe_set(entryInfo.parentageID());
   }
 
   ProductProvenance const* ProductProvenanceLookup::branchIDToProvenance(BranchID const& bid) const {

--- a/DataFormats/Provenance/src/classes_def.xml
+++ b/DataFormats/Provenance/src/classes_def.xml
@@ -73,7 +73,8 @@
  <class name="edm::BranchChildren" ClassVersion="10">
   <version ClassVersion="10" checksum="137742168"/>
  </class>
- <class name="edm::ProductProvenance" ClassVersion="11">
+ <class name="edm::ProductProvenance" ClassVersion="12">
+  <version ClassVersion="12" checksum="737844716"/>
   <version ClassVersion="11" checksum="3594205707"/>
   <version ClassVersion="10" checksum="3685381930"/>
  </class>
@@ -162,6 +163,7 @@
  <class name="std::pair<const edm::ParameterSetID,edm::ParameterSetBlob>"/>
  <class name="edm::ProcessConfigurationID"/>
  <class name="std::vector<edm::ProcessConfigurationID>"/>
+ <class name="edm::StoredParentageID"/>
  <class name="edm::ParentageID"/>
  <class name="edm::Parentage" ClassVersion="11">
   <version ClassVersion="11" checksum="3091321815"/>
@@ -257,6 +259,11 @@
  <ioread sourceClass="edm::Parentage" targetClass="edm::Parentage" version="[1-]" source="" target="transient_">
  <![CDATA[
 	newObj->initializeTransients();
+ ]]>
+ </ioread>
+ <ioread sourceClass="edm::Hash<5>" targetClass="edm::CompactHash<5>" version="[1-]" source="std::string hash_" target="hash_">
+ <![CDATA[
+  *newObj = edm::CompactHash<5>(onfile.hash_);
  ]]>
  </ioread>
  

--- a/DataFormats/Provenance/test/BuildFile.xml
+++ b/DataFormats/Provenance/test/BuildFile.xml
@@ -1,12 +1,15 @@
+<bin name="testDataFormatsProvenance" file="testRunner.cpp,eventid_t.cppunit.cc,timestamp_t.cppunit.cc,parametersetid_t.cppunit.cc,indexIntoFile_t.cppunit.cc,indexIntoFile1_t.cppunit.cc,indexIntoFile2_t.cppunit.cc,indexIntoFile3_t.cppunit.cc,indexIntoFile4_t.cppunit.cc,indexIntoFile5_t.cppunit.cc,lumirange_t.cppunit.cc,eventrange_t.cppunit.cc,compactEventAuxiliaryVector_t.cppunit.cc">
 <use name="cppunit"/>
 <use name="DataFormats/Provenance"/>
-<bin name="testDataFormatsProvenance" file="testRunner.cpp,eventid_t.cppunit.cc,timestamp_t.cppunit.cc,parametersetid_t.cppunit.cc,indexIntoFile_t.cppunit.cc,indexIntoFile1_t.cppunit.cc,indexIntoFile2_t.cppunit.cc,indexIntoFile3_t.cppunit.cc,indexIntoFile4_t.cppunit.cc,indexIntoFile5_t.cppunit.cc,lumirange_t.cppunit.cc,eventrange_t.cppunit.cc,compactEventAuxiliaryVector_t.cppunit.cc">
 </bin>
 
-<bin name="testDataFormatsProvenanceCatch2" file="ElementID_t.cpp,Parentage_t.cpp,StoredProcessBlockHelper_t.cpp">
+<bin name="testDataFormatsProvenanceCatch2" file="ElementID_t.cpp,Parentage_t.cpp,StoredProcessBlockHelper_t.cpp,CompactHash_t.cpp">
+  <use name="DataFormats/Provenance"/>
   <use name="catch2"/>
 </bin>
 
 <bin name="testProductResolverIndexHelper" file="testRunner.cpp productResolverIndexHelper_t.cppunit.cc">
   <use name="DataFormats/TestObjects"/>
+  <use name="cppunit"/>
+  <use name="DataFormats/Provenance"/>
 </bin>

--- a/DataFormats/Provenance/test/CompactHash_t.cpp
+++ b/DataFormats/Provenance/test/CompactHash_t.cpp
@@ -1,0 +1,35 @@
+#include "catch.hpp"
+
+#include "DataFormats/Provenance/interface/CompactHash.h"
+#include "FWCore/Utilities/interface/Digest.h"
+
+namespace {
+  using TestHash = edm::CompactHash<100>;
+}
+
+TEST_CASE("CompactHash", "[CompactHash]") {
+  SECTION("Default construction is invalid") { REQUIRE(TestHash{}.isValid() == false); }
+
+  SECTION("Basic operations") {
+    cms::Digest d("foo");
+    auto result = d.digest().bytes;
+
+    TestHash id{result};
+    REQUIRE(id.isValid() == true);
+    REQUIRE(id.compactForm() == result);
+
+    TestHash id2 = id;
+    REQUIRE(id2.isValid() == true);
+    REQUIRE(id2.compactForm() == result);
+
+    cms::Digest b("bar");
+    auto diffResult = b.digest().bytes;
+    REQUIRE(id2 == TestHash{result});
+    REQUIRE(id2 != TestHash{diffResult});
+
+    REQUIRE(id2 > TestHash{diffResult});
+    REQUIRE(TestHash{diffResult} < id2);
+
+    REQUIRE(not(id2 < id2));
+  }
+}

--- a/DataFormats/Provenance/test/Parentage_t.cpp
+++ b/DataFormats/Provenance/test/Parentage_t.cpp
@@ -32,4 +32,35 @@ TEST_CASE("test Parentage", "[Parentage]") {
   edm::ParentageID id4 = ed4.id();
   CHECK(ed4 == ed2);
   CHECK(id4 == id2);
+
+  SECTION("ParentageID unchanging") {
+    {
+      const std::string idString = "d41d8cd98f00b204e9800998ecf8427e";
+      std::string toString;
+      id1.toString(toString);
+      CHECK(toString == idString);
+    }
+
+    {
+      const std::string idString = "2e5751b7cfd7f053cd29e946fb2649a4";
+      std::string toString;
+      id2.toString(toString);
+      CHECK(toString == idString);
+    }
+    {
+      const std::string idString = "20e13ca818af45e50e369e50db3914b8";
+      std::string toString;
+      id3.toString(toString);
+      CHECK(toString == idString);
+    }
+    {
+      edm::Parentage ed_mult;
+      ed_mult.setParents(std::vector<edm::BranchID>({edm::BranchID(1), edm::BranchID(2), edm::BranchID(3)}));
+      auto id_mult = ed_mult.id();
+      const std::string idString = "6a5cf1697e50ec8e8dbe7a28ccad348b";
+      std::string toString;
+      id_mult.toString(toString);
+      CHECK(toString == idString);
+    }
+  }
 }

--- a/FWCore/Utilities/interface/Digest.h
+++ b/FWCore/Utilities/interface/Digest.h
@@ -5,6 +5,7 @@
 
 #include <iosfwd>
 #include <string>
+#include <string_view>
 #include <array>
 
 namespace cms {
@@ -48,9 +49,12 @@ namespace cms {
   public:
     Digest();
     explicit Digest(std::string const& s);
+    explicit Digest(std::string_view);
+    explicit Digest(const char*);
 
     void append(std::string const& s);
     void append(const char* data, size_t size);
+    void append(std::string_view v);
 
     MD5Result digest();
 

--- a/FWCore/Utilities/interface/Digest.h
+++ b/FWCore/Utilities/interface/Digest.h
@@ -28,7 +28,7 @@ namespace cms {
     std::string compactForm() const;
 
     // Set our data from the given hexdigest string.
-    void fromHexifiedString(std::string const& s);
+    void fromHexifiedString(std::string_view);
 
     bool isValid() const;
   };

--- a/FWCore/Utilities/src/Digest.cc
+++ b/FWCore/Utilities/src/Digest.cc
@@ -158,9 +158,24 @@ namespace cms {
     this->append(s);
   }
 
+  Digest::Digest(std::string_view v) : state_() {
+    md5_init(&state_);
+    this->append(v);
+  }
+
+  Digest::Digest(const char* s) : state_() {
+    md5_init(&state_);
+    this->append(s, strlen(s));
+  }
+
   void Digest::append(std::string const& s) {
     const md5_byte_t* data = reinterpret_cast<const md5_byte_t*>(s.data());
     md5_append(&state_, const_cast<md5_byte_t*>(data), s.size());
+  }
+
+  void Digest::append(std::string_view v) {
+    const md5_byte_t* data = reinterpret_cast<const md5_byte_t*>(v.data());
+    md5_append(&state_, const_cast<md5_byte_t*>(data), v.size());
   }
 
   void Digest::append(const char* s, size_t size) {

--- a/FWCore/Utilities/src/Digest.cc
+++ b/FWCore/Utilities/src/Digest.cc
@@ -114,13 +114,13 @@ namespace cms {
     return std::string(p, p + bytes.size());
   }
 
-  void MD5Result::fromHexifiedString(std::string const& hexy) {
+  void MD5Result::fromHexifiedString(std::string_view hexy) {
     switch (hexy.size()) {
       case 0: {
         set_to_default(*this);
       } break;
       case 32: {
-        std::string::const_iterator it = hexy.begin();
+        auto it = hexy.cbegin();
         for (size_t i = 0; i != 16; ++i) {
           // first nybble
           bytes[i] = (unhexify(*it++) << 4);

--- a/FWCore/Utilities/test/test_catch2_Digest.cc
+++ b/FWCore/Utilities/test/test_catch2_Digest.cc
@@ -26,7 +26,7 @@ namespace {
 TEST_CASE("Test cms::Digest", "[Digest]") {
   SECTION("Identical") {
     Digest dig1;
-    dig1.append("hello");
+    dig1.append(std::string_view("hello"));
     Digest dig2("hello");
 
     MD5Result r1 = dig1.digest();
@@ -80,5 +80,19 @@ TEST_CASE("Test cms::Digest", "[Digest]") {
         REQUIRE(lookup.compactForm() == fromHex.compactForm());
       }
     }
+  }
+  SECTION("append equal") {
+    std::string full("aldjfakl\tsdjf34234 \najdf");
+    Digest full_digest{full};
+    MD5Result full_r = full_digest.digest();
+    REQUIRE(full_r.isValid());
+
+    Digest append_digest;
+    append_digest.append(std::string_view(full.data(), 10));
+    append_digest.append(std::string_view(full.data() + 10, 10));
+    append_digest.append(std::string_view(full.data() + 20, 4));
+    MD5Result append_r = append_digest.digest();
+    REQUIRE(append_r.isValid());
+    REQUIRE(full_r == append_r);
   }
 }


### PR DESCRIPTION
#### PR description:

We were cycling memory each time a module put a data product into the event. This now has the ParentageID hold the 16 bytes directly instead of indirectly via a std::string.

#### PR validation:

All framework unit tests pass.