### PR TITLE
[DB-L1] Apply code checks/format

### DIFF
--- a/CondCore/L1TPlugins/plugins/L1TMuonGlobalParams_PayloadInspector.cc
+++ b/CondCore/L1TPlugins/plugins/L1TMuonGlobalParams_PayloadInspector.cc
@@ -72,7 +72,7 @@ namespace {
         leg.SetLineColor(0);
         leg.SetFillColor(0);
 
-        input1.SetStats(0);
+        input1.SetStats(false);
         input1.SetMaximum(5);
         input1.SetXTitle("InputBits");
         input1.SetYTitle("Bit value");


### PR DESCRIPTION
PGO changes ( e.g. using relative source path instead of full path ) broke `scram build code-checks` rule. So it has not been running properly on PR. `code-format` was working but only `code-checks` i.e. `clang-tidy` did not work as it required correct `compiler_command.json` with correct source file paths.

Build rules are fixed now, so this PR applies `code-checks` ( and format) for those files which were merged with proper code-checks