### PR TITLE
MTD reconstruction: save correct outermost hit position also for tracks w/o last hit in mtd

### DIFF
--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -620,6 +620,8 @@ private:
   const bool useSimVertex_;
   const float dzCut_;
   const float bsTimeSpread_;
+
+  static constexpr float trackMaxBtlEta_ = 1.5;
 };
 
 template <class TrackCollection>
@@ -1010,8 +1012,8 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
               mBTL.hit ? (float)(*track).outerRadius()
                        : (float)(*track).outerZ());  // save R of the outermost hit for BTL, z for ETL.
         } else {
-          outermostHitPosition.push_back(std::abs(track->eta()) < 1.48 ? (float)(*track).outerRadius()
-                                                                       : (float)(*track).outerZ());
+          outermostHitPosition.push_back(std::abs(track->eta()) < trackMaxBtlEta_ ? (float)(*track).outerRadius()
+                                                                                  : (float)(*track).outerZ());
         }
 
         LogTrace("TrackExtenderWithMTD") << "TrackExtenderWithMTD: tmtd " << tmtdMap << " +/- " << sigmatmtdMap

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -1004,9 +1004,15 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
 #endif
         npixBarrel.push_back(backtrack.hitPattern().numberOfValidPixelBarrelHits());
         npixEndcap.push_back(backtrack.hitPattern().numberOfValidPixelEndcapHits());
-        outermostHitPosition.push_back(
-            mBTL.hit ? (float)(*track).outerRadius()
-                     : (float)(*track).outerZ());  // save R of the outermost hit for BTL, z for ETL.
+
+        if (mBTL.hit || mETL.hit) {
+          outermostHitPosition.push_back(
+              mBTL.hit ? (float)(*track).outerRadius()
+                       : (float)(*track).outerZ());  // save R of the outermost hit for BTL, z for ETL.
+        } else {
+          outermostHitPosition.push_back(std::abs(track->eta()) < 1.48 ? (float)(*track).outerRadius()
+                                                                       : (float)(*track).outerZ());
+        }
 
         LogTrace("TrackExtenderWithMTD") << "TrackExtenderWithMTD: tmtd " << tmtdMap << " +/- " << sigmatmtdMap
                                          << " t0 " << t0Map << " +/- " << sigmat0Map << " tof pi/K/p " << tofpiMap


### PR DESCRIPTION
#### PR description:
This PR implement a fix of the outermost hit position value, saved by the TrackExtenterWithMTD class, for tracks w/o last hit in MTD.

#### PR validation:
The code compiles, runs and produces expected results. 
Tested on workflow 29607.0.