### PR TITLE
Implement a `GenericProduct` and `GenericCloner` test module

### DIFF
--- a/DataFormats/Common/interface/WrapperBase.h
+++ b/DataFormats/Common/interface/WrapperBase.h
@@ -51,12 +51,12 @@ namespace edm {
     bool isProductEqual(WrapperBase const* newProduct) const { return isProductEqual_(newProduct); }
     bool hasSwap() const { return hasSwap_(); }
     void swapProduct(WrapperBase* newProduct) { swapProduct_(newProduct); }
+    void moveFrom(void* ptr, std::type_info const& type) { moveFrom_(ptr, type); }
 
     std::shared_ptr<soa::TableExaminerBase> tableExaminer() const { return tableExaminer_(); }
 
   private:
     virtual std::type_info const& dynamicTypeInfo_() const = 0;
-
     virtual std::type_info const& wrappedTypeInfo_() const = 0;
 
     // This will never be called.
@@ -70,6 +70,7 @@ namespace edm {
     virtual bool isProductEqual_(WrapperBase const* newProduct) const = 0;
     virtual bool hasSwap_() const = 0;
     virtual void swapProduct_(WrapperBase* newProduct) = 0;
+    virtual void moveFrom_(void* ptr, std::type_info const& type) = 0;
 
     virtual void do_fillView(ProductID const& id,
                              std::vector<void const*>& pointers,

--- a/FWCore/Framework/interface/GenericProduct.h
+++ b/FWCore/Framework/interface/GenericProduct.h
@@ -1,0 +1,97 @@
+#ifndef FWCore_Framework_interface_GenericProduct_h
+#define FWCore_Framework_interface_GenericProduct_h
+
+#include <cstring>
+#include <memory>
+#include <typeinfo>
+#include <utility>
+
+#include "DataFormats/Common/interface/OrphanHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Reflection/interface/ObjectWithDict.h"
+#include "FWCore/Reflection/interface/TypeWithDict.h"
+
+namespace edm {
+
+  class GenericProduct {
+  public:
+    GenericProduct(ObjectWithDict const& object, TypeWithDict const& wrapper)
+        : object_{object}, wrapperType_{wrapper} {}
+
+    // The GenericProduct *does not* take ownership of the object.
+    // The caller must guarantee that the object remains valid as long as needed.
+    template <typename T>
+    GenericProduct(T& object) : object_{typeid(T), &object}, wrapperType_{typeid(Wrapper<T>)} {}
+
+    ObjectWithDict const& object() const { return object_; }
+    TypeWithDict const& wrapperType() const { return wrapperType_; }
+
+  private:
+    ObjectWithDict object_;
+    TypeWithDict wrapperType_;
+  };
+
+  template <>
+  class OrphanHandle<GenericProduct> : public OrphanHandleBase {
+  public:
+    OrphanHandle(ObjectWithDict prod, ProductID const& id) : OrphanHandleBase(prod.address(), id), prod_(prod) {}
+
+    ObjectWithDict const* product() const { return &prod_; }
+
+    ObjectWithDict const* operator->() const { return &prod_; }
+
+    ObjectWithDict const& operator*() const { return prod_; }
+
+  private:
+    ObjectWithDict prod_;
+  };
+
+  // specialise Event::putImpl for GenericProduct
+  template <>
+  inline OrphanHandle<GenericProduct> Event::putImpl(EDPutToken::value_type index,
+                                                     std::unique_ptr<GenericProduct> product) {
+    static const TypeWithDict classDoNotSortUponInsertion(typeid(DoNotSortUponInsertion));
+    static const TypeWithDict classWrapperBase(typeid(WrapperBase));
+
+    assert(index < putProducts().size());
+
+    // construct a wrapper for the product
+    ObjectWithDict const& wrapper = product->wrapperType().construct();
+    ObjectWithDict const& base = wrapper.castObject(classWrapperBase);
+    std::unique_ptr<WrapperBase> wp(reinterpret_cast<WrapperBase*>(base.address()));
+
+    // move the product into the wrapper and mark it as present
+    // internally this calls post_insert, if the underlying type has such a function
+    wp->moveFrom(product->object().address(), product->object().typeOf().typeInfo());
+
+    // move the wrapped product into the event
+    putProducts()[index] = std::move(wp);
+
+    // construct and return a handle to the product
+    ObjectWithDict prod(product->object().typeOf(), wrapper.get("obj").address());
+    auto const& prodID = provRecorder_.getProductID(index);
+    return OrphanHandle<GenericProduct>(prod, prodID);
+  }
+
+  // specialise Event::put for GenericProduct
+  template <>
+  inline OrphanHandle<GenericProduct> Event::put(EDPutToken token, std::unique_ptr<GenericProduct> product) {
+    if (UNLIKELY(product.get() == nullptr)) {  // null pointer is illegal
+      TypeID typeID(typeid(GenericProduct));
+      principal_get_adapter_detail::throwOnPutOfNullProduct("Event", typeID, provRecorder_.productInstanceLabel(token));
+    }
+    std::type_info const& type = product->object().typeOf().typeInfo();
+    if (UNLIKELY(token.isUninitialized())) {
+      principal_get_adapter_detail::throwOnPutOfUninitializedToken("Event", type);
+    }
+    TypeID const& expected = provRecorder_.getTypeIDForPutTokenIndex(token.index());
+    if (UNLIKELY(expected != TypeID{type})) {
+      principal_get_adapter_detail::throwOnPutOfWrongType(type, expected);
+    }
+
+    return putImpl(token.index(), std::move(product));
+  }
+
+}  // namespace edm
+
+#endif  // FWCore_Framework_interface_GenericProduct_h

--- a/FWCore/Integration/plugins/BuildFile.xml
+++ b/FWCore/Integration/plugins/BuildFile.xml
@@ -32,6 +32,15 @@
     <use name="DataFormats/TestObjects"/>
   </library>
 
+  <library file="GenericProductProducer.cc" name="FWCoreIntegrationGenericProduct">
+    <flags EDM_PLUGIN="1"/>
+    <use name="DataFormats/TestObjects"/>
+    <use name="FWCore/Framework"/>
+    <use name="FWCore/ParameterSet"/>
+    <use name="FWCore/Reflection"/>
+    <use name="FWCore/Utilities"/>
+  </library>
+
   <library file="HistProducer.cc" name="TestHistProducer">
     <flags EDM_PLUGIN="1"/>
     <use name="FWCore/Framework"/>

--- a/FWCore/Integration/plugins/GenericProductProducer.cc
+++ b/FWCore/Integration/plugins/GenericProductProducer.cc
@@ -1,0 +1,146 @@
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "DataFormats/TestObjects/interface/Thing.h"
+#include "DataFormats/TestObjects/interface/ThingWithDoNotSort.h"
+#include "DataFormats/TestObjects/interface/ThingWithPostInsert.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/GenericProduct.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
+
+namespace edmtest {
+
+  class GenericProductProducer : public edm::global::EDProducer<> {
+  public:
+    explicit GenericProductProducer(edm::ParameterSet const& ps);
+
+    void produce(edm::StreamID sid, edm::Event& event, edm::EventSetup const& es) const override;
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  private:
+    edm::EDPutToken intToken_;
+    edm::EDPutToken floatToken_;
+    edm::EDPutToken stringToken_;
+    edm::EDPutToken vectorToken_;
+    edm::EDPutToken thingToken_;
+    edm::EDPutToken thingWithPostInsertToken_;
+    edm::EDPutToken thingWithDoNotSortToken_;
+    edm::EDPutToken badToken_;
+  };
+
+  GenericProductProducer::GenericProductProducer(edm::ParameterSet const& iConfig)
+      : intToken_(produces(edm::TypeID(typeid(int)))),
+        floatToken_(produces(edm::TypeID(typeid(float)))),
+        stringToken_(produces(edm::TypeID(typeid(std::string)))),
+        vectorToken_(produces(edm::TypeID(typeid(std::vector<double>)))),
+        thingToken_(produces(edm::TypeID(typeid(Thing)))),
+        thingWithPostInsertToken_(produces(edm::TypeID(typeid(ThingWithPostInsert)))),
+        thingWithDoNotSortToken_(produces(edm::TypeID(typeid(ThingWithDoNotSort)))),
+        badToken_(produces(edm::TypeID(typeid(int)), "bad")) {}
+
+  void GenericProductProducer::produce(edm::StreamID sid, edm::Event& event, edm::EventSetup const& es) const {
+    {
+      // Check that an int can be put into the event via a GenericProduct.
+      int object = 42;
+      auto product = std::make_unique<edm::GenericProduct>(object);  // product does not own the underlying object
+      assert(product->object().objectCast<int>() == 42);
+      auto handle = event.put(intToken_, std::move(product));  // move the underlying object into the event
+      assert(handle->objectCast<int>() == 42);
+    }
+
+    {
+      // Check that a float can be put into the event via a GenericProduct.
+      float object = 3.14159f;
+      auto product = std::make_unique<edm::GenericProduct>(object);
+      assert(product->object().objectCast<float>() == 3.14159f);
+      auto handle = event.put(floatToken_, std::move(product));
+      assert(handle->objectCast<float>() == 3.14159f);
+    }
+
+    {
+      // Check that a string can be put into the event via a GenericProduct.
+      // With small string optimisation, the underlying buffer should be inside the string object itself.
+      std::string object = "42";
+      auto product = std::make_unique<edm::GenericProduct>(object);
+      assert(product->object().objectCast<std::string>() == "42");
+      auto handle = event.put(stringToken_, std::move(product));
+      assert(object.empty());  // the original string has been moved
+      assert(handle->objectCast<std::string>() == "42");
+    }
+
+    {
+      // Check that a vector can be put into the event via a GenericProduct.
+      // The underlying buffer is outside the vector object itself.
+      using Vector = std::vector<double>;
+      Vector object = {1., 1., 2., 3., 5., 8., 11., 19., 30.};
+      auto product = std::make_unique<edm::GenericProduct>(object);
+      assert(product->object().objectCast<Vector>() == Vector({1., 1., 2., 3., 5., 8., 11., 19., 30.}));
+      auto handle = event.put(vectorToken_, std::move(product));
+      assert(object.empty());  // the original vector has been moved
+      assert(handle->objectCast<Vector>() == Vector({1., 1., 2., 3., 5., 8., 11., 19., 30.}));
+    }
+
+    {
+      // Check that a Thing can be put into the event via a GenericProduct.
+      Thing object(99);
+      auto product = std::make_unique<edm::GenericProduct>(object);
+      assert(product->object().objectCast<Thing>().a == 99);
+      auto handle = event.put(thingToken_, std::move(product));
+      assert(handle->objectCast<Thing>().a == 99);
+    }
+
+    {
+      // Check that a ThingWithPostInsert can be put into the event via a GenericProduct,
+      // and that ThingWithPostInsert::post_insert() is called by event.put().
+      ThingWithPostInsert object(2147483647);
+      auto product = std::make_unique<edm::GenericProduct>(object);
+      assert(product->object().objectCast<ThingWithPostInsert>().value() == 2147483647);
+      assert(not product->object().objectCast<ThingWithPostInsert>().valid());
+      auto handle = event.put(thingWithPostInsertToken_, std::move(product));
+      assert(handle->objectCast<ThingWithPostInsert>().value() == 2147483647);
+      assert(handle->objectCast<ThingWithPostInsert>().valid());
+    }
+
+    {
+      // Check that a ThingWithDoNotSort can be put into the event via a GenericProduct,
+      // and that ThingWithDoNotSort::post_insert() is *not* called by event.put().
+      ThingWithDoNotSort object(2147483647);
+      auto product = std::make_unique<edm::GenericProduct>(object);
+      assert(product->object().objectCast<ThingWithDoNotSort>().value() == 2147483647);
+      auto handle = event.put(thingWithDoNotSortToken_, std::move(product));
+      assert(handle->objectCast<ThingWithDoNotSort>().value() == 2147483647);
+    }
+
+    {
+      // Check that mismatches in the type of the token and of the underlying object are caught
+      float object = 3.14159f;
+      auto product = std::make_unique<edm::GenericProduct>(object);
+      assert(product->object().objectCast<float>() == 3.14159f);
+      bool failed = false;
+      try {
+        event.put(badToken_, std::move(product));
+      } catch (edm::Exception const& e) {
+        assert(e.categoryCode() == edm::errors::LogicError);
+        failed = true;
+      }
+      assert(failed);
+    }
+  }
+
+  void GenericProductProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    descriptions.addWithDefaultLabel(desc);
+  }
+
+}  // namespace edmtest
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+using edmtest::GenericProductProducer;
+DEFINE_FWK_MODULE(GenericProductProducer);

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -43,6 +43,7 @@
   <test name="TestIntegrationEmptyRootFile" command="run_TestEmptyRootFile.sh"/>
   <test name="TestStdProducts" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/testStdProducts_cfg.py"/>
   <test name="TestPostInsertProducer" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/testPostInsertProducer_cfg.py"/>
+  <test name="TestGenericProductProducer" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/testGenericProductProducer_cfg.py"/>
 
   <bin file="ProcessConfiguration_t.cpp,ProcessHistory_t.cpp" name="TestIntegrationDataFormatsProvenance">
     <use name="FWCore/ParameterSet"/>

--- a/FWCore/Integration/test/testGenericProductProducer_cfg.py
+++ b/FWCore/Integration/test/testGenericProductProducer_cfg.py
@@ -1,0 +1,39 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(10)
+)
+
+process.producer = cms.EDProducer("GenericProductProducer")
+
+process.validateInt = cms.EDAnalyzer("edmtest::GlobalIntAnalyzer",
+    source = cms.InputTag("producer"),
+    expected = cms.int32(42)        # hard-coded in WrapperBaseProducer
+)
+
+process.validateFloat = cms.EDAnalyzer("edmtest::GlobalFloatAnalyzer",
+    source = cms.InputTag("producer"),
+    expected = cms.double(3.14159)  # hard-coded in WrapperBaseProducer
+)
+
+process.validateString = cms.EDAnalyzer("edmtest::GlobalStringAnalyzer",
+    source = cms.InputTag("producer"),
+    expected = cms.string("42")     # hard-coded in WrapperBaseProducer
+)
+
+process.validateVector = cms.EDAnalyzer("edmtest::GlobalVectorAnalyzer",
+    source = cms.InputTag("producer"),
+    expected = cms.vdouble(1., 1., 2., 3., 5., 8., 11., 19., 30.)   # hard-coded in WrapperBaseProducer
+)
+
+process.path = cms.Path(
+    process.producer +
+    process.validateInt +
+    process.validateFloat +
+    process.validateString +
+    process.validateVector
+)

--- a/FWCore/TestModules/README.md
+++ b/FWCore/TestModules/README.md
@@ -37,3 +37,14 @@ product read from the `Event`.
 Together `edmtest::EventIDProducer` and `edmtest::EventIDValidator` can be used
 to validate that an object produced in a given event is being read back in the
 same event.
+
+
+## `edmtest::GenericCloner`
+
+This module will clone all the event products declared by its configuration,
+using their ROOT dictionaries.
+The products can be specified either as module labels (_e.g._ `<module label>`)
+or as branch names (_e.g._ `<product type>_<module label>_<instance name>_<process name>`).
+Glob expressions (`?` and `*`) are supported in module labels and within the
+individual fields of branch names, similar to an `OutputModule`'s `keep`
+statements.

--- a/FWCore/TestModules/plugins/GenericCloner.cc
+++ b/FWCore/TestModules/plugins/GenericCloner.cc
@@ -1,0 +1,209 @@
+/*
+ * This EDProducer will clone all the event products declared by its configuration, using their ROOT dictionaries.
+ *
+ * The products can be specified either as module labels (e.g. "<module label>") or as branch names (e.g.
+ * "<product type>_<module label>_<instance name>_<process name>").
+ *
+ * If a module label is used, no underscore ("_") must be present; this module will clone all the products produced by
+ * that module, including those produced by the Transformer functionality (such as the implicitly copied-to-host
+ * products in case of Alpaka-based modules).
+ * If a branch name is used, all four fields must be present, separated by underscores; this module will clone only on
+ * the matching product(s).
+ *
+ * Glob expressions ("?" and "*") are supported in module labels and within the individual fields of branch names,
+ * similar to an OutputModule's "keep" statements.
+ * Use "*" to clone all products.
+ *
+ * For example, in the case of Alpaka-based modules running on a device, using
+ *
+ *   eventProducts = cms.untracked.vstring( "module" )
+ *
+ * will cause "module" to run, along with automatic copy of its device products to the host, and will attempt to clone
+ * all device and host products.
+ * To clone only the host product, the branch can be specified explicitly with
+ *
+ *   eventProducts = cms.untracked.vstring( "HostProductType_module_*_*" )
+ *
+ * .
+ */
+
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <TBufferFile.h>
+
+#include "DataFormats/Provenance/interface/ProductDescription.h"
+#include "DataFormats/Provenance/interface/ProductNamePattern.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/GenericHandle.h"
+#include "FWCore/Framework/interface/GenericProduct.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterDescriptionNode.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Reflection/interface/ObjectWithDict.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+
+namespace edmtest {
+
+  class GenericCloner : public edm::global::EDProducer<> {
+  public:
+    explicit GenericCloner(edm::ParameterSet const&);
+    ~GenericCloner() override = default;
+
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  private:
+    struct Entry {
+      edm::TypeWithDict objectType_;
+      edm::TypeWithDict wrappedType_;
+      edm::EDGetToken getToken_;
+      edm::EDPutToken putToken_;
+    };
+
+    std::vector<edm::ProductNamePattern> eventPatterns_;
+    std::vector<Entry> eventProducts_;
+    std::string label_;
+    bool verbose_;
+  };
+
+  GenericCloner::GenericCloner(edm::ParameterSet const& config)
+      : eventPatterns_(edm::productPatterns(config.getParameter<std::vector<std::string>>("eventProducts"))),
+        label_(config.getParameter<std::string>("@module_label")),
+        verbose_(config.getUntrackedParameter<bool>("verbose")) {
+    eventProducts_.reserve(eventPatterns_.size());
+
+    callWhenNewProductsRegistered([this](edm::ProductDescription const& branch) {
+      static const std::string_view kPathStatus("edm::PathStatus");
+      static const std::string_view kEndPathStatus("edm::EndPathStatus");
+
+      switch (branch.branchType()) {
+        case edm::InEvent:
+          if (branch.className() == kPathStatus or branch.className() == kEndPathStatus) {
+            return;
+          }
+          for (auto& pattern : eventPatterns_) {
+            if (pattern.match(branch)) {
+              Entry product;
+              product.objectType_ = branch.unwrappedType();
+              product.wrappedType_ = branch.wrappedType();
+              // TODO move this to EDConsumerBase::consumes() ?
+              product.getToken_ = this->consumes(
+                  edm::TypeToGet{branch.unwrappedTypeID(), edm::PRODUCT_TYPE},
+                  edm::InputTag{branch.moduleLabel(), branch.productInstanceName(), branch.processName()});
+              product.putToken_ = this->produces(branch.unwrappedTypeID(), branch.productInstanceName());
+              eventProducts_.push_back(product);
+
+              if (verbose_) {
+                edm::LogInfo("GenericCloner")
+                    << label_ << " will clone Event product " << branch.friendlyClassName() << '_'
+                    << branch.moduleLabel() << '_' << branch.productInstanceName() << '_' << branch.processName();
+              }
+              break;
+            }
+          }
+          break;
+
+        case edm::InLumi:
+        case edm::InRun:
+        case edm::InProcess:
+          // lumi, run and process products are not supported
+          break;
+
+        default:
+          throw edm::Exception(edm::errors::LogicError)
+              << "Unexpected branch type " << branch.branchType() << "\nPlease contact a Framework developer.";
+      }
+    });
+  }
+
+  void GenericCloner::produce(edm::StreamID /*unused*/, edm::Event& event, edm::EventSetup const& /*unused*/) const {
+    for (auto& product : eventProducts_) {
+      edm::GenericHandle handle(product.objectType_);
+      event.getByToken(product.getToken_, handle);
+      edm::ObjectWithDict const* object = handle.product();
+
+      // An ObjectWithDict can hold
+      //   - a fundamental type,
+      //   - a class type (class, struct or enum),
+      //   - a pointer,
+      //   - a C array.
+      //
+      // Pointers can be treated as fundamental types and shallow-copied.
+      // C arrays are not supported as event products, so can be skipped.
+      if (product.objectType_.isFundamental() or product.objectType_.isPointer()) {
+        // fundamental types can simply be copied, and the copy is done implicitly by the Event::put() specialisation for GenericProduct
+        event.put(product.putToken_, std::make_unique<edm::GenericProduct>(*object, product.wrappedType_));
+      } else if (product.objectType_.isClass()) {
+        // objects are cloned using their ROOT dictionary
+        if (product.wrappedType_.dataMemberByName("obj").isTransient()) {
+          throw edm::Exception(edm::errors::LogicError)
+              << "Type " << product.objectType_.name() << " is transient, and cannot be cloned.";
+        }
+
+        // write the product into a TBuffer
+        TBufferFile buffer(TBuffer::kWrite);
+        product.objectType_.getClass()->Streamer(object->address(), buffer);
+
+        // read back a copy of the product form the TBuffer
+        buffer.SetReadMode();
+        buffer.SetBufferOffset(0);
+        edm::ObjectWithDict clone = product.objectType_.construct();
+        product.objectType_.getClass()->Streamer(clone.address(), buffer);
+
+        // wrap the copy in a GenericProduct, and call the Event::put() method specialisation for GenericProduct
+        event.put(product.putToken_, std::make_unique<edm::GenericProduct>(clone, product.wrappedType_));
+
+        // the cloned object has been moved into the Event; now destroy the temporary object
+        clone.destruct(true);
+      } else {
+        // other types are not supported
+        throw edm::Exception(edm::errors::LogicError)
+            << "Unsupported type " << product.objectType_.name() << ".\nPlease contact a framework developer.";
+      }
+    }
+  }
+
+  void GenericCloner::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    descriptions.setComment(
+        R"(This EDProducer will clone all the event products declared by its configuration, using their ROOT dictionaries.
+
+The products can be specified either as module labels (e.g. "<module label>") or as branch names (e.g. "<product type>_<module label>_<instance name>_<process name>").
+If a module label is used, no underscore ("_") must be present; this module will clone all the products produced by that module, including those produced by the Transformer functionality (such as the implicitly copied-to-host products in case of Alpaka-based modules).
+If a branch name is used, all four fields must be present, separated by underscores; this module will clone only on the matching product(s).
+
+Glob expressions ("?" and "*") are supported in module labels and within the individual fields of branch names, similar to an OutputModule's "keep" statements.
+Use "*" to clone all products.
+
+For example, in the case of Alpaka-based modules running on a device, using
+
+    eventProducts = cms.untracked.vstring( "module" )
+
+will cause "module" to run, along with automatic copy of its device products to the host, and will attempt to clone all device and host products.
+To clone only the host product, the branch can be specified explicitly with
+
+    eventProducts = cms.untracked.vstring( "HostProductType_module_*_*" )
+
+.)");
+
+    edm::ParameterSetDescription desc;
+    desc.add<std::vector<std::string>>("eventProducts", {})
+        ->setComment("List of modules or branches whose event products will be cloned.");
+    desc.addUntracked<bool>("verbose", false)
+        ->setComment("Print the branch names of the products that will be cloned.");
+    descriptions.addWithDefaultLabel(desc);
+  }
+
+}  // namespace edmtest
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(edmtest::GenericCloner);

