### PR TITLE
Can specify TBranch aliases in PoolOutputModule

### DIFF
--- a/IOPool/Output/interface/PoolOutputModule.h
+++ b/IOPool/Output/interface/PoolOutputModule.h
@@ -128,11 +128,24 @@ namespace edm {
       int splitLevel_;
     };
 
+    struct AliasForBranch {
+      AliasForBranch(std::string const& iBranchName, std::string const& iAlias)
+          : branch_{convert(iBranchName)}, alias_{iAlias} {}
+
+      bool match(std::string const& iBranchName) const;
+      std::regex convert(std::string const& iGlobBranchExpression) const;
+
+      std::regex branch_;
+      std::string alias_;
+    };
+
     std::vector<OutputItemList> const& selectedOutputItemList() const { return selectedOutputItemList_; }
 
     std::vector<OutputItemList>& selectedOutputItemList() { return selectedOutputItemList_; }
 
     ProductDependencies const& productDependencies() const { return productDependencies_; }
+
+    std::vector<AliasForBranch> const& aliasForBranches() const { return aliasForBranches_; }
 
   protected:
     ///allow inheriting classes to override but still be able to call this method in the overridden version
@@ -192,6 +205,7 @@ namespace edm {
     AuxItemArray auxItems_;
     std::vector<OutputItemList> selectedOutputItemList_;
     std::vector<SpecialSplitLevelForBranch> specialSplitLevelForBranches_;
+    std::vector<AliasForBranch> aliasForBranches_;
     std::unique_ptr<edm::ProductRegistry const> reg_;
     std::string const fileName_;
     std::string const logicalFileName_;

--- a/IOPool/Output/src/RootOutputFile.cc
+++ b/IOPool/Output/src/RootOutputFile.cc
@@ -815,13 +815,21 @@ namespace edm {
                                         SelectedProducts const& branches,
                                         std::string const& processName) const {
     if (tree && tree->GetNbranches() != 0) {
+      auto const& aliasForBranches = om_->aliasForBranches();
       for (auto const& selection : branches) {
         ProductDescription const& pd = *selection.first;
         if (pd.branchType() == InProcess && processName != pd.processName()) {
           continue;
         }
         std::string const& full = pd.branchName() + "obj";
-        if (pd.branchAliases().empty()) {
+        bool matched = false;
+        for (auto const& matcher : aliasForBranches) {
+          if (matcher.match(pd.branchName())) {
+            tree->SetAlias(matcher.alias_.c_str(), full.c_str());
+            matched = true;
+          }
+        }
+        if (not matched and pd.branchAliases().empty()) {
           std::string const& alias = (pd.productInstanceName().empty() ? pd.moduleLabel() : pd.productInstanceName());
           tree->SetAlias(alias.c_str(), full.c_str());
         } else {

--- a/IOPool/Output/test/BuildFile.xml
+++ b/IOPool/Output/test/BuildFile.xml
@@ -1,1 +1,2 @@
 <test name="TestPoolOutput" command="TestPoolOutput.sh"/>
+<test name="TestPoolOutputAlias" command="PoolOutputAliasTest.sh"/>

--- a/IOPool/Output/test/PoolOutputAliasTest.sh
+++ b/IOPool/Output/test/PoolOutputAliasTest.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Pass in name and status
+function die { echo $1: status $2 ;  exit $2; }
+
+LOCAL_TEST_DIR=$SCRAM_TEST_PATH
+
+cmsRun ${LOCAL_TEST_DIR}/PoolOutputAliasTest_cfg.py || die 'Failure using PoolOutputAliasTest_cfg.py 1' $?
+python3 ${LOCAL_TEST_DIR}/PoolOutputAliasTestCheckResults.py || die 'results check failed' $?

--- a/IOPool/Output/test/PoolOutputAliasTestCheckResults.py
+++ b/IOPool/Output/test/PoolOutputAliasTestCheckResults.py
@@ -1,0 +1,8 @@
+import ROOT
+
+file = ROOT.TFile.Open("alias.root")
+events = file.Get("Events")
+
+b = events.GetAlias("foo")
+if not b:
+    raise RuntimeError("foo missing")

--- a/IOPool/Output/test/PoolOutputAliasTest_cfg.py
+++ b/IOPool/Output/test/PoolOutputAliasTest_cfg.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+process.maxEvents.input = 10
+
+from FWCore.Modules.modules import EmptySource
+
+process.source = EmptySource()
+
+from FWCore.Integration.modules import ThingProducer
+
+process.thing = ThingProducer()
+
+from IOPool.Output.modules import PoolOutputModule
+
+process.out = PoolOutputModule(fileName = "alias.root",
+                               branchAliases = [cms.PSet(branch=cms.untracked.string("*_thing_*_*"), alias = cms.untracked.string("foo"))])
+
+process.e = cms.EndPath(process.out, cms.Task(process.thing))


### PR DESCRIPTION
#### PR description:

Added ability to specify aliases for TBranches via the PoolOutputModule's configuration.

#### PR validation:

Code compiles and new unit test passes.

resolves https://github.com/cms-sw/framework-team/issues/1222