### PR TITLE
[ALCA-DB-L1] Apply code checks/format

### DIFF
--- a/CondFormats/L1TObjects/src/L1MuDTEtaPatternLut.cc
+++ b/CondFormats/L1TObjects/src/L1MuDTEtaPatternLut.cc
@@ -78,7 +78,7 @@ int L1MuDTEtaPatternLut::load() {
 
   // assemble file name
   edm::FileInPath lut_f = edm::FileInPath(string(defaultPath + eau_dir + "ETFPatternList.lut"));
-  string etf_file = lut_f.fullPath();
+  const string& etf_file = lut_f.fullPath();
 
   // open file
   L1TriggerLutFile file(etf_file);

--- a/CondFormats/L1TObjects/src/L1MuDTExtLut.cc
+++ b/CondFormats/L1TObjects/src/L1MuDTExtLut.cc
@@ -141,7 +141,7 @@ int L1MuDTExtLut::load() {
 
     // assemble file name
     edm::FileInPath lut_f = edm::FileInPath(string(defaultPath + ext_dir + ext_str + ".lut"));
-    string ext_file = lut_f.fullPath();
+    const string& ext_file = lut_f.fullPath();
 
     // open file
     L1TriggerLutFile file(ext_file);

--- a/CondFormats/L1TObjects/src/L1MuDTPhiLut.cc
+++ b/CondFormats/L1TObjects/src/L1MuDTPhiLut.cc
@@ -110,7 +110,7 @@ int L1MuDTPhiLut::load() {
 
     // assemble file name
     edm::FileInPath lut_f = edm::FileInPath(string(defaultPath + phi_dir + phi_str + ".lut"));
-    string phi_file = lut_f.fullPath();
+    const string& phi_file = lut_f.fullPath();
 
     // open file
     L1TriggerLutFile file(phi_file);

--- a/CondFormats/L1TObjects/src/L1MuDTPtaLut.cc
+++ b/CondFormats/L1TObjects/src/L1MuDTPtaLut.cc
@@ -221,7 +221,7 @@ int L1MuDTPtaLut::load() {
 
     // assemble file name
     edm::FileInPath lut_f = edm::FileInPath(string(defaultPath + pta_dir + pta_str + ".lut"));
-    string pta_file = lut_f.fullPath();
+    const string& pta_file = lut_f.fullPath();
 
     // open file
     L1TriggerLutFile file(pta_file);

--- a/CondFormats/L1TObjects/src/L1MuDTQualPatternLut.cc
+++ b/CondFormats/L1TObjects/src/L1MuDTQualPatternLut.cc
@@ -118,7 +118,7 @@ int L1MuDTQualPatternLut::load() {
 
     // assemble file name
     edm::FileInPath lut_f = edm::FileInPath(string(defaultPath + eau_dir + emu_str + ".lut"));
-    string emu_file = lut_f.fullPath();
+    const string& emu_file = lut_f.fullPath();
 
     // open file
     L1TriggerLutFile file(emu_file);


### PR DESCRIPTION
PGO changes ( e.g. using relative source path instead of full path ) broke `scram build code-checks` rule. So it has not been running properly on PR. `code-format` was working but only `code-checks` i.e. `clang-tidy` did not work as it required correct `compiler_command.json` with correct source file paths.

Build rules are fixed now, so this PR applies `code-checks` ( and format) for those files which were merged with proper code-checks