### PR TITLE
[RECONSTRUCTION] Apply code checks/format

### DIFF
--- a/CommonTools/Utils/src/ExpressionFunctionSetter.cc
+++ b/CommonTools/Utils/src/ExpressionFunctionSetter.cc
@@ -1,11 +1,12 @@
 #include "CommonTools/Utils/interface/parser/ExpressionFunctionSetter.h"
-#include "CommonTools/Utils/interface/parser/ExpressionUnaryOperator.h"
 #include "CommonTools/Utils/interface/parser/ExpressionBinaryOperator.h"
+#include "CommonTools/Utils/interface/parser/ExpressionUnaryOperator.h"
 #include "CommonTools/Utils/src/ExpressionQuaterOperator.h"
-#include <cmath>
-#include <Math/ProbFuncMathCore.h>
 #include <DataFormats/Math/interface/deltaPhi.h>
 #include <DataFormats/Math/interface/deltaR.h>
+#include <Math/ProbFuncMathCore.h>
+#include <cmath>
+#include <memory>
 
 namespace reco {
   namespace parser {
@@ -89,73 +90,73 @@ void ExpressionFunctionSetter::operator()(const char *, const char *) const {
   ExpressionPtr funExp;
   switch (fun) {
     case (kAbs):
-      funExp.reset(new ExpressionUnaryOperator<abs_f>(expStack_));
+      funExp = std::make_shared<ExpressionUnaryOperator<abs_f>>(expStack_);
       break;
     case (kAcos):
-      funExp.reset(new ExpressionUnaryOperator<acos_f>(expStack_));
+      funExp = std::make_shared<ExpressionUnaryOperator<acos_f>>(expStack_);
       break;
     case (kAsin):
-      funExp.reset(new ExpressionUnaryOperator<asin_f>(expStack_));
+      funExp = std::make_shared<ExpressionUnaryOperator<asin_f>>(expStack_);
       break;
     case (kAtan):
-      funExp.reset(new ExpressionUnaryOperator<atan_f>(expStack_));
+      funExp = std::make_shared<ExpressionUnaryOperator<atan_f>>(expStack_);
       break;
     case (kAtan2):
-      funExp.reset(new ExpressionBinaryOperator<atan2_f>(expStack_));
+      funExp = std::make_shared<ExpressionBinaryOperator<atan2_f>>(expStack_);
       break;
     case (kChi2Prob):
-      funExp.reset(new ExpressionBinaryOperator<chi2prob_f>(expStack_));
+      funExp = std::make_shared<ExpressionBinaryOperator<chi2prob_f>>(expStack_);
       break;
     case (kCos):
-      funExp.reset(new ExpressionUnaryOperator<cos_f>(expStack_));
+      funExp = std::make_shared<ExpressionUnaryOperator<cos_f>>(expStack_);
       break;
     case (kCosh):
-      funExp.reset(new ExpressionUnaryOperator<cosh_f>(expStack_));
+      funExp = std::make_shared<ExpressionUnaryOperator<cosh_f>>(expStack_);
       break;
     case (kDeltaR):
-      funExp.reset(new ExpressionQuaterOperator<deltaR_f>(expStack_));
+      funExp = std::make_shared<ExpressionQuaterOperator<deltaR_f>>(expStack_);
       break;
     case (kDeltaPhi):
-      funExp.reset(new ExpressionBinaryOperator<deltaPhi_f>(expStack_));
+      funExp = std::make_shared<ExpressionBinaryOperator<deltaPhi_f>>(expStack_);
       break;
     case (kExp):
-      funExp.reset(new ExpressionUnaryOperator<exp_f>(expStack_));
+      funExp = std::make_shared<ExpressionUnaryOperator<exp_f>>(expStack_);
       break;
     case (kHypot):
-      funExp.reset(new ExpressionBinaryOperator<hypot_f>(expStack_));
+      funExp = std::make_shared<ExpressionBinaryOperator<hypot_f>>(expStack_);
       break;
     case (kLog):
-      funExp.reset(new ExpressionUnaryOperator<log_f>(expStack_));
+      funExp = std::make_shared<ExpressionUnaryOperator<log_f>>(expStack_);
       break;
     case (kLog10):
-      funExp.reset(new ExpressionUnaryOperator<log10_f>(expStack_));
+      funExp = std::make_shared<ExpressionUnaryOperator<log10_f>>(expStack_);
       break;
     case (kMax):
-      funExp.reset(new ExpressionBinaryOperator<max_f>(expStack_));
+      funExp = std::make_shared<ExpressionBinaryOperator<max_f>>(expStack_);
       break;
     case (kMin):
-      funExp.reset(new ExpressionBinaryOperator<min_f>(expStack_));
+      funExp = std::make_shared<ExpressionBinaryOperator<min_f>>(expStack_);
       break;
     case (kPow):
-      funExp.reset(new ExpressionBinaryOperator<pow_f>(expStack_));
+      funExp = std::make_shared<ExpressionBinaryOperator<pow_f>>(expStack_);
       break;
     case (kSin):
-      funExp.reset(new ExpressionUnaryOperator<sin_f>(expStack_));
+      funExp = std::make_shared<ExpressionUnaryOperator<sin_f>>(expStack_);
       break;
     case (kSinh):
-      funExp.reset(new ExpressionUnaryOperator<sinh_f>(expStack_));
+      funExp = std::make_shared<ExpressionUnaryOperator<sinh_f>>(expStack_);
       break;
     case (kSqrt):
-      funExp.reset(new ExpressionUnaryOperator<sqrt_f>(expStack_));
+      funExp = std::make_shared<ExpressionUnaryOperator<sqrt_f>>(expStack_);
       break;
     case (kTan):
-      funExp.reset(new ExpressionUnaryOperator<tan_f>(expStack_));
+      funExp = std::make_shared<ExpressionUnaryOperator<tan_f>>(expStack_);
       break;
     case (kTanh):
-      funExp.reset(new ExpressionUnaryOperator<tanh_f>(expStack_));
+      funExp = std::make_shared<ExpressionUnaryOperator<tanh_f>>(expStack_);
       break;
     case (kTestBit):
-      funExp.reset(new ExpressionBinaryOperator<test_bit_f>(expStack_));
+      funExp = std::make_shared<ExpressionBinaryOperator<test_bit_f>>(expStack_);
       break;
   };
   expStack_.push_back(funExp);

--- a/CommonTools/Utils/src/TFileDirectory.cc
+++ b/CommonTools/Utils/src/TFileDirectory.cc
@@ -16,9 +16,9 @@ bool TFileDirectory::cd() const {
 
 TDirectory *TFileDirectory::_cd(const string &subdir, bool createNeededDirectories) const {
   string fpath = fullPath();
-  if (subdir.length()) {
+  if (!subdir.empty()) {
     // not empty, we need to append it to path
-    if (fpath.length()) {
+    if (!fpath.empty()) {
       // path is also not empty, so add a slash and let's get going.
       fpath += "/" + subdir;
     } else {
@@ -50,7 +50,7 @@ TDirectory *TFileDirectory::_cd(const string &subdir, bool createNeededDirectori
     // already exist (since you shoudln't be cd'ing into a directory
     // before making it and the cd with a subdir is only used to get
     // histograms that are already made).
-    if (subdir.length()) {
+    if (!subdir.empty()) {
       throw cms::Exception("InvalidDirectory") << "directory " << fpath << " doesn't exist.";
     }
     // if we're here, then that means that this is the first time
@@ -98,7 +98,7 @@ TObject *TFileDirectory::_getObj(const string &objname, const string &subdir) co
   TObject *objPtr = getBareDirectory(subdir)->Get(objname.c_str());
   if (!objPtr) {
     // no histogram found by that name.  Sorry dude.
-    if (subdir.length()) {
+    if (!subdir.empty()) {
       throw cms::Exception("ObjectNotFound") << "Can not find object named " << objname << " in subdir " << subdir;
     } else {
       throw cms::Exception("ObjectNotFound") << "Can not find object named " << objname;

--- a/DataFormats/Math/interface/private/AVXVec.h
+++ b/DataFormats/Math/interface/private/AVXVec.h
@@ -134,22 +134,22 @@ inline mathSSE::Vec4<double> operator/(mathSSE::Vec4<double> b, double a) {
   return _mm256_div_pd(b.vec, _mm256_set1_pd(a));
 }
 
-inline double __attribute__((always_inline)) __attribute__((pure))
-dot(mathSSE::Vec4<double> a, mathSSE::Vec4<double> b) {
+inline double __attribute__((always_inline)) __attribute__((pure)) dot(mathSSE::Vec4<double> a,
+                                                                       mathSSE::Vec4<double> b) {
   using mathSSE::_mm256_dot_pd;
   mathSSE::Vec4<double> ret;
   ret.vec = _mm256_dot_pd(a.vec, b.vec);
   return ret.arr[0];
 }
 
-inline mathSSE::Vec4<double> __attribute__((always_inline)) __attribute__((pure))
-cross(mathSSE::Vec4<double> a, mathSSE::Vec4<double> b) {
+inline mathSSE::Vec4<double> __attribute__((always_inline)) __attribute__((pure)) cross(mathSSE::Vec4<double> a,
+                                                                                        mathSSE::Vec4<double> b) {
   using mathSSE::_mm256_cross_pd;
   return _mm256_cross_pd(a.vec, b.vec);
 }
 
-inline double __attribute__((always_inline)) __attribute__((pure))
-dotxy(mathSSE::Vec4<double> a, mathSSE::Vec4<double> b) {
+inline double __attribute__((always_inline)) __attribute__((pure)) dotxy(mathSSE::Vec4<double> a,
+                                                                         mathSSE::Vec4<double> b) {
   mathSSE::Vec4<double> mul = a * b;
   mul = hadd(mul, mul);
   return mul.arr[0];

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/SuperclusValueMapProducer.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/SuperclusValueMapProducer.cc
@@ -18,7 +18,7 @@
 class SuperclusValueMapProducer : public edm::stream::EDProducer<> {
 public:
   explicit SuperclusValueMapProducer(const edm::ParameterSet&);
-  ~SuperclusValueMapProducer() = default;
+  ~SuperclusValueMapProducer() override = default;
 
 private:
   void produce(edm::Event&, const edm::EventSetup&) override;
@@ -108,6 +108,7 @@ std::vector<edm::EDGetTokenT<pat::PackedCandidateCollection>> SuperclusValueMapP
     const std::vector<edm::InputTag>& tags) {
   std::vector<edm::EDGetTokenT<pat::PackedCandidateCollection>> out;
 
+  out.reserve(tags.size());
   for (const auto& tag : tags)
     out.push_back(consumes<pat::PackedCandidateCollection>(tag));
 

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonXGBoostProducer.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonXGBoostProducer.cc
@@ -20,7 +20,7 @@
 class PhotonXGBoostProducer : public edm::global::EDProducer<> {
 public:
   explicit PhotonXGBoostProducer(edm::ParameterSet const&);
-  ~PhotonXGBoostProducer() = default;
+  ~PhotonXGBoostProducer() override = default;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 

--- a/RecoJets/JetAlgorithms/src/CMSBoostedTauSeedingAlgorithm.cc
+++ b/RecoJets/JetAlgorithms/src/CMSBoostedTauSeedingAlgorithm.cc
@@ -64,7 +64,7 @@ FASTJET_BEGIN_NAMESPACE  // defined in fastjet/internal/base.hh
     if (!hasSubjets)
       return;
     std::string depth_and_idx_string_subjet1 = depth_and_idx_string;
-    if (depth_and_idx_string_subjet1.length() > 0)
+    if (!depth_and_idx_string_subjet1.empty())
       depth_and_idx_string_subjet1.append(".");
     depth_and_idx_string_subjet1.append("0");
     for (int iSpace = 0; iSpace < depth; ++iSpace) {
@@ -76,7 +76,7 @@ FASTJET_BEGIN_NAMESPACE  // defined in fastjet/internal/base.hh
               << " (constituents = " << subjet1.constituents().size() << ")" << std::endl;
     dumpSubJetStructure(subjet1, depth + 1, maxDepth, depth_and_idx_string_subjet1);
     std::string depth_and_idx_string_subjet2 = depth_and_idx_string;
-    if (depth_and_idx_string_subjet2.length() > 0)
+    if (!depth_and_idx_string_subjet2.empty())
       depth_and_idx_string_subjet2.append(".");
     depth_and_idx_string_subjet2.append("1");
     for (int iSpace = 0; iSpace < depth; ++iSpace) {

--- a/RecoJets/JetProducers/plugins/ECFAdder.cc
+++ b/RecoJets/JetProducers/plugins/ECFAdder.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "RecoJets/JetProducers/interface/ECFAdder.h"
 #include "fastjet/PseudoJet.hh"
 #include "fastjet/ClusterSequence.hh"
@@ -28,23 +30,27 @@ ECFAdder::ECFAdder(const edm::ParameterSet& iConfig)
 
     if (ecftype_ == "ECF" || ecftype_.empty()) {
       ecfN_str << "ecf" << *n;
-      pfunc.reset(new fastjet::contrib::EnergyCorrelator(*n, beta_, fastjet::contrib::EnergyCorrelator::pt_R));
+      pfunc = std::make_shared<fastjet::contrib::EnergyCorrelator>(*n, beta_, fastjet::contrib::EnergyCorrelator::pt_R);
     } else if (ecftype_ == "C") {
       ecfN_str << "ecfC" << *n;
-      pfunc.reset(new fastjet::contrib::EnergyCorrelatorCseries(*n, beta_, fastjet::contrib::EnergyCorrelator::pt_R));
+      pfunc = std::make_shared<fastjet::contrib::EnergyCorrelatorCseries>(
+          *n, beta_, fastjet::contrib::EnergyCorrelator::pt_R);
     } else if (ecftype_ == "D") {
       ecfN_str << "ecfD" << *n;
-      pfunc.reset(
-          new fastjet::contrib::EnergyCorrelatorGeneralizedD2(alpha_, beta_, fastjet::contrib::EnergyCorrelator::pt_R));
+      pfunc = std::make_shared<fastjet::contrib::EnergyCorrelatorGeneralizedD2>(
+          alpha_, beta_, fastjet::contrib::EnergyCorrelator::pt_R);
     } else if (ecftype_ == "N") {
       ecfN_str << "ecfN" << *n;
-      pfunc.reset(new fastjet::contrib::EnergyCorrelatorNseries(*n, beta_, fastjet::contrib::EnergyCorrelator::pt_R));
+      pfunc = std::make_shared<fastjet::contrib::EnergyCorrelatorNseries>(
+          *n, beta_, fastjet::contrib::EnergyCorrelator::pt_R);
     } else if (ecftype_ == "M") {
       ecfN_str << "ecfM" << *n;
-      pfunc.reset(new fastjet::contrib::EnergyCorrelatorMseries(*n, beta_, fastjet::contrib::EnergyCorrelator::pt_R));
+      pfunc = std::make_shared<fastjet::contrib::EnergyCorrelatorMseries>(
+          *n, beta_, fastjet::contrib::EnergyCorrelator::pt_R);
     } else if (ecftype_ == "U") {
       ecfN_str << "ecfU" << *n;
-      pfunc.reset(new fastjet::contrib::EnergyCorrelatorUseries(*n, beta_, fastjet::contrib::EnergyCorrelator::pt_R));
+      pfunc = std::make_shared<fastjet::contrib::EnergyCorrelatorUseries>(
+          *n, beta_, fastjet::contrib::EnergyCorrelator::pt_R);
     }
     variables_.push_back(ecfN_str.str());
     produces<edm::ValueMap<float>>(ecfN_str.str());

--- a/RecoLocalMuon/RPCRecHit/plugins/DTSegtoRPC.cc
+++ b/RecoLocalMuon/RPCRecHit/plugins/DTSegtoRPC.cc
@@ -278,7 +278,7 @@ std::unique_ptr<RPCRecHitCollection> DTSegtoRPC::thePoints(const DTRecSegment4DC
             if (debug)
               LogDebug("DTSegtoRPC") << "DT \t \t \t No, Exrtrapolation too long!, canceled" << std::endl;
           }  //D so big
-        }    //loop over all the rolls asociated
+        }  //loop over all the rolls asociated
       }
     }
 

--- a/RecoLuminosity/LumiProducer/plugins/Lumi2DB.cc
+++ b/RecoLuminosity/LumiProducer/plugins/Lumi2DB.cc
@@ -680,7 +680,7 @@ void lumi::Lumi2DB::cleanTemporaryMemory(lumi::Lumi2DB::LumiResult::iterator lum
 lumi::Lumi2DB::Lumi2DB(const std::string& dest) : DataPipe(dest) {}
 void lumi::Lumi2DB::parseSourceString(lumi::Lumi2DB::LumiSource& result) const {
   //parse lumi source file name
-  if (m_source.length() == 0)
+  if (m_source.empty())
     throw lumi::Exception("lumi source is not set", "parseSourceString", "Lumi2DB");
   //std::cout<<"source "<<m_source<<std::endl;
   size_t tempIndex = m_source.find_last_of('.');

--- a/RecoLuminosity/LumiProducer/plugins/LumiCorrectionSource.cc
+++ b/RecoLuminosity/LumiProducer/plugins/LumiCorrectionSource.cc
@@ -147,7 +147,7 @@ std::string LumiCorrectionSource::translateFrontierConnect(const std::string& co
   if ((!servlet.empty()) && (servlet.find_first_of(":/)[]") == std::string::npos)) {
     if (servlet == "cms_conditions_data")
       servlet = "";
-    if (m_siteconfpath.length() == 0) {
+    if (m_siteconfpath.empty()) {
       std::string url = (std::filesystem::path("SITECONF") / std::filesystem::path("local") /
                          std::filesystem::path("JobConfig") / std::filesystem::path("site-local-config.xml"))
                             .string();

--- a/RecoLuminosity/LumiProducer/plugins/LumiProducer.cc
+++ b/RecoLuminosity/LumiProducer/plugins/LumiProducer.cc
@@ -253,7 +253,7 @@ LumiProducer::LumiProducer::LumiProducer(const edm::ParameterSet& iConfig)
         servlet = "";
 
       std::string siteconfpath = iConfig.getUntrackedParameter<std::string>("siteconfpath", "");
-      if (siteconfpath.length() == 0) {
+      if (siteconfpath.empty()) {
         std::string url = (std::filesystem::path("SITECONF") / std::filesystem::path("local") /
                            std::filesystem::path("JobConfig") / std::filesystem::path("site-local-config.xml"))
                               .string();

--- a/RecoMET/METFilters/plugins/MultiEventFilter.cc
+++ b/RecoMET/METFilters/plugins/MultiEventFilter.cc
@@ -36,7 +36,7 @@ MultiEventFilter::MultiEventFilter(const edm::ParameterSet& iConfig)
     : eventList_(iConfig.getParameter<std::vector<std::string> >("EventList")),
       taggingMode_(iConfig.getParameter<bool>("taggingMode")) {
   edm::FileInPath fp = iConfig.getParameter<edm::FileInPath>("file");
-  std::string fFile = fp.fullPath();
+  const std::string& fFile = fp.fullPath();
   std::ifstream inStream(fFile.c_str());
 
   for (unsigned int i = 0; i < eventList_.size(); ++i) {

--- a/RecoMuon/TrackerSeedGenerator/plugins/MuonHLTSeedMVAClassifierPhase2.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/MuonHLTSeedMVAClassifierPhase2.cc
@@ -155,11 +155,11 @@ void MuonHLTSeedMVAClassifierPhase2::produce(edm::Event& iEvent, const edm::Even
     return;
   }
 
-  if (h_L1TkMu->size() == 0 or h_Seed->size() == 0) {
-    if (h_Seed->size() != 0) {
+  if (h_L1TkMu->empty() or h_Seed->empty()) {
+    if (!h_Seed->empty()) {
       edm::LogInfo("SeedClassifierError") << "Empty L1TkMu collection" << '\n';
     }
-    if (h_L1TkMu->size() != 0) {
+    if (!h_L1TkMu->empty()) {
       edm::LogInfo("SeedClassifierError") << "Empty Muon Pixel seeds collection" << '\n';
     } else {
       edm::LogInfo("SeedClassifierError") << "Empty L1TkMu and Muon Pixel seeds collections" << '\n';

--- a/RecoMuon/TrackingTools/src/MuonErrorMatrix.cc
+++ b/RecoMuon/TrackingTools/src/MuonErrorMatrix.cc
@@ -120,7 +120,7 @@ MuonErrorMatrix::MuonErrorMatrix(const edm::ParameterSet &iConfig) : theD(nullpt
     if (!madeFromCff) {
       edm::LogInfo(theCategory) << "using an error matrix object from: " << fileName;
       edm::FileInPath data(fileName);
-      std::string fullpath = data.fullPath();
+      const std::string &fullpath = data.fullPath();
       gROOT->cd();
       theD = new TFile(fullpath.c_str());
       theD->SetWritable(false);

--- a/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <array>
+#include <memory>
 
 #include "GroupedCkfTrajectoryBuilder.h"
 #include "TrajectorySegmentBuilder.h"
@@ -230,7 +231,7 @@ void GroupedCkfTrajectoryBuilder::rebuildTrajectories(const TrajectorySeed& seed
   // better the seed to be always the same...
   std::shared_ptr<const TrajectorySeed> sharedSeed;
   if (result.empty())
-    sharedSeed.reset(new TrajectorySeed(seed));
+    sharedSeed = std::make_shared<TrajectorySeed>(seed);
   else
     sharedSeed = result.front().sharedSeed();
 

--- a/RecoTracker/CkfPattern/src/CkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/src/CkfTrajectoryBuilder.cc
@@ -118,7 +118,7 @@ unsigned int CkfTrajectoryBuilder::limitedCandidates(const std::shared_ptr<const
 
   while (!candidates.empty()) {
     newCand.clear();
-    bool full = 0;
+    bool full = false;
     for (auto traj = candidates.begin(); traj != candidates.end(); traj++) {
       std::vector<TM> meas;
       findCompatibleMeasurements(*sharedSeed, *traj, meas);

--- a/RecoTracker/NuclearSeedGenerator/src/SeedFromNuclearInteraction.cc
+++ b/RecoTracker/NuclearSeedGenerator/src/SeedFromNuclearInteraction.cc
@@ -35,7 +35,7 @@ void SeedFromNuclearInteraction::setMeasurements(const TSOS& inner_TSOS,
   //theHits.push_back(  inner_TM.recHit() ); // put temporarily - TODO: remove this line
   theHits.push_back(outerHit_);
 
-  initialTSOS_.reset(new TrajectoryStateOnSurface(inner_TSOS));
+  initialTSOS_ = std::make_shared<TrajectoryStateOnSurface>(inner_TSOS);
 
   // calculate the initial FreeTrajectoryState.
   freeTS_.reset(stateWithError());
@@ -70,7 +70,7 @@ void SeedFromNuclearInteraction::setMeasurements(TangentHelix& thePrimaryHelix,
   theHits.push_back(innerHit_);
   theHits.push_back(outerHit_);
 
-  initialTSOS_.reset(new TrajectoryStateOnSurface(inner_TSOS));
+  initialTSOS_ = std::make_shared<TrajectoryStateOnSurface>(inner_TSOS);
 
   // calculate the initial FreeTrajectoryState from the inner and outer TM assuming that the helix equation is already known.
   freeTS_.reset(stateWithError(helix));
@@ -149,7 +149,7 @@ bool SeedFromNuclearInteraction::construct() {
       return false;
 
     const TransientTrackingRecHit::ConstRecHitPointer& tth = theHits[iHit];
-    updatedTSOS_.reset(new TrajectoryStateOnSurface(theUpdator.update(state, *tth)));
+    updatedTSOS_ = std::make_shared<TrajectoryStateOnSurface>(theUpdator.update(state, *tth));
   }
 
   LogDebug("NuclearSeedGenerator") << "Seed ** updated state " << updatedTSOS_->cartesianError().matrix();

--- a/TrackingTools/TrajectoryParametrization/src/LocalTrajectoryError.cc
+++ b/TrackingTools/TrajectoryParametrization/src/LocalTrajectoryError.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "TrackingTools/TrajectoryParametrization/interface/LocalTrajectoryError.h"
 #include "DataFormats/Math/interface/invertPosDefMatrix.h"
 #include "FWCore/Utilities/interface/Likely.h"
@@ -13,7 +15,7 @@ LocalTrajectoryError::LocalTrajectoryError(float dx, float dy, float dxdir, floa
 
 const AlgebraicSymMatrix55& LocalTrajectoryError::weightMatrix() const {
   if UNLIKELY (theWeightMatrixPtr.get() == nullptr) {
-    theWeightMatrixPtr.reset(new AlgebraicSymMatrix55());
+    theWeightMatrixPtr = std::make_shared<AlgebraicSymMatrix55>();
     invertPosDefMatrix(theCovarianceMatrix, *theWeightMatrixPtr);
   }
   return *theWeightMatrixPtr;


### PR DESCRIPTION
PGO changes ( e.g. using relative source path instead of full path ) broke `scram build code-checks` rule. So it has not been running properly on PR. `code-format` was working but only `code-checks` i.e. `clang-tidy` did not work as it required correct `compiler_command.json` with correct source file paths.

Build rules are fixed now, so this PR applies `code-checks` ( and format) for those files which were merged with proper code-checks