### PR TITLE
Add additional information to the `SimTrack`s

### DIFF
--- a/SimDataFormats/Track/interface/SimTrack.h
+++ b/SimDataFormats/Track/interface/SimTrack.h
@@ -34,6 +34,7 @@ public:
   bool noVertex() const { return ivert == -1; }
 
   /// index of the corresponding Generator particle in the Event container (-1 if no Genpart)
+  bool isPrimary() const { return (trackInfo_ >> 1) & 1; }
   int genpartIndex() const { return isPrimary() ? igenpart : -1; }
   bool noGenpart() const { return isPrimary() ? igenpart == -1 : true; }
 
@@ -52,7 +53,7 @@ public:
                               math::XYZTLorentzVectorF positionAtBoundary,
                               math::XYZTLorentzVectorF momentumAtBoundary) {
     if (crossedBoundary)
-      trackInfo_ |= 1 << 2;
+      trackInfo_ |= (1 << 2);
     idAtBoundary_ = idAtBoundary;
     positionAtBoundary_ = positionAtBoundary;
     momentumAtBoundary_ = momentumAtBoundary;
@@ -62,11 +63,10 @@ public:
   const math::XYZTLorentzVectorF& getMomentumAtBoundary() const { return momentumAtBoundary_; }
   int getIDAtBoundary() const { return idAtBoundary_; }
 
-  bool isFromBackScattering() const { return (trackInfo_ >> 0) & 1; }
-  void setFromBackScattering() { trackInfo_ |= 1 << 0; }
+  bool isFromBackScattering() const { return trackInfo_ & 1; }
+  void setFromBackScattering() { trackInfo_ |= 1; }
 
-  bool isPrimary() const { return (trackInfo_ >> 1) & 1; }
-  void setIsPrimary() { trackInfo_ |= 1 << 1; }
+  void setIsPrimary() { trackInfo_ |= (1 << 1); }
   void setGenParticleID(const int idx) { igenpart = idx; }
   int getPrimaryID() const { return igenpart; }
   uint8_t getTrackInfo() const { return trackInfo_; }

--- a/SimDataFormats/Track/src/SimTrack.cc
+++ b/SimDataFormats/Track/src/SimTrack.cc
@@ -1,12 +1,12 @@
 #include "SimDataFormats/Track/interface/SimTrack.h"
 
-SimTrack::SimTrack() : ivert(-1), igenpart(-1), crossedBoundary_(false) {}
+SimTrack::SimTrack() : ivert(-1), igenpart(-1), trackInfo_(0) {}
 
 SimTrack::SimTrack(int ipart, const math::XYZTLorentzVectorD& p)
-    : Core(ipart, p), ivert(-1), igenpart(-1), crossedBoundary_(false) {}
+    : Core(ipart, p), ivert(-1), igenpart(-1), trackInfo_(0) {}
 
 SimTrack::SimTrack(int ipart, const math::XYZTLorentzVectorD& p, int iv, int ig)
-    : Core(ipart, p), ivert(iv), igenpart(ig), crossedBoundary_(false) {}
+    : Core(ipart, p), ivert(iv), igenpart(ig), trackInfo_(0) {}
 
 SimTrack::SimTrack(int ipart,
                    const math::XYZTLorentzVectorD& p,
@@ -14,9 +14,9 @@ SimTrack::SimTrack(int ipart,
                    int ig,
                    const math::XYZVectorD& tkp,
                    const math::XYZTLorentzVectorD& tkm)
-    : Core(ipart, p), ivert(iv), igenpart(ig), tkposition(tkp), tkmomentum(tkm), crossedBoundary_(false) {}
+    : Core(ipart, p), ivert(iv), igenpart(ig), tkposition(tkp), tkmomentum(tkm), trackInfo_(0) {}
 
-SimTrack::SimTrack(const CoreSimTrack& t, int iv, int ig) : Core(t), ivert(iv), igenpart(ig), crossedBoundary_(false) {}
+SimTrack::SimTrack(const CoreSimTrack& t, int iv, int ig) : Core(t), ivert(iv), igenpart(ig), trackInfo_(0) {}
 
 std::ostream& operator<<(std::ostream& o, const SimTrack& t) {
   return o << (SimTrack::Core)(t) << ", " << t.vertIndex() << ", " << t.genpartIndex();

--- a/SimDataFormats/Track/src/classes_def.xml
+++ b/SimDataFormats/Track/src/classes_def.xml
@@ -9,6 +9,22 @@
    <version ClassVersion="12" checksum="3470347245"/>
    <version ClassVersion="11" checksum="1785575744"/>
    <version ClassVersion="10" checksum="1430205451"/>
+   <ioread sourceClass = "SimTrack" version="[-12]" targetClass="SimTrack" source="" target="">
+    <![CDATA[
+        SimTrack tmp(newObj->type(), newObj->momentum(), newObj->vertIndex(), newObj->genpartIndex(), newObj->trackerSurfacePosition(), newObj->trackerSurfaceMomentum());
+        tmp.setTrackId(newObj->trackId());
+        tmp.setEventId(newObj->eventId());
+        tmp.setCrossedBoundaryVars(
+            newObj->crossedBoundary(), newObj->getIDAtBoundary(), newObj->getPositionAtBoundary(), newObj->getMomentumAtBoundary());
+        if (newObj->isFromBackScattering()) {
+          tmp.setFromBackScattering();
+        }
+        if (newObj->genpartIndex() != -1) {
+          tmp.setIsPrimary();
+        }
+        *newObj=tmp;
+    ]]>
+   </ioread>
   </class>
   <class name="edm::Wrapper<std::vector<SimTrack> >" />
   <class name="edm::RefProd<std::vector<SimTrack> >"/>

--- a/SimDataFormats/Track/src/classes_def.xml
+++ b/SimDataFormats/Track/src/classes_def.xml
@@ -4,7 +4,8 @@
   <class name="CoreSimTrack" ClassVersion="10">
    <version ClassVersion="10" checksum="3936841839"/>
   </class>
-  <class name="SimTrack" ClassVersion="12">
+  <class name="SimTrack" ClassVersion="13">
+   <version ClassVersion="13" checksum="1912247222"/>
    <version ClassVersion="12" checksum="3470347245"/>
    <version ClassVersion="11" checksum="1785575744"/>
    <version ClassVersion="10" checksum="1430205451"/>

--- a/SimG4Core/Application/plugins/OscarMTProducer.cc
+++ b/SimG4Core/Application/plugins/OscarMTProducer.cc
@@ -251,7 +251,7 @@ void OscarMTProducer::produce(edm::Event& e, const edm::EventSetup& es) {
 
   if (0 < m_verbose) {
     edm::LogVerbatim("SimG4CoreApplication")
-        << "Produced " << p2->size() << " SimVertecies: position(cm), time(s), parentID, vertexID, processType";
+        << "Produced " << p2->size() << " SimVertices: position(cm), time(s), parentID, vertexID, processType";
     if (1 < m_verbose) {
       int nn = p2->size();
       for (int i = 0; i < nn; ++i) {
@@ -260,12 +260,15 @@ void OscarMTProducer::produce(edm::Event& e, const edm::EventSetup& es) {
     }
     edm::LogVerbatim("SimG4CoreApplication")
         << "Produced " << p1->size()
-        << " SimTracks: pdg, 4-momentum(GeV), vertexID, mcTruthID, flagBoundary, trackID at boundary";
+        << " SimTracks: G4 Id, pdg, 4-momentum(GeV), vertexID, mcTruthID, crossedBoundary, trackID at boundary, from "
+           "backscattering, isPrimary, getPrimary";
     if (1 < m_verbose) {
       int nn = p1->size();
       for (int i = 0; i < nn; ++i) {
-        edm::LogVerbatim("Track") << " " << i << ". " << (*p1)[i] << " " << (*p1)[i].crossedBoundary() << " "
-                                  << (*p1)[i].getIDAtBoundary();
+        edm::LogVerbatim("Track") << " " << i << ". " << (*p1)[i].trackId() << " " << (*p1)[i] << " "
+                                  << (*p1)[i].crossedBoundary() << " " << (*p1)[i].getIDAtBoundary() << " "
+                                  << (*p1)[i].isFromBackScattering() << " " << (*p1)[i].isPrimary() << " "
+                                  << (*p1)[i].getPrimaryID();
       }
     }
   }

--- a/SimG4Core/Application/plugins/OscarMTProducer.cc
+++ b/SimG4Core/Application/plugins/OscarMTProducer.cc
@@ -260,14 +260,14 @@ void OscarMTProducer::produce(edm::Event& e, const edm::EventSetup& es) {
     }
     edm::LogVerbatim("SimG4CoreApplication")
         << "Produced " << p1->size()
-        << " SimTracks: G4 Id, pdg, 4-momentum(GeV), vertexID, mcTruthID, crossedBoundary, trackID at boundary, from "
-           "backscattering, isPrimary, getPrimary";
+        << " SimTracks: G4 Id, pdg, 4-momentum(GeV), vertexID, mcTruthID, crossedBoundary -> trackID at boundary, from "
+           "backscattering, isPrimary -> getPrimary";
     if (1 < m_verbose) {
       int nn = p1->size();
       for (int i = 0; i < nn; ++i) {
-        edm::LogVerbatim("Track") << " " << i << ". " << (*p1)[i].trackId() << " " << (*p1)[i] << " "
-                                  << (*p1)[i].crossedBoundary() << " " << (*p1)[i].getIDAtBoundary() << " "
-                                  << (*p1)[i].isFromBackScattering() << " " << (*p1)[i].isPrimary() << " "
+        edm::LogVerbatim("Track") << " " << i << ". " << (*p1)[i].trackId() << ", " << (*p1)[i] << ", "
+                                  << (*p1)[i].crossedBoundary() << "-> " << (*p1)[i].getIDAtBoundary() << ", "
+                                  << (*p1)[i].isFromBackScattering() << ", " << (*p1)[i].isPrimary() << "-> "
                                   << (*p1)[i].getPrimaryID();
       }
     }

--- a/SimG4Core/Notification/interface/TmpSimTrack.h
+++ b/SimG4Core/Notification/interface/TmpSimTrack.h
@@ -40,7 +40,7 @@ public:
   const math::XYZVectorD& momentum() const { return ip_; }
   double energy() const { return ie_; }
   int ivert() const { return ivert_; }
-  int igenpart() const { return igenpart_; }
+  int igenpart() const { return isPrimary_ ? igenpart_ : -1; }
   // parent momentum at interaction
   const math::XYZVectorD& parentMomentum() const { return parentMomentum_; }
   // Information at level of tracker surface
@@ -62,6 +62,12 @@ public:
   const math::XYZTLorentzVectorF& getPositionAtBoundary() const { return positionAtBoundary_; }
   const math::XYZTLorentzVectorF& getMomentumAtBoundary() const { return momentumAtBoundary_; }
   int getIDAtBoundary() const { return idAtBoundary_; }
+  bool isFromBackScattering() const { return isFromBackScattering_; }
+  void setFromBackScattering() { isFromBackScattering_ = true; }
+  void setGenParticleID(int i) { igenpart_ = i; }
+  bool isPrimary() const { return isPrimary_; }
+  void setIsPrimary() { isPrimary_ = true; }
+  int getPrimaryID() const { return igenpart_; }
 
 private:
   int id_;
@@ -74,7 +80,9 @@ private:
   math::XYZVectorD parentMomentum_{math::XYZVectorD(0., 0., 0.)};
   math::XYZVectorD tkSurfacePosition_{math::XYZVectorD(0., 0., 0.)};
   math::XYZTLorentzVectorD tkSurfaceMomentum_{math::XYZTLorentzVectorD(0., 0., 0., 0.)};
+  bool isFromBackScattering_{false};
   bool crossedBoundary_{false};
+  bool isPrimary_{false};
   int idAtBoundary_{-1};
   math::XYZTLorentzVectorF positionAtBoundary_{math::XYZTLorentzVectorF(0.f, 0.f, 0.f, 0.f)};
   math::XYZTLorentzVectorF momentumAtBoundary_{math::XYZTLorentzVectorF(0.f, 0.f, 0.f, 0.f)};

--- a/SimG4Core/Notification/interface/TrackWithHistory.h
+++ b/SimG4Core/Notification/interface/TrackWithHistory.h
@@ -14,7 +14,7 @@ class G4PrimaryParticle;
 
 class TrackWithHistory {
 public:
-  /** The constructor is called at time, 
+  /** The constructor is called at time,
      *  when some of the information may not available yet.
      */
   TrackWithHistory(const G4Track *g4track, int pID);
@@ -27,7 +27,7 @@ public:
   int trackID() const { return trackID_; }
   int particleID() const { return pdgID_; }
   int parentID() const { return parentID_; }
-  int genParticleID() const { return genParticleID_; }
+  int genParticleID() const { return isPrimary_ ? genParticleID_ : -1; }
   int vertexID() const { return vertexID_; }
   int processType() const { return procType_; }
   int getIDAtBoundary() const { return idAtBoundary_; }
@@ -67,6 +67,11 @@ public:
     tkSurfacePosition_ = pos;
     tkSurfaceMomentum_ = mom;
   }
+  bool isFromBackScattering() const { return isFromBackScattering_; }
+  void setFromBackScattering() { isFromBackScattering_ = true; }
+  bool isPrimary() const { return isPrimary_; }
+  void setIsPrimary() { isPrimary_ = true; }
+  int getPrimaryID() const { return genParticleID_; }
 
 private:
   int trackID_;
@@ -88,6 +93,8 @@ private:
   bool storeTrack_{false};
   bool saved_{false};
   bool crossedBoundary_{false};
+  bool isFromBackScattering_{false};
+  bool isPrimary_{false};
 };
 
 extern G4ThreadLocal G4Allocator<TrackWithHistory> *fpTrackWithHistoryAllocator;

--- a/SimG4Core/Notification/src/SimTrackManager.cc
+++ b/SimG4Core/Notification/src/SimTrackManager.cc
@@ -76,10 +76,12 @@ void SimTrackManager::addTrack(TrackWithHistory* iTrack, const G4Track* track, b
     auto info = static_cast<const TrackInformation*>(track->GetUserInformation());
     if (info->isInTrkFromBackscattering())
       iTrack->setFromBackScattering();
-    // set there *for all the tracks* the genParticle ID associated with the G4Track
-    // in the constructor of TrackWithHistory the info isPrimary is saved and used
-    // to give -1 if the track is not a primary
-    iTrack->setGenParticleID(info->mcTruthID());
+    // set there for the *non-primary* tracks the genParticle ID associated with the G4Track
+    // for the primaries this is done in the TrackWithHistory constructor.
+    // In the constructor of TrackWithHistory the info isPrimary is saved and used
+    // to give -1 if the track is not a primary.
+    if (not iTrack->isPrimary())
+      iTrack->setGenParticleID(info->mcTruthID());
     m_trackContainer.push_back(iTrack);
     const auto& v = track->GetStep()->GetPostStepPoint()->GetPosition();
     std::pair<int, math::XYZVectorD> p(iTrack->trackID(),

--- a/SimG4Core/Notification/src/SimTrackManager.cc
+++ b/SimG4Core/Notification/src/SimTrackManager.cc
@@ -73,6 +73,13 @@ void SimTrackManager::addTrack(TrackWithHistory* iTrack, const G4Track* track, b
   std::pair<int, int> thePair(iTrack->trackID(), iTrack->parentID());
   idsave.push_back(thePair);
   if (inHistory) {
+    auto info = static_cast<const TrackInformation *>(track->GetUserInformation());
+    if (info->isInTrkFromBackscattering())
+      iTrack->setFromBackScattering();
+    // set there *for all the tracks* the genParticle ID associated with the G4Track
+    // in the constructor of TrackWithHistory the info isPrimary is saved and used
+    // to give -1 if the track is not a primary
+    iTrack->setGenParticleID(info->mcTruthID());
     m_trackContainer.push_back(iTrack);
     const auto& v = track->GetStep()->GetPostStepPoint()->GetPosition();
     std::pair<int, math::XYZVectorD> p(iTrack->trackID(),
@@ -132,7 +139,10 @@ void SimTrackManager::reallyStoreTracks() {
     // at this stage there is one vertex per track,
     // so the vertex id of track N is also N
     int iParentID = trkH->parentID();
-    int ig = trkH->genParticleID();
+    int ig = trkH->genParticleID(); // filled only for primary tracks
+    bool isBackScatter = trkH->isFromBackScattering();
+    bool isPrimary = trkH->isPrimary();
+    int primaryGenPartId = trkH->getPrimaryID(); // filled if the G4Track had this info
     int ivertex = getOrCreateVertex(trkH, iParentID);
 
     auto ptr = trkH;
@@ -170,6 +180,11 @@ void SimTrackManager::reallyStoreTracks() {
     TmpSimTrack* g4simtrack =
         new TmpSimTrack(id, trkH->particleID(), trkH->momentum(), trkH->totalEnergy(), ivertex, ig, pm, spos, smom);
     g4simtrack->copyCrossedBoundaryVars(trkH);
+    if (isBackScatter)
+      g4simtrack->setFromBackScattering();
+    if (isPrimary)
+      g4simtrack->setIsPrimary();
+    g4simtrack->setGenParticleID(primaryGenPartId);
     m_simEvent->addTrack(g4simtrack);
   }
 }

--- a/SimG4Core/Notification/src/SimTrackManager.cc
+++ b/SimG4Core/Notification/src/SimTrackManager.cc
@@ -73,7 +73,7 @@ void SimTrackManager::addTrack(TrackWithHistory* iTrack, const G4Track* track, b
   std::pair<int, int> thePair(iTrack->trackID(), iTrack->parentID());
   idsave.push_back(thePair);
   if (inHistory) {
-    auto info = static_cast<const TrackInformation *>(track->GetUserInformation());
+    auto info = static_cast<const TrackInformation*>(track->GetUserInformation());
     if (info->isInTrkFromBackscattering())
       iTrack->setFromBackScattering();
     // set there *for all the tracks* the genParticle ID associated with the G4Track
@@ -131,7 +131,7 @@ void SimTrackManager::storeTracks() {
 void SimTrackManager::reallyStoreTracks() {
   // loop over the (now ordered) vector and really save the tracks
 #ifdef DebugLog
-  edm::LogVerbatim("SimTrackManager") << "reallyStoreTracks() NtracksWithHistory= " << m_trackContainer->size();
+  edm::LogVerbatim("SimTrackManager") << "reallyStoreTracks() NtracksWithHistory= " << m_trackContainer.size();
 #endif
 
   int nn = m_endPoints.size();
@@ -139,10 +139,10 @@ void SimTrackManager::reallyStoreTracks() {
     // at this stage there is one vertex per track,
     // so the vertex id of track N is also N
     int iParentID = trkH->parentID();
-    int ig = trkH->genParticleID(); // filled only for primary tracks
+    int ig = trkH->genParticleID();  // filled only for primary tracks
     bool isBackScatter = trkH->isFromBackScattering();
     bool isPrimary = trkH->isPrimary();
-    int primaryGenPartId = trkH->getPrimaryID(); // filled if the G4Track had this info
+    int primaryGenPartId = trkH->getPrimaryID();  // filled if the G4Track had this info
     int ivertex = getOrCreateVertex(trkH, iParentID);
 
     auto ptr = trkH;
@@ -319,7 +319,7 @@ void SimTrackManager::cleanTracksWithHistory() {
   std::stable_sort(idsave.begin(), idsave.end());
 
 #ifdef DebugLog
-  LogDebug("SimTrackManager") << " SimTrackManager::cleanTracksWithHistory knows " << m_trksForThisEvent->size()
+  LogDebug("SimTrackManager") << " SimTrackManager::cleanTracksWithHistory knows " << m_trackContainer.size()
                               << " tracks with history before branching";
   for (unsigned int it = 0; it < m_trackContainer.size(); it++) {
     LogDebug("SimTrackManager") << " 1 - Track in position " << it << " G4 track number "

--- a/SimG4Core/Notification/src/TmpSimEvent.cc
+++ b/SimG4Core/Notification/src/TmpSimEvent.cc
@@ -35,15 +35,25 @@ void TmpSimEvent::load(edm::SimTrackContainer& c) const {
     int iv = trk->ivert();
     int ig = trk->igenpart();
     int id = trk->id();
+    bool isBackScatter = trk->isFromBackScattering();
+    bool isPrimary = trk->isPrimary();
+    int primaryGenPartId = trk->getPrimaryID(); // filled if the G4Track had this info
     // ip = particle ID as PDG
-    // pp = 4-momentum in GeV
+    // p  = 4-momentum in GeV
     // iv = corresponding TmpSimVertex index
-    // ig = corresponding GenParticle index
+    // ig = corresponding GenParticle index only if is a primary, otherwise is -1
+    // primaryGenPartId = corresponding GenParticle index also if not primary
+    // id = corresponding g4Track Id
     SimTrack t = SimTrack(ip, p, iv, ig, trk->trackerSurfacePosition(), trk->trackerSurfaceMomentum());
     t.setTrackId(id);
     t.setEventId(EncodedEventId(0));
     t.setCrossedBoundaryVars(
         trk->crossedBoundary(), trk->getIDAtBoundary(), trk->getPositionAtBoundary(), trk->getMomentumAtBoundary());
+    if (isBackScatter)
+      t.setFromBackScattering();
+    if (isPrimary)
+      t.setIsPrimary();
+    t.setGenParticleID(primaryGenPartId);
     c.push_back(t);
   }
   std::stable_sort(c.begin(), c.end(), IdSort());

--- a/SimG4Core/Notification/src/TmpSimEvent.cc
+++ b/SimG4Core/Notification/src/TmpSimEvent.cc
@@ -53,7 +53,8 @@ void TmpSimEvent::load(edm::SimTrackContainer& c) const {
       t.setFromBackScattering();
     if (isPrimary)
       t.setIsPrimary();
-    t.setGenParticleID(primaryGenPartId);
+    else
+      t.setGenParticleID(primaryGenPartId);
     c.push_back(t);
   }
   std::stable_sort(c.begin(), c.end(), IdSort());

--- a/SimG4Core/Notification/src/TmpSimEvent.cc
+++ b/SimG4Core/Notification/src/TmpSimEvent.cc
@@ -37,7 +37,7 @@ void TmpSimEvent::load(edm::SimTrackContainer& c) const {
     int id = trk->id();
     bool isBackScatter = trk->isFromBackScattering();
     bool isPrimary = trk->isPrimary();
-    int primaryGenPartId = trk->getPrimaryID(); // filled if the G4Track had this info
+    int primaryGenPartId = trk->getPrimaryID();  // filled if the G4Track had this info
     // ip = particle ID as PDG
     // p  = 4-momentum in GeV
     // iv = corresponding TmpSimVertex index

--- a/SimG4Core/Notification/src/TrackWithHistory.cc
+++ b/SimG4Core/Notification/src/TrackWithHistory.cc
@@ -29,10 +29,15 @@ TrackWithHistory::TrackWithHistory(const G4Track* g4trk, int pID) {
   TrackInformation* trkinfo = static_cast<TrackInformation*>(g4trk->GetUserInformation());
   storeTrack_ = trkinfo->storeTrack();
   auto vgprimary = g4trk->GetDynamicParticle()->GetPrimaryParticle();
+  // GetPrimaryParticle() returns the pointer to the corresponding G4PrimaryParticle object
+  // if this particle is a primary particle OR is defined as a
+  // pre-assigned decay product. Otherwise return nullptr.
+  // Therefore here the genParticleID_ is -1 for not primary particles
   if (vgprimary != nullptr) {
     auto priminfo = static_cast<GenParticleInfo*>(vgprimary->GetUserInformation());
     if (nullptr != priminfo) {
       genParticleID_ = priminfo->id();
+      isPrimary_ = true;
     }
   }
   // V.I. weight is computed in the same way as before
@@ -53,6 +58,7 @@ TrackWithHistory::TrackWithHistory(const G4PrimaryParticle* ptr, int trackID, co
   auto priminfo = static_cast<GenParticleInfo*>(ptr->GetUserInformation());
   if (nullptr != priminfo) {
     genParticleID_ = priminfo->id();
+    isPrimary_ = true;
   }
   weight_ = 10000. * genParticleID_;
 }


### PR DESCRIPTION
#### PR description:

Looking at the SimTracks and SimVertices in single pion events we found some "orphan" vertices that were triggering the creation of `SimCluster`s not associated with any `CaloParticle`.
For example, when a particle enters HGCAL we stop keeping track of the history, if it does backscattering and enters the barrel calorimeters we lose the connection with the initial particle.
With this additional information, we can connect the orphan `simCluster`s to the original particle that created them and flag those that come from backscattering.

This information will be used at the `SimCluster` level in the `CaloTruthAccumulator` in a follow-up PR.

Note: the behaviour of the already existing methods (`genpartIndex()` and `noGenpart()`) has not been changed to preserve backward compatibility and the new `getPrimaryID()` method is used to obtain the `genParticle` index.
The logic with the `uint8_t` instead of a list of `bool` reduces the class size and gives the possibility to add more flags / categories in the future.

#### PR validation:

tested on a single pion workflow enabling Geant4-related cout.

FYI @rovere @felicepantaleo @fabiocos 