### PR TITLE
Phase2 inner tracker class def xml fix

### DIFF
--- a/DataFormats/Phase2TrackerDigi/src/classes_def.xml
+++ b/DataFormats/Phase2TrackerDigi/src/classes_def.xml
@@ -5,9 +5,17 @@
    <class name="edm::Ref< edm::DetSetVector< Phase2TrackerDigi >, Phase2TrackerDigi >"/>
    <class name="std::vector< edm::Ref< edm::DetSetVector< Phase2TrackerDigi >, Phase2TrackerDigi > >"/>
    <class name="edm::DetSet<Phase2TrackerDigi>"/>
-   <class name="edm::DetSet<Phase2ITQCore>"/>
-   <class name="edm::DetSet<Phase2ITChipBitStream>"/>
+   <class name="Phase2ITQCore" ClassVersion="3">
+    <version ClassVersion="3" checksum="2154561050"/>
+   </class>                                 
+   <class name="Phase2ITChipBitStream" ClassVersion="3">
+    <version ClassVersion="3" checksum="2503829339"/>
+   </class>                                 
    <class name="std::vector<Phase2TrackerDigi>"/>
+   <class name="edm::DetSet<Phase2ITChipBitStream>"/>
+   <class name="edm::DetSet<Phase2ITQCore>"/>
+   <class name="std::vector<Phase2ITChipBitStream>"/>
+   <class name="std::vector<Phase2ITQCore>"/>
    <class name="edm::DetSetVector<Phase2TrackerDigi>"/>
    <class name="edm::DetSetVector<Phase2ITQCore>"/>
    <class name="edm::DetSetVector<Phase2ITChipBitStream>"/>
@@ -26,3 +34,4 @@
    <class name="edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> >" />
    <class name="vector<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >" />
 </lcgdict>
+


### PR DESCRIPTION

  - what changes are expected in the output if any, 
  Bug fix so that QCore -related objects can actually be stored in the EDM output

  - what other PRs or externals it depends upon if any,
 https://github.com/cms-sw/cmssw/pull/45759 following up with lingering comments from this PR. proper class definitions in xml file (checked the output actually stores QCore objects)
