### PR TITLE
Fix gcc14 array-bound error

### DIFF
--- a/CondCore/CondDB/src/DbCore.h
+++ b/CondCore/CondDB/src/DbCore.h
@@ -32,7 +32,6 @@
 #include "RelationalAccess/IColumn.h"
 #include "RelationalAccess/ITableDataEditor.h"
 #include "RelationalAccess/IBulkOperation.h"
-#include "RelationalAccess/IBulkOperation.h"
 #include "RelationalAccess/SchemaException.h"
 //
 #include <tuple>
@@ -55,13 +54,13 @@
 // implementation for the column definition:
 
 // case with 3 params
-#define FIXSIZE_COLUMN(NAME, TYPE, SIZE)                                                \
-  struct NAME {                                                                         \
-    static constexpr char const* name = #NAME;                                          \
-    typedef TYPE type;                                                                  \
-    static constexpr size_t size = SIZE;                                                \
-    static std::string tableName() { return std::string(tname); }                       \
-    static std::string fullyQualifiedName() { return std::string(tname) + "." + name; } \
+#define FIXSIZE_COLUMN(NAME, TYPE, SIZE)                                                             \
+  struct NAME {                                                                                      \
+    static constexpr char const* name = #NAME;                                                       \
+    typedef TYPE type;                                                                               \
+    static constexpr size_t size = SIZE;                                                             \
+    static std::string tableName() { return std::string(tname); }                                    \
+    static std::string fullyQualifiedName() { return std::string(tname) + "." + std::string(name); } \
   };
 
 // case with 2 params


### PR DESCRIPTION
Looks like this change fixes the GCC 14 build error like [a]

```
In function 'copy',
    inlined from '__ct ' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gcc/14.2.1-60e8d7f953e2e96ab45420ba74bbf3ae/include/c++/14.2.1/bits/basic_string.h:688:23,
    inlined from 'operator+' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gcc/14.2.1-60e8d7f953e2e96ab45420ba74bbf3ae/include/c++/14.2.1/bits/basic_string.h:3735:43,
    inlined from 'fullyQualifiedName' at src/CondCore/CondDB/src/IOVSchema.h:77:7,
    inlined from 'get' at src/CondCore/CondDB/src/DbCore.h:430:83,
    inlined from 'operator*' at src/CondCore/CondDB/src/DbCore.h:433:111,
    inlined from 'getType' at src/CondCore/CondDB/src/IOVSchema.cc:507:23:
  /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gcc/14.2.1-60e8d7f953e2e96ab45420ba74bbf3ae/include/c++/14.2.1/bits/char_traits.h:427:56: error: '__builtin_memcpy' forming offset [32, 35] is out of the bounds [0, 32] of object '<anonymous>' with type 'struct string' [-Werror=array-bounds=]
   427 |         return static_cast<char_type*>(__builtin_memcpy(__s1, __s2, __n));

```