### PR TITLE
Remove redundant data members from InputFileCatalog to reduce memory use

### DIFF
--- a/FWCore/Catalog/interface/InputFileCatalog.h
+++ b/FWCore/Catalog/interface/InputFileCatalog.h
@@ -42,18 +42,19 @@ namespace edm {
 
     ~InputFileCatalog();
     std::vector<FileCatalogItem> const& fileCatalogItems() const { return fileCatalogItems_; }
-    std::vector<std::string> const& logicalFileNames() const { return logicalFileNames_; }
     std::vector<std::string> fileNames(unsigned iCatalog) const;
     bool empty() const { return fileCatalogItems_.empty(); }
     static bool isPhysical(std::string const& name) { return (name.empty() || name.find(':') != std::string::npos); }
 
   private:
-    void init(std::string const& override, bool useLFNasPFNifLFNnotFound, edm::CatalogType catType);
+    void init(std::vector<std::string> logicalFileNames,
+              std::string const& override,
+              bool useLFNasPFNifLFNnotFound,
+              edm::CatalogType catType);
     void findFile(std::string const& lfn,
                   std::vector<std::string>& pfns,
                   bool useLFNasPFNifLFNnotFound,
                   edm::CatalogType catType);
-    std::vector<std::string> logicalFileNames_;
     std::vector<FileCatalogItem> fileCatalogItems_;
     edm::propagate_const<std::unique_ptr<FileLocator>> overrideFileLocator_;
 

--- a/FWCore/Catalog/interface/InputFileCatalog.h
+++ b/FWCore/Catalog/interface/InputFileCatalog.h
@@ -19,7 +19,7 @@
 namespace edm {
   class FileCatalogItem {
   public:
-    FileCatalogItem(std::vector<std::string> const& pfns, std::string const& lfn) : pfns_(pfns), lfn_(lfn) {}
+    FileCatalogItem(std::vector<std::string> pfns, std::string lfn) : pfns_(std::move(pfns)), lfn_(std::move(lfn)) {}
 
     std::string const& fileName(unsigned iCatalog) const { return pfns_[iCatalog]; }
     std::string const& logicalFileName() const { return lfn_; }
@@ -54,7 +54,6 @@ namespace edm {
                   bool useLFNasPFNifLFNnotFound,
                   edm::CatalogType catType);
     std::vector<std::string> logicalFileNames_;
-    std::vector<std::string> fileNames_;
     std::vector<FileCatalogItem> fileCatalogItems_;
     edm::propagate_const<std::unique_ptr<FileLocator>> overrideFileLocator_;
 

--- a/FWCore/Catalog/interface/InputFileCatalog.h
+++ b/FWCore/Catalog/interface/InputFileCatalog.h
@@ -33,7 +33,7 @@ namespace edm {
 
   class InputFileCatalog {
   public:
-    InputFileCatalog(std::vector<std::string> const& fileNames,
+    InputFileCatalog(std::vector<std::string> fileNames,
                      std::string const& override,
                      bool useLFNasPFNifLFNnotFound = false,
                      //switching between two catalog types

--- a/FWCore/Catalog/src/InputFileCatalog.cc
+++ b/FWCore/Catalog/src/InputFileCatalog.cc
@@ -17,12 +17,12 @@
 
 namespace edm {
 
-  InputFileCatalog::InputFileCatalog(std::vector<std::string> const& fileNames,
+  InputFileCatalog::InputFileCatalog(std::vector<std::string> fileNames,
                                      std::string const& override,
                                      bool useLFNasPFNifLFNnotFound,
                                      edm::CatalogType catType)
       : fileCatalogItems_(), overrideFileLocator_() {
-    init(fileNames, override, useLFNasPFNifLFNnotFound, catType);
+    init(std::move(fileNames), override, useLFNasPFNifLFNnotFound, catType);
   }
 
   InputFileCatalog::~InputFileCatalog() {}

--- a/FWCore/Catalog/src/InputFileCatalog.cc
+++ b/FWCore/Catalog/src/InputFileCatalog.cc
@@ -21,8 +21,8 @@ namespace edm {
                                      std::string const& override,
                                      bool useLFNasPFNifLFNnotFound,
                                      edm::CatalogType catType)
-      : logicalFileNames_(fileNames), fileCatalogItems_(), overrideFileLocator_() {
-    init(override, useLFNasPFNifLFNnotFound, catType);
+      : fileCatalogItems_(), overrideFileLocator_() {
+    init(fileNames, override, useLFNasPFNifLFNnotFound, catType);
   }
 
   InputFileCatalog::~InputFileCatalog() {}
@@ -36,7 +36,8 @@ namespace edm {
     return tmp;
   }
 
-  void InputFileCatalog::init(std::string const& inputOverride,
+  void InputFileCatalog::init(std::vector<std::string> logicalFileNames,
+                              std::string const& inputOverride,
                               bool useLFNasPFNifLFNnotFound,
                               edm::CatalogType catType) {
     typedef std::vector<std::string>::iterator iter;
@@ -123,7 +124,7 @@ namespace edm {
       throw ex;
     }
 
-    for (auto& lfn : logicalFileNames_) {
+    for (auto& lfn : logicalFileNames) {
       boost::trim(lfn);
       std::vector<std::string> pfns;
       if (lfn.empty()) {
@@ -147,7 +148,7 @@ namespace edm {
       }
       lfn.shrink_to_fit();  // try to release memory
 
-      fileCatalogItems_.emplace_back(std::move(pfns), lfn);
+      fileCatalogItems_.emplace_back(std::move(pfns), std::move(lfn));
     }
   }
 

--- a/FWCore/Catalog/src/InputFileCatalog.cc
+++ b/FWCore/Catalog/src/InputFileCatalog.cc
@@ -21,7 +21,7 @@ namespace edm {
                                      std::string const& override,
                                      bool useLFNasPFNifLFNnotFound,
                                      edm::CatalogType catType)
-      : logicalFileNames_(fileNames), fileNames_(fileNames), fileCatalogItems_(), overrideFileLocator_() {
+      : logicalFileNames_(fileNames), fileCatalogItems_(), overrideFileLocator_() {
     init(override, useLFNasPFNifLFNnotFound, catType);
   }
 
@@ -123,32 +123,31 @@ namespace edm {
       throw ex;
     }
 
-    for (iter it = fileNames_.begin(), lt = logicalFileNames_.begin(), itEnd = fileNames_.end(); it != itEnd;
-         ++it, ++lt) {
-      boost::trim(*it);
+    for (auto& lfn : logicalFileNames_) {
+      boost::trim(lfn);
       std::vector<std::string> pfns;
-      if (it->empty()) {
+      if (lfn.empty()) {
         cms::Exception ex("FileCatalog");
         ex << "An empty string specified in the fileNames parameter for input source";
         ex.addContext("Calling edm::InputFileCatalog::init()");
         throw ex;
       }
-      if (isPhysical(*it)) {
-        if (it->back() == ':') {
+      if (isPhysical(lfn)) {
+        if (lfn.back() == ':') {
           cms::Exception ex("FileCatalog");
           ex << "An empty physical file name specified in the fileNames parameter for input source";
           ex.addContext("Calling edm::InputFileCatalog::init()");
           throw ex;
         }
-        pfns.push_back(*it);
+        pfns.push_back(lfn);
         // Clear the LFN.
-        lt->clear();
+        lfn.clear();
       } else {
-        boost::trim(*lt);
-        findFile(*lt, pfns, useLFNasPFNifLFNnotFound, catType);
+        findFile(lfn, pfns, useLFNasPFNifLFNnotFound, catType);
       }
+      lfn.shrink_to_fit();  // try to release memory
 
-      fileCatalogItems_.push_back(FileCatalogItem(pfns, *lt));
+      fileCatalogItems_.emplace_back(std::move(pfns), lfn);
     }
   }
 

--- a/FWCore/Catalog/test/BuildFile.xml
+++ b/FWCore/Catalog/test/BuildFile.xml
@@ -1,5 +1,5 @@
 <use name="FWCore/Catalog"/>
 <use name="FWCore/ServiceRegistry"/>
 <use name="catch2"/>
-<bin name="edmCatalogFileLocator_t" file="FileLocator_t.cpp">
+<bin name="TestFWCoreCatalog" file="FileLocator_t.cpp,InputFileCatalog_t.cpp">
 </bin>

--- a/FWCore/Catalog/test/InputFileCatalog_t.cpp
+++ b/FWCore/Catalog/test/InputFileCatalog_t.cpp
@@ -1,0 +1,163 @@
+#include "FWCore/Catalog/interface/InputFileCatalog.h"
+#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
+
+#include "TestSiteLocalConfig.h"
+
+#include "catch.hpp"
+
+TEST_CASE("InputFileCatalog with Rucio data catalog", "[FWCore/Catalog]") {
+  edm::ServiceToken tempToken = edmtest::catalog::makeTestSiteLocalConfigToken();
+
+  SECTION("Empty") {
+    edm::ServiceRegistry::Operate operate(tempToken);
+    edm::InputFileCatalog catalog({}, "");
+    REQUIRE(catalog.empty());
+  }
+
+  SECTION("isPhysical") {
+    REQUIRE(edm::InputFileCatalog::isPhysical(""));
+    REQUIRE(not edm::InputFileCatalog::isPhysical("/foo/bar"));
+    REQUIRE(edm::InputFileCatalog::isPhysical("file:/foo/bar"));
+  }
+
+  SECTION("Default behavior") {
+    edm::ServiceRegistry::Operate operate(tempToken);
+
+    edm::InputFileCatalog catalog(std::vector<std::string>{"/store/foo/bar", "   file:/foo/bar", "root://foobar "}, "");
+
+    SECTION("logicalFileNames") {
+      auto const& lfns = catalog.logicalFileNames();
+      REQUIRE(lfns.size() == 3);
+      CHECK(lfns[0] == "/store/foo/bar");
+      CHECK(lfns[1] == "");  // was PFN
+      CHECK(lfns[2] == "");  // was PFN
+    }
+
+    SECTION("fileNames") {
+      SECTION("Catalog 0") {
+        auto const names = catalog.fileNames(0);
+        REQUIRE(names.size() == 3);
+        CHECK(names[0] == "root://cmsxrootd.fnal.gov/store/foo/bar");
+        CHECK(names[1] == "file:/foo/bar");
+        CHECK(names[2] == "root://foobar");
+      }
+      // The fileNames() works only for catalog 0
+      // Catalog 1 or 2 leads to a crash because the input file list
+      // is a mixture of LFNs and PFNs
+      // This isn't really good behavior...
+    }
+
+    SECTION("fileCatalogItems") {
+      auto const& items = catalog.fileCatalogItems();
+      REQUIRE(items.size() == 3);
+      CHECK(items[0].logicalFileName() == "/store/foo/bar");
+      CHECK(items[1].logicalFileName() == "");
+      CHECK(items[2].logicalFileName() == "");
+
+      REQUIRE(items[0].fileNames().size() == 3);
+      REQUIRE(items[1].fileNames().size() == 1);
+      REQUIRE(items[2].fileNames().size() == 1);
+
+      SECTION("Catalog 0") {
+        CHECK(items[0].fileName(0) == "root://cmsxrootd.fnal.gov/store/foo/bar");
+        CHECK(items[1].fileName(0) == "file:/foo/bar");
+        CHECK(items[2].fileName(0) == "root://foobar");
+      }
+      SECTION("Catalog 1") {
+        CHECK(items[0].fileName(1) == "root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/foo/bar");
+      }
+      SECTION("Catalog 2") { CHECK(items[0].fileName(2) == "root://host.domain//pnfs/cms/store/foo/bar"); }
+    }
+  }
+
+  SECTION("Override catalog") {
+    edm::ServiceRegistry::Operate operate(tempToken);
+
+    edm::InputFileCatalog catalog(std::vector<std::string>{"/store/foo/bar", "   file:/foo/bar", "root://foobar "},
+                                  "T1_US_FNAL,,T1_US_FNAL,FNAL_dCache_EOS,XRootD");
+
+    SECTION("logicalFileNames") {
+      auto const& lfns = catalog.logicalFileNames();
+      REQUIRE(lfns.size() == 3);
+      CHECK(lfns[0] == "/store/foo/bar");
+      CHECK(lfns[1] == "");  // was PFN
+      CHECK(lfns[2] == "");  // was PFN
+    }
+
+    SECTION("fileNames") {
+      auto const names = catalog.fileNames(0);
+      REQUIRE(names.size() == 3);
+      CHECK(names[0] == "root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/foo/bar");
+      CHECK(names[1] == "file:/foo/bar");
+      CHECK(names[2] == "root://foobar");
+    }
+
+    SECTION("fileCatalogItems") {
+      auto const& items = catalog.fileCatalogItems();
+      REQUIRE(items.size() == 3);
+
+      CHECK(items[0].logicalFileName() == "/store/foo/bar");
+      CHECK(items[1].logicalFileName() == "");
+      CHECK(items[2].logicalFileName() == "");
+
+      REQUIRE(items[0].fileNames().size() == 1);
+      REQUIRE(items[1].fileNames().size() == 1);
+      REQUIRE(items[2].fileNames().size() == 1);
+
+      CHECK(items[0].fileName(0) == "root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/foo/bar");
+      CHECK(items[1].fileName(0) == "file:/foo/bar");
+      CHECK(items[2].fileName(0) == "root://foobar");
+    }
+  }
+
+  SECTION("useLFNasPFNifLFNnotFound") {
+    edm::ServiceRegistry::Operate operate(tempToken);
+
+    edm::InputFileCatalog catalog(
+        std::vector<std::string>{"/store/foo/bar", "/tmp/foo/bar", "root://foobar "}, "", true);
+
+    SECTION("logicalFileNames") {
+      auto const& lfns = catalog.logicalFileNames();
+      REQUIRE(lfns.size() == 3);
+      CHECK(lfns[0] == "/store/foo/bar");
+      CHECK(lfns[1] == "/tmp/foo/bar");
+      CHECK(lfns[2] == "");  // was PFN
+    }
+
+    SECTION("fileNames") {
+      SECTION("Catalog 0") {
+        auto const names = catalog.fileNames(0);
+        REQUIRE(names.size() == 3);
+        CHECK(names[0] == "root://cmsxrootd.fnal.gov/store/foo/bar");
+        CHECK(names[1] == "/tmp/foo/bar");
+        CHECK(names[2] == "root://foobar");
+      }
+    }
+
+    SECTION("fileCatalogItems") {
+      auto const& items = catalog.fileCatalogItems();
+      REQUIRE(items.size() == 3);
+      CHECK(items[0].logicalFileName() == "/store/foo/bar");
+      CHECK(items[1].logicalFileName() == "/tmp/foo/bar");
+      CHECK(items[2].logicalFileName() == "");
+
+      REQUIRE(items[0].fileNames().size() == 3);
+      REQUIRE(items[1].fileNames().size() == 3);
+      REQUIRE(items[2].fileNames().size() == 1);
+
+      SECTION("Catalog 0") {
+        CHECK(items[0].fileName(0) == "root://cmsxrootd.fnal.gov/store/foo/bar");
+        CHECK(items[1].fileName(0) == "/tmp/foo/bar");
+        CHECK(items[2].fileName(0) == "root://foobar");
+      }
+      SECTION("Catalog 1") {
+        CHECK(items[0].fileName(1) == "root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/foo/bar");
+        CHECK(items[1].fileName(1) == "/tmp/foo/bar");
+      }
+      SECTION("Catalog 2") {
+        CHECK(items[0].fileName(2) == "root://host.domain//pnfs/cms/store/foo/bar");
+        CHECK(items[1].fileName(2) == "/tmp/foo/bar");
+      }
+    }
+  }
+}

--- a/FWCore/Catalog/test/InputFileCatalog_t.cpp
+++ b/FWCore/Catalog/test/InputFileCatalog_t.cpp
@@ -25,14 +25,6 @@ TEST_CASE("InputFileCatalog with Rucio data catalog", "[FWCore/Catalog]") {
 
     edm::InputFileCatalog catalog(std::vector<std::string>{"/store/foo/bar", "   file:/foo/bar", "root://foobar "}, "");
 
-    SECTION("logicalFileNames") {
-      auto const& lfns = catalog.logicalFileNames();
-      REQUIRE(lfns.size() == 3);
-      CHECK(lfns[0] == "/store/foo/bar");
-      CHECK(lfns[1] == "");  // was PFN
-      CHECK(lfns[2] == "");  // was PFN
-    }
-
     SECTION("fileNames") {
       SECTION("Catalog 0") {
         auto const names = catalog.fileNames(0);
@@ -76,14 +68,6 @@ TEST_CASE("InputFileCatalog with Rucio data catalog", "[FWCore/Catalog]") {
     edm::InputFileCatalog catalog(std::vector<std::string>{"/store/foo/bar", "   file:/foo/bar", "root://foobar "},
                                   "T1_US_FNAL,,T1_US_FNAL,FNAL_dCache_EOS,XRootD");
 
-    SECTION("logicalFileNames") {
-      auto const& lfns = catalog.logicalFileNames();
-      REQUIRE(lfns.size() == 3);
-      CHECK(lfns[0] == "/store/foo/bar");
-      CHECK(lfns[1] == "");  // was PFN
-      CHECK(lfns[2] == "");  // was PFN
-    }
-
     SECTION("fileNames") {
       auto const names = catalog.fileNames(0);
       REQUIRE(names.size() == 3);
@@ -115,14 +99,6 @@ TEST_CASE("InputFileCatalog with Rucio data catalog", "[FWCore/Catalog]") {
 
     edm::InputFileCatalog catalog(
         std::vector<std::string>{"/store/foo/bar", "/tmp/foo/bar", "root://foobar "}, "", true);
-
-    SECTION("logicalFileNames") {
-      auto const& lfns = catalog.logicalFileNames();
-      REQUIRE(lfns.size() == 3);
-      CHECK(lfns[0] == "/store/foo/bar");
-      CHECK(lfns[1] == "/tmp/foo/bar");
-      CHECK(lfns[2] == "");  // was PFN
-    }
 
     SECTION("fileNames") {
       SECTION("Catalog 0") {

--- a/FWCore/Catalog/test/TestSiteLocalConfig.h
+++ b/FWCore/Catalog/test/TestSiteLocalConfig.h
@@ -1,0 +1,87 @@
+#ifndef FWCore_Catalog_test_TestSiteLocalConfig_h
+#define FWCore_Catalog_test_TestSiteLocalConfig_h
+
+#include "FWCore/Catalog/interface/SiteLocalConfig.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <string>
+
+namespace edmtest::catalog {
+  class TestSiteLocalConfig : public edm::SiteLocalConfig {
+  public:
+    //constructor using trivial data catalogs
+    TestSiteLocalConfig(std::vector<std::string> catalogs) : m_trivialCatalogs(std::move(catalogs)) {}
+    //constructor using Rucio data catalogs
+    TestSiteLocalConfig(std::vector<edm::CatalogAttributes> catalogs) : m_catalogs(std::move(catalogs)) {}
+    std::vector<std::string> const& trivialDataCatalogs() const final { return m_trivialCatalogs; }
+    std::vector<edm::CatalogAttributes> const& dataCatalogs() const final { return m_catalogs; }
+    std::filesystem::path const storageDescriptionPath(const edm::CatalogAttributes& aDataCatalog) const final {
+      std::string CMSSW_BASE(std::getenv("CMSSW_BASE"));
+      std::string CMSSW_RELEASE_BASE(std::getenv("CMSSW_RELEASE_BASE"));
+      std::string file_name("/src/FWCore/Catalog/test/storage.json");
+      std::string full_file_name = std::filesystem::exists((CMSSW_BASE + file_name).c_str())
+                                       ? CMSSW_BASE + file_name
+                                       : CMSSW_RELEASE_BASE + file_name;
+      return full_file_name;
+    }
+
+    std::string const lookupCalibConnect(std::string const& input) const final { return std::string(); }
+    std::string const rfioType(void) const final { return std::string(); }
+
+    std::string const* sourceCacheTempDir() const final { return nullptr; }
+    double const* sourceCacheMinFree() const final { return nullptr; }
+    std::string const* sourceCacheHint() const final { return nullptr; }
+    std::string const* sourceCloneCacheHint() const final { return nullptr; }
+    std::string const* sourceReadHint() const final { return nullptr; }
+    unsigned int const* sourceTTreeCacheSize() const final { return nullptr; }
+    unsigned int const* sourceTimeout() const final { return nullptr; }
+    bool enablePrefetching() const final { return false; }
+    unsigned int debugLevel() const final { return 0; }
+    std::vector<std::string> const* sourceNativeProtocols() const final { return nullptr; }
+    struct addrinfo const* statisticsDestination() const final { return nullptr; }
+    std::set<std::string> const* statisticsInfo() const final { return nullptr; }
+    std::string const& siteName(void) const final { return m_emptyString; }
+    std::string const& subSiteName(void) const final { return m_emptyString; }
+    bool useLocalConnectString() const final { return false; }
+    std::string const& localConnectPrefix() const final { return m_emptyString; }
+    std::string const& localConnectSuffix() const final { return m_emptyString; }
+
+  private:
+    std::vector<std::string> m_trivialCatalogs;
+    std::vector<edm::CatalogAttributes> m_catalogs;
+    std::filesystem::path m_storageDescription_path;
+    std::string m_emptyString;
+  };
+
+  inline edm::ServiceToken makeTestSiteLocalConfigToken() {
+    //catalog for testing "prefix"
+    edm::CatalogAttributes aCatalog;
+    aCatalog.site = "T1_US_FNAL";
+    aCatalog.subSite = "T1_US_FNAL";
+    aCatalog.storageSite = "T1_US_FNAL";
+    aCatalog.volume = "American_Federation";
+    aCatalog.protocol = "XRootD";
+    std::vector<edm::CatalogAttributes> tmp{aCatalog};
+    //catalog for testing "rules"
+    aCatalog.site = "T1_US_FNAL";
+    aCatalog.subSite = "T1_US_FNAL";
+    aCatalog.storageSite = "T1_US_FNAL";
+    aCatalog.volume = "FNAL_dCache_EOS";
+    aCatalog.protocol = "XRootD";
+    tmp.push_back(aCatalog);
+    //catalog for testing chained "rules"
+    aCatalog.site = "T1_US_FNAL";
+    aCatalog.subSite = "T1_US_FNAL";
+    aCatalog.storageSite = "T1_US_FNAL";
+    aCatalog.volume = "FNAL_dCache_EOS";
+    aCatalog.protocol = "root";
+    tmp.push_back(aCatalog);
+
+    //create the services
+    return edm::ServiceToken(edm::ServiceRegistry::createContaining(
+        std::unique_ptr<edm::SiteLocalConfig>(std::make_unique<TestSiteLocalConfig>(std::move(tmp)))));
+  }
+}  // namespace edmtest::catalog
+
+#endif

--- a/FWCore/Sources/interface/FromFiles.h
+++ b/FWCore/Sources/interface/FromFiles.h
@@ -18,7 +18,6 @@ namespace edm {
     FromFiles(ParameterSet const& pset);
     ~FromFiles();
 
-    std::vector<std::string> const& logicalFileNames() const { return catalog_.logicalFileNames(); }
     std::vector<std::string> fileNames(unsigned iCatalog) const { return catalog_.fileNames(iCatalog); }
     InputFileCatalog& catalog() { return catalog_; }
 

--- a/FWCore/Sources/interface/ProducerSourceFromFiles.h
+++ b/FWCore/Sources/interface/ProducerSourceFromFiles.h
@@ -21,7 +21,6 @@ namespace edm {
 
     using FromFiles::catalog;
     using FromFiles::fileNames;
-    using FromFiles::logicalFileNames;
 
     static void fillDescription(ParameterSetDescription& desc);
 

--- a/FWCore/Sources/interface/RawInputSourceFromFiles.h
+++ b/FWCore/Sources/interface/RawInputSourceFromFiles.h
@@ -20,7 +20,6 @@ namespace edm {
     ~RawInputSourceFromFiles() override;
 
     using FromFiles::catalog;
-    using FromFiles::logicalFileNames;
 
     static void fillDescription(ParameterSetDescription& desc);
 


### PR DESCRIPTION
#### PR description:

In https://github.com/cms-sw/cmssw/issues/46975#issuecomment-2552441759 I discovered the `InputFileCatalog` took ~488 MB memory per stream in a production DIGI job overlaying premixed pileup, where the job was configured with nearly 500k pileup files. A quick look in `InputFileCatalog` showed the input file names are more or less stored three times
* in `fileNames_` to communicate a copy of the input file names from constructor to `init()`
  * I think this copy is completely unnecessary, and is removed in the second commit
* in `logicalFileNames_` to partly communicate input file names from constructor to `init()`, and partly to allow cheap `logicalFileNames()` getter to them
  * I noticed the `logicalFileNames()` function is not really used, so in order to avoid storing the file names in member data, I decided to remove the member function and the `logicalFileNames_` member in the third commit
* in `FileCatalogItem::lfn_` stored in `fileCatalogItems_` member
  * This copy of the `lfn_` is being used

An alternative to the second commit could be to keep the `logicalFileNames_`, and store the `FileCatalogItem::lfn_` as `string_view`, but I felt that to be a tiny bit more complex.

The fourth commit avoids one copy of the `std::vector<std::string>` of the file names when the `InputFileCatalog` is constructed from a temporary `vector`, which is the case with all Sources that use `InputFileCatalog`.
 
The first commit adds a unit test for `InputFileCatalog`

Resolves https://github.com/cms-sw/framework-team/issues/1113

#### PR validation:

Unit tests passed in CMSSW_14_0_18. With example job https://github.com/cms-sw/cmssw/issues/46975#issuecomment-2552359306 MaxMemoryPreload showed 197 MB reduction in peak allocated memory on 1 thread.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 14_1_X and 14_0_X.