### PR TITLE
Add `BeamSpotCompatibilityChecker` to all alignment offline validation configuration files

### DIFF
--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlDiMuonAndVertex_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlDiMuonAndVertex_Output_cff.py
@@ -20,7 +20,8 @@ OutALCARECOTkAlDiMuonAndVertex_noDrop = cms.PSet(
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         'keep *_TriggerResults_*_*',
         'keep DcsStatuss_scalersRawToDigi_*_*',
-        'keep *_offlinePrimaryVertices_*_*')
+        'keep *_offlinePrimaryVertices_*_*',
+        'keep *_offlineBeamSpot_*_*')
 )
 
 # add branches for MC truth evaluation

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMu_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMu_Output_cff.py
@@ -15,7 +15,8 @@ OutALCARECOTkAlZMuMu_noDrop = cms.PSet(
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         'keep *_TriggerResults_*_*',
         'keep DcsStatuss_scalersRawToDigi_*_*',
-	'keep *_offlinePrimaryVertices_*_*')
+        'keep *_offlinePrimaryVertices_*_*',
+        'keep *_offlineBeamSpot_*_*')
 )
 
 # add branches for MC truth evaluation

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/DiMuonV_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/DiMuonV_cfg.py
@@ -134,7 +134,7 @@ process.load("RecoVertex.BeamSpotProducer.BeamSpot_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
 # default to remain in sycn with the default input sample
-process.GlobalTag = GlobalTag(process.GlobalTag, config["alignment"].get("globaltag", "auto:phase1_2022_realistic"))
+process.GlobalTag = GlobalTag(process.GlobalTag, config["alignment"].get("globaltag", "125X_mcRun3_2022_realistic_v3"))
 
 ####################################################################
 # Load conditions if wished
@@ -184,9 +184,21 @@ process.offlinePrimaryVerticesFromRefittedTrks = offlinePrimaryVertices.clone()
 process.offlinePrimaryVerticesFromRefittedTrks.TrackLabel = cms.InputTag("refittedVtxTracks")
 
 ####################################################################
+# BeamSpot check
+####################################################################
+from RecoVertex.BeamSpotProducer.beamSpotCompatibilityChecker_cfi import beamSpotCompatibilityChecker
+process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
+    bsFromEvent = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
+    bsFromDB = "offlineBeamSpot",           # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
+    warningThr = config["validation"].get("bsIncompatibleWarnThresh", 3), # significance threshold to emit a warning message
+    errorThr = config["validation"].get("bsIncompatibleErrThresh", 5),    # significance threshold to abort the job
+)
+
+####################################################################
 # Sequence
 ####################################################################
 process.seqRefitting = cms.Sequence(process.offlineBeamSpot   +
+                                    process.BeamSpotChecker   +
                                     process.refittedMuons     +
                                     process.refittedVtxTracks +
                                     process.offlinePrimaryVerticesFromRefittedTrks)

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/JetHT_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/JetHT_cfg.py
@@ -289,14 +289,27 @@ process.TFileService = cms.Service("TFileService",
                                    )
 
 
+###################################################################
+# Beamspot compatibility check
+###################################################################
+from RecoVertex.BeamSpotProducer.beamSpotCompatibilityChecker_cfi import beamSpotCompatibilityChecker
+process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
+    bsFromEvent = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
+    bsFromDB = "offlineBeamSpot",           # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
+    warningThr = configuration["validation"].get("bsIncompatibleWarnThresh", 3), # significance threshold to emit a warning message
+    errorThr = configuration["validation"].get("bsIncompatibleErrThresh", 5),    # significance threshold to abort the job
+)
+
 if (triggerFilter == "nothing" or triggerFilter == ""):
