### PR TITLE
[GCC14] Fix compilation errors

### DIFF
--- a/JetMETCorrections/Modules/src/JetResolution.cc
+++ b/JetMETCorrections/Modules/src/JetResolution.cc
@@ -9,6 +9,8 @@
 #include "JetResolution.h"
 #endif
 
+#include <algorithm>
+
 namespace JME {
 
   JetResolution::JetResolution(const std::string& filename) {

--- a/L1Trigger/GlobalCaloTrigger/src/L1GlobalCaloTrigger.cc
+++ b/L1Trigger/GlobalCaloTrigger/src/L1GlobalCaloTrigger.cc
@@ -14,6 +14,8 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+#include <algorithm>
+
 using std::vector;
 
 //DEFINE STATICS

--- a/RecoVertex/PixelVertexFinding/plugins/alpaka/clusterTracksDBSCAN.h
+++ b/RecoVertex/PixelVertexFinding/plugins/alpaka/clusterTracksDBSCAN.h
@@ -76,7 +76,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::vertexFinder {
       // fill hist (bin shall be wider than "eps")
       for (auto i : cms::alpakatools::uniform_elements(acc, nt)) {
         int iz = static_cast<int>(zt[i] * 10.f);  // valid if eps <= 0.1
-        iz = std::clamp(iz, INT8_MIN, INT8_MAX);
+        // Equivalent of iz = std::clamp(iz, INT8_MIN, INT8_MAX)
+        // which doesn't compile with gcc14 due to reference to __glibcxx_assert
+        // See https://github.com/llvm/llvm-project/issues/95183
+        int tmp_max = std::max<int>(iz, INT8_MIN);
+        iz = std::min<int>(tmp_max, INT8_MAX);
         izt[i] = iz - INT8_MIN;
         ALPAKA_ASSERT_ACC(iz - INT8_MIN >= 0);
         ALPAKA_ASSERT_ACC(iz - INT8_MIN < 256);

--- a/RecoVertex/PixelVertexFinding/plugins/alpaka/clusterTracksIterative.h
+++ b/RecoVertex/PixelVertexFinding/plugins/alpaka/clusterTracksIterative.h
@@ -76,7 +76,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::vertexFinder {
       // fill hist (bin shall be wider than "eps")
       for (auto i : cms::alpakatools::uniform_elements(acc, nt)) {
         int iz = static_cast<int>(zt[i] * 10.f);  // valid if eps <= 0.1
-        iz = std::clamp(iz, INT8_MIN, INT8_MAX);
+        // Equivalent of iz = std::clamp(iz, INT8_MIN, INT8_MAX)
+        // which doesn't compile with gcc14 due to reference to __glibcxx_assert
+        // See https://github.com/llvm/llvm-project/issues/95183
+        int tmp_max = std::max<int>(iz, INT8_MIN);
+        iz = std::min<int>(tmp_max, INT8_MAX);
         izt[i] = iz - INT8_MIN;
         ALPAKA_ASSERT_ACC(iz - INT8_MIN >= 0);
         ALPAKA_ASSERT_ACC(iz - INT8_MIN < 256);


### PR DESCRIPTION
#### PR description:

* Add missing `#include <algorithm>`
* Replace std::clamp with std::max+std::min in device code (same fix as  #47266)

#### PR validation:

Bot tests