### PR TITLE
New constructor for the SoAView and aggregate method for Collections

### DIFF
--- a/DataFormats/Portable/README.md
+++ b/DataFormats/Portable/README.md
@@ -98,6 +98,10 @@ SET_PORTABLEHOSTCOLLECTION_READ_RULES(portabletest::TestHostCollection);
 They have no implicit or explicit references to alpaka (neither as part of the class signature nor as part of its name).
 This could make it possible to read them back with different portability solutions in the future.
 
+The member function `void deepCopy(ConstView const& view)` copies the content of all scalars and columns from `view`
+(pointing to data in host memory and potentially to multiple buffers) into the `PortableHostCollection` contiguous buffer.
+See the [`View` section](../../DataFormats/SoATemplate/README.md#view) of [`DataFormats/SoATemplate/README.md`](../../DataFormats/SoATemplate/README.md) for more details.
+
 ### `PortableDeviceCollection<T, TDev>`
 
 `PortableDeviceCollection<T, TDev>` is a class template that wraps a SoA type `T` and an alpaka device buffer, which

--- a/DataFormats/Portable/interface/PortableHostCollection.h
+++ b/DataFormats/Portable/interface/PortableHostCollection.h
@@ -94,6 +94,10 @@ public:
     layout.ROOTStreamerCleaner();
   }
 
+  // Copy column by column the content of the given view into this PortableHostCollection.
+  // The view must point to data in host memory.
+  void deepCopy(ConstView const& view) { layout_.deepCopy(view); }
+
 private:
   std::optional<Buffer> buffer_;  //!
   Layout layout_;                 //

--- a/DataFormats/Portable/test/BuildFile.xml
+++ b/DataFormats/Portable/test/BuildFile.xml
@@ -2,4 +2,5 @@
   <use name="DataFormats/Portable"/>
   <use name="DataFormats/SoATemplate"/>
   <use name="catch2"/>
+  <use name="eigen"/>
 </bin>

