### PR TITLE
Created DroppedDataProductResolver

### DIFF
--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -218,8 +218,7 @@ namespace edm {
     virtual void changedIndexes_() {}
 
     //called by adjustIndexesAfterProductRegistryAddition
-    void addDelayedReaderInputProduct(std::shared_ptr<BranchDescription const> bd);
-    void addPutOnReadInputProduct(std::shared_ptr<BranchDescription const> bd);
+    void addDroppedProduct(BranchDescription const& bd);
 
     WrapperBase const* getIt(ProductID const&) const override;
     std::optional<std::tuple<WrapperBase const*, unsigned int>> getThinnedProduct(ProductID const&,

--- a/FWCore/Framework/src/DroppedDataProductResolver.cc
+++ b/FWCore/Framework/src/DroppedDataProductResolver.cc
@@ -1,0 +1,29 @@
+/*----------------------------------------------------------------------
+----------------------------------------------------------------------*/
+#include "DroppedDataProductResolver.h"
+#include "FWCore/Framework/interface/ProductProvenanceRetriever.h"
+
+namespace edm {
+
+  DroppedDataProductResolver::Resolution DroppedDataProductResolver::resolveProduct_(
+      Principal const& principal,
+      bool skipCurrentProcess,
+      SharedResourcesAcquirer* sra,
+      ModuleCallingContext const* mcc) const {
+    return Resolution(nullptr);
+  }
+  void DroppedDataProductResolver::prefetchAsync_(WaitingTaskHolder waitTask,
+                                                  Principal const& principal,
+                                                  bool skipCurrentProcess,
+                                                  ServiceToken const& token,
+                                                  SharedResourcesAcquirer* sra,
+                                                  ModuleCallingContext const* mcc) const noexcept {}
+
+  void DroppedDataProductResolver::retrieveAndMerge_(
+      Principal const& principal, MergeableRunProductMetadata const* mergeableRunProductMetadata) const {}
+
+  void DroppedDataProductResolver::setProductProvenanceRetriever_(ProductProvenanceRetriever const* provRetriever) {
+    m_provenance.setStore(provRetriever);
+  }
+
+}  // namespace edm

--- a/FWCore/Framework/src/DroppedDataProductResolver.h
+++ b/FWCore/Framework/src/DroppedDataProductResolver.h
@@ -1,0 +1,57 @@
+#ifndef FWCore_Framework_DroppedDataProductResolver_h
+#define FWCore_Framework_DroppedDataProductResolver_h
+
+/*----------------------------------------------------------------------
+
+ProductResolver: Class to handle access to a WrapperBase and its related information.
+
+ [The class was formerly called Group and later ProductHolder]
+----------------------------------------------------------------------*/
+
+#include "FWCore/Framework/interface/ProductResolverBase.h"
+
+namespace edm {
+  class DroppedDataProductResolver : public ProductResolverBase {
+  public:
+    DroppedDataProductResolver(std::shared_ptr<BranchDescription const> bd)
+        : ProductResolverBase(), m_provenance(bd, {}) {}
+
+    void connectTo(ProductResolverBase const&, Principal const*) final {}
+
+  private:
+    Resolution resolveProduct_(Principal const& principal,
+                               bool skipCurrentProcess,
+                               SharedResourcesAcquirer* sra,
+                               ModuleCallingContext const* mcc) const final;
+    void prefetchAsync_(WaitingTaskHolder waitTask,
+                        Principal const& principal,
+                        bool skipCurrentProcess,
+                        ServiceToken const& token,
+                        SharedResourcesAcquirer* sra,
+                        ModuleCallingContext const* mcc) const noexcept final;
+
+    void retrieveAndMerge_(Principal const& principal,
+                           MergeableRunProductMetadata const* mergeableRunProductMetadata) const final;
+    bool productUnavailable_() const final { return true; }
+    bool productResolved_() const final { return true; }
+    bool productWasDeleted_() const final { return false; }
+    bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const final { return false; }
+    bool unscheduledWasNotRun_() const final { return false; }
+    void resetProductData_(bool deleteEarly) final {}
+    BranchDescription const& branchDescription_() const final { return m_provenance.branchDescription(); }
+    void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) final {
+      m_provenance.setBranchDescription(bd);
+    }
+    Provenance const* provenance_() const final { return &m_provenance; }
+
+    std::string const& resolvedModuleLabel_() const final { return moduleLabel(); }
+    void setProductProvenanceRetriever_(ProductProvenanceRetriever const* provRetriever) final;
+    void setProductID_(ProductID const& pid) final { m_provenance.setProductID(pid); }
+    ProductProvenance const* productProvenancePtr_() const final { return m_provenance.productProvenance(); }
+    bool singleProduct_() const final { return true; }
+
+    Provenance m_provenance;
+  };
+}  // namespace edm
+
+#endif

--- a/FWCore/Framework/src/DroppedDataProductResolver.h
+++ b/FWCore/Framework/src/DroppedDataProductResolver.h
@@ -3,9 +3,8 @@
 
 /*----------------------------------------------------------------------
 
-ProductResolver: Class to handle access to a WrapperBase and its related information.
+DroppedDataProductResolver: Handles case of a DataProduct which was dropped on output
 
- [The class was formerly called Group and later ProductHolder]
 ----------------------------------------------------------------------*/
 
 #include "FWCore/Framework/interface/ProductResolverBase.h"
@@ -14,7 +13,7 @@ namespace edm {
   class DroppedDataProductResolver : public ProductResolverBase {
   public:
     DroppedDataProductResolver(std::shared_ptr<BranchDescription const> bd)
-        : ProductResolverBase(), m_provenance(bd, {}) {}
+        : ProductResolverBase(), m_provenance(std::move(bd), {}) {}
 
     void connectTo(ProductResolverBase const&, Principal const*) final {}
 

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -238,7 +238,15 @@ namespace edm {
 
   unsigned int EventPrincipal::transitionIndex_() const { return streamID_.value(); }
 
-  void EventPrincipal::changedIndexes_() { provRetrieverPtr_->update(productRegistry()); }
+  void EventPrincipal::changedIndexes_() {
+    provRetrieverPtr_->update(productRegistry());
+    //If new Retrievers were added, we need to pass the provenance retriever
+    for (auto& prod : *this) {
+      if (prod->singleProduct()) {
+        prod->setProductProvenanceRetriever(productProvenanceRetrieverPtr());
+      }
+    }
+  }
 
   static void throwProductDeletedException(ProductID const& pid,
                                            edm::EventPrincipal::ConstProductResolverPtr const phb) {

--- a/FWCore/Framework/src/ProductResolversFactory.cc
+++ b/FWCore/Framework/src/ProductResolversFactory.cc
@@ -2,6 +2,7 @@
 #include "FWCore/Framework/interface/ProductResolverBase.h"
 #include "DataFormats/Provenance/interface/ProductResolverIndexHelper.h"
 #include "ProductResolvers.h"
+#include "DroppedDataProductResolver.h"
 
 #include <memory>
 
@@ -25,6 +26,10 @@ namespace edm::productResolversFactory {
     std::shared_ptr<ProductResolverBase> makeTransformProduct(std::shared_ptr<BranchDescription const> bd) {
       return std::make_shared<TransformingProductResolver>(std::move(bd));
     }
+    std::shared_ptr<ProductResolverBase> makeDroppedProduct(std::shared_ptr<BranchDescription const> bd) {
+      return std::make_shared<DroppedDataProductResolver>(std::move(bd));
+    }
+
     std::shared_ptr<ProductResolverBase> makeAliasedProduct(
         std::shared_ptr<BranchDescription const> bd,
         ProductRegistry const& iReg,
@@ -98,6 +103,10 @@ namespace edm::productResolversFactory {
         return makeScheduledProduct(cbd);
       }
       /* not produced so comes from source */
+      if (bd.dropped()) {
+        //this allows access to provenance for the dropped product
+        return makeDroppedProduct(cbd);
+      }
       if (bd.onDemand()) {
         return makeDelayedReaderInputProduct(cbd);
       }

--- a/FWCore/Integration/plugins/TestFindProduct.cc
+++ b/FWCore/Integration/plugins/TestFindProduct.cc
@@ -199,15 +199,20 @@ namespace edmtest {
 
     const std::vector<edm::InputTag> emptyTagVector;
 
-    ps.addUntracked<std::vector<edm::InputTag>>("inputTags", emptyTagVector)->setComment("Get these IntProduct data products");
-    ps.addUntracked<int>("expectedSum", 0)->setComment("The sum of all values from data products obtained from entire job.");
+    ps.addUntracked<std::vector<edm::InputTag>>("inputTags", emptyTagVector)
+        ->setComment("Get these IntProduct data products");
+    ps.addUntracked<int>("expectedSum", 0)
+        ->setComment("The sum of all values from data products obtained from entire job.");
     ps.addUntracked<int>("expectedCache", 0)->setComment("Check value of ProcessBlock caches.");
     ps.addUntracked<bool>("getByTokenFirst", false)->setComment("Call getByToken before calling getByLabel");
     ps.addUntracked<bool>("runProducerParameterCheck", false);
     ps.addUntracked<bool>("testGetterOfProducts", false);
-    ps.addUntracked<std::vector<edm::InputTag>>("inputTagsNotFound", emptyTagVector)->setComment("Data products which should be missing from the job.");
-    ps.addUntracked<std::vector<edm::InputTag>>("inputTagsView", emptyTagVector)->setComment("Data products to get via View<int>.");
-    ps.addUntracked<std::vector<edm::InputTag>>("inputTagsUInt64", emptyTagVector)->setComment("Get these UInt64Product data products.");
+    ps.addUntracked<std::vector<edm::InputTag>>("inputTagsNotFound", emptyTagVector)
+        ->setComment("Data products which should be missing from the job.");
+    ps.addUntracked<std::vector<edm::InputTag>>("inputTagsView", emptyTagVector)
+        ->setComment("Data products to get via View<int>.");
+    ps.addUntracked<std::vector<edm::InputTag>>("inputTagsUInt64", emptyTagVector)
+        ->setComment("Get these UInt64Product data products.");
     ps.addUntracked<std::vector<edm::InputTag>>("inputTagsEndLumi", emptyTagVector);
     ps.addUntracked<std::vector<edm::InputTag>>("inputTagsEndRun", emptyTagVector);
     ps.addUntracked<std::vector<edm::InputTag>>("inputTagsBeginProcessBlock", emptyTagVector);

--- a/FWCore/Integration/plugins/TestFindProduct.cc
+++ b/FWCore/Integration/plugins/TestFindProduct.cc
@@ -57,6 +57,8 @@ namespace edmtest {
     void endProcessBlock(edm::ProcessBlock const&) override;
     void endJob() override;
 
+    static void fillDescriptions(edm::ConfigurationDescriptions& iDesc);
+
   private:
     std::vector<edm::InputTag> inputTags_;
     int expectedSum_;
@@ -189,6 +191,33 @@ namespace edmtest {
             return returnValue;
           });
     }
+  }
+
+  void TestFindProduct::fillDescriptions(edm::ConfigurationDescriptions& iDesc) {
+    iDesc.setComment("Tests state of IntProduct, UInt64Product, and/or View<int> data products in the job.");
+    edm::ParameterSetDescription ps;
+
+    const std::vector<edm::InputTag> emptyTagVector;
+
+    ps.addUntracked<std::vector<edm::InputTag>>("inputTags", emptyTagVector)->setComment("Get these IntProduct data products");
+    ps.addUntracked<int>("expectedSum", 0)->setComment("The sum of all values from data products obtained from entire job.");
+    ps.addUntracked<int>("expectedCache", 0)->setComment("Check value of ProcessBlock caches.");
+    ps.addUntracked<bool>("getByTokenFirst", false)->setComment("Call getByToken before calling getByLabel");
+    ps.addUntracked<bool>("runProducerParameterCheck", false);
+    ps.addUntracked<bool>("testGetterOfProducts", false);
+    ps.addUntracked<std::vector<edm::InputTag>>("inputTagsNotFound", emptyTagVector)->setComment("Data products which should be missing from the job.");
+    ps.addUntracked<std::vector<edm::InputTag>>("inputTagsView", emptyTagVector)->setComment("Data products to get via View<int>.");
+    ps.addUntracked<std::vector<edm::InputTag>>("inputTagsUInt64", emptyTagVector)->setComment("Get these UInt64Product data products.");
+    ps.addUntracked<std::vector<edm::InputTag>>("inputTagsEndLumi", emptyTagVector);
+    ps.addUntracked<std::vector<edm::InputTag>>("inputTagsEndRun", emptyTagVector);
+    ps.addUntracked<std::vector<edm::InputTag>>("inputTagsBeginProcessBlock", emptyTagVector);
+    ps.addUntracked<std::vector<edm::InputTag>>("inputTagsInputProcessBlock", emptyTagVector);
+    ps.addUntracked<std::vector<edm::InputTag>>("inputTagsEndProcessBlock", emptyTagVector);
+    ps.addUntracked<std::vector<edm::InputTag>>("inputTagsEndProcessBlock2", emptyTagVector);
+    ps.addUntracked<std::vector<edm::InputTag>>("inputTagsEndProcessBlock3", emptyTagVector);
+    ps.addUntracked<std::vector<edm::InputTag>>("inputTagsEndProcessBlock4", emptyTagVector);
+
+    iDesc.addDefault(ps);
   }
 
   TestFindProduct::~TestFindProduct() {}

--- a/FWCore/Integration/plugins/TestParentage.cc
+++ b/FWCore/Integration/plugins/TestParentage.cc
@@ -59,6 +59,8 @@ namespace edmtest {
 
     void analyze(edm::StreamID, edm::Event const& e, edm::EventSetup const& es) const override;
 
+    static void fillDescriptions(edm::ConfigurationDescriptions& iDesc);
+
   private:
     edm::EDGetTokenT<IntProduct> token_;
     std::vector<std::string> expectedAncestors_;
@@ -70,14 +72,31 @@ namespace edmtest {
         expectedAncestors_(pset.getParameter<std::vector<std::string> >("expectedAncestors")),
         callGetProvenance_(pset.getUntrackedParameter<bool>("callGetProvenance", true)) {}
 
+  void TestParentage::fillDescriptions(edm::ConfigurationDescriptions& iDesc) {
+    edm::ParameterSetDescription ps;
+    ps.add<edm::InputTag>("inputTag");
+    ps.add<std::vector<std::string> >("expectedAncestors")
+        ->setComment(
+            "Module labels for data products directly/indirectly obtained to make data product retrieved using "
+            "'inputTag'.");
+    ps.addUntracked<bool>("callGetProvenance", true)
+        ->setComment("Use Event::getProvenance to get ancestor provenance.");
+
+    iDesc.addDefault(ps);
+  }
+
   void TestParentage::analyze(edm::StreamID, edm::Event const& e, edm::EventSetup const&) const {
     edm::Handle<IntProduct> h = e.getHandle(token_);
-
+    *h;
     edm::Provenance const* prov = h.provenance();
 
+    if (not prov) {
+      throw cms::Exception("MissingProvenance") << "Failed to get provenance for 'inputTag'";
+    }
     if (prov->originalBranchID() != prov->branchDescription().originalBranchID()) {
-      std::cerr << "TestParentage::analyze: test of Provenance::originalBranchID function failed" << std::endl;
-      abort();
+      throw cms::Exception("InconsistentBranchID")
+          << " test of Provenance::originalBranchID function failed. Expected "
+          << prov->branchDescription().originalBranchID() << " but see " << prov->originalBranchID();
     }
 
     std::set<std::string> expectedAncestors(expectedAncestors_.begin(), expectedAncestors_.end());
@@ -91,6 +110,12 @@ namespace edmtest {
     // Currently we need to turn off this part of the test of when calling
     // from a SubProcess and the parentage includes a product not kept
     // in the SubProcess. This might get fixed someday ...
+    auto toException = [](auto& ex, auto const& ancestors) {
+      for (auto const& a : ancestors) {
+        ex << a << ", ";
+      }
+    };
+
     if (callGetProvenance_) {
       std::set<edm::BranchID> ancestors;
       getAncestors(e, prov->branchID(), ancestors);
@@ -100,8 +125,12 @@ namespace edmtest {
         ancestorLabels.insert(branchIDToLabel[ancestor]);
       }
       if (ancestorLabels != expectedAncestors) {
-        std::cerr << "TestParentage::analyze: ancestors do not match expected ancestors" << std::endl;
-        abort();
+        cms::Exception ex("WrongAncestors");
+        ex << "ancestors from Event::getProvenance\n";
+        toException(ex, ancestorLabels);
+        ex << "\n do not match expected ancestors\n";
+        toException(ex, expectedAncestors);
+        throw ex;
       }
     }
 
@@ -114,9 +143,12 @@ namespace edmtest {
       ancestorLabels2.insert(branchIDToLabel[ancestor]);
     }
     if (ancestorLabels2 != expectedAncestors) {
-      std::cerr << "TestParentage::analyze: ancestors do not match expected ancestors (parentage from retriever)"
-                << std::endl;
-      abort();
+      cms::Exception ex("WrongAncestors");
+      ex << "ancestors from ParentageRetriever\n";
+      toException(ex, ancestorLabels2);
+      ex << "\n do not match expected ancestors\n";
+      toException(ex, expectedAncestors);
+      throw ex;
     }
   }
 }  // namespace edmtest

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -133,6 +133,8 @@
   <test name="TestFWCoreIntegrationTryToContinueESProducer" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/test_TryToContinue_ESProducer_cfg.py"/>
   <test name="TestFWCoreIntegrationTryToContinueESProducerContinue" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/test_TryToContinue_ESProducer_cfg.py --continueAnalyzer"/>
 
+  <test name="TestFWCoreIntegrationInconsistentProducts" command="run_inconsistent_products.sh"/>
+
   <test name="TestIntegrationProcessBlock1" command="run_TestProcessBlock.sh 1"/>
   <test name="TestIntegrationProcessBlock2" command="run_TestProcessBlock.sh 2"/>
   <test name="TestIntegrationProcessBlock3" command="run_TestProcessBlock.sh 3"/>

--- a/FWCore/Integration/test/inconsistent_products_prod_cfg.py
+++ b/FWCore/Integration/test/inconsistent_products_prod_cfg.py
@@ -1,0 +1,59 @@
+import FWCore.ParameterSet.Config as cms
+
+import argparse
+import sys
+
+parser = argparse.ArgumentParser(prog=sys.argv[0], description='Test Processes with inconsistent data products.')
+
+parser.add_argument("--dropThing2", help="drop Thing2 from output", action="store_true")
+parser.add_argument("--fileName", help="name of output file")
+parser.add_argument("--noThing2Prod", help="do not include Thing2's producer", action="store_true")
+parser.add_argument("--startEvent", help="starting event number", type=int, default=1)
+parser.add_argument("--addAndStoreOther2", help='add the OtherThingProducer consuming thing2 and store it', action='store_true')
+parser.add_argument("--thing2DependsOnThing1", help="have thing2 depend on thing1", action='store_true')
+
+args = parser.parse_args()
+
+
+process = cms.Process("PROD")
+
+nEvents = 10
+from FWCore.Modules.modules import EmptySource
+process.source = EmptySource(firstEvent = args.startEvent)
+
+process.maxEvents.input = nEvents
+
+from FWCore.Framework.modules import IntProducer, AddIntsProducer
+process.thing1 = IntProducer(ivalue=1)
+
+process.t = cms.Task(process.thing1)
+if not args.noThing2Prod:
+    if args.thing2DependsOnThing1:
+        process.thing2 = AddIntsProducer(labels=['thing1'])
+    else:
+        process.thing2 = IntProducer(ivalue=2)
+    process.t.add(process.thing2)
+    if args.addAndStoreOther2:
+        process.other2 = AddIntsProducer(labels=['thing2'])
+        process.t.add(process.other2)
+elif args.addAndStoreOther2:
+    process.other2 = AddIntsProducer(labels=['thing1'])
+    process.t.add(process.other2)
+
+outputs = []
+if args.dropThing2:
+    outputs = ["keep *",
+                "drop *_thing2_*_*"]
+    
+
+from IOPool.Output.modules import PoolOutputModule
+process.o = PoolOutputModule(outputCommands = outputs,
+                             fileName = args.fileName
+                             )
+
+process.out = cms.EndPath(process.o, process.t)
+
+
+                             
+
+                            

--- a/FWCore/Integration/test/inconsistent_products_test_cfg.py
+++ b/FWCore/Integration/test/inconsistent_products_test_cfg.py
@@ -1,0 +1,44 @@
+import FWCore.ParameterSet.Config as cms
+import argparse
+import sys
+
+parser = argparse.ArgumentParser(prog=sys.argv[0], description='Test Refs after merge.')
+
+parser.add_argument("--fileNames", nargs='+', help="files to read")
+parser.add_argument("--nEventsToFail", help='number of events to fail before actually reading file', type=int)
+parser.add_argument("--thing2Dropped", help="tell `other` to expect thing2 to be missing", action='store_true')
+parser.add_argument("--thing2NotRun", help="the thing2 module was never run", action="store_true")
+parser.add_argument("--other2Run", help="the other2 module was run", action="store_true")
+parser.add_argument("--thing2DependsOnThing1", help="in previous job thing2 depends on thing1", action='store_true')
+args = parser.parse_args()
+
+print(args)
+process = cms.Process("TEST")
+
+from IOPool.Input.modules import PoolSource
+process.source = PoolSource(fileNames = [f"file:{n}" for n in args.fileNames])
+
+from FWCore.Integration.modules import TestFindProduct, TestParentage
+
+process.filt = cms.EDFilter("TestFilterModule", acceptValue = cms.untracked.int32(args.nEventsToFail))
+getTags=[]
+missingTags=[]
+if args.thing2Dropped or args.thing2NotRun:
+    missingTags=['thing2']
+else:
+    getTags=['thing2']
+process.other = TestFindProduct(getByTokenFirst=True, inputTags=getTags, inputTagsNotFound=missingTags)
+expectedAncestors = []
+if args.thing2NotRun:
+    expectedAncestors = ['thing1']
+else:
+    if args.thing2DependsOnThing1:
+        expectedAncestors = ['thing2', 'thing1']
+    else:
+        expectedAncestors = ['thing2']
+
+process.e = cms.Path(~process.filt+process.other)
+if args.other2Run:
+    process.parentage = TestParentage(inputTag='other2', expectedAncestors=expectedAncestors)
+    process.e +=process.parentage
+

--- a/FWCore/Integration/test/run_inconsistent_products.sh
+++ b/FWCore/Integration/test/run_inconsistent_products.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+test=inconsistent_products_
+
+function die { echo Failure $1: status $2 ; exit $2 ; }
+
+LOCAL_TEST_DIR=${SCRAM_TEST_PATH}
+echo ${test}prod_allThings ------------------------------------------------------------
+cmsRun ${LOCAL_TEST_DIR}/${test}prod_cfg.py --startEvent=11 --fileName='allThings.root' || die "cmsRun ${test}prod_cfg.py" $?
+
+echo ${test}prod_dropThing2 ------------------------------------------------------------
+cmsRun ${LOCAL_TEST_DIR}/${test}prod_cfg.py --dropThing2 --fileName 'dropThing2.root'|| die "cmsRun ${test}prod_cfg.py --dropThing2" $?
+
+echo ${test}test_dropThing2------------------------------------------------------------
+#If file which contains the branch is read second, things fail
+cmsRun ${LOCAL_TEST_DIR}/${test}test_cfg.py --nEventsToFail=10  --fileNames dropThing2.root allThings.root && die "cmsRun ${test}cfg.py dropThing2 --fileNames dropThing2.root allThings.root" 1
+
+echo ${test}test_dropThing2_2nd------------------------------------------------------------
+#If file which contains the branch is read first, things succeed
+cmsRun ${LOCAL_TEST_DIR}/${test}test_cfg.py --nEventsToFail=10  --thing2Dropped --fileNames allThings.root dropThing2.root  || die "cmsRun ${test}cfg.py --thing2Dropped --fileNames allThings.root dropThing2.root" $?
+
+echo ${test}prod_dropThing2_other2 ------------------------------------------------------------
+cmsRun ${LOCAL_TEST_DIR}/${test}prod_cfg.py --dropThing2 --addAndStoreOther2 --fileName 'dropThing2_other2.root'|| die "cmsRun ${test}prod_cfg.py --dropThing2 --addAndStoreOther2" $?
+
+echo ${test}prod_allThings ------------------------------------------------------------
+cmsRun ${LOCAL_TEST_DIR}/${test}prod_cfg.py --startEvent=11 --addAndStoreOther2 --fileName='allThings_other2.root' || die "cmsRun ${test}prod_cfg.py --addAndStoreOther2" $?
+
+echo ${test}test_dropThing2_other2_allThings------------------------------------------------------------
+#If file which contains the branch is read second, things fail
+cmsRun ${LOCAL_TEST_DIR}/${test}test_cfg.py --nEventsToFail=10  --fileNames dropThing2_other2.root allThings.root && die "cmsRun ${test}cfg.py --fileNames dropThing2_other2.root allThings.root" 1
+
+echo ${test}test_dropThing2_other2------------------------------------------------------------
+#If file which contains the branch is read second, things fail
+cmsRun ${LOCAL_TEST_DIR}/${test}test_cfg.py --nEventsToFail=10  --fileNames dropThing2_other2.root allThings_other2.root && die "cmsRun ${test}cfg.py --fileNames dropThing2_other2.root allThings_other2.root" 1
+
+echo ${test}test_dropThing2_other2_second_allThingsFirst------------------------------------------------------------
+#If file which contains the branch is read second, things fail, here the branch is other2
+cmsRun ${LOCAL_TEST_DIR}/${test}test_cfg.py --nEventsToFail=10  --thing2Dropped --fileNames allThings.root dropThing2_other2.root && die "cmsRun ${test}cfg.py --thing2Dropped --fileNames allThings.root dropThing2_other2.root" 1
+
+echo ${test}test_dropThing2_other2_second------------------------------------------------------------
+#If file which contains the branch is read first, things succeed
+cmsRun ${LOCAL_TEST_DIR}/${test}test_cfg.py --nEventsToFail=10  --thing2Dropped --other2Run --fileNames allThings_other2.root dropThing2_other2.root || die "cmsRun ${test}cfg.py --thing2Dropped --fileNames allThings_other2.root dropThing2_other2.root" $?
+
+echo ${test}prod_noThing2_other2 ------------------------------------------------------------
+cmsRun ${LOCAL_TEST_DIR}/${test}prod_cfg.py --noThing2Prod --addAndStoreOther2 --fileName 'noThing2_other2.root'|| die "cmsRun ${test}prod_cfg.py --dropThing2 --addAndStoreOther2" $?
+
+echo ${test}test_noThing2_other2_second------------------------------------------------------------
+#If file which contains the branch is read first, things succeed
+cmsRun ${LOCAL_TEST_DIR}/${test}test_cfg.py --nEventsToFail=10  --thing2NotRun --other2Run --fileNames allThings_other2.root noThing2_other2.root || die "cmsRun ${test}cfg.py --thing2Dropped --fileNames allThings_other2.root noThing2_other2.root" $?
+
+echo ${test}test_noThing2_other2_first------------------------------------------------------------
+#If file which contains the branch is read second, things fails
+cmsRun ${LOCAL_TEST_DIR}/${test}test_cfg.py --nEventsToFail=10 --other2Run --fileNames noThing2_other2.root allThings_other2.root && die "cmsRun ${test}cfg.py --thing2Dropped --fileNames noThing2_other2 allThings_other2.root" 1
+
+echo ${test}prod_dropThing2_other2_start11 ------------------------------------------------------------
+#if thing2 is dropped and we still run other2, then other2 will read from thing1 instead thereby changing the provenance
+cmsRun ${LOCAL_TEST_DIR}/${test}prod_cfg.py --startEvent=11 --dropThing2 --addAndStoreOther2  --fileName='dropThing2_other2_start11.root' || die "cmsRun ${test}prod_cfg.py --startEvent=11 --dropThing2 --addAndStoreOther2" $?
+
+#branch structures are the same but in one other2 depends on thing1 while in the other file other2 depends on thing2
+echo ${test}test_dropThing2_other2_first_noThing2_other2_second------------------------------------------------------------
+cmsRun ${LOCAL_TEST_DIR}/${test}test_cfg.py --nEventsToFail=10  --thing2NotRun --other2Run --fileNames dropThing2_other2_start11.root noThing2_other2.root || die "cmsRun ${test}cfg.py --thing2NotRun --other2Run --fileNames dropThing2_other2_start11.root noThing2_other2.root" $?
+
+echo ${test}test_noThing2_other2_first_dropThing2_other2_second------------------------------------------------------------
+cmsRun ${LOCAL_TEST_DIR}/${test}test_cfg.py --nEventsToFail=10 --other2Run --thing2Dropped --fileNames noThing2_other2.root dropThing2_other2_start11.root || die "cmsRun ${test}cfg.py --other2Run --thing2Dropped --fileNames noThing2_other2 dropThing2_other2_start11.root" $?
+
+echo ${test}prod_dropThing2_other2_depThing1_start11 ------------------------------------------------------------
+
+#if thing2 is dropped and we still run other2, then other2 will read from thing1 instead thereby changing the provenance
+echo ${test}prod_dropThing2_other2_depThing1_start11------------------------------------------------------------
+cmsRun ${LOCAL_TEST_DIR}/${test}prod_cfg.py --startEvent=11 --dropThing2 --thing2DependsOnThing1 --addAndStoreOther2  --fileName='dropThing2_other2_depThing1_start11.root' || die "cmsRun ${test}prod_cfg.py --startEvent=11 --dropThing2 --thing2DependsOnThing1 --addAndStoreOther2" $?
+
+#branch structures are the same but in one other2 depends on thing1 while in the other file other2 depends on thing2
+echo ${test}test_dropThing2_other2_first_noThing2_other2_second------------------------------------------------------------
+cmsRun ${LOCAL_TEST_DIR}/${test}test_cfg.py --nEventsToFail=10  --thing2NotRun --other2Run --fileNames dropThing2_other2_depThing1_start11.root noThing2_other2.root || die "cmsRun ${test}cfg.py --thing2NotRun --other2Run --fileNames dropThing2_other2_depThing1_start11.root noThing2_other2.root" $?
+
+echo ${test}test_noThing2_other2_first_dropThing2_other2_second------------------------------------------------------------
+cmsRun ${LOCAL_TEST_DIR}/${test}test_cfg.py --nEventsToFail=10 --other2Run --thing2Dropped --thing2DependsOnThing1 --fileNames noThing2_other2.root dropThing2_other2_depThing1_start11.root || die "cmsRun ${test}cfg.py --other2Run --thing2Dropped --fileNames noThing2_other2 dropThing2_other2_depThing1_start11.root" $?
+
+
+
+
+exit 0


### PR DESCRIPTION
#### PR description:

- Created the new resolver as the only type which can be added later to the Principal. It can only be used to get the provenance of the dropped data product.
- Added additional unit tests.
- Fixed case where provenance not properly accessible to type which was added later.

#### PR validation:

Code compiles and framework unit tests pass.

resolves https://github.com/cms-sw/framework-team/issues/1167