### PR TITLE
HcalNano for MC

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_nano.py
+++ b/Configuration/PyReleaseValidation/python/relval_nano.py
@@ -203,6 +203,13 @@ steps['scoutingNANO_mc14.0'] = merge([{'-s': 'NANO:@Scout'},
 steps['scoutingNANO_withPrompt_mc14.0'] = merge([{'-s': 'NANO:@Prompt+@Scout'},
                                                  steps['NANO_mc14.0']])
 
+steps['SinglePionRAW14.0'] = {'INPUT': InputInfo(
+    location='STD', dataSet='/SinglePion_E-50_Eta-0to3-pythia8-gun/Run3Winter25Digi-NoPU_142X_mcRun3_2025BOY_realistic_Candidate_2024_11_13_17_21_33-v2/GEN-SIM-RAW')}
+
+steps['hcalDPGNANO_mc14.0'] = merge([{'-s': 'RAW2DIGI,RECO,NANO:@HCALMC', '-n': '100',
+                                             '--processName': 'NANO'},
+                                            steps['NANO_mc14.0']])
+
 # 14.0 workflows -- data
 lumis_Run2024D = {380306: [[28, 273]]}
 steps['MuonEG2024MINIAOD14.0'] = {'INPUT': InputInfo(location='STD', ls=lumis_Run2024D,
@@ -368,6 +375,13 @@ workflows[_wfn()] = ['muDPGNANO140Xrun3', ['ZMuSkim2024RAWRECO14.0', 'muDPGNANO_
 workflows[_wfn()] = ['muDPGNANOBkg140Xrun3', ['ZeroBias2024RAW14.0', 'muDPGNANOBkg_data14.0']]
 workflows[_wfn()] = ['hcalDPGNANO140Xrun3', ['ZeroBias2024RAW14.0', 'hcalDPGNANO_data14.0']]
 workflows[_wfn()] = ['hcalDPGCalibNANO140Xrun3', ['TestEnablesEcalHcal2024RAW14.0', 'hcalDPGCalibNANO_data14.0']]
+
+# DPG custom NANOs, MC
+_wfn.subnext()
+workflows[_wfn()] = ['hcalDPGMCNANO140Xrun3', ['SinglePionRAW14.0', 'hcalDPGNANO_mc14.0']]
+# The above HCAL workflow is actually using data produced for 14.2
+# but I keep the 14.0 label for now since it's consistent with those ones
+# let me know if I should change this
 
 _wfn.next(9)
 ######## 2500.9xx ########

--- a/DPGAnalysis/HcalNanoAOD/python/customiseHcalMC_cff.py
+++ b/DPGAnalysis/HcalNanoAOD/python/customiseHcalMC_cff.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+# Customization for running on MC
+#   - Call from cmsDriver.py with: `--customise DPGAnalysis/HcalNanoAOD/customiseHcalMC_cff.customiseHcalMC`
+def customiseHcalMC(process):
+  # Point to appropriate MC digi collections
+  process.hcalDigiSortedTable.tagQIE11 = cms.untracked.InputTag("simHcalUnsuppressedDigis", "HBHEQIE11DigiCollection")
+  process.hcalDigiSortedTable.tagQIE10 = cms.untracked.InputTag("simHcalUnsuppressedDigis","HFQIE10DigiCollection")
+  process.hcalDigiSortedTable.tagHO = cms.untracked.InputTag("simHcalUnsuppressedDigis")
+
+  # Use the appropriate number of samples for digis in MC
+  process.hcalDigiSortedTable.nTS_HB = cms.untracked.uint32(10)
+  process.hcalDigiSortedTable.nTS_HE = cms.untracked.uint32(10)
+
+  return process

--- a/PhysicsTools/NanoAOD/python/autoNANO.py
+++ b/PhysicsTools/NanoAOD/python/autoNANO.py
@@ -58,6 +58,8 @@ autoNANO = {
     'HCAL': {'sequence': 'DPGAnalysis/HcalNanoAOD/hcalNano_cff.hcalNanoTask'},
     'HCALCalib': {'sequence': 'DPGAnalysis/HcalNanoAOD/hcalNano_cff.hcalNanoTask',
                   'customize': 'DPGAnalysis/HcalNanoAOD/customiseHcalCalib_cff.customiseHcalCalib'},
+    'HCALMC': {'sequence': 'DPGAnalysis/HcalNanoAOD/hcalNano_cff.hcalNanoTask',
+                  'customize': 'DPGAnalysis/HcalNanoAOD/customiseHcalMC_cff.customiseHcalMC'},
     # EGM flavours: add variables through customize
     'EGM': {'sequence': '@PHYS',
             'customize': '@PHYS+PhysicsTools/NanoAOD/egamma_custom_cff.addExtraEGammaVarsCustomize'},


### PR DESCRIPTION
#### PR description:

This PR adds a customization that enables hcalNano to be produced easily from MC samples, as well as a runTheMatrix workflow for it. HCAL DPG is currently using hcalNano to process MC for several important activities, but we don't have an official workflow built into CMSSW for this at the moment. So, this PR would help HCAL DPG by keeping an official recipe built into CMSSW.

No backport is needed.

#### PR validation:

Tested the new code and worflow using this command:
`runTheMatrix.py -l 2500.251 -w nano --ibeos`
and the output hcalNano looks good.

#### Note:
As noted in a comment in the code, some labels in the runTheMatrix code specify the CMSSW release 14_0, but this new workflow is actually using a sample generated using 14_2. This is just for the consistency of the names, but I could update the naming conventions if anyone has a preference (just please let me know what names are suggested.)
