### PR TITLE
Update 141X data GTs in autoCond

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -31,14 +31,14 @@ autoCond = {
     'run2_data_promptlike_hi'      :    '140X_dataRun2_PromptLike_HI_v1',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              :    '140X_dataRun2_HLT_relval_v1',
-    # GlobalTag for Run3 HLT: identical the online GT 140X_dataRun3_HLT_v3 with snapshot at 2024-06-13 14:22:43 (UTC)
-    'run3_hlt'                     :    '141X_dataRun3_HLT_frozen_v1',
-    # GlobalTag for Run3 data relvals (express GT): same as 141X_dataRun3_Express_v2 but with snapshot at 2024-09-12 10:35:04 (UTC)
-    'run3_data_express'            :    '141X_dataRun3_Express_frozen_v3',
-    # GlobalTag for Run3 data relvals (prompt GT): same as 141X_dataRun3_Prompt_v3 but with snapshot at 2024-09-12 11:03:32 (UTC)
-    'run3_data_prompt'             :    '141X_dataRun3_Prompt_frozen_v3',
+    # GlobalTag for Run3 HLT: identical the online GT 140X_dataRun3_HLT_v4 with snapshot at 2024-11-28 13:17:51 (UTC)
+    'run3_hlt'                     :    '141X_dataRun3_HLT_frozen_v2',
+    # GlobalTag for Run3 data relvals (express GT): same as 141X_dataRun3_Express_v4 but with snapshot at 2024-11-28 13:23:29 (UTC)
+    'run3_data_express'            :    '141X_dataRun3_Express_frozen_v4',
+    # GlobalTag for Run3 data relvals (prompt GT): same as 141X_dataRun3_Prompt_v4 but with snapshot at 2024-11-28 13:26:44 (UTC)
+    'run3_data_prompt'             :    '141X_dataRun3_Prompt_frozen_v4',
     # GlobalTag for Run3 offline data reprocessing - snapshot at 2024-11-12 07:39:42 (UTC)
-    'run3_data'                    :    '141X_dataRun3_v4',
+    'run3_data'                    :    '141X_dataRun3_v5',
     # GlobalTag for Run3 offline data reprocessing with Prompt GT, currently for 2022FG - snapshot at 2024-02-12 12:00:00 (UTC)
     'run3_data_PromptAnalysis'     :    '140X_dataRun3_PromptAnalysis_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)

--- a/DQM/Integration/python/clients/dt4ml_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/dt4ml_dqm_sourceclient-live_cfg.py
@@ -117,7 +117,7 @@ if (process.runType.getRunType() == process.runType.hi_run):
     process.twinMuxStage2Digis.DTTM7_FED_Source = "rawDataRepacker"
     process.dtunpacker.inputLabel = "rawDataRepacker"
     process.gtDigis.DaqGtInputTag = "rawDataRepacker"
-    process.gtStage2Digis.InputLabel = "rawDataCollector"
+    process.gtStage2Digis.InputLabel = "rawDataRepacker"
     process.scalersRawToDigi.scalersInputTag = "rawDataRepacker"
     
     process.dtDigiMonitor.ResetCycle = 9999

--- a/DQM/Integration/test/BuildFile.xml
+++ b/DQM/Integration/test/BuildFile.xml
@@ -20,7 +20,8 @@
 <test name="TestDQMOnlineClient-pixel_dqm_sourceclient" command="runtest.sh pixel_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-pixellumi_dqm_sourceclient" command="runtest.sh pixellumi_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-rpc_dqm_sourceclient" command="runtest.sh rpc_dqm_sourceclient-live_cfg.py"/>
-<test name="TestDQMOnlineClient-scal_dqm_sourceclient" command="runtest.sh scal_dqm_sourceclient-live_cfg.py"/>
+<!-- The SCAL FED has been removed from DAQ since the end of Run 2 -->
+<!-- <test name="TestDQMOnlineClient-scal_dqm_sourceclient" command="runtest.sh scal_dqm_sourceclient-live_cfg.py"/> -->
 <test name="TestDQMOnlineClient-sistrip_dqm_sourceclient" command="runtest.sh sistrip_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-sistrip_approx_dqm_sourceclient" command="runtest.sh sistrip_approx_dqm_sourceclient-live_cfg.py 362321 hi_run"/>
 <test name="TestDQMOnlineClient-onlinebeammonitor_dqm_sourceclient" command="runtest.sh onlinebeammonitor_dqm_sourceclient-live_cfg.py"/>


### PR DESCRIPTION
Update online GTs in autoCond after the end of the 2024 data taking (to be used for tests and development):
- `run3_hlt`:  [141X_dataRun3_HLT_frozen_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/141X_dataRun3_HLT_frozen_v2)
   - Same as [140X_dataRun3_HLT_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/141X_dataRun3_v2) with snapshot at 2024-06-13 14:22:43 (UTC)
   - Remove not-needed records from the HLT GT, see https://cms-talk.web.cern.ch/t/call-for-hlt-gt-record-information-by-subsystems/48795
   - Add records for GEM dead and masked strips, see https://cms-talk.web.cern.ch/t/gem-request-for-including-gts-gemmaskedstrips-gemdeadstrips/55154
   - Diff with respect to previous version _v1 is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/141X_dataRun3_HLT_v2/141X_dataRun3_HLT_v1) (unfrozen)
