### PR TITLE
[RECONSTRUCTION-XPOG] Apply code checks/format

### DIFF
--- a/DataFormats/PatCandidates/src/TriggerObjectStandAlone.cc
+++ b/DataFormats/PatCandidates/src/TriggerObjectStandAlone.cc
@@ -99,7 +99,7 @@ bool TriggerObjectStandAlone::hasAnyName(const std::string &name, const std::vec
       // Empty parts due to
       // - wild-card at beginning/end or
       // - multiple wild-cards (should be supressed by 'boost::token_compress_on')
-      if (iName->length() == 0)
+      if (iName->empty())
         continue;
       // Search from current index and
       // set index to found occurence
@@ -115,7 +115,7 @@ bool TriggerObjectStandAlone::hasAnyName(const std::string &name, const std::vec
       index += iName->length();
     }
     // Failed, if end of name not reached
-    if (index < iVec->length() && namePartsVec.back().length() != 0)
+    if (index < iVec->length() && !namePartsVec.back().empty())
       failed = true;
     // Match found!
     if (!failed)

--- a/PhysicsTools/PatAlgos/plugins/DeDxEstimatorRekeyer.cc
+++ b/PhysicsTools/PatAlgos/plugins/DeDxEstimatorRekeyer.cc
@@ -113,7 +113,7 @@ void DeDxEstimatorRekeyer::produce(edm::StreamID, edm::Event& iEvent, const edm:
   auto dedxHitInfoAssociation = std::make_unique<reco::DeDxHitInfoAss>(dedxHitInfoHandle);
   reco::DeDxHitInfoAss::Filler filler(*dedxHitInfoAssociation);
   auto resultdedxHitColl = std::make_unique<reco::DeDxHitInfoCollection>();
-  resultdedxHitColl->reserve(pcTrkMap.size() > 0 ? pcTrkMap.size() * pcTrkMap[0].second.size() : 0);
+  resultdedxHitColl->reserve(!pcTrkMap.empty() ? pcTrkMap.size() * pcTrkMap[0].second.size() : 0);
   std::vector<std::vector<float>> momenta;
   momenta.reserve(resultdedxHitColl->capacity());
   // Loop over packed candidates


### PR DESCRIPTION
PGO changes ( e.g. using relative source path instead of full path ) broke `scram build code-checks` rule. So it has not been running properly on PR. `code-format` was working but only `code-checks` i.e. `clang-tidy` did not work as it required correct `compiler_command.json` with correct source file paths.

Build rules are fixed now, so this PR applies `code-checks` ( and format) for those files which were merged with proper code-checks