### PR TITLE
Enable running ExternalDecays (photospp only for the moment) in the HepMC3 mode

### DIFF
--- a/GeneratorInterface/Core/interface/GeneratorFilter.h
+++ b/GeneratorInterface/Core/interface/GeneratorFilter.h
@@ -183,10 +183,18 @@ namespace edm {
       // The external decay driver is being added to the system,
       // it should be called here
       //
-      if (decayer_) {  // handle only HepMC2 for the moment
-        auto t = decayer_->decay(event.get());
-        if (t != event.get()) {
-          event.reset(t);
+      if (decayer_) {
+        if (ivhepmc == 2) { // handle HepMC2
+          auto t = decayer_->decay(event.get());
+          if (t != event.get()) {
+            event.reset(t);
+          }
+        }
+        if (ivhepmc == 3) { // handle HepMC3
+          auto t = decayer_->decay(event3.get());
+          if (t != event3.get()) {
+            event3.reset(t);
+          }
         }
       }
       if (ivhepmc == 2 && !event.get())

--- a/GeneratorInterface/Core/interface/GeneratorFilter.h
+++ b/GeneratorInterface/Core/interface/GeneratorFilter.h
@@ -184,13 +184,13 @@ namespace edm {
       // it should be called here
       //
       if (decayer_) {
-        if (ivhepmc == 2) { // handle HepMC2
+        if (ivhepmc == 2) {  // handle HepMC2
           auto t = decayer_->decay(event.get());
           if (t != event.get()) {
             event.reset(t);
           }
         }
-        if (ivhepmc == 3) { // handle HepMC3
+        if (ivhepmc == 3) {  // handle HepMC3
           auto t = decayer_->decay(event3.get());
           if (t != event3.get()) {
             event3.reset(t);

--- a/GeneratorInterface/Core/test/FailingGeneratorFilter.cc
+++ b/GeneratorInterface/Core/test/FailingGeneratorFilter.cc
@@ -119,6 +119,7 @@ namespace test {
     std::vector<std::string> sharedResources() const { return {}; }
 
     HepMC::GenEvent* decay(HepMC::GenEvent const*) { return nullptr; }
+    HepMC3::GenEvent* decay(HepMC3::GenEvent const*) { return nullptr; }
     void statistics() const {}
 
     void init(const edm::EventSetup&) const {}

--- a/GeneratorInterface/ExternalDecays/BuildFile.xml
+++ b/GeneratorInterface/ExternalDecays/BuildFile.xml
@@ -4,6 +4,7 @@
 <use name="heppdt"/>
 <use name="clhep"/>
 <use name="hepmc"/>
+<use name="hepmc3"/>
 <use name="GeneratorInterface/Core"/>
 <use name="GeneratorInterface/LHEInterface"/>
 <use name="GeneratorInterface/EvtGenInterface"/>

--- a/GeneratorInterface/ExternalDecays/interface/ExternalDecayDriver.h
+++ b/GeneratorInterface/ExternalDecays/interface/ExternalDecayDriver.h
@@ -12,6 +12,10 @@ namespace HepMC {
   class GenEvent;
 }
 
+namespace HepMC3 {
+  class GenEvent;
+}
+
 namespace CLHEP {
   class HepRandomEngine;
 }
@@ -39,6 +43,9 @@ namespace gen {
 
     HepMC::GenEvent* decay(HepMC::GenEvent* evt);
     HepMC::GenEvent* decay(HepMC::GenEvent* evt, lhef::LHEEvent* lheEvent);
+
+    HepMC3::GenEvent* decay(HepMC3::GenEvent* evt);
+    HepMC3::GenEvent* decay(HepMC3::GenEvent* evt, lhef::LHEEvent* lheEvent);
 
     void statistics() const;
 

--- a/GeneratorInterface/ExternalDecays/src/ExternalDecayDriver.cc
+++ b/GeneratorInterface/ExternalDecays/src/ExternalDecayDriver.cc
@@ -8,6 +8,7 @@
 #include "GeneratorInterface/PhotosInterface/interface/PhotosFactory.h"
 #include "GeneratorInterface/PhotosInterface/interface/PhotosInterfaceBase.h"
 #include "HepMC/GenEvent.h"
+#include "HepMC3/GenEvent.h"
 #include "FWCore/Concurrency/interface/SharedResourceNames.h"
 // LHE Run
 #include "SimDataFormats/GeneratorProducts/interface/LHERunInfoProduct.h"
@@ -63,6 +64,12 @@ HepMC::GenEvent* ExternalDecayDriver::decay(HepMC::GenEvent* evt, lhef::LHEEvent
   return decay(evt);
 }
 
+HepMC3::GenEvent* ExternalDecayDriver::decay(HepMC3::GenEvent* evt, lhef::LHEEvent* lheEvent) {
+  if (fTauolaInterface)
+    fTauolaInterface->SetLHE(lheEvent);
+  return decay(evt);
+}
+
 HepMC::GenEvent* ExternalDecayDriver::decay(HepMC::GenEvent* evt) {
   if (!fIsInitialized)
     return evt;
@@ -78,6 +85,33 @@ HepMC::GenEvent* ExternalDecayDriver::decay(HepMC::GenEvent* evt) {
     if (!evt)
       return nullptr;
   }
+
+  if (fPhotosInterface) {
+    evt = fPhotosInterface->apply(evt);
+    if (!evt)
+      return nullptr;
+  }
+
+  return evt;
+}
+
+HepMC3::GenEvent* ExternalDecayDriver::decay(HepMC3::GenEvent* evt) {
+  if (!fIsInitialized)
+    return evt;
+
+#if 0
+  if (fEvtGenInterface) {
+    evt = fEvtGenInterface->decay(evt);
+    if (!evt)
+      return nullptr;
+  }
+
+  if (fTauolaInterface) {
+    evt = fTauolaInterface->decay(evt);
+    if (!evt)
+      return nullptr;
+  }
+#endif
 
   if (fPhotosInterface) {
     evt = fPhotosInterface->apply(evt);

--- a/GeneratorInterface/PhotosInterface/BuildFile.xml
+++ b/GeneratorInterface/PhotosInterface/BuildFile.xml
@@ -2,6 +2,7 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/PluginManager"/>
 <use name="hepmc"/>
+<use name="hepmc3"/>
 <use name="clhep"/>
 <export>
   <lib name="1"/>

--- a/GeneratorInterface/PhotosInterface/interface/PhotosInterfaceBase.h
+++ b/GeneratorInterface/PhotosInterface/interface/PhotosInterfaceBase.h
@@ -4,6 +4,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "HepMC/GenEvent.h"
+#include "HepMC3/GenEvent.h"
 #include <vector>
 #include "CLHEP/Random/RandomEngine.h"
 #include "HepMC/SimpleVector.h"
@@ -21,6 +22,7 @@ namespace gen {
     virtual void init() = 0;
     virtual const std::vector<std::string>& specialSettings() { return fSpecialSettings; }
     virtual HepMC::GenEvent* apply(HepMC::GenEvent* evt) { return evt; }
+    virtual HepMC3::GenEvent* apply(HepMC3::GenEvent* evt) { return evt; }
     virtual void avoidTauLeptonicDecays() = 0;
     ;
     virtual void configureOnlyFor(int) = 0;

--- a/GeneratorInterface/PhotosInterface/interface/PhotosppInterface.h
+++ b/GeneratorInterface/PhotosInterface/interface/PhotosppInterface.h
@@ -15,6 +15,10 @@ namespace HepMC {
   class GenVertex;
 }  // namespace HepMC
 
+namespace HepMC3 {
+  class GenEvent;
+}  // namespace HepMC3
+
 namespace gen {
   class PhotosppInterface : public PhotosInterfaceBase {
   public:
@@ -25,6 +29,7 @@ namespace gen {
     void init() override;
     const std::vector<std::string>& specialSettings() override { return fSpecialSettings; }
     HepMC::GenEvent* apply(HepMC::GenEvent*) override;
+    HepMC3::GenEvent* apply(HepMC3::GenEvent*) override;
     void configureOnlyFor(int) override;
     void avoidTauLeptonicDecays() override {
       fAvoidTauLeptonicDecays = true;

--- a/GeneratorInterface/PhotosInterface/plugins/BuildFile.xml
+++ b/GeneratorInterface/PhotosInterface/plugins/BuildFile.xml
@@ -4,6 +4,7 @@
   <use name="GeneratorInterface/PhotosInterface"/>
   <use name="photospp"/>
   <use name="hepmc"/>
+  <use name="hepmc3"/>
   <use name="clhep"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/GeneratorInterface/PhotosInterface/plugins/PhotosppInterface.cc
+++ b/GeneratorInterface/PhotosInterface/plugins/PhotosppInterface.cc
@@ -290,7 +290,6 @@ HepMC3::GenEvent* PhotosppInterface::apply(HepMC3::GenEvent* evt) {
   Photospp::Photos::setRandomGenerator(PhotosppInterface::flat);
   if (!fIsInitialized)
     return evt;
-  int NPartBefore = evt->particles_size();
   Photospp::PhotosHepMC3Event PhotosEvt(evt);
   PhotosEvt.process();
   return evt;

--- a/GeneratorInterface/PhotosInterface/plugins/PhotosppInterface.cc
+++ b/GeneratorInterface/PhotosInterface/plugins/PhotosppInterface.cc
@@ -16,6 +16,7 @@ using namespace std;
 
 #include "Photos/Photos.h"
 #include "Photos/PhotosHepMCEvent.h"
+#include "Photos/PhotosHepMC3Event.h"
 
 CLHEP::HepRandomEngine* PhotosppInterface::fRandomEngine = nullptr;
 
@@ -282,6 +283,16 @@ HepMC::GenEvent* PhotosppInterface::apply(HepMC::GenEvent* evt) {
       }
     }
   }
+  return evt;
+}
+
+HepMC3::GenEvent* PhotosppInterface::apply(HepMC3::GenEvent* evt) {
+  Photospp::Photos::setRandomGenerator(PhotosppInterface::flat);
+  if (!fIsInitialized)
+    return evt;
+  int NPartBefore = evt->particles_size();
+  Photospp::PhotosHepMC3Event PhotosEvt(evt);
+  PhotosEvt.process();
   return evt;
 }
 

--- a/GeneratorInterface/Pythia8Interface/plugins/Pythia8HepMC3Hadronizer.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Pythia8HepMC3Hadronizer.cc
@@ -903,9 +903,8 @@ bool Pythia8HepMC3Hadronizer::residualDecay() {
 
   bool result = true;
 
-  for (auto p : (event3().get())->particles()) {
-    if(p->id() > NPartsBeforeDecays) {
-
+  for (const auto& p : (event3().get())->particles()) {
+    if (p->id() > NPartsBeforeDecays) {
       if (p->status() == 1 && (fDecayer->particleData).canDecay(p->pid())) {
         fDecayer->event.reset();
         Particle py8part(p->pid(),
@@ -922,7 +921,9 @@ bool Pythia8HepMC3Hadronizer::residualDecay() {
                          p->momentum().t(),
                          p->generated_mass());
 
-        py8part.vProd(p->production_vertex()->position().x(), p->production_vertex()->position().y(), p->production_vertex()->position().z(),
+        py8part.vProd(p->production_vertex()->position().x(),
+                      p->production_vertex()->position().y(),
+                      p->production_vertex()->position().z(),
                       p->production_vertex()->position().t());
 
         py8part.tau((fDecayer->particleData).tau0(p->pid()));
@@ -938,21 +939,24 @@ bool Pythia8HepMC3Hadronizer::residualDecay() {
         p->set_status(2);
 
         HepMC3::GenVertexPtr prod_vtx0 = make_shared<HepMC3::GenVertex>(  // neglect particle path to decay
-          HepMC3::FourVector(p->production_vertex()->position().x(), p->production_vertex()->position().y(), p->production_vertex()->position().z(),
-                             p->production_vertex()->position().t()));
-        prod_vtx0->add_particle_in( p );
-        (event3().get())->add_vertex( prod_vtx0 );
-        HepMC3::GenParticle* pnew;
+            HepMC3::FourVector(p->production_vertex()->position().x(),
+                               p->production_vertex()->position().y(),
+                               p->production_vertex()->position().z(),
+                               p->production_vertex()->position().t()));
+        prod_vtx0->add_particle_in(p);
+        (event3().get())->add_vertex(prod_vtx0);
+        HepMC3::GenParticle *pnew;
         Pythia8::Event pyev = fDecayer->event;
         double momFac = 1.;
         for (int i = 2; i < pyev.size(); ++i) {
           // Fill the particle.
           pnew = new HepMC3::GenParticle(
-            HepMC3::FourVector( momFac * pyev[i].px(), momFac * pyev[i].py(),
-                                momFac * pyev[i].pz(), momFac * pyev[i].e()  ),
-            pyev[i].id(), pyev[i].statusHepMC() );
-          pnew->set_generated_mass( momFac * pyev[i].m() );
-          prod_vtx0->add_particle_out( pnew );
+              HepMC3::FourVector(
+                  momFac * pyev[i].px(), momFac * pyev[i].py(), momFac * pyev[i].pz(), momFac * pyev[i].e()),
+              pyev[i].id(),
+              pyev[i].statusHepMC());
+          pnew->set_generated_mass(momFac * pyev[i].m());
+          prod_vtx0->add_particle_out(pnew);
         }
       }
     }

--- a/GeneratorInterface/Pythia8Interface/plugins/Pythia8HepMC3Hadronizer.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Pythia8HepMC3Hadronizer.cc
@@ -903,7 +903,7 @@ bool Pythia8HepMC3Hadronizer::residualDecay() {
 
   bool result = true;
 
-  for (const auto& p : (event3().get())->particles()) {
+  for (const auto &p : (event3().get())->particles()) {
     if (p->id() > NPartsBeforeDecays) {
       if (p->status() == 1 && (fDecayer->particleData).canDecay(p->pid())) {
         fDecayer->event.reset();

--- a/GeneratorInterface/Pythia8Interface/plugins/Pythia8HepMC3Hadronizer.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Pythia8HepMC3Hadronizer.cc
@@ -895,56 +895,68 @@ bool Pythia8HepMC3Hadronizer::residualDecay() {
   int NPartsBeforeDecays = pythiaEvent->size() - 1;  // do NOT count the very 1st "system" particle
                                                      // in Pythia8::Event record; it does NOT even
                                                      // get translated by the HepMCInterface to the
-                                                     // HepMC::GenEvent record !!!
-  //int NPartsAfterDecays = event().get()->particles_size();
-  int NPartsAfterDecays = 0;
-  for (auto p : (event3().get())->particles()) {
-    NPartsAfterDecays++;
-  }
+                                                     // HepMC3::GenEvent record !!!
 
+  int NPartsAfterDecays = ((event3().get())->particles()).size();
   if (NPartsAfterDecays == NPartsBeforeDecays)
     return true;
 
   bool result = true;
 
-// this below is to be rewritten in future development, then it will be uncommented
-#if 0
-  for (int ipart = NPartsAfterDecays; ipart > NPartsBeforeDecays; ipart--) {
-    HepMC::GenParticle *part = event().get()->barcode_to_particle(ipart);
+  for (auto p : (event3().get())->particles()) {
+    if(p->id() > NPartsBeforeDecays) {
 
-    if (part->status() == 1 && (fDecayer->particleData).canDecay(part->pdg_id())) {
-      fDecayer->event.reset();
-      Particle py8part(part->pdg_id(),
-                       93,
-                       0,
-                       0,
-                       0,
-                       0,
-                       0,
-                       0,
-                       part->momentum().x(),
-                       part->momentum().y(),
-                       part->momentum().z(),
-                       part->momentum().t(),
-                       part->generated_mass());
-      HepMC::GenVertex *ProdVtx = part->production_vertex();
-      py8part.vProd(ProdVtx->position().x(), ProdVtx->position().y(), ProdVtx->position().z(), ProdVtx->position().t());
-      py8part.tau((fDecayer->particleData).tau0(part->pdg_id()));
-      fDecayer->event.append(py8part);
-      int nentries = fDecayer->event.size();
-      if (!fDecayer->event[nentries - 1].mayDecay())
-        continue;
-      fDecayer->next();
-      int nentries1 = fDecayer->event.size();
-      if (nentries1 <= nentries)
-        continue;  //same number of particles, no decays...
+      if (p->status() == 1 && (fDecayer->particleData).canDecay(p->pid())) {
+        fDecayer->event.reset();
+        Particle py8part(p->pid(),
+                         93,
+                         0,
+                         0,
+                         0,
+                         0,
+                         0,
+                         0,
+                         p->momentum().x(),
+                         p->momentum().y(),
+                         p->momentum().z(),
+                         p->momentum().t(),
+                         p->generated_mass());
 
-      part->set_status(2);
+        py8part.vProd(p->production_vertex()->position().x(), p->production_vertex()->position().y(), p->production_vertex()->position().z(),
+                      p->production_vertex()->position().t());
 
-      result = toHepMC.fill_next_event(*(fDecayer.get()), event().get(), -1, true, part);
+        py8part.tau((fDecayer->particleData).tau0(p->pid()));
+        fDecayer->event.append(py8part);
+        int nentries = fDecayer->event.size();
+        if (!fDecayer->event[nentries - 1].mayDecay())
+          continue;
+        result = fDecayer->next();
+        int nentries1 = fDecayer->event.size();
+        if (nentries1 <= nentries)
+          continue;  //same number of particles, no decays...
+
+        p->set_status(2);
+
+        HepMC3::GenVertexPtr prod_vtx0 = make_shared<HepMC3::GenVertex>(  // neglect particle path to decay
+          HepMC3::FourVector(p->production_vertex()->position().x(), p->production_vertex()->position().y(), p->production_vertex()->position().z(),
+                             p->production_vertex()->position().t()));
+        prod_vtx0->add_particle_in( p );
+        (event3().get())->add_vertex( prod_vtx0 );
+        HepMC3::GenParticle* pnew;
+        Pythia8::Event pyev = fDecayer->event;
+        double momFac = 1.;
+        for (int i = 2; i < pyev.size(); ++i) {
+          // Fill the particle.
+          pnew = new HepMC3::GenParticle(
+            HepMC3::FourVector( momFac * pyev[i].px(), momFac * pyev[i].py(),
+                                momFac * pyev[i].pz(), momFac * pyev[i].e()  ),
+            pyev[i].id(), pyev[i].statusHepMC() );
+          pnew->set_generated_mass( momFac * pyev[i].m() );
+          prod_vtx0->add_particle_out( pnew );
+        }
+      }
     }
   }
-#endif
 
   return result;
 }

--- a/GeneratorInterface/Pythia8Interface/test/pythia8G4_cfg.py
+++ b/GeneratorInterface/Pythia8Interface/test/pythia8G4_cfg.py
@@ -1,0 +1,135 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: TTbar_8TeV_TuneCUETP8M1_cfi --conditions auto:run1_mc -n 10 --eventcontent RAWSIM --relval 9000,100 -s GEN,SIM --datatier GEN-SIM --beamspot Realistic8TeVCollision --fileout file:pythia8G4.root --suffix -j JobReport1.xml
+import FWCore.ParameterSet.Config as cms
+
+
+
+process = cms.Process('SIM')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.Geometry.GeometrySimDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedRealistic8TeVCollision_cfi')
+process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('Configuration.StandardSequences.SimIdeal_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(10),
+    output = cms.optional.untracked.allowed(cms.int32,cms.PSet)
+)
+
+# Input source
+process.source = cms.Source("EmptySource")
+
+process.options = cms.untracked.PSet(
+    IgnoreCompletely = cms.untracked.vstring(),
+    Rethrow = cms.untracked.vstring(),
+    accelerators = cms.untracked.vstring('*'),
+    allowUnscheduled = cms.obsolete.untracked.bool,
+    canDeleteEarly = cms.untracked.vstring(),
+    deleteNonConsumedUnscheduledModules = cms.untracked.bool(True),
+    dumpOptions = cms.untracked.bool(False),
+    emptyRunLumiMode = cms.obsolete.untracked.string,
+    eventSetup = cms.untracked.PSet(
+        forceNumberOfConcurrentIOVs = cms.untracked.PSet(
+            allowAnyLabel_=cms.required.untracked.uint32
+        ),
+        numberOfConcurrentIOVs = cms.untracked.uint32(0)
+    ),
+    fileMode = cms.untracked.string('FULLMERGE'),
+    forceEventSetupCacheClearOnNewRun = cms.untracked.bool(False),
+    makeTriggerResults = cms.obsolete.untracked.bool,
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(0),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfStreams = cms.untracked.uint32(0),
+    numberOfThreads = cms.untracked.uint32(1),
+    printDependencies = cms.untracked.bool(False),
+    sizeOfStackForThreadsInKB = cms.optional.untracked.uint32,
+    throwIfIllegalParameter = cms.untracked.bool(True),
+    wantSummary = cms.untracked.bool(False)
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('TTbar_8TeV_TuneCUETP8M1_cfi nevts:10'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+
+process.RAWSIMoutput = cms.OutputModule("PoolOutputModule",
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('generation_step')
+    ),
+    compressionAlgorithm = cms.untracked.string('LZMA'),
+    compressionLevel = cms.untracked.int32(1),
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('GEN-SIM'),
+        filterName = cms.untracked.string('')
+    ),
+    eventAutoFlushCompressedSize = cms.untracked.int32(20971520),
+    fileName = cms.untracked.string('file:pythia8G4.root'),
+    outputCommands = process.RAWSIMEventContent.outputCommands,
+    splitLevel = cms.untracked.int32(0)
+)
+
+# Additional output definition
+
+# Other statements
+process.genstepfilter.triggerConditions=cms.vstring("generation_step")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run1_mc', '')
+
+
+process.generator = cms.EDFilter("Pythia8GeneratorFilter",
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(True),
+    comEnergy = cms.double(7000.),
+    PythiaParameters = cms.PSet(
+        pythia8_example02 = cms.vstring('HardQCD:all = on',
+                                        'PhaseSpace:pTHatMin = 20.'),
+        parameterSets = cms.vstring('pythia8_example02')
+    )
+)
+
+
+process.ProductionFilterSequence = cms.Sequence(process.generator)
+
+# Path and EndPath definitions
+process.generation_step = cms.Path(process.pgen)
+process.simulation_step = cms.Path(process.psim)
+process.genfiltersummary_step = cms.EndPath(process.genFilterSummary)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RAWSIMoutput_step = cms.EndPath(process.RAWSIMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.generation_step,process.genfiltersummary_step,process.simulation_step,process.endjob_step,process.RAWSIMoutput_step)
+from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
+associatePatAlgosToolsTask(process)
+# filter all path with the production filter sequence
+for path in process.paths:
+	getattr(process,path).insert(0, process.ProductionFilterSequence)
+
+
+
+# Customisation from command line
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion

--- a/GeneratorInterface/Pythia8Interface/test/pythia8_photos_ZToTauTau_13TeV_cfg.py
+++ b/GeneratorInterface/Pythia8Interface/test/pythia8_photos_ZToTauTau_13TeV_cfg.py
@@ -1,0 +1,105 @@
+import FWCore.ParameterSet.Config as cms
+
+from FWCore.ParameterSet.VarParsing import VarParsing
+options = VarParsing ('python')
+options.register('outFilename', 'particleLevel.root',  VarParsing.multiplicity.singleton, VarParsing.varType.string, "Output file name")
+#options.register('photos', 'off', VarParsing.multiplicity.singleton, VarParsing.varType.string, "ME corrections")
+options.register('lepton', 13, VarParsing.multiplicity.singleton, VarParsing.varType.int, "Lepton ID for Z decays")
+options.register('cutoff', 0.00011, VarParsing.multiplicity.singleton, VarParsing.varType.float, "IR cutoff")
+options.register('taufilter', 'off', VarParsing.multiplicity.singleton, VarParsing.varType.string, "Filter tau -> leptons")
+options.parseArguments()
+print(options)
+
+process = cms.Process("PROD")
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = int(options.maxEvents/100)
+
+process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService",
+    generator = cms.PSet(
+        initialSeed = cms.untracked.uint32(123456789),
+    )
+)
+
+# set input to process
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100) )
+
+process.source = cms.Source("EmptySource")
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+process.generator = cms.EDFilter("Pythia8GeneratorFilter",
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CUEP8M1SettingsBlock,
+        processParameters = cms.vstring(
+            'WeakSingleBoson:ffbar2gmZ = on',
+            'PhaseSpace:mHatMin = 50.',
+            '23:onMode = off',
+            '23:onIfAny = 15',
+            'TimeShower:mMaxGamma = 4.0',
+            'TauDecays:externalMode = 0',
+            'ParticleDecays:allowPhotonRadiation = on', # allow photons from hadron decays
+            'TimeShower:QEDshowerByL = off', # no photons from leptons
+            'TimeShower:QEDshowerByOther = off', # no photons from W bosons
+            ),
+		parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CUEP8M1Settings',
+                                    'processParameters')
+    ),
+      	ExternalDecays = cms.PSet(
+        Photospp = cms.untracked.PSet(
+            parameterSets = cms.vstring("setExponentiation", "setInfraredCutOff", "setCorrectionWtForW", "setMeCorrectionWtForW",
+                                        "setMeCorrectionWtForZ", "setMomentumConservationThreshold", "setPairEmission", "setPhotonEmission",
+                                        "setStopAtCriticalError", "suppressAll", "forceBremForDecay"),
+            setExponentiation = cms.bool(True),
+            setCorrectionWtForW = cms.bool(False),
+            setMeCorrectionWtForW = cms.bool(False),
+            setMeCorrectionWtForZ = cms.bool(False),
+            setInfraredCutOff = cms.double(0.0000001),
+            setMomentumConservationThreshold = cms.double(0.1),
+            setPairEmission = cms.bool(False), # retain pair emission in MiNNLO x NLOEW / this
+            setPhotonEmission = cms.bool(True),
+            setStopAtCriticalError = cms.bool(False),
+            # Use Photos only for W/Z and tau decays
+            suppressAll = cms.bool(True),
+            forceBremForDecay = cms.PSet(
+                parameterSets = cms.vstring("Z", "Wp", "Wm", "tau", "atau"),
+                Z = cms.vint32(0, 23),
+                Wp = cms.vint32(0, 24),
+                Wm = cms.vint32(0, -24),
+                tau = cms.vint32(0, 15),
+                atau = cms.vint32(0, -15)
+            ),
+	),
+	parameterSets = cms.vstring("Photospp")
+    )
+)
+
+## configure process options
+process.options = cms.untracked.PSet(
+    allowUnscheduled = cms.untracked.bool(True),
+    wantSummary      = cms.untracked.bool(True)
+)
+
+process.genParticles = cms.EDProducer("GenParticleProducer",
+    saveBarCodes = cms.untracked.bool(True),
+    src = cms.InputTag("generator:unsmeared"),
+    abortOnUnknownPDGCode = cms.untracked.bool(False)
+)
+process.printTree1 = cms.EDAnalyzer("ParticleListDrawer",
+    src = cms.InputTag("genParticles"),
+    maxEventsToPrint  = cms.untracked.int32(10)
+)
+
+process.path = cms.Path(process.generator)
+

--- a/GeneratorInterface/Pythia8Interface/test/pythia8hmc3G4_cfg.py
+++ b/GeneratorInterface/Pythia8Interface/test/pythia8hmc3G4_cfg.py
@@ -1,0 +1,135 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: TTbar_8TeV_TuneCUETP8M1_cfi --conditions auto:run1_mc -n 10 --eventcontent RAWSIM --relval 9000,100 -s GEN,SIM --datatier GEN-SIM --beamspot Realistic8TeVCollision --fileout file:pythia8G4.root --suffix -j JobReport1.xml
+import FWCore.ParameterSet.Config as cms
+
+
+
+process = cms.Process('SIM')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.Geometry.GeometrySimDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedRealistic8TeVCollision_cfi')
+process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('Configuration.StandardSequences.SimIdeal_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(10),
+    output = cms.optional.untracked.allowed(cms.int32,cms.PSet)
+)
+
+# Input source
+process.source = cms.Source("EmptySource")
+
+process.options = cms.untracked.PSet(
+    IgnoreCompletely = cms.untracked.vstring(),
+    Rethrow = cms.untracked.vstring(),
+    accelerators = cms.untracked.vstring('*'),
+    allowUnscheduled = cms.obsolete.untracked.bool,
+    canDeleteEarly = cms.untracked.vstring(),
+    deleteNonConsumedUnscheduledModules = cms.untracked.bool(True),
+    dumpOptions = cms.untracked.bool(False),
+    emptyRunLumiMode = cms.obsolete.untracked.string,
+    eventSetup = cms.untracked.PSet(
+        forceNumberOfConcurrentIOVs = cms.untracked.PSet(
+            allowAnyLabel_=cms.required.untracked.uint32
+        ),
+        numberOfConcurrentIOVs = cms.untracked.uint32(0)
+    ),
+    fileMode = cms.untracked.string('FULLMERGE'),
+    forceEventSetupCacheClearOnNewRun = cms.untracked.bool(False),
+    makeTriggerResults = cms.obsolete.untracked.bool,
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(0),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfStreams = cms.untracked.uint32(0),
+    numberOfThreads = cms.untracked.uint32(1),
+    printDependencies = cms.untracked.bool(False),
+    sizeOfStackForThreadsInKB = cms.optional.untracked.uint32,
+    throwIfIllegalParameter = cms.untracked.bool(True),
+    wantSummary = cms.untracked.bool(False)
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('TTbar_8TeV_TuneCUETP8M1_cfi nevts:10'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+
+process.RAWSIMoutput = cms.OutputModule("PoolOutputModule",
+    SelectEvents = cms.untracked.PSet(
+#        SelectEvents = cms.vstring('generation_step')
+    ),
+    compressionAlgorithm = cms.untracked.string('LZMA'),
+    compressionLevel = cms.untracked.int32(1),
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('GEN-SIM'),
+        filterName = cms.untracked.string('')
+    ),
+    eventAutoFlushCompressedSize = cms.untracked.int32(20971520),
+    fileName = cms.untracked.string('file:pythia8hmc3G4.root'),
+    outputCommands = process.RAWSIMEventContent.outputCommands,
+    splitLevel = cms.untracked.int32(0)
+)
+
+# Additional output definition
+
+# Other statements
+process.genstepfilter.triggerConditions=cms.vstring("generation_step")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run1_mc', '')
+
+
+process.generator = cms.EDFilter("Pythia8HepMC3GeneratorFilter",
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(7000.),
+    PythiaParameters = cms.PSet(
+        pythia8_example02 = cms.vstring('HardQCD:all = on',
+                                        'PhaseSpace:pTHatMin = 20.'),
+        parameterSets = cms.vstring('pythia8_example02')
+    )
+)
+
+
+process.ProductionFilterSequence = cms.Sequence(process.generator)
+
+# Path and EndPath definitions
+process.generation_step = cms.Path(process.pgen)
+process.simulation_step = cms.Path(process.psim)
+process.genfiltersummary_step = cms.EndPath(process.genFilterSummary)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RAWSIMoutput_step = cms.EndPath(process.RAWSIMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.generation_step,process.genfiltersummary_step,process.simulation_step,process.endjob_step,process.RAWSIMoutput_step)
+from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
+associatePatAlgosToolsTask(process)
+# filter all path with the production filter sequence
+for path in process.paths:
+	getattr(process,path).insert(0, process.ProductionFilterSequence)
+
+
+
+# Customisation from command line
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion

--- a/GeneratorInterface/Pythia8Interface/test/pythia8hmc3_photos_ZToTauTau_13TeV_cfg.py
+++ b/GeneratorInterface/Pythia8Interface/test/pythia8hmc3_photos_ZToTauTau_13TeV_cfg.py
@@ -1,0 +1,102 @@
+import FWCore.ParameterSet.Config as cms
+
+from FWCore.ParameterSet.VarParsing import VarParsing
+options = VarParsing ('python')
+options.register('outFilename', 'particleLevel.root',  VarParsing.multiplicity.singleton, VarParsing.varType.string, "Output file name")
+#options.register('photos', 'off', VarParsing.multiplicity.singleton, VarParsing.varType.string, "ME corrections")
+options.register('lepton', 13, VarParsing.multiplicity.singleton, VarParsing.varType.int, "Lepton ID for Z decays")
+options.register('cutoff', 0.00011, VarParsing.multiplicity.singleton, VarParsing.varType.float, "IR cutoff")
+options.register('taufilter', 'off', VarParsing.multiplicity.singleton, VarParsing.varType.string, "Filter tau -> leptons")
+options.parseArguments()
+print(options)
+
+process = cms.Process("PROD")
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = int(options.maxEvents/100)
+
+process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService",
+    generator = cms.PSet(
+        initialSeed = cms.untracked.uint32(123456789),
+    )
+)
+
+# set input to process
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100) )
+
+process.source = cms.Source("EmptySource")
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+process.generator = cms.EDFilter("Pythia8HepMC3GeneratorFilter",
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CUEP8M1SettingsBlock,
+        processParameters = cms.vstring(
+            'WeakSingleBoson:ffbar2gmZ = on',
+            'PhaseSpace:mHatMin = 50.',
+            '23:onMode = off',
+            '23:onIfAny = 15',
+            'ParticleDecays:allowPhotonRadiation = on',
+            'TimeShower:QEDshowerByL = off',
+            ),
+		parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CUEP8M1Settings',
+                                    'processParameters')
+    ),
+      	ExternalDecays = cms.PSet(
+        Photospp = cms.untracked.PSet(
+            parameterSets = cms.vstring("setExponentiation", "setInfraredCutOff", "setCorrectionWtForW", "setMeCorrectionWtForW",
+                                        "setMeCorrectionWtForZ", "setMomentumConservationThreshold", "setPairEmission", "setPhotonEmission",
+                                        "setStopAtCriticalError", "suppressAll", "forceBremForDecay"),
+            setExponentiation = cms.bool(True),
+            setCorrectionWtForW = cms.bool(False),
+            setMeCorrectionWtForW = cms.bool(False),
+            setMeCorrectionWtForZ = cms.bool(False),
+            setInfraredCutOff = cms.double(0.0000001),
+            setMomentumConservationThreshold = cms.double(0.1),
+            setPairEmission = cms.bool(False), # retain pair emission in MiNNLO x NLOEW / this
+            setPhotonEmission = cms.bool(True),
+            setStopAtCriticalError = cms.bool(False),
+            # Use Photos only for W/Z and tau decays
+            suppressAll = cms.bool(True),
+            forceBremForDecay = cms.PSet(
+                parameterSets = cms.vstring("Z", "Wp", "Wm", "tau", "atau"),
+                Z = cms.vint32(0, 23),
+                Wp = cms.vint32(0, 24),
+                Wm = cms.vint32(0, -24),
+                tau = cms.vint32(0, 15),
+                atau = cms.vint32(0, -15)
+            ),
+	),
+	parameterSets = cms.vstring("Photospp")
+    )
+)
+
+## configure process options
+process.options = cms.untracked.PSet(
+    allowUnscheduled = cms.untracked.bool(True),
+    wantSummary      = cms.untracked.bool(True)
+)
+
+process.genParticles = cms.EDProducer("GenParticleProducer",
+    saveBarCodes = cms.untracked.bool(True),
+    src = cms.InputTag("generator:unsmeared"),
+    abortOnUnknownPDGCode = cms.untracked.bool(False)
+)
+process.printTree1 = cms.EDAnalyzer("ParticleListDrawer",
+    src = cms.InputTag("genParticles"),
+    maxEventsToPrint  = cms.untracked.int32(10)
+)
+
+process.path = cms.Path(process.generator)
+


### PR DESCRIPTION
#### PR description:

Enable running External Decays in the HepMC3 mode (generator output is in HepMC3 products). Only photos++ running is enabled in this mode  for the moment.

#### PR validation:

Validated using the configuration files that are being added in Pythis8Interface/test

