### PR TITLE
Fix the number for the last lumisection of the run

### DIFF
--- a/CondCore/CondDB/src/Time.cc
+++ b/CondCore/CondDB/src/Time.cc
@@ -114,7 +114,8 @@ namespace cond {
       switch (timetype) {
         case RUNNUMBER:
           // last lumi and event of this run
-          return edm::IOVSyncValue(edm::EventID(time, edm::EventID::maxEventNumber(), edm::EventID::maxEventNumber()));
+          return edm::IOVSyncValue(
+              edm::EventID(time, edm::LuminosityBlockID::maxLuminosityBlockNumber(), edm::EventID::maxEventNumber()));
         case LUMIID: {
           // the same lumiblock
           edm::LuminosityBlockID l(time);
@@ -132,8 +133,9 @@ namespace cond {
       switch (timetype) {
         case RUNNUMBER:
           // last event of this run
-          return edm::IOVSyncValue(
-              edm::EventID(time.eventID().run(), edm::EventID::maxEventNumber(), edm::EventID::maxEventNumber()));
+          return edm::IOVSyncValue(edm::EventID(time.eventID().run(),
+                                                edm::LuminosityBlockID::maxLuminosityBlockNumber(),
+                                                edm::EventID::maxEventNumber()));
         case LUMIID:
           // the same lumiblock
           return edm::IOVSyncValue(


### PR DESCRIPTION
#### PR description:

Use `edm::LuminosityBlockID::maxLuminosityBlockNumber()` instead of `edm::EventID::maxEventNumber()` as the last luimisection number for the run.

Fixes the overflow errors reported by gcc 13 while testing the `-fimplicit-constexpr` option:
```
src/CondCore/CondDB/src/Time.cc: In function 'edm::IOVSyncValue cond::time::limitedIOVSyncValue(Time_t, TimeType)':
src/CondCore/CondDB/src/Time.cc:117:83: error: conversion from 'long long unsigned int' to 'edm::LuminosityBlockNumber_t' {aka 'unsigned int'} changes value from '18446744073709551615' to '4294967295' [-Werror=overflow]
  117 |           return edm::IOVSyncValue(edm::EventID(time, edm::EventID::maxEventNumber(), edm::EventID::maxEventNumber()));
      |                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
src/CondCore/CondDB/src/Time.cc: In function 'edm::IOVSyncValue cond::time::limitedIOVSyncValue(const edm::IOVSyncValue&, TimeType)':
src/CondCore/CondDB/src/Time.cc:136:78: error: conversion from 'long long unsigned int' to 'edm::LuminosityBlockNumber_t' {aka 'unsigned int'} changes value from '18446744073709551615' to '4294967295' [-Werror=overflow]
  136 |               edm::EventID(time.eventID().run(), edm::EventID::maxEventNumber(), edm::EventID::maxEventNumber()));
      |                                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
```

#### PR validation:

The code compiles.