### PR TITLE
 Developing offline JetMET DQM for Scouting jets - complementary to PR #47212

### DIFF
--- a/DQMOffline/HLTScouting/python/HLTScoutingDqmOffline_cff.py
+++ b/DQMOffline/HLTScouting/python/HLTScoutingDqmOffline_cff.py
@@ -13,9 +13,13 @@ from HLTriggerOffline.Scouting.ScoutingMuonMonitoring_Client_cff import *
 
 from HLTriggerOffline.Scouting.HLTScoutingEGammaDqmOffline_cff import *
 
+from DQMOffline.JetMET.jetMETDQMOfflineSource_cff import *
+
 hltScoutingMuonDqmOffline = cms.Sequence(scoutingMonitoringTagProbeMuonNoVtx
                                          * scoutingMonitoringTagProbeMuonVtx                                                         
                                          * scoutingMonitoringTriggerMuon                                                              
-) 
+)
 
-hltScoutingDqmOffline = cms.Sequence(hltScoutingMuonDqmOffline + hltScoutingEGammaDqmOffline)
+hltScoutingJetDqmOffline = cms.Sequence(jetMETDQMOfflineSourceScouting)
+
+hltScoutingDqmOffline = cms.Sequence(hltScoutingMuonDqmOffline + hltScoutingEGammaDqmOffline + hltScoutingJetDqmOffline)

