### PR TITLE
Move `ResourceInformation` abstract base class to FWCore/AbstractServices, and few additional improvements

### DIFF
--- a/FWCore/AbstractServices/BuildFile.xml
+++ b/FWCore/AbstractServices/BuildFile.xml
@@ -1,0 +1,3 @@
+<export>
+  <lib name="1"/>
+</export>

--- a/FWCore/AbstractServices/interface/ResourceInformation.h
+++ b/FWCore/AbstractServices/interface/ResourceInformation.h
@@ -1,5 +1,5 @@
-#ifndef FWCore_Utilities_ResourceInformation_h
-#define FWCore_Utilities_ResourceInformation_h
+#ifndef FWCore_AbstractServices_ResourceInformation_h
+#define FWCore_AbstractServices_ResourceInformation_h
 
 /** \class edm::ResourceInformation
 

--- a/FWCore/AbstractServices/interface/ResourceInformation.h
+++ b/FWCore/AbstractServices/interface/ResourceInformation.h
@@ -22,9 +22,7 @@ namespace edm {
     ResourceInformation const& operator=(ResourceInformation const&) = delete;
     virtual ~ResourceInformation();
 
-    enum class AcceleratorType { GPU };
-
-    virtual std::vector<AcceleratorType> const& acceleratorTypes() const = 0;
+    virtual std::vector<std::string> const& selectedAccelerators() const = 0;
     virtual std::vector<std::string> const& cpuModels() const = 0;
     virtual std::vector<std::string> const& gpuModels() const = 0;
 
@@ -36,7 +34,7 @@ namespace edm {
     virtual std::string const& cpuModelsFormatted() const = 0;
     virtual double cpuAverageSpeed() const = 0;
 
-    virtual void initializeAcceleratorTypes(std::vector<std::string> const& selectedAccelerators) = 0;
+    virtual void setSelectedAccelerators(std::vector<std::string> const& selectedAccelerators) = 0;
     virtual void setCPUModels(std::vector<std::string> const&) = 0;
     virtual void setGPUModels(std::vector<std::string> const&) = 0;
 

--- a/FWCore/AbstractServices/interface/ResourceInformation.h
+++ b/FWCore/AbstractServices/interface/ResourceInformation.h
@@ -26,6 +26,8 @@ namespace edm {
     virtual std::vector<std::string> const& cpuModels() const = 0;
     virtual std::vector<std::string> const& gpuModels() const = 0;
 
+    virtual bool hasGpuNvidia() const = 0;
+
     virtual std::string const& nvidiaDriverVersion() const = 0;
     virtual int cudaDriverVersion() const = 0;
     virtual int cudaRuntimeVersion() const = 0;

--- a/FWCore/AbstractServices/src/ResourceInformation.cc
+++ b/FWCore/AbstractServices/src/ResourceInformation.cc
@@ -1,0 +1,6 @@
+#include "FWCore/AbstractServices/interface/ResourceInformation.h"
+
+namespace edm {
+  ResourceInformation::ResourceInformation() = default;
+  ResourceInformation::~ResourceInformation() = default;
+}  // namespace edm

--- a/FWCore/Framework/BuildFile.xml
+++ b/FWCore/Framework/BuildFile.xml
@@ -4,6 +4,7 @@
 <use name="tbb"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/Provenance"/>
+<use name="FWCore/AbstractServices"/>
 <use name="FWCore/Common"/>
 <use name="FWCore/Concurrency"/>
 <use name="FWCore/MessageLogger"/>

--- a/FWCore/Framework/src/ScheduleItems.cc
+++ b/FWCore/Framework/src/ScheduleItems.cc
@@ -6,6 +6,7 @@
 #include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
 #include "DataFormats/Provenance/interface/SubProcessParentageHelper.h"
 #include "DataFormats/Provenance/interface/SelectedProducts.h"
+#include "FWCore/AbstractServices/interface/ResourceInformation.h"
 #include "FWCore/Common/interface/SubProcessBlockHelper.h"
 #include "FWCore/Framework/interface/ExceptionActions.h"
 #include "FWCore/Framework/src/CommonParams.h"
@@ -19,7 +20,6 @@
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 #include "FWCore/Utilities/interface/BranchType.h"
 #include "FWCore/Utilities/interface/GetPassID.h"
-#include "FWCore/Utilities/interface/ResourceInformation.h"
 #include "FWCore/Version/interface/GetReleaseVersion.h"
 
 #include <memory>

--- a/FWCore/Framework/src/ScheduleItems.cc
+++ b/FWCore/Framework/src/ScheduleItems.cc
@@ -123,7 +123,7 @@ namespace edm {
     if (resourceInformationService.isAvailable()) {
       auto const& selectedAccelerators =
           parameterSet.getUntrackedParameter<std::vector<std::string>>("@selected_accelerators");
-      resourceInformationService->initializeAcceleratorTypes(selectedAccelerators);
+      resourceInformationService->setSelectedAccelerators(selectedAccelerators);
     }
 
     act_table_ = std::make_unique<ExceptionToActionTable>(parameterSet);

--- a/FWCore/Services/BuildFile.xml
+++ b/FWCore/Services/BuildFile.xml
@@ -1,9 +1,10 @@
 <use name="SimDataFormats/RandomEngine"/>
+<use name="FWCore/AbstractServices"/>
+<use name="FWCore/Catalog"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/ServiceRegistry"/>
 <use name="FWCore/Utilities"/>
-<use name="FWCore/Catalog"/>
 <use name="boost"/>
 <use name="tinyxml2"/>
 <use name="rootcore"/>

--- a/FWCore/Services/plugins/CPU.cc
+++ b/FWCore/Services/plugins/CPU.cc
@@ -8,6 +8,7 @@
 // Original Author:  Natalia Garcia
 // CPU.cc: v 1.0 2009/01/08 11:31:07
 
+#include "FWCore/AbstractServices/interface/ResourceInformation.h"
 #include "FWCore/MessageLogger/interface/JobReport.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
@@ -16,7 +17,6 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/CPUServiceBase.h"
-#include "FWCore/Utilities/interface/ResourceInformation.h"
 
 #include "cpu_features/cpu_features_macros.h"
 

--- a/FWCore/Services/plugins/CondorStatusUpdater.cc
+++ b/FWCore/Services/plugins/CondorStatusUpdater.cc
@@ -1,8 +1,8 @@
 
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
+#include "FWCore/AbstractServices/interface/ResourceInformation.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Utilities/interface/ResourceInformation.h"
 #include "FWCore/Utilities/interface/TimingServiceBase.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/ServiceRegistry/interface/ProcessContext.h"

--- a/FWCore/Services/plugins/ResourceInformationService.cc
+++ b/FWCore/Services/plugins/ResourceInformationService.cc
@@ -31,7 +31,7 @@ namespace edm {
 
       static void fillDescriptions(ConfigurationDescriptions&);
 
-      std::vector<AcceleratorType> const& acceleratorTypes() const final;
+      std::vector<std::string> const& selectedAccelerators() const final;
       std::vector<std::string> const& cpuModels() const final;
       std::vector<std::string> const& gpuModels() const final;
 
@@ -43,7 +43,7 @@ namespace edm {
       std::string const& cpuModelsFormatted() const final;
       double cpuAverageSpeed() const final;
 
-      void initializeAcceleratorTypes(std::vector<std::string> const& selectedAccelerators) final;
+      void setSelectedAccelerators(std::vector<std::string> const& selectedAccelerators) final;
       void setCPUModels(std::vector<std::string> const&) final;
       void setGPUModels(std::vector<std::string> const&) final;
 
@@ -59,7 +59,7 @@ namespace edm {
     private:
       void throwIfLocked() const;
 
-      std::vector<AcceleratorType> acceleratorTypes_;
+      std::vector<std::string> selectedAccelerators_;
       std::vector<std::string> cpuModels_;
       std::vector<std::string> gpuModels_;
 
@@ -87,8 +87,8 @@ namespace edm {
       descriptions.add("ResourceInformationService", desc);
     }
 
-    std::vector<ResourceInformation::AcceleratorType> const& ResourceInformationService::acceleratorTypes() const {
-      return acceleratorTypes_;
+    std::vector<std::string> const& ResourceInformationService::selectedAccelerators() const {
+      return selectedAccelerators_;
     }
 
     std::vector<std::string> const& ResourceInformationService::cpuModels() const { return cpuModels_; }
@@ -105,15 +105,9 @@ namespace edm {
 
     double ResourceInformationService::cpuAverageSpeed() const { return cpuAverageSpeed_; }
 
-    void ResourceInformationService::initializeAcceleratorTypes(std::vector<std::string> const& selectedAccelerators) {
+    void ResourceInformationService::setSelectedAccelerators(std::vector<std::string> const& selectedAccelerators) {
       if (!locked_) {
-        for (auto const& selected : selectedAccelerators) {
-          // Test if the string begins with "gpu-"
-          if (selected.rfind("gpu-", 0) == 0) {
-            acceleratorTypes_.push_back(AcceleratorType::GPU);
-            break;
-          }
-        }
+        selectedAccelerators_ = selectedAccelerators;
         locked_ = true;
       }
     }
@@ -182,16 +176,12 @@ namespace edm {
           }
         }
 
-        LogAbsolute("ResourceInformation") << "    acceleratorTypes:";
-        if (acceleratorTypes().empty()) {
+        LogAbsolute("ResourceInformation") << "    selectedAccelerators:";
+        if (selectedAccelerators().empty()) {
           LogAbsolute("ResourceInformation") << "        None";
         } else {
-          for (auto const& iter : acceleratorTypes()) {
-            std::string acceleratorTypeString("unknown type");
-            if (iter == AcceleratorType::GPU) {
-              acceleratorTypeString = std::string("GPU");
-            }
-            LogAbsolute("ResourceInformation") << "        " << acceleratorTypeString;
+          for (auto const& iter : selectedAccelerators()) {
+            LogAbsolute("ResourceInformation") << "        " << iter;
           }
         }
         LogAbsolute("ResourceInformation") << "    nvidiaDriverVersion: " << nvidiaDriverVersion();

--- a/FWCore/Services/plugins/ResourceInformationService.cc
+++ b/FWCore/Services/plugins/ResourceInformationService.cc
@@ -35,6 +35,8 @@ namespace edm {
       std::vector<std::string> const& cpuModels() const final;
       std::vector<std::string> const& gpuModels() const final;
 
+      bool hasGpuNvidia() const final;
+
       std::string const& nvidiaDriverVersion() const final;
       int cudaDriverVersion() const final;
       int cudaRuntimeVersion() const final;
@@ -70,6 +72,7 @@ namespace edm {
       std::string cpuModelsFormatted_;
       double cpuAverageSpeed_ = 0;
 
+      bool hasGpuNvidia_ = false;
       bool locked_ = false;
       bool verbose_;
     };
@@ -94,6 +97,8 @@ namespace edm {
     std::vector<std::string> const& ResourceInformationService::cpuModels() const { return cpuModels_; }
 
     std::vector<std::string> const& ResourceInformationService::gpuModels() const { return gpuModels_; }
+
+    bool ResourceInformationService::hasGpuNvidia() const { return hasGpuNvidia_; }
 
     std::string const& ResourceInformationService::nvidiaDriverVersion() const { return nvidiaDriverVersion_; }
 
@@ -125,16 +130,19 @@ namespace edm {
     void ResourceInformationService::setNvidiaDriverVersion(std::string const& val) {
       throwIfLocked();
       nvidiaDriverVersion_ = val;
+      hasGpuNvidia_ = true;
     }
 
     void ResourceInformationService::setCudaDriverVersion(int val) {
       throwIfLocked();
       cudaDriverVersion_ = val;
+      hasGpuNvidia_ = true;
     }
 
     void ResourceInformationService::setCudaRuntimeVersion(int val) {
       throwIfLocked();
       cudaRuntimeVersion_ = val;
+      hasGpuNvidia_ = true;
     }
 
     void ResourceInformationService::setCpuModelsFormatted(std::string const& val) {

--- a/FWCore/Services/plugins/ResourceInformationService.cc
+++ b/FWCore/Services/plugins/ResourceInformationService.cc
@@ -11,13 +11,13 @@
 
 */
 
