### PR TITLE
ECAL - Make EcalUncalibRecHitSoAToLegacy a global module

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -48,6 +48,23 @@ def customiseForOffline(process):
 
     return process
 
+def customizeHLTfor46935(process):
+    """Changes parameter names of EcalUncalibRecHitSoAToLegacy producer"""
+    for prod in producers_by_type(process, 'EcalUncalibRecHitSoAToLegacy'):
+        if hasattr(prod, 'uncalibRecHitsPortableEB'):
+            prod.inputCollectionEB = prod.uncalibRecHitsPortableEB
+            delattr(prod, 'uncalibRecHitsPortableEB')
+        if hasattr(prod, 'uncalibRecHitsPortableEE'):
+            prod.inputCollectionEE = prod.uncalibRecHitsPortableEE
+            delattr(prod, 'uncalibRecHitsPortableEE')
+        if hasattr(prod, 'recHitsLabelCPUEB'):
+            prod.outputLabelEB = prod.recHitsLabelCPUEB
+            delattr(prod, 'recHitsLabelCPUEB')
+        if hasattr(prod, 'recHitsLabelCPUEE'):
+            prod.outputLabelEE = prod.recHitsLabelCPUEE
+            delattr(prod, 'recHitsLabelCPUEE')
+    return process
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
@@ -55,5 +72,7 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
 
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
+
+    process = customizeHLTfor46935(process)
     
     return process

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitSoAToLegacy.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitSoAToLegacy.cc
@@ -4,14 +4,14 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/EmptyGroupDescription.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/EDPutToken.h"
 #include "DataFormats/EcalRecHit/interface/EcalUncalibratedRecHitHostCollection.h"
 
