### PR TITLE
Updated Input tags and code additions for TOP Production DQM GEN-SIM-RECO

### DIFF
--- a/DQM/Physics/interface/TopDQMHelpers.h
+++ b/DQM/Physics/interface/TopDQMHelpers.h
@@ -378,17 +378,13 @@ bool SelectionStep<Object>::select(const edm::Event& event, const std::string& t
     if (dynamic_cast<const reco::PFCandidate*>(&*obj)) {
       reco::PFCandidate objtmp = dynamic_cast<const reco::PFCandidate&>(*obj);
 
-      if (objtmp.muonRef().isNonnull() && type == "muon") {
+      if (type == "muon") {
         if (select_(*obj)) {
           ++n;
         }
-      } else if (objtmp.gsfElectronRef().isNonnull() && type == "electron") {
+      } else if (type == "electron") {
         if (select_(*obj)) {
-          if (electronId_.isUninitialized()) {
-            ++n;
-          } else if (((double)(*electronId)[obj->gsfElectronRef()] >= eidCutValue_)) {
-            ++n;
-          }
+          ++n;
         }
         //        idx_gsf++;
       }

--- a/DQM/Physics/python/singleTopDQM_cfi.py
+++ b/DQM/Physics/python/singleTopDQM_cfi.py
@@ -9,21 +9,21 @@ looseJetCut = "(chargedHadronEnergyFraction()>0 && chargedMultiplicity()>0 && ch
 tightJetCut = "(chargedHadronEnergyFraction()>0 && chargedMultiplicity()>0 && chargedEmEnergyFraction()<0.99 && neutralHadronEnergyFraction()<0.90 && neutralEmEnergyFraction()<0.90 && (chargedMultiplicity()+neutralMultiplicity())>1) && abs(eta)<=2.4 "
 
 #Loose muon selection
-looseMuonCut  = "(muonRef.isNonnull && (muonRef.isGlobalMuon || muonRef.isTrackerMuon) && muonRef.isPFMuon)"
-looseIsoCut   = "(muonRef.pfIsolationR04.sumChargedHadronPt + max(0., muonRef.pfIsolationR04.sumNeutralHadronEt + muonRef.pfIsolationR04.sumPhotonEt - 0.5 * muonRef.pfIsolationR04.sumPUPt) ) / muonRef.pt < 0.25"
+looseMuonCut  = "((isGlobalMuon || isTrackerMuon) && isPFMuon)"
+looseIsoCut   = "((pfIsolationR04.sumChargedHadronPt + max(0., pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - 0.5 * pfIsolationR04.sumPUPt) ) / pt < 0.25)"
 
 #Medium muon selection. Also requires either good global muon or tight segment compatibility
-mediumMuonCut = looseMuonCut + " muonRef.innerTrack.validFraction > 0.8"
+mediumMuonCut = looseMuonCut + " innerTrack.validFraction > 0.8"
 
 #Tight muon selection. Lacks distance to primary vertex variables, dz<0.5, dxy < 0.2. Now done at .cc
-tightMuonCut  = "muonRef.isNonnull && muonRef.isGlobalMuon && muonRef.isPFMuon && muonRef.globalTrack.normalizedChi2 < 10. && muonRef.globalTrack.hitPattern.numberOfValidMuonHits > 0 && " + \
-               "muonRef.numberOfMatchedStations > 1 && muonRef.innerTrack.hitPattern.numberOfValidPixelHits > 0 && muonRef.innerTrack.hitPattern.trackerLayersWithMeasurement > 5 "
-tightIsoCut   = "(muonRef.pfIsolationR04.sumChargedHadronPt + max(0., muonRef.pfIsolationR04.sumNeutralHadronEt + muonRef.pfIsolationR04.sumPhotonEt - 0.5 * muonRef.pfIsolationR04.sumPUPt) ) / muonRef.pt < 0.15"
+tightMuonCut  = "isGlobalMuon && isPFMuon && globalTrack.normalizedChi2 < 10. && globalTrack.hitPattern.numberOfValidMuonHits > 0 && " + \
+               "numberOfMatchedStations > 1 && innerTrack.hitPattern.numberOfValidPixelHits > 0 && innerTrack.hitPattern.trackerLayersWithMeasurement > 5 "
+tightIsoCut   = "(pfIsolationR04.sumChargedHadronPt + max(0., pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - 0.5 * pfIsolationR04.sumPUPt) ) / pt < 0.15"
 
 #Electron selections
-looseEleCut = "(( gsfElectronRef.full5x5_sigmaIetaIeta() < 0.011 && gsfElectronRef.superCluster().isNonnull() && gsfElectronRef.superCluster().seed().isNonnull() && (gsfElectronRef.deltaEtaSuperClusterTrackAtVtx() - gsfElectronRef.superCluster().eta() + gsfElectronRef.superCluster().seed().eta()) < 0.00477 && abs(gsfElectronRef.deltaPhiSuperClusterTrackAtVtx()) < 0.222 && gsfElectronRef.hadronicOverEm() < 0.298 && abs(1.0 - gsfElectronRef.eSuperClusterOverP())*1.0/gsfElectronRef.ecalEnergy() < 0.241 && gsfElectronRef.gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 1 && abs(gsfElectronRef.superCluster().eta()) < 1.479) || (gsfElectronRef.full5x5_sigmaIetaIeta() < 0.0314 && gsfElectronRef.superCluster().isNonnull() && gsfElectronRef.superCluster().seed().isNonnull() && (gsfElectronRef.deltaEtaSuperClusterTrackAtVtx() - gsfElectronRef.superCluster().eta() + gsfElectronRef.superCluster().seed().eta()) < 0.00868 && abs(gsfElectronRef.deltaPhiSuperClusterTrackAtVtx()) < 0.213 && gsfElectronRef.hadronicOverEm() < 0.101  && abs(1.0 - gsfElectronRef.eSuperClusterOverP())*1.0/gsfElectronRef.ecalEnergy() < 0.14 && gsfElectronRef.gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 1 && abs(gsfElectronRef.superCluster().eta()) > 1.479))"
+looseEleCut = "((full5x5_sigmaIetaIeta() < 0.011 && superCluster().isNonnull() && superCluster().seed().isNonnull() && (deltaEtaSuperClusterTrackAtVtx() - superCluster().eta() + superCluster().seed().eta()) < 0.00477 && abs(deltaPhiSuperClusterTrackAtVtx()) < 0.222 && hadronicOverEm() < 0.298 && abs(1.0 - eSuperClusterOverP())*1.0/ecalEnergy() < 0.241 && gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 1 && abs(superCluster().eta()) < 1.479) || (full5x5_sigmaIetaIeta() < 0.0314 && superCluster().isNonnull() && superCluster().seed().isNonnull() && (deltaEtaSuperClusterTrackAtVtx() - superCluster().eta() + superCluster().seed().eta()) < 0.00868 && abs(deltaPhiSuperClusterTrackAtVtx()) < 0.213 && hadronicOverEm() < 0.101  && abs(1.0 - eSuperClusterOverP())*1.0/ecalEnergy() < 0.14 && gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 1 && abs(superCluster().eta()) > 1.479))"
 
-tightEleCut = "((gsfElectronRef.full5x5_sigmaIetaIeta() < 0.00998 && gsfElectronRef.superCluster().isNonnull() && gsfElectronRef.superCluster().seed().isNonnull() && (gsfElectronRef.deltaEtaSuperClusterTrackAtVtx() - gsfElectronRef.superCluster().eta() + gsfElectronRef.superCluster().seed().eta()) < 0.00308  && abs(gsfElectronRef.deltaPhiSuperClusterTrackAtVtx()) < 0.0816 && gsfElectronRef.hadronicOverEm() < 0.0414 && abs(1.0 - gsfElectronRef.eSuperClusterOverP())*1.0/gsfElectronRef.ecalEnergy() < 0.0129 && gsfElectronRef.gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 1 && abs(gsfElectronRef.superCluster().eta()) < 1.479) ||  (gsfElectronRef.full5x5_sigmaIetaIeta() < 0.0292 && gsfElectronRef.superCluster().isNonnull() && gsfElectronRef.superCluster().seed().isNonnull() && (gsfElectronRef.deltaEtaSuperClusterTrackAtVtx() - gsfElectronRef.superCluster().eta() + gsfElectronRef.superCluster().seed().eta()) < 0.00605 && abs(gsfElectronRef.deltaPhiSuperClusterTrackAtVtx()) < 0.0394  && gsfElectronRef.hadronicOverEm() < 0.0641  && abs(1.0 - gsfElectronRef.eSuperClusterOverP())*1.0/gsfElectronRef.ecalEnergy() <	0.0129 && gsfElectronRef.gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 1 && abs(gsfElectronRef.superCluster().eta()) > 1.479))"
+tightEleCut = "((full5x5_sigmaIetaIeta() < 0.00998 && superCluster().isNonnull() && superCluster().seed().isNonnull() && (deltaEtaSuperClusterTrackAtVtx() - superCluster().eta() + superCluster().seed().eta()) < 0.00308  && abs(deltaPhiSuperClusterTrackAtVtx()) < 0.0816 && hadronicOverEm() < 0.0414 && abs(1.0 - eSuperClusterOverP())*1.0/ecalEnergy() < 0.0129 && gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 1 && abs(superCluster().eta()) < 1.479) ||  (full5x5_sigmaIetaIeta() < 0.0292 && superCluster().isNonnull() && superCluster().seed().isNonnull() && (deltaEtaSuperClusterTrackAtVtx() - superCluster().eta() + superCluster().seed().eta()) < 0.00605 && abs(deltaPhiSuperClusterTrackAtVtx()) < 0.0394  && hadronicOverEm() < 0.0641  && abs(1.0 - eSuperClusterOverP())*1.0/ecalEnergy() <	0.0129 && gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 1 && abs(superCluster().eta()) > 1.479))"
 
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 
@@ -37,8 +37,8 @@ singleTopMuonMediumDQM = DQMEDAnalyzer('SingleTopTChannelLeptonDQM',
     setup = cms.PSet(
     directory = cms.string("Physics/Top/SingleTopMuonMediumDQM/"),
     sources = cms.PSet(
-    muons = cms.InputTag("pfIsolatedMuonsEI"),
-    elecs = cms.InputTag("pfIsolatedElectronsEI"),
+    muons = cms.InputTag("muons"),
+    elecs = cms.InputTag("gedGsfElectrons"),
     jets  = cms.InputTag("ak4PFJetsCHS"),
     mets  = cms.VInputTag("pfMet"),
     pvs   = cms.InputTag("offlinePrimaryVertices")
@@ -50,7 +50,7 @@ singleTopMuonMediumDQM = DQMEDAnalyzer('SingleTopTChannelLeptonDQM',
       select = cms.string(PVCut)
     ),
     elecExtras = cms.PSet(
-      select     = cms.string(tightEleCut + "& pt>20 & abs(eta)<2.5 & (abs(gsfElectronRef.superCluster().eta()) <= 1.4442 || abs(gsfElectronRef.superCluster().eta()) >= 1.5660)"),
+      select     = cms.string(tightEleCut + "& pt>20 & abs(eta)<2.5 & (abs(superCluster().eta()) <= 1.4442 || abs(superCluster().eta()) >= 1.5660)"),
       rho = cms.InputTag("fixedGridRhoFastjetAll"),
     ),                                     
     muonExtras = cms.PSet(                                               
@@ -62,10 +62,10 @@ singleTopMuonMediumDQM = DQMEDAnalyzer('SingleTopTChannelLeptonDQM',
       select = cms.string("pt>30 & abs(eta)< 2.4"),
       jetBTaggers  = cms.PSet(
       	cvsVertex = cms.PSet(
-      	label = cms.InputTag("pfCombinedInclusiveSecondaryVertexV2BJetTags"),
-	    	workingPoint = cms.double(0.890)
+          label = cms.InputTag("pfDeepCSVJetTags:probb"),
+	    	  workingPoint = cms.double(0.4168)
         )
-      ),
+      )
     ),
     massExtras = cms.PSet(
     	lowerEdge = cms.double( 70.),
@@ -87,7 +87,7 @@ singleTopMuonMediumDQM = DQMEDAnalyzer('SingleTopTChannelLeptonDQM',
   selection = cms.VPSet(
     cms.PSet(
       label  = cms.string("muons/pf:step0"),
-      src    = cms.InputTag("pfIsolatedMuonsEI"),
+      src    = cms.InputTag("muons"),
       select = cms.string(tightMuonCut + " && pt>20 & abs(eta)<2.4"),
       min    = cms.int32(1),
     ),
@@ -118,8 +118,8 @@ singleTopElectronMediumDQM = DQMEDAnalyzer('SingleTopTChannelLeptonDQM',
     ## communication to TopCom!
     directory = cms.string("Physics/Top/SingleTopElectronMediumDQM/"),
     sources = cms.PSet(
-    muons = cms.InputTag("pfIsolatedMuonsEI"),
-    elecs = cms.InputTag("pfIsolatedElectronsEI"),
+    muons = cms.InputTag("muons"),
+    elecs = cms.InputTag("gedGsfElectrons"),
     jets  = cms.InputTag("ak4PFJetsCHS"),
     mets  = cms.VInputTag("pfMet"),
     pvs   = cms.InputTag("offlinePrimaryVertices")
@@ -131,7 +131,7 @@ singleTopElectronMediumDQM = DQMEDAnalyzer('SingleTopTChannelLeptonDQM',
       select = cms.string(PVCut)
     ),
     elecExtras = cms.PSet(
-      select     = cms.string(tightEleCut + "& pt>20 & abs(eta)<2.5 & (abs(gsfElectronRef.superCluster().eta()) <= 1.4442 || abs(gsfElectronRef.superCluster().eta()) >= 1.5660)"),
+      select     = cms.string(tightEleCut + "& pt>20 & abs(eta)<2.5 & (abs(superCluster().eta()) <= 1.4442 || abs(superCluster().eta()) >= 1.5660)"),
       rho = cms.InputTag("fixedGridRhoFastjetAll"),
     ),                                     
     muonExtras = cms.PSet(                                               
@@ -143,10 +143,10 @@ singleTopElectronMediumDQM = DQMEDAnalyzer('SingleTopTChannelLeptonDQM',
       select = cms.string("pt>30 & abs(eta)< 2.4"),
       jetBTaggers  = cms.PSet(
       	cvsVertex = cms.PSet(
-      	label = cms.InputTag("pfCombinedInclusiveSecondaryVertexV2BJetTags"),
-	    	workingPoint = cms.double(0.890)
+          label = cms.InputTag("pfDeepCSVJetTags:probb"),
+	    	  workingPoint = cms.double(0.4168)
         )
-      ),
+      )
     ),
     massExtras = cms.PSet(
     	lowerEdge = cms.double( 70.),
@@ -175,14 +175,14 @@ singleTopElectronMediumDQM = DQMEDAnalyzer('SingleTopTChannelLeptonDQM',
 #      label = cms.string("elecs/pf:step0"),
 #      src   = cms.InputTag("pfIsolatedElectronsEI"),
 #      electronId = cms.PSet( src = cms.InputTag("mvaTrigV0"), cutValue = cms.double(0.5) ),  
-#      select = cms.string("pt>30 & abs(eta)<2.5 & abs(gsfElectronRef.gsfTrack.d0)<0.02 && gsfElectronRef.gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 0 && (abs(gsfElectronRef.superCluster.eta) <= 1.4442 || abs(gsfElectronRef.superCluster.eta) >= 1.5660) && " + EletightIsoCut),
+#      select = cms.string("pt>30 & abs(eta)<2.5 & abs(gsfTrack.d0)<0.02 && gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 0 && (abs(superCluster.eta) <= 1.4442 || abs(superCluster.eta) >= 1.5660) && " + EletightIsoCut),
 #      min = cms.int32(1),
 #      max = cms.int32(1),
 #    ),*/
     cms.PSet(
       label  = cms.string("elecs/pf:step0"),
-      src    = cms.InputTag("pfIsolatedElectronsEI"),
-      select = cms.string("pt>20 & abs(eta)<2.5 & (abs(gsfElectronRef.superCluster().eta()) <= 1.4442 || abs(gsfElectronRef.superCluster().eta()) >= 1.5660) &&" + tightEleCut),  
+      src    = cms.InputTag("gedGsfElectrons"),
+      select = cms.string("pt>20 & abs(eta)<2.5 & (abs(superCluster().eta()) <= 1.4442 || abs(superCluster().eta()) >= 1.5660) &&" + tightEleCut),  
       min    = cms.int32(1),
     ),
     cms.PSet(

--- a/DQM/Physics/python/topSingleLeptonDQM_cfi.py
+++ b/DQM/Physics/python/topSingleLeptonDQM_cfi.py
@@ -9,21 +9,21 @@ looseJetCut = "(chargedHadronEnergyFraction()>0 && chargedMultiplicity()>0 && ch
 tightJetCut = "(chargedHadronEnergyFraction()>0 && chargedMultiplicity()>0 && chargedEmEnergyFraction()<0.99 && neutralHadronEnergyFraction()<0.90 && neutralEmEnergyFraction()<0.90 && (chargedMultiplicity()+neutralMultiplicity())>1) && abs(eta)<=2.4 "
 
 #Loose muon selection
-looseMuonCut  = "(muonRef.isNonnull && (muonRef.isGlobalMuon || muonRef.isTrackerMuon) && muonRef.isPFMuon)"
-looseIsoCut   = "((muonRef.pfIsolationR04.sumChargedHadronPt + max(0., muonRef.pfIsolationR04.sumNeutralHadronEt + muonRef.pfIsolationR04.sumPhotonEt - 0.5 * muonRef.pfIsolationR04.sumPUPt) ) / muonRef.pt < 0.25)"
+looseMuonCut  = "((isGlobalMuon || isTrackerMuon) && isPFMuon)"
+looseIsoCut   = "((pfIsolationR04.sumChargedHadronPt + max(0., pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - 0.5 * pfIsolationR04.sumPUPt) ) / pt < 0.25)"
 
 #Medium muon selection. Also requires either good global muon or tight segment compatibility
-mediumMuonCut = looseMuonCut + " muonRef.innerTrack.validFraction > 0.8"
+mediumMuonCut = looseMuonCut + " innerTrack.validFraction > 0.8"
 
 #Tight muon selection. Lacks distance to primary vertex variables, dz<0.5, dxy < 0.2. Now done at .cc
-tightMuonCut  = "muonRef.isNonnull && muonRef.isGlobalMuon && muonRef.isPFMuon && muonRef.globalTrack.normalizedChi2 < 10. && muonRef.globalTrack.hitPattern.numberOfValidMuonHits > 0 && " + \
-               "muonRef.numberOfMatchedStations > 1 && muonRef.innerTrack.hitPattern.numberOfValidPixelHits > 0 && muonRef.innerTrack.hitPattern.trackerLayersWithMeasurement > 5 "
-tightIsoCut   = "(muonRef.pfIsolationR04.sumChargedHadronPt + max(0., muonRef.pfIsolationR04.sumNeutralHadronEt + muonRef.pfIsolationR04.sumPhotonEt - 0.5 * muonRef.pfIsolationR04.sumPUPt) ) / muonRef.pt < 0.15"
+tightMuonCut  = "isGlobalMuon && isPFMuon && globalTrack.normalizedChi2 < 10. && globalTrack.hitPattern.numberOfValidMuonHits > 0 && " + \
+               "numberOfMatchedStations > 1 && innerTrack.hitPattern.numberOfValidPixelHits > 0 && innerTrack.hitPattern.trackerLayersWithMeasurement > 5 "
+tightIsoCut   = "(pfIsolationR04.sumChargedHadronPt + max(0., pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - 0.5 * pfIsolationR04.sumPUPt) ) / pt < 0.15"
 
 #Electron selections
-looseEleCut = "(( gsfElectronRef.full5x5_sigmaIetaIeta() < 0.011 && gsfElectronRef.superCluster().isNonnull() && gsfElectronRef.superCluster().seed().isNonnull() && (gsfElectronRef.deltaEtaSuperClusterTrackAtVtx() - gsfElectronRef.superCluster().eta() + gsfElectronRef.superCluster().seed().eta()) < 0.00477 && abs(gsfElectronRef.deltaPhiSuperClusterTrackAtVtx()) < 0.222 && gsfElectronRef.hadronicOverEm() < 0.298 && abs(1.0 - gsfElectronRef.eSuperClusterOverP())*1.0/gsfElectronRef.ecalEnergy() < 0.241 && gsfElectronRef.gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 1 && abs(gsfElectronRef.superCluster().eta()) < 1.479) || (gsfElectronRef.full5x5_sigmaIetaIeta() < 0.0314 && gsfElectronRef.superCluster().isNonnull() && gsfElectronRef.superCluster().seed().isNonnull() && (gsfElectronRef.deltaEtaSuperClusterTrackAtVtx() - gsfElectronRef.superCluster().eta() + gsfElectronRef.superCluster().seed().eta()) < 0.00868 && abs(gsfElectronRef.deltaPhiSuperClusterTrackAtVtx()) < 0.213 && gsfElectronRef.hadronicOverEm() < 0.101  && abs(1.0 - gsfElectronRef.eSuperClusterOverP())*1.0/gsfElectronRef.ecalEnergy() < 0.14 && gsfElectronRef.gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 1 && abs(gsfElectronRef.superCluster().eta()) > 1.479))"
+looseEleCut = "(( full5x5_sigmaIetaIeta() < 0.011 && superCluster().isNonnull() && superCluster().seed().isNonnull() && (deltaEtaSuperClusterTrackAtVtx() - superCluster().eta() + superCluster().seed().eta()) < 0.00477 && abs(deltaPhiSuperClusterTrackAtVtx()) < 0.222 && hadronicOverEm() < 0.298 && abs(1.0 - eSuperClusterOverP())*1.0/ecalEnergy() < 0.241 && gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 1 && abs(superCluster().eta()) < 1.479) || (full5x5_sigmaIetaIeta() < 0.0314 && superCluster().isNonnull() && superCluster().seed().isNonnull() && (deltaEtaSuperClusterTrackAtVtx() - superCluster().eta() + superCluster().seed().eta()) < 0.00868 && abs(deltaPhiSuperClusterTrackAtVtx()) < 0.213 && hadronicOverEm() < 0.101  && abs(1.0 - eSuperClusterOverP())*1.0/ecalEnergy() < 0.14 && gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 1 && abs(superCluster().eta()) > 1.479))"
 
-tightEleCut = "((gsfElectronRef.full5x5_sigmaIetaIeta() < 0.00998 && gsfElectronRef.superCluster().isNonnull() && gsfElectronRef.superCluster().seed().isNonnull() && (gsfElectronRef.deltaEtaSuperClusterTrackAtVtx() - gsfElectronRef.superCluster().eta() + gsfElectronRef.superCluster().seed().eta()) < 0.00308  && abs(gsfElectronRef.deltaPhiSuperClusterTrackAtVtx()) < 0.0816 && gsfElectronRef.hadronicOverEm() < 0.0414 && abs(1.0 - gsfElectronRef.eSuperClusterOverP())*1.0/gsfElectronRef.ecalEnergy() < 0.0129 && gsfElectronRef.gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 1 && abs(gsfElectronRef.superCluster().eta()) < 1.479) ||  (gsfElectronRef.full5x5_sigmaIetaIeta() < 0.0292 && gsfElectronRef.superCluster().isNonnull() && gsfElectronRef.superCluster().seed().isNonnull() && (gsfElectronRef.deltaEtaSuperClusterTrackAtVtx() - gsfElectronRef.superCluster().eta() + gsfElectronRef.superCluster().seed().eta()) < 0.00605 && abs(gsfElectronRef.deltaPhiSuperClusterTrackAtVtx()) < 0.0394  && gsfElectronRef.hadronicOverEm() < 0.0641  && abs(1.0 - gsfElectronRef.eSuperClusterOverP())*1.0/gsfElectronRef.ecalEnergy() <	0.0129 && gsfElectronRef.gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 1 && abs(gsfElectronRef.superCluster().eta()) > 1.479))"
+tightEleCut = "((full5x5_sigmaIetaIeta() < 0.00998 && superCluster().isNonnull() && superCluster().seed().isNonnull() && (deltaEtaSuperClusterTrackAtVtx() - superCluster().eta() + superCluster().seed().eta()) < 0.00308  && abs(deltaPhiSuperClusterTrackAtVtx()) < 0.0816 && hadronicOverEm() < 0.0414 && abs(1.0 - eSuperClusterOverP())*1.0/ecalEnergy() < 0.0129 && gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 1 && abs(superCluster().eta()) < 1.479) ||  (full5x5_sigmaIetaIeta() < 0.0292 && superCluster().isNonnull() && superCluster().seed().isNonnull() && (deltaEtaSuperClusterTrackAtVtx() - superCluster().eta() + superCluster().seed().eta()) < 0.00605 && abs(deltaPhiSuperClusterTrackAtVtx()) < 0.0394  && hadronicOverEm() < 0.0641  && abs(1.0 - eSuperClusterOverP())*1.0/ecalEnergy() <	0.0129 && gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 1 && abs(superCluster().eta()) > 1.479))"
 
 
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
@@ -38,8 +38,8 @@ topSingleMuonMediumDQM = DQMEDAnalyzer('TopSingleLeptonDQM',
   setup = cms.PSet(
     directory = cms.string("Physics/Top/TopSingleMuonMediumDQM/"),
     sources = cms.PSet(
-      muons = cms.InputTag("pfIsolatedMuonsEI"),
-      elecs = cms.InputTag("pfIsolatedElectronsEI"),
+      muons = cms.InputTag("muons"),
+      elecs = cms.InputTag("gedGsfElectrons"),
       jets  = cms.InputTag("ak4PFJetsCHS"),
       mets  = cms.VInputTag("pfMet"),
       pvs   = cms.InputTag("offlinePrimaryVertices")
@@ -52,7 +52,7 @@ topSingleMuonMediumDQM = DQMEDAnalyzer('TopSingleLeptonDQM',
       select = cms.string(PVCut)
     ),
     elecExtras = cms.PSet(
-      select     = cms.string(tightEleCut + "& pt>20 & abs(eta)<2.5 & (abs(gsfElectronRef.superCluster().eta()) <= 1.4442 || abs(gsfElectronRef.superCluster().eta()) >= 1.5660)"),
+      select     = cms.string(tightEleCut + "& pt>20 & abs(eta)<2.5 & (abs(superCluster().eta()) <= 1.4442 || abs(superCluster().eta()) >= 1.5660)"),
 			rho = cms.InputTag("fixedGridRhoFastjetAll"),
     ),                                     
     muonExtras = cms.PSet(
@@ -87,7 +87,7 @@ topSingleMuonMediumDQM = DQMEDAnalyzer('TopSingleLeptonDQM',
   selection = cms.VPSet(
     cms.PSet(
       label  = cms.string("muons:step0"),
-      src    = cms.InputTag("pfIsolatedMuonsEI"),
+      src    = cms.InputTag("muons"),
       select = cms.string(tightMuonCut + " && pt>20 & abs(eta)<2.4"),     
       min    = cms.int32(1),
     ),
@@ -116,8 +116,8 @@ topSingleElectronMediumDQM = DQMEDAnalyzer('TopSingleLeptonDQM',
   setup = cms.PSet(
     directory = cms.string("Physics/Top/TopSingleElectronMediumDQM/"),
     sources = cms.PSet(
-      muons = cms.InputTag("pfIsolatedMuonsEI"),
-      elecs = cms.InputTag("pfIsolatedElectronsEI"),
+      muons = cms.InputTag("muons"),
+      elecs = cms.InputTag("gedGsfElectrons"),
       jets  = cms.InputTag("ak4PFJetsCHS"),
       mets  = cms.VInputTag("pfMet"),
       pvs   = cms.InputTag("offlinePrimaryVertices")
@@ -130,7 +130,7 @@ topSingleElectronMediumDQM = DQMEDAnalyzer('TopSingleLeptonDQM',
       select   = cms.string(PVCut)
     ),
     elecExtras = cms.PSet(
-      select     = cms.string(tightEleCut + "& pt>20 & abs(eta)<2.5 & (abs(gsfElectronRef.superCluster().eta()) <= 1.4442 || abs(gsfElectronRef.superCluster().eta()) >= 1.5660)"),
+      select     = cms.string(tightEleCut + "& pt>20 & abs(eta)<2.5 & (abs(superCluster().eta()) <= 1.4442 || abs(superCluster().eta()) >= 1.5660)"),
 			rho = cms.InputTag("fixedGridRhoFastjetAll"),
     ),
     muonExtras = cms.PSet(
@@ -162,9 +162,9 @@ topSingleElectronMediumDQM = DQMEDAnalyzer('TopSingleLeptonDQM',
   selection = cms.VPSet(
     cms.PSet(
       label = cms.string("elecs:step0"),
-      src   = cms.InputTag("pfIsolatedElectronsEI"),
-      select = cms.string("pt>20 & abs(eta)<2.5 & (abs(gsfElectronRef.superCluster().eta()) <= 1.4442 || abs(gsfElectronRef.superCluster().eta()) >= 1.5660) &&" + tightEleCut),
- #     select = cms.string("pt>30 & abs(eta)<2.5 & abs(gsfElectronRef.gsfTrack.d0)<0.02 & gsfElectronRef.gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 0 & (abs(gsfElectronRef.superCluster.eta) <= 1.4442 || abs(gsfElectronRef.superCluster.eta) >= 1.5660) & " + EletightIsoCut),
+      src   = cms.InputTag("gedGsfElectrons"),
+      select = cms.string("pt>20 & abs(eta)<2.5 & (abs(superCluster().eta()) <= 1.4442 || abs(superCluster().eta()) >= 1.5660) &&" + tightEleCut),
+ #     select = cms.string("pt>30 & abs(eta)<2.5 & abs(gsfTrack.d0)<0.02 & gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 0 & (abs(superCluster.eta) <= 1.4442 || abs(superCluster.eta) >= 1.5660) & " + EletightIsoCut),
       min = cms.int32(1),
     ),
     cms.PSet(

--- a/DQM/Physics/python/topSingleLeptonDQM_cfi.py
+++ b/DQM/Physics/python/topSingleLeptonDQM_cfi.py
@@ -21,7 +21,7 @@ tightMuonCut  = "isGlobalMuon && isPFMuon && globalTrack.normalizedChi2 < 10. &&
 tightIsoCut   = "(pfIsolationR04.sumChargedHadronPt + max(0., pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - 0.5 * pfIsolationR04.sumPUPt) ) / pt < 0.15"
 
 #Electron selections
-looseEleCut = "(( full5x5_sigmaIetaIeta() < 0.011 && superCluster().isNonnull() && superCluster().seed().isNonnull() && (deltaEtaSuperClusterTrackAtVtx() - superCluster().eta() + superCluster().seed().eta()) < 0.00477 && abs(deltaPhiSuperClusterTrackAtVtx()) < 0.222 && hadronicOverEm() < 0.298 && abs(1.0 - eSuperClusterOverP())*1.0/ecalEnergy() < 0.241 && gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 1 && abs(superCluster().eta()) < 1.479) || (full5x5_sigmaIetaIeta() < 0.0314 && superCluster().isNonnull() && superCluster().seed().isNonnull() && (deltaEtaSuperClusterTrackAtVtx() - superCluster().eta() + superCluster().seed().eta()) < 0.00868 && abs(deltaPhiSuperClusterTrackAtVtx()) < 0.213 && hadronicOverEm() < 0.101  && abs(1.0 - eSuperClusterOverP())*1.0/ecalEnergy() < 0.14 && gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 1 && abs(superCluster().eta()) > 1.479))"
+looseEleCut = "((full5x5_sigmaIetaIeta() < 0.011 && superCluster().isNonnull() && superCluster().seed().isNonnull() && (deltaEtaSuperClusterTrackAtVtx() - superCluster().eta() + superCluster().seed().eta()) < 0.00477 && abs(deltaPhiSuperClusterTrackAtVtx()) < 0.222 && hadronicOverEm() < 0.298 && abs(1.0 - eSuperClusterOverP())*1.0/ecalEnergy() < 0.241 && gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 1 && abs(superCluster().eta()) < 1.479) || (full5x5_sigmaIetaIeta() < 0.0314 && superCluster().isNonnull() && superCluster().seed().isNonnull() && (deltaEtaSuperClusterTrackAtVtx() - superCluster().eta() + superCluster().seed().eta()) < 0.00868 && abs(deltaPhiSuperClusterTrackAtVtx()) < 0.213 && hadronicOverEm() < 0.101  && abs(1.0 - eSuperClusterOverP())*1.0/ecalEnergy() < 0.14 && gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 1 && abs(superCluster().eta()) > 1.479))"
 
 tightEleCut = "((full5x5_sigmaIetaIeta() < 0.00998 && superCluster().isNonnull() && superCluster().seed().isNonnull() && (deltaEtaSuperClusterTrackAtVtx() - superCluster().eta() + superCluster().seed().eta()) < 0.00308  && abs(deltaPhiSuperClusterTrackAtVtx()) < 0.0816 && hadronicOverEm() < 0.0414 && abs(1.0 - eSuperClusterOverP())*1.0/ecalEnergy() < 0.0129 && gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 1 && abs(superCluster().eta()) < 1.479) ||  (full5x5_sigmaIetaIeta() < 0.0292 && superCluster().isNonnull() && superCluster().seed().isNonnull() && (deltaEtaSuperClusterTrackAtVtx() - superCluster().eta() + superCluster().seed().eta()) < 0.00605 && abs(deltaPhiSuperClusterTrackAtVtx()) < 0.0394  && hadronicOverEm() < 0.0641  && abs(1.0 - eSuperClusterOverP())*1.0/ecalEnergy() <	0.0129 && gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 1 && abs(superCluster().eta()) > 1.479))"
 
@@ -61,15 +61,15 @@ topSingleMuonMediumDQM = DQMEDAnalyzer('TopSingleLeptonDQM',
       isolation = cms.string(looseIsoCut)
     ),
     jetExtras = cms.PSet(
-      jetCorrector = cms.InputTag("dqmAk4PFCHSL1FastL2L3Corrector"),  #Use pak4PFCHSL1FastL2L3Residual for data!!!                                            
-      select = cms.string("pt>30 & abs(eta)< 2.4"),                                                                                               
-      jetBTaggers  = cms.PSet(
+      jetCorrector = cms.InputTag("dqmAk4PFCHSL1FastL2L3Corrector"), #Use pak4PFCHSL1FastL2L3Residual for data!!!                                            
+      select = cms.string("pt>30 & abs(eta)<2.4"),                                                                                               
+      jetBTaggers = cms.PSet(
 				cvsVertex = cms.PSet(
-          label = cms.InputTag("pfCombinedInclusiveSecondaryVertexV2BJetTags"),
-	          workingPoint = cms.double(0.890)
-	          # CSV Medium from https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation74X
+            label = cms.InputTag("pfDeepCSVJetTags:probb"),
+	          workingPoint = cms.double(0.4168)
+	          # deepCSV Medium from https://btv-wiki.docs.cern.ch/ScaleFactors/UL2018/
         )
-      ),                                                                                                
+      ),                                                                                               
     ),
     massExtras = cms.PSet(
       lowerEdge = cms.double( 70.),
@@ -121,16 +121,15 @@ topSingleElectronMediumDQM = DQMEDAnalyzer('TopSingleLeptonDQM',
       jets  = cms.InputTag("ak4PFJetsCHS"),
       mets  = cms.VInputTag("pfMet"),
       pvs   = cms.InputTag("offlinePrimaryVertices")
-
     ),
     monitoring = cms.PSet(
       verbosity = cms.string("DEBUG")
     ),
     pvExtras = cms.PSet(                                                                                           
-      select   = cms.string(PVCut)
+      select = cms.string(PVCut)
     ),
     elecExtras = cms.PSet(
-      select     = cms.string(tightEleCut + "& pt>20 & abs(eta)<2.5 & (abs(superCluster().eta()) <= 1.4442 || abs(superCluster().eta()) >= 1.5660)"),
+      select   = cms.string(tightEleCut + "& pt>20 & abs(eta)<2.5 & (abs(superCluster().eta()) <= 1.4442 || abs(superCluster().eta()) >= 1.5660)"),
 			rho = cms.InputTag("fixedGridRhoFastjetAll"),
     ),
     muonExtras = cms.PSet(
@@ -140,13 +139,13 @@ topSingleElectronMediumDQM = DQMEDAnalyzer('TopSingleLeptonDQM',
     jetExtras = cms.PSet(
 			jetCorrector = cms.InputTag("dqmAk4PFCHSL1FastL2L3Corrector"), #Use pak4PFCHSL1FastL2L3Residual for data!!!
       select = cms.string("pt>30 & abs(eta)<2.4"),
-      jetBTaggers  = cms.PSet(
-			cvsVertex = cms.PSet(
-          label = cms.InputTag("pfCombinedInclusiveSecondaryVertexV2BJetTags"),
-	          workingPoint = cms.double(0.890)
-	          # CSV Medium from https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation74X
+      jetBTaggers = cms.PSet(
+			  cvsVertex = cms.PSet(
+          label = cms.InputTag("pfDeepCSVJetTags:probb"),
+	        workingPoint = cms.double(0.4168)
+	          # deepCSV Medium from https://btv-wiki.docs.cern.ch/ScaleFactors/UL2018/
         )
-      ),                                                
+      )                                                
     ),
     massExtras = cms.PSet(
       lowerEdge = cms.double( 70.),
@@ -164,7 +163,7 @@ topSingleElectronMediumDQM = DQMEDAnalyzer('TopSingleLeptonDQM',
       label = cms.string("elecs:step0"),
       src   = cms.InputTag("gedGsfElectrons"),
       select = cms.string("pt>20 & abs(eta)<2.5 & (abs(superCluster().eta()) <= 1.4442 || abs(superCluster().eta()) >= 1.5660) &&" + tightEleCut),
- #     select = cms.string("pt>30 & abs(eta)<2.5 & abs(gsfTrack.d0)<0.02 & gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 0 & (abs(superCluster.eta) <= 1.4442 || abs(superCluster.eta) >= 1.5660) & " + EletightIsoCut),
+ #    select = cms.string("pt>30 & abs(eta)<2.5 & abs(gsfTrack.d0)<0.02 & gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 0 & (abs(superCluster.eta) <= 1.4442 || abs(superCluster.eta) >= 1.5660) & " + EletightIsoCut),
       min = cms.int32(1),
     ),
     cms.PSet(

--- a/DQM/Physics/src/SingleTopTChannelLeptonDQM.cc
+++ b/DQM/Physics/src/SingleTopTChannelLeptonDQM.cc
@@ -139,7 +139,7 @@ namespace SingleTopTChannelLepton {
       includeBTag_ = jetExtras.existsAs<edm::ParameterSet>("jetBTaggers");
       if (includeBTag_) {
         edm::ParameterSet btagCSV =
-        jetExtras.getParameter<edm::ParameterSet>("jetBTaggers").getParameter<edm::ParameterSet>("cvsVertex");
+            jetExtras.getParameter<edm::ParameterSet>("jetBTaggers").getParameter<edm::ParameterSet>("cvsVertex");
         btagCSV_ = iC.consumes<reco::JetTagCollection>(btagCSV.getParameter<edm::InputTag>("label"));
         btagCSVWP_ = btagCSV.getParameter<double>("workingPoint");
       }

--- a/DQM/Physics/src/SingleTopTChannelLeptonDQM.h
+++ b/DQM/Physics/src/SingleTopTChannelLeptonDQM.h
@@ -110,14 +110,14 @@ namespace SingleTopTChannelLepton {
     /// instance label
     std::string label_;
     /// considers a vector of METs
-    std::vector<edm::EDGetTokenT<edm::View<reco::MET> > > mets_;
+    std::vector<edm::EDGetTokenT<edm::View<reco::MET>>> mets_;
     //    std::vector<edm::InputTag> mets_;
     /// input sources for monitoring
-    edm::EDGetTokenT<edm::View<reco::Jet> > jets_;
-    edm::EDGetTokenT<edm::View<reco::PFCandidate> > muons_;
-    edm::EDGetTokenT<edm::View<reco::GsfElectron> > elecs_gsf_;
-    edm::EDGetTokenT<edm::View<reco::PFCandidate> > elecs_;
-    edm::EDGetTokenT<edm::View<reco::Vertex> > pvs_;
+    edm::EDGetTokenT<edm::View<reco::Jet>> jets_;
+    edm::EDGetTokenT<edm::View<reco::Muon>> muons_;
+    //edm::EDGetTokenT<edm::View<reco::GsfElectron> > elecs_gsf_;
+    edm::EDGetTokenT<edm::View<reco::GsfElectron>> elecs_;
+    edm::EDGetTokenT<edm::View<reco::Vertex>> pvs_;
 
     //    edm::InputTag elecs_, elecs_gsf_, muons_, muons_reco_, jets_, pvs_;
 
@@ -131,7 +131,7 @@ namespace SingleTopTChannelLepton {
 
     /// electronId label
     //    edm::InputTag electronId_;
-    edm::EDGetTokenT<edm::ValueMap<float> > electronId_;
+    edm::EDGetTokenT<edm::ValueMap<float>> electronId_;
     /// electronId pattern we expect the following pattern:
     ///  0: fails
     ///  1: passes electron ID only
@@ -149,27 +149,27 @@ namespace SingleTopTChannelLepton {
     /// extra isolation criterion on electron
     std::string elecIso_;
     /// extra selection on electrons
-    std::unique_ptr<StringCutObjectSelector<reco::PFCandidate> > elecSelect_;
+    std::unique_ptr<StringCutObjectSelector<reco::GsfElectron>> elecSelect_;
     edm::InputTag rhoTag;
 
     /// extra selection on primary vertices; meant to investigate the pile-up
     /// effect
-    std::unique_ptr<StringCutObjectSelector<reco::Vertex> > pvSelect_;
+    std::unique_ptr<StringCutObjectSelector<reco::Vertex>> pvSelect_;
 
     /// extra isolation criterion on muon
-    std::unique_ptr<StringCutObjectSelector<reco::PFCandidate> > muonIso_;
+    std::unique_ptr<StringCutObjectSelector<reco::Muon>> muonIso_;
 
     /// extra selection on muons
-    std::unique_ptr<StringCutObjectSelector<reco::PFCandidate> > muonSelect_;
+    std::unique_ptr<StringCutObjectSelector<reco::Muon>> muonSelect_;
     /// jetCorrector
     edm::EDGetTokenT<reco::JetCorrector> jetCorrector_;
     /// jetID as an extra selection type
     edm::EDGetTokenT<reco::JetIDValueMap> jetIDLabel_;
 
     /// extra jetID selection on calo jets
-    std::unique_ptr<StringCutObjectSelector<reco::JetID> > jetIDSelect_;
-    std::unique_ptr<StringCutObjectSelector<reco::PFJet> > jetlooseSelection_;
-    std::unique_ptr<StringCutObjectSelector<reco::PFJet> > jetSelection_;
+    std::unique_ptr<StringCutObjectSelector<reco::JetID>> jetIDSelect_;
+    std::unique_ptr<StringCutObjectSelector<reco::PFJet>> jetlooseSelection_;
+    std::unique_ptr<StringCutObjectSelector<reco::PFJet>> jetSelection_;
     /// extra selection on jets (here given as std::string as it depends
     /// on the the jet type, which selections are valid and which not)
     std::string jetSelect_;
@@ -194,11 +194,11 @@ namespace SingleTopTChannelLepton {
 
     std::string directory_;
 
-    std::unique_ptr<StringCutObjectSelector<reco::PFCandidate, true> > muonSelect;
-    std::unique_ptr<StringCutObjectSelector<reco::PFCandidate, true> > muonIso;
+    std::unique_ptr<StringCutObjectSelector<reco::Muon, true>> muonSelect;
+    std::unique_ptr<StringCutObjectSelector<reco::Muon, true>> muonIso;
 
-    std::unique_ptr<StringCutObjectSelector<reco::PFCandidate, true> > elecSelect;
-    std::unique_ptr<StringCutObjectSelector<reco::PFCandidate, true> > elecIso;
+    std::unique_ptr<StringCutObjectSelector<reco::GsfElectron, true>> elecSelect;
+    std::unique_ptr<StringCutObjectSelector<reco::GsfElectron, true>> elecIso;
   };
 
   inline void MonitorEnsemble::triggerBinLabels(std::string channel, const std::vector<std::string> labels) {
@@ -304,13 +304,13 @@ private:
   edm::InputTag vertex_;
   edm::EDGetTokenT<reco::Vertex> vertex__;
   /// string cut selector
-  std::unique_ptr<StringCutObjectSelector<reco::Vertex> > vertexSelect_;
+  std::unique_ptr<StringCutObjectSelector<reco::Vertex>> vertexSelect_;
 
   /// beamspot
   edm::InputTag beamspot_;
   edm::EDGetTokenT<reco::BeamSpot> beamspot__;
   /// string cut selector
-  std::unique_ptr<StringCutObjectSelector<reco::BeamSpot> > beamspotSelect_;
+  std::unique_ptr<StringCutObjectSelector<reco::BeamSpot>> beamspotSelect_;
 
   /// needed to guarantee the selection order as defined by the order of
   /// ParameterSets in the _selection_ vector as defined in the config
@@ -320,20 +320,20 @@ private:
   /// the configuration of the selection for the SelectionStep class,
   /// MonitoringEnsemble keeps an instance of the MonitorEnsemble class to
   /// be filled _after_ each selection step
-  std::map<std::string, std::pair<edm::ParameterSet, std::unique_ptr<SingleTopTChannelLepton::MonitorEnsemble> > >
+  std::map<std::string, std::pair<edm::ParameterSet, std::unique_ptr<SingleTopTChannelLepton::MonitorEnsemble>>>
       selection_;
 
-  std::unique_ptr<SelectionStep<reco::Muon> > MuonStep;
-  std::unique_ptr<SelectionStep<reco::PFCandidate> > PFMuonStep;
-  std::unique_ptr<SelectionStep<reco::GsfElectron> > ElectronStep;
-  std::unique_ptr<SelectionStep<reco::PFCandidate> > PFElectronStep;
-  std::unique_ptr<SelectionStep<reco::Vertex> > PvStep;
+  std::unique_ptr<SelectionStep<reco::Muon>> MuonStep;
+  std::unique_ptr<SelectionStep<reco::Muon>> PFMuonStep;
+  std::unique_ptr<SelectionStep<reco::GsfElectron>> ElectronStep;
+  std::unique_ptr<SelectionStep<reco::GsfElectron>> PFElectronStep;
+  std::unique_ptr<SelectionStep<reco::Vertex>> PvStep;
 
-  std::vector<std::unique_ptr<SelectionStep<reco::Jet> > > JetSteps;
-  std::vector<std::unique_ptr<SelectionStep<reco::CaloJet> > > CaloJetSteps;
-  std::vector<std::unique_ptr<SelectionStep<reco::PFJet> > > PFJetSteps;
+  std::vector<std::unique_ptr<SelectionStep<reco::Jet>>> JetSteps;
+  std::vector<std::unique_ptr<SelectionStep<reco::CaloJet>>> CaloJetSteps;
+  std::vector<std::unique_ptr<SelectionStep<reco::PFJet>>> PFJetSteps;
 
-  std::unique_ptr<SelectionStep<reco::MET> > METStep;
+  std::unique_ptr<SelectionStep<reco::MET>> METStep;
   std::vector<edm::ParameterSet> sel;
 };
 

--- a/DQM/Physics/src/SingleTopTChannelLeptonDQM_miniAOD.cc
+++ b/DQM/Physics/src/SingleTopTChannelLeptonDQM_miniAOD.cc
@@ -315,9 +315,9 @@ namespace SingleTopTChannelLepton_miniAOD {
     //hists_["jetBDiscVtx_"] = ibooker.book1D("JetBDiscVtx",
     //    "Disc_{SSVHE}(Jet)", 35, -1., 6.);
     // multiplicity for combined secondary vertex
-    hists_["jetMultBDeepJetM_"] = ibooker.book1D("JetMultBDeepJetM", "N_{30}(DeepJetM)", 10, 0., 10.);
+    hists_["jetMultBPNetM_"] = ibooker.book1D("JetMultBPNetM", "N_{30}(PNetM)", 10, 0., 10.);
     // btag discriminator for combined secondary vertex
-    hists_["jetBDeepJet_"] = ibooker.book1D("JetDiscDeepJet", "BJet Disc_{DeepJet}(JET)", 100, -1., 2.);
+    hists_["jetBPNet_"] = ibooker.book1D("JetDiscPNet", "BJet Disc_{PNet}(JET)", 100, -1., 2.);
     // pt of the 1. leading jet (uncorrected)
     //hists_["jet1PtRaw_"] = ibooker.book1D("Jet1PtRaw", "pt_{Raw}(jet1)", 60, 0., 300.);
     // pt of the 2. leading jet (uncorrected)
@@ -571,7 +571,7 @@ namespace SingleTopTChannelLepton_miniAOD {
     pat::Jet TaggedJetCand;
     vector<double> bJetDiscVal;
 
-    unsigned int mult = 0, loosemult = 0, multBDeepJetM = 0;
+    unsigned int mult = 0, loosemult = 0, multBPNetM = 0;
 
     edm::Handle<edm::View<pat::Jet>> jets;
     if (!event.getByToken(jets_, jets)) {
@@ -603,25 +603,28 @@ namespace SingleTopTChannelLepton_miniAOD {
         correctedJets.push_back(monitorJet);
         ++loosemult;  // determine jet multiplicity
 
-        double discriminator = monitorJet.bDiscriminator("pfDeepFlavourJetTags:probb") +
-                               monitorJet.bDiscriminator("pfDeepFlavourJetTags:probbb") +
-                               monitorJet.bDiscriminator("pfDeepFlavourJetTags:problepb");
+        //ParticleNet discriminator
+        
+        double discriminator =
+            monitorJet.bDiscriminator("pfParticleNetFromMiniAODAK4CHSCentralDiscriminatorsJetTags:BvsAll") > 0
+		            ? monitorJet.bDiscriminator("pfParticleNetFromMiniAODAK4CHSCentralDiscriminatorsJetTags:BvsAll")
+		            : -1;
 
-        fill("jetBDeepJet_", discriminator);  //hard coded discriminator and value right now.
-        if (discriminator > 0.2435) {
-          if (multBDeepJetM == 0) {
+        fill("jetBPNet_", discriminator);  //hard coded discriminator and value right now.
+        if (discriminator > 0.1919) {
+          if (multBPNetM == 0) {
             TaggedJetCand = monitorJet;
             bJetDiscVal.push_back(discriminator);
-          } else if (multBDeepJetM == 1) {
+          } else if (multBPNetM == 1) {
             bJetDiscVal.push_back(discriminator);
             if (bJetDiscVal[1] > bJetDiscVal[0])
               TaggedJetCand = monitorJet;
           }
 
-          ++multBDeepJetM;
+          ++multBPNetM;
         }
 
-        // Fill a vector with Jet b-tag WP for later M3+1tag calculation: DeepJet
+        // Fill a vector with Jet b-tag WP for later M3+1tag calculation: PNet
         // tagger
         JetTagValues.push_back(discriminator);
         //    }
@@ -642,7 +645,7 @@ namespace SingleTopTChannelLepton_miniAOD {
     }
     fill("jetMult_", mult);
     fill("jetLooseMult_", loosemult);
-    fill("jetMultBDeepJetM_", multBDeepJetM);
+    fill("jetMultBPNetM_", multBPNetM);
 
     /*
   ------------------------------------------------------------
@@ -665,7 +668,7 @@ namespace SingleTopTChannelLepton_miniAOD {
         unsigned int idx = met_ - mets_.begin();
         if (idx == 0)
           fill("slimmedMETs_", met->begin()->et());
-        if (idx == 2)
+        if (idx == 1)
           fill("slimmedMETsPuppi_", met->begin()->et());
       }
     }
@@ -688,12 +691,12 @@ namespace SingleTopTChannelLepton_miniAOD {
       fill("massTop_", topMass);
     }
 
-    // Fill M3 with Btag (DeepJet Tight) requirement
+    // Fill M3 with Btag (PNet Tight) requirement
 
     // if (!includeBTag_) return;
     //if (correctedJets.size() != JetTagValues.size()) return;
     //double btopMass =
-    //    eventKinematics.massBTopQuark(correctedJets, JetTagValues, 0.2435); //hard coded DeepJet value
+    //    eventKinematics.massBTopQuark(correctedJets, JetTagValues, 0.2435); //hard coded PNet value
 
     //if (btopMass >= 0) fill("massBTop_", btopMass);
 
@@ -722,14 +725,14 @@ namespace SingleTopTChannelLepton_miniAOD {
       }
     }
 
-    if (multBDeepJetM != 0 && mTight == 1) {
+    if (multBPNetM != 0 && mTight == 1) {
       double mtW = eventKinematics.tmassWBoson(&mu, mET, TaggedJetCand);
       fill("MTWm_", mtW);
       double MTT = eventKinematics.tmassTopQuark(&mu, mET, TaggedJetCand);
       fill("mMTT_", MTT);
     }
 
-    if (multBDeepJetM != 0 && eMultIso == 1) {
+    if (multBPNetM != 0 && eMultIso == 1) {
       double mtW = eventKinematics.tmassWBoson(&e, mET, TaggedJetCand);
       fill("MTWe_", mtW);
       double MTT = eventKinematics.tmassTopQuark(&e, mET, TaggedJetCand);

--- a/DQM/Physics/src/SingleTopTChannelLeptonDQM_miniAOD.cc
+++ b/DQM/Physics/src/SingleTopTChannelLeptonDQM_miniAOD.cc
@@ -604,11 +604,11 @@ namespace SingleTopTChannelLepton_miniAOD {
         ++loosemult;  // determine jet multiplicity
 
         //ParticleNet discriminator
-        
+
         double discriminator =
             monitorJet.bDiscriminator("pfParticleNetFromMiniAODAK4CHSCentralDiscriminatorsJetTags:BvsAll") > 0
-		            ? monitorJet.bDiscriminator("pfParticleNetFromMiniAODAK4CHSCentralDiscriminatorsJetTags:BvsAll")
-		            : -1;
+                ? monitorJet.bDiscriminator("pfParticleNetFromMiniAODAK4CHSCentralDiscriminatorsJetTags:BvsAll")
+                : -1;
 
         fill("jetBPNet_", discriminator);  //hard coded discriminator and value right now.
         if (discriminator > 0.1919) {

--- a/DQM/Physics/src/TopSingleLeptonDQM.cc
+++ b/DQM/Physics/src/TopSingleLeptonDQM.cc
@@ -529,7 +529,7 @@ namespace TopSingleLepton {
     // check availability of the btaggers
     edm::Handle<reco::JetTagCollection> btagEff, btagPur, btagVtx, btagCSV;
     if (includeBTag_) {
-      if(!event.getByToken(btagCSV_,btagCSV)){
+      if (!event.getByToken(btagCSV_, btagCSV)) {
         return;
       }
     }

--- a/DQM/Physics/src/TopSingleLeptonDQM.cc
+++ b/DQM/Physics/src/TopSingleLeptonDQM.cc
@@ -86,14 +86,14 @@ namespace TopSingleLepton {
       // select is optional; in case it's not found no
       // selection will be applied
       if (muonExtras.existsAs<std::string>("select")) {
-        muonSelect_ = std::make_unique<StringCutObjectSelector<reco::Muon>>(
-            muonExtras.getParameter<std::string>("select"));
+        muonSelect_ =
+            std::make_unique<StringCutObjectSelector<reco::Muon>>(muonExtras.getParameter<std::string>("select"));
       }
       // isolation is optional; in case it's not found no
       // isolation will be applied
       if (muonExtras.existsAs<std::string>("isolation")) {
-        muonIso_ = std::make_unique<StringCutObjectSelector<reco::Muon>>(
-            muonExtras.getParameter<std::string>("isolation"));
+        muonIso_ =
+            std::make_unique<StringCutObjectSelector<reco::Muon>>(muonExtras.getParameter<std::string>("isolation"));
       }
     }
 
@@ -206,7 +206,7 @@ namespace TopSingleLepton {
     // multiplicity of jets with pt>30
     hists_["jetMult_"] = ibooker.book1D("JetMult", "N_{30}(jet)", 10, 0., 10.);
     // multiplicity of loose jets with pt>30
-    hists_["jetMultLoose_"] = ibooker.book1D("JetMultLoose", "N_{30, loose}(jet)", 10, 0., 10.);
+    hists_["jetMultLoose_"] = ibooker.book1D("JetMultLoose", "N_{30,loose}(jet)", 10, 0., 10.);
 
     // trigger efficiency estimates for single lepton triggers
     // hists_["triggerEff_"] = ibooker.book1D("TriggerEff",
@@ -357,7 +357,6 @@ namespace TopSingleLepton {
         pvMult++;
     }
     fill("pvMult_", pvMult);
-
     /*
   ------------------------------------------------------------
 
@@ -376,10 +375,10 @@ namespace TopSingleLepton {
     // check availability of electron id
     edm::Handle<edm::ValueMap<float>> electronId;
     if (!electronId_.isUninitialized()) {
-      if (!event.getByToken(electronId_, electronId))
+      if (!event.getByToken(electronId_, electronId)) {
         return;
+      }
     }
-
     // loop electron collection
     unsigned int eMult = 0, eMultIso = 0;
     std::vector<const reco::GsfElectron*> isoElecs;
@@ -530,8 +529,9 @@ namespace TopSingleLepton {
     // check availability of the btaggers
     edm::Handle<reco::JetTagCollection> btagEff, btagPur, btagVtx, btagCSV;
     if (includeBTag_) {
-      if (!event.getByToken(btagCSV_, btagCSV))
+      if(!event.getByToken(btagCSV_,btagCSV)){
         return;
+      }
     }
 
     // loop jet collection
@@ -555,7 +555,6 @@ namespace TopSingleLepton {
         if (!(*jetSelection_)(sel))
           continue;
       }
-
       // prepare jet to fill monitor histograms
       reco::Jet monitorJet = *jet;
 
@@ -616,8 +615,9 @@ namespace TopSingleLepton {
         continue;
       if (met->begin() != met->end()) {  //If we ever have to use more than one type of met again
         unsigned int idx = met_ - mets_.begin();
-        if (idx == 0)
+        if (idx == 0) {
           fill("metPflow_", met->begin()->et());
+        }
       }
     }
 
@@ -630,7 +630,6 @@ namespace TopSingleLepton {
   */
 
     // fill W boson and top mass estimates
-
     Calculate eventKinematics(MAXJETS, WMASS);
     double wMass = eventKinematics.massWBoson(correctedJets);
     double topMass = eventKinematics.massTopQuark(correctedJets);
@@ -646,8 +645,9 @@ namespace TopSingleLepton {
     if (correctedJets.size() != JetTagValues.size())
       return;
     double btopMass = eventKinematics.massBTopQuark(correctedJets, JetTagValues, btagCSVWP_);
-    if (btopMass >= 0)
+    if (btopMass >= 0) {
       fill("massBTop_", btopMass);
+    }
 
     // fill plots for trigger monitoring
     if ((lowerEdge_ == -1. && upperEdge_ == -1.) || (lowerEdge_ < wMass && wMass < upperEdge_)) {
@@ -686,7 +686,9 @@ TopSingleLeptonDQM::TopSingleLeptonDQM(const edm::ParameterSet& cfg)
   JetSteps.clear();
   CaloJetSteps.clear();
   PFJetSteps.clear();
+
   // configure preselection
+
   edm::ParameterSet presel = cfg.getParameter<edm::ParameterSet>("preselection");
   if (presel.existsAs<edm::ParameterSet>("trigger")) {
     edm::ParameterSet trigger = presel.getParameter<edm::ParameterSet>("trigger");
@@ -748,19 +750,23 @@ void TopSingleLeptonDQM::bookHistograms(DQMStore::IBooker& ibooker, edm::Run con
 void TopSingleLeptonDQM::analyze(const edm::Event& event, const edm::EventSetup& setup) {
   if (!triggerTable__.isUninitialized()) {
     edm::Handle<edm::TriggerResults> triggerTable;
-    if (!event.getByToken(triggerTable__, triggerTable))
+    if (!event.getByToken(triggerTable__, triggerTable)) {
       return;
-    if (!accept(event, *triggerTable, triggerPaths_))
+    }
+    if (!accept(event, *triggerTable, triggerPaths_)) {
       return;
+    }
   }
   if (!beamspot__.isUninitialized()) {
     edm::Handle<reco::BeamSpot> beamspot;
-    if (!event.getByToken(beamspot__, beamspot))
+    if (!event.getByToken(beamspot__, beamspot)) {
       return;
-    if (!(*beamspotSelect_)(*beamspot))
+    }
+    if (!(*beamspotSelect_)(*beamspot)) {
       return;
+    }
   }
-  //  cout<<" apply selection steps"<<endl;
+  // apply selection steps
   unsigned int nJetSteps = -1;
   unsigned int nPFJetSteps = -1;
   unsigned int nCaloJetSteps = -1;
@@ -773,34 +779,33 @@ void TopSingleLeptonDQM::analyze(const edm::Event& event, const edm::EventSetup&
       }
       if (type == "muons" && MuonStep != nullptr) {
         if (MuonStep->select(event)) {
-          //      cout<<"selected event! "<<selection_[key].second<<endl;
           selection_[key].second->fill(event, setup);
-        } else
+        } else {
           break;
+        }
       }
-      // cout<<" apply selection steps 2"<<endl;
       if (type == "elecs" && ElectronStep != nullptr) {
-        // cout<<"In electrons ..."<<endl;
         if (ElectronStep->select(event, "electron")) {
           selection_[key].second->fill(event, setup);
-        } else
+        } else {
           break;
+        }
       }
-      // cout<<" apply selection steps 3"<<endl;
       if (type == "pvs" && PvStep != nullptr) {
         if (PvStep->selectVertex(event)) {
           selection_[key].second->fill(event, setup);
-        } else
+        } else {
           break;
+        }
       }
-      // cout<<" apply selection steps 4"<<endl;
       if (type == "jets") {
         nJetSteps++;
         if (JetSteps[nJetSteps] != nullptr) {
           if (JetSteps[nJetSteps]->select(event, setup)) {
             selection_[key].second->fill(event, setup);
-          } else
+          } else {
             break;
+          }
         }
       }
       if (type == "jets/pf") {
@@ -808,8 +813,9 @@ void TopSingleLeptonDQM::analyze(const edm::Event& event, const edm::EventSetup&
         if (PFJetSteps[nPFJetSteps] != nullptr) {
           if (PFJetSteps[nPFJetSteps]->select(event, setup)) {
             selection_[key].second->fill(event, setup);
-          } else
+          } else {
             break;
+          }
         }
       }
       if (type == "jets/calo") {
@@ -817,21 +823,18 @@ void TopSingleLeptonDQM::analyze(const edm::Event& event, const edm::EventSetup&
         if (CaloJetSteps[nCaloJetSteps] != nullptr) {
           if (CaloJetSteps[nCaloJetSteps]->select(event, setup)) {
             selection_[key].second->fill(event, setup);
-          } else
+          } else {
             break;
+          }
         }
       }
       if (type == "met" && METStep != nullptr) {
         if (METStep->select(event)) {
           selection_[key].second->fill(event, setup);
-        } else
+        } else {
           break;
+        }
       }
     }
   }
 }
-
-// Local Variables:
-// show-trailing-whitespace: t
-// truncate-lines: t
-// End:

--- a/DQM/Physics/src/TopSingleLeptonDQM.h
+++ b/DQM/Physics/src/TopSingleLeptonDQM.h
@@ -108,8 +108,8 @@ namespace TopSingleLepton {
     std::vector<edm::EDGetTokenT<edm::View<reco::MET> > > mets_;
     /// input sources for monitoring
     edm::EDGetTokenT<edm::View<reco::Jet> > jets_;
-    edm::EDGetTokenT<edm::View<reco::PFCandidate> > muons_;
-    edm::EDGetTokenT<edm::View<reco::PFCandidate> > elecs_;
+    edm::EDGetTokenT<edm::View<reco::Muon> > muons_;
+    edm::EDGetTokenT<edm::View<reco::GsfElectron> > elecs_;
     edm::EDGetTokenT<edm::View<reco::Vertex> > pvs_;
     /// trigger table
     edm::EDGetTokenT<edm::TriggerResults> triggerTable_;
@@ -140,17 +140,17 @@ namespace TopSingleLepton {
 
     /// extra selection on electrons
 
-    std::unique_ptr<StringCutObjectSelector<reco::PFCandidate> > elecSelect_;
+    std::unique_ptr<StringCutObjectSelector<reco::GsfElectron> > elecSelect_;
 
     /// extra selection on primary vertices; meant to investigate the pile-up
     /// effect
     std::unique_ptr<StringCutObjectSelector<reco::Vertex> > pvSelect_;
 
     /// extra isolation criterion on muon
-    std::unique_ptr<StringCutObjectSelector<reco::PFCandidate> > muonIso_;
+    std::unique_ptr<StringCutObjectSelector<reco::Muon> > muonIso_;
 
     /// extra selection on muons
-    std::unique_ptr<StringCutObjectSelector<reco::PFCandidate> > muonSelect_;
+    std::unique_ptr<StringCutObjectSelector<reco::Muon> > muonSelect_;
 
     /// jetCorrector
     edm::EDGetTokenT<reco::JetCorrector> jetCorrector_;
@@ -306,8 +306,8 @@ private:
   /// MonitoringEnsemble keeps an instance of the MonitorEnsemble class to
   /// be filled _after_ each selection step
   std::map<std::string, std::pair<edm::ParameterSet, std::unique_ptr<TopSingleLepton::MonitorEnsemble> > > selection_;
-  std::unique_ptr<SelectionStep<reco::PFCandidate> > MuonStep;
-  std::unique_ptr<SelectionStep<reco::PFCandidate> > ElectronStep;
+  std::unique_ptr<SelectionStep<reco::Muon> > MuonStep;
+  std::unique_ptr<SelectionStep<reco::GsfElectron> > ElectronStep;
   std::unique_ptr<SelectionStep<reco::Vertex> > PvStep;
   std::unique_ptr<SelectionStep<reco::MET> > METStep;
   std::vector<std::unique_ptr<SelectionStep<reco::Jet> > > JetSteps;

--- a/DQM/Physics/src/TopSingleLeptonDQM.h
+++ b/DQM/Physics/src/TopSingleLeptonDQM.h
@@ -105,12 +105,13 @@ namespace TopSingleLepton {
     /// instance label
     std::string label_;
     /// considers a vector of METs
-    std::vector<edm::EDGetTokenT<edm::View<reco::MET> > > mets_;
+    std::vector<edm::EDGetTokenT<edm::View<reco::MET>>> mets_;
     /// input sources for monitoring
-    edm::EDGetTokenT<edm::View<reco::Jet> > jets_;
-    edm::EDGetTokenT<edm::View<reco::Muon> > muons_;
-    edm::EDGetTokenT<edm::View<reco::GsfElectron> > elecs_;
-    edm::EDGetTokenT<edm::View<reco::Vertex> > pvs_;
+    edm::EDGetTokenT<edm::View<reco::Jet>> jets_;
+    edm::EDGetTokenT<edm::View<reco::Muon>> muons_;
+    edm::EDGetTokenT<edm::View<reco::GsfElectron>> elecs_;
+    edm::EDGetTokenT<edm::View<reco::Vertex>> pvs_;
+    edm::EDGetTokenT<std::vector<reco::PFJet>> jetToken_;
     /// trigger table
     edm::EDGetTokenT<edm::TriggerResults> triggerTable_;
     /// trigger paths for monitoring, expected
@@ -118,7 +119,7 @@ namespace TopSingleLepton {
     std::vector<std::string> triggerPaths_;
 
     /// electronId label
-    edm::EDGetTokenT<edm::ValueMap<float> > electronId_;
+    edm::EDGetTokenT<edm::ValueMap<float>> electronId_;
 
     /// electronId pattern we expect the following pattern:
     ///  0: fails
@@ -140,17 +141,17 @@ namespace TopSingleLepton {
 
     /// extra selection on electrons
 
-    std::unique_ptr<StringCutObjectSelector<reco::GsfElectron> > elecSelect_;
+    std::unique_ptr<StringCutObjectSelector<reco::GsfElectron>> elecSelect_;
 
     /// extra selection on primary vertices; meant to investigate the pile-up
     /// effect
-    std::unique_ptr<StringCutObjectSelector<reco::Vertex> > pvSelect_;
+    std::unique_ptr<StringCutObjectSelector<reco::Vertex>> pvSelect_;
 
     /// extra isolation criterion on muon
-    std::unique_ptr<StringCutObjectSelector<reco::Muon> > muonIso_;
+    std::unique_ptr<StringCutObjectSelector<reco::Muon>> muonIso_;
 
     /// extra selection on muons
-    std::unique_ptr<StringCutObjectSelector<reco::Muon> > muonSelect_;
+    std::unique_ptr<StringCutObjectSelector<reco::Muon>> muonSelect_;
 
     /// jetCorrector
     edm::EDGetTokenT<reco::JetCorrector> jetCorrector_;
@@ -158,11 +159,11 @@ namespace TopSingleLepton {
     /// jetID as an extra selection type
     edm::EDGetTokenT<reco::JetIDValueMap> jetIDLabel_;
 
-    std::unique_ptr<StringCutObjectSelector<reco::JetID> > jetIDSelect_;
+    std::unique_ptr<StringCutObjectSelector<reco::JetID>> jetIDSelect_;
     /// extra selection on jets
     std::string jetSelect_;
-    std::unique_ptr<StringCutObjectSelector<reco::PFJet> > jetlooseSelection_;
-    std::unique_ptr<StringCutObjectSelector<reco::PFJet> > jetSelection_;
+    std::unique_ptr<StringCutObjectSelector<reco::PFJet>> jetlooseSelection_;
+    std::unique_ptr<StringCutObjectSelector<reco::PFJet>> jetSelection_;
     /// include btag information or not
     /// to be determined from the cfg
     bool includeBTag_;
@@ -245,8 +246,8 @@ namespace TopSingleLepton {
 
     - jets  : of type reco::Jet (jets), reco::CaloJet (jets/calo) or reco::PFJet
    (jets/pflow)
-    - elecs : of type reco::PFCandidate
-    - muons : of type reco::PFCandidate
+    - elecs : of type reco::GsfElectron
+    - muons : of type reco::Muon
     - met   : of type reco::MET
 
    These types have to be present as prefix of the selection step paramter
@@ -289,13 +290,13 @@ private:
   /// trigger paths
   std::vector<std::string> triggerPaths_;
   /// string cut selector
-  std::unique_ptr<StringCutObjectSelector<reco::Vertex> > vertexSelect_;
+  std::unique_ptr<StringCutObjectSelector<reco::Vertex>> vertexSelect_;
 
   /// beamspot
   edm::InputTag beamspot_;
   edm::EDGetTokenT<reco::BeamSpot> beamspot__;
   /// string cut selector
-  std::unique_ptr<StringCutObjectSelector<reco::BeamSpot> > beamspotSelect_;
+  std::unique_ptr<StringCutObjectSelector<reco::BeamSpot>> beamspotSelect_;
 
   /// needed to guarantee the selection order as defined by the order of
   /// ParameterSets in the _selection_ vector as defined in the config
@@ -305,14 +306,14 @@ private:
   /// the configuration of the selection for the SelectionStep class,
   /// MonitoringEnsemble keeps an instance of the MonitorEnsemble class to
   /// be filled _after_ each selection step
-  std::map<std::string, std::pair<edm::ParameterSet, std::unique_ptr<TopSingleLepton::MonitorEnsemble> > > selection_;
-  std::unique_ptr<SelectionStep<reco::Muon> > MuonStep;
-  std::unique_ptr<SelectionStep<reco::GsfElectron> > ElectronStep;
-  std::unique_ptr<SelectionStep<reco::Vertex> > PvStep;
-  std::unique_ptr<SelectionStep<reco::MET> > METStep;
-  std::vector<std::unique_ptr<SelectionStep<reco::Jet> > > JetSteps;
-  std::vector<std::unique_ptr<SelectionStep<reco::CaloJet> > > CaloJetSteps;
-  std::vector<std::unique_ptr<SelectionStep<reco::PFJet> > > PFJetSteps;
+  std::map<std::string, std::pair<edm::ParameterSet, std::unique_ptr<TopSingleLepton::MonitorEnsemble>>> selection_;
+  std::unique_ptr<SelectionStep<reco::Muon>> MuonStep;
+  std::unique_ptr<SelectionStep<reco::GsfElectron>> ElectronStep;
+  std::unique_ptr<SelectionStep<reco::Vertex>> PvStep;
+  std::unique_ptr<SelectionStep<reco::MET>> METStep;
+  std::vector<std::unique_ptr<SelectionStep<reco::Jet>>> JetSteps;
+  std::vector<std::unique_ptr<SelectionStep<reco::CaloJet>>> CaloJetSteps;
+  std::vector<std::unique_ptr<SelectionStep<reco::PFJet>>> PFJetSteps;
 
   std::vector<edm::ParameterSet> sel_;
   edm::ParameterSet setup_;

--- a/DQM/Physics/src/TopSingleLeptonDQM_miniAOD.cc
+++ b/DQM/Physics/src/TopSingleLeptonDQM_miniAOD.cc
@@ -305,9 +305,9 @@ namespace TopSingleLepton_miniAOD {
     //hists_["jetBDiscVtx_"] = ibooker.book1D("JetBDiscVtx",
     //    "Disc_{SSVHE}(Jet)", 35, -1., 6.);
     // multiplicity for combined secondary vertex
-    hists_["jetMultBDeepJetM_"] = ibooker.book1D("JetMultBDeepJetM", "N_{30}(DeepJetM)", 10, 0., 10.);
+    hists_["jetMultBPNetM_"] = ibooker.book1D("JetMultBPNetM", "N_{30}(PNetM)", 10, 0., 10.);
     // btag discriminator for combined secondary vertex
-    hists_["jetBDeepJet_"] = ibooker.book1D("JetDiscDeepJet", "BJet Disc_{DeepJet}(JET)", 100, -1., 2.);
+    hists_["jetBPNet_"] = ibooker.book1D("JetDiscPNet", "BJet Disc_{PNet}(JET)", 100, -1., 2.);
     // pt of the 1. leading jet (uncorrected)
     //hists_["jet1PtRaw_"] = ibooker.book1D("Jet1PtRaw", "pt_{Raw}(jet1)", 60, 0., 300.);
     // pt of the 2. leading jet (uncorrected)
@@ -550,7 +550,7 @@ namespace TopSingleLepton_miniAOD {
     // loop jet collection
     std::vector<pat::Jet> correctedJets;
     std::vector<double> JetTagValues;
-    unsigned int mult = 0, loosemult = 0, multBDeepJetM = 0;
+    unsigned int mult = 0, loosemult = 0, multBPNetM = 0;
 
     edm::Handle<edm::View<pat::Jet>> jets;
     if (!event.getByToken(jets_, jets)) {
@@ -579,15 +579,18 @@ namespace TopSingleLepton_miniAOD {
         correctedJets.push_back(monitorJet);
         ++loosemult;  // determine jet multiplicity
 
-        double discriminator = monitorJet.bDiscriminator("pfDeepFlavourJetTags:probb") +
-                               monitorJet.bDiscriminator("pfDeepFlavourJetTags:probbb") +
-                               monitorJet.bDiscriminator("pfDeepFlavourJetTags:problepb");
+        //ParticleNet discriminator
+        
+        double discriminator =
+            monitorJet.bDiscriminator("pfParticleNetFromMiniAODAK4CHSCentralDiscriminatorsJetTags:BvsAll") > 0
+		            ? monitorJet.bDiscriminator("pfParticleNetFromMiniAODAK4CHSCentralDiscriminatorsJetTags:BvsAll")
+		            : -1;
 
-        fill("jetBDeepJet_", discriminator);  //hard coded discriminator and value right now.
-        if (discriminator > 0.2435)
-          ++multBDeepJetM;
+        fill("jetBPNet_", discriminator);  //hard coded discriminator and value right now.
+        if (discriminator > 0.1919)
+          ++multBPNetM;
 
-        // Fill a vector with Jet b-tag WP for later M3+1tag calculation: DeepJet
+        // Fill a vector with Jet b-tag WP for later M3+1tag calculation: PNet
         // tagger
         JetTagValues.push_back(discriminator);
         //    }
@@ -618,7 +621,7 @@ namespace TopSingleLepton_miniAOD {
     }
     fill("jetMult_", mult);
     fill("jetLooseMult_", loosemult);
-    fill("jetMultBDeepJetM_", multBDeepJetM);
+    fill("jetMultBPNetM_", multBPNetM);
 
     /*
   ------------------------------------------------------------
@@ -638,7 +641,7 @@ namespace TopSingleLepton_miniAOD {
         unsigned int idx = met_ - mets_.begin();
         if (idx == 0)
           fill("slimmedMETs_", met->begin()->et());
-        if (idx == 2)
+        if (idx == 1)
           fill("slimmedMETsPuppi_", met->begin()->et());
       }
     }
@@ -661,13 +664,13 @@ namespace TopSingleLepton_miniAOD {
       fill("massTop_", topMass);
     }
 
-    // Fill M3 with Btag (DeepJet Tight) requirement
+    // Fill M3 with Btag (PNet Tight) requirement
 
     // if (!includeBTag_) return;
     if (correctedJets.size() != JetTagValues.size())
       return;
 
-    double btopMass = eventKinematics.massBTopQuark(correctedJets, JetTagValues, 0.2435);  //hard coded DeepJet value
+    double btopMass = eventKinematics.massBTopQuark(correctedJets, JetTagValues, 0.2435);  //hard coded PNet value
 
     if (btopMass >= 0)
       fill("massBTop_", btopMass);

--- a/DQM/Physics/src/TopSingleLeptonDQM_miniAOD.cc
+++ b/DQM/Physics/src/TopSingleLeptonDQM_miniAOD.cc
@@ -580,11 +580,11 @@ namespace TopSingleLepton_miniAOD {
         ++loosemult;  // determine jet multiplicity
 
         //ParticleNet discriminator
-        
+
         double discriminator =
             monitorJet.bDiscriminator("pfParticleNetFromMiniAODAK4CHSCentralDiscriminatorsJetTags:BvsAll") > 0
-		            ? monitorJet.bDiscriminator("pfParticleNetFromMiniAODAK4CHSCentralDiscriminatorsJetTags:BvsAll")
-		            : -1;
+                ? monitorJet.bDiscriminator("pfParticleNetFromMiniAODAK4CHSCentralDiscriminatorsJetTags:BvsAll")
+                : -1;
 
         fill("jetBPNet_", discriminator);  //hard coded discriminator and value right now.
         if (discriminator > 0.1919)

--- a/DQM/Physics/test/topDQM_harvesting_cfg.py
+++ b/DQM/Physics/test/topDQM_harvesting_cfg.py
@@ -36,7 +36,7 @@ process.EDMtoMEConverter.convertOnEndRun  = True
 process.dqmSaver.saveByRun      = cms.untracked.int32( -1)
 process.dqmSaver.saveAtJobEnd   = cms.untracked.bool(True)
 process.dqmSaver.forceRunNumber = cms.untracked.int32(  1)
-process.dqmSaver.workflow       = cms.untracked.string('/TopVal/CMSSW_3_8_4/RECO') ## adapt apropriately
+process.dqmSaver.workflow       = cms.untracked.string('/TopVal/CMSSW_14_1_0_pre6/RECO') ## adapt apropriately
 
 
 ## path definitions

--- a/DQM/Physics/test/topDQM_harvesting_cfg.py
+++ b/DQM/Physics/test/topDQM_harvesting_cfg.py
@@ -36,7 +36,7 @@ process.EDMtoMEConverter.convertOnEndRun  = True
 process.dqmSaver.saveByRun      = cms.untracked.int32( -1)
 process.dqmSaver.saveAtJobEnd   = cms.untracked.bool(True)
 process.dqmSaver.forceRunNumber = cms.untracked.int32(  1)
-process.dqmSaver.workflow       = cms.untracked.string('/TopVal/CMSSW_14_1_0_pre6/RECO') ## adapt apropriately
+process.dqmSaver.workflow       = cms.untracked.string('/TopVal/CMSSW_14_2_0_pre4/RECO') ## adapt apropriately
 
 
 ## path definitions

--- a/DQM/Physics/test/topDQM_production_cfg.py
+++ b/DQM/Physics/test/topDQM_production_cfg.py
@@ -21,7 +21,7 @@ process.source.skipEvents = cms.untracked.uint32(0)
 
 #process.source.fileNames = ['/store/relval/CMSSW_11_1_0_pre2/RelValTTbar_14TeV/GEN-SIM-RECO/110X_mcRun4_realistic_v2_2026D49noPU-v1/20000/02837764-A8F6-214F-AEE2-BCAEAAD7952A.root']
 
-process.source.fileNames = ['/store/relval/CMSSW_11_1_0_pre2/RelValTTbar_14TeV/GEN-SIM-RECO/110X_mcRun3_2021_realistic_v6-v1/20000/A8E66994-05C0-104A-A0F3-4D393C7E30C8.root']
+process.source.fileNames = ['/store/relval/CMSSW_14_1_0_pre5/RelValTTbar_14TeV/GEN-SIM-RECO/PU_140X_mcRun3_2024_realistic_v11_STD_2024_PU-v1/2580000/0a22c2b9-713c-4134-abd7-664c8b34ce94.root']
 
 ## number of events
 process.maxEvents = cms.untracked.PSet(

--- a/DQM/Physics/test/topDQM_production_cfg.py
+++ b/DQM/Physics/test/topDQM_production_cfg.py
@@ -14,14 +14,10 @@ from Configuration.AlCa.GlobalTag import GlobalTag
 #process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T15', '')
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 
-
 process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring())
 process.source.skipEvents = cms.untracked.uint32(0)
 
-
-#process.source.fileNames = ['/store/relval/CMSSW_11_1_0_pre2/RelValTTbar_14TeV/GEN-SIM-RECO/110X_mcRun4_realistic_v2_2026D49noPU-v1/20000/02837764-A8F6-214F-AEE2-BCAEAAD7952A.root']
-
-process.source.fileNames = ['/store/relval/CMSSW_14_1_0_pre5/RelValTTbar_14TeV/GEN-SIM-RECO/PU_140X_mcRun3_2024_realistic_v11_STD_2024_PU-v1/2580000/0a22c2b9-713c-4134-abd7-664c8b34ce94.root']
+process.source.fileNames = ['root://cmsxrootd.fnal.gov//store/relval/CMSSW_14_2_0_pre3/RelValTTbar_14TeV/GEN-SIM-RECO/PU_140X_mcRun3_2024_realistic_v26_STD_2024_PU-v1/2590000/3c568c90-b6ff-43be-9b24-8b4e9d862185.root']
 
 ## number of events
 process.maxEvents = cms.untracked.PSet(
@@ -79,10 +75,10 @@ process.p      = cms.Path(
     #process.topSingleMuonMediumDQM     +
 #    process.EIsequence * 
     process.jetCorrectorsSeq * process.dqmAk4PFCHSL1FastL2L3CorrectorChain *
-    process.topSingleMuonMediumDQM     +
+    process.topSingleMuonMediumDQM      +
     #process.topSingleElectronLooseDQM  +
     #process.ak4PFCHSL1FastL2L3CorrectorChain * 
-    process.topSingleElectronMediumDQM +
+    process.topSingleElectronMediumDQM  +
     #process.ak4PFCHSL1FastL2L3CorrectorChain * 
     process.singleTopMuonMediumDQM      +
     #process.ak4PFCHSL1FastL2L3CorrectorChain * 

--- a/DQM/Physics/test/topDQM_production_miniAOD.py
+++ b/DQM/Physics/test/topDQM_production_miniAOD.py
@@ -15,10 +15,7 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 
 process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring())
 process.source.skipEvents = cms.untracked.uint32(0)
-process.source.fileNames = ['/store/mc/Run3Winter24MiniAOD/TT_TuneCP5_13p6TeV_powheg-pythia8/MINIAODSIM/133X_mcRun3_2024_realistic_v8-v2/2540000/01f73297-b0d8-4458-a1c0-34a17148ca4a.root'] 
-
-#process.source.fileNames = ['/store/relval/CMSSW_11_1_0_pre2/RelValTTbar_14TeV/MINIAODSIM/110X_mcRun3_2021_realistic_v6-v1/20000/F594311A-0167-1A41-9984-753E9AFB1279.root']
-
+process.source.fileNames = ['/store/relval/CMSSW_14_2_0_pre3/RelValTTbar_14TeV/MINIAODSIM/PU_140X_mcRun3_2024_realistic_v26_STD_2024_PU-v1/2590000/a102b4b1-a67d-4b75-ae76-438f4dde5deb.root']
 
 ## number of events
 process.maxEvents = cms.untracked.PSet(


### PR DESCRIPTION
### **Description of PR**

- The main changes expected relate to the histograms for the non mini AOD (RECO) directories of TOP DQM Production now being filled (to previously being empty) after the input tags for Muons, Electrons, Jets and the B-tags were updated to non obsolete tags included in the most recent input files for `CMSSW_14_2_0_pre3`. Fot the updated B-tags from the old CSV ones to deepCSV the working points were updated accordingly based on the 2018 campaign as described on the BTV internal wiki. 
- Other changes made include: 

1. the update from `<reco::PFCandidate>` objects which are obsolete to  f.e. `<reco::Muon>`, `<reco::GsfElectron>` per the relevant objects found in the input files used. 
2.  The update of selection cuts structure to remove unnecessary references and dependencies e.g. `mediumMuonCut = looseMuonCut + " muonRef.innerTrack.validFraction > 0.8"` becomes `mediumMuonCut = looseMuonCut + " innerTrack.validFraction > 0.8"`.
3. Some unnecessary checks in loops like: 
```
 if (muonit->muonRef().isNull())
        continue;
      reco::MuonRef muon = muonit->muonRef();
```
in [TopSingleLeptonDQM.cc](https://github.com/cms-sw/cmssw/blob/48600daa76c0dd3925eb34d216bc756ed556016d/DQM/Physics/src/TopSingleLeptonDQM.cc#L465) were removed completely.
4. Histograms for jets 3 and 4 were added to [SingleTopTChannelLeptonDQM.cc](https://github.com/cms-sw/cmssw/blob/master/DQM/Physics/src/SingleTopTChannelLeptonDQM.cc) for completion purposes and to align it with the [TopSingleLeptonDQM.cc](https://github.com/cms-sw/cmssw/blob/master/DQM/Physics/src/TopSingleLeptonDQM.cc) analysis.
5. Certain comments that were not useful or obsolete were removed to make the code more conscise. 

- There is a minor dependence on a previous PR number #44299 which dealt with the same issues for the miniAOD directories in the TOP DQM where the main focus was tag updating as in here.
- [BTV internal wiki 2018 campaign](https://btv-wiki.docs.cern.ch/ScaleFactors/UL2018/)

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

Changes have been made to the following files:

- DQM/Physics/interface/TopDQMHelpers.h
- DQM/Physics/python/singleTopDQM_cfi.py
- DQM/Physics/python/topSingleLeptonDQM_cfi.py
- DQM/Physics/src/SingleTopTChannelLeptonDQM.cc
- DQM/Physics/src/SingleTopTChannelLeptonDQM.h
- DQM/Physics/src/TopDQMHelpers.cc
- DQM/Physics/src/TopSingleLeptonDQM.cc
- DQM/Physics/src/TopSingleLeptonDQM.h
- DQM/Physics/test/topDQM_harvesting_cfg.py
- DQM/Physics/test/topDQM_production_cfg.py

To verify the results of the aforementioned actions the file `DQM/Physics/test/topDQM_production_cfg.py` was executed with `cmsRun` to produce a .root file that was then used as input for the `DQM/Physics/test/topDQM_harvesting_cfg.py` to produce a tree with the relevant histograms needed that were browsed using the TBrowser root feature. As evidence of the success of the task two of those histograms (one from `TopSingleMuonMediumDQM` and the other from `SingleTopElectronMediumDQM`) are attached on this PR.

![TopSingleMuonMediumDQM_step1_Jet1Pt](https://github.com/user-attachments/assets/577778d5-0388-4adb-9675-c2c58da22781)
![SingleTopElectronMediumDQM_step2_METPflow](https://github.com/user-attachments/assets/b3674441-7bc2-430b-b269-fd7d7b38a2a4)
