### PR TITLE
[NGT] Implement new seeding module for HLT Standalone Muon seeding and streamline HLT L3 Tracker Muon reconstruction 

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -703,6 +703,12 @@ phase2_muon.toModify(FEVTDEBUGHLTEventContent,
         'keep *_hltPhase2L3MuonsNoID_*_*',
         'keep *_hltPhase2L3Muons_*_*'])
 
+from Configuration.ProcessModifiers.phase2L2AndL3Muons_cff import phase2L2AndL3Muons
+(phase2_muon & phase2L2AndL3Muons).toModify(FEVTDEBUGHLTEventContent, 
+    outputCommands = FEVTDEBUGHLTEventContent.outputCommands + [
+        'keep *_hltPhase2L3MuonFilter_*_*'
+    ])
+
 phase2_hgcal.toModify(FEVTDEBUGHLTEventContent,
     outputCommands = FEVTDEBUGHLTEventContent.outputCommands + TICL_FEVTHLT.outputCommands)
 

--- a/Configuration/ProcessModifiers/python/phase2L2AndL3Muons_cff.py
+++ b/Configuration/ProcessModifiers/python/phase2L2AndL3Muons_cff.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+# this modifier is for enabling Phase 2 L2 Muon seeding from L1Tk Muons 
+# and the simplified L3 Tracker Muon reconstruction (Inside-Out first)
+phase2L2AndL3Muons = cms.Modifier()

--- a/Configuration/ProcessModifiers/python/phase2L3MuonsOIFirst_cff.py
+++ b/Configuration/ProcessModifiers/python/phase2L3MuonsOIFirst_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+# this modifier is for enabling Phase 2 L3 Tracker Muon Outside-In first reconstruction 
+phase2L3MuonsOIFirst = cms.Modifier()

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -814,6 +814,70 @@ upgradeWFs['ticl_v5_superclustering_mustache_pf'] = UpgradeWorkflow_ticl_v5_supe
 upgradeWFs['ticl_v5_superclustering_mustache_pf'].step3 = {'--procModifiers': 'ticl_v5,ticl_superclustering_mustache_pf'}
 upgradeWFs['ticl_v5_superclustering_mustache_pf'].step4 = {'--procModifiers': 'ticl_v5,ticl_superclustering_mustache_pf'}
 
+# Improved L2 seeding from L1Tk Muons and L3 Tracker Muon Inside-Out reconstruction first (Phase-2 Muon default)
+class UpgradeWorkflow_phase2L2AndL3Muons(UpgradeWorkflow):
+    def setup_(self, step, stepName, stepDict, k, properties):
+        if ('Digi' in step and 'NoHLT' not in step) or ('HLTOnly' in step):
+            stepDict[stepName][k] = merge([self.step2, stepDict[step][k]])
+        if 'RecoGlobal' in step:
+            stepDict[stepName][k] = merge([self.step3, stepDict[step][k]])
+        if 'HARVESTGlobal' in step:
+            stepDict[stepName][k] = merge([self.step4, stepDict[step][k]])
+    def condition(self, fragment, stepList, key, hasHarvest):
+        return (fragment=="ZMM_14" or 'SingleMu' in fragment or 'TTbar_14' in fragment) and 'Run4' in key
+
+upgradeWFs['phase2L2AndL3Muons'] = UpgradeWorkflow_phase2L2AndL3Muons(
+    steps = [
+        'HLTOnly',
+        'DigiTrigger',
+        'RecoGlobal',
+        'HARVESTGlobal'
+    ],
+    PU = [
+        'HLTOnly',
+        'DigiTrigger',
+        'RecoGlobal',
+        'HARVESTGlobal'
+    ],
+    suffix = '_phase2L2AndL3MuonsIOFirst',
+    offset = 0.777,
+)
+upgradeWFs['phase2L2AndL3Muons'].step2 = {'--procModifiers':'phase2L2AndL3Muons'}
+upgradeWFs['phase2L2AndL3Muons'].step3 = {'--procModifiers':'phase2L2AndL3Muons'}
+upgradeWFs['phase2L2AndL3Muons'].step4 = {'--procModifiers':'phase2L2AndL3Muons'}
+
+# Improved L2 seeding from L1Tk Muons and L3 Tracker Muon Outside-In reconstruction first
+class UpgradeWorkflow_phase2L3MuonsOIFirst(UpgradeWorkflow):
+    def setup_(self, step, stepName, stepDict, k, properties):
+        if ('Digi' in step and 'NoHLT' not in step) or ('HLTOnly' in step):
+            stepDict[stepName][k] = merge([self.step2, stepDict[step][k]])
+        if 'RecoGlobal' in step:
+            stepDict[stepName][k] = merge([self.step3, stepDict[step][k]])
+        if 'HARVESTGlobal' in step:
+            stepDict[stepName][k] = merge([self.step4, stepDict[step][k]])
+    def condition(self, fragment, stepList, key, hasHarvest):
+        return (fragment=="ZMM_14" or 'SingleMu' in fragment or 'TTbar_14' in fragment) and 'Run4' in key
+
+upgradeWFs['phase2L3MuonsOIFirst'] = UpgradeWorkflow_phase2L3MuonsOIFirst(
+    steps = [
+        'HLTOnly',
+        'DigiTrigger',
+        'RecoGlobal',
+        'HARVESTGlobal'
+    ],
+    PU = [
+        'HLTOnly',
+        'DigiTrigger',
+        'RecoGlobal',
+        'HARVESTGlobal'
+    ],
+    suffix = '_phase2L2AndL3MuonsOIFirst',
+    offset = 0.778,
+)
+upgradeWFs['phase2L3MuonsOIFirst'].step2 = {'--procModifiers':'phase2L2AndL3Muons,phase2L3MuonsOIFirst'}
+upgradeWFs['phase2L3MuonsOIFirst'].step3 = {'--procModifiers':'phase2L2AndL3Muons,phase2L3MuonsOIFirst'}
+upgradeWFs['phase2L3MuonsOIFirst'].step4 = {'--procModifiers':'phase2L2AndL3Muons,phase2L3MuonsOIFirst'}
+
 # Track DNN workflows
 class UpgradeWorkflow_trackdnn(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):

--- a/DataFormats/MuonSeed/interface/L2MuonTrajectorySeed.h
+++ b/DataFormats/MuonSeed/interface/L2MuonTrajectorySeed.h
@@ -10,6 +10,7 @@
 
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeed.h"
 #include "DataFormats/L1Trigger/interface/L1MuonParticleFwd.h"
+#include "DataFormats/L1TMuonPhase2/interface/TrackerMuon.h"
 #include "DataFormats/L1Trigger/interface/Muon.h"
 #include "DataFormats/TrajectorySeed/interface/PropagationDirection.h"
 #include "DataFormats/TrajectoryState/interface/PTrajectoryStateOnDet.h"
@@ -31,6 +32,11 @@ public:
                        PropagationDirection dir,
                        l1t::MuonRef l1Ref);
 
+  L2MuonTrajectorySeed(PTrajectoryStateOnDet const& ptsos,
+                       RecHitContainer const& rh,
+                       PropagationDirection dir,
+                       l1t::TrackerMuonRef l1TkMuRef);
+
   /// Destructor
   ~L2MuonTrajectorySeed() override {}
 
@@ -39,10 +45,11 @@ public:
   /// Get L1 info
   inline l1extra::L1MuonParticleRef l1Particle() const { return theL1Particle; }
   inline l1t::MuonRef l1tParticle() const { return theL1TParticle; }
+  inline l1t::TrackerMuonRef l1TkMu() const { return theL1TkMu; }
 
-protected:
 private:
   l1extra::L1MuonParticleRef theL1Particle;
   l1t::MuonRef theL1TParticle;
+  l1t::TrackerMuonRef theL1TkMu;
 };
 #endif

