### PR TITLE
add DQM / Validation monitoring for `hltInitialStep` and  `hltHighPtTriplet` tracks in the Phase2 HLT menu

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -682,6 +682,8 @@ phase2_tracker.toModify(FEVTDEBUGHLTEventContent,
                             'keep *_hltPhase2PixelTracks_*_*',
                             'keep *_hltPhase2PixelVertices_*_*',
                             'keep *_hltGeneralTracks_*_*',
+                            'keep *_hltInitialStepTrackSelectionHighPurity_*_*',
+                            'keep *_hltHighPtTripletStepTrackSelectionHighPurity_*_*',
                             'keep *_hltOfflinePrimaryVertices_*_*',
                             'keep *_hltHGCalRecHit_*_*'
                         ])

--- a/DQMOffline/Trigger/python/TrackingMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/TrackingMonitoring_cff.py
@@ -118,6 +118,20 @@ phase2_tracker.toModify(iterHLTTracksMonitoringHLT,
                         TrackProducer    = 'hltGeneralTracks',
                         allTrackProducer = 'hltGeneralTracks')
 
+iterInitialStepMonitoringHLT = iterHLTTracksMonitoringHLT.clone(
+    primaryVertex    = 'hltPhase2PixelVertices',
+    FolderName       = 'HLT/Tracking/hltInitialStepTrackSelectionHighPurity',
+    TrackProducer    = 'hltInitialStepTrackSelectionHighPurity',
+    allTrackProducer = 'hltInitialStepTrackSelectionHighPurity',
+)
+
+iterHighPtTripletsMonitoringHLT = iterHLTTracksMonitoringHLT.clone(
+    primaryVertex    = 'hltPhase2PixelVertices',
+    FolderName       = 'HLT/Tracking/hltHighPtTripletStepTrackSelectionHighPurity',
+    TrackProducer    = 'hltHighPtTripletStepTrackSelectionHighPurity',
+    allTrackProducer = 'hltHighPtTripletStepTrackSelectionHighPurity',
+)
+
 iter3TracksMonitoringHLT = trackingMonHLT.clone(
     FolderName       = 'HLT/Tracking/iter3Merged',
     TrackProducer    = 'hltIter3Merged',
@@ -249,7 +263,7 @@ trkHLTDQMSourceExtra = cms.Sequence(
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toReplaceWith(trackingMonitorHLT, cms.Sequence(pixelTracksMonitoringHLT + iterHLTTracksMonitoringHLT + doubletRecoveryHPTracksMonitoringHLT )) # + iter0HPTracksMonitoringHLT ))
-phase2_tracker.toReplaceWith(trackingMonitorHLT, cms.Sequence(pixelTracksMonitoringHLT + iterHLTTracksMonitoringHLT))
+phase2_tracker.toReplaceWith(trackingMonitorHLT, cms.Sequence(pixelTracksMonitoringHLT + iterHLTTracksMonitoringHLT + iterInitialStepMonitoringHLT + iterHighPtTripletsMonitoringHLT))
 
 run3_common.toReplaceWith(trackingMonitorHLTall, cms.Sequence(pixelTracksMonitoringHLT + iter0TracksMonitoringHLT + iterHLTTracksMonitoringHLT))
 run3_common.toReplaceWith(egmTrackingMonitorHLT, cms.Sequence(gsfTracksMonitoringHLT))

--- a/Validation/RecoTrack/python/HLTmultiTrackValidator_cff.py
+++ b/Validation/RecoTrack/python/HLTmultiTrackValidator_cff.py
@@ -32,7 +32,7 @@ from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(hltTrackValidator, _modifyForRun3)
 
 def _modifyForPhase2(trackvalidator):
-    trackvalidator.label = ["hltGeneralTracks","hltPhase2PixelTracks"]
+    trackvalidator.label = ["hltGeneralTracks", "hltPhase2PixelTracks", "hltInitialStepTrackSelectionHighPurity", "hltHighPtTripletStepTrackSelectionHighPurity"]
 
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(hltTrackValidator, _modifyForPhase2)


### PR DESCRIPTION
#### PR description:

Recently the Phase-2 HLT group started to review and optimize the Pixel tracks as seeds (and more) for HLT. In this context it is not unreasonable to foresee changes in that iteration as well as in the other (high pT triplet iteration) currently in use to build the final HLT tracks collection in the phase-2 menu 
So it would be ideal to monitor both of them at the same time
This PR provides support for DQM and Validation for `hltInitialStep` and  `hltHighPtTriplet` tracks in the Phase2 HLT menu.

#### PR validation:

Run the following workflow:

```
runTheMatrix.py -l 29834.999 --ibeos
``` 

I observe in the output of the step3 the following additional collections:

```
$ edmEventSize -v -a 29834.999_TTbar_14TeV+Run4D110PU_PMXS1S2PR/step3.root | grep -E 'hltInitial|hltHighPt'
recoTrackExtras_hltInitialStepTrackSelectionHighPurity__HLT. 38142.7 27737.6
recoTrackExtras_hltHighPtTripletStepTrackSelectionHighPurity__HLT. 11475 8452.3
recoTracks_hltInitialStepTrackSelectionHighPurity__HLT. 15124.2 5281.5
TrackingRecHitsOwned_hltInitialStepTrackSelectionHighPurity__HLT. 40521.9 4144.9
recoTracks_hltHighPtTripletStepTrackSelectionHighPurity__HLT. 4760.4 1833.6
TrackingRecHitsOwned_hltHighPtTripletStepTrackSelectionHighPurity__HLT. 11860.7 1581.2
uchars_hltHighPtTripletStepTrackSelectionHighPurity_QualityMasks_HLT. 307.4 292.9
floats_hltHighPtTripletStepTrackSelectionHighPurity_MVAValues_HLT. 338.4 286.5
uchars_hltInitialStepTrackSelectionHighPurity_QualityMasks_HLT. 328.7 284.5
floats_hltInitialStepTrackSelectionHighPurity_MVAValues_HLT. 448.8 278.4
```

Inspecting the output DQM file I see the new plots appearing for the considered collections.
An example root DQM file that can be obtained with this branch is available [here](https://cernbox.cern.ch/s/D0DhmxwokBsHukl).

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, no interest in backporting (at least for the time being)