### PR TITLE
Add StreamID parameter to Transformer callback functions

### DIFF
--- a/FWCore/Framework/interface/TransformerBase.h
+++ b/FWCore/Framework/interface/TransformerBase.h
@@ -10,6 +10,7 @@
 
 #include "FWCore/Utilities/interface/EDPutToken.h"
 #include "FWCore/Utilities/interface/SoATuple.h"
+#include "FWCore/Utilities/interface/StreamID.h"
 #include "FWCore/Utilities/interface/TypeID.h"
 #include "FWCore/Utilities/interface/ProductResolverIndex.h"
 
@@ -38,8 +39,9 @@ namespace edm {
   protected:
     //The function takes the WrapperBase corresponding to the data product from the EDPutToken
     // and returns the WrapperBase associated to the id and instanceName
-    using TransformFunction = std::function<std::unique_ptr<edm::WrapperBase>(std::any)>;
-    using PreTransformFunction = std::function<std::any(edm::WrapperBase const&, edm::WaitingTaskWithArenaHolder)>;
+    using TransformFunction = std::function<std::unique_ptr<edm::WrapperBase>(edm::StreamID, std::any)>;
+    using PreTransformFunction =
+        std::function<std::any(edm::StreamID, edm::WrapperBase const&, edm::WaitingTaskWithArenaHolder)>;
 
     void registerTransformImp(ProducerBase&, EDPutToken, const TypeID& id, std::string instanceName, TransformFunction);
     void registerTransformAsyncImp(

--- a/FWCore/Framework/interface/limited/implementors.h
+++ b/FWCore/Framework/interface/limited/implementors.h
@@ -462,17 +462,17 @@ namespace edm {
 
         template <typename G, typename F>
         void registerTransform(edm::EDPutTokenT<G> iToken, F iF, std::string productInstance = std::string()) {
-          using ReturnTypeT = decltype(iF(std::declval<G>()));
+          using ReturnTypeT = decltype(iF(std::declval<edm::StreamID>(), std::declval<G>()));
           TypeID returnType(typeid(ReturnTypeT));
           TransformerBase::registerTransformImp(
               *this,
               EDPutToken(iToken),
               returnType,
               std::move(productInstance),
-              [f = std::move(iF)](std::any const& iGotProduct) {
+              [f = std::move(iF)](edm::StreamID id, std::any const& iGotProduct) {
                 auto pGotProduct = std::any_cast<edm::WrapperBase const*>(iGotProduct);
                 return std::make_unique<edm::Wrapper<ReturnTypeT>>(
-                    WrapperBase::Emplace{}, f(*static_cast<edm::Wrapper<G> const*>(pGotProduct)->product()));
+                    WrapperBase::Emplace{}, f(id, *static_cast<edm::Wrapper<G> const*>(pGotProduct)->product()));
               });
         }
 
@@ -481,20 +481,21 @@ namespace edm {
                                     P iPre,
                                     F iF,
                                     std::string productInstance = std::string()) {
-          using CacheTypeT = decltype(iPre(std::declval<G>(), WaitingTaskWithArenaHolder()));
-          using ReturnTypeT = decltype(iF(std::declval<CacheTypeT>()));
+          using CacheTypeT = decltype(iPre(std::declval<StreamID>(), std::declval<G>(), WaitingTaskWithArenaHolder()));
+          using ReturnTypeT = decltype(iF(std::declval<StreamID>(), std::declval<CacheTypeT>()));
           TypeID returnType(typeid(ReturnTypeT));
           TransformerBase::registerTransformAsyncImp(
               *this,
               EDPutToken(iToken),
               returnType,
               std::move(productInstance),
-              [p = std::move(iPre)](edm::WrapperBase const& iGotProduct, WaitingTaskWithArenaHolder iHolder) {
-                return std::any(p(*static_cast<edm::Wrapper<G> const&>(iGotProduct).product(), std::move(iHolder)));
+              [p = std::move(iPre)](
+                  edm::StreamID id, edm::WrapperBase const& iGotProduct, WaitingTaskWithArenaHolder iHolder) {
+                return std::any(p(id, *static_cast<edm::Wrapper<G> const&>(iGotProduct).product(), std::move(iHolder)));
               },
-              [f = std::move(iF)](std::any const& iCache) {
+              [f = std::move(iF)](edm::StreamID id, std::any const& iCache) {
                 auto cache = std::any_cast<CacheTypeT>(iCache);
-                return std::make_unique<edm::Wrapper<ReturnTypeT>>(WrapperBase::Emplace{}, f(cache));
+                return std::make_unique<edm::Wrapper<ReturnTypeT>>(WrapperBase::Emplace{}, f(id, cache));
               });
         }
 

--- a/FWCore/Framework/interface/one/implementors.h
+++ b/FWCore/Framework/interface/one/implementors.h
@@ -354,17 +354,18 @@ namespace edm {
 
         template <typename G, typename F>
         void registerTransform(edm::EDPutTokenT<G> iToken, F iF, std::string productInstance = std::string()) {
-          using ReturnTypeT = decltype(iF(std::declval<G>()));
+          using ReturnTypeT = decltype(iF(std::declval<edm::StreamID>(), std::declval<G>()));
           TypeID returnType(typeid(ReturnTypeT));
-          TransformerBase::registerTransformImp(*this,
-                                                EDPutToken(iToken),
-                                                returnType,
-                                                std::move(productInstance),
-                                                [f = std::move(iF)](edm::WrapperBase const& iGotProduct) {
-                                                  return std::make_unique<edm::Wrapper<ReturnTypeT>>(
-                                                      WrapperBase::Emplace{},
-                                                      f(*static_cast<edm::Wrapper<G> const&>(iGotProduct).product()));
-                                                });
+          TransformerBase::registerTransformImp(
+              *this,
+              EDPutToken(iToken),
+              returnType,
+              std::move(productInstance),
+              [f = std::move(iF)](edm::StreamID id, std::any const& iGotProduct) {
+                auto pGotProduct = std::any_cast<edm::WrapperBase const*>(iGotProduct);
+                return std::make_unique<edm::Wrapper<ReturnTypeT>>(
+                    WrapperBase::Emplace{}, f(id, *static_cast<edm::Wrapper<G> const*>(pGotProduct)->product()));
+              });
         }
 
         template <typename G, typename P, typename F>
@@ -372,20 +373,22 @@ namespace edm {
                                     P iPre,
                                     F iF,
                                     std::string productInstance = std::string()) {
-          using CacheTypeT = decltype(iPre(std::declval<G>(), WaitingTaskWithArenaHolder()));
-          using ReturnTypeT = decltype(iF(std::declval<CacheTypeT>()));
+          using CacheTypeT =
+              decltype(iPre(std::declval<edm::StreamID>(), std::declval<G>(), WaitingTaskWithArenaHolder()));
+          using ReturnTypeT = decltype(iF(std::declval<edm::StreamID>(), std::declval<CacheTypeT>()));
           TypeID returnType(typeid(ReturnTypeT));
           TransformerBase::registerTransformAsyncImp(
               *this,
               EDPutToken(iToken),
               returnType,
               std::move(productInstance),
-              [p = std::move(iPre)](edm::WrapperBase const& iGotProduct, WaitingTaskWithArenaHolder iHolder) {
-                return std::any(p(*static_cast<edm::Wrapper<G> const&>(iGotProduct).product(), std::move(iHolder)));
+              [p = std::move(iPre)](
+                  edm::StreamID id, edm::WrapperBase const& iGotProduct, WaitingTaskWithArenaHolder iHolder) {
+                return std::any(p(id, *static_cast<edm::Wrapper<G> const&>(iGotProduct).product(), std::move(iHolder)));
               },
-              [f = std::move(iF)](std::any const& iCache) {
+              [f = std::move(iF)](edm::StreamID id, std::any const& iCache) {
                 auto cache = std::any_cast<CacheTypeT>(iCache);
-                return std::make_unique<edm::Wrapper<ReturnTypeT>>(WrapperBase::Emplace{}, f(cache));
+                return std::make_unique<edm::Wrapper<ReturnTypeT>>(WrapperBase::Emplace{}, f(id, cache));
               });
         }
 

--- a/FWCore/Framework/interface/stream/implementors.h
+++ b/FWCore/Framework/interface/stream/implementors.h
@@ -328,17 +328,17 @@ namespace edm {
 
         template <typename G, typename F>
         void registerTransform(edm::EDPutTokenT<G> iToken, F iF, std::string productInstance = std::string()) {
-          using ReturnTypeT = decltype(iF(std::declval<G>()));
+          using ReturnTypeT = decltype(iF(std::declval<edm::StreamID>(), std::declval<G>()));
           TypeID returnType(typeid(ReturnTypeT));
           TransformerBase::registerTransformImp(
               *this,
               EDPutToken(iToken),
               returnType,
               std::move(productInstance),
-              [f = std::move(iF)](std::any const& iGotProduct) {
+              [f = std::move(iF)](edm::StreamID id, std::any const& iGotProduct) {
                 auto pGotProduct = std::any_cast<edm::WrapperBase const*>(iGotProduct);
                 return std::make_unique<edm::Wrapper<ReturnTypeT>>(
-                    WrapperBase::Emplace{}, f(*static_cast<edm::Wrapper<G> const*>(pGotProduct)->product()));
+                    WrapperBase::Emplace{}, f(id, *static_cast<edm::Wrapper<G> const*>(pGotProduct)->product()));
               });
         }
 
@@ -347,20 +347,22 @@ namespace edm {
                                     P iPre,
                                     F iF,
                                     std::string productInstance = std::string()) {
-          using CacheTypeT = decltype(iPre(std::declval<G>(), WaitingTaskWithArenaHolder()));
-          using ReturnTypeT = decltype(iF(std::declval<CacheTypeT>()));
+          using CacheTypeT =
+              decltype(iPre(std::declval<edm::StreamID>(), std::declval<G>(), WaitingTaskWithArenaHolder()));
+          using ReturnTypeT = decltype(iF(std::declval<edm::StreamID>(), std::declval<CacheTypeT>()));
           TypeID returnType(typeid(ReturnTypeT));
           TransformerBase::registerTransformAsyncImp(
               *this,
               EDPutToken(iToken),
               returnType,
               std::move(productInstance),
-              [p = std::move(iPre)](edm::WrapperBase const& iGotProduct, WaitingTaskWithArenaHolder iHolder) {
-                return std::any(p(*static_cast<edm::Wrapper<G> const&>(iGotProduct).product(), std::move(iHolder)));
+              [p = std::move(iPre)](
+                  edm::StreamID id, edm::WrapperBase const& iGotProduct, WaitingTaskWithArenaHolder iHolder) {
+                return std::any(p(id, *static_cast<edm::Wrapper<G> const&>(iGotProduct).product(), std::move(iHolder)));
               },
-              [f = std::move(iF)](std::any const& iCache) {
+              [f = std::move(iF)](edm::StreamID id, std::any const& iCache) {
                 auto cache = std::any_cast<CacheTypeT>(iCache);
-                return std::make_unique<edm::Wrapper<ReturnTypeT>>(WrapperBase::Emplace{}, f(cache));
+                return std::make_unique<edm::Wrapper<ReturnTypeT>>(WrapperBase::Emplace{}, f(id, cache));
               });
         }
 

--- a/FWCore/Framework/src/TransformerBase.cc
+++ b/FWCore/Framework/src/TransformerBase.cc
@@ -9,6 +9,8 @@
 
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 #include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
+#include "FWCore/ServiceRegistry/interface/StreamContext.h"
+
 #include <optional>
 
 namespace {
@@ -116,7 +118,8 @@ namespace edm {
       std::optional<decltype(iEvent.get(transformInfo_.get<kType>(iIndex), transformInfo_.get<kResolverIndex>(iIndex)))>
           handle;
       //transform acquiring signal
-      TransformAcquiringSignalSentry sentry(iAct, *mcc.getStreamContext(), mcc);
+      auto const& streamContext = *mcc.getStreamContext();
+      TransformAcquiringSignalSentry sentry(iAct, streamContext, mcc);
       CMS_SA_ALLOW try {
         handle = iEvent.get(transformInfo_.get<kType>(iIndex), transformInfo_.get<kResolverIndex>(iIndex));
       } catch (...) {
@@ -133,15 +136,16 @@ namespace edm {
               } else {
                 //transform signal
                 auto mcc = iEvent.moduleCallingContext();
-                TransformSignalSentry sentry(iAct, *mcc.getStreamContext(), mcc);
+                auto const& streamContext = *mcc.getStreamContext();
+                TransformSignalSentry sentry(iAct, streamContext, mcc);
                 iEvent.put(iBase.putTokenIndexToProductResolverIndex()[transformInfo_.get<kToken>(iIndex).index()],
-                           transformInfo_.get<kTransform>(iIndex)(std::move(*cache)),
+                           transformInfo_.get<kTransform>(iIndex)(streamContext.streamID(), std::move(*cache)),
                            handle);
               }
             });
         WaitingTaskWithArenaHolder wta(*iHolder.group(), nextTask);
         CMS_SA_ALLOW try {
-          *cache = transformInfo_.get<kPreTransform>(iIndex)(*(handle->wrapper()), wta);
+          *cache = transformInfo_.get<kPreTransform>(iIndex)(streamContext.streamID(), *(handle->wrapper()), wta);
         } catch (...) {
           wta.doneWaiting(std::current_exception());
         }
@@ -153,9 +157,10 @@ namespace edm {
         if (handle.wrapper()) {
           std::any v = handle.wrapper();
           //transform signal
-          TransformSignalSentry sentry(iAct, *mcc.getStreamContext(), mcc);
+          auto const& streamContext = *mcc.getStreamContext();
+          TransformSignalSentry sentry(iAct, streamContext, mcc);
           iEvent.put(iBase.putTokenIndexToProductResolverIndex()[transformInfo_.get<kToken>(iIndex).index()],
-                     transformInfo_.get<kTransform>(iIndex)(std::move(v)),
+                     transformInfo_.get<kTransform>(iIndex)(streamContext.streamID(), std::move(v)),
                      handle);
         }
       } catch (...) {

--- a/FWCore/Framework/test/global_filter_t.cppunit.cc
+++ b/FWCore/Framework/test/global_filter_t.cppunit.cc
@@ -357,7 +357,7 @@ private:
   public:
     TransformProd(edm::ParameterSet const&) {
       token_ = produces<float>();
-      registerTransform(token_, [](float iV) { return int(iV); });
+      registerTransform(token_, [](edm::StreamID, float iV) { return int(iV); });
     }
 
     bool filter(edm::StreamID, edm::Event& iEvent, edm::EventSetup const&) const {
@@ -380,8 +380,8 @@ private:
       token_ = produces<float>();
       registerTransformAsync(
           token_,
-          [](float iV, edm::WaitingTaskWithArenaHolder iHolder) { return IntHolder(iV); },
-          [](IntHolder iWaitValue) { return iWaitValue.value_; });
+          [](edm::StreamID, float iV, edm::WaitingTaskWithArenaHolder iHolder) { return IntHolder(iV); },
+          [](edm::StreamID, IntHolder iWaitValue) { return iWaitValue.value_; });
     }
 
     bool filter(edm::StreamID, edm::Event& iEvent, edm::EventSetup const&) const {

--- a/FWCore/Framework/test/global_producer_t.cppunit.cc
+++ b/FWCore/Framework/test/global_producer_t.cppunit.cc
@@ -325,7 +325,7 @@ private:
   public:
     TransformProd(edm::ParameterSet const&) {
       token_ = produces<float>();
-      registerTransform(token_, [](float iV) { return int(iV); });
+      registerTransform(token_, [](edm::StreamID, float iV) { return int(iV); });
     }
 
     void produce(edm::StreamID, edm::Event& iEvent, edm::EventSetup const&) const {
@@ -347,8 +347,8 @@ private:
       token_ = produces<float>();
       registerTransformAsync(
           token_,
-          [](float iV, edm::WaitingTaskWithArenaHolder iHolder) { return IntHolder(iV); },
-          [](IntHolder iWaitValue) { return iWaitValue.value_; });
+          [](edm::StreamID, float iV, edm::WaitingTaskWithArenaHolder iHolder) { return IntHolder(iV); },
+          [](edm::StreamID, IntHolder iWaitValue) { return iWaitValue.value_; });
     }
 
     void produce(edm::StreamID, edm::Event& iEvent, edm::EventSetup const&) const {

--- a/FWCore/Framework/test/limited_filter_t.cppunit.cc
+++ b/FWCore/Framework/test/limited_filter_t.cppunit.cc
@@ -391,7 +391,7 @@ private:
     TransformProd(edm::ParameterSet const&)
         : edm::limited::EDFilterBase(s_pset), edm::limited::EDFilter<edm::Transformer>(s_pset) {
       token_ = produces<float>();
-      registerTransform(token_, [](float iV) { return int(iV); });
+      registerTransform(token_, [](edm::StreamID, float iV) { return int(iV); });
     }
 
     bool filter(edm::StreamID, edm::Event& iEvent, edm::EventSetup const&) const {

--- a/FWCore/Framework/test/limited_producer_t.cppunit.cc
+++ b/FWCore/Framework/test/limited_producer_t.cppunit.cc
@@ -357,7 +357,7 @@ private:
     TransformProd(edm::ParameterSet const&)
         : edm::limited::EDProducerBase(s_pset), edm::limited::EDProducer<edm::Transformer>(s_pset) {
       token_ = produces<float>();
-      registerTransform(token_, [](float iV) { return int(iV); });
+      registerTransform(token_, [](edm::StreamID, float iV) { return int(iV); });
     }
 
     void produce(edm::StreamID, edm::Event& iEvent, edm::EventSetup const&) const {

--- a/FWCore/Framework/test/stream_producer_t.cppunit.cc
+++ b/FWCore/Framework/test/stream_producer_t.cppunit.cc
@@ -381,7 +381,7 @@ private:
   public:
     TransformProd(edm::ParameterSet const&) {
       token_ = produces<float>();
-      registerTransform(token_, [](float iV) { return int(iV); });
+      registerTransform(token_, [](edm::StreamID, float iV) { return int(iV); });
     }
 
     void produce(edm::Event& iEvent, edm::EventSetup const&) final {
@@ -403,8 +403,8 @@ private:
       token_ = produces<float>();
       registerTransformAsync(
           token_,
-          [](float iV, edm::WaitingTaskWithArenaHolder iHolder) { return IntHolder(iV); },
-          [](IntHolder iWaitValue) { return iWaitValue.value_; });
+          [](edm::StreamID, float iV, edm::WaitingTaskWithArenaHolder iHolder) { return IntHolder(iV); },
+          [](edm::StreamID, IntHolder iWaitValue) { return iWaitValue.value_; });
     }
 
     void produce(edm::Event& iEvent, edm::EventSetup const&) final {

--- a/FWCore/Framework/test/stream_producer_t.cppunit.cc
+++ b/FWCore/Framework/test/stream_producer_t.cppunit.cc
@@ -376,6 +376,44 @@ private:
       m_globalEndLuminosityBlockSummaryCalled = false;
     }
   };
+
+  class TransformProd : public edm::stream::EDProducer<edm::Transformer> {
+  public:
+    TransformProd(edm::ParameterSet const&) {
+      token_ = produces<float>();
+      registerTransform(token_, [](float iV) { return int(iV); });
+    }
+
+    void produce(edm::Event& iEvent, edm::EventSetup const&) final {
+      //iEvent.emplace(token_, 3.625);
+    }
+
+  private:
+    edm::EDPutTokenT<float> token_;
+  };
+
+  class TransformAsyncProd : public edm::stream::EDProducer<edm::Transformer> {
+  public:
+    struct IntHolder {
+      IntHolder() : value_(0) {}
+      IntHolder(int iV) : value_(iV) {}
+      int value_;
+    };
+    TransformAsyncProd(edm::ParameterSet const&) {
+      token_ = produces<float>();
+      registerTransformAsync(
+          token_,
+          [](float iV, edm::WaitingTaskWithArenaHolder iHolder) { return IntHolder(iV); },
+          [](IntHolder iWaitValue) { return iWaitValue.value_; });
+    }
+
+    void produce(edm::Event& iEvent, edm::EventSetup const&) final {
+      //iEvent.emplace(token_, 3.625);
+    }
+
+  private:
+    edm::EDPutTokenT<float> token_;
+  };
 };
 unsigned int testStreamProducer::BasicProd::m_count = 0;
 unsigned int testStreamProducer::GlobalProd::m_count = 0;

--- a/FWCore/Framework/test/stubs/ToyIntProducers.cc
+++ b/FWCore/Framework/test/stubs/ToyIntProducers.cc
@@ -1001,8 +1001,9 @@ namespace edm::test {
     public:
       explicit IntTransformer(edm::ParameterSet const& p)
           : token_{produces()}, value_(p.getParameter<int>("valueOther")) {
-        registerTransform(token_,
-                          [](edmtest::ATransientIntProduct const& iV) { return edmtest::IntProduct(iV.value); });
+        registerTransform(token_, [](edm::StreamID, edmtest::ATransientIntProduct const& iV) {
+          return edmtest::IntProduct(iV.value);
+        });
       }
       void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const final { e.emplace(token_, value_); }
 

--- a/FWCore/Integration/plugins/TransformAsyncIntProducer.cc
+++ b/FWCore/Integration/plugins/TransformAsyncIntProducer.cc
@@ -23,7 +23,7 @@ namespace edmtest {
       bool check = iPSet.getUntrackedParameter<bool>("checkTransformNotCalled");
       registerTransformAsync(
           putToken_,
-          [offset = transformOffset_, check](auto const& iFrom, auto iTask) {
+          [offset = transformOffset_, check](edm::StreamID, auto const& iFrom, auto iTask) {
             if (check) {
               throw cms::Exception("TransformShouldNotBeCalled");
             }
@@ -33,7 +33,7 @@ namespace edmtest {
             ret.value_ = IntProduct(iFrom.value + offset);
             return ret;
           },
-          [](auto const& iFrom) {
+          [](edm::StreamID, auto const& iFrom) {
             iFrom.thread_->join();
             return iFrom.value_;
           },

--- a/FWCore/Integration/plugins/TransformAsyncIntStreamProducer.cc
+++ b/FWCore/Integration/plugins/TransformAsyncIntStreamProducer.cc
@@ -22,7 +22,7 @@ namespace edmtest {
       bool check = iPSet.getUntrackedParameter<bool>("checkTransformNotCalled");
       registerTransformAsync(
           putToken_,
-          [offset = transformOffset_, check](auto const& iFrom, auto iTask) {
+          [offset = transformOffset_, check](edm::StreamID, auto const& iFrom, auto iTask) {
             if (check) {
               throw cms::Exception("TransformShouldNotBeCalled");
             }
@@ -32,7 +32,7 @@ namespace edmtest {
             ret.value_ = IntProduct(iFrom.value + offset);
             return ret;
           },
-          [](auto const& iFrom) {
+          [](edm::StreamID, auto const& iFrom) {
             iFrom.thread_->join();
             return iFrom.value_;
           },

--- a/FWCore/Integration/plugins/TransformIntProducer.cc
+++ b/FWCore/Integration/plugins/TransformIntProducer.cc
@@ -16,7 +16,7 @@ namespace edmtest {
       bool check = iPSet.getUntrackedParameter<bool>("checkTransformNotCalled");
       registerTransform(
           putToken_,
-          [offset = transformOffset_, check](auto const& iFrom) {
+          [offset = transformOffset_, check](edm::StreamID, auto const& iFrom) {
             if (check) {
               throw cms::Exception("TransformShouldNotBeCalled");
             }

--- a/FWCore/Integration/plugins/TransformIntStreamProducer.cc
+++ b/FWCore/Integration/plugins/TransformIntStreamProducer.cc
@@ -15,7 +15,7 @@ namespace edmtest {
       bool check = iPSet.getUntrackedParameter<bool>("checkTransformNotCalled");
       registerTransform(
           putToken_,
-          [offset = transformOffset_, check](auto const& iFrom) {
+          [offset = transformOffset_, check](edm::StreamID, auto const& iFrom) {
             if (check) {
               throw cms::Exception("TransformShouldNotBeCalled");
             }

--- a/HeterogeneousCore/AlpakaCore/interface/alpaka/ProducerBase.h
+++ b/HeterogeneousCore/AlpakaCore/interface/alpaka/ProducerBase.h
@@ -96,7 +96,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         using CopyT = cms::alpakatools::CopyToHost<TProduct>;
         this->registerTransformAsync(
             token,
-            [](TToken const& deviceProduct, edm::WaitingTaskWithArenaHolder holder) {
+            [](edm::StreamID, TToken const& deviceProduct, edm::WaitingTaskWithArenaHolder holder) {
               auto const& device = alpaka::getDev(deviceProduct.template metadata<EDMetadata>().queue());
               detail::EDMetadataAcquireSentry sentry(device, std::move(holder));
               auto metadataPtr = sentry.metadata();
@@ -112,7 +112,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
               // Wrap possibly move-only type into a copyable type
               return std::make_shared<TplType>(std::move(productOnHost), sentry.finish());
             },
-            [](auto tplPtr) {
+            [](edm::StreamID, auto tplPtr) {
               auto& productOnHost = std::get<0>(*tplPtr);
               if constexpr (requires { CopyT::postCopy(productOnHost); }) {
                 CopyT::postCopy(productOnHost);


### PR DESCRIPTION
#### PR description:

This PR adds `edm::StreamID` parameter to the callback functions for the Transformer EDModule ability. Knowing the `StreamID` would be useful in implementing implicit host-to-device data product copies for EDProducers (in addition to their implicit device-to-host copies).

Resolves https://github.com/cms-sw/framework-team/issues/1130

#### PR validation:

Framework unit tests run.