### PR TITLE
add `fillDescriptions` to several plugins used at HLT (5/N)

### DIFF
--- a/Alignment/CommonAlignmentProducer/interface/AlignmentCSCBeamHaloSelector.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentCSCBeamHaloSelector.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "DataFormats/TrackReco/interface/Track.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
 namespace edm {
   class Event;
@@ -24,6 +25,8 @@ public:
 
   /// select tracks
   Tracks select(const Tracks &tracks, const edm::Event &iEvent) const;
+
+  static void fillPSetDescription(edm::ParameterSetDescription &desc);
 
 private:
   unsigned int m_minStations;

--- a/Alignment/CommonAlignmentProducer/interface/AlignmentCSCOverlapSelector.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentCSCOverlapSelector.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include "DataFormats/TrackReco/interface/Track.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
 namespace edm {
   class Event;
@@ -23,6 +24,8 @@ public:
 
   /// select tracks
   Tracks select(const Tracks &tracks, const edm::Event &iEvent) const;
+
+  static void fillPSetDescription(edm::ParameterSetDescription &desc);
 
 private:
   int m_station;

--- a/Alignment/CommonAlignmentProducer/interface/AlignmentCSCTrackSelector.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentCSCTrackSelector.h
@@ -3,6 +3,7 @@
 
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include <vector>
 
 namespace edm {
@@ -24,6 +25,8 @@ public:
 
   /// select tracks
   Tracks select(const Tracks& tracks, const edm::Event& evt) const;
+
+  static void fillPSetDescription(edm::ParameterSetDescription& desc);
 
 private:
   edm::InputTag m_src;

--- a/Alignment/CommonAlignmentProducer/interface/AlignmentGlobalTrackSelector.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentGlobalTrackSelector.h
@@ -7,6 +7,7 @@
 //Framework
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 //STL
 #include <vector>
@@ -33,6 +34,8 @@ public:
   Tracks select(const Tracks& tracks, const edm::Event& iEvent, const edm::EventSetup& eSetup);
   ///returns if any of the Filters is used.
   bool useThisFilter();
+
+  static void fillPSetDescription(edm::ParameterSetDescription& desc);
 
 private:
   ///returns [tracks] if there are less than theMaxCount Jets with theMinJetPt and an empty set if not

--- a/Alignment/CommonAlignmentProducer/interface/AlignmentMuonSelector.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentMuonSelector.h
@@ -17,6 +17,7 @@
 
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "CommonTools/RecoAlgos/interface/MuonSelector.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include <vector>
 
 namespace edm {
@@ -35,6 +36,8 @@ public:
 
   /// select muons
   Muons select(const Muons& muons, const edm::Event& evt) const;
+
+  static void fillPSetDescription(edm::ParameterSetDescription& desc);
 
 private:
   /// apply basic cuts on pt,eta,phi,nhit

--- a/Alignment/CommonAlignmentProducer/interface/AlignmentSeedSelector.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentSeedSelector.h
@@ -3,6 +3,7 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeed.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include <vector>
 
 namespace edm {
@@ -21,6 +22,8 @@ public:
 
   /// select tracks
   Seeds select(const Seeds& seeds, const edm::Event& evt) const;
+
+  static void fillPSetDescription(edm::ParameterSetDescription& desc);
 
 private:
   /// private data members

--- a/Alignment/CommonAlignmentProducer/interface/AlignmentTrackSelector.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentTrackSelector.h
@@ -9,6 +9,7 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include <vector>
 
@@ -36,6 +37,8 @@ public:
   Tracks select(const Tracks& tracks, const edm::Event& evt, const edm::EventSetup& eSetup) const;
   ///returns if any of the Filters is used.
   bool useThisFilter();
+
+  static void fillPSetDescription(edm::ParameterSetDescription& desc);
 
 private:
   /// apply basic cuts on pt,eta,phi,nhit

--- a/Alignment/CommonAlignmentProducer/interface/AlignmentTwoBodyDecayTrackSelector.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentTwoBodyDecayTrackSelector.h
@@ -5,6 +5,7 @@
 //Framework
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 //STL
 #include <vector>
@@ -31,6 +32,8 @@ public:
   Tracks select(const Tracks& tracks, const edm::Event& iEvent, const edm::EventSetup& iSetup);
 
   bool useThisFilter();
+
+  static void fillPSetDescription(edm::ParameterSetDescription& desc);
 
 private:
   ///checks if the mass of the mother is in the mass region

--- a/Alignment/CommonAlignmentProducer/plugins/AlignmentCSCBeamHaloSelectorModule.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/AlignmentCSCBeamHaloSelectorModule.cc
@@ -1,8 +1,8 @@
-
+#include "Alignment/CommonAlignmentProducer/interface/AlignmentCSCBeamHaloSelector.h"
+#include "CommonTools/UtilAlgos/interface/ObjectSelector.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "CommonTools/UtilAlgos/interface/ObjectSelector.h"
-#include "Alignment/CommonAlignmentProducer/interface/AlignmentCSCBeamHaloSelector.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
 // the following include is necessary to clone all track branches
 // including recoTrackExtras and TrackingRecHitsOwned.
@@ -30,6 +30,10 @@ struct CSCBeamHaloConfigSelector {
       all_.push_back(&*i);
     }
     selected_ = theSelector.select(all_, evt);  // might add dummy...
+  }
+
+  static void fillPSetDescription(edm::ParameterSetDescription &desc) {
+    AlignmentCSCBeamHaloSelector::fillPSetDescription(desc);
   }
 
 private:

--- a/Alignment/CommonAlignmentProducer/plugins/AlignmentCSCOverlapSelectorModule.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/AlignmentCSCOverlapSelectorModule.cc
@@ -1,8 +1,8 @@
-
+#include "Alignment/CommonAlignmentProducer/interface/AlignmentCSCOverlapSelector.h"
+#include "CommonTools/UtilAlgos/interface/ObjectSelector.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "CommonTools/UtilAlgos/interface/ObjectSelector.h"
-#include "Alignment/CommonAlignmentProducer/interface/AlignmentCSCOverlapSelector.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
 // the following include is necessary to clone all track branches
 // including recoTrackExtras and TrackingRecHitsOwned.
@@ -28,6 +28,10 @@ struct CSCOverlapConfigSelector {
       all_.push_back(&*i);
     }
     selected_ = theSelector.select(all_, evt);  // might add dummy...
+  }
+
+  static void fillPSetDescription(edm::ParameterSetDescription &desc) {
+    AlignmentCSCOverlapSelector::fillPSetDescription(desc);
   }
 
 private:

--- a/Alignment/CommonAlignmentProducer/plugins/AlignmentCSCTrackSelectorModule.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/AlignmentCSCTrackSelectorModule.cc
@@ -1,6 +1,7 @@
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "CommonTools/UtilAlgos/interface/ObjectSelector.h"
 
 //the selectores used to select the tracks
@@ -31,6 +32,10 @@ struct CSCTrackConfigSelector {
       all.push_back(&*i);
     }
     theSelectedTracks = theBaseSelector.select(all, evt);  // might add dummy
+  }
+
+  static void fillPSetDescription(edm::ParameterSetDescription &desc) {
+    AlignmentCSCTrackSelector::fillPSetDescription(desc);
   }
 
 private:

--- a/Alignment/CommonAlignmentProducer/plugins/AlignmentMuonSelectorModule.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/AlignmentMuonSelectorModule.cc
@@ -14,6 +14,7 @@
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "CommonTools/UtilAlgos/interface/ObjectSelector.h"
 #include "Alignment/CommonAlignmentProducer/interface/AlignmentMuonSelector.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
@@ -41,6 +42,10 @@ struct MuonConfigSelector {
       all_.push_back(&*i);
     }
     selected_ = theSelector.select(all_, evt);  // might add dummy
+  }
+
+  static void fillPSetDescription(edm::ParameterSetDescription &desc) {
+    AlignmentMuonSelector::fillPSetDescription(desc);
   }
 
 private:

--- a/Alignment/CommonAlignmentProducer/plugins/AlignmentSeedSelectorModule.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/AlignmentSeedSelectorModule.cc
@@ -1,7 +1,7 @@
-
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "CommonTools/UtilAlgos/interface/ObjectSelector.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "Alignment/CommonAlignmentProducer/interface/AlignmentSeedSelector.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 
@@ -23,6 +23,10 @@ struct SeedConfigSelector {
       all_.push_back(&*i);
     }
     selected_ = theSelector.select(all_, evt);  // might add dummy...
+  }
+
+  static void fillPSetDescription(edm::ParameterSetDescription &desc) {
+    AlignmentSeedSelector::fillPSetDescription(desc);
   }
 
 private:

--- a/Alignment/CommonAlignmentProducer/plugins/AlignmentTrackSelectorModule.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/AlignmentTrackSelectorModule.cc
@@ -1,6 +1,6 @@
-
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "CommonTools/UtilAlgos/interface/ObjectSelector.h"
 
 //the selectores used to select the tracks
@@ -49,6 +49,18 @@ struct TrackConfigSelector {
       theSelectedTracks = theGlobalSelector.select(theSelectedTracks, evt, eSetup);
     if (theTwoBodyDecaySwitch)
       theSelectedTracks = theTwoBodyDecaySelector.select(theSelectedTracks, evt, eSetup);
+  }
+
+  static void fillPSetDescription(edm::ParameterSetDescription& desc) {
+    AlignmentTrackSelector::fillPSetDescription(desc);
+
+    edm::ParameterSetDescription globalSelectorDesc;
+    AlignmentGlobalTrackSelector::fillPSetDescription(globalSelectorDesc);
+    desc.add<edm::ParameterSetDescription>("GlobalSelector", globalSelectorDesc);
+
+    edm::ParameterSetDescription twoBodySelectorDesc;
+    AlignmentTwoBodyDecayTrackSelector::fillPSetDescription(twoBodySelectorDesc);
+    desc.add<edm::ParameterSetDescription>("TwoBodyDecaySelector", twoBodySelectorDesc);
   }
 
 private:

--- a/Alignment/CommonAlignmentProducer/src/AlignmentCSCBeamHaloSelector.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentCSCBeamHaloSelector.cc
@@ -19,6 +19,11 @@ AlignmentCSCBeamHaloSelector::AlignmentCSCBeamHaloSelector(const edm::ParameterS
       << " different CSC stations." << std::endl;
 }
 
+void AlignmentCSCBeamHaloSelector::fillPSetDescription(edm::ParameterSetDescription &desc) {
+  desc.add<unsigned int>("minStations", 0);
+  desc.add<unsigned int>("minHitsPerStation", 1);
+}
+
 // destructor -----------------------------------------------------------------
 
 AlignmentCSCBeamHaloSelector::~AlignmentCSCBeamHaloSelector() {}

--- a/Alignment/CommonAlignmentProducer/src/AlignmentCSCOverlapSelector.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentCSCOverlapSelector.cc
@@ -23,6 +23,11 @@ AlignmentCSCOverlapSelector::AlignmentCSCOverlapSelector(const edm::ParameterSet
   }
 }
 
+void AlignmentCSCOverlapSelector::fillPSetDescription(edm::ParameterSetDescription &desc) {
+  desc.add<int>("station", 1);
+  desc.add<unsigned int>("minHitsPerChamber", 0);
+}
+
 // destructor -----------------------------------------------------------------
 
 AlignmentCSCOverlapSelector::~AlignmentCSCOverlapSelector() {}

--- a/Alignment/CommonAlignmentProducer/src/AlignmentCSCTrackSelector.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentCSCTrackSelector.cc
@@ -20,6 +20,14 @@ AlignmentCSCTrackSelector::AlignmentCSCTrackSelector(const edm::ParameterSet& cf
       m_minHitsPerStation(cfg.getParameter<int>("minHitsPerStation")),
       m_maxHitsPerStation(cfg.getParameter<int>("maxHitsPerStation")) {}
 
+void AlignmentCSCTrackSelector::fillPSetDescription(edm::ParameterSetDescription& desc) {
+  desc.add<int>("stationA", 0);
+  desc.add<int>("stationB", 0);
+  desc.add<int>("minHitsDT", 0);
+  desc.add<int>("minHitsPerStation", 0);
+  desc.add<int>("maxHitsPerStation", 0);
+}
+
 // destructor -----------------------------------------------------------------
 
 AlignmentCSCTrackSelector::~AlignmentCSCTrackSelector() {}

--- a/Alignment/CommonAlignmentProducer/src/AlignmentGlobalTrackSelector.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentGlobalTrackSelector.cc
@@ -61,6 +61,27 @@ AlignmentGlobalTrackSelector::AlignmentGlobalTrackSelector(const edm::ParameterS
   }
 }
 
+void AlignmentGlobalTrackSelector::fillPSetDescription(edm::ParameterSetDescription& desc) {
+  // Global muon finding
+  desc.add<bool>("applyGlobalMuonFilter", false);
+  desc.add<edm::InputTag>("muonSource", edm::InputTag("muons"));
+  desc.add<double>("maxTrackDeltaR", 0.001);
+  desc.add<int>("minGlobalMuonCount", 1);
+
+  // Isolation tests
+  desc.add<bool>("applyIsolationtest", false);
+  desc.add<edm::InputTag>("jetIsoSource", edm::InputTag("kt6CaloJets"));
+  desc.add<double>("maxJetPt", 40.0);  // GeV
+  desc.add<double>("minJetDeltaR", 0.2);
+  desc.add<int>("minIsolatedCount", 0);
+
+  // Jet count filter
+  desc.add<bool>("applyJetCountFilter", false);
+  desc.add<edm::InputTag>("jetCountSource", edm::InputTag("kt6CaloJets"));
+  desc.add<double>("minJetPt", 40.0);  // GeV
+  desc.add<int>("maxJetCount", 3);
+}
+
 // destructor -----------------------------------------------------------------
 AlignmentGlobalTrackSelector::~AlignmentGlobalTrackSelector() {}
 

--- a/Alignment/CommonAlignmentProducer/src/AlignmentMuonSelector.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentMuonSelector.cc
@@ -53,6 +53,38 @@ AlignmentMuonSelector::AlignmentMuonSelector(const edm::ParameterSet& cfg)
         << "apply Mass Pair filter minMassPair=" << minMassPair << " maxMassPair=" << maxMassPair;
 }
 
