### PR TITLE
[14.0.X] Add GEN-SIM information to resonant di-muon TkAl ALCARECO producers

### DIFF
--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlDiMuonAndVertex_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlDiMuonAndVertex_Output_cff.py
@@ -28,6 +28,11 @@ from GeneratorInterface.Configuration.GeneratorInterface_EventContent_cff import
 from SimGeneral.Configuration.SimGeneral_EventContent_cff import SimGeneralAOD
 
 OutALCARECOTkAlDiMuonAndVertex_noDrop.outputCommands.extend(GeneratorInterfaceAOD.outputCommands)
+_modifiedCommandsForGEN =  OutALCARECOTkAlDiMuonAndVertex_noDrop.outputCommands.copy()
+_modifiedCommandsForGEN.remove('keep *_genParticles_*_*')    # full genParticles list is too heavy
+_modifiedCommandsForGEN.append('keep *_TkAlDiMuonAndVertexGenMuonSelector_*_*') # Keep only the filtered gen muons
+OutALCARECOTkAlDiMuonAndVertex_noDrop.outputCommands = _modifiedCommandsForGEN
+
 OutALCARECOTkAlDiMuonAndVertex_noDrop.outputCommands.extend(SimGeneralAOD.outputCommands)
 
 # in Phase2, remove the SiStrip clusters and keep the OT ones instead

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlDiMuonAndVertex_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlDiMuonAndVertex_Output_cff.py
@@ -23,6 +23,13 @@ OutALCARECOTkAlDiMuonAndVertex_noDrop = cms.PSet(
         'keep *_offlinePrimaryVertices_*_*')
 )
 
+# add branches for MC truth evaluation
+from GeneratorInterface.Configuration.GeneratorInterface_EventContent_cff import GeneratorInterfaceAOD
+from SimGeneral.Configuration.SimGeneral_EventContent_cff import SimGeneralAOD
+
+OutALCARECOTkAlDiMuonAndVertex_noDrop.outputCommands.extend(GeneratorInterfaceAOD.outputCommands)
+OutALCARECOTkAlDiMuonAndVertex_noDrop.outputCommands.extend(SimGeneralAOD.outputCommands)
+
 # in Phase2, remove the SiStrip clusters and keep the OT ones instead
 _phase2_common_removedCommands = OutALCARECOTkAlDiMuonAndVertex_noDrop.outputCommands.copy()
 _phase2_common_removedCommands.remove('keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlDiMuon_*_*')

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlDiMuonAndVertex_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlDiMuonAndVertex_cff.py
@@ -23,7 +23,8 @@ ALCARECOTkAlDiMuonVertexTracks = TracksFromVertex.AlignmentTracksFromVertexSelec
 TkAlDiMuonAndVertexGenMuonSelector = cms.EDFilter("GenParticleSelector",
                                                   src = cms.InputTag("genParticles"),
                                                   cut = cms.string("abs(pdgId) == 13"), # Select only muons
-                                                  filter = cms.bool(False))
+                                                  filter = cms.bool(False),
+                                                  throwOnMissing = cms.untracked.bool(False))
 
 ##################################################################
 # The sequence

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlDiMuonAndVertex_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlDiMuonAndVertex_cff.py
@@ -18,6 +18,14 @@ import Alignment.CommonAlignmentProducer.AlignmentTracksFromVertexSelector_cfi a
 ALCARECOTkAlDiMuonVertexTracks = TracksFromVertex.AlignmentTracksFromVertexSelector.clone()
 
 ##################################################################
