### PR TITLE
Fix compilation of EdmEventSize on clang

### DIFF
--- a/PerfTools/EdmEvent/interface/EdmEventSize.h
+++ b/PerfTools/EdmEvent/interface/EdmEventSize.h
@@ -95,10 +95,8 @@ namespace perftools {
     Records m_records;
   };
 
-  template class perftools::EdmEventSize<perftools::EdmEventMode::Leaves>;
-
-  template class perftools::EdmEventSize<perftools::EdmEventMode::Branches>;
-
+  extern template class perftools::EdmEventSize<perftools::EdmEventMode::Leaves>;
+  extern template class perftools::EdmEventSize<perftools::EdmEventMode::Branches>;
 }  // namespace perftools
 
 #endif  // PerfTools_EdmEventSize_H

--- a/PerfTools/EdmEvent/src/EdmEventSize.cc
+++ b/PerfTools/EdmEvent/src/EdmEventSize.cc
@@ -423,4 +423,6 @@ namespace perftools {
     }
   }
 
+  template class perftools::EdmEventSize<perftools::EdmEventMode::Leaves>;
+  template class perftools::EdmEventSize<perftools::EdmEventMode::Branches>;
 }  // namespace perftools


### PR DESCRIPTION
#### PR description:

Fixes https://github.com/cms-sw/cmssw/issues/47307

Resolves https://github.com/cms-sw/framework-team/issues/1228

#### PR validation:

Code compiles on CMSSW_15_1_CLANG_X_2025-02-09-2300