+void AlignmentMuonSelector::fillPSetDescription(edm::ParameterSetDescription& desc) {
+  desc.add<bool>("applyBasicCuts", true);
+  desc.add<bool>("applyNHighestPt", false);
+  desc.add<bool>("applyMultiplicityFilter", false);
+  desc.add<bool>("applyMassPairFilter", false);
+  desc.add<int>("nHighestPt", 2);
+  desc.add<int>("minMultiplicity", 1);
+  desc.add<double>("pMin", 0.0);
+  desc.add<double>("pMax", 999999.0);
+  desc.add<double>("ptMin", 10.);
+  desc.add<double>("ptMax", 999999.0);
+  desc.add<double>("etaMin", -2.4);
+  desc.add<double>("etaMax", 2.4);
+  desc.add<double>("phiMin", -3.1416);
+  desc.add<double>("phiMax", 3.1416);
+  desc.add<double>("nHitMinSA", 0.0);
+  desc.add<double>("nHitMaxSA", 999999.0);
+  desc.add<double>("chi2nMaxSA", 999999.0);
+  desc.add<double>("nHitMinGB", 0.0);
+  desc.add<double>("nHitMaxGB", 999999.0);
+  desc.add<double>("chi2nMaxGB", 999999.0);
+  desc.add<double>("nHitMinTO", 0.0);
+  desc.add<double>("nHitMaxTO", 999999.0);
+  desc.add<double>("chi2nMaxTO", 999999.0);
+  desc.add<double>("minMassPair", 89.0)
+      ->setComment(
+          "copy best mass pair combination muons to result vector \n Criteria: \n a) maxMassPair != minMassPair: the "
+          "two highest pt muons with mass pair inside the given mass window \n b) maxMassPair == minMassPair: the muon "
+          "pair with mass pair closest to given mass value");
+  desc.add<double>("maxMassPair", 90.0);
+}
+
 // destructor -----------------------------------------------------------------
 
 AlignmentMuonSelector::~AlignmentMuonSelector() {}

--- a/Alignment/CommonAlignmentProducer/src/AlignmentSeedSelector.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentSeedSelector.cc
@@ -12,6 +12,12 @@ AlignmentSeedSelector::AlignmentSeedSelector(const edm::ParameterSet& cfg)
     edm::LogInfo("AlignmentSeedSelector") << "apply seedNumber N<=" << minNSeeds;
 }
 
+void AlignmentSeedSelector::fillPSetDescription(edm::ParameterSetDescription& desc) {
+  desc.add<bool>("applySeedNumber", false);
+  desc.add<int>("minNSeeds", 0);
+  desc.add<int>("maxNSeeds", 999999.);
+}
+
 // destructor -----------------------------------------------------------------
 
 AlignmentSeedSelector::~AlignmentSeedSelector() {}

