### PR TITLE
Modify RPC isFront function to match criteria with will be modified RPC geometries for Run, Run 3 and Run 4

### DIFF
--- a/Configuration/Eras/python/Era_Phase2_cff.py
+++ b/Configuration/Eras/python/Era_Phase2_cff.py
@@ -20,6 +20,13 @@ from Configuration.Eras.Modifier_phase2_trigger_cff import phase2_trigger
 from Configuration.Eras.Modifier_ctpps_2022_cff import ctpps_2022
 from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
 from Configuration.Eras.ModifierChain_trackingMkFitProd_cff import trackingMkFitProdPhase2
+<<<<<<< HEAD
 
 Phase2 = cms.ModifierChain(Run3_noMkFit.copyAndExclude([phase1Pixel,trackingPhase1,seedingDeepCore,displacedRegionalTracking,ctpps_2022,dd4hep]), 
                            phase2_common, phase2_tracker, trackingPhase2PU140, phase2_ecal, phase2_hcal, phase2_hgcal, phase2_muon, phase2_GEM, hcalHardcodeConditions, phase2_timing, phase2_timing_layer, phase2_trigger, trackingMkFitProdPhase2)
+=======
+from Configuration.Eras.Modifier_phase2_RPC_cff import phase2_RPC
+
+Phase2 = cms.ModifierChain(Run3_noMkFit.copyAndExclude([phase1Pixel,trackingPhase1,seedingDeepCore,displacedRegionalTracking,ctpps_2022,dd4hep]), 
+                           phase2_common, phase2_tracker, trackingPhase2PU140, phase2_ecal, phase2_hcal, phase2_hgcal, phase2_muon, phase2_GEM, hcalHardcodeConditions, phase2_timing, phase2_timing_layer, phase2_trigger, trackingMkFitProdPhase2, phase2_RPC)
+>>>>>>> 65ec449574e (Add an RPC Modifier class for Phase2 and add it to the ModifierChain within the Phase2 Era)

--- a/Configuration/Eras/python/Era_Phase2_cff.py
+++ b/Configuration/Eras/python/Era_Phase2_cff.py
@@ -20,13 +20,7 @@ from Configuration.Eras.Modifier_phase2_trigger_cff import phase2_trigger
 from Configuration.Eras.Modifier_ctpps_2022_cff import ctpps_2022
 from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
 from Configuration.Eras.ModifierChain_trackingMkFitProd_cff import trackingMkFitProdPhase2
-<<<<<<< HEAD
-
-Phase2 = cms.ModifierChain(Run3_noMkFit.copyAndExclude([phase1Pixel,trackingPhase1,seedingDeepCore,displacedRegionalTracking,ctpps_2022,dd4hep]), 
-                           phase2_common, phase2_tracker, trackingPhase2PU140, phase2_ecal, phase2_hcal, phase2_hgcal, phase2_muon, phase2_GEM, hcalHardcodeConditions, phase2_timing, phase2_timing_layer, phase2_trigger, trackingMkFitProdPhase2)
-=======
 from Configuration.Eras.Modifier_phase2_RPC_cff import phase2_RPC
 
 Phase2 = cms.ModifierChain(Run3_noMkFit.copyAndExclude([phase1Pixel,trackingPhase1,seedingDeepCore,displacedRegionalTracking,ctpps_2022,dd4hep]), 
                            phase2_common, phase2_tracker, trackingPhase2PU140, phase2_ecal, phase2_hcal, phase2_hgcal, phase2_muon, phase2_GEM, hcalHardcodeConditions, phase2_timing, phase2_timing_layer, phase2_trigger, trackingMkFitProdPhase2, phase2_RPC)
->>>>>>> 65ec449574e (Add an RPC Modifier class for Phase2 and add it to the ModifierChain within the Phase2 Era)

--- a/Configuration/Eras/python/Era_Run3_2025_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2025_cff.py
@@ -8,11 +8,6 @@ from Configuration.Eras.Modifier_run3_SiPixel_2025_cff import run3_SiPixel_2025
 from Configuration.Eras.Modifier_run3_nanoAOD_2025_cff import run3_nanoAOD_2025
 from Configuration.ProcessModifiers.ecal_cctiming_cff import ecal_cctiming
 from Configuration.ProcessModifiers.siPixelGoodEdgeAlgo_cff import siPixelGoodEdgeAlgo
-<<<<<<< HEAD
-
-Run3_2025 = cms.ModifierChain(Run3_2024, run3_GEM_2025, stage2L1Trigger_2025, run3_SiPixel_2025, run3_CSC_2025, run3_nanoAOD_2025, ecal_cctiming, siPixelGoodEdgeAlgo)
-=======
 from Configuration.Eras.Modifier_run3_RPC_2025_cff import run3_RPC_2025
 
 Run3_2025 = cms.ModifierChain(Run3_2024, run3_GEM_2025, stage2L1Trigger_2025, run3_SiPixel_2025, run3_CSC_2025, run3_nanoAOD_2025, ecal_cctiming, siPixelGoodEdgeAlgo, run3_RPC_2025)
