### PR TITLE
Let `edm::Wrapper<T>` use the constructor `T{kUninitialized}`

### DIFF
--- a/DataFormats/Common/interface/DeviceProduct.h
+++ b/DataFormats/Common/interface/DeviceProduct.h
@@ -4,6 +4,8 @@
 #include <cassert>
 #include <memory>
 
+#include "DataFormats/Common/interface/Uninitialized.h"
+
 namespace edm {
   class DeviceProductBase {
   public:
@@ -45,7 +47,13 @@ namespace edm {
   template <typename T>
   class DeviceProduct : public DeviceProductBase {
   public:
-    DeviceProduct() = default;
+    DeviceProduct()
+      requires(requires { T(); })
+    = default;
+
+    explicit DeviceProduct(edm::Uninitialized)
+      requires(requires { T(edm::kUninitialized); })
+        : data_{edm::kUninitialized} {}
 
     template <typename M, typename... Args>
     explicit DeviceProduct(std::shared_ptr<M> metadata, Args&&... args)

--- a/DataFormats/Common/interface/Uninitialized.h
+++ b/DataFormats/Common/interface/Uninitialized.h
@@ -1,0 +1,19 @@
+#ifndef DataFormats_Common_interface_Uninitialized_h
+#define DataFormats_Common_interface_Uninitialized_h
+
+/* Uninitialized
+ *
+ * This is an empty struct used as a tag to signal that a constructor will leave an object (partially) uninitialised,
+ * with the assumption that it will be overwritten before being used.
+ * One expected use case is to replace the default constructor used when deserialising objects from a ROOT file.
+ */
+
+namespace edm {
+
+  struct Uninitialized {};
+
+  constexpr inline Uninitialized kUninitialized;
+
+}  // namespace edm
+
+#endif  // DataFormats_Common_interface_Uninitialized_h

--- a/DataFormats/Common/test/Wrapper_t.cpp
+++ b/DataFormats/Common/test/Wrapper_t.cpp
@@ -1,34 +1,32 @@
-/*
- *  CMSSW
- *
- */
-
 #include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
-#include "catch.hpp"
+
+#include <catch.hpp>
 
 #include "DataFormats/Common/interface/Wrapper.h"
 
 class CopyNoMove {
 public:
-  CopyNoMove() {}
+  CopyNoMove() = default;
   CopyNoMove(CopyNoMove const&) { /* std::cout << "copied\n"; */ }
   CopyNoMove& operator=(CopyNoMove const&) { /*std::cout << "assigned\n";*/ return *this; }
-
-private:
 };
 
 class MoveNoCopy {
 public:
-  MoveNoCopy() {}
+  MoveNoCopy() = default;
   MoveNoCopy(MoveNoCopy const&) = delete;
   MoveNoCopy& operator=(MoveNoCopy const&) = delete;
   MoveNoCopy(MoveNoCopy&&) { /* std::cout << "moved\n";*/ }
   MoveNoCopy& operator=(MoveNoCopy&&) { /* std::cout << "moved\n";*/ return *this; }
+};
 
-private:
+class NoDefaultCtor {
+public:
+  NoDefaultCtor() = delete;
+  NoDefaultCtor(edm::Uninitialized) {}
 };
 
 TEST_CASE("test Wrapper", "[Wrapper]") {
@@ -44,4 +42,7 @@ TEST_CASE("test Wrapper", "[Wrapper]") {
   edm::Wrapper<std::vector<double>> wrap3(std::move(thing3));
   REQUIRE(wrap3->size() == 10);
   REQUIRE(thing3.get() == 0);
+
+  auto thing4 = std::make_unique<NoDefaultCtor>(edm::kUninitialized);
+  edm::Wrapper<NoDefaultCtor> wrap4(std::move(thing4));
 }

--- a/DataFormats/Portable/interface/PortableDeviceCollection.h
+++ b/DataFormats/Portable/interface/PortableDeviceCollection.h
@@ -7,9 +7,10 @@
 
 #include <alpaka/alpaka.hpp>
 
+#include "DataFormats/Common/interface/Uninitialized.h"
+#include "DataFormats/Portable/interface/PortableCollectionCommon.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
-#include "DataFormats/Portable/interface/PortableCollectionCommon.h"
 
 // generic SoA-based product in device memory
 template <typename T, typename TDev, typename = std::enable_if_t<alpaka::isDevice<TDev>>>
@@ -24,7 +25,9 @@ public:
   using Buffer = cms::alpakatools::device_buffer<TDev, std::byte[]>;
   using ConstBuffer = cms::alpakatools::const_device_buffer<TDev, std::byte[]>;
 
-  PortableDeviceCollection() = default;
+  PortableDeviceCollection() = delete;
+
+  explicit PortableDeviceCollection(edm::Uninitialized) noexcept {}
 
   PortableDeviceCollection(int32_t elements, TDev const& device)
       : buffer_{cms::alpakatools::make_device_buffer<std::byte[]>(device, Layout::computeDataSize(elements))},
@@ -144,7 +147,9 @@ private:
   }
 
 public:
-  PortableDeviceMultiCollection() = default;
+  PortableDeviceMultiCollection() = delete;
+
+  explicit PortableDeviceMultiCollection(edm::Uninitialized) noexcept {};
 
   PortableDeviceMultiCollection(int32_t elements, TDev const& device)
       : buffer_{cms::alpakatools::make_device_buffer<std::byte[]>(device, Layout<>::computeDataSize(elements))},

--- a/DataFormats/Portable/interface/PortableDeviceObject.h
+++ b/DataFormats/Portable/interface/PortableDeviceObject.h
@@ -7,6 +7,7 @@
 
 #include <alpaka/alpaka.hpp>
 
+#include "DataFormats/Common/interface/Uninitialized.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
 
@@ -21,7 +22,9 @@ public:
   using Buffer = cms::alpakatools::device_buffer<TDev, Product>;
   using ConstBuffer = cms::alpakatools::const_device_buffer<TDev, Product>;
 
-  PortableDeviceObject() = default;
+  PortableDeviceObject() = delete;
+
+  PortableDeviceObject(edm::Uninitialized) {}
 
   PortableDeviceObject(TDev const& device)
       // allocate global device memory

--- a/DataFormats/Portable/interface/PortableHostCollection.h
+++ b/DataFormats/Portable/interface/PortableHostCollection.h
@@ -6,10 +6,11 @@
 
 #include <alpaka/alpaka.hpp>
 
+#include "DataFormats/Common/interface/Uninitialized.h"
+#include "DataFormats/Portable/interface/PortableCollectionCommon.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/host.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
-#include "DataFormats/Portable/interface/PortableCollectionCommon.h"
 
 // generic SoA-based product in host memory
 template <typename T>
@@ -21,7 +22,9 @@ public:
   using Buffer = cms::alpakatools::host_buffer<std::byte[]>;
   using ConstBuffer = cms::alpakatools::const_host_buffer<std::byte[]>;
 
-  PortableHostCollection() = default;
+  PortableHostCollection() = delete;
+
+  explicit PortableHostCollection(edm::Uninitialized) noexcept {};
 
   PortableHostCollection(int32_t elements, alpaka_common::DevHost const& host)
       // allocate pageable host memory
@@ -154,7 +157,9 @@ private:
   }
 
 public:
-  PortableHostMultiCollection() = default;
+  PortableHostMultiCollection() = delete;
+
+  explicit PortableHostMultiCollection(edm::Uninitialized) noexcept {};
 
   PortableHostMultiCollection(int32_t elements, alpaka_common::DevHost const& host)
       // allocate pageable host memory

--- a/DataFormats/Portable/interface/PortableHostObject.h
+++ b/DataFormats/Portable/interface/PortableHostObject.h
@@ -7,6 +7,7 @@
 
 #include <alpaka/alpaka.hpp>
 
+#include "DataFormats/Common/interface/Uninitialized.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/host.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
@@ -19,7 +20,9 @@ public:
   using Buffer = cms::alpakatools::host_buffer<Product>;
   using ConstBuffer = cms::alpakatools::const_host_buffer<Product>;
 
-  PortableHostObject() = default;
+  PortableHostObject() = delete;
+
+  PortableHostObject(edm::Uninitialized) noexcept {}
 
   PortableHostObject(alpaka_common::DevHost const& host)
       // allocate pageable host memory

--- a/DataFormats/SiPixelClusterSoA/interface/SiPixelClustersDevice.h
+++ b/DataFormats/SiPixelClusterSoA/interface/SiPixelClustersDevice.h
@@ -2,17 +2,20 @@
 #define DataFormats_SiPixelClusterSoA_interface_SiPixelClustersDevice_h
 
 #include <cstdint>
+
 #include <alpaka/alpaka.hpp>
-#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
-#include "DataFormats/SiPixelClusterSoA/interface/SiPixelClustersHost.h"
+
+#include "DataFormats/Common/interface/Uninitialized.h"
 #include "DataFormats/Portable/interface/PortableDeviceCollection.h"
+#include "DataFormats/SiPixelClusterSoA/interface/SiPixelClustersHost.h"
 #include "DataFormats/SiPixelClusterSoA/interface/SiPixelClustersSoA.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/CopyToHost.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 
 template <typename TDev>
 class SiPixelClustersDevice : public PortableDeviceCollection<SiPixelClustersSoA, TDev> {
 public:
-  SiPixelClustersDevice() = default;
+  SiPixelClustersDevice(edm::Uninitialized) : PortableDeviceCollection<SiPixelClustersSoA, TDev>{edm::kUninitialized} {}
 
   template <typename TQueue>
   explicit SiPixelClustersDevice(size_t maxModules, TQueue queue)

--- a/DataFormats/SiPixelClusterSoA/interface/SiPixelClustersHost.h
+++ b/DataFormats/SiPixelClusterSoA/interface/SiPixelClustersHost.h
@@ -2,16 +2,18 @@
 #define DataFormats_SiPixelClusterSoA_interface_SiPixelClustersHost_h
 
 #include <alpaka/alpaka.hpp>
-#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+#include "DataFormats/Common/interface/Uninitialized.h"
 #include "DataFormats/Portable/interface/PortableHostCollection.h"
 #include "DataFormats/SiPixelClusterSoA/interface/SiPixelClustersSoA.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 
 // TODO: The class is created via inheritance of the PortableCollection.
 // This is generally discouraged, and should be done via composition.
 // See: https://github.com/cms-sw/cmssw/pull/40465#discussion_r1067364306
 class SiPixelClustersHost : public PortableHostCollection<SiPixelClustersSoA> {
 public:
-  SiPixelClustersHost() = default;
+  SiPixelClustersHost(edm::Uninitialized) : PortableHostCollection<SiPixelClustersSoA>{edm::kUninitialized} {}
 
   template <typename TQueue>
   explicit SiPixelClustersHost(size_t maxModules, TQueue queue)

--- a/DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsDevice.h
+++ b/DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsDevice.h
@@ -5,6 +5,7 @@
 
 #include <alpaka/alpaka.hpp>
 
+#include "DataFormats/Common/interface/Uninitialized.h"
 #include "DataFormats/Portable/interface/PortableDeviceCollection.h"
 #include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsSoA.h"
 #include "DataFormats/SiPixelRawData/interface/SiPixelErrorCompact.h"
@@ -14,7 +15,9 @@
 template <typename TDev>
 class SiPixelDigiErrorsDevice : public PortableDeviceCollection<SiPixelDigiErrorsSoA, TDev> {
 public:
-  SiPixelDigiErrorsDevice() = default;
+  SiPixelDigiErrorsDevice(edm::Uninitialized)
+      : PortableDeviceCollection<SiPixelDigiErrorsSoA, TDev>{edm::kUninitialized} {}
+
   template <typename TQueue>
   explicit SiPixelDigiErrorsDevice(size_t maxFedWords, TQueue queue)
       : PortableDeviceCollection<SiPixelDigiErrorsSoA, TDev>(maxFedWords, queue), maxFedWords_(maxFedWords) {}

--- a/DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsHost.h
+++ b/DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsHost.h
@@ -5,6 +5,7 @@
 
 #include <alpaka/alpaka.hpp>
 
+#include "DataFormats/Common/interface/Uninitialized.h"
 #include "DataFormats/Portable/interface/PortableHostCollection.h"
 #include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsSoA.h"
 #include "DataFormats/SiPixelRawData/interface/SiPixelErrorCompact.h"
@@ -13,7 +14,8 @@
 
 class SiPixelDigiErrorsHost : public PortableHostCollection<SiPixelDigiErrorsSoA> {
 public:
-  SiPixelDigiErrorsHost() = default;
+  SiPixelDigiErrorsHost(edm::Uninitialized) : PortableHostCollection<SiPixelDigiErrorsSoA>{edm::kUninitialized} {}
+
   template <typename TQueue>
   explicit SiPixelDigiErrorsHost(int maxFedWords, TQueue queue)
       : PortableHostCollection<SiPixelDigiErrorsSoA>(maxFedWords, queue), maxFedWords_(maxFedWords) {}

--- a/DataFormats/SiPixelDigiSoA/interface/SiPixelDigisDevice.h
+++ b/DataFormats/SiPixelDigiSoA/interface/SiPixelDigisDevice.h
@@ -5,6 +5,7 @@
 
 #include <alpaka/alpaka.hpp>
 
+#include "DataFormats/Common/interface/Uninitialized.h"
 #include "DataFormats/Portable/interface/PortableDeviceCollection.h"
 #include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisSoA.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
@@ -12,7 +13,8 @@
 template <typename TDev>
 class SiPixelDigisDevice : public PortableDeviceCollection<SiPixelDigisSoA, TDev> {
 public:
-  SiPixelDigisDevice() = default;
+  SiPixelDigisDevice(edm::Uninitialized) : PortableDeviceCollection<SiPixelDigisSoA, TDev>{edm::kUninitialized} {}
+
   template <typename TQueue>
   explicit SiPixelDigisDevice(size_t maxFedWords, TQueue queue)
       : PortableDeviceCollection<SiPixelDigisSoA, TDev>(maxFedWords + 1, queue) {}

--- a/DataFormats/SiPixelDigiSoA/interface/SiPixelDigisHost.h
+++ b/DataFormats/SiPixelDigiSoA/interface/SiPixelDigisHost.h
@@ -1,6 +1,7 @@
 #ifndef DataFormats_SiPixelDigiSoA_interface_SiPixelDigisHost_h
 #define DataFormats_SiPixelDigiSoA_interface_SiPixelDigisHost_h
 
+#include "DataFormats/Common/interface/Uninitialized.h"
 #include "DataFormats/Portable/interface/PortableHostCollection.h"
 #include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisSoA.h"
 
@@ -9,7 +10,8 @@
 // See: https://github.com/cms-sw/cmssw/pull/40465#discussion_r1067364306
 class SiPixelDigisHost : public PortableHostCollection<SiPixelDigisSoA> {
 public:
-  SiPixelDigisHost() = default;
+  SiPixelDigisHost(edm::Uninitialized) : PortableHostCollection<SiPixelDigisSoA>{edm::kUninitialized} {}
+
   template <typename TQueue>
   explicit SiPixelDigisHost(size_t maxFedWords, TQueue queue)
       : PortableHostCollection<SiPixelDigisSoA>(maxFedWords + 1, queue) {}

--- a/DataFormats/TestObjects/interface/ToyProducts.h
+++ b/DataFormats/TestObjects/interface/ToyProducts.h
@@ -12,6 +12,7 @@ Toy EDProducts for testing purposes only.
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/Common/interface/OwnVector.h"
 #include "DataFormats/Common/interface/SortedCollection.h"
+#include "DataFormats/Common/interface/Uninitialized.h"
 #include "FWCore/Utilities/interface/typedefs.h"
 
 #include <stdexcept>
@@ -44,6 +45,16 @@ namespace edmtest {
     ~IntProduct() {}
 
     bool operator==(IntProduct const& rhs) const { return value == rhs.value; }
+
+    cms_int32_t value;
+  };
+
+  struct MaybeUninitializedIntProduct {
+    explicit MaybeUninitializedIntProduct(edm::Uninitialized) {}
+    explicit MaybeUninitializedIntProduct(int i) : value(i) {}
+    ~MaybeUninitializedIntProduct() {}
+
+    bool operator==(MaybeUninitializedIntProduct const& rhs) const { return value == rhs.value; }
 
     cms_int32_t value;
   };

--- a/DataFormats/TestObjects/src/classes_def.xml
+++ b/DataFormats/TestObjects/src/classes_def.xml
@@ -6,6 +6,9 @@
   <version ClassVersion="10" checksum="4286676158"/>
  </class>
  <class name="std::pair<edmtest::IntProduct, edm::RandomNumberGeneratorState>"/>
+ <class name="edmtest::MaybeUninitializedIntProduct" ClassVersion="3">
+  <version ClassVersion="3" checksum="3324182225"/>
+ </class>
  <class name="edmtest::UInt64Product" ClassVersion="11">
   <version ClassVersion="11" checksum="3240540910"/>
   <version ClassVersion="10" checksum="380152127"/>
@@ -85,6 +88,7 @@
  <class name="edm::Wrapper<edmtest::IntProduct>"/>
  <class name="std::vector<std::unique_ptr<edmtest::IntProduct>>"/>
  <class name="edm::Wrapper<std::vector<std::unique_ptr<edmtest::IntProduct>>>"/>
+ <class name="edm::Wrapper<edmtest::MaybeUninitializedIntProduct>"/>
  <class name="edm::Wrapper<edmtest::UInt64Product>"/>
  <class name="edm::Wrapper<edmtest::TransientIntProduct>" persistent="false"/>
  <class name="edm::Wrapper<edmtest::ATransientIntProduct>" persistent="false"/>

--- a/DataFormats/TrackSoA/interface/TracksDevice.h
+++ b/DataFormats/TrackSoA/interface/TracksDevice.h
@@ -2,10 +2,13 @@
 #define DataFormats_Track_interface_TracksDevice_h
 
 #include <cstdint>
+
 #include <alpaka/alpaka.hpp>
-#include "DataFormats/TrackSoA/interface/TracksSoA.h"
-#include "DataFormats/TrackSoA/interface/TrackDefinitions.h"
+
+#include "DataFormats/Common/interface/Uninitialized.h"
 #include "DataFormats/Portable/interface/PortableDeviceCollection.h"
+#include "DataFormats/TrackSoA/interface/TrackDefinitions.h"
+#include "DataFormats/TrackSoA/interface/TracksSoA.h"
 
 // TODO: The class is created via inheritance of the PortableCollection.
 // This is generally discouraged, and should be done via composition.
@@ -14,7 +17,10 @@ template <typename TrackerTraits, typename TDev>
 class TracksDevice : public PortableDeviceCollection<reco::TrackLayout<TrackerTraits>, TDev> {
 public:
   static constexpr int32_t S = TrackerTraits::maxNumberOfTuples;  //TODO: this could be made configurable at runtime
-  TracksDevice() = default;                                       // necessary for ROOT dictionaries
+
+  TracksDevice(edm::Uninitialized)
+      : PortableDeviceCollection<reco::TrackLayout<TrackerTraits>, TDev>{edm::kUninitialized} {
+  }  // necessary for ROOT dictionaries
 
   using PortableDeviceCollection<reco::TrackLayout<TrackerTraits>, TDev>::view;
   using PortableDeviceCollection<reco::TrackLayout<TrackerTraits>, TDev>::const_view;

--- a/DataFormats/TrackSoA/interface/TracksHost.h
+++ b/DataFormats/TrackSoA/interface/TracksHost.h
@@ -2,11 +2,14 @@
 #define DataFormats_Track_TracksHost_H
 
 #include <cstdint>
+
 #include <alpaka/alpaka.hpp>
-#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
-#include "DataFormats/TrackSoA/interface/TracksSoA.h"
-#include "DataFormats/TrackSoA/interface/TrackDefinitions.h"
+
+#include "DataFormats/Common/interface/Uninitialized.h"
 #include "DataFormats/Portable/interface/PortableHostCollection.h"
+#include "DataFormats/TrackSoA/interface/TrackDefinitions.h"
+#include "DataFormats/TrackSoA/interface/TracksSoA.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
 
 // TODO: The class is created via inheritance of the PortableHostCollection.
 // This is generally discouraged, and should be done via composition.
@@ -15,7 +18,10 @@ template <typename TrackerTraits>
 class TracksHost : public PortableHostCollection<reco::TrackLayout<TrackerTraits>> {
 public:
   static constexpr int32_t S = TrackerTraits::maxNumberOfTuples;  //TODO: this could be made configurable at runtime
-  TracksHost() = default;  // Needed for the dictionary; not sure if line above is needed anymore
+
+  TracksHost(edm::Uninitialized)
+      : PortableHostCollection<reco::TrackLayout<TrackerTraits>>{edm::kUninitialized} {
+  }  // necessary for ROOT dictionaries
 
   using PortableHostCollection<reco::TrackLayout<TrackerTraits>>::view;
   using PortableHostCollection<reco::TrackLayout<TrackerTraits>>::const_view;

--- a/DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsDevice.h
+++ b/DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsDevice.h
@@ -5,6 +5,7 @@
 
 #include <alpaka/alpaka.hpp>
 
+#include "DataFormats/Common/interface/Uninitialized.h"
 #include "DataFormats/Portable/interface/PortableDeviceCollection.h"
 #include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsHost.h"
 #include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsSoA.h"
@@ -19,7 +20,8 @@ public:
   using PortableDeviceCollection<TrackingRecHitLayout<TrackerTraits>, TDev>::const_view;
   using PortableDeviceCollection<TrackingRecHitLayout<TrackerTraits>, TDev>::buffer;
 
-  TrackingRecHitDevice() = default;
+  TrackingRecHitDevice(edm::Uninitialized)
+      : PortableDeviceCollection<TrackingRecHitLayout<TrackerTraits>, TDev>{edm::kUninitialized} {}
 
   // Constructor which specifies the SoA size, number of BPIX1 hits, and the modules entry points
   template <typename TQueue>

--- a/DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsHost.h
+++ b/DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsHost.h
@@ -5,6 +5,7 @@
 
 #include <alpaka/alpaka.hpp>
 
+#include "DataFormats/Common/interface/Uninitialized.h"
 #include "DataFormats/Portable/interface/PortableHostCollection.h"
 #include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsSoA.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
@@ -19,7 +20,8 @@ public:
   using PortableHostCollection<TrackingRecHitLayout<TrackerTraits>>::const_view;
   using PortableHostCollection<TrackingRecHitLayout<TrackerTraits>>::buffer;
 
-  TrackingRecHitHost() = default;
+  TrackingRecHitHost(edm::Uninitialized)
+      : PortableHostCollection<TrackingRecHitLayout<TrackerTraits>>{edm::kUninitialized} {}
 
   // Constructor which specifies only the SoA size, to be used when copying the results from the device to the host
   template <typename TQueue>

--- a/FWCore/Integration/plugins/BuildFile.xml
+++ b/FWCore/Integration/plugins/BuildFile.xml
@@ -75,6 +75,12 @@
     <use name="FWCore/ServiceRegistry"/>
   </library>
 
+  <library file="MaybeUninitializedIntProducer.cc, MaybeUninitializedIntAnalyzer.cc" name="FWCoreIntegrationMaybeUninitialized">
+    <flags EDM_PLUGIN="1"/>
+    <use name="DataFormats/TestObjects"/>
+    <use name="FWCore/Framework"/>
+    <use name="FWCore/Utilities"/>
+  </library>
 
   <library file="PathsAndConsumesOfModulesTestService.cc" name="FWCoreIntegrationPathsAndConsumesOfModulesTestService">
     <flags EDM_PLUGIN="1"/>

--- a/FWCore/Integration/plugins/MaybeUninitializedIntAnalyzer.cc
+++ b/FWCore/Integration/plugins/MaybeUninitializedIntAnalyzer.cc
@@ -1,0 +1,33 @@
+#include "DataFormats/TestObjects/interface/ToyProducts.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+namespace edmtest {
+
+  class MaybeUninitializedIntAnalyzer : public edm::global::EDAnalyzer<> {
+  public:
+    MaybeUninitializedIntAnalyzer(edm::ParameterSet const& config)
+        : value_{config.getParameter<int32_t>("value")},
+          token_{consumes(config.getParameter<edm::InputTag>("source"))} {}
+
+    void analyze(edm::StreamID, edm::Event const& event, edm::EventSetup const&) const final {
+      MaybeUninitializedIntProduct const& product = event.get(token_);
+      if (product.value != value_) {
+        throw cms::Exception("Inconsistent Data", "MaybeUninitializedIntAnalyzer::analyze")
+            << "Found value " << product.value << " while expecting value " << value_;
+      }
+    }
+
+  private:
+    const cms_int32_t value_;
+    const edm::EDGetTokenT<MaybeUninitializedIntProduct> token_;
+  };
+
+}  // namespace edmtest
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(edmtest::MaybeUninitializedIntAnalyzer);

--- a/FWCore/Integration/plugins/MaybeUninitializedIntProducer.cc
+++ b/FWCore/Integration/plugins/MaybeUninitializedIntProducer.cc
@@ -1,0 +1,26 @@
+#include "DataFormats/TestObjects/interface/ToyProducts.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
+
+namespace edmtest {
+
+  class MaybeUninitializedIntProducer : public edm::global::EDProducer<> {
+  public:
+    MaybeUninitializedIntProducer(edm::ParameterSet const& config)
+        : value_{config.getParameter<int32_t>("value")}, token_{produces()} {}
+
+    void produce(edm::StreamID, edm::Event& event, edm::EventSetup const&) const final {
+      event.emplace(token_, value_);
+    }
+
+  private:
+    const cms_int32_t value_;
+    const edm::EDPutTokenT<MaybeUninitializedIntProduct> token_;
+  };
+
+}  // namespace edmtest
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(edmtest::MaybeUninitializedIntProducer);

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -220,4 +220,5 @@
 
   <test name="TestIntegrationGetByLabel" command="run_TestGetByLabel.sh"/>
 
+  <test name="TestMaybeUninitializedIntProduct" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/testMaybeUninitializedIntProductPart1_cfg.py &amp;&amp; cmsRun ${LOCALTOP}/src/FWCore/Integration/test/testMaybeUninitializedIntProductPart2_cfg.py"/>
 </environment>

--- a/FWCore/Integration/test/testMaybeUninitializedIntProductPart1_cfg.py
+++ b/FWCore/Integration/test/testMaybeUninitializedIntProductPart1_cfg.py
@@ -1,0 +1,29 @@
+#! /usr/bin/env cmsRun
+
+# This configuration is designed to be run as the first in a series of two cmsRun processes.
+# It produces a collection of edmtest::MaybeUninitializedIntProduct and stores them to a ROOT file,
+# to test that edm::Wrapper<T> can be used to read and write objects without a default constructor.
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("Part1")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 1
+
+process.source = cms.Source("EmptySource")
+process.maxEvents.input = 10
+
+process.prod = cms.EDProducer("edmtest::MaybeUninitializedIntProducer",
+    value = cms.int32(42)
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testMaybeUninitializedIntProduct.root'),
+    outputCommands = cms.untracked.vstring(
+        'keep *_prod_*_*'
+    )
+)
+
+process.path = cms.Path(process.prod)
+process.endp = cms.EndPath(process.out)

--- a/FWCore/Integration/test/testMaybeUninitializedIntProductPart2_cfg.py
+++ b/FWCore/Integration/test/testMaybeUninitializedIntProductPart2_cfg.py
@@ -1,0 +1,23 @@
+#! /usr/bin/env cmsRun
+
+# This configuration is designed to be run as the second in a series of two cmsRun processes.
+# It reads a collection of edmtest::MaybeUninitializedIntProduct from a ROOT file and check their values,
+# to test that edm::Wrapper<T> can be used to read and write objects without a default constructor.
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("Part2")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 1
+
+process.source = cms.Source("PoolSource",
+  fileNames = cms.untracked.vstring('file:testMaybeUninitializedIntProduct.root')
+)
+
+process.read = cms.EDAnalyzer("edmtest::MaybeUninitializedIntAnalyzer",
+    source = cms.InputTag("prod"),
+    value = cms.int32(42)
+)
+
+process.path = cms.Path(process.read)

--- a/IOPool/Input/test/BuildFile.xml
+++ b/IOPool/Input/test/BuildFile.xml
@@ -25,7 +25,6 @@
   <test name="TestIOPoolInputNoParentDictionary" command="testNoParentDictionary.sh"/>
   <test name="TestFileOpenErrorExitCode" command="testFileOpenErrorExitCode.sh"/>
   <test name="TestIOPoolInputSchemaEvolution" command="testSchemaEvolution.sh"/>
-
-  <test name="TestIOPoolInputRefProductIDMetadataConsistency" command="run_TestRefProductIDMetadataConsistencyRoot.sh"/>
+  <test name="TestIOPoolInputRefProductIDMetadataConsistency" command="testRefProductIDMetadataConsistencyRoot.sh"/>
 
 </environment>

--- a/IOPool/Input/test/testNoParentDictionary.sh
+++ b/IOPool/Input/test/testNoParentDictionary.sh
@@ -11,11 +11,16 @@ cd $SCRAM_TEST_NAME
 NEW_CMSSW_BASE=$(/bin/pwd -P)/$CMSSW_VERSION
 scram -a $SCRAM_ARCH project $CMSSW_VERSION
 pushd $CMSSW_VERSION/src
+mkdir DataFormats
+
+# Copy DataFormats/Common if it was modified locally
+if [ -d ${CMSSW_BASE}/src/DataFormats/Common ]; then
+    cp -Lr ${CMSSW_BASE}/src/DataFormats/Common DataFormats/
+fi
 
 # Copy DataFormats/TestObjects code to be able to edit it to make ROOT header parsing to fail
 for DIR in ${CMSSW_BASE} ${CMSSW_RELEASE_BASE} ${CMSSW_FULL_RELEASE_BASE} ; do
     if [ -d ${DIR}/src/DataFormats/TestObjects ]; then
-        mkdir DataFormats
         cp -Lr ${DIR}/src/DataFormats/TestObjects DataFormats/
         break
     fi

--- a/IOPool/Input/test/testRefProductIDMetadataConsistencyRoot.sh
+++ b/IOPool/Input/test/testRefProductIDMetadataConsistencyRoot.sh
@@ -9,6 +9,5 @@ function runSuccess {
 
 runSuccess ${SCRAM_TEST_PATH}/testRefProductIDMetadataConsistencyRoot_cfg.py
 runSuccess ${SCRAM_TEST_PATH}/testRefProductIDMetadataConsistencyRoot_cfg.py --enableOther
-
 runSuccess ${SCRAM_TEST_PATH}/testRefProductIDMetadataConsistencyRootMerge_cfg.py
 runSuccess ${SCRAM_TEST_PATH}/testRefProductIDMetadataConsistencyRootTest_cfg.py


### PR DESCRIPTION
#### PR description:

Let `edm::Wrapper<T>` use a special constructor `T{kUninitialized}` instead of the default constructor `T{}`, if the latter does not exist.

Add to `DeviceProduct<T>` an explicit constructor `DeviceProduct{kUninitialized}` that calls `T{kUninitialized}`, if the latter is valid.

Remove the default constructor from `PortableCollection`, `PortableObject` and related types, and introduce the special constructor taking `kUninitialized`.


#### PR validation:

Unit tests pass, and the full 2024 HLT runs.