### PR TITLE
Update online GTs for 150X and GT for 2025 MC conditions in autoCond 

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -31,13 +31,13 @@ autoCond = {
     'run2_data_promptlike_hi'      :    '140X_dataRun2_PromptLike_HI_v1',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              :    '140X_dataRun2_HLT_relval_v1',
-    # GlobalTag for Run3 HLT: identical the online GT 140X_dataRun3_HLT_v4 with snapshot at 2024-11-28 13:17:51 (UTC)
-    'run3_hlt'                     :    '141X_dataRun3_HLT_frozen_v2',
-    # GlobalTag for Run3 data relvals (express GT): same as 141X_dataRun3_Express_v4 but with snapshot at 2024-11-28 13:23:29 (UTC)
-    'run3_data_express'            :    '141X_dataRun3_Express_frozen_v4',
-    # GlobalTag for Run3 data relvals (prompt GT): same as 141X_dataRun3_Prompt_v4 but with snapshot at 2024-11-28 13:26:44 (UTC)
-    'run3_data_prompt'             :    '141X_dataRun3_Prompt_frozen_v4',
-    # GlobalTag for Run3 offline data reprocessing - snapshot at 2024-11-12 07:39:42 (UTC)
+    # GlobalTag for Run3 HLT: identical the online GT 150X_dataRun3_HLT_v1 but with snapshot at 2025-01-22 13:40:56
+    'run3_hlt'                     :    '150X_dataRun3_HLT_frozen250122_v1',
+    # GlobalTag for Run3 data relvals (express GT): same as 150X_dataRun3_Express_v1 but with snapshot at 2025-01-22 13:46:42
+    'run3_data_express'            :    '150X_dataRun3_Express_frozen250122_v1',
+    # GlobalTag for Run3 data relvals (prompt GT): same as 150X_dataRun3_Prompt_v1 but with snapshot at 2025-01-22 13:49:01
+    'run3_data_prompt'             :    '150X_dataRun3_Prompt_frozen250122_v1',
+    # GlobalTag for Run3 offline data reprocessing - snapshot at 2024-11-27 13:03:22 (UTC)
     'run3_data'                    :    '141X_dataRun3_v5',
     # GlobalTag for Run3 offline data reprocessing with Prompt GT, currently for 2022FG - snapshot at 2024-02-12 12:00:00 (UTC)
     'run3_data_PromptAnalysis'     :    '140X_dataRun3_PromptAnalysis_v2',
@@ -100,11 +100,11 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2024 detector for Heavy Ion
     'phase1_2024_realistic_hi'     :    '141X_mcRun3_2024_realistic_HI_v13',
     # GlobalTag for MC production with realistic conditions for Phase1 2024 detector for ppRef5TeV
-    'phase1_2024_realistic_ppRef5TeV'     :    '141X_mcRun3_2024_realistic_ppRef5TeV_v7',
+    'phase1_2024_realistic_ppRef5TeV' : '141X_mcRun3_2024_realistic_ppRef5TeV_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2025
     'phase1_2025_design'           :    '140X_mcRun3_2024_design_v11',
-    # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2025_realistic'        :    '142X_mcRun3_2025_realistic_v2',
+    # GlobalTag for MC production with realistic conditions for Phase1 2025
+    'phase1_2025_realistic'        :    '142X_mcRun3_2025_realistic_v5',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             :    '141X_mcRun4_realistic_v3'
 }


### PR DESCRIPTION
#### PR description:

Online GTs were moved to 150X, with a few updates, in autoCond:
- `run3_hlt`   :  [150X_dataRun3_HLT_frozen250122_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/150X_dataRun3_HLT_frozen250122_v1) (same as [150X_dataRun3_HLT_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/150X_dataRun3_HLT_v1) but with snapshot at 2025-01-22)
  - Diff between 150X_dataRun3_HLT_v1 and previous 141X_dataRun3_HLT_v2 is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/150X_dataRun3_HLT_v1/141X_dataRun3_HLT_v2) 
  - (no changes)
- `run3_data_express`  :   [150X_dataRun3_Express_frozen250122_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/150X_dataRun3_Express_frozen250122_v1) (same as [150X_dataRun3_Express_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/150X_dataRun3_Express_v1) but with snapshot at 2025-01-22)
  - Diff between 150X_dataRun3_Express_v1 and previous 141X_dataRun3_Express_v4 is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/150X_dataRun3_Express_v1/141X_dataRun3_Express_v4)
  - (New dropbox metadata tag that adds the HLT HG-PCL combined workflow, introduced in https://github.com/cms-sw/cmssw/pull/46913)
- `run3_data_prompt`  :   [150X_dataRun3_Prompt_frozen250122_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/150X_dataRun3_Prompt_frozen250122_v1) (same as [150X_dataRun3_Prompt_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/150X_dataRun3_Prompt_v1) but with snapshot at 2025-01-22)
  - Diff between 150X_dataRun3_Prompt_v1 and previous 141X_dataRun3_Prompt_v4 is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/150X_dataRun3_Prompt_v1/141X_dataRun3_Prompt_v4)
  - (New dropbox metadata tag that adds the HLT HG-PCL combined workflow, introduced in https://github.com/cms-sw/cmssw/pull/46913)

Moreover, the GT for 2025 MC was integrated with the latest updates for the Winter25 campaign.
- `phase1_2025_realistic`  :  [142X_mcRun3_2025_realistic_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/142X_mcRun3_2025_realistic_v5)
  - GT for Winter 2025 MC Production, EOY conditions, so EOY Tracker + EOY Ecal ZS/SR settings + EOY ECAL PFRecHit thresholds + HCAL realistic PF Cuts + EOY for all other conditions, HcalRespCorrs_2025_MOY_v2_mc serving for both MOY/EOY, see https://cms-talk.web.cern.ch/t/call-for-run3winter25-mc-conditions-in-142x/55993/20
  - Diff with respect to `_v2` is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/142X_mcRun3_2025_realistic_v2/142X_mcRun3_2025_realistic_v5)
  - (Updated HCAL response corrections for MOY 2025)


#### PR validation:

GTs were already tested separately
Rely on PR tests for a wider set of workflows

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Limited backport of what relevant for the previous cycles will be allowed