-    process.p = cms.Path(process.offlineBeamSpot                        + 
+    process.p = cms.Path(process.offlineBeamSpot                        +
+                         process.BeamSpotChecker                        +
                          process.TrackRefitter                          + 
                          process.offlinePrimaryVerticesFromRefittedTrks +
                          process.jetHTAnalyzer)
 else:
     process.p = cms.Path(process.HLTFilter                              +
-                         process.offlineBeamSpot                        + 
+                         process.offlineBeamSpot                        +
+                         process.BeamSpotChecker                        +
                          process.TrackRefitter                          + 
                          process.offlinePrimaryVerticesFromRefittedTrks +
                          process.jetHTAnalyzer)

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/SplitV_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/SplitV_cfg.py
@@ -117,7 +117,7 @@ process.TrackRefitter.NavigationSchool = ""
 ####################################################################
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, config["alignment"].get("globaltag", "auto:phase1_2017_realistic"))
+process.GlobalTag = GlobalTag(process.GlobalTag, config["alignment"].get("globaltag", "105X_upgrade2018_realistic_v4"))
 
 ####################################################################
 # Load conditions if wished
@@ -196,7 +196,20 @@ process.TFileService = cms.Service("TFileService",
                                    )
 print("Saving the output at %s" % process.TFileService.fileName.value())
 
+
+###################################################################
+# Beamspot compatibility check
+###################################################################
+from RecoVertex.BeamSpotProducer.beamSpotCompatibilityChecker_cfi import beamSpotCompatibilityChecker
+process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
+    bsFromEvent = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
+    bsFromDB = "offlineBeamSpot",           # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
+    warningThr = config["validation"].get("bsIncompatibleWarnThresh", 3), # significance threshold to emit a warning message
+    errorThr = config["validation"].get("bsIncompatibleErrThresh", 5),    # significance threshold to abort the job
+)
+
 process.theValidSequence = cms.Sequence(process.offlineBeamSpot                        +
+                                        process.BeamSpotChecker                        +
                                         process.TrackRefitter                          +
                                         process.offlinePrimaryVerticesFromRefittedTrks +
                                         process.PrimaryVertexResolution)

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/Zmumu_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/Zmumu_cfg.py
@@ -194,4 +194,18 @@ if valiMode == "StandAlone":
             closeFileFast = cms.untracked.bool(True),
     )
 
-process.p = cms.Path(process.offlineBeamSpot*process.TrackRefitter*process.DiMuonMassValidation)
+###################################################################
+# Beamspot compatibility check
+###################################################################
+from RecoVertex.BeamSpotProducer.beamSpotCompatibilityChecker_cfi import beamSpotCompatibilityChecker
+process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
+    bsFromEvent = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
+    bsFromDB = "offlineBeamSpot",           # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
+    warningThr = config["validation"].get("bsIncompatibleWarnThresh", 3), # significance threshold to emit a warning message
+    errorThr = config["validation"].get("bsIncompatibleErrThresh", 5),    # significance threshold to abort the job
+)
+
+process.p = cms.Path(process.offlineBeamSpot*
+                     #process.BeamSpotChecker* # commented for now
+                     process.TrackRefitter*
+                     process.DiMuonMassValidation)

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/defaultInputFiles_cff.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/defaultInputFiles_cff.py
@@ -61,4 +61,8 @@ filesDefaultData_MinBias2018B = cms.untracked.vstring(
     '/store/express/Run2018B/StreamExpress/ALCARECO/TkAlMinBias-Express-v1/000/317/212/00000/00F0EFA7-8D64-E811-A594-FA163EFC96CC.root'
 )
 
+filesDefaultData_HLTPhys2024I = cms.untracked.vstring(
+    '/store/data/Run2024I/HLTPhysics/ALCARECO/TkAlMinBias-PromptReco-v2/000/386/803/00000/a95259f9-a333-44f9-b30f-803642e97590.root'
+)
+
 filesDefaultData_Cosmics_string = "/store/data/Run2022G/Cosmics/ALCARECO/TkAlCosmics0T-PromptReco-v1/000/362/440/00000/47f31eaa-1c00-4f39-902b-a09fa19c27f2.root"

