### PR TITLE
Reduced allocations in  ShiftedJetProducerT

### DIFF
--- a/CondFormats/JetMETObjects/interface/JetCorrectionUncertainty.h
+++ b/CondFormats/JetMETObjects/interface/JetCorrectionUncertainty.h
@@ -1,11 +1,10 @@
 #ifndef JetCorrectionUncertainty_h
 #define JetCorrectionUncertainty_h
 
-#include "CondFormats/Serialization/interface/Serializable.h"
-
 #include <string>
 #include <vector>
-class SimpleJetCorrectionUncertainty;
+#include "CondFormats/JetMETObjects/interface/SimpleJetCorrectionUncertainty.h"
+
 class JetCorrectorParameters;
 
 class JetCorrectionUncertainty {
@@ -15,7 +14,8 @@ public:
   JetCorrectionUncertainty(const JetCorrectorParameters& fParameters);
   JetCorrectionUncertainty(const JetCorrectionUncertainty&) = delete;
   JetCorrectionUncertainty& operator=(const JetCorrectionUncertainty&) = delete;
-  ~JetCorrectionUncertainty();
+  JetCorrectionUncertainty& operator=(JetCorrectionUncertainty&&) = default;
+  ~JetCorrectionUncertainty() = default;
 
   void setParameters(const std::string& fDataFile);
   void setJetEta(float fEta);
@@ -50,7 +50,7 @@ private:
   bool mIsLepPxset;
   bool mIsLepPyset;
   bool mIsLepPzset;
-  SimpleJetCorrectionUncertainty* mUncertainty;
+  SimpleJetCorrectionUncertainty mUncertainty;
 };
 
 #endif

--- a/CondFormats/JetMETObjects/interface/SimpleJetCorrectionUncertainty.h
+++ b/CondFormats/JetMETObjects/interface/SimpleJetCorrectionUncertainty.h
@@ -1,28 +1,26 @@
 #ifndef SimpleJetCorrectionUncertainty_h
 #define SimpleJetCorrectionUncertainty_h
 
-#include "CondFormats/Serialization/interface/Serializable.h"
-
 #include <string>
 #include <vector>
-class JetCorrectorParameters;
+#include "CondFormats/JetMETObjects/interface/JetCorrectorParameters.h"
 
 class SimpleJetCorrectionUncertainty {
 public:
-  SimpleJetCorrectionUncertainty();
+  SimpleJetCorrectionUncertainty() = default;
   SimpleJetCorrectionUncertainty(const std::string& fDataFile);
   SimpleJetCorrectionUncertainty(const JetCorrectorParameters& fParameters);
   SimpleJetCorrectionUncertainty(const SimpleJetCorrectionUncertainty&) = delete;
   SimpleJetCorrectionUncertainty& operator=(const SimpleJetCorrectionUncertainty&) = delete;
-  ~SimpleJetCorrectionUncertainty();
-  const JetCorrectorParameters& parameters() const { return *mParameters; }
+  SimpleJetCorrectionUncertainty& operator=(SimpleJetCorrectionUncertainty&&) = default;
+  ~SimpleJetCorrectionUncertainty() = default;
+  const JetCorrectorParameters& parameters() const { return mParameters; }
   float uncertainty(const std::vector<float>& fX, float fY, bool fDirection) const;
 
 private:
-  int findBin(const std::vector<float>& v, float x) const;
   float uncertaintyBin(unsigned fBin, float fY, bool fDirection) const;
   float linearInterpolation(float fZ, const float fX[2], const float fY[2]) const;
-  JetCorrectorParameters* mParameters;
+  JetCorrectorParameters mParameters;
 };
 
 #endif

--- a/CondFormats/JetMETObjects/src/JetCorrectionUncertainty.cc
+++ b/CondFormats/JetMETObjects/src/JetCorrectionUncertainty.cc
@@ -27,10 +27,9 @@ JetCorrectionUncertainty::JetCorrectionUncertainty() {
   mIsLepPyset = false;
   mIsLepPzset = false;
   mAddLepToJet = false;
-  mUncertainty = new SimpleJetCorrectionUncertainty();
 }
 /////////////////////////////////////////////////////////////////////////
