### PR TITLE
Fix edmDumpClassVersion call for CondFormats/L1TObjects

### DIFF
--- a/CondFormats/L1TObjects/interface/L1TMuonBarrelParams.h
+++ b/CondFormats/L1TObjects/interface/L1TMuonBarrelParams.h
@@ -7,12 +7,13 @@
 /// \author: Giannis Flouris
 ///
 
-#ifndef L1TBMTFParams_h
-#define L1TBMTFParams_h
+#ifndef CondFormats_L1TObjects_L1TMuonBarrelParams_h
+#define CondFormats_L1TObjects_L1TMuonBarrelParams_h
 
 #include <memory>
 #include <iostream>
 #include <vector>
+#include <map>
 
 #include "CondFormats/Serialization/interface/Serializable.h"
 #include "CondFormats/L1TObjects/interface/LUT.h"

--- a/CondFormats/L1TObjects/interface/L1TriggerKey.h
+++ b/CondFormats/L1TObjects/interface/L1TriggerKey.h
@@ -40,12 +40,12 @@ public:
 
   /* Adds new record and type mapping to payload. If such exists, nothing happens */
   void add(const std::string& record, const std::string& type, const std::string& key) {
-    m_recordToKey.insert(std::make_pair(record + "@" + type, key.empty() ? kNullKey : key));
+    m_recordToKey.emplace(record + "@" + type, key.empty() ? kNullKey : key);
   }
 
   void add(const RecordToKey& map) {
     for (RecordToKey::const_iterator itr = map.begin(); itr != map.end(); ++itr) {
-      m_recordToKey.insert(std::make_pair(itr->first, itr->second.empty() ? kNullKey : itr->second));
+      m_recordToKey.emplace(itr->first, itr->second.empty() ? kNullKey : itr->second);
     }
   }
 

--- a/CondFormats/L1TObjects/interface/L1TriggerKeyExt.h
+++ b/CondFormats/L1TObjects/interface/L1TriggerKeyExt.h
@@ -40,12 +40,12 @@ public:
 
   /* Adds new record and type mapping to payload. If such exists, nothing happens */
   void add(const std::string& record, const std::string& type, const std::string& key) {
-    m_recordToKey.insert(std::make_pair(record + "@" + type, key.empty() ? kNullKey : key));
+    m_recordToKey.emplace(record + "@" + type, key.empty() ? kNullKey : key);
   }
 
   void add(const RecordToKey& map) {
     for (RecordToKey::const_iterator itr = map.begin(); itr != map.end(); ++itr) {
-      m_recordToKey.insert(std::make_pair(itr->first, itr->second.empty() ? kNullKey : itr->second));
+      m_recordToKey.emplace(itr->first, itr->second.empty() ? kNullKey : itr->second);
     }
   }
 


### PR DESCRIPTION
#### PR description:

The IB run of edmDumpClassVersion was failing for CondFormat/L1TObjects. These small changes fixed the problem.

#### PR validation:

Code compiles. Running edmDumpClassVersion explicitly succeeds without issuing any Error messages.

resolves #47177