### PR TITLE
 Use `TriggerResultsFilterFromDB` instead of `HLTHighLevel`,  in order to allow prescaled HLT paths in `EcalESAlign` and `HcalCalIterativePhiSym` 

### DIFF
--- a/Calibration/EcalAlCaRecoProducers/python/ALCARECOEcalESAlign_cff.py
+++ b/Calibration/EcalAlCaRecoProducers/python/ALCARECOEcalESAlign_cff.py
@@ -1,9 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 
-import HLTrigger.HLTfilters.hltHighLevel_cfi
-ALCARECOEcalESAlignHLT = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone(
-    andOr = True, # choose logical OR between Triggerbits
+import HLTrigger.HLTfilters.triggerResultsFilterFromDB_cfi
+ALCARECOEcalESAlignHLT = HLTrigger.HLTfilters.triggerResultsFilterFromDB_cfi.triggerResultsFilterFromDB.clone(
     eventSetupPathsKey = 'EcalESAlign',
+    usePathStatus = False,
+    hltResults = 'TriggerResults::HLT',
+    l1tResults = '', # leaving empty (not interested in L1T results)
     throw = False # tolerate triggers stated above, but not available
 )
 

--- a/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalIterativePhiSym_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalIterativePhiSym_cff.py
@@ -6,12 +6,13 @@ import FWCore.ParameterSet.Config as cms
 
 from Calibration.HcalAlCaRecoProducers.alcaiterphisym_cfi import *
 
-
-import HLTrigger.HLTfilters.hltHighLevel_cfi
-hcalphisymHLT =  HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone(
-#    HLTPaths = ['HLT_HcalPhiSym'],
+import HLTrigger.HLTfilters.triggerResultsFilterFromDB_cfi
+hcalphisymHLT = HLTrigger.HLTfilters.triggerResultsFilterFromDB_cfi.triggerResultsFilterFromDB.clone(
     eventSetupPathsKey='HcalCalIterativePhiSym',
-    throw = False #dont throw except on unknown path name 
+    usePathStatus = False,
+    hltResults = 'TriggerResults::HLT',
+    l1tResults = '', # leaving empty (not interested in L1T results)
+    throw = False #dont throw except on unknown path name
 )
 
 seqALCARECOHcalCalIterativePhiSym = cms.Sequence(hcalphisymHLT*IterativePhiSymProd)


### PR DESCRIPTION
#### PR description:

`EcalESAlign` and `HcalCalIterativePhiSym` have been reported by Tier-0 experts to be resource intensive in terms of output data volume when run over the Raw Prime PDs during 2024 data-taking. This lead to PR https://github.com/dmwm/T0/pull/5025 where these producers are removed from the from Raw Prime PDs to reduce output volume.
To avoid having to manually change again Tier0 configuration in the future, I propose this PR to allow prescales in `AlCaRecoTriggerBits` for the two mentioned producers.
 This follows the same pattern used for https://github.com/cms-sw/cmssw/pull/42965. 
 
#### PR validation:

`runTheMatrix.py -l 1000.0 -t 4 -j 8` runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, not to be backported.