### PR TITLE
Fix PFClusterSoAProducer to read a device collection

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterECLCC.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterECLCC.h
@@ -1,10 +1,11 @@
 #ifndef RecoParticleFlow_PFClusterProducer_plugins_alpaka_PFClusterECLCC_h
 #define RecoParticleFlow_PFClusterProducer_plugins_alpaka_PFClusterECLCC_h
 
+#include "DataFormats/ParticleFlowReco/interface/alpaka/PFRecHitDeviceCollection.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
-#include "RecoParticleFlow/PFClusterProducer/interface/alpaka/PFClusteringVarsDeviceCollection.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/alpaka/PFClusteringEdgeVarsDeviceCollection.h"
+#include "RecoParticleFlow/PFClusterProducer/interface/alpaka/PFClusteringVarsDeviceCollection.h"
 
 // The following comment block is required in using the ECL-CC algorithm for topological clustering
 
@@ -79,9 +80,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   // Initial step of ECL-CC. Uses ID of first neighbour in edgeList with a smaller ID
   class ECLCCInit {
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(const TAcc& acc,
-                                  reco::PFRecHitHostCollection::ConstView pfRecHits,
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
+                                  reco::PFRecHitDeviceCollection::ConstView pfRecHits,
                                   reco::PFClusteringVarsDeviceCollection::View pfClusteringVars,
                                   reco::PFClusteringEdgeVarsDeviceCollection::View pfClusteringEdgeVars) const {
       const int nRH = pfRecHits.size();
@@ -103,9 +103,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   // Processes vertices
   class ECLCCCompute1 {
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(const TAcc& acc,
-                                  reco::PFRecHitHostCollection::ConstView pfRecHits,
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
+                                  reco::PFRecHitDeviceCollection::ConstView pfRecHits,
                                   reco::PFClusteringVarsDeviceCollection::View pfClusteringVars,
                                   reco::PFClusteringEdgeVarsDeviceCollection::View pfClusteringEdgeVars) const {
       const int nRH = pfRecHits.size();
@@ -148,9 +147,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   /* link all vertices to sink */
   class ECLCCFlatten {
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(const TAcc& acc,
-                                  reco::PFRecHitHostCollection::ConstView pfRecHits,
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
+                                  reco::PFRecHitDeviceCollection::ConstView pfRecHits,
                                   reco::PFClusteringVarsDeviceCollection::View pfClusteringVars,
                                   reco::PFClusteringEdgeVarsDeviceCollection::View pfClusteringEdgeVars) const {
       const int nRH = pfRecHits.size();

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducerKernel.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducerKernel.h
@@ -1,15 +1,14 @@
 #ifndef RecoParticleFlow_PFClusterProducer_PFClusterProducerAlpakaKernel_h
 #define RecoParticleFlow_PFClusterProducer_PFClusterProducerAlpakaKernel_h
 
-#include "DataFormats/ParticleFlowReco/interface/alpaka/PFRecHitDeviceCollection.h"
-#include "DataFormats/ParticleFlowReco/interface/PFRecHitHostCollection.h"
 #include "DataFormats/ParticleFlowReco/interface/alpaka/PFClusterDeviceCollection.h"
+#include "DataFormats/ParticleFlowReco/interface/alpaka/PFRecHitDeviceCollection.h"
 #include "DataFormats/ParticleFlowReco/interface/alpaka/PFRecHitFractionDeviceCollection.h"
-#include "RecoParticleFlow/PFClusterProducer/interface/alpaka/PFClusterParamsDeviceCollection.h"
-#include "RecoParticleFlow/PFClusterProducer/interface/alpaka/PFClusteringVarsDeviceCollection.h"
-#include "RecoParticleFlow/PFClusterProducer/interface/alpaka/PFClusteringEdgeVarsDeviceCollection.h"
-#include "RecoParticleFlow/PFRecHitProducer/interface/alpaka/PFRecHitTopologyDeviceCollection.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "RecoParticleFlow/PFClusterProducer/interface/alpaka/PFClusterParamsDeviceCollection.h"
+#include "RecoParticleFlow/PFClusterProducer/interface/alpaka/PFClusteringEdgeVarsDeviceCollection.h"
+#include "RecoParticleFlow/PFClusterProducer/interface/alpaka/PFClusteringVarsDeviceCollection.h"
+#include "RecoParticleFlow/PFRecHitProducer/interface/alpaka/PFRecHitTopologyDeviceCollection.h"
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
@@ -37,14 +36,15 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   class PFClusterProducerKernel {
   public:
-    PFClusterProducerKernel(Queue& queue, const reco::PFRecHitHostCollection& pfRecHits);
+    explicit PFClusterProducerKernel(Queue& queue);
 
     void seedTopoAndContract(Queue& queue,
                              const reco::PFClusterParamsDeviceCollection& params,
                              const reco::PFRecHitHCALTopologyDeviceCollection& topology,
                              reco::PFClusteringVarsDeviceCollection& pfClusteringVars,
                              reco::PFClusteringEdgeVarsDeviceCollection& pfClusteringEdgeVars,
-                             const reco::PFRecHitHostCollection& pfRecHits,
+                             const reco::PFRecHitDeviceCollection& pfRecHits,
+                             int nRH,
                              reco::PFClusterDeviceCollection& pfClusters,
                              uint32_t* __restrict__ nRHF);
 
@@ -53,7 +53,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                  const reco::PFRecHitHCALTopologyDeviceCollection& topology,
                  reco::PFClusteringVarsDeviceCollection& pfClusteringVars,
                  reco::PFClusteringEdgeVarsDeviceCollection& pfClusteringEdgeVars,
-                 const reco::PFRecHitHostCollection& pfRecHits,
+                 const reco::PFRecHitDeviceCollection& pfRecHits,
+                 int nRH,
                  reco::PFClusterDeviceCollection& pfClusters,
                  reco::PFRecHitFractionDeviceCollection& pfrhFractions);
 


### PR DESCRIPTION
#### PR description:

Fix `PFClusterSoAProducer` to read a device collection instead of a host collection, when running on a GPU backend.

**Note**:this is a quick workaround to let the device code use the device collection, while being able to access the actual number of pf rechits on the host side. It should replaced with a better and more general implementation, and the use of the host collection should be removed.


#### PR validation:

Full 2024 HLT menu works with these changes, both on CPU and on GPU.


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

May be backported to 14.2.x or earlier if there is interest.