--- a/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py
+++ b/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py
@@ -104,8 +104,7 @@ from JetMETCorrections.Configuration.JetCorrectors_cff import ak4PFL1FastL2L3Res
 
 ak4PFScoutingL1FastjetCorrector = ak4PFL1FastjetCorrector.clone(
     algorithm   = cms.string('AK4PFHLT'),
-    #srcRho = cms.InputTag("hltScoutingPFPacker","rho")      ### to be updated to this once 2025 ScoutingPFMonitor datasets are available, where the "hltScoutingPacker,rho" won't be missing!
-    srcRho = cms.InputTag('fixedGridRhoFastjetAll')    	     ### used only temporarily, because in some 2024 ScoutingPFMonitor datasets the "hltScoutingPacker,rho" is missing!
+    srcRho = cms.InputTag("hltScoutingPFPacker","rho")
     )
     
 ak4PFScoutingL2RelativeCorrector = ak4PFL2RelativeCorrector.clone( 

--- a/DQMOffline/JetMET/src/JetAnalyzer.cc
+++ b/DQMOffline/JetMET/src/JetAnalyzer.cc
@@ -292,7 +292,7 @@ JetAnalyzer::~JetAnalyzer() {
 
 // ***********************************************************
 void JetAnalyzer::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun, edm::EventSetup const&) {
-  if(isScoutingJet_){
+  if (isScoutingJet_) {
     if (!jetCleaningFlag_) {
       ibooker.setCurrentFolder("HLT/ScoutingOffline/Jet/Uncleaned" + mInputCollection_.label());
       DirName = "HLT/ScoutingOffline/Jet/Uncleaned" + mInputCollection_.label();
@@ -2591,7 +2591,7 @@ void JetAnalyzer::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetu
 // ***********************************************************
 void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   //set general folders first --> change later on for different folders
-  if(isScoutingJet_){
+  if (isScoutingJet_) {
     if (!jetCleaningFlag_) {
       DirName = "HLT/ScoutingOffline/Jet/Uncleaned" + mInputCollection_.label();
     }

--- a/DQMOffline/JetMET/src/JetAnalyzer.cc
+++ b/DQMOffline/JetMET/src/JetAnalyzer.cc
@@ -292,12 +292,19 @@ JetAnalyzer::~JetAnalyzer() {
 
 // ***********************************************************
 void JetAnalyzer::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun, edm::EventSetup const&) {
-  if (jetCleaningFlag_) {
-    ibooker.setCurrentFolder("JetMET/Jet/Cleaned" + mInputCollection_.label());
-    DirName = "JetMET/Jet/Cleaned" + mInputCollection_.label();
+  if(isScoutingJet_){
+    if (!jetCleaningFlag_) {
+      ibooker.setCurrentFolder("HLT/ScoutingOffline/Jet/Uncleaned" + mInputCollection_.label());
+      DirName = "HLT/ScoutingOffline/Jet/Uncleaned" + mInputCollection_.label();
+    }
   } else {
-    ibooker.setCurrentFolder("JetMET/Jet/Uncleaned" + mInputCollection_.label());
-    DirName = "JetMET/Jet/Uncleaned" + mInputCollection_.label();
+    if (jetCleaningFlag_) {
+      ibooker.setCurrentFolder("JetMET/Jet/Cleaned" + mInputCollection_.label());
+      DirName = "JetMET/Jet/Cleaned" + mInputCollection_.label();
+    } else {
+      ibooker.setCurrentFolder("JetMET/Jet/Uncleaned" + mInputCollection_.label());
+      DirName = "JetMET/Jet/Uncleaned" + mInputCollection_.label();
+    }
   }
 
   jetME = ibooker.book1D("jetReco", "jetReco", 5, 1, 5);  // --> for .../JetMET/Run summary/Jet/.../jetReco plots
@@ -2584,12 +2591,18 @@ void JetAnalyzer::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetu
 // ***********************************************************
 void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   //set general folders first --> change later on for different folders
-  if (jetCleaningFlag_) {
-    //dbe_->setCurrentFolder("JetMET/Jet/Cleaned"+mInputCollection_.label());
-    DirName = "JetMET/Jet/Cleaned" + mInputCollection_.label();
+  if(isScoutingJet_){
+    if (!jetCleaningFlag_) {
+      DirName = "HLT/ScoutingOffline/Jet/Uncleaned" + mInputCollection_.label();
+    }
   } else {
-    //dbe_->setCurrentFolder("JetMET/Jet/Uncleaned"+mInputCollection_.label());
-    DirName = "JetMET/Jet/Uncleaned" + mInputCollection_.label();
+    if (jetCleaningFlag_) {
+      //dbe_->setCurrentFolder("JetMET/Jet/Cleaned"+mInputCollection_.label());
+      DirName = "JetMET/Jet/Cleaned" + mInputCollection_.label();
+    } else {
+      //dbe_->setCurrentFolder("JetMET/Jet/Uncleaned"+mInputCollection_.label());
+      DirName = "JetMET/Jet/Uncleaned" + mInputCollection_.label();
+    }
   }
 
   Handle<ValueMap<float>> puJetIdMva;


### PR DESCRIPTION
#### PR description:

This PR is complementary to [cms-sw/cmssw#47212](https://github.com/cms-sw/cmssw/pull/47212) to add the **hltScoutingJetDqmOffline** sequence to the **@hltScouting** DQM sequence and to connect the PR #47212 with the PR [cms-sw/cmssw#47235](https://github.com/cms-sw/cmssw/pull/47235).

Also, the offline rho `srcRho = cms.InputTag("fixedGridRhoFastjetAll")` is changed to the scouting rho  `srcRho = cms.InputTag("hltScoutingPFPacker","rho"`. The offline rho was used only temporarily, until the **@hltScouting** DQM sequence was created (with PR #47235), to avoid crash with non-ScoutingPFMonitor datasets.


#### PR validation:

This PR has been prepared starting from CMSSW_15_1_X_2025-02-10-2300: 
`cmsrel CMSSW_15_1_X_2025-02-10-2300`
`cd CMSSW_15_1_X_2025-02-10-2300/src` 
`cmsenv `
`git cms-init` 
`git cms-addpkg DQMOffline/HLTScouting` 
`scram b` 
`scram build code-checks` 
`scram build code-format`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR should also be backported to CMSSW_15_0_X releases  so that the Offline Scouting DQM developments are linked and complete in all these releases.


Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

