### PR TITLE
Migrate Alpaka EDProducers to pass the edm::ParameterSet to base class constructor

### DIFF
--- a/EventFilter/EcalRawToDigi/plugins/alpaka/EcalRawToDigiPortable.cc
+++ b/EventFilter/EcalRawToDigi/plugins/alpaka/EcalRawToDigiPortable.cc
@@ -57,7 +57,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   }
 
   EcalRawToDigiPortable::EcalRawToDigiPortable(const edm::ParameterSet& ps)
-      : rawDataToken_{consumes<FEDRawDataCollection>(ps.getParameter<edm::InputTag>("InputLabel"))},
+      : EDProducer(ps),
+        rawDataToken_{consumes<FEDRawDataCollection>(ps.getParameter<edm::InputTag>("InputLabel"))},
         digisDevEBToken_{produces(ps.getParameter<std::string>("digisLabelEB"))},
         digisDevEEToken_{produces(ps.getParameter<std::string>("digisLabelEE"))},
         eMappingToken_{esConsumes()},

--- a/EventFilter/HcalRawToDigi/plugins/alpaka/HcalDigisSoAProducer.cc
+++ b/EventFilter/HcalRawToDigi/plugins/alpaka/HcalDigisSoAProducer.cc
@@ -65,7 +65,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   }
 
   HcalDigisSoAProducer::HcalDigisSoAProducer(const edm::ParameterSet& ps)
-      : hbheDigiToken_{consumes(ps.getParameter<edm::InputTag>("hbheDigisLabel"))},
+      : EDProducer(ps),
+        hbheDigiToken_{consumes(ps.getParameter<edm::InputTag>("hbheDigisLabel"))},
         qie11DigiToken_{consumes(ps.getParameter<edm::InputTag>("qie11DigiLabel"))},
         digisF01HEToken_{produces(ps.getParameter<std::string>("digisLabelF01HE"))},
         digisF5HBToken_{produces(ps.getParameter<std::string>("digisLabelF5HB"))},

--- a/HeterogeneousCore/AlpakaCore/plugins/alpaka/AlpakaBackendProducer.cc
+++ b/HeterogeneousCore/AlpakaCore/plugins/alpaka/AlpakaBackendProducer.cc
@@ -12,7 +12,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   class AlpakaBackendProducer : public global::EDProducer<> {
   public:
-    AlpakaBackendProducer(edm::ParameterSet const& config) {}
+    AlpakaBackendProducer(edm::ParameterSet const& config) : EDProducer(config) {}
 
     void produce(edm::StreamID sid, device::Event& event, device::EventSetup const&) const override {}
 

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaGlobalProducerCopyToDeviceCache.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaGlobalProducerCopyToDeviceCache.cc
@@ -19,7 +19,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   class TestAlpakaGlobalProducerCopyToDeviceCache : public global::EDProducer<> {
   public:
     TestAlpakaGlobalProducerCopyToDeviceCache(edm::ParameterSet const& config)
-        : getToken_(consumes(config.getParameter<edm::InputTag>("source"))),
+        : EDProducer(config),
+          getToken_(consumes(config.getParameter<edm::InputTag>("source"))),
           getTokenMulti2_(consumes(config.getParameter<edm::InputTag>("source"))),
           getTokenMulti3_(consumes(config.getParameter<edm::InputTag>("source"))),
           putToken_{produces()},

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaGlobalProducerMoveToDeviceCache.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaGlobalProducerMoveToDeviceCache.cc
@@ -20,7 +20,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   class TestAlpakaGlobalProducerMoveToDeviceCache : public global::EDProducer<> {
   public:
     TestAlpakaGlobalProducerMoveToDeviceCache(edm::ParameterSet const& config)
-        : getToken_(consumes(config.getParameter<edm::InputTag>("source"))),
+        : EDProducer(config),
+          getToken_(consumes(config.getParameter<edm::InputTag>("source"))),
           getTokenMulti2_(consumes(config.getParameter<edm::InputTag>("source"))),
           getTokenMulti3_(consumes(config.getParameter<edm::InputTag>("source"))),
           putToken_{produces()},

--- a/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalRecHitProducerPortable.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalRecHitProducerPortable.cc
@@ -137,7 +137,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   }
 
   EcalRecHitProducerPortable::EcalRecHitProducerPortable(const edm::ParameterSet& ps, EcalRecHitParametersCache const*)
-      : isPhase2_{ps.getParameter<bool>("isPhase2")},
+      : EDProducer(ps),
+        isPhase2_{ps.getParameter<bool>("isPhase2")},
         uncalibRecHitsTokenEB_{consumes(ps.getParameter<edm::InputTag>("uncalibrecHitsInLabelEB"))},
         uncalibRecHitsTokenEE_{isPhase2_ ? device::EDGetToken<InputProduct>{}
                                          : consumes(ps.getParameter<edm::InputTag>("uncalibrecHitsInLabelEE"))},

--- a/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalUncalibRecHitProducerPortable.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalUncalibRecHitProducerPortable.cc
@@ -138,7 +138,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   EcalUncalibRecHitProducerPortable::EcalUncalibRecHitProducerPortable(const edm::ParameterSet& ps,
                                                                        EcalMultifitParametersCache const*)
-      : digisTokenEB_{consumes(ps.getParameter<edm::InputTag>("digisLabelEB"))},
+      : SynchronizingEDProducer(ps),
+        digisTokenEB_{consumes(ps.getParameter<edm::InputTag>("digisLabelEB"))},
         digisTokenEE_{consumes(ps.getParameter<edm::InputTag>("digisLabelEE"))},
         uncalibRecHitsTokenEB_{produces(ps.getParameter<std::string>("recHitsLabelEB"))},
         uncalibRecHitsTokenEE_{produces(ps.getParameter<std::string>("recHitsLabelEE"))},

--- a/RecoLocalCalo/HGCalRecAlgos/plugins/alpaka/HGCalRecHitProducers.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/plugins/alpaka/HGCalRecHitProducers.cc
@@ -55,7 +55,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   };
 
   HGCalRecHitsProducer::HGCalRecHitsProducer(const edm::ParameterSet& iConfig)
-      : digisToken_{consumes<hgcaldigi::HGCalDigiHost>(iConfig.getParameter<edm::InputTag>("digis"))},
+      : EDProducer(iConfig),
+        digisToken_{consumes<hgcaldigi::HGCalDigiHost>(iConfig.getParameter<edm::InputTag>("digis"))},
         calibToken_{esConsumes(iConfig.getParameter<edm::ESInputTag>("calibSource"))},
         configToken_{esConsumes(iConfig.getParameter<edm::ESInputTag>("configSource"))},
         recHitsToken_{produces()},

--- a/RecoLocalCalo/HGCalRecAlgos/test/alpaka/HGCalRecHitESProducersTest.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/test/alpaka/HGCalRecHitESProducersTest.cc
@@ -44,7 +44,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     device::ESGetToken<hgcalrechit::HGCalCalibParamDevice, HGCalModuleConfigurationRcd> calibParamToken_;
   };
 
