### PR TITLE
[DAQ] Apply code checks/format

### DIFF
--- a/EventFilter/Utilities/plugins/GlobalEvFOutputModule.cc
+++ b/EventFilter/Utilities/plugins/GlobalEvFOutputModule.cc
@@ -31,9 +31,10 @@
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-#include <sys/stat.h>
-#include <filesystem>
 #include <boost/algorithm/string.hpp>
+#include <filesystem>
+#include <memory>
+#include <sys/stat.h>
 
 typedef edm::detail::TriggerResultsBasedEventSelector::handle_t Trig;
 
@@ -310,7 +311,7 @@ namespace evf {
     mergeType_.setName("MergeType");
     hltErrorEvents_.setName("HLTErrorEvents");
 
-    jsonMonitor_.reset(new jsoncollector::FastMonitor(&outJsonDef, true));
+    jsonMonitor_ = std::make_shared<jsoncollector::FastMonitor>(&outJsonDef, true);
     jsonMonitor_->setDefPath(outJsonDefName);
     jsonMonitor_->registerGlobalMonitorable(&processed_, false);
     jsonMonitor_->registerGlobalMonitorable(&accepted_, false);

--- a/EventFilter/Utilities/src/DAQSource.cc
+++ b/EventFilter/Utilities/src/DAQSource.cc
@@ -1,8 +1,9 @@
+#include <algorithm>
+#include <chrono>
+#include <memory>
 #include <sstream>
 #include <unistd.h>
 #include <vector>
-#include <chrono>
-#include <algorithm>
 
 #include "EventFilter/Utilities/interface/DAQSource.h"
 #include "EventFilter/Utilities/interface/DAQSourceModels.h"
@@ -78,11 +79,11 @@ DAQSource::DAQSource(edm::ParameterSet const& pset, edm::InputSourceDescription 
 
   //load mode class based on parameter
   if (dataModeConfig_ == "FRD") {
-    dataMode_.reset(new DataModeFRD(this));
+    dataMode_ = std::make_shared<DataModeFRD>(this);
   } else if (dataModeConfig_ == "FRDStriped") {
-    dataMode_.reset(new DataModeFRDStriped(this));
+    dataMode_ = std::make_shared<DataModeFRDStriped>(this);
   } else if (dataModeConfig_ == "ScoutingRun3") {
-    dataMode_.reset(new DataModeScoutingRun3(this));
+    dataMode_ = std::make_shared<DataModeScoutingRun3>(this);
   } else
     throw cms::Exception("DAQSource::DAQSource") << "Unknown data mode " << dataModeConfig_;
 

--- a/IORawData/CSCCommissioning/src/CSCFileDumper.cc
+++ b/IORawData/CSCCommissioning/src/CSCFileDumper.cc
@@ -45,7 +45,7 @@ CSCFileDumper::CSCFileDumper(edm::ParameterSet const &pset) {
       }
    */
 
-  if (events.length()) {
+  if (!events.empty()) {
     for (size_t pos1 = 0, pos2 = events.find(',');; pos1 = pos2 + 1, pos2 = events.find(',', pos2 + 1)) {
       if (pos2 != std::string::npos) {
         long event = 0;


### PR DESCRIPTION
PGO changes ( e.g. using relative source path instead of full path ) broke `scram build code-checks` rule. So it has not been running properly on PR. `code-format` was working but only `code-checks` i.e. `clang-tidy` did not work as it required correct `compiler_command.json` with correct source file paths.

Build rules are fixed now, so this PR applies `code-checks` ( and format) for those files which were merged with proper code-checks