### PR TITLE
Remove duplication of configuration of `EGammaSuperclusterProducer` in the Phase-2 HLT menu

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTHgcalTiclPFClusteringForEgammaL1SeededSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTHgcalTiclPFClusteringForEgammaL1SeededSequence_cfi.py
@@ -45,8 +45,12 @@ hltTiclTracksterLinksSuperclusteringMustacheL1Seeded = hltTiclTracksterLinksL1Se
     tracksters_collections = [cms.InputTag("hltTiclTrackstersCLUE3DHighL1Seeded")], # to be changed to ticlTrackstersCLUE3DEM once separate CLUE3D iterations are introduced
 )
 
-from RecoHGCal.TICL.ticlEGammaSuperClusterProducer_cfi import ticlEGammaSuperClusterProducer
-hltTiclEGammaSuperClusterProducerL1Seeded = ticlEGammaSuperClusterProducer.clone()
+from RecoHGCal.TICL.ticlEGammaSuperClusterProducer_cfi import ticlEGammaSuperClusterProducer as _ticlEGammaSuperClusterProducer
+hltTiclEGammaSuperClusterProducerL1Seeded = _ticlEGammaSuperClusterProducer.clone(
+    ticlSuperClusters = "hltTiclTracksterLinksSuperclusteringDNNL1Seeded",
+    ticlTrackstersEM = "hltTiclTrackstersCLUE3DHighL1Seeded",
+    layerClusters = "hltHgcalMergeLayerClustersL1Seeded"
+)
 
 # DNN
 from Configuration.ProcessModifiers.ticl_superclustering_dnn_cff import ticl_superclustering_dnn
@@ -55,11 +59,6 @@ ticl_superclustering_dnn.toReplaceWith(_SuperclusteringL1SeededSequence,
                                                     hltTiclTracksterLinksSuperclusteringDNNL1Seeded
                                                     + hltTiclEGammaSuperClusterProducerL1Seeded
                                        )
-)
-ticl_superclustering_dnn.toModify(hltTiclEGammaSuperClusterProducerL1Seeded, 
-                                  ticlSuperClusters=cms.InputTag("hltTiclTracksterLinksSuperclusteringDNNL1Seeded"),
-                                  ticlTrackstersEM=cms.InputTag("hltTiclTrackstersCLUE3DHighL1Seeded"),
-                                  layerClusters=cms.InputTag("hltHgcalMergeLayerClustersL1Seeded")
 )
 
 # Mustache

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTHgcalTiclPFClusteringForEgammaUnseededSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTHgcalTiclPFClusteringForEgammaUnseededSequence_cfi.py
@@ -67,20 +67,20 @@ hltTiclTracksterLinksSuperclusteringMustacheUnseeded = hltTiclTracksterLinks.clo
     tracksters_collections = [cms.InputTag("hltTiclTrackstersCLUE3DHigh")], # to be changed to ticlTrackstersCLUE3DEM once separate CLUE3D iterations are introduced
 )
 
-from RecoHGCal.TICL.ticlEGammaSuperClusterProducer_cfi import ticlEGammaSuperClusterProducer
-hltTiclEGammaSuperClusterProducerUnseeded = ticlEGammaSuperClusterProducer.clone()
+from RecoHGCal.TICL.ticlEGammaSuperClusterProducer_cfi import ticlEGammaSuperClusterProducer as _ticlEGammaSuperClusterProducer
+hltTiclEGammaSuperClusterProducerUnseeded = _ticlEGammaSuperClusterProducer.clone(
+    ticlSuperClusters = "hltTiclTracksterLinksSuperclusteringDNNUnseeded",
+    ticlTrackstersEM = "hltTiclTrackstersCLUE3DHigh",
+    layerClusters = "hltHgcalMergeLayerClusters"
+)
 
+# DNN
 from Configuration.ProcessModifiers.ticl_superclustering_dnn_cff import ticl_superclustering_dnn
 ticl_superclustering_dnn.toReplaceWith(_SuperclusteringUnseededSequence, 
                                        cms.Sequence(
                                                     hltTiclTracksterLinksSuperclusteringDNNUnseeded
                                                     + hltTiclEGammaSuperClusterProducerUnseeded
                                        )
-)
-ticl_superclustering_dnn.toModify(hltTiclEGammaSuperClusterProducerUnseeded,  
-                                  ticlSuperClusters=cms.InputTag("hltTiclTracksterLinksSuperclusteringDNNUnseeded"),
-                                  ticlTrackstersEM=cms.InputTag("hltTiclTrackstersCLUE3DHigh"),
-                                  layerClusters=cms.InputTag("hltHgcalMergeLayerClusters")
 )
 
 # Ticl mustache