--- a/DataFormats/Portable/test/test_catch2_deepCopyOnHost.cc
+++ b/DataFormats/Portable/test/test_catch2_deepCopyOnHost.cc
@@ -1,0 +1,126 @@
+#include <Eigen/Core>
+#include <Eigen/Dense>
+
+#include <catch.hpp>
+
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+#include "DataFormats/SoATemplate/interface/SoACommon.h"
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+#include "DataFormats/SoATemplate/interface/SoAView.h"
+
+GENERATE_SOA_LAYOUT(SoAPositionTemplate,
+                    SOA_COLUMN(float, x),
+                    SOA_COLUMN(float, y),
+                    SOA_COLUMN(float, z),
+                    SOA_SCALAR(int, detectorType))
+
+using SoAPosition = SoAPositionTemplate<>;
+using SoAPositionView = SoAPosition::View;
+using SoAPositionConstView = SoAPosition::ConstView;
+
+GENERATE_SOA_LAYOUT(SoAPCATemplate,
+                    SOA_COLUMN(float, eigenvalues),
+                    SOA_COLUMN(float, eigenvector_1),
+                    SOA_COLUMN(float, eigenvector_2),
+                    SOA_COLUMN(float, eigenvector_3),
+                    SOA_EIGEN_COLUMN(Eigen::Vector3d, candidateDirection))
+
+using SoAPCA = SoAPCATemplate<>;
+using SoAPCAView = SoAPCA::View;
+using SoAPCAConstView = SoAPCA::ConstView;
+
+GENERATE_SOA_LAYOUT(GenericSoATemplate,
+                    SOA_COLUMN(float, xPos),
+                    SOA_COLUMN(float, yPos),
+                    SOA_COLUMN(float, zPos),
+                    SOA_EIGEN_COLUMN(Eigen::Vector3d, candidateDirection))
+
+using GenericSoA = GenericSoATemplate<>;
+using GenericSoAView = GenericSoA::View;
+using GenericSoAConstView = GenericSoA::ConstView;
+
+TEST_CASE("Deep copy from SoA Generic View") {
+  // common number of elements for the SoAs
+  const std::size_t elems = 10;
+
+  // Portable Collections
+  PortableHostCollection<SoAPosition> positionCollection(elems, cms::alpakatools::host());
+  PortableHostCollection<SoAPCA> pcaCollection(elems, cms::alpakatools::host());
+
+  // Portable Collection Views
+  SoAPositionView& positionCollectionView = positionCollection.view();
+  SoAPCAView& pcaCollectionView = pcaCollection.view();
+  // Portable Collection ConstViews
+  const SoAPositionConstView& positionCollectionConstView = positionCollection.const_view();
+  const SoAPCAConstView& pcaCollectionConstView = pcaCollection.const_view();
+
+  // fill up
+  for (size_t i = 0; i < elems; i++) {
+    positionCollectionView[i] = {i * 1.0f, i * 2.0f, i * 3.0f};
+  }
+  positionCollectionView.detectorType() = 1;
+
+  float time = 0.01;
+  for (size_t i = 0; i < elems; i++) {
+    pcaCollectionView[i].eigenvector_1() = positionCollectionView[i].x() / time;
+    pcaCollectionView[i].eigenvector_2() = positionCollectionView[i].y() / time;
+    pcaCollectionView[i].eigenvector_3() = positionCollectionView[i].z() / time;
+    pcaCollectionView[i].candidateDirection()(0) = positionCollectionView[i].x() / time;
+    pcaCollectionView[i].candidateDirection()(1) = positionCollectionView[i].y() / time;
+    pcaCollectionView[i].candidateDirection()(2) = positionCollectionView[i].z() / time;
+  }
+
+  SECTION("Deep copy the View") {
+    // addresses and size of the SoA columns
+    const auto posRecs = positionCollectionView.records();
+    const auto pcaRecs = pcaCollectionView.records();
+
+    // building the View with runtime check for the size
+    GenericSoAView genericView(posRecs.x(), posRecs.y(), posRecs.z(), pcaRecs.candidateDirection());
+
+    // Check for equality of memory addresses
+    REQUIRE(genericView.metadata().addressOf_xPos() == positionCollectionView.metadata().addressOf_x());
+    REQUIRE(genericView.metadata().addressOf_yPos() == positionCollectionView.metadata().addressOf_y());
+    REQUIRE(genericView.metadata().addressOf_zPos() == positionCollectionView.metadata().addressOf_z());
+    REQUIRE(genericView.metadata().addressOf_candidateDirection() ==
+            pcaCollectionView.metadata().addressOf_candidateDirection());
+
+    // PortableHostCollection that will host the aggregated columns
+    PortableHostCollection<GenericSoA> genericCollection(elems, cms::alpakatools::host());
+    genericCollection.deepCopy(genericView);
+
+    // Check for inequality of memory addresses
+    REQUIRE(genericCollection.view().metadata().addressOf_xPos() != positionCollectionView.metadata().addressOf_x());
+    REQUIRE(genericCollection.view().metadata().addressOf_yPos() != positionCollectionView.metadata().addressOf_y());
+    REQUIRE(genericCollection.view().metadata().addressOf_zPos() != positionCollectionView.metadata().addressOf_z());
+    REQUIRE(genericCollection.view().metadata().addressOf_candidateDirection() !=
+            pcaCollectionView.metadata().addressOf_candidateDirection());
+  }
+
+  SECTION("Deep copy the ConstView") {
+    // addresses and size of the SoA columns
+    const auto posRecs = positionCollectionConstView.records();
+    const auto pcaRecs = pcaCollectionConstView.records();
+
+    // building the View with runtime check for the size
+    GenericSoAConstView genericConstView(posRecs.x(), posRecs.y(), posRecs.z(), pcaRecs.candidateDirection());
+
+    // Check for equality of memory addresses
+    REQUIRE(genericConstView.metadata().addressOf_xPos() == positionCollectionView.metadata().addressOf_x());
+    REQUIRE(genericConstView.metadata().addressOf_yPos() == positionCollectionView.metadata().addressOf_y());
+    REQUIRE(genericConstView.metadata().addressOf_zPos() == positionCollectionView.metadata().addressOf_z());
+    REQUIRE(genericConstView.metadata().addressOf_candidateDirection() ==
+            pcaCollectionView.metadata().addressOf_candidateDirection());
+
+    // PortableHostCollection that will host the aggregated columns
+    PortableHostCollection<GenericSoA> genericCollection(elems, cms::alpakatools::host());
+    genericCollection.deepCopy(genericConstView);
+
+    // Check for inequality of memory addresses
+    REQUIRE(genericCollection.view().metadata().addressOf_xPos() != positionCollectionView.metadata().addressOf_x());
+    REQUIRE(genericCollection.view().metadata().addressOf_yPos() != positionCollectionView.metadata().addressOf_y());
+    REQUIRE(genericCollection.view().metadata().addressOf_zPos() != positionCollectionView.metadata().addressOf_z());
+    REQUIRE(genericCollection.view().metadata().addressOf_candidateDirection() !=
+            pcaCollectionView.metadata().addressOf_candidateDirection());
+  }
+}

