### PR TITLE
[CORE] Apply code checks/format

### DIFF
--- a/DataFormats/Provenance/src/ProductProvenance.cc
+++ b/DataFormats/Provenance/src/ProductProvenance.cc
@@ -16,8 +16,7 @@ namespace edm {
 
   ProductProvenance::ProductProvenance(BranchID bid) : branchID_(bid), parentageID_() {}
 
-  ProductProvenance::ProductProvenance(BranchID bid, ParentageID edid)
-      : branchID_(bid), parentageID_(std::move(edid)) {}
+  ProductProvenance::ProductProvenance(BranchID bid, ParentageID edid) : branchID_(bid), parentageID_(edid) {}
 
   ProductProvenance::ProductProvenance(BranchID bid, std::vector<BranchID> const& parents)
       : branchID_(bid), parentageID_() {

--- a/FWCore/Framework/bin/cmsRun.cpp
+++ b/FWCore/Framework/bin/cmsRun.cpp
@@ -177,7 +177,7 @@ int main(int argc, const char* argv[]) {
       //NOTE: JobReport must have a lifetime shorter than jobReportStreamPtr so that when the JobReport destructor
       // is called jobReportStreamPtr is still valid
       auto jobRepPtr = std::make_unique<edm::JobReport>(jobReportStreamPtr.get());
-      jobRep.reset(new edm::serviceregistry::ServiceWrapper<edm::JobReport>(std::move(jobRepPtr)));
+      jobRep = std::make_shared<edm::serviceregistry::ServiceWrapper<edm::JobReport>>(std::move(jobRepPtr));
       edm::ServiceToken jobReportToken = edm::ServiceRegistry::createContaining(jobRep);
 
       if (!fileName.empty()) {

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -201,8 +201,7 @@ namespace edm {
     }
     auto phb = getProductResolverByIndex(index);
 
-    productProvenanceRetrieverPtr()->insertIntoSet(
-        ProductProvenance(phb->branchDescription().branchID(), std::move(parentage)));
+    productProvenanceRetrieverPtr()->insertIntoSet(ProductProvenance(phb->branchDescription().branchID(), parentage));
 
     assert(phb);
     // ProductResolver assumes ownership
@@ -214,7 +213,7 @@ namespace edm {
                                  std::optional<ProductProvenance> productProvenance) const {
     assert(!bd.produced());
     if (productProvenance) {
-      productProvenanceRetrieverPtr()->insertIntoSet(std::move(*productProvenance));
+      productProvenanceRetrieverPtr()->insertIntoSet(*productProvenance);
     }
     auto phb = getExistingProduct(bd.branchID());
     assert(phb);

--- a/FWCore/MessageService/src/ELoutput.cc
+++ b/FWCore/MessageService/src/ELoutput.cc
@@ -83,10 +83,11 @@
 // #define ELoutputTRACE_LOG
 // #define ELoutput_EMIT_TRACE
 
-#include <iostream>
-#include <fstream>
-#include <cstring>
 #include <cassert>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <memory>
 
 namespace {
   // ----------------------------------------------------------------------
@@ -375,14 +376,14 @@ namespace edm {
             needAspace = false;
           }
         }
-        if (wantModule && (xid.module.length() > 0)) {
+        if (wantModule && (!xid.module.empty())) {
           if (needAspace) {
             emitToken(" ");
             needAspace = false;
           }
           emitToken(xid.module + " ");
         }
-        if (wantSubroutine && (xid.subroutine.length() > 0)) {
+        if (wantSubroutine && (!xid.subroutine.empty())) {
           if (needAspace) {
             emitToken(" ");
             needAspace = false;
@@ -516,7 +517,7 @@ namespace edm {
       std::cerr << "[][][] in emit:  lineLength is " << lineLength << '\n';
 #endif
 
-      if (s.length() == 0) {
+      if (s.empty()) {
         if (nl) {
           (*os) << newline << std::flush;
           charsOnLine = 0;
@@ -632,7 +633,7 @@ namespace edm {
     }
 
     void ELoutput::changeFile(const std::string& filename) {
-      os.reset(new std::ofstream(filename.c_str(), std::ios /*_base*/ ::app), close_and_delete());
+      os.reset(new std::ofstream(filename.c_str(), std::ios /*_base*/ ::app), close_and_delete());  //NOLINT
       emitToken("\n=======================================================", true);
       emitToken("\nError Log changed to this file\n");
       std::string const& ftime = formatTime(time(nullptr));  // Change log 7

--- a/FWCore/Modules/src/BranchIDListsModifierProducer.cc
+++ b/FWCore/Modules/src/BranchIDListsModifierProducer.cc
@@ -14,7 +14,7 @@ class BranchIDListsModifierProducer : public edm::global::EDProducer<> {
 public:
   BranchIDListsModifierProducer(edm::ParameterSet const& iPSet);
 
-  void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const;
+  void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& iDesc);
 

--- a/FWCore/Modules/src/EmptySourceFromEventIDs.cc
+++ b/FWCore/Modules/src/EmptySourceFromEventIDs.cc
@@ -42,7 +42,7 @@ bool EmptySourceFromEventIDs::setRunAndEventInfo(edm::EventID& event,
     return false;
   }
 
-  event = std::move(events_.back());
+  event = events_.back();
   events_.pop_back();
   return true;
 }

--- a/FWCore/Services/plugins/SimpleMemoryCheck.cc
+++ b/FWCore/Services/plugins/SimpleMemoryCheck.cc
@@ -411,19 +411,19 @@ namespace edm {
         // query values
         size_t allocated, active, resident, mapped, metadata;
         size_t len = sizeof(size_t);
-        if (je_mallctl("stats.allocated", &allocated, &len, 0, 0) != 0) {
+        if (je_mallctl("stats.allocated", &allocated, &len, nullptr, 0) != 0) {
           return info;
         }
-        if (je_mallctl("stats.active", &active, &len, 0, 0) != 0) {
+        if (je_mallctl("stats.active", &active, &len, nullptr, 0) != 0) {
           return info;
         }
-        if (je_mallctl("stats.resident", &resident, &len, 0, 0) != 0) {
+        if (je_mallctl("stats.resident", &resident, &len, nullptr, 0) != 0) {
           return info;
         }
-        if (je_mallctl("stats.mapped", &mapped, &len, 0, 0) != 0) {
+        if (je_mallctl("stats.mapped", &mapped, &len, nullptr, 0) != 0) {
           return info;
         }
-        if (je_mallctl("stats.metadata", &metadata, &len, 0, 0) != 0) {
+        if (je_mallctl("stats.metadata", &metadata, &len, nullptr, 0) != 0) {
           return info;
         }
         info.allocated = allocated / 1024.0 / 1024.0;

--- a/IOPool/Streamer/src/StreamerInputSource.cc
+++ b/IOPool/Streamer/src/StreamerInputSource.cc
@@ -334,13 +334,12 @@ namespace edm::streamer {
         std::optional<ProductProvenance> productProvenance{std::in_place, spitem.branchID(), *spitem.parents()};
         if (spitem.prod() != nullptr) {
           FDEBUG(10) << "addproduct next " << spitem.branchID() << std::endl;
-          eventPrincipal.putOnRead(branchDesc,
-                                   std::unique_ptr<WrapperBase>(const_cast<WrapperBase*>(spitem.prod())),
-                                   std::move(productProvenance));
+          eventPrincipal.putOnRead(
+              branchDesc, std::unique_ptr<WrapperBase>(const_cast<WrapperBase*>(spitem.prod())), productProvenance);
           FDEBUG(10) << "addproduct done" << std::endl;
         } else {
           FDEBUG(10) << "addproduct empty next " << spitem.branchID() << std::endl;
-          eventPrincipal.putOnRead(branchDesc, std::unique_ptr<WrapperBase>(), std::move(productProvenance));
+          eventPrincipal.putOnRead(branchDesc, std::unique_ptr<WrapperBase>(), productProvenance);
           FDEBUG(10) << "addproduct empty done" << std::endl;
         }
       } else {

--- a/PerfTools/AllocMonitorPreload/src/memory_proxies.cc
+++ b/PerfTools/AllocMonitorPreload/src/memory_proxies.cc
@@ -148,7 +148,7 @@ namespace {
     }
   };
 
-  static ThreadTracker& getTracker() {
+  ThreadTracker& getTracker() {
     static ThreadTracker s_tracker;
     return s_tracker;
   }

--- a/Utilities/XrdAdaptor/src/XrdRequestManager.cc
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.cc
@@ -771,12 +771,12 @@ std::future<IOSize> XrdAdaptor::RequestManager::handle(std::shared_ptr<std::vect
   std::shared_ptr<XrdAdaptor::ClientRequest> c_ptr1, c_ptr2;
   std::future<IOSize> future1, future2;
   if (!req1->empty()) {
-    c_ptr1.reset(new XrdAdaptor::ClientRequest(*this, req1));
+    c_ptr1 = std::make_shared<XrdAdaptor::ClientRequest>(*this, req1);
     activeSources[0]->handle(c_ptr1);
     future1 = c_ptr1->get_future();
   }
   if (!req2->empty()) {
-    c_ptr2.reset(new XrdAdaptor::ClientRequest(*this, req2));
+    c_ptr2 = std::make_shared<XrdAdaptor::ClientRequest>(*this, req2);
     activeSources[1]->handle(c_ptr2);
     future2 = c_ptr2->get_future();
   }
@@ -1106,7 +1106,7 @@ void XrdAdaptor::RequestManager::OpenHandler::HandleResponseWithHosts(XrdCl::XRo
       std::string excludeString;
       Source::determineHostExcludeString(*m_file, hostList.get(), excludeString);
 
-      source.reset(new Source(now, std::move(m_file), excludeString));
+      source = std::make_shared<Source>(now, std::move(m_file), excludeString);
       m_promise.set_value(source);
     } else {
       releaseFile = std::move(m_file);


### PR DESCRIPTION
PGO changes ( e.g. using relative source path instead of full path ) broke `scram build code-checks` rule. So it has not been running properly on PR. `code-format` was working but only `code-checks` i.e. `clang-tidy` did not work as it required correct `compiler_command.json` with correct source file paths.

Build rules are fixed now, so this PR applies `code-checks` ( and format) for those files which were merged with proper code-checks