### PR TITLE
Update offline data GT in autoCond - CMSSW_14_1_X

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -37,8 +37,8 @@ autoCond = {
     'run3_data_express'            :    '141X_dataRun3_Express_frozen_v3',
     # GlobalTag for Run3 data relvals (prompt GT): same as 141X_dataRun3_Prompt_v3 but with snapshot at 2024-09-12 11:03:32 (UTC)
     'run3_data_prompt'             :    '141X_dataRun3_Prompt_frozen_v3',
-    # GlobalTag for Run3 offline data reprocessing - snapshot at 2024-11-12 07:39:42 (UTC) 
-    'run3_data'                    :    '141X_dataRun3_v4',
+    # GlobalTag for Run3 offline data reprocessing - snapshot at 2024-11-27 13:03:22 (UTC) 
+    'run3_data'                    :    '141X_dataRun3_v5',
     # GlobalTag for Run3 offline data reprocessing with Prompt GT, currently for 2022FG - snapshot at 2024-02-12 12:00:00 (UTC)
     'run3_data_PromptAnalysis'     :    '140X_dataRun3_PromptAnalysis_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)

--- a/DQM/Integration/python/clients/dt4ml_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/dt4ml_dqm_sourceclient-live_cfg.py
@@ -118,7 +118,7 @@ if (process.runType.getRunType() == process.runType.hi_run):
     process.twinMuxStage2Digis.DTTM7_FED_Source = "rawDataRepacker"
     process.dtunpacker.inputLabel = "rawDataRepacker"
     process.gtDigis.DaqGtInputTag = "rawDataRepacker"
-    process.gtStage2Digis.InputLabel = "rawDataCollector"
+    process.gtStage2Digis.InputLabel = "rawDataRepacker"
     process.scalersRawToDigi.scalersInputTag = "rawDataRepacker"
     
     process.dtDigiMonitor.ResetCycle = 9999

--- a/DQM/Integration/test/BuildFile.xml
+++ b/DQM/Integration/test/BuildFile.xml
@@ -20,7 +20,8 @@
 <test name="TestDQMOnlineClient-pixel_dqm_sourceclient" command="runtest.sh pixel_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-pixellumi_dqm_sourceclient" command="runtest.sh pixellumi_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-rpc_dqm_sourceclient" command="runtest.sh rpc_dqm_sourceclient-live_cfg.py"/>
-<test name="TestDQMOnlineClient-scal_dqm_sourceclient" command="runtest.sh scal_dqm_sourceclient-live_cfg.py"/>
+<!-- The SCAL FED has been removed from DAQ since the end of Run 2 -->
+<!-- <test name="TestDQMOnlineClient-scal_dqm_sourceclient" command="runtest.sh scal_dqm_sourceclient-live_cfg.py"/> -->
 <test name="TestDQMOnlineClient-sistrip_dqm_sourceclient" command="runtest.sh sistrip_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-sistrip_approx_dqm_sourceclient" command="runtest.sh sistrip_approx_dqm_sourceclient-live_cfg.py 362321 hi_run"/>
 <test name="TestDQMOnlineClient-onlinebeammonitor_dqm_sourceclient" command="runtest.sh onlinebeammonitor_dqm_sourceclient-live_cfg.py"/>


### PR DESCRIPTION
Update the offline data GT that needed to be fixed:
- `run3_data` :  [141X_dataRun3_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/141X_dataRun3_v5)
  - New offline HCAL response correction production tag with fixes for era 2024C and 2024E, see https://cms-talk.web.cern.ch/t/call-for-conditions-re-reco-of-2024-eras-c-d-e/42331/25
  - Add records for GEM dead and masked strips, see https://cms-talk.web.cern.ch/t/gem-request-for-including-gts-gemmaskedstrips-gemdeadstrips/55154
   - Diff with respect to previous version _v4 is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/141X_dataRun3_v4/141X_dataRun3_v5)

Online GTs were not updated, differently from what is done in the master version of this GT, so that the very same GTs used online during 2024 data taking are also kept in the CMSSW_14_1_X release that was used for them.

However, to avoid crashes in the unit tests because of the records that could be remover with that updated HLT GT, the commit 0f577af31a379ed705c096da23ccad83b9d4ed5b comments out the `scal_dqm_sourceclient-live_cfg.py` test from the ones run in the unit tests of DQM/Integration:  as correctly reported in a comment [here below](https://github.com/cms-sw/cmssw/pull/46824#discussion_r1863057715), the SCAL FED has been removed from DAQ since the end of Run 2.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #46824