### PR TITLE
clang19 fix: template argument list is expected after a name prefixed

### DIFF
--- a/CommonTools/UtilAlgos/interface/ParameterAdapter.h
+++ b/CommonTools/UtilAlgos/interface/ParameterAdapter.h
@@ -14,7 +14,7 @@ namespace reco {
       static S make(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC) { return S(cfg, iC); }
       static S make(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC) { return S(cfg, iC); }
 
-      static void fillPSetDescription(edm::ParameterSetDescription& desc) { S::template fillPSetDescription(desc); }
+      static void fillPSetDescription(edm::ParameterSetDescription& desc) { S::fillPSetDescription(desc); }
     };
 
     template <typename S>

--- a/DPGAnalysis/MuonTools/interface/MuLocalRecoBaseProducer.h
+++ b/DPGAnalysis/MuonTools/interface/MuLocalRecoBaseProducer.h
@@ -53,7 +53,7 @@ class MuRecObjBaseProducer
 
 public:
   MuRecObjBaseProducer(edm::ParameterSet const &params)
-      : SimpleFlatTableProducerBase<RECO_T, COLLECTION>(params), m_token{this->template esConsumes()} {
+      : SimpleFlatTableProducerBase<RECO_T, COLLECTION>(params), m_token{this->esConsumes()} {
     auto varCfgs = params.getParameter<edm::ParameterSet>("detIdVariables");
     auto varNames = varCfgs.getParameterNamesForType<edm::ParameterSet>();
 

--- a/RecoEgamma/EgammaTools/plugins/EGFull5x5ShowerShapeModifier.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGFull5x5ShowerShapeModifier.cc
@@ -12,7 +12,7 @@ namespace {
   template <typename T, typename U, typename V>
   inline void make_consumes(const T& tag, edm::EDGetTokenT<U>& tok, V& sume) {
     if (!(empty_tag == tag))
-      tok = sume.template consumes(tag);
+      tok = sume.consumes(tag);
   }
 }  // namespace
 


### PR DESCRIPTION
This fixes the Clang 19 [build errors](https://github.com/cms-sw/cmsdist/pull/9585)
```
src/RecoEgamma/EgammaTools/plugins/EGFull5x5ShowerShapeModifier.cc:15:27: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
src/DPGAnalysis/MuonTools/interface/MuLocalRecoBaseProducer.h:56:89: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
```