### PR TITLE
fix `CaloParticle` class version after #46678

### DIFF
--- a/SimDataFormats/CaloAnalysis/src/classes_def.xml
+++ b/SimDataFormats/CaloAnalysis/src/classes_def.xml
@@ -1,5 +1,6 @@
 <lcgdict>
-   <class name="CaloParticle"  ClassVersion="4">
+   <class name="CaloParticle"  ClassVersion="5">
+    <version ClassVersion="5" checksum="2074797506"/>
    <version ClassVersion="4" checksum="1423471036"/>
   </class>
   <class name="CaloParticleCollection"/>


### PR DESCRIPTION
#### PR description:

Title says it all, addresses https://github.com/cms-sw/cmssw/pull/46678#issuecomment-2513910181 and following

#### PR validation:

Run phase-2 HLT timing workflow successfully

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A