--- a/Alignment/CommonAlignmentProducer/src/AlignmentTrackSelector.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentTrackSelector.cc
@@ -78,10 +78,10 @@ AlignmentTrackSelector::AlignmentTrackSelector(const edm::ParameterSet& cfg, edm
       minHitsinENDCAPminus_(cfg.getParameter<edm::ParameterSet>("minHitsPerSubDet").getParameter<int>("inENDCAPminus")),
       maxHitDiffEndcaps_(cfg.getParameter<double>("maxHitDiffEndcaps")),
       nLostHitMax_(cfg.getParameter<double>("nLostHitMax")),
-      RorZofFirstHitMin_(cfg.getParameter<std::vector<double> >("RorZofFirstHitMin")),
-      RorZofFirstHitMax_(cfg.getParameter<std::vector<double> >("RorZofFirstHitMax")),
-      RorZofLastHitMin_(cfg.getParameter<std::vector<double> >("RorZofLastHitMin")),
-      RorZofLastHitMax_(cfg.getParameter<std::vector<double> >("RorZofLastHitMax")),
+      RorZofFirstHitMin_(cfg.getParameter<std::vector<double>>("RorZofFirstHitMin")),
+      RorZofFirstHitMax_(cfg.getParameter<std::vector<double>>("RorZofFirstHitMax")),
+      RorZofLastHitMin_(cfg.getParameter<std::vector<double>>("RorZofLastHitMin")),
+      RorZofLastHitMax_(cfg.getParameter<std::vector<double>>("RorZofLastHitMax")),
       clusterValueMapTag_(cfg.getParameter<edm::InputTag>("hitPrescaleMapTag")),
       minPrescaledHits_(cfg.getParameter<int>("minPrescaledHits")),
       applyPrescaledHitsFilter_(!clusterValueMapTag_.encode().empty() && minPrescaledHits_ > 0) {
@@ -96,7 +96,7 @@ AlignmentTrackSelector::AlignmentTrackSelector(const edm::ParameterSet& cfg, edm
   }
 
   //convert track quality from string to enum
-  std::vector<std::string> trkQualityStrings(cfg.getParameter<std::vector<std::string> >("trackQualities"));
+  std::vector<std::string> trkQualityStrings(cfg.getParameter<std::vector<std::string>>("trackQualities"));
   std::string qualities;
   if (!trkQualityStrings.empty()) {
     applyTrkQualityCheck_ = true;
@@ -107,7 +107,7 @@ AlignmentTrackSelector::AlignmentTrackSelector(const edm::ParameterSet& cfg, edm
   } else
     applyTrkQualityCheck_ = false;
 
-  std::vector<std::string> trkIterStrings(cfg.getParameter<std::vector<std::string> >("iterativeTrackingSteps"));
+  std::vector<std::string> trkIterStrings(cfg.getParameter<std::vector<std::string>>("iterativeTrackingSteps"));
   if (!trkIterStrings.empty()) {
     applyIterStepCheck_ = true;
     std::string tracksteps;
@@ -216,6 +216,83 @@ AlignmentTrackSelector::AlignmentTrackSelector(const edm::ParameterSet& cfg, edm
                                       << RorZofFirstHitMin_.at(1) << "]; Last hit(max): [" << RorZofLastHitMax_.at(0)
                                       << ", " << RorZofLastHitMax_.at(1) << "];";
   }
+}
+
+void AlignmentTrackSelector::fillPSetDescription(edm::ParameterSetDescription& desc) {
+  // Base TrackSelector settings
+  desc.add<bool>("applyBasicCuts", true);
+  desc.add<double>("ptMin", 0.0);
+  desc.add<double>("ptMax", 999.0);
+  desc.add<double>("pMin", 0.0);
+  desc.add<double>("pMax", 9999.0);
+  desc.add<double>("etaMin", -2.6);
+  desc.add<double>("etaMax", 2.6);
+  desc.add<double>("phiMax", 3.1416);
+  desc.add<double>("phiMin", -3.1416);
+  desc.add<double>("chi2nMax", 999999.0);
+  desc.add<int>("theCharge", 0);  // -1: neg charge, +1: pos charge, 0: all charges
+  desc.add<double>("d0Min", -999999.0);
+  desc.add<double>("d0Max", 999999.0);
+  desc.add<double>("dzMin", -999999.0);
+  desc.add<double>("dzMax", 999999.0);
+  desc.add<double>("nHitMin", 0.0);
+  desc.add<double>("nHitMax", 999.0);
+  desc.add<double>("nLostHitMax", 999.0);
+  desc.add<unsigned int>("nHitMin2D", 0);
+  desc.add<std::vector<double>>("RorZofFirstHitMin", {0.0, 0.0});
+  desc.add<std::vector<double>>("RorZofFirstHitMax", {999.0, 999.0});
+  desc.add<std::vector<double>>("RorZofLastHitMin", {0.0, 0.0});
+  desc.add<std::vector<double>>("RorZofLastHitMax", {999.0, 999.0});
+  desc.add<bool>("countStereoHitAs2D", true);
+
+  // Nested PSet for minHitsPerSubDet
+  edm::ParameterSetDescription minHitsPerSubDetDesc;
+  minHitsPerSubDetDesc.add<int>("inTEC", 0);
+  minHitsPerSubDetDesc.add<int>("inTOB", 0);
+  minHitsPerSubDetDesc.add<int>("inFPIX", 0);
+  minHitsPerSubDetDesc.add<int>("inTID", 0);
+  minHitsPerSubDetDesc.add<int>("inBPIX", 0);
+  minHitsPerSubDetDesc.add<int>("inTIB", 0);
+  minHitsPerSubDetDesc.add<int>("inPIXEL", 0);
+  minHitsPerSubDetDesc.add<int>("inTIDplus", 0);
+  minHitsPerSubDetDesc.add<int>("inTIDminus", 0);
+  minHitsPerSubDetDesc.add<int>("inTECplus", 0);
+  minHitsPerSubDetDesc.add<int>("inTECminus", 0);
+  minHitsPerSubDetDesc.add<int>("inFPIXplus", 0);
+  minHitsPerSubDetDesc.add<int>("inFPIXminus", 0);
+  minHitsPerSubDetDesc.add<int>("inENDCAP", 0);
+  minHitsPerSubDetDesc.add<int>("inENDCAPplus", 0);
+  minHitsPerSubDetDesc.add<int>("inENDCAPminus", 0);
+  desc.add<edm::ParameterSetDescription>("minHitsPerSubDet", minHitsPerSubDetDesc);
+
+  desc.add<double>("maxHitDiffEndcaps", 999.0);
+  desc.add<int>("seedOnlyFrom", 0);
+
+  // Multiplicity filtering
+  desc.add<bool>("applyMultiplicityFilter", false);
+  desc.add<int>("minMultiplicity", 1);
+  desc.add<int>("maxMultiplicity", 999999);
+  desc.add<bool>("multiplicityOnInput", false);
+
+  // NHighestPt settings
+  desc.add<bool>("applyNHighestPt", false);
+  desc.add<int>("nHighestPt", 2);
+
+  // Hit-related parameters
+  desc.add<edm::InputTag>("rphirecHits", edm::InputTag("siStripMatchedRecHits", "rphiRecHit"));
+  desc.add<edm::InputTag>("matchedrecHits", edm::InputTag("siStripMatchedRecHits", "matchedRecHit"));
+  desc.add<bool>("applyIsolationCut", false);
+  desc.add<double>("minHitIsolation", 0.01);
+  desc.add<bool>("applyChargeCheck", false);
+  desc.add<double>("minHitChargeStrip", 20.0);
+
+  // String-based settings
+  desc.add<std::vector<std::string>>("trackQualities", {});          // Take all if empty
+  desc.add<std::vector<std::string>>("iterativeTrackingSteps", {});  // Take all if empty
+
+  // Filtering on hits for Skim&Prescale workflow
+  desc.add<edm::InputTag>("hitPrescaleMapTag", edm::InputTag(""));  // Ignore prescale map if empty
+  desc.add<int>("minPrescaledHits", -1);
 }
 
 // destructor -----------------------------------------------------------------

--- a/Alignment/CommonAlignmentProducer/src/AlignmentTwoBoyDecayTrackSelector.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentTwoBoyDecayTrackSelector.cc
@@ -64,6 +64,34 @@ AlignmentTwoBodyDecayTrackSelector::AlignmentTwoBodyDecayTrackSelector(const edm
   }
 }
 
+void AlignmentTwoBodyDecayTrackSelector::fillPSetDescription(edm::ParameterSetDescription& desc) {
+  // Mass range filter
+  desc.add<bool>("applyMassrangeFilter", false);
+  desc.add<double>("daughterMass", 0.105);  // GeV
+
+  // Charge-related parameters
+  desc.add<bool>("useUnsignedCharge", true);
+  desc.add<int>("charge", 0);
+
+  // Missing ET source
+  desc.add<edm::InputTag>("missingETSource", edm::InputTag("met"));
+  desc.add<double>("maxXMass", 15000.0);  // GeV
+  desc.add<double>("minXMass", 0.0);      // GeV
+
+  // Acoplanarity settings
+  desc.add<double>("acoplanarDistance", 1.0);  // Radian
+
+  // Filters
+  desc.add<bool>("applyChargeFilter", false);
+  desc.add<bool>("applyAcoplanarityFilter", false);
+  desc.add<bool>("applyMissingETFilter", false);
+
+  // Candidate selection
+  desc.add<unsigned int>("numberOfCandidates", 1);
+  desc.add<bool>("applySecThreshold", false);
+  desc.add<double>("secondThreshold", 6.0);
+}
+
 // destructor -----------------------------------------------------------------
 
 AlignmentTwoBodyDecayTrackSelector::~AlignmentTwoBodyDecayTrackSelector() {}

--- a/Calibration/TkAlCaRecoProducers/interface/CalibrationTrackSelector.h
+++ b/Calibration/TkAlCaRecoProducers/interface/CalibrationTrackSelector.h
@@ -1,12 +1,14 @@
 #ifndef Calibration_TkAlCaRecoProducers_CalibrationTrackSelector_h
 #define Calibration_TkAlCaRecoProducers_CalibrationTrackSelector_h
 
+#include <vector>
+
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2DCollection.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2DCollection.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/Utilities/interface/InputTag.h"
-#include <vector>
 
 namespace edm {
   class Event;
@@ -27,6 +29,8 @@ public:
 
   /// select tracks
   Tracks select(const Tracks &tracks, const edm::Event &evt) const;
+
+  static void fillPSetDescription(edm::ParameterSetDescription &desc);
 
 private:
   /// apply basic cuts on pt,eta,phi,nhit

--- a/Calibration/TkAlCaRecoProducers/plugins/CalibrationTrackSelectorModule.cc
+++ b/Calibration/TkAlCaRecoProducers/plugins/CalibrationTrackSelectorModule.cc
@@ -1,7 +1,7 @@
-
 #include "CommonTools/UtilAlgos/interface/ObjectSelector.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
 // the selectores used to select the tracks
 #include "Calibration/TkAlCaRecoProducers/interface/CalibrationTrackSelector.h"
@@ -35,6 +35,10 @@ struct SiStripCalTrackConfigSelector {
     // might add EvetSetup to the select(...) method of the Selectors
     if (theBaseSwitch)
       theSelectedTracks = theBaseSelector.select(theSelectedTracks, evt);
+  }
+
+  static void fillPSetDescription(edm::ParameterSetDescription &desc) {
+    CalibrationTrackSelector::fillPSetDescription(desc);
   }
 
 private:

--- a/Calibration/TkAlCaRecoProducers/src/CalibrationTrackSelector.cc
+++ b/Calibration/TkAlCaRecoProducers/src/CalibrationTrackSelector.cc
@@ -83,6 +83,49 @@ CalibrationTrackSelector::CalibrationTrackSelector(const edm::ParameterSet &cfg,
       << minHitsinTOB_ << "/" << minHitsinTEC_ << "/" << minHitsinBPIX_ << "/" << minHitsinFPIX_;
 }
 
+// fillDescriptions ----------------------------------------------------------
+
+void CalibrationTrackSelector::fillPSetDescription(edm::ParameterSetDescription &desc) {
+  desc.add<double>("minHitChargeStrip", 20.0);
+  desc.add<edm::InputTag>("rphirecHits", edm::InputTag("siStripMatchedRecHits", "rphiRecHit"));
+  desc.add<bool>("applyMultiplicityFilter", false);
+  desc.add<edm::InputTag>("matchedrecHits", edm::InputTag("siStripMatchedRecHits", "matchedRecHit"));
+  desc.add<double>("etaMin", -2.6);
+  desc.add<double>("etaMax", 2.6);
+  desc.add<double>("minHitIsolation", 0.01);
+  desc.add<double>("phiMax", 3.1416);
+  desc.add<double>("phiMin", -3.1416);
+  desc.add<double>("ptMin", 10.0);
+  desc.add<int>("minMultiplicity", 1);
+  desc.add<double>("nHitMin", 0.0);
+  desc.add<double>("ptMax", 999.0);
+  desc.add<double>("nHitMax", 999.0);
+  desc.add<bool>("applyNHighestPt", false);
+  desc.add<bool>("applyChargeCheck", false);
+
+  // Nested PSet for minHitsPerSubDet
+  edm::ParameterSetDescription minHitsPerSubDetDesc;
+  minHitsPerSubDetDesc.add<int>("inTEC", 0);
+  minHitsPerSubDetDesc.add<int>("inTOB", 0);
+  minHitsPerSubDetDesc.add<int>("inFPIX", 0);
+  minHitsPerSubDetDesc.add<int>("inTID", 0);
+  minHitsPerSubDetDesc.add<int>("inBPIX", 0);
+  minHitsPerSubDetDesc.add<int>("inTIB", 0);
+  desc.add<edm::ParameterSetDescription>("minHitsPerSubDet", minHitsPerSubDetDesc);
+
+  desc.add<int>("nHighestPt", 2);
+  desc.add<unsigned int>("nHitMin2D", 0);
+
+  desc.add<bool>("applyIsolationCut", false);
+  desc.add<bool>("multiplicityOnInput", false);
+  desc.add<int>("maxMultiplicity", 999999);
+  desc.add<int>("seedOnlyFrom", 0);
+  desc.add<double>("chi2nMax", 999999.0);
+
+  // Settings for base TrackSelector
+  desc.add<bool>("applyBasicCuts", true);
+}
+
 // destructor -----------------------------------------------------------------
 
 CalibrationTrackSelector::~CalibrationTrackSelector() {}

--- a/Calibration/Tools/interface/IMASelector.h
+++ b/Calibration/Tools/interface/IMASelector.h
@@ -2,6 +2,8 @@
 #define UtilAlgos_IMASelector_h
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "CommonTools/UtilAlgos/interface/ParameterAdapter.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+
 #include <iostream>
 
 struct IMASelector {
@@ -55,6 +57,17 @@ namespace reco {
                            cfg.getParameter<double>("PinMPoutOPinMax"),
                            cfg.getParameter<double>("EMPoutMin"),
                            cfg.getParameter<double>("EMPoutMax"));
+      }
+
+      static void fillPSetDescription(edm::ParameterSetDescription& desc) {
+        desc.add<double>("ESCOPinMin", 0.0);
+        desc.add<double>("ESeedOPoutMin", 0.0);
+        desc.add<double>("PinMPoutOPinMin", 0.0);
+        desc.add<double>("ESCOPinMax", 0.0);
+        desc.add<double>("ESeedOPoutMax", 0.0);
+        desc.add<double>("PinMPoutOPinMax", 0.0);
+        desc.add<double>("EMPoutMin", 0.0);
+        desc.add<double>("EMPoutMax", 0.0);
       }
     };
   }  // namespace modules

--- a/Calibration/Tools/interface/PhiRangeSelector.h
+++ b/Calibration/Tools/interface/PhiRangeSelector.h
@@ -2,6 +2,7 @@
 #define UtilAlgos_PhiRangeSelector_h
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "CommonTools/UtilAlgos/interface/ParameterAdapter.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
 struct PhiRangeSelector {
   PhiRangeSelector(double phiMin, double phiMax) : phiMin_(phiMin), phiMax_(phiMax) {}
@@ -21,6 +22,11 @@ namespace reco {
     struct ParameterAdapter<PhiRangeSelector> {
       static PhiRangeSelector make(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC) {
         return PhiRangeSelector(cfg.getParameter<double>("phiMin"), cfg.getParameter<double>("phiMax"));
+      }
+
+      static void fillPSetDescription(edm::ParameterSetDescription& desc) {
+        desc.add<double>("phiMin", -3.2);
+        desc.add<double>("phiMax", 3.2);
       }
     };
   }  // namespace modules

--- a/CommonTools/CandAlgos/interface/GenJetParticleSelector.h
+++ b/CommonTools/CandAlgos/interface/GenJetParticleSelector.h
@@ -10,6 +10,7 @@
 #include "SimGeneral/HepPDTRecord/interface/PdtEntry.h"
 #include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include <set>
 
 namespace edm {
@@ -28,6 +29,8 @@ public:
   bool operator()(const reco::Candidate&);
   void init(const edm::EventSetup&);
 
+  static void fillPSetDescription(edm::ParameterSetDescription& desc);
+
 private:
   typedef std::vector<PdtEntry> vpdt;
   bool stableOnly_;
@@ -45,6 +48,10 @@ namespace reco {
     struct GenJetParticleSelectorEventSetupInit {
       static void init(GenJetParticleSelector& selector, const edm::Event& evt, const edm::EventSetup& es) {
         selector.init(es);
+      }
+
+      static void fillPSetDescription(edm::ParameterSetDescription& desc) {
+        GenJetParticleSelector::fillPSetDescription(desc);
       }
     };
 

--- a/CommonTools/CandAlgos/interface/GenParticleCustomSelector.h
+++ b/CommonTools/CandAlgos/interface/GenParticleCustomSelector.h
@@ -7,6 +7,7 @@
  */
 
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 class GenParticleCustomSelector {
 public:
@@ -123,6 +124,20 @@ namespace reco {
                                          cfg.getParameter<bool>("invertRapidityCut"),
                                          cfg.getParameter<double>("minPhi"),
                                          cfg.getParameter<double>("maxPhi"));
+      }
+
+      static void fillPSetDescription(edm::ParameterSetDescription& desc) {
+        desc.add<double>("ptMin", 0.9);
+        desc.add<double>("minRapidity", -2.4);
+        desc.add<double>("maxRapidity", 2.4);
+        desc.add<double>("tip", 3.5);
+        desc.add<double>("lip", 30.0);
+        desc.add<bool>("chargedOnly", true);
+        desc.add<int>("status", 1);
+        desc.add<std::vector<int> >("pdgId", {});
+        desc.add<bool>("invertRapidityCut", false);
+        desc.add<double>("minPhi", -3.2);
+        desc.add<double>("maxPhi", 3.2);
       }
     };
 

--- a/CommonTools/CandAlgos/src/GenJetParticleSelector.cc
+++ b/CommonTools/CandAlgos/src/GenJetParticleSelector.cc
@@ -1,6 +1,7 @@
 #include "CommonTools/CandAlgos/interface/GenJetParticleSelector.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "SimGeneral/HepPDTRecord/interface/PdtEntry.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -44,6 +45,10 @@ GenJetParticleSelector::GenJetParticleSelector(const ParameterSet& cfg, edm::Con
   if (stableOnly_ && partons_) {
     throw cms::Exception("ConfigError", "not allowed to have both stableOnly and partons true at the same time\n");
   }
+}
+
+void GenJetParticleSelector::fillPSetDescription(edm::ParameterSetDescription& desc) {
+  desc.add<bool>("stableOnly", true);
 }
 
 bool GenJetParticleSelector::operator()(const reco::Candidate& p) {

--- a/CommonTools/ParticleFlow/interface/ElectronIDPFCandidateSelectorDefinition.h
+++ b/CommonTools/ParticleFlow/interface/ElectronIDPFCandidateSelectorDefinition.h
@@ -12,6 +12,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/Common/interface/ValueMap.h"
@@ -59,6 +60,14 @@ namespace pf2pat {
         isBitMap_ = false;
         value_ = cfg.getParameter<double>("electronIdCut");
       }
+    }
+
+    static void fillPSetDescription(edm::ParameterSetDescription& desc) {
+      desc.add<edm::InputTag>("recoGsfElectrons", edm::InputTag(""));
+      desc.add<edm::InputTag>("electronIdMap", edm::InputTag(""));
+      //desc.add<std::vector<std::string> >("bitsToCheck");
+      //desc.add<uint32_t>("bitsToCheck");
+      desc.add<double>("electronIdCut", 0.);
     }
 
     void select(const HandleToCollection& hc, const edm::Event& e, const edm::EventSetup& s) {

--- a/CommonTools/ParticleFlow/interface/GenericPFCandidateSelectorDefinition.h
+++ b/CommonTools/ParticleFlow/interface/GenericPFCandidateSelectorDefinition.h
@@ -12,6 +12,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "CommonTools/ParticleFlow/interface/PFCandidateSelectorDefinition.h"
@@ -35,6 +36,8 @@ namespace pf2pat {
         }
       }
     }
+
+    static void fillPSetDescription(edm::ParameterSetDescription& desc) { desc.add<std::string>("cut", ""); }
 
   private:
     StringCutObjectSelector<reco::PFCandidate> selector_;

--- a/CommonTools/ParticleFlow/interface/GenericPFJetSelectorDefinition.h
+++ b/CommonTools/ParticleFlow/interface/GenericPFJetSelectorDefinition.h
@@ -4,6 +4,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "DataFormats/JetReco/interface/PFJet.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 #include "CommonTools/ParticleFlow/interface/PFJetSelectorDefinition.h"
@@ -14,6 +15,8 @@ namespace pf2pat {
   struct GenericPFJetSelectorDefinition : public PFJetSelectorDefinition {
     GenericPFJetSelectorDefinition(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC)
         : selector_(cfg.getParameter<std::string>("cut")) {}
+
+    static void fillPSetDescription(edm::ParameterSetDescription& desc) { desc.add<std::string>("cut", ""); }
 
     void select(const HandleToCollection& hc, const edm::Event& e, const edm::EventSetup& s) {
       selected_.clear();

--- a/CommonTools/ParticleFlow/interface/IPCutPFCandidateSelectorDefinition.h
+++ b/CommonTools/ParticleFlow/interface/IPCutPFCandidateSelectorDefinition.h
@@ -12,6 +12,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "CommonTools/ParticleFlow/interface/PFCandidateSelectorDefinition.h"
@@ -30,6 +31,16 @@ namespace pf2pat {
           d0SigCut_(cfg.getParameter<double>("d0SigCut")),
           dzSigCut_(cfg.getParameter<double>("dzSigCut")),
           dtSigCut_(cfg.getParameter<double>("dtSigCut")) {}
+
+    static void fillPSetDescription(edm::ParameterSetDescription &desc) {
+      desc.add<edm::InputTag>("vertices", edm::InputTag(""));
+      desc.add<double>("d0Cut", 0.2)->setComment("transverse IP");
+      desc.add<double>("dzCut", 0.5)->setComment("longitudingal IP");
+      desc.add<double>("dtCut", -1.0)->setComment("time");
+      desc.add<double>("d0SigCut", 99.)->setComment("transverse IP significance");
+      desc.add<double>("dzSigCut", 99.)->setComment("longitudingal IP significance");
+      desc.add<double>("dtSigCut", -1.0)->setComment("time significance");
+    }
 
     void select(const HandleToCollection &hc, const edm::Event &e, const edm::EventSetup &s) {
       selected_.clear();

--- a/CommonTools/ParticleFlow/interface/IsolatedPFCandidateSelectorDefinition.h
+++ b/CommonTools/ParticleFlow/interface/IsolatedPFCandidateSelectorDefinition.h
@@ -4,6 +4,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "CommonTools/ParticleFlow/interface/PFCandidateSelectorDefinition.h"
@@ -95,6 +96,16 @@ namespace pf2pat {
           selected_.back().setSourceCandidatePtr(ptrToMother);
         }
       }
+    }
+
+    static void fillPSetDescription(edm::ParameterSetDescription& desc) {
+      desc.add<std::vector<edm::InputTag> >("isolationValueMapsCharged", {});
+      desc.add<std::vector<edm::InputTag> >("isolationValueMapsNeutral", {});
+      desc.add<bool>("doDeltaBetaCorrection", false);
+      desc.add<edm::InputTag>("deltaBetaIsolationValueMap", edm::InputTag(""));
+      desc.add<double>("deltaBetaFactor", -0.5);
+      desc.add<bool>("isRelative", true)->setComment("if True isolation is relative to pT");
+      desc.add<double>("isolationCut", 999);
     }
 
   private:

--- a/CommonTools/ParticleFlow/interface/MuonIDPFCandidateSelectorDefinition.h
+++ b/CommonTools/ParticleFlow/interface/MuonIDPFCandidateSelectorDefinition.h
@@ -12,6 +12,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/Common/interface/ValueMap.h"
@@ -24,6 +25,8 @@ namespace pf2pat {
   struct MuonIDPFCandidateSelectorDefinition : public PFCandidateSelectorDefinition {
     MuonIDPFCandidateSelectorDefinition(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC)
         : muonCut_(cfg.getParameter<std::string>("cut")) {}
+
+    static void fillPSetDescription(edm::ParameterSetDescription& desc) { desc.add<std::string>("cut", ""); }
 
     void select(const HandleToCollection& hc, const edm::Event& e, const edm::EventSetup& s) {
       selected_.clear();

--- a/CommonTools/ParticleFlow/interface/PdgIdPFCandidateSelectorDefinition.h
+++ b/CommonTools/ParticleFlow/interface/PdgIdPFCandidateSelectorDefinition.h
@@ -5,6 +5,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "CommonTools/ParticleFlow/interface/PFCandidateSelectorDefinition.h"
@@ -15,6 +16,8 @@ namespace pf2pat {
   public:
     PdgIdPFCandidateSelectorDefinition(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC)
         : pdgIds_(cfg.getParameter<std::vector<int> >("pdgId")) {}
+
+    static void fillPSetDescription(edm::ParameterSetDescription& desc) { desc.add<std::vector<int> >("pdgId", {}); }
 
     void select(const HandleToCollection& hc, const edm::EventBase& e, const edm::EventSetup& s) {
       selected_.clear();

--- a/CommonTools/ParticleFlow/interface/PtMinPFCandidateSelectorDefinition.h
+++ b/CommonTools/ParticleFlow/interface/PtMinPFCandidateSelectorDefinition.h
@@ -4,6 +4,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "CommonTools/ParticleFlow/interface/PFCandidateSelectorDefinition.h"
@@ -14,6 +15,8 @@ namespace pf2pat {
   public:
     PtMinPFCandidateSelectorDefinition(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC)
         : ptMin_(cfg.getParameter<double>("ptMin")) {}
+
+    static void fillPSetDescription(edm::ParameterSetDescription& desc) { desc.add<double>("ptMin", 0.); }
 
     void select(const HandleToCollection& hc, const edm::EventBase& e, const edm::EventSetup& s) {
       selected_.clear();

--- a/CommonTools/RecoAlgos/interface/CosmicTrackingParticleSelector.h
+++ b/CommonTools/RecoAlgos/interface/CosmicTrackingParticleSelector.h
@@ -14,6 +14,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
 #include "TrackingTools/PatternTools/interface/TSCBLBuilderNoMaterial.h"
 #include "TrackingTools/PatternTools/interface/TSCPBuilderNoMaterial.h"
@@ -73,6 +74,17 @@ public:
         beamSpotToken_(iC.consumes<reco::BeamSpot>(edm::InputTag("offlineBeamSpot"))),
         globalTrackingGeomToken_(iC.esConsumes()),
         theMFToken_(iC.esConsumes()) {}
+
+  static void fillPSetDescription(edm::ParameterSetDescription& desc) {
+    desc.add<double>("ptMin", 0.9);
+    desc.add<double>("minRapidity", -2.4);
+    desc.add<double>("maxRapidity", 2.4);
+    desc.add<double>("tip", 100.0);
+    desc.add<double>("lip", 100.0);
+    desc.add<int>("minHit", 0);
+    desc.add<bool>("chargedOnly", true);
+    desc.add<std::vector<int> >("pdgId", {});
+  }
 
   void select(const edm::Handle<collection>& c, const edm::Event& event, const edm::EventSetup& setup) {
     selected_.clear();

--- a/CommonTools/RecoAlgos/python/TrackWithVertexSelectorParams_cff.py
+++ b/CommonTools/RecoAlgos/python/TrackWithVertexSelectorParams_cff.py
@@ -29,7 +29,4 @@ trackWithVertexSelectorParams = cms.PSet(
     zetaVtx = cms.double(1.0),
     rhoVtx = cms.double(0.2), ## tags used by b-tagging folks
     nSigmaDtVertex = cms.double(0),
-    # should _not_ be used for the TrackWithVertexRefSelector
-    copyExtras = cms.untracked.bool(False), ## copies also extras and rechits on RECO
-    copyTrajectories = cms.untracked.bool(False), # don't set this to true on AOD!
 )

--- a/CommonTools/UtilAlgos/interface/AssociatedVariableCollectionSelector.h
+++ b/CommonTools/UtilAlgos/interface/AssociatedVariableCollectionSelector.h
@@ -10,6 +10,7 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "CommonTools/UtilAlgos/interface/SelectionAdderTrait.h"
@@ -50,6 +51,11 @@ public:
       if (select_((*c)[idx], (*var)[edm::getRef(c, idx)]))
         addRef_(selected_, c, idx);
     }
+  }
+
+  static void fillPSetDescription(edm::ParameterSetDescription& desc) {
+    desc.add<edm::InputTag>("var", edm::InputTag(""));
+    Selector::fillPSetDescription(desc);
   }
 
 private:

--- a/CommonTools/UtilAlgos/interface/DummySelector.h
+++ b/CommonTools/UtilAlgos/interface/DummySelector.h
@@ -13,6 +13,7 @@
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 namespace edm {
   class ParameterSet;
@@ -30,6 +31,8 @@ public:
       throw edm::Exception(edm::errors::Configuration) << "DummySelector: forgot to call newEvent\n";
     return true;
   }
+
+  static void fillPSetDescription(edm::ParameterSetDescription& desc) {}
 
 private:
   bool updated_;

--- a/CommonTools/UtilAlgos/interface/FreeFunctionSelector.h
+++ b/CommonTools/UtilAlgos/interface/FreeFunctionSelector.h
@@ -13,6 +13,7 @@ struct FreeFunctionSelector {
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "CommonTools/UtilAlgos/interface/ParameterAdapter.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 namespace reco {
   namespace modules {
@@ -20,6 +21,8 @@ namespace reco {
     struct ParameterAdapter<FreeFunctionSelector<T, f> > {
       typedef FreeFunctionSelector<T, f> value_type;
       static value_type make(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC) { return value_type(); }
+
+      static void fillPSetDescription(edm::ParameterSetDescription& desc) {}
     };
   }  // namespace modules
 }  // namespace reco

--- a/CommonTools/UtilAlgos/interface/ObjectPairCollectionSelector.h
+++ b/CommonTools/UtilAlgos/interface/ObjectPairCollectionSelector.h
@@ -56,6 +56,11 @@ public:
         addRef_(selected_, c, i);
   }
 
+  static void fillPSetDescription(edm::ParameterSetDescription &desc) {
+    // Use ParameterAdapter to fill the descriptions
+    reco::modules::ParameterAdapter<Selector>::fillPSetDescription(desc);
+  }
+
 private:
   Selector select_;
   StoreContainer selected_;

--- a/CommonTools/UtilAlgos/interface/ObjectSelectorBase.h
+++ b/CommonTools/UtilAlgos/interface/ObjectSelectorBase.h
@@ -14,7 +14,9 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "CommonTools/UtilAlgos/interface/ParameterAdapter.h"
 #include <utility>
@@ -52,6 +54,10 @@ public:
   }
   /// destructor
   ~ObjectSelectorBase() override {}
+
+  static void fillPSetDescription(edm::ParameterSetDescription& desc) {
+    desc.addUntracked<bool>("throwOnMissing", true);
+  };
 
 private:
   /// process one event

--- a/CommonTools/UtilAlgos/interface/ObjectSelectorBase.h
+++ b/CommonTools/UtilAlgos/interface/ObjectSelectorBase.h
@@ -55,9 +55,14 @@ public:
   /// destructor
   ~ObjectSelectorBase() override {}
 
-  static void fillPSetDescription(edm::ParameterSetDescription& desc) {
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<edm::InputTag>("src", edm::InputTag(""));
+    Selector::fillPSetDescription(desc);
+    desc.add<bool>("filter", false);
     desc.addUntracked<bool>("throwOnMissing", true);
-  };
+    descriptions.addWithDefaultLabel(desc);
+  }
 
 private:
   /// process one event

--- a/CommonTools/UtilAlgos/interface/ObjectSelectorProducer.h
+++ b/CommonTools/UtilAlgos/interface/ObjectSelectorProducer.h
@@ -45,8 +45,7 @@ public:
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
-    desc.add<edm::InputTag>("src");
-    //Base::fillPSetDescription(desc);
+    desc.add<edm::InputTag>("src", edm::InputTag(""));
     Selector::fillPSetDescription(desc);
     descriptions.addWithDefaultLabel(desc);
   }

--- a/CommonTools/UtilAlgos/interface/ObjectSelectorProducer.h
+++ b/CommonTools/UtilAlgos/interface/ObjectSelectorProducer.h
@@ -4,6 +4,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "CommonTools/UtilAlgos/interface/StoreManagerTrait.h"
 #include "CommonTools/UtilAlgos/interface/SelectedOutputCollectionTrait.h"
@@ -41,6 +42,14 @@ public:
   }
   /// destructor
   ~ObjectSelectorProducer() override {}
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<edm::InputTag>("src");
+    //Base::fillPSetDescription(desc);
+    Selector::fillPSetDescription(desc);
+    descriptions.addWithDefaultLabel(desc);
+  }
 
 private:
   /// process one event

--- a/CommonTools/UtilAlgos/interface/OverlapExclusionSelector.h
+++ b/CommonTools/UtilAlgos/interface/OverlapExclusionSelector.h
@@ -1,5 +1,7 @@
 #ifndef CommonTools_UtilAlgos_OverlapExclusionSelector_h
 #define CommonTools_UtilAlgos_OverlapExclusionSelector_h
+
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -18,6 +20,10 @@ public:
   OverlapExclusionSelector(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC);
   void newEvent(const edm::Event&, const edm::EventSetup&) const;
   bool operator()(const T&) const;
+
+  static void fillPSetDescription(edm::ParameterSetDescription& desc) {
+    desc.add<edm::InputTag>("overlap", edm::InputTag(""));
+  }
 
 private:
   edm::EDGetTokenT<C> srcToken_;

--- a/CommonTools/UtilAlgos/interface/PairSelector.h
+++ b/CommonTools/UtilAlgos/interface/PairSelector.h
@@ -3,6 +3,7 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "CommonTools/UtilAlgos/interface/ParameterAdapter.h"
 #include "CommonTools/Utils/interface/PairSelector.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 namespace reco {
   namespace modules {
@@ -15,6 +16,8 @@ namespace reco {
       static PairSelector<S1, S2> make(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC) {
         return PairSelector<S1, S2>(modules::make<S1>(cfg, iC), modules::make<S2>(cfg, iC));
       }
+
+      static void fillPSetDescription(edm::ParameterSetDescription& desc) {}
     };
 
   }  // namespace modules

--- a/CommonTools/UtilAlgos/interface/PdgIdExcluder.h
+++ b/CommonTools/UtilAlgos/interface/PdgIdExcluder.h
@@ -1,6 +1,7 @@
 #ifndef CommonTools_UtilAlgos_PdgIdSelector_h
 #define CommonTools_UtilAlgos_PdgIdSelector_h
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "CommonTools/UtilAlgos/interface/ParameterAdapter.h"
 #include "CommonTools/Utils/interface/PdgIdExcluder.h"
 
@@ -12,6 +13,8 @@ namespace reco {
       static PdgIdExcluder make(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC) {
         return PdgIdExcluder(cfg.getParameter<std::vector<int> >("pdgId"));
       }
+
+      static void fillPSetDescription(edm::ParameterSetDescription& desc) { desc.add<std::vector<int> >("pdgId", {}); }
     };
 
   }  // namespace modules

--- a/CommonTools/UtilAlgos/interface/PdgIdSelector.h
+++ b/CommonTools/UtilAlgos/interface/PdgIdSelector.h
@@ -1,6 +1,7 @@
 #ifndef UtilAlgos_PdgIdSelector_h
 #define UtilAlgos_PdgIdSelector_h
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "CommonTools/UtilAlgos/interface/ParameterAdapter.h"
 #include "CommonTools/Utils/interface/PdgIdSelector.h"
 
@@ -12,6 +13,8 @@ namespace reco {
       static PdgIdSelector make(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC) {
         return PdgIdSelector(cfg.getParameter<std::vector<int> >("pdgId"));
       }
+
+      static void fillPSetDescription(edm::ParameterSetDescription& desc) { desc.add<std::vector<int> >("pdgId", {}); }
     };
 
   }  // namespace modules

--- a/CommonTools/UtilAlgos/interface/RangeObjectPairSelector.h
+++ b/CommonTools/UtilAlgos/interface/RangeObjectPairSelector.h
@@ -1,5 +1,6 @@
 #ifndef UtilAlgos_RangeObjectPairSelector_h
 #define UtilAlgos_RangeObjectPairSelector_h
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "CommonTools/Utils/interface/RangeObjectPairSelector.h"
 #include "CommonTools/UtilAlgos/interface/ParameterAdapter.h"
 
@@ -12,6 +13,11 @@ namespace reco {
         return RangeObjectPairSelector<F>(cfg.template getParameter<double>("rangeMin"),
                                           cfg.template getParameter<double>("rangeMax"),
                                           reco::modules::make<F>(cfg));
+      }
+
+      static void fillPSetDescription(edm::ParameterSetDescription& desc) {
+        desc.add<double>("rangeMin", 0.);
+        desc.add<double>("rangeMax", 0.);
       }
     };
 

--- a/CommonTools/UtilAlgos/interface/SingleElementCollectionRefSelector.h
+++ b/CommonTools/UtilAlgos/interface/SingleElementCollectionRefSelector.h
@@ -13,6 +13,7 @@
  *
  */
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "CommonTools/UtilAlgos/interface/SelectionAdderTrait.h"
 #include "CommonTools/UtilAlgos/interface/StoreContainerTrait.h"
 #include "CommonTools/UtilAlgos/interface/ParameterAdapter.h"
@@ -51,6 +52,11 @@ struct SingleElementCollectionRefSelector {
       if (select_(c->refAt(idx)))
         addRef_(selected_, c, idx);
     }
+  }
+
+  static void fillPSetDescription(edm::ParameterSetDescription& desc) {
+    // Use ParameterAdapter to fill the descriptions
+    reco::modules::ParameterAdapter<Selector>::fillPSetDescription(desc);
   }
 
 private:

--- a/CommonTools/UtilAlgos/interface/SingleElementCollectionSelector.h
+++ b/CommonTools/UtilAlgos/interface/SingleElementCollectionSelector.h
@@ -13,6 +13,7 @@
  *
  */
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "CommonTools/UtilAlgos/interface/SelectionAdderTrait.h"
 #include "CommonTools/UtilAlgos/interface/StoreContainerTrait.h"
 #include "CommonTools/UtilAlgos/interface/ParameterAdapter.h"
@@ -50,6 +51,10 @@ struct SingleElementCollectionSelector {
         addRef_(selected_, c, idx);
     }
   }
