### PR TITLE
Rename BranchDescription to ProductDescription

### DIFF
--- a/CalibTracker/SiStripCommon/plugins/ShallowTree.cc
+++ b/CalibTracker/SiStripCommon/plugins/ShallowTree.cc
@@ -44,7 +44,7 @@ ShallowTree::ShallowTree(const edm::ParameterSet& iConfig) {
 
   std::set<std::string> branchnames;
   callWhenNewProductsRegistered(
-      [productSelectorRules, branchnames, leafmap, this](edm::BranchDescription const& selection) mutable {
+      [productSelectorRules, branchnames, leafmap, this](edm::ProductDescription const& selection) mutable {
         if (productSelectorRules.select(selection)) {
           //Check for duplicate branch names
           if (branchnames.find(selection.productInstanceName()) != branchnames.end()) {
@@ -183,7 +183,7 @@ void ShallowTree::TypedBranchConnector<T>::connect(const edm::Event& iEvent) {
 }
 
 template <class T>
-ShallowTree::TypedBranchConnector<T>::TypedBranchConnector(edm::BranchDescription const* desc,
+ShallowTree::TypedBranchConnector<T>::TypedBranchConnector(edm::ProductDescription const* desc,
                                                            std::string t,
                                                            TTree* tree)
     : ml_(desc->moduleLabel()), pin_(desc->productInstanceName()) {

--- a/CalibTracker/SiStripCommon/plugins/ShallowTree.h
+++ b/CalibTracker/SiStripCommon/plugins/ShallowTree.h
@@ -36,7 +36,7 @@ private:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
   template <class T>
-  void eat(edm::BranchDescription const& desc) {
+  void eat(edm::ProductDescription const& desc) {
     consumes<T>(edm::InputTag(desc.moduleLabel(), desc.productInstanceName()));
   }
 
@@ -55,7 +55,7 @@ private:
     T* object_ptr_;
 
   public:
-    TypedBranchConnector(edm::BranchDescription const*, std::string, TTree*);
+    TypedBranchConnector(edm::ProductDescription const*, std::string, TTree*);
     void connect(const edm::Event&) override;
   };
 

--- a/DQMServices/Components/plugins/DQMFileSaver.cc
+++ b/DQMServices/Components/plugins/DQMFileSaver.cc
@@ -156,7 +156,7 @@ DQMFileSaver::DQMFileSaver(const edm::ParameterSet &ps)
       // Abuse ProcessMatch as a "match all".
       jobmegetter_(edm::GetterOfProducts<DQMToken>(edm::ProcessMatch("*"), this, edm::InProcess)),
       runmegetter_(edm::GetterOfProducts<DQMToken>(edm::ProcessMatch("*"), this, edm::InRun)) {
-  callWhenNewProductsRegistered([this](edm::BranchDescription const &bd) {
+  callWhenNewProductsRegistered([this](edm::ProductDescription const &bd) {
     this->jobmegetter_(bd);
     this->runmegetter_(bd);
   });

--- a/DQMServices/Components/plugins/MEtoEDMConverter.cc
+++ b/DQMServices/Components/plugins/MEtoEDMConverter.cc
@@ -164,7 +164,7 @@ MEtoEDMConverter::MEtoEDMConverter(const edm::ParameterSet& iPSet) : fName(""), 
 
   lumigetter_ = edm::GetterOfProducts<DQMToken>(edm::ProcessMatch("*"), this, edm::InLumi);
   rungetter_ = edm::GetterOfProducts<DQMToken>(edm::ProcessMatch("*"), this, edm::InRun);
-  callWhenNewProductsRegistered([this](edm::BranchDescription const& bd) {
+  callWhenNewProductsRegistered([this](edm::ProductDescription const& bd) {
     this->lumigetter_(bd);
     this->rungetter_(bd);
   });

--- a/DQMServices/Core/interface/DQMEDHarvester.h
+++ b/DQMServices/Core/interface/DQMEDHarvester.h
@@ -26,9 +26,9 @@ namespace edm {
       }
     }
 
-    bool operator()(edm::BranchDescription const &branchDescription) {
+    bool operator()(edm::ProductDescription const &productDescription) {
       for (auto &m : matchers_) {
-        if (m(branchDescription)) {
+        if (m(productDescription)) {
           return true;
         }
       }
@@ -88,7 +88,7 @@ public:
     jobmegetter_ = edm::GetterOfProducts<DQMToken>(edm::VInputTagMatch(inputtags), this, edm::InProcess);
     runmegetter_ = edm::GetterOfProducts<DQMToken>(edm::VInputTagMatch(inputtags), this, edm::InRun);
     lumimegetter_ = edm::GetterOfProducts<DQMToken>(edm::VInputTagMatch(inputtags), this, edm::InLumi);
-    callWhenNewProductsRegistered([this](edm::BranchDescription const &bd) {
+    callWhenNewProductsRegistered([this](edm::ProductDescription const &bd) {
       jobmegetter_(bd);
       runmegetter_(bd);
       lumimegetter_(bd);

--- a/DQMServices/FileIO/plugins/DQMFileSaverBase.cc
+++ b/DQMServices/FileIO/plugins/DQMFileSaverBase.cc
@@ -47,7 +47,7 @@ DQMFileSaverBase::DQMFileSaverBase(const edm::ParameterSet &ps) {
   // This makes sure a file saver runs in a very end
   lumigetter_ = edm::GetterOfProducts<DQMToken>(edm::ProcessMatch("*"), this, edm::InLumi);
   rungetter_ = edm::GetterOfProducts<DQMToken>(edm::ProcessMatch("*"), this, edm::InRun);
-  callWhenNewProductsRegistered([this](edm::BranchDescription const &bd) {
+  callWhenNewProductsRegistered([this](edm::ProductDescription const &bd) {
     this->lumigetter_(bd);
     this->rungetter_(bd);
   });

--- a/DQMServices/FwkIO/plugins/DQMRootOutputModule.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootOutputModule.cc
@@ -309,7 +309,7 @@ DQMRootOutputModule::DQMRootOutputModule(edm::ParameterSet const& pset)
   // DQM module labels.
   // This is needed to support unscheduled DQM modules now that
   // non-consumed EDProducers are deleted from the job at beginJob.
-  callWhenNewProductsRegistered([this](edm::BranchDescription const& bd) {
+  callWhenNewProductsRegistered([this](edm::ProductDescription const& bd) {
     m_getterOfProductsLumi(bd);
     m_getterOfProductsRun(bd);
   });

--- a/DataFormats/Common/doc/Common_edm.doc
+++ b/DataFormats/Common/doc/Common_edm.doc
@@ -11,7 +11,7 @@
 Commonly used EDM classes.
 
 \subsection interface Public interface
-- edm::BranchDescription:
+- edm::ProductDescription:
 - edm::BranchEntryDescription
 - edm::BranchKey:
 - edm::ConditionsID:

--- a/DataFormats/Common/interface/ProductData.h
+++ b/DataFormats/Common/interface/ProductData.h
@@ -9,11 +9,11 @@ is the storage unit of such information.
 ----------------------------------------------------------------------*/
 
 #include "DataFormats/Provenance/interface/Provenance.h"
+#include "DataFormats/Provenance/interface/ProductDescriptionFwd.h"
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
 #include <memory>
 
 namespace edm {
-  class ProductDescription;
   class MergeableRunProductMetadataBase;
   class WrapperBase;
 

--- a/DataFormats/Common/interface/ProductData.h
+++ b/DataFormats/Common/interface/ProductData.h
@@ -13,7 +13,7 @@ is the storage unit of such information.
 #include <memory>
 
 namespace edm {
-  class BranchDescription;
+  class ProductDescription;
   class MergeableRunProductMetadataBase;
   class WrapperBase;
 
@@ -21,13 +21,13 @@ namespace edm {
   public:
     ProductData();
 
-    explicit ProductData(std::shared_ptr<BranchDescription const> bd);
+    explicit ProductData(std::shared_ptr<ProductDescription const> bd);
 
     // For use by FWLite
     ProductData(WrapperBase* product, Provenance const& prov);
 
-    std::shared_ptr<BranchDescription const> const& branchDescription() const {
-      return prov_.constBranchDescriptionPtr();
+    std::shared_ptr<ProductDescription const> const& productDescription() const {
+      return prov_.constProductDescriptionPtr();
     }
 
     Provenance const& provenance() const { return prov_; }
@@ -47,7 +47,7 @@ namespace edm {
     void unsafe_setWrapper(std::unique_ptr<WrapperBase> iValue) const;
     void unsafe_setWrapper(std::shared_ptr<WrapperBase const> iValue) const;  // for SwitchProducer
 
-    void resetBranchDescription(std::shared_ptr<BranchDescription const> bd);
+    void resetProductDescription(std::shared_ptr<ProductDescription const> bd);
 
     void resetProductData() { wrapper_.reset(); }
 

--- a/DataFormats/Common/interface/setIsMergeable.h
+++ b/DataFormats/Common/interface/setIsMergeable.h
@@ -29,11 +29,9 @@
 // Original Author:  W. David Dagenhart
 //         Created:  21 June 2018
 //
+#include "DataFormats/Provenance/interface/ProductDescriptionFwd.h"
 
 namespace edm {
-
-  class ProductDescription;
-
   void setIsMergeable(ProductDescription&);
 }  // namespace edm
 

--- a/DataFormats/Common/interface/setIsMergeable.h
+++ b/DataFormats/Common/interface/setIsMergeable.h
@@ -6,19 +6,19 @@
 // Class  :     setIsMergeable
 //
 /*
- Description: Should be called only after the BranchDescription::init
+ Description: Should be called only after the ProductDescription::init
               function has been called either directly or through
-              the BranchDescription constructor.
+              the ProductDescription constructor.
 
               Helper function used to set the isMergeable data member
-              in BranchDescription. It would be much more convenient
-              to have been able to put this inside the BranchDescription
+              in ProductDescription. It would be much more convenient
+              to have been able to put this inside the ProductDescription
               class itself in the init function, but the WrapperBase
               class in package DataFormats/Common is needed to implement
               this and that cannot be used in package DataFormats/Provenance
               because it would create a circular dependency.
 
-              Anything creating a BranchDescription or reading one from
+              Anything creating a ProductDescription or reading one from
               a ROOT file will need to call this directly if they need
               the isMergeable data member to be set properly. Note that
               the isMergeable data member will default to false so if
@@ -32,9 +32,9 @@
 
 namespace edm {
 
-  class BranchDescription;
+  class ProductDescription;
 
-  void setIsMergeable(BranchDescription&);
+  void setIsMergeable(ProductDescription&);
 }  // namespace edm
 
 #endif

--- a/DataFormats/Common/src/ProductData.cc
+++ b/DataFormats/Common/src/ProductData.cc
@@ -11,14 +11,14 @@
 namespace edm {
   ProductData::ProductData() : wrapper_(), prov_() {}
 
-  ProductData::ProductData(std::shared_ptr<BranchDescription const> bd) : wrapper_(), prov_(bd, ProductID()) {}
+  ProductData::ProductData(std::shared_ptr<ProductDescription const> bd) : wrapper_(), prov_(bd, ProductID()) {}
 
   // For use by FWLite
   ProductData::ProductData(WrapperBase* product, Provenance const& prov)
       : wrapper_(product, do_nothing_deleter()), prov_(prov) {}
 
-  void ProductData::resetBranchDescription(std::shared_ptr<BranchDescription const> bd) {
-    prov_.setBranchDescription(bd);
+  void ProductData::resetProductDescription(std::shared_ptr<ProductDescription const> bd) {
+    prov_.setProductDescription(bd);
   }
 
   void ProductData::setWrapper(std::unique_ptr<WrapperBase> iValue) { wrapper_ = std::move(iValue); }

--- a/DataFormats/Common/src/setIsMergeable.cc
+++ b/DataFormats/Common/src/setIsMergeable.cc
@@ -2,7 +2,7 @@
 #include "DataFormats/Common/interface/setIsMergeable.h"
 
 #include "DataFormats/Common/interface/WrapperBase.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "FWCore/Utilities/interface/BranchType.h"
 #include "FWCore/Utilities/interface/getAnyPtr.h"
 
@@ -12,7 +12,7 @@
 
 namespace edm {
 
-  void setIsMergeable(BranchDescription& desc) {
+  void setIsMergeable(ProductDescription& desc) {
     // Save some time here with the knowledge that the isMergeable
     // data member can only be true for run or lumi products.
     // It defaults to false. Also if it is true that means it

--- a/DataFormats/FWLite/interface/ChainEvent.h
+++ b/DataFormats/FWLite/interface/ChainEvent.h
@@ -26,6 +26,7 @@
 // user include files
 #include "DataFormats/FWLite/interface/Event.h"
 #include "DataFormats/FWLite/interface/EventBase.h"
+#include "DataFormats/Provenance/interface/ProductDescriptionFwd.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
 
 // forward declarations
@@ -33,7 +34,6 @@ namespace edm {
   class WrapperBase;
   class ProductRegistry;
   class ProcessHistory;
-  class ProductDescription;
   class EDProductGetter;
   class EventAux;
   class TriggerResults;

--- a/DataFormats/FWLite/interface/ChainEvent.h
+++ b/DataFormats/FWLite/interface/ChainEvent.h
@@ -33,7 +33,7 @@ namespace edm {
   class WrapperBase;
   class ProductRegistry;
   class ProcessHistory;
-  class BranchDescription;
+  class ProductDescription;
   class EDProductGetter;
   class EventAux;
   class TriggerResults;
@@ -82,7 +82,7 @@ namespace fwlite {
 
     edm::EventAuxiliary const& eventAuxiliary() const override;
 
-    std::vector<edm::BranchDescription> const& getBranchDescriptions() const;
+    std::vector<edm::ProductDescription> const& getProductDescriptions() const;
     std::vector<std::string> const& getProcessHistory() const;
     edm::ProcessHistory const& processHistory() const override;
     TFile* getTFile() const { return event_->getTFile(); }

--- a/DataFormats/FWLite/interface/DataGetterHelper.h
+++ b/DataFormats/FWLite/interface/DataGetterHelper.h
@@ -20,6 +20,7 @@
 
 // user include files
 #include "DataFormats/Common/interface/EDProductGetter.h"
+#include "DataFormats/Provenance/interface/ProductDescriptionFwd.h"
 #include "DataFormats/FWLite/interface/HistoryGetterBase.h"
 #include "DataFormats/FWLite/interface/InternalDataKey.h"
 #include "FWCore/FWLite/interface/BranchMapReader.h"
@@ -41,7 +42,6 @@ class TTreeCache;
 class TTree;
 
 namespace edm {
-  class ProductDescription;
   class BranchID;
   class ObjectWithDict;
   class ProductID;

--- a/DataFormats/FWLite/interface/DataGetterHelper.h
+++ b/DataFormats/FWLite/interface/DataGetterHelper.h
@@ -41,7 +41,7 @@ class TTreeCache;
 class TTree;
 
 namespace edm {
-  class BranchDescription;
+  class ProductDescription;
   class BranchID;
   class ObjectWithDict;
   class ProductID;
@@ -99,7 +99,7 @@ namespace fwlite {
 
     internal::Data& getBranchDataFor(std::type_info const&, char const*, char const*, char const*) const;
     void getBranchData(edm::EDProductGetter const*, Long64_t, internal::Data&) const;
-    bool getByBranchDescription(edm::BranchDescription const&, Long_t eventEntry, KeyToDataMap::iterator&) const;
+    bool getByProductDescription(edm::ProductDescription const&, Long_t eventEntry, KeyToDataMap::iterator&) const;
     edm::WrapperBase const* wrapperBasePtr(edm::ObjectWithDict const&) const;
     edm::ThinnedAssociation const* getThinnedAssociation(edm::BranchID const& branchID, Long_t eventEntry) const;
 

--- a/DataFormats/FWLite/interface/Event.h
+++ b/DataFormats/FWLite/interface/Event.h
@@ -69,7 +69,7 @@
 namespace edm {
   class WrapperBase;
   class ProductRegistry;
-  class BranchDescription;
+  class ProductDescription;
   class EDProductGetter;
   class EventAux;
   class Timestamp;
@@ -173,8 +173,8 @@ namespace fwlite {
 
     edm::EventAuxiliary const& eventAuxiliary() const override;
 
-    std::vector<edm::BranchDescription> const& getBranchDescriptions() const {
-      return branchMap_.getBranchDescriptions();
+    std::vector<edm::ProductDescription> const& getProductDescriptions() const {
+      return branchMap_.getProductDescriptions();
     }
     std::vector<std::string> const& getProcessHistory() const;
     TFile* getTFile() const { return branchMap_.getFile(); }

--- a/DataFormats/FWLite/interface/Event.h
+++ b/DataFormats/FWLite/interface/Event.h
@@ -63,13 +63,13 @@
 #include "DataFormats/Provenance/interface/EventProcessHistoryID.h"
 #include "DataFormats/Provenance/interface/EventAuxiliary.h"
 #include "DataFormats/Provenance/interface/EventID.h"
+#include "DataFormats/Provenance/interface/ProductDescriptionFwd.h"
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 // forward declarations
 namespace edm {
   class WrapperBase;
   class ProductRegistry;
-  class ProductDescription;
   class EDProductGetter;
   class EventAux;
   class Timestamp;

--- a/DataFormats/FWLite/interface/LuminosityBlock.h
+++ b/DataFormats/FWLite/interface/LuminosityBlock.h
@@ -39,7 +39,7 @@
 namespace edm {
   class WrapperBase;
   class ProductRegistry;
-  class BranchDescription;
+  class ProductDescription;
   class EDProductGetter;
   class LuminosityBlockAux;
   class Timestamp;
@@ -89,8 +89,8 @@ namespace fwlite {
 
     edm::LuminosityBlockAuxiliary const& luminosityBlockAuxiliary() const override;
 
-    std::vector<edm::BranchDescription> const& getBranchDescriptions() const {
-      return branchMap_->getBranchDescriptions();
+    std::vector<edm::ProductDescription> const& getProductDescriptions() const {
+      return branchMap_->getProductDescriptions();
     }
 
     //       void setGetter(//Copy from Event if needed

--- a/DataFormats/FWLite/interface/LuminosityBlock.h
+++ b/DataFormats/FWLite/interface/LuminosityBlock.h
@@ -33,13 +33,13 @@
 #include "DataFormats/FWLite/interface/EntryFinder.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
 #include "DataFormats/Provenance/interface/LuminosityBlockAuxiliary.h"
+#include "DataFormats/Provenance/interface/ProductDescriptionFwd.h"
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 // forward declarations
 namespace edm {
   class WrapperBase;
   class ProductRegistry;
-  class ProductDescription;
   class EDProductGetter;
   class LuminosityBlockAux;
   class Timestamp;

--- a/DataFormats/FWLite/interface/MultiChainEvent.h
+++ b/DataFormats/FWLite/interface/MultiChainEvent.h
@@ -26,6 +26,7 @@
 // user include files
 #include "DataFormats/FWLite/interface/EventBase.h"
 #include "DataFormats/FWLite/interface/ChainEvent.h"
+#include "DataFormats/Provenance/interface/ProductDescriptionFwd.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
 
 // forward declarations
@@ -33,7 +34,6 @@ namespace edm {
   class WrapperBase;
   class ProductRegistry;
   class ProcessHistory;
-  class ProductDescription;
   class EDProductGetter;
   class EventAux;
   class TriggerResults;

--- a/DataFormats/FWLite/interface/MultiChainEvent.h
+++ b/DataFormats/FWLite/interface/MultiChainEvent.h
@@ -33,7 +33,7 @@ namespace edm {
   class WrapperBase;
   class ProductRegistry;
   class ProcessHistory;
-  class BranchDescription;
+  class ProductDescription;
   class EDProductGetter;
   class EventAux;
   class TriggerResults;
@@ -97,7 +97,7 @@ namespace fwlite {
 
     edm::EventAuxiliary const& eventAuxiliary() const override;
 
-    std::vector<edm::BranchDescription> const& getBranchDescriptions() const;
+    std::vector<edm::ProductDescription> const& getProductDescriptions() const;
     std::vector<std::string> const& getProcessHistory() const;
     edm::ProcessHistory const& processHistory() const override;
     TFile* getTFile() const { return event1_->getTFile(); }

--- a/DataFormats/FWLite/interface/Run.h
+++ b/DataFormats/FWLite/interface/Run.h
@@ -41,7 +41,7 @@
 namespace edm {
   class WrapperBase;
   class ProductRegistry;
-  class BranchDescription;
+  class ProductDescription;
   class EDProductGetter;
   class RunAux;
   class Timestamp;
@@ -86,8 +86,8 @@ namespace fwlite {
 
     edm::RunAuxiliary const& runAuxiliary() const override;
 
-    std::vector<edm::BranchDescription> const& getBranchDescriptions() const {
-      return branchMap_->getBranchDescriptions();
+    std::vector<edm::ProductDescription> const& getProductDescriptions() const {
+      return branchMap_->getProductDescriptions();
     }
 
     //       void setGetter(//Copy from Event if needed

--- a/DataFormats/FWLite/interface/Run.h
+++ b/DataFormats/FWLite/interface/Run.h
@@ -33,6 +33,7 @@
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
 #include "DataFormats/Provenance/interface/RunAuxiliary.h"
 #include "DataFormats/Provenance/interface/RunID.h"
+#include "DataFormats/Provenance/interface/ProductDescriptionFwd.h"
 #include "FWCore/FWLite/interface/BranchMapReader.h"
 #include "DataFormats/FWLite/interface/DataGetterHelper.h"
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
@@ -41,7 +42,6 @@
 namespace edm {
   class WrapperBase;
   class ProductRegistry;
-  class ProductDescription;
   class EDProductGetter;
   class RunAux;
   class Timestamp;

--- a/DataFormats/FWLite/src/ChainEvent.cc
+++ b/DataFormats/FWLite/src/ChainEvent.cc
@@ -195,8 +195,8 @@ namespace fwlite {
     return event_->getBranchNameFor(iType, iModule, iInstance, iProcess);
   }
 
-  std::vector<edm::BranchDescription> const& ChainEvent::getBranchDescriptions() const {
-    return event_->getBranchDescriptions();
+  std::vector<edm::ProductDescription> const& ChainEvent::getProductDescriptions() const {
+    return event_->getProductDescriptions();
   }
 
   std::vector<std::string> const& ChainEvent::getProcessHistory() const { return event_->getProcessHistory(); }

--- a/DataFormats/FWLite/src/DataGetterHelper.cc
+++ b/DataFormats/FWLite/src/DataGetterHelper.cc
@@ -155,7 +155,7 @@ namespace fwlite {
                             char const* iModuleLabel,
                             char const* iProductInstanceLabel,
                             char const* iProcessLabel) -> std::optional<edm::BranchID> {
-      for (auto const& bd : branchMap_->getBranchDescriptions()) {
+      for (auto const& bd : branchMap_->getProductDescriptions()) {
         if (bd.unwrappedTypeID() == iInfo and bd.moduleLabel() == iModuleLabel and
             bd.productInstanceName() == iProductInstanceLabel and bd.processName() == iProcessLabel) {
           return bd.branchID();
@@ -337,7 +337,7 @@ namespace fwlite {
       return true;
   }
 
-  bool DataGetterHelper::getByBranchDescription(edm::BranchDescription const& bDesc,
+  bool DataGetterHelper::getByProductDescription(edm::ProductDescription const& bDesc,
                                                 Long_t eventEntry,
                                                 KeyToDataMap::iterator& itData) const {
     if (!bDesc.branchID().isValid()) {
@@ -378,10 +378,10 @@ namespace fwlite {
     std::map<IDPair, std::shared_ptr<internal::Data>>::const_iterator itFound = idToData_.find(theID);
 
     if (itFound == idToData_.end()) {
-      edm::BranchDescription const& bDesc = branchMap_->productToBranch(iID);
+      edm::ProductDescription const& bDesc = branchMap_->productToBranch(iID);
       KeyToDataMap::iterator itData;
 
-      if (!getByBranchDescription(bDesc, eventEntry, itData)) {
+      if (!getByProductDescription(bDesc, eventEntry, itData)) {
         return nullptr;
       }
       itFound = idToData_.insert(std::make_pair(theID, itData->second)).first;
@@ -403,10 +403,10 @@ namespace fwlite {
     auto itFound = bidToData_.find(bid);
 
     if (itFound == bidToData_.end()) {
-      edm::BranchDescription const& bDesc = branchMap_->branchIDToBranch(bid);
+      edm::ProductDescription const& bDesc = branchMap_->branchIDToBranch(bid);
       KeyToDataMap::iterator itData;
 
-      if (!getByBranchDescription(bDesc, eventEntry, itData)) {
+      if (!getByProductDescription(bDesc, eventEntry, itData)) {
         return nullptr;
       }
       itFound = bidToData_.insert(std::make_pair(bid, itData->second)).first;

--- a/DataFormats/FWLite/src/DataGetterHelper.cc
+++ b/DataFormats/FWLite/src/DataGetterHelper.cc
@@ -338,8 +338,8 @@ namespace fwlite {
   }
 
   bool DataGetterHelper::getByProductDescription(edm::ProductDescription const& bDesc,
-                                                Long_t eventEntry,
-                                                KeyToDataMap::iterator& itData) const {
+                                                 Long_t eventEntry,
+                                                 KeyToDataMap::iterator& itData) const {
     if (!bDesc.branchID().isValid()) {
       return false;
     }

--- a/DataFormats/FWLite/src/EventBase.cc
+++ b/DataFormats/FWLite/src/EventBase.cc
@@ -25,8 +25,8 @@
 #include "FWCore/Utilities/interface/TypeID.h"
 
 static const edm::ProductID s_id;
-static edm::BranchDescription const s_branch = edm::BranchDescription(edm::BranchDescription());
-static const edm::Provenance s_prov(std::shared_ptr<edm::BranchDescription const>(&s_branch, edm::do_nothing_deleter()),
+static edm::ProductDescription const s_branch = edm::ProductDescription(edm::ProductDescription());
+static const edm::Provenance s_prov(std::shared_ptr<edm::ProductDescription const>(&s_branch, edm::do_nothing_deleter()),
                                     s_id);
 
 namespace fwlite {

--- a/DataFormats/FWLite/src/EventBase.cc
+++ b/DataFormats/FWLite/src/EventBase.cc
@@ -26,7 +26,8 @@
 
 static const edm::ProductID s_id;
 static edm::ProductDescription const s_branch = edm::ProductDescription(edm::ProductDescription());
-static const edm::Provenance s_prov(std::shared_ptr<edm::ProductDescription const>(&s_branch, edm::do_nothing_deleter()),
+static const edm::Provenance s_prov(std::shared_ptr<edm::ProductDescription const>(&s_branch,
+                                                                                   edm::do_nothing_deleter()),
                                     s_id);
 
 namespace fwlite {

--- a/DataFormats/FWLite/src/LuminosityBlockBase.cc
+++ b/DataFormats/FWLite/src/LuminosityBlockBase.cc
@@ -28,7 +28,8 @@
 
 static const edm::ProductID s_id;
 static edm::ProductDescription const s_branch = edm::ProductDescription(edm::ProductDescription());
-static const edm::Provenance s_prov(std::shared_ptr<edm::ProductDescription const>(&s_branch, edm::do_nothing_deleter()),
+static const edm::Provenance s_prov(std::shared_ptr<edm::ProductDescription const>(&s_branch,
+                                                                                   edm::do_nothing_deleter()),
                                     s_id);
 
 namespace fwlite {

--- a/DataFormats/FWLite/src/LuminosityBlockBase.cc
+++ b/DataFormats/FWLite/src/LuminosityBlockBase.cc
@@ -27,8 +27,8 @@
 #include "FWCore/Utilities/interface/TypeID.h"
 
 static const edm::ProductID s_id;
-static edm::BranchDescription const s_branch = edm::BranchDescription(edm::BranchDescription());
-static const edm::Provenance s_prov(std::shared_ptr<edm::BranchDescription const>(&s_branch, edm::do_nothing_deleter()),
+static edm::ProductDescription const s_branch = edm::ProductDescription(edm::ProductDescription());
+static const edm::Provenance s_prov(std::shared_ptr<edm::ProductDescription const>(&s_branch, edm::do_nothing_deleter()),
                                     s_id);
 
 namespace fwlite {

--- a/DataFormats/FWLite/src/MultiChainEvent.cc
+++ b/DataFormats/FWLite/src/MultiChainEvent.cc
@@ -290,8 +290,8 @@ namespace fwlite {
     return event1_->getBranchNameFor(iType, iModule, iInstance, iProcess);
   }
 
-  std::vector<edm::BranchDescription> const& MultiChainEvent::getBranchDescriptions() const {
-    return event1_->getBranchDescriptions();
+  std::vector<edm::ProductDescription> const& MultiChainEvent::getProductDescriptions() const {
+    return event1_->getProductDescriptions();
   }
 
   std::vector<std::string> const& MultiChainEvent::getProcessHistory() const { return event1_->getProcessHistory(); }

--- a/DataFormats/FWLite/src/RunBase.cc
+++ b/DataFormats/FWLite/src/RunBase.cc
@@ -28,7 +28,8 @@
 
 static const edm::ProductID s_id;
 static edm::ProductDescription const s_branch = edm::ProductDescription(edm::ProductDescription());
-static const edm::Provenance s_prov(std::shared_ptr<edm::ProductDescription const>(&s_branch, edm::do_nothing_deleter()),
+static const edm::Provenance s_prov(std::shared_ptr<edm::ProductDescription const>(&s_branch,
+                                                                                   edm::do_nothing_deleter()),
                                     s_id);
 
 namespace fwlite {

--- a/DataFormats/FWLite/src/RunBase.cc
+++ b/DataFormats/FWLite/src/RunBase.cc
@@ -27,8 +27,8 @@
 #include "FWCore/Utilities/interface/TypeID.h"
 
 static const edm::ProductID s_id;
-static edm::BranchDescription const s_branch = edm::BranchDescription(edm::BranchDescription());
-static const edm::Provenance s_prov(std::shared_ptr<edm::BranchDescription const>(&s_branch, edm::do_nothing_deleter()),
+static edm::ProductDescription const s_branch = edm::ProductDescription(edm::ProductDescription());
+static const edm::Provenance s_prov(std::shared_ptr<edm::ProductDescription const>(&s_branch, edm::do_nothing_deleter()),
                                     s_id);
 
 namespace fwlite {

--- a/DataFormats/HcalDigi/test/HcalDigiDump.cc
+++ b/DataFormats/HcalDigi/test/HcalDigiDump.cc
@@ -51,7 +51,7 @@ HcalDigiDump::HcalDigiDump(edm::ParameterSet const& conf)
       getterOfProducts12_(edm::TypeMatch(), this),
       getterOfProducts13_(edm::TypeMatch(), this),
       getterOfProducts14_(edm::TypeMatch(), this) {
-  callWhenNewProductsRegistered([this](edm::BranchDescription const& bd) {
+  callWhenNewProductsRegistered([this](edm::ProductDescription const& bd) {
     getterOfProducts1_(bd);
     getterOfProducts2_(bd);
     getterOfProducts3_(bd);

--- a/DataFormats/Provenance/interface/BranchChildren.h
+++ b/DataFormats/Provenance/interface/BranchChildren.h
@@ -13,7 +13,7 @@ BranchChildren: Dependency information between branches.
 
 namespace edm {
 
-  class BranchDescription;
+  class ProductDescription;
 
   class BranchChildren {
   private:
@@ -33,7 +33,7 @@ namespace edm {
     // Look up all the descendants of the given parent, and insert them
     // into descendants. N.B.: this does not clear out descendants first;
     // it only appends *new* elements to the collection.
-    void appendToDescendants(BranchDescription const& parent,
+    void appendToDescendants(ProductDescription const& parent,
                              BranchIDSet& descendants,
                              std::map<BranchID, BranchID> const& droppedToKeptAlias) const;
 

--- a/DataFormats/Provenance/interface/BranchChildren.h
+++ b/DataFormats/Provenance/interface/BranchChildren.h
@@ -10,10 +10,9 @@ BranchChildren: Dependency information between branches.
 #include <map>
 #include <set>
 #include "DataFormats/Provenance/interface/BranchID.h"
+#include "DataFormats/Provenance/interface/ProductDescriptionFwd.h"
 
 namespace edm {
-
-  class ProductDescription;
 
   class BranchChildren {
   private:

--- a/DataFormats/Provenance/interface/BranchDescription.h
+++ b/DataFormats/Provenance/interface/BranchDescription.h
@@ -20,6 +20,9 @@ This description also applies to every product instance on the branch.
 #include <set>
 #include <string>
 
+#if !defined(DataFormats_Provenance_ProductDescription_h)
+#error The name BranchDescription is deprecated, please use ProductDescription instead.
+#endif
 /*
   BranchDescription
 

--- a/DataFormats/Provenance/interface/BranchKey.h
+++ b/DataFormats/Provenance/interface/BranchKey.h
@@ -11,8 +11,9 @@ is determined entirely from the BranchKey.
 #include <iosfwd>
 #include <string>
 
+#include "DataFormats/Provenance/interface/ProductDescriptionFwd.h"
+
 namespace edm {
-  class ProductDescription;
 
   class BranchKey {
   public:

--- a/DataFormats/Provenance/interface/BranchKey.h
+++ b/DataFormats/Provenance/interface/BranchKey.h
@@ -12,7 +12,7 @@ is determined entirely from the BranchKey.
 #include <string>
 
 namespace edm {
-  class BranchDescription;
+  class ProductDescription;
 
   class BranchKey {
   public:
@@ -21,7 +21,7 @@ namespace edm {
     BranchKey(std::string const& cn, std::string const& ml, std::string const& pin, std::string const& pn)
         : friendlyClassName_(cn), moduleLabel_(ml), productInstanceName_(pin), processName_(pn) {}
 
-    explicit BranchKey(BranchDescription const& desc);
+    explicit BranchKey(ProductDescription const& desc);
 
     std::string const& friendlyClassName() const { return friendlyClassName_; }
     std::string const& moduleLabel() const { return moduleLabel_; }

--- a/DataFormats/Provenance/interface/ProductDescription.h
+++ b/DataFormats/Provenance/interface/ProductDescription.h
@@ -1,0 +1,9 @@
+#if !defined(DataFormats_Provenance_ProductDescription_h)
+#define DataFormats_Provenance_ProductDescription_h
+#include "DataFormats/Provenance/interface/BranchDescription.h"
+
+namespace edm {
+  using ProductDescription = BranchDescription;
+}
+
+#endif

--- a/DataFormats/Provenance/interface/ProductDescriptionFwd.h
+++ b/DataFormats/Provenance/interface/ProductDescriptionFwd.h
@@ -1,0 +1,9 @@
+#if !defined(DataFormats_Provenance_ProductDescriptionFwd_h)
+#define DataFormats_Provenance_ProductDescriptionFwd_h
+
+namespace edm {
+  class BranchDescription;
+  using ProductDescription = BranchDescription;
+}  // namespace edm
+
+#endif

--- a/DataFormats/Provenance/interface/ProductRegistry.h
+++ b/DataFormats/Provenance/interface/ProductRegistry.h
@@ -8,7 +8,7 @@
      \date 19 Jul 2005
 */
 
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/Provenance/interface/BranchKey.h"
 #include "DataFormats/Provenance/interface/BranchListIndex.h"
 #include "DataFormats/Provenance/interface/BranchType.h"
@@ -35,7 +35,7 @@ namespace edm {
 
   class ProductRegistry {
   public:
-    typedef std::map<BranchKey, BranchDescription> ProductList;
+    typedef std::map<BranchKey, ProductDescription> ProductList;
 
     ProductRegistry();
 
@@ -46,15 +46,15 @@ namespace edm {
 
     virtual ~ProductRegistry() {}
 
-    typedef std::map<BranchKey, BranchDescription const> ConstProductList;
+    typedef std::map<BranchKey, ProductDescription const> ConstProductList;
 
-    void addProduct(BranchDescription const& productdesc, bool iFromListener = false);
+    void addProduct(ProductDescription const& productdesc, bool iFromListener = false);
 
-    void addLabelAlias(BranchDescription const& productdesc,
+    void addLabelAlias(ProductDescription const& productdesc,
                        std::string const& labelAlias,
                        std::string const& instanceAlias);
 
-    void copyProduct(BranchDescription const& productdesc);
+    void copyProduct(ProductDescription const& productdesc);
 
     void setFrozen(bool initializeLookupInfo = true);
 
@@ -66,13 +66,13 @@ namespace edm {
 
     std::string merge(ProductRegistry const& other,
                       std::string const& fileName,
-                      BranchDescription::MatchMode branchesMustMatch = BranchDescription::Permissive);
+                      ProductDescription::MatchMode branchesMustMatch = ProductDescription::Permissive);
 
     void updateFromInput(ProductList const& other);
     // triggers callbacks for modules watching registration
     void addFromInput(edm::ProductRegistry const&);
 
-    void updateFromInput(std::vector<BranchDescription> const& other);
+    void updateFromInput(std::vector<ProductDescription> const& other);
 
     ProductList const& productList() const {
       //throwIfNotFrozen();
@@ -89,11 +89,11 @@ namespace edm {
     // a colon-initialization list.
     std::vector<std::string> allBranchNames() const;
 
-    // Return pointers to (const) BranchDescriptions for all the
-    // BranchDescriptions known to *this.  This does a
+    // Return pointers to (const) ProductDescriptions for all the
+    // ProductDescriptions known to *this.  This does a
     // return-by-value of the vector so that it may be used in a
     // colon-initialization list.
-    std::vector<BranchDescription const*> allBranchDescriptions() const;
+    std::vector<ProductDescription const*> allProductDescriptions() const;
 
     //NOTE: this is not const since we only want items that have non-const access to this class to be
     // able to call this internal iteration
@@ -183,9 +183,9 @@ namespace edm {
                                           std::map<TypeID, TypeID> const& containedTypeMap,
                                           std::map<TypeID, std::vector<TypeID>>& containedTypeToBaseTypesMap);
 
-    void checkForDuplicateProcessName(BranchDescription const& desc, std::string const* processName) const;
+    void checkForDuplicateProcessName(ProductDescription const& desc, std::string const* processName) const;
 
-    virtual void addCalled(BranchDescription const&, bool iFromListener);
+    virtual void addCalled(ProductDescription const&, bool iFromListener);
     void throwIfNotFrozen() const;
     void throwIfFrozen() const;
 

--- a/DataFormats/Provenance/interface/Provenance.h
+++ b/DataFormats/Provenance/interface/Provenance.h
@@ -35,16 +35,16 @@ namespace edm {
   public:
     Provenance();
 
-    Provenance(std::shared_ptr<BranchDescription const> const& p, ProductID const& pid);
+    Provenance(std::shared_ptr<ProductDescription const> const& p, ProductID const& pid);
 
     Provenance(StableProvenance const&);
 
     StableProvenance const& stable() const { return stableProvenance_; }
     StableProvenance& stable() { return stableProvenance_; }
 
-    BranchDescription const& branchDescription() const { return stable().branchDescription(); }
-    std::shared_ptr<BranchDescription const> const& constBranchDescriptionPtr() const {
-      return stable().constBranchDescriptionPtr();
+    ProductDescription const& productDescription() const { return stable().productDescription(); }
+    std::shared_ptr<ProductDescription const> const& constProductDescriptionPtr() const {
+      return stable().constProductDescriptionPtr();
     }
 
     ProductProvenance const* productProvenance() const;
@@ -83,7 +83,7 @@ namespace edm {
       mergeableRunProductMetadata_ = mrpm;
     }
 
-    void setBranchDescription(std::shared_ptr<BranchDescription const> const& p) { stable().setBranchDescription(p); }
+    void setProductDescription(std::shared_ptr<ProductDescription const> const& p) { stable().setProductDescription(p); }
 
     void swap(Provenance&);
 

--- a/DataFormats/Provenance/interface/Provenance.h
+++ b/DataFormats/Provenance/interface/Provenance.h
@@ -83,7 +83,9 @@ namespace edm {
       mergeableRunProductMetadata_ = mrpm;
     }
 
-    void setProductDescription(std::shared_ptr<ProductDescription const> const& p) { stable().setProductDescription(p); }
+    void setProductDescription(std::shared_ptr<ProductDescription const> const& p) {
+      stable().setProductDescription(p);
+    }
 
     void swap(Provenance&);
 

--- a/DataFormats/Provenance/interface/ProvenanceFwd.h
+++ b/DataFormats/Provenance/interface/ProvenanceFwd.h
@@ -2,12 +2,12 @@
 #define DataFormats_Provenance_ProvenanceFwd_h
 
 namespace edm {
-  class BranchDescription;
+  class ProductDescription;
   class BranchIDListHelper;
   class Parentage;
   class BranchID;
   class BranchKey;
-  class BranchDescription;
+  class ProductDescription;
   class ProductProvenance;
   class ProductProvenance;
   class EventAuxiliary;

--- a/DataFormats/Provenance/interface/ProvenanceFwd.h
+++ b/DataFormats/Provenance/interface/ProvenanceFwd.h
@@ -2,13 +2,10 @@
 #define DataFormats_Provenance_ProvenanceFwd_h
 
 namespace edm {
-  class ProductDescription;
   class BranchIDListHelper;
   class Parentage;
   class BranchID;
   class BranchKey;
-  class ProductDescription;
-  class ProductProvenance;
   class ProductProvenance;
   class EventAuxiliary;
   class EventID;
@@ -41,4 +38,5 @@ namespace cms {
 #include "DataFormats/Provenance/interface/ReleaseVersion.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
 #include "DataFormats/Provenance/interface/ProcessConfigurationID.h"
+#include "DataFormats/Provenance/interface/ProductDescriptionFwd.h"
 #endif

--- a/DataFormats/Provenance/interface/SelectedProducts.h
+++ b/DataFormats/Provenance/interface/SelectedProducts.h
@@ -5,10 +5,10 @@
 #include <vector>
 
 #include "DataFormats/Provenance/interface/BranchType.h"
+#include "DataFormats/Provenance/interface/ProductDescriptionFwd.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 
 namespace edm {
-  class ProductDescription;
   typedef std::vector<std::pair<ProductDescription const *, EDGetToken>> SelectedProducts;
   typedef std::array<SelectedProducts, NumBranchTypes> SelectedProductsForBranchType;
 }  // namespace edm

--- a/DataFormats/Provenance/interface/SelectedProducts.h
+++ b/DataFormats/Provenance/interface/SelectedProducts.h
@@ -8,8 +8,8 @@
 #include "FWCore/Utilities/interface/EDGetToken.h"
 
 namespace edm {
-  class BranchDescription;
-  typedef std::vector<std::pair<BranchDescription const *, EDGetToken>> SelectedProducts;
+  class ProductDescription;
+  typedef std::vector<std::pair<ProductDescription const *, EDGetToken>> SelectedProducts;
   typedef std::array<SelectedProducts, NumBranchTypes> SelectedProductsForBranchType;
 }  // namespace edm
 

--- a/DataFormats/Provenance/interface/StableProvenance.h
+++ b/DataFormats/Provenance/interface/StableProvenance.h
@@ -8,7 +8,7 @@ The parentage can change from event to event.
 
 ----------------------------------------------------------------------*/
 
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
 #include "DataFormats/Provenance/interface/ProcessHistory.h"
 #include "DataFormats/Provenance/interface/ProductID.h"
@@ -31,20 +31,20 @@ namespace edm {
   public:
     StableProvenance();
 
-    StableProvenance(std::shared_ptr<BranchDescription const> const& p, ProductID const& pid);
+    StableProvenance(std::shared_ptr<ProductDescription const> const& p, ProductID const& pid);
 
-    BranchDescription const& branchDescription() const { return *branchDescription_; }
-    std::shared_ptr<BranchDescription const> const& constBranchDescriptionPtr() const { return branchDescription_; }
+    ProductDescription const& productDescription() const { return *productDescription_; }
+    std::shared_ptr<ProductDescription const> const& constProductDescriptionPtr() const { return productDescription_; }
 
-    BranchID const& branchID() const { return branchDescription().branchID(); }
-    BranchID const& originalBranchID() const { return branchDescription().originalBranchID(); }
-    std::string const& branchName() const { return branchDescription().branchName(); }
-    std::string const& className() const { return branchDescription().className(); }
-    std::string const& moduleLabel() const { return branchDescription().moduleLabel(); }
-    std::string const& processName() const { return branchDescription().processName(); }
-    std::string const& productInstanceName() const { return branchDescription().productInstanceName(); }
-    std::string const& friendlyClassName() const { return branchDescription().friendlyClassName(); }
-    std::set<std::string> const& branchAliases() const { return branchDescription().branchAliases(); }
+    BranchID const& branchID() const { return productDescription().branchID(); }
+    BranchID const& originalBranchID() const { return productDescription().originalBranchID(); }
+    std::string const& branchName() const { return productDescription().branchName(); }
+    std::string const& className() const { return productDescription().className(); }
+    std::string const& moduleLabel() const { return productDescription().moduleLabel(); }
+    std::string const& processName() const { return productDescription().processName(); }
+    std::string const& productInstanceName() const { return productDescription().productInstanceName(); }
+    std::string const& friendlyClassName() const { return productDescription().friendlyClassName(); }
+    std::set<std::string> const& branchAliases() const { return productDescription().branchAliases(); }
 
     void write(std::ostream& os) const;
 
@@ -52,12 +52,12 @@ namespace edm {
 
     void setProductID(ProductID const& pid) { productID_ = pid; }
 
-    void setBranchDescription(std::shared_ptr<BranchDescription const> const& p) { branchDescription_ = p; }
+    void setProductDescription(std::shared_ptr<ProductDescription const> const& p) { productDescription_ = p; }
 
     void swap(StableProvenance&);
 
   private:
-    std::shared_ptr<BranchDescription const> branchDescription_;
+    std::shared_ptr<ProductDescription const> productDescription_;
     ProductID productID_;
   };
 

--- a/DataFormats/Provenance/interface/ThinnedAssociationsHelper.h
+++ b/DataFormats/Provenance/interface/ThinnedAssociationsHelper.h
@@ -6,14 +6,13 @@
 */
 
 #include "DataFormats/Provenance/interface/BranchID.h"
+#include "DataFormats/Provenance/interface/ProductDescriptionFwd.h"
 
 #include <map>
 #include <set>
 #include <vector>
 
 namespace edm {
-
-  class ProductDescription;
 
   class ThinnedAssociationBranches {
   public:

--- a/DataFormats/Provenance/interface/ThinnedAssociationsHelper.h
+++ b/DataFormats/Provenance/interface/ThinnedAssociationsHelper.h
@@ -13,7 +13,7 @@
 
 namespace edm {
 
-  class BranchDescription;
+  class ProductDescription;
 
   class ThinnedAssociationBranches {
   public:
@@ -51,7 +51,7 @@ namespace edm {
 
     void clear() { vThinnedAssociationBranches_.clear(); }
 
-    void selectAssociationProducts(std::vector<BranchDescription const*> const& associationDescriptions,
+    void selectAssociationProducts(std::vector<ProductDescription const*> const& associationDescriptions,
                                    std::set<BranchID> const& keptProductsInEvent,
                                    std::map<BranchID, bool>& keepAssociation) const;
 

--- a/DataFormats/Provenance/src/BranchChildren.cc
+++ b/DataFormats/Provenance/src/BranchChildren.cc
@@ -1,6 +1,6 @@
 #include "DataFormats/Provenance/interface/BranchChildren.h"
 
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 
 namespace edm {
   void BranchChildren::append_(map_t const& lookup,
@@ -39,7 +39,7 @@ namespace edm {
 
   void BranchChildren::insertChild(BranchID parent, BranchID child) { childLookup_[parent].insert(child); }
 
-  void BranchChildren::appendToDescendants(BranchDescription const& parent,
+  void BranchChildren::appendToDescendants(ProductDescription const& parent,
                                            BranchIDSet& descendants,
                                            std::map<BranchID, BranchID> const& droppedToKeptAlias) const {
     descendants.insert(parent.branchID());

--- a/DataFormats/Provenance/src/BranchDescription.cc
+++ b/DataFormats/Provenance/src/BranchDescription.cc
@@ -1,4 +1,4 @@
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/Exception.h"

--- a/DataFormats/Provenance/src/BranchKey.cc
+++ b/DataFormats/Provenance/src/BranchKey.cc
@@ -5,10 +5,10 @@
 #include <ostream>
 
 #include "DataFormats/Provenance/interface/BranchKey.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 
 namespace edm {
-  BranchKey::BranchKey(BranchDescription const& desc)
+  BranchKey::BranchKey(ProductDescription const& desc)
       : friendlyClassName_(desc.friendlyClassName()),
         moduleLabel_(desc.moduleLabel()),
         productInstanceName_(desc.productInstanceName()),

--- a/DataFormats/Provenance/src/ProductRegistry.cc
+++ b/DataFormats/Provenance/src/ProductRegistry.cc
@@ -65,7 +65,7 @@ namespace edm {
     freezeIt(toBeFrozen);
   }
 
-  void ProductRegistry::addProduct(BranchDescription const& productDesc, bool fromListener) {
+  void ProductRegistry::addProduct(ProductDescription const& productDesc, bool fromListener) {
     assert(productDesc.produced());
     throwIfFrozen();
     std::pair<ProductList::iterator, bool> ret =
@@ -105,13 +105,13 @@ namespace edm {
     addCalled(productDesc, fromListener);
   }
 
-  void ProductRegistry::addLabelAlias(BranchDescription const& productDesc,
+  void ProductRegistry::addLabelAlias(ProductDescription const& productDesc,
                                       std::string const& labelAlias,
                                       std::string const& instanceAlias) {
     assert(productDesc.produced());
     assert(productDesc.branchID().isValid());
     throwIfFrozen();
-    BranchDescription bd(productDesc, labelAlias, instanceAlias);
+    ProductDescription bd(productDesc, labelAlias, instanceAlias);
     std::pair<ProductList::iterator, bool> ret = productList_.insert(std::make_pair(BranchKey(bd), bd));
     assert(ret.second);
     transient_.aliasToOriginal_.emplace_back(
@@ -119,7 +119,7 @@ namespace edm {
     addCalled(bd, false);
   }
 
-  void ProductRegistry::copyProduct(BranchDescription const& productDesc) {
+  void ProductRegistry::copyProduct(ProductDescription const& productDesc) {
     assert(!productDesc.produced());
     throwIfFrozen();
     BranchKey k = BranchKey(productDesc);
@@ -184,7 +184,7 @@ namespace edm {
     }
   }
 
-  void ProductRegistry::addCalled(BranchDescription const&, bool) {}
+  void ProductRegistry::addCalled(ProductDescription const&, bool) {}
 
   std::vector<std::string> ProductRegistry::allBranchNames() const {
     std::vector<std::string> result;
@@ -196,8 +196,8 @@ namespace edm {
     return result;
   }
 
-  std::vector<BranchDescription const*> ProductRegistry::allBranchDescriptions() const {
-    std::vector<BranchDescription const*> result;
+  std::vector<ProductDescription const*> ProductRegistry::allProductDescriptions() const {
+    std::vector<ProductDescription const*> result;
     result.reserve(productList().size());
 
     for (auto const& product : productList()) {
@@ -212,9 +212,9 @@ namespace edm {
     }
   }
 
-  void ProductRegistry::updateFromInput(std::vector<BranchDescription> const& other) {
-    for (BranchDescription const& branchDescription : other) {
-      copyProduct(branchDescription);
+  void ProductRegistry::updateFromInput(std::vector<ProductDescription> const& other) {
+    for (ProductDescription const& productDescription : other) {
+      copyProduct(productDescription);
     }
   }
 
@@ -263,7 +263,7 @@ namespace edm {
 
   std::string ProductRegistry::merge(ProductRegistry const& other,
                                      std::string const& fileName,
-                                     BranchDescription::MatchMode branchesMustMatch) {
+                                     ProductDescription::MatchMode branchesMustMatch) {
     std::ostringstream differences;
 
     ProductRegistry::ProductList::iterator j = productList_.begin();
@@ -288,7 +288,7 @@ namespace edm {
         ++i;
       } else if (i == e || (j != s && j->first < i->first)) {
         if (j->second.present() &&
-            (branchesMustMatch == BranchDescription::Strict || j->second.branchType() == InProcess)) {
+            (branchesMustMatch == ProductDescription::Strict || j->second.branchType() == InProcess)) {
           differences << "Branch '" << j->second.branchName() << "' is in previous files\n";
           differences << "    but not in file '" << fileName << "'.\n";
         }
@@ -605,7 +605,7 @@ namespace edm {
     }
   }
 
-  void ProductRegistry::checkForDuplicateProcessName(BranchDescription const& desc,
+  void ProductRegistry::checkForDuplicateProcessName(ProductDescription const& desc,
                                                      std::string const* processName) const {
     if (processName && !desc.produced() && (*processName == desc.processName())) {
       throw Exception(errors::Configuration, "Duplicate Process Name.\n")

--- a/DataFormats/Provenance/src/Provenance.cc
+++ b/DataFormats/Provenance/src/Provenance.cc
@@ -15,7 +15,7 @@ namespace edm {
 
   Provenance::Provenance() : Provenance{StableProvenance()} {}
 
-  Provenance::Provenance(std::shared_ptr<BranchDescription const> const& p, ProductID const& pid)
+  Provenance::Provenance(std::shared_ptr<ProductDescription const> const& p, ProductID const& pid)
       : stableProvenance_(p, pid), store_(), mergeableRunProductMetadata_() {}
 
   Provenance::Provenance(StableProvenance const& stable)
@@ -29,7 +29,7 @@ namespace edm {
   }
 
   bool Provenance::knownImproperlyMerged() const {
-    if (mergeableRunProductMetadata_ && branchDescription().isMergeable()) {
+    if (mergeableRunProductMetadata_ && productDescription().isMergeable()) {
       // This part handles the cases where the product is
       // a mergeable run product from the input.
       return mergeableRunProductMetadata_->knownImproperlyMerged(processName());

--- a/DataFormats/Provenance/src/StableProvenance.cc
+++ b/DataFormats/Provenance/src/StableProvenance.cc
@@ -10,22 +10,22 @@
 
 namespace edm {
 
-  StableProvenance::StableProvenance() : StableProvenance{std::shared_ptr<BranchDescription const>(), ProductID()} {}
+  StableProvenance::StableProvenance() : StableProvenance{std::shared_ptr<ProductDescription const>(), ProductID()} {}
 
-  StableProvenance::StableProvenance(std::shared_ptr<BranchDescription const> const& p, ProductID const& pid)
-      : branchDescription_(p), productID_(pid) {}
+  StableProvenance::StableProvenance(std::shared_ptr<ProductDescription const> const& p, ProductID const& pid)
+      : productDescription_(p), productID_(pid) {}
 
   void StableProvenance::write(std::ostream& os) const {
     // This is grossly inadequate, but it is not critical for the first pass.
-    branchDescription().write(os);
+    productDescription().write(os);
   }
 
   bool operator==(StableProvenance const& a, StableProvenance const& b) {
-    return a.branchDescription() == b.branchDescription();
+    return a.productDescription() == b.productDescription();
   }
 
   void StableProvenance::swap(StableProvenance& iOther) {
-    branchDescription_.swap(iOther.branchDescription_);
+    productDescription_.swap(iOther.productDescription_);
     productID_.swap(iOther.productID_);
   }
 }  // namespace edm

--- a/DataFormats/Provenance/src/SubProcessParentageHelper.cc
+++ b/DataFormats/Provenance/src/SubProcessParentageHelper.cc
@@ -1,6 +1,6 @@
 #include "DataFormats/Provenance/interface/SubProcessParentageHelper.h"
 
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "FWCore/Utilities/interface/BranchType.h"
 
@@ -11,7 +11,7 @@ namespace edm {
     *this = parentSubProcessParentageHelper;
 
     for (auto const& prod : parentProductRegistry.productList()) {
-      BranchDescription const& desc = prod.second;
+      ProductDescription const& desc = prod.second;
       if (desc.produced() && desc.branchType() == InEvent && !desc.isAlias()) {
         producedProducts_.push_back(desc.branchID());
       }

--- a/DataFormats/Provenance/src/ThinnedAssociationsHelper.cc
+++ b/DataFormats/Provenance/src/ThinnedAssociationsHelper.cc
@@ -1,5 +1,5 @@
 #include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include <algorithm>
 
@@ -188,7 +188,7 @@ namespace edm {
   }
 
   void ThinnedAssociationsHelper::selectAssociationProducts(
-      std::vector<BranchDescription const*> const& associationDescriptions,
+      std::vector<ProductDescription const*> const& associationDescriptions,
       std::set<BranchID> const& keptProductsInEvent,
       std::map<BranchID, bool>& keepAssociation) const {
     keepAssociation.clear();

--- a/DataFormats/Provenance/src/classes.h
+++ b/DataFormats/Provenance/src/classes.h
@@ -1,4 +1,4 @@
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/Provenance/interface/BranchChildren.h"
 #include "DataFormats/Provenance/interface/BranchID.h"
 #include "DataFormats/Provenance/interface/BranchKey.h"

--- a/DataFormats/Streamer/interface/StreamedProducts.h
+++ b/DataFormats/Streamer/interface/StreamedProducts.h
@@ -13,7 +13,7 @@
  */
 
 #include <vector>
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/Provenance/interface/BranchID.h"
 #include "DataFormats/Provenance/interface/EventAuxiliary.h"
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
@@ -32,15 +32,15 @@ namespace edm {
   class StreamedProduct {
   public:
     StreamedProduct() : prod_(nullptr), desc_(nullptr), present_(false), parents_(nullptr) {}
-    explicit StreamedProduct(BranchDescription const& desc)
+    explicit StreamedProduct(ProductDescription const& desc)
         : prod_(nullptr), desc_(&desc), present_(false), parents_(nullptr) {}
 
     StreamedProduct(WrapperBase const* prod,
-                    BranchDescription const& desc,
+                    ProductDescription const& desc,
                     bool present,
                     std::vector<BranchID> const* parents);
 
-    BranchDescription const* desc() const { return desc_; }
+    ProductDescription const* desc() const { return desc_; }
     BranchID branchID() const { return desc_->branchID(); }
     bool present() const { return present_; }
     std::vector<BranchID> const* parents() const { return parents_; }
@@ -57,7 +57,7 @@ namespace edm {
 
   private:
     WrapperBase const* prod_;
-    BranchDescription const* desc_;
+    ProductDescription const* desc_;
     bool present_;
     std::vector<BranchID> const* parents_;
   };
@@ -115,7 +115,7 @@ namespace edm {
     // other tables necessary for provenance lookup
   };
 
-  typedef std::vector<BranchDescription> SendDescs;
+  typedef std::vector<ProductDescription> SendDescs;
 
   class SendJobHeader {
   public:
@@ -123,7 +123,7 @@ namespace edm {
     SendJobHeader() {}
     SendDescs const& descs() const { return descs_; }
     ParameterSetMap const& processParameterSet() const { return processParameterSet_; }
-    void push_back(BranchDescription const& bd) { descs_.push_back(bd); }
+    void push_back(ProductDescription const& bd) { descs_.push_back(bd); }
     void setParameterSetMap(ParameterSetMap const& psetMap) { processParameterSet_ = psetMap; }
     void initializeTransients();
 

--- a/DataFormats/Streamer/src/StreamedProducts.cc
+++ b/DataFormats/Streamer/src/StreamedProducts.cc
@@ -4,14 +4,14 @@
 
 namespace edm {
   StreamedProduct::StreamedProduct(WrapperBase const* prod,
-                                   BranchDescription const& desc,
+                                   ProductDescription const& desc,
                                    bool present,
                                    std::vector<BranchID> const* parents)
       : prod_(prod), desc_(&desc), present_(present), parents_(parents) {
     if (present_ && prod == nullptr) {
       std::string branchName = desc.branchName();
       if (branchName.empty()) {
-        BranchDescription localCopy(desc);
+        ProductDescription localCopy(desc);
         localCopy.initBranchName();
         branchName = localCopy.branchName();
       }
@@ -23,7 +23,7 @@ namespace edm {
   }
 
   void SendJobHeader::initializeTransients() {
-    for (BranchDescription& desc : descs_) {
+    for (ProductDescription& desc : descs_) {
       desc.init();
       desc.setIsProvenanceSetOnRead();
     }

--- a/EventFilter/Utilities/src/DAQSourceModelsDTH.cc
+++ b/EventFilter/Utilities/src/DAQSourceModelsDTH.cc
@@ -44,7 +44,7 @@ void DataModeDTH::readEvent(edm::EventPrincipal& eventPrincipal) {
 
   std::unique_ptr<edm::WrapperBase> edp(new edm::Wrapper<FEDRawDataCollection>(std::move(rawData)));
   eventPrincipal.put(
-      daqProvenanceHelpers_[0]->branchDescription(), std::move(edp), daqProvenanceHelpers_[0]->dummyProvenance());
+      daqProvenanceHelpers_[0]->productDescription(), std::move(edp), daqProvenanceHelpers_[0]->dummyProvenance());
   eventCached_ = false;
 }
 

--- a/EventFilter/Utilities/src/DAQSourceModelsFRD.cc
+++ b/EventFilter/Utilities/src/DAQSourceModelsFRD.cc
@@ -65,7 +65,7 @@ void DataModeFRD::readEvent(edm::EventPrincipal& eventPrincipal) {
 
   std::unique_ptr<edm::WrapperBase> edp(new edm::Wrapper<FEDRawDataCollection>(std::move(rawData)));
   eventPrincipal.put(
-      daqProvenanceHelpers_[0]->branchDescription(), std::move(edp), daqProvenanceHelpers_[0]->dummyProvenance());
+      daqProvenanceHelpers_[0]->productDescription(), std::move(edp), daqProvenanceHelpers_[0]->dummyProvenance());
 }
 
 edm::Timestamp DataModeFRD::fillFEDRawDataCollection(FEDRawDataCollection& rawData,
@@ -213,7 +213,7 @@ void DataModeFRDPreUnpack::readEvent(edm::EventPrincipal& eventPrincipal) {
 
   std::unique_ptr<edm::WrapperBase> edp(new edm::Wrapper<FEDRawDataCollection>(std::move(ec_->rawDataRef())));
   eventPrincipal.put(
-      daqProvenanceHelpers_[0]->branchDescription(), std::move(edp), daqProvenanceHelpers_[0]->dummyProvenance());
+      daqProvenanceHelpers_[0]->productDescription(), std::move(edp), daqProvenanceHelpers_[0]->dummyProvenance());
 }
 
 void DataModeFRDPreUnpack::unpackFile(RawInputFile* currentFile) {
@@ -405,7 +405,7 @@ void DataModeFRDStriped::readEvent(edm::EventPrincipal& eventPrincipal) {
   }
   std::unique_ptr<edm::WrapperBase> edp(new edm::Wrapper<FEDRawDataCollection>(std::move(rawData)));
   eventPrincipal.put(
-      daqProvenanceHelpers_[0]->branchDescription(), std::move(edp), daqProvenanceHelpers_[0]->dummyProvenance());
+      daqProvenanceHelpers_[0]->productDescription(), std::move(edp), daqProvenanceHelpers_[0]->dummyProvenance());
   eventCached_ = false;
 }
 

--- a/EventFilter/Utilities/src/DAQSourceModelsScoutingRun3.cc
+++ b/EventFilter/Utilities/src/DAQSourceModelsScoutingRun3.cc
@@ -75,7 +75,7 @@ void DataModeScoutingRun3::readEvent(edm::EventPrincipal& eventPrincipal) {
 
   std::unique_ptr<edm::WrapperBase> edp(new edm::Wrapper<SDSRawDataCollection>(std::move(rawData)));
   eventPrincipal.put(
-      daqProvenanceHelpers_[0]->branchDescription(), std::move(edp), daqProvenanceHelpers_[0]->dummyProvenance());
+      daqProvenanceHelpers_[0]->productDescription(), std::move(edp), daqProvenanceHelpers_[0]->dummyProvenance());
 
   eventCached_ = false;
 }

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -621,7 +621,7 @@ void FedRawDataInputSource::read(edm::EventPrincipal& eventPrincipal) {
 
   std::unique_ptr<edm::WrapperBase> edp(new edm::Wrapper<FEDRawDataCollection>(std::move(rawData)));
 
-  eventPrincipal.put(daqProvenanceHelper_.branchDescription(), std::move(edp), daqProvenanceHelper_.dummyProvenance());
+  eventPrincipal.put(daqProvenanceHelper_.productDescription(), std::move(edp), daqProvenanceHelper_.dummyProvenance());
 
   eventsThisLumi_++;
   setMonState(inReadCleanup);

--- a/FWCore/Common/src/ProcessBlockHelperBase.cc
+++ b/FWCore/Common/src/ProcessBlockHelperBase.cc
@@ -1,6 +1,6 @@
 #include "FWCore/Common/interface/ProcessBlockHelperBase.h"
 
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "FWCore/Utilities/interface/BranchType.h"
 #include "FWCore/Utilities/interface/ProductLabels.h"
@@ -35,7 +35,7 @@ namespace edm {
 
     unsigned int bestPosition = 0;
     for (auto const& prod : productRegistry.productList()) {
-      BranchDescription const& desc = prod.second;
+      ProductDescription const& desc = prod.second;
       if (desc.branchType() == InProcess && !desc.produced() && desc.present() &&
           desc.moduleLabel() == productLabels.module && desc.productInstanceName() == productLabels.productInstance &&
           desc.unwrappedTypeID() == typeID && (processName.empty() || processName == desc.processName())) {

--- a/FWCore/Common/src/SubProcessBlockHelper.cc
+++ b/FWCore/Common/src/SubProcessBlockHelper.cc
@@ -1,6 +1,6 @@
 #include "FWCore/Common/interface/SubProcessBlockHelper.h"
 
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "FWCore/Utilities/interface/BranchType.h"
 
@@ -51,7 +51,7 @@ namespace edm {
     assert(processesWithProcessBlockProducts().empty());
     for (auto const& processName : parentProcessBlockHelper.processesWithProcessBlockProducts()) {
       for (auto const& item : productRegistry.productList()) {
-        BranchDescription const& desc = item.second;
+        ProductDescription const& desc = item.second;
         if (desc.branchType() == InProcess && desc.present() && desc.processName() == processName) {
           emplaceBackProcessName(processName);
           break;
@@ -63,7 +63,7 @@ namespace edm {
     assert(addedProcesses().empty());
     for (auto const& processName : parentProcessBlockHelper.addedProcesses()) {
       for (auto const& item : productRegistry.productList()) {
-        BranchDescription const& desc = item.second;
+        ProductDescription const& desc = item.second;
         if (desc.branchType() == InProcess && desc.present() && desc.processName() == processName) {
           emplaceBackAddedProcessName(processName);
           break;

--- a/FWCore/FWLite/interface/BranchMapReader.h
+++ b/FWCore/FWLite/interface/BranchMapReader.h
@@ -23,7 +23,7 @@
 #include "TUUID.h"
 
 // user include files
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/Provenance/interface/BranchListIndex.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
 
@@ -49,9 +49,9 @@ namespace fwlite {
       virtual bool updateRun(Long_t runEntry) = 0;
       virtual bool updateMap() = 0;
       virtual edm::BranchID productToBranchID(const edm::ProductID& pid) = 0;
-      virtual const edm::BranchDescription& productToBranch(const edm::ProductID& pid) = 0;
-      virtual const edm::BranchDescription& branchIDToBranch(const edm::BranchID& bid) const = 0;
-      virtual const std::vector<edm::BranchDescription>& getBranchDescriptions() = 0;
+      virtual const edm::ProductDescription& productToBranch(const edm::ProductID& pid) = 0;
+      virtual const edm::ProductDescription& branchIDToBranch(const edm::BranchID& bid) const = 0;
+      virtual const std::vector<edm::ProductDescription>& getProductDescriptions() = 0;
       virtual const edm::BranchListIndexes& branchListIndexes() const = 0;
       virtual const edm::ThinnedAssociationsHelper& thinnedAssociationsHelper() const = 0;
 
@@ -82,8 +82,8 @@ namespace fwlite {
     bool updateLuminosityBlock(Long_t luminosityBlockEntry);
     bool updateRun(Long_t runEntry);
     edm::BranchID productToBranchID(const edm::ProductID& pid) { return strategy_->productToBranchID(pid); }
-    const edm::BranchDescription& productToBranch(const edm::ProductID& pid);
-    const edm::BranchDescription& branchIDToBranch(const edm::BranchID& bid) const {
+    const edm::ProductDescription& productToBranch(const edm::ProductID& pid);
+    const edm::ProductDescription& branchIDToBranch(const edm::BranchID& bid) const {
       return strategy_->branchIDToBranch(bid);
     }
     int getFileVersion(TFile* file);
@@ -101,7 +101,7 @@ namespace fwlite {
     Long_t getEventEntry() const { return strategy_->eventEntry_; }
     Long_t getLuminosityBlockEntry() const { return strategy_->luminosityBlockEntry_; }
     Long_t getRunEntry() const { return strategy_->runEntry_; }
-    const std::vector<edm::BranchDescription>& getBranchDescriptions();
+    const std::vector<edm::ProductDescription>& getProductDescriptions();
     const edm::BranchListIndexes& branchListIndexes() const {
       strategy_->updateMap();
       return strategy_->branchListIndexes();

--- a/FWCore/FWLite/src/BareRootProductGetterBase.cc
+++ b/FWCore/FWLite/src/BareRootProductGetterBase.cc
@@ -19,7 +19,7 @@
 #include "DataFormats/Common/interface/ThinnedAssociation.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/Common/interface/getThinned_implementation.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/Provenance/interface/BranchID.h"
 #include "DataFormats/Provenance/interface/BranchType.h"
 #include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
@@ -189,7 +189,7 @@ edm::OptionalThinnedKey BareRootProductGetterBase::getThinnedKeyFrom(edm::Produc
 
 BareRootProductGetterBase::Buffer* BareRootProductGetterBase::createNewBuffer(edm::BranchID const& branchID) const {
   //find the branch
-  edm::BranchDescription const& bdesc = branchMap_.branchIDToBranch(branchID);
+  edm::ProductDescription const& bdesc = branchMap_.branchIDToBranch(branchID);
 
   TBranch* branch = branchMap_.getEventTree()->GetBranch(bdesc.branchName().c_str());
   if (nullptr == branch) {

--- a/FWCore/FWLite/src/BranchMapReader.cc
+++ b/FWCore/FWLite/src/BranchMapReader.cc
@@ -37,7 +37,7 @@
 namespace fwlite {
   namespace internal {
 
-    static const edm::BranchDescription kDefaultBranchDescription;
+    static const edm::ProductDescription kDefaultProductDescription;
 
     BMRStrategy::BMRStrategy(TFile* file, int fileVersion)
         : currentFile_(file),
@@ -56,7 +56,7 @@ namespace fwlite {
 
     class Strategy : public BMRStrategy {
     public:
-      typedef std::map<edm::BranchID, edm::BranchDescription> bidToDesc;
+      typedef std::map<edm::BranchID, edm::ProductDescription> bidToDesc;
 
       Strategy(TFile* file, int fileVersion);
       ~Strategy() override;
@@ -75,17 +75,17 @@ namespace fwlite {
       }
       bool updateMap() override { return true; }
       edm::BranchID productToBranchID(edm::ProductID const& pid) override;
-      edm::BranchDescription const& productToBranch(edm::ProductID const& pid) override;
-      edm::BranchDescription const& branchIDToBranch(edm::BranchID const& bid) const override;
-      std::vector<edm::BranchDescription> const& getBranchDescriptions() override;
+      edm::ProductDescription const& productToBranch(edm::ProductID const& pid) override;
+      edm::ProductDescription const& branchIDToBranch(edm::BranchID const& bid) const override;
+      std::vector<edm::ProductDescription> const& getProductDescriptions() override;
       edm::ThinnedAssociationsHelper const& thinnedAssociationsHelper() const override {
         return *thinnedAssociationsHelper_;
       }
 
       TBranch* getBranchRegistry(edm::ProductRegistry** pReg);
 
-      bidToDesc branchDescriptionMap_;
-      std::vector<edm::BranchDescription> bDesc_;
+      bidToDesc productDescriptionMap_;
+      std::vector<edm::ProductDescription> bDesc_;
       bool mapperFilled_;
       edm::propagate_const<std::unique_ptr<edm::ThinnedAssociationsHelper>> thinnedAssociationsHelper_;
     };
@@ -108,7 +108,7 @@ namespace fwlite {
       luminosityBlockTree_ = dynamic_cast<TTree*>(currentFile_->Get(edm::poolNames::luminosityBlockTreeName().c_str()));
       runTree_ = dynamic_cast<TTree*>(currentFile_->Get(edm::poolNames::runTreeName().c_str()));
       fileUUID_ = currentFile_->GetUUID();
-      branchDescriptionMap_.clear();
+      productDescriptionMap_.clear();
       bDesc_.clear();
       return nullptr != eventTree_;
     }
@@ -125,9 +125,9 @@ namespace fwlite {
       return bReg;
     }
 
-    std::vector<edm::BranchDescription> const& Strategy::getBranchDescriptions() {
+    std::vector<edm::ProductDescription> const& Strategy::getProductDescriptions() {
       if (bDesc_.empty()) {
-        for (auto const& item : branchDescriptionMap_) {
+        for (auto const& item : productDescriptionMap_) {
           bDesc_.push_back(item.second);
         }
       }
@@ -138,19 +138,19 @@ namespace fwlite {
       throw edm::Exception(edm::errors::UnimplementedFeature) << "Unsupported EDM file version";
     }
 
-    edm::BranchDescription const& Strategy::productToBranch(edm::ProductID const& pid) {
+    edm::ProductDescription const& Strategy::productToBranch(edm::ProductID const& pid) {
       edm::BranchID bid = productToBranchID(pid);
-      bidToDesc::const_iterator bdi = branchDescriptionMap_.find(bid);
-      if (branchDescriptionMap_.end() == bdi) {
-        return kDefaultBranchDescription;
+      bidToDesc::const_iterator bdi = productDescriptionMap_.find(bid);
+      if (productDescriptionMap_.end() == bdi) {
+        return kDefaultProductDescription;
       }
       return bdi->second;
     }
 
-    edm::BranchDescription const& Strategy::branchIDToBranch(edm::BranchID const& bid) const {
-      bidToDesc::const_iterator bdi = branchDescriptionMap_.find(bid);
-      if (branchDescriptionMap_.end() == bdi) {
-        return kDefaultBranchDescription;
+    edm::ProductDescription const& Strategy::branchIDToBranch(edm::BranchID const& bid) const {
+      bidToDesc::const_iterator bdi = productDescriptionMap_.find(bid);
+      if (productDescriptionMap_.end() == bdi) {
+        return kDefaultProductDescription;
       }
       return bdi->second;
     }
@@ -183,7 +183,7 @@ namespace fwlite {
         return true;
       }
 
-      branchDescriptionMap_.clear();
+      productDescriptionMap_.clear();
       bDesc_.clear();
 
       edm::ProductRegistry reg;
@@ -194,11 +194,11 @@ namespace fwlite {
         edm::ProductRegistry::ProductList& prodList = reg.productListUpdator();
 
         for (auto& item : prodList) {
-          edm::BranchDescription& prod = item.second;
+          edm::ProductDescription& prod = item.second;
           if (edm::InEvent == prod.branchType()) {
             // call to regenerate branchName
             prod.init();
-            branchDescriptionMap_.insert(bidToDesc::value_type(prod.branchID(), prod));
+            productDescriptionMap_.insert(bidToDesc::value_type(prod.branchID(), prod));
           }
         }
         mapperFilled_ = true;
@@ -283,7 +283,7 @@ namespace fwlite {
       pEventEntryInfoVector_ = &eventEntryInfoVector_;
       entryInfoBranch_->SetAddress(&pEventEntryInfoVector_);
 
-      branchDescriptionMap_.clear();
+      productDescriptionMap_.clear();
       bDesc_.clear();
 
       edm::ProductRegistry reg;
@@ -294,11 +294,11 @@ namespace fwlite {
         edm::ProductRegistry::ProductList& prodList = reg.productListUpdator();
 
         for (auto& item : prodList) {
-          edm::BranchDescription& prod = item.second;
+          edm::ProductDescription& prod = item.second;
           if (edm::InEvent == prod.branchType()) {
             // call to regenerate branchName
             prod.init();
-            branchDescriptionMap_.insert(bidToDesc::value_type(prod.branchID(), prod));
+            productDescriptionMap_.insert(bidToDesc::value_type(prod.branchID(), prod));
           }
         }
       }
@@ -393,7 +393,7 @@ namespace fwlite {
 
       eventHistoryTree_ = dynamic_cast<TTree*>(currentFile_->Get(edm::poolNames::eventHistoryTreeName().c_str()));
 
-      branchDescriptionMap_.clear();
+      productDescriptionMap_.clear();
       bDesc_.clear();
 
       edm::ProductRegistry reg;
@@ -404,11 +404,11 @@ namespace fwlite {
         edm::ProductRegistry::ProductList& prodList = reg.productListUpdator();
 
         for (auto& item : prodList) {
-          edm::BranchDescription& prod = item.second;
+          edm::ProductDescription& prod = item.second;
           if (edm::InEvent == prod.branchType()) {
             // call to regenerate branchName
             prod.init();
-            branchDescriptionMap_.insert(bidToDesc::value_type(prod.branchID(), prod));
+            productDescriptionMap_.insert(bidToDesc::value_type(prod.branchID(), prod));
             //             std::cout << "v11 updatefile " << prod.branchID() << std::endl;
           }
         }
@@ -516,7 +516,7 @@ namespace fwlite {
 
       eventsTree_ = dynamic_cast<TTree*>(currentFile_->Get(edm::poolNames::eventTreeName().c_str()));
 
-      branchDescriptionMap_.clear();
+      productDescriptionMap_.clear();
       bDesc_.clear();
 
       edm::ProductRegistry reg;
@@ -527,11 +527,11 @@ namespace fwlite {
         edm::ProductRegistry::ProductList& prodList = reg.productListUpdator();
 
         for (auto& item : prodList) {
-          edm::BranchDescription& prod = item.second;
+          edm::ProductDescription& prod = item.second;
           if (edm::InEvent == prod.branchType()) {
             // call to regenerate branchName
             prod.init();
-            branchDescriptionMap_.insert(bidToDesc::value_type(prod.branchID(), prod));
+            productDescriptionMap_.insert(bidToDesc::value_type(prod.branchID(), prod));
             //             std::cout << "v11 updatefile " << prod.branchID() << std::endl;
           }
         }
@@ -637,12 +637,12 @@ namespace fwlite {
     return isNew;
   }
 
-  edm::BranchDescription const& BranchMapReader::productToBranch(edm::ProductID const& pid) {
+  edm::ProductDescription const& BranchMapReader::productToBranch(edm::ProductID const& pid) {
     return strategy_->productToBranch(pid);
   }
 
-  std::vector<edm::BranchDescription> const& BranchMapReader::getBranchDescriptions() {
-    return strategy_->getBranchDescriptions();
+  std::vector<edm::ProductDescription> const& BranchMapReader::getProductDescriptions() {
+    return strategy_->getProductDescriptions();
   }
 
   std::unique_ptr<internal::BMRStrategy> BranchMapReader::newStrategy(TFile* file, int fileVersion) {

--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -55,7 +55,7 @@ class testEvent;
 
 namespace edm {
 
-  class BranchDescription;
+  class ProductDescription;
   class ModuleCallingContext;
   class TriggerResultsByName;
   class TriggerResults;
@@ -270,7 +270,7 @@ namespace edm {
 
     void fillLuminosityBlock() const;
 
-    ProductID makeProductID(BranchDescription const& desc) const;
+    ProductID makeProductID(ProductDescription const& desc) const;
 
     //override used by EventBase class
     BasicHandle getByLabelImpl(std::type_info const& iWrapperType,

--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -29,6 +29,7 @@ For its usage, see "FWCore/Framework/interface/PrincipalGetAdapter.h"
 #include "DataFormats/Provenance/interface/EventSelectionID.h"
 #include "DataFormats/Provenance/interface/ProductID.h"
 #include "DataFormats/Provenance/interface/RunID.h"
+#include "DataFormats/Provenance/interface/ProductDescriptionFwd.h"
 
 #include "FWCore/Common/interface/EventBase.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -55,7 +56,6 @@ class testEvent;
 
 namespace edm {
 
-  class ProductDescription;
   class ModuleCallingContext;
   class TriggerResultsByName;
   class TriggerResults;

--- a/FWCore/Framework/interface/EventForOutput.h
+++ b/FWCore/Framework/interface/EventForOutput.h
@@ -21,6 +21,7 @@
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "DataFormats/Provenance/interface/EventSelectionID.h"
 #include "DataFormats/Provenance/interface/RunID.h"
+#include "DataFormats/Provenance/interface/ProductDescriptionFwd.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/OccurrenceForOutput.h"
@@ -42,7 +43,6 @@ namespace edmtest {
 
 namespace edm {
 
-  class ProductDescription;
   class ModuleCallingContext;
   class ProductProvenanceRetriever;
   class EDConsumerBase;

--- a/FWCore/Framework/interface/EventForOutput.h
+++ b/FWCore/Framework/interface/EventForOutput.h
@@ -42,7 +42,7 @@ namespace edmtest {
 
 namespace edm {
 
-  class BranchDescription;
+  class ProductDescription;
   class ModuleCallingContext;
   class ProductProvenanceRetriever;
   class EDConsumerBase;

--- a/FWCore/Framework/interface/EventPrincipal.h
+++ b/FWCore/Framework/interface/EventPrincipal.h
@@ -140,13 +140,13 @@ namespace edm {
 
     BasicHandle getByProductID(ProductID const& oid) const;
 
-    void put(BranchDescription const& bd,
+    void put(ProductDescription const& bd,
              std::unique_ptr<WrapperBase> edp,
              ProductProvenance const& productProvenance) const;
 
     void put(ProductResolverIndex index, std::unique_ptr<WrapperBase> edp, ParentageID productProvenance) const;
 
-    void putOnRead(BranchDescription const& bd,
+    void putOnRead(ProductDescription const& bd,
                    std::unique_ptr<WrapperBase> edp,
                    std::optional<ProductProvenance> productProvenance) const;
 

--- a/FWCore/Framework/interface/FileBlock.h
+++ b/FWCore/Framework/interface/FileBlock.h
@@ -9,6 +9,7 @@ FileBlock: Properties of an input file.
 
 #include "DataFormats/Provenance/interface/FileFormatVersion.h"
 #include "DataFormats/Provenance/interface/BranchChildren.h"
+#include "DataFormats/Provenance/interface/ProductDescriptionFwd.h"
 #include "FWCore/Utilities/interface/BranchType.h"
 class TTree;
 #include <memory>
@@ -18,7 +19,6 @@ class TTree;
 #include <vector>
 
 namespace edm {
-  class ProductDescription;
   class FileBlock {
   public:
     // bit mask for reasons fast cloning can be disabled or not applicable

--- a/FWCore/Framework/interface/FileBlock.h
+++ b/FWCore/Framework/interface/FileBlock.h
@@ -18,7 +18,7 @@ class TTree;
 #include <vector>
 
 namespace edm {
-  class BranchDescription;
+  class ProductDescription;
   class FileBlock {
   public:
     // bit mask for reasons fast cloning can be disabled or not applicable

--- a/FWCore/Framework/interface/GetterOfProducts.h
+++ b/FWCore/Framework/interface/GetterOfProducts.h
@@ -26,7 +26,7 @@ This method can select by type and branch type.
 There exists a predicate (in ProcessMatch.h)
 to also select on process name.  It is possible
 to write other predicates which will select on
-anything in the BranchDescription. The selection
+anything in the ProductDescription. The selection
 is done during the initialization of the process.
 During this initialization a list of tokens
 is filled with all matching products from the
@@ -78,7 +78,7 @@ There are some variants for special cases
   only tricky part is to use a lambda as follows to register the
   callbacks:
 
-    callWhenNewProductsRegistered([this](edm::BranchDescription const& bd) {
+    callWhenNewProductsRegistered([this](edm::ProductDescription const& bd) {
       getterOfProducts1_(bd);
       getterOfProducts2_(bd);
     });
@@ -88,7 +88,7 @@ There are some variants for special cases
 
   - You can define your own predicate to replace ProcessMatch
   in the above example and select based on anything in the
-  BranchDescription. See ProcessMatch.h for an example of how
+  ProductDescription. See ProcessMatch.h for an example of how
   to write this predicate.
 
 \author W. David Dagenhart, created 6 August, 2012
@@ -96,7 +96,7 @@ There are some variants for special cases
 */
 
 #include "DataFormats/Common/interface/Handle.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventForOutput.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
@@ -157,12 +157,12 @@ namespace edm {
           tokens_(new std::vector<edm::EDGetTokenT<T>>),
           branchType_(branchType) {}
 
-    void operator()(edm::BranchDescription const& branchDescription) {
-      if (branchDescription.dropped())
+    void operator()(edm::ProductDescription const& productDescription) {
+      if (productDescription.dropped())
         return;
-      if (branchDescription.branchType() == branchType_ &&
-          branchDescription.unwrappedTypeID() == edm::TypeID(typeid(T))) {
-        auto const& token = matcher_(branchDescription);
+      if (productDescription.branchType() == branchType_ &&
+          productDescription.unwrappedTypeID() == edm::TypeID(typeid(T))) {
+        auto const& token = matcher_(productDescription);
         if (not token.isUninitialized()) {
           tokens_->push_back(token);
         }
@@ -186,7 +186,7 @@ namespace edm {
     edm::BranchType branchType() const { return branchType_; }
 
   private:
-    std::function<EDGetTokenT<T>(BranchDescription const&)> matcher_;
+    std::function<EDGetTokenT<T>(ProductDescription const&)> matcher_;
     // A shared pointer is needed because objects of this type get assigned
     // to std::function's and we want the copies in those to share the same vector.
     std::shared_ptr<std::vector<edm::EDGetTokenT<T>>> tokens_;

--- a/FWCore/Framework/interface/InputTagMatch.h
+++ b/FWCore/Framework/interface/InputTagMatch.h
@@ -11,7 +11,7 @@ See comments in the file GetterOfProducts.h for a description.
 */
 
 #include "FWCore/Utilities/interface/InputTag.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 
 #include <string>
 
@@ -21,20 +21,20 @@ namespace edm {
   public:
     InputTagMatch(edm::InputTag const& inputTag) : inputTag_(inputTag) {}
 
-    bool operator()(edm::BranchDescription const& branchDescription) {
+    bool operator()(edm::ProductDescription const& productDescription) {
       bool result(true);
       bool match(false);
       if (!inputTag_.label().empty()) {
         match = true;
-        result = (result && branchDescription.moduleLabel() == inputTag_.label());
+        result = (result && productDescription.moduleLabel() == inputTag_.label());
       }
       if (!inputTag_.instance().empty()) {
         match = true;
-        result = (result && branchDescription.productInstanceName() == inputTag_.instance());
+        result = (result && productDescription.productInstanceName() == inputTag_.instance());
       }
       if (!inputTag_.process().empty()) {
         match = true;
-        result = (result && branchDescription.processName() == inputTag_.process());
+        result = (result && productDescription.processName() == inputTag_.process());
       }
       if (match)
         return result;

--- a/FWCore/Framework/interface/LuminosityBlockPrincipal.h
+++ b/FWCore/Framework/interface/LuminosityBlockPrincipal.h
@@ -71,7 +71,7 @@ namespace edm {
 
     void mergeAuxiliary(LuminosityBlockAuxiliary const& aux) { return aux_.mergeAuxiliary(aux); }
 
-    void put(BranchDescription const& bd, std::unique_ptr<WrapperBase> edp) const;
+    void put(ProductDescription const& bd, std::unique_ptr<WrapperBase> edp) const;
 
     void put(ProductResolverIndex index, std::unique_ptr<WrapperBase> edp) const;
 

--- a/FWCore/Framework/interface/ModuleLabelMatch.h
+++ b/FWCore/Framework/interface/ModuleLabelMatch.h
@@ -10,7 +10,7 @@ See comments in the file GetterOfProducts.h for a description.
 
 */
 
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 
 #include <string>
 
@@ -20,8 +20,8 @@ namespace edm {
   public:
     ModuleLabelMatch(std::string const& moduleLabel) : moduleLabel_(moduleLabel) {}
 
-    bool operator()(edm::BranchDescription const& branchDescription) {
-      return branchDescription.moduleLabel() == moduleLabel_;
+    bool operator()(edm::ProductDescription const& productDescription) {
+      return productDescription.moduleLabel() == moduleLabel_;
     }
 
   private:

--- a/FWCore/Framework/interface/OccurrenceForOutput.h
+++ b/FWCore/Framework/interface/OccurrenceForOutput.h
@@ -37,7 +37,7 @@ namespace edmtest {
 
 namespace edm {
 
-  class BranchDescription;
+  class ProductDescription;
   class ModuleCallingContext;
   class Principal;
   class EDConsumerBase;
@@ -69,7 +69,7 @@ namespace edm {
 
     void getAllStableProvenance(std::vector<StableProvenance const*>& provenances) const;
 
-    std::vector<BranchDescription const*> productDescriptions() const;
+    std::vector<ProductDescription const*> productDescriptions() const;
     ProductRegistry const& productRegistry() const;
 
     virtual ProcessHistory const& processHistory() const;

--- a/FWCore/Framework/interface/OccurrenceForOutput.h
+++ b/FWCore/Framework/interface/OccurrenceForOutput.h
@@ -17,6 +17,7 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/Provenance/interface/BranchListIndex.h"
+#include "DataFormats/Provenance/interface/ProductDescriptionFwd.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/PrincipalGetAdapter.h"
@@ -37,7 +38,6 @@ namespace edmtest {
 
 namespace edm {
 
-  class ProductDescription;
   class ModuleCallingContext;
   class Principal;
   class EDConsumerBase;

--- a/FWCore/Framework/interface/OutputModuleCore.h
+++ b/FWCore/Framework/interface/OutputModuleCore.h
@@ -29,7 +29,7 @@
 #include <set>
 
 // user include files
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/Provenance/interface/BranchID.h"
 #include "DataFormats/Provenance/interface/BranchIDList.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
@@ -91,7 +91,7 @@ namespace edm {
       /// -1 is used for unlimited.
       int remainingEvents() const { return remainingEvents_; }
 
-      bool selected(BranchDescription const& desc) const;
+      bool selected(ProductDescription const& desc) const;
 
       void selectProducts(ProductRegistry const& preg, ThinnedAssociationsHelper const&, ProcessBlockHelperBase const&);
       std::string const& processName() const { return process_name_; }
@@ -115,7 +115,7 @@ namespace edm {
 
       const ModuleDescription& moduleDescription() const { return moduleDescription_; }
 
-      void callWhenNewProductsRegistered(std::function<void(BranchDescription const&)> const& func) {
+      void callWhenNewProductsRegistered(std::function<void(ProductDescription const&)> const& func) {
         callWhenNewProductsRegistered_ = func;
       }
 
@@ -165,10 +165,10 @@ namespace edm {
       // newly-introduced interface.
       // TODO: Consider using shared pointers here?
 
-      // keptProducts_ are pointers to the BranchDescription objects describing
+      // keptProducts_ are pointers to the ProductDescription objects describing
       // the branches we are to write.
       //
-      // We do not own the BranchDescriptions to which we point.
+      // We do not own the ProductDescriptions to which we point.
       SelectedProductsForBranchType keptProducts_;
       std::array<bool, NumBranchTypes> hasNewlyDroppedBranch_;
 
@@ -197,7 +197,7 @@ namespace edm {
 
       OutputProcessBlockHelper outputProcessBlockHelper_;
 
-      std::function<void(BranchDescription const&)> callWhenNewProductsRegistered_;
+      std::function<void(ProductDescription const&)> callWhenNewProductsRegistered_;
 
       //------------------------------------------------------------------
       // private member functions
@@ -253,8 +253,8 @@ namespace edm {
 
       bool hasAccumulator() const noexcept { return false; }
 
-      void keepThisBranch(BranchDescription const& desc,
-                          std::map<BranchID, BranchDescription const*>& trueBranchIDToKeptBranchDesc,
+      void keepThisBranch(ProductDescription const& desc,
+                          std::map<BranchID, ProductDescription const*>& trueBranchIDToKeptBranchDesc,
                           std::set<BranchID>& keptProductsInEvent);
 
       void setModuleDescription(ModuleDescription const& md) { moduleDescription_ = md; }

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -137,7 +137,7 @@ namespace edm {
     ProcessConfiguration const& processConfiguration() const { return *processConfiguration_; }
 
     ProductRegistry const& productRegistry() const { return *preg_; }
-    std::vector<BranchDescription const*> productDescriptions() const;
+    std::vector<ProductDescription const*> productDescriptions() const;
 
     ProductResolverIndexHelper const& productLookup() const { return *productLookup_; }
 
@@ -204,7 +204,7 @@ namespace edm {
     ProductResolverBase const* getExistingProduct(BranchID const& branchID) const;
     ProductResolverBase const* getExistingProduct(ProductResolverBase const& phb) const;
 
-    void put_(BranchDescription const& bd, std::unique_ptr<WrapperBase> edp) const;
+    void put_(ProductDescription const& bd, std::unique_ptr<WrapperBase> edp) const;
 
     //F must take an argument of type ProductResolverBase*
     template <typename F>
@@ -219,7 +219,7 @@ namespace edm {
     virtual void changedIndexes_() {}
 
     //called by adjustIndexesAfterProductRegistryAddition
-    void addDroppedProduct(BranchDescription const& bd);
+    void addDroppedProduct(ProductDescription const& bd);
 
     WrapperBase const* getIt(ProductID const&) const override;
     std::optional<std::tuple<WrapperBase const*, unsigned int>> getThinnedProduct(ProductID const&,

--- a/FWCore/Framework/interface/PrincipalGetAdapter.h
+++ b/FWCore/Framework/interface/PrincipalGetAdapter.h
@@ -160,7 +160,7 @@ namespace edm {
 
     Principal const& principal() const { return principal_; }
 
-    BranchDescription const& getBranchDescription(TypeID const& type, std::string const& productInstanceName) const;
+    ProductDescription const& getProductDescription(TypeID const& type, std::string const& productInstanceName) const;
 
     EDPutToken::value_type getPutTokenIndex(TypeID const& type, std::string const& productInstanceName) const;
 
@@ -168,7 +168,7 @@ namespace edm {
     std::string const& productInstanceLabel(EDPutToken) const;
     typedef std::vector<BasicHandle> BasicHandleVec;
 
-    BranchDescription const& getBranchDescription(unsigned int iPutTokenIndex) const;
+    ProductDescription const& getProductDescription(unsigned int iPutTokenIndex) const;
     ProductID const& getProductID(unsigned int iPutTokenIndex) const;
     ModuleDescription const& moduleDescription() const { return md_; }
 

--- a/FWCore/Framework/interface/ProcessMatch.h
+++ b/FWCore/Framework/interface/ProcessMatch.h
@@ -10,7 +10,7 @@ See comments in the file GetterOfProducts.h for a description.
 
 */
 
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 
 #include <string>
 
@@ -20,8 +20,8 @@ namespace edm {
   public:
     ProcessMatch(std::string const& processName) : processName_(processName) {}
 
-    bool operator()(edm::BranchDescription const& branchDescription) {
-      return branchDescription.processName() == processName_ || processName_ == "*";
+    bool operator()(edm::ProductDescription const& productDescription) {
+      return productDescription.processName() == processName_ || processName_ == "*";
     }
 
   private:

--- a/FWCore/Framework/interface/ProducerBase.h
+++ b/FWCore/Framework/interface/ProducerBase.h
@@ -11,6 +11,7 @@ EDProducts into an Event.
 #include "FWCore/Framework/interface/ProductRegistryHelper.h"
 #include "FWCore/Framework/interface/ProducesCollector.h"
 #include "FWCore/Utilities/interface/ProductResolverIndex.h"
+#include "DataFormats/Provenance/interface/ProductDescriptionFwd.h"
 
 #include <functional>
 #include <unordered_map>
@@ -19,7 +20,6 @@ EDProducts into an Event.
 #include <array>
 
 namespace edm {
-  class ProductDescription;
   class ModuleDescription;
   class ProducesCollector;
   class SignallingProductRegistry;

--- a/FWCore/Framework/interface/ProducerBase.h
+++ b/FWCore/Framework/interface/ProducerBase.h
@@ -19,7 +19,7 @@ EDProducts into an Event.
 #include <array>
 
 namespace edm {
-  class BranchDescription;
+  class ProductDescription;
   class ModuleDescription;
   class ProducesCollector;
   class SignallingProductRegistry;
@@ -74,7 +74,7 @@ namespace edm {
     ~ProducerBase() noexcept(false) override;
 
     /// used by the fwk to register list of products
-    std::function<void(BranchDescription const&)> registrationCallback() const;
+    std::function<void(ProductDescription const&)> registrationCallback() const;
 
     void registerProducts(ProducerBase*, SignallingProductRegistry*, ModuleDescription const&);
 
@@ -84,7 +84,7 @@ namespace edm {
     template <typename T>
     using BranchAliasSetterT = ProductRegistryHelper::BranchAliasSetterT<T>;
 
-    void callWhenNewProductsRegistered(std::function<void(BranchDescription const&)> const& func) {
+    void callWhenNewProductsRegistered(std::function<void(ProductDescription const&)> const& func) {
       callWhenNewProductsRegistered_ = func;
     }
 
@@ -130,7 +130,7 @@ namespace edm {
 
     using ProductRegistryHelper::transforms;
 
-    std::function<void(BranchDescription const&)> callWhenNewProductsRegistered_;
+    std::function<void(ProductDescription const&)> callWhenNewProductsRegistered_;
     std::array<std::vector<edm::ProductResolverIndex>, edm::NumBranchTypes> putIndicies_;
     std::vector<edm::ProductResolverIndex> putTokenToResolverIndex_;
   };

--- a/FWCore/Framework/interface/ProductResolverBase.h
+++ b/FWCore/Framework/interface/ProductResolverBase.h
@@ -10,7 +10,7 @@ ProductResolver: Class to handle access to a WrapperBase and its related informa
 
 #include "DataFormats/Common/interface/WrapperBase.h"
 #include "DataFormats/Common/interface/ProductData.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/Provenance/interface/BranchID.h"
 #include "DataFormats/Provenance/interface/Provenance.h"
 #include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
@@ -107,16 +107,16 @@ namespace edm {
     ProductProvenance const* productProvenancePtr() const { return productProvenancePtr_(); }
 
     // Retrieves a reference to the event independent provenance.
-    BranchDescription const& branchDescription() const { return branchDescription_(); }
+    ProductDescription const& productDescription() const { return productDescription_(); }
 
     // Retrieves a reference to the event independent provenance.
     bool singleProduct() const { return singleProduct_(); }
 
     // Sets the pointer to the event independent provenance.
-    void resetBranchDescription(std::shared_ptr<BranchDescription const> bd) { resetBranchDescription_(bd); }
+    void resetProductDescription(std::shared_ptr<ProductDescription const> bd) { resetProductDescription_(bd); }
 
     // Retrieves a reference to the module label.
-    std::string const& moduleLabel() const { return branchDescription().moduleLabel(); }
+    std::string const& moduleLabel() const { return productDescription().moduleLabel(); }
 
     // Same as moduleLabel except in the case of an AliasProductResolver, in which
     // case it resolves the module which actually produces the product and returns
@@ -124,10 +124,10 @@ namespace edm {
     std::string const& resolvedModuleLabel() const { return resolvedModuleLabel_(); }
 
     // Retrieves a reference to the product instance name
-    std::string const& productInstanceName() const { return branchDescription().productInstanceName(); }
+    std::string const& productInstanceName() const { return productDescription().productInstanceName(); }
 
     // Retrieves a reference to the process name
-    std::string const& processName() const { return branchDescription().processName(); }
+    std::string const& processName() const { return productDescription().processName(); }
 
     // Retrieves pointer to a class containing both the event independent and the per even provenance.
     Provenance const* provenance() const;
@@ -183,8 +183,8 @@ namespace edm {
     virtual bool productWasDeleted_() const = 0;
     virtual bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const = 0;
 
-    virtual BranchDescription const& branchDescription_() const = 0;
-    virtual void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) = 0;
+    virtual ProductDescription const& productDescription_() const = 0;
+    virtual void resetProductDescription_(std::shared_ptr<ProductDescription const> bd) = 0;
     virtual Provenance const* provenance_() const = 0;
     virtual std::string const& resolvedModuleLabel_() const = 0;
     virtual void setProductProvenanceRetriever_(ProductProvenanceRetriever const* provRetriever) = 0;

--- a/FWCore/Framework/interface/ProductSelector.h
+++ b/FWCore/Framework/interface/ProductSelector.h
@@ -10,6 +10,7 @@
 //////////////////////////////////////////////////////////////////////
 
 #include "DataFormats/Provenance/interface/BranchID.h"
+#include "DataFormats/Provenance/interface/ProductDescriptionFwd.h"
 
 #include <iosfwd>
 #include <map>
@@ -17,8 +18,6 @@
 #include <vector>
 
 namespace edm {
-  class ProductDescription;
-  class BranchID;
   class ProductRegistry;
   class ProductSelectorRules;
   class ParameterSet;
@@ -28,7 +27,8 @@ namespace edm {
     ProductSelector();
 
     // N.B.: we assume there are not null pointers in the vector allBranches.
-    void initialize(ProductSelectorRules const& rules, std::vector<ProductDescription const*> const& productDescriptions);
+    void initialize(ProductSelectorRules const& rules,
+                    std::vector<ProductDescription const*> const& productDescriptions);
 
     bool selected(ProductDescription const& desc) const;
 
@@ -37,8 +37,8 @@ namespace edm {
 
     bool initialized() const { return initialized_; }
 
-    static void checkForDuplicateKeptBranch(ProductDescription const& desc,
-                                            std::map<BranchID, ProductDescription const*>& trueBranchIDToKeptBranchDesc);
+    static void checkForDuplicateKeptBranch(
+        ProductDescription const& desc, std::map<BranchID, ProductDescription const*>& trueBranchIDToKeptBranchDesc);
 
     static void fillDroppedToKept(ProductRegistry const& preg,
                                   std::map<BranchID, ProductDescription const*> const& trueBranchIDToKeptBranchDesc,

--- a/FWCore/Framework/interface/ProductSelector.h
+++ b/FWCore/Framework/interface/ProductSelector.h
@@ -17,7 +17,7 @@
 #include <vector>
 
 namespace edm {
-  class BranchDescription;
+  class ProductDescription;
   class BranchID;
   class ProductRegistry;
   class ProductSelectorRules;
@@ -28,29 +28,29 @@ namespace edm {
     ProductSelector();
 
     // N.B.: we assume there are not null pointers in the vector allBranches.
-    void initialize(ProductSelectorRules const& rules, std::vector<BranchDescription const*> const& branchDescriptions);
+    void initialize(ProductSelectorRules const& rules, std::vector<ProductDescription const*> const& productDescriptions);
 
-    bool selected(BranchDescription const& desc) const;
+    bool selected(ProductDescription const& desc) const;
 
     // Printout intended for debugging purposes.
     void print(std::ostream& os) const;
 
     bool initialized() const { return initialized_; }
 
-    static void checkForDuplicateKeptBranch(BranchDescription const& desc,
-                                            std::map<BranchID, BranchDescription const*>& trueBranchIDToKeptBranchDesc);
+    static void checkForDuplicateKeptBranch(ProductDescription const& desc,
+                                            std::map<BranchID, ProductDescription const*>& trueBranchIDToKeptBranchDesc);
 
     static void fillDroppedToKept(ProductRegistry const& preg,
-                                  std::map<BranchID, BranchDescription const*> const& trueBranchIDToKeptBranchDesc,
+                                  std::map<BranchID, ProductDescription const*> const& trueBranchIDToKeptBranchDesc,
                                   std::map<BranchID::value_type, BranchID::value_type>& droppedBranchIDToKeptBranchID_);
 
   private:
     // We keep a sorted collection of branch names, indicating the
     // products which are to be selected.
 
-    // TODO: See if we can keep pointer to (const) BranchDescriptions,
+    // TODO: See if we can keep pointer to (const) ProductDescriptions,
     // so that we can do pointer comparison rather than string
-    // comparison. This will work if the BranchDescription we are
+    // comparison. This will work if the ProductDescription we are
     // given in the 'selected' member function is one of the instances
     // that are managed by the ProductRegistry used to initialize the
     // entity that contains this ProductSelector.

--- a/FWCore/Framework/interface/ProductSelectorRules.h
+++ b/FWCore/Framework/interface/ProductSelectorRules.h
@@ -16,7 +16,7 @@
 #include <regex>
 
 namespace edm {
-  class BranchDescription;
+  class ProductDescription;
   class ProductSelector;
   class ParameterSet;
   class ParameterSetDescription;
@@ -27,18 +27,18 @@ namespace edm {
                          std::string const& parameterName,
                          std::string const& parameterOwnerName);
     //--------------------------------------------------
-    // BranchSelectState is a struct which associates a BranchDescription
+    // BranchSelectState is a struct which associates a ProductDescription
     // (*desc) with a bool indicating whether or not the branch with
     // that name is to be selected.  Note that desc may not be null.
     struct BranchSelectState {
-      edm::BranchDescription const* desc;
+      edm::ProductDescription const* desc;
       bool selectMe;
 
       // N.B.: We assume bd is not null.
-      explicit BranchSelectState(edm::BranchDescription const* bd) : desc(bd), selectMe(false) {}
+      explicit BranchSelectState(edm::ProductDescription const* bd) : desc(bd), selectMe(false) {}
     };
 
-    bool select(edm::BranchDescription const& bd) const;
+    bool select(edm::ProductDescription const& bd) const;
     void applyToAll(std::vector<BranchSelectState>& branchstates) const;
 
     bool keepAll() const { return keepAll_; }
@@ -58,19 +58,19 @@ namespace edm {
       // the given branch states.
       void applyToAll(std::vector<BranchSelectState>& branchstates) const;
 
-      // Apply the rule to the given BranchDescription. The return value
+      // Apply the rule to the given ProductDescription. The return value
       // is the value to which the 'select bit' should be set, according
       // to application of this rule.
-      //bool applyToOne(BranchDescription const* branch) const;
+      //bool applyToOne(ProductDescription const* branch) const;
 
-      // If this rule applies to the given BranchDescription, then
+      // If this rule applies to the given ProductDescription, then
       // modify 'result' to match the rule's select flag. If the rule does
       // not apply, do not modify 'result'.
-      void applyToOne(BranchDescription const* branch, bool& result) const;
+      void applyToOne(ProductDescription const* branch, bool& result) const;
 
       // Return the answer to the question: "Does the rule apply to this
-      // BranchDescription?"
-      bool appliesTo(BranchDescription const* branch) const;
+      // ProductDescription?"
+      bool appliesTo(ProductDescription const* branch) const;
 
     private:
       // selectflag_ carries the value to which we should set the 'select

--- a/FWCore/Framework/interface/ProductSelectorRules.h
+++ b/FWCore/Framework/interface/ProductSelectorRules.h
@@ -14,9 +14,9 @@
 #include <vector>
 
 #include <regex>
+#include "DataFormats/Provenance/interface/ProductDescriptionFwd.h"
 
 namespace edm {
-  class ProductDescription;
   class ProductSelector;
   class ParameterSet;
   class ParameterSetDescription;

--- a/FWCore/Framework/interface/RunPrincipal.h
+++ b/FWCore/Framework/interface/RunPrincipal.h
@@ -80,11 +80,11 @@ namespace edm {
 
     void mergeAuxiliary(RunAuxiliary const& aux) { return aux_.mergeAuxiliary(aux); }
 
-    void put(BranchDescription const& bd, std::unique_ptr<WrapperBase> edp) const;
+    void put(ProductDescription const& bd, std::unique_ptr<WrapperBase> edp) const;
 
     void put(ProductResolverIndex index, std::unique_ptr<WrapperBase> edp) const;
 
-    void putOrMerge(BranchDescription const& bd, std::unique_ptr<WrapperBase> edp) const;
+    void putOrMerge(ProductDescription const& bd, std::unique_ptr<WrapperBase> edp) const;
 
     MergeableRunProductMetadata* mergeableRunProductMetadata() { return mergeableRunProductMetadataPtr_.get(); }
 

--- a/FWCore/Framework/interface/SignallingProductRegistry.h
+++ b/FWCore/Framework/interface/SignallingProductRegistry.h
@@ -35,7 +35,7 @@ namespace edm {
     SignallingProductRegistry() : ProductRegistry(), productAddedSignal_(), typeAddedStack_() {}
     explicit SignallingProductRegistry(ProductRegistry const& preg)
         : ProductRegistry(preg.productList(), false), productAddedSignal_(), typeAddedStack_() {}
-    signalslot::Signal<void(BranchDescription const&)> productAddedSignal_;
+    signalslot::Signal<void(ProductDescription const&)> productAddedSignal_;
 
     SignallingProductRegistry(SignallingProductRegistry const&) = delete;             // Disallow copying and moving
     SignallingProductRegistry& operator=(SignallingProductRegistry const&) = delete;  // Disallow copying and moving
@@ -51,7 +51,7 @@ namespace edm {
     }
 
   private:
-    void addCalled(BranchDescription const&, bool) override;
+    void addCalled(ProductDescription const&, bool) override;
     // ---------- member data --------------------------------
     std::map<std::string, unsigned int> typeAddedStack_;
   };

--- a/FWCore/Framework/interface/StreamSchedule.h
+++ b/FWCore/Framework/interface/StreamSchedule.h
@@ -257,7 +257,7 @@ namespace edm {
     std::vector<Worker*> tryToPlaceConditionalModules(
         Worker*,
         std::unordered_set<std::string>& conditionalModules,
-        std::unordered_multimap<std::string, edm::BranchDescription const*> const& conditionalModuleBranches,
+        std::unordered_multimap<std::string, edm::ProductDescription const*> const& conditionalModuleBranches,
         std::unordered_multimap<std::string, AliasInfo> const& aliasMap,
         ParameterSet& proc_pset,
         SignallingProductRegistry& preg,

--- a/FWCore/Framework/interface/SubProcess.h
+++ b/FWCore/Framework/interface/SubProcess.h
@@ -2,6 +2,7 @@
 #define FWCore_Framework_SubProcess_h
 
 #include "DataFormats/Provenance/interface/BranchID.h"
+#include "DataFormats/Provenance/interface/ProductDescriptionFwd.h"
 #include "FWCore/Common/interface/FWCoreCommonFwd.h"
 #include "FWCore/Framework/interface/EventSetupProvider.h"
 #include "FWCore/Framework/interface/EDConsumerBase.h"
@@ -30,7 +31,6 @@
 
 namespace edm {
   class ActivityRegistry;
-  class ProductDescription;
   class BranchIDListHelper;
   class EventPrincipal;
   class EventSetupImpl;

--- a/FWCore/Framework/interface/SubProcess.h
+++ b/FWCore/Framework/interface/SubProcess.h
@@ -30,7 +30,7 @@
 
 namespace edm {
   class ActivityRegistry;
-  class BranchDescription;
+  class ProductDescription;
   class BranchIDListHelper;
   class EventPrincipal;
   class EventSetupImpl;
@@ -250,8 +250,8 @@ namespace edm {
     bool parentProducedProductIsKept(Principal const& parentPrincipal, Principal& principal) const;
     void fixBranchIDListsForEDAliases(
         std::map<BranchID::value_type, BranchID::value_type> const& droppedBranchIDToKeptBranchID);
-    void keepThisBranch(BranchDescription const& desc,
-                        std::map<BranchID, BranchDescription const*>& trueBranchIDToKeptBranchDesc,
+    void keepThisBranch(ProductDescription const& desc,
+                        std::map<BranchID, ProductDescription const*>& trueBranchIDToKeptBranchDesc,
                         std::set<BranchID>& keptProductsInEvent);
 
     std::map<BranchID::value_type, BranchID::value_type> const& droppedBranchIDToKeptBranchID() {
@@ -296,10 +296,10 @@ namespace edm {
     std::vector<SubProcess> subProcesses_;
     edm::propagate_const<std::unique_ptr<ParameterSet>> processParameterSet_;
 
-    // keptProducts_ are pointers to the BranchDescription objects describing
+    // keptProducts_ are pointers to the ProductDescription objects describing
     // the branches we are to write.
     //
-    // We do not own the BranchDescriptions to which we point.
+    // We do not own the ProductDescriptions to which we point.
     SelectedProductsForBranchType keptProducts_;
     ProductSelectorRules productSelectorRules_;
     ProductSelector productSelector_;

--- a/FWCore/Framework/interface/TransformerBase.h
+++ b/FWCore/Framework/interface/TransformerBase.h
@@ -13,6 +13,7 @@
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "FWCore/Utilities/interface/TypeID.h"
 #include "FWCore/Utilities/interface/ProductResolverIndex.h"
+#include "DataFormats/Provenance/interface/ProductDescriptionFwd.h"
 
 #include <string>
 #include <functional>
@@ -24,7 +25,6 @@ namespace edm {
   class TypeID;
   class WrapperBase;
   class EventForTransformer;
-  class ProductDescription;
   class ProductResolverIndexHelper;
   class ModuleDescription;
   class WaitingTaskWithArenaHolder;

--- a/FWCore/Framework/interface/TransformerBase.h
+++ b/FWCore/Framework/interface/TransformerBase.h
@@ -24,7 +24,7 @@ namespace edm {
   class TypeID;
   class WrapperBase;
   class EventForTransformer;
-  class BranchDescription;
+  class ProductDescription;
   class ProductResolverIndexHelper;
   class ModuleDescription;
   class WaitingTaskWithArenaHolder;
@@ -47,7 +47,7 @@ namespace edm {
     void registerTransformAsyncImp(
         ProducerBase&, EDPutToken, const TypeID& id, std::string instanceName, PreTransformFunction, TransformFunction);
 
-    std::size_t findMatchingIndex(ProducerBase const& iBase, edm::BranchDescription const&) const noexcept;
+    std::size_t findMatchingIndex(ProducerBase const& iBase, edm::ProductDescription const&) const noexcept;
     ProductResolverIndex prefetchImp(std::size_t iIndex) const noexcept {
       return transformInfo_.get<kResolverIndex>(iIndex);
     }

--- a/FWCore/Framework/interface/TypeMatch.h
+++ b/FWCore/Framework/interface/TypeMatch.h
@@ -12,13 +12,13 @@ duplication can occur when an EDAlias is involved.
 
 */
 
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 
 namespace edm {
   class TypeMatch {
   public:
-    bool operator()(edm::BranchDescription const& branchDescription) const {
-      return not branchDescription.isAnyAlias();
+    bool operator()(edm::ProductDescription const& productDescription) const {
+      return not productDescription.isAnyAlias();
     }
   };
 }  // namespace edm

--- a/FWCore/Framework/interface/WillGetIfMatch.h
+++ b/FWCore/Framework/interface/WillGetIfMatch.h
@@ -27,8 +27,9 @@ namespace edm {
     EDGetTokenT<T> operator()(ProductDescription const& productDescription) {
       if (match_(productDescription)) {
         auto transition = productDescription.branchType();
-        edm::InputTag tag{
-            productDescription.moduleLabel(), productDescription.productInstanceName(), productDescription.processName()};
+        edm::InputTag tag{productDescription.moduleLabel(),
+                          productDescription.productInstanceName(),
+                          productDescription.processName()};
         if (transition == edm::InEvent) {
           return module_->template consumes<T>(tag);
         } else if (transition == edm::InLumi) {

--- a/FWCore/Framework/interface/WillGetIfMatch.h
+++ b/FWCore/Framework/interface/WillGetIfMatch.h
@@ -11,7 +11,7 @@ See comments in the file GetterOfProducts.h.
 */
 
 #include <functional>
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "FWCore/Framework/interface/EDConsumerBase.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
@@ -24,11 +24,11 @@ namespace edm {
     template <typename U>
     WillGetIfMatch(U const& match, EDConsumerBase* module) : match_(match), module_(module) {}
 
-    EDGetTokenT<T> operator()(BranchDescription const& branchDescription) {
-      if (match_(branchDescription)) {
-        auto transition = branchDescription.branchType();
+    EDGetTokenT<T> operator()(ProductDescription const& productDescription) {
+      if (match_(productDescription)) {
+        auto transition = productDescription.branchType();
         edm::InputTag tag{
-            branchDescription.moduleLabel(), branchDescription.productInstanceName(), branchDescription.processName()};
+            productDescription.moduleLabel(), productDescription.productInstanceName(), productDescription.processName()};
         if (transition == edm::InEvent) {
           return module_->template consumes<T>(tag);
         } else if (transition == edm::InLumi) {
@@ -43,7 +43,7 @@ namespace edm {
     }
 
   private:
-    std::function<bool(BranchDescription const&)> match_;
+    std::function<bool(ProductDescription const&)> match_;
     EDConsumerBase* module_;
   };
 }  // namespace edm

--- a/FWCore/Framework/interface/global/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/global/EDAnalyzerBase.h
@@ -69,7 +69,7 @@ namespace edm {
       virtual bool wantsStreamRuns() const noexcept = 0;
       virtual bool wantsStreamLuminosityBlocks() const noexcept = 0;
 
-      void callWhenNewProductsRegistered(std::function<void(BranchDescription const&)> const& func) {
+      void callWhenNewProductsRegistered(std::function<void(ProductDescription const&)> const& func) {
         callWhenNewProductsRegistered_ = func;
       }
 
@@ -146,7 +146,7 @@ namespace edm {
       void setModuleDescription(ModuleDescription const& md) { moduleDescription_ = md; }
       ModuleDescription moduleDescription_;
 
-      std::function<void(BranchDescription const&)> callWhenNewProductsRegistered_;
+      std::function<void(ProductDescription const&)> callWhenNewProductsRegistered_;
     };
 
   }  // namespace global

--- a/FWCore/Framework/interface/global/EDFilterBase.h
+++ b/FWCore/Framework/interface/global/EDFilterBase.h
@@ -154,7 +154,7 @@ namespace edm {
       virtual void doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
       virtual void doEndLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
 
-      virtual size_t transformIndex_(edm::BranchDescription const& iBranch) const noexcept;
+      virtual size_t transformIndex_(edm::ProductDescription const& iBranch) const noexcept;
       virtual ProductResolverIndex transformPrefetch_(std::size_t iIndex) const noexcept;
       virtual void transformAsync_(WaitingTaskHolder iTask,
                                    std::size_t iIndex,

--- a/FWCore/Framework/interface/global/EDProducerBase.h
+++ b/FWCore/Framework/interface/global/EDProducerBase.h
@@ -156,7 +156,7 @@ namespace edm {
       virtual void doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
       virtual void doEndLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
 
-      virtual size_t transformIndex_(edm::BranchDescription const& iBranch) const noexcept;
+      virtual size_t transformIndex_(edm::ProductDescription const& iBranch) const noexcept;
       virtual ProductResolverIndex transformPrefetch_(std::size_t iIndex) const noexcept;
       virtual void transformAsync_(WaitingTaskHolder iTask,
                                    std::size_t iIndex,

--- a/FWCore/Framework/interface/global/implementors.h
+++ b/FWCore/Framework/interface/global/implementors.h
@@ -513,7 +513,7 @@ namespace edm {
         }
 
       private:
-        size_t transformIndex_(edm::BranchDescription const& iBranch) const noexcept final {
+        size_t transformIndex_(edm::ProductDescription const& iBranch) const noexcept final {
           return TransformerBase::findMatchingIndex(*this, iBranch);
         }
         ProductResolverIndex transformPrefetch_(std::size_t iIndex) const noexcept final {

--- a/FWCore/Framework/interface/limited/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/limited/EDAnalyzerBase.h
@@ -70,7 +70,7 @@ namespace edm {
       virtual bool wantsStreamRuns() const noexcept = 0;
       virtual bool wantsStreamLuminosityBlocks() const noexcept = 0;
 
-      void callWhenNewProductsRegistered(std::function<void(BranchDescription const&)> const& func) {
+      void callWhenNewProductsRegistered(std::function<void(ProductDescription const&)> const& func) {
         callWhenNewProductsRegistered_ = func;
       }
 
@@ -151,7 +151,7 @@ namespace edm {
       void setModuleDescription(ModuleDescription const& md) { moduleDescription_ = md; }
       ModuleDescription moduleDescription_;
 
-      std::function<void(BranchDescription const&)> callWhenNewProductsRegistered_;
+      std::function<void(ProductDescription const&)> callWhenNewProductsRegistered_;
 
       LimitedTaskQueue queue_;
     };

--- a/FWCore/Framework/interface/limited/EDFilterBase.h
+++ b/FWCore/Framework/interface/limited/EDFilterBase.h
@@ -158,7 +158,7 @@ namespace edm {
       virtual void doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
       virtual void doEndLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
 
-      virtual size_t transformIndex_(edm::BranchDescription const& iBranch) const noexcept;
+      virtual size_t transformIndex_(edm::ProductDescription const& iBranch) const noexcept;
       virtual ProductResolverIndex transformPrefetch_(std::size_t iIndex) const noexcept;
       virtual void transformAsync_(WaitingTaskHolder iTask,
                                    std::size_t iIndex,

--- a/FWCore/Framework/interface/limited/EDProducerBase.h
+++ b/FWCore/Framework/interface/limited/EDProducerBase.h
@@ -161,7 +161,7 @@ namespace edm {
       virtual void doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
       virtual void doEndLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
 
-      virtual size_t transformIndex_(edm::BranchDescription const& iBranch) const noexcept;
+      virtual size_t transformIndex_(edm::ProductDescription const& iBranch) const noexcept;
       virtual ProductResolverIndex transformPrefetch_(std::size_t iIndex) const noexcept;
       virtual void transformAsync_(WaitingTaskHolder iTask,
                                    std::size_t iIndex,

--- a/FWCore/Framework/interface/limited/implementors.h
+++ b/FWCore/Framework/interface/limited/implementors.h
@@ -500,7 +500,7 @@ namespace edm {
         }
 
       private:
-        size_t transformIndex_(edm::BranchDescription const& iBranch) const noexcept final {
+        size_t transformIndex_(edm::ProductDescription const& iBranch) const noexcept final {
           return TransformerBase::findMatchingIndex(*this, iBranch);
         }
         ProductResolverIndex transformPrefetch_(std::size_t iIndex) const noexcept final {

--- a/FWCore/Framework/interface/maker/Worker.h
+++ b/FWCore/Framework/interface/maker/Worker.h
@@ -166,7 +166,7 @@ namespace edm {
                                          ParentContext const&,
                                          typename T::Context const*) noexcept;
 
-    virtual size_t transformIndex(edm::BranchDescription const&) const noexcept = 0;
+    virtual size_t transformIndex(edm::ProductDescription const&) const noexcept = 0;
     void doTransformAsync(WaitingTaskHolder,
                           size_t iTransformIndex,
                           EventPrincipal const&,

--- a/FWCore/Framework/interface/maker/WorkerT.h
+++ b/FWCore/Framework/interface/maker/WorkerT.h
@@ -91,7 +91,7 @@ namespace edm {
 
     void implDoAcquire(EventTransitionInfo const&, ModuleCallingContext const*, WaitingTaskHolder&&) final;
 
-    size_t transformIndex(edm::BranchDescription const&) const noexcept final;
+    size_t transformIndex(edm::ProductDescription const&) const noexcept final;
     void implDoTransformAsync(WaitingTaskHolder,
                               size_t iTransformIndex,
                               EventPrincipal const&,

--- a/FWCore/Framework/interface/one/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/one/EDAnalyzerBase.h
@@ -72,7 +72,7 @@ namespace edm {
 
       virtual SerialTaskQueue* globalRunsQueue();
       virtual SerialTaskQueue* globalLuminosityBlocksQueue();
-      void callWhenNewProductsRegistered(std::function<void(BranchDescription const&)> const& func);
+      void callWhenNewProductsRegistered(std::function<void(ProductDescription const&)> const& func);
 
     private:
       bool doEvent(EventTransitionInfo const&, ActivityRegistry*, ModuleCallingContext const*);
@@ -126,7 +126,7 @@ namespace edm {
 
       void setModuleDescription(ModuleDescription const& md) { moduleDescription_ = md; }
       ModuleDescription moduleDescription_;
-      std::function<void(BranchDescription const&)> callWhenNewProductsRegistered_;
+      std::function<void(ProductDescription const&)> callWhenNewProductsRegistered_;
 
       SharedResourcesAcquirer resourcesAcquirer_;
     };

--- a/FWCore/Framework/interface/one/EDFilterBase.h
+++ b/FWCore/Framework/interface/one/EDFilterBase.h
@@ -134,7 +134,7 @@ namespace edm {
       virtual void doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
       virtual void doEndLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
 
-      virtual size_t transformIndex_(edm::BranchDescription const& iBranch) const noexcept;
+      virtual size_t transformIndex_(edm::ProductDescription const& iBranch) const noexcept;
       virtual ProductResolverIndex transformPrefetch_(std::size_t iIndex) const noexcept;
       virtual void transformAsync_(WaitingTaskHolder iTask,
                                    std::size_t iIndex,

--- a/FWCore/Framework/interface/one/EDProducerBase.h
+++ b/FWCore/Framework/interface/one/EDProducerBase.h
@@ -134,7 +134,7 @@ namespace edm {
       virtual void doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
       virtual void doEndLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
 
-      virtual size_t transformIndex_(edm::BranchDescription const& iBranch) const noexcept;
+      virtual size_t transformIndex_(edm::ProductDescription const& iBranch) const noexcept;
       virtual ProductResolverIndex transformPrefetch_(std::size_t iIndex) const noexcept;
       virtual void transformAsync_(WaitingTaskHolder iTask,
                                    std::size_t iIndex,

--- a/FWCore/Framework/interface/one/implementors.h
+++ b/FWCore/Framework/interface/one/implementors.h
@@ -393,7 +393,7 @@ namespace edm {
         }
 
       private:
-        size_t transformIndex_(edm::BranchDescription const& iBranch) const noexcept final {
+        size_t transformIndex_(edm::ProductDescription const& iBranch) const noexcept final {
           return TransformerBase::findMatchingIndex(*this, iBranch);
         }
         ProductResolverIndex transformPrefetch_(std::size_t iIndex) const noexcept final {

--- a/FWCore/Framework/interface/stream/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerBase.h
@@ -51,7 +51,7 @@ namespace edm {
       // Warning: the returned moduleDescription will be invalid during construction
       ModuleDescription const& moduleDescription() const { return *moduleDescriptionPtr_; }
 
-      void callWhenNewProductsRegistered(std::function<void(BranchDescription const&)> const& func);
+      void callWhenNewProductsRegistered(std::function<void(ProductDescription const&)> const& func);
 
     private:
       void registerProductsAndCallbacks(EDAnalyzerBase const*, SignallingProductRegistry* reg);
@@ -66,7 +66,7 @@ namespace edm {
 
       void setModuleDescriptionPtr(ModuleDescription const* iDesc) { moduleDescriptionPtr_ = iDesc; }
       // ---------- member data --------------------------------
-      std::function<void(BranchDescription const&)> callWhenNewProductsRegistered_;
+      std::function<void(ProductDescription const&)> callWhenNewProductsRegistered_;
       ModuleDescription const* moduleDescriptionPtr_;
     };
 

--- a/FWCore/Framework/interface/stream/EDProducerBase.h
+++ b/FWCore/Framework/interface/stream/EDProducerBase.h
@@ -74,7 +74,7 @@ namespace edm {
       virtual void registerThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) {}
 
       virtual void doAcquire_(Event const&, EventSetup const&, WaitingTaskHolder&&) = 0;
-      virtual size_t transformIndex_(edm::BranchDescription const& iBranch) const noexcept;
+      virtual size_t transformIndex_(edm::ProductDescription const& iBranch) const noexcept;
       virtual ProductResolverIndex transformPrefetch_(std::size_t iIndex) const noexcept;
       virtual void transformAsync_(WaitingTaskHolder iTask,
                                    std::size_t iIndex,

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
@@ -130,7 +130,7 @@ namespace edm {
       std::vector<edm::ProductResolverIndex> const& indiciesForPutProducts(BranchType iBranchType) const;
 
       ProductResolverIndex transformPrefetch_(size_t iTransformIndex) const noexcept;
-      size_t transformIndex_(edm::BranchDescription const& iBranch) const noexcept;
+      size_t transformIndex_(edm::ProductDescription const& iBranch) const noexcept;
       void doTransformAsync(WaitingTaskHolder iTask,
                             size_t iTransformIndex,
                             EventPrincipal const& iEvent,

--- a/FWCore/Framework/interface/stream/ThinningProducer.h
+++ b/FWCore/Framework/interface/stream/ThinningProducer.h
@@ -159,7 +159,7 @@ namespace edm {
 
     ProductRegistry::ProductList const& productList = productRegistry.productList();
     for (auto const& product : productList) {
-      BranchDescription const& desc = product.second;
+      ProductDescription const& desc = product.second;
       if (desc.dropped()) {
         // Dropped branch does not have type information, but they can
         // be ignored here because all of the parent/thinned/association

--- a/FWCore/Framework/interface/stream/implementors.h
+++ b/FWCore/Framework/interface/stream/implementors.h
@@ -367,7 +367,7 @@ namespace edm {
         }
 
       private:
-        size_t transformIndex_(edm::BranchDescription const& iBranch) const noexcept final {
+        size_t transformIndex_(edm::ProductDescription const& iBranch) const noexcept final {
           return TransformerBase::findMatchingIndex(*this, iBranch);
         }
         ProductResolverIndex transformPrefetch_(std::size_t iIndex) const noexcept final {

--- a/FWCore/Framework/src/DroppedDataProductResolver.h
+++ b/FWCore/Framework/src/DroppedDataProductResolver.h
@@ -12,7 +12,7 @@ DroppedDataProductResolver: Handles case of a DataProduct which was dropped on o
 namespace edm {
   class DroppedDataProductResolver : public ProductResolverBase {
   public:
-    DroppedDataProductResolver(std::shared_ptr<BranchDescription const> bd)
+    DroppedDataProductResolver(std::shared_ptr<ProductDescription const> bd)
         : ProductResolverBase(), m_provenance(std::move(bd), {}) {}
 
     void connectTo(ProductResolverBase const&, Principal const*) final {}
@@ -37,9 +37,9 @@ namespace edm {
     bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const final { return false; }
     bool unscheduledWasNotRun_() const final { return false; }
     void resetProductData_(bool deleteEarly) final {}
-    BranchDescription const& branchDescription_() const final { return m_provenance.branchDescription(); }
-    void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) final {
-      m_provenance.setBranchDescription(bd);
+    ProductDescription const& productDescription_() const final { return m_provenance.productDescription(); }
+    void resetProductDescription_(std::shared_ptr<ProductDescription const> bd) final {
+      m_provenance.setProductDescription(bd);
     }
     Provenance const* provenance_() const final { return &m_provenance; }
 

--- a/FWCore/Framework/src/Event.cc
+++ b/FWCore/Framework/src/Event.cc
@@ -105,7 +105,7 @@ namespace edm {
 
   EDProductGetter const& Event::productGetter() const { return provRecorder_.principal(); }
 
-  ProductID Event::makeProductID(BranchDescription const& desc) const {
+  ProductID Event::makeProductID(ProductDescription const& desc) const {
     return eventPrincipal().branchIDToProductID(desc.originalBranchID());
   }
 

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -161,7 +161,7 @@ namespace edm {
         //  If not, then we've internally changed the original BranchID to the alias BranchID
         //  in the ProductID lookup so we need the alias BranchID.
 
-        auto const& bd = prod->branchDescription();
+        auto const& bd = prod->productDescription();
         prod->setProductID(branchIDToProductID(bd.isAlias() ? bd.originalBranchID() : bd.branchID()));
       }
     }
@@ -178,7 +178,7 @@ namespace edm {
 
   RunPrincipal const& EventPrincipal::runPrincipal() const { return luminosityBlockPrincipal().runPrincipal(); }
 
-  void EventPrincipal::put(BranchDescription const& bd,
+  void EventPrincipal::put(ProductDescription const& bd,
                            std::unique_ptr<WrapperBase> edp,
                            ProductProvenance const& productProvenance) const {
     // assert commented out for DaqSource.  When DaqSource no longer uses put(), the assert can be restored.
@@ -201,14 +201,14 @@ namespace edm {
     }
     auto phb = getProductResolverByIndex(index);
 
-    productProvenanceRetrieverPtr()->insertIntoSet(ProductProvenance(phb->branchDescription().branchID(), parentage));
+    productProvenanceRetrieverPtr()->insertIntoSet(ProductProvenance(phb->productDescription().branchID(), parentage));
 
     assert(phb);
     // ProductResolver assumes ownership
     dynamic_cast<ProductPutterBase const*>(phb)->putProduct(std::move(edp));
   }
 
-  void EventPrincipal::putOnRead(BranchDescription const& bd,
+  void EventPrincipal::putOnRead(ProductDescription const& bd,
                                  std::unique_ptr<WrapperBase> edp,
                                  std::optional<ProductProvenance> productProvenance) const {
     assert(!bd.produced());

--- a/FWCore/Framework/src/LuminosityBlock.cc
+++ b/FWCore/Framework/src/LuminosityBlock.cc
@@ -94,7 +94,7 @@ namespace edm {
       for (auto index : iShouldPut) {
         auto resolver = p.getProductResolverByIndex(index);
         if (not resolver->productResolved() and isEndTransition(provRecorder_.transition()) ==
-                                                    resolver->branchDescription().availableOnlyAtEndTransition()) {
+                                                    resolver->productDescription().availableOnlyAtEndTransition()) {
           dynamic_cast<ProductPutterBase const*>(resolver)->putProduct(std::unique_ptr<WrapperBase>());
         }
       }

--- a/FWCore/Framework/src/LuminosityBlockPrincipal.cc
+++ b/FWCore/Framework/src/LuminosityBlockPrincipal.cc
@@ -15,7 +15,7 @@ namespace edm {
     fillPrincipal(aux_.processHistoryID(), processHistory, reader);
   }
 
-  void LuminosityBlockPrincipal::put(BranchDescription const& bd, std::unique_ptr<WrapperBase> edp) const {
+  void LuminosityBlockPrincipal::put(ProductDescription const& bd, std::unique_ptr<WrapperBase> edp) const {
     put_(bd, std::move(edp));
   }
 

--- a/FWCore/Framework/src/MergeableRunProductMetadata.cc
+++ b/FWCore/Framework/src/MergeableRunProductMetadata.cc
@@ -290,7 +290,7 @@ namespace edm {
     unsigned int processIndex = 0;
     for (auto const& metadataForProcess : metadataForProcesses_) {
       // This string comparison could be optimized away by storing an index in
-      // BranchDescription as a transient calculated once early in a job.
+      // ProductDescription as a transient calculated once early in a job.
       if (getProcessName(processIndex) == processName) {
         return &metadataForProcess;
       }

--- a/FWCore/Framework/src/MergeableRunProductProcesses.cc
+++ b/FWCore/Framework/src/MergeableRunProductProcesses.cc
@@ -2,7 +2,7 @@
 #include "FWCore/Framework/interface/MergeableRunProductProcesses.h"
 
 #include "DataFormats/Common/interface/WrapperBase.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "FWCore/Utilities/interface/getAnyPtr.h"
 
@@ -19,7 +19,7 @@ namespace edm {
     TClass* wrapperBaseTClass = TypeWithDict::byName("edm::WrapperBase").getClass();
     std::set<std::string> processSet;
     for (auto const& prod : productRegistry.productList()) {
-      BranchDescription const& desc = prod.second;
+      ProductDescription const& desc = prod.second;
       if (desc.branchType() == InRun && !desc.produced() && desc.present()) {
         TClass* cp = desc.wrappedType().getClass();
         void* p = cp->New();

--- a/FWCore/Framework/src/OccurrenceForOutput.cc
+++ b/FWCore/Framework/src/OccurrenceForOutput.cc
@@ -37,7 +37,7 @@ namespace edm {
     provRecorder_.principal().getAllStableProvenance(provenances);
   }
 
-  std::vector<BranchDescription const*> OccurrenceForOutput::productDescriptions() const {
+  std::vector<ProductDescription const*> OccurrenceForOutput::productDescriptions() const {
     return principal().productDescriptions();
   }
 

--- a/FWCore/Framework/src/OutputModuleCore.cc
+++ b/FWCore/Framework/src/OutputModuleCore.cc
@@ -19,7 +19,7 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/ThinnedAssociation.h"
 #include "DataFormats/Common/interface/EndPathStatus.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/Provenance/interface/BranchKey.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
@@ -108,20 +108,20 @@ namespace edm {
                                           ProcessBlockHelperBase const& processBlockHelper) {
       if (productSelector_.initialized())
         return;
-      productSelector_.initialize(productSelectorRules_, preg.allBranchDescriptions());
+      productSelector_.initialize(productSelectorRules_, preg.allProductDescriptions());
 
       // TODO: See if we can collapse keptProducts_ and productSelector_ into a
       // single object. See the notes in the header for ProductSelector
       // for more information.
 
-      std::map<BranchID, BranchDescription const*> trueBranchIDToKeptBranchDesc;
-      std::vector<BranchDescription const*> associationDescriptions;
+      std::map<BranchID, ProductDescription const*> trueBranchIDToKeptBranchDesc;
+      std::vector<ProductDescription const*> associationDescriptions;
       std::set<BranchID> keptProductsInEvent;
       std::set<std::string> processesWithSelectedMergeableRunProducts;
       std::set<std::string> processesWithKeptProcessBlockProducts;
 
       for (auto const& it : preg.productList()) {
-        BranchDescription const& desc = it.second;
+        ProductDescription const& desc = it.second;
         if (desc.transient()) {
           // if the class of the branch is marked transient, output nothing
         } else if (!desc.present() && !desc.produced()) {
@@ -182,8 +182,8 @@ namespace edm {
       }
     }
 
-    void OutputModuleCore::keepThisBranch(BranchDescription const& desc,
-                                          std::map<BranchID, BranchDescription const*>& trueBranchIDToKeptBranchDesc,
+    void OutputModuleCore::keepThisBranch(ProductDescription const& desc,
+                                          std::map<BranchID, ProductDescription const*>& trueBranchIDToKeptBranchDesc,
                                           std::set<BranchID>& keptProductsInEvent) {
       ProductSelector::checkForDuplicateKeptBranch(desc, trueBranchIDToKeptBranchDesc);
 
@@ -388,7 +388,7 @@ namespace edm {
 
     ModuleDescription const& OutputModuleCore::description() const { return moduleDescription_; }
 
-    bool OutputModuleCore::selected(BranchDescription const& desc) const { return productSelector_.selected(desc); }
+    bool OutputModuleCore::selected(ProductDescription const& desc) const { return productSelector_.selected(desc); }
 
     void OutputModuleCore::fillDescriptions(ConfigurationDescriptions& descriptions) {
       ParameterSetDescription desc;

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -312,7 +312,8 @@ namespace edm {
             << "\n"
             << "Workaround: change process name or product instance name of " << newProduct.branchName() << "\n";
       } else {
-        assert(nullptr == phb || BranchKey(productResolver.productDescription()) == BranchKey(phb->productDescription()));
+        assert(nullptr == phb ||
+               BranchKey(productResolver.productDescription()) == BranchKey(phb->productDescription()));
       }
     }
     return phb;

--- a/FWCore/Framework/src/PrincipalGetAdapter.cc
+++ b/FWCore/Framework/src/PrincipalGetAdapter.cc
@@ -209,7 +209,7 @@ namespace edm {
   }
 
   ProductDescription const& PrincipalGetAdapter::getProductDescription(TypeID const& type,
-                                                                     std::string const& productInstanceName) const {
+                                                                       std::string const& productInstanceName) const {
     ProductResolverIndexHelper const& productResolverIndexHelper = principal_.productLookup();
     ProductResolverIndex index = productResolverIndexHelper.index(
         PRODUCT_TYPE, type, md_.moduleLabel().c_str(), productInstanceName.c_str(), md_.processName().c_str());

--- a/FWCore/Framework/src/PrincipalGetAdapter.cc
+++ b/FWCore/Framework/src/PrincipalGetAdapter.cc
@@ -186,10 +186,10 @@ namespace edm {
   void PrincipalGetAdapter::throwUnregisteredPutException(TypeID const& type,
                                                           std::string const& productInstanceName) const {
     std::ostringstream str;
-    for (auto branchDescription : principal_.productRegistry().allBranchDescriptions()) {
-      if (branchDescription->moduleLabel() == md_.moduleLabel() and
-          branchDescription->processName() == md_.processName()) {
-        str << *branchDescription << "-----\n";
+    for (auto productDescription : principal_.productRegistry().allProductDescriptions()) {
+      if (productDescription->moduleLabel() == md_.moduleLabel() and
+          productDescription->processName() == md_.processName()) {
+        str << *productDescription << "-----\n";
       }
     }
     throw edm::Exception(edm::errors::InsertFailure)
@@ -208,7 +208,7 @@ namespace edm {
            "'put' call.";
   }
 
-  BranchDescription const& PrincipalGetAdapter::getBranchDescription(TypeID const& type,
+  ProductDescription const& PrincipalGetAdapter::getProductDescription(TypeID const& type,
                                                                      std::string const& productInstanceName) const {
     ProductResolverIndexHelper const& productResolverIndexHelper = principal_.productLookup();
     ProductResolverIndex index = productResolverIndexHelper.index(
@@ -218,14 +218,14 @@ namespace edm {
     }
     ProductResolverBase const* phb = principal_.getProductResolverByIndex(index);
     assert(phb != nullptr);
-    return phb->branchDescription();
+    return phb->productDescription();
   }
 
-  BranchDescription const& PrincipalGetAdapter::getBranchDescription(unsigned int iPutTokenIndex) const {
+  ProductDescription const& PrincipalGetAdapter::getProductDescription(unsigned int iPutTokenIndex) const {
     auto index = prodBase_->putTokenIndexToProductResolverIndex()[iPutTokenIndex];
     ProductResolverBase const* phb = principal_.getProductResolverByIndex(index);
     assert(phb != nullptr);
-    return phb->branchDescription();
+    return phb->productDescription();
   }
 
   ProductID const& PrincipalGetAdapter::getProductID(unsigned int iPutTokenIndex) const {

--- a/FWCore/Framework/src/ProcessBlock.cc
+++ b/FWCore/Framework/src/ProcessBlock.cc
@@ -44,7 +44,7 @@ namespace edm {
       for (auto index : iShouldPut) {
         auto resolver = principal.getProductResolverByIndex(index);
         if (not resolver->productResolved() and isEndTransition(provRecorder_.transition()) ==
-                                                    resolver->branchDescription().availableOnlyAtEndTransition()) {
+                                                    resolver->productDescription().availableOnlyAtEndTransition()) {
           dynamic_cast<ProductPutterBase const*>(resolver)->putProduct(std::unique_ptr<WrapperBase>());
         }
       }

--- a/FWCore/Framework/src/ProducerBase.cc
+++ b/FWCore/Framework/src/ProducerBase.cc
@@ -14,7 +14,7 @@ namespace edm {
   ProducerBase::ProducerBase() : ProductRegistryHelper(), callWhenNewProductsRegistered_() {}
   ProducerBase::~ProducerBase() noexcept(false) {}
 
-  std::function<void(BranchDescription const&)> ProducerBase::registrationCallback() const {
+  std::function<void(ProductDescription const&)> ProducerBase::registrationCallback() const {
     return callWhenNewProductsRegistered_;
   }
 
@@ -22,12 +22,12 @@ namespace edm {
     class CallbackWrapper {
     public:
       CallbackWrapper(ProductRegistryHelper* iProd,
-                      std::function<void(BranchDescription const&)> iCallback,
+                      std::function<void(ProductDescription const&)> iCallback,
                       ProductRegistry* iReg,
                       const ModuleDescription& iDesc)
           : prod_(iProd), callback_(iCallback), reg_(iReg), mdesc_(iDesc), lastSize_(iProd->typeLabelList().size()) {}
 
-      void operator()(BranchDescription const& iDesc) {
+      void operator()(ProductDescription const& iDesc) {
         callback_(iDesc);
         addToRegistry();
       }
@@ -45,7 +45,7 @@ namespace edm {
 
     private:
       ProductRegistryHelper* prod_;
-      std::function<void(BranchDescription const&)> callback_;
+      std::function<void(ProductDescription const&)> callback_;
       ProductRegistry* reg_;
       ModuleDescription mdesc_;
       unsigned int lastSize_;

--- a/FWCore/Framework/src/ProductRegistryHelper.cc
+++ b/FWCore/Framework/src/ProductRegistryHelper.cc
@@ -76,14 +76,14 @@ namespace edm {
 
       TypeWithDict type(p->typeID_.typeInfo());
       ProductDescription pdesc(branchType,
-                              iDesc.moduleLabel(),
-                              iDesc.processName(),
-                              p->typeID_.userClassName(),
-                              p->typeID_.friendlyClassName(),
-                              p->productInstanceName_,
-                              type,
-                              true,
-                              isEndTransition(p->transition_));
+                               iDesc.moduleLabel(),
+                               iDesc.processName(),
+                               p->typeID_.userClassName(),
+                               p->typeID_.friendlyClassName(),
+                               p->productInstanceName_,
+                               type,
+                               true,
+                               isEndTransition(p->transition_));
       if (p->aliasType_ == TypeLabelItem::AliasType::kSwitchAlias) {
         if (p->branchAlias_.empty()) {
           throw edm::Exception(edm::errors::LogicError)

--- a/FWCore/Framework/src/ProductRegistryHelper.cc
+++ b/FWCore/Framework/src/ProductRegistryHelper.cc
@@ -5,7 +5,7 @@
 #include "FWCore/Framework/interface/ProductRegistryHelper.h"
 #include "DataFormats/Common/interface/setIsMergeable.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "FWCore/Reflection/interface/DictionaryTools.h"
 #include "FWCore/Utilities/interface/EDMException.h"
@@ -75,7 +75,7 @@ namespace edm {
       }
 
       TypeWithDict type(p->typeID_.typeInfo());
-      BranchDescription pdesc(branchType,
+      ProductDescription pdesc(branchType,
                               iDesc.moduleLabel(),
                               iDesc.processName(),
                               p->typeID_.userClassName(),

--- a/FWCore/Framework/src/ProductResolverBase.cc
+++ b/FWCore/Framework/src/ProductResolverBase.cc
@@ -18,7 +18,7 @@ namespace edm {
   bool ProductResolverBase::provenanceAvailable() const {
     // If this product is from a the current process,
     // the provenance is available if and only if a product has been put.
-    if (branchDescription().produced()) {
+    if (productDescription().produced()) {
       return productResolved();
     }
     // If this product is from a prior process, the provenance is available,
@@ -26,7 +26,7 @@ namespace edm {
     return true;
   }
 
-  TypeID ProductResolverBase::productType() const { return TypeID(branchDescription().wrappedTypeID()); }
+  TypeID ProductResolverBase::productType() const { return TypeID(productDescription().wrappedTypeID()); }
 
   Provenance const* ProductResolverBase::provenance() const { return provenance_(); }
 

--- a/FWCore/Framework/src/ProductResolvers.h
+++ b/FWCore/Framework/src/ProductResolvers.h
@@ -12,7 +12,7 @@ a set of related EDProducts. This is the storage unit of such information.
 #include "FWCore/Framework/src/ProductPutOrMergerBase.h"
 #include "DataFormats/Common/interface/WrapperBase.h"
 #include "DataFormats/Common/interface/ProductData.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/Provenance/interface/BranchID.h"
 #include "DataFormats/Provenance/interface/Provenance.h"
 #include "FWCore/Framework/interface/Principal.h"
@@ -51,7 +51,7 @@ namespace edm {
   public:
     enum class ProductStatus { ProductSet, NotPut, ResolveFailed, ResolveNotRun, ProductDeleted };
 
-    DataManagingProductResolver(std::shared_ptr<BranchDescription const> bd, ProductStatus iDefaultStatus)
+    DataManagingProductResolver(std::shared_ptr<ProductDescription const> bd, ProductStatus iDefaultStatus)
         : DataManagingOrAliasProductResolver(),
           productData_(bd),
           theStatus_(iDefaultStatus),
@@ -86,9 +86,9 @@ namespace edm {
     bool productWasDeleted_() const final;
     bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const final;
 
-    BranchDescription const& branchDescription_() const final { return *getProductData().branchDescription(); }
-    void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) final {
-      productData_.resetBranchDescription(bd);
+    ProductDescription const& productDescription_() const final { return *getProductData().productDescription(); }
+    void resetProductDescription_(std::shared_ptr<ProductDescription const> bd) final {
+      productData_.resetProductDescription(bd);
     }
     Provenance const* provenance_() const final { return &productData_.provenance(); }
 
@@ -105,7 +105,7 @@ namespace edm {
 
   class MergeableInputProductResolver : public DataManagingProductResolver {
   public:
-    MergeableInputProductResolver(std::shared_ptr<BranchDescription const> bd, ProductStatus iDefaultStatus)
+    MergeableInputProductResolver(std::shared_ptr<ProductDescription const> bd, ProductStatus iDefaultStatus)
         : DataManagingProductResolver(bd, iDefaultStatus) {}
 
   protected:
@@ -118,7 +118,7 @@ namespace edm {
 
   class DelayedReaderInputProductResolver : public MergeableInputProductResolver {
   public:
-    explicit DelayedReaderInputProductResolver(std::shared_ptr<BranchDescription const> bd)
+    explicit DelayedReaderInputProductResolver(std::shared_ptr<ProductDescription const> bd)
         : MergeableInputProductResolver(bd, ProductStatus::ResolveNotRun), m_prefetchRequested{false}, aux_{nullptr} {
       assert(bd->onDemand());
       assert(not bd->produced());
@@ -158,7 +158,7 @@ namespace edm {
                                         public ProductPutterBase,
                                         public ProductPutOrMergerBase {
   public:
-    PutOnReadInputProductResolver(std::shared_ptr<BranchDescription const> bd)
+    PutOnReadInputProductResolver(std::shared_ptr<ProductDescription const> bd)
         : MergeableInputProductResolver(bd, ProductStatus::ResolveNotRun) {
       assert(not bd->produced());
       assert(not bd->onDemand());
@@ -186,7 +186,7 @@ namespace edm {
 
   class ProducedProductResolver : public DataManagingProductResolver, public ProductPutterBase {
   public:
-    ProducedProductResolver(std::shared_ptr<BranchDescription const> bd, ProductStatus iDefaultStatus)
+    ProducedProductResolver(std::shared_ptr<ProductDescription const> bd, ProductStatus iDefaultStatus)
         : DataManagingProductResolver(bd, iDefaultStatus) {
       assert(bd->produced());
     }
@@ -200,7 +200,7 @@ namespace edm {
 
   class PuttableProductResolver : public ProducedProductResolver {
   public:
-    explicit PuttableProductResolver(std::shared_ptr<BranchDescription const> bd)
+    explicit PuttableProductResolver(std::shared_ptr<ProductDescription const> bd)
         : ProducedProductResolver(bd, ProductStatus::NotPut) {}
 
     void setupUnscheduled(UnscheduledConfigurator const&) final;
@@ -228,7 +228,7 @@ namespace edm {
 
   class UnscheduledProductResolver : public ProducedProductResolver {
   public:
-    explicit UnscheduledProductResolver(std::shared_ptr<BranchDescription const> bd)
+    explicit UnscheduledProductResolver(std::shared_ptr<ProductDescription const> bd)
         : ProducedProductResolver(bd, ProductStatus::ResolveNotRun) {}
 
     void setupUnscheduled(UnscheduledConfigurator const&) final;
@@ -256,7 +256,7 @@ namespace edm {
 
   class TransformingProductResolver : public ProducedProductResolver {
   public:
-    explicit TransformingProductResolver(std::shared_ptr<BranchDescription const> bd)
+    explicit TransformingProductResolver(std::shared_ptr<ProductDescription const> bd)
         : ProducedProductResolver(bd, ProductStatus::ResolveNotRun), mcc_(nullptr) {}
 
     void setupUnscheduled(UnscheduledConfigurator const&) final;
@@ -288,7 +288,7 @@ namespace edm {
   class AliasProductResolver : public DataManagingOrAliasProductResolver {
   public:
     typedef ProducedProductResolver::ProductStatus ProductStatus;
-    explicit AliasProductResolver(std::shared_ptr<BranchDescription const> bd,
+    explicit AliasProductResolver(std::shared_ptr<ProductDescription const> bd,
                                   DataManagingOrAliasProductResolver& realProduct)
         : DataManagingOrAliasProductResolver(), realProduct_(realProduct), bd_(bd) {}
 
@@ -319,8 +319,8 @@ namespace edm {
       return realProduct_.productWasFetchedAndIsValid(iSkipCurrentProcess);
     }
 
-    BranchDescription const& branchDescription_() const override { return *bd_; }
-    void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) override { bd_ = bd; }
+    ProductDescription const& productDescription_() const override { return *bd_; }
+    void resetProductDescription_(std::shared_ptr<ProductDescription const> bd) override { bd_ = bd; }
     Provenance const* provenance_() const final { return realProduct_.provenance(); }
 
     std::string const& resolvedModuleLabel_() const override { return realProduct_.moduleLabel(); }
@@ -332,14 +332,14 @@ namespace edm {
     bool singleProduct_() const override;
 
     DataManagingOrAliasProductResolver& realProduct_;
-    std::shared_ptr<BranchDescription const> bd_;
+    std::shared_ptr<ProductDescription const> bd_;
   };
 
   // Switch is a mixture of DataManaging (for worker and provenance) and Alias (for product)
   class SwitchBaseProductResolver : public DataManagingOrAliasProductResolver {
   public:
     using ProductStatus = DataManagingProductResolver::ProductStatus;
-    SwitchBaseProductResolver(std::shared_ptr<BranchDescription const> bd,
+    SwitchBaseProductResolver(std::shared_ptr<ProductDescription const> bd,
                               DataManagingOrAliasProductResolver& realProduct);
 
     void connectTo(ProductResolverBase const& iOther, Principal const* iParentPrincipal) final;
@@ -360,12 +360,12 @@ namespace edm {
     bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const final {
       return realProduct_.productWasFetchedAndIsValid(iSkipCurrentProcess);
     }
-    BranchDescription const& branchDescription_() const final {
-      return *productData_.branchDescription();
+    ProductDescription const& productDescription_() const final {
+      return *productData_.productDescription();
       ;
     }
-    void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) final {
-      productData_.resetBranchDescription(bd);
+    void resetProductDescription_(std::shared_ptr<ProductDescription const> bd) final {
+      productData_.resetProductDescription(bd);
     }
     Provenance const* provenance_() const final { return &productData_.provenance(); }
     std::string const& resolvedModuleLabel_() const final { return moduleLabel(); }
@@ -389,7 +389,7 @@ namespace edm {
   // For the case when SwitchProducer is on a Path
   class SwitchProducerProductResolver : public SwitchBaseProductResolver, public ProductPutterBase {
   public:
-    SwitchProducerProductResolver(std::shared_ptr<BranchDescription const> bd,
+    SwitchProducerProductResolver(std::shared_ptr<ProductDescription const> bd,
                                   DataManagingOrAliasProductResolver& realProduct);
 
   private:
@@ -419,7 +419,7 @@ namespace edm {
   // For the case when SwitchProducer is not on any Path
   class SwitchAliasProductResolver : public SwitchBaseProductResolver {
   public:
-    SwitchAliasProductResolver(std::shared_ptr<BranchDescription const> bd,
+    SwitchAliasProductResolver(std::shared_ptr<ProductDescription const> bd,
                                DataManagingOrAliasProductResolver& realProduct)
         : SwitchBaseProductResolver(std::move(bd), realProduct) {}
 
@@ -441,7 +441,7 @@ namespace edm {
   class ParentProcessProductResolver : public ProductResolverBase {
   public:
     typedef ProducedProductResolver::ProductStatus ProductStatus;
-    explicit ParentProcessProductResolver(std::shared_ptr<BranchDescription const> bd)
+    explicit ParentProcessProductResolver(std::shared_ptr<ProductDescription const> bd)
         : ProductResolverBase(), realProduct_(nullptr), bd_(bd), provRetriever_(nullptr), parentPrincipal_(nullptr) {}
 
     void connectTo(ProductResolverBase const& iOther, Principal const* iParentPrincipal) final {
@@ -492,8 +492,8 @@ namespace edm {
       return realProduct_->productWasFetchedAndIsValid(iSkipCurrentProcess);
     }
 
-    BranchDescription const& branchDescription_() const override { return *bd_; }
-    void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) override { bd_ = bd; }
+    ProductDescription const& productDescription_() const override { return *bd_; }
+    void resetProductDescription_(std::shared_ptr<ProductDescription const> bd) override { bd_ = bd; }
     Provenance const* provenance_() const final { return realProduct_->provenance(); }
     std::string const& resolvedModuleLabel_() const override { return realProduct_->moduleLabel(); }
     void setProductProvenanceRetriever_(ProductProvenanceRetriever const* provRetriever) override;
@@ -504,7 +504,7 @@ namespace edm {
     void throwNullRealProduct() const;
 
     ProductResolverBase const* realProduct_;
-    std::shared_ptr<BranchDescription const> bd_;
+    std::shared_ptr<ProductDescription const> bd_;
     ProductProvenanceRetriever const* provRetriever_;
     Principal const* parentPrincipal_;
   };
@@ -553,8 +553,8 @@ namespace edm {
     bool productResolved_() const final;
     bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const override;
 
-    BranchDescription const& branchDescription_() const override;
-    void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) override;
+    ProductDescription const& productDescription_() const override;
+    void resetProductDescription_(std::shared_ptr<ProductDescription const> bd) override;
     Provenance const* provenance_() const override;
 
     std::string const& resolvedModuleLabel_() const override { return moduleLabel(); }
@@ -608,8 +608,8 @@ namespace edm {
     bool productResolved_() const final;
     bool productWasFetchedAndIsValid_(bool iSkipCurrentProcess) const override;
 
-    BranchDescription const& branchDescription_() const override;
-    void resetBranchDescription_(std::shared_ptr<BranchDescription const> bd) override;
+    ProductDescription const& productDescription_() const override;
+    void resetProductDescription_(std::shared_ptr<ProductDescription const> bd) override;
     Provenance const* provenance_() const override;
 
     std::string const& resolvedModuleLabel_() const override { return moduleLabel(); }

--- a/FWCore/Framework/src/ProductResolversFactory.cc
+++ b/FWCore/Framework/src/ProductResolversFactory.cc
@@ -8,30 +8,30 @@
 
 namespace edm::productResolversFactory {
   namespace {
-    std::shared_ptr<ProductResolverBase> makeScheduledProduct(std::shared_ptr<BranchDescription const> bd) {
+    std::shared_ptr<ProductResolverBase> makeScheduledProduct(std::shared_ptr<ProductDescription const> bd) {
       return std::make_shared<PuttableProductResolver>(std::move(bd));
     }
-    std::shared_ptr<ProductResolverBase> makeSourceProduct(std::shared_ptr<BranchDescription const> bd) {
+    std::shared_ptr<ProductResolverBase> makeSourceProduct(std::shared_ptr<ProductDescription const> bd) {
       return std::make_shared<PuttableProductResolver>(std::move(bd));
     }
-    std::shared_ptr<ProductResolverBase> makeDelayedReaderInputProduct(std::shared_ptr<BranchDescription const> bd) {
+    std::shared_ptr<ProductResolverBase> makeDelayedReaderInputProduct(std::shared_ptr<ProductDescription const> bd) {
       return std::make_shared<DelayedReaderInputProductResolver>(std::move(bd));
     }
-    std::shared_ptr<ProductResolverBase> makePutOnReadInputProduct(std::shared_ptr<BranchDescription const> bd) {
+    std::shared_ptr<ProductResolverBase> makePutOnReadInputProduct(std::shared_ptr<ProductDescription const> bd) {
       return std::make_shared<PutOnReadInputProductResolver>(std::move(bd));
     }
-    std::shared_ptr<ProductResolverBase> makeUnscheduledProduct(std::shared_ptr<BranchDescription const> bd) {
+    std::shared_ptr<ProductResolverBase> makeUnscheduledProduct(std::shared_ptr<ProductDescription const> bd) {
       return std::make_shared<UnscheduledProductResolver>(std::move(bd));
     }
-    std::shared_ptr<ProductResolverBase> makeTransformProduct(std::shared_ptr<BranchDescription const> bd) {
+    std::shared_ptr<ProductResolverBase> makeTransformProduct(std::shared_ptr<ProductDescription const> bd) {
       return std::make_shared<TransformingProductResolver>(std::move(bd));
     }
-    std::shared_ptr<ProductResolverBase> makeDroppedProduct(std::shared_ptr<BranchDescription const> bd) {
+    std::shared_ptr<ProductResolverBase> makeDroppedProduct(std::shared_ptr<ProductDescription const> bd) {
       return std::make_shared<DroppedDataProductResolver>(std::move(bd));
     }
 
     std::shared_ptr<ProductResolverBase> makeAliasedProduct(
-        std::shared_ptr<BranchDescription const> bd,
+        std::shared_ptr<ProductDescription const> bd,
         ProductRegistry const& iReg,
         std::vector<std::shared_ptr<ProductResolverBase>> const& iResolvers) {
       ProductResolverIndex index = iReg.indexFrom(bd->originalBranchID());
@@ -40,7 +40,7 @@ namespace edm::productResolversFactory {
           std::move(bd), dynamic_cast<DataManagingOrAliasProductResolver&>(*iResolvers[index]));
     }
     std::shared_ptr<ProductResolverBase> makeSwitchProducerProduct(
-        std::shared_ptr<BranchDescription const> bd,
+        std::shared_ptr<ProductDescription const> bd,
         ProductRegistry const& iReg,
         std::vector<std::shared_ptr<ProductResolverBase>> const& iResolvers) {
       ProductResolverIndex index = iReg.indexFrom(bd->switchAliasForBranchID());
@@ -51,7 +51,7 @@ namespace edm::productResolversFactory {
     }
 
     std::shared_ptr<ProductResolverBase> makeSwitchAliasProduct(
-        std::shared_ptr<BranchDescription const> bd,
+        std::shared_ptr<ProductDescription const> bd,
         ProductRegistry const& iReg,
         std::vector<std::shared_ptr<ProductResolverBase>> const& iResolvers) {
       ProductResolverIndex index = iReg.indexFrom(bd->switchAliasForBranchID());
@@ -61,7 +61,7 @@ namespace edm::productResolversFactory {
           std::move(bd), dynamic_cast<DataManagingOrAliasProductResolver&>(*iResolvers[index]));
     }
 
-    std::shared_ptr<ProductResolverBase> makeParentProcessProduct(std::shared_ptr<BranchDescription const> bd) {
+    std::shared_ptr<ProductResolverBase> makeParentProcessProduct(std::shared_ptr<ProductDescription const> bd) {
       return std::make_shared<ParentProcessProductResolver>(std::move(bd));
     }
 
@@ -69,7 +69,7 @@ namespace edm::productResolversFactory {
                            std::vector<std::shared_ptr<ProductResolverBase>>& oResolvers,
                            ProductRegistry const& iReg) {
       assert(bool(iResolver));
-      BranchDescription const& bd = iResolver->branchDescription();
+      ProductDescription const& bd = iResolver->productDescription();
       assert(!bd.className().empty());
       assert(!bd.friendlyClassName().empty());
       assert(!bd.moduleLabel().empty());
@@ -84,10 +84,10 @@ namespace edm::productResolversFactory {
       oResolvers[index] = std::move(iResolver);
     }
 
-    std::shared_ptr<ProductResolverBase> makeForPrimary(BranchDescription const& bd,
+    std::shared_ptr<ProductResolverBase> makeForPrimary(ProductDescription const& bd,
                                                         ProductRegistry const& iReg,
                                                         ProductResolverIndexHelper const& iHelper) {
-      auto cbd = std::make_shared<BranchDescription const>(bd);
+      auto cbd = std::make_shared<ProductDescription const>(bd);
       if (bd.produced()) {
         using namespace std::literals;
         if (bd.moduleLabel() == "source"sv) {
@@ -117,7 +117,7 @@ namespace edm::productResolversFactory {
                             std::vector<std::shared_ptr<edm::ProductResolverBase>> const& productResolvers) {
       for (unsigned int j = 0; j < matchingHolders.size(); ++j) {
         if ((not ambiguous[j]) and ProductResolverIndexInvalid != matchingHolders[j] and
-            productResolvers[matchingHolders[j]]->branchDescription().availableOnlyAtEndTransition()) {
+            productResolvers[matchingHolders[j]]->productDescription().availableOnlyAtEndTransition()) {
           return true;
         }
       }
@@ -206,7 +206,7 @@ namespace edm::productResolversFactory {
     bool hasAliases = false;
     bool hasSwitchAliases = false;
     for (auto const& prod : prodsList) {
-      BranchDescription const& bd = prod.second;
+      ProductDescription const& bd = prod.second;
       if (bd.branchType() == bt) {
         if (isForPrimaryProcess or bd.processName() == iProcessName) {
           if (bd.isAlias()) {
@@ -218,7 +218,7 @@ namespace edm::productResolversFactory {
           }
         } else {
           //We are in a SubProcess and this branch is from the parent
-          auto cbd = std::make_shared<BranchDescription const>(bd);
+          auto cbd = std::make_shared<ProductDescription const>(bd);
           if (bd.dropped()) {
             addProductOrThrow(makeDroppedProduct(cbd), productResolvers, iReg);
           } else {
@@ -230,9 +230,9 @@ namespace edm::productResolversFactory {
     // Now process any EDAliases
     if (hasAliases) {
       for (auto const& prod : prodsList) {
-        BranchDescription const& bd = prod.second;
+        ProductDescription const& bd = prod.second;
         if (bd.isAlias() && bd.branchType() == bt) {
-          addProductOrThrow(makeAliasedProduct(std::make_shared<BranchDescription const>(bd), iReg, productResolvers),
+          addProductOrThrow(makeAliasedProduct(std::make_shared<ProductDescription const>(bd), iReg, productResolvers),
                             productResolvers,
                             iReg);
         }
@@ -241,10 +241,10 @@ namespace edm::productResolversFactory {
     // Finally process any SwitchProducer aliases
     if (hasSwitchAliases) {
       for (auto const& prod : prodsList) {
-        BranchDescription const& bd = prod.second;
+        ProductDescription const& bd = prod.second;
         if (bd.isSwitchAlias() && bd.branchType() == bt) {
           assert(bt == InEvent);
-          auto cbd = std::make_shared<BranchDescription const>(bd);
+          auto cbd = std::make_shared<ProductDescription const>(bd);
           // Need different implementation for SwitchProducers not
           // in any Path (onDemand) and for those in a Path in order
           // to prevent the switch-aliased-for EDProducers from

--- a/FWCore/Framework/src/ProductSelector.cc
+++ b/FWCore/Framework/src/ProductSelector.cc
@@ -3,7 +3,7 @@
 #include <ostream>
 #include <cctype>
 
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "FWCore/Framework/interface/ProductSelector.h"
 #include "FWCore/Framework/interface/ProductSelectorRules.h"
@@ -13,21 +13,21 @@
 namespace edm {
   // The following typedef is used only in this implementation file, in
   // order to shorten several lines of code.
-  typedef std::vector<edm::BranchDescription const*> VCBDP;
+  typedef std::vector<edm::ProductDescription const*> VCBDP;
 
   ProductSelector::ProductSelector() : productsToSelect_(), initialized_(false) {}
 
-  void ProductSelector::initialize(ProductSelectorRules const& rules, VCBDP const& branchDescriptions) {
+  void ProductSelector::initialize(ProductSelectorRules const& rules, VCBDP const& productDescriptions) {
     typedef ProductSelectorRules::BranchSelectState BranchSelectState;
 
     // Get a BranchSelectState for each branch, containing the branch
     // name, with its 'select bit' set to false.
     std::vector<BranchSelectState> branchstates;
     {
-      branchstates.reserve(branchDescriptions.size());
+      branchstates.reserve(productDescriptions.size());
 
-      VCBDP::const_iterator it = branchDescriptions.begin();
-      VCBDP::const_iterator end = branchDescriptions.end();
+      VCBDP::const_iterator it = productDescriptions.begin();
+      VCBDP::const_iterator end = productDescriptions.end();
       for (; it != end; ++it)
         branchstates.emplace_back(*it);
     }
@@ -52,7 +52,7 @@ namespace edm {
     initialized_ = true;
   }
 
-  bool ProductSelector::selected(BranchDescription const& desc) const {
+  bool ProductSelector::selected(ProductDescription const& desc) const {
     if (!initialized_) {
       throw edm::Exception(edm::errors::LogicError) << "ProductSelector::selected() called prematurely\n"
                                                     << "before the product registry has been frozen.\n";
@@ -69,7 +69,7 @@ namespace edm {
   }
 
   void ProductSelector::checkForDuplicateKeptBranch(
-      BranchDescription const& desc, std::map<BranchID, BranchDescription const*>& trueBranchIDToKeptBranchDesc) {
+      ProductDescription const& desc, std::map<BranchID, ProductDescription const*>& trueBranchIDToKeptBranchDesc) {
     // Check if an equivalent branch has already been selected due to an EDAlias.
     // We only need the check for products produced in this process.
     if (desc.produced()) {
@@ -94,14 +94,14 @@ namespace edm {
   // Fills in a mapping needed in the case that a branch was dropped while its EDAlias was kept.
   void ProductSelector::fillDroppedToKept(
       ProductRegistry const& preg,
-      std::map<BranchID, BranchDescription const*> const& trueBranchIDToKeptBranchDesc,
+      std::map<BranchID, ProductDescription const*> const& trueBranchIDToKeptBranchDesc,
       std::map<BranchID::value_type, BranchID::value_type>& droppedBranchIDToKeptBranchID_) {
     for (auto const& it : preg.productList()) {
-      BranchDescription const& desc = it.second;
+      ProductDescription const& desc = it.second;
       if (!desc.produced() || desc.isAlias())
         continue;
       BranchID const& branchID = desc.branchID();
-      std::map<BranchID, BranchDescription const*>::const_iterator iter = trueBranchIDToKeptBranchDesc.find(branchID);
+      std::map<BranchID, ProductDescription const*>::const_iterator iter = trueBranchIDToKeptBranchDesc.find(branchID);
       if (iter != trueBranchIDToKeptBranchDesc.end()) {
         // This branch, produced in this process, or an alias of it, was persisted.
         BranchID const& keptBranchID = iter->second->branchID();

--- a/FWCore/Framework/src/ProductSelectorRules.cc
+++ b/FWCore/Framework/src/ProductSelectorRules.cc
@@ -5,7 +5,7 @@
 
 #include "boost/algorithm/string.hpp"
 
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "FWCore/Framework/interface/ProductSelectorRules.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -14,7 +14,7 @@
 namespace edm {
   // The following typedef is used only in this implementation file, in
   // order to shorten several lines of code.
-  typedef std::vector<edm::BranchDescription const*> VCBDP;
+  typedef std::vector<edm::ProductDescription const*> VCBDP;
 
   namespace {
 
@@ -28,7 +28,7 @@ namespace edm {
 
   //--------------------------------------------------
   // Class Rule is used to determine whether or not a given branch
-  // (really a ProductResolver, as described by the BranchDescription object
+  // (really a ProductResolver, as described by the ProductDescription object
   // that specifies that ProductResolver) matches a 'rule' specified by the
   // configuration. Each Rule is configured with a single std::string from
   // the configuration file.
@@ -170,7 +170,7 @@ namespace edm {
       it->applyToAll(branchstates);
   }
 
-  bool ProductSelectorRules::select(edm::BranchDescription const& bd) const {
+  bool ProductSelectorRules::select(edm::ProductDescription const& bd) const {
     bool selected = false;
     for (auto const& rule : rules_) {
       rule.applyToOne(&bd, selected);
@@ -182,7 +182,7 @@ namespace edm {
   }
 
   //   bool
-  //   Rule::applyToOne(edm::BranchDescription const* branch) const
+  //   Rule::applyToOne(edm::ProductDescription const* branch) const
   //   {
   //     bool match =
   //       partial_match(productType_, branch->friendlyClassName()) &&
@@ -193,12 +193,12 @@ namespace edm {
   //     return match ? selectflag_ : !selectflag_;
   //   }
 
-  void ProductSelectorRules::Rule::applyToOne(edm::BranchDescription const* branch, bool& result) const {
+  void ProductSelectorRules::Rule::applyToOne(edm::ProductDescription const* branch, bool& result) const {
     if (this->appliesTo(branch))
       result = selectflag_;
   }
 
-  bool ProductSelectorRules::Rule::appliesTo(edm::BranchDescription const* branch) const {
+  bool ProductSelectorRules::Rule::appliesTo(edm::ProductDescription const* branch) const {
     return partial_match(productType_, branch->friendlyClassName()) &&
            partial_match(moduleLabel_, branch->moduleLabel()) &&
            partial_match(instanceName_, branch->productInstanceName()) &&

--- a/FWCore/Framework/src/Run.cc
+++ b/FWCore/Framework/src/Run.cc
@@ -100,7 +100,7 @@ namespace edm {
       for (auto index : iShouldPut) {
         auto resolver = p.getProductResolverByIndex(index);
         if (not resolver->productResolved() and isEndTransition(provRecorder_.transition()) ==
-                                                    resolver->branchDescription().availableOnlyAtEndTransition()) {
+                                                    resolver->productDescription().availableOnlyAtEndTransition()) {
           dynamic_cast<ProductPutterBase const*>(resolver)->putProduct(std::unique_ptr<WrapperBase>());
         }
       }

--- a/FWCore/Framework/src/RunPrincipal.cc
+++ b/FWCore/Framework/src/RunPrincipal.cc
@@ -32,7 +32,7 @@ namespace edm {
     }
   }
 
-  void RunPrincipal::put(BranchDescription const& bd, std::unique_ptr<WrapperBase> edp) const {
+  void RunPrincipal::put(ProductDescription const& bd, std::unique_ptr<WrapperBase> edp) const {
     put_(bd, std::move(edp));
   }
 
@@ -41,7 +41,7 @@ namespace edm {
     dynamic_cast<ProductPutterBase const*>(phb)->putProduct(std::move(edp));
   }
 
-  void RunPrincipal::putOrMerge(BranchDescription const& bd, std::unique_ptr<WrapperBase> prod) const {
+  void RunPrincipal::putOrMerge(ProductDescription const& bd, std::unique_ptr<WrapperBase> prod) const {
     if (prod.get() == nullptr) {
       throw edm::Exception(edm::errors::InsertFailure, "Null Pointer")
           << "putOrMerge: Cannot put because unique_ptr to product is null."

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -155,7 +155,7 @@ namespace edm {
     void processSwitchProducers(ParameterSet const& proc_pset,
                                 std::string const& processName,
                                 SignallingProductRegistry& preg) {
-      // Update Switch BranchDescriptions for the chosen case
+      // Update Switch ProductDescriptions for the chosen case
       struct BranchesCases {
         BranchesCases(std::vector<std::string> cases) : caseLabels{std::move(cases)} {}
         std::vector<BranchKey> chosenBranches;
@@ -184,7 +184,7 @@ namespace edm {
               continue;
             }
 
-            BranchDescription const& desc = productIter.second;
+            ProductDescription const& desc = productIter.second;
             if (desc.branchType() == prod.second.branchType() and
                 desc.unwrappedTypeID().typeInfo() == prod.second.unwrappedTypeID().typeInfo() and
                 branchKey.moduleLabel() == prod.second.switchAliasModuleLabel() and
@@ -198,7 +198,7 @@ namespace edm {
           }
           if (not found) {
             Exception ex(errors::LogicError);
-            ex << "Trying to find a BranchDescription to be aliased-for by SwitchProducer with\n"
+            ex << "Trying to find a ProductDescription to be aliased-for by SwitchProducer with\n"
                << "  friendly class name = " << prod.second.friendlyClassName() << "\n"
                << "  module label = " << prod.second.moduleLabel() << "\n"
                << "  product instance name = " << prod.second.productInstanceName() << "\n"
@@ -608,7 +608,7 @@ namespace edm {
       detail::processEDAliases(aliases, {}, proc_pset, processConfiguration->processName(), preg);
     }
 
-    // At this point all BranchDescriptions are created. Mark now the
+    // At this point all ProductDescriptions are created. Mark now the
     // ones of unscheduled workers to be on-demand.
     {
       auto const& unsched = streamSchedules_[0]->unscheduledWorkersLumisAndEvents();

--- a/FWCore/Framework/src/ScheduleItems.cc
+++ b/FWCore/Framework/src/ScheduleItems.cc
@@ -1,6 +1,6 @@
 #include "FWCore/Framework/interface/ScheduleItems.h"
 
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/Provenance/interface/BranchID.h"
 #include "DataFormats/Provenance/interface/BranchIDListHelper.h"
 #include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
@@ -50,7 +50,7 @@ namespace edm {
         act_table_(),
         processConfiguration_() {
     for (auto& item : preg_->productListUpdator()) {
-      BranchDescription& prod = item.second;
+      ProductDescription& prod = item.second;
       prod.setOnDemand(false);
       prod.setProduced(false);
     }
@@ -59,26 +59,26 @@ namespace edm {
     std::set<BranchID> keptBranches;
     SelectedProducts const& keptVectorP = om.keptProducts()[InProcess];
     for (auto const& item : keptVectorP) {
-      BranchDescription const& desc = *item.first;
+      ProductDescription const& desc = *item.first;
       keptBranches.insert(desc.branchID());
     }
     SelectedProducts const& keptVectorR = om.keptProducts()[InRun];
     for (auto const& item : keptVectorR) {
-      BranchDescription const& desc = *item.first;
+      ProductDescription const& desc = *item.first;
       keptBranches.insert(desc.branchID());
     }
     SelectedProducts const& keptVectorL = om.keptProducts()[InLumi];
     for (auto const& item : keptVectorL) {
-      BranchDescription const& desc = *item.first;
+      ProductDescription const& desc = *item.first;
       keptBranches.insert(desc.branchID());
     }
     SelectedProducts const& keptVectorE = om.keptProducts()[InEvent];
     for (auto const& item : keptVectorE) {
-      BranchDescription const& desc = *item.first;
+      ProductDescription const& desc = *item.first;
       keptBranches.insert(desc.branchID());
     }
     for (auto& item : preg_->productListUpdator()) {
-      BranchDescription& prod = item.second;
+      ProductDescription& prod = item.second;
       if (keptBranches.find(prod.branchID()) == keptBranches.end()) {
         prod.setDropped(true);
       }

--- a/FWCore/Framework/src/SignallingProductRegistry.cc
+++ b/FWCore/Framework/src/SignallingProductRegistry.cc
@@ -42,7 +42,7 @@ namespace {
   };
 }  // namespace
 
-void SignallingProductRegistry::addCalled(BranchDescription const& iProd, bool iFromListener) {
+void SignallingProductRegistry::addCalled(ProductDescription const& iProd, bool iFromListener) {
   // Call only for present branches (part of avoiding adding type information for dropped branches)
   if (iProd.dropped())
     return;

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -184,7 +184,7 @@ namespace edm {
     }
 
     std::optional<std::string> findBestMatchingAlias(
-        std::unordered_multimap<std::string, edm::BranchDescription const*> const& conditionalModuleBranches,
+        std::unordered_multimap<std::string, edm::ProductDescription const*> const& conditionalModuleBranches,
         std::unordered_multimap<std::string, StreamSchedule::AliasInfo> const& aliasMap,
         std::string const& productModuleLabel,
         ConsumesInfo const& consumesInfo) {
@@ -299,9 +299,9 @@ namespace edm {
 
     std::unordered_multimap<std::string, AliasInfo> const& aliasMap() const { return aliasMap_; }
 
-    std::unordered_multimap<std::string, edm::BranchDescription const*> conditionalModuleBranches(
+    std::unordered_multimap<std::string, edm::ProductDescription const*> conditionalModuleBranches(
         std::unordered_set<std::string> const& conditionalmods) const {
-      std::unordered_multimap<std::string, edm::BranchDescription const*> ret;
+      std::unordered_multimap<std::string, edm::ProductDescription const*> ret;
       for (auto const& mod : conditionalmods) {
         auto range = conditionalModsBranches_.equal_range(mod);
         ret.insert(range.first, range.second);
@@ -363,7 +363,7 @@ namespace edm {
     }
 
     std::unordered_multimap<std::string, AliasInfo> aliasMap_;
-    std::unordered_multimap<std::string, edm::BranchDescription const*> conditionalModsBranches_;
+    std::unordered_multimap<std::string, edm::ProductDescription const*> conditionalModsBranches_;
   };
 
   // -----------------------------
@@ -559,7 +559,7 @@ namespace edm {
           // so we should remove it from our list
           SelectedProductsForBranchType const& kept = comm->keptProducts();
           for (auto const& item : kept[InEvent]) {
-            BranchDescription const& desc = *item.first;
+            ProductDescription const& desc = *item.first;
             auto found = branchToReadingWorker.equal_range(desc.branchName());
             if (found.first != found.second) {
               --nUniqueBranchesToDelete;
@@ -751,7 +751,7 @@ namespace edm {
   std::vector<Worker*> StreamSchedule::tryToPlaceConditionalModules(
       Worker* worker,
       std::unordered_set<std::string>& conditionalModules,
-      std::unordered_multimap<std::string, edm::BranchDescription const*> const& conditionalModuleBranches,
+      std::unordered_multimap<std::string, edm::ProductDescription const*> const& conditionalModuleBranches,
       std::unordered_multimap<std::string, AliasInfo> const& aliasMap,
       ParameterSet& proc_pset,
       SignallingProductRegistry& preg,
@@ -842,7 +842,7 @@ namespace edm {
 
     std::unordered_set<std::string> conditionalmods;
     //An EDAlias may be redirecting to a module on a ConditionalTask
-    std::unordered_multimap<std::string, edm::BranchDescription const*> conditionalModsBranches;
+    std::unordered_multimap<std::string, edm::ProductDescription const*> conditionalModsBranches;
     std::unordered_map<std::string, unsigned int> conditionalModOrder;
     if (condRange.first != condRange.second) {
       for (auto it = condRange.first; it != condRange.second; ++it) {

--- a/FWCore/Framework/src/SubProcess.cc
+++ b/FWCore/Framework/src/SubProcess.cc
@@ -355,18 +355,18 @@ namespace edm {
                                   std::map<BranchID, bool>& keepAssociation) {
     if (productSelector_.initialized())
       return;
-    productSelector_.initialize(productSelectorRules_, preg.allBranchDescriptions());
+    productSelector_.initialize(productSelectorRules_, preg.allProductDescriptions());
 
     // TODO: See if we can collapse keptProducts_ and productSelector_ into a
     // single object. See the notes in the header for ProductSelector
     // for more information.
 
-    std::map<BranchID, BranchDescription const*> trueBranchIDToKeptBranchDesc;
-    std::vector<BranchDescription const*> associationDescriptions;
+    std::map<BranchID, ProductDescription const*> trueBranchIDToKeptBranchDesc;
+    std::vector<ProductDescription const*> associationDescriptions;
     std::set<BranchID> keptProductsInEvent;
 
     for (auto const& it : preg.productList()) {
-      BranchDescription const& desc = it.second;
+      ProductDescription const& desc = it.second;
       if (desc.transient()) {
         // if the class of the branch is marked transient, output nothing
       } else if (!desc.present() && !desc.produced()) {
@@ -392,8 +392,8 @@ namespace edm {
     ProductSelector::fillDroppedToKept(preg, trueBranchIDToKeptBranchDesc, droppedBranchIDToKeptBranchID_);
   }
 
-  void SubProcess::keepThisBranch(BranchDescription const& desc,
-                                  std::map<BranchID, BranchDescription const*>& trueBranchIDToKeptBranchDesc,
+  void SubProcess::keepThisBranch(ProductDescription const& desc,
+                                  std::map<BranchID, ProductDescription const*>& trueBranchIDToKeptBranchDesc,
                                   std::set<BranchID>& keptProductsInEvent) {
     ProductSelector::checkForDuplicateKeptBranch(desc, trueBranchIDToKeptBranchDesc);
 
@@ -799,7 +799,7 @@ namespace edm {
   void SubProcess::propagateProducts(BranchType type, Principal const& parentPrincipal, Principal& principal) const {
     SelectedProducts const& keptVector = keptProducts()[type];
     for (auto const& item : keptVector) {
-      BranchDescription const& desc = *item.first;
+      ProductDescription const& desc = *item.first;
       ProductResolverBase const* parentProductResolver = parentPrincipal.getProductResolver(desc.branchID());
       if (parentProductResolver != nullptr) {
         ProductResolverBase* productResolver = principal.getModifiableProductResolver(desc.branchID());
@@ -814,13 +814,13 @@ namespace edm {
   bool SubProcess::parentProducedProductIsKept(Principal const& parentPrincipal, Principal& principal) const {
     SelectedProducts const& keptVector = keptProducts()[InProcess];
     for (auto const& item : keptVector) {
-      BranchDescription const& desc = *item.first;
+      ProductDescription const& desc = *item.first;
       assert(desc.branchType() == InProcess);
       ProductResolverBase const* parentProductResolver = parentPrincipal.getProductResolver(desc.branchID());
       if (parentProductResolver != nullptr) {
         ProductResolverBase* productResolver = principal.getModifiableProductResolver(desc.branchID());
         if (productResolver != nullptr) {
-          if (parentProductResolver->branchDescription().produced()) {
+          if (parentProductResolver->productDescription().produced()) {
             return true;
           }
         }

--- a/FWCore/Framework/src/TransformerBase.cc
+++ b/FWCore/Framework/src/TransformerBase.cc
@@ -4,7 +4,7 @@
 #include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 #include "FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h"
 #include "DataFormats/Provenance/interface/ProductResolverIndexHelper.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
@@ -73,7 +73,7 @@ namespace edm {
   }
 
   std::size_t TransformerBase::findMatchingIndex(ProducerBase const& iBase,
-                                                 edm::BranchDescription const& iBranch) const noexcept {
+                                                 edm::ProductDescription const& iBranch) const noexcept {
     auto const& list = iBase.typeLabelList();
 
     std::size_t index = 0;

--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -250,7 +250,7 @@ namespace edm {
 
   void Worker::setEarlyDeleteHelper(EarlyDeleteHelper* iHelper) { earlyDeleteHelper_ = iHelper; }
 
-  size_t Worker::transformIndex(edm::BranchDescription const&) const noexcept { return -1; }
+  size_t Worker::transformIndex(edm::ProductDescription const&) const noexcept { return -1; }
   void Worker::doTransformAsync(WaitingTaskHolder iTask,
                                 size_t iTransformIndex,
                                 EventPrincipal const& iPrincipal,

--- a/FWCore/Framework/src/WorkerT.cc
+++ b/FWCore/Framework/src/WorkerT.cc
@@ -304,36 +304,36 @@ namespace edm {
   }
 
   template <typename T>
-  inline size_t WorkerT<T>::transformIndex(edm::BranchDescription const&) const noexcept {
+  inline size_t WorkerT<T>::transformIndex(edm::ProductDescription const&) const noexcept {
     return -1;
   }
   template <>
-  inline size_t WorkerT<global::EDFilterBase>::transformIndex(edm::BranchDescription const& iBranch) const noexcept {
+  inline size_t WorkerT<global::EDFilterBase>::transformIndex(edm::ProductDescription const& iBranch) const noexcept {
     return module_->transformIndex_(iBranch);
   }
   template <>
-  inline size_t WorkerT<global::EDProducerBase>::transformIndex(edm::BranchDescription const& iBranch) const noexcept {
+  inline size_t WorkerT<global::EDProducerBase>::transformIndex(edm::ProductDescription const& iBranch) const noexcept {
     return module_->transformIndex_(iBranch);
   }
   template <>
   inline size_t WorkerT<stream::EDProducerAdaptorBase>::transformIndex(
-      edm::BranchDescription const& iBranch) const noexcept {
+      edm::ProductDescription const& iBranch) const noexcept {
     return module_->transformIndex_(iBranch);
   }
   template <>
-  inline size_t WorkerT<limited::EDFilterBase>::transformIndex(edm::BranchDescription const& iBranch) const noexcept {
+  inline size_t WorkerT<limited::EDFilterBase>::transformIndex(edm::ProductDescription const& iBranch) const noexcept {
     return module_->transformIndex_(iBranch);
   }
   template <>
-  inline size_t WorkerT<limited::EDProducerBase>::transformIndex(edm::BranchDescription const& iBranch) const noexcept {
+  inline size_t WorkerT<limited::EDProducerBase>::transformIndex(edm::ProductDescription const& iBranch) const noexcept {
     return module_->transformIndex_(iBranch);
   }
   template <>
-  inline size_t WorkerT<one::EDFilterBase>::transformIndex(edm::BranchDescription const& iBranch) const noexcept {
+  inline size_t WorkerT<one::EDFilterBase>::transformIndex(edm::ProductDescription const& iBranch) const noexcept {
     return module_->transformIndex_(iBranch);
   }
   template <>
-  inline size_t WorkerT<one::EDProducerBase>::transformIndex(edm::BranchDescription const& iBranch) const noexcept {
+  inline size_t WorkerT<one::EDProducerBase>::transformIndex(edm::ProductDescription const& iBranch) const noexcept {
     return module_->transformIndex_(iBranch);
   }
 

--- a/FWCore/Framework/src/getProducerParameterSet.cc
+++ b/FWCore/Framework/src/getProducerParameterSet.cc
@@ -1,6 +1,6 @@
 #include "FWCore/Framework/interface/getProducerParameterSet.h"
 
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
 #include "DataFormats/Provenance/interface/ProcessConfiguration.h"
 #include "DataFormats/Provenance/interface/ProcessHistory.h"
@@ -14,11 +14,11 @@
 namespace edm {
 
   ParameterSet const* getProducerParameterSet(Provenance const& provenance, ProcessHistory const& processHistory) {
-    const std::shared_ptr<BranchDescription const>& branchDescription = provenance.constBranchDescriptionPtr();
+    const std::shared_ptr<ProductDescription const>& productDescription = provenance.constProductDescriptionPtr();
 
-    if (branchDescription) {
-      std::string const& process = branchDescription->processName();
-      std::string const& label = branchDescription->moduleLabel();
+    if (productDescription) {
+      std::string const& process = productDescription->processName();
+      std::string const& label = productDescription->moduleLabel();
 
       for (ProcessConfiguration const& pc : processHistory) {
         if (pc.processName() == process) {

--- a/FWCore/Framework/src/global/EDFilterBase.cc
+++ b/FWCore/Framework/src/global/EDFilterBase.cc
@@ -91,7 +91,7 @@ namespace edm {
       transformAsync_(iTask, iTransformIndex, ev, iAct, iToken);
     }
 
-    size_t EDFilterBase::transformIndex_(edm::BranchDescription const& iBranch) const noexcept { return -1; }
+    size_t EDFilterBase::transformIndex_(edm::ProductDescription const& iBranch) const noexcept { return -1; }
     ProductResolverIndex EDFilterBase::transformPrefetch_(std::size_t iIndex) const noexcept { return 0; }
     void EDFilterBase::transformAsync_(WaitingTaskHolder iTask,
                                        std::size_t iIndex,

--- a/FWCore/Framework/src/global/EDProducerBase.cc
+++ b/FWCore/Framework/src/global/EDProducerBase.cc
@@ -97,7 +97,7 @@ namespace edm {
       transformAsync_(iTask, iTransformIndex, ev, iAct, iToken);
     }
 
-    size_t EDProducerBase::transformIndex_(edm::BranchDescription const& iBranch) const noexcept { return -1; }
+    size_t EDProducerBase::transformIndex_(edm::ProductDescription const& iBranch) const noexcept { return -1; }
     ProductResolverIndex EDProducerBase::transformPrefetch_(std::size_t iIndex) const noexcept { return 0; }
     void EDProducerBase::transformAsync_(WaitingTaskHolder iTask,
                                          std::size_t iIndex,

--- a/FWCore/Framework/src/insertSelectedProcesses.cc
+++ b/FWCore/Framework/src/insertSelectedProcesses.cc
@@ -1,7 +1,7 @@
 #include "FWCore/Framework/src/insertSelectedProcesses.h"
 
 #include "DataFormats/Common/interface/WrapperBase.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "FWCore/Utilities/interface/BranchType.h"
 #include "FWCore/Utilities/interface/getAnyPtr.h"
 #include "FWCore/Reflection/interface/TypeWithDict.h"
@@ -12,7 +12,7 @@
 
 namespace edm {
 
-  void insertSelectedProcesses(BranchDescription const& desc,
+  void insertSelectedProcesses(ProductDescription const& desc,
                                std::set<std::string>& processes,
                                std::set<std::string>& processesWithKeptProcessBlockProducts) {
     // Select input processes in which mergeable run products were produced

--- a/FWCore/Framework/src/insertSelectedProcesses.h
+++ b/FWCore/Framework/src/insertSelectedProcesses.h
@@ -3,10 +3,9 @@
 
 #include <set>
 #include <string>
+#include "DataFormats/Provenance/interface/ProductDescriptionFwd.h"
 
 namespace edm {
-
-  class ProductDescription;
 
   void insertSelectedProcesses(ProductDescription const& desc,
                                std::set<std::string>& processes,

--- a/FWCore/Framework/src/insertSelectedProcesses.h
+++ b/FWCore/Framework/src/insertSelectedProcesses.h
@@ -6,9 +6,9 @@
 
 namespace edm {
 
-  class BranchDescription;
+  class ProductDescription;
 
-  void insertSelectedProcesses(BranchDescription const& desc,
+  void insertSelectedProcesses(ProductDescription const& desc,
                                std::set<std::string>& processes,
                                std::set<std::string>& processesWithKeptProcessBlockProducts);
 }  // namespace edm

--- a/FWCore/Framework/src/limited/EDFilterBase.cc
+++ b/FWCore/Framework/src/limited/EDFilterBase.cc
@@ -78,7 +78,7 @@ namespace edm {
       transformAsync_(iTask, iTransformIndex, ev, iAct, iToken);
     }
 
-    size_t EDFilterBase::transformIndex_(edm::BranchDescription const& iBranch) const noexcept { return -1; }
+    size_t EDFilterBase::transformIndex_(edm::ProductDescription const& iBranch) const noexcept { return -1; }
     ProductResolverIndex EDFilterBase::transformPrefetch_(std::size_t iIndex) const noexcept { return 0; }
     void EDFilterBase::transformAsync_(WaitingTaskHolder iTask,
                                        std::size_t iIndex,

--- a/FWCore/Framework/src/limited/EDProducerBase.cc
+++ b/FWCore/Framework/src/limited/EDProducerBase.cc
@@ -78,7 +78,7 @@ namespace edm {
       transformAsync_(iTask, iTransformIndex, ev, iAct, iToken);
     }
 
-    size_t EDProducerBase::transformIndex_(edm::BranchDescription const& iBranch) const noexcept { return -1; }
+    size_t EDProducerBase::transformIndex_(edm::ProductDescription const& iBranch) const noexcept { return -1; }
     ProductResolverIndex EDProducerBase::transformPrefetch_(std::size_t iIndex) const noexcept { return 0; }
     void EDProducerBase::transformAsync_(WaitingTaskHolder iTask,
                                          std::size_t iIndex,

--- a/FWCore/Framework/src/one/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/one/EDAnalyzerBase.cc
@@ -44,7 +44,7 @@ namespace edm {
 
     EDAnalyzerBase::~EDAnalyzerBase() {}
 
-    void EDAnalyzerBase::callWhenNewProductsRegistered(std::function<void(BranchDescription const&)> const& func) {
+    void EDAnalyzerBase::callWhenNewProductsRegistered(std::function<void(ProductDescription const&)> const& func) {
       callWhenNewProductsRegistered_ = func;
     }
 

--- a/FWCore/Framework/src/one/EDFilterBase.cc
+++ b/FWCore/Framework/src/one/EDFilterBase.cc
@@ -90,7 +90,7 @@ namespace edm {
       transformAsync_(iTask, iTransformIndex, ev, iAct, iToken);
     }
 
-    size_t EDFilterBase::transformIndex_(edm::BranchDescription const& iBranch) const noexcept { return -1; }
+    size_t EDFilterBase::transformIndex_(edm::ProductDescription const& iBranch) const noexcept { return -1; }
     ProductResolverIndex EDFilterBase::transformPrefetch_(std::size_t iIndex) const noexcept { return 0; }
     void EDFilterBase::transformAsync_(WaitingTaskHolder iTask,
                                        std::size_t iIndex,

--- a/FWCore/Framework/src/one/EDProducerBase.cc
+++ b/FWCore/Framework/src/one/EDProducerBase.cc
@@ -81,7 +81,7 @@ namespace edm {
       transformAsync_(iTask, iTransformIndex, ev, iAct, iToken);
     }
 
-    size_t EDProducerBase::transformIndex_(edm::BranchDescription const& iBranch) const noexcept { return -1; }
+    size_t EDProducerBase::transformIndex_(edm::ProductDescription const& iBranch) const noexcept { return -1; }
     ProductResolverIndex EDProducerBase::transformPrefetch_(std::size_t iIndex) const noexcept { return 0; }
     void EDProducerBase::transformAsync_(WaitingTaskHolder iTask,
                                          std::size_t iIndex,

--- a/FWCore/Framework/src/one/OutputModuleBase.cc
+++ b/FWCore/Framework/src/one/OutputModuleBase.cc
@@ -19,7 +19,7 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/ThinnedAssociation.h"
 #include "DataFormats/Common/interface/EndPathStatus.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/Provenance/interface/BranchKey.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"

--- a/FWCore/Framework/src/processEDAliases.cc
+++ b/FWCore/Framework/src/processEDAliases.cc
@@ -1,4 +1,4 @@
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/Provenance/interface/BranchKey.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/EDMException.h"

--- a/FWCore/Framework/src/stream/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/stream/EDAnalyzerBase.cc
@@ -56,7 +56,7 @@ EDAnalyzerBase::~EDAnalyzerBase() {}
 //
 // member functions
 //
-void EDAnalyzerBase::callWhenNewProductsRegistered(std::function<void(BranchDescription const&)> const& func) {
+void EDAnalyzerBase::callWhenNewProductsRegistered(std::function<void(ProductDescription const&)> const& func) {
   callWhenNewProductsRegistered_ = func;
 }
 

--- a/FWCore/Framework/src/stream/EDProducerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDProducerAdaptorBase.cc
@@ -39,7 +39,7 @@ namespace edm {
     }
     template <>
     size_t ProducingModuleAdaptorBase<edm::stream::EDProducerBase>::transformIndex_(
-        edm::BranchDescription const& iBranch) const noexcept {
+        edm::ProductDescription const& iBranch) const noexcept {
       return m_streamModules[0]->transformIndex_(iBranch);
     }
     template <>

--- a/FWCore/Framework/src/stream/EDProducerBase.cc
+++ b/FWCore/Framework/src/stream/EDProducerBase.cc
@@ -69,7 +69,7 @@ void EDProducerBase::fillDescriptions(ConfigurationDescriptions& descriptions) {
   descriptions.addDefault(desc);
 }
 
-size_t EDProducerBase::transformIndex_(edm::BranchDescription const& iBranch) const noexcept { return -1; }
+size_t EDProducerBase::transformIndex_(edm::ProductDescription const& iBranch) const noexcept { return -1; }
 edm::ProductResolverIndex EDProducerBase::transformPrefetch_(std::size_t iIndex) const noexcept { return 0; }
 void EDProducerBase::transformAsync_(WaitingTaskHolder iTask,
                                      std::size_t iIndex,

--- a/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
@@ -76,7 +76,7 @@ namespace edm {
       if (firstMod->registrationCallback() and m_streamModules.size() > 1) {
         //we have a callback so we will collect all callbacks and create a new callback which calls them all.
 
-        std::vector<std::function<void(BranchDescription const&)>> callbacks;
+        std::vector<std::function<void(ProductDescription const&)>> callbacks;
         callbacks.reserve(m_streamModules.size());
 
         for (auto mod : m_streamModules) {
@@ -84,7 +84,7 @@ namespace edm {
         }
         //Since only the first module will actually do the registration
         // we will change its callback to call all the callbacks
-        firstMod->callWhenNewProductsRegistered([callbacks](BranchDescription const& iBD) {
+        firstMod->callWhenNewProductsRegistered([callbacks](ProductDescription const& iBD) {
           for (const auto& c : callbacks) {
             c(iBD);
           }
@@ -188,7 +188,7 @@ namespace edm {
       return 0;
     }
     template <typename T>
-    size_t ProducingModuleAdaptorBase<T>::transformIndex_(edm::BranchDescription const& iBranch) const noexcept {
+    size_t ProducingModuleAdaptorBase<T>::transformIndex_(edm::ProductDescription const& iBranch) const noexcept {
       return 0;
     }
     template <typename T>

--- a/FWCore/Framework/test/Event_t.cpp
+++ b/FWCore/Framework/test/Event_t.cpp
@@ -217,12 +217,12 @@ void testEvent::registerProduct(std::string const& tag,
   TypeWithDict product_type(typeid(T));
 
   ProductDescription branch(InEvent,
-                           moduleLabel,
-                           processName,
-                           product_type.userClassName(),
-                           product_type.friendlyClassName(),
-                           productInstanceName,
-                           product_type);
+                            moduleLabel,
+                            processName,
+                            product_type.userClassName(),
+                            product_type.friendlyClassName(),
+                            productInstanceName,
+                            product_type);
 
   moduleDescriptions_[tag] = ModuleDescription(
       moduleParams.id(), moduleClassName, moduleLabel, processX.get(), ModuleDescription::getUniqueID());
@@ -364,12 +364,12 @@ testEvent::testEvent()
   std::string productInstanceName("int1");
 
   ProductDescription branch(InEvent,
-                           moduleLabel,
-                           processName,
-                           product_type.userClassName(),
-                           product_type.friendlyClassName(),
-                           productInstanceName,
-                           product_type);
+                            moduleLabel,
+                            processName,
+                            product_type.userClassName(),
+                            product_type.friendlyClassName(),
+                            productInstanceName,
+                            product_type);
 
   availableProducts_->addProduct(branch);
 

--- a/FWCore/Framework/test/Event_t.cpp
+++ b/FWCore/Framework/test/Event_t.cpp
@@ -7,7 +7,7 @@ Test program for edm::Event.
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/OrphanHandle.h"
 #include "DataFormats/Common/interface/Wrapper.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/Provenance/interface/BranchIDListHelper.h"
 #include "DataFormats/Provenance/interface/EventAuxiliary.h"
 #include "DataFormats/Provenance/interface/EventID.h"
@@ -216,7 +216,7 @@ void testEvent::registerProduct(std::string const& tag,
 
   TypeWithDict product_type(typeid(T));
 
-  BranchDescription branch(InEvent,
+  ProductDescription branch(InEvent,
                            moduleLabel,
                            processName,
                            product_type.userClassName(),
@@ -363,7 +363,7 @@ testEvent::testEvent()
 
   std::string productInstanceName("int1");
 
-  BranchDescription branch(InEvent,
+  ProductDescription branch(InEvent,
                            moduleLabel,
                            processName,
                            product_type.userClassName(),
@@ -990,7 +990,7 @@ void testEvent::deleteProduct() {
 
   BranchID id;
 
-  availableProducts_->callForEachBranch([&id](const BranchDescription& iDesc) {
+  availableProducts_->callForEachBranch([&id](const ProductDescription& iDesc) {
     if (iDesc.moduleLabel() == "modMulti" && iDesc.productInstanceName() == "int1") {
       id = iDesc.branchID();
     }

--- a/FWCore/Framework/test/ProductSelector_t.cpp
+++ b/FWCore/Framework/test/ProductSelector_t.cpp
@@ -8,13 +8,13 @@
 #include "FWCore/Framework/interface/ProductSelectorRules.h"
 #include "FWCore/Framework/interface/ProductSelector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "DataFormats/Provenance/interface/ProcessConfiguration.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Reflection/interface/TypeWithDict.h"
 
-typedef std::vector<edm::BranchDescription const*> VCBDP;
+typedef std::vector<edm::ProductDescription const*> VCBDP;
 
 void apply_gs(edm::ProductSelector const& gs, VCBDP const& allbranches, std::vector<bool>& results) {
   VCBDP::const_iterator it = allbranches.begin();
@@ -53,8 +53,8 @@ TEST_CASE("test ProductSelector", "[ProductSelector]") {
   modAparams.registerIt();
   psetsA.insert(modAparams.id());
 
-  edm::BranchDescription b1(edm::InEvent, "modA", "PROD", "UglyProdTypeA", "ProdTypeA", "i1", dummyTypeWithDict);
-  edm::BranchDescription b2(edm::InEvent, "modA", "PROD", "UglyProdTypeA", "ProdTypeA", "i2", dummyTypeWithDict);
+  edm::ProductDescription b1(edm::InEvent, "modA", "PROD", "UglyProdTypeA", "ProdTypeA", "i1", dummyTypeWithDict);
+  edm::ProductDescription b2(edm::InEvent, "modA", "PROD", "UglyProdTypeA", "ProdTypeA", "i2", dummyTypeWithDict);
 
   // Our second pretend module has only one product, and gives it no
   // instance name.
@@ -64,13 +64,13 @@ TEST_CASE("test ProductSelector", "[ProductSelector]") {
   modBparams.registerIt();
   psetsB.insert(modBparams.id());
 
-  edm::BranchDescription b3(edm::InEvent, "modB", "HLT", "UglyProdTypeB", "ProdTypeB", "", dummyTypeWithDict);
+  edm::ProductDescription b3(edm::InEvent, "modB", "HLT", "UglyProdTypeB", "ProdTypeB", "", dummyTypeWithDict);
 
   // Our third pretend is like modA, except it hass processName_ of
   // "USER"
 
-  edm::BranchDescription b4(edm::InEvent, "modA", "USER", "UglyProdTypeA", "ProdTypeA", "i1", dummyTypeWithDict);
-  edm::BranchDescription b5(edm::InEvent, "modA", "USER", "UglyProdTypeA", "ProdTypeA", "i2", dummyTypeWithDict);
+  edm::ProductDescription b4(edm::InEvent, "modA", "USER", "UglyProdTypeA", "ProdTypeA", "i1", dummyTypeWithDict);
+  edm::ProductDescription b5(edm::InEvent, "modA", "USER", "UglyProdTypeA", "ProdTypeA", "i2", dummyTypeWithDict);
 
   // These are pointers to all the branches that are available. In a
   // framework program, these would come from the ProductRegistry

--- a/FWCore/Framework/test/edproducer_productregistry_callback.cc
+++ b/FWCore/Framework/test/edproducer_productregistry_callback.cc
@@ -56,7 +56,7 @@ namespace {
 
     void produce(StreamID, Event& e, EventSetup const&) const override;
 
-    void listen(BranchDescription const&);
+    void listen(ProductDescription const&);
   };
 
   TestMod::TestMod(ParameterSet const&) { produces<int>(); }
@@ -67,16 +67,16 @@ namespace {
   public:
     explicit ListenMod(ParameterSet const&);
     void produce(StreamID, Event& e, EventSetup const&) const override;
-    void listen(BranchDescription const&);
+    void listen(ProductDescription const&);
   };
 
   ListenMod::ListenMod(ParameterSet const&) {
     callWhenNewProductsRegistered(
-        [this](BranchDescription const& branchDescription) { this->listen(branchDescription); });
+        [this](ProductDescription const& productDescription) { this->listen(productDescription); });
   }
   void ListenMod::produce(StreamID, Event&, EventSetup const&) const {}
 
-  void ListenMod::listen(BranchDescription const& iDesc) {
+  void ListenMod::listen(ProductDescription const& iDesc) {
     edm::TypeID intType(typeid(int));
     //std::cout << "see class " << iDesc.typeName() << std::endl;
     if (iDesc.friendlyClassName() == intType.friendlyClassName()) {
@@ -89,16 +89,16 @@ namespace {
   public:
     explicit ListenFloatMod(ParameterSet const&);
     void produce(StreamID, Event& e, EventSetup const&) const;
-    void listen(BranchDescription const&);
+    void listen(ProductDescription const&);
   };
 
   ListenFloatMod::ListenFloatMod(ParameterSet const&) {
     callWhenNewProductsRegistered(
-        [this](BranchDescription const& branchDescription) { this->listen(branchDescription); });
+        [this](ProductDescription const& productDescription) { this->listen(productDescription); });
   }
   void ListenFloatMod::produce(StreamID, Event&, EventSetup const&) const {}
 
-  void ListenFloatMod::listen(BranchDescription const& iDesc) {
+  void ListenFloatMod::listen(ProductDescription const& iDesc) {
     edm::TypeID intType(typeid(int));
     //std::cout <<"see class "<<iDesc.typeName()<<std::endl;
     if (iDesc.friendlyClassName() == intType.friendlyClassName()) {

--- a/FWCore/Framework/test/event_getrefbeforeput_t.cppunit.cc
+++ b/FWCore/Framework/test/event_getrefbeforeput_t.cppunit.cc
@@ -9,7 +9,7 @@ Test of the EventPrincipal class.
 #include "DataFormats/Provenance/interface/RunAuxiliary.h"
 #include "DataFormats/Provenance/interface/ProcessConfiguration.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/Provenance/interface/BranchIDListHelper.h"
 #include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
 #include "DataFormats/Provenance/interface/Timestamp.h"
@@ -150,7 +150,7 @@ void testEventGetRefBeforePut::getRefTest() {
   auto processConfiguration = std::make_shared<edm::ProcessConfiguration>();
   processConfiguration->setParameterSetID(dummyProcessPset.id());
 
-  edm::BranchDescription product(
+  edm::ProductDescription product(
       edm::InEvent, label, processName, dummytype.userClassName(), className, productInstanceName, dummytype);
 
   product.init();

--- a/FWCore/Framework/test/eventprincipal_t.cppunit.cc
+++ b/FWCore/Framework/test/eventprincipal_t.cppunit.cc
@@ -103,8 +103,8 @@ std::shared_ptr<edm::ProcessConfiguration> test_ep::fake_single_module_process(s
 }
 
 std::shared_ptr<edm::ProductDescription> test_ep::fake_single_process_branch(std::string const& tag,
-                                                                            std::string const& processName,
-                                                                            std::string const& productInstanceName) {
+                                                                             std::string const& processName,
+                                                                             std::string const& productInstanceName) {
   std::string moduleLabel = processName + "dummyMod";
   std::string moduleClass("DummyModule");
   edm::TypeWithDict dummyType(typeid(edmtest::DummyProduct));
@@ -117,12 +117,12 @@ std::shared_ptr<edm::ProductDescription> test_ep::fake_single_process_branch(std
   std::shared_ptr<edm::ProcessConfiguration> process(fake_single_module_process(tag, processName, modParams));
 
   auto result = std::make_shared<edm::ProductDescription>(edm::InEvent,
-                                                         moduleLabel,
-                                                         processName,
-                                                         productClassName,
-                                                         friendlyProductClassName,
-                                                         productInstanceName,
-                                                         dummyType);
+                                                          moduleLabel,
+                                                          processName,
+                                                          productClassName,
+                                                          friendlyProductClassName,
+                                                          productInstanceName,
+                                                          dummyType);
   productDescriptions_[tag] = result;
   return result;
 }

--- a/FWCore/Framework/test/eventprincipal_t.cppunit.cc
+++ b/FWCore/Framework/test/eventprincipal_t.cppunit.cc
@@ -5,7 +5,7 @@ Test of the EventPrincipal class.
 ----------------------------------------------------------------------*/
 #include "DataFormats/Common/interface/BasicHandle.h"
 #include "DataFormats/Common/interface/Wrapper.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/Provenance/interface/BranchID.h"
 #include "DataFormats/Provenance/interface/BranchIDListHelper.h"
 #include "DataFormats/Provenance/interface/EventAuxiliary.h"
@@ -65,10 +65,10 @@ private:
       edm::ParameterSet const& moduleParams,
       std::string const& release = edm::getReleaseVersion(),
       std::string const& pass = edm::getPassID());
-  std::shared_ptr<edm::BranchDescription> fake_single_process_branch(
+  std::shared_ptr<edm::ProductDescription> fake_single_process_branch(
       std::string const& tag, std::string const& processName, std::string const& productInstanceName = std::string());
 
-  std::map<std::string, std::shared_ptr<edm::BranchDescription> > branchDescriptions_;
+  std::map<std::string, std::shared_ptr<edm::ProductDescription> > productDescriptions_;
   std::map<std::string, std::shared_ptr<edm::ProcessConfiguration> > processConfigurations_;
 
   std::shared_ptr<edm::ProductRegistry> pProductRegistry_;
@@ -102,7 +102,7 @@ std::shared_ptr<edm::ProcessConfiguration> test_ep::fake_single_module_process(s
   return result;
 }
 
-std::shared_ptr<edm::BranchDescription> test_ep::fake_single_process_branch(std::string const& tag,
+std::shared_ptr<edm::ProductDescription> test_ep::fake_single_process_branch(std::string const& tag,
                                                                             std::string const& processName,
                                                                             std::string const& productInstanceName) {
   std::string moduleLabel = processName + "dummyMod";
@@ -116,14 +116,14 @@ std::shared_ptr<edm::BranchDescription> test_ep::fake_single_process_branch(std:
   modParams.registerIt();
   std::shared_ptr<edm::ProcessConfiguration> process(fake_single_module_process(tag, processName, modParams));
 
-  auto result = std::make_shared<edm::BranchDescription>(edm::InEvent,
+  auto result = std::make_shared<edm::ProductDescription>(edm::InEvent,
                                                          moduleLabel,
                                                          processName,
                                                          productClassName,
                                                          friendlyProductClassName,
                                                          productInstanceName,
                                                          dummyType);
-  branchDescriptions_[tag] = result;
+  productDescriptions_[tag] = result;
   return result;
 }
 
@@ -152,8 +152,8 @@ void test_ep::setUp() {
     std::unique_ptr<edm::WrapperBase> product = std::make_unique<WDP>(std::make_unique<PRODUCT_TYPE>());
 
     std::string tag("rick");
-    assert(branchDescriptions_[tag]);
-    edm::BranchDescription branch = *branchDescriptions_[tag];
+    assert(productDescriptions_[tag]);
+    edm::ProductDescription branch = *productDescriptions_[tag];
 
     branch.init();
 
@@ -161,7 +161,7 @@ void test_ep::setUp() {
     edm::BranchKey const bk(branch);
     edm::ProductRegistry::ProductList::const_iterator it = pl.find(bk);
 
-    edm::BranchDescription const branchFromRegistry(it->second);
+    edm::ProductDescription const branchFromRegistry(it->second);
 
     std::vector<edm::BranchID> const ids;
     edm::ProductProvenance prov(branchFromRegistry.branchID(), ids);
@@ -200,7 +200,7 @@ void clear_map(MAP& m) {
 }
 
 void test_ep::tearDown() {
-  clear_map(branchDescriptions_);
+  clear_map(productDescriptions_);
   clear_map(processConfigurations_);
 
   pEvent_.reset();

--- a/FWCore/Framework/test/generichandle_t.cppunit.cc
+++ b/FWCore/Framework/test/generichandle_t.cppunit.cc
@@ -145,7 +145,7 @@ void testGenericHandle::getbyLabelTest() {
   edm::ParameterSet pset;
   pset.registerIt();
 
-  edm::BranchDescription product(
+  edm::ProductDescription product(
       edm::InEvent, label, processName, dummytype.userClassName(), className, productInstanceName, dummytype);
 
   product.init();
@@ -183,10 +183,10 @@ void testGenericHandle::getbyLabelTest() {
                          edm::StreamID::invalidStreamID());
   ep.fillEventPrincipal(eventAux, nullptr);
   ep.setLuminosityBlockPrincipal(lbp.get());
-  edm::BranchDescription const& branchFromRegistry = it->second;
+  edm::ProductDescription const& branchFromRegistry = it->second;
   std::vector<edm::BranchID> const ids;
   edm::ProductProvenance prov(branchFromRegistry.branchID(), ids);
-  edm::BranchDescription const desc(branchFromRegistry);
+  edm::ProductDescription const desc(branchFromRegistry);
   ep.put(desc, std::move(pprod), prov);
 
   edm::GenericHandle h("edmtest::DummyProduct");

--- a/FWCore/Framework/test/productregistry.cppunit.cc
+++ b/FWCore/Framework/test/productregistry.cppunit.cc
@@ -76,12 +76,12 @@ namespace {
       pc->setParameterSetID(dummyProcessPset.id());
 
       edm::ProductDescription prod(iDesc.branchType(),
-                                  name_,
-                                  iDesc.processName(),
-                                  iDesc.fullClassName(),
-                                  iDesc.friendlyClassName(),
-                                  iDesc.productInstanceName() + "-" + name_,
-                                  iDesc.unwrappedType());
+                                   name_,
+                                   iDesc.processName(),
+                                   iDesc.fullClassName(),
+                                   iDesc.friendlyClassName(),
+                                   iDesc.productInstanceName() + "-" + name_,
+                                   iDesc.unwrappedType());
       reg_->addProduct(prod);
     }
   };
@@ -108,20 +108,20 @@ void testProductRegistry::setUp() {
 
   simpleVecBranch_ =
       std::make_shared<edm::ProductDescription>(edm::InEvent,
-                                               "labelovsimple",
-                                               "PROD",
-                                               "edm::OwnVector<edmtest::Simple>",
-                                               "edmtestSimplesOwned",
-                                               "ovsimple",
-                                               edm::TypeWithDict(typeid(edm::OwnVector<edmtest::Simple>)));
+                                                "labelovsimple",
+                                                "PROD",
+                                                "edm::OwnVector<edmtest::Simple>",
+                                                "edmtestSimplesOwned",
+                                                "ovsimple",
+                                                edm::TypeWithDict(typeid(edm::OwnVector<edmtest::Simple>)));
   simpleDerivedVecBranch_ =
       std::make_shared<edm::ProductDescription>(edm::InEvent,
-                                               "labelovsimplederived",
-                                               "PROD",
-                                               "edm::OwnVector<edmtest::SimpleDerived>",
-                                               "edmtestSimpleDerivedsOwned",
-                                               "ovsimplederived",
-                                               edm::TypeWithDict(typeid(edm::OwnVector<edmtest::SimpleDerived>)));
+                                                "labelovsimplederived",
+                                                "PROD",
+                                                "edm::OwnVector<edmtest::SimpleDerived>",
+                                                "edmtestSimpleDerivedsOwned",
+                                                "ovsimplederived",
+                                                edm::TypeWithDict(typeid(edm::OwnVector<edmtest::SimpleDerived>)));
 }
 
 namespace {

--- a/FWCore/Framework/test/productregistry.cppunit.cc
+++ b/FWCore/Framework/test/productregistry.cppunit.cc
@@ -6,7 +6,7 @@
    \date 21 July 2005
 */
 
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/Provenance/interface/ProcessConfiguration.h"
 #include "DataFormats/TestObjects/interface/ToyProducts.h"
 #include "FWCore/Framework/interface/EventProcessor.h"
@@ -46,11 +46,11 @@ public:
   void testAddAlias();
 
 private:
-  std::shared_ptr<edm::BranchDescription> intBranch_;
-  std::shared_ptr<edm::BranchDescription> floatBranch_;
-  std::shared_ptr<edm::BranchDescription> intVecBranch_;
-  std::shared_ptr<edm::BranchDescription> simpleVecBranch_;
-  std::shared_ptr<edm::BranchDescription> simpleDerivedVecBranch_;
+  std::shared_ptr<edm::ProductDescription> intBranch_;
+  std::shared_ptr<edm::ProductDescription> floatBranch_;
+  std::shared_ptr<edm::ProductDescription> intVecBranch_;
+  std::shared_ptr<edm::ProductDescription> simpleVecBranch_;
+  std::shared_ptr<edm::ProductDescription> simpleDerivedVecBranch_;
 };
 
 ///registration of the test so that the runner can find it
@@ -60,7 +60,7 @@ namespace {
   struct Listener {
     int* heard_;
     Listener(int& hear) : heard_(&hear) {}
-    void operator()(edm::BranchDescription const&) { ++(*heard_); }
+    void operator()(edm::ProductDescription const&) { ++(*heard_); }
   };
 
   struct Responder {
@@ -69,13 +69,13 @@ namespace {
     Responder(std::string const& iName, edm::SignallingProductRegistry& iReg) : name_(iName), reg_(&iReg) {
       iReg.watchProductAdditions(this, &Responder::respond);
     }
-    void respond(edm::BranchDescription const& iDesc) {
+    void respond(edm::ProductDescription const& iDesc) {
       edm::ParameterSet dummyProcessPset;
       dummyProcessPset.registerIt();
       auto pc = std::make_shared<edm::ProcessConfiguration>();
       pc->setParameterSetID(dummyProcessPset.id());
 
-      edm::BranchDescription prod(iDesc.branchType(),
+      edm::ProductDescription prod(iDesc.branchType(),
                                   name_,
                                   iDesc.processName(),
                                   iDesc.fullClassName(),
@@ -97,17 +97,17 @@ void testProductRegistry::setUp() {
 
   edm::ParameterSet pset;
   pset.registerIt();
-  intBranch_ = std::make_shared<edm::BranchDescription>(
+  intBranch_ = std::make_shared<edm::ProductDescription>(
       edm::InEvent, "labeli", "PROD", "int", "int", "int", edm::TypeWithDict(typeid(int)));
 
-  floatBranch_ = std::make_shared<edm::BranchDescription>(
+  floatBranch_ = std::make_shared<edm::ProductDescription>(
       edm::InEvent, "labelf", "PROD", "float", "float", "float", edm::TypeWithDict(typeid(float)));
 
-  intVecBranch_ = std::make_shared<edm::BranchDescription>(
+  intVecBranch_ = std::make_shared<edm::ProductDescription>(
       edm::InEvent, "labelvi", "PROD", "std::vector<int>", "ints", "vint", edm::TypeWithDict(typeid(std::vector<int>)));
 
   simpleVecBranch_ =
-      std::make_shared<edm::BranchDescription>(edm::InEvent,
+      std::make_shared<edm::ProductDescription>(edm::InEvent,
                                                "labelovsimple",
                                                "PROD",
                                                "edm::OwnVector<edmtest::Simple>",
@@ -115,7 +115,7 @@ void testProductRegistry::setUp() {
                                                "ovsimple",
                                                edm::TypeWithDict(typeid(edm::OwnVector<edmtest::Simple>)));
   simpleDerivedVecBranch_ =
-      std::make_shared<edm::BranchDescription>(edm::InEvent,
+      std::make_shared<edm::ProductDescription>(edm::InEvent,
                                                "labelovsimplederived",
                                                "PROD",
                                                "edm::OwnVector<edmtest::SimpleDerived>",
@@ -144,7 +144,7 @@ void testProductRegistry::testSignal() {
   Listener listening(hear);
   reg.productAddedSignal_.connect(listening);
 
-  //BranchDescription prod(InEvent, "label", "PROD", "int", "int", "int", md);
+  //ProductDescription prod(InEvent, "label", "PROD", "int", "int", "int", md);
 
   //   reg.addProduct(prod);
   reg.addProduct(*intBranch_);
@@ -162,11 +162,11 @@ void testProductRegistry::testWatch() {
 
   Responder one("one", reg);
 
-  //BranchDescription prod(InEvent, "label", "PROD", "int", "int", "int");
+  //ProductDescription prod(InEvent, "label", "PROD", "int", "int", "int");
   //reg.addProduct(prod);
   reg.addProduct(*intBranch_);
 
-  //BranchDescription prod2(InEvent, "label", "PROD", "float", "float", "float");
+  //ProductDescription prod2(InEvent, "label", "PROD", "float", "float", "float");
   //   reg.addProduct(prod2);
   reg.addProduct(*floatBranch_);
 
@@ -190,7 +190,7 @@ void testProductRegistry::testCircular() {
   Responder one("one", reg);
   Responder two("two", reg);
 
-  //BranchDescription prod(InEvent, "label","PROD","int","int","int");
+  //ProductDescription prod(InEvent, "label","PROD","int","int","int");
   //reg.addProduct(prod);
   reg.addProduct(*intBranch_);
 

--- a/FWCore/Framework/test/stubs/TestGlobalAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/TestGlobalAnalyzers.cc
@@ -13,7 +13,7 @@ for testing purposes only.
 #include <tuple>
 #include <vector>
 
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/TestObjects/interface/ToyProducts.h"
 #include "FWCore/Framework/interface/CacheHandle.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -52,7 +52,7 @@ namespace edmtest {
       explicit StreamIntAnalyzer(edm::ParameterSet const& p)
           : trans_(p.getParameter<int>("transitions")), nLumis_(p.getUntrackedParameter<unsigned int>("nLumis", 1)) {
         bool verbose = p.getUntrackedParameter<bool>("verbose", true);
-        callWhenNewProductsRegistered([verbose](edm::BranchDescription const& desc) {
+        callWhenNewProductsRegistered([verbose](edm::ProductDescription const& desc) {
           if (verbose) {
             std::cout << "global::StreamIntAnalyzer " << desc.moduleLabel() << std::endl;
           }

--- a/FWCore/Framework/test/stubs/TestGlobalProducers.cc
+++ b/FWCore/Framework/test/stubs/TestGlobalProducers.cc
@@ -13,7 +13,7 @@ for testing purposes only.
 #include <tuple>
 #include <vector>
 
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/TestObjects/interface/ToyProducts.h"
 #include "FWCore/Framework/interface/CacheHandle.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -60,7 +60,7 @@ namespace edmtest {
     public:
       explicit StreamIntProducer(edm::ParameterSet const& p)
           : trans_(p.getParameter<int>("transitions")), nLumis_(p.getUntrackedParameter<unsigned int>("nLumis", 1)) {
-        callWhenNewProductsRegistered([](edm::BranchDescription const& desc) {
+        callWhenNewProductsRegistered([](edm::ProductDescription const& desc) {
           std::cout << "global::StreamIntProducer " << desc.moduleLabel() << std::endl;
         });
         produces<unsigned int>();

--- a/FWCore/Framework/test/stubs/TestLimitedAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/TestLimitedAnalyzers.cc
@@ -13,7 +13,7 @@ for testing purposes only.
 #include <tuple>
 #include <vector>
 
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/TestObjects/interface/ToyProducts.h"
 #include "FWCore/Framework/interface/CacheHandle.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -54,7 +54,7 @@ namespace edmtest {
             edm::limited::EDAnalyzer<edm::StreamCache<UnsafeCache>>(p),
             trans_(p.getParameter<int>("transitions")),
             nLumis_(p.getUntrackedParameter<unsigned int>("nLumis", 1)) {
-        callWhenNewProductsRegistered([](edm::BranchDescription const& desc) {
+        callWhenNewProductsRegistered([](edm::ProductDescription const& desc) {
           std::cout << "limited::StreamIntAnalyzer " << desc.moduleLabel() << std::endl;
         });
       }

--- a/FWCore/Framework/test/stubs/TestMergeResults.cc
+++ b/FWCore/Framework/test/stubs/TestMergeResults.cc
@@ -10,7 +10,7 @@
 
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/Wrapper.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/Provenance/interface/BranchID.h"
 #include "DataFormats/Provenance/interface/ProcessHistory.h"
 #include "DataFormats/Provenance/interface/Provenance.h"
@@ -387,7 +387,7 @@ namespace edmtest {
       e.getByLabel(inputTag, h_thing);
       assert(h_thing->a == 11);
 
-      edm::BranchID const& originalBranchID = h_thing.provenance()->branchDescription().originalBranchID();
+      edm::BranchID const& originalBranchID = h_thing.provenance()->productDescription().originalBranchID();
       //this will throw if the original provenance is not available
       e.getProvenance(originalBranchID);
     }
@@ -448,7 +448,7 @@ namespace edmtest {
       run.getByLabel(inputTag, h_thing);
       assert(h_thing->a == 100001);
 
-      edm::BranchID const& originalBranchID = h_thing.provenance()->branchDescription().originalBranchID();
+      edm::BranchID const& originalBranchID = h_thing.provenance()->productDescription().originalBranchID();
       run.getProvenance(originalBranchID);
     }
 
@@ -503,7 +503,7 @@ namespace edmtest {
       lumi.getByLabel(inputTag, h_thing);
       assert(h_thing->a == 1001);
 
-      edm::BranchID const& originalBranchID = h_thing.provenance()->branchDescription().originalBranchID();
+      edm::BranchID const& originalBranchID = h_thing.provenance()->productDescription().originalBranchID();
       lumi.getProvenance(originalBranchID);
     }
     indexLumi_ += 3;
@@ -546,8 +546,8 @@ namespace edmtest {
             abortWithMessage(functionName, "ThingWithMerge", tag, 0, 0, true);
           }
         }
-        if (!h_thingWithMerge.provenance()->branchDescription().isMergeable()) {
-          std::cerr << "TestMergeResults::checkExpectedRunProducts isMergeable from BranchDescription returns\n"
+        if (!h_thingWithMerge.provenance()->productDescription().isMergeable()) {
+          std::cerr << "TestMergeResults::checkExpectedRunProducts isMergeable from ProductDescription returns\n"
                     << "unexpected value for ThingWithMerge type." << std::endl;
           abort();
         }
@@ -565,8 +565,8 @@ namespace edmtest {
             abortWithMessage(functionName, "ThingWithIsEqual", tag, 0, 0, true);
           }
         }
-        if (h_thingWithIsEqual.provenance()->branchDescription().isMergeable()) {
-          std::cerr << "TestMergeResults::checkExpectedRunProducts isMergeable from BranchDescription returns\n"
+        if (h_thingWithIsEqual.provenance()->productDescription().isMergeable()) {
+          std::cerr << "TestMergeResults::checkExpectedRunProducts isMergeable from ProductDescription returns\n"
                     << "unexpected value for ThingWithIsEqual type." << std::endl;
           abort();
         }
@@ -606,8 +606,8 @@ namespace edmtest {
             abortWithMessage(functionName, "ThingWithMerge", tag, 0, 0, true);
           }
         }
-        if (!h_thingWithMerge.provenance()->branchDescription().isMergeable()) {
-          std::cerr << "TestMergeResults::checkExpectedLumiProducts isMergeable from BranchDescription returns\n"
+        if (!h_thingWithMerge.provenance()->productDescription().isMergeable()) {
+          std::cerr << "TestMergeResults::checkExpectedLumiProducts isMergeable from ProductDescription returns\n"
                     << "unexpected value for ThingWithMerge type." << std::endl;
           abort();
         }
@@ -625,8 +625,8 @@ namespace edmtest {
             abortWithMessage(functionName, "ThingWithIsEqual", tag, 0, 0, true);
           }
         }
-        if (h_thingWithIsEqual.provenance()->branchDescription().isMergeable()) {
-          std::cerr << "TestMergeResults::checkExpectedLumiProducts isMergeable from BranchDescription returns\n"
+        if (h_thingWithIsEqual.provenance()->productDescription().isMergeable()) {
+          std::cerr << "TestMergeResults::checkExpectedLumiProducts isMergeable from ProductDescription returns\n"
                     << "unexpected value for ThingWithIsEqual type." << std::endl;
           abort();
         }

--- a/FWCore/Framework/test/stubs/TestOneAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/TestOneAnalyzers.cc
@@ -12,7 +12,7 @@ for testing purposes only.
 #include <tuple>
 #include <vector>
 
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/TestObjects/interface/ToyProducts.h"
 #include "FWCore/Framework/interface/CacheHandle.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -37,7 +37,7 @@ namespace edmtest {
     public:
       explicit SharedResourcesAnalyzer(edm::ParameterSet const& p) : trans_(p.getParameter<int>("transitions")) {
         usesResource("foo");
-        callWhenNewProductsRegistered([](edm::BranchDescription const& desc) {
+        callWhenNewProductsRegistered([](edm::ProductDescription const& desc) {
           std::cout << "one::SharedResourcesAnalyzer " << desc.moduleLabel() << std::endl;
         });
       }

--- a/FWCore/Framework/test/stubs/TestStreamAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/TestStreamAnalyzers.cc
@@ -30,7 +30,7 @@ for testing purposes only.
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/EDMException.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/TestObjects/interface/ToyProducts.h"
 
 namespace edmtest {
@@ -75,7 +75,7 @@ namespace edmtest {
       GlobalIntAnalyzer(edm::ParameterSet const& p, Cache const* iGlobal) {
         trans_ = p.getParameter<int>("transitions");
         cvalue_ = p.getParameter<int>("cachevalue");
-        callWhenNewProductsRegistered([](edm::BranchDescription const& desc) {
+        callWhenNewProductsRegistered([](edm::ProductDescription const& desc) {
           std::cout << "stream::GlobalIntAnalyzer " << desc.moduleLabel() << std::endl;
         });
       }

--- a/FWCore/Framework/test/stubs/ToyIntProducers.cc
+++ b/FWCore/Framework/test/stubs/ToyIntProducers.cc
@@ -614,7 +614,7 @@ namespace edmtest {
   public:
     explicit ManyIntWhenRegisteredProducer(edm::ParameterSet const& p)
         : sourceLabel_(p.getParameter<std::string>("src")) {
-      callWhenNewProductsRegistered([=, this](edm::BranchDescription const& iBranch) {
+      callWhenNewProductsRegistered([=, this](edm::ProductDescription const& iBranch) {
         if (iBranch.moduleLabel() == sourceLabel_) {
           if (iBranch.branchType() != edm::InEvent) {
             throw edm::Exception(edm::errors::UnimplementedFeature)

--- a/FWCore/Framework/test/test_catch2notTP_MergeableRunProductMetadata.cc
+++ b/FWCore/Framework/test/test_catch2notTP_MergeableRunProductMetadata.cc
@@ -1,6 +1,6 @@
 #include "catch.hpp"
 
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/Provenance/interface/IndexIntoFile.h"
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
@@ -67,7 +67,7 @@ TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
     edm::ProductRegistry productRegistry;
 
     // not mergeable
-    edm::BranchDescription prod1(edm::InRun,
+    edm::ProductDescription prod1(edm::InRun,
                                  "label",
                                  "PROD",
                                  "edmtest::Thing",
@@ -78,7 +78,7 @@ TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
     productRegistry.copyProduct(prod1);
 
     // This one should be used
-    edm::BranchDescription prod2(edm::InRun,
+    edm::ProductDescription prod2(edm::InRun,
                                  "aLabel",
                                  "APROD",
                                  "edmtest::ThingWithMerge",
@@ -89,7 +89,7 @@ TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
     productRegistry.copyProduct(prod2);
 
     //not in a Run
-    edm::BranchDescription prod3(edm::InLumi,
+    edm::ProductDescription prod3(edm::InLumi,
                                  "bLabel",
                                  "BPROD",
                                  "edmtest::ThingWithMerge",
@@ -100,7 +100,7 @@ TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
     productRegistry.copyProduct(prod3);
 
     // produced
-    edm::BranchDescription prod4(edm::InRun,
+    edm::ProductDescription prod4(edm::InRun,
                                  "cLabel",
                                  "CPROD",
                                  "edmtest::ThingWithMerge",
@@ -111,7 +111,7 @@ TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
     productRegistry.addProduct(prod4);
 
     // dropped
-    edm::BranchDescription prod5(edm::InRun,
+    edm::ProductDescription prod5(edm::InRun,
                                  "dLabel",
                                  "DPROD",
                                  "edmtest::ThingWithMerge",
@@ -123,7 +123,7 @@ TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
     productRegistry.copyProduct(prod5);
 
     // Should be used but the same process name
-    edm::BranchDescription prod6(edm::InRun,
+    edm::ProductDescription prod6(edm::InRun,
                                  "eLabel",
                                  "APROD",
                                  "edmtest::ThingWithMerge",
@@ -134,7 +134,7 @@ TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
     productRegistry.copyProduct(prod6);
 
     // Should be used
-    edm::BranchDescription prod7(edm::InRun,
+    edm::ProductDescription prod7(edm::InRun,
                                  "fLabel",
                                  "AAPROD",
                                  "edmtest::ThingWithMerge",

--- a/FWCore/Framework/test/test_catch2notTP_MergeableRunProductMetadata.cc
+++ b/FWCore/Framework/test/test_catch2notTP_MergeableRunProductMetadata.cc
@@ -68,80 +68,80 @@ TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
 
     // not mergeable
     edm::ProductDescription prod1(edm::InRun,
-                                 "label",
-                                 "PROD",
-                                 "edmtest::Thing",
-                                 "edmtestThing",
-                                 "instance",
-                                 edm::TypeWithDict::byName("edmtest::Thing"),
-                                 false);
+                                  "label",
+                                  "PROD",
+                                  "edmtest::Thing",
+                                  "edmtestThing",
+                                  "instance",
+                                  edm::TypeWithDict::byName("edmtest::Thing"),
+                                  false);
     productRegistry.copyProduct(prod1);
 
     // This one should be used
     edm::ProductDescription prod2(edm::InRun,
-                                 "aLabel",
-                                 "APROD",
-                                 "edmtest::ThingWithMerge",
-                                 "edmtestThingWithMerge",
-                                 "instance",
-                                 edm::TypeWithDict::byName("edmtest::ThingWithMerge"),
-                                 false);
+                                  "aLabel",
+                                  "APROD",
+                                  "edmtest::ThingWithMerge",
+                                  "edmtestThingWithMerge",
+                                  "instance",
+                                  edm::TypeWithDict::byName("edmtest::ThingWithMerge"),
+                                  false);
     productRegistry.copyProduct(prod2);
 
     //not in a Run
     edm::ProductDescription prod3(edm::InLumi,
-                                 "bLabel",
-                                 "BPROD",
-                                 "edmtest::ThingWithMerge",
-                                 "edmtestThingWithMerge",
-                                 "instance",
-                                 edm::TypeWithDict::byName("edmtest::ThingWithMerge"),
-                                 false);
+                                  "bLabel",
+                                  "BPROD",
+                                  "edmtest::ThingWithMerge",
+                                  "edmtestThingWithMerge",
+                                  "instance",
+                                  edm::TypeWithDict::byName("edmtest::ThingWithMerge"),
+                                  false);
     productRegistry.copyProduct(prod3);
 
     // produced
     edm::ProductDescription prod4(edm::InRun,
-                                 "cLabel",
-                                 "CPROD",
-                                 "edmtest::ThingWithMerge",
-                                 "edmtestThingWithMerge",
-                                 "instance",
-                                 edm::TypeWithDict::byName("edmtest::ThingWithMerge"),
-                                 true);
+                                  "cLabel",
+                                  "CPROD",
+                                  "edmtest::ThingWithMerge",
+                                  "edmtestThingWithMerge",
+                                  "instance",
+                                  edm::TypeWithDict::byName("edmtest::ThingWithMerge"),
+                                  true);
     productRegistry.addProduct(prod4);
 
     // dropped
     edm::ProductDescription prod5(edm::InRun,
-                                 "dLabel",
-                                 "DPROD",
-                                 "edmtest::ThingWithMerge",
-                                 "edmtestThingWithMerge",
-                                 "instance",
-                                 edm::TypeWithDict::byName("edmtest::ThingWithMerge"),
-                                 false);
+                                  "dLabel",
+                                  "DPROD",
+                                  "edmtest::ThingWithMerge",
+                                  "edmtestThingWithMerge",
+                                  "instance",
+                                  edm::TypeWithDict::byName("edmtest::ThingWithMerge"),
+                                  false);
     prod5.setDropped(true);
     productRegistry.copyProduct(prod5);
 
     // Should be used but the same process name
     edm::ProductDescription prod6(edm::InRun,
-                                 "eLabel",
-                                 "APROD",
-                                 "edmtest::ThingWithMerge",
-                                 "edmtestThingWithMerge",
-                                 "instance",
-                                 edm::TypeWithDict::byName("edmtest::ThingWithMerge"),
-                                 false);
+                                  "eLabel",
+                                  "APROD",
+                                  "edmtest::ThingWithMerge",
+                                  "edmtestThingWithMerge",
+                                  "instance",
+                                  edm::TypeWithDict::byName("edmtest::ThingWithMerge"),
+                                  false);
     productRegistry.copyProduct(prod6);
 
     // Should be used
     edm::ProductDescription prod7(edm::InRun,
-                                 "fLabel",
-                                 "AAPROD",
-                                 "edmtest::ThingWithMerge",
-                                 "edmtestThingWithMerge",
-                                 "instance",
-                                 edm::TypeWithDict::byName("edmtest::ThingWithMerge"),
-                                 false);
+                                  "fLabel",
+                                  "AAPROD",
+                                  "edmtest::ThingWithMerge",
+                                  "edmtestThingWithMerge",
+                                  "instance",
+                                  edm::TypeWithDict::byName("edmtest::ThingWithMerge"),
+                                  false);
     productRegistry.copyProduct(prod7);
 
     edm::MergeableRunProductProcesses mergeableRunProductProcesses;

--- a/FWCore/Integration/plugins/DelayedReaderThrowingSource.cc
+++ b/FWCore/Integration/plugins/DelayedReaderThrowingSource.cc
@@ -92,14 +92,14 @@ namespace edm {
     std::vector<ProductDescription> branches;
     for (auto const& label : pset.getUntrackedParameter<std::vector<std::string>>("labels")) {
       branches.push_back(ProductDescription(InEvent,
-                                           label,        //module label
-                                           "INPUTTEST",  //can't be the present process name
-                                           twd.userClassName(),
-                                           twd.friendlyClassName(),
-                                           "",  //product instance name
-                                           twd,
-                                           false  //not produced
-                                           ));
+                                            label,        //module label
+                                            "INPUTTEST",  //can't be the present process name
+                                            twd.userClassName(),
+                                            twd.friendlyClassName(),
+                                            "",  //product instance name
+                                            twd,
+                                            false  //not produced
+                                            ));
       branches.back().setOnDemand(true);  //says we use delayed reader
     }
     productRegistryUpdate().updateFromInput(branches);

--- a/FWCore/Integration/plugins/DelayedReaderThrowingSource.cc
+++ b/FWCore/Integration/plugins/DelayedReaderThrowingSource.cc
@@ -89,9 +89,9 @@ namespace edm {
     dummy.registerIt();
     auto twd = TypeWithDict::byTypeInfo(typeid(edmtest::IntProduct));
 
-    std::vector<BranchDescription> branches;
+    std::vector<ProductDescription> branches;
     for (auto const& label : pset.getUntrackedParameter<std::vector<std::string>>("labels")) {
-      branches.push_back(BranchDescription(InEvent,
+      branches.push_back(ProductDescription(InEvent,
                                            label,        //module label
                                            "INPUTTEST",  //can't be the present process name
                                            twd.userClassName(),

--- a/FWCore/Integration/plugins/PutOrMergeTestSource.cc
+++ b/FWCore/Integration/plugins/PutOrMergeTestSource.cc
@@ -38,9 +38,9 @@ namespace edmtest {
     void readEvent_(EventPrincipal& eventPrincipal) final;
 
     int stage_;
-    BranchDescription thingDesc_;
-    BranchDescription thingWithMergeDesc_;
-    BranchDescription thingWithEqualDesc_;
+    ProductDescription thingDesc_;
+    ProductDescription thingWithMergeDesc_;
+    ProductDescription thingWithEqualDesc_;
     ProcessHistoryID historyID_;
   };
 }  // namespace edmtest

--- a/FWCore/Integration/plugins/SwitchProducerProvenanceAnalyzer.cc
+++ b/FWCore/Integration/plugins/SwitchProducerProvenanceAnalyzer.cc
@@ -94,7 +94,7 @@ namespace edmtest {
       // that case the normal grandparent can be found on the place of
       // the parent.
 
-      assert(parentProvenance.branchDescription().moduleLabel() == moduleLabel + "@test" + std::to_string(mode));
+      assert(parentProvenance.productDescription().moduleLabel() == moduleLabel + "@test" + std::to_string(mode));
 
       // Check grandparent as well
       parentProductProvenance = parentProvenance.productProvenance();
@@ -108,7 +108,7 @@ namespace edmtest {
     if (aliasMode_ and mode == 2) {
       postfix = 3;
     }
-    assert(grandParentProvenance.branchDescription().moduleLabel() == producerPrefix_ + std::to_string(postfix));
+    assert(grandParentProvenance.productDescription().moduleLabel() == producerPrefix_ + std::to_string(postfix));
   }
 }  // namespace edmtest
 using edmtest::SwitchProducerProvenanceAnalyzer;

--- a/FWCore/Integration/plugins/TableTestModules.cc
+++ b/FWCore/Integration/plugins/TableTestModules.cc
@@ -105,8 +105,8 @@ namespace edmtest {
       using namespace edm;
       assert(!keptProducts()[InEvent].empty());
       for (auto product : keptProducts()[InEvent]) {
-        BranchDescription const* branchDescription = product.first;
-        TypeID const& tid = branchDescription->unwrappedTypeID();
+        ProductDescription const* productDescription = product.first;
+        TypeID const& tid = productDescription->unwrappedTypeID();
         EDGetToken const& token = product.second;
         BasicHandle bh = e.getByToken(token, tid);
         assert(bh.isValid());

--- a/FWCore/Integration/plugins/TestGetterOfProducts.cc
+++ b/FWCore/Integration/plugins/TestGetterOfProducts.cc
@@ -3,6 +3,7 @@
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "DataFormats/TestObjects/interface/Thing.h"
 #include "DataFormats/TestObjects/interface/ToyProducts.h"
+#include "DataFormats/Provenance/interface/ProductDescriptionFwd.h"
 #include "FWCore/Framework/interface/GetterOfProducts.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/ModuleLabelMatch.h"
@@ -16,7 +17,6 @@
 #include <vector>
 
 namespace edm {
-  class ProductDescription;
   class Event;
   class EventSetup;
 }  // namespace edm

--- a/FWCore/Integration/plugins/TestGetterOfProducts.cc
+++ b/FWCore/Integration/plugins/TestGetterOfProducts.cc
@@ -16,7 +16,7 @@
 #include <vector>
 
 namespace edm {
-  class BranchDescription;
+  class ProductDescription;
   class Event;
   class EventSetup;
 }  // namespace edm
@@ -150,7 +150,7 @@ namespace edmtest {
     getterOfProducts_ = edm::GetterOfProducts<Thing>(edm::ProcessMatch(processName_), this, branchType_);
     getterUsingLabel_ = edm::GetterOfProducts<Thing>(edm::ModuleLabelMatch("A"), this, branchType_);
 
-    callWhenNewProductsRegistered([this](edm::BranchDescription const& bd) {
+    callWhenNewProductsRegistered([this](edm::ProductDescription const& bd) {
       getterOfIntProducts_(bd);
       getterOfProducts_(bd);
       getterUsingLabel_(bd);

--- a/FWCore/Integration/plugins/TestOutputWithGetterOfProducts.cc
+++ b/FWCore/Integration/plugins/TestOutputWithGetterOfProducts.cc
@@ -60,7 +60,7 @@ namespace edm {
         getterOfProductsRun_(TypeMatch(), this, InRun),
         getterOfProductsLumi_(edm::TypeMatch(), this, InLumi),
         getterOfProductsEvent_(edm::TypeMatch(), this) {
-    callWhenNewProductsRegistered([this](edm::BranchDescription const& bd) {
+    callWhenNewProductsRegistered([this](edm::ProductDescription const& bd) {
       getterOfProductsRun_(bd);
       getterOfProductsLumi_(bd);
       getterOfProductsEvent_(bd);

--- a/FWCore/Integration/plugins/TestOutputWithGetterOfProductsGlobal.cc
+++ b/FWCore/Integration/plugins/TestOutputWithGetterOfProductsGlobal.cc
@@ -61,7 +61,7 @@ namespace edm {
         getterOfProductsRun_(TypeMatch(), this, InRun),
         getterOfProductsLumi_(edm::TypeMatch(), this, InLumi),
         getterOfProductsEvent_(edm::TypeMatch(), this) {
-    callWhenNewProductsRegistered([this](edm::BranchDescription const& bd) {
+    callWhenNewProductsRegistered([this](edm::ProductDescription const& bd) {
       getterOfProductsRun_(bd);
       getterOfProductsLumi_(bd);
       getterOfProductsEvent_(bd);

--- a/FWCore/Integration/plugins/TestOutputWithGetterOfProductsLimited.cc
+++ b/FWCore/Integration/plugins/TestOutputWithGetterOfProductsLimited.cc
@@ -61,7 +61,7 @@ namespace edm {
         getterOfProductsRun_(TypeMatch(), this, InRun),
         getterOfProductsLumi_(edm::TypeMatch(), this, InLumi),
         getterOfProductsEvent_(edm::TypeMatch(), this) {
-    callWhenNewProductsRegistered([this](edm::BranchDescription const& bd) {
+    callWhenNewProductsRegistered([this](edm::ProductDescription const& bd) {
       getterOfProductsRun_(bd);
       getterOfProductsLumi_(bd);
       getterOfProductsEvent_(bd);

--- a/FWCore/Integration/plugins/TestParentage.cc
+++ b/FWCore/Integration/plugins/TestParentage.cc
@@ -92,10 +92,10 @@ namespace edmtest {
     if (not prov) {
       throw cms::Exception("MissingProvenance") << "Failed to get provenance for 'inputTag'";
     }
-    if (prov->originalBranchID() != prov->branchDescription().originalBranchID()) {
+    if (prov->originalBranchID() != prov->productDescription().originalBranchID()) {
       throw cms::Exception("InconsistentBranchID")
           << " test of Provenance::originalBranchID function failed. Expected "
-          << prov->branchDescription().originalBranchID() << " but see " << prov->originalBranchID();
+          << prov->productDescription().originalBranchID() << " but see " << prov->originalBranchID();
     }
 
     std::set<std::string> expectedAncestors(expectedAncestors_.begin(), expectedAncestors_.end());

--- a/FWCore/Modules/src/AsciiOutputModule.cc
+++ b/FWCore/Modules/src/AsciiOutputModule.cc
@@ -72,7 +72,7 @@ namespace edm {
 
     // Loop over products, and write some output for each...
     for (auto const& prod : e.productRegistry().productList()) {
-      BranchDescription const& desc = prod.second;
+      ProductDescription const& desc = prod.second;
       if (selected(desc)) {
         if (desc.isAlias()) {
           LogAbsolute("AsciiOut") << "ModuleLabel " << desc.moduleLabel() << " is an alias for";
@@ -82,7 +82,7 @@ namespace edm {
         LogAbsolute("AsciiOut") << prov;
 
         if (verbosity_ > 2) {
-          BranchDescription const& desc2 = prov.branchDescription();
+          ProductDescription const& desc2 = prov.productDescription();
           std::string const& process = desc2.processName();
           std::string const& label = desc2.moduleLabel();
           ProcessHistory const& processHistory = e.processHistory();

--- a/FWCore/Modules/src/EventContentAnalyzer.cc
+++ b/FWCore/Modules/src/EventContentAnalyzer.cc
@@ -299,7 +299,7 @@ namespace edm {
     sort_all(moduleLabels_);
     sort_all(getModuleLabels_);
     if (getData_) {
-      callWhenNewProductsRegistered([this](edm::BranchDescription const& iBranch) {
+      callWhenNewProductsRegistered([this](edm::ProductDescription const& iBranch) {
         if (getModuleLabels_.empty()) {
           const std::string kPathStatus("edm::PathStatus");
           const std::string kEndPathStatus("edm::EndPathStatus");
@@ -371,7 +371,7 @@ namespace edm {
                                     << " (productId = " << provenance->productID() << ")" << std::endl;
 
         if (listProvenance_) {
-          const bool isAlias = provenance->branchDescription().isAlias();
+          const bool isAlias = provenance->productDescription().isAlias();
           std::string aliasForModLabel;
           LogAbsolute("EventContent") << *provenance;
           if (isAlias) {

--- a/FWCore/Modules/src/GenericConsumer.cc
+++ b/FWCore/Modules/src/GenericConsumer.cc
@@ -33,7 +33,7 @@
 
 #include <boost/algorithm/string/replace.hpp>
 
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "FWCore/Framework/interface/global/EDAnalyzer.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
@@ -86,7 +86,7 @@ namespace {
       }
     }
 
-    bool match(edm::BranchDescription const& branch) const {
+    bool match(edm::ProductDescription const& branch) const {
       return (std::regex_match(branch.friendlyClassName(), type_) and
               std::regex_match(branch.moduleLabel(), moduleLabel_) and
               std::regex_match(branch.productInstanceName(), productInstanceName_) and
@@ -141,7 +141,7 @@ namespace edm {
         processProducts_(make_patterns(config.getUntrackedParameter<std::vector<std::string>>("processProducts"))),
         label_(config.getParameter<std::string>("@module_label")),
         verbose_(config.getUntrackedParameter<bool>("verbose")) {
-    callWhenNewProductsRegistered([this](edm::BranchDescription const& branch) {
+    callWhenNewProductsRegistered([this](edm::ProductDescription const& branch) {
       static const std::string kPathStatus("edm::PathStatus");
       static const std::string kEndPathStatus("edm::EndPathStatus");
 

--- a/FWCore/Modules/src/GetProductCheckerOutputModule.cc
+++ b/FWCore/Modules/src/GetProductCheckerOutputModule.cc
@@ -96,8 +96,8 @@ namespace edm {
                                        << productDescription->processName();
         } else {
           edm::LogInfo("DidNotFindProduct")
-              << "did not find " << productDescription->moduleLabel() << " '" << productDescription->productInstanceName()
-              << "' " << productDescription->processName();
+              << "did not find " << productDescription->moduleLabel() << " '"
+              << productDescription->productInstanceName() << "' " << productDescription->processName();
         }
       }
       if (nullptr != bh.provenance() &&

--- a/FWCore/Modules/src/GetProductCheckerOutputModule.cc
+++ b/FWCore/Modules/src/GetProductCheckerOutputModule.cc
@@ -85,28 +85,28 @@ namespace edm {
   template <typename T>
   static void check(T const& p, std::string const& id, SelectedProducts const& iProducts, bool iVerbose) {
     for (auto const& product : iProducts) {
-      BranchDescription const* branchDescription = product.first;
-      TypeID const& tid = branchDescription->unwrappedTypeID();
+      ProductDescription const* productDescription = product.first;
+      TypeID const& tid = productDescription->unwrappedTypeID();
       EDGetToken const& token = product.second;
       BasicHandle bh = p.getByToken(token, tid);
       if (iVerbose) {
         if (bh.isValid()) {
-          edm::LogInfo("FoundProduct") << "found " << branchDescription->moduleLabel() << " '"
-                                       << branchDescription->productInstanceName() << "' "
-                                       << branchDescription->processName();
+          edm::LogInfo("FoundProduct") << "found " << productDescription->moduleLabel() << " '"
+                                       << productDescription->productInstanceName() << "' "
+                                       << productDescription->processName();
         } else {
           edm::LogInfo("DidNotFindProduct")
-              << "did not find " << branchDescription->moduleLabel() << " '" << branchDescription->productInstanceName()
-              << "' " << branchDescription->processName();
+              << "did not find " << productDescription->moduleLabel() << " '" << productDescription->productInstanceName()
+              << "' " << productDescription->processName();
         }
       }
       if (nullptr != bh.provenance() &&
-          bh.provenance()->branchDescription().branchID() != branchDescription->branchID()) {
+          bh.provenance()->productDescription().branchID() != productDescription->branchID()) {
         throw cms::Exception("BranchIDMissMatch")
-            << "While processing " << id << " getByToken request for " << branchDescription->moduleLabel() << " '"
-            << branchDescription->productInstanceName() << "' " << branchDescription->processName()
-            << "\n should have returned BranchID " << branchDescription->branchID() << " but returned BranchID "
-            << bh.provenance()->branchDescription().branchID() << "\n";
+            << "While processing " << id << " getByToken request for " << productDescription->moduleLabel() << " '"
+            << productDescription->productInstanceName() << "' " << productDescription->processName()
+            << "\n should have returned BranchID " << productDescription->branchID() << " but returned BranchID "
+            << bh.provenance()->productDescription().branchID() << "\n";
       }
     }
   }

--- a/FWCore/Modules/src/LogErrorHarvester.cc
+++ b/FWCore/Modules/src/LogErrorHarvester.cc
@@ -64,7 +64,7 @@ namespace edm {
     //Need to be sure to run only after all other EDProducers have run
     callWhenNewProductsRegistered(
         [this, endPathStatusType, pathStatusType, triggerResultsType, excludedModules, includeModules](
-            edm::BranchDescription const& iBD) {
+            edm::ProductDescription const& iBD) {
           if ((iBD.branchType() == edm::InEvent and moduleDescription().processName() == iBD.processName()) and
               ((includeModules.empty() or includeModules.end() != includeModules.find(iBD.moduleLabel())) and
                (iBD.unwrappedTypeID() != endPathStatusType and iBD.unwrappedTypeID() != pathStatusType and

--- a/FWCore/Modules/src/ProvenanceCheckerOutputModule.cc
+++ b/FWCore/Modules/src/ProvenanceCheckerOutputModule.cc
@@ -102,12 +102,12 @@ namespace edm {
     std::set<BranchID> missingFromMapper;
     std::set<BranchID> missingProductProvenance;
 
-    std::map<BranchID, const BranchDescription*> idToBranchDescriptions;
+    std::map<BranchID, const ProductDescription*> idToProductDescriptions;
     for (auto const& product : keptProducts()[InEvent]) {
-      BranchDescription const* branchDescription = product.first;
-      BranchID branchID = branchDescription->branchID();
-      idToBranchDescriptions[branchID] = branchDescription;
-      TypeID const& tid(branchDescription->unwrappedTypeID());
+      ProductDescription const* productDescription = product.first;
+      BranchID branchID = productDescription->branchID();
+      idToProductDescriptions[branchID] = productDescription;
+      TypeID const& tid(productDescription->unwrappedTypeID());
       EDGetToken const& token = product.second;
       BasicHandle bh = e.getByToken(token, tid);
       bool cannotFindProductProvenance = false;
@@ -131,7 +131,7 @@ namespace edm {
     std::set<BranchID> branchesInReg;
     for (auto const& product : e.productRegistry().productList()) {
       branchesInReg.insert(product.second.branchID());
-      idToBranchDescriptions[product.second.branchID()] = &product.second;
+      idToProductDescriptions[product.second.branchID()] = &product.second;
     }
 
     std::set<BranchID> missingFromReg;
@@ -145,7 +145,7 @@ namespace edm {
       LogError("ProvenanceChecker") << "Missing the following BranchIDs from ProductProvenanceRetriever\n";
       for (std::set<BranchID>::iterator it = missingFromMapper.begin(), itEnd = missingFromMapper.end(); it != itEnd;
            ++it) {
-        LogProblem("ProvenanceChecker") << *it << " " << *(idToBranchDescriptions[*it]);
+        LogProblem("ProvenanceChecker") << *it << " " << *(idToProductDescriptions[*it]);
       }
     }
 
@@ -154,14 +154,14 @@ namespace edm {
       for (std::set<BranchID>::iterator it = missingProductProvenance.begin(), itEnd = missingProductProvenance.end();
            it != itEnd;
            ++it) {
-        LogProblem("ProvenanceChecker") << *it << " " << *(idToBranchDescriptions[*it]);
+        LogProblem("ProvenanceChecker") << *it << " " << *(idToProductDescriptions[*it]);
       }
     }
 
     if (!missingFromReg.empty()) {
       LogError("ProvenanceChecker") << "Missing the following BranchIDs from ProductRegistry\n";
       for (auto const& item : missingFromReg) {
-        LogProblem("ProvenanceChecker") << item << " " << *(idToBranchDescriptions[item]);
+        LogProblem("ProvenanceChecker") << item << " " << *(idToProductDescriptions[item]);
       }
     }
 

--- a/FWCore/Modules/src/SwitchProducer.cc
+++ b/FWCore/Modules/src/SwitchProducer.cc
@@ -14,7 +14,7 @@ namespace edm {
    *
    * The purposes of this EDProducer are
    * - Create the consumes() links to the chosen case to make the prefetching work correclty
-   * - Forward the produces() information to create proper BranchDescription objects
+   * - Forward the produces() information to create proper ProductDescription objects
    */
   class SwitchProducer : public global::EDProducer<> {
   public:
@@ -28,7 +28,7 @@ namespace edm {
     auto const& moduleLabel = iConfig.getParameter<std::string>("@module_label");
     auto const& chosenLabel = iConfig.getUntrackedParameter<std::string>("@chosen_case");
     auto const& processName = iConfig.getUntrackedParameter<std::string>("@process_name");
-    callWhenNewProductsRegistered([=, this](edm::BranchDescription const& iBranch) {
+    callWhenNewProductsRegistered([=, this](edm::ProductDescription const& iBranch) {
       if (iBranch.moduleLabel() == chosenLabel and iBranch.processName() == processName) {
         if (iBranch.branchType() != InEvent) {
           throw Exception(errors::UnimplementedFeature)
@@ -39,7 +39,7 @@ namespace edm {
         // With consumes, create the connection to the chosen case EDProducer for prefetching
         this->consumes(edm::TypeToGet{iBranch.unwrappedTypeID(), PRODUCT_TYPE},
                        edm::InputTag{iBranch.moduleLabel(), iBranch.productInstanceName(), iBranch.processName()});
-        // With produces, create a producer-like BranchDescription
+        // With produces, create a producer-like ProductDescription
         // early-enough for it to be flagged as non-OnDemand in case
         // the SwithcProducer is on a Path
         this->produces(iBranch.unwrappedTypeID(), iBranch.productInstanceName()).setSwitchAlias(iBranch.moduleLabel());

--- a/FWCore/Sources/interface/DaqProvenanceHelper.h
+++ b/FWCore/Sources/interface/DaqProvenanceHelper.h
@@ -6,7 +6,7 @@
 #include <vector>
 #include "oneapi/tbb/concurrent_unordered_map.h"
 
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/Provenance/interface/ParentageID.h"
 #include "DataFormats/Provenance/interface/ProcessConfiguration.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
@@ -33,7 +33,7 @@ namespace edm {
                                  std::string const& friendlyName,
                                  std::string const& sourceLabel);
     ProcessHistoryID daqInit(ProductRegistry& productRegistry, ProcessHistoryRegistry& processHistoryRegistry) const;
-    void saveInfo(BranchDescription const& oldBD, BranchDescription const& newBD) {
+    void saveInfo(ProductDescription const& oldBD, ProductDescription const& newBD) {
       oldProcessName_ = oldBD.processName();
       oldBranchID_ = oldBD.branchID();
       newBranchID_ = newBD.branchID();
@@ -47,14 +47,14 @@ namespace edm {
     ParentageID const& mapParentageID(ParentageID const& phid) const;
     BranchID const& mapBranchID(BranchID const& branchID) const;
 
-    BranchDescription const& branchDescription() const { return constBranchDescription_; }
+    ProductDescription const& productDescription() const { return constProductDescription_; }
     ProcessHistoryID const* oldProcessHistoryID() const { return oldProcessHistoryID_; }
     ProductProvenance const& dummyProvenance() const { return dummyProvenance_; }
 
     void setOldParentageIDToNew(ParentageID const& iOld, ParentageID const& iNew);
 
   private:
-    BranchDescription const constBranchDescription_;
+    ProductDescription const constProductDescription_;
     ProductProvenance dummyProvenance_;
     ParameterSet processParameterSet_;
 

--- a/FWCore/Sources/src/DaqProvenanceHelper.cc
+++ b/FWCore/Sources/src/DaqProvenanceHelper.cc
@@ -17,19 +17,19 @@
 
 namespace {
   edm::ProductDescription makeDescriptionForDaqProvHelper(edm::TypeID const& rawDataType,
-                                                         std::string const& collectionName,
-                                                         std::string const& friendlyName,
-                                                         std::string const& sourceLabel) {
+                                                          std::string const& collectionName,
+                                                          std::string const& friendlyName,
+                                                          std::string const& sourceLabel) {
     edm::ProductDescription desc(edm::InEvent,
-                                "rawDataCollector",
-                                // "source",
-                                "LHC",
-                                // "HLT",
-                                collectionName,
-                                friendlyName,
-                                "",
-                                edm::TypeWithDict(rawDataType.typeInfo()),
-                                false);
+                                 "rawDataCollector",
+                                 // "source",
+                                 "LHC",
+                                 // "HLT",
+                                 collectionName,
+                                 friendlyName,
+                                 "",
+                                 edm::TypeWithDict(rawDataType.typeInfo()),
+                                 false);
     desc.setIsProvenanceSetOnRead();
     return desc;
   }
@@ -97,7 +97,8 @@ namespace edm {
 
     // Insert an entry for this process in the process history registry
     ProcessHistory ph;
-    ph.emplace_back(constProductDescription_.processName(), processParameterSet_.id(), getReleaseVersion(), getPassID());
+    ph.emplace_back(
+        constProductDescription_.processName(), processParameterSet_.id(), getReleaseVersion(), getPassID());
     processHistoryRegistry.registerProcessHistory(ph);
 
     // Save the process history ID for use every event.

--- a/FWCore/Sources/src/DaqProvenanceHelper.cc
+++ b/FWCore/Sources/src/DaqProvenanceHelper.cc
@@ -16,11 +16,11 @@
 #include "FWCore/Version/interface/GetReleaseVersion.h"
 
 namespace {
-  edm::BranchDescription makeDescriptionForDaqProvHelper(edm::TypeID const& rawDataType,
+  edm::ProductDescription makeDescriptionForDaqProvHelper(edm::TypeID const& rawDataType,
                                                          std::string const& collectionName,
                                                          std::string const& friendlyName,
                                                          std::string const& sourceLabel) {
-    edm::BranchDescription desc(edm::InEvent,
+    edm::ProductDescription desc(edm::InEvent,
                                 "rawDataCollector",
                                 // "source",
                                 "LHC",
@@ -40,9 +40,9 @@ namespace edm {
                                            std::string const& collectionName,
                                            std::string const& friendlyName,
                                            std::string const& sourceLabel)
-      : constBranchDescription_(
+      : constProductDescription_(
             makeDescriptionForDaqProvHelper(rawDataType, collectionName, friendlyName, sourceLabel)),
-        dummyProvenance_(constBranchDescription_.branchID()),
+        dummyProvenance_(constProductDescription_.branchID()),
         processParameterSet_(),
         oldProcessName_(),
         oldBranchID_(),
@@ -51,8 +51,8 @@ namespace edm {
         phidMap_() {
     // Now we create a process parameter set for the "LHC" process.
     // We don't currently use the untracked parameters, However, we make them available, just in case.
-    std::string const& moduleLabel = constBranchDescription_.moduleLabel();
-    std::string const& processName = constBranchDescription_.processName();
+    std::string const& moduleLabel = constProductDescription_.moduleLabel();
+    std::string const& processName = constProductDescription_.processName();
     typedef std::vector<std::string> vstring;
     vstring empty;
 
@@ -93,11 +93,11 @@ namespace edm {
                                                 ProcessHistoryRegistry& processHistoryRegistry) const {
     // Now we need to set all the metadata
     // Add the product to the product registry
-    productRegistry.copyProduct(constBranchDescription_);
+    productRegistry.copyProduct(constProductDescription_);
 
     // Insert an entry for this process in the process history registry
     ProcessHistory ph;
-    ph.emplace_back(constBranchDescription_.processName(), processParameterSet_.id(), getReleaseVersion(), getPassID());
+    ph.emplace_back(constProductDescription_.processName(), processParameterSet_.id(), getReleaseVersion(), getPassID());
     processHistoryRegistry.registerProcessHistory(ph);
 
     // Save the process history ID for use every event.
@@ -119,7 +119,7 @@ namespace edm {
     for (auto const& pc : pcv) {
       if (pc.processName() == oldProcessName_) {
         newPCs.emplace_back(
-            constBranchDescription_.processName(), processParameterSet_.id(), pc.releaseVersion(), pc.passID());
+            constProductDescription_.processName(), processParameterSet_.id(), pc.releaseVersion(), pc.passID());
       }
     }
     if (newPCs.empty()) {

--- a/FWCore/TestProcessor/interface/TestProcessor.h
+++ b/FWCore/TestProcessor/interface/TestProcessor.h
@@ -366,7 +366,7 @@ This simulates a problem happening early in the job which causes processing not 
       std::shared_ptr<RunPrincipal> runPrincipal_;
       std::shared_ptr<LuminosityBlockPrincipal> lumiPrincipal_;
 
-      std::vector<std::pair<edm::BranchDescription, std::unique_ptr<WrapperBase>>> dataProducts_;
+      std::vector<std::pair<edm::ProductDescription, std::unique_ptr<WrapperBase>>> dataProducts_;
 
       RunNumber_t runNumber_ = 1;
       LuminosityBlockNumber_t lumiNumber_ = 1;

--- a/FWCore/TestProcessor/src/TestProcessor.cc
+++ b/FWCore/TestProcessor/src/TestProcessor.cc
@@ -131,7 +131,7 @@ namespace edm {
           processName = processConfiguration_->processName();
         }
         edm::TypeWithDict twd(produce.type_.typeInfo());
-        edm::BranchDescription product(edm::InEvent,
+        edm::ProductDescription product(edm::InEvent,
                                        produce.moduleLabel_,
                                        processName,
                                        twd.userClassName(),

--- a/FWCore/TestProcessor/src/TestProcessor.cc
+++ b/FWCore/TestProcessor/src/TestProcessor.cc
@@ -132,13 +132,13 @@ namespace edm {
         }
         edm::TypeWithDict twd(produce.type_.typeInfo());
         edm::ProductDescription product(edm::InEvent,
-                                       produce.moduleLabel_,
-                                       processName,
-                                       twd.userClassName(),
-                                       twd.friendlyClassName(),
-                                       produce.instanceLabel_,
-                                       twd,
-                                       true  //force this to come from 'source'
+                                        produce.moduleLabel_,
+                                        processName,
+                                        twd.userClassName(),
+                                        twd.friendlyClassName(),
+                                        produce.instanceLabel_,
+                                        twd,
+                                        true  //force this to come from 'source'
         );
         product.init();
         dataProducts_.emplace_back(product, std::unique_ptr<WrapperBase>());

--- a/Fireworks/Core/src/FWDetailViewManager.cc
+++ b/Fireworks/Core/src/FWDetailViewManager.cc
@@ -37,7 +37,7 @@
 #include "Fireworks/Core/interface/fwLog.h"
 #include "Fireworks/Core/interface/FWJobMetadataManager.h"
 
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "FWCore/Common/interface/EventBase.h"
 #include "DataFormats/FWLite/interface/Event.h"
 static std::string viewNameFrom(const std::string& iFull) {

--- a/Fireworks/Core/src/FWLiteJobMetadataManager.cc
+++ b/Fireworks/Core/src/FWLiteJobMetadataManager.cc
@@ -2,7 +2,7 @@
 #include "Fireworks/Core/interface/FWLiteJobMetadataUpdateRequest.h"
 #include "Fireworks/Core/interface/fwLog.h"
 #include "Fireworks/Core/interface/FWItemAccessorFactory.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/FWLite/interface/Event.h"
 
 #include "TFile.h"
@@ -13,7 +13,7 @@ FWLiteJobMetadataManager::FWLiteJobMetadataManager(void) : FWJobMetadataManager(
 
 bool FWLiteJobMetadataManager::hasModuleLabel(std::string& moduleLabel) {
   if (m_event) {
-    for (auto bit = m_event->getBranchDescriptions().begin(); bit != m_event->getBranchDescriptions().end(); ++bit) {
+    for (auto bit = m_event->getProductDescriptions().begin(); bit != m_event->getProductDescriptions().end(); ++bit) {
       if (bit->moduleLabel() == moduleLabel) {
         return true;
       }
@@ -57,7 +57,7 @@ bool FWLiteJobMetadataManager::doUpdate(FWJobMetadataUpdateRequest* request) {
   std::copy(history.rbegin(), history.rend(), std::back_inserter(processNamesInJob()));
 
   static const std::string s_blank;
-  const std::vector<edm::BranchDescription>& descriptions = m_event->getBranchDescriptions();
+  const std::vector<edm::ProductDescription>& descriptions = m_event->getProductDescriptions();
 
   Data d;
 
@@ -75,7 +75,7 @@ bool FWLiteJobMetadataManager::doUpdate(FWJobMetadataUpdateRequest* request) {
   std::string classType;
 
   for (size_t bi = 0, be = descriptions.size(); bi != be; ++bi) {
-    const edm::BranchDescription& desc = descriptions[bi];
+    const edm::ProductDescription& desc = descriptions[bi];
 
     if (!desc.present() || branchNamesInFile.end() == branchNamesInFile.find(desc.branchName()))
       continue;

--- a/Fireworks/FWInterface/src/FWFFMetadataManager.cc
+++ b/Fireworks/FWInterface/src/FWFFMetadataManager.cc
@@ -2,7 +2,7 @@
 #include "Fireworks/FWInterface/src/FWFFMetadataUpdateRequest.h"
 #include "Fireworks/Core/interface/fwLog.h"
 #include "DataFormats/Provenance/interface/StableProvenance.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "Fireworks/Core/interface/FWItemAccessorFactory.h"
 
@@ -16,7 +16,7 @@ bool FWFFMetadataManager::hasModuleLabel(std::string &iModuleLabel) {
 
     for (size_t pi = 0, pe = provenances.size(); pi != pe; ++pi) {
       edm::StableProvenance const *provenance = provenances[pi];
-      if (provenance && (provenance->branchDescription().moduleLabel() == iModuleLabel))
+      if (provenance && (provenance->productDescription().moduleLabel() == iModuleLabel))
         return true;
     }
   }
@@ -45,7 +45,7 @@ bool FWFFMetadataManager::doUpdate(FWJobMetadataUpdateRequest *request) {
     if (!provenance)
       continue;
     Data d;
-    const edm::BranchDescription &desc = provenance->branchDescription();
+    const edm::ProductDescription &desc = provenance->productDescription();
 
     const std::vector<FWRepresentationInfo> &infos = m_typeAndReps->representationsForType(desc.fullClassName());
 

--- a/GeneratorInterface/Core/interface/ConcurrentGeneratorFilter.h
+++ b/GeneratorInterface/Core/interface/ConcurrentGeneratorFilter.h
@@ -64,7 +64,7 @@
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/TypeID.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "CLHEP/Random/RandomEngine.h"
 
 // LHE Run

--- a/GeneratorInterface/Core/interface/ConcurrentHadronizerFilter.h
+++ b/GeneratorInterface/Core/interface/ConcurrentHadronizerFilter.h
@@ -64,7 +64,7 @@
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/TypeID.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "CLHEP/Random/RandomEngine.h"
 
 #include "GeneratorInterface/Core/interface/HepMCFilterDriver.h"
@@ -194,7 +194,7 @@ namespace edm {
         nAttempts_(1),
         hasFilter_(ps.exists("HepMCFilter")) {
     auto ptrThis = this;
-    this->callWhenNewProductsRegistered([ptrThis](BranchDescription const& iBD) {
+    this->callWhenNewProductsRegistered([ptrThis](ProductDescription const& iBD) {
       //this is called each time a module registers that it will produce a LHERunInfoProduct
       if (iBD.unwrappedTypeID() == edm::TypeID(typeid(LHERunInfoProduct)) && iBD.branchType() == InRun) {
         ++(ptrThis->counterRunInfoProducts_);

--- a/GeneratorInterface/Core/interface/HadronizerFilter.h
+++ b/GeneratorInterface/Core/interface/HadronizerFilter.h
@@ -28,7 +28,7 @@
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/TypeID.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "CLHEP/Random/RandomEngine.h"
 
 // #include "GeneratorInterface/ExternalDecays/interface/ExternalDecayDriver.h"
@@ -103,7 +103,7 @@ namespace edm {
         eventProductToken_(),
         counterRunInfoProducts_(0),
         nAttempts_(1) {
-    callWhenNewProductsRegistered([this](BranchDescription const& iBD) {
+    callWhenNewProductsRegistered([this](ProductDescription const& iBD) {
       //this is called each time a module registers that it will produce a LHERunInfoProduct
       if (iBD.unwrappedTypeID() == edm::TypeID(typeid(LHERunInfoProduct)) && iBD.branchType() == InRun) {
         ++(this->counterRunInfoProducts_);

--- a/GeneratorInterface/LHEInterface/plugins/LH5Source.cc
+++ b/GeneratorInterface/LHEInterface/plugins/LH5Source.cc
@@ -118,7 +118,7 @@ void LH5Source::putRunInfoProduct(edm::RunPrincipal& iRunPrincipal) {
   if (runInfoProductLast_) {
     auto product = std::make_unique<LHERunInfoProduct>(*runInfoProductLast_);
     std::unique_ptr<edm::WrapperBase> rdp = std::make_unique<edm::Wrapper<LHERunInfoProduct>>(std::move(product));
-    iRunPrincipal.put(lheProvenanceHelper_.runProductBranchDescription_, std::move(rdp));
+    iRunPrincipal.put(lheProvenanceHelper_.runProductProductDescription_, std::move(rdp));
   }
 }
 
@@ -160,7 +160,7 @@ void LH5Source::readEvent_(edm::EventPrincipal& eventPrincipal) {
                 std::bind(&LHEEventProduct::addComment, product.get(), std::placeholders::_1));
 
   std::unique_ptr<edm::WrapperBase> edp = std::make_unique<edm::Wrapper<LHEEventProduct>>(std::move(product));
-  eventPrincipal.put(lheProvenanceHelper_.eventProductBranchDescription_,
+  eventPrincipal.put(lheProvenanceHelper_.eventProductProductDescription_,
                      std::move(edp),
                      lheProvenanceHelper_.eventProductProvenance_);
 

--- a/GeneratorInterface/LHEInterface/plugins/LHEProvenanceHelper.cc
+++ b/GeneratorInterface/LHEInterface/plugins/LHEProvenanceHelper.cc
@@ -22,25 +22,25 @@ namespace edm {
                                            ProductRegistry& productRegistry,
                                            BranchIDListHelper& branchIDListHelper)
       : eventProductProductDescription_(ProductDescription(InEvent,
+                                                           "source",
+                                                           "LHEFile"
+                                                           // , "LHE"
+                                                           ,
+                                                           "LHEEventProduct",
+                                                           "LHEEventProduct",
+                                                           "",
+                                                           TypeWithDict(eventProductType.typeInfo()),
+                                                           false)),
+        runProductProductDescription_(ProductDescription(InRun,
                                                          "source",
                                                          "LHEFile"
                                                          // , "LHE"
                                                          ,
-                                                         "LHEEventProduct",
-                                                         "LHEEventProduct",
+                                                         "LHERunInfoProduct",
+                                                         "LHERunInfoProduct",
                                                          "",
-                                                         TypeWithDict(eventProductType.typeInfo()),
+                                                         TypeWithDict(runProductType.typeInfo()),
                                                          false)),
-        runProductProductDescription_(ProductDescription(InRun,
-                                                       "source",
-                                                       "LHEFile"
-                                                       // , "LHE"
-                                                       ,
-                                                       "LHERunInfoProduct",
-                                                       "LHERunInfoProduct",
-                                                       "",
-                                                       TypeWithDict(runProductType.typeInfo()),
-                                                       false)),
         eventProductProvenance_(eventProductProductDescription_.branchID()),
         commonProcessParameterSet_(fillCommonProcessParameterSet()),
         processParameterSet_(),

--- a/GeneratorInterface/LHEInterface/plugins/LHEProvenanceHelper.cc
+++ b/GeneratorInterface/LHEInterface/plugins/LHEProvenanceHelper.cc
@@ -21,7 +21,7 @@ namespace edm {
                                            TypeID const& runProductType,
                                            ProductRegistry& productRegistry,
                                            BranchIDListHelper& branchIDListHelper)
-      : eventProductBranchDescription_(BranchDescription(InEvent,
+      : eventProductProductDescription_(ProductDescription(InEvent,
                                                          "source",
                                                          "LHEFile"
                                                          // , "LHE"
@@ -31,7 +31,7 @@ namespace edm {
                                                          "",
                                                          TypeWithDict(eventProductType.typeInfo()),
                                                          false)),
-        runProductBranchDescription_(BranchDescription(InRun,
+        runProductProductDescription_(ProductDescription(InRun,
                                                        "source",
                                                        "LHEFile"
                                                        // , "LHE"
@@ -41,15 +41,15 @@ namespace edm {
                                                        "",
                                                        TypeWithDict(runProductType.typeInfo()),
                                                        false)),
-        eventProductProvenance_(eventProductBranchDescription_.branchID()),
+        eventProductProvenance_(eventProductProductDescription_.branchID()),
         commonProcessParameterSet_(fillCommonProcessParameterSet()),
         processParameterSet_(),
         branchListIndexes_(1, 0) {
     // Add the products to the product registry
-    auto ep = eventProductBranchDescription_;
+    auto ep = eventProductProductDescription_;
     ep.setIsProvenanceSetOnRead();
     productRegistry.copyProduct(ep);
-    auto rp = runProductBranchDescription_;
+    auto rp = runProductProductDescription_;
     rp.setIsProvenanceSetOnRead();
     productRegistry.copyProduct(rp);
     BranchIDList bli(1UL, ep.branchID().id());
@@ -61,8 +61,8 @@ namespace edm {
     // This function only fills parameters whose values are independent of the LHE input files.
     // We don't currently use the untracked parameters, However, we make them available, just in case.
     ParameterSet pset;
-    std::string const& moduleLabel = eventProductBranchDescription_.moduleLabel();
-    std::string const& processName = eventProductBranchDescription_.processName();
+    std::string const& moduleLabel = eventProductProductDescription_.moduleLabel();
+    std::string const& processName = eventProductProductDescription_.processName();
     std::string const moduleName = "LHESource";
     typedef std::vector<std::string> vstring;
     vstring empty;
@@ -124,7 +124,7 @@ namespace edm {
     // Insert an entry for this process in the process history registry
     ProcessHistory ph;
     ph.emplace_back(
-        eventProductBranchDescription_.processName(), processParameterSet_.id(), getReleaseVersion(), getPassID());
+        eventProductProductDescription_.processName(), processParameterSet_.id(), getReleaseVersion(), getPassID());
     processHistoryRegistry.registerProcessHistory(ph);
 
     // Save the process history ID for use every event.

--- a/GeneratorInterface/LHEInterface/plugins/LHEProvenanceHelper.h
+++ b/GeneratorInterface/LHEInterface/plugins/LHEProvenanceHelper.h
@@ -1,7 +1,7 @@
 #ifndef FWCore_Sources_LHEProvenanceHelper_h
 #define FWCore_Sources_LHEProvenanceHelper_h
 
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
 #include "DataFormats/Provenance/interface/ProductProvenance.h"
 #include "DataFormats/Provenance/interface/BranchListIndex.h"
@@ -24,8 +24,8 @@ namespace edm {
     ParameterSet fillCommonProcessParameterSet();
     void lheAugment(lhef::LHERunInfo const* runInfo);
     ProcessHistoryID lheInit(ProcessHistoryRegistry& processHistoryRegistry);
-    BranchDescription const eventProductBranchDescription_;
-    BranchDescription const runProductBranchDescription_;
+    ProductDescription const eventProductProductDescription_;
+    ProductDescription const runProductProductDescription_;
     ProductProvenance eventProductProvenance_;
     ParameterSet const commonProcessParameterSet_;
     ParameterSet processParameterSet_;

--- a/GeneratorInterface/LHEInterface/plugins/LHESource.cc
+++ b/GeneratorInterface/LHEInterface/plugins/LHESource.cc
@@ -117,7 +117,7 @@ void LHESource::putRunInfoProduct(edm::RunPrincipal& iRunPrincipal) {
   if (runInfoProductLast_) {
     auto product = std::make_unique<LHERunInfoProduct>(*runInfoProductLast_);
     std::unique_ptr<edm::WrapperBase> rdp = std::make_unique<edm::Wrapper<LHERunInfoProduct>>(std::move(product));
-    iRunPrincipal.putOrMerge(lheProvenanceHelper_.runProductBranchDescription_, std::move(rdp));
+    iRunPrincipal.putOrMerge(lheProvenanceHelper_.runProductProductDescription_, std::move(rdp));
   }
 }
 
@@ -159,7 +159,7 @@ void LHESource::readEvent_(edm::EventPrincipal& eventPrincipal) {
                 std::bind(&LHEEventProduct::addComment, product.get(), std::placeholders::_1));
 
   std::unique_ptr<edm::WrapperBase> edp = std::make_unique<edm::Wrapper<LHEEventProduct>>(std::move(product));
-  eventPrincipal.put(lheProvenanceHelper_.eventProductBranchDescription_,
+  eventPrincipal.put(lheProvenanceHelper_.eventProductProductDescription_,
                      std::move(edp),
                      lheProvenanceHelper_.eventProductProvenance_);
 

--- a/HLTrigger/HLTcore/interface/TriggerExpressionData.h
+++ b/HLTrigger/HLTcore/interface/TriggerExpressionData.h
@@ -119,7 +119,7 @@ namespace triggerExpression {
     }
 
     // set path status token
-    void setPathStatusToken(edm::BranchDescription const& branch, edm::ConsumesCollector&& iC);
+    void setPathStatusToken(edm::ProductDescription const& branch, edm::ConsumesCollector&& iC);
 
     // set the new event
     bool setEvent(const edm::Event& event, const edm::EventSetup& setup);

--- a/HLTrigger/HLTcore/plugins/TriggerSummaryProducerAOD.cc
+++ b/HLTrigger/HLTcore/plugins/TriggerSummaryProducerAOD.cc
@@ -107,7 +107,7 @@ TriggerSummaryProducerAOD::TriggerSummaryProducerAOD(const edm::ParameterSet& ps
   auto const& moduleLabelPatternsToMatch = moduleLabelPatternsToMatch_;
   auto const& moduleLabelPatternsToSkip = moduleLabelPatternsToSkip_;
   auto productMatch = [pProcessName, &moduleLabelPatternsToSkip, &moduleLabelPatternsToMatch](
-                          edm::BranchDescription const& iBranch) -> bool {
+                          edm::ProductDescription const& iBranch) -> bool {
     if (iBranch.processName() == *pProcessName || *pProcessName == "*") {
       auto const& label = iBranch.moduleLabel();
       for (auto& match : moduleLabelPatternsToMatch) {
@@ -161,7 +161,7 @@ TriggerSummaryProducerAOD::TriggerSummaryProducerAOD(const edm::ParameterSet& ps
 
   getL1TP2GTCandCollection_ = edm::GetterOfProducts<l1t::P2GTCandidateCollection>(productMatch, this);
 
-  callWhenNewProductsRegistered([this](edm::BranchDescription const& bd) {
+  callWhenNewProductsRegistered([this](edm::ProductDescription const& bd) {
     getTriggerFilterObjectWithRefs_(bd);
     getRecoEcalCandidateCollection_(bd);
     getElectronCollection_(bd);

--- a/HLTrigger/HLTcore/src/TriggerExpressionData.cc
+++ b/HLTrigger/HLTcore/src/TriggerExpressionData.cc
@@ -11,7 +11,7 @@
 
 namespace triggerExpression {
 
-  void Data::setPathStatusToken(edm::BranchDescription const& branch, edm::ConsumesCollector&& iC) {
+  void Data::setPathStatusToken(edm::ProductDescription const& branch, edm::ConsumesCollector&& iC) {
     m_pathStatusTokens[branch.moduleLabel()] = iC.consumes<edm::HLTPathStatus>(
         edm::InputTag(branch.moduleLabel(), branch.productInstanceName(), branch.processName()));
   }

--- a/HLTrigger/HLTfilters/plugins/TriggerResultsFilter.cc
+++ b/HLTrigger/HLTfilters/plugins/TriggerResultsFilter.cc
@@ -44,7 +44,7 @@ TriggerResultsFilter::TriggerResultsFilter(const edm::ParameterSet& config)
     }
 
     // consume all matching paths
-    callWhenNewProductsRegistered([this](edm::BranchDescription const& branch) {
+    callWhenNewProductsRegistered([this](edm::ProductDescription const& branch) {
       if (branch.branchType() == edm::InEvent and branch.className() == "edm::HLTPathStatus") {
         bool consumeBranch = true;
         for (auto& pattern : hltPathStatusPatterns_) {

--- a/HLTrigger/btau/plugins/HLTJetTag.h
+++ b/HLTrigger/btau/plugins/HLTJetTag.h
@@ -137,7 +137,7 @@ bool HLTJetTag<T>::hltFilter(edm::Event& event,
   if (not dependent.isNull() and not dependent.hasCache()) {
     // only an empty AssociationVector can have an invalid dependent collection
     edm::StableProvenance const& dependent_provenance = event.getStableProvenance(dependent.id());
-    if (dependent_provenance.branchDescription().dropped())
+    if (dependent_provenance.productDescription().dropped())
       // FIXME the error message should be made prettier
       throw cms::Exception("ProductNotFound") << "Product " << handle.provenance()->branchName() << " requires product "
                                               << dependent_provenance.branchName() << ", which has been dropped";

--- a/IOPool/Common/bin/EdmProvDump.cc
+++ b/IOPool/Common/bin/EdmProvDump.cc
@@ -36,7 +36,7 @@
 #include <sstream>
 #include <vector>
 
-typedef std::map<std::string, std::vector<edm::BranchDescription>> IdToBranches;
+typedef std::map<std::string, std::vector<edm::ProductDescription>> IdToBranches;
 typedef std::map<std::pair<std::string, std::string>, IdToBranches> ModuleToIdBranches;
 
 static std::ostream& prettyPrint(std::ostream& oStream,
@@ -899,7 +899,7 @@ void ProvenanceDumper::work_() {
   }
 
   //using edm::ParameterSetID as the key does not work
-  //   typedef std::map<edm::ParameterSetID, std::vector<edm::BranchDescription> > IdToBranches
+  //   typedef std::map<edm::ParameterSetID, std::vector<edm::ProductDescription> > IdToBranches
   ModuleToIdBranches moduleToIdBranches;
   //IdToBranches idToBranches;
 

--- a/IOPool/Input/src/PoolSource.cc
+++ b/IOPool/Input/src/PoolSource.cc
@@ -6,7 +6,7 @@
 #include "RootSecondaryFileSequence.h"
 #include "RunHelper.h"
 #include "DataFormats/Common/interface/ThinnedAssociation.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/Provenance/interface/IndexIntoFile.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"

--- a/IOPool/Input/src/ProvenanceAdaptor.cc
+++ b/IOPool/Input/src/ProvenanceAdaptor.cc
@@ -98,7 +98,7 @@ namespace edm {
       std::set<std::string> processNamesThatProduced;
       ProductRegistry::ProductList& prodList = productRegistry.productListUpdator();
       for (auto& item : prodList) {
-        BranchDescription& prod = item.second;
+        ProductDescription& prod = item.second;
         if (prod.branchType() == InEvent) {
           prod.init();
           processNamesThatProduced.insert(prod.processName());

--- a/IOPool/Input/src/RootDelayedReader.cc
+++ b/IOPool/Input/src/RootDelayedReader.cc
@@ -79,7 +79,7 @@ namespace edm {
     });
     TClass* cp = branchInfo->classCache_;
     if (nullptr == cp) {
-      branchInfo->classCache_ = TClass::GetClass(branchInfo->branchDescription_.wrappedName().c_str());
+      branchInfo->classCache_ = TClass::GetClass(branchInfo->productDescription_.wrappedName().c_str());
       cp = branchInfo->classCache_;
       branchInfo->offsetToWrapperBase_ = cp->GetBaseClassOffset(wrapperBaseTClass_);
     }

--- a/IOPool/Input/src/RootFile.h
+++ b/IOPool/Input/src/RootFile.h
@@ -317,7 +317,7 @@ namespace edm {
     std::string const& newBranchToOldBranch(std::string const& newBranch) const;
     void setPresenceInProductRegistry(ProductRegistry&, StoredProcessBlockHelper const&);
     void markBranchToBeDropped(bool dropDescendants,
-                               BranchDescription const& branch,
+                               ProductDescription const& branch,
                                std::set<BranchID>& branchesToDrop,
                                std::map<BranchID, BranchID> const& droppedToKeptAlias) const;
     void dropOnInputAndReorder(ProductRegistry&,

--- a/IOPool/Input/src/RootPrimaryFileSequence.cc
+++ b/IOPool/Input/src/RootPrimaryFileSequence.cc
@@ -25,7 +25,7 @@ namespace edm {
       : RootInputFileSequence(pset, catalog),
         input_(input),
         firstFile_(true),
-        branchesMustMatch_(BranchDescription::Permissive),
+        branchesMustMatch_(ProductDescription::Permissive),
         orderedProcessHistoryIDs_(),
         eventSkipperByID_(EventSkipperByID::create(pset).release()),
         initialNumberOfEventsToSkip_(pset.getUntrackedParameter<unsigned int>("skipEvents")),
@@ -56,7 +56,7 @@ namespace edm {
     std::string branchesMustMatch =
         pset.getUntrackedParameter<std::string>("branchesMustMatch", std::string("permissive"));
     if (branchesMustMatch == std::string("strict"))
-      branchesMustMatch_ = BranchDescription::Strict;
+      branchesMustMatch_ = ProductDescription::Strict;
 
     // Prestage the files
     for (setAtFirstFile(); !noMoreFiles(); setAtNextFile()) {

--- a/IOPool/Input/src/RootPrimaryFileSequence.h
+++ b/IOPool/Input/src/RootPrimaryFileSequence.h
@@ -14,7 +14,7 @@ RootPrimaryFileSequence: This is an InputSource
 #include "FWCore/Framework/interface/ProcessingController.h"
 #include "FWCore/Sources/interface/EventSkipperByID.h"
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
 
 #include <memory>
@@ -63,7 +63,7 @@ namespace edm {
 
     PoolSource& input_;
     bool firstFile_;
-    BranchDescription::MatchMode branchesMustMatch_;
+    ProductDescription::MatchMode branchesMustMatch_;
     std::vector<ProcessHistoryID> orderedProcessHistoryIDs_;
 
     std::shared_ptr<EventSkipperByID const> eventSkipperByID() const { return get_underlying_safe(eventSkipperByID_); }

--- a/IOPool/Input/src/RootTree.cc
+++ b/IOPool/Input/src/RootTree.cc
@@ -146,14 +146,14 @@ namespace edm {
 
   DelayedReader* RootTree::rootDelayedReader() const { return rootDelayedReader_.get(); }
 
-  void RootTree::setPresence(BranchDescription& prod, std::string const& oldBranchName) {
+  void RootTree::setPresence(ProductDescription& prod, std::string const& oldBranchName) {
     assert(isValid());
     if (tree_->GetBranch(oldBranchName.c_str()) == nullptr) {
       prod.setDropped(true);
     }
   }
 
-  void RootTree::addBranch(BranchDescription const& prod, std::string const& oldBranchName) {
+  void RootTree::addBranch(ProductDescription const& prod, std::string const& oldBranchName) {
     assert(isValid());
     //use the translated branch name
     TBranch* branch = tree_->GetBranch(oldBranchName.c_str());

--- a/IOPool/Input/src/RootTree.h
+++ b/IOPool/Input/src/RootTree.h
@@ -7,7 +7,7 @@ RootTree.h // used by ROOT input sources
 
 ----------------------------------------------------------------------*/
 
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/Provenance/interface/BranchID.h"
 #include "DataFormats/Provenance/interface/IndexIntoFile.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -41,9 +41,9 @@ namespace edm {
     unsigned int const defaultNonEventLearningEntries = 1U;
     using EntryNumber = IndexIntoFile::EntryNumber_t;
     struct BranchInfo {
-      BranchInfo(BranchDescription const& prod)
-          : branchDescription_(prod), productBranch_(nullptr), classCache_(nullptr), offsetToWrapperBase_(0) {}
-      BranchDescription const branchDescription_;
+      BranchInfo(ProductDescription const& prod)
+          : productDescription_(prod), productBranch_(nullptr), classCache_(nullptr), offsetToWrapperBase_(0) {}
+      ProductDescription const productDescription_;
       TBranch* productBranch_;
       //All access to a ROOT file is serialized
       CMS_SA_ALLOW mutable TClass* classCache_;
@@ -116,10 +116,10 @@ namespace edm {
 
     bool isValid() const;
     void numberOfBranchesToAdd(BranchMap::Map::size_type iSize) { branches_.reserve(iSize); }
-    void addBranch(BranchDescription const& prod, std::string const& oldBranchName);
+    void addBranch(ProductDescription const& prod, std::string const& oldBranchName);
     void dropBranch(std::string const& oldBranchName);
     void getEntry(TBranch* branch, EntryNumber entry) const;
-    void setPresence(BranchDescription& prod, std::string const& oldBranchName);
+    void setPresence(ProductDescription& prod, std::string const& oldBranchName);
 
     bool next() { return ++entryNumber_ < entries_; }
     bool nextWithCache();

--- a/IOPool/Input/test/ProductInfo.h
+++ b/IOPool/Input/test/ProductInfo.h
@@ -30,7 +30,7 @@ private:
 
 ProductInfo::ProductInfo(const edm::Provenance &prov, TBranch &branch, edm::EDGetToken const &token)
     : m_tag(prov.moduleLabel(), prov.productInstanceName(), prov.processName()),
-      m_type(prov.branchDescription().unwrappedTypeID()),
+      m_type(prov.productDescription().unwrappedTypeID()),
       m_token(token),
       m_size(0) {
   addBranchSizes(branch, m_size);

--- a/IOPool/Input/test/testNoParentDictionary.sh
+++ b/IOPool/Input/test/testNoParentDictionary.sh
@@ -17,6 +17,9 @@ mkdir DataFormats
 if [ -d ${CMSSW_BASE}/src/DataFormats/Common ]; then
     cp -Lr ${CMSSW_BASE}/src/DataFormats/Common DataFormats/
 fi
+if [ -d ${CMSSW_BASE}/src/DataFormats/Provenance ]; then
+    cp -Lr ${CMSSW_BASE}/src/DataFormats/Provenance DataFormats/
+fi
 
 # Copy DataFormats/TestObjects code to be able to edit it to make ROOT header parsing to fail
 for DIR in ${CMSSW_BASE} ${CMSSW_RELEASE_BASE} ${CMSSW_FULL_RELEASE_BASE} ; do

--- a/IOPool/Output/interface/PoolOutputModule.h
+++ b/IOPool/Output/interface/PoolOutputModule.h
@@ -91,14 +91,14 @@ namespace edm {
         std::shared_ptr<std::map<std::string, int>> treeMap_;
       };
 
-      explicit OutputItem(BranchDescription const* bd, EDGetToken const& token, int splitLevel, int basketSize);
+      explicit OutputItem(ProductDescription const* bd, EDGetToken const& token, int splitLevel, int basketSize);
 
-      BranchID branchID() const { return branchDescription_->branchID(); }
-      std::string const& branchName() const { return branchDescription_->branchName(); }
+      BranchID branchID() const { return productDescription_->branchID(); }
+      std::string const& branchName() const { return productDescription_->branchName(); }
 
-      bool operator<(OutputItem const& rh) const { return *branchDescription_ < *rh.branchDescription_; }
+      bool operator<(OutputItem const& rh) const { return *productDescription_ < *rh.productDescription_; }
 
-      BranchDescription const* branchDescription() const { return branchDescription_; }
+      ProductDescription const* productDescription() const { return productDescription_; }
       EDGetToken token() const { return token_; }
       void const* const product() const { return product_; }
       void const*& product() { return product_; }
@@ -107,7 +107,7 @@ namespace edm {
       int basketSize() const { return basketSize_; }
 
     private:
-      BranchDescription const* branchDescription_;
+      ProductDescription const* productDescription_;
       EDGetToken token_;
       void const* product_;
       int splitLevel_;

--- a/IOPool/Output/src/RootOutputTree.cc
+++ b/IOPool/Output/src/RootOutputTree.cc
@@ -2,7 +2,7 @@
 #include "RootOutputTree.h"
 
 #include "DataFormats/Common/interface/RefCoreStreamer.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "FWCore/MessageLogger/interface/JobReport.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -376,8 +376,8 @@ namespace edm {
                                  int splitLevel,
                                  int basketSize,
                                  bool produced) {
-    assert(splitLevel != BranchDescription::invalidSplitLevel);
-    assert(basketSize != BranchDescription::invalidBasketSize);
+    assert(splitLevel != ProductDescription::invalidSplitLevel);
+    assert(basketSize != ProductDescription::invalidBasketSize);
     TBranch* branch = tree_->Branch(branchName.c_str(), className.c_str(), &pProd, basketSize, splitLevel);
     assert(branch != nullptr);
     /*

--- a/IOPool/Streamer/doc/EventStreamingNotes.txt
+++ b/IOPool/Streamer/doc/EventStreamingNotes.txt
@@ -133,7 +133,7 @@ added a bunch of code for declaring classes explicitly to root using the
 pool utilities and the reflex information in order to debug a problem.
 The problem appears to stem from a giving class definition in the
 xml file of StreamerData - I've added it now.  The missing class was
-vector<BranchDescription>.
+vector<ProductDescription>.
 
 5-12-05 jbk:
 

--- a/IOPool/Streamer/src/ClassFiller.cc
+++ b/IOPool/Streamer/src/ClassFiller.cc
@@ -37,7 +37,7 @@ namespace edm::streamer {
       loadCap(std::string("edm::StreamedProduct"), missingDictionaries);
       loadCap(std::string("std::vector<edm::StreamedProduct>"), missingDictionaries);
       loadCap(std::string("edm::SendEvent"), missingDictionaries);
-      loadCap(std::string("std::vector<edm::BranchDescription>"), missingDictionaries);
+      loadCap(std::string("std::vector<edm::ProductDescription>"), missingDictionaries);
       loadCap(std::string("edm::SendJobHeader"), missingDictionaries);
       if (!missingDictionaries.empty()) {
         std::string context("Calling loadExtraClasses, checking dictionaries");

--- a/IOPool/Streamer/src/ClassFiller.cc
+++ b/IOPool/Streamer/src/ClassFiller.cc
@@ -37,7 +37,7 @@ namespace edm::streamer {
       loadCap(std::string("edm::StreamedProduct"), missingDictionaries);
       loadCap(std::string("std::vector<edm::StreamedProduct>"), missingDictionaries);
       loadCap(std::string("edm::SendEvent"), missingDictionaries);
-      loadCap(std::string("std::vector<edm::ProductDescription>"), missingDictionaries);
+      loadCap(std::string("std::vector<edm::BranchDescription>"), missingDictionaries);
       loadCap(std::string("edm::SendJobHeader"), missingDictionaries);
       if (!missingDictionaries.empty()) {
         std::string context("Calling loadExtraClasses, checking dictionaries");

--- a/IOPool/Streamer/src/DumpTools.cc
+++ b/IOPool/Streamer/src/DumpTools.cc
@@ -98,7 +98,7 @@ namespace edm::streamer {
       SendDescs const& descs = sd->descs();
       SendDescs::const_iterator iDesc(descs.begin()), eDesc(descs.end());
       while (iDesc != eDesc) {
-        BranchDescription branchDesc = *iDesc;
+        ProductDescription branchDesc = *iDesc;
         branchDesc.init();
         //branchDesc.write(std::cout);
         std::cout << branchDesc.branchName() << std::endl;

--- a/IOPool/Streamer/src/StreamSerializer.cc
+++ b/IOPool/Streamer/src/StreamSerializer.cc
@@ -5,7 +5,7 @@
  * Event) into streamer message objects.
  */
 #include "IOPool/Streamer/interface/StreamSerializer.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/Provenance/interface/ParentageRegistry.h"
 #include "DataFormats/Provenance/interface/Parentage.h"
 #include "DataFormats/Provenance/interface/ProductProvenance.h"
@@ -153,7 +153,7 @@ namespace edm::streamer {
     // lost when the streamer output module is used.
 
     for (auto const &selection : *selections_) {
-      BranchDescription const &desc = *selection.first;
+      ProductDescription const &desc = *selection.first;
       BasicHandle result = event.getByToken(selection.second, desc.unwrappedTypeID());
       if (!result.isValid()) {
         // No product with this ID was put in the event.

--- a/IOPool/Streamer/src/StreamerInputSource.cc
+++ b/IOPool/Streamer/src/StreamerInputSource.cc
@@ -6,7 +6,7 @@
 
 #include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/Framework/interface/FileBlock.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/Provenance/interface/ProductProvenance.h"
 #include "DataFormats/Provenance/interface/EventAuxiliary.h"
 #include "DataFormats/Provenance/interface/LuminosityBlockAuxiliary.h"
@@ -64,7 +64,7 @@ namespace edm::streamer {
     if (subsequent) {
       ProductRegistry pReg;
       pReg.updateFromInput(descs);
-      std::string mergeInfo = reg.merge(pReg, std::string(), BranchDescription::Permissive);
+      std::string mergeInfo = reg.merge(pReg, std::string(), ProductDescription::Permissive);
       if (!mergeInfo.empty()) {
         throw cms::Exception("MismatchedInput", "StreamerInputSource::mergeIntoRegistry") << mergeInfo;
       }
@@ -328,7 +328,7 @@ namespace edm::streamer {
                 << " " << spitem.desc()->className() << " " << spitem.desc()->productInstanceName() << " "
                 << spitem.desc()->branchID() << std::endl;
 
-      BranchDescription const branchDesc(*spitem.desc());
+      ProductDescription const branchDesc(*spitem.desc());
       // This ProductProvenance constructor inserts into the entry description registry
       if (spitem.parents()) {
         std::optional<ProductProvenance> productProvenance{std::in_place, spitem.branchID(), *spitem.parents()};

--- a/L1Trigger/GlobalTriggerAnalyzer/interface/L1GtUtilsHelper.h
+++ b/L1Trigger/GlobalTriggerAnalyzer/interface/L1GtUtilsHelper.h
@@ -20,6 +20,7 @@
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerRecord.h"
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"
 #include "DataFormats/L1GlobalTrigger/interface/L1GtTriggerMenuLite.h"
+#include "DataFormats/Provenance/interface/ProductDescriptionFwd.h"
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -30,7 +31,6 @@
 #include <utility>
 
 namespace edm {
-  class ProductDescription;
   class ParameterSetDescription;
 }  // namespace edm
 

--- a/L1Trigger/GlobalTriggerAnalyzer/interface/L1GtUtilsHelper.h
+++ b/L1Trigger/GlobalTriggerAnalyzer/interface/L1GtUtilsHelper.h
@@ -30,7 +30,7 @@
 #include <utility>
 
 namespace edm {
-  class BranchDescription;
+  class ProductDescription;
   class ParameterSetDescription;
 }  // namespace edm
 
@@ -79,7 +79,7 @@ private:
   // Callback which will be registered with the Framework if the InputTags
   // are not specified in the configuration or constructor arguments. It
   // will get called for each product in the ProductRegistry.
-  void checkToUpdateTags(edm::BranchDescription const& branchDescription,
+  void checkToUpdateTags(edm::ProductDescription const& productDescription,
                          edm::ConsumesCollector,
                          bool findRecord,
                          bool findReadoutRecord,

--- a/L1Trigger/GlobalTriggerAnalyzer/src/L1GtUtilsHelper.cc
+++ b/L1Trigger/GlobalTriggerAnalyzer/src/L1GtUtilsHelper.cc
@@ -1,5 +1,5 @@
 #include "L1Trigger/GlobalTriggerAnalyzer/interface/L1GtUtilsHelper.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/BranchType.h"
 #include "FWCore/Utilities/interface/TypeID.h"
@@ -25,7 +25,7 @@ void L1GtUtilsHelper::fillDescription(edm::ParameterSetDescription& desc) {
 
 namespace {
   template <typename C, typename T>
-  void setConsumesAndCheckAmbiguities(edm::BranchDescription const& iDesc,
+  void setConsumesAndCheckAmbiguities(edm::ProductDescription const& iDesc,
                                       C const& iPreferredTags,
                                       T& ioToken,
                                       edm::InputTag& ioTag,
@@ -85,12 +85,12 @@ namespace {
     }
   }
 }  // namespace
-void L1GtUtilsHelper::checkToUpdateTags(edm::BranchDescription const& branchDescription,
+void L1GtUtilsHelper::checkToUpdateTags(edm::ProductDescription const& productDescription,
                                         edm::ConsumesCollector consumesCollector,
                                         bool findRecord,
                                         bool findReadoutRecord,
                                         bool findMenuLite) {
-  if (branchDescription.dropped()) {
+  if (productDescription.dropped()) {
     return;
   }
   // This is only used if required InputTags were not specified already.
@@ -125,9 +125,9 @@ void L1GtUtilsHelper::checkToUpdateTags(edm::BranchDescription const& branchDesc
 
   // L1GlobalTriggerRecord
 
-  if (findRecord && (branchDescription.unwrappedTypeID() == edm::TypeID(typeid(L1GlobalTriggerRecord))) &&
-      (branchDescription.branchType() == edm::InEvent)) {
-    setConsumesAndCheckAmbiguities(branchDescription,
+  if (findRecord && (productDescription.unwrappedTypeID() == edm::TypeID(typeid(L1GlobalTriggerRecord))) &&
+      (productDescription.branchType() == edm::InEvent)) {
+    setConsumesAndCheckAmbiguities(productDescription,
                                    preferredL1GtRecordInputTag,
                                    m_l1GtRecordToken,
                                    m_l1GtRecordInputTag,
@@ -137,9 +137,9 @@ void L1GtUtilsHelper::checkToUpdateTags(edm::BranchDescription const& branchDesc
 
   // L1GlobalTriggerReadoutRecord
 
-  if (findReadoutRecord && (branchDescription.unwrappedTypeID() == edm::TypeID(typeid(L1GlobalTriggerReadoutRecord))) &&
-      (branchDescription.branchType() == edm::InEvent)) {
-    setConsumesAndCheckAmbiguities(branchDescription,
+  if (findReadoutRecord && (productDescription.unwrappedTypeID() == edm::TypeID(typeid(L1GlobalTriggerReadoutRecord))) &&
+      (productDescription.branchType() == edm::InEvent)) {
+    setConsumesAndCheckAmbiguities(productDescription,
                                    preferredL1GtReadoutRecordInputTag,
                                    m_l1GtReadoutRecordToken,
                                    m_l1GtReadoutRecordInputTag,
@@ -149,9 +149,9 @@ void L1GtUtilsHelper::checkToUpdateTags(edm::BranchDescription const& branchDesc
 
   // L1GtTriggerMenuLite
 
-  if (findMenuLite && (branchDescription.unwrappedTypeID() == edm::TypeID(typeid(L1GtTriggerMenuLite))) &&
-      (branchDescription.branchType() == edm::InEvent)) {
-    setConsumesAndCheckAmbiguities(branchDescription,
+  if (findMenuLite && (productDescription.unwrappedTypeID() == edm::TypeID(typeid(L1GtTriggerMenuLite))) &&
+      (productDescription.branchType() == edm::InEvent)) {
+    setConsumesAndCheckAmbiguities(productDescription,
                                    preferredL1GtTriggerMenuLiteInputTag,
                                    m_l1GtTriggerMenuLiteToken,
                                    m_l1GtTriggerMenuLiteInputTag,

--- a/L1Trigger/GlobalTriggerAnalyzer/src/L1GtUtilsHelper.cc
+++ b/L1Trigger/GlobalTriggerAnalyzer/src/L1GtUtilsHelper.cc
@@ -137,7 +137,8 @@ void L1GtUtilsHelper::checkToUpdateTags(edm::ProductDescription const& productDe
 
   // L1GlobalTriggerReadoutRecord
 
-  if (findReadoutRecord && (productDescription.unwrappedTypeID() == edm::TypeID(typeid(L1GlobalTriggerReadoutRecord))) &&
+  if (findReadoutRecord &&
+      (productDescription.unwrappedTypeID() == edm::TypeID(typeid(L1GlobalTriggerReadoutRecord))) &&
       (productDescription.branchType() == edm::InEvent)) {
     setConsumesAndCheckAmbiguities(productDescription,
                                    preferredL1GtReadoutRecordInputTag,

--- a/L1Trigger/L1TGlobal/interface/L1TGlobalUtilHelper.h
+++ b/L1Trigger/L1TGlobal/interface/L1TGlobalUtilHelper.h
@@ -19,6 +19,7 @@
 
 #include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
 #include "DataFormats/L1TGlobal/interface/GlobalExtBlk.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -29,7 +30,6 @@
 #include <utility>
 
 namespace edm {
-  class ProductDescription;
   class ParameterSetDescription;
 }  // namespace edm
 

--- a/L1Trigger/L1TGlobal/interface/L1TGlobalUtilHelper.h
+++ b/L1Trigger/L1TGlobal/interface/L1TGlobalUtilHelper.h
@@ -29,7 +29,7 @@
 #include <utility>
 
 namespace edm {
-  class BranchDescription;
+  class ProductDescription;
   class ParameterSetDescription;
 }  // namespace edm
 
@@ -79,7 +79,7 @@ namespace l1t {
     // Callback which will be registered with the Framework if the InputTags
     // are not specified in the configuration or constructor arguments. It
     // will get called for each product in the ProductRegistry.
-    void checkToUpdateTags(edm::BranchDescription const& branchDescription,
+    void checkToUpdateTags(edm::ProductDescription const& productDescription,
                            edm::ConsumesCollector,
                            bool findL1TAlgBlk,
                            bool findL1TExtBlk);

--- a/L1Trigger/L1TGlobal/src/L1TGlobalUtilHelper.cc
+++ b/L1Trigger/L1TGlobal/src/L1TGlobalUtilHelper.cc
@@ -1,5 +1,5 @@
 #include "L1Trigger/L1TGlobal/interface/L1TGlobalUtilHelper.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/BranchType.h"
 #include "FWCore/Utilities/interface/TypeID.h"
@@ -25,7 +25,7 @@ void l1t::L1TGlobalUtilHelper::fillDescription(edm::ParameterSetDescription& des
 
 namespace {
   template <typename C, typename T>
-  void setConsumesAndCheckAmbiguities(edm::BranchDescription const& iDesc,
+  void setConsumesAndCheckAmbiguities(edm::ProductDescription const& iDesc,
                                       C const& iPreferredTags,
                                       T& ioToken,
                                       edm::InputTag& ioTag,
@@ -82,7 +82,7 @@ namespace {
   }
 }  // namespace
 
-void l1t::L1TGlobalUtilHelper::checkToUpdateTags(edm::BranchDescription const& branchDescription,
+void l1t::L1TGlobalUtilHelper::checkToUpdateTags(edm::ProductDescription const& productDescription,
                                                  edm::ConsumesCollector consumesCollector,
                                                  bool findL1TAlgBlk,
                                                  bool findL1TExtBlk) {
@@ -108,7 +108,7 @@ void l1t::L1TGlobalUtilHelper::checkToUpdateTags(edm::BranchDescription const& b
   // TODO decide if the preferred input tags must be given as input parameters
   // or stay hardwired
 
-  if (branchDescription.dropped()) {
+  if (productDescription.dropped()) {
     return;
   }
 
@@ -120,9 +120,9 @@ void l1t::L1TGlobalUtilHelper::checkToUpdateTags(edm::BranchDescription const& b
 
   // GlobalAlgBlkBxCollection
 
-  if (findL1TAlgBlk && (branchDescription.unwrappedTypeID() == edm::TypeID(typeid(GlobalAlgBlkBxCollection))) &&
-      (branchDescription.branchType() == edm::InEvent)) {
-    setConsumesAndCheckAmbiguities(branchDescription,
+  if (findL1TAlgBlk && (productDescription.unwrappedTypeID() == edm::TypeID(typeid(GlobalAlgBlkBxCollection))) &&
+      (productDescription.branchType() == edm::InEvent)) {
+    setConsumesAndCheckAmbiguities(productDescription,
                                    preferredL1TAlgBlkInputTag,
                                    m_l1tAlgBlkToken,
                                    m_l1tAlgBlkInputTag,
@@ -132,9 +132,9 @@ void l1t::L1TGlobalUtilHelper::checkToUpdateTags(edm::BranchDescription const& b
 
   // GlobalExtBlkBxCollection
 
-  if (findL1TExtBlk && (branchDescription.unwrappedTypeID() == edm::TypeID(typeid(GlobalExtBlkBxCollection))) &&
-      (branchDescription.branchType() == edm::InEvent)) {
-    setConsumesAndCheckAmbiguities(branchDescription,
+  if (findL1TExtBlk && (productDescription.unwrappedTypeID() == edm::TypeID(typeid(GlobalExtBlkBxCollection))) &&
+      (productDescription.branchType() == edm::InEvent)) {
+    setConsumesAndCheckAmbiguities(productDescription,
                                    preferredL1TExtBlkInputTag,
                                    m_l1tExtBlkToken,
                                    m_l1tExtBlkInputTag,

--- a/PhysicsTools/NanoAOD/plugins/EventStringOutputBranches.h
+++ b/PhysicsTools/NanoAOD/plugins/EventStringOutputBranches.h
@@ -5,12 +5,12 @@
 #include <vector>
 #include <TTree.h>
 #include "FWCore/Framework/interface/EventForOutput.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 
 class EventStringOutputBranches {
 public:
-  EventStringOutputBranches(const edm::BranchDescription *desc,
+  EventStringOutputBranches(const edm::ProductDescription *desc,
                             const edm::EDGetToken &token,
                             bool update_only_at_new_lumi = false)
       : m_token(token), m_lastLumi(-1), m_fills(0), m_update_only_at_new_lumi(update_only_at_new_lumi) {

--- a/PhysicsTools/NanoAOD/plugins/LumiOutputBranches.h
+++ b/PhysicsTools/NanoAOD/plugins/LumiOutputBranches.h
@@ -6,12 +6,12 @@
 #include <TTree.h>
 #include "FWCore/Framework/interface/LuminosityBlockForOutput.h"
 #include "DataFormats/NanoAOD/interface/FlatTable.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 
 class LumiOutputBranches {
 public:
-  LumiOutputBranches(const edm::BranchDescription *desc, const edm::EDGetToken &token)
+  LumiOutputBranches(const edm::ProductDescription *desc, const edm::EDGetToken &token)
       : m_token(token),
         m_singleton(false),
         m_extension(DontKnowYetIfMainOrExtension),

--- a/PhysicsTools/NanoAOD/plugins/NanoAODOutputModule.cc
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODOutputModule.cc
@@ -34,7 +34,7 @@
 #include "FWCore/Utilities/interface/Digest.h"
 #include "IOPool/Provenance/interface/CommonProvenanceFiller.h"
 #include "DataFormats/Provenance/interface/BranchType.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
 #include "DataFormats/NanoAOD/interface/FlatTable.h"
 #include "DataFormats/NanoAOD/interface/UniqueString.h"

--- a/PhysicsTools/NanoAOD/plugins/SummaryTableOutputBranches.h
+++ b/PhysicsTools/NanoAOD/plugins/SummaryTableOutputBranches.h
@@ -6,12 +6,12 @@
 #include <TTree.h>
 #include "FWCore/Framework/interface/OccurrenceForOutput.h"
 #include "DataFormats/NanoAOD/interface/MergeableCounterTable.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 
 class SummaryTableOutputBranches {
 public:
-  SummaryTableOutputBranches(const edm::BranchDescription *desc, const edm::EDGetToken &token)
+  SummaryTableOutputBranches(const edm::ProductDescription *desc, const edm::EDGetToken &token)
       : m_token(token), m_fills(0) {
     if (desc->className() != "nanoaod::MergeableCounterTable")
       throw cms::Exception("Configuration", "NanoAODOutputModule can only write out MergableCounterTable objects");

--- a/PhysicsTools/NanoAOD/plugins/TableOutputBranches.h
+++ b/PhysicsTools/NanoAOD/plugins/TableOutputBranches.h
@@ -6,12 +6,12 @@
 #include <TTree.h>
 #include "FWCore/Framework/interface/OccurrenceForOutput.h"
 #include "DataFormats/NanoAOD/interface/FlatTable.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 
 class TableOutputBranches {
 public:
-  TableOutputBranches(const edm::BranchDescription *desc, const edm::EDGetToken &token)
+  TableOutputBranches(const edm::ProductDescription *desc, const edm::EDGetToken &token)
       : m_token(token), m_extension(DontKnowYetIfMainOrExtension), m_branchesBooked(false) {
     if (desc->className() != "nanoaod::FlatTable")
       throw cms::Exception("Configuration", "NanoAODOutputModule can only write out nanoaod::FlatTable objects");

--- a/PhysicsTools/NanoAOD/plugins/TriggerOutputBranches.h
+++ b/PhysicsTools/NanoAOD/plugins/TriggerOutputBranches.h
@@ -7,12 +7,12 @@
 #include "FWCore/Framework/interface/EventForOutput.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "FWCore/Common/interface/TriggerNames.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 
 class TriggerOutputBranches {
 public:
-  TriggerOutputBranches(const edm::BranchDescription *desc, const edm::EDGetToken &token)
+  TriggerOutputBranches(const edm::ProductDescription *desc, const edm::EDGetToken &token)
       : m_token(token), m_lastRun(-1), m_fills(0), m_processName(desc->processName()) {
     if (desc->className() != "edm::TriggerResults")
       throw cms::Exception("Configuration",

--- a/PhysicsTools/PatAlgos/plugins/PATTriggerEventProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerEventProducer.cc
@@ -144,7 +144,7 @@ PATTriggerEventProducer::PATTriggerEventProducer(const ParameterSet& iConfig)
   triggerMatcherTokens_ = vector_transform(
       tagsTriggerMatcher_, [this](InputTag const& tag) { return mayConsume<TriggerObjectStandAloneMatch>(tag); });
 
-  callWhenNewProductsRegistered([this](BranchDescription const& bd) {
+  callWhenNewProductsRegistered([this](ProductDescription const& bd) {
     if (not(this->autoProcessName_ and bd.processName() == this->moduleDescription().processName())) {
       triggerResultsGetter_(bd);
     }

--- a/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.cc
@@ -343,7 +343,7 @@ PATTriggerProducer::PATTriggerProducer(const ParameterSet& iConfig)
   if (iConfig.exists("exludeCollections"))
     exludeCollections_ = iConfig.getParameter<std::vector<std::string> >("exludeCollections");
 
-  callWhenNewProductsRegistered([this, &iConfig](BranchDescription const& bd) {
+  callWhenNewProductsRegistered([this, &iConfig](ProductDescription const& bd) {
     if (iConfig.exists("l1ExtraMu"))
       l1ExtraMuGetter_(bd);
     if (iConfig.exists("l1ExtraNoIsoEG"))

--- a/RecoMET/METFilters/plugins/EcalDeadCellTriggerPrimitiveFilter.cc
+++ b/RecoMET/METFilters/plugins/EcalDeadCellTriggerPrimitiveFilter.cc
@@ -185,7 +185,7 @@ EcalDeadCellTriggerPrimitiveFilter::EcalDeadCellTriggerPrimitiveFilter(const edm
       usekTPSaturated_(iConfig.getParameter<bool>("usekTPSaturated")),
       putToken_(produces<bool>()),
       tokens_(consumesCollector()) {
-  callWhenNewProductsRegistered([this](edm::BranchDescription const& iBranch) {
+  callWhenNewProductsRegistered([this](edm::ProductDescription const& iBranch) {
     // If TP is available, always use TP.
     // In RECO file, we always have ecalTPSkim (at least from 38X for data and 39X for MC).
     // In AOD file, we can only have recovered rechits in the reduced rechits collection after 42X

--- a/RecoMuon/L3MuonProducer/plugins/L3TkMuonProducer.cc
+++ b/RecoMuon/L3MuonProducer/plugins/L3TkMuonProducer.cc
@@ -33,7 +33,7 @@ L3TkMuonProducer::L3TkMuonProducer(const ParameterSet& parameterSet) {
   produces<TrackExtraCollection>();
   produces<TrackingRecHitCollection>();
 
-  callWhenNewProductsRegistered([this](const edm::BranchDescription& iBD) {
+  callWhenNewProductsRegistered([this](const edm::ProductDescription& iBD) {
     edm::TypeID id(typeid(L3MuonTrajectorySeedCollection));
     if (iBD.unwrappedTypeID() == id) {
       this->mayConsume<L3MuonTrajectorySeedCollection>(

--- a/SimGeneral/DataMixingModule/plugins/DataMixingModule.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingModule.cc
@@ -211,13 +211,13 @@ namespace edm {
 
     //  **** Check this out.... ****
 
-    // See FWCore/Framework/interface/BranchDescription.h
-    // BranchDescription contains all the information for the product.
+    // See FWCore/Framework/interface/ProductDescription.h
+    // ProductDescription contains all the information for the product.
 
     // This section not very backwards-compatible in terms of digi-merging.  Need
     // to be able to specify here which data format to look at...
 
-    //      edm::BranchDescription desc = it->second;
+    //      edm::ProductDescription desc = it->second;
     // if (!desc.friendlyClassName_.compare(0,9,"EBRecHitC")) {
     //	Subdetectors_.push_back(desc.productInstanceName_);
     // LogInfo("DataMixingModule") <<"Adding container

--- a/SimGeneral/MixingModule/plugins/CFWriter.cc
+++ b/SimGeneral/MixingModule/plugins/CFWriter.cc
@@ -14,7 +14,7 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Provenance/interface/Provenance.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "FWCore/Framework/interface/TriggerNamesService.h"
 
 #include "SimDataFormats/CrossingFrame/interface/MixCollection.h"

--- a/SimGeneral/MixingModule/plugins/HiMixingModule.cc
+++ b/SimGeneral/MixingModule/plugins/HiMixingModule.cc
@@ -50,7 +50,7 @@
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Provenance/interface/Provenance.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 
 #include <string>
 

--- a/SimGeneral/MixingModule/plugins/MixingModule.cc
+++ b/SimGeneral/MixingModule/plugins/MixingModule.cc
@@ -26,7 +26,7 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Provenance/interface/Provenance.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "SimDataFormats/CrossingFrame/interface/CrossingFramePlaybackInfoExtended.h"
 #include "SimDataFormats/CrossingFrame/interface/CrossingFramePlaybackInfoNew.h"
 #include "FWCore/Utilities/interface/TypeID.h"

--- a/Validation/GlobalHits/src/GlobalHitsAnalyzer.cc
+++ b/Validation/GlobalHits/src/GlobalHitsAnalyzer.cc
@@ -764,7 +764,7 @@ void GlobalHitsAnalyzer::fillG4MC(const edm::Event &iEvent) {
   // should have the information needed
   for (unsigned int i = 0; i < AllHepMCEvt.size(); ++i) {
     HepMCEvt = AllHepMCEvt[i];
-    if ((HepMCEvt.provenance()->branchDescription()).moduleLabel() == "generatorSmeared")
+    if ((HepMCEvt.provenance()->productDescription()).moduleLabel() == "generatorSmeared")
       break;
   }
 
@@ -773,7 +773,7 @@ void GlobalHitsAnalyzer::fillG4MC(const edm::Event &iEvent) {
     validHepMCevt = false;
   } else {
     eventout += "\n          Using HepMCProduct: ";
-    eventout += (HepMCEvt.provenance()->branchDescription()).moduleLabel();
+    eventout += (HepMCEvt.provenance()->productDescription()).moduleLabel();
   }
   if (validHepMCevt) {
     const HepMC::GenEvent *MCEvt = HepMCEvt->GetEvent();

--- a/Validation/GlobalHits/src/GlobalHitsProdHist.cc
+++ b/Validation/GlobalHits/src/GlobalHitsProdHist.cc
@@ -735,7 +735,7 @@ void GlobalHitsProdHist::fillG4MC(edm::Event &iEvent) {
   // should have the information needed
   for (unsigned int i = 0; i < AllHepMCEvt.size(); ++i) {
     HepMCEvt = AllHepMCEvt[i];
-    if ((HepMCEvt.provenance()->branchDescription()).moduleLabel() == "generatorSmeared")
+    if ((HepMCEvt.provenance()->productDescription()).moduleLabel() == "generatorSmeared")
       break;
   }
 
@@ -744,7 +744,7 @@ void GlobalHitsProdHist::fillG4MC(edm::Event &iEvent) {
     return;
   } else {
     eventout += "\n          Using HepMCProduct: ";
-    eventout += (HepMCEvt.provenance()->branchDescription()).moduleLabel();
+    eventout += (HepMCEvt.provenance()->productDescription()).moduleLabel();
   }
   const HepMC::GenEvent *MCEvt = HepMCEvt->GetEvent();
   nRawGenPart = MCEvt->particles_size();

--- a/Validation/GlobalHits/src/GlobalHitsProdHistStripper.cc
+++ b/Validation/GlobalHits/src/GlobalHitsProdHistStripper.cc
@@ -144,25 +144,25 @@ void GlobalHitsProdHistStripper::endRun(const edm::Run &iRun, const edm::EventSe
     /*
     std::cout << "Extracting histogram: " << std::endl
               << "       Module       : "
-              << (histogram1D.provenance()->branchDescription()).moduleLabel()
+              << (histogram1D.provenance()->productDescription()).moduleLabel()
               << std::endl
               << "       ProductID    : "
               <<
-    (histogram1D.provenance()->branchDescription()).productID().id()
+    (histogram1D.provenance()->productDescription()).productID().id()
               << std::endl
               << "       ClassName    : "
-              << (histogram1D.provenance()->branchDescription()).className()
+              << (histogram1D.provenance()->productDescription()).className()
               << std::endl
               << "       InstanceName : "
               <<
-    (histogram1D.provenance()->branchDescription()).productInstanceName()
+    (histogram1D.provenance()->productDescription()).productInstanceName()
               << std::endl
               << "       BranchName   : "
-              << (histogram1D.provenance()->branchDescription()).branchName()
+              << (histogram1D.provenance()->productDescription()).branchName()
               << std::endl;
     */
 
-    if ((histogram1D.provenance()->branchDescription()).moduleLabel() != "globalhitsprodhist")
+    if ((histogram1D.provenance()->productDescription()).moduleLabel() != "globalhitsprodhist")
       continue;
 
     std::string histname = histogram1D->GetName();

--- a/Validation/GlobalHits/src/GlobalHitsProducer.cc
+++ b/Validation/GlobalHits/src/GlobalHitsProducer.cc
@@ -262,7 +262,7 @@ void GlobalHitsProducer::fillG4MC(edm::Event &iEvent) {
   // should have the information needed
   for (unsigned int i = 0; i < AllHepMCEvt.size(); ++i) {
     HepMCEvt = AllHepMCEvt[i];
-    if ((HepMCEvt.provenance()->branchDescription()).moduleLabel() == "generatorSmeared")
+    if ((HepMCEvt.provenance()->productDescription()).moduleLabel() == "generatorSmeared")
       break;
   }
 
@@ -271,7 +271,7 @@ void GlobalHitsProducer::fillG4MC(edm::Event &iEvent) {
     return;
   } else {
     eventout += "\n          Using HepMCProduct: ";
-    eventout += (HepMCEvt.provenance()->branchDescription()).moduleLabel();
+    eventout += (HepMCEvt.provenance()->productDescription()).moduleLabel();
   }
   const HepMC::GenEvent *MCEvt = HepMCEvt->GetEvent();
   nRawGenPart = MCEvt->particles_size();

--- a/Validation/GlobalRecHits/src/GlobalRecHitsAnalyzer.cc
+++ b/Validation/GlobalRecHits/src/GlobalRecHitsAnalyzer.cc
@@ -36,7 +36,7 @@ GlobalRecHitsAnalyzer::GlobalRecHitsAnalyzer(const edm::ParameterSet& iPSet)
       edm::ProcessMatch("*"), this);
   HORecHitgetter_ = edm::GetterOfProducts<edm::SortedCollection<HORecHit, edm::StrictWeakOrdering<HORecHit>>>(
       edm::ProcessMatch("*"), this);
-  callWhenNewProductsRegistered([this](edm::BranchDescription const& bd) {
+  callWhenNewProductsRegistered([this](edm::ProductDescription const& bd) {
     // in case of EDAliases, consume only the aliased-for original products
     if (bd.isAnyAlias())
       return;


### PR DESCRIPTION
#### PR description:

Utilize using to rename BranchDescription to the more accurate ProductDescription. A future change will involve creating a ProductDescription class and possibly relegating BranchDescription to be used internally for the root file format.

#### PR validation:

Code compiles. Relevant unit tests passed.

resolves https://github.com/cms-sw/framework-team/issues/1190