### PR TITLE
[14.2.X]Fix for importing ClassesDefXmlUtils

### DIFF
--- a/FWCore/Reflection/scripts/edmCheckClassVersion
+++ b/FWCore/Reflection/scripts/edmCheckClassVersion
@@ -1,7 +1,12 @@
 #!  /usr/bin/env python3
 
 import sys
-import FWCore.Reflection.ClassesDefXmlUtils as ClassesDefUtils
+try:
+  import FWCore.Reflection.ClassesDefXmlUtils as ClassesDefUtils
+except:
+  import os
+  sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)),"python"))
+  import ClassesDefXmlUtils as ClassesDefUtils
 
 # recursively check the base classes for a class pointer
 # as building the streamer will crash if base classes are


### PR DESCRIPTION
backport of #46919
This should fix the patch [build errors](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_14_2_X_2024-12-11-2300/AnalysisDataFormats/SUSYBSMObjects) like
```
>> Checking EDM Class Version for src/AnalysisDataFormats/SUSYBSMObjects/src/classes_def.xml in libAnalysisDataFormatsSUSYBSMObjects.so
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/cms/cmssw/CMSSW_14_2_X_2024-12-08-0000/src/FWCore/Reflection/scripts/edmCheckClassVersion -l libAnalysisDataFormatsSUSYBSMObjects.so -x /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/51a12ecc6fa5b95709134408c954413b/opt/cmssw/el8_amd64_gcc12/cms/cmssw-patch/CMSSW_14_2_X_2024-12-11-2300/src/AnalysisDataFormats/SUSYBSMObjects/src/classes_def.xml
Traceback (most recent call last):
  File "/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/cms/cmssw/CMSSW_14_2_X_2024-12-08-0000/src/FWCore/Reflection/scripts/edmCheckClassVersion", line 4, in <module>
    import FWCore.Reflection.ClassesDefXmlUtils as ClassesDefUtils
ModuleNotFoundError: No module named 'FWCore.Reflection.ClassesDefXmlUtils'

```