### PR TITLE
avoid holding memory between events in Multi5x5ClusterProducer 

### DIFF
--- a/RecoEcal/EgammaClusterProducers/src/Multi5x5ClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/Multi5x5ClusterProducer.cc
@@ -14,6 +14,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
@@ -24,6 +25,7 @@
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "RecoEcal/EgammaClusterAlgos/interface/Multi5x5ClusterAlgo.h"
 #include "RecoEcal/EgammaCoreTools/interface/PositionCalc.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
 #include <ctime>
 #include <iostream>
@@ -34,142 +36,113 @@ class Multi5x5ClusterProducer : public edm::stream::EDProducer<> {
 public:
   Multi5x5ClusterProducer(const edm::ParameterSet& ps);
 
-  ~Multi5x5ClusterProducer() override;
+  void produce(edm::Event&, const edm::EventSetup&) final;
 
-  void produce(edm::Event&, const edm::EventSetup&) override;
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
 
 private:
-  int nMaxPrintout_;  // max # of printouts
-  int nEvt_;          // internal counter of events
+  const edm::EDGetTokenT<EcalRecHitCollection> barrelHitToken_;
+  const edm::EDGetTokenT<EcalRecHitCollection> endcapHitToken_;
+  const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeometryToken_;
+
+  const edm::EDPutTokenT<reco::BasicClusterCollection> barrelToken_;
+  const edm::EDPutTokenT<reco::BasicClusterCollection> endcapToken_;
+
+  Multi5x5ClusterAlgo island_;
 
   // cluster which regions
-  bool doBarrel_;
-  bool doEndcap_;
+  const bool doBarrel_;
+  const bool doEndcap_;
 
-  edm::EDGetTokenT<EcalRecHitCollection> barrelHitToken_;
-  edm::EDGetTokenT<EcalRecHitCollection> endcapHitToken_;
-  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeometryToken_;
+  reco::BasicClusterCollection clusterizeECALPart(const EcalRecHitCollection& hits,
+                                                  const edm::EventSetup& es,
+                                                  const reco::CaloID::Detectors detector);
 
-  std::string barrelClusterCollection_;
-  std::string endcapClusterCollection_;
-
-  PositionCalc posCalculator_;  // position calculation algorithm
-  Multi5x5ClusterAlgo* island_p;
-
-  bool counterExceeded() const { return ((nEvt_ > nMaxPrintout_) || (nMaxPrintout_ < 0)); }
-
-  const EcalRecHitCollection* getCollection(edm::Event& evt, const edm::EDGetTokenT<EcalRecHitCollection>& token);
-
-  void clusterizeECALPart(edm::Event& evt,
-                          const edm::EventSetup& es,
-                          const edm::EDGetTokenT<EcalRecHitCollection>& token,
-                          const std::string& clusterCollection,
-                          const reco::CaloID::Detectors detector);
-
-  void outputValidationInfo(reco::CaloClusterPtrVector& clusterPtrVector);
+  reco::BasicClusterCollection makeClusters(const EcalRecHitCollection& hits,
+                                            const CaloSubdetectorGeometry* geom,
+                                            const CaloSubdetectorGeometry* preshower,
+                                            const CaloSubdetectorTopology* topology,
+                                            const reco::CaloID::Detectors detector);
 };
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(Multi5x5ClusterProducer);
 
-Multi5x5ClusterProducer::Multi5x5ClusterProducer(const edm::ParameterSet& ps) {
-  // Parameters to identify the hit collections
-  barrelHitToken_ = consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("barrelHitTag"));
+Multi5x5ClusterProducer::Multi5x5ClusterProducer(const edm::ParameterSet& ps)
+    : barrelHitToken_{consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("barrelHitTag"))},
+      endcapHitToken_{consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("endcapHitTag"))},
+      caloGeometryToken_{esConsumes<CaloGeometry, CaloGeometryRecord>()},
+      barrelToken_{produces<reco::BasicClusterCollection>(ps.getParameter<std::string>("barrelClusterCollection"))},
+      endcapToken_{produces<reco::BasicClusterCollection>(ps.getParameter<std::string>("endcapClusterCollection"))},
+      island_{ps.getParameter<double>("IslandBarrelSeedThr"),
+              ps.getParameter<double>("IslandEndcapSeedThr"),
+              StringToEnumValue<EcalRecHit::Flags>(ps.getParameter<std::vector<std::string>>("RecHitFlagToBeExcluded")),
+              PositionCalc(ps.getParameter<edm::ParameterSet>("posCalcParameters")),
+              ps.getParameter<bool>("reassignSeedCrysToClusterItSeeds")},
+      doBarrel_{ps.getParameter<bool>("doBarrel")},
+      doEndcap_{ps.getParameter<bool>("doEndcap")} {}
 
