### PR TITLE
speedup SiStripClusterizer(FromRaw) using ThreeThresholdAlgorithm

### DIFF
--- a/CalibFormats/SiStripObjects/interface/SiStripClusterizerConditions.h
+++ b/CalibFormats/SiStripObjects/interface/SiStripClusterizerConditions.h
@@ -14,18 +14,21 @@ public:
 
   struct Det {
     bool valid() const { return ind != invalidI; }
-    uint16_t rawNoise(const uint16_t strip) const { return SiStripNoises::getRawNoise(strip, noiseRange); }
-    float noise(const uint16_t strip) const { return SiStripNoises::getNoise(strip, noiseRange); }
+    uint16_t rawNoise(const uint16_t strip) const { return rawNoises[strip]; }
+    float noise(const uint16_t strip) const { return 0.1f * float(rawNoises[strip]); }
     float weight(const uint16_t strip) const { return m_weight[strip / 128]; }
-    bool bad(const uint16_t strip) const { return quality->IsStripBad(qualityRange, strip); }
+    bool bad(const uint16_t strip) const { return qualityBits[strip]; }
     bool allBadBetween(uint16_t L, const uint16_t& R) const {
       while (++L < R && bad(L)) {
       };
       return L == R;
     }
+    static constexpr uint16_t kMaxStrips = 768;
     SiStripQuality const* quality;
-    SiStripNoises::Range noiseRange;
     SiStripQuality::Range qualityRange;
+    std::array<bool, kMaxStrips> qualityBits = {};
+    SiStripNoises::Range noiseRange;
+    std::array<uint16_t, kMaxStrips> rawNoises = {};
     float m_weight[6];
     uint32_t detId = 0;
     unsigned short ind = invalidI;
@@ -72,7 +75,15 @@ public:
     auto& det = m_dets.emplace_back();
     det.quality = m_quality;
     det.qualityRange = qualityRange;
+    for (uint16_t s = 0U; s < det.kMaxStrips; ++s)
+      det.qualityBits[s] = m_quality->IsStripBad(qualityRange, s);
     det.noiseRange = noiseRange;
+    auto maxRange8 = (noiseRange.second - noiseRange.first) * 8;
+    for (uint16_t s = 0U; s < det.kMaxStrips; ++s) {
+      if (9 * s >= maxRange8)
+        break;
+      det.rawNoises[s] = SiStripNoises::getRawNoise(s, noiseRange);
+    }
     for (uint32_t i = 0; i != invGains.size(); ++i) {
       det.m_weight[i] = invGains[i];
     }

--- a/RecoLocalTracker/SiStripClusterizer/interface/ThreeThresholdAlgorithm.h
+++ b/RecoLocalTracker/SiStripClusterizer/interface/ThreeThresholdAlgorithm.h
@@ -180,5 +180,4 @@ inline void ThreeThresholdAlgorithm::appendBadNeighbors(State& state) const {
   }
 }
 
-
 #endif

--- a/RecoLocalTracker/SiStripClusterizer/interface/ThreeThresholdAlgorithm.h
+++ b/RecoLocalTracker/SiStripClusterizer/interface/ThreeThresholdAlgorithm.h
@@ -1,7 +1,15 @@
 #ifndef RecoLocalTracker_SiStripClusterizer_ThreeThresholdAlgorithm_h
 #define RecoLocalTracker_SiStripClusterizer_ThreeThresholdAlgorithm_h
+
+#include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
+#include "DataFormats/SiStripCluster/interface/SiStripClusterTools.h"
+#include "DataFormats/SiStripDigi/interface/SiStripDigi.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "RecoLocalTracker/SiStripClusterizer/interface/StripClusterizerAlgorithm.h"
 #include "RecoLocalTracker/SiStripClusterizer/interface/SiStripApvShotCleaner.h"
