### PR TITLE
use faster variant of OmniClusterRef and RefCoreWithIndex initialization

### DIFF
--- a/DataFormats/Common/interface/RefCoreWithIndex.h
+++ b/DataFormats/Common/interface/RefCoreWithIndex.h
@@ -33,6 +33,7 @@ namespace edm {
                      bool transient,
                      unsigned int elementIndex);
 
+    /**No checks are done: id must be valid; transient bit is not set  */
     RefCoreWithIndex(ProductID const& id, void const* prodPtr, unsigned int index)
         : cachePtr_(prodPtr),
           processIndex_(id.processIndex()),

--- a/DataFormats/Common/interface/RefCoreWithIndex.h
+++ b/DataFormats/Common/interface/RefCoreWithIndex.h
@@ -33,6 +33,12 @@ namespace edm {
                      bool transient,
                      unsigned int elementIndex);
 
+    RefCoreWithIndex(ProductID const& id, void const* prodPtr, unsigned int index)
+        : cachePtr_(prodPtr),
+          processIndex_(id.processIndex()),
+          productIndex_(id.productIndex()),
+          elementIndex_(index) {}
+
     RefCoreWithIndex(RefCore const& iCore, unsigned int);
 
     RefCoreWithIndex(RefCoreWithIndex const&);

--- a/DataFormats/TrackerRecHit2D/interface/OmniClusterRef.h
+++ b/DataFormats/TrackerRecHit2D/interface/OmniClusterRef.h
@@ -28,6 +28,7 @@ public:
   typedef edm::Ref<FTLClusterCollection, FTLCluster> ClusterMTDRef;
 
   OmniClusterRef() : me(edm::RefCore(), kInvalid) {}
+  OmniClusterRef(edm::ProductID const& id, SiStripCluster const* clu, unsigned int key) : me(id, clu, key | kIsStrip) {}
   explicit OmniClusterRef(ClusterPixelRef const& ref, unsigned int subClus = 0)
       : me(ref.refCore(), (ref.isNonnull() ? ref.key() | (subClus << subClusShift) : kInvalid)) {}
   explicit OmniClusterRef(ClusterStripRef const& ref, unsigned int subClus = 0)

--- a/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitConverterAlgorithm.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitConverterAlgorithm.cc
@@ -59,6 +59,7 @@ void SiStripRecHitConverterAlgorithm::run(edm::Handle<edmNew::DetSetVector<SiStr
 void SiStripRecHitConverterAlgorithm::run(edm::Handle<edmNew::DetSetVector<SiStripCluster>> inputhandle,
                                           products& output,
                                           LocalVector trackdirection) {
+  auto const inputID = inputhandle.id();
   for (auto const& DS : *inputhandle) {
     auto id = DS.id();
     if (!useModule(id))
@@ -75,8 +76,8 @@ void SiStripRecHitConverterAlgorithm::run(edm::Handle<edmNew::DetSetVector<SiStr
         continue;
 
       StripClusterParameterEstimator::LocalValues parameters = parameterestimator->localParameters(cluster, du);
-      collector.push_back(
-          SiStripRecHit2D(parameters.first, parameters.second, du, DS.makeRefTo(inputhandle, &cluster)));
+      collector.push_back(SiStripRecHit2D(
+          parameters.first, parameters.second, du, OmniClusterRef(inputID, &cluster, DS.makeKeyOf(&cluster))));
     }
 
     if (collector.empty())


### PR DESCRIPTION
this was motivated by inspection of `SiStripRecHitConverterAlgorithm` in the HLT context (runs without matching; expected to be used in HLT in combination with mkFit)

The overhead of making the `OmniClusterRef` via `edmNew::DetSet::makeRefTo` appeared too costly due to mostly trivial calls cluttered by unnecessary out-of-line calls that prevented the compiler optimization.
- In the setup with mkFit in HLT the speedup in `SiStripRecHitConverter::produce` is around 6% (relative); 
- the change in the offline setup is mostly negligible due to running rphi-stereo matching which dominates `SiStripRecHitConverter`

No physics changes are expected.

There are probably benefits from using a similar `OmniClusterRef` constructor in other places, like `SiPixelRecHitFromSoAAlpaka`, but it's not a significant contributor to the total cost.

@cms-sw/tracking-pog-l2 @cms-sw/trk-dpg-l2 