### PR TITLE
enable a `printf` call in `fitVertices` only in `verbose` mode

### DIFF
--- a/RecoVertex/PixelVertexFinding/plugins/alpaka/fitVertices.h
+++ b/RecoVertex/PixelVertexFinding/plugins/alpaka/fitVertices.h
@@ -75,19 +75,19 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::vertexFinder {
     alpaka::syncBlockThreads(acc);
     // reuse nn
     for (auto i : cms::alpakatools::uniform_elements(acc, foundClusters)) {
-      bool const wv_cond = (wv[i] > 0.f);
-      if (not wv_cond) {
-        printf("ERROR: wv[%d] (%f) > 0.f failed\n", i, wv[i]);
-        // printing info on tracks associated to this vertex
-        for (auto trk_i = 0u; trk_i < nt; ++trk_i) {
-          if (iv[trk_i] != int(i)) {
-            continue;
+      if constexpr (verbose) {
+        if (not(wv[i] > 0.f)) {
+          printf("ERROR: wv[%d] (%f) > 0.f failed\n", i, wv[i]);
+          // printing info on tracks associated to this vertex
+          for (auto trk_i = 0u; trk_i < nt; ++trk_i) {
+            if (iv[trk_i] != int(i)) {
+              continue;
+            }
+            printf("   iv[%d]=%d zt[%d]=%f ezt2[%d]=%f\n", trk_i, iv[trk_i], trk_i, zt[trk_i], trk_i, ezt2[trk_i]);
           }
-          printf("   iv[%d]=%d zt[%d]=%f ezt2[%d]=%f\n", trk_i, iv[trk_i], trk_i, zt[trk_i], trk_i, ezt2[trk_i]);
         }
-        ALPAKA_ASSERT_ACC(false);
       }
-
+      ALPAKA_ASSERT_ACC(wv[i] > 0.f);
       zv[i] /= wv[i];
       nn[i] = -1;  // ndof
     }


### PR DESCRIPTION
#### PR description:

Replaces #47129 based on the suggestion in https://github.com/cms-sw/cmssw/pull/47129#discussion_r1920857507.

For more context, see https://github.com/cms-sw/cmssw/pull/47129#issue-2796037204 and https://github.com/cms-sw/cmssw/pull/47129#issuecomment-2599351272.

Merely technical. No changes expected.

#### PR validation:

None.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A