### PR TITLE
MTD geometry: activate the reordering of MTD reconstruction geometry

### DIFF
--- a/Geometry/MTDNumberingBuilder/plugins/CmsMTDConstruction.cc
+++ b/Geometry/MTDNumberingBuilder/plugins/CmsMTDConstruction.cc
@@ -9,8 +9,6 @@
 #include "DataFormats/ForwardDetId/interface/ETLDetId.h"
 #include "Geometry/MTDCommonData/interface/MTDBaseNumber.h"
 
-#include "DataFormats/Math/interface/deltaPhi.h"
-
 using angle_units::operators::convertRadToDeg;
 
 template <class FilteredView>
@@ -39,14 +37,14 @@ bool CmsMTDConstruction<FilteredView>::mtdOrderPhi(const GeometricTimingDet* a, 
 
 template <class FilteredView>
 bool CmsMTDConstruction<FilteredView>::btlOrderPhi(const GeometricTimingDet* a, const GeometricTimingDet* b) {
-  return static_cast<int>(convertRadToDeg(angle0to2pi::make0To2pi(a->phi()))) <
-         static_cast<int>(convertRadToDeg(angle0to2pi::make0To2pi(b->phi())));
+  return static_cast<int>(convertRadToDeg(makempiToppi(a->phi()))) <
+         static_cast<int>(convertRadToDeg(makempiToppi(b->phi())));
 }
 
 template <class FilteredView>
 bool CmsMTDConstruction<FilteredView>::btlOrderZ(const GeometricTimingDet* a, const GeometricTimingDet* b) {
-  bool order = (static_cast<int>(convertRadToDeg(angle0to2pi::make0To2pi(a->phi()))) ==
-                static_cast<int>(convertRadToDeg(angle0to2pi::make0To2pi(b->phi())))) &&
+  bool order = (static_cast<int>(convertRadToDeg(makempiToppi(a->phi()))) ==
+                static_cast<int>(convertRadToDeg(makempiToppi(b->phi())))) &&
                (a->translation().z() < b->translation().z());
   return order;
 }

--- a/Geometry/MTDNumberingBuilder/plugins/CmsMTDConstruction.h
+++ b/Geometry/MTDNumberingBuilder/plugins/CmsMTDConstruction.h
@@ -7,6 +7,19 @@
 #include "Geometry/MTDCommonData/interface/BTLNumberingScheme.h"
 #include "Geometry/MTDCommonData/interface/ETLNumberingScheme.h"
 
+#include "DataFormats/Math/interface/deltaPhi.h"
+
+namespace {
+
+  template <class valType>
+  inline constexpr valType makempiToppi(valType angle) {
+    constexpr valType twoPi = 2. * M_PI;
+    constexpr valType epsilon = 1.e-13;
+    auto tmpphi = angle0to2pi::make0To2pi(angle);
+    return (tmpphi - M_PI > epsilon) ? tmpphi - twoPi : tmpphi;
+  }
+}  // namespace
+
 /**
  * Adds GeometricTimingDets representing final modules to the previous level
  */

--- a/RecoMTD/DetLayers/test/mtd_cfg.py
+++ b/RecoMTD/DetLayers/test/mtd_cfg.py
@@ -65,5 +65,4 @@ process.prod = cms.EDAnalyzer("MTDRecoGeometryAnalyzer")
 process.prod1 = cms.EDAnalyzer("TestBTLNavigation")
 process.prod2 = cms.EDAnalyzer("TestETLNavigation")
 
-# process.p1 = cms.Path(cms.wait(process.prod)+cms.wait(process.prod1)+process.prod2)
-process.p1 = cms.Path(cms.wait(process.prod)+process.prod2)
+process.p1 = cms.Path(cms.wait(process.prod)+cms.wait(process.prod1)+process.prod2)


### PR DESCRIPTION
#### PR description:

This reverts commit 06d30e104bc56cf687bf9722599b95a364470199 and activates the new order in BTL reconstruction geometry from -pi to pi, aligning the order of BTL modules in MTD geometry and the tracking navigation geometry in ```RecoMTD/DetLayers```.
It is integrated on top of #46911 , and it requires the update of the unit test references. This update is proposed in parallel to the update of the BTL numbering scheme, that also requires the update of all references.

#### PR validation:

Code compiles, runs and provide the desired order in the output ```MTDgeometry``` for the BTL part.