### PR TITLE
update seed for l1tObjectsTiming

### DIFF
--- a/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
@@ -129,6 +129,8 @@ if process.runType.getRunType() == process.runType.hi_run:
     rawDataRepackerLabel = 'rawDataRepacker'
     process.l1tStage2uGTTiming.firstBXInTrainAlgo=cms.untracked.string("L1_FirstBunchInTrain_50ns")
     process.l1tStage2uGTTiming.lastBXInTrainAlgo=cms.untracked.string("L1_LastBunchInTrain_50ns")
+    process.l1tObjectsTiming.firstBXInTrainAlgo=cms.untracked.string("L1_FirstBunchInTrain_50ns")
+    process.l1tObjectsTiming.lastBXInTrainAlgo=cms.untracked.string("L1_LastBunchInTrain_50ns")
     process.onlineMetaDataDigis.onlineMetaDataInputLabel = rawDataRepackerLabel
     process.onlineMetaDataRawToDigi.onlineMetaDataInputLabel = rawDataRepackerLabel
     process.castorDigis.InputLabel = rawDataRepackerLabel


### PR DESCRIPTION
#### PR description:

- Extend the L1 seeds that correspond to the 50 ns bunch spacing of the HI run to l1tObjectsTiming plots 
- This change applies to HI conditions only


<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->



<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->


<!-- Please delete the text above after you verified all points of the checklist  -->
