### PR TITLE
Sort hybrid taus with descending pt [fix]

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATTauHybridProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTauHybridProducer.cc
@@ -10,6 +10,7 @@
 #include "RecoTauTag/RecoTau/interface/RecoTauCommonUtilities.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "CommonTools/Utils/interface/PtComparator.h"
 
 class PATTauHybridProducer : public edm::stream::EDProducer<> {
 public:
@@ -37,6 +38,7 @@ private:
   const bool checkTauScoreIsBest_;
   const bool usePFLeptonsAsChargedHadrons_;
 
+  GreaterByPt<pat::Tau> pTTauComparator_;
   const std::map<std::string, int> tagToDM_;
   enum class tauId_utag_idx : size_t { dm = 0, vsjet, vse, vsmu, ptcorr, qconf, pdm0, pdm1, pdm2, pdm10, pdm11, last };
   enum class tauId_min_idx : size_t { hpsnew = 0, last };
@@ -324,6 +326,9 @@ void PATTauHybridProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
       outputTaus->push_back(outputTau);
     }
   }  //non-matched taus
+
+  // sort taus in pT
+  std::sort(outputTaus->begin(), outputTaus->end(), pTTauComparator_);
 
   evt.put(std::move(outputTaus));
 }


### PR DESCRIPTION
#### PR description:

This PR adds sorting of output tau collection in pt which is normal behavior of the physics object collections in CMSSW.

As it is behavior expected by users and it does not change event content **we ask that it is accepted as (bug)fix for the "Nano v15" production release series**. 

#### PR validation:

Validated with custom mini+nano and 16834.0 workflows.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 14_2 if needed for v15 production.