--- a/Alignment/OfflineValidation/test/PVValidation_TEMPL_cfg.py
+++ b/Alignment/OfflineValidation/test/PVValidation_TEMPL_cfg.py
@@ -165,11 +165,22 @@ process.filterOutLowPt.thresh = 1
 process.filterOutLowPt.ptmin  = PTCUTTEMPLATE
 process.filterOutLowPt.runControl = RUNCONTROLTEMPLATE
 process.filterOutLowPt.runControlNumber = [runboundary]
-                                
+
+###################################################################
+# Beamspot compatibility check
+###################################################################
+from RecoVertex.BeamSpotProducer.beamSpotCompatibilityChecker_cfi import beamSpotCompatibilityChecker
+process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
+    bsFromEvent = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
+    bsFromDB = "offlineBeamSpot",           # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
+    warningThr = 3, # significance threshold to emit a warning message
+    errorThr = 5,    # significance threshold to abort the job
+)
+
 if isMC:
-     process.goodvertexSkim = cms.Sequence(process.noscraping + process.filterOutLowPt)
+     process.goodvertexSkim = cms.Sequence(process.BeamSpotChecker + process.noscraping + process.filterOutLowPt)
 else:
-     process.goodvertexSkim = cms.Sequence(process.primaryVertexFilter + process.noscraping + process.filterOutLowPt)
+     process.goodvertexSkim = cms.Sequence(process.BeamSpotChecker + process.primaryVertexFilter + process.noscraping + process.filterOutLowPt)
 
 ####################################################################
 # Load and Configure Measurement Tracker Event

--- a/Alignment/OfflineValidation/test/PVValidation_T_cfg.py
+++ b/Alignment/OfflineValidation/test/PVValidation_T_cfg.py
@@ -162,10 +162,21 @@ process.filterOutLowPt.ptmin  = PTCUTTEMPLATE
 process.filterOutLowPt.runControl = RUNCONTROLTEMPLATE
 process.filterOutLowPt.runControlNumber = [runboundary]
 
+####################################################################
+# BeamSpot check
+####################################################################
+from RecoVertex.BeamSpotProducer.beamSpotCompatibilityChecker_cfi import beamSpotCompatibilityChecker
+process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
+    bsFromEvent = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
+    bsFromDB = "offlineBeamSpot",           # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
+    warningThr = 3, # significance threshold to emit a warning message
+    errorThr = 5,    # significance threshold to abort the job
+)
+
 if isMC:
-     process.goodvertexSkim = cms.Sequence(process.noscraping+process.filterOutLowPt)
+     process.goodvertexSkim = cms.Sequence(process.BeamSpotChecker + process.noscraping+process.filterOutLowPt)
 else:
-     process.goodvertexSkim = cms.Sequence(process.primaryVertexFilter + process.noscraping + process.filterOutLowPt)
+     process.goodvertexSkim = cms.Sequence(process.BeamSpotChecker + process.primaryVertexFilter + process.noscraping + process.filterOutLowPt)
 
 ####################################################################
 # Load and Configure Measurement Tracker Event

--- a/Alignment/OfflineValidation/test/PrimaryVertexResolution_cfg.py
+++ b/Alignment/OfflineValidation/test/PrimaryVertexResolution_cfg.py
@@ -188,17 +188,33 @@ process.PrimaryVertexResolution = cms.EDAnalyzer('SplitVertexResolution',
                                                  nVtxBins = cms.untracked.double(40.)
                                                  )
 
+###################################################################
+# TFileService
+###################################################################
 process.TFileService = cms.Service("TFileService",
                                    fileName = cms.string(options.outputRootFile),	
                                    closeFileFast = cms.untracked.bool(False)
                                    )
 
