### PR TITLE
Rename reduceRange to reducePhiRange

### DIFF
--- a/DQM/TrackingMonitor/src/TrackBuildingAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackBuildingAnalyzer.cc
@@ -750,12 +750,12 @@ void TrackBuildingAnalyzer::analyzeRegions(const T& regions) {
       }
       if (doAllSeedPlots || doPHI) {
         for (auto phi = phiMin; phi < phiMax; phi += phiBinWidth) {
-          TrackingRegionPhi->Fill(reco::reduceRange(phi));
+          TrackingRegionPhi->Fill(reco::reducePhiRange(phi));
         }
       }
       if (doAllSeedPlots || doPHIVsETA) {
         for (auto phi = phiMin; phi < phiMax; phi += phiBinWidth) {
-          const auto reducedPhi = reco::reduceRange(phi);
+          const auto reducedPhi = reco::reducePhiRange(phi);
           for (auto eta = etaMin; eta < etaMax; eta += etaBinWidth) {
             TrackingRegionPhiVsEta->Fill(eta, reducedPhi);
           }

--- a/DataFormats/GeometryVector/test/PhiTest.cc
+++ b/DataFormats/GeometryVector/test/PhiTest.cc
@@ -15,7 +15,7 @@ using namespace std::chrono;
 template <class valType>
 inline constexpr valType useReduceRange(valType angle) {
   constexpr valType twoPi = 2._pi;
-  angle = reduceRange(angle);
+  angle = reducePhiRange(angle);
   if (angle < 0.)
     angle += twoPi;
   return angle;

--- a/DataFormats/L1TParticleFlow/src/layer1_emulator.cpp
+++ b/DataFormats/L1TParticleFlow/src/layer1_emulator.cpp
@@ -9,14 +9,14 @@
 #else
 namespace reco {
   template <typename T>
-  inline T reduceRange(T x) {
+  inline T reducePhiRange(T x) {
     T o2pi = 1. / (2. * M_PI);
     if (std::abs(x) <= T(M_PI))
       return x;
     T n = std::round(x * o2pi);
     return x - n * T(2. * M_PI);
   }
-  inline double deltaPhi(double phi1, double phi2) { return reduceRange(phi1 - phi2); }
+  inline double deltaPhi(double phi1, double phi2) { return reducePhiRange(phi1 - phi2); }
 }  // namespace reco
 #endif
 

--- a/DataFormats/Math/interface/deltaPhi.h
+++ b/DataFormats/Math/interface/deltaPhi.h
@@ -15,7 +15,7 @@ namespace reco {
 
   // reduce to [-pi,pi]
   template <typename T>
-  constexpr T reduceRange(T x) {
+  constexpr T reducePhiRange(T x) {
     constexpr T o2pi = 1. / (2. * M_PI);
     if (std::abs(x) <= T(M_PI))
       return x;
@@ -23,13 +23,13 @@ namespace reco {
     return x - n * T(2. * M_PI);
   }
 
-  constexpr double deltaPhi(double phi1, double phi2) { return reduceRange(phi1 - phi2); }
+  constexpr double deltaPhi(double phi1, double phi2) { return reducePhiRange(phi1 - phi2); }
 
   constexpr double deltaPhi(float phi1, double phi2) { return deltaPhi(static_cast<double>(phi1), phi2); }
 
   constexpr double deltaPhi(double phi1, float phi2) { return deltaPhi(phi1, static_cast<double>(phi2)); }
 
-  constexpr float deltaPhi(float phi1, float phi2) { return reduceRange(phi1 - phi2); }
+  constexpr float deltaPhi(float phi1, float phi2) { return reducePhiRange(phi1 - phi2); }
 
   template <typename T1, typename T2>
   constexpr auto deltaPhi(T1 const& t1, T2 const& t2) -> decltype(deltaPhi(t1.phi(), t2.phi())) {
@@ -38,7 +38,7 @@ namespace reco {
 
   template <typename T>
   constexpr T deltaPhi(T phi1, T phi2) {
-    return reduceRange(phi1 - phi2);
+    return reducePhiRange(phi1 - phi2);
   }
 }  // namespace reco
 
@@ -57,7 +57,7 @@ namespace angle0to2pi {
   using angle_units::operators::operator""_pi;
 
   // make0To2pi constrains an angle to be >= 0 and < 2pi.
-  // This function is a faster version of reco::reduceRange.
+  // This function is a faster version of reco::reducePhiRange.
   // In timing tests, it is almost always faster than reco::reduceRange.
   // It also protects against floating-point value drift over repeated calculations.
   // This implementation uses multiplication instead of division and avoids

--- a/DataFormats/Math/interface/normalizedPhi.h
+++ b/DataFormats/Math/interface/normalizedPhi.h
@@ -6,7 +6,7 @@
 // return a value of phi into interval [-pi,+pi]
 template <typename T>
 constexpr T normalizedPhi(T phi) {
-  return reco::reduceRange(phi);
+  return reco::reducePhiRange(phi);
 }
 
 // cernlib V306

--- a/DataFormats/Math/test/deltaR_t.cpp
+++ b/DataFormats/Math/test/deltaR_t.cpp
@@ -32,9 +32,9 @@ inline int diff(float a, float b) {
 #include <vector>
 int main() {
   for (float q = -10.; q < 10.; q += 0.5)
-    std::cout << q << ' ' << q - std::copysign(2 * M_PI, q) << ' ' << reco::reduceRange(q) << std::endl;
+    std::cout << q << ' ' << q - std::copysign(2 * M_PI, q) << ' ' << reco::reducePhiRange(q) << std::endl;
 
-  std::cout << reco::reduceRange(std::sqrt(-1)) << std::endl;
+  std::cout << reco::reducePhiRange(std::sqrt(-1)) << std::endl;
 
   std::vector<Vector> vs;
   for (float x = -1000.; x <= 1010.; x += 100)

--- a/DataFormats/Math/test/testAtan2.cpp
+++ b/DataFormats/Math/test/testAtan2.cpp
@@ -11,12 +11,12 @@
 namespace {
   template <typename T>
   inline T toPhi(T phi) {
-    return reco::reduceRange(phi);
+    return reco::reducePhiRange(phi);
   }
 
   template <typename T>
   inline T deltaPhi(T phi1, T phi2) {
-    return reco::reduceRange(phi1 - phi2);
+    return reco::reducePhiRange(phi1 - phi2);
   }
 
   inline bool phiLess(float x, float y) {

--- a/HeterogeneousCore/AlpakaMath/interface/deltaPhi.h
+++ b/HeterogeneousCore/AlpakaMath/interface/deltaPhi.h
@@ -7,7 +7,7 @@ namespace cms::alpakatools {
 
   // reduce to [-pi,pi]
   template <typename TAcc, std::floating_point T>
-  ALPAKA_FN_HOST_ACC inline T reduceRange(TAcc const& acc, T x) {
+  ALPAKA_FN_HOST_ACC inline T reducePhiRange(TAcc const& acc, T x) {
     constexpr T o2pi = T{1.} / (T{2.} * std::numbers::pi_v<T>);
     if (alpaka::math::abs(acc, x) <= std::numbers::pi_v<T>)
       return x;
@@ -17,17 +17,17 @@ namespace cms::alpakatools {
 
   template <typename TAcc, typename T>
   ALPAKA_FN_HOST_ACC inline T phi(TAcc const& acc, T x, T y) {
-    return reduceRange(acc, std::numbers::pi_v<T> + alpaka::math::atan2(acc, -y, -x));
+    return reducePhiRange(acc, std::numbers::pi_v<T> + alpaka::math::atan2(acc, -y, -x));
   }
 
   template <typename TAcc, typename T>
   ALPAKA_FN_HOST_ACC inline T deltaPhi(TAcc const& acc, T x1, T y1, T x2, T y2) {
-    return reduceRange(acc, alpaka::math::atan2(acc, -y2, -x2) - alpaka::math::atan2(acc, -y1, -x1));
+    return reducePhiRange(acc, alpaka::math::atan2(acc, -y2, -x2) - alpaka::math::atan2(acc, -y1, -x1));
   }
 
   template <typename TAcc, typename T>
   ALPAKA_FN_HOST_ACC inline T deltaPhi(TAcc const& acc, T phi1, T phi2) {
-    return reduceRange(acc, phi1 - phi2);
+    return reducePhiRange(acc, phi1 - phi2);
   }
 
 }  // namespace cms::alpakatools

--- a/L1Trigger/L1THGCal/src/backend/HGCalHistoSeedingImpl.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalHistoSeedingImpl.cc
@@ -92,7 +92,7 @@ HGCalHistoSeedingImpl::Histogram HGCalHistoSeedingImpl::fillHistoClusters(
     switch (seedingSpace_) {
       case RPhi:
         x1 = sqrt(pow(clu->centreProj().x(), 2) + pow(clu->centreProj().y(), 2));
-        x2 = reco::reduceRange(clu->phi());
+        x2 = reco::reducePhiRange(clu->phi());
         break;
       case XY:
         x1 = clu->centreProj().x();

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc
@@ -647,7 +647,7 @@ void L1TCorrelatorLayer1Producer::initSectorsAndRegions(const edm::ParameterSet 
   event_.decoded.track.clear();
   for (unsigned int ieta = 0, neta = 2; ieta < neta; ++ieta) {
     for (unsigned int iphi = 0; iphi < TF_phiSlices; ++iphi) {
-      float phiCenter = reco::reduceRange(iphi * TF_phiWidth);
+      float phiCenter = reco::reducePhiRange(iphi * TF_phiWidth);
       event_.decoded.track.emplace_back((ieta ? 0. : -2.5), (ieta ? 2.5 : 0.0), phiCenter, TF_phiWidth);
       event_.raw.track.emplace_back((ieta ? 0. : -2.5), (ieta ? 2.5 : 0.0), phiCenter, TF_phiWidth);
     }
@@ -671,7 +671,7 @@ void L1TCorrelatorLayer1Producer::initSectorsAndRegions(const edm::ParameterSet 
       if (etaWidth > 2 * l1ct::Scales::maxAbsEta())
         throw cms::Exception("Configuration", "caloSectors eta range too large for eta_t data type");
       for (unsigned int iphi = 0; iphi < phiSlices; ++iphi) {
-        float phiCenter = reco::reduceRange(iphi * phiWidth + phiZero);
+        float phiCenter = reco::reducePhiRange(iphi * phiWidth + phiZero);
         event_.decoded.hadcalo.emplace_back(etaBoundaries[ieta], etaBoundaries[ieta + 1], phiCenter, phiWidth);
         event_.decoded.emcalo.emplace_back(etaBoundaries[ieta], etaBoundaries[ieta + 1], phiCenter, phiWidth);
         event_.raw.hgcalcluster.emplace_back(etaBoundaries[ieta], etaBoundaries[ieta + 1], phiCenter, phiWidth);
@@ -693,7 +693,7 @@ void L1TCorrelatorLayer1Producer::initSectorsAndRegions(const edm::ParameterSet 
     float phiWidth = 2 * M_PI / phiSlices;
     for (unsigned int ieta = 0, neta = etaBoundaries.size() - 1; ieta < neta; ++ieta) {
       for (unsigned int iphi = 0; iphi < phiSlices; ++iphi) {
-        float phiCenter = reco::reduceRange(iphi * phiWidth);  //align with L1 TrackFinder phi sector indexing
+        float phiCenter = reco::reducePhiRange(iphi * phiWidth);  //align with L1 TrackFinder phi sector indexing
         event_.pfinputs.emplace_back(
             etaBoundaries[ieta], etaBoundaries[ieta + 1], phiCenter, phiWidth, etaExtra, phiExtra);
       }

--- a/L1Trigger/Phase2L1ParticleFlow/src/CaloClusterer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/CaloClusterer.cc
@@ -84,8 +84,8 @@ int l1tpf_calo::Phase1GridBase::find_cell(float eta, float phi) const {
     ieta = nEta_;
   if (eta < 0)
     ieta = -ieta;
-  phi = reco::reduceRange(phi);  // [-PI, PI]
-  if (phi < 0)                   // then bring to [0, 2*PI]
+  phi = reco::reducePhiRange(phi);  // [-PI, PI]
+  if (phi < 0)                      // then bring to [0, 2*PI]
     phi += 2 * M_PI;
   int iphi = std::floor(phi * nPhi_ / (2 * M_PI));
   if (phi >= 2 * M_PI)
@@ -356,7 +356,7 @@ void l1tpf_calo::SingleCaloClusterer::run() {
           cluster.eta = grid_->eta(i) + avg_eta / tot;
           cluster.phi = grid_->phi(i) + avg_phi / tot;
           // wrap around phi
-          cluster.phi = reco::reduceRange(cluster.phi);
+          cluster.phi = reco::reducePhiRange(cluster.phi);
         } else {
           cluster.eta = grid_->eta(i);
           cluster.phi = grid_->phi(i);
@@ -592,7 +592,7 @@ void l1tpf_calo::SimpleCaloLinker::run() {
           cluster.ecal_eta = cluster.eta;
           cluster.ecal_phi = cluster.phi;
           // wrap around phi
-          cluster.phi = reco::reduceRange(cluster.phi);
+          cluster.phi = reco::reducePhiRange(cluster.phi);
           cluster.constituents.emplace_back(-i - 1, 1);
         }
       } else {
@@ -622,7 +622,7 @@ void l1tpf_calo::SimpleCaloLinker::run() {
           cluster.ecal_eta = cluster.eta;
           cluster.ecal_phi = cluster.phi;
           // wrap around phi
-          cluster.phi = reco::reduceRange(cluster.phi);
+          cluster.phi = reco::reducePhiRange(cluster.phi);
         }
       }
       if (cluster.et > 0) {

--- a/L1Trigger/TrackFindingTracklet/src/HybridFit.cc
+++ b/L1Trigger/TrackFindingTracklet/src/HybridFit.cc
@@ -142,7 +142,7 @@ void HybridFit::Fit(Tracklet* tracklet, std::vector<const Stub*>& trackstublist)
   }
 
   // KF wants global phi0, not phi0 measured with respect to lower edge of sector (Tracklet convention).
-  kfphi0 = reco::reduceRange(kfphi0 + iSector_ * settings_.dphisector() - 0.5 * settings_.dphisectorHG());
+  kfphi0 = reco::reducePhiRange(kfphi0 + iSector_ * settings_.dphisector() - 0.5 * settings_.dphisectorHG());
 
   std::pair<float, float> helixrphi(kfrinv / (0.01 * settings_.c() * settings_.bfield()), kfphi0);
   std::pair<float, float> helixrz(kfz0, kft);
@@ -210,7 +210,7 @@ void HybridFit::Fit(Tracklet* tracklet, std::vector<const Stub*>& trackstublist)
       }
 
       // Tracklet wants phi0 with respect to lower edge of sector, not global phi0.
-      double phi0fit = reco::reduceRange(phi0 - iSector_ * 2 * M_PI / N_SECTOR + 0.5 * settings_.dphisectorHG());
+      double phi0fit = reco::reducePhiRange(phi0 - iSector_ * 2 * M_PI / N_SECTOR + 0.5 * settings_.dphisectorHG());
       double rinvfit = 0.01 * settings_.c() * settings_.bfield() * qoverpt;
 
       int irinvfit = floor(rinvfit / settings_.krinvpars());

--- a/L1Trigger/TrackFindingTracklet/src/MatchCalculator.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchCalculator.cc
@@ -199,7 +199,7 @@ void MatchCalculator::execute(unsigned int iSector, double phioffset) {
       double z = stub->z();
 
       if (settings_.useapprox()) {
-        double dphi = reco::reduceRange(phi - fpgastub->phiapprox(0.0, 0.0));
+        double dphi = reco::reducePhiRange(phi - fpgastub->phiapprox(0.0, 0.0));
         assert(std::abs(dphi) < 0.001);
         phi = fpgastub->phiapprox(0.0, 0.0);
         z = fpgastub->zapprox();
@@ -212,11 +212,11 @@ void MatchCalculator::execute(unsigned int iSector, double phioffset) {
       double dr = r - settings_.rmean(layerdisk_);
       assert(std::abs(dr) < settings_.drmax());
 
-      double dphi = reco::reduceRange(phi - (proj.phiproj() + dr * proj.phiprojder()));
+      double dphi = reco::reducePhiRange(phi - (proj.phiproj() + dr * proj.phiprojder()));
 
       double dz = z - (proj.rzproj() + dr * proj.rzprojder());
 
-      double dphiapprox = reco::reduceRange(phi - (proj.phiprojapprox() + dr * proj.phiprojderapprox()));
+      double dphiapprox = reco::reducePhiRange(phi - (proj.phiprojapprox() + dr * proj.phiprojderapprox()));
 
       double dzapprox = z - (proj.rzprojapprox() + dr * proj.rzprojderapprox());
 
@@ -363,7 +363,7 @@ void MatchCalculator::execute(unsigned int iSector, double phioffset) {
       double r = stub->r();
 
       if (settings_.useapprox()) {
-        double dphi = reco::reduceRange(phi - fpgastub->phiapprox(0.0, 0.0));
+        double dphi = reco::reducePhiRange(phi - fpgastub->phiapprox(0.0, 0.0));
         assert(std::abs(dphi) < 0.001);
         phi = fpgastub->phiapprox(0.0, 0.0);
         z = fpgastub->zapprox();
@@ -388,9 +388,9 @@ void MatchCalculator::execute(unsigned int iSector, double phioffset) {
 
       double dr = stub->r() - rproj;
 
-      double dphi = reco::reduceRange(phi - phiproj);
+      double dphi = reco::reducePhiRange(phi - phiproj);
 
-      double dphiapprox = reco::reduceRange(phi - (proj.phiprojapprox() + dz * proj.phiprojderapprox()));
+      double dphiapprox = reco::reducePhiRange(phi - (proj.phiprojapprox() + dz * proj.phiprojderapprox()));
 
       double drapprox = stub->r() - (proj.rzprojapprox() + dz * proj.rzprojderapprox());
 

--- a/L1Trigger/TrackFindingTracklet/src/MatchProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchProcessor.cc
@@ -515,7 +515,7 @@ bool MatchProcessor::matchCalculator(Tracklet* tracklet, const Stub* fpgastub, b
     double z = stub->z();
 
     if (settings_.useapprox()) {
-      double dphi = reco::reduceRange(phi - fpgastub->phiapprox(phimin_, 0.0));
+      double dphi = reco::reducePhiRange(phi - fpgastub->phiapprox(phimin_, 0.0));
       assert(std::abs(dphi) < 0.001);
       phi = fpgastub->phiapprox(phimin_, 0.0);
       z = fpgastub->zapprox();
@@ -529,11 +529,11 @@ bool MatchProcessor::matchCalculator(Tracklet* tracklet, const Stub* fpgastub, b
     double dr = r - settings_.rmean(layerdisk_);
     assert(std::abs(dr) < settings_.drmax());
 
-    double dphi = reco::reduceRange(phi - (proj.phiproj() + dr * proj.phiprojder()));
+    double dphi = reco::reducePhiRange(phi - (proj.phiproj() + dr * proj.phiprojder()));
 
     double dz = z - (proj.rzproj() + dr * proj.rzprojder());
 
-    double dphiapprox = reco::reduceRange(phi - (proj.phiprojapprox() + dr * proj.phiprojderapprox()));
+    double dphiapprox = reco::reducePhiRange(phi - (proj.phiprojapprox() + dr * proj.phiprojderapprox()));
 
     double dzapprox = z - (proj.rzprojapprox() + dr * proj.rzprojderapprox());
 
@@ -689,7 +689,7 @@ bool MatchProcessor::matchCalculator(Tracklet* tracklet, const Stub* fpgastub, b
     double r = stub->r();
 
     if (settings_.useapprox()) {
-      double dphi = reco::reduceRange(phi - fpgastub->phiapprox(phimin_, 0.0));
+      double dphi = reco::reducePhiRange(phi - fpgastub->phiapprox(phimin_, 0.0));
       assert(std::abs(dphi) < 0.001);
       phi = fpgastub->phiapprox(phimin_, 0.0);
       z = fpgastub->zapprox();
@@ -715,9 +715,9 @@ bool MatchProcessor::matchCalculator(Tracklet* tracklet, const Stub* fpgastub, b
     double dr = stub->r() - rproj;
     double drapprox = stub->r() - (proj.rzprojapprox() + dz * proj.rzprojderapprox());
 
-    double dphi = reco::reduceRange(phi - phiproj);
+    double dphi = reco::reducePhiRange(phi - phiproj);
 
-    double dphiapprox = reco::reduceRange(phi - (proj.phiprojapprox() + dz * proj.phiprojderapprox()));
+    double dphiapprox = reco::reducePhiRange(phi - (proj.phiprojapprox() + dz * proj.phiprojderapprox()));
 
     double drphi = dphi * stub->r();
     double drphiapprox = dphiapprox * stub->r();

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -640,13 +640,13 @@ std::vector<double> PurgeDuplicate::getInventedCoords(unsigned int iSector,
     stub_r = settings_.rmean(stubLayer - 1);
     stub_phi = tracklet->phi0() - std::asin(stub_r * tracklet_rinv / 2);
     stub_phi = stub_phi + iSector * settings_.dphisector() - 0.5 * settings_.dphisectorHG();
-    stub_phi = reco::reduceRange(stub_phi);
+    stub_phi = reco::reducePhiRange(stub_phi);
     stub_z = tracklet->z0() + 2 * tracklet->t() * 1 / tracklet_rinv * std::asin(stub_r * tracklet_rinv / 2);
   } else {
     stub_z = settings_.zmean(stubDisk - 1) * tracklet->disk() / abs(tracklet->disk());
     stub_phi = tracklet->phi0() - (stub_z - tracklet->z0()) * tracklet_rinv / 2 / tracklet->t();
     stub_phi = stub_phi + iSector * settings_.dphisector() - 0.5 * settings_.dphisectorHG();
-    stub_phi = reco::reduceRange(stub_phi);
+    stub_phi = reco::reducePhiRange(stub_phi);
     stub_r = 2 / tracklet_rinv * std::sin((stub_z - tracklet->z0()) * tracklet_rinv / 2 / tracklet->t());
   }
 
@@ -689,7 +689,7 @@ std::vector<double> PurgeDuplicate::getInventedCoordsExtended(unsigned int iSect
       sin_val = std::max(std::min(sin_val, 1.0), -1.0);
       stub_phi = tracklet->phi0() - std::asin(sin_val);
       stub_phi = stub_phi + iSector * settings_.dphisector() - 0.5 * settings_.dphisectorHG();
-      stub_phi = reco::reduceRange(stub_phi);
+      stub_phi = reco::reducePhiRange(stub_phi);
 
       // The expanded version of this expression is more stable for extremely
       // high-pT (high-rho) tracks. But we also explicitly restrict cos_val to
@@ -714,7 +714,7 @@ std::vector<double> PurgeDuplicate::getInventedCoordsExtended(unsigned int iSect
       sin_val = std::max(std::min(sin_val, 1.0), -1.0);
       stub_phi = tracklet->phi0() - std::asin(sin_val);
       stub_phi = stub_phi + iSector * settings_.dphisector() - 0.5 * settings_.dphisectorHG();
-      stub_phi = reco::reduceRange(stub_phi);
+      stub_phi = reco::reducePhiRange(stub_phi);
     }
   }
 

--- a/L1Trigger/TrackFindingTracklet/src/Sector.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Sector.cc
@@ -62,8 +62,8 @@ void Sector::setSector(unsigned int isector) {
   phimax_ = phimin_ + dphi + 2 * dphiHG;
   phimin_ -= M_PI / N_SECTOR;
   phimax_ -= M_PI / N_SECTOR;
-  phimin_ = reco::reduceRange(phimin_);
-  phimax_ = reco::reduceRange(phimax_);
+  phimin_ = reco::reducePhiRange(phimin_);
+  phimax_ = reco::reducePhiRange(phimax_);
   if (phimin_ > phimax_) {
     phimin_ -= 2 * M_PI;
   }

--- a/L1Trigger/TrackFindingTracklet/src/Stub.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Stub.cc
@@ -187,7 +187,7 @@ double Stub::phiapprox(double phimin, double) const {
   if (layer_.value() >= 3) {
     lphi = 8;
   }
-  return reco::reduceRange(phimin + phi_.value() * settings_.kphi() / lphi);
+  return reco::reducePhiRange(phimin + phi_.value() * settings_.kphi() / lphi);
 }
 
 unsigned int Stub::layerdisk() const {

--- a/L1Trigger/TrackFindingTracklet/src/Track.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Track.cc
@@ -42,13 +42,13 @@ double Track::phi0(Settings const& settings) const {
   double phimax = phimin + dphi + 2 * dphiHG;
   phimin -= M_PI / N_SECTOR;
   phimax -= M_PI / N_SECTOR;
-  phimin = reco::reduceRange(phimin);
-  phimax = reco::reduceRange(phimax);
+  phimin = reco::reducePhiRange(phimin);
+  phimax = reco::reducePhiRange(phimax);
   if (phimin > phimax)
     phimin -= 2 * M_PI;
   double phioffset = phimin;
 
   double phi0 = ipars_.phi0() * settings.kphi0pars() + phioffset;
-  phi0 = reco::reduceRange(phi0);
+  phi0 = reco::reducePhiRange(phi0);
   return phi0;
 }

--- a/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorBase.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorBase.cc
@@ -37,7 +37,7 @@ void TrackletCalculatorBase::exacttracklet(double r1,
                                            double rprojdisk[N_DISK],
                                            double phiderdisk[N_DISK],
                                            double rderdisk[N_DISK]) {
-  double deltaphi = reco::reduceRange(phi1 - phi2);
+  double deltaphi = reco::reducePhiRange(phi1 - phi2);
 
   double dist = sqrt(r2 * r2 + r1 * r1 - 2 * r1 * r2 * cos(deltaphi));
 
@@ -45,7 +45,7 @@ void TrackletCalculatorBase::exacttracklet(double r1,
 
   double phi1tmp = phi1 - phimin_;
 
-  phi0 = reco::reduceRange(phi1tmp + asin(0.5 * r1 * rinv));
+  phi0 = reco::reducePhiRange(phi1tmp + asin(0.5 * r1 * rinv));
 
   double rhopsi1 = 2 * asin(0.5 * r1 * rinv) / rinv;
   double rhopsi2 = 2 * asin(0.5 * r2 * rinv) / rinv;
@@ -90,7 +90,7 @@ void TrackletCalculatorBase::exacttrackletdisk(double r1,
                                                double rproj[N_DISK - 2],
                                                double phider[N_DISK - 2],
                                                double rder[N_DISK - 2]) {
-  double deltaphi = reco::reduceRange(phi1 - phi2);
+  double deltaphi = reco::reducePhiRange(phi1 - phi2);
 
   double dist = sqrt(r2 * r2 + r1 * r1 - 2 * r1 * r2 * cos(deltaphi));
 
@@ -98,7 +98,7 @@ void TrackletCalculatorBase::exacttrackletdisk(double r1,
 
   double phi1tmp = phi1 - phimin_;
 
-  phi0 = reco::reduceRange(phi1tmp + asin(0.5 * r1 * rinv));
+  phi0 = reco::reducePhiRange(phi1tmp + asin(0.5 * r1 * rinv));
 
   double rhopsi1 = 2 * asin(0.5 * r1 * rinv) / rinv;
   double rhopsi2 = 2 * asin(0.5 * r2 * rinv) / rinv;
@@ -143,7 +143,7 @@ void TrackletCalculatorBase::exacttrackletOverlap(double r1,
                                                   double rproj[N_DISK - 2],
                                                   double phider[N_DISK - 2],
                                                   double rder[N_DISK - 2]) {
-  double deltaphi = reco::reduceRange(phi1 - phi2);
+  double deltaphi = reco::reducePhiRange(phi1 - phi2);
 
   double dist = sqrt(r2 * r2 + r1 * r1 - 2 * r1 * r2 * cos(deltaphi));
 
@@ -154,7 +154,7 @@ void TrackletCalculatorBase::exacttrackletOverlap(double r1,
 
   double phi1tmp = phi1 - phimin_;
 
-  phi0 = reco::reduceRange(phi1tmp + asin(0.5 * r1 * rinv));
+  phi0 = reco::reducePhiRange(phi1tmp + asin(0.5 * r1 * rinv));
 
   double rhopsi1 = 2 * asin(0.5 * r1 * rinv) / rinv;
   double rhopsi2 = 2 * asin(0.5 * r2 * rinv) / rinv;

--- a/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorDisplaced.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorDisplaced.cc
@@ -1651,7 +1651,7 @@ void TrackletCalculatorDisplaced::exactprojdisk(double zproj,
 
   phiproj = atan2(y, x);
 
-  phiproj = reco::reduceRange(phiproj - phimin_);
+  phiproj = reco::reducePhiRange(phiproj - phimin_);
 
   rproj = sqrt(x * x + y * y);
 
@@ -1731,7 +1731,7 @@ void TrackletCalculatorDisplaced::exacttracklet(double r1,
 
   d0 = -R1 + sqrt(x0 * x0 + y0 * y0);
   //sign of rinv:
-  double dphi = reco::reduceRange(phi3 - atan2(y0, x0));
+  double dphi = reco::reducePhiRange(phi3 - atan2(y0, x0));
   if (dphi < 0) {
     rinv = -rinv;
     d0 = -d0;
@@ -1741,9 +1741,9 @@ void TrackletCalculatorDisplaced::exacttracklet(double r1,
 
   //now in RZ:
   //turning angle
-  double beta1 = reco::reduceRange(atan2(y1 - y0, x1 - x0) - atan2(-y0, -x0));
-  double beta2 = reco::reduceRange(atan2(y2 - y0, x2 - x0) - atan2(-y0, -x0));
-  double beta3 = reco::reduceRange(atan2(y3 - y0, x3 - x0) - atan2(-y0, -x0));
+  double beta1 = reco::reducePhiRange(atan2(y1 - y0, x1 - x0) - atan2(-y0, -x0));
+  double beta2 = reco::reducePhiRange(atan2(y2 - y0, x2 - x0) - atan2(-y0, -x0));
+  double beta3 = reco::reducePhiRange(atan2(y3 - y0, x3 - x0) - atan2(-y0, -x0));
 
   double t12 = (z2 - z1) / std::abs(beta2 - beta1) / R1;
   double z12 = (z1 * beta2 - z2 * beta1) / (beta2 - beta1);

--- a/L1Trigger/TrackFindingTracklet/test/Makefile
+++ b/L1Trigger/TrackFindingTracklet/test/Makefile
@@ -152,7 +152,7 @@ $(shell echo "};" >> FWCore/MessageLogger/interface/MessageLogger.h)
 $(shell echo "#endif" >> FWCore/MessageLogger/interface/MessageLogger.h)
 endif
 
-# reduceRange for standalone
+# reducePhiRange for standalone
 ifeq ("$(wildcard DataFormats/Math/interface)","")
 $(shell mkdir DataFormats)
 $(shell mkdir DataFormats/Math)
@@ -163,7 +163,7 @@ ifeq ("$(wildcard DataFormats/Math/interface/deltaPhi.h)","")
 $(shell echo "#ifndef DataFormats_Math_interface_deltaPhi_h" > DataFormats/Math/interface/deltaPhi.h)
 $(shell echo "#define DataFormats_Math_interface_deltaPhi_h" >> DataFormats/Math/interface/deltaPhi.h)
 $(shell echo "namespace reco {" >> DataFormats/Math/interface/deltaPhi.h)
-$(shell echo "  inline double reduceRange(double phi) { assert(std::abs(phi) < 100.0); " >> DataFormats/Math/interface/deltaPhi.h)
+$(shell echo "  inline double reducePhiRange(double phi) { assert(std::abs(phi) < 100.0); " >> DataFormats/Math/interface/deltaPhi.h)
 $(shell echo "    while (phi < -M_PI) { phi += 2 * M_PI; }" >> DataFormats/Math/interface/deltaPhi.h)
 $(shell echo "    while (phi > M_PI) { phi -= 2 * M_PI; }" >> DataFormats/Math/interface/deltaPhi.h)
 $(shell echo "    return phi; } " >> DataFormats/Math/interface/deltaPhi.h)

--- a/RecoMuon/L2MuonSeedGenerator/plugins/L2MuonSeedGeneratorFromL1TkMu.cc
+++ b/RecoMuon/L2MuonSeedGenerator/plugins/L2MuonSeedGeneratorFromL1TkMu.cc
@@ -223,7 +223,7 @@ void L2MuonSeedGeneratorFromL1TkMu::produce(edm::Event &iEvent, const edm::Event
       deta = deta * tanh(tk_eta);
     }
     float resPhi = tk_phi - phiCorr0_ * tk_q * cosh(phiCorr1_) / cosh(etaProp) / tk_pt * dzCorrPhi - M_PI / phiCorr2_;
-    resPhi = reco::reduceRange(resPhi);
+    resPhi = reco::reducePhiRange(resPhi);
 
     float pt = tk_pt;  //not corrected for eloss
     float eta = tk_eta + deta;


### PR DESCRIPTION
During the review of #47033 it was pointed out that the name `reduceRange` for the functions that restrict the φ angle is too generic and provides no connection to the fact that it is meant to be used for angles: https://github.com/cms-sw/cmssw/pull/47033#discussion_r1910650586.

This PR aims to rename the relevant function(s) to `reducePhiRange` to make their purpose clear. It is purely technical (no changes expected) and has been validated by making sure that the code compiles successfully.