### PR TITLE
disable -Ofast for MkFitCore/src/IterationConfig.cc due to json.hpp use of IEEE infinities

### DIFF
--- a/RecoTracker/MkFitCore/BuildFile.xml
+++ b/RecoTracker/MkFitCore/BuildFile.xml
@@ -5,6 +5,7 @@
 <use name="ofast-flag"/>
 <flags CXXFLAGS="-fopenmp-simd"/>
 <flags ADD_SUBDIR="1"/>
+<flags REM_CXXFLAGS="-Ofast" FILE="IterationConfig.cc"/>
 <export>
   <lib name="RecoTrackerMkFitCore"/>
 </export>


### PR DESCRIPTION
#### PR description:

nlohmann/json.hpp uses IEEE infinity and NaN which are not handled by -Ofast. This PR disables -Ofast for IterationConfig.cc, the only module that includes the full json.hpp header.  Iteration configs should be strictly finite, so clients should not depend on the handling of infinities etc. by the JSON parser.

Addresses an issue raised in https://github.com/cms-sw/cmssw/issues/46932#issuecomment-2541563365

#### PR validation:

Compiles, purely technical fix.
