### PR TITLE
Improve L1TRawToDigi

### DIFF
--- a/DQM/L1TMonitor/plugins/L1TBMTFAlgoSelector.cc
+++ b/DQM/L1TMonitor/plugins/L1TBMTFAlgoSelector.cc
@@ -82,8 +82,8 @@ void dqmBmtfAlgoSelector::L1TBMTFAlgoSelector::produce(edm::Event &eve, const ed
   unsigned algo_ver;
   if (!packet.payload().empty()) {
     auto payload64 = (packet.payload().at(0)).data();
-    const uint32_t *start = (const uint32_t *)payload64.get();
-    const uint32_t *end = start + (packet.payload().at(0).size() * 2);
+    const uint32_t *start = reinterpret_cast<const uint32_t *>(&payload64.front());
+    const uint32_t *end = start + (payload64.size() * 2);
 
     l1t::MP7Payload payload(start, end, false);
     algo_ver = payload.getAlgorithmFWVersion();

--- a/DQM/L1TMonitor/src/L1TMP7ZeroSupp.cc
+++ b/DQM/L1TMonitor/src/L1TMP7ZeroSupp.cc
@@ -231,16 +231,16 @@ void L1TMP7ZeroSupp::analyze(const edm::Event& e, const edm::EventSetup& c) {
         continue;
 
       auto payload64 = amc.data();
-      auto start = (const uint32_t*)payload64.get();
+      auto start = reinterpret_cast<const uint32_t*>(&payload64.front());
       // Want to have payload size in 32 bit words, but AMC measures
       // it in 64 bit words -> factor 2.
-      const uint32_t* end = start + (amc.size() * 2);
+      const uint32_t* end = start + (payload64.size() * 2);
 
       auto payload = std::make_unique<l1t::MP7Payload>(start, end, false);
 
-      // getBlock() returns a non-null unique_ptr on success
-      std::unique_ptr<l1t::Block> block;
-      while ((block = payload->getBlock()) != nullptr) {
+      // getBlock() returns a non-nullopt_t optional on success
+      std::optional<l1t::Block> block;
+      while ((block = payload->getBlock())) {
         if (verbose_) {
           std::cout << ">>> check zero suppression for block <<<" << std::endl
                     << "hdr:  " << std::hex << std::setw(8) << std::setfill('0') << block->header().raw() << std::dec

--- a/EventFilter/L1TRawToDigi/interface/AMC13Spec.h
+++ b/EventFilter/L1TRawToDigi/interface/AMC13Spec.h
@@ -89,7 +89,7 @@ namespace amc13 {
                bool mtf7_mode = false);
     bool write(const edm::Event &ev, unsigned char *ptr, unsigned int skip, unsigned int size) const;
 
-    inline std::vector<amc::Packet> payload() const { return payload_; };
+    inline const std::vector<amc::Packet> &payload() const { return payload_; };
 
   private:
     Header header_;

--- a/EventFilter/L1TRawToDigi/interface/AMCSpec.h
+++ b/EventFilter/L1TRawToDigi/interface/AMCSpec.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <vector>
 #include <cstdint>
+#include <span>
 
 namespace amc {
   static const unsigned int split_block_size = 0x1000;
@@ -143,8 +144,11 @@ namespace amc {
     // cross-checks for data consistency.
     void finalize(unsigned int lv1, unsigned int bx, bool legacy_mc = false, bool mtf7_mode = false);
 
-    std::vector<uint64_t> block(unsigned int id) const;
-    std::unique_ptr<uint64_t[]> data();
+    std::span<const uint64_t> block(unsigned int id) const;
+    std::span<const uint64_t> data() const {
+      // Remove 3 words: 2 for the header, 1 for the trailer
+      return payload_.empty() ? std::span<const uint64_t>() : std::span<const uint64_t>(payload_).subspan(2, size());
+    };
     BlockHeader blockHeader(unsigned int block = 0) const { return block_header_; };
     Header header() const { return header_; };
     Trailer trailer() const { return trailer_; };

--- a/EventFilter/L1TRawToDigi/interface/Block.h
+++ b/EventFilter/L1TRawToDigi/interface/Block.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <vector>
+#include <optional>
 
 #include "EventFilter/L1TRawToDigi/interface/AMCSpec.h"
 #include "DataFormats/L1Trigger/interface/BxBlock.h"
@@ -109,7 +110,7 @@ namespace l1t {
     // header.  Called by getBlock(), which also checks that data_ !=
     // end_ before calling (assumes size of one 32 bit word).
     virtual BlockHeader getHeader() = 0;
-    virtual std::unique_ptr<Block> getBlock();
+    virtual std::optional<Block> getBlock();
 
   protected:
     const uint32_t* data_;
@@ -132,7 +133,7 @@ namespace l1t {
     // Unused methods - we override getBlock() instead
     unsigned getHeaderSize() const override { return 0; };
     BlockHeader getHeader() override { return BlockHeader(nullptr); };
-    std::unique_ptr<Block> getBlock() override;
+    std::optional<Block> getBlock() override;
 
   private:
     // sizes in 16 bit words
@@ -174,7 +175,7 @@ namespace l1t {
     CTP7Payload(const uint32_t* data, const uint32_t* end, amc::Header amcHeader);
     unsigned getHeaderSize() const override { return 2; };
     BlockHeader getHeader() override;
-    std::unique_ptr<Block> getBlock() override;
+    std::optional<Block> getBlock() override;
 
   private:
     // FIXME check values

--- a/EventFilter/L1TRawToDigi/plugins/OmtfUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/OmtfUnpacker.cc
@@ -309,8 +309,7 @@ namespace omtf {
         // AMC trailer
         //
         //amc::Trailer trailerAmc = amc.trailer();              //this is the expected way but does not work
-        amc::Trailer trailerAmc(amc.data().get() + amc.size() -
-                                1);  //FIXME: the above is prefered but this works (CMSSW900)
+        amc::Trailer trailerAmc(&amc.data().back());  //FIXME: the above is prefered but this works (CMSSW900)
         if (debug) {
           std::ostringstream str;
           str << " AMC trailer:  " << std::bitset<64>(trailerAmc.raw()) << std::endl;
@@ -323,7 +322,7 @@ namespace omtf {
         // AMC payload
         //
         const auto& payload64 = amc.data();
-        const Word64* word = payload64.get();
+        const Word64* word = &payload64.front();
         for (unsigned int iWord = 1; iWord <= amc.size(); iWord++, word++) {
           if (iWord <= 2)
             continue;  // two header words for each AMC

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTCollections.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTCollections.cc
@@ -7,23 +7,25 @@
 namespace l1t {
   namespace stage2 {
     GMTCollections::~GMTCollections() {
-      event_.put(std::move(regionalMuonCandsBMTF_), "BMTF");
-      event_.put(std::move(regionalMuonCandsOMTF_), "OMTF");
-      event_.put(std::move(regionalMuonCandsEMTF_), "EMTF");
-      event_.put(std::move(muons_[0]), "Muon");
+      event_.emplace(tokens_.bmtf_, std::move(regionalMuonCandsBMTF_));
+      event_.emplace(tokens_.omtf_, std::move(regionalMuonCandsOMTF_));
+      event_.emplace(tokens_.emtf_, std::move(regionalMuonCandsEMTF_));
+      event_.emplace(tokens_.muon_, std::move(muons_[0]));
+      assert(NUM_OUTPUT_COPIES == tokens_.muonCopies_.size());
       for (size_t i = 1; i < NUM_OUTPUT_COPIES; ++i) {
-        event_.put(std::move(muons_[i]), "MuonCopy" + std::to_string(i));
+        event_.emplace(tokens_.muonCopies_[i], std::move(muons_[i]));
       }
-      event_.put(std::move(imdMuonsBMTF_), "imdMuonsBMTF");
-      event_.put(std::move(imdMuonsEMTFNeg_), "imdMuonsEMTFNeg");
-      event_.put(std::move(imdMuonsEMTFPos_), "imdMuonsEMTFPos");
-      event_.put(std::move(imdMuonsOMTFNeg_), "imdMuonsOMTFNeg");
-      event_.put(std::move(imdMuonsOMTFPos_), "imdMuonsOMTFPos");
+      event_.emplace(tokens_.imdMuonsBMTF_, std::move(imdMuonsBMTF_));
+      event_.emplace(tokens_.imdMuonsEMTFNeg_, std::move(imdMuonsEMTFNeg_));
+      event_.emplace(tokens_.imdMuonsEMTFPos_, std::move(imdMuonsEMTFPos_));
+      event_.emplace(tokens_.imdMuonsOMTFNeg_, std::move(imdMuonsOMTFNeg_));
+      event_.emplace(tokens_.imdMuonsOMTFPos_, std::move(imdMuonsOMTFPos_));
 
-      event_.put(std::move(regionalMuonShowersEMTF_), "EMTF");
-      event_.put(std::move(muonShowers_[0]), "MuonShower");
+      event_.emplace(tokens_.showerEMTF_, std::move(regionalMuonShowersEMTF_));
+      event_.emplace(tokens_.muonShower_, std::move(muonShowers_[0]));
+      assert(tokens_.muonShowerCopy_.size() == NUM_OUTPUT_COPIES);
       for (size_t i = 1; i < NUM_OUTPUT_COPIES; ++i) {
-        event_.put(std::move(muonShowers_[i]), "MuonShowerCopy" + std::to_string(i));
+        event_.emplace(tokens_.muonShowerCopy_[i], std::move(muonShowers_[i]));
       }
     }
   }  // namespace stage2

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTCollections.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTCollections.h
@@ -8,6 +8,7 @@
 #include "DataFormats/L1Trigger/interface/MuonShower.h"
 
 #include "L1TObjectCollections.h"
+#include "GMTPutTokens.h"
 
 #include <array>
 
@@ -19,61 +20,67 @@ namespace l1t {
       // fill a collection the BX range cannot be determined.
       // Set default values here to then create an empty collection
       // with a defined BX range.
-      GMTCollections(
-          edm::Event& e, const int iFirstBx = -2, const int iLastBx = 2, const int oFirstBx = -2, const int oLastBx = 2)
+      GMTCollections(edm::Event& e,
+                     GMTPutTokens const& iTokens,
+                     const int iFirstBx = -2,
+                     const int iLastBx = 2,
+                     const int oFirstBx = -2,
+                     const int oLastBx = 2)
           : L1TObjectCollections(e),
-            regionalMuonCandsBMTF_(std::make_unique<RegionalMuonCandBxCollection>(0, iFirstBx, iLastBx)),
-            regionalMuonCandsOMTF_(std::make_unique<RegionalMuonCandBxCollection>(0, iFirstBx, iLastBx)),
-            regionalMuonCandsEMTF_(std::make_unique<RegionalMuonCandBxCollection>(0, iFirstBx, iLastBx)),
-            muons_(),
-            imdMuonsBMTF_(std::make_unique<MuonBxCollection>(0, oFirstBx, oLastBx)),
-            imdMuonsEMTFNeg_(std::make_unique<MuonBxCollection>(0, oFirstBx, oLastBx)),
-            imdMuonsEMTFPos_(std::make_unique<MuonBxCollection>(0, oFirstBx, oLastBx)),
-            imdMuonsOMTFNeg_(std::make_unique<MuonBxCollection>(0, oFirstBx, oLastBx)),
-            imdMuonsOMTFPos_(std::make_unique<MuonBxCollection>(0, oFirstBx, oLastBx)),
-
-            regionalMuonShowersEMTF_(std::make_unique<RegionalMuonShowerBxCollection>(0, iFirstBx, iLastBx)),
-            muonShowers_() {
-        std::generate(muons_.begin(), muons_.end(), [&oFirstBx, &oLastBx] {
-          return std::make_unique<MuonBxCollection>(0, oFirstBx, oLastBx);
-        });
-        std::generate(muonShowers_.begin(), muonShowers_.end(), [&oFirstBx, &oLastBx] {
-          return std::make_unique<MuonShowerBxCollection>(0, oFirstBx, oLastBx);
-        });
-      };
+            regionalMuonCandsBMTF_(0, iFirstBx, iLastBx),
+            regionalMuonCandsOMTF_(0, iFirstBx, iLastBx),
+            regionalMuonCandsEMTF_(0, iFirstBx, iLastBx),
+            muons_{{{0, oFirstBx, oLastBx},
+                    {0, oFirstBx, oLastBx},
+                    {0, oFirstBx, oLastBx},
+                    {0, oFirstBx, oLastBx},
+                    {0, oFirstBx, oLastBx},
+                    {0, oFirstBx, oLastBx}}},
+            imdMuonsBMTF_(0, oFirstBx, oLastBx),
+            imdMuonsEMTFNeg_(0, oFirstBx, oLastBx),
+            imdMuonsEMTFPos_(0, oFirstBx, oLastBx),
+            imdMuonsOMTFNeg_(0, oFirstBx, oLastBx),
+            imdMuonsOMTFPos_(0, oFirstBx, oLastBx),
+            regionalMuonShowersEMTF_(0, iFirstBx, iLastBx),
+            muonShowers_{{{0, oFirstBx, oLastBx},
+                          {0, oFirstBx, oLastBx},
+                          {0, oFirstBx, oLastBx},
+                          {0, oFirstBx, oLastBx},
+                          {0, oFirstBx, oLastBx},
+                          {0, oFirstBx, oLastBx}}},
+            tokens_(iTokens) {};
 
       ~GMTCollections() override;
 
-      inline RegionalMuonCandBxCollection* getRegionalMuonCandsBMTF() { return regionalMuonCandsBMTF_.get(); };
-      inline RegionalMuonCandBxCollection* getRegionalMuonCandsOMTF() { return regionalMuonCandsOMTF_.get(); };
-      inline RegionalMuonCandBxCollection* getRegionalMuonCandsEMTF() { return regionalMuonCandsEMTF_.get(); };
-      inline MuonBxCollection* getMuons(const unsigned int copy) override { return muons_[copy].get(); };
-      inline MuonBxCollection* getImdMuonsBMTF() { return imdMuonsBMTF_.get(); };
-      inline MuonBxCollection* getImdMuonsEMTFNeg() { return imdMuonsEMTFNeg_.get(); };
-      inline MuonBxCollection* getImdMuonsEMTFPos() { return imdMuonsEMTFPos_.get(); };
-      inline MuonBxCollection* getImdMuonsOMTFNeg() { return imdMuonsOMTFNeg_.get(); };
-      inline MuonBxCollection* getImdMuonsOMTFPos() { return imdMuonsOMTFPos_.get(); };
+      inline RegionalMuonCandBxCollection* getRegionalMuonCandsBMTF() { return &regionalMuonCandsBMTF_; };
+      inline RegionalMuonCandBxCollection* getRegionalMuonCandsOMTF() { return &regionalMuonCandsOMTF_; };
+      inline RegionalMuonCandBxCollection* getRegionalMuonCandsEMTF() { return &regionalMuonCandsEMTF_; };
+      inline MuonBxCollection* getMuons(const unsigned int copy) override { return &muons_[copy]; };
+      inline MuonBxCollection* getImdMuonsBMTF() { return &imdMuonsBMTF_; };
+      inline MuonBxCollection* getImdMuonsEMTFNeg() { return &imdMuonsEMTFNeg_; };
+      inline MuonBxCollection* getImdMuonsEMTFPos() { return &imdMuonsEMTFPos_; };
+      inline MuonBxCollection* getImdMuonsOMTFNeg() { return &imdMuonsOMTFNeg_; };
+      inline MuonBxCollection* getImdMuonsOMTFPos() { return &imdMuonsOMTFPos_; };
 
-      inline RegionalMuonShowerBxCollection* getRegionalMuonShowersEMTF() { return regionalMuonShowersEMTF_.get(); };
-      inline MuonShowerBxCollection* getMuonShowers(const unsigned int copy) override {
-        return muonShowers_[copy].get();
-      };
+      inline RegionalMuonShowerBxCollection* getRegionalMuonShowersEMTF() { return &regionalMuonShowersEMTF_; };
+      inline MuonShowerBxCollection* getMuonShowers(const unsigned int copy) override { return &muonShowers_[copy]; };
 
       static constexpr size_t NUM_OUTPUT_COPIES{6};
 
     private:
-      std::unique_ptr<RegionalMuonCandBxCollection> regionalMuonCandsBMTF_;
-      std::unique_ptr<RegionalMuonCandBxCollection> regionalMuonCandsOMTF_;
-      std::unique_ptr<RegionalMuonCandBxCollection> regionalMuonCandsEMTF_;
-      std::array<std::unique_ptr<MuonBxCollection>, 6> muons_;
-      std::unique_ptr<MuonBxCollection> imdMuonsBMTF_;
-      std::unique_ptr<MuonBxCollection> imdMuonsEMTFNeg_;
-      std::unique_ptr<MuonBxCollection> imdMuonsEMTFPos_;
-      std::unique_ptr<MuonBxCollection> imdMuonsOMTFNeg_;
-      std::unique_ptr<MuonBxCollection> imdMuonsOMTFPos_;
+      RegionalMuonCandBxCollection regionalMuonCandsBMTF_;
+      RegionalMuonCandBxCollection regionalMuonCandsOMTF_;
+      RegionalMuonCandBxCollection regionalMuonCandsEMTF_;
+      std::array<MuonBxCollection, 6> muons_;
+      MuonBxCollection imdMuonsBMTF_;
+      MuonBxCollection imdMuonsEMTFNeg_;
+      MuonBxCollection imdMuonsEMTFPos_;
+      MuonBxCollection imdMuonsOMTFNeg_;
+      MuonBxCollection imdMuonsOMTFPos_;
 
-      std::unique_ptr<RegionalMuonShowerBxCollection> regionalMuonShowersEMTF_;
-      std::array<std::unique_ptr<MuonShowerBxCollection>, 6> muonShowers_;
+      RegionalMuonShowerBxCollection regionalMuonShowersEMTF_;
+      std::array<MuonShowerBxCollection, 6> muonShowers_;
+      GMTPutTokens tokens_;
     };
   }  // namespace stage2
 }  // namespace l1t

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTPutTokens.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTPutTokens.h
@@ -1,0 +1,58 @@
+#ifndef Subsystem_Package_GMTPutTokens_h
+#define Subsystem_Package_GMTPutTokens_h
+// -*- C++ -*-
+//
+// Package:     Subsystem/Package
+// Class  :     GMTPutTokens
+//
+/**\class GMTPutTokens GMTPutTokens.h "GMTPutTokens.h"
+
+ Description: Holder for the EDPutTokens
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Wed, 11 Dec 2024 13:41:10 GMT
+//
+#include "DataFormats/L1TMuon/interface/RegionalMuonCand.h"
+#include "DataFormats/L1Trigger/interface/Muon.h"
+
+#include "DataFormats/L1TMuon/interface/RegionalMuonShower.h"
+#include "DataFormats/L1Trigger/interface/MuonShower.h"
+
+#include "L1TObjectCollections.h"
+
+// system include files
+#include <vector>
+
+// user include files
+#include "FWCore/Utilities/interface/EDPutToken.h"
+
+// forward declarations
+
+namespace l1t {
+  namespace stage2 {
+    struct GMTPutTokens {
+      edm::EDPutTokenT<RegionalMuonCandBxCollection> bmtf_;
+      edm::EDPutTokenT<RegionalMuonCandBxCollection> omtf_;
+      edm::EDPutTokenT<RegionalMuonCandBxCollection> emtf_;
+
+      edm::EDPutTokenT<MuonBxCollection> muon_;
+      std::vector<edm::EDPutTokenT<MuonBxCollection>> muonCopies_;
+
+      edm::EDPutTokenT<MuonBxCollection> imdMuonsBMTF_;
+      edm::EDPutTokenT<MuonBxCollection> imdMuonsEMTFNeg_;
+      edm::EDPutTokenT<MuonBxCollection> imdMuonsEMTFPos_;
+      edm::EDPutTokenT<MuonBxCollection> imdMuonsOMTFNeg_;
+      edm::EDPutTokenT<MuonBxCollection> imdMuonsOMTFPos_;
+
+      edm::EDPutTokenT<RegionalMuonShowerBxCollection> showerEMTF_;
+      edm::EDPutTokenT<MuonShowerBxCollection> muonShower_;
+      std::vector<edm::EDPutTokenT<MuonShowerBxCollection>> muonShowerCopy_;
+    };
+  }  // namespace stage2
+}  // namespace l1t
+#endif

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTSetup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTSetup.cc
@@ -75,28 +75,33 @@ namespace l1t {
     }
 
     void GMTSetup::registerProducts(edm::ProducesCollector prod) {
-      prod.produces<RegionalMuonCandBxCollection>("BMTF");
-      prod.produces<RegionalMuonCandBxCollection>("OMTF");
-      prod.produces<RegionalMuonCandBxCollection>("EMTF");
-      prod.produces<MuonBxCollection>("Muon");
+      putTokens_.bmtf_ = prod.produces<RegionalMuonCandBxCollection>("BMTF");
+      putTokens_.omtf_ = prod.produces<RegionalMuonCandBxCollection>("OMTF");
+      putTokens_.emtf_ = prod.produces<RegionalMuonCandBxCollection>("EMTF");
+      putTokens_.muon_ = prod.produces<MuonBxCollection>("Muon");
+      putTokens_.muonCopies_.reserve(GMTCollections::NUM_OUTPUT_COPIES);
+      putTokens_.muonCopies_.emplace_back();  //first one is never used
       for (size_t i = 1; i < GMTCollections::NUM_OUTPUT_COPIES; ++i) {
-        prod.produces<MuonBxCollection>("MuonCopy" + std::to_string(i));
+        putTokens_.muonCopies_.emplace_back(prod.produces<MuonBxCollection>("MuonCopy" + std::to_string(i)));
       }
-      prod.produces<MuonBxCollection>("imdMuonsBMTF");
-      prod.produces<MuonBxCollection>("imdMuonsEMTFNeg");
-      prod.produces<MuonBxCollection>("imdMuonsEMTFPos");
-      prod.produces<MuonBxCollection>("imdMuonsOMTFNeg");
-      prod.produces<MuonBxCollection>("imdMuonsOMTFPos");
+      putTokens_.imdMuonsBMTF_ = prod.produces<MuonBxCollection>("imdMuonsBMTF");
+      putTokens_.imdMuonsEMTFNeg_ = prod.produces<MuonBxCollection>("imdMuonsEMTFNeg");
+      putTokens_.imdMuonsEMTFPos_ = prod.produces<MuonBxCollection>("imdMuonsEMTFPos");
+      putTokens_.imdMuonsOMTFNeg_ = prod.produces<MuonBxCollection>("imdMuonsOMTFNeg");
+      putTokens_.imdMuonsOMTFPos_ = prod.produces<MuonBxCollection>("imdMuonsOMTFPos");
 
-      prod.produces<RegionalMuonShowerBxCollection>("EMTF");
-      prod.produces<MuonShowerBxCollection>("MuonShower");
+      putTokens_.showerEMTF_ = prod.produces<RegionalMuonShowerBxCollection>("EMTF");
+      putTokens_.muonShower_ = prod.produces<MuonShowerBxCollection>("MuonShower");
+      putTokens_.muonShowerCopy_.reserve(GMTCollections::NUM_OUTPUT_COPIES);
+      putTokens_.muonShowerCopy_.emplace_back();  //first one is never used
       for (size_t i = 1; i < GMTCollections::NUM_OUTPUT_COPIES; ++i) {
-        prod.produces<MuonShowerBxCollection>("MuonShowerCopy" + std::to_string(i));
+        putTokens_.muonShowerCopy_.emplace_back(
+            prod.produces<MuonShowerBxCollection>("MuonShowerCopy" + std::to_string(i)));
       }
     }
 
     std::unique_ptr<UnpackerCollections> GMTSetup::getCollections(edm::Event& e) {
-      return std::unique_ptr<UnpackerCollections>(new GMTCollections(e));
+      return std::unique_ptr<UnpackerCollections>(new GMTCollections(e, putTokens_));
     }
 
     UnpackerMap GMTSetup::getUnpackers(int fed, int board, int amc, unsigned int fw) {

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTSetup.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTSetup.h
@@ -9,6 +9,7 @@
 
 #include "GMTCollections.h"
 #include "GMTTokens.h"
+#include "GMTPutTokens.h"
 
 namespace l1t {
   namespace stage2 {
@@ -20,6 +21,8 @@ namespace l1t {
       void registerProducts(edm::ProducesCollector) override;
       std::unique_ptr<UnpackerCollections> getCollections(edm::Event& e) override;
       UnpackerMap getUnpackers(int fed, int board, int amc, unsigned int fw) override;
+
+      GMTPutTokens putTokens_;
     };
   }  // namespace stage2
 }  // namespace l1t

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.cc
@@ -34,18 +34,14 @@ namespace l1t {
       unsigned int linkId = blockId / 2;
       int processor;
       RegionalMuonCandBxCollection* regionalMuonCollection;
-      RegionalMuonShowerBxCollection* regionalMuonShowerCollection;
+      RegionalMuonShowerBxCollection* regionalMuonShowerCollection = nullptr;
       tftype trackFinder;
       if (linkId > 47 && linkId < 60) {
         regionalMuonCollection = static_cast<GMTCollections*>(coll)->getRegionalMuonCandsBMTF();
-        regionalMuonShowerCollection =
-            new RegionalMuonShowerBxCollection();  // To avoid warning re uninitialised collection
         trackFinder = tftype::bmtf;
         processor = linkId - 48;
       } else if (linkId > 41 && linkId < 66) {
         regionalMuonCollection = static_cast<GMTCollections*>(coll)->getRegionalMuonCandsOMTF();
-        regionalMuonShowerCollection =
-            new RegionalMuonShowerBxCollection();  // To avoid warning re uninitialised collection
         if (linkId < 48) {
           trackFinder = tftype::omtf_pos;
           processor = linkId - 42;
@@ -68,8 +64,9 @@ namespace l1t {
         return false;
       }
       regionalMuonCollection->setBXRange(firstBX, lastBX);
-      regionalMuonShowerCollection->setBXRange(firstBX, lastBX);
-
+      if (regionalMuonShowerCollection) {
+        regionalMuonShowerCollection->setBXRange(firstBX, lastBX);
+      }
       LogDebug("L1T") << "nBX = " << nBX << " first BX = " << firstBX << " lastBX = " << lastBX;
 
       // Get the BX blocks and unpack them
@@ -127,7 +124,8 @@ namespace l1t {
           // Fill RegionalMuonShower objects. For this we need to look at all six words together.
           RegionalMuonShower muShower;
           if (RegionalMuonRawDigiTranslator::fillRegionalMuonShower(
-                  muShower, bxPayload, processor, trackFinder, useEmtfNominalTightShowers_, useEmtfLooseShowers_)) {
+                  muShower, bxPayload, processor, trackFinder, useEmtfNominalTightShowers_, useEmtfLooseShowers_) and
+              regionalMuonShowerCollection) {
             regionalMuonShowerCollection->push_back(bx, muShower);
           }
         } else {

--- a/EventFilter/L1TRawToDigi/src/AMCSpec.cc
+++ b/EventFilter/L1TRawToDigi/src/AMCSpec.cc
@@ -140,22 +140,14 @@ namespace amc {
     }
   }
 
-  std::vector<uint64_t> Packet::block(unsigned int id) const {
+  std::span<const uint64_t> Packet::block(unsigned int id) const {
     if (id == 0 and id == block_header_.getBlocks() - 1) {
-      return payload_;
+      return std::span<const uint64_t>(payload_);
     } else if (id == block_header_.getBlocks() - 1) {
-      return std::vector<uint64_t>(payload_.begin() + id * split_block_size, payload_.end());
+      return std::span<const uint64_t>(payload_.begin() + id * split_block_size, payload_.end());
     } else {
-      return std::vector<uint64_t>(payload_.begin() + id * split_block_size,
-                                   payload_.begin() + (id + 1) * split_block_size);
+      return std::span<const uint64_t>(payload_.begin() + id * split_block_size,
+                                       payload_.begin() + (id + 1) * split_block_size);
     }
-  }
-
-  std::unique_ptr<uint64_t[]> Packet::data() {
-    // Remove 3 words: 2 for the header, 1 for the trailer
-    std::unique_ptr<uint64_t[]> res(new uint64_t[payload_.size() - 3]);
-    for (unsigned int i = 0; i < payload_.size() - 3; ++i)
-      res.get()[i] = payload_[i + 2];
-    return res;
   }
 }  // namespace amc

--- a/L1Trigger/L1TNtuples/plugins/L1UpgradeTfMuonTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1UpgradeTfMuonTreeProducer.cc
@@ -257,7 +257,7 @@ unsigned L1UpgradeTfMuonTreeProducer::getAlgoFwVersion() {
 
   if (!packet.payload().empty()) {
     auto payload64 = (packet.payload().at(0)).data();
-    const uint32_t* start = (const uint32_t*)payload64.get();
+    const uint32_t* start = reinterpret_cast<const uint32_t*>(&payload64.front());
     const uint32_t* end = start + (packet.payload().at(0).size() * 2);
 
     l1t::MP7Payload payload(start, end, false);


### PR DESCRIPTION
#### PR description:

- decrease number of allocations
- use more efficient framework APIs
- fixed memory leak in RegionalMuonGMTUnpacker

#### PR validation:

A slightly simpler version (without the use of std::span) was tested on PromptReco test job using CMSSW_14_0_9.

This includes the commit from #46918