### PR TITLE
[14.1.X] `SiStripZeroSupperssion`: discard processing unphysical clusters in `suppressHybridData`

### DIFF
--- a/DataFormats/SiStripDetId/interface/SiStripDetId.h
+++ b/DataFormats/SiStripDetId/interface/SiStripDetId.h
@@ -3,6 +3,7 @@
 
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/SiStripDetId/interface/SiStripEnums.h"
+#include "FWCore/Utilities/interface/Exception.h"
 #include <ostream>
 
 class SiStripDetId;
@@ -58,6 +59,9 @@ public:
 
   /** Returns strip length of strip tracker sensor, otherwise null. */
   inline double stripLength() const;
+
+  /** Returns number of APVs connected to each strip tracker module */
+  inline unsigned int numberOfAPVs() const;
 
   // ---------- Constructors that set "reserved" field ----------
 
@@ -182,5 +186,26 @@ uint32_t SiStripDetId::partnerDetId() const {
 double SiStripDetId::stripLength() const { return 0.; }
 
 uint16_t SiStripDetId::reserved() const { return static_cast<uint16_t>((id_ >> reservedStartBit_) & reservedMask_); }
+
+unsigned int SiStripDetId::numberOfAPVs() const {
+  const auto &moduleGeometry = this->moduleGeometry();
+
+  // Check for unknown geometry and throw a meaningful exception
+  if (moduleGeometry == SiStripModuleGeometry::UNKNOWNGEOMETRY) {
+    throw cms::Exception("InvalidModuleGeometry")
+        << "Error in SiStripDetId::numberOfAPVs(): Module geometry is UNKNOWNGEOMETRY. "
+        << "This indicates an invalid or unsupported module geometry for the current DetId: " << this->rawId();
+  }
+
+  // Determine the number of APVs based on the module geometry
+  if (moduleGeometry == SiStripModuleGeometry::IB1 || moduleGeometry == SiStripModuleGeometry::OB1 ||
+      moduleGeometry == SiStripModuleGeometry::W1A || moduleGeometry == SiStripModuleGeometry::W1B ||
+      moduleGeometry == SiStripModuleGeometry::W2A || moduleGeometry == SiStripModuleGeometry::W2B ||
+      moduleGeometry == SiStripModuleGeometry::W5) {
+    return 6;
+  } else {
+    return 4;
+  }
+}
 
 #endif  // DataFormats_SiStripDetId_SiStripDetId_h

--- a/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
@@ -12,6 +12,7 @@
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h"
 #include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
+#include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
 
 #include "CalibFormats/SiStripObjects/interface/SiStripDetCabling.h"
 
@@ -407,7 +408,9 @@ void ClusterFiller::fill(StripClusterizerAlgorithm::output_t::TSFastFiller& reco
               buffer->channel(fedCh), std::back_inserter(unpDigis), ipair * 256, isNonLite, mode, legacy_, lmode, pCode);
           if (fedchannelunpacker::StatusCode::SUCCESS == st_ch) {
             edm::DetSet<SiStripDigi> suppDigis{id};
-            rawAlgos.suppressHybridData(unpDigis, suppDigis, ipair * 2);
+            unsigned int detId = suppDigis.id;
+            uint16_t maxNStrips = SiStripDetId(detId).numberOfAPVs() * 128;
+            rawAlgos.suppressHybridData(maxNStrips, unpDigis, suppDigis, ipair * 2);
             std::copy(std::begin(suppDigis), std::end(suppDigis), perStripAdder);
           }
         }

--- a/RecoLocalTracker/SiStripZeroSuppression/interface/SiStripRawProcessingAlgorithms.h
+++ b/RecoLocalTracker/SiStripZeroSuppression/interface/SiStripRawProcessingAlgorithms.h
@@ -21,7 +21,8 @@ public:
   void initialize(const edm::EventSetup&);
   void initialize(const edm::EventSetup&, const edm::Event&);
 
