### PR TITLE
revert #45630 (remove `printf` call in `alpaka/fitVertices.h`)

### DIFF
--- a/RecoVertex/PixelVertexFinding/plugins/alpaka/fitVertices.h
+++ b/RecoVertex/PixelVertexFinding/plugins/alpaka/fitVertices.h
@@ -75,19 +75,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::vertexFinder {
     alpaka::syncBlockThreads(acc);
     // reuse nn
     for (auto i : cms::alpakatools::uniform_elements(acc, foundClusters)) {
-      bool const wv_cond = (wv[i] > 0.f);
-      if (not wv_cond) {
-        printf("ERROR: wv[%d] (%f) > 0.f failed\n", i, wv[i]);
-        // printing info on tracks associated to this vertex
-        for (auto trk_i = 0u; trk_i < nt; ++trk_i) {
-          if (iv[trk_i] != int(i)) {
-            continue;
-          }
-          printf("   iv[%d]=%d zt[%d]=%f ezt2[%d]=%f\n", trk_i, iv[trk_i], trk_i, zt[trk_i], trk_i, ezt2[trk_i]);
-        }
-        ALPAKA_ASSERT_ACC(false);
-      }
-
+      ALPAKA_ASSERT_ACC(wv[i] > 0.f);
       zv[i] /= wv[i];
       nn[i] = -1;  // ndof
     }


### PR DESCRIPTION
#### PR description:

While addressing #44923, my comment in https://github.com/cms-sw/cmssw/issues/44923#issuecomment-2267853936 led to #45630 for debugging purposes, but I had not considered that the latter could have some computational cost (as explained in [#45631 (comment)](https://github.com/cms-sw/cmssw/pull/45631/files#r1704060016)).

Soon after #45630, #45656 provided the actual solution to #44923. Based on that, it looks like #45630 could be reverted at this point, but please comment if you disagree (@mmusich, @fwyzard, @slava77).

#### PR validation:

None.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A