### PR TITLE
Fix for importing ClassesDefXmlUtils

### DIFF
--- a/FWCore/Reflection/scripts/edmCheckClassVersion
+++ b/FWCore/Reflection/scripts/edmCheckClassVersion
@@ -1,7 +1,12 @@
 #!  /usr/bin/env python3
 
 import sys
-import FWCore.Reflection.ClassesDefXmlUtils as ClassesDefUtils
+try:
+  import FWCore.Reflection.ClassesDefXmlUtils as ClassesDefUtils
+except:
+  import os
+  sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)),"python"))
+  import ClassesDefXmlUtils as ClassesDefUtils
 
 # recursively check the base classes for a class pointer
 # as building the streamer will crash if base classes are


### PR DESCRIPTION
This change allows to import `ClassesDefXmlUtils` while building patch release where python path is not set during build phase. 
This change allows to build patch releases without the fix in the cmsdist. This should be backported to 14.1.X and 14.2.X so that we can build patch releases for those release cycles if needed. 
I will fix the build recipe (cmsdist / cmssw-config) for 14.1.X and above but that will only go in the next full build. 