+
+#include <cmath>
+#include <numeric>
 
 class ThreeThresholdAlgorithm final : public StripClusterizerAlgorithm {
   friend class StripClusterizerAlgorithmFactory;
@@ -16,9 +24,13 @@ public:
   void stripByStripAdd(State& state, uint16_t strip, uint8_t adc, std::vector<SiStripCluster>& out) const override;
   void stripByStripEnd(State& state, std::vector<SiStripCluster>& out) const override;
 
-  void stripByStripAdd(State& state, uint16_t strip, uint8_t adc, output_t::TSFastFiller& out) const override;
+  void stripByStripAdd(State& state, uint16_t strip, uint8_t adc, output_t::TSFastFiller& out) const override {
+    if (candidateEnded(state, strip))
+      endCandidate(state, out);
+    addToCandidate(state, strip, adc);
+  }
 
-  void stripByStripEnd(State& state, output_t::TSFastFiller& out) const override;
+  void stripByStripEnd(State& state, output_t::TSFastFiller& out) const override { endCandidate(state, out); }
 
 private:
   template <class T>
@@ -59,5 +71,114 @@ private:
   bool RemoveApvShots;
   float minGoodCharge;
 };
+
+template <class digiDetSet>
+inline void ThreeThresholdAlgorithm::clusterizeDetUnit_(const digiDetSet& digis, output_t::TSFastFiller& output) const {
+  const auto& cond = conditions();
+  if (cond.isModuleBad(digis.detId()))
+    return;
+
+  auto const& det = cond.findDetId(digis.detId());
+  if (!det.valid())
+    return;
+
+#ifdef EDM_ML_DEBUG
+  if (!cond.isModuleUsable(digis.detId()))
+    edm::LogWarning("ThreeThresholdAlgorithm") << " id " << digis.detId() << " not usable???" << std::endl;
+#endif
+
+  typename digiDetSet::const_iterator scan(digis.begin()), end(digis.end());
+
+  SiStripApvShotCleaner ApvCleaner;
+  if (RemoveApvShots) {
+    ApvCleaner.clean(digis, scan, end);
+  }
+
+  output.reserve(16);
+  State state(det);
+  while (scan != end) {
+    while (scan != end && !candidateEnded(state, scan->strip()))
+      addToCandidate(state, *scan++);
+    endCandidate(state, output);
+  }
+}
+
+inline bool ThreeThresholdAlgorithm::candidateEnded(State const& state, const uint16_t& testStrip) const {
+  uint16_t holes = testStrip - state.lastStrip - 1;
+  return (((!state.ADCs.empty()) &       // a candidate exists, and
+           (holes > MaxSequentialHoles)  // too many holes if not all are bad strips, and
+           ) &&
+          (holes > MaxSequentialBad ||                             // (too many bad strips anyway, or
+           !state.det().allBadBetween(state.lastStrip, testStrip)  // not all holes are bad strips)
+           ));
+}
+
+inline void ThreeThresholdAlgorithm::addToCandidate(State& state, uint16_t strip, uint8_t adc) const {
+  float Noise = state.det().noise(strip);
+  if (adc < static_cast<uint8_t>(Noise * ChannelThreshold) || state.det().bad(strip))
+    return;
+
+  if (state.candidateLacksSeed)
+    state.candidateLacksSeed = adc < static_cast<uint8_t>(Noise * SeedThreshold);
+  if (state.ADCs.empty())
+    state.lastStrip = strip - 1;  // begin candidate
+  while (++state.lastStrip < strip)
+    state.ADCs.push_back(0);  // pad holes
+
+  if (state.ADCs.size() <= MaxClusterSize)
+    state.ADCs.push_back(adc);
+  state.noiseSquared += Noise * Noise;
+}
+
+inline void ThreeThresholdAlgorithm::clusterizeDetUnit(const edmNew::DetSet<SiStripDigi>& digis,
+                                                       output_t::TSFastFiller& output) const {
+  clusterizeDetUnit_(digis, output);
+}
+
+template <class T>
+inline void ThreeThresholdAlgorithm::endCandidate(State& state, T& out) const {
+  if (candidateAccepted(state)) {
+    applyGains(state);
+    if (MaxAdjacentBad > 0)
+      appendBadNeighbors(state);
+    if (minGoodCharge <= 0 ||
+        siStripClusterTools::chargePerCM(state.det().detId, state.ADCs.begin(), state.ADCs.end()) > minGoodCharge)
+      out.push_back(std::move(SiStripCluster(firstStrip(state), state.ADCs.begin(), state.ADCs.end())));
+  }
+  clearCandidate(state);
+}
+
+inline bool ThreeThresholdAlgorithm::candidateAccepted(State const& state) const {
+  return (!state.candidateLacksSeed && state.ADCs.size() <= MaxClusterSize &&
+          state.noiseSquared * ClusterThresholdSquared <=
+              std::pow(float(std::accumulate(state.ADCs.begin(), state.ADCs.end(), int(0))), 2.f));
+}
+
+inline void ThreeThresholdAlgorithm::applyGains(State& state) const {
+  uint16_t strip = firstStrip(state);
+  for (auto& adc : state.ADCs) {
+#ifdef EDM_ML_DEBUG
+    // if(adc > 255) throw InvalidChargeException( SiStripDigi(strip,adc) );
+#endif
+    // if(adc > 253) continue; //saturated, do not scale
+    auto charge = int(float(adc) * state.det().weight(strip++) + 0.5f);  //adding 0.5 turns truncation into rounding
+    if (adc < 254)
+      adc = (charge > 1022 ? 255 : (charge > 253 ? 254 : charge));
+  }
+}
+
+inline void ThreeThresholdAlgorithm::appendBadNeighbors(State& state) const {
+  uint8_t max = MaxAdjacentBad;
+  while (0 < max--) {
+    if (state.det().bad(firstStrip(state) - 1)) {
+      state.ADCs.insert(state.ADCs.begin(), 0);
+    }
+    if (state.det().bad(state.lastStrip + 1)) {
+      state.ADCs.push_back(0);
+      state.lastStrip++;
+    }
+  }
+}
+
 
 #endif

