### PR TITLE
Fix typo with lhe numbering matching

### DIFF
--- a/GeneratorInterface/Herwig7Interface/plugins/Herwig7Hadronizer.cc
+++ b/GeneratorInterface/Herwig7Interface/plugins/Herwig7Hadronizer.cc
@@ -181,7 +181,7 @@ bool Herwig7Hadronizer::hadronize()
     if (evtnum == -1) {
         edm::LogError("Generator|Herwig7Hadronizer") << "Event number not set in lhe file, needed for correctly aligning Herwig and LHE events!";
         return false;
-    } else if (thepegEvent->number() == evtnum) {
+    } else if (thepegEvent->number() < evtnum) {
         edm::LogError("Herwig7 interface") << "Herwig does not seem to be generating events in order, did you set /Herwig/EventHandlers/FxFxLHReader:AllowedToReOpen Yes?";
         return false;
     } else if (thepegEvent->number() == evtnum) {


### PR DESCRIPTION
#### PR description:

While making the backport https://github.com/cms-sw/cmssw/pull/42907, I seemingly introduced a typo into the Herwig7HadronizerFilter, which causes it to reject events it should accept. This was seemingly not caught by the relevant relvals as they still showed as "passing" even though all events were skipped. This PR fixes the issue, it would be good to have it merged quickly and a new 10_6 release or a patch, as currently run II Herwig lhe requests won't work

#### PR validation:

Tested with relvals 535,537 and 538 (including checking in the logs that the events are actually produced)