### PR TITLE
Fix event number overflow in ES packer

### DIFF
--- a/EventFilter/ESDigiToRaw/interface/ESDataFormatter.h
+++ b/EventFilter/ESDigiToRaw/interface/ESDataFormatter.h
@@ -11,19 +11,25 @@
 #include "DataFormats/EcalDigi/interface/ESDataFrame.h"
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "DataFormats/FEDRawData/interface/FEDRawData.h"
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 class ESDataFormatter {
 public:
   struct Meta_Data {
-    int run_number = 0;
-    int orbit_number = 0;
-    int bx = 0;
-    int lv1 = 0;
-    int kchip_bc = 0;
-    int kchip_ec = 0;
+    edm::RunNumber_t run_number = 0;
+    edm::EventNumber_t orbit_number = 0;
+    unsigned int bx = 0;
+    edm::EventNumber_t lv1 = 0;
+    unsigned int kchip_bc = 0;
+    unsigned int kchip_ec = 0;
     Meta_Data() = default;
-    Meta_Data(int r, int o, int b, int l, int k_bc, int k_ec)
+    Meta_Data(edm::RunNumber_t r,
+              edm::EventNumber_t o,
+              unsigned int b,
+              edm::EventNumber_t l,
+              unsigned int k_bc,
+              unsigned int k_ec)
         : run_number(r), orbit_number(o), bx(b), lv1(l), kchip_bc(k_bc), kchip_ec(k_ec) {}
   };
 

--- a/EventFilter/ESDigiToRaw/interface/ESDigiToRaw.h
+++ b/EventFilter/ESDigiToRaw/interface/ESDigiToRaw.h
@@ -27,10 +27,9 @@ public:
   typedef uint32_t Word32;
   typedef uint64_t Word64;
 
-  static const int BXMAX = 2808;
-  static const int LHC_BX_RANGE = 3564;
-  static const int KCHIP_BC_RANGE = 4096;
-  static const int KCHIP_EC_RANGE = 256;
+  static constexpr unsigned int LHC_BX_RANGE = 3564;
+  static constexpr unsigned int KCHIP_BC_RANGE = 4096;
+  static constexpr unsigned int KCHIP_EC_RANGE = 256;
 
 private:
   int fedId_[2][2][40][40];


### PR DESCRIPTION
#### PR description:

The event number is stored in an `int` variable in the ES packer, which overflows for event numbers > 2^31 and stores wrong data in the raw data. When this raw data are later unpacked there are no ES digis unpacked.
This PR changes the data types of the struct storing event number and run number in the ES packer data formatter to match the types in RunLumiEventNumber.h.
The dependent types in the struct are also changed.

#### PR validation:

Generated electron gun events with event numbers around 2^31 and run DIGI_L1_DIGI2RAW_HLT and RAW2DIGI_L1Reco_RECO_RECOSIM_PAT_NANO_VALIDATION_DQM steps. Without this PR events with event number > 2^31 have zero ES digis and with this PR digis are properly be unpacked.