### PR TITLE
[15_0_X] Reduce minYsizeB1 and minYsizeB2 CA cuts for Phase1

### DIFF
--- a/Geometry/CommonTopologies/interface/SimplePixelTopology.h
+++ b/Geometry/CommonTopologies/interface/SimplePixelTopology.h
@@ -367,9 +367,6 @@ namespace pixelTopology {
 
     static constexpr float dzdrFact = 8 * 0.0285 / 0.015;  // from dz/dr to "DY"
 
-    static constexpr int minYsizeB1 = 25;
-    static constexpr int minYsizeB2 = 15;
-
     static constexpr int nPairsMinimal = 33;
     static constexpr int nPairsFarForwards = nPairsMinimal + 8;  // include barrel "jumping" layer pairs
     static constexpr int nPairs = phase2PixelTopology::nPairs;   // include far forward layer pairs
@@ -463,9 +460,6 @@ namespace pixelTopology {
     static constexpr float bigPixYCorrection = 8.0f;
 
     static constexpr float dzdrFact = 8 * 0.0285 / 0.015;  // from dz/dr to "DY"
-
-    static constexpr int minYsizeB1 = 1;
-    static constexpr int minYsizeB2 = 1;
 
     static constexpr int nPairsForQuadruplets = 13;                     // quadruplets require hits in all layers
     static constexpr int nPairsForTriplets = nPairsForQuadruplets + 2;  // include barrel "jumping" layer pairs

--- a/Geometry/CommonTopologies/interface/SimplePixelTopology.h
+++ b/Geometry/CommonTopologies/interface/SimplePixelTopology.h
@@ -464,8 +464,8 @@ namespace pixelTopology {
 
     static constexpr float dzdrFact = 8 * 0.0285 / 0.015;  // from dz/dr to "DY"
 
-    static constexpr int minYsizeB1 = 36;
-    static constexpr int minYsizeB2 = 28;
+    static constexpr int minYsizeB1 = 1;
+    static constexpr int minYsizeB2 = 1;
 
     static constexpr int nPairsForQuadruplets = 13;                     // quadruplets require hits in all layers
     static constexpr int nPairsForTriplets = nPairsForQuadruplets + 2;  // include barrel "jumping" layer pairs

--- a/RecoTracker/PixelSeeding/plugins/CAHitNtupletGeneratorOnGPU.cc
+++ b/RecoTracker/PixelSeeding/plugins/CAHitNtupletGeneratorOnGPU.cc
@@ -130,6 +130,8 @@ namespace {
                                     cfg.getParameter<bool>("idealConditions"),
                                     (float)cfg.getParameter<double>("z0Cut"),
                                     (float)cfg.getParameter<double>("ptCut"),
+                                    cfg.getParameter<int>("minYsizeB1"),
+                                    cfg.getParameter<int>("minYsizeB2"),
                                     cfg.getParameter<std::vector<int>>("phiCuts")};
   }
 
@@ -197,6 +199,9 @@ void CAHitNtupletGeneratorOnGPU<pixelTopology::Phase1>::fillDescriptions(edm::Pa
   trackQualityCuts.add<double>("quadrupletMaxTip", 0.5)->setComment("Max |Tip| for quadruplets, in cm");
   trackQualityCuts.add<double>("quadrupletMaxZip", 12.)->setComment("Max |Zip| for quadruplets, in cm");
 
+  desc.add<int>("minYsizeB1", 1)->setComment("Min Y cluster size in pixel B1");
+  desc.add<int>("minYsizeB2", 1)->setComment("Min Y cluster size in pixel B2");
+
   desc.add<std::vector<int>>(
           "phiCuts", std::vector<int>(std::begin(phase1PixelTopology::phicuts), std::end(phase1PixelTopology::phicuts)))
       ->setComment("Cuts in phi for cells");
@@ -230,6 +235,9 @@ void CAHitNtupletGeneratorOnGPU<pixelTopology::HIonPhase1>::fillDescriptions(edm
   trackQualityCuts.add<double>("quadrupletMaxTip", 0.5)->setComment("Max |Tip| for quadruplets, in cm");
   trackQualityCuts.add<double>("quadrupletMaxZip", 6.)->setComment("Max |Zip| for quadruplets, in cm");
 
+  desc.add<int>("minYsizeB1", 36)->setComment("Min Y cluster size in pixel B1");
+  desc.add<int>("minYsizeB2", 28)->setComment("Min Y cluster size in pixel B2");
+
   desc.add<std::vector<int>>(
           "phiCuts", std::vector<int>(std::begin(phase1PixelTopology::phicuts), std::end(phase1PixelTopology::phicuts)))
       ->setComment("Cuts in phi for cells");
@@ -255,6 +263,9 @@ void CAHitNtupletGeneratorOnGPU<pixelTopology::Phase2>::fillDescriptions(edm::Pa
   trackQualityCuts.add<double>("minPt", 0.5)->setComment("Min pT in GeV");
   trackQualityCuts.add<double>("maxTip", 0.3)->setComment("Max |Tip| in cm");
   trackQualityCuts.add<double>("maxZip", 12.)->setComment("Max |Zip|, in cm");
+
+  desc.add<int>("minYsizeB1", 25)->setComment("Min Y cluster size in pixel B1");
+  desc.add<int>("minYsizeB2", 15)->setComment("Min Y cluster size in pixel B2");
 
   desc.add<std::vector<int>>(
           "phiCuts", std::vector<int>(std::begin(phase2PixelTopology::phicuts), std::end(phase2PixelTopology::phicuts)))

--- a/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGenerator.cc
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGenerator.cc
@@ -150,6 +150,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                       cfg.getParameter<bool>("idealConditions"),
                                       (float)cfg.getParameter<double>("cellZ0Cut"),
                                       (float)cfg.getParameter<double>("cellPtCut"),
+                                      cfg.getParameter<int>("minYsizeB1"),
+                                      cfg.getParameter<int>("minYsizeB2"),
                                       cfg.getParameter<std::vector<int>>("phiCuts")};
     }
 
@@ -221,6 +223,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
             "\"region "
             "cuts\" based on the fit results (pT, Tip, Zip).");
 
+    desc.add<int>("minYsizeB1", 1)->setComment("Min Y cluster size in pixel B1");
+    desc.add<int>("minYsizeB2", 1)->setComment("Min Y cluster size in pixel B2");
+
     desc.add<std::vector<int>>(
             "phiCuts",
             std::vector<int>(std::begin(phase1PixelTopology::phicuts), std::end(phase1PixelTopology::phicuts)))
@@ -257,6 +262,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
             "\"region "
             "cuts\" based on the fit results (pT, Tip, Zip).");
 
+    desc.add<int>("minYsizeB1", 36)->setComment("Min Y cluster size in pixel B1");
+    desc.add<int>("minYsizeB2", 28)->setComment("Min Y cluster size in pixel B2");
+
     desc.add<std::vector<int>>(
             "phiCuts",
             std::vector<int>(std::begin(phase1PixelTopology::phicuts), std::end(phase1PixelTopology::phicuts)))
@@ -283,6 +291,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         ->setComment(
             "Quality cuts based on the results of the track fit:\n  - apply cuts based on the fit results (pT, Tip, "
             "Zip).");
+
+    desc.add<int>("minYsizeB1", 25)->setComment("Min Y cluster size in pixel B1");
+    desc.add<int>("minYsizeB2", 15)->setComment("Min Y cluster size in pixel B2");
 
     desc.add<std::vector<int>>(
             "phiCuts",

--- a/RecoTracker/PixelSeeding/plugins/alpaka/CAPixelDoubletsAlgos.h
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CAPixelDoubletsAlgos.h
@@ -52,13 +52,17 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::caPixelDoublets {
               const bool idealConditions,
               const float z0Cut,
               const float ptCut,
+              const int minYsizeB1,
+              const int minYsizeB2,
               const std::vector<int>& phiCutsV)
         : doClusterCut_(doClusterCut),
           doZ0Cut_(doZ0Cut),
           doPtCut_(doPtCut),
           idealConditions_(idealConditions),
           z0Cut_(z0Cut),
-          ptCut_(ptCut) {
+          ptCut_(ptCut),
+          minYsizeB1_(minYsizeB1),
+          minYsizeB2_(minYsizeB2) {
       assert(phiCutsV.size() == TrackerTraits::nPairs);
       std::copy(phiCutsV.begin(), phiCutsV.end(), &phiCuts[0]);
     }
@@ -70,6 +74,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::caPixelDoublets {
 
     float z0Cut_;  //FIXME: check if could be const now
     float ptCut_;
+
+    int minYsizeB1_;
+    int minYsizeB2_;
 
     int phiCuts[T::nPairs];
 
@@ -119,11 +126,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::caPixelDoublets {
       auto mes = (!innerB1) || isOuterLadder ? hh[i].clusterSizeY() : -1;
 
       if (innerB1)  // B1
-        if (mes > 0 && mes < T::minYsizeB1)
+        if (mes > 0 && mes < minYsizeB1_)
           return true;                                                                 // only long cluster  (5*8)
       bool innerB2 = (mi >= T::last_bpix1_detIndex) && (mi < T::last_bpix2_detIndex);  //FIXME number
       if (innerB2)                                                                     // B2 and F1
-        if (mes > 0 && mes < T::minYsizeB2)
+        if (mes > 0 && mes < minYsizeB2_)
           return true;
 
       return false;

--- a/RecoTracker/PixelSeeding/plugins/gpuPixelDoubletsAlgos.h
+++ b/RecoTracker/PixelSeeding/plugins/gpuPixelDoubletsAlgos.h
@@ -47,13 +47,17 @@ namespace gpuPixelDoublets {
               const bool idealConditions,
               const float z0Cut,
               const float ptCut,
+              const int minYsizeB1,
+              const int minYsizeB2,
               const std::vector<int>& phiCutsV)
         : doClusterCut_(doClusterCut),
           doZ0Cut_(doZ0Cut),
           doPtCut_(doPtCut),
           idealConditions_(idealConditions),
           z0Cut_(z0Cut),
-          ptCut_(ptCut) {
+          ptCut_(ptCut),
+          minYsizeB1_(minYsizeB1),
+          minYsizeB2_(minYsizeB2) {
       assert(phiCutsV.size() == TrackerTraits::nPairs);
       std::copy(phiCutsV.begin(), phiCutsV.end(), &phiCuts[0]);
     }
@@ -65,6 +69,9 @@ namespace gpuPixelDoublets {
 
     float z0Cut_;
     float ptCut_;
+
+    int minYsizeB1_;
+    int minYsizeB2_;
 
     int phiCuts[T::nPairs];
 
@@ -107,11 +114,11 @@ namespace gpuPixelDoublets {
       auto mes = (!innerB1) || isOuterLadder ? hh[i].clusterSizeY() : -1;
 
       if (innerB1)  // B1
-        if (mes > 0 && mes < T::minYsizeB1)
+        if (mes > 0 && mes < minYsizeB1_)
           return true;                                                                 // only long cluster  (5*8)
       bool innerB2 = (mi >= T::last_bpix1_detIndex) && (mi < T::last_bpix2_detIndex);  //FIXME number
       if (innerB2)                                                                     // B2 and F1
-        if (mes > 0 && mes < T::minYsizeB2)
+        if (mes > 0 && mes < minYsizeB2_)
           return true;
 
       return false;


### PR DESCRIPTION
#### PR description:

This PR is a **backport of #47271**.  

The PR aims to minimize the Cluster Size Cuts for the Phase 1 geometry on the B1 and B2 layers, specifically when considering B1-FPIX and B2-FPIX doublets. These doublets serve as the initial inputs for the CA. The changes have been tested on top of the Phase 1 CA-tuned parameters.

This adjustment results in about 5% relative efficiency gain in `hltIter0PFlowTrackSelectionHighPurity` and a 3% gain in `hltMerged`. Additionally, it reduces the reliance on the Doublet Recovery iteration, leading to a corresponding decrease in efficiency for `hltDoubletRecoveryPFlowTrackSelectionHighPurity`. Track resolution shows a small improvement as a function of pT.

#### PR validation:

600 events TTBarPU 2025 (/RelValTTbar_14TeV/CMSSW_14_2_1-PU_142X_mcRun3_2025_realistic_v4_STD_Winter25_PU-v1/GEN-SIM-DIGI-RAW):
http://uaf-3.t2.ucsd.edu/~bdanzi/PR_2025/plots_hlt.html
500 events TTBarPU EEOR3 (/RelValTTbar_14TeV/CMSSW_14_0_9-PU_140X_mcRun3_2024_realistic_EOR3_TkDPGv7_RV245_2024-v2/GEN-SIM-DIGI-RAW):
http://uaf-3.t2.ucsd.edu/~bdanzi/PRClusterSize_EEOR3_TTBarPU/plots_hlt.html

@mmasciov @mmusich 
<details>
  <summary>Instructions on how to run </summary>

Tested in `CMSSW_15_0_0_pre2` at HLT step. 

Generate the `.cff `file on lxplus and place it inside `HLTrigger/Configuration/python` by running:

`hltGetConfiguration /dev/CMSSW_14_2_0/GRun/V10 --globaltag 140X_mcRun3_2024_realistic_EOR3_TkDPGv7  --mc --unprescale --output minimal --max-events 500 --input file:input_file.root --cff --eras Run3_2024 --l1-emulator uGT --l1 L1Menu_Collisions2024_v1_3_0_xml  --paths MC_ReducedIterativeTracking_v22  > hltMC_default_onlyTracking.py`

The `.cff` should be loaded to run the following script:

```
import FWCore.ParameterSet.Config as cms
from Configuration.Eras.Era_Run3_2024_cff import Run3_2024
process = cms.Process( "HLTX", Run3_2024)

process.load("Configuration.StandardSequences.Accelerators_cff")
# import of standard configurations
process.load('Configuration.StandardSequences.Services_cff')
process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
process.load('FWCore.MessageService.MessageLogger_cfi')
process.load('Configuration.EventContent.EventContent_cff')
process.load('SimGeneral.MixingModule.mixNoPU_cfi')
process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
process.load('Configuration.StandardSequences.MagneticField_cff')
process.load('HLTrigger.Configuration.hltMC_default_onlyTracking')
process.load('Configuration.StandardSequences.Validation_cff')
process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')

process.maxEvents = cms.untracked.PSet(
    input = cms.untracked.int32(-1),
    output = cms.optional.untracked.allowed(cms.int32,cms.PSet)
)

# Input source
process.source = cms.Source("PoolSource",
    fileNames = cms.untracked.vstring(
    'file:input_file.root'
    ),
    secondaryFileNames = cms.untracked.vstring()
)

process.options = cms.untracked.PSet(
    IgnoreCompletely = cms.untracked.vstring(),
    Rethrow = cms.untracked.vstring(),
    TryToContinue = cms.untracked.vstring(),
    accelerators = cms.untracked.vstring('*'),
    allowUnscheduled = cms.obsolete.untracked.bool,
    canDeleteEarly = cms.untracked.vstring(),
    deleteNonConsumedUnscheduledModules = cms.untracked.bool(True),
    dumpOptions = cms.untracked.bool(False),
    emptyRunLumiMode = cms.obsolete.untracked.string,
    eventSetup = cms.untracked.PSet(
        forceNumberOfConcurrentIOVs = cms.untracked.PSet(
            allowAnyLabel_=cms.required.untracked.uint32
        ),
        numberOfConcurrentIOVs = cms.untracked.uint32(0)
    ),
    fileMode = cms.untracked.string('FULLMERGE'),
    forceEventSetupCacheClearOnNewRun = cms.untracked.bool(False),
    holdsReferencesToDeleteEarly = cms.untracked.VPSet(),
    makeTriggerResults = cms.obsolete.untracked.bool,
    modulesToCallForTryToContinue = cms.untracked.vstring(),
    modulesToIgnoreForDeleteEarly = cms.untracked.vstring(),
    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(0),
    numberOfConcurrentRuns = cms.untracked.uint32(1),
    numberOfStreams = cms.untracked.uint32(0),
    numberOfThreads = cms.untracked.uint32(8),
    printDependencies = cms.untracked.bool(False),
    sizeOfStackForThreadsInKB = cms.optional.untracked.uint32,
    throwIfIllegalParameter = cms.untracked.bool(True),
    wantSummary = cms.untracked.bool(False)
)

# Production Info
process.configurationMetadata = cms.untracked.PSet(
    annotation = cms.untracked.string('step2 nevts:10'),
    name = cms.untracked.string('Applications'),
    version = cms.untracked.string('$Revision: 1.19 $')
)

# Output definition

process.DQMoutput = cms.OutputModule("DQMRootOutputModule",
    dataset = cms.untracked.PSet(
        dataTier = cms.untracked.string('DQMIO'),
        filterName = cms.untracked.string('')
    ),
    fileName = cms.untracked.string('step2_HLT_VALIDATION_paramTuned.root'),
    outputCommands = process.DQMEventContent.outputCommands,
    splitLevel = cms.untracked.int32(0)
)

# Additional output definition

# Other statements
from HLTrigger.Configuration.CustomConfigs import ProcessName
process = ProcessName(process)

from Configuration.Applications.ConfigBuilder import ConfigBuilder
process.hltMultiTrackValidation.visit(ConfigBuilder.MassSearchReplaceProcessNameVisitor("HLT", "HLTX", whitelist = ("subSystemFolder",), verbose = False))
process.mix.playback = True
process.mix.digitizers = cms.PSet()
for a in process.aliases: delattr(process, a)
process.RandomNumberGeneratorService.restoreStateLabel=cms.untracked.string("randomEngineStateProducer")
from Configuration.AlCa.GlobalTag import GlobalTag
process.GlobalTag = GlobalTag(process.GlobalTag, '140X_mcRun3_2024_realistic_EOR3_TkDPGv7', '')
process.hltTrackValidator.label = ["hltPixelTracks", "hltIter0PFlowCtfWithMaterialTracks", "hltIter0PFlowTrackSelectionHighPurity", "hltMergedTracks","hltDoubletRecoveryPFlowTrackSelectionHighPurity"]
# Path and EndPath definitions
process.validation_step = cms.EndPath(process.hltMultiTrackValidation)
process.DQMoutput_step = cms.EndPath(process.DQMoutput)

process.hltSiStripRawToClustersFacility.onDemand = cms.bool(False)
process.hltPixelTracksSoA.CAThetaCutBarrel = cms.double(0.00111685053)
process.hltPixelTracksSoA.CAThetaCutForward = cms.double(0.00249872683)
process.hltPixelTracksSoA.hardCurvCut =  cms.double(0.695091509)
process.hltPixelTracksSoA.dcaCutInnerTriplet = cms.double(0.0419242041)
process.hltPixelTracksSoA.dcaCutOuterTriplet = cms.double(0.293522194)
process.hltPixelTracksSoA.phiCuts = cms.vint32(
    832, 379, 481, 765, 1136,
    706, 656, 407, 1212, 404,
    699, 470, 652, 621, 1017,
    616, 450, 555, 572
)
# Schedule definition
# process.schedule imported from cff in HLTrigger.Configuration
process.schedule.extend([process.validation_step,process.DQMoutput_step])
from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
associatePatAlgosToolsTask(process)

# customisation of the process.

# Automatic addition of the customisation function from HLTrigger.Configuration.customizeHLTforMC
from HLTrigger.Configuration.customizeHLTforMC import customizeHLTforMC 

#call to customisation function customizeHLTforMC imported from HLTrigger.Configuration.customizeHLTforMC
process = customizeHLTforMC(process)

# Automatic addition of the customisation function from SimGeneral.MixingModule.fullMixCustomize_cff
from SimGeneral.MixingModule.fullMixCustomize_cff import setCrossingFrameOn 

#call to customisation function setCrossingFrameOn imported from SimGeneral.MixingModule.fullMixCustomize_cff
process = setCrossingFrameOn(process)
```
</details>