### PR TITLE
12_4_X Fixed FullModelHadronicProcess.cc energy deposit model

### DIFF
--- a/SimG4Core/CustomPhysics/src/FullModelHadronicProcess.cc
+++ b/SimG4Core/CustomPhysics/src/FullModelHadronicProcess.cc
@@ -354,10 +354,7 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
   G4LorentzVector p_g_cms = gluinoMomentum;  //gluino in CMS BEFORE collision
   p_g_cms.boost(trafo_full_cms);
 
-  double e = cloud_p4_new.e() + gluinoMomentum.e();
-  if (outgoingRhadron)
-    e += outgoingRhadron->GetPDGMass();
-  G4LorentzVector p4_new(cloud_p4_new.v() + gluinoMomentum.v(), e);
+  G4LorentzVector p4_new(cloud_p4_new.v() + gluinoMomentum.v(), outgoingRhadron->GetPDGMass());
   //  G4cout<<"P4-diff: "<<(p4_new-cloud_p4_new-gluinoMomentum)/GeV<<", magnitude: "
   // <<(p4_new-cloud_p4_new-gluinoMomentum).m()/MeV<<" MeV" <<G4endl;
 


### PR DESCRIPTION
#### PR description:

#### PR validation:

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of [previous PR](https://github.com/cms-sw/cmssw/pull/46728) to CMSSW_12_4_X. This backport is necessary because CMSSW_12_4_X is a version that we expect to use for an upcoming analysis.
