### PR TITLE
[Geometry] Use std::abs to fix clang compilation warnings

### DIFF
--- a/DetectorDescription/DDCMS/test/DDFilteredView.find.cppunit.cc
+++ b/DetectorDescription/DDCMS/test/DDFilteredView.find.cppunit.cc
@@ -70,8 +70,8 @@ void testDDFilteredViewFind::checkFilteredView() {
   double radLength = fview.getNextValue("TrackerRadLength");
   std::cout << radLength << "\n";
   double xi = fview.getNextValue("TrackerXi");
-  CPPUNIT_ASSERT(abs(radLength - refRadLength_) < 10e-6);
-  CPPUNIT_ASSERT(abs(xi - refXi_) < 10e-6);
+  CPPUNIT_ASSERT(std::abs(radLength - refRadLength_) < 10e-6);
+  CPPUNIT_ASSERT(std::abs(xi - refXi_) < 10e-6);
 
   std::cout << "TrackerRadLength = " << radLength << "\nTrackerXi = " << xi << "\n";
 

--- a/DetectorDescription/DDCMS/test/DDFilteredView.get.cppunit.cc
+++ b/DetectorDescription/DDCMS/test/DDFilteredView.get.cppunit.cc
@@ -69,8 +69,8 @@ void testDDFilteredViewGet::checkFilteredView() {
 
   double radLength = fview.getNextValue("TrackerRadLength");
   double xi = fview.getNextValue("TrackerXi");
-  CPPUNIT_ASSERT(abs(radLength - refRadLength_) < 10e-6);
-  CPPUNIT_ASSERT(abs(xi - refXi_) < 10e-6);
+  CPPUNIT_ASSERT(std::abs(radLength - refRadLength_) < 10e-6);
+  CPPUNIT_ASSERT(std::abs(xi - refXi_) < 10e-6);
 
   std::cout << "TrackerRadLength = " << radLength << "\nTrackerXi = " << xi << "\n";
   auto vals = fview.getValuesNS<std::string>("TrackerRadLength");

--- a/DetectorDescription/DDCMS/test/DDFilteredView.goto.cppunit.cc
+++ b/DetectorDescription/DDCMS/test/DDFilteredView.goto.cppunit.cc
@@ -65,8 +65,8 @@ void testDDFilteredViewGoTo::checkFilteredView() {
 
   double radLength = fview.get<double>("TrackerRadLength");
   double xi = fview.getNextValue("TrackerXi");
-  CPPUNIT_ASSERT(abs(radLength - refRadLength_) < 10e-6);
-  CPPUNIT_ASSERT(abs(xi - refXi_) < 10e-6);
+  CPPUNIT_ASSERT(std::abs(radLength - refRadLength_) < 10e-6);
+  CPPUNIT_ASSERT(std::abs(xi - refXi_) < 10e-6);
 
   std::cout << "TrackerRadLength = " << radLength << "\nTrackerXi = " << xi << "\n";
 


### PR DESCRIPTION
#### PR description:

Title says it all. Compilation log: [link](http://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc12/CMSSW_15_0_CLANG_X_2024-12-16-2300/DetectorDescription/DDCMS)

#### PR validation:

Bot tests