+# for the GEN level information
+##################################################################
+TkAlDiMuonAndVertexGenMuonSelector = cms.EDFilter("GenParticleSelector",
+                                                  src = cms.InputTag("genParticles"),
+                                                  cut = cms.string("abs(pdgId) == 13"), # Select only muons
+                                                  filter = cms.bool(False))
+
+##################################################################
 # The sequence
 #################################################################
 seqALCARECOTkAlDiMuonAndVertex = cms.Sequence(ALCARECOTkAlDiMuonHLT+
@@ -25,7 +33,8 @@ seqALCARECOTkAlDiMuonAndVertex = cms.Sequence(ALCARECOTkAlDiMuonHLT+
                                               ALCARECOTkAlDiMuonGoodMuons+
                                               ALCARECOTkAlDiMuonRelCombIsoMuons+
                                               ALCARECOTkAlDiMuon+
-                                              ALCARECOTkAlDiMuonVertexTracks)
+                                              ALCARECOTkAlDiMuonVertexTracks+
+                                              TkAlDiMuonAndVertexGenMuonSelector)
 
 ## customizations for the pp_on_AA eras
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJpsiMuMu_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJpsiMuMu_Output_cff.py
@@ -23,6 +23,11 @@ from GeneratorInterface.Configuration.GeneratorInterface_EventContent_cff import
 from SimGeneral.Configuration.SimGeneral_EventContent_cff import SimGeneralAOD
 
 OutALCARECOTkAlJpsiMuMu_noDrop.outputCommands.extend(GeneratorInterfaceAOD.outputCommands)
+_modifiedCommandsForGEN =  OutALCARECOTkAlJpsiMuMu_noDrop.outputCommands.copy()
+_modifiedCommandsForGEN.remove('keep *_genParticles_*_*')    # full genParticles list is too heavy
+_modifiedCommandsForGEN.append('keep *_TkAlJpsiMuMuGenMuonSelector_*_*') # Keep only the filtered gen muons
+OutALCARECOTkAlJpsiMuMu_noDrop.outputCommands = _modifiedCommandsForGEN
+
 OutALCARECOTkAlJpsiMuMu_noDrop.outputCommands.extend(SimGeneralAOD.outputCommands)
 
 # in Run3, SCAL digis replaced by onlineMetaDataDigis

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJpsiMuMu_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJpsiMuMu_Output_cff.py
@@ -18,6 +18,13 @@ OutALCARECOTkAlJpsiMuMu_noDrop = cms.PSet(
 	'keep *_offlinePrimaryVertices_*_*')
 )
 
+# add branches for MC truth evaluation
+from GeneratorInterface.Configuration.GeneratorInterface_EventContent_cff import GeneratorInterfaceAOD
+from SimGeneral.Configuration.SimGeneral_EventContent_cff import SimGeneralAOD
+
+OutALCARECOTkAlJpsiMuMu_noDrop.outputCommands.extend(GeneratorInterfaceAOD.outputCommands)
+OutALCARECOTkAlJpsiMuMu_noDrop.outputCommands.extend(SimGeneralAOD.outputCommands)
+
 # in Run3, SCAL digis replaced by onlineMetaDataDigis
 import copy
 _run3_common_removedCommands = OutALCARECOTkAlJpsiMuMu_noDrop.outputCommands.copy()

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJpsiMuMu_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJpsiMuMu_cff.py
@@ -53,7 +53,8 @@ ALCARECOTkAlJpsiMuMu.TwoBodyDecaySelector.numberOfCandidates = 1
 TkAlJpsiMuMuGenMuonSelector = cms.EDFilter("GenParticleSelector",
                                            src = cms.InputTag("genParticles"),
                                            cut = cms.string("abs(pdgId) == 13"), # Select only muons
-                                           filter = cms.bool(False))
+                                           filter = cms.bool(False),
+                                           throwOnMissing = cms.untracked.bool(False))
 
 seqALCARECOTkAlJpsiMuMu = cms.Sequence(ALCARECOTkAlJpsiMuMuHLT+ALCARECOTkAlJpsiMuMuDCSFilter+ALCARECOTkAlJpsiMuMuGoodMuons+ALCARECOTkAlJpsiMuMu+TkAlJpsiMuMuGenMuonSelector)
 

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJpsiMuMu_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJpsiMuMu_cff.py
@@ -49,7 +49,13 @@ ALCARECOTkAlJpsiMuMu.TwoBodyDecaySelector.applyAcoplanarityFilter = False
 ALCARECOTkAlJpsiMuMu.TwoBodyDecaySelector.acoplanarDistance = 1 ##radian
 ALCARECOTkAlJpsiMuMu.TwoBodyDecaySelector.numberOfCandidates = 1 	 
 
