### PR TITLE
[Visualization] Replace fabs with std::abs to fix clang compilation warnings

### DIFF
--- a/Fireworks/Calo/plugins/FWTracksterLayersProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWTracksterLayersProxyBuilder.cc
@@ -237,7 +237,7 @@ void FWTracksterLayersProxyBuilder::build(const ticl::Trackster &iData,
       const bool isAdjacent = std::abs(layerOut - layerIn) == 1;
 
       // draw 3D cross
-      if (layer_ == 0 || fabs(layerIn - layer_) == 0 || fabs(layerOut - layer_) == 0) {
+      if (layer_ == 0 || std::abs(layerIn - layer_) == 0 || std::abs(layerOut - layer_) == 0) {
         if (isAdjacent)
           adjacent_marker->AddLine(doublet.first.x(),
                                    doublet.first.y(),


### PR DESCRIPTION
#### PR description:

Title says it all. Compilation log: [link](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_15_0_CLANG_X_2024-12-16-2300/Fireworks/Calo)

#### PR validation:

Bot tests
