### PR TITLE
[MTD Validation]: update to MtdTracksValidation

### DIFF
--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -749,7 +749,8 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
             });
             // Find the first direct hit in time
             directSimClusIt = std::find_if(simClustersRefs.begin(), simClustersRefs.end(), [](const auto& simCluster) {
-              return simCluster->trackIdOffset() == 0;
+              MTDDetId mtddetid = simCluster->detIds_and_rows().front().first;
+              return (mtddetid.mtdSubDetector() == 1 && simCluster->trackIdOffset() == 0);
             });
             // Check if TP has direct or other sim cluster for BTL
             for (const auto& simClusterRef : simClustersRefs) {

--- a/Validation/MtdValidation/test/mtdHarvesting_cfg.py
+++ b/Validation/MtdValidation/test/mtdHarvesting_cfg.py
@@ -8,7 +8,7 @@ process.load('Configuration.StandardSequences.Services_cff')
 process.load('Configuration.StandardSequences.EDMtoMEAtRunEnd_cff')
 process.load('SimGeneral.MixingModule.mixNoPU_cfi')
 
-process.load("Configuration.Geometry.GeometryExtended2026D110Reco_cff")
+process.load("Configuration.Geometry.GeometryExtendedRun4D110Reco_cff")
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 

--- a/Validation/MtdValidation/test/mtdValidation_cfg.py
+++ b/Validation/MtdValidation/test/mtdValidation_cfg.py
@@ -10,7 +10,7 @@ process.load('Configuration.EventContent.EventContent_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('SimGeneral.MixingModule.mixNoPU_cfi')
 
-process.load("Configuration.Geometry.GeometryExtended2026D110Reco_cff")
+process.load("Configuration.Geometry.GeometryExtendedRun4D110Reco_cff")
 process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag


### PR DESCRIPTION
#### PR description:
This PR provides an update of the MtdTracksValidation class:

* add requirement that the sim direct hit is in BTL for tracks within trackMaxBtlEta_

* update  Configuration.Geometry cff in the config files mtdTracksValidation_cfg.py and mtdHarvesting_cfg.py


#### PR validation:
Code compiles, runs and produces the desired plots. It was tested on:
/RelValSingleMuPt10/CMSSW_14_2_0_pre4-141X_mcRun4_realistic_v3_STD_RegeneratedGS_2026D110_noPU-v1/GEN-SIM-RECO
