### PR TITLE
Dynamic Memory Allocation for LST Objects

### DIFF
--- a/RecoTracker/LSTCore/interface/PixelSegmentsHostCollection.h
+++ b/RecoTracker/LSTCore/interface/PixelSegmentsHostCollection.h
@@ -1,0 +1,10 @@
+#ifndef RecoTracker_LSTCore_interface_PixelSegmentsHostCollection_h
+#define RecoTracker_LSTCore_interface_PixelSegmentsHostCollection_h
+
+#include "RecoTracker/LSTCore/interface/PixelSegmentsSoA.h"
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+
+namespace lst {
+  using PixelSegmentsHostCollection = PortableHostCollection<PixelSegmentsSoA>;
+}  // namespace lst
+#endif

--- a/RecoTracker/LSTCore/interface/PixelSegmentsSoA.h
+++ b/RecoTracker/LSTCore/interface/PixelSegmentsSoA.h
@@ -1,0 +1,40 @@
+#ifndef RecoTracker_LSTCore_interface_PixelSegmentsSoA_h
+#define RecoTracker_LSTCore_interface_PixelSegmentsSoA_h
+
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+#include "DataFormats/Portable/interface/PortableCollection.h"
+
+#include "RecoTracker/LSTCore/interface/Common.h"
+
+namespace lst {
+
+  GENERATE_SOA_LAYOUT(PixelSegmentsSoALayout,
+                      SOA_COLUMN(unsigned int, seedIdx),
+                      SOA_COLUMN(int, charge),
+                      SOA_COLUMN(int, superbin),
+                      SOA_COLUMN(uint4, pLSHitsIdxs),
+                      SOA_COLUMN(PixelType, pixelType),
+                      SOA_COLUMN(char, isQuad),
+                      SOA_COLUMN(char, isDup),
+                      SOA_COLUMN(bool, partOfPT5),
+                      SOA_COLUMN(float, ptIn),
+                      SOA_COLUMN(float, ptErr),
+                      SOA_COLUMN(float, px),
+                      SOA_COLUMN(float, py),
+                      SOA_COLUMN(float, pz),
+                      SOA_COLUMN(float, etaErr),
+                      SOA_COLUMN(float, eta),
+                      SOA_COLUMN(float, phi),
+                      SOA_COLUMN(float, score),
+                      SOA_COLUMN(float, circleCenterX),
+                      SOA_COLUMN(float, circleCenterY),
+                      SOA_COLUMN(float, circleRadius))
+
+  using PixelSegmentsSoA = PixelSegmentsSoALayout<>;
+
+  using PixelSegments = PixelSegmentsSoA::View;
+  using PixelSegmentsConst = PixelSegmentsSoA::ConstView;
+
+}  // namespace lst
+
+#endif

--- a/RecoTracker/LSTCore/interface/SegmentsHostCollection.h
+++ b/RecoTracker/LSTCore/interface/SegmentsHostCollection.h
@@ -5,6 +5,6 @@
 #include "DataFormats/Portable/interface/PortableHostCollection.h"
 
 namespace lst {
-  using SegmentsHostCollection = PortableHostMultiCollection<SegmentsSoA, SegmentsOccupancySoA, SegmentsPixelSoA>;
+  using SegmentsHostCollection = PortableHostMultiCollection<SegmentsSoA, SegmentsOccupancySoA>;
 }  // namespace lst
 #endif

--- a/RecoTracker/LSTCore/interface/SegmentsSoA.h
+++ b/RecoTracker/LSTCore/interface/SegmentsSoA.h
@@ -25,38 +25,13 @@ namespace lst {
                       SOA_COLUMN(unsigned int, nSegments),  //number of segments per inner lower module
                       SOA_COLUMN(unsigned int, totOccupancySegments))
 
-  GENERATE_SOA_LAYOUT(SegmentsPixelSoALayout,
-                      SOA_COLUMN(unsigned int, seedIdx),
-                      SOA_COLUMN(int, charge),
-                      SOA_COLUMN(int, superbin),
-                      SOA_COLUMN(uint4, pLSHitsIdxs),
-                      SOA_COLUMN(PixelType, pixelType),
-                      SOA_COLUMN(char, isQuad),
-                      SOA_COLUMN(char, isDup),
-                      SOA_COLUMN(bool, partOfPT5),
-                      SOA_COLUMN(float, ptIn),
-                      SOA_COLUMN(float, ptErr),
-                      SOA_COLUMN(float, px),
-                      SOA_COLUMN(float, py),
-                      SOA_COLUMN(float, pz),
-                      SOA_COLUMN(float, etaErr),
-                      SOA_COLUMN(float, eta),
-                      SOA_COLUMN(float, phi),
-                      SOA_COLUMN(float, score),
-                      SOA_COLUMN(float, circleCenterX),
-                      SOA_COLUMN(float, circleCenterY),
-                      SOA_COLUMN(float, circleRadius))
-
   using SegmentsSoA = SegmentsSoALayout<>;
   using SegmentsOccupancySoA = SegmentsOccupancySoALayout<>;
-  using SegmentsPixelSoA = SegmentsPixelSoALayout<>;
 
   using Segments = SegmentsSoA::View;
   using SegmentsConst = SegmentsSoA::ConstView;
   using SegmentsOccupancy = SegmentsOccupancySoA::View;
   using SegmentsOccupancyConst = SegmentsOccupancySoA::ConstView;
-  using SegmentsPixel = SegmentsPixelSoA::View;
-  using SegmentsPixelConst = SegmentsPixelSoA::ConstView;
 
 }  // namespace lst
 

