### PR TITLE
add BX info to `GlobalObjectMap` (L1uGT emulation)

### DIFF
--- a/DataFormats/L1TGlobal/interface/GlobalObjectMap.h
+++ b/DataFormats/L1TGlobal/interface/GlobalObjectMap.h
@@ -1,5 +1,5 @@
-#ifndef L1GlobalTrigger_L1TGtObjectMap_h
-#define L1GlobalTrigger_L1TGtObjectMap_h
+#ifndef DataFormats_L1TGlobal_GlobalObjectMap_h
+#define DataFormats_L1TGlobal_GlobalObjectMap_h
 
 /**
  * \class GlobalObjectMap
@@ -15,27 +15,16 @@
  *
  */
 
-// system include files
 #include <string>
 #include <vector>
-
 #include <iosfwd>
 
-// user include files
 #include "DataFormats/L1TGlobal/interface/GlobalObjectMapFwd.h"
-
 #include "DataFormats/L1TGlobal/interface/GlobalLogicParser.h"
 
-// forward declarations
-
-// class declaration
 class GlobalObjectMap {
 public:
-  /// constructor(s)
   GlobalObjectMap() {}
-
-  /// destructor
-  //~GlobalObjectMap(){}
 
 public:
   /// get / set name for algorithm in the object map
@@ -56,13 +45,13 @@ public:
 
   /// get / set the vector of combinations for the algorithm
   /// return a constant reference to the vector of combinations for the algorithm
-  inline const std::vector<CombinationsInCond>& combinationVector() const { return m_combinationVector; }
+  inline const std::vector<CombinationsWithBxInCond>& combinationVector() const { return m_combinationWithBxVector; }
 
-  void setCombinationVector(const std::vector<CombinationsInCond>& combinationVectorValue) {
-    m_combinationVector = combinationVectorValue;
+  void setCombinationVector(const std::vector<CombinationsWithBxInCond>& combinationVectorValue) {
+    m_combinationWithBxVector = combinationVectorValue;
   }
-  void swapCombinationVector(std::vector<CombinationsInCond>& combinationVectorValue) {
-    m_combinationVector.swap(combinationVectorValue);
+  void swapCombinationVector(std::vector<CombinationsWithBxInCond>& combinationVectorValue) {
+    m_combinationWithBxVector.swap(combinationVectorValue);
   }
 
   /// get / set the vector of operand tokens
@@ -79,6 +68,7 @@ public:
   /// get / set the vector of object types
   /// return a constant reference to the vector of operand tokens
   inline const std::vector<L1TObjectTypeInCond>& objectTypeVector() const { return m_objectTypeVector; }
+
   void setObjectTypeVector(const std::vector<L1TObjectTypeInCond>& objectTypeVectorValue) {
     m_objectTypeVector = objectTypeVectorValue;
   }
@@ -88,10 +78,10 @@ public:
 
 public:
   /// return all the combinations passing the requirements imposed in condition condNameVal
-  const CombinationsInCond* getCombinationsInCond(const std::string& condNameVal) const;
+  const CombinationsWithBxInCond* getCombinationsInCond(const std::string& condNameVal) const;
 
   /// return all the combinations passing the requirements imposed in condition condNumberVal
-  const CombinationsInCond* getCombinationsInCond(const int condNumberVal) const;
+  const CombinationsWithBxInCond* getCombinationsInCond(const int condNumberVal) const;
 
   /// return the result for the condition condNameVal
   const bool getConditionResult(const std::string& condNameVal) const;
@@ -118,10 +108,10 @@ private:
   std::vector<GlobalLogicParser::OperandToken> m_operandTokenVector;
 
   // vector of combinations for all conditions in an algorithm
-  std::vector<CombinationsInCond> m_combinationVector;
+  std::vector<CombinationsWithBxInCond> m_combinationWithBxVector;
 
   // vector of object type vectors for all conditions in an algorithm
   std::vector<L1TObjectTypeInCond> m_objectTypeVector;
 };
 
-#endif /* L1GlobalTrigger_L1TGtObjectMap_h */
+#endif

--- a/DataFormats/L1TGlobal/interface/GlobalObjectMapFwd.h
+++ b/DataFormats/L1TGlobal/interface/GlobalObjectMapFwd.h
@@ -1,8 +1,8 @@
-#ifndef L1GlobalTrigger_L1TGtObjectMapFwd_h
-#define L1GlobalTrigger_L1TGtObjectMapFwd_h
+#ifndef DataFormats_L1TGlobal_L1TGtObjectMapFwd_h
+#define DataFormats_L1TGlobal_L1TGtObjectMapFwd_h
 
 /**
- * \class GlobalObjectMap
+ * \class GlobalObjectMapFwd
  * 
  * 
  * Description: group typedefs used by GlobalObjectMap.  
@@ -16,6 +16,7 @@
  */
 
 // system include files
+#include <utility>
 #include <vector>
 
 // user include files
@@ -24,14 +25,15 @@
 // forward declarations
 
 /// typedefs
+typedef int16_t L1TObjBxIndexType;
+typedef int L1TObjIndexType;
 
-/// list of object indices corresponding to a condition evaluated to true
-typedef std::vector<int> SingleCombInCond;
+/// list of object indices:bx pairs corresponding to a condition evaluated to true
+typedef std::vector<std::pair<L1TObjBxIndexType, L1TObjIndexType>> SingleCombWithBxInCond;
 
-/// all the object combinations evaluated to true in the condition
-typedef std::vector<SingleCombInCond> CombinationsInCond;
+/// all the object combinations evaluated to true in the condition (object indices + BX indices)
+typedef std::vector<SingleCombWithBxInCond> CombinationsWithBxInCond;
 
 typedef std::vector<l1t::GlobalObject> L1TObjectTypeInCond;
-//typedef std::vector<int> ObjectTypeInCond;
 
-#endif /* L1GlobalTrigger_L1TGtObjectMapFwd_h */
+#endif

--- a/DataFormats/L1TGlobal/interface/GlobalObjectMapRecord.h
+++ b/DataFormats/L1TGlobal/interface/GlobalObjectMapRecord.h
@@ -1,5 +1,5 @@
-#ifndef L1GlobalTrigger_L1TGtObjectMapRecord_h
-#define L1GlobalTrigger_L1TGtObjectMapRecord_h
+#ifndef DataFormats_L1TGlobal_GlobalObjectMapRecord_h
+#define DataFormats_L1TGlobal_GlobalObjectMapRecord_h
 
 /**
  * \class GlobalObjectMapRecord
@@ -45,11 +45,13 @@ public:
 
   /// return all the combinations passing the requirements imposed in condition condNameVal
   /// from algorithm with name algoNameVal
-  const CombinationsInCond* getCombinationsInCond(const std::string& algoNameVal, const std::string& condNameVal) const;
+  const CombinationsWithBxInCond* getCombinationsInCond(const std::string& algoNameVal,
+                                                        const std::string& condNameVal) const;
 
   /// return all the combinations passing the requirements imposed in condition condNameVal
   /// from algorithm with bit number algoBitNumberVal
-  const CombinationsInCond* getCombinationsInCond(const int algoBitNumberVal, const std::string& condNameVal) const;
+  const CombinationsWithBxInCond* getCombinationsInCond(const int algoBitNumberVal,
+                                                        const std::string& condNameVal) const;
 
   /// return the result for the condition condNameVal
   /// from algorithm with name algoNameVal
@@ -73,4 +75,4 @@ private:
 
 inline void swap(GlobalObjectMapRecord& lh, GlobalObjectMapRecord& rh) { lh.swap(rh); }
 
-#endif /* L1GlobalTrigger_L1TGtObjectMapRecord_h */
+#endif

--- a/DataFormats/L1TGlobal/src/GlobalObjectMap.cc
+++ b/DataFormats/L1TGlobal/src/GlobalObjectMap.cc
@@ -12,57 +12,47 @@
  *
  */
 
-// this class header
 #include "DataFormats/L1TGlobal/interface/GlobalObjectMap.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-// system include files
 #include <iostream>
 #include <iomanip>
 #include <iterator>
-
 #include <algorithm>
 
-// user include files
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-// forward declarations
-
-// methods
-
-// return all the combinations passing the requirements imposed in condition condNameVal
-const CombinationsInCond* GlobalObjectMap::getCombinationsInCond(const std::string& condNameVal) const {
+/// return all the combinations passing the requirements imposed in condition condNameVal
+const CombinationsWithBxInCond* GlobalObjectMap::getCombinationsInCond(const std::string& condNameVal) const {
   for (size_t i = 0; i < m_operandTokenVector.size(); ++i) {
     if ((m_operandTokenVector[i]).tokenName == condNameVal) {
-      return &(m_combinationVector.at((m_operandTokenVector[i]).tokenNumber));
+      return &(m_combinationWithBxVector.at((m_operandTokenVector[i]).tokenNumber));
     }
   }
 
   // return a null address - should not arrive here
   edm::LogError("GlobalObjectMap") << "\n\n  ERROR: The requested condition with tokenName = " << condNameVal
                                    << "\n  does not exists in the operand token vector."
-                                   << "\n  Returning zero pointer for getCombinationsInCond\n\n"
-                                   << std::endl;
+                                   << "\n  Returning zero pointer for getCombinationsInCond\n\n";
 
   return nullptr;
 }
 
 /// return all the combinations passing the requirements imposed in condition condNumberVal
-const CombinationsInCond* GlobalObjectMap::getCombinationsInCond(const int condNumberVal) const {
+const CombinationsWithBxInCond* GlobalObjectMap::getCombinationsInCond(const int condNumberVal) const {
   for (size_t i = 0; i < m_operandTokenVector.size(); ++i) {
     if ((m_operandTokenVector[i]).tokenNumber == condNumberVal) {
-      return &(m_combinationVector.at((m_operandTokenVector[i]).tokenNumber));
+      return &(m_combinationWithBxVector.at((m_operandTokenVector[i]).tokenNumber));
     }
   }
 
   // return a null address - should not arrive here
   edm::LogError("GlobalObjectMap") << "\n\n  ERROR: The requested condition with tokenNumber = " << condNumberVal
                                    << "\n  does not exists in the operand token vector."
-                                   << "\n  Returning zero pointer for getCombinationsInCond\n\n"
-                                   << std::endl;
+                                   << "\n  Returning zero pointer for getCombinationsInCond\n\n";
 
   return nullptr;
 }
-// return the result for the condition condNameVal
+
+/// return the result for the condition condNameVal
 const bool GlobalObjectMap::getConditionResult(const std::string& condNameVal) const {
   for (size_t i = 0; i < m_operandTokenVector.size(); ++i) {
     if ((m_operandTokenVector[i]).tokenName == condNameVal) {
@@ -73,8 +63,8 @@ const bool GlobalObjectMap::getConditionResult(const std::string& condNameVal) c
   // return false - should not arrive here
   edm::LogError("GlobalObjectMap") << "\n\n  ERROR: The requested condition with name = " << condNameVal
                                    << "\n  does not exists in the operand token vector."
-                                   << "\n  Returning false for getConditionResult\n\n"
-                                   << std::endl;
+                                   << "\n  Returning false for getConditionResult\n\n";
+
   return false;
 }
 
@@ -92,7 +82,7 @@ void GlobalObjectMap::reset() {
   m_operandTokenVector.clear();
 
   // vector of combinations for all conditions in an algorithm
-  m_combinationVector.clear();
+  m_combinationWithBxVector.clear();
 }
 
 void GlobalObjectMap::print(std::ostream& myCout) const {
@@ -117,35 +107,29 @@ void GlobalObjectMap::print(std::ostream& myCout) const {
     }
   }
 
-  myCout << "    CombinationVector size: " << m_combinationVector.size() << std::endl;
+  myCout << "    CombinationWithBxVector size: " << m_combinationWithBxVector.size() << std::endl;
 
   myCout << "  conditions: " << std::endl;
 
-  std::vector<CombinationsInCond>::const_iterator itVVV;
-  int iCond = 0;
-  for (itVVV = m_combinationVector.begin(); itVVV != m_combinationVector.end(); itVVV++) {
-    std::string condName = (m_operandTokenVector[iCond]).tokenName;
-    bool condResult = (m_operandTokenVector[iCond]).tokenResult;
-
+  for (size_t i1 = 0; i1 < m_combinationWithBxVector.size(); ++i1) {
+    auto const& condName = m_operandTokenVector[i1].tokenName;
+    auto const condResult = m_operandTokenVector[i1].tokenResult;
     myCout << "    Condition " << condName << " evaluated to " << condResult << std::endl;
-
     myCout << "    List of combinations passing all requirements for this condition:" << std::endl;
-
     myCout << "    ";
 
-    if ((*itVVV).empty()) {
+    if (m_combinationWithBxVector[i1].empty()) {
       myCout << "(none)";
     } else {
-      CombinationsInCond::const_iterator itVV;
-      for (itVV = (*itVVV).begin(); itVV != (*itVVV).end(); itVV++) {
+      for (size_t i2 = 0; i2 < m_combinationWithBxVector[i1].size(); ++i2) {
         myCout << "( ";
-
-        std::copy((*itVV).begin(), (*itVV).end(), std::ostream_iterator<int>(myCout, " "));
-
+        for (size_t i3 = 0; i3 < m_combinationWithBxVector[i1][i2].size(); ++i3) {
+          myCout << m_combinationWithBxVector[i1][i2][i3].first << ":";
+          myCout << m_combinationWithBxVector[i1][i2][i3].second << " ";
+        }
         myCout << "); ";
       }
     }
-    iCond++;
     myCout << "\n\n";
   }
 }

--- a/DataFormats/L1TGlobal/src/GlobalObjectMapRecord.cc
+++ b/DataFormats/L1TGlobal/src/GlobalObjectMapRecord.cc
@@ -64,8 +64,8 @@ const GlobalObjectMap* GlobalObjectMapRecord::getObjectMap(const int algoBitNumb
 
 // return all the combinations passing the requirements imposed in condition condNameVal
 // from algorithm algoNameVal
-const CombinationsInCond* GlobalObjectMapRecord::getCombinationsInCond(const std::string& algoNameVal,
-                                                                       const std::string& condNameVal) const {
+const CombinationsWithBxInCond* GlobalObjectMapRecord::getCombinationsInCond(const std::string& algoNameVal,
+                                                                             const std::string& condNameVal) const {
   for (std::vector<GlobalObjectMap>::const_iterator itObj = m_gtObjectMap.begin(); itObj != m_gtObjectMap.end();
        ++itObj) {
     if (itObj->algoName() == algoNameVal) {
@@ -85,8 +85,8 @@ const CombinationsInCond* GlobalObjectMapRecord::getCombinationsInCond(const std
 
 // return all the combinations passing the requirements imposed in condition condNameVal
 // from algorithm with bit number algoBitNumberVal
-const CombinationsInCond* GlobalObjectMapRecord::getCombinationsInCond(const int algoBitNumberVal,
-                                                                       const std::string& condNameVal) const {
+const CombinationsWithBxInCond* GlobalObjectMapRecord::getCombinationsInCond(const int algoBitNumberVal,
+                                                                             const std::string& condNameVal) const {
   for (std::vector<GlobalObjectMap>::const_iterator itObj = m_gtObjectMap.begin(); itObj != m_gtObjectMap.end();
        ++itObj) {
     if (itObj->algoBitNumber() == algoBitNumberVal) {

--- a/DataFormats/L1TGlobal/src/classes_def.xml
+++ b/DataFormats/L1TGlobal/src/classes_def.xml
@@ -31,12 +31,34 @@
   </class>
   <class name="edm::Wrapper<GlobalObjectMapRecord>"/>
 
-  <class name="GlobalObjectMap" ClassVersion="10">
+  <class name="GlobalObjectMap" ClassVersion="11">
+   <version ClassVersion="11" checksum="760424007"/>
    <version ClassVersion="10" checksum="1899280385"/>
   </class>
   <class name="edm::Wrapper<GlobalObjectMap>"/>
   <class name="std::vector<GlobalObjectMap>"/>
   <class name="edm::Wrapper<std::vector<GlobalObjectMap> >"/>
+  <!-- Adding ioread rules for backwards compatibility -->
+  <ioread sourceClass="GlobalObjectMap" version="[3-10]"
+	  source="std::vector<std::vector<std::vector<L1TObjIndexType>>> m_combinationVector;"
+	  targetClass="GlobalObjectMap" target="m_combinationWithBxVector">
+    <![CDATA[
+	     m_combinationWithBxVector.clear();
+             m_combinationWithBxVector.reserve(onfile.m_combinationVector.size());
+             for(auto const& a0 : onfile.m_combinationVector) {
+               CombinationsWithBxInCond b0;
+               b0.reserve(a0.size());
+               for(auto const& a1 : a0) {
+                 SingleCombWithBxInCond b1;
+                 b1.reserve(a1.size());
+                 for(auto const a2 : a1) {
+                   b1.emplace_back(0, a2);
+                 }
+                 b0.emplace_back(b1);
+               }
+               m_combinationWithBxVector.emplace_back(b0);
+             }]]>
+  </ioread>
 
   <class name="std::vector<l1t::GlobalObject>"/>
   <class name="std::vector<std::vector<l1t::GlobalObject> >"/>

--- a/DataFormats/L1TGlobal/test/TestGlobalObjectMapRecordFormat.sh
+++ b/DataFormats/L1TGlobal/test/TestGlobalObjectMapRecordFormat.sh
@@ -4,11 +4,9 @@ function die { echo $1: status $2 ;  exit $2; }
 
 LOCAL_TEST_DIR=${SCRAM_TEST_PATH}
 
-cmsRun ${LOCAL_TEST_DIR}/create_GlobalObjectMapRecord_test_file_cfg.py || die 'Failure using create_GlobalObjectMapRecord_test_file_cfg.py' $?
-
-file=testGlobalObjectMapRecord.root
-
-cmsRun ${LOCAL_TEST_DIR}/test_readGlobalObjectMapRecord_cfg.py "$file" || die "Failure using test_readGlobalObjectMapRecord_cfg.py $file" $?
+tmpfile=testGlobalObjectMapRecord.root
+cmsRun ${LOCAL_TEST_DIR}/create_GlobalObjectMapRecord_test_file_cfg.py --outputFileName "${tmpfile}" || die 'Failure using create_GlobalObjectMapRecord_test_file_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/test_readGlobalObjectMapRecord_cfg.py --inputFileName "${tmpfile}" --globalObjectMapClassVersion 11 || die "Failure using test_readGlobalObjectMapRecord_cfg.py ${tmpfile}" $?
 
 # The old files read below were generated as follows.
 #
@@ -28,7 +26,13 @@ oldFiles="testGlobalObjectMapRecord_CMSSW_13_0_0_split_99.root testGlobalObjectM
 oldFiles+=" testGlobalObjectMapRecord_CMSSW_13_1_0_pre3_split_99.root testGlobalObjectMapRecord_CMSSW_13_1_0_pre3_split_0.root"
 for file in $oldFiles; do
   inputfile=$(edmFileInPath DataFormats/L1TGlobal/data/$file) || die "Failure edmFileInPath DataFormats/L1TGlobal/data/$file" $?
-  cmsRun ${LOCAL_TEST_DIR}/test_readGlobalObjectMapRecord_cfg.py "$inputfile" || die "Failed to read old file $file" $?
+  cmsRun ${LOCAL_TEST_DIR}/test_readGlobalObjectMapRecord_cfg.py --inputFileName "$inputfile" --globalObjectMapClassVersion 10 || die "Failed to read old file $file" $?
 done
+
+#oldFiles="testGlobalObjectMapRecord_CMSSW_15_0_0_pre2_split_99.root testGlobalObjectMapRecord_CMSSW_15_0_0_pre2_split_0.root"
+#for file in $oldFiles; do
+#  inputfile=$(edmFileInPath DataFormats/L1TGlobal/data/$file) || die "Failure edmFileInPath DataFormats/L1TGlobal/data/$file" $?
+#  cmsRun ${LOCAL_TEST_DIR}/test_readGlobalObjectMapRecord_cfg.py --inputFileName "$inputfile" --globalObjectMapClassVersion 11 || die "Failed to read old file $file" $?
+#done
 
 exit 0

--- a/DataFormats/L1TGlobal/test/TestWriteGlobalObjectMapRecord.cc
+++ b/DataFormats/L1TGlobal/test/TestWriteGlobalObjectMapRecord.cc
@@ -56,6 +56,7 @@ namespace edmtest {
     unsigned int nElements3_;
     int firstElement_;
     int elementDelta_;
+    uint bxIndexModulus_;
 
     edm::EDPutTokenT<GlobalObjectMapRecord> globalObjectMapRecordPutToken_;
   };
@@ -76,6 +77,7 @@ namespace edmtest {
         nElements3_(iPSet.getParameter<unsigned int>("nElements3")),
         firstElement_(iPSet.getParameter<int>("firstElement")),
         elementDelta_(iPSet.getParameter<int>("elementDelta")),
+        bxIndexModulus_(iPSet.getParameter<uint>("bxIndexModulus")),
         globalObjectMapRecordPutToken_(produces()) {
     if (algoNames_.size() != nGlobalObjectMaps_ || algoBitNumbers_.size() != nGlobalObjectMaps_ ||
         algoResults_.size() != nGlobalObjectMaps_ || tokenNames0_.size() != nGlobalObjectMaps_ ||
@@ -121,14 +123,20 @@ namespace edmtest {
       // The only purpose is to later check that when
       // we read we get values that match what we wrote.
       int value = firstElement_;
-      std::vector<CombinationsInCond> combinationsInCondVector;
+      uint bxCounter = 0;
+      std::vector<CombinationsWithBxInCond> combinationsInCondVector;
+      combinationsInCondVector.reserve(nElements1_);
       for (unsigned int i = 0; i < nElements1_; ++i) {
-        CombinationsInCond combinationsInCond;
+        CombinationsWithBxInCond combinationsInCond;
+        combinationsInCond.reserve(nElements2_);
         for (unsigned int j = 0; j < nElements2_; ++j) {
-          SingleCombInCond singleCombInCond;
+          SingleCombWithBxInCond singleCombInCond;
+          singleCombInCond.reserve(nElements3_);
           for (unsigned int k = 0; k < nElements3_; ++k) {
-            singleCombInCond.push_back(value);
+            L1TObjBxIndexType const bxIdx = bxCounter % bxIndexModulus_;
+            singleCombInCond.emplace_back(bxIdx, value);
             value += elementDelta_;
+            ++bxCounter;
           }
           combinationsInCond.push_back(std::move(singleCombInCond));
         }
@@ -172,6 +180,7 @@ namespace edmtest {
     desc.add<unsigned int>("nElements3");
     desc.add<int>("firstElement");
     desc.add<int>("elementDelta");
+    desc.add<uint>("bxIndexModulus");
 
     descriptions.addDefault(desc);
   }

--- a/DataFormats/L1TGlobal/test/create_GlobalObjectMapRecord_test_file_cfg.py
+++ b/DataFormats/L1TGlobal/test/create_GlobalObjectMapRecord_test_file_cfg.py
@@ -1,4 +1,11 @@
 import FWCore.ParameterSet.Config as cms
+import argparse
+import sys
+
+parser = argparse.ArgumentParser(prog=sys.argv[0], description='Test GlobalObjectMapRecord')
+
+parser.add_argument('--outputFileName', type=str, help='Output file name (default: testGlobalObjectMapRecord.root)', default='testGlobalObjectMapRecord.root')
+args = parser.parse_args()
 
 process = cms.Process("PROD")
 
@@ -24,11 +31,12 @@ process.globalObjectMapRecordProducer = cms.EDProducer("TestWriteGlobalObjectMap
     nElements2 = cms.uint32(4),
     nElements3 = cms.uint32(5),
     firstElement = cms.int32(11),
-    elementDelta = cms.int32(3)
+    elementDelta = cms.int32(3),
+    bxIndexModulus = cms.uint32(3),
 )
 
 process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('testGlobalObjectMapRecord.root')
+    fileName = cms.untracked.string(f'{args.outputFileName}')
 )
 
 process.path = cms.Path(process.globalObjectMapRecordProducer)

--- a/DataFormats/L1TGlobal/test/test_readGlobalObjectMapRecord_cfg.py
+++ b/DataFormats/L1TGlobal/test/test_readGlobalObjectMapRecord_cfg.py
@@ -1,12 +1,20 @@
 import FWCore.ParameterSet.Config as cms
+import argparse
 import sys
 
-process = cms.Process("READ")
+parser = argparse.ArgumentParser(prog=sys.argv[0], description='Test GlobalObjectMapRecord')
 
-process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring("file:"+sys.argv[1]))
+parser.add_argument('--globalObjectMapClassVersion', type=int, help='Class version of GlobalObjectMap (default: 10)', default=10)
+parser.add_argument('--inputFileName', type=str, help='Input file name (default: testGlobalObjectMapRecord.root)', default='testGlobalObjectMapRecord.root')
+parser.add_argument('--outputFileName', type=str, help='Output file name (default: testGlobalObjectMapRecord2.root)', default='testGlobalObjectMapRecord2.root')
+args = parser.parse_args()
+
+process = cms.Process('READ')
+
+process.source = cms.Source('PoolSource', fileNames = cms.untracked.vstring(f'file:{args.inputFileName}'))
 process.maxEvents.input = 1
 
-process.testReadGlobalObjectMapRecord = cms.EDAnalyzer("TestReadGlobalObjectMapRecord",
+process.testReadGlobalObjectMapRecord = cms.EDAnalyzer('TestReadGlobalObjectMapRecord',
     expectedAlgoNames = cms.vstring('muonAlgo', 'electronAlgo'),
     expectedAlgoBitNumbers = cms.vint32(11, 21),
     expectedAlgoGtlResults = cms.vint32(1, 0),
@@ -18,13 +26,15 @@ process.testReadGlobalObjectMapRecord = cms.EDAnalyzer("TestReadGlobalObjectMapR
     expectedTokenResults3 = cms.vint32(0, 1),
     expectedFirstElement = cms.int32(11),
     expectedElementDelta = cms.int32(3),
+    expectedBxIndexModulus = cms.uint32(3),
     # 3 (delta) * (3*4*5 + 3*4) + 11 = 227
     expectedFinalValue = cms.int32(227),
-    globalObjectMapRecordTag = cms.InputTag("globalObjectMapRecordProducer", "", "PROD"),
+    globalObjectMapRecordTag = cms.InputTag('globalObjectMapRecordProducer', '', 'PROD'),
+    globalObjectMapClassVersion = cms.uint32(args.globalObjectMapClassVersion),
 )
 
-process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('testGlobalObjectMapRecord2.root'),
+process.out = cms.OutputModule('PoolOutputModule',
+    fileName = cms.untracked.string(f'{args.outputFileName}'),
     fastCloning = cms.untracked.bool(False)
 )
 

--- a/HLTrigger/HLTfilters/plugins/HLTL1TSeed.h
+++ b/HLTrigger/HLTfilters/plugins/HLTL1TSeed.h
@@ -1,5 +1,5 @@
-#ifndef HLTfilters_HLTL1TSeed_h
-#define HLTfilters_HLTL1TSeed_h
+#ifndef HLTrigger_HLTfilters_HLTL1TSeed_h
+#define HLTrigger_HLTfilters_HLTL1TSeed_h
 
 /**
  * \class HLTL1TSeed
@@ -49,7 +49,7 @@ public:
   explicit HLTL1TSeed(const edm::ParameterSet&);
 
   /// destructor
-  ~HLTL1TSeed() override;
+  ~HLTL1TSeed() override = default;
 
   /// parameter description
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);

--- a/L1Trigger/L1TGlobal/interface/AlgorithmEvaluation.h
+++ b/L1Trigger/L1TGlobal/interface/AlgorithmEvaluation.h
@@ -68,9 +68,8 @@ namespace l1t {
     /// evaluate an algorithm
     void evaluateAlgorithm(const int chipNumber, const std::vector<ConditionEvaluationMap>&);
 
-    /// get all the object combinations evaluated to true in the conditions
-    /// from the algorithm
-    inline std::vector<CombinationsInCond>& gtAlgoCombinationVector() { return m_algoCombinationVector; }
+    /// get all the object combinations evaluated to true in the conditions from the algorithm
+    inline std::vector<CombinationsWithBxInCond>& gtAlgoCombinationVector() { return m_algoCombinationVector; }
 
     inline std::vector<GlobalLogicParser::OperandToken>& operandTokenVector() { return m_operandTokenVector; }
 
@@ -86,7 +85,7 @@ namespace l1t {
 
     std::vector<OperandToken> m_operandTokenVector;
 
-    std::vector<CombinationsInCond> m_algoCombinationVector;
+    std::vector<CombinationsWithBxInCond> m_algoCombinationVector;
   };
 
 }  // namespace l1t

--- a/L1Trigger/L1TGlobal/interface/ConditionEvaluation.h
+++ b/L1Trigger/L1TGlobal/interface/ConditionEvaluation.h
@@ -78,7 +78,7 @@ namespace l1t {
     }
 
     /// get all the object combinations evaluated to true in the condition
-    inline CombinationsInCond const& getCombinationsInCond() const { return m_combinationsInCond; }
+    inline CombinationsWithBxInCond const& getCombinationsInCond() const { return m_combinationsInCond; }
 
     /// print condition
     virtual void print(std::ostream& myCout) const;
@@ -87,7 +87,7 @@ namespace l1t {
 
   protected:
     /// get all the object combinations (to fill it...)
-    inline CombinationsInCond& combinationsInCond() const { return m_combinationsInCond; }
+    inline CombinationsWithBxInCond& combinationsInCond() const { return m_combinationsInCond; }
 
     /// check if a value is greater than a threshold or
     /// greater-or-equal depending on the value of the condGEqValue flag
@@ -166,7 +166,7 @@ namespace l1t {
     bool m_condLastResult;
 
     /// store all the object combinations evaluated to true in the condition
-    mutable CombinationsInCond m_combinationsInCond;
+    mutable CombinationsWithBxInCond m_combinationsInCond;
 
     /// verbosity level
     int m_verbosity;

--- a/L1Trigger/L1TGlobal/plugins/GtRecordDump.cc
+++ b/L1Trigger/L1TGlobal/plugins/GtRecordDump.cc
@@ -287,28 +287,24 @@ namespace l1t {
             // Combination
             const std::vector<GlobalLogicParser::OperandToken>& opTokenVecObjMap = oMap.operandTokenVector();
             const std::vector<L1TObjectTypeInCond>& condObjTypeVec = oMap.objectTypeVector();
-            //		   const std::vector<CombinationsInCond>& condCombinations = oMapcombinationVector();
 
             for (size_t iCond = 0; iCond < opTokenVecObjMap.size(); iCond++) {
-              std::cout << "       " << iCond << ") Condition Token: " << opTokenVecObjMap.at(iCond).tokenName
+              std::cout << "       " << iCond << ") Condition Token: " << opTokenVecObjMap[iCond].tokenName
                         << "  Types: ";
-              std::vector<l1t::GlobalObject> condObjType = condObjTypeVec[iCond];
+              auto const& condObjType = condObjTypeVec[iCond];
               for (size_t iCondType = 0; iCondType < condObjType.size(); iCondType++) {
                 std::cout << condObjType.at(iCondType) << "  ";
               }
               std::cout << std::endl;
 
-              const CombinationsInCond* condComb = oMap.getCombinationsInCond(iCond);
+              const CombinationsWithBxInCond* condComb = oMap.getCombinationsInCond(iCond);
               std::cout << "            Combinations in Condition [" << condComb->size() << "] : ";
-              for (std::vector<SingleCombInCond>::const_iterator itComb = (*condComb).begin();
-                   itComb != (*condComb).end();
-                   itComb++) {
+              for (auto const& itComb : *condComb) {
                 // loop over objects in a combination for a given condition
                 //
                 unsigned int iType = 0;
                 std::cout << "(";
-                for (SingleCombInCond::const_iterator itObject = (*itComb).begin(); itObject != (*itComb).end();
-                     itObject++) {
+                for (auto const& [bxIdx, objIdx] : itComb) {
                   // loop over types for the object in a combination.  This object might have more then one type (i.e. mu-eg)
                   //
 
@@ -318,12 +314,12 @@ namespace l1t {
                   //
                   //const l1t::GlobalObject objTypeVal = condObjType.at(iType);
 
-                  std::cout << (*itObject);
-                  //std::cout <<objTypeVal << "@" << (*itObject);
+                  std::cout << bxIdx << ":" << objIdx;
+                  //std::cout <<objTypeVal << "@" << bxIdx << ":" << objIdx;
                   if (iType < condObjType.size() - 1)
                     std::cout << ",";
                   //std::cout
-                  //<< "\tAdd object of type " << objTypeVal << " and index " << (*itObject) << " to the seed list."
+                  //<< "\tAdd object of type " << objTypeVal << " and bx:index " << bxIdx << ":" << objIdx << " to the seed list."
                   //<< std::endl;
 
                   //		             } // end loop over objs in combination

--- a/L1Trigger/L1TGlobal/src/AlgorithmEvaluation.cc
+++ b/L1Trigger/L1TGlobal/src/AlgorithmEvaluation.cc
@@ -99,7 +99,7 @@ void l1t::AlgorithmEvaluation::evaluateAlgorithm(const int chipNumber,
           opNumber++;
 
           //
-          CombinationsInCond const& combInCondition = (itCond->second)->getCombinationsInCond();
+          auto const& combInCondition = (itCond->second)->getCombinationsInCond();
           m_algoCombinationVector.push_back(combInCondition);
 
         } else {
@@ -161,9 +161,9 @@ void l1t::AlgorithmEvaluation::evaluateAlgorithm(const int chipNumber,
 void l1t::AlgorithmEvaluation::print(std::ostream& myCout) const {
   myCout << std::endl;
 
-  myCout << "    Algorithm result:          " << m_algoResult << std::endl;
+  myCout << "    Algorithm result:       " << m_algoResult << std::endl;
 
-  myCout << "    CombinationVector size:    " << m_algoCombinationVector.size() << std::endl;
+  myCout << "    CombinationVector size: " << m_algoCombinationVector.size() << std::endl;
 
   int operandTokenVectorSize = m_operandTokenVector.size();
 

--- a/L1Trigger/L1TGlobal/src/CaloCondition.cc
+++ b/L1Trigger/L1TGlobal/src/CaloCondition.cc
@@ -155,7 +155,7 @@ const bool l1t::CaloCondition::evaluateCondition(const int bxEval) const {
   }
 
   // Look at objects in bx = bx + relativeBx
-  int useBx = bxEval + m_gtCaloTemplate->condRelativeBx();
+  L1TObjBxIndexType const useBx = bxEval + m_gtCaloTemplate->condRelativeBx();
 
   // Fail condition if attempting to get Bx outside of range
   if ((useBx < candVec->getFirstBX()) || (useBx > candVec->getLastBX())) {
@@ -185,7 +185,7 @@ const bool l1t::CaloCondition::evaluateCondition(const int bxEval) const {
 
   // store the indices of the calorimeter objects
   // from the combination evaluated in the condition
-  SingleCombInCond objectsInComb;
+  SingleCombWithBxInCond objectsInComb;
   objectsInComb.reserve(nObjInCond);
 
   // clear the m_combinationsInCond vector
@@ -203,7 +203,7 @@ const bool l1t::CaloCondition::evaluateCondition(const int bxEval) const {
       totalLoops++;
       bool passCondition = checkObjectParameter(0, *(candVec->at(useBx, i)), index[i]);
       if (passCondition) {
-        objectsInComb.push_back(i);
+        objectsInComb.emplace_back(useBx, i);
         condResult = true;
         passLoops++;
         combinationsInCond().push_back(objectsInComb);
@@ -268,8 +268,8 @@ const bool l1t::CaloCondition::evaluateCondition(const int bxEval) const {
           }  // end wsc check
 
           objectsInComb.clear();
-          objectsInComb.push_back(i);
-          objectsInComb.push_back(j);
+          objectsInComb.emplace_back(useBx, i);
+          objectsInComb.emplace_back(useBx, j);
           condResult = true;
           passLoops++;
           combinationsInCond().push_back(objectsInComb);
@@ -315,9 +315,9 @@ const bool l1t::CaloCondition::evaluateCondition(const int bxEval) const {
             condResult = true;
             passLoops++;
             objectsInComb.clear();
-            objectsInComb.push_back(i);
-            objectsInComb.push_back(j);
-            objectsInComb.push_back(k);
+            objectsInComb.emplace_back(useBx, i);
+            objectsInComb.emplace_back(useBx, j);
+            objectsInComb.emplace_back(useBx, k);
             combinationsInCond().push_back(objectsInComb);
           }
         }  // end loop on k
@@ -394,10 +394,10 @@ const bool l1t::CaloCondition::evaluateCondition(const int bxEval) const {
                          (passCondition0m && passCondition1k && passCondition2j && passCondition3i));
             if (pass) {
               objectsInComb.clear();
-              objectsInComb.push_back(i);
-              objectsInComb.push_back(j);
-              objectsInComb.push_back(k);
-              objectsInComb.push_back(m);
+              objectsInComb.emplace_back(useBx, i);
+              objectsInComb.emplace_back(useBx, j);
+              objectsInComb.emplace_back(useBx, k);
+              objectsInComb.emplace_back(useBx, m);
               condResult = true;
               passLoops++;
               combinationsInCond().push_back(objectsInComb);

--- a/L1Trigger/L1TGlobal/src/ConditionEvaluation.cc
+++ b/L1Trigger/L1TGlobal/src/ConditionEvaluation.cc
@@ -12,21 +12,9 @@
  *
  */
 
-// this class header
 #include "L1Trigger/L1TGlobal/interface/ConditionEvaluation.h"
 
-// system include files
-#include <iostream>
-#include <iomanip>
-#include <iterator>
-
-// user include files
-
-//   base class
-
-//
-
-// methods
+#include <ostream>
 
 /// print condition
 void l1t::ConditionEvaluation::print(std::ostream& myCout) const {
@@ -34,14 +22,12 @@ void l1t::ConditionEvaluation::print(std::ostream& myCout) const {
   myCout << "  Maximum number of objects in condition: " << m_condMaxNumberObjects << std::endl;
   myCout << "  Condition result:                       " << m_condLastResult << std::endl;
 
-  CombinationsInCond::const_iterator itVV;
   std::ostringstream myCout1;
-
-  for (itVV = (m_combinationsInCond).begin(); itVV != (m_combinationsInCond).end(); itVV++) {
+  for (size_t i1 = 0; i1 < m_combinationsInCond.size(); ++i1) {
     myCout1 << "( ";
-
-    std::copy((*itVV).begin(), (*itVV).end(), std::ostream_iterator<int>(myCout1, " "));
-
+    for (size_t i2 = 0; i2 < m_combinationsInCond[i1].size(); ++i2) {
+      myCout1 << m_combinationsInCond[i1][i2].first << ":" << m_combinationsInCond[i1][i2].second << " ";
+    }
     myCout1 << "); ";
   }
 

--- a/L1Trigger/L1TGlobal/src/CorrCondition.cc
+++ b/L1Trigger/L1TGlobal/src/CorrCondition.cc
@@ -126,11 +126,8 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
   const EnergySumTemplate* corrEnergySum = nullptr;
 
   // FIXME copying is slow...
-  CombinationsInCond cond0Comb;
-  CombinationsInCond cond1Comb;
-
-  int cond0bx(0);
-  int cond1bx(0);
+  CombinationsWithBxInCond cond0Comb{};
+  CombinationsWithBxInCond cond1Comb{};
 
   switch (cond0Categ) {
     case CondMuon: {
@@ -142,7 +139,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
       reqObjResult = muCondition.condLastResult();
 
       cond0Comb = (muCondition.getCombinationsInCond());
-      cond0bx = bxEval + (corrMuon->condRelativeBx());
+
       cndObjTypeVec[0] = (corrMuon->objectType())[0];
 
       if (m_verbosity) {
@@ -162,7 +159,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
       reqObjResult = caloCondition.condLastResult();
 
       cond0Comb = (caloCondition.getCombinationsInCond());
-      cond0bx = bxEval + (corrCalo->condRelativeBx());
+
       cndObjTypeVec[0] = (corrCalo->objectType())[0];
 
       if (m_verbosity) {
@@ -180,7 +177,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
       reqObjResult = eSumCondition.condLastResult();
 
       cond0Comb = (eSumCondition.getCombinationsInCond());
-      cond0bx = bxEval + (corrEnergySum->condRelativeBx());
+
       cndObjTypeVec[0] = (corrEnergySum->objectType())[0];
 
       if (m_verbosity) {
@@ -214,7 +211,6 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
       reqObjResult = muCondition.condLastResult();
 
       cond1Comb = (muCondition.getCombinationsInCond());
-      cond1bx = bxEval + (corrMuon->condRelativeBx());
 
       cndObjTypeVec[1] = (corrMuon->objectType())[0];
 
@@ -234,7 +230,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
       reqObjResult = caloCondition.condLastResult();
 
       cond1Comb = (caloCondition.getCombinationsInCond());
-      cond1bx = bxEval + (corrCalo->condRelativeBx());
+
       cndObjTypeVec[1] = (corrCalo->objectType())[0];
 
       if (m_verbosity) {
@@ -254,7 +250,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
       reqObjResult = eSumCondition.condLastResult();
 
       cond1Comb = (eSumCondition.getCombinationsInCond());
-      cond1bx = bxEval + (corrEnergySum->condRelativeBx());
+
       cndObjTypeVec[1] = (corrEnergySum->objectType())[0];
 
       if (m_verbosity) {
@@ -285,7 +281,7 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
 
   // vector to store the indices of the calorimeter objects
   // from the combination evaluated in the condition
-  SingleCombInCond objectsInComb;
+  SingleCombWithBxInCond objectsInComb;
   objectsInComb.reserve(nObjInCond);
 
   // clear the m_combinationsInCond vector
@@ -385,25 +381,23 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
   std::string lutObj0 = "NULL";
   std::string lutObj1 = "NULL";
 
-  LogTrace("L1TGlobal") << "  Sub-condition 0: std::vector<SingleCombInCond> size: " << (cond0Comb.size()) << std::endl;
-  LogTrace("L1TGlobal") << "  Sub-condition 1: std::vector<SingleCombInCond> size: " << (cond1Comb.size()) << std::endl;
+  LogTrace("L1TGlobal") << "  Sub-condition 0: std::vector<SingleCombWithBxInCond> size: " << cond0Comb.size();
+  LogTrace("L1TGlobal") << "  Sub-condition 1: std::vector<SingleCombWithBxInCond> size: " << cond1Comb.size();
 
   // loop over all combinations which produced individually "true" as Type1s
   //
   // BLW: Optimization issue: potentially making the same comparison twice
   //                          if both legs are the same object type.
-  for (std::vector<SingleCombInCond>::const_iterator it0Comb = cond0Comb.begin(); it0Comb != cond0Comb.end();
-       it0Comb++) {
-    // Type1s: there is 1 object only, no need for a loop, index 0 should be OK in (*it0Comb)[0]
+  for (auto const& it0Comb : cond0Comb) {
+    // Type1s: there is 1 object only, no need for a loop, index 0 should be OK in it0Comb[0]
     // ... but add protection to not crash
-    int obj0Index = -1;
-
-    if (!(*it0Comb).empty()) {
-      obj0Index = (*it0Comb)[0];
-    } else {
-      LogTrace("L1TGlobal") << "\n  SingleCombInCond (*it0Comb).size() " << ((*it0Comb).size()) << std::endl;
+    if (it0Comb.empty()) {
+      LogTrace("L1TGlobal") << "\n  SingleCombWithBxInCond it0Comb.size() " << it0Comb.size();
       return false;
     }
+
+    auto const cond0bx = it0Comb[0].first;
+    auto const obj0Index = it0Comb[0].second;
 
     // Collect the information on the first leg of the correlation
     switch (cond0Categ) {
@@ -684,19 +678,17 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
     }  //end switch on first leg type
 
     // Now loop over the second leg to get its information
-    for (std::vector<SingleCombInCond>::const_iterator it1Comb = cond1Comb.begin(); it1Comb != cond1Comb.end();
-         it1Comb++) {
-      LogDebug("L1TGlobal") << "Looking at second Condition" << std::endl;
-      // Type1s: there is 1 object only, no need for a loop (*it1Comb)[0]
+    for (auto const& it1Comb : cond1Comb) {
+      LogDebug("L1TGlobal") << "Looking at second Condition";
+      // Type1s: there is 1 object only, no need for a loop it1Comb[0]
       // ... but add protection to not crash
-      int obj1Index = -1;
-
-      if (!(*it1Comb).empty()) {
-        obj1Index = (*it1Comb)[0];
-      } else {
-        LogTrace("L1TGlobal") << "\n  SingleCombInCond (*it1Comb).size() " << ((*it1Comb).size()) << std::endl;
+      if (it1Comb.empty()) {
+        LogTrace("L1TGlobal") << "\n  SingleCombWithBxInCond it1Comb.size() " << it1Comb.size();
         return false;
       }
+
+      auto const cond1bx = it1Comb[0].first;
+      auto const obj1Index = it1Comb[0].second;
 
       //If we are dealing with the same object type avoid the two legs
       // either being the same object
@@ -995,8 +987,8 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
       // clear the indices in the combination
       objectsInComb.clear();
 
-      objectsInComb.push_back(obj0Index);
-      objectsInComb.push_back(obj1Index);
+      objectsInComb.emplace_back(cond0bx, obj0Index);
+      objectsInComb.emplace_back(cond1bx, obj1Index);
 
       // if we get here all checks were successful for this combination
       // set the general result for evaluateCondition to "true"

--- a/L1Trigger/L1TGlobal/src/CorrThreeBodyCondition.cc
+++ b/L1Trigger/L1TGlobal/src/CorrThreeBodyCondition.cc
@@ -106,13 +106,9 @@ const bool l1t::CorrThreeBodyCondition::evaluateCondition(const int bxEval) cons
 
   const MuonTemplate* corrMuon = nullptr;
 
-  CombinationsInCond cond0Comb;
-  CombinationsInCond cond1Comb;
-  CombinationsInCond cond2Comb;
-
-  int cond0bx(0);
-  int cond1bx(0);
-  int cond2bx(0);
+  CombinationsWithBxInCond cond0Comb{};
+  CombinationsWithBxInCond cond1Comb{};
+  CombinationsWithBxInCond cond2Comb{};
 
   // FIRST OBJECT
   bool reqObjResult = false;
@@ -126,7 +122,7 @@ const bool l1t::CorrThreeBodyCondition::evaluateCondition(const int bxEval) cons
     reqObjResult = muCondition.condLastResult();
 
     cond0Comb = (muCondition.getCombinationsInCond());
-    cond0bx = bxEval + (corrMuon->condRelativeBx());
+
     cndObjTypeVec[0] = (corrMuon->objectType())[0];
 
     if (m_verbosity) {
@@ -157,7 +153,7 @@ const bool l1t::CorrThreeBodyCondition::evaluateCondition(const int bxEval) cons
     reqObjResult = muCondition.condLastResult();
 
     cond1Comb = (muCondition.getCombinationsInCond());
-    cond1bx = bxEval + (corrMuon->condRelativeBx());
+
     cndObjTypeVec[1] = (corrMuon->objectType())[0];
 
     if (m_verbosity) {
@@ -190,7 +186,7 @@ const bool l1t::CorrThreeBodyCondition::evaluateCondition(const int bxEval) cons
     reqObjResult = muCondition.condLastResult();
 
     cond2Comb = (muCondition.getCombinationsInCond());
-    cond2bx = bxEval + (corrMuon->condRelativeBx());
+
     cndObjTypeVec[2] = (corrMuon->objectType())[0];
 
     if (m_verbosity) {
@@ -221,7 +217,7 @@ const bool l1t::CorrThreeBodyCondition::evaluateCondition(const int bxEval) cons
       *(m_gtCorrelationThreeBodyTemplate->correlationThreeBodyParameter());
 
   // Vector to store the indices of the objects involved in the condition evaluation
-  SingleCombInCond objectsInComb;
+  SingleCombWithBxInCond objectsInComb;
   objectsInComb.reserve(nObjInCond);
 
   // Clear the m_combinationsInCond vector:
@@ -291,28 +287,28 @@ const bool l1t::CorrThreeBodyCondition::evaluateCondition(const int bxEval) cons
   unsigned int preShift = 0;
 
   // *** Looking for a set of three objects
-  for (std::vector<SingleCombInCond>::const_iterator it0Comb = cond0Comb.begin(); it0Comb != cond0Comb.end();
-       it0Comb++) {
+  for (auto const& it0Comb : cond0Comb) {
     // Type1s: there is 1 object only, no need for a loop, index 0 should be OK in (*it0Comb)[0]
     // ... but add protection to not crash
     LogDebug("L1TGlobal") << "Looking at first subcondition" << std::endl;
-    int obj0Index = -1;
 
-    if (!(*it0Comb).empty()) {
-      obj0Index = (*it0Comb)[0];
-    } else {
-      LogTrace("L1TGlobal") << "\n  SingleCombInCond (*it0Comb).size() " << ((*it0Comb).size()) << std::endl;
+    if (it0Comb.empty()) {
+      LogTrace("L1TGlobal") << "\n  SingleCombWithBxInCond it0Comb.size() " << it0Comb.size();
       return false;
     }
+
+    auto const cond0bx = it0Comb[0].first;
+    auto const obj0Index = it0Comb[0].second;
 
     // FIRST OBJECT: Collect the information on the first leg of the correlation
     if (cond0Categ == CondMuon) {
       lutObj0 = "MU";
       candMuVec = m_uGtB->getCandL1Mu();
-      phiIndex0 = (candMuVec->at(cond0bx, obj0Index))->hwPhiAtVtx();
-      etaIndex0 = (candMuVec->at(cond0bx, obj0Index))->hwEtaAtVtx();
-      etIndex0 = (candMuVec->at(cond0bx, obj0Index))->hwPt();
-      chrg0 = (candMuVec->at(cond0bx, obj0Index))->hwCharge();
+      auto const* mu0 = candMuVec->at(cond0bx, obj0Index);
+      phiIndex0 = mu0->hwPhiAtVtx();
+      etaIndex0 = mu0->hwEtaAtVtx();
+      etIndex0 = mu0->hwPt();
+      chrg0 = mu0->hwCharge();
 
       etaBin0 = etaIndex0;
       if (etaBin0 < 0)
@@ -340,17 +336,16 @@ const bool l1t::CorrThreeBodyCondition::evaluateCondition(const int bxEval) cons
     }
 
     // SECOND OBJECT: Now loop over the second leg to get its information
-    for (std::vector<SingleCombInCond>::const_iterator it1Comb = cond1Comb.begin(); it1Comb != cond1Comb.end();
-         it1Comb++) {
+    for (auto const& it1Comb : cond1Comb) {
       LogDebug("L1TGlobal") << "Looking at second subcondition" << std::endl;
-      int obj1Index = -1;
 
-      if (!(*it1Comb).empty()) {
-        obj1Index = (*it1Comb)[0];
-      } else {
-        LogTrace("L1TGlobal") << "\n  SingleCombInCond (*it1Comb).size() " << ((*it1Comb).size()) << std::endl;
+      if (it1Comb.empty()) {
+        LogTrace("L1TGlobal") << "\n  SingleCombWithBxInCond it1Comb.size() " << it1Comb.size();
         return false;
       }
+
+      auto const cond1bx = it1Comb[0].first;
+      auto const obj1Index = it1Comb[0].second;
 
       // If we are dealing with the same object type avoid the two legs either being the same object
       if (cndObjTypeVec[0] == cndObjTypeVec[1] && obj0Index == obj1Index && cond0bx == cond1bx) {
@@ -361,10 +356,11 @@ const bool l1t::CorrThreeBodyCondition::evaluateCondition(const int bxEval) cons
       if (cond1Categ == CondMuon) {
         lutObj1 = "MU";
         candMuVec = m_uGtB->getCandL1Mu();
-        phiIndex1 = (candMuVec->at(cond1bx, obj1Index))->hwPhiAtVtx();
-        etaIndex1 = (candMuVec->at(cond1bx, obj1Index))->hwEtaAtVtx();
-        etIndex1 = (candMuVec->at(cond1bx, obj1Index))->hwPt();
-        chrg1 = (candMuVec->at(cond1bx, obj1Index))->hwCharge();
+        auto const* mu1 = candMuVec->at(cond1bx, obj1Index);
+        phiIndex1 = mu1->hwPhiAtVtx();
+        etaIndex1 = mu1->hwEtaAtVtx();
+        etIndex1 = mu1->hwPt();
+        chrg1 = mu1->hwCharge();
 
         etaBin1 = etaIndex1;
         if (etaBin1 < 0)
@@ -392,17 +388,16 @@ const bool l1t::CorrThreeBodyCondition::evaluateCondition(const int bxEval) cons
       }
 
       // THIRD OBJECT: Finally loop over the third leg to get its information
-      for (std::vector<SingleCombInCond>::const_iterator it2Comb = cond2Comb.begin(); it2Comb != cond2Comb.end();
-           it2Comb++) {
+      for (auto const& it2Comb : cond2Comb) {
         LogDebug("L1TGlobal") << "Looking at the third object for the three-body condition" << std::endl;
-        int obj2Index = -1;
 
-        if (!(*it2Comb).empty()) {
-          obj2Index = (*it2Comb)[0];
-        } else {
-          LogTrace("L1TGlobal") << "\n  SingleCombInCond (*it2Comb).size() " << ((*it2Comb).size()) << std::endl;
+        if (it2Comb.empty()) {
+          LogTrace("L1TGlobal") << "\n  SingleCombWithBxInCond it2Comb.size() " << it2Comb.size();
           return false;
         }
+
+        auto const cond2bx = it2Comb[0].first;
+        auto const obj2Index = it2Comb[0].second;
 
         // If we are dealing with the same object type avoid the two legs
         // either being the same object
@@ -415,10 +410,11 @@ const bool l1t::CorrThreeBodyCondition::evaluateCondition(const int bxEval) cons
         if (cond2Categ == CondMuon) {
           lutObj2 = "MU";
           candMuVec = m_uGtB->getCandL1Mu();
-          phiIndex2 = (candMuVec->at(cond2bx, obj2Index))->hwPhiAtVtx();
-          etaIndex2 = (candMuVec->at(cond2bx, obj2Index))->hwEtaAtVtx();
-          etIndex2 = (candMuVec->at(cond2bx, obj2Index))->hwPt();
-          chrg2 = (candMuVec->at(cond2bx, obj2Index))->hwCharge();
+          auto const* mu2 = candMuVec->at(cond2bx, obj2Index);
+          phiIndex2 = mu2->hwPhiAtVtx();
+          etaIndex2 = mu2->hwEtaAtVtx();
+          etIndex2 = mu2->hwPt();
+          chrg2 = mu2->hwCharge();
 
           etaBin2 = etaIndex2;
           if (etaBin2 < 0)
@@ -487,9 +483,9 @@ const bool l1t::CorrThreeBodyCondition::evaluateCondition(const int bxEval) cons
 
         // Clear the vector containing indices of the objects of the combination involved in the condition evaluation
         objectsInComb.clear();
-        objectsInComb.push_back(obj0Index);
-        objectsInComb.push_back(obj1Index);
-        objectsInComb.push_back(obj2Index);
+        objectsInComb.emplace_back(cond0bx, obj0Index);
+        objectsInComb.emplace_back(cond1bx, obj1Index);
+        objectsInComb.emplace_back(cond2bx, obj2Index);
 
         // Delta eta and phi calculations needed to evaluate the three-body invariant mass
         double deltaPhiPhy_01 = fabs(phi1Phy - phi0Phy);

--- a/L1Trigger/L1TGlobal/src/CorrWithOverlapRemovalCondition.cc
+++ b/L1Trigger/L1TGlobal/src/CorrWithOverlapRemovalCondition.cc
@@ -175,13 +175,9 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
   const EnergySumTemplate* corrEnergySum = nullptr;
 
   // FIXME copying is slow...
-  CombinationsInCond cond0Comb;
-  CombinationsInCond cond1Comb;
-  CombinationsInCond cond2Comb;
-
-  int cond0bx(0);
-  int cond1bx(0);
-  int cond2bx(0);
+  CombinationsWithBxInCond cond0Comb{};
+  CombinationsWithBxInCond cond1Comb{};
+  CombinationsWithBxInCond cond2Comb{};
 
   switch (cond0Categ) {
     case CondMuon: {
@@ -193,7 +189,6 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
       reqObjResult = muCondition.condLastResult();
 
       cond0Comb = (muCondition.getCombinationsInCond());
-      cond0bx = bxEval + (corrMuon->condRelativeBx());
 
       cndObjTypeVec[0] = (corrMuon->objectType())[0];
 
@@ -213,8 +208,7 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
       caloCondition.evaluateConditionStoreResult(bxEval);
       reqObjResult = caloCondition.condLastResult();
 
-      cond0Comb = (caloCondition.getCombinationsInCond());
-      cond0bx = bxEval + (corrCalo->condRelativeBx());
+      cond0Comb = caloCondition.getCombinationsInCond();
 
       cndObjTypeVec[0] = (corrCalo->objectType())[0];
 
@@ -232,8 +226,7 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
       eSumCondition.evaluateConditionStoreResult(bxEval);
       reqObjResult = eSumCondition.condLastResult();
 
-      cond0Comb = (eSumCondition.getCombinationsInCond());
-      cond0bx = bxEval + (corrEnergySum->condRelativeBx());
+      cond0Comb = eSumCondition.getCombinationsInCond();
 
       cndObjTypeVec[0] = (corrEnergySum->objectType())[0];
 
@@ -267,8 +260,8 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
       muCondition.evaluateConditionStoreResult(bxEval);
       reqObjResult = muCondition.condLastResult();
 
-      cond1Comb = (muCondition.getCombinationsInCond());
-      cond1bx = bxEval + (corrMuon->condRelativeBx());
+      cond1Comb = muCondition.getCombinationsInCond();
+
       cndObjTypeVec[1] = (corrMuon->objectType())[0];
 
       if (m_verbosity) {
@@ -286,8 +279,7 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
       caloCondition.evaluateConditionStoreResult(bxEval);
       reqObjResult = caloCondition.condLastResult();
 
-      cond1Comb = (caloCondition.getCombinationsInCond());
-      cond1bx = bxEval + (corrCalo->condRelativeBx());
+      cond1Comb = caloCondition.getCombinationsInCond();
 
       cndObjTypeVec[1] = (corrCalo->objectType())[0];
 
@@ -307,8 +299,8 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
       eSumCondition.evaluateConditionStoreResult(bxEval);
       reqObjResult = eSumCondition.condLastResult();
 
-      cond1Comb = (eSumCondition.getCombinationsInCond());
-      cond1bx = bxEval + (corrEnergySum->condRelativeBx());
+      cond1Comb = eSumCondition.getCombinationsInCond();
+
       cndObjTypeVec[1] = (corrEnergySum->objectType())[0];
 
       if (m_verbosity) {
@@ -344,8 +336,8 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
       muCondition.evaluateConditionStoreResult(bxEval);
       reqObjResult = muCondition.condLastResult();
 
-      cond2Comb = (muCondition.getCombinationsInCond());
-      cond2bx = bxEval + (corrMuon->condRelativeBx());
+      cond2Comb = muCondition.getCombinationsInCond();
+
       cndObjTypeVec[2] = (corrMuon->objectType())[0];
 
       if (m_verbosity) {
@@ -363,8 +355,8 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
       caloCondition.evaluateConditionStoreResult(bxEval);
       reqObjResult = caloCondition.condLastResult();
 
-      cond2Comb = (caloCondition.getCombinationsInCond());
-      cond2bx = bxEval + (corrCalo->condRelativeBx());
+      cond2Comb = caloCondition.getCombinationsInCond();
+
       cndObjTypeVec[2] = (corrCalo->objectType())[0];
 
       if (m_verbosity) {
@@ -383,8 +375,8 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
       eSumCondition.evaluateConditionStoreResult(bxEval);
       reqObjResult = eSumCondition.condLastResult();
 
-      cond2Comb = (eSumCondition.getCombinationsInCond());
-      cond2bx = bxEval + (corrEnergySum->condRelativeBx());
+      cond2Comb = eSumCondition.getCombinationsInCond();
+
       cndObjTypeVec[2] = (corrEnergySum->objectType())[0];
 
       if (m_verbosity) {
@@ -420,7 +412,7 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
 
   // vector to store the indices of the calorimeter objects
   // from the combination evaluated in the condition
-  SingleCombInCond objectsInComb;
+  SingleCombWithBxInCond objectsInComb;
   objectsInComb.reserve(nObjInCond);
 
   // clear the m_combinationsInCond vector
@@ -500,28 +492,27 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
   // BLW: Optimization issue: potentially making the same comparison twice
   //                          if both legs are the same object type.
   // ///////////////////////////////////////////////////////////////////////////////////////////
-  for (std::vector<SingleCombInCond>::const_iterator it0Comb = cond0Comb.begin(); it0Comb != cond0Comb.end();
-       it0Comb++) {
-    // Type1s: there is 1 object only, no need for a loop, index 0 should be OK in (*it0Comb)[0]
+  for (auto const& it0Comb : cond0Comb) {
+    // Type1s: there is 1 object only, no need for a loop, index 0 should be OK in it0Comb[0]
     // ... but add protection to not crash
-    int obj0Index = -1;
-
-    if (!(*it0Comb).empty()) {
-      obj0Index = (*it0Comb)[0];
-    } else {
-      LogTrace("L1TGlobal") << "\n  SingleCombInCond (*it0Comb).size() " << ((*it0Comb).size()) << std::endl;
+    if (it0Comb.empty()) {
+      LogTrace("L1TGlobal") << "\n  SingleCombWithBxCond it0Comb.size() " << it0Comb.size();
       return false;
     }
+
+    auto const cond0bx = it0Comb[0].first;
+    auto const obj0Index = it0Comb[0].second;
 
     // Collect the information on the first leg of the correlation
     switch (cond0Categ) {
       case CondMuon: {
         lutObj0 = "MU";
         candMuVec = m_uGtB->getCandL1Mu();
-        phiIndex0 = (candMuVec->at(cond0bx, obj0Index))->hwPhi();  //(*candMuVec)[obj0Index]->phiIndex();
-        etaIndex0 = (candMuVec->at(cond0bx, obj0Index))->hwEta();
-        etIndex0 = (candMuVec->at(cond0bx, obj0Index))->hwPt();
-        chrg0 = (candMuVec->at(cond0bx, obj0Index))->hwCharge();
+        auto const* mu0 = candMuVec->at(cond0bx, obj0Index);
+        phiIndex0 = mu0->hwPhi();  //mu0->phiIndex();
+        etaIndex0 = mu0->hwEta();
+        etIndex0 = mu0->hwPt();
+        chrg0 = mu0->hwCharge();
         int etaBin0 = etaIndex0;
         if (etaBin0 < 0)
           etaBin0 = m_gtScales->getMUScales().etaBins.size() + etaBin0;  //twos complement
@@ -792,19 +783,17 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
     // ///////////////////////////////////////////////////////////////////////////////////////////
     // Now loop over the second leg to get its information
     // ///////////////////////////////////////////////////////////////////////////////////////////
-    for (std::vector<SingleCombInCond>::const_iterator it1Comb = cond1Comb.begin(); it1Comb != cond1Comb.end();
-         it1Comb++) {
+    for (auto const& it1Comb : cond1Comb) {
       LogDebug("L1TGlobal") << "Looking at second Condition" << std::endl;
-      // Type1s: there is 1 object only, no need for a loop (*it1Comb)[0]
+      // Type1s: there is 1 object only, no need for a loop it1Comb[0]
       // ... but add protection to not crash
-      int obj1Index = -1;
-
-      if (!(*it1Comb).empty()) {
-        obj1Index = (*it1Comb)[0];
-      } else {
-        LogTrace("L1TGlobal") << "\n  SingleCombInCond (*it1Comb).size() " << ((*it1Comb).size()) << std::endl;
+      if (it1Comb.empty()) {
+        LogTrace("L1TGlobal") << "\n  SingleCombWithBxCond it1Comb.size() " << it1Comb.size();
         return false;
       }
+
+      auto const cond1bx = it1Comb[0].first;
+      auto const obj1Index = it1Comb[0].second;
 
       //If we are dealing with the same object type avoid the two legs
       // either being the same object
@@ -1422,18 +1411,16 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
       // ///////////////////////////////////////////////////////////////////////////////////////////
       // loop over overlap-removal leg combination which produced individually "true" as Type1s
       // ///////////////////////////////////////////////////////////////////////////////////////////
-      for (std::vector<SingleCombInCond>::const_iterator it2Comb = cond2Comb.begin(); it2Comb != cond2Comb.end();
-           it2Comb++) {
-        // Type1s: there is 1 object only, no need for a loop, index 0 should be OK in (*it2Comb)[0]
+      for (auto const& it2Comb : cond2Comb) {
+        // Type1s: there is 1 object only, no need for a loop, index 0 should be OK in it2Comb[0]
         // ... but add protection to not crash
-        int obj2Index = -1;
-
-        if (!(*it2Comb).empty()) {
-          obj2Index = (*it2Comb)[0];
-        } else {
-          LogTrace("L1TGlobal") << "\n  SingleCombInCond (*it2Comb).size() " << ((*it2Comb).size()) << std::endl;
+        if (it2Comb.empty()) {
+          LogTrace("L1TGlobal") << "\n  SingleCombWithBxCond it2Comb.size() " << it2Comb.size();
           return false;
         }
+
+        auto const cond2bx = it2Comb[0].first;
+        auto const obj2Index = it2Comb[0].second;
 
         // Collect the information on the overlap-removal leg
         switch (cond2Categ) {
@@ -1898,10 +1885,9 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
 
         // clear the indices in the combination
         objectsInComb.clear();
-
-        objectsInComb.push_back(obj0Index);
-        objectsInComb.push_back(obj1Index);
-        objectsInComb.push_back(obj2Index);
+        objectsInComb.emplace_back(cond0bx, obj0Index);
+        objectsInComb.emplace_back(cond1bx, obj1Index);
+        objectsInComb.emplace_back(cond2bx, obj2Index);
 
         (combinationsInCond()).push_back(objectsInComb);
 

--- a/L1Trigger/L1TGlobal/src/EnergySumCondition.cc
+++ b/L1Trigger/L1TGlobal/src/EnergySumCondition.cc
@@ -95,7 +95,7 @@ const bool l1t::EnergySumCondition::evaluateCondition(const int bxEval) const {
 
   // store the indices of the calorimeter objects
   // from the combination evaluated in the condition
-  SingleCombInCond objectsInComb;
+  SingleCombWithBxInCond objectsInComb;
 
   // clear the m_combinationsInCond vector
   (combinationsInCond()).clear();
@@ -106,7 +106,7 @@ const bool l1t::EnergySumCondition::evaluateCondition(const int bxEval) const {
   const BXVector<const l1t::EtSum*>* candVec = m_uGtB->getCandL1EtSum();
 
   // Look at objects in bx = bx + relativeBx
-  int useBx = bxEval + m_gtEnergySumTemplate->condRelativeBx();
+  L1TObjBxIndexType const useBx = bxEval + m_gtEnergySumTemplate->condRelativeBx();
 
   // Fail condition if attempting to get Bx outside of range
   if ((useBx < candVec->getFirstBX()) || (useBx > candVec->getLastBX())) {
@@ -247,9 +247,10 @@ const bool l1t::EnergySumCondition::evaluateCondition(const int bxEval) const {
   // get energy, phi (ETM and HTM) and overflow for the trigger object
   unsigned int candEt = 0;
   unsigned int candPhi = 0;
+
   bool candOverflow = false;
   for (int iEtSum = 0; iEtSum < numberObjects; ++iEtSum) {
-    l1t::EtSum cand = *(candVec->at(useBx, iEtSum));
+    auto const& cand = *(candVec->at(useBx, iEtSum));
     if (cand.getType() != type)
       continue;
     candEt = cand.hwPt();
@@ -302,9 +303,7 @@ const bool l1t::EnergySumCondition::evaluateCondition(const int bxEval) const {
   }
 
   // index is always zero, as they are global quantities (there is only one object)
-  int indexObj = 0;
-
-  objectsInComb.push_back(indexObj);
+  objectsInComb.emplace_back(useBx, 0);
   (combinationsInCond()).push_back(objectsInComb);
 
   // if we get here all checks were successfull for this combination

--- a/L1Trigger/L1TGlobal/src/EnergySumZdcCondition.cc
+++ b/L1Trigger/L1TGlobal/src/EnergySumZdcCondition.cc
@@ -96,7 +96,7 @@ const bool l1t::EnergySumZdcCondition::evaluateCondition(const int bxEval) const
 
   // store the indices of the calorimeter objects
   // from the combination evaluated in the condition
-  SingleCombInCond objectsInComb;
+  SingleCombWithBxInCond objectsInComb;
 
   // clear the m_combinationsInCond vector
   (combinationsInCond()).clear();
@@ -107,7 +107,7 @@ const bool l1t::EnergySumZdcCondition::evaluateCondition(const int bxEval) const
   const BXVector<const l1t::EtSum*>* candVecZdc = m_uGtB->getCandL1EtSumZdc();
 
   // Look at objects in bx = bx + relativeBx
-  int useBx = bxEval + m_gtEnergySumZdcTemplate->condRelativeBx();
+  L1TObjBxIndexType const useBx = bxEval + m_gtEnergySumZdcTemplate->condRelativeBx();
 
   // Fail condition if attempting to get Bx outside of range
   if ((useBx < candVecZdc->getFirstBX()) || (useBx > candVecZdc->getLastBX())) {
@@ -116,7 +116,6 @@ const bool l1t::EnergySumZdcCondition::evaluateCondition(const int bxEval) const
 
   // If no candidates, no use looking any further
   int numberObjectsZdc = candVecZdc->size(useBx);
-
   if (numberObjectsZdc < 1) {
     return false;
   }
@@ -150,7 +149,7 @@ const bool l1t::EnergySumZdcCondition::evaluateCondition(const int bxEval) const
   bool myres = false;
 
   for (int iEtSum = 0; iEtSum < numberObjectsZdc; ++iEtSum) {
-    l1t::EtSum candZdc = *(candVecZdc->at(useBx, iEtSum));
+    auto const& candZdc = *(candVecZdc->at(useBx, iEtSum));
 
     if (candZdc.getType() != type)
       continue;
@@ -182,9 +181,7 @@ const bool l1t::EnergySumZdcCondition::evaluateCondition(const int bxEval) const
     return false;
 
   // index is always zero, as they are global quantities (there is only one object)
-  int indexObj = 0;
-
-  objectsInComb.push_back(indexObj);
+  objectsInComb.emplace_back(useBx, 0);
   (combinationsInCond()).push_back(objectsInComb);
 
   // if we get here all checks were successful for this combination

--- a/L1Trigger/L1TGlobal/src/ExternalCondition.cc
+++ b/L1Trigger/L1TGlobal/src/ExternalCondition.cc
@@ -100,7 +100,7 @@ const bool l1t::ExternalCondition::evaluateCondition(const int bxEval) const {
 
   // store the indices of the calorimeter objects
   // from the combination evaluated in the condition
-  SingleCombInCond objectsInComb;
+  SingleCombWithBxInCond objectsInComb;
 
   // clear the m_combinationsInCond vector
   (combinationsInCond()).clear();
@@ -111,34 +111,32 @@ const bool l1t::ExternalCondition::evaluateCondition(const int bxEval) const {
   const BXVector<const GlobalExtBlk*>* candVec = m_uGtB->getCandL1External();
 
   // Look at objects in bx = bx + relativeBx
-  int useBx = bxEval + m_gtExternalTemplate->condRelativeBx();
-  unsigned int exCondCh = m_gtExternalTemplate->extChannel();
+  L1TObjBxIndexType const useBx = bxEval + m_gtExternalTemplate->condRelativeBx();
 
   // Fail condition if attempting to get Bx outside of range
   if ((useBx < candVec->getFirstBX()) || (useBx > candVec->getLastBX())) {
     return false;
   }
 
-  int numberObjects = candVec->size(useBx);
+  auto const numberObjects = candVec->size(useBx);
   if (numberObjects < 1) {
     return false;
   }
 
   //get external block (should only be one for the bx)
-  GlobalExtBlk ext = *(candVec->at(useBx, 0));
+  unsigned int const candIndex{0u};
+  GlobalExtBlk const& ext = *(candVec->at(useBx, candIndex));
   //ext.print(std::cout);
 
   // check external bit
+  unsigned int exCondCh = m_gtExternalTemplate->extChannel();
   if (!ext.getExternalDecision(exCondCh)) {
     LogDebug("L1TGlobal") << "\t\t External Condition was not set" << std::endl;
     return false;
   }
 
-  // index is always zero, as they are global quantities (there is only one object)
-  int indexObj = 0;
-
-  //Do we need this?
-  objectsInComb.push_back(indexObj);
+  // Do we need this?
+  objectsInComb.emplace_back(useBx, candIndex);
   (combinationsInCond()).push_back(objectsInComb);
 
   // if we get here all checks were successfull for this combination

--- a/L1Trigger/L1TGlobal/src/MuCondition.cc
+++ b/L1Trigger/L1TGlobal/src/MuCondition.cc
@@ -111,7 +111,7 @@ const bool l1t::MuCondition::evaluateCondition(const int bxEval) const {
   const BXVector<const l1t::Muon*>* candVec = m_gtGTL->getCandL1Mu();  //BLW Change for BXVector
 
   // Look at objects in bx = bx + relativeBx
-  int useBx = bxEval + m_gtMuonTemplate->condRelativeBx();
+  L1TObjBxIndexType const useBx = bxEval + m_gtMuonTemplate->condRelativeBx();
 
   // Fail condition if attempting to get Bx outside of range
   if ((useBx < candVec->getFirstBX()) || (useBx > candVec->getLastBX())) {
@@ -148,7 +148,7 @@ const bool l1t::MuCondition::evaluateCondition(const int bxEval) const {
 
   // store the indices of the muon objects
   // from the combination evaluated in the condition
-  SingleCombInCond objectsInComb;
+  SingleCombWithBxInCond objectsInComb;
   objectsInComb.reserve(nObjInCond);
 
   // clear the m_combinationsInCond vector
@@ -176,7 +176,7 @@ const bool l1t::MuCondition::evaluateCondition(const int bxEval) const {
       else
         LogDebug("L1TGlobal") << "===> MuCondition::evaluateCondition, FAIL!! This muon failed the condition."
                               << std::endl;
-      objectsInComb.push_back(index[i]);
+      objectsInComb.emplace_back(useBx, index[i]);
     }
 
     // if permutation does not match particle conditions
@@ -304,7 +304,7 @@ const bool l1t::MuCondition::evaluateCondition(const int bxEval) const {
     // set the general result for evaluateCondition to "true"
 
     condResult = true;
-    (combinationsInCond()).push_back(objectsInComb);
+    combinationsInCond().push_back(objectsInComb);
 
   } while (std::next_permutation(index.begin(), index.end()));
 

--- a/L1Trigger/L1TGlobal/src/MuonShowerCondition.cc
+++ b/L1Trigger/L1TGlobal/src/MuonShowerCondition.cc
@@ -102,7 +102,7 @@ const bool l1t::MuonShowerCondition::evaluateCondition(const int bxEval) const {
   const BXVector<std::shared_ptr<l1t::MuonShower>>* candVec = m_gtGTL->getCandL1MuShower();
 
   // Look at objects in BX = BX + relativeBX
-  int useBx = bxEval + m_gtMuonShowerTemplate->condRelativeBx();
+  L1TObjBxIndexType const useBx = bxEval + m_gtMuonShowerTemplate->condRelativeBx();
   LogDebug("MuonShowerCondition") << "Considering BX " << useBx << std::endl;
 
   // Fail condition if attempting to get BX outside of range
@@ -111,7 +111,7 @@ const bool l1t::MuonShowerCondition::evaluateCondition(const int bxEval) const {
   }
 
   // Store the indices of the shower objects from the combination evaluated in the condition
-  SingleCombInCond objectsInComb;
+  SingleCombWithBxInCond objectsInComb;
   objectsInComb.reserve(nObjInCond);
 
   // Clear the m_combinationsInCond vector
@@ -144,7 +144,7 @@ const bool l1t::MuonShowerCondition::evaluateCondition(const int bxEval) const {
     if (passCondition) {
       LogDebug("MuonShowerCondition")
           << "===> MuShowerCondition::evaluateCondition, PASS! This muon shower passed the condition." << std::endl;
-      objectsInComb.push_back(indexObj);
+      objectsInComb.emplace_back(useBx, indexObj);
     } else
       LogDebug("MuonShowerCondition")
           << "===> MuShowerCondition::evaluateCondition, FAIL! This muon shower failed the condition." << std::endl;


### PR DESCRIPTION
#### PR description:

https://github.com/cms-sw/cmssw/issues/44940 was solved with a workaround, but it exposed a shortcoming of the L1T-emulation software, namely the fact that the `GlobalObjectMap` data format does not keep track of the BX values of the L1T objects firing a given L1T algorithm. At HLT, one instance of `GlobalObjectMap(Record)` is produced by running the emulation of the L1uGT (plugin: `L1TGlobalProducer`) in order to know the indices of the L1T objects that fired a given L1T algorithm. The main consumers of this information at HLT are the many instances of the `HLTL1TSeed` plugin, which add these L1T objects to the Event via `trigger::TriggerFilterObjectWithRefs`. Since `GlobalObjectMap` does not provide BX info, `HLTL1TSeed` currently assumes that all these indices refer to L1T objects in BX=0. This assumption is most often correct, because almost all L1T algorithms use only L1T objects assigned to BX=0. On the other hand, L1T algorithms using objects from different BXs do exist (e.g. Cosmics-During-Collisions triggers), and in that case said assumption fails (for more context, see https://github.com/cms-sw/cmssw/issues/44940#issuecomment-2132094439, [CMSHLT-3216](https://its.cern.ch/jira/browse/CMSHLT-3216) and [CMSHLT-3218](https://its.cern.ch/jira/browse/CMSHLT-3218)).

This PR aims to add BX info to the `GlobalObjectMap`, as a way to fully address the problem described above. The risk/reward ratio of this PR is arguably high: the problem in question has fairly minor consequences in the current HLT menu (only 1 seed is affected), while this PR touches heavily the L1uGT-emulation software, incl. a data format used in RAW data, requiring careful review and validation.

Short description of the changes in this PR.
 - One data member of the `GlobalObjectMap` data format (nested vector of `int`s holding the indices of L1T objects) is replaced with a nested vector of `bx:index` pairs; backward compatibility with older version of this class is maintained via an `iorule` in `classes_def.xml`. The unit test introduced in #41565 is updated accordingly (if this PR is merged, there will have to be a follow-up PR to add to `cms-data` a new version of the unit-test input files).
 - Other classes used in the L1-uGT emulation (e.g. `ConditionEvaluation`) are updated in order to propagate downstream the BX values of the relevant L1T objects. This is done by changing the current vector of indices to a vector of `bx:index` pairs (these classes do not correspond to persistent data formats).
 - `HLTL1TSeed` is updated to make use of the BX value of the L1T objects, without assuming said BX to be zero. There is one exception to the latter point: in the case where the `GlobalObjectMap` used by `HLTL1TSeed` does not contain BX info (which can happen if one reads a `GlobalObjectMap` object directly from a file written before this PR), `HLTL1TSeed` will assumes that the BX is 0 (as it does now, in the absence of any alternatives). I do not know of any production workflows that rely on reading a `GlobalObjectMap` object from older files, so this exception should apply only in very rare cases (if at all).
 - ~~https://github.com/cms-sw/cmssw/pull/46026 is reverted. While validating this PR, I came to the conclusion that #46026 should be reverted, see item b) in the validation section below.~~ Edit (Jan-12): the revert of #46026 has been moved to #47088 (see https://github.com/cms-sw/cmssw/pull/47030#issuecomment-2585841659).

#### PR validation:

`addOnTests.py`, `runTheMatrix.py -l 12834.0` and the unit tests of the affected packages passed.

a) Expected output for the problematic event in #44940. Using [1] with this PR, I see that the module `hltL1sCDC` adds the expected 2 muons to the Event (one from BX=-1, and one from BX=0); see the printout below, to be compared to the one in https://github.com/cms-sw/cmssw/issues/44940#issuecomment-2132094439.
```text
--------------------------------------------------
Run             = 381147
LuminosityBlock = 202
Event           = 351398133
--------------------------------------------------

TriggerResults = "TriggerResults" [2 Paths]

   [0] | 0 | HLT_CDC_L2cosmic_10_er1p0_v10
   [1] | 0 | HLTriggerFinalPath

--------------------

TriggerEvent = "hltTriggerSummaryAOD::HLTX" [3 Filters, 188 TriggerObjects]


    [0] hltL1fL1sCDCL1Filtered0::HLTX (2 TriggerObjects)
         [3] FilterId = -81 : pt =    4.000, eta =  0.370, phi =  2.880, id =   0
         [4] FilterId = -81 : pt =    4.000, eta =  0.816, phi = -0.633, id =   0

    [1] hltL1sCDC::HLTX (2 TriggerObjects)
         [3] FilterId = -81 : pt =    4.000, eta =  0.370, phi =  2.880, id =   0
         [4] FilterId = -81 : pt =    4.000, eta =  0.816, phi = -0.633, id =   0

    [2] hltL2fL1sCDCL2CosmicMuL2Filtered3er2stations10er1p0::HLTX (0 TriggerObjects)
```

b) Revert of #46026 (note: the revert of #46026 has been moved to #47088, see https://github.com/cms-sw/cmssw/pull/47030#issuecomment-2585841659): running [1] in `CMSSW_15_0_0_pre1`, I see that the emulated decision of the CDC seed `L1_CDC_SingleMu_3_er1p2_TOP120_DPHI2p618_3p142` from the object-map used at HLT is `false` and disagrees with the 'firmware' decision in data (which is `true`). Reverting #46026 fixes this disagreement.

c) Using the test in [2], one can verify that the TriggerObjects in `trigger::TriggerEvent` are exactly the same before and after this PR, except for the expected difference related to the CDC seed. It's worth noting that this test is limited to the pp menu and 200 input events.

[1] Updated version of the test in https://github.com/cms-sw/cmssw/issues/44940#issuecomment-2131391510 on 1 event where the CDC seed fired during data-taking.
```bash
#!/bin/bash

[ $# -ge 1 ] || exit 1
hltLabel="${1}"

hltGetConfiguration /dev/CMSSW_14_2_0/GRun/V11 \
  --globaltag 141X_dataRun3_HLT_v2 \
  --no-prescale \
  --output minimal \
  --max-events 1 \
  --paths HLT_CDC_L2cosmic_10_er1p0_v*,HLTriggerFinalPath,HLTAnalyzerEndpath \
  --input root://eoscms.cern.ch//eos/cms/store/group/tsg/FOG/error_stream_root/run381147/run381147_ls0202_index000187_fu-c2b05-29-01_pid2159904.root \
  > "${hltLabel}".py

cat <<@EOF >> "${hltLabel}".py
process.options.numberOfThreads = 1
process.options.numberOfStreams = 0

process.source.skipEvents = cms.untracked.uint32( 56 )

del process.MessageLogger
process.load("FWCore.MessageLogger.MessageLogger_cfi")
process.MessageLogger.L1TGlobalSummary = cms.untracked.PSet()

# print the (unprescaled) emulated L1T decisions
process.hltL1TGlobalSummaryEmul = process.hltL1TGlobalSummary.clone(
    AlgInputTag = 'hltGtStage2ObjectMap',
    ExtInputTag = 'hltGtStage2ObjectMap',
)
process.HLTAnalyzerEndpath += process.hltL1TGlobalSummaryEmul
@EOF

cmsRun "${hltLabel}".py &> "${hltLabel}".log
mv output.root "${hltLabel}".root

# script to print the TriggerObjects in an EDM file
wget https://raw.githubusercontent.com/missirol/hltScripts/33d04bc85c5cb1581442ff5465904706ccb9b969/hltTests/hltFWLite_exa01.py -O printTriggerObjects.py
chmod u+x printTriggerObjects.py
./printTriggerObjects.py -n 1 -v 10 -i "${hltLabel}".root > "${hltLabel}"_triggerObjects.txt
rm -f printTriggerObjects.py
```

[2] Test running the latest HLT pp menu on 200 events of 2024 HLTPhysics data.
```bash
#!/bin/bash

[ $# -ge 1 ] || exit 1
hltLabel="${1}"

hltGetConfiguration /dev/CMSSW_14_2_0/GRun/V11 \
  --globaltag 141X_dataRun3_HLT_v2 \
  --no-prescale \
  --output minimal \
  --max-events 200 \
  --input root://eoscms.cern.ch//eos/cms/store/user/cmsbuild/store/data/Run2024I/EphemeralHLTPhysics0/RAW/v1/000/386/593/00000/91a08676-199e-404c-9957-f72772ef1354.root \
  > "${hltLabel}".py

cat <<@EOF >> "${hltLabel}".py
process.options.numberOfThreads = 1
process.options.numberOfStreams = 0
@EOF

cmsRun "${hltLabel}".py &> "${hltLabel}".log
mv output.root "${hltLabel}".root

# script to print the TriggerObjects in an EDM file
wget https://raw.githubusercontent.com/missirol/hltScripts/33d04bc85c5cb1581442ff5465904706ccb9b969/hltTests/hltFWLite_exa01.py -O printTriggerObjects.py
chmod u+x printTriggerObjects.py
./printTriggerObjects.py -n -1 -v 10 -i "${hltLabel}".root > "${hltLabel}"_triggerObjects.txt
rm -f printTriggerObjects.py
```

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A

~~If there is agreement on reverting #46026, that revert should arguably be backported to `CMSSW_14_2_X`.~~ (see #47089)
