### PR TITLE
Silence gcc 13.3.0 spurious array bounds warnings for std::vector initialization

### DIFF
--- a/CondFormats/JetMETObjects/test/BuildFile.xml
+++ b/CondFormats/JetMETObjects/test/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags REM_CXXFLAGS="-Werror=array-bounds"/>
 <bin file="testSerializationJetMETObjects.cpp">
   <use name="CondFormats/JetMETObjects"/>
 </bin>

--- a/L1Trigger/TrackFindingTMTT/BuildFile.xml
+++ b/L1Trigger/TrackFindingTMTT/BuildFile.xml
@@ -16,6 +16,7 @@
 <use name="DataFormats/JetReco"/>
 <use name="L1Trigger/TrackTrigger"/>
 <use name="roothistmatrix"/>
+<flags REM_CXXFLAGS="-Werror=array-bounds"/>
 <export>
     <lib name="1"/>
 </export>

--- a/L1Trigger/TrackFindingTracklet/BuildFile.xml
+++ b/L1Trigger/TrackFindingTracklet/BuildFile.xml
@@ -9,7 +9,7 @@
 <use name="L1Trigger/TrackFindingTMTT"/>
 <use name="L1Trigger/TrackerTFP"/>
 <flags CXXFLAGS="-DUSEHYBRID"/>
-
+<flags REM_CXXFLAGS="-Werror=array-bounds"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/PhysicsTools/MVAComputer/test/BuildFile.xml
+++ b/PhysicsTools/MVAComputer/test/BuildFile.xml
@@ -5,6 +5,7 @@
 <use name="CondFormats/PhysicsToolsObjects"/>
 <use name="CondFormats/DataRecord"/>
 <use name="PhysicsTools/MVAComputer"/>
+<flags REM_CXXFLAGS="-Werror=array-bounds"/>
 <library file="testWriteMVAComputerCondDB.cc" name="testWriteMVAComputerCondDB">
   <use name="CondCore/DBOutputService"/>
   <flags EDM_PLUGIN="1"/>

--- a/RecoEgamma/EgammaIsolationAlgos/BuildFile.xml
+++ b/RecoEgamma/EgammaIsolationAlgos/BuildFile.xml
@@ -14,6 +14,7 @@
 <use name="RecoLocalCalo/HcalRecAlgos"/>
 <use name="CommonTools/Statistics"/>
 <use name="CondFormats/DataRecord"/>
+<flags REM_CXXFLAGS="-Werror=array-bounds"/>
 <export>
   <lib name="1"/>
 </export>

--- a/RecoTauTag/RecoTau/BuildFile.xml
+++ b/RecoTauTag/RecoTau/BuildFile.xml
@@ -26,6 +26,7 @@
 <use name="RecoLocalCalo/HGCalRecAlgos"/>
 <use name="roottmva"/>
 <use name="PhysicsTools/TensorFlow"/>
+<flags REM_CXXFLAGS="-Werror=array-bounds"/>
 <export>
   <lib name="1"/>
 </export>

--- a/RecoTauTag/RecoTau/plugins/BuildFile.xml
+++ b/RecoTauTag/RecoTau/plugins/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags REM_CXXFLAGS="-Werror=array-bounds"/>
 <library file="*.cc" name="RecoTauTagRecoTauPlugins">
   <use name="root"/>
   <use name="tbb"/>


### PR DESCRIPTION
gcc 13.3 produces spurious array bounds warning/error for std::vector initialization with curly braces.
addresses
https://github.com/cms-sw/cmssw/issues/47218
https://github.com/cms-sw/cmssw/issues/47219
https://github.com/cms-sw/cmssw/issues/47220
https://github.com/cms-sw/cmssw/issues/47221
https://github.com/cms-sw/cmssw/issues/47222