+
+  static void fillPSetDescription(edm::ParameterSetDescription& desc) {
+    reco::modules::ParameterAdapter<Selector>::fillPSetDescription(desc);
+  };
 
 private:
   container selected_;

--- a/CommonTools/UtilAlgos/interface/SingleElementCollectionSelectorPlusEvent.h
+++ b/CommonTools/UtilAlgos/interface/SingleElementCollectionSelectorPlusEvent.h
@@ -13,6 +13,7 @@
  *
  */
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "CommonTools/UtilAlgos/interface/SelectionAdderTrait.h"
 #include "CommonTools/UtilAlgos/interface/StoreContainerTrait.h"
 #include "CommonTools/UtilAlgos/interface/ParameterAdapter.h"
@@ -43,6 +44,8 @@ struct SingleElementCollectionSelectorPlusEvent {
         addRef_(selected_, c, idx);
     }
   }
+
+  static void fillPSetDescription(edm::ParameterSetDescription &desc) { Selector::fillPSetDescription(desc); };
 
 private:
   StoreContainer selected_;

--- a/CommonTools/UtilAlgos/interface/SortCollectionSelector.h
+++ b/CommonTools/UtilAlgos/interface/SortCollectionSelector.h
@@ -14,6 +14,7 @@
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "CommonTools/UtilAlgos/interface/SelectionAdderTrait.h"
 #include "CommonTools/UtilAlgos/interface/StoreContainerTrait.h"
 #include "CommonTools/UtilAlgos/interface/ParameterAdapter.h"
