### PR TITLE
Fix `EmptySourceFromEventIDs` test configuration

### DIFF
--- a/FWCore/Modules/test/testEmptySourceFromEventIDs_cfg.py
+++ b/FWCore/Modules/test/testEmptySourceFromEventIDs_cfg.py
@@ -39,10 +39,8 @@ process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(42)
 )
 
-# EventIDChecker requires synchronizing on LuminosityBlock boundaries
-process.options.numberOfThreads = 4
-process.options.numberOfStreams = 4
-process.options.numberOfConcurrentLuminosityBlocks = 1
+# EventIDChecker requires processing the events serially
+process.options.numberOfStreams = 1
 
 process.check = cms.EDAnalyzer("EventIDChecker", eventSequence = cms.untracked(events))
 


### PR DESCRIPTION
#### PR description:

Fix the `EmptySourceFromEventIDs` test configuration.

The `EventIDChecker` module requires that events be created and analysed in a specific order, which cannot be guaranteed in a multi-stream, multi-threaded configuration.

#### PR validation:

The `TestFWCoreModulesEmptySourceFromEventIDs` unit test should now pass.
