### PR TITLE
Make all RunLumiEventAnalyzer instances to use `vector<unsigned long long>`

### DIFF
--- a/FWCore/Framework/test/stubs/RunLumiEventAnalyzer.cc
+++ b/FWCore/Framework/test/stubs/RunLumiEventAnalyzer.cc
@@ -9,7 +9,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/Exception.h"
-#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include <cassert>
 #include <vector>
@@ -29,9 +28,9 @@ namespace edmtest {
     void endJob();
 
   private:
-    std::vector<unsigned long long> expectedRunLumisEvents0_;
-    std::vector<unsigned long long> expectedRunLumisEvents1_;
-    edm::propagate_const<std::vector<unsigned long long>*> const expectedRunLumisEvents_;
+    std::vector<unsigned long long> const expectedRunLumisEvents0_;
+    std::vector<unsigned long long> const expectedRunLumisEvents1_;
+    std::vector<unsigned long long> const* const expectedRunLumisEvents_;
     bool const verbose_;
     bool const dumpTriggerResults_;
     int const expectedEndingIndex0_;
@@ -42,27 +41,14 @@ namespace edmtest {
   };
 
   RunLumiEventAnalyzer::RunLumiEventAnalyzer(edm::ParameterSet const& pset)
-      : expectedRunLumisEvents0_(),
-        expectedRunLumisEvents1_(),
+      : expectedRunLumisEvents0_(pset.getUntrackedParameter<std::vector<unsigned long long>>("expectedRunLumiEvents")),
+        expectedRunLumisEvents1_(pset.getUntrackedParameter<std::vector<unsigned long long>>("expectedRunLumiEvents1")),
         expectedRunLumisEvents_(&expectedRunLumisEvents0_),
         verbose_(pset.getUntrackedParameter<bool>("verbose")),
         dumpTriggerResults_(pset.getUntrackedParameter<bool>("dumpTriggerResults")),
         expectedEndingIndex0_(pset.getUntrackedParameter<int>("expectedEndingIndex")),
         expectedEndingIndex1_(pset.getUntrackedParameter<int>("expectedEndingIndex1")),
         expectedEndingIndex_(expectedEndingIndex0_) {
-    if (pset.existsAs<std::vector<unsigned int>>("expectedRunLumiEvents", false)) {
-      std::vector<unsigned int> temp = pset.getUntrackedParameter<std::vector<unsigned int>>("expectedRunLumiEvents");
-      expectedRunLumisEvents0_.assign(temp.begin(), temp.end());
-    } else {
-      expectedRunLumisEvents0_ = pset.getUntrackedParameter<std::vector<unsigned long long>>("expectedRunLumiEvents");
-    }
-
-    if (pset.existsAs<std::vector<unsigned int>>("expectedRunLumiEvents1", false)) {
-      std::vector<unsigned int> temp = pset.getUntrackedParameter<std::vector<unsigned int>>("expectedRunLumiEvents1");
-      expectedRunLumisEvents1_.assign(temp.begin(), temp.end());
-    } else {
-      expectedRunLumisEvents1_ = pset.getUntrackedParameter<std::vector<unsigned long long>>("expectedRunLumiEvents1");
-    }
     if (dumpTriggerResults_) {
       triggerResultsToken_ = consumes(edm::InputTag("TriggerResults"));
     }
@@ -74,10 +60,8 @@ namespace edmtest {
     desc.addUntracked<bool>("dumpTriggerResults", false);
     desc.addUntracked<int>("expectedEndingIndex", -1);
     desc.addUntracked<int>("expectedEndingIndex1", -1);
-    desc.addNode(edm::ParameterDescription<std::vector<unsigned long long>>("expectedRunLumiEvents", {}, false) xor
-                 edm::ParameterDescription<std::vector<unsigned int>>("expectedRunLumiEvents", {}, false));
-    desc.addNode(edm::ParameterDescription<std::vector<unsigned long long>>("expectedRunLumiEvents1", {}, false) xor
-                 edm::ParameterDescription<std::vector<unsigned int>>("expectedRunLumiEvents1", {}, false));
+    desc.addUntracked<std::vector<unsigned long long>>("expectedRunLumiEvents", {});
+    desc.addUntracked<std::vector<unsigned long long>>("expectedRunLumiEvents1", {});
 
     descriptions.addDefault(desc);
   }

--- a/FWCore/Integration/test/readSubProcessOutput_cfg.py
+++ b/FWCore/Integration/test/readSubProcessOutput_cfg.py
@@ -2,46 +2,42 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("READ")
 
-process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring("file:testSubProcess.root")
-)
+from IOPool.Input.modules import PoolSource
+process.source = PoolSource(fileNames = "file:testSubProcess.root")
 
-process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string(
-      'readSubprocessOutput.root'
-    )
-)
+from IOPool.Output.modules import PoolOutputModule
+process.out = PoolOutputModule(fileName = 'readSubprocessOutput.root')
 
 
+from FWCore.Framework.modules import TestMergeResults, RunLumiEventAnalyzer
 # Reusing some code I used for testing merging, although in this
 # context it has nothing to do with merging.
 # Here we are checking the event, run, and lumi products
 # from the last subprocess in the chain of subprocesses
 # are there.
