### PR TITLE
Remove commented-out `putenv()` calls from `SiPixelFedCablingMapWriter`

### DIFF
--- a/CalibTracker/SiPixelConnectivity/test/SiPixelFedCablingMapWriter.cc
+++ b/CalibTracker/SiPixelConnectivity/test/SiPixelFedCablingMapWriter.cc
@@ -45,9 +45,6 @@ SiPixelFedCablingMapWriter::SiPixelFedCablingMapWriter(const edm::ParameterSet& 
   out << " input file name " << fileName_ << endl;
   //out << " phase " << phase1_ << endl;
   LogInfo("initialisation: ") << out.str();
-
-  //::putenv(const_cast<char*>(std::string("CORAL_AUTH_USER=me").c_str()));
-  //::putenv(const_cast<char*>(std::string("CORAL_AUTH_PASSWORD=none").c_str()));
 }
 
 SiPixelFedCablingMapWriter::~SiPixelFedCablingMapWriter() = default;


### PR DESCRIPTION
#### PR description:

Identified as part of https://github.com/cms-sw/cmssw/issues/46002#issuecomment-2451996693. Removing the commented-out part makes it easier to not get false positives with searches like `git grep`.

Resolves https://github.com/cms-sw/framework-team/issues/1143

#### PR validation:

Code compiles