### PR TITLE
L1 P2GT region cut checks and fixing menu config

### DIFF
--- a/L1Trigger/Configuration/python/Phase2GTMenus/SeedDefinitions/step1_2024/l1tGTMenu_hadr_crossLepSeeds_cff.py
+++ b/L1Trigger/Configuration/python/Phase2GTMenus/SeedDefinitions/step1_2024/l1tGTMenu_hadr_crossLepSeeds_cff.py
@@ -39,13 +39,13 @@ TkMuTriPuppiJetdRMaxDoubleJetdEtaMax = l1tGTQuadObjectCond.clone( #needs z0 betw
         primVertex = cms.uint32(0), # primary vertex index (choose 0)
     ),
     collection2 = l1tGTsc4Jet.clone(
-        regionsMinPt=cms.vdouble(25,25), #safety cut
+        minPt = cms.double(25) #safety cut
     ),
     collection3 = l1tGTsc4Jet.clone(
-        regionsMinPt=cms.vdouble(25,25), #safety cut
+        minPt = cms.double(25) #safety cut
     ),
     collection4 = l1tGTsc4Jet.clone(
-        regionsMinPt=cms.vdouble(25,25), #safety cut
+        minPt = cms.double(25) #safety cut
     ),
     correl12 = cms.PSet(
         maxDR = cms.double(0.4),
@@ -169,7 +169,7 @@ TkElePuppiJetMinDR = l1tGTDoubleObjectCond.clone( #missing z0 between electron a
         primVertex = cms.uint32(0), # primary vertex index (choose 0)
     ),
     collection2 = l1tGTsc4Jet.clone(
-        regionsMinPt=cms.vdouble(25,25), #safety cut
+        minPt = cms.double(25) #safety cut
     ),
     minDR = cms.double(0.3)
 )

--- a/L1Trigger/Configuration/python/Phase2GTMenus/SeedDefinitions/step1_2024_explicitSeeds/l1tGTMenu_hadr_crossLepSeeds_cff.py
+++ b/L1Trigger/Configuration/python/Phase2GTMenus/SeedDefinitions/step1_2024_explicitSeeds/l1tGTMenu_hadr_crossLepSeeds_cff.py
@@ -53,21 +53,21 @@ TkMuTriPuppiJetdRMaxDoubleJetdEtaMax = l1tGTQuadObjectCond.clone( #needs z0 betw
         minEta = cms.double(-2.4),
         maxEta = cms.double(2.4),
         regionsAbsEtaLowerBounds = get_object_etalowbounds("CL2JetsSC4"),
-        regionsMinPt=cms.vdouble(25,25), #safety cut
+        minPt = cms.double(25) #safety cut
     ),
     collection3 = cms.PSet(
         tag = cms.InputTag("l1tGTProducer", "CL2JetsSC4"),
         minEta = cms.double(-2.4),
         maxEta = cms.double(2.4),
         regionsAbsEtaLowerBounds = get_object_etalowbounds("CL2JetsSC4"),
-        regionsMinPt=cms.vdouble(25,25), #safety cut
+        minPt = cms.double(25) #safety cut
     ),
     collection4 = cms.PSet(
         tag = cms.InputTag("l1tGTProducer", "CL2JetsSC4"),
         minEta = cms.double(-2.4),
         maxEta = cms.double(2.4),
         regionsAbsEtaLowerBounds = get_object_etalowbounds("CL2JetsSC4"),
-        regionsMinPt=cms.vdouble(25,25), #safety cut
+        minPt = cms.double(25) #safety cut
     ),
     correl12 = cms.PSet(
         maxDR = cms.double(0.4),
@@ -247,7 +247,7 @@ TkElePuppiJetMinDR = l1tGTDoubleObjectCond.clone( #missing z0 between electron a
         minEta = cms.double(-2.4),
         maxEta = cms.double(2.4),
         regionsAbsEtaLowerBounds = get_object_etalowbounds("CL2JetsSC4"),
-        regionsMinPt=cms.vdouble(25,25), #safety cut
+        minPt = cms.double(25) #safety cut
     ),
     minDR = cms.double(0.3)
 )