-seqALCARECOTkAlJpsiMuMu = cms.Sequence(ALCARECOTkAlJpsiMuMuHLT+ALCARECOTkAlJpsiMuMuDCSFilter+ALCARECOTkAlJpsiMuMuGoodMuons+ALCARECOTkAlJpsiMuMu)
+## for the GEN level information
+TkAlJpsiMuMuGenMuonSelector = cms.EDFilter("GenParticleSelector",
+                                           src = cms.InputTag("genParticles"),
+                                           cut = cms.string("abs(pdgId) == 13"), # Select only muons
+                                           filter = cms.bool(False))
+
+seqALCARECOTkAlJpsiMuMu = cms.Sequence(ALCARECOTkAlJpsiMuMuHLT+ALCARECOTkAlJpsiMuMuDCSFilter+ALCARECOTkAlJpsiMuMuGoodMuons+ALCARECOTkAlJpsiMuMu+TkAlJpsiMuMuGenMuonSelector)
 
 ## customizations for the pp_on_AA eras
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMu_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMu_Output_cff.py
@@ -18,6 +18,13 @@ OutALCARECOTkAlUpsilonMuMu_noDrop = cms.PSet(
 	'keep *_offlinePrimaryVertices_*_*')
 )
 
+# add branches for MC truth evaluation
+from GeneratorInterface.Configuration.GeneratorInterface_EventContent_cff import GeneratorInterfaceAOD
+from SimGeneral.Configuration.SimGeneral_EventContent_cff import SimGeneralAOD
+
+OutALCARECOTkAlUpsilonMuMu_noDrop.outputCommands.extend(GeneratorInterfaceAOD.outputCommands)
+OutALCARECOTkAlUpsilonMuMu_noDrop.outputCommands.extend(SimGeneralAOD.outputCommands)
+
 # in Run3, SCAL digis replaced by onlineMetaDataDigis
 import copy
 _run3_common_removedCommands = OutALCARECOTkAlUpsilonMuMu_noDrop.outputCommands.copy()

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMu_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMu_Output_cff.py
@@ -23,6 +23,11 @@ from GeneratorInterface.Configuration.GeneratorInterface_EventContent_cff import
 from SimGeneral.Configuration.SimGeneral_EventContent_cff import SimGeneralAOD
 
 OutALCARECOTkAlUpsilonMuMu_noDrop.outputCommands.extend(GeneratorInterfaceAOD.outputCommands)
+_modifiedCommandsForGEN =  OutALCARECOTkAlUpsilonMuMu_noDrop.outputCommands.copy()
+_modifiedCommandsForGEN.remove('keep *_genParticles_*_*')    # full genParticles list is too heavy
+_modifiedCommandsForGEN.append('keep *_TkAlUpsilonMuMuGenMuonSelector_*_*') # Keep only the filtered gen muons
+OutALCARECOTkAlUpsilonMuMu_noDrop.outputCommands = _modifiedCommandsForGEN
+
 OutALCARECOTkAlUpsilonMuMu_noDrop.outputCommands.extend(SimGeneralAOD.outputCommands)
 
 # in Run3, SCAL digis replaced by onlineMetaDataDigis

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMu_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMu_cff.py
@@ -56,9 +56,10 @@ ALCARECOTkAlUpsilonMuMu.TwoBodyDecaySelector.numberOfCandidates = 1
 
 ## for the GEN level information
 TkAlUpsilonMuMuGenMuonSelector = cms.EDFilter("GenParticleSelector",
-                                        src = cms.InputTag("genParticles"),
-                                        cut = cms.string("abs(pdgId) == 13"), # Select only muons
-                                        filter = cms.bool(False))
+                                              src = cms.InputTag("genParticles"),
+                                              cut = cms.string("abs(pdgId) == 13"), # Select only muons
+                                              filter = cms.bool(False),
+                                              throwOnMissing = cms.untracked.bool(False))
 
 seqALCARECOTkAlUpsilonMuMu = cms.Sequence(ALCARECOTkAlUpsilonMuMuHLT+ALCARECOTkAlUpsilonMuMuDCSFilter+ALCARECOTkAlUpsilonMuMuGoodMuons+ALCARECOTkAlUpsilonMuMuRelCombIsoMuons+ALCARECOTkAlUpsilonMuMu+TkAlUpsilonMuMuGenMuonSelector)
 

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMu_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMu_cff.py
@@ -54,7 +54,13 @@ ALCARECOTkAlUpsilonMuMu.TwoBodyDecaySelector.applyAcoplanarityFilter = False
 ALCARECOTkAlUpsilonMuMu.TwoBodyDecaySelector.acoplanarDistance = 1 ##radian
 ALCARECOTkAlUpsilonMuMu.TwoBodyDecaySelector.numberOfCandidates = 1	 
 
