### PR TITLE
[ROOT6]Drop extra space from the key name

### DIFF
--- a/Validation/MuonHits/plugins/MuonSimHitsValidAnalyzer.cc
+++ b/Validation/MuonHits/plugins/MuonSimHitsValidAnalyzer.cc
@@ -123,8 +123,8 @@ void MuonSimHitsValidAnalyzer::bookHistograms(DQMStore::IBooker& iBooker,
   sprintf(histo_t, "Number_of_muon_DT_hits");
   meMuDTHits = iBooker.book1D(histo_n, histo_t, 150, 1.0, 151.0);
 
-  sprintf(histo_n, "Tof_of_hits ");
-  sprintf(histo_t, "Tof_of_hits ");
+  sprintf(histo_n, "Tof_of_hits");
+  sprintf(histo_t, "Tof_of_hits");
   meToF = iBooker.book1D(histo_n, histo_t, 100, -0.5, 50.);
 
   sprintf(histo_n, "DT_energy_loss_keV");


### PR DESCRIPTION
Latest ROOT master [change](https://github.com/root-project/root/commit/b3868102a787e7b44c1ba49d8446f5796568ec42)  now warns about the trailing blanks in the key name. As we convert root warnings in to errors so PR relvals are [failing](https://github.com/cms-sw/cmsdist/pull/9529#issuecomment-2498307557) [a] with latest root changes. Note that root was always removing the trailing spaces, it is just that in latest root they print a warning

This PR fixes the trailing space for `Tof_of_hits` 
 

[a]
```
----- Begin Fatal Exception 25-Nov-2024 15:49:40 CET-----------------------
An exception of category 'FatalRootError' occurred while
   [0] Processing end ProcessBlock
   [1] Calling method for module DQMFileSaver/'dqmSaver'
   Additional Info:
      [a] Fatal Root Error: @SUB=TDirectoryFile::WriteTObject
The key name 'Tof_of_hits ' will be stored in file without the trailing blanks.
----- End Fatal Exception -------------------------------------------------
```