### PR TITLE
Change Vtx generators to allow HepMC3Product smearing

### DIFF
--- a/IOMC/EventVertexGenerators/interface/BaseEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/BaseEvtVtxGenerator.h
@@ -6,6 +6,7 @@
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 
+#include "Math/Vector4D.h"
 #include "TMatrixD.h"
 
 namespace HepMC {
@@ -29,12 +30,7 @@ public:
 
   void produce(edm::Event&, const edm::EventSetup&) override;
 
-  virtual HepMC::FourVector newVertex(CLHEP::HepRandomEngine*) const = 0;
-  /** This method - and the comment - is a left-over from COBRA-OSCAR time :
-    *  return the last generated event vertex.
-    *  If no vertex has been generated yet, a NULL pointer is returned. */
-  //virtual CLHEP::Hep3Vector* lastVertex() { return fVertex; }
-  //virtual HepMC::FourVector* lastVertex() { return fVertex; }
+  virtual ROOT::Math::XYZTVector vertexShift(CLHEP::HepRandomEngine*) const = 0;
 
   virtual TMatrixD const* GetInvLorentzBoost() const = 0;
 

--- a/IOMC/EventVertexGenerators/interface/BeamProfileVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/BeamProfileVtxGenerator.h
@@ -26,8 +26,7 @@ public:
   ~BeamProfileVtxGenerator() override;
 
   /// return a new event vertex
-  //virtual CLHEP::Hep3Vector * newVertex();
-  HepMC::FourVector newVertex(CLHEP::HepRandomEngine*) const override;
+  ROOT::Math::XYZTVector vertexShift(CLHEP::HepRandomEngine*) const override;
 
   TMatrixD const* GetInvLorentzBoost() const override { return nullptr; }
 

--- a/IOMC/EventVertexGenerators/interface/BetafuncEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/BetafuncEvtVtxGenerator.h
@@ -43,8 +43,7 @@ public:
   void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
   /// return a new event vertex
-  //virtual CLHEP::Hep3Vector * newVertex();
-  HepMC::FourVector newVertex(CLHEP::HepRandomEngine*) const override;
+  ROOT::Math::XYZTVector vertexShift(CLHEP::HepRandomEngine*) const override;
 
   TMatrixD const* GetInvLorentzBoost() const override;
 

--- a/IOMC/EventVertexGenerators/interface/FlatEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/FlatEvtVtxGenerator.h
@@ -29,8 +29,7 @@ public:
   ~FlatEvtVtxGenerator() override;
 
   /// return a new event vertex
-  //virtual CLHEP::Hep3Vector* newVertex();
-  HepMC::FourVector newVertex(CLHEP::HepRandomEngine*) const override;
+  ROOT::Math::XYZTVector vertexShift(CLHEP::HepRandomEngine*) const override;
 
   const TMatrixD* GetInvLorentzBoost() const override { return nullptr; }
 

--- a/IOMC/EventVertexGenerators/interface/GaussEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/GaussEvtVtxGenerator.h
@@ -32,8 +32,7 @@ public:
   void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
   /// return a new event vertex
-  //virtual CLHEP::Hep3Vector* newVertex();
-  HepMC::FourVector newVertex(CLHEP::HepRandomEngine*) const override;
+  ROOT::Math::XYZTVector vertexShift(CLHEP::HepRandomEngine*) const override;
 
   TMatrixD const* GetInvLorentzBoost() const override { return nullptr; }
 

--- a/IOMC/EventVertexGenerators/interface/HLLHCEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/HLLHCEvtVtxGenerator.h
@@ -44,7 +44,7 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
   /// return a new event vertex
-  HepMC::FourVector newVertex(CLHEP::HepRandomEngine*) const override;
+  ROOT::Math::XYZTVector vertexShift(CLHEP::HepRandomEngine*) const override;
 
   TMatrixD const* GetInvLorentzBoost() const override { return nullptr; };
 

--- a/IOMC/EventVertexGenerators/interface/PassThroughEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/PassThroughEvtVtxGenerator.h
@@ -4,21 +4,11 @@
 */
 
 #include "IOMC/EventVertexGenerators/interface/BaseEvtVtxGenerator.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
-#include "FWCore/Utilities/interface/EDGetToken.h"
 
 #include "TMatrixD.h"
 
-namespace HepMC {
-  class FourVector;
-}
-
 namespace CLHEP {
   class HepRandomEngine;
-}
-
-namespace edm {
-  class HepMCProduct;
 }
 
 class PassThroughEvtVtxGenerator : public BaseEvtVtxGenerator {
@@ -27,14 +17,12 @@ public:
   explicit PassThroughEvtVtxGenerator(const edm::ParameterSet&);
   ~PassThroughEvtVtxGenerator() override;
 
-  void produce(edm::Event&, const edm::EventSetup&) override;
-
-  HepMC::FourVector newVertex(CLHEP::HepRandomEngine*) const override;
+  ROOT::Math::XYZTVector vertexShift(CLHEP::HepRandomEngine*) const override;
 
   TMatrixD const* GetInvLorentzBoost() const override { return nullptr; };
 
 private:
-  edm::EDGetTokenT<edm::HepMCProduct> sourceToken;
+
 };
 
 #endif

--- a/IOMC/EventVertexGenerators/interface/PassThroughEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/PassThroughEvtVtxGenerator.h
@@ -22,7 +22,6 @@ public:
   TMatrixD const* GetInvLorentzBoost() const override { return nullptr; };
 
 private:
-
 };
 
 #endif

