### PR TITLE
Fix `cfi` creation for conf db parsing

### DIFF
--- a/CommonTools/RecoAlgos/src/MassiveCandidateConverter.cc
+++ b/CommonTools/RecoAlgos/src/MassiveCandidateConverter.cc
@@ -22,7 +22,7 @@ void MassiveCandidateConverter::beginFirstRun(const EventSetup& es) {
 }
 
 void MassiveCandidateConverter::fillPSetDescription(edm::ParameterSetDescription& desc) {
-  desc.addNode(edm::ParameterDescription<int>("particleType", true) xor
-               edm::ParameterDescription<std::string>("particleType", true))
+  desc.addNode(edm::ParameterDescription<std::string>("particleType", std::string("pi+"), true) xor
+               edm::ParameterDescription<int>("particleType", true))
       ->setComment("the PdtEntry can be specified as either an 'int' or via its name using a 'string'");
 }

--- a/RecoLocalMuon/CSCSegment/src/CSCSegmentBuilder.cc
+++ b/RecoLocalMuon/CSCSegment/src/CSCSegmentBuilder.cc
@@ -106,25 +106,10 @@ void CSCSegmentBuilder::fillPSetDescription(edm::ParameterSetDescription& desc) 
   /// Top-level parameters
   desc.add<int>("algo_type", 5)->setComment("Choice of the building algo: 1 SK, 2 TC, 3 DF, 4 ST, 5 RU, ...");
 
-  // Define the nested PSet for individual configurations
-  edm::ParameterSetDescription algoPSet;
-  algoPSet.add<std::vector<int>>("parameters_per_chamber_type", {1, 2, 3, 4, 5, 6, 5, 6, 5, 6});
-
-  // Define the VPSet inside algo_psets
+  // Define the validator for entries in algo_psets
   edm::ParameterSetDescription innerPSet;
-  // Allow any parameter in the innerPSet
-  innerPSet.setAllowAnything();
+  innerPSet.setAllowAnything();  // Allow any parameters in the inner PSet
 
-  // Fill the VPSet for algo_psets
-  edm::ParameterSetDescription innerAlgoPSet;
-  innerAlgoPSet.addVPSet("algo_psets", innerPSet);
-
-  // Additional top-level keys
-  algoPSet.addVPSet("algo_psets", innerPSet);
-  algoPSet.add<std::string>("algo_name", "CSCSegAlgoRU");
-  algoPSet.add<std::vector<std::string>>(
-      "chamber_types", {"ME1/a", "ME1/b", "ME1/2", "ME1/3", "ME2/1", "ME2/2", "ME3/1", "ME3/2", "ME4/1", "ME4/2"});
-
-  // Add to the top-level VPSet
-  desc.addVPSet("algo_psets", algoPSet);
+  // Add algo_psets as a VPSet with an empty default value
+  desc.addVPSet("algo_psets", innerPSet, {})->setComment("Default empty VPSet, can contain anything");
 }


### PR DESCRIPTION
#### PR description:

@Martin-Grunewald reported an issue in the confDB parsing of `CMSSW_15_0_0_pre2` concerning:

```
 -> hltBcJpsiTkAllConeTracksIter [ConcreteChargedCandidateProducer] CHANGED
       string particleType = "K+" [REMOVED]
  -> hltCscSegments [CSCSegmentProducer] CHANGED
       VPSet algo_psets [REMOVED]
```

this is due to https://github.com/cms-sw/cmssw/pull/47017 and https://github.com/cms-sw/cmssw/pull/47045 having the modules  `ConcreteChargedCandidateProducer` and `CSCSegmentProducer`  auto-generate cfi files with incomplete top level parameter configurations.
This PR fixes the issue

#### PR validation:

Upon compilation I get the following python files available:

```python
$ more ../cfipython/el9_amd64_gcc12/CommonTools/RecoAlgos/ConcreteChargedCandidateProducer.py
import FWCore.ParameterSet.Config as cms

def ConcreteChargedCandidateProducer(*args, **kwargs):
  mod = cms.EDProducer('ConcreteChargedCandidateProducer',
    src = cms.InputTag(''),
    particleType = cms.string('pi+'),
    mightGet = cms.optional.untracked.vstring
  )
  for a in args:
    mod.update_(a)
  mod.update_(kwargs)
  return mod
```

and

```python
$ more ../cfipython/el9_amd64_gcc12/RecoLocalMuon/CSCSegment/CSCSegmentProducer.py                                                                                                   import FWCore.ParameterSet.Config as cms

def CSCSegmentProducer(*args, **kwargs):
  mod = cms.EDProducer('CSCSegmentProducer',
    inputObjects = cms.InputTag('csc2DRecHits'),
    algo_type = cms.int32(5),
    algo_psets = cms.VPSet(
    ),
    mightGet = cms.optional.untracked.vstring
  )
  for a in args:
    mod.update_(a)
  mod.update_(kwargs)
  return mod
```

which is fine for parsing purposes.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A