### PR TITLE
Update MC GTs for Winter25 and 2024 HI/ppRef in autoCond - CMSSW_142X

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -98,13 +98,13 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2024, Strip tracker in DECO mode
     'phase1_2024_cosmics_design'   :    '140X_mcRun3_2024cosmics_design_deco_v11',
     # GlobalTag for MC production with realistic conditions for Phase1 2024 detector for Heavy Ion
-    'phase1_2024_realistic_hi'     :    '141X_mcRun3_2024_realistic_HI_v10',
+    'phase1_2024_realistic_hi'     :    '141X_mcRun3_2024_realistic_HI_v13',
     # GlobalTag for MC production with realistic conditions for Phase1 2024 detector for ppRef5TeV
-    'phase1_2024_realistic_ppRef5TeV'     :    '141X_mcRun3_2024_realistic_ppRef5TeV_v5',
+    'phase1_2024_realistic_ppRef5TeV'     :    '141X_mcRun3_2024_realistic_ppRef5TeV_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2025
     'phase1_2025_design'           :    '140X_mcRun3_2024_design_v11',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2025_realistic'        :    '142X_mcRun3_2025_realistic_v1',
+    'phase1_2025_realistic'        :    '142X_mcRun3_2025_realistic_v2',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             :    '141X_mcRun4_realistic_v3'
 }


### PR DESCRIPTION
The following GTs have been updated in autoCond

- 'phase1_2025_realistic'        :    [142X_mcRun3_2025_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/142X_mcRun3_2025_realistic_v2)
  - Difference with baseline v1 is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/142X_mcRun3_2025_realistic_v2/142X_mcRun3_2025_realistic_v1)
  - What’s included (on top of the baseline):
    - ECAL EOY conditions, [cmsTalk](https://cms-talk.web.cern.ch/t/call-for-run3winter25-mc-conditions-in-142x/55993/11) 
    - HCAL EOY conditions, [cmsTalk](https://cms-talk.web.cern.ch/t/call-for-run3winter25-mc-conditions-in-142x/55993/9)
    - SiStripBadComponents, [cmsTalk](https://cms-talk.web.cern.ch/t/call-for-run3winter25-mc-conditions-in-142x/55993/12)
    - EOY Tracker alignment ([cmsTalk](https://cms-talk.web.cern.ch/t/call-for-run3winter25-mc-conditions-in-142x/55993/13)) and SiPixel tags ([cmTalk](https://cms-talk.web.cern.ch/t/call-for-run3winter25-mc-conditions-in-142x/55993/14))
    - Corresponding beam spot, [cmsTalk](https://cms-talk.web.cern.ch/t/call-for-run3winter25-mc-conditions-in-142x/55993/15)

- 'phase1_2024_realistic_hi'    :    [141X_mcRun3_2024_realistic_HI_v13](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/141X_mcRun3_2024_realistic_HI_v13)
  - Difference wrt previous _v10 is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/141X_mcRun3_2024_realistic_HI_v13/141X_mcRun3_2024_realistic_HI_v10)
  - Latest additions since _v10:
    - Updated BeamSpot for ppRef
    - Updated ECAL tags
    - Updated SiStrip bad components
    - Updated L1T CaloParams tag

- 'phase1_2024_realistic_ppRef5TeV'     :    [141X_mcRun3_2024_realistic_ppRef5TeV_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/141X_mcRun3_2024_realistic_ppRef5TeV_v7)
  - Difference wrt previous _v5 is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/141X_mcRun3_2024_realistic_ppRef5TeV_v7/141X_mcRun3_2024_realistic_ppRef5TeV_v5)
  - Latest additions since _v5:
    - Updated BeamSpot for ppRef
    - Updated ECAL tags
    - Updater SiPixel quality and status scenario
    - Updated SiStrip bad components
    - Updated L1T CaloParams tag
 
Backport of #46945