### PR TITLE
Work around ROOT bug in HitPattern IO read rule

### DIFF
--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -29,16 +29,16 @@
   </class>
  <ioread
     sourceClass="reco::HitPattern"
-      source="uint16_t hitPattern[50]; uint8_t hitCount; uint8_t beginTrackHits; uint8_t endTrackHits;uint8_t beginInner; uint8_t endInner; uint8_t beginOuter; uint8_t endOuter;"
+      source="uint8_t hitCount; uint8_t beginTrackHits; uint8_t endTrackHits;uint8_t beginInner; uint8_t endInner; uint8_t beginOuter; uint8_t endOuter; uint16_t hitPattern[50];"
       targetClass="reco::HitPattern"
       target="hitPattern,hitCount,beginTrackHits,endTrackHits,beginInner,endInner,beginOuter,endOuter"
       version="[12]"
       >
    <![CDATA[
-            (void) reco::HitPattern::fillNewHitPatternWithOldHitPattern_v12(onfile.hitPattern, *onfile.hitCount,
-                    *onfile.beginTrackHits, *onfile.endTrackHits,
-                    *onfile.beginInner,  *onfile.endInner,
-                    *onfile.beginOuter, *onfile.endOuter,
+            (void) reco::HitPattern::fillNewHitPatternWithOldHitPattern_v12(onfile.hitPattern, onfile.hitCount,
+                    onfile.beginTrackHits, onfile.endTrackHits,
+                    onfile.beginInner,  onfile.endInner,
+                    onfile.beginOuter, onfile.endOuter,
                     newObj);
       ]]>
  </ioread>


### PR DESCRIPTION
#### PR description:

Until https://github.com/root-project/root/pull/17523, ROOT had a (long-standing) issue that array dimensions would spill into all following source types. To allow the rule to compile with old and new versions of ROOT, move the array source last to work around the issue.

For illustration purposes, here is the generated type of onfile before:
```
struct recocLcLHitPattern_Onfile {
   typedef uint16_t onfile_hitPattern_t[50];
   onfile_hitPattern_t &hitPattern;
   typedef uint8_t onfile_hitCount_t[50];
   onfile_hitCount_t &hitCount;
   typedef uint8_t onfile_beginTrackHits_t[50];
   onfile_beginTrackHits_t &beginTrackHits;
   typedef uint8_t onfile_endTrackHits_t[50];
   onfile_endTrackHits_t &endTrackHits;
   typedef uint8_t onfile_beginInner_t[50];
   onfile_beginInner_t &beginInner;
   typedef uint8_t onfile_endInner_t[50];
   onfile_endInner_t &endInner;
   typedef uint8_t onfile_beginOuter_t[50];
   onfile_beginOuter_t &beginOuter;
   typedef uint8_t onfile_endOuter_t[50];
   onfile_endOuter_t &endOuter;
}
```
and after this change:
```
struct recocLcLHitPattern_Onfile {
   uint8_t &hitCount;
   uint8_t &beginTrackHits;
   uint8_t &endTrackHits;
   uint8_t &beginInner;
   uint8_t &endInner;
   uint8_t &beginOuter;
   uint8_t &endOuter;
   typedef uint16_t onfile_hitPattern_t[50];
};
```

As far as I can tell from quick searches, this is the only rule in CMSSW that is affected by the problem. The only other C-style array is in the other rule targeting `HitPattern` up to version 11, but it only has one `source`.

#### PR validation:

None, rules *should* behave the same.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport probably not needed.

FYI @iarspider @smuzaffar @makortel 