### PR TITLE
[GEM] Allow storing 2025 geometry in GEMGeometryParsFromDD

### DIFF
--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.cc
@@ -371,7 +371,7 @@ void GEMGeometryBuilder::build(GEMGeometry& theGeometry,
     }
   }
 
-  bool demonstratorGeometry = nGE21 % 2 == 1;
+  bool demonstratorGeometry = (nGE21 < 8);
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("Geometry") << "Found " << nGE21 << " GE2/1 chambers. Demonstrator geometry on? "
                                << demonstratorGeometry;

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.cc
@@ -77,8 +77,9 @@ void GEMGeometryParsFromDD::buildGeometry(DDFilteredView& fv,
       fvGE2.parent();
       fvGE2.parent();
       // in 2021 we have 1 demonstrator chamber in 2024 we have 3 chambers.
+      // in 2025 we have 7 chambers.
       // Need to account for both
-      doSuper = (nGE21 < 4 && fvGE2.nextSibling());
+      doSuper = (nGE21 < 8 && fvGE2.nextSibling());
     } else {
       edm::LogError("GEMGeometryParsFromDD") << "Failed to find next child volume. Cannot determine presence of GE 2/1";
     }

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.cc
@@ -84,7 +84,7 @@ void GEMGeometryParsFromDD::buildGeometry(DDFilteredView& fv,
       edm::LogError("GEMGeometryParsFromDD") << "Failed to find next child volume. Cannot determine presence of GE 2/1";
     }
   }
-  bool demonstratorGeometry = nGE21 % 2 == 1;
+  bool demonstratorGeometry = (nGE21 < 8);
 
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("Geometry") << "Found " << nGE21 << " GE2/1 chambers. Demonstrator geometry on? "


### PR DESCRIPTION
#### PR description:

* The GEMGeometryParsFromDDD checks the number of GE21 chambers to decide if it works for Run 3 condition. If the number of chambers is in the range of Run 3 condition, it allows to dump the demonstrator chamber which has layer number 2 without layer 1.
* In the 2024, we had 3 installed GE21 chambers. So the range is set as less than 4.
* In the 2025, we are planning to install 4 more chambers, so we need to increase the range.
* The update only works when we create the GEMRecoGeometryRcd, we don't expect any changes in the test or central production.
* related PR : #44429 

#### PR validation:

* The geometry tag is created with the `CondTools/Geometry/test/gemgeometrywriter.py`, and we tested the geometry from the tag.
* Without this update, the created geometry tag does not include the GE21 demonstrator. However, after the update, we could dump the GE21 demonstrator in the `GEMRecoGeometryRcd`.

@watson-ij 