-  endcapHitToken_ = consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("endcapHitTag"));
+void Multi5x5ClusterProducer::fillDescriptions(edm::ConfigurationDescriptions& iDesc) {
+  edm::ParameterSetDescription ps;
+  ps.add<edm::InputTag>("barrelHitTag");
+  ps.add<edm::InputTag>("endcapHitTag");
+  ps.add<bool>("doEndcap");
+  ps.add<bool>("doBarrel");
+  ps.add<std::string>("barrelClusterCollection");
+  ps.add<std::string>("endcapClusterCollection");
+  ps.add<double>("IslandBarrelSeedThr");
+  ps.add<double>("IslandEndcapSeedThr");
+  ps.add<std::vector<std::string>>("RecHitFlagToBeExcluded");
 
-  //EventSetup Token for CaloGeometry
-  caloGeometryToken_ = esConsumes<CaloGeometry, CaloGeometryRecord>();
+  edm::ParameterSetDescription posCal;
+  posCal.add<bool>("LogWeighted");
+  posCal.add<double>("T0_barl");
+  posCal.add<double>("T0_endc");
+  posCal.add<double>("T0_endcPresh");
+  posCal.add<double>("W0");
+  posCal.add<double>("X0");
+  ps.add<edm::ParameterSetDescription>("posCalcParameters", posCal);
 
-  // should cluster algo be run in barrel and endcap?
-  doEndcap_ = ps.getParameter<bool>("doEndcap");
-  doBarrel_ = ps.getParameter<bool>("doBarrel");
-
-  // The names of the produced cluster collections
-  barrelClusterCollection_ = ps.getParameter<std::string>("barrelClusterCollection");
-  endcapClusterCollection_ = ps.getParameter<std::string>("endcapClusterCollection");
-
-  // Island algorithm parameters
-  double barrelSeedThreshold = ps.getParameter<double>("IslandBarrelSeedThr");
-  double endcapSeedThreshold = ps.getParameter<double>("IslandEndcapSeedThr");
-
-  const std::vector<std::string> flagnames = ps.getParameter<std::vector<std::string> >("RecHitFlagToBeExcluded");
-
-  const std::vector<int> v_chstatus = StringToEnumValue<EcalRecHit::Flags>(flagnames);
-
-  // Parameters for the position calculation:
-  edm::ParameterSet posCalcParameters = ps.getParameter<edm::ParameterSet>("posCalcParameters");
-  posCalculator_ = PositionCalc(posCalcParameters);
-
-  // Produces a collection of barrel and a collection of endcap clusters
-  produces<reco::BasicClusterCollection>(endcapClusterCollection_);
-  produces<reco::BasicClusterCollection>(barrelClusterCollection_);
-
-  bool reassignSeedCrysToClusterItSeeds = false;
-  if (ps.exists("reassignSeedCrysToClusterItSeeds"))
-    reassignSeedCrysToClusterItSeeds = ps.getParameter<bool>("reassignSeedCrysToClusterItSeeds");
-
-  island_p = new Multi5x5ClusterAlgo(
-      barrelSeedThreshold, endcapSeedThreshold, v_chstatus, posCalculator_, reassignSeedCrysToClusterItSeeds);
-
-  nEvt_ = 0;
+  ps.add<bool>("reassignSeedCrysToClusterItSeeds", false);
+  iDesc.addDefault(ps);
 }
-
-Multi5x5ClusterProducer::~Multi5x5ClusterProducer() { delete island_p; }
 
 void Multi5x5ClusterProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
   if (doEndcap_) {
-    clusterizeECALPart(evt, es, endcapHitToken_, endcapClusterCollection_, reco::CaloID::DET_ECAL_ENDCAP);
+    // get the hit collection from the event:
+    const EcalRecHitCollection& hitCollection = evt.get(endcapHitToken_);
+    evt.emplace(endcapToken_, clusterizeECALPart(hitCollection, es, reco::CaloID::DET_ECAL_ENDCAP));
   }
   if (doBarrel_) {
-    clusterizeECALPart(evt, es, barrelHitToken_, barrelClusterCollection_, reco::CaloID::DET_ECAL_BARREL);
+    // get the hit collection from the event:
+    const EcalRecHitCollection& hitCollection = evt.get(barrelHitToken_);
+    evt.emplace(barrelToken_, clusterizeECALPart(hitCollection, es, reco::CaloID::DET_ECAL_BARREL));
   }
