### PR TITLE
[SIMULATION] Apply code checks/format

### DIFF
--- a/Mixing/Base/src/BMixingModule.cc
+++ b/Mixing/Base/src/BMixingModule.cc
@@ -43,7 +43,7 @@ namespace {
         //in case of DB access, do not try to load anything from the PSet, but wait for beginRun.
         edm::LogError("BMixingModule") << "Will read from DB: reset to a dummy PileUp object.";
         std::unique_ptr<TH1F> h;
-        pileupconfig.reset(new edm::PileUpConfig(sourceName, 0.0, h, playback));
+        pileupconfig = std::make_shared<edm::PileUpConfig>(sourceName, 0.0, h, playback);
         return pileupconfig;
       }
       if (type_ != "none") {
@@ -51,7 +51,7 @@ namespace {
           edm::ParameterSet psin_average = psin.getParameter<edm::ParameterSet>("nbPileupEvents");
           if (psin_average.exists("averageNumber")) {
             averageNumber = psin_average.getParameter<double>("averageNumber");
-            pileupconfig.reset(new edm::PileUpConfig(sourceName, averageNumber, h, playback));
+            pileupconfig = std::make_shared<edm::PileUpConfig>(sourceName, averageNumber, h, playback);
             edm::LogInfo("MixingModule") << " Created source " << sourceName << " with averageNumber " << averageNumber;
           } else if (psin_average.exists("fileName") && psin_average.exists("histoName")) {
             std::string histoFileName = psin_average.getUntrackedParameter<std::string>("fileName");
@@ -79,7 +79,7 @@ namespace {
             // Get the averageNumber from the histo
             averageNumber = h->GetMean();
 
-            pileupconfig.reset(new edm::PileUpConfig(sourceName, averageNumber, h, playback));
+            pileupconfig = std::make_shared<edm::PileUpConfig>(sourceName, averageNumber, h, playback);
             edm::LogInfo("MixingModule") << " Created source " << sourceName << " with averageNumber " << averageNumber;
 
           } else if (psin_average.exists("probFunctionVariable") && psin_average.exists("probValue") &&
@@ -155,14 +155,14 @@ namespace {
             outfile->Close();
             outfile->Delete();
 
-            pileupconfig.reset(new edm::PileUpConfig(sourceName, averageNumber, hprob, playback));
+            pileupconfig = std::make_shared<edm::PileUpConfig>(sourceName, averageNumber, hprob, playback);
             edm::LogInfo("MixingModule") << " Created source " << sourceName << " with averageNumber " << averageNumber;
           }
           //special for pileup input
           else if (sourceName == "input" && psin_average.exists("Lumi") && psin_average.exists("sigmaInel")) {
             averageNumber = psin_average.getParameter<double>("Lumi") * psin_average.getParameter<double>("sigmaInel") *
                             ps.getParameter<int>("bunchspace") / 1000 * 3564. / 2808.;  //FIXME
-            pileupconfig.reset(new edm::PileUpConfig(sourceName, averageNumber, h, playback));
+            pileupconfig = std::make_shared<edm::PileUpConfig>(sourceName, averageNumber, h, playback);
             edm::LogInfo("MixingModule") << " Created source " << sourceName << " with minBunch,maxBunch " << minb
                                          << " " << maxb;
             edm::LogInfo("MixingModule") << " Luminosity configuration, average number used is " << averageNumber;

--- a/Mixing/Base/src/PileUp.cc
+++ b/Mixing/Base/src/PileUp.cc
@@ -210,7 +210,7 @@ namespace edm {
 
   void PileUp::beginStream(edm::StreamID) {
     auto iID = eventPrincipal_->streamID();  // each producer has its own workermanager, so use default streamid
-    streamContext_.reset(new StreamContext(iID, processContext_.get()));
+    streamContext_ = std::make_shared<StreamContext>(iID, processContext_.get());
     streamContext_->setTransition(StreamContext::Transition::kBeginStream);
     if (provider_.get() != nullptr) {
       edm::ServiceRegistry::Operate guard(*serviceToken_);
@@ -245,7 +245,7 @@ namespace edm {
 
   void PileUp::beginRun(const edm::Run& run, const edm::EventSetup& setup) {
     if (provider_.get() != nullptr) {
-      runPrincipal_.reset(new RunPrincipal(productRegistry_, *processConfiguration_, nullptr, 0));
+      runPrincipal_ = std::make_shared<RunPrincipal>(productRegistry_, *processConfiguration_, nullptr, 0);
       runPrincipal_->setAux(run.runAuxiliary());
       edm::ServiceRegistry::Operate guard(*serviceToken_);
       streamContext_->setTransition(StreamContext::Transition::kBeginRun);
@@ -254,7 +254,7 @@ namespace edm {
   }
   void PileUp::beginLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup& setup) {
     if (provider_.get() != nullptr) {
-      lumiPrincipal_.reset(new LuminosityBlockPrincipal(productRegistry_, *processConfiguration_, nullptr, 0));
+      lumiPrincipal_ = std::make_shared<LuminosityBlockPrincipal>(productRegistry_, *processConfiguration_, nullptr, 0);
       lumiPrincipal_->setAux(lumi.luminosityBlockAuxiliary());
       lumiPrincipal_->setRunPrincipal(runPrincipal_);
       setRandomEngine(lumi);
@@ -348,7 +348,7 @@ namespace edm {
       edm::LogInfo("MixingModule") << "An histogram will be created with " << numBins << " bins in the range (" << xmin
                                    << "," << xmax << ")." << std::endl;
 
-      histo_.reset(new TH1F("h", "Histo from the user's probability function", numBins, xmin, xmax));
+      histo_ = std::make_shared<TH1F>("h", "Histo from the user's probability function", numBins, xmin, xmax);
 
       LogDebug("MixingModule") << "Filling histogram with the following data:" << std::endl;
 

--- a/SimG4CMS/Calo/plugins/HGCalTestGuardRing.cc
+++ b/SimG4CMS/Calo/plugins/HGCalTestGuardRing.cc
@@ -77,7 +77,7 @@ HGCalTestGuardRing::HGCalTestGuardRing(const edm::ParameterSet& ps)
                               HGCalTypes::WaferFive,
                               HGCalTypes::WaferThree};
     edm::FileInPath filetmp("SimG4CMS/Calo/data/" + waferFile_);
-    std::string fileName = filetmp.fullPath();
+    const std::string& fileName = filetmp.fullPath();
     std::ifstream fInput(fileName.c_str());
     if (!fInput.good()) {
       edm::LogVerbatim("HGCalSim") << "Cannot open file " << fileName;

--- a/SimG4CMS/Calo/plugins/HGCalTestPartialWaferHits.cc
+++ b/SimG4CMS/Calo/plugins/HGCalTestPartialWaferHits.cc
@@ -60,7 +60,7 @@ HGCalTestPartialWaferHits::HGCalTestPartialWaferHits(const edm::ParameterSet& ps
                                << "   Hits: " << caloHitSource_ << " Missing Wafer file " << missingFile_;
   if (!missingFile_.empty()) {
     edm::FileInPath filetmp("SimG4CMS/Calo/data/" + missingFile_);
-    std::string fileName = filetmp.fullPath();
+    const std::string& fileName = filetmp.fullPath();
     std::ifstream fInput(fileName.c_str());
     if (!fInput.good()) {
       edm::LogVerbatim("HGCalSim") << "Cannot open file " << fileName;

--- a/SimG4CMS/Calo/plugins/HGCalTestScintHits.cc
+++ b/SimG4CMS/Calo/plugins/HGCalTestScintHits.cc
@@ -56,7 +56,7 @@ HGCalTestScintHits::HGCalTestScintHits(const edm::ParameterSet& ps)
                                << "   Hits: " << caloHitSource_ << " Tile file " << tileFileName_;
   if (!tileFileName_.empty()) {
     edm::FileInPath filetmp("SimG4CMS/Calo/data/" + tileFileName_);
-    std::string fileName = filetmp.fullPath();
+    const std::string& fileName = filetmp.fullPath();
     std::ifstream fInput(fileName.c_str());
     if (!fInput.good()) {
       edm::LogVerbatim("HGCalSim") << "Cannot open file " << fileName;

--- a/SimG4CMS/Calo/src/CaloMeanResponse.cc
+++ b/SimG4CMS/Calo/src/CaloMeanResponse.cc
@@ -13,7 +13,7 @@ using CLHEP::GeV;
 CaloMeanResponse::CaloMeanResponse(edm::ParameterSet const& p) {
   edm::ParameterSet m_p = p.getParameter<edm::ParameterSet>("CaloResponse");
   edm::FileInPath fp = m_p.getParameter<edm::FileInPath>("ResponseFile");
-  std::string fName = fp.fullPath();
+  const std::string& fName = fp.fullPath();
   useTable = m_p.getParameter<bool>("UseResponseTable");
   scale = m_p.getParameter<double>("ResponseScale");
   edm::LogVerbatim("CaloSim") << "CaloMeanResponse initialized with scale " << scale << " and use Table " << useTable

--- a/SimG4CMS/Calo/src/HGCScintSD.cc
+++ b/SimG4CMS/Calo/src/HGCScintSD.cc
@@ -94,7 +94,7 @@ HGCScintSD::HGCScintSD(const std::string& name,
 
   if (!fileName_.empty()) {
     edm::FileInPath filetmp("SimG4CMS/Calo/data/" + fileName_);
-    std::string fileName = filetmp.fullPath();
+    const std::string& fileName = filetmp.fullPath();
     std::ifstream fInput(fileName.c_str());
     if (!fInput.good()) {
       edm::LogVerbatim("HGCSim") << "Cannot open file " << fileName;

--- a/SimG4CMS/Calo/src/HGCalNumberingScheme.cc
+++ b/SimG4CMS/Calo/src/HGCalNumberingScheme.cc
@@ -34,7 +34,7 @@ HGCalNumberingScheme::HGCalNumberingScheme(const HGCalDDDConstants& hgc,
   firstLayer_ = hgcons_.getLayerOffset();
   if (!fileName.empty()) {
     edm::FileInPath filetmp1("SimG4CMS/Calo/data/" + fileName);
-    std::string filetmp2 = filetmp1.fullPath();
+    const std::string& filetmp2 = filetmp1.fullPath();
     std::ifstream fInput(filetmp2.c_str());
     if (!fInput.good()) {
       edm::LogVerbatim("HGCalSim") << "Cannot open file " << filetmp2;

--- a/SimG4Core/CustomPhysics/src/CMSAntiSQ.cc
+++ b/SimG4Core/CustomPhysics/src/CMSAntiSQ.cc
@@ -11,16 +11,16 @@
 // ###                       ANTI-SEXAQUARK                           ###
 // ######################################################################
 
-CMSAntiSQ* CMSAntiSQ::theInstance = 0;
+CMSAntiSQ* CMSAntiSQ::theInstance = nullptr;
 
 CMSAntiSQ* CMSAntiSQ::Definition(double mass) {
-  if (theInstance != 0)
+  if (theInstance != nullptr)
     return theInstance;
   const G4String name = "anti_sexaq";
   // search in particle table]
   G4ParticleTable* pTable = G4ParticleTable::GetParticleTable();
   G4ParticleDefinition* anInstance = pTable->FindParticle(name);
-  if (anInstance == 0) {
+  if (anInstance == nullptr) {
     // create particle
     //
     //    Arguments for constructor are as follows

--- a/SimG4Core/CustomPhysics/src/CMSSQ.cc
+++ b/SimG4Core/CustomPhysics/src/CMSSQ.cc
@@ -11,16 +11,16 @@
 // ###                          SEXAQUARK                             ###
 // ######################################################################
 
-CMSSQ* CMSSQ::theInstance = 0;
+CMSSQ* CMSSQ::theInstance = nullptr;
 
 CMSSQ* CMSSQ::Definition(double mass) {
-  if (theInstance != 0)
+  if (theInstance != nullptr)
     return theInstance;
   const G4String name = "sexaq";
   // search in particle table]
   G4ParticleTable* pTable = G4ParticleTable::GetParticleTable();
   G4ParticleDefinition* anInstance = pTable->FindParticle(name);
-  if (anInstance == 0) {
+  if (anInstance == nullptr) {
     // create particle
     //
     //    Arguments for constructor are as follows

--- a/SimG4Core/CustomPhysics/src/CMSSQNeutronAnnih.cc
+++ b/SimG4Core/CustomPhysics/src/CMSSQNeutronAnnih.cc
@@ -1,12 +1,12 @@
 
+#include "G4NucleiProperties.hh"
+#include "G4ParticleDefinition.hh"
+#include "G4ParticleTable.hh"
 #include "G4PhysicalConstants.hh"
 #include "G4SystemOfUnits.hh"
-#include "G4ParticleTable.hh"
-#include "G4ParticleDefinition.hh"
 #include "Randomize.hh"
-#include "G4NucleiProperties.hh"
-#include <math.h>
 #include "TMath.h"
+#include <cmath>
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -125,7 +125,7 @@ G4HadFinalState* CMSSQNeutronAnnih::ApplyYourself(const G4HadProjectile& aTrack,
   //           << " PDGcode= " << projPDG << " on nucleus Z= " << Z
   //           << " A= " << A << " N= " << N;
 
-  G4LorentzVector lv1 = aParticle->Get4Momentum();
+  const G4LorentzVector& lv1 = aParticle->Get4Momentum();
   edm::LogVerbatim("CMSSWNeutronAnnih") << "The neutron Fermi momentum (mag, x, y, z) "
                                         << targetNucleus.GetFermiMomentum().mag() / MeV << " "
                                         << targetNucleus.GetFermiMomentum().x() / MeV << " "

--- a/SimG4Core/CustomPhysics/src/CustomParticleFactory.cc
+++ b/SimG4Core/CustomPhysics/src/CustomParticleFactory.cc
@@ -51,7 +51,7 @@ void CustomParticleFactory::loadCustomParticles(const std::string &filePath) {
   G4ParticleTable *theParticleTable = G4ParticleTable::GetParticleTable();
   while (getline(configFile, line)) {
     line.erase(0, line.find_first_not_of(" \t"));  // Remove leading whitespace.
-    if (line.length() == 0 || line.at(0) == '#') {
+    if (line.empty() || line.at(0) == '#') {
       continue;
     }  // Skip blank lines and comments.
     // The mass table begins with a line containing "BLOCK MASS"
@@ -255,7 +255,7 @@ void CustomParticleFactory::getMassTable(std::ifstream *configFile) {
   // This should be compatible IMO to SLHA
   while (getline(*configFile, line)) {
     line.erase(0, line.find_first_not_of(" \t"));  // remove leading whitespace
-    if (line.length() == 0 || line.at(0) == '#')
+    if (line.empty() || line.at(0) == '#')
       continue;  // skip blank lines and comments
     if (ToLower(line).find("block") < line.npos) {
       edm::LogInfo("SimG4CoreCustomPhysics") << "CustomParticleFactory: Finished the Mass Table ";
@@ -348,7 +348,7 @@ G4DecayTable *CustomParticleFactory::getDecayTable(std::ifstream *configFile, in
 
   while (getline(*configFile, line)) {
     line.erase(0, line.find_first_not_of(" \t"));  // remove leading whitespace
-    if (line.length() == 0)
+    if (line.empty())
       continue;  // skip blank lines
     if (line.at(0) == '#' && ToLower(line).find("br") < line.npos && ToLower(line).find("nda") < line.npos)
       continue;  // skip a comment of the form:  # BR  NDA  ID1  ID2

--- a/SimG4Core/CustomPhysics/src/G4ProcessHelper.cc
+++ b/SimG4Core/CustomPhysics/src/G4ProcessHelper.cc
@@ -27,7 +27,7 @@ G4ProcessHelper::G4ProcessHelper(const edm::ParameterSet& p, CustomParticleFacto
   G4String line;
 
   edm::FileInPath fp = p.getParameter<edm::FileInPath>("processesDef");
-  std::string processDefFilePath = fp.fullPath();
+  const std::string& processDefFilePath = fp.fullPath();
   std::ifstream process_stream(processDefFilePath.c_str());
 
   resonant = p.getParameter<bool>("resonant");

--- a/SimG4Core/Generators/src/Generator3.cc
+++ b/SimG4Core/Generators/src/Generator3.cc
@@ -132,7 +132,7 @@ void Generator3::HepMC2G4(const HepMC3::GenEvent *evt_orig, G4Event *g4evt) {
     delete vtx_;
   }
 
-  for (HepMC3::GenVertexPtr v : evt->vertices()) {
+  for (const HepMC3::GenVertexPtr &v : evt->vertices()) {
     vtx_ =
         new math::XYZTLorentzVector((v->position()).x(), (v->position()).y(), (v->position()).z(), (v->position()).t());
     break;
@@ -144,13 +144,13 @@ void Generator3::HepMC2G4(const HepMC3::GenEvent *evt_orig, G4Event *g4evt) {
   unsigned int ng4vtx = 0;
   unsigned int ng4par = 0;
 
-  for (HepMC3::GenVertexPtr vitr : evt->vertices()) {
+  for (const HepMC3::GenVertexPtr &vitr : evt->vertices()) {
     // loop for vertex, is it a real vertex?
     // Set qvtx to true for any particles that should be propagated by GEANT,
     // i.e., status 1 particles or status 2 particles that decay outside the
     // beampipe.
     G4bool qvtx = false;
-    for (HepMC3::GenParticlePtr pitr : vitr->particles_out()) {
+    for (const HepMC3::GenParticlePtr &pitr : vitr->particles_out()) {
       // For purposes of this function, the status is defined as follows:
       // 1:  particles are not decayed by generator
       // 2:  particles are decayed by generator but need to be propagated by GEANT
@@ -221,7 +221,7 @@ void Generator3::HepMC2G4(const HepMC3::GenEvent *evt_orig, G4Event *g4evt) {
 
     G4PrimaryVertex *g4vtx = new G4PrimaryVertex(x1, y1, z1, t1);
 
-    for (HepMC3::GenParticlePtr pitr : vitr->particles_out()) {
+    for (const HepMC3::GenParticlePtr &pitr : vitr->particles_out()) {
       int status = pitr->status();
       int pdg = pitr->pid();
       bool hasDecayVertex = (nullptr != pitr->end_vertex());
@@ -454,7 +454,7 @@ void Generator3::particleAssignDaughters(G4PrimaryParticle *g4p, HepMC3::GenPart
   double y1 = vp->end_vertex()->position().y();
   double z1 = vp->end_vertex()->position().z();
 
-  for (HepMC3::GenParticlePtr vpdec : vp->end_vertex()->particles_out()) {
+  for (const HepMC3::GenParticlePtr &vpdec : vp->end_vertex()->particles_out()) {
     // transform decay products such that in the rest frame of mother
     math::XYZTLorentzVector pdec(
         vpdec->momentum().px(), vpdec->momentum().py(), vpdec->momentum().pz(), vpdec->momentum().e());

--- a/SimMuon/Neutron/plugins/NeutronHitsCollector.cc
+++ b/SimMuon/Neutron/plugins/NeutronHitsCollector.cc
@@ -110,7 +110,7 @@ void NeutronHitsCollector::produce(edm::Event& iEvent, const edm::EventSetup& iS
   // ----- MuonCSCHits -----
   //
   std::unique_ptr<edm::PSimHitContainer> simCSC(new edm::PSimHitContainer);
-  if (neutron_label_csc.length() > 0) {
+  if (!neutron_label_csc.empty()) {
     const edm::Handle<edm::PSimHitContainer>& MuonCSCHits = iEvent.getHandle(tokenCSC_);
     for (hit = MuonCSCHits->begin(); hit != MuonCSCHits->end(); ++hit)
       simCSC->push_back(*hit);
@@ -120,7 +120,7 @@ void NeutronHitsCollector::produce(edm::Event& iEvent, const edm::EventSetup& iS
   // ----- MuonDTHits -----
   //
   std::unique_ptr<edm::PSimHitContainer> simDT(new edm::PSimHitContainer);
-  if (neutron_label_dt.length() > 0) {
+  if (!neutron_label_dt.empty()) {
     const edm::Handle<edm::PSimHitContainer>& MuonDTHits = iEvent.getHandle(tokenDT_);
     for (hit = MuonDTHits->begin(); hit != MuonDTHits->end(); ++hit)
       simDT->push_back(*hit);
@@ -130,7 +130,7 @@ void NeutronHitsCollector::produce(edm::Event& iEvent, const edm::EventSetup& iS
   // ----- MuonRPCHits -----
   //
   std::unique_ptr<edm::PSimHitContainer> simRPC(new edm::PSimHitContainer);
-  if (neutron_label_rpc.length() > 0) {
+  if (!neutron_label_rpc.empty()) {
     const edm::Handle<edm::PSimHitContainer>& MuonRPCHits = iEvent.getHandle(tokenRPC_);
     for (hit = MuonRPCHits->begin(); hit != MuonRPCHits->end(); ++hit)
       simRPC->push_back(*hit);

--- a/TauAnalysis/MCEmbeddingTools/plugins/CaloCleaner.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/CaloCleaner.cc
@@ -60,7 +60,7 @@ void CaloCleaner<T>::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) 
   }
 
   // Copy the old collection and correct if necessary
-  for (auto input_ : inputs_) {
+  for (const auto &input_ : inputs_) {
     std::unique_ptr<RecHitCollection> recHitCollection_output(new RecHitCollection());
     edm::Handle<RecHitCollection> recHitCollection;
     iEvent.getByToken(input_.second, recHitCollection);

--- a/TauAnalysis/MCEmbeddingTools/plugins/MuonDetCleaner.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/MuonDetCleaner.cc
@@ -186,7 +186,7 @@ void MuonDetCleaner<T1, T2>::produce(edm::Event &iEvent, edm::EventSetup const &
   vetoHits.erase(unique(vetoHits.begin(), vetoHits.end()), vetoHits.end());
 
   // Now this can also handle different instance
-  for (auto input_ : inputs_) {
+  for (const auto &input_ : inputs_) {
     // Second read in the RecHit Colltection which is to be replaced, without the vetoRecHits
     typedef edm::Handle<RecHitCollection> RecHitCollectionHandle;
     RecHitCollectionHandle RecHitinput;

--- a/TauAnalysis/MCEmbeddingTools/plugins/TrackerCleaner.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/TrackerCleaner.cc
@@ -36,7 +36,7 @@ void TrackerCleaner<T>::produce(edm::Event &iEvent, const edm::EventSetup &iSetu
   iEvent.getByToken(mu_input_, muonHandle);
   edm::View<pat::Muon> muons = *muonHandle;
 
-  for (auto input_ : inputs_) {
+  for (const auto &input_ : inputs_) {
     edm::Handle<TrackClusterCollection> inputClusters;
     iEvent.getByToken(input_.second, inputClusters);
 


### PR DESCRIPTION
PGO changes ( e.g. using relative source path instead of full path ) broke `scram build code-checks` rule. So it has not been running properly on PR. `code-format` was working but only `code-checks` i.e. `clang-tidy` did not work as it required correct `compiler_command.json` with correct source file paths.

Build rules are fixed now, so this PR applies `code-checks` ( and format) for those files which were merged with proper code-checks