### PR TITLE
Adding UParT scores to offline HLT DQM

### DIFF
--- a/DQMOffline/Trigger/python/BTaggingMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/BTaggingMonitoring_Client_cff.py
@@ -60,6 +60,16 @@ BTVEfficiency_BTagMu_DiJet_DeepJet = DQMEDHarvester("DQMGenericClient",
     )    
 )
 
+BTVEfficiency_BTagMu_DiJet_UParT = DQMEDHarvester("DQMGenericClient",
+    subDirs        = cms.untracked.vstring("HLT/BTV/BTagMu_DiJet/*_UParTAK4"),
+    verbose        = cms.untracked.uint32(0),
+    resolution     = cms.vstring(),
+    efficiency     = cms.vstring(
+        "effic_bjetCSV_1     'efficiency vs 1st b-jet UParT score; UParT score; efficiency' bjetCSV_1_numerator  bjetCSV_1_denominator"
+    )
+)
+
+
 BTVEfficiency_BTagMu_Jet = DQMEDHarvester("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/BTV/BTagMu_Jet/*"),
     verbose        = cms.untracked.uint32(0),
@@ -108,6 +118,15 @@ BTVEfficiency_BTagMu_Jet_DeepJet = DQMEDHarvester("DQMGenericClient",
     resolution     = cms.vstring(),
     efficiency     = cms.vstring(
         "effic_bjetCSV_1     'efficiency vs 1st b-jet DeepJet score; DeepJet score; efficiency' bjetCSV_1_numerator  bjetCSV_1_denominator"
+    )
+)
+
+BTVEfficiency_BTagMu_Jet_UParT = DQMEDHarvester("DQMGenericClient",
+    subDirs        = cms.untracked.vstring("HLT/BTV/BTagMu_Jet/*_UParTAK4"),
+    verbose        = cms.untracked.uint32(0),
+    resolution     = cms.vstring(),
+    efficiency     = cms.vstring(
+        "effic_bjetCSV_1     'efficiency vs 1st b-jet UParT score;UParT score; efficiency' bjetCSV_1_numerator  bjetCSV_1_denominator"
     )
 )
 
@@ -170,6 +189,15 @@ BTVEfficiency_BTagDiMu_Jet_DeepJet = DQMEDHarvester("DQMGenericClient",
     )
 )
 
+BTVEfficiency_BTagDiMu_Jet_UParT = DQMEDHarvester("DQMGenericClient",
+    subDirs        = cms.untracked.vstring("HLT/BTV/BTagDiMu_Jet/*_UParTAK4"),
+    verbose        = cms.untracked.uint32(0),
+    resolution     = cms.vstring(),
+    efficiency     = cms.vstring(
+        "effic_bjetCSV_1     'efficiency vs 1st b-jet UParT score; UParT score; efficiency' bjetCSV_1_numerator  bjetCSV_1_denominator"
+    )
+)
+
 BTVEfficiency_PFJet = DQMEDHarvester("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/BTV/PFJet/*"),
     verbose        = cms.untracked.uint32(0),
@@ -209,6 +237,15 @@ BTVEfficiency_PFJet_DeepJet = DQMEDHarvester("DQMGenericClient",
     resolution     = cms.vstring(),
     efficiency     = cms.vstring(
         "effic_bjetCSV_1     'efficiency vs 1st b-jet DeepJet score; DeepJet score; efficiency' bjetCSV_1_numerator  bjetCSV_1_denominator"
+    )
+)
+
+BTVEfficiency_PFJet_UParT = DQMEDHarvester("DQMGenericClient",
+    subDirs        = cms.untracked.vstring("HLT/BTV/PFJet/*_UParTAK4"),
+    verbose        = cms.untracked.uint32(0),
+    resolution     = cms.vstring(),
+    efficiency     = cms.vstring(
+        "effic_bjetCSV_1     'efficiency vs 1st b-jet UParT score; UParT score; efficiency' bjetCSV_1_numerator  bjetCSV_1_denominator"
     )
 )
 
@@ -280,5 +317,9 @@ btaggingClient = cms.Sequence(
   + BTVEfficiency_BTagMu_Jet_DeepJet
   + BTVEfficiency_BTagDiMu_Jet_DeepJet
   + BTVEfficiency_PFJet_DeepJet
+  + BTVEfficiency_BTagMu_DiJet_UParT
+  + BTVEfficiency_BTagMu_Jet_UParT
+  + BTVEfficiency_BTagDiMu_Jet_UParT
+  + BTVEfficiency_PFJet_UParT    
   + BJetTrackToTrackEfficiencies
 )

