### PR TITLE
Remove the explicit dependency on non-alpaka main library

### DIFF
--- a/HeterogeneousCore/AlpakaTest/BuildFile.xml
+++ b/HeterogeneousCore/AlpakaTest/BuildFile.xml
@@ -1,14 +1,6 @@
 <use name="FWCore/Framework"/>
 <use name="HeterogeneousCore/AlpakaCore"/>
 <use name="HeterogeneousCore/AlpakaInterface"/>
-<!--
-Let the alpaka libraries depend on the main library.
-The possible syntaxes are:
-  <use name="HeterogeneousCore/AlpakaTest" for="alpaka"/>
-  <use name="1" for="alpaka"/>
-  <flags USE_ALPAKA="1"/>
--->
-<use name="HeterogeneousCore/AlpakaTest" for="alpaka"/>
 <flags ALPAKA_BACKENDS="1"/>
 <export>
   <lib name="1"/>

--- a/RecoTracker/LSTCore/BuildFile.xml
+++ b/RecoTracker/LSTCore/BuildFile.xml
@@ -2,7 +2,6 @@
 <use name="boost_header"/>
 <use name="root"/>
 <use name="HeterogeneousCore/AlpakaInterface"/>
-<use name="RecoTracker/LSTCore" for="alpaka"/>
 <flags ALPAKA_BACKENDS="1"/>
 <export>
   <lib name="1"/>


### PR DESCRIPTION
#### PR description:

Remove the explicit dependency of alpaka libraries on the non-alpaka main library, since this is now enabled by default in the 15.0.x branch.

#### PR validation:

Unit tests pass.