-process.testproducts = cms.EDAnalyzer("TestMergeResults",
-
-    expectedBeginRunProd = cms.untracked.vint32(
+process.testproducts = TestMergeResults(
+    expectedBeginRunProd = [
         10001,   10002,  10003,   # end run 1
         10001,   10002,  10003,   # end run 2
         10001,   10002,  10003    # end run 3
-    ),
+    ],
 
-    expectedEndRunProd = cms.untracked.vint32(
+    expectedEndRunProd = [
         100001,   100002,  100003,   # end run 1
         100001,   100002,  100003,   # end run 2
         100001,   100002,  100003    # end run 3
-    ),
+    ],
 
-    expectedBeginLumiProd = cms.untracked.vint32(
+    expectedBeginLumiProd = [
         101,       102,    103    # end run 1 lumi 1
 # There are more, but all with the same pattern as the first        
-    ),
+    ],
 
-    expectedEndLumiProd = cms.untracked.vint32(
+    expectedEndLumiProd = [
         1001,     1002,   1003    # end run 1 lumi 1
-    ),
+    ],
 
-    expectedProcessHistoryInRuns = cms.untracked.vstring(
+    expectedProcessHistoryInRuns = [
         'PROD',            # Run 1
         'PROD2',
         'READ',
@@ -51,13 +47,13 @@ process.testproducts = cms.EDAnalyzer("TestMergeResults",
         'PROD',            # Run 3
         'PROD2',
         'READ'
-    ),
-    verbose = cms.untracked.bool(True)
+    ],
+    verbose = True
 )
 
-process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
-    verbose = cms.untracked.bool(True),
-    expectedRunLumiEvents = cms.untracked.vuint32(
+process.test = RunLumiEventAnalyzer(
+    verbose = True,
+    expectedRunLumiEvents = [
 1,   0,   0,
 1,   1,   0,
 1,   1,   1,
@@ -112,7 +108,7 @@ process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
 3,   3,   10,
 3,   3,   0,
 3,   0,   0
-)
+]
 )
 
 process.path1 = cms.Path(process.test*process.testproducts)

--- a/FWCore/Integration/test/testGetByWithEmptyRun_cfg.py
+++ b/FWCore/Integration/test/testGetByWithEmptyRun_cfg.py
@@ -7,24 +7,25 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("PROD3")
 
-process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring(
+from IOPool.Input.modules import PoolSource
+process.source = PoolSource(
+    fileNames = [
         'file:testGetByRunsMode.root',
         'file:testGetBy1.root'
-    ),
-    inputCommands=cms.untracked.vstring(
+    ],
+    inputCommands = [
         'keep *',
         'drop *_*_*_PROD2'
-    )
+    ]
 )
 
-process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('testGetByWithEmptyRun.root')
-)
+from IOPool.Output.modules import PoolOutputModule
+process.out = PoolOutputModule(fileName = 'testGetByWithEmptyRun.root')
 
-process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
-                              verbose = cms.untracked.bool(True),
-                              expectedRunLumiEvents = cms.untracked.vuint32(
+from FWCore.Framework.modules import RunLumiEventAnalyzer
+process.test = RunLumiEventAnalyzer(
+    verbose = True,
+    expectedRunLumiEvents = [
 1, 0, 0,
 1, 0, 0,
 1, 0, 0,
@@ -34,7 +35,7 @@ process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
 1, 1, 3,
 1, 1, 0,
 1, 0, 0
-)
+]
 )
 
 process.p1 = cms.Path(process.test)

--- a/FWCore/Integration/test/testLooperEventNavigation1_cfg.py
+++ b/FWCore/Integration/test/testLooperEventNavigation1_cfg.py
@@ -5,8 +5,6 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
-
-process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.FwkReport.reportEvery = 1000
 process.MessageLogger.cerr.threshold = 'ERROR'
 
@@ -15,24 +13,25 @@ process.options = cms.untracked.PSet(
   Rethrow = FWCore.Framework.test.cmsExceptionsFatalOption_cff.Rethrow
 )
 
-process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring(
+from IOPool.Input.modules import PoolSource
+process.source = PoolSource(
+    fileNames = [
         'file:testRunMerge1.root',
         'file:testRunMerge2.root'
-    )
-    #, processingMode = cms.untracked.string('RunsAndLumis')
-    #, duplicateCheckMode = cms.untracked.string('checkEachRealDataFile')
-    , noEventSort = cms.untracked.bool(True)
-    , inputCommands = cms.untracked.vstring(
+    ]
+    #, processingMode = 'RunsAndLumis'
+    #, duplicateCheckMode = 'checkEachRealDataFile'
+    , noEventSort = True
+    , inputCommands = [
         'keep *',
         'drop edmtestThingWithMerge_makeThingToBeDropped1_*_*'
-    )
+    ]
 )
 
-
-process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
-    verbose = cms.untracked.bool(True)
-    , expectedRunLumiEvents = cms.untracked.vuint32(
+from FWCore.Framework.modules import RunLumiEventAnalyzer
+process.test = RunLumiEventAnalyzer(
+    verbose = True
+    , expectedRunLumiEvents = [
     1, 0, 0,
     1, 1, 0,
     1, 1, 11,
@@ -62,14 +61,15 @@ process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
     1, 1, 21,
     1, 1, 0,
     1, 0, 0
-    )
+    ]
 )
 
 process.looper = cms.Looper("NavigateEventsLooper")
 
-process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('file:testLooperEventNavigation.root'),
-    fastCloning = cms.untracked.bool(False)
+from IOPool.Output.modules import PoolOutputModule
+process.out = PoolOutputModule(
+    fileName = 'testLooperEventNavigation.root',
+    fastCloning = False
 )
 
 process.path1 = cms.Path(process.test)

--- a/FWCore/Integration/test/testLooperEventNavigation_cfg.py
+++ b/FWCore/Integration/test/testLooperEventNavigation_cfg.py
@@ -1,29 +1,28 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
-
-process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.FwkReport.reportEvery = 1000
 process.MessageLogger.cerr.threshold = 'ERROR'
 
-process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring(
+from IOPool.Input.modules import PoolSource
+process.source = PoolSource(
+    fileNames = [
         'file:testRunMerge1.root',
         'file:testRunMerge2.root'
-    )
-    #, processingMode = cms.untracked.string('RunsAndLumis')
-    #, duplicateCheckMode = cms.untracked.string('checkEachRealDataFile')
-    , noEventSort = cms.untracked.bool(False)
-    , inputCommands = cms.untracked.vstring(
+    ]
+    #, processingMode = 'RunsAndLumis'
+    #, duplicateCheckMode = 'checkEachRealDataFile'
+    , noEventSort = False
+    , inputCommands = [
         'keep *',
         'drop edmtestThingWithMerge_makeThingToBeDropped1_*_*'
-    )
+    ]
 )
 
-
-process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
-    verbose = cms.untracked.bool(True)
-    , expectedRunLumiEvents = cms.untracked.vuint32(
+from FWCore.Framework.modules import RunLumiEventAnalyzer
+process.test = RunLumiEventAnalyzer(
+    verbose = True
+    , expectedRunLumiEvents = [
     1, 0, 0,
     1, 1, 0,
     1, 1, 11,
@@ -53,14 +52,15 @@ process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
     1, 1, 21,
     1, 1, 0,
     1, 0, 0
-    )
+    ]
 )
 
 process.looper = cms.Looper("NavigateEventsLooper")
 
-process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('file:testLooperEventNavigation.root'),
-    fastCloning = cms.untracked.bool(False)
+from IOPool.Output.modules import PoolOutputModule
+process.out = PoolOutputModule(
+    fileName = 'testLooperEventNavigation.root',
+    fastCloning = False
 )
 
 process.path1 = cms.Path(process.test)

--- a/FWCore/Integration/test/testRunMergeCOPY1_cfg.py
+++ b/FWCore/Integration/test/testRunMergeCOPY1_cfg.py
@@ -8,8 +8,6 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("COPY")
-
-process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.FwkReport.reportEvery = 1000
 process.MessageLogger.cerr.threshold = 'ERROR'
 
@@ -19,20 +17,21 @@ process.options = cms.untracked.PSet(
   Rethrow = FWCore.Framework.test.cmsExceptionsFatalOption_cff.Rethrow
 )
 
-
-process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring(
+from IOPool.Input.modules import PoolSource
+process.source = PoolSource(
+    fileNames = [
         'file:testRunMergeRecombined.root',
         'file:testRunMergeRecombined.root'
-    )
-    , duplicateCheckMode = cms.untracked.string('checkEachFile')
-    , skipEvents = cms.untracked.uint32(3)
-    , noEventSort = cms.untracked.bool(False)
+    ]
+    , duplicateCheckMode = 'checkEachFile'
+    , skipEvents = 3
+    , noEventSort = False
 )
 
-process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
-    verbose = cms.untracked.bool(True),
-    expectedRunLumiEvents = cms.untracked.vuint32(
+from FWCore.Framework.modules import RunLumiEventAnalyzer
+process.test = RunLumiEventAnalyzer(
+    verbose = True,
+    expectedRunLumiEvents = [
 1, 0, 0,
 1, 1, 0,
 1, 1, 4,
@@ -113,7 +112,7 @@ process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
 1, 1, 10,
 1, 1, 0,
 1, 0, 0
-)
+]
 )
 # At this point the first input file is done and
 # we start with the second input file here.
@@ -205,8 +204,7 @@ process.test.expectedRunLumiEvents.extend([
 
 process.path1 = cms.Path(process.test)
 
-process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('file:testRunMergeRecombinedCopied1.root')
-)
+from IOPool.Output.modules import PoolOutputModule
+process.out = PoolOutputModule(fileName = 'testRunMergeRecombinedCopied1.root')
 
 process.endpath1 = cms.EndPath(process.out)

--- a/FWCore/Integration/test/testRunMergeCOPY_cfg.py
+++ b/FWCore/Integration/test/testRunMergeCOPY_cfg.py
@@ -8,8 +8,6 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("COPY")
-
-process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.FwkReport.reportEvery = 1000
 process.MessageLogger.cerr.threshold = 'ERROR'
 
@@ -19,20 +17,21 @@ process.options = cms.untracked.PSet(
   Rethrow = FWCore.Framework.test.cmsExceptionsFatalOption_cff.Rethrow
 )
 
-
-process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring(
+from IOPool.Input.modules import PoolSource
+process.source = PoolSource(
+    fileNames = [
         'file:testRunMergeRecombined.root',
         'file:testRunMergeRecombined.root'
-    )
-    , duplicateCheckMode = cms.untracked.string('checkAllFilesOpened')
-    , skipEvents = cms.untracked.uint32(14)
-    , noEventSort = cms.untracked.bool(False)
+    ]
+    , duplicateCheckMode = 'checkAllFilesOpened'
+    , skipEvents = 14
+    , noEventSort = False
 )
 
-process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
-    verbose = cms.untracked.bool(True),
-    expectedRunLumiEvents = cms.untracked.vuint32(
+from FWCore.Framework.modules import RunLumiEventAnalyzer
+process.test = RunLumiEventAnalyzer(
+    verbose = True,
+    expectedRunLumiEvents = [
 1, 0, 0,
 1, 1, 0,
 1, 1, 15,
@@ -102,7 +101,7 @@ process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
 1, 1, 10,
 1, 1, 0,
 1, 0, 0
-)
+]
 )
 # At this point the first input file is done and
 # we start with the second input file here.
@@ -141,8 +140,7 @@ process.test.expectedRunLumiEvents.extend([
 
 process.path1 = cms.Path(process.test)
 
-process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('file:testRunMergeRecombinedCopied.root')
-)
+from IOPool.Output.modules import PoolOutputModule
+process.out = PoolOutputModule(fileName = 'testRunMergeRecombinedCopied.root')
 
 process.endpath1 = cms.EndPath(process.out)

--- a/FWCore/Integration/test/testRunMergeMERGE1_cfg.py
+++ b/FWCore/Integration/test/testRunMergeMERGE1_cfg.py
@@ -6,8 +6,6 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("MERGE")
-
-process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.FwkReport.reportEvery = 1000
 process.MessageLogger.cerr.threshold = 'ERROR'
 
@@ -17,35 +15,37 @@ process.options = cms.untracked.PSet(
   Rethrow = FWCore.Framework.test.cmsExceptionsFatalOption_cff.Rethrow
 )
 
-process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring(
+from IOPool.Input.modules import PoolSource
+process.source = PoolSource(
+    fileNames = [
         'file:testRunMerge1.root', 
         'file:testRunMerge2.root', 
         'file:testRunMerge3.root',
         'file:testRunMerge4.root',
         'file:testRunMerge5.root'
-    )
-    , firstRun = cms.untracked.uint32(17)
-    , firstLuminosityBlock = cms.untracked.uint32(3)
-    , firstEvent = cms.untracked.uint32(6)
-    , lumisToSkip = cms.untracked.VLuminosityBlockRange(
-                                           '18:3',
-                                           '19:2',
-                                           '21:4',
-                                           '16:2'
-                                          )
-    , duplicateCheckMode = cms.untracked.string('checkEachRealDataFile')
+    ]
+    , firstRun = 17
+    , firstLuminosityBlock = 3
+    , firstEvent = 6
+    , lumisToSkip = [
+        '18:3',
+        '19:2',
+        '21:4',
+        '16:2'
+    ]
+    , duplicateCheckMode = 'checkEachRealDataFile'
 )
 
-process.thingWithMergeProducer = cms.EDProducer("ThingWithMergeProducer")
+from FWCore.Integration.modules import ThingWithMergeProducer
+process.thingWithMergeProducer = ThingWithMergeProducer()
 
-process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('testRunMerge_a.root')
-)
+from IOPool.Output.modules import PoolOutputModule
+process.out = PoolOutputModule(fileName = 'testRunMerge_a.root')
 
-process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
-    verbose = cms.untracked.bool(True),
-    expectedRunLumiEvents = cms.untracked.vuint32(
+from FWCore.Framework.modules import RunLumiEventAnalyzer
+process.test = RunLumiEventAnalyzer(
+    verbose = True,
+    expectedRunLumiEvents = [
 17, 0, 0,
 17, 3, 0,
 17, 3, 6,
@@ -109,7 +109,7 @@ process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
 21, 3, 6,
 21, 3, 0,
 21, 0, 0
-)
+]
 )
 
 process.path1 = cms.Path(process.thingWithMergeProducer + process.test)

--- a/FWCore/Integration/test/testRunMergeMERGE3_cfg.py
+++ b/FWCore/Integration/test/testRunMergeMERGE3_cfg.py
@@ -5,8 +5,6 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("MERGE")
-
-process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.FwkReport.reportEvery = 1000
 process.MessageLogger.cerr.threshold = 'ERROR'
 
@@ -15,36 +13,38 @@ process.options = cms.untracked.PSet(
   Rethrow = FWCore.Framework.test.cmsExceptionsFatalOption_cff.Rethrow
 )
 
-process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring(
+from IOPool.Input.modules import PoolSource
+process.source = PoolSource(
+    fileNames = [
         'file:testRunMerge1.root', 
         'file:testRunMerge2.root', 
         'file:testRunMerge3.root',
         'file:testRunMerge4.root',
         'file:testRunMerge5.root'
-    )
-    , lumisToProcess = cms.untracked.VLuminosityBlockRange(
-                                           '11:2',
-                                           '15:2-15:8',
-                                           '19:2-20:2',
-                                           '21:4'
-                                          )
-    , eventsToSkip = cms.untracked.VEventRange(
-                                           '19:6-19:8',
-                                           '21:8'
-                                           )
-    , duplicateCheckMode = cms.untracked.string('checkEachRealDataFile')
+    ]
+    , lumisToProcess = [
+        '11:2',
+        '15:2-15:8',
+        '19:2-20:2',
+        '21:4'
+    ]
+    , eventsToSkip = [
+        '19:6-19:8',
+        '21:8'
+    ]
+    , duplicateCheckMode = 'checkEachRealDataFile'
 )
 
-process.thingWithMergeProducer = cms.EDProducer("ThingWithMergeProducer")
+from FWCore.Integration.modules import ThingWithMergeProducer
+process.thingWithMergeProducer = ThingWithMergeProducer()
 
-process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('testRunMergeMERGE3.root')
-)
+from IOPool.Output.modules import PoolOutputModule
+process.out = PoolOutputModule(fileName = 'testRunMergeMERGE3.root')
 
-process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
-    verbose = cms.untracked.bool(True),
-    expectedRunLumiEvents = cms.untracked.vuint32(
+from FWCore.Framework.modules import RunLumiEventAnalyzer
+process.test = RunLumiEventAnalyzer(
+    verbose = True,
+    expectedRunLumiEvents = [
 11, 0, 0,
 11, 2, 0,
 11, 2, 1,
@@ -96,7 +96,7 @@ process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
 21, 4, 9,
 21, 4, 0,
 21, 0, 0
-)
+]
 )
 
 process.path1 = cms.Path(process.thingWithMergeProducer + process.test)

--- a/FWCore/Integration/test/testRunMergeMERGE3x_cfg.py
+++ b/FWCore/Integration/test/testRunMergeMERGE3x_cfg.py
@@ -5,8 +5,6 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("MERGE")
-
-process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.FwkReport.reportEvery = 1000
 process.MessageLogger.cerr.threshold = 'ERROR'
 
@@ -15,32 +13,35 @@ process.options = cms.untracked.PSet(
   Rethrow = FWCore.Framework.test.cmsExceptionsFatalOption_cff.Rethrow
 )
 
-process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring(
+from IOPool.Input.modules import PoolSource
+process.source = PoolSource(
+    fileNames = [
         'file:testRunMerge1.root', 
         'file:testRunMerge2.root', 
         'file:testRunMerge3.root',
         'file:testRunMerge4.root',
         'file:testRunMerge5.root'
-    )
-    , lumisToProcess = cms.untracked.VLuminosityBlockRange(
-                                           '11:2',
-                                           '15:2-15:8',
-                                           '19:2-20:2',
-                                           '21:4'
-                                          )
-    , eventsToSkip = cms.untracked.VEventRange(
-                                           '19:4:6-19:4:8',
-                                           '21:3:8'
-                                           )
-    , duplicateCheckMode = cms.untracked.string('checkEachRealDataFile')
+    ]
+    , lumisToProcess = [
+        '11:2',
+        '15:2-15:8',
+        '19:2-20:2',
+        '21:4'
+    ]
+    , eventsToSkip = [
+        '19:4:6-19:4:8',
+        '21:3:8'
+    ]
+    , duplicateCheckMode = 'checkEachRealDataFile'
 )
 
-process.thingWithMergeProducer = cms.EDProducer("ThingWithMergeProducer")
+from FWCore.Integration.modules import ThingWithMergeProducer
+process.thingWithMergeProducer = ThingWithMergeProducer()
 
-process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
-    verbose = cms.untracked.bool(True),
-    expectedRunLumiEvents = cms.untracked.vuint32(
+from FWCore.Framework.modules import RunLumiEventAnalyzer
+process.test = RunLumiEventAnalyzer(
+    verbose = True,
+    expectedRunLumiEvents = [
 11, 0, 0,
 11, 2, 0,
 11, 2, 1,
@@ -94,7 +95,7 @@ process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
 21, 4, 9,
 21, 4, 0,
 21, 0, 0
-)
+]
 )
 
 process.path1 = cms.Path(process.thingWithMergeProducer + process.test)

--- a/FWCore/Integration/test/testRunMergeNoRunLumiSort_cfg.py
+++ b/FWCore/Integration/test/testRunMergeNoRunLumiSort_cfg.py
@@ -10,18 +10,20 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("NORUNLUMISORT")
 
-process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring(
+from IOPool.Input.modules import PoolSource
+process.source = PoolSource(
+    fileNames = [
         'file:testRunMergeMERGE6.root', 
         'file:testRunMergeMERGE6.root'
-    ),
-    duplicateCheckMode = cms.untracked.string('checkEachRealDataFile'),
-    noRunLumiSort = cms.untracked.bool(True)
+    ],
+    duplicateCheckMode = 'checkEachRealDataFile',
+    noRunLumiSort = True
 )
 
-process.test2 = cms.EDAnalyzer('RunLumiEventAnalyzer',
-    verbose = cms.untracked.bool(True),
-    expectedRunLumiEvents = cms.untracked.vuint32(
+from FWCore.Framework.modules import RunLumiEventAnalyzer
+process.test2 = RunLumiEventAnalyzer(
+    verbose = True,
+    expectedRunLumiEvents = [
 1, 0, 0,
 1, 1, 0,
 1, 1, 11,
@@ -62,7 +64,7 @@ process.test2 = cms.EDAnalyzer('RunLumiEventAnalyzer',
 1, 1, 8,
 1, 1, 9,
 1, 1, 10
-)
+]
 )
 process.test2.expectedRunLumiEvents.extend([
 1, 1, 11,
@@ -107,9 +109,8 @@ process.test2.expectedRunLumiEvents.extend([
 1, 0, 0,
 ])
 
-process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('testRunMergeNoRunLumiSort.root')
-)
+from IOPool.Output.modules import PoolOutputModule
+process.out = PoolOutputModule(fileName = 'testRunMergeNoRunLumiSort.root')
 
 process.path1 = cms.Path(process.test2)
 

--- a/FWCore/Integration/test/testRunMergePickEvents_cfg.py
+++ b/FWCore/Integration/test/testRunMergePickEvents_cfg.py
@@ -7,8 +7,6 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("COPY")
-
-process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.FwkReport.reportEvery = 1000
 process.MessageLogger.cerr.threshold = 'ERROR'
 
@@ -18,20 +16,21 @@ process.options = cms.untracked.PSet(
   Rethrow = FWCore.Framework.test.cmsExceptionsFatalOption_cff.Rethrow
 )
 
-
-process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring(
+from IOPool.Input.modules import PoolSource
+process.source = PoolSource(
+    fileNames = [
         'file:testRunMergeRecombined.root',
         'file:testRunMergeRecombined.root'
-    )
-    #, duplicateCheckMode = cms.untracked.string('checkAllFilesOpened')
-    , skipEvents = cms.untracked.uint32(3)
-    , eventsToProcess = cms.untracked.VEventRange('1:2-1:7')
+    ]
+    #, duplicateCheckMode = 'checkAllFilesOpened'
+    , skipEvents = 3
+    , eventsToProcess = ['1:2-1:7']
 )
 
-process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
-    verbose = cms.untracked.bool(True),
-    expectedRunLumiEvents = cms.untracked.vuint32(
+from FWCore.Framework.modules import RunLumiEventAnalyzer
+process.test = RunLumiEventAnalyzer(
+    verbose = True,
+    expectedRunLumiEvents = [
 1, 0, 0,
 1, 1, 0,
 1, 1, 5,
@@ -39,13 +38,14 @@ process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
 1, 1, 7,
 1, 1, 0,
 1, 0, 0,
-)
+]
 )
 
 process.path1 = cms.Path(process.test)
 
-process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('file:testRunMergePickEvent.root')
+from IOPool.Output.modules import PoolOutputModule
+process.out = PoolOutputModule(
+    fileName = 'testRunMergePickEvent.root'
 )
 
 process.endpath1 = cms.EndPath(process.out)

--- a/FWCore/Integration/test/testRunMergePickEventsx_cfg.py
+++ b/FWCore/Integration/test/testRunMergePickEventsx_cfg.py
@@ -7,8 +7,6 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("COPY")
-
-process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.FwkReport.reportEvery = 1000
 process.MessageLogger.cerr.threshold = 'ERROR'
 
@@ -18,19 +16,20 @@ process.options = cms.untracked.PSet(
   Rethrow = FWCore.Framework.test.cmsExceptionsFatalOption_cff.Rethrow
 )
 
-
-process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring(
+from IOPool.Input.modules import PoolSource
+process.source = PoolSource(
+    fileNames = [
         'file:testRunMergeRecombined.root'
-    )
-    #, duplicateCheckMode = cms.untracked.string('checkAllFilesOpened')
-    , skipEvents = cms.untracked.uint32(3)
-    , eventsToProcess = cms.untracked.VEventRange('1:1:2-1:1:7')
+    ]
+    #, duplicateCheckMode = 'checkAllFilesOpened'
+    , skipEvents = 3
+    , eventsToProcess = ['1:1:2-1:1:7']
 )
 
-process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
-    verbose = cms.untracked.bool(True),
-    expectedRunLumiEvents = cms.untracked.vuint32(
+from FWCore.Framework.modules import RunLumiEventAnalyzer
+process.test = RunLumiEventAnalyzer(
+    verbose = True,
+    expectedRunLumiEvents = [
 1, 0, 0,
 1, 1, 0,
 1, 1, 5,
@@ -38,7 +37,7 @@ process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
 1, 1, 7,
 1, 1, 0,
 1, 0, 0,
-)
+]
 )
 
 process.path1 = cms.Path(process.test)

--- a/FWCore/Integration/test/testRunMergeTEST1_cfg.py
+++ b/FWCore/Integration/test/testRunMergeTEST1_cfg.py
@@ -8,8 +8,6 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
-
-process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.FwkReport.reportEvery = 1000
 process.MessageLogger.cerr.threshold = 'ERROR'
 
@@ -19,29 +17,29 @@ process.options = cms.untracked.PSet(
   Rethrow = FWCore.Framework.test.cmsExceptionsFatalOption_cff.Rethrow
 )
 
-
-process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring(
+from IOPool.Input.modules import PoolSource
+process.source = PoolSource(
+    fileNames = [
         'file:testRunMerge.root',
         'file:testRunMerge.root'
-    ),
-    secondaryFileNames = cms.untracked.vstring(
+    ],
+    secondaryFileNames = [
         'file:testRunMerge1.root', 
         'file:testRunMerge2.root', 
         'file:testRunMerge3.root',
         'file:testRunMerge4.root',
         'file:testRunMerge5.root'
 
-    ),
-    noEventSort = cms.untracked.bool(True)
-    , duplicateCheckMode = cms.untracked.string('checkEachRealDataFile')
+    ],
+    noEventSort = True
+    , duplicateCheckMode = 'checkEachRealDataFile'
 )
 
-process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('file:testRunMergeRecombined1.root')
-)
+from IOPool.Output.modules import PoolOutputModule
+process.out = PoolOutputModule(fileName = 'testRunMergeRecombined1.root')
 
-process.test = cms.EDAnalyzer("TestMergeResults",
+from FWCore.Framework.modules import TestMergeResults, RunLumiEventAnalyzer
+process.test = TestMergeResults(
 
     #   Check to see that the value we read matches what we know
     #   was written. Expected values listed below come in sets of three
@@ -55,25 +53,25 @@ process.test = cms.EDAnalyzer("TestMergeResults",
     #   When the sequence of parameter values is exhausted it stops checking
     #   0's are just placeholders, if the value is a "0" the check is not made.
 
-    expectedBeginRunProd = cms.untracked.vint32(
+    expectedBeginRunProd = [
         10001,   30006,  10003,  # end run 1
         10001,   10002,  10003,  # end run 2
         10001,   20004,  10003,  # end run 11
         10001,   30006,  10003,  # end run 1
         10001,   10002,  10003,  # end run 2
         10001,   20004,  10003   # end run 11
-    ),
+    ],
 
-    expectedEndRunProd = cms.untracked.vint32(
+    expectedEndRunProd = [
         100001, 300006, 100003,  # end run 1
         100001, 100002, 100003,  # end run 2
         100001, 200004, 100003,  # end run 11
         100001, 300006, 100003,  # end run 1
         100001, 100002, 100003,  # end run 2
         100001, 200004, 100003   # end run 11
-    ),
+    ],
 
-    expectedBeginLumiProd = cms.untracked.vint32(
+    expectedBeginLumiProd = [
         101,       306,    103,  # end run 1 lumi 1
         101,       102,    103,  # end run 2 lumi 1
         101,       102,    103,  # end run 11 lumi 1
@@ -82,9 +80,9 @@ process.test = cms.EDAnalyzer("TestMergeResults",
         101,       102,    103,  # end run 2 lumi 1
         101,       102,    103,  # end run 11 lumi 1
         101,       102,    103   # end run 11 lumi 2
-    ),
+    ],
 
-    expectedEndLumiProd = cms.untracked.vint32(
+    expectedEndLumiProd = [
         1001,     3006,   1003,  # end run 1 lumi 1
         1001,     1002,   1003,  # end run 2 lumi 1
         1001,     1002,   1003,  # end run 11 lumi 1
@@ -93,27 +91,27 @@ process.test = cms.EDAnalyzer("TestMergeResults",
         1001,     1002,   1003,  # end run 2 lumi 1
         1001,     1002,   1003,  # end run 11 lumi 1
         1001,     1002,   1003   # end run 11 lumi 2
-    ),
+    ],
 
-    expectedBeginRunNew = cms.untracked.vint32(
+    expectedBeginRunNew = [
         10001,   20004,  10003,  # end run 1
         10001,   10002,  10003,  # end run 2
         10001,   10002,  10003,  # end run 11
         10001,   20004,  10003,  # end run 1
         10001,   10002,  10003,  # end run 2
         10001,   10002,  10003   # end run 11
-    ),
+    ],
 
-    expectedEndRunNew = cms.untracked.vint32(
+    expectedEndRunNew = [
         100001, 200004, 100003,  # end run 1
         100001, 100002, 100003,  # end run 2
         100001, 100002, 100003,  # end run 11
         100001, 200004, 100003,  # end run 1
         100001, 100002, 100003,  # end run 2
         100001, 100002, 100003   # end run 11
-    ),
+    ],
 
-    expectedBeginLumiNew = cms.untracked.vint32(
+    expectedBeginLumiNew = [
         101,       204,    103,  # end run 1 lumi 1
         101,       102,    103,  # end run 2 lumi 1
         101,       102,    103,  # end run 11 lumi 1
@@ -122,9 +120,9 @@ process.test = cms.EDAnalyzer("TestMergeResults",
         101,       102,    103,  # end run 2 lumi 1
         101,       102,    103,  # end run 11 lumi 1
         101,       102,    103   # end run 11 lumi 2
-    ),
+    ],
 
-    expectedEndLumiNew = cms.untracked.vint32(
+    expectedEndLumiNew = [
         1001,     2004,   1003,  # end run 1 lumi 1
         1001,     1002,   1003,  # end run 2 lumi 1
         1001,     1002,   1003,  # end run 11 lumi 1
@@ -133,12 +131,12 @@ process.test = cms.EDAnalyzer("TestMergeResults",
         1001,     1002,   1003,  # end run 2 lumi 1
         1001,     1002,   1003,  # end run 11 lumi 1
         1001,     1002,   1003   # end run 11 lumi 2
-    ),
+    ],
 
-    expectedDroppedEvent = cms.untracked.vint32(13, 10003, 100003, 103, 1003),
-    verbose = cms.untracked.bool(False),
+    expectedDroppedEvent = [13, 10003, 100003, 103, 1003],
+    verbose = False,
 
-    expectedParents = cms.untracked.vstring(
+    expectedParents = [
         'm1', 'm1', 'm1', 'm1', 'm1',
         'm1', 'm1', 'm1', 'm1', 'm1',
         'm2', 'm2', 'm2', 'm2', 'm2',
@@ -153,12 +151,12 @@ process.test = cms.EDAnalyzer("TestMergeResults",
         'm3', 'm3', 'm3', 'm3', 'm3',
         'm2', 'm2', 'm2', 'm2', 'm2',
         'm1', 'm1'
-   )
+   ]
 )
 
-process.test2 = cms.EDAnalyzer('RunLumiEventAnalyzer',
-    verbose = cms.untracked.bool(True),
-    expectedRunLumiEvents = cms.untracked.vuint32(
+process.test2 = RunLumiEventAnalyzer(
+    verbose = True,
+    expectedRunLumiEvents = [
 1, 0, 0,
 1, 1, 0,
 1, 1, 11,
@@ -243,7 +241,7 @@ process.test2 = cms.EDAnalyzer('RunLumiEventAnalyzer',
 2, 1, 5,
 2, 1, 0,
 2, 0, 0
-)
+]
 )
 
 process.path1 = cms.Path(process.test + process.test2)

--- a/FWCore/Integration/test/testRunMergeTEST2_cfg.py
+++ b/FWCore/Integration/test/testRunMergeTEST2_cfg.py
@@ -6,8 +6,6 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
-
-process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.FwkReport.reportEvery = 1000
 process.MessageLogger.cerr.threshold = 'ERROR'
 
@@ -17,20 +15,13 @@ process.options = cms.untracked.PSet(
   Rethrow = FWCore.Framework.test.cmsExceptionsFatalOption_cff.Rethrow
 )
 
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(10)
-)
+process.maxEvents.input = 10
 
+from IOPool.Input.modules import PoolSource
+process.source = PoolSource(fileNames = ['file:testRunMerge4.root', 'file:testRunMerge6.root'])
 
-process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring(
-        'file:testRunMerge4.root',
-        'file:testRunMerge6.root'
-    )
-)
-
-process.test = cms.EDAnalyzer("TestMergeResults",
-
+from FWCore.Framework.modules import TestMergeResults, RunLumiEventAnalyzer
+process.test = TestMergeResults(
     #   Check to see that the value we read matches what we know
     #   was written. Expected values listed below come in sets of three
     #      value expected in Thing
@@ -43,33 +34,32 @@ process.test = cms.EDAnalyzer("TestMergeResults",
     #   When the sequence of parameter values is exhausted it stops checking
     #   0's are just placeholders, if the value is a "0" the check is not made.
 
-    expectedBeginRunProd = cms.untracked.vint32(
+    expectedBeginRunProd = [
         10001,   20004,  10003  # end run 11
-    ),
+    ],
 
-    expectedEndRunProd = cms.untracked.vint32(
+    expectedEndRunProd = [
         100001,   200004,  100003  #end run 11
-    ),
+    ],
 
-    expectedBeginLumiProd = cms.untracked.vint32(
+    expectedBeginLumiProd = [
         101,       102,    103,  # end run 11 lumi 1
         101,       102,    103,  # end run 11 lumi 2
         101,       102,    103   # end run 11 lumi 3
-    ),
+    ],
 
-    expectedEndLumiProd = cms.untracked.vint32(
+    expectedEndLumiProd = [
          1001,       1002,    1003,  # end run 11 lumi 1
          1001,       1002,    1003,  # end run 11 lumi 2
          1001,       1002,    1003   # end run 11 lumi 3
-    ),
+    ],
 
-    verbose = cms.untracked.bool(False)
-
+    verbose = False
 )
 
-process.test2 = cms.EDAnalyzer('RunLumiEventAnalyzer',
-    verbose = cms.untracked.bool(True),
-    expectedRunLumiEvents = cms.untracked.vuint32(
+process.test2 = RunLumiEventAnalyzer(
+    verbose = True,
+    expectedRunLumiEvents = [
 11, 0, 0,
 11, 1, 0,
 11, 1, 1,
@@ -90,7 +80,7 @@ process.test2 = cms.EDAnalyzer('RunLumiEventAnalyzer',
 11, 4, 10,
 11, 4, 0,
 11, 0, 0
-)
+]
 )
 
 process.path1 = cms.Path(process.test + process.test2)

--- a/FWCore/Integration/test/testRunMergeTEST3_cfg.py
+++ b/FWCore/Integration/test/testRunMergeTEST3_cfg.py
@@ -1,8 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
-
-process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.FwkReport.reportEvery = 1000
 process.MessageLogger.cerr.threshold = 'ERROR'
 
@@ -12,34 +10,33 @@ process.options = cms.untracked.PSet(
   Rethrow = FWCore.Framework.test.cmsExceptionsFatalOption_cff.Rethrow
 )
 
-
-process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring(
+from IOPool.Input.modules import PoolSource
+process.source = PoolSource(
+    fileNames = [
         # CAUTION if you recreate the PROD files then you must recreate BOTH
         # of these files otherwise you will get exceptions because the GUIDs
         # used to check the match of the event in the secondary files will
         # not be the same.
         'file:testRunMergeMERGE2.root',
         'file:testRunMerge.root'
-    ),
-    secondaryFileNames = cms.untracked.vstring(
+    ],
+    secondaryFileNames = [
         'file:testRunMerge0.root', 
         'file:testRunMerge1.root', 
         'file:testRunMerge2.root', 
         'file:testRunMerge3.root',
         'file:testRunMerge4.root',
         'file:testRunMerge5.root'
-    )
-    , duplicateCheckMode = cms.untracked.string('checkEachRealDataFile')
-    , noEventSort = cms.untracked.bool(True)
+    ]
+    , duplicateCheckMode = 'checkEachRealDataFile'
+    , noEventSort = True
 )
 
-process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('file:testRunMergeRecombined2.root')
-)
+from IOPool.Output.modules import PoolOutputModule
+process.out = PoolOutputModule(fileName = 'testRunMergeRecombined2.root')
 
-process.test = cms.EDAnalyzer("TestMergeResults",
-
+from FWCore.Framework.modules import TestMergeResults, RunLumiEventAnalyzer
+process.test = TestMergeResults(
     #   Check to see that the value we read matches what we know
     #   was written. Expected values listed below come in sets of three
     #      value expected in Thing
@@ -52,7 +49,7 @@ process.test = cms.EDAnalyzer("TestMergeResults",
     #   When the sequence of parameter values is exhausted it stops checking
     #   0's are just placeholders, if the value is a "0" the check is not made.
 
-    expectedBeginRunProd = cms.untracked.vint32(
+    expectedBeginRunProd = [
     10001,   10002,  10003,  # end run 100
     10001,   10002,  10003,  # end run 1
     10001,   10002,  10003,  # end run 1
@@ -62,9 +59,9 @@ process.test = cms.EDAnalyzer("TestMergeResults",
     10001,   30006,  10003,  # end run 1
     10001,   10002,  10003,  # end run 2
     10001,   20004,  10003   # end run 11
-    ),
+    ],
 
-    expectedEndRunProd = cms.untracked.vint32(
+    expectedEndRunProd = [
         100001,  100002, 100003,  # end run 100
         100001,  100002, 100003,  # end run 1
         100001,  100002, 100003,  # end run 1
@@ -74,9 +71,9 @@ process.test = cms.EDAnalyzer("TestMergeResults",
         100001,  300006, 100003,  # end run 1
         100001,  100002, 100003,  # end run 2
         100001,  200004, 100003   # end run 11
-    ),
+    ],
 
-    expectedBeginLumiProd = cms.untracked.vint32(
+    expectedBeginLumiProd = [
         101,  102, 103,  # end run 100 lumi 100
         101,  102, 103,  # end run 1 lumi 1
         101,  102, 103,  # end run 1 lumi 1
@@ -88,10 +85,9 @@ process.test = cms.EDAnalyzer("TestMergeResults",
         101,  102, 103,  # end run 2 lumi 1
         101,  102, 103,  # end run 11 lumi 1
         101,  102, 103   # end run 11 lumi 2
-        
-    ),
+    ],
 
-    expectedEndLumiProd = cms.untracked.vint32(
+    expectedEndLumiProd = [
         1001,  1002, 1003,  # end run 100 lumi 100
         1001,  1002, 1003,  # end run 1 lumi 1
         1001,  1002, 1003,  # end run 1 lumi 1
@@ -103,9 +99,9 @@ process.test = cms.EDAnalyzer("TestMergeResults",
         1001,  1002, 1003,  # end run 2 lumi 1
         1001,  1002, 1003,  # end run 11 lumi 1
         1001,  1002, 1003   # end run 11 lumi 2
-    ),
+    ],
 
-    expectedBeginRunNew = cms.untracked.vint32(
+    expectedBeginRunNew = [
         10001,   10002,  10003,  # end run 100
         10001,   10002,  10003,  # end run 1
         10001,   10002,  10003,  # end run 1
@@ -115,9 +111,9 @@ process.test = cms.EDAnalyzer("TestMergeResults",
         10001,   20004,  10003,  # end run 1
         10001,   10002,  10003,  # end run 2
         10001,   10002,  10003   # end run 11
-    ),
+    ],
 
-    expectedEndRunNew = cms.untracked.vint32(
+    expectedEndRunNew = [
         100001,  100002, 100003,  # end run 100
         100001,  100002, 100003,  # end run 1
         100001,  100002, 100003,  # end run 1
@@ -127,9 +123,9 @@ process.test = cms.EDAnalyzer("TestMergeResults",
         100001,  200004, 100003,  # end run 1
         100001,  100002, 100003,  # end run 2
         100001,  100002, 100003   # end run 11
-    ),
+    ],
 
-    expectedBeginLumiNew = cms.untracked.vint32(
+    expectedBeginLumiNew = [
         101,  102, 103,  # end run 100 lumi 100
         101,  102, 103,  # end run 1 lumi 1
         101,  102, 103,  # end run 1 lumi 1
@@ -141,9 +137,9 @@ process.test = cms.EDAnalyzer("TestMergeResults",
         101,  102, 103,  # end run 2 lumi 1
         101,  102, 103,  # end run 11 lumi 1
         101,  102, 103   # end run 11 lumi 2
-    ),
+    ],
 
-    expectedEndLumiNew = cms.untracked.vint32(
+    expectedEndLumiNew = [
         1001,  1002, 1003,  # end run 100 lumi 100
         1001,  1002, 1003,  # end run 1 lumi 1
         1001,  1002, 1003,  # end run 1 lumi 1
@@ -155,12 +151,12 @@ process.test = cms.EDAnalyzer("TestMergeResults",
         1001,  1002, 1003,  # end run 2 lumi 1
         1001,  1002, 1003,  # end run 11 lumi 1
         1001,  1002, 1003   # end run 11 lumi 2
-    ),
+    ],
 
-    expectedDroppedEvent = cms.untracked.vint32(13, 10003, 100003, 103, 1003),
-    verbose = cms.untracked.bool(True),
+    expectedDroppedEvent = [13, 10003, 100003, 103, 1003],
+    verbose = True,
 
-    expectedParents = cms.untracked.vstring(
+    expectedParents = [
     'm1', #(100,100,100)
     'm1', 'm1', 'm1', 'm1', 'm1',
     'm1', 'm1', 'm1', 'm1', 'm1',
@@ -177,13 +173,12 @@ process.test = cms.EDAnalyzer("TestMergeResults",
     'm3', 'm3', 'm3', 'm3', 'm3',
     'm2', 'm2', 'm2', 'm2', 'm2',
     'm1', 'm1'
-
-   )
+    ]
 )
 
-process.test2 = cms.EDAnalyzer('RunLumiEventAnalyzer',
-    verbose = cms.untracked.bool(True),
-    expectedRunLumiEvents = cms.untracked.vuint32(
+process.test2 = RunLumiEventAnalyzer(
+    verbose = True,
+    expectedRunLumiEvents = [
     100, 0, 0,
     100, 100, 0,
     100, 100, 100,
@@ -243,7 +238,7 @@ process.test2 = cms.EDAnalyzer('RunLumiEventAnalyzer',
     11, 2, 1,
     11, 2, 0,
     11, 0, 0
-)
+]
 )
 process.test2.expectedRunLumiEvents.extend([
 1, 0, 0,

--- a/FWCore/Integration/test/testRunMergeTEST4_cfg.py
+++ b/FWCore/Integration/test/testRunMergeTEST4_cfg.py
@@ -1,8 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
-
-process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.FwkReport.reportEvery = 1000
 process.MessageLogger.cerr.threshold = 'ERROR'
 
@@ -12,23 +10,22 @@ process.options = cms.untracked.PSet(
   Rethrow = FWCore.Framework.test.cmsExceptionsFatalOption_cff.Rethrow
 )
 
-
-process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring(
+from IOPool.Input.modules import PoolSource
+process.source = PoolSource(
+    fileNames = [
         'file:testRunMergeMERGE4.root',
         'file:testRunMergeMERGE4.root'
-    )
-    , duplicateCheckMode = cms.untracked.string('checkEachRealDataFile')
-    , noEventSort = cms.untracked.bool(True)
-    , lumisToProcess = cms.untracked.VLuminosityBlockRange('1:1')
+    ]
+    , duplicateCheckMode = 'checkEachRealDataFile'
+    , noEventSort = True
+    , lumisToProcess = ['1:1']
 )
 
-process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('file:testRunMergeRecombined4.root')
-)
+from IOPool.Output.modules import PoolOutputModule
+process.out = PoolOutputModule(fileName = 'testRunMergeRecombined4.root')
 
-process.test = cms.EDAnalyzer("TestMergeResults",
-
+from FWCore.Framework.modules import TestMergeResults, RunLumiEventAnalyzer
+process.test = TestMergeResults(
     #   Check to see that the value we read matches what we know
     #   was written. Expected values listed below come in sets of three
     #      value expected in Thing
@@ -41,44 +38,44 @@ process.test = cms.EDAnalyzer("TestMergeResults",
     #   When the sequence of parameter values is exhausted it stops checking
     #   0's are just placeholders, if the value is a "0" the check is not made.
 
-    expectedBeginRunProd = cms.untracked.vint32(
+    expectedBeginRunProd = [
         10001,   80016,  10003   # end run 1
-    ),
+    ],
 
-    expectedEndRunProd = cms.untracked.vint32(
+    expectedEndRunProd = [
         100001,  800016, 100003   # end run 1
-    ),
+    ],
 
-    expectedBeginLumiProd = cms.untracked.vint32(
+    expectedBeginLumiProd = [
         101,  816, 103  # end run 1 lumi 1
-    ),
+    ],
 
-    expectedEndLumiProd = cms.untracked.vint32(
+    expectedEndLumiProd = [
         1001,  8016, 1003   # end run 1 lumi 1
-    ),
+    ],
 
-    expectedBeginRunNew = cms.untracked.vint32(
+    expectedBeginRunNew = [
         10001,   60012,  10003   # end run 1
-    ),
+    ],
 
-    expectedEndRunNew = cms.untracked.vint32(
+    expectedEndRunNew = [
         100001,  600012, 100003   # end run 1
-    ),
+    ],
 
-    expectedBeginLumiNew = cms.untracked.vint32(
+    expectedBeginLumiNew = [
         101,  612, 103   # end run 1 lumi 1
-    ),
+    ],
 
-    expectedEndLumiNew = cms.untracked.vint32(
+    expectedEndLumiNew = [
         1001,  6012, 1003   # end run 1 lumi 1
-    ),
+    ],
 
-    verbose = cms.untracked.bool(True)
+    verbose = True
 )
 
-process.test2 = cms.EDAnalyzer('RunLumiEventAnalyzer',
-    verbose = cms.untracked.bool(True),
-    expectedRunLumiEvents = cms.untracked.vuint32(
+process.test2 = RunLumiEventAnalyzer(
+    verbose = True,
+    expectedRunLumiEvents = [
 1, 0, 0,
 1, 1, 0,
 1, 1, 11,
@@ -135,7 +132,7 @@ process.test2 = cms.EDAnalyzer('RunLumiEventAnalyzer',
 1, 1, 26,
 1, 1, 0,
 1, 0, 0
-)
+]
 )
 
 process.path1 = cms.Path(process.test + process.test2)

--- a/FWCore/Integration/test/testRunMergeTEST6_cfg.py
+++ b/FWCore/Integration/test/testRunMergeTEST6_cfg.py
@@ -13,15 +13,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring(
-        'file:testRunMergeNoRunLumiSort.root'
-    ),
-    duplicateCheckMode = cms.untracked.string('noDuplicateCheck')
+from IOPool.Input.modules import PoolSource
+process.source = PoolSource(
+    fileNames = 'file:testRunMergeNoRunLumiSort.root',
+    duplicateCheckMode = 'noDuplicateCheck'
 )
 
-process.test = cms.EDAnalyzer("TestMergeResults",
-                            
+from FWCore.Framework.modules import TestMergeResults, RunLumiEventAnalyzer
+process.test = TestMergeResults(
     #   Check to see that the value we read matches what we know
     #   was written. Expected values listed below come in sets of three
     #      value expected in Thing
@@ -34,50 +33,50 @@ process.test = cms.EDAnalyzer("TestMergeResults",
     #   When the sequence of parameter values is exhausted it stops checking
     #   0's are just placeholders, if the value is a "0" the check is not made.
 
-    expectedBeginRunProd = cms.untracked.vint32(
+    expectedBeginRunProd = [
         0,   60012,  10003,
         0,   20004,  10003
-    ),
+    ],
                             
-    expectedEndRunProd = cms.untracked.vint32(
+    expectedEndRunProd = [
         0, 600012, 100003,
         0, 200004, 100003
-    ),
+    ],
 
-    expectedBeginLumiProd = cms.untracked.vint32(
+    expectedBeginLumiProd = [
         0,       612,    103,
         0,       204,    103
-    ),
+    ],
 
-    expectedEndLumiProd = cms.untracked.vint32(
+    expectedEndLumiProd = [
         0,     6012,   1003,
         0,     2004,   1003
-    ),
+    ],
 
-    expectedBeginRunNew = cms.untracked.vint32(
+    expectedBeginRunNew = [
         10001,   40008,  10003,
         10001,   20004,  10003
-    ),
+    ],
 
-    expectedEndRunNew = cms.untracked.vint32(
+    expectedEndRunNew = [
         100001, 400008, 100003,
         100001, 200004, 100003
-    ),
+    ],
 
-    expectedBeginLumiNew = cms.untracked.vint32(
+    expectedBeginLumiNew = [
         101,       408,    103,
         101,       204,    103
-    ),
+    ],
 
-    expectedEndLumiNew = cms.untracked.vint32(
+    expectedEndLumiNew = [
         1001,     4008,   1003,
         1001,     2004,   1003
-    )
+    ]
 )
 
-process.test2 = cms.EDAnalyzer('RunLumiEventAnalyzer',
-    verbose = cms.untracked.bool(True),
-    expectedRunLumiEvents = cms.untracked.vuint32(
+process.test2 = RunLumiEventAnalyzer(
+    verbose = True,
+    expectedRunLumiEvents = [
 1, 0, 0,
 1, 1, 0,
 1, 1, 11,
@@ -132,7 +131,7 @@ process.test2 = cms.EDAnalyzer('RunLumiEventAnalyzer',
 1, 1, 10,
 1, 1, 0,
 1, 0, 0
-)
+]
 )
 process.test2.expectedRunLumiEvents.extend([
 2, 0, 0,
@@ -151,9 +150,8 @@ process.test2.expectedRunLumiEvents.extend([
 2, 0, 0
 ])
 
-process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('testRunMergeTEST6.root')
-)
+from IOPool.Output.modules import PoolOutputModule
+process.out = PoolOutputModule(fileName = 'testRunMergeTEST6.root')
 
 process.path1 = cms.Path(process.test * process.test2)
 process.e = cms.EndPath(process.out)

--- a/FWCore/Integration/test/testRunMergeTEST_cfg.py
+++ b/FWCore/Integration/test/testRunMergeTEST_cfg.py
@@ -1,8 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
-
-process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.FwkReport.reportEvery = 1000
 process.MessageLogger.cerr.threshold = 'ERROR'
 
@@ -12,34 +10,33 @@ process.options = cms.untracked.PSet(
   Rethrow = FWCore.Framework.test.cmsExceptionsFatalOption_cff.Rethrow
 )
 
-
-process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring(
+from IOPool.Input.modules import PoolSource
+process.source = PoolSource(
+    fileNames = [
         # CAUTION if you recreate the PROD files then you must recreate BOTH
         # of these files otherwise you will get exceptions because the GUIDs
         # used to check the match of the event in the secondary files will
         # not be the same.
         'file:testRunMerge.root',
         'file:testRunMergeMERGE2.root'
-    ),
-    secondaryFileNames = cms.untracked.vstring(
+    ],
+    secondaryFileNames = [
         'file:testRunMerge0.root', 
         'file:testRunMerge1.root', 
         'file:testRunMerge2.root', 
         'file:testRunMerge3.root',
         'file:testRunMerge4.root',
         'file:testRunMerge5.root'
-    )
-    , duplicateCheckMode = cms.untracked.string('checkEachRealDataFile')
-    , noEventSort = cms.untracked.bool(False)
+    ]
+    , duplicateCheckMode = 'checkEachRealDataFile'
+    , noEventSort = False
 )
 
-process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('file:testRunMergeRecombined.root')
-)
+from IOPool.Output.modules import PoolOutputModule
+process.out = PoolOutputModule(fileName = 'testRunMergeRecombined.root')
 
-process.test = cms.EDAnalyzer("TestMergeResults",
-
+from FWCore.Framework.modules import TestMergeResults, RunLumiEventAnalyzer
+process.test = TestMergeResults(
     #   Check to see that the value we read matches what we know
     #   was written. Expected values listed below come in sets of three
     #      value expected in Thing
@@ -52,7 +49,7 @@ process.test = cms.EDAnalyzer("TestMergeResults",
     #   When the sequence of parameter values is exhausted it stops checking
     #   0's are just placeholders, if the value is a "0" the check is not made.
 
-    expectedBeginRunProd = cms.untracked.vint32(
+    expectedBeginRunProd = [
         10001,   30006,  10003,  # end run 1, merged run entries within a file
         10001,   10002,  10003,  # end run 2
         10001,   20004,  10003,  # end run 11
@@ -62,9 +59,9 @@ process.test = cms.EDAnalyzer("TestMergeResults",
         10001,   10002,  10003,  # end run 1, not merged different ProcessHistoryID
         10001,   10002,  10003,  # end run 2
         10001,   10002,  10004   # end run 1
-    ),
+    ],
 
-    expectedEndRunProd = cms.untracked.vint32(
+    expectedEndRunProd = [
         100001,  300006, 100003,  # end run 1
         100001,  100002, 100003,  # end run 2
         100001,  200004, 100003,  # end run 11
@@ -74,9 +71,9 @@ process.test = cms.EDAnalyzer("TestMergeResults",
         100001,  100002, 100003,  # end run 1
         100001,  100002, 100003,  # end run 2
         100001,  100002, 100004   # end run 1
-    ),
+    ],
 
-    expectedBeginLumiProd = cms.untracked.vint32(
+    expectedBeginLumiProd = [
         101,  306, 103,  # end run 1 lumi 1
         101,  102, 103,  # end run 2 lumi 1
         101,  102, 103,  # end run 11 lumi 1
@@ -88,9 +85,9 @@ process.test = cms.EDAnalyzer("TestMergeResults",
         101,  102, 103,  # end run 1 lumi 1
         101,  102, 103,  # end run 2 lumi 1
         101,  102, 104   # end run 1 lumi 1
-    ),
+    ],
 
-    expectedEndLumiProd = cms.untracked.vint32(
+    expectedEndLumiProd = [
         1001,  3006, 1003,  # end run 1 lumi 1
         1001,  1002, 1003,  # end run 2 lumi 1
         1001,  1002, 1003,  # end run 11 lumi 1
@@ -102,9 +99,9 @@ process.test = cms.EDAnalyzer("TestMergeResults",
         1001,  1002, 1003,  # end run 1 lumi 1
         1001,  1002, 1003,  # end run 2 lumi 1
         1001,  1002, 1004   # end run 1 lumi 1
-    ),
+    ],
 
-    expectedBeginRunNew = cms.untracked.vint32(
+    expectedBeginRunNew = [
         10001,   20004,  10003,  # end run 1
         10001,   10002,  10003,  # end run 2
         10001,   10002,  10003,  # end run 11
@@ -114,9 +111,9 @@ process.test = cms.EDAnalyzer("TestMergeResults",
         10001,   10002,  10003,  # end run 1
         10001,   10002,  10003,  # end run 2
         10001,   10002,  10003   # end run 1
-    ),
+    ],
 
-    expectedEndRunNew = cms.untracked.vint32(
+    expectedEndRunNew = [
         100001,  200004, 100003,  # end run 1
         100001,  100002, 100003,  # end run 2
         100001,  100002, 100003,  # end run 11
@@ -126,9 +123,9 @@ process.test = cms.EDAnalyzer("TestMergeResults",
         100001,  100002, 100003,  # end run 1
         100001,  100002, 100003,  # end run 2
         100001,  100002, 100003   # end run 1
-    ),
+    ],
 
-    expectedBeginLumiNew = cms.untracked.vint32(
+    expectedBeginLumiNew = [
         101,  204, 103,  # end run 1 lumi 1
         101,  102, 103,  # end run 2 lumi 1
         101,  102, 103,  # end run 11 lumi 1
@@ -140,9 +137,9 @@ process.test = cms.EDAnalyzer("TestMergeResults",
         101,  102, 103,  # end run 1 lumi 1
         101,  102, 103,  # end run 2 lumi 1
         101,  102, 103   # end run 1 lumi 1
-    ),
+    ],
 
-    expectedEndLumiNew = cms.untracked.vint32(
+    expectedEndLumiNew = [
         1001,  2004, 1003,  # end run 1 lumi 1
         1001,  1002, 1003,  # end run 2 lumi 1
         1001,  1002, 1003,  # end run 11 lumi 1
@@ -154,12 +151,12 @@ process.test = cms.EDAnalyzer("TestMergeResults",
         1001,  1002, 1003,  # end run 1 lumi 1
         1001,  1002, 1003,  # end run 2 lumi 1
         1001,  1002, 1003   # end run 1 lumi 1
-    ),
+    ],
 
-    expectedDroppedEvent = cms.untracked.vint32(13, 10003, 100003, 103, 1003),
-    verbose = cms.untracked.bool(True),
+    expectedDroppedEvent = [13, 10003, 100003, 103, 1003],
+    verbose = True,
 
-    expectedParents = cms.untracked.vstring(
+    expectedParents = [
         'm3', 'm3', 'm3', 'm3', 'm3',
         'm3', 'm3', 'm3', 'm3', 'm3',
         'm1', 'm1', 'm1', 'm1', 'm1',
@@ -175,13 +172,13 @@ process.test = cms.EDAnalyzer("TestMergeResults",
         'm2', 'm2', 'm2', 'm2', 'm2',
         'm3', 'm3', 'm3', 'm3', 'm3',
         'm3', 'm3', 'm3', 'm3', 'm3'
-   ),
-   testAlias = cms.untracked.bool(True)
+   ],
+   testAlias = True
 )
 
-process.test2 = cms.EDAnalyzer('RunLumiEventAnalyzer',
-    verbose = cms.untracked.bool(True),
-    expectedRunLumiEvents = cms.untracked.vuint32(
+process.test2 = RunLumiEventAnalyzer(
+    verbose = True,
+    expectedRunLumiEvents = [
 1, 0, 0,
 1, 1, 0,
 1, 1, 1,
@@ -255,7 +252,7 @@ process.test2 = cms.EDAnalyzer('RunLumiEventAnalyzer',
 100, 100, 100,
 100, 100, 0,
 100, 0, 0
-)
+]
 )
 process.test2.expectedRunLumiEvents.extend([
 1, 0, 0,

--- a/IOPool/Common/test/ReadFastMergeTestOutput_cfg.py
+++ b/IOPool/Common/test/ReadFastMergeTestOutput_cfg.py
@@ -3,31 +3,27 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("READTESTMERGE")
 process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
 
-process.AdaptorConfig = cms.Service("AdaptorConfig",
-    stats = cms.untracked.bool(False)
-)
+from IOPool.TFileAdaptor.modules import AdaptorConfig
+process.add_(AdaptorConfig(stats = False))
 
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(-1)
-)
+process.maxEvents.input = -1
 
-process.output = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string(
-      'file:ReadFastMerge_out.root'
-    )
-)
+from IOPool.Output.modules import PoolOutputModule
+process.output = PoolOutputModule(fileName = 'ReadFastMerge_out.root')
 
-process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring(
+from IOPool.Input.modules import PoolSource
+process.source = PoolSource(
+    fileNames = [
       'file:FastMerge_out.root',
       'file:FastMergeRL_out.root',
       'file:FastMergeR_out.root',
-    )
+    ]
 )
 
-process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
-    verbose = cms.untracked.bool(True),
-    expectedRunLumiEvents = cms.untracked.vuint32(
+from FWCore.Framework.modules import RunLumiEventAnalyzer
+process.test = RunLumiEventAnalyzer(
+    verbose = True,
+    expectedRunLumiEvents = [
 100, 0, 0,
 100, 1, 0,
 100, 1, 1,
@@ -73,7 +69,7 @@ process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
 100, 0, 0,
 200, 0, 0,
 200, 0, 0
-)
+]
 )
 
 process.path1 = cms.Path(process.test)

--- a/IOPool/Input/test/test_complex_before_3_8_0_cfg.py
+++ b/IOPool/Input/test/test_complex_before_3_8_0_cfg.py
@@ -4,27 +4,21 @@ import sys
 process = cms.Process("READMERGE")
 process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
 
-process.AdaptorConfig = cms.Service("AdaptorConfig",
-    stats = cms.untracked.bool(False)
-)
+from IOPool.TFileAdaptor.modules import AdaptorConfig
+process.add_(AdaptorConfig(stats = False))
 
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(-1)
-)
+process.maxEvents.input = -1
 
-process.output = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string(
-      'file:ReadMerge_out.root'
-    )
-)
+from IOPool.Output.modules import PoolOutputModule
+process.output = PoolOutputModule(fileName = 'ReadMerge_out.root')
 
-process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring("file:"+sys.argv[1])
-)
+from IOPool.Input.modules import PoolSource
+process.source = PoolSource(fileNames = [f"file:{sys.argv[1]}"])
 
-process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
-    verbose = cms.untracked.bool(True),
-    expectedRunLumiEvents = cms.untracked.vuint32(
+from FWCore.Framework.modules import RunLumiEventAnalyzer
+process.test = RunLumiEventAnalyzer(
+    verbose = True,
+    expectedRunLumiEvents = [
 100,   0,   0,
 100, 100,   0,
 100, 100, 100,
@@ -75,7 +69,7 @@ process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
   2,   1,   5,
   2,   1,   0,
   2,   0,   0
-)
+]
 )
 
 process.test.expectedRunLumiEvents.extend([

--- a/IOPool/Input/test/test_complex_old_formats_cfg.py
+++ b/IOPool/Input/test/test_complex_old_formats_cfg.py
@@ -4,27 +4,21 @@ import sys
 process = cms.Process("READMERGE")
 process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
 
-process.AdaptorConfig = cms.Service("AdaptorConfig",
-    stats = cms.untracked.bool(False)
-)
+from IOPool.TFileAdaptor.modules import AdaptorConfig
+process.add_(AdaptorConfig(stats = False))
 
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(-1)
-)
+process.maxEvents.input = -1
 
-process.output = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string(
-      'file:ReadMerge_out.root'
-    )
-)
+from IOPool.Output.modules import PoolOutputModule
+process.output = PoolOutputModule(fileName = 'ReadMerge_out.root')
 
-process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring("file:"+sys.argv[1])
-)
+from IOPool.Input.modules import PoolSource
+process.source = PoolSource(fileNames = [f"file:{sys.argv[1]}"])
 
-process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
-    verbose = cms.untracked.bool(True),
-    expectedRunLumiEvents = cms.untracked.vuint32(
+from FWCore.Framework.modules import RunLumiEventAnalyzer
+process.test = RunLumiEventAnalyzer(
+    verbose = True,
+    expectedRunLumiEvents = [
 100,   0,   0,
 100, 100,   0,
 100, 100, 100,
@@ -75,7 +69,7 @@ process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
   2,   1,   5,
   2,   1,   0,
   2,   0,   0
-)
+]
 )
 
 process.test.expectedRunLumiEvents.extend([

--- a/IOPool/Input/test/test_reduced_ProcessHistory_cfg.py
+++ b/IOPool/Input/test/test_reduced_ProcessHistory_cfg.py
@@ -2,29 +2,21 @@ import FWCore.ParameterSet.Config as cms
 import sys
 
 process = cms.Process("READMERGE")
-
-process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.FwkReport.reportEvery = 1000
 process.MessageLogger.cerr.threshold = cms.untracked.string('ERROR')
 
 process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
 
-process.AdaptorConfig = cms.Service("AdaptorConfig",
-    stats = cms.untracked.bool(False)
-)
+from IOPool.TFileAdaptor.modules import AdaptorConfig
+process.add_(AdaptorConfig(stats = False))
 
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(-1)
-)
+process.maxEvents.input = -1
 
-process.output = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string(
-      'file:reduced_test.root'
-    )
-)
+from IOPool.Output.modules import PoolOutputModule
+process.output = PoolOutputModule(fileName = 'reduced_test.root')
 
-process.testmerge = cms.EDAnalyzer("TestMergeResults",
-                            
+from FWCore.Framework.modules import TestMergeResults
+process.testmerge = TestMergeResults(
     #   Check to see that the value we read matches what we know
     #   was written. Expected values listed below come in sets of three
     #      value expected in Thing
@@ -37,7 +29,7 @@ process.testmerge = cms.EDAnalyzer("TestMergeResults",
     #   When the sequence of parameter values is exhausted it stops checking
     #   0's are just placeholders, if the value is a "0" the check is not made.
 
-    expectedBeginRunNew = cms.untracked.vint32(
+    expectedBeginRunNew = [
         10001,   20004,  10003,   # end run 100
         10001,   20004,  10003,   # end run 1
         10001,   20004,  10003,   # end run 1
@@ -51,9 +43,9 @@ process.testmerge = cms.EDAnalyzer("TestMergeResults",
         10001,   20004,  10003,   # end run 2000
         10001,   20004,  10003,   # end run 2001
         10001,   20004,  10003    # end run 2002
-    ),
+    ],
 
-    expectedEndRunNew = cms.untracked.vint32(
+    expectedEndRunNew = [
         100001,   200004,  100003,   # end run 100
         100001,   200004,  100003,   # end run 1
         100001,   200004,  100003,   # end run 1
@@ -67,18 +59,18 @@ process.testmerge = cms.EDAnalyzer("TestMergeResults",
         100001,   200004,  100003,   # end run 2000
         100001,   200004,  100003,   # end run 2001
         100001,   200004,  100003    # end run 2002
-    ),
+    ],
 
-    expectedBeginLumiNew = cms.untracked.vint32(
+    expectedBeginLumiNew = [
         101,       204,    103    # end run 100 lumi 100
 # There are more, but all with the same pattern as the first        
-    ),
+    ],
 
-    expectedEndLumiNew = cms.untracked.vint32(
+    expectedEndLumiNew = [
         1001,     2004,   1003,   # end run 100 lumi 100
-    ),
+    ],
 
-    expectedProcessHistoryInRuns = cms.untracked.vstring(
+    expectedProcessHistoryInRuns = [
         'PROD',            # Run 100
         'MERGE',
         'MERGETWOFILES',
@@ -139,18 +131,20 @@ process.testmerge = cms.EDAnalyzer("TestMergeResults",
         'MERGE',
         'MERGETWOFILES',
         'READMERGE'
-    ),
-    verbose = cms.untracked.bool(True)
+    ],
+    verbose = True
 )
 
-process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring("file:"+sys.argv[1]),
-    duplicateCheckMode = cms.untracked.string("noDuplicateCheck")
+from IOPool.Input.modules import PoolSource
+process.source = PoolSource(
+    fileNames = [f"file:{sys.argv[1]}"],
+    duplicateCheckMode = "noDuplicateCheck"
 )
 
-process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
-    verbose = cms.untracked.bool(True),
-    expectedRunLumiEvents = cms.untracked.vuint32(
+from FWCore.Framework.modules import RunLumiEventAnalyzer
+process.test = RunLumiEventAnalyzer(
+    verbose = True,
+    expectedRunLumiEvents = [
 100,   0,   0,
 100, 100,   0,
 100, 100, 100,
@@ -233,7 +227,7 @@ process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
   2,   1,   5,
   2,   1,   0,
   2,   0,   0
-)
+]
 )
 
 process.test.expectedRunLumiEvents.extend([

--- a/IOPool/Input/test/test_reduced_ProcessHistory_dup_cfg.py
+++ b/IOPool/Input/test/test_reduced_ProcessHistory_dup_cfg.py
@@ -9,22 +9,16 @@ process.MessageLogger.cerr.threshold = cms.untracked.string('ERROR')
 
 process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
 
-process.AdaptorConfig = cms.Service("AdaptorConfig",
-    stats = cms.untracked.bool(False)
-)
+from IOPool.TFileAdaptor.modules import AdaptorConfig
+process.add_(AdaptorConfig(stats = False))
 
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(-1)
-)
+process.maxEvents.input = -1
 
-process.output = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string(
-      'file:reduced_test.root'
-    )
-)
+from IOPool.Output.modules import PoolOutputModule
+process.output = PoolOutputModule(fileName = 'reduced_test.root')
 
-process.testmerge = cms.EDAnalyzer("TestMergeResults",
-                            
+from FWCore.Framework.modules import TestMergeResults, RunLumiEventAnalyzer
+process.testmerge = TestMergeResults(
     #   Check to see that the value we read matches what we know
     #   was written. Expected values listed below come in sets of three
     #      value expected in Thing
@@ -37,7 +31,7 @@ process.testmerge = cms.EDAnalyzer("TestMergeResults",
     #   When the sequence of parameter values is exhausted it stops checking
     #   0's are just placeholders, if the value is a "0" the check is not made.
 
-    expectedBeginRunNew = cms.untracked.vint32(
+    expectedBeginRunNew = [
         10001,   20004,  10003,   # end run 100
         10001,   20004,  10003,   # end run 1
         10001,   20004,  10003,   # end run 1
@@ -51,9 +45,9 @@ process.testmerge = cms.EDAnalyzer("TestMergeResults",
         10001,   20004,  10003,   # end run 2000
         10001,   20004,  10003,   # end run 2001
         10001,   20004,  10003    # end run 2002
-    ),
+    ],
 
-    expectedEndRunNew = cms.untracked.vint32(
+    expectedEndRunNew = [
         100001,   200004,  100003,   # end run 100
         100001,   200004,  100003,   # end run 1
         100001,   200004,  100003,   # end run 1
@@ -67,27 +61,26 @@ process.testmerge = cms.EDAnalyzer("TestMergeResults",
         100001,   200004,  100003,   # end run 2000
         100001,   200004,  100003,   # end run 2001
         100001,   200004,  100003    # end run 2002
-    ),
+    ],
 
-    expectedBeginLumiNew = cms.untracked.vint32(
+    expectedBeginLumiNew = [
         101,       204,    103    # end run 100 lumi 100
 # There are more, but all with the same pattern as the first        
-    ),
+    ],
 
-    expectedEndLumiNew = cms.untracked.vint32(
+    expectedEndLumiNew = [
         1001,     2004,   1003,   # end run 100 lumi 100
-    ),
+    ],
 
-    verbose = cms.untracked.bool(True)
+    verbose = True
 )
 
-process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring("file:"+sys.argv[1])
-)
+from IOPool.Input.modules import PoolSource
+process.source = PoolSource(fileNames = f"file:{sys.argv[1]}")
 
-process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
-    verbose = cms.untracked.bool(True),
-    expectedRunLumiEvents = cms.untracked.vuint32(
+process.test = RunLumiEventAnalyzer(
+    verbose = True,
+    expectedRunLumiEvents = [
 100,   0,   0,
 100, 100,   0,
 100, 100, 100,
@@ -138,7 +131,7 @@ process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
   2,   1,   5,
   2,   1,   0,
   2,   0,   0
-)
+]
 )
 
 process.test.expectedRunLumiEvents.extend([

--- a/IOPool/Input/test/test_reduced_ProcessHistory_end_cfg.py
+++ b/IOPool/Input/test/test_reduced_ProcessHistory_end_cfg.py
@@ -7,29 +7,21 @@ import FWCore.ParameterSet.Config as cms
 import sys
 
 process = cms.Process("READMERGE")
-
-process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.FwkReport.reportEvery = 1000
 process.MessageLogger.cerr.threshold = cms.untracked.string('ERROR')
 
 process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
 
-process.AdaptorConfig = cms.Service("AdaptorConfig",
-    stats = cms.untracked.bool(False)
-)
+from IOPool.TFileAdaptor.modules import AdaptorConfig
+process.add_(AdaptorConfig(stats = False))
 
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(-1)
-)
+process.maxEvents.input = -1
 
-process.output = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string(
-      'file:reduced_test.root'
-    )
-)
+from IOPool.Output.modules import PoolOutputModule
+process.output = PoolOutputModule(fileName = 'reduced_test.root')
 
-process.testmerge = cms.EDAnalyzer("TestMergeResults",
-                            
+from FWCore.Framework.modules import TestMergeResults, RunLumiEventAnalyzer
+process.testmerge = TestMergeResults(
     #   Check to see that the value we read matches what we know
     #   was written. Expected values listed below come in sets of three
     #      value expected in Thing
@@ -42,7 +34,7 @@ process.testmerge = cms.EDAnalyzer("TestMergeResults",
     #   When the sequence of parameter values is exhausted it stops checking
     #   0's are just placeholders, if the value is a "0" the check is not made.
 
-    expectedBeginRunNew = cms.untracked.vint32(
+    expectedBeginRunNew = [
         10001,   20004,  10003,   # end run 100
         10001,   20004,  10003,   # end run 1
         10001,   20004,  10003,   # end run 1
@@ -56,9 +48,9 @@ process.testmerge = cms.EDAnalyzer("TestMergeResults",
         10001,   20004,  10003,   # end run 2000
         10001,   20004,  10003,   # end run 2001
         10001,   20004,  10003    # end run 2002
-    ),
+    ],
 
-    expectedEndRunNew = cms.untracked.vint32(
+    expectedEndRunNew = [
         100001,   200004,  100003,   # end run 100
         100001,   200004,  100003,   # end run 1
         100001,   200004,  100003,   # end run 1
@@ -72,18 +64,18 @@ process.testmerge = cms.EDAnalyzer("TestMergeResults",
         100001,   200004,  100003,   # end run 2000
         100001,   200004,  100003,   # end run 2001
         100001,   200004,  100003    # end run 2002
-    ),
+    ],
 
-    expectedBeginLumiNew = cms.untracked.vint32(
+    expectedBeginLumiNew = [
         101,       204,    103    # end run 100 lumi 100
 # There are more, but all with the same pattern as the first        
-    ),
+    ],
 
-    expectedEndLumiNew = cms.untracked.vint32(
+    expectedEndLumiNew = [
         1001,     2004,   1003,   # end run 100 lumi 100
-    ),
+    ],
 
-    expectedProcessHistoryInRuns = cms.untracked.vstring(
+    expectedProcessHistoryInRuns = [
         'PROD',            # Run 100
         'MERGE',
         'MERGETWOFILES',
@@ -131,18 +123,19 @@ process.testmerge = cms.EDAnalyzer("TestMergeResults",
         'EXTRA',
         'MERGE',
         'MERGETWOFILES'
-    ),
-    verbose = cms.untracked.bool(True)
+    ],
+    verbose = True
 )
 
-process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring("file:"+sys.argv[1]),
-    duplicateCheckMode = cms.untracked.string("noDuplicateCheck")
+from IOPool.Input.modules import PoolSource
+process.source = PoolSource(
+    fileNames = [f"file:{sys.argv[1]}"],
+    duplicateCheckMode = "noDuplicateCheck"
 )
 
-process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
-    verbose = cms.untracked.bool(True),
-    expectedRunLumiEvents = cms.untracked.vuint32(
+process.test = RunLumiEventAnalyzer(
+    verbose = True,
+    expectedRunLumiEvents = [
 100,   0,   0,
 100, 100,   0,
 100, 100, 100,
@@ -225,7 +218,7 @@ process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
   2,   1,   5,
   2,   1,   0,
   2,   0,   0
-)
+]
 )
 
 process.test.expectedRunLumiEvents.extend([

--- a/IOPool/Streamer/test/NewStreamCopy2_cfg.py
+++ b/IOPool/Streamer/test/NewStreamCopy2_cfg.py
@@ -5,20 +5,18 @@ process = cms.Process("COPY")
 import FWCore.Framework.test.cmsExceptionsFatal_cff
 process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 
-process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.maxEvents.input = -1
 
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(-1)
-)
-
-process.source = cms.Source("PoolSource",
+# Must use old syntax for now because of the need to use firstEvent as uint64
+process.source = process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring('file:myout.root'),
     firstEvent = cms.untracked.uint64(10123456792)
 )
 
-process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
-    verbose = cms.untracked.bool(False),
-    expectedRunLumiEvents = cms.untracked.vuint64(
+from FWCore.Framework.modules import RunLumiEventAnalyzer
+process.test = RunLumiEventAnalyzer(
+    verbose = False,
+    expectedRunLumiEvents = [
       1, 0, 0,
       1, 1, 0,
       #1, 1, 10123456789,
@@ -73,8 +71,8 @@ process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
       1, 1, 10123456838,
       1, 1, 0,
       1, 0, 0
-    ),
-    expectedEndingIndex = cms.untracked.int32(153)
+    ],
+    expectedEndingIndex = 153
 )
 
 process.e = cms.EndPath(process.test)

--- a/IOPool/Streamer/test/NewStreamCopy_cfg.py
+++ b/IOPool/Streamer/test/NewStreamCopy_cfg.py
@@ -11,18 +11,18 @@ process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(-1)
 )
 
-process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring('file:myout.root')
-)
+from IOPool.Input.modules import PoolSource
+process.source = PoolSource(fileNames = 'file:myout.root')
 
 process.a1 = cms.EDAnalyzer("StreamThingAnalyzer",
     product_to_get = cms.string('m1'),
     inChecksum = cms.untracked.string('out')
 )
 
-process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
-    verbose = cms.untracked.bool(False),
-    expectedRunLumiEvents = cms.untracked.vuint64(
+from FWCore.Framework.modules import RunLumiEventAnalyzer
+process.test = RunLumiEventAnalyzer(
+    verbose = False,
+    expectedRunLumiEvents = [
       1, 0, 0,
       1, 1, 0,
       1, 1, 10123456789,
@@ -77,19 +77,19 @@ process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
       1, 1, 10123456838,
       1, 1, 0,
       1, 0, 0
-    ),
-    expectedEndingIndex = cms.untracked.int32(162)
+    ],
+    expectedEndingIndex = 162
 )
 
-process.out = cms.OutputModule("EventStreamFileWriter",
-    fileName = cms.untracked.string('teststreamfile_copy.dat'),
-    compression_level = cms.untracked.int32(1),
-    use_compression = cms.untracked.bool(True),
-    max_event_size = cms.untracked.int32(7000000)
+from IOPool.Streamer.modules import EventStreamFileWriter
+process.out = EventStreamFileWriter(
+    fileName = 'teststreamfile_copy.dat',
+    compression_level = 1,
+    use_compression = True,
+    max_event_size = 7000000
 )
 
-process.outp = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('myout2.root')
-)
+from IOPool.Output.modules import PoolOutputModule
+process.outp = PoolOutputModule(fileName = cms.untracked.string('myout2.root'))
 
 process.e = cms.EndPath(process.test*process.a1*process.out*process.outp)


### PR DESCRIPTION
#### PR description:

Following up https://github.com/cms-sw/cmssw/pull/47032#discussion_r1905630126 this PR modernizes all uses of `RunLumiEventAnalyzer`, and removes the `existsAs()` call.

Resolves https://github.com/cms-sw/framework-team/issues/1155

#### PR validation:

Framework unit tests run