--- a/RecoTracker/LSTCore/interface/alpaka/PixelSegmentsDeviceCollection.h
+++ b/RecoTracker/LSTCore/interface/alpaka/PixelSegmentsDeviceCollection.h
@@ -1,0 +1,13 @@
+#ifndef RecoTracker_LSTCore_interface_alpaka_PixelSegmentsDeviceCollection_h
+#define RecoTracker_LSTCore_interface_alpaka_PixelSegmentsDeviceCollection_h
+
+#include "DataFormats/Portable/interface/alpaka/PortableCollection.h"
+
+#include "RecoTracker/LSTCore/interface/alpaka/Common.h"
+#include "RecoTracker/LSTCore/interface/PixelSegmentsSoA.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
+  using PixelSegmentsDeviceCollection = PortableCollection<PixelSegmentsSoA>;
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::lst
+
+#endif

--- a/RecoTracker/LSTCore/interface/alpaka/SegmentsDeviceCollection.h
+++ b/RecoTracker/LSTCore/interface/alpaka/SegmentsDeviceCollection.h
@@ -7,7 +7,7 @@
 #include "RecoTracker/LSTCore/interface/SegmentsSoA.h"
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
-  using SegmentsDeviceCollection = PortableCollection3<SegmentsSoA, SegmentsOccupancySoA, SegmentsPixelSoA>;
+  using SegmentsDeviceCollection = PortableCollection2<SegmentsSoA, SegmentsOccupancySoA>;
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE::lst
 
 #endif

--- a/RecoTracker/LSTCore/src/alpaka/LST.cc
+++ b/RecoTracker/LSTCore/src/alpaka/LST.cc
@@ -302,24 +302,19 @@ void LST::run(Queue& queue,
                ptCut);
 
   event.addHitToEvent(in_trkX_, in_trkY_, in_trkZ_, in_hitId_, in_hitIdxs_);
-  event.addPixelSegmentToEvent(in_hitIndices_vec0_,
-                               in_hitIndices_vec1_,
-                               in_hitIndices_vec2_,
-                               in_hitIndices_vec3_,
-                               in_deltaPhi_vec_,
-                               in_ptIn_vec_,
-                               in_ptErr_vec_,
-                               in_px_vec_,
-                               in_py_vec_,
-                               in_pz_vec_,
-                               in_eta_vec_,
-                               in_etaErr_vec_,
-                               in_phi_vec_,
-                               in_charge_vec_,
-                               in_seedIdx_vec_,
-                               in_superbin_vec_,
-                               in_pixelType_vec_,
-                               in_isQuad_vec_);
+  event.addPixelSegmentToEventStart(in_ptIn_vec_,
+                                    in_ptErr_vec_,
+                                    in_px_vec_,
+                                    in_py_vec_,
+                                    in_pz_vec_,
+                                    in_eta_vec_,
+                                    in_etaErr_vec_,
+                                    in_phi_vec_,
+                                    in_charge_vec_,
+                                    in_seedIdx_vec_,
+                                    in_superbin_vec_,
+                                    in_pixelType_vec_,
+                                    in_isQuad_vec_);
   event.createMiniDoublets();
   if (verbose) {
     alpaka::wait(queue);  // event calls are asynchronous: wait before printing
@@ -387,6 +382,9 @@ void LST::run(Queue& queue,
     printf("# of Quintuplets produced endcap layer 4: %d\n", event.getNumberOfQuintupletsByLayerEndcap(3));
     printf("# of Quintuplets produced endcap layer 5: %d\n", event.getNumberOfQuintupletsByLayerEndcap(4));
   }
+
+  event.addPixelSegmentToEventFinalize(
+      in_hitIndices_vec0_, in_hitIndices_vec1_, in_hitIndices_vec2_, in_hitIndices_vec3_, in_deltaPhi_vec_);
 
   event.pixelLineSegmentCleaning(no_pls_dupclean);
 

--- a/RecoTracker/LSTCore/src/alpaka/LSTEvent.h
+++ b/RecoTracker/LSTCore/src/alpaka/LSTEvent.h
@@ -9,6 +9,7 @@
 #include "RecoTracker/LSTCore/interface/PixelTripletsHostCollection.h"
 #include "RecoTracker/LSTCore/interface/QuintupletsHostCollection.h"
 #include "RecoTracker/LSTCore/interface/SegmentsHostCollection.h"
+#include "RecoTracker/LSTCore/interface/PixelSegmentsHostCollection.h"
 #include "RecoTracker/LSTCore/interface/TrackCandidatesHostCollection.h"
 #include "RecoTracker/LSTCore/interface/TripletsHostCollection.h"
 #include "RecoTracker/LSTCore/interface/ObjectRangesHostCollection.h"
@@ -21,6 +22,7 @@
 #include "RecoTracker/LSTCore/interface/alpaka/PixelTripletsDeviceCollection.h"
 #include "RecoTracker/LSTCore/interface/alpaka/QuintupletsDeviceCollection.h"
 #include "RecoTracker/LSTCore/interface/alpaka/SegmentsDeviceCollection.h"
+#include "RecoTracker/LSTCore/interface/alpaka/PixelSegmentsDeviceCollection.h"
 #include "RecoTracker/LSTCore/interface/alpaka/TrackCandidatesDeviceCollection.h"
 #include "RecoTracker/LSTCore/interface/alpaka/TripletsDeviceCollection.h"
 #include "RecoTracker/LSTCore/interface/alpaka/ModulesDeviceCollection.h"
@@ -45,12 +47,15 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     std::array<unsigned int, 6> n_quintuplets_by_layer_barrel_{};
     std::array<unsigned int, 5> n_quintuplets_by_layer_endcap_{};
     unsigned int nTotalSegments_;
+    unsigned int pixelSize_;
+    uint16_t pixelModuleIndex_;
 
     //Device stuff
     std::optional<ObjectRangesDeviceCollection> rangesDC_;
     std::optional<HitsDeviceCollection> hitsDC_;
     std::optional<MiniDoubletsDeviceCollection> miniDoubletsDC_;
     std::optional<SegmentsDeviceCollection> segmentsDC_;
+    std::optional<PixelSegmentsDeviceCollection> pixelSegmentsDC_;
     std::optional<TripletsDeviceCollection> tripletsDC_;
     std::optional<QuintupletsDeviceCollection> quintupletsDC_;
     std::optional<TrackCandidatesDeviceCollection> trackCandidatesDC_;
@@ -62,6 +67,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     std::optional<HitsHostCollection> hitsHC_;
     std::optional<MiniDoubletsHostCollection> miniDoubletsHC_;
     std::optional<SegmentsHostCollection> segmentsHC_;
+    std::optional<PixelSegmentsHostCollection> pixelSegmentsHC_;
     std::optional<TripletsHostCollection> tripletsHC_;
     std::optional<TrackCandidatesHostCollection> trackCandidatesHC_;
     std::optional<ModulesHostCollection> modulesHC_;
@@ -106,26 +112,26 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                        std::vector<float> const& z,
                        std::vector<unsigned int> const& detId,
                        std::vector<unsigned int> const& idxInNtuple);
