### PR TITLE
fill charge_ and barycenter_ for all SiStripClusters

### DIFF
--- a/DataFormats/SiStripCluster/interface/SiStripCluster.h
+++ b/DataFormats/SiStripCluster/interface/SiStripCluster.h
@@ -102,6 +102,8 @@ public:
   float getSplitClusterError() const { return error_x; }
   void setSplitClusterError(float errx) { error_x = errx; }
 
+  void initQB();
+
 private:
   std::vector<uint8_t> amplitudes_;
 
@@ -127,8 +129,6 @@ private:
   // The CPE will check these errors and if they are not un-physical,
   // it will recognize the clusters as split and assign these (increased)
   // errors to the corresponding rechit.
-
-  void initQB();
 };
 
 // Comparison operators
@@ -159,4 +159,5 @@ inline void SiStripCluster::initQB() {
   // Need to mask off the high bit of firstStrip_, which contains the merged status.
   barycenter_ = float((firstStrip_ & stripIndexMask)) + float(sumx) / float(suma) + 0.5f;
 }
+
 #endif  // DATAFORMATS_SISTRIPCLUSTER_H

--- a/DataFormats/SiStripCluster/src/SiStripCluster.cc
+++ b/DataFormats/SiStripCluster/src/SiStripCluster.cc
@@ -20,6 +20,7 @@ SiStripCluster::SiStripCluster(const SiStripDigiRange& range) : firstStrip_(rang
     v.push_back(i->adc());
   }
   amplitudes_ = v;