+###################################################################
+# Beamspot compatibility check
+###################################################################
+from RecoVertex.BeamSpotProducer.beamSpotCompatibilityChecker_cfi import beamSpotCompatibilityChecker
+process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
+    bsFromEvent = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
+    bsFromDB = "offlineBeamSpot",           # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
+    warningThr = 3, # significance threshold to emit a warning message
+    errorThr = 5    # significance threshold to abort the job
+)
+
+###################################################################
+# Path
+###################################################################
 process.p = cms.Path(process.HLTFilter                               +
                      #process.offlineBeamSpot                        +
                      #process.TrackRefitter                          +
+                     process.BeamSpotChecker                         +
                      process.seqTrackselRefit                        +
                      process.offlinePrimaryVerticesFromRefittedTrks  +
                      process.PrimaryVertexResolution                 +
                      process.myanalysis)
-
-

--- a/Alignment/OfflineValidation/test/PrimaryVertexResolution_templ_cfg.py
+++ b/Alignment/OfflineValidation/test/PrimaryVertexResolution_templ_cfg.py
@@ -176,15 +176,31 @@ process.PrimaryVertexResolution = cms.EDAnalyzer('SplitVertexResolution',
                                                  nVtxBins = cms.untracked.double(40.)
                                                  )
 
+###################################################################
+# TFileService
+###################################################################
 process.TFileService = cms.Service("TFileService",
                                    fileName = cms.string(options.outputRootFile),	
                                    closeFileFast = cms.untracked.bool(False)
                                    )
 
-process.p = cms.Path(process.seqTrackselRefit                       +
+###################################################################
+# Beamspot compatibility check
+###################################################################
+from RecoVertex.BeamSpotProducer.beamSpotCompatibilityChecker_cfi import beamSpotCompatibilityChecker
+process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
+    bsFromEvent = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
+    bsFromDB = "offlineBeamSpot",           # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
+    warningThr = 3, # significance threshold to emit a warning message
+    errorThr = 5    # significance threshold to abort the job
+)
+
+###################################################################
+# Path
+###################################################################
+process.p = cms.Path(process.BeamSpotChecker                        +
+                     process.seqTrackselRefit                       +
                      #process.offlineBeamSpot                       +
                      #process.TrackRefitter                         +
                      process.offlinePrimaryVerticesFromRefittedTrks +
                      process.PrimaryVertexResolution)
-
-

--- a/Alignment/OfflineValidation/test/testPrimaryVertexRelatedValidations_cfg.py
+++ b/Alignment/OfflineValidation/test/testPrimaryVertexRelatedValidations_cfg.py
@@ -36,8 +36,9 @@ _theTrackCollection = 'generalTracks' # FIXME: 'ALCARECOTkAlMinBias' once a samp
 ###################################################################
 # Set default phase-2 settings
 ###################################################################
-import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
-_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
+if(options.isPhase2):
+     import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+     _PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
 
 ###################################################################
 # Set the era
@@ -123,7 +124,7 @@ process.load("RecoVertex.BeamSpotProducer.BeamSpot_cff")
 ####################################################################
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, (_PH2_GLOBAL_TAG if options.isPhase2 else 'auto:phase1_2022_realistic'), '')
+process.GlobalTag = GlobalTag(process.GlobalTag, (_PH2_GLOBAL_TAG if options.isPhase2 else '125X_mcRun3_2022_realistic_v3'), '')
 
 if _allFromGT:
      print("############ testPVValidation_cfg.py: msg%-i: All is taken from GT")
@@ -214,10 +215,21 @@ process.noslowpt = cms.EDFilter("FilterOutLowPt",
                                 runControlNumber = cms.untracked.vuint32(int(runboundary))
                                 )
 
+####################################################################
+# BeamSpot check
+####################################################################
+from RecoVertex.BeamSpotProducer.beamSpotCompatibilityChecker_cfi import beamSpotCompatibilityChecker
+process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
+     bsFromEvent = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
+     bsFromDB = "offlineBeamSpot",           # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
+     warningThr = 5, # significance threshold to emit a warning message
+     errorThr = 10,  # significance threshold to abort the job
+)
+
 if _isMC:
-     process.goodvertexSkim = cms.Sequence(process.noscraping)
+     process.goodvertexSkim = cms.Sequence(process.BeamSpotChecker + process.noscraping)
 else:
-     process.goodvertexSkim = cms.Sequence(process.primaryVertexFilter + process.noscraping + process.noslowpt)
+     process.goodvertexSkim = cms.Sequence(process.BeamSpotChecker + process.primaryVertexFilter + process.noscraping + process.noslowpt)
 
 
 if(_theRefitter == RefitType.COMMON):

--- a/Alignment/OfflineValidation/test/test_all_Phase2_cfg.py
+++ b/Alignment/OfflineValidation/test/test_all_Phase2_cfg.py
@@ -180,10 +180,21 @@ process.noslowpt = cms.EDFilter("FilterOutLowPt",
                                 runControlNumber = cms.untracked.vuint32(int(runboundary))
                                 )
 
+####################################################################
+# BeamSpot check
+####################################################################
+from RecoVertex.BeamSpotProducer.beamSpotCompatibilityChecker_cfi import beamSpotCompatibilityChecker
+process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
+    bsFromEvent = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
+    bsFromDB = "offlineBeamSpot",           # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
+    warningThr = 3, # significance threshold to emit a warning message
+    errorThr = 5,    # significance threshold to abort the job
+)
+
 if isMC:
-     process.goodvertexSkim = cms.Sequence(process.noscraping)
+     process.goodvertexSkim = cms.Sequence(process.BeamSpotChecker + process.noscraping)
 else:
-     process.goodvertexSkim = cms.Sequence(process.primaryVertexFilter + process.noscraping + process.noslowpt)
+     process.goodvertexSkim = cms.Sequence(process.BeamSpotChecker + process.primaryVertexFilter + process.noscraping + process.noslowpt)
 
 
 if(theRefitter == RefitType.COMMON):

--- a/Alignment/OfflineValidation/test/test_all_cfg.py
+++ b/Alignment/OfflineValidation/test/test_all_cfg.py
@@ -178,10 +178,21 @@ process.noslowpt = cms.EDFilter("FilterOutLowPt",
                                 runControlNumber = cms.untracked.vuint32(int(runboundary))
                                 )
 
+####################################################################
+# BeamSpot check
+####################################################################
+from RecoVertex.BeamSpotProducer.beamSpotCompatibilityChecker_cfi import beamSpotCompatibilityChecker
+process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
+    bsFromEvent = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
+    bsFromDB = "offlineBeamSpot",           # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
+    warningThr = 3, # significance threshold to emit a warning message
+    errorThr = 5,    # significance threshold to abort the job
+)
+
 if isMC:
-     process.goodvertexSkim = cms.Sequence(process.noscraping)
+     process.goodvertexSkim = cms.Sequence(process.BeamSpotChecker + process.noscraping)
 else:
-     process.goodvertexSkim = cms.Sequence(process.primaryVertexFilter + process.noscraping + process.noslowpt)
+     process.goodvertexSkim = cms.Sequence(process.BeamSpotChecker + process.primaryVertexFilter + process.noscraping + process.noslowpt)
 
 
 if(theRefitter == RefitType.COMMON):

--- a/Alignment/OfflineValidation/test/unit_test.json
+++ b/Alignment/OfflineValidation/test/unit_test.json
@@ -11,7 +11,7 @@
         },
         "unitTestPV": {
            "color": "1",
-           "globaltag": "110X_dataRun2_v10",
+           "globaltag": "140X_dataRun3_Prompt_v4",
            "style": "2001",
            "title": "unit test"
         },
@@ -147,6 +147,8 @@
                       "alignments": ["unitTestPV"],
                       "trackcollection": "ALCARECOTkAlMinBias",
                       "vertexcollection": "offlinePrimaryVertices",
+		      "bsIncompatibleWarnThresh": "100",
+        	      "bsIncompatibleErrThresh": "1000",
                       "maxevents": "10",
                       "isda": "true",
                       "ismc": "false"