+#include "FWCore/AbstractServices/interface/ResourceInformation.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 #include "FWCore/Utilities/interface/EDMException.h"
-#include "FWCore/Utilities/interface/ResourceInformation.h"
 
 #include <string>
 #include <vector>

--- a/FWCore/Services/test/test_resourceInformationService.sh
+++ b/FWCore/Services/test/test_resourceInformationService.sh
@@ -4,7 +4,10 @@ function die { echo Failure $1: status $2 ; exit $2 ; }
 
 cmsRun ${SCRAM_TEST_PATH}/test_resourceInformationService_cfg.py &> test_resourceInformationService.log || die "cmsRun test_resourceInformationService_cfg.py" $?
 
-grep -A 1 "acceleratorTypes:" test_resourceInformationService.log | grep "GPU" || die "Check for existence of GPU acceleratorType" $?
+grep -A 4 "selectedAccelerators:" test_resourceInformationService.log | grep "cpu" || die "Check for existence of cpu in selectedAccelerators" $?
+grep -A 4 "selectedAccelerators:" test_resourceInformationService.log | grep "gpu-foo" || die "Check for existence of gpu-foo in selectedAccelerators" $?
+grep -A 4 "selectedAccelerators:" test_resourceInformationService.log | grep "test1" || die "Check for existence of test1 in selectedAccelerators" $?
+grep -A 4 "selectedAccelerators:" test_resourceInformationService.log | grep "test2" || die "Check for existence of test2 in selectedAccelerators" $?
 grep -A 1 "cpu models:" test_resourceInformationService.log | grep "None" && die "Check there is at least one model (not None)" 1
 
 exit 0

