### PR TITLE
move `HGCalHitCalibrationHLT` DQM plots from top folder to inside `HLT` folder

### DIFF
--- a/HLTriggerOffline/Common/python/HLTValidation_cff.py
+++ b/HLTriggerOffline/Common/python/HLTValidation_cff.py
@@ -20,14 +20,15 @@ from Validation.HcalRecHits.HLTHcalRecHitParam_cfi import *
 
 # HGCAL Rechit Calibration
 from Validation.HGCalValidation.hgcalHitCalibrationDefault_cfi import hgcalHitCalibrationDefault as _hgcalHitCalibrationDefault
-hgcalHitCalibrationHLT = _hgcalHitCalibrationDefault.clone()
-hgcalHitCalibrationHLT.folder = "HGCalHitCalibrationHLT"
-hgcalHitCalibrationHLT.recHitsEE = cms.InputTag("hltHGCalRecHit", "HGCEERecHits", "HLT")
-hgcalHitCalibrationHLT.recHitsFH = cms.InputTag("hltHGCalRecHit", "HGCHEFRecHits", "HLT")
-hgcalHitCalibrationHLT.recHitsBH = cms.InputTag("hltHGCalRecHit", "HGCHEBRecHits", "HLT")
-hgcalHitCalibrationHLT.hgcalMultiClusters = cms.InputTag("None")
-hgcalHitCalibrationHLT.electrons = cms.InputTag("None")
-hgcalHitCalibrationHLT.photons = cms.InputTag("None")
+hgcalHitCalibrationHLT = _hgcalHitCalibrationDefault.clone(
+    folder = "HLT/HGCalHitCalibration",
+    recHitsEE = ("hltHGCalRecHit", "HGCEERecHits", "HLT"),
+    recHitsFH = ("hltHGCalRecHit", "HGCHEFRecHits", "HLT"),
+    recHitsBH = ("hltHGCalRecHit", "HGCHEBRecHits", "HLT"),
+    hgcalMultiClusters = "None",
+    electrons = "None",
+    photons = "None"
+)
 
 # offline dqm:
 # from DQMOffline.Trigger.DQMOffline_Trigger_cff.py import *


### PR DESCRIPTION
#### PR description:

Title says it all, purely technical.
Profited to remove cms type specification inside clone.

#### PR validation:

run `runTheMatrix.py -l 29634.0 --ibeos -t 4 -j 8` successfully and observed the plots booked in the right place.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A

