### PR TITLE
[DAQ-L1] Apply code checks/format

### DIFF
--- a/L1TriggerScouting/OnlineProcessing/plugins/FinalBxSelector.cc
+++ b/L1TriggerScouting/OnlineProcessing/plugins/FinalBxSelector.cc
@@ -22,7 +22,7 @@
 class FinalBxSelector : public edm::stream::EDFilter<> {
 public:
   explicit FinalBxSelector(const edm::ParameterSet&);
-  ~FinalBxSelector() {}
+  ~FinalBxSelector() override {}
   static void fillDescriptions(edm::ConfigurationDescriptions&);
 
 private:

--- a/L1TriggerScouting/OnlineProcessing/plugins/JetBxSelector.cc
+++ b/L1TriggerScouting/OnlineProcessing/plugins/JetBxSelector.cc
@@ -26,7 +26,7 @@ using namespace l1ScoutingRun3;
 class JetBxSelector : public edm::stream::EDProducer<> {
 public:
   explicit JetBxSelector(const edm::ParameterSet&);
-  ~JetBxSelector() {}
+  ~JetBxSelector() override {}
   static void fillDescriptions(edm::ConfigurationDescriptions&);
 
 private:

--- a/L1TriggerScouting/OnlineProcessing/plugins/MaskOrbitBx.cc
+++ b/L1TriggerScouting/OnlineProcessing/plugins/MaskOrbitBx.cc
@@ -27,7 +27,7 @@ template <typename T>
 class MaskOrbitBx : public edm::stream::EDProducer<> {
 public:
   explicit MaskOrbitBx(const edm::ParameterSet&);
-  ~MaskOrbitBx() {}
+  ~MaskOrbitBx() override {}
   static void fillDescriptions(edm::ConfigurationDescriptions&);
 
 private:

--- a/L1TriggerScouting/OnlineProcessing/plugins/MuBxSelector.cc
+++ b/L1TriggerScouting/OnlineProcessing/plugins/MuBxSelector.cc
@@ -26,7 +26,7 @@ using namespace l1ScoutingRun3;
 class MuBxSelector : public edm::stream::EDProducer<> {
 public:
   explicit MuBxSelector(const edm::ParameterSet&);
-  ~MuBxSelector() {}
+  ~MuBxSelector() override {}
   static void fillDescriptions(edm::ConfigurationDescriptions&);
 
 private:

--- a/L1TriggerScouting/OnlineProcessing/plugins/MuTagJetBxSelector.cc
+++ b/L1TriggerScouting/OnlineProcessing/plugins/MuTagJetBxSelector.cc
@@ -31,7 +31,7 @@ using namespace l1ScoutingRun3;
 class MuTagJetBxSelector : public edm::stream::EDProducer<> {
 public:
   explicit MuTagJetBxSelector(const edm::ParameterSet&);
-  ~MuTagJetBxSelector() {}
+  ~MuTagJetBxSelector() override {}
   static void fillDescriptions(edm::ConfigurationDescriptions&);
 
 private:


### PR DESCRIPTION
PGO changes ( e.g. using relative source path instead of full path ) broke `scram build code-checks` rule. So it has not been running properly on PR. `code-format` was working but only `code-checks` i.e. `clang-tidy` did not work as it required correct `compiler_command.json` with correct source file paths.

Build rules are fixed now, so this PR applies `code-checks` ( and format) for those files which were merged with proper code-checks