### PR TITLE
`jetTools`: do not run `svClustering` for `pfDeepCSV{*}TagInfos`

### DIFF
--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -461,22 +461,16 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
                                     btag.pfDeepCSVTagInfos.clone(
                                         svTagInfos = cms.InputTag(btagPrefix+'pfInclusiveSecondaryVertexFinderTagInfos'+labelName+postfix)),
                                     process, task)
-                if svClustering or fatJets != cms.InputTag(''):
-                    setupSVClustering(getattr(process, btagPrefix+btagInfo+labelName+postfix), svClustering, algo, rParam, fatJets, groomedFatJets)
             if btagInfo == 'pfDeepCSVNegativeTagInfos':
                 addToProcessAndTask(btagPrefix+btagInfo+labelName+postfix,
                                     btag.pfDeepCSVNegativeTagInfos.clone(
                                         svTagInfos = cms.InputTag(btagPrefix+'pfInclusiveSecondaryVertexFinderNegativeTagInfos'+labelName+postfix)),
                                     process, task)
-                if svClustering or fatJets != cms.InputTag(''):
-                    setupSVClustering(getattr(process, btagPrefix+btagInfo+labelName+postfix), svClustering, algo, rParam, fatJets, groomedFatJets)
             if btagInfo == 'pfDeepCSVPositiveTagInfos':
                 addToProcessAndTask(btagPrefix+btagInfo+labelName+postfix,
                                     btag.pfDeepCSVPositiveTagInfos.clone(
                                         svTagInfos = cms.InputTag(btagPrefix+'pfInclusiveSecondaryVertexFinderTagInfos'+labelName+postfix)),
                                     process, task)
-                if svClustering or fatJets != cms.InputTag(''):
-                    setupSVClustering(getattr(process, btagPrefix+btagInfo+labelName+postfix), svClustering, algo, rParam, fatJets, groomedFatJets)
             if btagInfo == 'pfDeepCMVATagInfos':
                 addToProcessAndTask(btagPrefix+btagInfo+labelName+postfix,
                                     btag.pfDeepCMVATagInfos.clone(


### PR DESCRIPTION
#### PR description:

Title say it all. 
PR https://github.com/cms-sw/cmssw/pull/47045 introduced a `fillDescriptions` method for `DeepNNTagInfoProducer`.
This exposed the fact that, in the `addJetCollection` function, the `setupBTagging` function (responsible for handling b-tagging related configurations, including `fatJets` and `groomedFatJets` and other parameters) sets few parameters for  `DeepNNTagInfoProducer` which are not existing:

https://github.com/cms-sw/cmssw/blob/b5cf409295907a43444824cff362eec933950b47/PhysicsTools/PatAlgos/python/tools/jetTools.py#L231-L239

resulting in a failure of the test `runtestPhysicsToolsPatAlgos` (see for example this [log](https://cmssdt.cern.ch/SDT/jenkins-artifacts/pull-request-integration/PR-693680/43653/unitTests/src/PhysicsTools/PatAlgos/test/runtestPhysicsToolsPatAlgos/testing.log)).
This PR fixes the issue by removing the `setupSVClustering` calls where unnecessary.

#### PR validation:

`scram b runtests_runtestPhysicsToolsPatAlgos`  runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A