### PR TITLE
[UBSAN][LST]Fix runtime error by keep the region object alive

### DIFF
--- a/RecoTracker/LST/plugins/LSTOutputConverter.cc
+++ b/RecoTracker/LST/plugins/LSTOutputConverter.cc
@@ -194,8 +194,8 @@ void LSTOutputConverter::produce(edm::Event& iEvent, const edm::EventSetup& iSet
           hitsForSeed.emplace_back(dynamic_cast<Hit>(&hit));
           nHits++;
         }
-
-        seedCreator_->init(GlobalTrackingRegion(), iSetup, nullptr);
+        GlobalTrackingRegion region;
+        seedCreator_->init(region, iSetup, nullptr);
         seedCreator_->makeSeed(seeds, hitsForSeed);
         if (seeds.empty()) {
           edm::LogInfo("LSTOutputConverter")


### PR DESCRIPTION
This should fix the UBSAN runtime error [a]. The issue is that `GlobalTrackingRegion()` gets destroyed after the https://github.com/cms-sw/cmssw/blob/CMSSW_14_2_UBSAN_X_2024-11-20-2300/RecoTracker/LST/plugins/LSTOutputConverter.cc#L198C28-L198C50 call and the pointer to this stored https://github.com/cms-sw/cmssw/blob/CMSSW_14_2_UBSAN_X_2024-11-20-2300/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsCreator.cc#L55 is invalid when `seedCreator_->makeSeed(seeds, hitsForSeed);` call is make

[a] https://cmssdt.cern.ch/SDT/jenkins-artifacts/ubsan_logs/CMSSW_14_2_X_2024-11-20-2300/
```
[1 RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsCreator.cc:119:48: runtime error: member call on address 0x7ffc2e1a4fb0 which does not point to an object of type 'TrackingRegion'](https://cmssdt.cern.ch/SDT/jenkins-artifacts/ubsan_logs/CMSSW_14_2_X_2024-11-20-2300/logs/e2/e29e8ea225af97ed47471854089ce942/log)
[1 RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsCreator.cc:149:48: runtime error: member call on address 0x14f6e55f8680 which does not point to an object of type 'TrackingRegion'](https://cmssdt.cern.ch/SDT/jenkins-artifacts/ubsan_logs/CMSSW_14_2_X_2024-11-20-2300/logs/59/59239ac295c69eb51ea906bb27ee3f55/log)
[1 RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsCreator.cc:82:24: runtime error: member call on address 0x14f6e75f7680 which does not point to an object of type 'TrackingRegion'](https://cmssdt.cern.ch/SDT/jenkins-artifacts/ubsan_logs/CMSSW_14_2_X_2024-11-20-2300/logs/a9/a9209aee6ea190192918bd5dde34a8b1/log)
```

- https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc12/CMSSW_14_2_UBSAN_X_2024-11-20-2300/pyRelValMatrixLogs/run/24834.703_TTbar_14TeV+Run4D98_lstOnCPUIters01TrackingOnly/step3_TTbar_14TeV+Run4D98_lstOnCPUIters01TrackingOnly.log#/
```
src/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsCreator.cc:119:48: runtime error: member call on address 0x7ffc2e1a4fb0 which does not point to an object of type 'TrackingRegion'
0x7ffc2e1a4fb0: note: object has invalid vptr
 03 00 00 00  40 4c dc 9c f7 14 00 00  80 4c dc 9c f7 14 00 00  80 4c dc 9c f7 14 00 00  00 00 00 00
    #0 0x14f684bf3e4d in SeedFromConsecutiveHitsCreator::initialKinematic(GlobalTrajectoryParameters&, SeedingHitSet const&) const src/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsCreator.cc:119
    #1 0x14f684c10535 in SeedFromConsecutiveHitsCreator::makeSeed(std::vector<TrajectorySeed, std::allocator<TrajectorySeed> >&, SeedingHitSet const&) src/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsCreator.cc:74
    #2 0x14f683fbf896 in LSTOutputConverter::produce(edm::Event&, edm::EventSetup const&) src/RecoTracker/LST/plugins/LSTOutputConverter.cc:199
    #3 0x14f7d58db29f in edm::stream::EDProducerAdaptorBase::doEvent(edm::EventTransitionInfo const&, edm::ActivityRegistry*, edm::ModuleCallingContext const*) src/FWCore/Framework/src/stream/EDProducerAdaptorBase.cc:83
```
```
