### PR TITLE
Avoid using past module for python2/3 compatibility

### DIFF
--- a/FWCore/ParameterSet/python/Types.py
+++ b/FWCore/ParameterSet/python/Types.py
@@ -3,12 +3,12 @@ from .Mixins import PrintOptions, _SimpleParameterTypeBase, _ParameterTypeBase, 
 from .Mixins import _ValidatingParameterListBase, specialImportRegistry
 from .Mixins import saveOrigin
 from .ExceptionHandling import format_typename, format_outerframe
-from past.builtins import long
 import codecs
 import copy
 import math
 import builtins
 
+long = int
 _builtin_bool = bool
 
 class _Untracked(object):

--- a/FWCore/PythonUtilities/scripts/generateEDF.py
+++ b/FWCore/PythonUtilities/scripts/generateEDF.py
@@ -2,7 +2,6 @@
 
 from builtins import zip
 from builtins import object
-from past.utils import old_div
 from builtins import range
 import sys
 import re
@@ -14,6 +13,9 @@ import math
 
 sepRE      = re.compile (r'[\s,;:]+')
 nonSpaceRE = re.compile (r'\S')
+
+def old_div(a, b):
+  return a // b
 
 ##########################
 ## #################### ##


### PR DESCRIPTION
We were using `past` python2/3 compatibility to support both `py2 and py3`. As CMSSW stack is `python3` only so this PR proposes to drop the use of  `past`. 

- `from past.builtins import long` : use `long=int` as https://github.com/PythonCharmers/python-future/blob/master/src/past/types/__init__.py#L26 was doing
- `from past.utils import old_div`: We can either use `floor division operator //` everywhere or just add our own `old_div` which does the same. 