### PR TITLE
SubProcess bug fix, updateLookup called too early

### DIFF
--- a/FWCore/Framework/interface/EventSetupProvider.h
+++ b/FWCore/Framework/interface/EventSetupProvider.h
@@ -96,6 +96,8 @@ namespace edm {
           std::map<EventSetupRecordKey, std::vector<ComponentDescription const*>>& referencedESProducers,
           EventSetupsController& esController);
 
+      void updateLookup();
+
       bool doRecordsMatch(EventSetupProvider& precedingESProvider,
                           EventSetupRecordKey const& eventSetupRecordKey,
                           std::map<EventSetupRecordKey, bool>& allComponentsMatch,

--- a/FWCore/Framework/interface/EventSetupRecordProvider.h
+++ b/FWCore/Framework/interface/EventSetupRecordProvider.h
@@ -23,6 +23,7 @@
 #include "FWCore/Framework/interface/EventSetupRecordImpl.h"
 #include "FWCore/Framework/interface/ValidityInterval.h"
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 // system include files
 #include <map>
@@ -40,6 +41,7 @@ namespace edm {
     struct ComponentDescription;
     class DataKey;
     class ESProductResolverProvider;
+    class ESRecordsToProductResolverIndices;
     class EventSetupProvider;
     class EventSetupRecordImpl;
     class ParameterSetIDHolder;
@@ -156,6 +158,8 @@ namespace edm {
       void setEventSetupImpl(EventSetupImpl* value) { eventSetupImpl_ = value; }
 
       IntervalStatus intervalStatus() const { return intervalStatus_; }
+
+      void updateLookup(ESRecordsToProductResolverIndices const&);
 
     protected:
       void addResolversToRecordHelper(edm::propagate_const<std::shared_ptr<ESProductResolverProvider>>& dpp,

--- a/FWCore/Framework/src/ESProducer.cc
+++ b/FWCore/Framework/src/ESProducer.cc
@@ -28,12 +28,12 @@ namespace edm {
       sharedResourceNames_.reset();
     }
 
-    itemsToGetFromRecords_.reserve(consumesInfos_.size());
-    recordsUsedDuringGet_.reserve(consumesInfos_.size());
-
     if (itemsToGetFromRecords_.size() == consumesInfos_.size()) {
       return;
     }
+
+    itemsToGetFromRecords_.reserve(consumesInfos_.size());
+    recordsUsedDuringGet_.reserve(consumesInfos_.size());
 
     for (auto& info : consumesInfos_) {
       auto& items = itemsToGetFromRecords_.emplace_back();

--- a/FWCore/Framework/src/EventSetupProvider.cc
+++ b/FWCore/Framework/src/EventSetupProvider.cc
@@ -347,10 +347,6 @@ namespace edm {
         }
       }
 
-      auto indices = recordsToResolverIndices();
-      for (auto& provider : *dataProviders_) {
-        provider->updateLookup(indices);
-      }
       dataProviders_.reset();
 
       mustFinishConfiguration_ = false;
@@ -538,6 +534,13 @@ namespace edm {
             ModuleFactory::get()->addTo(esController, *this, pset, resolverMaker, true);
           }
         }
+      }
+    }
+
+    void EventSetupProvider::updateLookup() {
+      auto indices = recordsToResolverIndices();
+      for (auto& recordProvider : recordProviders_) {
+        recordProvider->updateLookup(indices);
       }
     }
 

--- a/FWCore/Framework/src/EventSetupRecordProvider.cc
+++ b/FWCore/Framework/src/EventSetupRecordProvider.cc
@@ -252,6 +252,12 @@ namespace edm {
       for_all(providers_, std::bind(&EventSetupRecordProvider::addResolversToRecordHelper, this, _1, iMap));
     }
 
+    void EventSetupRecordProvider::updateLookup(ESRecordsToProductResolverIndices const& iResolverToIndices) {
+      for (auto& productResolverProvider : providers_) {
+        productResolverProvider->updateLookup(iResolverToIndices);
+      }
+    }
+
     std::set<EventSetupRecordKey> EventSetupRecordProvider::dependentRecords() const { return dependencies(key()); }
 
     std::set<ComponentDescription> EventSetupRecordProvider::resolverProviderDescriptions() const {

--- a/FWCore/Framework/src/EventSetupsController.cc
+++ b/FWCore/Framework/src/EventSetupsController.cc
@@ -87,8 +87,16 @@ namespace edm {
         // In the following function, all the other components that contribute
         // to the same record and also the records that record depends on are
         // also checked. The component sharing is appropriately fixed as necessary.
+        // (this needs to be done before updateLookup because this can cause new
+        // ESProducers to be constructed).
         checkESProducerSharing();
         clearComponents();
+
+        // updateLookup needs to be called after checkESProducerSharing because
+        // that can cause new ESProducers to be constructed
+        for (auto& eventSetupProvider : providers_) {
+          eventSetupProvider->updateLookup();
+        }
 
         initializeEventSetupRecordIOVQueues();
         numberOfConcurrentIOVs_.clear();


### PR DESCRIPTION
#### PR description:

This is a bug fix that should only affect jobs using SubProcess. For ESProducers, the updateLookup function was being called too early. For SubProcesses, there is a late step where sharing of ESProducers is checked and new ESProducers might be created at that point. We have been calling ESProducer::updateLookup just before that so ESProducers constructed at that late time would have missed the call to updateLookup.

This only affects jobs with SubProcess and none of the CMS production jobs use that feature. It is also somewhat of an unusual corner case even in a job with SubProcess. As far as I know, the Core unit tests are the only tests using SubProcess. 

#### PR validation:

Existing unit tests pass.

I noticed this while developing a separate PR. I will submit the other PR in the near future and it contains code modifications that cause existing unit tests to fail because of this bug (that is how I noticed the bug in the first place, it has been lurking there for years).
