### PR TITLE
Remove unused iorules of missing reco::LeafParticle class

### DIFF
--- a/DataFormats/HcalIsolatedTrack/src/classes_def.xml
+++ b/DataFormats/HcalIsolatedTrack/src/classes_def.xml
@@ -23,12 +23,6 @@
    <version ClassVersion="12" checksum="554168470"/>
    <version ClassVersion="10" checksum="4174683084"/>
    <version ClassVersion="11" checksum="928263435"/>
-   <ioread sourceClass="reco::EcalIsolatedParticleCandidate" version="[1-11]" targetClass="reco::LeafParticle" source="double eta_" target="float eta_">
-   <![CDATA[eta_ = onfile.eta_;]]>
-   </ioread>  
-   <ioread sourceClass="reco::EcalIsolatedParticleCandidate" version="[1-11]" targetClass="reco::LeafParticle" source="double phi_" target="float phi_">
-   <![CDATA[phi_ = onfile.phi_;]]>
-   </ioread>   
   </class>
   <class name="reco::EcalIsolatedParticleCandidateCollection"/>
   <class name="reco::EcalIsolatedParticleCandidateRef"/>


### PR DESCRIPTION
Latest ROOT change https://github.com/root-project/root/pull/17347#issuecomment-2602579627 generate warnings when there are unused iorules. We do not have `reco::LeafParticle` class in CMSSW and previously root was just ignoring these unused iorule but now it generate warning which then break the build as we trest root warnings as errors.

See details https://github.com/cms-sw/cmsdist/pull/9627