-seqALCARECOTkAlUpsilonMuMu = cms.Sequence(ALCARECOTkAlUpsilonMuMuHLT+ALCARECOTkAlUpsilonMuMuDCSFilter+ALCARECOTkAlUpsilonMuMuGoodMuons+ALCARECOTkAlUpsilonMuMuRelCombIsoMuons+ALCARECOTkAlUpsilonMuMu)
+## for the GEN level information
+TkAlUpsilonMuMuGenMuonSelector = cms.EDFilter("GenParticleSelector",
+                                        src = cms.InputTag("genParticles"),
+                                        cut = cms.string("abs(pdgId) == 13"), # Select only muons
+                                        filter = cms.bool(False))
+
+seqALCARECOTkAlUpsilonMuMu = cms.Sequence(ALCARECOTkAlUpsilonMuMuHLT+ALCARECOTkAlUpsilonMuMuDCSFilter+ALCARECOTkAlUpsilonMuMuGoodMuons+ALCARECOTkAlUpsilonMuMuRelCombIsoMuons+ALCARECOTkAlUpsilonMuMu+TkAlUpsilonMuMuGenMuonSelector)
 
 ## customizations for the pp_on_AA eras
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMu_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMu_Output_cff.py
@@ -18,6 +18,13 @@ OutALCARECOTkAlZMuMu_noDrop = cms.PSet(
 	'keep *_offlinePrimaryVertices_*_*')
 )
 
+# add branches for MC truth evaluation
+from GeneratorInterface.Configuration.GeneratorInterface_EventContent_cff import GeneratorInterfaceAOD
+from SimGeneral.Configuration.SimGeneral_EventContent_cff import SimGeneralAOD
+
+OutALCARECOTkAlZMuMu_noDrop.outputCommands.extend(GeneratorInterfaceAOD.outputCommands)
+OutALCARECOTkAlZMuMu_noDrop.outputCommands.extend(SimGeneralAOD.outputCommands)
+
 # in Run3, SCAL digis replaced by onlineMetaDataDigis
 import copy
 _run3_common_removedCommands = OutALCARECOTkAlZMuMu_noDrop.outputCommands.copy()

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMu_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMu_Output_cff.py
@@ -23,6 +23,11 @@ from GeneratorInterface.Configuration.GeneratorInterface_EventContent_cff import
 from SimGeneral.Configuration.SimGeneral_EventContent_cff import SimGeneralAOD
 
 OutALCARECOTkAlZMuMu_noDrop.outputCommands.extend(GeneratorInterfaceAOD.outputCommands)
+_modifiedCommandsForGEN =  OutALCARECOTkAlZMuMu_noDrop.outputCommands.copy()
+_modifiedCommandsForGEN.remove('keep *_genParticles_*_*')    # full genParticles list is too heavy
+_modifiedCommandsForGEN.append('keep *_TkAlZMuMuGenMuonSelector_*_*') # Keep only the filtered gen muons
+OutALCARECOTkAlZMuMu_noDrop.outputCommands = _modifiedCommandsForGEN
+
 OutALCARECOTkAlZMuMu_noDrop.outputCommands.extend(SimGeneralAOD.outputCommands)
 
 # in Run3, SCAL digis replaced by onlineMetaDataDigis

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMu_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMu_cff.py
@@ -55,7 +55,8 @@ ALCARECOTkAlZMuMu.TwoBodyDecaySelector.numberOfCandidates = 1
 TkAlZMuMuGenMuonSelector = cms.EDFilter("GenParticleSelector",
                                         src = cms.InputTag("genParticles"),
                                         cut = cms.string("abs(pdgId) == 13"), # Select only muons
-                                        filter = cms.bool(False))
+                                        filter = cms.bool(False),
+                                        throwOnMissing = cms.untracked.bool(False))
 
 seqALCARECOTkAlZMuMu = cms.Sequence(ALCARECOTkAlZMuMuHLT+ALCARECOTkAlZMuMuDCSFilter+ALCARECOTkAlZMuMuGoodMuons+ALCARECOTkAlZMuMuRelCombIsoMuons+ALCARECOTkAlZMuMu+TkAlZMuMuGenMuonSelector)
 

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMu_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMu_cff.py
@@ -51,7 +51,13 @@ ALCARECOTkAlZMuMu.TwoBodyDecaySelector.charge = 0
 ALCARECOTkAlZMuMu.TwoBodyDecaySelector.applyAcoplanarityFilter = False
 ALCARECOTkAlZMuMu.TwoBodyDecaySelector.numberOfCandidates = 1
 
