### PR TITLE
[GENERATORS] Apply code checks/format

### DIFF
--- a/GeneratorInterface/CepGenInterface/src/CepGenEventGenerator.cc
+++ b/GeneratorInterface/CepGenInterface/src/CepGenEventGenerator.cc
@@ -20,6 +20,8 @@
 #include <CepGen/Process/Process.h>
 #include <CepGenAddOns/HepMC2Wrapper/HepMC2EventInterface.h>
 
+#include <memory>
+
 using namespace gen;
 
 CepGenEventGenerator::CepGenEventGenerator(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC)
@@ -85,7 +87,7 @@ bool CepGenEventGenerator::initializeForInternalPartons() {
 }
 
 bool CepGenEventGenerator::generatePartonsAndHadronize() {
-  event().reset(new HepMC::CepGenEvent(gen_->next()));
+  event() = std::make_unique<HepMC::CepGenEvent>(gen_->next());
   event()->set_cross_section(xsec_);
   event()->weights().push_back(1.);
   return true;

--- a/GeneratorInterface/Herwig7Interface/src/Herwig7Interface.cc
+++ b/GeneratorInterface/Herwig7Interface/src/Herwig7Interface.cc
@@ -99,7 +99,7 @@ void Herwig7Interface::initRepository(const edm::ParameterSet &pset) {
     else
       runModeTemp.erase(0, pos + 1);
 
-    HwUI_.reset(new Herwig::HerwigUIProvider(pset, dumpConfig_, Herwig::RunMode::READ));
+    HwUI_ = std::make_shared<Herwig::HerwigUIProvider>(pset, dumpConfig_, Herwig::RunMode::READ);
     edm::LogInfo("Herwig7Interface") << "HerwigUIProvider object with run mode " << HwUI_->runMode() << " created.\n";
 
     // Chose run mode

--- a/GeneratorInterface/LHEInterface/src/LH5Reader.cc
+++ b/GeneratorInterface/LHEInterface/src/LH5Reader.cc
@@ -233,7 +233,7 @@ namespace lhef {
         // Use temporary process info block to define const HEPRUP
         const HEPRUP heprup(tmprup);
 
-        curRunInfo.reset(new LHERunInfo(heprup));
+        curRunInfo = std::make_shared<LHERunInfo>(heprup);
         // Run info has now been set when a new file is encountered
       }
       // Handler should be modified to have these capabilities
@@ -277,7 +277,7 @@ namespace lhef {
       // Use temporary event to construct const HEPEUP;
       const HEPEUP hepeup(tmp);
 
-      lheevent.reset(new LHEEvent(curRunInfo, hepeup));
+      lheevent = std::make_shared<LHEEvent>(curRunInfo, hepeup);
       // Might have to add this capability later
       /*          const XMLHandler::wgt_info &info = handler->weightsinevent;
           for (size_t i = 0; i < info.size(); ++i) {

--- a/GeneratorInterface/LHEInterface/src/LHEReader.cc
+++ b/GeneratorInterface/LHEInterface/src/LHEReader.cc
@@ -489,7 +489,7 @@ namespace lhef {
           data.str(handler->buffer);
           handler->buffer.clear();
 
-          curRunInfo.reset(new LHERunInfo(data));
+          curRunInfo = std::make_shared<LHERunInfo>(data);
 
           std::for_each(handler->headers.begin(),
                         handler->headers.end(),
@@ -521,7 +521,7 @@ namespace lhef {
           handler->buffer.clear();
 
           std::shared_ptr<LHEEvent> lheevent;
-          lheevent.reset(new LHEEvent(curRunInfo, data));
+          lheevent = std::make_shared<LHEEvent>(curRunInfo, data);
           const XMLHandler::wgt_info &info = handler->weightsinevent;
           for (size_t i = 0; i < info.size(); ++i) {
             double num = -1.0;

--- a/GeneratorInterface/Pythia6Interface/src/PtYDistributor.cc
+++ b/GeneratorInterface/Pythia6Interface/src/PtYDistributor.cc
@@ -22,7 +22,7 @@ PtYDistributor::PtYDistributor(const edm::FileInPath& fip,
                                int ybins = 50)
     : ptmax_(ptmax), ptmin_(ptmin), ymax_(ymax), ymin_(ymin), ptbins_(ptbins), ybins_(ybins) {
   // edm::FileInPath f1(input);
-  std::string fDataFile = fip.fullPath();
+  const std::string& fDataFile = fip.fullPath();
 
   std::cout << " File from " << fDataFile << std::endl;
   TFile f(fDataFile.c_str(), "READ");

--- a/GeneratorInterface/Pythia6Interface/src/Pythia6Service.cc
+++ b/GeneratorInterface/Pythia6Interface/src/Pythia6Service.cc
@@ -175,7 +175,7 @@ void Pythia6Service::setCSAParams() {
     for (size_t i = 0; i < SETCSAPARBUFSIZE; ++i)
       buf[i] = ' ';
     // Skip empty parameters.
-    if (iter->length() <= 0)
+    if (iter->empty())
       continue;
     // Limit the size of the string to something which fits the buffer.
     size_t maxSize = iter->length() > (SETCSAPARBUFSIZE - 2) ? (SETCSAPARBUFSIZE - 2) : iter->length();
@@ -251,7 +251,7 @@ void Pythia6Service::setSLHAParams() {
     //std::cout << " start, end = " << start << " " << end << std::endl;
     std::string shortfile = iter->substr(start, end - start + 1);
     FileInPath f1(shortfile);
-    std::string file = f1.fullPath();
+    const std::string& file = f1.fullPath();
 
     /*
 	//

--- a/GeneratorInterface/Pythia8Interface/plugins/Pythia8HepMC3Hadronizer.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Pythia8HepMC3Hadronizer.cc
@@ -218,8 +218,8 @@ Pythia8HepMC3Hadronizer::Pythia8HepMC3Hadronizer(const edm::ParameterSet &params
   if (params.exists("reweightGen")) {
     edm::LogInfo("Pythia8Interface") << "Start setup for reweightGen";
     edm::ParameterSet rgParams = params.getParameter<edm::ParameterSet>("reweightGen");
-    fReweightUserHook.reset(
-        new PtHatReweightUserHook(rgParams.getParameter<double>("pTRef"), rgParams.getParameter<double>("power")));
+    fReweightUserHook = std::make_shared<PtHatReweightUserHook>(rgParams.getParameter<double>("pTRef"),
+                                                                rgParams.getParameter<double>("power"));
     edm::LogInfo("Pythia8Interface") << "End setup for reweightGen";
   }
   if (params.exists("reweightGenEmp")) {
@@ -229,29 +229,30 @@ Pythia8HepMC3Hadronizer::Pythia8HepMC3Hadronizer(const edm::ParameterSet &params
     std::string tuneName = "";
     if (rgeParams.exists("tune"))
       tuneName = rgeParams.getParameter<std::string>("tune");
-    fReweightEmpUserHook.reset(new PtHatEmpReweightUserHook(tuneName));
+    fReweightEmpUserHook = std::make_shared<PtHatEmpReweightUserHook>(tuneName);
     edm::LogInfo("Pythia8Interface") << "End setup for reweightGenEmp";
   }
   if (params.exists("reweightGenRap")) {
     edm::LogInfo("Pythia8Interface") << "Start setup for reweightGenRap";
     edm::ParameterSet rgrParams = params.getParameter<edm::ParameterSet>("reweightGenRap");
-    fReweightRapUserHook.reset(new RapReweightUserHook(rgrParams.getParameter<std::string>("yLabSigmaFunc"),
-                                                       rgrParams.getParameter<double>("yLabPower"),
-                                                       rgrParams.getParameter<std::string>("yCMSigmaFunc"),
-                                                       rgrParams.getParameter<double>("yCMPower"),
-                                                       rgrParams.getParameter<double>("pTHatMin"),
-                                                       rgrParams.getParameter<double>("pTHatMax")));
+    fReweightRapUserHook = std::make_shared<RapReweightUserHook>(rgrParams.getParameter<std::string>("yLabSigmaFunc"),
+                                                                 rgrParams.getParameter<double>("yLabPower"),
+                                                                 rgrParams.getParameter<std::string>("yCMSigmaFunc"),
+                                                                 rgrParams.getParameter<double>("yCMPower"),
+                                                                 rgrParams.getParameter<double>("pTHatMin"),
+                                                                 rgrParams.getParameter<double>("pTHatMax"));
     edm::LogInfo("Pythia8Interface") << "End setup for reweightGenRap";
   }
   if (params.exists("reweightGenPtHatRap")) {
     edm::LogInfo("Pythia8Interface") << "Start setup for reweightGenPtHatRap";
     edm::ParameterSet rgrParams = params.getParameter<edm::ParameterSet>("reweightGenPtHatRap");
-    fReweightPtHatRapUserHook.reset(new PtHatRapReweightUserHook(rgrParams.getParameter<std::string>("yLabSigmaFunc"),
-                                                                 rgrParams.getParameter<double>("yLabPower"),
-                                                                 rgrParams.getParameter<std::string>("yCMSigmaFunc"),
-                                                                 rgrParams.getParameter<double>("yCMPower"),
-                                                                 rgrParams.getParameter<double>("pTHatMin"),
-                                                                 rgrParams.getParameter<double>("pTHatMax")));
+    fReweightPtHatRapUserHook =
+        std::make_shared<PtHatRapReweightUserHook>(rgrParams.getParameter<std::string>("yLabSigmaFunc"),
+                                                   rgrParams.getParameter<double>("yLabPower"),
+                                                   rgrParams.getParameter<std::string>("yCMSigmaFunc"),
+                                                   rgrParams.getParameter<double>("yCMPower"),
+                                                   rgrParams.getParameter<double>("pTHatMin"),
+                                                   rgrParams.getParameter<double>("pTHatMax"));
     edm::LogInfo("Pythia8Interface") << "End setup for reweightGenPtHatRap";
   }
 
@@ -265,7 +266,7 @@ Pythia8HepMC3Hadronizer::Pythia8HepMC3Hadronizer(const edm::ParameterSet &params
     edm::ParameterSet jmParams = params.getUntrackedParameter<edm::ParameterSet>("jetMatching");
     std::string scheme = jmParams.getParameter<std::string>("scheme");
     if (scheme == "Madgraph" || scheme == "MadgraphFastJet") {
-      fJetMatchingHook.reset(new JetMatchingHook(jmParams, &fMasterGen->info));
+      fJetMatchingHook = std::make_shared<JetMatchingHook>(jmParams, &fMasterGen->info);
     }
   }
 
@@ -304,17 +305,17 @@ Pythia8HepMC3Hadronizer::Pythia8HepMC3Hadronizer(const edm::ParameterSet &params
     EV1_nFinalMode = 0;
     if (params.exists("EV1_nFinalMode"))
       EV1_nFinalMode = params.getParameter<int>("EV1_nFinalMode");
-    fEmissionVetoHook1.reset(new EmissionVetoHook1(EV1_nFinal,
-                                                   EV1_vetoOn,
-                                                   EV1_maxVetoCount,
-                                                   EV1_pThardMode,
-                                                   EV1_pTempMode,
-                                                   EV1_emittedMode,
-                                                   EV1_pTdefMode,
-                                                   EV1_MPIvetoOn,
-                                                   EV1_QEDvetoMode,
-                                                   EV1_nFinalMode,
-                                                   0));
+    fEmissionVetoHook1 = std::make_shared<EmissionVetoHook1>(EV1_nFinal,
+                                                             EV1_vetoOn,
+                                                             EV1_maxVetoCount,
+                                                             EV1_pThardMode,
+                                                             EV1_pTempMode,
+                                                             EV1_emittedMode,
+                                                             EV1_pTdefMode,
+                                                             EV1_MPIvetoOn,
+                                                             EV1_QEDvetoMode,
+                                                             EV1_nFinalMode,
+                                                             0);
   }
 
   if (params.exists("UserCustomization")) {
@@ -364,7 +365,7 @@ bool Pythia8HepMC3Hadronizer::initializeForInternalPartons() {
   }
 
   if (!fUserHooksVector.get())
-    fUserHooksVector.reset(new UserHooksVector);
+    fUserHooksVector = std::make_shared<UserHooksVector>();
   (fUserHooksVector->hooks).clear();
 
   if (fReweightUserHook.get())
@@ -389,7 +390,7 @@ bool Pythia8HepMC3Hadronizer::initializeForInternalPartons() {
              "are : jetMatching, emissionVeto1 \n";
 
     if (!fEmissionVetoHook.get())
-      fEmissionVetoHook.reset(new PowhegHooks());
+      fEmissionVetoHook = std::make_shared<PowhegHooks>();
 
     edm::LogInfo("Pythia8Interface") << "Turning on Emission Veto Hook from pythia8 code";
     (fUserHooksVector->hooks).push_back(fEmissionVetoHook);
@@ -399,7 +400,7 @@ bool Pythia8HepMC3Hadronizer::initializeForInternalPartons() {
   if (PowhegRes) {
     edm::LogInfo("Pythia8Interface") << "Turning on resonance scale setting from CMSSW Pythia8Interface";
     if (!fPowhegResHook.get())
-      fPowhegResHook.reset(new PowhegResHook());
+      fPowhegResHook = std::make_shared<PowhegResHook>();
     (fUserHooksVector->hooks).push_back(fPowhegResHook);
   }
 
@@ -407,7 +408,7 @@ bool Pythia8HepMC3Hadronizer::initializeForInternalPartons() {
   if (PowhegBB4L) {
     edm::LogInfo("Pythia8Interface") << "Turning on BB4l hook from CMSSW Pythia8Interface";
     if (!fPowhegHooksBB4L.get())
-      fPowhegHooksBB4L.reset(new PowhegHooksBB4L());
+      fPowhegHooksBB4L = std::make_shared<PowhegHooksBB4L>();
     (fUserHooksVector->hooks).push_back(fPowhegHooksBB4L);
   }
 
@@ -422,7 +423,7 @@ bool Pythia8HepMC3Hadronizer::initializeForInternalPartons() {
 
   if (internalMatching) {
     if (!fJetMatchingPy8InternalHook.get())
-      fJetMatchingPy8InternalHook.reset(new Pythia8::JetMatchingMadgraph);
+      fJetMatchingPy8InternalHook = std::make_shared<Pythia8::JetMatchingMadgraph>();
     (fUserHooksVector->hooks).push_back(fJetMatchingPy8InternalHook);
   }
 
@@ -436,7 +437,7 @@ bool Pythia8HepMC3Hadronizer::initializeForInternalPartons() {
                             ? 2
                             : 0);
     if (!fMergingHook.get())
-      fMergingHook.reset(new Pythia8::amcnlo_unitarised_interface(scheme));
+      fMergingHook = std::make_shared<Pythia8::amcnlo_unitarised_interface>(scheme);
     (fUserHooksVector->hooks).push_back(fMergingHook);
   }
 
@@ -444,7 +445,7 @@ bool Pythia8HepMC3Hadronizer::initializeForInternalPartons() {
   if (biasedTauDecayer) {
     if (!fBiasedTauDecayer.get()) {
       Pythia8::Info localInfo = fMasterGen->info;
-      fBiasedTauDecayer.reset(new BiasedTauDecayer(&localInfo, &(fMasterGen->settings)));
+      fBiasedTauDecayer = std::make_shared<BiasedTauDecayer>(&localInfo, &(fMasterGen->settings));
     }
     std::vector<int> handledParticles;
     handledParticles.push_back(15);
@@ -453,13 +454,13 @@ bool Pythia8HepMC3Hadronizer::initializeForInternalPartons() {
 
   bool resonanceDecayFilter = fMasterGen->settings.flag("ResonanceDecayFilter:filter");
   if (resonanceDecayFilter) {
-    fResonanceDecayFilterHook.reset(new ResonanceDecayFilterHook);
+    fResonanceDecayFilterHook = std::make_shared<ResonanceDecayFilterHook>();
     (fUserHooksVector->hooks).push_back(fResonanceDecayFilterHook);
   }
 
   bool PTFilter = fMasterGen->settings.flag("PTFilter:filter");
   if (PTFilter) {
-    fPTFilterHook.reset(new PTFilterHook);
+    fPTFilterHook = std::make_shared<PTFilterHook>();
     (fUserHooksVector->hooks).push_back(fPTFilterHook);
   }
 
@@ -501,7 +502,7 @@ bool Pythia8HepMC3Hadronizer::initializeForInternalPartons() {
   if (useEvtGen) {
     edm::LogInfo("Pythia8Hadronizer") << "Creating and initializing pythia8 EvtGen plugin";
     if (!evtgenDecays.get()) {
-      evtgenDecays.reset(new EvtGenDecays(fMasterGen.get(), evtgenDecFile, evtgenPdlFile));
+      evtgenDecays = std::make_shared<EvtGenDecays>(fMasterGen.get(), evtgenDecFile, evtgenPdlFile);
       for (unsigned int i = 0; i < evtgenUserFiles.size(); i++)
         evtgenDecays->readDecayFile(evtgenUserFiles.at(i));
     }
@@ -516,7 +517,7 @@ bool Pythia8HepMC3Hadronizer::initializeForExternalPartons() {
   bool status = false, status1 = false;
 
   if (!fUserHooksVector.get())
-    fUserHooksVector.reset(new UserHooksVector);
+    fUserHooksVector = std::make_shared<UserHooksVector>();
   (fUserHooksVector->hooks).clear();
 
   if (fReweightUserHook.get())
@@ -548,7 +549,7 @@ bool Pythia8HepMC3Hadronizer::initializeForExternalPartons() {
              "are : jetMatching, emissionVeto1 \n";
 
     if (!fEmissionVetoHook.get())
-      fEmissionVetoHook.reset(new PowhegHooks());
+      fEmissionVetoHook = std::make_shared<PowhegHooks>();
 
     edm::LogInfo("Pythia8Interface") << "Turning on Emission Veto Hook from pythia8 code";
     (fUserHooksVector->hooks).push_back(fEmissionVetoHook);
@@ -558,7 +559,7 @@ bool Pythia8HepMC3Hadronizer::initializeForExternalPartons() {
   if (PowhegRes) {
     edm::LogInfo("Pythia8Interface") << "Turning on resonance scale setting from CMSSW Pythia8Interface";
     if (!fPowhegResHook.get())
-      fPowhegResHook.reset(new PowhegResHook());
+      fPowhegResHook = std::make_shared<PowhegResHook>();
     (fUserHooksVector->hooks).push_back(fPowhegResHook);
   }
 
@@ -566,7 +567,7 @@ bool Pythia8HepMC3Hadronizer::initializeForExternalPartons() {
   if (PowhegBB4L) {
     edm::LogInfo("Pythia8Interface") << "Turning on BB4l hook from CMSSW Pythia8Interface";
     if (!fPowhegHooksBB4L.get())
-      fPowhegHooksBB4L.reset(new PowhegHooksBB4L());
+      fPowhegHooksBB4L = std::make_shared<PowhegHooksBB4L>();
     (fUserHooksVector->hooks).push_back(fPowhegHooksBB4L);
   }
 
@@ -581,7 +582,7 @@ bool Pythia8HepMC3Hadronizer::initializeForExternalPartons() {
 
   if (internalMatching) {
     if (!fJetMatchingPy8InternalHook.get())
-      fJetMatchingPy8InternalHook.reset(new Pythia8::JetMatchingMadgraph);
+      fJetMatchingPy8InternalHook = std::make_shared<Pythia8::JetMatchingMadgraph>();
     (fUserHooksVector->hooks).push_back(fJetMatchingPy8InternalHook);
   }
 
@@ -595,7 +596,7 @@ bool Pythia8HepMC3Hadronizer::initializeForExternalPartons() {
                             ? 2
                             : 0);
     if (!fMergingHook.get())
-      fMergingHook.reset(new Pythia8::amcnlo_unitarised_interface(scheme));
+      fMergingHook = std::make_shared<Pythia8::amcnlo_unitarised_interface>(scheme);
     (fUserHooksVector->hooks).push_back(fMergingHook);
   }
 
@@ -603,7 +604,7 @@ bool Pythia8HepMC3Hadronizer::initializeForExternalPartons() {
   if (biasedTauDecayer) {
     if (!fBiasedTauDecayer.get()) {
       Pythia8::Info localInfo = fMasterGen->info;
-      fBiasedTauDecayer.reset(new BiasedTauDecayer(&localInfo, &(fMasterGen->settings)));
+      fBiasedTauDecayer = std::make_shared<BiasedTauDecayer>(&localInfo, &(fMasterGen->settings));
     }
     std::vector<int> handledParticles;
     handledParticles.push_back(15);
@@ -612,13 +613,13 @@ bool Pythia8HepMC3Hadronizer::initializeForExternalPartons() {
 
   bool resonanceDecayFilter = fMasterGen->settings.flag("ResonanceDecayFilter:filter");
   if (resonanceDecayFilter) {
-    fResonanceDecayFilterHook.reset(new ResonanceDecayFilterHook);
+    fResonanceDecayFilterHook = std::make_shared<ResonanceDecayFilterHook>();
     (fUserHooksVector->hooks).push_back(fResonanceDecayFilterHook);
   }
 
   bool PTFilter = fMasterGen->settings.flag("PTFilter:filter");
   if (PTFilter) {
-    fPTFilterHook.reset(new PTFilterHook);
+    fPTFilterHook = std::make_shared<PTFilterHook>();
     (fUserHooksVector->hooks).push_back(fPTFilterHook);
   }
 
@@ -637,7 +638,7 @@ bool Pythia8HepMC3Hadronizer::initializeForExternalPartons() {
     status = fMasterGen->init();
 
   } else {
-    lhaUP.reset(new LHAupLesHouches());
+    lhaUP = std::make_shared<LHAupLesHouches>();
     lhaUP->setScalesFromLHEF(fMasterGen->settings.flag("Beams:setProductionScalesFromLHEF"));
     lhaUP->loadRunInfo(lheRunInfo());
 
@@ -672,7 +673,7 @@ bool Pythia8HepMC3Hadronizer::initializeForExternalPartons() {
   if (useEvtGen) {
     edm::LogInfo("Pythia8Hadronizer") << "Creating and initializing pythia8 EvtGen plugin";
     if (!evtgenDecays.get()) {
-      evtgenDecays.reset(new EvtGenDecays(fMasterGen.get(), evtgenDecFile, evtgenPdlFile));
+      evtgenDecays = std::make_shared<EvtGenDecays>(fMasterGen.get(), evtgenDecFile, evtgenPdlFile);
       for (unsigned int i = 0; i < evtgenUserFiles.size(); i++)
         evtgenDecays->readDecayFile(evtgenUserFiles.at(i));
     }

--- a/GeneratorInterface/Pythia8Interface/src/Py8GunBase.cc
+++ b/GeneratorInterface/Pythia8Interface/src/Py8GunBase.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "GeneratorInterface/Pythia8Interface/interface/Py8GunBase.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Concurrency/interface/SharedResourceNames.h"
@@ -45,7 +47,7 @@ namespace gen {
 
     if (useEvtGen) {
       edm::LogInfo("Pythia8Interface") << "Creating and initializing pythia8 EvtGen plugin";
-      evtgenDecays.reset(new EvtGenDecays(fMasterGen.get(), evtgenDecFile, evtgenPdlFile));
+      evtgenDecays = std::make_shared<EvtGenDecays>(fMasterGen.get(), evtgenDecFile, evtgenPdlFile);
       for (unsigned int i = 0; i < evtgenUserFiles.size(); i++)
         evtgenDecays->readDecayFile(evtgenUserFiles.at(i));
     }

--- a/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
+++ b/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
@@ -99,7 +99,7 @@ void GenParticles2HepMCConverter::produce(edm::Event& event, const edm::EventSet
 
   hepmc_event.weights() = genEventInfoHandle->weights();
   // add dummy weight if necessary
-  if (hepmc_event.weights().size() == 0) {
+  if (hepmc_event.weights().empty()) {
     hepmc_event.weights().push_back(1.);
   }
 

--- a/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
@@ -84,7 +84,7 @@ void HTXSRivetProducer::produce(edm::Event& iEvent, const edm::EventSetup&) {
         ConstGenVertexPtr HSvtx = myGenEvent->vertices()[0];
 
         if (HSvtx) {
-          for (auto ptcl : HepMCUtils::particles(HSvtx, Relatives::CHILDREN)) {
+          for (const auto& ptcl : HepMCUtils::particles(HSvtx, Relatives::CHILDREN)) {
             if (std::abs(ptcl->pdg_id()) == 24)
               ++nWs;
             if (ptcl->pdg_id() == 23)

--- a/GeneratorInterface/RivetInterface/src/HiggsTemplateCrossSections.cc
+++ b/GeneratorInterface/RivetInterface/src/HiggsTemplateCrossSections.cc
@@ -73,7 +73,7 @@ namespace Rivet {
 
     /// @brief Checks whether the input particle has a parent with a given PDGID
     bool hasParent(const ConstGenParticlePtr &ptcl, int pdgID) {
-      for (auto parent : HepMCUtils::particles(ptcl->production_vertex(), Relatives::PARENTS))
+      for (const auto &parent : HepMCUtils::particles(ptcl->production_vertex(), Relatives::PARENTS))
         if (parent->pdg_id() == pdgID)
           return true;
       return false;
@@ -191,7 +191,7 @@ namespace Rivet {
       FourVector uncatV_v4(0, 0, 0, 0);
       int nWs = 0, nZs = 0;
       if (isVH(prodMode)) {
-        for (auto ptcl : HepMCUtils::particles(HSvtx, Relatives::CHILDREN)) {
+        for (const auto &ptcl : HepMCUtils::particles(HSvtx, Relatives::CHILDREN)) {
           if (PID::isW(ptcl->pdg_id())) {
             ++nWs;
             cat.V = Particle(ptcl);
@@ -204,7 +204,7 @@ namespace Rivet {
         if (nWs + nZs > 0)
           cat.V = getLastInstance(cat.V);
         else {
-          for (auto ptcl : HepMCUtils::particles(HSvtx, Relatives::CHILDREN)) {
+          for (const auto &ptcl : HepMCUtils::particles(HSvtx, Relatives::CHILDREN)) {
             if (!PID::isHiggs(ptcl->pdg_id())) {
               uncatV_decays += Particle(ptcl);
               uncatV_p4 += Particle(ptcl).momentum();
@@ -236,7 +236,7 @@ namespace Rivet {
       Particles Ws;
       if (prodMode == HTXS::TTH || prodMode == HTXS::TH) {
         // loop over particles produced in hard-scatter vertex
-        for (auto ptcl : HepMCUtils::particles(HSvtx, Relatives::CHILDREN)) {
+        for (const auto &ptcl : HepMCUtils::particles(HSvtx, Relatives::CHILDREN)) {
           if (!PID::isTop(ptcl->pdg_id()))
             continue;
           Particle top = getLastInstance(Particle(ptcl));

--- a/IOMC/ParticleGuns/src/BeamMomentumGunProducer.cc
+++ b/IOMC/ParticleGuns/src/BeamMomentumGunProducer.cc
@@ -47,7 +47,7 @@ namespace edm {
           << "Beam vertex offset (cm) " << xoff_ << ":" << yoff_ << " and z position " << zpos_;
 
     edm::FileInPath fp = pgun_params.getParameter<edm::FileInPath>("FileName");
-    std::string infileName = fp.fullPath();
+    const std::string& infileName = fp.fullPath();
 
     fFile_ = new TFile(infileName.c_str());
     fFile_->GetObject("EventTree", fTree_);

--- a/IOMC/ParticleGuns/src/FileRandomKEThetaGunProducer.cc
+++ b/IOMC/ParticleGuns/src/FileRandomKEThetaGunProducer.cc
@@ -23,7 +23,7 @@ FileRandomKEThetaGunProducer::FileRandomKEThetaGunProducer(const edm::ParameterS
   edm::ParameterSet pgun_params = pset.getParameter<edm::ParameterSet>("PGunParameters");
 
   edm::FileInPath fp = pgun_params.getParameter<edm::FileInPath>("File");
-  std::string file = fp.fullPath();
+  const std::string& file = fp.fullPath();
   particleN = pgun_params.getParameter<int>("Particles");
   if (particleN <= 0)
     particleN = 1;

--- a/IOMC/ParticleGuns/src/FileRandomMultiParticlePGunProducer.cc
+++ b/IOMC/ParticleGuns/src/FileRandomMultiParticlePGunProducer.cc
@@ -24,7 +24,7 @@ FileRandomMultiParticlePGunProducer::FileRandomMultiParticlePGunProducer(const P
   fMinP_ = pgunParams.getParameter<double>("MinP");
   fMaxP_ = pgunParams.getParameter<double>("MaxP");
   edm::FileInPath fp = pgunParams.getParameter<edm::FileInPath>("FileName");
-  std::string file = fp.fullPath();
+  const std::string& file = fp.fullPath();
 
   produces<HepMCProduct>("unsmeared");
   produces<GenEventInfoProduct>();


### PR DESCRIPTION
PGO changes ( e.g. using relative source path instead of full path ) broke `scram build code-checks` rule. So it has not been running properly on PR. `code-format` was working but only `code-checks` i.e. `clang-tidy` did not work as it required correct `compiler_command.json` with correct source file paths.

Build rules are fixed now, so this PR applies `code-checks` ( and format) for those files which were merged with proper code-checks