### PR TITLE
ECAL - Fix compilation issue with gcc13

### DIFF
--- a/CondFormats/EcalObjects/interface/EcalRecHitParameters.h
+++ b/CondFormats/EcalObjects/interface/EcalRecHitParameters.h
@@ -1,12 +1,13 @@
 #ifndef CondFormats_EcalObjects_EcalRecHitParameters_h
 #define CondFormats_EcalObjects_EcalRecHitParameters_h
 
-#include <bitset>
 #include <array>
+#include <bitset>
+#include <cstdint>
 
 constexpr size_t kNEcalChannelStatusCodes = 16;  // The HW supports 16 channel status codes
 using RecoFlagBitsArray =
-    std::array<uint32_t, kNEcalChannelStatusCodes>;  // associate recoFlagBits to all channel status codes
+    std::array<std::uint32_t, kNEcalChannelStatusCodes>;  // associate recoFlagBits to all channel status codes
 
 struct EcalRecHitParameters {
   RecoFlagBitsArray recoFlagBits;


### PR DESCRIPTION
#### PR description:

This addresses the compilation error reported in https://github.com/cms-sw/cmssw/pull/46453#issuecomment-2571310475

#### PR validation:

Compilation of the `CondFormats/EcalObjects` package works on `el9_amd64_gcc13` with CMSSW_15_0_X_2025-01-03-2300 + this PR.