### PR TITLE
[HLT] Apply code checks/format

### DIFF
--- a/HLTrigger/Tools/bin/hltDiff.cc
+++ b/HLTrigger/Tools/bin/hltDiff.cc
@@ -697,7 +697,7 @@ public:
   // methods
   JsonOutputProducer(bool _writeJson, std::string _file_name)
       : writeJson(_writeJson), out_filename_base(std::move(_file_name)) {
-    useSingleOutFile = out_filename_base.length() > 0;
+    useSingleOutFile = !out_filename_base.empty();
   }
 
   JsonEvent& pushEvent(int _run, int _lumi, int _event) {


### PR DESCRIPTION
PGO changes ( e.g. using relative source path instead of full path ) broke `scram build code-checks` rule. So it has not been running properly on PR. `code-format` was working but only `code-checks` i.e. `clang-tidy` did not work as it required correct `compiler_command.json` with correct source file paths.

Build rules are fixed now, so this PR applies `code-checks` ( and format) for those files which were merged with proper code-checks