--- a/DataFormats/SoATemplate/README.md
+++ b/DataFormats/SoATemplate/README.md
@@ -44,6 +44,9 @@ provided: `ViewTemplate`, `ViewViewTemplateFreeParams` and respectively `ConstVi
 `ConstViewTemplateFreeParams`. The parametrization of those templates is explained in the [Template
 parameters section](#template-parameters).
 
+It is also possible to build a generic `View` or `ConstView` passing from the [Metarecords sublass](#metarecords-subclass). This
+view can point to data belonging to different SoAs and thus not contiguous in memory.
+
 ## Metadata subclass
 
 In order to no clutter the namespace of the generated class, a subclass name `Metadata` is generated. It is
@@ -51,6 +54,13 @@ instanciated with the `metadata()` member function and contains various utility 
 of elements in the SoA), `byteSize()`, `byteAlignment()`, `data()` (a pointer to the buffer). A `nextByte()`
 function computes the first byte of a structure right after a layout, allowing using a single buffer for multiple
 layouts.
+
+## Metarecords subclass
+
+The nested type `Metarecords` describes the elements of the SoA. It can be instantiated by the `records()` member 
+function of a `View` or `ConstView`. Every object contains the address of the first element of the column, the number
+of elements per column, and the stride for the Eigen columns. These are used to validate the columns size at run time 
+and to build a generic `View` as described in [View](#view).
 
 ## ROOT serialization and de-serialization
 

--- a/DataFormats/SoATemplate/interface/SoAView.h
+++ b/DataFormats/SoATemplate/interface/SoAView.h
@@ -487,6 +487,117 @@ namespace cms::soa {
 
 #define _TRIVIAL_VIEW_ASSIGN_VALUE_ELEMENT(R, DATA, TYPE_NAME) _TRIVIAL_VIEW_ASSIGN_VALUE_ELEMENT_IMPL TYPE_NAME
 
+/**
+ * Generator of parameters for (const) view Metarecords subclass.
+ */
+#define _DECLARE_CONST_VIEW_CONSTRUCTOR_COLUMNS_IMPL(LAYOUT_NAME, LAYOUT_MEMBER, LOCAL_NAME) \
+  (typename Metadata::BOOST_PP_CAT(ParametersTypeOf_, LOCAL_NAME)::ConstType LOCAL_NAME)
+
+#define _DECLARE_CONST_VIEW_CONSTRUCTOR_COLUMNS(R, DATA, LAYOUT_MEMBER_NAME) \
+  BOOST_PP_EXPAND(_DECLARE_CONST_VIEW_CONSTRUCTOR_COLUMNS_IMPL LAYOUT_MEMBER_NAME)
+
+/**
+ * Generator of parameters for view Metarecords subclass.
+ */
+#define _DECLARE_VIEW_CONSTRUCTOR_COLUMNS_IMPL(LAYOUT_NAME, LAYOUT_MEMBER, LOCAL_NAME) \
+  (typename Metadata::BOOST_PP_CAT(ParametersTypeOf_, LOCAL_NAME) LOCAL_NAME)
+
+#define _DECLARE_VIEW_CONSTRUCTOR_COLUMNS(R, DATA, LAYOUT_MEMBER_NAME) \
+  BOOST_PP_EXPAND(_DECLARE_VIEW_CONSTRUCTOR_COLUMNS_IMPL LAYOUT_MEMBER_NAME)
+
+/**
+ * Generator of members for (const) view Metarecords subclass.
+ */
+#define _DECLARE_STRUCT_CONST_DATA_MEMBER_IMPL(LAYOUT_NAME, LAYOUT_MEMBER, LOCAL_NAME) \
+  typename Metadata::BOOST_PP_CAT(ParametersTypeOf_, LOCAL_NAME)::ConstType BOOST_PP_CAT(LOCAL_NAME, _);
+
+#define _DECLARE_STRUCT_CONST_DATA_MEMBER(R, DATA, LAYOUT_MEMBER_NAME) \
+  BOOST_PP_EXPAND(_DECLARE_STRUCT_CONST_DATA_MEMBER_IMPL LAYOUT_MEMBER_NAME)
+
+/**
+ * Generator of members for view Metarecords subclass.
+ */
+#define _DECLARE_STRUCT_DATA_MEMBER_IMPL(LAYOUT_NAME, LAYOUT_MEMBER, LOCAL_NAME) \
+  typename Metadata::BOOST_PP_CAT(ParametersTypeOf_, LOCAL_NAME) BOOST_PP_CAT(LOCAL_NAME, _);
+
+#define _DECLARE_STRUCT_DATA_MEMBER(R, DATA, LAYOUT_MEMBER_NAME) \
+  BOOST_PP_EXPAND(_DECLARE_STRUCT_DATA_MEMBER_IMPL LAYOUT_MEMBER_NAME)
+
+/**
+ * Assign the value of the records to the column parameters.
+ */
+#define _STRUCT_ELEMENT_INITIALIZERS_IMPL(LAYOUT_NAME, LAYOUT_MEMBER, LOCAL_NAME) \
+  (BOOST_PP_CAT(LOCAL_NAME, _){parent_.metadata().BOOST_PP_CAT(parametersOf_, LOCAL_NAME)()})
+
+#define _STRUCT_ELEMENT_INITIALIZERS(R, DATA, LAYOUT_MEMBER_NAME) \
+  BOOST_PP_EXPAND(_STRUCT_ELEMENT_INITIALIZERS_IMPL LAYOUT_MEMBER_NAME)
+
+/**
+ * Generator of accessors for (const) view Metarecords subclass.
+ */
+#define _CONST_ACCESSORS_STRUCT_MEMBERS_IMPL(LAYOUT_NAME, LAYOUT_MEMBER, LOCAL_NAME)                    \
+  const typename Metadata::BOOST_PP_CAT(ParametersTypeOf_, LOCAL_NAME)::ConstType& LOCAL_NAME() const { \
+    return BOOST_PP_CAT(LOCAL_NAME, _);                                                                 \
+  }
+
+#define _CONST_ACCESSORS_STRUCT_MEMBERS(R, DATA, LAYOUT_MEMBER_NAME) \
+  BOOST_PP_EXPAND(_CONST_ACCESSORS_STRUCT_MEMBERS_IMPL LAYOUT_MEMBER_NAME)
+
+/**
+ * Generator of accessors for (const) view Metarecords subclass.
+ */
+#define _ACCESSORS_STRUCT_MEMBERS_IMPL(LAYOUT_NAME, LAYOUT_MEMBER, LOCAL_NAME)                \
+  const typename Metadata::BOOST_PP_CAT(ParametersTypeOf_, LOCAL_NAME) & LOCAL_NAME() const { \
+    return BOOST_PP_CAT(LOCAL_NAME, _);                                                       \
+  }
+
+#define _ACCESSORS_STRUCT_MEMBERS(R, DATA, LAYOUT_MEMBER_NAME) \
+  BOOST_PP_EXPAND(_ACCESSORS_STRUCT_MEMBERS_IMPL LAYOUT_MEMBER_NAME)
+
+// clang-format off
+#define _INITIALIZE_VIEW_PARAMETERS_AND_SIZE_IMPL(LAYOUT_NAME, LAYOUT_MEMBER, LOCAL_NAME)                              \
+        if (not readyToSet) {                                                                                          \
+          base_type::elements_ = LOCAL_NAME.size_;                                                                     \
+          readyToSet = true;                                                                                           \
+        }                                                                                                              \
+        auto BOOST_PP_CAT(LOCAL_NAME, _tmp) = [&]() -> auto {                                                          \
+          if (base_type::elements_ != LOCAL_NAME.size_)                                                                \
+            throw std::runtime_error(                                                                                  \
+              "In constructor by column pointers: number of elements not equal for every column: "                     \
+              BOOST_PP_STRINGIZE(LOCAL_NAME));                                                                         \
+          if constexpr (alignmentEnforcement == AlignmentEnforcement::enforced)                                        \
+            if (Metadata:: BOOST_PP_CAT(ParametersTypeOf_, LOCAL_NAME)::checkAlignment(LOCAL_NAME, alignment))         \
+              throw std::runtime_error("In constructor by column: misaligned column: " #LOCAL_NAME);                   \
+          return LOCAL_NAME;                                                                                           \
+            }();                                                                                                       \
+        base_type::BOOST_PP_CAT(LOCAL_NAME, Parameters_) = BOOST_PP_CAT(LOCAL_NAME, _tmp); \
+  // clang-format on
+
+#define _INITIALIZE_VIEW_PARAMETERS_AND_SIZE(R, DATA, LAYOUT_MEMBER_NAME) \
+  BOOST_PP_EXPAND(_INITIALIZE_VIEW_PARAMETERS_AND_SIZE_IMPL LAYOUT_MEMBER_NAME)
+
+// clang-format off
+#define _INITIALIZE_CONST_VIEW_PARAMETERS_AND_SIZE_IMPL(LAYOUT_NAME, LAYOUT_MEMBER, LOCAL_NAME)                        \
+        if (not readyToSet) {                                                                                          \
+          elements_ = LOCAL_NAME.size_;                                                                                \
+          readyToSet = true;                                                                                           \
+        }                                                                                                              \
+        auto BOOST_PP_CAT(LOCAL_NAME, _tmp) = [&]() -> auto {                                                          \
+          if (elements_ != LOCAL_NAME.size_)                                                                           \
+            throw std::runtime_error(                                                                                  \
+              "In constructor by column pointers: number of elements not equal for every column: "                     \
+              BOOST_PP_STRINGIZE(LOCAL_NAME));                                                                         \
+          if constexpr (alignmentEnforcement == AlignmentEnforcement::enforced)                                        \
+            if (Metadata:: BOOST_PP_CAT(ParametersTypeOf_, LOCAL_NAME)::checkAlignment(LOCAL_NAME, alignment))         \
+              throw std::runtime_error("In constructor by column: misaligned column: " #LOCAL_NAME);                   \
+          return LOCAL_NAME;                                                                                           \
+            }();                                                                                                       \
+        BOOST_PP_CAT(LOCAL_NAME, Parameters_) = BOOST_PP_CAT(LOCAL_NAME, _tmp); \
+  // clang-format on
+
+#define _INITIALIZE_CONST_VIEW_PARAMETERS_AND_SIZE(R, DATA, LAYOUT_MEMBER_NAME) \
+  BOOST_PP_EXPAND(_INITIALIZE_CONST_VIEW_PARAMETERS_AND_SIZE_IMPL LAYOUT_MEMBER_NAME)
+
 /* ---- MUTABLE VIEW ------------------------------------------------------------------------------------------------ */
 // clang-format off
 #define _GENERATE_SOA_VIEW_PART_0(CONST_VIEW, VIEW, LAYOUTS_LIST, VALUE_LIST)                                          \
@@ -571,8 +682,25 @@ namespace cms::soa {
     };                                                                                                                 \
                                                                                                                        \
     friend Metadata;                                                                                                   \
+                                                                                                                       \
+    /**                                                                                                                \
+     * Helper/friend class allowing access to size from columns.                                                       \
+     */                                                                                                                \
+    struct Metarecords {                                                                                               \
+      friend VIEW;                                                                                                     \
+      Metarecords(const VIEW& _soa_impl_parent) :                                                                      \
+                  parent_(_soa_impl_parent),                                                                           \
+                  _ITERATE_ON_ALL_COMMA(_STRUCT_ELEMENT_INITIALIZERS, ~, VALUE_LIST) {}                                \
+      _ITERATE_ON_ALL(_ACCESSORS_STRUCT_MEMBERS, ~, VALUE_LIST)                                                        \
+      private:                                                                                                         \
+        const VIEW& parent_;                                                                                           \
+        _ITERATE_ON_ALL(_DECLARE_STRUCT_DATA_MEMBER, ~, VALUE_LIST)                                                    \
+    };                                                                                                                 \
+                                                                                                                       \
     SOA_HOST_DEVICE SOA_INLINE const Metadata metadata() const { return Metadata(*this); }                             \
     SOA_HOST_DEVICE SOA_INLINE Metadata metadata() { return Metadata(*this); }                                         \
+    SOA_HOST_DEVICE SOA_INLINE const Metarecords records() const { return Metarecords(*this); }                        \
+    SOA_HOST_DEVICE SOA_INLINE Metarecords records() { return Metarecords(*this); }                                    \
                                                                                                                        \
     /* Trivial constuctor */                                                                                           \
     VIEW() = default;                                                                                                  \
@@ -589,6 +717,12 @@ namespace cms::soa {
         : base_type{_soa_impl_elements,                                                                                \
                     _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_MEMBER_LIST, BOOST_PP_EMPTY(), VALUE_LIST)                     \
           } {}                                                                                                         \
+                                                                                                                       \
+    /* Constructor relying on individually provided column structs */                                                  \
+    SOA_HOST_ONLY VIEW(_ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_CONSTRUCTOR_COLUMNS, BOOST_PP_EMPTY(), VALUE_LIST)) {       \
+      bool readyToSet = false;                                                                                         \
+      _ITERATE_ON_ALL(_INITIALIZE_VIEW_PARAMETERS_AND_SIZE, BOOST_PP_EMPTY(), VALUE_LIST)                              \
+    }                                                                                                                  \
                                                                                                                        \
     /* Copiable */                                                                                                     \
     VIEW(VIEW const&) = default;                                                                                       \
@@ -746,7 +880,22 @@ namespace cms::soa {
     };                                                                                                                 \
                                                                                                                        \
     friend Metadata;                                                                                                   \
+                                                                                                                       \
+    /**                                                                                                                \
+     * Helper/friend class allowing access to size from columns.                                                       \
+     */                                                                                                                \
+    struct Metarecords {                                                                                               \
+      friend CONST_VIEW;                                                                                               \
+      Metarecords(const CONST_VIEW& _soa_impl_parent) :                                                                \
+                  parent_(_soa_impl_parent),                                                                           \
+                  _ITERATE_ON_ALL_COMMA(_STRUCT_ELEMENT_INITIALIZERS, ~, VALUE_LIST) {}                                \
+      _ITERATE_ON_ALL(_CONST_ACCESSORS_STRUCT_MEMBERS, ~, VALUE_LIST)                                                  \
+      private:                                                                                                         \
+        const CONST_VIEW& parent_;                                                                                     \
+        _ITERATE_ON_ALL(_DECLARE_STRUCT_CONST_DATA_MEMBER, ~, VALUE_LIST)                                              \
+    };                                                                                                                 \
     SOA_HOST_DEVICE SOA_INLINE const Metadata metadata() const { return Metadata(*this); }                             \
+    SOA_HOST_DEVICE SOA_INLINE const Metarecords records() const { return Metarecords(*this); }                        \
                                                                                                                        \
     /* Trivial constuctor */                                                                                           \
     CONST_VIEW() = default;                                                                                            \
@@ -766,6 +915,13 @@ namespace cms::soa {
                         _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_CONSTRUCTION_BYCOLUMN_PARAMETERS, const, VALUE_LIST))      \
         : elements_(_soa_impl_elements),                                                                               \
           _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_MEMBER_INITIALIZERS_BYCOLUMN, ~, VALUE_LIST) {}                          \
+                                                                                                                       \
+    /* Constructor relying on individually provided column structs */                                                  \
+    SOA_HOST_ONLY CONST_VIEW(_ITERATE_ON_ALL_COMMA(                                                                    \
+                             _DECLARE_CONST_VIEW_CONSTRUCTOR_COLUMNS, BOOST_PP_EMPTY(), VALUE_LIST)) {                 \
+      bool readyToSet = false;                                                                                         \
+      _ITERATE_ON_ALL(_INITIALIZE_CONST_VIEW_PARAMETERS_AND_SIZE, BOOST_PP_EMPTY(), VALUE_LIST)                        \
+    }                                                                                                                  \
                                                                                                                        \
     /* Copiable */                                                                                                     \
     CONST_VIEW(CONST_VIEW const&) = default;                                                                           \

--- a/DataFormats/SoATemplate/test/BuildFile.xml
+++ b/DataFormats/SoATemplate/test/BuildFile.xml
@@ -21,6 +21,12 @@
   <use name="catch2"/>
 </bin>
 
+<bin file="SoAGenericView_t.cc" name="SoAGenericView_t">
+  <use name="boost"/>
+  <use name="catch2"/>
+  <use name="eigen"/>
+</bin>
+
 
 <!-- This test triggers a bug in ROOT, so it's kept disabled
 <bin file="SoAStreamer_t.cpp" name="SoAStreamer_t">

--- a/DataFormats/SoATemplate/test/SoAGenericView_t.cc
+++ b/DataFormats/SoATemplate/test/SoAGenericView_t.cc
@@ -1,0 +1,189 @@
+#include <Eigen/Core>
+#include <Eigen/Dense>
+
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+
+GENERATE_SOA_LAYOUT(SoAPositionTemplate,
+                    SOA_COLUMN(float, x),
+                    SOA_COLUMN(float, y),
+                    SOA_COLUMN(float, z),
+                    SOA_SCALAR(int, detectorType))
+
+using SoAPosition = SoAPositionTemplate<>;
+using SoAPositionView = SoAPosition::View;
+using SoAPositionConstView = SoAPosition::ConstView;
+
+GENERATE_SOA_LAYOUT(SoAPCATemplate,
+                    SOA_COLUMN(float, eigenvalues),
+                    SOA_COLUMN(float, eigenvector_1),
+                    SOA_COLUMN(float, eigenvector_2),
+                    SOA_COLUMN(float, eigenvector_3),
+                    SOA_EIGEN_COLUMN(Eigen::Vector3d, candidateDirection))
+
+using SoAPCA = SoAPCATemplate<>;
+using SoAPCAView = SoAPCA::View;
+using SoAPCAConstView = SoAPCA::ConstView;
+
+GENERATE_SOA_LAYOUT(GenericSoATemplate,
+                    SOA_COLUMN(float, xPos),
+                    SOA_COLUMN(float, yPos),
+                    SOA_COLUMN(float, zPos),
+                    SOA_EIGEN_COLUMN(Eigen::Vector3d, candidateDirection))
+
+using GenericSoA = GenericSoATemplate<cms::soa::CacheLineSize::IntelCPU>;
+using GenericSoAView = GenericSoA::View;
+using GenericSoAConstView = GenericSoA::ConstView;
+
+TEST_CASE("SoAGenericView") {
+  // common number of elements for the SoAs
+  const std::size_t elems = 17;
+
+  // buffer sizes
+  const std::size_t positionBufferSize = SoAPosition::computeDataSize(elems);
+  const std::size_t pcaBufferSize = SoAPCA::computeDataSize(elems);
+
+  // memory buffer for the SoA of positions
+  std::unique_ptr<std::byte, decltype(std::free) *> bufferPos{
+      reinterpret_cast<std::byte *>(aligned_alloc(SoAPosition::alignment, positionBufferSize)), std::free};
+  // memory buffer for the SoA of the PCA
+  std::unique_ptr<std::byte, decltype(std::free) *> bufferPCA{
+      reinterpret_cast<std::byte *>(aligned_alloc(SoAPCA::alignment, pcaBufferSize)), std::free};
+
+  // SoA Layouts
+  SoAPosition position{bufferPos.get(), elems};
+  SoAPCA pca{bufferPCA.get(), elems};
+
+  // SoA Views
+  SoAPositionView positionView{position};
+  SoAPositionConstView positionConstView{position};
+  SoAPCAView pcaView{pca};
+  SoAPCAConstView pcaConstView{pca};
+
+  // fill up
+  for (size_t i = 0; i < elems; i++) {
+    positionView[i] = {i * 1.0f, i * 2.0f, i * 3.0f};
+  }
+  positionView.detectorType() = 1;
+
+  float time = 0.01;
+  for (size_t i = 0; i < elems; i++) {
+    pcaView[i].eigenvector_1() = positionView[i].x() / time;
+    pcaView[i].eigenvector_2() = positionView[i].y() / time;
+    pcaView[i].eigenvector_3() = positionView[i].z() / time;
+    pcaView[i].candidateDirection()(0) = positionView[i].x() / time;
+    pcaView[i].candidateDirection()(1) = positionView[i].y() / time;
+    pcaView[i].candidateDirection()(2) = positionView[i].z() / time;
+  }
+
+  SECTION("Generic View") {
+    // addresses and size of the SoA columns
+    const auto posRecs = positionView.records();
+    const auto pcaRecs = pcaView.records();
+
+    // building the View with runtime check for the size
+    GenericSoAView genericView(posRecs.x(), posRecs.y(), posRecs.z(), pcaRecs.candidateDirection());
+
+    // Check for equality of memory addresses
+    REQUIRE(genericView.metadata().addressOf_xPos() == positionView.metadata().addressOf_x());
+    REQUIRE(genericView.metadata().addressOf_yPos() == positionView.metadata().addressOf_y());
+    REQUIRE(genericView.metadata().addressOf_zPos() == positionView.metadata().addressOf_z());
+    REQUIRE(genericView.metadata().addressOf_candidateDirection() == pcaView.metadata().addressOf_candidateDirection());
+
+    // Check for reference to original SoA
+    genericView[3].xPos() = 0.;
+    REQUIRE(genericView[3].xPos() == positionConstView[3].x());
+  }
+
+  SECTION("Generic ConstView") {
+    // addresses and size of the SoA columns
+    const auto posRecs = positionConstView.records();
+    const auto pcaRecs = pcaConstView.records();
+
+    // building the ConstView with runtime check for the size
+    GenericSoAConstView genericConstView(posRecs.x(), posRecs.y(), posRecs.z(), pcaRecs.candidateDirection());
+
+    // Check for equality of memory addresses
+    REQUIRE(genericConstView.metadata().addressOf_xPos() == positionConstView.metadata().addressOf_x());
+    REQUIRE(genericConstView.metadata().addressOf_yPos() == positionConstView.metadata().addressOf_y());
+    REQUIRE(genericConstView.metadata().addressOf_zPos() == positionConstView.metadata().addressOf_z());
+    REQUIRE(genericConstView.metadata().addressOf_candidateDirection() ==
+            pcaConstView.metadata().addressOf_candidateDirection());
+  }
+
+  SECTION("Generic ConstView from Views") {
+    // addresses and size of the SoA columns
+    const auto posRecs = positionView.records();
+    const auto pcaRecs = pcaView.records();
+
+    // building the ConstView with runtime check for the size
+    GenericSoAConstView genericConstView(posRecs.x(), posRecs.y(), posRecs.z(), pcaRecs.candidateDirection());
+
+    // Check for reference to the Generic SoA - it is possible to modify the ConstView by reference modifying the Views
+    positionView[3].x() = 0.;
+    REQUIRE(genericConstView[3].xPos() == positionView[3].x());
+  }
+
+  SECTION("Deep copy the Generic View") {
+    // building the Layout
+    const std::size_t genericBufferSize = GenericSoA::computeDataSize(elems);
+    std::unique_ptr<std::byte, decltype(std::free) *> bufferGeneric{
+        reinterpret_cast<std::byte *>(aligned_alloc(GenericSoA::alignment, genericBufferSize)), std::free};
+    GenericSoA genericSoA(bufferGeneric.get(), elems);
+
+    // building the Generic View
+    const auto posRecs = positionView.records();
+    const auto pcaRecs = pcaView.records();
+    GenericSoAView genericView(posRecs.x(), posRecs.y(), posRecs.z(), pcaRecs.candidateDirection());
+
+    // aggregate the columns from the view with runtime check for the size
+    genericSoA.deepCopy(genericView);
+
+    // building the View of the new SoA
+    GenericSoAView genericSoAView{genericSoA};
+
+    // Check for inequality of memory addresses
+    REQUIRE(genericSoAView.metadata().addressOf_xPos() != positionConstView.metadata().addressOf_x());
+    REQUIRE(genericSoAView.metadata().addressOf_yPos() != positionConstView.metadata().addressOf_y());
+    REQUIRE(genericSoAView.metadata().addressOf_zPos() != positionConstView.metadata().addressOf_z());
+    REQUIRE(genericSoAView.metadata().addressOf_candidateDirection() !=
+            pcaConstView.metadata().addressOf_candidateDirection());
+
+    // Check for column alignments
+    REQUIRE(0 ==
+            reinterpret_cast<uintptr_t>(genericSoAView.metadata().addressOf_xPos()) % decltype(genericSoA)::alignment);
+    REQUIRE(0 ==
+            reinterpret_cast<uintptr_t>(genericSoAView.metadata().addressOf_yPos()) % decltype(genericSoA)::alignment);
+    REQUIRE(0 ==
+            reinterpret_cast<uintptr_t>(genericSoAView.metadata().addressOf_zPos()) % decltype(genericSoA)::alignment);
+    REQUIRE(0 == reinterpret_cast<uintptr_t>(genericSoAView.metadata().addressOf_candidateDirection()) %
+                     decltype(genericSoA)::alignment);
+
+    // Check for contiguity of columns
+    REQUIRE(reinterpret_cast<std::byte *>(genericSoAView.metadata().addressOf_xPos()) +
+                cms::soa::alignSize(elems * sizeof(float), GenericSoA::alignment) ==
+            reinterpret_cast<std::byte *>(genericSoAView.metadata().addressOf_yPos()));
+    REQUIRE(reinterpret_cast<std::byte *>(genericSoAView.metadata().addressOf_yPos()) +
+                cms::soa::alignSize(elems * sizeof(float), GenericSoA::alignment) ==
+            reinterpret_cast<std::byte *>(genericSoAView.metadata().addressOf_zPos()));
+    REQUIRE(reinterpret_cast<std::byte *>(genericSoAView.metadata().addressOf_zPos()) +
+                cms::soa::alignSize(elems * sizeof(float), GenericSoA::alignment) ==
+            reinterpret_cast<std::byte *>(genericSoAView.metadata().addressOf_candidateDirection()));
+
+    // Ckeck the correctness of the copy
+    for (size_t i = 0; i < elems; i++) {
+      REQUIRE(genericSoAView[i].xPos() == positionConstView[i].x());
+      REQUIRE(genericSoAView[i].yPos() == positionConstView[i].y());
+      REQUIRE(genericSoAView[i].zPos() == positionConstView[i].z());
+      REQUIRE(genericSoAView[i].candidateDirection()(0) == pcaConstView[i].candidateDirection()(0));
+      REQUIRE(genericSoAView[i].candidateDirection()(1) == pcaConstView[i].candidateDirection()(1));
+      REQUIRE(genericSoAView[i].candidateDirection()(2) == pcaConstView[i].candidateDirection()(2));
+    }
+
+    // Check for the independency of the aggregated SoA
+    genericSoAView[3].xPos() = 0.;
+    REQUIRE(genericSoAView[3].xPos() != positionView[3].x());
+  }
+}


### PR DESCRIPTION
#### PR description:
Added a new constructor for the `SoAView` taking as input columns from different `View`s and putting them in a single object. A run-time check on the column sizes being the same is performed. 
Additionally, a new `aggregate` method has been added to `PortableHostCollection` taking as input a `SoAView` and creating a unique memory buffer to save its columns contiguously. This is useful to create a PortableCollection from the VIew built with the newly implemented constructor. 
Unit tests for both these features have been added as well.

#### PR validation:
Unit tests created pass.
