### PR TITLE
MTD simulation: fix association tracking particle - MtdSimLayerCluster

### DIFF
--- a/SimFastTiming/MtdAssociatorProducers/plugins/MtdSimLayerClusterToTPAssociatorByTrackIdImpl.cc
+++ b/SimFastTiming/MtdAssociatorProducers/plugins/MtdSimLayerClusterToTPAssociatorByTrackIdImpl.cc
@@ -29,11 +29,13 @@ reco::SimToTPCollectionMtd MtdSimLayerClusterToTPAssociatorByTrackIdImpl::associ
   std::map<std::pair<unsigned int, uint32_t>, TrackingParticleRef> tpIdMap;
   for (auto tpIt = trackingParticles.begin(); tpIt != trackingParticles.end(); tpIt++) {
     const auto& tp = *tpIt;
-    unsigned int tpTrackId = tp.g4Tracks()[0].trackId();
-    EncodedEventId tpEventId = tp.eventId();
-    TrackingParticleRef tpRef =
-        edm::Ref<TrackingParticleCollection>(trackingParticleH, tpIt - trackingParticles.begin());
-    tpIdMap[std::make_pair(tpTrackId, tpEventId.rawId())] = tpRef;
+    for (unsigned int igt = 0; igt < tp.g4Tracks().size(); igt++) {
+      unsigned int tpTrackId = tp.g4Tracks()[igt].trackId();
+      EncodedEventId tpEventId = tp.eventId();
+      TrackingParticleRef tpRef =
+          edm::Ref<TrackingParticleCollection>(trackingParticleH, tpIt - trackingParticles.begin());
+      tpIdMap[std::make_pair(tpTrackId, tpEventId.rawId())] = tpRef;
+    }
   }
 
   // -- loop over sim clusters and get the trackId, eventId
@@ -45,31 +47,26 @@ reco::SimToTPCollectionMtd MtdSimLayerClusterToTPAssociatorByTrackIdImpl::associ
     const auto& simClus = *simClusIt;
     size_t simClusIndex = simClusIt - simClusters.begin();
     MtdSimLayerClusterRef simClusterRef = edm::Ref<MtdSimLayerClusterCollection>(simClusH, simClusIndex);
-    unsigned int simClusTrackId = simClus.g4Tracks()[0].trackId();
-    EncodedEventId simClusEventId = simClus.eventId();
+    for (unsigned int igt = 0; igt < simClus.g4Tracks().size(); igt++) {
+      unsigned int simClusTrackId = simClus.g4Tracks()[igt].trackId();
+      EncodedEventId simClusEventId = simClus.eventId();
+      std::pair uniqueId = std::make_pair(simClusTrackId, simClusEventId.rawId());
+      auto it = tpIdMap.find(uniqueId);
 
-    // -- Check the trackId offset of the sim hits and keep only clusters with "direct" hits (offset == 0)
-    /* 
-       if (simClus.trackIdOffset() != 0 ) continue; 
-    */
+      if (it != tpIdMap.end()) {
+        TrackingParticleRef tpRef = tpIdMap[uniqueId];
+        outputCollection.insert(simClusterRef, tpRef);
 
-    std::pair uniqueId = std::make_pair(simClusTrackId, simClusEventId.rawId());
-    auto it = tpIdMap.find(uniqueId);
-
-    if (it != tpIdMap.end()) {
-      TrackingParticleRef tpRef = tpIdMap[uniqueId];
-      outputCollection.insert(simClusterRef, tpRef);
-
-      LogDebug("MtdSimLayerClusterToTPAssociator::associateSimToTP")
-          << "MtdSimLayerCluster: index = " << simClusIndex << "   simClus TrackId = " << simClusTrackId
-          << " simClus EventId = " << simClusEventId.rawId() << " simClus Eta = " << simClus.eta()
-          << " simClus Phi = " << simClus.phi() << "  simClus Time = " << simClus.simLCTime()
-          << "  simClus Energy = " << simClus.simLCEnergy() << std::endl;
-      LogDebug("MtdSimLayerClusterToTPAssociator::associateSimToTP")
-          << "  --> Found associated tracking particle:  tp TrackId = " << (*tpRef).g4Tracks()[0].trackId()
-          << " tp EventId = " << (*tpRef).eventId().rawId() << std::endl;
+        LogDebug("MtdSimLayerClusterToTPAssociator::associateSimToTP")
+            << "MtdSimLayerCluster: index = " << simClusIndex << "   simClus TrackId = " << simClusTrackId
+            << " simClus EventId = " << simClusEventId.rawId() << " simClus Eta = " << simClus.eta()
+            << " simClus Phi = " << simClus.phi() << "  simClus Time = " << simClus.simLCTime()
+            << "  simClus Energy = " << simClus.simLCEnergy() << std::endl;
+        LogDebug("MtdSimLayerClusterToTPAssociator::associateSimToTP")
+            << "  --> Found associated tracking particle:  tp TrackId = " << (*tpRef).g4Tracks()[0].trackId()
+            << " tp EventId = " << (*tpRef).eventId().rawId() << std::endl;
+      }
     }
-
   }  // -- end loop over sim clus
 
   return outputCollection;
