### PR TITLE
throw in presence of mismatched `SimBeamSpot` types in `BetafuncEvtVtxGenerator` and `GaussEvtVtxGenerator`

### DIFF
--- a/CondFormats/BeamSpotObjects/interface/SimBeamSpotObjects.h
+++ b/CondFormats/BeamSpotObjects/interface/SimBeamSpotObjects.h
@@ -87,16 +87,23 @@ public:
   double alpha() const { return fAlpha; }
   double timeOffset() const { return fTimeOffset; }
 
+  /// Method to check if the object corresponds to GaussEvtVtxGenerator parameters
+  bool isGaussian() const {
+    // Check for the presence of GaussEvtVtxGenerator-specific parameters
+    return ((fMeanX != 0.0 || fMeanY != 0.0 || fMeanZ != 0.0) ||  // either centroid is not 0,0,0
+            (fSigmaX != -1.0 && fSigmaY != -1.0));                // or the withs are not defaults
+  }
+
   /// print sim beam spot parameters
   void print(std::stringstream& ss) const;
 
 private:
-  double fX0, fY0, fZ0;
-  double fMeanX, fMeanY, fMeanZ;
-  double fSigmaX, fSigmaY, fSigmaZ;
-  double fbetastar, femittance;
-  double fPhi, fAlpha;
-  double fTimeOffset;
+  double fX0, fY0, fZ0;              // for beta-function
+  double fMeanX, fMeanY, fMeanZ;     // for gaussian
+  double fSigmaX, fSigmaY, fSigmaZ;  // for gaussian
+  double fbetastar, femittance;      // for beta-function
+  double fPhi, fAlpha;               // for beta-function
+  double fTimeOffset;                // for both
 
   COND_SERIALIZABLE;
 };

--- a/IOMC/EventVertexGenerators/src/BetafuncEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/BetafuncEvtVtxGenerator.cc
@@ -60,14 +60,21 @@ void BetafuncEvtVtxGenerator::beginLuminosityBlock(edm::LuminosityBlock const&, 
 void BetafuncEvtVtxGenerator::update(const edm::EventSetup& iEventSetup) {
   if (readDB_ && parameterWatcher_.check(iEventSetup)) {
     edm::ESHandle<SimBeamSpotObjects> beamhandle = iEventSetup.getHandle(beamToken_);
-    fX0 = beamhandle->x() * cm;
-    fY0 = beamhandle->y() * cm;
-    fZ0 = beamhandle->z() * cm;
-    fSigmaZ = beamhandle->sigmaZ() * cm;
-    fTimeOffset = beamhandle->timeOffset() * ns * c_light;  // HepMC distance units are in mm
-    fbetastar = beamhandle->betaStar() * cm;
-    femittance = beamhandle->emittance() * cm;
-    setBoost(beamhandle->alpha() * radian, beamhandle->phi() * radian);
+    if (!beamhandle->isGaussian()) {
+      fX0 = beamhandle->x() * cm;
+      fY0 = beamhandle->y() * cm;
+      fZ0 = beamhandle->z() * cm;
+      fSigmaZ = beamhandle->sigmaZ() * cm;
+      fTimeOffset = beamhandle->timeOffset() * ns * c_light;  // HepMC distance units are in mm
+      fbetastar = beamhandle->betaStar() * cm;
+      femittance = beamhandle->emittance() * cm;
+      setBoost(beamhandle->alpha() * radian, beamhandle->phi() * radian);
+    } else {
+      throw cms::Exception("Configuration")
+          << "Error in BetafuncEvtVtxGenerator::update: The provided SimBeamSpotObjects is Gaussian.\n"
+          << "Please check the configuration and ensure that the beam spot parameters are appropriate for a Betafunc "
+             "distribution.";
+    }
   }
 }
 

--- a/IOMC/EventVertexGenerators/src/GaussEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/GaussEvtVtxGenerator.cc
@@ -47,13 +47,20 @@ void GaussEvtVtxGenerator::beginLuminosityBlock(edm::LuminosityBlock const&, edm
 void GaussEvtVtxGenerator::update(const edm::EventSetup& iEventSetup) {
   if (readDB_ && parameterWatcher_.check(iEventSetup)) {
     edm::ESHandle<SimBeamSpotObjects> beamhandle = iEventSetup.getHandle(beamToken_);
-    fMeanX = beamhandle->meanX() * cm;
-    fMeanY = beamhandle->meanY() * cm;
-    fMeanZ = beamhandle->meanZ() * cm;
-    fSigmaX = beamhandle->sigmaX() * cm;
-    fSigmaY = beamhandle->sigmaY() * cm;
-    fSigmaZ = beamhandle->sigmaZ() * cm;
-    fTimeOffset = beamhandle->timeOffset() * ns * c_light;  // HepMC distance units are in mm
+    if (beamhandle->isGaussian()) {
+      fMeanX = beamhandle->meanX() * cm;
+      fMeanY = beamhandle->meanY() * cm;
+      fMeanZ = beamhandle->meanZ() * cm;
+      fSigmaX = beamhandle->sigmaX() * cm;
+      fSigmaY = beamhandle->sigmaY() * cm;
+      fSigmaZ = beamhandle->sigmaZ() * cm;
+      fTimeOffset = beamhandle->timeOffset() * ns * c_light;  // HepMC distance units are in mm
+    } else {
+      throw cms::Exception("Configuration")
+          << "Error in GaussEvtVtxGenerator::update: The provided SimBeamSpotObjects is not Gaussian.\n"
+          << "Please check the configuration and ensure that the beam spot parameters are appropriate for a Gaussian "
+             "distribution.";
+    }
   }
 }
 


### PR DESCRIPTION
#### PR description:

Title says it all. Should make the usage of "mismatched" conditions / beam spot options throw a clearer exception when these are used at cmsDriver level, as it happened at https://gitlab.cern.ch/cms-ppd/cms-ppd-matters/-/issues/52#note_8968304 
Technical, no regressions are expected.

#### PR validation:

Trying to run the "wrong" `cmsDriver` command:

```
cmsDriver.py MinBias_14TeV_pythia8_TuneCP5_cfi --beamspot DBrealistic --conditions 142X_mcRun3_2025_realistic_FlatBeamConfigTest_v1 --datatier GEN-SIM --era Run3_2025 --eventcontent FEVTDEBUG --fileout "file:step1.root" --geometry DB:Extended --nStreams 2 --nThreads 2 --number 10000 --python_filename step_1_cfg.py --relval 1000000,1000 --step GEN,SIM 
```
I get now the following (clearer) error:

```
----- Begin Fatal Exception 25-Jan-2025 11:52:02 CET-----------------------
An exception of category 'Configuration' occurred while
   [0] Processing  stream begin LuminosityBlock run: 1 luminosityBlock: 1 stream: 1
   [1] Calling method for module BetafuncEvtVtxGenerator/'VtxSmeared'
Exception Message:
Error in BetafuncEvtVtxGenerator::update: The provided SimBeamSpotObjects is Gaussian.
Please check the configuration and ensure that the beam spot parameters are appropriate for a Betafunc distribution.
----- End Fatal Exception -------------------------------------------------
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A