### PR TITLE
Add Et distributions for BC & SC energy ECAL DQM plots [14_2_X]

### DIFF
--- a/DQM/EcalMonitorTasks/python/ClusterTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/ClusterTask_cfi.py
@@ -103,6 +103,19 @@ ecalClusterTask = cms.untracked.PSet(
             btype = cms.untracked.string('User'),
             description = cms.untracked.string('Basic cluster energy distribution.')
         ),
+        BCEt = cms.untracked.PSet(
+            path = cms.untracked.string('%(subdet)s/%(prefix)sClusterTask/%(prefix)sCLT BC transverse energy'),
+            kind = cms.untracked.string('TH1F'),
+            otype = cms.untracked.string('Ecal2P'),
+            xaxis = cms.untracked.PSet(
+                high = cms.untracked.double(150.0),
+                nbins = cms.untracked.int32(50),
+                low = cms.untracked.double(0.0),
+                title = cms.untracked.string('energy (GeV)')
+            ),
+            btype = cms.untracked.string('User'),
+            description = cms.untracked.string('Basic cluster transverse energy distribution.')
+        ),
         BCSizeMap = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sClusterTask/%(prefix)sCLT BC size map%(suffix)s'),
             kind = cms.untracked.string('TProfile2D'),
@@ -151,6 +164,16 @@ ecalClusterTask = cms.untracked.PSet(
             otype = cms.untracked.string('Ecal3P'),
             btype = cms.untracked.string('SuperCrystal'),
             description = cms.untracked.string('2D distribution of the mean energy of the basic clusters.')
+        ),
+        BCEtMap = cms.untracked.PSet(
+            path = cms.untracked.string('%(subdet)s/%(prefix)sClusterTask/%(prefix)sCLT BC transverse energy map%(suffix)s'),
+            kind = cms.untracked.string('TProfile2D'),
+            zaxis = cms.untracked.PSet(
+                title = cms.untracked.string('energy (GeV)')
+            ),
+            otype = cms.untracked.string('Ecal3P'),
+            btype = cms.untracked.string('SuperCrystal'),
+            description = cms.untracked.string('2D distribution of the mean transverse energy of the basic clusters.')
         ),
         BCEtMapProjEta = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sClusterTask/%(prefix)sCLT BC ET projection eta%(suffix)s'),
@@ -272,6 +295,19 @@ ecalClusterTask = cms.untracked.PSet(
             btype = cms.untracked.string('User'),
             description = cms.untracked.string('Super cluster energy distribution.')
         ),
+        SCEt = cms.untracked.PSet(
+            path = cms.untracked.string('%(subdet)s/%(prefix)sClusterTask/%(prefix)sCLT SC transverse energy'),
+            kind = cms.untracked.string('TH1F'),
+            otype = cms.untracked.string('Ecal2P'),
+            xaxis = cms.untracked.PSet(
+                high = cms.untracked.double(150.0),
+                nbins = cms.untracked.int32(50),
+                low = cms.untracked.double(0.0),
+                title = cms.untracked.string('energy (GeV)')
+            ),
+            btype = cms.untracked.string('User'),
+            description = cms.untracked.string('Super cluster transverse energy distribution.')
+        ),
         SCRawE = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sClusterTask/%(prefix)sCLT SC raw energy'),
             kind = cms.untracked.string('TH1F'),
@@ -284,6 +320,19 @@ ecalClusterTask = cms.untracked.PSet(
             ),
             btype = cms.untracked.string('User'),
             description = cms.untracked.string('Super cluster raw energy distribution.')
+        ),
+        SCRawEt = cms.untracked.PSet(
+            path = cms.untracked.string('%(subdet)s/%(prefix)sClusterTask/%(prefix)sCLT SC raw transverse energy'),
+            kind = cms.untracked.string('TH1F'),
+            otype = cms.untracked.string('Ecal2P'),
+            xaxis = cms.untracked.PSet(
+                high = cms.untracked.double(150.0),
+                nbins = cms.untracked.int32(50),
+                low = cms.untracked.double(0.0),
+                title = cms.untracked.string('energy (GeV)')
+            ),
+            btype = cms.untracked.string('User'),
+            description = cms.untracked.string('Super cluster raw transverse energy distribution.')
         ),
         SCNcrystals = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sClusterTask/%(prefix)sCLT SC size (crystal)'),
@@ -336,6 +385,19 @@ ecalClusterTask = cms.untracked.PSet(
             btype = cms.untracked.string('User'),
             description = cms.untracked.string('Energy distribution (raw energy) of the super clusters (low scale).')
         ),
+        SCEtLow = cms.untracked.PSet(
+            path = cms.untracked.string('%(subdet)s/%(prefix)sClusterTask/%(prefix)sCLT SC transverse energy (low scale)'),
+            kind = cms.untracked.string('TH1F'),
+            otype = cms.untracked.string('Ecal2P'),
+            xaxis = cms.untracked.PSet(
+                high = cms.untracked.double(10.0),
+                nbins = cms.untracked.int32(50),
+                low = cms.untracked.double(0.0),
+                title = cms.untracked.string('energy (GeV)')
+            ),
+            btype = cms.untracked.string('User'),
+            description = cms.untracked.string('Transverse energy distribution (raw energy) of the super clusters (low scale).')
+        ),
         SCRawELow = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sClusterTask/%(prefix)sCLT SC raw energy (low scale)'),
             kind = cms.untracked.string('TH1F'),
@@ -348,6 +410,19 @@ ecalClusterTask = cms.untracked.PSet(
             ),
             btype = cms.untracked.string('User'),
             description = cms.untracked.string('Energy distribution of the super clusters (low scale).')
