### PR TITLE
[L1-XPOG] Apply code checks/format

### DIFF
--- a/DPGAnalysis/L1TNanoAOD/plugins/P2GTTriggerResultsConverter.cc
+++ b/DPGAnalysis/L1TNanoAOD/plugins/P2GTTriggerResultsConverter.cc
@@ -58,7 +58,7 @@ void P2GTTriggerResultsConverter::produce(edm::Event& event, const edm::EventSet
 
   bool fillAlgoNames = false;
 
-  if (algoNames_.size() == 0) {
+  if (algoNames_.empty()) {
     algoNames_ = std::vector<std::string>(algoBlockMap.size());
     fillAlgoNames = true;
   }


### PR DESCRIPTION
PGO changes ( e.g. using relative source path instead of full path ) broke `scram build code-checks` rule. So it has not been running properly on PR. `code-format` was working but only `code-checks` i.e. `clang-tidy` did not work as it required correct `compiler_command.json` with correct source file paths.

Build rules are fixed now, so this PR applies `code-checks` ( and format) for those files which were merged with proper code-checks