### PR TITLE
[GCC14] template-id not allowed for constructor in C++20

### DIFF
--- a/DataFormats/TrackSoA/interface/TracksDevice.h
+++ b/DataFormats/TrackSoA/interface/TracksDevice.h
@@ -28,8 +28,7 @@ public:
 
   // Constructor which specifies the SoA size
   template <typename TQueue>
-  explicit TracksDevice<TrackerTraits, TDev>(TQueue& queue)
-      : PortableDeviceCollection<reco::TrackLayout<TrackerTraits>, TDev>(S, queue) {}
+  explicit TracksDevice(TQueue& queue) : PortableDeviceCollection<reco::TrackLayout<TrackerTraits>, TDev>(S, queue) {}
 };
 
 namespace pixelTrack {

--- a/DataFormats/TrackSoA/interface/TracksHost.h
+++ b/DataFormats/TrackSoA/interface/TracksHost.h
@@ -29,8 +29,7 @@ public:
 
   // Constructor which specifies the SoA size
   template <typename TQueue>
-  explicit TracksHost<TrackerTraits>(TQueue& queue)
-      : PortableHostCollection<reco::TrackLayout<TrackerTraits>>(S, queue) {}
+  explicit TracksHost(TQueue& queue) : PortableHostCollection<reco::TrackLayout<TrackerTraits>>(S, queue) {}
 
   // Constructor which specifies the DevHost
   explicit TracksHost(alpaka_common::DevHost const& host)


### PR DESCRIPTION
#### PR description:

GCC14 complains that template-id is not allowed for constructor:

```
    In file included from src/DataFormats/TrackSoA/interface/alpaka/TracksSoACollection.h:9,
                     from src/RecoVertex/PixelVertexFinding/plugins/alpaka/PixelVertexProducerAlpaka.cc:17:
    src/DataFormats/TrackSoA/interface/TracksDevice.h:31:46: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
       31 |   explicit TracksDevice<TrackerTraits, TDev>(TQueue& queue)
          |                                              ^~~~~~
    src/DataFormats/TrackSoA/interface/TracksDevice.h:31:46: note: remove the '< >'
    In file included from src/DataFormats/TrackSoA/interface/alpaka/TracksSoACollection.h:10:
    src/DataFormats/TrackSoA/interface/TracksHost.h:32:38: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
       32 |   explicit TracksHost<TrackerTraits>(TQueue& queue)
          |                                      ^~~~~~
    src/DataFormats/TrackSoA/interface/TracksHost.h:32:38: note: remove the '< >'
```

This PR fixes this warning.

#### PR validation:

Bot tests.
