### PR TITLE
Use central phi functions instead LST ones

### DIFF
--- a/RecoTracker/LSTCore/src/alpaka/Kernels.h
+++ b/RecoTracker/LSTCore/src/alpaka/Kernels.h
@@ -162,7 +162,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
             float eta2 = __H2F(quintuplets.eta()[jx]);
             float phi2 = __H2F(quintuplets.phi()[jx]);
             float dEta = alpaka::math::abs(acc, eta1 - eta2);
-            float dPhi = calculate_dPhi(phi1, phi2);
+            float dPhi = reco::deltaPhi(phi1, phi2);
             float score_rphisum2 = __H2F(quintuplets.score_rphisum()[jx]);
 
             if (dEta > 0.1f)
@@ -237,7 +237,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
               float score_rphisum2 = __H2F(quintuplets.score_rphisum()[jx]);
 
               float dEta = alpaka::math::abs(acc, eta1 - eta2);
-              float dPhi = calculate_dPhi(phi1, phi2);
+              float dPhi = reco::deltaPhi(phi1, phi2);
 
               if (dEta > 0.1f)
                 continue;
@@ -394,7 +394,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
           }
           if (secondpass) {
             float dEta = alpaka::math::abs(acc, eta_pix1 - eta_pix2);
-            float dPhi = calculate_dPhi(phi_pix1, phi_pix2);
+            float dPhi = reco::deltaPhi(phi_pix1, phi_pix2);
 
             float dR2 = dEta * dEta + dPhi * dPhi;
             if ((npMatched >= 1) || (dR2 < 1e-5f)) {

--- a/RecoTracker/LSTCore/src/alpaka/MiniDoublet.h
+++ b/RecoTracker/LSTCore/src/alpaka/MiniDoublet.h
@@ -429,22 +429,22 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
         shiftedZ = zUpper;
         shiftedRt2 = xn * xn + yn * yn;
 
-        dPhi = deltaPhi(acc, xLower, yLower, shiftedX, shiftedY);  //function from Hit.cc
-        noShiftedDphi = deltaPhi(acc, xLower, yLower, xUpper, yUpper);
+        dPhi = cms::alpakatools::deltaPhi(acc, xLower, yLower, shiftedX, shiftedY);  //function from Hit.cc
+        noShiftedDphi = cms::alpakatools::deltaPhi(acc, xLower, yLower, xUpper, yUpper);
       } else {
         shiftedX = xn;
         shiftedY = yn;
         shiftedZ = zLower;
         shiftedRt2 = xn * xn + yn * yn;
-        dPhi = deltaPhi(acc, shiftedX, shiftedY, xUpper, yUpper);
-        noShiftedDphi = deltaPhi(acc, xLower, yLower, xUpper, yUpper);
+        dPhi = cms::alpakatools::deltaPhi(acc, shiftedX, shiftedY, xUpper, yUpper);
+        noShiftedDphi = cms::alpakatools::deltaPhi(acc, xLower, yLower, xUpper, yUpper);
       }
     } else {
       shiftedX = 0.f;
       shiftedY = 0.f;
       shiftedZ = 0.f;
       shiftedRt2 = 0.f;
-      dPhi = deltaPhi(acc, xLower, yLower, xUpper, yUpper);
+      dPhi = cms::alpakatools::deltaPhi(acc, xLower, yLower, xUpper, yUpper);
       noShiftedDphi = dPhi;
     }
 
@@ -557,21 +557,21 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
         shiftedX = xn;
         shiftedY = yn;
         shiftedZ = zUpper;
-        dPhi = deltaPhi(acc, xLower, yLower, shiftedX, shiftedY);
-        noShiftedDphi = deltaPhi(acc, xLower, yLower, xUpper, yUpper);
+        dPhi = cms::alpakatools::deltaPhi(acc, xLower, yLower, shiftedX, shiftedY);
+        noShiftedDphi = cms::alpakatools::deltaPhi(acc, xLower, yLower, xUpper, yUpper);
       } else {
         shiftedX = xn;
         shiftedY = yn;
         shiftedZ = zLower;
-        dPhi = deltaPhi(acc, shiftedX, shiftedY, xUpper, yUpper);
-        noShiftedDphi = deltaPhi(acc, xLower, yLower, xUpper, yUpper);
+        dPhi = cms::alpakatools::deltaPhi(acc, shiftedX, shiftedY, xUpper, yUpper);
+        noShiftedDphi = cms::alpakatools::deltaPhi(acc, xLower, yLower, xUpper, yUpper);
       }
     } else {
       shiftedX = xn;
       shiftedY = yn;
       shiftedZ = zUpper;
-      dPhi = deltaPhi(acc, xLower, yLower, xn, yn);
-      noShiftedDphi = deltaPhi(acc, xLower, yLower, xUpper, yUpper);
+      dPhi = cms::alpakatools::deltaPhi(acc, xLower, yLower, xn, yn);
+      noShiftedDphi = cms::alpakatools::deltaPhi(acc, xLower, yLower, xUpper, yUpper);
     }
 
     // dz needs to change if it is a PS module where the strip hits are shifted in order to properly account for the case when a tilted module falls under "endcap logic"

--- a/RecoTracker/LSTCore/src/alpaka/NeuralNetwork.h
+++ b/RecoTracker/LSTCore/src/alpaka/NeuralNetwork.h
@@ -1,6 +1,7 @@
 #ifndef RecoTracker_LSTCore_src_alpaka_NeuralNetwork_h
 #define RecoTracker_LSTCore_src_alpaka_NeuralNetwork_h
 
