### PR TITLE
Allow using fake pixels from the digi morphing algorithm as cluster seeds but drop them from final clusters

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
@@ -390,7 +390,9 @@ SiPixelCluster PixelThresholdClusterizer::make_cluster(const SiPixelCluster::Pix
 
   AccretionCluster acluster, cldata;
   acluster.add(pix, seed_adc);
-  cldata.add(pix, seed_adc);
+  if (!theFakePixels[pix.row() * theNumOfCols + pix.col()]) {
+    cldata.add(pix, seed_adc);
+  }
 
   //Here we search all pixels adjacent to all pixels in the cluster.
   bool dead_flag = false;


### PR DESCRIPTION
#### PR description:

This PR introduces a fix for a bug in the digi morphing code described [here](https://indico.cern.ch/event/1000806/contributions/4305637/attachments/2221772/3762550/tanjaPixelOfflineMeeting_07042021.pdf) and [here](https://indico.cern.ch/event/1140520/contributions/4859648/attachments/2437514/4174904/Saswat-220504.pdf).

#### PR validation:

The code compiles. The digi morhing code (enabled using `--procModifiers siPixelDigiMorphing`) is disabled by default so no impact is expected on any reconstructed quantities. The PR is primarily intended to fix the bug so that further testing and validation can be done.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR will be backported to CMSSW_14_0_X, CMSSW_14_1_X and CMSSW_14_2_X.
