### PR TITLE
Change ElectronID to the latest in python configuration for JetPlusTrack algoritm

### DIFF
--- a/RecoJets/JetPlusTracks/plugins/JetPlusTrackCorrector.cc
+++ b/RecoJets/JetPlusTracks/plugins/JetPlusTrackCorrector.cc
@@ -1124,25 +1124,26 @@ bool JetPlusTrackCorrector::matchMuons(TrackRefs::const_iterator& itrk,
 // -----------------------------------------------------------------------------
 //
 bool JetPlusTrackCorrector::matchElectrons(TrackRefs::const_iterator& itrk,
-                                           const edm::Handle<RecoElectrons>& elecs,
-                                           const edm::Handle<RecoElectronIds>& elec_ids) const {
-  if (elecs->empty()) {
+                                           const edm::Handle<RecoElectrons>& gsfEles,
+                                           const edm::Handle<RecoElectronIds>& idDecisionMap) const {
+  if (!gsfEles.isValid()) {
     return false;
   }
 
   double deltaRMIN = 999.;
 
-  uint32_t electron_index = 0;
-  for (auto const& ielec : *elecs) {
-    edm::Ref<RecoElectrons> electron_ref(elecs, electron_index);
-    electron_index++;
+  for (auto ele = gsfEles->begin(); ele != gsfEles->end(); ++ele) {
+    const edm::Ptr<reco::GsfElectron> elePtr(gsfEles, ele - gsfEles->begin());
+    bool passID = false;
+    if (idDecisionMap.isValid())
+      passID = (*idDecisionMap)[elePtr];
 
-    if ((*elec_ids)[electron_ref] < 1.e-6) {
+    if (!passID) {
       continue;
-    }  //@@ Check for null value
+    }  //@@ Check for electronID
 
     // DR matching b/w electron and track
-    auto dR2 = deltaR2(ielec, **itrk);
+    auto dR2 = deltaR2(*ele, **itrk);
     if (dR2 < deltaRMIN) {
       deltaRMIN = dR2;
     }

--- a/RecoJets/JetPlusTracks/python/JetPlusTrackCorrections_cff.py
+++ b/RecoJets/JetPlusTracks/python/JetPlusTrackCorrections_cff.py
@@ -6,10 +6,6 @@ ak4JetTracksAssociatorAtVertexJPT = ak4JetTracksAssociatorAtVertex.clone(
     useAssigned = True,
     pvSrc       = "offlinePrimaryVertices"
 )
-# ---------- Tight Electron ID
-
-from RecoEgamma.ElectronIdentification.electronIdSequence_cff import eidTight
-JPTeidTight = eidTight.clone()
 
 # ---------- Seeds from TrackJets
 
@@ -47,7 +43,6 @@ JetPlusTrackZSPCorJetAntiKt4.JetSplitMerge = 2
 # Anti-Kt
 
 JetPlusTrackCorrectionsAntiKt4Task = cms.Task(
-    JPTeidTight,
     JetPlusTrackAddonSeedReco,
     ak4JetTracksAssociatorAtVertexJPT,
     ak4JetTracksAssociatorAtCaloFace,

--- a/RecoJets/JetPlusTracks/python/JetPlusTrackCorrections_cff.py
+++ b/RecoJets/JetPlusTracks/python/JetPlusTrackCorrections_cff.py
@@ -7,6 +7,22 @@ ak4JetTracksAssociatorAtVertexJPT = ak4JetTracksAssociatorAtVertex.clone(
     pvSrc       = "offlinePrimaryVertices"
 )
 
+# ---------- Tight Electron ID
+
+from RecoEgamma.ElectronIdentification.egmGsfElectronIDs_cff import egmGsfElectronIDs
+JPTegmGsfElectronIDs = egmGsfElectronIDs.clone(
+    physicsObjectsIDs = cms.VPSet(),
+    physicsObjectSrc = 'gedGsfElectrons'
+)
+from PhysicsTools.SelectorUtils.tools.vid_id_tools import setupVIDSelection
+my_id_modules = ['RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Winter22_122X_V1_cff']
+for id_module_name in my_id_modules:
+    idmod= __import__(id_module_name, globals(), locals(), ['idName','cutFlow'])
+    for name in dir(idmod):
+        item = getattr(idmod,name)
+        if hasattr(item,'idName') and hasattr(item,'cutFlow'):
+            setupVIDSelection(JPTegmGsfElectronIDs,item)
+
 # ---------- Seeds from TrackJets
 
 from RecoJets.JetPlusTracks.jetPlusTrackAddonSeedProducer_cfi import *

--- a/RecoJets/JetPlusTracks/python/JetPlusTrackCorrections_cfi.py
+++ b/RecoJets/JetPlusTracks/python/JetPlusTrackCorrections_cfi.py
@@ -39,7 +39,7 @@ JPTZSPCorrectorAntiKt4 = cms.PSet(
     # Electrons
     UseElectrons    = cms.bool(True),
     Electrons       = cms.InputTag("gedGsfElectrons"),
-    ElectronIds     = cms.InputTag("JPTeidTight"),
+    ElectronIds     = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-RunIIIWinter22-V1-tight"),
     PatElectrons       = cms.InputTag("slimmedElectrons"),
     electronDRmatch = cms.double(0.02), 
     

--- a/RecoJets/JetPlusTracks/python/JetPlusTrackCorrections_cfi.py
+++ b/RecoJets/JetPlusTracks/python/JetPlusTrackCorrections_cfi.py
@@ -38,7 +38,7 @@ JPTZSPCorrectorAntiKt4 = cms.PSet(
 
     # Electrons
     UseElectrons    = cms.bool(True),
-    Electrons       = cms.InputTag("gedGsfElectrons"),
+    Electrons       = cms.InputTag("reducedGedGsfElectrons"),
     ElectronIds     = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-RunIIIWinter22-V1-tight"),
     PatElectrons       = cms.InputTag("slimmedElectrons"),
     electronDRmatch = cms.double(0.02), 


### PR DESCRIPTION
#### PR description:

According the request in https://github.com/cms-sw/cmssw/pull/46868
ElectronID was changed in JetPlusTrackCorrections_cfi.py
to egmGsfElectronIDs:cutBasedElectronID-RunIIIWinter22-V1-tight
re-reco of electronid was removed from JetPlusTrackCorrections_cff.py

Changed in pythons configuration for the new ElectronID according the
https://github.com/cms-sw/cmssw/pull/46868 
  
#### PR validation:
runMatrix results are in
/afs/cern.ch/work/k/kodolova/public/HMUMUBB/NEWEGMID/MATRIX/

<!-- code-check, code-format-->
<!-- Please delete the text above after you verified all points of the checklist  -->