--- a/IOMC/EventVertexGenerators/src/BaseEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/BaseEvtVtxGenerator.cc
@@ -1,4 +1,3 @@
-
 /*
 */
 
@@ -18,13 +17,8 @@
 #include "DataFormats/Provenance/interface/Provenance.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 
-//#include "HepMC/GenEvent.h"
-// #include "CLHEP/Vector/ThreeVector.h"
-// #include "HepMC/SimpleVector.h"
-
 using namespace edm;
 using namespace CLHEP;
-//using namespace HepMC;
 
 BaseEvtVtxGenerator::BaseEvtVtxGenerator(const ParameterSet& pset) {
   Service<RandomNumberGenerator> rng;
@@ -59,7 +53,8 @@ void BaseEvtVtxGenerator::produce(Event& evt, const EventSetup&) {
     std::unique_ptr<edm::HepMCProduct> HepMCEvt(new edm::HepMCProduct(genevt));
     // generate new vertex & apply the shift
     //
-    HepMCEvt->applyVtxGen(newVertex(engine));
+    ROOT::Math::XYZTVector VertexShift = vertexShift(engine);
+    HepMCEvt->applyVtxGen(HepMC::FourVector(VertexShift.x(), VertexShift.y(), VertexShift.z(), VertexShift.t()));
 
     HepMCEvt->boostToLab(GetInvLorentzBoost(), "vertex");
     HepMCEvt->boostToLab(GetInvLorentzBoost(), "momentum");
@@ -76,7 +71,22 @@ void BaseEvtVtxGenerator::produce(Event& evt, const EventSetup&) {
 
     HepMC3::GenEvent* genevt3 = new HepMC3::GenEvent();
     genevt3->read_data(*HepUnsmearedMCEvt3->GetEvent());
-    HepMC3Product* productcopy3 = new HepMC3Product(genevt3);  // For the moment do not really smear HepMC3
+    HepMC3Product* productcopy3 = new HepMC3Product(genevt3);
+    ROOT::Math::XYZTVector VertexShift = vertexShift(engine);
+    productcopy3->applyVtxGen(HepMC3::FourVector(VertexShift.x(), VertexShift.y(), VertexShift.z(), VertexShift.t()));
+
+    if(GetInvLorentzBoost() != nullptr) {
+      TMatrixD tmplorentz(*GetInvLorentzBoost());
+      TMatrixD p4(4, 1);
+      p4(0, 0) = 1.; p4(1, 0) = 1.; p4(2, 0) = 1.; p4(3, 0) = 1.; // Check if the boost matrix is not trivial
+      TMatrixD p4lab(4, 1);
+      p4lab = tmplorentz * p4;
+      if (p4lab(0, 0) - p4(0, 0) != 0. || p4lab(1, 0) - p4(1, 0) != 0. || p4lab(2, 0) - p4(2, 0) != 0. || p4lab(3, 0) - p4(3, 0) != 0.) {  // not trivial
+        productcopy3->boostToLab(GetInvLorentzBoost(), "vertex");
+        productcopy3->boostToLab(GetInvLorentzBoost(), "momentum");
+      }
+    }
+
     std::unique_ptr<edm::HepMC3Product> HepMC3Evt(productcopy3);
     evt.put(std::move(HepMC3Evt));
   }

--- a/IOMC/EventVertexGenerators/src/BaseEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/BaseEvtVtxGenerator.cc
@@ -75,13 +75,17 @@ void BaseEvtVtxGenerator::produce(Event& evt, const EventSetup&) {
     ROOT::Math::XYZTVector VertexShift = vertexShift(engine);
     productcopy3->applyVtxGen(HepMC3::FourVector(VertexShift.x(), VertexShift.y(), VertexShift.z(), VertexShift.t()));
 
-    if(GetInvLorentzBoost() != nullptr) {
+    if (GetInvLorentzBoost() != nullptr) {
       TMatrixD tmplorentz(*GetInvLorentzBoost());
       TMatrixD p4(4, 1);
-      p4(0, 0) = 1.; p4(1, 0) = 1.; p4(2, 0) = 1.; p4(3, 0) = 1.; // Check if the boost matrix is not trivial
+      p4(0, 0) = 1.;
+      p4(1, 0) = 1.;
+      p4(2, 0) = 1.;
+      p4(3, 0) = 1.; // Check if the boost matrix is not trivial
       TMatrixD p4lab(4, 1);
       p4lab = tmplorentz * p4;
-      if (p4lab(0, 0) - p4(0, 0) != 0. || p4lab(1, 0) - p4(1, 0) != 0. || p4lab(2, 0) - p4(2, 0) != 0. || p4lab(3, 0) - p4(3, 0) != 0.) {  // not trivial
+      if (p4lab(0, 0) - p4(0, 0) != 0. || p4lab(1, 0) - p4(1, 0) != 0. ||
+          p4lab(2, 0) - p4(2, 0) != 0. || p4lab(3, 0) - p4(3, 0) != 0.) {  // not trivial
         productcopy3->boostToLab(GetInvLorentzBoost(), "vertex");
         productcopy3->boostToLab(GetInvLorentzBoost(), "momentum");
       }

--- a/IOMC/EventVertexGenerators/src/BaseEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/BaseEvtVtxGenerator.cc
@@ -81,11 +81,11 @@ void BaseEvtVtxGenerator::produce(Event& evt, const EventSetup&) {
       p4(0, 0) = 1.;
       p4(1, 0) = 1.;
       p4(2, 0) = 1.;
-      p4(3, 0) = 1.; // Check if the boost matrix is not trivial
+      p4(3, 0) = 1.;  // Check if the boost matrix is not trivial
       TMatrixD p4lab(4, 1);
       p4lab = tmplorentz * p4;
-      if (p4lab(0, 0) - p4(0, 0) != 0. || p4lab(1, 0) - p4(1, 0) != 0. ||
-          p4lab(2, 0) - p4(2, 0) != 0. || p4lab(3, 0) - p4(3, 0) != 0.) {  // not trivial
+      if (p4lab(0, 0) - p4(0, 0) != 0. || p4lab(1, 0) - p4(1, 0) != 0. || p4lab(2, 0) - p4(2, 0) != 0. ||
+          p4lab(3, 0) - p4(3, 0) != 0.) {  // not trivial:
         productcopy3->boostToLab(GetInvLorentzBoost(), "vertex");
         productcopy3->boostToLab(GetInvLorentzBoost(), "momentum");
       }

--- a/IOMC/EventVertexGenerators/src/BeamProfileVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/BeamProfileVtxGenerator.cc
@@ -11,7 +11,6 @@
 #include <CLHEP/Random/RandGaussQ.h>
 #include <CLHEP/Units/SystemOfUnits.h>
 #include <CLHEP/Units/GlobalPhysicalConstants.h>
-#include "HepMC/SimpleVector.h"
 
 #include <fstream>
 #include <string>
@@ -80,8 +79,7 @@ BeamProfileVtxGenerator::BeamProfileVtxGenerator(const edm::ParameterSet& p) : B
 
 BeamProfileVtxGenerator::~BeamProfileVtxGenerator() {}
 
-//Hep3Vector * BeamProfileVtxGenerator::newVertex() {
-HepMC::FourVector BeamProfileVtxGenerator::newVertex(CLHEP::HepRandomEngine* engine) const {
+ROOT::Math::XYZTVector BeamProfileVtxGenerator::vertexShift(CLHEP::HepRandomEngine* engine) const {
   double aX, aY;
   if (ffile) {
     double r1 = engine->flat();
@@ -121,10 +119,11 @@ HepMC::FourVector BeamProfileVtxGenerator::newVertex(CLHEP::HepRandomEngine* eng
     /*
      static const double kRadToDeg ( 180./M_PI ) ;
      std::cout<<"theta = "<<std::setw(7) << std::setiosflags( std::ios::fixed ) << std::setprecision(5)
-	      <<fTheta*kRadToDeg<<", phi="<<std::setw(7) << std::setiosflags( std::ios::fixed ) << std::setprecision(5)
-	      << fPhi*kRadToDeg <<", PSI="<<std::setw(7) << std::setiosflags( std::ios::fixed ) << std::setprecision(5)
-	      <<fPsi*kRadToDeg<<std::endl ;
-*/
+              <<fTheta*kRadToDeg<<", phi="<<std::setw(7) << std::setiosflags( std::ios::fixed ) << std::setprecision(5)
+              << fPhi*kRadToDeg <<", PSI="<<std::setw(7) << std::setiosflags( std::ios::fixed ) << std::setprecision(5)
+              <<fPsi*kRadToDeg<<std::endl ;
+    */
+
     const HepGeom::RotateZ3D R1(fPhi - M_PI);
     const HepGeom::Point3D<double> xUnit(0, 1, 0);
     const HepGeom::Point3D<double> zUnit(0, 0, 1);
@@ -132,21 +131,21 @@ HepMC::FourVector BeamProfileVtxGenerator::newVertex(CLHEP::HepRandomEngine* eng
     const HepGeom::Transform3D TRF(HepGeom::Rotate3D(fPsi, RXRZ * zUnit) * RXRZ);
     /*
      std::cout<<"\n\n$$$$$$$$$$$Transform="
-	      <<" thetaZ = "<<std::setw(7) << std::setiosflags( std::ios::fixed ) << std::setprecision(5)
-	      <<TRF.getRotation().thetaZ()*kRadToDeg
-	      <<", phiZ = "<<std::setw(7) << std::setiosflags( std::ios::fixed ) << std::setprecision(5)
-	      <<TRF.getRotation().phiZ()*kRadToDeg
-	      <<", thetaY = "<<std::setw(7) << std::setiosflags( std::ios::fixed ) << std::setprecision(5)
-	      <<TRF.getRotation().thetaY()*kRadToDeg
-	      <<", phiY = "<<std::setw(7) << std::setiosflags( std::ios::fixed ) << std::setprecision(5)
-	      <<TRF.getRotation().phiY()*kRadToDeg
-	      <<", thetaX = "<<std::setw(7) << std::setiosflags( std::ios::fixed ) << std::setprecision(5)
-	      <<TRF.getRotation().thetaX()*kRadToDeg
-	      <<", phiX = "<<std::setw(7) << std::setiosflags( std::ios::fixed ) << std::setprecision(5)
-	      <<TRF.getRotation().phiX()*kRadToDeg
-	      <<std::setw(7) << std::setiosflags( std::ios::fixed ) << std::setprecision(5)
-	      <<TRF.getTranslation()<<std::endl ;
-*/
+              <<" thetaZ = "<<std::setw(7) << std::setiosflags( std::ios::fixed ) << std::setprecision(5)
+              <<TRF.getRotation().thetaZ()*kRadToDeg
+              <<", phiZ = "<<std::setw(7) << std::setiosflags( std::ios::fixed ) << std::setprecision(5)
+              <<TRF.getRotation().phiZ()*kRadToDeg
+              <<", thetaY = "<<std::setw(7) << std::setiosflags( std::ios::fixed ) << std::setprecision(5)
+              <<TRF.getRotation().thetaY()*kRadToDeg
+              <<", phiY = "<<std::setw(7) << std::setiosflags( std::ios::fixed ) << std::setprecision(5)
+              <<TRF.getRotation().phiY()*kRadToDeg
+              <<", thetaX = "<<std::setw(7) << std::setiosflags( std::ios::fixed ) << std::setprecision(5)
+              <<TRF.getRotation().thetaX()*kRadToDeg
+              <<", phiX = "<<std::setw(7) << std::setiosflags( std::ios::fixed ) << std::setprecision(5)
+              <<TRF.getRotation().phiX()*kRadToDeg
+              <<std::setw(7) << std::setiosflags( std::ios::fixed ) << std::setprecision(5)
+              <<TRF.getTranslation()<<std::endl ;
+    */
     const HepGeom::Vector3D<double> pv(TRF * av);
 
     xp = pv.x();
@@ -156,7 +155,7 @@ HepMC::FourVector BeamProfileVtxGenerator::newVertex(CLHEP::HepRandomEngine* eng
 
   LogDebug("VertexGenerator") << "BeamProfileVtxGenerator: Vertex created "
                               << "at (" << xp << ", " << yp << ", " << zp << ", " << fTimeOffset << ")";
-  return HepMC::FourVector(xp, yp, zp, fTimeOffset);
+  return ROOT::Math::XYZTVector(xp, yp, zp, fTimeOffset);
   ;
 }
 

--- a/IOMC/EventVertexGenerators/src/BetafuncEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/BetafuncEvtVtxGenerator.cc
@@ -24,7 +24,6 @@ ________________________________________________________________________
 #include <CLHEP/Random/RandGaussQ.h>
 #include <CLHEP/Units/SystemOfUnits.h>
 #include <CLHEP/Units/GlobalPhysicalConstants.h>
-#include "HepMC/SimpleVector.h"
 
 using CLHEP::cm;
 using CLHEP::ns;
@@ -72,7 +71,7 @@ void BetafuncEvtVtxGenerator::update(const edm::EventSetup& iEventSetup) {
   }
 }
 
-HepMC::FourVector BetafuncEvtVtxGenerator::newVertex(CLHEP::HepRandomEngine* engine) const {
+ROOT::Math::XYZTVector BetafuncEvtVtxGenerator::vertexShift(CLHEP::HepRandomEngine* engine) const {
   double X, Y, Z;
 
   double tmp_sigz = CLHEP::RandGaussQ::shoot(engine, 0., fSigmaZ);
@@ -91,7 +90,7 @@ HepMC::FourVector BetafuncEvtVtxGenerator::newVertex(CLHEP::HepRandomEngine* eng
   double tmp_sigt = CLHEP::RandGaussQ::shoot(engine, 0., fSigmaZ);
   double T = tmp_sigt + fTimeOffset;
 
-  return HepMC::FourVector(X, Y, Z, T);
+  return ROOT::Math::XYZTVector(X, Y, Z, T);
 }
 
 double BetafuncEvtVtxGenerator::BetaFunction(double z, double z0) const {

--- a/IOMC/EventVertexGenerators/src/FlatEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/FlatEvtVtxGenerator.cc
@@ -9,8 +9,6 @@
 #include <CLHEP/Random/RandFlat.h>
 #include <CLHEP/Units/SystemOfUnits.h>
 #include <CLHEP/Units/GlobalPhysicalConstants.h>
-//#include "CLHEP/Vector/ThreeVector.h"
-#include "HepMC/SimpleVector.h"
 
 using CLHEP::cm;
 using CLHEP::ns;
@@ -48,8 +46,7 @@ FlatEvtVtxGenerator::FlatEvtVtxGenerator(const edm::ParameterSet& p) : BaseEvtVt
 
 FlatEvtVtxGenerator::~FlatEvtVtxGenerator() {}
 
-//Hep3Vector * FlatEvtVtxGenerator::newVertex() {
-HepMC::FourVector FlatEvtVtxGenerator::newVertex(CLHEP::HepRandomEngine* engine) const {
+ROOT::Math::XYZTVector FlatEvtVtxGenerator::vertexShift(CLHEP::HepRandomEngine* engine) const {
   double aX, aY, aZ, aT;
   aX = CLHEP::RandFlat::shoot(engine, fMinX, fMaxX);
   aY = CLHEP::RandFlat::shoot(engine, fMinY, fMaxY);
@@ -59,7 +56,7 @@ HepMC::FourVector FlatEvtVtxGenerator::newVertex(CLHEP::HepRandomEngine* engine)
   edm::LogVerbatim("FlatEvtVtx") << "FlatEvtVtxGenerator Vertex at [" << aX << ", " << aY << ", " << aZ << ", " << aT
                                  << "]";
 
-  return HepMC::FourVector(aX, aY, aZ, aT);
+  return ROOT::Math::XYZTVector(aX, aY, aZ, aT);
 }
 
 void FlatEvtVtxGenerator::minX(double min) { fMinX = min; }

--- a/IOMC/EventVertexGenerators/src/GaussEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/GaussEvtVtxGenerator.cc
@@ -5,7 +5,6 @@
 #include <CLHEP/Random/RandGaussQ.h>
 #include <CLHEP/Units/SystemOfUnits.h>
 #include <CLHEP/Units/GlobalPhysicalConstants.h>
-#include "HepMC/SimpleVector.h"
 
 using CLHEP::cm;
 using CLHEP::ns;
@@ -58,14 +57,14 @@ void GaussEvtVtxGenerator::update(const edm::EventSetup& iEventSetup) {
   }
 }
 
-HepMC::FourVector GaussEvtVtxGenerator::newVertex(CLHEP::HepRandomEngine* engine) const {
+ROOT::Math::XYZTVector GaussEvtVtxGenerator::vertexShift(CLHEP::HepRandomEngine* engine) const {
   double X, Y, Z, T;
   X = CLHEP::RandGaussQ::shoot(engine, fMeanX, fSigmaX);
   Y = CLHEP::RandGaussQ::shoot(engine, fMeanY, fSigmaY);
   Z = CLHEP::RandGaussQ::shoot(engine, fMeanZ, fSigmaZ);
   T = CLHEP::RandGaussQ::shoot(engine, fTimeOffset, fSigmaZ);
 
-  return HepMC::FourVector(X, Y, Z, T);
+  return ROOT::Math::XYZTVector(X, Y, Z, T);
 }
 
 void GaussEvtVtxGenerator::sigmaX(double s) {

--- a/IOMC/EventVertexGenerators/src/HLLHCEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/HLLHCEvtVtxGenerator.cc
@@ -11,7 +11,6 @@
 #include <CLHEP/Random/RandFlat.h>
 #include <CLHEP/Units/SystemOfUnits.h>
 #include <CLHEP/Units/GlobalPhysicalConstants.h>
-#include "HepMC/SimpleVector.h"
 
 using namespace std;
 
@@ -119,7 +118,7 @@ void HLLHCEvtVtxGenerator::update(const edm::EventSetup& iEventSetup) {
   }
 }
 
-HepMC::FourVector HLLHCEvtVtxGenerator::newVertex(CLHEP::HepRandomEngine* engine) const {
+ROOT::Math::XYZTVector HLLHCEvtVtxGenerator::vertexShift(CLHEP::HepRandomEngine* engine) const {
   double imax = intensity(0., 0., 0., 0.);
 
   double x(0.), y(0.), z(0.), t(0.), i(0.);
@@ -155,7 +154,7 @@ HepMC::FourVector HLLHCEvtVtxGenerator::newVertex(CLHEP::HepRandomEngine* engine
   z += fMeanZ;
   t += fTimeOffset_c_light;
 
-  return HepMC::FourVector(x, y, z, t);
+  return ROOT::Math::XYZTVector(x, y, z, t);
 }
 
 double HLLHCEvtVtxGenerator::sigma(double z, double epsilon, double beta, double betagamma) const {

--- a/IOMC/EventVertexGenerators/src/PassThroughEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/PassThroughEvtVtxGenerator.cc
@@ -4,58 +4,20 @@
 
 #include "IOMC/EventVertexGenerators/interface/PassThroughEvtVtxGenerator.h"
 
-#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
-#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
-
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include "DataFormats/Provenance/interface/Provenance.h"
-#include "FWCore/Utilities/interface/EDMException.h"
-
-//#include "HepMC/GenEvent.h"
-// #include "CLHEP/Vector/ThreeVector.h"
-// #include "HepMC/SimpleVector.h"
-
 using namespace edm;
-using namespace CLHEP;
-//using namespace HepMC;
 
 PassThroughEvtVtxGenerator::PassThroughEvtVtxGenerator(const ParameterSet& pset) : BaseEvtVtxGenerator(pset) {
   Service<RandomNumberGenerator> rng;
-  if (!rng.isAvailable()) {
-    throw cms::Exception("Configuration")
-        << "The PassThroughEvtVtxGenerator requires the RandomNumberGeneratorService\n"
-           "which is not present in the configuration file. \n"
-           "You must add the service\n"
-           "in the configuration file or remove the modules that require it.";
-  }
-  sourceToken = consumes<edm::HepMCProduct>(pset.getParameter<edm::InputTag>("src"));
 }
 
 PassThroughEvtVtxGenerator::~PassThroughEvtVtxGenerator() {}
 
-HepMC::FourVector PassThroughEvtVtxGenerator::newVertex(CLHEP::HepRandomEngine*) const {
-  return HepMC::FourVector(0., 0., 0., 0);
-}
-
-void PassThroughEvtVtxGenerator::produce(Event& evt, const EventSetup&) {
-  edm::Service<edm::RandomNumberGenerator> rng;
-
-  Handle<HepMCProduct> HepUnsmearedMCEvt;
-
-  evt.getByToken(sourceToken, HepUnsmearedMCEvt);
-
-  // Copy the HepMC::GenEvent
-  HepMC::GenEvent* genevt = new HepMC::GenEvent(*HepUnsmearedMCEvt->GetEvent());
-  std::unique_ptr<edm::HepMCProduct> HepMCEvt(new edm::HepMCProduct(genevt));
-
-  evt.put(std::move(HepMCEvt));
-
-  return;
+ROOT::Math::XYZTVector PassThroughEvtVtxGenerator::vertexShift(CLHEP::HepRandomEngine*) const {
+  return ROOT::Math::XYZTVector(0., 0., 0., 0.);
 }


### PR DESCRIPTION
Vtx generators are changed so that smearing of HepMC3Product is possible as well as HepMCProduct. It is done by default if only the first one is available. The type of returned value of vertex shift is changed to ROOT XYZTVector instead of HepMC::FourVector. This way it will be easy to get rid of HepMC in future. The function name is changed from newVertex to vertexShift, the code inside it is exactly the same. 

Some cleanup of design and code is also performed.

The code of one generator "BeamDivergenceVtxGenerator" is not changed for the moment. To be checked that it is still needed.

The code is validated by checking the coordinates of primary vertex in the interface to G4.