--- a/HLTrigger/Configuration/test/BuildFile.xml
+++ b/HLTrigger/Configuration/test/BuildFile.xml
@@ -17,3 +17,6 @@
 
 <!-- test script testOnlineVsDevTablesConsistency -->
 <test name="test_OnlineVsDevTablesConsistency" command="test_OnlineVsDevTablesConsistency.sh"/>
+
+<!-- test script check_phase2_hlt_duplicates.sh -->
+<test name="test_check_phase2_hlt_duplicates" command="check_phase2_hlt_duplicates.sh"/>

--- a/HLTrigger/Configuration/test/check_phase2_hlt_duplicates.sh
+++ b/HLTrigger/Configuration/test/check_phase2_hlt_duplicates.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Pass in name and status
+function die {
+  printf "\n%s: status %s\n" "$1" "$2"
+  if [ $# -gt 2 ]; then
+    printf "%s\n" "=== Log File =========="
+    cat $3
+    printf "%s\n" "=== End of Log File ==="
+  fi
+  exit $2
+}
+
+# Directory for the generated files
+PYTHON_FILE="Phase2_dump_cfg.py"
+DUMP_FILE="Phase2_dump.py"
+GROUPS_FILE="hltFindDuplicates_output/groups.txt"
+
+# Step 1: Generate the Python file
+cat << EOF > "$PYTHON_FILE"
+import FWCore.ParameterSet.Config as cms
+process = cms.Process("HLT")
+process.load("HLTrigger.Configuration.HLT_75e33_cff")
+EOF
+
+# Step 2: Run edmConfigDump on the generated Python file
+echo "Running edmConfigDump..."
+edmConfigDump "$PYTHON_FILE" > "$DUMP_FILE"
+if [[ $? -ne 0 ]]; then
+  echo "Error: edmConfigDump failed."
+  exit 1
+fi
+
+# Step 3: Check the dumped configuration for syntax errors
+echo "Running compilation check..."
+python3 -m py_compile "$DUMP_FILE" 2> "syntax_errors.txt"
+if [[ $? -ne 0 ]]; then
+  echo "Error: The dumped configuration has syntax errors."
+  cat "syntax_errors.txt"
+  exit 1
+fi
+
+# Step 3: Run hltFindDuplicates on the dumped configuration
+echo "Running hltFindDuplicates..."
+hltFindDuplicates $DUMP_FILE -v 2 \
+  -o hltFindDuplicates_output &> test_hltFindDuplicates_log \
+  || die 'Failure running hltFindDuplicates' $? test_hltFindDuplicates_log
+if [[ $? -ne 0 ]]; then
+  echo "Error: hltFindDuplicates failed."
+  exit 1
+fi
+
+# Step 4: Check if groups.txt is empty
+echo "Checking group file..."
+if [[ ! -f "$GROUPS_FILE" ]]; then
+  echo "Error: $GROUPS_FILE not found."
+  exit 1
+fi
+
+if [[ -s "$GROUPS_FILE" ]]; then
+  echo "Duplicates found. Contents of $GROUPS_FILE:"
+  cat "$GROUPS_FILE"
+  exit 1
+else
+  echo "No duplicates found. Exiting successfully."
+  exit 0
+fi


### PR DESCRIPTION
fixes https://github.com/cms-sw/cmssw/issues/47145

#### PR description:

Title says it all. Addresses the "duplication" (even though the modules are not actually scheduled) of  `EGammaSuperclusterProducer` modules configured with the same parameters in the Phase-2 HLT menu, by changing the `InputTags` of `hltTiclEGammaSuperClusterProducerL1Seeded` and `hltTiclEGammaSuperClusterProducerUnseeded` directly in the clone of the offline configuration, instead of within the `toModify` calls of the process modifiers (commit fa54d4313bdd6a791cb0dc8c39384158a0102900), such that two fully independent configuration are.
In the other commit 8cf372891f85d219bacf524c96208da469ce590c, I introduce a new unit test aimed to catch any possible duplicates in the Phase-2 HLT menu and fail in case it finds any.   

#### PR validation:

`scram b runtests_test_check_phase2_hlt_duplicates`   

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A

Cc:

@rovere @waredjeb 