--- a/FWCore/TestModules/test/BuildFile.xml
+++ b/FWCore/TestModules/test/BuildFile.xml
@@ -1,1 +1,3 @@
 <test name="TestFWCoreModulesEventIDValidator" command="cmsRun ${LOCALTOP}/src/FWCore/TestModules/test/testEventIDValidator_cfg.py"/>
+
+<test name="TestFWCoreModulesGenericCloner" command="cmsRun ${LOCALTOP}/src/FWCore/TestModules/test/testGenericCloner_cfg.py"/>

--- a/FWCore/TestModules/test/testGenericCloner_cfg.py
+++ b/FWCore/TestModules/test/testGenericCloner_cfg.py
@@ -1,0 +1,75 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.INFO.limit = 10000000
+
+process.options.numberOfThreads = 1
+process.options.numberOfStreams = 1
+
+process.source = cms.Source("EmptySource")
+process.maxEvents.input = 10
+
+# produce, clone and validate products of type int
+process.produceInt = cms.EDProducer("edmtest::GlobalIntProducer",
+    value = cms.int32(42)
+)
+
+process.cloneInt = cms.EDProducer("edmtest::GenericCloner",
+    eventProducts = cms.vstring("produceInt"),
+    verbose = cms.untracked.bool(True)
+)
+
+process.validateInt = cms.EDAnalyzer("BuiltinIntTestAnalyzer",
+    moduleLabel = cms.untracked.InputTag("cloneInt"),
+    valueMustMatch = cms.untracked.int32(42)
+)
+
+process.taskInt = cms.Task(process.produceInt, process.cloneInt)
+
+process.pathInt = cms.Path(process.validateInt, process.taskInt)
+
+# produce, clone and validate products of type std::string
+process.produceString = cms.EDProducer("edmtest::GlobalStringProducer",
+    value = cms.string("Hello world")
+)
+
+process.cloneString = cms.EDProducer("edmtest::GenericCloner",
+    eventProducts = cms.vstring("produceString"),
+    verbose = cms.untracked.bool(True)
+)
+
+process.validateString = cms.EDAnalyzer("edmtest::GlobalStringAnalyzer",
+    source = cms.InputTag("cloneString"),
+    expected = cms.string("Hello world")
+)
+
+process.taskString = cms.Task(process.produceString, process.cloneString)
+
+process.pathString = cms.Path(process.validateString, process.taskString)
+
+# produce, clone and validate products of type edm::EventID
+process.eventIds = cms.EDProducer("edmtest::EventIDProducer")
+
+process.cloneIdsByLabel = cms.EDProducer("edmtest::GenericCloner",
+    eventProducts = cms.vstring("eventIds"),
+    verbose = cms.untracked.bool(True)
+)
+
+process.cloneIdsByBranch = cms.EDProducer("edmtest::GenericCloner",
+    eventProducts = cms.vstring("*_eventIds__TEST"),
+    verbose = cms.untracked.bool(True)
+)
+
+process.validateIdsByLabel = cms.EDAnalyzer("edmtest::EventIDValidator",
+    source = cms.untracked.InputTag('cloneIdsByLabel')
+)
+
+process.validateIdsByBranch = cms.EDAnalyzer("edmtest::EventIDValidator",
+    source = cms.untracked.InputTag('cloneIdsByBranch')
+)
+
+process.taskIds = cms.Task(process.eventIds, process.cloneIdsByLabel, process.cloneIdsByBranch)
+
+process.pathIds = cms.Path(process.validateIdsByLabel + process.validateIdsByBranch, process.taskIds)


### PR DESCRIPTION
#### PR description:

Implement additional framework functionality used by the MPI-based modules developed in #32632:
  - `edm::GenericProduct` can be used to produce any collection using its ROOT dictionary;
  - `edmtest::GenericCloner` can be used to clone the event products declared by its configuration, using their ROOT dictionaries.

Extend few core features:
  - `edm::Wrapper<T>` can be populated moving from an object using a type-erased `void*` and the object's `std::type_info`; `edm::WrapperBase` provides the `moveFrom()` public interface.

#### PR validation:

New unit test pass.