### PR TITLE
Added template argument to VPSet

### DIFF
--- a/FWCore/ParameterSet/python/Mixins.py
+++ b/FWCore/ParameterSet/python/Mixins.py
@@ -706,13 +706,20 @@ class _ValidatingParameterListBase(_ValidatingListBase,_ParameterTypeBase):
                 else:
                     result += ', '
             result += self.pythonValueForItem(v,options)
+        if n>=256:
+            result +=' ) '
+        moreArgs = self._additionalInitArguments(options)
+        if moreArgs:
+            if i > 0:
+                result += ', \n' + options.indentation()
+            result += moreArgs
         if n>nPerLine:
             options.unindent()
             result += '\n'+options.indentation()
-        if n>=256:
-            result +=' ) '
         result += ')'
-        return result            
+        return result  
+    def _additionalInitArguments(self, options):
+        return ''
     def directDependencies(self):
         return []
     @staticmethod


### PR DESCRIPTION
#### PR description:

One can now pass a PSetTemplate to VPSet to describe how the PSets should be configured. This is used to convert any dict to a PSet when passed to the VPSet.

#### PR validation:

New unit tests pass.

resolves https://github.com/cms-sw/framework-team/issues/1224