@@ -262,7 +262,7 @@ NNPuppiTauPuppiMet = l1tGTDoubleObjectCond.clone(
         tag = cms.InputTag("l1tGTProducer", "CL2Taus"),
         minEta = cms.double(-2.172),
         maxEta = cms.double(2.172),
-        regionsAbsEtaLowerBounds = get_object_etalowbounds("CL2JetsSC4"),
+        regionsAbsEtaLowerBounds = get_object_etalowbounds("CL2Taus"),
         regionsMinPt = get_object_thrs(55, "CL2Taus","default"),
         minQualityScore = get_object_ids("CL2Taus","default")
     ),

--- a/L1Trigger/Configuration/python/Phase2GTMenus/SeedDefinitions/step1_2024_explicitSeeds/l1tGTMenu_lepSeeds_cff.py
+++ b/L1Trigger/Configuration/python/Phase2GTMenus/SeedDefinitions/step1_2024_explicitSeeds/l1tGTMenu_lepSeeds_cff.py
@@ -241,7 +241,7 @@ DoublePuppiTau5252 = l1tGTDoubleObjectCond.clone(
         tag = cms.InputTag("l1tGTProducer", "CL2Taus"),
         minEta = cms.double(-2.172),
         maxEta = cms.double(2.172),
-        regionsAbsEtaLowerBounds = get_object_etalowbounds("CL2JetsSC4"),
+        regionsAbsEtaLowerBounds = get_object_etalowbounds("CL2Taus"),
         regionsMinPt = get_object_thrs(52, "CL2Taus","default"),
         minQualityScore = get_object_ids("CL2Taus","default")
     ),
@@ -249,7 +249,7 @@ DoublePuppiTau5252 = l1tGTDoubleObjectCond.clone(
         tag = cms.InputTag("l1tGTProducer", "CL2Taus"),
         minEta = cms.double(-2.172),
         maxEta = cms.double(2.172),
-        regionsAbsEtaLowerBounds = get_object_etalowbounds("CL2JetsSC4"),
+        regionsAbsEtaLowerBounds = get_object_etalowbounds("CL2Taus"),
         regionsMinPt = get_object_thrs(52, "CL2Taus","default"),
         minQualityScore = get_object_ids("CL2Taus","default")
     ),

--- a/L1Trigger/Phase2L1GT/plugins/L1GTSingleCollectionCut.h
+++ b/L1Trigger/Phase2L1GT/plugins/L1GTSingleCollectionCut.h
@@ -98,7 +98,12 @@ namespace l1t {
       }
       if (!regionsMaxRelIsolationPt_.empty() && regionsAbsEtaLowerBounds_.size() != regionsMaxRelIsolationPt_.size()) {
         throw cms::Exception("Configuration")
-            << "\'regionsMinPt\' has " << regionsMaxRelIsolationPt_.size() << " entries, but requires "
+            << "\'regionsMaxRelIsolationPt\' has " << regionsMaxRelIsolationPt_.size() << " entries, but requires "
+            << regionsAbsEtaLowerBounds_.size() << " in " << tag_ << " .";
+      }
+      if (!regionsQualityFlags_.empty() && regionsAbsEtaLowerBounds_.size() != regionsQualityFlags_.size()) {
+        throw cms::Exception("Configuration")
+            << "\'regionsMaxRelIsolationPt\' has " << regionsQualityFlags_.size() << " entries, but requires "
             << regionsAbsEtaLowerBounds_.size() << " in " << tag_ << " .";
       }
     }

