### PR TITLE
[SIMULATION-UPGRADE] Apply code checks/format

### DIFF
--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/AllLayerClusterToTracksterAssociatorsProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/AllLayerClusterToTracksterAssociatorsProducer.cc
@@ -32,7 +32,7 @@ AllLayerClusterToTracksterAssociatorsProducer::AllLayerClusterToTracksterAssocia
   const auto& tracksterCollections = pset.getParameter<std::vector<edm::InputTag>>("tracksterCollections");
   for (const auto& tag : tracksterCollections) {
     std::string label = tag.label();
-    if (tag.instance() != "") {
+    if (!tag.instance().empty()) {
       label += tag.instance();
     }
     tracksterCollectionTokens_.emplace_back(label, consumes<std::vector<ticl::Trackster>>(tag));

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToCPAssociatorByEnergyScoreProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToCPAssociatorByEnergyScoreProducer.cc
@@ -1,5 +1,7 @@
 #include "LCToCPAssociatorByEnergyScoreProducer.h"
 
+#include <memory>
+
 template <typename HIT>
 LCToCPAssociatorByEnergyScoreProducer<HIT>::LCToCPAssociatorByEnergyScoreProducer(const edm::ParameterSet &ps)
     : hitMap_(consumes<std::unordered_map<DetId, const unsigned int>>(ps.getParameter<edm::InputTag>("hitMapTag"))),
@@ -13,7 +15,7 @@ LCToCPAssociatorByEnergyScoreProducer<HIT>::LCToCPAssociatorByEnergyScoreProduce
       hits_token_.push_back(consumes<std::vector<HIT>>(label));
   }
 
-  rhtools_.reset(new hgcal::RecHitTools());
+  rhtools_ = std::make_shared<hgcal::RecHitTools>();
 
   // Register the product
   produces<ticl::LayerClusterToCaloParticleAssociator>();

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorByEnergyScoreProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorByEnergyScoreProducer.cc
@@ -1,5 +1,7 @@
 #include "LCToSCAssociatorByEnergyScoreProducer.h"
 
+#include <memory>
+
 template <typename HIT>
 LCToSCAssociatorByEnergyScoreProducer<HIT>::LCToSCAssociatorByEnergyScoreProducer(const edm::ParameterSet &ps)
     : hitMap_(consumes<std::unordered_map<DetId, const unsigned int>>(ps.getParameter<edm::InputTag>("hitMapTag"))),
@@ -13,7 +15,7 @@ LCToSCAssociatorByEnergyScoreProducer<HIT>::LCToSCAssociatorByEnergyScoreProduce
       hits_token_.push_back(consumes<std::vector<HIT>>(label));
   }
 
-  rhtools_.reset(new hgcal::RecHitTools());
+  rhtools_ = std::make_shared<hgcal::RecHitTools>();
 
   // Register the product
   produces<ticl::LayerClusterToSimClusterAssociator>();

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorByEnergyScoreProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorByEnergyScoreProducer.cc
@@ -1,6 +1,8 @@
 // Original author: Leonardo Cristella
 
 // user include files
+#include <memory>
+
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/global/EDProducer.h"
 
@@ -29,7 +31,7 @@ private:
 
 LCToSimTSAssociatorByEnergyScoreProducer::LCToSimTSAssociatorByEnergyScoreProducer(const edm::ParameterSet &ps)
     : caloGeometry_(esConsumes<CaloGeometry, CaloGeometryRecord>()) {
-  rhtools_.reset(new hgcal::RecHitTools());
+  rhtools_ = std::make_shared<hgcal::RecHitTools>();
 
   // Register the product
   produces<ticl::LayerClusterToSimTracksterAssociator>();

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/MultiClusterAssociatorByEnergyScoreProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/MultiClusterAssociatorByEnergyScoreProducer.cc
@@ -1,6 +1,8 @@
 // Original author: Leonardo Cristella
 
 // user include files
+#include <memory>
+
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/global/EDProducer.h"
 
@@ -41,7 +43,7 @@ MultiClusterAssociatorByEnergyScoreProducer::MultiClusterAssociatorByEnergyScore
   for (auto &label : hits_label_) {
     hits_token_.push_back(consumes<HGCRecHitCollection>(label));
   }
-  rhtools_.reset(new hgcal::RecHitTools());
+  rhtools_ = std::make_shared<hgcal::RecHitTools>();
 
   // Register the product
   produces<hgcal::MultiClusterToCaloParticleAssociator>();

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSCAssociatorByEnergyScoreProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSCAssociatorByEnergyScoreProducer.cc
@@ -1,6 +1,8 @@
 // Original author: Leonardo Cristella
 
 // user include files
+#include <memory>
+
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/global/EDProducer.h"
 
@@ -38,7 +40,7 @@ TSToSCAssociatorByEnergyScoreProducer::TSToSCAssociatorByEnergyScoreProducer(con
       caloGeometry_(esConsumes<CaloGeometry, CaloGeometryRecord>()),
       hardScatterOnly_(ps.getParameter<bool>("hardScatterOnly")),
       hits_label_(ps.getParameter<std::vector<edm::InputTag>>("hits")) {
-  rhtools_.reset(new hgcal::RecHitTools());
+  rhtools_ = std::make_shared<hgcal::RecHitTools>();
 
   for (auto &label : hits_label_) {
     hits_token_.push_back(consumes<HGCRecHitCollection>(label));

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorByEnergyScoreProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorByEnergyScoreProducer.cc
@@ -1,6 +1,8 @@
 // Original author: Leonardo Cristella
 
 // user include files
+#include <memory>
+
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/global/EDProducer.h"
 
@@ -38,7 +40,7 @@ TSToSimTSAssociatorByEnergyScoreProducer::TSToSimTSAssociatorByEnergyScoreProduc
       caloGeometry_(esConsumes<CaloGeometry, CaloGeometryRecord>()),
       hardScatterOnly_(ps.getParameter<bool>("hardScatterOnly")),
       hits_label_(ps.getParameter<std::vector<edm::InputTag>>("hits")) {
-  rhtools_.reset(new hgcal::RecHitTools());
+  rhtools_ = std::make_shared<hgcal::RecHitTools>();
 
   for (auto &label : hits_label_) {
     hits_token_.push_back(consumes<HGCRecHitCollection>(label));

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSHitLCAssociatorByEnergyScoreProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSHitLCAssociatorByEnergyScoreProducer.cc
@@ -1,6 +1,8 @@
 // Original author: Leonardo Cristella
 
 // user include files
+#include <memory>
+
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/global/EDProducer.h"
 
@@ -38,7 +40,7 @@ TSToSimTSHitLCAssociatorByEnergyScoreProducer::TSToSimTSHitLCAssociatorByEnergyS
       caloGeometry_(esConsumes<CaloGeometry, CaloGeometryRecord>()),
       hardScatterOnly_(ps.getParameter<bool>("hardScatterOnly")),
       hits_label_(ps.getParameter<std::vector<edm::InputTag>>("hits")) {
-  rhtools_.reset(new hgcal::RecHitTools());
+  rhtools_ = std::make_shared<hgcal::RecHitTools>();
 
   for (auto &label : hits_label_) {
     hits_token_.push_back(consumes<HGCRecHitCollection>(label));


### PR DESCRIPTION
PGO changes ( e.g. using relative source path instead of full path ) broke `scram build code-checks` rule. So it has not been running properly on PR. `code-format` was working but only `code-checks` i.e. `clang-tidy` did not work as it required correct `compiler_command.json` with correct source file paths.

Build rules are fixed now, so this PR applies `code-checks` ( and format) for those files which were merged with proper code-checks