-  `run3_data_express` :  [141X_dataRun3_Express_frozen_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/141X_dataRun3_Express_frozen_v4)
   - Same as [141X_dataRun3_Express_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/141X_dataRun3_Express_v4) but with snapshot at 2024-11-28 13:23:29 (UTC)
   - Add records for GEM dead and masked strips, see https://cms-talk.web.cern.ch/t/gem-request-for-including-gts-gemmaskedstrips-gemdeadstrips/55154
   - Diff with respect to previous version _v3 is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/141X_dataRun3_Express_v4/141X_dataRun3_Express_v3) (unfrozen)
-  `run3_data_prompt` :  [141X_dataRun3_Prompt_frozen_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/141X_dataRun3_Prompt_frozen_v4)
   - Same as [141X_dataRun3_Prompt_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/141X_dataRun3_Prompt_v4) but with snapshot at 2024-11-28 13:26:44 (UTC)
   - Add records for GEM dead and masked strips, see https://cms-talk.web.cern.ch/t/gem-request-for-including-gts-gemmaskedstrips-gemdeadstrips/55154
   - Diff with respect to previous version _v3 is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/141X_dataRun3_Prompt_v4/141X_dataRun3_Prompt_v3) (unfrozen)

Also the offline data GT needed to be fixed:
- `run3_data` :  [141X_dataRun3_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/141X_dataRun3_v5)
  - New offline HCAL response correction production tag with fixes for era 2024C and 2024E, see https://cms-talk.web.cern.ch/t/call-for-conditions-re-reco-of-2024-eras-c-d-e/42331/25
  - Add records for GEM dead and masked strips, see https://cms-talk.web.cern.ch/t/gem-request-for-including-gts-gemmaskedstrips-gemdeadstrips/55154
   - Diff with respect to previous version _v4 is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/141X_dataRun3_v4/141X_dataRun3_v5)

Moreover, to avoid crashes in the unit tests because of the removed (now unused) records in the HLT GT, the commit 61981542668b080cac6feb6e4e8c2eb4d48c4d3d comments out the `scal_dqm_sourceclient-live_cfg.py` test from the ones run in the unit tests of DQM/Integration:  as correctly reported in a comment [here below](https://github.com/cms-sw/cmssw/pull/46824#discussion_r1863057715), the SCAL FED has been removed from DAQ since the end of Run 2.

#### PR validation:

The removal of the not-needed records from the HLT GT was verified online as  documented in [CMSALCAFAST-94](https://its.cern.ch/jira/browse/CMSALCAFAST-94)
Rely on these PR tests for a wider coverage