### PR TITLE
Remove size scalar from HcalRecHitSoALayout as unused

### DIFF
--- a/DataFormats/HcalRecHit/interface/HcalRecHitSoA.h
+++ b/DataFormats/HcalRecHit/interface/HcalRecHitSoA.h
@@ -6,7 +6,6 @@
 namespace hcal {
 
   GENERATE_SOA_LAYOUT(HcalRecHitSoALayout,
-                      SOA_SCALAR(uint32_t, size),
                       SOA_COLUMN(uint32_t, detId),
                       SOA_COLUMN(float, energy),
                       SOA_COLUMN(float, chi2),


### PR DESCRIPTION
#### PR description:

While investigating https://github.com/cms-sw/cmssw/issues/47233 I noticed the `size` scalar is unused. This PR suggests to remove it.

Resolves https://github.com/cms-sw/framework-team/issues/1216

#### PR validation:

Code compiles