### PR TITLE
Fix `HOST_DEVICE_CONSTANT` macro for AMD GPUs [14.2.x]

### DIFF
--- a/FWCore/Utilities/interface/HostDeviceConstant.h
+++ b/FWCore/Utilities/interface/HostDeviceConstant.h
@@ -16,7 +16,7 @@
 // Note these objects may be at different memory addresses on the host and device, so their pointers will be different
 // -- but the actual values should be the same.
 
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) or defined(__HIP_DEVICE_COMPILE__)
 #define HOST_DEVICE_CONSTANT __device__ constexpr
 #else
 #define HOST_DEVICE_CONSTANT constexpr


### PR DESCRIPTION
#### PR description:

Fix `HOST_DEVICE_CONSTANT` macro for AMD GPUs using HIP/ROCm as well as NVIDIA GPUs using CUDA.

Targets using SYCL can correctly fall back to the `constexpr` case.

#### PR validation:

None.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport #46952 to 14.2.x releases to fix AMD GPU back-ends.

