### PR TITLE
[GEOMETRY] Apply code checks/format

### DIFF
--- a/DetectorDescription/Core/src/DDValue.cc
+++ b/DetectorDescription/Core/src/DDValue.cc
@@ -5,6 +5,7 @@
 #include "DetectorDescription/Core/interface/DDComparator.h"
 
 #include <cassert>
+#include <memory>
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
@@ -49,7 +50,7 @@ DDValue::DDValue(const std::string& name, const std::vector<DDValuePair>& v) : i
   auto it = v.begin();
   std::vector<std::string> svec;
   std::vector<double> dvec;
-  vecPair_.reset(new vecpair_type(false, std::make_pair(svec, dvec)));
+  vecPair_ = std::make_shared<vecpair_type>(false, std::make_pair(svec, dvec));
   for (; it != v.end(); ++it) {
     vecPair_->second.first.emplace_back(it->first);
     vecPair_->second.second.emplace_back(it->second);
@@ -62,7 +63,7 @@ DDValue::DDValue(const std::string& name, double val) : id_(0) {
   std::vector<std::string> svec(1, "");
   std::vector<double> dvec(1, val);
 
-  vecPair_.reset(new vecpair_type(false, std::make_pair(svec, dvec)));
+  vecPair_ = std::make_shared<vecpair_type>(false, std::make_pair(svec, dvec));
   setEvalState(true);
 }
 
@@ -71,7 +72,7 @@ DDValue::DDValue(const std::string& name, const std::string& sval, double dval) 
 
   std::vector<std::string> svec(1, sval);
   std::vector<double> dvec(1, dval);
-  vecPair_.reset(new vecpair_type(false, std::make_pair(svec, dvec)));
+  vecPair_ = std::make_shared<vecpair_type>(false, std::make_pair(svec, dvec));
   setEvalState(true);
 }
 
@@ -80,7 +81,7 @@ DDValue::DDValue(const std::string& name, const std::string& sval) : id_(0) {
 
   std::vector<std::string> svec(1, sval);
   std::vector<double> dvec(1, 0);
-  vecPair_.reset(new vecpair_type(false, std::make_pair(svec, dvec)));
+  vecPair_ = std::make_shared<vecpair_type>(false, std::make_pair(svec, dvec));
   setEvalState(false);
 }
 

--- a/DetectorDescription/Parser/src/DDLParser.cc
+++ b/DetectorDescription/Parser/src/DDLParser.cc
@@ -80,7 +80,7 @@ bool DDLParser::isParsed(const std::string& filename) {
 bool DDLParser::parseOneFile(const std::string& fullname) {
   std::string filename = extractFileName(fullname);
   edm::FileInPath fp(fullname);
-  std::string absoluteFileName = fp.fullPath();
+  const std::string& absoluteFileName = fp.fullPath();
   size_t foundFile = isFound(filename);
   if (!foundFile) {
     pair<std::string, std::string> pss;

--- a/Geometry/ForwardGeometry/plugins/moduleDB.cc
+++ b/Geometry/ForwardGeometry/plugins/moduleDB.cc
@@ -41,7 +41,7 @@ CaloGeometryDBEP<ZdcGeometry, CaloGeometryDBReader>::produceAligned(const typena
   ZdcGeometry* zdcGeometry = new ZdcGeometry(&zdcTopology);
   PtrType ptr(zdcGeometry);
 
-  if (dins.size() > 0) {
+  if (!dins.empty()) {
     const unsigned int nTrParm(tvec.size() / zdcTopology.kSizeForDenseIndexing());
 
     assert(dvec.size() == ZdcGeometry::k_NumberOfShapes * ZdcGeometry::k_NumberOfParametersPerShape);


### PR DESCRIPTION
PGO changes ( e.g. using relative source path instead of full path ) broke `scram build code-checks` rule. So it has not been running properly on PR. `code-format` was working but only `code-checks` i.e. `clang-tidy` did not work as it required correct `compiler_command.json` with correct source file paths.

Build rules are fixed now, so this PR applies `code-checks` ( and format) for those files which were merged with proper code-checks