### PR TITLE
Update clang-tidy test

### DIFF
--- a/Utilities/ReleaseScripts/test/BuildFile.xml
+++ b/Utilities/ReleaseScripts/test/BuildFile.xml
@@ -4,6 +4,10 @@
 <test name="test-clang-tidy" command="test-clang-tidy.sh">
   <use name="llvm"/>
 </test>
+<test name="test-scram-code-checks" command="test-scram-code-checks.sh">
+  <use name="cmssw-config"/>
+  <use name="llvm"/>
+</test>
 <ifrelease name="!ASAN">
   <test name="TestValgrind" command="test-valgrind.sh">
     <flags PRE_TEST="test-valgrind-memleak"/>

--- a/Utilities/ReleaseScripts/test/ref/test-clang-tidy.cc
+++ b/Utilities/ReleaseScripts/test/ref/test-clang-tidy.cc
@@ -2,7 +2,7 @@ class BaseClass {
 public:
   BaseClass(int x) {
     m_x = x;
-    ch = 0;
+    ch = nullptr;
   };
   virtual ~BaseClass();
   virtual int someMethod();
@@ -13,9 +13,9 @@ protected:
 };
 
 BaseClass::~BaseClass() {
-  if (ch != 0) {
+  if (ch != nullptr) {
     delete ch;
-    ch = 0;
+    ch = nullptr;
   }
 }
 int BaseClass::someMethod() { return m_x; }
@@ -23,8 +23,8 @@ int BaseClass::someMethod() { return m_x; }
 class DrivedClass : public BaseClass {
 public:
   DrivedClass(int x) : BaseClass(x) {};
-  virtual ~DrivedClass();
-  virtual int someMethod();
+  ~DrivedClass() override;
+  int someMethod() override;
 };
 
 DrivedClass::~DrivedClass() {}

--- a/Utilities/ReleaseScripts/test/test-clang-tidy.cc.yaml
+++ b/Utilities/ReleaseScripts/test/test-clang-tidy.cc.yaml
@@ -35,28 +35,28 @@ Diagnostics:
     DiagnosticMessage:
       Message:         'prefer using ''override'' or (rarely) ''final'' instead of ''virtual'''
       FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
-      FileOffset:      385
+      FileOffset:      386
       Replacements:
         - FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
-          Offset:          377
+          Offset:          378
           Length:          8
           ReplacementText: ''
         - FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
-          Offset:          399
+          Offset:          400
           Length:          0
           ReplacementText: ' override'
   - DiagnosticName:  modernize-use-override
     DiagnosticMessage:
       Message:         'prefer using ''override'' or (rarely) ''final'' instead of ''virtual'''
       FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
-      FileOffset:      415
+      FileOffset:      416
       Replacements:
         - FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
-          Offset:          403
+          Offset:          404
           Length:          8
           ReplacementText: ''
         - FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
-          Offset:          427
+          Offset:          428
           Length:          0
           ReplacementText: ' override'
 ...

--- a/Utilities/ReleaseScripts/test/test-scram-code-checks.sh
+++ b/Utilities/ReleaseScripts/test/test-scram-code-checks.sh
@@ -1,0 +1,38 @@
+#!/bin/bash -ex
+
+ORIG_TEST_PATH=$SCRAM_TEST_PATH
+scram project $CMSSW_VERSION
+cd $CMSSW_VERSION
+
+#Get FWCore/Version
+mkdir src/FWCore
+RefDir=$CMSSW_BASE/src/FWCore/Version
+[ -e $RefDir ] || RefDir=$CMSSW_RELEASE_BASE/src/FWCore/Version
+rsync -a $RefDir/ src/FWCore/Version/
+chmod -R u+w src/FWCore/Version
+
+#Get latest clang-tidy and format files
+RefDir=$CMSSW_BASE/src
+[ -e ${RefDir}/.clang-tidy ] || RefDir=$CMSSW_RELEASE_BASE/src
+cp ${RefDir}/.clang-tidy src/
+cp ${RefDir}/.clang-format src/
+
+#Get latest build rules
+rm -rf config/SCRAM
+rsync -a $CMSSW_BASE/config/SCRAM/ config/SCRAM/
+
+#Make sure external release external lib/bin are in env
+chmod a-x config/SCRAM/hooks/runtime/50-remove-release-external-lib
+
+#Test clang-tidy
+cp $ORIG_TEST_PATH/test-clang-tidy.cc src/FWCore/Version/src
+USER_CODE_CHECKS_FILES=src/FWCore/Version/src/test-clang-tidy.cc scram b code-checks
+diff -u src/FWCore/Version/src/test-clang-tidy.cc $ORIG_TEST_PATH/ref/test-clang-tidy.cc
+cp $ORIG_TEST_PATH/test-clang-tidy.cc src/FWCore/Version/src
+scram b code-checks-all
+diff -u src/FWCore/Version/src/test-clang-tidy.cc $ORIG_TEST_PATH/ref/test-clang-tidy.cc
+
+#Test clang-format
+sed -i -e 's|int m_x|    int     m_x   |' src/FWCore/Version/src/test-clang-tidy.cc
+USER_CODE_FORMAT_FILES=src/FWCore/Version/src/test-clang-tidy.cc scram b code-format
+diff -u src/FWCore/Version/src/test-clang-tidy.cc $ORIG_TEST_PATH/ref/test-clang-tidy.cc

--- a/Utilities/ReleaseScripts/test/test-scram-code-checks.sh
+++ b/Utilities/ReleaseScripts/test/test-scram-code-checks.sh
@@ -8,7 +8,7 @@ cd $CMSSW_VERSION
 mkdir src/FWCore
 RefDir=$CMSSW_BASE/src/FWCore/Version
 [ -e $RefDir ] || RefDir=$CMSSW_RELEASE_BASE/src/FWCore/Version
-rsync -a $RefDir/ src/FWCore/Version/
+rsync -a --no-g $RefDir/ src/FWCore/Version/
 chmod -R u+w src/FWCore/Version
 
 #Get latest clang-tidy and format files


### PR DESCRIPTION
PGO changes ( e.g. using relative source path instead of full path ) broke `scram build code-checks` rule. So it has not been running properly on PR. code-format was working but only `code-checks i.e. clang-tidy` did not work as it required correct `compiler_command.json` with correct source file paths.

Updated clang-tidy unit test now makes sure
- `scram build code-checks` and `scram build code-checks-all` rules work correctly
- `scram build code-format-all` also works

This will require also cmsdist update with correct code-checks rule