### PR TITLE
fix miscellaneous python configuration files

### DIFF
--- a/EventFilter/ESRawToDigi/python/esRawToDigiTmp_cfi.py
+++ b/EventFilter/ESRawToDigi/python/esRawToDigiTmp_cfi.py
@@ -1,5 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 
-from EventFilter.ESRawToDigi.esRawToDigi_cfi import *
-
-esRawToDigiTmp= esRawToDigi
+from EventFilter.ESRawToDigi.esRawToDigi_cfi import esRawToDigi as _esRawToDigi
+esRawToDigiTmp = _esRawToDigi.clone()

--- a/EventFilter/SiPixelRawToDigi/python/SiPixelRawToDigiRegional_cfi.py
+++ b/EventFilter/SiPixelRawToDigi/python/SiPixelRawToDigiRegional_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from EventFilter.SiPixelRawToDigi.SiPixelRawToDigi_cfi import *
 
 ## regional seeded unpacking for specialized HLT paths
-siPixelDigisRegional = siPixelDigis.cpu.clone()
+siPixelDigisRegional = siPixelDigis.clone()
 siPixelDigisRegional.Regions = cms.PSet(
     inputs = cms.VInputTag( "hltL2EtCutDoublePFIsoTau45Trk5" ),
     deltaPhi = cms.vdouble( 0.5 ),

--- a/RecoMuon/MuonIdentification/python/links_cfi.py
+++ b/RecoMuon/MuonIdentification/python/links_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from RecoMuon.MuonIdentificationp.muonLinksProducer_cfi import muonLinksProducer
-globalMuonLinks = muonLinksProducer.clone(
-    inputCollection = cms.InputTag("muons","","@skipCurrentProcess")
+from RecoMuon.MuonIdentification.muonLinksProducer_cfi import muonLinksProducer as _muonLinksProducer
+globalMuonLinks = _muonLinksProducer.clone(
+    inputCollection = ("muons","","@skipCurrentProcess")
 )
 

--- a/RecoTracker/MeasurementDet/python/MaskedMeasurementTrackerEventProducer_cfi.py
+++ b/RecoTracker/MeasurementDet/python/MaskedMeasurementTrackerEventProducer_cfi.py
@@ -1,4 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 
 from RecoTracker.MeasurementDet.maskedMeasurementTrackerEventProducer_cfi import maskedMeasurementTrackerEventProducer as _maskedMeasurementTrackerEventProducer
-MaskedMeasurementTrackerEvent = _maskedMeasurementTrackerEvent.clone()
+MaskedMeasurementTrackerEvent = _maskedMeasurementTrackerEventProducer.clone()


### PR DESCRIPTION
#### PR description:

Trivial PR, fixes few configuration fragments that don't compile in `CMSSW_15_0_X_2025-01-19-0000`.

#### PR validation:

Used [this script](https://github.com/cms-sw/hlt-confdb/blob/confdbv3/parser/ConfdbLoadParamsFromConfigsPy3.py). `ImportError` and `NameError` are removed.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A