### PR TITLE
Remove unused variable in TestAssociator.cc

### DIFF
--- a/SimTracker/TrackerHitAssociation/test/TestAssociator.cc
+++ b/SimTracker/TrackerHitAssociation/test/TestAssociator.cc
@@ -109,7 +109,7 @@ void TestAssociator::printRechitSimhit(const edm::Handle<edmNew::DetSetVector<re
           edm::LogVerbatim("TrackAssociator")
               << " simtrack ID = " << m.trackId() << "                            Simhit Pos = " << m.localPosition();
           // Seek the smallest residual
-          auto ptr = dynamic_cast<const SiPixelRecHit*>(&rechit));
+          auto ptr = dynamic_cast<const SiPixelRecHit*>(&rechit);
           if (nullptr != ptr) {
             isPixel = true;
             dist = (rechit.localPosition() - m.localPosition()).mag();  // pixels measure 2 dimensions

--- a/SimTracker/TrackerHitAssociation/test/TestAssociator.cc
+++ b/SimTracker/TrackerHitAssociation/test/TestAssociator.cc
@@ -109,7 +109,7 @@ void TestAssociator::printRechitSimhit(const edm::Handle<edmNew::DetSetVector<re
           edm::LogVerbatim("TrackAssociator")
               << " simtrack ID = " << m.trackId() << "                            Simhit Pos = " << m.localPosition();
           // Seek the smallest residual
-          if (const SiPixelRecHit* dummy = dynamic_cast<const SiPixelRecHit*>(&rechit)) {
+          if (dynamic_cast<const SiPixelRecHit*>(&rechit)) {
             isPixel = true;
             dist = (rechit.localPosition() - m.localPosition()).mag();  // pixels measure 2 dimensions
           } else {

--- a/SimTracker/TrackerHitAssociation/test/TestAssociator.cc
+++ b/SimTracker/TrackerHitAssociation/test/TestAssociator.cc
@@ -109,7 +109,8 @@ void TestAssociator::printRechitSimhit(const edm::Handle<edmNew::DetSetVector<re
           edm::LogVerbatim("TrackAssociator")
               << " simtrack ID = " << m.trackId() << "                            Simhit Pos = " << m.localPosition();
           // Seek the smallest residual
-          if (dynamic_cast<const SiPixelRecHit*>(&rechit)) {
+          auto ptr = dynamic_cast<const SiPixelRecHit*>(&rechit));
+          if (nullptr != ptr) {
             isPixel = true;
             dist = (rechit.localPosition() - m.localPosition()).mag();  // pixels measure 2 dimensions
           } else {


### PR DESCRIPTION
#### PR description:

Fixes clang warning:

```
  src/SimTracker/TrackerHitAssociation/test/TestAssociator.cc:112:36: warning: variable 'dummy' set but not used [-Wunused-but-set-variable]
   112 |           if (const SiPixelRecHit* dummy = dynamic_cast<const SiPixelRecHit*>(&rechit)) {
      |                                    ^
```

#### PR validation:

Bot tests