->>>>>>> 23630d193b4 (Add an RPC Modifier class for Run3 2025 and add it to the ModifierChain within the Run3 2025 Era)

--- a/Configuration/Eras/python/Era_Run3_2025_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2025_cff.py
@@ -8,5 +8,11 @@ from Configuration.Eras.Modifier_run3_SiPixel_2025_cff import run3_SiPixel_2025
 from Configuration.Eras.Modifier_run3_nanoAOD_2025_cff import run3_nanoAOD_2025
 from Configuration.ProcessModifiers.ecal_cctiming_cff import ecal_cctiming
 from Configuration.ProcessModifiers.siPixelGoodEdgeAlgo_cff import siPixelGoodEdgeAlgo
+<<<<<<< HEAD
 
 Run3_2025 = cms.ModifierChain(Run3_2024, run3_GEM_2025, stage2L1Trigger_2025, run3_SiPixel_2025, run3_CSC_2025, run3_nanoAOD_2025, ecal_cctiming, siPixelGoodEdgeAlgo)
+=======
+from Configuration.Eras.Modifier_run3_RPC_2025_cff import run3_RPC_2025
+
+Run3_2025 = cms.ModifierChain(Run3_2024, run3_GEM_2025, stage2L1Trigger_2025, run3_SiPixel_2025, run3_CSC_2025, run3_nanoAOD_2025, ecal_cctiming, siPixelGoodEdgeAlgo, run3_RPC_2025)
+>>>>>>> 23630d193b4 (Add an RPC Modifier class for Run3 2025 and add it to the ModifierChain within the Run3 2025 Era)

--- a/Configuration/Eras/python/Modifier_phase2_RPC_cff.py
+++ b/Configuration/Eras/python/Modifier_phase2_RPC_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+phase2_RPC =  cms.Modifier()

--- a/Configuration/Eras/python/Modifier_run3_RPC_2025_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_RPC_2025_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+run3_RPC_2025 =  cms.Modifier()
+

