### PR TITLE
Update BTV offline DQM sequences

### DIFF
--- a/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
@@ -99,7 +99,7 @@ DQMOffline_SecondStepEGamma = cms.Sequence( egammaPostProcessing )
 DQMOffline_SecondStepTrigger = cms.Sequence( triggerOfflineDQMClient *
 						hltOfflineDQMClient )
 
-DQMOffline_SecondStepBTag = cms.Sequence( bTagCollectorSequenceDATA )
+DQMOffline_SecondStepBTag = cms.Sequence( bTagMiniDQMHarvesting )
 
 DQMOffline_SecondStepBeam = cms.Sequence( alcaBeamMonitorClient )
 
@@ -155,7 +155,7 @@ DQMOffline_SecondStep_FakeHLT = cms.Sequence( DQMOffline_SecondStep )
 DQMOffline_SecondStep_FakeHLT.remove( HLTMonitoringClient )
 DQMOffline_SecondStep_FakeHLT.remove( DQMOffline_SecondStepTrigger )
 
-DQMOffline_SecondStep_PrePOGMC = cms.Sequence( bTagCollectorSequenceDATA )
+DQMOffline_SecondStep_PrePOGMC = cms.Sequence( bTagMiniDQMHarvesting )
 
 DQMOffline_SecondStepPOGMC = cms.Sequence( DQMOffline_SecondStep_PrePOGMC *
                                            DQMMessageLoggerClientSeq )
@@ -269,7 +269,6 @@ DQMHarvestBTag = cms.Sequence( bTagMiniDQMHarvesting )
 
 from PhysicsTools.NanoAOD.nanoDQM_cff import *
 from Validation.RecoParticleFlow.DQMForPF_MiniAOD_cff import *
-from DQMOffline.RecoB.bTagMiniDQM_cff import *
 
 DQMHarvestMiniAOD = cms.Sequence( dataCertificationJetMETSequence * muonQualityTests_miniAOD * DQMHarvestPF * bTagMiniDQMHarvesting)
 DQMHarvestNanoAOD = cms.Sequence( nanoHarvest )

--- a/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
@@ -86,7 +86,7 @@ from DQMOffline.Muon.muonQualityTests_cff import *
 from DQMOffline.EGamma.egammaPostProcessing_cff import *
 from DQMOffline.Trigger.DQMOffline_Trigger_Client_cff import *
 from DQMOffline.Trigger.DQMOffline_HLT_Client_cff import *
-from DQMOffline.RecoB.dqmCollector_cff import *
+from DQMOffline.RecoB.bTagMiniDQM_cff import *
 from DQM.BeamMonitor.AlcaBeamMonitorClient_cff import *
 from DQMOffline.JetMET.SusyPostProcessor_cff import *
 
@@ -265,7 +265,7 @@ DQMHarvestJetMET = cms.Sequence( SusyPostProcessorSequence )
 
 DQMHarvestEGamma = cms.Sequence( egammaPostProcessing )
 
-DQMHarvestBTag = cms.Sequence( bTagCollectorSequenceDATA )
+DQMHarvestBTag = cms.Sequence( bTagMiniDQMHarvesting )
 
 from PhysicsTools.NanoAOD.nanoDQM_cff import *
 from Validation.RecoParticleFlow.DQMForPF_MiniAOD_cff import *

--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -117,7 +117,7 @@ from DQMOffline.Muon.muonMonitors_cff import *
 from DQMOffline.JetMET.jetMETDQMOfflineSource_cff import *
 from DQMOffline.EGamma.egammaDQMOffline_cff import *
 from DQMOffline.Trigger.DQMOffline_Trigger_cff import *
-from DQMOffline.RecoB.dqmAnalyzer_cff import *
+from DQMOffline.RecoB.bTagMiniDQM_cff import *
 from DQM.BeamMonitor.AlcaBeamMonitor_cff import *
 from DQM.Physics.DQMPhysics_cff import *
 from DQM.Physics.heavyFlavorDQMFirstStep_cff import *
@@ -140,7 +140,7 @@ DQMOfflineEGamma = cms.Sequence( egammaDQMOffline )
 
 DQMOfflineTrigger = cms.Sequence( triggerOfflineDQMSource )
 
-DQMOfflineBTag = cms.Sequence( bTagPlotsDATA )
+DQMOfflineBTag = cms.Sequence( bTagMiniDQMSource )
 
 DQMOfflineBeam = cms.Sequence( alcaBeamMonitor )
 


### PR DESCRIPTION
#### PR description:

This PR updates the DQM sequences corresponding to the offline BTV DQM. Following the recent PR https://github.com/cms-sw/cmssw/pull/46674 to include the DQM histograms of the newest Run-3 b-taggers, the `DQMOfflineBTag` sequence is redefined such that the `bTagMiniDQMSource` producing the DQM histograms for the Run-3 taggers is executed. The harvesting step of the DQM is modified accordingly such that the `DQMHarvestBTag` sequence is executed to fill the histograms.
These changes are needed such that the alias `btag` defined in [DQMOffline/Configuration/python/autoDQM.py](https://github.com/cms-sw/cmssw/blob/93af1c75d8d6cf955f23f5f9deeca49b76357262/DQMOffline/Configuration/python/autoDQM.py#L137-L139), including the sequences `DQMOfflineBTag` and `DQMHarvestBTag`, is running the production of the offline BTV DQM histograms.
After this PR is merged, the tag `@btag` can be used in https://github.com/dmwm/T0/blob/master/etc/ProdOfflineConfiguration.py to run the BTV offline DQM on datasets at Tier-0.

#### PR validation:

In order to test that the `@btag` tag is running the updated DQM sequences, the following command on the `Run2024D/BTagMu` dataset is run to run the prompt reconstruction and DQM steps:
```
python3 $CMSSW_RELEASE_BASE/src/Configuration/DataProcessing/test/RunPromptReco.py --scenario=ppEra_Run3 --reco --aod --miniaod --global-tag 140X_dataRun3_Prompt_v2 --lfn=file:/eos/user/m/mmarcheg/BTVOfflineDQM/store/data/Run2024D/BTagMu/RAW/v1/000/380/649/00000/ff51f62b-a054-4b81-a6f3-58996b9044f6.root --alcarecos=TkAlMinBias+TkAlV0s --PhysicsSkims=LogError+LogErrorMonitor --dqmio --dqmSeq=@common+@btag
```
Finally, the harvesting step is run with the following command:
```
cmsDriver.py step4  -s HARVESTING:@btag --conditions auto:run3_data --data  --filetype DQM --scenario pp --era Run3_2024 -n 100 --filein file:output_inDQMIO.root --fileout file:step4.root
```

The output file `DQM_V0001_R000380649__Global__CMSSW_X_Y_Z__RECO.root` is then opened with ROOT and explored with TBrowser to ensure that the BTV DQM histograms are correctly saved in the output.

The generic tests described in https://cms-sw.github.io/PRWorkflow.html have been executed. All the tests run with `scram b runtests use-ibeos` are successful. Most of the tests run with `runTheMatrix.py -l limited -i all --ibeos` are successful, with some tests failed due to `Step0-DAS_ERROR`:

```
2022.000001_RunJetHT2022C_10k Step0-DAS_ERROR Step1-NOTRUN Step2-NOTRUN Step3-NOTRUN  - time date Thu Nov 28 19:38:13 2024-date Thu Nov 28 19:38:10 2024; exit: 256 0 0 0
2022.002001_RunZeroBias2022C_10k Step0-DAS_ERROR Step1-NOTRUN Step2-NOTRUN Step3-NOTRUN  - time date Thu Nov 28 19:38:16 2024-date Thu Nov 28 19:38:14 2024; exit: 256 0 0 0
2023.002001_RunZeroBias2023D_10k Step0-DAS_ERROR Step1-NOTRUN Step2-NOTRUN Step3-NOTRUN  - time date Thu Nov 28 19:38:18 2024-date Thu Nov 28 19:38:17 2024; exit: 256 0 0 0
2024.000001_RunZeroBias2024B_10k Step0-DAS_ERROR Step1-NOTRUN Step2-NOTRUN Step3-NOTRUN  - time date Thu Nov 28 19:38:21 2024-date Thu Nov 28 19:38:19 2024; exit: 256 0 0 0
2024.101001_RunBTagMu2024C_10k Step0-DAS_ERROR Step1-NOTRUN Step2-NOTRUN Step3-NOTRUN  - time date Thu Nov 28 19:38:23 2024-date Thu Nov 28 19:38:22 2024; exit: 256 0 0 0
2024.202001_RunJetMET02024D_10k Step0-DAS_ERROR Step1-NOTRUN Step2-NOTRUN Step3-NOTRUN  - time date Thu Nov 28 19:38:26 2024-date Thu Nov 28 19:38:24 2024; exit: 256 0 0 0
2024.303001_RunDisplacedJet2024E_10k Step0-DAS_ERROR Step1-NOTRUN Step2-NOTRUN Step3-NOTRUN  - time date Thu Nov 28 19:38:27 2024-date Thu Nov 28 19:38:26 2024; exit: 256 0 0 0
```
However, the `Step0-DAS_ERROR` is related to fetching the datasets and is not an error specific to our changes, therefore we open the PR.
