### PR TITLE
Add era modifiers for ScoutingNano to account for changes in 2022-24 and beginning of 2025

### DIFF
--- a/Configuration/Eras/python/Era_Run3_2023_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2023_cff.py
@@ -2,5 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Run3_cff import Run3
 from Configuration.Eras.Modifier_run3_egamma_2023_cff import run3_egamma_2023
+from Configuration.Eras.Modifier_run3_scouting_nanoAOD_2023_cff import run3_scouting_nanoAOD_2023
 
-Run3_2023 = cms.ModifierChain(Run3, run3_egamma_2023)
+Run3_2023 = cms.ModifierChain(Run3, run3_egamma_2023, run3_scouting_nanoAOD_2023)

--- a/Configuration/Eras/python/Era_Run3_2024_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2024_cff.py
@@ -2,6 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Run3_cff import Run3
 from Configuration.Eras.Modifier_stage2L1Trigger_2024_cff import stage2L1Trigger_2024
-from Configuration.Eras.Modifier_run3_scouting_nanoAOD_post2023_cff import run3_scouting_nanoAOD_post2023
+from Configuration.Eras.Modifier_run3_scouting_nanoAOD_2024_cff import run3_scouting_nanoAOD_2024
 
-Run3_2024 = cms.ModifierChain(Run3, stage2L1Trigger_2024, run3_scouting_nanoAOD_post2023)
+Run3_2024 = cms.ModifierChain(Run3, stage2L1Trigger_2024, run3_scouting_nanoAOD_2024)

--- a/Configuration/Eras/python/Era_Run3_2025_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2025_cff.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Run3_2024_cff import Run3_2024
+from Configuration.Eras.Modifier_run3_scouting_nanoAOD_2025_cff import run3_scouting_nanoAOD_2025
 
-Run3_2025 = cms.ModifierChain(Run3_2024)
+Run3_2025 = cms.ModifierChain(Run3_2024, run3_scouting_nanoAOD_2025)

--- a/Configuration/Eras/python/Modifier_run3_scouting_nanoAOD_2023_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_scouting_nanoAOD_2023_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+run3_scouting_nanoAOD_2023 = cms.Modifier()

--- a/Configuration/Eras/python/Modifier_run3_scouting_nanoAOD_2024_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_scouting_nanoAOD_2024_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+run3_scouting_nanoAOD_2024 = cms.Modifier()

--- a/Configuration/Eras/python/Modifier_run3_scouting_nanoAOD_2025_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_scouting_nanoAOD_2025_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+run3_scouting_nanoAOD_2025 = cms.Modifier()

--- a/Configuration/Eras/python/Modifier_run3_scouting_nanoAOD_post2023_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_scouting_nanoAOD_post2023_cff.py
@@ -1,3 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-run3_scouting_nanoAOD_post2023 = cms.Modifier()

