### PR TITLE
move per-run changes of L1-uGT emulator to `beginRun` (incl. loading of AXOL1TL model)

### DIFF
--- a/L1Trigger/L1TGlobal/interface/AXOL1TLCondition.h
+++ b/L1Trigger/L1TGlobal/interface/AXOL1TLCondition.h
@@ -7,14 +7,13 @@
  * Description: evaluation of a CondAXOL1TL condition.
  */
 
-// system include files
 #include <iosfwd>
 #include <string>
 
-// user include files
-//   base classes
 #include "L1Trigger/L1TGlobal/interface/ConditionEvaluation.h"
 #include "DataFormats/L1Trigger/interface/L1Candidate.h"
+
+#include "hls4ml/emulator.h"
 
 // forward declarations
 class GlobalCondition;
@@ -64,6 +63,10 @@ namespace l1t {
 
     inline float getScore() const { return m_savedscore; }
 
+    void loadModel();
+
+    inline hls4mlEmulator::ModelLoader const& model_loader() const { return m_model_loader; }
+
   private:
     /// copy function for copy constructor and operator=
     void copy(const AXOL1TLCondition& cp);
@@ -73,6 +76,11 @@ namespace l1t {
 
     /// pointer to uGt GlobalBoard, to be able to get the trigger objects
     const GlobalBoard* m_gtGTB;
+
+    static constexpr char const* kModelNamePrefix = "GTADModel_";
+
+    hls4mlEmulator::ModelLoader m_model_loader;
+    std::shared_ptr<hls4mlEmulator::Model> m_model;
 
     ///axo score for possible score saving
     mutable float m_savedscore;

--- a/L1Trigger/L1TGlobal/interface/AlgorithmEvaluation.h
+++ b/L1Trigger/L1TGlobal/interface/AlgorithmEvaluation.h
@@ -22,6 +22,7 @@
 
 #include <iostream>
 #include <map>
+#include <memory>
 #include <queue>
 #include <stack>
 #include <string>
@@ -55,9 +56,7 @@ namespace l1t {
     // virtual ~AlgorithmEvaluation();
 
     //typedef std::map<std::string, ConditionEvaluation*> ConditionEvaluationMap;
-    typedef std::unordered_map<std::string, ConditionEvaluation*> ConditionEvaluationMap;
-    typedef ConditionEvaluationMap::const_iterator CItEvalMap;
-    typedef ConditionEvaluationMap::iterator ItEvalMap;
+    typedef std::unordered_map<std::string, std::unique_ptr<ConditionEvaluation>> ConditionEvaluationMap;
 
   public:
     /// get / set the result of the algorithm

--- a/L1Trigger/L1TGlobal/interface/ConditionEvaluation.h
+++ b/L1Trigger/L1TGlobal/interface/ConditionEvaluation.h
@@ -22,22 +22,13 @@
  *
  */
 
-// system include files
+#include <cstdint>
 #include <iostream>
-
 #include <string>
 #include <vector>
 
-// user include files
-
-//   base class
-
-//
 #include "DataFormats/L1TGlobal/interface/GlobalObjectMapFwd.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include <cstdint>
-
-// forward declarations
 
 namespace l1t {
 

--- a/L1Trigger/L1TGlobal/interface/CorrCondition.h
+++ b/L1Trigger/L1TGlobal/interface/CorrCondition.h
@@ -42,9 +42,11 @@ namespace l1t {
     CorrCondition();
 
     ///     from base template condition (from event setup usually)
-    CorrCondition(const GlobalCondition*, const GlobalCondition*, const GlobalCondition*, const GlobalBoard*
-
-    );
+    CorrCondition(const GlobalCondition*,
+                  const GlobalCondition*,
+                  const GlobalCondition*,
+                  const GlobalBoard*,
+                  const GlobalScales*);
 
     // copy constructor
     CorrCondition(const CorrCondition&);
@@ -63,16 +65,13 @@ namespace l1t {
     void print(std::ostream& myCout) const override;
 
   public:
-    ///   get / set the pointer to a Condition
     inline const CorrelationTemplate* gtCorrelationTemplate() const { return m_gtCorrelationTemplate; }
-
     void setGtCorrelationTemplate(const CorrelationTemplate*);
 
-    ///   get / set the pointer to uGt GlobalBoard
     inline const GlobalBoard* getuGtB() const { return m_uGtB; }
-
     void setuGtB(const GlobalBoard*);
 
+    inline const GlobalScales* getScales() const { return m_gtScales; }
     void setScales(const GlobalScales*);
 
     /*   //BLW Comment out for now

--- a/L1Trigger/L1TGlobal/interface/CorrThreeBodyCondition.h
+++ b/L1Trigger/L1TGlobal/interface/CorrThreeBodyCondition.h
@@ -46,9 +46,8 @@ namespace l1t {
                            const GlobalCondition*,
                            const GlobalCondition*,
                            const GlobalCondition*,
-                           const GlobalBoard*
-
-    );
+                           const GlobalBoard*,
+                           const GlobalScales*);
 
     // copy constructor
     CorrThreeBodyCondition(const CorrThreeBodyCondition&);
@@ -67,18 +66,15 @@ namespace l1t {
     void print(std::ostream& myCout) const override;
 
   public:
-    ///   get / set the pointer to a Condition
     inline const CorrelationThreeBodyTemplate* gtCorrelationThreeBodyTemplate() const {
       return m_gtCorrelationThreeBodyTemplate;
     }
-
     void setGtCorrelationThreeBodyTemplate(const CorrelationThreeBodyTemplate*);
 
-    ///   get / set the pointer to uGt GlobalBoard
     inline const GlobalBoard* getuGtB() const { return m_uGtB; }
-
     void setuGtB(const GlobalBoard*);
 
+    inline const GlobalScales* getScales() const { return m_gtScales; }
     void setScales(const GlobalScales*);
 
   private:

--- a/L1Trigger/L1TGlobal/interface/CorrWithOverlapRemovalCondition.h
+++ b/L1Trigger/L1TGlobal/interface/CorrWithOverlapRemovalCondition.h
@@ -47,9 +47,8 @@ namespace l1t {
                                     const GlobalCondition*,
                                     const GlobalCondition*,
                                     const GlobalCondition*,
-                                    const GlobalBoard*
-
-    );
+                                    const GlobalBoard*,
+                                    const GlobalScales*);
 
     // copy constructor
     CorrWithOverlapRemovalCondition(const CorrWithOverlapRemovalCondition&);
@@ -68,18 +67,16 @@ namespace l1t {
     void print(std::ostream& myCout) const override;
 
   public:
-    ///   get / set the pointer to a Condition
     inline const CorrelationWithOverlapRemovalTemplate* gtCorrelationWithOverlapRemovalTemplate() const {
       return m_gtCorrelationWithOverlapRemovalTemplate;
     }
 
     void setGtCorrelationWithOverlapRemovalTemplate(const CorrelationWithOverlapRemovalTemplate*);
 
-    ///   get / set the pointer to uGt GlobalBoard
     inline const GlobalBoard* getuGtB() const { return m_uGtB; }
-
     void setuGtB(const GlobalBoard*);
 
+    inline const GlobalScales* getScales() const { return m_gtScales; }
     void setScales(const GlobalScales*);
 
     /*   //BLW Comment out for now

--- a/L1Trigger/L1TGlobal/interface/GlobalBoard.h
+++ b/L1Trigger/L1TGlobal/interface/GlobalBoard.h
@@ -1,14 +1,11 @@
-#ifndef GtBoard_h
-#define GtBoard_h
+#ifndef L1Trigger_L1TGlobal_GlobalBoard_h
+#define L1Trigger_L1TGlobal_GlobalBoard_h
 
 /**
  * \class GlobalBoard
  *
  *
  * Description: Global Trigger Logic board.
- *
- * Implementation:
- *    <TODO: enter implementation details>
  *
  */
 
@@ -18,6 +15,7 @@
 #include <vector>
 #include <cmath>
 #include <memory>
+#include <string>
 
 // user include files
 #include "FWCore/Utilities/interface/typedefs.h"
@@ -46,11 +44,6 @@
 
 // forward declarations
 class TriggerMenu;
-class L1CaloGeometry;
-class L1MuTriggerScales;
-//class L1GtEtaPhiConversions;
-
-// class declaration
 
 namespace l1t {
 
@@ -107,19 +100,23 @@ namespace l1t {
               int bxFirst,
               int bxLast);
 
-    /// run the uGT GTL (Conditions and Algorithms)
+    /// initialise Trigger Conditions
+    void initTriggerConditions(const edm::EventSetup& evSetup,
+                               const TriggerMenu* m_l1GtMenu,
+                               const int nrL1Mu,
+                               const int nrL1MuShower,
+                               const int nrL1EG,
+                               const int nrL1Tau,
+                               const int nrL1Jet);
+
+    /// run the uGT GTL (Algorithms, per-event decisions)
     void runGTL(const edm::Event& iEvent,
                 const edm::EventSetup& evSetup,
                 const TriggerMenu* m_l1GtMenu,
                 const bool produceL1GtObjectMapRecord,
                 const int iBxInEvent,
                 std::unique_ptr<GlobalObjectMapRecord>& gtObjectMapRecord,  //GTO
-                const unsigned int numberPhysTriggers,
-                const int nrL1Mu,
-                const int nrL1MuShower,
-                const int nrL1EG,
-                const int nrL1Tau,
-                const int nrL1Jet);
+                const unsigned int numberPhysTriggers);
 
     /// run the uGT FDL (Apply Prescales and Veto)
     void runFDL(const edm::Event& iEvent,
@@ -221,23 +218,6 @@ namespace l1t {
     inline void enableAXOScoreSaving(bool savescore) { m_saveAXOScore = savescore; }
 
   private:
-    // cached stuff
-
-    // trigger menu
-    const TriggerMenu* m_l1GtMenu;
-    unsigned long long m_l1GtMenuCacheID;
-
-    // L1 scales (phi, eta) for Mu, Calo and EnergySum objects
-    const L1CaloGeometry* m_l1CaloGeometry;
-    unsigned long long m_l1CaloGeometryCacheID;
-
-    const L1MuTriggerScales* m_l1MuTriggerScales;
-    unsigned long long m_l1MuTriggerScalesCacheID;
-
-    // conversions for eta and phi
-    //    L1GtEtaPhiConversions* m_gtEtaPhiConversions;
-
-  private:
     BXVector<const l1t::Muon*>* m_candL1Mu;
     BXVector<std::shared_ptr<l1t::MuonShower>>* m_candL1MuShower;
     BXVector<const l1t::L1Candidate*>* m_candL1EG;
@@ -264,8 +244,9 @@ namespace l1t {
 
     //for optional software-only saving of axol1tl score
     AXOL1TLScore m_uGtAXOScore;       //score dataformat
-    float m_storedAXOScore = -999.0;  //score from cond class
+    float m_storedAXOScore = -999.f;  //score from cond class
     bool m_saveAXOScore = false;
+    std::string m_axoScoreConditionName;
 
     // cache of maps
     std::vector<AlgorithmEvaluation::ConditionEvaluationMap> m_conditionResultMaps;
@@ -283,13 +264,6 @@ namespace l1t {
     bool m_algPrescaledOr;
     bool m_algFinalOr;
     bool m_algFinalOrVeto;
-
-    // Counter for number of events seen by this board
-    unsigned int m_boardEventCount;
-
-    // Information about board
-    int m_uGtBoardNumber;
-    bool m_uGtFinalBoard;
 
     // whether we reset the prescales each lumi or not
     bool m_resetPSCountersEachLumiSec = false;

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
@@ -139,23 +139,25 @@ L1TGlobalProducer::L1TGlobalProducer(const edm::ParameterSet& parSet)
       m_semiRandomInitialPSCounters(parSet.getParameter<bool>("semiRandomInitialPSCounters")),
       m_useMuonShowers(parSet.getParameter<bool>("useMuonShowers")),
       m_produceAXOL1TLScore(parSet.getParameter<bool>("produceAXOL1TLScore")) {
-  m_egInputToken = consumes<BXVector<EGamma>>(m_egInputTag);
-  m_tauInputToken = consumes<BXVector<Tau>>(m_tauInputTag);
-  m_jetInputToken = consumes<BXVector<Jet>>(m_jetInputTag);
-  m_sumInputToken = consumes<BXVector<EtSum>>(m_sumInputTag);
-  m_sumZdcInputToken = consumes<BXVector<EtSum>>(m_sumZdcInputTag);
-  m_CICADAInputToken = consumes<BXVector<float>>(m_CICADAInputTag);
-  m_muInputToken = consumes<BXVector<Muon>>(m_muInputTag);
+  m_egInputToken = consumes(m_egInputTag);
+  m_tauInputToken = consumes(m_tauInputTag);
+  m_jetInputToken = consumes(m_jetInputTag);
+  m_sumInputToken = consumes(m_sumInputTag);
+  m_sumZdcInputToken = consumes(m_sumZdcInputTag);
+  m_CICADAInputToken = consumes(m_CICADAInputTag);
+  m_muInputToken = consumes(m_muInputTag);
   if (m_useMuonShowers)
-    m_muShowerInputToken = consumes<BXVector<MuonShower>>(m_muShowerInputTag);
-  m_extInputToken = consumes<BXVector<GlobalExtBlk>>(m_extInputTag);
-  m_l1GtStableParToken = esConsumes<L1TGlobalParameters, L1TGlobalParametersRcd>();
-  m_l1GtMenuToken = esConsumes<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd>();
+    m_muShowerInputToken = consumes(m_muShowerInputTag);
+  m_extInputToken = consumes(m_extInputTag);
+  m_l1GtStableParToken = esConsumes<edm::Transition::BeginRun>();
+  m_l1GtMenuToken = esConsumes<edm::Transition::BeginRun>();
+
   if (!(m_algorithmTriggersUnprescaled && m_algorithmTriggersUnmasked)) {
-    m_l1GtPrescaleVetosToken = esConsumes<L1TGlobalPrescalesVetosFract, L1TGlobalPrescalesVetosFractRcd>();
+    m_l1GtPrescaleVetosToken = esConsumes();
   }
+
   if (m_getPrescaleColumnFromData || m_requireMenuToMatchAlgoBlkInput) {
-    m_algoblkInputToken = consumes<BXVector<GlobalAlgBlk>>(m_algoblkInputTag);
+    m_algoblkInputToken = consumes(m_algoblkInputTag);
   }
 
   if (m_verbosity) {
@@ -227,11 +229,7 @@ L1TGlobalProducer::L1TGlobalProducer(const edm::ParameterSet& parSet)
   m_uGtBrd->setResetPSCountersEachLumiSec(m_resetPSCountersEachLumiSec);
   m_uGtBrd->setSemiRandomInitialPSCounters(m_semiRandomInitialPSCounters);
 
-  // initialize cached IDs
-
-  //
-  m_l1GtParCacheID = 0ULL;
-  m_l1GtMenuCacheID = 0ULL;
+  m_utml1GtMenu = nullptr;
 
   m_numberPhysTriggers = 0;
   m_numberDaqPartitions = 0;
@@ -246,9 +244,6 @@ L1TGlobalProducer::L1TGlobalProducer(const edm::ParameterSet& parSet)
   m_ifMuEtaNumberBits = 0;
   m_ifCaloEtaNumberBits = 0;
 
-  //
-  m_l1GtParCacheID = 0ULL;
-
   m_totalBxInEvent = 0;
 
   m_activeBoardsGtDaq = 0;
@@ -256,15 +251,9 @@ L1TGlobalProducer::L1TGlobalProducer(const edm::ParameterSet& parSet)
 
   //
   m_l1GtBMCacheID = 0ULL;
-
-  //
   m_l1GtPfAlgoCacheID = 0ULL;
-
   m_l1GtTmAlgoCacheID = 0ULL;
-
   m_l1GtTmVetoAlgoCacheID = 0ULL;
-
-  m_currentLumi = 0;
 
   //
   std::vector<l1t::Muon> muonVec_bxm2;
@@ -277,66 +266,52 @@ L1TGlobalProducer::L1TGlobalProducer(const edm::ParameterSet& parSet)
   m_initialPrescaleFactorsAlgoTrig = temp_prescaleTable;
 }
 
-// destructor
-L1TGlobalProducer::~L1TGlobalProducer() {}
-
-// member functions
-
-// method called to produce the data
-void L1TGlobalProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSetup) {
-  // process event iEvent
+// method called once at the beginning of every Run
+void L1TGlobalProducer::beginRun(edm::Run const& iRun, const edm::EventSetup& evSetup) {
   // get / update the stable parameters from the EventSetup
-  // local cache & check on cacheIdentifier
 
-  unsigned long long l1GtParCacheID = evSetup.get<L1TGlobalParametersRcd>().cacheIdentifier();
+  auto const& l1GtStablePar = evSetup.getData(m_l1GtStableParToken);
+  const GlobalParamsHelper* data = GlobalParamsHelper::readFromEventSetup(&l1GtStablePar);
 
-  if (m_l1GtParCacheID != l1GtParCacheID) {
-    edm::ESHandle<L1TGlobalParameters> l1GtStablePar = evSetup.getHandle(m_l1GtStableParToken);
-    m_l1GtStablePar = l1GtStablePar.product();
-    const GlobalParamsHelper* data = GlobalParamsHelper::readFromEventSetup(m_l1GtStablePar);
+  // number of bx
+  m_totalBxInEvent = data->totalBxInEvent();
 
-    // number of bx
-    m_totalBxInEvent = data->totalBxInEvent();
+  // number of physics triggers
+  m_numberPhysTriggers = data->numberPhysTriggers();
 
-    // number of physics triggers
-    m_numberPhysTriggers = data->numberPhysTriggers();
+  // number of objects of each type
+  m_nrL1Mu = data->numberL1Mu();
 
-    // number of objects of each type
-    m_nrL1Mu = data->numberL1Mu();
+  // There should be at most 1 muon shower object per BX
+  // This object contains information for the in-time
+  // showers and out-of-time showers
+  if (m_useMuonShowers)
+    m_nrL1MuShower = 1;
 
-    // There should be at most 1 muon shower object per BX
-    // This object contains information for the in-time
-    // showers and out-of-time showers
-    if (m_useMuonShowers)
-      m_nrL1MuShower = 1;
+  // EG
+  m_nrL1EG = data->numberL1EG();
 
-    // EG
-    m_nrL1EG = data->numberL1EG();
+  // jets
+  m_nrL1Jet = data->numberL1Jet();
 
-    // jets
-    m_nrL1Jet = data->numberL1Jet();
+  // taus
+  m_nrL1Tau = data->numberL1Tau();
 
-    // taus
-    m_nrL1Tau = data->numberL1Tau();
+  if (m_L1DataBxInEvent < 1)
+    m_L1DataBxInEvent = 1;
 
-    if (m_L1DataBxInEvent < 1)
-      m_L1DataBxInEvent = 1;
-    int minL1DataBxInEvent = (m_L1DataBxInEvent + 1) / 2 - m_L1DataBxInEvent;
-    int maxL1DataBxInEvent = (m_L1DataBxInEvent + 1) / 2 - 1;
+  int const minL1DataBxInEvent = (m_L1DataBxInEvent + 1) / 2 - m_L1DataBxInEvent;
+  int const maxL1DataBxInEvent = (m_L1DataBxInEvent + 1) / 2 - 1;
 
-    // Initialize Board
-    m_uGtBrd->init(m_numberPhysTriggers,
-                   m_nrL1Mu,
-                   m_nrL1MuShower,
-                   m_nrL1EG,
-                   m_nrL1Tau,
-                   m_nrL1Jet,
-                   minL1DataBxInEvent,
-                   maxL1DataBxInEvent);
-
-    //
-    m_l1GtParCacheID = l1GtParCacheID;
-  }
+  // Initialize Board
+  m_uGtBrd->init(m_numberPhysTriggers,
+                 m_nrL1Mu,
+                 m_nrL1MuShower,
+                 m_nrL1EG,
+                 m_nrL1Tau,
+                 m_nrL1Jet,
+                 minL1DataBxInEvent,
+                 maxL1DataBxInEvent);
 
   if (m_emulateBxInEvent < 0) {
     m_emulateBxInEvent = m_totalBxInEvent;
@@ -344,80 +319,52 @@ void L1TGlobalProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSet
 
   if (m_emulateBxInEvent < 1)
     m_emulateBxInEvent = 1;
-  int minEmulBxInEvent = (m_emulateBxInEvent + 1) / 2 - m_emulateBxInEvent;
-  int maxEmulBxInEvent = (m_emulateBxInEvent + 1) / 2 - 1;
 
   // get / update the trigger menu from the EventSetup
-  // local cache & check on cacheIdentifier
-  unsigned long long l1GtMenuCacheID = evSetup.get<L1TUtmTriggerMenuRcd>().cacheIdentifier();
 
-  if (m_l1GtMenuCacheID != l1GtMenuCacheID) {
-    const GlobalParamsHelper* data = GlobalParamsHelper::readFromEventSetup(m_l1GtStablePar);
+  // Instantiate Parser
+  TriggerMenuParser gtParser = TriggerMenuParser();
+  gtParser.setGtNumberConditionChips(data->numberChips());
+  gtParser.setGtPinsOnConditionChip(data->pinsOnChip());
+  gtParser.setGtOrderConditionChip(data->orderOfChip());
+  gtParser.setGtNumberPhysTriggers(data->numberPhysTriggers());
 
-    edm::ESHandle<L1TUtmTriggerMenu> l1GtMenu = evSetup.getHandle(m_l1GtMenuToken);
-    const L1TUtmTriggerMenu* utml1GtMenu = l1GtMenu.product();
+  // parse menu into emulator classes
+  m_utml1GtMenu = &(evSetup.getData(m_l1GtMenuToken));
+  gtParser.parseCondFormats(m_utml1GtMenu);
 
-    if (m_requireMenuToMatchAlgoBlkInput) {
-      edm::Handle<BXVector<GlobalAlgBlk>> m_uGtAlgBlk;
-      iEvent.getByToken(m_algoblkInputToken, m_uGtAlgBlk);
-      if (m_uGtAlgBlk->size() >= 1) {
-        if ((*m_uGtAlgBlk)[0].getL1FirmwareUUID() != static_cast<int>(utml1GtMenu->getFirmwareUuidHashed())) {
-          throw cms::Exception("ConditionsError")
-              << " Error L1 menu loaded in via conditions does not match the L1 actually run "
-              << (*m_uGtAlgBlk)[0].getL1FirmwareUUID() << " vs " << utml1GtMenu->getFirmwareUuidHashed()
-              << ". This means that the mapping of the names to the bits may be incorrect. Please check the "
-                 "L1TUtmTriggerMenuRcd record supplied. Unless you know what you are doing, do not simply disable this "
-                 "check via the config as this a major error and the indication of something very wrong";
-        }
-      }
-    }
+  // transfer the condition map and algorithm map from parser to L1uGtTriggerMenu
+  m_l1GtMenu = std::make_unique<TriggerMenu>(gtParser.gtTriggerMenuName(),
+                                             data->numberChips(),
+                                             gtParser.vecMuonTemplate(),
+                                             gtParser.vecMuonShowerTemplate(),
+                                             gtParser.vecCaloTemplate(),
+                                             gtParser.vecEnergySumTemplate(),
+                                             gtParser.vecEnergySumZdcTemplate(),
+                                             gtParser.vecAXOL1TLTemplate(),
+                                             gtParser.vecCICADATemplate(),
+                                             gtParser.vecExternalTemplate(),
+                                             gtParser.vecCorrelationTemplate(),
+                                             gtParser.vecCorrelationThreeBodyTemplate(),
+                                             gtParser.vecCorrelationWithOverlapRemovalTemplate(),
+                                             gtParser.corMuonTemplate(),
+                                             gtParser.corCaloTemplate(),
+                                             gtParser.corEnergySumTemplate());
 
-    // Instantiate Parser
-    TriggerMenuParser gtParser = TriggerMenuParser();
+  m_l1GtMenu->setGtTriggerMenuInterface(gtParser.gtTriggerMenuInterface());
+  m_l1GtMenu->setGtTriggerMenuImplementation(gtParser.gtTriggerMenuImplementation());
+  m_l1GtMenu->setGtScaleDbKey(gtParser.gtScaleDbKey());
+  m_l1GtMenu->setGtScales(gtParser.gtScales());
+  m_l1GtMenu->setGtTriggerMenuUUID(gtParser.gtTriggerMenuUUID());
 
-    gtParser.setGtNumberConditionChips(data->numberChips());
-    gtParser.setGtPinsOnConditionChip(data->pinsOnChip());
-    gtParser.setGtOrderConditionChip(data->orderOfChip());
-    gtParser.setGtNumberPhysTriggers(data->numberPhysTriggers());
+  m_l1GtMenu->setGtAlgorithmMap(gtParser.gtAlgorithmMap());
+  m_l1GtMenu->setGtAlgorithmAliasMap(gtParser.gtAlgorithmAliasMap());
 
-    //Parse menu into emulator classes
-    gtParser.parseCondFormats(utml1GtMenu);
+  m_l1GtMenu->buildGtConditionMap();
 
-    // transfer the condition map and algorithm map from parser to L1uGtTriggerMenu
-    m_l1GtMenu = std::make_unique<TriggerMenu>(gtParser.gtTriggerMenuName(),
-                                               data->numberChips(),
-                                               gtParser.vecMuonTemplate(),
-                                               gtParser.vecMuonShowerTemplate(),
-                                               gtParser.vecCaloTemplate(),
-                                               gtParser.vecEnergySumTemplate(),
-                                               gtParser.vecEnergySumZdcTemplate(),
-                                               gtParser.vecAXOL1TLTemplate(),
-                                               gtParser.vecCICADATemplate(),
-                                               gtParser.vecExternalTemplate(),
-                                               gtParser.vecCorrelationTemplate(),
-                                               gtParser.vecCorrelationThreeBodyTemplate(),
-                                               gtParser.vecCorrelationWithOverlapRemovalTemplate(),
-                                               gtParser.corMuonTemplate(),
-                                               gtParser.corCaloTemplate(),
-                                               gtParser.corEnergySumTemplate());
-
-    m_l1GtMenu->setGtTriggerMenuInterface(gtParser.gtTriggerMenuInterface());
-    m_l1GtMenu->setGtTriggerMenuImplementation(gtParser.gtTriggerMenuImplementation());
-    m_l1GtMenu->setGtScaleDbKey(gtParser.gtScaleDbKey());
-    m_l1GtMenu->setGtScales(gtParser.gtScales());
-    m_l1GtMenu->setGtTriggerMenuUUID(gtParser.gtTriggerMenuUUID());
-
-    m_l1GtMenu->setGtAlgorithmMap(gtParser.gtAlgorithmMap());
-    m_l1GtMenu->setGtAlgorithmAliasMap(gtParser.gtAlgorithmAliasMap());
-
-    m_l1GtMenu->buildGtConditionMap();
-
-    int printV = 2;
-    if (m_printL1Menu)
-      m_l1GtMenu->print(std::cout, printV);
-
-    m_l1GtMenuCacheID = l1GtMenuCacheID;
-  }
+  int printV = 2;
+  if (m_printL1Menu)
+    m_l1GtMenu->print(std::cout, printV);
 
   // get / update the board maps from the EventSetup
   // local cache & check on cacheIdentifier
@@ -443,48 +390,6 @@ void L1TGlobalProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSet
     // TODO need changes in CondFormats to cache the maps
     const std::vector<L1GtBoard>& boardMaps = m_l1GtBM->gtBoardMaps();
 */
-  // get / update the prescale factors from the EventSetup
-  // local cache & check on cacheIdentifier
-
-  // Only get event record if not unprescaled and not unmasked
-  if (!(m_algorithmTriggersUnprescaled && m_algorithmTriggersUnmasked)) {
-    unsigned long long l1GtPfAlgoCacheID = evSetup.get<L1TGlobalPrescalesVetosFractRcd>().cacheIdentifier();
-
-    if (m_l1GtPfAlgoCacheID != l1GtPfAlgoCacheID) {
-      edm::ESHandle<L1TGlobalPrescalesVetosFract> l1GtPrescalesFractVetoes =
-          evSetup.getHandle(m_l1GtPrescaleVetosToken);
-      const L1TGlobalPrescalesVetosFract* es = l1GtPrescalesFractVetoes.product();
-      m_l1GtPrescalesVetosFract = PrescalesVetosFractHelper::readFromEventSetup(es);
-
-      m_prescaleFactorsAlgoTrig = &(m_l1GtPrescalesVetosFract->prescaleTable());
-      m_triggerMaskVetoAlgoTrig = &(m_l1GtPrescalesVetosFract->triggerMaskVeto());
-
-      m_l1GtPfAlgoCacheID = l1GtPfAlgoCacheID;
-    }
-    if (m_getPrescaleColumnFromData &&
-        (m_currentLumi != iEvent.luminosityBlock())) {  // get prescale column from unpacked data
-
-      m_currentLumi = iEvent.luminosityBlock();
-
-      edm::Handle<BXVector<GlobalAlgBlk>> m_uGtAlgBlk;
-      iEvent.getByToken(m_algoblkInputToken, m_uGtAlgBlk);
-
-      if (m_uGtAlgBlk.isValid() && !m_uGtAlgBlk->isEmpty(0)) {
-        std::vector<GlobalAlgBlk>::const_iterator algBlk = m_uGtAlgBlk->begin(0);
-        m_prescaleSet = static_cast<unsigned int>(algBlk->getPreScColumn());
-      } else {
-        m_prescaleSet = 1;
-        edm::LogError("L1TGlobalProduce")
-            << "Could not find valid algo block. Setting prescale column to 1" << std::endl;
-      }
-    }
-  } else {
-    // Set Prescale factors to initial dummy values
-    m_prescaleSet = 0;
-    m_prescaleFactorsAlgoTrig = &m_initialPrescaleFactorsAlgoTrig;
-    m_triggerMaskAlgoTrig = &m_initialTriggerMaskAlgoTrig;
-    m_triggerMaskVetoAlgoTrig = &m_initialTriggerMaskVetoAlgoTrig;
-  }
 
   // get / update the trigger mask from the EventSetup
   // local cache & check on cacheIdentifier
@@ -522,6 +427,54 @@ void L1TGlobalProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSet
 
     }
 */
+
+  // initialise Trigger Conditions
+  m_uGtBrd->initTriggerConditions(evSetup, m_l1GtMenu.get(), m_nrL1Mu, m_nrL1MuShower, m_nrL1EG, m_nrL1Tau, m_nrL1Jet);
+}
+
+// method called to produce the data
+void L1TGlobalProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSetup) {
+  if (m_requireMenuToMatchAlgoBlkInput) {
+    auto const& uGtAlgBlk = iEvent.get(m_algoblkInputToken);
+    if (uGtAlgBlk.size() >= 1) {
+      if (uGtAlgBlk[0].getL1FirmwareUUID() != static_cast<int>(m_utml1GtMenu->getFirmwareUuidHashed())) {
+        throw cms::Exception("ConditionsError")
+            << " Error L1 menu loaded in via conditions does not match the L1 actually run "
+            << uGtAlgBlk[0].getL1FirmwareUUID() << " vs " << m_utml1GtMenu->getFirmwareUuidHashed()
+            << ". This means that the mapping of the names to the bits may be incorrect. Please check the "
+               "L1TUtmTriggerMenuRcd record supplied. Unless you know what you are doing, do not simply disable this "
+               "check via the config as this a major error and the indication of something very wrong";
+      }
+    }
+  }
+
+  // get / update the prescale factors from the EventSetup
+
+  // Only get event record if not unprescaled and not unmasked
+  if (not(m_algorithmTriggersUnprescaled and m_algorithmTriggersUnmasked)) {
+    auto const& l1GtPrescalesFractVetoes = evSetup.getData(m_l1GtPrescaleVetosToken);
+    m_l1GtPrescalesVetosFract = PrescalesVetosFractHelper::readFromEventSetup(&l1GtPrescalesFractVetoes);
+
+    m_prescaleFactorsAlgoTrig = &(m_l1GtPrescalesVetosFract->prescaleTable());
+    m_triggerMaskVetoAlgoTrig = &(m_l1GtPrescalesVetosFract->triggerMaskVeto());
+
+    // get prescale column from unpacked data
+    if (m_getPrescaleColumnFromData) {
+      auto const uGtAlgBlk = iEvent.getHandle(m_algoblkInputToken);
+      if (uGtAlgBlk.isValid() && !uGtAlgBlk->isEmpty(0)) {
+        m_prescaleSet = static_cast<unsigned int>(uGtAlgBlk->at(0, 0).getPreScColumn());
+      } else {
+        m_prescaleSet = 1;
+        edm::LogError("L1TGlobalProduce") << "Could not find valid algo block. Setting prescale column to 1";
+      }
+    }
+  } else {
+    // Set Prescale factors to initial dummy values
+    m_prescaleSet = 0;
+    m_prescaleFactorsAlgoTrig = &m_initialPrescaleFactorsAlgoTrig;
+    m_triggerMaskAlgoTrig = &m_initialTriggerMaskAlgoTrig;
+    m_triggerMaskVetoAlgoTrig = &m_initialTriggerMaskVetoAlgoTrig;
+  }
 
   // ******  Board Maps Need to be redone....hard code for now ******
   // loop over blocks in the GT DAQ record receiving data, count them if they are active
@@ -567,6 +520,9 @@ void L1TGlobalProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSet
 
     }
 */
+
+  int const minEmulBxInEvent = (m_emulateBxInEvent + 1) / 2 - m_emulateBxInEvent;
+  int const maxEmulBxInEvent = (m_emulateBxInEvent + 1) / 2 - 1;
 
   // Produce the Output Records for the GT
   std::unique_ptr<GlobalAlgBlkBxCollection> uGtAlgRecord(
@@ -667,12 +623,7 @@ void L1TGlobalProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSet
                      m_produceL1GtObjectMapRecord,
                      iBxInEvent,
                      gtObjectMapRecord,
-                     m_numberPhysTriggers,
-                     m_nrL1Mu,
-                     m_nrL1MuShower,
-                     m_nrL1EG,
-                     m_nrL1Tau,
-                     m_nrL1Jet);
+                     m_numberPhysTriggers);
 
     //  run FDL
     LogDebug("L1TGlobalProducer") << "\nL1TGlobalProducer : running FDL for bx = " << iBxInEvent << "\n" << std::endl;

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.h
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.h
@@ -43,22 +43,18 @@ class TriggerMenu;
 class L1TGlobalProducer : public edm::stream::EDProducer<> {
 public:
   explicit L1TGlobalProducer(const edm::ParameterSet&);
-  ~L1TGlobalProducer() override;
+  ~L1TGlobalProducer() override = default;
 
-  void produce(edm::Event&, const edm::EventSetup&) override;
+  void beginRun(edm::Run const& iRun, const edm::EventSetup& iEventSetup) override;
+
+  void produce(edm::Event& iEvent, const edm::EventSetup& iEventSetup) override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  /// cached stuff
-
-  /// stable parameters
-  const L1TGlobalParameters* m_l1GtStablePar;
-  unsigned long long m_l1GtParCacheID;
-
   // trigger menu
   std::unique_ptr<TriggerMenu> m_l1GtMenu;
-  unsigned long long m_l1GtMenuCacheID;
+  L1TUtmTriggerMenu const* m_utml1GtMenu;
 
   // number of physics triggers
   unsigned int m_numberPhysTriggers;
@@ -97,8 +93,6 @@ private:
 
   const std::vector<std::vector<double>>* m_prescaleFactorsAlgoTrig;
   std::vector<std::vector<double>> m_initialPrescaleFactorsAlgoTrig;
-
-  uint m_currentLumi;
 
   /// trigger masks & veto masks
   const L1GtTriggerMask* m_l1GtTmAlgo;
@@ -184,7 +178,7 @@ private:
   bool m_getPrescaleColumnFromData;
   bool m_requireMenuToMatchAlgoBlkInput;
   edm::InputTag m_algoblkInputTag;
-  edm::EDGetToken m_algoblkInputToken;
+  edm::EDGetTokenT<BXVector<GlobalAlgBlk>> m_algoblkInputToken;
 
   edm::ESGetToken<L1TGlobalParameters, L1TGlobalParametersRcd> m_l1GtStableParToken;
   edm::ESGetToken<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd> m_l1GtMenuToken;

--- a/L1Trigger/L1TGlobal/src/AXOL1TLCondition.cc
+++ b/L1Trigger/L1TGlobal/src/AXOL1TLCondition.cc
@@ -19,7 +19,6 @@
 #include <vector>
 #include <algorithm>
 #include "ap_fixed.h"
-#include "hls4ml/emulator.h"
 
 // user include files
 //   base classes
@@ -42,17 +41,16 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/MessageLogger/interface/MessageDrop.h"
 
-// constructors
-//     default
-l1t::AXOL1TLCondition::AXOL1TLCondition() : ConditionEvaluation() {
-  // empty
-}
+l1t::AXOL1TLCondition::AXOL1TLCondition()
+    : ConditionEvaluation(), m_gtAXOL1TLTemplate{nullptr}, m_gtGTB{nullptr}, m_model{nullptr} {}
 
-//     from base template condition (from event setup usually)
 l1t::AXOL1TLCondition::AXOL1TLCondition(const GlobalCondition* axol1tlTemplate, const GlobalBoard* ptrGTB)
     : ConditionEvaluation(),
       m_gtAXOL1TLTemplate(static_cast<const AXOL1TLTemplate*>(axol1tlTemplate)),
-      m_gtGTB(ptrGTB) {}
+      m_gtGTB(ptrGTB),
+      m_model_loader{kModelNamePrefix + m_gtAXOL1TLTemplate->modelVersion()} {
+  loadModel();
+}
 
 // copy constructor
 void l1t::AXOL1TLCondition::copy(const l1t::AXOL1TLCondition& cp) {
@@ -64,6 +62,9 @@ void l1t::AXOL1TLCondition::copy(const l1t::AXOL1TLCondition& cp) {
   m_combinationsInCond = cp.getCombinationsInCond();
 
   m_verbosity = cp.m_verbosity;
+
+  m_model_loader.reset(cp.model_loader().model_name());
+  loadModel();
 }
 
 l1t::AXOL1TLCondition::AXOL1TLCondition(const l1t::AXOL1TLCondition& cp) : ConditionEvaluation() { copy(cp); }
@@ -88,25 +89,24 @@ void l1t::AXOL1TLCondition::setuGtB(const GlobalBoard* ptrGTB) { m_gtGTB = ptrGT
 /// set score for score saving
 void l1t::AXOL1TLCondition::setScore(const float scoreval) const { m_savedscore = scoreval; }
 
+void l1t::AXOL1TLCondition::loadModel() {
+  try {
+    m_model = m_model_loader.load_model();
+  } catch (std::runtime_error& e) {
+    throw cms::Exception("ModelError") << " ERROR: failed to load AXOL1TL model version \""
+                                       << m_model_loader.model_name()
+                                       << "\". Model version not found in cms-hls4ml externals.";
+  }
+}
+
 const bool l1t::AXOL1TLCondition::evaluateCondition(const int bxEval) const {
+  if (m_model == nullptr) {
+    throw cms::Exception("ModelError") << " ERROR: no model was loaded for AXOL1TL model version \""
+                                       << m_model_loader.model_name() << "\".";
+  }
+
   bool condResult = false;
   int useBx = bxEval + m_gtAXOL1TLTemplate->condRelativeBx();
-
-  //HLS4ML stuff
-  std::string AXOL1TLmodelversion = "GTADModel_" + m_gtAXOL1TLTemplate->modelVersion();  //loading from menu/template
-
-  //otherwise load model (if possible) and run inference
-  hls4mlEmulator::ModelLoader loader(AXOL1TLmodelversion);
-  std::shared_ptr<hls4mlEmulator::Model> model;
-
-  try {
-    model = loader.load_model();
-  } catch (std::runtime_error& e) {
-    // for stopping with exception if model version cannot be loaded
-    throw cms::Exception("ModelError")
-        << " ERROR: failed to load AXOL1TL model version \"" << AXOL1TLmodelversion
-        << "\" that was specified in menu. Model version not found in cms-hls4ml externals.";
-  }
 
   // //pointers to objects
   const BXVector<const l1t::Muon*>* candMuVec = m_gtGTB->getCandL1Mu();
@@ -232,9 +232,9 @@ const bool l1t::AXOL1TLCondition::evaluateCondition(const int bxEval) const {
   }
 
   //now run the inference
-  model->prepare_input(ADModelInput);  //scaling internal here
-  model->predict();
-  model->read_result(&ADModelResult);  // this should be the square sum model result
+  m_model->prepare_input(ADModelInput);  //scaling internal here
+  m_model->predict();
+  m_model->read_result(&ADModelResult);  // this should be the square sum model result
 
   result = ADModelResult.first;
   loss = ADModelResult.second;

--- a/L1Trigger/L1TGlobal/src/AlgorithmEvaluation.cc
+++ b/L1Trigger/L1TGlobal/src/AlgorithmEvaluation.cc
@@ -75,7 +75,7 @@ void l1t::AlgorithmEvaluation::evaluateAlgorithm(const int chipNumber,
 
     switch (it->operation) {
       case GlobalLogicParser::OP_OPERAND: {
-        CItEvalMap itCond = (conditionResultMaps.at(chipNumber)).find(it->operand);
+        auto itCond = conditionResultMaps.at(chipNumber).find(it->operand);
         if (itCond != (conditionResultMaps[chipNumber]).end()) {
           if (nullptr == itCond->second) {
             // it should never be happen, only valid conditions are in the maps

--- a/L1Trigger/L1TGlobal/src/CorrCondition.cc
+++ b/L1Trigger/L1TGlobal/src/CorrCondition.cc
@@ -50,17 +50,20 @@ l1t::CorrCondition::CorrCondition() : ConditionEvaluation() {}
 l1t::CorrCondition::CorrCondition(const GlobalCondition* corrTemplate,
                                   const GlobalCondition* cond0Condition,
                                   const GlobalCondition* cond1Condition,
-                                  const GlobalBoard* ptrGTB)
+                                  const GlobalBoard* ptrGTB,
+                                  const GlobalScales* ptrGS)
     : ConditionEvaluation(),
       m_gtCorrelationTemplate(static_cast<const CorrelationTemplate*>(corrTemplate)),
       m_gtCond0(cond0Condition),
       m_gtCond1(cond1Condition),
-      m_uGtB(ptrGTB) {}
+      m_uGtB(ptrGTB),
+      m_gtScales(ptrGS) {}
 
 // copy constructor
 void l1t::CorrCondition::copy(const l1t::CorrCondition& cp) {
   m_gtCorrelationTemplate = cp.gtCorrelationTemplate();
   m_uGtB = cp.getuGtB();
+  m_gtScales = cp.getScales();
 
   m_condMaxNumberObjects = cp.condMaxNumberObjects();
   m_condLastResult = cp.condLastResult();

--- a/L1Trigger/L1TGlobal/src/CorrThreeBodyCondition.cc
+++ b/L1Trigger/L1TGlobal/src/CorrThreeBodyCondition.cc
@@ -45,18 +45,21 @@ l1t::CorrThreeBodyCondition::CorrThreeBodyCondition(const GlobalCondition* corrT
                                                     const GlobalCondition* cond0Condition,
                                                     const GlobalCondition* cond1Condition,
                                                     const GlobalCondition* cond2Condition,
-                                                    const GlobalBoard* ptrGTB)
+                                                    const GlobalBoard* ptrGTB,
+                                                    const GlobalScales* ptrGS)
     : ConditionEvaluation(),
       m_gtCorrelationThreeBodyTemplate(static_cast<const CorrelationThreeBodyTemplate*>(corrTemplate)),
       m_gtCond0(cond0Condition),
       m_gtCond1(cond1Condition),
       m_gtCond2(cond2Condition),
-      m_uGtB(ptrGTB) {}
+      m_uGtB(ptrGTB),
+      m_gtScales(ptrGS) {}
 
 // copy constructor
 void l1t::CorrThreeBodyCondition::copy(const l1t::CorrThreeBodyCondition& cp) {
   m_gtCorrelationThreeBodyTemplate = cp.gtCorrelationThreeBodyTemplate();
   m_uGtB = cp.getuGtB();
+  m_gtScales = cp.getScales();
 
   m_condMaxNumberObjects = cp.condMaxNumberObjects();
   m_condLastResult = cp.condLastResult();

--- a/L1Trigger/L1TGlobal/src/CorrWithOverlapRemovalCondition.cc
+++ b/L1Trigger/L1TGlobal/src/CorrWithOverlapRemovalCondition.cc
@@ -81,19 +81,22 @@ l1t::CorrWithOverlapRemovalCondition::CorrWithOverlapRemovalCondition(const Glob
                                                                       const GlobalCondition* cond0Condition,
                                                                       const GlobalCondition* cond1Condition,
                                                                       const GlobalCondition* cond2Condition,
-                                                                      const GlobalBoard* ptrGTB)
+                                                                      const GlobalBoard* ptrGTB,
+                                                                      const GlobalScales* ptrGS)
     : ConditionEvaluation(),
       m_gtCorrelationWithOverlapRemovalTemplate(
           static_cast<const CorrelationWithOverlapRemovalTemplate*>(corrTemplate)),
       m_gtCond0(cond0Condition),
       m_gtCond1(cond1Condition),
       m_gtCond2(cond2Condition),
-      m_uGtB(ptrGTB) {}
+      m_uGtB(ptrGTB),
+      m_gtScales(ptrGS) {}
 
 // copy constructor
 void l1t::CorrWithOverlapRemovalCondition::copy(const l1t::CorrWithOverlapRemovalCondition& cp) {
   m_gtCorrelationWithOverlapRemovalTemplate = cp.gtCorrelationWithOverlapRemovalTemplate();
   m_uGtB = cp.getuGtB();
+  m_gtScales = cp.getScales();
 
   m_condMaxNumberObjects = cp.condMaxNumberObjects();
   m_condLastResult = cp.condLastResult();

--- a/L1Trigger/L1TGlobal/src/GlobalBoard.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalBoard.cc
@@ -78,24 +78,14 @@ l1t::GlobalBoard::GlobalBoard()
       m_currentLumi(0),
       m_isDebugEnabled(edm::isDebugEnabled()) {
   m_uGtAlgBlk.reset();
-  m_uGtAXOScore.reset();
 
   m_gtlAlgorithmOR.reset();
   m_gtlDecisionWord.reset();
 
   m_prescaleCounterAlgoTrig.clear();
 
-  // Initialize cached IDs
-  m_l1GtMenuCacheID = 0ULL;
-  m_l1CaloGeometryCacheID = 0ULL;
-  m_l1MuTriggerScalesCacheID = 0ULL;
-
-  // Counter for number of events board sees
-  m_boardEventCount = 0;
-
-  // A single uGT GlobalBoard is taken into account in the emulator
-  m_uGtBoardNumber = 0;
-  m_uGtFinalBoard = true;
+  m_uGtAXOScore.reset();
+  m_axoScoreConditionName = "";
 }
 
 // Destructor
@@ -567,32 +557,18 @@ void l1t::GlobalBoard::fillAXOScore(int iBxInEvent, std::unique_ptr<AXOL1TLScore
   AxoScoreRecord->push_back(iBxInEvent, m_uGtAXOScore);
 }
 
-// run GTL
-void l1t::GlobalBoard::runGTL(const edm::Event&,
-                              const edm::EventSetup& evSetup,
-                              const TriggerMenu* m_l1GtMenu,
-                              const bool produceL1GtObjectMapRecord,
-                              const int iBxInEvent,
-                              std::unique_ptr<GlobalObjectMapRecord>& gtObjectMapRecord,
-                              const unsigned int numberPhysTriggers,
-                              const int nrL1Mu,
-                              const int nrL1MuShower,
-                              const int nrL1EG,
-                              const int nrL1Tau,
-                              const int nrL1Jet) {
+// Initialise Trigger Conditions
+void l1t::GlobalBoard::initTriggerConditions(const edm::EventSetup& evSetup,
+                                             const TriggerMenu* m_l1GtMenu,
+                                             const int nrL1Mu,
+                                             const int nrL1MuShower,
+                                             const int nrL1EG,
+                                             const int nrL1Tau,
+                                             const int nrL1Jet) {
   const std::vector<ConditionMap>& conditionMap = m_l1GtMenu->gtConditionMap();
-  const AlgorithmMap& algorithmMap = m_l1GtMenu->gtAlgorithmMap();
   const GlobalScales& gtScales = m_l1GtMenu->gtScales();
   const std::string scaleSetName = gtScales.getScalesName();
   LogDebug("L1TGlobal") << " L1 Menu Scales -- Set Name: " << scaleSetName;
-
-  // Reset AlgBlk for this bx
-  m_uGtAlgBlk.reset();
-  m_algInitialOr = false;
-  m_algPrescaledOr = false;
-  m_algIntermOr = false;
-  m_algFinalOr = false;
-  m_algFinalOrVeto = false;
 
   const std::vector<std::vector<MuonTemplate>>& corrMuon = m_l1GtMenu->corMuonTemplate();
 
@@ -608,179 +584,132 @@ void l1t::GlobalBoard::runGTL(const edm::Event&,
   // then loop over conditions in the map and
   // save the results in temporary maps
   // -----------------------------------------------------
-  // never happens in production but at first event...
-  if (m_conditionResultMaps.size() != conditionMap.size()) {
-    m_conditionResultMaps.clear();
-    m_conditionResultMaps.resize(conditionMap.size());
-  }
+  m_conditionResultMaps.clear();
+  m_conditionResultMaps.resize(conditionMap.size());
 
   int iChip = -1;
 
-  for (std::vector<ConditionMap>::const_iterator itCondOnChip = conditionMap.begin();
-       itCondOnChip != conditionMap.end();
-       itCondOnChip++) {
-    iChip++;
+  for (auto const& itCondOnChip : conditionMap) {
+    ++iChip;
 
-    AlgorithmEvaluation::ConditionEvaluationMap& cMapResults = m_conditionResultMaps[iChip];
+    auto& cMapResults = m_conditionResultMaps[iChip];
 
-    for (CItCond itCond = itCondOnChip->begin(); itCond != itCondOnChip->end(); itCond++) {
+    for (auto const& itCond : itCondOnChip) {
+      cMapResults[itCond.first] = nullptr;
+      auto& theCondition = cMapResults[itCond.first];
+
       // evaluate condition
-      switch ((itCond->second)->condCategory()) {
+      switch ((itCond.second)->condCategory()) {
         case CondMuon: {
           // BLW Not sure what to do with this for now
           const int ifMuEtaNumberBits = 0;
 
-          MuCondition* muCondition = new MuCondition(itCond->second, this, nrL1Mu, ifMuEtaNumberBits);
-
-          muCondition->setVerbosity(m_verbosity);
-
-          muCondition->evaluateConditionStoreResult(iBxInEvent);
-
-          cMapResults[itCond->first] = muCondition;
+          theCondition = std::make_unique<MuCondition>(itCond.second, this, nrL1Mu, ifMuEtaNumberBits);
+          theCondition->setVerbosity(m_verbosity);
 
           if (m_verbosity && m_isDebugEnabled) {
             std::ostringstream myCout;
-            muCondition->print(myCout);
+            theCondition->print(myCout);
 
             LogTrace("L1TGlobal") << myCout.str();
           }
-          //delete muCondition;
-
         } break;
+
         case CondMuonShower: {
-          MuonShowerCondition* muShowerCondition = new MuonShowerCondition(itCond->second, this, nrL1MuShower);
-
-          muShowerCondition->setVerbosity(m_verbosity);
-
-          muShowerCondition->evaluateConditionStoreResult(iBxInEvent);
-
-          cMapResults[itCond->first] = muShowerCondition;
+          theCondition = std::make_unique<MuonShowerCondition>(itCond.second, this, nrL1MuShower);
+          theCondition->setVerbosity(m_verbosity);
 
           if (m_verbosity && m_isDebugEnabled) {
             std::ostringstream myCout;
-            muShowerCondition->print(myCout);
+            theCondition->print(myCout);
 
-            edm::LogWarning("L1TGlobal") << "MuonShowerCondition " << myCout.str();
+            LogTrace("L1TGlobal") << myCout.str();
           }
-          //delete muShowerCondition;
-
         } break;
+
         case CondCalo: {
           // BLW Not sure w hat to do with this for now
           const int ifCaloEtaNumberBits = 0;
 
-          CaloCondition* caloCondition =
-              new CaloCondition(itCond->second, this, nrL1EG, nrL1Jet, nrL1Tau, ifCaloEtaNumberBits);
-
-          caloCondition->setVerbosity(m_verbosity);
-
-          caloCondition->evaluateConditionStoreResult(iBxInEvent);
-
-          cMapResults[itCond->first] = caloCondition;
+          theCondition =
+              std::make_unique<CaloCondition>(itCond.second, this, nrL1EG, nrL1Jet, nrL1Tau, ifCaloEtaNumberBits);
+          theCondition->setVerbosity(m_verbosity);
 
           if (m_verbosity && m_isDebugEnabled) {
             std::ostringstream myCout;
-            caloCondition->print(myCout);
+            theCondition->print(myCout);
 
             LogTrace("L1TGlobal") << myCout.str();
           }
-          //                    delete caloCondition;
-
         } break;
+
         case CondEnergySum: {
-          EnergySumCondition* eSumCondition = new EnergySumCondition(itCond->second, this);
-
-          eSumCondition->setVerbosity(m_verbosity);
-          eSumCondition->evaluateConditionStoreResult(iBxInEvent);
-
-          cMapResults[itCond->first] = eSumCondition;
+          theCondition = std::make_unique<EnergySumCondition>(itCond.second, this);
+          theCondition->setVerbosity(m_verbosity);
 
           if (m_verbosity && m_isDebugEnabled) {
             std::ostringstream myCout;
-            eSumCondition->print(myCout);
+            theCondition->print(myCout);
 
             LogTrace("L1TGlobal") << myCout.str();
           }
-          //                    delete eSumCondition;
-
         } break;
+
         case CondEnergySumZdc: {
-          EnergySumZdcCondition* eSumZdcCondition = new EnergySumZdcCondition(itCond->second, this);
-
-          eSumZdcCondition->setVerbosity(m_verbosity);
-          eSumZdcCondition->evaluateConditionStoreResult(iBxInEvent);
-
-          cMapResults[itCond->first] = eSumZdcCondition;
+          theCondition = std::make_unique<EnergySumZdcCondition>(itCond.second, this);
+          theCondition->setVerbosity(m_verbosity);
 
           if (m_verbosity && m_isDebugEnabled) {
             std::ostringstream myCout;
-            eSumZdcCondition->print(myCout);
+            theCondition->print(myCout);
 
             LogTrace("L1TGlobal") << myCout.str();
           }
-          //                    delete eSumZdcCondition;
-
         } break;
+
         case CondAXOL1TL: {
-          AXOL1TLCondition* axol1tlCondition = new AXOL1TLCondition(itCond->second, this);
+          theCondition = std::make_unique<AXOL1TLCondition>(itCond.second, this);
+          theCondition->setVerbosity(m_verbosity);
 
-          axol1tlCondition->setVerbosity(m_verbosity);
-
-          axol1tlCondition->evaluateConditionStoreResult(iBxInEvent);
-
-          cMapResults[itCond->first] = axol1tlCondition;
-
-          //for optional software-only saving of axol1tl score
-          //m_storedAXOScore < 0.0 ensures only sets once per condition if score not default of -999
-          if (m_saveAXOScore && m_storedAXOScore < 0.0) {
-            m_storedAXOScore = axol1tlCondition->getScore();
+          if (m_saveAXOScore and not m_axoScoreConditionName.empty()) {
+            m_axoScoreConditionName = itCond.first;
           }
 
           if (m_verbosity && m_isDebugEnabled) {
             std::ostringstream myCout;
-            axol1tlCondition->print(myCout);
+            theCondition->print(myCout);
 
-            edm::LogWarning("L1TGlobal") << "axol1tlCondition " << myCout.str();
+            LogTrace("L1TGlobal") << myCout.str();
           }
-          //delete axol1tlCCondition;
-
         } break;
+
         case CondCICADA: {
-          CICADACondition* cicadaCondition = new CICADACondition(itCond->second, this);
-
-          cicadaCondition->setVerbosity(m_verbosity);
-          cicadaCondition->evaluateConditionStoreResult(iBxInEvent);
-
-          cMapResults[itCond->first] = cicadaCondition;
+          theCondition = std::make_unique<CICADACondition>(itCond.second, this);
+          theCondition->setVerbosity(m_verbosity);
 
           if (m_verbosity && m_isDebugEnabled) {
             std::ostringstream myCout;
-            cicadaCondition->print(myCout);
+            theCondition->print(myCout);
 
-            edm::LogWarning("L1TGlobal") << "cicadaCondition " << myCout.str();
+            LogTrace("L1TGlobal") << myCout.str();
           }
         } break;
 
         case CondExternal: {
-          ExternalCondition* extCondition = new ExternalCondition(itCond->second, this);
-
-          extCondition->setVerbosity(m_verbosity);
-          extCondition->evaluateConditionStoreResult(iBxInEvent);
-
-          cMapResults[itCond->first] = extCondition;
+          theCondition = std::make_unique<ExternalCondition>(itCond.second, this);
+          theCondition->setVerbosity(m_verbosity);
 
           if (m_verbosity && m_isDebugEnabled) {
             std::ostringstream myCout;
-            extCondition->print(myCout);
+            theCondition->print(myCout);
 
             LogTrace("L1TGlobal") << myCout.str();
           }
-          //                    delete extCondition;
-
         } break;
+
         case CondCorrelation: {
           // get first the subconditions
-          const CorrelationTemplate* corrTemplate = static_cast<const CorrelationTemplate*>(itCond->second);
+          const CorrelationTemplate* corrTemplate = static_cast<const CorrelationTemplate*>(itCond.second);
           const GtConditionCategory cond0Categ = corrTemplate->cond0Category();
           const GtConditionCategory cond1Categ = corrTemplate->cond1Category();
           const int cond0Ind = corrTemplate->cond0Index();
@@ -825,28 +754,22 @@ void l1t::GlobalBoard::runGTL(const edm::Event&,
             } break;
           }
 
-          CorrCondition* correlationCond = new CorrCondition(itCond->second, cond0Condition, cond1Condition, this);
-
-          correlationCond->setVerbosity(m_verbosity);
-          correlationCond->setScales(&gtScales);
-          correlationCond->evaluateConditionStoreResult(iBxInEvent);
-
-          cMapResults[itCond->first] = correlationCond;
+          theCondition =
+              std::make_unique<CorrCondition>(itCond.second, cond0Condition, cond1Condition, this, &gtScales);
+          theCondition->setVerbosity(m_verbosity);
 
           if (m_verbosity && m_isDebugEnabled) {
             std::ostringstream myCout;
-            correlationCond->print(myCout);
+            theCondition->print(myCout);
 
             LogTrace("L1TGlobal") << myCout.str();
           }
-
-          //  		delete correlationCond;
-
         } break;
+
         case CondCorrelationThreeBody: {
           // get first the subconditions
           const CorrelationThreeBodyTemplate* corrTemplate =
-              static_cast<const CorrelationThreeBodyTemplate*>(itCond->second);
+              static_cast<const CorrelationThreeBodyTemplate*>(itCond.second);
           const GtConditionCategory cond0Categ = corrTemplate->cond0Category();
           const GtConditionCategory cond1Categ = corrTemplate->cond1Category();
           const GtConditionCategory cond2Categ = corrTemplate->cond2Category();
@@ -880,27 +803,22 @@ void l1t::GlobalBoard::runGTL(const edm::Event&,
             LogDebug("L1TGlobal") << "No muon2 to evaluate three-body correlation condition";
           }
 
-          CorrThreeBodyCondition* correlationThreeBodyCond =
-              new CorrThreeBodyCondition(itCond->second, cond0Condition, cond1Condition, cond2Condition, this);
-
-          correlationThreeBodyCond->setVerbosity(m_verbosity);
-          correlationThreeBodyCond->setScales(&gtScales);
-          correlationThreeBodyCond->evaluateConditionStoreResult(iBxInEvent);
-          cMapResults[itCond->first] = correlationThreeBodyCond;
+          theCondition = std::make_unique<CorrThreeBodyCondition>(
+              itCond.second, cond0Condition, cond1Condition, cond2Condition, this, &gtScales);
+          theCondition->setVerbosity(m_verbosity);
 
           if (m_verbosity && m_isDebugEnabled) {
             std::ostringstream myCout;
-            correlationThreeBodyCond->print(myCout);
+            theCondition->print(myCout);
 
             LogTrace("L1TGlobal") << myCout.str();
           }
-          //              delete correlationThreeBodyCond;
         } break;
 
         case CondCorrelationWithOverlapRemoval: {
           // get first the subconditions
           const CorrelationWithOverlapRemovalTemplate* corrTemplate =
-              static_cast<const CorrelationWithOverlapRemovalTemplate*>(itCond->second);
+              static_cast<const CorrelationWithOverlapRemovalTemplate*>(itCond.second);
           const GtConditionCategory cond0Categ = corrTemplate->cond0Category();
           const GtConditionCategory cond1Categ = corrTemplate->cond1Category();
           const GtConditionCategory cond2Categ = corrTemplate->cond2Category();
@@ -964,33 +882,64 @@ void l1t::GlobalBoard::runGTL(const edm::Event&,
             } break;
           }
 
-          CorrWithOverlapRemovalCondition* correlationCondWOR =
-              new CorrWithOverlapRemovalCondition(itCond->second, cond0Condition, cond1Condition, cond2Condition, this);
-
-          correlationCondWOR->setVerbosity(m_verbosity);
-          correlationCondWOR->setScales(&gtScales);
-          correlationCondWOR->evaluateConditionStoreResult(iBxInEvent);
-
-          cMapResults[itCond->first] = correlationCondWOR;
+          theCondition = std::make_unique<CorrWithOverlapRemovalCondition>(
+              itCond.second, cond0Condition, cond1Condition, cond2Condition, this, &gtScales);
+          theCondition->setVerbosity(m_verbosity);
 
           if (m_verbosity && m_isDebugEnabled) {
             std::ostringstream myCout;
-            correlationCondWOR->print(myCout);
+            theCondition->print(myCout);
 
             LogTrace("L1TGlobal") << myCout.str();
           }
-
-          //  		delete correlationCondWOR;
-
         } break;
+
         case CondNull: {
           // do nothing
-
         } break;
+
         default: {
           // do nothing
-
         } break;
+      }
+    }
+  }
+}
+
+// -------
+// Run GTL
+// -------
+void l1t::GlobalBoard::runGTL(const edm::Event&,
+                              const edm::EventSetup& evSetup,
+                              const TriggerMenu* m_l1GtMenu,
+                              const bool produceL1GtObjectMapRecord,
+                              const int iBxInEvent,
+                              std::unique_ptr<GlobalObjectMapRecord>& gtObjectMapRecord,
+                              const unsigned int numberPhysTriggers) {
+  const std::vector<ConditionMap>& conditionMap = m_l1GtMenu->gtConditionMap();
+  const AlgorithmMap& algorithmMap = m_l1GtMenu->gtAlgorithmMap();
+
+  // Reset AlgBlk for this bx
+  m_uGtAlgBlk.reset();
+  m_algInitialOr = false;
+  m_algPrescaledOr = false;
+  m_algIntermOr = false;
+  m_algFinalOr = false;
+  m_algFinalOrVeto = false;
+
+  // -------------------------------
+  // Evaluate conditions for this bx
+  // -------------------------------
+  for (auto& condMap : m_conditionResultMaps) {
+    for (auto& cond : condMap) {
+      cond.second->evaluateConditionStoreResult(iBxInEvent);
+
+      // for optional software-only saving of axol1tl score
+      // m_storedAXOScore < 0.0 ensures this gets set only once per condition if score not default of -999
+      if (m_saveAXOScore and m_storedAXOScore < 0 and cond.first == m_axoScoreConditionName and
+          not m_axoScoreConditionName.empty()) {
+        auto const* theCondition = dynamic_cast<AXOL1TLCondition*>(cond.second.get());
+        m_storedAXOScore = theCondition->getScore();
       }
     }
   }
@@ -1003,25 +952,24 @@ void l1t::GlobalBoard::runGTL(const edm::Event&,
   if (produceL1GtObjectMapRecord && (iBxInEvent == 0))
     objMapVec.reserve(numberPhysTriggers);
 
-  for (CItAlgo itAlgo = algorithmMap.begin(); itAlgo != algorithmMap.end(); itAlgo++) {
-    AlgorithmEvaluation gtAlg(itAlgo->second);
-    gtAlg.evaluateAlgorithm((itAlgo->second).algoChipNumber(), m_conditionResultMaps);
+  for (auto const& itAlgo : algorithmMap) {
+    AlgorithmEvaluation gtAlg(itAlgo.second);
+    gtAlg.evaluateAlgorithm(itAlgo.second.algoChipNumber(), m_conditionResultMaps);
 
-    int algBitNumber = (itAlgo->second).algoBitNumber();
-    bool algResult = gtAlg.gtAlgoResult();
+    int const algBitNumber = (itAlgo.second).algoBitNumber();
+    bool const algResult = gtAlg.gtAlgoResult();
 
-    LogDebug("L1TGlobal") << " ===> for iBxInEvent = " << iBxInEvent << ":\t algBitName = " << itAlgo->first
+    LogDebug("L1TGlobal") << " ===> for iBxInEvent = " << iBxInEvent << ":\t algBitName = " << itAlgo.first
                           << ",\t algBitNumber = " << algBitNumber << ",\t algResult = " << algResult;
 
     if (algResult) {
-      //            m_gtlAlgorithmOR.set(algBitNumber);
       m_uGtAlgBlk.setAlgoDecisionInitial(algBitNumber, algResult);
       m_algInitialOr = true;
     }
 
     if (m_verbosity && m_isDebugEnabled) {
       std::ostringstream myCout;
-      (itAlgo->second).print(myCout);
+      itAlgo.second.print(myCout);
       gtAlg.print(myCout);
 
       LogTrace("L1TGlobal") << myCout.str();
@@ -1048,6 +996,7 @@ void l1t::GlobalBoard::runGTL(const edm::Event&,
             }
           }
         }
+
         if (!found) {
           edm::LogWarning("L1TGlobal") << "\n Failed to find match for operand token " << iop->tokenName << "\n";
         } else {
@@ -1057,8 +1006,7 @@ void l1t::GlobalBoard::runGTL(const edm::Event&,
 
       // set object map
       GlobalObjectMap objMap;
-
-      objMap.setAlgoName(itAlgo->first);
+      objMap.setAlgoName(itAlgo.first);
       objMap.setAlgoBitNumber(algBitNumber);
       objMap.setAlgoGtlResult(algResult);
       objMap.swapOperandTokenVector(gtAlg.operandTokenVector());
@@ -1067,10 +1015,10 @@ void l1t::GlobalBoard::runGTL(const edm::Event&,
       objMap.swapObjectTypeVector(otypes);
 
       if (m_verbosity && m_isDebugEnabled) {
-        std::ostringstream myCout1;
-        objMap.print(myCout1);
+        std::ostringstream myCout;
+        objMap.print(myCout);
 
-        LogTrace("L1TGlobal") << myCout1.str();
+        LogTrace("L1TGlobal") << myCout.str();
       }
 
       objMapVec.push_back(objMap);
@@ -1081,22 +1029,10 @@ void l1t::GlobalBoard::runGTL(const edm::Event&,
   if (produceL1GtObjectMapRecord && (iBxInEvent == 0)) {
     gtObjectMapRecord->swapGtObjectMap(objMapVec);
   }
-
-  // loop over condition maps (one map per condition chip)
-  // then loop over conditions in the map
-  // delete the conditions created with new, zero pointer, do not clear map, keep the vector as is...
-  for (std::vector<AlgorithmEvaluation::ConditionEvaluationMap>::iterator itCondOnChip = m_conditionResultMaps.begin();
-       itCondOnChip != m_conditionResultMaps.end();
-       itCondOnChip++) {
-    for (AlgorithmEvaluation::ItEvalMap itCond = itCondOnChip->begin(); itCond != itCondOnChip->end(); itCond++) {
-      delete itCond->second;
-      itCond->second = nullptr;
-    }
-  }
 }
 
 // -------
-// Run GTL
+// Run FDL
 // -------
 void l1t::GlobalBoard::runFDL(const edm::Event& iEvent,
                               const int iBxInEvent,
@@ -1251,8 +1187,9 @@ void l1t::GlobalBoard::reset() {
   m_uGtAlgBlk.reset();
 
   //reset AXO score
-  m_storedAXOScore = -999.0;
+  m_storedAXOScore = -999.f;
   m_uGtAXOScore.reset();
+  m_axoScoreConditionName = "";
 
   m_gtlDecisionWord.reset();
   m_gtlAlgorithmOR.reset();


### PR DESCRIPTION
#### PR description:

This PR implements two improvements to the L1-uGT emulator. It goes in the direction of addressing #46740.

 - https://github.com/missirol/cmssw/commit/9dc135c19d7b352c094cf3eef14168fe6656bf3d moves several operations from `L1TGlobalProducer::produce` to `L1TGlobalProducer::beginRun` (these are operations that depend only on the L1T trigger menu, which (afaik) may only change during run transitions). In particular, this leads to building the map of "trigger conditions" (instances of classes inhering from `ConditionEvaluation`, one of them being `AXOL1TLCondition`) only once per run, as opposed to once per event.

 - https://github.com/missirol/cmssw/commit/fe94271275060f4dbd6f700ce190feca79dc286d moves the initialisation of the `hls4ml` model in `AXOL1TLCondition` from its `evaluateCondition` method (used multiple times per event) to its constructor (called only a few times per run given https://github.com/missirol/cmssw/commit/9dc135c19d7b352c094cf3eef14168fe6656bf3d).

This PR requires https://github.com/cms-hls4ml/hls4mlEmulatorExtras/pull/6, a simple improvement of the methods of the class `hls4mlEmulatorExtras::ModelLoader` in the `hls4mlEmulatorExtras` external (this update is available via https://github.com/cms-sw/cmsdist/pull/9606).

(This PR will likely need to be rebased if #47030 is merged first.)

#### PR validation:

Validated in `CMSSW_15_0_0_pre1` with the checks described in https://github.com/cms-sw/cmssw/issues/46740#issuecomment-2571706939.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A