-seqALCARECOTkAlZMuMu = cms.Sequence(ALCARECOTkAlZMuMuHLT+ALCARECOTkAlZMuMuDCSFilter+ALCARECOTkAlZMuMuGoodMuons+ALCARECOTkAlZMuMuRelCombIsoMuons+ALCARECOTkAlZMuMu)
+## for the GEN level information
+TkAlZMuMuGenMuonSelector = cms.EDFilter("GenParticleSelector",
+                                        src = cms.InputTag("genParticles"),
+                                        cut = cms.string("abs(pdgId) == 13"), # Select only muons
+                                        filter = cms.bool(False))
+
+seqALCARECOTkAlZMuMu = cms.Sequence(ALCARECOTkAlZMuMuHLT+ALCARECOTkAlZMuMuDCSFilter+ALCARECOTkAlZMuMuGoodMuons+ALCARECOTkAlZMuMuRelCombIsoMuons+ALCARECOTkAlZMuMu+TkAlZMuMuGenMuonSelector)
 
 ## customizations for the pp_on_AA eras
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017

--- a/CommonTools/UtilAlgos/interface/ObjectSelectorBase.h
+++ b/CommonTools/UtilAlgos/interface/ObjectSelectorBase.h
@@ -59,7 +59,7 @@ private:
     selectorInit_.init(selector_, evt, es);
     edm::Handle<typename Selector::collection> source;
     if (!throwOnMissing_ && !source.isValid()) {
-      return false;
+      return !filter_;
     }
     evt.getByToken(srcToken_, source);
     StoreManager manager(source);

--- a/CommonTools/UtilAlgos/interface/ObjectSelectorBase.h
+++ b/CommonTools/UtilAlgos/interface/ObjectSelectorBase.h
@@ -38,6 +38,7 @@ public:
         srcToken_(
             this->template consumes<typename Selector::collection>(cfg.template getParameter<edm::InputTag>("src"))),
         filter_(false),
+        throwOnMissing_(cfg.template getUntrackedParameter<bool>("throwOnMissing", true)),
         selectorInit_(this->consumesCollector()),
         selector_(cfg, this->consumesCollector()),
         sizeSelector_(reco::modules::make<SizeSelector>(cfg)),
