### PR TITLE
Disable ROOT automatic class parsing during finishSchedule()

### DIFF
--- a/DataFormats/Provenance/interface/ProductRegistry.h
+++ b/DataFormats/Provenance/interface/ProductRegistry.h
@@ -60,7 +60,8 @@ namespace edm {
 
     void setFrozen(std::set<TypeID> const& productTypesConsumed,
                    std::set<TypeID> const& elementTypesConsumed,
-                   std::string const& processName);
+                   std::string const& processName,
+                   bool disableRootAutoParsing = false);
 
     void setUnscheduledProducts(std::set<std::string> const& unscheduledLabels);
 

--- a/DataFormats/Provenance/src/ProductRegistry.cc
+++ b/DataFormats/Provenance/src/ProductRegistry.cc
@@ -11,11 +11,12 @@
 
 #include "DataFormats/Provenance/interface/ProductResolverIndexHelper.h"
 
+#include "FWCore/Reflection/interface/DictionaryTools.h"
+#include "FWCore/Reflection/interface/SetClassParsing.h"
+#include "FWCore/Reflection/interface/TypeWithDict.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/EDMException.h"
-#include "FWCore/Reflection/interface/DictionaryTools.h"
 #include "FWCore/Utilities/interface/TypeID.h"
-#include "FWCore/Reflection/interface/TypeWithDict.h"
 #include "FWCore/Utilities/interface/WrappedClassName.h"
 
 #include "TDictAttributeMap.h"
