### PR TITLE
[DQM] Apply code checks/format

### DIFF
--- a/DQM/GEM/plugins/GEMRecHitSource.cc
+++ b/DQM/GEM/plugins/GEMRecHitSource.cc
@@ -287,7 +287,7 @@ void GEMRecHitSource::analyze(edm::Event const& event, edm::EventSetup const& ev
   for (auto [key, num_total_rechit] : total_rechit_iEta) {
     mapTotalRecHitPerEvtIEta_.Fill(key, num_total_rechit);
   }
-  for (auto [key, mapSub] : mapCLSOver5) {
+  for (const auto& [key, mapSub] : mapCLSOver5) {
     for (auto [chamber, b] : mapSub) {
       mapCLSOver5_.Fill(key4Tokey3(key), chamber, keyToIEta(key));
     }

--- a/DQM/L1TMonitor/src/L1TCaloLayer1Summary.cc
+++ b/DQM/L1TMonitor/src/L1TCaloLayer1Summary.cc
@@ -78,7 +78,7 @@ void L1TCaloLayer1Summary::analyze(const edm::Event& iEvent, const edm::EventSet
   }
 
   auto caloCICADAScores = iEvent.get(caloLayer1CICADAScoreToken_);
-  auto gtCICADAScores = iEvent.get(gtCICADAScoreToken_);
+  const auto& gtCICADAScores = iEvent.get(gtCICADAScoreToken_);
   auto simCICADAScores = iEvent.get(simCICADAScoreToken_);
 
   if (caloCICADAScores.size() > 0) {

--- a/DQM/SiStripMonitorClient/plugins/SiStripOfflineDQM.cc
+++ b/DQM/SiStripMonitorClient/plugins/SiStripOfflineDQM.cc
@@ -78,7 +78,7 @@ SiStripOfflineDQM::SiStripOfflineDQM(edm::ParameterSet const& pSet)
       auto token = useSSQ ? QualityToken{esConsumes<edm::Transition::EndRun>(
                                 edm::ESInputTag{"", tkMapPSet.getUntrackedParameter<std::string>("ssqLabel", "")})}
                           : QualityToken{};
-      tkMapOptions_.emplace_back(map_type, std::move(tkMapPSet), useSSQ, std::move(token));
+      tkMapOptions_.emplace_back(map_type, std::move(tkMapPSet), useSSQ, token);
     }
   }
 

--- a/DQM/SiStripMonitorClient/plugins/SiStripOfflineDQM.cc
+++ b/DQM/SiStripMonitorClient/plugins/SiStripOfflineDQM.cc
@@ -78,7 +78,7 @@ SiStripOfflineDQM::SiStripOfflineDQM(edm::ParameterSet const& pSet)
       auto token = useSSQ ? QualityToken{esConsumes<edm::Transition::EndRun>(
                                 edm::ESInputTag{"", tkMapPSet.getUntrackedParameter<std::string>("ssqLabel", "")})}
                           : QualityToken{};
-      tkMapOptions_.emplace_back(map_type, std::move(tkMapPSet), useSSQ, token);
+      tkMapOptions_.emplace_back(map_type, std::move(tkMapPSet), useSSQ, std::move(token));  //NOLINT
     }
   }
 