--- a/Configuration/PyReleaseValidation/python/relval_nano.py
+++ b/Configuration/PyReleaseValidation/python/relval_nano.py
@@ -250,10 +250,7 @@ steps['jmeNANO_rePuppi_data14.0'] = merge([{'-s': 'NANO:@JMErePuppi', '-n': '100
 steps['scoutingNANO_data14.0'] = merge([{'-s': 'NANO:@Scout'},
                                         steps['NANO_data14.0']])
 
-# Process.options.TryToContinue = cms.untracked.vstring(\'ProductNotFound\') is needed here because some events in ScoutingPFMonitor in 2024 do not contain scouting objects.
-# This should be fixed in 2025 (https://its.cern.ch/jira/browse/CMSHLT-3331) so customise_commands won't be needed for 2025 workflow.
-steps['scoutingNANO_withPrompt_data14.0'] = merge([{'-s': 'NANO:@Prompt+@Scout', 
-                                                   '--customise_commands': '"process.options.TryToContinue = cms.untracked.vstring(\'ProductNotFound\')"'},
+steps['scoutingNANO_withPrompt_data14.0'] = merge([{'-s': 'NANO:@Prompt+@ScoutMonitor'},
                                                    steps['NANO_data14.0']])
 
 # DPG custom NANO

--- a/PhysicsTools/NanoAOD/python/autoNANO.py
+++ b/PhysicsTools/NanoAOD/python/autoNANO.py
@@ -34,8 +34,10 @@ autoNANO = {
     # Scouting nano
     'Scout' : {'sequence': 'PhysicsTools/NanoAOD/custom_run3scouting_cff.scoutingNanoSequence',
                'customize': 'PhysicsTools/NanoAOD/custom_run3scouting_cff.customiseScoutingNano'},
+    'ScoutMonitor' : {'sequence': '@Scout',
+                       'customize': 'PhysicsTools/NanoAOD/custom_run3scouting_cff.customiseScoutingNanoForScoutingPFMonitor+@Scout'},
     'ScoutFromMini' : {'sequence': '@Scout',
-                       'customize': '@Scout+PhysicsTools/NanoAOD/custom_run3scouting_cff.customiseScoutingNanoFromMini'},
+                       'customize': 'PhysicsTools/NanoAOD/custom_run3scouting_cff.customiseScoutingNanoFromMini+@Scout'},
     # JME nano
     'JME': {'sequence': '@PHYS',
             'customize': '@PHYS+PhysicsTools/NanoAOD/custom_jme_cff.PrepJMECustomNanoAOD'},

--- a/PhysicsTools/NanoAOD/python/run3scouting_cff.py
+++ b/PhysicsTools/NanoAOD/python/run3scouting_cff.py
@@ -76,7 +76,8 @@ scoutingMuonTable = cms.EDProducer("SimpleRun3ScoutingMuonFlatTableProducer",
 )
 
 # Scouting Displaced Vertex (Muon)
-# https://github.com/cms-sw/cmssw/blob/CMSSW_14_0_X/DataFormats/Scouting/interface/Run3ScoutingVertex.h
+# format during 2022-23 data-taking
+# https://github.com/cms-sw/cmssw/blob/CMSSW_13_0_X/DataFormats/Scouting/interface/Run3ScoutingVertex.h
 
 scoutingMuonDisplacedVertexTable = cms.EDProducer("SimpleRun3ScoutingVertexFlatTableProducer",
     src = cms.InputTag("hltScoutingMuonPacker","displacedVtx"),
@@ -127,8 +128,9 @@ scoutingMuonNoVtxDisplacedVertexTable = scoutingMuonDisplacedVertexTable.clone(
 )
 
 # Scouting Electron
-# https://github.com/cms-sw/cmssw/blob/CMSSW_14_0_X/DataFormats/Scouting/interface/Run3ScoutingElectron.h
-
+# format during 2022 data-taking 
+# for accessing d0, dz, and charge, use changes from  https://github.com/cms-sw/cmssw/pull/41025
+# https://github.com/cms-sw/cmssw/blob/CMSSW_12_4_X/DataFormats/Scouting/interface/Run3ScoutingElectron.h
 scoutingElectronTable = cms.EDProducer("SimpleRun3ScoutingElectronFlatTableProducer",
     src = cms.InputTag("hltScoutingEgammaPacker"),
     cut = cms.string(""),
@@ -138,15 +140,18 @@ scoutingElectronTable = cms.EDProducer("SimpleRun3ScoutingElectronFlatTableProdu
     extension = cms.bool(False),
     variables = cms.PSet(
         pt = Var('pt', 'float', precision=10, doc='super-cluster (SC) pt'),
-        eta = Var('eta', 'float', precision=10, doc='SC eta'),
-        phi = Var('phi', 'float', precision=10, doc='SC phi'),
-        m = Var('m', 'float', precision=10, doc='SC mass'),
+        eta = Var('eta', 'float', precision=10, doc='super-cluster (SC) eta'),
+        phi = Var('phi', 'float', precision=10, doc='super-cluster (SC) phi'),
+        m = Var('m', 'float', precision=10, doc='super-cluster (SC) mass'),
+        d0 = Var('trkd0[0]', 'float', precision=10, doc='electron track d0'),
+        dz = Var('trkdz[0]', 'float', precision=10, doc='electron track dz'),
         dEtaIn = Var('dEtaIn', 'float', precision=10, doc='#Delta#eta(SC seed, track pixel seed)'),
         dPhiIn = Var('dPhiIn', 'float', precision=10, doc='#Delta#phi(SC seed, track pixel seed)'),
         sigmaIetaIeta = Var('sigmaIetaIeta', 'float', precision=10, doc='sigmaIetaIeta of the SC, calculated with full 5x5 region, noise cleaned'),
         hOverE = Var('hOverE', 'float', precision=10, doc='Energy in HCAL / Energy in ECAL'),
         ooEMOop = Var('ooEMOop', 'float', precision=10, doc='1/E(SC) - 1/p(track momentum)'),
         missingHits = Var('missingHits', 'int', doc='missing hits in the tracker'),
+        charge = Var('trkcharge[0]', 'int', doc='electron track charge'),
         ecalIso = Var('ecalIso', 'float', precision=10, doc='Isolation of SC in the ECAL'),
         hcalIso = Var('hcalIso', 'float', precision=10, doc='Isolation of SC in the HCAL'),
         trackIso = Var('trackIso', 'float', precision=10, doc='Isolation of electron track in the tracker'),
@@ -154,11 +159,37 @@ scoutingElectronTable = cms.EDProducer("SimpleRun3ScoutingElectronFlatTableProdu
         sMin = Var('sMin', 'float', precision=10, doc='minor moment of the SC shower shape'),
         sMaj = Var('sMaj', 'float', precision=10, doc='major moment of the SC shower shape'),
         seedId = Var('seedId', 'int', doc='ECAL ID of the SC seed'),
+        rechitZeroSuppression = Var('rechitZeroSuppression', 'bool', doc='rechit zero suppression'),
     ),
 )
 
+# scouting electron format changed for 2023 data-taking in https://github.com/cms-sw/cmssw/pull/41025
+# https://github.com/cms-sw/cmssw/blob/CMSSW_13_0_X/DataFormats/Scouting/interface/Run3ScoutingElectron.h
+def modifyScoutingElectronTable2023(scoutingElectronTable):
+    del scoutingElectronTable.variables.d0       # replaced with trkd0 (std::vector)
+    del scoutingElectronTable.variables.dz       # replaced with trkdz (std::vector)
+    del scoutingElectronTable.variables.charge   # replacec with trkcharge (std::vector)
+
+    return scoutingElectronTable
+
+# scouting electron format changed for 2024 data-taking in https://github.com/cms-sw/cmssw/pull/43744
+# https://github.com/cms-sw/cmssw/blob/CMSSW_14_0_X/DataFormats/Scouting/interface/Run3ScoutingElectron.h
+def modifyScoutingElectronTable2024(scoutingElectronTable):
+    del scoutingElectronTable.variables.d0       # replaced with trkd0 (std::vector)
+    del scoutingElectronTable.variables.dz       # replaced with trkdz (std::vector)
+    del scoutingElectronTable.variables.charge   # replacec with trkcharge (std::vector)
+
+    scoutingElectronTable.variables.rawEnergy = Var('rawEnergy', 'float', precision=10, doc='raw energy')
+    scoutingElectronTable.variables.preshowerEnergy = Var('preshowerEnergy', 'float', precision=10, doc='preshower energy')
+    scoutingElectronTable.variables.corrEcalEnergyError = Var('corrEcalEnergyError', 'float', precision=10, doc='corrEcalEnergyError')
+    scoutingElectronTable.variables.nClusters = Var('nClusters', 'uint', precision=10, doc='number of clusters')
+    scoutingElectronTable.variables.nCrystals = Var('nCrystals', 'uint', precision=10, doc='number of crystals')
+
+    return scoutingElectronTable
+
 # Scouting Photon
-# https://github.com/cms-sw/cmssw/blob/CMSSW_14_0_X/DataFormats/Scouting/interface/Run3ScoutingPhoton.h
+# format during 2022-23 data-taking
+# https://github.com/cms-sw/cmssw/blob/CMSSW_13_0_X/DataFormats/Scouting/interface/Run3ScoutingPhoton.h
 
 scoutingPhotonTable = cms.EDProducer("SimpleRun3ScoutingPhotonFlatTableProducer",
     src = cms.InputTag("hltScoutingEgammaPacker"),
@@ -180,9 +211,21 @@ scoutingPhotonTable = cms.EDProducer("SimpleRun3ScoutingPhotonFlatTableProducer"
         r9 = Var('r9', 'float', precision=10, doc='Photon SC r9 as defined in https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideEgammaShowerShape'),
         sMin = Var('sMin', 'float', precision=10, doc='minor moment of the SC shower shape'),
         sMaj = Var('sMaj', 'float', precision=10, doc='major moment of the SC shower shape'),
-        seedId = Var('seedId', 'int', doc='ECAL ID of the SC seed'),
+        seedId = Var('seedId', 'uint', doc='ECAL ID of the SC seed'),
+        rechitZeroSuppression = Var('rechitZeroSuppression', 'bool', doc='rechit zero suppression'),
     ),
 )
+
+# scouting photon format changed for 2024 data-taking in https://github.com/cms-sw/cmssw/pull/43744
+# https://github.com/cms-sw/cmssw/blob/CMSSW_14_0_X/DataFormats/Scouting/interface/Run3ScoutingPhoton.h
+def modifyScoutingPhotonTable2024(scoutingPhotonTable):
+    scoutingPhotonTable.variables.rawEnergy = Var('rawEnergy', 'float', precision=10, doc='raw energy')
+    scoutingPhotonTable.variables.preshowerEnergy = Var('preshowerEnergy', 'float', precision=10, doc='preshower energy')
+    scoutingPhotonTable.variables.corrEcalEnergyError = Var('corrEcalEnergyError', 'float', precision=10, doc='corrEcalEnergyError')
+    scoutingPhotonTable.variables.nClusters = Var('nClusters', 'uint', precision=10, doc='number of clusters')
+    scoutingPhotonTable.variables.nCrystals = Var('nCrystals', 'uint', precision=10, doc='number of crystals')
+
+    return scoutingPhotonTable
 
 # Scouting Track
 # https://github.com/cms-sw/cmssw/blob/CMSSW_14_0_X/DataFormats/Scouting/interface/Run3ScoutingTrack.h
@@ -233,7 +276,8 @@ scoutingTrackTable = cms.EDProducer("SimpleRun3ScoutingTrackFlatTableProducer",
 )
 
 # Scouting Primary Vertex
-# https://github.com/cms-sw/cmssw/blob/CMSSW_14_0_X/DataFormats/Scouting/interface/Run3ScoutingVertex.h
+# format during 2022-23 data-taking
+# https://github.com/cms-sw/cmssw/blob/CMSSW_13_0_X/DataFormats/Scouting/interface/Run3ScoutingVertex.h
 
 scoutingPrimaryVertexTable = cms.EDProducer("SimpleRun3ScoutingVertexFlatTableProducer",
     src = cms.InputTag("hltScoutingPrimaryVertexPacker", "primaryVtx"),
@@ -255,6 +299,16 @@ scoutingPrimaryVertexTable = cms.EDProducer("SimpleRun3ScoutingVertexFlatTablePr
         isValidVtx = Var('isValidVtx', 'bool', doc='is valid'),
     ),
 )
+
+# scouting vertex format changed for 2024 data-taking in https://github.com/cms-sw/cmssw/pull/43758
+# used for both primary vertex and muon displaced vertex
+# https://github.com/cms-sw/cmssw/blob/CMSSW_14_0_X/DataFormats/Scouting/interface/Run3ScoutingPhoton.h
+def modifyScoutingVertexTable2024(scoutingVertexTable):
+    scoutingVertexTable.variables.xyCov = Var('xyCov', 'float', precision=10, doc='xy covariance')
+    scoutingVertexTable.variables.xzCov = Var('xzCov', 'float', precision=10, doc='xz covariance')
+    scoutingVertexTable.variables.yzCov = Var('yzCov', 'float', precision=10, doc='yz covariance')
+
+    return scoutingVertexTable
 
 # Scouting Particle (PF candidate)
 # https://github.com/cms-sw/cmssw/blob/CMSSW_14_0_X/DataFormats/Scouting/interface/Run3ScoutingParticle.h

--- a/PhysicsTools/Scouting/plugins/BuildFile.xml
+++ b/PhysicsTools/Scouting/plugins/BuildFile.xml
@@ -1,6 +1,14 @@
+<use name="FWCore/Framework"/>
+<use name="FWCore/ParameterSet"/>
+<use name="FWCore/Utilities"/>
+<use name="FWCore/PluginManager"/>
+<use name="DataFormats/Common"/>
+<use name="DataFormats/Scouting"/>
+<use name="DataFormats/ParticleFlowCandidate"/>
+<use name="PhysicsTools/PatAlgos"/>
+<use name="SimGeneral/HepPDTRecord"/>
 <use name="fastjet"/>
 <use name="fastjet-contrib"/>
-<use name="PhysicsTools/PatAlgos"/>
 <library file="*.cc" name="PhysicsToolsScoutingPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/PhysicsTools/Scouting/plugins/ProductExistenceFilter.cc
+++ b/PhysicsTools/Scouting/plugins/ProductExistenceFilter.cc
@@ -15,7 +15,7 @@ class ProductExistenceFilter : public edm::global::EDFilter<> {
 public:
   ProductExistenceFilter(const edm::ParameterSet &);
   ~ProductExistenceFilter() override = default;
-  
+
   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 private:
@@ -26,8 +26,7 @@ private:
 
 template <typename T>
 ProductExistenceFilter<T>::ProductExistenceFilter(const edm::ParameterSet &iConfig)
-  : productToken_(consumes(iConfig.getParameter<edm::InputTag>("product"))) {
-}
+    : productToken_(consumes(iConfig.getParameter<edm::InputTag>("product"))) {}
 
 template <typename T>
 void ProductExistenceFilter<T>::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
@@ -41,31 +40,31 @@ bool ProductExistenceFilter<T>::filter(edm::StreamID, edm::Event &iEvent, const 
   return iEvent.getHandle(productToken_).isValid();
 }
 
-# include "DataFormats/Scouting/interface/Run3ScoutingMuon.h"
+#include "DataFormats/Scouting/interface/Run3ScoutingMuon.h"
 using Run3ScoutingMuonExistenceFilter = ProductExistenceFilter<Run3ScoutingMuonCollection>;
 DEFINE_FWK_MODULE(Run3ScoutingMuonExistenceFilter);
 
-# include "DataFormats/Scouting/interface/Run3ScoutingElectron.h"
+#include "DataFormats/Scouting/interface/Run3ScoutingElectron.h"
 using Run3ScoutingElectronExistenceFilter = ProductExistenceFilter<Run3ScoutingElectronCollection>;
 DEFINE_FWK_MODULE(Run3ScoutingElectronExistenceFilter);
 
-# include "DataFormats/Scouting/interface/Run3ScoutingPhoton.h"
+#include "DataFormats/Scouting/interface/Run3ScoutingPhoton.h"
 using Run3ScoutingPhotonExistenceFilter = ProductExistenceFilter<Run3ScoutingPhotonCollection>;
 DEFINE_FWK_MODULE(Run3ScoutingPhotonExistenceFilter);
 
-# include "DataFormats/Scouting/interface/Run3ScoutingTrack.h"
+#include "DataFormats/Scouting/interface/Run3ScoutingTrack.h"
 using Run3ScoutingTrackExistenceFilter = ProductExistenceFilter<Run3ScoutingTrackCollection>;
 DEFINE_FWK_MODULE(Run3ScoutingTrackExistenceFilter);
 
-# include "DataFormats/Scouting/interface/Run3ScoutingVertex.h"
+#include "DataFormats/Scouting/interface/Run3ScoutingVertex.h"
 using Run3ScoutingVertexExistenceFilter = ProductExistenceFilter<Run3ScoutingVertexCollection>;
 DEFINE_FWK_MODULE(Run3ScoutingVertexExistenceFilter);
 
-# include "DataFormats/Scouting/interface/Run3ScoutingParticle.h"
+#include "DataFormats/Scouting/interface/Run3ScoutingParticle.h"
 using Run3ScoutingParticleExistenceFilter = ProductExistenceFilter<Run3ScoutingParticleCollection>;
 DEFINE_FWK_MODULE(Run3ScoutingParticleExistenceFilter);
 
-# include "DataFormats/Scouting/interface/Run3ScoutingPFJet.h"
+#include "DataFormats/Scouting/interface/Run3ScoutingPFJet.h"
 using Run3ScoutingPFJetExistenceFilter = ProductExistenceFilter<Run3ScoutingPFJetCollection>;
 DEFINE_FWK_MODULE(Run3ScoutingPFJetExistenceFilter);
 

--- a/PhysicsTools/Scouting/plugins/ProductExistenceFilter.cc
+++ b/PhysicsTools/Scouting/plugins/ProductExistenceFilter.cc
@@ -11,7 +11,6 @@
 #include <iostream>
 
 template <typename T>
-//class ProductExistenceFilter : public edm::stream::EDFilter<> {
 class ProductExistenceFilter : public edm::global::EDFilter<> {
 public:
   ProductExistenceFilter(const edm::ParameterSet &);
@@ -20,10 +19,7 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 private:
-  //void beginStream(edm::StreamID) override {};
-  //bool filter(edm::Event &, const edm::EventSetup &) override;
   bool filter(edm::StreamID, edm::Event &, const edm::EventSetup &) const override;
-  //void endStream() override {};
 
   edm::EDGetTokenT<T> productToken_;
 };
@@ -42,7 +38,6 @@ void ProductExistenceFilter<T>::fillDescriptions(edm::ConfigurationDescriptions 
 
 template <typename T>
 bool ProductExistenceFilter<T>::filter(edm::StreamID, edm::Event &iEvent, const edm::EventSetup &iSetup) const {
-//bool ProductExistenceFilter<T>::filter(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   return iEvent.getHandle(productToken_).isValid();
 }
 
@@ -77,13 +72,3 @@ DEFINE_FWK_MODULE(Run3ScoutingPFJetExistenceFilter);
 // MET and Rho
 using DoubleExistenceFilter = ProductExistenceFilter<double>;
 DEFINE_FWK_MODULE(DoubleExistenceFilter);
-
-# include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
-using FEDRawDataCollectionExistenceFilter = ProductExistenceFilter<FEDRawDataCollection>;
-DEFINE_FWK_MODULE(FEDRawDataCollectionExistenceFilter);
-
-# include "DataFormats/L1Trigger/interface/BXVector.h"
-
-# include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
-using GlobalAlgBlkBXVectorExistenceFilter = ProductExistenceFilter<BXVector<GlobalAlgBlk>>;
-DEFINE_FWK_MODULE(GlobalAlgBlkBXVectorExistenceFilter);

--- a/PhysicsTools/Scouting/plugins/ProductExistenceFilter.cc
+++ b/PhysicsTools/Scouting/plugins/ProductExistenceFilter.cc
@@ -1,0 +1,89 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include <iostream>
+
+template <typename T>
+//class ProductExistenceFilter : public edm::stream::EDFilter<> {
+class ProductExistenceFilter : public edm::global::EDFilter<> {
+public:
+  ProductExistenceFilter(const edm::ParameterSet &);
+  ~ProductExistenceFilter() override = default;
+  
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+
+private:
+  //void beginStream(edm::StreamID) override {};
+  //bool filter(edm::Event &, const edm::EventSetup &) override;
+  bool filter(edm::StreamID, edm::Event &, const edm::EventSetup &) const override;
+  //void endStream() override {};
+
+  edm::EDGetTokenT<T> productToken_;
+};
+
+template <typename T>
+ProductExistenceFilter<T>::ProductExistenceFilter(const edm::ParameterSet &iConfig)
+  : productToken_(consumes(iConfig.getParameter<edm::InputTag>("product"))) {
+}
+
+template <typename T>
+void ProductExistenceFilter<T>::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("product");
+  descriptions.addWithDefaultLabel(desc);
+}
+
+template <typename T>
+bool ProductExistenceFilter<T>::filter(edm::StreamID, edm::Event &iEvent, const edm::EventSetup &iSetup) const {
+//bool ProductExistenceFilter<T>::filter(edm::Event &iEvent, const edm::EventSetup &iSetup) {
+  return iEvent.getHandle(productToken_).isValid();
+}
+
+# include "DataFormats/Scouting/interface/Run3ScoutingMuon.h"
+using Run3ScoutingMuonExistenceFilter = ProductExistenceFilter<Run3ScoutingMuonCollection>;
+DEFINE_FWK_MODULE(Run3ScoutingMuonExistenceFilter);
+
+# include "DataFormats/Scouting/interface/Run3ScoutingElectron.h"
+using Run3ScoutingElectronExistenceFilter = ProductExistenceFilter<Run3ScoutingElectronCollection>;
+DEFINE_FWK_MODULE(Run3ScoutingElectronExistenceFilter);
+
+# include "DataFormats/Scouting/interface/Run3ScoutingPhoton.h"
+using Run3ScoutingPhotonExistenceFilter = ProductExistenceFilter<Run3ScoutingPhotonCollection>;
+DEFINE_FWK_MODULE(Run3ScoutingPhotonExistenceFilter);
+
+# include "DataFormats/Scouting/interface/Run3ScoutingTrack.h"
+using Run3ScoutingTrackExistenceFilter = ProductExistenceFilter<Run3ScoutingTrackCollection>;
+DEFINE_FWK_MODULE(Run3ScoutingTrackExistenceFilter);
+
+# include "DataFormats/Scouting/interface/Run3ScoutingVertex.h"
+using Run3ScoutingVertexExistenceFilter = ProductExistenceFilter<Run3ScoutingVertexCollection>;
+DEFINE_FWK_MODULE(Run3ScoutingVertexExistenceFilter);
+
+# include "DataFormats/Scouting/interface/Run3ScoutingParticle.h"
+using Run3ScoutingParticleExistenceFilter = ProductExistenceFilter<Run3ScoutingParticleCollection>;
+DEFINE_FWK_MODULE(Run3ScoutingParticleExistenceFilter);
+
+# include "DataFormats/Scouting/interface/Run3ScoutingPFJet.h"
+using Run3ScoutingPFJetExistenceFilter = ProductExistenceFilter<Run3ScoutingPFJetCollection>;
+DEFINE_FWK_MODULE(Run3ScoutingPFJetExistenceFilter);
+
+// MET and Rho
+using DoubleExistenceFilter = ProductExistenceFilter<double>;
+DEFINE_FWK_MODULE(DoubleExistenceFilter);
+
+# include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
+using FEDRawDataCollectionExistenceFilter = ProductExistenceFilter<FEDRawDataCollection>;
+DEFINE_FWK_MODULE(FEDRawDataCollectionExistenceFilter);
+
+# include "DataFormats/L1Trigger/interface/BXVector.h"
+
+# include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
+using GlobalAlgBlkBXVectorExistenceFilter = ProductExistenceFilter<BXVector<GlobalAlgBlk>>;
+DEFINE_FWK_MODULE(GlobalAlgBlkBXVectorExistenceFilter);

--- a/PhysicsTools/Scouting/python/scoutingExistenceFilter_cff.py
+++ b/PhysicsTools/Scouting/python/scoutingExistenceFilter_cff.py
@@ -1,0 +1,82 @@
+import FWCore.ParameterSet.Config as cms
+
+scoutingMuonExistenceFilter = cms.EDFilter("Run3ScoutingMuonExistenceFilter",
+    product = cms.InputTag("hltScoutingMuonPacker")
+)
+
+scoutingMuonDisplacedVertexExistenceFilter = cms.EDFilter("Run3ScoutingVertexExistenceFilter",
+    product = cms.InputTag("hltScoutingMuonPacker", "displacedVtx")
+)
+
+scoutingMuonNoVtxExistenceFilter = cms.EDFilter("Run3ScoutingMuonExistenceFilter",
+    product = cms.InputTag("hltScoutingMuonPackerNoVtx")
+)
+
+scoutingMuonNoVtxDisplacedVertexExistenceFilter = cms.EDFilter("Run3ScoutingVertexExistenceFilter",
+    product = cms.InputTag("hltScoutingMuonPackerNoVtx", "displacedVtx")
+)
+
+scoutingMuonVtxExistenceFilter = cms.EDFilter("Run3ScoutingMuonExistenceFilter",
+    product = cms.InputTag("hltScoutingMuonPackerVtx")
+)
+
+scoutingMuonVtxDisplacedVertexExistenceFilter = cms.EDFilter("Run3ScoutingVertexExistenceFilter",
+    product = cms.InputTag("hltScoutingMuonPackerVtx", "displacedVtx")
+)
+
+scoutingElectronExistenceFilter = cms.EDFilter("Run3ScoutingElectronExistenceFilter",
+    product = cms.InputTag("hltScoutingEgammaPacker")
+)
+
+scoutingPhotonExistenceFilter = cms.EDFilter("Run3ScoutingPhotonExistenceFilter",
+    product = cms.InputTag("hltScoutingEgammaPacker")
+)
+
+scoutingTrackExistenceFilter = cms.EDFilter("Run3ScoutingTrackExistenceFilter",
+    product = cms.InputTag("hltScoutingTrackPacker")
+)
+
+scoutingPrimaryVertexExistenceFilter = cms.EDFilter("Run3ScoutingVertexExistenceFilter",
+    product = cms.InputTag("hltScoutingPrimaryVertexPacker", "primaryVtx")
+)
+
+scoutingParticleExistenceFilter = cms.EDFilter("Run3ScoutingParticleExistenceFilter",
+    product = cms.InputTag("hltScoutingPFPacker")
+)
+
+scoutingPFJetExistenceFilter = cms.EDFilter("Run3ScoutingPFJetExistenceFilter",
+    product = cms.InputTag("hltScoutingPFPacker")
+)
+
+scoutingMETptExistenceFilter = cms.EDFilter("DoubleExistenceFilter",
+    product = cms.InputTag("hltScoutingPFPacker", "pfMetPt")
+)
+
+scoutingMETphiExistenceFilter = cms.EDFilter("DoubleExistenceFilter",
+    product = cms.InputTag("hltScoutingPFPacker", "pfMetPhi")
+)
+
+scoutingRhoExistenceFilter = cms.EDFilter("DoubleExistenceFilter",
+    product = cms.InputTag("hltScoutingPFPacker", "rho")
+)
+
+# from 2024, there are two scouting muon collections (https://its.cern.ch/jira/browse/CMSHLT-3089)
+from Configuration.Eras.Modifier_run3_scouting_nanoAOD_2024_cff import run3_scouting_nanoAOD_2024
+scoutingMuonExistenceFilterSequence = cms.Sequence(scoutingMuonExistenceFilter*scoutingMuonDisplacedVertexExistenceFilter)
+run3_scouting_nanoAOD_2024.toReplaceWith(scoutingMuonExistenceFilterSequence,
+    cms.Sequence(scoutingMuonNoVtxExistenceFilter*scoutingMuonNoVtxDisplacedVertexExistenceFilter\
+                *scoutingMuonVtxExistenceFilter*scoutingMuonVtxDisplacedVertexExistenceFilter)
+)
+
+scoutingExistenceFilter = cms.Sequence(
+    scoutingMuonExistenceFilterSequence
+    *scoutingElectronExistenceFilter
+    *scoutingPhotonExistenceFilter
+    *scoutingTrackExistenceFilter
+    *scoutingPrimaryVertexExistenceFilter
+    *scoutingParticleExistenceFilter
+    *scoutingPFJetExistenceFilter
+    *scoutingMETptExistenceFilter
+    *scoutingMETphiExistenceFilter
+    *scoutingRhoExistenceFilter
+)


### PR DESCRIPTION
#### PR description:

This enables ScoutingNano workflows in CMSSW_15_0_X+ to run on scouting samples (```ScoutingPFRun3```, ```ScoutingPFMonitor```) collected in 2022-2024. Addressed changes are as follows:

2022:
- Add EDFilter to skip events without scouting object products in ScoutingPFMonitor

2023:
- Add additional track variables to the Run 3 scouting electron collection for low pT electrons ([cms-sw/cmssw#41025](https://github.com/cms-sw/cmssw/pull/41025))
- Add EDFilter to skip events without scouting object products in ScoutingPFMonitor

2024:
- Add off-diagonal entries of the vertex fit covariance matrix ([cms-sw/cmssw#43758](https://github.com/cms-sw/cmssw/pull/43758))
- Electron and Photon Scouting Data Format Update for 2024 pp Collisions ([cms-sw/cmssw#43744](https://github.com/cms-sw/cmssw/pull/43744))
- Add EDFilter to skip events without scouting object products in ScoutingPFMonitor

2025:
- Remove EDFilter to skip events without scouting object products in ScoutingPFMonitor since all ScoutingPFMonitor events should now have scouting object products ([CMSHLT-3089](https://its.cern.ch/jira/browse/CMSHLT-3089))

In summary, this PR
- adds era modifiers for 2023,2024,2025: ```run3_scouting_nanoAOD_2023```, ```run3_scouting_nanoAOD_2024```, and ```run3_scouting_nanoAOD_2025``` which are added to ```Run3_2023```, ```Run3_2024```, and ```Run3_2025```.
- removes era modifer ```run3_scouting_nanoAOD_post2023``` as ```run3_scouting_nanoAOD_2024``` and ```run3_scouting_nanoAOD_2025``` are introduced instead.
- adds EDFilter to skip events without scouting object products in ScoutingPFMonitor. This can also be configured in ```cmsDriver.py``` by adding ```--customise PhysicsTools/NanoAOD/custom_run3scouting_cff.skipEventsWithoutScouting```
- adds ```@ScoutMonitor``` flavour to automatically turn on/off the EDFilter based on era modifiers (turn on for 2022-24 and turn off for 2025). This should be used when running with ```ScoutingPFMonitor/RAW``` in scouting-only configuration.
- adds the above feature to automatically turn on/off the EDFilter based on era modifiers to ```@ScoutFromMini```. When running on data, this assumes running on ```ScoutingPFMonitor/MINIAOD``` and will turn on the EDFilter for 2022-24 and turn off on 2025. When running on MC, EDFilter will be turn off.

Note on different flavours:
- Data. The default ```Scout``` is designed to be used with ```ScoutingPFRun3``` (containing scouting only). ```ScoutMonitor``` should be used with ```ScoutingPFMonitor/RAW``` and ```ScoutFromMini``` should be used with ```ScoutingPFMonitor/MiniAOD```. The default ```Scout``` will not check for events without scouting products while ```ScoutMonitor``` and ```ScoutFromMini``` will check and skip events without scouting products with 2022-24 samples but turn off this check for 2025. For L1 bits and objects, ```Scout``` assume ```hltFEDSelectorL1``` of type ```FEDRawDataCollection``` exists, ```ScoutMonitor```  assume ```rawDataCollector``` of type ```FEDRawDataCollection``` exists, and ```ScoutFromMini``` assume ```gtStage2Digis, gmtStage2Digis, caloStage2Digis``` exists in the input files. In all flavours, reduced variables for L1 objects are used.
- MC. The default ```Scout``` and ```ScoutFromMini``` can be used and they differ in how L1 bits and objects are handled. For ```Scout```, L1 bits and objects are produced from ```gtStage2DigisScouting``` (similar to ```gtStage2Digis```) with ```hltFEDSelectorL1``` of type ```FEDRawDataCollection``` as input. For```ScoutFromMini```,  L1bits are obtained from standard ```L1TriggerResultsConverter``` (similar to standard NanoAOD) and L1 objects are obtained from ```gmtStage2Digis``` (L1 Muon) and ```caloStage2Digis``` (L1 EG, Jet, EtSum, Tau). In all flavours, reduced variables for L1 objects are used. Both ```Scout``` and ```ScoutFromMini``` will not check for events without scouting products. ```ScoutMonitor``` should not be used.

Proposal for this change was presented [1].

#### PR validation:

Pass all tests from ```scram b runtests use-ibeos```.
Pass all ScoutingNano-related relval_nano workflows from ```runTheMatrix.py --ibeos -l 2500.131,2500.227,2500.228,2500.237,2500.238```

In addition, several ```cmsDriver.py``` commands have been tested on data and MC samples documented in [2].
In brief, concerning data:
- ```@Scout``` works for ScoutingPFRun3 2022-24
- ```@ScoutMonitor``` works for ScoutingPFMonitor 2022-24
- ```@ScoutFromMini``` works for ScoutingPFMonitor 2024 (Scouting objects are in MiniAOD starting in Prompt 2024)
- ```@Prompt+@ScoutMonitor``` works for ScoutingPFMonitor 2023. Input 2022 fails because of Tau.
- ```@Prompt+@ScoutFromMini``` works for ScoutingPFMonitor 2024 (Scouting objects are in MiniAOD starting in Prompt 2024)
Please see commands in [2]. Relevant test results (python config, root, event content, size report, log) are included in [3]. Summary of size report is in [4].

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is not a backport, but backport to 15_0_0 will likely follow.

[1] https://indico.cern.ch/event/1492373/#11-offline-scoutingnano-develo
[2] https://codimd.web.cern.ch/s/Fgye0cLYG
[3] https://cernbox.cern.ch/s/5P2nt1ChLhcwhFU
[4] [2025-02-08_ScoutingNano_Size-Report-Summary](https://docs.google.com/spreadsheets/d/1oKOjjTCHuYAyIsJhQar60sRwfTATLwOAbPXtxX-atIE/edit?usp=sharing)