-
-  nEvt_++;
 }
 
-const EcalRecHitCollection* Multi5x5ClusterProducer::getCollection(
-    edm::Event& evt, const edm::EDGetTokenT<EcalRecHitCollection>& token) {
-  edm::Handle<EcalRecHitCollection> rhcHandle;
-  evt.getByToken(token, rhcHandle);
-  return rhcHandle.product();
-}
-
-void Multi5x5ClusterProducer::clusterizeECALPart(edm::Event& evt,
-                                                 const edm::EventSetup& es,
-                                                 const edm::EDGetTokenT<EcalRecHitCollection>& token,
-                                                 const std::string& clusterCollection,
-                                                 const reco::CaloID::Detectors detector) {
-  // get the hit collection from the event:
-  const EcalRecHitCollection* hitCollection_p = getCollection(evt, token);
-
-  // get the geometry and topology from the event setup:
-  edm::ESHandle<CaloGeometry> geoHandle = es.getHandle(caloGeometryToken_);
-
-  const CaloSubdetectorGeometry* geometry_p;
-  std::unique_ptr<CaloSubdetectorTopology> topology_p;
-
-  if (detector == reco::CaloID::DET_ECAL_BARREL) {
-    geometry_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
-    topology_p = std::make_unique<EcalBarrelTopology>(*geoHandle);
-  } else {
-    geometry_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
-    topology_p = std::make_unique<EcalEndcapTopology>(*geoHandle);
-  }
-
-  const CaloSubdetectorGeometry* geometryES_p;
-  geometryES_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
-
+reco::BasicClusterCollection Multi5x5ClusterProducer::makeClusters(const EcalRecHitCollection& hits,
+                                                                   const CaloSubdetectorGeometry* geom,
+                                                                   const CaloSubdetectorGeometry* preshower,
+                                                                   const CaloSubdetectorTopology* topology,
+                                                                   const reco::CaloID::Detectors detector) {
   // Run the clusterization algorithm:
-  reco::BasicClusterCollection clusters;
-  clusters = island_p->makeClusters(hitCollection_p, geometry_p, topology_p.get(), geometryES_p, detector);
+  return island_.makeClusters(&hits, geom, topology, preshower, detector);
+}
 
-  // create a unique_ptr to a BasicClusterCollection, copy the barrel clusters into it and put in the Event:
-  auto clusters_p = std::make_unique<reco::BasicClusterCollection>();
-  clusters_p->assign(clusters.begin(), clusters.end());
-  edm::OrphanHandle<reco::BasicClusterCollection> bccHandle;
-  if (detector == reco::CaloID::DET_ECAL_BARREL)
-    bccHandle = evt.put(std::move(clusters_p), barrelClusterCollection_);
-  else
-    bccHandle = evt.put(std::move(clusters_p), endcapClusterCollection_);
+reco::BasicClusterCollection Multi5x5ClusterProducer::clusterizeECALPart(const EcalRecHitCollection& hitCollection,
+                                                                         const edm::EventSetup& es,
+                                                                         const reco::CaloID::Detectors detector) {
+  // get the geometry and topology from the event setup:
+  CaloGeometry const& geo = es.getData(caloGeometryToken_);
+
+  const CaloSubdetectorGeometry* preshower_p = geo.getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
+  if (detector == reco::CaloID::DET_ECAL_BARREL) {
+    auto geometry_p = geo.getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
+    EcalBarrelTopology topology{geo};
+    return makeClusters(hitCollection, geometry_p, preshower_p, &topology, detector);
+  } else {
+    auto geometry_p = geo.getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
+    EcalEndcapTopology topology{geo};
+    return makeClusters(hitCollection, geometry_p, preshower_p, &topology, detector);
+  }
 }


### PR DESCRIPTION
#### PR description:

- modernized Multi5x5ClusterProducer
  - added fillDescriptions
- reworked Multi5x5ClusterAlgo
  - removed use of member data just for temporary storage
  - moved code doing related things into new functions/classes
  - use more modern C++ constructs

The holding and then clearing of memory across events was found by a prototype Alloc Monitor service.

NOTE: the only reason I could not change Multi5x5ClusterProducer to be a global module was the use of `PositionCalc` in Multi5x5ClusterAlgo.

#### PR validation:

Code compiles and running a very simple RECO job succeeded.

This is purely a refactoring so should not affect any physics results.