### PR TITLE
[RECONSTRUCTION-UPGRADE] Apply code checks/format

### DIFF
--- a/RecoHGCal/TICL/plugins/TICLDumper.cc
+++ b/RecoHGCal/TICL/plugins/TICLDumper.cc
@@ -992,7 +992,7 @@ void TICLDumper::beginJob() {
     superclustering_tree_->Branch("recoSuperCluster_constituentTs", &recoSuperCluster_constituentTs);
   }
 
-  if (associations_parameterSets_.size() > 0) {
+  if (!associations_parameterSets_.empty()) {
     associations_tree_ = fs->make<TTree>("associations", "Associations");
     associations_tree_->Branch("event", &eventId_);
   }
@@ -1291,7 +1291,7 @@ void TICLDumper::analyze(const edm::Event& event, const edm::EventSetup& setup) 
     associations_dumperHelpers_[i].fillFromEvent(event.get(associations_recoToSim_token_[i]),
                                                  event.get(associations_simToReco_token_[i]));
   }
-  if (associations_dumperHelpers_.size() > 0)
+  if (!associations_dumperHelpers_.empty())
     associations_tree_->Fill();
 
   //Tracks

--- a/RecoHGCal/TICL/plugins/TICLGraph.cc
+++ b/RecoHGCal/TICL/plugins/TICLGraph.cc
@@ -58,14 +58,14 @@ std::vector<std::vector<unsigned int>> TICLGraph::findSubComponents(std::vector<
 
 inline void TICLGraph::findRootNodes() {
   for (auto const& n : nodes_) {
-    if (n.getInnerNeighbours().size() == 0) {
+    if (n.getInnerNeighbours().empty()) {
       rootNodes_.push_back(n);
     }
   }
 }
 
 bool TICLGraph::isGraphOk() {
-  for (auto n : nodes_) {
+  for (const auto& n : nodes_) {
     if (n.getInnerNeighbours().size() > 1) {
       return false;
     }

--- a/RecoHGCal/TICL/plugins/TracksterLinkingbySkeletons.cc
+++ b/RecoHGCal/TICL/plugins/TracksterLinkingbySkeletons.cc
@@ -145,7 +145,7 @@ std::array<ticl::Vector, 3> TracksterLinkingbySkeletons::findSkeletonNodes(
   // sort vertices by layerId
   std::array<ticl::Vector, 3> skeleton;
   if (trackster.vertices().size() < 3) {
-    auto v = layerClusters[trackster.vertices()[0]];
+    const auto &v = layerClusters[trackster.vertices()[0]];
     const Vector intersection(v.x(), v.y(), v.z());
     skeleton = {{intersection, intersection, intersection}};
     return skeleton;


### PR DESCRIPTION
PGO changes ( e.g. using relative source path instead of full path ) broke `scram build code-checks` rule. So it has not been running properly on PR. `code-format` was working but only `code-checks` i.e. `clang-tidy` did not work as it required correct `compiler_command.json` with correct source file paths.

Build rules are fixed now, so this PR applies `code-checks` ( and format) for those files which were merged with proper code-checks