### PR TITLE
[DB-HLT] Apply code checks/format

### DIFF
--- a/CondCore/HLTPlugins/plugins/AlCaRecoTriggerBits_PayloadInspector.cc
+++ b/CondCore/HLTPlugins/plugins/AlCaRecoTriggerBits_PayloadInspector.cc
@@ -347,7 +347,7 @@ namespace {
                 toAppend += not_in_last[iPath] + ";";
               }
               // if it's the last and not empty, dump it
-              if (toAppend.length() > 0 && iPath == not_in_last.size() - 1)
+              if (!toAppend.empty() && iPath == not_in_last.size() - 1)
                 output.push_back(toAppend);
             }
 
@@ -372,7 +372,7 @@ namespace {
                 toAppend += not_in_first[jPath] + ";";
               }
               // if it's the last and not empty, dump it
-              if (toAppend.length() > 0 && jPath == not_in_first.size() - 1)
+              if (!toAppend.empty() && jPath == not_in_first.size() - 1)
                 output.push_back(toAppend);
             }
 


### PR DESCRIPTION
PGO changes ( e.g. using relative source path instead of full path ) broke `scram build code-checks` rule. So it has not been running properly on PR. `code-format` was working but only `code-checks` i.e. `clang-tidy` did not work as it required correct `compiler_command.json` with correct source file paths.

Build rules are fixed now, so this PR applies `code-checks` ( and format) for those files which were merged with proper code-checks