### PR TITLE
[L1T] Peak Finding Algorithm for Vertex Reconstruction (Phase 2)

### DIFF
--- a/L1Trigger/VertexFinder/interface/AlgoSettings.h
+++ b/L1Trigger/VertexFinder/interface/AlgoSettings.h
@@ -11,6 +11,8 @@
 namespace l1tVertexFinder {
 
   enum class Algorithm {
+    PFA,
+    PFASingleVertex,
     fastHisto,
     fastHistoEmulation,
     fastHistoLooseAssociation,
@@ -49,6 +51,25 @@ namespace l1tVertexFinder {
     float vx_chi2cut() const { return vx_chi2cut_; }
     // Do track quality cuts in emulation algorithms
     bool vx_DoQualityCuts() const { return vx_DoQualityCuts_; }
+    // PFA scan parameters (min, max, width)
+    std::vector<double> vx_pfa_scanparameters() const { return vx_pfa_scanparameters_; }
+    double vx_pfa_min() const { return vx_pfa_scanparameters_.at(0); }
+    double vx_pfa_max() const { return vx_pfa_scanparameters_.at(1); }
+    double vx_pfa_binwidth() const { return vx_pfa_scanparameters_.at(2); }
+    // Include eta-dependence of the estimated track resolution used in PFA
+    bool vx_pfa_etadependentresolution() const { return vx_pfa_etadependentresolution_; }
+    // Scale factor for the PFA track resolution parameter (where the nominal values with and without eta-dependence are hard-coded using the fit results from Giovanna's thesis)
+    double vx_pfa_resolutionSF() const { return vx_pfa_resolutionSF_; }
+    // PFA Gaussian width cutoff
+    double vx_pfa_width() const { return vx_pfa_width_; }
+    // Enable 2-step process where the weighted pT sum is only calculated at positions where the weighted multiplicity is maximum ("local maxima"). In the second step, the local maximum with the largest weighted pT sum is chosen as the vertex.
+    bool vx_pfa_usemultiplicitymaxima() const { return vx_pfa_usemultiplicitymaxima_; }
+    // Weight function to use in PFA. 0: Gaussian, 1: Gaussian without width normalisation, 2: Complementary error function
+    unsigned int vx_pfa_weightfunction() const { return vx_pfa_weightfunction_; }
+    // Instead of taking the z0 value from the discrete PFA scan (0), calculate it from the Gaussian and pT-weighted sum of track z0 (1) or the optimal (1/variance) weighted mean of associated tracks, weighted also by pT and association probability (2)
+    unsigned int vx_pfa_weightedz0() const { return vx_pfa_weightedz0_; }
+    // Use vx_TrackMinPt cut specified below (otherwise no additional track selection is applied)
+    bool vx_pfa_doqualitycuts() const { return vx_pfa_doqualitycuts_; }
     // Window size of the sliding window
     unsigned int vx_windowSize() const { return vx_windowSize_; }
     // fastHisto histogram parameters (min, max, width)
@@ -112,6 +133,14 @@ namespace l1tVertexFinder {
     unsigned int vx_weightedmean_;
     float vx_chi2cut_;
     bool vx_DoQualityCuts_;
+    std::vector<double> vx_pfa_scanparameters_;
+    bool vx_pfa_etadependentresolution_;
+    double vx_pfa_resolutionSF_;
+    double vx_pfa_width_;
+    bool vx_pfa_usemultiplicitymaxima_;
+    unsigned int vx_pfa_weightfunction_;
+    unsigned int vx_pfa_weightedz0_;
+    bool vx_pfa_doqualitycuts_;
     bool vx_DoPtComp_;
     bool vx_DoTightChi2_;
     std::vector<double> vx_histogram_parameters_;

--- a/L1Trigger/VertexFinder/interface/AlgoSettings.h
+++ b/L1Trigger/VertexFinder/interface/AlgoSettings.h
@@ -68,8 +68,6 @@ namespace l1tVertexFinder {
     unsigned int vx_pfa_weightfunction() const { return vx_pfa_weightfunction_; }
     // Instead of taking the z0 value from the discrete PFA scan (0), calculate it from the Gaussian and pT-weighted average of track z0 (1) or the optimal (1/variance) weighted mean of associated tracks, weighted also by pT and association probability (2). Step function and pT-weighted average (3) is only designed for use with vx_pfa_weightfunction=3 (to replicate fastHisto).
     unsigned int vx_pfa_weightedz0() const { return vx_pfa_weightedz0_; }
-    // Use above vx_pfa_resolutionSF also in weighted-average z0 computation
-    bool vx_pfa_useSFforweightedz0() const { return vx_pfa_useSFforweightedz0_; }
     // Use vx_TrackMinPt cut specified below (otherwise no additional track selection is applied)
     bool vx_pfa_doqualitycuts() const { return vx_pfa_doqualitycuts_; }
     // Window size of the sliding window
@@ -142,7 +140,6 @@ namespace l1tVertexFinder {
     bool vx_pfa_usemultiplicitymaxima_;
     unsigned int vx_pfa_weightfunction_;
     unsigned int vx_pfa_weightedz0_;
-    bool vx_pfa_useSFforweightedz0_;
     bool vx_pfa_doqualitycuts_;
     bool vx_DoPtComp_;
     bool vx_DoTightChi2_;

--- a/L1Trigger/VertexFinder/interface/AlgoSettings.h
+++ b/L1Trigger/VertexFinder/interface/AlgoSettings.h
@@ -13,6 +13,7 @@ namespace l1tVertexFinder {
   enum class Algorithm {
     PFA,
     PFASingleVertex,
+    PFASimple,
     fastHisto,
     fastHistoEmulation,
     fastHistoLooseAssociation,

--- a/L1Trigger/VertexFinder/interface/AlgoSettings.h
+++ b/L1Trigger/VertexFinder/interface/AlgoSettings.h
@@ -64,10 +64,12 @@ namespace l1tVertexFinder {
     double vx_pfa_width() const { return vx_pfa_width_; }
     // Enable 2-step process where the weighted pT sum is only calculated at positions where the weighted multiplicity is maximum ("local maxima"). In the second step, the local maximum with the largest weighted pT sum is chosen as the vertex.
     bool vx_pfa_usemultiplicitymaxima() const { return vx_pfa_usemultiplicitymaxima_; }
-    // Weight function to use in PFA. 0: Gaussian, 1: Gaussian without width normalisation, 2: Complementary error function
+    // Weight function to use in PFA. 0: Gaussian, 1: Gaussian without width normalisation, 2: Complementary error function, 3: Step function
     unsigned int vx_pfa_weightfunction() const { return vx_pfa_weightfunction_; }
-    // Instead of taking the z0 value from the discrete PFA scan (0), calculate it from the Gaussian and pT-weighted sum of track z0 (1) or the optimal (1/variance) weighted mean of associated tracks, weighted also by pT and association probability (2)
+    // Instead of taking the z0 value from the discrete PFA scan (0), calculate it from the Gaussian and pT-weighted average of track z0 (1) or the optimal (1/variance) weighted mean of associated tracks, weighted also by pT and association probability (2)
     unsigned int vx_pfa_weightedz0() const { return vx_pfa_weightedz0_; }
+    // Use above vx_pfa_resolutionSF also in weighted-average z0 computation
+    bool vx_pfa_useSFforweightedz0() const { return vx_pfa_useSFforweightedz0_; }
     // Use vx_TrackMinPt cut specified below (otherwise no additional track selection is applied)
     bool vx_pfa_doqualitycuts() const { return vx_pfa_doqualitycuts_; }
     // Window size of the sliding window
@@ -140,6 +142,7 @@ namespace l1tVertexFinder {
     bool vx_pfa_usemultiplicitymaxima_;
     unsigned int vx_pfa_weightfunction_;
     unsigned int vx_pfa_weightedz0_;
+    bool vx_pfa_useSFforweightedz0_;
     bool vx_pfa_doqualitycuts_;
     bool vx_DoPtComp_;
     bool vx_DoTightChi2_;

--- a/L1Trigger/VertexFinder/interface/AlgoSettings.h
+++ b/L1Trigger/VertexFinder/interface/AlgoSettings.h
@@ -66,7 +66,7 @@ namespace l1tVertexFinder {
     bool vx_pfa_usemultiplicitymaxima() const { return vx_pfa_usemultiplicitymaxima_; }
     // Weight function to use in PFA. 0: Gaussian, 1: Gaussian without width normalisation, 2: Complementary error function, 3: Step function
     unsigned int vx_pfa_weightfunction() const { return vx_pfa_weightfunction_; }
-    // Instead of taking the z0 value from the discrete PFA scan (0), calculate it from the Gaussian and pT-weighted average of track z0 (1) or the optimal (1/variance) weighted mean of associated tracks, weighted also by pT and association probability (2)
+    // Instead of taking the z0 value from the discrete PFA scan (0), calculate it from the Gaussian and pT-weighted average of track z0 (1) or the optimal (1/variance) weighted mean of associated tracks, weighted also by pT and association probability (2). Step function and pT-weighted average (3) is only designed for use with vx_pfa_weightfunction=3 (to replicate fastHisto).
     unsigned int vx_pfa_weightedz0() const { return vx_pfa_weightedz0_; }
     // Use above vx_pfa_resolutionSF also in weighted-average z0 computation
     bool vx_pfa_useSFforweightedz0() const { return vx_pfa_useSFforweightedz0_; }

--- a/L1Trigger/VertexFinder/interface/AlgoSettings.h
+++ b/L1Trigger/VertexFinder/interface/AlgoSettings.h
@@ -95,7 +95,7 @@ namespace l1tVertexFinder {
     unsigned int vx_kmeans_nclusters() const { return vx_kmeans_nclusters_; }
     float vx_TrackMinPt() const { return vx_TrackMinPt_; }
     float vx_TrackMaxPt() const { return vx_TrackMaxPt_; }
-    float vx_TrackMaxPtBehavior() const { return vx_TrackMaxPtBehavior_; }
+    int vx_TrackMaxPtBehavior() const { return vx_TrackMaxPtBehavior_; }
     float vx_TrackMaxChi2() const { return vx_TrackMaxChi2_; }
     unsigned int vx_NStubMin() const { return vx_NStubMin_; }
     unsigned int vx_NStubPSMin() const { return vx_NStubPSMin_; }
@@ -155,7 +155,7 @@ namespace l1tVertexFinder {
     unsigned int vx_NStubMin_;
     unsigned int vx_NStubPSMin_;
     float vx_dbscan_pt_;
-    float vx_dbscan_mintracks_;
+    unsigned int vx_dbscan_mintracks_;
     unsigned int vx_kmeans_iterations_;
     unsigned int vx_kmeans_nclusters_;
     edm::FileInPath vx_trkw_graph_;     //For NNVtx (TrackWeight)

--- a/L1Trigger/VertexFinder/interface/AlgoSettings.h
+++ b/L1Trigger/VertexFinder/interface/AlgoSettings.h
@@ -67,7 +67,7 @@ namespace l1tVertexFinder {
     // Weight function to use in PFA (not used in PFASimple). 0: Gaussian, 1: Gaussian without width normalisation, 2: Complementary error function, 3: Step function. With vx_pfa_weightfunction=3 and PFA_UseMultiplicityMaxima=False, PFA and PFASimple are the same.
     unsigned int vx_pfa_weightfunction() const { return vx_pfa_weightfunction_; }
     // Instead of taking the z0 value from the discrete PFA scan (0), calculate it from the Gaussian and pT^N-weighted average of track z0 (1) or the optimal (1/variance) weighted mean of associated tracks, weighted also by pT^N and association probability (2). Step function and pT^N-weighted average (3) is intended for use with vx_pfa_weightfunction=3 or PFASimple (to replicate fastHisto).
-    // Additional options (4-11) have different uses of the track resolution (only relevant when eta-dependent) and different powers of trackPt in the weighted sum: see VertexFinder.cc for details.
+    // Additional options (4-11) have different uses of the track resolution (only relevant when eta-dependent) and different powers of trackPt in the weighted sum: see VertexFinder::calcPFAweights() for details.
     unsigned int vx_pfa_weightedz0() const { return vx_pfa_weightedz0_; }
     // Use vx_TrackMinPt cut specified below (otherwise no additional track selection is applied)
     bool vx_pfa_doqualitycuts() const { return vx_pfa_doqualitycuts_; }

--- a/L1Trigger/VertexFinder/interface/AlgoSettings.h
+++ b/L1Trigger/VertexFinder/interface/AlgoSettings.h
@@ -12,7 +12,6 @@ namespace l1tVertexFinder {
 
   enum class Algorithm {
     PFA,
-    PFASingleVertex,
     PFASimple,
     fastHisto,
     fastHistoEmulation,

--- a/L1Trigger/VertexFinder/interface/AlgoSettings.h
+++ b/L1Trigger/VertexFinder/interface/AlgoSettings.h
@@ -67,7 +67,8 @@ namespace l1tVertexFinder {
     bool vx_pfa_usemultiplicitymaxima() const { return vx_pfa_usemultiplicitymaxima_; }
     // Weight function to use in PFA. 0: Gaussian, 1: Gaussian without width normalisation, 2: Complementary error function, 3: Step function
     unsigned int vx_pfa_weightfunction() const { return vx_pfa_weightfunction_; }
-    // Instead of taking the z0 value from the discrete PFA scan (0), calculate it from the Gaussian and pT-weighted average of track z0 (1) or the optimal (1/variance) weighted mean of associated tracks, weighted also by pT and association probability (2). Step function and pT-weighted average (3) is only designed for use with vx_pfa_weightfunction=3 (to replicate fastHisto).
+    // Instead of taking the z0 value from the discrete PFA scan (0), calculate it from the Gaussian and pT^N-weighted average of track z0 (1) or the optimal (1/variance) weighted mean of associated tracks, weighted also by pT^N and association probability (2). Step function and pT^N-weighted average (3) is intended for use with vx_pfa_weightfunction=3 (to replicate fastHisto).
+    // Additional options (4-11) have different uses of the track resolution (only relevant when eta-dependent) and different powers of trackPt in the weighted sum: see VertexFinder.cc for details.
     unsigned int vx_pfa_weightedz0() const { return vx_pfa_weightedz0_; }
     // Use vx_TrackMinPt cut specified below (otherwise no additional track selection is applied)
     bool vx_pfa_doqualitycuts() const { return vx_pfa_doqualitycuts_; }

--- a/L1Trigger/VertexFinder/interface/AlgoSettings.h
+++ b/L1Trigger/VertexFinder/interface/AlgoSettings.h
@@ -51,22 +51,22 @@ namespace l1tVertexFinder {
     float vx_chi2cut() const { return vx_chi2cut_; }
     // Do track quality cuts in emulation algorithms
     bool vx_DoQualityCuts() const { return vx_DoQualityCuts_; }
-    // PFA scan parameters (min, max, width)
+    // PFA scan parameters (min, max, spacing) [cm]
     std::vector<double> vx_pfa_scanparameters() const { return vx_pfa_scanparameters_; }
     double vx_pfa_min() const { return vx_pfa_scanparameters_.at(0); }
     double vx_pfa_max() const { return vx_pfa_scanparameters_.at(1); }
     double vx_pfa_binwidth() const { return vx_pfa_scanparameters_.at(2); }
     // Include eta-dependence of the estimated track resolution used in PFA
     bool vx_pfa_etadependentresolution() const { return vx_pfa_etadependentresolution_; }
-    // Scale factor for the PFA track resolution parameter (where the nominal values with and without eta-dependence are hard-coded using the fit results from Giovanna's thesis)
+    // Multiplicative scale factor for the above PFA track resolution parameter
     double vx_pfa_resolutionSF() const { return vx_pfa_resolutionSF_; }
-    // PFA Gaussian width cutoff
+    // PFA Gaussian width cutoff for input tracks [cm] (not used in PFASimple)
     double vx_pfa_width() const { return vx_pfa_width_; }
-    // Enable 2-step process where the weighted pT sum is only calculated at positions where the weighted multiplicity is maximum ("local maxima"). In the second step, the local maximum with the largest weighted pT sum is chosen as the vertex.
+    // Enable 2-step process where the weighted pT sum is only calculated at positions where the weighted multiplicity is maximum ("local maxima"). In the second step, the local maximum with the largest weighted pT sum is chosen as the vertex. Only relevant for PFA (not used in PFASimple).
     bool vx_pfa_usemultiplicitymaxima() const { return vx_pfa_usemultiplicitymaxima_; }
-    // Weight function to use in PFA. 0: Gaussian, 1: Gaussian without width normalisation, 2: Complementary error function, 3: Step function
+    // Weight function to use in PFA (not used in PFASimple). 0: Gaussian, 1: Gaussian without width normalisation, 2: Complementary error function, 3: Step function. With vx_pfa_weightfunction=3 and PFA_UseMultiplicityMaxima=False, PFA and PFASimple are the same.
     unsigned int vx_pfa_weightfunction() const { return vx_pfa_weightfunction_; }
-    // Instead of taking the z0 value from the discrete PFA scan (0), calculate it from the Gaussian and pT^N-weighted average of track z0 (1) or the optimal (1/variance) weighted mean of associated tracks, weighted also by pT^N and association probability (2). Step function and pT^N-weighted average (3) is intended for use with vx_pfa_weightfunction=3 (to replicate fastHisto).
+    // Instead of taking the z0 value from the discrete PFA scan (0), calculate it from the Gaussian and pT^N-weighted average of track z0 (1) or the optimal (1/variance) weighted mean of associated tracks, weighted also by pT^N and association probability (2). Step function and pT^N-weighted average (3) is intended for use with vx_pfa_weightfunction=3 or PFASimple (to replicate fastHisto).
     // Additional options (4-11) have different uses of the track resolution (only relevant when eta-dependent) and different powers of trackPt in the weighted sum: see VertexFinder.cc for details.
     unsigned int vx_pfa_weightedz0() const { return vx_pfa_weightedz0_; }
     // Use vx_TrackMinPt cut specified below (otherwise no additional track selection is applied)

--- a/L1Trigger/VertexFinder/interface/AlgoSettings.h
+++ b/L1Trigger/VertexFinder/interface/AlgoSettings.h
@@ -51,17 +51,17 @@ namespace l1tVertexFinder {
     float vx_chi2cut() const { return vx_chi2cut_; }
     // Do track quality cuts in emulation algorithms
     bool vx_DoQualityCuts() const { return vx_DoQualityCuts_; }
-    // PFA scan parameters (min, max, spacing) [cm]
+    // PFA scan parameters (min, max, interval) [cm]
     std::vector<double> vx_pfa_scanparameters() const { return vx_pfa_scanparameters_; }
     double vx_pfa_min() const { return vx_pfa_scanparameters_.at(0); }
     double vx_pfa_max() const { return vx_pfa_scanparameters_.at(1); }
-    double vx_pfa_binwidth() const { return vx_pfa_scanparameters_.at(2); }
+    double vx_pfa_interval() const { return vx_pfa_scanparameters_.at(2); }
     // Include eta-dependence of the estimated track resolution used in PFA
     bool vx_pfa_etadependentresolution() const { return vx_pfa_etadependentresolution_; }
     // Multiplicative scale factor for the above PFA track resolution parameter
     double vx_pfa_resolutionSF() const { return vx_pfa_resolutionSF_; }
     // PFA Gaussian width cutoff for input tracks [cm] (not used in PFASimple)
-    double vx_pfa_width() const { return vx_pfa_width_; }
+    double vx_pfa_cutoff() const { return vx_pfa_cutoff_; }
     // Enable 2-step process where the weighted pT sum is only calculated at positions where the weighted multiplicity is maximum ("local maxima"). In the second step, the local maximum with the largest weighted pT sum is chosen as the vertex. Only relevant for PFA (not used in PFASimple).
     bool vx_pfa_usemultiplicitymaxima() const { return vx_pfa_usemultiplicitymaxima_; }
     // Weight function to use in PFA (not used in PFASimple). 0: Gaussian, 1: Gaussian without width normalisation, 2: Complementary error function, 3: Step function. With vx_pfa_weightfunction=3 and PFA_UseMultiplicityMaxima=False, PFA and PFASimple are the same.
@@ -137,7 +137,7 @@ namespace l1tVertexFinder {
     std::vector<double> vx_pfa_scanparameters_;
     bool vx_pfa_etadependentresolution_;
     double vx_pfa_resolutionSF_;
-    double vx_pfa_width_;
+    double vx_pfa_cutoff_;
     bool vx_pfa_usemultiplicitymaxima_;
     unsigned int vx_pfa_weightfunction_;
     unsigned int vx_pfa_weightedz0_;

--- a/L1Trigger/VertexFinder/interface/VertexFinder.h
+++ b/L1Trigger/VertexFinder/interface/VertexFinder.h
@@ -135,6 +135,12 @@ namespace l1tVertexFinder {
     void computeAndSetVertexParameters(RecoVertex<>& vertex,
                                        const std::vector<float>& bin_centers,
                                        const std::vector<unsigned int>& counts);
+
+    double computeAndSetVertexParametersPFA(RecoVertex<>& vertex);
+    /// Peak finding algorithm
+    void PFA();
+    /// Peak finding algorithm, single vertex
+    void PFASingleVertex();
     /// DBSCAN algorithm
     void DBSCAN();
     /// High pT Vertex Algorithm

--- a/L1Trigger/VertexFinder/interface/VertexFinder.h
+++ b/L1Trigger/VertexFinder/interface/VertexFinder.h
@@ -141,6 +141,8 @@ namespace l1tVertexFinder {
     void PFA();
     /// Peak finding algorithm, single vertex
     void PFASingleVertex();
+    /// Peak finding algorithm, single vertex, fastHisto-like simplification (by using step functon PFA weights)
+    void PFASimple();
     /// DBSCAN algorithm
     void DBSCAN();
     /// High pT Vertex Algorithm

--- a/L1Trigger/VertexFinder/interface/VertexFinder.h
+++ b/L1Trigger/VertexFinder/interface/VertexFinder.h
@@ -131,7 +131,7 @@ namespace l1tVertexFinder {
 
     /// Vertexing algorithms
 
-    /// Returns the track resolution in cm (which can depend on track eta)
+    /// Returns the track resolution in cm (which can depend on track eta), to be used in PFA
     float computeTrackZ0Res(const L1Track* track) const;
     /// Calculates the PFA weight and the weighted average z weight for a given track
     std::pair<float, float> calcPFAweights(const L1Track* track, double vertexZ0) const;

--- a/L1Trigger/VertexFinder/interface/VertexFinder.h
+++ b/L1Trigger/VertexFinder/interface/VertexFinder.h
@@ -142,7 +142,7 @@ namespace l1tVertexFinder {
                                         const std::vector<unsigned int>& counts);
     /// Peak finding algorithm
     void PFA();
-    /// Peak finding algorithm, single vertex, fastHisto-like simplification (by using step functon PFA weights)
+    /// Peak finding algorithm, single vertex, fastHisto-like simplification (by using PFA weight=1 for all tracks in the "bin" and 0 otherwise)
     void PFASimple();
     /// DBSCAN algorithm
     void DBSCAN();

--- a/L1Trigger/VertexFinder/interface/VertexFinder.h
+++ b/L1Trigger/VertexFinder/interface/VertexFinder.h
@@ -131,12 +131,15 @@ namespace l1tVertexFinder {
 
     /// Vertexing algorithms
 
+    /// Returns the track resolution in cm (which can depend on track eta)
+    float computeTrackZ0Res(const L1Track* track) const;
+    /// Calculates the PFA weight and the weighted average z weight for a given track
+    std::pair<float, float> calcPFAweights(const L1Track* track, double vertexZ0) const;
+
     /// Compute the vertex parameters
     float computeAndSetVertexParameters(RecoVertex<>& vertex,
                                         const std::vector<float>& bin_centers,
                                         const std::vector<unsigned int>& counts);
-    /// Calculates the PFA weight and the weighted average z weight for a given track
-    std::pair<float, float> calcPFAweights(const L1Track* track, double vertexZ0);
     /// Peak finding algorithm
     void PFA();
     /// Peak finding algorithm, single vertex, fastHisto-like simplification (by using step functon PFA weights)

--- a/L1Trigger/VertexFinder/interface/VertexFinder.h
+++ b/L1Trigger/VertexFinder/interface/VertexFinder.h
@@ -132,11 +132,9 @@ namespace l1tVertexFinder {
     /// Vertexing algorithms
 
     /// Compute the vertex parameters
-    void computeAndSetVertexParameters(RecoVertex<>& vertex,
+    float computeAndSetVertexParameters(RecoVertex<>& vertex,
                                        const std::vector<float>& bin_centers,
                                        const std::vector<unsigned int>& counts);
-    /// Dedicated function used only in PFA(). Not used in PFASimple(), which uses the computeAndSetVertexParameters() function shared with other algorithms.
-    double computeAndSetVertexParametersPFA(RecoVertex<>& vertex);
     /// Calculates the PFA weight and the weighted average z weight for a given track
     std::pair<float,float> calcPFAweights(const L1Track* track, double vertexZ0);
     /// Peak finding algorithm

--- a/L1Trigger/VertexFinder/interface/VertexFinder.h
+++ b/L1Trigger/VertexFinder/interface/VertexFinder.h
@@ -133,10 +133,10 @@ namespace l1tVertexFinder {
 
     /// Compute the vertex parameters
     float computeAndSetVertexParameters(RecoVertex<>& vertex,
-                                       const std::vector<float>& bin_centers,
-                                       const std::vector<unsigned int>& counts);
+                                        const std::vector<float>& bin_centers,
+                                        const std::vector<unsigned int>& counts);
     /// Calculates the PFA weight and the weighted average z weight for a given track
-    std::pair<float,float> calcPFAweights(const L1Track* track, double vertexZ0);
+    std::pair<float, float> calcPFAweights(const L1Track* track, double vertexZ0);
     /// Peak finding algorithm
     void PFA();
     /// Peak finding algorithm, single vertex, fastHisto-like simplification (by using step functon PFA weights)

--- a/L1Trigger/VertexFinder/interface/VertexFinder.h
+++ b/L1Trigger/VertexFinder/interface/VertexFinder.h
@@ -135,8 +135,10 @@ namespace l1tVertexFinder {
     void computeAndSetVertexParameters(RecoVertex<>& vertex,
                                        const std::vector<float>& bin_centers,
                                        const std::vector<unsigned int>& counts);
-
+    /// Dedicated function used only in PFA(). Not used in PFASimple(), which uses the computeAndSetVertexParameters() function shared with other algorithms.
     double computeAndSetVertexParametersPFA(RecoVertex<>& vertex);
+    /// Calculates the PFA weight and the weighted average z weight for a given track
+    std::pair<float,float> calcPFAweights(const L1Track* track, double vertexZ0);
     /// Peak finding algorithm
     void PFA();
     /// Peak finding algorithm, single vertex, fastHisto-like simplification (by using step functon PFA weights)

--- a/L1Trigger/VertexFinder/interface/VertexFinder.h
+++ b/L1Trigger/VertexFinder/interface/VertexFinder.h
@@ -139,8 +139,6 @@ namespace l1tVertexFinder {
     double computeAndSetVertexParametersPFA(RecoVertex<>& vertex);
     /// Peak finding algorithm
     void PFA();
-    /// Peak finding algorithm, single vertex
-    void PFASingleVertex();
     /// Peak finding algorithm, single vertex, fastHisto-like simplification (by using step functon PFA weights)
     void PFASimple();
     /// DBSCAN algorithm

--- a/L1Trigger/VertexFinder/plugins/VertexProducer.cc
+++ b/L1Trigger/VertexFinder/plugins/VertexProducer.cc
@@ -23,6 +23,12 @@ VertexProducer::VertexProducer(const edm::ParameterSet& iConfig)
   // Get configuration parameters
 
   switch (settings_.vx_algo()) {
+    case Algorithm::PFA:
+      edm::LogInfo("VertexProducer") << "VertexProducer::Finding vertices using the PFA algorithm";
+      break;
+    case Algorithm::PFASingleVertex:
+      edm::LogInfo("VertexProducer") << "VertexProducer::Finding vertices using the PFASingleVertex algorithm";
+      break;
     case Algorithm::fastHisto:
       edm::LogInfo("VertexProducer") << "VertexProducer::Finding vertices using the fastHisto binning algorithm";
       break;
@@ -110,6 +116,12 @@ void VertexProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Event
   VertexFinder vf(l1Tracks, settings_);
 
   switch (settings_.vx_algo()) {
+    case Algorithm::PFA:
+      vf.PFA();
+      break;
+    case Algorithm::PFASingleVertex:
+      vf.PFASingleVertex();
+      break;
     case Algorithm::fastHisto: {
       const TrackerTopology& tTopo = iSetup.getData(tTopoToken);
       vf.fastHisto(&tTopo);

--- a/L1Trigger/VertexFinder/plugins/VertexProducer.cc
+++ b/L1Trigger/VertexFinder/plugins/VertexProducer.cc
@@ -29,6 +29,9 @@ VertexProducer::VertexProducer(const edm::ParameterSet& iConfig)
     case Algorithm::PFASingleVertex:
       edm::LogInfo("VertexProducer") << "VertexProducer::Finding vertices using the PFASingleVertex algorithm";
       break;
+    case Algorithm::PFASimple:
+      edm::LogInfo("VertexProducer") << "VertexProducer::Finding vertices using the PFASimple algorithm";
+      break;
     case Algorithm::fastHisto:
       edm::LogInfo("VertexProducer") << "VertexProducer::Finding vertices using the fastHisto binning algorithm";
       break;
@@ -121,6 +124,9 @@ void VertexProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Event
       break;
     case Algorithm::PFASingleVertex:
       vf.PFASingleVertex();
+      break;
+    case Algorithm::PFASimple:
+      vf.PFASimple();
       break;
     case Algorithm::fastHisto: {
       const TrackerTopology& tTopo = iSetup.getData(tTopoToken);

--- a/L1Trigger/VertexFinder/plugins/VertexProducer.cc
+++ b/L1Trigger/VertexFinder/plugins/VertexProducer.cc
@@ -26,9 +26,6 @@ VertexProducer::VertexProducer(const edm::ParameterSet& iConfig)
     case Algorithm::PFA:
       edm::LogInfo("VertexProducer") << "VertexProducer::Finding vertices using the PFA algorithm";
       break;
-    case Algorithm::PFASingleVertex:
-      edm::LogInfo("VertexProducer") << "VertexProducer::Finding vertices using the PFASingleVertex algorithm";
-      break;
     case Algorithm::PFASimple:
       edm::LogInfo("VertexProducer") << "VertexProducer::Finding vertices using the PFASimple algorithm";
       break;
@@ -121,9 +118,6 @@ void VertexProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Event
   switch (settings_.vx_algo()) {
     case Algorithm::PFA:
       vf.PFA();
-      break;
-    case Algorithm::PFASingleVertex:
-      vf.PFASingleVertex();
       break;
     case Algorithm::PFASimple:
       vf.PFASimple();

--- a/L1Trigger/VertexFinder/python/l1tVertexProducer_cfi.py
+++ b/L1Trigger/VertexFinder/python/l1tVertexProducer_cfi.py
@@ -44,8 +44,6 @@ l1tVertexProducer = cms.EDProducer('VertexProducer',
         PFA_WeightFunction = cms.uint32(1),
         # Instead of taking the z0 value from the discrete PFA scan (0), calculate it from the Gaussian and pT-weighted average of track z0 (1) or the optimal (1/variance) weighted mean of associated tracks, weighted also by pT and association probability (2). Step function and pT-weighted average (3) is only designed for use with PFA_WeightFunction=3 (to replicate fastHisto).
         PFA_WeightedZ0 = cms.uint32(1),
-        # Use above PFA_ResolutionSF also in weighted-average z0 computation
-        PFA_UseSFforWeightedZ0 = cms.bool(True),
         # Use VxMinTrackPt cut specified below (otherwise no additional track selection is applied)
         PFA_DoQualityCuts = cms.bool(False),
         # fastHisto algorithm histogram parameters (min,max,width) [cm]

--- a/L1Trigger/VertexFinder/python/l1tVertexProducer_cfi.py
+++ b/L1Trigger/VertexFinder/python/l1tVertexProducer_cfi.py
@@ -31,7 +31,7 @@ l1tVertexProducer = cms.EDProducer('VertexProducer',
         # chi2dof < 5 for tracks with Pt > 10
         FH_DoTightChi2 = cms.bool(False),
         # PFA algorithm scan parameters (min,max,width) [cm]
-        PFA_ScanParameters = cms.vdouble(-20.46912512, 20.46912512, 0.03997876),
+        PFA_ScanParameters = cms.vdouble(-20.46912512, 20.46912512, 0.15991504),
         # Include eta-dependence of the estimated track resolution used in PFA
         PFA_EtaDependentResolution = cms.bool(True),
         # Scale factor for the PFA track resolution parameter (where the nominal values with and without eta-dependence are hard-coded using the fit results from Giovanna's thesis)

--- a/L1Trigger/VertexFinder/python/l1tVertexProducer_cfi.py
+++ b/L1Trigger/VertexFinder/python/l1tVertexProducer_cfi.py
@@ -42,7 +42,7 @@ l1tVertexProducer = cms.EDProducer('VertexProducer',
         PFA_UseMultiplicityMaxima = cms.bool(False),
         # Weight function to use in PFA. 0: Gaussian, 1: Gaussian without width normalisation, 2: Complementary error function, 3: Step function
         PFA_WeightFunction = cms.uint32(1),
-        # Instead of taking the z0 value from the discrete PFA scan (0), calculate it from the Gaussian and pT-weighted average of track z0 (1) or the optimal (1/variance) weighted mean of associated tracks, weighted also by pT and association probability (2)
+        # Instead of taking the z0 value from the discrete PFA scan (0), calculate it from the Gaussian and pT-weighted average of track z0 (1) or the optimal (1/variance) weighted mean of associated tracks, weighted also by pT and association probability (2). Step function and pT-weighted average (3) is only designed for use with PFA_WeightFunction=3 (to replicate fastHisto).
         PFA_WeightedZ0 = cms.uint32(1),
         # Use above PFA_ResolutionSF also in weighted-average z0 computation
         PFA_UseSFforWeightedZ0 = cms.bool(True),

--- a/L1Trigger/VertexFinder/python/l1tVertexProducer_cfi.py
+++ b/L1Trigger/VertexFinder/python/l1tVertexProducer_cfi.py
@@ -8,7 +8,7 @@ l1tVertexProducer = cms.EDProducer('VertexProducer',
   # === Vertex Reconstruction configuration
   VertexReconstruction = cms.PSet(
         # Vertex Reconstruction Algorithm
-        Algorithm = cms.string("fastHisto"),
+        Algorithm = cms.string("PFA"),
         # Vertex distance [cm]
         VertexDistance = cms.double(.15),
         # Assumed Vertex Resolution [cm]
@@ -21,15 +21,31 @@ l1tVertexProducer = cms.EDProducer('VertexProducer',
         #   0 = unweighted
         #   1 = pT weighted
         #   2 = pT^2 weighted
-        WeightedMean = cms.uint32(1),
+        WeightedMean = cms.uint32(2),
         # Chi2 cut for the Adaptive Vertex Reconstruction Algorithm
         AVR_chi2cut = cms.double(5.),
         # Do track quality cuts in emulation algorithms
         EM_DoQualityCuts = cms.bool(False),
         # Track-stubs Pt compatibility cut
-        FH_DoPtComp = cms.bool(True),
+        FH_DoPtComp = cms.bool(False),
         # chi2dof < 5 for tracks with Pt > 10
         FH_DoTightChi2 = cms.bool(False),
+        # PFA algorithm scan parameters (min,max,width) [cm]
+        PFA_ScanParameters = cms.vdouble(-20.46912512, 20.46912512, 0.03997876),
+        # Include eta-dependence of the estimated track resolution used in PFA
+        PFA_EtaDependentResolution = cms.bool(True),
+        # Scale factor for the PFA track resolution parameter (where the nominal values with and without eta-dependence are hard-coded using the fit results from Giovanna's thesis)
+        PFA_ResolutionSF = cms.double(2.),
+        # PFA Gaussian width cutoff [cm]
+        PFA_VertexWidth = cms.double(1.31), # Giovanna's recommendation of 3*sigma(lowest-resolution tracks).
+        # Enable 2-step process where the weighted pT sum is only calculated at positions where the weighted multiplicity is maximum ("local maxima"). In the second step, the local maximum with the largest weighted pT sum is chosen as the vertex.
+        PFA_UseMultiplicityMaxima = cms.bool(False),
+        # Weight function to use in PFA. 0: Gaussian, 1: Gaussian without width normalisation, 2: Complementary error function
+        PFA_WeightFunction = cms.uint32(1),
+        # Instead of taking the z0 value from the discrete PFA scan (0), calculate it from the Gaussian and pT-weighted sum of track z0 (1) or the optimal (1/variance) weighted mean of associated tracks, weighted also by pT and association probability (2)
+        PFA_WeightedZ0 = cms.uint32(1),
+        # Use VxMinTrackPt cut specified below (otherwise no additional track selection is applied)
+        PFA_DoQualityCuts = cms.bool(False),
         # fastHisto algorithm histogram parameters (min,max,width) [cm]
         # TDR settings: [-14.95, 15.0, 0.1]
         # L1TkPrimaryVertexProducer: [-30.0, 30.0, 0.09983361065]
@@ -38,7 +54,7 @@ l1tVertexProducer = cms.EDProducer('VertexProducer',
         # Track word limits (256 binns): [-20.46912512, 20.46912512, 0.15991504]
         FH_HistogramParameters = cms.vdouble(-20.46912512, 20.46912512, 0.15991504),
         # The number of vertixes to return (i.e. N windows with the highest combined pT)
-        FH_NVtx = cms.uint32(1),
+        FH_NVtx = cms.uint32(10),
         # fastHisto algorithm assumed vertex half-width [cm]
         FH_VertexWidth = cms.double(.15),
         # Window size of the sliding window
@@ -62,11 +78,11 @@ l1tVertexProducer = cms.EDProducer('VertexProducer',
         # Option '0' was used for the TDR, but '1' is used for the firmware
         VxMaxTrackPtBehavior = cms.int32(1),
         # Maximum chi2 of tracks used to create vertex
-        VxMaxTrackChi2 = cms.double(100.),
+        VxMaxTrackChi2 = cms.double(99999999.),
         # Minimum number of stubs associated to a track
-        VxMinNStub = cms.uint32(4),
+        VxMinNStub = cms.uint32(0),
         # Minimum number of stubs in PS modules associated to a track
-        VxMinNStubPS = cms.uint32(3),
+        VxMinNStubPS = cms.uint32(0),
         # Track weight NN graph 
         TrackWeightGraph = cms.FileInPath("L1Trigger/VertexFinder/data/NNVtx_WeightModelGraph.pb"),
         # Pattern recognition NN graph

--- a/L1Trigger/VertexFinder/python/l1tVertexProducer_cfi.py
+++ b/L1Trigger/VertexFinder/python/l1tVertexProducer_cfi.py
@@ -40,10 +40,12 @@ l1tVertexProducer = cms.EDProducer('VertexProducer',
         PFA_VertexWidth = cms.double(1.31), # Giovanna's recommendation of 3*sigma(lowest-resolution tracks).
         # Enable 2-step process where the weighted pT sum is only calculated at positions where the weighted multiplicity is maximum ("local maxima"). In the second step, the local maximum with the largest weighted pT sum is chosen as the vertex.
         PFA_UseMultiplicityMaxima = cms.bool(False),
-        # Weight function to use in PFA. 0: Gaussian, 1: Gaussian without width normalisation, 2: Complementary error function
+        # Weight function to use in PFA. 0: Gaussian, 1: Gaussian without width normalisation, 2: Complementary error function, 3: Step function
         PFA_WeightFunction = cms.uint32(1),
-        # Instead of taking the z0 value from the discrete PFA scan (0), calculate it from the Gaussian and pT-weighted sum of track z0 (1) or the optimal (1/variance) weighted mean of associated tracks, weighted also by pT and association probability (2)
+        # Instead of taking the z0 value from the discrete PFA scan (0), calculate it from the Gaussian and pT-weighted average of track z0 (1) or the optimal (1/variance) weighted mean of associated tracks, weighted also by pT and association probability (2)
         PFA_WeightedZ0 = cms.uint32(1),
+        # Use above PFA_ResolutionSF also in weighted-average z0 computation
+        PFA_UseSFforWeightedZ0 = cms.bool(True),
         # Use VxMinTrackPt cut specified below (otherwise no additional track selection is applied)
         PFA_DoQualityCuts = cms.bool(False),
         # fastHisto algorithm histogram parameters (min,max,width) [cm]

--- a/L1Trigger/VertexFinder/python/l1tVertexProducer_cfi.py
+++ b/L1Trigger/VertexFinder/python/l1tVertexProducer_cfi.py
@@ -43,7 +43,7 @@ l1tVertexProducer = cms.EDProducer('VertexProducer',
         # Weight function to use in PFA (not used in PFASimple). 0: Gaussian, 1: Gaussian without width normalisation, 2: Complementary error function, 3: Step function. With PFA_WeightFunction=3 and PFA_UseMultiplicityMaxima=False, PFA and PFASimple are the same.
         PFA_WeightFunction = cms.uint32(3),
         # Instead of taking the z0 value from the discrete PFA scan (0), calculate it from the Gaussian and pT^N-weighted average of track z0 (1) or the optimal (1/variance) weighted mean of associated tracks, weighted also by pT^N and association probability (2). Step function and pT^N-weighted average (3) is intended for use with PFA_WeightFunction=3 or PFASimple (to replicate fastHisto).
-        # Additional options (4-11) have different uses of the track resolution (only relevant when eta-dependent) and different powers of trackPt in the weighted sum: see VertexFinder.cc for details.
+        # Additional options (4-11) have different uses of the track resolution (only relevant when eta-dependent) and different powers of trackPt in the weighted sum: see VertexFinder::calcPFAweights() for details.
         PFA_WeightedZ0 = cms.uint32(10), # 10 seems best overall for PFA when using WeightedMean=2, but 7-11 all have similar performance (with the best one depending on the process)
         # Use VxMinTrackPt cut specified below (otherwise no additional track selection is applied)
         PFA_DoQualityCuts = cms.bool(False),

--- a/L1Trigger/VertexFinder/python/l1tVertexProducer_cfi.py
+++ b/L1Trigger/VertexFinder/python/l1tVertexProducer_cfi.py
@@ -37,7 +37,7 @@ l1tVertexProducer = cms.EDProducer('VertexProducer',
         # Multiplicative scale factor for the above PFA track resolution parameter
         PFA_ResolutionSF = cms.double(1.3),
         # PFA Gaussian width cutoff for input tracks [cm] (not used in PFASimple)
-        PFA_Cutoff = cms.double(1.31), # Giovanna's recommendation of 3*sigma(lowest-resolution tracks).
+        PFA_Cutoff = cms.double(1.31), # Using recommendation of 3*sigma(lowest-resolution tracks) from CERN-THESIS-2024-143
         # Enable 2-step process where the weighted pT sum is only calculated at positions where the weighted multiplicity is maximum ("local maxima"). In the second step, the local maximum with the largest weighted pT sum is chosen as the vertex. Only relevant for PFA (not used in PFASimple).
         PFA_UseMultiplicityMaxima = cms.bool(False),
         # Weight function to use in PFA (not used in PFASimple). 0: Gaussian, 1: Gaussian without width normalisation, 2: Complementary error function, 3: Step function. With PFA_WeightFunction=3 and PFA_UseMultiplicityMaxima=False, PFA and PFASimple are the same.

--- a/L1Trigger/VertexFinder/python/l1tVertexProducer_cfi.py
+++ b/L1Trigger/VertexFinder/python/l1tVertexProducer_cfi.py
@@ -42,7 +42,8 @@ l1tVertexProducer = cms.EDProducer('VertexProducer',
         PFA_UseMultiplicityMaxima = cms.bool(False),
         # Weight function to use in PFA. 0: Gaussian, 1: Gaussian without width normalisation, 2: Complementary error function, 3: Step function
         PFA_WeightFunction = cms.uint32(1),
-        # Instead of taking the z0 value from the discrete PFA scan (0), calculate it from the Gaussian and pT-weighted average of track z0 (1) or the optimal (1/variance) weighted mean of associated tracks, weighted also by pT and association probability (2). Step function and pT-weighted average (3) is only designed for use with PFA_WeightFunction=3 (to replicate fastHisto).
+        # Instead of taking the z0 value from the discrete PFA scan (0), calculate it from the Gaussian and pT-weighted average of track z0 (1) or the optimal (1/variance) weighted mean of associated tracks, weighted also by pT and association probability (2). Step function and pT-weighted average (3) is intended for use with PFA_WeightFunction=3 (to replicate fastHisto).
+        # Additional options (4-11) have different uses of the track resolution (only relevant when eta-dependent) and different powers of trackPt in the weighted sum: see VertexFinder.cc for details.
         PFA_WeightedZ0 = cms.uint32(1),
         # Use VxMinTrackPt cut specified below (otherwise no additional track selection is applied)
         PFA_DoQualityCuts = cms.bool(False),

--- a/L1Trigger/VertexFinder/python/l1tVertexProducer_cfi.py
+++ b/L1Trigger/VertexFinder/python/l1tVertexProducer_cfi.py
@@ -8,7 +8,7 @@ l1tVertexProducer = cms.EDProducer('VertexProducer',
   # === Vertex Reconstruction configuration
   VertexReconstruction = cms.PSet(
         # Vertex Reconstruction Algorithm
-        Algorithm = cms.string("PFA"),
+        Algorithm = cms.string("fastHisto"),
         # Vertex distance [cm]
         VertexDistance = cms.double(.15),
         # Assumed Vertex Resolution [cm]
@@ -35,16 +35,16 @@ l1tVertexProducer = cms.EDProducer('VertexProducer',
         # Include eta-dependence of the estimated track resolution used in PFA
         PFA_EtaDependentResolution = cms.bool(True),
         # Scale factor for the PFA track resolution parameter (where the nominal values with and without eta-dependence are hard-coded using the fit results from Giovanna's thesis)
-        PFA_ResolutionSF = cms.double(2.),
+        PFA_ResolutionSF = cms.double(1.3),
         # PFA Gaussian width cutoff [cm]
         PFA_VertexWidth = cms.double(1.31), # Giovanna's recommendation of 3*sigma(lowest-resolution tracks).
         # Enable 2-step process where the weighted pT sum is only calculated at positions where the weighted multiplicity is maximum ("local maxima"). In the second step, the local maximum with the largest weighted pT sum is chosen as the vertex.
         PFA_UseMultiplicityMaxima = cms.bool(False),
         # Weight function to use in PFA. 0: Gaussian, 1: Gaussian without width normalisation, 2: Complementary error function, 3: Step function
-        PFA_WeightFunction = cms.uint32(1),
+        PFA_WeightFunction = cms.uint32(2),
         # Instead of taking the z0 value from the discrete PFA scan (0), calculate it from the Gaussian and pT-weighted average of track z0 (1) or the optimal (1/variance) weighted mean of associated tracks, weighted also by pT and association probability (2). Step function and pT-weighted average (3) is intended for use with PFA_WeightFunction=3 (to replicate fastHisto).
         # Additional options (4-11) have different uses of the track resolution (only relevant when eta-dependent) and different powers of trackPt in the weighted sum: see VertexFinder.cc for details.
-        PFA_WeightedZ0 = cms.uint32(1),
+        PFA_WeightedZ0 = cms.uint32(8),
         # Use VxMinTrackPt cut specified below (otherwise no additional track selection is applied)
         PFA_DoQualityCuts = cms.bool(False),
         # fastHisto algorithm histogram parameters (min,max,width) [cm]
@@ -55,7 +55,7 @@ l1tVertexProducer = cms.EDProducer('VertexProducer',
         # Track word limits (256 binns): [-20.46912512, 20.46912512, 0.15991504]
         FH_HistogramParameters = cms.vdouble(-20.46912512, 20.46912512, 0.15991504),
         # The number of vertixes to return (i.e. N windows with the highest combined pT)
-        FH_NVtx = cms.uint32(10),
+        FH_NVtx = cms.uint32(1),
         # fastHisto algorithm assumed vertex half-width [cm]
         FH_VertexWidth = cms.double(.15),
         # Window size of the sliding window

--- a/L1Trigger/VertexFinder/python/l1tVertexProducer_cfi.py
+++ b/L1Trigger/VertexFinder/python/l1tVertexProducer_cfi.py
@@ -30,14 +30,14 @@ l1tVertexProducer = cms.EDProducer('VertexProducer',
         FH_DoPtComp = cms.bool(False),
         # chi2dof < 5 for tracks with Pt > 10
         FH_DoTightChi2 = cms.bool(False),
-        # PFA algorithm scan parameters (min,max,spacing) [cm]
+        # PFA algorithm scan parameters (min,max,interval) [cm]
         PFA_ScanParameters = cms.vdouble(-20.46912512, 20.46912512, 0.15991504), # set to the same values as for FH for ease of comparison
         # Include eta-dependence of the estimated track resolution used in PFA
         PFA_EtaDependentResolution = cms.bool(True),
         # Multiplicative scale factor for the above PFA track resolution parameter
         PFA_ResolutionSF = cms.double(1.3),
         # PFA Gaussian width cutoff for input tracks [cm] (not used in PFASimple)
-        PFA_VertexWidth = cms.double(1.31), # Giovanna's recommendation of 3*sigma(lowest-resolution tracks).
+        PFA_Cutoff = cms.double(1.31), # Giovanna's recommendation of 3*sigma(lowest-resolution tracks).
         # Enable 2-step process where the weighted pT sum is only calculated at positions where the weighted multiplicity is maximum ("local maxima"). In the second step, the local maximum with the largest weighted pT sum is chosen as the vertex. Only relevant for PFA (not used in PFASimple).
         PFA_UseMultiplicityMaxima = cms.bool(False),
         # Weight function to use in PFA (not used in PFASimple). 0: Gaussian, 1: Gaussian without width normalisation, 2: Complementary error function, 3: Step function. With PFA_WeightFunction=3 and PFA_UseMultiplicityMaxima=False, PFA and PFASimple are the same.

--- a/L1Trigger/VertexFinder/python/l1tVertexProducer_cfi.py
+++ b/L1Trigger/VertexFinder/python/l1tVertexProducer_cfi.py
@@ -30,21 +30,21 @@ l1tVertexProducer = cms.EDProducer('VertexProducer',
         FH_DoPtComp = cms.bool(False),
         # chi2dof < 5 for tracks with Pt > 10
         FH_DoTightChi2 = cms.bool(False),
-        # PFA algorithm scan parameters (min,max,width) [cm]
-        PFA_ScanParameters = cms.vdouble(-20.46912512, 20.46912512, 0.15991504),
+        # PFA algorithm scan parameters (min,max,spacing) [cm]
+        PFA_ScanParameters = cms.vdouble(-20.46912512, 20.46912512, 0.15991504), # set to the same values as for FH for ease of comparison
         # Include eta-dependence of the estimated track resolution used in PFA
         PFA_EtaDependentResolution = cms.bool(True),
-        # Scale factor for the PFA track resolution parameter (where the nominal values with and without eta-dependence are hard-coded using the fit results from Giovanna's thesis)
+        # Multiplicative scale factor for the above PFA track resolution parameter
         PFA_ResolutionSF = cms.double(1.3),
-        # PFA Gaussian width cutoff [cm]
+        # PFA Gaussian width cutoff for input tracks [cm] (not used in PFASimple)
         PFA_VertexWidth = cms.double(1.31), # Giovanna's recommendation of 3*sigma(lowest-resolution tracks).
-        # Enable 2-step process where the weighted pT sum is only calculated at positions where the weighted multiplicity is maximum ("local maxima"). In the second step, the local maximum with the largest weighted pT sum is chosen as the vertex.
+        # Enable 2-step process where the weighted pT sum is only calculated at positions where the weighted multiplicity is maximum ("local maxima"). In the second step, the local maximum with the largest weighted pT sum is chosen as the vertex. Only relevant for PFA (not used in PFASimple).
         PFA_UseMultiplicityMaxima = cms.bool(False),
-        # Weight function to use in PFA. 0: Gaussian, 1: Gaussian without width normalisation, 2: Complementary error function, 3: Step function
-        PFA_WeightFunction = cms.uint32(2),
-        # Instead of taking the z0 value from the discrete PFA scan (0), calculate it from the Gaussian and pT-weighted average of track z0 (1) or the optimal (1/variance) weighted mean of associated tracks, weighted also by pT and association probability (2). Step function and pT-weighted average (3) is intended for use with PFA_WeightFunction=3 (to replicate fastHisto).
+        # Weight function to use in PFA (not used in PFASimple). 0: Gaussian, 1: Gaussian without width normalisation, 2: Complementary error function, 3: Step function. With PFA_WeightFunction=3 and PFA_UseMultiplicityMaxima=False, PFA and PFASimple are the same.
+        PFA_WeightFunction = cms.uint32(3),
+        # Instead of taking the z0 value from the discrete PFA scan (0), calculate it from the Gaussian and pT^N-weighted average of track z0 (1) or the optimal (1/variance) weighted mean of associated tracks, weighted also by pT^N and association probability (2). Step function and pT^N-weighted average (3) is intended for use with PFA_WeightFunction=3 or PFASimple (to replicate fastHisto).
         # Additional options (4-11) have different uses of the track resolution (only relevant when eta-dependent) and different powers of trackPt in the weighted sum: see VertexFinder.cc for details.
-        PFA_WeightedZ0 = cms.uint32(8),
+        PFA_WeightedZ0 = cms.uint32(10), # 10 seems best overall for PFA, but 7-11 all have similar performance (with the best one depending on the process)
         # Use VxMinTrackPt cut specified below (otherwise no additional track selection is applied)
         PFA_DoQualityCuts = cms.bool(False),
         # fastHisto algorithm histogram parameters (min,max,width) [cm]

--- a/L1Trigger/VertexFinder/python/l1tVertexProducer_cfi.py
+++ b/L1Trigger/VertexFinder/python/l1tVertexProducer_cfi.py
@@ -21,7 +21,7 @@ l1tVertexProducer = cms.EDProducer('VertexProducer',
         #   0 = unweighted
         #   1 = pT weighted
         #   2 = pT^2 weighted
-        WeightedMean = cms.uint32(2),
+        WeightedMean = cms.uint32(1),
         # Chi2 cut for the Adaptive Vertex Reconstruction Algorithm
         AVR_chi2cut = cms.double(5.),
         # Do track quality cuts in emulation algorithms
@@ -44,7 +44,7 @@ l1tVertexProducer = cms.EDProducer('VertexProducer',
         PFA_WeightFunction = cms.uint32(3),
         # Instead of taking the z0 value from the discrete PFA scan (0), calculate it from the Gaussian and pT^N-weighted average of track z0 (1) or the optimal (1/variance) weighted mean of associated tracks, weighted also by pT^N and association probability (2). Step function and pT^N-weighted average (3) is intended for use with PFA_WeightFunction=3 or PFASimple (to replicate fastHisto).
         # Additional options (4-11) have different uses of the track resolution (only relevant when eta-dependent) and different powers of trackPt in the weighted sum: see VertexFinder.cc for details.
-        PFA_WeightedZ0 = cms.uint32(10), # 10 seems best overall for PFA, but 7-11 all have similar performance (with the best one depending on the process)
+        PFA_WeightedZ0 = cms.uint32(10), # 10 seems best overall for PFA when using WeightedMean=2, but 7-11 all have similar performance (with the best one depending on the process)
         # Use VxMinTrackPt cut specified below (otherwise no additional track selection is applied)
         PFA_DoQualityCuts = cms.bool(False),
         # fastHisto algorithm histogram parameters (min,max,width) [cm]

--- a/L1Trigger/VertexFinder/python/l1tVertexProducer_cfi.py
+++ b/L1Trigger/VertexFinder/python/l1tVertexProducer_cfi.py
@@ -27,7 +27,7 @@ l1tVertexProducer = cms.EDProducer('VertexProducer',
         # Do track quality cuts in emulation algorithms
         EM_DoQualityCuts = cms.bool(False),
         # Track-stubs Pt compatibility cut
-        FH_DoPtComp = cms.bool(False),
+        FH_DoPtComp = cms.bool(True),
         # chi2dof < 5 for tracks with Pt > 10
         FH_DoTightChi2 = cms.bool(False),
         # PFA algorithm scan parameters (min,max,interval) [cm]
@@ -79,11 +79,11 @@ l1tVertexProducer = cms.EDProducer('VertexProducer',
         # Option '0' was used for the TDR, but '1' is used for the firmware
         VxMaxTrackPtBehavior = cms.int32(1),
         # Maximum chi2 of tracks used to create vertex
-        VxMaxTrackChi2 = cms.double(99999999.),
+        VxMaxTrackChi2 = cms.double(100.),
         # Minimum number of stubs associated to a track
-        VxMinNStub = cms.uint32(0),
+        VxMinNStub = cms.uint32(4),
         # Minimum number of stubs in PS modules associated to a track
-        VxMinNStubPS = cms.uint32(0),
+        VxMinNStubPS = cms.uint32(3),
         # Track weight NN graph 
         TrackWeightGraph = cms.FileInPath("L1Trigger/VertexFinder/data/NNVtx_WeightModelGraph.pb"),
         # Pattern recognition NN graph

--- a/L1Trigger/VertexFinder/src/AlgoSettings.cc
+++ b/L1Trigger/VertexFinder/src/AlgoSettings.cc
@@ -20,6 +20,7 @@ namespace l1tVertexFinder {
         vx_pfa_usemultiplicitymaxima_(vertex_.getParameter<bool>("PFA_UseMultiplicityMaxima")),
         vx_pfa_weightfunction_(vertex_.getParameter<unsigned int>("PFA_WeightFunction")),
         vx_pfa_weightedz0_(vertex_.getParameter<unsigned int>("PFA_WeightedZ0")),
+        vx_pfa_useSFforweightedz0_(vertex_.getParameter<bool>("PFA_UseSFforWeightedZ0")),
         vx_pfa_doqualitycuts_(vertex_.getParameter<bool>("PFA_DoQualityCuts")),
         vx_DoPtComp_(vertex_.getParameter<bool>("FH_DoPtComp")),
         vx_DoTightChi2_(vertex_.getParameter<bool>("FH_DoTightChi2")),

--- a/L1Trigger/VertexFinder/src/AlgoSettings.cc
+++ b/L1Trigger/VertexFinder/src/AlgoSettings.cc
@@ -20,7 +20,6 @@ namespace l1tVertexFinder {
         vx_pfa_usemultiplicitymaxima_(vertex_.getParameter<bool>("PFA_UseMultiplicityMaxima")),
         vx_pfa_weightfunction_(vertex_.getParameter<unsigned int>("PFA_WeightFunction")),
         vx_pfa_weightedz0_(vertex_.getParameter<unsigned int>("PFA_WeightedZ0")),
-        vx_pfa_useSFforweightedz0_(vertex_.getParameter<bool>("PFA_UseSFforWeightedZ0")),
         vx_pfa_doqualitycuts_(vertex_.getParameter<bool>("PFA_DoQualityCuts")),
         vx_DoPtComp_(vertex_.getParameter<bool>("FH_DoPtComp")),
         vx_DoTightChi2_(vertex_.getParameter<bool>("FH_DoTightChi2")),

--- a/L1Trigger/VertexFinder/src/AlgoSettings.cc
+++ b/L1Trigger/VertexFinder/src/AlgoSettings.cc
@@ -67,6 +67,7 @@ namespace l1tVertexFinder {
   const std::map<std::string, Algorithm> AlgoSettings::algoNameMap = {
       {"PFA", Algorithm::PFA},
       {"PFASingleVertex", Algorithm::PFASingleVertex},
+      {"PFASimple", Algorithm::PFASimple},
       {"fastHisto", Algorithm::fastHisto},
       {"fastHistoEmulation", Algorithm::fastHistoEmulation},
       {"fastHistoLooseAssociation", Algorithm::fastHistoLooseAssociation},
@@ -82,6 +83,7 @@ namespace l1tVertexFinder {
   const std::map<Algorithm, Precision> AlgoSettings::algoPrecisionMap = {
       {Algorithm::PFA, Precision::Simulation},
       {Algorithm::PFASingleVertex, Precision::Simulation},
+      {Algorithm::PFASimple, Precision::Simulation},
       {Algorithm::fastHisto, Precision::Simulation},
       {Algorithm::fastHistoEmulation, Precision::Emulation},
       {Algorithm::fastHistoLooseAssociation, Precision::Simulation},

--- a/L1Trigger/VertexFinder/src/AlgoSettings.cc
+++ b/L1Trigger/VertexFinder/src/AlgoSettings.cc
@@ -13,6 +13,14 @@ namespace l1tVertexFinder {
         vx_weightedmean_(vertex_.getParameter<unsigned int>("WeightedMean")),
         vx_chi2cut_(vertex_.getParameter<double>("AVR_chi2cut")),
         vx_DoQualityCuts_(vertex_.getParameter<bool>("EM_DoQualityCuts")),
+        vx_pfa_scanparameters_(vertex_.getParameter<std::vector<double> >("PFA_ScanParameters")),
+        vx_pfa_etadependentresolution_(vertex_.getParameter<bool>("PFA_EtaDependentResolution")),
+        vx_pfa_resolutionSF_(vertex_.getParameter<double>("PFA_ResolutionSF")),
+        vx_pfa_width_(vertex_.getParameter<double>("PFA_VertexWidth")),
+        vx_pfa_usemultiplicitymaxima_(vertex_.getParameter<bool>("PFA_UseMultiplicityMaxima")),
+        vx_pfa_weightfunction_(vertex_.getParameter<unsigned int>("PFA_WeightFunction")),
+        vx_pfa_weightedz0_(vertex_.getParameter<unsigned int>("PFA_WeightedZ0")),
+        vx_pfa_doqualitycuts_(vertex_.getParameter<bool>("PFA_DoQualityCuts")),
         vx_DoPtComp_(vertex_.getParameter<bool>("FH_DoPtComp")),
         vx_DoTightChi2_(vertex_.getParameter<bool>("FH_DoTightChi2")),
         vx_histogram_parameters_(vertex_.getParameter<std::vector<double> >("FH_HistogramParameters")),
@@ -57,6 +65,8 @@ namespace l1tVertexFinder {
   }
 
   const std::map<std::string, Algorithm> AlgoSettings::algoNameMap = {
+      {"PFA", Algorithm::PFA},
+      {"PFASingleVertex", Algorithm::PFASingleVertex},
       {"fastHisto", Algorithm::fastHisto},
       {"fastHistoEmulation", Algorithm::fastHistoEmulation},
       {"fastHistoLooseAssociation", Algorithm::fastHistoLooseAssociation},
@@ -70,6 +80,8 @@ namespace l1tVertexFinder {
       {"NNEmulation", Algorithm::NNEmulation}};
 
   const std::map<Algorithm, Precision> AlgoSettings::algoPrecisionMap = {
+      {Algorithm::PFA, Precision::Simulation},
+      {Algorithm::PFASingleVertex, Precision::Simulation},
       {Algorithm::fastHisto, Precision::Simulation},
       {Algorithm::fastHistoEmulation, Precision::Emulation},
       {Algorithm::fastHistoLooseAssociation, Precision::Simulation},

--- a/L1Trigger/VertexFinder/src/AlgoSettings.cc
+++ b/L1Trigger/VertexFinder/src/AlgoSettings.cc
@@ -66,7 +66,6 @@ namespace l1tVertexFinder {
 
   const std::map<std::string, Algorithm> AlgoSettings::algoNameMap = {
       {"PFA", Algorithm::PFA},
-      {"PFASingleVertex", Algorithm::PFASingleVertex},
       {"PFASimple", Algorithm::PFASimple},
       {"fastHisto", Algorithm::fastHisto},
       {"fastHistoEmulation", Algorithm::fastHistoEmulation},
@@ -82,7 +81,6 @@ namespace l1tVertexFinder {
 
   const std::map<Algorithm, Precision> AlgoSettings::algoPrecisionMap = {
       {Algorithm::PFA, Precision::Simulation},
-      {Algorithm::PFASingleVertex, Precision::Simulation},
       {Algorithm::PFASimple, Precision::Simulation},
       {Algorithm::fastHisto, Precision::Simulation},
       {Algorithm::fastHistoEmulation, Precision::Emulation},

--- a/L1Trigger/VertexFinder/src/AlgoSettings.cc
+++ b/L1Trigger/VertexFinder/src/AlgoSettings.cc
@@ -16,7 +16,7 @@ namespace l1tVertexFinder {
         vx_pfa_scanparameters_(vertex_.getParameter<std::vector<double> >("PFA_ScanParameters")),
         vx_pfa_etadependentresolution_(vertex_.getParameter<bool>("PFA_EtaDependentResolution")),
         vx_pfa_resolutionSF_(vertex_.getParameter<double>("PFA_ResolutionSF")),
-        vx_pfa_width_(vertex_.getParameter<double>("PFA_VertexWidth")),
+        vx_pfa_cutoff_(vertex_.getParameter<double>("PFA_Cutoff")),
         vx_pfa_usemultiplicitymaxima_(vertex_.getParameter<bool>("PFA_UseMultiplicityMaxima")),
         vx_pfa_weightfunction_(vertex_.getParameter<unsigned int>("PFA_WeightFunction")),
         vx_pfa_weightedz0_(vertex_.getParameter<unsigned int>("PFA_WeightedZ0")),

--- a/L1Trigger/VertexFinder/src/VertexFinder.cc
+++ b/L1Trigger/VertexFinder/src/VertexFinder.cc
@@ -76,11 +76,22 @@ namespace l1tVertexFinder {
           // Estimates of vertex z0 and z0square based on optimal combination (weighted by 1/variance) of the z0 of the tracks associated to the vertex, weighted also by pT and association probability
           // Note, all tracks in the bin have association probability 1 based on the definiton of deltaZ above, so this method won't work well for large bin widths. In that case, the ErfcWeight should really be iteratively recalculated at the best estimate point of z0 (and not subtracting half the bin width in deltaZ), but this would require a second loop over tracks.
           zweight = ErfcWeight * std::pow(trackPt, settings_->vx_weightedmean()) / GaussianWidth / GaussianWidth;
-        }
-
-        if (settings_->vx_pfa_weightedz0() == 3) {
+        } else if (settings_->vx_pfa_weightedz0() == 3) {
           // Step function weight, to replicate fastHisto when used with settings_->vx_pfa_weightfunction() == 3
           zweight = StepFunctionWeight * std::pow(trackPt, settings_->vx_weightedmean());
+        }
+        // Additional undocumented options for the purpose of comparison (to demonstrate the effect of using the eta-dependent width in the weighted sum)
+        else if (settings_->vx_pfa_weightedz0() == 4) {
+          // Step function weight divided by step function width (to maintain constant area when using eta-dependent resolution)
+          zweight = StepFunctionWeight * std::pow(trackPt, settings_->vx_weightedmean()) /
+                    (GaussianWidth + 0.5 * settings_->vx_pfa_binwidth());
+        } else if (settings_->vx_pfa_weightedz0() == 5) {
+          // Step function weight weighted by 1/variance (relevant when using eta-dependent resolution)
+          zweight =
+              StepFunctionWeight * std::pow(trackPt, settings_->vx_weightedmean()) / GaussianWidth / GaussianWidth;
+        } else if (settings_->vx_pfa_weightedz0() == 6) {
+          // ErfcWeight with only 1/width
+          zweight = ErfcWeight * std::pow(trackPt, settings_->vx_weightedmean()) / GaussianWidth;
         }
 
         SumZWeight += zweight;

--- a/L1Trigger/VertexFinder/src/VertexFinder.cc
+++ b/L1Trigger/VertexFinder/src/VertexFinder.cc
@@ -717,7 +717,7 @@ namespace l1tVertexFinder {
   }
 
   /**
-  * @note This method is the same as PFA when settings_->vx_nvtx()=1
+  * @note This method is the same as PFA() when settings_->vx_nvtx()=1
   * @note This method does not support settings_->vx_pfa_usemultiplicitymaxima()=True (which requires a 2-step process).
   */
   void VertexFinder::PFASingleVertex() {
@@ -748,7 +748,7 @@ namespace l1tVertexFinder {
     }
 
     vertices_.emplace_back(leading_vertex);
-    pv_index_ = 0;  // finds only hard PV
+    pv_index_ = 0;
   }  // end of PFASingleVertex
 
   void VertexFinder::PFA() {
@@ -815,16 +815,17 @@ namespace l1tVertexFinder {
         vertexScore4 = vertex4.pt();
       }
 
-      // find out if vertex3 is a local maximum
-      vertex3LocalMaximum = (counter > 1) && (vertexScore3 > vertexScore2) && (vertexScore3 > vertexScore4);
+      // Find out if vertex3 is a local maximum. The >= are necessary because there can be 3 vertices in a row with the same score when using narrow binning and step function weights.
+      vertex3LocalMaximum =
+          (counter > 1) && (vertexScore3 >= vertexScore2) && (vertexScore3 >= vertexScore4) && (vertexScore3 > 0);
 
       bool adjacentR = false;
       bool adjacentL = false;
 
       if (settings_->vx_pfa_weightedz0() > 0) {
         zCorrection4 = vertex4.z0() - z;
-        adjacentR = (counter > 2) && (vertex1LocalMaximum) && (vertexScore2 > vertexScore3) && (zCorrection2 > 0);
-        adjacentL = (counter > 2) && (vertex3LocalMaximum) && (vertexScore2 > vertexScore1) && (zCorrection2 < 0);
+        adjacentR = (counter > 2) && (vertex1LocalMaximum) && (vertexScore2 >= vertexScore3) && (zCorrection2 > 0);
+        adjacentL = (counter > 2) && (vertex3LocalMaximum) && (vertexScore2 >= vertexScore1) && (zCorrection2 < 0);
       }
 
       if (vertex2LocalMaximum || adjacentL ||

--- a/L1Trigger/VertexFinder/src/VertexFinder.cc
+++ b/L1Trigger/VertexFinder/src/VertexFinder.cc
@@ -7,7 +7,7 @@ namespace l1tVertexFinder {
   // Returns the track resolution in cm (which can depend on track eta), to be used in PFA. Note in future this may not be necessary if the z0 uncertainty is included as a TTTrack property.
   float VertexFinder::computeTrackZ0Res(const L1Track* track) const {
     float trackAbsEta = std::abs(track->eta());
-    // Hard-coded eta-dependent and constant parametrisations of the track resolution taken from the PFA section of Giovanna's thesis: https://cds.cern.ch/record/2909504
+    // Hard-coded eta-dependent and constant parametrisations of the track resolution taken from the PFA section of Giovanna Salvi's CERN-THESIS-2024-143
     return settings_->vx_pfa_etadependentresolution()
                ? 0.09867 + 0.0007 * trackAbsEta + 0.0587 * trackAbsEta * trackAbsEta
                : 0.15;
@@ -22,7 +22,7 @@ namespace l1tVertexFinder {
     float deltaZ = std::abs(track->z0() - vertexZ0);
     float GaussianWeight = std::exp(-0.5 * std::pow(deltaZ / PFAWidth, 2)) / PFAWidth;
 
-    // Alternative definitions of PFA weights (added subsequent to Giovanna's thesis)
+    // Alternative definitions of PFA weights (added subsequent to CERN-THESIS-2024-143)
     // Redefine deltaZ as the distance of the track from the bin edge (zero if inside the bin)
     deltaZ = (deltaZ > 0.5 * settings_->vx_pfa_interval()) ? deltaZ - 0.5 * settings_->vx_pfa_interval() : 0;
     // Use Erfc to reduce the weight based on the probability that a track from a vertex in this bin would be closer than deltaZ to the edge of the bin
@@ -39,7 +39,7 @@ namespace l1tVertexFinder {
       weight *= PFAWidth;
     }
 
-    // Calculate z-weight for weighted average z0 calculation (added subsequent to Giovanna's thesis)
+    // Calculate z-weight for weighted average z0 calculation (added subsequent to CERN-THESIS-2024-143)
     float trackPt = track->pt();
     float zweight = 0.;
 
@@ -65,17 +65,17 @@ namespace l1tVertexFinder {
       // ErfcWeight with only 1/width
       zweight = ErfcWeight * std::pow(trackPt, settings_->vx_weightedmean()) / PFAWidth;
     }
-    // Copies of the above options using only trackPt^1 (instead of settings_->vx_weightedmean(), which defaults to 2)
+    // Copies of the above options using only trackPt^1 (instead of settings_->vx_weightedmean(), which is usually set to 2 for PFA)
     else if (settings_->vx_pfa_weightedz0() == 7) {
-      zweight = ErfcWeight * std::pow(trackPt, 1) / PFAWidth / PFAWidth;
+      zweight = ErfcWeight * trackPt / PFAWidth / PFAWidth;
     } else if (settings_->vx_pfa_weightedz0() == 8) {
-      zweight = ErfcWeight * std::pow(trackPt, 1) / PFAWidth;
+      zweight = ErfcWeight * trackPt / PFAWidth;
     } else if (settings_->vx_pfa_weightedz0() == 9) {
-      zweight = StepFunctionWeight * std::pow(trackPt, 1);
+      zweight = StepFunctionWeight * trackPt;
     } else if (settings_->vx_pfa_weightedz0() == 10) {
-      zweight = StepFunctionWeight * std::pow(trackPt, 1) / (PFAWidth + 0.5 * settings_->vx_pfa_interval());
+      zweight = StepFunctionWeight * trackPt / (PFAWidth + 0.5 * settings_->vx_pfa_interval());
     } else if (settings_->vx_pfa_weightedz0() == 11) {
-      zweight = StepFunctionWeight * std::pow(trackPt, 1) / PFAWidth / PFAWidth;
+      zweight = StepFunctionWeight * trackPt / PFAWidth / PFAWidth;
     }
 
     return std::make_pair(weight, zweight);

--- a/L1Trigger/VertexFinder/src/VertexFinder.cc
+++ b/L1Trigger/VertexFinder/src/VertexFinder.cc
@@ -6,11 +6,15 @@ namespace l1tVertexFinder {
 
   // Returns the track resolution in cm (which can depend on track eta), to be used in PFA. Note in future this may not be necessary if the z0 uncertainty is included as a TTTrack property.
   float VertexFinder::computeTrackZ0Res(const L1Track* track) const {
+    constexpr float kPfaZ0ResP0 = 0.09867f;
+    constexpr float kPfaZ0ResP1 = 0.0007f;
+    constexpr float kPfaZ0ResP2 = 0.0587f;
+    constexpr float kPfaZ0ResConst = 0.15f;
     float trackAbsEta = std::abs(track->eta());
     // Hard-coded eta-dependent and constant parametrisations of the track resolution taken from the PFA section of Giovanna Salvi's CERN-THESIS-2024-143
     return settings_->vx_pfa_etadependentresolution()
-               ? 0.09867 + 0.0007 * trackAbsEta + 0.0587 * trackAbsEta * trackAbsEta
-               : 0.15;
+               ? kPfaZ0ResP0 + kPfaZ0ResP1 * trackAbsEta + kPfaZ0ResP2 * trackAbsEta * trackAbsEta
+               : kPfaZ0ResConst;
   }
 
   // Calculates the PFA weight and the weighted average z weight for a given track

--- a/L1Trigger/VertexFinder/src/VertexFinder.cc
+++ b/L1Trigger/VertexFinder/src/VertexFinder.cc
@@ -90,6 +90,7 @@ namespace l1tVertexFinder {
     bool highPt = false;
     double highestPt = 0.;
     unsigned int numHighPtTracks = 0;
+    unsigned int numSelectedTracks = 0;
 
     float SumZ = 0.;
     float z0square = 0.;
@@ -120,6 +121,7 @@ namespace l1tVertexFinder {
         else if (settings_->vx_TrackMaxPtBehavior() == 1)
           trackPt = settings_->vx_TrackMaxPt();  // saturate
       }
+      numSelectedTracks++;
 
       std::pair<float, float> PFAweights;
       if (isPFA) {
@@ -167,9 +169,9 @@ namespace l1tVertexFinder {
         z0 = vertex.z0();
         z0width = 0.;
       }
-    } else {
-      z0 = SumZ / ((settings_->vx_weightedmean() > 0) ? pt : vertex.numTracks());
-      z0square /= vertex.numTracks();
+    } else if (pt > 0) {  // Avoid dividing by 0 when there are no tracks. pt > 0 also implies numSelectedTracks > 0.
+      z0 = SumZ / ((settings_->vx_weightedmean() > 0) ? pt : numSelectedTracks);
+      z0square /= numSelectedTracks;
       z0width = sqrt(std::abs(z0 * z0 - z0square));
     }
 

--- a/L1Trigger/VertexFinder/src/VertexFinder.cc
+++ b/L1Trigger/VertexFinder/src/VertexFinder.cc
@@ -127,7 +127,7 @@ namespace l1tVertexFinder {
       }
 
       if (settings_->vx_algo() == Algorithm::PFA) {
-        // note this is not used in PFASimple(), where the simplification is that all tracks in the "bin" have PFA weight 1 (and 0 otherwise)
+        // Note this weight is not used in Algorithm::PFASimple, where the simplification is that all tracks in the "bin" have PFA weight 1 (and 0 otherwise)
         float weight = weights.first;
         SumWeightPFA += weight;
         pt += weight * std::pow(trackPt, settings_->vx_weightedmean());

--- a/L1Trigger/VertexFinder/src/VertexFinder.cc
+++ b/L1Trigger/VertexFinder/src/VertexFinder.cc
@@ -32,8 +32,8 @@ namespace l1tVertexFinder {
 
     // Choice of weight function to use for the vertex score in PFA
     float weight = settings_->vx_pfa_weightfunction() == 3
-                        ? StepFunctionWeight
-                        : (settings_->vx_pfa_weightfunction() == 2 ? ErfcWeight : GaussianWeight);
+                       ? StepFunctionWeight
+                       : (settings_->vx_pfa_weightfunction() == 2 ? ErfcWeight : GaussianWeight);
     if (settings_->vx_pfa_weightfunction() == 1) {
       weight *= GaussianWidth;
     }
@@ -57,8 +57,7 @@ namespace l1tVertexFinder {
                 (GaussianWidth + 0.5 * settings_->vx_pfa_binwidth());
     } else if (settings_->vx_pfa_weightedz0() == 5) {
       // Step function weight weighted by 1/variance (relevant when using eta-dependent resolution)
-      zweight =
-          StepFunctionWeight * std::pow(trackPt, settings_->vx_weightedmean()) / GaussianWidth / GaussianWidth;
+      zweight = StepFunctionWeight * std::pow(trackPt, settings_->vx_weightedmean()) / GaussianWidth / GaussianWidth;
     } else if (settings_->vx_pfa_weightedz0() == 6) {
       // ErfcWeight with only 1/width
       zweight = ErfcWeight * std::pow(trackPt, settings_->vx_weightedmean()) / GaussianWidth;
@@ -80,8 +79,8 @@ namespace l1tVertexFinder {
   }
 
   float VertexFinder::computeAndSetVertexParameters(RecoVertex<>& vertex,
-                                                   const std::vector<float>& bin_centers,
-                                                   const std::vector<unsigned int>& counts) {
+                                                    const std::vector<float>& bin_centers,
+                                                    const std::vector<unsigned int>& counts) {
     double pt = 0.;
     double z0 = -999.;
     double z0width = 0.;
@@ -129,8 +128,7 @@ namespace l1tVertexFinder {
         float weight = weights.first;
         SumWeightPFA += weight;
         pt += weight * std::pow(trackPt, settings_->vx_weightedmean());
-      }
-      else {
+      } else {
         pt += std::pow(trackPt, settings_->vx_weightedmean());
       }
 

--- a/L1Trigger/VertexFinder/src/VertexFinder.cc
+++ b/L1Trigger/VertexFinder/src/VertexFinder.cc
@@ -24,7 +24,7 @@ namespace l1tVertexFinder {
 
     // Alternative definitions of PFA weights (added subsequent to Giovanna's thesis)
     // Redefine deltaZ as the distance of the track from the bin edge (zero if inside the bin)
-    deltaZ = (deltaZ > 0.5 * settings_->vx_pfa_binwidth()) ? deltaZ - 0.5 * settings_->vx_pfa_binwidth() : 0;
+    deltaZ = (deltaZ > 0.5 * settings_->vx_pfa_interval()) ? deltaZ - 0.5 * settings_->vx_pfa_interval() : 0;
     // Use Erfc to reduce the weight based on the probability that a track from a vertex in this bin would be closer than deltaZ to the edge of the bin
     float ErfcWeight = std::erfc(M_SQRT1_2 * deltaZ / PFAWidth);
 
@@ -57,7 +57,7 @@ namespace l1tVertexFinder {
     else if (settings_->vx_pfa_weightedz0() == 4) {
       // Step function weight divided by step function width (to maintain constant area when using eta-dependent resolution)
       zweight = StepFunctionWeight * std::pow(trackPt, settings_->vx_weightedmean()) /
-                (PFAWidth + 0.5 * settings_->vx_pfa_binwidth());
+                (PFAWidth + 0.5 * settings_->vx_pfa_interval());
     } else if (settings_->vx_pfa_weightedz0() == 5) {
       // Step function weight weighted by 1/variance (only relevant when using eta-dependent resolution)
       zweight = StepFunctionWeight * std::pow(trackPt, settings_->vx_weightedmean()) / PFAWidth / PFAWidth;
@@ -73,7 +73,7 @@ namespace l1tVertexFinder {
     } else if (settings_->vx_pfa_weightedz0() == 9) {
       zweight = StepFunctionWeight * std::pow(trackPt, 1);
     } else if (settings_->vx_pfa_weightedz0() == 10) {
-      zweight = StepFunctionWeight * std::pow(trackPt, 1) / (PFAWidth + 0.5 * settings_->vx_pfa_binwidth());
+      zweight = StepFunctionWeight * std::pow(trackPt, 1) / (PFAWidth + 0.5 * settings_->vx_pfa_interval());
     } else if (settings_->vx_pfa_weightedz0() == 11) {
       zweight = StepFunctionWeight * std::pow(trackPt, 1) / PFAWidth / PFAWidth;
     }
@@ -724,15 +724,15 @@ namespace l1tVertexFinder {
     float vxPt = 0.;
     RecoVertex leading_vertex;
 
-    int nbins = std::ceil((settings_->vx_pfa_max() - settings_->vx_pfa_min()) / settings_->vx_pfa_binwidth());
+    int nbins = std::ceil((settings_->vx_pfa_max() - settings_->vx_pfa_min()) / settings_->vx_pfa_interval());
     for (int i = 0; i <= nbins; ++i) {
-      float z = settings_->vx_pfa_min() + i * settings_->vx_pfa_binwidth();
+      float z = settings_->vx_pfa_min() + i * settings_->vx_pfa_interval();
       RecoVertex vertex;
       vertex.setZ0(z);
       for (const L1Track& track : fitTracks_) {
         // Calculate PFA width parameter (customised using multiplicative scale factor)
         float PFAWidth = computeTrackZ0Res(&track) * settings_->vx_pfa_resolutionSF();
-        if (std::abs(z - track.z0()) > PFAWidth + 0.5 * settings_->vx_pfa_binwidth())
+        if (std::abs(z - track.z0()) > PFAWidth + 0.5 * settings_->vx_pfa_interval())
           continue;
 
         if (settings_->vx_pfa_doqualitycuts() &
@@ -775,11 +775,11 @@ namespace l1tVertexFinder {
     bool vertex2LocalMaximum = false;
     bool vertex3LocalMaximum = false;
 
-    int nbins = std::ceil((settings_->vx_pfa_max() - settings_->vx_pfa_min()) / settings_->vx_pfa_binwidth());
+    int nbins = std::ceil((settings_->vx_pfa_max() - settings_->vx_pfa_min()) / settings_->vx_pfa_interval());
     std::vector<RecoVertex<>> sums;
     int counter = 0;
     for (int i = -1; i <= nbins + 2; ++i) {
-      float z = settings_->vx_pfa_min() + i * settings_->vx_pfa_binwidth();
+      float z = settings_->vx_pfa_min() + i * settings_->vx_pfa_interval();
 
       // Store vertex scores in 3 successive bins so we can identify local maxima
       vertexScore1 = vertexScore2;
@@ -799,7 +799,7 @@ namespace l1tVertexFinder {
       RecoVertex vertex;
       vertex.setZ0(z);
       for (const L1Track& track : fitTracks_) {
-        if (std::abs(z - track.z0()) > settings_->vx_pfa_width())
+        if (std::abs(z - track.z0()) > settings_->vx_pfa_cutoff())
           continue;
 
         if (settings_->vx_pfa_doqualitycuts() &

--- a/L1Trigger/VertexFinder/src/VertexFinder.cc
+++ b/L1Trigger/VertexFinder/src/VertexFinder.cc
@@ -47,11 +47,10 @@ namespace l1tVertexFinder {
       // Gaussian- and pT-weighted average
       zweight = GaussianWeight * std::pow(trackPt, settings_->vx_weightedmean());
     } else if (settings_->vx_pfa_weightedz0() == 2) {
-      // Estimates of vertex z0 and z0square based on optimal combination (weighted by 1/variance) of the z0 of the tracks associated to the vertex, weighted also by pT and association probability
-      // Note, all tracks in the bin have association probability 1 based on the definiton of deltaZ above, so this method won't work well for large bin widths. In that case, the ErfcWeight should really be iteratively recalculated at the best estimate point of z0 (and not subtracting half the bin width in deltaZ), but this would require a second loop over tracks.
+      // Estimates of vertex z0 and z0square based on optimal combination (weighted by 1/variance) of the z0 of the tracks associated to the vertex, weighted also by pT and association probability (ErfcWeight)
       zweight = ErfcWeight * std::pow(trackPt, settings_->vx_weightedmean()) / PFAWidth / PFAWidth;
     } else if (settings_->vx_pfa_weightedz0() == 3) {
-      // Step function weight, to replicate fastHisto when used with settings_->vx_pfa_weightfunction() == 3
+      // Step function weight, to replicate fastHisto when used with settings_->vx_pfa_weightfunction() == 3 or Algorithm::PFASimple
       zweight = StepFunctionWeight * std::pow(trackPt, settings_->vx_weightedmean());
     }
     // Additional options with different uses of the eta-dependent width
@@ -60,13 +59,13 @@ namespace l1tVertexFinder {
       zweight = StepFunctionWeight * std::pow(trackPt, settings_->vx_weightedmean()) /
                 (PFAWidth + 0.5 * settings_->vx_pfa_binwidth());
     } else if (settings_->vx_pfa_weightedz0() == 5) {
-      // Step function weight weighted by 1/variance (relevant when using eta-dependent resolution)
+      // Step function weight weighted by 1/variance (only relevant when using eta-dependent resolution)
       zweight = StepFunctionWeight * std::pow(trackPt, settings_->vx_weightedmean()) / PFAWidth / PFAWidth;
     } else if (settings_->vx_pfa_weightedz0() == 6) {
       // ErfcWeight with only 1/width
       zweight = ErfcWeight * std::pow(trackPt, settings_->vx_weightedmean()) / PFAWidth;
     }
-    // Additional options using only trackPt^1 (instead of settings_->vx_weightedmean(), which defaults to 2)
+    // Copies of the above options using only trackPt^1 (instead of settings_->vx_weightedmean(), which defaults to 2)
     else if (settings_->vx_pfa_weightedz0() == 7) {
       zweight = ErfcWeight * std::pow(trackPt, 1) / PFAWidth / PFAWidth;
     } else if (settings_->vx_pfa_weightedz0() == 8) {
@@ -138,7 +137,7 @@ namespace l1tVertexFinder {
 
       if (isPFA) {
         if (settings_->vx_pfa_weightedz0() > 0) {
-          // Calculate weighted-average z0 for PFASimple and PFA
+          // Calculate sums for weighted-average z0 for PFASimple and PFA
           float zweight = PFAweights.second;
           SumZWeightPFA += zweight;
           SumZ += track->z0() * zweight;

--- a/L1Trigger/VertexFinder/src/VertexFinder.cc
+++ b/L1Trigger/VertexFinder/src/VertexFinder.cc
@@ -4,7 +4,7 @@ using namespace std;
 
 namespace l1tVertexFinder {
 
-  // Returns the track resolution in cm (which can depend on track eta), to be used in PFA
+  // Returns the track resolution in cm (which can depend on track eta), to be used in PFA. Note in future this may not be necessary if the z0 uncertainty is included as a TTTrack property.
   float VertexFinder::computeTrackZ0Res(const L1Track* track) const {
     float trackAbsEta = std::fabs(track->eta());
     // Hard-coded eta-dependent and constant parametrisations of the track resolution taken from the PFA section of Giovanna's thesis: https://cds.cern.ch/record/2909504
@@ -39,7 +39,7 @@ namespace l1tVertexFinder {
       weight *= PFAWidth;
     }
 
-    // Calculate z-weight for weighted average z0 calculation
+    // Calculate z-weight for weighted average z0 calculation (added subsequent to Giovanna's thesis)
     float trackPt = track->pt();
     float zweight = 0.;
 
@@ -50,7 +50,7 @@ namespace l1tVertexFinder {
       // Estimates of vertex z0 and z0square based on optimal combination (weighted by 1/variance) of the z0 of the tracks associated to the vertex, weighted also by pT and association probability (ErfcWeight)
       zweight = ErfcWeight * std::pow(trackPt, settings_->vx_weightedmean()) / PFAWidth / PFAWidth;
     } else if (settings_->vx_pfa_weightedz0() == 3) {
-      // Step function weight, to replicate fastHisto when used with settings_->vx_pfa_weightfunction() == 3 or Algorithm::PFASimple
+      // Step function weight, to replicate fastHisto when used with settings_->vx_pfa_weightfunction() = 3 or Algorithm::PFASimple
       zweight = StepFunctionWeight * std::pow(trackPt, settings_->vx_weightedmean());
     }
     // Additional options with different uses of the eta-dependent width

--- a/L1Trigger/VertexFinder/src/VertexFinder.cc
+++ b/L1Trigger/VertexFinder/src/VertexFinder.cc
@@ -734,14 +734,11 @@ namespace l1tVertexFinder {
         float PFAWidth = computeTrackZ0Res(&track) * settings_->vx_pfa_resolutionSF();
         if (std::abs(z - track.z0()) > PFAWidth + 0.5 * settings_->vx_pfa_interval())
           continue;
-
-        if (settings_->vx_pfa_doqualitycuts() &
-            (track.pt() <
-             settings_->vx_TrackMinPt()))  // minimal additional quality cut as done in fastHistoEmulation()
-          continue;
-
+        if (settings_->vx_pfa_doqualitycuts() && (track.pt() < settings_->vx_TrackMinPt()))
+          continue;  // minimal additional quality cut as done in fastHistoEmulation()
         vertex.insert(&track);
       }  // end loop over tracks
+
       computeAndSetVertexParameters(vertex, {}, {});
       if (vertex.pt() > vxPt) {
         leading_vertex = vertex;
@@ -801,12 +798,8 @@ namespace l1tVertexFinder {
       for (const L1Track& track : fitTracks_) {
         if (std::abs(z - track.z0()) > settings_->vx_pfa_cutoff())
           continue;
-
-        if (settings_->vx_pfa_doqualitycuts() &
-            (track.pt() <
-             settings_->vx_TrackMinPt()))  // minimal additional quality cut as done in fastHistoEmulation()
-          continue;
-
+        if (settings_->vx_pfa_doqualitycuts() && (track.pt() < settings_->vx_TrackMinPt()))
+          continue;  // minimal additional quality cut as done in fastHistoEmulation()
         vertex.insert(&track);
       }  // end loop over tracks
 

--- a/L1Trigger/VertexFinder/src/VertexFinder.cc
+++ b/L1Trigger/VertexFinder/src/VertexFinder.cc
@@ -854,41 +854,6 @@ namespace l1tVertexFinder {
     pv_index_ = 0;
   }  // end of PFASimple
 
-  /**
-  * @note This method is the same as PFA() when settings_->vx_nvtx()=1
-  * @note This method does not support settings_->vx_pfa_usemultiplicitymaxima()=True (which requires a 2-step process).
-  */
-  void VertexFinder::PFASingleVertex() {
-    float vxPt = 0.;
-    RecoVertex leading_vertex;
-
-    int nbins = std::ceil((settings_->vx_pfa_max() - settings_->vx_pfa_min()) / settings_->vx_pfa_binwidth());
-    for (int i = 0; i <= nbins; ++i) {
-      float z = settings_->vx_pfa_min() + i * settings_->vx_pfa_binwidth();
-      RecoVertex vertex;
-      vertex.setZ0(z);
-      for (const L1Track& track : fitTracks_) {
-        if (std::abs(z - track.z0()) > settings_->vx_pfa_width())
-          continue;
-
-        if (settings_->vx_pfa_doqualitycuts() &
-            (track.pt() <
-             settings_->vx_TrackMinPt()))  // minimal additional quality cut as done in fastHistoEmulation()
-          continue;
-
-        vertex.insert(&track);
-      }  // end loop over tracks
-      computeAndSetVertexParametersPFA(vertex);
-      if (vertex.pt() > vxPt) {
-        leading_vertex = vertex;
-        vxPt = vertex.pt();
-      }
-    }
-
-    vertices_.emplace_back(leading_vertex);
-    pv_index_ = 0;
-  }  // end of PFASingleVertex
-
   void VertexFinder::PFA() {
     RecoVertex vertex2(-999.);
     RecoVertex vertex3(-999.);

--- a/L1Trigger/VertexFinder/src/VertexFinder.cc
+++ b/L1Trigger/VertexFinder/src/VertexFinder.cc
@@ -80,7 +80,7 @@ namespace l1tVertexFinder {
           // Step function weight, to replicate fastHisto when used with settings_->vx_pfa_weightfunction() == 3
           zweight = StepFunctionWeight * std::pow(trackPt, settings_->vx_weightedmean());
         }
-        // Additional undocumented options for the purpose of comparison (to demonstrate the effect of using the eta-dependent width in the weighted sum)
+        // Additional options for the purpose of comparison (to demonstrate the effect of using the eta-dependent width in the weighted sum)
         else if (settings_->vx_pfa_weightedz0() == 4) {
           // Step function weight divided by step function width (to maintain constant area when using eta-dependent resolution)
           zweight = StepFunctionWeight * std::pow(trackPt, settings_->vx_weightedmean()) /
@@ -93,7 +93,7 @@ namespace l1tVertexFinder {
           // ErfcWeight with only 1/width
           zweight = ErfcWeight * std::pow(trackPt, settings_->vx_weightedmean()) / GaussianWidth;
         }
-        // Additional undocumented options using only trackPt^1 (instead of settings_->vx_weightedmean(), which defaults to 2)
+        // Additional options using only trackPt^1 (instead of settings_->vx_weightedmean(), which defaults to 2)
         else if (settings_->vx_pfa_weightedz0() == 7) {
           zweight = ErfcWeight * std::pow(trackPt, 1) / GaussianWidth / GaussianWidth;
         } else if (settings_->vx_pfa_weightedz0() == 8) {
@@ -191,50 +191,42 @@ namespace l1tVertexFinder {
         // Alternative definitions of PFA weights (added subsequent to Giovanna's thesis)
         // Redefine deltaZ as the distance of the track from the bin edge (zero if inside the bin)
         deltaZ = (deltaZ > 0.5 * settings_->vx_pfa_binwidth()) ? deltaZ - 0.5 * settings_->vx_pfa_binwidth() : 0;
+        // Erfc to be used to reduce the weight based on the probability that a track from a vertex in this bin would be closer than deltaZ to the edge of the bin
+        float ErfcWeight = std::erfc(sqrt0p5 * deltaZ / GaussianWidth);
+        // Step function that allows tracks at most 1 sigma from the bin edge
+        float StepFunctionWeight = deltaZ > GaussianWidth ? 0 : 1;
 
         if (settings_->vx_pfa_weightedz0() == 2) {
-          // Use Erfc to reduce the weight based on the probability that a track from a vertex in this bin would be closer than deltaZ to the edge of the bin
-          float ErfcWeight = std::erfc(sqrt0p5 * deltaZ / GaussianWidth);
           // Estimates of vertex z0 and z0square based on optimal combination (weighted by 1/variance) of the z0 of the tracks associated to the vertex, weighted also by pT and association probability
           // Note, all tracks in the bin have association probability 1 based on the definiton of deltaZ above, so this method won't work well for large bin widths. In that case, the ErfcWeight should really be iteratively recalculated at the best estimate point of z0 (and not subtracting half the bin width in deltaZ), but this would require a second loop over tracks.
           zweight = ErfcWeight * std::pow(trackPt, settings_->vx_weightedmean()) / GaussianWidth / GaussianWidth;
         } else if (settings_->vx_pfa_weightedz0() == 3) {
-          // Step function that allows tracks at most 1 sigma from the bin edge
-          float StepFunctionWeight = deltaZ > GaussianWidth ? 0 : 1;
           // Step function weight, to replicate fastHisto when used with settings_->vx_pfa_weightfunction() == 3
           zweight = StepFunctionWeight * std::pow(trackPt, settings_->vx_weightedmean());
         }
-        // Additional undocumented options with different uses of the eta-dependent width
+        // Additional options with different uses of the eta-dependent width
         else if (settings_->vx_pfa_weightedz0() == 4) {
           // Step function weight divided by step function width (to maintain constant area when using eta-dependent resolution)
-          float StepFunctionWeight = deltaZ > GaussianWidth ? 0 : 1;
           zweight = StepFunctionWeight * std::pow(trackPt, settings_->vx_weightedmean()) /
                     (GaussianWidth + 0.5 * settings_->vx_pfa_binwidth());
         } else if (settings_->vx_pfa_weightedz0() == 5) {
           // Step function weight weighted by 1/variance (relevant when using eta-dependent resolution)
-          float StepFunctionWeight = deltaZ > GaussianWidth ? 0 : 1;
           zweight =
               StepFunctionWeight * std::pow(trackPt, settings_->vx_weightedmean()) / GaussianWidth / GaussianWidth;
         } else if (settings_->vx_pfa_weightedz0() == 6) {
           // ErfcWeight with only 1/width
-          float ErfcWeight = std::erfc(sqrt0p5 * deltaZ / GaussianWidth);
           zweight = ErfcWeight * std::pow(trackPt, settings_->vx_weightedmean()) / GaussianWidth;
         }
-        // Additional undocumented options using only trackPt^1 (instead of settings_->vx_weightedmean(), which defaults to 2)
+        // Additional options using only trackPt^1 (instead of settings_->vx_weightedmean(), which defaults to 2)
         else if (settings_->vx_pfa_weightedz0() == 7) {
-          float ErfcWeight = std::erfc(sqrt0p5 * deltaZ / GaussianWidth);
           zweight = ErfcWeight * std::pow(trackPt, 1) / GaussianWidth / GaussianWidth;
         } else if (settings_->vx_pfa_weightedz0() == 8) {
-          float ErfcWeight = std::erfc(sqrt0p5 * deltaZ / GaussianWidth);
           zweight = ErfcWeight * std::pow(trackPt, 1) / GaussianWidth;
         } else if (settings_->vx_pfa_weightedz0() == 9) {
-          float StepFunctionWeight = deltaZ > GaussianWidth ? 0 : 1;
           zweight = StepFunctionWeight * std::pow(trackPt, 1);
         } else if (settings_->vx_pfa_weightedz0() == 10) {
-          float StepFunctionWeight = deltaZ > GaussianWidth ? 0 : 1;
           zweight = StepFunctionWeight * std::pow(trackPt, 1) / (GaussianWidth + 0.5 * settings_->vx_pfa_binwidth());
         } else if (settings_->vx_pfa_weightedz0() == 11) {
-          float StepFunctionWeight = deltaZ > GaussianWidth ? 0 : 1;
           zweight = StepFunctionWeight * std::pow(trackPt, 1) / GaussianWidth / GaussianWidth;
         }
         SumZWeightPFA += zweight;

--- a/L1Trigger/VertexFinder/src/VertexFinder.cc
+++ b/L1Trigger/VertexFinder/src/VertexFinder.cc
@@ -93,6 +93,18 @@ namespace l1tVertexFinder {
           // ErfcWeight with only 1/width
           zweight = ErfcWeight * std::pow(trackPt, settings_->vx_weightedmean()) / GaussianWidth;
         }
+        // Additional undocumented options using only trackPt^1 (instead of settings_->vx_weightedmean(), which defaults to 2)
+        else if (settings_->vx_pfa_weightedz0() == 7) {
+          zweight = ErfcWeight * std::pow(trackPt, 1) / GaussianWidth / GaussianWidth;
+        } else if (settings_->vx_pfa_weightedz0() == 8) {
+          zweight = ErfcWeight * std::pow(trackPt, 1) / GaussianWidth;
+        } else if (settings_->vx_pfa_weightedz0() == 9) {
+          zweight = StepFunctionWeight * std::pow(trackPt, 1);
+        } else if (settings_->vx_pfa_weightedz0() == 10) {
+          zweight = StepFunctionWeight * std::pow(trackPt, 1) / (GaussianWidth + 0.5 * settings_->vx_pfa_binwidth());
+        } else if (settings_->vx_pfa_weightedz0() == 11) {
+          zweight = StepFunctionWeight * std::pow(trackPt, 1) / GaussianWidth / GaussianWidth;
+        }
 
         SumZWeight += zweight;
         SumZ += track->z0() * zweight;
@@ -191,6 +203,39 @@ namespace l1tVertexFinder {
           float StepFunctionWeight = deltaZ > GaussianWidth ? 0 : 1;
           // Step function weight, to replicate fastHisto when used with settings_->vx_pfa_weightfunction() == 3
           zweight = StepFunctionWeight * std::pow(trackPt, settings_->vx_weightedmean());
+        }
+        // Additional undocumented options with different uses of the eta-dependent width
+        else if (settings_->vx_pfa_weightedz0() == 4) {
+          // Step function weight divided by step function width (to maintain constant area when using eta-dependent resolution)
+          float StepFunctionWeight = deltaZ > GaussianWidth ? 0 : 1;
+          zweight = StepFunctionWeight * std::pow(trackPt, settings_->vx_weightedmean()) /
+                    (GaussianWidth + 0.5 * settings_->vx_pfa_binwidth());
+        } else if (settings_->vx_pfa_weightedz0() == 5) {
+          // Step function weight weighted by 1/variance (relevant when using eta-dependent resolution)
+          float StepFunctionWeight = deltaZ > GaussianWidth ? 0 : 1;
+          zweight =
+              StepFunctionWeight * std::pow(trackPt, settings_->vx_weightedmean()) / GaussianWidth / GaussianWidth;
+        } else if (settings_->vx_pfa_weightedz0() == 6) {
+          // ErfcWeight with only 1/width
+          float ErfcWeight = std::erfc(sqrt0p5 * deltaZ / GaussianWidth);
+          zweight = ErfcWeight * std::pow(trackPt, settings_->vx_weightedmean()) / GaussianWidth;
+        }
+        // Additional undocumented options using only trackPt^1 (instead of settings_->vx_weightedmean(), which defaults to 2)
+        else if (settings_->vx_pfa_weightedz0() == 7) {
+          float ErfcWeight = std::erfc(sqrt0p5 * deltaZ / GaussianWidth);
+          zweight = ErfcWeight * std::pow(trackPt, 1) / GaussianWidth / GaussianWidth;
+        } else if (settings_->vx_pfa_weightedz0() == 8) {
+          float ErfcWeight = std::erfc(sqrt0p5 * deltaZ / GaussianWidth);
+          zweight = ErfcWeight * std::pow(trackPt, 1) / GaussianWidth;
+        } else if (settings_->vx_pfa_weightedz0() == 9) {
+          float StepFunctionWeight = deltaZ > GaussianWidth ? 0 : 1;
+          zweight = StepFunctionWeight * std::pow(trackPt, 1);
+        } else if (settings_->vx_pfa_weightedz0() == 10) {
+          float StepFunctionWeight = deltaZ > GaussianWidth ? 0 : 1;
+          zweight = StepFunctionWeight * std::pow(trackPt, 1) / (GaussianWidth + 0.5 * settings_->vx_pfa_binwidth());
+        } else if (settings_->vx_pfa_weightedz0() == 11) {
+          float StepFunctionWeight = deltaZ > GaussianWidth ? 0 : 1;
+          zweight = StepFunctionWeight * std::pow(trackPt, 1) / GaussianWidth / GaussianWidth;
         }
         SumZWeightPFA += zweight;
         SumZ += track->z0() * zweight;

--- a/L1Trigger/VertexFinder/src/VertexFinder.cc
+++ b/L1Trigger/VertexFinder/src/VertexFinder.cc
@@ -6,7 +6,7 @@ namespace l1tVertexFinder {
 
   // Returns the track resolution in cm (which can depend on track eta), to be used in PFA. Note in future this may not be necessary if the z0 uncertainty is included as a TTTrack property.
   float VertexFinder::computeTrackZ0Res(const L1Track* track) const {
-    float trackAbsEta = std::fabs(track->eta());
+    float trackAbsEta = std::abs(track->eta());
     // Hard-coded eta-dependent and constant parametrisations of the track resolution taken from the PFA section of Giovanna's thesis: https://cds.cern.ch/record/2909504
     return settings_->vx_pfa_etadependentresolution()
                ? 0.09867 + 0.0007 * trackAbsEta + 0.0587 * trackAbsEta * trackAbsEta
@@ -19,7 +19,7 @@ namespace l1tVertexFinder {
     float PFAWidth = computeTrackZ0Res(track) * settings_->vx_pfa_resolutionSF();
 
     // PFA weights. No need to include 1/sqrt(2pi) normalisation constant in weight function, as it cancels out in the weighted sum.
-    float deltaZ = std::fabs(track->z0() - vertexZ0);
+    float deltaZ = std::abs(track->z0() - vertexZ0);
     float GaussianWeight = std::exp(-0.5 * std::pow(deltaZ / PFAWidth, 2)) / PFAWidth;
 
     // Alternative definitions of PFA weights (added subsequent to Giovanna's thesis)
@@ -95,7 +95,7 @@ namespace l1tVertexFinder {
     float z0square = 0.;
     float trackPt = 0.;
 
-    bool isPFA = settings_->vx_algo() == Algorithm::PFA || settings_->vx_algo() == Algorithm::PFASimple;
+    const bool isPFA = settings_->vx_algo() == Algorithm::PFA || settings_->vx_algo() == Algorithm::PFASimple;
     float SumWeightPFA = 0.;
     float SumZWeightPFA = 0.;
 


### PR DESCRIPTION
This PR implements the Peak Finding Algorithm (PFA) described in Giovanna Salvi's [thesis](https://eprints.soton.ac.uk/492698/).

Two new `Algorithm`s with `Precision::Simulation` are added to `VertexFinder`.

`Algorithm::PFA` can be configured to exactly reproduce Giovanna's thesis algorithm, with the option for a 2-step vertex-finding process (first finding local maxima based on Gaussian-weighted multiplicity alone, before choosing the one with the largest Gaussian-and-pT-weighted sum). Subsequent to Giovanna's thesis, the algorithm was [further developed](https://indico.cern.ch/event/1486447/contributions/6265950/attachments/2981672/5251234/PFA%20studies.pdf) to allow different choices of PFA weighting function and to refine the vertex z position using a weighted average over the tracks.

Ultimately it was found (and [presented](https://indico.cern.ch/event/1519772/contributions/6394788/attachments/3023831/5336170/PFA%20studies%20update.pdf) in a GTT meeting) that a simplified version of the algorithm, `Algorithm::PFASimple`, shows no significant performance degradation. This is a simple 1-step vertex-finding process using tracks from a more restricted range in z (corresponding to a set of overlapping bins like in `Algorithm::fastHistoLooseAssociation`, but where the "bin" width can optionally be track-eta-dependent) and with no PFA weighting function (i.e. all tracks in the bin effectively have PFA weight = 1), but still optionally refining the vertex z position using a weighted average of the tracks in the bin. When considering a range of processes, it was found that using track pT2 weighting (`WeightedMean=2`) and track-eta dependent width (`PFA_EtaDependentResolution=True`) with a scale factor of about 1.3 (`PFA_ResolutionSF=1.3`) for the vertex finding combined with track pT weighting in the weighted-average z computation (`PFA_WeightedZ0=10`) give best performance, and the default PFA parameters are configured as such in `L1Trigger/VertexFinder/python/l1tVertexProducer_cfi.py`. 

`Algorithm::PFASimple` is identical to `Algorithm::fastHistoLooseAssociation` when using `PFA_WeightedZ0=3`, `PFA_EtaDependentResolution=False`, and setting `PFA_ResolutionSF` to give bin widths that match those set by `FH_VertexWidth`, so PFA can be considered a generalisation of fastHisto.

The code was [tested](https://indico.cern.ch/event/1519772/contributions/6394788/attachments/3023831/5336170/PFA%20studies%20update.pdf) by running `L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker_cfg.py` on a variety of processes. There are no changes in the output when running one of the existing vertexing algorithms.