@@ -57,6 +58,9 @@ private:
   bool filter(edm::Event& evt, const edm::EventSetup& es) override {
     selectorInit_.init(selector_, evt, es);
     edm::Handle<typename Selector::collection> source;
+    if (!throwOnMissing_ && !source.isValid()) {
+      return false;
+    }
     evt.getByToken(srcToken_, source);
     StoreManager manager(source);
     selector_.select(source, evt, es);
@@ -70,6 +74,8 @@ private:
   edm::EDGetTokenT<typename Selector::collection> srcToken_;
   /// filter event
   bool filter_;
+  /// trhow on missing
+  bool throwOnMissing_;
   /// Object collection selector
   Init selectorInit_;
   Selector selector_;


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/45357
backport of https://github.com/cms-sw/cmssw/pull/45385

#### PR description:

From the original description at https://github.com/cms-sw/cmssw/pull/45357#issue-2386223979:

> The goal of this PR is to add `GEN-SIM` related branches to the outputs of several Tracker Alignment ALCARECO producers (using resonant di-muon inputs).
> The main goal is to be able to produce MC-truth based validations like the ones shown [here](https://indico.cern.ch/event/1431066/contributions/6022416/attachments/2888005/5061991/AlCaDB_meeting_010724.pdf#page=34) readily from ALCARECO samples instead of relying on scarce and not very easily available `GEN-SIM-RECO` samples.
> A similar request was done for analysis purposes e.g. in [this ticket](https://its.cern.ch/jira/browse/PDMVMCPROD-59).
> To limit the output size, we don't add the whole `genParticles` collection, but just the particles with `abs(pdgId) == 13`.
> In order to do that some gymnastics with the `outputCommands` is required. A simpler solution might entail adding directly a new event content `GeneratorInterfaceALCARECO` [here](https://github.com/cms-sw/cmssw/blob/master/GeneratorInterface/Configuration/python/GeneratorInterface_EventContent_cff.py).
> The increase of data volume (limited by construction only to the MC samples, since the added branches are not available in data) is marginal (estimated in less than 1% on 100 input events).

in addition from https://github.com/cms-sw/cmssw/pull/45385#issue-2392303729

> fixes https://github.com/cms-sw/cmssw/issues/45384, 

#### PR validation:

Run the following command: `runTheMatrix.py --what upgrade -l 12842.0 -t 4 -j 8 --nEvents=100` to produce an input file, then analyzed with `SagittaBiasNtuplizer` (introduced back then at PR https://github.com/cms-sw/cmssw/pull/44297) by using this patch:

```diff
diff --git a/Alignment/OfflineValidation/test/SagittaBiasNtuplizer_cfg.py b/Alignment/OfflineValidation/test/SagittaBiasNtuplizer_cfg.py
index e5f08e57ebf..bfeb8c65021 100644
--- a/Alignment/OfflineValidation/test/SagittaBiasNtuplizer_cfg.py
+++ b/Alignment/OfflineValidation/test/SagittaBiasNtuplizer_cfg.py
@@ -179,18 +179,19 @@ process.refittedTracks = RecoTracker.TrackProducer.TrackRefitter_cfi.TrackRefitt
 ####################################################################
 from RecoVertex.PrimaryVertexProducer.OfflinePrimaryVertices_cfi import offlinePrimaryVertices
 process.offlinePrimaryVerticesFromRefittedTrks = offlinePrimaryVertices.clone()
-#process.offlinePrimaryVerticesFromRefittedTrks.TrackLabel = cms.InputTag("refittedVtxTracks")
-process.offlinePrimaryVerticesFromRefittedTrks.TrackLabel = cms.InputTag("refittedTracks")
+process.offlinePrimaryVerticesFromRefittedTrks.TrackLabel = cms.InputTag("refittedVtxTracks")
+#process.offlinePrimaryVerticesFromRefittedTrks.TrackLabel = cms.InputTag("refittedTracks")
 
 ###################################################################
 # The analysis modules
 ###################################################################
 process.ZtoMMNtuple = cms.EDAnalyzer("SagittaBiasNtuplizer",
-                                     #tracks = cms.InputTag('refittedMuons'),
-                                     useReco = cms.bool(True),
-                                     muons = cms.InputTag('muons'),
+                                     muonTracks = cms.InputTag('refittedMuons'),
+                                     useReco = cms.bool(False),
+                                     #muons = cms.InputTag('muons'),
                                      doGen = cms.bool(True),
-                                     tracks = cms.InputTag('refittedTracks'),
+                                     #tracks = cms.InputTag('refittedTracks'),
+                                     genParticles = cms.InputTag('TkAlDiMuonAndVertexGenMuonSelector'),
                                      vertices = cms.InputTag('offlinePrimaryVerticesFromRefittedTrks'))
 
 process.DiMuonVertexValidation = cms.EDAnalyzer("DiMuonVertexValidation",
@@ -257,9 +258,9 @@ process.TFileService = cms.Service("TFileService",
 # Path
 ###################################################################
 process.p1 = cms.Path(process.offlineBeamSpot
-                      #* process.refittedMuons
-                      #* process.refittedVtxTracks
-                      * process.refittedTracks
+                      * process.refittedMuons
+                      * process.refittedVtxTracks
+                      #* process.refittedTracks
                       * process.offlinePrimaryVerticesFromRefittedTrks
                       * process.ZtoMMNtuple) 
                       #* process.DiMuonVertexValidation
```

and analyzed with: `cmsRun SagittaBiasNtuplizer_cfg.py myfile=file:../../../12842.0_ZMM_13+2024/TkAlDiMuonAndVertex.root`. Finally the resulting output ntuple has been checked for having appropriate branches filled.

`runTheMatrix.py -l 1001.3` runs with this addition.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/45357 and  https://github.com/cms-sw/cmssw/pull/45385 for 2024 MC production purposes.