### PR TITLE
Add protection for type change when updating branches

### DIFF
--- a/PhysicsTools/NanoAODTools/python/postprocessing/framework/preskimming.py
+++ b/PhysicsTools/NanoAODTools/python/postprocessing/framework/preskimming.py
@@ -8,7 +8,9 @@ class JSONFilter:
     def __init__(self, fname="", runsAndLumis={}):
         self.keep = {}
         if fname != "":
-            self.runsAndLumis = json.load(open(fname, 'r'))
+            jsonfp = open(fname, 'r')
+            self.runsAndLumis = json.load(jsonfp)
+            jsonfp.close()
         else:
             self.runsAndLumis = runsAndLumis
         for _run, lumis in self.runsAndLumis.items():

--- a/PhysicsTools/NanoAODTools/python/postprocessing/framework/treeReaderArrayTools.py
+++ b/PhysicsTools/NanoAODTools/python/postprocessing/framework/treeReaderArrayTools.py
@@ -10,6 +10,7 @@ def InputTree(tree, entrylist=ROOT.MakeNullPointer(ROOT.TEntryList)):
     tree.entry = -1
     tree._entrylist = entrylist
     tree._ttreereader = ROOT.TTreeReader(tree, tree._entrylist)
+    ROOT.SetOwnership(tree._ttreereader, False)
     tree._ttreereader._isClean = True
     tree._ttrvs = {}
     tree._ttras = {}
@@ -117,6 +118,7 @@ def _makeValueReader(tree, typ, nam):
 
 def _remakeAllReaders(tree):
     _ttreereader = ROOT.TTreeReader(tree, getattr(tree, '_entrylist', ROOT.MakeNullPointer(ROOT.TEntryList)))
+    ROOT.SetOwnership(_ttreereader, False)
     _ttreereader._isClean = True
     _ttrvs = {}
     for k in tree._ttrvs.keys():


### PR DESCRIPTION
#### PR description:

This PR includes some improvements:
- Preserve original branch type when updating an existing branch. This fixes a nasty issue that occurs when the user updates a branch but specifies a different type than the original one (eg Int instead of Short). The previous implementation did not check the existing type and replaced the internal buffer with a new one of the specified type, resulting in memory corruption within ROOT, and random crashes. 
- In the context of the above, the default type for len variables has be changed to "I" as this is currently the type of all lenVars in recent nanoAOD versions.
- Properly close the json file, that was opened and never closed.
- fix a ROOT vs Python ownership race for the TTreeReader, which was sometimes deleted by both at end of job, causing, in very rare cases, a crash.

#### PR validation:
- Tested running on existing nanos, with replaced variables of mismatched type
- The ownership problem was showing up as an error in the valgrind memcheck output. With the fix, the valgrind error disappears..