@@ -55,6 +56,8 @@ public:
     for (size_t i = 0; i < maxNumber_ && i < v.size(); ++i)
       addRef_(selected_, c, v[i].second);
   }
+
+  static void fillPSetDescription(edm::ParameterSetDescription &desc) { desc.add<unsigned int>("maxNumber", 1); }
 
 private:
   struct PairComparator {

--- a/CommonTools/UtilAlgos/interface/StatusSelector.h
+++ b/CommonTools/UtilAlgos/interface/StatusSelector.h
@@ -1,6 +1,7 @@
 #ifndef UtilAlgos_StatusSelector_h
 #define UtilAlgos_StatusSelector_h
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "CommonTools/UtilAlgos/interface/ParameterAdapter.h"
 #include "CommonTools/Utils/interface/StatusSelector.h"
 
@@ -12,6 +13,8 @@ namespace reco {
       static StatusSelector make(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC) {
         return StatusSelector(cfg.getParameter<std::vector<int> >("status"));
       }
+
+      static void fillPSetDescription(edm::ParameterSetDescription& desc) { desc.add<std::vector<int> >("status", {}); }
     };
 
   }  // namespace modules

--- a/CommonTools/UtilAlgos/interface/StringCutObjectSelector.h
+++ b/CommonTools/UtilAlgos/interface/StringCutObjectSelector.h
@@ -29,6 +29,8 @@ namespace reco {
   public:
     explicit StringCutObjectSelectorHandler(const edm::ParameterSet& cfg)
         : StringCutObjectSelector<T, Lazy>(cfg.getParameter<std::string>("cut")) {}
+
+    static void fillPSetDescription(edm::ParameterSetDescription& desc) { desc.add<std::string>("cut", ""); }
   };
 }  // namespace reco
 

--- a/CommonTools/Utils/interface/AndSelector.h
+++ b/CommonTools/Utils/interface/AndSelector.h
@@ -7,6 +7,8 @@
  * $Id: AndSelector.h,v 1.7 2008/05/20 15:13:27 piccolo Exp $
  */
 
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
 namespace helpers {
   struct NullAndOperand;
 }
@@ -31,6 +33,8 @@ struct AndSelector {
     return s1_(t) && s2_(t) && s3_(t) && s4_(t) && s5_(t);
   }
 
+  static void fillPSetDescription(edm::ParameterSetDescription& desc) {}
+
 private:
   friend struct reco::modules::CombinedEventSetupInit<S1, S2, S3, S4, S5>;
   S1 s1_;
@@ -52,6 +56,8 @@ struct AndSelector<S1, S2, helpers::NullAndOperand, helpers::NullAndOperand, hel
     return s1_(t1) && s2_(t2);
   }
 
+  static void fillPSetDescription(edm::ParameterSetDescription& desc) {}
+
 private:
   friend struct reco::modules::
       CombinedEventSetupInit<S1, S2, helpers::NullAndOperand, helpers::NullAndOperand, helpers::NullAndOperand>;
@@ -71,6 +77,8 @@ struct AndSelector<S1, S2, S3, helpers::NullAndOperand, helpers::NullAndOperand>
     return s1_(t1) && s2_(t2) && s3_(t3);
   }
 
+  static void fillPSetDescription(edm::ParameterSetDescription& desc) {}
+
 private:
   friend struct reco::modules::CombinedEventSetupInit<S1, S2, S3, helpers::NullAndOperand, helpers::NullAndOperand>;
   S1 s1_;
