### PR TITLE
MTD geometry: address static CLANG analyzer error in Geometry/MTDNumberingBuilder

### DIFF
--- a/Geometry/MTDNumberingBuilder/plugins/CmsMTDConstruction.h
+++ b/Geometry/MTDNumberingBuilder/plugins/CmsMTDConstruction.h
@@ -7,6 +7,19 @@
 #include "Geometry/MTDCommonData/interface/BTLNumberingScheme.h"
 #include "Geometry/MTDCommonData/interface/ETLNumberingScheme.h"
 
+#include "DataFormats/Math/interface/deltaPhi.h"
+
+namespace {
+
+  template <class valType>
+  inline constexpr valType makempiToppi(valType angle) {
+    constexpr valType twoPi = 2. * M_PI;
+    constexpr valType epsilon = 1.e-13;
+    auto tmpphi = angle0to2pi::make0To2pi(angle);
+    return (tmpphi - M_PI > epsilon) ? tmpphi - twoPi : tmpphi;
+  }
+}  // namespace
+
 /**
  * Adds GeometricTimingDets representing final modules to the previous level
  */


### PR DESCRIPTION
#### PR description:

PR https://github.com/cms-sw/cmssw/pull/47115 brings back the MTD geometry to its status previous to the update of BTL DetId/numbering scheme. In this way the reordering of BTL modules, added to that PR to minimize the number of updates of references, is undone as well, leaving a function ```makempiToppi```, used in preprocessor blocks for debugging, not defined. 

While this has no impact in normal code operation, it introduces a static CLANG analyzer error. This PR fixes the problem, without activating the change of order.

#### PR validation:

Code compiles, runs, unit test for the package passes, ```scram b checker``` does not show any more the CLANG error reported by the IB.