### PR TITLE
Update clang-tidy test to make sure it process header file too

### DIFF
--- a/Utilities/ReleaseScripts/test/ref/test-clang-tidy.cc
+++ b/Utilities/ReleaseScripts/test/ref/test-clang-tidy.cc
@@ -1,10 +1,12 @@
-class BaseClass {
+#include "test-clang-tidy.h"
+class BaseClass : public BaseClass2 {
 public:
   BaseClass(int x) {
     m_x = x;
     ch = nullptr;
   };
-  virtual ~BaseClass();
+  void override_func() override {}
+  ~BaseClass() override;
   virtual int someMethod();
 
 protected:

--- a/Utilities/ReleaseScripts/test/ref/test-clang-tidy.h
+++ b/Utilities/ReleaseScripts/test/ref/test-clang-tidy.h
@@ -1,0 +1,13 @@
+class BaseClass1 {
+public:
+  BaseClass1() {}
+  virtual void override_func() = 0;
+  virtual ~BaseClass1() {}
+};
+
+class BaseClass2 : public BaseClass1 {
+public:
+  BaseClass2() {}
+  void override_func() override {}
+  ~BaseClass2() override {}
+};

--- a/Utilities/ReleaseScripts/test/test-clang-tidy.cc
+++ b/Utilities/ReleaseScripts/test/test-clang-tidy.cc
@@ -1,9 +1,11 @@
-class BaseClass {
+#include "test-clang-tidy.h"
+class BaseClass : public BaseClass2 {
 public:
   BaseClass(int x) {
     m_x = x;
     ch = 0;
   };
+  void override_func() {}
   virtual ~BaseClass();
   virtual int someMethod();
 

--- a/Utilities/ReleaseScripts/test/test-clang-tidy.cc.yaml
+++ b/Utilities/ReleaseScripts/test/test-clang-tidy.cc.yaml
@@ -5,58 +5,106 @@ Diagnostics:
     DiagnosticMessage:
       Message:         use nullptr
       FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
-      FileOffset:      69
+      FileOffset:      118
       Replacements:
         - FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
-          Offset:          69
-          Length:          1
-          ReplacementText: nullptr
-  - DiagnosticName:  modernize-use-nullptr
-    DiagnosticMessage:
-      Message:         use nullptr
-      FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
-      FileOffset:      206
-      Replacements:
-        - FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
-          Offset:          206
-          Length:          1
-          ReplacementText: nullptr
-  - DiagnosticName:  modernize-use-nullptr
-    DiagnosticMessage:
-      Message:         use nullptr
-      FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
-      FileOffset:      235
-      Replacements:
-        - FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
-          Offset:          235
+          Offset:          118
           Length:          1
           ReplacementText: nullptr
   - DiagnosticName:  modernize-use-override
     DiagnosticMessage:
-      Message:         'prefer using ''override'' or (rarely) ''final'' instead of ''virtual'''
+      Message:         'annotate this function with ''override'' or (rarely) ''final'''
       FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
-      FileOffset:      386
+      FileOffset:      133
       Replacements:
         - FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
-          Offset:          378
-          Length:          8
-          ReplacementText: ''
-        - FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
-          Offset:          400
+          Offset:          148
           Length:          0
           ReplacementText: ' override'
   - DiagnosticName:  modernize-use-override
     DiagnosticMessage:
       Message:         'prefer using ''override'' or (rarely) ''final'' instead of ''virtual'''
       FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
-      FileOffset:      416
+      FileOffset:      162
       Replacements:
         - FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
-          Offset:          404
+          Offset:          154
           Length:          8
           ReplacementText: ''
         - FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
-          Offset:          428
+          Offset:          174
+          Length:          0
+          ReplacementText: ' override'
+  - DiagnosticName:  modernize-use-nullptr
+    DiagnosticMessage:
+      Message:         use nullptr
+      FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
+      FileOffset:      281
+      Replacements:
+        - FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
+          Offset:          281
+          Length:          1
+          ReplacementText: nullptr
+  - DiagnosticName:  modernize-use-nullptr
+    DiagnosticMessage:
+      Message:         use nullptr
+      FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
+      FileOffset:      310
+      Replacements:
+        - FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
+          Offset:          310
+          Length:          1
+          ReplacementText: nullptr
+  - DiagnosticName:  modernize-use-override
+    DiagnosticMessage:
+      Message:         'prefer using ''override'' or (rarely) ''final'' instead of ''virtual'''
+      FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
+      FileOffset:      461
+      Replacements:
+        - FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
+          Offset:          453
+          Length:          8
+          ReplacementText: ''
+        - FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
+          Offset:          475
+          Length:          0
+          ReplacementText: ' override'
+  - DiagnosticName:  modernize-use-override
+    DiagnosticMessage:
+      Message:         'prefer using ''override'' or (rarely) ''final'' instead of ''virtual'''
+      FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
+      FileOffset:      491
+      Replacements:
+        - FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
+          Offset:          479
+          Length:          8
+          ReplacementText: ''
+        - FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.cc'
+          Offset:          503
+          Length:          0
+          ReplacementText: ' override'
+  - DiagnosticName:  modernize-use-override
+    DiagnosticMessage:
+      Message:         'annotate this function with ''override'' or (rarely) ''final'''
+      FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.h'
+      FileOffset:      184
+      Replacements:
+        - FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.h'
+          Offset:          199
+          Length:          0
+          ReplacementText: ' override'
+  - DiagnosticName:  modernize-use-override
+    DiagnosticMessage:
+      Message:         'prefer using ''override'' or (rarely) ''final'' instead of ''virtual'''
+      FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.h'
+      FileOffset:      213
+      Replacements:
+        - FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.h'
+          Offset:          205
+          Length:          8
+          ReplacementText: ''
+        - FilePath:        'Utilities/ReleaseScripts/test/test-clang-tidy.h'
+          Offset:          226
           Length:          0
           ReplacementText: ' override'
 ...

--- a/Utilities/ReleaseScripts/test/test-clang-tidy.h
+++ b/Utilities/ReleaseScripts/test/test-clang-tidy.h
@@ -1,0 +1,13 @@
+class BaseClass1 {
+public:
+  BaseClass1() {}
+  virtual void override_func() = 0;
+  virtual ~BaseClass1() {}
+};
+
+class BaseClass2 : public BaseClass1 {
+public:
+  BaseClass2() {}
+  void override_func() {}
+  virtual ~BaseClass2() {}
+};

--- a/Utilities/ReleaseScripts/test/test-clang-tidy.sh
+++ b/Utilities/ReleaseScripts/test/test-clang-tidy.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -ex
-clang-tidy -export-fixes $CMSSW_BASE/test-clang-tidy.cc.yaml -header-filter "$CMSSW_BASE/src/.*" $CMSSW_BASE/src/Utilities/ReleaseScripts/test/test-clang-tidy.cc
-sed -i -e "s|$CMSSW_BASE/src/||" $CMSSW_BASE/test-clang-tidy.cc.yaml
-sed -i -e '/^\s\s*BuildDirectory/d;/^\s\s*Level:/d' $CMSSW_BASE/test-clang-tidy.cc.yaml
-diff -u $CMSSW_BASE/test-clang-tidy.cc.yaml $CMSSW_BASE/src/Utilities/ReleaseScripts/test/test-clang-tidy.cc.yaml
-rm -f $CMSSW_BASE/test-clang-tidy.cc.yaml
+clang-tidy -export-fixes test-clang-tidy.cc.yaml -header-filter "src/.*" $CMSSW_BASE/src/Utilities/ReleaseScripts/test/test-clang-tidy.cc
+sed -i -e "s|$CMSSW_BASE/src/||" test-clang-tidy.cc.yaml
+sed -i -e '/^\s\s*BuildDirectory/d;/^\s\s*Level:/d' test-clang-tidy.cc.yaml
+diff -u test-clang-tidy.cc.yaml $CMSSW_BASE/src/Utilities/ReleaseScripts/test/test-clang-tidy.cc.yaml

--- a/Utilities/ReleaseScripts/test/test-scram-code-checks.sh
+++ b/Utilities/ReleaseScripts/test/test-scram-code-checks.sh
@@ -26,13 +26,20 @@ chmod a-x config/SCRAM/hooks/runtime/50-remove-release-external-lib
 
 #Test clang-tidy
 cp $ORIG_TEST_PATH/test-clang-tidy.cc src/FWCore/Version/src
-USER_CODE_CHECKS_FILES=src/FWCore/Version/src/test-clang-tidy.cc scram b code-checks
+cp $ORIG_TEST_PATH/test-clang-tidy.h src/FWCore/Version/src
+FILES="src/FWCore/Version/src/test-clang-tidy.cc src/FWCore/Version/src/test-clang-tidy.h"
+USER_CODE_CHECKS_FILES="${FILES}" scram b code-checks
+
 diff -u src/FWCore/Version/src/test-clang-tidy.cc $ORIG_TEST_PATH/ref/test-clang-tidy.cc
+diff -u src/FWCore/Version/src/test-clang-tidy.h $ORIG_TEST_PATH/ref/test-clang-tidy.h
 cp $ORIG_TEST_PATH/test-clang-tidy.cc src/FWCore/Version/src
 scram b code-checks-all
 diff -u src/FWCore/Version/src/test-clang-tidy.cc $ORIG_TEST_PATH/ref/test-clang-tidy.cc
+diff -u src/FWCore/Version/src/test-clang-tidy.h $ORIG_TEST_PATH/ref/test-clang-tidy.h
 
 #Test clang-format
-sed -i -e 's|int m_x|    int     m_x   |' src/FWCore/Version/src/test-clang-tidy.cc
-USER_CODE_FORMAT_FILES=src/FWCore/Version/src/test-clang-tidy.cc scram b code-format
+sed -i -e 's|int m_x|    int     m_x   |'      src/FWCore/Version/src/test-clang-tidy.cc
+sed -i -e 's|override_func|  override_func  |' src/FWCore/Version/src/test-clang-tidy.h
+USER_CODE_FORMAT_FILES="${FILES}" scram b code-format
 diff -u src/FWCore/Version/src/test-clang-tidy.cc $ORIG_TEST_PATH/ref/test-clang-tidy.cc
+diff -u src/FWCore/Version/src/test-clang-tidy.h $ORIG_TEST_PATH/ref/test-clang-tidy.h


### PR DESCRIPTION
Improved clang-tidy and clang-format tests. Now these tests make sure that cmssw header files are also properly processed