### PR TITLE
Update SiPixelAliHGRcd_prod.json

### DIFF
--- a/CondFormats/Common/data/SiPixelAliHGRcd_prod.json
+++ b/CondFormats/Common/data/SiPixelAliHGRcd_prod.json
@@ -1,8 +1,8 @@
 {
     "destinationDatabase": "oracle://cms_orcon_prod/CMS_CONDITIONS", 
     "destinationTags": {
-        "SiPixelAli_PCL_v0_hlt": {}, 
-        "TrackerAlignment_PCL_byRun_v2_express": {}
+        "SiPixelAliHG_PCL_v0_hlt": {}, 
+        "TrackerAlignmentHG_PCL_byRun_v2_express": {}
     }, 
     "inputTag": "SiPixelAliHG_pcl", 
     "since": null, 


### PR DESCRIPTION
#### PR description:

PR  #39553 made on purpose the change which I am reverting here. However, the DropBoxMetadata tags in GT still consider the destinationTags with the string "HG" in it, see e.g. the destinationTags of TrackerAlignmentHGRcd in [DropBoxMetadata_v8.5_express](https://cms-conddb.cern.ch/cmsDbBrowser/payload_inspector/Prod/CMSSW_15_0_0_pre1/eyJwbG90cyI6MSwicGxvdDEiOnsidGFnIjoiRHJvcEJveE1ldGFkYXRhX3Y4LjVfZXhwcmVzcyIsInBsb3QiOiJwbG90X0Ryb3BCb3hNZXRhZGF0YV9EaXNwbGF5IiwicGx1Z2luIjoicGx1Z2luRHJvcEJveE1ldGFkYXRhX1BheWxvYWRJbnNwZWN0b3IiLCJ0eXBlIjoiSW1hZ2UiLCJpbnB1dF9wYXJhbXMiOnt9LCJpb3ZzIjp7InN0YXJ0X2lvdiI6IjM4NzM0MCIsImVuZF9pb3YiOiIzODczNDAifX19).

Not having the "HG" string written explicitly in the SiPixelAliHGRcd_prod.json in the release may produce some confusion when activating/deactivating HG PCL for the tracker Alignment (at least it happened to me when I created  [DropBoxMetadata_v8.6_express](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/tags/DropBoxMetadata_v8.6_express)

Of course, since the update I propose to revert here was originally done on purpose I may misunderstand its real usefulness. Therefore, I'd ask @tvami and @mmusich to confirm whether this update makes sense or not: if not, I will close this PR


#### PR validation:

No changes expected in any workflow.
It can only avoid errors when producing new DropBoxMetadata payloads.
