### PR TITLE
[GCC13]Workaround to avoid false-positive partly outside array bounds

### DIFF
--- a/RecoTracker/PixelTrackFitting/test/BuildFile.xml
+++ b/RecoTracker/PixelTrackFitting/test/BuildFile.xml
@@ -59,7 +59,7 @@
   <use name="cuda"/>
   <use name="eigen"/>
   <use name="root"/>
-  <flags CXXFLAGS="-DEIGEN_NO_DEBUG"/>
+  <flags CXXFLAGS="-DEIGEN_NO_DEBUG -O2"/>
 </bin>
 
 <bin file="PixelTrackFits.cc" name="PixelTrackBrokenLineFit">


### PR DESCRIPTION
In GCC13 IBs, we are build time error [a]. This looks like a bug in GCC 

- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=106247
- https://gitlab.com/libeigen/eigen/-/issues/2506

Compiling this unit tests with `-O2` seems to avoid this error, so this PR proposes to use `-O2` for building/linking this test 

[a] https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el9_amd64_gcc13/CMSSW_15_0_X_2025-01-17-2300/RecoTracker/PixelTrackFitting
```
In function '_mm256_loadu_pd',
    inlined from 'ploadu' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc13/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-777da7040cb89c68e8201affdcbf2aca/include/eigen3/Eigen/src/Core/arch/AVX/PacketMath.h:884:129,
    inlined from 'ploadt' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc13/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-777da7040cb89c68e8201affdcbf2aca/include/eigen3/Eigen/src/Core/GenericPacketMath.h:1092:26,
    inlined from 'packet' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc13/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-777da7040cb89c68e8201affdcbf2aca/include/eigen3/Eigen/src/Core/CoreEvaluators.h:240:42,
    inlined from 'assignPacket' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc13/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-777da7040cb89c68e8201affdcbf2aca/include/eigen3/Eigen/src/Core/AssignEvaluator.h:676:116,
    inlined from 'assignPacketByOuterInner' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc13/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-777da7040cb89c68e8201affdcbf2aca/include/eigen3/Eigen/src/Core/AssignEvaluator.h:690:48,
    inlined from 'run' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc13/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-777da7040cb89c68e8201affdcbf2aca/include/eigen3/Eigen/src/Core/AssignEvaluator.h:573:86,
    inlined from 'call_dense_assignment_loop' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc13/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-777da7040cb89c68e8201affdcbf2aca/include/eigen3/Eigen/src/Core/AssignEvaluator.h:786:37,
    inlined from 'run' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc13/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-777da7040cb89c68e8201affdcbf2aca/include/eigen3/Eigen/src/Core/AssignEvaluator.h:955:31,
    inlined from 'call_assignment_no_alias' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc13/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-777da7040cb89c68e8201affdcbf2aca/include/eigen3/Eigen/src/Core/AssignEvaluator.h:891:49,
    inlined from 'call_assignment' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc13/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-777da7040cb89c68e8201affdcbf2aca/include/eigen3/Eigen/src/Core/AssignEvaluator.h:859:27,
    inlined from 'call_assignment' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc13/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-777da7040cb89c68e8201affdcbf2aca/include/eigen3/Eigen/src/Core/AssignEvaluator.h:837:18,
    inlined from 'operator=' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc13/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-777da7040cb89c68e8201affdcbf2aca/include/eigen3/Eigen/src/Core/Assign.h:68:28,
    inlined from 'circleFit.constprop' at src/RecoTracker/PixelTrackFitting/interface/RiemannFit.h:732:34:
  /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc13/external/gcc/13.2.0-b4f157aad5ba3fefd6a4401833585549/lib/gcc/x86_64-redhat-linux-gnu/13.2.0/include/avxintrin.h:893:24: error: array subscript '__m256d_u[0]' is partly outside array bounds of 'struct Vector3d[1]' [-Werror=array-bounds=]
   893 |   return *(__m256d_u *)__P;
      |                        ^
src/RecoTracker/PixelTrackFitting/interface/RiemannFit.h: In function 'circleFit.constprop':
src/RecoTracker/PixelTrackFitting/interface/RiemannFit.h:730:18: note: object 't1' of size 24
  730 |         Vector3d t1 = -t0 * r0;
```