### PR TITLE
Standard 2024(2022,2023) Wfs For PR Testing

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -573,57 +573,19 @@ workflows[143.902] = ['',['RunUPC2024','RECODR3_2025_HIN','HARVESTDPROMPTR3']]
 ### run3-2025 (2025 HI OXY data)
 workflows[143.911] = ['',['RunUPC2024','RECODR3_2025_OXY','HARVESTDPROMPTR3']]
 
-##################################################################
-### Golden Data Wfs
-# for a limited set of eras and PDs not to overflow the IB matrices
-# the full set in relval_data_highstats.py
 
-offset_era = 0.1 # less than 10 eras per year
+## Lumi mask fixed 2024 wfs
+base_wf = 145.0
+offset_era = 0.1 # less than 10 eras per year (hopefully)
 offset_pd = 0.001 # less than 100 pds per year
 
-# 2024
-base_wf = 2024
-for e_n,era in enumerate(['Run2024B','Run2024C','Run2024D','Run2024E']):
-    for p_n,pd in enumerate(['ZeroBias','BTagMu','JetMET0','DisplacedJet']):
-        wf_number = base_wf
-        wf_number = wf_number + offset_era * e_n
-        wf_number = wf_number + offset_pd * p_n
-        wf_number = wf_number + 0.0001 * 0.01 
-        wf_number = round(wf_number,6)
-
-        step_name = "Run" + pd.replace("ParkingDouble","Park2") + era.split("Run")[1] + "_10k"
-        y = str(base_wf)
+for e_n,era in enumerate(era_mask_2024):
+    for p_n,pd in enumerate(pds_2024):
+        wf_number = round(base_wf + offset_era * e_n + offset_pd * p_n,3)
+        dataset = "/" + pd + "/" + era + "-v1/RAW"
+        step_name = "Run" + pd.replace("ParkingDouble","Park2") + era.split("Run")[1]
         suff = "ZB_" if "ZeroBias" in step_name else ""
