### PR TITLE
[MiniAOD] Remove slimmedGenJets minimum pt cut

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/slimmedGenJets_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedGenJets_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 slimmedGenJets = cms.EDProducer("PATGenJetSlimmer",
     src = cms.InputTag("ak4GenJetsNoNu"),
     packedGenParticles = cms.InputTag("packedGenParticles"),
-    cut = cms.string("pt > 8"),
+    cut = cms.string(""),
     cutLoose = cms.string(""),
     nLoose = cms.uint32(0),
     clearDaughters = cms.bool(False), #False means rekeying


### PR DESCRIPTION
#### PR description:

This PR removes the minimum pt cut for `slimmedGenJets` (AK4 gen-jets) in MiniAOD, effectively storing gen-jets with `pt > 3 GeV`.

This PR presents one way that we can overcome the `partonFlavour` inconsistency between jets built at `RECO`-level and jets reclustered from MiniAOD inputs. By storing all gen-jets that we produce, there is no need to recluster gen-jets with MiniAOD and the gen-jets retain their `partonFlavour` values, as calculated at RECO level. For reco-jets that are reclustered with MiniAOD inputs, their flavour labelling can be retrieved from matched gen-jets. 

#### PR validation:

- Passes the usual runTheMatrix test: `runTheMatrix.py -l limited -i all --ibeos` with the exception of a few workflows which failed because of missing relval input files.

- The event size increases from 83.83 to 84.58 kb/event (+0.9%), using an MC TTto4Q `RunIII2024Summer24` AOD file as the input test file.