### PR TITLE
[ALCA-DB] Apply code checks/format

### DIFF
--- a/Alignment/CocoaUtilities/src/ALIFileIn.cc
+++ b/Alignment/CocoaUtilities/src/ALIFileIn.cc
@@ -128,9 +128,9 @@ ALIint ALIFileIn::getWordsInLine(std::vector<ALIstring>& wordlist) {
         }
       }
       tt++;
-    } while (*tt != '\0' && stemp.length() != 0);
+    } while (*tt != '\0' && !stemp.empty());
     ALIstring stempt(ltemp);
-    if (stempt.length() == 0)
+    if (stempt.empty())
       NoWords = 0;
 
     //--------- Read words from istr_line and write them into wordlist
@@ -138,7 +138,7 @@ ALIint ALIFileIn::getWordsInLine(std::vector<ALIstring>& wordlist) {
     for (ii = 0; ii < NoWords; ii++) {
       ALIstring stemp = "";
       istr_line >> stemp;  //?? gives warning in Insure++
-      if (stemp.length() == 0)
+      if (stemp.empty())
         break;
       ALIint comment = stemp.find(ALIstring("//"));
       //    std::cout << "!!!COMMENT" << comment << stemp.c_str() << std::endl;

--- a/Alignment/CommonAlignment/src/AlignableModifier.cc
+++ b/Alignment/CommonAlignment/src/AlignableModifier.cc
@@ -174,7 +174,7 @@ bool AlignableModifier::modify(Alignable* alignable, const edm::ParameterSet& pS
                                           << "with 's' or a digit at the end.\n";
       }  // other PSets should now be hierarchy levels and thus be OK to ignore here
     } else {
-      if (!error.str().length())
+      if (error.str().empty())
         error << "Unknown parameter name(s): ";
       error << " " << *iParam;
     }
@@ -189,7 +189,7 @@ bool AlignableModifier::modify(Alignable* alignable, const edm::ParameterSet& pS
     throw cms::Exception("BadConfig") << "Found both localZ and phiZlocal";
 
   // Check error
-  if (error.str().length())
+  if (!error.str().empty())
     throw cms::Exception("BadConfig") << error.str();
 
   // Decode distribution

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
@@ -396,7 +396,7 @@ void MillePedeAlignmentAlgorithm::terminate() {
     std::string filesForLogOutput;
     for (const auto &file : files)
       filesForLogOutput += " " + file + ",";
-    if (filesForLogOutput.length() != 0)
+    if (!filesForLogOutput.empty())
       filesForLogOutput.pop_back();
     edm::LogInfo("Alignment") << "Based on the config parameter mergeBinaryFiles, using the following "
                               << "files as input (assigned weights are indicated by ' -- <weight>'):"

--- a/Alignment/MuonAlignment/src/MuonScenarioBuilder.cc
+++ b/Alignment/MuonAlignment/src/MuonScenarioBuilder.cc
@@ -89,7 +89,7 @@ align::Scalars MuonScenarioBuilder::extractParameters(const edm::ParameterSet& p
     else if ((*iParam) == "dZ")
       dZ_ = Parameters.getParameter<double>(*iParam);
     else if (Parameters.retrieve(*iParam).typeCode() != 'P') {  // Add unknown parameter to list
-      if (!error.str().length())
+      if (error.str().empty())
         error << "Unknown parameter name(s): ";
       error << " " << *iParam;
     }

--- a/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
+++ b/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
@@ -169,8 +169,8 @@ private:
                      const std::string& basedir,
                      bool useDqmMode)
         : tfd(nullptr), dqmMode(useDqmMode), theDbe(nullptr) {
-      if (newDir.length() != 0) {
-        if (upDir.directoryString.length() != 0)
+      if (!newDir.empty()) {
+        if (!upDir.directoryString.empty())
           directoryString = upDir.directoryString + "/" + newDir;
         else
           directoryString = newDir;
@@ -178,7 +178,7 @@ private:
         directoryString = upDir.directoryString;
 
       if (!dqmMode) {
-        if (newDir.length() == 0)
+        if (newDir.empty())
           tfd.reset(&(*upDir.tfd));
         else
           tfd = std::make_unique<TFileDirectory>(upDir.tfd->mkdir(newDir));
@@ -191,15 +191,15 @@ private:
         : tfd(nullptr), dqmMode(useDqmMode), theDbe(nullptr) {
       if (!dqmMode) {
         edm::Service<TFileService> fs;
-        if (newDir.length() == 0) {
+        if (newDir.empty()) {
           tfd = std::make_unique<TFileDirectory>(fs->tFileDirectory());
         } else {
           tfd = std::make_unique<TFileDirectory>(fs->mkdir(newDir));
           directoryString = newDir;
         }
       } else {
-        if (newDir.length() != 0) {
-          if (basedir.length() != 0)
+        if (!newDir.empty()) {
+          if (!basedir.empty())
             directoryString = basedir + "/" + newDir;
           else
             directoryString = newDir;

--- a/Alignment/OfflineValidation/plugins/TrackerOfflineValidationSummary.cc
+++ b/Alignment/OfflineValidation/plugins/TrackerOfflineValidationSummary.cc
@@ -504,7 +504,7 @@ const std::string TrackerOfflineValidationSummary::associateModuleHistsWithTree(
     std::map<std::string, std::string>& substructureName) {
   std::stringstream histDir, sSubdetName;
   std::string componentName;
-  if (moduleDirectory_.length() != 0)
+  if (!moduleDirectory_.empty())
     histDir << moduleDirectory_ << "/";
   std::string wheelOrLayer("_layer_");
   if (treeMem.subDetId == PixelSubdetector::PixelBarrel) {
@@ -770,7 +770,7 @@ void TrackerOfflineValidationSummary::applyHarvestingHierarchy(TTree& tree) {
                                             iSubdet == StripSubdetector::TID || iSubdet == StripSubdetector::TEC))
             continue;
           treeEntries.push_back(iTree);
-          if (hierarchyName.length() == 0) {
+          if (hierarchyName.empty()) {
             hierarchyName = (*substructureName)["subdet"];
             componentName = (*substructureName)["component"];
           }
@@ -804,7 +804,7 @@ void TrackerOfflineValidationSummary::bookHarvestingHists() {
     dmrYprimeHistoTitle << "DMR for " << iHier->hierarchyName << ";<#DeltaY> [cm];# modules";
 
     std::string directoryString(moduleDirectory_);
-    if (directoryString.length() != 0)
+    if (!directoryString.empty())
       directoryString += "/";
     directoryString += iHier->componentName;
     dbe_->setCurrentFolder(directoryString);

--- a/CalibPPS/AlignmentRelative/plugins/PPSModifySingularModes.cc
+++ b/CalibPPS/AlignmentRelative/plugins/PPSModifySingularModes.cc
@@ -60,7 +60,7 @@ void PPSModifySingularModes::beginRun(edm::Run const &, edm::EventSetup const &e
   const double de_rho2 = ps_.getUntrackedParameter<double>("de_rho2");
 
   FileInPath inputFileInPath(ps_.getUntrackedParameter<string>("inputFile"));
-  const string inputFile = inputFileInPath.fullPath();
+  const string &inputFile = inputFileInPath.fullPath();
   const string outputFile = ps_.getUntrackedParameter<string>("outputFile");
 
   // validate config parameters

--- a/CalibTracker/SiStripChannelGain/src/APVGainHelpers.cc
+++ b/CalibTracker/SiStripChannelGain/src/APVGainHelpers.cc
@@ -225,7 +225,7 @@ std::vector<std::pair<std::string, std::string>> APVGain::monHnames(std::vector<
   out.reserve(re);
 
   std::string Tag = tag;
-  if (Tag.length())
+  if (!Tag.empty())
     Tag = "__" + Tag;
 
   std::string h_tag = "";

--- a/CaloOnlineTools/HcalOnlineDb/src/RooGKCounter.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/RooGKCounter.cc
@@ -14,7 +14,7 @@ RooGKCounter::RooGKCounter() { init(); }
 RooGKCounter::RooGKCounter(const char *message) {
   init();
   _message = message;
-  if (_message.length() == 0)
+  if (_message.empty())
     printCount = false;
 }
 

--- a/CondCore/CondDB/src/Binary.cc
+++ b/CondCore/CondDB/src/Binary.cc
@@ -5,8 +5,9 @@
 //
 #include <cstring>
 
-#include <openssl/sha.h>
 #include <cstring>
+#include <memory>
+#include <openssl/sha.h>
 
 cond::Binary::Binary() : m_data(new coral::Blob(0)) {}
 
@@ -30,7 +31,7 @@ cond::Binary& cond::Binary::operator=(const Binary& rhs) {
 const coral::Blob& cond::Binary::get() const { return *m_data; }
 
 void cond::Binary::copy(const std::string& source) {
-  m_data.reset(new coral::Blob(source.size()));
+  m_data = std::make_shared<coral::Blob>(source.size());
   ::memcpy(m_data->startingAddress(), source.c_str(), source.size());
 }
 

--- a/CondCore/CondDB/src/CoralMsgReporter.cc
+++ b/CondCore/CondDB/src/CoralMsgReporter.cc
@@ -2,6 +2,7 @@
 #include <cstdio>
 #include <cstring>   // fix bug #58581
 #include <iostream>  // fix bug #58581
+#include <memory>
 
 // Local include files
 #include "CondCore/CondDB/interface/Logger.h"
@@ -142,7 +143,7 @@ void cond::persistency::CoralMsgReporter::report(int lvl, const std::string&, co
 }
 
 void cond::persistency::CoralMsgReporter::subscribe(Logger& logger) {
-  m_dispatcher.reset(new MsgDispatcher(logger));
+  m_dispatcher = std::make_shared<MsgDispatcher>(logger);
   std::weak_ptr<MsgDispatcher> callBack(m_dispatcher);
   logger.subscribeCoralMessages(callBack);
 }

--- a/CondCore/CondDB/src/PayloadReader.cc
+++ b/CondCore/CondDB/src/PayloadReader.cc
@@ -1,10 +1,12 @@
+#include <memory>
+
 #include "CondCore/CondDB/interface/PayloadReader.h"
 
 namespace cond {
 
   namespace persistency {
 
-    PayloadReader::PayloadReader() { m_connection.reset(new ConnectionPool); }
+    PayloadReader::PayloadReader() { m_connection = std::make_shared<ConnectionPool>(); }
 
     PayloadReader::PayloadReader(const PayloadReader& rhs) : m_connection(rhs.m_connection), m_session(rhs.m_session) {}
 

--- a/CondCore/Utilities/bin/conddb_test_gt_load.cpp
+++ b/CondCore/Utilities/bin/conddb_test_gt_load.cpp
@@ -6,6 +6,7 @@
 #include <iostream>
 
 #include <chrono>
+#include <memory>
 
 // ================================================================================
 
@@ -156,7 +157,7 @@ namespace cond {
 }  // namespace cond
 
 cond::UntypedPayloadProxy::UntypedPayloadProxy(Session& session) : m_session(session) {
-  m_data.reset(new pimpl);
+  m_data = std::make_shared<pimpl>();
   m_data->current.clear();
 }
 

--- a/CondCore/Utilities/bin/conddb_test_gt_perf.cpp
+++ b/CondCore/Utilities/bin/conddb_test_gt_perf.cpp
@@ -115,7 +115,7 @@ cond::Session cond::ConnectionPoolWrapper::createSession(const std::string& conn
 }
 
 cond::UntypedPayloadProxy::UntypedPayloadProxy() : m_session(), m_iov(), m_data(), m_buffer() {
-  m_data.reset(new pimpl);
+  m_data = std::make_shared<pimpl>();
   m_data->current.clear();
 }
 

--- a/CondCore/Utilities/src/Utilities.cc
+++ b/CondCore/Utilities/src/Utilities.cc
@@ -42,7 +42,7 @@ namespace cond {
 
     while ((ch = getch()) != RETURN) {
       if (ch == BACKSPACE) {
-        if (password.length() != 0) {
+        if (!password.empty()) {
           if (show_asterisk)
             std::cout << "\b \b";
           password.resize(password.length() - 1);

--- a/CondFormats/JetMETObjects/src/FactorizedJetCorrectorCalculator.cc
+++ b/CondFormats/JetMETObjects/src/FactorizedJetCorrectorCalculator.cc
@@ -118,15 +118,15 @@ void FactorizedJetCorrectorCalculator::initCorrectors(const std::string& fLevels
     if (mLevels[i] == kL1 || mLevels[i] == kL1JPT || mLevels[i] == kL2 || mLevels[i] == kL3 || mLevels[i] == kL4 ||
         mLevels[i] == kL6 || mLevels[i] == kL1fj)
       mCorrectors.push_back(new SimpleJetCorrector(Files[i]));
-    else if (mLevels[i] == kL5 && FlavorOption.length() == 0)
+    else if (mLevels[i] == kL5 && FlavorOption.empty())
       handleError("FactorizedJetCorrectorCalculator",
                   "must specify flavor option when requesting L5Flavor correction!");
-    else if (mLevels[i] == kL5 && FlavorOption.length() > 0)
+    else if (mLevels[i] == kL5 && !FlavorOption.empty())
       mCorrectors.push_back(new SimpleJetCorrector(Files[i], FlavorOption));
-    else if (mLevels[i] == kL7 && PartonOption.length() == 0)
+    else if (mLevels[i] == kL7 && PartonOption.empty())
       handleError("FactorizedJetCorrectorCalculator",
                   "must specify parton option when requesting L7Parton correction!");
-    else if (mLevels[i] == kL7 && PartonOption.length() > 0)
+    else if (mLevels[i] == kL7 && !PartonOption.empty())
       mCorrectors.push_back(new SimpleJetCorrector(Files[i], PartonOption));
     else {
       std::stringstream sserr;

--- a/CondFormats/JetMETObjects/src/SimpleJetCorrectionUncertainty.cc
+++ b/CondFormats/JetMETObjects/src/SimpleJetCorrectionUncertainty.cc
@@ -54,7 +54,7 @@ float SimpleJetCorrectionUncertainty::uncertaintyBin(unsigned fBin, float fY, bo
     return -999.0;
   }
   const std::vector<float>& p = mParameters.record(fBin).parameters();
-  if ((p.size() % 3) != 0 or p.size() == 0)
+  if ((p.size() % 3) != 0 or p.empty())
     throw cms::Exception("SimpleJetCorrectionUncertainty")
         << "wrong # of parameters: multiple of 3 expected, " << p.size() << " got";
   Span3 yGrid{p};

--- a/MuonAnalysis/MomentumScaleCalibration/plugins/DBReader.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/plugins/DBReader.cc
@@ -1,6 +1,7 @@
 // system include files
 #include <cstdio>
 #include <iostream>
+#include <memory>
 #include <string>
 #include <sys/time.h>
 #include <vector>
@@ -71,11 +72,11 @@ void DBReader::initialize(const edm::EventSetup& iSetup) {
   // This string is one of: scale, resolution, background.
   // Create the corrector and set the parameters
   if (type_ == "scale")
-    corrector_.reset(new MomentumScaleCorrector(dbObject));
+    corrector_ = std::make_shared<MomentumScaleCorrector>(dbObject);
   else if (type_ == "resolution")
-    resolution_.reset(new ResolutionFunction(dbObject));
+    resolution_ = std::make_shared<ResolutionFunction>(dbObject);
   else if (type_ == "background")
-    background_.reset(new BackgroundFunction(dbObject));
+    background_ = std::make_shared<BackgroundFunction>(dbObject);
   else {
     edm::LogPrint("DBReader") << "Error: unrecognized type. Use one of those: 'scale', 'resolution', 'background'"
                               << std::endl;

--- a/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitMuonProducer.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitMuonProducer.cc
@@ -104,7 +104,7 @@ void MuScleFitMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
   //std::cout << "parameters size from dbObject = " << dbObject_->parameters.size() << std::endl;;
 
   // Create the corrector and set the parameters
-  corrector_.reset(new MomentumScaleCorrector(dbObject_.product()));
+  corrector_ = std::make_shared<MomentumScaleCorrector>(dbObject_.product());
 
   if (patMuons_ == true) {
     edm::Handle<pat::MuonCollection> allMuons;

--- a/OnlineDB/EcalCondDB/bin/cmsecal_rootplot.cpp
+++ b/OnlineDB/EcalCondDB/bin/cmsecal_rootplot.cpp
@@ -744,7 +744,7 @@ int main(int argc, char* argv[]) {
     string line;
 
     ifstream* finput = (ifstream*)&cin;
-    if (file.length() > 0) {
+    if (!file.empty()) {
       finput = new ifstream(file.c_str());
     }
     while (getline(*finput, line) && finput->good() && !finput->eof()) {
@@ -757,7 +757,7 @@ int main(int argc, char* argv[]) {
 
     finput->close();
 
-    if (file.length() > 0) {
+    if (!file.empty()) {
       delete finput;
     }
     rootplot.draw();

--- a/OnlineDB/EcalCondDB/src/LMFDat.cc
+++ b/OnlineDB/EcalCondDB/src/LMFDat.cc
@@ -131,7 +131,7 @@ std::string LMFDat::buildSelectSql(int logic_id, int direction) {
   std::stringstream sql;
   int count = 1;
   if (getLMFRunIOVID() > 0) {
-    if (_where.length() > 0) {
+    if (!_where.empty()) {
       // check if this is an expert query. If so, add a WHERE clause
       _where = " AND " + _where;
     }

--- a/OnlineDB/EcalCondDB/src/LMFRunTag.cc
+++ b/OnlineDB/EcalCondDB/src/LMFRunTag.cc
@@ -79,7 +79,7 @@ bool LMFRunTag::isValid() {
   if (getVersion() <= 0) {
     ret = false;
   }
-  if (getGeneralTag().length() <= 0) {
+  if (getGeneralTag().empty()) {
     ret = false;
   }
   return ret;

--- a/OnlineDB/EcalCondDB/src/LMFSeqDat.cc
+++ b/OnlineDB/EcalCondDB/src/LMFSeqDat.cc
@@ -129,7 +129,7 @@ bool LMFSeqDat::isValid() const {
   if (getSequenceStart().isNull()) {
     ret = false;
   }
-  if ((getSequenceStop().str().length() > 0) && (getSequenceStop().microsTime() < getSequenceStart().microsTime())) {
+  if ((!getSequenceStop().str().empty()) && (getSequenceStop().microsTime() < getSequenceStart().microsTime())) {
     ret = false;
   }
   if (getSequenceStop() == Tm().plusInfinity()) {
@@ -147,7 +147,7 @@ std::string LMFSeqDat::writeDBSql(Statement *stmt) {
     throw(std::runtime_error("LMFSeqDat::writeDB: not valid"));
   }
 
-  if (getSequenceStop().str().length() == 0) {
+  if (getSequenceStop().str().empty()) {
     setSequenceStop(dh.getPlusInfTm());
   }
   int runIOVID = m_runIOV.getID();


### PR DESCRIPTION
PGO changes ( e.g. using relative source path instead of full path ) broke `scram build code-checks` rule. So it has not been running properly on PR. `code-format` was working but only `code-checks` i.e. `clang-tidy` did not work as it required correct `compiler_command.json` with correct source file paths.

Build rules are fixed now, so this PR applies `code-checks` ( and format) for those files which were merged with proper code-checks