-    void addPixelSegmentToEvent(std::vector<unsigned int> const& hitIndices0,
-                                std::vector<unsigned int> const& hitIndices1,
-                                std::vector<unsigned int> const& hitIndices2,
-                                std::vector<unsigned int> const& hitIndices3,
-                                std::vector<float> const& dPhiChange,
-                                std::vector<float> const& ptIn,
-                                std::vector<float> const& ptErr,
-                                std::vector<float> const& px,
-                                std::vector<float> const& py,
-                                std::vector<float> const& pz,
-                                std::vector<float> const& eta,
-                                std::vector<float> const& etaErr,
-                                std::vector<float> const& phi,
-                                std::vector<int> const& charge,
-                                std::vector<unsigned int> const& seedIdx,
-                                std::vector<int> const& superbin,
-                                std::vector<PixelType> const& pixelType,
-                                std::vector<char> const& isQuad);
+    void addPixelSegmentToEventStart(std::vector<float> const& ptIn,
+                                     std::vector<float> const& ptErr,
+                                     std::vector<float> const& px,
+                                     std::vector<float> const& py,
+                                     std::vector<float> const& pz,
+                                     std::vector<float> const& eta,
+                                     std::vector<float> const& etaErr,
+                                     std::vector<float> const& phi,
+                                     std::vector<int> const& charge,
+                                     std::vector<unsigned int> const& seedIdx,
+                                     std::vector<int> const& superbin,
+                                     std::vector<PixelType> const& pixelType,
+                                     std::vector<char> const& isQuad);
 
     void createMiniDoublets();
+    void addPixelSegmentToEventFinalize(std::vector<unsigned int> hitIndices0,
+                                        std::vector<unsigned int> hitIndices1,
+                                        std::vector<unsigned int> hitIndices2,
+                                        std::vector<unsigned int> hitIndices3,
+                                        std::vector<float> deltaPhi_vec);
     void createSegmentsWithModuleMap();
     void createTriplets();
     void createTrackCandidates(bool no_pls_dupclean, bool tc_pls_triplets);
@@ -185,6 +191,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     typename TSoA::ConstView getQuintuplets(bool sync = true);
     template <typename TDev = Device>
     PixelTripletsConst getPixelTriplets(bool sync = true);
+    template <typename TDev = Device>
+    PixelSegmentsConst getPixelSegments(bool sync = true);
     template <typename TDev = Device>
     PixelQuintupletsConst getPixelQuintuplets(bool sync = true);
     const TrackCandidatesConst& getTrackCandidates(bool inCMSSW = false, bool sync = true);

--- a/RecoTracker/LSTCore/src/alpaka/PixelQuintuplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/PixelQuintuplet.h
@@ -7,6 +7,7 @@
 #include "RecoTracker/LSTCore/interface/ObjectRangesSoA.h"
 #include "RecoTracker/LSTCore/interface/MiniDoubletsSoA.h"
 #include "RecoTracker/LSTCore/interface/PixelTripletsSoA.h"
+#include "RecoTracker/LSTCore/interface/PixelSegmentsSoA.h"
 #include "RecoTracker/LSTCore/interface/QuintupletsSoA.h"
 #include "RecoTracker/LSTCore/interface/SegmentsSoA.h"
 #include "RecoTracker/LSTCore/interface/TripletsSoA.h"
@@ -469,7 +470,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                                                     ObjectRangesConst ranges,
                                                                     MiniDoubletsConst mds,
                                                                     SegmentsConst segments,
-                                                                    SegmentsPixelConst segmentsPixel,
+                                                                    PixelSegmentsConst pixelSegments,
                                                                     TripletsConst triplets,
                                                                     QuintupletsConst quintuplets,
                                                                     unsigned int pixelSegmentIndex,
@@ -494,7 +495,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                        ranges,
                                        mds,
                                        segments,
-                                       segmentsPixel,
+                                       pixelSegments,
                                        triplets,
                                        pixelSegmentIndex,
                                        t5InnerT3Index,
@@ -546,16 +547,16 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                      mds.anchorRt()[fourthMDIndex],
                                      mds.anchorRt()[fifthMDIndex]};
 
-    float pixelSegmentPt = segmentsPixel.ptIn()[pixelSegmentArrayIndex];
-    float pixelSegmentPx = segmentsPixel.px()[pixelSegmentArrayIndex];
-    float pixelSegmentPy = segmentsPixel.py()[pixelSegmentArrayIndex];
-    float pixelSegmentPz = segmentsPixel.pz()[pixelSegmentArrayIndex];
-    int pixelSegmentCharge = segmentsPixel.charge()[pixelSegmentArrayIndex];
+    float pixelSegmentPt = pixelSegments.ptIn()[pixelSegmentArrayIndex];
+    float pixelSegmentPx = pixelSegments.px()[pixelSegmentArrayIndex];
+    float pixelSegmentPy = pixelSegments.py()[pixelSegmentArrayIndex];
+    float pixelSegmentPz = pixelSegments.pz()[pixelSegmentArrayIndex];
+    int pixelSegmentCharge = pixelSegments.charge()[pixelSegmentArrayIndex];
 
     rzChiSquared = 0;
 
     //get the appropriate centers
