### PR TITLE
fix replacing of split pixel clusters in DQM online clients after #46694

### DIFF
--- a/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
@@ -222,7 +222,8 @@ if (process.runType.getRunType() == process.runType.pp_run or process.runType.ge
     process.InitialStepPreSplittingTask.remove(process.siPixelClusterShapeCache)
 
     # Redefinition of siPixelClusters: has to be after RecoTracker.IterativeTracking.InitialStepPreSplitting_cff 
-    process.load("RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizer_cfi")
+    from RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizer_cfi import siPixelClusters as _siPixelClusters
+    process.siPixelClusters = _siPixelClusters.clone()
 
     from RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi import *
     process.PixelLayerTriplets.BPix.HitProducer = cms.string('siPixelRecHitsPreSplitting')

--- a/DQM/Integration/python/clients/sistrip_approx_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/sistrip_approx_dqm_sourceclient-live_cfg.py
@@ -215,7 +215,8 @@ if process.runType.getRunType() == process.runType.hi_run:
     process.InitialStepPreSplittingTask.remove(process.MeasurementTrackerEvent)
 
     # Redefinition of siPixelClusters: has to be after RecoTracker.IterativeTracking.InitialStepPreSplitting_cff
-    process.load("RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizer_cfi")
+    from RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizer_cfi import siPixelClusters as _siPixelClusters
+    process.siPixelClusters = _siPixelClusters.clone()
 
     # Select events based on the pixel cluster multiplicity
     import  HLTrigger.special.hltPixelActivityFilter_cfi

--- a/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
@@ -388,7 +388,8 @@ if (process.runType.getRunType() == process.runType.pp_run or process.runType.ge
     process.InitialStepPreSplittingTask.remove(process.MeasurementTrackerEvent)
 
     # Redefinition of siPixelClusters: has to be after RecoTracker.IterativeTracking.InitialStepPreSplitting_cff
-    process.load("RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizer_cfi")
+    from RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizer_cfi import siPixelClusters as _siPixelClusters
+    process.siPixelClusters = _siPixelClusters.clone()
 
     from RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi import *
     process.PixelLayerTriplets.BPix.HitProducer = cms.string('siPixelRecHitsPreSplitting')
@@ -623,7 +624,8 @@ if process.runType.getRunType() == process.runType.hi_run:
     process.InitialStepPreSplittingTask.remove(process.MeasurementTrackerEvent)
 
     # Redefinition of siPixelClusters: has to be after RecoTracker.IterativeTracking.InitialStepPreSplitting_cff
-    process.load("RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizer_cfi")
+    from RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizer_cfi import siPixelClusters as _siPixelClusters
+    process.siPixelClusters = _siPixelClusters.clone()
 
     # Select events based on the pixel cluster multiplicity
     import  HLTrigger.special.hltPixelActivityFilter_cfi


### PR DESCRIPTION
#### PR description:

After https://github.com/cms-sw/cmssw/pull/46694 was integrated, several DQM online client started to fail (see e.g. [here](https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/el8_amd64_gcc12/www/fri/15.0-fri-23/CMSSW_15_0_X_2024-12-06-2300?utests)) with exceptions of the type:

```console
----- Begin Fatal Exception 07-Dec-2024 03:14:55 CET-----------------------
An exception of category 'ConfigFileReadError' occurred while
   [0] Processing the python configuration file named /data/cmsbld/jenkins/workspace/ib-run-qa/CMSSW_15_0_X_2024-12-06-2300/src/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
Exception Message:
 unknown python problem occurred.
ValueError: Trying to override definition of siPixelClusters while it is used by the task InitialStepPreSplittingFromHLTTask
 new object defined in: /cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02866/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-06-2300/src/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
 existing object defined in: /cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02866/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-06-2300/src/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py

At:
  /cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02866/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-06-2300/src/FWCore/ParameterSet/python/Config.py(494): __setattr__
  /cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02866/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-06-2300/src/FWCore/ParameterSet/python/Config.py(784): extend
  /cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02866/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-06-2300/src/FWCore/ParameterSet/python/Config.py(761): load
  /data/cmsbld/jenkins/workspace/ib-run-qa/CMSSW_15_0_X_2024-12-06-2300/src/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py(225): <module>

----- End Fatal Exception -------------------------------------------------
```

#### PR validation:

Run successfully the whole battery of unit tests of the `DQM/Integration` package

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A