-JetCorrectionUncertainty::JetCorrectionUncertainty(const std::string& fDataFile) {
+JetCorrectionUncertainty::JetCorrectionUncertainty(const std::string& fDataFile) : mUncertainty{fDataFile} {
   mJetEta = -9999;
   mJetPt = -9999;
   mJetPhi = -9999;
@@ -48,10 +47,10 @@ JetCorrectionUncertainty::JetCorrectionUncertainty(const std::string& fDataFile)
   mIsLepPyset = false;
   mIsLepPzset = false;
   mAddLepToJet = false;
-  mUncertainty = new SimpleJetCorrectionUncertainty(fDataFile);
 }
 /////////////////////////////////////////////////////////////////////////
-JetCorrectionUncertainty::JetCorrectionUncertainty(const JetCorrectorParameters& fParameters) {
+JetCorrectionUncertainty::JetCorrectionUncertainty(const JetCorrectorParameters& fParameters)
+    : mUncertainty{fParameters} {
   mJetEta = -9999;
   mJetPt = -9999;
   mJetPhi = -9999;
@@ -69,23 +68,19 @@ JetCorrectionUncertainty::JetCorrectionUncertainty(const JetCorrectorParameters&
   mIsLepPyset = false;
   mIsLepPzset = false;
   mAddLepToJet = false;
-  mUncertainty = new SimpleJetCorrectionUncertainty(fParameters);
 }
-/////////////////////////////////////////////////////////////////////////
-JetCorrectionUncertainty::~JetCorrectionUncertainty() { delete mUncertainty; }
 /////////////////////////////////////////////////////////////////////////
 void JetCorrectionUncertainty::setParameters(const std::string& fDataFile) {
   //---- delete the mParameters pointer before setting the new address ---
-  delete mUncertainty;
-  mUncertainty = new SimpleJetCorrectionUncertainty(fDataFile);
+  mUncertainty = SimpleJetCorrectionUncertainty(fDataFile);
 }
 /////////////////////////////////////////////////////////////////////////
 float JetCorrectionUncertainty::getUncertainty(bool fDirection) {
   float result;
   std::vector<float> vx, vy;
-  vx = fillVector(mUncertainty->parameters().definitions().binVar());
-  vy = fillVector(mUncertainty->parameters().definitions().parVar());
-  result = mUncertainty->uncertainty(vx, vy[0], fDirection);
+  vx = fillVector(mUncertainty.parameters().definitions().binVar());
+  vy = fillVector(mUncertainty.parameters().definitions().parVar());
+  result = mUncertainty.uncertainty(vx, vy[0], fDirection);
   mIsJetEset = false;
   mIsJetPtset = false;
   mIsJetPhiset = false;

--- a/CondFormats/JetMETObjects/src/JetCorrectionUncertainty.cc
+++ b/CondFormats/JetMETObjects/src/JetCorrectionUncertainty.cc
@@ -71,7 +71,6 @@ JetCorrectionUncertainty::JetCorrectionUncertainty(const JetCorrectorParameters&
 }
 /////////////////////////////////////////////////////////////////////////
 void JetCorrectionUncertainty::setParameters(const std::string& fDataFile) {
-  //---- delete the mParameters pointer before setting the new address ---
   mUncertainty = SimpleJetCorrectionUncertainty(fDataFile);
 }
 /////////////////////////////////////////////////////////////////////////

--- a/CondFormats/JetMETObjects/src/SimpleJetCorrectionUncertainty.cc
+++ b/CondFormats/JetMETObjects/src/SimpleJetCorrectionUncertainty.cc
@@ -5,21 +5,14 @@
 #include <string>
 
 /////////////////////////////////////////////////////////////////////////
-SimpleJetCorrectionUncertainty::SimpleJetCorrectionUncertainty() { mParameters = new JetCorrectorParameters(); }
+SimpleJetCorrectionUncertainty::SimpleJetCorrectionUncertainty(const std::string& fDataFile) : mParameters{fDataFile} {}
 /////////////////////////////////////////////////////////////////////////
-SimpleJetCorrectionUncertainty::SimpleJetCorrectionUncertainty(const std::string& fDataFile) {
-  mParameters = new JetCorrectorParameters(fDataFile);
-}
-/////////////////////////////////////////////////////////////////////////
-SimpleJetCorrectionUncertainty::SimpleJetCorrectionUncertainty(const JetCorrectorParameters& fParameters) {
-  mParameters = new JetCorrectorParameters(fParameters);
-}
-/////////////////////////////////////////////////////////////////////////
-SimpleJetCorrectionUncertainty::~SimpleJetCorrectionUncertainty() { delete mParameters; }
+SimpleJetCorrectionUncertainty::SimpleJetCorrectionUncertainty(const JetCorrectorParameters& fParameters)
+    : mParameters{fParameters} {}
 /////////////////////////////////////////////////////////////////////////
 float SimpleJetCorrectionUncertainty::uncertainty(const std::vector<float>& fX, float fY, bool fDirection) const {
   float result = 1.;
-  int bin = mParameters->binIndex(fX);
+  int bin = mParameters.binIndex(fX);
   if (bin < 0) {
     edm::LogError("SimpleJetCorrectionUncertainty") << " bin variables out of range";
     result = -999.0;
@@ -28,31 +21,49 @@ float SimpleJetCorrectionUncertainty::uncertainty(const std::vector<float>& fX, 
   return result;
 }
 /////////////////////////////////////////////////////////////////////////
+namespace {
+  class Span3 {
+  public:
+    Span3(std::vector<float> const& iFrom, int offset = 0) : start_{iFrom.data() + offset}, size_{iFrom.size() / 3} {}
+    float last() const { return fromIndex(size_ - 1); }
+    float operator[](std::size_t i) const { return fromIndex(i); }
+    std::size_t size() const { return size_; }
+
+  private:
+    float fromIndex(std::size_t i) const { return *(start_ + 3 * i); }
+    float const* start_;
+    std::size_t size_;
+  };
+  int findBin(const Span3& v, float x) {
+    int n = v.size() - 1;
+    if (n <= 0)
+      return -1;
+    if (x < v[0] || x >= v[n])
+      return -1;
+    for (int i = 0; i < n; i++) {
+      if (x >= v[i] && x < v[i + 1])
+        return i;
+    }
+    return 0;
+  }
+}  // namespace
 float SimpleJetCorrectionUncertainty::uncertaintyBin(unsigned fBin, float fY, bool fDirection) const {
-  if (fBin >= mParameters->size()) {
+  if (fBin >= mParameters.size()) {
     edm::LogError("SimpleJetCorrectionUncertainty")
-        << " wrong bin: " << fBin << ": only " << mParameters->size() << " are available";
+        << " wrong bin: " << fBin << ": only " << mParameters.size() << " are available";
     return -999.0;
   }
-  const std::vector<float>& p = mParameters->record(fBin).parameters();
-  if ((p.size() % 3) != 0)
+  const std::vector<float>& p = mParameters.record(fBin).parameters();
+  if ((p.size() % 3) != 0 or p.size() == 0)
     throw cms::Exception("SimpleJetCorrectionUncertainty")
         << "wrong # of parameters: multiple of 3 expected, " << p.size() << " got";
-  std::vector<float> yGrid, value;
-  unsigned int N = p.size() / 3;
+  Span3 yGrid{p};
+  Span3 value{p, fDirection ? 1 : 2};
   float result = -1.0;
-  for (unsigned i = 0; i < N; i++) {
-    unsigned ind = 3 * i;
-    yGrid.push_back(p[ind]);
-    if (fDirection)  // true = UP
-      value.push_back(p[ind + 1]);
-    else  // false = DOWN
-      value.push_back(p[ind + 2]);
-  }
   if (fY <= yGrid[0])
     result = value[0];
-  else if (fY >= yGrid[N - 1])
-    result = value[N - 1];
+  else if (fY >= yGrid.last())
+    result = value.last();
   else {
     int bin = findBin(yGrid, fY);
     float vx[2], vy[2];
@@ -82,18 +93,4 @@ float SimpleJetCorrectionUncertainty::linearInterpolation(float fZ, const float 
     r = a * fZ + b;
   }
   return r;
-}
-/////////////////////////////////////////////////////////////////////////
-int SimpleJetCorrectionUncertainty::findBin(const std::vector<float>& v, float x) const {
-  int i;
-  int n = v.size() - 1;
-  if (n <= 0)
-    return -1;
-  if (x < v[0] || x >= v[n])
-    return -1;
-  for (i = 0; i < n; i++) {
-    if (x >= v[i] && x < v[i + 1])
-      return i;
-  }
-  return 0;
 }


### PR DESCRIPTION
#### PR description:

- Reduced allocations within jet correction uncertainties conditions
- Improved ShiftedJetProducerT
   - reduced allocations
   - added fillDescriptions
   - modernized C++ syntax
   - updated to newer framework syntax
   - only update data derived from the EventSetup if the EventSetup data changes

#### PR validation:

Code compiles. A simple job using a prototype alloc monitor showed reduced amount of memory held from event to event.

NOTE: this should just be a refactoring so the PR tests should show no differences. If there are differences than debugging will be necessary.