--- a/RecoLocalTracker/SiStripClusterizer/interface/ThreeThresholdAlgorithm.h
+++ b/RecoLocalTracker/SiStripClusterizer/interface/ThreeThresholdAlgorithm.h
@@ -16,13 +16,9 @@ public:
   void stripByStripAdd(State& state, uint16_t strip, uint8_t adc, std::vector<SiStripCluster>& out) const override;
   void stripByStripEnd(State& state, std::vector<SiStripCluster>& out) const override;
 
-  void stripByStripAdd(State& state, uint16_t strip, uint8_t adc, output_t::TSFastFiller& out) const override {
-    if (candidateEnded(state, strip))
-      endCandidate(state, out);
-    addToCandidate(state, strip, adc);
-  }
+  void stripByStripAdd(State& state, uint16_t strip, uint8_t adc, output_t::TSFastFiller& out) const override;
 
-  void stripByStripEnd(State& state, output_t::TSFastFiller& out) const override { endCandidate(state, out); }
+  void stripByStripEnd(State& state, output_t::TSFastFiller& out) const override;
 
 private:
   template <class T>

--- a/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
@@ -89,10 +89,11 @@ namespace {
     return buffer;
   }
 
+  template <class AlgoT>
   class ClusterFiller final : public StripClusterizerAlgorithm::output_t::Getter {
   public:
     ClusterFiller(const FEDRawDataCollection& irawColl,
-                  const ThreeThresholdAlgorithm& iclusterizer,
+                  const AlgoT& iclusterizer,
                   SiStripRawProcessingAlgorithms& irawAlgos,
                   bool idoAPVEmulatorCheck,
                   bool legacy,
@@ -119,7 +120,7 @@ namespace {
 
     const FEDRawDataCollection& rawColl;
 
-    const ThreeThresholdAlgorithm& clusterizer;
+    const AlgoT& clusterizer;
     const SiStripClusterizerConditions& conditions;
     SiStripRawProcessingAlgorithms& rawAlgos;
 
@@ -181,7 +182,7 @@ public:
         legacy_(conf.getParameter<bool>("LegacyUnpacker")),
         hybridZeroSuppressed_(conf.getParameter<bool>("HybridZeroSuppressed")) {
     productToken_ = consumes<FEDRawDataCollection>(conf.getParameter<edm::InputTag>("ProductLabel"));
-    produces<edmNew::DetSetVector<SiStripCluster> >();
+    produces<edmNew::DetSetVector<SiStripCluster>>();
     assert(clusterizer_.get());
     assert(rawAlgos_.get());
   }
@@ -193,17 +194,23 @@ public:
     edm::Handle<FEDRawDataCollection> rawData;
     ev.getByToken(productToken_, rawData);
 
-    std::unique_ptr<edmNew::DetSetVector<SiStripCluster> > output(
-        onDemand ? new edmNew::DetSetVector<SiStripCluster>(
-                       std::shared_ptr<edmNew::DetSetVector<SiStripCluster>::Getter>(
-                           std::make_shared<ClusterFiller>(*rawData,
-                                                           dynamic_cast<const ThreeThresholdAlgorithm&>(*clusterizer_),
-                                                           *rawAlgos_,
-                                                           doAPVEmulatorCheck_,
-                                                           legacy_,
-                                                           hybridZeroSuppressed_)),
-                       clusterizer_->conditions().allDetIds())
-                 : new edmNew::DetSetVector<SiStripCluster>());
+    const ThreeThresholdAlgorithm* clusterizer3 = dynamic_cast<const ThreeThresholdAlgorithm*>(clusterizer_.get());
+    std::unique_ptr<edmNew::DetSetVector<SiStripCluster>> output;
+    if (onDemand) {
+      if (clusterizer3 == nullptr)
+        output = std::make_unique<edmNew::DetSetVector<SiStripCluster>>(edmNew::DetSetVector<SiStripCluster>(
+            std::shared_ptr<edmNew::DetSetVector<SiStripCluster>::Getter>(
+                std::make_shared<ClusterFiller<StripClusterizerAlgorithm>>(
+                    *rawData, *clusterizer_, *rawAlgos_, doAPVEmulatorCheck_, legacy_, hybridZeroSuppressed_)),
+            clusterizer_->conditions().allDetIds()));
+      else
+        output = std::make_unique<edmNew::DetSetVector<SiStripCluster>>(edmNew::DetSetVector<SiStripCluster>(
+            std::shared_ptr<edmNew::DetSetVector<SiStripCluster>::Getter>(
+                std::make_shared<ClusterFiller<ThreeThresholdAlgorithm>>(
+                    *rawData, *clusterizer3, *rawAlgos_, doAPVEmulatorCheck_, legacy_, hybridZeroSuppressed_)),
+            clusterizer_->conditions().allDetIds()));
+    } else
+      output = std::make_unique<edmNew::DetSetVector<SiStripCluster>>(edmNew::DetSetVector<SiStripCluster>());
 
     if (onDemand)
       assert(output->onDemand());
@@ -271,25 +278,38 @@ void SiStripClusterizerFromRaw::initialize(const edm::EventSetup& es) {
 }
 
 void SiStripClusterizerFromRaw::run(const FEDRawDataCollection& rawColl, edmNew::DetSetVector<SiStripCluster>& output) {
-  ClusterFiller filler(rawColl,
-                       dynamic_cast<const ThreeThresholdAlgorithm&>(*clusterizer_),
-                       *rawAlgos_,
-                       doAPVEmulatorCheck_,
-                       legacy_,
-                       hybridZeroSuppressed_);
+  const ThreeThresholdAlgorithm* clusterizer3 = dynamic_cast<const ThreeThresholdAlgorithm*>(clusterizer_.get());
+  if (clusterizer3 == nullptr) {
+    ClusterFiller<StripClusterizerAlgorithm> filler(
+        rawColl, *clusterizer_, *rawAlgos_, doAPVEmulatorCheck_, legacy_, hybridZeroSuppressed_);
 
-  // loop over good det in cabling
-  for (auto idet : clusterizer_->conditions().allDetIds()) {
-    StripClusterizerAlgorithm::output_t::TSFastFiller record(output, idet);
+    // loop over good det in cabling
+    for (auto idet : clusterizer_->conditions().allDetIds()) {
+      StripClusterizerAlgorithm::output_t::TSFastFiller record(output, idet);
 
-    filler.fill(record);
+      filler.fill(record);
 
-    if (record.empty())
-      record.abort();
-  }  // end loop over dets
+      if (record.empty())
+        record.abort();
+    }  // end loop over dets
+  } else {
+    ClusterFiller<ThreeThresholdAlgorithm> filler(
+        rawColl, *clusterizer3, *rawAlgos_, doAPVEmulatorCheck_, legacy_, hybridZeroSuppressed_);
+
+    // loop over good det in cabling
+    for (auto idet : clusterizer_->conditions().allDetIds()) {
+      StripClusterizerAlgorithm::output_t::TSFastFiller record(output, idet);
+
+      filler.fill(record);
+
+      if (record.empty())
+        record.abort();
+    }  // end loop over dets
+  }
 }
 
 namespace {
+  template <class AlgoT>
   class StripByStripAdder {
   public:
     typedef std::output_iterator_tag iterator_category;
@@ -298,7 +318,7 @@ namespace {
     typedef void pointer;
     typedef void reference;
 
-    StripByStripAdder(const ThreeThresholdAlgorithm& clusterizer,
+    StripByStripAdder(const AlgoT& clusterizer,
                       StripClusterizerAlgorithm::State& state,
                       StripClusterizerAlgorithm::output_t::TSFastFiller& record)
         : clusterizer_(clusterizer), state_(state), record_(record) {}
@@ -313,7 +333,7 @@ namespace {
     StripByStripAdder& operator++(int) { return *this; }
 
   private:
-    const ThreeThresholdAlgorithm& clusterizer_;
+    const AlgoT& clusterizer_;
     StripClusterizerAlgorithm::State& state_;
     StripClusterizerAlgorithm::output_t::TSFastFiller& record_;
   };
@@ -336,7 +356,8 @@ namespace {
   };
 }  // namespace
 
-void ClusterFiller::fill(StripClusterizerAlgorithm::output_t::TSFastFiller& record) const {
+template <class AlgoT>
+void ClusterFiller<AlgoT>::fill(StripClusterizerAlgorithm::output_t::TSFastFiller& record) const {
   try {  // edmNew::CapacityExaustedException
     incReady();
 
@@ -403,7 +424,7 @@ void ClusterFiller::fill(StripClusterizerAlgorithm::output_t::TSFastFiller& reco
 
       using namespace sistrip;
       if LIKELY (fedchannelunpacker::isZeroSuppressed(mode, legacy_, lmode)) {
-        auto perStripAdder = StripByStripAdder(clusterizer, state, record);
+        auto perStripAdder = StripByStripAdder<AlgoT>(clusterizer, state, record);
         const auto isNonLite = fedchannelunpacker::isNonLiteZS(mode, legacy_, lmode);
         const uint8_t pCode = (isNonLite ? buffer->packetCode(legacy_, fedCh) : 0);
         auto st_ch = fedchannelunpacker::StatusCode::SUCCESS;

--- a/RecoLocalTracker/SiStripClusterizer/src/ThreeThresholdAlgorithm.cc
+++ b/RecoLocalTracker/SiStripClusterizer/src/ThreeThresholdAlgorithm.cc
@@ -1,11 +1,4 @@
 #include "RecoLocalTracker/SiStripClusterizer/interface/ThreeThresholdAlgorithm.h"
-#include "DataFormats/SiStripDigi/interface/SiStripDigi.h"
-#include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
-#include <cmath>
-#include <numeric>
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-#include "DataFormats/SiStripCluster/interface/SiStripClusterTools.h"
 
 ThreeThresholdAlgorithm::ThreeThresholdAlgorithm(
     const edm::ESGetToken<SiStripClusterizerConditions, SiStripClusterizerConditionsRcd>& conditionsToken,
@@ -29,114 +22,7 @@ ThreeThresholdAlgorithm::ThreeThresholdAlgorithm(
       RemoveApvShots(removeApvShots),
       minGoodCharge(minGoodCharge) {}
 
-template <class digiDetSet>
-inline void ThreeThresholdAlgorithm::clusterizeDetUnit_(const digiDetSet& digis, output_t::TSFastFiller& output) const {
-  const auto& cond = conditions();
-  if (cond.isModuleBad(digis.detId()))
-    return;
-
-  auto const& det = cond.findDetId(digis.detId());
-  if (!det.valid())
-    return;
-
-#ifdef EDM_ML_DEBUG
-  if (!cond.isModuleUsable(digis.detId()))
-    edm::LogWarning("ThreeThresholdAlgorithm") << " id " << digis.detId() << " not usable???" << std::endl;
-#endif
-
-  typename digiDetSet::const_iterator scan(digis.begin()), end(digis.end());
-
-  SiStripApvShotCleaner ApvCleaner;
-  if (RemoveApvShots) {
-    ApvCleaner.clean(digis, scan, end);
-  }
-
-  output.reserve(16);
-  State state(det);
-  while (scan != end) {
-    while (scan != end && !candidateEnded(state, scan->strip()))
-      addToCandidate(state, *scan++);
-    endCandidate(state, output);
-  }
-}
-
-inline bool ThreeThresholdAlgorithm::candidateEnded(State const& state, const uint16_t& testStrip) const {
-  uint16_t holes = testStrip - state.lastStrip - 1;
-  return (((!state.ADCs.empty()) &       // a candidate exists, and
-           (holes > MaxSequentialHoles)  // too many holes if not all are bad strips, and
-           ) &&
-          (holes > MaxSequentialBad ||                             // (too many bad strips anyway, or
-           !state.det().allBadBetween(state.lastStrip, testStrip)  // not all holes are bad strips)
-           ));
-}
-
-inline void ThreeThresholdAlgorithm::addToCandidate(State& state, uint16_t strip, uint8_t adc) const {
-  float Noise = state.det().noise(strip);
-  if (adc < static_cast<uint8_t>(Noise * ChannelThreshold) || state.det().bad(strip))
-    return;
-
-  if (state.candidateLacksSeed)
-    state.candidateLacksSeed = adc < static_cast<uint8_t>(Noise * SeedThreshold);
-  if (state.ADCs.empty())
-    state.lastStrip = strip - 1;  // begin candidate
-  while (++state.lastStrip < strip)
-    state.ADCs.push_back(0);  // pad holes
-
-  if (state.ADCs.size() <= MaxClusterSize)
-    state.ADCs.push_back(adc);
-  state.noiseSquared += Noise * Noise;
-}
-
-template <class T>
-inline void ThreeThresholdAlgorithm::endCandidate(State& state, T& out) const {
-  if (candidateAccepted(state)) {
-    applyGains(state);
-    if (MaxAdjacentBad > 0)
-      appendBadNeighbors(state);
-    if (minGoodCharge <= 0 ||
-        siStripClusterTools::chargePerCM(state.det().detId, state.ADCs.begin(), state.ADCs.end()) > minGoodCharge)
-      out.push_back(std::move(SiStripCluster(firstStrip(state), state.ADCs.begin(), state.ADCs.end())));
-  }
-  clearCandidate(state);
-}
-
-inline bool ThreeThresholdAlgorithm::candidateAccepted(State const& state) const {
-  return (!state.candidateLacksSeed && state.ADCs.size() <= MaxClusterSize &&
-          state.noiseSquared * ClusterThresholdSquared <=
-              std::pow(float(std::accumulate(state.ADCs.begin(), state.ADCs.end(), int(0))), 2.f));
-}
-
-inline void ThreeThresholdAlgorithm::applyGains(State& state) const {
-  uint16_t strip = firstStrip(state);
-  for (auto& adc : state.ADCs) {
-#ifdef EDM_ML_DEBUG
-    // if(adc > 255) throw InvalidChargeException( SiStripDigi(strip,adc) );
-#endif
-    // if(adc > 253) continue; //saturated, do not scale
-    auto charge = int(float(adc) * state.det().weight(strip++) + 0.5f);  //adding 0.5 turns truncation into rounding
-    if (adc < 254)
-      adc = (charge > 1022 ? 255 : (charge > 253 ? 254 : charge));
-  }
-}
-
-inline void ThreeThresholdAlgorithm::appendBadNeighbors(State& state) const {
-  uint8_t max = MaxAdjacentBad;
-  while (0 < max--) {
-    if (state.det().bad(firstStrip(state) - 1)) {
-      state.ADCs.insert(state.ADCs.begin(), 0);
-    }
-    if (state.det().bad(state.lastStrip + 1)) {
-      state.ADCs.push_back(0);
-      state.lastStrip++;
-    }
-  }
-}
-
 void ThreeThresholdAlgorithm::clusterizeDetUnit(const edm::DetSet<SiStripDigi>& digis,
-                                                output_t::TSFastFiller& output) const {
-  clusterizeDetUnit_(digis, output);
-}
-void ThreeThresholdAlgorithm::clusterizeDetUnit(const edmNew::DetSet<SiStripDigi>& digis,
                                                 output_t::TSFastFiller& output) const {
   clusterizeDetUnit_(digis, output);
 }
@@ -150,19 +36,6 @@ void ThreeThresholdAlgorithm::stripByStripAdd(State& state,
   addToCandidate(state, SiStripDigi(strip, adc));
 }
 
-void ThreeThresholdAlgorithm::stripByStripAdd(State& state,
-                                              uint16_t strip,
-                                              uint8_t adc,
-                                              output_t::TSFastFiller& out) const {
-  if (candidateEnded(state, strip))
-    endCandidate(state, out);
-  addToCandidate(state, strip, adc);
-}
-
 void ThreeThresholdAlgorithm::stripByStripEnd(State& state, std::vector<SiStripCluster>& out) const {
-  endCandidate(state, out);
-}
-
-void ThreeThresholdAlgorithm::stripByStripEnd(State& state, output_t::TSFastFiller& out) const {
   endCandidate(state, out);
 }

--- a/RecoLocalTracker/SiStripClusterizer/src/ThreeThresholdAlgorithm.cc
+++ b/RecoLocalTracker/SiStripClusterizer/src/ThreeThresholdAlgorithm.cc
@@ -150,6 +150,19 @@ void ThreeThresholdAlgorithm::stripByStripAdd(State& state,
   addToCandidate(state, SiStripDigi(strip, adc));
 }
 
+void ThreeThresholdAlgorithm::stripByStripAdd(State& state,
+                                              uint16_t strip,
+                                              uint8_t adc,
+                                              output_t::TSFastFiller& out) const {
+  if (candidateEnded(state, strip))
+    endCandidate(state, out);
+  addToCandidate(state, strip, adc);
+}
+
 void ThreeThresholdAlgorithm::stripByStripEnd(State& state, std::vector<SiStripCluster>& out) const {
+  endCandidate(state, out);
+}
+
+void ThreeThresholdAlgorithm::stripByStripEnd(State& state, output_t::TSFastFiller& out) const {
   endCandidate(state, out);
 }


### PR DESCRIPTION
The primary goal was to speedup the full-unpacking configuration of `SiStripClusterizerFromRaw`. 

The following relatively straightforward updates are made:
- concrete `ThreeThresholdAlgorithm` is passed using templates and most methods of `ThreeThresholdAlgorithm` are inlined
- per-strip noise and quality bit values are precomputed in creation of `SiStripClusterizerConditions` (the downside here is around 32MB of memory in conditions data and the cost of precomputation equal to around 10 events of strip unpacking cost)

Overall `SiStripClusterizerFromRaw` is faster by 27% on ttbar relval Run3 MC, running with full unpacking (measured with callgrind on 300 events on the HLT config in CMSSW_14_1_4_patch5):
- inlines and templates give 14%
- conditions precomputation another 13%

No differences in physics results are expected.

In case backports are needed, the commits are made so that the backport is trivial down to 14_1_X. 


@mmasciov 