--- a/RecoMuon/DetLayers/plugins/MuonDetLayerGeometryESProducer.cc
+++ b/RecoMuon/DetLayers/plugins/MuonDetLayerGeometryESProducer.cc
@@ -54,7 +54,7 @@ using namespace edm;
 
 MuonDetLayerGeometryESProducer::MuonDetLayerGeometryESProducer(const edm::ParameterSet& p) {
   MuonRPCDetLayerGeometryBuilder::useUpdatedRPCIsFront = p.getParameter<bool>("useUpdatedRPCIsFront");
-  
+
   auto cc = setWhatProduced(this);
   dtToken_ = cc.consumes();
   cscToken_ = cc.consumes();

--- a/RecoMuon/DetLayers/plugins/MuonDetLayerGeometryESProducer.cc
+++ b/RecoMuon/DetLayers/plugins/MuonDetLayerGeometryESProducer.cc
@@ -53,6 +53,8 @@ private:
 using namespace edm;
 
 MuonDetLayerGeometryESProducer::MuonDetLayerGeometryESProducer(const edm::ParameterSet& p) {
+  MuonRPCDetLayerGeometryBuilder::useUpdatedRPCIsFront = p.getParameter<bool>("useUpdatedRPCIsFront");
+  
   auto cc = setWhatProduced(this);
   dtToken_ = cc.consumes();
   cscToken_ = cc.consumes();
@@ -109,7 +111,7 @@ std::unique_ptr<MuonDetLayerGeometry> MuonDetLayerGeometryESProducer::produce(co
 
 void MuonDetLayerGeometryESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  //no parameters are used
+  desc.add<bool>("useUpdatedRPCIsFront", false);
   descriptions.addDefault(desc);
 }
 

--- a/RecoMuon/DetLayers/python/muonDetLayerGeometry_cfi.py
+++ b/RecoMuon/DetLayers/python/muonDetLayerGeometry_cfi.py
@@ -4,10 +4,10 @@ import FWCore.ParameterSet.Config as cms
 # This cfi should be included to build the muon DetLayers.
 #
 
-MuonDetLayerGeometryESProducer = cms.ESProducer("MuonDetLayerGeometryESProducer", useUpdatedRPCIsFront=cms.bool(False))
+MuonDetLayerGeometryESProducer = cms.ESProducer("MuonDetLayerGeometryESProducer", useUpdatedRPCIsFront=False)
 
 from Configuration.Eras.Modifier_run3_RPC_2025_cff import run3_RPC_2025
 from Configuration.Eras.Modifier_phase2_RPC_cff import phase2_RPC
 
-run3_RPC_2025.toModify(MuonDetLayerGeometryESProducer, useUpdatedRPCIsFront=cms.bool(True))
-phase2_RPC.toModify(MuonDetLayerGeometryESProducer, useUpdatedRPCIsFront=cms.bool(True))
+run3_RPC_2025.toModify(MuonDetLayerGeometryESProducer, useUpdatedRPCIsFront=True)
+phase2_RPC.toModify(MuonDetLayerGeometryESProducer, useUpdatedRPCIsFront=True)

--- a/RecoMuon/DetLayers/python/muonDetLayerGeometry_cfi.py
+++ b/RecoMuon/DetLayers/python/muonDetLayerGeometry_cfi.py
@@ -3,7 +3,11 @@ import FWCore.ParameterSet.Config as cms
 #
 # This cfi should be included to build the muon DetLayers.
 #
-MuonDetLayerGeometryESProducer = cms.ESProducer("MuonDetLayerGeometryESProducer")
 
+MuonDetLayerGeometryESProducer = cms.ESProducer("MuonDetLayerGeometryESProducer", useUpdatedRPCIsFront=cms.bool(False))
 
+from Configuration.Eras.Modifier_run3_RPC_2025_cff import run3_RPC_2025
+from Configuration.Eras.Modifier_phase2_RPC_cff import phase2_RPC
 
+run3_RPC_2025.toModify(MuonDetLayerGeometryESProducer, useUpdatedRPCIsFront=cms.bool(True))
+phase2_RPC.toModify(MuonDetLayerGeometryESProducer, useUpdatedRPCIsFront=cms.bool(True))

--- a/RecoMuon/DetLayers/python/muonDetLayerGeometry_cfi.py
+++ b/RecoMuon/DetLayers/python/muonDetLayerGeometry_cfi.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 # This cfi should be included to build the muon DetLayers.
 #
 
-MuonDetLayerGeometryESProducer = cms.ESProducer("MuonDetLayerGeometryESProducer", useUpdatedRPCIsFront=False)
+MuonDetLayerGeometryESProducer = cms.ESProducer("MuonDetLayerGeometryESProducer", useUpdatedRPCIsFront=cms.bool(False))
 
 from Configuration.Eras.Modifier_run3_RPC_2025_cff import run3_RPC_2025
 from Configuration.Eras.Modifier_phase2_RPC_cff import phase2_RPC

--- a/RecoMuon/DetLayers/src/MuRingForwardDoubleLayer.cc
+++ b/RecoMuon/DetLayers/src/MuRingForwardDoubleLayer.cc
@@ -196,49 +196,41 @@ void MuRingForwardDoubleLayer::selfTest() const {
   std::vector<const GeomDet*> frontIRPCs, backIRPCs;
   std::vector<const GeomDet*> frontME0s, backME0s;
 
-  for ( const GeomDet* frontDet : frontDets ) {
+  for (const GeomDet* frontDet : frontDets) {
     const int subdetId = frontDet->geographicalId().subdetId();
-    if ( subdetId == MuonSubdetId::CSC ) {
+    if (subdetId == MuonSubdetId::CSC) {
       frontCSCs.push_back(frontDet);
-    }
-    else if ( subdetId == MuonSubdetId::GEM ) {
+    } else if (subdetId == MuonSubdetId::GEM) {
       frontGEMs.push_back(frontDet);
-    }
-    else if ( subdetId == MuonSubdetId::ME0 ) {
+    } else if (subdetId == MuonSubdetId::ME0) {
       frontME0s.push_back(frontDet);
-    }
-    else if ( subdetId == MuonSubdetId::RPC ) {
+    } else if (subdetId == MuonSubdetId::RPC) {
       // RPC has to split existing RPC and iRPC
       const RPCDetId rpcId(frontDet->geographicalId());
       const int ring = rpcId.ring();
-      if ( ring == 1 ) {
+      if (ring == 1) {
         frontIRPCs.push_back(frontDet);
-      }
-      else {
+      } else {
         frontRPCs.push_back(frontDet);
       }
     }
   }
 
-  for ( const GeomDet* backDet : backDets ) {
+  for (const GeomDet* backDet : backDets) {
     const int subdetId = backDet->geographicalId().subdetId();
-    if ( subdetId == MuonSubdetId::CSC ) {
+    if (subdetId == MuonSubdetId::CSC) {
       backCSCs.push_back(backDet);
-    }
-    else if ( subdetId == MuonSubdetId::GEM ) {
+    } else if (subdetId == MuonSubdetId::GEM) {
       backGEMs.push_back(backDet);
-    }
-    else if ( subdetId == MuonSubdetId::ME0 ) {
+    } else if (subdetId == MuonSubdetId::ME0) {
       backME0s.push_back(backDet);
-    }
-    else if ( subdetId == MuonSubdetId::RPC ) {
+    } else if (subdetId == MuonSubdetId::RPC) {
       // RPC has to split existing RPC and iRPC
       const RPCDetId rpcId(backDet->geographicalId());
       const int ring = rpcId.ring();
-      if ( ring == 1 ) {
+      if (ring == 1) {
         backIRPCs.push_back(backDet);
-      }
-      else {
+      } else {
         backRPCs.push_back(backDet);
       }
     }
@@ -249,67 +241,81 @@ void MuRingForwardDoubleLayer::selfTest() const {
 
   // Check the CSC ordering
   double maxZFrontCSC = 0, minZBackCSC = 1e9;
-  for ( auto frontCSC : frontCSCs ) {
+  for (auto frontCSC : frontCSCs) {
     const double z = std::abs(frontCSC->surface().position().z());
-    if ( maxZFrontCSC < z ) maxZFrontCSC = z;
+    if (maxZFrontCSC < z)
+      maxZFrontCSC = z;
   }
-  for ( auto backCSC : backCSCs ) {
+  for (auto backCSC : backCSCs) {
     const double z = std::abs(backCSC->surface().position().z());
-    if ( minZBackCSC > z ) minZBackCSC = z;
+    if (minZBackCSC > z)
+      minZBackCSC = z;
   }
-  if ( frontCSCs.size() + backCSCs.size() != 0 ) LogTrace(metname) << "CSC " << maxZFrontCSC << '<' << minZBackCSC << endl;
+  if (frontCSCs.size() + backCSCs.size() != 0)
+    LogTrace(metname) << "CSC " << maxZFrontCSC << '<' << minZBackCSC << endl;
   assert(maxZFrontCSC < minZBackCSC);
 
   // Check the RPC ordering
   double maxZFrontRPC = 0, minZBackRPC = 1e9;
-  for ( auto frontRPC : frontRPCs ) {
+  for (auto frontRPC : frontRPCs) {
     const double z = std::abs(frontRPC->surface().position().z());
-    if ( maxZFrontRPC < z ) maxZFrontRPC = z;
+    if (maxZFrontRPC < z)
+      maxZFrontRPC = z;
   }
-  for ( auto backRPC : backRPCs ) {
+  for (auto backRPC : backRPCs) {
     const double z = std::abs(backRPC->surface().position().z());
-    if ( minZBackRPC > z ) minZBackRPC = z;
+    if (minZBackRPC > z)
+      minZBackRPC = z;
   }
-  if ( frontRPCs.size() + backRPCs.size() != 0 ) LogTrace(metname) << "RPC " << maxZFrontRPC << '<' << minZBackRPC << endl;
+  if (frontRPCs.size() + backRPCs.size() != 0)
+    LogTrace(metname) << "RPC " << maxZFrontRPC << '<' << minZBackRPC << endl;
   assert(maxZFrontRPC < minZBackRPC);
 
   // Check the GEM ordering
   double maxZFrontGEM = 0, minZBackGEM = 1e9;
-  for ( auto frontGEM : frontGEMs ) {
+  for (auto frontGEM : frontGEMs) {
     const double z = std::abs(frontGEM->surface().position().z());
-    if ( maxZFrontGEM < z ) maxZFrontGEM = z;
+    if (maxZFrontGEM < z)
+      maxZFrontGEM = z;
   }
-  for ( auto backGEM : backGEMs ) {
+  for (auto backGEM : backGEMs) {
     const double z = std::abs(backGEM->surface().position().z());
-    if ( minZBackGEM > z ) minZBackGEM = z;
+    if (minZBackGEM > z)
+      minZBackGEM = z;
   }
-  if ( frontGEMs.size() + backGEMs.size() != 0 ) LogTrace(metname) << "GEM " << maxZFrontGEM << '<' << minZBackGEM << endl;
+  if (frontGEMs.size() + backGEMs.size() != 0)
+    LogTrace(metname) << "GEM " << maxZFrontGEM << '<' << minZBackGEM << endl;
   assert(maxZFrontGEM < minZBackGEM);
 
   // Check the IRPC ordering
   double maxZFrontIRPC = 0, minZBackIRPC = 1e9;
-  for ( auto frontIRPC : frontIRPCs ) {
+  for (auto frontIRPC : frontIRPCs) {
     const double z = std::abs(frontIRPC->surface().position().z());
-    if ( maxZFrontIRPC < z ) maxZFrontIRPC = z;
+    if (maxZFrontIRPC < z)
+      maxZFrontIRPC = z;
   }
-  for ( auto backIRPC : backIRPCs ) {
+  for (auto backIRPC : backIRPCs) {
     const double z = std::abs(backIRPC->surface().position().z());
-    if ( minZBackIRPC > z ) minZBackIRPC = z;
+    if (minZBackIRPC > z)
+      minZBackIRPC = z;
   }
-  if ( frontIRPCs.size() + backIRPCs.size() != 0 ) LogTrace(metname) << "IRPC " << maxZFrontIRPC << '<' << minZBackIRPC << endl;
+  if (frontIRPCs.size() + backIRPCs.size() != 0)
+    LogTrace(metname) << "IRPC " << maxZFrontIRPC << '<' << minZBackIRPC << endl;
   assert(maxZFrontIRPC < minZBackIRPC);
 
   // Check the ME0 ordering
   double maxZFrontME0 = 0, minZBackME0 = 1e9;
-  for ( auto frontME0 : frontME0s ) {
+  for (auto frontME0 : frontME0s) {
     const double z = std::abs(frontME0->surface().position().z());
-    if ( maxZFrontME0 < z ) maxZFrontME0 = z;
+    if (maxZFrontME0 < z)
+      maxZFrontME0 = z;
   }
-  for ( auto backME0 : backME0s ) {
+  for (auto backME0 : backME0s) {
     const double z = std::abs(backME0->surface().position().z());
-    if ( minZBackME0 > z ) minZBackME0 = z;
+    if (minZBackME0 > z)
+      minZBackME0 = z;
   }
-  if ( frontME0s.size() + backME0s.size() != 0 ) LogTrace(metname) << "ME0 " << maxZFrontME0 << '<' << minZBackME0 << endl;
+  if (frontME0s.size() + backME0s.size() != 0)
+    LogTrace(metname) << "ME0 " << maxZFrontME0 << '<' << minZBackME0 << endl;
   assert(maxZFrontME0 < minZBackME0);
-
 }

--- a/RecoMuon/DetLayers/src/MuRingForwardDoubleLayer.cc
+++ b/RecoMuon/DetLayers/src/MuRingForwardDoubleLayer.cc
@@ -6,6 +6,8 @@
 #include <RecoMuon/DetLayers/interface/MuRingForwardDoubleLayer.h>
 #include <RecoMuon/DetLayers/interface/MuDetRing.h>
 #include <Geometry/CommonDetUnit/interface/GeomDet.h>
+#include <DataFormats/MuonDetId/interface/MuonSubdetId.h>
+#include <DataFormats/MuonDetId/interface/RPCDetId.h>
 #include <DataFormats/GeometrySurface/interface/SimpleDiskBounds.h>
 #include <TrackingTools/GeomPropagators/interface/Propagator.h>
 #include <TrackingTools/DetLayers/interface/MeasurementEstimator.h>
@@ -182,18 +184,132 @@ bool MuRingForwardDoubleLayer::isCrack(const GlobalPoint& gp) const {
 }
 
 void MuRingForwardDoubleLayer::selfTest() const {
+  const std::string metname = "Muon|RecoMuon|RecoMuonDetLayers|MuRingForwardDoubleLayer";
+
   const std::vector<const GeomDet*>& frontDets = theFrontLayer.basicComponents();
   const std::vector<const GeomDet*>& backDets = theBackLayer.basicComponents();
 
-  std::vector<const GeomDet*>::const_iterator frontItr = frontDets.begin(), lastFront = frontDets.end(),
-                                              backItr = backDets.begin(), lastBack = backDets.end();
+  // Collect front/back chambers by sub-detectors
+  std::vector<const GeomDet*> frontCSCs, backCSCs;
+  std::vector<const GeomDet*> frontRPCs, backRPCs;
+  std::vector<const GeomDet*> frontGEMs, backGEMs;
+  std::vector<const GeomDet*> frontIRPCs, backIRPCs;
+  std::vector<const GeomDet*> frontME0s, backME0s;
 
-  // test that each front z is less than each back z
-  for (; frontItr != lastFront; ++frontItr) {
-    float frontz = fabs((**frontItr).surface().position().z());
-    for (; backItr != lastBack; ++backItr) {
-      float backz = fabs((**backItr).surface().position().z());
-      assert(frontz < backz);
+  for ( const GeomDet* frontDet : frontDets ) {
+    const int subdetId = frontDet->geographicalId().subdetId();
+    if ( subdetId == MuonSubdetId::CSC ) {
+      frontCSCs.push_back(frontDet);
+    }
+    else if ( subdetId == MuonSubdetId::GEM ) {
+      frontGEMs.push_back(frontDet);
+    }
+    else if ( subdetId == MuonSubdetId::ME0 ) {
+      frontME0s.push_back(frontDet);
+    }
+    else if ( subdetId == MuonSubdetId::RPC ) {
+      // RPC has to split existing RPC and iRPC
+      const RPCDetId rpcId(frontDet->geographicalId());
+      const int ring = rpcId.ring();
+      if ( ring == 1 ) {
+        frontIRPCs.push_back(frontDet);
+      }
+      else {
+        frontRPCs.push_back(frontDet);
+      }
     }
   }
+
+  for ( const GeomDet* backDet : backDets ) {
+    const int subdetId = backDet->geographicalId().subdetId();
+    if ( subdetId == MuonSubdetId::CSC ) {
+      backCSCs.push_back(backDet);
+    }
+    else if ( subdetId == MuonSubdetId::GEM ) {
+      backGEMs.push_back(backDet);
+    }
+    else if ( subdetId == MuonSubdetId::ME0 ) {
+      backME0s.push_back(backDet);
+    }
+    else if ( subdetId == MuonSubdetId::RPC ) {
+      // RPC has to split existing RPC and iRPC
+      const RPCDetId rpcId(backDet->geographicalId());
+      const int ring = rpcId.ring();
+      if ( ring == 1 ) {
+        backIRPCs.push_back(backDet);
+      }
+      else {
+        backRPCs.push_back(backDet);
+      }
+    }
+  }
+
+  // Perform test for each subsystems, that front-z is less than back-z
+  // In other word, maximum of front-z must be less than minimum of back-z
+
+  // Check the CSC ordering
+  double maxZFrontCSC = 0, minZBackCSC = 1e9;
+  for ( auto frontCSC : frontCSCs ) {
+    const double z = std::abs(frontCSC->surface().position().z());
+    if ( maxZFrontCSC < z ) maxZFrontCSC = z;
+  }
+  for ( auto backCSC : backCSCs ) {
+    const double z = std::abs(backCSC->surface().position().z());
+    if ( minZBackCSC > z ) minZBackCSC = z;
+  }
+  if ( frontCSCs.size() + backCSCs.size() != 0 ) LogTrace(metname) << "CSC " << maxZFrontCSC << '<' << minZBackCSC << endl;
+  assert(maxZFrontCSC < minZBackCSC);
+
+  // Check the RPC ordering
+  double maxZFrontRPC = 0, minZBackRPC = 1e9;
+  for ( auto frontRPC : frontRPCs ) {
+    const double z = std::abs(frontRPC->surface().position().z());
+    if ( maxZFrontRPC < z ) maxZFrontRPC = z;
+  }
+  for ( auto backRPC : backRPCs ) {
+    const double z = std::abs(backRPC->surface().position().z());
+    if ( minZBackRPC > z ) minZBackRPC = z;
+  }
+  if ( frontRPCs.size() + backRPCs.size() != 0 ) LogTrace(metname) << "RPC " << maxZFrontRPC << '<' << minZBackRPC << endl;
+  assert(maxZFrontRPC < minZBackRPC);
+
+  // Check the GEM ordering
+  double maxZFrontGEM = 0, minZBackGEM = 1e9;
+  for ( auto frontGEM : frontGEMs ) {
+    const double z = std::abs(frontGEM->surface().position().z());
+    if ( maxZFrontGEM < z ) maxZFrontGEM = z;
+  }
+  for ( auto backGEM : backGEMs ) {
+    const double z = std::abs(backGEM->surface().position().z());
+    if ( minZBackGEM > z ) minZBackGEM = z;
+  }
+  if ( frontGEMs.size() + backGEMs.size() != 0 ) LogTrace(metname) << "GEM " << maxZFrontGEM << '<' << minZBackGEM << endl;
+  assert(maxZFrontGEM < minZBackGEM);
+
+  // Check the IRPC ordering
+  double maxZFrontIRPC = 0, minZBackIRPC = 1e9;
+  for ( auto frontIRPC : frontIRPCs ) {
+    const double z = std::abs(frontIRPC->surface().position().z());
+    if ( maxZFrontIRPC < z ) maxZFrontIRPC = z;
+  }
+  for ( auto backIRPC : backIRPCs ) {
+    const double z = std::abs(backIRPC->surface().position().z());
+    if ( minZBackIRPC > z ) minZBackIRPC = z;
+  }
+  if ( frontIRPCs.size() + backIRPCs.size() != 0 ) LogTrace(metname) << "IRPC " << maxZFrontIRPC << '<' << minZBackIRPC << endl;
+  assert(maxZFrontIRPC < minZBackIRPC);
+
+  // Check the ME0 ordering
+  double maxZFrontME0 = 0, minZBackME0 = 1e9;
+  for ( auto frontME0 : frontME0s ) {
+    const double z = std::abs(frontME0->surface().position().z());
+    if ( maxZFrontME0 < z ) maxZFrontME0 = z;
+  }
+  for ( auto backME0 : backME0s ) {
+    const double z = std::abs(backME0->surface().position().z());
+    if ( minZBackME0 > z ) minZBackME0 = z;
+  }
+  if ( frontME0s.size() + backME0s.size() != 0 ) LogTrace(metname) << "ME0 " << maxZFrontME0 << '<' << minZBackME0 << endl;
+  assert(maxZFrontME0 < minZBackME0);
+
 }

--- a/RecoMuon/DetLayers/src/MuRingForwardDoubleLayer.cc
+++ b/RecoMuon/DetLayers/src/MuRingForwardDoubleLayer.cc
@@ -47,7 +47,7 @@ MuRingForwardDoubleLayer::MuRingForwardDoubleLayer(const vector<const ForwardDet
                     << " Z: " << specificSurface().position().z() << " R1: " << specificSurface().innerRadius()
                     << " R2: " << specificSurface().outerRadius();
 
-  // selfTest();
+  selfTest();
 }
 
 BoundDisk* MuRingForwardDoubleLayer::computeSurface() {

--- a/RecoMuon/DetLayers/src/MuonRPCDetLayerGeometryBuilder.cc
+++ b/RecoMuon/DetLayers/src/MuonRPCDetLayerGeometryBuilder.cc
@@ -300,13 +300,16 @@ void MuonRPCDetLayerGeometryBuilder::makeBarrelRods(vector<const GeomDet*>& geom
 bool MuonRPCDetLayerGeometryBuilder::isFront(const RPCDetId& rpcId) {
   const int station = rpcId.station();
   const int ring = rpcId.ring();
-  const int segment = RPCGeomServ(rpcId).segment();
+  const int sector = RPCGeomServ(rpcId).segment();
 
+  // The front/back or off-yoke/on-yoke rule is different for the iRPC, RE+-1, and the others.
   if (ring == 1) {
-    return true;
+    return (sector % 2 != 0);
   } else if (station == 1) {
-    return (segment % 2 == 0);
+    // For RE+-1, even chambers are closer to the IP
+    return (sector % 2 == 0);
   } else {
-    return (segment % 2 != 0);
+    // For the others, odd chambers are closer to the IP
+    return (sector % 2 != 0);
   }
 }

--- a/RecoMuon/DetLayers/src/MuonRPCDetLayerGeometryBuilder.cc
+++ b/RecoMuon/DetLayers/src/MuonRPCDetLayerGeometryBuilder.cc
@@ -1,6 +1,7 @@
 #include <RecoMuon/DetLayers/src/MuonRPCDetLayerGeometryBuilder.h>
 
 #include <DataFormats/MuonDetId/interface/RPCDetId.h>
+#include <Geometry/RPCGeometry/interface/RPCGeomServ.h>
 #include <Geometry/CommonDetUnit/interface/GeomDet.h>
 #include <RecoMuon/DetLayers/interface/MuRingForwardDoubleLayer.h>
 #include <RecoMuon/DetLayers/interface/MuRodBarrelLayer.h>
@@ -297,31 +298,15 @@ void MuonRPCDetLayerGeometryBuilder::makeBarrelRods(vector<const GeomDet*>& geom
 }
 
 bool MuonRPCDetLayerGeometryBuilder::isFront(const RPCDetId& rpcId) {
-  // ME1/2 is always in back
-  //  if(rpcId.station() == 1 && rpcId.ring() == 2)  return false;
+  const int station = rpcId.station();
+  const int ring = rpcId.ring();
+  const int segment = RPCGeomServ(rpcId).segment();
 
-  bool result = false;
-  int ring = rpcId.ring();
-  int station = rpcId.station();
-  // 20 degree rings are a little weird! not anymore from 17x
-  if (ring == 1 && station > 1) {
-    // RE2/1 RE3/1  Upscope Geometry
-    /* goes (sector) (subsector)            1/3
-    1 1 back   // front 
-    1 2 front  // back  
-    1 3 front  // front 
-    2 1 front  // back  
-    2 2 back   // from  
-    2 3 back   // back  
-                        
-    */
-    result = (rpcId.subsector() != 2);
-    if (rpcId.sector() % 2 == 0)
-      result = !result;
-    return result;
+  if (ring == 1) {
+    return true;
+  } else if (station == 1) {
+    return (segment % 2 == 0);
   } else {
-    // 10 degree rings have odd subsectors in front
-    result = (rpcId.subsector() % 2 == 0);
+    return (segment % 2 != 0);
   }
-  return result;
 }

--- a/RecoMuon/DetLayers/src/MuonRPCDetLayerGeometryBuilder.cc
+++ b/RecoMuon/DetLayers/src/MuonRPCDetLayerGeometryBuilder.cc
@@ -312,7 +312,7 @@ bool MuonRPCDetLayerGeometryBuilder::isFront(const RPCDetId& rpcId) {
     } else {
       // For the others, odd chambers are closer to the IP
       return (sector % 2 != 0);
-    }    
+    }
   } else {
     // ME1/2 is always in back
     //  if(rpcId.station() == 1 && rpcId.ring() == 2)  return false;
@@ -340,6 +340,6 @@ bool MuonRPCDetLayerGeometryBuilder::isFront(const RPCDetId& rpcId) {
       // 10 degree rings have odd subsectors in front
       result = (rpcId.subsector() % 2 == 0);
     }
-    return result;       
+    return result;
   }
 }

--- a/RecoMuon/DetLayers/src/MuonRPCDetLayerGeometryBuilder.cc
+++ b/RecoMuon/DetLayers/src/MuonRPCDetLayerGeometryBuilder.cc
@@ -298,7 +298,7 @@ void MuonRPCDetLayerGeometryBuilder::makeBarrelRods(vector<const GeomDet*>& geom
 }
 
 bool MuonRPCDetLayerGeometryBuilder::isFront(const RPCDetId& rpcId) {
-  if (MuonRPCDetLayerGeometryBuilder::useUpdatedRPCIsFront) {
+  if (useUpdatedRPCIsFront) {
     const int station = rpcId.station();
     const int ring = rpcId.ring();
     const int sector = RPCGeomServ(rpcId).segment();

--- a/RecoMuon/DetLayers/src/MuonRPCDetLayerGeometryBuilder.cc
+++ b/RecoMuon/DetLayers/src/MuonRPCDetLayerGeometryBuilder.cc
@@ -298,18 +298,48 @@ void MuonRPCDetLayerGeometryBuilder::makeBarrelRods(vector<const GeomDet*>& geom
 }
 
 bool MuonRPCDetLayerGeometryBuilder::isFront(const RPCDetId& rpcId) {
-  const int station = rpcId.station();
-  const int ring = rpcId.ring();
-  const int sector = RPCGeomServ(rpcId).segment();
+  if (MuonRPCDetLayerGeometryBuilder::useUpdatedRPCIsFront) {
+    const int station = rpcId.station();
+    const int ring = rpcId.ring();
+    const int sector = RPCGeomServ(rpcId).segment();
 
-  // The front/back or off-yoke/on-yoke rule is different for the iRPC, RE+-1, and the others.
-  if (ring == 1) {
-    return (sector % 2 != 0);
-  } else if (station == 1) {
-    // For RE+-1, even chambers are closer to the IP
-    return (sector % 2 == 0);
+    // The front/back or off-yoke/on-yoke rule is different for the iRPC, RE+-1, and the others.
+    if (ring == 1) {
+      return (sector % 2 != 0);
+    } else if (station == 1) {
+      // For RE+-1, even chambers are closer to the IP
+      return (sector % 2 == 0);
+    } else {
+      // For the others, odd chambers are closer to the IP
+      return (sector % 2 != 0);
+    }    
   } else {
-    // For the others, odd chambers are closer to the IP
-    return (sector % 2 != 0);
+    // ME1/2 is always in back
+    //  if(rpcId.station() == 1 && rpcId.ring() == 2)  return false;
+
+    bool result = false;
+    int ring = rpcId.ring();
+    int station = rpcId.station();
+    // 20 degree rings are a little weird! not anymore from 17x
+    if (ring == 1 && station > 1) {
+      // RE2/1 RE3/1  Upscope Geometry
+      /* goes (sector) (subsector)            1/3
+      1 1 back   // front 
+      1 2 front  // back  
+      1 3 front  // front 
+      2 1 front  // back  
+      2 2 back   // from  
+      2 3 back   // back  
+
+      */
+      result = (rpcId.subsector() != 2);
+      if (rpcId.sector() % 2 == 0)
+        result = !result;
+      return result;
+    } else {
+      // 10 degree rings have odd subsectors in front
+      result = (rpcId.subsector() % 2 == 0);
+    }
+    return result;       
   }
 }

--- a/RecoMuon/DetLayers/src/MuonRPCDetLayerGeometryBuilder.h
+++ b/RecoMuon/DetLayers/src/MuonRPCDetLayerGeometryBuilder.h
@@ -31,6 +31,8 @@ public:
   /// Builds the barrel layers. Result vector is sorted inside-out
   static std::vector<DetLayer*> buildBarrelLayers(const RPCGeometry& geo);
 
+  inline static bool useUpdatedRPCIsFront = false;
+
 private:
   static void makeBarrelLayers(std::vector<const GeomDet*>& geomDets, std::vector<MuRodBarrelLayer*>& result);
   static void makeBarrelRods(std::vector<const GeomDet*>& geomDets, std::vector<const DetRod*>& result);


### PR DESCRIPTION
#### PR description:

This PR modifies the isFront function inside the RPC Endcap Geometry Builder.
It will be applied in synchronization with PR (#47134) by Sunanda Banerjee.

The isFront function classifies RPCs as front or back chambers by RPC Ids.

As the PR (#47134) modifies the z coordinates of RPCs inside RPC endcap stations (RE-4, RE-3, RE-2, RE+2, RE+3, RE+4),
The criteria for the isFront function needs to be changed as well.
Therefore, this PR modifies the criteria for the isFront function correctly as the z coordinate changes.

For history and more details, see the previous meeting materials.
(https://indico.cern.ch/event/1475698/contributions/6214667/attachments/2962024/5210467/RPCGeomReport_241106RPCDPG_JShin.pdf)


#### PR validation:

To avoid errors, this PR should be used with #47134 and the new scenario.
Otherwise (when applying this PR alone), the error below will be raised by the selfTest function in the Geometry Builder.

Error reproduction)
```
A fatal system signal has occurred: abort signal
The following is the call stack containing the origin of the signal.
...
#9  0x00007f62d8e9276c in MuRingForwardDoubleLayer::selfTest() const () from /eos/home-j/joshin/workspace-eos/rpc-geometry/update-isfront/CMSSW_15_0_0_pre1/lib/el9_amd64_gcc12/libRecoMuonDetLayers.so
#10 0x00007f62d8e9359b in MuRingForwardDoubleLayer::MuRingForwardDoubleLayer(std::vector<ForwardDetRing const*, std::allocator<ForwardDetRing const*> > const&, std::vector<ForwardDetRing const*, std::allocator<ForwardDetRing const*> > const&) () from /eos/home-j/joshin/workspace-eos/rpc-geometry/update-isfront/CMSSW_15_0_0_pre1/lib/el9_amd64_gcc12/libRecoMuonDetLayers.so
#11 0x00007f62d8e9f36f in MuonRPCDetLayerGeometryBuilder::buildLayer(int, std::vector<int, std::allocator<int> > const&, int, int, std::vector<int, std::allocator<int> >&, RPCGeometry const&) () from /eos/home-j/joshin/workspace-eos/rpc-geometry/update-isfront/CMSSW_15_0_0_pre1/lib/el9_amd64_gcc12/libRecoMuonDetLayers.so
#12 0x00007f62d8e9fea8 in MuonRPCDetLayerGeometryBuilder::buildEndcapLayers(RPCGeometry const&) () from /eos/home-j/joshin/workspace-eos/rpc-geometry/update-isfront/CMSSW_15_0_0_pre1/lib/el9_amd64_gcc12/libRecoMuonDetLayers.so
#13 0x00007f62bb85a0bf in MuonDetLayerGeometryESProducer::produce(MuonRecoGeometryRecord const&) () from /cvmfs/cms.cern.ch/el9_amd64_gcc12/cms/cmssw/CMSSW_15_0_0_pre1/lib/el9_amd64_gcc12/pluginRecoMuonDetLayersPlugins.so
...
```

This change will also require a new payload for RPC Geometry when working with Global Tags.


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special
