### PR TITLE
[SIM/MTD] Fixed ECAL GFlash for Phase2

### DIFF
--- a/SimG4CMS/Forward/src/MtdSD.cc
+++ b/SimG4CMS/Forward/src/MtdSD.cc
@@ -131,6 +131,9 @@ int MtdSD::getTrackID(const G4Track* aTrack) {
       edm::LogVerbatim("MtdSim") << "MtdSD: Track ID: " << aTrack->GetTrackID()
                                  << " ETL Track ID: " << trkInfo->mcTruthID() << ":" << theID;
 #endif
+      // In the case of ECAL GFlash fast spot may be inside MTD and should be ignored
+    } else if (rname == "EcalRegion") {
+      theID = -2;
     } else {
       throw cms::Exception("MtdSDError") << "MtdSD called in incorrect region " << rname;
     }

--- a/SimG4CMS/Forward/src/TimingSD.cc
+++ b/SimG4CMS/Forward/src/TimingSD.cc
@@ -104,7 +104,7 @@ bool TimingSD::ProcessHits(G4Step* aStep, G4TouchableHistory*) {
   edeposit = aStep->GetTotalEnergyDeposit();
   if (edeposit > 0.f) {
     getStepInfo(aStep);
-    // (primaryID = -2) means ECAL GFlash spot inside MTD  
+    // (primaryID = -2) means ECAL GFlash spot inside MTD
     if (-1 <= primaryID && !hitExists(aStep)) {
       createNewHit(aStep);
     }
@@ -117,8 +117,10 @@ void TimingSD::getStepInfo(const G4Step* aStep) {
   // exclude ECAL gflash spots inside MTD detectors,
   // which not possible correctly handle
   primaryID = getTrackID(newTrack);
-  if (primaryID < -1) { return; }
-  
+  if (primaryID < -1) {
+    return;
+  }
+
   preStepPoint = aStep->GetPreStepPoint();
   postStepPoint = aStep->GetPostStepPoint();
   hitPointExit = postStepPoint->GetPosition();

--- a/SimG4CMS/Forward/src/TimingSD.cc
+++ b/SimG4CMS/Forward/src/TimingSD.cc
@@ -104,7 +104,8 @@ bool TimingSD::ProcessHits(G4Step* aStep, G4TouchableHistory*) {
   edeposit = aStep->GetTotalEnergyDeposit();
   if (edeposit > 0.f) {
     getStepInfo(aStep);
-    if (!hitExists(aStep)) {
+    // (primaryID = -2) means ECAL GFlash spot inside MTD  
+    if (-1 <= primaryID && !hitExists(aStep)) {
       createNewHit(aStep);
     }
   }
@@ -112,11 +113,16 @@ bool TimingSD::ProcessHits(G4Step* aStep, G4TouchableHistory*) {
 }
 
 void TimingSD::getStepInfo(const G4Step* aStep) {
+  const G4Track* newTrack = aStep->GetTrack();
+  // exclude ECAL gflash spots inside MTD detectors,
+  // which not possible correctly handle
+  primaryID = getTrackID(newTrack);
+  if (primaryID < -1) { return; }
+  
   preStepPoint = aStep->GetPreStepPoint();
   postStepPoint = aStep->GetPostStepPoint();
   hitPointExit = postStepPoint->GetPosition();
   setToLocal(preStepPoint, hitPointExit, hitPointLocalExit);
-  const G4Track* newTrack = aStep->GetTrack();
 
   // neutral particles deliver energy post step
   // charged particle start deliver energy pre step
@@ -185,7 +191,6 @@ void TimingSD::getStepInfo(const G4Step* aStep) {
 
   setHitClassID(aStep);
   unitID = setDetUnitId(aStep);
-  primaryID = getTrackID(theTrack);
 }
 
 bool TimingSD::hitExists(const G4Step* aStep) {

--- a/SimG4Core/Application/src/LowEnergyFastSimModel.cc
+++ b/SimG4Core/Application/src/LowEnergyFastSimModel.cc
@@ -100,14 +100,14 @@ void LowEnergyFastSimModel::DoIt(const G4FastTrack& fastTrack, G4FastStep& fastS
 
   // in point energy deposition
   GFlashEnergySpot spot;
-  spot.SetEnergy(inPointEnergy*wt2);
+  spot.SetEnergy(inPointEnergy * wt2);
   spot.SetPosition(pos);
   fHitMaker.make(&spot, &fastTrack);
 
   G4double zz = 0.0;
   if (0 < nspots) {
     etail *= wt2 / (G4double)nspots;
-  /*  
+    /*  
   edm::LogVerbatim("LowEnergyFastSimModel") << track->GetDefinition()->GetParticleName()
 					    << " Ekin(MeV)=" << energy << " material: <"
                                             << track->GetMaterial()->GetName() 


### PR DESCRIPTION
#### PR description:
In the case of Phase2, there is a problem when fast energy spot appears outside ecal inside MTD sensitive detector. the probability of this is not high but previously this situation provided crash at SIM step. In this PR a protection is added.

this fix should not affect any production and any default WF.

#### PR validation:
private

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for: NO backport