--- a/DQMOffline/Trigger/python/BTaggingMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/BTaggingMonitoring_cff.py
@@ -28,6 +28,19 @@ BTagMu_AK4DiJet20_Mu5_DeepJet = hltBTVmonitoring.clone(
     histoPSet = dict(jetPtBinning = [0,10,15,20,30,50,70,100,150,200,400,700,1000,1500,3000])
 )
 
+BTagMu_AK4DiJet20_Mu5_UParT = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/BTagMu_DiJet/AK4DiJet20_Mu5_UParTAK4',
+    nmuons = 1,
+    nelectrons = 0,
+    njets = 2,
+    muoSelection = 'pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
+    jetSelection = 'pt>10 & abs(eta)<2.4',
+    bjetSelection = 'pt>5 & abs(eta)<2.4',
+    btagAlgos = ["pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll"],
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK4DiJet20_Mu5_v*']),
+    histoPSet = dict(jetPtBinning = [0,10,15,20,30,50,70,100,150,200,400,700,1000,1500,3000])
+)
+
 BTagMu_AK4DiJet40_Mu5 = hltBTVmonitoring.clone(
     FolderName = 'HLT/BTV/BTagMu_DiJet/BTagMu_AK4DiJet40_Mu5',
     nmuons = 1,
@@ -49,6 +62,19 @@ BTagMu_AK4DiJet40_Mu5_DeepJet = hltBTVmonitoring.clone(
     jetSelection = 'pt>30 & abs(eta)<2.4',
     bjetSelection = 'pt>20 & abs(eta)<2.4',
     btagAlgos = ["pfDeepFlavourJetTags:probb", "pfDeepFlavourJetTags:probbb","pfDeepFlavourJetTags:problepb"],
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK4DiJet40_Mu5_v*']),
+    histoPSet = dict(jetPtBinning = [0,30,40,50,70,100,150,200,400,700,1000,1500,3000])
+)
+
+BTagMu_AK4DiJet40_Mu5_UParT = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/BTagMu_DiJet/AK4DiJet40_Mu5_UParTAK4',
+    nmuons = 1,
+    nelectrons = 0,
+    njets = 2,
+    muoSelection = 'pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
+    jetSelection = 'pt>30 & abs(eta)<2.4',
+    bjetSelection = 'pt>20 & abs(eta)<2.4',
+    btagAlgos = ["pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll"],
     numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK4DiJet40_Mu5_v*']),
     histoPSet = dict(jetPtBinning = [0,30,40,50,70,100,150,200,400,700,1000,1500,3000])
 )
@@ -76,6 +102,18 @@ BTagMu_AK4DiJet70_Mu5_DeepJet = hltBTVmonitoring.clone(
     histoPSet = dict(jetPtBinning = [0,50,60,70,80,90,100,150,200,400,700,1000,1500,3000])
 )
 
+BTagMu_AK4DiJet70_Mu5_UParT = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/BTagMu_DiJet/AK4DiJet70_Mu5_UParTAK4',
+    nmuons = 1,
+    nelectrons = 0,
+    njets = 2,
+    muoSelection = 'pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
+    jetSelection = 'pt>50 & abs(eta)<2.4',
+    btagAlgos = ["pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll"],
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK4DiJet70_Mu5_v*']),
+    histoPSet = dict(jetPtBinning = [0,50,60,70,80,90,100,150,200,400,700,1000,1500,3000])
+)
+
 BTagMu_AK4DiJet110_Mu5 = hltBTVmonitoring.clone(
     FolderName = 'HLT/BTV/BTagMu_DiJet/BTagMu_AK4DiJet110_Mu5',
     nmuons = 1,
@@ -95,6 +133,18 @@ BTagMu_AK4DiJet110_Mu5_DeepJet = hltBTVmonitoring.clone(
     muoSelection = 'pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
     jetSelection = 'pt>90 & abs(eta)<2.4',
     btagAlgos = ["pfDeepFlavourJetTags:probb", "pfDeepFlavourJetTags:probbb","pfDeepFlavourJetTags:problepb"],
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK4DiJet110_Mu5_v*']),
+    histoPSet = dict(jetPtBinning = [0,90,100,110,120,130,150,200,400,700,1000,1500,3000])
+)
+
+BTagMu_AK4DiJet110_Mu5_UParT = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/BTagMu_DiJet/AK4DiJet110_Mu5_UParTAK4',
+    nmuons = 1,
+    nelectrons = 0,
+    njets = 2,
+    muoSelection = 'pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
+    jetSelection = 'pt>90 & abs(eta)<2.4',
+    btagAlgos = ["pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll"],
     numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK4DiJet110_Mu5_v*']),
     histoPSet = dict(jetPtBinning = [0,90,100,110,120,130,150,200,400,700,1000,1500,3000])
 )