--- a/L1Trigger/Phase2L1GT/plugins/L1GTSingleCollectionCut.h
+++ b/L1Trigger/Phase2L1GT/plugins/L1GTSingleCollectionCut.h
@@ -91,13 +91,17 @@ namespace l1t {
           minPtMultiplicityN_(config.getParameter<unsigned int>("minPtMultiplicityN")),
           minPtMultiplicityCut_(getOptionalParam<int, double>(
               "minPtMultiplicityCut", config, [&scales](double value) { return scales.to_hw_pT_floor(value); })) {
-                if (!regionsMinPt_.empty() && regionsAbsEtaLowerBounds_.size() != regionsMinPt_.size()) {
-                  throw cms::Exception("Configuration") << "\'regionsMinPt\' has " << regionsMinPt_.size() << " entries, but requires " << regionsAbsEtaLowerBounds_.size() << " in " << tag_ << " .";
-                  }
-                if (!regionsMaxRelIsolationPt_.empty() && regionsAbsEtaLowerBounds_.size() != regionsMaxRelIsolationPt_.size()) {
-                  throw cms::Exception("Configuration") << "\'regionsMinPt\' has " << regionsMaxRelIsolationPt_.size() << " entries, but requires " << regionsAbsEtaLowerBounds_.size() << " in " << tag_ << " .";
-                  }
-              }
+      if (!regionsMinPt_.empty() && regionsAbsEtaLowerBounds_.size() != regionsMinPt_.size()) {
+        throw cms::Exception("Configuration")
+            << "\'regionsMinPt\' has " << regionsMinPt_.size() << " entries, but requires "
+            << regionsAbsEtaLowerBounds_.size() << " in " << tag_ << " .";
+      }
+      if (!regionsMaxRelIsolationPt_.empty() && regionsAbsEtaLowerBounds_.size() != regionsMaxRelIsolationPt_.size()) {
+        throw cms::Exception("Configuration")
+            << "\'regionsMinPt\' has " << regionsMaxRelIsolationPt_.size() << " entries, but requires "
+            << regionsAbsEtaLowerBounds_.size() << " in " << tag_ << " .";
+      }
+    }
 
     bool checkObject(const P2GTCandidate& obj) const {
       bool result = true;

--- a/L1Trigger/Phase2L1GT/plugins/L1GTSingleCollectionCut.h
+++ b/L1Trigger/Phase2L1GT/plugins/L1GTSingleCollectionCut.h
@@ -90,7 +90,14 @@ namespace l1t {
           primVertex_(getOptionalParam<unsigned int>("primVertex", config)),
           minPtMultiplicityN_(config.getParameter<unsigned int>("minPtMultiplicityN")),
           minPtMultiplicityCut_(getOptionalParam<int, double>(
-              "minPtMultiplicityCut", config, [&scales](double value) { return scales.to_hw_pT_floor(value); })) {}
+              "minPtMultiplicityCut", config, [&scales](double value) { return scales.to_hw_pT_floor(value); })) {
+                if (!regionsMinPt_.empty() && regionsAbsEtaLowerBounds_.size() != regionsMinPt_.size()) {
+                  throw cms::Exception("Configuration") << "\'regionsMinPt\' has " << regionsMinPt_.size() << " entries, but requires " << regionsAbsEtaLowerBounds_.size() << " in " << tag_ << " .";
+                  }
+                if (!regionsMaxRelIsolationPt_.empty() && regionsAbsEtaLowerBounds_.size() != regionsMaxRelIsolationPt_.size()) {
+                  throw cms::Exception("Configuration") << "\'regionsMinPt\' has " << regionsMaxRelIsolationPt_.size() << " entries, but requires " << regionsAbsEtaLowerBounds_.size() << " in " << tag_ << " .";
+                  }
+              }
 
     bool checkObject(const P2GTCandidate& obj) const {
       bool result = true;

--- a/L1Trigger/Phase2L1GT/plugins/L1GTSingleCollectionCut.h
+++ b/L1Trigger/Phase2L1GT/plugins/L1GTSingleCollectionCut.h
@@ -103,7 +103,7 @@ namespace l1t {
       }
       if (!regionsQualityFlags_.empty() && regionsAbsEtaLowerBounds_.size() != regionsQualityFlags_.size()) {
         throw cms::Exception("Configuration")
-            << "\'regionsMaxRelIsolationPt\' has " << regionsQualityFlags_.size() << " entries, but requires "
+            << "\'regionsQualityFlags\' has " << regionsQualityFlags_.size() << " entries, but requires "
             << regionsAbsEtaLowerBounds_.size() << " in " << tag_ << " .";
       }
     }


### PR DESCRIPTION
#### PR description:

This is a follow up to #46489 addressing #47194

The issue appeared when the number of eta regions (bounds) did not match e.g. the number of pt region thresholds.

1. An exception has been introduced in the P2GT condition parser when the cut number does not match the number of eta regions as @HaarigerHarald suggested
2. Fixed menu conditions where the number of pt and eta regions did not match (should not affect trigger results)

#### PR validation:

In `CMSSW_15_0_ASAN_X_2025-01-27-2300` workflow `29634.78` ran fine with the default `L1P2GT:step1_2024` and the `step1_2024_explicitSeeds` menu.
