### PR TITLE
Fix DQM config test: Increase number of sequences to process

### DIFF
--- a/DQMOffline/Configuration/test/BuildFile.xml
+++ b/DQMOffline/Configuration/test/BuildFile.xml
@@ -4,12 +4,12 @@
 <test name="GetTestDQMOfflineConfigurationFile" command="edmCopyUtil ${INFILE} $(LOCALTOP)/tmp/"/>
 
 <!-- To make the tests run in parallel, we chunk up the work into arbitrary sets of 10 sequences. -->
-<test name="TestDQMOfflineConfiguration" command="runtests.sh   ${step_value} ${value} file://${LOCALTOP}/tmp/${INFILE_NAME}" for="0,329,10">
+<test name="TestDQMOfflineConfiguration" command="runtests.sh   ${step_value} ${value} file://${LOCALTOP}/tmp/${INFILE_NAME}" for="0,339,10">
   <flags PRE_TEST="GetTestDQMOfflineConfigurationFile"/>
 </test>
 
 <!-- To make sure we actually got all sequences, the last check checks that there are no sequences beyond the last test -->
 <!-- This might need to updated when the number of distinct sequences grows, add more rows above and change the number here. -->
-<test name="TestDQMOfflineConfigurationGotAll" command="runrest.sh file://${LOCALTOP}/tmp/${INFILE_NAME} 329">
+<test name="TestDQMOfflineConfigurationGotAll" command="runrest.sh file://${LOCALTOP}/tmp/${INFILE_NAME} 339">
   <flags PRE_TEST="GetTestDQMOfflineConfigurationFile"/>
 </test>


### PR DESCRIPTION
Looks like DQM sequences to process has increased to 331 that is why `TestDQMOfflineConfigurationGotAll` unittest is failing in IBS.  This PR changes the DQM sequences limit to 339 now.