@@ -89,6 +97,8 @@ struct AndSelector<S1, S2, S3, S4, helpers::NullAndOperand> {
   bool operator()(const T1& t1, const T2& t2, const T3& t3, const T4& t4) const {
     return s1_(t1) && s2_(t2) && s3_(t3) && s4_(t4);
   }
+
+  static void fillPSetDescription(edm::ParameterSetDescription& desc) {}
 
 private:
   friend struct reco::modules::CombinedEventSetupInit<S1, S2, S3, S4, helpers::NullAndOperand>;

--- a/DPGAnalysis/Skims/src/IsoPhotonEBSelector.cc
+++ b/DPGAnalysis/Skims/src/IsoPhotonEBSelector.cc
@@ -1,5 +1,5 @@
 // -*- C++ -*-
-// Class:      ZElectronsSelector
+// Class:      IsoPhotonEBSelector
 //
 // Original Author:  Silvia Taroni
 //         Created:  Wed, 29 Nov 2017 18:23:54 GMT
@@ -24,6 +24,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
 #include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
@@ -42,6 +43,9 @@ namespace edm {
 class IsoPhotonEBSelector {
 public:
   IsoPhotonEBSelector(const edm::ParameterSet&, edm::ConsumesCollector& iC);
+
+  static void fillPSetDescription(edm::ParameterSetDescription& desc);
+
   bool operator()(const reco::Photon&) const;
   void newEvent(const edm::Event&, const edm::EventSetup&);
   const float getEffectiveArea(float eta) const;
@@ -81,15 +85,31 @@ const float IsoPhotonEBSelector::getEffectiveArea(float eta) const {
   return effArea;
 }
 
+void IsoPhotonEBSelector::fillPSetDescription(edm::ParameterSetDescription& desc) {
+  desc.add<edm::InputTag>("rho", edm::InputTag("fixedGridRhoFastjetCentralCalo"));
+  desc.add<std::vector<double>>("absEtaMin", {0.0000, 1.0000, 1.4790, 2.0000, 2.2000, 2.3000, 2.4000});
+  desc.add<std::vector<double>>("absEtaMax", {1.0000, 1.4790, 2.0000, 2.2000, 2.3000, 2.4000, 5.0000});
+  desc.add<std::vector<double>>("effectiveAreaValues", {0.1703, 0.1715, 0.1213, 0.1230, 0.1635, 0.1937, 0.2393});
+
+  // Define the photonIDWP PSet
+  edm::ParameterSetDescription photonIDWP;
+  photonIDWP.add<std::vector<double>>("full5x5_sigmaIEtaIEtaCut", {0.011, -1.0});
+  photonIDWP.add<std::vector<double>>("hOverECut", {0.1, -1.0});
+  photonIDWP.add<std::vector<double>>("relCombIsolationWithEACut", {0.05, -1.0});
+
+  // Add the PSet to the main description
+  desc.add<edm::ParameterSetDescription>("phID", photonIDWP);
+}
+
 IsoPhotonEBSelector::IsoPhotonEBSelector(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC)
     : theRhoToken_(iC.consumes<double>(cfg.getParameter<edm::InputTag>("rho"))),
-      absEtaMin_(cfg.getParameter<std::vector<double> >("absEtaMin")),
-      absEtaMax_(cfg.getParameter<std::vector<double> >("absEtaMax")),
-      effectiveAreaValues_(cfg.getParameter<std::vector<double> >("effectiveAreaValues")),
+      absEtaMin_(cfg.getParameter<std::vector<double>>("absEtaMin")),
+      absEtaMax_(cfg.getParameter<std::vector<double>>("absEtaMax")),
+      effectiveAreaValues_(cfg.getParameter<std::vector<double>>("effectiveAreaValues")),
       phIDWP_(cfg.getParameter<edm::ParameterSet>("phID")),
-      sigmaIEtaIEtaCut_(phIDWP_.getParameter<std::vector<double> >("full5x5_sigmaIEtaIEtaCut")),
-      hOverECut_(phIDWP_.getParameter<std::vector<double> >("hOverECut")),
-      relCombIso_(phIDWP_.getParameter<std::vector<double> >("relCombIsolationWithEACut")) {
+      sigmaIEtaIEtaCut_(phIDWP_.getParameter<std::vector<double>>("full5x5_sigmaIEtaIEtaCut")),
+      hOverECut_(phIDWP_.getParameter<std::vector<double>>("hOverECut")),
+      relCombIso_(phIDWP_.getParameter<std::vector<double>>("relCombIsolationWithEACut")) {
   //printEffectiveAreas();
 }
 

--- a/DPGAnalysis/Skims/src/ZElectronsSelector.cc
+++ b/DPGAnalysis/Skims/src/ZElectronsSelector.cc
@@ -24,6 +24,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
@@ -45,6 +46,9 @@ namespace edm {
 class ZElectronsSelector {
 public:
   ZElectronsSelector(const edm::ParameterSet&, edm::ConsumesCollector& iC);
+
+  static void fillPSetDescription(edm::ParameterSetDescription& desc);
+
   bool operator()(const reco::GsfElectron&) const;
   void newEvent(const edm::Event&, const edm::EventSetup&);
   const float getEffectiveArea(float eta) const;
@@ -89,21 +93,40 @@ const float ZElectronsSelector::getEffectiveArea(float eta) const {
   return effArea;
 }
 
+void ZElectronsSelector::fillPSetDescription(edm::ParameterSetDescription& desc) {
+  desc.add<edm::InputTag>("rho", edm::InputTag("fixedGridRhoFastjetCentralCalo"));
+  desc.add<std::vector<double>>("absEtaMin", {0.0000, 1.0000, 1.4790, 2.0000, 2.2000, 2.3000, 2.4000});
+  desc.add<std::vector<double>>("absEtaMax", {1.0000, 1.4790, 2.0000, 2.2000, 2.3000, 2.4000, 5.0000});
+  desc.add<std::vector<double>>("effectiveAreaValues", {0.1703, 0.1715, 0.1213, 0.1230, 0.1635, 0.1937, 0.2393});
+
+  edm::ParameterSetDescription eleIDWP;
+  eleIDWP.add<std::vector<double>>("full5x5_sigmaIEtaIEtaCut", {0.0128, 0.0445});
+  eleIDWP.add<std::vector<double>>("dEtaInSeedCut", {0.00523, 0.00984});
+  eleIDWP.add<std::vector<double>>("dPhiInCut", {0.159, 0.157});
+  eleIDWP.add<std::vector<double>>("hOverECut", {0.247, 0.0982});
+  eleIDWP.add<std::vector<double>>("relCombIsolationWithEACut", {0.168, 0.185});
+  eleIDWP.add<std::vector<double>>("EInverseMinusPInverseCut", {0.193, 0.0962});
+  eleIDWP.add<std::vector<int>>("missingHitsCut", {2, 3});
+
+  // Add the PSet to the main description
+  desc.add<edm::ParameterSetDescription>("eleID", eleIDWP);
+}
+
 ZElectronsSelector::ZElectronsSelector(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC)
     : theRhoToken(iC.consumes<double>(cfg.getParameter<edm::InputTag>("rho"))) {
-  absEtaMin_ = cfg.getParameter<std::vector<double> >("absEtaMin");
-  absEtaMax_ = cfg.getParameter<std::vector<double> >("absEtaMax");
-  effectiveAreaValues_ = cfg.getParameter<std::vector<double> >("effectiveAreaValues");
+  absEtaMin_ = cfg.getParameter<std::vector<double>>("absEtaMin");
+  absEtaMax_ = cfg.getParameter<std::vector<double>>("absEtaMax");
+  effectiveAreaValues_ = cfg.getParameter<std::vector<double>>("effectiveAreaValues");
   //printEffectiveAreas();
   eleIDWP = cfg.getParameter<edm::ParameterSet>("eleID");
 
-  missHits = eleIDWP.getParameter<std::vector<int> >("missingHitsCut");
-  sigmaIEtaIEtaCut = eleIDWP.getParameter<std::vector<double> >("full5x5_sigmaIEtaIEtaCut");
-  dEtaInSeedCut = eleIDWP.getParameter<std::vector<double> >("dEtaInSeedCut");
-  dPhiInCut = eleIDWP.getParameter<std::vector<double> >("dPhiInCut");
-  hOverECut = eleIDWP.getParameter<std::vector<double> >("hOverECut");
-  relCombIso = eleIDWP.getParameter<std::vector<double> >("relCombIsolationWithEACut");
-  EInvMinusPInv = eleIDWP.getParameter<std::vector<double> >("EInverseMinusPInverseCut");
+  missHits = eleIDWP.getParameter<std::vector<int>>("missingHitsCut");
+  sigmaIEtaIEtaCut = eleIDWP.getParameter<std::vector<double>>("full5x5_sigmaIEtaIEtaCut");
+  dEtaInSeedCut = eleIDWP.getParameter<std::vector<double>>("dEtaInSeedCut");
+  dPhiInCut = eleIDWP.getParameter<std::vector<double>>("dPhiInCut");
+  hOverECut = eleIDWP.getParameter<std::vector<double>>("hOverECut");
+  relCombIso = eleIDWP.getParameter<std::vector<double>>("relCombIsolationWithEACut");
+  EInvMinusPInv = eleIDWP.getParameter<std::vector<double>>("EInverseMinusPInverseCut");
 }
 
 void ZElectronsSelector::newEvent(const edm::Event& ev, const edm::EventSetup&) {

--- a/DQM/TrackingMonitorSource/python/TrackCollections2monitor_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackCollections2monitor_cff.py
@@ -280,10 +280,7 @@ trackAssociated2pvSelector = trackWithVertexSelector.clone(
     zetaVtx = 999.,
     #rhoVtx = 0.2, ## tags used by b-tagging folks
     rhoVtx = 999., ## tags used by b-tagging folks
-    nSigmaDtVertex = 0.,
-    # should _not_ be used for the TrackWithVertexRefSelector
-    copyExtras = False, ## copies also extras and rechits on RECO
-    copyTrajectories = False # don't set this to true on AOD!
+    nSigmaDtVertex = 0.
 )
 
 highPurityPV0p1 = trackAssociated2pvSelector.clone(

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltTrackWithVertexRefSelectorBeforeSorting_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltTrackWithVertexRefSelectorBeforeSorting_cfi.py
@@ -1,8 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 hltTrackWithVertexRefSelectorBeforeSorting = cms.EDProducer("TrackWithVertexRefSelector",
-    copyExtras = cms.untracked.bool(False),
-    copyTrajectories = cms.untracked.bool(False),
     d0Max = cms.double(999.0),
     dzMax = cms.double(999.0),
     etaMax = cms.double(5.0),

--- a/HLTriggerOffline/Exotica/python/ExoticaValidation_cff.py
+++ b/HLTriggerOffline/Exotica/python/ExoticaValidation_cff.py
@@ -49,7 +49,6 @@ recoExoticaValidationCaloHT = cms.EDProducer(
     alias = cms.string('CaloMHT'),
     globalThreshold = cms.double(30.0),
     calculateSignificance = cms.bool( False ),
-    jets = cms.InputTag("ak4CaloJets") # for significance calculation
     )
 
 ExoticaValidationProdSeq = cms.Sequence(

--- a/PhysicsTools/HepMCCandAlgos/plugins/MCMatchCandRefSelector.cc
+++ b/PhysicsTools/HepMCCandAlgos/plugins/MCMatchCandRefSelector.cc
@@ -1,6 +1,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Common/interface/Handle.h"
@@ -42,6 +43,10 @@ namespace reco {
     struct ParameterAdapter<MCMatchCandRefSelector> {
       static MCMatchCandRefSelector make(const ParameterSet& cfg, edm::ConsumesCollector& iC) {
         return MCMatchCandRefSelector(iC.consumes<GenParticleMatch>(cfg.getParameter<InputTag>("match")));
+      }
+
+      static void fillPSetDescription(edm::ParameterSetDescription& desc) {
+        desc.add<edm::InputTag>("match", edm::InputTag(""));
       }
     };
 

--- a/PhysicsTools/JetMCAlgos/plugins/TauGenJetDecayModeSelector.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/TauGenJetDecayModeSelector.cc
@@ -6,6 +6,10 @@ TauGenJetDecayModeSelectorImp::TauGenJetDecayModeSelectorImp(const edm::Paramete
   selectedTauDecayModes_ = cfg.getParameter<vstring>("select");
 }
 
+void TauGenJetDecayModeSelectorImp::fillPSetDescription(edm::ParameterSetDescription& desc) {
+  desc.add<std::vector<std::string>>("select", {});
+}
+
 bool TauGenJetDecayModeSelectorImp::operator()(const reco::GenJet& tauGenJet) const {
   std::string tauGenJetDecayMode = JetMCTagUtils::genTauDecayMode(tauGenJet);
   for (vstring::const_iterator selectedTauDecayMode = selectedTauDecayModes_.begin();

--- a/PhysicsTools/JetMCAlgos/plugins/TauGenJetDecayModeSelector.h
+++ b/PhysicsTools/JetMCAlgos/plugins/TauGenJetDecayModeSelector.h
@@ -15,6 +15,7 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "CommonTools/UtilAlgos/interface/SingleObjectSelector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
 #include "DataFormats/JetReco/interface/GenJet.h"
@@ -26,6 +27,8 @@ public:
   explicit TauGenJetDecayModeSelectorImp(const edm::ParameterSet&, edm::ConsumesCollector& iC);
 
   bool operator()(const reco::GenJet&) const;
+
+  static void fillPSetDescription(edm::ParameterSetDescription& desc);
 
 private:
   typedef std::vector<std::string> vstring;

--- a/PhysicsTools/PatAlgos/interface/PATPrimaryVertexSelector.h
+++ b/PhysicsTools/PatAlgos/interface/PATPrimaryVertexSelector.h
@@ -16,6 +16,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
@@ -36,6 +37,8 @@ public:
   size_t size() const { return selected_.size(); }
   /// operator used in sorting the selected vertices
   bool operator()(const reco::Vertex*, const reco::Vertex*) const;
+
+  static void fillPSetDescription(edm::ParameterSetDescription& desc);
 
 private:
   /// access to track-related vertex quantities (multiplicity and pt-sum)

--- a/PhysicsTools/PatAlgos/src/PATPrimaryVertexSelector.cc
+++ b/PhysicsTools/PatAlgos/src/PATPrimaryVertexSelector.cc
@@ -33,6 +33,15 @@ void PATPrimaryVertexSelector::select(const edm::Handle<collection>& handle,
   sort(selected_.begin(), selected_.end(), *this);
 }
 
+void PATPrimaryVertexSelector::fillPSetDescription(edm::ParameterSetDescription& desc) {
+  desc.add<unsigned int>("minMultiplicity", 1);
+  desc.add<double>("minPtSum", 0.);
+  desc.add<double>("maxTrackEta", 9999.);
+  desc.add<double>("maxNormChi2", 9999.);
+  desc.add<double>("maxDeltaR", 9999.);
+  desc.add<double>("maxDeltaZ", 9999.);
+}
+
 bool PATPrimaryVertexSelector::operator()(const reco::Vertex* v1, const reco::Vertex* v2) const {
   unsigned int mult1;
   double ptSum1;

--- a/RecoEgamma/ElectronIdentification/plugins/CutBasedElectronID.h
+++ b/RecoEgamma/ElectronIdentification/plugins/CutBasedElectronID.h
@@ -21,6 +21,8 @@ public:
   int classify(const reco::GsfElectron*);
   bool compute_cut(double x, double et, double cut_min, double cut_max, bool gtn = false);
 
+  static void fillPSetDescription(edm::ParameterSetDescription& desc);
+
 private:
   bool wantBinning_;
   bool newCategories_;

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronIDAlgo.h
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronIDAlgo.h
@@ -7,6 +7,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/EgammaReco/interface/BasicClusterFwd.h"

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronIDSelector.h
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronIDSelector.h
@@ -6,6 +6,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
@@ -44,6 +45,11 @@ public:
       //selected_.push_back ( & * eleIt) ;
       ++i;
     }
+  }
+
+  static void fillPSetDescription(edm::ParameterSetDescription& desc) {
+    desc.add<double>("threshold", -1.0);
+    algo::fillPSetDescription(desc);
   }
 
 private:

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronIDSelectorCutBased.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronIDSelectorCutBased.cc
@@ -16,6 +16,11 @@ ElectronIDSelectorCutBased::ElectronIDSelectorCutBased(const edm::ParameterSet& 
   }
 }
 
+void ElectronIDSelectorCutBased::fillPSetDescription(edm::ParameterSetDescription& desc) {
+  desc.add<std::string>("algorithm", "");
+  CutBasedElectronID::fillPSetDescription(desc);
+}
+
 ElectronIDSelectorCutBased::~ElectronIDSelectorCutBased() { delete electronIDAlgo_; }
 
 void ElectronIDSelectorCutBased::newEvent(const edm::Event& e, const edm::EventSetup& es) {

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronIDSelectorCutBased.h
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronIDSelectorCutBased.h
@@ -7,6 +7,7 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 
 #include "ClassBasedElectronID.h"
@@ -23,6 +24,8 @@ public:
 
   void newEvent(const edm::Event&, const edm::EventSetup&);
   double operator()(const reco::GsfElectron&, const edm::Event&, const edm::EventSetup&);
+
+  static void fillPSetDescription(edm::ParameterSetDescription& desc);
 
 private:
   ElectronIDAlgo* electronIDAlgo_;

--- a/RecoMET/METAlgorithms/interface/SignAlgoResolutions.h
+++ b/RecoMET/METAlgorithms/interface/SignAlgoResolutions.h
@@ -24,6 +24,7 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "DataFormats/METReco/interface/SigInputObj.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
@@ -78,6 +79,8 @@ namespace metsig {
     metsig::SigInputObj evalPF(const reco::PFCandidate *candidate) const;
     metsig::SigInputObj evalPFJet(const reco::Jet *jet) const;
     bool isFilled() const { return !functionmap_.empty(); }
+
+    static void fillPSetDescription(edm::ParameterSetDescription &desc);
 
   private:
     double getfunc(const resolutionType &type, const resolutionFunc &func, std::vector<double> &x) const;

--- a/RecoMET/METAlgorithms/src/SignAlgoResolutions.cc
+++ b/RecoMET/METAlgorithms/src/SignAlgoResolutions.cc
@@ -159,8 +159,8 @@ void metsig::SignAlgoResolutions::addResolutions(const edm::ParameterSet &iConfi
 
   //get temporary low pT pfjet resolutions
   for (int ieta = 0; ieta < 10; ieta++) {
-    jdpt[ieta] = iConfig.getParameter<std::vector<double> >(Form("jdpt%d", ieta));
-    jdphi[ieta] = iConfig.getParameter<std::vector<double> >(Form("jdphi%d", ieta));
+    jdpt[ieta] = iConfig.getParameter<std::vector<double>>(Form("jdpt%d", ieta));
+    jdphi[ieta] = iConfig.getParameter<std::vector<double>>(Form("jdphi%d", ieta));
   }
 
   // for now: do this by hand - this can obviously also be done via ESSource etc.
@@ -168,8 +168,8 @@ void metsig::SignAlgoResolutions::addResolutions(const edm::ParameterSet &iConfi
   functionPars phiparameters(1, 0);
   // set the parameters per function:
   // ECAL, BARREL:
-  std::vector<double> ebet = iConfig.getParameter<std::vector<double> >("EB_EtResPar");
-  std::vector<double> ebphi = iConfig.getParameter<std::vector<double> >("EB_PhiResPar");
+  std::vector<double> ebet = iConfig.getParameter<std::vector<double>>("EB_EtResPar");
+  std::vector<double> ebphi = iConfig.getParameter<std::vector<double>>("EB_PhiResPar");
 
   etparameters[0] = ebet[0];
   etparameters[1] = ebet[1];
@@ -178,8 +178,8 @@ void metsig::SignAlgoResolutions::addResolutions(const edm::ParameterSet &iConfi
   addfunction(caloEB, ET, etparameters);
   addfunction(caloEB, PHI, phiparameters);
   // ECAL, ENDCAP:
-  std::vector<double> eeet = iConfig.getParameter<std::vector<double> >("EE_EtResPar");
-  std::vector<double> eephi = iConfig.getParameter<std::vector<double> >("EE_PhiResPar");
+  std::vector<double> eeet = iConfig.getParameter<std::vector<double>>("EE_EtResPar");
+  std::vector<double> eephi = iConfig.getParameter<std::vector<double>>("EE_PhiResPar");
 
   etparameters[0] = eeet[0];
   etparameters[1] = eeet[1];
@@ -188,8 +188,8 @@ void metsig::SignAlgoResolutions::addResolutions(const edm::ParameterSet &iConfi
   addfunction(caloEE, ET, etparameters);
   addfunction(caloEE, PHI, phiparameters);
   // HCAL, BARREL:
-  std::vector<double> hbet = iConfig.getParameter<std::vector<double> >("HB_EtResPar");
-  std::vector<double> hbphi = iConfig.getParameter<std::vector<double> >("HB_PhiResPar");
+  std::vector<double> hbet = iConfig.getParameter<std::vector<double>>("HB_EtResPar");
+  std::vector<double> hbphi = iConfig.getParameter<std::vector<double>>("HB_PhiResPar");
 
   etparameters[0] = hbet[0];
   etparameters[1] = hbet[1];
@@ -198,8 +198,8 @@ void metsig::SignAlgoResolutions::addResolutions(const edm::ParameterSet &iConfi
   addfunction(caloHB, ET, etparameters);
   addfunction(caloHB, PHI, phiparameters);
   // HCAL, ENDCAP:
-  std::vector<double> heet = iConfig.getParameter<std::vector<double> >("HE_EtResPar");
-  std::vector<double> hephi = iConfig.getParameter<std::vector<double> >("HE_PhiResPar");
+  std::vector<double> heet = iConfig.getParameter<std::vector<double>>("HE_EtResPar");
+  std::vector<double> hephi = iConfig.getParameter<std::vector<double>>("HE_PhiResPar");
 
   etparameters[0] = heet[0];
   etparameters[1] = heet[1];
@@ -208,8 +208,8 @@ void metsig::SignAlgoResolutions::addResolutions(const edm::ParameterSet &iConfi
   addfunction(caloHE, ET, etparameters);
   addfunction(caloHE, PHI, phiparameters);
   // HCAL, Outer
-  std::vector<double> hoet = iConfig.getParameter<std::vector<double> >("HO_EtResPar");
-  std::vector<double> hophi = iConfig.getParameter<std::vector<double> >("HO_PhiResPar");
+  std::vector<double> hoet = iConfig.getParameter<std::vector<double>>("HO_EtResPar");
+  std::vector<double> hophi = iConfig.getParameter<std::vector<double>>("HO_PhiResPar");
 
   etparameters[0] = hoet[0];
   etparameters[1] = hoet[1];
@@ -218,8 +218,8 @@ void metsig::SignAlgoResolutions::addResolutions(const edm::ParameterSet &iConfi
   addfunction(caloHO, ET, etparameters);
   addfunction(caloHO, PHI, phiparameters);
   // HCAL, Forward
-  std::vector<double> hfet = iConfig.getParameter<std::vector<double> >("HF_EtResPar");
-  std::vector<double> hfphi = iConfig.getParameter<std::vector<double> >("HF_PhiResPar");
+  std::vector<double> hfet = iConfig.getParameter<std::vector<double>>("HF_EtResPar");
+  std::vector<double> hfphi = iConfig.getParameter<std::vector<double>>("HF_PhiResPar");
 
   etparameters[0] = hfet[0];
   etparameters[1] = hfet[1];
@@ -230,8 +230,8 @@ void metsig::SignAlgoResolutions::addResolutions(const edm::ParameterSet &iConfi
 
   // PF objects:
   // type 1:
-  std::vector<double> pf1et = iConfig.getParameter<std::vector<double> >("PF_EtResType1");
-  std::vector<double> pf1phi = iConfig.getParameter<std::vector<double> >("PF_PhiResType1");
+  std::vector<double> pf1et = iConfig.getParameter<std::vector<double>>("PF_EtResType1");
+  std::vector<double> pf1phi = iConfig.getParameter<std::vector<double>>("PF_PhiResType1");
   etparameters[0] = pf1et[0];
   etparameters[1] = pf1et[1];
   etparameters[2] = pf1et[2];
@@ -241,8 +241,8 @@ void metsig::SignAlgoResolutions::addResolutions(const edm::ParameterSet &iConfi
 
   // PF objects:
   // type 2:
-  std::vector<double> pf2et = iConfig.getParameter<std::vector<double> >("PF_EtResType2");
-  std::vector<double> pf2phi = iConfig.getParameter<std::vector<double> >("PF_PhiResType2");
+  std::vector<double> pf2et = iConfig.getParameter<std::vector<double>>("PF_EtResType2");
+  std::vector<double> pf2phi = iConfig.getParameter<std::vector<double>>("PF_PhiResType2");
   etparameters[0] = pf2et[0];
   etparameters[1] = pf2et[1];
   etparameters[2] = pf2et[2];
@@ -252,8 +252,8 @@ void metsig::SignAlgoResolutions::addResolutions(const edm::ParameterSet &iConfi
 
   // PF objects:
   // type 3:
-  std::vector<double> pf3et = iConfig.getParameter<std::vector<double> >("PF_EtResType3");
-  std::vector<double> pf3phi = iConfig.getParameter<std::vector<double> >("PF_PhiResType3");
+  std::vector<double> pf3et = iConfig.getParameter<std::vector<double>>("PF_EtResType3");
+  std::vector<double> pf3phi = iConfig.getParameter<std::vector<double>>("PF_PhiResType3");
   etparameters[0] = pf3et[0];
   etparameters[1] = pf3et[1];
   etparameters[2] = pf3et[2];
@@ -263,8 +263,8 @@ void metsig::SignAlgoResolutions::addResolutions(const edm::ParameterSet &iConfi
 
   // PF objects:
   // type 4:
-  std::vector<double> pf4et = iConfig.getParameter<std::vector<double> >("PF_EtResType4");
-  std::vector<double> pf4phi = iConfig.getParameter<std::vector<double> >("PF_PhiResType4");
+  std::vector<double> pf4et = iConfig.getParameter<std::vector<double>>("PF_EtResType4");
+  std::vector<double> pf4phi = iConfig.getParameter<std::vector<double>>("PF_PhiResType4");
   etparameters[0] = pf4et[0];
   etparameters[1] = pf4et[1];
   etparameters[2] = pf4et[2];
@@ -274,8 +274,8 @@ void metsig::SignAlgoResolutions::addResolutions(const edm::ParameterSet &iConfi
 
   // PF objects:
   // type 5:
-  std::vector<double> pf5et = iConfig.getParameter<std::vector<double> >("PF_EtResType5");
-  std::vector<double> pf5phi = iConfig.getParameter<std::vector<double> >("PF_PhiResType5");
+  std::vector<double> pf5et = iConfig.getParameter<std::vector<double>>("PF_EtResType5");
+  std::vector<double> pf5phi = iConfig.getParameter<std::vector<double>>("PF_PhiResType5");
   etparameters[0] = pf5et[0];
   etparameters[1] = pf5et[1];
   etparameters[2] = pf5et[2];
@@ -285,8 +285,8 @@ void metsig::SignAlgoResolutions::addResolutions(const edm::ParameterSet &iConfi
 
   // PF objects:
   // type 6:
-  std::vector<double> pf6et = iConfig.getParameter<std::vector<double> >("PF_EtResType6");
-  std::vector<double> pf6phi = iConfig.getParameter<std::vector<double> >("PF_PhiResType6");
+  std::vector<double> pf6et = iConfig.getParameter<std::vector<double>>("PF_EtResType6");
+  std::vector<double> pf6phi = iConfig.getParameter<std::vector<double>>("PF_PhiResType6");
   etparameters[0] = pf6et[0];
   etparameters[1] = pf6et[1];
   etparameters[2] = pf6et[2];
@@ -296,8 +296,8 @@ void metsig::SignAlgoResolutions::addResolutions(const edm::ParameterSet &iConfi
 
   // PF objects:
   // type 7:
-  std::vector<double> pf7et = iConfig.getParameter<std::vector<double> >("PF_EtResType7");
-  std::vector<double> pf7phi = iConfig.getParameter<std::vector<double> >("PF_PhiResType7");
+  std::vector<double> pf7et = iConfig.getParameter<std::vector<double>>("PF_EtResType7");
+  std::vector<double> pf7phi = iConfig.getParameter<std::vector<double>>("PF_PhiResType7");
   etparameters[0] = pf7et[0];
   etparameters[1] = pf7et[1];
   etparameters[2] = pf7et[2];
@@ -402,4 +402,49 @@ double metsig::SignAlgoResolutions::ElectronPtResolution(const reco::PFCandidate
   double dEnergy = pfresol_->getEnergyResolutionEm(energy, eta);
 
   return dEnergy / cosh(eta);
+}
+
+void metsig::SignAlgoResolutions::fillPSetDescription(edm::ParameterSetDescription &desc) {
+  // ECAL
+  desc.addOptional<std::vector<double>>("EB_EtResPar", {0.2, 0.03, 0.005});
+  desc.addOptional<std::vector<double>>("EB_PhiResPar", {0.00502});
+  desc.addOptional<std::vector<double>>("EE_EtResPar", {0.2, 0.03, 0.005});
+  desc.addOptional<std::vector<double>>("EE_PhiResPar", {0.02511});
+
+  // HCAL
+  desc.addOptional<std::vector<double>>("HB_EtResPar", {0., 1.22, 0.05});
+  desc.addOptional<std::vector<double>>("HB_PhiResPar", {0.02511});
+  desc.addOptional<std::vector<double>>("HE_EtResPar", {0., 1.3, 0.05});
+  desc.addOptional<std::vector<double>>("HE_PhiResPar", {0.02511});
+  desc.addOptional<std::vector<double>>("HO_EtResPar", {0., 1.3, 0.005});
+  desc.addOptional<std::vector<double>>("HO_PhiResPar", {0.02511});
+  desc.addOptional<std::vector<double>>("HF_EtResPar", {0., 1.82, 0.09});
+  desc.addOptional<std::vector<double>>("HF_PhiResPar", {0.05022});
+
+  // PF
+  desc.addOptional<std::vector<double>>("PF_EtResType1", {0.05, 0, 0});
+  desc.addOptional<std::vector<double>>("PF_PhiResType1", {0.002});
+  desc.addOptional<std::vector<double>>("PF_EtResType2", {0.05, 0, 0});
+  desc.addOptional<std::vector<double>>("PF_PhiResType2", {0.002});
+  desc.addOptional<std::vector<double>>("PF_EtResType3", {0.05, 0, 0});
+  desc.addOptional<std::vector<double>>("PF_PhiResType3", {0.002});
+  desc.addOptional<std::vector<double>>("PF_EtResType4", {0.042, 0.100, 0.});
+  desc.addOptional<std::vector<double>>("PF_PhiResType4", {0.0028, 0.0, 0.0022});
+  desc.addOptional<std::vector<double>>("PF_EtResType5", {0.41, 0.52, 0.25});
+  desc.addOptional<std::vector<double>>("PF_PhiResType5", {0.10, 0.10, 0.13});
+  desc.addOptional<std::vector<double>>("PF_EtResType6", {0., 1.22, 0.05});
+  desc.addOptional<std::vector<double>>("PF_PhiResType6", {0.02511});
+  desc.addOptional<std::vector<double>>("PF_EtResType7", {0., 1.22, 0.05});
+  desc.addOptional<std::vector<double>>("PF_PhiResType7", {0.02511});
+
+  // Jet Resolution
+  desc.addOptional<std::string>("resolutionsEra", "Spring10");
+  desc.addOptional<std::string>("resolutionsAlgo", "AK5PF");
+  desc.addOptional<double>("ptresolthreshold", 10.0);
+
+  // JD parameters
+  for (int i = 0; i < 10; ++i) {
+    desc.add<std::vector<double>>("jdpt" + std::to_string(i), {});
+    desc.add<std::vector<double>>("jdphi" + std::to_string(i), {});
+  }
 }

--- a/RecoMET/METProducers/interface/CaloMETProducer.h
+++ b/RecoMET/METProducers/interface/CaloMETProducer.h
@@ -26,6 +26,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
@@ -42,6 +43,8 @@ namespace cms {
     explicit CaloMETProducer(const edm::ParameterSet &);
     ~CaloMETProducer() override;
     void produce(edm::Event &, const edm::EventSetup &) override;
+
+    static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
   private:
     edm::EDGetTokenT<edm::View<reco::Candidate> > inputToken_;

--- a/RecoMET/METProducers/src/CaloMETProducer.cc
+++ b/RecoMET/METProducers/src/CaloMETProducer.cc
@@ -37,8 +37,7 @@ namespace cms {
         globalThreshold_(iConfig.getParameter<double>("globalThreshold")) {
     noHF_ = iConfig.getParameter<bool>("noHF");
 
-    std::string alias = iConfig.exists("alias") ? iConfig.getParameter<std::string>("alias") : "";
-
+    std::string alias = iConfig.getParameter<std::string>("alias");
     produces<reco::CaloMETCollection>().setBranchAlias(alias);
 
     if (calculateSignificance_)
@@ -74,6 +73,18 @@ namespace cms {
     auto calometcoll = std::make_unique<reco::CaloMETCollection>();
     calometcoll->push_back(calomet);
     event.put(std::move(calometcoll));
+  }
+
+  //____________________________________________________________________________||
+  void CaloMETProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<edm::InputTag>("src", edm::InputTag("towerMaker"));
+    desc.add<bool>("calculateSignificance", false);
+    desc.add<double>("globalThreshold", 0.3);
+    desc.add<bool>("noHF", false);
+    desc.add<std::string>("alias", "");
+    metsig::SignAlgoResolutions::fillPSetDescription(desc);
+    descriptions.addWithDefaultLabel(desc);
   }
 
   //____________________________________________________________________________||

--- a/RecoTracker/ConversionSeedGenerators/plugins/SeedChargeSelector.h
+++ b/RecoTracker/ConversionSeedGenerators/plugins/SeedChargeSelector.h
@@ -28,6 +28,8 @@ namespace reco {
       static SeedChargeSelector make(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC) {
         return SeedChargeSelector(cfg.getParameter<int>("charge"));
       }
+
+      static void fillPSetDescription(edm::ParameterSetDescription& desc) { desc.add<int>("charge", 0); }
     };
 
   }  // namespace modules

--- a/RecoTracker/ConversionSeedGenerators/plugins/TrackChargeSelector.h
+++ b/RecoTracker/ConversionSeedGenerators/plugins/TrackChargeSelector.h
@@ -19,6 +19,7 @@ private:
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "CommonTools/UtilAlgos/interface/ParameterAdapter.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
 namespace reco {
   namespace modules {
@@ -28,6 +29,8 @@ namespace reco {
       static TrackChargeSelector make(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC) {
         return TrackChargeSelector(cfg.getParameter<int>("charge"));
       }
+
+      static void fillPSetDescription(edm::ParameterSetDescription& desc) { desc.add<int>("charge", 0); }
     };
 
   }  // namespace modules

--- a/SimTracker/Common/interface/TrackingParticleSelector.h
+++ b/SimTracker/Common/interface/TrackingParticleSelector.h
@@ -8,6 +8,7 @@
  *  $Revision: 1.5.4.2 $
  *
  */
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "DataFormats/Math/interface/PtEtaPhiMass.h"
 #include "DataFormats/Math/interface/deltaPhi.h"
@@ -199,6 +200,24 @@ namespace reco {
                                         cfg.getParameter<bool>("invertRapidityCut"),
                                         cfg.getParameter<double>("minPhi"),
                                         cfg.getParameter<double>("maxPhi"));
+      }
+
+      static void fillPSetDescription(edm::ParameterSetDescription &desc) {
+        desc.add<double>("ptMin", 0.9);
+        desc.add<double>("ptMax", 1e100);
+        desc.add<double>("minRapidity", -2.4);
+        desc.add<double>("maxRapidity", 2.4);
+        desc.add<double>("tip", 3.5);
+        desc.add<double>("lip", 30.0);
+        desc.add<int>("minHit", 0);
+        desc.add<bool>("signalOnly", true);
+        desc.add<bool>("intimeOnly", false);
+        desc.add<bool>("chargedOnly", true);
+        desc.add<bool>("stableOnly", false);
+        desc.add<std::vector<int>>("pdgId", {});
+        desc.add<bool>("invertRapidityCut", false);
+        desc.add<double>("minPhi", -3.2);
+        desc.add<double>("maxPhi", 3.2);
       }
     };
 

--- a/SimTracker/TrackHistory/interface/CategoryCriteria.h
+++ b/SimTracker/TrackHistory/interface/CategoryCriteria.h
@@ -1,13 +1,13 @@
-#ifndef CategoryCriteria_h
-#define CategoryCriteria_h
+#ifndef SimTracker_TrackHistory_CategoryCriteria_h
+#define SimTracker_TrackHistory_CategoryCriteria_h
 
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+#include "DataFormats/Common/interface/Ref.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-#include "DataFormats/Common/interface/Ref.h"
 
 //! Implement a selector given a track or vertex collection and track or vertex
 //! classifier.
@@ -29,6 +29,11 @@ public:
   // Constructor from parameter set configurability
   CategoryCriteria(const edm::ParameterSet &config, edm::ConsumesCollector &&iC)
       : classifier_(config, std::move(iC)), evaluate_(config.getParameter<std::string>("cut")) {}
+
+  static void fillPSetDescription(edm::ParameterSetDescription &desc) {
+    desc.add<std::string>("cut", "");
+    Classifier::fillPSetDescription(desc);
+  }
 
   // Select object from a collection and possibly event content
   void select(const edm::Handle<collection> &collectionHandler, const edm::Event &event, const edm::EventSetup &setup) {

--- a/SimTracker/TrackHistory/interface/TrackClassifier.h
+++ b/SimTracker/TrackHistory/interface/TrackClassifier.h
@@ -1,23 +1,18 @@
-
-#ifndef TrackClassifier_h
-#define TrackClassifier_h
-
-#include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-
-#include "MagneticField/Engine/interface/MagneticField.h"
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#ifndef SimTracker_TrackHistory_TrackClassifier_h
+#define SimTracker_TrackHistory_TrackClassifier_h
 
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
-
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
-
 #include "SimTracker/TrackHistory/interface/CMSProcessTypes.h"
 #include "SimTracker/TrackHistory/interface/TrackCategories.h"
 #include "SimTracker/TrackHistory/interface/TrackHistory.h"
 #include "SimTracker/TrackHistory/interface/TrackQuality.h"
-
 #include "TrackingTools/PatternTools/interface/TSCPBuilderNoMaterial.h"
 #include "TrackingTools/Records/interface/TransientTrackRecord.h"
 #include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
@@ -51,6 +46,8 @@ public:
 
   //! Returns a reference to the track quality used in the classification.
   TrackQuality const &quality() const { return quality_; }
+
+  static void fillPSetDescription(edm::ParameterSetDescription &desc);
 
 private:
   const edm::InputTag hepMCLabel_;

--- a/SimTracker/TrackHistory/interface/TrackHistory.h
+++ b/SimTracker/TrackHistory/interface/TrackHistory.h
@@ -8,6 +8,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 #include "SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h"
 #include "SimTracker/TrackHistory/interface/HistoryBase.h"
@@ -64,6 +65,8 @@ public:
   }
 
   double quality() const { return quality_; }
+
+  static void fillPSetDescription(edm::ParameterSetDescription &desc);
 
 private:
   bool newEvent_;

--- a/SimTracker/TrackHistory/interface/TrackQuality.h
+++ b/SimTracker/TrackHistory/interface/TrackQuality.h
@@ -76,6 +76,8 @@ public:
   //! Return information about the given layer by index
   const Layer &layer(unsigned int index) const { return layers_[index]; }
 
+  static void fillPSetDescription(edm::ParameterSetDescription &desc);
+
 private:
   TrackerHitAssociator::Config trackerHitAssociatorConfig_;
   std::unique_ptr<TrackerHitAssociator> associator_;

--- a/SimTracker/TrackHistory/interface/VertexClassifier.h
+++ b/SimTracker/TrackHistory/interface/VertexClassifier.h
@@ -1,15 +1,12 @@
-
-#ifndef VertexClassifier_h
-#define VertexClassifier_h
-
-#include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/InputTag.h"
+#ifndef SimTracker_TrackHistory_VertexClassifier_h
+#define SimTracker_TrackHistory_VertexClassifier_h
 
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
-
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
 #include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
-
 #include "SimTracker/TrackHistory/interface/CMSProcessTypes.h"
 #include "SimTracker/TrackHistory/interface/VertexCategories.h"
 #include "SimTracker/TrackHistory/interface/VertexHistory.h"
@@ -39,6 +36,8 @@ public:
 
   //! Returns a reference to the vertex history used in the classification.
   VertexHistory const &history() const { return tracer_; }
+
+  static void fillPSetDescription(edm::ParameterSetDescription &desc);
 
 private:
   VertexHistory tracer_;

--- a/SimTracker/TrackHistory/interface/VertexClassifierByProxy.h
+++ b/SimTracker/TrackHistory/interface/VertexClassifierByProxy.h
@@ -1,10 +1,10 @@
-
 #ifndef VertexClassifierByProxy_h
 #define VertexClassifierByProxy_h
 
 #include "DataFormats/Common/interface/AssociationMap.h"
 
 #include "SimTracker/TrackHistory/interface/VertexClassifier.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
 //! Get track history and classification by proxy
 template <typename Collection>
@@ -18,6 +18,11 @@ public:
       : VertexClassifier(config, std::move(collector)),
         proxy_(config.getUntrackedParameter<edm::InputTag>("vertexProducer")) {
     collector.consumes<Association>(proxy_);
+  }
+
+  static void fillPSetDescription(edm::ParameterSetDescription &desc) {
+    desc.add<edm::InputTag>("vertexProducer", edm::InputTag(""));
+    VertexClassifier::fillPSetDescription(desc);
   }
 
   //! Pre-process event information (for accessing reconstraction information).

--- a/SimTracker/TrackHistory/interface/VertexHistory.h
+++ b/SimTracker/TrackHistory/interface/VertexHistory.h
@@ -9,6 +9,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 #include "SimDataFormats/Associations/interface/VertexAssociation.h"
 #include "SimTracker/TrackHistory/interface/HistoryBase.h"
@@ -57,6 +58,8 @@ public:
 
   //! Return the quality of the match.
   double quality() const { return quality_; }
+
+  static void fillPSetDescription(edm::ParameterSetDescription &desc);
 
 private:
   bool bestMatchByMaxValue_;

--- a/SimTracker/TrackHistory/src/TrackClassifier.cc
+++ b/SimTracker/TrackHistory/src/TrackClassifier.cc
@@ -110,6 +110,22 @@ TrackClassifier const &TrackClassifier::evaluate(reco::TrackBaseRef const &track
   return *this;
 }
 
+void TrackClassifier::fillPSetDescription(edm::ParameterSetDescription &desc) {
+  TrackHistory::fillPSetDescription(desc);
+
+  edm::ParameterSetDescription trackQualityDesc;
+  TrackQuality::fillPSetDescription(trackQualityDesc);
+  desc.add<edm::ParameterSetDescription>("hitAssociator", trackQualityDesc);
+
+  desc.addUntracked<edm::InputTag>("hepMC", edm::InputTag("generatorSmeared"));
+  desc.addUntracked<edm::InputTag>("beamSpot", edm::InputTag("offlineBeamSpot"));
+  desc.addUntracked<double>("badPull", 3.0);
+  desc.addUntracked<double>("longLivedDecayLength", 1e-14);
+  desc.addUntracked<double>("vertexClusteringDistance", 0.0001);
+  desc.addUntracked<unsigned int>("numberOfInnerLayers", 2);
+  desc.addUntracked<unsigned int>("minTrackerSimHits", 3);
+}
+
 TrackClassifier const &TrackClassifier::evaluate(TrackingParticleRef const &track) {
   // Initializing the category vector
   reset();

--- a/SimTracker/TrackHistory/src/TrackHistory.cc
+++ b/SimTracker/TrackHistory/src/TrackHistory.cc
@@ -29,6 +29,15 @@ TrackHistory::TrackHistory(const edm::ParameterSet &config, edm::ConsumesCollect
   quality_ = 0.;
 }
 
+void TrackHistory::fillPSetDescription(edm::ParameterSetDescription &desc) {
+  desc.addUntracked<edm::InputTag>("trackProducer", edm::InputTag("generalTracks"));
+  desc.addUntracked<edm::InputTag>("trackingTruth", edm::InputTag("mix", "MergedTrackTruth"));
+  desc.addUntracked<edm::InputTag>("trackAssociator", edm::InputTag("quickTrackAssociatorByHits"));
+  desc.addUntracked<bool>("bestMatchByMaxValue", true);
+  desc.addUntracked<bool>("enableRecoToSim", true);
+  desc.addUntracked<bool>("enableSimToReco", false);
+}
+
 void TrackHistory::newEvent(const edm::Event &event, const edm::EventSetup &setup) {
   if (enableRecoToSim_ || enableSimToReco_) {
     // Track collection

--- a/SimTracker/TrackHistory/src/TrackQuality.cc
+++ b/SimTracker/TrackHistory/src/TrackQuality.cc
@@ -139,6 +139,10 @@ void TrackQuality::newEvent(const edm::Event &ev, const edm::EventSetup &es) {
   associator_ = std::make_unique<TrackerHitAssociator>(ev, trackerHitAssociatorConfig_);
 }
 
+void TrackQuality::fillPSetDescription(edm::ParameterSetDescription &desc) {
+  TrackerHitAssociator::fillPSetDescription(desc);
+}
+
 void TrackQuality::evaluate(SimParticleTrail const &spt, reco::TrackBaseRef const &tr, const TrackerTopology *tTopo) {
   std::vector<MatchedHit> matchedHits;
 

--- a/SimTracker/TrackHistory/src/VertexClassifier.cc
+++ b/SimTracker/TrackHistory/src/VertexClassifier.cc
@@ -45,6 +45,13 @@ void VertexClassifier::newEvent(edm::Event const &event, edm::EventSetup const &
   genPrimaryVertices();
 }
 
+void VertexClassifier::fillPSetDescription(edm::ParameterSetDescription &desc) {
+  VertexHistory::fillPSetDescription(desc);
+  desc.addUntracked<edm::InputTag>("hepMC", edm::InputTag("generatorSmeared"));
+  desc.addUntracked<double>("longLivedDecayLength", 1e-14);
+  desc.addUntracked<double>("vertexClusteringDistance", 0.003);
+}
+
 VertexClassifier const &VertexClassifier::evaluate(reco::VertexBaseRef const &vertex) {
   // Initializing the category vector
   reset();

--- a/SimTracker/TrackHistory/src/VertexHistory.cc
+++ b/SimTracker/TrackHistory/src/VertexHistory.cc
@@ -1,4 +1,3 @@
-
 #include "SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h"
 #include "SimDataFormats/Associations/interface/VertexToTrackingVertexAssociator.h"
 #include "SimTracker/TrackHistory/interface/VertexHistory.h"
@@ -29,6 +28,14 @@ VertexHistory::VertexHistory(const edm::ParameterSet &config, edm::ConsumesColle
   }
 
   quality_ = 0.;
+}
+
+void VertexHistory::fillPSetDescription(edm::ParameterSetDescription &desc) {
+  desc.addUntracked<edm::InputTag>("trackingTruth", edm::InputTag("mix", "MergedTrackTruth"));
+  desc.addUntracked<edm::InputTag>("vertexAssociator", edm::InputTag("vertexAssociatorByTracksByHits"));
+  desc.addUntracked<bool>("bestMatchByMaxValue", true);
+  desc.addUntracked<bool>("enableRecoToSim", true);
+  desc.addUntracked<bool>("enableSimToReco", false);
 }
 
 void VertexHistory::newEvent(const edm::Event &event, const edm::EventSetup &setup) {

--- a/Validation/RecoHI/plugins/HitPixelLayersTPSelector.h
+++ b/Validation/RecoHI/plugins/HitPixelLayersTPSelector.h
@@ -1,15 +1,15 @@
-#ifndef HitPixelLayersTrackSelection_h
-#define HitPixelLayersTrackSelection_h
+#ifndef Validation_RecoHI_HitPixelLayersTrackSelection_h
+#define Validation_RecoHI_HitPixelLayersTrackSelection_h
 
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h"
-
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
 /**
  Selector to select only tracking particles that leave hits in three pixel layers
@@ -44,6 +44,21 @@ public:
         tpStatusBased_(iConfig.getParameter<bool>("tpStatusBased")),
         pdgId_(iConfig.getParameter<std::vector<int> >("pdgId")),
         tTopoToken_(iC.esConsumes()) {}
+
+  static void fillPSetDescription(edm::ParameterSetDescription& desc) {
+    desc.add<bool>("tripletSeedOnly", true);
+    desc.add<double>("ptMin", 2.0);
+    desc.add<double>("minRapidity", -2.5);
+    desc.add<double>("maxRapidity", 2.5);
+    desc.add<double>("tip", 3.5);
+    desc.add<double>("lip", 30.0);
+    desc.add<int>("minHit", 8);
+    desc.add<bool>("signalOnly", false);
+    desc.add<bool>("chargedOnly", true);
+    desc.add<bool>("primaryOnly", true);
+    desc.add<bool>("tpStatusBased", true);
+    desc.add<std::vector<int> >("pdgId", {});
+  }
 
   // select object from a collection and
   // possibly event content

--- a/Validation/RecoParticleFlow/plugins/GenJetClosestMatchSelectorDefinition.h
+++ b/Validation/RecoParticleFlow/plugins/GenJetClosestMatchSelectorDefinition.h
@@ -1,14 +1,13 @@
-#ifndef PhysicsTools_PFCandProducer_GenJetClosestMatchSelectorDefinition
-#define PhysicsTools_PFCandProducer_GenJetClosestMatchSelectorDefinition
+#ifndef Validation_RecoParticleFlow_GenJetClosestMatchSelectorDefinition
+#define Validation_RecoParticleFlow_GenJetClosestMatchSelectorDefinition
 
+#include "DataFormats/JetReco/interface/GenJet.h"
+#include "DataFormats/Math/interface/deltaR.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-#include "DataFormats/JetReco/interface/GenJet.h"
-
-#include "DataFormats/Math/interface/deltaR.h"
 
 #include <iostream>
 
@@ -20,6 +19,10 @@ struct GenJetClosestMatchSelectorDefinition {
 
   GenJetClosestMatchSelectorDefinition(const edm::ParameterSet &cfg, edm::ConsumesCollector &&iC) {
     matchTo_ = iC.consumes<edm::View<reco::Candidate>>(cfg.getParameter<edm::InputTag>("MatchTo"));
+  }
+
+  static void fillPSetDescription(edm::ParameterSetDescription &desc) {
+    desc.add<edm::InputTag>("MatchTo", edm::InputTag(""));
   }
 
   const_iterator begin() const { return selected_.begin(); }

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -1080,7 +1080,7 @@ cutstring = "pt > 0.9"
 pixelTracksPt09 = trackRefSelector.clone( cut = cutstring )
 #pixelTracksPt09 = generalTracksPt09.clone(quality = ["undefQuality"], **_pixelTracksCustom)
 
-pixelTracksFromPV = generalTracksFromPV.clone(quality = "highPurity", ptMin = 0.0, ptMax = 99999., ptErrorCut = 99999., copyExtras = True, **_pixelTracksCustom)
+pixelTracksFromPV = generalTracksFromPV.clone(quality = "highPurity", ptMin = 0.0, ptMax = 99999., ptErrorCut = 99999., **_pixelTracksCustom)
 #pixelTracksFromPVPt09 = generalTracksPt09.clone(quality = ["loose","tight","highPurity"], vertexTag = "pixelVertices", src = "pixelTracksFromPV")
 pixelTracksFromPVPt09 = pixelTracksFromPV.clone(ptMin = 0.9)
 


### PR DESCRIPTION
#### PR description:

This PR is similar in spirit to https://github.com/cms-sw/cmssw/pull/47017, https://github.com/cms-sw/cmssw/pull/47045, https://github.com/cms-sw/cmssw/pull/47079, https://github.com/cms-sw/cmssw/pull/47107, https://github.com/cms-sw/cmssw/pull/47136 and https://github.com/cms-sw/cmssw/pull/47191. It adds `fillDescriptions` (and applies light modification to modernize the source code) to a few `EDProducer`s used at HLT for both Run 3 and Phase 2. 
   * unfortunately due to the inheritance structure of the general utility classes in the `CommonTools` subsystem the changes needed to be extended to a lot of other modules that are not used at HLT (commit https://github.com/cms-sw/cmssw/pull/47224/commits/083eb7b1f687e0cd88c5c07bcd2b6c69f4dd6cd7). 

#### PR validation:

   * `addOnTests.py` runs fine. 
   * `hltPhase2UpgradeIntegrationTests` runs fine. 
   * `runTheMatrix.py -l limited` runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A
