### PR TITLE
[UBSAN]Fix runtime error for invalid bool value assignment

### DIFF
--- a/SimDataFormats/GeneratorProducts/src/HepMCProduct.cc
+++ b/SimDataFormats/GeneratorProducts/src/HepMCProduct.cc
@@ -36,7 +36,6 @@ void HepMCProduct::addHepMCData(HepMC::GenEvent* evt) {
 
 void HepMCProduct::applyVtxGen(HepMC::FourVector const& vtxShift) {
   //std::cout<< " applyVtxGen called " << isVtxGenApplied_ << endl;
-  //fTimeOffset = 0;
 
   if (isVtxGenApplied())
     return;
@@ -126,16 +125,14 @@ HepMCProduct::HepMCProduct(HepMCProduct const& other) : evt_(nullptr) {
   isVtxGenApplied_ = other.isVtxGenApplied_;
   isVtxBoostApplied_ = other.isVtxBoostApplied_;
   isPBoostApplied_ = other.isPBoostApplied_;
-  //fTimeOffset = other.fTimeOffset;
 }
 
 // swap
 void HepMCProduct::swap(HepMCProduct& other) {
   std::swap(evt_, other.evt_);
-  std::swap(isVtxGenApplied_, other.isVtxGenApplied_);
-  std::swap(isVtxBoostApplied_, other.isVtxBoostApplied_);
-  std::swap(isPBoostApplied_, other.isPBoostApplied_);
-  //std::swap(fTimeOffset, other.fTimeOffset);
+  isVtxGenApplied_ = other.isVtxGenApplied_;
+  isVtxBoostApplied_ = other.isVtxBoostApplied_;
+  isPBoostApplied_ = other.isPBoostApplied_;
 }
 
 // assignment: use copy/swap idiom for exception safety.


### PR DESCRIPTION
For UBSAN IBs, few workflows show runtime errors like [a]. Looks like this happens when we try to swap uninitialized bool values [here](https://github.com/cms-sw/cmssw/blob/master/SimDataFormats/GeneratorProducts/src/HepMCProduct.cc#L135-L137)  e.g from https://github.com/cms-sw/cmssw/blob/master/SimDataFormats/GeneratorProducts/src/HepMCProduct.cc#L149 . If I am not wrong, there is no need to use swap for boolean types, just assignment should be enough

Also removed using `fTimeOffset` comments

[a]
```
 gcc/include/c++/12.3.1/bits/move.h:204:11: runtime error: load of value 224, which is not a valid value for type 'bool'

    #0 0x14a7a7ba4fbc in std::enable_if<std::__and_<std::__not_<std::__is_tuple_like<bool> >, std::is_move_constructible<bool>, std::is_move_assignable<bool> >::value, void>::type std::swap<bool>(bool&, bool&) /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/move.h:204
    #1 0x14a7a7ba4fbc in edm::HepMCProduct::swap(edm::HepMCProduct&) src/SimDataFormats/GeneratorProducts/src/HepMCProduct.cc:135
    #2 0x14a77bcb7e7d in edm::Wrapper<edm::HepMCProduct>::Wrapper<edm::HepMCProduct>(edm::WrapperBase::Emplace, edm::HepMCProduct&&) src/DataFormats/Common/interface/Wrapper.h:89
    #3 0x14a77bcb7e7d in edm::OrphanHandle<edm::HepMCProduct> edm::Event::emplaceImpl<edm::HepMCProduct, edm::HepMCProduct>(unsigned int, edm::HepMCProduct&&) src/FWCore/Framework/interface/Event.h:454
    #4 0x14a77bc8719c in edm::OrphanHandle<edm::HepMCProduct> edm::Event::emplace<edm::HepMCProduct, edm::HepMCProduct>(edm::EDPutTokenT<edm::HepMCProduct>, edm::HepMCProduct&&) src/FWCore/Framework/interface/Event.h:434
    #5 0x14a77bc8719c in ExternalGeneratorFilter::filter(edm::StreamID, edm::Event&, edm::EventSetup const&) const src/GeneratorInterface/Core/plugins/ExternalGeneratorFilter.cc:270
```