### PR TITLE
[GCC14] Avoid std::clamp in device code

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforDevice.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforDevice.h
@@ -379,7 +379,11 @@ namespace pixelCPEforDevice {
     int high_value = kNumErrorBins - 1;
     int bin_value = float(kNumErrorBins) * (cp.xpos[ic] + xoff) / (2 * xoff);
     // return estimated bin value truncated to [0, 15]
-    int jx = std::clamp(bin_value, low_value, high_value);
+    // Equivalent of jx = std::clamp(bin_value, low_value, high_value)
+    // which doesn't compile with gcc14 due to reference to __glibcxx_assert
+    // See https://github.com/llvm/llvm-project/issues/95183
+    int tmp_max = std::max<int>(bin_value, low_value);
+    int jx = std::min<int>(tmp_max, high_value);
 
     auto toCM = [](uint8_t x) { return float(x) * 1.e-4f; };
 

--- a/RecoVertex/PixelVertexFinding/plugins/alpaka/clusterTracksByDensity.h
+++ b/RecoVertex/PixelVertexFinding/plugins/alpaka/clusterTracksByDensity.h
@@ -76,7 +76,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::vertexFinder {
     // fill hist (bin shall be wider than "eps")
     for (auto i : cms::alpakatools::uniform_elements(acc, nt)) {
       int iz = static_cast<int>(zt[i] * 10.f);  // valid if eps <= 0.1
-      iz = std::clamp(iz, INT8_MIN, INT8_MAX);
+      // Equivalent of iz = std::clamp(iz, INT8_MIN, INT8_MAX)
+      // which doesn't compile with gcc14 due to reference to __glibcxx_assert
+      // See https://github.com/llvm/llvm-project/issues/95183
+      int tmp_max = std::max<int>(iz, INT8_MIN);
+      iz = std::min<int>(tmp_max, INT8_MAX);
       ALPAKA_ASSERT_ACC(iz - INT8_MIN >= 0);
       ALPAKA_ASSERT_ACC(iz - INT8_MIN < 256);
       izt[i] = iz - INT8_MIN;


### PR DESCRIPTION
#### PR description:

When testing CMSSW with gcc14, the following error is emitted:

```
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02874/el8_amd64_gcc14/external/gcc/14.2.1-60e8d7f953e2e96ab45420ba74bbf3ae/lib/gcc/x86_64-redhat-linux-gnu/14.2.1/../../../../include/c++/14.2.1/bits/stl_algo.h:3626:7: error: reference to __host__ function '__glibcxx_assert_fail' in __host__ __device__ function
 3626 |       __glibcxx_assert(!(__hi < __lo));
      |       ^
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02874/el8_amd64_gcc14/external/gcc/14.2.1-60e8d7f953e2e96ab45420ba74bbf3ae/lib/gcc/x86_64-redhat-linux-gnu/14.2.1/../../../../include/c++/14.2.1/x86_64-redhat-linux-gnu/bits/c++config.h:614:12: note: expanded from macro '__glibcxx_assert'
  614 |       std::__glibcxx_assert_fail();                                     \
      |            ^
src/RecoVertex/PixelVertexFinding/plugins/alpaka/clusterTracksByDensity.h:79:17: note: called by 'clusterTracksByDensity'
   79 |       iz = std::clamp(iz, INT8_MIN, INT8_MAX);
      |                 ^
```

This issue was reported to [LLVM](https://github.com/llvm/llvm-project/issues/95183) and [GCC](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115740). Fix inspired by [pytorch's fix](https://github.com/lamikr/rocm_sdk_builder/commit/c9f6a0057c354bd5032287fdd2d6d0d9ee83a6cc#diff-7e7718ec4f2da71ae727c3f24784e81b54a205177da5c2bbbe5a7ee1213d6700) of the same problem.

#### PR validation:

Bot tests