### PR TITLE
Fix generation of cmsDriver command if accelerators contain asterisk symbol

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2942,12 +2942,12 @@ step3_alpaka_cpu = {
 }
 step3_alpaka_gpu = {
     '--procModifiers': 'alpaka',
-    '--accelerators' : '*' ## redundant, here just for readability
+    '--accelerators' : '"*"' ## redundant, here just for readability
 }
 
 step3_alpaka_gpu_validation = {
     '--procModifiers': 'alpaka,alpakaValidation',
-    '--accelerators' : 'gpu*'
+    '--accelerators' : '"gpu*"'
 }
 step3_pixel_triplets = {
     '--customise': 'RecoTracker/Configuration/customizePixelTracksForTriplets.customizePixelTracksForTriplets'
@@ -3243,7 +3243,7 @@ steps['RecoData_Alpaka_AllGPU_Validation_2023'] = merge([{'-s':'RAW2DIGI:RawToDi
                                                              '--eventcontent':'RECO,MINIAOD,DQM',
                                                              '--geometry':'DB:Extended',
                                                              '--era':'Run3',
-                                                             '--accelerators': 'gpu-*',
+                                                             '--accelerators': '"gpu-*"',
                                                              '--procModifiers':'alpakaValidation'},dataReco])
 
 # Run-3 2022 skim


### PR DESCRIPTION
#### PR description:

Fix generation of cmsDriver command if accelerators contain asterisk symbol. This should fix RelVals failing with 

```
usage: cmsDriver.py <TYPE> [options].
Example:

cmsDriver.py reco -s RAW2DIGI,RECO --conditions STARTUP_V4::All --eventcontent RECOSIM
cmsDriver.py: error: unrecognized arguments: cmdLog step1_dasquery.log step1_lumiRanges.log step2.root step2_L1REPACK_HLT.py step2_Run3-2023_JetMET2023D_RecoPixelOnlyTripletsGPU_Profiling.log threads.txt wf_stats-step2.json wf_steps.txt workflow.log
```

due to `*` expansion by the shell.

#### PR validation:

runTheMatrix.py works locally