-    pixelRadius = segmentsPixel.circleRadius()[pixelSegmentArrayIndex];
+    pixelRadius = pixelSegments.circleRadius()[pixelSegmentArrayIndex];
 
     if (pixelRadius < 5.0f * kR1GeVf) {  //only apply r-z chi2 cuts for <5GeV tracks
       rzChiSquared = computePT5RZChiSquared(acc,
@@ -595,8 +596,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                     mds.anchorY()[fifthMDIndex]};
 
     //get the appropriate centers
-    centerX = segmentsPixel.circleCenterX()[pixelSegmentArrayIndex];
-    centerY = segmentsPixel.circleCenterY()[pixelSegmentArrayIndex];
+    centerX = pixelSegments.circleCenterX()[pixelSegmentArrayIndex];
+    centerY = pixelSegments.circleCenterY()[pixelSegmentArrayIndex];
 
     float T5CenterX = quintuplets.regressionCenterX()[quintupletIndex];
     float T5CenterY = quintuplets.regressionCenterY()[quintupletIndex];
@@ -640,7 +641,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                   ModulesPixelConst modulesPixel,
                                   MiniDoubletsConst mds,
                                   SegmentsConst segments,
-                                  SegmentsPixel segmentsPixel,
+                                  PixelSegments pixelSegments,
                                   Triplets triplets,
                                   Quintuplets quintuplets,
                                   QuintupletsOccupancyConst quintupletsOccupancy,
@@ -661,7 +662,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
           if (modules.moduleType()[quintupletLowerModuleIndex] == TwoS)
             continue;
           uint16_t pixelModuleIndex = modules.nLowerModules();
-          if (segmentsPixel.isDup()[i_pLS])
+          if (pixelSegments.isDup()[i_pLS])
             continue;
           unsigned int nOuterQuintuplets = quintupletsOccupancy.nQuintuplets()[quintupletLowerModuleIndex];
 
@@ -685,7 +686,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                                          ranges,
                                                          mds,
                                                          segments,
-                                                         segmentsPixel,
+                                                         pixelSegments,
                                                          triplets,
                                                          quintuplets,
                                                          pixelSegmentIndex,
@@ -733,7 +734,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
 
                 triplets.partOfPT5()[quintuplets.tripletIndices()[quintupletIndex][0]] = true;
                 triplets.partOfPT5()[quintuplets.tripletIndices()[quintupletIndex][1]] = true;
-                segmentsPixel.partOfPT5()[i_pLS] = true;
+                pixelSegments.partOfPT5()[i_pLS] = true;
                 quintuplets.partOfPT5()[quintupletIndex] = true;
               }  // tot occupancy
             }  // end success

--- a/RecoTracker/LSTCore/src/alpaka/PixelTriplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/PixelTriplet.h
@@ -6,6 +6,7 @@
 #include "RecoTracker/LSTCore/interface/ObjectRangesSoA.h"
 #include "RecoTracker/LSTCore/interface/MiniDoubletsSoA.h"
 #include "RecoTracker/LSTCore/interface/PixelTripletsSoA.h"
+#include "RecoTracker/LSTCore/interface/PixelSegmentsSoA.h"
 #include "RecoTracker/LSTCore/interface/QuintupletsSoA.h"
 #include "RecoTracker/LSTCore/interface/SegmentsSoA.h"
 #include "RecoTracker/LSTCore/interface/TripletsSoA.h"
@@ -20,7 +21,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                                                 ObjectRangesConst ranges,
                                                                 MiniDoubletsConst mds,
                                                                 SegmentsConst segments,
-                                                                SegmentsPixelConst segmentsPixel,
+                                                                PixelSegmentsConst pixelSegments,
                                                                 uint16_t pixelModuleIndex,
                                                                 uint16_t outerInnerLowerModuleIndex,
                                                                 uint16_t outerOuterLowerModuleIndex,
@@ -37,7 +38,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                                                 ObjectRangesConst ranges,
                                                                 MiniDoubletsConst mds,
                                                                 SegmentsConst segments,
-                                                                SegmentsPixelConst segmentsPixel,
+                                                                PixelSegmentsConst pixelSegments,
                                                                 uint16_t pixelModuleIndex,
                                                                 uint16_t outerInnerLowerModuleIndex,
                                                                 uint16_t outerOuterLowerModuleIndex,
@@ -120,7 +121,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                                                      ObjectRangesConst ranges,
                                                                      MiniDoubletsConst mds,
                                                                      SegmentsConst segments,
-                                                                     SegmentsPixelConst segmentsPixel,
+                                                                     PixelSegmentsConst pixelSegments,
                                                                      uint16_t pixelLowerModuleIndex,
                                                                      uint16_t outerInnerLowerModuleIndex,
                                                                      uint16_t outerOuterLowerModuleIndex,
@@ -143,7 +144,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                        ranges,
                                        mds,
                                        segments,
-                                       segmentsPixel,
+                                       pixelSegments,
                                        pixelLowerModuleIndex,
                                        outerInnerLowerModuleIndex,
                                        outerOuterLowerModuleIndex,
@@ -160,7 +161,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                        ranges,
                                        mds,
                                        segments,
-                                       segmentsPixel,
+                                       pixelSegments,
                                        pixelLowerModuleIndex,
                                        outerInnerLowerModuleIndex,
                                        outerOuterLowerModuleIndex,
@@ -633,7 +634,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                                                  ObjectRangesConst ranges,
                                                                  MiniDoubletsConst mds,
                                                                  SegmentsConst segments,
-                                                                 SegmentsPixelConst segmentsPixel,
+                                                                 PixelSegmentsConst pixelSegments,
                                                                  TripletsConst triplets,
                                                                  unsigned int pixelSegmentIndex,
                                                                  unsigned int tripletIndex,
@@ -660,7 +661,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                              ranges,
                                              mds,
                                              segments,
