### PR TITLE
fixing one include-guard and use of tabs post-#47030

### DIFF
--- a/DataFormats/L1TGlobal/interface/GlobalObjectMapFwd.h
+++ b/DataFormats/L1TGlobal/interface/GlobalObjectMapFwd.h
@@ -1,5 +1,5 @@
-#ifndef DataFormats_L1TGlobal_L1TGtObjectMapFwd_h
-#define DataFormats_L1TGlobal_L1TGtObjectMapFwd_h
+#ifndef DataFormats_L1TGlobal_GlobalObjectMapFwd_h
+#define DataFormats_L1TGlobal_GlobalObjectMapFwd_h
 
 /**
  * \class GlobalObjectMapFwd

--- a/DataFormats/L1TGlobal/src/classes_def.xml
+++ b/DataFormats/L1TGlobal/src/classes_def.xml
@@ -40,10 +40,10 @@
   <class name="edm::Wrapper<std::vector<GlobalObjectMap> >"/>
   <!-- Adding ioread rules for backwards compatibility -->
   <ioread sourceClass="GlobalObjectMap" version="[3-10]"
-	  source="std::vector<std::vector<std::vector<L1TObjIndexType>>> m_combinationVector;"
-	  targetClass="GlobalObjectMap" target="m_combinationWithBxVector">
+          source="std::vector<std::vector<std::vector<L1TObjIndexType>>> m_combinationVector;"
+          targetClass="GlobalObjectMap" target="m_combinationWithBxVector">
     <![CDATA[
-	     m_combinationWithBxVector.clear();
+             m_combinationWithBxVector.clear();
              m_combinationWithBxVector.reserve(onfile.m_combinationVector.size());
              for(auto const& a0 : onfile.m_combinationVector) {
                CombinationsWithBxInCond b0;


### PR DESCRIPTION
#### PR description:

Very minor follow-up to #47030.

 - Fixed the name of one include guard.
 - Replaced tabs with whitespaces in a `classes_def.xml` file.

#### PR validation:

Unit tests of the package in question passed.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A