### PR TITLE
`DeDxCalibration` as `SiStrip` gains and fixes to the APV gain payload inspector

### DIFF
--- a/CondTools/SiStrip/plugins/SiStripApvGainFromDeDxCalibration.cc
+++ b/CondTools/SiStrip/plugins/SiStripApvGainFromDeDxCalibration.cc
@@ -1,0 +1,107 @@
+// system include files
+#include <fstream>
+#include <iostream>
+
+// user include files
+#include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
+#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
+#include "CondFormats/SiStripObjects/interface/SiStripApvGain.h"
+#include "CondFormats/PhysicsToolsObjects/interface/DeDxCalibration.h"
+#include "CondFormats/DataRecord/interface/DeDxCalibrationRcd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+class SiStripApvGainFromDeDxCalibration : public edm::one::EDAnalyzer<> {
+public:
+  explicit SiStripApvGainFromDeDxCalibration(const edm::ParameterSet& iConfig);
+
+  ~SiStripApvGainFromDeDxCalibration() override = default;
+
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+  typedef std::pair<uint32_t, unsigned char> ChipId;
+
+private:
+  const edm::ESGetToken<DeDxCalibration, DeDxCalibrationRcd> dedxCalibToken_;
+  const edm::FileInPath fp_;
+  const bool printdebug_;
+};
+
+SiStripApvGainFromDeDxCalibration::SiStripApvGainFromDeDxCalibration(const edm::ParameterSet& iConfig)
+    : dedxCalibToken_(esConsumes<DeDxCalibration, DeDxCalibrationRcd>()),
+      fp_(iConfig.getUntrackedParameter<edm::FileInPath>("file",
+                                                         edm::FileInPath(SiStripDetInfoFileReader::kDefaultFile))),
+      printdebug_(iConfig.getUntrackedParameter<uint32_t>("printDebug", 1)) {}
+
+void SiStripApvGainFromDeDxCalibration::analyze(const edm::Event& evt, const edm::EventSetup& iSetup) {
+  unsigned int run = evt.id().run();
+
+  edm::LogInfo("SiStripApvGainFromDeDxCalibration")
+      << "... creating dummy SiStripApvGain Data for Run " << run << "\n " << std::endl;
+
+  SiStripApvGain obj;
+
+  const auto& reader = SiStripDetInfoFileReader::read(fp_.fullPath());
+  const auto& DetInfos = reader.getAllData();
+  const auto& dedxCalib = iSetup.getData(dedxCalibToken_);
+
+  int count = -1;
+  for (const auto& it : DetInfos) {
+    const auto& nAPVs = it.second.nApvs;
+    count++;
+    //Generate Gain for det detid
+    std::vector<float> theSiStripVector;
+    for (unsigned short j = 0; j < nAPVs; j++) {
+      const auto& chipId = ChipId(it.first, j);
+      const auto& g = dedxCalib.gain().find(chipId);
+
+      if (g == dedxCalib.gain().end())
+        continue;
+
+      if (count < printdebug_)
+        edm::LogInfo("SiStripApvGainFromDeDxCalibration") << "detid " << it.first << " \t"
+                                                          << " apv " << j << " \t" << g->second << " \t" << std::endl;
+      theSiStripVector.push_back(g->second);
+    }
+
+    SiStripApvGain::Range range(theSiStripVector.begin(), theSiStripVector.end());
+    if (!obj.put(it.first, range))
+      edm::LogError("SiStripApvGainFromDeDxCalibration")
+          << "[SiStripApvGainFromDeDxCalibration::analyze] detid already exists" << std::endl;
+  }
+
+  //End now write sistripnoises data in DB
+  edm::Service<cond::service::PoolDBOutputService> mydbservice;
+
+  if (mydbservice.isAvailable()) {
+    if (mydbservice->isNewTagRequest("SiStripApvGainRcd")) {
+      mydbservice->createOneIOV<SiStripApvGain>(obj, mydbservice->beginOfTime(), "SiStripApvGainRcd");
+    } else {
+      mydbservice->appendOneIOV<SiStripApvGain>(obj, mydbservice->currentTime(), "SiStripApvGainRcd");
+    }
+  } else {
+    edm::LogError("SiStripApvGainFromDeDxCalibration") << "Service is unavailable" << std::endl;
+  }
+}
+
+void SiStripApvGainFromDeDxCalibration::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.addUntracked<edm::FileInPath>("file", edm::FileInPath(SiStripDetInfoFileReader::kDefaultFile));
+  desc.addUntracked<uint32_t>("printDebug", 1);
+  descriptions.addWithDefaultLabel(desc);
+}
+
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+DEFINE_FWK_MODULE(SiStripApvGainFromDeDxCalibration);

