### PR TITLE
Fix improper use of std::unique and std::remove

### DIFF
--- a/DQM/HLTEvF/plugins/TrigObjTnPHistColl.cc
+++ b/DQM/HLTEvF/plugins/TrigObjTnPHistColl.cc
@@ -122,7 +122,8 @@ void TrigObjTnPHistColl::FilterSelector::mergeTrigKeys(trigger::Keys& keys,
 
 void TrigObjTnPHistColl::FilterSelector::cleanTrigKeys(trigger::Keys& keys) {
   std::sort(keys.begin(), keys.end());
-  std::unique(keys.begin(), keys.end());
+  auto last = std::unique(keys.begin(), keys.end());
+  keys.erase(last, keys.end());
   while (!keys.empty() && keys.back() == std::numeric_limits<trigger::size_type>::max()) {
     keys.pop_back();
   }

--- a/DQMOffline/RecoB/src/BTagDifferentialPlot.cc
+++ b/DQMOffline/RecoB/src/BTagDifferentialPlot.cc
@@ -222,7 +222,8 @@ void BTagDifferentialPlot::bookHisto(DQMStore::IBooker& ibook) {
   stream << constVariableValue.second << "_"
          << "_Vs_" << diffVariableName;
   commonName += stream.str();
-  std::remove(commonName.begin(), commonName.end(), ' ');
+  auto last = std::remove(commonName.begin(), commonName.end(), ' ');
+  commonName.erase(last, commonName.end());
   std::replace(commonName.begin(), commonName.end(), '.', 'v');
 
   std::string label(commonName);

--- a/DQMOffline/RecoB/src/EtaPtBin.cc
+++ b/DQMOffline/RecoB/src/EtaPtBin.cc
@@ -34,7 +34,8 @@ std::string EtaPtBin::buildDescriptionString(const bool& etaActive_,
 
   std::string descr(stream.str());
   // remove blanks which are introduced when adding doubles
-  std::remove(descr.begin(), descr.end(), ' ');
+  auto last = std::remove(descr.begin(), descr.end(), ' ');
+  descr.erase(last, descr.end());
   std::replace(descr.begin(), descr.end(), '.', 'v');
 
   return descr;

--- a/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
@@ -724,7 +724,8 @@ void PATElectronProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
 
           //remove duplicates
           std::sort(selectedCells.begin(), selectedCells.end());
-          std::unique(selectedCells.begin(), selectedCells.end());
+          auto last = std::unique(selectedCells.begin(), selectedCells.end());
+          selectedCells.erase(last, selectedCells.end());
 
           // Retrieve the corresponding RecHits
 
@@ -968,7 +969,8 @@ void PATElectronProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
 
       //remove duplicates
       std::sort(selectedCells.begin(), selectedCells.end());
-      std::unique(selectedCells.begin(), selectedCells.end());
+      auto last = std::unique(selectedCells.begin(), selectedCells.end());
+      selectedCells.erase(last, selectedCells.end());
 
       // Retrieve the corresponding RecHits
 

--- a/PhysicsTools/PatAlgos/plugins/PATPhotonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPhotonProducer.cc
@@ -417,7 +417,8 @@ void PATPhotonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
 
     //remove duplicates
     std::sort(selectedCells.begin(), selectedCells.end());
-    std::unique(selectedCells.begin(), selectedCells.end());
+    auto last = std::unique(selectedCells.begin(), selectedCells.end());
+    selectedCells.erase(last, selectedCells.end());
 
     // Retrieve the corresponding RecHits
 

--- a/RecoEcal/EgammaClusterProducers/src/InterestingDetIdCollectionProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/InterestingDetIdCollectionProducer.cc
@@ -194,7 +194,8 @@ void InterestingDetIdCollectionProducer::produce(edm::StreamID,
 
   //unify the vector
   std::sort(indexToStore.begin(), indexToStore.end());
-  std::unique(indexToStore.begin(), indexToStore.end());
+  auto last = std::unique(indexToStore.begin(), indexToStore.end());
+  indexToStore.erase(last, indexToStore.end());
 
   iEvent.put(std::make_unique<DetIdCollection>(indexToStore), interestingDetIdCollection_);
 }

--- a/RecoEcal/EgammaClusterProducers/src/InterestingDetIdFromSuperClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/InterestingDetIdFromSuperClusterProducer.cc
@@ -193,7 +193,8 @@ void InterestingDetIdFromSuperClusterProducer::produce(edm::StreamID,
 
   //unify the vector
   std::sort(indexToStore.begin(), indexToStore.end());
-  std::unique(indexToStore.begin(), indexToStore.end());
+  auto last = std::unique(indexToStore.begin(), indexToStore.end());
+  indexToStore.erase(last, indexToStore.end());
 
   auto detIdCollection = std::make_unique<DetIdCollection>(indexToStore);
 

--- a/RecoEcal/EgammaClusterProducers/src/ReducedRecHitCollectionProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/ReducedRecHitCollectionProducer.cc
@@ -117,7 +117,8 @@ void ReducedRecHitCollectionProducer::produce(edm::Event& iEvent, const edm::Eve
   }
 
   std::sort(xtalsToStore.begin(), xtalsToStore.end());
-  std::unique(xtalsToStore.begin(), xtalsToStore.end());
+  auto last = std::unique(xtalsToStore.begin(), xtalsToStore.end());
+  xtalsToStore.erase(last, xtalsToStore.end());
 
   //   std::cout << "New Collection " << reducedHitsCollection_ << " size is " << miniRecHitCollection->size() << " original is " << recHitsHandle->size() << std::endl;
   iEvent.put(std::move(miniRecHitCollection), reducedHitsCollection_);

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaIsoESDetIdCollectionProducer.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaIsoESDetIdCollectionProducer.cc
@@ -114,7 +114,8 @@ void EgammaIsoESDetIdCollectionProducer::produce(edm::StreamID, edm::Event& iEve
 
   //unify the vector
   std::sort(indexToStore.begin(), indexToStore.end());
-  std::unique(indexToStore.begin(), indexToStore.end());
+  auto last = std::unique(indexToStore.begin(), indexToStore.end());
+  indexToStore.erase(last, indexToStore.end());
 
   auto detIdCollection = std::make_unique<DetIdCollection>(indexToStore);
 

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaIsoHcalDetIdCollectionProducer.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaIsoHcalDetIdCollectionProducer.cc
@@ -125,7 +125,8 @@ void EgammaIsoHcalDetIdCollectionProducer::produce(edm::Event& iEvent, const edm
 
   //unify the vector
   std::sort(indexToStore.begin(), indexToStore.end());
-  std::unique(indexToStore.begin(), indexToStore.end());
+  auto last = std::unique(indexToStore.begin(), indexToStore.end());
+  indexToStore.erase(last, indexToStore.end());
 
   auto detIdCollection = std::make_unique<DetIdCollection>(indexToStore);
 

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
@@ -246,7 +246,8 @@ void PixelThresholdClusterizer::copy_to_buffer(DigiIterator begin, DigiIterator 
       // the 2nd occurrence (duplicate pixel: reset the buffer to 0 and remove from the list of seed pixels)
       case 2:
         theBuffer.set_adc(row, col, 0);
-        std::remove(theSeeds.begin(), theSeeds.end(), SiPixelCluster::PixelPos(row, col));
+        auto last = std::remove(theSeeds.begin(), theSeeds.end(), SiPixelCluster::PixelPos(row, col));
+        theSeeds.erase(last, theSeeds.end());
         break;
 
         // in case a pixel appears more than twice, nothing needs to be done because it was already removed at the 2nd occurrence


### PR DESCRIPTION
#### PR description:

In GCC14 builds, a warning is emitted when discarding output value of function marked `nodiscard`, such as `std::unique` and `std::remove`. Since both of these functions take iterators, they are not modifying the length of the original sequence (`std::vector`) - i.e. the removed elements are still accessible but their value is undefined. One must call `erase(...)` to update the number of elements.

The proposed changes cleanup most of the reported issues. 

#### PR validation:

Bot tests