### PR TITLE
[L1] Apply code checks/format

### DIFF
--- a/DataFormats/L1GlobalTrigger/src/L1GtLogicParser.cc
+++ b/DataFormats/L1GlobalTrigger/src/L1GtLogicParser.cc
@@ -187,7 +187,7 @@ bool L1GtLogicParser::buildRpnVector(const std::string& logicalExpressionVal) {
     exprStringStream >> std::skipws >> std::ws >> tokenString;
 
     // skip the end
-    if (tokenString.find_first_not_of(whitespaces) == std::string::npos || tokenString.length() == 0) {
+    if (tokenString.find_first_not_of(whitespaces) == std::string::npos || tokenString.empty()) {
       //LogTrace("L1GtLogicParser")
       //<< "  Break for token string = " << tokenString
       //<< std::endl;

--- a/DataFormats/L1TGlobal/src/GlobalLogicParser.cc
+++ b/DataFormats/L1TGlobal/src/GlobalLogicParser.cc
@@ -187,7 +187,7 @@ bool GlobalLogicParser::buildRpnVector(const std::string& logicalExpressionVal) 
     exprStringStream >> std::skipws >> std::ws >> tokenString;
 
     // skip the end
-    if (tokenString.find_first_not_of(whitespaces) == std::string::npos || tokenString.length() == 0) {
+    if (tokenString.find_first_not_of(whitespaces) == std::string::npos || tokenString.empty()) {
       //LogTrace("L1TGlobal")
       //<< "  Break for token string = " << tokenString
       //<< std::endl;

--- a/EventFilter/CSCTFRawToDigi/plugins/CSCTFPacker.cc
+++ b/EventFilter/CSCTFRawToDigi/plugins/CSCTFPacker.cc
@@ -75,7 +75,7 @@ CSCTFPacker::CSCTFPacker(const edm::ParameterSet& conf) : edm::one::EDProducer<>
   swapME1strips = conf.getParameter<bool>("swapME1strips");
 
   file = nullptr;
-  if (outputFile.length() && (file = fopen(outputFile.c_str(), "wt")) == nullptr)
+  if (!outputFile.empty() && (file = fopen(outputFile.c_str(), "wt")) == nullptr)
     throw cms::Exception("OutputFile ") << "CSCTFPacker: cannot open output file (errno=" << errno
                                         << "). Try outputFile=\"\"";
 

--- a/EventFilter/CSCTFRawToDigi/plugins/CSCTFUnpacker.cc
+++ b/EventFilter/CSCTFRawToDigi/plugins/CSCTFUnpacker.cc
@@ -94,7 +94,7 @@ CSCTFUnpacker::CSCTFUnpacker(const edm::ParameterSet& pset) : edm::stream::EDPro
 
   // As we use standard CSC digi containers, we have to initialize mapping:
   std::string mappingFile = pset.getParameter<std::string>("mappingFile");
-  if (mappingFile.length()) {
+  if (!mappingFile.empty()) {
     LogDebug("CSCTFUnpacker|ctor") << "Define ``mapping'' only if you want to screw up real geometry";
     mapping = new CSCTriggerMappingFromFile(mappingFile);
   } else {

--- a/L1Trigger/GlobalCaloTrigger/plugins/L1GctEmulator.cc
+++ b/L1Trigger/GlobalCaloTrigger/plugins/L1GctEmulator.cc
@@ -80,7 +80,7 @@ L1GctEmulator::L1GctEmulator(const edm::ParameterSet& ps)
   for (unsigned ieta = 0; ieta < L1GctJetFinderParams::NUMBER_ETA_VALUES; ieta++) {
     nextLut->setEtaBin(ieta);
     m_jetEtCalibLuts.push_back(nextLut);
-    nextLut.reset(new L1GctJetEtCalibrationLut());
+    nextLut = std::make_shared<L1GctJetEtCalibrationLut>();
   }
 
   // Setup the tau algorithm parameters

--- a/L1Trigger/GlobalCaloTrigger/plugins/L1GctPrintLuts.cc
+++ b/L1Trigger/GlobalCaloTrigger/plugins/L1GctPrintLuts.cc
@@ -16,8 +16,9 @@
 #include "L1Trigger/GlobalCaloTrigger/interface/L1GctHfEtSumsLut.h"
 #include "L1Trigger/GlobalCaloTrigger/interface/L1GlobalCaloTrigger.h"
 
-#include <iostream>
 #include <fstream>
+#include <iostream>
+#include <memory>
 #include <sys/stat.h>
 
 L1GctPrintLuts::L1GctPrintLuts(const edm::ParameterSet& iConfig)
@@ -33,7 +34,7 @@ L1GctPrintLuts::L1GctPrintLuts(const edm::ParameterSet& iConfig)
   for (unsigned ieta = 0; ieta < L1GctJetFinderBase::COL_OFFSET; ieta++) {
     nextLut->setEtaBin(ieta);
     m_jetEtCalibLuts.push_back(nextLut);
-    nextLut.reset(new L1GctJetEtCalibrationLut());
+    nextLut = std::make_shared<L1GctJetEtCalibrationLut>();
   }
   m_jfParsToken = esConsumes<L1GctJetFinderParams, L1GctJetFinderParamsRcd>();
   m_etScaleToken = esConsumes<L1CaloEtScale, L1JetEtScaleRcd>();

--- a/L1Trigger/L1TCaloLayer1/plugins/L1TCaloSummary.cc
+++ b/L1Trigger/L1TCaloLayer1/plugins/L1TCaloSummary.cc
@@ -202,7 +202,7 @@ void L1TCaloSummary<INPUT, OUTPUT>::produce(edm::Event& iEvent, const edm::Event
     edm::LogError("L1TCaloSummary") << "UCT: Failed to get regions from region collection!";
   iEvent.getByToken(regionToken, regionCollection);
 
-  if (regionCollection->size() == 0) {
+  if (regionCollection->empty()) {
     iEvent.getByToken(backupRegionToken, regionCollection);
     edm::LogWarning("L1TCaloSummary") << "Switched to emulated regions since data regions was empty.\n";
   }
@@ -285,7 +285,7 @@ void L1TCaloSummary<INPUT, OUTPUT>::produce(edm::Event& iEvent, const edm::Event
   std::list<std::shared_ptr<UCTObject>> boostedJetObjs = summaryCard.getBoostedJetObjs();
   for (std::list<std::shared_ptr<UCTObject>>::const_iterator i = boostedJetObjs.begin(); i != boostedJetObjs.end();
        i++) {
-    const std::shared_ptr<UCTObject> object = *i;
+    const std::shared_ptr<UCTObject>& object = *i;
     pt = ((double)object->et()) * caloScaleFactor * boostedJetPtFactor;
     eta = g.getUCTTowerEta(object->iEta());
     phi = g.getUCTTowerPhi(object->iPhi());

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalPrescalesVetosESProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalPrescalesVetosESProducer.cc
@@ -103,16 +103,16 @@ L1TGlobalPrescalesVetosESProducer::L1TGlobalPrescalesVetosESProducer(const edm::
 
   // Full path
   edm::FileInPath f1_prescale("L1Trigger/L1TGlobal/data/Luminosity/" + menuDir + "/" + prescalesFileName);
-  std::string m_prescaleFile = f1_prescale.fullPath();
+  const std::string& m_prescaleFile = f1_prescale.fullPath();
 
   edm::FileInPath f1_mask_algobx("L1Trigger/L1TGlobal/data/Luminosity/" + menuDir + "/" + algobxmaskFileName);
-  std::string m_algobxmaskFile = f1_mask_algobx.fullPath();
+  const std::string& m_algobxmaskFile = f1_mask_algobx.fullPath();
 
   edm::FileInPath f1_mask_finor("L1Trigger/L1TGlobal/data/Luminosity/" + menuDir + "/" + finormaskFileName);
-  std::string m_finormaskFile = f1_mask_finor.fullPath();
+  const std::string& m_finormaskFile = f1_mask_finor.fullPath();
 
   edm::FileInPath f1_mask_veto("L1Trigger/L1TGlobal/data/Luminosity/" + menuDir + "/" + vetomaskFileName);
-  std::string m_vetomaskFile = f1_mask_veto.fullPath();
+  const std::string& m_vetomaskFile = f1_mask_veto.fullPath();
 
   // XML payloads
   std::string xmlPayload_prescale;

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalPrescalesVetosFractESProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalPrescalesVetosFractESProducer.cc
@@ -103,16 +103,16 @@ L1TGlobalPrescalesVetosFractESProducer::L1TGlobalPrescalesVetosFractESProducer(c
 
   // Full path
   edm::FileInPath f1_prescale("L1Trigger/L1TGlobal/data/Luminosity/" + menuDir + "/" + prescalesFileName);
-  std::string m_prescaleFile = f1_prescale.fullPath();
+  const std::string& m_prescaleFile = f1_prescale.fullPath();
 
   edm::FileInPath f1_mask_algobx("L1Trigger/L1TGlobal/data/Luminosity/" + menuDir + "/" + algobxmaskFileName);
-  std::string m_algobxmaskFile = f1_mask_algobx.fullPath();
+  const std::string& m_algobxmaskFile = f1_mask_algobx.fullPath();
 
   edm::FileInPath f1_mask_finor("L1Trigger/L1TGlobal/data/Luminosity/" + menuDir + "/" + finormaskFileName);
-  std::string m_finormaskFile = f1_mask_finor.fullPath();
+  const std::string& m_finormaskFile = f1_mask_finor.fullPath();
 
   edm::FileInPath f1_mask_veto("L1Trigger/L1TGlobal/data/Luminosity/" + menuDir + "/" + vetomaskFileName);
-  std::string m_vetomaskFile = f1_mask_veto.fullPath();
+  const std::string& m_vetomaskFile = f1_mask_veto.fullPath();
 
   // XML payloads
   std::string xmlPayload_prescale;

--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
@@ -2849,7 +2849,7 @@ bool l1t::TriggerMenuParser::parseAXOL1TL(L1TUtmCondition condAXOL1TL, unsigned 
   }
 
   // check model version is not empty
-  if (model == "") {
+  if (model.empty()) {
     edm::LogError("TriggerMenuParser") << "    Error: AXOL1TL movel version is empty" << std::endl;
     return false;
   }

--- a/L1Trigger/L1TMuonBarrel/src/L1MuBMTEtaPatternLut.cc
+++ b/L1Trigger/L1TMuonBarrel/src/L1MuBMTEtaPatternLut.cc
@@ -79,7 +79,7 @@ int L1MuBMTEtaPatternLut::load() {
 
   // assemble file name
   edm::FileInPath lut_f = edm::FileInPath(string(defaultPath + eau_dir + "ETFPatternList.lut"));
-  string etf_file = lut_f.fullPath();
+  const string& etf_file = lut_f.fullPath();
 
   // open file
   L1TriggerLutFile file(etf_file);

--- a/L1Trigger/L1TMuonBarrel/src/L1MuBMTQualPatternLut.cc
+++ b/L1Trigger/L1TMuonBarrel/src/L1MuBMTQualPatternLut.cc
@@ -86,7 +86,7 @@ int L1MuBMTQualPatternLut::load() {
 
     // assemble file name
     edm::FileInPath lut_f = edm::FileInPath(string(defaultPath + eau_dir + emu_str + ".lut"));
-    string emu_file = lut_f.fullPath();
+    const string& emu_file = lut_f.fullPath();
 
     // open file
     L1TriggerLutFile file(emu_file);

--- a/L1Trigger/L1TMuonBarrel/src/L1TMuonBarrelParamsHelper.cc
+++ b/L1Trigger/L1TMuonBarrel/src/L1TMuonBarrelParamsHelper.cc
@@ -399,7 +399,7 @@ int L1TMuonBarrelParamsHelper::load_pt(std::vector<LUT>& pta_lut,
     // assemble file name
     const string& lutpath = AssLUTpath;
     edm::FileInPath lut_f = edm::FileInPath(string(lutpath + pta_str + ".lut"));
-    string pta_file = lut_f.fullPath();
+    const string& pta_file = lut_f.fullPath();
 
     // open file
     L1TriggerLutFile file(pta_file);
@@ -476,7 +476,7 @@ int L1TMuonBarrelParamsHelper::load_phi(std::vector<LUT>& phi_lut,
 
     // assemble file name
     edm::FileInPath lut_f = edm::FileInPath(string(AssLUTpath + phi_str + ".lut"));
-    string phi_file = lut_f.fullPath();
+    const string& phi_file = lut_f.fullPath();
 
     // open file
     L1TriggerLutFile file(phi_file);
@@ -599,7 +599,7 @@ int L1TMuonBarrelParamsHelper::load_ext(std::vector<L1TMuonBarrelParams::LUTPara
 
     // assemble file name
     edm::FileInPath lut_f = edm::FileInPath(string(defaultPath + ext_dir + ext_str + ".lut"));
-    string ext_file = lut_f.fullPath();
+    const string& ext_file = lut_f.fullPath();
 
     // open file
     L1TriggerLutFile file(ext_file);

--- a/L1Trigger/L1TMuonOverlapPhase1/src/Omtf/OMTFReconstruction.cc
+++ b/L1Trigger/L1TMuonOverlapPhase1/src/Omtf/OMTFReconstruction.cc
@@ -122,7 +122,7 @@ void OMTFReconstruction::beginRun(edm::Run const& run,
     XMLConfigReader xmlConfigReader;
     xmlConfigReader.setConfigFile(fName);
 
-    omtfParams.reset(new L1TMuonOverlapParams());
+    omtfParams = std::make_unique<L1TMuonOverlapParams>();
     xmlConfigReader.readConfig(omtfParams.get());
 
     //getPatternsVersion() parses the entire patterns xml - si it is very inefficient

--- a/L1Trigger/L1TMuonOverlapPhase1/src/Tools/EmulationObserverBase.cc
+++ b/L1Trigger/L1TMuonOverlapPhase1/src/Tools/EmulationObserverBase.cc
@@ -5,6 +5,8 @@
  *      Author: kbunkow
  */
 
+#include <memory>
+
 #include "L1Trigger/L1TMuonOverlapPhase1/interface/Tools/EmulationObserverBase.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -65,7 +67,7 @@ void EmulationObserverBase::observeProcesorEmulation(unsigned int iProcessor,
 }
 
 void EmulationObserverBase::observeEventBegin(const edm::Event& iEvent) {
-  omtfCand.reset(new AlgoMuon());
+  omtfCand = std::make_shared<AlgoMuon>();
   candProcIndx = 0xffff;
 
   simMuon = findSimMuon(iEvent);

--- a/L1TriggerConfig/CSCTFConfigProducers/src/CSCTFConfigProducer.cc
+++ b/L1TriggerConfig/CSCTFConfigProducers/src/CSCTFConfigProducer.cc
@@ -58,7 +58,7 @@ std::unique_ptr<L1MuCSCPtLut> CSCTFConfigProducer::produceL1MuCSCPtLutRcd(const 
 
   std::unique_ptr<L1MuCSCPtLut> pt_lut = std::make_unique<L1MuCSCPtLut>();
 
-  if (ptLUT_path.length()) {
+  if (!ptLUT_path.empty()) {
     readLUT(ptLUT_path, (unsigned short*)pt_lut->pt_lut, 1 << 21);  //CSCBitWidths::kPtAddressWidth
   } else {
     throw cms::Exception("Undefined pT LUT")

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtVhdlTemplateFile.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtVhdlTemplateFile.cc
@@ -120,7 +120,7 @@ bool L1GtVhdlTemplateFile::open(const std::string &fileName, bool internal) {
     //remove empty lines
     iter = lines_.begin();
     while (iter != lines_.end()) {
-      if ((*iter).empty() || (*iter).length() == 0 || (*iter) == "    ")
+      if ((*iter).empty() || (*iter).empty() || (*iter) == "    ")
         lines_.erase(iter);
       else
         iter++;
@@ -293,7 +293,7 @@ bool L1GtVhdlTemplateFile::removeEmptyLines() {
   std::vector<std::string>::iterator iter = lines_.begin();
 
   while (iter != lines_.end()) {
-    if ((*iter).empty() || (*iter).length() == 0 || (*iter) == "    ")
+    if ((*iter).empty() || (*iter).empty() || (*iter) == "    ")
       lines_.erase(iter);
     else
       iter++;

--- a/L1TriggerConfig/L1TConfigProducers/src/OnlineDBqueryHelper.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/OnlineDBqueryHelper.cc
@@ -4,7 +4,7 @@ std::map<std::string, std::string> l1t::OnlineDBqueryHelper::fetch(const std::ve
                                                                    const std::string &table,
                                                                    const std::string &key,
                                                                    l1t::OMDSReader &m_omdsReader) {
-  if (queryColumns.empty() || table.length() == 0)
+  if (queryColumns.empty() || table.empty())
     return std::map<std::string, std::string>();
 
   l1t::OMDSReader::QueryResults queryResult =

--- a/L1TriggerConfig/RPCTriggerConfig/src/RPCTriggerConfig.cc
+++ b/L1TriggerConfig/RPCTriggerConfig/src/RPCTriggerConfig.cc
@@ -74,7 +74,7 @@ RPCTriggerConfig::RPCTriggerConfig(const edm::ParameterSet& iConfig) {
   std::string dataDir = iConfig.getUntrackedParameter<std::string>("filedir");
 
   edm::FileInPath fp(dataDir + "pacPat_t0sc0sg0.xml");
-  std::string patternsDirNameUnstriped = fp.fullPath();
+  const std::string& patternsDirNameUnstriped = fp.fullPath();
   m_patternsDir = patternsDirNameUnstriped.substr(0, patternsDirNameUnstriped.find_last_of('/') + 1);
 }
 


### PR DESCRIPTION
PGO changes ( e.g. using relative source path instead of full path ) broke `scram build code-checks` rule. So it has not been running properly on PR. `code-format` was working but only `code-checks` i.e. `clang-tidy` did not work as it required correct `compiler_command.json` with correct source file paths.

Build rules are fixed now, so this PR applies `code-checks` ( and format) for those files which were merged with proper code-checks