### PR TITLE
(HLT) fix service discovery in HLTriggerJSONMonitoring

### DIFF
--- a/HLTrigger/JSONMonitoring/plugins/HLTriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/HLTriggerJSONMonitoring.cc
@@ -430,11 +430,8 @@ void HLTriggerJSONMonitoring::globalEndLuminosityBlockSummary(edm::LuminosityBlo
   unsigned int run = lumi.run();
 
   bool writeFiles = true;
-  if (edm::Service<evf::FastMonitoringService*>().isAvailable()) {
-    evf::FastMonitoringService* fms =
-        (evf::FastMonitoringService*)(edm::Service<evf::FastMonitoringService*>().operator->());
-    if (fms)
-      writeFiles = fms->shouldWriteFiles(ls);
+  if (edm::Service<evf::FastMonitoringService>().isAvailable()) {
+    writeFiles = edm::Service<evf::FastMonitoringService>()->shouldWriteFiles(ls);
   }
   if (not writeFiles)
     return;

--- a/HLTrigger/JSONMonitoring/plugins/HLTriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/HLTriggerJSONMonitoring.cc
@@ -429,12 +429,10 @@ void HLTriggerJSONMonitoring::globalEndLuminosityBlockSummary(edm::LuminosityBlo
   unsigned int ls = lumi.luminosityBlock();
   unsigned int run = lumi.run();
 
-  bool writeFiles = true;
   if (edm::Service<evf::FastMonitoringService>().isAvailable()) {
-    writeFiles = edm::Service<evf::FastMonitoringService>()->shouldWriteFiles(ls);
+    if (!edm::Service<evf::FastMonitoringService>()->shouldWriteFiles(ls))
+      return;
   }
-  if (not writeFiles)
-    return;
 
   unsigned int processed = lumidata->processed.value().at(0);
   auto const& rundata = *runCache(lumi.getRun().index());

--- a/HLTrigger/JSONMonitoring/plugins/L1TriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/L1TriggerJSONMonitoring.cc
@@ -367,10 +367,7 @@ void L1TriggerJSONMonitoring::globalEndLuminosityBlockSummary(edm::LuminosityBlo
 
   bool writeFiles = true;
   if (edm::Service<evf::FastMonitoringService>().isAvailable()) {
-    evf::FastMonitoringService* fms =
-        (evf::FastMonitoringService*)(edm::Service<evf::FastMonitoringService>().operator->());
-    if (fms)
-      writeFiles = fms->shouldWriteFiles(ls);
+    writeFiles = edm::Service<evf::FastMonitoringService>()->shouldWriteFiles(ls);
   }
   if (not writeFiles)
     return;

--- a/HLTrigger/JSONMonitoring/plugins/L1TriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/L1TriggerJSONMonitoring.cc
@@ -365,12 +365,10 @@ void L1TriggerJSONMonitoring::globalEndLuminosityBlockSummary(edm::LuminosityBlo
   unsigned int ls = lumi.luminosityBlock();
   unsigned int run = lumi.run();
 
-  bool writeFiles = true;
   if (edm::Service<evf::FastMonitoringService>().isAvailable()) {
-    writeFiles = edm::Service<evf::FastMonitoringService>()->shouldWriteFiles(ls);
+    if (!edm::Service<evf::FastMonitoringService>()->shouldWriteFiles(ls))
+      return;
   }
-  if (not writeFiles)
-    return;
 
   unsigned int processed = lumidata->processed.value().at(0);
   auto const& rundata = *runCache(lumi.getRun().index());


### PR DESCRIPTION
#### PR description:

Service template type should not be a pointer. This caused FastMonitoringService service to not be detected and caused output not being suppressed when exception is thrown in HLT.

#### PR validation:

Modification was tested on replayed error stream data from 2024 HI run and fixes the problem.