### PR TITLE
Temporary Rollback for DIP BeamSpot client

### DIFF
--- a/DQM/Integration/python/clients/beamspotdip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamspotdip_dqm_sourceclient-live_cfg.py
@@ -48,9 +48,10 @@ process.GlobalTag.toGet = cms.VPSet(
 process.load("DQM.BeamMonitor.BeamSpotDipServer_cff")
 
 process.beamSpotDipServer.verbose = cms.untracked.bool(True)
-process.beamSpotDipServer.sourceFile  = cms.untracked.string(
-    "/nfshome0/dqmpro/BeamMonitorDQM/BeamFitResultsForDIP.txt"
-)
+# Temporary roll-back to using default input txt file
+#process.beamSpotDipServer.sourceFile  = cms.untracked.string(
+#    "/nfshome0/dqmpro/BeamMonitorDQM/BeamFitResultsForDIP.txt"
+#)
 
 # process customizations included here
 from DQM.Integration.config.online_customizations_cfi import *


### PR DESCRIPTION
#### PR description:
This PR is a "forwardport" of https://github.com/cms-sw/cmssw/pull/46736
Original description:

> As reported on Mattermost ([here](https://mattermost.web.cern.ch/cms-online-ops/pl/ezuk9mw9m3nhmjreni8kqnwekc)) there is an issue with the publication of the online BeamSpot to DIP (and consequently to OMS) since online DQM was switched to CMSSW_14_1_patch1.
> 
> In this PR I'm temporarily rolling-back the changes introduced in https://github.com/cms-sw/cmssw/pull/46614, i.e. we go back to reading the default input file `BeamFitResults.txt` instead of `BeamFitResultsForDIP.txt` which is in the wrong format, hence causing the DIP publication issue.
> 
> Since we have only ~1 week of data-taking left in 2024, the correct implementation will come for 2025 data-taking.

#### PR validation:
14_1_X backport to be tested in P5

#### Backport:
Not a backport. 14_1_X backport provided in #46736