### PR TITLE
[NGT] Fix double inclusion of Phase2HLTMuonSelectorForL3 module 

### DIFF
--- a/RecoMuon/L3TrackFinder/interface/Phase2HLTMuonSelectorForL3.h
+++ b/RecoMuon/L3TrackFinder/interface/Phase2HLTMuonSelectorForL3.h
@@ -30,7 +30,6 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"

--- a/RecoMuon/L3TrackFinder/plugins/SealModules.cc
+++ b/RecoMuon/L3TrackFinder/plugins/SealModules.cc
@@ -4,6 +4,8 @@
 #include "RecoMuon/L3TrackFinder/interface/MuonCkfTrajectoryBuilder.h"
 #include "RecoTracker/CkfPattern/interface/BaseCkfTrajectoryBuilderFactory.h"
 #include "RecoMuon/L3TrackFinder/interface/HLTMuonL2SelectorForL3IO.h"
+#include "RecoMuon/L3TrackFinder/interface/Phase2HLTMuonSelectorForL3.h"
 
 DEFINE_EDM_VALIDATED_PLUGIN(BaseCkfTrajectoryBuilderFactory, MuonCkfTrajectoryBuilder, "MuonCkfTrajectoryBuilder");
 DEFINE_FWK_MODULE(HLTMuonL2SelectorForL3IO);
+DEFINE_FWK_MODULE(Phase2HLTMuonSelectorForL3);

--- a/RecoMuon/L3TrackFinder/src/Phase2HLTMuonSelectorForL3.cc
+++ b/RecoMuon/L3TrackFinder/src/Phase2HLTMuonSelectorForL3.cc
@@ -202,5 +202,3 @@ const bool Phase2HLTMuonSelectorForL3::rejectL3Track(l1t::TrackerMuonRef l1TkMuR
   LogDebug(metname) << "Reject L3 Track: " << reject;
   return reject;
 }
-
-DEFINE_FWK_MODULE(Phase2HLTMuonSelectorForL3);


### PR DESCRIPTION
#### PR description:

This PR fixes the following error: 
```bash
----- Begin Fatal Exception 07-Jan-2025 11:36:39 CET-----------------------
An exception of category 'WrongPluginLoaded' occurred while
   [0] Constructing the EventProcessor
Exception Message:
The plugin 'Phase2HLTMuonSelectorForL3' should have been loaded from
 '/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02870/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-29-0000/lib/el8_amd64_gcc12/pluginRecoMuonL3MuonProducer.so'
 but instead it was already loaded from
 '/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02870/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_X_2024-12-29-0000/lib/el8_amd64_gcc12/pluginRecoMuonL3TrackFinderPlugins.so'
 because some other plugin was loaded from the latter loadables.
To work around the problem the plugin 'Phase2HLTMuonSelectorForL3' should only be defined in one of these loadables.
----- End Fatal Exception -------------------------------------------------
```
I first noticed this when developing on top of one of the latest IBs and then followed it in the past few IBs. The IB logs mostly detect it in the [arm backend](https://cmssdt.cern.ch/SDT/cgi-bin/newQA.py?arch=el8_aarch64_gcc12&release=CMSSW_15_0_X_2025-01-06-1100), but I've found the reported error when trying to run the 29850.778 workflow. Curiously, this issue is only present in the IBs: I have not been able to reproduce it starting from CMSSW_15_0_0_pre1 and just merging #46897. 

#### PR validation:

**I've tested the fix once again on 29834 and 29850 workflows with no modifiers as well as .777 and .778 in both cases.**  No such error is reported anymore.