### PR TITLE
Temporarily deactivate selfTest during integrate RPC geometry and isFront function modifications

### DIFF
--- a/RecoMuon/DetLayers/src/MuRingForwardDoubleLayer.cc
+++ b/RecoMuon/DetLayers/src/MuRingForwardDoubleLayer.cc
@@ -45,7 +45,7 @@ MuRingForwardDoubleLayer::MuRingForwardDoubleLayer(const vector<const ForwardDet
                     << " Z: " << specificSurface().position().z() << " R1: " << specificSurface().innerRadius()
                     << " R2: " << specificSurface().outerRadius();
 
-  selfTest();
+  // selfTest();
 }
 
 BoundDisk* MuRingForwardDoubleLayer::computeSurface() {


### PR DESCRIPTION
#### PR description:

Temporarily deactivate selfTest inside the constructor of MuonSystem's Endcap Geometry object class. 

This is to resolve errors that occur while updating and integrating all RPC geometries, scenarios, RPC isFront functions, and payloads.

The plan is to reactivate them after all updates and integrations are complete, and they are expected to work without issues.

For more details,
[Update of RPC geometry.pdf](https://indico.cern.ch/event/1507600/contributions/6349059/attachments/3006783/5300230/UpdateOfRPCGeometry_250131_JShin.pdf) - Simulation meeting in 31Jan2025

#### PR validation:

Use the runTheMatrix test workflows

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

nothing special