--- a/DataFormats/MuonSeed/src/L2MuonTrajectorySeed.cc
+++ b/DataFormats/MuonSeed/src/L2MuonTrajectorySeed.cc
@@ -26,3 +26,11 @@ L2MuonTrajectorySeed::L2MuonTrajectorySeed(PTrajectoryStateOnDet const& ptsos,
     : TrajectorySeed(ptsos, rh, dir) {
   theL1TParticle = l1Ref;
 }
+
+L2MuonTrajectorySeed::L2MuonTrajectorySeed(PTrajectoryStateOnDet const& ptsos,
+                                           RecHitContainer const& rh,
+                                           PropagationDirection dir,
+                                           l1t::TrackerMuonRef l1TkMuRef)
+    : TrajectorySeed(ptsos, rh, dir) {
+  theL1TkMu = l1TkMuRef;
+}

--- a/DataFormats/MuonSeed/src/classes_def.xml
+++ b/DataFormats/MuonSeed/src/classes_def.xml
@@ -1,5 +1,6 @@
 <lcgdict>
-      <class name="L2MuonTrajectorySeed"  ClassVersion="12">
+      <class name="L2MuonTrajectorySeed"  ClassVersion="13">
+       <version ClassVersion="13" checksum="2121764882"/>
        <version ClassVersion="12" checksum="2773784798"/>
        <version ClassVersion="11" checksum="541533207"/>
        <version ClassVersion="10" checksum="2502730614"/>

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltIter2Phase2L3FromL1TkMuonPixelSeedsFiltered_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltIter2Phase2L3FromL1TkMuonPixelSeedsFiltered_cfi.py
@@ -33,3 +33,10 @@ hltIter2Phase2L3FromL1TkMuonPixelSeedsFiltered = cms.EDProducer("MuonHLTSeedMVAC
     nSeedsMax_E = cms.int32(20),
     src = cms.InputTag("hltIter2Phase2L3FromL1TkMuonPixelSeeds")
 )
+
+from Configuration.ProcessModifiers.phase2L2AndL3Muons_cff import phase2L2AndL3Muons
+from Configuration.ProcessModifiers.phase2L3MuonsOIFirst_cff import phase2L3MuonsOIFirst
+(phase2L2AndL3Muons & phase2L3MuonsOIFirst).toModify(
+    hltIter2Phase2L3FromL1TkMuonPixelSeedsFiltered, 
+    L1TkMu = "hltPhase2L3MuonFilter:L1TkMuToReuse"
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltL2MuonSeedsFromL1TkMuon_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltL2MuonSeedsFromL1TkMuon_cfi.py
@@ -22,24 +22,28 @@ hltL2MuonSeedsFromL1TkMuon = cms.EDProducer("L2MuonSeedGeneratorFromL1TkMu",
 )
 
 phase2HltL2MuonSeedsFromL1TkMuon = cms.EDProducer('Phase2L2MuonSeedCreator',
-    InputObjects = cms.InputTag('l1tTkMuonsGmt'),
-    CSCRecSegmentLabel = cms.InputTag('hltCscSegments'),
-    DTRecSegmentLabel = cms.InputTag('hltDt4DSegments'),
-    MinPL1Tk = cms.double(3.5),
-    MaxPL1Tk = cms.double(200),
+    inputObjects = cms.InputTag('l1tTkMuonsGmt'),
+    cscRecSegmentLabel = cms.InputTag('hltCscSegments'),
+    dtRecSegmentLabel = cms.InputTag('hltDt4DSegments'),
+    minPL1Tk = cms.double(3.5),
+    maxPL1Tk = cms.double(200),
     stubMatchDPhi = cms.double(0.05),
     stubMatchDTheta = cms.double(0.1),
     extrapolationWindowClose = cms.double(0.2),
     extrapolationWindowFar = cms.double(0.1),
     maximumEtaBarrel = cms.double(0.7),
     maximumEtaOverlap = cms.double(1.3),
-    Propagator = cms.string('SteppingHelixPropagatorAny'),
-    ServiceParameters = cms.PSet(
+    propagator = cms.string('SteppingHelixPropagatorAny'),
+    serviceParameters = cms.PSet(
         Propagators = cms.untracked.vstring('SteppingHelixPropagatorAny'),
         RPCLayers = cms.bool(True),
         UseMuonNavigation = cms.untracked.bool(True)
-    )
+    ),
+    estimatorMaxChi2 = cms.double(1000.0)
 )   
 
 from Configuration.ProcessModifiers.phase2L2AndL3Muons_cff import phase2L2AndL3Muons
-phase2L2AndL3Muons.toReplaceWith(hltL2MuonSeedsFromL1TkMuon, phase2HltL2MuonSeedsFromL1TkMuon)
+phase2L2AndL3Muons.toReplaceWith(
+    hltL2MuonSeedsFromL1TkMuon,
+    phase2HltL2MuonSeedsFromL1TkMuon
+    )

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltL2MuonSeedsFromL1TkMuon_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltL2MuonSeedsFromL1TkMuon_cfi.py
@@ -20,3 +20,26 @@ hltL2MuonSeedsFromL1TkMuon = cms.EDProducer("L2MuonSeedGeneratorFromL1TkMu",
     UseOfflineSeed = cms.untracked.bool(True),
     UseUnassociatedL1 = cms.bool(False)
 )
+
+phase2HltL2MuonSeedsFromL1TkMuon = cms.EDProducer('Phase2L2MuonSeedCreator',
+    InputObjects = cms.InputTag('l1tTkMuonsGmt'),
+    CSCRecSegmentLabel = cms.InputTag('hltCscSegments'),
+    DTRecSegmentLabel = cms.InputTag('hltDt4DSegments'),
+    MinPL1Tk = cms.double(3.5),
+    MaxPL1Tk = cms.double(200),
+    stubMatchDPhi = cms.double(0.05),
+    stubMatchDTheta = cms.double(0.1),
+    extrapolationWindowClose = cms.double(0.2),
+    extrapolationWindowFar = cms.double(0.1),
+    maximumEtaBarrel = cms.double(0.7),
+    maximumEtaOverlap = cms.double(1.3),
+    Propagator = cms.string('SteppingHelixPropagatorAny'),
+    ServiceParameters = cms.PSet(
+        Propagators = cms.untracked.vstring('SteppingHelixPropagatorAny'),
+        RPCLayers = cms.bool(True),
+        UseMuonNavigation = cms.untracked.bool(True)
+    )
+)   
+
+from Configuration.ProcessModifiers.phase2L2AndL3Muons_cff import phase2L2AndL3Muons
+phase2L2AndL3Muons.toReplaceWith(hltL2MuonSeedsFromL1TkMuon, phase2HltL2MuonSeedsFromL1TkMuon)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2L3FromL1TkMuonPixelTracksTrackingRegions_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2L3FromL1TkMuonPixelTracksTrackingRegions_cfi.py
@@ -22,3 +22,10 @@ hltPhase2L3FromL1TkMuonPixelTracksTrackingRegions = cms.EDProducer("CandidateSee
         zErrorVetex = cms.double(0.2)
     )
 )
+
+from Configuration.ProcessModifiers.phase2L2AndL3Muons_cff import phase2L2AndL3Muons
+from Configuration.ProcessModifiers.phase2L3MuonsOIFirst_cff import phase2L3MuonsOIFirst
+(phase2L2AndL3Muons & phase2L3MuonsOIFirst).toModify(
+    hltPhase2L3FromL1TkMuonPixelTracksTrackingRegions.RegionPSet,
+    input = "hltPhase2L3MuonFilter:L1TkMuToReuse"
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2L3MuonFilter_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2L3MuonFilter_cfi.py
@@ -1,0 +1,24 @@
+import FWCore.ParameterSet.Config as cms
+
+hltPhase2L3MuonFilter = cms.EDProducer("phase2HLTMuonSelectorForL3",
+    l1TkMuons = cms.InputTag("l1tTkMuonsGmt"),
+    l2MuonsUpdVtx = cms.InputTag("hltL2MuonsFromL1TkMuon:UpdatedAtVtx"),
+    l3Tracks = cms.InputTag("hltIter2Phase2L3FromL1TkMuonMerged"),
+    IOFirst = cms.bool(True),
+    matchingDr = cms.double(0.02),
+    applyL3Filters = cms.bool(True),
+    MinNhits = cms.int32(1),
+    MaxNormalizedChi2 = cms.double(5.0),
+    MinNhitsMuons = cms.int32(0),
+    MinNhitsPixel = cms.int32(1),
+    MinNhitsTracker = cms.int32(6),
+    MaxPtDifference = cms.double(999.0),
+)
+
+from Configuration.ProcessModifiers.phase2L2AndL3Muons_cff import phase2L2AndL3Muons
+from Configuration.ProcessModifiers.phase2L3MuonsOIFirst_cff import phase2L3MuonsOIFirst
+(phase2L2AndL3Muons & phase2L3MuonsOIFirst).toModify(
+    hltPhase2L3MuonFilter,
+    l3Tracks = "hltPhase2L3OIMuonTrackSelectionHighPurity",
+    IOFirst = False,
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2L3MuonFilter_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2L3MuonFilter_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-hltPhase2L3MuonFilter = cms.EDProducer("phase2HLTMuonSelectorForL3",
+hltPhase2L3MuonFilter = cms.EDProducer("Phase2HLTMuonSelectorForL3",
     l1TkMuons = cms.InputTag("l1tTkMuonsGmt"),
     l2MuonsUpdVtx = cms.InputTag("hltL2MuonsFromL1TkMuon:UpdatedAtVtx"),
     l3Tracks = cms.InputTag("hltIter2Phase2L3FromL1TkMuonMerged"),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2L3MuonMerged_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2L3MuonMerged_cfi.py
@@ -8,18 +8,47 @@ hltPhase2L3MuonMerged = cms.EDProducer("TrackListMerger",
     MinFound = cms.int32(3),
     MinPT = cms.double(0.05),
     ShareFrac = cms.double(0.19),
-    TrackProducers = cms.VInputTag("hltPhase2L3OIMuonTrackSelectionHighPurity", "hltIter2Phase2L3FromL1TkMuonMerged"),
+    TrackProducers = cms.VInputTag(
+        "hltPhase2L3OIMuonTrackSelectionHighPurity",
+        "hltIter2Phase2L3FromL1TkMuonMerged",
+    ),
     allowFirstHitShare = cms.bool(True),
     copyExtras = cms.untracked.bool(True),
     copyMVA = cms.bool(False),
     hasSelector = cms.vint32(0, 0),
     indivShareFrac = cms.vdouble(1.0, 1.0),
-    newQuality = cms.string('confirmed'),
-    selectedTrackQuals = cms.VInputTag("hltPhase2L3OIMuonTrackSelectionHighPurity", "hltIter2Phase2L3FromL1TkMuonMerged"),
-    setsToMerge = cms.VPSet(cms.PSet(
-        pQual = cms.bool(False),
-        tLists = cms.vint32(0, 1)
-    )),
-    trackAlgoPriorityOrder = cms.string('hltESPTrackAlgoPriorityOrder'),
-    writeOnlyTrkQuals = cms.bool(False)
+    newQuality = cms.string("confirmed"),
+    selectedTrackQuals = cms.VInputTag(
+        "hltPhase2L3OIMuonTrackSelectionHighPurity",
+        "hltIter2Phase2L3FromL1TkMuonMerged",
+    ),
+    setsToMerge = cms.VPSet(cms.PSet(pQual = cms.bool(False), tLists = cms.vint32(0, 1))),
+    trackAlgoPriorityOrder = cms.string("hltESPTrackAlgoPriorityOrder"),
+    writeOnlyTrkQuals = cms.bool(False),
+)
+
+from Configuration.ProcessModifiers.phase2L2AndL3Muons_cff import phase2L2AndL3Muons
+phase2L2AndL3Muons.toModify(
+    hltPhase2L3MuonMerged,
+    TrackProducers = cms.VInputTag(
+        "hltPhase2L3OIMuonTrackSelectionHighPurity",
+        "hltPhase2L3MuonFilter:L3IOTracksFiltered",
+    ),
+    selectedTrackQuals = cms.VInputTag(
+        "hltPhase2L3OIMuonTrackSelectionHighPurity",
+        "hltPhase2L3MuonFilter:L3IOTracksFiltered",
+    ),
+)
+
+from Configuration.ProcessModifiers.phase2L3MuonsOIFirst_cff import phase2L3MuonsOIFirst
+(phase2L2AndL3Muons & phase2L3MuonsOIFirst).toModify(
+    hltPhase2L3MuonMerged,
+    TrackProducers = cms.VInputTag(
+        "hltPhase2L3MuonFilter:L3OITracksFiltered",
+        "hltIter2Phase2L3FromL1TkMuonMerged",
+    ),
+    selectedTrackQuals = cms.VInputTag(
+        "hltPhase2L3MuonFilter:L3OITracksFiltered",
+        "hltIter2Phase2L3FromL1TkMuonMerged",
+    ),
 )

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2L3OISeedsFromL2Muons_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2L3OISeedsFromL2Muons_cfi.py
@@ -39,3 +39,15 @@ hltPhase2L3OISeedsFromL2Muons = cms.EDProducer("TSGForOIFromL2",
     tsosDiff1 = cms.double(0.2),
     tsosDiff2 = cms.double(0.02)
 )
+
+from Configuration.ProcessModifiers.phase2L2AndL3Muons_cff import phase2L2AndL3Muons
+phase2L2AndL3Muons.toModify(
+    hltPhase2L3OISeedsFromL2Muons,
+    src = "hltPhase2L3MuonFilter:L2MuToReuse"
+)
+
+from Configuration.ProcessModifiers.phase2L3MuonsOIFirst_cff import phase2L3MuonsOIFirst
+(phase2L2AndL3Muons & phase2L3MuonsOIFirst).toModify(
+    hltPhase2L3OISeedsFromL2Muons,
+    src ="hltL2MuonsFromL1TkMuon:UpdatedAtVtx"
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_AK4PFPuppiJet520_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_AK4PFPuppiJet520_cfi.py
@@ -12,4 +12,16 @@ from ..sequences.HLTTrackingV61Sequence_cfi import *
 from ..sequences.HLTLocalrecoSequence_cfi import *
 from ..sequences.HLTRawToDigiSequence_cfi import *
 
-HLT_AK4PFPuppiJet520 = cms.Path(HLTBeginSequence+hltL1SeedsForPuppiJetFilter+HLTRawToDigiSequence+HLTHgcalLocalRecoSequence+HLTLocalrecoSequence+HLTTrackingV61Sequence+HLTMuonsSequence+HLTParticleFlowSequence+HLTAK4PFPuppiJetsReconstruction+hltSingleAK4PFPuppiJet520+HLTEndSequence)
+HLT_AK4PFPuppiJet520 = cms.Path(
+    HLTBeginSequence
+    + hltL1SeedsForPuppiJetFilter
+    + HLTRawToDigiSequence
+    + HLTHgcalLocalRecoSequence
+    + HLTLocalrecoSequence
+    + HLTTrackingV61Sequence
+    + HLTMuonsSequence
+    + HLTParticleFlowSequence
+    + HLTAK4PFPuppiJetsReconstruction
+    + hltSingleAK4PFPuppiJet520
+    + HLTEndSequence
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_DoubleMediumChargedIsoPFTauHPS40_eta2p1_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_DoubleMediumChargedIsoPFTauHPS40_eta2p1_cfi.py
@@ -17,4 +17,21 @@ from ..sequences.HLTLocalrecoSequence_cfi import *
 from ..sequences.HLTRawToDigiSequence_cfi import *
 from ..modules.hltL1SeedForDoublePuppiTau_cfi import *
 
-HLT_DoubleMediumChargedIsoPFTauHPS40_eta2p1 = cms.Path(HLTBeginSequence+hltL1SeedForDoublePuppiTau+hltPreDoublePFTauHPS+HLTRawToDigiSequence+HLTHgcalLocalRecoSequence+HLTLocalrecoSequence+HLTTrackingV61Sequence+HLTMuonsSequence+HLTParticleFlowSequence+HLTAK4PFJetsReconstruction+hltAK4PFJetsForTaus+HLTPFTauHPS+HLTHPSMediumChargedIsoPFTauSequence+hltHpsSelectedPFTausTrackPt1MediumChargedIsolation+hltHpsDoublePFTau40TrackPt1MediumChargedIsolation+HLTEndSequence)
+HLT_DoubleMediumChargedIsoPFTauHPS40_eta2p1 = cms.Path(
+    HLTBeginSequence
+    + hltL1SeedForDoublePuppiTau
+    + hltPreDoublePFTauHPS
+    + HLTRawToDigiSequence
+    + HLTHgcalLocalRecoSequence
+    + HLTLocalrecoSequence
+    + HLTTrackingV61Sequence
+    + HLTMuonsSequence
+    + HLTParticleFlowSequence
+    + HLTAK4PFJetsReconstruction
+    + hltAK4PFJetsForTaus
+    + HLTPFTauHPS
+    + HLTHPSMediumChargedIsoPFTauSequence
+    + hltHpsSelectedPFTausTrackPt1MediumChargedIsolation
+    + hltHpsDoublePFTau40TrackPt1MediumChargedIsolation
+    + HLTEndSequence
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_DoubleMediumDeepTauPFTauHPS35_eta2p1_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_DoubleMediumDeepTauPFTauHPS35_eta2p1_cfi.py
@@ -17,4 +17,21 @@ from ..sequences.HLTLocalrecoSequence_cfi import *
 from ..sequences.HLTRawToDigiSequence_cfi import *
 from ..modules.hltL1SeedForDoublePuppiTau_cfi import *
 
-HLT_DoubleMediumDeepTauPFTauHPS35_eta2p1 = cms.Path(HLTBeginSequence+hltL1SeedForDoublePuppiTau+hltPreDoublePFTauHPS+HLTRawToDigiSequence+HLTHgcalLocalRecoSequence+HLTLocalrecoSequence+HLTTrackingV61Sequence+HLTMuonsSequence+HLTParticleFlowSequence+HLTAK4PFJetsReconstruction+hltAK4PFJetsForTaus+HLTPFTauHPS+HLTHPSDeepTauPFTauSequence+hltHpsSelectedPFTausMediumDitauWPDeepTau+hltHpsDoublePFTau35MediumDitauWPDeepTau+HLTEndSequence)
+HLT_DoubleMediumDeepTauPFTauHPS35_eta2p1 = cms.Path(
+    HLTBeginSequence
+    + hltL1SeedForDoublePuppiTau
+    + hltPreDoublePFTauHPS
+    + HLTRawToDigiSequence
+    + HLTHgcalLocalRecoSequence
+    + HLTLocalrecoSequence
+    + HLTTrackingV61Sequence
+    + HLTMuonsSequence
+    + HLTParticleFlowSequence
+    + HLTAK4PFJetsReconstruction
+    + hltAK4PFJetsForTaus
+    + HLTPFTauHPS
+    + HLTHPSDeepTauPFTauSequence
+    + hltHpsSelectedPFTausMediumDitauWPDeepTau
+    + hltHpsDoublePFTau35MediumDitauWPDeepTau
+    + HLTEndSequence
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_DoublePFPuppiJets128_DoublePFPuppiBTagDeepCSV_2p4_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_DoublePFPuppiJets128_DoublePFPuppiBTagDeepCSV_2p4_cfi.py
@@ -15,4 +15,19 @@ from ..sequences.HLTTrackingV61Sequence_cfi import *
 from ..sequences.HLTLocalrecoSequence_cfi import *
 from ..sequences.HLTRawToDigiSequence_cfi import *
 
-HLT_DoublePFPuppiJets128_DoublePFPuppiBTagDeepCSV_2p4 = cms.Path(HLTBeginSequence+hltL1SeedsForDoublePuppiJetBtagFilter+HLTRawToDigiSequence+HLTHgcalLocalRecoSequence+HLTLocalrecoSequence+HLTTrackingV61Sequence+HLTMuonsSequence+HLTParticleFlowSequence+HLTAK4PFPuppiJetsReconstruction+hltDoublePFPuppiJets128MaxEta2p4+hltDoublePFPuppiJets128Eta2p4MaxDeta1p6+HLTBtagDeepCSVSequencePFPuppiModEta2p4+hltBTagPFPuppiDeepCSV0p865DoubleEta2p4+HLTEndSequence)
+HLT_DoublePFPuppiJets128_DoublePFPuppiBTagDeepCSV_2p4 = cms.Path(
+    HLTBeginSequence
+    + hltL1SeedsForDoublePuppiJetBtagFilter
+    + HLTRawToDigiSequence
+    + HLTHgcalLocalRecoSequence
+    + HLTLocalrecoSequence
+    + HLTTrackingV61Sequence
+    + HLTMuonsSequence
+    + HLTParticleFlowSequence
+    + HLTAK4PFPuppiJetsReconstruction
+    + hltDoublePFPuppiJets128MaxEta2p4
+    + hltDoublePFPuppiJets128Eta2p4MaxDeta1p6
+    + HLTBtagDeepCSVSequencePFPuppiModEta2p4
+    + hltBTagPFPuppiDeepCSV0p865DoubleEta2p4
+    + HLTEndSequence
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_DoublePFPuppiJets128_DoublePFPuppiBTagDeepFlavour_2p4_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_DoublePFPuppiJets128_DoublePFPuppiBTagDeepFlavour_2p4_cfi.py
@@ -15,4 +15,19 @@ from ..sequences.HLTTrackingV61Sequence_cfi import *
 from ..sequences.HLTLocalrecoSequence_cfi import *
 from ..sequences.HLTRawToDigiSequence_cfi import *
 
-HLT_DoublePFPuppiJets128_DoublePFPuppiBTagDeepFlavour_2p4 = cms.Path(HLTBeginSequence+hltL1SeedsForDoublePuppiJetBtagFilter+HLTRawToDigiSequence+HLTHgcalLocalRecoSequence+HLTLocalrecoSequence+HLTTrackingV61Sequence+HLTMuonsSequence+HLTParticleFlowSequence+HLTAK4PFPuppiJetsReconstruction+hltDoublePFPuppiJets128MaxEta2p4+hltDoublePFPuppiJets128Eta2p4MaxDeta1p6+HLTBtagDeepFlavourSequencePFPuppiModEta2p4+hltBTagPFPuppiDeepFlavour0p935DoubleEta2p4+HLTEndSequence)
+HLT_DoublePFPuppiJets128_DoublePFPuppiBTagDeepFlavour_2p4 = cms.Path(
+    HLTBeginSequence
+    + hltL1SeedsForDoublePuppiJetBtagFilter
+    + HLTRawToDigiSequence
+    + HLTHgcalLocalRecoSequence
+    + HLTLocalrecoSequence
+    + HLTTrackingV61Sequence
+    + HLTMuonsSequence
+    + HLTParticleFlowSequence
+    + HLTAK4PFPuppiJetsReconstruction
+    + hltDoublePFPuppiJets128MaxEta2p4
+    + hltDoublePFPuppiJets128Eta2p4MaxDeta1p6
+    + HLTBtagDeepFlavourSequencePFPuppiModEta2p4
+    + hltBTagPFPuppiDeepFlavour0p935DoubleEta2p4
+    + HLTEndSequence
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_IsoMu20_eta2p1_LooseDeepTauPFTauHPS27_eta2p1_CrossL1_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_IsoMu20_eta2p1_LooseDeepTauPFTauHPS27_eta2p1_CrossL1_cfi.py
@@ -32,29 +32,34 @@ from ..modules.hltL3fL1TkSingleMu18Filtered20_cfi import *
 from ..modules.hltPhase2L3MuonsTrkIsoRegionalNewdR0p3dRVeto0p005dz0p25dr0p20ChisqInfPtMin0p0Cut0p07_cfi import *
 
 HLT_IsoMu20_eta2p1_LooseDeepTauPFTauHPS27_eta2p1_CrossL1 = cms.Path(
-    HLTBeginSequence +
-    hltPuppiTauTkMuon4218L1TkFilter +
-    HLTRawToDigiSequence + HLTHgcalLocalRecoSequence +
-    HLTLocalrecoSequence + HLTTrackingV61Sequence +
-    HLTMuonsSequence + HLTParticleFlowSequence +
-    hltParticleFlowRecHitECALUnseeded +
-    hltParticleFlowClusterECALUncorrectedUnseeded +
-    hltParticleFlowClusterECALUnseeded +
-    hltFixedGridRhoFastjetAllCaloForEGamma +
-    hltPhase2L3MuonCandidates +
-    hltPhase2L3MuonsEcalIsodR0p3dRVeto0p000 +
-    hltPhase2L3MuonsHcalIsodR0p3dRVeto0p000 +
-    hltPhase2L3MuonsHgcalLCIsodR0p2dRVetoEM0p00dRVetoHad0p02minEEM0p00minEHad0p00 +
-    hltL3fL1TkSingleMu18Filtered20 +
-    hltL3crIsoL1TkSingleMu22EcalIso0p41 +        
-    hltL3crIsoL1TkSingleMu22HcalIso0p40 +
-    hltL3crIsoL1TkSingleMu22HgcalIso4p70 +
-    HLTPhase2L3MuonGeneralTracksSequence +
-    hltPhase2L3MuonsTrkIsoRegionalNewdR0p3dRVeto0p005dz0p25dr0p20ChisqInfPtMin0p0Cut0p07 + 
-    hltL3crIsoL1TkSingleMu22TrkIsoRegionalNewFiltered0p07EcalHcalHgcalTrk +
-    HLTAK4PFJetsReconstruction + hltAK4PFJetsForTaus + 
-    HLTPFTauHPS + HLTHPSDeepTauPFTauSequence +
-    hltHpsSelectedPFTauLooseTauWPDeepTau + 
-    hltHpsPFTau27LooseTauWPDeepTau +
-    HLTEndSequence
+    HLTBeginSequence
+    + hltPuppiTauTkMuon4218L1TkFilter
+    + HLTRawToDigiSequence
+    + HLTHgcalLocalRecoSequence
+    + HLTLocalrecoSequence
+    + HLTTrackingV61Sequence
+    + HLTMuonsSequence
+    + HLTParticleFlowSequence
+    + hltParticleFlowRecHitECALUnseeded
+    + hltParticleFlowClusterECALUncorrectedUnseeded
+    + hltParticleFlowClusterECALUnseeded
+    + hltFixedGridRhoFastjetAllCaloForEGamma
+    + hltPhase2L3MuonCandidates
+    + hltPhase2L3MuonsEcalIsodR0p3dRVeto0p000
+    + hltPhase2L3MuonsHcalIsodR0p3dRVeto0p000
+    + hltPhase2L3MuonsHgcalLCIsodR0p2dRVetoEM0p00dRVetoHad0p02minEEM0p00minEHad0p00
+    + hltL3fL1TkSingleMu18Filtered20
+    + hltL3crIsoL1TkSingleMu22EcalIso0p41
+    + hltL3crIsoL1TkSingleMu22HcalIso0p40
+    + hltL3crIsoL1TkSingleMu22HgcalIso4p70
+    + HLTPhase2L3MuonGeneralTracksSequence
+    + hltPhase2L3MuonsTrkIsoRegionalNewdR0p3dRVeto0p005dz0p25dr0p20ChisqInfPtMin0p0Cut0p07
+    + hltL3crIsoL1TkSingleMu22TrkIsoRegionalNewFiltered0p07EcalHcalHgcalTrk
+    + HLTAK4PFJetsReconstruction
+    + hltAK4PFJetsForTaus
+    + HLTPFTauHPS
+    + HLTHPSDeepTauPFTauSequence
+    + hltHpsSelectedPFTauLooseTauWPDeepTau
+    + hltHpsPFTau27LooseTauWPDeepTau
+    + HLTEndSequence
 )

--- a/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_IsoMu24_FromL1TkMuon_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_IsoMu24_FromL1TkMuon_cfi.py
@@ -8,14 +8,9 @@ from ..sequences.HLTOtLocalRecoSequence_cfi import *
 from ..sequences.HLTHgcalLocalRecoSequence_cfi import *
 from ..sequences.HLTDoLocalHcalSequence_cfi import *
 from ..sequences.HLTDoFullUnpackingEgammaEcalSequence_cfi import *
+from ..sequences.HLTMuonsSequence_cfi import *
 from ..sequences.HLTFastJetForEgammaSequence_cfi import *
-from ..sequences.HLTIter0Phase2L3FromL1TkSequence_cfi import *
-from ..sequences.HLTIter2Phase2L3FromL1TkSequence_cfi import *
 from ..sequences.HLTPfClusteringHBHEHFSequence_cfi import *
-from ..sequences.HLTPhase2L3FromL1TkSequence_cfi import *
-from ..sequences.HLTPhase2L3OISequence_cfi import *
-from ..sequences.HLTPhase2L3MuonsSequence_cfi import *
-from ..sequences.HLTL2MuonsFromL1TkSequence_cfi import *
 from ..sequences.HLTPFClusteringForEgammaUnseededSequence_cfi import *
 from ..sequences.HLTPhase2L3MuonGeneralTracksSequence_cfi import *
 from ..modules.hltSingleTkMuon22L1TkMuonFilter_cfi import *
@@ -31,35 +26,30 @@ from ..modules.hltPhase2L3MuonsHcalIsodR0p3dRVeto0p000_cfi import *
 from ..modules.hltPhase2L3MuonsHgcalLCIsodR0p2dRVetoEM0p00dRVetoHad0p02minEEM0p00minEHad0p00_cfi import *
 from ..modules.hltPhase2L3MuonsTrkIsoRegionalNewdR0p3dRVeto0p005dz0p25dr0p20ChisqInfPtMin0p0Cut0p07_cfi import *
 
-
-
-HLT_IsoMu24_FromL1TkMuon = cms.Path(HLTBeginSequence
-    +hltSingleTkMuon22L1TkMuonFilter
-    +HLTRawToDigiSequence
-    +HLTItLocalRecoSequence
-    +HLTOtLocalRecoSequence
-    +HLTL2MuonsFromL1TkSequence
-    +HLTPhase2L3OISequence
-    +hltPhase2PixelFitterByHelixProjections
-    +hltPhase2PixelTrackFilterByKinematics
-    +HLTPhase2L3FromL1TkSequence
-    +HLTIter0Phase2L3FromL1TkSequence
-    +HLTIter2Phase2L3FromL1TkSequence
-    +HLTPhase2L3MuonsSequence
-    +hltL3fL1TkSingleMu22L3Filtered24Q
-    +HLTHgcalLocalRecoSequence
-    +HLTDoLocalHcalSequence
-    +HLTDoFullUnpackingEgammaEcalSequence
-    +HLTFastJetForEgammaSequence
-    +HLTPfClusteringHBHEHFSequence
-    +HLTPFClusteringForEgammaUnseededSequence
-    +hltPhase2L3MuonsEcalIsodR0p3dRVeto0p000
-    +hltPhase2L3MuonsHcalIsodR0p3dRVeto0p000
-    +hltPhase2L3MuonsHgcalLCIsodR0p2dRVetoEM0p00dRVetoHad0p02minEEM0p00minEHad0p00
-    +hltL3crIsoL1TkSingleMu22L3f24QL3pfecalIsoFiltered0p41
-    +hltL3crIsoL1TkSingleMu22L3f24QL3pfhcalIsoFiltered0p40
-    +hltL3crIsoL1TkSingleMu22L3f24QL3pfhgcalIsoFiltered4p70
-    +HLTPhase2L3MuonGeneralTracksSequence
-    +hltPhase2L3MuonsTrkIsoRegionalNewdR0p3dRVeto0p005dz0p25dr0p20ChisqInfPtMin0p0Cut0p07
-    +hltL3crIsoL1TkSingleMu22L3f24QL3trkIsoRegionalNewFiltered0p07EcalHcalHgcalTrk
-    +HLTEndSequence)
+HLT_IsoMu24_FromL1TkMuon = cms.Path(
+    HLTBeginSequence
+    + hltSingleTkMuon22L1TkMuonFilter
+    + HLTRawToDigiSequence
+    + HLTItLocalRecoSequence
+    + HLTOtLocalRecoSequence
+    + hltPhase2PixelFitterByHelixProjections
+    + hltPhase2PixelTrackFilterByKinematics
+    + HLTMuonsSequence
+    + hltL3fL1TkSingleMu22L3Filtered24Q
+    + HLTHgcalLocalRecoSequence
+    + HLTDoLocalHcalSequence
+    + HLTDoFullUnpackingEgammaEcalSequence
+    + HLTFastJetForEgammaSequence
+    + HLTPfClusteringHBHEHFSequence
+    + HLTPFClusteringForEgammaUnseededSequence
+    + hltPhase2L3MuonsEcalIsodR0p3dRVeto0p000
+    + hltPhase2L3MuonsHcalIsodR0p3dRVeto0p000
+    + hltPhase2L3MuonsHgcalLCIsodR0p2dRVetoEM0p00dRVetoHad0p02minEEM0p00minEHad0p00
+    + hltL3crIsoL1TkSingleMu22L3f24QL3pfecalIsoFiltered0p41
+    + hltL3crIsoL1TkSingleMu22L3f24QL3pfhcalIsoFiltered0p40
+    + hltL3crIsoL1TkSingleMu22L3f24QL3pfhgcalIsoFiltered4p70
+    + HLTPhase2L3MuonGeneralTracksSequence
+    + hltPhase2L3MuonsTrkIsoRegionalNewdR0p3dRVeto0p005dz0p25dr0p20ChisqInfPtMin0p0Cut0p07
+    + hltL3crIsoL1TkSingleMu22L3f24QL3trkIsoRegionalNewFiltered0p07EcalHcalHgcalTrk
+    + HLTEndSequence
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_FromL1TkMuon_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_FromL1TkMuon_cfi.py
@@ -9,13 +9,8 @@ from ..sequences.HLTHgcalLocalRecoSequence_cfi import *
 from ..sequences.HLTDoLocalHcalSequence_cfi import *
 from ..sequences.HLTDoFullUnpackingEgammaEcalSequence_cfi import *
 from ..sequences.HLTFastJetForEgammaSequence_cfi import *
-from ..sequences.HLTIter0Phase2L3FromL1TkSequence_cfi import *
-from ..sequences.HLTIter2Phase2L3FromL1TkSequence_cfi import *
 from ..sequences.HLTPfClusteringHBHEHFSequence_cfi import *
-from ..sequences.HLTPhase2L3FromL1TkSequence_cfi import *
-from ..sequences.HLTPhase2L3OISequence_cfi import *
-from ..sequences.HLTPhase2L3MuonsSequence_cfi import *
-from ..sequences.HLTL2MuonsFromL1TkSequence_cfi import *
+from ..sequences.HLTMuonsSequence_cfi import *
 from ..sequences.HLTPFClusteringForEgammaUnseededSequence_cfi import *
 from ..sequences.HLTPhase2L3MuonGeneralTracksSequence_cfi import *
 from ..modules.hltDoubleTkMuon157L1TkMuonFilter_cfi import *
@@ -30,24 +25,21 @@ from ..modules.hltL3fL1DoubleMu155fFiltered17_cfi import *
 from ..modules.hltL3fL1DoubleMu155fPreFiltered8_cfi import *
 from ..modules.hltPhase2L3MuonsTrkIsoRegionalNewdR0p3dRVeto0p005dz0p25dr0p20ChisqInfPtMin0p0Cut0p4_cfi import *
 
-HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_FromL1TkMuon = cms.Path(HLTBeginSequence
-    +hltDoubleTkMuon157L1TkMuonFilter
-    +hltDoubleMuon7DZ1p0
-    +HLTRawToDigiSequence
-    +HLTItLocalRecoSequence
-    +HLTOtLocalRecoSequence
-    +HLTL2MuonsFromL1TkSequence
-    +HLTPhase2L3OISequence
-    +hltPhase2PixelFitterByHelixProjections
-    +hltPhase2PixelTrackFilterByKinematics
-    +HLTPhase2L3FromL1TkSequence
-    +HLTIter0Phase2L3FromL1TkSequence
-    +HLTIter2Phase2L3FromL1TkSequence
-    +HLTPhase2L3MuonsSequence
-    +hltL3fL1DoubleMu155fPreFiltered8
-    +hltL3fL1DoubleMu155fFiltered17
-    +HLTPhase2L3MuonGeneralTracksSequence
-    +hltPhase2L3MuonsTrkIsoRegionalNewdR0p3dRVeto0p005dz0p25dr0p20ChisqInfPtMin0p0Cut0p4
-    +hltDiMuon178RelTrkIsoFiltered0p4
-    +hltDiMuon178RelTrkIsoFiltered0p4DzFiltered0p2
-    +HLTEndSequence)
+HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_FromL1TkMuon = cms.Path(
+    HLTBeginSequence
+    + hltDoubleTkMuon157L1TkMuonFilter
+    + hltDoubleMuon7DZ1p0
+    + HLTRawToDigiSequence
+    + HLTItLocalRecoSequence
+    + HLTOtLocalRecoSequence
+    + hltPhase2PixelFitterByHelixProjections
+    + hltPhase2PixelTrackFilterByKinematics
+    + HLTMuonsSequence
+    + hltL3fL1DoubleMu155fPreFiltered8
+    + hltL3fL1DoubleMu155fFiltered17
+    + HLTPhase2L3MuonGeneralTracksSequence
+    + hltPhase2L3MuonsTrkIsoRegionalNewdR0p3dRVeto0p005dz0p25dr0p20ChisqInfPtMin0p0Cut0p4
+    + hltDiMuon178RelTrkIsoFiltered0p4
+    + hltDiMuon178RelTrkIsoFiltered0p4DzFiltered0p2
+    + HLTEndSequence
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_Mu37_Mu27_FromL1TkMuon_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_Mu37_Mu27_FromL1TkMuon_cfi.py
@@ -13,15 +13,17 @@ from ..sequences.HLTItLocalRecoSequence_cfi import *
 from ..sequences.HLTMuonlocalrecoSequence_cfi import *
 from ..sequences.HLTOtLocalRecoSequence_cfi import *
 
-HLT_Mu37_Mu27_FromL1TkMuon = cms.Path(HLTBeginSequence
-+hltDoubleMuon7DZ1p0
-+HLTMuonlocalrecoSequence
-+HLTItLocalRecoSequence
-+HLTOtLocalRecoSequence
-+hltPhase2PixelFitterByHelixProjections
-+hltPhase2PixelTrackFilterByKinematics
-+HLTMuonsSequence
-+hltPhase2L3MuonCandidates
-+hltL3fL1DoubleMu155fPreFiltered27
-+hltL3fL1DoubleMu155fFiltered37
-+HLTEndSequence)
+HLT_Mu37_Mu27_FromL1TkMuon = cms.Path(
+    HLTBeginSequence
+    + hltDoubleMuon7DZ1p0
+    + HLTMuonlocalrecoSequence
+    + HLTItLocalRecoSequence
+    + HLTOtLocalRecoSequence
+    + hltPhase2PixelFitterByHelixProjections
+    + hltPhase2PixelTrackFilterByKinematics
+    + HLTMuonsSequence
+    + hltPhase2L3MuonCandidates
+    + hltL3fL1DoubleMu155fPreFiltered27
+    + hltL3fL1DoubleMu155fFiltered37
+    + HLTEndSequence
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_Mu50_FromL1TkMuon_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_Mu50_FromL1TkMuon_cfi.py
@@ -13,14 +13,16 @@ from ..sequences.HLTItLocalRecoSequence_cfi import *
 from ..sequences.HLTMuonlocalrecoSequence_cfi import *
 from ..sequences.HLTOtLocalRecoSequence_cfi import *
 
-HLT_Mu50_FromL1TkMuon = cms.Path(HLTBeginSequence
-    +hltSingleTkMuon22L1TkMuonFilter
-    +HLTMuonlocalrecoSequence
-    +HLTItLocalRecoSequence
-    +HLTOtLocalRecoSequence
-    +hltPhase2PixelFitterByHelixProjections
-    +hltPhase2PixelTrackFilterByKinematics
-    +HLTMuonsSequence
-    +hltPhase2L3MuonCandidates
-    +hltL3fL1TkSingleMu22L3Filtered50Q
-    +HLTEndSequence)
+HLT_Mu50_FromL1TkMuon = cms.Path(
+    HLTBeginSequence
+    + hltSingleTkMuon22L1TkMuonFilter
+    + HLTMuonlocalrecoSequence
+    + HLTItLocalRecoSequence
+    + HLTOtLocalRecoSequence
+    + hltPhase2PixelFitterByHelixProjections
+    + hltPhase2PixelTrackFilterByKinematics
+    + HLTMuonsSequence
+    + hltPhase2L3MuonCandidates
+    + hltL3fL1TkSingleMu22L3Filtered50Q
+    + HLTEndSequence
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_PFHT200PT30_QuadPFPuppiJet_70_40_30_30_TriplePFPuppiBTagDeepCSV_2p4_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_PFHT200PT30_QuadPFPuppiJet_70_40_30_30_TriplePFPuppiBTagDeepCSV_2p4_cfi.py
@@ -18,4 +18,22 @@ from ..sequences.HLTTrackingV61Sequence_cfi import *
 from ..sequences.HLTLocalrecoSequence_cfi import *
 from ..sequences.HLTRawToDigiSequence_cfi import *
 
-HLT_PFHT200PT30_QuadPFPuppiJet_70_40_30_30_TriplePFPuppiBTagDeepCSV_2p4 = cms.Path(HLTBeginSequence+hltL1SeedsForQuadPuppiJetTripleBtagFilter+HLTRawToDigiSequence+HLTHgcalLocalRecoSequence+HLTLocalrecoSequence+HLTTrackingV61Sequence+HLTMuonsSequence+HLTParticleFlowSequence+HLTAK4PFPuppiJetsReconstruction+hltPFPuppiCentralJetQuad30MaxEta2p4+hlt1PFPuppiCentralJet70MaxEta2p4+hlt2PFPuppiCentralJet40MaxEta2p4+hltHtMhtPFPuppiCentralJetsQuadC30MaxEta2p4+hltPFPuppiCentralJetsQuad30HT200MaxEta2p4+HLTBtagDeepCSVSequencePFPuppiModEta2p4+hltBTagPFPuppiDeepCSV0p38Eta2p4TripleEta2p4+HLTEndSequence)
+HLT_PFHT200PT30_QuadPFPuppiJet_70_40_30_30_TriplePFPuppiBTagDeepCSV_2p4 = cms.Path(
+    HLTBeginSequence
+    + hltL1SeedsForQuadPuppiJetTripleBtagFilter
+    + HLTRawToDigiSequence
+    + HLTHgcalLocalRecoSequence
+    + HLTLocalrecoSequence
+    + HLTTrackingV61Sequence
+    + HLTMuonsSequence
+    + HLTParticleFlowSequence
+    + HLTAK4PFPuppiJetsReconstruction
+    + hltPFPuppiCentralJetQuad30MaxEta2p4
+    + hlt1PFPuppiCentralJet70MaxEta2p4
+    + hlt2PFPuppiCentralJet40MaxEta2p4
+    + hltHtMhtPFPuppiCentralJetsQuadC30MaxEta2p4
+    + hltPFPuppiCentralJetsQuad30HT200MaxEta2p4
+    + HLTBtagDeepCSVSequencePFPuppiModEta2p4
+    + hltBTagPFPuppiDeepCSV0p38Eta2p4TripleEta2p4
+    + HLTEndSequence
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_PFHT200PT30_QuadPFPuppiJet_70_40_30_30_TriplePFPuppiBTagDeepFlavour_2p4_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_PFHT200PT30_QuadPFPuppiJet_70_40_30_30_TriplePFPuppiBTagDeepFlavour_2p4_cfi.py
@@ -18,4 +18,22 @@ from ..sequences.HLTTrackingV61Sequence_cfi import *
 from ..sequences.HLTLocalrecoSequence_cfi import *
 from ..sequences.HLTRawToDigiSequence_cfi import *
 
-HLT_PFHT200PT30_QuadPFPuppiJet_70_40_30_30_TriplePFPuppiBTagDeepFlavour_2p4 = cms.Path(HLTBeginSequence+hltL1SeedsForQuadPuppiJetTripleBtagFilter+HLTRawToDigiSequence+HLTHgcalLocalRecoSequence+HLTLocalrecoSequence+HLTTrackingV61Sequence+HLTMuonsSequence+HLTParticleFlowSequence+HLTAK4PFPuppiJetsReconstruction+hltPFPuppiCentralJetQuad30MaxEta2p4+hlt1PFPuppiCentralJet70MaxEta2p4+hlt2PFPuppiCentralJet40MaxEta2p4+hltHtMhtPFPuppiCentralJetsQuadC30MaxEta2p4+hltPFPuppiCentralJetsQuad30HT200MaxEta2p4+HLTBtagDeepFlavourSequencePFPuppiModEta2p4+hltBTagPFPuppiDeepFlavour0p375Eta2p4TripleEta2p4+HLTEndSequence)
+HLT_PFHT200PT30_QuadPFPuppiJet_70_40_30_30_TriplePFPuppiBTagDeepFlavour_2p4 = cms.Path(
+    HLTBeginSequence
+    + hltL1SeedsForQuadPuppiJetTripleBtagFilter
+    + HLTRawToDigiSequence
+    + HLTHgcalLocalRecoSequence
+    + HLTLocalrecoSequence
+    + HLTTrackingV61Sequence
+    + HLTMuonsSequence
+    + HLTParticleFlowSequence
+    + HLTAK4PFPuppiJetsReconstruction
+    + hltPFPuppiCentralJetQuad30MaxEta2p4
+    + hlt1PFPuppiCentralJet70MaxEta2p4
+    + hlt2PFPuppiCentralJet40MaxEta2p4
+    + hltHtMhtPFPuppiCentralJetsQuadC30MaxEta2p4
+    + hltPFPuppiCentralJetsQuad30HT200MaxEta2p4
+    + HLTBtagDeepFlavourSequencePFPuppiModEta2p4
+    + hltBTagPFPuppiDeepFlavour0p375Eta2p4TripleEta2p4
+    + HLTEndSequence
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_PFHT330PT30_QuadPFPuppiJet_75_60_45_40_TriplePFPuppiBTagDeepCSV_2p4_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_PFHT330PT30_QuadPFPuppiJet_75_60_45_40_TriplePFPuppiBTagDeepCSV_2p4_cfi.py
@@ -20,4 +20,24 @@ from ..sequences.HLTTrackingV61Sequence_cfi import *
 from ..sequences.HLTLocalrecoSequence_cfi import *
 from ..sequences.HLTRawToDigiSequence_cfi import *
 
-HLT_PFHT330PT30_QuadPFPuppiJet_75_60_45_40_TriplePFPuppiBTagDeepCSV_2p4 = cms.Path(HLTBeginSequence+hltL1SeedsForQuadPuppiJetTripleBtagFilter+HLTRawToDigiSequence+HLTHgcalLocalRecoSequence+HLTLocalrecoSequence+HLTTrackingV61Sequence+HLTMuonsSequence+HLTParticleFlowSequence+HLTAK4PFPuppiJetsReconstruction+hltPFPuppiCentralJetQuad30MaxEta2p4+hlt1PFPuppiCentralJet75MaxEta2p4+hlt2PFPuppiCentralJet60MaxEta2p4+hlt3PFPuppiCentralJet45MaxEta2p4+hlt4PFPuppiCentralJet40MaxEta2p4+hltHtMhtPFPuppiCentralJetsQuadC30MaxEta2p4+hltPFPuppiCentralJetsQuad30HT330MaxEta2p4+HLTBtagDeepCSVSequencePFPuppiModEta2p4+hltBTagPFPuppiDeepCSV0p31Eta2p4TripleEta2p4+HLTEndSequence)
+HLT_PFHT330PT30_QuadPFPuppiJet_75_60_45_40_TriplePFPuppiBTagDeepCSV_2p4 = cms.Path(
+    HLTBeginSequence
+    + hltL1SeedsForQuadPuppiJetTripleBtagFilter
+    + HLTRawToDigiSequence
+    + HLTHgcalLocalRecoSequence
+    + HLTLocalrecoSequence
+    + HLTTrackingV61Sequence
+    + HLTMuonsSequence
+    + HLTParticleFlowSequence
+    + HLTAK4PFPuppiJetsReconstruction
+    + hltPFPuppiCentralJetQuad30MaxEta2p4
+    + hlt1PFPuppiCentralJet75MaxEta2p4
+    + hlt2PFPuppiCentralJet60MaxEta2p4
+    + hlt3PFPuppiCentralJet45MaxEta2p4
+    + hlt4PFPuppiCentralJet40MaxEta2p4
+    + hltHtMhtPFPuppiCentralJetsQuadC30MaxEta2p4
+    + hltPFPuppiCentralJetsQuad30HT330MaxEta2p4
+    + HLTBtagDeepCSVSequencePFPuppiModEta2p4
+    + hltBTagPFPuppiDeepCSV0p31Eta2p4TripleEta2p4
+    + HLTEndSequence
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_PFHT330PT30_QuadPFPuppiJet_75_60_45_40_TriplePFPuppiBTagDeepFlavour_2p4_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_PFHT330PT30_QuadPFPuppiJet_75_60_45_40_TriplePFPuppiBTagDeepFlavour_2p4_cfi.py
@@ -20,4 +20,24 @@ from ..sequences.HLTTrackingV61Sequence_cfi import *
 from ..sequences.HLTLocalrecoSequence_cfi import *
 from ..sequences.HLTRawToDigiSequence_cfi import *
 
-HLT_PFHT330PT30_QuadPFPuppiJet_75_60_45_40_TriplePFPuppiBTagDeepFlavour_2p4 = cms.Path(HLTBeginSequence+hltL1SeedsForQuadPuppiJetTripleBtagFilter+HLTRawToDigiSequence+HLTHgcalLocalRecoSequence+HLTLocalrecoSequence+HLTTrackingV61Sequence+HLTMuonsSequence+HLTParticleFlowSequence+HLTAK4PFPuppiJetsReconstruction+hltPFPuppiCentralJetQuad30MaxEta2p4+hlt1PFPuppiCentralJet75MaxEta2p4+hlt2PFPuppiCentralJet60MaxEta2p4+hlt3PFPuppiCentralJet45MaxEta2p4+hlt4PFPuppiCentralJet40MaxEta2p4+hltHtMhtPFPuppiCentralJetsQuadC30MaxEta2p4+hltPFPuppiCentralJetsQuad30HT330MaxEta2p4+HLTBtagDeepFlavourSequencePFPuppiModEta2p4+hltBTagPFPuppiDeepFlavour0p275Eta2p4TripleEta2p4+HLTEndSequence)
+HLT_PFHT330PT30_QuadPFPuppiJet_75_60_45_40_TriplePFPuppiBTagDeepFlavour_2p4 = cms.Path(
+    HLTBeginSequence
+    + hltL1SeedsForQuadPuppiJetTripleBtagFilter
+    + HLTRawToDigiSequence
+    + HLTHgcalLocalRecoSequence
+    + HLTLocalrecoSequence
+    + HLTTrackingV61Sequence
+    + HLTMuonsSequence
+    + HLTParticleFlowSequence
+    + HLTAK4PFPuppiJetsReconstruction
+    + hltPFPuppiCentralJetQuad30MaxEta2p4
+    + hlt1PFPuppiCentralJet75MaxEta2p4
+    + hlt2PFPuppiCentralJet60MaxEta2p4
+    + hlt3PFPuppiCentralJet45MaxEta2p4
+    + hlt4PFPuppiCentralJet40MaxEta2p4
+    + hltHtMhtPFPuppiCentralJetsQuadC30MaxEta2p4
+    + hltPFPuppiCentralJetsQuad30HT330MaxEta2p4
+    + HLTBtagDeepFlavourSequencePFPuppiModEta2p4
+    + hltBTagPFPuppiDeepFlavour0p275Eta2p4TripleEta2p4
+    + HLTEndSequence
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_PFPuppiHT1070_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_PFPuppiHT1070_cfi.py
@@ -13,4 +13,17 @@ from ..sequences.HLTTrackingV61Sequence_cfi import *
 from ..sequences.HLTLocalrecoSequence_cfi import *
 from ..sequences.HLTRawToDigiSequence_cfi import *
 
-HLT_PFPuppiHT1070 = cms.Path(HLTBeginSequence+hltL1SeedsForPuppiHTFilter+HLTRawToDigiSequence+HLTHgcalLocalRecoSequence+HLTLocalrecoSequence+HLTTrackingV61Sequence+HLTMuonsSequence+HLTParticleFlowSequence+HLTAK4PFPuppiJetsReconstruction+hltPFPuppiHT+hltPFPuppiHT1070+HLTEndSequence)
+HLT_PFPuppiHT1070 = cms.Path(
+    HLTBeginSequence
+    + hltL1SeedsForPuppiHTFilter
+    + HLTRawToDigiSequence
+    + HLTHgcalLocalRecoSequence
+    + HLTLocalrecoSequence
+    + HLTTrackingV61Sequence
+    + HLTMuonsSequence
+    + HLTParticleFlowSequence
+    + HLTAK4PFPuppiJetsReconstruction
+    + hltPFPuppiHT
+    + hltPFPuppiHT1070
+    + HLTEndSequence
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_PFPuppiMETTypeOne140_PFPuppiMHT140_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_PFPuppiMETTypeOne140_PFPuppiMHT140_cfi.py
@@ -17,4 +17,21 @@ from ..sequences.HLTTrackingV61Sequence_cfi import *
 from ..sequences.HLTLocalrecoSequence_cfi import *
 from ..sequences.HLTRawToDigiSequence_cfi import *
 
-HLT_PFPuppiMETTypeOne140_PFPuppiMHT140 = cms.Path(HLTBeginSequence+hltL1SeedsForPuppiMETFilter+HLTRawToDigiSequence+HLTHgcalLocalRecoSequence+HLTLocalrecoSequence+HLTTrackingV61Sequence+HLTMuonsSequence+HLTParticleFlowSequence+HLTAK4PFPuppiJetsReconstruction+HLTPFPuppiMETReconstruction+hltPFPuppiMETTypeOneCorrector+hltPFPuppiMETTypeOne+hltPFPuppiMETTypeOne140+hltPFPuppiMHT+hltPFPuppiMHT140+HLTEndSequence)
+HLT_PFPuppiMETTypeOne140_PFPuppiMHT140 = cms.Path(
+    HLTBeginSequence
+    + hltL1SeedsForPuppiMETFilter
+    + HLTRawToDigiSequence
+    + HLTHgcalLocalRecoSequence
+    + HLTLocalrecoSequence
+    + HLTTrackingV61Sequence
+    + HLTMuonsSequence
+    + HLTParticleFlowSequence
+    + HLTAK4PFPuppiJetsReconstruction
+    + HLTPFPuppiMETReconstruction
+    + hltPFPuppiMETTypeOneCorrector
+    + hltPFPuppiMETTypeOne
+    + hltPFPuppiMETTypeOne140
+    + hltPFPuppiMHT
+    + hltPFPuppiMHT140
+    + HLTEndSequence
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_TriMu_10_5_5_DZ_FromL1TkMuon_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_TriMu_10_5_5_DZ_FromL1TkMuon_cfi.py
@@ -20,17 +20,18 @@ from ..modules.hltL3fL1TkTripleMu533PreFiltered555_cfi import *
 from ..modules.hltTripleMuon3DR0_cfi import *
 from ..modules.hltTripleMuon3DZ1p0_cfi import *
 
-HLT_TriMu_10_5_5_DZ_FromL1TkMuon = cms.Path(HLTBeginSequence
-    +hltTripleMuon3DZ1p0
-    +hltTripleMuon3DR0
-    +HLTRawToDigiSequence
-    +HLTItLocalRecoSequence
-    +HLTOtLocalRecoSequence
-    +hltPhase2PixelFitterByHelixProjections
-    +hltPhase2PixelTrackFilterByKinematics
-    +HLTMuonsSequence
-    +hltL3fL1TkTripleMu533PreFiltered555
-    +hltL3fL1TkTripleMu533L3Filtered1055
-    +hltL3fL1TkTripleMu533L31055DZFiltered0p2
-    +HLTEndSequence)
-#
+HLT_TriMu_10_5_5_DZ_FromL1TkMuon = cms.Path(
+    HLTBeginSequence
+    + hltTripleMuon3DZ1p0
+    + hltTripleMuon3DR0
+    + HLTRawToDigiSequence
+    + HLTItLocalRecoSequence
+    + HLTOtLocalRecoSequence
+    + hltPhase2PixelFitterByHelixProjections
+    + hltPhase2PixelTrackFilterByKinematics
+    + HLTMuonsSequence
+    + hltL3fL1TkTripleMu533PreFiltered555
+    + hltL3fL1TkTripleMu533L3Filtered1055
+    + hltL3fL1TkTripleMu533L31055DZFiltered0p2
+    + HLTEndSequence
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/paths/MC_BTV_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/MC_BTV_cfi.py
@@ -11,4 +11,15 @@ from ..sequences.HLTTrackingV61Sequence_cfi import *
 from ..sequences.HLTLocalrecoSequence_cfi import *
 from ..sequences.HLTRawToDigiSequence_cfi import *
 
-MC_BTV = cms.Path(HLTBeginSequence+HLTRawToDigiSequence+HLTHgcalLocalRecoSequence+HLTLocalrecoSequence+HLTTrackingV61Sequence+HLTMuonsSequence+HLTParticleFlowSequence+HLTAK4PFPuppiJetsReconstruction+HLTBtagDeepCSVSequencePFPuppi+HLTBtagDeepFlavourSequencePFPuppi)
+MC_BTV = cms.Path(
+    HLTBeginSequence
+    + HLTRawToDigiSequence
+    + HLTHgcalLocalRecoSequence
+    + HLTLocalrecoSequence
+    + HLTTrackingV61Sequence
+    + HLTMuonsSequence
+    + HLTParticleFlowSequence
+    + HLTAK4PFPuppiJetsReconstruction
+    + HLTBtagDeepCSVSequencePFPuppi
+    + HLTBtagDeepFlavourSequencePFPuppi
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/paths/MC_JME_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/MC_JME_cfi.py
@@ -12,4 +12,16 @@ from ..sequences.HLTTrackingV61Sequence_cfi import *
 from ..sequences.HLTLocalrecoSequence_cfi import *
 from ..sequences.HLTRawToDigiSequence_cfi import *
 
-MC_JME = cms.Path(HLTBeginSequence+HLTRawToDigiSequence+HLTHgcalLocalRecoSequence+HLTLocalrecoSequence+HLTTrackingV61Sequence+HLTMuonsSequence+HLTParticleFlowSequence+HLTHgcalTiclPFClusteringForEgamma+HLTJMESequence+hltPFPuppiHT+hltPFPuppiMHT)
+MC_JME = cms.Path(
+    HLTBeginSequence
+    + HLTRawToDigiSequence
+    + HLTHgcalLocalRecoSequence
+    + HLTLocalrecoSequence
+    + HLTTrackingV61Sequence
+    + HLTMuonsSequence
+    + HLTParticleFlowSequence
+    + HLTHgcalTiclPFClusteringForEgamma
+    + HLTJMESequence
+    + hltPFPuppiHT
+    + hltPFPuppiMHT
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTIter0Phase2L3FromL1TkSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTIter0Phase2L3FromL1TkSequence_cfi.py
@@ -6,4 +6,10 @@ from ..modules.hltIter0Phase2L3FromL1TkMuonPixelSeedsFromPixelTracks_cfi import 
 from ..modules.hltIter0Phase2L3FromL1TkMuonTrackCutClassifier_cfi import *
 from ..modules.hltIter0Phase2L3FromL1TkMuonTrackSelectionHighPurity_cfi import *
 
-HLTIter0Phase2L3FromL1TkSequence = cms.Sequence(hltIter0Phase2L3FromL1TkMuonPixelSeedsFromPixelTracks+hltIter0Phase2L3FromL1TkMuonCkfTrackCandidates+hltIter0Phase2L3FromL1TkMuonCtfWithMaterialTracks+hltIter0Phase2L3FromL1TkMuonTrackCutClassifier+hltIter0Phase2L3FromL1TkMuonTrackSelectionHighPurity)
+HLTIter0Phase2L3FromL1TkSequence = cms.Sequence(
+    hltIter0Phase2L3FromL1TkMuonPixelSeedsFromPixelTracks
+    + hltIter0Phase2L3FromL1TkMuonCkfTrackCandidates
+    + hltIter0Phase2L3FromL1TkMuonCtfWithMaterialTracks
+    + hltIter0Phase2L3FromL1TkMuonTrackCutClassifier
+    + hltIter0Phase2L3FromL1TkMuonTrackSelectionHighPurity
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTIter2Phase2L3FromL1TkSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTIter2Phase2L3FromL1TkSequence_cfi.py
@@ -14,4 +14,18 @@ from ..modules.hltIter2Phase2L3FromL1TkMuonPixelSeedsFiltered_cfi import *
 from ..modules.hltIter2Phase2L3FromL1TkMuonTrackCutClassifier_cfi import *
 from ..modules.hltIter2Phase2L3FromL1TkMuonTrackSelectionHighPurity_cfi import *
 
-HLTIter2Phase2L3FromL1TkSequence = cms.Sequence(hltIter2Phase2L3FromL1TkMuonClustersRefRemoval+hltIter2Phase2L3FromL1TkMuonMaskedMeasurementTrackerEvent+hltIter2Phase2L3FromL1TkMuonPixelLayerTriplets+hltIter2Phase2L3FromL1TkMuonPixelClusterCheck+hltIter2Phase2L3FromL1TkMuonPixelHitDoublets+hltIter2Phase2L3FromL1TkMuonPixelHitTriplets+hltIter2Phase2L3FromL1TkMuonPixelSeeds+hltIter2Phase2L3FromL1TkMuonPixelSeedsFiltered+hltIter2Phase2L3FromL1TkMuonCkfTrackCandidates+hltIter2Phase2L3FromL1TkMuonCtfWithMaterialTracks+hltIter2Phase2L3FromL1TkMuonTrackCutClassifier+hltIter2Phase2L3FromL1TkMuonTrackSelectionHighPurity+hltIter2Phase2L3FromL1TkMuonMerged)
+HLTIter2Phase2L3FromL1TkSequence = cms.Sequence(
+    hltIter2Phase2L3FromL1TkMuonClustersRefRemoval
+    + hltIter2Phase2L3FromL1TkMuonMaskedMeasurementTrackerEvent
+    + hltIter2Phase2L3FromL1TkMuonPixelLayerTriplets
+    + hltIter2Phase2L3FromL1TkMuonPixelClusterCheck
+    + hltIter2Phase2L3FromL1TkMuonPixelHitDoublets
+    + hltIter2Phase2L3FromL1TkMuonPixelHitTriplets
+    + hltIter2Phase2L3FromL1TkMuonPixelSeeds
+    + hltIter2Phase2L3FromL1TkMuonPixelSeedsFiltered
+    + hltIter2Phase2L3FromL1TkMuonCkfTrackCandidates
+    + hltIter2Phase2L3FromL1TkMuonCtfWithMaterialTracks
+    + hltIter2Phase2L3FromL1TkMuonTrackCutClassifier
+    + hltIter2Phase2L3FromL1TkMuonTrackSelectionHighPurity
+    + hltIter2Phase2L3FromL1TkMuonMerged
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTL2MuonsFromL1TkSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTL2MuonsFromL1TkSequence_cfi.py
@@ -5,4 +5,16 @@ from ..modules.hltL2MuonsFromL1TkMuon_cfi import *
 from ..modules.hltL2OfflineMuonSeeds_cfi import *
 from ..sequences.HLTMuonlocalrecoSequence_cfi import *
 
-HLTL2MuonsFromL1TkSequence = cms.Sequence(HLTMuonlocalrecoSequence+hltL2OfflineMuonSeeds+hltL2MuonSeedsFromL1TkMuon+hltL2MuonsFromL1TkMuon)
+HLTL2MuonsFromL1TkSequence = cms.Sequence(
+    HLTMuonlocalrecoSequence
+    + hltL2OfflineMuonSeeds
+    + hltL2MuonSeedsFromL1TkMuon
+    + hltL2MuonsFromL1TkMuon
+)
+
+from Configuration.ProcessModifiers.phase2L2AndL3Muons_cff import phase2L2AndL3Muons
+
+phase2L2AndL3Muons.toReplaceWith(
+    HLTL2MuonsFromL1TkSequence,
+    HLTL2MuonsFromL1TkSequence.copyAndExclude([hltL2OfflineMuonSeeds]),
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTMuonsSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTMuonsSequence_cfi.py
@@ -7,4 +7,44 @@ from ..sequences.HLTPhase2L3FromL1TkSequence_cfi import *
 from ..sequences.HLTPhase2L3MuonsSequence_cfi import *
 from ..sequences.HLTPhase2L3OISequence_cfi import *
 
-HLTMuonsSequence = cms.Sequence(HLTL2MuonsFromL1TkSequence+HLTPhase2L3OISequence+HLTPhase2L3FromL1TkSequence+HLTIter0Phase2L3FromL1TkSequence+HLTIter2Phase2L3FromL1TkSequence+HLTPhase2L3MuonsSequence)
+HLTMuonsSequence = cms.Sequence(
+    HLTL2MuonsFromL1TkSequence
+    + HLTPhase2L3OISequence
+    + HLTPhase2L3FromL1TkSequence
+    + HLTIter0Phase2L3FromL1TkSequence
+    + HLTIter2Phase2L3FromL1TkSequence
+    + HLTPhase2L3MuonsSequence
+)
+
+from ..modules.hltPhase2L3MuonFilter_cfi import *
+
+# The IO first HLT Muons sequence
+Phase2HLTMuonsSequenceIOFirst = cms.Sequence(
+    HLTL2MuonsFromL1TkSequence
+    + HLTPhase2L3FromL1TkSequence
+    + HLTIter0Phase2L3FromL1TkSequence
+    + HLTIter2Phase2L3FromL1TkSequence
+    + hltPhase2L3MuonFilter
+    + HLTPhase2L3OISequence
+    + HLTPhase2L3MuonsSequence
+)
+# The OI first HLT Muons sequence
+Phase2HLTMuonsSequenceOIFirst = cms.Sequence(
+    HLTL2MuonsFromL1TkSequence
+    + HLTPhase2L3OISequence
+    + hltPhase2L3MuonFilter
+    + HLTPhase2L3FromL1TkSequence
+    + HLTIter0Phase2L3FromL1TkSequence
+    + HLTIter2Phase2L3FromL1TkSequence
+    + HLTPhase2L3MuonsSequence
+)
+
+from Configuration.ProcessModifiers.phase2L2AndL3Muons_cff import phase2L2AndL3Muons
+
+phase2L2AndL3Muons.toReplaceWith(HLTMuonsSequence, Phase2HLTMuonsSequenceIOFirst)
+
+from Configuration.ProcessModifiers.phase2L3MuonsOIFirst_cff import phase2L3MuonsOIFirst
+
+(phase2L2AndL3Muons & phase2L3MuonsOIFirst).toReplaceWith(
+    HLTMuonsSequence, Phase2HLTMuonsSequenceOIFirst
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTPhase2L3FromL1TkSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTPhase2L3FromL1TkSequence_cfi.py
@@ -8,4 +8,12 @@ from ..modules.hltPhase2L3FromL1TkMuonPixelTracksTrackingRegions_cfi import *
 from ..modules.hltPhase2L3FromL1TkMuonPixelVertices_cfi import *
 from ..modules.hltPhase2L3FromL1TkMuonTrimmedPixelVertices_cfi import *
 
-HLTPhase2L3FromL1TkSequence = cms.Sequence(hltPhase2L3FromL1TkMuonPixelLayerQuadruplets+hltPhase2L3FromL1TkMuonPixelTracksTrackingRegions+hltPhase2L3FromL1TkMuonPixelTracksHitDoublets+hltPhase2L3FromL1TkMuonPixelTracksHitQuadruplets+hltPhase2L3FromL1TkMuonPixelTracks+hltPhase2L3FromL1TkMuonPixelVertices+hltPhase2L3FromL1TkMuonTrimmedPixelVertices)
+HLTPhase2L3FromL1TkSequence = cms.Sequence(
+    hltPhase2L3FromL1TkMuonPixelLayerQuadruplets
+    + hltPhase2L3FromL1TkMuonPixelTracksTrackingRegions
+    + hltPhase2L3FromL1TkMuonPixelTracksHitDoublets
+    + hltPhase2L3FromL1TkMuonPixelTracksHitQuadruplets
+    + hltPhase2L3FromL1TkMuonPixelTracks
+    + hltPhase2L3FromL1TkMuonPixelVertices
+    + hltPhase2L3FromL1TkMuonTrimmedPixelVertices
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTPhase2L3MuonsSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTPhase2L3MuonsSequence_cfi.py
@@ -6,4 +6,10 @@ from ..modules.hltPhase2L3Muons_cfi import *
 from ..modules.hltPhase2L3MuonsNoID_cfi import *
 from ..modules.hltPhase2L3MuonCandidates_cfi import *
 
-HLTPhase2L3MuonsSequence = cms.Sequence(hltPhase2L3MuonMerged+hltPhase2L3GlbMuon+hltPhase2L3MuonsNoID+hltPhase2L3Muons+hltPhase2L3MuonCandidates)
+HLTPhase2L3MuonsSequence = cms.Sequence(
+    hltPhase2L3MuonMerged
+    + hltPhase2L3GlbMuon
+    + hltPhase2L3MuonsNoID
+    + hltPhase2L3Muons
+    + hltPhase2L3MuonCandidates
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTPhase2L3OISequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTPhase2L3OISequence_cfi.py
@@ -6,4 +6,10 @@ from ..modules.hltPhase2L3OIMuonTrackSelectionHighPurity_cfi import *
 from ..modules.hltPhase2L3OISeedsFromL2Muons_cfi import *
 from ..modules.hltPhase2L3OITrackCandidates_cfi import *
 
-HLTPhase2L3OISequence = cms.Sequence(hltPhase2L3OISeedsFromL2Muons+hltPhase2L3OITrackCandidates+hltPhase2L3OIMuCtfWithMaterialTracks+hltPhase2L3OIMuonTrackCutClassifier+hltPhase2L3OIMuonTrackSelectionHighPurity)
+HLTPhase2L3OISequence = cms.Sequence(
+    hltPhase2L3OISeedsFromL2Muons
+    + hltPhase2L3OITrackCandidates
+    + hltPhase2L3OIMuCtfWithMaterialTracks
+    + hltPhase2L3OIMuonTrackCutClassifier
+    + hltPhase2L3OIMuonTrackSelectionHighPurity
+)

--- a/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
+++ b/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
@@ -251,7 +251,7 @@ def _appendPhase2Digis(obj):
         'keep *_TTClustersFromPhase2TrackerDigis_*_*',
         'keep *_l1tTTTracksFromExtendedTrackletEmulation_*_*',
         'keep *_l1tTTTracksFromTrackletEmulation_*_*',
-        'keep *_l1tTkStubsGmt_*_*',
+        'keep *_l1tStubsGmt_*_*',
         'keep *_l1tTkMuonsGmt_*_*',
         'keep *_l1tSAMuonsGmt_*_*',
         'keep *_l1tTkMuonsGmtLowPtFix_*_*', # in the long run this should be removed, but these fix objects will be used for now.

--- a/RecoMuon/L2MuonSeedGenerator/src/Phase2L2MuonSeedCreator.cc
+++ b/RecoMuon/L2MuonSeedGenerator/src/Phase2L2MuonSeedCreator.cc
@@ -1,0 +1,844 @@
+/**  \class phase2L2MuonSeedCreator
+ *   See header file for a description of this class
+ *   \author Luca Ferragina (INFN BO), 2024
+ */
+
+#include "RecoMuon/L2MuonSeedGenerator/src/Phase2L2MuonSeedCreator.h"
+#include "RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHit.h"
+#include "RecoMuon/TrackingTools/interface/MuonPatternRecoDumper.h"
+
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
+#include "TrackingTools/DetLayers/interface/DetLayer.h"
+
+#include "DataFormats/Common/interface/OwnVector.h"
+#include "DataFormats/CSCRecHit/interface/CSCSegmentCollection.h"
+#include "DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h"
+#include "DataFormats/GeometrySurface/interface/BoundCylinder.h"
+#include "DataFormats/L1TMuonPhase2/interface/TrackerMuon.h"
+#include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/MuonSeed/interface/L2MuonTrajectorySeed.h"
+#include "DataFormats/MuonSeed/interface/L2MuonTrajectorySeedCollection.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeed.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
+#include "DataFormats/TrajectoryState/interface/LocalTrajectoryParameters.h"
+#include "DataFormats/TrajectoryState/interface/PTrajectoryStateOnDet.h"
+
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "CLHEP/Vector/ThreeVector.h"
+
+#include <vector>
+
+// Constructor
+Phase2L2MuonSeedCreator::Phase2L2MuonSeedCreator(const edm::ParameterSet& pset)
+    : l1TkMuCollToken_{consumes(pset.getParameter<edm::InputTag>("InputObjects"))},
+      cscSegmentCollToken_{consumes(pset.getParameter<edm::InputTag>("CSCRecSegmentLabel"))},
+      dtSegmentCollToken_{consumes(pset.getParameter<edm::InputTag>("DTRecSegmentLabel"))},
+      cscGeometryToken_{esConsumes<CSCGeometry, MuonGeometryRecord>()},
+      dtGeometryToken_{esConsumes<DTGeometry, MuonGeometryRecord>()},
+      magneticFieldToken_{esConsumes<MagneticField, IdealMagneticFieldRecord>()},
+      minMomentum_{pset.getParameter<double>("MinPL1Tk")},
+      maxMomentum_{pset.getParameter<double>("MaxPL1Tk")},
+      matchingPhiWindow_{pset.getParameter<double>("stubMatchDPhi")},
+      matchingThetaWindow_{pset.getParameter<double>("stubMatchDTheta")},
+      extrapolationDeltaPhiClose_{pset.getParameter<double>("extrapolationWindowClose")},
+      extrapolationDeltaPhiFar_{pset.getParameter<double>("extrapolationWindowFar")},
+      maxEtaBarrel_{pset.getParameter<double>("maximumEtaBarrel")},
+      maxEtaOverlap_{pset.getParameter<double>("maximumEtaOverlap")},
+      propagatorName_{pset.getParameter<string>("Propagator")} {
+  // Service parameters
+  edm::ParameterSet serviceParameters = pset.getParameter<edm::ParameterSet>("ServiceParameters");
+  // Services
+  service_ = std::make_unique<MuonServiceProxy>(serviceParameters, consumesCollector());
+  estimator_ = std::make_unique<Chi2MeasurementEstimator>(10000.);
+  produces<L2MuonTrajectorySeedCollection>();
+}
+
+void Phase2L2MuonSeedCreator::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("InputObjects", edm::InputTag("l1tTkMuonsGmt"));
+  desc.add<edm::InputTag>("CSCRecSegmentLabel", edm::InputTag("hltCscSegments"));
+  desc.add<edm::InputTag>("DTRecSegmentLabel", edm::InputTag("hltDt4DSegments"));
+  desc.add<double>("MinPL1Tk", 3.5);
+  desc.add<double>("MaxPL1Tk", 200);
+  desc.add<double>("stubMatchDPhi", 0.05);
+  desc.add<double>("stubMatchDTheta", 0.1);
+  desc.add<double>("extrapolationWindowClose", 0.1);
+  desc.add<double>("extrapolationWindowFar", 0.05);
+  desc.add<double>("maximumEtaBarrel", 0.7);
+  desc.add<double>("maximumEtaOverlap", 1.3);
+  desc.add<string>("Propagator", "SteppingHelixPropagatorAny");
+
+  // Service parameters
+  edm::ParameterSetDescription psd0;
+  psd0.addUntracked<std::vector<std::string>>("Propagators", {"SteppingHelixPropagatorAny"});
+  psd0.add<bool>("RPCLayers", true);
+  psd0.addUntracked<bool>("UseMuonNavigation", true);
+  desc.add<edm::ParameterSetDescription>("ServiceParameters", psd0);
+  descriptions.add("Phase2L2MuonSeedCreator", desc);
+}
+
+void Phase2L2MuonSeedCreator::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  const std::string metname = "RecoMuon|Phase2L2MuonSeedCreator";
+
+  auto output = std::make_unique<L2MuonTrajectorySeedCollection>();
+
+  auto const l1TkMuColl = iEvent.getHandle(l1TkMuCollToken_);
+
+  auto cscHandle = iEvent.getHandle(cscSegmentCollToken_);
+  auto cscSegments = *cscHandle;
+  auto dtHandle = iEvent.getHandle(dtSegmentCollToken_);
+  auto dtSegments = *dtHandle;
+
+  cscGeometry_ = iSetup.getHandle(cscGeometryToken_);
+  dtGeometry_ = iSetup.getHandle(dtGeometryToken_);
+  magneticField_ = iSetup.getHandle(magneticFieldToken_);
+
+  LogDebug(metname) << "Number of L1 Tracker Muons in the Event: " << l1TkMuColl->size();
+
+  // Loop on all L1TkMu in event
+  for (size_t l1TkMuIndex = 0; l1TkMuIndex != l1TkMuColl->size(); ++l1TkMuIndex) {
+    l1t::TrackerMuonRef l1TkMuRef(l1TkMuColl, l1TkMuIndex);
+
+    // Physical info of L1TkMu
+    float pt = l1TkMuRef->phPt();
+    if (pt < minMomentum_) {
+      continue;
+    }
+    float eta = l1TkMuRef->phEta();
+    float theta = 2 * std::atan(std::exp(-eta));
+    float phi = l1TkMuRef->phPhi();
+    int charge = l1TkMuRef->phCharge();
+
+    LogDebug(metname) << "L1TKMu pT: " << pt << ", eta: " << eta << ", phi: " << phi;
+    Type muonType = overlap;
+    if (std::abs(eta) < maxEtaBarrel_) {
+      muonType = barrel;
+      LogDebug(metname) << "L1TkMu found in the barrel";
+    } else if (std::abs(eta) > maxEtaOverlap_) {
+      muonType = endcap;
+      LogDebug(metname) << "L1TkMu found in the endcap";
+    }
+
+    // Starting seed creation
+    LogDebug(metname) << "Start seed creation";
+
+    l1t::MuonStubRefVector stubRefs = l1TkMuRef->stubs();
+
+    LogDebug(metname) << "Number of stubs per L1TkMu: " << stubRefs.size();
+    LogDebug(metname) << "Number of DT segments in event: " << dtSegments.size();
+    LogDebug(metname) << "Number of CSC segments in event: " << cscSegments.size();
+
+    // Pairs segIndex, segQuality for matches in Barrel/Overlap/Endcap
+    std::map<DTChamberId, std::pair<int, int>> matchesInBarrel;
+    std::map<CSCDetId, std::pair<int, int>> matchesInEndcap;
+
+    // Matching info
+    bool atLeastOneMatch = false;
+    bool bestInDt = false;
+
+    // Variables for matches in Overlap
+    int totalBarrelQuality = 0;
+    int totalEndcapQuality = 0;
+    unsigned int nDtHits = 0;
+    unsigned int nCscHits = 0;
+
+    // Loop on L1TkMu stubs to find best association to DT/CSC segments
+    for (auto stub : stubRefs) {
+#ifdef EDM_ML_DEBUG
+      stub->print();
+#endif
+      // Separate barrel, endcap and overlap cases
+      switch (muonType) {
+        case barrel: {
+          if (!stub->isBarrel()) {
+            continue;  // skip all non-barrel stubs
+          }
+          // Create detId for stub
+          DTChamberId stubId = DTChamberId(stub->etaRegion(),       // wheel
+                                           stub->depthRegion(),     // station
+                                           stub->phiRegion() + 1);  // sector, online to offline
+          LogDebug(metname) << "Stub DT detId: " << stubId << ". RawId: " << stubId.rawId();
+
+          auto& tmpMatch = matchingStubSegment(stubId, stub, dtSegments, l1TkMuRef);
+
+          // Found a match -> update matching info
+          if (tmpMatch.first != -1) {
+            matchesInBarrel.emplace(stubId, tmpMatch);
+            atLeastOneMatch = true;
+            bestInDt = true;
+          }
+
+#ifdef EDM_ML_DEBUG
+          LogDebug(metname) << "BARREL best segments:";
+          for (const auto& [detId, matchingPair] : matchesInBarrel) {
+            LogDebug(metname) << "Station " << detId.station() << " (" << matchingPair.first << ", "
+                              << matchingPair.second << ")";
+          }
+#endif
+          break;
+        }  // End barrel
+
+        case endcap: {
+          if (!stub->isEndcap()) {
+            continue;  // skip all non-endcap stubs
+          }
+          // Create detId for stub
+          int endcap = (eta > 0) ? 1 : 2;  // CSC DetId endcap (1 -> Forward, 2 -> Backwards)
+          CSCDetId stubId = CSCDetId(endcap,
+                                     stub->depthRegion(),              // station
+                                     6 - std::abs(stub->etaRegion()),  // ring, online to offline
+                                     stub->phiRegion());               // chamber
+          LogDebug(metname) << "Stub CSC detId: " << stubId << ". RawId: " << stubId.rawId();
+
+          auto& tmpMatch = matchingStubSegment(stubId, stub, cscSegments, l1TkMuRef);
+
+          // Found a match -> update matching info
+          if (tmpMatch.first != -1) {
+            matchesInEndcap.emplace(stubId, tmpMatch);
+            atLeastOneMatch = true;
+          }
+
+#ifdef EDM_ML_DEBUG
+          LogDebug(metname) << "ENDCAP best segments:";
+          for (const auto& [detId, matchingPair] : matchesInEndcap) {
+            LogDebug(metname) << "Station " << detId.station() << " (" << matchingPair.first << ", "
+                              << matchingPair.second << ")";
+          }
+#endif
+          break;
+        }  // End endcap
+
+        case overlap: {
+          // Overlap runs on both DTs and CSCs and picks the best overall match
+          if (stub->isBarrel()) {
+            // Check DTs
+            LogDebug(metname) << "OVERLAP stub in DTs, checking " << dtSegments.size() << " DT segments";
+            // Create detId for stub
+            DTChamberId stubId = DTChamberId(stub->etaRegion(),       // wheel
+                                             stub->depthRegion(),     // station
+                                             stub->phiRegion() + 1);  // sector, online to offline
+            LogDebug(metname) << "Stub DT detId: " << stubId << ". RawId: " << stubId.rawId();
+
+            auto& tmpMatch = matchingStubSegment(stubId, stub, dtSegments, l1TkMuRef);
+            totalBarrelQuality += tmpMatch.second;
+
+            // Found a match -> update matching info
+            if (tmpMatch.first != -1) {
+              matchesInBarrel.emplace(stubId, tmpMatch);
+              atLeastOneMatch = true;
+              auto dtSegment = dtSegments.begin() + tmpMatch.first;
+              nDtHits += (dtSegment->hasPhi() ? dtSegment->phiSegment()->recHits().size() : 0);
+              nDtHits += (dtSegment->hasZed() ? dtSegment->zSegment()->recHits().size() : 0);
+            }
+
+#ifdef EDM_ML_DEBUG
+            LogDebug(metname) << "OVERLAP best segments in DTs:";
+            for (auto& [detId, matchingPair] : matchesInBarrel) {
+              LogDebug(metname) << "Station " << detId.station() << " (" << matchingPair.first << ", "
+                                << matchingPair.second << ")";
+            }
+#endif
+          } else if (stub->isEndcap()) {
+            // Check CSCs
+            LogDebug(metname) << "OVERLAP stub in CSCs, checking " << cscSegments.size() << " CSC segments";
+            int endcap = (eta > 0) ? 1 : 2;  // CSC DetId endcap (1 -> Forward, 2 -> Backwards)
+            CSCDetId stubId = CSCDetId(endcap,
+                                       stub->depthRegion(),              // station
+                                       6 - std::abs(stub->etaRegion()),  // ring, online to offline
+                                       stub->phiRegion());               // chamber
+            LogDebug(metname) << "Stub CSC detId: " << stubId << ". RawId: " << stubId.rawId();
+
+            auto& tmpMatch = matchingStubSegment(stubId, stub, cscSegments, l1TkMuRef);
+            totalEndcapQuality += tmpMatch.second;
+
+            // Found a match -> update matching info
+            if (tmpMatch.first != -1) {
+              matchesInEndcap.emplace(stubId, tmpMatch);
+              atLeastOneMatch = true;
+              auto cscSegment = cscSegments.begin() + tmpMatch.first;
+              nCscHits += cscSegment->nRecHits();
+            }
+
+#ifdef EDM_ML_DEBUG
+            LogDebug(metname) << "OVERLAP best segments in CSCs:";
+            for (auto& [detId, matchingPair] : matchesInEndcap) {
+              LogDebug(metname) << "Station " << detId.station() << " (" << matchingPair.first << ", "
+                                << matchingPair.second << ")";
+            }
+#endif
+          }
+
+          LogDebug(metname) << "OVERLAP comparing total qualities. DT: " << totalBarrelQuality
+                            << ", CSC: " << totalEndcapQuality;
+
+          // Pick segments in DTs / CSCs based on quality
+          bestInDt = (totalBarrelQuality > totalEndcapQuality) ? true : false;
+
+          // Same qualities, pick higher number of hits
+          if (totalBarrelQuality == totalEndcapQuality and totalBarrelQuality > -1) {
+            LogDebug(metname) << "Same quality " << totalBarrelQuality << ". Checking total number of hits";
+            LogDebug(metname) << "DT hits: " << nDtHits << ", CSC hits: " << nCscHits;
+            LogDebug(metname) << (nDtHits > nCscHits ? "More hits in DT segment" : "More hits in CSC segment");
+            bestInDt = (nDtHits >= nCscHits) ? true : false;
+          }
+#ifdef EDM_ML_DEBUG
+          LogDebug(metname) << "OVERLAP best segments:";
+          if (bestInDt) {
+            LogDebug(metname) << "OVERLAP best match in DTs:";
+            for (auto& [detId, matchingPair] : matchesInBarrel) {
+              LogDebug(metname) << "Station " << detId.station() << " (" << matchingPair.first << ", "
+                                << matchingPair.second << ")";
+            }
+          } else if (!bestInDt) {
+            LogDebug(metname) << "OVERLAP best match in CSCs:";
+            for (auto& [detId, matchingPair] : matchesInEndcap) {
+              LogDebug(metname) << "Station " << detId.station() << " (" << matchingPair.first << ", "
+                                << matchingPair.second << ")";
+            }
+          }
+#endif
+          break;
+        }  // End overlap
+
+        default:
+          edm::LogError("L1TkMu must be either barrel, endcap or overlap");
+          break;
+      }
+    }  // End loop on stubs
+
+    // Emplace seeds in output
+    if (!atLeastOneMatch) {
+      LogDebug(metname) << "No matching stub found, skipping seed";
+      continue;  // skip unmatched L1TkMu
+    } else {
+      // Info for propagation to MB2 or ME2
+      service_->update(iSetup);
+      const DetLayer* detLayer = nullptr;
+      float radius = 0.;
+
+      CLHEP::Hep3Vector vec(0., 1., 0.);
+      vec.setTheta(theta);
+      vec.setPhi(phi);
+
+      DetId propagateToId;
+
+      edm::OwnVector<TrackingRecHit> container;
+      if (bestInDt) {
+        // Found at least one matching segment in DT -> propagate to MB2
+        LogDebug(metname) << "Found matching segment(s) in DTs, propagating L1TkMu info to MB2 to seed";
+        // MB2
+        propagateToId = DTChamberId(0, 2, 0);
+        detLayer = service_->detLayerGeometry()->idToLayer(propagateToId);
+        const BoundSurface* sur = &(detLayer->surface());
+        const BoundCylinder* bc = dynamic_cast<const BoundCylinder*>(sur);
+        radius = std::abs(bc->radius() / sin(theta));
+
+        // Propagate matched segments to the seed and try to extrapolate in unmatched chambers
+        std::vector<int> matchedStations;
+        matchedStations.reserve(4);
+        for (auto& [detId, matchingPair] : matchesInBarrel) {
+          // Add matched segments to the seed
+          LogDebug(metname) << "Adding matched DT segment in station " << detId.station() << " to the seed";
+          container.push_back(dtSegments[matchingPair.first]);
+          matchedStations.push_back(detId.station());
+        }
+        for (int station = 1; station != 5; ++station) {
+          if (std::find(matchedStations.begin(), matchedStations.end(), station) == matchedStations.end()) {
+            // Try to extrapolate from stations with a match to the ones without
+            LogDebug(metname) << "No matching DT segment found in station " << station;
+            auto extrapolatedMatch = extrapolateToNearbyStation(station, matchesInBarrel, dtSegments);
+            if (extrapolatedMatch.first != -1) {
+              LogDebug(metname) << "Adding extrapolated DT segment " << extrapolatedMatch.first << " with quality "
+                                << extrapolatedMatch.second << " found in station " << station << " to the seed";
+              container.push_back(dtSegments[extrapolatedMatch.first]);
+            }
+          }
+        }
+      } else if (!bestInDt) {
+        // Found a matching segment in CSC -> propagate to ME2
+        LogDebug(metname) << "Found matching segment(s) in CSCs, propagating L1TkMu info to ME2 to seed";
+        // ME2
+        propagateToId = eta > 0 ? CSCDetId(1, 2, 0, 0, 0) : CSCDetId(2, 2, 0, 0, 0);
+        detLayer = service_->detLayerGeometry()->idToLayer(propagateToId);
+        radius = std::abs(detLayer->position().z() / cos(theta));
+
+        // Fill seed with matched segment(s)
+        for (auto& [detId, matchingPair] : matchesInEndcap) {
+          LogDebug(metname) << "Adding matched CSC segment in station " << detId.station() << " to the seed";
+          container.push_back(cscSegments[matchingPair.first]);
+        }
+      }
+      vec.setMag(radius);
+      // Get Global point and direction
+      GlobalPoint pos(vec.x(), vec.y(), vec.z());
+      GlobalVector mom(pt * cos(phi), pt * sin(phi), pt * cos(theta) / sin(theta));
+
+      GlobalTrajectoryParameters param(pos, mom, charge, &*magneticField_);
+
+      AlgebraicSymMatrix55 mat;
+
+      mat[0][0] = bestInDt ? (0.25 / pt) * (0.25 / pt) : (0.4 / pt) * (0.4 / pt);  // sigma^2(charge/abs_momentum)
+      mat[1][1] = 0.05 * 0.05;                                                     // sigma^2(lambda)
+      mat[2][2] = 0.2 * 0.2;                                                       // sigma^2(phi)
+      mat[3][3] = 20. * 20.;                                                       // sigma^2(x_transverse)
+      mat[4][4] = 20. * 20.;                                                       // sigma^2(y_transverse)
+
+      CurvilinearTrajectoryError error(mat);
+
+      const FreeTrajectoryState state(param, error);
+
+      // Create the TrajectoryStateOnSurface
+      TrajectoryStateOnSurface tsos = service_->propagator(propagatorName_)->propagate(state, detLayer->surface());
+      // Find valid detectors with states
+      auto detsWithStates = detLayer->compatibleDets(tsos, *service_->propagator(propagatorName_), *estimator_);
+      // Check that at least one valid detector was found
+      if (detsWithStates.size() > 0) {
+        // Update the detId with the one from the first valid detector with measurments found
+        propagateToId = detsWithStates.front().first->geographicalId();
+        // Create the Trajectory State on that detector's surface
+        tsos = detsWithStates.front().second;
+      } else if (detsWithStates.empty() and bestInDt) {
+        // Propagation to MB2 failed, fallback to ME2 (might be an overlap edge case)
+        LogDebug(metname) << "Warning: detsWithStates collection is empty for a barrel collection. Falling back to ME2";
+        // Get ME2 DetLayer
+        DetId fallback_id;
+        theta < Geom::pi() / 2. ? fallback_id = CSCDetId(1, 2, 0, 0, 0) : fallback_id = CSCDetId(2, 2, 0, 0, 0);
+        const DetLayer* ME2DetLayer = service_->detLayerGeometry()->idToLayer(fallback_id);
+        // Trajectory state on ME2 DetLayer
+        tsos = service_->propagator(propagatorName_)->propagate(state, ME2DetLayer->surface());
+        // Find the detectors with states on ME2
+        detsWithStates = ME2DetLayer->compatibleDets(tsos, *service_->propagator(propagatorName_), *estimator_);
+      }
+      // Use the valid detector found to produce the persistentState for the seed
+      if (!detsWithStates.empty()) {
+        LogDebug(metname) << "Found a compatible detWithStates";
+        TrajectoryStateOnSurface newTSOS = detsWithStates.front().second;
+        const GeomDet* newTSOSDet = detsWithStates.front().first;
+        LogDebug(metname) << "Most compatible detector: " << newTSOSDet->geographicalId().rawId();
+        if (newTSOS.isValid()) {
+          LogDebug(metname) << "pos: (r=" << newTSOS.globalPosition().mag()
+                            << ", phi=" << newTSOS.globalPosition().phi() << ", eta=" << newTSOS.globalPosition().eta()
+                            << ")";
+          LogDebug(metname) << "mom: (q*pt=" << newTSOS.charge() * newTSOS.globalMomentum().perp()
+                            << ", phi=" << newTSOS.globalMomentum().phi() << ", eta=" << newTSOS.globalMomentum().eta()
+                            << ")";
+          // Transform the TrajectoryStateOnSurface in a Persistent TrajectoryStateOnDet
+          const PTrajectoryStateOnDet& seedTSOS =
+              trajectoryStateTransform::persistentState(newTSOS, newTSOSDet->geographicalId().rawId());
+
+          // Emplace seed in output
+          LogDebug(metname) << "Emplacing seed in output";
+          output->emplace_back(L2MuonTrajectorySeed(seedTSOS, container, alongMomentum, l1TkMuRef));
+        }
+      }
+    }  // End seed emplacing (one seed per L1TkMu)
+  }  // End loop on L1TkMu
+  LogDebug(metname) << "All L1TkMu in event processed";
+  iEvent.put(std::move(output));
+}
+
+// In DT station 4 the top and bottom sectors are made of two chambers
+// due to material requirements. Online is not split:
+// Online sector 4 == offline sector 4 or 13, Online sector 10 == offline sector 10 or 14
+const std::vector<DTChamberId> Phase2L2MuonSeedCreator::matchingIds(const DTChamberId& stubId) const {
+  std::vector<DTChamberId> matchingDtIds;
+  matchingDtIds.reserve(2);
+  matchingDtIds.push_back(stubId);
+  if (stubId.station() == 4) {
+    if (stubId.sector() == 4) {
+      matchingDtIds.emplace_back(DTChamberId(stubId.wheel(), stubId.station(), 13));
+    }
+    if (stubId.sector() == 10) {
+      matchingDtIds.emplace_back(DTChamberId(stubId.wheel(), stubId.station(), 14));
+    }
+  }
+  return matchingDtIds;
+}
+
+// Pair bestSegIndex, quality for DT segments matching
+const std::pair<int, int> Phase2L2MuonSeedCreator::matchingStubSegment(const DTChamberId& stubId,
+                                                                       const l1t::MuonStubRef stub,
+                                                                       const DTRecSegment4DCollection& segments,
+                                                                       const l1t::TrackerMuonRef l1TkMuRef) const {
+  const std::string metname = "RecoMuon|Phase2L2MuonSeedCreator";
+
+  int bestSegIndex = -1;
+  int quality = -1;
+  unsigned int nHitsPhiBest = 0;
+  unsigned int nHitsThetaBest = 0;
+
+  LogDebug(metname) << "Matching stub with DT segment";
+  int nMatchingIds = 0;
+
+  for (DTChamberId id : matchingIds(stubId)) {
+    DTRecSegment4DCollection::range segmentsInChamber = segments.get(id);
+    for (DTRecSegment4DCollection::const_iterator segment = segmentsInChamber.first;
+         segment != segmentsInChamber.second;
+         ++segment) {
+      ++nMatchingIds;
+      DTChamberId segId = segment->chamberId();
+      LogDebug(metname) << "Segment DT detId: " << segId << ". RawId: " << segId.rawId();
+
+      // Global position of the segment
+      GlobalPoint segPos = dtGeometry_->idToDet(segId)->toGlobal(segment->localPosition());
+
+      // Check delta phi
+      double deltaPhi = std::abs(segPos.phi() - stub->offline_coord1());
+      LogDebug(metname) << "deltaPhi: " << deltaPhi;
+
+      double deltaTheta = std::abs(segPos.theta() - 2 * std::atan(std::exp(-l1TkMuRef->phEta())));
+      LogDebug(metname) << "deltaTheta: " << deltaTheta;
+
+      // Skip segments outside phi window or very far in the theta view
+      if (deltaPhi > matchingPhiWindow_ or deltaTheta > 4 * matchingThetaWindow_) {
+        continue;
+      }
+
+      // Inside phi window -> check hit multiplicity
+      unsigned int nHitsPhi = (segment->hasPhi() ? segment->phiSegment()->recHits().size() : 0);
+      unsigned int nHitsTheta = (segment->hasZed() ? segment->zSegment()->recHits().size() : 0);
+      LogDebug(metname) << "DT found match in deltaPhi: " << std::distance(segments.begin(), segment) << " with "
+                        << nHitsPhi << " hits in phi and " << nHitsTheta << " hits in theta";
+
+      if (nHitsPhi == nHitsPhiBest and segment->hasZed()) {
+        // Same phi hit multiplicity -> check delta theta
+        LogDebug(metname) << "DT found segment with same hits in phi as previous best (" << nHitsPhiBest
+                          << "), checking theta window";
+
+        // More precise check in theta window
+        if (deltaTheta > matchingThetaWindow_) {
+          continue;  // skip segments outside theta window
+        }
+
+        LogDebug(metname) << "DT found match in deltaTheta: " << std::distance(segments.begin(), segment) << " with "
+                          << nHitsPhi << " hits in phi and " << nHitsTheta << " hits in theta";
+
+        // Inside theta window -> check hit multiplicity (theta)
+        if (nHitsTheta > nHitsThetaBest) {
+          // More hits in theta -> update bestSegment and quality
+          LogDebug(metname) << "DT found segment with more hits in theta than previous best";
+          bestSegIndex = std::distance(segments.begin(), segment);
+          quality = 2;
+          LogDebug(metname) << "DT updating bestSegIndex (nHitsTheta): " << bestSegIndex << " with "
+                            << nHitsPhi + nHitsTheta << ">" << nHitsPhiBest + nHitsThetaBest
+                            << " total hits and quality " << quality;
+          nHitsThetaBest = nHitsTheta;
+        }
+      } else if (nHitsPhi > nHitsPhiBest) {
+        // More hits in phi -> update bestSegment and quality
+        LogDebug(metname) << "DT found segment with more hits in phi than previous best";
+        bestSegIndex = std::distance(segments.begin(), segment);
+        quality = 1;
+        LogDebug(metname) << "DT updating bestSegIndex (nHitsPhi): " << bestSegIndex << " with " << nHitsPhi << ">"
+                          << nHitsPhiBest << " hits in phi, " << nHitsTheta << " hits in theta and quality " << quality;
+        nHitsPhiBest = nHitsPhi;
+        nHitsThetaBest = nHitsTheta;
+      }
+    }  // End loop on segments
+  }
+
+  LogDebug(metname) << "DT looped over " << nMatchingIds << (nMatchingIds > 1 ? " segments" : " segment")
+                    << " with same DT detId as stub";
+
+  if (quality < 0) {
+    LogDebug(metname) << "DT proposed match: " << bestSegIndex << " with quality " << quality << ". Not good enough!";
+    return std::make_pair(-1, -1);
+  } else {
+    LogDebug(metname) << "Found DT segment match";
+    LogDebug(metname) << "New DT segment: " << bestSegIndex << " with " << nHitsPhiBest + nHitsThetaBest
+                      << " total hits and quality " << quality;
+    return std::make_pair(bestSegIndex, quality);
+  }
+}
+
+// Match online-level CSCDetIds to offline labels
+const std::vector<CSCDetId> Phase2L2MuonSeedCreator::matchingIds(const CSCDetId& stubId) const {
+  std::vector<CSCDetId> matchingCscIds;
+  matchingCscIds.push_back(stubId);
+
+  if (stubId.station() == 1 and stubId.ring() == 1) {
+    matchingCscIds.emplace_back(CSCDetId(stubId.endcap(), stubId.station(), 4, stubId.chamber()));
+  }
+
+  return matchingCscIds;
+}
+
+// Pair bestSegIndex, quality for CSC segments matching
+const std::pair<int, int> Phase2L2MuonSeedCreator::matchingStubSegment(const CSCDetId& stubId,
+                                                                       const l1t::MuonStubRef stub,
+                                                                       const CSCSegmentCollection& segments,
+                                                                       const l1t::TrackerMuonRef l1TkMuRef) const {
+  const std::string metname = "RecoMuon|Phase2L2MuonSeedCreator";
+
+  int bestSegIndex = -1;
+  int quality = -1;
+  unsigned int nHitsBest = 0;
+
+  LogDebug(metname) << "Matching stub with CSC segment";
+  int nMatchingIds = 0;
+  for (CSCDetId id : matchingIds(stubId)) {
+    CSCSegmentCollection::range segmentsInChamber = segments.get(id);
+    for (CSCSegmentCollection::const_iterator segment = segmentsInChamber.first; segment != segmentsInChamber.second;
+         ++segment) {
+      ++nMatchingIds;
+      CSCDetId segId = segment->cscDetId();
+      LogDebug(metname) << "Segment CSC detId: " << segId << ". RawId: " << segId.rawId();
+
+      // Global position of the segment
+      GlobalPoint segPos = cscGeometry_->idToDet(segId)->toGlobal(segment->localPosition());
+
+      // Check delta phi
+      double deltaPhi = std::abs(segPos.phi() - stub->offline_coord1());
+      LogDebug(metname) << "deltaPhi: " << deltaPhi;
+
+      double deltaTheta = std::abs(segPos.theta() - 2 * std::atan(std::exp(-l1TkMuRef->phEta())));
+      LogDebug(metname) << "deltaTheta: " << deltaTheta;
+
+      if (deltaPhi > matchingPhiWindow_ or deltaTheta > 0.4) {
+        continue;  // skip segments outside phi window
+      }
+
+      // Inside phi window -> check hit multiplicity
+      unsigned int nHits = segment->nRecHits();
+      LogDebug(metname) << "CSC found match in deltaPhi: " << std::distance(segments.begin(), segment) << " with "
+                        << nHits << " hits";
+
+      if (nHits == nHitsBest) {
+        // Same hit multiplicity -> check delta theta
+        LogDebug(metname) << "Found CSC segment with same hits (" << nHitsBest
+                          << ") as previous best, checking theta window";
+
+        if (deltaTheta > matchingThetaWindow_) {
+          continue;  // skip segments outside theta window
+        }
+
+        // Inside theta window -> update bestSegment and quality
+        bestSegIndex = std::distance(segments.begin(), segment);
+        quality = 1;
+        LogDebug(metname) << "CSC found match in deltaTheta: " << bestSegIndex << " with " << nHits
+                          << " hits and quality " << quality;
+      } else if (nHits > nHitsBest) {
+        // More hits -> update bestSegment and quality
+        bestSegIndex = std::distance(segments.begin(), segment);
+        quality = 2;
+        LogDebug(metname) << "Found CSC segment with more hits. Index: " << bestSegIndex << " with " << nHits << ">"
+                          << nHitsBest << " hits and quality " << quality;
+        nHitsBest = nHits;
+      }
+    }  // End loop on segments
+  }
+
+  LogDebug(metname) << "CSC looped over " << nMatchingIds << (nMatchingIds != 1 ? " segments" : " segment")
+                    << " with same CSC detId as stub";
+
+  if (quality < 0) {
+    LogDebug(metname) << "CSC proposed match: " << bestSegIndex << " with quality " << quality << ". Not good enough!";
+    return std::make_pair(-1, -1);
+  } else {
+    LogDebug(metname) << "Found CSC segment match";
+    LogDebug(metname) << "New CSC segment: " << bestSegIndex << " with " << nHitsBest << " hits and quality "
+                      << quality;
+    return std::make_pair(bestSegIndex, quality);
+  }
+}
+
+const std::pair<int, int> Phase2L2MuonSeedCreator::extrapolateToNearbyStation(
+    const int endingStation,
+    const std::map<DTChamberId, std::pair<int, int>>& matchesInBarrel,
+    const DTRecSegment4DCollection& segments) const {
+  const std::string metname = "RecoMuon|Phase2L2MuonSeedCreator";
+
+  std::pair<int, int> extrapolatedMatch = std::make_pair(-1, -1);
+  bool foundExtrapolatedMatch = false;
+  switch (endingStation) {
+    case 1: {
+      // Station 1. Extrapolate 2->1 or 3->1 (4->1)
+      int startingStation = 2;
+      while (startingStation < 5) {
+        for (auto& [detId, matchingPair] : matchesInBarrel) {
+          if (detId.station() == startingStation) {
+            LogDebug(metname) << "Extrapolating from station " << startingStation << " to station " << endingStation;
+            extrapolatedMatch = extrapolateMatch(matchingPair.first, endingStation, segments);
+            if (extrapolatedMatch.first != -1) {
+              LogDebug(metname) << "Found extrapolated match in station " << endingStation << " from station "
+                                << startingStation;
+              foundExtrapolatedMatch = true;
+              break;
+            }
+          }
+        }
+        if (foundExtrapolatedMatch) {
+          break;
+        }
+        ++startingStation;
+      }
+      break;
+    }
+    case 2: {
+      // Station 2. Extrapolate 1->2 or 3->2 (4->2)
+      int startingStation = 1;
+      while (startingStation < 5) {
+        for (auto& [detId, matchingPair] : matchesInBarrel) {
+          if (detId.station() == startingStation) {
+            LogDebug(metname) << "Extrapolating from station " << startingStation << " to station " << endingStation;
+            extrapolatedMatch = extrapolateMatch(matchingPair.first, endingStation, segments);
+            if (extrapolatedMatch.first != -1) {
+              LogDebug(metname) << "Found extrapolated match in station " << endingStation << " from station "
+                                << startingStation;
+              foundExtrapolatedMatch = true;
+              break;
+            }
+          }
+        }
+        if (foundExtrapolatedMatch) {
+          break;
+        }
+        startingStation = startingStation == 1 ? startingStation + 2 : startingStation + 1;
+      }
+      break;
+    }
+    case 3: {
+      // Station 3. Extrapolate 2->3 or 4->3 (1->3)
+      int startingStation = 2;
+      while (startingStation > 0) {
+        for (auto& [detId, matchingPair] : matchesInBarrel) {
+          if (detId.station() == startingStation) {
+            LogDebug(metname) << "Extrapolating from station " << startingStation << " to station " << endingStation;
+            extrapolatedMatch = extrapolateMatch(matchingPair.first, endingStation, segments);
+            if (extrapolatedMatch.first != -1) {
+              LogDebug(metname) << "Found extrapolated match in station " << endingStation << " from station "
+                                << startingStation;
+              foundExtrapolatedMatch = true;
+              break;
+            }
+          }
+        }
+        if (foundExtrapolatedMatch) {
+          break;
+        }
+        startingStation = startingStation == 2 ? startingStation + 2 : startingStation - 3;
+      }
+      break;
+    }
+    case 4: {
+      // Station 4. Extrapolate 2->4 or 3->4 (1->4)
+      int startingStation = 2;
+      while (startingStation > 0) {
+        for (auto& [detId, matchingPair] : matchesInBarrel) {
+          if (detId.station() == startingStation) {
+            LogDebug(metname) << "Extrapolating from station " << startingStation << " to station " << endingStation;
+            extrapolatedMatch = extrapolateMatch(matchingPair.first, endingStation, segments);
+            if (extrapolatedMatch.first != -1) {
+              LogDebug(metname) << "Found extrapolated match in station " << endingStation << " from station "
+                                << startingStation;
+              foundExtrapolatedMatch = true;
+              break;
+            }
+          }
+        }
+        if (foundExtrapolatedMatch) {
+          break;
+        }
+        startingStation = startingStation == 2 ? startingStation + 1 : startingStation - 2;
+      }
+      break;
+    }
+    default:
+      std::cerr << "Muon stations only go from 1 to 4" << std::endl;
+      break;
+  }  // end endingStation switch
+  return extrapolatedMatch;
+}
+
+const std::pair<int, int> Phase2L2MuonSeedCreator::extrapolateMatch(const int bestStartingSegIndex,
+                                                                    const int endingStation,
+                                                                    const DTRecSegment4DCollection& segments) const {
+  const std::string metname = "RecoMuon|Phase2L2MuonSeedCreator";
+
+  const auto& segmentInStartingStation = segments.begin() + bestStartingSegIndex;
+  auto matchId = segmentInStartingStation->chamberId();
+  GlobalPoint matchPos = dtGeometry_->idToDet(matchId)->toGlobal(segmentInStartingStation->localPosition());
+
+  int bestSegIndex = -1;
+  int quality = -1;
+  unsigned int nHitsPhiBest = 0;
+  unsigned int nHitsThetaBest = 0;
+
+  // Find possible extrapolation from startingStation to endingStation
+  for (DTRecSegment4DCollection::const_iterator segment = segments.begin(), last = segments.end(); segment != last;
+       ++segment) {
+    auto segId = segment->chamberId();
+
+    if (segId.station() != endingStation) {
+      continue;  // skip segments outside of endingStation
+    }
+
+    // Global positions of the segment
+    GlobalPoint segPos = dtGeometry_->idToDet(segId)->toGlobal(segment->localPosition());
+
+    double deltaPhi = std::abs(segPos.phi() - matchPos.phi());
+    LogDebug(metname) << "Extrapolation deltaPhi: " << deltaPhi;
+
+    double deltaTheta = std::abs(segPos.theta() - matchPos.theta());
+    LogDebug(metname) << "Extrapolation deltaTheta: " << deltaTheta;
+
+    double matchingDeltaPhi =
+        std::abs(matchId.station() - endingStation) == 1 ? extrapolationDeltaPhiClose_ : extrapolationDeltaPhiFar_;
+
+    if (deltaPhi > matchingDeltaPhi or deltaTheta > 0.4) {
+      continue;
+    }
+
+    // Inside phi window -> check hit multiplicity
+    unsigned int nHitsPhi = (segment->hasPhi() ? segment->phiSegment()->recHits().size() : 0);
+    unsigned int nHitsTheta = (segment->hasZed() ? segment->zSegment()->recHits().size() : 0);
+    LogDebug(metname) << "Extrapolation found match in deltaPhi: " << std::distance(segments.begin(), segment)
+                      << " with " << nHitsPhi << " hits in phi and " << nHitsTheta << " hits in theta";
+
+    if (nHitsPhi == nHitsPhiBest and segment->hasZed()) {
+      // Same phi hit multiplicity -> check delta theta
+      LogDebug(metname) << "Extrapolation found segment with same hits in phi as previous best (" << nHitsPhiBest
+                        << "), checking theta window";
+      double deltaTheta = std::abs(segPos.theta() - matchPos.theta());
+      LogDebug(metname) << "Extrapolation deltaTheta: " << deltaTheta;
+
+      if (deltaTheta > matchingThetaWindow_) {
+        continue;  // skip segments outside theta window
+      }
+
+      LogDebug(metname) << "Extrapolation found match in deltaTheta: " << std::distance(segments.begin(), segment)
+                        << " with " << nHitsPhi << " hits in phi and " << nHitsTheta << " hits in theta";
+
+      // Inside theta window -> check hit multiplicity (theta)
+      if (nHitsTheta > nHitsThetaBest) {
+        // More hits in theta -> update bestSegment and quality
+        LogDebug(metname) << "Extrapolation found segment with more hits in theta than previous best";
+        bestSegIndex = std::distance(segments.begin(), segment);
+        quality = 2;
+        LogDebug(metname) << "Extrapolation updating bestSegIndex (nHitsTheta): " << bestSegIndex << " with "
+                          << nHitsPhi + nHitsTheta << ">" << nHitsPhiBest + nHitsThetaBest << " total hits and quality "
+                          << quality;
+        nHitsThetaBest = nHitsTheta;
+      }
+    } else if (nHitsPhi > nHitsPhiBest) {
+      // More hits in phi -> update bestSegment and quality
+      LogDebug(metname) << "Extrapolation found segment with more hits in phi than previous best";
+      bestSegIndex = std::distance(segments.begin(), segment);
+      quality = 1;
+      LogDebug(metname) << "Extrapolation updating bestSegIndex (nHitsPhi): " << bestSegIndex << " with " << nHitsPhi
+                        << ">" << nHitsPhiBest << " hits in phi, " << nHitsTheta << " hits in theta and quality "
+                        << quality;
+      nHitsPhiBest = nHitsPhi;
+      nHitsThetaBest = nHitsTheta;
+    }
+  }  // end loop on segments
+  return std::make_pair(bestSegIndex, quality);
+}
+
+DEFINE_FWK_MODULE(Phase2L2MuonSeedCreator);

--- a/RecoMuon/L2MuonSeedGenerator/src/Phase2L2MuonSeedCreator.h
+++ b/RecoMuon/L2MuonSeedGenerator/src/Phase2L2MuonSeedCreator.h
@@ -1,0 +1,152 @@
+#ifndef RecoMuon_L2MuonSeedCreator_Phase2L2MuonSeedCreator_H
+#define RecoMuon_L2MuonSeedCreator_Phase2L2MuonSeedCreator_H
+
+/** \class Phase2L2MuonSeedCreator
+ * 
+ *  Standalone Muon seeds for Phase-2
+ *  This class takes in input the full L1 Tracker Muon collection
+ *  and the collections of (DT/CSC) segments in the muon chambers.
+ *  For each L1 Tracker Muon, the stubs used to produce it are 
+ *  matched with segments in the muon chambers looking, in order,
+ *  at deltaPhi, number of hits, and deltaTheta. All matched segments
+ *  are added to the seed, together with the pT information from the
+ *  tracker muon itself. Specifically for the barrel region and in 
+ *  stations where no stub is found, a simple extrapolation is 
+ *  attempted from nearby stations with a match (e.g no stub found in 
+ *  station 2, attempt to match segments extrapolating from station
+ *  1, 3, and 4 in this order).
+ * 
+ *  The logic allows a single-step extension to seed displaced muons
+ *  (currently not implemented)
+ * 
+ *  \author Luca Ferragina (INFN BO), 2024
+ */
+
+#include "DataFormats/MuonSeed/interface/L2MuonTrajectorySeed.h"
+#include "DataFormats/L1TMuonPhase2/interface/TrackerMuon.h"
+
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "DataFormats/L1TMuonPhase2/interface/MuonStub.h"
+#include "DataFormats/CSCRecHit/interface/CSCSegment.h"
+#include "DataFormats/DTRecHit/interface/DTRecSegment4D.h"
+#include "DataFormats/MuonDetId/interface/DTChamberId.h"
+#include "DataFormats/MuonDetId/interface/CSCDetId.h"
+
+#include "Geometry/CSCGeometry/interface/CSCGeometry.h"
+#include "Geometry/DTGeometry/interface/DTGeometry.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+
+#include "RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHit.h"
+#include "RecoMuon/MeasurementDet/interface/MuonDetLayerMeasurements.h"
+#include "RecoMuon/DetLayers/interface/MuonDetLayerGeometry.h"
+#include "RecoMuon/Records/interface/MuonRecoGeometryRecord.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h"
+
+#include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
+
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
+
+#include <map>
+#include <utility>
+
+class RecHit;
+class Plane;
+class GeomDet;
+class MagneticField;
+class MuonTransientTrackingRecHit;
+
+enum Type { barrel, overlap, endcap };
+
+class Phase2L2MuonSeedCreator : public edm::stream::EDProducer<> {
+public:
+  typedef MuonTransientTrackingRecHit::MuonRecHitContainer SegmentContainer;
+
+  // Constructor
+  explicit Phase2L2MuonSeedCreator(const edm::ParameterSet& pset);
+
+  // Destructor
+  ~Phase2L2MuonSeedCreator() override = default;
+
+  // Operations
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+private:
+  // Tokens
+  const edm::EDGetTokenT<l1t::TrackerMuonCollection> l1TkMuCollToken_;
+  const edm::EDGetTokenT<CSCSegmentCollection> cscSegmentCollToken_;
+  const edm::EDGetTokenT<DTRecSegment4DCollection> dtSegmentCollToken_;
+
+  const edm::ESGetToken<CSCGeometry, MuonGeometryRecord> cscGeometryToken_;
+  const edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeometryToken_;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magneticFieldToken_;
+
+  // Miminum and maximum pt momentum of a track
+  const double minMomentum_;
+  const double maxMomentum_;
+
+  // Parameters to match L1 stubs to DT/CSC segments
+  const double matchingPhiWindow_;
+  const double matchingThetaWindow_;
+
+  // Parameters to extrapolate matches in nearby stations
+  const double extrapolationDeltaPhiClose_;
+  const double extrapolationDeltaPhiFar_;
+
+  const double maxEtaBarrel_;   // barrel with |eta| < 0.7
+  const double maxEtaOverlap_;  // overlap with |eta| < 1.3, endcap after that
+
+  // Handles
+  edm::ESHandle<MagneticField> magneticField_;
+  edm::ESHandle<CSCGeometry> cscGeometry_;
+  edm::ESHandle<DTGeometry> dtGeometry_;
+
+  std::unique_ptr<MuonServiceProxy> service_;
+  std::unique_ptr<MeasurementEstimator> estimator_;
+
+  const std::string propagatorName_;
+
+  // In DT station 4 the top and bottom sectors are made of two chambers
+  // due to material requirements. Online is not split:
+  // Online sector 4 == offline sector 4 or 10, Online sector 10 == offline sector 10 or 14
+  const std::vector<DTChamberId> matchingIds(const DTChamberId& stubId) const;
+
+  // Match online-level CSCDetIds with offline
+  const std::vector<CSCDetId> matchingIds(const CSCDetId& stubId) const;
+
+  // Logic to match L1 stubs to DT segments
+  const std::pair<int, int> matchingStubSegment(const DTChamberId& stubId,
+                                                const l1t::MuonStubRef stub,
+                                                const DTRecSegment4DCollection& segments,
+                                                const l1t::TrackerMuonRef l1TkMuRef) const;
+
+  // Logic to match L1 stubs to CSC segments
+  const std::pair<int, int> matchingStubSegment(const CSCDetId& stubId,
+                                                const l1t::MuonStubRef stub,
+                                                const CSCSegmentCollection& segments,
+                                                const l1t::TrackerMuonRef l1TkMuRef) const;
+
+  // Logic to extrapolate from nearby stations in the barrel
+  const std::pair<int, int> extrapolateToNearbyStation(const int endingStation,
+                                                       const std::map<DTChamberId, std::pair<int, int>>& matchesInBarrel,
+                                                       const DTRecSegment4DCollection& segments) const;
+
+  const std::pair<int, int> extrapolateMatch(const int bestStartingSegIndex,
+                                             const int endingStation,
+                                             const DTRecSegment4DCollection& segments) const;
+};
+#endif

--- a/RecoMuon/L2MuonSeedGenerator/src/Phase2L2MuonSeedCreator.h
+++ b/RecoMuon/L2MuonSeedGenerator/src/Phase2L2MuonSeedCreator.h
@@ -111,7 +111,6 @@ private:
   const double maxEtaOverlap_;  // overlap with |eta| < 1.3, endcap after that
 
   // Handles
-  edm::ESHandle<MagneticField> magneticField_;
   edm::ESHandle<CSCGeometry> cscGeometry_;
   edm::ESHandle<DTGeometry> dtGeometry_;
 
@@ -132,13 +131,13 @@ private:
   const std::pair<int, int> matchingStubSegment(const DTChamberId& stubId,
                                                 const l1t::MuonStubRef stub,
                                                 const DTRecSegment4DCollection& segments,
-                                                const l1t::TrackerMuonRef l1TkMuRef) const;
+                                                const float l1TkMuTheta) const;
 
   // Logic to match L1 stubs to CSC segments
   const std::pair<int, int> matchingStubSegment(const CSCDetId& stubId,
                                                 const l1t::MuonStubRef stub,
                                                 const CSCSegmentCollection& segments,
-                                                const l1t::TrackerMuonRef l1TkMuRef) const;
+                                                const float l1TkMuTheta) const;
 
   // Logic to extrapolate from nearby stations in the barrel
   const std::pair<int, int> extrapolateToNearbyStation(const int endingStation,

--- a/RecoMuon/L3TrackFinder/interface/Phase2HLTMuonSelectorForL3.h
+++ b/RecoMuon/L3TrackFinder/interface/Phase2HLTMuonSelectorForL3.h
@@ -1,7 +1,7 @@
 #ifndef RecoMuon_L3TrackFinder_phase2HLTMuonSelectorForL3_H
 #define RecoMuon_L3TrackFinder_phase2HLTMuonSelectorForL3_H
 
-/**  \class phase2HLTMuonSelectorForL3
+/**  \class Phase2HLTMuonSelectorForL3
  * 
  *   Phase-2 L3 selector for Muons
  *   This module allows to choose whether to perform 
@@ -49,13 +49,13 @@ namespace edm {
   class EventSetup;
 }  // End namespace edm
 
-class phase2HLTMuonSelectorForL3 : public edm::stream::EDProducer<> {
+class Phase2HLTMuonSelectorForL3 : public edm::stream::EDProducer<> {
 public:
   // Constructor
-  phase2HLTMuonSelectorForL3(const edm::ParameterSet&);
+  Phase2HLTMuonSelectorForL3(const edm::ParameterSet&);
 
   // Destructor
-  ~phase2HLTMuonSelectorForL3() override = default;
+  ~Phase2HLTMuonSelectorForL3() override = default;
 
   // Default values
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);

--- a/RecoMuon/L3TrackFinder/interface/phase2HLTMuonSelectorForL3.h
+++ b/RecoMuon/L3TrackFinder/interface/phase2HLTMuonSelectorForL3.h
@@ -1,0 +1,81 @@
+#ifndef RecoMuon_L3TrackFinder_phase2HLTMuonSelectorForL3_H
+#define RecoMuon_L3TrackFinder_phase2HLTMuonSelectorForL3_H
+
+/**  \class phase2HLTMuonSelectorForL3
+ * 
+ *   Phase-2 L3 selector for Muons
+ *   This module allows to choose whether to perform 
+ *   Inside-Out or Outside-In reconstruction first for L3 Muons, 
+ *   performing the second pass only on candidates that were not
+ *   reconstructed or whose quality was not good enough. Required 
+ *   quality criteria are configurable, the default parameters 
+ *   match the requests of HLT Muon ID. 
+ *   When Inside-Out reconstruction is performed first, the resulting
+ *   L3 Tracks are filtered and geometrically matched with L2
+ *   Standalone Muons. If either the match is unsuccessful, or 
+ *   the L3 track is not of good-enough quality, the associated 
+ *   Standalone Muon will be re-used to seed the Outside-In step.
+ *   The Outside-In first approach follows a similar logic by 
+ *   matching the L3 tracks directly with L1 Tracker Muons. 
+ *   Then, when either the match fails or the track is not of 
+ *   good-enough quality, the L1 Tracker Muon is re-used to seed
+ *   the Inside-Out reconstruction.
+ *
+ *   \author Luca Ferragina (INFN BO), 2024
+ */
+
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "DataFormats/L1TMuonPhase2/interface/TrackerMuon.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
+#include "DataFormats/MuonSeed/interface/L2MuonTrajectorySeedCollection.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+
+namespace edm {
+  class ParameterSet;
+  class Event;
+  class EventSetup;
+}  // End namespace edm
+
+class phase2HLTMuonSelectorForL3 : public edm::stream::EDProducer<> {
+public:
+  // Constructor
+  phase2HLTMuonSelectorForL3(const edm::ParameterSet&);
+
+  // Destructor
+  ~phase2HLTMuonSelectorForL3() override = default;
+
+  // Default values
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  // Select objects to be reused
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+private:
+  const edm::EDGetTokenT<l1t::TrackerMuonCollection> l1TkMuCollToken_;
+  const edm::EDGetTokenT<reco::TrackCollection> l2MuCollectionToken_;
+  const edm::EDGetTokenT<reco::TrackCollection> l3TrackCollectionToken_;
+
+  const bool IOFirst_;
+  const double matchingDr_;
+  const bool applyL3Filters_;
+  const double maxNormalizedChi2_, maxPtDifference_;
+  const int minNhits_, minNhitsMuons_, minNhitsPixel_, minNhitsTracker_;
+
+  // Check L3 inner track quality parameters
+  const bool rejectL3Track(l1t::TrackerMuonRef l1TkMuRef, reco::TrackRef l3TrackRef) const;
+};
+
+#endif

--- a/RecoMuon/L3TrackFinder/src/Phase2HLTMuonSelectorForL3.cc
+++ b/RecoMuon/L3TrackFinder/src/Phase2HLTMuonSelectorForL3.cc
@@ -1,8 +1,8 @@
-/**  \class phase2HLTMuonSelectorForL3
+/**  \class Phase2HLTMuonSelectorForL3
  *   See header file for a description of this class
  *   \author Luca Ferragina (INFN BO), 2024
  */
-#include "RecoMuon/L3TrackFinder/interface/phase2HLTMuonSelectorForL3.h"
+#include "RecoMuon/L3TrackFinder/interface/Phase2HLTMuonSelectorForL3.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -11,7 +11,7 @@
 #include <unordered_set>
 
 // Constructor
-phase2HLTMuonSelectorForL3::phase2HLTMuonSelectorForL3(const edm::ParameterSet& iConfig)
+Phase2HLTMuonSelectorForL3::Phase2HLTMuonSelectorForL3(const edm::ParameterSet& iConfig)
     : l1TkMuCollToken_(consumes<l1t::TrackerMuonCollection>(iConfig.getParameter<edm::InputTag>("l1TkMuons"))),
       l2MuCollectionToken_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("l2MuonsUpdVtx"))),
       l3TrackCollectionToken_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("l3Tracks"))),
@@ -33,7 +33,7 @@ phase2HLTMuonSelectorForL3::phase2HLTMuonSelectorForL3(const edm::ParameterSet& 
   }
 }
 
-void phase2HLTMuonSelectorForL3::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void Phase2HLTMuonSelectorForL3::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("l1TkMuons", edm::InputTag("l1tTkMuonsGmt"));
   desc.add<edm::InputTag>("l2MuonsUpdVtx", edm::InputTag("hltL2MuonsFromL1TkMuon", "UpdatedAtVtx"));
@@ -47,13 +47,13 @@ void phase2HLTMuonSelectorForL3::fillDescriptions(edm::ConfigurationDescriptions
   desc.add<int>("MinNhitsPixel", 1);
   desc.add<int>("MinNhitsTracker", 6);
   desc.add<double>("MaxPtDifference", 999.0);  //relative difference
-  descriptions.add("phase2HLTMuonSelectorForL3", desc);
+  descriptions.add("Phase2HLTMuonSelectorForL3", desc);
 }
 
 // IO first -> collection of L2 muons not already matched to a L3 inner track
 // OI first -> collection of L1Tk Muons not matched to a L3 track
-void phase2HLTMuonSelectorForL3::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  const std::string metname = "RecoMuon|phase2HLTMuonSelectorForL3";
+void Phase2HLTMuonSelectorForL3::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  const std::string metname = "RecoMuon|Phase2HLTMuonSelectorForL3";
 
   // L3 tracks (IO or OI)
   auto l3TracksCollectionH = iEvent.getHandle(l3TrackCollectionToken_);
@@ -183,8 +183,8 @@ void phase2HLTMuonSelectorForL3::produce(edm::Event& iEvent, const edm::EventSet
   }
 }
 
-const bool phase2HLTMuonSelectorForL3::rejectL3Track(l1t::TrackerMuonRef l1TkMuRef, reco::TrackRef l3TrackRef) const {
-  const std::string metname = "RecoMuon|phase2HLTMuonSelectorForL3";
+const bool Phase2HLTMuonSelectorForL3::rejectL3Track(l1t::TrackerMuonRef l1TkMuRef, reco::TrackRef l3TrackRef) const {
+  const std::string metname = "RecoMuon|Phase2HLTMuonSelectorForL3";
 
   bool nHitsCut = l3TrackRef->numberOfValidHits() < minNhits_;
   bool chi2Cut = l3TrackRef->normalizedChi2() > maxNormalizedChi2_;
@@ -203,4 +203,4 @@ const bool phase2HLTMuonSelectorForL3::rejectL3Track(l1t::TrackerMuonRef l1TkMuR
   return reject;
 }
 
-DEFINE_FWK_MODULE(phase2HLTMuonSelectorForL3);
+DEFINE_FWK_MODULE(Phase2HLTMuonSelectorForL3);

--- a/RecoMuon/L3TrackFinder/src/phase2HLTMuonSelectorForL3.cc
+++ b/RecoMuon/L3TrackFinder/src/phase2HLTMuonSelectorForL3.cc
@@ -1,0 +1,206 @@
+/**  \class phase2HLTMuonSelectorForL3
+ *   See header file for a description of this class
+ *   \author Luca Ferragina (INFN BO), 2024
+ */
+#include "RecoMuon/L3TrackFinder/interface/phase2HLTMuonSelectorForL3.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DataFormats/Math/interface/deltaR.h"
+
+#include <unordered_set>
+
+// Constructor
+phase2HLTMuonSelectorForL3::phase2HLTMuonSelectorForL3(const edm::ParameterSet& iConfig)
+    : l1TkMuCollToken_(consumes<l1t::TrackerMuonCollection>(iConfig.getParameter<edm::InputTag>("l1TkMuons"))),
+      l2MuCollectionToken_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("l2MuonsUpdVtx"))),
+      l3TrackCollectionToken_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("l3Tracks"))),
+      IOFirst_(iConfig.getParameter<bool>("IOFirst")),
+      matchingDr_(iConfig.getParameter<double>("matchingDr")),
+      applyL3Filters_(iConfig.getParameter<bool>("applyL3Filters")),
+      maxNormalizedChi2_(iConfig.getParameter<double>("MaxNormalizedChi2")),
+      maxPtDifference_(iConfig.getParameter<double>("MaxPtDifference")),
+      minNhits_(iConfig.getParameter<int>("MinNhits")),
+      minNhitsMuons_(iConfig.getParameter<int>("MinNhitsMuons")),
+      minNhitsPixel_(iConfig.getParameter<int>("MinNhitsPixel")),
+      minNhitsTracker_(iConfig.getParameter<int>("MinNhitsTracker")) {
+  if (IOFirst_) {
+    produces<reco::TrackCollection>("L2MuToReuse");
+    produces<reco::TrackCollection>("L3IOTracksFiltered");
+  } else {
+    produces<l1t::TrackerMuonCollection>("L1TkMuToReuse");
+    produces<reco::TrackCollection>("L3OITracksFiltered");
+  }
+}
+
+void phase2HLTMuonSelectorForL3::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("l1TkMuons", edm::InputTag("l1tTkMuonsGmt"));
+  desc.add<edm::InputTag>("l2MuonsUpdVtx", edm::InputTag("hltL2MuonsFromL1TkMuon", "UpdatedAtVtx"));
+  desc.add<edm::InputTag>("l3Tracks", edm::InputTag("hltIter2Phase2L3FromL1TkMuonMerged"));
+  desc.add<bool>("IOFirst", true);
+  desc.add<double>("matchingDr", 0.02);
+  desc.add<bool>("applyL3Filters", true);
+  desc.add<int>("MinNhits", 1);
+  desc.add<double>("MaxNormalizedChi2", 5.0);
+  desc.add<int>("MinNhitsMuons", 0);
+  desc.add<int>("MinNhitsPixel", 1);
+  desc.add<int>("MinNhitsTracker", 6);
+  desc.add<double>("MaxPtDifference", 999.0);  //relative difference
+  descriptions.add("phase2HLTMuonSelectorForL3", desc);
+}
+
+// IO first -> collection of L2 muons not already matched to a L3 inner track
+// OI first -> collection of L1Tk Muons not matched to a L3 track
+void phase2HLTMuonSelectorForL3::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  const std::string metname = "RecoMuon|phase2HLTMuonSelectorForL3";
+
+  // L3 tracks (IO or OI)
+  auto l3TracksCollectionH = iEvent.getHandle(l3TrackCollectionToken_);
+
+  if (IOFirst_) {
+    LogDebug(metname) << "Inside-Out reconstruction done first, looping over L2 muons";
+
+    // L2 Muons collection
+    auto const l2MuonsCollectionH = iEvent.getHandle(l2MuCollectionToken_);
+
+    // Output
+    std::unique_ptr<reco::TrackCollection> L2MuToReuse = std::make_unique<reco::TrackCollection>();
+    std::unique_ptr<reco::TrackCollection> L3IOTracksFiltered = std::make_unique<reco::TrackCollection>();
+
+    // Indexes of good L3 Tracks
+    std::unordered_set<size_t> goodL3Indexes;
+
+    // Loop over L2 Muons
+    for (size_t l2MuIndex = 0; l2MuIndex != l2MuonsCollectionH->size(); ++l2MuIndex) {
+      reco::TrackRef l2MuRef(l2MuonsCollectionH, l2MuIndex);
+      bool reuseL2 = true;
+
+      // Extract L1TkMu from L2 Muon
+      edm::RefToBase<TrajectorySeed> seedRef = l2MuRef->seedRef();
+      edm::Ref<L2MuonTrajectorySeedCollection> l2Seed = seedRef.castTo<edm::Ref<L2MuonTrajectorySeedCollection>>();
+      l1t::TrackerMuonRef l1TkMuRef = l2Seed->l1TkMu();
+
+      // Check validity of cast (actually found a L1TkMu)
+      if (l1TkMuRef.isNonnull()) {
+        // Loop over L3 tracks
+        LogDebug(metname) << "Looping over L3 tracks";
+        for (size_t l3MuIndex = 0; l3MuIndex != l3TracksCollectionH->size(); ++l3MuIndex) {
+          reco::TrackRef l3TrackRef(l3TracksCollectionH, l3MuIndex);
+          bool rejectL3 = true;
+          // Filter L3 Tracks
+          if (applyL3Filters_) {
+            LogDebug(metname) << "Checking L3 Track quality";
+            rejectL3 = rejectL3Track(l1TkMuRef, l3TrackRef);
+            if (!rejectL3) {
+              LogDebug(metname) << "Adding good quality L3 IO track to filtered collection";
+              goodL3Indexes.insert(l3MuIndex);
+            }
+          }
+          // Check match in dR
+          float dR2 = deltaR2(l1TkMuRef->phEta(), l1TkMuRef->phPhi(), l3TrackRef->eta(), l3TrackRef->phi());
+          LogDebug(metname) << "deltaR2: " << dR2;
+          if (dR2 < matchingDr_ * matchingDr_) {
+            LogDebug(metname) << "Found L2 muon that matches the L3 track";
+            reuseL2 = applyL3Filters_ ? rejectL3 : false;
+            LogDebug(metname) << "Reuse L2: " << reuseL2;
+          }
+        }  // End loop over L3 Tracks
+      } else {
+        LogDebug(metname) << "Found L2 muon without an associated L1TkMu";
+      }
+      if (reuseL2) {
+        LogDebug(metname) << "Found a L2 muon to be reused";
+        L2MuToReuse->push_back(*l2MuRef);
+      }
+    }  // End loop over L2 Muons
+
+    // Fill L3 IO Tracks Filtered
+    for (const size_t index : goodL3Indexes) {
+      L3IOTracksFiltered->push_back(*(reco::TrackRef(l3TracksCollectionH, index)));
+    }
+
+    LogDebug(metname) << "Placing L2 Muons to be reused in the event";
+    iEvent.put(std::move(L2MuToReuse), "L2MuToReuse");
+    LogDebug(metname) << "Placing good quality L3 IO Tracks in the event";
+    iEvent.put(std::move(L3IOTracksFiltered), "L3IOTracksFiltered");
+  } else {
+    LogDebug(metname) << "Outside-In reconstruction done first, looping over L1Tk muons";
+
+    // L1Tk Muons collection
+    auto const l1TkMuonsCollectionH = iEvent.getHandle(l1TkMuCollToken_);
+
+    // Output
+    std::unique_ptr<l1t::TrackerMuonCollection> L1TkMuToReuse = std::make_unique<l1t::TrackerMuonCollection>();
+    std::unique_ptr<reco::TrackCollection> L3OITracksFiltered = std::make_unique<reco::TrackCollection>();
+
+    // Indexes of good L3 Tracks
+    std::unordered_set<size_t> goodL3Indexes;
+
+    // Loop over L1Tk Muons
+    for (size_t l1TkMuIndex = 0; l1TkMuIndex != l1TkMuonsCollectionH->size(); ++l1TkMuIndex) {
+      l1t::TrackerMuonRef l1TkMuRef(l1TkMuonsCollectionH, l1TkMuIndex);
+      bool reuseL1TkMu = true;
+
+      // Loop over L3 tracks
+      LogDebug(metname) << "Looping over L3 tracks";
+      for (size_t l3MuIndex = 0; l3MuIndex != l3TracksCollectionH->size(); ++l3MuIndex) {
+        reco::TrackRef l3TrackRef(l3TracksCollectionH, l3MuIndex);
+        bool rejectL3 = true;
+        // Filter L3 Tracks
+        if (applyL3Filters_) {
+          LogDebug(metname) << "Checking L3 Track quality";
+          rejectL3 = rejectL3Track(l1TkMuRef, l3TrackRef);
+          if (!rejectL3) {
+            LogDebug(metname) << "Adding good quality L3 OI track to filtered collection";
+            goodL3Indexes.insert(l3MuIndex);
+          }
+        }
+        // Check match in dR
+        float dR2 = deltaR2(l1TkMuRef->phEta(), l1TkMuRef->phPhi(), l3TrackRef->eta(), l3TrackRef->phi());
+        LogDebug(metname) << "deltaR2: " << dR2;
+        if (dR2 < matchingDr_ * matchingDr_) {
+          LogDebug(metname) << "Found L1TkMu that matches the L3 track";
+          reuseL1TkMu = applyL3Filters_ ? rejectL3 : false;
+          LogDebug(metname) << "Reuse L1TkMu: " << reuseL1TkMu;
+        }
+      }  // End loop over L3 Tracks
+      if (reuseL1TkMu) {
+        LogDebug(metname) << "Found a L1TkMu to be reused";
+        L1TkMuToReuse->push_back(*l1TkMuRef);
+      }
+    }  // End loop over L1Tk Muons
+
+    // Fill L3 OI Tracks Filtered
+    for (const size_t index : goodL3Indexes) {
+      L3OITracksFiltered->push_back(*(reco::TrackRef(l3TracksCollectionH, index)));
+    }
+
+    LogDebug(metname) << "Placing L1Tk Muons to be reused in the event";
+    iEvent.put(std::move(L1TkMuToReuse), "L1TkMuToReuse");
+    LogDebug(metname) << "Placing good quality L3 OI Tracks in the event";
+    iEvent.put(std::move(L3OITracksFiltered), "L3OITracksFiltered");
+  }
+}
+
+const bool phase2HLTMuonSelectorForL3::rejectL3Track(l1t::TrackerMuonRef l1TkMuRef, reco::TrackRef l3TrackRef) const {
+  const std::string metname = "RecoMuon|phase2HLTMuonSelectorForL3";
+
+  bool nHitsCut = l3TrackRef->numberOfValidHits() < minNhits_;
+  bool chi2Cut = l3TrackRef->normalizedChi2() > maxNormalizedChi2_;
+  bool nHitsMuonsCut = l3TrackRef->hitPattern().numberOfValidMuonHits() < minNhitsMuons_;
+  bool nHitsPixelCut = l3TrackRef->hitPattern().numberOfValidPixelHits() < minNhitsPixel_;
+  bool nHitsTrackerCut = l3TrackRef->hitPattern().trackerLayersWithMeasurement() < minNhitsTracker_;
+  bool ptCut = std::abs(l3TrackRef->pt() - l1TkMuRef->phPt()) > maxPtDifference_ * l3TrackRef->pt();
+
+  bool reject = nHitsCut or chi2Cut or nHitsMuonsCut or nHitsPixelCut or nHitsTrackerCut or ptCut;
+
+  LogDebug(metname) << "nHits: " << l3TrackRef->numberOfValidHits() << " | chi2: " << l3TrackRef->normalizedChi2()
+                    << " | nHitsMuon: " << l3TrackRef->hitPattern().numberOfValidMuonHits()
+                    << " | nHitsPixel: " << l3TrackRef->hitPattern().numberOfValidPixelHits()
+                    << " | nHitsTracker: " << l3TrackRef->hitPattern().trackerLayersWithMeasurement();
+  LogDebug(metname) << "Reject L3 Track: " << reject;
+  return reject;
+}
+
+DEFINE_FWK_MODULE(phase2HLTMuonSelectorForL3);

--- a/Validation/RecoMuon/python/associators_cff.py
+++ b/Validation/RecoMuon/python/associators_cff.py
@@ -265,6 +265,24 @@ Phase2tpToL3OITkAssociation = MABHhlt.clone(
     UseTracker = True,
     UseMuon = False
 )
+# L2 muons to reuse (IO first only)
+Phase2tpToL2MuonToReuseAssociation = MABHhlt.clone(
+    tracksTag = 'hltPhase2L3MuonFilter:L2MuToReuse',
+    UseTracker = False,
+    UseMuon = True
+)
+# L3 IO inner tracks filtered (IO first only)
+Phase2tpToL3IOTkFilteredAssociation = MABHhlt.clone(
+    tracksTag = 'hltPhase2L3MuonFilter:L3IOTracksFiltered',
+    UseTracker = True,
+    UseMuon = False
+)
+# L3 OI inner tracks filtered (OI first only)
+Phase2tpToL3OITkFilteredAssociation = MABHhlt.clone(
+    tracksTag = 'hltPhase2L3MuonFilter:L3OITracksFiltered',
+    UseTracker = True,
+    UseMuon = False
+)
 # L3 inner tracks merged
 Phase2tpToL3TkMergedAssociation = MABHhlt.clone(
     tracksTag = 'hltPhase2L3MuonMerged',
@@ -408,6 +426,33 @@ Phase2MuonAssociationHLT_seq = cms.Sequence(
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toReplaceWith(muonAssociationHLT_seq, Phase2MuonAssociationHLT_seq)
 
+# Inside-Out first
+Phase2IOFirstMuonAssociationHLT_seq = cms.Sequence(
+    hltPhase2L2MuonSeedTracks+Phase2tpToL2SeedAssociation
+    +Phase2tpToL2MuonAssociation+Phase2tpToL2MuonUpdAssociation
+    +Phase2tpToL3IOTkAssociation+Phase2tpToL3OITkAssociation
+    +Phase2tpToL2MuonToReuseAssociation+Phase2tpToL3IOTkFilteredAssociation
+    +Phase2tpToL3TkMergedAssociation+Phase2tpToL3GlbMuonMergedAssociation
+    +hltPhase2L3MuonNoIdTracks+Phase2tpToL3MuonNoIdAssociation
+    +hltPhase2L3MuonIdTracks+Phase2tpToL3MuonIdAssociation
+    )
+# Outside-In first
+Phase2OIFirstMuonAssociationHLT_seq = cms.Sequence(
+    hltPhase2L2MuonSeedTracks+Phase2tpToL2SeedAssociation
+    +Phase2tpToL2MuonAssociation+Phase2tpToL2MuonUpdAssociation
+    +Phase2tpToL3OITkAssociation+Phase2tpToL3OITkFilteredAssociation
+    +Phase2tpToL3IOTkAssociation+Phase2tpToL3TkMergedAssociation
+    +Phase2tpToL3GlbMuonMergedAssociation
+    +hltPhase2L3MuonNoIdTracks+Phase2tpToL3MuonNoIdAssociation
+    +hltPhase2L3MuonIdTracks+Phase2tpToL3MuonIdAssociation
+    )
+
+from Configuration.ProcessModifiers.phase2L2AndL3Muons_cff import phase2L2AndL3Muons
+phase2L2AndL3Muons.toReplaceWith(muonAssociationHLT_seq, Phase2IOFirstMuonAssociationHLT_seq)
+
+from Configuration.ProcessModifiers.phase2L3MuonsOIFirst_cff import phase2L3MuonsOIFirst
+(phase2L2AndL3Muons & phase2L3MuonsOIFirst).toReplaceWith(muonAssociationHLT_seq, Phase2OIFirstMuonAssociationHLT_seq)
+
 # fastsim has no hlt specific dt hit collection
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 _DTrechitTag = SimMuon.MCTruth.MuonAssociatorByHits_cfi.muonAssociatorByHits.DTrechitTag
@@ -427,6 +472,9 @@ fastSim.toModify(Phase2tpToL2MuonAssociation, DTrechitTag = _DTrechitTag)
 fastSim.toModify(Phase2tpToL2MuonUpdAssociation, DTrechitTag = _DTrechitTag)
 fastSim.toModify(Phase2tpToL3IOTkAssociation, DTrechitTag = _DTrechitTag)
 fastSim.toModify(Phase2tpToL3OITkAssociation, DTrechitTag = _DTrechitTag)
+fastSim.toModify(Phase2tpToL2MuonToReuseAssociation, DTrechitTag = _DTrechitTag)
+fastSim.toModify(Phase2tpToL3IOTkFilteredAssociation, DTrechitTag = _DTrechitTag)
+fastSim.toModify(Phase2tpToL3OITkFilteredAssociation, DTrechitTag = _DTrechitTag)
 fastSim.toModify(Phase2tpToL3TkMergedAssociation, DTrechitTag = _DTrechitTag)
 fastSim.toModify(Phase2tpToL3GlbMuonMergedAssociation, DTrechitTag = _DTrechitTag)
 fastSim.toModify(Phase2tpToL3MuonNoIdAssociation, DTrechitTag = _DTrechitTag)

--- a/Validation/RecoMuon/python/muonValidationHLT_cff.py
+++ b/Validation/RecoMuon/python/muonValidationHLT_cff.py
@@ -101,6 +101,24 @@ Phase2l3OITkV = MTVhlt.clone(
     label = ('hltPhase2L3OIMuonTrackSelectionHighPurity',),
     muonHistoParameters = trkMuonHistoParameters
 )
+# L2 muons to reuse (IO first only)
+Phase2L2MuToReuseV = MTVhlt.clone(
+    associatormap = 'Phase2tpToL2MuonToReuseAssociation',
+    label = ('hltPhase2L3MuonFilter:L2MuToReuse',),
+    muonHistoParameters = staMuonHistoParameters
+)
+# L3 IO inner tracks filtered (IO first only)
+Phase2l3IOTkFilteredV = MTVhlt.clone(
+    associatormap = 'Phase2tpToL3IOTkFilteredAssociation',
+    label = ('hltPhase2L3MuonFilter:L3IOTracksFiltered',),
+    muonHistoParameters = trkMuonHistoParameters
+)
+# L3 OI inner tracks filtered (OI first only)
+Phase2l3OITkFilteredV = MTVhlt.clone(
+    associatormap = 'Phase2tpToL3OITkFilteredAssociation',
+    label = ('hltPhase2L3MuonFilter:L3OITracksFiltered',),
+    muonHistoParameters = trkMuonHistoParameters
+)
 # L3 inner tracks merged
 Phase2l3TkMergedV = MTVhlt.clone(
     associatormap = 'Phase2tpToL3TkMergedAssociation',
@@ -157,9 +175,42 @@ Phase2MuonValidationHLT_seq = cms.Sequence(muonAssociationHLT_seq
                                     +Phase2l3MuNoIdTrackV
                                     +Phase2l3MuIdTrackV
                                     )
+# Inside-Out first sequence
+Phase2IOFirstMuonValidationHLT_seq = cms.Sequence(muonAssociationHLT_seq
+                                    +Phase2l2MuSeedV
+                                    +Phase2l2MuV
+                                    +Phase2l2MuUpdV
+                                    +Phase2l3IOTkV
+                                    +Phase2L2MuToReuseV
+                                    +Phase2l3IOTkFilteredV
+                                    +Phase2l3OITkV
+                                    +Phase2l3TkMergedV
+                                    +Phase2l3GlbMuonV
+                                    +Phase2l3MuNoIdTrackV
+                                    +Phase2l3MuIdTrackV
+                                    )
+# Outside-In first sequence
+Phase2OIFirstMuonValidationHLT_seq = cms.Sequence(muonAssociationHLT_seq
+                                    +Phase2l2MuSeedV
+                                    +Phase2l2MuV
+                                    +Phase2l2MuUpdV
+                                    +Phase2l3OITkV
+                                    +Phase2l3OITkFilteredV
+                                    +Phase2l3IOTkV
+                                    +Phase2l3TkMergedV
+                                    +Phase2l3GlbMuonV
+                                    +Phase2l3MuNoIdTrackV
+                                    +Phase2l3MuIdTrackV
+                                    )
 
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toReplaceWith(muonValidationHLT_seq, Phase2MuonValidationHLT_seq)
+
+from Configuration.ProcessModifiers.phase2L2AndL3Muons_cff import phase2L2AndL3Muons
+phase2L2AndL3Muons.toReplaceWith(muonValidationHLT_seq, Phase2IOFirstMuonValidationHLT_seq)
+
+from Configuration.ProcessModifiers.phase2L3MuonsOIFirst_cff import phase2L3MuonsOIFirst
+(phase2L2AndL3Muons & phase2L3MuonsOIFirst).toReplaceWith(muonValidationHLT_seq, Phase2OIFirstMuonValidationHLT_seq)
 
 recoMuonValidationHLT_seq = cms.Sequence(
     cms.SequencePlaceholder("TPmu") +


### PR DESCRIPTION
#### PR description:

This PR implements a new Standalone (L2) Muon seeding strategy that fully utilizes the L1 Tracker Muons (L1TkMu) information. 
L3 Tracker Muon reconstruction is also streamlined, also taking advantage of the improved L1TkMu, to reduce redundancy. 
The full scope of the changes was described in the [HLT Upgrade meeting on 8/10/2024](https://indico.cern.ch/event/1460055/contributions/6147459/attachments/2941712/5168585/2024_10_08_thesis_results.pdf), while the details on the integration were presented in the [meeting on 3/12/2024](https://indico.cern.ch/event/1482695/contributions/6261220/attachments/2978788/5244435/2024-12-03%20Phase%202%20validation%20and%20integration%20in%20CMSSW.pdf#page=4).

The new L2 seeder directly matches the stubs used to produce each L1TkMu with segments in DTs/CSCs. All matched segments are assigned to the seed, together with the pT measurement from the L1TkMu. This approach produces a single collection of seeds. 
On the other hand, the current implementation produces two collections of seeds (from L1TkMu and "offline") that require matching and produces roughly a factor of 5 more seeds in ZMM simulated events with 200 PU.
The changes implemented in the seeding module results in a significant improvement in timing (about 42%) with mostly compatible efficiency.

The streamlining of the L3 reconstruction hinges on the idea of performing either the Inside-Out or the Outside-In L3 Tracker Muon reconstruction first, to then execute a second pass only for candidates that require it (i.e. either they were not reconstructed in the first pass or the quality of the track was not good enough). This approach starts from either reconstruction path (flexible in case of future changes or detectors' requirements) to produce a filtered collection of L3 tracks: the filter uses some of the same criteria used in the HLT Muon ID step (e.g. number of hits in the pixel, number of hits in the tracker, normalized chi2, ...). The filtered L3 Tracks are geometrically matched to either L1TkMu (Outside-In first) or Standalone Muons (Inside-Out first):
- if the match is successful, the track is considered good enough and passes to the next phase;
- if the match is unsuccessful, the lower-level object will be reused to seed the second reconstruction path.
From the current results, the Inside-Out first approach seems to perform better, with more than 80% of the events in a ZMM sample at 200 PU requiring a single reconstruction path, to be compared with about 20% for the Outside-In first approach.
In any case, the streamlined L3 reconstruction reduces the fakerate in the merged (L3 IO + L3 OI) tracks collection as well as timing, while maintaining compatible physics perfomance until and including the final HLT Muon ID objects. All results, validation plots and ntuples are available [here](https://lferragi.web.cern.ch/plots/muon_hlt_phase2/14_2_0_pre4_PR/)

The changes have been implemented using two new process modifiers:
- phase2L2AndL3Muons implements the new Standalone Muon seeding and executes the L3 Tracker Muon reconstruction Inside-Out first;
- phase2L3MuonsOIFirst to be used on top of the previous one, swaps the L3 Tracker Muon reconstruction from Inside-Out first to Outside-In first

These process modifiers have been included in a set of workflows targeting SingleMu, TTbar, and ZMM samples:
- .777 includes the phase2L2AndL3Muons 
- .778 includes the phase2L2AndL3Muons and the phase2L3MuonsOIFirst process modifiers
 
#### PR validation:

Validation builds on top of #46860 introducing specific validation paths for the new objects (e.g. filtered collections, objects to reuse). Physics performance mostly compatible with the current implementation. Tested on CMSSW_14_2_0_pre3 RelVals (TTbar and ZMM) (not pre4 due to those being limited to 35 PU) as well as private production with workflows 29834(.0, .777, .778) (TTbar) and 29850 (.0, .777, .778) (ZMM). 
**Please test on Phase 2 workflows using also .777 and .778 modifiers** 
