### PR TITLE
Do not use default-constructed PortableCollections

### DIFF
--- a/DataFormats/VertexSoA/test/alpaka/ZVertexSoA_test.cc
+++ b/DataFormats/VertexSoA/test/alpaka/ZVertexSoA_test.cc
@@ -56,11 +56,10 @@ int main() {
 
       // If the device is actually the host, use the collection as-is.
       // Otherwise, copy the data from the device to the host.
-      ZVertexHost zvertex_h;
 #ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
-      zvertex_h = std::move(zvertex_d);
+      ZVertexHost zvertex_h = std::move(zvertex_d);
 #else
-      zvertex_h = cms::alpakatools::CopyToHost<ZVertexSoACollection>::copyAsync(queue, zvertex_d);
+      ZVertexHost zvertex_h = cms::alpakatools::CopyToHost<ZVertexSoACollection>::copyAsync(queue, zvertex_d);
 #endif
       alpaka::wait(queue);
       std::cout << zvertex_h.view().metadata().size() << std::endl;

--- a/EventFilter/HcalRawToDigi/plugins/alpaka/HcalDigisSoAProducer.cc
+++ b/EventFilter/HcalRawToDigi/plugins/alpaka/HcalDigisSoAProducer.cc
@@ -116,8 +116,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     event.emplace(digisF5HBToken_, std::move(df5_));
 
     if (qie11Digis.empty()) {
-      event.emplace(digisF01HEToken_);
-      event.emplace(digisF3HBToken_);
+      event.emplace(digisF01HEToken_, 0, event.queue());
+      event.emplace(digisF3HBToken_, 0, event.queue());
 
     } else {
       auto size_f1 = 0;

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestHelperClass.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestHelperClass.cc
@@ -23,8 +23,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     hostProductMulti2_ = portabletest::TestHostMultiCollection2{deviceProductMulti2.sizes(), iEvent.queue()};
     hostProductMulti3_ = portabletest::TestHostMultiCollection3{deviceProductMulti3.sizes(), iEvent.queue()};
 
-    alpaka::memcpy(iEvent.queue(), hostProduct_.buffer(), deviceProduct.const_buffer());
-    alpaka::memcpy(iEvent.queue(), hostProductMulti2_.buffer(), deviceProductMulti2.const_buffer());
-    alpaka::memcpy(iEvent.queue(), hostProductMulti3_.buffer(), deviceProductMulti3.const_buffer());
+    alpaka::memcpy(iEvent.queue(), hostProduct_->buffer(), deviceProduct.const_buffer());
+    alpaka::memcpy(iEvent.queue(), hostProductMulti2_->buffer(), deviceProductMulti2.const_buffer());
+    alpaka::memcpy(iEvent.queue(), hostProductMulti3_->buffer(), deviceProductMulti3.const_buffer());
   }
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestHelperClass.h
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestHelperClass.h
@@ -1,6 +1,8 @@
 #ifndef HeterogeneousCore_AlpakaTest_plugins_alpaka_TestHelperClass_h
 #define HeterogeneousCore_AlpakaTest_plugins_alpaka_TestHelperClass_h
 
+#include <optional>
+
 #include "DataFormats/PortableTestObjects/interface/TestHostCollection.h"
 #include "DataFormats/PortableTestObjects/interface/alpaka/TestDeviceCollection.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
@@ -23,9 +25,23 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     void makeAsync(device::Event const& iEvent, device::EventSetup const& iSetup);
 
-    portabletest::TestHostCollection moveFrom() { return std::move(hostProduct_); }
-    portabletest::TestHostMultiCollection2 moveFromMulti2() { return std::move(hostProductMulti2_); }
-    portabletest::TestHostMultiCollection3 moveFromMulti3() { return std::move(hostProductMulti3_); }
+    portabletest::TestHostCollection moveFrom() {
+      auto product = std::move(*hostProduct_);
+      hostProduct_.reset();
+      return product;
+    }
+
+    portabletest::TestHostMultiCollection2 moveFromMulti2() {
+      auto product = std::move(*hostProductMulti2_);
+      hostProductMulti2_.reset();
+      return product;
+    }
+
+    portabletest::TestHostMultiCollection3 moveFromMulti3() {
+      auto product = std::move(*hostProductMulti3_);
+      hostProductMulti3_.reset();
+      return product;
+    }
 
   private:
     const device::EDGetToken<portabletest::TestDeviceCollection> getToken_;
@@ -35,9 +51,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     const device::ESGetToken<AlpakaESTestDataCDevice, AlpakaESTestRecordC> esTokenDevice_;
 
     // hold the output product between acquire() and produce()
-    portabletest::TestHostCollection hostProduct_;
-    portabletest::TestHostMultiCollection2 hostProductMulti2_;
-    portabletest::TestHostMultiCollection3 hostProductMulti3_;
+    std::optional<portabletest::TestHostCollection> hostProduct_;
+    std::optional<portabletest::TestHostMultiCollection2> hostProductMulti2_;
+    std::optional<portabletest::TestHostMultiCollection3> hostProductMulti3_;
   };
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE
 

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToCluster.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToCluster.cc
@@ -1,4 +1,5 @@
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -262,10 +263,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       // are no valid pointers to clusters' Collection columns, instantiation
       // of TrackingRecHits fail. Example: workflow 11604.0
 
-      iEvent.emplace(digiPutToken_, nDigis_, iEvent.queue());
+      iEvent.emplace(digiPutToken_, 0, iEvent.queue());
       iEvent.emplace(clusterPutToken_, pixelTopology::Phase1::numberOfModules, iEvent.queue());
       if (includeErrors_) {
-        iEvent.emplace(digiErrorPutToken_);
+        iEvent.emplace(digiErrorPutToken_, 0, iEvent.queue());
         iEvent.emplace(fmtErrorToken_);
       }
       return;


### PR DESCRIPTION
#### PR description:

Do not use default-constructed `PortableCollections` and similar objects: these have a not well-defined semantics, especially if put into the Event.

#### PR validation:

The full release builds ~~and unit tests pass.~~