### PR TITLE
Process modifier for displaced SUSY simulation fix

### DIFF
--- a/Configuration/ProcessModifiers/python/fixLongLivedSleptonSim_cff.py
+++ b/Configuration/ProcessModifiers/python/fixLongLivedSleptonSim_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+# Designed to disable a bug affecting long lived slepton decays in HepMC-G4 interface
+fixLongLivedSleptonSim = cms.Modifier()

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -285,7 +285,7 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
         MinPhiCut = cms.double(-3.14159265359), ## (radians)
         MaxPhiCut = cms.double(3.14159265359),  ## according to CMS conventions
         ApplyLumiMonitorCuts = cms.bool(False), ## primary for lumi monitors
-        IsSmuon = cms.bool(False),
+        IsSlepton = cms.bool(False),
         Verbosity = cms.untracked.int32(0),
         PDGselection = cms.PSet(
             PDGfilterSel = cms.bool(False), ## filter out unwanted particles
@@ -789,4 +789,12 @@ from Configuration.Eras.Modifier_phase2_hgcalV18_cff import phase2_hgcalV18
 phase2_hgcalV18.toModify(g4SimHits,
                  HGCSD = dict(
                      HitCollection = 2)
+)
+
+##
+## Fix for long-lived slepton simulation
+##
+from Configuration.ProcessModifiers.fixLongLivedSleptonSim_cff import fixLongLivedSleptonSim
+dd4hep.toModify( g4SimHits,
+                 Generator = dict(IsSlepton = True)
 )

--- a/SimG4Core/Generators/interface/Generator.h
+++ b/SimG4Core/Generators/interface/Generator.h
@@ -45,7 +45,7 @@ private:
   bool fEtaCuts;
   bool fPhiCuts;
   bool fFiductialCuts;
-  bool fSmuon;
+  bool fSlepton;
   double theMinPhiCut;
   double theMaxPhiCut;
   double theMinEtaCut;

--- a/SimG4Core/Generators/interface/Generator3.h
+++ b/SimG4Core/Generators/interface/Generator3.h
@@ -45,6 +45,7 @@ private:
   bool fEtaCuts;
   bool fPhiCuts;
   bool fFiductialCuts;
+  bool fSlepton;
   double theMinPhiCut;
   double theMaxPhiCut;
   double theMinEtaCut;

--- a/SimG4Core/Generators/src/Generator.cc
+++ b/SimG4Core/Generators/src/Generator.cc
@@ -25,7 +25,7 @@ Generator::Generator(const ParameterSet &p)
       fPtransCut(p.getParameter<bool>("ApplyPtransCut")),
       fEtaCuts(p.getParameter<bool>("ApplyEtaCuts")),
       fPhiCuts(p.getParameter<bool>("ApplyPhiCuts")),
-      fSmuon(p.getParameter<bool>("IsSmuon")),
+      fSlepton(p.getParameter<bool>("IsSlepton")),
       theMinPhiCut(p.getParameter<double>("MinPhiCut")),  // in radians (CMS standard)
       theMaxPhiCut(p.getParameter<double>("MaxPhiCut")),
       theMinEtaCut(p.getParameter<double>("MinEtaCut")),
@@ -366,7 +366,7 @@ void Generator::HepMC2G4(const HepMC::GenEvent *evt_orig, G4Event *g4evt) {
           // Decay chain outside the fiducial cylinder defined by theRDecLenCut
           // are used for Geant4 tracking with predefined decay channel
           // In the case of decay in vacuum particle is not tracked by Geant4
-        } else if (2 == status && x2 * x2 + y2 * y2 >= theDecRCut2 && (fSmuon || std::abs(z2) < Z_hector)) {
+        } else if (2 == status && x2 * x2 + y2 * y2 >= theDecRCut2 && (fSlepton || std::abs(z2) < Z_hector)) {
           toBeAdded = true;
           if (verbose > 1)
             edm::LogVerbatim("SimG4CoreGenerator") << "GenParticle barcode = " << (*pitr)->barcode() << " passed case 2"
@@ -478,7 +478,7 @@ void Generator::particleAssignDaughters(G4PrimaryParticle *g4p, HepMC::GenPartic
           << "Assigning a " << (*vpdec)->pdg_id() << " as daughter of a " << vp->pdg_id() << " status=" << status;
 
     bool isInList;
-    if (fSmuon) {
+    if (fSlepton) {
       std::vector<int> fParticleList = {1000011, 1000013, 1000015, 2000011, 2000013, 2000015};
       isInList = (std::find(fParticleList.begin(), fParticleList.end(), std::abs(vp->pdg_id())) != fParticleList.end());
     } else {


### PR DESCRIPTION
#### PR description:

This PR is a follow up of PR #47165 . It adds a process modifier for automatically activating the flag "IsSlepton", needed for production of signal samples involving long-lived sleptons.

Also, two additional minor modifications are introduced:
1. The changes added in PR #47165 are propagated to Generator3.cc.
2. Flag "IsSmuon" is renamed to "IsSlepton", as it applies for selectrons as well.

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

This PR has been validated with signal samples of smuon pair production decaying to a muon and a gravitino (SMuon -> muon + G).

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR needs to be backported (together with #47165) to 10_6_X, 12_4_X and 13_0_X for Run2 and Run3 signal sample productions.

@civanch @kpedro88 @tvami @jaimeleonh 