### PR TITLE
SeedToTrackProducer: return early if L2 seed collection is not found

### DIFF
--- a/SimMuon/MCTruth/plugins/SeedToTrackProducerBase.cc
+++ b/SimMuon/MCTruth/plugins/SeedToTrackProducerBase.cc
@@ -65,8 +65,10 @@ void SeedToTrackProducerBase<SeedCollection>::produce(edm::StreamID,
   const std::vector<SeedType> *L2seeds = nullptr;
   if (L2seedsCollection.isValid())
     L2seeds = L2seedsCollection.product();
-  else
+  else {
     edm::LogError("SeedToTrackProducerBase") << "L2 seeds collection not found !! " << endl;
+    return;
+  }
 
   edm::Handle<edm::View<TrajectorySeed>> seedHandle;
   iEvent.getByToken(L2seedsTagS_, seedHandle);


### PR DESCRIPTION
#### PR description:

This should fix RelVal 24034.0: [log](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc12/CMSSW_15_0_X_2024-12-08-0000/pyRelValMatrixLogs/run/24034.0_TTbar_14TeV+Run4D96/step3_TTbar_14TeV+Run4D96.log#/126-126)

```
%MSG-e SeedToTrackProducerBase:   Phase2SeedToTrackProducer:hltPhase2L2MuonSeedTracks 08-Dec-2024 06:03:03 CET  Run: 1 Event: 2
L2 seeds collection not found !! 
%MSG


A fatal system signal has occurred: segmentation violation
The following is the call stack containing the origin of the signal.

Sun Dec  8 06:03:03 CET 2024
Thread 8 (Thread 0x14a7e6fff700 (LWP 2778991) "cmsRun"):
#0  0x000014a8873ee47c in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
#1  0x000014a84bef57ee in Eigen::ThreadPoolTempl<tsl::thread::EigenEnvironment>::WaitForWork(Eigen::EventCount::Waiter*, tsl::thread::EigenEnvironment::Task*) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/external/el8_amd64_gcc12/lib/libtensorflow_cc.so.2
#2  0x000014a84bef5da3 in Eigen::ThreadPoolTempl<tsl::thread::EigenEnvironment>::WorkerLoop(int) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/external/el8_amd64_gcc12/lib/libtensorflow_cc.so.2
#3  0x000014a84bef3518 in std::_Function_handler<void (), tsl::thread::EigenEnvironment::CreateThread(std::function<void ()>)::{lambda()#1}>::_M_invoke(std::_Any_data const&) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/external/el8_amd64_gcc12/lib/libtensorflow_cc.so.2
#4  0x000014a83b283e62 in tsl::(anonymous namespace)::PThread::ThreadFn(void*) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/external/el8_amd64_gcc12/lib/libtensorflow_framework.so.2
#5  0x000014a8873e81ca in start_thread () from /lib64/libpthread.so.0
#6  0x000014a887a638d3 in clone () from /lib64/libc.so.6
Thread 7 (Thread 0x14a7e7957700 (LWP 2778990) "cmsRun"):
#0  0x000014a8873ee47c in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
#1  0x000014a84bef57ee in Eigen::ThreadPoolTempl<tsl::thread::EigenEnvironment>::WaitForWork(Eigen::EventCount::Waiter*, tsl::thread::EigenEnvironment::Task*) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/external/el8_amd64_gcc12/lib/libtensorflow_cc.so.2
#2  0x000014a84bef5da3 in Eigen::ThreadPoolTempl<tsl::thread::EigenEnvironment>::WorkerLoop(int) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/external/el8_amd64_gcc12/lib/libtensorflow_cc.so.2
#3  0x000014a84bef3518 in std::_Function_handler<void (), tsl::thread::EigenEnvironment::CreateThread(std::function<void ()>)::{lambda()#1}>::_M_invoke(std::_Any_data const&) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/external/el8_amd64_gcc12/lib/libtensorflow_cc.so.2
#4  0x000014a83b283e62 in tsl::(anonymous namespace)::PThread::ThreadFn(void*) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/external/el8_amd64_gcc12/lib/libtensorflow_framework.so.2
#5  0x000014a8873e81ca in start_thread () from /lib64/libpthread.so.0
#6  0x000014a887a638d3 in clone () from /lib64/libc.so.6
Thread 6 (Thread 0x14a7e7f57700 (LWP 2778989) "cmsRun"):
#0  0x000014a8873ee47c in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
#1  0x000014a84bef57ee in Eigen::ThreadPoolTempl<tsl::thread::EigenEnvironment>::WaitForWork(Eigen::EventCount::Waiter*, tsl::thread::EigenEnvironment::Task*) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/external/el8_amd64_gcc12/lib/libtensorflow_cc.so.2
#2  0x000014a84bef5da3 in Eigen::ThreadPoolTempl<tsl::thread::EigenEnvironment>::WorkerLoop(int) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/external/el8_amd64_gcc12/lib/libtensorflow_cc.so.2
#3  0x000014a84bef3518 in std::_Function_handler<void (), tsl::thread::EigenEnvironment::CreateThread(std::function<void ()>)::{lambda()#1}>::_M_invoke(std::_Any_data const&) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/external/el8_amd64_gcc12/lib/libtensorflow_cc.so.2
#4  0x000014a83b283e62 in tsl::(anonymous namespace)::PThread::ThreadFn(void*) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/external/el8_amd64_gcc12/lib/libtensorflow_framework.so.2
#5  0x000014a8873e81ca in start_thread () from /lib64/libpthread.so.0
#6  0x000014a887a638d3 in clone () from /lib64/libc.so.6
Thread 5 (Thread 0x14a830b6b700 (LWP 2778816) "cmsRun"):
#0  0x000014a887b32098 in nanosleep () from /lib64/libc.so.6
#1  0x000014a887b31f9e in sleep () from /lib64/libc.so.6
#2  0x000014a8834fe360 in sig_pause_for_stacktrace () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/pluginFWCoreServicesPlugins.so
#3  <signal handler called>
#4  0x000014a8873f184d in __lll_lock_wait () from /lib64/libpthread.so.0
#5  0x000014a8873eab94 in pthread_mutex_lock () from /lib64/libpthread.so.0
#6  0x000014a888dda6b7 in edm::DelayedReaderInputProductResolver::resolveProduct_(edm::Principal const&, bool, edm::SharedResourcesAcquirer*, edm::ModuleCallingContext const*) const::{lambda()#1}::operator()() const () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/libFWCoreFramework.so
#7  0x000014a888dda7bc in edm::DelayedReaderInputProductResolver::resolveProduct_(edm::Principal const&, bool, edm::SharedResourcesAcquirer*, edm::ModuleCallingContext const*) const () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/libFWCoreFramework.so
#8  0x000014a888ddeab2 in edm::NoProcessProductResolver::resolveProduct_(edm::Principal const&, bool, edm::SharedResourcesAcquirer*, edm::ModuleCallingContext const*) const () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/libFWCoreFramework.so
#9  0x000014a888dd0dce in edm::Principal::findProductByLabel(edm::KindOfType, edm::TypeID const&, edm::InputTag const&, edm::EDConsumerBase const*, edm::SharedResourcesAcquirer*, edm::ModuleCallingContext const*) const () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/libFWCoreFramework.so
#10 0x000014a888dd1122 in edm::Principal::getByLabel(edm::KindOfType, edm::TypeID const&, edm::InputTag const&, edm::EDConsumerBase const*, edm::SharedResourcesAcquirer*, edm::ModuleCallingContext const*) const () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/libFWCoreFramework.so
#11 0x000014a888dd1280 in edm::PrincipalGetAdapter::getByLabel_(edm::TypeID const&, edm::InputTag const&, edm::ModuleCallingContext const*) const () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/libFWCoreFramework.so
#12 0x000014a883893f15 in edm::service::RandomNumberGeneratorService::readFromEvent(edm::Event const&) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/pluginIOMCRandomEnginePlugins.so
#13 0x000014a88388da0b in edm::service::RandomNumberGeneratorService::postEventRead(edm::Event const&) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/pluginIOMCRandomEnginePlugins.so
#14 0x000014a888d5737f in edm::EventProcessor::processEventAsyncImpl(edm::WaitingTaskHolder, unsigned int) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/libFWCoreFramework.so
#15 0x000014a888d76baa in tbb::detail::d1::function_task<edm::EventProcessor::processEventAsync(edm::WaitingTaskHolder, unsigned int)::{lambda()#1}>::execute(tbb::detail::d1::execution_data&) [clone .lto_priv.0] () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/libFWCoreFramework.so
#16 0x000014a8890b2b3b in tbb::detail::r1::task_dispatcher::local_wait_for_all<false, tbb::detail::r1::outermost_worker_waiter> (t=0x14a7a795ec00, waiter=..., this=0x14a885dc9500) at /data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/BUILD/el8_amd64_gcc12/external/tbb/v2021.9.0-e785b749a0b6cb9c66dc1d78066210e0/tbb-v2021.9.0/src/tbb/task_dispatcher.h:322
#17 tbb::detail::r1::task_dispatcher::local_wait_for_all<tbb::detail::r1::outermost_worker_waiter> (t=0x0, waiter=..., this=0x14a885dc9500) at /data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/BUILD/el8_amd64_gcc12/external/tbb/v2021.9.0-e785b749a0b6cb9c66dc1d78066210e0/tbb-v2021.9.0/src/tbb/task_dispatcher.h:458
#18 tbb::detail::r1::arena::process (tls=..., this=<optimized out>) at /data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/BUILD/el8_amd64_gcc12/external/tbb/v2021.9.0-e785b749a0b6cb9c66dc1d78066210e0/tbb-v2021.9.0/src/tbb/arena.cpp:137
#19 tbb::detail::r1::market::process (this=<optimized out>, j=...) at /data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/BUILD/el8_amd64_gcc12/external/tbb/v2021.9.0-e785b749a0b6cb9c66dc1d78066210e0/tbb-v2021.9.0/src/tbb/market.cpp:599
#20 0x000014a8890b4cee in tbb::detail::r1::rml::private_worker::run (this=0x14a883db4000) at /data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/BUILD/el8_amd64_gcc12/external/tbb/v2021.9.0-e785b749a0b6cb9c66dc1d78066210e0/tbb-v2021.9.0/src/tbb/private_server.cpp:271
#21 tbb::detail::r1::rml::private_worker::thread_routine (arg=0x14a883db4000) at /data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/BUILD/el8_amd64_gcc12/external/tbb/v2021.9.0-e785b749a0b6cb9c66dc1d78066210e0/tbb-v2021.9.0/src/tbb/private_server.cpp:221
#22 0x000014a8873e81ca in start_thread () from /lib64/libpthread.so.0
#23 0x000014a887a638d3 in clone () from /lib64/libc.so.6
Thread 4 (Thread 0x14a831c57700 (LWP 2778815) "cmsRun"):
#0  0x000014a887b32098 in nanosleep () from /lib64/libc.so.6
#1  0x000014a887b31f9e in sleep () from /lib64/libc.so.6
#2  0x000014a8834fe360 in sig_pause_for_stacktrace () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/pluginFWCoreServicesPlugins.so
#3  <signal handler called>
#4  0x000014a859b0c010 in HcalDDDRecConstants::layerGroupSize(int) const () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/libGeometryHcalCommonData.so
#5  0x000014a859b091c3 in HcalDDDRecConstants::getMinDepth(int const&, int const&, int const&, int const&) const () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/libGeometryHcalCommonData.so
#6  0x000014a85e5ed93a in HcalTopology::validRaw(HcalDetId const&, bool) const () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/libGeometryCaloTopology.so
#7  0x000014a85e5edad3 in HcalTopology::validHcal(HcalDetId const&) const () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/libGeometryCaloTopology.so
#8  0x000014a85e5f05ab in HcalTopology::valid(DetId const&) const () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/libGeometryCaloTopology.so
#9  0x000014a87bf489fc in CaloTPGTranscoderULUT::setup(HcalLutMetadata const&, HcalTrigTowerGeometry const&, int, int, double, double, bool) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/libCalibCalorimetryCaloTPG.so
#10 0x000014a8599c8bff in CaloTPGTranscoderULUTs::produce(CaloTPGRecord const&) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/pluginCalibCalorimetryCaloTPGPlugins.so
#11 0x000014a8599c54a9 in void edm::SerialTaskQueueChain::actionToRun<edm::eventsetup::CallbackBase<edm::ESProducer, edm::ESProducer::setWhatProduced<CaloTPGTranscoderULUTs, std::unique_ptr<CaloTPGTranscoder, std::default_delete<CaloTPGTranscoder> >, CaloTPGRecord, edm::eventsetup::CallbackSimpleDecorator<CaloTPGRecord> >(CaloTPGTranscoderULUTs*, std::unique_ptr<CaloTPGTranscoder, std::default_delete<CaloTPGTranscoder> > (CaloTPGTranscoderULUTs::*)(CaloTPGRecord const&), edm::eventsetup::CallbackSimpleDecorator<CaloTPGRecord> const&, edm::es::Label const&)::{lambda(CaloTPGRecord const&)#1}, std::unique_ptr<CaloTPGTranscoder, std::default_delete<CaloTPGTranscoder> >, CaloTPGRecord, edm::eventsetup::CallbackSimpleDecorator<CaloTPGRecord> >::makeProduceTask<edm::eventsetup::Callback<edm::ESProducer, edm::ESProducer::setWhatProduced<CaloTPGTranscoderULUTs, std::unique_ptr<CaloTPGTranscoder, std::default_delete<CaloTPGTranscoder> >, CaloTPGRecord, edm::eventsetup::CallbackSimpleDecorator<CaloTPGRecord> >(CaloTPGTranscoderULUTs*, std::unique_ptr<CaloTPGTranscoder, std::default_delete<CaloTPGTranscoder> > (CaloTPGTranscoderULUTs::*)(CaloTPGRecord const&), edm::eventsetup::CallbackSimpleDecorator<CaloTPGRecord> const&, edm::es::Label const&)::{lambda(CaloTPGRecord const&)#1}, std::unique_ptr<CaloTPGTranscoder, std::default_delete<CaloTPGTranscoder> >, CaloTPGRecord, edm::eventsetup::CallbackSimpleDecorator<CaloTPGRecord> >::prefetchAsync(edm::WaitingTaskHolder, edm::eventsetup::EventSetupRecordImpl const*, edm::EventSetupImpl const*, edm::ServiceToken const&, edm::ESParentContext const&)::{lambda(auto:1&&, auto:2&&, auto:3&&, auto:4&&)#1}::operator()<tbb::detail::d1::task_group*&, edm::ServiceWeakToken&, edm::eventsetup::EventSetupRecordImpl const*&, edm::EventSetupImpl const*&>(tbb::detail::d1::task_group*&, edm::ServiceWeakToken&, edm::eventsetup::EventSetupRecordImpl const*&, edm::EventSetupImpl const*&) const::{lambda(CaloTPGRecord const&)#1}>(tbb::detail::d1::task_group*, edm::ServiceWeakToken const&, edm::eventsetup::EventSetupRecordImpl const*, edm::EventSetupImpl const*, bool, tbb::detail::d1::task_group*&)::{lambda(std::__exception_ptr::exception_ptr const*)#1}::operator()(std::__exception_ptr::exception_ptr const*) const::{lambda()#2}&>(tbb::detail::d1::task_group*&) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/pluginCalibCalorimetryCaloTPGPlugins.so
#12 0x000014a8599c5801 in edm::SerialTaskQueue::QueuedTask<edm::SerialTaskQueueChain::push<edm::eventsetup::CallbackBase<edm::ESProducer, edm::ESProducer::setWhatProduced<CaloTPGTranscoderULUTs, std::unique_ptr<CaloTPGTranscoder, std::default_delete<CaloTPGTranscoder> >, CaloTPGRecord, edm::eventsetup::CallbackSimpleDecorator<CaloTPGRecord> >(CaloTPGTranscoderULUTs*, std::unique_ptr<CaloTPGTranscoder, std::default_delete<CaloTPGTranscoder> > (CaloTPGTranscoderULUTs::*)(CaloTPGRecord const&), edm::eventsetup::CallbackSimpleDecorator<CaloTPGRecord> const&, edm::es::Label const&)::{lambda(CaloTPGRecord const&)#1}, std::unique_ptr<CaloTPGTranscoder, std::default_delete<CaloTPGTranscoder> >, CaloTPGRecord, edm::eventsetup::CallbackSimpleDecorator<CaloTPGRecord> >::makeProduceTask<edm::eventsetup::Callback<edm::ESProducer, edm::ESProducer::setWhatProduced<CaloTPGTranscoderULUTs, std::unique_ptr<CaloTPGTranscoder, std::default_delete<CaloTPGTranscoder> >, CaloTPGRecord, edm::eventsetup::CallbackSimpleDecorator<CaloTPGRecord> >(CaloTPGTranscoderULUTs*, std::unique_ptr<CaloTPGTranscoder, std::default_delete<CaloTPGTranscoder> > (CaloTPGTranscoderULUTs::*)(CaloTPGRecord const&), edm::eventsetup::CallbackSimpleDecorator<CaloTPGRecord> const&, edm::es::Label const&)::{lambda(CaloTPGRecord const&)#1}, std::unique_ptr<CaloTPGTranscoder, std::default_delete<CaloTPGTranscoder> >, CaloTPGRecord, edm::eventsetup::CallbackSimpleDecorator<CaloTPGRecord> >::prefetchAsync(edm::WaitingTaskHolder, edm::eventsetup::EventSetupRecordImpl const*, edm::EventSetupImpl const*, edm::ServiceToken const&, edm::ESParentContext const&)::{lambda(auto:1&&, auto:2&&, auto:3&&, auto:4&&)#1}::operator()<tbb::detail::d1::task_group*&, edm::ServiceWeakToken&, edm::eventsetup::EventSetupRecordImpl const*&, edm::EventSetupImpl const*&>(tbb::detail::d1::task_group*&, edm::ServiceWeakToken&, edm::eventsetup::EventSetupRecordImpl const*&, edm::EventSetupImpl const*&) const::{lambda(CaloTPGRecord const&)#1}>(tbb::detail::d1::task_group*, edm::ServiceWeakToken const&, edm::eventsetup::EventSetupRecordImpl const*, edm::EventSetupImpl const*, bool, tbb::detail::d1::task_group*&)::{lambda(std::__exception_ptr::exception_ptr const*)#1}::operator()(std::__exception_ptr::exception_ptr const*) const::{lambda()#2}>(tbb::detail::d1::task_group&, tbb::detail::d1::task_group*&)::{lambda()#1}>::execute() () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/pluginCalibCalorimetryCaloTPGPlugins.so
#13 0x000014a88915db35 in tbb::detail::d1::function_task<edm::SerialTaskQueue::spawn(edm::SerialTaskQueue::TaskBase&)::{lambda()#1}>::execute(tbb::detail::d1::execution_data&) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/libFWCoreConcurrency.so
#14 0x000014a8890b2b3b in tbb::detail::r1::task_dispatcher::local_wait_for_all<false, tbb::detail::r1::outermost_worker_waiter> (t=0x14a760cc7400, waiter=..., this=0x14a885dc9400) at /data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/BUILD/el8_amd64_gcc12/external/tbb/v2021.9.0-e785b749a0b6cb9c66dc1d78066210e0/tbb-v2021.9.0/src/tbb/task_dispatcher.h:322
#15 tbb::detail::r1::task_dispatcher::local_wait_for_all<tbb::detail::r1::outermost_worker_waiter> (t=0x0, waiter=..., this=0x14a885dc9400) at /data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/BUILD/el8_amd64_gcc12/external/tbb/v2021.9.0-e785b749a0b6cb9c66dc1d78066210e0/tbb-v2021.9.0/src/tbb/task_dispatcher.h:458
#16 tbb::detail::r1::arena::process (tls=..., this=<optimized out>) at /data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/BUILD/el8_amd64_gcc12/external/tbb/v2021.9.0-e785b749a0b6cb9c66dc1d78066210e0/tbb-v2021.9.0/src/tbb/arena.cpp:137
#17 tbb::detail::r1::market::process (this=<optimized out>, j=...) at /data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/BUILD/el8_amd64_gcc12/external/tbb/v2021.9.0-e785b749a0b6cb9c66dc1d78066210e0/tbb-v2021.9.0/src/tbb/market.cpp:599
#18 0x000014a8890b4cee in tbb::detail::r1::rml::private_worker::run (this=0x14a883db4100) at /data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/BUILD/el8_amd64_gcc12/external/tbb/v2021.9.0-e785b749a0b6cb9c66dc1d78066210e0/tbb-v2021.9.0/src/tbb/private_server.cpp:271
#19 tbb::detail::r1::rml::private_worker::thread_routine (arg=0x14a883db4100) at /data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/BUILD/el8_amd64_gcc12/external/tbb/v2021.9.0-e785b749a0b6cb9c66dc1d78066210e0/tbb-v2021.9.0/src/tbb/private_server.cpp:221
#20 0x000014a8873e81ca in start_thread () from /lib64/libpthread.so.0
#21 0x000014a887a638d3 in clone () from /lib64/libc.so.6
Thread 3 (Thread 0x14a832658700 (LWP 2778814) "cmsRun"):
#0  0x000014a887b5cac1 in poll () from /lib64/libc.so.6
#1  0x000014a883501507 in edm::service::InitRootHandlers::stacktraceFromThread() () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/pluginFWCoreServicesPlugins.so
#2  0x000014a883501704 in sig_dostack_then_abort () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/pluginFWCoreServicesPlugins.so
#3  <signal handler called>
#4  0x000014a810683a85 in SeedToTrackProducerBase<std::vector<L2MuonTrajectorySeed, std::allocator<L2MuonTrajectorySeed> > >::produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/pluginSimMuonMCTruthPlugins.so
#5  0x000014a888e44635 in edm::global::EDProducerBase::doEvent(edm::EventTransitionInfo const&, edm::ActivityRegistry*, edm::ModuleCallingContext const*) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/libFWCoreFramework.so
#6  0x000014a888e3dcdc in edm::WorkerT<edm::global::EDProducerBase>::implDo(edm::EventTransitionInfo const&, edm::ModuleCallingContext const*) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/libFWCoreFramework.so
#7  0x000014a888dc2df9 in std::__exception_ptr::exception_ptr edm::Worker::runModuleAfterAsyncPrefetch<edm::OccurrenceTraits<edm::EventPrincipal, (edm::BranchActionType)1> >(std::__exception_ptr::exception_ptr, edm::OccurrenceTraits<edm::EventPrincipal, (edm::BranchActionType)1>::TransitionInfoType const&, edm::StreamID, edm::ParentContext const&, edm::OccurrenceTraits<edm::EventPrincipal, (edm::BranchActionType)1>::Context const*) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/libFWCoreFramework.so
#8  0x000014a888dc32f1 in edm::Worker::RunModuleTask<edm::OccurrenceTraits<edm::EventPrincipal, (edm::BranchActionType)1> >::execute() () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/libFWCoreFramework.so
#9  0x000014a888d2d28e in tbb::detail::d1::function_task<edm::WaitingTaskHolder::doneWaiting(std::__exception_ptr::exception_ptr)::{lambda()#1}>::execute(tbb::detail::d1::execution_data&) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/libFWCoreFramework.so
#10 0x000014a8890b2b3b in tbb::detail::r1::task_dispatcher::local_wait_for_all<false, tbb::detail::r1::outermost_worker_waiter> (t=0x14a7a78c9100, waiter=..., this=0x14a885dc9480) at /data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/BUILD/el8_amd64_gcc12/external/tbb/v2021.9.0-e785b749a0b6cb9c66dc1d78066210e0/tbb-v2021.9.0/src/tbb/task_dispatcher.h:322
#11 tbb::detail::r1::task_dispatcher::local_wait_for_all<tbb::detail::r1::outermost_worker_waiter> (t=0x0, waiter=..., this=0x14a885dc9480) at /data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/BUILD/el8_amd64_gcc12/external/tbb/v2021.9.0-e785b749a0b6cb9c66dc1d78066210e0/tbb-v2021.9.0/src/tbb/task_dispatcher.h:458
#12 tbb::detail::r1::arena::process (tls=..., this=<optimized out>) at /data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/BUILD/el8_amd64_gcc12/external/tbb/v2021.9.0-e785b749a0b6cb9c66dc1d78066210e0/tbb-v2021.9.0/src/tbb/arena.cpp:137
#13 tbb::detail::r1::market::process (this=<optimized out>, j=...) at /data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/BUILD/el8_amd64_gcc12/external/tbb/v2021.9.0-e785b749a0b6cb9c66dc1d78066210e0/tbb-v2021.9.0/src/tbb/market.cpp:599
#14 0x000014a8890b4cee in tbb::detail::r1::rml::private_worker::run (this=0x14a883db4080) at /data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/BUILD/el8_amd64_gcc12/external/tbb/v2021.9.0-e785b749a0b6cb9c66dc1d78066210e0/tbb-v2021.9.0/src/tbb/private_server.cpp:271
#15 tbb::detail::r1::rml::private_worker::thread_routine (arg=0x14a883db4080) at /data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/BUILD/el8_amd64_gcc12/external/tbb/v2021.9.0-e785b749a0b6cb9c66dc1d78066210e0/tbb-v2021.9.0/src/tbb/private_server.cpp:221
#16 0x000014a8873e81ca in start_thread () from /lib64/libpthread.so.0
#17 0x000014a887a638d3 in clone () from /lib64/libc.so.6
Thread 2 (Thread 0x14a85cf03700 (LWP 2778805) "cmsRun"):
#0  0x000014a887b31e42 in waitpid () from /lib64/libc.so.6
#1  0x000014a8834fe4b7 in edm::service::cmssw_stacktrace_fork() () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/pluginFWCoreServicesPlugins.so
#2  0x000014a8835012ea in edm::service::InitRootHandlers::stacktraceHelperThread() () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/pluginFWCoreServicesPlugins.so
#3  0x000014a887ed8a73 in std::execute_native_thread_routine (__p=0x14a87a2af5f0) at ../../../../../libstdc++-v3/src/c++11/thread.cc:82
#4  0x000014a8873e81ca in start_thread () from /lib64/libpthread.so.0
#5  0x000014a887a638d3 in clone () from /lib64/libc.so.6
Thread 1 (Thread 0x14a888acc580 (LWP 2778671) "cmsRun"):
#0  0x000014a887b32098 in nanosleep () from /lib64/libc.so.6
#1  0x000014a887b31f9e in sleep () from /lib64/libc.so.6
#2  0x000014a8834fe360 in sig_pause_for_stacktrace () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/pluginFWCoreServicesPlugins.so
#3  <signal handler called>
#4  0x000014a8881d5f38 in ZSTD_decompressSequences_bmi2.constprop.0 () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/external/el8_amd64_gcc12/lib/libzstd.so.1
#5  0x000014a8881ddb6e in ZSTD_decompressBlock_internal () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/external/el8_amd64_gcc12/lib/libzstd.so.1
#6  0x000014a8881d2e17 in ZSTD_decompressMultiFrame () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/external/el8_amd64_gcc12/lib/libzstd.so.1
#7  0x000014a8881d31f0 in ZSTD_decompress_usingDDict () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/external/el8_amd64_gcc12/lib/libzstd.so.1
#8  0x000014a88896c938 in R__unzipZSTD () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/external/el8_amd64_gcc12/lib/libCore.so
#9  0x000014a88896bfec in R__unzip () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/external/el8_amd64_gcc12/lib/libCore.so
#10 0x000014a88338b537 in TBasket::ReadBasketBuffers(long long, int, TFile*) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/external/el8_amd64_gcc12/lib/libTree.so
#11 0x000014a8833964e4 in TBranch::GetBasketImpl(int, TBuffer*) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/external/el8_amd64_gcc12/lib/libTree.so
#12 0x000014a8833981cd in TBranch::GetBasketAndFirst(TBasket*&, long long&, TBuffer*) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/external/el8_amd64_gcc12/lib/libTree.so
#13 0x000014a8833983b7 in TBranch::GetEntry(long long, int) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/external/el8_amd64_gcc12/lib/libTree.so
#14 0x000014a8833ab974 in TBranchElement::GetEntry(long long, int) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/external/el8_amd64_gcc12/lib/libTree.so
#15 0x000014a8833ab92d in TBranchElement::GetEntry(long long, int) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/external/el8_amd64_gcc12/lib/libTree.so
#16 0x000014a830fcea4c in edm::RootTree::getEntry(TBranch*, long long) const () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/pluginIOPoolInput.so
#17 0x000014a830fb1a38 in edm::RootDelayedReader::getProduct_(edm::BranchID const&, edm::EDProductGetter const*) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/pluginIOPoolInput.so
#18 0x000014a888d2d8db in edm::DelayedReader::getProduct(edm::BranchID const&, edm::EDProductGetter const*, edm::ModuleCallingContext const*) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/libFWCoreFramework.so
#19 0x000014a888dda8e2 in edm::DelayedReaderInputProductResolver::prefetchAsync_(edm::WaitingTaskHolder, edm::Principal const&, bool, edm::ServiceToken const&, edm::SharedResourcesAcquirer*, edm::ModuleCallingContext const*) const::{lambda()#1}::operator()() const::{lambda()#1}::operator()() const () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/libFWCoreFramework.so
#20 0x000014a888ddaabc in edm::DelayedReaderInputProductResolver::prefetchAsync_(edm::WaitingTaskHolder, edm::Principal const&, bool, edm::ServiceToken const&, edm::SharedResourcesAcquirer*, edm::ModuleCallingContext const*) const::{lambda()#1}::operator()() const [clone .lto_priv.0] () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/libFWCoreFramework.so
#21 0x000014a888ddcd63 in edm::SerialTaskQueue::QueuedTask<edm::SerialTaskQueueChain::push<edm::DelayedReaderInputProductResolver::prefetchAsync_(edm::WaitingTaskHolder, edm::Principal const&, bool, edm::ServiceToken const&, edm::SharedResourcesAcquirer*, edm::ModuleCallingContext const*) const::{lambda()#1}&>(tbb::detail::d1::task_group&, edm::DelayedReaderInputProductResolver::prefetchAsync_(edm::WaitingTaskHolder, edm::Principal const&, bool, edm::ServiceToken const&, edm::SharedResourcesAcquirer*, edm::ModuleCallingContext const*) const::{lambda()#1}&)::{lambda()#1}>::execute() [clone .lto_priv.0] () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/libFWCoreFramework.so
#22 0x000014a88915db35 in tbb::detail::d1::function_task<edm::SerialTaskQueue::spawn(edm::SerialTaskQueue::TaskBase&)::{lambda()#1}>::execute(tbb::detail::d1::execution_data&) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/libFWCoreConcurrency.so
#23 0x000014a8890bb3e1 in tbb::detail::r1::task_dispatcher::local_wait_for_all<false, tbb::detail::r1::external_waiter> (waiter=..., t=<optimized out>, this=0x14a885dc9380) at /data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/BUILD/el8_amd64_gcc12/external/tbb/v2021.9.0-e785b749a0b6cb9c66dc1d78066210e0/tbb-v2021.9.0/src/tbb/task_dispatcher.h:322
#24 tbb::detail::r1::task_dispatcher::local_wait_for_all<tbb::detail::r1::external_waiter> (waiter=..., t=<optimized out>, this=0x14a885dc9380) at /data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/BUILD/el8_amd64_gcc12/external/tbb/v2021.9.0-e785b749a0b6cb9c66dc1d78066210e0/tbb-v2021.9.0/src/tbb/task_dispatcher.h:458
#25 tbb::detail::r1::task_dispatcher::execute_and_wait (t=<optimized out>, wait_ctx=..., w_ctx=...) at /data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/BUILD/el8_amd64_gcc12/external/tbb/v2021.9.0-e785b749a0b6cb9c66dc1d78066210e0/tbb-v2021.9.0/src/tbb/task_dispatcher.cpp:168
#26 0x000014a888d42d1b in edm::FinalWaitingTask::wait() () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/libFWCoreFramework.so
#27 0x000014a888d507df in edm::EventProcessor::processRuns() () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/libFWCoreFramework.so
#28 0x000014a888d50c91 in edm::EventProcessor::runToCompletion() () from /cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-08-0000/lib/el8_amd64_gcc12/libFWCoreFramework.so
#29 0x000000000040840c in tbb::detail::d1::task_arena_function<main::{lambda()#1}::operator()() const::{lambda()#1}, void>::operator()() const ()
#30 0x000014a8890a79ad in tbb::detail::r1::task_arena_impl::execute (ta=..., d=...) at /data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/BUILD/el8_amd64_gcc12/external/tbb/v2021.9.0-e785b749a0b6cb9c66dc1d78066210e0/tbb-v2021.9.0/src/tbb/arena.cpp:688
#31 0x000000000040a0f2 in main::{lambda()#1}::operator()() const ()
#32 0x0000000000405100 in main ()

Current Modules:

Module: Phase2SeedToTrackProducer:hltPhase2L2MuonSeedTracks (crashed)
Module: none
Module: none
Module: none

A fatal system signal has occurred: segmentation violation
timeout: the monitored command dumped core
````

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

<!-- Please delete the text above after you verified all points of the checklist  -->
