### PR TITLE
Add missing `#include` in `CondFormats/Common`

### DIFF
--- a/CondFormats/Common/interface/SmallWORMDict.h
+++ b/CondFormats/Common/interface/SmallWORMDict.h
@@ -26,8 +26,8 @@ namespace cond {
     friend int test::SmallWORMDict::test();
 
   public:
-    SmallWORMDict();
-    ~SmallWORMDict();
+    SmallWORMDict() = default;
+    ~SmallWORMDict() = default;
 
     struct Frame {
       Frame() : b(nullptr) {}

--- a/CondFormats/Common/src/SmallWORMDict.cc
+++ b/CondFormats/Common/src/SmallWORMDict.cc
@@ -1,13 +1,10 @@
-#include "CondFormats/Common/interface/SmallWORMDict.h"
-#include <string>
+#include <algorithm>
 #include <functional>
 #include <numeric>
 
-namespace cond {
-  using namespace std::placeholders;
+#include "CondFormats/Common/interface/SmallWORMDict.h"
 
-  SmallWORMDict::SmallWORMDict() {}
-  SmallWORMDict::~SmallWORMDict() {}
+namespace cond {
 
   SmallWORMDict::SmallWORMDict(std::vector<std::string> const& idict)
       : m_data(std::accumulate(idict.begin(), idict.end(), 0, [](int a, std::string b) { return a + b.size(); })),


### PR DESCRIPTION
#### PR description:

Add missing `#include` statement.

Fixes the error
```
src/CondFormats/Common/src/SmallWORMDict.cc: In constructor 'cond::SmallWORMDict::SmallWORMDict(const std::vector<std::__cxx11::basic_string<char> >&)':
src/CondFormats/Common/src/SmallWORMDict.cc:20:10: error: 'sort' is not a member of 'std'; did you mean 'qsort'?
   20 |     std::sort(m_index.begin(), m_index.end(), [&idict](unsigned int a, unsigned int b) {
      |          ^~~~
```
observed in the GCC 14 builds.

#### PR validation:

The code compiles.