### PR TITLE
[VISUALIZATION] Apply code checks/format

### DIFF
--- a/Fireworks/Core/src/FWEveViewManager.cc
+++ b/Fireworks/Core/src/FWEveViewManager.cc
@@ -13,6 +13,7 @@
 // system include files
 
 #include <functional>
+#include <memory>
 
 // user include files
 #include "TEveManager.h"
@@ -278,25 +279,25 @@ FWViewBase* FWEveViewManager::buildView(TEveWindowSlot* iParent, const std::stri
   std::shared_ptr<FWEveView> view;
   switch (type) {
     case FWViewType::k3D:
-      view.reset(new FW3DView(iParent, type));
+      view = std::make_shared<FW3DView>(iParent, type);
       break;
     case FWViewType::kISpy:
-      view.reset(new FWISpyView(iParent, type));
+      view = std::make_shared<FWISpyView>(iParent, type);
       break;
     case FWViewType::kRhoPhi:
     case FWViewType::kRhoZ:
     case FWViewType::kRhoPhiPF:
-      view.reset(new FWRPZView(iParent, type));
+      view = std::make_shared<FWRPZView>(iParent, type);
       break;
     case FWViewType::kLego:
     case FWViewType::kLegoPFECAL:
-      view.reset(new FWEveLegoView(iParent, type));
+      view = std::make_shared<FWEveLegoView>(iParent, type);
       break;
     case FWViewType::kLegoHF:
-      view.reset(new FWHFView(iParent, type));
+      view = std::make_shared<FWHFView>(iParent, type);
       break;
     case FWViewType::kGlimpse:
-      view.reset(new FWGlimpseView(iParent, type));
+      view = std::make_shared<FWGlimpseView>(iParent, type);
       break;
     default:
       break;

--- a/Fireworks/Core/src/FWGeometryTableViewManager.cc
+++ b/Fireworks/Core/src/FWGeometryTableViewManager.cc
@@ -11,6 +11,7 @@
 //
 
 #include <functional>
+#include <memory>
 
 #include "TFile.h"
 #include "TSystem.h"
@@ -48,9 +49,9 @@ FWViewBase* FWGeometryTableViewManager::buildView(TEveWindowSlot* iParent, const
   FWViewType::EType typeId =
       (type == FWViewType::sName[FWViewType::kGeometryTable]) ? FWViewType::kGeometryTable : FWViewType::kOverlapTable;
   if (typeId == FWViewType::kGeometryTable)
-    view.reset(new FWGeometryTableView(iParent, &colorManager()));
+    view = std::make_shared<FWGeometryTableView>(iParent, &colorManager());
   else
-    view.reset(new FWOverlapTableView(iParent, &colorManager()));
+    view = std::make_shared<FWOverlapTableView>(iParent, &colorManager());
 
   view->setBackgroundColor();
   m_views.push_back(std::shared_ptr<FWGeometryTableViewBase>(view));

--- a/Fireworks/Core/src/FWTriggerTableViewManager.cc
+++ b/Fireworks/Core/src/FWTriggerTableViewManager.cc
@@ -12,8 +12,9 @@
 
 // system include files
 #include <cassert>
-#include <iostream>
 #include <functional>
+#include <iostream>
+#include <memory>
 
 // user include files
 
@@ -39,9 +40,9 @@ class FWViewBase* FWTriggerTableViewManager::buildView(TEveWindowSlot* iParent, 
   std::shared_ptr<FWTriggerTableView> view;
 
   if (type == FWViewType::sName[FWViewType::kTableHLT])
-    view.reset(new FWHLTTriggerTableView(iParent));
+    view = std::make_shared<FWHLTTriggerTableView>(iParent);
   else
-    view.reset(new FWL1TriggerTableView(iParent));
+    view = std::make_shared<FWL1TriggerTableView>(iParent);
 
   view->setProcessList(&(context().metadataManager()->processNamesInJob()));
 


### PR DESCRIPTION
PGO changes ( e.g. using relative source path instead of full path ) broke `scram build code-checks` rule. So it has not been running properly on PR. `code-format` was working but only `code-checks` i.e. `clang-tidy` did not work as it required correct `compiler_command.json` with correct source file paths.

Build rules are fixed now, so this PR applies `code-checks` ( and format) for those files which were merged with proper code-checks