### PR TITLE
Remove mkFit based workflow 12834.7 from short matrix

### DIFF
--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -96,7 +96,6 @@ if __name__ == '__main__':
             12834.0,    # RelValTTbar_14TeV             2024
             12846.0,    # RelValZEE_13                  2024
             13034.0,    # RelValTTbar_14TeV             2024 PU = Run3_Flat55To75_PoissonOOTPU
-            12834.7,    # RelValTTbar_14TeV             2024 mkFit
             16834.0,    # RelValTTbar_14TeV             2025
             17034.0,    # RelValTTbar_14TeV		2025 PU = Run3_Flat55To75_PoissonOOTPU
             14034.0,    # RelValTTbar_14TeV             Run3_2023_FastSim


### PR DESCRIPTION
To avoid the [spurious differences in outputs of Run-3 wfs `*.7`  ( see https://github.com/cms-sw/cmssw/issues/39803) , it is suggedted to remove worklfow `12834.7` from short/selected runTheMatrix and run it for PR tests when a PR touches `tracking` code ( i.e PR with `tracking` labels). 

This PR removes the workflow  `12834.7` from short/selected runTheMatrix . I will soon open a cms-bot PR to add  `12834.7` for 15.0.X PR tests

FYI @makortel 

