### PR TITLE
Fix event number overflow in ECAL packer

### DIFF
--- a/EventFilter/EcalDigiToRaw/interface/BlockFormatter.h
+++ b/EventFilter/EcalDigiToRaw/interface/BlockFormatter.h
@@ -9,6 +9,7 @@
 #include <DataFormats/FEDRawData/interface/FEDRawDataCollection.h>
 #include <DataFormats/FEDRawData/interface/FEDRawData.h>
 #include <DataFormats/FEDRawData/interface/FEDRawDataCollection.h>
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
 
 class BlockFormatter {
 public:
@@ -26,11 +27,10 @@ public:
     bool doTower_;
   };
   struct Params {
-    int counter_;
     int orbit_number_;
     int bx_;
-    int lv1_;
-    int runnumber_;
+    unsigned int lv1_;
+    edm::RunNumber_t runnumber_;
   };
 
   explicit BlockFormatter(Config const& iC, Params const& iP);
@@ -44,11 +44,10 @@ public:
 protected:
   const std::vector<int32_t>* plistDCCId_;
 
-  int counter_;
   int orbit_number_;
   int bx_;
-  int lv1_;
-  int runnumber_;
+  unsigned int lv1_;
+  edm::RunNumber_t runnumber_;
 
   const bool debug_;
 

--- a/EventFilter/EcalDigiToRaw/src/BlockFormatter.cc
+++ b/EventFilter/EcalDigiToRaw/src/BlockFormatter.cc
@@ -10,7 +10,6 @@ using namespace std;
 
 BlockFormatter::BlockFormatter(Config const& iC, Params const& iP)
     : plistDCCId_{iC.plistDCCId_},
-      counter_{iP.counter_},
       orbit_number_{iP.orbit_number_},
       bx_{iP.bx_},
       lv1_{iP.lv1_},
@@ -23,9 +22,9 @@ BlockFormatter::BlockFormatter(Config const& iC, Params const& iP)
       doTower_{iC.doTower_} {}
 
 void BlockFormatter::DigiToRaw(FEDRawDataCollection* productRawData) {
-  int run_number = runnumber_;
-  int bx = bx_;
-  int lv1 = lv1_;
+  auto const run_number = runnumber_;
+  auto const bx = bx_;
+  auto const lv1 = lv1_;
 
   if (debug_)
     cout << "in BlockFormatter::DigiToRaw  run_number orbit_number bx lv1 " << dec << run_number << " " << orbit_number_

--- a/EventFilter/EcalDigiToRaw/src/EcalDigiToRaw.cc
+++ b/EventFilter/EcalDigiToRaw/src/EcalDigiToRaw.cc
@@ -61,8 +61,6 @@ public:
   typedef long long Word64;
   typedef unsigned int Word32;
 
-  static const int BXMAX = 2808;
-
 private:
   // ----------member data ---------------------------
 
@@ -125,11 +123,9 @@ void EcalDigiToRaw::produce(edm::StreamID, edm::Event& iEvent, const edm::EventS
   FEDRawDataCollection productRawData;
 
   BlockFormatter::Params params;
-  int counter = iEvent.id().event();
-  params.counter_ = counter;
   params.orbit_number_ = iEvent.orbitNumber();
   params.bx_ = iEvent.bunchCrossing();
-  params.lv1_ = counter % (0x1 << 24);
+  params.lv1_ = iEvent.id().event() % (0x1 << 24);
   params.runnumber_ = iEvent.id().run();
 
   BlockFormatter Headerblockformatter(config_, params);

--- a/EventFilter/EcalDigiToRaw/src/SRBlockFormatter.cc
+++ b/EventFilter/EcalDigiToRaw/src/SRBlockFormatter.cc
@@ -12,8 +12,8 @@ void SRBlockFormatter::DigiToRaw(int dccid, int dcc_channel, int flag, FEDRawDat
   if (debug_)
     print(rawdata);
 
-  int bx = bx_;
-  int lv1 = lv1_;
+  auto const bx = bx_;
+  auto const lv1 = lv1_;
 
   int Nrows_SRP = 5;  // Both for Barrel and EndCap (without the header row)
   int SRid = (dccid - 1) / 3 + 1;

--- a/EventFilter/EcalDigiToRaw/src/TCCBlockFormatter.cc
+++ b/EventFilter/EcalDigiToRaw/src/TCCBlockFormatter.cc
@@ -21,8 +21,8 @@ void TCCBlockFormatter::DigiToRaw(const EcalTriggerPrimitiveDigi& trigprim,
     cout << "enter in TCCBlockFormatter::DigiToRaw " << endl;
 
   int HEADER_SIZE = 8 * 9;
-  int bx = bx_;
-  int lv1 = lv1_;
+  auto const bx = bx_;
+  auto const lv1 = lv1_;
 
   const EcalTrigTowerDetId& detid = trigprim.id();
 

--- a/EventFilter/EcalDigiToRaw/src/TowerBlockFormatter.cc
+++ b/EventFilter/EcalDigiToRaw/src/TowerBlockFormatter.cc
@@ -16,8 +16,8 @@ void TowerBlockFormatter::DigiToRaw(const EBDataFrame& dataframe,
                                     const EcalElectronicsMapping* TheMapping)
 
 {
-  int bx = bx_;
-  int lv1 = lv1_ - 1;
+  auto const bx = bx_;
+  auto const lv1 = lv1_ - 1;
 
   int rdsize = rawdata.size() / 8;  // size in Word64
 


### PR DESCRIPTION
#### PR description:

This PR fixes the event number overflow occurring in the ECAL packer when event numbers > 2^31 should be packed.
The `int` variable to which the event number was written is not used in the `BlockFormatter` and has therefore been removed.
The `lv1` variable, which is derived from the event number has been changed to unsigned and the type of the variable holding the run number has been changed to the one in `RunLumiEventNumber.h`.

#### PR validation:

Passes limited matrix tests.
