### PR TITLE
Fix PFClusterSoAProducer to read a device collection

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterECLCC.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterECLCC.h
@@ -1,10 +1,11 @@
 #ifndef RecoParticleFlow_PFClusterProducer_plugins_alpaka_PFClusterECLCC_h
 #define RecoParticleFlow_PFClusterProducer_plugins_alpaka_PFClusterECLCC_h
 
+#include "DataFormats/ParticleFlowReco/interface/alpaka/PFRecHitDeviceCollection.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
-#include "RecoParticleFlow/PFClusterProducer/interface/alpaka/PFClusteringVarsDeviceCollection.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/alpaka/PFClusteringEdgeVarsDeviceCollection.h"
+#include "RecoParticleFlow/PFClusterProducer/interface/alpaka/PFClusteringVarsDeviceCollection.h"
 
 // The following comment block is required in using the ECL-CC algorithm for topological clustering
 
@@ -79,9 +80,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   // Initial step of ECL-CC. Uses ID of first neighbour in edgeList with a smaller ID
   class ECLCCInit {
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(const TAcc& acc,
-                                  reco::PFRecHitHostCollection::ConstView pfRecHits,
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
+                                  reco::PFRecHitDeviceCollection::ConstView pfRecHits,
                                   reco::PFClusteringVarsDeviceCollection::View pfClusteringVars,
                                   reco::PFClusteringEdgeVarsDeviceCollection::View pfClusteringEdgeVars) const {
       const int nRH = pfRecHits.size();
@@ -103,9 +103,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   // Processes vertices
   class ECLCCCompute1 {
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(const TAcc& acc,
-                                  reco::PFRecHitHostCollection::ConstView pfRecHits,
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
+                                  reco::PFRecHitDeviceCollection::ConstView pfRecHits,
                                   reco::PFClusteringVarsDeviceCollection::View pfClusteringVars,
                                   reco::PFClusteringEdgeVarsDeviceCollection::View pfClusteringEdgeVars) const {
       const int nRH = pfRecHits.size();
@@ -148,9 +147,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   /* link all vertices to sink */
   class ECLCCFlatten {
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(const TAcc& acc,
-                                  reco::PFRecHitHostCollection::ConstView pfRecHits,
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
+                                  reco::PFRecHitDeviceCollection::ConstView pfRecHits,
                                   reco::PFClusteringVarsDeviceCollection::View pfClusteringVars,
                                   reco::PFClusteringEdgeVarsDeviceCollection::View pfClusteringEdgeVars) const {
       const int nRH = pfRecHits.size();

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducerKernel.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducerKernel.h
@@ -1,15 +1,14 @@
 #ifndef RecoParticleFlow_PFClusterProducer_PFClusterProducerAlpakaKernel_h
 #define RecoParticleFlow_PFClusterProducer_PFClusterProducerAlpakaKernel_h
 
-#include "DataFormats/ParticleFlowReco/interface/alpaka/PFRecHitDeviceCollection.h"
-#include "DataFormats/ParticleFlowReco/interface/PFRecHitHostCollection.h"
 #include "DataFormats/ParticleFlowReco/interface/alpaka/PFClusterDeviceCollection.h"
+#include "DataFormats/ParticleFlowReco/interface/alpaka/PFRecHitDeviceCollection.h"
 #include "DataFormats/ParticleFlowReco/interface/alpaka/PFRecHitFractionDeviceCollection.h"
-#include "RecoParticleFlow/PFClusterProducer/interface/alpaka/PFClusterParamsDeviceCollection.h"
-#include "RecoParticleFlow/PFClusterProducer/interface/alpaka/PFClusteringVarsDeviceCollection.h"
-#include "RecoParticleFlow/PFClusterProducer/interface/alpaka/PFClusteringEdgeVarsDeviceCollection.h"
-#include "RecoParticleFlow/PFRecHitProducer/interface/alpaka/PFRecHitTopologyDeviceCollection.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "RecoParticleFlow/PFClusterProducer/interface/alpaka/PFClusterParamsDeviceCollection.h"
+#include "RecoParticleFlow/PFClusterProducer/interface/alpaka/PFClusteringEdgeVarsDeviceCollection.h"
+#include "RecoParticleFlow/PFClusterProducer/interface/alpaka/PFClusteringVarsDeviceCollection.h"
+#include "RecoParticleFlow/PFRecHitProducer/interface/alpaka/PFRecHitTopologyDeviceCollection.h"
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
@@ -37,14 +36,15 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   class PFClusterProducerKernel {
   public:
-    PFClusterProducerKernel(Queue& queue, const reco::PFRecHitHostCollection& pfRecHits);
+    explicit PFClusterProducerKernel(Queue& queue);
 
     void seedTopoAndContract(Queue& queue,
                              const reco::PFClusterParamsDeviceCollection& params,
                              const reco::PFRecHitHCALTopologyDeviceCollection& topology,
                              reco::PFClusteringVarsDeviceCollection& pfClusteringVars,
                              reco::PFClusteringEdgeVarsDeviceCollection& pfClusteringEdgeVars,
-                             const reco::PFRecHitHostCollection& pfRecHits,
+                             const reco::PFRecHitDeviceCollection& pfRecHits,
+                             int nRH,
                              reco::PFClusterDeviceCollection& pfClusters,
                              uint32_t* __restrict__ nRHF);
 
@@ -53,7 +53,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                  const reco::PFRecHitHCALTopologyDeviceCollection& topology,
                  reco::PFClusteringVarsDeviceCollection& pfClusteringVars,
                  reco::PFClusteringEdgeVarsDeviceCollection& pfClusteringEdgeVars,
-                 const reco::PFRecHitHostCollection& pfRecHits,
+                 const reco::PFRecHitDeviceCollection& pfRecHits,
+                 int nRH,
                  reco::PFClusterDeviceCollection& pfClusters,
                  reco::PFRecHitFractionDeviceCollection& pfrhFractions);
 

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitSoAProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitSoAProducer.cc
@@ -3,11 +3,12 @@
 
 #include <alpaka/alpaka.hpp>
 
+#include "DataFormats/ParticleFlowReco/interface/alpaka/PFRecHitDeviceCollection.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/InputTag.h"
-#include "HeterogeneousCore/AlpakaCore/interface/alpaka/global/EDProducer.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/stream/SynchronizingEDProducer.h"
 #include "RecoParticleFlow/PFRecHitProducer/interface/PFRecHitParamsRecord.h"
 #include "RecoParticleFlow/PFRecHitProducer/interface/PFRecHitTopologyRecord.h"
 
@@ -18,12 +19,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   using namespace particleFlowRecHitProducer;
 
   template <typename CAL>
-  class PFRecHitSoAProducer : public global::EDProducer<> {
+  class PFRecHitSoAProducer : public stream::SynchronizingEDProducer<> {
   public:
     PFRecHitSoAProducer(edm::ParameterSet const& config)
         : topologyToken_(esConsumes(config.getParameter<edm::ESInputTag>("topology"))),
           pfRecHitsToken_(produces()),
-          synchronise_(config.getUntrackedParameter<bool>("synchronise")) {
+          sizeToken_(produces()),
+          synchronise_(config.getUntrackedParameter<bool>("synchronise")),
+          size_{cms::alpakatools::make_host_buffer<uint32_t, Platform>()} {
       const std::vector<edm::ParameterSet> producers = config.getParameter<std::vector<edm::ParameterSet>>("producers");
       recHitsToken_.reserve(producers.size());
       for (const edm::ParameterSet& producer : producers) {
@@ -32,27 +35,34 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       }
     }
 
-    void produce(edm::StreamID, device::Event& event, const device::EventSetup& setup) const override {
+    void acquire(device::Event const& event, const device::EventSetup& setup) override {
       const typename CAL::TopologyTypeDevice& topology = setup.getData(topologyToken_);
 
       uint32_t num_recHits = 0;
       for (const auto& token : recHitsToken_)
         num_recHits += event.get(token.first)->metadata().size();
 
-      reco::PFRecHitDeviceCollection pfRecHits{(int)num_recHits, event.queue()};
+      pfRecHits_.emplace((int)num_recHits, event.queue());
+      *size_ = 0;
 
       if (num_recHits != 0) {
         PFRecHitProducerKernel<CAL> kernel{event.queue(), num_recHits};
         for (const auto& token : recHitsToken_)
           kernel.processRecHits(
-              event.queue(), event.get(token.first), setup.getData(token.second), topology, pfRecHits);
-        kernel.associateTopologyInfo(event.queue(), topology, pfRecHits);
+              event.queue(), event.get(token.first), setup.getData(token.second), topology, *pfRecHits_);
+        kernel.associateTopologyInfo(event.queue(), topology, *pfRecHits_);
+        auto size_d = cms::alpakatools::make_device_view<uint32_t>(event.queue(), pfRecHits_->view().size());
+        alpaka::memcpy(event.queue(), size_, size_d);
       }
+    }
+
+    void produce(device::Event& event, const device::EventSetup& setup) override {
+      event.emplace(pfRecHitsToken_, std::move(*pfRecHits_));
+      event.emplace(sizeToken_, *size_);
+      pfRecHits_.reset();
 
       if (synchronise_)
         alpaka::wait(event.queue());
-
-      event.emplace(pfRecHitsToken_, std::move(pfRecHits));
     }
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -71,12 +81,18 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     }
 
   private:
+    // module configuration
     const device::ESGetToken<typename CAL::TopologyTypeDevice, typename CAL::TopologyRecordType> topologyToken_;
     std::vector<std::pair<device::EDGetToken<typename CAL::CaloRecHitSoATypeDevice>,
                           device::ESGetToken<typename CAL::ParameterType, typename CAL::ParameterRecordType>>>
         recHitsToken_;
     const device::EDPutToken<reco::PFRecHitDeviceCollection> pfRecHitsToken_;
+    const edm::EDPutTokenT<cms_uint32_t> sizeToken_;
     const bool synchronise_;
+
+    // data members used to communicate between acquire() and produce()
+    cms::alpakatools::host_buffer<uint32_t> size_;
+    std::optional<reco::PFRecHitDeviceCollection> pfRecHits_;
   };
 
   using PFRecHitSoAProducerHCAL = PFRecHitSoAProducer<HCAL>;


### PR DESCRIPTION
#### PR description:

Fix `PFClusterSoAProducer` to read a device collection instead of a host collection, when running on a GPU backend.

Make the `PFRecHitSoAProducer` produce an additional host-only collection with the number of PF rechits. The `PFClusterSoAProducer` can then consume the device collection of PF rechits, and the host collection with the number of PF rechits.

#### PR validation:

Tested that the 2024 HLT menu runs.


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

May be backported to 14.2.x or earlier if there is interest.