### PR TITLE
Enable implicit host-to-device copy for Alpaka EDProducers

### DIFF
--- a/DataFormats/Portable/interface/PortableCollection.h
+++ b/DataFormats/Portable/interface/PortableCollection.h
@@ -5,6 +5,7 @@
 
 #include "DataFormats/Portable/interface/PortableHostCollection.h"
 #include "DataFormats/Portable/interface/PortableDeviceCollection.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/concepts.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/CopyToDevice.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/CopyToHost.h"
 
@@ -47,8 +48,10 @@ using PortableMultiCollection = typename traits::PortableMultiCollectionTrait<TD
 // define how to copy PortableCollection between host and device
 namespace cms::alpakatools {
   template <typename TLayout, typename TDevice>
+    requires alpaka::isDevice<TDevice>
   struct CopyToHost<PortableDeviceCollection<TLayout, TDevice>> {
     template <typename TQueue>
+      requires alpaka::isQueue<TQueue>
     static auto copyAsync(TQueue& queue, PortableDeviceCollection<TLayout, TDevice> const& srcData) {
       PortableHostCollection<TLayout> dstData(srcData->metadata().size(), queue);
       alpaka::memcpy(queue, dstData.buffer(), srcData.buffer());
@@ -57,8 +60,10 @@ namespace cms::alpakatools {
   };
 
   template <typename TDev, typename T0, typename... Args>
+    requires alpaka::isDevice<TDev>
   struct CopyToHost<PortableDeviceMultiCollection<TDev, T0, Args...>> {
     template <typename TQueue>
+      requires alpaka::isQueue<TQueue>
     static auto copyAsync(TQueue& queue, PortableDeviceMultiCollection<TDev, T0, Args...> const& srcData) {
       PortableHostMultiCollection<T0, Args...> dstData(srcData.sizes(), queue);
       alpaka::memcpy(queue, dstData.buffer(), srcData.buffer());
@@ -68,7 +73,7 @@ namespace cms::alpakatools {
 
   template <typename TLayout>
   struct CopyToDevice<PortableHostCollection<TLayout>> {
-    template <typename TQueue>
+    template <cms::alpakatools::NonCPUQueue TQueue>
     static auto copyAsync(TQueue& queue, PortableHostCollection<TLayout> const& srcData) {
       using TDevice = typename alpaka::trait::DevType<TQueue>::type;
       PortableDeviceCollection<TLayout, TDevice> dstData(srcData->metadata().size(), queue);
@@ -79,7 +84,7 @@ namespace cms::alpakatools {
 
   template <typename T0, typename... Args>
   struct CopyToDevice<PortableHostMultiCollection<T0, Args...>> {
-    template <typename TQueue>
+    template <cms::alpakatools::NonCPUQueue TQueue>
     static auto copyAsync(TQueue& queue, PortableHostMultiCollection<T0, Args...> const& srcData) {
       using TDevice = typename alpaka::trait::DevType<TQueue>::type;
       PortableDeviceMultiCollection<TDevice, T0, Args...> dstData(srcData.sizes(), queue);

--- a/HeterogeneousCore/AlpakaCore/README.md
+++ b/HeterogeneousCore/AlpakaCore/README.md
@@ -58,32 +58,11 @@ Note that even if for Event data formats the examples above used `DataFormats` p
 
 ### Implicit data transfers
 
-Both EDProducers and ESProducers make use of implicit data transfers.
+Both EDProducers and ESProducers make use of implicit data transfers. In CPU backends these data transfers are omitted, and the host-side and the "device-side" data products are the same.
 
-#### EDProducer
+#### Data copy definitions
 
-In EDProducers for each device-side data product a transfer from the device memory space to the host memory space is registered automatically. The data product is copied only if the job has another EDModule that consumes the host-side data product. The framework code to issue the transfer makes use of `cms::alpakatools::CopyToHost` class template that must be specialized along
-```cpp
-#include "HeterogeneousCore/AlpakaInterface/interface/CopyToHost.h"
-
-namespace cms::alpakatools {
-  template <>
-  struct CopyToHost<TSrc> {
-    template <typename TQueue>
-    static auto copyAsync(TQueue& queue, TSrc const& deviceProduct) -> TDst {
-      // code to construct TDst object, and launch the asynchronous memcpy from the device of TQueue to the host
-      return ...;
-    }
-  };
-}
-```
-Note that the destination (host-side) type `TDst` can be different from or the same as the source (device-side) type `TSrc` as far as the framework is concerned. For example, in the `PortableCollection` model the types are different. The `copyAsync()` member function is easiest to implement as a template over `TQueue`. The framework handles the necessary synchronization between the copy function and the consumer in a non-blocking way.
-
-The `CopyToHost` class template is partially specialized for all `PortableCollection` instantiations.
-
-#### ESProducer
-
-In ESProducers for each host-side data product a transfer from the host memory space to the device memory space (of the backend of the ESProducer) is registered automatically. The data product is copied only if the job has another ESProducer or EDModule that consumes the device-side data product. The framework code to issue makes use of `cms::alpakatools::CopyToDevice` class template that must be specialized along 
+The implicit host-to-device and device-to-host copies rely on specialization of `cms::alpakatools::CopyToDevice` and `cms::alpakatools::CopyToHost` class templates, respectively. These have to be specialized along
 ```cpp
 #include "HeterogeneousCore/AlpakaInterface/interface/CopyToDevice.h"
 
@@ -91,6 +70,7 @@ namespace cms::alpakatools {
   template<>
   struct CopyToDevice<TSrc> {
     template <typename TQueue>
+      requires alpaka::isQueue<TQueue>
     static auto copyAsync(TQueue& queue, TSrc const& hostProduct) -> TDst {
       // code to construct TDst object, and launch the asynchronous memcpy from the host to the device of TQueue
       return ...;
@@ -98,13 +78,32 @@ namespace cms::alpakatools {
   };
 }
 ```
-Note that the destination (device-side) type `TDst` can be different from or the same as the source (host-side) type `TSrc` as far as the framework is concerned. For example, in the `PortableCollection` model the types are different. The `copyAsync()` member function is easiest to implement as a template over `TQueue`. The framework handles the necessary synchronization between the copy function and the consumer in a non-blocking way.
+or
+```cpp
+#include "HeterogeneousCore/AlpakaInterface/interface/CopyToHost.h"
 
-The `CopyToDevice` class template is partially specialized for all `PortableCollection` instantiations.
+namespace cms::alpakatools {
+  template <>
+  struct CopyToHost<TSrc> {
+    template <typename TQueue>
+      requires alpaka::isQueue<TQueue>
+    static auto copyAsync(TQueue& queue, TSrc const& deviceProduct) -> TDst {
+      // code to construct TDst object, and launch the asynchronous memcpy from the device of TQueue to the host
+      return ...;
+    }
+  };
+}
+```
+respectively. 
 
-#### Data products with `memcpy()`ed pointers
+Note that the destination (device-side/host-side) type `TDst` can be different from or the same as the source (host-side/device-side) type `TSrc` as far as the framework is concerned. For example, in the `PortableCollection` model the types are different. The `copyAsync()` member function is easiest to implement as a template over `TQueue`. The framework handles the necessary synchronization between the copy function and the consumer in a non-blocking way.
 
-If the data product in question contains pointers to memory elsewhere within the data product, after the `alpaka::memcpy()` calls in the `copyAsync()` those pointers still point to device memory, and need to be updated. **Such data products are generally discouraged.** Nevertheless, such pointers can be updated without any additional synchronization by implementing a `postCopy()` function in the `CopyToHost` specialization along (extending the `CopyToHost` example [above](#edproducer))
+Both `CopyToDevice` and `CopyToHost` class templates are partially specialized for all `PortableObject` and `PortableCollection` instantiations.
+
+
+##### Data products with `memcpy()`ed pointers
+
+If the data product in question contains pointers to memory elsewhere within the data product, after the `alpaka::memcpy()` calls in the `copyAsync()` those pointers still point to device memory, and need to be updated. **Such data products are generally discouraged.** Nevertheless, such pointers can be updated without any additional synchronization by implementing a `postCopy()` function in the `CopyToHost` specialization along (extending the `CopyToHost` example [above](#data-copy-definitions))
 ```cpp
 namespace cms::alpakatools {
   template <>
@@ -121,7 +120,18 @@ namespace cms::alpakatools {
 ```
 The `postCopy()` is called after the operations enqueued in the `copyAsync()` have finished. The code in `postCopy()` must be such that the call to `postCopy()` can be omitted on CPU backends.
 
-Note that for `CopyToDevice` such `postCopy()` functionality is **not** provided. It should be possible to a issue kernel call (via an intermediate host-side function) from the `CopyToDevice::copyAsync()` function to achieve the same effect.
+Note that for `CopyToDevice` such `postCopy()` functionality is **not** provided. It should be possible to a issue kernel call from the `CopyToDevice::copyAsync()` function to achieve the same effect.
+
+
+#### EDProducer
+
+In EDProducers for each device-side data product a transfer from the device memory space to the host memory space is registered automatically. The data product is copied only if the job has another EDModule that consumes the host-side data product. For each device-side data product a specialization of `cms::alpakatools::CopyToHost` is required to exist.
+
+In addition, for each host-side data product a transfer from the host memory space to the device meory space is registered autmatically **if** a `cms::alpakatools::CopyToDevice` specialization exists. The data product is copied only if the job has another EDModule that consumes the device-side data product.
+
+#### ESProducer
+
+In ESProducers for each host-side data product a transfer from the host memory space to the device memory space (of the backend of the ESProducer) is registered automatically. The data product is copied only if the job has another ESProducer or EDModule that consumes the device-side data product. For each host-side data product a specialization of `cms::alpakatools::CopyToDevice` is required to exist.
 
 ### `PortableCollection`
 
@@ -157,7 +167,7 @@ Note that currently Alpaka-based ESSources are not supported. If you need to pro
 
 The Alpaka-based modules have a notion of a _host memory space_ and _device memory space_ for the Event and EventSetup data products. The data products in the host memory space are accessible for non-Alpaka modules, whereas the data products in device memory space are available only for modules of the specific Alpaka backend. The host backend(s) use the host memory space directly.
 
-The EDModules get `device::Event` and `device::EventSetup` from the framework, from which data products in both host memory space and device memory space can be accessed. Data products can also be produced to either memory space. For all data products produced in the device memory space an implicit data copy from the device memory space to the host memory space is registered as discussed above. The `device::Event::queue()` returns the Alpaka `Queue` object into which all work in the EDModule must be enqueued. 
+The EDModules get `device::Event` and `device::EventSetup` from the framework, from which data products in both host memory space and device memory space can be accessed. Data products can also be produced to either memory space. As discussed [above](#edproducer), for each data product produced into the device memory space an implicit data copy from the device memory space to the host memory space is registered, and for each data produced produced into the host memory space for which `cms::alpakatools::CopyToDevice` is specialized an implicit data copy from the host memory space to the device memory space is registered. The `device::Event::queue()` returns the Alpaka `Queue` object into which all work in the EDModule must be enqueued.
 
 The ESProducer can have two different `produce()` function signatures
 * If the function has the usual `TRecord const&` parameter, the function can read an ESProduct from the host memory space, and produce another product into the host memory space. An implicit copy of the data product from the host memory space to the device memory space (of the backend of the ESProducer) is registered as discussed above.

--- a/HeterogeneousCore/AlpakaInterface/interface/concepts.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/concepts.h
@@ -1,0 +1,13 @@
+#ifndef HeterogeneousCore_AlpakaInterface_interface_concepts_h
+#define HeterogeneousCore_AlpakaInterface_interface_concepts_h
+
+#include <type_traits>
+
+#include <alpaka/alpaka.hpp>
+
+namespace cms::alpakatools {
+  template <typename T>
+  concept NonCPUQueue = alpaka::isQueue<T> and not std::is_same_v<alpaka::Dev<T>, alpaka::DevCpu>;
+}  // namespace cms::alpakatools
+
+#endif

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaGlobalProducerImplicitCopyToDevice.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaGlobalProducerImplicitCopyToDevice.cc
@@ -1,0 +1,39 @@
+#include "DataFormats/Portable/interface/PortableObject.h"
+#include "DataFormats/PortableTestObjects/interface/TestHostObject.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/global/EDProducer.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/host.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+  /**
+   * This class demonstrates a global EDProducer that
+   * - produces a host-side EDProduct that is copied to device automatically
+   */
+  class TestAlpakaGlobalProducerImplicitCopyToDevice : public global::EDProducer<> {
+  public:
+    TestAlpakaGlobalProducerImplicitCopyToDevice(edm::ParameterSet const& config)
+        : EDProducer<>(config), putToken_{produces()}, putTokenInstance_{produces("instance")} {}
+
+    void produce(edm::StreamID, device::Event& iEvent, device::EventSetup const& iSetup) const override {
+      portabletest::TestStruct test{6., 14., 15., 52};
+      iEvent.emplace(putToken_, cms::alpakatools::host(), test);
+      iEvent.emplace(putTokenInstance_, cms::alpakatools::host(), test);
+    }
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+      descriptions.addWithDefaultLabel(desc);
+    }
+
+  private:
+    const edm::EDPutTokenT<portabletest::TestHostObject> putToken_;
+    const edm::EDPutTokenT<portabletest::TestHostObject> putTokenInstance_;
+  };
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/MakerMacros.h"
+DEFINE_FWK_ALPAKA_MODULE(TestAlpakaGlobalProducerImplicitCopyToDevice);

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaVerifyObjectOnDevice.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaVerifyObjectOnDevice.cc
@@ -1,0 +1,51 @@
+#include "DataFormats/PortableTestObjects/interface/alpaka/TestDeviceObject.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/EDGetToken.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/stream/SynchronizingEDProducer.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/host.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+
+#include "verifyDeviceObjectAsync.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+  class TestAlpakaVerifyObjectOnDevice : public stream::SynchronizingEDProducer<> {
+  public:
+    TestAlpakaVerifyObjectOnDevice(edm::ParameterSet const& config)
+        : SynchronizingEDProducer<>(config),
+          getToken_{consumes(config.getParameter<edm::InputTag>("source"))},
+          putToken_{produces()} {}
+
+    void acquire(device::Event const& iEvent, device::EventSetup const& iSetup) override {
+      auto const& deviceObject = iEvent.get(getToken_);
+      succeeded_ = verifyDeviceObjectAsync(iEvent.queue(), deviceObject);
+    }
+
+    void produce(device::Event& iEvent, device::EventSetup const& iSetup) override {
+      if (not **succeeded_) {
+        throw cms::Exception("Assert") << "Device object verification failed";
+      }
+      iEvent.emplace(putToken_, true);
+    }
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+      desc.add<edm::InputTag>("source");
+      descriptions.addWithDefaultLabel(desc);
+    }
+
+  private:
+    const device::EDGetToken<portabletest::TestDeviceObject> getToken_;
+    const edm::EDPutTokenT<bool> putToken_;
+    std::optional<cms::alpakatools::host_buffer<bool>> succeeded_;
+  };
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/MakerMacros.h"
+DEFINE_FWK_ALPAKA_MODULE(TestAlpakaVerifyObjectOnDevice);

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/verifyDeviceObjectAsync.dev.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/verifyDeviceObjectAsync.dev.cc
@@ -1,0 +1,23 @@
+#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
+
+#include "verifyDeviceObjectAsync.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+  cms::alpakatools::host_buffer<bool> verifyDeviceObjectAsync(Queue& queue,
+                                                              portabletest::TestDeviceObject const& deviceObject) {
+    auto tmp = cms::alpakatools::make_device_buffer<bool>(queue);
+    alpaka::exec<Acc1D>(
+        queue,
+        cms::alpakatools::make_workdiv<Acc1D>(1, 1),
+        [] ALPAKA_FN_ACC(Acc1D const& acc, portabletest::TestStruct const* obj, bool* result) {
+          if (cms::alpakatools::once_per_grid(acc)) {
+            *result = (obj->x == 6. and obj->y == 14. and obj->z == 15. and obj->id == 52);
+          }
+        },
+        deviceObject.data(),
+        tmp.data());
+    auto ret = cms::alpakatools::make_host_buffer<bool>(queue);
+    alpaka::memcpy(queue, ret, tmp);
+    return ret;
+  }
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/verifyDeviceObjectAsync.h
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/verifyDeviceObjectAsync.h
@@ -1,0 +1,13 @@
+#ifndef HeterogeneousCore_AlpakaTest_plugins_alpaka_verifyDeviceObjectAsync_h
+#define HeterogeneousCore_AlpakaTest_plugins_alpaka_verifyDeviceObjectAsync_h
+
+#include "DataFormats/PortableTestObjects/interface/alpaka/TestDeviceObject.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+  cms::alpakatools::host_buffer<bool> verifyDeviceObjectAsync(Queue& queue,
+                                                              portabletest::TestDeviceObject const& deviceObject);
+}
+
+#endif

--- a/HeterogeneousCore/AlpakaTest/test/testAlpakaModules_cfg.py
+++ b/HeterogeneousCore/AlpakaTest/test/testAlpakaModules_cfg.py
@@ -92,6 +92,7 @@ process.alpakaGlobalProducerMoveToDeviceCache = cms.EDProducer("TestAlpakaGlobal
     y = cms.int32(42),
     z = cms.int32(52),
 )
+process.alpakaGlobalProducerImplicitCopyToDevice = cms.EDProducer("TestAlpakaGlobalProducerImplicitCopyToDevice@alpaka")
 process.alpakaStreamProducer = cms.EDProducer("TestAlpakaStreamProducer@alpaka",
     source = cms.InputTag("intProduct"),
     eventSetupSource = cms.ESInputTag("alpakaESProducerB", "explicitLabel"),
@@ -144,6 +145,13 @@ process.alpakaGlobalConsumerMoveToDeviceCache = process.alpakaGlobalConsumer.clo
     source = "alpakaGlobalProducerMoveToDeviceCache",
     expectXvalues = cms.vdouble([32]*10)
 )
+from HeterogeneousCore.AlpakaTest.modules import TestAlpakaVerifyObjectOnDevice_alpaka
+process.alpakaGlobalConsumerImplicitCopyToDevice = TestAlpakaVerifyObjectOnDevice_alpaka(
+    source = "alpakaGlobalProducerImplicitCopyToDevice"
+)
+process.alpakaGlobalConsumerImplicitCopyToDeviceInstance = TestAlpakaVerifyObjectOnDevice_alpaka(
+    source = ("alpakaGlobalProducerImplicitCopyToDevice", "instance")
+)
 process.alpakaStreamConsumer = cms.EDAnalyzer("TestAlpakaAnalyzer",
     source = cms.InputTag("alpakaStreamProducer"),
     expectSize = cms.int32(5),
@@ -174,8 +182,10 @@ _postfixes = ["ESProducerA", "ESProducerB", "ESProducerC", "ESProducerD", "ESPro
               "ESProducerNull",
               "GlobalProducer", "GlobalProducerE",
               "GlobalProducerCopyToDeviceCache", "GlobalProducerMoveToDeviceCache",
+              "GlobalProducerImplicitCopyToDevice",
               "StreamProducer", "StreamInstanceProducer",
               "StreamSynchronizingProducer", "StreamSynchronizingProducerToDevice",
+              "GlobalConsumerImplicitCopyToDevice", "GlobalConsumerImplicitCopyToDeviceInstance",
               "GlobalDeviceConsumer", "StreamDeviceConsumer",
               "StreamSynchronizingProducerToDeviceDeviceConsumer1", "StreamSynchronizingProducerToDeviceDeviceConsumer2",
               "NullESConsumer"]
@@ -240,6 +250,7 @@ process.t = cms.Task(
     process.alpakaGlobalProducerE,
     process.alpakaGlobalProducerCopyToDeviceCache,
     process.alpakaGlobalProducerMoveToDeviceCache,
+    process.alpakaGlobalProducerImplicitCopyToDevice,
     process.alpakaStreamProducer,
     process.alpakaStreamInstanceProducer,
     process.alpakaStreamSynchronizingProducer,
@@ -251,6 +262,8 @@ process.p = cms.Path(
     process.alpakaGlobalConsumerE+
     process.alpakaGlobalConsumerCopyToDeviceCache+
     process.alpakaGlobalConsumerMoveToDeviceCache+
+    process.alpakaGlobalConsumerImplicitCopyToDevice+
+    process.alpakaGlobalConsumerImplicitCopyToDeviceInstance+
     process.alpakaStreamConsumer+
     process.alpakaStreamDeviceConsumer+
     process.alpakaStreamInstanceConsumer+


### PR DESCRIPTION
#### PR description:

This PR adds a capability for Alpaka-based EDProducers to implicitly copy the produced host-side data products (declared to be produced via `edm::EDPutToken<T>`) **if** a `cms::alpakatools::CopyToDevice<T>` specialization exists.

In order to be able to ask the question "does the specialization exist", the first commit constrains the `CopyToDevice<T>` specializations for `PortableCollection` and `PortableObject` to exists only when the Queue is a non-CPU queue (because both `PortableDeviceCollection` and `PortableDeviceObject` can be constructed only for non-CPU devices), otherwise already asking the question would result in a compilation error (at least with the `requires` expression).

Resolves https://github.com/cms-sw/framework-team/issues/1131

#### PR validation:

The `testHeterogeneousCoreAlpakaTestModules{CPU,CUDA}` tests pass on a machine without and with NVIDIA GPU, respectively.