--- a/DQM/TrackerRemapper/bin/printPixelROCsMap.cc
+++ b/DQM/TrackerRemapper/bin/printPixelROCsMap.cc
@@ -170,11 +170,11 @@ int main(int argc, char* argv[]) {
   // Draw and save the map
   TCanvas canvas("Summary", "Summary", 1200, k_height[static_cast<int>(region)]);
   if (region == Region::Full) {
-    theMap.drawMaps(canvas, title.c_str());
+    theMap.drawMaps(canvas, title);
   } else if (region == Region::Barrel) {
-    theMap.drawBarrelMaps(canvas, title.c_str());
+    theMap.drawBarrelMaps(canvas, title);
   } else if (region == Region::Forward) {
-    theMap.drawForwardMaps(canvas, title.c_str());
+    theMap.drawForwardMaps(canvas, title);
   }
 
   // Construct the filename string based on the region

--- a/DQM/TrackerRemapper/src/Phase1PixelMaps.cc
+++ b/DQM/TrackerRemapper/src/Phase1PixelMaps.cc
@@ -446,7 +446,7 @@ const indexedCorners Phase1PixelMaps::retrieveCorners(const std::vector<edm::Fil
   indexedCorners theOutMap;
 
   for (const auto& file : cornerFiles) {
-    auto cornerFileName = file.fullPath();
+    const auto& cornerFileName = file.fullPath();
     std::ifstream cornerFile(cornerFileName.c_str());
     if (!cornerFile.good()) {
       throw cms::Exception("FileError") << "Problem opening corner file: " << cornerFileName;

--- a/DQM/TrackerRemapper/src/Phase1PixelSummaryMap.cc
+++ b/DQM/TrackerRemapper/src/Phase1PixelSummaryMap.cc
@@ -179,7 +179,7 @@ void Phase1PixelSummaryMap::setZAxisRange(const double min, const double max) {
 //============================================================================
 void Phase1PixelSummaryMap::addNamedBins(
     edm::FileInPath geoFile, int tX, int tY, int sX, int sY, bool applyModuleRotation) {
-  auto cornerFileName = geoFile.fullPath();
+  const auto& cornerFileName = geoFile.fullPath();
   std::ifstream cornerFile(cornerFileName.c_str());
   if (!cornerFile.good()) {
     throw cms::Exception("FileError") << "Problem opening corner file: " << cornerFileName;

--- a/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc
+++ b/DQMOffline/ParticleFlow/plugins/PFAnalyzer.cc
@@ -98,8 +98,8 @@ PFAnalyzer::PFAnalyzer(const edm::ParameterSet& pSet) {
   //
   for (unsigned int i = 0; i < m_cutList.size(); i++) {
     m_fullCutList.push_back(std::vector<std::string>());
-    while (m_cutList[i].find("]") != std::string::npos) {
-      size_t pos = m_cutList[i].find("]");
+    while (m_cutList[i].find(']') != std::string::npos) {
+      size_t pos = m_cutList[i].find(']');
       m_fullCutList[i].push_back(m_cutList[i].substr(1, pos));
       m_cutList[i].erase(0, pos + 1);
     }
@@ -108,7 +108,7 @@ PFAnalyzer::PFAnalyzer(const edm::ParameterSet& pSet) {
   for (unsigned int i = 0; i < m_fullCutList.size(); i++) {
     m_binList.push_back(std::vector<std::vector<double>>());
     for (unsigned int j = 0; j < m_fullCutList[i].size(); j++) {
-      size_t pos = m_fullCutList[i][j].find(";");
+      size_t pos = m_fullCutList[i][j].find(';');
       std::string observableName = m_fullCutList[i][j].substr(0, pos);
       m_fullCutList[i][j].erase(0, pos + 1);
 
@@ -125,8 +125,8 @@ PFAnalyzer::PFAnalyzer(const edm::ParameterSet& pSet) {
   //
   for (unsigned int i = 0; i < m_jetCutList.size(); i++) {
     m_fullJetCutList.push_back(std::vector<std::string>());
-    while (m_jetCutList[i].find("]") != std::string::npos) {
-      size_t pos = m_jetCutList[i].find("]");
+    while (m_jetCutList[i].find(']') != std::string::npos) {
+      size_t pos = m_jetCutList[i].find(']');
       m_fullJetCutList[i].push_back(m_jetCutList[i].substr(1, pos));
       m_jetCutList[i].erase(0, pos + 1);
     }
@@ -135,7 +135,7 @@ PFAnalyzer::PFAnalyzer(const edm::ParameterSet& pSet) {
   for (unsigned int i = 0; i < m_fullJetCutList.size(); i++) {
     m_jetBinList.push_back(std::vector<std::vector<double>>());
     for (unsigned int j = 0; j < m_fullJetCutList[i].size(); j++) {
-      size_t pos = m_fullJetCutList[i][j].find(";");
+      size_t pos = m_fullJetCutList[i][j].find(';');
       std::string observableName = m_fullJetCutList[i][j].substr(0, pos);
       m_fullJetCutList[i][j].erase(0, pos + 1);
 
@@ -219,31 +219,31 @@ void PFAnalyzer::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun
     // Do the same for global observables (things like the number of PFCs in an event, or in a jet, etc)
     for (unsigned int i = 0; i < m_eventObservables.size(); i++) {
       std::string cEventObservable = m_eventObservables[i];
-      size_t pos = cEventObservable.find(";");
+      size_t pos = cEventObservable.find(';');
       std::string observableName = cEventObservable.substr(0, pos);
       cEventObservable.erase(0, pos + 1);
 
-      pos = cEventObservable.find(";");
+      pos = cEventObservable.find(';');
       std::string axisString = cEventObservable.substr(0, pos);
       cEventObservable.erase(0, pos + 1);
 
-      pos = cEventObservable.find(";");
+      pos = cEventObservable.find(';');
       int nBins = atoi(cEventObservable.substr(0, pos).c_str());
       cEventObservable.erase(0, pos + 1);
 
-      pos = cEventObservable.find(";");
+      pos = cEventObservable.find(';');
       float binMin = atof(cEventObservable.substr(0, pos).c_str());
       cEventObservable.erase(0, pos + 1);
 
-      pos = cEventObservable.find(";");
+      pos = cEventObservable.find(';');
       float binMax = atof(cEventObservable.substr(0, pos).c_str());
       cEventObservable.erase(0, pos + 1);
 
-      pos = cEventObservable.find(";");
+      pos = cEventObservable.find(';');
       int nBinsJet = atoi(cEventObservable.substr(0, pos).c_str());
       cEventObservable.erase(0, pos + 1);
 
-      pos = cEventObservable.find(";");
+      pos = cEventObservable.find(';');
       float binMinJet = atof(cEventObservable.substr(0, pos).c_str());
       cEventObservable.erase(0, pos + 1);
 
@@ -333,20 +333,20 @@ void PFAnalyzer::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun
 PFAnalyzer::binInfo PFAnalyzer::getBinInfo(std::string observableString) {
   PFAnalyzer::binInfo binningDetails;
 
-  size_t pos = observableString.find(";");
+  size_t pos = observableString.find(';');
   binningDetails.observable = observableString.substr(0, pos);
   observableString.erase(0, pos + 1);
 
   std::vector<double> binList = getBinList(observableString);
-  pos = observableString.find(";");
+  pos = observableString.find(';');
   binningDetails.axisName = observableString.substr(0, pos);
   observableString.erase(0, pos + 1);
 
-  pos = observableString.find(";");
+  pos = observableString.find(';');
   binningDetails.nBins = atoi(observableString.substr(0, pos).c_str());
   observableString.erase(0, pos + 1);
 
-  pos = observableString.find(";");
+  pos = observableString.find(';');
   binningDetails.binMin = atof(observableString.substr(0, pos).c_str());
   observableString.erase(0, pos + 1);
 
@@ -399,8 +399,8 @@ std::string PFAnalyzer::stringWithDecimals(int bin, std::vector<double> bins) {
 std::vector<double> PFAnalyzer::getBinList(std::string binString) {
   std::vector<double> binList;
 
-  while (binString.find(";") != std::string::npos) {
-    size_t pos = binString.find(";");
+  while (binString.find(';') != std::string::npos) {
+    size_t pos = binString.find(';');
     binList.push_back(atof(binString.substr(0, pos).c_str()));
     binString.erase(0, pos + 1);
   }
@@ -431,6 +431,7 @@ std::vector<std::string> PFAnalyzer::getAllSuffixes(std::vector<std::string> obs
 
   std::vector<std::vector<int>> binList;
 
+  binList.reserve(nTotalBins);
   for (int i = 0; i < nTotalBins; i++) {
     binList.push_back(std::vector<int>());
   }
@@ -451,6 +452,7 @@ std::vector<std::string> PFAnalyzer::getAllSuffixes(std::vector<std::string> obs
   }
 
   std::vector<std::string> allSuffixes;
+  allSuffixes.reserve(nTotalBins);
   for (int i = 0; i < nTotalBins; i++) {
     allSuffixes.push_back(getSuffix(binList[i], observables, binnings));
   }
@@ -702,7 +704,7 @@ void PFAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
 
       std::vector<reco::PFCandidatePtr> pfConstits = cjet->getPFConstituents();
 
-      for (auto recoPF : pfConstits) {
+      for (const auto& recoPF : pfConstits) {
         for (unsigned int j = 0; j < m_fullCutList.size(); j++) {
           int binNumber = getPFBin(*recoPF, j);
           if (binNumber < 0)

--- a/DQMOffline/Trigger/plugins/ZGammaplusJetsMonitor.cc
+++ b/DQMOffline/Trigger/plugins/ZGammaplusJetsMonitor.cc
@@ -322,7 +322,7 @@ void ZGammaplusJetsMonitor::analyze(edm::Event const& iEvent, edm::EventSetup co
   if (!aodTriggerEvent.isValid())
     return;
 
-  edm::TriggerNames triggerNames_ = iEvent.triggerNames(*triggerResults);  // all trigger names available
+  const edm::TriggerNames& triggerNames_ = iEvent.triggerNames(*triggerResults);  // all trigger names available
 
   bool passTrig = false;
 

--- a/DQMOffline/Trigger/src/HLTTauDQMPath.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMPath.cc
@@ -47,7 +47,7 @@ namespace {
       for (auto iLabel = moduleLabels.begin(); iLabel != moduleLabels.end(); ++iLabel) {
         if (HLTCP.moduleEDMType(*iLabel) != "EDFilter")
           continue;
-        const std::string type = HLTCP.moduleType(*iLabel);
+        const std::string& type = HLTCP.moduleType(*iLabel);
         LogTrace("HLTTauDQMOffline") << "  " << std::distance(moduleLabels.begin(), iLabel) << " " << *iLabel << " "
                                      << type << " saveTags " << HLTCP.saveTags(*iLabel);
         if (type.find("Selector") != std::string::npos)
@@ -99,7 +99,7 @@ namespace {
     }
 
     bool isL3TauProducer(const HLTConfigProvider& HLTCP, const std::string& producerLabel) const {
-      const std::string type = HLTCP.moduleType(producerLabel);
+      const std::string& type = HLTCP.moduleType(producerLabel);
       if (type == "PFRecoTauProducer" || type == "RecoTauPiZeroUnembedder" ||
           type == "BTagProbabilityToDiscriminator") {
         LogDebug("HLTTauDQMOffline") << "Found tau producer " << type << " with label " << producerLabel
@@ -110,7 +110,7 @@ namespace {
     }
 
     bool isL3ElectronProducer(const HLTConfigProvider& HLTCP, const std::string& producerLabel) const {
-      const std::string type = HLTCP.moduleType(producerLabel);
+      const std::string& type = HLTCP.moduleType(producerLabel);
       if (type == "EgammaHLTPixelMatchElectronProducers") {
         LogDebug("HLTTauDQMOffline") << "Found electron producer " << type << " with label " << producerLabel
                                      << " from path " << name_;
@@ -120,7 +120,7 @@ namespace {
     }
 
     bool isL3MuonProducer(const HLTConfigProvider& HLTCP, const std::string& producerLabel) const {
-      const std::string type = HLTCP.moduleType(producerLabel);
+      const std::string& type = HLTCP.moduleType(producerLabel);
       if (type == "L3MuonCandidateProducer" || type == "L3MuonCombinedRelativeIsolationProducer") {
         LogDebug("HLTTauDQMOffline") << "Found muon producer " << type << " with label " << producerLabel
                                      << " from path " << name_;

--- a/DQMOffline/Trigger/src/HLTTauDQMPathPlotter.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMPathPlotter.cc
@@ -454,7 +454,7 @@ void HLTTauDQMPathPlotter::analyze(const edm::TriggerResults& triggerResults,
   int firstMatchedMETFilter = -1;
   if (hCounter_) {
     hCounter_->Fill(0.5);
-    if (refCollection.taus.size() > 0) {
+    if (!refCollection.taus.empty()) {
       hCounter_->Fill(1.5);
       if (hltPath_.fired(triggerResults))
         hCounter_->Fill(2.5);

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -749,7 +749,7 @@ namespace dqm::implementation {
     }
     std::vector<std::string> out;
     for (const auto& dir : subdirs) {
-      if (dir.length() == 0)
+      if (dir.empty())
         continue;
       out.push_back(this->cwd_ + dir);
     }

--- a/DQMServices/StreamerIO/plugins/DQMStreamerReader.cc
+++ b/DQMServices/StreamerIO/plugins/DQMStreamerReader.cc
@@ -10,12 +10,13 @@
 #include "FWCore/Utilities/interface/UnixSignalHandlers.h"
 #include "IOPool/Streamer/interface/DumpTools.h"
 
+#include <algorithm>
+#include <cctype>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <memory>
 #include <queue>
-#include <algorithm>
-#include <cctype>
 
 namespace dqmservices {
   using namespace edm::streamer;
@@ -114,7 +115,7 @@ namespace dqmservices {
       std::vector<std::string> tnames;
       header->hltTriggerNames(tnames);
 
-      triggerSelector_.reset(new TriggerSelector(hltSel_, tnames));
+      triggerSelector_ = std::make_shared<TriggerSelector>(hltSel_, tnames);
 
       // check if any trigger path name requested matches with trigger name in the header file
       setMatchTriggerSel(tnames);

--- a/DQMServices/StreamerIO/plugins/TriggerSelector.cc
+++ b/DQMServices/StreamerIO/plugins/TriggerSelector.cc
@@ -11,6 +11,7 @@
 #include <algorithm>
 
 #include <boost/regex.hpp>
+#include <memory>
 
 namespace dqmservices {
 
@@ -18,7 +19,7 @@ namespace dqmservices {
 
   TriggerSelector::TriggerSelector(Strings const& pathspecs, Strings const& triggernames) : useOld_(true) {
     acceptAll_ = false;
-    eventSelector_.reset(new edm::EventSelector(pathspecs, triggernames));
+    eventSelector_ = std::make_shared<edm::EventSelector>(pathspecs, triggernames);
   }
 
   TriggerSelector::TriggerSelector(std::string const& expression, Strings const& triggernames) : useOld_(false) {
@@ -47,7 +48,7 @@ namespace dqmservices {
     }
 
     // build decision tree
-    masterElement_.reset(new TreeElement(expression_, triggernames));
+    masterElement_ = std::make_shared<TreeElement>(expression_, triggernames);
   }
 
   bool TriggerSelector::acceptEvent(edm::TriggerResults const& tr) const {

--- a/HLTriggerOffline/Egamma/src/EmDQM.cc
+++ b/HLTriggerOffline/Egamma/src/EmDQM.cc
@@ -1116,7 +1116,7 @@ void EmDQM::dqmEndRun(edm::Run const &iRun, edm::EventSetup const &iSetup) {
 
 // returns count of non-overlapping occurrences of 'sub' in 'str'
 int EmDQM::countSubstring(const std::string &str, const std::string &sub) {
-  if (sub.length() == 0)
+  if (sub.empty())
     return 0;
   int count = 0;
   for (size_t offset = str.find(sub); offset != std::string::npos; offset = str.find(sub, offset + sub.length())) {

--- a/Validation/HGCalValidation/plugins/HGCalTestPartialWaferRecHits.cc
+++ b/Validation/HGCalValidation/plugins/HGCalTestPartialWaferRecHits.cc
@@ -57,7 +57,7 @@ HGCalTestPartialWaferRecHits::HGCalTestPartialWaferRecHits(const edm::ParameterS
                                << " Missing Wafer file " << missingFile_;
   if (!missingFile_.empty()) {
     edm::FileInPath filetmp("SimG4CMS/Calo/data/" + missingFile_);
-    std::string fileName = filetmp.fullPath();
+    const std::string& fileName = filetmp.fullPath();
     std::ifstream fInput(fileName.c_str());
     if (!fInput.good()) {
       edm::LogVerbatim("HGCalSim") << "Cannot open file " << fileName;

--- a/Validation/HGCalValidation/src/TICLCandidateValidator.cc
+++ b/Validation/HGCalValidation/src/TICLCandidateValidator.cc
@@ -361,7 +361,7 @@ void TICLCandidateValidator::fillCandidateHistos(const edm::Event& event,
 
     int32_t cand_idx = -1;
     float shared_energy = 0.;
-    const auto ts_vec = mergeTsSimToRecoMap[i];
+    const auto& ts_vec = mergeTsSimToRecoMap[i];
     if (!ts_vec.empty()) {
       auto min_elem =
           std::min_element(ts_vec.begin(), ts_vec.end(), [](auto const& ts1_id_pair, auto const& ts2_id_pair) {
@@ -438,7 +438,7 @@ void TICLCandidateValidator::fillCandidateHistos(const edm::Event& event,
 
     int32_t cand_idx = -1;
     float shared_energy = 0.;
-    const auto ts_vec = mergeTsSimToRecoMap[i];
+    const auto& ts_vec = mergeTsSimToRecoMap[i];
     if (!ts_vec.empty()) {
       auto min_elem =
           std::min_element(ts_vec.begin(), ts_vec.end(), [](auto const& ts1_id_pair, auto const& ts2_id_pair) {
@@ -549,7 +549,7 @@ void TICLCandidateValidator::fillCandidateHistos(const edm::Event& event,
     histograms.h_chg_candidate_partType[index]->Fill(std::max_element(arr.begin(), arr.end()) - arr.begin());
 
     int32_t simCand_idx = -1;
-    const auto sts_vec = mergeTsRecoToSimMap[mergeTs_id];
+    const auto& sts_vec = mergeTsRecoToSimMap[mergeTs_id];
     float shared_energy = 0.;
     // search for reco cand associated
     if (!sts_vec.empty()) {
@@ -635,7 +635,7 @@ void TICLCandidateValidator::fillCandidateHistos(const edm::Event& event,
     histograms.h_neut_candidate_partType[index]->Fill(std::max_element(arr.begin(), arr.end()) - arr.begin());
 
     int32_t simCand_idx = -1;
-    const auto sts_vec = mergeTsRecoToSimMap[mergeTs_id];
+    const auto& sts_vec = mergeTsRecoToSimMap[mergeTs_id];
     float shared_energy = 0.;
     // search for reco cand associated
     if (!sts_vec.empty()) {

--- a/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
+++ b/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
@@ -1476,7 +1476,7 @@ void Primary4DVertexValidation::observablesFromJets(const std::vector<reco::Trac
   fjInputs_.clear();
   size_t countScale0 = 0;
   for (size_t i = 0; i < reco_Tracks.size(); i++) {
-    const auto recotr = reco_Tracks[i];
+    const auto& recotr = reco_Tracks[i];
     const auto mass = mass_Tracks[i];
     float scale = 1.;
     if (recotr.charge() == 0) {

--- a/Validation/MuonCSCDigis/src/CSCDigiMatcher.cc
+++ b/Validation/MuonCSCDigis/src/CSCDigiMatcher.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "Validation/MuonCSCDigis/interface/CSCDigiMatcher.h"
 
 using namespace std;
@@ -22,7 +24,7 @@ CSCDigiMatcher::CSCDigiMatcher(const edm::ParameterSet& pset, edm::ConsumesColle
   matchDeltaStrip_ = stripDigi.getParameter<int>("matchDeltaStrip");
 
   // make a new simhits matcher
-  muonSimHitMatcher_.reset(new CSCSimHitMatcher(pset, std::move(iC)));
+  muonSimHitMatcher_ = std::make_shared<CSCSimHitMatcher>(pset, std::move(iC));
 
   comparatorDigiInput_ =
       iC.consumes<CSCComparatorDigiCollection>(comparatorDigi.getParameter<edm::InputTag>("inputTag"));

--- a/Validation/MuonCSCDigis/src/CSCStubMatcher.cc
+++ b/Validation/MuonCSCDigis/src/CSCStubMatcher.cc
@@ -1,6 +1,7 @@
 #include "Validation/MuonCSCDigis/interface/CSCStubMatcher.h"
 #include "DataFormats/CSCDigi/interface/CSCConstants.h"
 #include <algorithm>
+#include <memory>
 
 using namespace std;
 
@@ -34,8 +35,8 @@ CSCStubMatcher::CSCStubMatcher(const edm::ParameterSet& pSet, edm::ConsumesColle
   minNHitsChamberMPLCT_ = cscMPLCT.getParameter<int>("minNHitsChamber");
 
   if (useGEMs_)
-    gemDigiMatcher_.reset(new GEMDigiMatcher(pSet, std::move(iC)));
-  cscDigiMatcher_.reset(new CSCDigiMatcher(pSet, std::move(iC)));
+    gemDigiMatcher_ = std::make_shared<GEMDigiMatcher>(pSet, std::move(iC));
+  cscDigiMatcher_ = std::make_shared<CSCDigiMatcher>(pSet, std::move(iC));
 
   clctInputTag_ = cscCLCT.getParameter<edm::InputTag>("inputTag");
   alctInputTag_ = cscALCT.getParameter<edm::InputTag>("inputTag");

--- a/Validation/MuonGEMDigis/src/GEMDigiMatcher.cc
+++ b/Validation/MuonGEMDigis/src/GEMDigiMatcher.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "Validation/MuonGEMDigis/interface/GEMDigiMatcher.h"
 
 using namespace std;
@@ -31,7 +33,7 @@ GEMDigiMatcher::GEMDigiMatcher(const edm::ParameterSet& pset, edm::ConsumesColle
   verboseCoPad_ = gemCoPad.getParameter<int>("verbose");
 
   // make a new simhits matcher
-  muonSimHitMatcher_.reset(new GEMSimHitMatcher(pset, std::move(iC)));
+  muonSimHitMatcher_ = std::make_shared<GEMSimHitMatcher>(pset, std::move(iC));
 
   if (matchToSimLink_)
     gemSimLinkToken_ =

--- a/Validation/MuonGEMRecHits/src/GEMRecHitMatcher.cc
+++ b/Validation/MuonGEMRecHits/src/GEMRecHitMatcher.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "Validation/MuonGEMRecHits/interface/GEMRecHitMatcher.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "Geometry/GEMGeometry/interface/GEMGeometry.h"
@@ -11,7 +13,7 @@ GEMRecHitMatcher::GEMRecHitMatcher(const edm::ParameterSet& pset, edm::ConsumesC
   verbose_ = gemRecHit.getParameter<int>("verbose");
 
   // make a new digi matcher
-  gemDigiMatcher_.reset(new GEMDigiMatcher(pset, std::move(iC)));
+  gemDigiMatcher_ = std::make_shared<GEMDigiMatcher>(pset, std::move(iC));
 
   gemRecHitToken_ = iC.consumes<GEMRecHitCollection>(gemRecHit.getParameter<edm::InputTag>("inputTag"));
   geomToken_ = iC.esConsumes<GEMGeometry, MuonGeometryRecord>();

--- a/Validation/MuonRPCDigis/src/RPCDigiValid.cc
+++ b/Validation/MuonRPCDigis/src/RPCDigiValid.cc
@@ -78,7 +78,7 @@ void RPCDigiValid::analyze(const Event &event, const EventSetup &eventSetup) {
         match->second->Fill(gp.x(), gp.y());
     }
   }
-  for (auto detToSimHitXs : detToSimHitXsMap) {
+  for (const auto &detToSimHitXs : detToSimHitXsMap) {
     hNSimHitPerRoll_->Fill(detToSimHitXs.second.size());
   }
 
@@ -143,7 +143,7 @@ void RPCDigiValid::analyze(const Event &event, const EventSetup &eventSetup) {
       detToDigiXsMap[roll].push_back(digiX);
     }
   }
-  for (auto detToDigiXs : detToDigiXsMap) {
+  for (const auto &detToDigiXs : detToDigiXsMap) {
     const auto digiXs = detToDigiXs.second;
     const int nDigi = digiXs.size();
     hNDigiPerRoll_->Fill(nDigi);


### PR DESCRIPTION
PGO changes ( e.g. using relative source path instead of full path ) broke `scram build code-checks` rule. So it has not been running properly on PR. `code-format` was working but only `code-checks` i.e. `clang-tidy` did not work as it required correct `compiler_command.json` with correct source file paths.

Build rules are fixed now, so this PR applies `code-checks` ( and format) for those files which were merged with proper code-checks