### PR TITLE
Add HardwareResourcesDescription class

### DIFF
--- a/DataFormats/Provenance/interface/HardwareResourcesDescription.h
+++ b/DataFormats/Provenance/interface/HardwareResourcesDescription.h
@@ -1,0 +1,27 @@
+#ifndef DataFormats_Provenance_interface_HardwareResourcesDescription_h
+#define DataFormats_Provenance_interface_HardwareResourcesDescription_h
+
+#include <iosfwd>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace edm {
+  struct HardwareResourcesDescription {
+    HardwareResourcesDescription() = default;
+    explicit HardwareResourcesDescription(std::string_view serialized);
+
+    std::string serialize() const;
+
+    bool operator==(HardwareResourcesDescription const& other) const;
+
+    std::string microarchitecture;
+    std::vector<std::string> cpuModels;
+    std::vector<std::string> selectedAccelerators;
+    std::vector<std::string> gpuModels;
+  };
+
+  std::ostream& operator<<(std::ostream& os, HardwareResourcesDescription const& rd);
+}  // namespace edm
+
+#endif

--- a/DataFormats/Provenance/src/HardwareResourcesDescription.cc
+++ b/DataFormats/Provenance/src/HardwareResourcesDescription.cc
@@ -1,0 +1,57 @@
+#include "DataFormats/Provenance/interface/HardwareResourcesDescription.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Utilities/interface/compactStringSerializer.h"
+
+#include <iterator>
+#include <ostream>
+
+namespace edm {
+  HardwareResourcesDescription::HardwareResourcesDescription(std::string_view serialized) {
+    // allowing empty input is mostly for backwards compatibility
+    if (not serialized.empty()) {
+      auto ret = edm::compactString::deserialize(serialized,
+                                                 microarchitecture,
+                                                 std::back_inserter(cpuModels),
+                                                 std::back_inserter(selectedAccelerators),
+                                                 std::back_inserter(gpuModels));
+      // not comparing against serialized.size() to allow serialized
+      // to have more content (for kind of forward compatibility)
+      if (ret == 0) {
+        throw Exception(errors::EventCorruption) << "Failed to deserialize HardwareResourcesDescription string format";
+      }
+    }
+  }
+
+  std::string HardwareResourcesDescription::serialize() const {
+    return edm::compactString::serialize(microarchitecture, cpuModels, selectedAccelerators, gpuModels);
+  }
+
+  bool HardwareResourcesDescription::operator==(HardwareResourcesDescription const& other) const {
+    return microarchitecture == other.microarchitecture and std::ranges::equal(cpuModels, other.cpuModels) and
+           std::ranges::equal(selectedAccelerators, other.selectedAccelerators) and
+           std::ranges::equal(gpuModels, other.gpuModels);
+  }
+
+  std::ostream& operator<<(std::ostream& os, HardwareResourcesDescription const& rd) {
+    auto printContainer = [&os](std::string_view header, std::vector<std::string> const& cont) {
+      os << header << ": " << cont.front();
+      for (auto it = cont.begin() + 1; it != cont.end(); ++it) {
+        os << ", " << *it;
+      }
+    };
+
+    os << "uarch: " << rd.microarchitecture << "\n";
+    if (not rd.cpuModels.empty()) {
+      printContainer("CPU models", rd.cpuModels);
+      os << "\n";
+    }
+    if (not rd.selectedAccelerators.empty()) {
+      printContainer("Selected accelerators", rd.selectedAccelerators);
+      os << "\n";
+    }
+    if (not rd.gpuModels.empty()) {
+      printContainer("GPU models", rd.gpuModels);
+    }
+    return os;
+  }
+}  // namespace edm

--- a/DataFormats/Provenance/test/BuildFile.xml
+++ b/DataFormats/Provenance/test/BuildFile.xml
@@ -3,7 +3,7 @@
 <use name="DataFormats/Provenance"/>
 </bin>
 
