### PR TITLE
revert #46026 (L1-uGT emulator)

### DIFF
--- a/L1Trigger/L1TGlobal/interface/GlobalBoard.h
+++ b/L1Trigger/L1TGlobal/interface/GlobalBoard.h
@@ -77,9 +77,7 @@ namespace l1t {
     void receiveMuonObjectData(const edm::Event&,
                                const edm::EDGetTokenT<BXVector<l1t::Muon>>&,
                                const bool receiveMu,
-                               const int nrL1Mu,
-                               const std::vector<l1t::Muon>* muonVec_bxm2,
-                               const std::vector<l1t::Muon>* muonVec_bxm1);
+                               const int nrL1Mu);
 
     void receiveMuonShowerObjectData(const edm::Event&,
                                      const edm::EDGetTokenT<BXVector<l1t::MuonShower>>&,

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
@@ -255,10 +255,6 @@ L1TGlobalProducer::L1TGlobalProducer(const edm::ParameterSet& parSet)
   m_l1GtTmAlgoCacheID = 0ULL;
   m_l1GtTmVetoAlgoCacheID = 0ULL;
 
-  //
-  std::vector<l1t::Muon> muonVec_bxm2;
-  std::vector<l1t::Muon> muonVec_bxm1;
-
   // Set default, initial, dummy prescale factor table
   std::vector<std::vector<double>> temp_prescaleTable;
 
@@ -601,7 +597,7 @@ void L1TGlobalProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSet
                                   receiveEtSumsZdc,
                                   receiveCICADA);
 
-  m_uGtBrd->receiveMuonObjectData(iEvent, m_muInputToken, receiveMu, m_nrL1Mu, &muonVec_bxm2, &muonVec_bxm1);
+  m_uGtBrd->receiveMuonObjectData(iEvent, m_muInputToken, receiveMu, m_nrL1Mu);
 
   if (m_useMuonShowers)
     m_uGtBrd->receiveMuonShowerObjectData(iEvent, m_muShowerInputToken, receiveMuShower, m_nrL1MuShower);
@@ -655,13 +651,6 @@ void L1TGlobalProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSet
 
   }  //End Loop over Bx
 
-  muonVec_bxm2 = muonVec_bxm1;
-  muonVec_bxm1.clear();
-  for (std::vector<const l1t::Muon*>::const_iterator iMu = (*(m_uGtBrd->getCandL1Mu())).begin(0);
-       iMu != (*(m_uGtBrd->getCandL1Mu())).end(0);
-       ++iMu) {
-    muonVec_bxm1.push_back(**iMu);
-  }
   // Add explicit reset of Board
   m_uGtBrd->reset();
 

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.h
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.h
@@ -196,10 +196,6 @@ private:
 
   //switch to save axo scores in global board
   bool m_produceAXOL1TLScore;
-
-  //vectors to store muon data for previous relative bx crossings
-  std::vector<l1t::Muon> muonVec_bxm2;
-  std::vector<l1t::Muon> muonVec_bxm1;
 };
 
 #endif  // L1TGlobalProducer_h

