### PR TITLE
[DQM] Replace fabs with std::abs to fix clang warnings

### DIFF
--- a/DPGAnalysis/HcalTools/plugins/CMTRawAnalyzer.cc
+++ b/DPGAnalysis/HcalTools/plugins/CMTRawAnalyzer.cc
@@ -5349,12 +5349,12 @@ void CMTRawAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
               mapRADDAM_HED2[k1][k2] /= mapRADDAM_HED2[2][kk2];
               // (d1 & eta 17-29)                       L1
               int LLLLLL111111 = 0;
-              if ((k1 == 0 && fabs(kkk - 41) > 16 && fabs(kkk - 41) < 30))
+              if ((k1 == 0 && std::abs(kkk - 41) > 16 && std::abs(kkk - 41) < 30))
                 LLLLLL111111 = 1;
               // (d2 & eta 17-26) && (d3 & eta 27-28)   L2
               int LLLLLL222222 = 0;
-              if ((k1 == 1 && fabs(kkk - 41) > 16 && fabs(kkk - 41) < 27) ||
-                  (k1 == 2 && fabs(kkk - 41) > 26 && fabs(kkk - 41) < 29))
+              if ((k1 == 1 && std::abs(kkk - 41) > 16 && std::abs(kkk - 41) < 27) ||
+                  (k1 == 2 && std::abs(kkk - 41) > 26 && std::abs(kkk - 41) < 29))
                 LLLLLL222222 = 1;
               //
               if (LLLLLL111111 == 1) {
@@ -5389,11 +5389,11 @@ void CMTRawAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
               if (mapRADDAM_HE[k1][k2][k3] != 0. && mapRADDAM_HE[2][kk2][k3] != 0) {
                 mapRADDAM_HE[k1][k2][k3] /= mapRADDAM_HE[2][kk2][k3];
                 int LLLLLL111111 = 0;
-                if ((k1 == 0 && fabs(kkk - 41) > 16 && fabs(kkk - 41) < 30))
+                if ((k1 == 0 && std::abs(kkk - 41) > 16 && std::abs(kkk - 41) < 30))
                   LLLLLL111111 = 1;
                 int LLLLLL222222 = 0;
-                if ((k1 == 1 && fabs(kkk - 41) > 16 && fabs(kkk - 41) < 27) ||
-                    (k1 == 2 && fabs(kkk - 41) > 26 && fabs(kkk - 41) < 29))
+                if ((k1 == 1 && std::abs(kkk - 41) > 16 && std::abs(kkk - 41) < 27) ||
+                    (k1 == 2 && std::abs(kkk - 41) > 26 && std::abs(kkk - 41) < 29))
                   LLLLLL222222 = 1;
                 if (LLLLLL111111 == 1) {
                   h_sigLayer1RADDAM5_HE->Fill(double(kkk - 41), mapRADDAM_HE[k1][k2][k3]);
@@ -9945,12 +9945,12 @@ void CMTRawAnalyzer::fillDigiAmplitude(HBHEDigiCollection::const_iterator& digiI
 
         // (d1 & eta 17-29)                       L1
         int LLLLLL111111 = 0;
-        if ((mdepth == 1 && fabs(ieta0) > 16 && fabs(ieta0) < 30))
+        if ((mdepth == 1 && std::abs(ieta0) > 16 && std::abs(ieta0) < 30))
           LLLLLL111111 = 1;
         // (d2 & eta 17-26) && (d3 & eta 27-28)   L2
         int LLLLLL222222 = 0;
-        if ((mdepth == 2 && fabs(ieta0) > 16 && fabs(ieta0) < 27) ||
-            (mdepth == 3 && fabs(ieta0) > 26 && fabs(ieta0) < 29))
+        if ((mdepth == 2 && std::abs(ieta0) > 16 && std::abs(ieta0) < 27) ||
+            (mdepth == 3 && std::abs(ieta0) > 26 && std::abs(ieta0) < 29))
           LLLLLL222222 = 1;
         //
         if (LLLLLL111111 == 1) {
@@ -9965,7 +9965,7 @@ void CMTRawAnalyzer::fillDigiAmplitude(HBHEDigiCollection::const_iterator& digiI
         }
 
         //
-        if (mdepth == 3 && fabs(ieta0) == 16) {
+        if (mdepth == 3 && std::abs(ieta0) == 16) {
           h_mapDepth3RADDAM16_HE->Fill(amplitudewithPedSubtr);
           // forStudy     h_mapDepth3RADDAM160_HE->Fill(1.);
         }

--- a/DQM/SiStripCommissioningAnalysis/src/CalibrationScanAlgorithm.cc
+++ b/DQM/SiStripCommissioningAnalysis/src/CalibrationScanAlgorithm.cc
@@ -425,7 +425,7 @@ void CalibrationScanAlgorithm::tuneIndependently(const int& iapv,
     imap = 0;
     // store for each isha value all rise time (changing isha)
     for (auto map_element : histo_) {
-      if (fabs(scanned_vfs_.at(imap) - cal_->vfs_[iapv]) < CalibrationScanAnalysis::VFSrange_ and
+      if (std::abs(scanned_vfs_.at(imap) - cal_->vfs_[iapv]) < CalibrationScanAnalysis::VFSrange_ and
           cal_->isValid(map_element.first)[iapv])  //around chosen VFS by \pm 20
         riseTime_vs_isha[scanned_isha_.at(imap)].push_back(cal_->riseTime(map_element.first)[iapv]);
       if (name == "") {
@@ -568,8 +568,8 @@ void CalibrationScanAlgorithm::fillTunedObservables(const int& apvid) {
 
   // find close by ISHA
   for (size_t i = 0; i < scanned_isha_.size(); i++) {
-    if (fabs(scanned_isha_.at(i) - cal_->bestISHA().at(apvid)) < distance_apv) {
-      distance_apv = fabs(scanned_isha_.at(i) - cal_->bestISHA().at(apvid));
+    if (std::abs(scanned_isha_.at(i) - cal_->bestISHA().at(apvid)) < distance_apv) {
+      distance_apv = std::abs(scanned_isha_.at(i) - cal_->bestISHA().at(apvid));
       cal_->tunedISHA_.at(apvid) = scanned_isha_.at(i);
     }
   }
@@ -578,8 +578,8 @@ void CalibrationScanAlgorithm::fillTunedObservables(const int& apvid) {
 
   // find close by VFS
   for (size_t i = 0; i < scanned_vfs_.size(); i++) {
-    if (fabs(scanned_vfs_.at(i) - cal_->bestVFS().at(apvid)) < distance_apv) {
-      distance_apv = fabs(scanned_vfs_.at(i) - cal_->bestVFS().at(apvid));
+    if (std::abs(scanned_vfs_.at(i) - cal_->bestVFS().at(apvid)) < distance_apv) {
+      distance_apv = std::abs(scanned_vfs_.at(i) - cal_->bestVFS().at(apvid));
       cal_->tunedVFS_.at(apvid) = scanned_vfs_.at(i);
     }
   }

--- a/DQMOffline/CalibCalo/plugins/DQMHcalPhiSymAlCaReco.cc
+++ b/DQMOffline/CalibCalo/plugins/DQMHcalPhiSymAlCaReco.cc
@@ -456,8 +456,8 @@ void DQMHcalPhiSymAlCaReco::analyze(const edm::Event &iEvent, const edm::EventSe
         hiDistrNoisePl2D_->Fill(hid.ieta(), hid.iphi(), hbheItr->energy());
         hiDistrNoise2Pl2D_->Fill(hid.ieta(), hid.iphi(), hbheItr->energy() * hbheItr->energy());
       } else {
-        hiDistrNoiseMin2D_->Fill(fabs(hid.ieta()), hid.iphi(), hbheItr->energy());
-        hiDistrNoise2Min2D_->Fill(fabs(hid.ieta()), hid.iphi(), hbheItr->energy() * hbheItr->energy());
+        hiDistrNoiseMin2D_->Fill(std::abs(hid.ieta()), hid.iphi(), hbheItr->energy());
+        hiDistrNoise2Min2D_->Fill(std::abs(hid.ieta()), hid.iphi(), hbheItr->energy() * hbheItr->energy());
       }
     }
   }
@@ -473,8 +473,8 @@ void DQMHcalPhiSymAlCaReco::analyze(const edm::Event &iEvent, const edm::EventSe
         hiDistrMBPl2D_->Fill(hid.ieta(), hid.iphi(), hbheItr->energy());
         hiDistrMB2Pl2D_->Fill(hid.ieta(), hid.iphi(), hbheItr->energy() * hbheItr->energy());
       } else {
-        hiDistrMBMin2D_->Fill(fabs(hid.ieta()), hid.iphi(), hbheItr->energy());
-        hiDistrMB2Min2D_->Fill(fabs(hid.ieta()), hid.iphi(), hbheItr->energy() * hbheItr->energy());
+        hiDistrMBMin2D_->Fill(std::abs(hid.ieta()), hid.iphi(), hbheItr->energy());
+        hiDistrMB2Min2D_->Fill(std::abs(hid.ieta()), hid.iphi(), hbheItr->energy() * hbheItr->energy());
       }
     }
   }
@@ -492,8 +492,8 @@ void DQMHcalPhiSymAlCaReco::analyze(const edm::Event &iEvent, const edm::EventSe
         hiDistrNoisePl2D_->Fill(hid.ieta(), hid.iphi(), hbheItr->energy());
         hiDistrNoise2Pl2D_->Fill(hid.ieta(), hid.iphi(), hbheItr->energy() * hbheItr->energy());
       } else {
-        hiDistrNoiseMin2D_->Fill(fabs(hid.ieta()), hid.iphi(), hbheItr->energy());
-        hiDistrNoise2Min2D_->Fill(fabs(hid.ieta()), hid.iphi(), hbheItr->energy() * hbheItr->energy());
+        hiDistrNoiseMin2D_->Fill(std::abs(hid.ieta()), hid.iphi(), hbheItr->energy());
+        hiDistrNoise2Min2D_->Fill(std::abs(hid.ieta()), hid.iphi(), hbheItr->energy() * hbheItr->energy());
       }
     }
   }
@@ -509,8 +509,8 @@ void DQMHcalPhiSymAlCaReco::analyze(const edm::Event &iEvent, const edm::EventSe
         hiDistrMBPl2D_->Fill(hid.ieta(), hid.iphi(), hbheItr->energy());
         hiDistrMB2Pl2D_->Fill(hid.ieta(), hid.iphi(), hbheItr->energy() * hbheItr->energy());
       } else {
-        hiDistrMBMin2D_->Fill(fabs(hid.ieta()), hid.iphi(), hbheItr->energy());
-        hiDistrMB2Min2D_->Fill(fabs(hid.ieta()), hid.iphi(), hbheItr->energy() * hbheItr->energy());
+        hiDistrMBMin2D_->Fill(std::abs(hid.ieta()), hid.iphi(), hbheItr->energy());
+        hiDistrMB2Min2D_->Fill(std::abs(hid.ieta()), hid.iphi(), hbheItr->energy() * hbheItr->energy());
       }
     }
   }


### PR DESCRIPTION
#### PR description:

Title says it all. Compilation logs: [1](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_15_0_CLANG_X_2024-12-16-2300/DPGAnalysis/HcalTools), [2](http://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc12/CMSSW_15_0_CLANG_X_2024-12-16-2300/DQM/SiStripCommissioningAnalysis), [3](http://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc12/CMSSW_15_0_CLANG_X_2024-12-16-2300/DQMOffline/CalibCalo).

#### PR validation:

Bot tests