### PR TITLE
Remove unused variable in TrackingManagerHelper.icc

### DIFF
--- a/SimG4Core/PhysicsLists/src/TrackingManagerHelper.icc
+++ b/SimG4Core/PhysicsLists/src/TrackingManagerHelper.icc
@@ -243,7 +243,7 @@ void TrackingManagerHelper::TrackChargedParticle(G4Track* aTrack, PhysicsImpl& p
       bool fieldExertsForce = false;
       if (auto* fieldMgr = fFieldPropagator->FindAndSetFieldManager(track.GetVolume())) {
         fieldMgr->ConfigureForTrack(&track);
-        if (const G4Field* ptrField = fieldMgr->GetDetectorField()) {
+        if (fieldMgr->GetDetectorField()) {
           fieldExertsForce = true;
         }
       }


### PR DESCRIPTION
#### PR description:

Fixes clang warning:

```
In file included from src/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsTrackingManager.cc:2:
In file included from src/SimG4Core/PhysicsLists/src/TrackingManagerHelper.h:103:
  src/SimG4Core/PhysicsLists/src/TrackingManagerHelper.icc:246:28: warning: variable 'ptrField' set but not used [-Wunused-but-set-variable]
   246 |         if (const G4Field* ptrField = fieldMgr->GetDetectorField()) {
      |                            ^
```

#### PR validation:

Bot tests

