### PR TITLE
[FASTSIM] Apply code checks/format

### DIFF
--- a/FastSimulation/ForwardDetectors/plugins/ProtonTaggerFilter.cc
+++ b/FastSimulation/ForwardDetectors/plugins/ProtonTaggerFilter.cc
@@ -119,7 +119,7 @@ void ProtonTaggerFilter::beginJob() {
   edm::LogVerbatim("FastSimProtonTaggerFilter") << "ProtonTaggerFilter: Getting ready ...";
 
   edm::FileInPath myDataFile("FastSimulation/ForwardDetectors/data/acceptance_420_220.root");
-  std::string fullPath = myDataFile.fullPath();
+  const std::string& fullPath = myDataFile.fullPath();
 
   edm::LogVerbatim("FastSimProtonTaggerFilter") << "Opening " << fullPath;
   TFile f(fullPath.c_str());


### PR DESCRIPTION
PGO changes ( e.g. using relative source path instead of full path ) broke `scram build code-checks` rule. So it has not been running properly on PR. `code-format` was working but only `code-checks` i.e. `clang-tidy` did not work as it required correct `compiler_command.json` with correct source file paths.

Build rules are fixed now, so this PR applies `code-checks` ( and format) for those files which were merged with proper code-checks