### PR TITLE
Fix off by 1 error in Multi5x5ClusterAlgo

### DIFF
--- a/RecoEcal/EgammaClusterAlgos/src/Multi5x5ClusterAlgo.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/Multi5x5ClusterAlgo.cc
@@ -137,7 +137,7 @@ namespace {
       clusters_.push_back(std::move(c));
       if (reassignSeedCrysToClusterItSeeds_) {
         for (auto const& hit : clusters_.back().hits()) {
-          whichClusCrysBelongsTo_.push_back(std::pair<DetId, int>(hit.first, clusters_.size()));
+          whichClusCrysBelongsTo_.push_back(std::pair<DetId, int>(hit.first, clusters_.size() - 1));
         }
       }
     }


### PR DESCRIPTION
#### PR description:

This fixes an off by one error introduced in #46756

#### PR validation:

Added printout of Clusters in the changed module both before and after #46756 and found differences with hits in cluster. With this change the printouts now match the results of before the PR.