### PR TITLE
add vertex trimming to the phase2 hlt tracking iterations

### DIFF
--- a/Configuration/ProcessModifiers/python/phase2_hlt_vertexTrimming_cff.py
+++ b/Configuration/ProcessModifiers/python/phase2_hlt_vertexTrimming_cff.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+# This modifier is used to enable vertex trimming in the tracking sequences
+# and in all related reconstruction modules
+phase2_hlt_vertexTrimming = cms.Modifier()

--- a/Configuration/PyReleaseValidation/README.md
+++ b/Configuration/PyReleaseValidation/README.md
@@ -59,6 +59,9 @@ The offsets currently in use are:
 * 0.753: HLT phase-2 timing menu Alpaka, single tracking iteration variant
 * 0.754: HLT phase-2 timing menu Alpaka, single tracking iteration, LST building variant
 * 0.755: HLT phase-2 timing menu Alpaka, LST building variant
+* 0.756 HLT phase-2 timing menu trimmed tracking
+* 0.7561 HLT phase-2 timing menu Alpaka, trimmed tracking
+* 0.7562 HLT phase-2 timing menu Alpaka, trimmed tracking, single tracking iteration variant
 * 0.777 New Phase 2 Standalone Muon seeding, streamlined L3 Tracker Muons reconstruction (Inside-Out first), HLT Muon NanoAOD
 * 0.778 New Phase 2 Standalone Muon seeding, streamlined L3 Tracker Muons reconstruction (Outside-In first), HLT Muon NanoAOD
 * 0.78: Complete L1 workflow

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1848,6 +1848,36 @@ upgradeWFs['HLTTiming75e33AlpakaLST'].step3 = {
     '-s':'HARVESTING:@hltValidation'
 }
 
+upgradeWFs['HLTTiming75e33TrimmedTracking'] = deepcopy(upgradeWFs['HLTTiming75e33'])
+upgradeWFs['HLTTiming75e33TrimmedTracking'].suffix = '_HLT75e33TimingTrimmedTracking'
+upgradeWFs['HLTTiming75e33TrimmedTracking'].offset = 0.756
+upgradeWFs['HLTTiming75e33TrimmedTracking'].step2 = {
+    '-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:75e33_timing,VALIDATION:@hltValidation',
+    '--procModifiers': 'phase2_hlt_vertexTrimming',
+    '--datatier':'GEN-SIM-DIGI-RAW,DQMIO',
+    '--eventcontent':'FEVTDEBUGHLT,DQMIO'
+}
+
+upgradeWFs['HLTTiming75e33AlpakaTrimmedTracking'] = deepcopy(upgradeWFs['HLTTiming75e33'])
+upgradeWFs['HLTTiming75e33AlpakaTrimmedTracking'].suffix = '_HLT75e33TimingAlpakaTrimmedTracking'
+upgradeWFs['HLTTiming75e33AlpakaTrimmedTracking'].offset = 0.7561
+upgradeWFs['HLTTiming75e33AlpakaTrimmedTracking'].step2 = {
+    '-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:75e33_timing,VALIDATION:@hltValidation',
+    '--procModifiers': 'alpaka,phase2_hlt_vertexTrimming',
+    '--datatier':'GEN-SIM-DIGI-RAW,DQMIO',
+    '--eventcontent':'FEVTDEBUGHLT,DQMIO'
+}
+
+upgradeWFs['HLTTiming75e33AlpakaTrimmedTrackingSingleIter'] = deepcopy(upgradeWFs['HLTTiming75e33'])
+upgradeWFs['HLTTiming75e33AlpakaTrimmedTrackingSingleIter'].suffix = '_HLT75e33TimingAlpakaTrimmedTrackingSingleIter'
+upgradeWFs['HLTTiming75e33AlpakaTrimmedTrackingSingleIter'].offset = 0.7562
+upgradeWFs['HLTTiming75e33AlpakaTrimmedTrackingSingleIter'].step2 = {
+    '-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:75e33_timing,VALIDATION:@hltValidation',
+    '--procModifiers': 'alpaka,phase2_hlt_vertexTrimming,singleIterPatatrack',
+    '--datatier':'GEN-SIM-DIGI-RAW,DQMIO',
+    '--eventcontent':'FEVTDEBUGHLT,DQMIO'
+}
+
 class UpgradeWorkflow_HLTwDIGI75e33(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):
         if 'DigiTrigger' in step:

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepHitDoublets_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepHitDoublets_cfi.py
@@ -12,3 +12,6 @@ hltHighPtTripletStepHitDoublets = cms.EDProducer("HitPairEDProducer",
     trackingRegions = cms.InputTag("hltPhase2PixelTracksAndHighPtStepTrackingRegions"),
     trackingRegionsSeedingLayers = cms.InputTag("")
 )
