### PR TITLE
Class version update unit test fix

### DIFF
--- a/FWCore/Reflection/test/run_classVersionUpdate.sh
+++ b/FWCore/Reflection/test/run_classVersionUpdate.sh
@@ -36,7 +36,7 @@ mv TestObjects.h.tmp FWCore/Reflection/test/stubs/TestObjects.h
 
 
 #Set env and build in sub-shel
-(eval $(scram run -sh) ; scram build -j $(nproc))
+(eval $(scram run -sh) ; SCRAM_NOEDM_CHECKS=yes scram build -j $(nproc))
 
 popd
 


### PR DESCRIPTION
This should fix the failing `TestFWCoreReflectionClassVersionUpdate` unit test. 

There was a bug and `scram build` was not running the edm class version that is why [scram build](https://github.com/cms-sw/cmssw/blob/master/FWCore/Reflection/test/run_classVersionUpdate.sh#L39) (run via this test) was not failing. The bug has been fixed so `scram build` now correctly fails which causes this unit test to not work. 

This change allows scram to build the test library without running edm class checks during the `scram build` phase. 

Fixes https://github.com/cms-sw/cmssw/issues/46869