### PR TITLE
Add Mother Indices to LHEPart 

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/LHETablesProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/LHETablesProducer.cc
@@ -66,8 +66,8 @@ public:
     std::vector<int> vals_pid;
     std::vector<int> vals_status;
     std::vector<int> vals_spin;
-    std::vector<Short_t> vals_firstMotherIdx;
-    std::vector<Short_t> vals_lastMotherIdx;
+    std::vector<int16_t> vals_firstMotherIdx;
+    std::vector<int16_t> vals_lastMotherIdx;
     alphaS = hepeup.AQCDUP;
 
     int nOutPart = 0;
@@ -170,9 +170,9 @@ public:
     outPart->addColumn<int>("pdgId", vals_pid, "PDG ID of LHE particles");
     outPart->addColumn<int>("status", vals_status, "LHE particle status; -1:incoming, 1:outgoing");
     outPart->addColumn<int>("spin", vals_spin, "Spin of LHE particles");
-    outPart->addColumn<Short_t>(
+    outPart->addColumn<int16_t>(
         "firstMotherIdx", vals_firstMotherIdx, "Index of this particle's first mother in the LHEPart collection");
-    outPart->addColumn<Short_t>(
+    outPart->addColumn<int16_t>(
         "lastMotherIdx", vals_lastMotherIdx, "Index of this particle's last mother in the LHEPart collection");
 
     return outPart;

--- a/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
@@ -521,6 +521,8 @@ nanoDQM = DQMEDAnalyzer("NanoAODDQM",
                 Plot1D('pdgId', 'pdgId', 20, -6000, 6000, 'PDG id'),
                 Plot1D('phi', 'phi', 20, -3.14159, 3.14159, 'phi'),
                 Plot1D('pt', 'pt', 20, 0, 200, 'pt'),
+                NoPlot('firstMotherIdx'),
+                NoPlot('lastMotherIdx'),
             )
         ),
         LHEPdfWeight = cms.PSet(


### PR DESCRIPTION
#### PR description:

The indices of a particle's mother are not currently stored in the LHEPart collection. 
This PR would add two lists of indices to the LHEPart collection:

- LHEPart_firstMotherIdx: The index of an LHE particle's first mother in the LHEPart collection.
- LHEPart_lastMotherIdx: The index of an LHE particle's last mother in the LHEPart collection. 

The ability to track an LHE particle's ancestry is necessary for performing matrix-element calculations as done in HIG-19-009 and HIG-21-013 for the purposes of reweighting. Future Higgs property measurements in H -> 4l and other channels will require this additional information. 

I have discussed the code of this PR with the following members of the HZZ group: Nicola Amapane (@namapane), and Jeffrey Davis (@jdavis36). 

#### PR validation:
The code was tested on a sample of ZH, (H -->ZZ-->4l) events from /ZHto2Zto4L_M125_TuneCP5_13p6TeV_powheg2-minlo-HZJ-JHUGenV752-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM in CMSSW_13_3_3. 

A ZH sample was chosen so that the LHE history was sufficiently complex.

It was verified that the indices stored in the output nanoAOD file correspond to the same particle in the input miniAOD. 

According to the size report, each of the 2 new variables adds 0.1 b/item; in this sample there are in average 14 items/evt, so the total size increase is be 2.8  b/evt, which is a very small addition.