@@ -182,6 +184,8 @@
                       "IOV": ["1"],
                       "alignments": ["unitTest"],
                       "trackcollection": "generalTracks",
+		      "bsIncompatibleWarnThresh": "100",
+        	      "bsIncompatibleErrThresh": "1000",
 		      "HLTSelection": "False",
                       "triggerBits" : "HLT_*",
                       "maxevents": "10"
@@ -198,6 +202,8 @@
 		"testUnits" : {
 		    "IOV" : ["1"],
                     "alignments" : ["unitTestDiMuonVMC"],
+		    "bsIncompatibleWarnThresh": "100",
+        	    "bsIncompatibleErrThresh": "1000",
                     "trackcollection" : "generalTracks",
                     "maxevents" : "10"
 		}
@@ -244,13 +250,17 @@
                     "alignments": ["unitTestJetHT"],
                     "trackCollection": "ALCARECOTkAlMinBias",
                     "maxevents": 100,
-                    "iovListFile": "Alignment/OfflineValidation/data/lumiPerRun_Run2.txt"
+                    "iovListFile": "Alignment/OfflineValidation/data/lumiPerRun_Run2.txt",
+		    "bsIncompatibleWarnThresh": "100",
+        	    "bsIncompatibleErrThresh": "1000"
                 },
                 "testMC": {
                     "alignments": ["unitTestJetHTMC"],
                     "trackCollection": "ALCARECOTkAlMinBias",
                     "mc": "True",
-                    "maxevents": 100
+                    "maxevents": 100,
+		    "bsIncompatibleWarnThresh": "100",
+        	    "bsIncompatibleErrThresh": "1000"
                 }
             },
             "merge": {

--- a/Alignment/OfflineValidation/test/unit_test.yaml
+++ b/Alignment/OfflineValidation/test/unit_test.yaml
@@ -8,7 +8,7 @@ alignments:
         title: unit test
     unitTestPV:
         color: 1
-        globaltag: 110X_dataRun2_v10
+        globaltag: 140X_dataRun3_Prompt_v4
         style: 2001
         title: unit test
     ideal:
@@ -144,6 +144,8 @@ validations:
                 alignments:
                     - unitTestPV
                 maxevents: 10
+                bsIncompatibleWarnThresh: 100
+                bsIncompatibleErrThresh: 1000
                 trackcollection: ALCARECOTkAlMinBias
                 vertexcollection: offlinePrimaryVertices
                 isda: true
@@ -180,6 +182,8 @@ validations:
                 alignments:
                 - unitTest
                 trackcollection: generalTracks
+                bsIncompatibleWarnThresh: 100
+                bsIncompatibleErrThresh: 1000
                 HLTSelection: False
                 triggerBits: HLT_*
                 maxevents: 10
@@ -194,6 +198,8 @@ validations:
                 - 1
                 alignments:
                 - unitTestDiMuonVMC
+                bsIncompatibleWarnThresh: 100
+                bsIncompatibleErrThresh: 1000
                 trackcollection: generalTracks
                 maxevents: 10
 
@@ -209,6 +215,8 @@ validations:
                 alignments:
                 - unitTestZmumuMCreal
                 - unitTestZmumuMCdesign
+                bsIncompatibleWarnThresh: 100
+                bsIncompatibleErrThresh: 1000
                 trackcollection: ALCARECOTkAlZMuMu
                 maxevents: 100
     MTS:
@@ -247,12 +255,16 @@ validations:
                 alignments:
                 - unitTestJetHT
                 trackCollection: ALCARECOTkAlMinBias
+                bsIncompatibleWarnThresh: 100
+                bsIncompatibleErrThresh: 1000
                 maxevents: 100
                 iovListFile: Alignment/OfflineValidation/data/lumiPerRun_Run2.txt
 
             testMC:
                 alignments:
                 - unitTestJetHTMC
+                bsIncompatibleWarnThresh: 100
+                bsIncompatibleErrThresh: 1000
                 trackCollection: ALCARECOTkAlMinBias
                 mc: True
                 maxevents: 100

--- a/RecoVertex/BeamSpotProducer/plugins/BuildFile.xml
+++ b/RecoVertex/BeamSpotProducer/plugins/BuildFile.xml
@@ -8,6 +8,7 @@
 <use name="FWCore/ServiceRegistry"/>
 <use name="FWCore/Utilities"/>
 <use name="RecoVertex/BeamSpotProducer"/>
+<use name="RecoVertex/VertexTools"/>
 
 <library file="BeamSpotProducer.cc" name="BeamSpotProducer">
   <flags EDM_PLUGIN="1"/>

--- a/RecoVertex/BeamSpotProducer/test/BuildFile.xml
+++ b/RecoVertex/BeamSpotProducer/test/BuildFile.xml
@@ -19,6 +19,7 @@
 </bin>
 
 <bin file="testBeamSpotCompatibility.cc">
+  <use name="RecoVertex/VertexTools"/>
   <use name="CondFormats/BeamSpotObjects"/>
   <use name="CondFormats/DataRecord"/>
   <use name="FWCore/TestProcessor"/>

--- a/RecoVertex/BeamSpotProducer/test/testBeamSpotCompatibility.cc
+++ b/RecoVertex/BeamSpotProducer/test/testBeamSpotCompatibility.cc
@@ -12,7 +12,7 @@ TEST_CASE("Significance Calculation", "[Significance]") {
   double errA = 1.0;
   double errB = 1.5;
 
-  Significance sig(a, b, errA, errB);
+  Significance sig(a, b, errA, errB, "test");
   float significance = sig.getSig(false);
 
   // Correct the expected value based on actual calculation
@@ -47,7 +47,7 @@ TEST_CASE("BeamSpot Compatibility Checker", "[compareBS]") {
   pset.addParameter<edm::InputTag>("bsFromDB", edm::InputTag(""));
 
   BeamSpotCompatibilityChecker checker(pset);
-  auto significances = checker.compareBS(beamSpotA, beamSpotB);
+  auto significances = checker.compareBS(beamSpotA, beamSpotB, true);
 
   // Print significances
   for (size_t i = 0; i < significances.size(); ++i) {


### PR DESCRIPTION
#### PR description:

PR https://github.com/cms-sw/cmssw/pull/45589 introduced `BeamSpotCompatibilityChecker` an `edm::global::EDAnalyzer` designed to compare the Beam Spot payload in the Database with the one (potentially) available as a collection in the input data.
This is useful when e.g. refitting tracks from file and using a `GlobalTag` (too much) different from the one used for the original processing. This would allow the user to catch the configuration mistake and correct it.
As per internal discussion with the alignment conveners I add this module to *all* the the cmssw paths present in the configuration files related to the alignment offline validation package. This should allow to catch early on during the validation procedure if the configuration used for the validation is inconsistent (the users can still allow to use stale beam spot conditions via the all-in-one meta configuration language be it `yaml` or `json`).
Unit tests of the package are changed in order to allow them to pass automatic execution. This is done as the generic autoCond keys were updated with respect to the one used to create the samples used for the tests. Keeping the `autoCond` entry makes the test fail (as expected as the Beam Spot in the GlobalTag is not the one used to process the input data).
Finally commit https://github.com/cms-sw/cmssw/pull/47044/commits/8f9313e751991951e4bae3eb103bf2cefbb86480 adds the `offlineBeamSpot` collection to the `TkAlZMuMu` and `TkAlDiMuonAndVertex` data-tiers. 
This is useful in order to apply the same sort of checks also to the resonant di-muon based validations. The increase in data volume should be negligible. 

#### PR validation:

`scram b runtests` runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, could be backported if there is interest.

FYI: @henriettepetersen @TomasKello 