### PR TITLE
[GEOMETRY-UPGRADE] Apply code checks/format

### DIFF
--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalPassive.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalPassive.cc
@@ -32,6 +32,7 @@ struct HGCalPassive {
     double moduleThick = args.value<double>("ModuleThick");                  // Thickness of the overall module
     int sectors = args.value<int>("Sectors");                                // number of phi sectors (cassettes)
     std::vector<std::string> tagsector;                                      // Tag of the sector (to be added to name)
+    tagsector.reserve(sectors);
     for (int k = 0; k < sectors; ++k)
       tagsector.emplace_back("F" + std::to_string(k));
     int position = args.value<int>("Position");  // 0 if -z; 1 if +z

--- a/Geometry/MTDNumberingBuilder/plugins/DDCmsMTDConstruction.cc
+++ b/Geometry/MTDNumberingBuilder/plugins/DDCmsMTDConstruction.cc
@@ -29,7 +29,7 @@ public:
   void veto(const std::string& veto) { veto_.emplace_back(veto); }
 
   bool accept(const DDExpandedView& ev) const final {
-    if (allowedNS_.size() == 0 && allowed_.size() == 0 && veto_.size() == 0) {
+    if (allowedNS_.empty() && allowed_.empty() && veto_.empty()) {
       return true;
     }
     bool out(false);
@@ -37,7 +37,7 @@ public:
     for (const auto& test : allowedNS_) {
       if (currentNSName.find(test) != std::string::npos) {
         out = true;
-        if (allowed_.size() > 0 || veto_.size() > 0) {
+        if (!allowed_.empty() || !veto_.empty()) {
           std::string_view currentName(ev.logicalPart().name().name());
           for (const auto& test : veto_) {
             if (currentName.find(test) != std::string::npos) {


### PR DESCRIPTION
PGO changes ( e.g. using relative source path instead of full path ) broke `scram build code-checks` rule. So it has not been running properly on PR. `code-format` was working but only `code-checks` i.e. `clang-tidy` did not work as it required correct `compiler_command.json` with correct source file paths.

Build rules are fixed now, so this PR applies `code-checks` ( and format) for those files which were merged with proper code-checks