### PR TITLE
Reduce memory held between Events in PFProducer

### DIFF
--- a/RecoParticleFlow/PFProducer/interface/PFAlgo.h
+++ b/RecoParticleFlow/PFProducer/interface/PFAlgo.h
@@ -112,9 +112,17 @@ public:
   reco::PFCandidateCollection& getCleanedCandidates() { return pfCleanedCandidates_; }
 
   /// \return the collection of candidates
-  reco::PFCandidateCollection makeConnectedCandidates() { return connector_.connect(*pfCandidates_); }
+  reco::PFCandidateCollection makeConnectedCandidates() { return connector_.connect(pfCandidates_); }
 
   friend std::ostream& operator<<(std::ostream& out, const PFAlgo& algo);
+
+  void clear() {
+    pfCandidates_.clear();
+    pfCleanedCandidates_.clear();
+    if (useVertices_) {
+      primaryVertex_ = decltype(primaryVertex_)();
+    }
+  };
 
 private:
   void egammaFilters(const reco::PFBlockRef& blockref, std::vector<bool>& active, PFEGammaFilters const* pfegamma);
@@ -223,7 +231,7 @@ private:
   double nSigmaHFEM(double clusterEnergy) const;
   double nSigmaHFHAD(double clusterEnergy) const;
 
-  std::unique_ptr<reco::PFCandidateCollection> pfCandidates_;
+  reco::PFCandidateCollection pfCandidates_;
   // the post-HF-cleaned candidates
   reco::PFCandidateCollection pfCleanedCandidates_;
 

--- a/RecoParticleFlow/PFProducer/plugins/PFProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFProducer.cc
@@ -291,8 +291,8 @@ void PFProducer::produce(Event& iEvent, const EventSetup& iSetup) {
   }
 
   // Write in the event
-  iEvent.emplace(pfCandidatesToken_, pOutputCandidateCollection);
-  iEvent.emplace(pfCleanedCandidatesToken_, pfAlgo_.getCleanedCandidates());
+  iEvent.emplace(pfCandidatesToken_, std::move(pOutputCandidateCollection));
+  iEvent.emplace(pfCleanedCandidatesToken_, std::move(pfAlgo_.getCleanedCandidates()));
 
   if (postMuonCleaning_) {
     auto& muAlgo = *pfAlgo_.getPFMuonAlgo();
@@ -309,6 +309,7 @@ void PFProducer::produce(Event& iEvent, const EventSetup& iSetup) {
     // Save added muon candidates
     iEvent.put(muAlgo.transferAddedMuonCandidates(), "AddedMuonsAndHadrons");
   }
+  pfAlgo_.clear();
 }
 
 void PFProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/RecoParticleFlow/PFProducer/src/PFMuonAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFMuonAlgo.cc
@@ -16,12 +16,12 @@ using namespace boost;
 
 PFMuonAlgo::PFMuonAlgo(const edm::ParameterSet& iConfig, bool postMuonCleaning)
 
-    : pfCosmicsMuonCleanedCandidates_(std::make_unique<reco::PFCandidateCollection>()),
-      pfCleanedTrackerAndGlobalMuonCandidates_(std::make_unique<reco::PFCandidateCollection>()),
-      pfFakeMuonCleanedCandidates_(std::make_unique<reco::PFCandidateCollection>()),
-      pfPunchThroughMuonCleanedCandidates_(std::make_unique<reco::PFCandidateCollection>()),
-      pfPunchThroughHadronCleanedCandidates_(std::make_unique<reco::PFCandidateCollection>()),
-      pfAddedMuonCandidates_(std::make_unique<reco::PFCandidateCollection>()),
+    : pfCosmicsMuonCleanedCandidates_(),
+      pfCleanedTrackerAndGlobalMuonCandidates_(),
+      pfFakeMuonCleanedCandidates_(),
+      pfPunchThroughMuonCleanedCandidates_(),
+      pfPunchThroughHadronCleanedCandidates_(),
+      pfAddedMuonCandidates_(),
 
       maxDPtOPt_(iConfig.getParameter<double>("maxDPtOPt")),
       trackQuality_(reco::TrackBase::qualityByName(iConfig.getParameter<std::string>("trackQuality"))),


### PR DESCRIPTION
#### PR description:

- clear memory at end of event rather than at beginning of next event.

#### PR validation:

Code compiles. Using ModuleEventAllocMonitor service on a ReRECO test job showed the module no longer retains temporary memory between events.