### PR TITLE
Renamed BranchChildren to ProductDependencies

### DIFF
--- a/DataFormats/Provenance/interface/BranchChildren.h
+++ b/DataFormats/Provenance/interface/BranchChildren.h
@@ -6,6 +6,9 @@
 BranchChildren: Dependency information between branches.
 
 ----------------------------------------------------------------------*/
+#if !defined(DataFormats_Provenance_ProductDependencies_h)
+#error The name BranchChildren is deprecated, please use ProductDependencies instead.
+#endif
 
 #include <map>
 #include <set>

--- a/DataFormats/Provenance/interface/ProductDependencies.h
+++ b/DataFormats/Provenance/interface/ProductDependencies.h
@@ -1,0 +1,9 @@
+#if !defined(DataFormats_Provenance_ProductDependencies_h)
+#define DataFormats_Provenance_ProductDependencies_h
+#include "DataFormats/Provenance/interface/BranchChildren.h"
+
+namespace edm {
+  using ProductDependencies = BranchChildren;
+}
+
+#endif

--- a/DataFormats/Provenance/interface/ProductDependenciesFwd.h
+++ b/DataFormats/Provenance/interface/ProductDependenciesFwd.h
@@ -1,0 +1,9 @@
+#if !defined(DataFormats_Provenance_ProductDependenciesFwd_h)
+#define DataFormats_Provenance_ProductDependenciesFwd_h
+
+namespace edm {
+  class BranchChildren;
+  using ProductDependencies = BranchChildren;
+}  // namespace edm
+
+#endif

--- a/DataFormats/Provenance/interface/SubProcessParentageHelper.h
+++ b/DataFormats/Provenance/interface/SubProcessParentageHelper.h
@@ -2,7 +2,7 @@
 #define DataFormats_Provenance_SubProcessParentageHelper_h
 
 // This class is used to properly fill Parentage in SubProcesses.
-// In particular it helps filling the BranchChildren container
+// In particular it helps filling the ProductDependencies container
 // that is used when dropping descendants of products that
 // have been dropped on input.
 //

--- a/DataFormats/Provenance/src/BranchChildren.cc
+++ b/DataFormats/Provenance/src/BranchChildren.cc
@@ -1,4 +1,4 @@
-#include "DataFormats/Provenance/interface/BranchChildren.h"
+#include "DataFormats/Provenance/interface/ProductDependencies.h"
 
 #include "DataFormats/Provenance/interface/ProductDescription.h"
 

--- a/DataFormats/Provenance/src/classes.h
+++ b/DataFormats/Provenance/src/classes.h
@@ -1,5 +1,5 @@
 #include "DataFormats/Provenance/interface/ProductDescription.h"
-#include "DataFormats/Provenance/interface/BranchChildren.h"
+#include "DataFormats/Provenance/interface/ProductDependencies.h"
 #include "DataFormats/Provenance/interface/BranchID.h"
 #include "DataFormats/Provenance/interface/BranchKey.h"
 #include "DataFormats/Provenance/interface/ElementID.h"

--- a/FWCore/Framework/interface/FileBlock.h
+++ b/FWCore/Framework/interface/FileBlock.h
@@ -8,7 +8,7 @@ FileBlock: Properties of an input file.
 ----------------------------------------------------------------------*/
 
 #include "DataFormats/Provenance/interface/FileFormatVersion.h"
-#include "DataFormats/Provenance/interface/BranchChildren.h"
+#include "DataFormats/Provenance/interface/ProductDependencies.h"
 #include "DataFormats/Provenance/interface/ProductDescriptionFwd.h"
 #include "FWCore/Utilities/interface/BranchType.h"
 class TTree;
