### PR TITLE
Make implicit copy of `TrackingRecHitsSoACollection<TrackerTraits>` to host asynchronous

### DIFF
--- a/DataFormats/TrackingRecHitSoA/interface/alpaka/TrackingRecHitsSoACollection.h
+++ b/DataFormats/TrackingRecHitSoA/interface/alpaka/TrackingRecHitsSoACollection.h
@@ -51,8 +51,15 @@ namespace cms::alpakatools {
       assert(deviceData.nHits() == hostData.nHits());
       assert(deviceData.offsetBPIX2() == hostData.offsetBPIX2());
 #endif
-      // Update the contents address of the phiBinner histo container after the copy from device happened
-      alpaka::wait(queue);
+      return hostData;
+    }
+
+    // Update the contents address of the phiBinner histo container after the copy from device happened
+    static void postCopy(TrackingRecHitHost<TrackerTraits>& hostData) {
+      // Don't bother if zero hits
+      if (hostData.view().metadata().size() == 0) {
+        return;
+      }
       typename TrackingRecHitSoA<TrackerTraits>::PhiBinnerView pbv;
       pbv.assoc = &(hostData.view().phiBinner());
       pbv.offSize = -1;
@@ -60,8 +67,6 @@ namespace cms::alpakatools {
       pbv.contentSize = hostData.nHits();
       pbv.contentStorage = hostData.view().phiBinnerStorage();
       hostData.view().phiBinner().initStorage(pbv);
-
-      return hostData;
     }
   };
 }  // namespace cms::alpakatools


### PR DESCRIPTION
#### PR description:

This PR is a follow-up to https://github.com/cms-sw/cmssw/pull/45743 by making the implicit copy-to-host operation of `TrackingRecHitsSoACollection<TrackerTraits>` asynchronous, as planned in https://github.com/cms-sw/cmssw/issues/45708#issuecomment-2299066421 and https://github.com/cms-sw/cmssw/issues/45708#issuecomment-2324539478 (using the functionality added in https://github.com/cms-sw/cmssw/pull/45801)

Resolves https://github.com/cms-sw/framework-team/issues/1128

#### PR validation:

Unit tests pass on nodes with and without NVIDIA GPU