### PR TITLE
Remove -Werror=array-bounds CXXFLAG for spurious array bounds warning from gcc 13.3.1 in multiple packages

### DIFF
--- a/Geometry/HGCalCommonData/BuildFile.xml
+++ b/Geometry/HGCalCommonData/BuildFile.xml
@@ -4,6 +4,7 @@
 <use name="DetectorDescription/DDCMS"/>
 <use name="FWCore/ParameterSet"/>
 <use name="dd4hep"/>
+<flags REM_CXXFLAGS="-Werror=array-bounds"/>
 <export>
   <lib name="1"/>
 </export>


### PR DESCRIPTION
Spurious array bounds warning from gcc13.3.0 causes build error  in `Geometry/HGCalCommonData`
``` 
>> Compiling  src/Geometry/HGCalCommonData/src/HGCalWaferType.cc
/data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc13/external/gcc/13.3.1-92b2d78dc343ed2bc93c8eb414ddc9ff/bin/c++ -c -DCMS_MICRO_ARCH='' -DGNU_GCC -D_GNU_SOURCE -DCMS_ADDRESS_SANITIZER -DTBB_USE_GLIBCXX_VERSION=130301 -DTBB_SUPPRESS_DEPRECATED_MESSAGES -DTBB_PREVIEW_RESUMABLE_TASKS=1 -DTBB_PREVIEW_TASK_GROUP_EXTENSIONS=1 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -DBOOST_MATH_DISABLE_STD_FPCLASSIFY -DBOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX -DDD4HEP_USE_GEANT4_UNITS=1 -DCMSSW_GIT_HASH='CMSSW_15_0_ASAN_X_2025-01-29-2300' -DPROJECT_NAME='CMSSW' -DPROJECT_VERSION='CMSSW_15_0_ASAN_X_2025-01-29-2300' -Isrc -Ipoison -I/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02874/el8_amd64_gcc13/cms/cmssw/CMSSW_15_0_ASAN_X_2025-01-29-2300/src -I/data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc13/external/dd4hep/v01-29-00-5ae634f4b026ab0975c69e2150254b16/include -I/data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc13/external/pcre/8.43-98b91818238e6315baa782c93d2e1a8d/include -isystem/data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc13/external/boost/1.80.0-219130170382a74ab026bc7e8f3aed50/include -I/data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc13/external/bz2lib/1.0.6-f92c52f66bf6507988f946bd77fb689c/include -isystem/data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc13/external/clhep/2.4.7.1-702cdfb6dd16a41af8674f0bf734e863/include -I/data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc13/external/gsl/2.6-1e2efc87aa19e599c5e55ee8595b7eaf/include -I/data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc13/external/libuuid/2.34-c2b49c79f52c48d7cb42b214bd8f95f6/include -isystem/data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc13/lcg/root/6.32.09-673228292062580b5c2725e1de3085a5/include -isystem/data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc13/external/tbb/v2021.9.0-fc977fda7ed4cc29c17d19c6703a0199/include -I/data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc13/external/xerces-c/3.1.3-14d6230deabf01bcafd3d32c7a59dc27/include -I/data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc13/external/xz/5.2.5-5f1d064218d21615d94b64b937b2e0b3/include -I/data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc13/external/zlib/1.2.13-31c9b620a337e84039f8c84b7cc46501/include -I/data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc13/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-f69c28fbc641f93cf8259f2f47a6ec08/include -I/data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc13/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-f69c28fbc641f93cf8259f2f47a6ec08/include/eigen3 -I/data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc13/external/fmt/10.2.1-36fc7f6c79f01f17e1a4b853aff183cd/include -I/data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc13/external/md5/1.0.0-ea9ab1991fd07bc46b92ce4a79651057/include -I/data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc13/external/OpenBLAS/0.3.27-b82cdf3e5810569d313c8857a6214285/include -I/data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc13/external/tinyxml2/6.2.0-f3fb3ad5f8c256e1e42fc6264747acf5/include -O3 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++20 -ftree-vectorize -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -fuse-ld=bfd -march=x86-64-v3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-unused-parameter -Wunused -Wparentheses -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -fno-omit-frame-pointer -fsanitize=address -fsanitize=pointer-subtract -DEIGEN_DONT_PARALLELIZE -DEIGEN_MAX_ALIGN_BYTES=64 -Wno-error=unused-variable -DBOOST_DISABLE_ASSERTS -fPIC -MMD -MF tmp/el8_amd64_gcc13/src/Geometry/HGCalCommonData/src/GeometryHGCalCommonData/HGCalWaferType.cc.d src/Geometry/HGCalCommonData/src/HGCalWaferType.cc -o tmp/el8_amd64_gcc13/src/Geometry/HGCalCommonData/src/GeometryHGCalCommonData/HGCalWaferType.cc.o
src/Geometry/HGCalCommonData/src/HGCalCellOffset.cc: In constructor 'HGCalCellOffset::HGCalCellOffset(double, int32_t, int32_t, double, double, double)':
  [src/Geometry/HGCalCommonData/src/HGCalCellOffset.cc:592](https://github.com/cms-sw/cmssw/blob/CMSSW_15_0_ASAN_X_2025-01-29-2300/Geometry/HGCalCommonData/src/HGCalCellOffset.cc#L592):27: error: array subscript 20 is above array bounds of 'double [6]' [-Werror=array-bounds=]
   592 |             (cellArea[k][j]);
      |             ~~~~~~~~~~~~~~^~
In file included from src/Geometry/HGCalCommonData/src/HGCalCellOffset.cc:2:
src/Geometry/HGCalCommonData/interface/HGCalCellOffset.h:31:45: note: while referencing 'HGCalCellOffset::cellArea'
   31 |   double cellX_[2], cellY_[2], fullArea[2], cellArea[2][6], cellAreaPartial[2][25];
      |                                             ^~~~~~~~
  [src/Geometry/HGCalCommonData/src/HGCalCellOffset.cc:573](https://github.com/cms-sw/cmssw/blob/CMSSW_15_0_ASAN_X_2025-01-29-2300/Geometry/HGCalCommonData/src/HGCalCellOffset.cc#L573):39: error: array subscript 21 is above array bounds of 'double [6]' [-Werror=array-bounds=]
   573 |                         (cellArea[k][j]);  // Magnitude of offset
      |                         ~~~~~~~~~~~~~~^~
src/Geometry/HGCalCommonData/interface/HGCalCellOffset.h:31:45: note: while referencing 'HGCalCellOffset::cellArea'
   31 |   double cellX_[2], cellY_[2], fullArea[2], cellArea[2][6], cellAreaPartial[2][25];
      |                                             ^~~~~~~~
cc1plus: some warnings being treated as errors
```