--- a/FWCore/Utilities/src/ResourceInformation.cc
+++ b/FWCore/Utilities/src/ResourceInformation.cc
@@ -1,4 +1,0 @@
-#include "FWCore/Utilities/interface/ResourceInformation.h"
-
-edm::ResourceInformation::ResourceInformation() {}
-edm::ResourceInformation::~ResourceInformation() {}

--- a/HeterogeneousCore/CUDAServices/plugins/BuildFile.xml
+++ b/HeterogeneousCore/CUDAServices/plugins/BuildFile.xml
@@ -3,6 +3,7 @@
   <use name="tbb"/>
   <use name="DataFormats/Common"/>
   <use name="DataFormats/Provenance"/>
+  <use name="FWCore/AbstractServices"/>
   <use name="FWCore/MessageLogger"/>
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/ServiceRegistry"/>

--- a/HeterogeneousCore/CUDAServices/plugins/CUDAService.cc
+++ b/HeterogeneousCore/CUDAServices/plugins/CUDAService.cc
@@ -11,12 +11,12 @@
 #include <cuda_runtime.h>
 #include <nvml.h>
 
+#include "FWCore/AbstractServices/interface/ResourceInformation.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-#include "FWCore/Utilities/interface/ResourceInformation.h"
 #include "FWCore/Utilities/interface/ReusableObjectHolder.h"
 #include "HeterogeneousCore/CUDAServices/interface/CUDAInterface.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/EventCache.h"