+  initQB();
 }
 
 SiStripCluster::SiStripCluster(const SiStripApproximateCluster cluster, const uint16_t maxStrips) : error_x(-99999.9) {
@@ -36,35 +37,5 @@ SiStripCluster::SiStripCluster(const SiStripApproximateCluster cluster, const ui
   if UNLIKELY (firstStrip_ + cluster.width() > maxStrips) {
     firstStrip_ = maxStrips - cluster.width();
   }
+  firstStrip_ |= approximateMask;
 }
-
-int SiStripCluster::charge() const {
-  if (barycenter_ > 0)
-    return charge_;
-  return std::accumulate(begin(), end(), int(0));
-}
-
-float SiStripCluster::barycenter() const {
-  if (barycenter_ > 0)
-    return barycenter_;
-
-  int sumx = 0;
-  int suma = 0;
-  auto asize = size();
-  for (auto i = 0U; i < asize; ++i) {
-    sumx += i * amplitudes_[i];
-    suma += amplitudes_[i];
-  }
-
-  // strip centers are offcet by half pitch w.r.t. strip numbers,
-  // so one has to add 0.5 to get the correct barycenter position.
-  // Need to mask off the high bit of firstStrip_, which contains the merged status.
-  return float((firstStrip_ & stripIndexMask)) + float(sumx) / float(suma) + 0.5f;
-}
-bool SiStripCluster::filter() const {
-  if (barycenter_ > 0)
-    return filter_;
-  return false;
-}
-
-bool SiStripCluster::isFromApprox() const { return (barycenter_ > 0); }

--- a/DataFormats/SiStripCluster/src/classes_def.xml
+++ b/DataFormats/SiStripCluster/src/classes_def.xml
@@ -8,10 +8,10 @@
   <version ClassVersion="10" checksum="3791198690"/>
   <field name="error_x" transient="true"/>
  </class>
- <ioread sourceClass="SiStripCluster" version="[10]" targetClass="SiStripCluster" source="std::vector<uint8_t> amplitudes_; uint16_t firstStrip_;" target="amplitudes_,firstStrip_,barycenter_,charge_" >
+ <ioread sourceClass="SiStripCluster" version="[10-11]" targetClass="SiStripCluster" source="std::vector<uint8_t> amplitudes_; uint16_t firstStrip_;" target="amplitudes_,firstStrip_,barycenter_,charge_" >
    <![CDATA[amplitudes_ = onfile.amplitudes_; firstStrip_ = onfile.firstStrip_; newObj->initQB();]]>
  </ioread>
- <ioread sourceClass="SiStripCluster" version="[11-13]" targetClass="SiStripCluster" source="std::vector<uint8_t> amplitudes_; uint16_t firstStrip_; float barycenter_; int charge_;" target="amplitudes_,firstStrip_,barycenter_,charge_" >
+ <ioread sourceClass="SiStripCluster" version="[12-13]" targetClass="SiStripCluster" source="std::vector<uint8_t> amplitudes_; uint16_t firstStrip_; float barycenter_; int charge_;" target="amplitudes_,firstStrip_,barycenter_,charge_" >
    <![CDATA[amplitudes_ = onfile.amplitudes_; firstStrip_ = onfile.firstStrip_; barycenter_ = onfile.barycenter_; charge_ = onfile.charge_; if (onfile.barycenter_ == 0) { newObj->initQB(); } else { firstStrip_ |= SiStripCluster::approximateMask; }]]>
  </ioread>
  <class name="std::vector<SiStripCluster>"/>

--- a/DataFormats/SiStripCluster/src/classes_def.xml
+++ b/DataFormats/SiStripCluster/src/classes_def.xml
@@ -1,12 +1,19 @@
 <lcgdict>
 
- <class name="SiStripCluster" ClassVersion="13">
+ <class name="SiStripCluster" ClassVersion="14">
+  <version ClassVersion="14" checksum="1374720584"/>
   <version ClassVersion="13" checksum="1374720584"/>
   <version ClassVersion="12" checksum="2984011925"/>
   <version ClassVersion="11" checksum="3702468681"/>
   <version ClassVersion="10" checksum="3791198690"/>
   <field name="error_x" transient="true"/>
  </class>
+ <ioread sourceClass="SiStripCluster" version="[10]" targetClass="SiStripCluster" source="" target="" >
+   <![CDATA[newObj->initQB();]]>
+ </ioread>
+ <ioread sourceClass="SiStripCluster" version="[11-13]" targetClass="SiStripCluster" source="float barycenter_;" target="firstStrip_" >
+   <![CDATA[if (onfile.barycenter_ == 0) { newObj->initQB(); } else { firstStrip_ |= SiStripCluster::approximateMask; }]]>
+ </ioread>
  <class name="std::vector<SiStripCluster>"/>
 
  <class name="edmNew::DetSetVector<SiStripCluster>"/>

--- a/DataFormats/SiStripCluster/src/classes_def.xml
+++ b/DataFormats/SiStripCluster/src/classes_def.xml
@@ -8,11 +8,11 @@
   <version ClassVersion="10" checksum="3791198690"/>
   <field name="error_x" transient="true"/>
  </class>
- <ioread sourceClass="SiStripCluster" version="[10]" targetClass="SiStripCluster" source="" target="" >
-   <![CDATA[newObj->initQB();]]>
+ <ioread sourceClass="SiStripCluster" version="[10]" targetClass="SiStripCluster" source="std::vector<uint8_t> amplitudes_; uint16_t firstStrip_;" target="amplitudes_,firstStrip_,barycenter_,charge_" >
+   <![CDATA[amplitudes_ = onfile.amplitudes_; firstStrip_ = onfile.firstStrip_; newObj->initQB();]]>
  </ioread>
- <ioread sourceClass="SiStripCluster" version="[11-13]" targetClass="SiStripCluster" source="float barycenter_;" target="firstStrip_" >
-   <![CDATA[if (onfile.barycenter_ == 0) { newObj->initQB(); } else { firstStrip_ |= SiStripCluster::approximateMask; }]]>
+ <ioread sourceClass="SiStripCluster" version="[11-13]" targetClass="SiStripCluster" source="std::vector<uint8_t> amplitudes_; uint16_t firstStrip_; float barycenter_; int charge_;" target="amplitudes_,firstStrip_,barycenter_,charge_" >
+   <![CDATA[amplitudes_ = onfile.amplitudes_; firstStrip_ = onfile.firstStrip_; barycenter_ = onfile.barycenter_; charge_ = onfile.charge_; if (onfile.barycenter_ == 0) { newObj->initQB(); } else { firstStrip_ |= SiStripCluster::approximateMask; }]]>
  </ioread>
  <class name="std::vector<SiStripCluster>"/>
 


### PR DESCRIPTION
- fill `charge_` and `barycenter_` for all SiStripClusters
- use another bit in `firstStrip_` to signal it's an approximate cluster (to preserve detection of approximate clusters)

motivated by technical performance: offline pp reco calls `SiStripCluster::barycenter` and `::charge` around x100 times the number of clusters per event, adding up to around 0.88% of reco time.

Smaller speedup is expected in the HLT setup (different CPE and no strip seeding). 
- In a setup with mkFit running in HLT the run time of `MkFitSiStripHitConverter` goes down fractionally by 28% (0.45% of a job running tracking only HLT)

No changes are expected in workflows using regular clustering (although in pp I wouldn't be surprised if some math compiler optimization can create a difference).

There may be some change in (HI) workflows reading stored data with approximate clusters converted to regular clusters. From a brief [discussion](https://mattermost.web.cern.ch/cms-exp/pl/s4shbyac8jd8ujeoq4e5yfsykr), it sounds like this is only in specialized workflows, probably not captured by anything in the bot tests.

@cms-sw/trk-dpg-l2 @cms-sw/tracking-pog-l2 