### PR TITLE
Update Default Datasets for 2022 (was 2021)

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -4382,10 +4382,9 @@ defaultDataSets['2017']='CMSSW_12_0_0_pre4-113X_mc2017_realistic_v5-v'
 defaultDataSets['2017Design']='CMSSW_12_0_0_pre4-113X_mc2017_design_v5-v'
 defaultDataSets['2018']='CMSSW_12_0_0_pre4-113X_upgrade2018_realistic_v5-v'
 defaultDataSets['2018Design']='CMSSW_12_0_0_pre4-113X_upgrade2018_design_v5-v'
-defaultDataSets['2021']='CMSSW_13_1_0_pre1-130X_mcRun3_2022_realistic_withNewBSFromEOY2022Data_v2_RV186-v'
-defaultDataSets['2021Design']='CMSSW_12_5_0_pre4-124X_mcRun3_2022_design_v7_design_BS2022-v'
-defaultDataSets['2021FS']='CMSSW_12_4_13-124X_mcRun3_2022_realistic_v12_2021_FastSim-v'
-defaultDataSets['2023']='CMSSW_13_0_10-130X_mcRun3_2023_realistic_withEarly2023BS_v1_2023-v'
+defaultDataSets['2022']='CMSSW_14_0_18-140X_mcRun3_2022_realistic_v12_STD_noPU_2022_reMC-v'
+defaultDataSets['2022Design']='CMSSW_12_5_0_pre4-124X_mcRun3_2022_design_v7_design_BS2022-v'
+defaultDataSets['2022FS']='CMSSW_14_0_18-140X_mcRun3_2022_realistic_v12_2022_FastSim_Run3_FastSim-v'
 defaultDataSets['2023FS']='CMSSW_13_0_11-130X_mcRun3_2023_realistic_withEarly2023BS_v1_FastSim-v'
 defaultDataSets['2024']='CMSSW_14_1_0_pre7-140X_mcRun3_2024_realistic_v21_STD_RegeneratedGS_2024_noPU-v'
 defaultDataSets['2025']='CMSSW_14_1_0_pre7-140X_mcRun3_2024_realistic_v21_STD_RegeneratedGS_2024_noPU-v'
@@ -4429,7 +4428,7 @@ for ds in defaultDataSets:
         PUDataSets[ds]={'-n':10,'--pileup':'AVE_35_BX_25ns','--pileup_input':'das:/RelValMinBias_13/%s/GEN-SIM'%(name,)}
     elif '2018' in ds or 'postLS2' in ds:
         PUDataSets[ds]={'-n':10,'--pileup':'AVE_50_BX_25ns','--pileup_input':'das:/RelValMinBias_13/%s/GEN-SIM'%(name,)}
-    elif '2021' in ds or '2023' in ds or '2024' in ds:
+    elif '2022' in ds or '2023' in ds or '2024' in ds:
         if 'FS' not in ds:
             PUDataSets[ds]={'-n':10,'--pileup':'Run3_Flat55To75_PoissonOOTPU','--pileup_input':'das:/RelValMinBias_14TeV/%s/GEN-SIM'%(name,)}
         else:


### PR DESCRIPTION
#### PR description:

Updating the default datasets for 2022 (was 2021) conditions. Prompted by https://github.com/cms-sw/cmssw/pull/46649#issuecomment-2497763234.

#### PR validation:

Checking `runTheMatrix.py -w upgrade -l 11834.0 --dryRun` without this PR:

```
# in: /lustre/home/adrianodif/random_devs/PR_Fix2021/cmssw/src dryRun for 'cd 11834.0_TTbar_14TeV+2022PU
 cmsDriver.py TTbar_14TeV_TuneCP5_cfi  -s GEN,SIM -n 10 --conditions auto:phase1_2022_realistic --beamspot DBrealistic --datatier GEN-SIM --eventcontent FEVTDEBUG --geometry DB:Extended --era Run3 --relval 9000,100 --fileout file:step1.root  > step1_TTbar_14TeV+2022PU.log  2>&1
 

# in: /lustre/home/adrianodif/random_devs/PR_Fix2021/cmssw/src dryRun for 'cd 11834.0_TTbar_14TeV+2022PU
 cmsDriver.py step2  -s DIGI:pdigi_valid,L1,DIGI2RAW,HLT:@relval2022 --conditions auto:phase1_2022_realistic --datatier GEN-SIM-DIGI-RAW -n 10 --eventcontent FEVTDEBUGHLT --geometry DB:Extended --era Run3 --pileup AVE_35_BX_25ns --pileup_input das:/RelValMinBias_14TeV/1/GEN-SIM --filein  file:step1.root  --fileout file:step2.root  > step2_TTbar_14TeV+2022PU.log  2>&1
 

# in: /lustre/home/adrianodif/random_devs/PR_Fix2021/cmssw/src dryRun for 'cd 11834.0_TTbar_14TeV+2022PU
 cmsDriver.py step3  -s RAW2DIGI,L1Reco,RECO,RECOSIM,PAT,NANO,VALIDATION:@standardValidationNoHLT+@miniAODValidation,DQM:@standardDQMFakeHLT+@miniAODDQM+@nanoAODDQM --conditions auto:phase1_2022_realistic --datatier GEN-SIM-RECO,MINIAODSIM,NANOAODSIM,DQMIO -n 10 --eventcontent RECOSIM,MINIAODSIM,NANOEDMAODSIM,DQM --geometry DB:Extended --era Run3 --pileup AVE_35_BX_25ns --pileup_input das:/RelValMinBias_14TeV/1/GEN-SIM --filein  file:step2.root  --fileout file:step3.root  > step3_TTbar_14TeV+2022PU.log  2>&1
 

# in: /lustre/home/adrianodif/random_devs/PR_Fix2021/cmssw/src dryRun for 'cd 11834.0_TTbar_14TeV+2022PU
 cmsDriver.py step4  -s HARVESTING:@standardValidationNoHLT+@standardDQMFakeHLT+@miniAODValidation+@miniAODDQM+@nanoAODDQM --conditions auto:phase1_2022_realistic --mc  --geometry DB:Extended --scenario pp --filetype DQM --era Run3 -n 10 --pileup AVE_35_BX_25ns --pileup_input das:/RelValMinBias_14TeV/1/GEN-SIM --filein file:step3_inDQM.root --fileout file:step4.root  > step4_TTbar_14TeV+2022PU.log  2>&1
 
11834.0_TTbar_14TeV+2022PU Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Mon Nov 25 12:41:20 2024-date Mon Nov 25 12:41:20 2024; exit: 0 0 0 0
```