--- a/HeterogeneousCore/CUDAServices/test/BuildFile.xml
+++ b/HeterogeneousCore/CUDAServices/test/BuildFile.xml
@@ -1,5 +1,6 @@
 <use name="catch2"/>
 <use name="fmt"/>
+<use name="FWCore/AbstractServices"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/ParameterSetReader"/>
 <use name="FWCore/PluginManager"/>

--- a/HeterogeneousCore/CUDAServices/test/testCUDAService.cpp
+++ b/HeterogeneousCore/CUDAServices/test/testCUDAService.cpp
@@ -133,6 +133,7 @@ TEST_CASE("Tests of CUDAService", "[CUDAService]") {
       REQUIRE(cuda->enabled());
       edm::Service<edm::ResourceInformation> ri;
       REQUIRE(ri);
+      REQUIRE(ri->hasGpuNvidia());
       REQUIRE(ri->gpuModels().size() > 0);
       REQUIRE(ri->nvidiaDriverVersion().size() > 0);
       REQUIRE(ri->cudaDriverVersion() == driverVersion);

--- a/HeterogeneousCore/CUDAServices/test/testCUDAService.cpp
+++ b/HeterogeneousCore/CUDAServices/test/testCUDAService.cpp
@@ -10,6 +10,7 @@
 
 #include <catch.hpp>
 
+#include "FWCore/AbstractServices/interface/ResourceInformation.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSetReader/interface/ParameterSetReader.h"
@@ -17,7 +18,6 @@
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 #include "FWCore/ServiceRegistry/interface/ServiceToken.h"
 #include "FWCore/Utilities/interface/Exception.h"
-#include "FWCore/Utilities/interface/ResourceInformation.h"
 #include "HeterogeneousCore/CUDAServices/interface/CUDAInterface.h"
 
 namespace {

--- a/HeterogeneousCore/ROCmServices/plugins/BuildFile.xml
+++ b/HeterogeneousCore/ROCmServices/plugins/BuildFile.xml
@@ -1,6 +1,7 @@
 <iftool name="rocm">
   <use name="rocm"/>
   <use name="DataFormats/Provenance"/>
+  <use name="FWCore/AbstractServices"/>
   <use name="FWCore/MessageLogger"/>
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/ServiceRegistry"/>

--- a/HeterogeneousCore/ROCmServices/plugins/ROCmService.cc
+++ b/HeterogeneousCore/ROCmServices/plugins/ROCmService.cc
@@ -14,12 +14,12 @@
 #endif  // HIP_VERSION_MAJOR
 #include <rocm_smi/rocm_smi.h>
 
+#include "FWCore/AbstractServices/interface/ResourceInformation.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-#include "FWCore/Utilities/interface/ResourceInformation.h"
 #include "HeterogeneousCore/ROCmServices/interface/ROCmInterface.h"
 #include "HeterogeneousCore/ROCmUtilities/interface/hipCheck.h"
 #include "HeterogeneousCore/ROCmUtilities/interface/rsmiCheck.h"

--- a/HeterogeneousCore/ROCmServices/test/BuildFile.xml
+++ b/HeterogeneousCore/ROCmServices/test/BuildFile.xml
@@ -1,5 +1,6 @@
 <use name="catch2"/>
 <use name="fmt"/>
+<use name="FWCore/AbstractServices"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/ParameterSetReader"/>
 <use name="FWCore/PluginManager"/>

--- a/HeterogeneousCore/ROCmServices/test/testROCmService.cpp
+++ b/HeterogeneousCore/ROCmServices/test/testROCmService.cpp
@@ -10,6 +10,7 @@
 
 #include <catch.hpp>
 
+#include "FWCore/AbstractServices/interface/ResourceInformation.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSetReader/interface/ParameterSetReader.h"
@@ -17,7 +18,6 @@
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 #include "FWCore/ServiceRegistry/interface/ServiceToken.h"
 #include "FWCore/Utilities/interface/Exception.h"
-#include "FWCore/Utilities/interface/ResourceInformation.h"
 #include "HeterogeneousCore/ROCmServices/interface/ROCmInterface.h"
 
 namespace {

--- a/PhysicsTools/PyTorch/test/BuildFile.xml
+++ b/PhysicsTools/PyTorch/test/BuildFile.xml
@@ -15,6 +15,7 @@
     <use name="cppunit"/>
     <use name="cuda"/>
     <use name="pytorch"/>
+    <use name="FWCore/AbstractServices"/>
     <use name="FWCore/ParameterSet"/>
     <use name="FWCore/ParameterSetReader"/>
     <use name="FWCore/PluginManager"/>

--- a/PhysicsTools/PyTorch/test/testBaseCUDA.h
+++ b/PhysicsTools/PyTorch/test/testBaseCUDA.h
@@ -11,6 +11,7 @@
 #include <cppunit/extensions/HelperMacros.h>
 #include <stdexcept>
 
+#include "FWCore/AbstractServices/interface/ResourceInformation.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSetReader/interface/ParameterSetReader.h"
@@ -20,7 +21,6 @@
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 #include "FWCore/ServiceRegistry/interface/ServiceToken.h"
 #include "FWCore/Utilities/interface/Exception.h"
-#include "FWCore/Utilities/interface/ResourceInformation.h"
 
 class testBasePyTorchCUDA : public CppUnit::TestFixture {
 public:

--- a/PhysicsTools/TensorFlow/BuildFile.xml
+++ b/PhysicsTools/TensorFlow/BuildFile.xml
@@ -1,5 +1,6 @@
 <use name="tbb"/>
 <use name="tensorflow-cc"/>
+<use name="FWCore/AbstractServices"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>

--- a/PhysicsTools/TensorFlow/src/TensorFlow.cc
+++ b/PhysicsTools/TensorFlow/src/TensorFlow.cc
@@ -6,9 +6,9 @@
  */
 
 #include "PhysicsTools/TensorFlow/interface/TensorFlow.h"
+#include "FWCore/AbstractServices/interface/ResourceInformation.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-#include "FWCore/Utilities/interface/ResourceInformation.h"
 
 namespace tensorflow {
 

--- a/PhysicsTools/TensorFlow/src/TensorFlow.cc
+++ b/PhysicsTools/TensorFlow/src/TensorFlow.cc
@@ -41,7 +41,7 @@ namespace tensorflow {
     }
     // NVidia GPU
     else if (backend == Backend::cuda) {
-      if (not ri->nvidiaDriverVersion().empty()) {
+      if (ri->hasGpuNvidia()) {
         // Check if one GPU device is visible to TF
         // If not, an exception is raised --> this can happen in case of driver version mismatch
         // or missing CUDA support in TF compilation
@@ -73,7 +73,7 @@ namespace tensorflow {
     // Get NVidia GPU if possible or fallback to CPU
     else if (backend == Backend::best) {
       // Check if a Nvidia GPU is availabl
-      if (not ri->nvidiaDriverVersion().empty()) {
+      if (ri->hasGpuNvidia()) {
         // Take only the first GPU in the CUDA_VISIBLE_DEVICE list
         (*_options.config.mutable_device_count())["GPU"] = 1;
         _options.config.mutable_gpu_options()->set_visible_device_list("0");

--- a/PhysicsTools/TensorFlow/test/BuildFile.xml
+++ b/PhysicsTools/TensorFlow/test/BuildFile.xml
@@ -12,6 +12,7 @@
     <use name="cppunit"/>
     <use name="cuda"/>
     <use name="tensorflow-cc"/>
+    <use name="FWCore/AbstractServices"/>
     <use name="FWCore/ParameterSet"/>
     <use name="FWCore/ParameterSetReader"/>
     <use name="FWCore/PluginManager"/>
@@ -26,6 +27,7 @@
 <bin name="testTFMetaGraphLoading" file="testRunner.cpp,testMetaGraphLoading.cc">
   <use name="boost_filesystem"/>
   <use name="cppunit"/>
+  <use name="FWCore/AbstractServices"/>
   <use name="PhysicsTools/TensorFlow"/>
 </bin>
 
@@ -35,6 +37,7 @@
     <use name="catch2"/>
     <use name="cppunit"/>
     <use name="cuda"/>
+    <use name="FWCore/AbstractServices"/>
     <use name="FWCore/ParameterSet"/>
     <use name="FWCore/ParameterSetReader"/>
     <use name="FWCore/PluginManager"/>
@@ -82,6 +85,7 @@
     <use name="catch2"/>
     <use name="cppunit"/>
     <use name="cuda"/>
+    <use name="FWCore/AbstractServices"/>
     <use name="FWCore/ParameterSet"/>
     <use name="FWCore/ParameterSetReader"/>
     <use name="FWCore/PluginManager"/>
@@ -105,6 +109,7 @@
     <use name="catch2"/>
     <use name="cppunit"/>
     <use name="cuda"/>
+    <use name="FWCore/AbstractServices"/>
     <use name="FWCore/ParameterSet"/>
     <use name="FWCore/ParameterSetReader"/>
     <use name="FWCore/PluginManager"/>
@@ -129,6 +134,7 @@
     <use name="catch2"/>
     <use name="cppunit"/>
     <use name="cuda"/>
+    <use name="FWCore/AbstractServices"/>
     <use name="FWCore/ParameterSet"/>
     <use name="FWCore/ParameterSetReader"/>
     <use name="FWCore/PluginManager"/>
@@ -160,6 +166,7 @@
     <use name="catch2"/>
     <use name="cppunit"/>
     <use name="cuda"/>
+    <use name="FWCore/AbstractServices"/>
     <use name="FWCore/ParameterSet"/>
     <use name="FWCore/ParameterSetReader"/>
     <use name="FWCore/PluginManager"/>

--- a/PhysicsTools/TensorFlow/test/testBaseCUDA.h
+++ b/PhysicsTools/TensorFlow/test/testBaseCUDA.h
@@ -13,6 +13,7 @@
 #include <stdexcept>
 #include "catch.hpp"
 
+#include "FWCore/AbstractServices/interface/ResourceInformation.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSetReader/interface/ParameterSetReader.h"
@@ -22,7 +23,6 @@
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 #include "FWCore/ServiceRegistry/interface/ServiceToken.h"
 #include "FWCore/Utilities/interface/Exception.h"
-#include "FWCore/Utilities/interface/ResourceInformation.h"
 #include "HeterogeneousCore/CUDAServices/interface/CUDAInterface.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/requireDevices.h"
 


### PR DESCRIPTION
#### PR description:

This PR is part of https://github.com/cms-sw/cmssw/issues/30044.

It primarily moves the `ResourceInformation` abstract base class to a new `FWCore/AbstractServices` package, in order to (in a subsequent PR) to have the `ResourceInformation` to return `HardwareResourcesDescription` object (added in  https://github.com/cms-sw/cmssw/pull/47175, located in `DataFormats/Provenance`). We can't make `FWCore/Utilities` to depend on `DataFormats/Provenance`, and moving a service base class to `DataFormats/Provenance` didn't feel good either. We will later move other abstract base classes from `FWCore/Utilities` to `FWCore/AbstractServices`.

In addition, to prepare for `HardwareResourcesDescription`, this PR replaces the `enum` for "available accelerator types" as string(s) for "selected accelerators", that is just what comes from `process.options.accelerators`.

In addition (mostly to just take advantage of the PR touching these packages), this PR adds `hasGpuNvidia()` member function to `ResourceInformation` that can be used (e.g. in `TensorFlow` or `PyTorch` packages) to check if the job should use NVIDIA GPUs in a way that does not directly depend on CUDA. The last commit then changes the code in `TensorFlow` to use this function.

Resolves https://github.com/cms-sw/framework-team/issues/1198
Resolves https://github.com/cms-sw/framework-team/issues/1200

#### PR validation:

Code compiles

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be eventually backported to 15_0_X.