### PR TITLE
run more testing in `CalibTracker/SiStripCommon` unit tests

### DIFF
--- a/CalibTracker/SiStripCommon/test/BuildFile.xml
+++ b/CalibTracker/SiStripCommon/test/BuildFile.xml
@@ -1,4 +1,5 @@
-<test name="testCalibTrackerSiStripCommon" command="test_all.sh"/>
+<test name="testCalibTrackerSiStripCommonOneByOne" command="run_tests.sh"/>
+<test name="testCalibTrackerSiStripCommonAll" command="test_all.sh"/>
 
 <use name="CalibTracker/SiStripCommon"/>
 <library file="*.cc" name="CalibTrackerSiStripCommonTest">

--- a/CalibTracker/SiStripCommon/test/run_tests.sh
+++ b/CalibTracker/SiStripCommon/test/run_tests.sh
@@ -3,33 +3,32 @@
 function die { echo $1: status $2 ;  exit $2; }
 
 echo cmsRun test_shallowClustersProducer_cfg.py
-cmsRun test_shallowClustersProducer_cfg.py || die "Failure using test_shallowClustersProducer_cfg.py" $?
+cmsRun ${SCRAM_TEST_PATH}/test_shallowClustersProducer_cfg.py || die "Failure using test_shallowClustersProducer_cfg.py" $?
+
 echo cmsRun test_shallowDigisProducer_cfg.py
-cmsRun test_shallowDigisProducer_cfg.py || die "Failure using test_shallowDigisProducer_cfg.py" $?
+cmsRun ${SCRAM_TEST_PATH}/test_shallowDigisProducer_cfg.py || die "Failure using test_shallowDigisProducer_cfg.py" $?
+
 echo cmsRun test_shallowEventDataProducer_cfg.py
-cmsRun test_shallowEventDataProducer_cfg.py || die "Failure using test_shallowEventDataProducer_cfg.py" $?
-echo cmsRun test_shallowGainCalibration_cfg.py #SOLVED
-## Looking for type: edm::AssociationMap<edm::OneToOne<std::vector<Trajectory>,std::vector<reco::Track>,unsigned short> >
-## Looking for module label: generalTracks
-cmsRun test_shallowGainCalibration_cfg.py || die "Failure using test_shallowGainCalibration_cfg.py" $?
+cmsRun ${SCRAM_TEST_PATH}/test_shallowEventDataProducer_cfg.py || die "Failure using test_shallowEventDataProducer_cfg.py" $?
 
-echo cmsRun test_shallowRechitClustersProducer_cfg.py #SOLVED
-## Looking for type: edmNew::DetSetVector<SiStripRecHit2D>
-## Looking for module label: siStripMatchedRecHits
-cmsRun test_shallowRechitClustersProducer_cfg.py || die "Failure using test_shallowRechitClustersProducer_cfg.py" $?
+echo cmsRun test_shallowGainCalibration_cfg.py
+cmsRun ${SCRAM_TEST_PATH}/test_shallowGainCalibration_cfg.py || die "Failure using test_shallowGainCalibration_cfg.py" $?
 
-echo cmsRun test_shallowSimTracksProducer_cfg.py #fails due to missing product  
-cmsRun test_shallowSimTracksProducer_cfg.py || die "Failure using test_shallowSimTracksProducer_cfg.py" $?
+echo cmsRun test_shallowRechitClustersProducer_cfg.py
+cmsRun ${SCRAM_TEST_PATH}/test_shallowRechitClustersProducer_cfg.py || die "Failure using test_shallowRechitClustersProducer_cfg.py" $?
+
+#echo cmsRun test_shallowSimTracksProducer_cfg.py #fails due to missing product
+#cmsRun ${SCRAM_TEST_PATH}/test_shallowSimTracksProducer_cfg.py || die "Failure using test_shallowSimTracksProducer_cfg.py" $?
 ## Looking for type: reco::TrackToTrackingParticleAssociator
 ## Looking for module label: trackAssociatorByHits
 
-echo cmsRun test_shallowSimhitClustersProducer_cfg.py #fails due to missing product  
-cmsRun test_shallowSimhitClustersProducer_cfg.py || die "Failure using test_shallowSimhitClustersProducer_cfg.py" $?
+#echo cmsRun test_shallowSimhitClustersProducer_cfg.py #fails due to missing product
+#cmsRun ${SCRAM_TEST_PATH}/test_shallowSimhitClustersProducer_cfg.py || die "Failure using test_shallowSimhitClustersProducer_cfg.py" $?
 ## Looking for type: std::vector<PSimHit>
 ## Looking for module label: g4SimHits
 
 echo cmsRun test_shallowTrackClustersProducer_cfg.py
-cmsRun test_shallowTrackClustersProducer_cfg.py || die "Failure using test_shallowTrackClustersProducer_cfg.py" $?
+cmsRun ${SCRAM_TEST_PATH}/test_shallowTrackClustersProducer_cfg.py || die "Failure using test_shallowTrackClustersProducer_cfg.py" $?
 
 echo cmsRun test_shallowTracksProducer_cfg.py
-cmsRun test_shallowTracksProducer_cfg.py || die "Failure using test_shallowTracksProducer_cfg.py" $?
+cmsRun ${SCRAM_TEST_PATH}/test_shallowTracksProducer_cfg.py || die "Failure using test_shallowTracksProducer_cfg.py" $?

--- a/CalibTracker/SiStripCommon/test/test_all.sh
+++ b/CalibTracker/SiStripCommon/test/test_all.sh
@@ -3,5 +3,8 @@
 function die { echo $1: status $2 ; exit $2; }
 
 echo "TESTING CalibTracker/SiStripCommon ..."
+echo cmsRun test_all_cfg.py
 cmsRun ${SCRAM_TEST_PATH}/test_all_cfg.py || die "Failure running test_CalibTrackerSiStripCommon_cfg.py" $?
+
+echo cmsRun testProduceCalibrationTree_cfg.py
 cmsRun ${SCRAM_TEST_PATH}/testProduceCalibrationTree_cfg.py maxEvents=10 unitTest=True || die "Failure running produceCalibrationTree_template_cfg.py" $?


### PR DESCRIPTION
#### PR description:

Due to recent works ongoing to streamline / optimize strip local reconstruction, I think it's prudent to enable more testing of the calibration tree workflows. 

#### PR validation:

`scram b runtests` runs fine in `CMSSW_15_0_X_2025-01-19-2300`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A