--- a/L1Trigger/L1TGlobal/src/GlobalBoard.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalBoard.cc
@@ -366,9 +366,7 @@ void l1t::GlobalBoard::receiveCaloObjectData(const edm::Event& iEvent,
 void l1t::GlobalBoard::receiveMuonObjectData(const edm::Event& iEvent,
                                              const edm::EDGetTokenT<BXVector<l1t::Muon>>& muInputToken,
                                              const bool receiveMu,
-                                             const int nrL1Mu,
-                                             const std::vector<l1t::Muon>* muonVec_bxm2,
-                                             const std::vector<l1t::Muon>* muonVec_bxm1) {
+                                             const int nrL1Mu) {
   if (m_verbosity) {
     LogDebug("L1TGlobal") << "\n**** GlobalBoard receiving muon data = ";
     //<< "\n     from input tag " << muInputTag << "\n"
@@ -395,45 +393,16 @@ void l1t::GlobalBoard::receiveMuonObjectData(const edm::Event& iEvent,
 
         //Loop over Muons in this bx
         int nObj = 0;
-        if (i == -2) {
-          for (std::vector<l1t::Muon>::const_iterator mu = muonVec_bxm2->begin(); mu != muonVec_bxm2->end(); ++mu) {
-            if (nObj < nrL1Mu) {
-              (*m_candL1Mu).push_back(i, &(*mu));
-            } else {
-              edm::LogWarning("L1TGlobal")
-                  << " Too many Muons (" << nObj << ") for uGT Configuration maxMu =" << nrL1Mu;
-            }
-
-            LogDebug("L1TGlobal") << "Muon  Pt " << mu->hwPt() << " EtaAtVtx  " << mu->hwEtaAtVtx() << " PhiAtVtx "
-                                  << mu->hwPhiAtVtx() << "  Qual " << mu->hwQual() << "  Iso " << mu->hwIso();
-            nObj++;
+        for (std::vector<l1t::Muon>::const_iterator mu = muonData->begin(i); mu != muonData->end(i); ++mu) {
+          if (nObj < nrL1Mu) {
+            (*m_candL1Mu).push_back(i, &(*mu));
+          } else {
+            edm::LogWarning("L1TGlobal") << " Too many Muons (" << nObj << ") for uGT Configuration maxMu =" << nrL1Mu;
           }
-        } else if (i == -1) {
-          for (std::vector<l1t::Muon>::const_iterator mu = muonVec_bxm1->begin(); mu != muonVec_bxm1->end(); ++mu) {
-            if (nObj < nrL1Mu) {
-              (*m_candL1Mu).push_back(i, &(*mu));
-            } else {
-              edm::LogWarning("L1TGlobal")
-                  << " Too many Muons (" << nObj << ") for uGT Configuration maxMu =" << nrL1Mu;
-            }
 
-            LogDebug("L1TGlobal") << "Muon  Pt " << mu->hwPt() << " EtaAtVtx  " << mu->hwEtaAtVtx() << " PhiAtVtx "
-                                  << mu->hwPhiAtVtx() << "  Qual " << mu->hwQual() << "  Iso " << mu->hwIso();
-            nObj++;
-          }
-        } else {
-          for (std::vector<l1t::Muon>::const_iterator mu = muonData->begin(i); mu != muonData->end(i); ++mu) {
-            if (nObj < nrL1Mu) {
-              (*m_candL1Mu).push_back(i, &(*mu));
-            } else {
-              edm::LogWarning("L1TGlobal")
-                  << " Too many Muons (" << nObj << ") for uGT Configuration maxMu =" << nrL1Mu;
-            }
-
-            LogDebug("L1TGlobal") << "Muon  Pt " << mu->hwPt() << " EtaAtVtx  " << mu->hwEtaAtVtx() << " PhiAtVtx "
-                                  << mu->hwPhiAtVtx() << "  Qual " << mu->hwQual() << "  Iso " << mu->hwIso();
-            nObj++;
-          }
+          LogDebug("L1TGlobal") << "Muon  Pt " << mu->hwPt() << " EtaAtVtx  " << mu->hwEtaAtVtx() << " PhiAtVtx "
+                                << mu->hwPhiAtVtx() << "  Qual " << mu->hwQual() << "  Iso " << mu->hwIso();
+          nObj++;
         }  //end loop over muons in bx
       }  //end loop over bx
     }  //end if over valid muon data


### PR DESCRIPTION
#### PR description:

This PR updates the L1-uGT emulator by reverting #46026. Checks described in #46026 and #47030 show that #46026 introduced disagreements between the unpacked and emulated L1-uGT decisions for seeds using muons reconstructed in separate bunch crossings (specifically, the seed `L1_CDC_SingleMu_3_er1p2_TOP120_DPHI2p618_3p142`).

#### PR validation:

See https://github.com/cms-sw/cmssw/pull/47030#issue-2761795624 and https://github.com/cms-sw/cmssw/pull/46026#issuecomment-2585362554.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

`CMSSW_14_2_X`

Bugfix to the L1-uGT emulator, to be backported to `14_2_X` (earlier cycles are not affected by the bug in question).