-class EcalUncalibRecHitSoAToLegacy : public edm::stream::EDProducer<> {
+class EcalUncalibRecHitSoAToLegacy : public edm::global::EDProducer<> {
 public:
   explicit EcalUncalibRecHitSoAToLegacy(edm::ParameterSet const &ps);
   ~EcalUncalibRecHitSoAToLegacy() override = default;
@@ -19,86 +19,84 @@ public:
 
 private:
   using InputProduct = EcalUncalibratedRecHitHostCollection;
-  void produce(edm::Event &, edm::EventSetup const &) override;
+  void produce(edm::StreamID, edm::Event &, edm::EventSetup const &) const override;
 
 private:
   const bool isPhase2_;
-  const edm::EDGetTokenT<InputProduct> uncalibRecHitsPortableEB_;
-  const edm::EDGetTokenT<InputProduct> uncalibRecHitsPortableEE_;
-  const edm::EDPutTokenT<EBUncalibratedRecHitCollection> uncalibRecHitsCPUEBToken_;
-  const edm::EDPutTokenT<EEUncalibratedRecHitCollection> uncalibRecHitsCPUEEToken_;
+  const edm::EDGetTokenT<InputProduct> inputTokenEB_;
+  const edm::EDGetTokenT<InputProduct> inputTokenEE_;
+  const edm::EDPutTokenT<EBUncalibratedRecHitCollection> outputTokenEB_;
+  const edm::EDPutTokenT<EEUncalibratedRecHitCollection> outputTokenEE_;
 };
 
 void EcalUncalibRecHitSoAToLegacy::fillDescriptions(edm::ConfigurationDescriptions &confDesc) {
   edm::ParameterSetDescription desc;
 
-  desc.add<edm::InputTag>("uncalibRecHitsPortableEB",
+  desc.add<edm::InputTag>("inputCollectionEB",
                           edm::InputTag("ecalMultiFitUncalibRecHitPortable", "EcalUncalibRecHitsEB"));
-  desc.add<std::string>("recHitsLabelCPUEB", "EcalUncalibRecHitsEB");
+  desc.add<std::string>("outputLabelEB", "EcalUncalibRecHitsEB");
   desc.ifValue(edm::ParameterDescription<bool>("isPhase2", false, true),
                false >> (edm::ParameterDescription<edm::InputTag>(
-                             "uncalibRecHitsPortableEE",
+                             "inputCollectionEE",
                              edm::InputTag("ecalMultiFitUncalibRecHitPortable", "EcalUncalibRecHitsEE"),
                              true) and
-                         edm::ParameterDescription<std::string>("recHitsLabelCPUEE", "EcalUncalibRecHitsEE", true)) or
+                         edm::ParameterDescription<std::string>("outputLabelEE", "EcalUncalibRecHitsEE", true)) or
                    true >> edm::EmptyGroupDescription());
   confDesc.add("ecalUncalibRecHitSoAToLegacy", desc);
 }
 
 EcalUncalibRecHitSoAToLegacy::EcalUncalibRecHitSoAToLegacy(edm::ParameterSet const &ps)
     : isPhase2_{ps.getParameter<bool>("isPhase2")},
-      uncalibRecHitsPortableEB_{consumes<InputProduct>(ps.getParameter<edm::InputTag>("uncalibRecHitsPortableEB"))},
-      uncalibRecHitsPortableEE_{
-          isPhase2_ ? edm::EDGetTokenT<InputProduct>{}
-                    : consumes<InputProduct>(ps.getParameter<edm::InputTag>("uncalibRecHitsPortableEE"))},
-      uncalibRecHitsCPUEBToken_{
-          produces<EBUncalibratedRecHitCollection>(ps.getParameter<std::string>("recHitsLabelCPUEB"))},
-      uncalibRecHitsCPUEEToken_{
-          isPhase2_ ? edm::EDPutTokenT<EEUncalibratedRecHitCollection>{}
-                    : produces<EEUncalibratedRecHitCollection>(ps.getParameter<std::string>("recHitsLabelCPUEE"))} {}
+      inputTokenEB_{consumes<InputProduct>(ps.getParameter<edm::InputTag>("inputCollectionEB"))},
+      inputTokenEE_{isPhase2_ ? edm::EDGetTokenT<InputProduct>{}
+                              : consumes<InputProduct>(ps.getParameter<edm::InputTag>("inputCollectionEE"))},
+      outputTokenEB_{produces<EBUncalibratedRecHitCollection>(ps.getParameter<std::string>("outputLabelEB"))},
+      outputTokenEE_{isPhase2_
+                         ? edm::EDPutTokenT<EEUncalibratedRecHitCollection>{}
+                         : produces<EEUncalibratedRecHitCollection>(ps.getParameter<std::string>("outputLabelEE"))} {}
 
-void EcalUncalibRecHitSoAToLegacy::produce(edm::Event &event, edm::EventSetup const &setup) {
-  auto const &uncalRecHitsEBColl = event.get(uncalibRecHitsPortableEB_);
-  auto const &uncalRecHitsEBCollView = uncalRecHitsEBColl.const_view();
-  auto recHitsCPUEB = std::make_unique<EBUncalibratedRecHitCollection>();
-  recHitsCPUEB->reserve(uncalRecHitsEBCollView.size());
+void EcalUncalibRecHitSoAToLegacy::produce(edm::StreamID sid, edm::Event &event, edm::EventSetup const &setup) const {
+  auto const &inputCollEB = event.get(inputTokenEB_);
+  auto const &inputCollEBView = inputCollEB.const_view();
+  auto outputCollEB = std::make_unique<EBUncalibratedRecHitCollection>();
+  outputCollEB->reserve(inputCollEBView.size());
 
-  for (uint32_t i = 0; i < uncalRecHitsEBCollView.size(); ++i) {
-    recHitsCPUEB->emplace_back(DetId{uncalRecHitsEBCollView.id()[i]},
-                               uncalRecHitsEBCollView.amplitude()[i],
-                               uncalRecHitsEBCollView.pedestal()[i],
-                               uncalRecHitsEBCollView.jitter()[i],
-                               uncalRecHitsEBCollView.chi2()[i],
-                               uncalRecHitsEBCollView.flags()[i]);
+  for (uint32_t i = 0; i < inputCollEBView.size(); ++i) {
+    outputCollEB->emplace_back(DetId{inputCollEBView.id()[i]},
+                               inputCollEBView.amplitude()[i],
+                               inputCollEBView.pedestal()[i],
+                               inputCollEBView.jitter()[i],
+                               inputCollEBView.chi2()[i],
+                               inputCollEBView.flags()[i]);
     if (isPhase2_) {
-      (*recHitsCPUEB)[i].setAmplitudeError(uncalRecHitsEBCollView.amplitudeError()[i]);
+      (*outputCollEB)[i].setAmplitudeError(inputCollEBView.amplitudeError()[i]);
     }
-    (*recHitsCPUEB)[i].setJitterError(uncalRecHitsEBCollView.jitterError()[i]);
+    (*outputCollEB)[i].setJitterError(inputCollEBView.jitterError()[i]);
     for (uint32_t sample = 0; sample < EcalDataFrame::MAXSAMPLES; ++sample) {
-      (*recHitsCPUEB)[i].setOutOfTimeAmplitude(sample, uncalRecHitsEBCollView.outOfTimeAmplitudes()[i][sample]);
+      (*outputCollEB)[i].setOutOfTimeAmplitude(sample, inputCollEBView.outOfTimeAmplitudes()[i][sample]);
     }
   }
-  event.put(uncalibRecHitsCPUEBToken_, std::move(recHitsCPUEB));
+  event.put(outputTokenEB_, std::move(outputCollEB));
 
   if (!isPhase2_) {
-    auto const &uncalRecHitsEEColl = event.get(uncalibRecHitsPortableEE_);
-    auto const &uncalRecHitsEECollView = uncalRecHitsEEColl.const_view();
-    auto recHitsCPUEE = std::make_unique<EEUncalibratedRecHitCollection>();
-    recHitsCPUEE->reserve(uncalRecHitsEECollView.size());
+    auto const &inputCollEE = event.get(inputTokenEE_);
+    auto const &inputCollEEView = inputCollEE.const_view();
+    auto outputCollEE = std::make_unique<EEUncalibratedRecHitCollection>();
+    outputCollEE->reserve(inputCollEEView.size());
 
-    for (uint32_t i = 0; i < uncalRecHitsEECollView.size(); ++i) {
-      recHitsCPUEE->emplace_back(DetId{uncalRecHitsEECollView.id()[i]},
-                                 uncalRecHitsEECollView.amplitude()[i],
-                                 uncalRecHitsEECollView.pedestal()[i],
-                                 uncalRecHitsEECollView.jitter()[i],
-                                 uncalRecHitsEECollView.chi2()[i],
-                                 uncalRecHitsEECollView.flags()[i]);
-      (*recHitsCPUEE)[i].setJitterError(uncalRecHitsEECollView.jitterError()[i]);
+    for (uint32_t i = 0; i < inputCollEEView.size(); ++i) {
+      outputCollEE->emplace_back(DetId{inputCollEEView.id()[i]},
+                                 inputCollEEView.amplitude()[i],
+                                 inputCollEEView.pedestal()[i],
+                                 inputCollEEView.jitter()[i],
+                                 inputCollEEView.chi2()[i],
+                                 inputCollEEView.flags()[i]);
+      (*outputCollEE)[i].setJitterError(inputCollEEView.jitterError()[i]);
       for (uint32_t sample = 0; sample < EcalDataFrame::MAXSAMPLES; ++sample) {
-        (*recHitsCPUEE)[i].setOutOfTimeAmplitude(sample, uncalRecHitsEECollView.outOfTimeAmplitudes()[i][sample]);
+        (*outputCollEE)[i].setOutOfTimeAmplitude(sample, inputCollEEView.outOfTimeAmplitudes()[i][sample]);
       }
     }
-    event.put(uncalibRecHitsCPUEEToken_, std::move(recHitsCPUEE));
+    event.put(outputTokenEE_, std::move(outputCollEE));
   }
 }
 


### PR DESCRIPTION
#### PR description:

This PR changes the EcalUncalibRecHitSoAToLegacy from a stream to a global module as suggested [here](https://github.com/cms-sw/cmssw/pull/46453#discussion_r1857362953).
In addition the parameter names for inputs and output labels are simplified and aligned to changes in the equivalent module of the calibrated rechit module as mentioned in [this comment](https://github.com/cms-sw/cmssw/pull/46453#discussion_r1857377161).

No changes expected in output.

#### PR validation:

Passes 12834.412.
