### PR TITLE
remove warning on value of `pcrhFracSize`

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducerKernel.dev.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducerKernel.dev.cc
@@ -1304,10 +1304,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         *nRHF = totalSeedFracOffset;
         clusterView.nSeeds() = *nSeeds;
         clusterView.nTopos() = pfClusteringVars.nTopos();
-
-        if (pfClusteringVars.pcrhFracSize() > 200000)  // Warning in case the fraction is too large
-          printf("At the end of topoClusterContraction, found large *pcrhFracSize = %d\n",
-                 pfClusteringVars.pcrhFracSize());
       }
     }
   };


### PR DESCRIPTION
#### PR description:

The HLT log file in https://github.com/cms-sw/cmssw/issues/47021#issue-2753244354 from a 2024 PbPb run shows dozens of printouts of the following kind.
```
At the end of topoClusterContraction, found large *pcrhFracSize = 212602
At the end of topoClusterContraction, found large *pcrhFracSize = 234862
At the end of topoClusterContraction, found large *pcrhFracSize = 228108
At the end of topoClusterContraction, found large *pcrhFracSize = 231427
```

For what I understand, this warning is not necessary anymore, ever since #46135 improved the handling of 'PFRecHit fractions' without relying on a fixed upper limit.

This PR removes the warning.

Merely technical. No changes expected.

FYI: @jsamudio @fwyzard 

#### PR validation:

None.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A