-                                             segmentsPixel,
+                                             pixelSegments,
                                              pixelModuleIndex,
                                              lowerModuleIndex,
                                              middleModuleIndex,
@@ -675,7 +676,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                              ranges,
                                              mds,
                                              segments,
-                                             segmentsPixel,
+                                             pixelSegments,
                                              pixelModuleIndex,
                                              middleModuleIndex,
                                              upperModuleIndex,
@@ -687,16 +688,16 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
 
     //pt matching between the pixel ptin and the triplet circle pt
     unsigned int pixelSegmentArrayIndex = pixelSegmentIndex - ranges.segmentModuleIndices()[pixelModuleIndex];
-    float pixelSegmentPt = segmentsPixel.ptIn()[pixelSegmentArrayIndex];
-    float pixelSegmentPtError = segmentsPixel.ptErr()[pixelSegmentArrayIndex];
-    float pixelSegmentPx = segmentsPixel.px()[pixelSegmentArrayIndex];
-    float pixelSegmentPy = segmentsPixel.py()[pixelSegmentArrayIndex];
-    float pixelSegmentPz = segmentsPixel.pz()[pixelSegmentArrayIndex];
-    int pixelSegmentCharge = segmentsPixel.charge()[pixelSegmentArrayIndex];
+    float pixelSegmentPt = pixelSegments.ptIn()[pixelSegmentArrayIndex];
+    float pixelSegmentPtError = pixelSegments.ptErr()[pixelSegmentArrayIndex];
+    float pixelSegmentPx = pixelSegments.px()[pixelSegmentArrayIndex];
+    float pixelSegmentPy = pixelSegments.py()[pixelSegmentArrayIndex];
+    float pixelSegmentPz = pixelSegments.pz()[pixelSegmentArrayIndex];
+    int pixelSegmentCharge = pixelSegments.charge()[pixelSegmentArrayIndex];
 
-    float pixelG = segmentsPixel.circleCenterX()[pixelSegmentArrayIndex];
-    float pixelF = segmentsPixel.circleCenterY()[pixelSegmentArrayIndex];
-    float pixelRadiusPCA = segmentsPixel.circleRadius()[pixelSegmentArrayIndex];
+    float pixelG = pixelSegments.circleCenterX()[pixelSegmentArrayIndex];
+    float pixelF = pixelSegments.circleCenterY()[pixelSegmentArrayIndex];
+    float pixelRadiusPCA = pixelSegments.circleRadius()[pixelSegmentArrayIndex];
 
     unsigned int pixelInnerMDIndex = segments.mdIndices()[pixelSegmentIndex][0];
     unsigned int pixelOuterMDIndex = segments.mdIndices()[pixelSegmentIndex][1];
@@ -792,7 +793,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                   ObjectRangesConst ranges,
                                   MiniDoubletsConst mds,
                                   SegmentsConst segments,
-                                  SegmentsPixelConst segmentsPixel,
+                                  PixelSegmentsConst pixelSegments,
                                   Triplets triplets,
                                   TripletsOccupancyConst tripletsOccupancy,
                                   PixelTriplets pixelTriplets,
@@ -827,9 +828,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
 
           unsigned int pixelSegmentIndex = ranges.segmentModuleIndices()[pixelModuleIndex] + i_pLS;
 
-          if (segmentsPixel.isDup()[i_pLS])
+          if (pixelSegments.isDup()[i_pLS])
             continue;
-          if (segmentsPixel.partOfPT5()[i_pLS])
+          if (pixelSegments.partOfPT5()[i_pLS])
             continue;  //don't make pT3s for those pixels that are part of pT5
 
           short layer2_adjustment;
@@ -859,7 +860,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                                       ranges,
                                                       mds,
                                                       segments,
-                                                      segmentsPixel,
+                                                      pixelSegments,
                                                       triplets,
                                                       pixelSegmentIndex,
                                                       outerTripletIndex,
@@ -879,9 +880,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
               float eta =
                   mds.anchorEta()[segments
                                       .mdIndices()[triplets.segmentIndices()[outerTripletIndex][0]][layer2_adjustment]];
-              float eta_pix = segmentsPixel.eta()[i_pLS];
-              float phi_pix = segmentsPixel.phi()[i_pLS];
-              float pt = segmentsPixel.ptIn()[i_pLS];
+              float eta_pix = pixelSegments.eta()[i_pLS];
+              float phi_pix = pixelSegments.phi()[i_pLS];
+              float pt = pixelSegments.ptIn()[i_pLS];
               float score = rPhiChiSquared + rPhiChiSquaredInwards;
               unsigned int totOccupancyPixelTriplets =
                   alpaka::atomicAdd(acc, &pixelTriplets.totOccupancyPixelTriplets(), 1u, alpaka::hierarchy::Threads{});
@@ -927,7 +928,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                                                 ObjectRangesConst ranges,
                                                                 MiniDoubletsConst mds,
                                                                 SegmentsConst segments,
-                                                                SegmentsPixelConst segmentsPixel,
+                                                                PixelSegmentsConst pixelSegments,
                                                                 uint16_t pixelModuleIndex,
                                                                 uint16_t outerInnerLowerModuleIndex,
                                                                 uint16_t outerOuterLowerModuleIndex,
@@ -966,13 +967,13 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
       return false;
 
     unsigned int pixelSegmentArrayIndex = innerSegmentIndex - ranges.segmentModuleIndices()[pixelModuleIndex];
-    float ptIn = segmentsPixel.ptIn()[pixelSegmentArrayIndex];
+    float ptIn = pixelSegments.ptIn()[pixelSegmentArrayIndex];
     float ptSLo = ptIn;
