### PR TITLE
Implement a compile-time warp size constant

### DIFF
--- a/HeterogeneousCore/AlpakaInterface/interface/warpsize.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/warpsize.h
@@ -1,0 +1,24 @@
+#ifndef HeterogeneousCore_AlpakaInterface_interface_warpsize_h
+#define HeterogeneousCore_AlpakaInterface_interface_warpsize_h
+
+namespace cms::alpakatools {
+
+  // TODO implement constexpt warp size in alpaka, and replace this workaround with that functionality.
+#if defined(__SYCL_DEVICE_ONLY__)
+// the warp size is not defined at compile time for SYCL backend
+#error "The SYCL backend does not support compile-time warp size"
+  inline constexpr int warpSize = 0;
+#elif defined(__CUDA_ARCH__)
+  // CUDA always has a warp size of 32
+  inline constexpr int warpSize = 32;
+#elif defined(__HIP_DEVICE_COMPILE__)
+  // HIP/ROCm defines warpSize as a constant expression in device code, with value 32 or 64 depending on the target device
+  inline constexpr int warpSize = ::warpSize;
+#else
+  // CPU back-ends always have a warp size of 1
+  inline constexpr int warpSize = 1;
+#endif
+
+}  // namespace cms::alpakatools
+
+#endif  // HeterogeneousCore_AlpakaInterface_interface_warpsize_h

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/PixelClustering.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/PixelClustering.h
@@ -14,6 +14,7 @@
 #include "HeterogeneousCore/AlpakaInterface/interface/HistoContainer.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/SimpleVector.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/warpsize.h"
 
 //#define GPU_DEBUG
 
@@ -179,11 +180,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering {
                                                       TrackerTraits::maxPixInModule,
                                                       TrackerTraits::clusterBits,
                                                       uint16_t>;
-#if defined(__HIP_DEVICE_COMPILE__)
-        constexpr auto warpSize = __AMDGCN_WAVEFRONT_SIZE;
-#else
-        constexpr auto warpSize = 32;
-#endif
+        constexpr int warpSize = cms::alpakatools::warpSize;
         auto& hist = alpaka::declareSharedVar<Hist, __COUNTER__>(acc);
         auto& ws = alpaka::declareSharedVar<typename Hist::Counter[warpSize], __COUNTER__>(acc);
         for (uint32_t j : cms::alpakatools::independent_group_elements(acc, Hist::totbins())) {

--- a/RecoVertex/PixelVertexFinding/plugins/alpaka/clusterTracksByDensity.h
+++ b/RecoVertex/PixelVertexFinding/plugins/alpaka/clusterTracksByDensity.h
@@ -10,6 +10,7 @@
 #include "DataFormats/VertexSoA/interface/ZVertexSoA.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/HistoContainer.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/warpsize.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
 #include "RecoVertex/PixelVertexFinding/interface/PixelVertexWorkSpaceLayout.h"
 
@@ -54,12 +55,13 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::vertexFinder {
 
     using Hist = cms::alpakatools::HistoContainer<uint8_t, 256, 16000, 8, uint16_t>;
     auto& hist = alpaka::declareSharedVar<Hist, __COUNTER__>(acc);
-    auto& hws = alpaka::declareSharedVar<Hist::Counter[32], __COUNTER__>(acc);
+    constexpr int warpSize = cms::alpakatools::warpSize;
+    auto& hws = alpaka::declareSharedVar<Hist::Counter[warpSize], __COUNTER__>(acc);
 
     for (auto j : cms::alpakatools::uniform_elements(acc, Hist::totbins())) {
       hist.off[j] = 0;
     }
-    for (auto j : cms::alpakatools::uniform_elements(acc, 32)) {
+    for (auto j : cms::alpakatools::uniform_elements(acc, warpSize)) {
       hws[j] = 0;  // used by prefix scan in hist.finalize()
     }
     alpaka::syncBlockThreads(acc);

--- a/RecoVertex/PixelVertexFinding/plugins/alpaka/sortByPt2.h
+++ b/RecoVertex/PixelVertexFinding/plugins/alpaka/sortByPt2.h
@@ -12,6 +12,7 @@
 #include "HeterogeneousCore/AlpakaInterface/interface/HistoContainer.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/radixSort.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/warpsize.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
 #include "RecoVertex/PixelVertexFinding/interface/PixelVertexWorkSpaceLayout.h"
 
@@ -61,7 +62,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::vertexFinder {
     }
 
     if constexpr (not cms::alpakatools::requires_single_thread_per_block_v<Acc1D>) {
-      auto& sws = alpaka::declareSharedVar<uint16_t[1024], __COUNTER__>(acc);
+      constexpr int warpSize = cms::alpakatools::warpSize;
+      auto& sws = alpaka::declareSharedVar<uint16_t[warpSize * warpSize], __COUNTER__>(acc);
       // sort using only 16 bits
       cms::alpakatools::radixSort<Acc1D, float, 2>(acc, ptv2, sortInd, sws, nvFinal);
     } else {


### PR DESCRIPTION
#### PR description:

Implement a compile-time warp size constant, and update the alpaka-based modules to use it instead of assuming a warp size of 32.

#### PR validation:

More unit tests and relvals succeed on LUMI with MI250x GPUs.
No changes expected on Radeon Pro or CUDA GPUs.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Fix to be backported to 15.0.x (#47301, same branch)