-<bin name="testDataFormatsProvenanceCatch2" file="ElementID_t.cpp,Parentage_t.cpp,StoredProcessBlockHelper_t.cpp,CompactHash_t.cpp">
+<bin name="testDataFormatsProvenanceCatch2" file="ElementID_t.cpp,Parentage_t.cpp,StoredProcessBlockHelper_t.cpp,CompactHash_t.cpp,HardwareResourcesDescription_t.cpp">
   <use name="DataFormats/Provenance"/>
   <use name="catch2"/>
 </bin>

--- a/DataFormats/Provenance/test/HardwareResourcesDescription_t.cpp
+++ b/DataFormats/Provenance/test/HardwareResourcesDescription_t.cpp
@@ -1,0 +1,80 @@
+#include "catch.hpp"
+
+#include "DataFormats/Provenance/interface/HardwareResourcesDescription.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+
+TEST_CASE("HardwareResourcesDescription", "[HardwareResourcesDescription]") {
+  SECTION("Construction from empty string") {
+    CHECK(edm::HardwareResourcesDescription("") == edm::HardwareResourcesDescription());
+  }
+
+  SECTION("Default construction") {
+    edm::HardwareResourcesDescription resources;
+    CHECK(edm::HardwareResourcesDescription(resources.serialize()) == resources);
+  }
+
+  SECTION("Microarchitecture") {
+    edm::HardwareResourcesDescription resources;
+    resources.microarchitecture = "x86-64-v3";
+    CHECK(edm::HardwareResourcesDescription(resources.serialize()) == resources);
+  }
+
+  SECTION("CPU models") {
+    edm::HardwareResourcesDescription resources;
+    resources.cpuModels = {"Intel something", "AMD something else"};
+    CHECK(edm::HardwareResourcesDescription(resources.serialize()) == resources);
+  }
+
+  SECTION("accelerators") {
+    edm::HardwareResourcesDescription resources;
+    resources.selectedAccelerators = {"cpu", "gpu"};
+    CHECK(edm::HardwareResourcesDescription(resources.serialize()) == resources);
+  }
+
+  SECTION("GPU models") {
+    edm::HardwareResourcesDescription resources;
+    resources.gpuModels = {"NVIDIA something", "NVIDIA something else"};
+    CHECK(edm::HardwareResourcesDescription(resources.serialize()) == resources);
+  }
+
+  SECTION("All fields") {
+    edm::HardwareResourcesDescription resources;
+    resources.microarchitecture = "x86-64-v3";
+    resources.cpuModels = {"Intel something", "AMD something else"};
+    resources.selectedAccelerators = {"cpu", "gpu"};
+    resources.gpuModels = {"NVIDIA something", "NVIDIA something else"};
+    CHECK(edm::HardwareResourcesDescription(resources.serialize()) == resources);
+  }
+
+  SECTION("Serialization has additional things (forward compatibility)") {
+    edm::HardwareResourcesDescription resources, resources2;
+    resources.microarchitecture = "x86-64-v3";
+    resources.cpuModels = {"Intel something", "AMD something else"};
+    resources.selectedAccelerators = {"cpu", "gpu"};
+    resources.gpuModels = {"NVIDIA something", "NVIDIA something else"};
+    resources2.microarchitecture = "this";
+    resources2.cpuModels = {"is"};
+    resources2.selectedAccelerators = {"something"};
+    resources2.gpuModels = {"else"};
+    auto const serial = resources.serialize() + resources2.serialize();
+    CHECK(edm::HardwareResourcesDescription(serial) == resources);
+  }
+
+  SECTION("Error cases") {
+    SECTION("Invalid serialized string") {
+      CHECK_THROWS_AS(edm::HardwareResourcesDescription("foo"), edm::Exception);
+
+      edm::HardwareResourcesDescription resources;
+      resources.microarchitecture = "x86-64-v3";
+      auto serialized = resources.serialize();
+      SECTION("Last container does not have the delimiter") {
+        serialized.back() = ',';
+        CHECK_THROWS_AS(edm::HardwareResourcesDescription(serialized), edm::Exception);
+      }
+      SECTION("Too few containers") {
+        serialized.pop_back();
+        CHECK_THROWS_AS(edm::HardwareResourcesDescription(serialized), edm::Exception);
+      }
+    }
+  }
+}

