### PR TITLE
simplify flat mixing configuration

### DIFF
--- a/Configuration/StandardSequences/python/Mixing.py
+++ b/Configuration/StandardSequences/python/Mixing.py
@@ -222,4 +222,18 @@ def defineMixing(dict):
     if 'F' in dict:
         commands.append('process.mix.input.fileNames = cms.untracked.vstring(%s)'%(repr(dict['F'])))
         dict.pop('F')
+    if 'BS' in dict:
+        bunch_space = dict['BS']
+        commands.append(f'process.mix.bunchspace = cms.int32({bunch_space})')
+        dict.pop('BS')
+    if 'Flat' in dict:
+        pu_min,pu_max=dict['Flat']
+        pu_x = list(range(pu_max+1))
+        pu_y = [0]*(pu_max+1)
+        prob=1./(pu_max+1-pu_min)
+        for pu in range(pu_min,pu_max+1):
+            pu_y[pu]=prob
+        commands.append(f'process.mix.input.nbPileupEvents.probFunctionVariable = cms.vint32({pu_x})')
+        commands.append(f'process.mix.input.nbPileupEvents.probValue = cms.vdouble({pu_y})')
+        dict.pop('Flat')
     return commands


### PR DESCRIPTION
#### PR description:

When defining a flat mixing that is not in the release, one has to use the --customise_command .
With this PR it becomes simpler, just by adding `--pileup 'Flat_10_50_25ns,{"Flat":[0,120]}'` instead of 

```
--pileup Flat_10_50_25ns --customise_commands "process.mix.input.nbPileupEvents.probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120) \n process.mix.input.nbPileupEvents.probValue = cms.vdouble(0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446,0.00826446)"
```

#### PR validation:

the cmsDriver with the short option returns a valid configuration file.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

this might need to get back ported if people find this useful