-        workflows[wf_number] = ['',[step_name,'HLTDR3_' + y,'RECONANORUN3_' + suff + 'reHLT_'+y,'HARVESTRUN3_' + suff + y]]
-
-# 2023
-base_wf = 2023
-for e_n,era in enumerate(['Run2023D']):
-    for p_n,pd in enumerate(['MuonEG','DisplacedJet','ZeroBias']):
-        wf_number = base_wf
-        wf_number = wf_number + offset_era * e_n
-        wf_number = wf_number + offset_pd * p_n
-        wf_number = wf_number + 0.0001 * 0.01
-        wf_number = round(wf_number,6)
-
-        step_name = "Run" + pd.replace("ParkingDouble","Park2") + era.split("Run")[1] + "_10k"
-        y = str(base_wf) + "B" if "2023B" in era else str(base_wf)
-        suff = "ZB_" if "ZeroBias" in step_name else ""
-        workflows[wf_number] = ['',[step_name,'HLTDR3_' + y,'RECONANORUN3_' + suff + 'reHLT_'+y,'HARVESTRUN3_' + suff + y]]
-
-# 2022
-base_wf = 2022
-for e_n,era in enumerate(['Run2022C']):
-    for p_n,pd in enumerate(['JetHT','EGamma','ZeroBias']):
-        wf_number = base_wf
-        wf_number = wf_number + offset_era * e_n
-        wf_number = wf_number + offset_pd * p_n
-        wf_number = wf_number + 0.0001 * 0.01 
-        wf_number = round(wf_number,6)
-        step_name = "Run" + pd + era.split("Run")[1] + "_10k"
-        y = str(base_wf)
-        suff = "ZB_" if "ZeroBias" in step_name else ""
-        workflows[wf_number] = ['',[step_name,'HLTDR3_' + y,'RECONANORUN3_' + suff + 'reHLT_'+y,'HARVESTRUN3_' + suff + y]]
+        workflows[wf_number] = ['',[step_name,'HLTDR3_2024','RECONANORUN3_' + suff + 'reHLT_2024','HARVESTRUN3_' + suff + '2024']]
 
 ##################################################################
 

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -654,7 +654,7 @@ steps['RunHIPhysicsRawPrime2023A']={'INPUT':InputInfo(dataSet='/HIPhysicsRawPrim
 ###2024 
 
 pds_2024  = ['BTagMu', 'DisplacedJet', 'EGamma0', 'HcalNZS', 'JetMET0', 'Muon0', 'MuonEG', 'NoBPTX', 'ParkingDoubleMuonLowMass0', 'ParkingHH', 'ParkingLLP', 'ParkingSingleMuon0', 'ParkingVBF0', 'Tau', 'ZeroBias']
-eras_2024 = ['Run2024B', 'Run2024C', 'Run2024D', 'Run2024E', 'Run2024F']
+eras_2024 = ['Run2024B', 'Run2024C', 'Run2024D', 'Run2024E', 'Run2024F','Run2024G','Run2024H','Run2024I']
 for era in eras_2024:
     for pd in pds_2024:
         dataset = "/" + pd + "/" + era + "-v1/RAW"
@@ -696,6 +696,21 @@ for era in eras_2022_2:
         for e_key,evs in event_steps_dict.items():
             step_name = "Run" + pd + era.split("Run")[1] + "_" + e_key
             steps[step_name] = {'INPUT':InputInfo(dataSet=dataset,label=era.split("Run")[1],events=int(evs*1e6), skimEvents=True, location='STD')}
+
+
+### 2024 single lumi mask wfs for the limited matrix only
+### Mask chosen from golden json away from run start
+
+good_runs_2024 = [379238,379454,380360,381079,382258,383814,385889,386593]
+lumi_mask_2024 = [{ r : [[110, 111]]} for r in good_runs_2024]
+era_mask_2024  = dict(zip(eras_2024,lumi_mask_2024))
+
+for era in era_mask_2024:
+    for pd in pds_2024:
+        dataset = "/" + pd + "/" + era + "-v1/RAW"
+        lm = era_mask_2024[era]
+        step_name = "Run" + pd.replace("ParkingDouble","Park2") + era.split("Run")[1]
+        steps[step_name]={'INPUT':InputInfo(dataSet=dataset,label=era.split("Run")[1],events=100000,location='STD', ls=lm)}
 
 
 ##################################################################

--- a/Configuration/PyReleaseValidation/scripts/README.md
+++ b/Configuration/PyReleaseValidation/scripts/README.md
@@ -369,12 +369,18 @@ pp Data reRECO workflows:
 | 2022 	|  	|  	|  	|  	|  	
 | 2022.002001 	| Run2022D ZeroBias 	|  	run3_hlt_relval + run3_data_relval |  	Run3 |  	HLT:@relval2022 | 
 | 2022.000001 	| Run2022D JetHT 	|  	run3_hlt_relval + run3_data_relval |  	Run3 |  	HLT:@relval2022 |  	
+| 2023 	|  	|  	|  	|  	|  
 | 2023.002001 	| Run2023D ZeroBias 	|  	run3_hlt_relval + run3_data_relval|  	Run3_2023 |  	HLT:@relval2023 | 
 | 2023.000001 	| Run2023D MuonEG 	|  	run3_hlt_relval + run3_data_relval|  	Run3_2023 |  	HLT:@relval2023 | 
-| 2024.000001 	| Run2024B ZeroBias 	|  	run3_hlt_relval + run3_data_prompt_relval|  	Run3_2024 |  	HLT:@relval2023 |  
-| 2024.101001 	| Run2024C BTagMu 	|  	run3_hlt_relval + run3_data_prompt_relval|  	Run3_2024 |  	HLT:@relval2025 |  
-| 2024.202001 	| Run2024D JetMET0 	|  	run3_hlt_relval + run3_data_prompt_relval|  	Run3_2024 |  	HLT:@relval2025 |  
-| 2024.303001 	| Run2024E RunDisplacedJet 	|  	run3_hlt_relval + run3_data_prompt_relval|  	Run3_2024 |  	HLT:@relval2025 |  
+| 2024 	|  	|  	|  	|  	|
+| 145.014 	| Run2024B ZeroBias 	|  	run3_hlt_relval + run3_data_prompt_relval|  	Run3_2024 |  	HLT:@relval2025 |  
+| 145.104 	| Run2024C JetMet0 	|  	run3_hlt_relval + run3_data_prompt_relval|  	Run3_2024 |  	HLT:@relval2025 |  
+| 145.202 	| Run2024D EGamma0 	|  	run3_hlt_relval + run3_data_prompt_relval|  	Run3_2024 |  	HLT:@relval2025 |  
+| 145.301 	| Run2024E DisplacedJet 	|  	run3_hlt_relval + run3_data_prompt_relval|  	Run3_2024 |  	HLT:@relval2025 |  
+| 145.408 	| Run2024B ParkingDoubleMuonLowMass0 	|  	run3_hlt_relval + run3_data_prompt_relval|  	Run3_2024 |  	HLT:@relval2025 |  
+| 145.500 	| Run2024B BTagMu 	|  	run3_hlt_relval + run3_data_prompt_relval|  	Run3_2024 |  	HLT:@relval2025 |  
+| 145.604 	| Run2024B JetMET0 	|  	run3_hlt_relval + run3_data_prompt_relval|  	Run3_2024 |  	HLT:@relval2025 |  
+| 145.713 	| Run2024B Tau 	|  	run3_hlt_relval + run3_data_prompt_relval|  	Run3_2024 |  	HLT:@relval2025 |  
 
 And Heavy Ion workflows:
 

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -115,18 +115,20 @@ if __name__ == '__main__':
                     139.001,    # Run2021  MinimumBias                  Commissioning2021   
                     
                     # 2022
-                    2022.002001,    # Run2022C ZeroBias
-                    2022.000001,    # Run2022C JetHT
+                    140.045,    # Run2022C JetHT
 
                     # 2023
-                    2023.002001,    # Run2023D ZeroBias
-                    2023.002001,    # Run2023D MuonEG
+                    141.042,    # Run2023D ZeroBias
 
                     # 2024
-                    2024.000001,      # Run2024B ZeroBias
-                    2024.101001,      # Run2024C BTagMu 
-                    2024.202001,      # Run2024D JetMET0
-                    2024.303001,      # Run2024E DisplacedJet
+                    145.014,      # Run2024B ZeroBias
+                    145.104,      # Run2024C JetMet0 
+                    145.202,      # Run2024D EGamma0
+                    145.301,      # Run2024E DisplacedJet
+                    145.408,      # Run2024F ParkingDoubleMuonLowMass0
+                    145.500,      # Run2024G BTagMu
+                    145.604,      # Run2024H JetMET0
+                    145.713,      # Run2024I Tau
                     
                     ###### Heavy Ions
                     ## Data


### PR DESCRIPTION
#### PR description:

Given the fact that in the tests the golden wfs are quite unstable (and I'm not sure to understand why), this PR proposes to use some standard fixed lumi mask wfs for 2022,2023,2024 data wfs in the limited matrix. I took the change to add wfs for latest 2024 Eras and to have more of them in the limited matrix (removing a couple fo 2022/2023 ones).

#### PR validation:

`runTheMatrix.py -l 145.014,145.104,145.202,145.301,145.408,145.500,145.604,145.713`