### PR TITLE
Replace `TAcc` with explicit accelerator type

### DIFF
--- a/DataFormats/SiPixelClusterSoA/test/alpaka/Clusters_test.dev.cc
+++ b/DataFormats/SiPixelClusterSoA/test/alpaka/Clusters_test.dev.cc
@@ -14,8 +14,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::testClusterSoA {
 
   class TestFillKernel {
   public:
-    template <typename TAcc, typename = std::enable_if_t<isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc, SiPixelClustersSoAView clust_view) const {
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc, SiPixelClustersSoAView clust_view) const {
       for (int32_t j : cms::alpakatools::uniform_elements(acc, clust_view.metadata().size())) {
         clust_view[j].moduleStart() = j;
         clust_view[j].clusInModule() = j * 2;
@@ -27,8 +26,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::testClusterSoA {
 
   class TestVerifyKernel {
   public:
-    template <typename TAcc, typename = std::enable_if_t<isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc, SiPixelClustersSoAConstView clust_view) const {
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc, SiPixelClustersSoAConstView clust_view) const {
       for (uint32_t j : cms::alpakatools::uniform_elements(acc, clust_view.metadata().size())) {
         ALPAKA_ASSERT_ACC(clust_view[j].moduleStart() == j);
         ALPAKA_ASSERT_ACC(clust_view[j].clusInModule() == j * 2);

--- a/DataFormats/SiPixelDigiSoA/test/alpaka/DigiErrors_test.dev.cc
+++ b/DataFormats/SiPixelDigiSoA/test/alpaka/DigiErrors_test.dev.cc
@@ -15,8 +15,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::testDigisSoA {
 
   class TestFillKernel {
   public:
-    template <typename TAcc, typename = std::enable_if_t<isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc, SiPixelDigiErrorsSoAView digiErrors_view) const {
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc, SiPixelDigiErrorsSoAView digiErrors_view) const {
       for (uint32_t j : cms::alpakatools::uniform_elements(acc, digiErrors_view.metadata().size())) {
         digiErrors_view[j].pixelErrors().rawId = j;
         digiErrors_view[j].pixelErrors().word = j;
@@ -28,8 +27,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::testDigisSoA {
 
   class TestVerifyKernel {
   public:
-    template <typename TAcc, typename = std::enable_if_t<isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc, SiPixelDigiErrorsSoAConstView digiErrors_view) const {
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc, SiPixelDigiErrorsSoAConstView digiErrors_view) const {
       for (uint32_t j : cms::alpakatools::uniform_elements(acc, digiErrors_view.metadata().size())) {
         ALPAKA_ASSERT_ACC(digiErrors_view[j].pixelErrors().rawId == j);
         ALPAKA_ASSERT_ACC(digiErrors_view[j].pixelErrors().word == j);

--- a/DataFormats/SiPixelDigiSoA/test/alpaka/Digis_test.dev.cc
+++ b/DataFormats/SiPixelDigiSoA/test/alpaka/Digis_test.dev.cc
@@ -12,8 +12,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::testDigisSoA {
 
   class TestFillKernel {
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc, SiPixelDigisSoAView digi_view) const {
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc, SiPixelDigisSoAView digi_view) const {
       for (int32_t j : cms::alpakatools::uniform_elements(acc, digi_view.metadata().size())) {
         digi_view[j].clus() = j;
         digi_view[j].rawIdArr() = j * 2;
@@ -25,8 +24,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::testDigisSoA {
 
   class TestVerifyKernel {
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc, SiPixelDigisSoAConstView digi_view) const {
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc, SiPixelDigisSoAConstView digi_view) const {
       for (uint32_t j : cms::alpakatools::uniform_elements(acc, digi_view.metadata().size())) {
         ALPAKA_ASSERT_ACC(digi_view[j].clus() == int(j));
         ALPAKA_ASSERT_ACC(digi_view[j].rawIdArr() == j * 2);

--- a/DataFormats/TrackSoA/test/alpaka/TrackSoAHeterogeneous_test.dev.cc
+++ b/DataFormats/TrackSoA/test/alpaka/TrackSoAHeterogeneous_test.dev.cc
@@ -23,8 +23,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     template <typename TrackerTraits>
     class TestFillKernel {
     public:
-      template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-      ALPAKA_FN_ACC void operator()(TAcc const& acc, TrackSoAView<TrackerTraits> tracks_view, int32_t nTracks) const {
+      ALPAKA_FN_ACC void operator()(Acc1D const& acc, TrackSoAView<TrackerTraits> tracks_view, int32_t nTracks) const {
         if (cms::alpakatools::once_per_grid(acc)) {
           tracks_view.nTracks() = nTracks;
         }
@@ -45,8 +44,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     template <typename TrackerTraits>
     class TestVerifyKernel {
     public:
-      template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-      ALPAKA_FN_ACC void operator()(TAcc const& acc,
+      ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                     TrackSoAConstView<TrackerTraits> tracks_view,
                                     int32_t nTracks) const {
         if (cms::alpakatools::once_per_grid(acc)) {

--- a/DataFormats/TrackingRecHitSoA/test/alpaka/Hits_test.dev.cc
+++ b/DataFormats/TrackingRecHitSoA/test/alpaka/Hits_test.dev.cc
@@ -19,8 +19,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     template <typename TrackerTraits>
     struct TestFillKernel {
-      template <typename TAcc, typename = std::enable_if_t<isAccelerator<TAcc>>>
-      ALPAKA_FN_ACC void operator()(TAcc const& acc, TrackingRecHitSoAView<TrackerTraits> soa) const {
+      ALPAKA_FN_ACC void operator()(Acc1D const& acc, TrackingRecHitSoAView<TrackerTraits> soa) const {
         const uint32_t i(alpaka::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
         const uint32_t j(alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u]);
 
@@ -36,8 +35,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     template <typename TrackerTraits>
     struct ShowKernel {
-      template <typename TAcc, typename = std::enable_if_t<isAccelerator<TAcc>>>
-      ALPAKA_FN_ACC void operator()(TAcc const& acc, TrackingRecHitSoAConstView<TrackerTraits> soa) const {
+      ALPAKA_FN_ACC void operator()(Acc1D const& acc, TrackingRecHitSoAConstView<TrackerTraits> soa) const {
         if (cms::alpakatools::once_per_grid(acc)) {
           printf("nbins = %d\n", soa.phiBinner().nbins());
           printf("offsetBPIX = %d\n", soa.offsetBPIX2());

--- a/DataFormats/VertexSoA/test/alpaka/ZVertexSoA_test.dev.cc
+++ b/DataFormats/VertexSoA/test/alpaka/ZVertexSoA_test.dev.cc
@@ -10,8 +10,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::testZVertexSoAT {
 
   class TestFillKernel {
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc,
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                   reco::ZVertexSoAView zvertex_view,
                                   reco::ZVertexTracksSoAView ztracks_view) const {
       if (cms::alpakatools::once_per_grid(acc)) {
@@ -34,8 +33,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::testZVertexSoAT {
 
   class TestVerifyKernel {
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc,
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                   reco::ZVertexSoAView zvertex_view,
                                   reco::ZVertexTracksSoAView ztracks_view) const {
       if (cms::alpakatools::once_per_grid(acc)) {

--- a/EventFilter/EcalRawToDigi/plugins/alpaka/UnpackPortable.dev.cc
+++ b/EventFilter/EcalRawToDigi/plugins/alpaka/UnpackPortable.dev.cc
@@ -15,8 +15,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::ecal::raw {
 
   class Kernel_unpack {
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc,
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                   unsigned char const* __restrict__ data,
                                   uint32_t const* __restrict__ offsets,
                                   int const* __restrict__ feds,

--- a/HeterogeneousCore/AlpakaInterface/test/alpaka/testAtomicPairCounter.dev.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/alpaka/testAtomicPairCounter.dev.cc
@@ -18,9 +18,8 @@ using namespace ALPAKA_ACCELERATOR_NAMESPACE;
 static constexpr auto s_tag = "[" ALPAKA_TYPE_ALIAS_NAME(alpakaTestAtomicPair) "]";
 
 struct update {
-  template <typename TAcc>
   ALPAKA_FN_ACC void operator()(
-      const TAcc &acc, AtomicPairCounter *dc, uint32_t *ind, uint32_t *cont, uint32_t n) const {
+      const Acc1D &acc, AtomicPairCounter *dc, uint32_t *ind, uint32_t *cont, uint32_t n) const {
     for (auto i : uniform_elements(acc, n)) {
       auto m = i % 11;
       m = m % 6 + 1;  // max 6, no 0
@@ -34,9 +33,8 @@ struct update {
 };
 
 struct finalize {
-  template <typename TAcc>
   ALPAKA_FN_ACC void operator()(
-      const TAcc &acc, AtomicPairCounter const *dc, uint32_t *ind, uint32_t *cont, uint32_t n) const {
+      const Acc1D &acc, AtomicPairCounter const *dc, uint32_t *ind, uint32_t *cont, uint32_t n) const {
     ALPAKA_ASSERT_ACC(dc->get().first == n);
     ind[n] = dc->get().second;
   }

--- a/HeterogeneousCore/AlpakaInterface/test/alpaka/testIndependentKernel.dev.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/alpaka/testIndependentKernel.dev.cc
@@ -18,8 +18,8 @@ using namespace ALPAKA_ACCELERATOR_NAMESPACE;
  * Each group is composed by the elements first[group]..first[group+1]-1 .
  */
 struct IndependentWorkKernel {
-  template <typename TAcc, typename T>
-  ALPAKA_FN_ACC void operator()(TAcc const& acc,
+  template <typename T>
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                 T const* __restrict__ in,
                                 T* __restrict__ out,
                                 size_t const* __restrict__ indices,

--- a/HeterogeneousCore/AlpakaInterface/test/alpaka/testKernel.dev.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/alpaka/testKernel.dev.cc
@@ -15,9 +15,9 @@
 using namespace ALPAKA_ACCELERATOR_NAMESPACE;
 
 struct VectorAddKernel {
-  template <typename TAcc, typename T>
+  template <typename T>
   ALPAKA_FN_ACC void operator()(
-      TAcc const& acc, T const* __restrict__ in1, T const* __restrict__ in2, T* __restrict__ out, size_t size) const {
+      Acc1D const& acc, T const* __restrict__ in1, T const* __restrict__ in2, T* __restrict__ out, size_t size) const {
     for (auto index : cms::alpakatools::uniform_elements(acc, size)) {
       out[index] = in1[index] + in2[index];
     }
@@ -25,8 +25,8 @@ struct VectorAddKernel {
 };
 
 struct VectorAddKernelSkip {
-  template <typename TAcc, typename T>
-  ALPAKA_FN_ACC void operator()(TAcc const& acc,
+  template <typename T>
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                 T const* __restrict__ in1,
                                 T const* __restrict__ in2,
                                 T* __restrict__ out,
@@ -39,9 +39,9 @@ struct VectorAddKernelSkip {
 };
 
 struct VectorAddKernel1D {
-  template <typename TAcc, typename T>
+  template <typename T>
   ALPAKA_FN_ACC void operator()(
-      TAcc const& acc, T const* __restrict__ in1, T const* __restrict__ in2, T* __restrict__ out, Vec1D size) const {
+      Acc1D const& acc, T const* __restrict__ in1, T const* __restrict__ in2, T* __restrict__ out, Vec1D size) const {
     for (auto ndindex : cms::alpakatools::uniform_elements_nd(acc, size)) {
       auto index = ndindex[0];
       out[index] = in1[index] + in2[index];
@@ -50,9 +50,9 @@ struct VectorAddKernel1D {
 };
 
 struct VectorAddKernel2D {
-  template <typename TAcc, typename T>
+  template <typename T>
   ALPAKA_FN_ACC void operator()(
-      TAcc const& acc, T const* __restrict__ in1, T const* __restrict__ in2, T* __restrict__ out, Vec2D size) const {
+      Acc2D const& acc, T const* __restrict__ in1, T const* __restrict__ in2, T* __restrict__ out, Vec2D size) const {
     for (auto ndindex : cms::alpakatools::uniform_elements_nd(acc, size)) {
       auto index = ndindex[0] * size[1] + ndindex[1];
       out[index] = in1[index] + in2[index];
@@ -61,9 +61,9 @@ struct VectorAddKernel2D {
 };
 
 struct VectorAddKernel3D {
-  template <typename TAcc, typename T>
+  template <typename T>
   ALPAKA_FN_ACC void operator()(
-      TAcc const& acc, T const* __restrict__ in1, T const* __restrict__ in2, T* __restrict__ out, Vec3D size) const {
+      Acc3D const& acc, T const* __restrict__ in1, T const* __restrict__ in2, T* __restrict__ out, Vec3D size) const {
     for (auto ndindex : cms::alpakatools::uniform_elements_nd(acc, size)) {
       auto index = (ndindex[0] * size[1] + ndindex[1]) * size[2] + ndindex[2];
       out[index] = in1[index] + in2[index];
@@ -76,9 +76,9 @@ struct VectorAddKernel3D {
  */
 
 struct VectorAddBlockKernel {
-  template <typename TAcc, typename T>
+  template <typename T>
   ALPAKA_FN_ACC void operator()(
-      TAcc const& acc, T const* __restrict__ in1, T const* __restrict__ in2, T* __restrict__ out, size_t size) const {
+      Acc1D const& acc, T const* __restrict__ in1, T const* __restrict__ in2, T* __restrict__ out, size_t size) const {
     // block size
     auto const blockSize = alpaka::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u];
     // get the dynamic shared memory buffer
@@ -119,9 +119,9 @@ struct VectorAddBlockKernel {
  */
 
 struct VectorAddKernelSerial {
-  template <typename TAcc, typename T>
+  template <typename T>
   ALPAKA_FN_ACC void operator()(
-      TAcc const& acc, T const* __restrict__ in1, T const* __restrict__ in2, T* __restrict__ out, size_t size) const {
+      Acc1D const& acc, T const* __restrict__ in1, T const* __restrict__ in2, T* __restrict__ out, size_t size) const {
     // the operations are performed by a single thread
     if (cms::alpakatools::once_per_grid(acc)) {
       for (Idx index = 0; index < size; ++index) {
@@ -137,9 +137,9 @@ struct VectorAddKernelSerial {
  */
 
 struct VectorAddKernelBlockSerial {
-  template <typename TAcc, typename T>
+  template <typename T>
   ALPAKA_FN_ACC void operator()(
-      TAcc const& acc, T const* __restrict__ in1, T const* __restrict__ in2, T* __restrict__ out, size_t size) const {
+      Acc1D const& acc, T const* __restrict__ in1, T const* __restrict__ in2, T* __restrict__ out, size_t size) const {
     // block size
     auto const blockSize = alpaka::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u];
     // the loop is used to repeat the "block" as many times as needed to cover the whole problem space
@@ -160,8 +160,8 @@ struct VectorAddKernelBlockSerial {
 namespace alpaka::trait {
   // specialize the BlockSharedMemDynSizeBytes trait to specify the amount of
   // block shared dynamic memory for the VectorAddBlockKernel kernel
-  template <typename TAcc>
-  struct BlockSharedMemDynSizeBytes<VectorAddBlockKernel, TAcc> {
+  template <>
+  struct BlockSharedMemDynSizeBytes<VectorAddBlockKernel, Acc1D> {
     // the size in bytes of the shared memory allocated for a block
     template <typename T>
     ALPAKA_FN_HOST_ACC static std::size_t getBlockSharedMemDynSizeBytes(VectorAddBlockKernel const& /* kernel */,

--- a/HeterogeneousCore/AlpakaInterface/test/alpaka/testOneHistoContainer.dev.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/alpaka/testOneHistoContainer.dev.cc
@@ -16,13 +16,12 @@ using namespace ALPAKA_ACCELERATOR_NAMESPACE;
 
 template <int NBINS, int S, int DELTA>
 struct mykernel {
-  template <typename TAcc, typename T>
-  ALPAKA_FN_ACC void operator()(const TAcc& acc, T const* __restrict__ v, uint32_t N) const {
+  template <typename T>
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc, T const* __restrict__ v, uint32_t N) const {
     ALPAKA_ASSERT_ACC(v);
     ALPAKA_ASSERT_ACC(N == 12000);
 
-    const uint32_t threadIdxLocal(alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u]);
-    if (threadIdxLocal == 0) {
+    if (once_per_block(acc)) {
       printf("start kernel for %d data\n", N);
     }
 

--- a/HeterogeneousCore/AlpakaInterface/test/alpaka/testOneToManyAssoc.dev.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/alpaka/testOneToManyAssoc.dev.cc
@@ -35,8 +35,7 @@ namespace {
 }  // namespace
 
 struct countMultiLocal {
-  template <typename TAcc>
-  ALPAKA_FN_ACC void operator()(const TAcc& acc,
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                 TK const* __restrict__ tk,
                                 Multiplicity* __restrict__ assoc,
                                 uint32_t n) const {
@@ -58,8 +57,7 @@ struct countMultiLocal {
 };
 
 struct countMulti {
-  template <typename TAcc>
-  ALPAKA_FN_ACC void operator()(const TAcc& acc,
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                 TK const* __restrict__ tk,
                                 Multiplicity* __restrict__ assoc,
                                 uint32_t n) const {
@@ -70,8 +68,7 @@ struct countMulti {
 };
 
 struct verifyMulti {
-  template <typename TAcc>
-  ALPAKA_FN_ACC void operator()(const TAcc& acc, Multiplicity* __restrict__ m1, Multiplicity* __restrict__ m2) const {
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc, Multiplicity* __restrict__ m1, Multiplicity* __restrict__ m2) const {
     for ([[maybe_unused]] auto i : uniform_elements(acc, Multiplicity{}.totOnes())) {
       ALPAKA_ASSERT_ACC(m1->off[i] == m2->off[i]);
     }
@@ -79,8 +76,7 @@ struct verifyMulti {
 };
 
 struct count {
-  template <typename TAcc>
-  ALPAKA_FN_ACC void operator()(const TAcc& acc,
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                 TK const* __restrict__ tk,
                                 AssocRandomAccess* __restrict__ assoc,
                                 uint32_t n) const {
@@ -99,8 +95,7 @@ struct count {
 };
 
 struct fill {
-  template <typename TAcc>
-  ALPAKA_FN_ACC void operator()(const TAcc& acc,
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                 TK const* __restrict__ tk,
                                 AssocRandomAccess* __restrict__ assoc,
                                 uint32_t n) const {
@@ -119,16 +114,19 @@ struct fill {
 };
 
 struct verify {
-  template <typename TAcc, typename Assoc>
-  ALPAKA_FN_ACC void operator()(const TAcc& acc, Assoc* __restrict__ assoc) const {
+  template <typename Assoc>
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc, Assoc* __restrict__ assoc) const {
     ALPAKA_ASSERT_ACC(assoc->size() < Assoc{}.capacity());
   }
 };
 
 struct fillBulk {
-  template <typename TAcc, typename Assoc>
-  ALPAKA_FN_ACC void operator()(
-      const TAcc& acc, AtomicPairCounter* apc, TK const* __restrict__ tk, Assoc* __restrict__ assoc, uint32_t n) const {
+  template <typename Assoc>
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc,
+                                AtomicPairCounter* apc,
+                                TK const* __restrict__ tk,
+                                Assoc* __restrict__ assoc,
+                                uint32_t n) const {
     for (auto k : uniform_elements(acc, n)) {
       auto m = tk[k][3] < MaxElem ? 4 : 3;
       assoc->bulkFill(acc, *apc, &tk[k][0], m);
@@ -137,8 +135,8 @@ struct fillBulk {
 };
 
 struct verifyBulk {
-  template <typename TAcc, typename Assoc>
-  ALPAKA_FN_ACC void operator()(const TAcc& acc, Assoc const* __restrict__ assoc, AtomicPairCounter const* apc) const {
+  template <typename Assoc>
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc, Assoc const* __restrict__ assoc, AtomicPairCounter const* apc) const {
     if (::toSigned(apc->get().first) >= Assoc::ctNOnes()) {
       printf("Overflow %d %d\n", apc->get().first, Assoc::ctNOnes());
     }

--- a/HeterogeneousCore/AlpakaInterface/test/alpaka/testPrefixScan.dev.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/alpaka/testPrefixScan.dev.cc
@@ -32,8 +32,7 @@ public:
 
 template <typename T>
 struct testPrefixScan {
-  template <typename TAcc>
-  ALPAKA_FN_ACC void operator()(const TAcc& acc, unsigned int size) const {
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc, unsigned int size) const {
     // alpaka::warp::getSize(acc) is runtime, but we need a compile-time or constexpr value
 #if defined(__CUDA_ARCH__)
     // CUDA always has a warp size of 32
@@ -85,9 +84,8 @@ struct testPrefixScan {
  */
 template <typename T>
 struct testWarpPrefixScan {
-  template <typename TAcc>
-  ALPAKA_FN_ACC void operator()(const TAcc& acc, uint32_t size) const {
-    if constexpr (!requires_single_thread_per_block_v<TAcc>) {
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc, uint32_t size) const {
+    if constexpr (not requires_single_thread_per_block_v<Acc1D>) {
       ALPAKA_ASSERT_ACC(size <= static_cast<uint32_t>(alpaka::warp::getSize(acc)));
       auto& c = alpaka::declareSharedVar<T[1024], __COUNTER__>(acc);
       auto& co = alpaka::declareSharedVar<T[1024], __COUNTER__>(acc);
@@ -115,15 +113,14 @@ struct testWarpPrefixScan {
         ALPAKA_ASSERT_ACC(c[i] == co[i]);
       }
     } else {
-      // We should never be called outsie of the GPU.
+      // This should never be called outsie for the serial CPU backend.
       ALPAKA_ASSERT_ACC(false);
     }
   }
 };
 
 struct init {
-  template <typename TAcc>
-  ALPAKA_FN_ACC void operator()(const TAcc& acc, uint32_t* v, uint32_t val, uint32_t n) const {
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc, uint32_t* v, uint32_t val, uint32_t n) const {
     for (auto index : uniform_elements(acc, n)) {
       v[index] = val;
 
@@ -134,8 +131,7 @@ struct init {
 };
 
 struct verify {
-  template <typename TAcc>
-  ALPAKA_FN_ACC void operator()(const TAcc& acc, uint32_t const* v, uint32_t n) const {
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc, uint32_t const* v, uint32_t n) const {
     for (auto index : uniform_elements(acc, n)) {
       ALPAKA_ASSERT_ACC(v[index] == index + 1);
 

--- a/HeterogeneousCore/AlpakaInterface/test/alpaka/testSimpleVector.dev.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/alpaka/testSimpleVector.dev.cc
@@ -16,23 +16,18 @@ using namespace cms::alpakatools;
 using namespace ALPAKA_ACCELERATOR_NAMESPACE;
 
 struct vector_pushback {
-  template <typename TAcc>
-  ALPAKA_FN_ACC void operator()(const TAcc& acc, SimpleVector<int>* foo) const {
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc, SimpleVector<int>* foo) const {
     for (auto index : uniform_elements(acc))
       foo->push_back(acc, index);
   }
 };
 
 struct vector_reset {
-  template <typename TAcc>
-  ALPAKA_FN_ACC void operator()(const TAcc& acc, SimpleVector<int>* foo) const {
-    foo->reset();
-  }
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc, SimpleVector<int>* foo) const { foo->reset(); }
 };
 
 struct vector_emplace_back {
-  template <typename TAcc>
-  ALPAKA_FN_ACC void operator()(const TAcc& acc, SimpleVector<int>* foo) const {
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc, SimpleVector<int>* foo) const {
     for (auto index : uniform_elements(acc))
       foo->emplace_back(acc, index);
   }

--- a/HeterogeneousCore/AlpakaInterface/test/alpaka/testWorkDivision.dev.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/alpaka/testWorkDivision.dev.cc
@@ -21,19 +21,6 @@ enum class RangeType { Default, ExtentLimited, ExtentLimitedWithShift };
 // The concurrency scope between threads
 enum class LoopScope { Block, Grid };
 
-template <RangeType rangeType, LoopScope loopScope, typename TAcc>
-size_t constexpr expectedCount(TAcc const& acc, size_t skip, size_t size) {
-  if constexpr (rangeType == RangeType::ExtentLimitedWithShift)
-    return skip < size ? size - skip : 0;
-  else if constexpr (rangeType == RangeType::ExtentLimited)
-    return size;
-  else /* rangeType == RangeType::Default */
-    if constexpr (loopScope == LoopScope::Block)
-      return alpaka::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u];
-    else
-      return alpaka::getWorkDiv<alpaka::Grid, alpaka::Elems>(acc)[0u];
-}
-
 template <RangeType rangeType, LoopScope loopScope>
 size_t constexpr expectedCount(WorkDiv1D const& workDiv, size_t skip, size_t size) {
   if constexpr (rangeType == RangeType::ExtentLimitedWithShift)
@@ -49,8 +36,7 @@ size_t constexpr expectedCount(WorkDiv1D const& workDiv, size_t skip, size_t siz
 
 template <RangeType rangeType, LoopScope loopScope>
 struct testWordDivisionDefaultRange {
-  template <typename TAcc>
-  ALPAKA_FN_ACC void operator()(TAcc const& acc, size_t size, size_t skip, size_t* globalCounter) const {
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc, size_t size, size_t skip, size_t* globalCounter) const {
     size_t& counter =
         (loopScope == LoopScope::Grid ? *globalCounter : alpaka::declareSharedVar<size_t, __COUNTER__>(acc));
     // Init the counter for block range. Grid range does so my mean of memset.

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlgo.dev.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlgo.dev.cc
@@ -17,8 +17,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   class TestAlgoKernel {
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc, portabletest::TestDeviceCollection::View view, double xvalue) const {
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
+                                  portabletest::TestDeviceCollection::View view,
+                                  double xvalue) const {
       const portabletest::Matrix matrix{{1, 2, 3, 4, 5, 6}, {2, 4, 6, 8, 10, 12}, {3, 6, 9, 12, 15, 18}};
       const portabletest::Array flags = {{6, 4, 2, 0}};
 
@@ -36,8 +37,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   class TestAlgoMultiKernel2 {
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc,
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                   portabletest::TestDeviceMultiCollection2::View<1> view,
                                   double xvalue) const {
       const portabletest::Matrix matrix{{1, 2, 3, 4, 5, 6}, {2, 4, 6, 8, 10, 12}, {3, 6, 9, 12, 15, 18}};
@@ -56,8 +56,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   class TestAlgoMultiKernel3 {
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc,
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                   portabletest::TestDeviceMultiCollection3::View<2> view,
                                   double xvalue) const {
       const portabletest::Matrix matrix{{1, 2, 3, 4, 5, 6}, {2, 4, 6, 8, 10, 12}, {3, 6, 9, 12, 15, 18}};
@@ -109,8 +108,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   class TestAlgoStructKernel {
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc,
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                   portabletest::TestDeviceObject::Product* data,
                                   double x,
                                   double y,
@@ -157,8 +155,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   class TestAlgoKernelUpdate {
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc,
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                   portabletest::TestDeviceCollection::ConstView input,
                                   AlpakaESTestDataEDevice::ConstView esData,
                                   portabletest::TestDeviceCollection::View output) const {
@@ -197,8 +194,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   class TestAlgoKernelUpdateMulti2 {
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc,
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                   portabletest::TestSoA::ConstView input,
                                   portabletest::TestSoA2::ConstView input2,
                                   AlpakaESTestDataEDevice::ConstView esData,
@@ -255,8 +251,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   class TestAlgoKernelUpdateMulti3 {
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc,
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                   portabletest::TestSoA::ConstView input,
                                   portabletest::TestSoA2::ConstView input2,
                                   portabletest::TestSoA3::ConstView input3,
@@ -497,8 +492,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   class TestZeroCollectionKernel {
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc, portabletest::TestDeviceCollection::ConstView view) const {
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc, portabletest::TestDeviceCollection::ConstView view) const {
       const portabletest::Matrix matrix{{0, 0, 0, 0, 0, 0}, {0, 0, 0, 0, 0, 0}, {0, 0, 0, 0, 0, 0}};
       const portabletest::Array flags = {{0, 0, 0, 0}};
 
@@ -522,8 +516,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   class TestZeroMultiCollectionKernel2 {
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc, portabletest::TestDeviceMultiCollection2::ConstView<1> view) const {
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc, portabletest::TestDeviceMultiCollection2::ConstView<1> view) const {
       const portabletest::Matrix matrix{{0, 0, 0, 0, 0, 0}, {0, 0, 0, 0, 0, 0}, {0, 0, 0, 0, 0, 0}};
 
       // check this only once in the whole kernel grid
@@ -545,8 +538,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   class TestZeroMultiCollectionKernel3 {
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc, portabletest::TestDeviceMultiCollection3::ConstView<2> view) const {
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc, portabletest::TestDeviceMultiCollection3::ConstView<2> view) const {
       const portabletest::Matrix matrix{{0, 0, 0, 0, 0, 0}, {0, 0, 0, 0, 0, 0}, {0, 0, 0, 0, 0, 0}};
 
       // check this only once in the whole kernel grid
@@ -568,8 +560,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   class TestZeroStructKernel {
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc, portabletest::TestDeviceObject::Product const* data) const {
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc, portabletest::TestDeviceObject::Product const* data) const {
       // check this only once in the whole kernel grid
       if (once_per_grid(acc)) {
         ALPAKA_ASSERT(data->x == 0.);

--- a/MagneticField/ParametrizedEngine/test/alpaka/testParabolicParametrizedMagneticField.dev.cc
+++ b/MagneticField/ParametrizedEngine/test/alpaka/testParabolicParametrizedMagneticField.dev.cc
@@ -20,8 +20,8 @@ using namespace magneticFieldParabolicPortable;
 using Vector3f = Eigen::Matrix<float, 3, 1>;
 
 struct MagneticFieldKernel {
-  template <typename TAcc, typename T>
-  ALPAKA_FN_ACC void operator()(TAcc const& acc, T const* __restrict__ in, T* __restrict__ out, size_t size) const {
+  template <typename T>
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc, T const* __restrict__ in, T* __restrict__ out, size_t size) const {
     for (auto index : cms::alpakatools::uniform_elements(acc, size)) {
       out[index](0) = 0;
       out[index](1) = 0;

--- a/RecoLocalCalo/EcalRecProducers/plugins/alpaka/AmplitudeComputationCommonKernels.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/alpaka/AmplitudeComputationCommonKernels.h
@@ -28,8 +28,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::ecal::multifit {
   ///
   class Kernel_prep_1d_and_initialize {
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc,
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                   EcalDigiDeviceCollection::ConstView digisDevEB,
                                   EcalDigiDeviceCollection::ConstView digisDevEE,
                                   EcalUncalibratedRecHitDeviceCollection::View uncalibRecHitsEB,
@@ -328,8 +327,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::ecal::multifit {
   ///
   class Kernel_prep_2d {
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc,
+    ALPAKA_FN_ACC void operator()(Acc2D const& acc,
                                   EcalDigiDeviceCollection::ConstView digisDevEB,
                                   EcalDigiDeviceCollection::ConstView digisDevEE,
                                   EcalMultifitConditionsDevice::ConstView conditionsDev,
@@ -466,11 +464,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::ecal::multifit {
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE::ecal::multifit
 
 namespace alpaka::trait {
+  using namespace ALPAKA_ACCELERATOR_NAMESPACE;
   using namespace ALPAKA_ACCELERATOR_NAMESPACE::ecal::multifit;
 
   //! The trait for getting the size of the block shared dynamic memory for Kernel_prep_1d_and_initialize.
-  template <typename TAcc>
-  struct BlockSharedMemDynSizeBytes<Kernel_prep_1d_and_initialize, TAcc> {
+  template <>
+  struct BlockSharedMemDynSizeBytes<Kernel_prep_1d_and_initialize, Acc1D> {
     //! \return The size of the shared memory allocated for a block.
     template <typename TVec, typename... TArgs>
     ALPAKA_FN_HOST_ACC static auto getBlockSharedMemDynSizeBytes(Kernel_prep_1d_and_initialize const&,

--- a/RecoLocalCalo/EcalRecProducers/plugins/alpaka/AmplitudeComputationKernels.dev.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/alpaka/AmplitudeComputationKernels.dev.cc
@@ -55,8 +55,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::ecal::multifit {
   ///
   class Kernel_minimize {
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc,
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                   InputProduct::ConstView const& digisDevEB,
                                   InputProduct::ConstView const& digisDevEE,
                                   OutputProduct::View uncalibRecHitsEB,
@@ -293,23 +292,25 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::ecal::multifit {
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE::ecal::multifit
 
 namespace alpaka::trait {
+  using namespace ALPAKA_ACCELERATOR_NAMESPACE;
   using namespace ALPAKA_ACCELERATOR_NAMESPACE::ecal::multifit;
 
   //! The trait for getting the size of the block shared dynamic memory for Kernel_minimize.
-  template <typename TAcc>
-  struct BlockSharedMemDynSizeBytes<Kernel_minimize, TAcc> {
+  template <>
+  struct BlockSharedMemDynSizeBytes<Kernel_minimize, Acc1D> {
     //! \return The size of the shared memory allocated for a block.
     template <typename TVec, typename... TArgs>
     ALPAKA_FN_HOST_ACC static auto getBlockSharedMemDynSizeBytes(Kernel_minimize const&,
                                                                  TVec const& threadsPerBlock,
                                                                  TVec const& elemsPerThread,
                                                                  TArgs const&...) -> std::size_t {
-      using ScalarType = ecal::multifit::SampleVector::Scalar;
+      using ScalarType = ::ecal::multifit::SampleVector::Scalar;
 
       // return the amount of dynamic shared memory needed
-      std::size_t bytes = 2 * threadsPerBlock[0u] * elemsPerThread[0u] *
-                          calo::multifit::MapSymM<ScalarType, ecal::multifit::SampleVector::RowsAtCompileTime>::total *
-                          sizeof(ScalarType);
+      std::size_t bytes =
+          2 * threadsPerBlock[0u] * elemsPerThread[0u] *
+          calo::multifit::MapSymM<ScalarType, ::ecal::multifit::SampleVector::RowsAtCompileTime>::total *
+          sizeof(ScalarType);
       return bytes;
     }
   };

--- a/RecoLocalCalo/EcalRecProducers/plugins/alpaka/TimeComputationKernels.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/alpaka/TimeComputationKernels.h
@@ -33,8 +33,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::ecal::multifit {
     using ScalarType = ::ecal::multifit::SampleVector::Scalar;
 
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc,
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                   ScalarType* const sample_values,
                                   ScalarType* const sample_value_errors,
                                   bool* const useless_sample_values,
@@ -120,8 +119,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::ecal::multifit {
     using ScalarType = ::ecal::multifit::SampleVector::Scalar;
 
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc,
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                   EcalDigiDeviceCollection::ConstView digisDevEB,
                                   EcalDigiDeviceCollection::ConstView digisDevEE,
                                   ScalarType* const sample_values,
@@ -523,8 +521,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::ecal::multifit {
     using ScalarType = ::ecal::multifit::SampleVector::Scalar;
 
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc,
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                   EcalDigiDeviceCollection::ConstView digisDevEB,
                                   EcalDigiDeviceCollection::ConstView digisDevEE,
                                   ScalarType* const sample_values,
@@ -730,8 +727,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::ecal::multifit {
     using ScalarType = ::ecal::multifit::SampleVector::Scalar;
 
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc,
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                   EcalDigiDeviceCollection::ConstView digisDevEB,
                                   EcalDigiDeviceCollection::ConstView digisDevEE,
                                   EcalMultifitConditionsDevice::ConstView conditionsDev,
@@ -777,8 +773,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::ecal::multifit {
     using ScalarType = ::ecal::multifit::SampleVector::Scalar;
 
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc,
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                   EcalDigiDeviceCollection::ConstView digisDevEB,
                                   EcalDigiDeviceCollection::ConstView digisDevEE,
                                   EcalMultifitConditionsDevice::ConstView conditionsDev,
@@ -960,8 +955,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::ecal::multifit {
     using ScalarType = ::ecal::multifit::SampleVector::Scalar;
 
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc,
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                   EcalDigiDeviceCollection::ConstView digisDevEB,
                                   EcalDigiDeviceCollection::ConstView digisDevEE,
                                   EcalUncalibratedRecHitDeviceCollection::View uncalibRecHitsEB,
@@ -1095,18 +1089,19 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::ecal::multifit {
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE::ecal::multifit
 
 namespace alpaka::trait {
+  using namespace ALPAKA_ACCELERATOR_NAMESPACE;
   using namespace ALPAKA_ACCELERATOR_NAMESPACE::ecal::multifit;
 
   //! The trait for getting the size of the block shared dynamic memory for Kernel_time_compute_nullhypot.
-  template <typename TAcc>
-  struct BlockSharedMemDynSizeBytes<Kernel_time_compute_nullhypot, TAcc> {
+  template <>
+  struct BlockSharedMemDynSizeBytes<Kernel_time_compute_nullhypot, Acc1D> {
     //! \return The size of the shared memory allocated for a block.
     template <typename TVec, typename... TArgs>
     ALPAKA_FN_HOST_ACC static auto getBlockSharedMemDynSizeBytes(Kernel_time_compute_nullhypot const&,
                                                                  TVec const& threadsPerBlock,
                                                                  TVec const& elemsPerThread,
                                                                  TArgs const&...) -> std::size_t {
-      using ScalarType = ecal::multifit::SampleVector::Scalar;
+      using ScalarType = ::ecal::multifit::SampleVector::Scalar;
 
       // return the amount of dynamic shared memory needed
       std::size_t bytes = threadsPerBlock[0u] * elemsPerThread[0u] * 4 * sizeof(ScalarType);
@@ -1115,14 +1110,14 @@ namespace alpaka::trait {
   };
 
   //! The trait for getting the size of the block shared dynamic memory for Kernel_time_compute_makeratio.
-  template <typename TAcc>
-  struct BlockSharedMemDynSizeBytes<Kernel_time_compute_makeratio, TAcc> {
+  template <>
+  struct BlockSharedMemDynSizeBytes<Kernel_time_compute_makeratio, Acc1D> {
     template <typename TVec, typename... TArgs>
     ALPAKA_FN_HOST_ACC static auto getBlockSharedMemDynSizeBytes(Kernel_time_compute_makeratio const&,
                                                                  TVec const& threadsPerBlock,
                                                                  TVec const& elemsPerThread,
                                                                  TArgs const&...) -> std::size_t {
-      using ScalarType = ecal::multifit::SampleVector::Scalar;
+      using ScalarType = ::ecal::multifit::SampleVector::Scalar;
 
       std::size_t bytes = (8 * sizeof(ScalarType) + 3 * sizeof(bool)) * threadsPerBlock[0u] * elemsPerThread[0u];
       return bytes;
@@ -1130,14 +1125,14 @@ namespace alpaka::trait {
   };
 
   //! The trait for getting the size of the block shared dynamic memory for Kernel_time_compute_findamplchi2_and_finish.
-  template <typename TAcc>
-  struct BlockSharedMemDynSizeBytes<Kernel_time_compute_findamplchi2_and_finish, TAcc> {
+  template <>
+  struct BlockSharedMemDynSizeBytes<Kernel_time_compute_findamplchi2_and_finish, Acc1D> {
     template <typename TVec, typename... TArgs>
     ALPAKA_FN_HOST_ACC static auto getBlockSharedMemDynSizeBytes(Kernel_time_compute_findamplchi2_and_finish const&,
                                                                  TVec const& threadsPerBlock,
                                                                  TVec const& elemsPerThread,
                                                                  TArgs const&...) -> std::size_t {
-      using ScalarType = ecal::multifit::SampleVector::Scalar;
+      using ScalarType = ::ecal::multifit::SampleVector::Scalar;
 
       std::size_t bytes = 2 * threadsPerBlock[0u] * elemsPerThread[0u] * sizeof(ScalarType);
       return bytes;
@@ -1145,14 +1140,14 @@ namespace alpaka::trait {
   };
 
   //! The trait for getting the size of the block shared dynamic memory for Kernel_time_computation_init.
-  template <typename TAcc>
-  struct BlockSharedMemDynSizeBytes<Kernel_time_computation_init, TAcc> {
+  template <>
+  struct BlockSharedMemDynSizeBytes<Kernel_time_computation_init, Acc1D> {
     template <typename TVec, typename... TArgs>
     ALPAKA_FN_HOST_ACC static auto getBlockSharedMemDynSizeBytes(Kernel_time_computation_init const&,
                                                                  TVec const& threadsPerBlock,
                                                                  TVec const& elemsPerThread,
                                                                  TArgs const&...) -> std::size_t {
-      using ScalarType = ecal::multifit::SampleVector::Scalar;
+      using ScalarType = ::ecal::multifit::SampleVector::Scalar;
 
       std::size_t bytes = 2 * threadsPerBlock[0u] * elemsPerThread[0u] * sizeof(ScalarType);
       return bytes;

--- a/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalLayerClustersSoAAlgoWrapper.dev.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalLayerClustersSoAAlgoWrapper.dev.cc
@@ -13,8 +13,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   // Set energy and number of hits in each clusters
   class HGCalLayerClustersSoAAlgoKernelEnergy {
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc,
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                   const unsigned int numer_of_clusters,
                                   const HGCalSoARecHitsDeviceCollection::ConstView input_rechits_soa,
                                   const HGCalSoARecHitsExtraDeviceCollection::ConstView input_clusters_soa,
@@ -38,8 +37,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   // Kernel to find the max for every cluster
   class HGCalLayerClustersSoAAlgoKernelPositionByHits {
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc,
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                   const unsigned int numer_of_clusters,
                                   float thresholdW0,
                                   float positionDeltaRho2,
@@ -83,8 +81,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   // Real Kernel position
   class HGCalLayerClustersSoAAlgoKernelPositionByHits2 {
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc,
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                   const unsigned int numer_of_clusters,
                                   float thresholdW0,
                                   float positionDeltaRho2,
@@ -121,8 +118,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   // Besides the final position, add also the DetId of the seed of each cluster
   class HGCalLayerClustersSoAAlgoKernelPositionByHits3 {
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc,
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                   const unsigned int numer_of_clusters,
                                   float thresholdW0,
                                   float positionDeltaRho2,

--- a/RecoLocalCalo/HcalRecProducers/plugins/alpaka/Mahi.dev.cc
+++ b/RecoLocalCalo/HcalRecProducers/plugins/alpaka/Mahi.dev.cc
@@ -268,8 +268,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
       class Kernel_prep1d_sameNumberOfSamples {
       public:
-        template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-        ALPAKA_FN_ACC void operator()(TAcc const& acc,
+        ALPAKA_FN_ACC void operator()(Acc2D const& acc,
                                       OProductType::View outputGPU,
                                       IProductTypef01::ConstView f01HEDigis,
                                       IProductTypef5::ConstView f5HBDigis,
@@ -748,8 +747,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
       class Kernel_prep_pulseMatrices_sameNumberOfSamples {
       public:
-        template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-        ALPAKA_FN_ACC void operator()(TAcc const& acc,
+        ALPAKA_FN_ACC void operator()(Acc3D const& acc,
                                       float* pulseMatrices,
                                       float* pulseMatricesM,
                                       float* pulseMatricesP,
@@ -968,8 +966,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       template <int NSAMPLES, int NPULSES>
       class Kernel_minimize {
       public:
-        template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-        ALPAKA_FN_ACC void operator()(TAcc const& acc,
+        ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                       OProductType::View outputGPU,
                                       float const* amplitudes,
                                       float* pulseMatrices,
@@ -1408,11 +1405,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE
 
 namespace alpaka::trait {
+  using namespace ALPAKA_ACCELERATOR_NAMESPACE;
   using namespace ALPAKA_ACCELERATOR_NAMESPACE::hcal::reconstruction::mahi;
 
   //! The trait for getting the size of the block shared dynamic memory for Kernel_prep_1d_and_initialize.
-  template <typename TAcc>
-  struct BlockSharedMemDynSizeBytes<Kernel_prep1d_sameNumberOfSamples, TAcc> {
+  template <>
+  struct BlockSharedMemDynSizeBytes<Kernel_prep1d_sameNumberOfSamples, Acc2D> {
     //! \return The size of the shared memory allocated for a block.
     template <typename TVec, typename... TArgs>
     ALPAKA_FN_HOST_ACC static auto getBlockSharedMemDynSizeBytes(Kernel_prep1d_sameNumberOfSamples const&,
@@ -1431,8 +1429,8 @@ namespace alpaka::trait {
   };
 
   //! The trait for getting the size of the block shared dynamic memory for kernel_minimize.
-  template <int NSAMPLES, int NPULSES, typename TAcc>
-  struct BlockSharedMemDynSizeBytes<Kernel_minimize<NSAMPLES, NPULSES>, TAcc> {
+  template <int NSAMPLES, int NPULSES>
+  struct BlockSharedMemDynSizeBytes<Kernel_minimize<NSAMPLES, NPULSES>, Acc1D> {
     //! \return The size of the shared memory allocated for a block.
     template <typename TVec, typename... TArgs>
     ALPAKA_FN_HOST_ACC static auto getBlockSharedMemDynSizeBytes(Kernel_minimize<NSAMPLES, NPULSES> const&,

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.dev.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.dev.cc
@@ -289,8 +289,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     // Kernel to perform Raw to Digi conversion
     template <bool debug = false>
     struct RawToDigi_kernel {
-      template <typename TAcc>
-      ALPAKA_FN_ACC void operator()(const TAcc &acc,
+      ALPAKA_FN_ACC void operator()(Acc1D const &acc,
                                     const SiPixelMappingSoAConstView &cablingMap,
                                     const unsigned char *modToUnp,
                                     const uint32_t wordCounter,
@@ -430,8 +429,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     template <typename TrackerTraits>
     struct FillHitsModuleStart {
-      template <typename TAcc>
-      ALPAKA_FN_ACC void operator()(const TAcc &acc, SiPixelClustersSoAView clus_view) const {
+      ALPAKA_FN_ACC void operator()(Acc1D const &acc, SiPixelClustersSoAView clus_view) const {
         constexpr bool isPhase2 = std::is_base_of<pixelTopology::Phase2, TrackerTraits>::value;
 
         // For Phase1 there are 1856 pixel modules

--- a/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/PixelRecHitKernels.dev.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/PixelRecHitKernels.dev.cc
@@ -29,8 +29,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   template <typename TrackerTraits>
   class setHitsLayerStart {
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc,
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                   uint32_t const* __restrict__ hitsModuleStart,
                                   pixelCPEforDevice::ParamsOnDeviceT<TrackerTraits> const* __restrict__ cpeParams,
                                   uint32_t* __restrict__ hitsLayerStart) const {

--- a/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/PixelRecHits.h
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/PixelRecHits.h
@@ -29,8 +29,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     template <typename TrackerTraits>
     class GetHits {
     public:
-      template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-      ALPAKA_FN_ACC void operator()(const TAcc& acc,
+      ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                     pixelCPEforDevice::ParamsOnDeviceT<TrackerTraits> const* __restrict__ cpeParams,
                                     BeamSpotPOD const* __restrict__ bs,
                                     SiPixelDigisSoAConstView digis,

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducerKernel.dev.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducerKernel.dev.cc
@@ -86,9 +86,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   // Processing single seed clusters
   // Device function designed to be called by all threads of a given block
-  template <bool debug = false, typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
+  template <bool debug = false>
   ALPAKA_FN_ACC static void hcalFastCluster_singleSeed(
-      const TAcc& acc,
+      const Acc1D& acc,
       ::reco::PFClusterParamsSoA::ConstView pfClusParams,
       const reco::PFRecHitHCALTopologyDeviceCollection::ConstView topology,
       int topoId,   // from selection
@@ -254,9 +254,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   // Processing clusters up to 100 seeds and 512 non-seed rechits using shared memory accesses
   // Device function designed to be called by all threads of a given block
-  template <bool debug = false, typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
+  template <bool debug = false>
   ALPAKA_FN_ACC static void hcalFastCluster_multiSeedParallel(
-      const TAcc& acc,
+      const Acc1D& acc,
       ::reco::PFClusterParamsSoA::ConstView pfClusParams,
       const reco::PFRecHitHCALTopologyDeviceCollection::ConstView topology,
       int topoId,   // from selection
@@ -541,8 +541,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   // Process very large exotic clusters, from nSeeds > 400 and non-seeds > 1500
   // Uses global memory access
   // Device function designed to be called by all threads of a given block
-  template <bool debug = false, typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-  ALPAKA_FN_ACC static void hcalFastCluster_exotic(const TAcc& acc,
+  template <bool debug = false>
+  ALPAKA_FN_ACC static void hcalFastCluster_exotic(const Acc1D& acc,
                                                    ::reco::PFClusterParamsSoA::ConstView pfClusParams,
                                                    const reco::PFRecHitHCALTopologyDeviceCollection::ConstView topology,
                                                    int topoId,
@@ -815,9 +815,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   // Process clusters with up to 400 seeds and 1500 non seeds using shared memory
   // Device function designed to be called by all threads of a given block
-  template <bool debug = false, typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
+  template <bool debug = false>
   ALPAKA_FN_ACC static void hcalFastCluster_multiSeedIterative(
-      const TAcc& acc,
+      const Acc1D& acc,
       ::reco::PFClusterParamsSoA::ConstView pfClusParams,
       const reco::PFRecHitHCALTopologyDeviceCollection::ConstView topology,
       int topoId,
@@ -1082,8 +1082,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   // Seeding using local energy maxima
   class SeedingTopoThresh {
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(const TAcc& acc,
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                   reco::PFClusteringVarsDeviceCollection::View pfClusteringVars,
                                   const ::reco::PFClusterParamsSoA::ConstView pfClusParams,
                                   const reco::PFRecHitHCALTopologyDeviceCollection::ConstView topology,
@@ -1162,8 +1161,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   // Preparation of topo inputs. Initializing topoId, egdeIdx, nEdges, edgeList
   class PrepareTopoInputs {
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(const TAcc& acc,
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                   const reco::PFRecHitDeviceCollection::ConstView pfRecHits,
                                   reco::PFClusteringVarsDeviceCollection::View pfClusteringVars,
                                   reco::PFClusteringEdgeVarsDeviceCollection::View pfClusteringEdgeVars,
@@ -1192,8 +1190,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   // Contraction in a single block
   class TopoClusterContraction {
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(const TAcc& acc,
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                   const reco::PFRecHitDeviceCollection::ConstView pfRecHits,
                                   reco::PFClusteringVarsDeviceCollection::View pfClusteringVars,
                                   reco::PFClusterDeviceCollection::View clusterView,
@@ -1316,8 +1313,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   // Optimized for GPU parallel, but works on any backend
   class FillRhfIndex {
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(const TAcc& acc,
+    ALPAKA_FN_ACC void operator()(Acc2D const& acc,
                                   const reco::PFRecHitDeviceCollection::ConstView pfRecHits,
                                   reco::PFClusteringVarsDeviceCollection::View pfClusteringVars,
                                   reco::PFRecHitFractionDeviceCollection::View fracView) const {
@@ -1347,8 +1343,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   class FastCluster {
   public:
-    template <bool debug = false, typename TAcc, typename = std::enable_if<!std::is_same_v<Device, alpaka::DevCpu>>>
-    ALPAKA_FN_ACC void operator()(const TAcc& acc,
+    template <bool debug = false, typename = std::enable_if<!std::is_same_v<Device, alpaka::DevCpu>>>
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                   const reco::PFRecHitDeviceCollection::ConstView pfRecHits,
                                   const ::reco::PFClusterParamsSoA::ConstView pfClusParams,
                                   const reco::PFRecHitHCALTopologyDeviceCollection::ConstView topology,
@@ -1409,8 +1405,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   // Process very large, exotic topo clusters
   class FastClusterExotic {
   public:
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(const TAcc& acc,
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                   const reco::PFRecHitDeviceCollection::ConstView pfRecHits,
                                   const ::reco::PFClusterParamsSoA::ConstView pfClusParams,
                                   const reco::PFRecHitHCALTopologyDeviceCollection::ConstView topology,

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitProducerKernel.dev.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitProducerKernel.dev.cc
@@ -13,8 +13,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   // Kernel to apply cuts to calorimeter hits and construct PFRecHits
   template <typename CAL>
   struct PFRecHitProducerKernelConstruct {
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(const TAcc& acc,
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                   const typename CAL::ParameterType::ConstView params,
                                   const typename CAL::TopologyTypeDevice::ConstView topology,
                                   const typename CAL::CaloRecHitSoATypeDevice::ConstView recHits,
@@ -142,8 +141,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   // Kernel to associate topology information of PFRecHits
   template <typename CAL>
   struct PFRecHitProducerKernelTopology {
-    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-    ALPAKA_FN_ACC void operator()(const TAcc& acc,
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                   const typename CAL::TopologyTypeDevice::ConstView topology,
                                   reco::PFRecHitDeviceCollection::View pfRecHits,
                                   const uint32_t* __restrict__ denseId2pfRecHit,


### PR DESCRIPTION
#### PR description:

Replace the `TAcc` template with the explicit accelerator type (`Acc1D`, `Acc2D`, or `Acc3D`).

#### PR validation:

The code builds.