--- a/FWCore/Utilities/interface/compactStringSerializer.h
+++ b/FWCore/Utilities/interface/compactStringSerializer.h
@@ -1,0 +1,140 @@
+#ifndef FWCore_Utilities_interface_compactStringSerializer_h
+#define FWCore_Utilities_interface_compactStringSerializer_h
+
+#include <cassert>
+#include <iterator>
+#include <numeric>
+#include <ranges>
+#include <string>
+#include <string_view>
+
+namespace edm::compactString {
+  namespace detail {
+    constexpr std::string_view kDelimiters = "\x1d\x1e";
+    constexpr char kContainerDelimiter = kDelimiters[0];  // "group separator" in ASCII
+    constexpr char kElementDelimiter = kDelimiters[1];    // "record separator" in ASCII
+
+    void throwIfContainsDelimiters(std::string const& str);
+  }  // namespace detail
+
+  /**
+   * Following three functions serialize a sequence of strings and containers of strings
+   *
+   * Each top-level string or container of strings is separated with kContainerDelimeter
+   * In case of container of strings, each element is separated with kElementDelimeter
+   * The serialized string will end with kContainerDelimeter and a null character
+   *
+   * The functions throw an exception if the serialized strings
+   * contain any of the delimeter characters. The underlying string
+   * operations may also throw exceptions.
+   */
+  inline std::string serialize(std::string arg) noexcept(false) {
+    detail::throwIfContainsDelimiters(arg);
+    arg += detail::kContainerDelimiter;
+    return arg;
+  }
+
+  template <typename R>
+    requires std::ranges::input_range<R> and std::is_same_v<std::ranges::range_value_t<R>, std::string>
+  std::string serialize(R const& arg) noexcept(false) {
+    std::string ret;
+
+    if (not std::ranges::empty(arg)) {
+      for (std::string const& elem : arg) {
+        ret.reserve(ret.size() + elem.size() + 1);
+        detail::throwIfContainsDelimiters(elem);
+        ret += elem;
+        ret += detail::kElementDelimiter;
+      }
+    }
+
+    ret += detail::kContainerDelimiter;
+    return ret;
+  }
+
+  template <typename T, typename... Args>
+    requires(sizeof...(Args) >= 1)
+  std::string serialize(T&& arg0, Args&&... args) noexcept(false) {
+    return serialize(std::forward<T>(arg0)) + serialize(std::forward<Args>(args)...);
+  }
+
+  /**
+   * Following three functions deserialize a string 'input' into a
+   * sequence of strings and containers of strings
+   *
+   * The 'input' string is assumed to be serialized with the
+   * serialize() functions above.
+   *
+   * The output arguments following the 'input' define the schema of
+   * the deserialization.
+   * - std::string& for strings
+   * - output iterator for containers of strings (e.g. std::back_inserter(vector))
+   *
+   * Upon success, the return value is the position in `input` for the
+   * next possible element (i.e. the position after the
+   * kContainerDelimiter), that is also the number of characters
+   * consumed by the deserializatiom..
+   *
+   * Upon failure, returns 0 to denote the beginning of `input`. The
+   * output arguments may have been modified.
+   *
+   * The functions do not explicitly throw exceptions, but underlying
+   * operations may throw exceptions.
+   */
+  inline std::string_view::size_type deserialize(std::string_view input, std::string& arg) {
+    auto const pos = input.find_first_of(detail::kDelimiters);
+    if (pos == std::string_view::npos or input[pos] != detail::kContainerDelimiter) {
+      return 0;
+    }
+    arg = input.substr(0, pos);
+    return pos + 1;  // skip delimiter
+  }
+
+  template <std::output_iterator<std::string> I>
+  inline std::string_view::size_type deserialize(std::string_view input, I arg) {
+    auto pos = input.find_first_of(detail::kDelimiters);
+    // invalid input
+    if (pos == std::string_view::npos) {
+      return 0;
+    }
+    // no elements
+    if (input[pos] == detail::kContainerDelimiter) {
+      // invalid input for empty container
+      if (pos != 0) {
+        return 0;
+      }
+      // skip delimiter
+      return pos + 1;
+    }
+
+    std::string_view::size_type prev = 0;
+    while (pos != std::string_view::npos and input[pos] == detail::kElementDelimiter) {
+      *arg = std::string(input.substr(prev, pos - prev));
+      ++arg;
+      prev = pos + 1;  //skip delimiter
+      pos = input.find_first_of(detail::kDelimiters, prev);
+    }
+
+    // every container must end with kContainerDelimiter
+    // reaching npos is an error
+    if (pos == std::string_view::npos) {
+      return 0;
+    }
+    assert(input[pos] == detail::kContainerDelimiter);
+
+    return pos + 1;  // skip delimiter
+  }
+
+  template <typename T, typename... Args>
+    requires(sizeof...(Args) >= 1)
+  std::string_view::size_type deserialize(std::string_view input, T&& arg0, Args&&... args) {
+    auto pos = deserialize(input, std::forward<T>(arg0));
+    if (pos != 0) {
+      auto const ret = deserialize(input.substr(pos), std::forward<Args>(args)...);
+      pos = (ret == 0) ? 0 : pos + ret;
+    }
+    return pos;
+  }
+}  // namespace edm::compactString
+
+#endif

