### PR TITLE
Replace `ALPAKA_STATIC_ACC_MEM_GLOBAL` with `HOST_DEVICE_CONSTANT`

### DIFF
--- a/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EnergyComputationKernels.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EnergyComputationKernels.h
@@ -10,6 +10,7 @@
 #include "DataFormats/EcalRecHit/interface/EcalRecHit.h"
 #include "DataFormats/EcalRecHit/interface/EcalUncalibratedRecHit.h"
 #include "DataFormats/Provenance/interface/Timestamp.h"
+#include "FWCore/Utilities/interface/HostDeviceConstant.h"
 
 #include "DeclsForKernels.h"
 #include "KernelHelpers.h"
@@ -19,8 +20,7 @@
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE::ecal::rechit {
 
-  ALPAKA_STATIC_ACC_MEM_CONSTANT constexpr float ip10[] = {
-      1.e5f, 1.e4f, 1.e3f, 1.e2f, 1.e1f, 1.e0f, 1.e-1f, 1.e-2f, 1.e-3f, 1.e-4};
+  HOST_DEVICE_CONSTANT float ip10[] = {1.e5f, 1.e4f, 1.e3f, 1.e2f, 1.e1f, 1.e0f, 1.e-1f, 1.e-2f, 1.e-3f, 1.e-4};
 
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool checkUncalibRecHitFlag(uint32_t const flags, EcalUncalibratedRecHit::Flags flag) {
     return flags & (0x1 << flag);

--- a/RecoLocalCalo/EcalRecProducers/plugins/alpaka/KernelHelpers.dev.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/alpaka/KernelHelpers.dev.cc
@@ -1,5 +1,6 @@
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
+#include "FWCore/Utilities/interface/HostDeviceConstant.h"
 
 #include "KernelHelpers.h"
 
@@ -132,7 +133,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::ecal::reconstruction {
     ALPAKA_FN_ACC ALPAKA_FN_INLINE bool positiveZ(uint32_t id) { return id & 0x4000; }
 
     // these constants come from EE Det Id
-    ALPAKA_STATIC_ACC_MEM_CONSTANT const unsigned short kxf[] = {
+    HOST_DEVICE_CONSTANT unsigned short kxf[] = {
         41, 51, 41, 51, 41, 51, 36, 51, 36, 51, 26, 51, 26, 51, 26, 51, 21, 51, 21, 51, 21, 51, 21, 51, 21,
         51, 16, 51, 16, 51, 14, 51, 14, 51, 14, 51, 14, 51, 14, 51, 9,  51, 9,  51, 9,  51, 9,  51, 9,  51,
         6,  51, 6,  51, 6,  51, 6,  51, 6,  51, 6,  51, 6,  51, 6,  51, 6,  51, 6,  51, 4,  51, 4,  51, 4,
@@ -142,7 +143,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::ecal::reconstruction {
         9,  51, 9,  51, 9,  51, 9,  51, 9,  51, 14, 51, 14, 51, 14, 51, 14, 51, 14, 51, 16, 51, 16, 51, 21,
         51, 21, 51, 21, 51, 21, 51, 21, 51, 26, 51, 26, 51, 26, 51, 36, 51, 36, 51, 41, 51, 41, 51, 41, 51};
 
-    ALPAKA_STATIC_ACC_MEM_CONSTANT const unsigned short kdi[] = {
+    HOST_DEVICE_CONSTANT unsigned short kdi[] = {
         0,    10,   20,   30,   40,   50,   60,   75,   90,   105,  120,  145,  170,  195,  220,  245,  270,
         300,  330,  360,  390,  420,  450,  480,  510,  540,  570,  605,  640,  675,  710,  747,  784,  821,
         858,  895,  932,  969,  1006, 1043, 1080, 1122, 1164, 1206, 1248, 1290, 1332, 1374, 1416, 1458, 1500,
@@ -279,8 +280,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::ecal::reconstruction {
     return value;
   }
 
-  ALPAKA_STATIC_ACC_MEM_CONSTANT constexpr float p10[] = {
-      1.e-2f, 1.e-1f, 1.f, 1.e1f, 1.e2f, 1.e3f, 1.e4f, 1.e5f, 1.e6f};
+  HOST_DEVICE_CONSTANT float p10[] = {1.e-2f, 1.e-1f, 1.f, 1.e1f, 1.e2f, 1.e3f, 1.e4f, 1.e5f, 1.e6f};
 
   ALPAKA_FN_ACC int32_t rechitGetPower10(float e) {
     int b = e < p10[4] ? 0 : 5;

--- a/RecoLocalCalo/HcalRecProducers/plugins/alpaka/Mahi.dev.cc
+++ b/RecoLocalCalo/HcalRecProducers/plugins/alpaka/Mahi.dev.cc
@@ -9,6 +9,7 @@
 // needed to compile with USER_CXXFLAGS="-DCOMPUTE_TDC_TIME"
 #include "DataFormats/HcalRecHit/interface/HcalSpecialTimes.h"
 #include "FWCore/Utilities/interface/CMSUnrollLoop.h"
+#include "FWCore/Utilities/interface/HostDeviceConstant.h"
 // TODO reuse some of the HCAL constats from
 //#include "RecoLocalCalo/HcalRecAlgos/interface/HcalConstants.h"
 
@@ -50,7 +51,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
       // HcalQIEShapes are hardcoded in HcalQIEData.cc basically
       // + some logic to generate 128 and 256 value arrays...
-      ALPAKA_STATIC_ACC_MEM_CONSTANT float const qie8shape[129] = {
+      HOST_DEVICE_CONSTANT float qie8shape[129] = {
           -1,   0,    1,    2,    3,    4,    5,    6,    7,    8,    9,    10,   11,   12,   13,   14,   16,
           18,   20,   22,   24,   26,   28,   31,   34,   37,   40,   44,   48,   52,   57,   62,   57,   62,
           67,   72,   77,   82,   87,   92,   97,   102,  107,  112,  117,  122,  127,  132,  142,  152,  162,
@@ -60,7 +61,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           2547, 2672, 2797, 2922, 3047, 3172, 3297, 3422, 3547, 3672, 3922, 4172, 4422, 4672, 4922, 5172, 5422,
           5797, 6172, 6547, 6922, 7422, 7922, 8422, 9047, 9672, 10297};
 
-      ALPAKA_STATIC_ACC_MEM_CONSTANT float const qie11shape[257] = {
+      HOST_DEVICE_CONSTANT float qie11shape[257] = {
           -0.5,    0.5,     1.5,     2.5,     3.5,     4.5,     5.5,     6.5,     7.5,     8.5,     9.5,     10.5,
           11.5,    12.5,    13.5,    14.5,    15.5,    17.5,    19.5,    21.5,    23.5,    25.5,    27.5,    29.5,
           31.5,    33.5,    35.5,    37.5,    39.5,    41.5,    43.5,    45.5,    47.5,    49.5,    51.5,    53.5,


### PR DESCRIPTION
#### PR description:

Replace `ALPAKA_STATIC_ACC_MEM_GLOBAL` with `HOST_DEVICE_CONSTANT`.

`ALPAKA_STATIC_ACC_MEM_GLOBAL` gets a different, more complex syntax in alpaka 1.2.0 (in order to support Intel oneAPI).
It also has a slightly different meaning, providing global symbols that can be device-`memcpy`'ed over from the host, while `HOST_DEVICE_CONSTANT` supports only plain constants.

Follow up to #47108.

#### PR validation:

None.

No changes expected.