-  HGCalRecHitESProducersTest::HGCalRecHitESProducersTest(const edm::ParameterSet& iConfig) {
+  HGCalRecHitESProducersTest::HGCalRecHitESProducersTest(const edm::ParameterSet& iConfig) : EDProducer(iConfig) {
     std::cout << "HGCalRecHitESProducersTest::HGCalRecHitESProducersTest" << std::endl;
     indexerToken_ = esConsumes(iConfig.getParameter<edm::ESInputTag>("indexSource"));
     configToken_ = esConsumes(iConfig.getParameter<edm::ESInputTag>("configSource"));

--- a/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalSoALayerClustersProducer.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalSoALayerClustersProducer.cc
@@ -26,7 +26,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   class HGCalSoALayerClustersProducer : public stream::SynchronizingEDProducer<> {
   public:
     HGCalSoALayerClustersProducer(edm::ParameterSet const& config)
-        : getTokenDeviceRecHits_{consumes(config.getParameter<edm::InputTag>("hgcalRecHitsSoA"))},
+        : SynchronizingEDProducer(config),
+          getTokenDeviceRecHits_{consumes(config.getParameter<edm::InputTag>("hgcalRecHitsSoA"))},
           getTokenDeviceClusters_{consumes(config.getParameter<edm::InputTag>("hgcalRecHitsLayerClustersSoA"))},
           deviceTokenSoAClusters_{produces()},
           thresholdW0_(config.getParameter<double>("thresholdW0")),

--- a/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalSoARecHitsLayerClustersProducer.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalSoARecHitsLayerClustersProducer.cc
@@ -33,7 +33,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   class HGCalSoARecHitsLayerClustersProducer : public stream::EDProducer<> {
   public:
     HGCalSoARecHitsLayerClustersProducer(edm::ParameterSet const& config)
-        : getTokenDevice_{consumes(config.getParameter<edm::InputTag>("hgcalRecHitsSoA"))},
+        : EDProducer(config),
+          getTokenDevice_{consumes(config.getParameter<edm::InputTag>("hgcalRecHitsSoA"))},
           deviceToken_{produces()},
           deltac_((float)config.getParameter<double>("deltac")),
           kappa_((float)config.getParameter<double>("kappa")),

--- a/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalSoARecHitsProducer.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalSoARecHitsProducer.cc
@@ -22,7 +22,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   class HGCalSoARecHitsProducer : public stream::EDProducer<> {
   public:
     HGCalSoARecHitsProducer(edm::ParameterSet const& config)
-        : detector_(config.getParameter<std::string>("detector")),
+        : EDProducer(config),
+          detector_(config.getParameter<std::string>("detector")),
           initialized_(false),
           isNose_(detector_ == "HFNose"),
           maxNumberOfThickIndices_(config.getParameter<unsigned>("maxNumberOfThickIndices")),

--- a/RecoLocalCalo/HcalRecProducers/plugins/alpaka/HBHERecHitProducerPortable.cc
+++ b/RecoLocalCalo/HcalRecProducers/plugins/alpaka/HBHERecHitProducerPortable.cc
@@ -65,7 +65,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   };
 
   HBHERecHitProducerPortable::HBHERecHitProducerPortable(edm::ParameterSet const& ps, HcalMahiPulseOffsetsCache const*)
-      : digisTokenF01HE_{consumes(ps.getParameter<edm::InputTag>("digisLabelF01HE"))},
+      : EDProducer(ps),
+        digisTokenF01HE_{consumes(ps.getParameter<edm::InputTag>("digisLabelF01HE"))},
         digisTokenF5HB_{consumes(ps.getParameter<edm::InputTag>("digisLabelF5HB"))},
         digisTokenF3HB_{consumes(ps.getParameter<edm::InputTag>("digisLabelF3HB"))},
         rechitsM0Token_{produces()},

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelPhase2DigiToCluster.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelPhase2DigiToCluster.cc
@@ -54,7 +54,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   };
 
   SiPixelPhase2DigiToCluster::SiPixelPhase2DigiToCluster(const edm::ParameterSet& iConfig)
-      : geomToken_(esConsumes()),
+      : SynchronizingEDProducer(iConfig),
+        geomToken_(esConsumes()),
         pixelDigiToken_(consumes<edm::DetSetVector<PixelDigi>>(iConfig.getParameter<edm::InputTag>("InputDigis"))),
         digiPutToken_(produces()),
         clusterPutToken_(produces()),

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToCluster.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToCluster.cc
@@ -80,7 +80,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   template <typename TrackerTraits>
   SiPixelRawToCluster<TrackerTraits>::SiPixelRawToCluster(const edm::ParameterSet& iConfig)
-      : rawGetToken_(consumes(iConfig.getParameter<edm::InputTag>("InputLabel"))),
+      : SynchronizingEDProducer(iConfig),
+        rawGetToken_(consumes(iConfig.getParameter<edm::InputTag>("InputLabel"))),
         digiPutToken_(produces()),
         clusterPutToken_(produces()),
         mapToken_(esConsumes()),

--- a/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/SiPixelRecHitAlpaka.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/SiPixelRecHitAlpaka.cc
@@ -56,7 +56,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   template <typename TrackerTraits>
   SiPixelRecHitAlpaka<TrackerTraits>::SiPixelRecHitAlpaka(const edm::ParameterSet& iConfig)
-      : cpeToken_(esConsumes(edm::ESInputTag("", iConfig.getParameter<std::string>("CPE")))),
+      : EDProducer(iConfig),
+        cpeToken_(esConsumes(edm::ESInputTag("", iConfig.getParameter<std::string>("CPE")))),
         tBeamSpot(consumes(iConfig.getParameter<edm::InputTag>("beamSpot"))),
         tokenClusters_(consumes(iConfig.getParameter<edm::InputTag>("src"))),
         tokenDigi_(consumes(iConfig.getParameter<edm::InputTag>("src"))),

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducer.cc
@@ -152,7 +152,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     }
 
     PFClusterSoAProducer(edm::ParameterSet const& config, PFClusterParamsCache const*)
-        : topologyToken_(esConsumes(config.getParameter<edm::ESInputTag>("topology"))),
+        : SynchronizingEDProducer(config),
+          topologyToken_(esConsumes(config.getParameter<edm::ESInputTag>("topology"))),
           inputPFRecHitSoA_Token_{consumes(config.getParameter<edm::InputTag>("pfRecHits"))},
           inputPFRecHitNum_Token_{consumes(config.getParameter<edm::InputTag>("pfRecHits"))},
           outputPFClusterSoA_Token_{produces()},

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/CaloRecHitSoAProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/CaloRecHitSoAProducer.cc
@@ -26,7 +26,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   class CaloRecHitSoAProducer : public global::EDProducer<> {
   public:
     CaloRecHitSoAProducer(edm::ParameterSet const& config)
-        : recHitsToken_(consumes(config.getParameter<edm::InputTag>("src"))),
+        : EDProducer(config),
+          recHitsToken_(consumes(config.getParameter<edm::InputTag>("src"))),
           deviceToken_(produces()),
           synchronise_(config.getUntrackedParameter<bool>("synchronise")) {}
 

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitSoAProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitSoAProducer.cc
@@ -22,7 +22,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   class PFRecHitSoAProducer : public stream::SynchronizingEDProducer<> {
   public:
     PFRecHitSoAProducer(edm::ParameterSet const& config)
-        : topologyToken_(esConsumes(config.getParameter<edm::ESInputTag>("topology"))),
+        : SynchronizingEDProducer(config),
+          topologyToken_(esConsumes(config.getParameter<edm::ESInputTag>("topology"))),
           pfRecHitsToken_(produces()),
           sizeToken_(produces()),
           synchronise_(config.getUntrackedParameter<bool>("synchronise")),

--- a/RecoTracker/LST/plugins/alpaka/LSTProducer.cc
+++ b/RecoTracker/LST/plugins/alpaka/LSTProducer.cc
@@ -26,7 +26,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   class LSTProducer : public stream::SynchronizingEDProducer<> {
   public:
     LSTProducer(edm::ParameterSet const& config)
-        : lstPixelSeedInputToken_{consumes(config.getParameter<edm::InputTag>("pixelSeedInput"))},
+        : SynchronizingEDProducer(config),
+          lstPixelSeedInputToken_{consumes(config.getParameter<edm::InputTag>("pixelSeedInput"))},
           lstPhase2OTHitsInputToken_{consumes(config.getParameter<edm::InputTag>("phase2OTHitsInput"))},
           lstESToken_{esConsumes(edm::ESInputTag("", config.getParameter<std::string>("ptCutLabel")))},
           verbose_(config.getParameter<bool>("verbose")),

--- a/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtuplet.cc
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtuplet.cc
@@ -54,7 +54,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   template <typename TrackerTraits>
   CAHitNtupletAlpaka<TrackerTraits>::CAHitNtupletAlpaka(const edm::ParameterSet& iConfig)
-      : tokenField_(esConsumes()),
+      : EDProducer(iConfig),
+        tokenField_(esConsumes()),
         cpeToken_(esConsumes(edm::ESInputTag("", iConfig.getParameter<std::string>("CPE")))),
         tokenHit_(consumes(iConfig.getParameter<edm::InputTag>("pixelRecHitSrc"))),
         tokenTrack_(produces()),

--- a/RecoVertex/BeamSpotProducer/plugins/alpaka/BeamSpotDeviceProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/alpaka/BeamSpotDeviceProducer.cc
@@ -15,7 +15,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   class BeamSpotDeviceProducer : public global::EDProducer<> {
   public:
     BeamSpotDeviceProducer(edm::ParameterSet const& config)
-        : legacyToken_{consumes(config.getParameter<edm::InputTag>("src"))}, deviceToken_{produces()} {}
+        : EDProducer(config),
+          legacyToken_{consumes(config.getParameter<edm::InputTag>("src"))},
+          deviceToken_{produces()} {}
 
     void produce(edm::StreamID, device::Event& event, device::EventSetup const& setup) const override {
       reco::BeamSpot const& beamspot = event.get(legacyToken_);

--- a/RecoVertex/PixelVertexFinding/plugins/alpaka/PixelVertexProducerAlpaka.cc
+++ b/RecoVertex/PixelVertexFinding/plugins/alpaka/PixelVertexProducerAlpaka.cc
@@ -55,7 +55,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   template <typename TrackerTraits>
   PixelVertexProducerAlpaka<TrackerTraits>::PixelVertexProducerAlpaka(const edm::ParameterSet& conf)
-      : algo_(conf.getParameter<bool>("oneKernel"),
+      : EDProducer(conf),
+        algo_(conf.getParameter<bool>("oneKernel"),
               conf.getParameter<bool>("useDensity"),
               conf.getParameter<bool>("useDBSCAN"),
               conf.getParameter<bool>("useIterative"),


### PR DESCRIPTION
#### PR description:

This PR is a follow-up to https://github.com/cms-sw/cmssw/pull/47028 and migrates all present Alpaka EDProducers to pass the `edm::ParameterSet` to their base class constructor.

Resolves https://github.com/cms-sw/framework-team/issues/1189

#### PR validation:

Code compiles