+        ),
+        SCRawEtLow = cms.untracked.PSet(
+            path = cms.untracked.string('%(subdet)s/%(prefix)sClusterTask/%(prefix)sCLT SC raw transverse energy (low scale)'),
+            kind = cms.untracked.string('TH1F'),
+            otype = cms.untracked.string('Ecal2P'),
+            xaxis = cms.untracked.PSet(
+                high = cms.untracked.double(10.0),
+                nbins = cms.untracked.int32(50),
+                low = cms.untracked.double(0.0),
+                title = cms.untracked.string('energy (GeV)')
+            ),
+            btype = cms.untracked.string('User'),
+            description = cms.untracked.string('Transverse energy distribution of the super clusters (low scale).')
         ),
         SCRawEHigh = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sClusterTask/%(prefix)sCLT SC raw energy (high scale)'),

--- a/DQM/EcalMonitorTasks/src/ClusterTask.cc
+++ b/DQM/EcalMonitorTasks/src/ClusterTask.cc
@@ -216,7 +216,9 @@ namespace ecaldqm {
 
   void ClusterTask::runOnBasicClusters(edm::View<reco::CaloCluster> const& _bcs, Collections _collection) {
     MESet& meBCE(MEs_.at("BCE"));
+    MESet& meBCEt(MEs_.at("BCEt"));
     MESet& meBCEMap(MEs_.at("BCEMap"));
+    MESet& meBCEtMap(MEs_.at("BCEtMap"));
     MESet& meBCEMapProjEta(MEs_.at("BCEMapProjEta"));
     MESet& meBCEMapProjPhi(MEs_.at("BCEMapProjPhi"));
     MESet& meBCEtMapProjEta(MEs_.at("BCEtMapProjEta"));
@@ -268,8 +270,10 @@ namespace ecaldqm {
         subdet = -EcalEndcap;
 
       meBCE.fill(getEcalDQMSetupObjects(), id, energy);
+      meBCEt.fill(getEcalDQMSetupObjects(), id, et);
 
       meBCEMap.fill(getEcalDQMSetupObjects(), id, energy);
+      meBCEtMap.fill(getEcalDQMSetupObjects(), id, et);
       meBCEMapProjEta.fill(getEcalDQMSetupObjects(), posEta, energy);
       meBCEMapProjPhi.fill(getEcalDQMSetupObjects(), subdet, posPhi, energy);
       meBCEtMapProjEta.fill(getEcalDQMSetupObjects(), posEta, et);
@@ -368,9 +372,13 @@ namespace ecaldqm {
     EcalSubdetector subdet(isBarrel ? EcalBarrel : EcalEndcap);
 
     MESet& meSCE(MEs_.at("SCE"));
+    MESet& meSCEt(MEs_.at("SCEt"));
     MESet& meSCELow(MEs_.at("SCELow"));
+    MESet& meSCEtLow(MEs_.at("SCEtLow"));
     MESet& meSCRawE(MEs_.at("SCRawE"));
+    MESet& meSCRawEt(MEs_.at("SCRawEt"));
     MESet& meSCRawELow(MEs_.at("SCRawELow"));
+    MESet& meSCRawEtLow(MEs_.at("SCRawEtLow"));
     MESet& meSCRawEHigh(MEs_.at("SCRawEHigh"));
     MESet& meSCNBCs(MEs_.at("SCNBCs"));
     MESet& meSCNcrystals(MEs_.at("SCNcrystals"));
@@ -402,9 +410,8 @@ namespace ecaldqm {
 
     for (reco::SuperClusterCollection::const_iterator scItr(_scs.begin()); scItr != _scs.end(); ++scItr) {
       DetId seedId(scItr->seed()->seed());
+      math::XYZPoint const& position(scItr->position());
       if (seedId.null()) {
-        math::XYZPoint const& position(scItr->position());
-
         GlobalPoint gp(position.x(), position.y(), position.z());
 
         CaloSubdetectorGeometry const* subgeom(
@@ -424,13 +431,20 @@ namespace ecaldqm {
 
       float energy(scItr->energy());
       float rawEnergy(scItr->rawEnergy());
+      float posEta(position.eta());
+      float et(energy / std::cosh(posEta));
+      float rawEt(rawEnergy / std::cosh(posEta));
       float size(scItr->size());
 
       meSCE.fill(getEcalDQMSetupObjects(), seedId, energy);
+      meSCEt.fill(getEcalDQMSetupObjects(), seedId, et);
       meSCELow.fill(getEcalDQMSetupObjects(), seedId, energy);
-
+      meSCEtLow.fill(getEcalDQMSetupObjects(), seedId, et);
+  
       meSCRawE.fill(getEcalDQMSetupObjects(), seedId, rawEnergy);
+      meSCRawEt.fill(getEcalDQMSetupObjects(), seedId, rawEt);
       meSCRawELow.fill(getEcalDQMSetupObjects(), seedId, rawEnergy);
+      meSCRawEtLow.fill(getEcalDQMSetupObjects(), seedId, rawEt);
       meSCRawEHigh.fill(getEcalDQMSetupObjects(), seedId, rawEnergy);
 
       meSCNBCs.fill(getEcalDQMSetupObjects(), seedId, scItr->clustersSize());


### PR DESCRIPTION
#### PR description:

This PR adds the ECAL DQM plots for transverse energy of basic and superclusters (in Layout/04 Energy).

#### PR validation:

PR is validated by running the ECAL online DQM configuration and verifying the plots on a test DQM GUI.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is the backport to `14_2_X`. Master PR is made in #46809