+#include "DataFormats/Math/interface/deltaPhi.h"
 #include "FWCore/Utilities/interface/CMSUnrollLoop.h"
 
 #include "RecoTracker/LSTCore/interface/alpaka/Common.h"
@@ -36,18 +37,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst::t5dnn {
         output[i] += input[j] * weights[j][i];
       }
     }
-  }
-
-  ALPAKA_FN_ACC ALPAKA_FN_INLINE float delta_phi(const float phi1, const float phi2) {
-    float delta = phi1 - phi2;
-    // Adjust delta to be within the range [-M_PI, M_PI]
-    if (delta > kPi) {
-      delta -= 2 * kPi;
-    } else if (delta < -kPi) {
-      delta += 2 * kPi;
-    }
-
-    return delta;
   }
 
   template <typename TAcc>
@@ -96,25 +85,25 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst::t5dnn {
         z1 / kZ_max,                               // inner T3: First hit z normalized
         r1 / kR_max,                               // inner T3: First hit r normalized
 
-        eta2 - eta1,                        // inner T3: Difference in eta between hit 2 and 1
-        delta_phi(phi2, phi1) / kPhi_norm,  // inner T3: Difference in phi between hit 2 and 1
-        (z2 - z1) / kZ_max,                 // inner T3: Difference in z between hit 2 and 1 normalized
-        (r2 - r1) / kR_max,                 // inner T3: Difference in r between hit 2 and 1 normalized
+        eta2 - eta1,                             // inner T3: Difference in eta between hit 2 and 1
+        reco::deltaPhi(phi2, phi1) / kPhi_norm,  // inner T3: Difference in phi between hit 2 and 1
+        (z2 - z1) / kZ_max,                      // inner T3: Difference in z between hit 2 and 1 normalized
+        (r2 - r1) / kR_max,                      // inner T3: Difference in r between hit 2 and 1 normalized
 
-        eta3 - eta2,                        // inner T3: Difference in eta between hit 3 and 2
-        delta_phi(phi3, phi2) / kPhi_norm,  // inner T3: Difference in phi between hit 3 and 2
-        (z3 - z2) / kZ_max,                 // inner T3: Difference in z between hit 3 and 2 normalized
-        (r3 - r2) / kR_max,                 // inner T3: Difference in r between hit 3 and 2 normalized
+        eta3 - eta2,                             // inner T3: Difference in eta between hit 3 and 2
+        reco::deltaPhi(phi3, phi2) / kPhi_norm,  // inner T3: Difference in phi between hit 3 and 2
+        (z3 - z2) / kZ_max,                      // inner T3: Difference in z between hit 3 and 2 normalized
+        (r3 - r2) / kR_max,                      // inner T3: Difference in r between hit 3 and 2 normalized
 
-        eta4 - eta3,                        // outer T3: Difference in eta between hit 4 and 3
-        delta_phi(phi4, phi3) / kPhi_norm,  // inner T3: Difference in phi between hit 4 and 3
-        (z4 - z3) / kZ_max,                 // outer T3: Difference in z between hit 4 and 3 normalized
-        (r4 - r3) / kR_max,                 // outer T3: Difference in r between hit 4 and 3 normalized
+        eta4 - eta3,                             // outer T3: Difference in eta between hit 4 and 3
+        reco::deltaPhi(phi4, phi3) / kPhi_norm,  // inner T3: Difference in phi between hit 4 and 3
+        (z4 - z3) / kZ_max,                      // outer T3: Difference in z between hit 4 and 3 normalized
+        (r4 - r3) / kR_max,                      // outer T3: Difference in r between hit 4 and 3 normalized
 
-        eta5 - eta4,                        // outer T3: Difference in eta between hit 5 and 4
-        delta_phi(phi5, phi4) / kPhi_norm,  // inner T3: Difference in phi between hit 5 and 4
-        (z5 - z4) / kZ_max,                 // outer T3: Difference in z between hit 5 and 4 normalized
-        (r5 - r4) / kR_max,                 // outer T3: Difference in r between hit 5 and 4 normalized
+        eta5 - eta4,                             // outer T3: Difference in eta between hit 5 and 4
+        reco::deltaPhi(phi5, phi4) / kPhi_norm,  // inner T3: Difference in phi between hit 5 and 4
+        (z5 - z4) / kZ_max,                      // outer T3: Difference in z between hit 5 and 4 normalized
+        (r5 - r4) / kR_max,                      // outer T3: Difference in r between hit 5 and 4 normalized
 
         alpaka::math::log10(acc, innerRadius),   // T5 inner radius (t5_innerRadius)
         alpaka::math::log10(acc, bridgeRadius),  // T5 bridge radius (t5_bridgeRadius)

--- a/RecoTracker/LSTCore/src/alpaka/PixelTriplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/PixelTriplet.h
@@ -962,7 +962,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
 
     float rt_InOut = rt_InUp;
 
-    if (alpaka::math::abs(acc, deltaPhi(acc, x_InUp, y_InUp, x_OutLo, y_OutLo)) > kPi / 2.f)
+    if (alpaka::math::abs(acc, cms::alpakatools::deltaPhi(acc, x_InUp, y_InUp, x_OutLo, y_OutLo)) > kPi / 2.f)
       return false;
 
     unsigned int pixelSegmentArrayIndex = innerSegmentIndex - ranges.segmentModuleIndices()[pixelModuleIndex];
@@ -1036,7 +1036,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     float diffX = x_OutLo - x_InLo;
     float diffY = y_OutLo - y_InLo;
 
-    dPhi = deltaPhi(acc, midPointX, midPointY, diffX, diffY);
+    dPhi = cms::alpakatools::deltaPhi(acc, midPointX, midPointY, diffX, diffY);
 
     if (alpaka::math::abs(acc, dPhi) > dPhiCut)
       return false;
@@ -1050,7 +1050,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                           modules.moduleType()[outerOuterLowerModuleIndex] == TwoS;
 
     float alpha_OutUp, alpha_OutUp_highEdge, alpha_OutUp_lowEdge;
-    alpha_OutUp = deltaPhi(acc, x_OutUp, y_OutUp, x_OutUp - x_OutLo, y_OutUp - y_OutLo);
+    alpha_OutUp = cms::alpakatools::deltaPhi(acc, x_OutUp, y_OutUp, x_OutUp - x_OutLo, y_OutUp - y_OutLo);
 
     alpha_OutUp_highEdge = alpha_OutUp;
     alpha_OutUp_lowEdge = alpha_OutUp;
@@ -1064,42 +1064,42 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     float tl_axis_lowEdge_x = tl_axis_x;
     float tl_axis_lowEdge_y = tl_axis_y;
 
-    betaIn = -deltaPhi(acc, px, py, tl_axis_x, tl_axis_y);
+    betaIn = -cms::alpakatools::deltaPhi(acc, px, py, tl_axis_x, tl_axis_y);
     float betaInRHmin = betaIn;
     float betaInRHmax = betaIn;
 
-    betaOut = -alpha_OutUp + deltaPhi(acc, x_OutUp, y_OutUp, tl_axis_x, tl_axis_y);
+    betaOut = -alpha_OutUp + cms::alpakatools::deltaPhi(acc, x_OutUp, y_OutUp, tl_axis_x, tl_axis_y);
 
     float betaOutRHmin = betaOut;
     float betaOutRHmax = betaOut;
 
     if (isEC_lastLayer) {
-      alpha_OutUp_highEdge = deltaPhi(acc,
-                                      mds.anchorHighEdgeX()[fourthMDIndex],
-                                      mds.anchorHighEdgeY()[fourthMDIndex],
-                                      mds.anchorHighEdgeX()[fourthMDIndex] - x_OutLo,
-                                      mds.anchorHighEdgeY()[fourthMDIndex] - y_OutLo);
-      alpha_OutUp_lowEdge = deltaPhi(acc,
-                                     mds.anchorLowEdgeX()[fourthMDIndex],
-                                     mds.anchorLowEdgeY()[fourthMDIndex],
-                                     mds.anchorLowEdgeX()[fourthMDIndex] - x_OutLo,
-                                     mds.anchorLowEdgeY()[fourthMDIndex] - y_OutLo);
+      alpha_OutUp_highEdge = cms::alpakatools::deltaPhi(acc,
+                                                        mds.anchorHighEdgeX()[fourthMDIndex],
+                                                        mds.anchorHighEdgeY()[fourthMDIndex],
+                                                        mds.anchorHighEdgeX()[fourthMDIndex] - x_OutLo,
+                                                        mds.anchorHighEdgeY()[fourthMDIndex] - y_OutLo);
+      alpha_OutUp_lowEdge = cms::alpakatools::deltaPhi(acc,
+                                                       mds.anchorLowEdgeX()[fourthMDIndex],
+                                                       mds.anchorLowEdgeY()[fourthMDIndex],
+                                                       mds.anchorLowEdgeX()[fourthMDIndex] - x_OutLo,
+                                                       mds.anchorLowEdgeY()[fourthMDIndex] - y_OutLo);
 
       tl_axis_highEdge_x = mds.anchorHighEdgeX()[fourthMDIndex] - x_InUp;
       tl_axis_highEdge_y = mds.anchorHighEdgeY()[fourthMDIndex] - y_InUp;
       tl_axis_lowEdge_x = mds.anchorLowEdgeX()[fourthMDIndex] - x_InUp;
       tl_axis_lowEdge_y = mds.anchorLowEdgeY()[fourthMDIndex] - y_InUp;
 
-      betaOutRHmin = -alpha_OutUp_highEdge + deltaPhi(acc,
-                                                      mds.anchorHighEdgeX()[fourthMDIndex],
-                                                      mds.anchorHighEdgeY()[fourthMDIndex],
-                                                      tl_axis_highEdge_x,
-                                                      tl_axis_highEdge_y);
-      betaOutRHmax = -alpha_OutUp_lowEdge + deltaPhi(acc,
-                                                     mds.anchorLowEdgeX()[fourthMDIndex],
-                                                     mds.anchorLowEdgeY()[fourthMDIndex],
-                                                     tl_axis_lowEdge_x,
-                                                     tl_axis_lowEdge_y);
+      betaOutRHmin = -alpha_OutUp_highEdge + cms::alpakatools::deltaPhi(acc,
+                                                                        mds.anchorHighEdgeX()[fourthMDIndex],
+                                                                        mds.anchorHighEdgeY()[fourthMDIndex],
+                                                                        tl_axis_highEdge_x,
+                                                                        tl_axis_highEdge_y);
+      betaOutRHmax = -alpha_OutUp_lowEdge + cms::alpakatools::deltaPhi(acc,
+                                                                       mds.anchorLowEdgeX()[fourthMDIndex],
+                                                                       mds.anchorLowEdgeY()[fourthMDIndex],
+                                                                       tl_axis_lowEdge_x,
+                                                                       tl_axis_lowEdge_y);
     }
 
     //beta computation
@@ -1300,7 +1300,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     float diffX = x_OutLo - x_InLo;
     float diffY = y_OutLo - y_InLo;
 
-    dPhi = deltaPhi(acc, midPointX, midPointY, diffX, diffY);
+    dPhi = cms::alpakatools::deltaPhi(acc, midPointX, midPointY, diffX, diffY);
 
     // Cut #5: deltaPhiChange
     if (alpaka::math::abs(acc, dPhi) > dPhiCut)
@@ -1314,7 +1314,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
 
     float alpha_OutUp, alpha_OutUp_highEdge, alpha_OutUp_lowEdge;
 
-    alpha_OutUp = deltaPhi(acc, x_OutUp, y_OutUp, x_OutUp - x_OutLo, y_OutUp - y_OutLo);
+    alpha_OutUp = cms::alpakatools::deltaPhi(acc, x_OutUp, y_OutUp, x_OutUp - x_OutLo, y_OutUp - y_OutLo);
     alpha_OutUp_highEdge = alpha_OutUp;
     alpha_OutUp_lowEdge = alpha_OutUp;
 
@@ -1327,41 +1327,41 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     float tl_axis_lowEdge_x = tl_axis_x;
     float tl_axis_lowEdge_y = tl_axis_y;
 
-    betaIn = -deltaPhi(acc, px, py, tl_axis_x, tl_axis_y);
+    betaIn = -cms::alpakatools::deltaPhi(acc, px, py, tl_axis_x, tl_axis_y);
     float betaInRHmin = betaIn;
     float betaInRHmax = betaIn;
 
-    betaOut = -alpha_OutUp + deltaPhi(acc, x_OutUp, y_OutUp, tl_axis_x, tl_axis_y);
+    betaOut = -alpha_OutUp + cms::alpakatools::deltaPhi(acc, x_OutUp, y_OutUp, tl_axis_x, tl_axis_y);
     float betaOutRHmin = betaOut;
     float betaOutRHmax = betaOut;
 
     if (isEC_lastLayer) {
-      alpha_OutUp_highEdge = deltaPhi(acc,
-                                      mds.anchorHighEdgeX()[fourthMDIndex],
-                                      mds.anchorHighEdgeY()[fourthMDIndex],
-                                      mds.anchorHighEdgeX()[fourthMDIndex] - x_OutLo,
-                                      mds.anchorHighEdgeY()[fourthMDIndex] - y_OutLo);
-      alpha_OutUp_lowEdge = deltaPhi(acc,
-                                     mds.anchorLowEdgeX()[fourthMDIndex],
-                                     mds.anchorLowEdgeY()[fourthMDIndex],
-                                     mds.anchorLowEdgeX()[fourthMDIndex] - x_OutLo,
-                                     mds.anchorLowEdgeY()[fourthMDIndex] - y_OutLo);
+      alpha_OutUp_highEdge = cms::alpakatools::deltaPhi(acc,
+                                                        mds.anchorHighEdgeX()[fourthMDIndex],
+                                                        mds.anchorHighEdgeY()[fourthMDIndex],
+                                                        mds.anchorHighEdgeX()[fourthMDIndex] - x_OutLo,
+                                                        mds.anchorHighEdgeY()[fourthMDIndex] - y_OutLo);
+      alpha_OutUp_lowEdge = cms::alpakatools::deltaPhi(acc,
+                                                       mds.anchorLowEdgeX()[fourthMDIndex],
+                                                       mds.anchorLowEdgeY()[fourthMDIndex],
+                                                       mds.anchorLowEdgeX()[fourthMDIndex] - x_OutLo,
+                                                       mds.anchorLowEdgeY()[fourthMDIndex] - y_OutLo);
 
       tl_axis_highEdge_x = mds.anchorHighEdgeX()[fourthMDIndex] - x_InUp;
       tl_axis_highEdge_y = mds.anchorHighEdgeY()[fourthMDIndex] - y_InUp;
       tl_axis_lowEdge_x = mds.anchorLowEdgeX()[fourthMDIndex] - x_InUp;
       tl_axis_lowEdge_y = mds.anchorLowEdgeY()[fourthMDIndex] - y_InUp;
 
-      betaOutRHmin = -alpha_OutUp_highEdge + deltaPhi(acc,
-                                                      mds.anchorHighEdgeX()[fourthMDIndex],
-                                                      mds.anchorHighEdgeY()[fourthMDIndex],
-                                                      tl_axis_highEdge_x,
-                                                      tl_axis_highEdge_y);
-      betaOutRHmax = -alpha_OutUp_lowEdge + deltaPhi(acc,
-                                                     mds.anchorLowEdgeX()[fourthMDIndex],
-                                                     mds.anchorLowEdgeY()[fourthMDIndex],
-                                                     tl_axis_lowEdge_x,
-                                                     tl_axis_lowEdge_y);
+      betaOutRHmin = -alpha_OutUp_highEdge + cms::alpakatools::deltaPhi(acc,
+                                                                        mds.anchorHighEdgeX()[fourthMDIndex],
+                                                                        mds.anchorHighEdgeY()[fourthMDIndex],
+                                                                        tl_axis_highEdge_x,
+                                                                        tl_axis_highEdge_y);
+      betaOutRHmax = -alpha_OutUp_lowEdge + cms::alpakatools::deltaPhi(acc,
+                                                                       mds.anchorLowEdgeX()[fourthMDIndex],
+                                                                       mds.anchorLowEdgeY()[fourthMDIndex],
+                                                                       tl_axis_lowEdge_x,
+                                                                       tl_axis_lowEdge_y);
     }
 
     //beta computation

--- a/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
@@ -902,7 +902,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     float diffX = mds.anchorX()[thirdMDIndex] - mds.anchorX()[firstMDIndex];
     float diffY = mds.anchorY()[thirdMDIndex] - mds.anchorY()[firstMDIndex];
 
-    float dPhi = deltaPhi(acc, midPointX, midPointY, diffX, diffY);
+    float dPhi = cms::alpakatools::deltaPhi(acc, midPointX, midPointY, diffX, diffY);
 
     // First obtaining the raw betaIn and betaOut values without any correction and just purely based on the mini-doublet hit positions
     float alpha_InLo = __H2F(segments.dPhiChanges()[innerSegmentIndex]);
@@ -913,11 +913,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
 
     float alpha_OutUp, alpha_OutUp_highEdge, alpha_OutUp_lowEdge;
 
-    alpha_OutUp = phi_mpi_pi(acc,
-                             phi(acc,
-                                 mds.anchorX()[fourthMDIndex] - mds.anchorX()[thirdMDIndex],
-                                 mds.anchorY()[fourthMDIndex] - mds.anchorY()[thirdMDIndex]) -
-                                 mds.anchorPhi()[fourthMDIndex]);
+    alpha_OutUp = cms::alpakatools::reducePhiRange(
+        acc,
+        cms::alpakatools::phi(acc,
+                              mds.anchorX()[fourthMDIndex] - mds.anchorX()[thirdMDIndex],
+                              mds.anchorY()[fourthMDIndex] - mds.anchorY()[thirdMDIndex]) -
+            mds.anchorPhi()[fourthMDIndex]);
 
     alpha_OutUp_highEdge = alpha_OutUp;
     alpha_OutUp_lowEdge = alpha_OutUp;
@@ -929,38 +930,46 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     float tl_axis_lowEdge_x = tl_axis_x;
     float tl_axis_lowEdge_y = tl_axis_y;
 
-    float betaIn = alpha_InLo - phi_mpi_pi(acc, phi(acc, tl_axis_x, tl_axis_y) - mds.anchorPhi()[firstMDIndex]);
+    float betaIn =
+        alpha_InLo - cms::alpakatools::reducePhiRange(
+                         acc, cms::alpakatools::phi(acc, tl_axis_x, tl_axis_y) - mds.anchorPhi()[firstMDIndex]);
 
     float betaInRHmin = betaIn;
     float betaInRHmax = betaIn;
-    float betaOut = -alpha_OutUp + phi_mpi_pi(acc, phi(acc, tl_axis_x, tl_axis_y) - mds.anchorPhi()[fourthMDIndex]);
+    float betaOut =
+        -alpha_OutUp + cms::alpakatools::reducePhiRange(
+                           acc, cms::alpakatools::phi(acc, tl_axis_x, tl_axis_y) - mds.anchorPhi()[fourthMDIndex]);
 
     float betaOutRHmin = betaOut;
     float betaOutRHmax = betaOut;
 
     if (isEC_lastLayer) {
-      alpha_OutUp_highEdge = phi_mpi_pi(acc,
-                                        phi(acc,
-                                            mds.anchorHighEdgeX()[fourthMDIndex] - mds.anchorX()[thirdMDIndex],
-                                            mds.anchorHighEdgeY()[fourthMDIndex] - mds.anchorY()[thirdMDIndex]) -
-                                            mds.anchorHighEdgePhi()[fourthMDIndex]);
-      alpha_OutUp_lowEdge = phi_mpi_pi(acc,
-                                       phi(acc,
-                                           mds.anchorLowEdgeX()[fourthMDIndex] - mds.anchorX()[thirdMDIndex],
-                                           mds.anchorLowEdgeY()[fourthMDIndex] - mds.anchorY()[thirdMDIndex]) -
-                                           mds.anchorLowEdgePhi()[fourthMDIndex]);
+      alpha_OutUp_highEdge = cms::alpakatools::reducePhiRange(
+          acc,
+          cms::alpakatools::phi(acc,
+                                mds.anchorHighEdgeX()[fourthMDIndex] - mds.anchorX()[thirdMDIndex],
+                                mds.anchorHighEdgeY()[fourthMDIndex] - mds.anchorY()[thirdMDIndex]) -
+              mds.anchorHighEdgePhi()[fourthMDIndex]);
+      alpha_OutUp_lowEdge = cms::alpakatools::reducePhiRange(
+          acc,
+          cms::alpakatools::phi(acc,
+                                mds.anchorLowEdgeX()[fourthMDIndex] - mds.anchorX()[thirdMDIndex],
+                                mds.anchorLowEdgeY()[fourthMDIndex] - mds.anchorY()[thirdMDIndex]) -
+              mds.anchorLowEdgePhi()[fourthMDIndex]);
 
       tl_axis_highEdge_x = mds.anchorHighEdgeX()[fourthMDIndex] - mds.anchorX()[firstMDIndex];
       tl_axis_highEdge_y = mds.anchorHighEdgeY()[fourthMDIndex] - mds.anchorY()[firstMDIndex];
       tl_axis_lowEdge_x = mds.anchorLowEdgeX()[fourthMDIndex] - mds.anchorX()[firstMDIndex];
       tl_axis_lowEdge_y = mds.anchorLowEdgeY()[fourthMDIndex] - mds.anchorY()[firstMDIndex];
 
-      betaOutRHmin =
-          -alpha_OutUp_highEdge +
-          phi_mpi_pi(acc, phi(acc, tl_axis_highEdge_x, tl_axis_highEdge_y) - mds.anchorHighEdgePhi()[fourthMDIndex]);
-      betaOutRHmax =
-          -alpha_OutUp_lowEdge +
-          phi_mpi_pi(acc, phi(acc, tl_axis_lowEdge_x, tl_axis_lowEdge_y) - mds.anchorLowEdgePhi()[fourthMDIndex]);
+      betaOutRHmin = -alpha_OutUp_highEdge + cms::alpakatools::reducePhiRange(
+                                                 acc,
+                                                 cms::alpakatools::phi(acc, tl_axis_highEdge_x, tl_axis_highEdge_y) -
+                                                     mds.anchorHighEdgePhi()[fourthMDIndex]);
+      betaOutRHmax = -alpha_OutUp_lowEdge +
+                     cms::alpakatools::reducePhiRange(acc,
+                                                      cms::alpakatools::phi(acc, tl_axis_lowEdge_x, tl_axis_lowEdge_y) -
+                                                          mds.anchorLowEdgePhi()[fourthMDIndex]);
     }
 
     //beta computation
@@ -1070,31 +1079,36 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     float diffX = mds.anchorX()[thirdMDIndex] - mds.anchorX()[firstMDIndex];
     float diffY = mds.anchorY()[thirdMDIndex] - mds.anchorY()[firstMDIndex];
 
-    float dPhi = deltaPhi(acc, midPointX, midPointY, diffX, diffY);
+    float dPhi = cms::alpakatools::deltaPhi(acc, midPointX, midPointY, diffX, diffY);
 
     float sdIn_alpha = __H2F(segments.dPhiChanges()[innerSegmentIndex]);
     float sdIn_alpha_min = __H2F(segments.dPhiChangeMins()[innerSegmentIndex]);
     float sdIn_alpha_max = __H2F(segments.dPhiChangeMaxs()[innerSegmentIndex]);
     float sdOut_alpha = sdIn_alpha;
 
-    float sdOut_dPhiPos = phi_mpi_pi(acc, mds.anchorPhi()[fourthMDIndex] - mds.anchorPhi()[thirdMDIndex]);
+    float sdOut_dPhiPos =
+        cms::alpakatools::reducePhiRange(acc, mds.anchorPhi()[fourthMDIndex] - mds.anchorPhi()[thirdMDIndex]);
 
     float sdOut_dPhiChange = __H2F(segments.dPhiChanges()[outerSegmentIndex]);
     float sdOut_dPhiChange_min = __H2F(segments.dPhiChangeMins()[outerSegmentIndex]);
     float sdOut_dPhiChange_max = __H2F(segments.dPhiChangeMaxs()[outerSegmentIndex]);
 
-    float sdOut_alphaOutRHmin = phi_mpi_pi(acc, sdOut_dPhiChange_min - sdOut_dPhiPos);
-    float sdOut_alphaOutRHmax = phi_mpi_pi(acc, sdOut_dPhiChange_max - sdOut_dPhiPos);
-    float sdOut_alphaOut = phi_mpi_pi(acc, sdOut_dPhiChange - sdOut_dPhiPos);
+    float sdOut_alphaOutRHmin = cms::alpakatools::reducePhiRange(acc, sdOut_dPhiChange_min - sdOut_dPhiPos);
+    float sdOut_alphaOutRHmax = cms::alpakatools::reducePhiRange(acc, sdOut_dPhiChange_max - sdOut_dPhiPos);
+    float sdOut_alphaOut = cms::alpakatools::reducePhiRange(acc, sdOut_dPhiChange - sdOut_dPhiPos);
 
     float tl_axis_x = mds.anchorX()[fourthMDIndex] - mds.anchorX()[firstMDIndex];
     float tl_axis_y = mds.anchorY()[fourthMDIndex] - mds.anchorY()[firstMDIndex];
 
-    float betaIn = sdIn_alpha - phi_mpi_pi(acc, phi(acc, tl_axis_x, tl_axis_y) - mds.anchorPhi()[firstMDIndex]);
+    float betaIn =
+        sdIn_alpha - cms::alpakatools::reducePhiRange(
+                         acc, cms::alpakatools::phi(acc, tl_axis_x, tl_axis_y) - mds.anchorPhi()[firstMDIndex]);
 
     float betaInRHmin = betaIn;
     float betaInRHmax = betaIn;
-    float betaOut = -sdOut_alphaOut + phi_mpi_pi(acc, phi(acc, tl_axis_x, tl_axis_y) - mds.anchorPhi()[fourthMDIndex]);
+    float betaOut =
+        -sdOut_alphaOut + cms::alpakatools::reducePhiRange(
+                              acc, cms::alpakatools::phi(acc, tl_axis_x, tl_axis_y) - mds.anchorPhi()[fourthMDIndex]);
 
     float betaOutRHmin = betaOut;
     float betaOutRHmax = betaOut;
@@ -1226,27 +1240,32 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     float thetaMuls2 = (kMulsInGeV * kMulsInGeV) * (0.1f + 0.2f * (rt_OutLo - rt_InLo) / 50.f);
     float sdIn_alpha = __H2F(segments.dPhiChanges()[innerSegmentIndex]);
     float sdOut_alpha = sdIn_alpha;  //weird
-    float sdOut_dPhiPos = phi_mpi_pi(acc, mds.anchorPhi()[fourthMDIndex] - mds.anchorPhi()[thirdMDIndex]);
+    float sdOut_dPhiPos =
+        cms::alpakatools::reducePhiRange(acc, mds.anchorPhi()[fourthMDIndex] - mds.anchorPhi()[thirdMDIndex]);
 
     float sdOut_dPhiChange = __H2F(segments.dPhiChanges()[outerSegmentIndex]);
     float sdOut_dPhiChange_min = __H2F(segments.dPhiChangeMins()[outerSegmentIndex]);
     float sdOut_dPhiChange_max = __H2F(segments.dPhiChangeMaxs()[outerSegmentIndex]);
 
-    float sdOut_alphaOutRHmin = phi_mpi_pi(acc, sdOut_dPhiChange_min - sdOut_dPhiPos);
-    float sdOut_alphaOutRHmax = phi_mpi_pi(acc, sdOut_dPhiChange_max - sdOut_dPhiPos);
-    float sdOut_alphaOut = phi_mpi_pi(acc, sdOut_dPhiChange - sdOut_dPhiPos);
+    float sdOut_alphaOutRHmin = cms::alpakatools::reducePhiRange(acc, sdOut_dPhiChange_min - sdOut_dPhiPos);
+    float sdOut_alphaOutRHmax = cms::alpakatools::reducePhiRange(acc, sdOut_dPhiChange_max - sdOut_dPhiPos);
+    float sdOut_alphaOut = cms::alpakatools::reducePhiRange(acc, sdOut_dPhiChange - sdOut_dPhiPos);
 
     float tl_axis_x = mds.anchorX()[fourthMDIndex] - mds.anchorX()[firstMDIndex];
     float tl_axis_y = mds.anchorY()[fourthMDIndex] - mds.anchorY()[firstMDIndex];
 
-    float betaIn = sdIn_alpha - phi_mpi_pi(acc, phi(acc, tl_axis_x, tl_axis_y) - mds.anchorPhi()[firstMDIndex]);
+    float betaIn =
+        sdIn_alpha - cms::alpakatools::reducePhiRange(
+                         acc, cms::alpakatools::phi(acc, tl_axis_x, tl_axis_y) - mds.anchorPhi()[firstMDIndex]);
 
     float sdIn_alphaRHmin = __H2F(segments.dPhiChangeMins()[innerSegmentIndex]);
     float sdIn_alphaRHmax = __H2F(segments.dPhiChangeMaxs()[innerSegmentIndex]);
     float betaInRHmin = betaIn + sdIn_alphaRHmin - sdIn_alpha;
     float betaInRHmax = betaIn + sdIn_alphaRHmax - sdIn_alpha;
 
-    float betaOut = -sdOut_alphaOut + phi_mpi_pi(acc, phi(acc, tl_axis_x, tl_axis_y) - mds.anchorPhi()[fourthMDIndex]);
+    float betaOut =
+        -sdOut_alphaOut + cms::alpakatools::reducePhiRange(
+                              acc, cms::alpakatools::phi(acc, tl_axis_x, tl_axis_y) - mds.anchorPhi()[fourthMDIndex]);
 
     float betaOutRHmin = betaOut - sdOut_alphaOutRHmin + sdOut_alphaOut;
     float betaOutRHmax = betaOut - sdOut_alphaOutRHmax + sdOut_alphaOut;

--- a/RecoTracker/LSTCore/src/alpaka/Segment.h
+++ b/RecoTracker/LSTCore/src/alpaka/Segment.h
@@ -314,12 +314,13 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
 
     float sdCut = sdSlope + alpaka::math::sqrt(acc, sdMuls * sdMuls + sdPVoff * sdPVoff);
 
-    dPhi = phi_mpi_pi(acc, mds.anchorPhi()[outerMDIndex] - mds.anchorPhi()[innerMDIndex]);
+    dPhi = cms::alpakatools::reducePhiRange(acc, mds.anchorPhi()[outerMDIndex] - mds.anchorPhi()[innerMDIndex]);
 
     if (alpaka::math::abs(acc, dPhi) > sdCut)
       return false;
 
-    dPhiChange = phi_mpi_pi(acc, phi(acc, xOut - xIn, yOut - yIn) - mds.anchorPhi()[innerMDIndex]);
+    dPhiChange = cms::alpakatools::reducePhiRange(
+        acc, cms::alpakatools::phi(acc, xOut - xIn, yOut - yIn) - mds.anchorPhi()[innerMDIndex]);
 
     if (alpaka::math::abs(acc, dPhiChange) > sdCut)
       return false;
@@ -415,12 +416,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     if ((rtOut < rtLo) || (rtOut > rtHi))
       return false;
 
-    dPhi = phi_mpi_pi(acc, mds.anchorPhi()[outerMDIndex] - mds.anchorPhi()[innerMDIndex]);
+    dPhi = cms::alpakatools::reducePhiRange(acc, mds.anchorPhi()[outerMDIndex] - mds.anchorPhi()[innerMDIndex]);
 
     float sdCut = sdSlope;
     if (outerLayerEndcapTwoS) {
-      float dPhiPos_high = phi_mpi_pi(acc, mds.anchorHighEdgePhi()[outerMDIndex] - mds.anchorPhi()[innerMDIndex]);
-      float dPhiPos_low = phi_mpi_pi(acc, mds.anchorLowEdgePhi()[outerMDIndex] - mds.anchorPhi()[innerMDIndex]);
+      float dPhiPos_high =
+          cms::alpakatools::reducePhiRange(acc, mds.anchorHighEdgePhi()[outerMDIndex] - mds.anchorPhi()[innerMDIndex]);
+      float dPhiPos_low =
+          cms::alpakatools::reducePhiRange(acc, mds.anchorLowEdgePhi()[outerMDIndex] - mds.anchorPhi()[innerMDIndex]);
 
       dPhiMax = alpaka::math::abs(acc, dPhiPos_high) > alpaka::math::abs(acc, dPhiPos_low) ? dPhiPos_high : dPhiPos_low;
       dPhiMin = alpaka::math::abs(acc, dPhiPos_high) > alpaka::math::abs(acc, dPhiPos_low) ? dPhiPos_low : dPhiPos_high;

--- a/RecoTracker/LSTCore/src/alpaka/TrackCandidate.h
+++ b/RecoTracker/LSTCore/src/alpaka/TrackCandidate.h
@@ -131,7 +131,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
           float eta2 = segmentsPixel.eta()[pLS_jx - prefix];
           float phi2 = segmentsPixel.phi()[pLS_jx - prefix];
           float dEta = alpaka::math::abs(acc, (eta1 - eta2));
-          float dPhi = calculate_dPhi(phi1, phi2);
+          float dPhi = reco::deltaPhi(phi1, phi2);
 
           float dR2 = dEta * dEta + dPhi * dPhi;
           if (dR2 < 1e-5f)
@@ -178,7 +178,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
             }
 
             float dEta = alpaka::math::abs(acc, eta1 - eta2);
-            float dPhi = calculate_dPhi(phi1, phi2);
+            float dPhi = reco::deltaPhi(phi1, phi2);
 
             float dR2 = dEta * dEta + dPhi * dPhi;
             if (dR2 < 1e-3f)
@@ -220,7 +220,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
             float eta2 = __H2F(quintuplets.eta()[quintupletIndex]);
             float phi2 = __H2F(quintuplets.phi()[quintupletIndex]);
             float dEta = alpaka::math::abs(acc, eta1 - eta2);
-            float dPhi = calculate_dPhi(phi1, phi2);
+            float dPhi = reco::deltaPhi(phi1, phi2);
 
             float dR2 = dEta * dEta + dPhi * dPhi;
             if (dR2 < 1e-3f)
@@ -236,7 +236,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
             float eta2 = __H2F(pixelTriplets.eta_pix()[pT3Index]);
             float phi2 = __H2F(pixelTriplets.phi_pix()[pT3Index]);
             float dEta = alpaka::math::abs(acc, eta1 - eta2);
-            float dPhi = calculate_dPhi(phi1, phi2);
+            float dPhi = reco::deltaPhi(phi1, phi2);
 
             float dR2 = dEta * dEta + dPhi * dPhi;
             if (dR2 < 0.000001f)
@@ -252,7 +252,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
             float eta2 = segmentsPixel.eta()[pLSIndex - prefix];
             float phi2 = segmentsPixel.phi()[pLSIndex - prefix];
             float dEta = alpaka::math::abs(acc, eta1 - eta2);
-            float dPhi = calculate_dPhi(phi1, phi2);
+            float dPhi = reco::deltaPhi(phi1, phi2);
 
             float dR2 = dEta * dEta + dPhi * dPhi;
             if (dR2 < 0.000001f)

--- a/RecoTracker/LSTCore/src/alpaka/Triplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/Triplet.h
@@ -390,7 +390,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     float alpha_InLo = __H2F(segments.dPhiChanges()[innerSegmentIndex]);
     float tl_axis_x = mds.anchorX()[thirdMDIndex] - mds.anchorX()[firstMDIndex];
     float tl_axis_y = mds.anchorY()[thirdMDIndex] - mds.anchorY()[firstMDIndex];
-    betaIn = alpha_InLo - phi_mpi_pi(acc, phi(acc, tl_axis_x, tl_axis_y) - mds.anchorPhi()[firstMDIndex]);
+    betaIn = alpha_InLo - cms::alpakatools::reducePhiRange(
+                              acc, cms::alpakatools::phi(acc, tl_axis_x, tl_axis_y) - mds.anchorPhi()[firstMDIndex]);
 
     //beta computation
     float drt_tl_axis = alpaka::math::sqrt(acc, tl_axis_x * tl_axis_x + tl_axis_y * tl_axis_y);
@@ -436,7 +437,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     float tl_axis_x = mds.anchorX()[thirdMDIndex] - mds.anchorX()[firstMDIndex];
     float tl_axis_y = mds.anchorY()[thirdMDIndex] - mds.anchorY()[firstMDIndex];
 
-    betaIn = sdIn_alpha - phi_mpi_pi(acc, phi(acc, tl_axis_x, tl_axis_y) - mds.anchorPhi()[firstMDIndex]);
+    betaIn = sdIn_alpha - cms::alpakatools::reducePhiRange(
+                              acc, cms::alpakatools::phi(acc, tl_axis_x, tl_axis_y) - mds.anchorPhi()[firstMDIndex]);
 
     float betaInRHmin = betaIn;
     float betaInRHmax = betaIn;
@@ -489,7 +491,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     float tl_axis_x = mds.anchorX()[thirdMDIndex] - mds.anchorX()[firstMDIndex];
     float tl_axis_y = mds.anchorY()[thirdMDIndex] - mds.anchorY()[firstMDIndex];
 
-    betaIn = sdIn_alpha - phi_mpi_pi(acc, phi(acc, tl_axis_x, tl_axis_y) - mds.anchorPhi()[firstMDIndex]);
+    betaIn = sdIn_alpha - cms::alpakatools::reducePhiRange(
+                              acc, cms::alpakatools::phi(acc, tl_axis_x, tl_axis_y) - mds.anchorPhi()[firstMDIndex]);
 
     float sdIn_alphaRHmin = __H2F(segments.dPhiChangeMins()[innerSegmentIndex]);
     float sdIn_alphaRHmax = __H2F(segments.dPhiChangeMaxs()[innerSegmentIndex]);


### PR DESCRIPTION
With the introduction in CMSSW of alpaka functions for the computation of φ-related variables in #47033 and the related updates in #47154, these functions can be removed for the LST code and their centrally implemented equivalents can be used.

The code has been tested locally: it compiles and gives the identical results  (on CPU) for LST.