### PR TITLE
ParameterSet/Config.py: Use realpath of  cmssw area to avoid symlink issue

### DIFF
--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -52,7 +52,7 @@ def checkImportPermission(minLevel: int = 2, allowedPatterns = []):
     import os
 
     ignorePatterns = ['FWCore/ParameterSet/Config.py', 'FWCore/ParameterSet/python/Config.py','<string>','<frozen ']
-    CMSSWPath = [os.getenv(base) for base in ['CMSSW_BASE', 'CMSSW_RELEASE_BASE', 'CMSSW_FULL_RELEASE_BASE'] if os.getenv(base, '')]
+    CMSSWPath = [os.path.realpath(os.getenv(base)) for base in ['CMSSW_BASE', 'CMSSW_RELEASE_BASE', 'CMSSW_FULL_RELEASE_BASE'] if os.getenv(base, '')]
 
     # Filter the stack to things in CMSSWPath and not in ignorePatterns
     trueStack = []


### PR DESCRIPTION
This fixes the FW unit test [a]. The issue is that python modules are loaded using realpath while https://github.com/cms-sw/cmssw/blob/master/FWCore/ParameterSet/python/Config.py#L55 is not resolving the symlink [b]. This change fix this unit test by using the realpath of `CMSSW_BASE, CMSSW_RELEASE_BASE and CMSSW_FULL_RELEASE_BASE` env


[a] https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc12/CMSSW_15_0_ROOT6_X_2024-12-22-2300/unitTestLogs/FWCore/Integration#/3356-3356
```
cmsRun importRestrictions2.py ------------------------------------------------------------
Failure cmsRun importRestrictions2.py: status 1

---> test TestIntegrationParameterSet had ERRORS
```

[b] `CMSSWPath` has `/cvmfs/cms-ib.cern.ch/sw/x86_64/week1` which is symlink to `/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02869` while the import module has realpth `/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02869/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-22-0000/src/FWCore/ParameterSet/python/Config.py`

```
(Pdb) print(CMSSWPath)
['/build/muz/br/cvmfs/CMSSW_15_0_X_2024-12-22-0000', '/cvmfs/cms-ib.cern.ch/sw/x86_64/week1/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-22-0000']
(Pdb) print(item)
FrameInfo(frame=<frame at 0x1ac9720, file '/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02869/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-22-0000/src/FWCore/ParameterSet/python/Config.py', line 63, code checkImportPermission>, filename='/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02869/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-22-0000/src/FWCore/ParameterSet/python/Config.py', lineno=59, function='checkImportPermission', code_context=['    for item in inspect.stack():\n'], index=0)
```