### PR TITLE
Hepmc3tog4, addind the codes that provide a possibility to transfer HepMC3Product from the GEN step to the SIM step 

### DIFF
--- a/GeneratorInterface/Core/plugins/GeneratorSmearedProducer.cc
+++ b/GeneratorInterface/Core/plugins/GeneratorSmearedProducer.cc
@@ -5,6 +5,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/HepMC3Product.h"
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -16,7 +17,6 @@ namespace edm {
   class ConfigurationDescriptions;
   class Event;
   class EventSetup;
-  class HepMCProduct;
 }  // namespace edm
 
 class GeneratorSmearedProducer : public edm::global::EDProducer<> {
@@ -29,14 +29,19 @@ public:
 private:
   const edm::EDGetTokenT<edm::HepMCProduct> newToken_;
   const edm::EDGetTokenT<edm::HepMCProduct> oldToken_;
+  const edm::EDGetTokenT<edm::HepMC3Product> Token3_;
 };
 
 GeneratorSmearedProducer::GeneratorSmearedProducer(edm::ParameterSet const& ps)
     : newToken_(consumes<edm::HepMCProduct>(ps.getUntrackedParameter<edm::InputTag>("currentTag"))),
-      oldToken_(consumes<edm::HepMCProduct>(ps.getUntrackedParameter<edm::InputTag>("previousTag"))) {
+      oldToken_(consumes<edm::HepMCProduct>(ps.getUntrackedParameter<edm::InputTag>("previousTag"))),
+      Token3_(consumes<edm::HepMC3Product>(ps.getUntrackedParameter<edm::InputTag>("currentTag"))) {
   // This producer produces a HepMCProduct, a copy of the original one
-  // It is used for backwaerd compatibility
+  // It is used for backward compatibility
+  // If HepMC3Product exists, it produces its copy
+  // It adds "generatorSmeared" to description, which is needed for further processing
   produces<edm::HepMCProduct>();
+  produces<edm::HepMC3Product>();
 }
 
 void GeneratorSmearedProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& es) const {
@@ -48,6 +53,13 @@ void GeneratorSmearedProducer::produce(edm::StreamID, edm::Event& iEvent, const 
   if (found) {
     std::unique_ptr<edm::HepMCProduct> theCopy(new edm::HepMCProduct(*theHepMCProduct));
     iEvent.put(std::move(theCopy));
+  }
+
+  edm::Handle<edm::HepMC3Product> theHepMC3Product;
+  found = iEvent.getByToken(Token3_, theHepMC3Product);
+  if (found) {
+    std::unique_ptr<edm::HepMC3Product> theCopy3(new edm::HepMC3Product(*theHepMC3Product));
+    iEvent.put(std::move(theCopy3));
   }
 }
 

--- a/GeneratorInterface/Pythia8Interface/test/pythia8test/runtest
+++ b/GeneratorInterface/Pythia8Interface/test/pythia8test/runtest
@@ -4,4 +4,4 @@ rm -f p8test.html
 cmsRun p8test1step1_cfg.py
 cmsRun ZJetsTest_cfg.py
 cp testi.dat test.dat
-cmpr.sh test.dat html > p8test.html
+./cmpr.sh test.dat html > p8test.html

--- a/IOMC/EventVertexGenerators/interface/BaseEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/BaseEvtVtxGenerator.h
@@ -19,7 +19,7 @@ namespace CLHEP {
 namespace edm {
   class HepMCProduct;
   class HepMC3Product;
-} // namespace edm
+}  // namespace edm
 
 class BaseEvtVtxGenerator : public edm::stream::EDProducer<> {
 public:

--- a/IOMC/EventVertexGenerators/interface/BaseEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/BaseEvtVtxGenerator.h
@@ -19,7 +19,7 @@ namespace CLHEP {
 namespace edm {
   class HepMCProduct;
   class HepMC3Product;
-}
+} // namespace edm
 
 class BaseEvtVtxGenerator : public edm::stream::EDProducer<> {
 public:

--- a/IOMC/EventVertexGenerators/interface/BaseEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/BaseEvtVtxGenerator.h
@@ -18,6 +18,7 @@ namespace CLHEP {
 
 namespace edm {
   class HepMCProduct;
+  class HepMC3Product;
 }
 
 class BaseEvtVtxGenerator : public edm::stream::EDProducer<> {
@@ -39,6 +40,7 @@ public:
 
 private:
   edm::EDGetTokenT<edm::HepMCProduct> sourceToken;
+  edm::EDGetTokenT<edm::HepMC3Product> sourceToken3;
 };
 
 #endif

--- a/IOMC/EventVertexGenerators/src/BaseEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/BaseEvtVtxGenerator.cc
@@ -8,7 +8,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
-#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/HepMC3Product.h"
 
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
@@ -35,7 +35,9 @@ BaseEvtVtxGenerator::BaseEvtVtxGenerator(const ParameterSet& pset) {
                                              "in the configuration file or remove the modules that require it.";
   }
 
+  sourceToken3 = consumes<edm::HepMC3Product>(pset.getParameter<edm::InputTag>("src"));
   sourceToken = consumes<edm::HepMCProduct>(pset.getParameter<edm::InputTag>("src"));
+  produces<edm::HepMC3Product>();
   produces<edm::HepMCProduct>();
 }
 
@@ -47,20 +49,38 @@ void BaseEvtVtxGenerator::produce(Event& evt, const EventSetup&) {
 
   Handle<HepMCProduct> HepUnsmearedMCEvt;
 
-  evt.getByToken(sourceToken, HepUnsmearedMCEvt);
+  bool found = evt.getByToken(sourceToken, HepUnsmearedMCEvt);
 
-  // Copy the HepMC::GenEvent
-  HepMC::GenEvent* genevt = new HepMC::GenEvent(*HepUnsmearedMCEvt->GetEvent());
-  std::unique_ptr<edm::HepMCProduct> HepMCEvt(new edm::HepMCProduct(genevt));
-  // generate new vertex & apply the shift
-  //
-  HepMCEvt->applyVtxGen(newVertex(engine));
+  if (found) { // HepMC event exists
 
-  //HepMCEvt->LorentzBoost( 0., 142.e-6 );
-  HepMCEvt->boostToLab(GetInvLorentzBoost(), "vertex");
-  HepMCEvt->boostToLab(GetInvLorentzBoost(), "momentum");
+    // Make a copy
+    HepMC::GenEvent* genevt = new HepMC::GenEvent(*HepUnsmearedMCEvt->GetEvent());
 
-  evt.put(std::move(HepMCEvt));
+    std::unique_ptr<edm::HepMCProduct> HepMCEvt(new edm::HepMCProduct(genevt));
+    // generate new vertex & apply the shift
+    //
+    HepMCEvt->applyVtxGen(newVertex(engine));
+
+    //HepMCEvt->LorentzBoost( 0., 142.e-6 );
+    HepMCEvt->boostToLab(GetInvLorentzBoost(), "vertex");
+    HepMCEvt->boostToLab(GetInvLorentzBoost(), "momentum");
+
+    evt.put(std::move(HepMCEvt));
+
+  } else { // no HepMC event, try to get HepMC3 event
+
+    Handle<HepMC3Product> HepUnsmearedMCEvt3;
+    found = evt.getByToken(sourceToken3, HepUnsmearedMCEvt3);
+
+    if(!found) throw cms::Exception("ProductAbsent") << "No HepMCProduct, tried to get HepMC3Product, but it is also absent " << std::endl;
+
+    HepMC3::GenEvent* genevt3 = new HepMC3::GenEvent();
+    genevt3->read_data(*HepUnsmearedMCEvt3->GetEvent());
+    HepMC3Product* productcopy3 = new HepMC3Product(genevt3);    // For the moment do not really smear HepMC3
+    std::unique_ptr<edm::HepMC3Product> HepMC3Evt(productcopy3);
+    evt.put(std::move(HepMC3Evt)); 
+
+  }
 
   return;
 }

--- a/IOMC/EventVertexGenerators/src/BaseEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/BaseEvtVtxGenerator.cc
@@ -51,7 +51,7 @@ void BaseEvtVtxGenerator::produce(Event& evt, const EventSetup&) {
 
   bool found = evt.getByToken(sourceToken, HepUnsmearedMCEvt);
 
-  if (found) { // HepMC event exists
+  if (found) {  // HepMC event exists
 
     // Make a copy
     HepMC::GenEvent* genevt = new HepMC::GenEvent(*HepUnsmearedMCEvt->GetEvent());
@@ -67,19 +67,20 @@ void BaseEvtVtxGenerator::produce(Event& evt, const EventSetup&) {
 
     evt.put(std::move(HepMCEvt));
 
-  } else { // no HepMC event, try to get HepMC3 event
+  } else {  // no HepMC event, try to get HepMC3 event
 
     Handle<HepMC3Product> HepUnsmearedMCEvt3;
     found = evt.getByToken(sourceToken3, HepUnsmearedMCEvt3);
 
-    if(!found) throw cms::Exception("ProductAbsent") << "No HepMCProduct, tried to get HepMC3Product, but it is also absent " << std::endl;
+    if (!found)
+      throw cms::Exception("ProductAbsent")
+          << "No HepMCProduct, tried to get HepMC3Product, but it is also absent " << std::endl;
 
     HepMC3::GenEvent* genevt3 = new HepMC3::GenEvent();
     genevt3->read_data(*HepUnsmearedMCEvt3->GetEvent());
-    HepMC3Product* productcopy3 = new HepMC3Product(genevt3);    // For the moment do not really smear HepMC3
+    HepMC3Product* productcopy3 = new HepMC3Product(genevt3);  // For the moment do not really smear HepMC3
     std::unique_ptr<edm::HepMC3Product> HepMC3Evt(productcopy3);
     evt.put(std::move(HepMC3Evt)); 
-
   }
 
   return;

--- a/IOMC/EventVertexGenerators/src/BaseEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/BaseEvtVtxGenerator.cc
@@ -80,7 +80,7 @@ void BaseEvtVtxGenerator::produce(Event& evt, const EventSetup&) {
     genevt3->read_data(*HepUnsmearedMCEvt3->GetEvent());
     HepMC3Product* productcopy3 = new HepMC3Product(genevt3);  // For the moment do not really smear HepMC3
     std::unique_ptr<edm::HepMC3Product> HepMC3Evt(productcopy3);
-    evt.put(std::move(HepMC3Evt)); 
+    evt.put(std::move(HepMC3Evt));
   }
 
   return;

--- a/IOMC/EventVertexGenerators/src/BaseEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/BaseEvtVtxGenerator.cc
@@ -61,7 +61,6 @@ void BaseEvtVtxGenerator::produce(Event& evt, const EventSetup&) {
     //
     HepMCEvt->applyVtxGen(newVertex(engine));
 
-    //HepMCEvt->LorentzBoost( 0., 142.e-6 );
     HepMCEvt->boostToLab(GetInvLorentzBoost(), "vertex");
     HepMCEvt->boostToLab(GetInvLorentzBoost(), "momentum");
 

--- a/IOMC/EventVertexGenerators/src/BaseEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/BaseEvtVtxGenerator.cc
@@ -72,8 +72,7 @@ void BaseEvtVtxGenerator::produce(Event& evt, const EventSetup&) {
     found = evt.getByToken(sourceToken3, HepUnsmearedMCEvt3);
 
     if (!found)
-      throw cms::Exception("ProductAbsent")
-          << "No HepMCProduct, tried to get HepMC3Product, but it is also absent.";
+      throw cms::Exception("ProductAbsent") << "No HepMCProduct, tried to get HepMC3Product, but it is also absent.";
 
     HepMC3::GenEvent* genevt3 = new HepMC3::GenEvent();
     genevt3->read_data(*HepUnsmearedMCEvt3->GetEvent());

--- a/IOMC/EventVertexGenerators/src/BaseEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/BaseEvtVtxGenerator.cc
@@ -73,7 +73,7 @@ void BaseEvtVtxGenerator::produce(Event& evt, const EventSetup&) {
 
     if (!found)
       throw cms::Exception("ProductAbsent")
-          << "No HepMCProduct, tried to get HepMC3Product, but it is also absent " << std::endl;
+          << "No HepMCProduct, tried to get HepMC3Product, but it is also absent.";
 
     HepMC3::GenEvent* genevt3 = new HepMC3::GenEvent();
     genevt3->read_data(*HepUnsmearedMCEvt3->GetEvent());

--- a/PhysicsTools/HepMCCandAlgos/plugins/GenParticleProducer.cc
+++ b/PhysicsTools/HepMCCandAlgos/plugins/GenParticleProducer.cc
@@ -175,7 +175,6 @@ std::shared_ptr<IDto3Charge> GenParticleProducer::globalBeginRun(const Run&, con
 }
 
 void GenParticleProducer::produce(StreamID, Event& evt, const EventSetup& es) const {
-
   std::unordered_map<int, size_t> barcodes;
 
   size_t totalSize = 0;
@@ -196,7 +195,6 @@ void GenParticleProducer::produce(StreamID, Event& evt, const EventSetup& es) co
     }
     LogDebug("GenParticleProducer") << "totalSize : " << totalSize << endl;
   } else {
-
     Handle<HepMCProduct> mcp;
     bool found = evt.getByToken(srcToken_, mcp);
     if (found) {
@@ -288,29 +286,29 @@ void GenParticleProducer::produce(StreamID, Event& evt, const EventSetup& es) co
     }
   } else {
     if (totalSize) {
-    auto origin = (*mc->vertices_begin())->position();
-    xyz0Ptr->SetXYZ(origin.x() * mmToCm, origin.y() * mmToCm, origin.z() * mmToCm);
-    *t0Ptr = origin.t() * mmToNs;
-    fillIndices(mc, particles, *barCodeVector, 0, barcodes);
+      auto origin = (*mc->vertices_begin())->position();
+      xyz0Ptr->SetXYZ(origin.x() * mmToCm, origin.y() * mmToCm, origin.z() * mmToCm);
+      *t0Ptr = origin.t() * mmToNs;
+      fillIndices(mc, particles, *barCodeVector, 0, barcodes);
 
-    // fill output collection and save association
-    for (size_t i = 0; i < particles.size(); ++i) {
-      const HepMC::GenParticle* part = particles[i];
-      reco::GenParticle& cand = cands[i];
-      // convert HepMC::GenParticle to new reco::GenParticle
-      convertParticle(cand, part, id2Charge);
-      cand.resetDaughters(ref.id());
-    }
+      // fill output collection and save association
+      for (size_t i = 0; i < particles.size(); ++i) {
+        const HepMC::GenParticle* part = particles[i];
+        reco::GenParticle& cand = cands[i];
+        // convert HepMC::GenParticle to new reco::GenParticle
+        convertParticle(cand, part, id2Charge);
+        cand.resetDaughters(ref.id());
+      }
 
-    // fill references to daughters
-    for (size_t d = 0; d < cands.size(); ++d) {
-      const HepMC::GenParticle* part = particles[d];
-      const GenVertex* productionVertex = part->production_vertex();
-      // search barcode map and attach daughters
-      if (productionVertex != nullptr)
-        fillDaughters(cands, part, ref, d, barcodes);
-      cands[d].setCollisionId(0);
-    }
+      // fill references to daughters
+      for (size_t d = 0; d < cands.size(); ++d) {
+        const HepMC::GenParticle* part = particles[d];
+        const GenVertex* productionVertex = part->production_vertex();
+        // search barcode map and attach daughters
+        if (productionVertex != nullptr)
+          fillDaughters(cands, part, ref, d, barcodes);
+        cands[d].setCollisionId(0);
+      }
     }
   }
 
@@ -321,7 +319,6 @@ void GenParticleProducer::produce(StreamID, Event& evt, const EventSetup& es) co
     delete cfhepmcprod;
   evt.put(std::move(xyz0Ptr), "xyz0");
   evt.put(std::move(t0Ptr), "t0");
-
 }
 
 bool GenParticleProducer::convertParticle(reco::GenParticle& cand,

--- a/SimG4Core/Application/interface/RunManagerMTWorker.h
+++ b/SimG4Core/Application/interface/RunManagerMTWorker.h
@@ -7,6 +7,7 @@
 #include "SimDataFormats/Forward/interface/LHCTransportLinkContainer.h"
 
 #include "SimG4Core/Generators/interface/Generator.h"
+#include "SimG4Core/Generators/interface/Generator3.h"
 #include "SimG4Core/Notification/interface/TmpSimEvent.h"
 
 #include "MagneticField/Engine/interface/MagneticField.h"
@@ -22,6 +23,7 @@ namespace edm {
   class EventSetup;
   class ConsumesCollector;
   class HepMCProduct;
+  class HepMC3Product;
 }  // namespace edm
 
 class Generator;
@@ -89,7 +91,9 @@ private:
   void DumpMagneticField(const G4Field*, const std::string&) const;
 
   Generator m_generator;
+  Generator3 m_generator3;
   edm::EDGetTokenT<edm::HepMCProduct> m_InToken;
+  edm::EDGetTokenT<edm::HepMC3Product> m_InToken3;
   edm::EDGetTokenT<edm::HepMCProduct> m_LHCToken;
   edm::EDGetTokenT<edm::LHCTransportLinkContainer> m_theLHCTlinkToken;
   edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> m_MagField;

--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -655,14 +655,10 @@ G4Event* RunManagerMTWorker::generateEvent(const edm::Event& inpevt) {
   // along the beam pipe to their original value for SimTrack creation
   resetGenParticleId(inpevt);
 
-
   edm::Handle<edm::HepMCProduct> HepMCEvt;
   bool found = inpevt.getByToken(m_InToken, HepMCEvt);
 
-  // extract the HepMC::GenEvent
-//  HepMC::GenEvent* genevt = new HepMC::GenEvent(*HepMCEvt->GetEvent());
-
-  if (found) { // HepMC event exists
+  if (found) {  // HepMC event exists
 
     m_generator.setGenEvent(HepMCEvt->GetEvent());
 
@@ -677,7 +673,7 @@ G4Event* RunManagerMTWorker::generateEvent(const edm::Event& inpevt) {
       m_generator.nonCentralEvent2G4(HepMCEvt->GetEvent(), evt);
     }
 
-  } else { // no HepMC event, try to get HepMC3 event
+  } else {  // no HepMC event, try to get HepMC3 event
 
     edm::Handle<edm::HepMC3Product> HepMCEvt3;
     inpevt.getByToken(m_InToken3, HepMCEvt3);
@@ -697,7 +693,7 @@ G4Event* RunManagerMTWorker::generateEvent(const edm::Event& inpevt) {
       //m_generator3.nonCentralEvent2G4(HepMCEvt->GetEvent(), evt);
     }
   }
-  return evt;  
+  return evt;
 }
 
 void RunManagerMTWorker::resetGenParticleId(const edm::Event& inpevt) {

--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -35,7 +35,9 @@
 #include "SimG4Core/MagneticField/interface/CMSFieldManager.h"
 
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/HepMC3Product.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "HepMC3/Print.h"
 
 #include "SimG4Core/Physics/interface/PhysicsList.h"
 
@@ -152,7 +154,10 @@ struct RunManagerMTWorker::TLSData {
 
 RunManagerMTWorker::RunManagerMTWorker(const edm::ParameterSet& p, edm::ConsumesCollector&& iC)
     : m_generator(p.getParameter<edm::ParameterSet>("Generator")),
+      m_generator3(p.getParameter<edm::ParameterSet>("Generator")),
       m_InToken(iC.consumes<edm::HepMCProduct>(
+          p.getParameter<edm::ParameterSet>("Generator").getParameter<edm::InputTag>("HepMCProductLabel"))),
+      m_InToken3(iC.consumes<edm::HepMC3Product>(
           p.getParameter<edm::ParameterSet>("Generator").getParameter<edm::InputTag>("HepMCProductLabel"))),
       m_theLHCTlinkToken(iC.consumes<edm::LHCTransportLinkContainer>(p.getParameter<edm::InputTag>("theLHCTlinkTag"))),
       m_nonBeam(p.getParameter<bool>("NonBeamEvent")),
@@ -572,6 +577,7 @@ TmpSimEvent* RunManagerMTWorker::produce(const edm::Event& inpevt,
   }
 
   // event and primary
+
   m_tls->currentEvent.reset(generateEvent(inpevt));
   m_simEvent.clear();
   m_simEvent.setHepEvent(m_generator.genEvent());
@@ -645,27 +651,53 @@ G4Event* RunManagerMTWorker::generateEvent(const edm::Event& inpevt) {
   G4int evtid = (G4int)inpevt.id().event();
   G4Event* evt = new G4Event(evtid);
 
-  edm::Handle<edm::HepMCProduct> HepMCEvt;
-  inpevt.getByToken(m_InToken, HepMCEvt);
-
-  m_generator.setGenEvent(HepMCEvt->GetEvent());
-
   // required to reset the GenParticle Id for particles transported
   // along the beam pipe to their original value for SimTrack creation
   resetGenParticleId(inpevt);
 
-  if (!m_nonBeam) {
-    m_generator.HepMC2G4(HepMCEvt->GetEvent(), evt);
-    if (m_LHCTransport) {
-      edm::Handle<edm::HepMCProduct> LHCMCEvt;
-      inpevt.getByToken(m_LHCToken, LHCMCEvt);
-      m_generator.nonCentralEvent2G4(LHCMCEvt->GetEvent(), evt);
-    }
-  } else {
-    m_generator.nonCentralEvent2G4(HepMCEvt->GetEvent(), evt);
-  }
 
-  return evt;
+  edm::Handle<edm::HepMCProduct> HepMCEvt;
+  bool found = inpevt.getByToken(m_InToken, HepMCEvt);
+
+  // extract the HepMC::GenEvent
+//  HepMC::GenEvent* genevt = new HepMC::GenEvent(*HepMCEvt->GetEvent());
+
+  if (found) { // HepMC event exists
+
+    m_generator.setGenEvent(HepMCEvt->GetEvent());
+
+    if (!m_nonBeam) {
+      m_generator.HepMC2G4(HepMCEvt->GetEvent(), evt);
+      if (m_LHCTransport) {
+        edm::Handle<edm::HepMCProduct> LHCMCEvt;
+        inpevt.getByToken(m_LHCToken, LHCMCEvt);
+        m_generator.nonCentralEvent2G4(LHCMCEvt->GetEvent(), evt);
+      }
+    } else {
+      m_generator.nonCentralEvent2G4(HepMCEvt->GetEvent(), evt);
+    }
+
+  } else { // no HepMC event, try to get HepMC3 event
+
+    edm::Handle<edm::HepMC3Product> HepMCEvt3;
+    inpevt.getByToken(m_InToken3, HepMCEvt3);
+
+    HepMC3::GenEvent* genevt3 = new HepMC3::GenEvent();
+    genevt3->read_data(*HepMCEvt3->GetEvent());
+    m_generator3.setGenEvent(genevt3);
+
+    if (!m_nonBeam) {
+      m_generator3.HepMC2G4(genevt3, evt);
+      if (m_LHCTransport) {
+        edm::Handle<edm::HepMC3Product> LHCMCEvt;
+        inpevt.getByToken(m_LHCToken, LHCMCEvt);
+        //m_generator3.nonCentralEvent2G4(LHCMCEvt->GetEvent(), evt);
+      }
+    } else {
+      //m_generator3.nonCentralEvent2G4(HepMCEvt->GetEvent(), evt);
+    }
+  }
+  return evt;  
 }
 
 void RunManagerMTWorker::resetGenParticleId(const edm::Event& inpevt) {

--- a/SimG4Core/Generators/BuildFile.xml
+++ b/SimG4Core/Generators/BuildFile.xml
@@ -5,6 +5,7 @@
 <use name="FWCore/MessageLogger"/>
 <use name="boost"/>
 <use name="hepmc"/>
+<use name="hepmc3"/>
 <use name="heppdt"/>
 <use name="geant4core"/>
 <use name="rootmath"/>

--- a/SimG4Core/Generators/interface/Generator3.h
+++ b/SimG4Core/Generators/interface/Generator3.h
@@ -1,0 +1,70 @@
+#ifndef SimG4Core_Generator3_H
+#define SimG4Core_Generator3_H
+
+#include "DataFormats/Math/interface/LorentzVector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "SimG4Core/Generators/interface/HepMCParticle.h"
+#include "SimG4Core/Notification/interface/GenParticleInfo.h"
+
+#include "HepMC3/GenEvent.h"
+#include "HepMC3/GenParticle.h"
+
+#include <vector>
+
+class G4Event;
+class G4PrimaryParticle;
+class LumiMonitorFilter;
+
+class Generator3 {
+public:
+  Generator3(const edm::ParameterSet &p);
+  virtual ~Generator3();
+
+  void setGenEvent(const HepMC3::GenEvent *inpevt) {
+    evt_ = (HepMC3::GenEvent *)inpevt;
+    return;
+  }
+  void HepMC2G4(const HepMC3::GenEvent *g, G4Event *e);
+  void nonCentralEvent2G4(const HepMC3::GenEvent *g, G4Event *e);
+  virtual const HepMC3::GenEvent *genEvent() const { return evt_; }
+  virtual const math::XYZTLorentzVector *genVertex() const { return vtx_; }
+  virtual const double eventWeight() const { return weight_; }
+
+private:
+  bool particlePassesPrimaryCuts(const G4ThreeVector &p) const;
+  bool isExotic(int pdgcode) const;
+  bool isExoticNonDetectable(int pdgcode) const;
+  bool IsInTheFilterList(int pdgcode) const;
+  void particleAssignDaughters(G4PrimaryParticle *p, HepMC3::GenParticle *hp, double length);
+  void setGenId(G4PrimaryParticle *p, int id) const { p->SetUserInformation(new GenParticleInfo(id)); }
+
+private:
+  bool fPCuts;
+  bool fPtransCut;
+  bool fEtaCuts;
+  bool fPhiCuts;
+  bool fFiductialCuts;
+  double theMinPhiCut;
+  double theMaxPhiCut;
+  double theMinEtaCut;
+  double theMaxEtaCut;
+  double theMinPCut;
+  double theMinPtCut2;
+  double theMaxPCut;
+  double theDecRCut2;
+  double theEtaCutForHector;
+  double theDecLenCut;
+  double maxZCentralCMS;
+  int verbose;
+  LumiMonitorFilter *fLumiFilter;
+  HepMC3::GenEvent *evt_;
+  math::XYZTLorentzVector *vtx_;
+  double weight_;
+  double Z_lmin, Z_lmax, Z_hector;
+  std::vector<int> pdgFilter;
+  bool pdgFilterSel;
+  bool fPDGFilter;
+};
+
+#endif

--- a/SimG4Core/Generators/interface/LumiMonitorFilter.h
+++ b/SimG4Core/Generators/interface/LumiMonitorFilter.h
@@ -2,6 +2,7 @@
 #define SimG4Core_LumiMonitorFilter_H
 
 #include "HepMC/GenParticle.h"
+#include "HepMC3/GenParticle.h"
 
 class LumiMonitorFilter {
 public:
@@ -10,6 +11,7 @@ public:
 
   void Describe() const;
   bool isGoodForLumiMonitor(const HepMC::GenParticle *) const;
+  bool isGoodForLumiMonitor(const HepMC3::GenParticle *) const;
 
 private:
 };

--- a/SimG4Core/Generators/src/Generator3.cc
+++ b/SimG4Core/Generators/src/Generator3.cc
@@ -89,12 +89,11 @@ Generator3::Generator3(const ParameterSet &p)
 
   edm::LogVerbatim("SimG4CoreGenerator3")
       << "SimG4Core/Generator3: Rdecaycut= " << theRDecLenCut / CLHEP::cm
-      << " cm;  Zdecaycut= " << theDecLenCut / CLHEP::cm
-      << "Z_min= " << Z_lmin / CLHEP::cm << " cm; Z_max= " << Z_lmax / CLHEP::cm << " cm;\n"
+      << " cm;  Zdecaycut= " << theDecLenCut / CLHEP::cm << "Z_min= " << Z_lmin / CLHEP::cm
+      << " cm; Z_max= " << Z_lmax / CLHEP::cm << " cm;\n"
       << "                     MaxZCentralCMS = " << maxZCentralCMS / CLHEP::m << " m;"
       << " Z_hector = " << Z_hector / CLHEP::cm << " cm\n"
-      << "                     ApplyCuts: " << fFiductialCuts
-      << "  PCuts: " << fPCuts << "  PtransCut: " << fPtransCut
+      << "                     ApplyCuts: " << fFiductialCuts << "  PCuts: " << fPCuts << "  PtransCut: " << fPtransCut
       << "  EtaCut: " << fEtaCuts << "  PhiCut: " << fPhiCuts << "  LumiMonitorCut: " << lumi;
   if (fFiductialCuts) {
     edm::LogVerbatim("SimG4CoreGenerator3")
@@ -135,7 +134,7 @@ void Generator3::HepMC2G4(const HepMC3::GenEvent *evt_orig, G4Event *g4evt) {
 
   for (HepMC3::GenVertexPtr v : evt->vertices()) {
     vtx_ =
-        new math::XYZTLorentzVector( (v->position()).x(), (v->position()).y(), (v->position()).z(), (v->position()).t());
+        new math::XYZTLorentzVector((v->position()).x(), (v->position()).y(), (v->position()).z(), (v->position()).t());
     break;
   }
 
@@ -179,8 +178,9 @@ void Generator3::HepMC2G4(const HepMC3::GenEvent *evt_orig, G4Event *g4evt) {
 
         qvtx = true;
         if (verbose > 2)
-          LogDebug("SimG4CoreGenerator3") << "GenVertex barcode = " << vitr->id() << " " << qvtx
-                                         << " selected for GenParticle barcode = " << pitr->id(); // barcode is substituted by id
+          LogDebug("SimG4CoreGenerator3")
+              << "GenVertex barcode = " << vitr->id() << " " << qvtx
+              << " selected for GenParticle barcode = " << pitr->id();  // barcode is substituted by id
         break;
       }
       // The selection is made considering if the partcile with status = 2
@@ -195,8 +195,8 @@ void Generator3::HepMC2G4(const HepMC3::GenEvent *evt_orig, G4Event *g4evt) {
             qvtx = true;
             if (verbose > 2)
               LogDebug("SimG4CoreGenerator3")
-                  << "GenVertex barcode = " << vitr->id()
-                  << " selected for GenParticle barcode = " << pitr->id() << " radius = " << std::sqrt(r_dd); // barcode is substituted by id
+                  << "GenVertex barcode = " << vitr->id() << " selected for GenParticle barcode = " << pitr->id()
+                  << " radius = " << std::sqrt(r_dd); // barcode is substituted by id
             break;
           }
         } else {
@@ -221,7 +221,7 @@ void Generator3::HepMC2G4(const HepMC3::GenEvent *evt_orig, G4Event *g4evt) {
 
     G4PrimaryVertex *g4vtx = new G4PrimaryVertex(x1, y1, z1, t1);
 
-    for (HepMC3::GenParticlePtr pitr : vitr->particles_out() ) {
+    for (HepMC3::GenParticlePtr pitr : vitr->particles_out()) {
       int status = pitr->status();
       int pdg = pitr->pid();
       bool hasDecayVertex = (nullptr != pitr->end_vertex());
@@ -250,7 +250,7 @@ void Generator3::HepMC2G4(const HepMC3::GenEvent *evt_orig, G4Event *g4evt) {
       if (status > 3 && isExotic(pdg) && (!(isExoticNonDetectable(pdg)))) {
         status = hasDecayVertex ? 2 : 1;
       }
-      if (status == 2 && abs(pdg) == 9900015) { // Additional photon?
+      if (status == 2 && abs(pdg) == 9900015) {  // Additional photon?
         status = 3;
       }
 
@@ -298,10 +298,10 @@ void Generator3::HepMC2G4(const HepMC3::GenEvent *evt_orig, G4Event *g4evt) {
 
       if (verbose > 2)
         LogDebug("SimG4CoreGenerator3") << "Processing GenParticle barcode= " << pitr->id() << " pdg= " << pdg
-                                       << " status= " << pitr->status() << " st= " << status
-                                       << " rimpact(cm)= " << std::sqrt(rimpact2) / CLHEP::cm
-                                       << " zimpact(cm)= " << zimpact / CLHEP::cm << " ptot(GeV)= " << ptot
-                                       << " pz(GeV)= " << pz;
+                                        << " status= " << pitr->status() << " st= " << status
+                                        << " rimpact(cm)= " << std::sqrt(rimpact2) / CLHEP::cm
+                                        << " zimpact(cm)= " << zimpact / CLHEP::cm << " ptot(GeV)= " << ptot
+                                        << " pz(GeV)= " << pz;
 
       // Particles of status 1 trasnported along the beam pipe
       // HECTOR transport of protons are done in corresponding PPS producer
@@ -313,7 +313,7 @@ void Generator3::HepMC2G4(const HepMC3::GenEvent *evt_orig, G4Event *g4evt) {
               << "GenParticle barcode = " << pitr->id() << " very forward; to be added: " << toBeAdded;
         }
       } else {
-     	// Standard case: particles not decayed by the generator and not forward
+        // Standard case: particles not decayed by the generator and not forward
         if (1 == status && (std::abs(zimpact) < Z_hector || rimpact2 > theDecRCut2)) {
           // Ptot cut for all particles
           if (fPCuts && (ptot < theMinPCut || ptot > theMaxPCut)) {
@@ -357,13 +357,12 @@ void Generator3::HepMC2G4(const HepMC3::GenEvent *evt_orig, G4Event *g4evt) {
             }
           }
           const HepMC3::GenParticle* ppointer = pitr.get();
-          if (fLumiFilter && !fLumiFilter->isGoodForLumiMonitor(ppointer)) { // MK: this function is always true
+          if (fLumiFilter && !fLumiFilter->isGoodForLumiMonitor(ppointer)) {  // MK: this function is always true
             continue;
           }
           toBeAdded = true;
           if (verbose > 1)
-            edm::LogVerbatim("SimG4CoreGenerator3")
-                << "GenParticle barcode = " << pitr->id() << " passed case 1";
+            edm::LogVerbatim("SimG4CoreGenerator3") << "GenParticle barcode = " << pitr->id() << " passed case 1";
 
           // Decay chain outside the fiducial cylinder defined by theRDecLenCut
           // are used for Geant4 tracking with predefined decay channel
@@ -372,7 +371,7 @@ void Generator3::HepMC2G4(const HepMC3::GenEvent *evt_orig, G4Event *g4evt) {
           toBeAdded = true;
           if (verbose > 1)
             edm::LogVerbatim("SimG4CoreGenerator3") << "GenParticle barcode = " << pitr->id() << " passed case 2"
-                                                   << " decay_length(cm)= " << decay_length / CLHEP::cm;
+                                                    << " decay_length(cm)= " << decay_length / CLHEP::cm;
         }
       }
       if (toBeAdded) {
@@ -390,7 +389,7 @@ void Generator3::HepMC2G4(const HepMC3::GenEvent *evt_orig, G4Event *g4evt) {
           g4prim->SetCharge(charge);
         }
 
-     	// V.I. do not use SetWeight but the same code
+        // V.I. do not use SetWeight but the same code
         // value of the code compute inside TrackWithHistory
         // g4prim->SetWeight( 10000*(*vpitr)->barcode() ) ;
         setGenId(g4prim, pitr->id());
@@ -404,8 +403,8 @@ void Generator3::HepMC2G4(const HepMC3::GenEvent *evt_orig, G4Event *g4evt) {
         ++ng4par;
         g4vtx->SetPrimary(g4prim);
         edm::LogVerbatim("SimG4CoreGenerator3") << "   " << ng4par << ". new Geant4 particle pdg= " << pdg
-                                               << " Ptot(GeV/c)= " << ptot << " Pt= " << std::sqrt(px * px + py * py)
-                                               << " status= " << status << "; dir= " << g4prim->GetMomentumDirection();
+                                                << " Ptot(GeV/c)= " << ptot << " Pt= " << std::sqrt(px * px + py * py)
+                                                << " status= " << status << "; dir= " << g4prim->GetMomentumDirection();
       }
     }
 
@@ -425,13 +424,13 @@ void Generator3::HepMC2G4(const HepMC3::GenEvent *evt_orig, G4Event *g4evt) {
     g4evt->AddPrimaryVertex(g4vtx);
   }
 
-  edm::LogVerbatim("SimG4CoreGenerator3") << "The list of Geant4 primaries includes " << ng4par << " particles in "
-                                         << ng4vtx << " vertex";
+  edm::LogVerbatim("SimG4CoreGenerator3")
+      << "The list of Geant4 primaries includes " << ng4par << " particles in " << ng4vtx << " vertex";
 
   delete evt;
 }
 
-void Generator3::particleAssignDaughters(G4PrimaryParticle *g4p, HepMC3::GenParticle* vp, double decaylength) {
+void Generator3::particleAssignDaughters(G4PrimaryParticle *g4p, HepMC3::GenParticle *vp, double decaylength) {
   if (verbose > 1) {
     LogDebug("SimG4CoreGenerator3") << "Special case of long decay length \n"
                                    << "Assign daughters with to mother with decaylength=" << decaylength / CLHEP::cm
@@ -445,8 +444,8 @@ void Generator3::particleAssignDaughters(G4PrimaryParticle *g4p, HepMC3::GenPart
 
   if (verbose > 2) {
     LogDebug("SimG4CoreGenerator3") << " px= " << p.px() << " py= " << p.py() << " pz= " << p.pz() << " e= " << p.e()
-                                   << " beta= " << p.Beta() << " gamma= " << p.Gamma()
-                                   << " Proper time= " << proper_time / CLHEP::ns << " ns";
+                                    << " beta= " << p.Beta() << " gamma= " << p.Gamma()
+                                    << " Proper time= " << proper_time / CLHEP::ns << " ns";
   }
 
   // the particle will decay after the same length if it
@@ -455,14 +454,13 @@ void Generator3::particleAssignDaughters(G4PrimaryParticle *g4p, HepMC3::GenPart
   double y1 = vp->end_vertex()->position().y();
   double z1 = vp->end_vertex()->position().z();
 
-  for (HepMC3::GenParticlePtr vpdec : vp->end_vertex()->particles_out() ) {
-
+  for (HepMC3::GenParticlePtr vpdec : vp->end_vertex()->particles_out()) {
     // transform decay products such that in the rest frame of mother
     math::XYZTLorentzVector pdec(
         vpdec->momentum().px(), vpdec->momentum().py(), vpdec->momentum().pz(), vpdec->momentum().e());
 
     // children should only be taken into account once
-    G4PrimaryParticle* g4daught =
+    G4PrimaryParticle *g4daught =
         new G4PrimaryParticle(vpdec->pid(), pdec.x() * CLHEP::GeV, pdec.y() * CLHEP::GeV, pdec.z() * CLHEP::GeV);
 
     if (g4daught->GetG4code() != nullptr) {
@@ -523,7 +521,7 @@ bool Generator3::particlePassesPrimaryCuts(const G4ThreeVector &p) const {
 
   if (verbose > 2)
     LogDebug("SimG4CoreGenerator3") << "Generator ptot(GeV)= " << ptot / CLHEP::GeV << " eta= " << p.eta()
-                                   << "  phi= " << p.phi() << " Flag= " << flag;
+                                    << "  phi= " << p.phi() << " Flag= " << flag;
 
   return flag;
 }
@@ -554,7 +552,6 @@ bool Generator3::IsInTheFilterList(int pdgcode) const {
 }
 
 void Generator3::nonCentralEvent2G4(const HepMC3::GenEvent *evt, G4Event *g4evt) {
-
 #if 0
 
   int i = g4evt->GetNumberOfPrimaryVertex();
@@ -585,5 +582,4 @@ void Generator3::nonCentralEvent2G4(const HepMC3::GenEvent *evt, G4Event *g4evt)
   }  // end loop on HepMC particles
 
 #endif
-
 }

--- a/SimG4Core/Generators/src/Generator3.cc
+++ b/SimG4Core/Generators/src/Generator3.cc
@@ -1,0 +1,594 @@
+#include "SimG4Core/Generators/interface/Generator3.h"
+#include "SimG4Core/Generators/interface/HepMCParticle.h"
+#include "SimG4Core/Generators/interface/LumiMonitorFilter.h"
+
+#include "SimG4Core/Notification/interface/SimG4Exception.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "HepPDT/ParticleID.hh"
+
+#include "G4Event.hh"
+#include "G4HEPEvtParticle.hh"
+#include "G4Log.hh"
+#include "G4ParticleDefinition.hh"
+#include "G4PhysicalConstants.hh"
+#include <CLHEP/Units/SystemOfUnits.h>
+#include "G4UnitsTable.hh"
+
+#include "HepMC3/Print.h"
+
+#include <sstream>
+
+using namespace edm;
+
+Generator3::Generator3(const ParameterSet &p)
+    : fPCuts(p.getParameter<bool>("ApplyPCuts")),
+      fPtransCut(p.getParameter<bool>("ApplyPtransCut")),
+      fEtaCuts(p.getParameter<bool>("ApplyEtaCuts")),
+      fPhiCuts(p.getParameter<bool>("ApplyPhiCuts")),
+      theMinPhiCut(p.getParameter<double>("MinPhiCut")),  // in radians (CMS standard)
+      theMaxPhiCut(p.getParameter<double>("MaxPhiCut")),
+      theMinEtaCut(p.getParameter<double>("MinEtaCut")),
+      theMaxEtaCut(p.getParameter<double>("MaxEtaCut")),
+      theMinPCut(p.getParameter<double>("MinPCut")),  // in GeV (CMS standard)
+      theMaxPCut(p.getParameter<double>("MaxPCut")),
+      theEtaCutForHector(p.getParameter<double>("EtaCutForHector")),
+      verbose(p.getUntrackedParameter<int>("Verbosity", 0)),
+      fLumiFilter(nullptr),
+      evt_(nullptr),
+      vtx_(nullptr),
+      weight_(0),
+      Z_lmin(0),
+      Z_lmax(0),
+      Z_hector(0),
+      pdgFilterSel(false),
+      fPDGFilter(false) {
+  bool lumi = p.getParameter<bool>("ApplyLumiMonitorCuts");
+  if (lumi) {
+    fLumiFilter = new LumiMonitorFilter();
+  }
+
+  double theRDecLenCut = p.getParameter<double>("RDecLenCut") * CLHEP::cm;
+  theDecRCut2 = theRDecLenCut * theRDecLenCut;
+
+  theMinPtCut2 = theMinPCut * theMinPCut;
+
+  double theDecLenCut = p.getParameter<double>("LDecLenCut") * CLHEP::cm;
+
+  maxZCentralCMS = p.getParameter<double>("MaxZCentralCMS") * CLHEP::m;
+
+  fFiductialCuts = (fPCuts || fPtransCut || fEtaCuts || fPhiCuts);
+
+  pdgFilter.resize(0);
+  if (p.exists("PDGselection")) {
+    pdgFilterSel = (p.getParameter<edm::ParameterSet>("PDGselection")).getParameter<bool>("PDGfilterSel");
+    pdgFilter = (p.getParameter<edm::ParameterSet>("PDGselection")).getParameter<std::vector<int>>("PDGfilter");
+    if (!pdgFilter.empty()) {
+      fPDGFilter = true;
+      std::stringstream ss;
+      ss << "SimG4Core/Generator3: ";
+      if (pdgFilterSel) {
+        ss << " Selecting only PDG ID = ";
+      } else {
+        ss << " Filtering out PDG ID = ";
+      }
+      for (unsigned int ii = 0; ii < pdgFilter.size(); ++ii) {
+        ss << pdgFilter[ii] << "  ";
+      }
+      edm::LogVerbatim("SimG4CoreGenerator3") << ss.str();
+    }
+  }
+
+  if (fEtaCuts) {
+    Z_lmax = theRDecLenCut * ((1 - exp(-2 * theMaxEtaCut)) / (2 * exp(-theMaxEtaCut)));
+    Z_lmin = theRDecLenCut * ((1 - exp(-2 * theMinEtaCut)) / (2 * exp(-theMinEtaCut)));
+  }
+
+  Z_hector = theRDecLenCut * ((1 - exp(-2 * theEtaCutForHector)) / (2 * exp(-theEtaCutForHector)));
+
+  edm::LogVerbatim("SimG4CoreGenerator3") << "SimG4Core/Generator3: Rdecaycut= " << theRDecLenCut / CLHEP::cm
+                                         << " cm;  Zdecaycut= " << theDecLenCut / CLHEP::cm
+                                         << "Z_min= " << Z_lmin / CLHEP::cm << " cm; Z_max= " << Z_lmax / CLHEP::cm
+                                         << " cm;\n"
+                                         << "                     MaxZCentralCMS = " << maxZCentralCMS / CLHEP::m
+                                         << " m;"
+                                         << " Z_hector = " << Z_hector / CLHEP::cm << " cm\n"
+                                         << "                     ApplyCuts: " << fFiductialCuts
+                                         << "  PCuts: " << fPCuts << "  PtransCut: " << fPtransCut
+                                         << "  EtaCut: " << fEtaCuts << "  PhiCut: " << fPhiCuts
+                                         << "  LumiMonitorCut: " << lumi;
+  if (fFiductialCuts) {
+    edm::LogVerbatim("SimG4CoreGenerator3")
+        << "SimG4Core/Generator3: Pmin(GeV)= " << theMinPCut << "; Pmax(GeV)= " << theMaxPCut
+        << "; EtaMin= " << theMinEtaCut << "; EtaMax= " << theMaxEtaCut << "; PhiMin(rad)= " << theMinPhiCut
+        << "; PhiMax(rad)= " << theMaxPhiCut;
+  }
+  if (lumi) {
+    fLumiFilter->Describe();
+  }
+}
+
+Generator3::~Generator3() { delete fLumiFilter; }
+
+void Generator3::HepMC2G4(const HepMC3::GenEvent *evt_orig, G4Event *g4evt) {
+  HepMC3::GenEvent* evt = new HepMC3::GenEvent(*evt_orig);
+  //HepMC3::Print::listing(*evt);
+
+  if ( (evt->vertices()).empty() ) {
+    std::stringstream ss;
+    ss << "SimG4Core/Generator3: in event " << g4evt->GetEventID() << " Corrupted Event - GenEvent with no vertex \n";
+    throw SimG4Exception(ss.str());
+  }
+
+  if (!evt->weights().empty()) {
+    weight_ = evt->weights()[0];
+    for (unsigned int iw = 1; iw < evt->weights().size(); ++iw) {
+      // terminate if the vector of weights contains a zero-weight
+      if (evt->weights()[iw] <= 0)
+        break;
+      weight_ *= evt->weights()[iw];
+    }
+  }
+
+  if (vtx_ != nullptr) {
+    delete vtx_;
+  }
+
+  for (HepMC3::GenVertexPtr v : evt->vertices() ) {
+    vtx_ = new math::XYZTLorentzVector( (v->position()).x(),
+                                        (v->position()).y(),
+                                        (v->position()).z(),
+                                        (v->position()).t() );
+    //std::cout << "primary vertex z, t = " << (v->position()).x() << " " << (v->position()).t() << std::endl;
+    break;
+  }
+
+  edm::LogVerbatim("SimG4CoreGenerator3") << "Generator3: primary Vertex = (" << vtx_->x() << ", " << vtx_->y() << ", "
+                                          << vtx_->z() << ")";
+
+  unsigned int ng4vtx = 0;
+  unsigned int ng4par = 0;
+
+  for (HepMC3::GenVertexPtr vitr : evt->vertices() ) {
+    // loop for vertex, is it a real vertex?
+    // Set qvtx to true for any particles that should be propagated by GEANT,
+    // i.e., status 1 particles or status 2 particles that decay outside the
+    // beampipe.
+    G4bool qvtx = false;
+    for (HepMC3::GenParticlePtr pitr : vitr->particles_out() ) {
+      // For purposes of this function, the status is defined as follows:
+      // 1:  particles are not decayed by generator
+      // 2:  particles are decayed by generator but need to be propagated by GEANT
+      // 3:  particles are decayed by generator and do not need to be propagated by GEANT
+      int status = pitr->status();
+      int pdg = pitr->pid();
+      if (status > 3 && isExotic(pdg) && (!(isExoticNonDetectable(pdg)))) {
+        // In Pythia 8, there are many status codes besides 1, 2, 3.
+        // By setting the status to 2 for exotic particles, they will be
+        // checked: if its decay vertex is outside the beampipe, it will be
+        // propagated by GEANT. Some Standard Model particles, e.g., K0, cannot
+        // be propagated by GEANT, so do not change their status code.
+        status = 2;
+      }
+      if (status == 2 && abs(pdg) == 9900015) { // Additional photon?
+        status = 3;
+      }
+
+      // Particles which are not decayed by generator
+      if (status == 1) {
+        // filter out unwanted particles and vertices
+        if (fPDGFilter && !pdgFilterSel && IsInTheFilterList(pdg)) {
+          continue;
+        }
+
+	qvtx = true;
+        if (verbose > 2)
+          LogDebug("SimG4CoreGenerator3") << "GenVertex barcode = " << vitr->id() << " " << qvtx
+                                         << " selected for GenParticle barcode = " << pitr->id(); // barcode is substituted by id
+        break;
+      }
+      // The selection is made considering if the partcile with status = 2
+      // have the end_vertex with a radius greater than the radius of beampipe
+      // cylinder (no requirement on the Z of the vertex is applyed).
+      else if (status == 2) {
+        if (pitr->end_vertex() != nullptr) {
+          double xx = (pitr->end_vertex())->position().x();
+          double yy = (pitr->end_vertex())->position().y();
+          double r_dd = xx * xx + yy * yy;
+          if (r_dd > theDecRCut2) {
+            qvtx = true;
+            if (verbose > 2)
+              LogDebug("SimG4CoreGenerator3")
+                  << "GenVertex barcode = " << vitr->id()
+                  << " selected for GenParticle barcode = " << pitr->id() << " radius = " << std::sqrt(r_dd); // barcode is substituted by id
+            break;
+          }
+        } else {
+          // particles with status 2 without end_vertex are
+          // equivalent to stable
+          qvtx = true;
+          break;
+        }
+      }
+    }
+
+    // if this vertex is inside fiductial volume inside the beam pipe
+    // and has no long-lived secondary the vertex is not saved
+    if (!qvtx) {
+      continue;
+    }
+
+    double x1 = vitr->position().x() * CLHEP::mm;
+    double y1 = vitr->position().y() * CLHEP::mm;
+    double z1 = vitr->position().z() * CLHEP::mm;
+    double t1 = vitr->position().t() * CLHEP::mm / CLHEP::c_light;
+
+    G4PrimaryVertex *g4vtx = new G4PrimaryVertex(x1, y1, z1, t1);
+
+    for (HepMC3::GenParticlePtr pitr : vitr->particles_out() ) {
+      int status = pitr->status();
+      int pdg = pitr->pid();
+      bool hasDecayVertex = (nullptr != pitr->end_vertex());
+
+      // Filter on allowed particle species if required
+      if (fPDGFilter) {
+        bool isInTheList = IsInTheFilterList(pdg);
+        if ((!pdgFilterSel && isInTheList) || (pdgFilterSel && !isInTheList)) {
+          if (0 < verbose)
+            edm::LogVerbatim("SimG4CoreGenerator3")
+                << " Skiped GenParticle barcode= " << pitr->id() << " PDGid= " << pdg << " status= " << status
+                << " isExotic: " << isExotic(pdg) << " isExoticNotDet: " << isExoticNonDetectable(pdg)
+                << " isInTheList: " << isInTheList << " hasDecayVertex: " << hasDecayVertex;
+          continue;
+        }
+      }
+
+      if (0 < verbose) {
+        edm::LogVerbatim("SimG4CoreGenerator3")
+            << "Generator3: pdg= " << pdg << " status= " << status << " hasPreDefinedDecay: " << hasDecayVertex
+            << "\n           isExotic: " << isExotic(pdg) << " isExoticNotDet: " << isExoticNonDetectable(pdg)
+            << " isInTheList: " << IsInTheFilterList(pdg) << "\n"
+            << " MaxZCentralCMS = " << maxZCentralCMS / CLHEP::m << " m;  (x,y,z,t): (" << x1 << "," << y1 << "," << z1
+            << "," << t1 << ")";
+      }
+      if (status > 3 && isExotic(pdg) && (!(isExoticNonDetectable(pdg)))) {
+        status = hasDecayVertex ? 2 : 1;
+      }
+      if (status == 2 && abs(pdg) == 9900015) { // Additional photon?
+        status = 3;
+      }
+
+      // this particle has predefined decay but has no vertex
+      if (2 == status && !hasDecayVertex) {
+        edm::LogWarning("SimG4CoreGenerator3: in event ")
+            << g4evt->GetEventID() << " a particle "
+            << " pdgid= " << pdg << " has status=2 but has no decay vertex, so will be fully tracked by Geant4";
+        status = 1;
+      }
+
+      double x2 = x1;
+      double y2 = y1;
+      double z2 = z1;
+      double decay_length = 0.0;
+      if (2 == status) {
+        x2 = pitr->end_vertex()->position().x();
+        y2 = pitr->end_vertex()->position().y();
+        z2 = pitr->end_vertex()->position().z();
+        decay_length = std::sqrt((x2 - x1) * (x2 - x1) + (y2 - y1) * (y2 - y1) + (z2 - z1) * (z2 - z1));
+      }
+
+      bool toBeAdded = !fFiductialCuts;
+
+      double px = pitr->momentum().px();
+      double py = pitr->momentum().py();
+      double pz = pitr->momentum().pz();
+      double ptot = std::sqrt(px * px + py * py + pz * pz);
+      math::XYZTLorentzVector p(px, py, pz, pitr->momentum().e());
+
+      double ximpact = x1;
+      double yimpact = y1;
+      double zimpact = z1;
+
+      // protection against numerical problems for extremely low momenta
+      // compute impact point at transition to Hector
+      const double minTan = 1.e-20;
+      if (std::abs(z1) < Z_hector && std::abs(pz) >= minTan * ptot) {
+        zimpact = (pz > 0.0) ? Z_hector : -Z_hector;
+        double del = (zimpact - z1) / pz;
+        ximpact += del * px;
+        yimpact += del * py;
+      }
+      double rimpact2 = ximpact * ximpact + yimpact * yimpact;
+
+      if (verbose > 2)
+        LogDebug("SimG4CoreGenerator3") << "Processing GenParticle barcode= " << pitr->id() << " pdg= " << pdg
+                                       << " status= " << pitr->status() << " st= " << status
+                                       << " rimpact(cm)= " << std::sqrt(rimpact2) / CLHEP::cm
+                                       << " zimpact(cm)= " << zimpact / CLHEP::cm << " ptot(GeV)= " << ptot
+                                       << " pz(GeV)= " << pz;
+
+      // Particles of status 1 trasnported along the beam pipe
+      // HECTOR transport of protons are done in corresponding PPS producer
+      if (1 == status && std::abs(zimpact) >= Z_hector && rimpact2 <= theDecRCut2) {
+        // very forward n, nbar, gamma are allowed
+        toBeAdded = (2112 == std::abs(pdg) || 22 == pdg);
+        if (verbose > 1) {
+          edm::LogVerbatim("SimG4CoreGenerator3")
+              << "GenParticle barcode = " << pitr->id() << " very forward; to be added: " << toBeAdded;
+        }
+      } else {
+     	// Standard case: particles not decayed by the generator and not forward
+        if (1 == status && (std::abs(zimpact) < Z_hector || rimpact2 > theDecRCut2)) {
+          // Ptot cut for all particles
+          if (fPCuts && (ptot < theMinPCut || ptot > theMaxPCut)) {
+            continue;
+          }
+          // phi cut is applied mainly for particle gun
+          if (fPhiCuts) {
+            double phi = p.phi();
+            if (phi < theMinPhiCut || phi > theMaxPhiCut) {
+              continue;
+            }
+          }
+          // eta cut is applied if position of the decay
+          // is within vacuum chamber and limited in Z
+          if (fEtaCuts) {
+            // eta cut
+            double xi = x1;
+            double yi = y1;
+            double zi = z1;
+
+            // can be propagated along Z
+            if (std::abs(pz) >= minTan * ptot) {
+              if ((zi >= Z_lmax) & (pz < 0.0)) {
+                zi = Z_lmax;
+              } else if ((zi <= Z_lmin) & (pz > 0.0)) {
+                zi = Z_lmin;
+              } else {
+                if (pz > 0) {
+                  zi = Z_lmax;
+                } else {
+                  zi = Z_lmin;
+                }
+              }
+              double del = (zi - z1) / pz;
+              xi += del * px;
+              yi += del * py;
+            }
+            // check eta cut
+            if ((zi >= Z_lmin) & (zi <= Z_lmax) & (xi * xi + yi * yi < theDecRCut2)) {
+              continue;
+            }
+          }
+          const HepMC3::GenParticle* ppointer = pitr.get();
+          if (fLumiFilter && !fLumiFilter->isGoodForLumiMonitor(ppointer)) { // MK: this function is always true
+            continue;
+          }
+          toBeAdded = true;
+          if (verbose > 1)
+            edm::LogVerbatim("SimG4CoreGenerator3")
+                << "GenParticle barcode = " << pitr->id() << " passed case 1";
+
+          // Decay chain outside the fiducial cylinder defined by theRDecLenCut
+          // are used for Geant4 tracking with predefined decay channel
+          // In the case of decay in vacuum particle is not tracked by Geant4
+        } else if (2 == status && x2 * x2 + y2 * y2 >= theDecRCut2 && std::abs(z2) < Z_hector) {
+          toBeAdded = true;
+          if (verbose > 1)
+            edm::LogVerbatim("SimG4CoreGenerator3") << "GenParticle barcode = " << pitr->id() << " passed case 2"
+                                                   << " decay_length(cm)= " << decay_length / CLHEP::cm;
+        }
+      }
+      if (toBeAdded) {
+        G4PrimaryParticle *g4prim = new G4PrimaryParticle(pdg, px * CLHEP::GeV, py * CLHEP::GeV, pz * CLHEP::GeV);
+
+        if (g4prim->GetG4code() != nullptr) {
+          g4prim->SetMass(g4prim->GetG4code()->GetPDGMass());
+          double charge = g4prim->GetG4code()->GetPDGCharge();
+
+          // apply Pt cut
+          if (fPtransCut && 1 == status && 0.0 != charge && px * px + py * py < theMinPtCut2) {
+            delete g4prim;
+            continue;
+          }
+          g4prim->SetCharge(charge);
+        }
+
+     	// V.I. do not use SetWeight but the same code
+        // value of the code compute inside TrackWithHistory
+        // g4prim->SetWeight( 10000*(*vpitr)->barcode() ) ;
+        setGenId(g4prim, pitr->id());
+
+        if (2 == status) {
+          particleAssignDaughters(g4prim, pitr.get(), decay_length);
+        }
+        if (verbose > 1)
+          g4prim->Print();
+
+        ++ng4par;
+        g4vtx->SetPrimary(g4prim);
+        edm::LogVerbatim("SimG4CoreGenerator3") << "   " << ng4par << ". new Geant4 particle pdg= " << pdg
+                                               << " Ptot(GeV/c)= " << ptot << " Pt= " << std::sqrt(px * px + py * py)
+                                               << " status= " << status << "; dir= " << g4prim->GetMomentumDirection();
+      }
+    }
+
+    if (verbose > 1)
+      g4vtx->Print();
+    g4evt->AddPrimaryVertex(g4vtx);
+    ++ng4vtx;
+  }
+
+  // Add a protection for completely empty events (produced by LHCTransport):
+  // add a dummy vertex with no particle attached to it
+  if (ng4vtx == 0) {
+    G4PrimaryVertex *g4vtx = new G4PrimaryVertex(0.0, 0.0, 0.0, 0.0);
+    if (verbose > 1)
+      g4vtx->Print();
+
+    g4evt->AddPrimaryVertex(g4vtx);
+  }
+
+  edm::LogVerbatim("SimG4CoreGenerator3") << "The list of Geant4 primaries includes " << ng4par << " particles in "
+                                         << ng4vtx << " vertex";
+
+  delete evt;
+}
+
+void Generator3::particleAssignDaughters(G4PrimaryParticle *g4p, HepMC3::GenParticle* vp, double decaylength) {
+  if (verbose > 1) {
+    LogDebug("SimG4CoreGenerator3") << "Special case of long decay length \n"
+                                   << "Assign daughters with to mother with decaylength=" << decaylength / CLHEP::cm
+                                   << " cm";
+  }
+  math::XYZTLorentzVector p(vp->momentum().px(), vp->momentum().py(), vp->momentum().pz(), vp->momentum().e());
+
+  // defined preassigned decay time
+  double proper_time = decaylength / (p.Beta() * p.Gamma() * c_light);
+  g4p->SetProperTime(proper_time);
+
+  if (verbose > 2) {
+    LogDebug("SimG4CoreGenerator3") << " px= " << p.px() << " py= " << p.py() << " pz= " << p.pz() << " e= " << p.e()
+                                   << " beta= " << p.Beta() << " gamma= " << p.Gamma()
+                                   << " Proper time= " << proper_time / CLHEP::ns << " ns";
+  }
+
+  // the particle will decay after the same length if it
+  // has not interacted before
+  double x1 = vp->end_vertex()->position().x();
+  double y1 = vp->end_vertex()->position().y();
+  double z1 = vp->end_vertex()->position().z();
+
+  for (HepMC3::GenParticlePtr vpdec : vp->end_vertex()->particles_out() ) {
+
+    // transform decay products such that in the rest frame of mother
+    math::XYZTLorentzVector pdec(
+        vpdec->momentum().px(), vpdec->momentum().py(), vpdec->momentum().pz(), vpdec->momentum().e());
+
+    // children should only be taken into account once
+    G4PrimaryParticle* g4daught =
+        new G4PrimaryParticle(vpdec->pid(), pdec.x() * CLHEP::GeV, pdec.y() * CLHEP::GeV, pdec.z() * CLHEP::GeV);
+
+    if (g4daught->GetG4code() != nullptr) {
+      g4daught->SetMass(g4daught->GetG4code()->GetPDGMass());
+      g4daught->SetCharge(g4daught->GetG4code()->GetPDGCharge());
+    }
+
+    // V.I. do not use SetWeight but the same code
+    // value of the code compute inside TrackWithHistory
+    setGenId(g4daught, vpdec->id());
+
+    int status = vpdec->status();
+    if (verbose > 1)
+      LogDebug("SimG4CoreGenerator3::::particleAssignDaughters")
+          << "Assigning a " << vpdec->pid() << " as daughter of a " << vp->pid() << " status=" << status;
+
+    if ((status == 2 || (status == 23 && std::abs(vp->pid()) == 1000015) || (status > 50 && status < 100)) &&
+        vpdec->end_vertex() != nullptr) {
+      double x2 = vpdec->end_vertex()->position().x();
+      double y2 = vpdec->end_vertex()->position().y();
+      double z2 = vpdec->end_vertex()->position().z();
+      double dd = std::sqrt((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2) + (z1 - z2) * (z1 - z2));
+      particleAssignDaughters(g4daught, vpdec.get(), dd);
+    }
+    vpdec->set_status(1000 + status);
+    g4p->SetDaughter(g4daught);
+
+    if (verbose > 1)
+      g4daught->Print();
+  }
+}
+
+// Used for non-beam particles
+bool Generator3::particlePassesPrimaryCuts(const G4ThreeVector &p) const {
+  bool flag = true;
+  double ptot = p.mag();
+  if (fPCuts && (ptot < theMinPCut * CLHEP::GeV || ptot > theMaxPCut * CLHEP::GeV)) {
+    flag = false;
+  }
+  if (fEtaCuts && flag) {
+    double pz = p.z();
+    if (ptot < pz + 1.e-10) {
+      flag = false;
+
+    } else {
+      double eta = 0.5 * G4Log((ptot + pz) / (ptot - pz));
+      if (eta < theMinEtaCut || eta > theMaxEtaCut) {
+        flag = false;
+      }
+    }
+  }
+  if (fPhiCuts && flag) {
+    double phi = p.phi();
+    if (phi < theMinPhiCut || phi > theMaxPhiCut) {
+      flag = false;
+    }
+  }
+
+  if (verbose > 2)
+    LogDebug("SimG4CoreGenerator3") << "Generator ptot(GeV)= " << ptot / CLHEP::GeV << " eta= " << p.eta()
+                                   << "  phi= " << p.phi() << " Flag= " << flag;
+
+  return flag;
+}
+
+bool Generator3::isExotic(int pdgcode) const {
+  int pdgid = std::abs(pdgcode);
+  return ((pdgid >= 1000000 && pdgid < 4000000 && pdgid != 3000022) ||  // SUSY, R-hadron, and technicolor particles
+          pdgid == 17 ||                                                // 4th generation lepton
+          pdgid == 34 ||                                                // W-prime
+          pdgid == 37);                                                 // charged Higgs
+}
+
+bool Generator3::isExoticNonDetectable(int pdgcode) const {
+  int pdgid = std::abs(pdgcode);
+  HepPDT::ParticleID pid(pdgcode);
+  int charge = pid.threeCharge();
+  return ((charge == 0) && (pdgid >= 1000000 && pdgid < 1000040));  // SUSY
+}
+
+bool Generator3::IsInTheFilterList(int pdgcode) const {
+  int pdgid = std::abs(pdgcode);
+  for (auto &pdg : pdgFilter) {
+    if (std::abs(pdg) == pdgid) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void Generator3::nonCentralEvent2G4(const HepMC3::GenEvent *evt, G4Event *g4evt) {
+
+#if 0
+
+  int i = g4evt->GetNumberOfPrimaryVertex();
+  for (HepMC3::GenEvent::particle_const_iterator it = evt->particles_begin(); it != evt->particles_end(); ++it) {
+    ++i;
+    HepMC3::GenParticle *gp = (*it);
+
+    // storing only particle with status == 1
+    if (gp->status() != 1)
+      continue;
+
+    int pdg = gp->pdg_id();
+    G4PrimaryParticle *g4p = new G4PrimaryParticle(
+        pdg, gp->momentum().px() * CLHEP::GeV, gp->momentum().py() * CLHEP::GeV, gp->momentum().pz() * CLHEP::GeV);
+    if (g4p->GetG4code() != nullptr) {
+      g4p->SetMass(g4p->GetG4code()->GetPDGMass());
+      g4p->SetCharge(g4p->GetG4code()->GetPDGCharge());
+    }
+    setGenId(g4p, i);
+    G4PrimaryVertex *v = new G4PrimaryVertex(gp->production_vertex()->position().x() * CLHEP::mm,
+                                             gp->production_vertex()->position().y() * CLHEP::mm,
+                                             gp->production_vertex()->position().z() * CLHEP::mm,
+                                             gp->production_vertex()->position().t() * CLHEP::mm / CLHEP::c_light);
+    v->SetPrimary(g4p);
+    g4evt->AddPrimaryVertex(v);
+    if (verbose > 0)
+      v->Print();
+  }  // end loop on HepMC particles
+
+#endif
+
+}

--- a/SimG4Core/Generators/src/Generator3.cc
+++ b/SimG4Core/Generators/src/Generator3.cc
@@ -87,17 +87,15 @@ Generator3::Generator3(const ParameterSet &p)
 
   Z_hector = theRDecLenCut * ((1 - exp(-2 * theEtaCutForHector)) / (2 * exp(-theEtaCutForHector)));
 
-  edm::LogVerbatim("SimG4CoreGenerator3") << "SimG4Core/Generator3: Rdecaycut= " << theRDecLenCut / CLHEP::cm
-                                         << " cm;  Zdecaycut= " << theDecLenCut / CLHEP::cm
-                                         << "Z_min= " << Z_lmin / CLHEP::cm << " cm; Z_max= " << Z_lmax / CLHEP::cm
-                                         << " cm;\n"
-                                         << "                     MaxZCentralCMS = " << maxZCentralCMS / CLHEP::m
-                                         << " m;"
-                                         << " Z_hector = " << Z_hector / CLHEP::cm << " cm\n"
-                                         << "                     ApplyCuts: " << fFiductialCuts
-                                         << "  PCuts: " << fPCuts << "  PtransCut: " << fPtransCut
-                                         << "  EtaCut: " << fEtaCuts << "  PhiCut: " << fPhiCuts
-                                         << "  LumiMonitorCut: " << lumi;
+  edm::LogVerbatim("SimG4CoreGenerator3")
+      << "SimG4Core/Generator3: Rdecaycut= " << theRDecLenCut / CLHEP::cm
+      << " cm;  Zdecaycut= " << theDecLenCut / CLHEP::cm
+      << "Z_min= " << Z_lmin / CLHEP::cm << " cm; Z_max= " << Z_lmax / CLHEP::cm << " cm;\n"
+      << "                     MaxZCentralCMS = " << maxZCentralCMS / CLHEP::m << " m;"
+      << " Z_hector = " << Z_hector / CLHEP::cm << " cm\n"
+      << "                     ApplyCuts: " << fFiductialCuts
+      << "  PCuts: " << fPCuts << "  PtransCut: " << fPtransCut
+      << "  EtaCut: " << fEtaCuts << "  PhiCut: " << fPhiCuts << "  LumiMonitorCut: " << lumi;
   if (fFiductialCuts) {
     edm::LogVerbatim("SimG4CoreGenerator3")
         << "SimG4Core/Generator3: Pmin(GeV)= " << theMinPCut << "; Pmax(GeV)= " << theMaxPCut
@@ -112,10 +110,10 @@ Generator3::Generator3(const ParameterSet &p)
 Generator3::~Generator3() { delete fLumiFilter; }
 
 void Generator3::HepMC2G4(const HepMC3::GenEvent *evt_orig, G4Event *g4evt) {
-  HepMC3::GenEvent* evt = new HepMC3::GenEvent(*evt_orig);
+  HepMC3::GenEvent *evt = new HepMC3::GenEvent(*evt_orig);
   //HepMC3::Print::listing(*evt);
 
-  if ( (evt->vertices()).empty() ) {
+  if ((evt->vertices()).empty()) {
     std::stringstream ss;
     ss << "SimG4Core/Generator3: in event " << g4evt->GetEventID() << " Corrupted Event - GenEvent with no vertex \n";
     throw SimG4Exception(ss.str());
@@ -135,28 +133,25 @@ void Generator3::HepMC2G4(const HepMC3::GenEvent *evt_orig, G4Event *g4evt) {
     delete vtx_;
   }
 
-  for (HepMC3::GenVertexPtr v : evt->vertices() ) {
-    vtx_ = new math::XYZTLorentzVector( (v->position()).x(),
-                                        (v->position()).y(),
-                                        (v->position()).z(),
-                                        (v->position()).t() );
-    //std::cout << "primary vertex z, t = " << (v->position()).x() << " " << (v->position()).t() << std::endl;
+  for (HepMC3::GenVertexPtr v : evt->vertices()) {
+    vtx_ =
+        new math::XYZTLorentzVector( (v->position()).x(), (v->position()).y(), (v->position()).z(), (v->position()).t());
     break;
   }
 
-  edm::LogVerbatim("SimG4CoreGenerator3") << "Generator3: primary Vertex = (" << vtx_->x() << ", " << vtx_->y() << ", "
-                                          << vtx_->z() << ")";
+  edm::LogVerbatim("SimG4CoreGenerator3")
+      << "Generator3: primary Vertex = (" << vtx_->x() << ", " << vtx_->y() << ", " << vtx_->z() << ")";
 
   unsigned int ng4vtx = 0;
   unsigned int ng4par = 0;
 
-  for (HepMC3::GenVertexPtr vitr : evt->vertices() ) {
+  for (HepMC3::GenVertexPtr vitr : evt->vertices()) {
     // loop for vertex, is it a real vertex?
     // Set qvtx to true for any particles that should be propagated by GEANT,
     // i.e., status 1 particles or status 2 particles that decay outside the
     // beampipe.
     G4bool qvtx = false;
-    for (HepMC3::GenParticlePtr pitr : vitr->particles_out() ) {
+    for (HepMC3::GenParticlePtr pitr : vitr->particles_out()) {
       // For purposes of this function, the status is defined as follows:
       // 1:  particles are not decayed by generator
       // 2:  particles are decayed by generator but need to be propagated by GEANT
@@ -171,7 +166,7 @@ void Generator3::HepMC2G4(const HepMC3::GenEvent *evt_orig, G4Event *g4evt) {
         // be propagated by GEANT, so do not change their status code.
         status = 2;
       }
-      if (status == 2 && abs(pdg) == 9900015) { // Additional photon?
+      if (status == 2 && abs(pdg) == 9900015) {  // Additional photon?
         status = 3;
       }
 
@@ -182,7 +177,7 @@ void Generator3::HepMC2G4(const HepMC3::GenEvent *evt_orig, G4Event *g4evt) {
           continue;
         }
 
-	qvtx = true;
+        qvtx = true;
         if (verbose > 2)
           LogDebug("SimG4CoreGenerator3") << "GenVertex barcode = " << vitr->id() << " " << qvtx
                                          << " selected for GenParticle barcode = " << pitr->id(); // barcode is substituted by id

--- a/SimG4Core/Generators/src/Generator3.cc
+++ b/SimG4Core/Generators/src/Generator3.cc
@@ -196,7 +196,7 @@ void Generator3::HepMC2G4(const HepMC3::GenEvent *evt_orig, G4Event *g4evt) {
             if (verbose > 2)
               LogDebug("SimG4CoreGenerator3")
                   << "GenVertex barcode = " << vitr->id() << " selected for GenParticle barcode = " << pitr->id()
-                  << " radius = " << std::sqrt(r_dd); // barcode is substituted by id
+                  << " radius = " << std::sqrt(r_dd);  // barcode is substituted by id
             break;
           }
         } else {
@@ -356,7 +356,7 @@ void Generator3::HepMC2G4(const HepMC3::GenEvent *evt_orig, G4Event *g4evt) {
               continue;
             }
           }
-          const HepMC3::GenParticle* ppointer = pitr.get();
+          const HepMC3::GenParticle *ppointer = pitr.get();
           if (fLumiFilter && !fLumiFilter->isGoodForLumiMonitor(ppointer)) {  // MK: this function is always true
             continue;
           }
@@ -431,10 +431,10 @@ void Generator3::HepMC2G4(const HepMC3::GenEvent *evt_orig, G4Event *g4evt) {
 }
 
 void Generator3::particleAssignDaughters(G4PrimaryParticle *g4p, HepMC3::GenParticle *vp, double decaylength) {
-  if (verbose > 1) {
+  if (verbose > 1) {  // MK: Check message below
     LogDebug("SimG4CoreGenerator3") << "Special case of long decay length \n"
-                                   << "Assign daughters with to mother with decaylength=" << decaylength / CLHEP::cm
-                                   << " cm";
+                                    << "Assign daughters to mother with decaylength=" << decaylength / CLHEP::cm
+                                    << " cm";
   }
   math::XYZTLorentzVector p(vp->momentum().px(), vp->momentum().py(), vp->momentum().pz(), vp->momentum().e());
 

--- a/SimG4Core/Generators/src/LumiMonitorFilter.cc
+++ b/SimG4Core/Generators/src/LumiMonitorFilter.cc
@@ -15,4 +15,3 @@ void LumiMonitorFilter::Describe() const { edm::LogInfo("LumiMonitorFilter") << 
 bool LumiMonitorFilter::isGoodForLumiMonitor(const HepMC::GenParticle *) const { return true; }
 
 bool LumiMonitorFilter::isGoodForLumiMonitor(const HepMC3::GenParticle *) const { return true; }
-

--- a/SimG4Core/Generators/src/LumiMonitorFilter.cc
+++ b/SimG4Core/Generators/src/LumiMonitorFilter.cc
@@ -13,3 +13,6 @@ LumiMonitorFilter::~LumiMonitorFilter() {}
 void LumiMonitorFilter::Describe() const { edm::LogInfo("LumiMonitorFilter") << " is active "; }
 
 bool LumiMonitorFilter::isGoodForLumiMonitor(const HepMC::GenParticle *) const { return true; }
+
+bool LumiMonitorFilter::isGoodForLumiMonitor(const HepMC3::GenParticle *) const { return true; }
+


### PR DESCRIPTION
This is a continuation of the work described in the issue #36662
The added code allows to transfer the HepMC3 event record to Sim and load particles in Geant4. It is NOT USED if HepMC record is produced in the Genarator part.
Two test configurations are added in Pythia8Interface/test