### PR TITLE
Sources now have independent ProductRegistry

### DIFF
--- a/FWCore/Framework/interface/InputSourceDescription.h
+++ b/FWCore/Framework/interface/InputSourceDescription.h
@@ -19,16 +19,9 @@ namespace edm {
   class ThinnedAssociationsHelper;
 
   struct InputSourceDescription {
-    InputSourceDescription()
-        : moduleDescription_(),
-          productRegistry_(nullptr),
-          actReg_(),
-          maxEvents_(-1),
-          maxLumis_(-1),
-          allocations_(nullptr) {}
+    InputSourceDescription() : moduleDescription_(), actReg_(), maxEvents_(-1), maxLumis_(-1), allocations_(nullptr) {}
 
     InputSourceDescription(ModuleDescription const& md,
-                           std::shared_ptr<ProductRegistry> preg,
                            std::shared_ptr<BranchIDListHelper> branchIDListHelper,
                            std::shared_ptr<ProcessBlockHelper> const& processBlockHelper,
                            std::shared_ptr<ThinnedAssociationsHelper> thinnedAssociationsHelper,
@@ -38,7 +31,6 @@ namespace edm {
                            int maxSecondsUntilRampdown,
                            PreallocationConfiguration const& allocations)
         : moduleDescription_(md),
-          productRegistry_(preg),
           branchIDListHelper_(branchIDListHelper),
           processBlockHelper_(processBlockHelper),
           thinnedAssociationsHelper_(thinnedAssociationsHelper),
@@ -49,7 +41,6 @@ namespace edm {
           allocations_(&allocations) {}
 
     ModuleDescription moduleDescription_;
-    std::shared_ptr<ProductRegistry> productRegistry_;
     std::shared_ptr<BranchIDListHelper> branchIDListHelper_;
     std::shared_ptr<ProcessBlockHelper> processBlockHelper_;
     std::shared_ptr<ThinnedAssociationsHelper> thinnedAssociationsHelper_;

--- a/FWCore/Framework/interface/maker/InputSourceFactory.h
+++ b/FWCore/Framework/interface/maker/InputSourceFactory.h
@@ -21,9 +21,7 @@ namespace edm {
 
     static InputSourceFactory const* get();
 
-    std::unique_ptr<InputSource> makeInputSource(ParameterSet const&,
-                                                 SignallingProductRegistry&,
-                                                 InputSourceDescription const&) const;
+    std::unique_ptr<InputSource> makeInputSource(ParameterSet const&, InputSourceDescription const&) const;
 
   private:
     InputSourceFactory();

--- a/FWCore/Framework/src/InputSource.cc
+++ b/FWCore/Framework/src/InputSource.cc
@@ -54,7 +54,6 @@ namespace edm {
         maxSecondsUntilRampdown_(desc.maxSecondsUntilRampdown_),
         processingMode_(RunsLumisAndEvents),
         moduleDescription_(desc.moduleDescription_),
-        productRegistry_(desc.productRegistry_),
         processHistoryRegistry_(new ProcessHistoryRegistry),
         branchIDListHelper_(desc.branchIDListHelper_),
         processBlockHelper_(desc.processBlockHelper_),
@@ -205,7 +204,7 @@ namespace edm {
                                                                     "Calling InputSource::readRunAuxiliary_");
   }
 
-  void InputSource::doBeginJob() { this->beginJob(); }
+  void InputSource::doBeginJob(edm::ProductRegistry const& iReg) { this->beginJob(iReg); }
 
   void InputSource::doEndJob() { endJob(); }
 
@@ -217,7 +216,7 @@ namespace edm {
     return std::pair<SharedResourcesAcquirer*, std::recursive_mutex*>(nullptr, nullptr);
   }
 
-  void InputSource::registerProducts(SignallingProductRegistry&) {}
+  void InputSource::registerProducts() {}
 
   // Return a dummy file block.
   std::shared_ptr<FileBlock> InputSource::readFile() {
@@ -436,7 +435,7 @@ namespace edm {
                                                                         "Calling InputSource::reverseState__");
   }
 
-  void InputSource::beginJob() {}
+  void InputSource::beginJob(ProductRegistry const&) {}
 
   void InputSource::endJob() {}
 

--- a/FWCore/Framework/src/InputSourceFactory.cc
+++ b/FWCore/Framework/src/InputSourceFactory.cc
@@ -24,7 +24,6 @@ namespace edm {
   }
 
   std::unique_ptr<InputSource> InputSourceFactory::makeInputSource(ParameterSet const& conf,
-                                                                   SignallingProductRegistry& reg,
                                                                    InputSourceDescription const& desc) const
 
   {
@@ -40,7 +39,7 @@ namespace edm {
           << "Try running EdmPluginDump to obtain a list of available Plugins.";
     }
 
-    wm->registerProducts(reg);
+    wm->registerProducts();
 
     FDEBUG(1) << "InputSourceFactory: created input source " << modtype << std::endl;
 

--- a/FWCore/Integration/plugins/PutOrMergeTestSource.cc
+++ b/FWCore/Integration/plugins/PutOrMergeTestSource.cc
@@ -27,7 +27,7 @@ namespace edmtest {
     PutOrMergeTestSource(ParameterSet const&, InputSourceDescription const&);
 
     /// Register any produced products
-    void registerProducts(SignallingProductRegistry&) final;
+    void registerProducts() final;
 
   private:
     ItemTypeInfo getNextItemType() final;
@@ -86,7 +86,7 @@ PutOrMergeTestSource::PutOrMergeTestSource(ParameterSet const& iPS, InputSourceD
   historyID_ = history.id();
 }
 
-void PutOrMergeTestSource::registerProducts(SignallingProductRegistry&) {
+void PutOrMergeTestSource::registerProducts() {
   edm::ParameterSet dummyPset;
   dummyPset.registerIt();
 

--- a/FWCore/Integration/plugins/ThrowingSource.cc
+++ b/FWCore/Integration/plugins/ThrowingSource.cc
@@ -12,7 +12,7 @@ namespace edm {
     explicit ThrowingSource(ParameterSet const&, InputSourceDescription const&);
     ~ThrowingSource() noexcept(false) override;
 
-    void beginJob() override;
+    void beginJob(ProductRegistry const&) override;
     void endJob() override;
     void beginLuminosityBlock(edm::LuminosityBlock&) override;
     void beginRun(edm::Run&) override;
@@ -63,7 +63,7 @@ namespace edm {
 
   void ThrowingSource::produce(edm::Event&) {}
 
-  void ThrowingSource::beginJob() {
+  void ThrowingSource::beginJob(edm::ProductRegistry const&) {
     if (whenToThrow_ == kBeginJob)
       throw cms::Exception("TestThrow") << "ThrowingSource::beginJob";
   }

--- a/FWCore/Sources/interface/IDGeneratorSourceBase.h
+++ b/FWCore/Sources/interface/IDGeneratorSourceBase.h
@@ -71,7 +71,7 @@ namespace edm {
     virtual bool setRunAndEventInfo(EventID& id, TimeValue_t& time, EventAuxiliary::ExperimentType& etype) = 0;
     virtual bool noFiles() const;
     virtual size_t fileIndex() const;
-    void beginJob() override;
+    void beginJob(ProductRegistry const&) override;
 
     std::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_() override;
     std::shared_ptr<RunAuxiliary> readRunAuxiliary_() override;

--- a/FWCore/Sources/interface/PuttableSourceBase.h
+++ b/FWCore/Sources/interface/PuttableSourceBase.h
@@ -40,7 +40,7 @@ namespace edm {
     // ---------- member functions ---------------------------
     using ProducerBase::registerProducts;
     using ProducerBase::resolvePutIndicies;
-    void registerProducts(SignallingProductRegistry&) final;
+    void registerProducts() final;
 
     bool hasAbilityToProduceInBeginRuns() const final { return true; }
 
@@ -48,7 +48,7 @@ namespace edm {
 
   protected:
     //If inheriting class overrides, they need to call this function as well
-    void beginJob() override;
+    void beginJob(edm::ProductRegistry const&) override;
 
   private:
     void doBeginLumi(LuminosityBlockPrincipal& lbp, ProcessContext const*) override;

--- a/FWCore/Sources/src/IDGeneratorSourceBase.cc
+++ b/FWCore/Sources/src/IDGeneratorSourceBase.cc
@@ -113,8 +113,8 @@ namespace edm {
   }
 
   template <typename BASE>
-  void IDGeneratorSourceBase<BASE>::beginJob() {
-    BASE::beginJob();
+  void IDGeneratorSourceBase<BASE>::beginJob(ProductRegistry const& iReg) {
+    BASE::beginJob(iReg);
     // Initialize cannot be called from the constructor, because it is a virtual function
     // that needs to be invoked from a derived class if the derived class overrides it.
     initialize(eventID_, presentTime_, timeBetweenEvents_);

--- a/FWCore/Sources/src/PuttableSourceBase.cc
+++ b/FWCore/Sources/src/PuttableSourceBase.cc
@@ -22,6 +22,7 @@
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ExceptionHelpers.h"
+#include "FWCore/Framework/interface/SignallingProductRegistry.h"
 
 using namespace edm;
 //
@@ -38,15 +39,16 @@ using namespace edm;
 PuttableSourceBase::PuttableSourceBase(ParameterSet const& iPSet, InputSourceDescription const& iISD)
     : InputSource(iPSet, iISD) {}
 
-void PuttableSourceBase::registerProducts(SignallingProductRegistry& iReg) {
-  registerProducts(this, &iReg, moduleDescription());
+void PuttableSourceBase::registerProducts() {
+  SignallingProductRegistry reg;
+  registerProducts(this, &reg, moduleDescription());
+  productRegistryUpdate().addFromInput(reg);
 }
 
-void PuttableSourceBase::beginJob() {
-  auto r = productRegistry();
-  auto const runLookup = r->productLookup(InRun);
-  auto const lumiLookup = r->productLookup(InLumi);
-  auto const eventLookup = r->productLookup(InEvent);
+void PuttableSourceBase::beginJob(edm::ProductRegistry const& r) {
+  auto const runLookup = r.productLookup(InRun);
+  auto const lumiLookup = r.productLookup(InLumi);
+  auto const eventLookup = r.productLookup(InEvent);
   auto const& processName = moduleDescription().processName();
   auto const& moduleLabel = moduleDescription().moduleLabel();
 

--- a/IOPool/Input/src/RepeatingCachedRootSource.cc
+++ b/IOPool/Input/src/RepeatingCachedRootSource.cc
@@ -36,6 +36,7 @@
 #include "FWCore/Catalog/interface/InputFileCatalog.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/do_nothing_deleter.h"
 #include "FWCore/Sources/interface/EventSkipperByID.h"
 
 #include "FWCore/Framework/interface/InputSourceMacros.h"
@@ -125,7 +126,7 @@ namespace edm {
     bool readIt(EventID const& id, EventPrincipal& eventPrincipal, StreamContext& streamContext) override;
     void skip(int offset) override;
     bool goToEvent_(EventID const& eventID) override;
-    void beginJob() override;
+    void beginJob(ProductRegistry const&) override;
 
     void fillProcessBlockHelper_() override;
     bool nextProcessBlock_(ProcessBlockPrincipal&) override;
@@ -228,13 +229,16 @@ RepeatingCachedRootSource::RepeatingCachedRootSource(ParameterSet const& pset, I
   }
 }
 
-void RepeatingCachedRootSource::beginJob() {
+void RepeatingCachedRootSource::beginJob(ProductRegistry const&) {
   ProcessConfiguration processConfiguration;
   processConfiguration.setParameterSetID(ParameterSet::emptyParameterSetID());
   processConfiguration.setProcessConfigurationID();
 
+  //in order to use the source's internal ProductRegistry for looking up date
+  // it needs to be frozen (which setups the other structures)
+  productRegistryUpdate().setFrozen();
   //Thinned collection associations are not supported at this time
-  EventPrincipal eventPrincipal(productRegistry(),
+  EventPrincipal eventPrincipal(std::shared_ptr<ProductRegistry const>(&productRegistry(), do_nothing_deleter()),
                                 edm::productResolversFactory::makePrimary,
                                 branchIDListHelper(),
                                 std::make_shared<ThinnedAssociationsHelper>(),

--- a/IOPool/Streamer/src/StreamerInputSource.cc
+++ b/IOPool/Streamer/src/StreamerInputSource.cc
@@ -299,7 +299,7 @@ namespace edm::streamer {
   void StreamerInputSource::read(EventPrincipal& eventPrincipal) {
     if (adjustEventToNewProductRegistry_) {
       eventPrincipal.adjustIndexesAfterProductRegistryAddition();
-      bool eventOK = eventPrincipal.adjustToNewProductRegistry(*productRegistry());
+      bool eventOK = eventPrincipal.adjustToNewProductRegistry(productRegistry());
       assert(eventOK);
       adjustEventToNewProductRegistry_ = false;
     }


### PR DESCRIPTION
#### PR description:

Sources can now update their ProductRegistry without affecting the rest of the system. The system will pick up the changes when they are needed.

#### PR validation:

Framework code compiles and framework related unit tests pass.

resolves https://github.com/cms-sw/framework-team/issues/1207