### PR TITLE
[15_0_X] Remove size scalar from HcalRecHitSoALayout as unused

### DIFF
--- a/DataFormats/HcalRecHit/interface/HcalRecHitSoA.h
+++ b/DataFormats/HcalRecHit/interface/HcalRecHitSoA.h
@@ -6,7 +6,6 @@
 namespace hcal {
 
   GENERATE_SOA_LAYOUT(HcalRecHitSoALayout,
-                      SOA_SCALAR(uint32_t, size),
                       SOA_COLUMN(uint32_t, detId),
                       SOA_COLUMN(float, energy),
                       SOA_COLUMN(float, chi2),


### PR DESCRIPTION
#### PR description:

Backport of https://github.com/cms-sw/cmssw/pull/47281 (same branch)


#### PR validation:

None beyond https://github.com/cms-sw/cmssw/pull/47281

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of https://github.com/cms-sw/cmssw/pull/47281