### PR TITLE
[14_2_X] Update `ecalMultiFitUncalibRecHit_cfi.py` parameters for CC

### DIFF
--- a/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
@@ -12,8 +12,8 @@ ecal_cctiming.toModify(ecalMultiFitUncalibRecHit,
         EBtimeConstantTerm = 0.85,
         outOfTimeThresholdGain12pEB = 3.0,
         outOfTimeThresholdGain12mEB = 3.0,
-        outOfTimeThresholdGain61pEB = 3.0,
-        outOfTimeThresholdGain61mEB = 3.0,
+        outOfTimeThresholdGain61pEB = 12.0,
+        outOfTimeThresholdGain61mEB = 12.0,
         timeCalibTag = ':CC',
         timeOffsetTag = ':CC'
     )


### PR DESCRIPTION
BackPort of PR #46763
This PR does not affect the default reconstruction. The changes made by this PR are only activated by a special modifier. This PR is needed for a reprocessing discussed with PPD.
Changed ourOfTimeThresholdGain61pEB and ourOfTimeThresholdGain61mEB parameters for CC reconstruction from 3.0 to 12.0 on lines 15 and 16 of RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
PR description:
This change address discrepancy seen in JERSF for TeV jets.
PR validation:
This PR makes an adjustment to config parameters and does not touch the code.
Details are documented in: [SupplementalMaterialPR46763.pdf](https://github.com/user-attachments/files/17995656/SupplementalMaterialPR46763.pdf)