-    float px = segmentsPixel.px()[pixelSegmentArrayIndex];
-    float py = segmentsPixel.py()[pixelSegmentArrayIndex];
-    float pz = segmentsPixel.pz()[pixelSegmentArrayIndex];
-    float ptErr = segmentsPixel.ptErr()[pixelSegmentArrayIndex];
-    float etaErr = segmentsPixel.etaErr()[pixelSegmentArrayIndex];
+    float px = pixelSegments.px()[pixelSegmentArrayIndex];
+    float py = pixelSegments.py()[pixelSegmentArrayIndex];
+    float pz = pixelSegments.pz()[pixelSegmentArrayIndex];
+    float ptErr = pixelSegments.ptErr()[pixelSegmentArrayIndex];
+    float etaErr = pixelSegments.etaErr()[pixelSegmentArrayIndex];
     ptSLo = alpaka::math::max(acc, ptCut, ptSLo - 10.0f * alpaka::math::max(acc, ptErr, 0.005f * ptSLo));
     ptSLo = alpaka::math::min(acc, 10.0f, ptSLo);
 
@@ -1186,7 +1187,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                                                 ObjectRangesConst ranges,
                                                                 MiniDoubletsConst mds,
                                                                 SegmentsConst segments,
-                                                                SegmentsPixelConst segmentsPixel,
+                                                                PixelSegmentsConst pixelSegments,
                                                                 uint16_t pixelModuleIndex,
                                                                 uint16_t outerInnerLowerModuleIndex,
                                                                 uint16_t outerOuterLowerModuleIndex,
@@ -1224,13 +1225,13 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
 
     unsigned int pixelSegmentArrayIndex = innerSegmentIndex - ranges.segmentModuleIndices()[pixelModuleIndex];
 
-    float ptIn = segmentsPixel.ptIn()[pixelSegmentArrayIndex];
+    float ptIn = pixelSegments.ptIn()[pixelSegmentArrayIndex];
     float ptSLo = ptIn;
-    float px = segmentsPixel.px()[pixelSegmentArrayIndex];
-    float py = segmentsPixel.py()[pixelSegmentArrayIndex];
-    float pz = segmentsPixel.pz()[pixelSegmentArrayIndex];
-    float ptErr = segmentsPixel.ptErr()[pixelSegmentArrayIndex];
-    float etaErr = segmentsPixel.etaErr()[pixelSegmentArrayIndex];
+    float px = pixelSegments.px()[pixelSegmentArrayIndex];
+    float py = pixelSegments.py()[pixelSegmentArrayIndex];
+    float pz = pixelSegments.pz()[pixelSegmentArrayIndex];
+    float ptErr = pixelSegments.ptErr()[pixelSegmentArrayIndex];
+    float etaErr = pixelSegments.etaErr()[pixelSegmentArrayIndex];
 
     ptSLo = alpaka::math::max(acc, ptCut, ptSLo - 10.0f * alpaka::math::max(acc, ptErr, 0.005f * ptSLo));
     ptSLo = alpaka::math::min(acc, 10.0f, ptSLo);

