### PR TITLE
Improvements for HCAL LUT XML Diffing

### DIFF
--- a/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
+++ b/CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h
@@ -6,6 +6,7 @@
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "CalibCalorimetry/HcalAlgos/interface/HcalPulseContainmentManager.h"
+#include "CondFormats/HcalObjects/interface/HcalElectronicsMap.h"
 
 #include <bitset>
 #include <vector>
@@ -34,10 +35,10 @@ public:
   static const float lsb_;
 
   HcaluLUTTPGCoder();
-  HcaluLUTTPGCoder(const HcalTopology* topo, const HcalTimeSlew* delay);
+  HcaluLUTTPGCoder(const HcalTopology* topo, const HcalElectronicsMap* emap, const HcalTimeSlew* delay);
   ~HcaluLUTTPGCoder() override;
 
-  void init(const HcalTopology* top, const HcalTimeSlew* delay);
+  void init(const HcalTopology* top, const HcalElectronicsMap* emap, const HcalTimeSlew* delay);
 
   void adc2Linear(const HBHEDataFrame& df, IntegerCaloSamples& ics) const override;
   void adc2Linear(const HFDataFrame& df, IntegerCaloSamples& ics) const override;
@@ -110,6 +111,7 @@ private:
 
   // member variables
   const HcalTopology* topo_;
+  const HcalElectronicsMap* emap_;
   const HcalTimeSlew* delay_;
   bool LUTGenerationMode_;
   std::vector<uint32_t> FG_HF_thresholds_;

--- a/CalibCalorimetry/HcalTPGAlgos/interface/LutXml.h
+++ b/CalibCalorimetry/HcalTPGAlgos/interface/LutXml.h
@@ -21,7 +21,8 @@
 #include <vector>
 #include <map>
 #include "CalibCalorimetry/HcalTPGAlgos/interface/XMLDOMBlock.h"
