### PR TITLE
MTD Validation: removed duplicated statement in BtlLocalRecoValidation

### DIFF
--- a/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
@@ -884,9 +884,6 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
         continue;
       }
 
-      hit_amplitude /= nHits;
-      hit_time /= nHits;
-
       if (hit_amplitude < hitMinAmplitude_)
         continue;
 


### PR DESCRIPTION
#### PR description:

Minor fix of the BtlLocalRecoValidation class, removed duplicated statement in the UncRecoHit section normally not run

#### PR validation:

Code compiles and runs with the fixed part activated 
