### PR TITLE
`TriggerResultsFilterFromDB`: accept all triggers paths in presence of an empty list of expressions

### DIFF
--- a/HLTrigger/HLTfilters/plugins/TriggerResultsFilterFromDB.cc
+++ b/HLTrigger/HLTfilters/plugins/TriggerResultsFilterFromDB.cc
@@ -67,7 +67,8 @@ void TriggerResultsFilterFromDB::fillDescriptions(edm::ConfigurationDescriptions
 void TriggerResultsFilterFromDB::parse(const std::vector<std::string>& expressions) {
   // parse the logical expressions into functionals
   if (expressions.empty()) {
-    edm::LogWarning("Configuration") << "Empty trigger results expression";
+    edm::LogWarning("Configuration") << "Empty trigger results expression. Will substitute with *";
+    m_expression = triggerExpression::parse("*");
   } else if (expressions.size() == 1) {
     parse(expressions[0]);
   } else {


### PR DESCRIPTION
#### PR description:

In PR https://github.com/cms-sw/cmssw/pull/42965 (and similarly more recently in https://github.com/cms-sw/cmssw/pull/46742) few AlCaReco producers were changed such that `TriggerResultsFilterFromDB` is employed instead of `HLTHighLevel` to select events. 
The two behave differently in presence of an empty logic expression: `HLTHighLevel` selects all events (filter effectively is ignored), while  `TriggerResultsFilterFromDB` accepts none.
The goal of this PR is to make the behaviour uniform among the two. This is particularly convenient because the empty expression list is very common in many `eventSetupPath` keys across different Global Tags and it would avoid to make massive clean-up campaign.
While this PR changes the behaviour of the module I couldn't find any other consumers of it other than named AlCaReco producers, so it should be safe to do.

#### PR validation:

Used the configuration file obtained from the following cmsDriver command (borrowed from [this JIRA ticket](https://its.cern.ch/jira/browse/PDMVRELVALS-257) and the [stats2](https://cms-pdmv-prod.web.cern.ch/stats?prepid=CMSSW_14_1_6__Run3_2024HIN_noPU_RV257-DIGIHI2024-00002) link therein) that used to produce an empty dataset:

```bash
#!/bin/bash -ex                                                                                                                                                                                            

cmsDriver.py step3 \
             --conditions 141X_mcRun3_2024_realistic_HI_Candidate_2024_11_19_14_38_08 \
             --datatier ALCARECO \
             --era Run3_pp_on_PbPb_2023 \
             --eventcontent ALCARECO \
             --filein /store/relval/CMSSW_14_1_6/RelValHydjetQ_B12_5362GeV_2024/GEN-SIM-RECO/141X_mcRun3_2024_realistic_HI_Candidate_2024_11_19_14_38_08_MinBias_2024HIN_noPU_RV257-v2/2590000/0052ce44-83\
da-4782-b2f7-3e16e58e42be.root \
             --fileout file:step3.root \
             --nStreams 1 \
             --nThreads 8 \
             --no_exec \
             --number 100 \
             --python_filename step_3_cfg.py \
             --step ALCA:TkAlMinBias+SiStripCalMinBias
```

and verified that there are events in output, where the same command without this PR produces a file without any events in it.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, might be backported. 