### PR TITLE
Remove default constructor from Alpaka EDProducer base classes

### DIFF
--- a/HeterogeneousCore/AlpakaCore/interface/alpaka/ProducerBase.h
+++ b/HeterogeneousCore/AlpakaCore/interface/alpaka/ProducerBase.h
@@ -46,8 +46,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     using Base = BaseT<Args..., edm::Transformer>;
 
   public:
-    // TODO: default constructor to be removed after all derived classes have been migrated
-    ProducerBase() : backendToken_(Base::produces("backend")) {}
     ProducerBase(edm::ParameterSet const& iConfig)
         : backendToken_(Base::produces("backend")),
           // The 'synchronize' parameter can be unset in Alpaka

--- a/HeterogeneousCore/AlpakaCore/interface/alpaka/global/EDProducer.h
+++ b/HeterogeneousCore/AlpakaCore/interface/alpaka/global/EDProducer.h
@@ -18,7 +18,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       using Base = ProducerBase<edm::global::EDProducer, Args...>;
 
     protected:
-      EDProducer() = default;  // to be removed in the near future
       EDProducer(edm::ParameterSet const iConfig) : Base(iConfig) {}
 
     public:

--- a/HeterogeneousCore/AlpakaCore/interface/alpaka/stream/EDProducer.h
+++ b/HeterogeneousCore/AlpakaCore/interface/alpaka/stream/EDProducer.h
@@ -18,7 +18,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       using Base = ProducerBase<edm::stream::EDProducer, Args...>;
 
     protected:
-      EDProducer() = default;  // to be removed in the near future
       EDProducer(edm::ParameterSet const iConfig) : Base(iConfig) {}
 
     public:

--- a/HeterogeneousCore/AlpakaCore/interface/alpaka/stream/SynchronizingEDProducer.h
+++ b/HeterogeneousCore/AlpakaCore/interface/alpaka/stream/SynchronizingEDProducer.h
@@ -21,7 +21,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       using Base = ProducerBase<edm::stream::EDProducer, edm::ExternalWork, Args...>;
 
     protected:
-      SynchronizingEDProducer() = default;  // to be removed in the near future
       SynchronizingEDProducer(edm::ParameterSet const iConfig) : Base(iConfig) {}
 
     public:


### PR DESCRIPTION
#### PR description:

Following https://github.com/cms-sw/cmssw/pull/47028 and https://github.com/cms-sw/cmssw/pull/47216 this PR removes the default constructor from Alpaka EDPRoducer base classes so that the behavior of `alpaka.synchronize` configuration parameter becomes well defined for all Alpaka modules.

Resolves https://github.com/cms-sw/framework-team/issues/1210

#### PR validation:

Code compiles (with https://github.com/cms-sw/cmssw/pull/47216)