### PR TITLE
Add Phase1 pixel tracker maps to `TrackerAlignmentErrorExtended_PayloadInspector`

### DIFF
--- a/CondCore/AlignmentPlugins/plugins/BuildFile.xml
+++ b/CondCore/AlignmentPlugins/plugins/BuildFile.xml
@@ -5,6 +5,7 @@
   <use name="CondFormats/Alignment"/>
   <use name="CommonTools/TrackerMap"/>
   <use name="CalibTracker/StandaloneTrackerTopology"/>
+  <use name="DQM/TrackerRemapper"/>
 </library>
 
 <library file="TrackerAlignment_PayloadInspector.cc" name="TrackerAlignment_PayloadInspector">


### PR DESCRIPTION
#### PR description:

Title says it all, there is a project to make η-dependent APEs in the pixel detector (see for instance [here](https://indico.cern.ch/event/1468895/contributions/6186934/attachments/2975259/5238530/PPD_workshop_tracker_DPG_v2.pdf#page=18)). This development might help in inspecting the payloads created according to this principle.

#### PR validation:

Private, code compiles

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A