@@ -88,11 +85,13 @@ reco::TPToSimCollectionMtd MtdSimLayerClusterToTPAssociatorByTrackIdImpl::associ
   std::map<std::pair<unsigned int, uint32_t>, std::vector<MtdSimLayerClusterRef>> simClusIdMap;
   for (auto simClusIt = simClusters.begin(); simClusIt != simClusters.end(); simClusIt++) {
     const auto& simClus = *simClusIt;
-    unsigned int simClusTrackId = simClus.g4Tracks()[0].trackId();
-    EncodedEventId simClusEventId = simClus.eventId();
-    MtdSimLayerClusterRef simClusterRef =
-        edm::Ref<MtdSimLayerClusterCollection>(simClusH, simClusIt - simClusters.begin());
-    simClusIdMap[std::make_pair(simClusTrackId, simClusEventId.rawId())].push_back(simClusterRef);
+    for (unsigned int igt = 0; igt < simClus.g4Tracks().size(); igt++) {
+      unsigned int simClusTrackId = simClus.g4Tracks()[igt].trackId();
+      EncodedEventId simClusEventId = simClus.eventId();
+      MtdSimLayerClusterRef simClusterRef =
+          edm::Ref<MtdSimLayerClusterCollection>(simClusH, simClusIt - simClusters.begin());
+      simClusIdMap[std::make_pair(simClusTrackId, simClusEventId.rawId())].push_back(simClusterRef);
+    }
   }
 
   // -- Loop over the tracking particles
@@ -100,31 +99,28 @@ reco::TPToSimCollectionMtd MtdSimLayerClusterToTPAssociatorByTrackIdImpl::associ
     const auto& tp = *tpIt;
     size_t tpIndex = tpIt - trackingParticles.begin();
     TrackingParticleRef tpRef = edm::Ref<TrackingParticleCollection>(trackingParticleH, tpIndex);
