### PR TITLE
add `fillDescriptions` to several `ESproducer`s used at HLT (1/N)

### DIFF
--- a/CalibTracker/SiStripESProducers/plugins/geom/SiStripRegionConnectivity.cc
+++ b/CalibTracker/SiStripESProducers/plugins/geom/SiStripRegionConnectivity.cc
@@ -1,6 +1,8 @@
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
@@ -16,9 +18,11 @@ using namespace sistrip;
 class SiStripRegionConnectivity : public edm::ESProducer {
 public:
   SiStripRegionConnectivity(const edm::ParameterSet&);
-  ~SiStripRegionConnectivity() override;
+  ~SiStripRegionConnectivity() override = default;
 
   std::unique_ptr<SiStripRegionCabling> produceRegionCabling(const SiStripRegionCablingRcd&);
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
   edm::ESGetToken<SiStripDetCabling, SiStripDetCablingRcd> detcablingToken_;
@@ -45,7 +49,13 @@ SiStripRegionConnectivity::SiStripRegionConnectivity(const edm::ParameterSet& ps
   tTopoToken_ = cc.consumes();
 }
 
-SiStripRegionConnectivity::~SiStripRegionConnectivity() {}
+void SiStripRegionConnectivity::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.addUntracked<unsigned int>("EtaDivisions", 10);
+  desc.addUntracked<unsigned int>("PhiDivisions", 10);
+  desc.addUntracked<double>("EtaMax", 2.4);
+  descriptions.addWithDefaultLabel(desc);
+}
 
 std::unique_ptr<SiStripRegionCabling> SiStripRegionConnectivity::produceRegionCabling(
     const SiStripRegionCablingRcd& iRecord) {

--- a/CalibTracker/SiStripESProducers/python/SiStripRegionConnectivity_cfi.py
+++ b/CalibTracker/SiStripESProducers/python/SiStripRegionConnectivity_cfi.py
@@ -1,9 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
-SiStripRegionConnectivity = cms.ESProducer("SiStripRegionConnectivity",
-    EtaDivisions = cms.untracked.uint32(20),
-    PhiDivisions = cms.untracked.uint32(20),
-    EtaMax = cms.untracked.double(2.5)
+from CalibTracker.SiStripESProducers.siStripRegionConnectivity_cfi import siStripRegionConnectivity as _siStripRegionConnectivity
+SiStripRegionConnectivity = _siStripRegionConnectivity.clone(
+    EtaDivisions = 20,
+    PhiDivisions = 20,
+    EtaMax = 2.5
 )
 
 

--- a/RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPE.h
+++ b/RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPE.h
@@ -1,15 +1,16 @@
 #ifndef RecoLocalTracker_Phase2TrackerRecHits_Phase2StripCPE_H
 #define RecoLocalTracker_Phase2TrackerRecHits_Phase2StripCPE_H
 
-#include "RecoLocalTracker/ClusterParameterEstimator/interface/ClusterParameterEstimator.h"
-#include "MagneticField/Engine/interface/MagneticField.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "CondFormats/SiPhase2TrackerObjects/interface/SiPhase2OuterTrackerLorentzAngle.h"
+#include "DataFormats/Phase2TrackerCluster/interface/Phase2TrackerCluster1D.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
-#include "DataFormats/Phase2TrackerCluster/interface/Phase2TrackerCluster1D.h"
-#include "CondFormats/SiPhase2TrackerObjects/interface/SiPhase2OuterTrackerLorentzAngle.h"
-
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "RecoLocalTracker/ClusterParameterEstimator/interface/ClusterParameterEstimator.h"
 
 class Phase2StripCPE final : public ClusterParameterEstimator<Phase2TrackerCluster1D> {
 public:
@@ -23,6 +24,8 @@ public:
     LocalError localErr;
     float coveredStrips;
   };
+
+  static void fillPSetDescription(edm::ParameterSetDescription& desc);
 
 public:
   Phase2StripCPE(edm::ParameterSet& conf,

--- a/RecoLocalTracker/Phase2TrackerRecHits/plugins/Phase2StripCPEESProducer.cc
+++ b/RecoLocalTracker/Phase2TrackerRecHits/plugins/Phase2StripCPEESProducer.cc
@@ -23,6 +23,7 @@ class Phase2StripCPEESProducer : public edm::ESProducer {
 public:
   Phase2StripCPEESProducer(const edm::ParameterSet&);
   std::unique_ptr<ClusterParameterEstimator<Phase2TrackerCluster1D> > produce(const TkPhase2OTCPERecord& iRecord);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
   enum CPE_t { DEFAULT, GEOMETRIC };
@@ -51,6 +52,19 @@ Phase2StripCPEESProducer::Phase2StripCPEESProducer(const edm::ParameterSet& p) {
     pDDToken_ = c.consumes();
     lorentzAngleToken_ = c.consumes();
   }
+}
+
+void Phase2StripCPEESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<std::string>("ComponentType", "Phase2StripCPE");
+
+  {
+    edm::ParameterSetDescription paramsDesc;
+    Phase2StripCPE::fillPSetDescription(paramsDesc);
+    desc.add<edm::ParameterSetDescription>("parameters", paramsDesc);
+  }
+
+  descriptions.addWithDefaultLabel(desc);
 }
 
 std::unique_ptr<ClusterParameterEstimator<Phase2TrackerCluster1D> > Phase2StripCPEESProducer::produce(

--- a/RecoLocalTracker/Phase2TrackerRecHits/python/Phase2StripCPEESProducer_cfi.py
+++ b/RecoLocalTracker/Phase2TrackerRecHits/python/Phase2StripCPEESProducer_cfi.py
@@ -1,8 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-phase2StripCPEESProducer = cms.ESProducer("Phase2StripCPEESProducer",
-                                          ComponentType = cms.string('Phase2StripCPE'),
-                                          parameters    = cms.PSet(LorentzAngle_DB = cms.bool(True),			
-                                                                   TanLorentzAnglePerTesla = cms.double(0.07)
-                                                                   )
-                                         )
+from RecoLocalTracker.Phase2TrackerRecHits.phase2StripCPEESProducer_cfi import phase2StripCPEESProducer as _phase2StripCPEESProducer
+phase2StripCPEESProducer = _phase2StripCPEESProducer.clone(ComponentType = 'Phase2StripCPE',
+                                                           parameters    = dict(LorentzAngle_DB = True,
+                                                                                TanLorentzAnglePerTesla = 0.07))

--- a/RecoLocalTracker/Phase2TrackerRecHits/src/Phase2StripCPE.cc
+++ b/RecoLocalTracker/Phase2TrackerRecHits/src/Phase2StripCPE.cc
@@ -14,6 +14,11 @@ Phase2StripCPE::Phase2StripCPE(edm::ParameterSet& conf,
   fillParam();
 }
 
+void Phase2StripCPE::fillPSetDescription(edm::ParameterSetDescription& desc) {
+  desc.add<double>("TanLorentzAnglePerTesla", 0.07);
+  desc.add<bool>("LorentzAngle_DB", true);
+}
+
 Phase2StripCPE::LocalValues Phase2StripCPE::localParameters(const Phase2TrackerCluster1D& cluster,
                                                             const GeomDetUnit& detunit) const {
   auto const& p = m_Params[detunit.index() - m_off];

--- a/RecoLocalTracker/SiStripRecHitConverter/interface/StripCPEfromTrackAngle.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/StripCPEfromTrackAngle.h
@@ -2,6 +2,8 @@
 #define RecoLocalTracker_SiStripRecHitConverter_StripCPEfromTrackAngle_H
 
 #include "RecoLocalTracker/SiStripRecHitConverter/interface/StripCPE.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 class StripCPEfromTrackAngle : public StripCPE {
 private:
@@ -27,6 +29,8 @@ private:
   Algo m_algo;
 
 public:
+  static void fillPSetDescription(edm::ParameterSetDescription& desc);
+
   using AlgoParam = StripCPE::AlgoParam;
   using AClusters = StripClusterParameterEstimator::AClusters;
   using ALocalValues = StripClusterParameterEstimator::ALocalValues;

--- a/RecoLocalTracker/SiStripRecHitConverter/src/StripCPEfromTrackAngle.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/StripCPEfromTrackAngle.cc
@@ -12,21 +12,37 @@ StripCPEfromTrackAngle::StripCPEfromTrackAngle(edm::ParameterSet& conf,
                                                const SiStripConfObject& confObj,
                                                const SiStripLatency& latency)
     : StripCPE(conf, mag, geom, lorentz, backPlaneCorrection, confObj, latency),
-      useLegacyError(conf.existsAs<bool>("useLegacyError") ? conf.getParameter<bool>("useLegacyError") : true),
-      maxChgOneMIP(conf.existsAs<float>("maxChgOneMIP") ? conf.getParameter<double>("maxChgOneMIP") : -6000.),
+      useLegacyError(conf.getParameter<bool>("useLegacyError")),
+      maxChgOneMIP(conf.getParameter<double>("maxChgOneMIP")),
       m_algo(useLegacyError ? Algo::legacy : (maxChgOneMIP < 0 ? Algo::mergeCK : Algo::chargeCK)) {
-  mLC_P[0] = conf.existsAs<double>("mLC_P0") ? conf.getParameter<double>("mLC_P0") : -.326;
-  mLC_P[1] = conf.existsAs<double>("mLC_P1") ? conf.getParameter<double>("mLC_P1") : .618;
-  mLC_P[2] = conf.existsAs<double>("mLC_P2") ? conf.getParameter<double>("mLC_P2") : .300;
+  mLC_P[0] = conf.getParameter<double>("mLC_P0");
+  mLC_P[1] = conf.getParameter<double>("mLC_P1");
+  mLC_P[2] = conf.getParameter<double>("mLC_P2");
 
-  mHC_P[SiStripDetId::TIB - 3][0] = conf.existsAs<double>("mTIB_P0") ? conf.getParameter<double>("mTIB_P0") : -.742;
-  mHC_P[SiStripDetId::TIB - 3][1] = conf.existsAs<double>("mTIB_P1") ? conf.getParameter<double>("mTIB_P1") : .202;
-  mHC_P[SiStripDetId::TID - 3][0] = conf.existsAs<double>("mTID_P0") ? conf.getParameter<double>("mTID_P0") : -1.026;
-  mHC_P[SiStripDetId::TID - 3][1] = conf.existsAs<double>("mTID_P1") ? conf.getParameter<double>("mTID_P1") : .253;
-  mHC_P[SiStripDetId::TOB - 3][0] = conf.existsAs<double>("mTOB_P0") ? conf.getParameter<double>("mTOB_P0") : -1.427;
-  mHC_P[SiStripDetId::TOB - 3][1] = conf.existsAs<double>("mTOB_P1") ? conf.getParameter<double>("mTOB_P1") : .433;
-  mHC_P[SiStripDetId::TEC - 3][0] = conf.existsAs<double>("mTEC_P0") ? conf.getParameter<double>("mTEC_P0") : -1.885;
-  mHC_P[SiStripDetId::TEC - 3][1] = conf.existsAs<double>("mTEC_P1") ? conf.getParameter<double>("mTEC_P1") : .471;
+  mHC_P[SiStripDetId::TIB - 3][0] = conf.getParameter<double>("mTIB_P0");
+  mHC_P[SiStripDetId::TIB - 3][1] = conf.getParameter<double>("mTIB_P1");
+  mHC_P[SiStripDetId::TID - 3][0] = conf.getParameter<double>("mTID_P0");
+  mHC_P[SiStripDetId::TID - 3][1] = conf.getParameter<double>("mTID_P1");
+  mHC_P[SiStripDetId::TOB - 3][0] = conf.getParameter<double>("mTOB_P0");
+  mHC_P[SiStripDetId::TOB - 3][1] = conf.getParameter<double>("mTOB_P1");
+  mHC_P[SiStripDetId::TEC - 3][0] = conf.getParameter<double>("mTEC_P0");
+  mHC_P[SiStripDetId::TEC - 3][1] = conf.getParameter<double>("mTEC_P1");
+}
+
+void StripCPEfromTrackAngle::fillPSetDescription(edm::ParameterSetDescription& desc) {
+  desc.add<bool>("useLegacyError", true);
+  desc.add<double>("maxChgOneMIP", -6000.);
+  desc.add<double>("mLC_P0", -.326);
+  desc.add<double>("mLC_P1", .618);
+  desc.add<double>("mLC_P2", .300);
+  desc.add<double>("mTIB_P0", -.742);
+  desc.add<double>("mTIB_P1", .202);
+  desc.add<double>("mTID_P0", -1.026);
+  desc.add<double>("mTID_P1", .253);
+  desc.add<double>("mTOB_P0", -1.427);
+  desc.add<double>("mTOB_P1", .433);
+  desc.add<double>("mTEC_P0", -1.885);
+  desc.add<double>("mTEC_P1", .471);
 }
 
 float StripCPEfromTrackAngle::stripErrorSquared(const unsigned N,

--- a/RecoMuon/TransientTrackingRecHit/plugins/MuonTransientTrackingRecHitBuilderESProducer.cc
+++ b/RecoMuon/TransientTrackingRecHit/plugins/MuonTransientTrackingRecHitBuilderESProducer.cc
@@ -51,8 +51,8 @@ std::unique_ptr<TransientTrackingRecHitBuilder> MuonTransientTrackingRecHitBuild
 
 void MuonTransientTrackingRecHitBuilderESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<string>("ComponentName");
-  descriptions.addDefault(desc);
+  desc.add<string>("ComponentName", "MuonRecHitBuilder");
+  descriptions.addWithDefaultLabel(desc);
 }
 
 DEFINE_FWK_EVENTSETUP_MODULE(MuonTransientTrackingRecHitBuilderESProducer);

--- a/RecoMuon/TransientTrackingRecHit/python/MuonTransientTrackingRecHitBuilder_cfi.py
+++ b/RecoMuon/TransientTrackingRecHit/python/MuonTransientTrackingRecHitBuilder_cfi.py
@@ -1,8 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 
-MuonTransientTrackingRecHitBuilderESProducer = cms.ESProducer("MuonTransientTrackingRecHitBuilderESProducer",
-    ComponentName = cms.string('MuonRecHitBuilder')
-)
-
-
-
+from RecoMuon.TransientTrackingRecHit.muonTransientTrackingRecHitBuilderESProducer_cfi import muonTransientTrackingRecHitBuilderESProducer as _muonTransientTrackingRecHitBuilderESProducer
+MuonTransientTrackingRecHitBuilderESProducer = _muonTransientTrackingRecHitBuilderESProducer.clone()

--- a/TrackPropagation/SteppingHelixPropagator/plugins/SteppingHelixPropagatorESProducer.cc
+++ b/TrackPropagation/SteppingHelixPropagator/plugins/SteppingHelixPropagatorESProducer.cc
@@ -1,26 +1,27 @@
-#include "TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixPropagator.h"
-#include "MagneticField/Engine/interface/MagneticField.h"
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
-#include "MagneticField/VolumeBasedEngine/interface/VolumeBasedMagneticField.h"
-
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/ModuleFactory.h"
-#include "FWCore/Framework/interface/ESProducer.h"
-
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
 #include <string>
 #include <memory>
 
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "MagneticField/VolumeBasedEngine/interface/VolumeBasedMagneticField.h"
+#include "TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixPropagator.h"
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
 
 class SteppingHelixPropagatorESProducer : public edm::ESProducer {
 public:
   SteppingHelixPropagatorESProducer(const edm::ParameterSet& p);
-  ~SteppingHelixPropagatorESProducer() override;
+  ~SteppingHelixPropagatorESProducer() override = default;
   std::unique_ptr<Propagator> produce(const TrackingComponentsRecord&);
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
   const edm::ParameterSet pset_;
@@ -40,8 +41,6 @@ SteppingHelixPropagatorESProducer::SteppingHelixPropagatorESProducer(const edm::
     vbMagToken_ = c.consumes(edm::ESInputTag("", pset_.getParameter<std::string>("VBFName")));
   }
 }
-
-SteppingHelixPropagatorESProducer::~SteppingHelixPropagatorESProducer() {}
 
 std::unique_ptr<Propagator> SteppingHelixPropagatorESProducer::produce(const TrackingComponentsRecord& iRecord) {
   //   if (_propagator){
@@ -130,6 +129,30 @@ std::unique_ptr<Propagator> SteppingHelixPropagatorESProducer::produce(const Tra
   }
 
   return shProp;
+}
+
+void SteppingHelixPropagatorESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<std::string>("ComponentName", "SteppingHelixPropagator");
+  desc.add<bool>("NoErrorPropagation", false);
+  desc.add<std::string>("PropagationDirection", "alongMomentum");
+  desc.add<bool>("useTuningForL2Speed", false);
+  desc.add<bool>("useIsYokeFlag", true);
+  desc.add<double>("endcapShiftInZNeg", 0.0);
+  desc.add<bool>("SetVBFPointer", false);
+  desc.add<bool>("AssumeNoMaterial", false);
+  desc.add<double>("endcapShiftInZPos", 0.0);
+  desc.add<bool>("useInTeslaFromMagField", false);
+  desc.add<std::string>("VBFName", "VolumeBasedMagneticField");
+  desc.add<bool>("useEndcapShiftsInZ", false);
+  desc.add<bool>("sendLogWarning", false);
+  desc.add<bool>("useMatVolumes", true);
+  desc.add<bool>("debug", false);
+  desc.add<bool>("ApplyRadX0Correction", true)
+      ->setComment("this sort of works but assumes a measurement at propagation origin ");
+  desc.add<bool>("useMagVolumes", true);
+  desc.add<bool>("returnTangentPlane", true);
+  descriptions.addWithDefaultLabel(desc);
 }
 
 #include "FWCore/Utilities/interface/typelookup.h"

--- a/TrackPropagation/SteppingHelixPropagator/python/SteppingHelixPropagator_cfi.py
+++ b/TrackPropagation/SteppingHelixPropagator/python/SteppingHelixPropagator_cfi.py
@@ -1,25 +1,26 @@
 import FWCore.ParameterSet.Config as cms
 
-SteppingHelixPropagator = cms.ESProducer("SteppingHelixPropagatorESProducer",
-    ComponentName = cms.string('SteppingHelixPropagator'),
-    NoErrorPropagation = cms.bool(False),
-    PropagationDirection = cms.string('alongMomentum'),
-    useTuningForL2Speed = cms.bool(False),
-    useIsYokeFlag = cms.bool(True),
-    endcapShiftInZNeg = cms.double(0.0),
-    SetVBFPointer = cms.bool(False),
-    AssumeNoMaterial = cms.bool(False),
-    endcapShiftInZPos = cms.double(0.0),
-    useInTeslaFromMagField = cms.bool(False),
-    VBFName = cms.string('VolumeBasedMagneticField'),
-    useEndcapShiftsInZ = cms.bool(False),
-    sendLogWarning = cms.bool(False),
-    useMatVolumes = cms.bool(True),
-    debug = cms.bool(False),
+from TrackPropagation.SteppingHelixPropagator.steppingHelixPropagatorESProducer_cfi import steppingHelixPropagatorESProducer
+SteppingHelixPropagator = steppingHelixPropagatorESProducer.clone(
+    ComponentName = 'SteppingHelixPropagator',
+    NoErrorPropagation = False,
+    PropagationDirection = 'alongMomentum',
+    useTuningForL2Speed = False,
+    useIsYokeFlag = True,
+    endcapShiftInZNeg = 0.0,
+    SetVBFPointer = False,
+    AssumeNoMaterial = False,
+    endcapShiftInZPos = 0.0,
+    useInTeslaFromMagField = False,
+    VBFName = 'VolumeBasedMagneticField',
+    useEndcapShiftsInZ = False,
+    sendLogWarning = False,
+    useMatVolumes = True,
+    debug = False,
     #This sort of works but assumes a measurement at propagation origin  
-    ApplyRadX0Correction = cms.bool(True),
-    useMagVolumes = cms.bool(True),
-    returnTangentPlane = cms.bool(True)
+    ApplyRadX0Correction = True,
+    useMagVolumes = True,
+    returnTangentPlane = True
 )
 
 

--- a/TrackingTools/GeomPropagators/python/AnalyticalPropagator_cfi.py
+++ b/TrackingTools/GeomPropagators/python/AnalyticalPropagator_cfi.py
@@ -1,9 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 
-AnalyticalPropagator = cms.ESProducer("AnalyticalPropagatorESProducer",
-    MaxDPhi = cms.double(1.6),
-    ComponentName = cms.string('AnalyticalPropagator'),
-    PropagationDirection = cms.string('alongMomentum')
-)
-
-
+from TrackingTools.Producers.analyticalPropagatorESProducer_cfi import analyticalPropagatorESProducer as _analyticalPropagatorESProducer
+AnalyticalPropagator = _analyticalPropagatorESProducer.clone()

--- a/TrackingTools/GeomPropagators/python/SmartPropagator_cfi.py
+++ b/TrackingTools/GeomPropagators/python/SmartPropagator_cfi.py
@@ -1,11 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 
-SmartPropagator = cms.ESProducer("SmartPropagatorESProducer",
-                                 ComponentName = cms.string('SmartPropagator'),
-                                 TrackerPropagator = cms.string('PropagatorWithMaterial'),
-                                 MuonPropagator = cms.string('SteppingHelixPropagatorAlong'),
-                                 PropagationDirection = cms.string('alongMomentum'),
-                                 Epsilon = cms.double(5.0)
-                                 )
-
-
+from TrackingTools.Producers.smartPropagatorESProducer_cfi import smartPropagatorESProducer as _smartPropagatorESProducer
+SmartPropagator = _smartPropagatorESProducer.clone()

--- a/TrackingTools/KalmanUpdators/plugins/KFUpdatorESProducer.cc
+++ b/TrackingTools/KalmanUpdators/plugins/KFUpdatorESProducer.cc
@@ -37,8 +37,8 @@ std::unique_ptr<TrajectoryStateUpdator> KFUpdatorESProducer::produce(const Track
 
 void KFUpdatorESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<std::string>("ComponentName");
-  descriptions.addDefault(desc);
+  desc.add<std::string>("ComponentName", "KFUpdator");
+  descriptions.addWithDefaultLabel(desc);
 }
 
 DEFINE_FWK_EVENTSETUP_MODULE(KFUpdatorESProducer);

--- a/TrackingTools/KalmanUpdators/python/KFUpdatorESProducer_cfi.py
+++ b/TrackingTools/KalmanUpdators/python/KFUpdatorESProducer_cfi.py
@@ -1,7 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-KFUpdatorESProducer = cms.ESProducer("KFUpdatorESProducer",
-    ComponentName = cms.string('KFUpdator')
-)
+from TrackingTools.KalmanUpdators.kfUpdatorESProducer_cfi import kfUpdatorESProducer as _kfUpdatorESProducer
+KFUpdatorESProducer = _kfUpdatorESProducer.clone()
 
 

--- a/TrackingTools/Producers/src/AnalyticalPropagatorESProducer.cc
+++ b/TrackingTools/Producers/src/AnalyticalPropagatorESProducer.cc
@@ -48,12 +48,12 @@ AnalyticalPropagatorESProducer::AnalyticalPropagatorESProducer(const edm::Parame
 
 void AnalyticalPropagatorESProducer::fillDescriptions(edm::ConfigurationDescriptions& oDesc) {
   edm::ParameterSetDescription desc;
-  desc.add<std::string>("ComponentName")->setComment("the data label assigned to the Propagator");
+  desc.add<std::string>("ComponentName", "AnalyticalPropagator")
+      ->setComment("the data label assigned to the Propagator");
   desc.add<std::string>("SimpleMagneticField", "")->setComment("the data label used to retrieve the MagneticField");
-  desc.add<std::string>("PropagationDirection");
-  desc.add<double>("MaxDPhi");
-
-  oDesc.addDefault(desc);
+  desc.add<std::string>("PropagationDirection", "alongMomentum");
+  desc.add<double>("MaxDPhi", 1.6);
+  oDesc.addWithDefaultLabel(desc);
 }
 
 std::unique_ptr<Propagator> AnalyticalPropagatorESProducer::produce(const TrackingComponentsRecord& iRecord) {


### PR DESCRIPTION
#### PR description:

This PR is similar in spirit to https://github.com/cms-sw/cmssw/pull/47017, https://github.com/cms-sw/cmssw/pull/47045, https://github.com/cms-sw/cmssw/pull/47079 and https://github.com/cms-sw/cmssw/pull/47107. It adds `fillDescriptions` (and applies light modification to modernize the source code) to a few `ESProducer`s used at HLT for both Run 3 and Phase 2. 

#### PR validation:

   * `addOnTests.py` runs fine. 
   * `hltPhase2UpgradeIntegrationTests` runs fine. 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A