+
+from Configuration.ProcessModifiers.phase2_hlt_vertexTrimming_cff import phase2_hlt_vertexTrimming
+phase2_hlt_vertexTrimming.toModify(hltHighPtTripletStepHitDoublets, trackingRegions = "hltTrackingRegionFromTrimmedVertices")

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepTrackingRegionFromTrimmedVertices_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepTrackingRegionFromTrimmedVertices_cfi.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+hltTrackingRegionFromTrimmedVertices = cms.EDProducer('GlobalTrackingRegionWithVerticesEDProducer',
+  RegionPSet = cms.PSet(
+    ptMin                   = cms.double(0.9),
+    beamSpot                = cms.InputTag('hltOnlineBeamSpot'),
+    VertexCollection        = cms.InputTag('hltPhase2TrimmedPixelVertices'),
+    originRadius            = cms.double(0.02),
+    precise                 = cms.bool(True),
+    useMultipleScattering   = cms.bool(False),
+    useFixedError           = cms.bool(True),
+    sigmaZVertex            = cms.double(3.0),
+    fixedError              = cms.double(0.2),
+    useFoundVertices        = cms.bool(True),
+    useFakeVertices         = cms.bool(False),
+    maxNVertices            = cms.int32(-1),
+    nSigmaZ                 = cms.double(4.0),
+    pixelClustersForScaling = cms.InputTag('hltSiPixelClusters'),
+    originRScaling4BigEvts  = cms.bool(False),
+    ptMinScaling4BigEvts    = cms.bool(False),
+    halfLengthScaling4BigEvts = cms.bool(False),
+    allowEmpty              = cms.bool(False),
+    minOriginR              = cms.double(0),
+    maxPtMin                = cms.double(1000),
+    minHalfLength           = cms.double(0),
+    scalingStartNPix        = cms.double(0.0),
+    scalingEndNPix          = cms.double(1.0),
+  )
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepSeeds_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepSeeds_cfi.py
@@ -17,3 +17,6 @@ hltInitialStepSeeds = cms.EDProducer("SeedGeneratorFromProtoTracksEDProducer",
 
 from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
 trackingLST.toModify(hltInitialStepSeeds, includeFourthHit = True)
+
+from Configuration.ProcessModifiers.phase2_hlt_vertexTrimming_cff import phase2_hlt_vertexTrimming
+phase2_hlt_vertexTrimming.toModify(hltInitialStepSeeds, InputVertexCollection = "hltPhase2TrimmedPixelVertices")

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2TrimmedPixelVertices_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2TrimmedPixelVertices_cfi.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+hltPhase2TrimmedPixelVertices = cms.EDProducer("PixelVertexCollectionTrimmer",
+    src             = cms.InputTag("hltPhase2PixelVertices"),
+    maxVtx          = cms.uint32(300),
+    fractionSumPt2  = cms.double(0.3),
+    minSumPt2       = cms.double(0.0),
+    PVcomparer      = cms.PSet(
+        refToPSet_ = cms.string("pSetPvClusterComparerForIT"),
+    )
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTHighPtTripletStepSeedingSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTHighPtTripletStepSeedingSequence_cfi.py
@@ -5,5 +5,11 @@ from ..modules.hltHighPtTripletStepHitDoublets_cfi import *
 from ..modules.hltHighPtTripletStepHitTriplets_cfi import *
 from ..modules.hltHighPtTripletStepSeedLayers_cfi import *
 from ..modules.hltHighPtTripletStepSeeds_cfi import *
+from ..modules.hltHighPtTripletStepTrackingRegionFromTrimmedVertices_cfi import *
 
 HLTHighPtTripletStepSeedingSequence = cms.Sequence(hltHighPtTripletStepClusters+hltHighPtTripletStepSeedLayers+hltHighPtTripletStepHitDoublets+hltHighPtTripletStepHitTriplets+hltHighPtTripletStepSeeds)
+
+from Configuration.ProcessModifiers.phase2_hlt_vertexTrimming_cff import phase2_hlt_vertexTrimming
+_HLTHighPtTripletStepSeedingSequenceTrimming = HLTHighPtTripletStepSeedingSequence.copy()
+_HLTHighPtTripletStepSeedingSequenceTrimming.insert(0, hltTrackingRegionFromTrimmedVertices)
+phase2_hlt_vertexTrimming.toReplaceWith(HLTHighPtTripletStepSeedingSequence, _HLTHighPtTripletStepSeedingSequenceTrimming)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTTrackingSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTTrackingSequence_cfi.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from ..modules.hltGeneralTracks_cfi import *
 from ..modules.hltPhase2PixelVertices_cfi import *
+from ..modules.hltPhase2TrimmedPixelVertices_cfi import *
 from ..modules.hltTrackerClusterCheck_cfi import *
 from ..sequences.HLTHighPtTripletStepSequence_cfi import *
 from ..sequences.HLTPhase2PixelTracksSequence_cfi import *
@@ -20,3 +21,8 @@ HLTTrackingSequence = cms.Sequence(HLTItLocalRecoSequence+
 
 from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
 singleIterPatatrack.toReplaceWith(HLTTrackingSequence, HLTTrackingSequence.copyAndExclude([HLTHighPtTripletStepSequence]))
+
+from Configuration.ProcessModifiers.phase2_hlt_vertexTrimming_cff import phase2_hlt_vertexTrimming
+_HLTTrackingSequenceTrimming = HLTTrackingSequence.copy()
+_HLTTrackingSequenceTrimming.insert(_HLTTrackingSequenceTrimming.index(hltPhase2PixelVertices)+1, hltPhase2TrimmedPixelVertices)
+phase2_hlt_vertexTrimming.toReplaceWith(HLTTrackingSequence, _HLTTrackingSequenceTrimming)


### PR DESCRIPTION
#### PR description:

This PR adds vertex trimming to the phase2 hlt menu with a proc. modifier. This modifier allows to select and build only initial step seeds and high-pt triplet step doublets compatible with a subset of pixel vertices.
Preliminary studies of this configuration are available [here](https://indico.cern.ch/event/1497974/#54-trackinghlt-a-summary-of-cu) for the legacy iterations.

**update**: the LST workflows have been removed from the PR.

#### PR validation:

This PR has been validated comparing the results of the customisation function used so far with the proc. modifier approach. [Comparison plots](https://lguzzi.web.cern.ch/lguzzi/Tracking/Phase2/trimming/procModifier_validation/) show no difference.
Efficiency and fake rates for the alpaka and LST configurations are outlined [here](https://docs.google.com/presentation/d/1_viXZDe-MINZvIUvu4wN75QO3yKMfJUGmwwMuZrIDXI/edit?usp=sharing).

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
not needed