### PR TITLE
Removed use of ConstProductRegistry outside of the framework

### DIFF
--- a/CalibTracker/SiStripCommon/plugins/ShallowTree.cc
+++ b/CalibTracker/SiStripCommon/plugins/ShallowTree.cc
@@ -11,10 +11,10 @@ ShallowTree::ShallowTree(const edm::ParameterSet& iConfig) {
 
   //int compSettings= iConfig.getParameter<int>("CompressionSettings",-1);
   int compSettings = iConfig.getUntrackedParameter<int>("CompressionSettings", -1);
-  edm::Service<TFileService> fs_;
+  edm::Service<TFileService> fs;
   if (compSettings > 0)
-    fs_->file().SetCompressionSettings(compSettings);
-  tree_ = fs_->make<TTree>("tree", "");
+    fs->file().SetCompressionSettings(compSettings);
+  tree_ = fs->make<TTree>("tree", "");
 
   std::map<std::string, LEAFTYPE> leafmap;
   leafmap["bool"] = BOOL;
@@ -177,22 +177,22 @@ void ShallowTree::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
 
 template <class T>
 void ShallowTree::TypedBranchConnector<T>::connect(const edm::Event& iEvent) {
-  edm::Handle<T> handle_;
-  iEvent.getByLabel(ml, pin, handle_);
-  object_ = *handle_;
+  edm::Handle<T> handle;
+  iEvent.getByLabel(ml_, pin_, handle);
+  object_ = *handle;
 }
 
 template <class T>
 ShallowTree::TypedBranchConnector<T>::TypedBranchConnector(edm::BranchDescription const* desc,
                                                            std::string t,
                                                            TTree* tree)
-    : ml(desc->moduleLabel()), pin(desc->productInstanceName()) {
+    : ml_(desc->moduleLabel()), pin_(desc->productInstanceName()) {
   object_ptr_ = &object_;
-  std::string s = pin + t;
+  std::string s = pin_ + t;
   if (!t.empty()) {
-    tree->Branch(pin.c_str(), object_ptr_, s.c_str());
+    tree->Branch(pin_.c_str(), object_ptr_, s.c_str());
   }  //raw type
   else {
-    tree->Branch(pin.c_str(), &object_ptr_);
+    tree->Branch(pin_.c_str(), &object_ptr_);
   }  //vector<type>
 }

--- a/CalibTracker/SiStripCommon/plugins/ShallowTree.cc
+++ b/CalibTracker/SiStripCommon/plugins/ShallowTree.cc
@@ -1,6 +1,5 @@
 #include "ShallowTree.h"
 
-#include "FWCore/Framework/interface/ConstProductRegistry.h"
 #include "FWCore/Framework/interface/ProductSelector.h"
 #include "FWCore/Framework/interface/ProductSelectorRules.h"
 
@@ -12,6 +11,7 @@ ShallowTree::ShallowTree(const edm::ParameterSet& iConfig) {
 
   //int compSettings= iConfig.getParameter<int>("CompressionSettings",-1);
   int compSettings = iConfig.getUntrackedParameter<int>("CompressionSettings", -1);
+  edm::Service<TFileService> fs_;
   if (compSettings > 0)
     fs_->file().SetCompressionSettings(compSettings);
   tree_ = fs_->make<TTree>("tree", "");
@@ -40,136 +40,136 @@ ShallowTree::ShallowTree(const edm::ParameterSet& iConfig) {
   leafmap["uchar"] = U_CHAR;
   leafmap["uchars"] = U_CHAR_V;
 
-  edm::Service<edm::ConstProductRegistry> reg;
-  auto allBranches = reg->allBranchDescriptions();
-  edm::ProductSelectorRules productSelectorRules_(iConfig, "outputCommands", "ShallowTree");
-  edm::ProductSelector productSelector_;
-  productSelector_.initialize(productSelectorRules_, allBranches);
+  edm::ProductSelectorRules productSelectorRules(iConfig, "outputCommands", "ShallowTree");
 
   std::set<std::string> branchnames;
-
-  for (auto const& selection : allBranches) {
-    if (productSelector_.selected(*selection)) {
-      //Check for duplicate branch names
-      if (branchnames.find(selection->productInstanceName()) != branchnames.end()) {
-        throw edm::Exception(edm::errors::Configuration)
-            << "More than one branch named: " << selection->productInstanceName() << std::endl
-            << "Exception thrown from ShallowTree::ShallowTree" << std::endl;
-      } else {
-        branchnames.insert(selection->productInstanceName());
-      }
-
-      //Create ShallowTree branch
-      switch (leafmap.find(selection->friendlyClassName())->second) {
-        case BOOL:
-          connectors_.push_back(new TypedBranchConnector<bool>(selection, "/O", tree_));
-          eat<bool>(selection);
-          break;
-        case BOOL_V:
-          connectors_.push_back(new TypedBranchConnector<std::vector<bool> >(selection, "", tree_));
-          eat<std::vector<bool> >(selection);
-          break;
-        case INT:
-          connectors_.push_back(new TypedBranchConnector<int>(selection, "/I", tree_));
-          eat<int>(selection);
-          break;
-        case INT_V:
-          connectors_.push_back(new TypedBranchConnector<std::vector<int> >(selection, "", tree_));
-          eat<std::vector<int> >(selection);
-          break;
-        case U_INT:
-          connectors_.push_back(new TypedBranchConnector<unsigned int>(selection, "/i", tree_));
-          eat<unsigned int>(selection);
-          break;
-        case U_INT_V:
-          connectors_.push_back(new TypedBranchConnector<std::vector<unsigned int> >(selection, "", tree_));
-          eat<std::vector<unsigned int> >(selection);
-          break;
-        case SHORT:
-          connectors_.push_back(new TypedBranchConnector<short>(selection, "/S", tree_));
-          eat<short>(selection);
-          break;
-        case SHORT_V:
-          connectors_.push_back(new TypedBranchConnector<std::vector<short> >(selection, "", tree_));
-          eat<std::vector<short> >(selection);
-          break;
-        case U_SHORT:
-          connectors_.push_back(new TypedBranchConnector<unsigned short>(selection, "/s", tree_));
-          eat<unsigned short>(selection);
-          break;
-        case U_SHORT_V:
-          connectors_.push_back(new TypedBranchConnector<std::vector<unsigned short> >(selection, "", tree_));
-          eat<std::vector<unsigned short> >(selection);
-          break;
-        case FLOAT:
-          connectors_.push_back(new TypedBranchConnector<float>(selection, "/F", tree_));
-          eat<float>(selection);
-          break;
-        case FLOAT_V:
-          connectors_.push_back(new TypedBranchConnector<std::vector<float> >(selection, "", tree_));
-          eat<std::vector<float> >(selection);
-          break;
-        case DOUBLE:
-          connectors_.push_back(new TypedBranchConnector<double>(selection, "/D", tree_));
-          eat<double>(selection);
-          break;
-        case DOUBLE_V:
-          connectors_.push_back(new TypedBranchConnector<std::vector<double> >(selection, "", tree_));
-          eat<std::vector<double> >(selection);
-          break;
-        case LONG:
-          connectors_.push_back(new TypedBranchConnector<long>(selection, "/L", tree_));
-          eat<long>(selection);
-          break;
-        case LONG_V:
-          connectors_.push_back(new TypedBranchConnector<std::vector<long> >(selection, "", tree_));
-          eat<std::vector<long> >(selection);
-          break;
-        case U_LONG:
-          connectors_.push_back(new TypedBranchConnector<unsigned long>(selection, "/l", tree_));
-          eat<unsigned long>(selection);
-          break;
-        case U_LONG_V:
-          connectors_.push_back(new TypedBranchConnector<std::vector<unsigned long> >(selection, "", tree_));
-          eat<std::vector<unsigned long> >(selection);
-          break;
-        case CHAR:
-          connectors_.push_back(new TypedBranchConnector<char>(selection, "/B", tree_));
-          eat<char>(selection);
-          break;
-        case CHAR_V:
-          connectors_.push_back(new TypedBranchConnector<std::vector<char> >(selection, "", tree_));
-          eat<std::vector<char> >(selection);
-          break;
-        case U_CHAR:
-          connectors_.push_back(new TypedBranchConnector<unsigned char>(selection, "/b", tree_));
-          eat<unsigned char>(selection);
-          break;
-        case U_CHAR_V:
-          connectors_.push_back(new TypedBranchConnector<std::vector<unsigned char> >(selection, "", tree_));
-          eat<std::vector<unsigned char> >(selection);
-          break;
-        default: {
-          std::string leafstring = "";
-          typedef std::pair<std::string, LEAFTYPE> pair_t;
-          for (const auto& leaf : leafmap) {
-            leafstring += "\t" + leaf.first + "\n";
+  callWhenNewProductsRegistered(
+      [productSelectorRules, branchnames, leafmap, this](edm::BranchDescription const& selection) mutable {
+        if (productSelectorRules.select(selection)) {
+          //Check for duplicate branch names
+          if (branchnames.find(selection.productInstanceName()) != branchnames.end()) {
+            throw edm::Exception(edm::errors::Configuration)
+                << "More than one branch named: " << selection.productInstanceName() << std::endl
+                << "Exception thrown from ShallowTree::ShallowTree" << std::endl;
+          } else {
+            branchnames.insert(selection.productInstanceName());
           }
 
-          throw edm::Exception(edm::errors::Configuration)
-              << "class ShallowTree does not handle leaves of type " << selection->className() << " like\n"
-              << selection->friendlyClassName() << "_" << selection->moduleLabel() << "_"
-              << selection->productInstanceName() << "_" << selection->processName() << std::endl
-              << "Valid leaf types are (friendlyClassName):\n"
-              << leafstring << "Exception thrown from ShallowTree::ShallowTree\n";
+          //Create ShallowTree branch
+          switch (leafmap.find(selection.friendlyClassName())->second) {
+            case BOOL:
+              connectors_.push_back(std::make_unique<TypedBranchConnector<bool>>(&selection, "/O", tree_));
+              eat<bool>(selection);
+              break;
+            case BOOL_V:
+              connectors_.push_back(std::make_unique<TypedBranchConnector<std::vector<bool>>>(&selection, "", tree_));
+              eat<std::vector<bool>>(selection);
+              break;
+            case INT:
+              connectors_.push_back(std::make_unique<TypedBranchConnector<int>>(&selection, "/I", tree_));
+              eat<int>(selection);
+              break;
+            case INT_V:
+              connectors_.push_back(std::make_unique<TypedBranchConnector<std::vector<int>>>(&selection, "", tree_));
+              eat<std::vector<int>>(selection);
+              break;
+            case U_INT:
+              connectors_.push_back(std::make_unique<TypedBranchConnector<unsigned int>>(&selection, "/i", tree_));
+              eat<unsigned int>(selection);
+              break;
+            case U_INT_V:
+              connectors_.push_back(
+                  std::make_unique<TypedBranchConnector<std::vector<unsigned int>>>(&selection, "", tree_));
+              eat<std::vector<unsigned int>>(selection);
+              break;
+            case SHORT:
+              connectors_.push_back(std::make_unique<TypedBranchConnector<short>>(&selection, "/S", tree_));
+              eat<short>(selection);
+              break;
+            case SHORT_V:
+              connectors_.push_back(std::make_unique<TypedBranchConnector<std::vector<short>>>(&selection, "", tree_));
+              eat<std::vector<short>>(selection);
+              break;
+            case U_SHORT:
+              connectors_.push_back(std::make_unique<TypedBranchConnector<unsigned short>>(&selection, "/s", tree_));
+              eat<unsigned short>(selection);
+              break;
+            case U_SHORT_V:
+              connectors_.push_back(
+                  std::make_unique<TypedBranchConnector<std::vector<unsigned short>>>(&selection, "", tree_));
+              eat<std::vector<unsigned short>>(selection);
+              break;
+            case FLOAT:
+              connectors_.push_back(std::make_unique<TypedBranchConnector<float>>(&selection, "/F", tree_));
+              eat<float>(selection);
+              break;
+            case FLOAT_V:
+              connectors_.push_back(std::make_unique<TypedBranchConnector<std::vector<float>>>(&selection, "", tree_));
+              eat<std::vector<float>>(selection);
+              break;
+            case DOUBLE:
+              connectors_.push_back(std::make_unique<TypedBranchConnector<double>>(&selection, "/D", tree_));
+              eat<double>(selection);
+              break;
+            case DOUBLE_V:
+              connectors_.push_back(std::make_unique<TypedBranchConnector<std::vector<double>>>(&selection, "", tree_));
+              eat<std::vector<double>>(selection);
+              break;
+            case LONG:
+              connectors_.push_back(std::make_unique<TypedBranchConnector<long>>(&selection, "/L", tree_));
+              eat<long>(selection);
+              break;
+            case LONG_V:
+              connectors_.push_back(std::make_unique<TypedBranchConnector<std::vector<long>>>(&selection, "", tree_));
+              eat<std::vector<long>>(selection);
+              break;
+            case U_LONG:
+              connectors_.push_back(std::make_unique<TypedBranchConnector<unsigned long>>(&selection, "/l", tree_));
+              eat<unsigned long>(selection);
+              break;
+            case U_LONG_V:
+              connectors_.push_back(
+                  std::make_unique<TypedBranchConnector<std::vector<unsigned long>>>(&selection, "", tree_));
+              eat<std::vector<unsigned long>>(selection);
+              break;
+            case CHAR:
+              connectors_.push_back(std::make_unique<TypedBranchConnector<char>>(&selection, "/B", tree_));
+              eat<char>(selection);
+              break;
+            case CHAR_V:
+              connectors_.push_back(std::make_unique<TypedBranchConnector<std::vector<char>>>(&selection, "", tree_));
+              eat<std::vector<char>>(selection);
+              break;
+            case U_CHAR:
+              connectors_.push_back(std::make_unique<TypedBranchConnector<unsigned char>>(&selection, "/b", tree_));
+              eat<unsigned char>(selection);
+              break;
+            case U_CHAR_V:
+              connectors_.push_back(
+                  std::make_unique<TypedBranchConnector<std::vector<unsigned char>>>(&selection, "", tree_));
+              eat<std::vector<unsigned char>>(selection);
+              break;
+            default: {
+              std::string leafstring = "";
+              typedef std::pair<std::string, LEAFTYPE> pair_t;
+              for (const auto& leaf : leafmap) {
+                leafstring += "\t" + leaf.first + "\n";
+              }
+
+              throw edm::Exception(edm::errors::Configuration)
+                  << "class ShallowTree does not handle leaves of type " << selection.className() << " like\n"
+                  << selection.friendlyClassName() << "_" << selection.moduleLabel() << "_"
+                  << selection.productInstanceName() << "_" << selection.processName() << std::endl
+                  << "Valid leaf types are (friendlyClassName):\n"
+                  << leafstring << "Exception thrown from ShallowTree::ShallowTree\n";
+            }
+          }
         }
-      }
-    }
-  }
+      });
 }
 
 void ShallowTree::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  for (BranchConnector* connector : connectors_) {
+  for (auto& connector : connectors_) {
     connector->connect(iEvent);
   }
   tree_->Fill();

--- a/CalibTracker/SiStripCommon/plugins/ShallowTree.h
+++ b/CalibTracker/SiStripCommon/plugins/ShallowTree.h
@@ -49,8 +49,8 @@ private:
   template <class T>
   class TypedBranchConnector : public BranchConnector {
   private:
-    std::string ml;   //module label
-    std::string pin;  //product instance name
+    std::string ml_;   //module label
+    std::string pin_;  //product instance name
     T object_;
     T* object_ptr_;
 

--- a/CalibTracker/SiStripCommon/plugins/ShallowTree.h
+++ b/CalibTracker/SiStripCommon/plugins/ShallowTree.h
@@ -29,14 +29,15 @@
 #include <string>
 #include <vector>
 #include <TTree.h>
+#include <memory>
 
 class ShallowTree : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 private:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
   template <class T>
-  void eat(edm::BranchDescription const* desc) {
-    consumes<T>(edm::InputTag(desc->moduleLabel(), desc->productInstanceName()));
+  void eat(edm::BranchDescription const& desc) {
+    consumes<T>(edm::InputTag(desc.moduleLabel(), desc.productInstanceName()));
   }
 
   class BranchConnector {
@@ -58,9 +59,8 @@ private:
     void connect(const edm::Event&) override;
   };
 
-  edm::Service<TFileService> fs_;
   TTree* tree_;
-  std::vector<BranchConnector*> connectors_;
+  std::vector<std::unique_ptr<BranchConnector>> connectors_;
 
 public:
   explicit ShallowTree(const edm::ParameterSet& iConfig);  // : pset(iConfig) {}

--- a/FWCore/Framework/interface/ProductSelectorRules.h
+++ b/FWCore/Framework/interface/ProductSelectorRules.h
@@ -38,6 +38,7 @@ namespace edm {
       explicit BranchSelectState(edm::BranchDescription const* bd) : desc(bd), selectMe(false) {}
     };
 
+    bool select(edm::BranchDescription const& bd) const;
     void applyToAll(std::vector<BranchSelectState>& branchstates) const;
 
     bool keepAll() const { return keepAll_; }

--- a/FWCore/Framework/src/ProductSelectorRules.cc
+++ b/FWCore/Framework/src/ProductSelectorRules.cc
@@ -170,6 +170,17 @@ namespace edm {
       it->applyToAll(branchstates);
   }
 
+  bool ProductSelectorRules::select(edm::BranchDescription const& bd) const {
+    bool selected = false;
+    for (auto const& rule : rules_) {
+      rule.applyToOne(&bd, selected);
+      if (selected) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   //   bool
   //   Rule::applyToOne(edm::BranchDescription const* branch) const
   //   {


### PR DESCRIPTION
#### PR description:

Either replaced use with equivalent code (by extending ProductSelectorRules) or removing unused code.
This is in anticipation of removing all uses of ConstProductRegistry.

#### PR validation:

Code compiles.

resolves https://github.com/cms-sw/framework-team/issues/1173