-#include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "CondFormats/HcalObjects/interface/HcalElectronicsMap.h"
 #include <cstdint>
 
 class LutXml : public XMLDOMBlock {
@@ -56,9 +57,9 @@ public:
   //
   //std::vector<unsigned int> getLut( int lut_type, int crate, int slot, int topbottom, int fiber, int fiber_channel );
 
-  HcalSubdetector subdet_from_crate(int crate, int slot, int fiber);
+  DetId detid_from_crate(int crate, int slot, int fiber, int fiberch, bool isTrigger, const HcalElectronicsMap* emap);
   int a_to_i(char* inbuf);
-  int create_lut_map(void);
+  int create_lut_map(const HcalElectronicsMap* emap);
 
   static std::string get_checksum(std::vector<unsigned int>& lut);
 

--- a/CalibCalorimetry/HcalTPGEventSetup/src/HcalTPGCoderULUT.cc
+++ b/CalibCalorimetry/HcalTPGEventSetup/src/HcalTPGCoderULUT.cc
@@ -32,6 +32,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 #include "CalibFormats/HcalObjects/interface/HcalDbService.h"
+#include "CondFormats/HcalObjects/interface/HcalElectronicsMap.h"
 
 //
 // class decleration
@@ -49,7 +50,7 @@ public:
 private:
   using HostType = edm::ESProductHost<HcaluLUTTPGCoder, HcalDbRecord>;
 
-  void buildCoder(const HcalTopology*, const HcalTimeSlew*, HcaluLUTTPGCoder*);
+  void buildCoder(const HcalTopology*, const HcalElectronicsMap*, const HcalTimeSlew*, HcaluLUTTPGCoder*);
 
   // ----------member data ---------------------------
   edm::ReusableObjectHolder<HostType> holder_;
@@ -96,6 +97,7 @@ HcalTPGCoderULUT::HcalTPGCoderULUT(const edm::ParameterSet& iConfig) {
   auto cc = setWhatProduced(this);
   topoToken_ = cc.consumes();
   delayToken_ = cc.consumes(edm::ESInputTag{"", "HBHE"});
+  serviceToken_ = cc.consumes();
 
   if (!(read_Ascii_ || read_XML_)) {
     LUTGenerationMode_ = iConfig.getParameter<bool>("LUTGenerationMode");
@@ -106,15 +108,17 @@ HcalTPGCoderULUT::HcalTPGCoderULUT(const edm::ParameterSet& iConfig) {
     linearLSB_QIE11Overlap_ = scales.getParameter<double>("LSBQIE11Overlap");
     maskBit_ = iConfig.getParameter<int>("MaskBit");
     FG_HF_thresholds_ = iConfig.getParameter<std::vector<uint32_t> >("FG_HF_thresholds");
-    serviceToken_ = cc.consumes();
   } else {
     ifilename_ = iConfig.getParameter<edm::FileInPath>("inputLUTs");
   }
 }
 
-void HcalTPGCoderULUT::buildCoder(const HcalTopology* topo, const HcalTimeSlew* delay, HcaluLUTTPGCoder* theCoder) {
+void HcalTPGCoderULUT::buildCoder(const HcalTopology* topo,
+                                  const HcalElectronicsMap* emap,
+                                  const HcalTimeSlew* delay,
+                                  HcaluLUTTPGCoder* theCoder) {
   using namespace edm::es;
-  theCoder->init(topo, delay);
+  theCoder->init(topo, emap, delay);
 
   theCoder->setOverrideDBweightsAndFilterHB(overrideDBweightsAndFilterHB_);
   theCoder->setOverrideDBweightsAndFilterHE(overrideDBweightsAndFilterHE_);
@@ -161,12 +165,14 @@ HcalTPGCoderULUT::ReturnType HcalTPGCoderULUT::produce(const HcalTPGRecord& iRec
 
   const auto& topo = iRecord.get(topoToken_);
   const auto& delayRcd = iRecord.getRecord<HcalDbRecord>();
+  const auto& dbServ = iRecord.get(serviceToken_);
+  const auto* emap = dbServ.getHcalMapping();
   const auto& delay = delayRcd.get(delayToken_);
   if (read_Ascii_ || read_XML_) {
-    buildCoder(&topo, &delay, host.get());
+    buildCoder(&topo, emap, &delay, host.get());
   } else {
-    host->ifRecordChanges<HcalDbRecord>(iRecord, [this, &topo, &delay, h = host.get()](auto const& rec) {
-      buildCoder(&topo, &delay, h);
+    host->ifRecordChanges<HcalDbRecord>(iRecord, [this, &topo, emap, &delay, h = host.get()](auto const& rec) {
+      buildCoder(&topo, emap, &delay, h);
       h->update(rec.get(serviceToken_));
       // Temporary update for FG Lut
       // Will be moved to DB

--- a/CaloOnlineTools/HcalOnlineDb/bin/hcalLUT.cc
+++ b/CaloOnlineTools/HcalOnlineDb/bin/hcalLUT.cc
@@ -19,111 +19,6 @@ void mergeLUTs(const char *flist, const char *out) {
   xmls.write(out);
 }
 
-void dumpLutDiff(LutXml &xmls1, LutXml &xmls2, bool testFormat = true, int detail = 0) {
-  const int ndet = 5;
-  const char *DET[ndet] = {"HB", "HE", "HO", "HF", "HT"};
-  const int dtype[ndet] = {0, 1, 2, 3, 4};
-  const int HBandHE_fgBits = 0xFC00;
-
-  const int nvar = 5;
-  enum vtype { total, extra, zeros, match, fgMatch };
-
-  std::array<int, nvar> n[ndet];
-
-  for (auto &d : n) {
-    for (auto &v : d) {
-      v = 0;
-    }
-  }
-
-  for (auto &x1 : xmls1) {
-    HcalGenericDetId id(x1.first);
-    auto x2 = xmls2.find(id.rawId());
-    auto subdet = id.genericSubdet();
-    if (subdet == 0 or subdet == 6)
-      continue;  //'empty' or 'other'
-
-    auto &m = n[subdet - 1];
-
-    m[total]++;
-    if (x2 == xmls2.end()) {
-      m[extra]++;
-      if (testFormat)
-        cout << "Extra detId: " << id << endl;
-      else
-        continue;
-    }
-
-    const auto &lut1 = x1.second;
-    size_t size = lut1.size();
-
-    bool zero = true;
-    for (auto &i : lut1) {
-      if (i > 0) {
-        zero = false;
-        break;
-      }
-    }
-    if (zero) {
-      m[zeros]++;
-      if (detail == 1 and testFormat) {
-        cout << "Zero LUT: " << id << endl;
-      }
-    }
-
-    if (testFormat)
-      continue;
-
-    const auto &lut2 = x2->second;
-    bool good = size == lut2.size();
-    bool fgGood = size == lut2.size();
-    for (size_t i = 0; i < size and (good or fgGood); ++i) {
-      if (lut1[i] != lut2[i]) {
-        good = false;
-        //Only check fine grain bits in HB and HE
-        if (subdet == 1 || subdet == 2) {
-          if ((lut1[i] & HBandHE_fgBits) != (lut2[i] & HBandHE_fgBits))
-            fgGood = false;
-        }
-        if (detail == 2) {
-          cout << Form("Mismatach in index=%3d, %4d!=%4d, ", int(i), lut1[i], lut2[i]) << id << endl;
-        }
-      }
-    }
-    if (good)
-      m[match]++;
-    if (fgGood)
-      m[fgMatch]++;
-  }
-
-  if (testFormat) {
-    cout << Form("%3s:  %8s  %8s  %8s", "Det", "total", "zeroes", "extra") << endl;
-    for (auto i : dtype)
-      cout << Form("%3s:  %8d  %8d  %8d", DET[i], n[i][total], n[i][zeros], n[i][extra]) << endl;
-    cout << "--------------------------------------------" << endl;
-  } else {
-    bool good = true;
-    for (auto &d : n) {
-      if (d[total] != d[match]) {
-        good = false;
-      }
-    }
-    cout << Form("%3s:  %8s  %8s  %8s  %8s  %8s", "Det", "total", "match", "mismatch", "FG match", "FG mismatch")
-         << endl;
-    for (auto i : dtype)
-      cout << Form("%3s:  %8d  %8d  %8d  %8d  %8d",
-                   DET[i],
-                   n[i][total],
-                   n[i][match],
-                   n[i][total] - n[i][match],
-                   n[i][fgMatch],
-                   n[i][total] - n[i][fgMatch])
-           << endl;
-    cout << "--------------------------------------------" << endl;
-    cout << (good ? "PASS!" : "FAIL!") << endl;
-  }
-}
-
 int main(int argc, char **argv) {
   optutl::CommandLineParser parser("runTestParameters");
   parser.parseArguments(argc, argv, true);
@@ -133,24 +28,6 @@ int main(int argc, char **argv) {
     std::string flist_ = parser.stringValue("storePrepend");
     std::string out_ = parser.stringValue("outputFile");
     mergeLUTs(flist_.c_str(), out_.c_str());
-  } else if (strcmp(argv[1], "diff") == 0) {
-    auto files = parser.stringVector("inputFiles");
-    auto detail = parser.integerValue("section");
-
-    LutXml xmls1(edm::FileInPath(files[0]).fullPath());
-    LutXml xmls2(edm::FileInPath(files[1]).fullPath());
-
-    xmls1.create_lut_map();
-    xmls2.create_lut_map();
-
-    cout << files[0] << endl;
-    dumpLutDiff(xmls1, xmls2, true, detail);
-
-    cout << files[1] << endl;
-    dumpLutDiff(xmls2, xmls1, true, detail);
-
-    cout << "Comparison" << endl;
-    dumpLutDiff(xmls1, xmls2, false, detail);
   } else if (strcmp(argv[1], "create-lut-loader") == 0) {
     std::string _file_list = parser.stringValue("outputFile");
     std::string _tag = parser.stringValue("tag");

--- a/CaloOnlineTools/HcalOnlineDb/plugins/HcalLutAnalyzer.cc
+++ b/CaloOnlineTools/HcalOnlineDb/plugins/HcalLutAnalyzer.cc
@@ -36,6 +36,7 @@
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
 
 #include "TString.h"
 #include "TH1D.h"
@@ -72,6 +73,7 @@ private:
   double Pmax;
 
   edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> tok_htopo_;
+  edm::ESGetToken<HcalElectronicsMap, HcalDbRecord> tok_emap_;
 };
 
 HcalLutAnalyzer::HcalLutAnalyzer(const edm::ParameterSet& iConfig) {
@@ -92,12 +94,14 @@ HcalLutAnalyzer::HcalLutAnalyzer(const edm::ParameterSet& iConfig) {
   Pmax = iConfig.getParameter<double>("Pmax");
 
   tok_htopo_ = esConsumes<HcalTopology, HcalRecNumberingRecord>();
+  tok_emap_ = esConsumes<HcalElectronicsMap, HcalDbRecord>();
 }
 
 void HcalLutAnalyzer::analyze(const edm::Event&, const edm::EventSetup& iSetup) {
   using namespace std;
 
   const HcalTopology* topology = &iSetup.getData(tok_htopo_);
+  const HcalElectronicsMap* electronicsMap = &iSetup.getData(tok_emap_);
 
   typedef std::vector<std::string> vstring;
   typedef std::map<unsigned long int, float> LUTINPUT;
@@ -350,8 +354,8 @@ void HcalLutAnalyzer::analyze(const edm::Event&, const edm::EventSetup& iSetup) 
   LutXml xmls1(edm::FileInPath(Form("%s/%s/%s.xml", inputDir.c_str(), tags_[0].c_str(), tags_[0].c_str())).fullPath());
   LutXml xmls2(edm::FileInPath(Form("%s/%s/%s.xml", inputDir.c_str(), tags_[1].c_str(), tags_[1].c_str())).fullPath());
 
-  xmls1.create_lut_map();
-  xmls2.create_lut_map();
+  xmls1.create_lut_map(electronicsMap);
+  xmls2.create_lut_map(electronicsMap);
 
   for (const auto& xml2 : xmls2) {
     HcalGenericDetId detid(xml2.first);

--- a/CaloOnlineTools/HcalOnlineDb/plugins/HcalLutComparer.cc
+++ b/CaloOnlineTools/HcalOnlineDb/plugins/HcalLutComparer.cc
@@ -1,0 +1,265 @@
+// -*- C++ -*-
+//
+// Package:    Test/HcalLutComparer
+// Class:      HcalLutComparer
+//
+/**\class HcalLutComparer HcalLutComparer.cc Test/HcalLutComparer/plugins/HcalLutComparer.cc
+
+ Description: [one line class summary]
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Joshua C. Hiltbrand
+//         Created:  Tue, 12 Nov 2024 05:57:40 GMT
+//
+//
+
+// system include files
+#include <memory>
+#include <iostream>
+#include <fstream>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+#include "CalibCalorimetry/HcalTPGAlgos/interface/XMLProcessor.h"
+#include "CalibCalorimetry/HcalTPGAlgos/interface/LutXml.h"
+#include "DataFormats/HcalDetId/interface/HcalGenericDetId.h"
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "DataFormats/HcalDetId/interface/HcalZDCDetId.h"
+#include "Geometry/CaloTopology/interface/HcalTopology.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "Geometry/Records/interface/HcalRecNumberingRecord.h"
+#include "CondFormats/DataRecord/interface/HcalElectronicsMapRcd.h"
+
+class HcalLutComparer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
+public:
+  explicit HcalLutComparer(const edm::ParameterSet &);
+  ~HcalLutComparer() override {}
+  void dumpLutDiff(LutXml &xmls1, LutXml &xmls2, bool testFormat);
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+
+private:
+  void analyze(const edm::Event &, const edm::EventSetup &) override;
+
+  edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> tok_htopo_;
+  edm::ESGetToken<HcalElectronicsMap, HcalElectronicsMapRcd> tok_emap_;
+
+  std::string lutXML1_;
+  std::string lutXML2_;
+  unsigned int verbosity_;
+};
+
+HcalLutComparer::HcalLutComparer(const edm::ParameterSet &iConfig) {
+  lutXML1_ = iConfig.getParameter<std::string>("lutXML1");
+  lutXML2_ = iConfig.getParameter<std::string>("lutXML2");
+  verbosity_ = iConfig.getParameter<unsigned int>("verbosity");
+
+  tok_htopo_ = esConsumes<HcalTopology, HcalRecNumberingRecord>();
+  tok_emap_ = esConsumes<HcalElectronicsMap, HcalElectronicsMapRcd>();
+}
+
+void HcalLutComparer::dumpLutDiff(LutXml &xmls1, LutXml &xmls2, bool testFormat = true) {
+  std::vector<int> detCodes = {1, -1, 2, -2, 3, -3, 4, -4, 5, -5, 9, -9, 10, -10, 11, -11, 12, -12};
+  std::vector<std::string> detNames = {"HBP",
+                                       "HBM",
+                                       "HEP",
+                                       "HEM",
+                                       "HOP",
+                                       "HOM",
+                                       "HFP",
+                                       "HFM",
+                                       "HTP",
+                                       "HTM",
+                                       "ZDCP_EM",
+                                       "ZDCM_EM",
+                                       "ZDCP_HAD",
+                                       "ZDCM_HAD",
+                                       "ZDCP_LUM",
+                                       "ZDCM_LUM",
+                                       "ZDCP_RPD",
+                                       "ZDCM_RPD"};
+
+  const int HBandHE_fgBits = 0xF000;
+  const int HF_fgBits = 0x3000;
+
+  unsigned int nvars = 5;
+  enum vtype { total, extra, zeros, match, fgMatch };
+
+  std::map<int, std::vector<int>> n;
+
+  for (const auto &detCode : detCodes) {
+    n[detCode] = std::vector<int>{};
+    for (unsigned int j = 0; j < nvars; j++) {
+      n[detCode].push_back(0);
+    }
+  }
+
+  for (auto &x1 : xmls1) {
+    auto x2 = xmls2.find(x1.first);
+
+    HcalGenericDetId id = HcalGenericDetId(x1.first);
+    int subdet = id.genericSubdet();
+    if (subdet == 0 or subdet == 6)
+      continue;  //'empty' or 'other'
+
+    int side = 1;
+    int section = 0;
+    if (id.isHcalDetId()) {
+      HcalDetId hdetId = HcalDetId(x1.first);
+      side = hdetId.zside();
+    } else if (id.isHcalTrigTowerDetId()) {
+      HcalTrigTowerDetId htdetId = HcalTrigTowerDetId(x1.first);
+      side = htdetId.zside();
+    } else if (id.isHcalZDCDetId()) {
+      HcalZDCDetId zdetId = HcalZDCDetId(x1.first);
+      side = zdetId.zside();
+      section = zdetId.section();
+    }
+
+    int detCode = side * (subdet + section);
+
+    auto &m = n[detCode];
+
+    m[total]++;
+    if (x2 == xmls2.end()) {
+      m[extra]++;
+      if (testFormat)
+        std::cout << "Extra detId: " << id << std::endl;
+      else
+        continue;
+    }
+
+    const auto &lut1 = x1.second;
+    size_t size = lut1.size();
+
+    bool zero = true;
+    for (auto &i : lut1) {
+      if (i > 0) {
+        zero = false;
+        break;
+      }
+    }
+    if (zero) {
+      m[zeros]++;
+      if (verbosity_ == 1 and testFormat) {
+        std::cout << "Zero LUT: " << id << std::endl;
+      }
+    }
+
+    if (testFormat)
+      continue;
+
+    const auto &lut2 = x2->second;
+    bool good = size == lut2.size();
+    bool fgGood = size == lut2.size();
+    for (size_t i = 0; i < size and (good or fgGood); ++i) {
+      if (lut1[i] != lut2[i]) {
+        good = false;
+        if (subdet == 1 || subdet == 2) {
+          if ((lut1[i] & HBandHE_fgBits) != (lut2[i] & HBandHE_fgBits))
+            fgGood = false;
+        } else if (subdet == 4) {
+          if ((lut1[i] & HF_fgBits) != (lut2[i] & HF_fgBits))
+            fgGood = false;
+        }
+
+        if (verbosity_ == 2) {
+          std::cout << Form("Mismatach in index=%3d, %4d!=%4d, ", int(i), lut1[i], lut2[i]) << id << std::endl;
+        }
+      }
+    }
+    if (good)
+      m[match]++;
+    if (fgGood)
+      m[fgMatch]++;
+  }
+
+  if (testFormat) {
+    std::cout << Form("%9s  %6s  %6s  %6s", "Det", "total", "zeroes", "extra") << std::endl;
+    for (unsigned int i = 0; i < detCodes.size(); i++) {
+      int detCode = detCodes.at(i);
+      std::string detName = detNames.at(i);
+      std::cout << Form("%9s  %6d  %6d  %6d", detName.c_str(), n[detCode][total], n[detCode][zeros], n[detCode][extra])
+                << std::endl;
+      if (detCode < 0) {
+        std::cout << Form("%9s  %6d  %6d  %6d",
+                          " ",
+                          n[detCode][total] + n[-1 * detCode][total],
+                          n[detCode][zeros] + n[-1 * detCode][zeros],
+                          n[detCode][extra] + n[-1 * detCode][extra])
+                  << std::endl;
+        std::cout << std::endl;
+      }
+    }
+    std::cout << "--------------------------------------------" << std::endl;
+  } else {
+    bool good = true;
+    for (const auto &it : n) {
+      if (it.second[total] != it.second[match]) {
+        good = false;
+      }
+    }
+    std::cout << Form("%9s  %6s  %6s  %8s  %8s  %11s", "Det", "total", "match", "mismatch", "FG match", "FG mismatch")
+              << std::endl;
+    for (unsigned int i = 0; i < detCodes.size(); i++) {
+      int detCode = detCodes.at(i);
+      std::string detName = detNames.at(i);
+      std::cout << Form("%9s  %6d  %6d  %8d  %8d  %11d",
+                        detName.c_str(),
+                        n[detCode][total],
+                        n[detCode][match],
+                        n[detCode][total] - n[detCode][match],
+                        n[detCode][fgMatch],
+                        n[detCode][total] - n[detCode][fgMatch])
+                << std::endl;
+      if (detCode < 0) {
+        std::cout << Form("%9s  %6d  %6d  %8d  %8d  %11d",
+                          " ",
+                          n[detCode][total] + n[-1 * detCode][total],
+                          n[detCode][match] + n[-1 * detCode][match],
+                          n[detCode][total] - n[detCode][match] + n[-1 * detCode][total] - n[-1 * detCode][match],
+                          n[detCode][fgMatch] + n[-1 * detCode][fgMatch],
+                          n[detCode][total] - n[detCode][fgMatch] + n[-1 * detCode][total] - n[-1 * detCode][fgMatch])
+                  << std::endl;
+        std::cout << std::endl;
+      }
+    }
+    std::cout << "--------------------------------------------" << std::endl;
+    std::cout << (good ? "PASS!" : "FAIL!") << std::endl;
+  }
+}
+
+void HcalLutComparer::analyze(const edm::Event &, const edm::EventSetup &iSetup) {
+  const HcalElectronicsMap *electronicsMap = &iSetup.getData(tok_emap_);
+
+  LutXml xmls1(edm::FileInPath(lutXML1_).fullPath());
+  LutXml xmls2(edm::FileInPath(lutXML2_).fullPath());
+
+  xmls1.create_lut_map(electronicsMap);
+  xmls2.create_lut_map(electronicsMap);
+
+  std::cout << lutXML1_ << std::endl;
+  dumpLutDiff(xmls1, xmls2, true);
+
+  std::cout << lutXML2_ << std::endl;
+  dumpLutDiff(xmls2, xmls1, true);
+
+  std::cout << "Comparison" << std::endl;
+  dumpLutDiff(xmls1, xmls2, false);
+}
+
+void HcalLutComparer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+DEFINE_FWK_MODULE(HcalLutComparer);

--- a/CaloOnlineTools/HcalOnlineDb/test/DiffLUT.py
+++ b/CaloOnlineTools/HcalOnlineDb/test/DiffLUT.py
@@ -1,0 +1,28 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+options = VarParsing.VarParsing('analysis')
+options.register('globaltag',	'', VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.string, '') 
+options.register('run',	'', VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.int, '') 
+options.register('lutXML1',	'', VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.string, '') 
+options.register('lutXML2',	'', VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.string, '') 
+options.register('verbosity',	'', VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.int, '') 
+
+options.parseArguments()
+
+process = cms.Process("LutDiff")
+
+process.load("Configuration.Geometry.GeometryDB_cff")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+process.GlobalTag.globaltag = options.globaltag 
+
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1))
+process.source = cms.Source("EmptySource")
+process.source.firstRun = cms.untracked.uint32(options.run)
+
+process.diff  = cms.EDAnalyzer("HcalLutComparer",
+    lutXML1  = cms.string(options.lutXML1),
+    lutXML2  = cms.string(options.lutXML2),
+    verbosity = cms.uint32(options.verbosity),
+)
+process.p = cms.Path(process.diff)

--- a/CaloOnlineTools/HcalOnlineDb/test/cardPhysicsSkeleton.sh
+++ b/CaloOnlineTools/HcalOnlineDb/test/cardPhysicsSkeleton.sh
@@ -1,6 +1,7 @@
 Tag="<LUTTAG>"
 Run=1
 GlobalTag="<Globaltag>"
+Era="<Era>"
 description="<Description of updates>"
 HOAsciiInput=HO_ped9_inputLUTcoderDec.txt
 

--- a/CaloOnlineTools/HcalOnlineDb/test/genLUT.sh
+++ b/CaloOnlineTools/HcalOnlineDb/test/genLUT.sh
@@ -6,7 +6,7 @@ cat << EOF
 examples:
     ./genLUT.sh dumpAll card=cardPhysics.sh
     ./genLUT.sh generate card=cardPhysics.sh
-    ./genLUT.sh diff conditions/newtag/newtag.xml conditions/oldtag/oldtag.xml
+    ./genLUT.sh diff card=cardPhysics.sh conditions/newtag/newtag.xml conditions/oldtag/oldtag.xml
     ./genLUT.sh validate card=cardPhysics.sh
 
 EOF
@@ -141,6 +141,7 @@ then
     -e "s#__CONDDIR__#$BaseDir/$CondDir#g" \
     -e "s#__GlobalTag__#$GlobalTag#g" \
     -e "s#__HO_master_file__#$HOAsciiInput#g" \
+    -e "s#__ERA__#$Era#g" \
     $templatefile > $Tag.py
 
     echo "genLUT.sh::generate: Running..."
@@ -274,19 +275,21 @@ then
 	exit 1
     fi
 
-    CheckFile $2
+    source $card
+
+    lutFile1="$BaseDir/$3"
+    lutFile2="$BaseDir/$4"
     CheckFile $3
-    echo $BaseDir/$2,$BaseDir/$3
+    CheckFile $4
+    echo $lutFile1,$lutFile2
 
     if [[ -z $verbosity ]]
     then
 	verbosity=0
     fi
 
-    hcalLUT diff inputFiles=$BaseDir/$2,$BaseDir/$3 section=$verbosity
+    cmsRun DiffLUT.py globaltag=$GlobalTag run=$Run lutXML1=$lutFile1 lutXML2=$lutFile2 verbosity=$verbosity 
 
 else
     dumpHelpAndExit
 fi
-
-

--- a/CaloOnlineTools/HcalOnlineDb/test/template.py
+++ b/CaloOnlineTools/HcalOnlineDb/test/template.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Eras.Era_Run3_cff import Run3
-process = cms.Process("TEST", Run3)
+from Configuration.Eras.Era___ERA___cff import __ERA__
+process = cms.Process("TEST", __ERA__)
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.MessageLogger.LUT=dict()


### PR DESCRIPTION
#### PR description:

This PR concerns some improvements to HCAL LUT XML comparing. Note that HCAL LUT XML generation/diffing code is run manually offline and not a part of standard workflows.
The only regularly-used "mainline" code that is modified for this PR is `HcaluLUTTPGCoder` and `HcalTPGCoderULUT`. This is due to a single function call, which _now_ requires an `HcalElectronicsEmap` pointer, as the function is depended upon in the LUT XML gen/diff code. The including of `HcalElectronicsMap` pointer in these two classes is accommodated in the same way that they are passed a topology and time slew pointer at construction time.

Notable changes introduced in this PR:
- Explicitly show ZDC in LUT XML diffing
- Split results by zside in addition to showing total for each HCAL subdetector i.e. HBP, HBM, HB, etc.
- Fix check of fine-grain (FG) bits in HBHE and introduce check for HF FG
- Make use of `HcalElectronicsEmap` via DB conditions in order scary `subdet_from_crate` hard-coding
- Move diff module from standalone executable and make it an EDAnalyzer to have native access to `HcalElectronicsMap`

#### PR validation:

A XML LUT was generated with and without the PR and with intentional input conditions differences. With the PR, the LUT diff finds the same number of HCAL channels for the various subdetectors and show ZDC channels, along with expected differences based on input conditions differences.

ATTN: @hjbossi @abdoulline @akhukhun 