-    unsigned int tpTrackId = tp.g4Tracks()[0].trackId();
-    EncodedEventId tpEventId = tp.eventId();
+    for (unsigned int igt = 0; igt < tp.g4Tracks().size(); igt++) {
+      unsigned int tpTrackId = tp.g4Tracks()[igt].trackId();
+      EncodedEventId tpEventId = tp.eventId();
+      std::pair uniqueId = std::make_pair(tpTrackId, tpEventId.rawId());
+      auto it = simClusIdMap.find(uniqueId);
 
-    std::pair uniqueId = std::make_pair(tpTrackId, tpEventId.rawId());
-    auto it = simClusIdMap.find(uniqueId);
+      if (it != simClusIdMap.end()) {
+        for (unsigned int i = 0; i < simClusIdMap[uniqueId].size(); i++) {
+          MtdSimLayerClusterRef simClusterRef = simClusIdMap[uniqueId][i];
 
-    if (it != simClusIdMap.end()) {
-      for (unsigned int i = 0; i < simClusIdMap[uniqueId].size(); i++) {
-        MtdSimLayerClusterRef simClusterRef = simClusIdMap[uniqueId][i];
-        // -- Check the trackId offset of the sim hits and keep only clusters with "direct" hits (offset == 0)
-        /*
-	  if (simClus.trackIdOffset() != 0 ) continue; 
-	*/
+          outputCollection.insert(tpRef, simClusterRef);
 
-        outputCollection.insert(tpRef, simClusterRef);
-
-        LogDebug("MtdSimLayerClusterToTPAssociator")
-            << "Tracking particle:  index = " << tpIndex << "  tp TrackId = " << tpTrackId
-            << "  tp EventId = " << tpEventId.rawId();
-        LogDebug("MtdSimLayerClusterToTPAssociator")
-            << " --> Found associated MtdSimLayerCluster:  simClus TrackId = "
-            << (*simClusterRef).g4Tracks()[0].trackId() << " simClus EventId = " << (*simClusterRef).eventId().rawId()
-            << " simClus Eta = " << (*simClusterRef).eta() << " simClus Phi = " << (*simClusterRef).phi()
-            << "  simClus Time = " << (*simClusterRef).simLCTime()
-            << "  simClus Energy = " << (*simClusterRef).simLCEnergy() << std::endl;
+          LogDebug("MtdSimLayerClusterToTPAssociator")
+              << "Tracking particle:  index = " << tpIndex << "  tp TrackId = " << tpTrackId
+              << "  tp EventId = " << tpEventId.rawId();
+          LogDebug("MtdSimLayerClusterToTPAssociator")
+              << " --> Found associated MtdSimLayerCluster:  simClus TrackId = "
+              << (*simClusterRef).g4Tracks()[0].trackId() << " simClus EventId = " << (*simClusterRef).eventId().rawId()
+              << " simClus Eta = " << (*simClusterRef).eta() << " simClus Phi = " << (*simClusterRef).phi()
+              << "  simClus Time = " << (*simClusterRef).simLCTime()
+              << "  simClus Energy = " << (*simClusterRef).simLCEnergy() << std::endl;
+        }
       }
     }
   }

--- a/SimFastTiming/MtdAssociatorProducers/plugins/MtdSimLayerClusterToTPAssociatorByTrackIdImpl.cc
+++ b/SimFastTiming/MtdAssociatorProducers/plugins/MtdSimLayerClusterToTPAssociatorByTrackIdImpl.cc
@@ -29,9 +29,9 @@ reco::SimToTPCollectionMtd MtdSimLayerClusterToTPAssociatorByTrackIdImpl::associ
   std::map<std::pair<unsigned int, uint32_t>, TrackingParticleRef> tpIdMap;
   for (auto tpIt = trackingParticles.begin(); tpIt != trackingParticles.end(); tpIt++) {
     const auto& tp = *tpIt;
+    EncodedEventId tpEventId = tp.eventId();
     for (unsigned int igt = 0; igt < tp.g4Tracks().size(); igt++) {
       unsigned int tpTrackId = tp.g4Tracks()[igt].trackId();
-      EncodedEventId tpEventId = tp.eventId();
       TrackingParticleRef tpRef =
           edm::Ref<TrackingParticleCollection>(trackingParticleH, tpIt - trackingParticles.begin());
       tpIdMap[std::make_pair(tpTrackId, tpEventId.rawId())] = tpRef;
@@ -47,9 +47,9 @@ reco::SimToTPCollectionMtd MtdSimLayerClusterToTPAssociatorByTrackIdImpl::associ
     const auto& simClus = *simClusIt;
     size_t simClusIndex = simClusIt - simClusters.begin();
     MtdSimLayerClusterRef simClusterRef = edm::Ref<MtdSimLayerClusterCollection>(simClusH, simClusIndex);
+    EncodedEventId simClusEventId = simClus.eventId();
     for (unsigned int igt = 0; igt < simClus.g4Tracks().size(); igt++) {
       unsigned int simClusTrackId = simClus.g4Tracks()[igt].trackId();
-      EncodedEventId simClusEventId = simClus.eventId();
       std::pair uniqueId = std::make_pair(simClusTrackId, simClusEventId.rawId());
       auto it = tpIdMap.find(uniqueId);
 
@@ -85,9 +85,9 @@ reco::TPToSimCollectionMtd MtdSimLayerClusterToTPAssociatorByTrackIdImpl::associ
   std::map<std::pair<unsigned int, uint32_t>, std::vector<MtdSimLayerClusterRef>> simClusIdMap;
   for (auto simClusIt = simClusters.begin(); simClusIt != simClusters.end(); simClusIt++) {
     const auto& simClus = *simClusIt;
+    EncodedEventId simClusEventId = simClus.eventId();
     for (unsigned int igt = 0; igt < simClus.g4Tracks().size(); igt++) {
       unsigned int simClusTrackId = simClus.g4Tracks()[igt].trackId();
-      EncodedEventId simClusEventId = simClus.eventId();
       MtdSimLayerClusterRef simClusterRef =
           edm::Ref<MtdSimLayerClusterCollection>(simClusH, simClusIt - simClusters.begin());
       simClusIdMap[std::make_pair(simClusTrackId, simClusEventId.rawId())].push_back(simClusterRef);
@@ -99,9 +99,9 @@ reco::TPToSimCollectionMtd MtdSimLayerClusterToTPAssociatorByTrackIdImpl::associ
     const auto& tp = *tpIt;
     size_t tpIndex = tpIt - trackingParticles.begin();
     TrackingParticleRef tpRef = edm::Ref<TrackingParticleCollection>(trackingParticleH, tpIndex);
+    EncodedEventId tpEventId = tp.eventId();
     for (unsigned int igt = 0; igt < tp.g4Tracks().size(); igt++) {
       unsigned int tpTrackId = tp.g4Tracks()[igt].trackId();
-      EncodedEventId tpEventId = tp.eventId();
       std::pair uniqueId = std::make_pair(tpTrackId, tpEventId.rawId());
       auto it = simClusIdMap.find(uniqueId);
 


### PR DESCRIPTION
#### PR description:
This PR updates the association map TrackingParticle - MtdSimLayerCluster to include all g4Tracks of a tracking particle (not only the first one).
  
#### PR validation:
Tested on workflow 29623.0

