### PR TITLE
Fixes to the ChiSquared Test in RelMon

### DIFF
--- a/Utilities/RelMon/python/utils.py
+++ b/Utilities/RelMon/python/utils.py
@@ -248,16 +248,20 @@ class Chi2(StatisticalTest):
     StatisticalTest.__init__(self,threshold)
     self.name="Chi2"     
 
-  def check_filled_bins(self,min_filled):
-    nbins=self.h1.GetNbinsX()
-    n_filled_l=[]
-    for h in self.h1,self.h2:
-      nfilled=0.
-      for ibin in range(0,nbins+2):
-        if h.GetBinContent(ibin)>0:
-          nfilled+=1
+  def check_filled_bins(self, min_filled=1):
+    nbinsX = self.h1.GetNbinsX()
+    nbinsY = self.h1.GetNbinsY()
+    n_filled_l = []
+    for h in self.h1, self.h2:
+      nfilled = 0
+      for ibinX in range(1, nbinsX+1):
+        for ibinY in range(1, nbinsY+1):
+          if h.GetBinContent(ibinX, ibinY) > 0:
+            nfilled += 1
       n_filled_l.append(nfilled)
-    return len([x for x in n_filled_l if x>=min_filled] )>0
+    is_filled = len([x for x in n_filled_l if x >= min_filled]) > 0
+    single_bin_filled = len([x for x in n_filled_l if x == 1]) == len(n_filled_l)
+    return is_filled, single_bin_filled
 
   def absval(self):
     nbins=getNbins(self.h1)
@@ -272,20 +276,34 @@ class Chi2(StatisticalTest):
           h.SetBinContent(i,0)
 
   def check_histograms(self, histogram):
-      if histogram.InheritsFrom("TProfile") or  (histogram.GetEntries()!=histogram.GetSumOfWeights()):
-          return 'W'
-      else:
-          return 'U'
+    if histogram.InheritsFrom("TProfile") or (histogram.GetEntries()!=histogram.GetSumOfWeights()):
+      return 'W'
+    else:
+      return 'U'
+
+  def compare_filled_bin(self):
+    nbinsX = self.h1.GetNbinsX()
+    nbinsY = self.h1.GetNbinsY()
+    for ibinX in range(1, nbinsX+1):
+      for ibinY in range(1, nbinsY+1):
+        if self.h1.GetBinContent(ibinX, ibinY) >= 1 and self.h2.GetBinContent(ibinX, ibinY) >= 1:
+          return 1
+    return 0
 
   def do_test(self):
     self.absval()
-    if self.check_filled_bins(3):
+    is_filled, single_bin_filled = self.check_filled_bins()
+    if is_filled:
+      if single_bin_filled:
+         return self.compare_filled_bin()
+      #print(self.h1.GetName())
       #if self.h1.InheritsFrom("TProfile") or  (self.h1.GetEntries()!=self.h1.GetSumOfWeights()):
       #  chi2=self.h1.Chi2Test(self.h2,'WW')
       #  #if chi2==0: print "DEBUG",self.h1.GetName(),"Chi2 is:", chi2
       #  return chi2
       #else:
       #  return self.h1.Chi2Test(self.h2,'UU')
+      #
       hist1 = self.check_histograms(self.h1)
       hist2 = self.check_histograms(self.h2)
       if hist1 =='W' and hist2 =='W': ##in case 


### PR DESCRIPTION
#### PR description:

Histograms with a single filled bin are checked separately for the bin position. This avoids a ChiSquared test with zero degrees of freedom. The counting of filled bins was fixed for two-dimensional histograms.
[update_relmon.pdf](https://github.com/user-attachments/files/18689023/update_relmon.pdf)


<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide documentation for this PR (slides, JIRA tickets, related pull requests, hypernews, TWiki or Indico pages)  -->

#### PR validation:

The fixes were validated with [DQM_V0001_R000000001__RelValDisplacedSUSY_14TeV__CMSSW_14_1_0_pre5-PU_140X_mcRun3_2024_realistic_v11_STD_2024_PU-v1__DQMIO.root](https://cmsweb.cern.ch/dqm/relval/data/browse/ROOT/RelVal/CMSSW_14_1_x/DQM_V0001_R000000001__RelValDisplacedSUSY_14TeV__CMSSW_14_1_0_pre5-PU_140X_mcRun3_2024_realistic_v11_STD_2024_PU-v1__DQMIO.root) comparing it against itself. The file was provided by @AdrianoDee. There are still issues with histograms created using TH1::Divide for which the check between weighted and unweighted histograms fails. In these cases an unweighted test is applied to weighted histograms, leading to a rounding down of all bin contents (to zero).
This is a list of all failing histograms:
[failing_list.txt](https://github.com/user-attachments/files/18674880/failing_list.txt)

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions, or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

<!-- Please delete the text above after you verified all points of the checklist  -->
