### PR TITLE
update `customiseHybrid` to comply with new definition of `siStripClusters`

### DIFF
--- a/RecoLocalTracker/SiStripZeroSuppression/python/customiseHybrid.py
+++ b/RecoLocalTracker/SiStripZeroSuppression/python/customiseHybrid.py
@@ -8,9 +8,15 @@ def runOnHybridZS(process):
     zsInputs = process.siStripZeroSuppression.RawDigiProducersList
     clusInputs = process.siStripClusters.DigiProducersList
     unpackedZS = cms.InputTag("siStripDigis", "ZeroSuppressed")
+
+    # Convert string elements to cms.InputTag objects if necessary
+    clusInputs = [cms.InputTag(x) if isinstance(x, str) else x for x in clusInputs]
+
     zsInputs.append(unpackedZS)
-    clusInputs.remove(unpackedZS)
-    clusInputs.append(cms.InputTag("siStripZeroSuppression","ZeroSuppressed"))
+    if unpackedZS in clusInputs:
+        clusInputs.remove(unpackedZS)
+    clusInputs.append(cms.InputTag("siStripZeroSuppression", "ZeroSuppressed"))
+
     # for on-demand clusterizer
     from FWCore.ParameterSet.MassReplace import massReplaceParameter
     massReplaceParameter(process, "HybridZeroSuppressed", cms.bool(False), cms.bool(True))


### PR DESCRIPTION
#### PR description:

PR https://github.com/cms-sw/cmssw/pull/47017 introduced a `fillDescriptions` method for `SiStripClusterizer` and refined the object `siStripClusters` as

```python
from RecoLocalTracker.SiStripClusterizer.siStripClusterizer_cfi import siStripClusterizer as _siStripClusterizer
siStripClusters = _siStripClusterizer.clone()
```

this broke several unit tests of the package `Configuration/DataProcessing`, see e.g. this [log](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc12/CMSSW_15_0_X_2025-01-07-2300/unitTestLogs/Configuration/DataProcessing#/626-626).
This PR fixes the issue by updating `customiseHybrid` to comply with new definition of `siStripClusters`

#### PR validation:

The following unit tests now run fine:

```
scram b runtests_TestConfigDP_2
scram b runtests_TestConfigDP_3
scram b runtests_TestConfigDP_5
```
#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A