### PR TITLE
Phase2-hgx360U Update the code for guard ring and mouse bite usage in full and partial wafers in HGCal geometry definition

### DIFF
--- a/SimG4CMS/Calo/plugins/HGCalMouseBiteTester.cc
+++ b/SimG4CMS/Calo/plugins/HGCalMouseBiteTester.cc
@@ -111,11 +111,11 @@ void HGCalMouseBiteTester::analyze(const edm::Event& iEvent, const edm::EventSet
   int orient = HGCalWaferType::getOrient(index, hgcons_.getParameter()->waferInfoMap_);
   int placeIndex_ = HGCalCell::cellPlacementIndex(zside, frontBack, orient);
   int waferType_ = HGCalWaferType::getType(index, hgcons_.getParameter()->waferInfoMap_);
-  double mouseBiteCut_ = waferSize_ * tan(30.0 * CLHEP::deg) - 5.0;
+  double mouseBiteCut_ = hgcons_.mouseBite(false);
   bool v17OrLess = hgcons_.v17OrLess();
   HGCGuardRing guardRing_(hgcons_);
   HGCGuardRingPartial guardRingPartial_(hgcons_);
-  HGCMouseBite mouseBite_(hgcons_, angle_, mouseBiteCut_, true);
+  HGCMouseBite mouseBite_(hgcons_, angle_, (waferSize_ * tan(30.0 * CLHEP::deg) - mouseBiteCut_), true);
   const int nFine(12), nCoarse(8);
   double r2 = 0.5 * waferSize_;
   double R2 = 2 * r2 / sqrt(3);

--- a/SimG4CMS/Calo/src/HGCGuardRing.cc
+++ b/SimG4CMS/Calo/src/HGCGuardRing.cc
@@ -11,10 +11,10 @@ HGCGuardRing::HGCGuardRing(const HGCalDDDConstants& hgc)
       modeUV_(hgcons_.geomMode()),
       v17OrLess_(hgcons_.v17OrLess()),
       waferSize_(hgcons_.waferSize(false)),
-      sensorSizeOffset_(hgcons_.getParameter()->sensorSizeOffset_),
-      guardRingOffset_(hgcons_.getParameter()->guardRingOffset_) {
-  offset_ = sensorSizeOffset_ + 2.0 * guardRingOffset_;
-  xmax_ = 0.5 * (waferSize_ - offset_);
+      sensorSizeOffset_(hgcons_.sensorSizeOffset(false)),
+      guardRingOffset_(hgcons_.guardRingOffset(false)) {
+  offset_ = sensorSizeOffset_ + guardRingOffset_;
+  xmax_ = 0.5 * waferSize_ - offset_;
   ymax_ = xmax_ / sqrt3_;
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HGCSim") << "Creating HGCGuardRing with wafer size " << waferSize_ << ", Offsets "

--- a/SimG4CMS/Calo/src/HGCGuardRingPartial.cc
+++ b/SimG4CMS/Calo/src/HGCGuardRingPartial.cc
@@ -13,7 +13,7 @@ HGCGuardRingPartial::HGCGuardRingPartial(const HGCalDDDConstants& hgc)
       modeUV_(hgcons_.geomMode()),
       v17OrLess_(hgcons_.v17OrLess()),
       waferSize_(hgcons_.waferSize(false)),
-      guardRingOffset_(hgcons_.getParameter()->guardRingOffset_) {
+      guardRingOffset_(hgcons_.guardRingOffset(false)) {
   offset_ = guardRingOffset_;
   c22_ = (v17OrLess_) ? HGCalTypes::c22O : HGCalTypes::c22;
   c27_ = (v17OrLess_) ? HGCalTypes::c27O : HGCalTypes::c27;


### PR DESCRIPTION
#### PR description:

Update the code for guard ring and mouse bite usage in full and partial wafers in HGCal geometry definition

#### PR validation:

Use the runTheMatrix test workflows

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special