### PR TITLE
Update on genDressedLepton pT threshold for nanoAOD

### DIFF
--- a/PhysicsTools/NanoAOD/python/particlelevel_cff.py
+++ b/PhysicsTools/NanoAOD/python/particlelevel_cff.py
@@ -63,7 +63,7 @@ rivetProducerHTXS = cms.EDProducer('HTXSRivetProducer',
 ##################### Tables for final output and docs ##########################
 rivetLeptonTable = simpleCandidateFlatTableProducer.clone(
     src = cms.InputTag("particleLevel:leptons"),
-    cut = cms.string("pt > 15"),
+    cut = cms.string("pt > 10"),
     name= cms.string("GenDressedLepton"),
     doc = cms.string("Dressed leptons from Rivet-based ParticleLevelProducer"),
     externalVariables = cms.PSet(


### PR DESCRIPTION
#### PR description:
Dear reviewers,

This PR is to reduce the threshold of the current nanoAOD genDressedLeptons to 15 GeV. This would benefit future differential measurements that would be able to target the 10 GeV to 15 GeV region of the lepton pT threshold, but so far have been unable to do so because the genDressedLepton collection in the current nanoAODs did not include these leptons. 

The idea is to include this in the nanoAOD v15. 

#### PR validation:

The change is trivial, but still double-checked with the runTheMatrix.py tests.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

The idea is to have this included in nanoAODv15, so we would like to have this backported to CMSSW_14_0_18 (if I'm not mistaken, that is the CMSSW version for the RunIIISummer campaigns that have been created recently).