### PR TITLE
[UBSAN]Check for finite tracklet seeding or d0 cut

### DIFF
--- a/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorDisplaced.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorDisplaced.cc
@@ -8,6 +8,7 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/isFinite.h"
 #include "DataFormats/Math/interface/deltaPhi.h"
 
 using namespace std;
@@ -937,10 +938,8 @@ bool TrackletCalculatorDisplaced::DDLSeeding(const Stub* innerFPGAStub,
     edm::LogVerbatim("Tracklet") << "d0approx: " << d0approx << " d0: " << d0 << endl;
     edm::LogVerbatim("Tracklet") << "tapprox: " << tapprox << " t: " << t << endl;
     edm::LogVerbatim("Tracklet") << "z0approx: " << z0approx << " z0: " << z0 << endl;
-  }
 
-  for (unsigned int i = 0; i < toR_.size(); ++i) {
-    if (settings_.debugTracklet()) {
+    for (unsigned int i = 0; i < toR_.size(); ++i) {
       edm::LogVerbatim("Tracklet") << "phiprojapprox[" << i << "]: " << phiprojapprox[i] << " phiproj[" << i
                                    << "]: " << phiproj[i] << endl;
       edm::LogVerbatim("Tracklet") << "zprojapprox[" << i << "]: " << zprojapprox[i] << " zproj[" << i
@@ -950,10 +949,8 @@ bool TrackletCalculatorDisplaced::DDLSeeding(const Stub* innerFPGAStub,
       edm::LogVerbatim("Tracklet") << "zderapprox[" << i << "]: " << zderapprox[i] << " zder[" << i << "]: " << zder[i]
                                    << endl;
     }
-  }
 
-  for (unsigned int i = 0; i < toZ_.size(); ++i) {
-    if (settings_.debugTracklet()) {
+    for (unsigned int i = 0; i < toZ_.size(); ++i) {
       edm::LogVerbatim("Tracklet") << "phiprojdiskapprox[" << i << "]: " << phiprojdiskapprox[i] << " phiprojdisk[" << i
                                    << "]: " << phiprojdisk[i] << endl;
       edm::LogVerbatim("Tracklet") << "rprojdiskapprox[" << i << "]: " << rprojdiskapprox[i] << " rprojdisk[" << i
@@ -991,7 +988,7 @@ bool TrackletCalculatorDisplaced::DDLSeeding(const Stub* innerFPGAStub,
   iz0 = z0approx / kz0;
 
   bool success = true;
-  if (std::abs(rinvapprox) > settings_.rinvcut()) {
+  if ((std::abs(rinvapprox) > settings_.rinvcut()) || (!edm::isFinite(rinvapprox))) {
     if (settings_.debugTracklet())
       edm::LogVerbatim("Tracklet") << "TrackletCalculator::DDL Seeding irinv too large: " << rinvapprox << "(" << irinv
                                    << ")";
@@ -1002,7 +999,7 @@ bool TrackletCalculatorDisplaced::DDLSeeding(const Stub* innerFPGAStub,
       edm::LogVerbatim("Tracklet") << "Failed tracklet z0 cut " << z0approx;
     success = false;
   }
-  if (std::abs(d0approx) > settings_.maxd0()) {
+  if ((std::abs(d0approx) > settings_.maxd0()) || (!edm::isFinite(d0approx))) {
     if (settings_.debugTracklet())
       edm::LogVerbatim("Tracklet") << "Failed tracklet approx d0 cut " << d0approx;
     success = false;


### PR DESCRIPTION
This PR fixes a runtime error (shown in UBSAN IBs [a] workflow 29751.85/step2). This happens when either [rinvapprox](https://github.com/cms-sw/cmssw/blob/master/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorDisplaced.cc#L987) or [d0approx](https://github.com/cms-sw/cmssw/blob/master/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorDisplaced.cc#L989) are `nan`. This change now also check if these variables have finite values. @cms-sw/l1-l2  [TrackletCalculatorDisplaced::LLLSeeding(...)](https://github.com/cms-sw/cmssw/blob/master/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorDisplaced.cc#L372) also have similar code, so let me know if we should add these check in there.

I also moved https://github.com/cms-sw/cmssw/blob/master/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorDisplaced.cc#L942-L966 code under `if (settings_.debugTracklet())` condition ( just to avoid running for loops if `settings_.debugTracklet()` is not true


[a] https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/raw/el8_amd64_gcc12/CMSSW_15_0_UBSAN_X_2024-11-22-2300/pyRelValMatrixLogs/run/29751.85_HydjetQMinBias_5519GeV+Run4D110_hi/step2_HydjetQMinBias_5519GeV+Run4D110_hi.log
```
src/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorDisplaced.cc:1020:27: runtime error: signed integer overflow: -2147483648 * 2 cannot be represented in type 'int'
    #0 0x1477a984083f in trklet::TrackletCalculatorDisplaced::DDLSeeding(trklet::Stub const*, trklet::L1TStub const*, trklet::Stub const*, trklet::L1TStub const*, trklet::Stub const*, trklet::L1TStub const*) src/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorDisplaced.cc:1020
    #1 0x1477a9af4430 in trklet::TrackletProcessorDisplaced::execute(unsigned int, double, double) src/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc:296
    #2 0x1477a9494fe8 in trklet::Sector::executeTPD() src/L1Trigger/TrackFindingTracklet/src/Sector.cc:379
    #3 0x1477a99c560c in trklet::TrackletEventProcessor::event(trklet::SLHCEvent&, std::vector<std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, 
```