### PR TITLE
Replicate the mocked version -based reduced ProcessHistory tests for streamer file format

### DIFF
--- a/IOPool/Streamer/test/BuildFile.xml
+++ b/IOPool/Streamer/test/BuildFile.xml
@@ -32,6 +32,8 @@
 
   <test name="TestIOPoolStreamerFailures" command="run_failures.sh"/>
 
+  <test name="TestIOPoolStreamerReducedProcessHistory" command="run_TestReducedProcessHistory.sh"/>
+
   <library file="StreamThingProducer.cc" name="StreamThingProducer">
     <flags EDM_PLUGIN="1"/>
     <use name="DataFormats/TestObjects"/>

--- a/IOPool/Streamer/test/run_TestReducedProcessHistory.sh
+++ b/IOPool/Streamer/test/run_TestReducedProcessHistory.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+function die { echo Failure $1: status $2 ; exit $2 ; }
+function runSuccess {
+    echo "cmsRun $@"
+    cmsRun $@ || die "cmsRun $*" $?
+    echo
+}
+function runFailure {
+    echo "cmsRun $@ (expected to fail)"
+    cmsRun $@ && die "cmsRun $*" 1
+    echo
+}
+
+VERSION_ARR=(${CMSSW_VERSION//_/ })
+VERSION1="${VERSION_ARR[0]}_${VERSION_ARR[1]}_${VERSION_ARR[2]}_0"
+VERSION2="${VERSION_ARR[0]}_${VERSION_ARR[1]}_${VERSION_ARR[2]}_1"
+VERSION3="${VERSION_ARR[0]}_${VERSION_ARR[1]}_$((${VERSION_ARR[2]}+1))_0"
+
+# Check that changing the patch version does not lead to new lumi or run
+runSuccess ${SCRAM_TEST_PATH}/testReducedProcessHistoryCreate_cfg.py --version ${VERSION1} --firstEvent 1 --output version1.dat
+runSuccess ${SCRAM_TEST_PATH}/testReducedProcessHistoryCreate_cfg.py --version ${VERSION2} --firstEvent 101 --output version2.dat
+
+CatStreamerFiles merged.dat version1.dat version2.dat
+
+runSuccess ${SCRAM_TEST_PATH}/testReducedProcessHistory_cfg.py --input merged.dat --output merged.root
+
+edmProvDump merged.root | grep -q "PROD.*'${VERSION1}'" || die "Did not find ${VERSION1} from merged.root provenance" $?
+edmProvDump merged.root | grep -q "PROD.*'${VERSION2}'" || die "Did not find ${VERSION2} from merged.root provenance" $?
+
+
+# Check that changing the minor version leads to new lumi
+runSuccess ${SCRAM_TEST_PATH}/testReducedProcessHistoryCreate_cfg.py --version ${VERSION3} --firstEvent 201 --output version3_lumi.dat
+
+CatStreamerFiles merged3_lumi.dat version1.dat version3_lumi.dat
+
+runFailure ${SCRAM_TEST_PATH}/testReducedProcessHistory_cfg.py --input merged3_lumi.dat --output merged3_lumi.root
+
+runSuccess ${SCRAM_TEST_PATH}/testReducedProcessHistory_cfg.py --input merged3_lumi.dat --output merged3_lumi.root --expectNewLumi
+
+edmProvDump merged3_lumi.root | grep -q "PROD.*'${VERSION3}'" || die "Did not find ${VERSION3} from merged3_lumi.root provenance" $?
+
+
+# Check that changing the minor version leads to new run
+runSuccess ${SCRAM_TEST_PATH}/testReducedProcessHistoryCreate_cfg.py --version ${VERSION3} --firstEvent 201 --lumi 2 --output version3_run.dat
+
+CatStreamerFiles merged3_run.dat version1.dat version3_run.dat
+
+runFailure ${SCRAM_TEST_PATH}/testReducedProcessHistory_cfg.py --input merged3_run.dat --output merged3_run.root
+
+runSuccess ${SCRAM_TEST_PATH}/testReducedProcessHistory_cfg.py --input merged3_run.dat --output merged3_run.root --expectNewRun
+
+edmProvDump merged3_run.root | grep -q "PROD.*'${VERSION3}'" || die "Did not find ${VERSION3} from merged3_run.root provenance" $?
+
+exit 0

--- a/IOPool/Streamer/test/run_TestRefProductIDMetadataConsistencyStreamer.sh
+++ b/IOPool/Streamer/test/run_TestRefProductIDMetadataConsistencyStreamer.sh
@@ -7,7 +7,7 @@ function runSuccess {
     echo
 }
 function runFailure {
-    echo "cmsRun $@ (exepcted to fail)"
+    echo "cmsRun $@ (expected to fail)"
     cmsRun $@ && die "cmsRun $*" 1
     echo
 }

--- a/IOPool/Streamer/test/testReducedProcessHistoryCreate_cfg.py
+++ b/IOPool/Streamer/test/testReducedProcessHistoryCreate_cfg.py
@@ -1,0 +1,39 @@
+import FWCore.ParameterSet.Config as cms
+import argparse
+
+parser = argparse.ArgumentParser(description='Create files for reduced ProcessHistory test')
+parser.add_argument("--version", type=str, help="CMSSW version to be used in the ProcessHistory")
+parser.add_argument("--firstEvent", default=1, type=int, help="Number of first event")
+parser.add_argument("--lumi", default=1, type=int, help="LuminosityBlock number")
+parser.add_argument("--output", type=str, help="Output file name")
+
+args = parser.parse_args()
+
+process = cms.Process("PROD")
+process._specialOverrideReleaseVersionOnlyForTesting(args.version)
+
+process.maxEvents.input = 10
+
+from FWCore.Modules.modules import EmptySource
+process.source = EmptySource(
+    firstEvent = args.firstEvent,
+    firstLuminosityBlock = args.lumi,
+)
+
+from IOPool.Streamer.modules import EventStreamFileWriter
+process.out = EventStreamFileWriter(
+    fileName = args.output
+)
+
+from FWCore.Framework.modules import IntProducer
+process.intProducer = IntProducer(ivalue = 42)
+
+from FWCore.Integration.modules import ThingProducer
+process.thing = ThingProducer()
+
+process.t = cms.Task(
+    process.intProducer,
+    process.thing,
+)
+process.p = cms.Path(process.t)
+process.ep = cms.EndPath(process.out)

--- a/IOPool/Streamer/test/testReducedProcessHistory_cfg.py
+++ b/IOPool/Streamer/test/testReducedProcessHistory_cfg.py
@@ -1,0 +1,100 @@
+import FWCore.ParameterSet.Config as cms
+import argparse
+
+parser = argparse.ArgumentParser(description='Test reduced ProcessHistory')
+parser.add_argument("--input", type=str, help="Input file")
+#parser.add_argument("--bypassVersionCheck", action="store_true", help="Bypass version check")
+parser.add_argument("--expectNewLumi", action="store_true", help="Set this if a new lumi is expected between the original files")
+parser.add_argument("--expectNewRun", action="store_true", help="Set this if a new run is expected between the original files")
+parser.add_argument("--output", type=str, help="Output file name")
+
+args = parser.parse_args()
+
+process = cms.Process("READ")
+
+from IOPool.Streamer.modules import NewEventStreamFileReader
+process.source = NewEventStreamFileReader(
+    fileNames = [f"file:{args.input}"],
+#    bypassVersionCheck = args.bypassVersionCheck,
+)
+
+from IOPool.Output.modules import PoolOutputModule
+process.out = PoolOutputModule(
+    fileName = args.output
+)
+
+from FWCore.Framework.modules import RunLumiEventAnalyzer
+process.test = RunLumiEventAnalyzer(
+    expectedRunLumiEvents = [
+        1, 0, 0, # beginRun
+        1, 1, 0, # beginLumi
+        1, 1, 1,
+        1, 1, 2,
+        1, 1, 3,
+        1, 1, 4,
+        1, 1, 5,
+        1, 1, 6,
+        1, 1, 7,
+        1, 1, 8,
+        1, 1, 9,
+        1, 1, 10,
+        1, 1, 101,
+        1, 1, 102,
+        1, 1, 103,
+        1, 1, 104,
+        1, 1, 105,
+        1, 1, 106,
+        1, 1, 107,
+        1, 1, 108,
+        1, 1, 109,
+        1, 1, 110,
+        1, 1, 0, # endLumi
+        1, 0, 0, # endRun
+    ]
+)
+endFirstFileIndex = 3*(10+2)
+if args.expectNewLumi:
+    process.test.expectedRunLumiEvents = process.test.expectedRunLumiEvents[:endFirstFileIndex] + [
+        1, 1, 0, # endLumi
+        1, 0, 0, # endRun
+        1, 0, 0, # beginRun
+        1, 1, 0, # beginLumi
+        1, 1, 201,
+        1, 1, 202,
+        1, 1, 203,
+        1, 1, 204,
+        1, 1, 205,
+        1, 1, 206,
+        1, 1, 207,
+        1, 1, 208,
+        1, 1, 209,
+        1, 1, 210,
+        1, 1, 0, # endLumi
+        1, 0, 0, # endRun
+    ]
+elif args.expectNewRun:
+    process.test.expectedRunLumiEvents = process.test.expectedRunLumiEvents[:endFirstFileIndex] + [
+        1, 1, 0, # endLumi
+        1, 0, 0, # endRun
+        1, 0, 0, # beginRun
+        1, 2, 0, # beginLumi
+        1, 2, 201,
+        1, 2, 202,
+        1, 2, 203,
+        1, 2, 204,
+        1, 2, 205,
+        1, 2, 206,
+        1, 2, 207,
+        1, 2, 208,
+        1, 2, 209,
+        1, 2, 210,
+        1, 2, 0, # endLumi
+        1, 0, 0, # endRun
+    ]
+
+process.p = cms.Path(
+    process.test
+)
+process.ep = cms.EndPath(
+    process.out
+)


### PR DESCRIPTION
#### PR description:

This PR replicates the reduced ProcessHistory tests (based on mocked CMSSW version) that I added in https://github.com/cms-sw/cmssw/pull/47032 for the streamer file format.

Resolves https://github.com/cms-sw/framework-team/issues/1140

#### PR validation:

Added unit test runs