### PR TITLE
add a filter sequence if it is present in the fragment

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1447,7 +1447,8 @@ class ConfigBuilder(object):
                             self._options.nConcurrentIOVs = 1
                     elif isinstance(theObject, cms.Sequence) or isinstance(theObject, cmstypes.ESProducer):
                         self._options.inlineObjects+=','+name
-
+                    if name == 'ProductionFilterSequence':
+                        self.productionFilterSequence = 'ProductionFilterSequence'
             if stepSpec == self.GENDefaultSeq or stepSpec == 'pgen_genonly':
                 if 'ProductionFilterSequence' in genModules and ('generator' in genModules):
                     self.productionFilterSequence = 'ProductionFilterSequence'


### PR DESCRIPTION
#### PR description:

looks like when a user adds a ProductionFilterSequence in the fragment, it is not systematically added in the final configuration for filtering. This PR remedies that.

#### PR validation:

should be rather transparent. tested using a request configuration.