@@ -69,7 +69,7 @@ namespace edm {
           fileName_(),
           branchListIndexesUnchanged_(false),
           modifiedIDs_(false),
-          branchChildren_(new BranchChildren) {}
+          productDependencies_(new ProductDependencies) {}
 
     FileBlock(FileFormatVersion const& version,
               TTree* ev,
@@ -85,7 +85,7 @@ namespace edm {
               std::string const& fileName,
               bool branchListIndexesUnchanged,
               bool modifiedIDs,
-              std::shared_ptr<BranchChildren const> branchChildren)
+              std::shared_ptr<ProductDependencies const> productDependencies)
         : fileFormatVersion_(version),
           tree_(ev),
           metaTree_(meta),
@@ -100,7 +100,7 @@ namespace edm {
           fileName_(fileName),
           branchListIndexesUnchanged_(branchListIndexesUnchanged),
           modifiedIDs_(modifiedIDs),
-          branchChildren_(branchChildren) {}
+          productDependencies_(productDependencies) {}
 
     ~FileBlock() {}
 
@@ -132,7 +132,7 @@ namespace edm {
     bool modifiedIDs() const { return modifiedIDs_; }
 
     void setNotFastClonable(WhyNotFastClonable const& why) { whyNotFastClonable_ |= why; }
-    BranchChildren const& branchChildren() const { return *branchChildren_; }
+    ProductDependencies const& productDependencies() const { return *productDependencies_; }
     void close();
 
   private:
@@ -151,7 +151,7 @@ namespace edm {
     std::string fileName_;
     bool branchListIndexesUnchanged_;
     bool modifiedIDs_;
-    std::shared_ptr<BranchChildren const> branchChildren_;
+    std::shared_ptr<ProductDependencies const> productDependencies_;
   };
 }  // namespace edm
 #endif

--- a/FWCore/Sources/interface/DaqProvenanceHelper.h
+++ b/FWCore/Sources/interface/DaqProvenanceHelper.h
@@ -7,6 +7,7 @@
 #include "oneapi/tbb/concurrent_unordered_map.h"
 
 #include "DataFormats/Provenance/interface/ProductDescription.h"
+#include "DataFormats/Provenance/interface/ProductDependenciesFwd.h"
 #include "DataFormats/Provenance/interface/ParentageID.h"
 #include "DataFormats/Provenance/interface/ProcessConfiguration.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
@@ -15,7 +16,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 namespace edm {
-  class BranchChildren;
   class ProcessHistoryRegistry;
 
   namespace dqh {
@@ -42,7 +42,7 @@ namespace edm {
     void fixMetaData(ProcessConfigurationVector& pcv, std::vector<ProcessHistory>& phv);
     void fixMetaData(std::vector<BranchID>& branchIDs) const;
     void fixMetaData(BranchIDLists const&) const;
-    void fixMetaData(BranchChildren& branchChildren) const;
+    void fixMetaData(ProductDependencies& productDependencies) const;
     ProcessHistoryID const& mapProcessHistoryID(ProcessHistoryID const& phid);
     ParentageID const& mapParentageID(ParentageID const& phid) const;
     BranchID const& mapBranchID(BranchID const& branchID) const;

--- a/FWCore/Sources/src/DaqProvenanceHelper.cc
+++ b/FWCore/Sources/src/DaqProvenanceHelper.cc
@@ -4,7 +4,7 @@
 
 #include "FWCore/Sources/interface/DaqProvenanceHelper.h"
 
-#include "DataFormats/Provenance/interface/BranchChildren.h"
+#include "DataFormats/Provenance/interface/ProductDependencies.h"
 #include "DataFormats/Provenance/interface/BranchIDList.h"
 #include "DataFormats/Provenance/interface/ProcessHistory.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
@@ -165,10 +165,10 @@ namespace edm {
     }
   }
 
-  void DaqProvenanceHelper::fixMetaData(BranchChildren& branchChildren) const {
+  void DaqProvenanceHelper::fixMetaData(ProductDependencies& productDependencies) const {
     typedef std::map<BranchID, std::set<BranchID> > BCMap;
     // The const_cast is ugly, but it beats the alternatives.
-    BCMap& childLookup = const_cast<BCMap&>(branchChildren.childLookup());
+    BCMap& childLookup = const_cast<BCMap&>(productDependencies.childLookup());
     // First fix any old branchID's in the key.
     {
       BCMap::iterator i = childLookup.find(oldBranchID_);

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -244,7 +244,7 @@ namespace edm {
                 ? eventTree_.tree()->GetBranch(poolNames::eventToProcessBlockIndexesBranchName().c_str())
                 : nullptr),
         history_(),
-        branchChildren_(new BranchChildren),
+        productDependencies_(new ProductDependencies),
         duplicateChecker_(duplicateChecker),
         provenanceAdaptor_(),
         provenanceReaderMaker_(),
@@ -381,9 +381,9 @@ namespace edm {
       }
     }
 
-    BranchChildren* branchChildrenBuffer = branchChildren_.get();
+    ProductDependencies* productDependenciesBuffer = productDependencies_.get();
     if (metaDataTree->FindBranch(poolNames::productDependenciesBranchName().c_str()) != nullptr) {
-      metaDataTree->SetBranchAddress(poolNames::productDependenciesBranchName().c_str(), &branchChildrenBuffer);
+      metaDataTree->SetBranchAddress(poolNames::productDependenciesBranchName().c_str(), &productDependenciesBuffer);
     }
 
     // backward compatibility
@@ -495,7 +495,7 @@ namespace edm {
         // Fix up other per file metadata.
         daqProvenanceHelper_->fixMetaData(processConfigurations, pHistVector);
         daqProvenanceHelper_->fixMetaData(*branchIDLists_);
-        daqProvenanceHelper_->fixMetaData(*branchChildren_);
+        daqProvenanceHelper_->fixMetaData(*productDependencies_);
       }
     }
 
@@ -797,7 +797,7 @@ namespace edm {
                                        file_,
                                        branchListIndexesUnchanged(),
                                        modifiedIDs(),
-                                       branchChildren());
+                                       productDependencies());
   }
 
   void RootFile::updateFileBlock(FileBlock& fileBlock) {
@@ -1939,7 +1939,7 @@ namespace edm {
                                        std::set<BranchID>& branchesToDrop,
                                        std::map<BranchID, BranchID> const& droppedToKeptAlias) const {
     if (dropDescendants) {
-      branchChildren_->appendToDescendants(branch, branchesToDrop, droppedToKeptAlias);
+      productDependencies_->appendToDescendants(branch, branchesToDrop, droppedToKeptAlias);
     } else {
       branchesToDrop.insert(branch.branchID());
     }

--- a/IOPool/Input/src/RootFile.h
+++ b/IOPool/Input/src/RootFile.h
@@ -8,7 +8,7 @@ RootFile.h // used by ROOT input sources
 ----------------------------------------------------------------------*/
 
 #include "RootTree.h"
-#include "DataFormats/Provenance/interface/BranchChildren.h"
+#include "DataFormats/Provenance/interface/ProductDependencies.h"
 #include "DataFormats/Provenance/interface/BranchIDList.h"
 #include "DataFormats/Provenance/interface/BranchListIndex.h"
 #include "DataFormats/Provenance/interface/EntryDescriptionID.h"  // backward compatibility
@@ -345,8 +345,10 @@ namespace edm {
     std::shared_ptr<RunAuxiliary const> savedRunAuxiliary() const { return get_underlying_safe(savedRunAuxiliary_); }
     std::shared_ptr<RunAuxiliary>& savedRunAuxiliary() { return get_underlying_safe(savedRunAuxiliary_); }
 
-    std::shared_ptr<BranchChildren const> branchChildren() const { return get_underlying_safe(branchChildren_); }
-    std::shared_ptr<BranchChildren>& branchChildren() { return get_underlying_safe(branchChildren_); }
+    std::shared_ptr<ProductDependencies const> productDependencies() const {
+      return get_underlying_safe(productDependencies_);
+    }
+    std::shared_ptr<ProductDependencies>& productDependencies() { return get_underlying_safe(productDependencies_); }
 
     std::shared_ptr<ProductProvenanceRetriever const> eventProductProvenanceRetriever(size_t index) const {
       return get_underlying_safe(eventProductProvenanceRetrievers_[index]);
@@ -403,7 +405,7 @@ namespace edm {
     EventToProcessBlockIndexes eventToProcessBlockIndexes_;
     edm::propagate_const<TBranch*> eventToProcessBlockIndexesBranch_;
     edm::propagate_const<std::unique_ptr<History>> history_;  // backward compatibility
-    edm::propagate_const<std::shared_ptr<BranchChildren>> branchChildren_;
+    edm::propagate_const<std::shared_ptr<ProductDependencies>> productDependencies_;
     edm::propagate_const<std::shared_ptr<DuplicateChecker>> duplicateChecker_;
     edm::propagate_const<std::unique_ptr<ProvenanceAdaptor>> provenanceAdaptor_;  // backward comatibility
     edm::propagate_const<std::unique_ptr<MakeProvenanceReader>> provenanceReaderMaker_;

--- a/IOPool/Output/interface/PoolOutputModule.h
+++ b/IOPool/Output/interface/PoolOutputModule.h
@@ -23,7 +23,7 @@
 #include "FWCore/Framework/interface/one/OutputModule.h"
 #include "FWCore/Utilities/interface/BranchType.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
-#include "DataFormats/Provenance/interface/BranchChildren.h"
+#include "DataFormats/Provenance/interface/ProductDependencies.h"
 #include "DataFormats/Provenance/interface/BranchID.h"
 #include "DataFormats/Provenance/interface/BranchType.h"
 #include "DataFormats/Provenance/interface/ParentageID.h"
@@ -132,7 +132,7 @@ namespace edm {
 
     std::vector<OutputItemList>& selectedOutputItemList() { return selectedOutputItemList_; }
 
-    BranchChildren const& branchChildren() const { return branchChildren_; }
+    ProductDependencies const& productDependencies() const { return productDependencies_; }
 
   protected:
     ///allow inheriting classes to override but still be able to call this method in the overridden version
@@ -212,7 +212,7 @@ namespace edm {
     int outputFileCount_;
     int inputFileCount_;
     BranchParents branchParents_;
-    BranchChildren branchChildren_;
+    ProductDependencies productDependencies_;
     std::vector<BranchID> producedBranches_;
     bool overrideInputFileSplitLevels_;
     bool compactEventAuxiliary_;

--- a/IOPool/Output/src/PoolOutputModule.cc
+++ b/IOPool/Output/src/PoolOutputModule.cc
@@ -59,7 +59,7 @@ namespace edm {
         outputFileCount_(0),
         inputFileCount_(0),
         branchParents_(),
-        branchChildren_(),
+        productDependencies_(),
         overrideInputFileSplitLevels_(pset.getUntrackedParameter<bool>("overrideInputFileSplitLevels")),
         compactEventAuxiliary_(pset.getUntrackedParameter<bool>("compactEventAuxiliary")),
         mergeJob_(pset.getUntrackedParameter<bool>("mergeJob")),
@@ -245,10 +245,10 @@ namespace edm {
     if (isFileOpen()) {
       //Faster to read ChildrenBranches directly from input
       // file than to build it every event
-      auto const& branchToChildMap = fb.branchChildren().childLookup();
+      auto const& branchToChildMap = fb.productDependencies().childLookup();
       for (auto const& parentToChildren : branchToChildMap) {
         for (auto const& child : parentToChildren.second) {
-          branchChildren_.insertChild(parentToChildren.first, child);
+          productDependencies_.insertChild(parentToChildren.first, child);
         }
       }
       rootOutputFile_->beginInputFile(fb, remainingEvents());
@@ -343,9 +343,9 @@ namespace edm {
     writeParentageRegistry();
     writeBranchIDListRegistry();
     writeThinnedAssociationsHelper();
-    writeProductDependencies();  //branchChildren used here
+    writeProductDependencies();  //productDependencies used here
     writeProcessBlockHelper();
-    branchChildren_.clear();
+    productDependencies_.clear();
     finishEndFile();
 
     doExtrasAfterCloseFile();
@@ -475,7 +475,7 @@ namespace edm {
         ParentageRegistry::instance()->getMapped(eId, entryDesc);
         std::vector<BranchID> const& parents = entryDesc.parents();
         for (auto const& parent : parents) {
-          branchChildren_.insertChild(parent, child);
+          productDependencies_.insertChild(parent, child);
         }
       }
     }

--- a/IOPool/Output/src/RootOutputFile.cc
+++ b/IOPool/Output/src/RootOutputFile.cc
@@ -21,7 +21,7 @@
 #include "FWCore/MessageLogger/interface/JobReport.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/Common/interface/BasicHandle.h"
-#include "DataFormats/Provenance/interface/BranchChildren.h"
+#include "DataFormats/Provenance/interface/ProductDependencies.h"
 #include "DataFormats/Provenance/interface/BranchIDList.h"
 #include "DataFormats/Provenance/interface/Parentage.h"
 #include "DataFormats/Provenance/interface/ParentageRegistry.h"
@@ -698,8 +698,8 @@ namespace edm {
     b->Fill();
   }
   void RootOutputFile::writeProductDependencies() {
-    BranchChildren& pDeps = const_cast<BranchChildren&>(om_->branchChildren());
-    BranchChildren* ppDeps = &pDeps;
+    ProductDependencies& pDeps = const_cast<ProductDependencies&>(om_->productDependencies());
+    ProductDependencies* ppDeps = &pDeps;
     TBranch* b =
         metaDataTree_->Branch(poolNames::productDependenciesBranchName().c_str(), &ppDeps, om_->basketSize(), 0);
     assert(b);


### PR DESCRIPTION
#### PR description:

Handled via a using statement.
Added #error to BranchChildren.h to cause error if header added directly.

#### PR validation:

Code compiles. Framework unit tests pass.

Resolves https://github.com/cms-sw/framework-team/issues/1214