With this PR:

```
# in: /lustre/home/adrianodif/random_devs/PR_Fix2021/cmssw/src dryRun for 'cd 11834.0_TTbar_14TeV+2022PU
 cmsDriver.py TTbar_14TeV_TuneCP5_cfi  -s GEN,SIM -n 10 --conditions auto:phase1_2022_realistic --beamspot DBrealistic --datatier GEN-SIM --eventcontent FEVTDEBUG --geometry DB:Extended --era Run3 --relval 9000,100 --fileout file:step1.root  > step1_TTbar_14TeV+2022PU.log  2>&1
 

# in: /lustre/home/adrianodif/random_devs/PR_Fix2021/cmssw/src dryRun for 'cd 11834.0_TTbar_14TeV+2022PU
 cmsDriver.py step2  -s DIGI:pdigi_valid,L1,DIGI2RAW,HLT:@relval2022 --conditions auto:phase1_2022_realistic --datatier GEN-SIM-DIGI-RAW -n 10 --eventcontent FEVTDEBUGHLT --geometry DB:Extended --era Run3 --pileup AVE_35_BX_25ns --pileup_input das:/RelValMinBias_14TeV/CMSSW_13_1_0_pre1-130X_mcRun3_2022_realistic_withNewBSFromEOY2022Data_v2_RV186-v1/GEN-SIM --filein  file:step1.root  --fileout file:step2.root  > step2_TTbar_14TeV+2022PU.log  2>&1
 

# in: /lustre/home/adrianodif/random_devs/PR_Fix2021/cmssw/src dryRun for 'cd 11834.0_TTbar_14TeV+2022PU
 cmsDriver.py step3  -s RAW2DIGI,L1Reco,RECO,RECOSIM,PAT,NANO,VALIDATION:@standardValidationNoHLT+@miniAODValidation,DQM:@standardDQMFakeHLT+@miniAODDQM+@nanoAODDQM --conditions auto:phase1_2022_realistic --datatier GEN-SIM-RECO,MINIAODSIM,NANOAODSIM,DQMIO -n 10 --eventcontent RECOSIM,MINIAODSIM,NANOEDMAODSIM,DQM --geometry DB:Extended --era Run3 --pileup AVE_35_BX_25ns --pileup_input das:/RelValMinBias_14TeV/CMSSW_13_1_0_pre1-130X_mcRun3_2022_realistic_withNewBSFromEOY2022Data_v2_RV186-v1/GEN-SIM --filein  file:step2.root  --fileout file:step3.root  > step3_TTbar_14TeV+2022PU.log  2>&1
 

# in: /lustre/home/adrianodif/random_devs/PR_Fix2021/cmssw/src dryRun for 'cd 11834.0_TTbar_14TeV+2022PU
 cmsDriver.py step4  -s HARVESTING:@standardValidationNoHLT+@standardDQMFakeHLT+@miniAODValidation+@miniAODDQM+@nanoAODDQM --conditions auto:phase1_2022_realistic --mc  --geometry DB:Extended --scenario pp --filetype DQM --era Run3 -n 10 --pileup AVE_35_BX_25ns --pileup_input das:/RelValMinBias_14TeV/CMSSW_13_1_0_pre1-130X_mcRun3_2022_realistic_withNewBSFromEOY2022Data_v2_RV186-v1/GEN-SIM --filein file:step3_inDQM.root --fileout file:step4.root  > step4_TTbar_14TeV+2022PU.log  2>&1
 
11834.0_TTbar_14TeV+2022PU Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Mon Nov 25 12:42:30 2024-date Mon Nov 25 12:42:30 2024; exit: 0 0 0 0
```


