### PR TITLE
update `TestGlobalObjectMapRecordFormat` unit test with `CMSSW_15_0_0_pre2` inputs

### DIFF
--- a/DataFormats/L1TGlobal/test/TestGlobalObjectMapRecordFormat.sh
+++ b/DataFormats/L1TGlobal/test/TestGlobalObjectMapRecordFormat.sh
@@ -29,10 +29,10 @@ for file in $oldFiles; do
   cmsRun ${LOCAL_TEST_DIR}/test_readGlobalObjectMapRecord_cfg.py --inputFileName "$inputfile" --globalObjectMapClassVersion 10 || die "Failed to read old file $file" $?
 done
 
-#oldFiles="testGlobalObjectMapRecord_CMSSW_15_0_0_pre2_split_99.root testGlobalObjectMapRecord_CMSSW_15_0_0_pre2_split_0.root"
-#for file in $oldFiles; do
-#  inputfile=$(edmFileInPath DataFormats/L1TGlobal/data/$file) || die "Failure edmFileInPath DataFormats/L1TGlobal/data/$file" $?
-#  cmsRun ${LOCAL_TEST_DIR}/test_readGlobalObjectMapRecord_cfg.py --inputFileName "$inputfile" --globalObjectMapClassVersion 11 || die "Failed to read old file $file" $?
-#done
+oldFiles="testGlobalObjectMapRecord_CMSSW_15_0_0_pre2_split_99.root testGlobalObjectMapRecord_CMSSW_15_0_0_pre2_split_0.root"
+for file in $oldFiles; do
+  inputfile=$(edmFileInPath DataFormats/L1TGlobal/data/$file) || die "Failure edmFileInPath DataFormats/L1TGlobal/data/$file" $?
+  cmsRun ${LOCAL_TEST_DIR}/test_readGlobalObjectMapRecord_cfg.py --inputFileName "$inputfile" --globalObjectMapClassVersion 11 || die "Failed to read old file $file" $?
+done
 
 exit 0

--- a/DataFormats/L1TGlobal/test/create_GlobalObjectMapRecord_test_file_cfg.py
+++ b/DataFormats/L1TGlobal/test/create_GlobalObjectMapRecord_test_file_cfg.py
@@ -5,6 +5,7 @@ import sys
 parser = argparse.ArgumentParser(prog=sys.argv[0], description='Test GlobalObjectMapRecord')
 
 parser.add_argument('--outputFileName', type=str, help='Output file name (default: testGlobalObjectMapRecord.root)', default='testGlobalObjectMapRecord.root')
+parser.add_argument('--splitLevel', type=int, help='Split level of ROOT branches in EDM output file (default: 99)', default=99)
 args = parser.parse_args()
 
 process = cms.Process("PROD")
@@ -36,7 +37,8 @@ process.globalObjectMapRecordProducer = cms.EDProducer("TestWriteGlobalObjectMap
 )
 
 process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string(f'{args.outputFileName}')
+    fileName = cms.untracked.string(f'{args.outputFileName}'),
+    splitLevel = cms.untracked.int32(args.splitLevel)
 )
 
 process.path = cms.Path(process.globalObjectMapRecordProducer)


### PR DESCRIPTION
#### PR description:

This PR updates the unit test on the backward-compatibility of the data formats in `DataFormats/L1TGlobal`, extending it using inputs produced with `CMSSW_15_0_0_pre2`, given the data-format change introduced in #47030.

In addition, a cmd-line argument is added to `create_GlobalObjectMapRecord_test_file_cfg.py` to specify the "split level" of the output file (just for convenience when producing future unit-test input files).

This PR requires https://github.com/cms-data/DataFormats-L1TGlobal/pull/3.

#### PR validation:

The relevant unit test passes.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A