@@ -162,11 +163,18 @@ namespace edm {
 
   void ProductRegistry::setFrozen(std::set<TypeID> const& productTypesConsumed,
                                   std::set<TypeID> const& elementTypesConsumed,
-                                  std::string const& processName) {
+                                  std::string const& processName,
+                                  bool disableRootAutoParsing) {
     if (frozen())
       return;
     freezeIt();
-    initializeLookupTables(&productTypesConsumed, &elementTypesConsumed, &processName);
+    if (disableRootAutoParsing) {
+      // disable ROOT automatic class parsing while checking for missing dictionaries
+      edm::SetClassParsing guard(false);
+      initializeLookupTables(&productTypesConsumed, &elementTypesConsumed, &processName);
+    } else {
+      initializeLookupTables(&productTypesConsumed, &elementTypesConsumed, &processName);
+    }
     sort_all(transient_.aliasToOriginal_);
   }
 

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -682,7 +682,7 @@ namespace edm {
       }
       // The RandomNumberGeneratorService is not a module, yet it consumes.
       { RngEDConsumer rngConsumer = RngEDConsumer(productTypesConsumed); }
-      preg.setFrozen(productTypesConsumed, elementTypesConsumed, processConfiguration->processName());
+      preg.setFrozen(productTypesConsumed, elementTypesConsumed, processConfiguration->processName(), true);
     }
 
     for (auto& c : all_output_communicators_) {

--- a/FWCore/Framework/test/productregistry.cppunit.cc
+++ b/FWCore/Framework/test/productregistry.cppunit.cc
@@ -248,7 +248,7 @@ void testProductRegistry::testAddAlias() {
                                              simpleVecBranch_->unwrappedTypeID(),
                                              simpleDerivedVecBranch_->unwrappedTypeID()};
   std::set<edm::TypeID> elementTypesConsumed{intBranch_->unwrappedTypeID(), edm::TypeID(typeid(edmtest::Simple))};
-  reg.setFrozen(productTypesConsumed, elementTypesConsumed, "TEST");
+  reg.setFrozen(productTypesConsumed, elementTypesConsumed, "TEST", true);
   {
     auto notFound = reg.aliasToModules(edm::PRODUCT_TYPE, intBranch_->unwrappedTypeID(), "alias", "instance");
     CPPUNIT_ASSERT(notFound.empty());

--- a/HeterogeneousCore/CUDATest/interface/MissingDictionaryCUDAObject.h
+++ b/HeterogeneousCore/CUDATest/interface/MissingDictionaryCUDAObject.h
@@ -1,0 +1,23 @@
+#ifndef HeterogeneousCore_CUDATest_interface_MissingDictionaryCUDAObject_h
+#define HeterogeneousCore_CUDATest_interface_MissingDictionaryCUDAObject_h
+
+#include <string>
+
+namespace edmtest {
+
+  // A simple data product used to test that the framework handles correctly the case of
+  // edm::Wrapper<T> where
+  //   - T has a dictionary
+  //   - edm::Wrapper<T> does not have a dictionary
+  //   - the corresponding classes.h file includes CUDA headers
+
+  struct MissingDictionaryCUDAObject {
+    MissingDictionaryCUDAObject() {};
+    MissingDictionaryCUDAObject(std::string s) : value(std::move(s)) {}
+
+    std::string value;
+  };
+
+}  // namespace edmtest
+
+#endif  // HeterogeneousCore_CUDATest_interface_MissingDictionaryCUDAObject_h

--- a/HeterogeneousCore/CUDATest/plugins/MissingDictionaryCUDAProducer.cc
+++ b/HeterogeneousCore/CUDATest/plugins/MissingDictionaryCUDAProducer.cc
@@ -1,0 +1,24 @@
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "HeterogeneousCore/CUDATest/interface/MissingDictionaryCUDAObject.h"
+
+namespace edmtest {
+
+  class MissingDictionaryCUDAProducer : public edm::global::EDProducer<> {
+  public:
+    explicit MissingDictionaryCUDAProducer(edm::ParameterSet const& config) : token_(produces()) {}
+
+    void produce(edm::StreamID sid, edm::Event& event, edm::EventSetup const& setup) const final {
+      event.emplace(token_);
+    }
+
+  private:
+    const edm::EDPutTokenT<MissingDictionaryCUDAObject> token_;
+  };
+
+}  // namespace edmtest
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(edmtest::MissingDictionaryCUDAProducer);

--- a/HeterogeneousCore/CUDATest/src/classes.h
+++ b/HeterogeneousCore/CUDATest/src/classes.h
@@ -1,3 +1,6 @@
-#include "DataFormats/Common/interface/Wrapper.h"
+#include <cuda_runtime.h>
+
 #include "CUDADataFormats/Common/interface/Product.h"
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "HeterogeneousCore/CUDATest/interface/MissingDictionaryCUDAObject.h"
 #include "HeterogeneousCore/CUDATest/interface/Thing.h"

--- a/HeterogeneousCore/CUDATest/src/classes_def.xml
+++ b/HeterogeneousCore/CUDATest/src/classes_def.xml
@@ -1,4 +1,16 @@
 <lcgdict>
     <class name="cms::cuda::Product<cms::cudatest::Thing>" persistent="false"/>
     <class name="edm::Wrapper<cms::cuda::Product<cms::cudatest::Thing>>" persistent="false"/>
+
+    <!--
+    A simple data product used to test that the framework handles correctly the case of
+    edm::Wrapper<T> where
+      - T has a dictionary
+      - edm::Wrapper<T> does not have a dictionary
+      - the corresponding classes.h file includes CUDA headers
+    -->
+    <class name="edmtest::MissingDictionaryCUDAObject"/>
+    <!--
+    <class name="edm::Wrapper<edmtest::MissingDictionaryCUDAObject>" splitLevel="0"/>
+    -->
 </lcgdict>

--- a/HeterogeneousCore/CUDATest/test/BuildFile.xml
+++ b/HeterogeneousCore/CUDATest/test/BuildFile.xml
@@ -12,4 +12,12 @@
   </ifrelease>
 
   <test name="testHeterogeneousCoreCUDATestWriteRead" command="testHeterogeneousCoreCUDATestWriteRead.sh"/>
+
+  <!--
+  Test that the framework handles correctly the case of edm::Wrapper<T> where
+    - T has a dictionary
+    - edm::Wrapper<T> does not have a dictionary
+    - the corresponding classes.h file includes CUDA headers
+  -->
+  <test name="testMissingDictionaryCUDA" command="testMissingDictionaryCUDA.sh"/>
 </iftool>

--- a/HeterogeneousCore/CUDATest/test/testMissingDictionaryCUDA.sh
+++ b/HeterogeneousCore/CUDATest/test/testMissingDictionaryCUDA.sh
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+function die {
+  echo -e "$1"
+  echo "exit status $2"
+  exit $2
+}
+
+LOCAL_TEST_DIR=${SCRAM_TEST_PATH:-$CMSSW_BASE/src/HeterogeneousCore/CUDATest/test}
+
+cmsRun ${LOCAL_TEST_DIR}/testMissingDictionaryCUDA_cfg.py >& testMissingDictionaryCUDA.log && die "The cmsRun test job succeeded unexpectedly" $?
+grep -q "An exception of category 'DictionaryNotFound' occurred" testMissingDictionaryCUDA.log || die "Cannot find the following string in the exception message:\nAn exception of category 'DictionaryNotFound' occurred" $?
+grep -q "edm::Wrapper<edmtest::MissingDictionaryCUDAObject>"     testMissingDictionaryCUDA.log || die "Cannot find the following string in the exception message:\nedm::Wrapper<edmtest::MissingDictionaryCUDAObject>" $?

--- a/HeterogeneousCore/CUDATest/test/testMissingDictionaryCUDA_cfg.py
+++ b/HeterogeneousCore/CUDATest/test/testMissingDictionaryCUDA_cfg.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("EmptySource")
+process.maxEvents.input = 10
+
+process.producer = cms.EDProducer("edmtest::MissingDictionaryCUDAProducer")
+
+process.path = cms.Path(process.producer)


### PR DESCRIPTION
#### PR description:

Disable ROOT automatic class parsing during `ScheduleItems::finishSchedule()`, while checking for missing dictionaries.

Add a test to check that the framework handles correctly the case of `edm::Wrapper<T>` where:
  - `T` has a dictionary;
  - `edm::Wrapper<T>` does not have a dictionary;
  - the corresponding `classes.h` file includes CUDA headers.


#### PR validation:

Unit tests and HLT pass.