### PR TITLE
[XPOG] Apply code checks/format

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/TauSpinnerTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/TauSpinnerTableProducer.cc
@@ -60,10 +60,10 @@ private:
       std::string name = std::to_string(val);
       name.erase(name.find_last_not_of('0') + 1, std::string::npos);
       name.erase(name.find_last_not_of('.') + 1, std::string::npos);
-      size_t pos = name.find(".");
+      size_t pos = name.find('.');
       if (pos != std::string::npos)
         name.replace(pos, 1, "p");
-      pos = name.find("-");
+      pos = name.find('-');
       if (pos != std::string::npos)
         name.replace(pos, 1, "minus");
       out.push_back(std::make_pair(name, val));


### PR DESCRIPTION
PGO changes ( e.g. using relative source path instead of full path ) broke `scram build code-checks` rule. So it has not been running properly on PR. `code-format` was working but only `code-checks` i.e. `clang-tidy` did not work as it required correct `compiler_command.json` with correct source file paths.

Build rules are fixed now, so this PR applies `code-checks` ( and format) for those files which were merged with proper code-checks