@@ -122,6 +172,19 @@ BTagMu_AK4DiJet170_Mu5_DeepJet = hltBTVmonitoring.clone(
     histoPSet = dict(jetPtBinning = [0,150,160,170,180,190,200,400,700,1000,1500,3000])
 )
 
+BTagMu_AK4DiJet170_Mu5_UParT = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/BTagMu_DiJet/AK4DiJet170_Mu5_UParTAK4',
+    nmuons = 1,
+    nelectrons = 0,
+    njets = 2,
+    muoSelection = 'pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
+    jetSelection = 'pt>150 & abs(eta)<2.4',
+    btagAlgos = ["pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll"],
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK4DiJet170_Mu5_v*']),
+    histoPSet = dict(jetPtBinning = [0,150,160,170,180,190,200,400,700,1000,1500,3000])
+)
+
+
 BTagMu_AK4Jet300_Mu5 = hltBTVmonitoring.clone(
     FolderName = 'HLT/BTV/BTagMu_Jet/BTagMu_AK4Jet300_Mu5',
     nmuons = 1,
@@ -145,6 +208,17 @@ BTagMu_AK4Jet300_Mu5_DeepJet = hltBTVmonitoring.clone(
     histoPSet = dict(jetPtBinning = [0,250,280,300,320,360,400,700,1000,1500,3000])
 )
 
+BTagMu_AK4Jet300_Mu5_UParT = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/BTagMu_Jet/BTagMu_AK4Jet300_Mu5_UParTAK4',
+    nmuons = 1,
+    nelectrons = 0,
+    njets = 1,
+    muoSelection = 'pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
+    jetSelection = 'pt>250 & abs(eta)<2.4',
+    btagAlgos = ["pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll"],
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK4Jet300_Mu5_v*']),
+    histoPSet = dict(jetPtBinning = [0,250,280,300,320,360,400,700,1000,1500,3000])
+)
 
 #BTagMu AK8
 BTagMu_AK8DiJet170_Mu5 = hltBTVmonitoring.clone(
@@ -212,6 +286,18 @@ BTagMonitor_PFJet40_DeepJet = hltBTVmonitoring.clone(
     numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJet40_v*'])
 )
 
+BTagMonitor_PFJet40_UParT = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/PFJet40_UParTAK4',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jetSelection = 'pt>30 & abs(eta)<2.4',
+    bjetSelection = 'pt>20 & abs(eta)<2.4',
+    btagAlgos = ["pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll"],
+    histoPSet = dict(jetPtBinning = [0,30,35,40,45,50,60,70,100,150,200,400,700,1000,1500,3000]),
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJet40_v*'])
+)
+
 # PFJet AK8
 BTagMonitor_AK8PFJet40 = hltBTVmonitoring.clone(
     FolderName = 'HLT/BTV/PFJet/AK8PFJet40',
@@ -235,6 +321,23 @@ BTagMonitor_PFJetFwd40_DeepJet = hltBTVmonitoring.clone(
     jetSelection = 'pt>30 & abs(eta)>2.7 & abs(eta)<5.0',
     bjetSelection = 'pt>20 & abs(eta)>2.7 & abs(eta)<5.0',
     btagAlgos = ["pfDeepFlavourJetTags:probb", "pfDeepFlavourJetTags:probbb","pfDeepFlavourJetTags:problepb"],
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJetFwd40_v*']),
+    histoPSet = dict(
+        jetPtBinning = [0,30,35,40,45,50,60,70,100,150,200,400,700,1000,1500,3000],
+        jetEtaBinning = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        jetEtaBinning2D = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        etaPSet = dict(nbins=50, xmin=-5.0, xmax=5.0)
+    )
+)
+
+BTagMonitor_PFJetFwd40_UParT = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/PFJetFwd40_UParTAK4',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jetSelection = 'pt>30 & abs(eta)>2.7 & abs(eta)<5.0',
+    bjetSelection = 'pt>20 & abs(eta)>2.7 & abs(eta)<5.0',
+    btagAlgos = ["pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll"], 
     numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJetFwd40_v*']),
     histoPSet = dict(
         jetPtBinning = [0,30,35,40,45,50,60,70,100,150,200,400,700,1000,1500,3000],
@@ -268,18 +371,24 @@ BTagMonitor_AK8PFJetFwd40_DeepJet = hltBTVmonitoring.clone(
 btagMonitorHLT = cms.Sequence(
     BTagMu_AK4DiJet20_Mu5
   + BTagMu_AK4DiJet20_Mu5_DeepJet
+  + BTagMu_AK4DiJet20_Mu5_UParT
   + BTagMu_AK4DiJet40_Mu5
   + BTagMu_AK4DiJet40_Mu5_DeepJet
+  + BTagMu_AK4DiJet40_Mu5_UParT
   + BTagMu_AK4DiJet70_Mu5
   + BTagMu_AK4DiJet70_Mu5_DeepJet
+  + BTagMu_AK4DiJet70_Mu5_UParT
   + BTagMu_AK4DiJet110_Mu5
   + BTagMu_AK4DiJet110_Mu5_DeepJet
+  + BTagMu_AK4DiJet110_Mu5_UParT
   + BTagMu_AK4DiJet170_Mu5
   + BTagMu_AK4DiJet170_Mu5_DeepJet
+  + BTagMu_AK4DiJet170_Mu5_UParT
   + BTagMu_AK8DiJet170_Mu5
   + BTagMu_AK8Jet170_DoubleMu5
   + BTagMu_AK4Jet300_Mu5
   + BTagMu_AK4Jet300_Mu5_DeepJet
+  + BTagMu_AK4Jet300_Mu5_UParT
   + BTagMu_AK8Jet300_Mu5
 )
 
@@ -290,7 +399,9 @@ pp_on_PbPb_run3.toReplaceWith(btagMonitorHLT,btagMonitorHLT.copyAndExclude([BTag
 btvHLTDQMSourceExtra = cms.Sequence(
     BTagMonitor_PFJet40
   + BTagMonitor_PFJet40_DeepJet
+  + BTagMonitor_PFJet40_UParT
   + BTagMonitor_AK8PFJet40
   + BTagMonitor_PFJetFwd40_DeepJet
+  + BTagMonitor_PFJetFwd40_UParT    
   + BTagMonitor_AK8PFJetFwd40_DeepJet
 )

--- a/DQMOffline/Trigger/python/BTaggingMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/BTaggingMonitoring_cff.py
@@ -330,23 +330,6 @@ BTagMonitor_PFJetFwd40_DeepJet = hltBTVmonitoring.clone(
     )
 )
 
-BTagMonitor_PFJetFwd40_UParT = hltBTVmonitoring.clone(
-    FolderName = 'HLT/BTV/PFJet/PFJetFwd40_UParTAK4',
-    nmuons = 0,
-    nelectrons = 0,
-    njets = 1,
-    jetSelection = 'pt>30 & abs(eta)>2.7 & abs(eta)<5.0',
-    bjetSelection = 'pt>20 & abs(eta)>2.7 & abs(eta)<5.0',
-    btagAlgos = ["pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll"], 
-    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJetFwd40_v*']),
-    histoPSet = dict(
-        jetPtBinning = [0,30,35,40,45,50,60,70,100,150,200,400,700,1000,1500,3000],
-        jetEtaBinning = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
-        jetEtaBinning2D = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
-        etaPSet = dict(nbins=50, xmin=-5.0, xmax=5.0)
-    )
-)
-
 # PFJetFwd AK8
 BTagMonitor_AK8PFJetFwd40_DeepJet = hltBTVmonitoring.clone(
     FolderName = 'HLT/BTV/PFJet/AK8PFJetFwd40',
@@ -402,6 +385,5 @@ btvHLTDQMSourceExtra = cms.Sequence(
   + BTagMonitor_PFJet40_UParT
   + BTagMonitor_AK8PFJet40
   + BTagMonitor_PFJetFwd40_DeepJet
-  + BTagMonitor_PFJetFwd40_UParT    
   + BTagMonitor_AK8PFJetFwd40_DeepJet
 )

--- a/RecoBTag/Configuration/python/RecoBTag_cff.py
+++ b/RecoBTag/Configuration/python/RecoBTag_cff.py
@@ -114,7 +114,8 @@ _pfBTaggingTask_run3 = cms.Task(
     pixelClusterTagInfos,
 
     pfParticleNetAK4TaskForRECO,
-    pfParticleNetTask
+    pfParticleNetTask,
+    pfUnifiedParticleTransformerAK4Task
 )
 _pfCTaggingTask_run3 = cms.Task(
     inclusiveCandidateVertexingCvsLTask,


### PR DESCRIPTION
**PR Description:**

This PR aims to add UParT b-tagging scores for AK4 jets to offline HLT DQM, updating https://github.com/cms-sw/cmssw/pull/44754. As previously done, a separate folder is added for trigger paths using the UParT tagger, while still keeping DeepJet and ParticleNet folders.  Only expected change is a separate folder ending with *_UParTAK4 for the different paths containing all the same plots. 

**PR Validation:**

These changes pass the basic tests suggested in [https://cms-sw.github.io/PRWorkflow.html](https://cms-sw.github.io/PRWorkflow.html) with the exception of some workflows that have missing input files. Workflow 12834.0 runs without any error and the new folders and plots are visible in the local GUI for this workflow. 