### PR TITLE
ETL simulation: update of TWC parameters

### DIFF
--- a/RecoLocalFastTime/FTLRecProducers/python/mtdUncalibratedRecHits_cfi.py
+++ b/RecoLocalFastTime/FTLRecProducers/python/mtdUncalibratedRecHits_cfi.py
@@ -23,10 +23,10 @@ _endcapAlgo = cms.PSet(
     toaLSB_ns     = mtdDigitizer.endcapDigitizer.ElectronicsSimulation.toaLSB_ns,
     tofDelay      = mtdDigitizer.endcapDigitizer.DeviceSimulation.tofDelay,
     timeResolutionInNs = cms.string("0.0370"), # [ns]
-    timeCorr_p0 = cms.double(1.07959),
-    timeCorr_p1 = cms.double(-0.274148),
-    timeCorr_p2 = cms.double(0.0241685),
-    timeCorr_p3 = cms.double(-0.000665249)
+    timeCorr_p0 = cms.double(0.974683),
+    timeCorr_p1 = cms.double(-0.237274),
+    timeCorr_p2 = cms.double(0.021455),
+    timeCorr_p3 = cms.double(-0.000727429)
 )
 
 


### PR DESCRIPTION
#### PR description:

This PR aims to update the time walk correction parameters for ETL hit reconstruction, as a consequence of a bias observed in ETL time resolution [1].
TWC parameters have been recomputed to fit better the high statistics region. More details in [2].

[1] https://indico.cern.ch/event/1498634/#13-report-on-14_2_0_pre4-valid
[2] https://indico.cern.ch/event/1498383/#13-update-of-etl-time-walk-cor

#### PR validation:

PR has been validated with a sample of 1000 events of ttbar 14TeV. 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not meant to be backported.

@fabiocos @martinamalberti 