### PR TITLE
Removal of LST *ByLayer( functions to fix build errors

### DIFF
--- a/RecoTracker/LSTCore/src/alpaka/LSTEvent.dev.cc
+++ b/RecoTracker/LSTCore/src/alpaka/LSTEvent.dev.cc
@@ -1271,13 +1271,6 @@ unsigned int LSTEvent::getNumberOfMiniDoublets() {
   return miniDoublets;
 }
 
-unsigned int LSTEvent::getNumberOfMiniDoubletsByLayer(unsigned int layer) {
-  if (layer == 6)
-    return n_minidoublets_by_layer_barrel_[layer];
-  else
-    return n_minidoublets_by_layer_barrel_[layer] + n_minidoublets_by_layer_endcap_[layer];
-}
-
 unsigned int LSTEvent::getNumberOfMiniDoubletsByLayerBarrel(unsigned int layer) {
   return n_minidoublets_by_layer_barrel_[layer];
 }
@@ -1298,13 +1291,6 @@ unsigned int LSTEvent::getNumberOfSegments() {
   return segments;
 }
 
-unsigned int LSTEvent::getNumberOfSegmentsByLayer(unsigned int layer) {
-  if (layer == 6)
-    return n_segments_by_layer_barrel_[layer];
-  else
-    return n_segments_by_layer_barrel_[layer] + n_segments_by_layer_endcap_[layer];
-}
-
 unsigned int LSTEvent::getNumberOfSegmentsByLayerBarrel(unsigned int layer) {
   return n_segments_by_layer_barrel_[layer];
 }
@@ -1323,13 +1309,6 @@ unsigned int LSTEvent::getNumberOfTriplets() {
   }
 
   return triplets;
-}
-
-unsigned int LSTEvent::getNumberOfTripletsByLayer(unsigned int layer) {
-  if (layer == 6)
-    return n_triplets_by_layer_barrel_[layer];
-  else
-    return n_triplets_by_layer_barrel_[layer] + n_triplets_by_layer_endcap_[layer];
 }
 
 unsigned int LSTEvent::getNumberOfTripletsByLayerBarrel(unsigned int layer) {
@@ -1371,13 +1350,6 @@ unsigned int LSTEvent::getNumberOfQuintuplets() {
   }
 
   return quintuplets;
-}
-
-unsigned int LSTEvent::getNumberOfQuintupletsByLayer(unsigned int layer) {
-  if (layer == 6)
-    return n_quintuplets_by_layer_barrel_[layer];
-  else
-    return n_quintuplets_by_layer_barrel_[layer] + n_quintuplets_by_layer_endcap_[layer];
 }
 
 unsigned int LSTEvent::getNumberOfQuintupletsByLayerBarrel(unsigned int layer) {

--- a/RecoTracker/LSTCore/src/alpaka/LSTEvent.h
+++ b/RecoTracker/LSTCore/src/alpaka/LSTEvent.h
@@ -137,17 +137,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     void resetObjectsInModule();
 
     unsigned int getNumberOfMiniDoublets();
-    unsigned int getNumberOfMiniDoubletsByLayer(unsigned int layer);
     unsigned int getNumberOfMiniDoubletsByLayerBarrel(unsigned int layer);
     unsigned int getNumberOfMiniDoubletsByLayerEndcap(unsigned int layer);
 
     unsigned int getNumberOfSegments();
-    unsigned int getNumberOfSegmentsByLayer(unsigned int layer);
     unsigned int getNumberOfSegmentsByLayerBarrel(unsigned int layer);
     unsigned int getNumberOfSegmentsByLayerEndcap(unsigned int layer);
 
     unsigned int getNumberOfTriplets();
-    unsigned int getNumberOfTripletsByLayer(unsigned int layer);
     unsigned int getNumberOfTripletsByLayerBarrel(unsigned int layer);
     unsigned int getNumberOfTripletsByLayerEndcap(unsigned int layer);
 
@@ -155,7 +152,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     int getNumberOfPixelQuintuplets();
 
     unsigned int getNumberOfQuintuplets();
-    unsigned int getNumberOfQuintupletsByLayer(unsigned int layer);
     unsigned int getNumberOfQuintupletsByLayerBarrel(unsigned int layer);
     unsigned int getNumberOfQuintupletsByLayerEndcap(unsigned int layer);
 


### PR DESCRIPTION
This PR aims to solve the [build errors](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el9_amd64_gcc13/CMSSW_15_0_X_2024-11-22-2300/RecoTracker/LSTCore) related to LST that were reported in https://github.com/cms-sw/cmssw/pull/45117#issuecomment-2499098246. The offending functions are not currently in use, so they are removed with this PR, solving the issue.

FYI: @smuzaffar 