--- a/CondTools/SiStrip/test/SiStripApvGainFromDeDxCalibration_cfg.py
+++ b/CondTools/SiStrip/test/SiStripApvGainFromDeDxCalibration_cfg.py
@@ -1,0 +1,65 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("ICALIB")
+process.source = cms.Source("EmptyIOVSource",
+    firstValue = cms.uint64(1),
+    lastValue = cms.uint64(1),
+    timetype = cms.string('runnumber'),
+    interval = cms.uint64(1)
+)
+
+process.load('FWCore.MessageService.MessageLogger_cfi')   
+process.MessageLogger.cerr.enable = False
+process.MessageLogger.SiStripApvGainFromDeDxCalibration=dict()  
+process.MessageLogger.cout = cms.untracked.PSet(
+    enable = cms.untracked.bool(True),
+    threshold = cms.untracked.string("DEBUG"),
+    default   = cms.untracked.PSet(limit = cms.untracked.int32(0)),                       
+    FwkReport = cms.untracked.PSet(limit = cms.untracked.int32(-1),
+                                   reportEvery = cms.untracked.int32(1000)
+                                   ),                                                      
+    SiStripApvGainFromDeDxCalibration = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
+    enableStatistics = cms.untracked.bool(True)
+    )
+
+
+process.load("Configuration.Geometry.GeometryExtended2024_cff")
+process.load("Geometry.TrackerGeometryBuilder.trackerParameters_cfi")
+process.TrackerTopologyEP = cms.ESProducer("TrackerTopologyEP")
+
+#Setup the SiSTripFedCabling and the SiStripDetCabling
+process.load("CondCore.CondDB.CondDB_cfi")
+process.CondDB.connect='frontier://FrontierProd/CMS_CONDITIONS'
+
+process.poolDBESSource = cms.ESSource('PoolDBESSource',
+                                      process.CondDB,
+                                      BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
+                                      toGet = cms.VPSet( cms.PSet(record = cms.string('DeDxCalibrationRcd'),
+                                                                  tag    = cms.string('DeDxCalibration_HI_2024_prompt_v2')
+                                                                  )
+                                                        )
+                                     )
+                                                                    
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+    BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
+    DBParameters = cms.PSet(
+        authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
+    ),
+    timetype = cms.untracked.string('runnumber'),
+    connect = cms.string('sqlite_file:SiStripApvGainFromDeDxCalibration_HI_2024_prompt_v2.db'),
+    toPut = cms.VPSet(cms.PSet(
+        record = cms.string('SiStripApvGainRcd'),
+        tag = cms.string('SiStripApvGainFromDeDxCalibration_HI_2024_prompt_v2')
+    ))
+)
+
+from CondTools.SiStrip.siStripApvGainFromDeDxCalibration_cfi import siStripApvGainFromDeDxCalibration
+process.prod = siStripApvGainFromDeDxCalibration.clone(
+    file = cms.untracked.FileInPath('CalibTracker/SiStripCommon/data/SiStripDetInfo.dat'),
+    printDebug = cms.untracked.uint32(100)  
+)
+process.p = cms.Path(process.prod)


### PR DESCRIPTION
#### PR description:

This PR adds a couple of utility commits:
   * 8a5042648addfbafcb2848e0fa67147d9e07d085 adds a tool to convert part of the `DeDexCalibration` calibration format (introduced at https://github.com/cms-sw/cmssw/pull/45024) as SiStrip APV Gains 
   * a3a383d3889b9ba1a919ae8ce6673426e404f60e fixes few bugs that crept in in `SiStripApvGain_PayloadInspector`.

#### PR validation:

Relies on the existing unit tests of the package

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A