--- a/RecoTracker/LSTCore/standalone/bin/lst.cc
+++ b/RecoTracker/LSTCore/standalone/bin/lst.cc
@@ -430,11 +430,6 @@ void run_lst() {
                                                      out_trkZ.at(evt),
                                                      out_hitId.at(evt),
                                                      out_hitIdxs.at(evt),
-                                                     out_hitIndices_vec0.at(evt),
-                                                     out_hitIndices_vec1.at(evt),
-                                                     out_hitIndices_vec2.at(evt),
-                                                     out_hitIndices_vec3.at(evt),
-                                                     out_deltaPhi_vec.at(evt),
                                                      out_ptIn_vec.at(evt),
                                                      out_ptErr_vec.at(evt),
                                                      out_px_vec.at(evt),
@@ -453,7 +448,15 @@ void run_lst() {
       timing_LS = runSegment(events.at(omp_get_thread_num()));
       timing_T3 = runT3(events.at(omp_get_thread_num()));
       timing_T5 = runQuintuplet(events.at(omp_get_thread_num()));
-      timing_pLS = runPixelLineSegment(events.at(omp_get_thread_num()), ana.no_pls_dupclean);
+
+      timing_pLS = runPixelLineSegment(events.at(omp_get_thread_num()),
+                                       out_hitIndices_vec0.at(evt),
+                                       out_hitIndices_vec1.at(evt),
+                                       out_hitIndices_vec2.at(evt),
+                                       out_hitIndices_vec3.at(evt),
+                                       out_deltaPhi_vec.at(evt),
+                                       ana.no_pls_dupclean);
+
       timing_pT5 = runPixelQuintuplet(events.at(omp_get_thread_num()));
       timing_pT3 = runpT3(events.at(omp_get_thread_num()));
       timing_TC = runTrackCandidate(events.at(omp_get_thread_num()), ana.no_pls_dupclean, ana.tc_pls_triplets);

--- a/RecoTracker/LSTCore/standalone/code/core/trkCore.cc
+++ b/RecoTracker/LSTCore/standalone/code/core/trkCore.cc
@@ -216,11 +216,19 @@ float runQuintuplet(LSTEvent *event) {
 }
 
 //___________________________________________________________________________________________________________________________________________________________________________________________
-float runPixelLineSegment(LSTEvent *event, bool no_pls_dupclean) {
+float runPixelLineSegment(LSTEvent *event,
+                          std::vector<unsigned int> hitIndices_vec0,
+                          std::vector<unsigned int> hitIndices_vec1,
+                          std::vector<unsigned int> hitIndices_vec2,
+                          std::vector<unsigned int> hitIndices_vec3,
+                          std::vector<float> deltaPhi_vec,
+                          bool no_pls_dupclean) {
   TStopwatch my_timer;
   if (ana.verbose >= 2)
     std::cout << "Reco Pixel Line Segment start" << std::endl;
   my_timer.Start();
+  event->addPixelSegmentToEventFinalize(
+      hitIndices_vec0, hitIndices_vec1, hitIndices_vec2, hitIndices_vec3, deltaPhi_vec);
   event->pixelLineSegmentCleaning(no_pls_dupclean);
   event->wait();  // device side event calls are asynchronous: wait to measure time or print
   float pls_elapsed = my_timer.RealTime();
@@ -860,11 +868,6 @@ float addInputsToEventPreLoad(LSTEvent *event,
                               std::vector<float> trkZ,
                               std::vector<unsigned int> hitId,
                               std::vector<unsigned int> hitIdxs,
-                              std::vector<unsigned int> hitIndices_vec0,
-                              std::vector<unsigned int> hitIndices_vec1,
-                              std::vector<unsigned int> hitIndices_vec2,
-                              std::vector<unsigned int> hitIndices_vec3,
-                              std::vector<float> deltaPhi_vec,
                               std::vector<float> ptIn_vec,
                               std::vector<float> ptErr_vec,
                               std::vector<float> px_vec,
@@ -888,24 +891,19 @@ float addInputsToEventPreLoad(LSTEvent *event,
 
   event->addHitToEvent(trkX, trkY, trkZ, hitId, hitIdxs);
 
-  event->addPixelSegmentToEvent(hitIndices_vec0,
-                                hitIndices_vec1,
-                                hitIndices_vec2,
-                                hitIndices_vec3,
-                                deltaPhi_vec,
-                                ptIn_vec,
-                                ptErr_vec,
-                                px_vec,
-                                py_vec,
-                                pz_vec,
-                                eta_vec,
-                                etaErr_vec,
-                                phi_vec,
-                                charge_vec,
-                                seedIdx_vec,
-                                superbin_vec,
-                                pixelType_vec,
-                                isQuad_vec);
+  event->addPixelSegmentToEventStart(ptIn_vec,
+                                     ptErr_vec,
+                                     px_vec,
+                                     py_vec,
+                                     pz_vec,
+                                     eta_vec,
+                                     etaErr_vec,
+                                     phi_vec,
+                                     charge_vec,
+                                     seedIdx_vec,
+                                     superbin_vec,
+                                     pixelType_vec,
+                                     isQuad_vec);
   event->wait();  // device side event calls are asynchronous: wait to measure time or print
   float hit_loading_elapsed = my_timer.RealTime();
 

--- a/RecoTracker/LSTCore/standalone/code/core/trkCore.h
+++ b/RecoTracker/LSTCore/standalone/code/core/trkCore.h
@@ -27,7 +27,13 @@ float runT3(LSTEvent *event);
 float runTrackCandidate(LSTEvent *event, bool no_pls_dupclean, bool tc_pls_triplets);
 float runQuintuplet(LSTEvent *event);
 float runPixelQuintuplet(LSTEvent *event);
-float runPixelLineSegment(LSTEvent *event, bool no_pls_dupclean);
+float runPixelLineSegment(LSTEvent *event,
+                          std::vector<unsigned int> hitIndices_vec0,
+                          std::vector<unsigned int> hitIndices_vec1,
+                          std::vector<unsigned int> hitIndices_vec2,
+                          std::vector<unsigned int> hitIndices_vec3,
+                          std::vector<float> deltaPhi_vec,
+                          bool no_pls_dupclean);
 float runpT3(LSTEvent *event);
 
 // --------------------- ======================== ---------------------
@@ -81,11 +87,6 @@ float addInputsToEventPreLoad(LSTEvent *event,
                               std::vector<float> trkZ,
                               std::vector<unsigned int> hitId,
                               std::vector<unsigned int> hitIdxs,
-                              std::vector<unsigned int> hitIndices_vec0,
-                              std::vector<unsigned int> hitIndices_vec1,
-                              std::vector<unsigned int> hitIndices_vec2,
-                              std::vector<unsigned int> hitIndices_vec3,
-                              std::vector<float> deltaPhi_vec,
                               std::vector<float> ptIn_vec,
                               std::vector<float> ptErr_vec,
                               std::vector<float> px_vec,

--- a/RecoTracker/LSTCore/standalone/code/core/write_lst_ntuple.cc
+++ b/RecoTracker/LSTCore/standalone/code/core/write_lst_ntuple.cc
@@ -411,7 +411,7 @@ void setPixelQuintupletOutputBranches(LSTEvent* event) {
   // ============ pT5 =============
   auto const pixelQuintuplets = event->getPixelQuintuplets();
   auto const quintuplets = event->getQuintuplets<QuintupletsSoA>();
-  auto const segmentsPixel = event->getSegments<SegmentsPixelSoA>();
+  auto const pixelSegments = event->getPixelSegments();
   auto modules = event->getModules<ModulesSoA>();
   int n_accepted_simtrk = ana.tx->getBranch<std::vector<int>>("sim_TC_matched").size();
 
@@ -422,9 +422,9 @@ void setPixelQuintupletOutputBranches(LSTEvent* event) {
   for (unsigned int pT5 = 0; pT5 < nPixelQuintuplets; pT5++) {
     unsigned int T5Index = getT5FrompT5(event, pT5);
     unsigned int pLSIndex = getPixelLSFrompT5(event, pT5);
-    float pt = (__H2F(quintuplets.innerRadius()[T5Index]) * k2Rinv1GeVf * 2 + segmentsPixel.ptIn()[pLSIndex]) / 2;
-    float eta = segmentsPixel.eta()[pLSIndex];
-    float phi = segmentsPixel.phi()[pLSIndex];
+    float pt = (__H2F(quintuplets.innerRadius()[T5Index]) * k2Rinv1GeVf * 2 + pixelSegments.ptIn()[pLSIndex]) / 2;
+    float eta = pixelSegments.eta()[pLSIndex];
+    float phi = pixelSegments.phi()[pLSIndex];
 
     std::vector<unsigned int> hit_idx = getHitIdxsFrompT5(event, pT5);
     std::vector<unsigned int> module_idx = getModuleIdxsFrompT5(event, pT5);
@@ -578,7 +578,7 @@ void setQuintupletOutputBranches(LSTEvent* event) {
 void setPixelTripletOutputBranches(LSTEvent* event) {
   auto const pixelTriplets = event->getPixelTriplets();
   auto modules = event->getModules<ModulesSoA>();
-  SegmentsPixelConst segmentsPixel = event->getSegments<SegmentsPixelSoA>();
+  PixelSegmentsConst pixelSegments = event->getPixelSegments();
   int n_accepted_simtrk = ana.tx->getBranch<std::vector<int>>("sim_TC_matched").size();
 
   unsigned int nPixelTriplets = pixelTriplets.nPixelTriplets();
@@ -588,10 +588,10 @@ void setPixelTripletOutputBranches(LSTEvent* event) {
   for (unsigned int pT3 = 0; pT3 < nPixelTriplets; pT3++) {
     unsigned int T3Index = getT3FrompT3(event, pT3);
     unsigned int pLSIndex = getPixelLSFrompT3(event, pT3);
-    const float pt = segmentsPixel.ptIn()[pLSIndex];
+    const float pt = pixelSegments.ptIn()[pLSIndex];
 
-    float eta = segmentsPixel.eta()[pLSIndex];
-    float phi = segmentsPixel.phi()[pLSIndex];
+    float eta = pixelSegments.eta()[pLSIndex];
+    float phi = pixelSegments.phi()[pLSIndex];
     std::vector<unsigned int> hit_idx = getHitIdxsFrompT3(event, pT3);
     std::vector<unsigned int> hit_type = getHitTypesFrompT3(event, pT3);
 
@@ -984,7 +984,7 @@ std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned 
   // Get relevant information
   auto const trackCandidates = event->getTrackCandidates();
   auto const quintuplets = event->getQuintuplets<QuintupletsSoA>();
-  auto const segmentsPixel = event->getSegments<SegmentsPixelSoA>();
+  auto const pixelSegments = event->getPixelSegments();
 
   //
   // pictorial representation of a pT5
@@ -1077,9 +1077,9 @@ std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned 
   // And from there we estimate the pt's and we compute pt_T5.
 
   // pixel pt
-  const float pt_pLS = segmentsPixel.ptIn()[pLS];
-  const float eta_pLS = segmentsPixel.eta()[pLS];
-  const float phi_pLS = segmentsPixel.phi()[pLS];
+  const float pt_pLS = pixelSegments.ptIn()[pLS];
+  const float eta_pLS = pixelSegments.eta()[pLS];
+  const float phi_pLS = pixelSegments.phi()[pLS];
   float pt_T5 = __H2F(quintuplets.innerRadius()[T5Index]) * 2 * k2Rinv1GeVf;
   const float pt = (pt_T5 + pt_pLS) / 2;
 
@@ -1096,7 +1096,7 @@ std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned 
   // Get relevant information
   auto const trackCandidates = event->getTrackCandidates();
   auto const triplets = event->getTriplets<TripletsSoA>();
-  auto const segmentsPixel = event->getSegments<SegmentsPixelSoA>();
+  auto const pixelSegments = event->getPixelSegments();
 
   //
   // pictorial representation of a pT3
@@ -1110,9 +1110,9 @@ std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned 
   unsigned int T3 = getT3FrompT3(event, pT3);
 
   // pixel pt
-  const float pt_pLS = segmentsPixel.ptIn()[pLS];
-  const float eta_pLS = segmentsPixel.eta()[pLS];
-  const float phi_pLS = segmentsPixel.phi()[pLS];
+  const float pt_pLS = pixelSegments.ptIn()[pLS];
+  const float eta_pLS = pixelSegments.eta()[pLS];
+  const float phi_pLS = pixelSegments.phi()[pLS];
   float pt_T3 = triplets.radius()[T3] * 2 * k2Rinv1GeVf;
 
   // average pt
@@ -1163,15 +1163,15 @@ std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned 
 std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned int>> parsepLS(LSTEvent* event,
                                                                                                unsigned int idx) {
   auto const& trackCandidates = event->getTrackCandidates();
-  SegmentsPixelConst segmentsPixel = event->getSegments<SegmentsPixelSoA>();
+  PixelSegmentsConst pixelSegments = event->getPixelSegments();
 
   // Getting pLS index
   unsigned int pLS = trackCandidates.directObjectIndices()[idx];
 
   // Getting pt eta and phi
-  float pt = segmentsPixel.ptIn()[pLS];
-  float eta = segmentsPixel.eta()[pLS];
-  float phi = segmentsPixel.phi()[pLS];
+  float pt = pixelSegments.ptIn()[pLS];
+  float eta = pixelSegments.eta()[pLS];
+  float phi = pixelSegments.phi()[pLS];
 
   // Getting hit indices and types
   std::vector<unsigned int> hit_idx = getPixelHitIdxsFrompLS(event, pLS);


### PR DESCRIPTION
### Dynamic Memory Limits

I compute a dynamic max for each module that is the max possible number of objects that can be created given the number of lower level objects (so for example the number of possible T5's for a given module given the total number of T3's in modules where two T3's can be connected). This upper bound provides a large reduction in the occupancies. This is also accomplished with no new truncations, since this dynamic max represents the maximum number of possible objects that can be created.

For the segments, I had to rearrange the addPixelSegmentToEvent() function so that the segments container is instantiated after the MDs container is filled. Right now the segments object is instantiated during the pLS loading, which is done before the MDs container is filled.

### Object Size Reduction

Reduction in object sizes (total occupancy basically) at current max occupancies (averaged over 10 events, 0.8 GeV):
- 682,404 -> 303,891 (55% decrease) for MD's.
- 1,930,994->857,880 (56% decrease) for Segments.
- 1,980,235 -> 737,502 (63% decrease) for T3's.
- 502,053 -> 212,953 (58% decrease) for T5's.

### Total Memory Decrease

For single stream, 100 events at current occupancies:

1695MiB -> 1275MiB (**25%** decrease, 0.8 GeV)

The code has been tested locally: it compiles and gives the identical results (on CPU) for LST.