--- a/FWCore/Utilities/src/compactStringSerializer.cc
+++ b/FWCore/Utilities/src/compactStringSerializer.cc
@@ -1,0 +1,19 @@
+#include "FWCore/Utilities/interface/compactStringSerializer.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+namespace edm::compactString::detail {
+  void throwIfContainsDelimiters(std::string const& str) {
+    auto pos = str.find_first_of(kDelimiters);
+    if (pos != std::string::npos) {
+      cms::Exception ex("compactString");
+      ex << "Serialized string '" << str << "' contains ";
+      if (str[pos] == kContainerDelimiter) {
+        ex << "container";
+      } else {
+        ex << "element";
+      }
+      ex << " delimiter at position " << pos;
+      throw ex;
+    }
+  }
+}  // namespace edm::compactString::detail

--- a/FWCore/Utilities/test/test_catch2_compactStringSerializer.cc
+++ b/FWCore/Utilities/test/test_catch2_compactStringSerializer.cc
@@ -1,0 +1,365 @@
+#include "catch.hpp"
+
+#include <iostream>
+#include <list>
+#include <string>
+#include <vector>
+
+#include "FWCore/Utilities/interface/compactStringSerializer.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+namespace cs = edm::compactString;
+
+TEST_CASE("Test edm::compactString serializer", "[edm::compactString]") {
+  using namespace std::string_literals;
+  SECTION("Empty inputs") {
+    SECTION("Serialization") {
+      SECTION("Empty string") {
+        auto result = cs::serialize(""s);
+        CHECK(result.size() == 1);  // one delimiter
+        result = cs::serialize("");
+        CHECK(result.size() == 1);  // one delimiter
+      }
+
+      SECTION("Two empty strings") {
+        auto result = cs::serialize(""s, ""s);
+        CHECK(result.size() == 2);
+        result = cs::serialize(""s, "");
+        CHECK(result.size() == 2);
+        result = cs::serialize("", ""s);
+        CHECK(result.size() == 2);
+        result = cs::serialize("", "");
+        CHECK(result.size() == 2);
+      }
+
+      SECTION("Empty vector of strings and empty string") {
+        auto result = cs::serialize(std::vector<std::string>());
+        CHECK(result.size() == 1);
+        result = cs::serialize(""s, std::vector<std::string>());
+        CHECK(result.size() == 2);
+        result = cs::serialize(std::vector<std::string>(), "");
+        CHECK(result.size() == 2);
+        result = cs::serialize(std::vector<std::string>(), std::vector<std::string>());
+        CHECK(result.size() == 2);
+      }
+
+      SECTION("Empty list and vector of strings and empty string") {
+        auto result = cs::serialize(std::list<std::string>());
+        CHECK(result.size() == 1);
+        result = cs::serialize(""s, std::list<std::string>());
+        CHECK(result.size() == 2);
+        result = cs::serialize(std::list<std::string>(), "");
+        CHECK(result.size() == 2);
+        result = cs::serialize(std::list<std::string>(), std::list<std::string>());
+        CHECK(result.size() == 2);
+        result = cs::serialize(std::vector<std::string>(), std::list<std::string>());
+        CHECK(result.size() == 2);
+        result = cs::serialize(std::list<std::string>(), std::vector<std::string>());
+        CHECK(result.size() == 2);
+      }
+
+      SECTION("Vectors of empty strings") {
+        auto result = cs::serialize(std::vector<std::string>{""});
+        CHECK(result.size() == 2);
+        result = cs::serialize(std::vector<std::string>{"", ""});
+        CHECK(result.size() == 3);
+        result = cs::serialize(std::vector<std::string>{""}, std::vector<std::string>{});
+        CHECK(result.size() == 3);
+        result = cs::serialize(std::vector<std::string>{"", ""}, std::vector<std::string>{});
+        CHECK(result.size() == 4);
+        result = cs::serialize(std::vector<std::string>{""}, std::vector<std::string>{""});
+        CHECK(result.size() == 4);
+        result = cs::serialize(std::vector<std::string>{"", ""}, std::vector<std::string>{""});
+        CHECK(result.size() == 5);
+        result = cs::serialize(std::vector<std::string>{""}, std::vector<std::string>{"", ""});
+        CHECK(result.size() == 5);
+        result = cs::serialize(std::vector<std::string>{"", ""}, std::vector<std::string>{"", ""});
+        CHECK(result.size() == 6);
+      }
+    }
+
+    SECTION("Serialization and deserialization") {
+      SECTION("Empty string") {
+        std::string res;
+        auto ret = cs::deserialize(cs::serialize(""), res);
+        CHECK(ret == 1);
+        CHECK(res.empty());
+      }
+
+      SECTION("Two empty strings") {
+        std::string res1, res2;
+        auto ret = cs::deserialize(cs::serialize("", ""), res1, res2);
+        CHECK(ret == 2);
+        CHECK(res1.empty());
+        CHECK(res2.empty());
+      }
+
+      SECTION("Empty vector") {
+        std::vector<std::string> res;
+        auto ret = cs::deserialize(cs::serialize(std::vector<std::string>()), std::back_inserter(res));
+        CHECK(ret == 1);
+        CHECK(res.empty());
+      }
+
+      SECTION("Two empty vectors") {
+        std::vector<std::string> res1, res2;
+        auto ret = cs::deserialize(cs::serialize(std::vector<std::string>(), std::vector<std::string>()),
+                                   std::back_inserter(res1),
+                                   std::back_inserter(res2));
+        CHECK(ret == 2);
+        CHECK(res1.empty());
+        CHECK(res2.empty());
+      }
+
+      SECTION("Mixture") {
+        std::string res1;
+        std::vector<std::string> res2;
+        std::list<std::string> res3;
+        auto ret = cs::deserialize(cs::serialize("", std::vector<std::string>(), std::list<std::string>()),
+                                   res1,
+                                   std::back_inserter(res2),
+                                   std::back_inserter(res3));
+        CHECK(ret == 3);
+        CHECK(res1.empty());
+        CHECK(res2.empty());
+        CHECK(res3.empty());
+
+        ret = cs::deserialize(cs::serialize(std::vector<std::string>(), "", std::list<std::string>()),
+                              std::back_inserter(res3),
+                              res1,
+                              std::back_inserter(res2));
+        CHECK(ret == 3);
+        CHECK(res1.empty());
+        CHECK(res2.empty());
+        CHECK(res3.empty());
+      }
+    }
+  }
+
+  SECTION("Inputs with values") {
+    SECTION("Strings") {
+      std::string res1, res2;
+      auto serial = cs::serialize("foo");
+      REQUIRE(serial == "foo"s + cs::detail::kContainerDelimiter);
+      auto ret = cs::deserialize(serial, res1);
+      CHECK(ret == 3 + 1);
+      CHECK(res1 == "foo");
+
+      serial = cs::serialize("foo", "bar");
+      REQUIRE(serial == "foo"s + cs::detail::kContainerDelimiter + "bar"s + cs::detail::kContainerDelimiter);
+      ret = cs::deserialize(serial, res1, res2);
+      CHECK(ret == 3 + 1 + 3 + 1);
+      CHECK(res1 == "foo");
+      CHECK(res2 == "bar");
+    }
+
+    SECTION("Vector of strings") {
+      std::vector<std::string> res;
+      auto serial = cs::serialize(std::vector<std::string>{"foo"});
+      REQUIRE(serial == "foo"s + cs::detail::kElementDelimiter + cs::detail::kContainerDelimiter);
+      auto ret = cs::deserialize(serial, std::back_inserter(res));
+      CHECK(ret == 3 + 2);
+      REQUIRE(res.size() == 1);
+      REQUIRE(res[0] == "foo");
+      res.clear();
+
+      serial = cs::serialize(std::vector<std::string>{"foo", "bar"});
+      REQUIRE(serial == "foo"s + cs::detail::kElementDelimiter + "bar"s + cs::detail::kElementDelimiter +
+                            cs::detail::kContainerDelimiter);
+      ret = cs::deserialize(serial, std::back_inserter(res));
+      CHECK(ret == 3 + 1 + 3 + 2);
+      REQUIRE(res.size() == 2);
+      CHECK(res[0] == "foo");
+      CHECK(res[1] == "bar");
+      res.clear();
+
+      serial = cs::serialize(std::vector<std::string>{"foo", "bar", "xyzzy"});
+      ret = cs::deserialize(serial, std::back_inserter(res));
+      CHECK(ret == serial.size());
+      REQUIRE(res.size() == 3);
+      CHECK(res[0] == "foo");
+      CHECK(res[1] == "bar");
+      CHECK(res[2] == "xyzzy");
+      res.clear();
+
+      SECTION("Deserialize to list") {
+        std::list<std::string> res2;
+        ret = cs::deserialize(serial, std::front_inserter(res2));
+        CHECK(ret == serial.size());
+        REQUIRE(res2.size() == 3);
+        auto it = res2.begin();
+        CHECK(*it == "xyzzy");
+        ++it;
+        CHECK(*it == "bar");
+        ++it;
+        CHECK(*it == "foo");
+      }
+    }
+
+    SECTION("Vectors of strings") {
+      std::vector<std::string> res1, res2;
+      ;
+      auto serial =
+          cs::serialize(std::vector<std::string>{"foo", "bar", "xyzzy"}, std::vector<std::string>{"fred", "wilma"});
+      auto ret = cs::deserialize(serial, std::back_inserter(res1), std::back_inserter(res2));
+      CHECK(ret == serial.size());
+      REQUIRE(res1.size() == 3);
+      CHECK(res1[0] == "foo");
+      CHECK(res1[1] == "bar");
+      CHECK(res1[2] == "xyzzy");
+      REQUIRE(res2.size() == 2);
+      CHECK(res2[0] == "fred");
+      CHECK(res2[1] == "wilma");
+    }
+
+    SECTION("Mixture") {
+      auto serial = cs::serialize(
+          "foobar", std::vector<std::string>{"fred", "wilma"}, "xyzzy", std::list<std::string>{"one", "two", "th ree"});
+      std::string res1, res3;
+      std::vector<std::string> res2, res4;
+      auto ret = cs::deserialize(serial, res1, std::back_inserter(res2), res3, std::back_inserter(res4));
+      CHECK(ret == serial.size());
+      CHECK(res1 == "foobar");
+      REQUIRE(res2.size() == 2);
+      CHECK(res2[0] == "fred");
+      CHECK(res2[1] == "wilma");
+      CHECK(res3 == "xyzzy");
+      REQUIRE(res4.size() == 3);
+      CHECK(res4[0] == "one");
+      CHECK(res4[1] == "two");
+      CHECK(res4[2] == "th ree");
+    }
+  }
+  SECTION("Deserialize only part of the serialized content") {
+    SECTION("String") {
+      std::string res;
+      auto serial = cs::serialize("foo", "bar");
+      auto ret = cs::deserialize(serial, res);
+      CHECK(ret != 0);
+      CHECK(ret != serial.size());
+      CHECK(res == "foo");
+      res.clear();
+
+      serial = cs::serialize("bar", std::vector<std::string>{"foo"});
+      ret = cs::deserialize(serial, res);
+      CHECK(ret != 0);
+      CHECK(ret != serial.size());
+      CHECK(res == "bar");
+    }
+
+    SECTION("Vector of strings") {
+      std::vector<std::string> res;
+      auto serial = cs::serialize(std::vector<std::string>{"foo", "bar"}, std::vector<std::string>{"fred", "wilma"});
+      auto ret = cs::deserialize(serial, std::back_inserter(res));
+      CHECK(ret != 0);
+      CHECK(ret != serial.size());
+      REQUIRE(res.size() == 2);
+      CHECK(res[0] == "foo");
+      CHECK(res[1] == "bar");
+      res.clear();
+
+      serial = cs::serialize(std::vector<std::string>{"wilma", "fred"}, "fintstones");
+      ret = cs::deserialize(serial, std::back_inserter(res));
+      CHECK(ret != 0);
+      CHECK(ret != serial.size());
+      REQUIRE(res.size() == 2);
+      CHECK(res[0] == "wilma");
+      CHECK(res[1] == "fred");
+    }
+  }
+
+  SECTION("Serialization error cases") {
+    CHECK_THROWS_AS(cs::serialize(""s + cs::detail::kElementDelimiter), cms::Exception);
+    CHECK_THROWS_AS(cs::serialize("foo"s + cs::detail::kElementDelimiter), cms::Exception);
+    CHECK_THROWS_AS(cs::serialize(cs::detail::kElementDelimiter + "bar"s), cms::Exception);
+    CHECK_THROWS_AS(cs::serialize("foo"s + cs::detail::kElementDelimiter + "bar"s), cms::Exception);
+    CHECK_THROWS_AS(cs::serialize(""s + cs::detail::kContainerDelimiter), cms::Exception);
+    CHECK_THROWS_AS(cs::serialize("foo"s + cs::detail::kContainerDelimiter), cms::Exception);
+    CHECK_THROWS_AS(cs::serialize(cs::detail::kContainerDelimiter + "bar"s), cms::Exception);
+    CHECK_THROWS_AS(cs::serialize("foo"s + cs::detail::kContainerDelimiter + "bar"s), cms::Exception);
+
+    std::string str = "foo"s + cs::detail::kContainerDelimiter;
+    std::vector<std::string> vstr{str};
+    CHECK_THROWS_AS(cs::serialize(str, std::vector<std::string>{"foo"}), cms::Exception);
+    CHECK_THROWS_AS(cs::serialize(std::vector<std::string>{"foo"}, str), cms::Exception);
+    CHECK_THROWS_AS(cs::serialize(vstr, "foo"), cms::Exception);
+    CHECK_THROWS_AS(cs::serialize("foo", vstr), cms::Exception);
+  }
+
+  SECTION("Deserialization error cases") {
+    SECTION("Invalid input") {
+      SECTION("Deserializing to string") {
+        std::string res;
+        CHECK(cs::deserialize("", res) == 0);
+        CHECK(cs::deserialize(" ", res) == 0);
+        CHECK(cs::deserialize("foo", res) == 0);
+        CHECK(cs::deserialize("foo"s + cs::detail::kElementDelimiter + "bar"s, res) == 0);
+        CHECK(cs::deserialize("foo"s + cs::detail::kElementDelimiter + "bar"s + cs::detail::kContainerDelimiter, res) ==
+              0);
+      }
+
+      SECTION("Deserializing to container") {
+        std::vector<std::string> res;
+        CHECK(cs::deserialize("", std::back_inserter(res)) == 0);
+        CHECK(cs::deserialize(" ", std::back_inserter(res)) == 0);
+        CHECK(cs::deserialize("foo", std::back_inserter(res)) == 0);
+        CHECK(cs::deserialize("foo"s + cs::detail::kElementDelimiter + "bar"s, std::back_inserter(res)) == 0);
+        CHECK(cs::deserialize("foo"s + cs::detail::kContainerDelimiter, std::back_inserter(res)) == 0);
+      }
+    }
+
+    SECTION("Schema mismatch") {
+      // Note: empty container and empty string have the same
+      // presentation, but this behavior is not tested here as one
+      // should not rely on it
+
+      SECTION("Deserializing container as string") {
+        std::string res;
+        auto ret = cs::deserialize(cs::serialize(std::vector<std::string>{""}), res);
+        CHECK(ret == 0);
+        ret = cs::deserialize(cs::serialize(std::vector<std::string>{"foo"}), res);
+        CHECK(ret == 0);
+        ret = cs::deserialize(cs::serialize(std::vector<std::string>{"foo", "bar"}), res);
+        CHECK(ret == 0);
+      }
+
+      SECTION("Deserializing string as container") {
+        std::vector<std::string> res;
+        auto ret = cs::deserialize(cs::serialize("foo"), std::back_inserter(res));
+        CHECK(ret == 0);
+        ret = cs::deserialize(cs::serialize("foo", "bar"), std::back_inserter(res));
+        CHECK(ret == 0);
+      }
+    }
+
+    SECTION("Deserializing too much") {
+      SECTION("Strings") {
+        std::string res1, res2;
+        auto ret = cs::deserialize(cs::serialize("foo"), res1, res2);
+        CHECK(ret == 0);
+        CHECK(res2.empty());
+      }
+
+      SECTION("Vector of strings") {
+        std::vector<std::string> res1, res2;
+        auto ret = cs::deserialize(
+            cs::serialize(std::vector<std::string>{"foo", "bar"}), std::back_inserter(res1), std::back_inserter(res2));
+        CHECK(ret == 0);
+        CHECK(res2.empty());
+      }
+
+      SECTION("Mixture") {
+        std::string ress;
+        std::vector<std::string> resv;
+        auto ret = cs::deserialize(cs::serialize("foo"), ress, std::back_inserter(resv));
+        CHECK(ret == 0);
+        CHECK(resv.empty());
+        ress.clear();
+
+        ret = cs::deserialize(cs::serialize(std::vector<std::string>{"foo"}), std::back_inserter(resv), ress);
+        CHECK(ret == 0);
+        CHECK(ress.empty());
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### PR description:

This PR adds a `HardwareResourcesDescription` class to hold the "hardware provenance" information (and thus is part of https://github.com/cms-sw/cmssw/issues/30044). Given the plan to add the information to `ProcessConfiguration` by replacing the so-far-pratically-unused https://github.com/cms-sw/cmssw/blob/75451d59a7acc30aec874be9a6b9a8835f2f7b3e/DataFormats/Provenance/interface/ProcessConfiguration.h#L58
with this information, and to avoid any backwards or forwards compatibility issues, the `HardwareResourcesDescription` will be serialized to a string. For that purpose this PR adds a "compact string serializer" that serializes a list of `std::string`s and containers of `std::string`s into one string. A compact representation is achieved by using non-printable ASCII characters as the delimiters.

A following PR will replace the `PassID` with the `HardwareResourcesDescription` in the `ProcessConfiguration` interface.

Resolves https://github.com/cms-sw/framework-team/issues/1172

#### PR validation:

Added unit tests work.