-  uint16_t suppressHybridData(const edm::DetSet<SiStripDigi>& inDigis,
+  uint16_t suppressHybridData(const uint16_t maxStrip,
+                              const edm::DetSet<SiStripDigi>& inDigis,
                               edm::DetSet<SiStripDigi>& suppressedDigis,
                               uint16_t firstAPV = 0);
 

--- a/RecoLocalTracker/SiStripZeroSuppression/plugins/SiStripZeroSuppression.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/plugins/SiStripZeroSuppression.cc
@@ -5,10 +5,12 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
 #include "DataFormats/SiStripDigi/interface/SiStripDigi.h"
 #include "DataFormats/SiStripDigi/interface/SiStripRawDigi.h"
 #include "RecoLocalTracker/SiStripZeroSuppression/interface/SiStripRawProcessingFactory.h"
 #include "FWCore/Utilities/interface/transform.h"
+#include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
 #include <memory>
 
 SiStripZeroSuppression::SiStripZeroSuppression(edm::ParameterSet const& conf)
@@ -151,8 +153,11 @@ inline void SiStripZeroSuppression::processHybrid(const edm::DetSetVector<SiStri
   for (const auto& inDigis : input) {
     edm::DetSet<SiStripDigi> suppressedDigis(inDigis.id);
 
+    unsigned int detId = inDigis.id;
+    uint16_t maxNStrips = SiStripDetId(detId).numberOfAPVs() * 128;
+
     uint16_t nAPVflagged = 0;
-    nAPVflagged = algorithms->suppressHybridData(inDigis, suppressedDigis);
+    nAPVflagged = algorithms->suppressHybridData(maxNStrips, inDigis, suppressedDigis);
 
     storeExtraOutput(inDigis.id, nAPVflagged);
     if (!suppressedDigis.empty())


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/46722

#### PR description:

This PR is meant as a patch for the issue described at https://github.com/cms-sw/cmssw/issues/43078, where the fix consists simply in discarding the APVs in which the request of the strip number is higher than the maximum allowed in the module.

   * 2e37ec281fb820b0d3568248dbd5ec576d77baa5: adds a utility method to `SiStripDetId` that returns if the underlying Strip module is connected to 4 or 6 APVs.
   * 7f5283ea1fada44eda4efdbef9f0b5f49d356bb0: discard strip digi payloads with unphysical numer of strips in `processHybrid`, using `SiStripDetId::numberOfAPVs()`.

#### PR validation:

Run the following script:

```bash
#!/bin/bash -ex

# CMSSW_14_1_5_patch1       
                                                                                              
hltGetConfiguration run:388419 \
  --globaltag 141X_dataRun3_HLT_v1 \
  --data \
  --no-prescale \
  --no-output \
  --max-events -1 \
  --input file:converted.root  > hlt.py

# Define a function to execute each iteration of the loop
process_file() {
    inputfile="$1"
    outputfile="${inputfile%.root}"
    cp hlt.py hlt_${outputfile}.py
    sed -i "s/file:converted\.root/\/store\/group\/tsg\/FOG\/error_stream_root\/run388419\/${inputfile}/g" hlt_${outputfile}.py
    cmsRun hlt_${outputfile}.py &> "${outputfile}.log"
}

# Export the function so it can be used by parallel
export -f process_file

# Find the root files and run the function in parallel using GNU Parallel
eos ls /eos/cms/store/group/tsg/FOG/error_stream_root/run388419/ | grep '\.root$' | parallel -j 4 process_file
```

which runs over the list of error stream files from [run-388419](https://cmsoms.cern.ch/cms/runs/report?cms_run=388419) ([elog/1247892](http://cmsonline.cern.ch/cms-elog/1247892)) where we had in excess of 1k HLT crashes, and didn't observe residual crashes. 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/46722 for HLT online operations during the 2024 PbPb run.