### PR TITLE
Removed -Wconversion warnings in part of framework

### DIFF
--- a/DataFormats/Common/interface/Association.h
+++ b/DataFormats/Common/interface/Association.h
@@ -43,7 +43,7 @@ namespace edm {
       size_t k = i;
       if (k >= ref_->size())
         throwIndexMapBound();
-      return reference_type(ref_, k);
+      return reference_type(ref_, static_cast<typename reference_type::key_type>(k));
     }
 
     reference_type get(ProductID id, size_t idx) const { return get(rawIndexOf(id, idx)); }

--- a/DataFormats/Common/interface/AssociationMap.h
+++ b/DataFormats/Common/interface/AssociationMap.h
@@ -175,31 +175,31 @@ namespace edm {
     const_iterator find(const key_type& k) const {
       if (ref_.key.id() != k.id())
         return end();
-      return find(k.key());
+      return find(static_cast<index_type>(k.key()));
     }
     /// erase the element whose key is k
     size_type erase(const key_type& k) {
-      index_type i = k.key();
+      index_type i = static_cast<index_type>(k.key());
       transientMap_.unsafe_erase(i);
       return map_.erase(i);
     }
     /// find element with specified reference key
     const result_type& operator[](const key_type& k) const {
       helpers::checkRef(ref_.key, k);
-      return get(k.key()).val;
+      return get(static_cast<index_type>(k.key())).val;
     }
 
     template <typename K>
     const result_type& operator[](const K& k) const {
       helpers::checkRef(ref_.key, k);
-      return get(k.key()).val;
+      return get(static_cast<index_type>(k.key())).val;
     }
 
     /// number of associations to a key
     size_type numberOfAssociations(const key_type& k) const {
       if (ref_.key.id() != k.id())
         return 0;
-      typename map_type::const_iterator f = map_.find(k.key());
+      auto f = map_.find(static_cast<index_type>(k.key()));
       if (f == map_.end())
         return 0;
       return Tag::size(f->second);
@@ -252,22 +252,21 @@ namespace edm {
     /// transient reference map
     mutable internal_transient_map_type transientMap_;
     /// find element with index i
-    const_iterator find(size_type i) const {
-      typename map_type::const_iterator f = map_.find(i);
+    const_iterator find(index_type i) const {
+      auto f = map_.find(i);
       if (f == map_.end())
         return end();
       return const_iterator(this, f);
     }
     /// return value_typeelement with key i
-    const value_type& get(size_type i) const {
-      typename internal_transient_map_type::const_iterator tf = transientMap_.find(i);
+    const value_type& get(index_type i) const {
+      auto tf = transientMap_.find(i);
       if (tf == transientMap_.end()) {
-        typename map_type::const_iterator f = map_.find(i);
+        auto f = map_.find(i);
         if (f == map_.end())
           Exception::throwThis(edm::errors::InvalidReference, "can't find reference in AssociationMap at position ", i);
         value_type v(key_type(ref_.key, i), Tag::val(ref_, f->second));
-        std::pair<typename internal_transient_map_type::const_iterator, bool> ins =
-            transientMap_.insert(std::make_pair(i, v));
+        auto ins = transientMap_.insert(std::make_pair(i, v));
         return ins.first->second;
       } else {
         return tf->second;

--- a/DataFormats/Common/interface/AssociationVector.h
+++ b/DataFormats/Common/interface/AssociationVector.h
@@ -225,7 +225,7 @@ namespace edm {
   template <typename KeyRefProd, typename CVal, typename KeyRef, typename SizeType, typename KeyReferenceHelper>
   inline typename AssociationVector<KeyRefProd, CVal, KeyRef, SizeType, KeyReferenceHelper>::size_type
   AssociationVector<KeyRefProd, CVal, KeyRef, SizeType, KeyReferenceHelper>::size() const {
-    return data_.size();
+    return static_cast<size_type>(data_.size());
   }
 
   template <typename KeyRefProd, typename CVal, typename KeyRef, typename SizeType, typename KeyReferenceHelper>

--- a/DataFormats/Common/interface/ContainerMask.h
+++ b/DataFormats/Common/interface/ContainerMask.h
@@ -79,7 +79,7 @@ namespace edm {
 
   template <typename T>
   bool ContainerMask<T>::mask(const typename ContainerMaskTraits<T>::value_type* iElement) {
-    unsigned int index = ContainerMaskTraits<T>::indexFor(iElement, m_prod.product());
+    auto index = ContainerMaskTraits<T>::indexFor(iElement, m_prod.product());
     return this->mask(index);
   }
 

--- a/DataFormats/Common/interface/ContainerMaskTraits.h
+++ b/DataFormats/Common/interface/ContainerMaskTraits.h
@@ -32,7 +32,7 @@ namespace edm {
 
     static size_t size(const T* iContainer) { return iContainer->size(); }
     static unsigned int indexFor(const value_type* iElement, const T* iContainer) {
-      return iElement - &(iContainer->front());
+      return static_cast<unsigned int>(iElement - &(iContainer->front()));
     }
 
     ContainerMaskTraits() = delete;

--- a/DataFormats/Common/interface/DataFrameContainer.h
+++ b/DataFormats/Common/interface/DataFrameContainer.h
@@ -63,7 +63,7 @@ namespace edm {
     DataFrameContainer() : m_subdetId(0), m_stride(0), m_ids(), m_data() {}
 
     explicit DataFrameContainer(size_t istride, int isubdet = 0, size_t isize = 0)
-        : m_subdetId(isubdet), m_stride(istride), m_ids(isize), m_data(isize * m_stride) {}
+        : m_subdetId(isubdet), m_stride(static_cast<size_type>(istride)), m_ids(isize), m_data(isize * m_stride) {}
 
     void swap(DataFrameContainer& rh) {
       std::swap(m_subdetId, rh.m_subdetId);
@@ -126,9 +126,9 @@ namespace edm {
 
     const_IterPair pair(size_t i) const { return const_IterPair(m_ids.begin() + i, m_data.begin() + i * m_stride); }
 
-    DataFrame operator[](size_t i) { return DataFrame(*this, i); }
+    DataFrame operator[](size_t i) { return DataFrame(*this, static_cast<DataFrame::size_type>(i)); }
 
-    DataFrame operator[](size_t i) const { return DataFrame(*this, i); }
+    DataFrame operator[](size_t i) const { return DataFrame(*this, static_cast<DataFrame::size_type>(i)); }
 
     /// slow interface
     /// The iterator returned can not safely be used across threads
@@ -136,7 +136,8 @@ namespace edm {
       const_IdIter p = std::lower_bound(m_ids.begin(), m_ids.end(), i);
       return (p == m_ids.end() || (*p) != i)
                  ? end()
-                 : boost::make_transform_iterator(boost::counting_iterator<int>(p - m_ids.begin()), IterHelp(*this));
+                 : boost::make_transform_iterator(boost::counting_iterator<int>(static_cast<int>(p - m_ids.begin())),
+                                                  IterHelp(*this));
     }
 
     /// The iterator returned can not safely be used across threads
@@ -153,7 +154,7 @@ namespace edm {
 
     bool empty() const { return m_ids.empty(); }
 
-    size_type size() const { return m_ids.size(); }
+    size_type size() const { return static_cast<size_type>(m_ids.size()); }
 
     data_type operator()(size_t cell, size_t frame) const { return m_data[cell * m_stride + frame]; }
 

--- a/DataFormats/Common/interface/DetSetVectorNew.h
+++ b/DataFormats/Common/interface/DetSetVectorNew.h
@@ -256,7 +256,7 @@ namespace edmNew {
       void resize(size_type s) {
         checkCapacityExausted(s);
         m_v.m_data.resize(m_item.offset + s);
-        m_v.m_dataSize = m_v.m_data.size();
+        m_v.m_dataSize = static_cast<unsigned int>(m_v.m_data.size());
         m_item.size = s;
       }
 
@@ -329,16 +329,16 @@ namespace edmNew {
           expected = false;
           nanosleep(nullptr, nullptr);
         }
-        int offset = m_v.m_data.size();
+        int offset = static_cast<int>(m_v.m_data.size());
         if (m_v.onDemand() && full()) {
           m_v.m_filling = false;
           dstvdetails::throwCapacityExausted();
         }
         std::move(m_lv.begin(), m_lv.end(), std::back_inserter(m_v.m_data));
-        m_item.size = m_lv.size();
+        m_item.size = static_cast<size_type>(m_lv.size());
         m_item.offset = offset;
 
-        m_v.m_dataSize = m_v.m_data.size();
+        m_v.m_dataSize = static_cast<unsigned int>(m_v.m_data.size());
         assert(m_v.m_filling == true);
         m_v.m_filling = false;
       }
@@ -355,7 +355,7 @@ namespace edmNew {
       void resize(size_type s) { m_lv.resize(s); }
 
       id_type id() const { return m_item.id; }
-      size_type size() const { return m_lv.size(); }
+      size_type size() const { return static_cast<size_type>(m_lv.size()); }
       bool empty() const { return m_lv.empty(); }
 
       data_type& operator[](size_type i) { return m_lv[i]; }
@@ -451,7 +451,7 @@ namespace edmNew {
     void resize(size_t isize, size_t dsize) {
       m_ids.resize(isize);
       m_data.resize(dsize);
-      m_dataSize = m_data.size();
+      m_dataSize = static_cast<unsigned int>(m_data.size());
     }
 
     void clean() {
@@ -463,14 +463,14 @@ namespace edmNew {
       Item& item = addItem(iid, isize);
       m_data.resize(m_data.size() + isize);
       std::copy(idata, idata + isize, m_data.begin() + item.offset);
-      m_dataSize = m_data.size();
+      m_dataSize = static_cast<unsigned int>(m_data.size());
       return DetSet(*this, item, false);
     }
     //make space for it
     DetSet insert(id_type iid, size_type isize) {
       Item& item = addItem(iid, isize);
       m_data.resize(m_data.size() + isize);
-      m_dataSize = m_data.size();
+      m_dataSize = static_cast<unsigned int>(m_data.size());
       return DetSet(*this, item, false);
     }
 
@@ -485,7 +485,7 @@ namespace edmNew {
       // sanity checks...  (shall we throw or assert?)
       if ((*p).isValid() && (*p).size > 0 && m_data.size() == (*p).offset + (*p).size) {
         m_data.resize((*p).offset);
-        m_dataSize = m_data.size();
+        m_dataSize = static_cast<size_type>(m_data.size());
       }
       m_ids.erase(m_ids.begin() + (p - m_ids.begin()));
     }
@@ -562,7 +562,7 @@ namespace edmNew {
 
     size_type dataSize() const { return onDemand() ? size_type(m_dataSize) : size_type(m_data.size()); }
 
-    size_type size() const { return m_ids.size(); }
+    size_type size() const { return static_cast<size_type>(m_ids.size()); }
 
     //FIXME fast interfaces, not consistent with associative nature of container....
 
@@ -718,7 +718,7 @@ namespace edm {
 
     static size_t size(const edmNew::DetSetVector<T>* iContainer) { return iContainer->dataSize(); }
     static unsigned int indexFor(const value_type* iElement, const edmNew::DetSetVector<T>* iContainer) {
-      return iElement - &(iContainer->data().front());
+      return static_cast<unsigned int>(iElement - &(iContainer->data().front()));
     }
   };
 }  // namespace edm

--- a/DataFormats/Common/interface/HLTGlobalStatus.h
+++ b/DataFormats/Common/interface/HLTGlobalStatus.h
@@ -30,16 +30,18 @@ namespace edm {
     std::vector<HLTPathStatus> paths_;
 
   public:
+    using size_type = decltype(paths_)::size_type;
+
     /// Constructor - for n paths
-    HLTGlobalStatus(const unsigned int n = 0) : paths_(n) {}
+    HLTGlobalStatus(size_type n = 0) : paths_(n) {}
 
     /// Get number of paths stored
-    unsigned int size() const { return paths_.size(); }
+    auto size() const { return paths_.size(); }
 
     /// Reset status for all paths
     void reset() {
-      const unsigned int n(size());
-      for (unsigned int i = 0; i != n; ++i)
+      const auto n(size());
+      for (decltype(size()) i = 0; i != n; ++i)
         paths_[i].reset();
     }
 
@@ -54,24 +56,24 @@ namespace edm {
 
     // accessors to ith element of paths_
 
-    const HLTPathStatus& at(const unsigned int i) const { return paths_.at(i); }
-    HLTPathStatus& at(const unsigned int i) { return paths_.at(i); }
-    const HLTPathStatus& operator[](const unsigned int i) const { return paths_[i]; }
-    HLTPathStatus& operator[](const unsigned int i) { return paths_[i]; }
+    const HLTPathStatus& at(size_type i) const { return paths_.at(i); }
+    HLTPathStatus& at(size_type i) { return paths_.at(i); }
+    const HLTPathStatus& operator[](size_type i) const { return paths_[i]; }
+    HLTPathStatus& operator[](size_type i) { return paths_[i]; }
 
     /// Was ith path run?
-    bool wasrun(const unsigned int i) const { return at(i).wasrun(); }
+    bool wasrun(size_type i) const { return at(i).wasrun(); }
     /// Has ith path accepted the event?
-    bool accept(const unsigned int i) const { return at(i).accept(); }
+    bool accept(size_type i) const { return at(i).accept(); }
     /// Has ith path encountered an error (exception)?
-    bool error(const unsigned int i) const { return at(i).error(); }
+    bool error(size_type i) const { return at(i).error(); }
 
     /// Get status of ith path
-    hlt::HLTState state(const unsigned int i) const { return at(i).state(); }
+    hlt::HLTState state(size_type i) const { return at(i).state(); }
     /// Get index (slot position) of module giving the decision of the ith path
-    unsigned int index(const unsigned int i) const { return at(i).index(); }
+    unsigned int index(size_type i) const { return at(i).index(); }
     /// Reset the ith path
-    void reset(const unsigned int i) { at(i).reset(); }
+    void reset(size_type i) { at(i).reset(); }
     /// swap function
     void swap(HLTGlobalStatus& other) { paths_.swap(other.paths_); }
 
@@ -79,7 +81,7 @@ namespace edm {
     /// Global state variable calculated on the fly
     bool State(unsigned int icase) const {
       bool flags[3] = {false, false, false};
-      const unsigned int n(size());
+      const auto n(size());
       for (unsigned int i = 0; i != n; ++i) {
         const hlt::HLTState s(state(i));
         if (s != hlt::Ready) {
@@ -105,7 +107,7 @@ namespace edm {
     text[1] = "1";
     text[2] = "0";
     text[3] = "e";
-    const unsigned int n(hlt.size());
+    const auto n(hlt.size());
     for (unsigned int i = 0; i != n; ++i)
       ost << text[hlt.state(i)];
     return ost;

--- a/DataFormats/Common/interface/HLTPathStatus.h
+++ b/DataFormats/Common/interface/HLTPathStatus.h
@@ -39,7 +39,8 @@ namespace edm {
 
   public:
     /// constructor
-    HLTPathStatus(const hlt::HLTState state = hlt::Ready, const unsigned int index = 0) : status_(index * 4 + state) {
+    HLTPathStatus(const hlt::HLTState state = hlt::Ready, const unsigned int index = 0)
+        : status_(static_cast<uint16_t>(index * 4 + state)) {
       assert(((int)state) < 4);
       assert(index < 16384);
     }

--- a/DataFormats/Common/interface/MapOfVectors.h
+++ b/DataFormats/Common/interface/MapOfVectors.h
@@ -76,7 +76,7 @@ namespace edm {
       m_keys.reserve(it.size());
       m_offsets.reserve(it.size() + 1);
       m_offsets.push_back(0);
-      size_type tot = 0;
+      size_t tot = 0;
       for (typename TheMap::const_iterator p = it.begin(); p != it.end(); ++p)
         tot += (*p).second.size();
       m_data.reserve(tot);
@@ -88,10 +88,10 @@ namespace edm {
       m_keys.push_back(k);
       m_data.resize(m_offsets.back() + v.size());
       std::copy(v.begin(), v.end(), m_data.begin() + m_offsets.back());
-      m_offsets.push_back(m_data.size());
+      m_offsets.push_back(static_cast<unsigned int>(m_data.size()));
     }
 
-    size_type size() const { return m_keys.size(); }
+    size_type size() const { return static_cast<size_type>(m_keys.size()); }
 
     bool empty() const { return m_keys.empty(); }
 
@@ -111,7 +111,7 @@ namespace edm {
       key_iterator p = findKey(k);
       if (p == m_keys.end())
         return emptyRange();
-      size_type loc = p - m_keys.begin();
+      auto loc = p - m_keys.begin();
       data_iterator b = m_data.begin() + m_offsets[loc];
       data_iterator e = m_data.begin() + m_offsets[loc + 1];
       return range(b, e);

--- a/DataFormats/Common/interface/Ptr.h
+++ b/DataFormats/Common/interface/Ptr.h
@@ -184,9 +184,9 @@ namespace edm {
       EDProductGetter const* getter = productGetter();
       if (getter != nullptr) {
         WrapperBase const* prod = getter->getIt(core_.id());
-        unsigned int iKey = key_;
+        unsigned int iKey = static_cast<unsigned int>(key_);
         if (prod == nullptr) {
-          auto optionalProd = getter->getThinnedProduct(core_.id(), key_);
+          auto optionalProd = getter->getThinnedProduct(core_.id(), iKey);
           if (not optionalProd.has_value()) {
             if (throwIfNotFound) {
               core_.productNotFoundException(typeid(T));

--- a/DataFormats/Common/interface/RangeMap.h
+++ b/DataFormats/Common/interface/RangeMap.h
@@ -115,10 +115,10 @@ namespace edm {
       }
       assert(i == map_.end());
       pairType& p = map_[id];
-      p.first = collection_.size();
+      p.first = static_cast<decltype(p.first)>(collection_.size());
       for (CI ii = begin; ii != end; ++ii)
         collection_.push_back(P::clone(*ii));
-      p.second = collection_.size();
+      p.second = static_cast<decltype(p.second)>(collection_.size());
     }
     /// return number of contained object
     size_t size() const { return collection_.size(); }

--- a/DataFormats/Common/interface/RefToBase.h
+++ b/DataFormats/Common/interface/RefToBase.h
@@ -253,7 +253,7 @@ namespace edm {
 
     EDProductGetter const* getter = productGetter();
     if (getter) {
-      return REF(id(), key(), getter);
+      return REF(id(), static_cast<typename REF::key_type>(key()), getter);
     }
 
     T const* value = get();
@@ -267,7 +267,7 @@ namespace edm {
       newValue = dynamic_cast<typename REF::value_type const*>(value);
     }
     if (newValue) {
-      return REF(id(), newValue, key(), isTransient());
+      return REF(id(), newValue, static_cast<typename REF::key_type>(key()), isTransient());
     }
 
     Exception::throwThis(errors::InvalidReference,
@@ -341,11 +341,11 @@ namespace edm {
 namespace edm {
   template <class T>
   inline RefToBase<T>::RefToBase(RefToBaseProd<T> const& r, size_t i)
-      : holder_(r.operator->()->refAt(i).holder_->clone()) {}
+      : holder_(r.operator->()->refAt(static_cast<typename View<T>::size_type>(i)).holder_->clone()) {}
 
   template <typename T>
   inline RefToBase<T>::RefToBase(Handle<View<T>> const& handle, size_t i)
-      : holder_(handle.operator->()->refAt(i).holder_->clone()) {}
+      : holder_(handle.operator->()->refAt(static_cast<typename View<T>::size_type>(i)).holder_->clone()) {}
 
 }  // namespace edm
 

--- a/DataFormats/Common/interface/RefToBaseVector.h
+++ b/DataFormats/Common/interface/RefToBaseVector.h
@@ -141,8 +141,10 @@ namespace edm {
   template <class T>
   inline typename RefToBaseVector<T>::value_type RefToBaseVector<T>::at(size_type idx) const {
     if (holder_ == nullptr)
-      Exception::throwThis(
-          errors::InvalidReference, "Trying to dereference null RefToBaseVector<T> in method: at(", idx, ")\n");
+      Exception::throwThis(errors::InvalidReference,
+                           "Trying to dereference null RefToBaseVector<T> in method: at(",
+                           static_cast<int>(idx),
+                           ")\n");
     return holder_->at(idx);
   }
 

--- a/DataFormats/Common/interface/Trie.h
+++ b/DataFormats/Common/interface/Trie.h
@@ -184,17 +184,17 @@ namespace edm {
     /// add an entry in the Trie, if entry already exist an exception
     /// is throw
     void insert(std::string const &str, const T &value);
-    void insert(const char *str, unsigned strLen, const T &value);
+    void insert(const char *str, size_t strLen, const T &value);
     /// associates a value to a string, if string is already in Trie,
     /// value is overwriten
     void setEntry(std::string const &str, const T &value);
-    void setEntry(const char *str, unsigned strLen, const T &value);
+    void setEntry(const char *str, size_t strLen, const T &value);
     /// get an entry in the Trie
     const T &find(std::string const &str) const;
-    const T &find(const char *str, unsigned strLen) const;
+    const T &find(const char *str, size_t strLen) const;
     /// get node matching a string
     const TrieNode<T> *node(std::string const &str) const;
-    const TrieNode<T> *node(const char *str, unsigned strLen) const;
+    const TrieNode<T> *node(const char *str, size_t strLen) const;
     ///  get initial TrieNode
     const TrieNode<T> *initialNode() const;
     /// display content of trie in output stream
@@ -203,7 +203,7 @@ namespace edm {
     void clear();
 
   private:
-    TrieNode<T> *_addEntry(const char *str, unsigned strLen);
+    TrieNode<T> *_addEntry(const char *str, size_t strLen);
 
   private:
     /// value returned when no match is found in trie
@@ -505,14 +505,14 @@ void edm::Trie<T>::setEntry(std::string const &str, const T &value) {
   setEntry(str.c_str(), str.size(), value);
 }
 template <typename T>
-void edm::Trie<T>::setEntry(const char *str, unsigned strLen, const T &value) {
+void edm::Trie<T>::setEntry(const char *str, size_t strLen, const T &value) {
   TrieNode<T> *node = _addEntry(str, strLen);
   node->setValue(value);
 }
 
 template <typename T>
-edm::TrieNode<T> *edm::Trie<T>::_addEntry(const char *str, unsigned strLen) {
-  unsigned pos = 0;
+edm::TrieNode<T> *edm::Trie<T>::_addEntry(const char *str, size_t strLen) {
+  size_t pos = 0;
   bool found = true;
   TrieNode<T> *node = _initialNode, *previous = nullptr;
 
@@ -530,7 +530,7 @@ edm::TrieNode<T> *edm::Trie<T>::_addEntry(const char *str, unsigned strLen) {
   // Add part of the word which is not in Trie
   if (!node || pos != strLen) {
     node = previous;
-    for (unsigned i = pos; i < strLen; ++i) {
+    for (auto i = pos; i < strLen; ++i) {
       TrieNode<T> *newNode = _factory->newNode(_empty);
       node->addSubNode(str[pos], newNode);
       node = newNode;
@@ -547,7 +547,7 @@ void edm::Trie<T>::insert(std::string const &str, const T &value) {
 }
 
 template <typename T>
-void edm::Trie<T>::insert(const char *str, unsigned strLen, const T &value) {
+void edm::Trie<T>::insert(const char *str, size_t strLen, const T &value) {
   TrieNode<T> *node = _addEntry(str, strLen);
 
   // Set the value on the last node
@@ -562,8 +562,8 @@ const T &edm::Trie<T>::find(std::string const &str) const {
 }
 
 template <typename T>
-const T &edm::Trie<T>::find(const char *str, unsigned strLen) const {
-  unsigned pos = 0;
+const T &edm::Trie<T>::find(const char *str, size_t strLen) const {
+  size_t pos = 0;
   bool found = true;
   const TrieNode<T> *node = _initialNode;
 
@@ -586,8 +586,8 @@ edm::TrieNode<T> const *edm::Trie<T>::node(std::string const &str) const {
 }
 
 template <typename T>
-edm::TrieNode<T> const *edm::Trie<T>::node(const char *str, unsigned strLen) const {
-  unsigned pos = 0;
+edm::TrieNode<T> const *edm::Trie<T>::node(const char *str, size_t strLen) const {
+  size_t pos = 0;
   bool found = true;
   const TrieNode<T> *node = _initialNode;
 

--- a/DataFormats/Common/interface/TriggerResults.h
+++ b/DataFormats/Common/interface/TriggerResults.h
@@ -71,12 +71,12 @@ namespace edm {
     const std::vector<std::string>& getTriggerNames() const { return names_; }
 
     /// Obsolete
-    const std::string& name(unsigned int i) const { return names_.at(i); }
+    const std::string& name(size_t i) const { return names_.at(i); }
 
     /// Obsolete
-    unsigned int find(const std::string& name) const {
-      const unsigned int n(size());
-      for (unsigned int i = 0; i != n; ++i)
+    auto find(const std::string& name) const {
+      const auto n(size());
+      for (decltype(size()) i = 0; i != n; ++i)
         if (names_[i] == name)
           return i;
       return n;

--- a/DataFormats/Common/interface/View.h
+++ b/DataFormats/Common/interface/View.h
@@ -166,7 +166,7 @@ namespace edm {
                 FillViewHelperVector const& helpers,
                 EDProductGetter const* getter)
       : items_(), vPtrs_() {
-    size_type numElements = pointers.size();
+    size_type numElements = static_cast<size_type>(pointers.size());
 
     // If the two input vectors are not of the same size, there is a
     // logic error in the framework code that called this.
@@ -223,7 +223,7 @@ namespace edm {
 
   template <typename T>
   inline typename View<T>::size_type View<T>::size() const {
-    return items_.size();
+    return static_cast<typename View<T>::size_type>(items_.size());
   }
 
   template <typename T>

--- a/DataFormats/Common/interface/getThinned_implementation.h
+++ b/DataFormats/Common/interface/getThinned_implementation.h
@@ -143,10 +143,10 @@ namespace edm {
     inline auto makeThinnedIndexes(std::vector<unsigned int> const& keys,
                                    std::vector<WrapperBase const*> const& foundContainers,
                                    ThinnedAssociation const* thinnedAssociation) {
-      unsigned const nKeys = keys.size();
+      auto const nKeys = keys.size();
       std::vector<unsigned int> thinnedIndexes(nKeys, kThinningDoNotLookForThisIndex);
       bool hasAny = false;
-      for (unsigned k = 0; k < nKeys; ++k) {
+      for (size_t k = 0; k < nKeys; ++k) {
         // Already found this one
         if (foundContainers[k] != nullptr) {
           continue;
@@ -241,7 +241,7 @@ namespace edm {
         // Set the pointers and indexes into the thinned container (if we can find it)
         ProductID thinnedCollectionPID = thinnedAssociation->thinnedCollectionID();
         WrapperBase const* thinnedCollection = getByProductID(thinnedCollectionPID);
-        unsigned const nKeys = keys.size();
+        auto const nKeys = keys.size();
         if (thinnedCollection == nullptr) {
           // Thinned container is not found, try looking recursively in thinned containers
           // which were made by selecting elements from this thinned container.
@@ -255,7 +255,7 @@ namespace edm {
           if (slimmedAllowed and slimmed.has_value()) {
             return slimmed;
           }
-          for (unsigned k = 0; k < nKeys; ++k) {
+          for (decltype(keys.size()) k = 0; k < nKeys; ++k) {
             if (foundContainers[k] == nullptr)
               continue;
             if (thinnedIndexes[k] == kThinningDoNotLookForThisIndex)
@@ -263,7 +263,7 @@ namespace edm {
             keys[k] = thinnedIndexes[k];
           }
         } else {
-          for (unsigned k = 0; k < nKeys; ++k) {
+          for (decltype(keys.size()) k = 0; k < nKeys; ++k) {
             if (thinnedIndexes[k] == kThinningDoNotLookForThisIndex)
               continue;
             keys[k] = thinnedIndexes[k];
@@ -346,7 +346,7 @@ namespace edm {
         auto [slimmedAssociation, slimmedIndexes] = std::move(*slimmed);
         ProductID const& slimmedCollectionPID = slimmedAssociation->thinnedCollectionID();
         WrapperBase const* slimmedCollection = getByProductID(slimmedCollectionPID);
-        unsigned const nKeys = keys.size();
+        auto nKeys = keys.size();
         if (slimmedCollection == nullptr) {
           getThinnedProducts(slimmedCollectionPID,
                              thinnedAssociationsHelper,
@@ -355,7 +355,7 @@ namespace edm {
                              getByProductID,
                              foundContainers,
                              slimmedIndexes);
-          for (unsigned k = 0; k < nKeys; ++k) {
+          for (decltype(nKeys) k = 0; k < nKeys; ++k) {
             if (foundContainers[k] == nullptr)
               continue;
             if (slimmedIndexes[k] == kThinningDoNotLookForThisIndex)
@@ -363,7 +363,7 @@ namespace edm {
             keys[k] = slimmedIndexes[k];
           }
         } else {
-          for (unsigned k = 0; k < nKeys; ++k) {
+          for (decltype(nKeys) k = 0; k < nKeys; ++k) {
             if (slimmedIndexes[k] == kThinningDoNotLookForThisIndex)
               continue;
             keys[k] = slimmedIndexes[k];

--- a/DataFormats/Common/src/MultiAssociation.cc
+++ b/DataFormats/Common/src/MultiAssociation.cc
@@ -39,10 +39,12 @@ void IndexRangeAssociation::swap(IndexRangeAssociation &other) {
   ref_offsets_.swap(other.ref_offsets_);
 }
 
-IndexRangeAssociation::FastFiller::FastFiller(IndexRangeAssociation &assoc, ProductID id, unsigned int size)
+IndexRangeAssociation::FastFiller::FastFiller(IndexRangeAssociation &assoc, ProductID id, size_type size)
     : assoc_(assoc),
       id_(id),
-      start_(assoc.ref_offsets_.empty() ? 0 : assoc.ref_offsets_.size() - 1),  // must skip the end marker element
+      start_(assoc.ref_offsets_.empty()
+                 ? 0
+                 : static_cast<decltype(start_)>(assoc.ref_offsets_.size() - 1)),  // must skip the end marker element
       end_(start_ + size),
       lastKey_(-1) {
   if (assoc_.isFilling_)
@@ -95,8 +97,8 @@ IndexRangeAssociation::FastFiller::~FastFiller() {
 
 void IndexRangeAssociation::FastFiller::insert(edm::ProductID id,
                                                unsigned int key,
-                                               unsigned int startingOffset,
-                                               unsigned int size) {
+                                               size_type startingOffset,
+                                               size_type size) {
   if (id != id_)
     IndexRangeAssociation::throwUnexpectedProductID(id, id_, "FastFiller::insert");
   if (int(key) <= lastKey_)

--- a/DataFormats/Common/src/PtrVectorBase.cc
+++ b/DataFormats/Common/src/PtrVectorBase.cc
@@ -136,7 +136,7 @@ namespace edm {
     thinnedKeys.assign(indicies_.begin(), indicies_.end());
     std::vector<WrapperBase const*> wrappers(indicies_.size(), nullptr);
     tmpProductGetter->getThinnedProducts(id(), wrappers, thinnedKeys);
-    unsigned int nWrappers = wrappers.size();
+    auto nWrappers = wrappers.size();
     assert(wrappers.size() == indicies_.size());
     assert(wrappers.size() == tmpCachedItems->size());
     for (unsigned k = 0; k < nWrappers; ++k) {

--- a/DataFormats/Common/test/DetSetNew_t.cpp
+++ b/DataFormats/Common/test/DetSetNew_t.cpp
@@ -184,7 +184,7 @@ void TestDetSet::filling() {
     CPPUNIT_ASSERT(ff.m_item.size == 0);
     CPPUNIT_ASSERT(ff.m_item.id == id);
     ntot += 1;
-    ff.push_back(3.14);
+    ff.push_back(3.14f);
     CPPUNIT_ASSERT(detsets.dataSize() == ntot);
     CPPUNIT_ASSERT(detsets.detsetSize(n - 1) == 1);
     CPPUNIT_ASSERT(detsets.m_data.back().v == 3.14f);
@@ -294,7 +294,7 @@ void TestDetSet::fillingTS() {
       CPPUNIT_ASSERT(ff.m_item.size == 0);
       CPPUNIT_ASSERT(ff.id() == id);
       ntot += 1;
-      ff.push_back(3.14);
+      ff.push_back(3.14f);
       CPPUNIT_ASSERT(detsets.dataSize() == ntot - 1);
       CPPUNIT_ASSERT(ff.m_item.size == 0);
       CPPUNIT_ASSERT(ff.size() == 1);
@@ -389,7 +389,7 @@ namespace {
         ff.resize(n);
         int nCopied = n;
         if (static_cast<size_t>(n) > test.sv.size()) {
-          nCopied = test.sv.size();
+          nCopied = static_cast<int>(test.sv.size());
         }
         std::copy(test.sv.begin(), test.sv.begin() + nCopied, ff.begin());
         if (ff.full()) {

--- a/DataFormats/Common/test/MapOfVectors_t.cpp
+++ b/DataFormats/Common/test/MapOfVectors_t.cpp
@@ -83,7 +83,7 @@ void TestMapOfVectors::find() {
 void TestMapOfVectors::iterator() {
   MII m(om);
   TheMap::const_iterator op = om.begin();
-  unsigned int lt = 0;
+  size_t lt = 0;
   for (MII::const_iterator p = m.begin(); p != m.end(); ++p) {
     CPPUNIT_ASSERT((*p).first == (*op).first);
     CPPUNIT_ASSERT(std::equal((*p).second.begin(), (*p).second.end(), (*op).second.begin()));

--- a/DataFormats/Common/test/TestWriteTriggerResults.cc
+++ b/DataFormats/Common/test/TestWriteTriggerResults.cc
@@ -56,7 +56,7 @@ namespace edmtest {
         triggerResultsPutToken_(produces()) {}
 
   void TestWriteTriggerResults::produce(edm::StreamID, edm::Event& iEvent, edm::EventSetup const&) const {
-    edm::HLTGlobalStatus hltGlobalStatus(hltStates_.size());
+    edm::HLTGlobalStatus hltGlobalStatus(static_cast<unsigned int>(hltStates_.size()));
     for (unsigned int i = 0; i < hltStates_.size(); ++i) {
       assert(i < moduleIndexes_.size());
       hltGlobalStatus[i] = edm::HLTPathStatus(static_cast<edm::hlt::HLTState>(hltStates_[i]), moduleIndexes_[i]);

--- a/DataFormats/Common/test/exDSTV.cpp
+++ b/DataFormats/Common/test/exDSTV.cpp
@@ -20,7 +20,7 @@ TEST_CASE("test edmNew::DetSetVector", "[edmNew::DetSetVector]") {
   {
     FF ff(dstv, 1);
     ff.push_back(T());
-    ff[0].v = 2.1;
+    ff[0].v = 2.1f;
   }
   {
     FF ff(dstv, 2);
@@ -32,9 +32,9 @@ TEST_CASE("test edmNew::DetSetVector", "[edmNew::DetSetVector]") {
   REQUIRE(dstv.detsetSize(0) == 1);
 
   DST d1 = *dstv.find(2);
-  d1[0].v = 3.14;
+  d1[0].v = 3.14f;
   DST d2 = dstv.insert(4, 3);
-  d2[0].v = 4.15;
+  d2[0].v = 4.15f;
 
   SECTION("iterator") {
     int i = 0;

--- a/DataFormats/Common/test/testMultiAssociation.cc
+++ b/DataFormats/Common/test/testMultiAssociation.cc
@@ -122,10 +122,10 @@ public:
       RefVector<CVal> vals;
       for (std::vector<double>::const_iterator it2 = k.begin(), ed2 = k.end(); it2 != ed2; ++it2) {
         if (f(*it, *it2)) {
-          vals.push_back(Ref<CVal>(handleV, it2 - k.begin()));
+          vals.push_back(Ref<CVal>(handleV, static_cast<Ref<CVal>::key_type>(it2 - k.begin())));
         }
       }
-      filler.setValues(Ref<Key>(handle, it - handle->begin()), vals);
+      filler.setValues(Ref<Key>(handle, static_cast<Ref<Key>::key_type>(it - handle->begin())), vals);
     }
   }
 
@@ -139,13 +139,13 @@ public:
       RefVector<CVal> vals;
       for (std::vector<double>::const_iterator it2 = k.begin(), ed2 = k.end(); it2 != ed2; ++it2) {
         if (f(*it, *it2)) {
-          vals.push_back(Ref<CVal>(handleV, it2 - k.begin()));
+          vals.push_back(Ref<CVal>(handleV, static_cast<Ref<CVal>::key_type>(it2 - k.begin())));
         }
       }
       if (swap) {
-        filler.swapValues(Ref<Key>(handle, it - handle->begin()), vals);
+        filler.swapValues(Ref<Key>(handle, static_cast<Ref<Key>::key_type>(it - handle->begin())), vals);
       } else {
-        filler.setValues(Ref<Key>(handle, it - handle->begin()), vals);
+        filler.setValues(Ref<Key>(handle, static_cast<Ref<Key>::key_type>(it - handle->begin())), vals);
       }
     }
   }
@@ -162,7 +162,7 @@ public:
           vals.push_back(*it2);
         }
       }
-      filler.setValues(Ref<Key>(handle, it - handle->begin()), vals);
+      filler.setValues(Ref<Key>(handle, static_cast<Ref<Key>::key_type>(it - handle->begin())), vals);
     }
   }
 
@@ -180,9 +180,9 @@ public:
         }
       }
       if (swap) {
-        filler.swapValues(Ref<Key>(handle, it - handle->begin()), vals);
+        filler.swapValues(Ref<Key>(handle, static_cast<Ref<Key>::key_type>(it - handle->begin())), vals);
       } else {
-        filler.setValues(Ref<Key>(handle, it - handle->begin()), vals);
+        filler.setValues(Ref<Key>(handle, static_cast<Ref<Key>::key_type>(it - handle->begin())), vals);
       }
     }
   }
@@ -581,6 +581,7 @@ void testMultiAssociation::checkUnsortedKeys() {
 bool testMultiAssociation::tryBadFill(int i) {
   MultiRef m;
   MultiRef::Collection coll1;
+  using key1_type = Ref<CKey1>::key_type;
   coll1.push_back(Ref<CVal>(handleV, 1));
   switch (i) {
     case 0: {  // fill with right prod. id
@@ -630,7 +631,7 @@ bool testMultiAssociation::tryBadFill(int i) {
     } break;
     case 9: {  // Check index out of bounds
       MultiRef::FastFiller filler = m.fastFiller(handleK1);
-      filler.setValues(Ref<CKey1>(handleK1, handleK1->size() + 5, false), coll1);
+      filler.setValues(Ref<CKey1>(handleK1, static_cast<key1_type>(handleK1->size() + 5), false), coll1);
     } break;
     case 10: {  // Can copy a LazyFiller, if I don't fill twice
       MultiRef::LazyFiller filler = m.lazyFiller(handleK1, false);
@@ -721,6 +722,7 @@ void testMultiAssociation::checkBadRead() {
 
 void testMultiAssociation::checkWithPtr() {
   MultiPtr map;
+  using key_type = Ref<CKey1>::key_type;
   {  // Fill the map
     MultiPtr::FastFiller filler = map.fastFiller(handleK1);
     edm::TestHandle<CObj> handleObj(&der1s, ProductID(10));
@@ -730,12 +732,12 @@ void testMultiAssociation::checkWithPtr() {
         vals.push_back(PObj(handleObj, (3 * i + 4 * j) % 10));
       }
       if (!vals.empty())
-        filler.setValues(Ref<CKey1>(handleK1, i), vals);
+        filler.setValues(Ref<CKey1>(handleK1, static_cast<key_type>(i)), vals);
     }
   }
   {  // Read the map
     for (size_t i = 0; i < handleK1->size(); ++i) {
-      MultiPtr::const_range r = map[Ref<CKey1>(handleK1, i)];
+      MultiPtr::const_range r = map[Ref<CKey1>(handleK1, static_cast<key_type>(i))];
       CPPUNIT_ASSERT(static_cast<size_t>(r.size()) == ((i + 2) % 3));
       for (size_t j = 0; j < ((i + 2) % 3); ++j) {
         CPPUNIT_ASSERT(r[j].key() == (3 * i + 4 * j) % 10);
@@ -748,6 +750,7 @@ void testMultiAssociation::checkWithPtr() {
 }
 void testMultiAssociation::checkWithOwn() {
   MultiOwn map;
+  using key_type = Ref<CKey1>::key_type;
   {  // Fill the map
     MultiOwn::FastFiller filler = map.fastFiller(handleK1);
     for (size_t i = 0; i < handleK1->size(); ++i) {
@@ -756,12 +759,12 @@ void testMultiAssociation::checkWithOwn() {
         vals.push_back(bases[(i + j) % 3].clone());
       }
       if (!vals.empty())
-        filler.setValues(Ref<CKey1>(handleK1, i), vals);
+        filler.setValues(Ref<CKey1>(handleK1, static_cast<key_type>(i)), vals);
     }
   }
   {  // Read the map
     for (size_t i = 0; i < handleK1->size(); ++i) {
-      MultiOwn::const_range r = map[Ref<CKey1>(handleK1, i)];
+      MultiOwn::const_range r = map[Ref<CKey1>(handleK1, static_cast<key_type>(i))];
       CPPUNIT_ASSERT(static_cast<size_t>(r.size()) == ((i + 2) % 3));
       for (size_t j = 0; j < ((i + 2) % 3); ++j) {
         CPPUNIT_ASSERT((r.begin() + j)->id() == bases[(i + j) % 3].id());

--- a/DataFormats/Common/test/testOneToManyAssociation.cc
+++ b/DataFormats/Common/test/testOneToManyAssociation.cc
@@ -42,7 +42,7 @@ void testOneToManyAssociation::dummy() {
     Assoc::const_iterator f = v.find(edm::Ref<CKey>());
     v.numberOfAssociations(edm::Ref<CKey>());
     const edm::RefVector<CVal>& x = v[edm::Ref<CKey>()];
-    int n = x.size();
+    auto n = x.size();
     ++f;
     n = v.numberOfAssociations(edm::Ref<CKey>());
     ++n;
@@ -64,7 +64,7 @@ void testOneToManyAssociation::dummy() {
     Assoc::const_iterator f = v.find(edm::Ref<CKey>());
     v.numberOfAssociations(edm::Ref<CKey>());
     const std::vector<std::pair<edm::Ref<CVal>, double> >& x = v[edm::Ref<CKey>()];
-    int n = x.size();
+    auto n = x.size();
     ++f;
     n = v.numberOfAssociations(edm::Ref<CKey>());
     ++n;

--- a/DataFormats/Common/test/testOneToOneAssociation.cc
+++ b/DataFormats/Common/test/testOneToOneAssociation.cc
@@ -43,7 +43,7 @@ void testOneToOneAssociation::dummy() {
   const edm::Ref<CVal>& x = v[edm::Ref<CKey>()];
   x.id();
   ++f;
-  int n = v.numberOfAssociations(edm::Ref<CKey>());
+  auto n = v.numberOfAssociations(edm::Ref<CKey>());
   ++n;
   std::cout << "numberOfAssociations:" << n << std::endl;
   edm::Ref<Assoc> r;

--- a/DataFormats/Provenance/interface/IndexIntoFile.h
+++ b/DataFormats/Provenance/interface/IndexIntoFile.h
@@ -860,17 +860,17 @@ namespace edm {
       void handleToEndOfContiguousEventsInLumis(EntryOrderInitializationInfo& info,
                                                 EntryNumber_t currentRun,
                                                 int endOfRunEntries);
-      EntryNumber_t lowestInLumi(EntryOrderInitializationInfo& info, int currentLumi) const;
+      EntryNumber_t lowestInLumi(EntryOrderInitializationInfo& info, EntryNumber_t currentLumi) const;
       void handleLumisWithNoEvents(std::vector<TTreeEntryAndIndex>::const_iterator& nextLumiWithNoEvents,
                                    std::vector<TTreeEntryAndIndex>::const_iterator& endLumisWithNoEvents,
                                    EntryNumber_t lumiTTreeEntryNumber,
                                    bool completeAll = false);
       void handleLumiWithEvents(EntryOrderInitializationInfo& info,
-                                int currentLumi,
+                                EntryNumber_t currentLumi,
                                 EntryNumber_t firstBeginEventsContiguousLumi);
       void handleLumiEntriesNoRemainingEvents(EntryOrderInitializationInfo& info,
                                               int& iLumiIndex,
-                                              int currentLumi,
+                                              EntryNumber_t currentLumi,
                                               EntryNumber_t firstBeginEventsContiguousLumi,
                                               bool completeAll = false);
 

--- a/DataFormats/Provenance/src/BranchIDListHelper.cc
+++ b/DataFormats/Provenance/src/BranchIDListHelper.cc
@@ -23,13 +23,13 @@ namespace edm {
     inputIndexToJobIndex_.clear();
     inputIndexToJobIndex_.resize(bidlists.size());
     for (auto it = bidlists.begin(), itEnd = bidlists.end(); it != itEnd; ++it) {
-      BranchListIndex oldBlix = it - bidlists.begin();
+      auto oldBlix = static_cast<BranchListIndex>(it - bidlists.begin());
       auto j = find_in_all(branchIDLists_, *it);
-      BranchListIndex blix = j - branchIDLists_.begin();
+      auto blix = static_cast<BranchListIndex>(j - branchIDLists_.begin());
       if (j == branchIDLists_.end()) {
         branchIDLists_.push_back(*it);
         for (BranchIDList::const_iterator i = it->begin(), iEnd = it->end(); i != iEnd; ++i) {
-          ProductIndex pix = i - it->begin();
+          auto pix = static_cast<ProductIndex>(i - it->begin());
           branchIDToIndexMap_.insert(std::make_pair(BranchID(*i), std::make_pair(blix, pix)));
         }
       }
@@ -44,11 +44,11 @@ namespace edm {
   void BranchIDListHelper::updateFromParent(BranchIDLists const& bidlists) {
     inputIndexToJobIndex_.resize(bidlists.size());
     for (auto it = bidlists.begin() + nAlreadyCopied_, itEnd = bidlists.end(); it != itEnd; ++it) {
-      BranchListIndex oldBlix = it - bidlists.begin();
-      BranchListIndex blix = branchIDLists_.size();
+      auto oldBlix = static_cast<BranchListIndex>(it - bidlists.begin());
+      BranchListIndex blix = static_cast<BranchListIndex>(branchIDLists_.size());
       branchIDLists_.push_back(*it);
       for (BranchIDList::const_iterator i = it->begin(), iEnd = it->end(); i != iEnd; ++i) {
-        ProductIndex pix = i - it->begin();
+        auto pix = static_cast<ProductIndex>(i - it->begin());
         branchIDToIndexMap_.insert(std::make_pair(BranchID(*i), std::make_pair(blix, pix)));
       }
       inputIndexToJobIndex_[oldBlix] = blix;
@@ -70,12 +70,12 @@ namespace edm {
       }
     }
     if (!bidlist.empty()) {
-      BranchListIndex blix = branchIDLists_.size();
+      auto blix = static_cast<BranchListIndex>(branchIDLists_.size());
       producedBranchListIndex_ = blix;
       //preg.setProducedBranchListIndex(blix);
       branchIDLists_.push_back(bidlist);
       for (BranchIDList::const_iterator i = bidlist.begin(), iEnd = bidlist.end(); i != iEnd; ++i) {
-        ProductIndex pix = i - bidlist.begin();
+        auto pix = static_cast<ProductIndex>(i - bidlist.begin());
         branchIDToIndexMap_.insert(std::make_pair(BranchID(*i), std::make_pair(blix, pix)));
       }
     }

--- a/DataFormats/Provenance/src/IndexIntoFile.cc
+++ b/DataFormats/Provenance/src/IndexIntoFile.cc
@@ -171,7 +171,7 @@ namespace edm {
              beginOfLumi->run() == endOfLumi->run() && beginOfLumi->lumi() == endOfLumi->lumi()) {
         ++endOfLumi;
       }
-      int nEvents = 0;
+      long long int nEvents = 0;
       for (std::vector<RunOrLumiIndexes>::iterator iter = beginOfLumi; iter != endOfLumi; ++iter) {
         if (runOrLumiEntries_[iter->indexToGetEntry()].beginEvents() != invalidEntry) {
           nEvents += runOrLumiEntries_[iter->indexToGetEntry()].endEvents() -
@@ -312,7 +312,7 @@ namespace edm {
       insertResult = reducedPHIDToIndex.insert(mapEntry);
 
       if (insertResult.second) {
-        insertResult.first->second = reducedPHIDs.size();
+        insertResult.first->second = static_cast<int>(reducedPHIDs.size());
         reducedPHIDs.push_back(reducedPHID);
       }
       phidIndexConverter.push_back(insertResult.first->second);
@@ -326,11 +326,8 @@ namespace edm {
       return;
     }
 
-    std::map<IndexIntoFile::IndexRunKey, int> runOrderMap;
-    std::pair<std::map<IndexIntoFile::IndexRunKey, int>::iterator, bool> runInsertResult;
-
-    std::map<IndexIntoFile::IndexRunLumiKey, int> lumiOrderMap;
-    std::pair<std::map<IndexIntoFile::IndexRunLumiKey, int>::iterator, bool> lumiInsertResult;
+    std::map<IndexIntoFile::IndexRunKey, EntryNumber_t> runOrderMap;
+    std::map<IndexIntoFile::IndexRunLumiKey, EntryNumber_t> lumiOrderMap;
 
     // loop over all the RunOrLumiEntry's
     for (auto& item : runOrLumiEntries_) {
@@ -339,7 +336,7 @@ namespace edm {
 
       // Convert the phid-run order
       IndexIntoFile::IndexRunKey runKey(item.processHistoryIDIndex(), item.run());
-      runInsertResult = runOrderMap.insert(std::pair<IndexIntoFile::IndexRunKey, int>(runKey, 0));
+      auto runInsertResult = runOrderMap.emplace(runKey, 0);
       if (runInsertResult.second) {
         runInsertResult.first->second = item.orderPHIDRun();
       } else {
@@ -349,7 +346,7 @@ namespace edm {
       // Convert the phid-run-lumi order for the lumi entries
       if (item.lumi() != 0) {
         IndexIntoFile::IndexRunLumiKey lumiKey(item.processHistoryIDIndex(), item.run(), item.lumi());
-        lumiInsertResult = lumiOrderMap.insert(std::pair<IndexIntoFile::IndexRunLumiKey, int>(lumiKey, 0));
+        auto lumiInsertResult = lumiOrderMap.emplace(lumiKey, 0);
         if (lumiInsertResult.second) {
           lumiInsertResult.first->second = item.orderPHIDRunLumi();
         } else {
@@ -369,10 +366,11 @@ namespace edm {
       std::vector<ProcessHistoryID>::const_iterator iterExisting =
           std::find(processHistoryIDs.begin(), processHistoryIDs.end(), *iter);
       if (iterExisting == processHistoryIDs.end()) {
-        oldToNewIndex[iter - processHistoryIDs_.begin()] = processHistoryIDs.size();
+        oldToNewIndex[static_cast<int>(iter - processHistoryIDs_.begin())] = static_cast<int>(processHistoryIDs.size());
         processHistoryIDs.push_back(*iter);
       } else {
-        oldToNewIndex[iter - processHistoryIDs_.begin()] = iterExisting - processHistoryIDs.begin();
+        oldToNewIndex[static_cast<int>(iter - processHistoryIDs_.begin())] =
+            static_cast<int>(iterExisting - processHistoryIDs.begin());
       }
     }
     processHistoryIDs_ = processHistoryIDs;
@@ -553,8 +551,14 @@ namespace edm {
         continue;
 
       if (lumi == invalidLumi && event == invalidEvent) {
-        IndexIntoFileItr indexItr(
-            this, numericalOrder, kRun, iRun - runOrLumiIndexes().begin(), invalidIndex, invalidIndex, 0, 0);
+        IndexIntoFileItr indexItr(this,
+                                  numericalOrder,
+                                  kRun,
+                                  static_cast<int>(iRun - runOrLumiIndexes().begin()),
+                                  invalidIndex,
+                                  invalidIndex,
+                                  0,
+                                  0);
         indexItr.initializeRun();
         return indexItr;
       }
@@ -569,8 +573,8 @@ namespace edm {
           IndexIntoFileItr indexItr(this,
                                     numericalOrder,
                                     kRun,
-                                    iRun - runOrLumiIndexes().begin(),
-                                    iLumi - runOrLumiIndexes().begin(),
+                                    static_cast<int>(iRun - runOrLumiIndexes().begin()),
+                                    static_cast<int>(iLumi - runOrLumiIndexes().begin()),
                                     invalidIndex,
                                     0,
                                     0);
@@ -603,7 +607,7 @@ namespace edm {
           indexToEvent = eventIter - eventNumbers().begin() - beginEventNumbers;
         }
 
-        int newIndexToLumi = iLumi - runOrLumiIndexes().begin();
+        auto newIndexToLumi = iLumi - runOrLumiIndexes().begin();
         while (runOrLumiEntries_[runOrLumiIndexes()[newIndexToLumi].indexToGetEntry()].entry() == invalidEntry) {
           ++newIndexToLumi;
           assert(static_cast<unsigned>(newIndexToLumi) < runOrLumiEntries_.size());
@@ -613,9 +617,9 @@ namespace edm {
         return IndexIntoFileItr(this,
                                 numericalOrder,
                                 kRun,
-                                iRun - runOrLumiIndexes().begin(),
-                                newIndexToLumi,
-                                iLumi - runOrLumiIndexes().begin(),
+                                static_cast<int>(iRun - runOrLumiIndexes().begin()),
+                                static_cast<int>(newIndexToLumi),
+                                static_cast<int>(iLumi - runOrLumiIndexes().begin()),
                                 indexToEvent,
                                 endEventNumbers - beginEventNumbers);
       }
@@ -655,7 +659,7 @@ namespace edm {
             indexToEvent = eventIter - eventNumbers().begin() - beginEventNumbers;
           }
 
-          int newIndexToLumi = iLumi - runOrLumiIndexes().begin();
+          auto newIndexToLumi = iLumi - runOrLumiIndexes().begin();
           while (runOrLumiEntries_[runOrLumiIndexes()[newIndexToLumi].indexToGetEntry()].entry() == invalidEntry) {
             ++newIndexToLumi;
             assert(static_cast<unsigned>(newIndexToLumi) < runOrLumiEntries_.size());
@@ -665,9 +669,9 @@ namespace edm {
           return IndexIntoFileItr(this,
                                   numericalOrder,
                                   kRun,
-                                  iRun - runOrLumiIndexes().begin(),
-                                  newIndexToLumi,
-                                  iLumi - runOrLumiIndexes().begin(),
+                                  static_cast<int>(iRun - runOrLumiIndexes().begin()),
+                                  static_cast<int>(newIndexToLumi),
+                                  static_cast<int>(iLumi - runOrLumiIndexes().begin()),
                                   indexToEvent,
                                   endEventNumbers - beginEventNumbers);
         }
@@ -755,7 +759,7 @@ namespace edm {
   IndexIntoFile::SortedRunOrLumiItr IndexIntoFile::beginRunOrLumi() const { return SortedRunOrLumiItr(this, 0); }
 
   IndexIntoFile::SortedRunOrLumiItr IndexIntoFile::endRunOrLumi() const {
-    return SortedRunOrLumiItr(this, runOrLumiEntries().size());
+    return SortedRunOrLumiItr(this, static_cast<unsigned int>(runOrLumiEntries().size()));
   }
 
   void IndexIntoFile::set_intersection(IndexIntoFile const& indexIntoFile,
@@ -1826,7 +1830,7 @@ namespace edm {
     // This takes care of only Runs with no Events at the end of
     // the Runs TTree that were not already added.
     addRunsWithNoEvents(info);
-    indexedSize_ = fileOrderRunOrLumiEntry_.size();
+    indexedSize_ = static_cast<int>(fileOrderRunOrLumiEntry_.size());
   }
 
   IndexIntoFile::IndexIntoFileItrImpl* IndexIntoFile::IndexIntoFileItrEntryOrder::clone() const {
@@ -2361,7 +2365,7 @@ namespace edm {
   }
 
   IndexIntoFile::EntryNumber_t IndexIntoFile::IndexIntoFileItrEntryOrder::lowestInLumi(
-      EntryOrderInitializationInfo& info, int currentLumi) const {
+      EntryOrderInitializationInfo& info, EntryNumber_t currentLumi) const {
     auto const& runOrLumiEntries = indexIntoFile()->runOrLumiEntries();
     int iEnd = static_cast<int>(runOrLumiEntries.size());
 
@@ -2399,7 +2403,7 @@ namespace edm {
   }
 
   void IndexIntoFile::IndexIntoFileItrEntryOrder::handleLumiWithEvents(EntryOrderInitializationInfo& info,
-                                                                       int currentLumi,
+                                                                       EntryNumber_t currentLumi,
                                                                        EntryNumber_t firstBeginEventsContiguousLumi) {
     auto const& runOrLumiEntries = indexIntoFile()->runOrLumiEntries();
     int iLumiIndex = info.firstIndexOfLumi_[currentLumi];
@@ -2421,7 +2425,7 @@ namespace edm {
   void IndexIntoFile::IndexIntoFileItrEntryOrder::handleLumiEntriesNoRemainingEvents(
       EntryOrderInitializationInfo& info,
       int& iLumiIndex,
-      int currentLumi,
+      EntryNumber_t currentLumi,
       EntryNumber_t firstBeginEventsContiguousLumi,
       bool completeAll) {
     auto const& runOrLumiEntries = indexIntoFile()->runOrLumiEntries();

--- a/DataFormats/Provenance/src/ProductResolverIndexHelper.cc
+++ b/DataFormats/Provenance/src/ProductResolverIndexHelper.cc
@@ -317,7 +317,7 @@ namespace edm {
     std::string previousModuleLabel;
     std::string previousInstance;
     unsigned int iCountTypes = 0;
-    unsigned int iCountCharacters = 0;
+    size_t iCountCharacters = 0;
     for (auto const& item : *items_) {
       if (iFirstThisType || item.typeID() != previousTypeID || item.kindOfType() != previousKindOfType) {
         ++iCountTypes;
@@ -348,7 +348,7 @@ namespace edm {
     }
 
     // Size and fill the process name vector
-    unsigned int processNamesSize = 0;
+    size_t processNamesSize = 0;
     for (auto const& processItem : *processItems_) {
       processNamesSize += processItem.size();
       ++processNamesSize;
@@ -375,7 +375,7 @@ namespace edm {
     unsigned int iCount = 0;
     unsigned int iBeginning = 0;
     iCountCharacters = 0;
-    unsigned int previousCharacterCount = 0;
+    size_t previousCharacterCount = 0;
     if (!items_->empty()) {
       for (auto const& item : *items_) {
         if (iFirstThisType || item.typeID() != previousTypeID || item.kindOfType() != previousKindOfType) {
@@ -391,22 +391,20 @@ namespace edm {
         ++iCount;
 
         if (iFirstThisType || item.moduleLabel() != previousModuleLabel || item.instance() != previousInstance) {
-          unsigned int labelSize = item.moduleLabel().size();
-          for (unsigned int j = 0; j < labelSize; ++j) {
-            bigNamesContainer_.push_back(item.moduleLabel()[j]);
+          for (auto const& label : item.moduleLabel()) {
+            bigNamesContainer_.push_back(label);
           }
           bigNamesContainer_.push_back('\0');
 
-          unsigned int instanceSize = item.instance().size();
-          for (unsigned int j = 0; j < instanceSize; ++j) {
-            bigNamesContainer_.push_back(item.instance()[j]);
+          for (auto const& instance : item.instance()) {
+            bigNamesContainer_.push_back(instance);
           }
           bigNamesContainer_.push_back('\0');
 
           previousCharacterCount = iCountCharacters;
 
-          iCountCharacters += labelSize;
-          iCountCharacters += instanceSize;
+          iCountCharacters += item.moduleLabel().size();
+          iCountCharacters += item.instance().size();
           iCountCharacters += 2;
         }
 
@@ -536,7 +534,7 @@ namespace edm {
     unsigned int endType = beginElements_;
     if (kindOfType == ELEMENT_TYPE) {
       beginType = beginElements_;
-      endType = sortedTypeIDs_.size();
+      endType = static_cast<unsigned int>(sortedTypeIDs_.size());
     }
 
     while (beginType < endType) {
@@ -565,7 +563,7 @@ namespace edm {
         ++p;
       }
       if (*ptr == *p) {
-        return beginName - begin;
+        return static_cast<unsigned int>(beginName - begin);
       }
       while (*ptr) {
         ++ptr;

--- a/FWCore/Common/interface/TriggerNames.h
+++ b/FWCore/Common/interface/TriggerNames.h
@@ -74,11 +74,11 @@ namespace edm {
     Strings const& triggerNames() const;
 
     // Throws if the index is out of range.
-    std::string const& triggerName(unsigned int index) const;
+    std::string const& triggerName(std::size_t index) const;
 
     // If the input name is not known, this returns a value
     // equal to the size.
-    unsigned int triggerIndex(std::string_view name) const;
+    std::size_t triggerIndex(std::string_view name) const;
 
     // The number of trigger names.
     std::size_t size() const;

--- a/FWCore/Common/interface/TriggerResultsByName.h
+++ b/FWCore/Common/interface/TriggerResultsByName.h
@@ -47,6 +47,7 @@ namespace edm {
 
   class TriggerResultsByName {
   public:
+    using size_type = std::vector<std::string>::size_type;
     TriggerResultsByName(TriggerResults const* triggerResults, TriggerNames const* triggerNames);
 
     bool isValid() const;
@@ -91,17 +92,17 @@ namespace edm {
     std::vector<std::string> const& triggerNames() const;
 
     // Throws if the number is out of range.
-    std::string const& triggerName(unsigned i) const;
+    std::string const& triggerName(size_type i) const;
 
     // If the input name is not known, this returns a value
     // equal to the size.
-    unsigned triggerIndex(std::string const& pathName) const;
+    size_type triggerIndex(std::string const& pathName) const;
 
     // The number of trigger names.
-    std::vector<std::string>::size_type size() const;
+    size_type size() const;
 
   private:
-    unsigned getAndCheckIndex(std::string const& pathName) const;
+    size_type getAndCheckIndex(std::string const& pathName) const;
 
     void throwTriggerResultsMissing() const;
     void throwTriggerNamesMissing() const;

--- a/FWCore/Common/src/OutputProcessBlockHelper.cc
+++ b/FWCore/Common/src/OutputProcessBlockHelper.cc
@@ -58,7 +58,8 @@ namespace edm {
     std::vector<unsigned int> storedCacheIndices;
 
     // Number of processes in StoredProcessBlockHelper.
-    unsigned int nStoredProcesses = storedProcessBlockHelper.processesWithProcessBlockProducts().size();
+    unsigned int nStoredProcesses =
+        static_cast<unsigned int>(storedProcessBlockHelper.processesWithProcessBlockProducts().size());
 
     if (!productsFromInputKept_) {
       // This is really simple if we are not keeping any ProcessBlock products

--- a/FWCore/Common/src/ProcessBlockHelper.cc
+++ b/FWCore/Common/src/ProcessBlockHelper.cc
@@ -125,7 +125,8 @@ namespace edm {
 
       assert(processesWithProcessBlockProducts().empty());
       setProcessesWithProcessBlockProducts(storedProcessBlockHelper.processesWithProcessBlockProducts());
-      nProcessesInFirstFile_ = processesWithProcessBlockProducts().size();
+      nProcessesInFirstFile_ =
+          static_cast<decltype(nProcessesInFirstFile_)>(processesWithProcessBlockProducts().size());
     }
   }
 
@@ -138,7 +139,7 @@ namespace edm {
     std::vector<std::string> const& storedProcesses = storedProcessBlockHelper.processesWithProcessBlockProducts();
     std::vector<unsigned int> const& storedCacheIndices = storedProcessBlockHelper.processBlockCacheIndices();
 
-    outerOffset_ = processBlockCacheIndices_.size();
+    outerOffset_ = static_cast<decltype(outerOffset_)>(processBlockCacheIndices_.size());
 
     if (nProcessesInFirstFile_ == 0) {
       // There were no ProcessBlock products in the first file. Nothing to do.
@@ -190,7 +191,7 @@ namespace edm {
         offset += entries;
       }
 
-      unsigned int nFinalProcesses = finalProcesses.size();
+      unsigned int nFinalProcesses = static_cast<unsigned int>(finalProcesses.size());
       std::vector<unsigned int> newOffsets;
       newOffsets.reserve(nFinalProcesses);
       offset = 0;
@@ -199,7 +200,7 @@ namespace edm {
         offset += nEntries[finalIndexToStoredIndex[iNew]];
       }
 
-      unsigned int nOuterLoop = storedCacheIndices.size() / storedProcesses.size();
+      unsigned int nOuterLoop = static_cast<unsigned int>(storedCacheIndices.size() / storedProcesses.size());
       assert(nOuterLoop * storedProcesses.size() == storedCacheIndices.size());
       newCacheIndices.reserve(nOuterLoop * nFinalProcesses);
       unsigned int storedOuterOffset = 0;
@@ -214,7 +215,7 @@ namespace edm {
           }
           newCacheIndices.emplace_back(newCacheIndex);
         }
-        storedOuterOffset += storedProcesses.size();
+        storedOuterOffset += static_cast<unsigned int>(storedProcesses.size());
       }
     }
     storedProcessBlockHelper.setProcessBlockCacheIndices(std::move(newCacheIndices));
@@ -243,7 +244,7 @@ namespace edm {
 
     // Append the cache indices from the current input file to the
     // cache indices container from the previous files.
-    unsigned int nCacheIndexVectors = storedCacheIndices.size() / storedProcesses.size();
+    unsigned int nCacheIndexVectors = static_cast<unsigned int>(storedCacheIndices.size() / storedProcesses.size());
     assert(storedProcesses.size() * nCacheIndexVectors == storedCacheIndices.size());
     processBlockCacheIndices_.resize(processBlockCacheIndices_.size() + nCacheIndexVectors);
     unsigned int storedIndex = 0;

--- a/FWCore/Common/src/ProcessBlockHelperBase.cc
+++ b/FWCore/Common/src/ProcessBlockHelperBase.cc
@@ -33,7 +33,7 @@ namespace edm {
     std::string processName(productLabels.process);
     std::string selectedProcess;
 
-    unsigned int bestPosition = 0;
+    long int bestPosition = 0;
     for (auto const& prod : productRegistry.productList()) {
       ProductDescription const& desc = prod.second;
       if (desc.branchType() == InProcess && !desc.produced() && desc.present() &&
@@ -45,7 +45,9 @@ namespace edm {
                          processesWithProcessBlockProducts_.end(),
                          [&desc](auto const& processFromHelper) { return processFromHelper == desc.processName(); });
         if (found != processesWithProcessBlockProducts_.end()) {
-          const unsigned int position = std::distance(processesWithProcessBlockProducts_.begin(), found);
+          const auto position = std::distance(processesWithProcessBlockProducts_.begin(), found);
+          static_assert(std::is_same_v<decltype(bestPosition),
+                                       decltype(std::distance(processesWithProcessBlockProducts_.begin(), found))>);
           if (position >= bestPosition) {
             bestPosition = position;
             selectedProcess = desc.processName();

--- a/FWCore/Common/src/TriggerNames.cc
+++ b/FWCore/Common/src/TriggerNames.cc
@@ -47,9 +47,9 @@ namespace edm {
 
   TriggerNames::Strings const& TriggerNames::triggerNames() const { return triggerNames_; }
 
-  std::string const& TriggerNames::triggerName(unsigned int index) const { return triggerNames_.at(index); }
+  std::string const& TriggerNames::triggerName(std::size_t index) const { return triggerNames_.at(index); }
 
-  unsigned int TriggerNames::triggerIndex(std::string_view name) const {
+  std::size_t TriggerNames::triggerIndex(std::string_view name) const {
     auto found = std::equal_range(indexMap_.begin(), indexMap_.end(), name, PairSort());
     if (found.first == found.second)
       return indexMap_.size();

--- a/FWCore/Common/src/TriggerResultsByName.cc
+++ b/FWCore/Common/src/TriggerResultsByName.cc
@@ -64,7 +64,7 @@ namespace edm {
   HLTPathStatus const& TriggerResultsByName::at(std::string const& pathName) const {
     if (triggerResults_ == nullptr)
       throwTriggerResultsMissing();
-    unsigned i = getAndCheckIndex(pathName);
+    auto i = getAndCheckIndex(pathName);
     return triggerResults_->at(i);
   }
 
@@ -77,7 +77,7 @@ namespace edm {
   HLTPathStatus const& TriggerResultsByName::operator[](std::string const& pathName) const {
     if (triggerResults_ == nullptr)
       throwTriggerResultsMissing();
-    unsigned i = getAndCheckIndex(pathName);
+    auto i = getAndCheckIndex(pathName);
     return triggerResults_->at(i);
   }
 
@@ -90,7 +90,7 @@ namespace edm {
   bool TriggerResultsByName::wasrun(std::string const& pathName) const {
     if (triggerResults_ == nullptr)
       throwTriggerResultsMissing();
-    unsigned i = getAndCheckIndex(pathName);
+    auto i = getAndCheckIndex(pathName);
     return triggerResults_->wasrun(i);
   }
 
@@ -103,7 +103,7 @@ namespace edm {
   bool TriggerResultsByName::accept(std::string const& pathName) const {
     if (triggerResults_ == nullptr)
       throwTriggerResultsMissing();
-    unsigned i = getAndCheckIndex(pathName);
+    auto i = getAndCheckIndex(pathName);
     return triggerResults_->accept(i);
   }
 
@@ -116,7 +116,7 @@ namespace edm {
   bool TriggerResultsByName::error(std::string const& pathName) const {
     if (triggerResults_ == nullptr)
       throwTriggerResultsMissing();
-    unsigned i = getAndCheckIndex(pathName);
+    auto i = getAndCheckIndex(pathName);
     return triggerResults_->error(i);
   }
 
@@ -129,7 +129,7 @@ namespace edm {
   hlt::HLTState TriggerResultsByName::state(std::string const& pathName) const {
     if (triggerResults_ == nullptr)
       throwTriggerResultsMissing();
-    unsigned i = getAndCheckIndex(pathName);
+    auto i = getAndCheckIndex(pathName);
     return triggerResults_->state(i);
   }
 
@@ -142,7 +142,7 @@ namespace edm {
   unsigned TriggerResultsByName::index(std::string const& pathName) const {
     if (triggerResults_ == nullptr)
       throwTriggerResultsMissing();
-    unsigned i = getAndCheckIndex(pathName);
+    auto i = getAndCheckIndex(pathName);
     return triggerResults_->index(i);
   }
 
@@ -160,7 +160,7 @@ namespace edm {
     return triggerNames_->triggerNames();
   }
 
-  std::string const& TriggerResultsByName::triggerName(unsigned i) const {
+  std::string const& TriggerResultsByName::triggerName(size_type i) const {
     if (triggerResults_ == nullptr)
       throwTriggerResultsMissing();
     if (triggerNames_ == nullptr)
@@ -168,7 +168,7 @@ namespace edm {
     return triggerNames_->triggerName(i);
   }
 
-  unsigned TriggerResultsByName::triggerIndex(std::string const& pathName) const {
+  TriggerResultsByName::size_type TriggerResultsByName::triggerIndex(std::string const& pathName) const {
     if (triggerResults_ == nullptr)
       throwTriggerResultsMissing();
     if (triggerNames_ == nullptr)
@@ -176,16 +176,16 @@ namespace edm {
     return triggerNames_->triggerIndex(pathName);
   }
 
-  std::vector<std::string>::size_type TriggerResultsByName::size() const {
+  TriggerResultsByName::size_type TriggerResultsByName::size() const {
     if (triggerResults_ == nullptr)
       throwTriggerResultsMissing();
     return triggerResults_->size();
   }
 
-  unsigned TriggerResultsByName::getAndCheckIndex(std::string const& pathName) const {
+  TriggerResultsByName::size_type TriggerResultsByName::getAndCheckIndex(std::string const& pathName) const {
     if (triggerNames_ == nullptr)
       throwTriggerNamesMissing();
-    unsigned i = triggerNames_->triggerIndex(pathName);
+    auto i = triggerNames_->triggerIndex(pathName);
     if (i == triggerNames_->size()) {
       throw edm::Exception(edm::errors::LogicError)
           << "TriggerResultsByName::getAndCheckIndex\n"

--- a/FWCore/Concurrency/interface/LimitedTaskQueue.h
+++ b/FWCore/Concurrency/interface/LimitedTaskQueue.h
@@ -104,7 +104,7 @@ namespace edm {
     template <typename T>
     void pushAndPause(oneapi::tbb::task_group& iGroup, T&& iAction);
 
-    unsigned int concurrencyLimit() const { return m_queues.size(); }
+    size_t concurrencyLimit() const { return m_queues.size(); }
 
   private:
     // ---------- member data --------------------------------

--- a/FWCore/FWLite/test/ref_t.cppunit.cpp
+++ b/FWCore/FWLite/test/ref_t.cppunit.cpp
@@ -172,8 +172,8 @@ static void testTree(TTree* events) {
   TBranch* thingBranch = events->GetBranch("edmtestThings_Thing__TEST.");
   CPPUNIT_ASSERT(thingBranch != nullptr);
 
-  int nev = events->GetEntries();
-  for (int ev = 0; ev < nev; ++ev) {
+  auto nev = events->GetEntries();
+  for (decltype(nev) ev = 0; ev < nev; ++ev) {
     events->GetEntry(ev, 0);
     otherBranch->SetAddress(&pOthers);
     thingBranch->SetAddress(&pThings);
@@ -225,8 +225,8 @@ void testRefInROOT::testGoodChain() {
   TBranch* thingsBranch = nullptr;
   eventChain.SetBranchAddress("edmtestThings_Thing__TEST.", &pThings, &thingsBranch);
 
-  int nev = eventChain.GetEntries();
-  for (int ev = 0; ev < nev; ++ev) {
+  auto nev = eventChain.GetEntries();
+  for (decltype(nev) ev = 0; ev < nev; ++ev) {
     std::cout << "event #" << ev << std::endl;
     othersBranch->SetAddress(&pOthers);
     thingsBranch->SetAddress(&pThings);
@@ -251,8 +251,8 @@ void testRefInROOT::testMissingRef() {
 
   CPPUNIT_ASSERT(otherBranch != nullptr);
 
-  int nev = events->GetEntries();
-  for (int ev = 0; ev < nev; ++ev) {
+  auto nev = events->GetEntries();
+  for (decltype(nev) ev = 0; ev < nev; ++ev) {
     events->GetEntry(ev, 0);
     otherBranch->SetAddress(&pOthers);
     otherBranch->GetEntry(ev);
@@ -327,13 +327,13 @@ void testRefInROOT::testThinning() {
 
   std::vector<edmtest::TrackOfThings> const* vTracks = nullptr;
 
-  int nev = events->GetEntries();
-  for (int ev = 0; ev < nev; ++ev) {
+  auto nev = events->GetEntries();
+  for (decltype(nev) ev = 0; ev < nev; ++ev) {
     // The values in the tests below have no particular meaning.
     // It is just checking that we read the values known to be
     // be put in by the relevant producer.
 
-    int offset = 200 + ev * 100;
+    auto offset = 200 + ev * 100;
 
     events->GetEntry(ev, 0);
 

--- a/FWCore/Framework/interface/ESProducer.h
+++ b/FWCore/Framework/interface/ESProducer.h
@@ -243,7 +243,7 @@ namespace edm {
     // These next four functions are intended for use in this class and
     // class ESProducerExternalWork only. They should not be used in
     // other classes derived from them.
-    unsigned int consumesInfoSize() const { return consumesInfos_.size(); }
+    size_t consumesInfoSize() const { return consumesInfos_.size(); }
 
     ESConsumesInfo* consumesInfoPushBackNew() {
       consumesInfos_.push_back(std::make_unique<ESConsumesInfo>());

--- a/FWCore/Framework/interface/EventSetupsController.h
+++ b/FWCore/Framework/interface/EventSetupsController.h
@@ -145,7 +145,7 @@ namespace edm {
       void finishConfiguration();
       void clearComponents();
 
-      unsigned indexOfNextProcess() const { return providers_.size(); }
+      auto indexOfNextProcess() const { return providers_.size(); }
 
       void lookForMatches(ParameterSetID const& psetID,
                           unsigned subProcessIndex,

--- a/FWCore/Framework/interface/ProductRegistryHelper.h
+++ b/FWCore/Framework/interface/ProductRegistryHelper.h
@@ -168,7 +168,7 @@ namespace edm {
     BranchAliasSetter produces(const TypeID& id,
                                std::string instanceName = std::string(),
                                bool recordProvenance = true) {
-      unsigned int index = typeLabelList_.size();
+      auto index = typeLabelList_.size();
       typeLabelList_.emplace_back(convertToTransition(B), id, std::move(instanceName));
       recordProvenanceList_.push_back(recordProvenance and B == InEvent);
       return BranchAliasSetter{typeLabelList_.back(), EDPutToken{static_cast<unsigned int>(index)}};
@@ -177,18 +177,18 @@ namespace edm {
     BranchAliasSetter produces(const TypeID& id,
                                std::string instanceName = std::string(),
                                bool recordProvenance = true) {
-      unsigned int index = typeLabelList_.size();
+      auto index = typeLabelList_.size();
       typeLabelList_.emplace_back(B, id, std::move(instanceName));
       recordProvenanceList_.push_back(recordProvenance and B == Transition::Event);
-      return BranchAliasSetter{typeLabelList_.back(), EDPutToken{index}};
+      return BranchAliasSetter{typeLabelList_.back(), EDPutToken{static_cast<unsigned int>(index)}};
     }
 
     EDPutToken transforms(const TypeID& id, std::string instanceName) {
-      unsigned int index = typeLabelList_.size();
+      auto index = typeLabelList_.size();
       typeLabelList_.emplace_back(Transition::Event, id, std::move(instanceName));
       typeLabelList_.back().isTransform_ = true;
       recordProvenanceList_.push_back(true);
-      return EDPutToken{index};
+      return EDPutToken{static_cast<unsigned int>(index)};
     }
 
     virtual bool hasAbilityToProduceInBeginProcessBlocks() const { return false; }

--- a/FWCore/Framework/interface/TriggerNamesService.h
+++ b/FWCore/Framework/interface/TriggerNamesService.h
@@ -114,7 +114,7 @@ namespace edm {
       void loadPosMap(PosMap& posmap, Strings const& names) {
         size_type const n(names.size());
         for (size_type i = 0; i != n; ++i) {
-          posmap[names[i]] = i;
+          posmap[names[i]] = static_cast<unsigned int>(i);
         }
       }
 

--- a/FWCore/Framework/interface/TriggerResultsBasedEventSelector.h
+++ b/FWCore/Framework/interface/TriggerResultsBasedEventSelector.h
@@ -60,7 +60,7 @@ namespace edm {
 
       bool wantEvent(EventForOutput const& e);
 
-      unsigned int numberOfTokens() const { return selectors_.size(); }
+      auto numberOfTokens() const { return selectors_.size(); }
       EDGetToken token(unsigned int index) const { return selectors_[index].token(); }
 
     private:

--- a/FWCore/Framework/interface/global/implementors.h
+++ b/FWCore/Framework/interface/global/implementors.h
@@ -128,7 +128,7 @@ namespace edm {
         }
 
         // This is intended for use by Framework unit tests only
-        unsigned int cacheSize() const { return cacheImpl_.cacheSize(); }
+        auto cacheSize() const { return cacheImpl_.cacheSize(); }
 
       private:
         void doSelectInputProcessBlocks(ProductRegistry const& productRegistry,

--- a/FWCore/Framework/interface/limited/implementors.h
+++ b/FWCore/Framework/interface/limited/implementors.h
@@ -128,7 +128,7 @@ namespace edm {
         }
 
         // This is intended for use by Framework unit tests only
-        unsigned int cacheSize() const { return cacheImpl_.cacheSize(); }
+        auto cacheSize() const { return cacheImpl_.cacheSize(); }
 
       private:
         void doSelectInputProcessBlocks(ProductRegistry const& productRegistry,

--- a/FWCore/Framework/interface/one/implementors.h
+++ b/FWCore/Framework/interface/one/implementors.h
@@ -243,7 +243,7 @@ namespace edm {
         }
 
         // This is intended for use by Framework unit tests only
-        unsigned int cacheSize() const { return cacheImpl_.cacheSize(); }
+        auto cacheSize() const { return cacheImpl_.cacheSize(); }
 
       private:
         void doSelectInputProcessBlocks(ProductRegistry const& productRegistry,

--- a/FWCore/Framework/src/EDConsumerBase.cc
+++ b/FWCore/Framework/src/EDConsumerBase.cc
@@ -67,15 +67,16 @@ unsigned int EDConsumerBase::recordConsumes(BranchType iBranch,
     throwConsumesCallAfterFrozen(iType, iTag);
   }
 
-  unsigned int index = m_tokenInfo.size();
+  unsigned int index = static_cast<unsigned int>(m_tokenInfo.size());
 
   bool skipCurrentProcess = iTag.willSkipCurrentProcess();
 
   const size_t labelSize = iTag.label().size();
   const size_t productInstanceSize = iTag.instance().size();
-  unsigned int labelStart = m_tokenLabels.size();
-  unsigned short delta1 = labelSize + 1;
-  unsigned short delta2 = labelSize + 2 + productInstanceSize;
+  unsigned int labelStart = static_cast<unsigned int>(m_tokenLabels.size());
+  assert(labelSize + 2 + productInstanceSize < std::numeric_limits<unsigned short>::max());
+  unsigned short delta1 = static_cast<unsigned short>(labelSize + 1);
+  unsigned short delta2 = static_cast<unsigned short>(labelSize + 2 + productInstanceSize);
   m_tokenInfo.emplace_back(TokenLookupInfo{iType.type(), ProductResolverIndexInvalid, skipCurrentProcess, iBranch},
                            iAlwaysGets,
                            LabelPlacement{labelStart, delta1, delta2},
@@ -199,7 +200,7 @@ std::tuple<ESTokenIndex, char const*> EDConsumerBase::recordESConsumes(
   // empty labels we will assume we can reuse the first entry
   unsigned int startOfComponentName = 0;
   if (not iTag.module().empty()) {
-    startOfComponentName = m_tokenLabels.size();
+    startOfComponentName = static_cast<unsigned int>(m_tokenLabels.size());
 
     m_tokenLabels.reserve(m_tokenLabels.size() + iTag.module().size() + 1);
     {
@@ -529,7 +530,7 @@ void EDConsumerBase::convertCurrentProcessAlias(std::string const& processName) 
     auto newTokenLabels = makeEmptyTokenLabels();
 
     // first calculate the size of the new vector and reserve memory for it
-    std::vector<char>::size_type newSize = newTokenLabels.size();
+    auto newSize = newTokenLabels.size();
     std::string newProcessName;
     for (auto iter = m_tokenInfo.begin<kLabels>(), itEnd = m_tokenInfo.end<kLabels>(); iter != itEnd; ++iter) {
       newProcessName = &m_tokenLabels[iter->m_startOfModuleLabel + iter->m_deltaToProcessName];
@@ -540,7 +541,7 @@ void EDConsumerBase::convertCurrentProcessAlias(std::string const& processName) 
     }
     newTokenLabels.reserve(newSize);
 
-    unsigned int newStartOfModuleLabel = newTokenLabels.size();
+    auto newStartOfModuleLabel = newTokenLabels.size();
     for (auto iter = m_tokenInfo.begin<kLabels>(), itEnd = m_tokenInfo.end<kLabels>(); iter != itEnd; ++iter) {
       unsigned int startOfModuleLabel = iter->m_startOfModuleLabel;
       unsigned short deltaToProcessName = iter->m_deltaToProcessName;

--- a/FWCore/Framework/test/stubs/ToyIntProducers.cc
+++ b/FWCore/Framework/test/stubs/ToyIntProducers.cc
@@ -208,7 +208,7 @@ namespace edmtest {
       sum += stepSize * cos(i * stepSize);
     }
 
-    e.emplace(token_, value_ + sum);
+    e.emplace(token_, value_ + static_cast<int>(sum));
 
     if (e.luminosityBlock() == lumiNumberToThrow_) {
       throw cms::Exception("Test");
@@ -257,7 +257,7 @@ namespace edmtest {
       sum += stepSize * cos(i * stepSize);
     }
 
-    e.emplace(token_, value_ + sum);
+    e.emplace(token_, value_ + static_cast<decltype(value_)>(sum));
     --reentrancy_;
   }
 

--- a/FWCore/Integration/plugins/RandomIntProducer.cc
+++ b/FWCore/Integration/plugins/RandomIntProducer.cc
@@ -31,12 +31,12 @@ namespace edmtest {
 
   void RandomIntProducer::produce(edm::Event& iEvent, edm::EventSetup const&) {
     edm::Service<edm::RandomNumberGenerator> gen;
-    iEvent.emplace(evToken_, CLHEP::RandFlat::shootInt(&gen->getEngine(iEvent.streamID()), 10));
+    iEvent.emplace(evToken_, static_cast<int>(CLHEP::RandFlat::shootInt(&gen->getEngine(iEvent.streamID()), 10)));
   }
 
   void RandomIntProducer::beginLuminosityBlockProduce(edm::LuminosityBlock& iLumi, edm::EventSetup const&) {
     edm::Service<edm::RandomNumberGenerator> gen;
-    iLumi.emplace(lumiToken_, CLHEP::RandFlat::shootInt(&gen->getEngine(iLumi.index()), 10));
+    iLumi.emplace(lumiToken_, static_cast<int>(CLHEP::RandFlat::shootInt(&gen->getEngine(iLumi.index()), 10)));
   }
 
 }  // namespace edmtest

--- a/FWCore/Integration/plugins/ViewAnalyzer.cc
+++ b/FWCore/Integration/plugins/ViewAnalyzer.cc
@@ -177,8 +177,8 @@ namespace edmtest {
     }
 
     // Make sure the references are right.
-    size_t numElements = hview->size();
-    for (size_t i = 0; i < numElements; ++i) {
+    auto numElements = hview->size();
+    for (typename view_t::size_type i = 0; i < numElements; ++i) {
       RefToBase<value_t> ref = hview->refAt(i);
       assert(ref.isNonnull());
     }

--- a/FWCore/MessageLogger/src/JobReport.cc
+++ b/FWCore/MessageLogger/src/JobReport.cc
@@ -319,7 +319,7 @@ namespace edm {
         // while comments are usually ignored by xml parsers
         auto padding = (endpos - pos) - (kJobReportEndElement.size() + kMinSizeOfComment);
         *(impl_->ost_) << "<!--";
-        for (int i = padding; i > 0; --i) {
+        for (auto i = padding; i > 0; --i) {
           (*impl_->ost_) << ' ';
         }
         *(impl_->ost_) << "-->\n";

--- a/FWCore/MessageService/plugins/MessageServicePSetValidation.cc
+++ b/FWCore/MessageService/plugins/MessageServicePSetValidation.cc
@@ -434,7 +434,7 @@ namespace edm {
                << *i << " is an unrecognized name for a PSet\n";
       }
       psnames.clear();
-      unsigned int n = pset.getParameterSetNames(psnames, true);
+      auto n = pset.getParameterSetNames(psnames, true);
       if (n > 0) {
         end = psnames.end();
         for (vString::const_iterator i = psnames.begin(); i != end; ++i) {
@@ -656,7 +656,7 @@ namespace edm {
         flaws_ << psetName << " PSet: \n" << *i << " is an unrecognized name for a PSet in this context \n";
       }
       psnames.clear();
-      unsigned int n = pset.getParameterSetNames(psnames, true);
+      auto n = pset.getParameterSetNames(psnames, true);
       if (n > 0) {
         end = psnames.end();
         for (vString::const_iterator i = psnames.begin(); i != end; ++i) {
@@ -740,7 +740,7 @@ namespace edm {
                << "PSets not allowed within a category PSet\n";
       }
       psnames.clear();
-      unsigned int n = pset.getParameterSetNames(psnames, true);
+      auto n = pset.getParameterSetNames(psnames, true);
       if (n > 0) {
         end = psnames.end();
         for (vString::const_iterator i = psnames.begin(); i != end; ++i) {

--- a/FWCore/MessageService/src/ELoutput.cc
+++ b/FWCore/MessageService/src/ELoutput.cc
@@ -567,14 +567,14 @@ namespace edm {
           (*os) << indent;                    //of the ELstring
           if (last != ' ')
             (*os) << ' ';
-          charsOnLine = indent.length() + 1;
+          charsOnLine = static_cast<decltype(charsOnLine)>(indent.length() + 1);
         }
 
         if (nl) {
           (*os) << newline << std::flush;
           charsOnLine = 0;
         } else {
-          charsOnLine += s.length();
+          charsOnLine += static_cast<decltype(charsOnLine)>(s.length());
         }
       }
 

--- a/FWCore/MessageService/src/ELstatistics.cc
+++ b/FWCore/MessageService/src/ELstatistics.cc
@@ -458,7 +458,7 @@ namespace edm {
           sevName = std::string("Log") + sevName;
           sevName = dualLogName(sevName);
           if (sevName != "UnusedSeverity") {
-            sm[sevName] = p3[k].t;
+            sm[sevName] = static_cast<double>(p3[k].t);
           }
         }
       }  // for k

--- a/FWCore/ParameterSet/interface/DocFormatHelper.h
+++ b/FWCore/ParameterSet/interface/DocFormatHelper.h
@@ -22,7 +22,7 @@ namespace edm {
         : brief_(false),
           lineWidth_(80),
           indentation_(4),
-          startColumn2_(24U),
+          startColumn2_(24),
           section_(),
           pass_(0),
           column1_(0),
@@ -48,22 +48,25 @@ namespace edm {
     int pass() const { return pass_; }
     void setPass(int value) { pass_ = value; }
 
-    size_t column1() const { return column1_; }
-    size_t column2() const { return column2_; }
-    size_t column3() const { return column3_; }
+    int column1() const { return column1_; }
+    int column2() const { return column2_; }
+    int column3() const { return column3_; }
 
-    void setAtLeast1(size_t width) {
+    void setAtLeast1(int width) {
       if (width > column1_)
         column1_ = width;
     }
-    void setAtLeast2(size_t width) {
+    void setAtLeast1(size_t width) { setAtLeast1(static_cast<int>(width)); }
+    void setAtLeast2(int width) {
       if (width > column2_)
         column2_ = width;
     }
-    void setAtLeast3(size_t width) {
+    void setAtLeast2(size_t width) { setAtLeast2(static_cast<int>(width)); }
+    void setAtLeast3(int width) {
       if (width > column3_)
         column3_ = width;
     }
+    void setAtLeast3(size_t width) { setAtLeast3(static_cast<int>(width)); }
 
     int counter() const { return counter_; }
     void setCounter(int value) { counter_ = value; }
@@ -75,7 +78,7 @@ namespace edm {
 
     size_t commentWidth() const;
 
-    static void wrapAndPrintText(std::ostream& os, std::string const& text, size_t indent, size_t suggestedWidth);
+    static void wrapAndPrintText(std::ostream& os, std::string const& text, int indent, size_t suggestedWidth);
 
     void indent(std::ostream& os) const;
     void indent2(std::ostream& os) const;
@@ -92,15 +95,15 @@ namespace edm {
     bool brief_;
     size_t lineWidth_;
     int indentation_;
-    size_t startColumn2_;
+    int startColumn2_;
 
     std::string section_;
 
     int pass_;
 
-    size_t column1_;
-    size_t column2_;
-    size_t column3_;
+    int column1_;
+    int column2_;
+    int column3_;
 
     int counter_;
 

--- a/FWCore/ParameterSet/src/DocFormatHelper.cc
+++ b/FWCore/ParameterSet/src/DocFormatHelper.cc
@@ -8,7 +8,7 @@
 namespace edm {
 
   namespace {
-    void wrapAndPrintLine(std::ostream& os, std::string const& text, size_t indent, size_t suggestedWidth) {
+    void wrapAndPrintLine(std::ostream& os, std::string const& text, int indent, size_t suggestedWidth) {
       char oldFill = os.fill();
 
       size_t length = text.size();
@@ -95,10 +95,7 @@ namespace edm {
   // by a single blank space with no extra space in the input text,
   // otherwise the extra spaces and newlines get printed
   // making the output not nicely formatted ...
-  void DocFormatHelper::wrapAndPrintText(std::ostream& os,
-                                         std::string const& text,
-                                         size_t indent,
-                                         size_t suggestedWidth) {
+  void DocFormatHelper::wrapAndPrintText(std::ostream& os, std::string const& text, int indent, size_t suggestedWidth) {
     size_t pos = text.find_first_of('\n');
     if (pos == std::string::npos) {
       // no embedded newlines

--- a/FWCore/ParameterSet/src/ParameterDescriptionBase.cc
+++ b/FWCore/ParameterSet/src/ParameterDescriptionBase.cc
@@ -240,7 +240,7 @@ namespace edm {
         dfh.setAtLeast2(parameterTypeEnumToString(type()).size() + 10U);
       }
       if (optional) {
-        dfh.setAtLeast3(8U);
+        dfh.setAtLeast3(8);
       }
     } else {
       if (dfh.brief()) {

--- a/FWCore/ParameterSet/src/ParameterSwitchBase.cc
+++ b/FWCore/ParameterSet/src/ParameterSwitchBase.cc
@@ -72,7 +72,7 @@ namespace edm {
       } else {
         dfh.setAtLeast2(typeString.size() + 10U);
       }
-      dfh.setAtLeast3(8U);
+      dfh.setAtLeast3(8);
     }
     if (dfh.pass() == 1) {
       dfh.indent(os);

--- a/FWCore/ParameterSet/src/ParameterWildcardBase.cc
+++ b/FWCore/ParameterSet/src/ParameterWildcardBase.cc
@@ -63,13 +63,13 @@ namespace edm {
 
   void ParameterWildcardBase::print_(std::ostream& os, bool optional, bool /*writeToCfi*/, DocFormatHelper& dfh) const {
     if (dfh.pass() == 0) {
-      dfh.setAtLeast1(11U);
+      dfh.setAtLeast1(11);
       if (isTracked()) {
         dfh.setAtLeast2(parameterTypeEnumToString(type()).size());
       } else {
         dfh.setAtLeast2(parameterTypeEnumToString(type()).size() + 10U);
       }
-      dfh.setAtLeast3(8U);
+      dfh.setAtLeast3(8);
     } else {
       if (dfh.brief()) {
         dfh.indent(os);

--- a/FWCore/ParameterSet/src/defaultModuleLabel.cc
+++ b/FWCore/ParameterSet/src/defaultModuleLabel.cc
@@ -22,9 +22,10 @@ namespace edm {
         break;
     if (ups > 1 and ups != label.size())
       --ups;
-    for (unsigned int i = 0; i < ups; ++i)
-      label[i] = std::tolower(label[i]);
-
+    for (unsigned int i = 0; i < ups; ++i) {
+      //documentation for tolower says to cast the input
+      label[i] = static_cast<char>(std::tolower(static_cast<unsigned char>(label[i])));
+    }
     return label;
   }
 }  // namespace edm

--- a/FWCore/ParameterSet/src/types.cc
+++ b/FWCore/ParameterSet/src/types.cc
@@ -24,7 +24,7 @@ using namespace edm;
 // utility functions
 // ----------------------------------------------------------------------
 
-static char to_hex(unsigned int i) { return i + (i < 10u ? '0' : ('A' - 10)); }
+static char to_hex(unsigned int i) { return static_cast<char>(i + (i < 10u ? '0' : ('A' - 10))); }
 
 // ----------------------------------------------------------------------
 
@@ -690,9 +690,10 @@ bool edm::encode(std::string& to, std::vector<ESInputTag> const& from) {
 bool edm::decode(edm::EventID& to, std::string_view from) {
   std::vector<std::string> tokens = edm::tokenize(std::string(from), ":");
   assert(tokens.size() == 2 || tokens.size() == 3);
-  unsigned int run = strtoul(tokens[0].c_str(), nullptr, 0);
-  unsigned int lumi = (tokens.size() == 2 ? 0 : strtoul(tokens[1].c_str(), nullptr, 0));
-  unsigned long long event = strtoull(tokens[tokens.size() - 1].c_str(), nullptr, 0);
+  RunNumber_t run = static_cast<RunNumber_t>(strtoul(tokens[0].c_str(), nullptr, 0));
+  LuminosityBlockNumber_t lumi =
+      (tokens.size() == 2 ? 0 : static_cast<LuminosityBlockNumber_t>(strtoul(tokens[1].c_str(), nullptr, 0)));
+  EventNumber_t event = strtoull(tokens[tokens.size() - 1].c_str(), nullptr, 0);
   to = edm::EventID(run, lumi, event);
 
   return true;
@@ -746,8 +747,8 @@ bool edm::encode(std::string& to, std::vector<edm::EventID> const& from) {
 bool edm::decode(edm::LuminosityBlockID& to, std::string_view from) {
   std::vector<std::string> tokens = edm::tokenize(std::string(from), ":");
   assert(tokens.size() == 2);
-  unsigned int run = strtoul(tokens[0].c_str(), nullptr, 0);
-  unsigned int lumi = strtoul(tokens[1].c_str(), nullptr, 0);
+  auto run = static_cast<RunNumber_t>(strtoul(tokens[0].c_str(), nullptr, 0));
+  auto lumi = static_cast<LuminosityBlockNumber_t>(strtoul(tokens[1].c_str(), nullptr, 0));
   to = edm::LuminosityBlockID(run, lumi);
   return true;
 }  // decode to LuminosityBlockID

--- a/FWCore/PrescaleService/interface/PrescaleService.h
+++ b/FWCore/PrescaleService/interface/PrescaleService.h
@@ -39,7 +39,7 @@ namespace edm {
       const VString_t& getLvl1Labels() const { return lvl1Labels_; }
       const PrescaleTable_t& getPrescaleTable() const { return prescaleTable_; }
 
-      static unsigned int findDefaultIndex(std::string const& label, std::vector<std::string> const& labels);
+      static size_t findDefaultIndex(std::string const& label, std::vector<std::string> const& labels);
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
     private:
@@ -54,7 +54,7 @@ namespace edm {
       //
       const bool forceDefault_;
       const VString_t lvl1Labels_;
-      const unsigned int lvl1Default_;
+      const size_t lvl1Default_;
       const std::vector<ParameterSet> vpsetPrescales_;
       PrescaleTable_t prescaleTable_;
       ParameterSetID processParameterSetID_;

--- a/FWCore/PrescaleService/src/PrescaleService.cc
+++ b/FWCore/PrescaleService/src/PrescaleService.cc
@@ -148,8 +148,8 @@ namespace edm {
     }
 
     // static method
-    unsigned int PrescaleService::findDefaultIndex(std::string const& label, std::vector<std::string> const& labels) {
-      for (unsigned int i = 0; i < labels.size(); ++i) {
+    size_t PrescaleService::findDefaultIndex(std::string const& label, std::vector<std::string> const& labels) {
+      for (size_t i = 0; i < labels.size(); ++i) {
         if (labels[i] == label) {
           return i;
         }

--- a/FWCore/PythonParameterSet/src/PyBind11ProcessDesc.cc
+++ b/FWCore/PythonParameterSet/src/PyBind11ProcessDesc.cc
@@ -49,7 +49,7 @@ PyBind11ProcessDesc::PyBind11ProcessDesc(std::string const& config, bool isFile,
 
     wchar_t** argvt = vp_argv.data();
 
-    PySys_SetArgv(args.size(), argvt);
+    PySys_SetArgv(static_cast<int>(args.size()), argvt);
   }
   read(config, isFile);
 }

--- a/FWCore/PythonParameterSet/test/makepset_t.cppunit.cc
+++ b/FWCore/PythonParameterSet/test/makepset_t.cppunit.cc
@@ -380,7 +380,7 @@ void testmakepset::typesTest() {
   CPPUNIT_ASSERT("" == test.getParameter<std::string>("sb2"));
   CPPUNIT_ASSERT(4 == test.getParameter<std::string>("sb3").size());
   std::vector<std::string> vs = test.getParameter<std::vector<std::string> >("vs");
-  int vssize = vs.size();
+  auto vssize = vs.size();
   //FIXME doesn't do spaces right
   edm::Entry e(test.retrieve("vs"));
   CPPUNIT_ASSERT(5 == vssize);

--- a/FWCore/Reflection/src/FunctionWithDict.cc
+++ b/FWCore/Reflection/src/FunctionWithDict.cc
@@ -77,10 +77,10 @@ namespace edm {
     void** data = const_cast<void**>(values.data());
     assert(funcptr_.fGeneric);
     if (ret == nullptr) {
-      (*funcptr_.fGeneric)(obj.address(), values.size(), data, nullptr);
+      (*funcptr_.fGeneric)(obj.address(), static_cast<int>(values.size()), data, nullptr);
       return;
     }
-    (*funcptr_.fGeneric)(obj.address(), values.size(), data, ret->address());
+    (*funcptr_.fGeneric)(obj.address(), static_cast<int>(values.size()), data, ret->address());
   }
 
   /// Call a static function.
@@ -89,10 +89,10 @@ namespace edm {
     void** data = const_cast<void**>(values.data());
     assert(funcptr_.fGeneric);
     if (ret == nullptr) {
-      (*funcptr_.fGeneric)(nullptr, values.size(), data, nullptr);
+      (*funcptr_.fGeneric)(nullptr, static_cast<int>(values.size()), data, nullptr);
       return;
     }
-    (*funcptr_.fGeneric)(nullptr, values.size(), data, ret->address());
+    (*funcptr_.fGeneric)(nullptr, static_cast<int>(values.size()), data, ret->address());
   }
 
   IterWithDict<TMethodArg> FunctionWithDict::begin() const {

--- a/FWCore/SOA/interface/Table.h
+++ b/FWCore/SOA/interface/Table.h
@@ -177,9 +177,9 @@ namespace edm {
       }
       Table<Args...>& operator=(Table<Args...> const& iOther) { return operator=(Table<Args...>(iOther)); }
 
-      unsigned int size() const { return m_size; }
+      auto size() const { return m_size; }
 
-      void resize(unsigned int iNewSize) {
+      void resize(size_t iNewSize) {
         if (m_size == iNewSize) {
           return;
         }
@@ -239,7 +239,7 @@ namespace edm {
 
     private:
       // Member data
-      unsigned int m_size = 0;
+      size_t m_size = 0;
       std::array<void*, sizeof...(Args)> m_values = {{nullptr}};  //! keep ROOT from trying to store this
 
       template <typename U>

--- a/FWCore/SOA/interface/TableItr.h
+++ b/FWCore/SOA/interface/TableItr.h
@@ -89,7 +89,7 @@ namespace edm {
         impl::TableItrAdvance<sizeof...(Args) - 1, Args...>::advance(m_values, iOffset);
       }
 
-      explicit TableItr(std::array<void*, sizeof...(Args)> const& iValues, unsigned int iOffset) : m_values{iValues} {
+      explicit TableItr(std::array<void*, sizeof...(Args)> const& iValues, size_t iOffset) : m_values{iValues} {
         impl::TableItrAdvance<sizeof...(Args) - 1, Args...>::advance(m_values, static_cast<long>(iOffset));
       }
 
@@ -126,7 +126,7 @@ namespace edm {
         impl::ConstTableItrAdvance<sizeof...(Args) - 1, Args...>::advance(m_values, iOffset);
       }
 
-      ConstTableItr(std::array<void const*, sizeof...(Args)> const& iValues, unsigned int iOffset) : m_values{iValues} {
+      ConstTableItr(std::array<void const*, sizeof...(Args)> const& iValues, size_t iOffset) : m_values{iValues} {
         impl::ConstTableItrAdvance<sizeof...(Args) - 1, Args...>::advance(m_values, static_cast<long>(iOffset));
       }
 

--- a/FWCore/SOA/interface/TableView.h
+++ b/FWCore/SOA/interface/TableView.h
@@ -56,12 +56,11 @@ namespace edm {
       TableView(Table<OArgs...> const& iTable) : m_size(iTable.size()) {
         fillArray(iTable, std::make_index_sequence<sizeof...(Args)>{});
       }
-      TableView(unsigned int iSize, std::array<void*, sizeof...(Args)>& iArray) : m_size(iSize), m_values(iArray) {}
+      TableView(size_t iSize, std::array<void*, sizeof...(Args)>& iArray) : m_size(iSize), m_values(iArray) {}
 
-      TableView(unsigned int iSize, std::array<void const*, sizeof...(Args)>& iArray)
-          : m_size(iSize), m_values(iArray) {}
+      TableView(size_t iSize, std::array<void const*, sizeof...(Args)>& iArray) : m_size(iSize), m_values(iArray) {}
 
-      unsigned int size() const { return m_size; }
+      auto size() const { return m_size; }
 
       template <typename U>
       typename U::type const& get(size_t iRow) const {
@@ -78,7 +77,7 @@ namespace edm {
 
     private:
       std::array<void const*, sizeof...(Args)> m_values;
-      unsigned int m_size;
+      size_t m_size;
 
       template <typename U>
       void const* columnAddress() const {

--- a/FWCore/SOA/test/table_filling_t.cppunit.cpp
+++ b/FWCore/SOA/test/table_filling_t.cppunit.cpp
@@ -83,7 +83,7 @@ struct JetType1 {
 };
 
 void testTableFilling::soaDeclareDefaultTest1() {
-  std::vector<JetType1> jets = {{1., 3.14}, {2., 0.}, {4., 1.3}};
+  std::vector<JetType1> jets = {{1.f, 3.14f}, {2.f, 0.f}, {4.f, 1.3f}};
   std::vector<std::string> labels = {{"jet0", "jet1", "jet2"}};
 
   ts::EtaPhiTable table(jets);
@@ -101,10 +101,10 @@ struct JetType2 {
 };
 
 // ...so we need to write our own value_for_column function for JetType2
-double value_for_column(JetType2 const& iJ, ts::col::Phi*) { return iJ.phi_; }
+auto value_for_column(JetType2 const& iJ, ts::col::Phi*) { return iJ.phi_; }
 
 void testTableFilling::soaDeclareDefaultTest2() {
-  std::vector<JetType2> jets = {{1., 3.14}, {2., 0.}, {4., 1.3}};
+  std::vector<JetType2> jets = {{1.f, 3.14f}, {2.f, 0.f}, {4.f, 1.3f}};
   std::vector<std::string> labels = {{"jet0", "jet1", "jet2"}};
 
   ts::EtaPhiTable table(jets);
@@ -121,13 +121,13 @@ namespace ts::reco {
     const float phi_;
   };
 
-  double value_for_column(ts::reco::JetType3 const& iJ, ts::col::Phi*) { return iJ.phi_; }
+  auto value_for_column(ts::reco::JetType3 const& iJ, ts::col::Phi*) { return iJ.phi_; }
 }  // namespace ts::reco
 
 // same tests as for JetType2 but with the type and the value_for_column
 // defined in their own test namespace
 void testTableFilling::soaDeclareDefaultTest3() {
-  std::vector<ts::reco::JetType3> jets = {{1., 3.14}, {2., 0.}, {4., 1.3}};
+  std::vector<ts::reco::JetType3> jets = {{1.f, 3.14f}, {2.f, 0.f}, {4.f, 1.3f}};
   std::vector<std::string> labels = {{"jet0", "jet1", "jet2"}};
 
   ts::EtaPhiTable table(jets);
@@ -147,10 +147,10 @@ struct JetType4 {
   const float phi_;
 };
 
-double value_for_column(JetType4 const& iJ, ts::col::Phi*) { return iJ.phi_; }
+auto value_for_column(JetType4 const& iJ, ts::col::Phi*) { return iJ.phi_; }
 
 void testTableFilling::soaDeclareDefaultTest4() {
-  std::vector<JetType4> jets = {{1., 3.14}, {2., 0.}, {4., 1.3}};
+  std::vector<JetType4> jets = {{1.f, 3.14f}, {2.f, 0.f}, {4.f, 1.3f}};
   std::vector<std::string> labels = {{"jet0", "jet1", "jet2"}};
 
   ts::EtaPhiTable table(jets);
@@ -172,12 +172,12 @@ namespace ts::reco {
     const float phi_;
   };
 
-  double value_for_column(ts::reco::JetType5 const& iJ, ts::col::Phi*) { return iJ.phi_; }
+  auto value_for_column(ts::reco::JetType5 const& iJ, ts::col::Phi*) { return iJ.phi_; }
 
 }  // namespace ts::reco
 
 void testTableFilling::soaDeclareDefaultTest5() {
-  std::vector<ts::reco::JetType5> jets = {{1., 3.14}, {2., 0.}, {4., 1.3}};
+  std::vector<ts::reco::JetType5> jets = {{1.f, 3.14f}, {2.f, 0.f}, {4.f, 1.3f}};
   std::vector<std::string> labels = {{"jet0", "jet1", "jet2"}};
 
   ts::EtaPhiTable table(jets);

--- a/FWCore/SOA/test/table_t.cppunit.cpp
+++ b/FWCore/SOA/test/table_t.cppunit.cpp
@@ -77,8 +77,8 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testTable);
 
 void testTable::rowviewCtrTest() {
   int id = 1;
-  float eta = 3.14;
-  float phi = 1.5;
+  float eta = 3.14f;
+  float phi = 1.5f;
   std::string label{"foo"};
 
   std::array<void const*, 4> variables{{&id, &eta, &phi, &label}};
@@ -93,8 +93,8 @@ void testTable::rowviewCtrTest() {
 
 void testTable::rawTableItrTest() {
   int ids[] = {1, 2, 3};
-  float etas[] = {3.14, 2.5, 0.3};
-  float phis[] = {1.5, -0.2, 2.9};
+  float etas[] = {3.14f, 2.5f, 0.3f};
+  float phis[] = {1.5f, -0.2f, 2.9f};
 
   std::array<void*, 3> variables{{ids, etas, phis}};
 
@@ -136,9 +136,9 @@ namespace {
     double phi_;
   };
 
-  double value_for_column(JetType const& iJ, ts::Eta*) { return iJ.eta_; }
+  auto value_for_column(JetType const& iJ, ts::Eta*) { return static_cast<ts::Eta::type>(iJ.eta_); }
 
-  double value_for_column(JetType const& iJ, ts::Phi*) { return iJ.phi_; }
+  auto value_for_column(JetType const& iJ, ts::Phi*) { return static_cast<ts::Phi::type>(iJ.phi_); }
 
   bool tolerance(double a, double b) { return std::abs(a - b) < 10E-6; }
 }  // namespace
@@ -146,8 +146,8 @@ namespace {
 void testTable::tableColumnTest() {
   using namespace ts;
   using namespace edm::soa;
-  std::array<double, 3> eta = {{1., 2., 4.}};
-  std::array<double, 3> phi = {{3.14, 0., 1.3}};
+  std::array<float, 3> eta = {{1.f, 2.f, 4.f}};
+  std::array<float, 3> phi = {{3.14f, 0.f, 1.3f}};
 
   JetTable jets{eta, phi};
   {
@@ -170,8 +170,8 @@ void testTable::tableColumnTest() {
 void testTable::tableViewConversionTest() {
   using namespace ts;
   using namespace edm::soa;
-  std::array<double, 3> eta = {{1., 2., 4.}};
-  std::array<double, 3> phi = {{3.14, 0., 1.3}};
+  std::array<float, 3> eta = {{1.f, 2.f, 4.f}};
+  std::array<float, 3> phi = {{3.14f, 0.f, 1.3f}};
 
   JetTable jets{eta, phi};
 
@@ -192,7 +192,7 @@ void testTable::tableViewConversionTest() {
   std::vector<double> px = {0.1, 0.9, 1.3};
   std::vector<double> py = {0.8, 1.7, 2.1};
   std::vector<double> pz = {0.4, 1.0, 0.7};
-  std::vector<double> energy = {1.4, 3.7, 4.1};
+  std::vector<float> energy = {1.4f, 3.7f, 4.1f};
 
   ParticleTable particles{px, py, pz, energy};
 
@@ -213,8 +213,8 @@ void testTable::tableViewConversionTest() {
 void testTable::tableCtrTest() {
   using namespace ts;
   using namespace edm::soa;
-  std::array<double, 3> eta = {{1., 2., 4.}};
-  std::array<double, 3> phi = {{3.14, 0., 1.3}};
+  std::array<float, 3> eta = {{1.f, 2.f, 4.f}};
+  std::array<float, 3> phi = {{3.14f, 0.f, 1.3f}};
 
   JetTable jets{eta, phi};
 
@@ -231,7 +231,7 @@ void testTable::tableCtrTest() {
   std::vector<double> px = {0.1, 0.9, 1.3};
   std::vector<double> py = {0.8, 1.7, 2.1};
   std::vector<double> pz = {0.4, 1.0, 0.7};
-  std::vector<double> energy = {1.4, 3.7, 4.1};
+  std::vector<float> energy = {1.4f, 3.7f, 4.1f};
 
   ParticleTable particles{px, py, pz, energy};
 
@@ -273,7 +273,7 @@ void testTable::tableStandardOpsTest() {
   std::vector<double> px = {0.1, 0.9, 1.3};
   std::vector<double> py = {0.8, 1.7, 2.1};
   std::vector<double> pz = {0.4, 1.0, 0.7};
-  std::vector<double> energy = {1.4, 3.7, 4.1};
+  std::vector<float> energy = {1.4f, 3.7f, 4.1f};
 
   ParticleTable particles{px, py, pz, energy};
 
@@ -339,8 +339,8 @@ void testTable::tableExaminerTest() {
   using namespace edm::soa;
   using namespace ts;
 
-  std::array<double, 3> eta = {{1., 2., 4.}};
-  std::array<double, 3> phi = {{3.14, 0., 1.3}};
+  std::array<float, 3> eta = {{1.f, 2.f, 4.f}};
+  std::array<float, 3> phi = {{3.14f, 0.f, 1.3f}};
   int size = eta.size();
   CPPUNIT_ASSERT(size == 3);
 
@@ -358,7 +358,7 @@ void testTable::tableResizeTest() {
   std::vector<double> px = {0.1, 0.9, 1.3};
   std::vector<double> py = {0.8, 1.7, 2.1};
   std::vector<double> pz = {0.4, 1.0, 0.7};
-  std::vector<double> energy = {1.4, 3.7, 4.1};
+  std::vector<float> energy = {1.4f, 3.7f, 4.1f};
 
   ParticleTable particlesStandard{px, py, pz, energy};
 
@@ -394,13 +394,13 @@ void testTable::mutabilityTest() {
   using namespace edm::soa;
   using namespace ts;
 
-  std::array<double, 3> eta = {{1., 2., 4.}};
-  std::array<double, 3> phi = {{3.14, 0., 1.3}};
+  std::array<float, 3> eta = {{1.f, 2.f, 4.f}};
+  std::array<float, 3> phi = {{3.14f, 0.f, 1.3f}};
   JetTable jets{eta, phi};
 
   jets.get<Eta>(0) = 0.;
   CPPUNIT_ASSERT(jets.get<Eta>(0) == 0.);
-  jets.get<Phi>(1) = 0.03;
+  jets.get<Phi>(1) = 0.03f;
   CPPUNIT_ASSERT(tolerance(jets.get<Phi>(1), 0.03));
 
   auto row = jets.row(2);
@@ -411,7 +411,7 @@ void testTable::mutabilityTest() {
   CPPUNIT_ASSERT(row.get<Eta>() == 5.);
   CPPUNIT_ASSERT(row.get<Phi>() == 6.);
 
-  row.copyValuesFrom(JetType{7., 8.}, column_fillers(Phi::filler([](JetType const&) { return 9.; })));
+  row.copyValuesFrom(JetType{7., 8.}, column_fillers(Phi::filler([](JetType const&) { return 9.f; })));
   CPPUNIT_ASSERT(row.get<Eta>() == 7.);
   CPPUNIT_ASSERT(row.get<Phi>() == 9.);
 

--- a/FWCore/Services/plugins/StallMonitor.cc
+++ b/FWCore/Services/plugins/StallMonitor.cc
@@ -636,11 +636,11 @@ void StallMonitor::postEvent(StreamContext const& sc) {
 
 void StallMonitor::postEndJob() {
   // Prepare summary
-  std::size_t width{};
+  int width{};
   edm::for_all(moduleStats_, [&width](auto const& stats) {
     if (stats.numberOfStalls() == 0u)
       return;
-    width = std::max(width, stats.label().size());
+    width = std::max(width, static_cast<int>(stats.label().size()));
   });
 
   OStreamColumn tag{"StallMonitor>"};

--- a/FWCore/Services/plugins/monitor_file_utilities.cc
+++ b/FWCore/Services/plugins/monitor_file_utilities.cc
@@ -13,7 +13,7 @@ namespace edm::service::monitor_file_utilities {
                        char moduleIdSymbol,
                        std::string const& iIDHeader,
                        std::string const& iLabelHeader) {
-    std::size_t const width{std::to_string(iModuleLabels.size()).size()};
+    int const width{static_cast<int>(std::to_string(iModuleLabels.size()).size())};
     OStreamColumn col0{iIDHeader, width};
     std::string const& lastCol = iLabelHeader;
 

--- a/FWCore/Services/plugins/tracer_setupFile.cc
+++ b/FWCore/Services/plugins/tracer_setupFile.cc
@@ -234,7 +234,7 @@ namespace {
     }
 
   private:
-    int findRecordIndices(edm::eventsetup::EventSetupRecordKey const& iKey) const {
+    auto findRecordIndices(edm::eventsetup::EventSetupRecordKey const& iKey) const {
       auto index = std::type_index(iKey.type().value());
       auto itFind = std::find(recordIndices_->begin(), recordIndices_->end(), index);
       return itFind - recordIndices_->begin();

--- a/FWCore/SharedMemory/interface/ROOTDeserializer.h
+++ b/FWCore/SharedMemory/interface/ROOTDeserializer.h
@@ -59,7 +59,7 @@ namespace edm::shared_memory {
     READBUFFER& buffer_;
     TClass* const class_;
     TBufferFile bufferFile_;
-    int previousBufferIdentifier_ = 0;
+    decltype(buffer_.bufferIdentifier()) previousBufferIdentifier_ = 0;
   };
 }  // namespace edm::shared_memory
 

--- a/FWCore/SharedMemory/src/WriteBuffer.cc
+++ b/FWCore/SharedMemory/src/WriteBuffer.cc
@@ -62,7 +62,7 @@ WriteBuffer::~WriteBuffer() {
 // member functions
 //
 void WriteBuffer::growBuffer(std::size_t iLength) {
-  int newBuffer = (bufferInfo_->index_ + 1) % 2;
+  char newBuffer = static_cast<char>((bufferInfo_->index_ + 1) % 2);
   bool destroyedBuffer = false;
   auto oldIndex = bufferInfo_->index_;
   if (sm_) {

--- a/FWCore/SharedMemory/test/test_catch2_serialize.cc
+++ b/FWCore/SharedMemory/test/test_catch2_serialize.cc
@@ -10,7 +10,7 @@
 
 namespace {
   struct ReadWriteTestBuffer {
-    std::pair<char*, std::size_t> buffer() { return std::pair(&buffer_.front(), size()); }
+    std::pair<char*, UInt_t> buffer() { return std::pair(&buffer_.front(), size()); }
 
     int bufferIdentifier() { return bufferIdentifier_; }
 
@@ -23,7 +23,7 @@ namespace {
       std::copy(iStart, iStart + iLength, std::back_insert_iterator(buffer_));
     }
 
-    std::size_t size() const { return buffer_.size(); }
+    UInt_t size() const { return static_cast<UInt_t>(buffer_.size()); }
 
     std::vector<char> buffer_;
     int bufferIdentifier_ = 1;

--- a/FWCore/SharedMemory/test/test_monitorthread.cc
+++ b/FWCore/SharedMemory/test/test_monitorthread.cc
@@ -12,7 +12,7 @@ int main(int argc, char** argv) {
   monitor.setAction([&]() { std::cerr << "Action run\n"; });
   if (argc > 1) {
     char* end;
-    int sig = std::strtol(argv[1], &end, 10);
+    int sig = static_cast<int>(std::strtol(argv[1], &end, 10));
     raise(sig);
   }
   return 0;

--- a/FWCore/Sources/interface/IDGeneratorSourceBase.h
+++ b/FWCore/Sources/interface/IDGeneratorSourceBase.h
@@ -29,7 +29,7 @@ namespace edm {
     unsigned int numberEventsInRun() const { return numberEventsInRun_; }
     unsigned int numberEventsInLumi() const { return numberEventsInLumi_; }
     TimeValue_t presentTime() const { return presentTime_; }
-    unsigned int timeBetweenEvents() const { return timeBetweenEvents_; }
+    auto timeBetweenEvents() const { return timeBetweenEvents_; }
     unsigned int eventCreationDelay() const { return eventCreationDelay_; }
     unsigned int numberEventsInThisRun() const { return numberEventsInThisRun_; }
     unsigned int numberEventsInThisLumi() const { return numberEventsInThisLumi_; }

--- a/FWCore/TestProcessor/interface/TestProcessor.h
+++ b/FWCore/TestProcessor/interface/TestProcessor.h
@@ -81,14 +81,14 @@ namespace edm {
     public:
       ProcessToken() : index_{undefinedIndex()} {}
 
-      int index() const { return index_; }
+      long long index() const { return index_; }
 
-      static int undefinedIndex() { return -1; }
+      static long long int undefinedIndex() { return -1; }
 
     private:
-      explicit ProcessToken(int index) : index_{index} {}
+      explicit ProcessToken(long long int index) : index_{index} {}
 
-      int index_;
+      long long int index_;
     };
 
     class TestProcessorConfig {
@@ -101,7 +101,7 @@ namespace edm {
      then the call order will be the order of the Processes in the history.*/
       ProcessToken addExtraProcess(std::string const& iProcessName) {
         extraProcesses_.emplace_back(iProcessName);
-        return ProcessToken(extraProcesses_.size() - 1);
+        return ProcessToken(static_cast<long long int>(extraProcesses_.size()) - 1);
       }
 
       std::vector<std::string> const& extraProcesses() const { return extraProcesses_; }

--- a/FWCore/Utilities/bin/adler32.cc
+++ b/FWCore/Utilities/bin/adler32.cc
@@ -48,9 +48,9 @@ int main(int argc, char* argv[]) {
 
     lseek(myFD, 0, SEEK_SET);
 
-    int readSize = 0;
+    decltype(read(myFD, nullptr, EDMFILEUTILADLERBUFSIZE)) readSize = 0;
     while ((readSize = read(myFD, buffer.get(), EDMFILEUTILADLERBUFSIZE)) > 0) {
-      adlerCksum = adler32(adlerCksum, buffer.get(), readSize);
+      adlerCksum = adler32(adlerCksum, buffer.get(), static_cast<unsigned int>(readSize));
       fileSize += readSize;
     }
 

--- a/FWCore/Utilities/interface/EDPutToken.h
+++ b/FWCore/Utilities/interface/EDPutToken.h
@@ -103,7 +103,7 @@ namespace edm {
     static constexpr unsigned int s_uninitializedValue = 0xFFFFFFFF;
 
     constexpr explicit EDPutTokenT(unsigned int iValue) noexcept : m_value(iValue) {}
-    constexpr explicit EDPutTokenT(unsigned long int iValue) noexcept : m_value(iValue) {}
+    constexpr explicit EDPutTokenT(unsigned long int iValue) noexcept : m_value(static_cast<unsigned int>(iValue)) {}
 
     // ---------- member data --------------------------------
     value_type m_value;

--- a/FWCore/Utilities/interface/OStreamColumn.h
+++ b/FWCore/Utilities/interface/OStreamColumn.h
@@ -53,18 +53,18 @@ namespace edm {
   class OStreamColumn {
   public:
     explicit OStreamColumn(std::string const& t);
-    explicit OStreamColumn(std::string const& t, std::size_t const w);
+    explicit OStreamColumn(std::string const& t, int const w);
 
     template <typename T>
     auto operator()(T const& t) const {
       return OStreamColumnEntry<T>{*this, t};
     }
 
-    std::size_t width() const { return width_; }
+    auto width() const { return width_; }
 
   private:
     std::string title_;
-    std::size_t width_;
+    int width_;
 
     friend std::ostream& operator<<(std::ostream&, OStreamColumn const&);
 

--- a/FWCore/Utilities/interface/OffsetToBase.h
+++ b/FWCore/Utilities/interface/OffsetToBase.h
@@ -46,7 +46,7 @@ namespace edm {
   template <typename T>
   void const* pointerToBase(std::type_info const& baseTypeInfo, T const* address) {
     OffsetToBase<T> offsetToBase;
-    int offset = offsetToBase.offsetToBase(baseTypeInfo);
+    auto offset = offsetToBase.offsetToBase(baseTypeInfo);
     void const* ptr = address;
     return static_cast<char const*>(ptr) + offset;
   }

--- a/FWCore/Utilities/interface/SoATuple.h
+++ b/FWCore/Utilities/interface/SoATuple.h
@@ -159,7 +159,7 @@ namespace edm {
     /** Returns const access to data element I of item iIndex */
     template <unsigned int I>
     typename soahelper::AlignmentHelper<typename std::tuple_element<I, std::tuple<Args...>>::type>::Type const& get(
-        unsigned int iIndex) const {
+        size_t iIndex) const {
       typedef typename soahelper::AlignmentHelper<typename std::tuple_element<I, std::tuple<Args...>>::type>::Type
           ReturnType;
       return *(static_cast<ReturnType const*>(m_values[I]) + iIndex);
@@ -188,7 +188,7 @@ namespace edm {
 
     // ---------- member functions ---------------------------
     /** Makes sure to hold enough memory to contain at least iToSize entries. */
-    void reserve(unsigned int iToSize) {
+    void reserve(size_t iToSize) {
       if (iToSize > m_reserved) {
         changeSize(iToSize);
       }
@@ -258,7 +258,7 @@ namespace edm {
     }
 
   private:
-    void changeSize(unsigned int iToSize) {
+    void changeSize(size_t iToSize) {
       assert(m_size <= iToSize);
       const size_t memoryNeededInBytes = soahelper::SoATupleHelper<sizeof...(Args), Args...>::spaceNeededFor(iToSize);
       //align memory of the array to be on the strictest alignment boundary for any type in the Tuple

--- a/FWCore/Utilities/interface/SoATupleHelper.h
+++ b/FWCore/Utilities/interface/SoATupleHelper.h
@@ -31,7 +31,7 @@ namespace edm {
     /**Given a leading memory size, iSizeSoFar, and an alignment boundary requirement of iBoundary, returns how much additional memory padding is needed.
      This function assumes that when iSizeSoFar==0 that we are already properly aligned.*/
     constexpr unsigned int padding_needed(size_t iSizeSoFar, unsigned int iBoundary) {
-      return (iBoundary - iSizeSoFar % iBoundary) % iBoundary;
+      return static_cast<unsigned int>((iBoundary - iSizeSoFar % iBoundary) % iBoundary);
     }
 
     /**
@@ -99,7 +99,7 @@ namespace edm {
       // ---------- static member functions --------------------
       static size_t moveToNew(char* iNewMemory, size_t iSize, size_t iReserve, void** oToSet);
       static size_t copyToNew(char* iNewMemory, size_t iSize, size_t iReserve, void* const* iFrom, void** oToSet);
-      static size_t spaceNeededFor(unsigned int iNElements);
+      static size_t spaceNeededFor(size_t iNElements);
       static void push_back(void** iToSet, size_t iSize, std::tuple<Args...> const& iValues);
       template <typename... FArgs>
       static void emplace_back(void** iToSet, size_t iSize, FArgs... iValues);
@@ -122,7 +122,7 @@ namespace edm {
       template <typename... FArgs>
       static void emplace_back(void** iToSet, size_t iSize, FArgs... iValues) {}
 
-      static size_t spaceNeededFor(unsigned int /*iNElements*/) { return 0; }
+      static size_t spaceNeededFor(size_t /*iNElements*/) { return 0; }
 
       static size_t moveToNew(char* /*iNewMemory*/, size_t /*iSize*/, size_t /*iReserve*/, void** /*oToSet*/) {
         return 0;
@@ -156,7 +156,7 @@ namespace edm {
         }
       }
       *oldStart = newStart;
-      unsigned int additionalSize = padding_needed(usedSoFar, boundary) + iReserve * sizeof(Type);
+      auto additionalSize = padding_needed(usedSoFar, boundary) + iReserve * sizeof(Type);
       return usedSoFar + additionalSize;
     }
 
@@ -180,15 +180,15 @@ namespace edm {
         }
       }
       *(oToSet + I - 1) = newStart;
-      unsigned int additionalSize = padding_needed(usedSoFar, boundary) + iReserve * sizeof(Type);
+      auto additionalSize = padding_needed(usedSoFar, boundary) + iReserve * sizeof(Type);
       return usedSoFar + additionalSize;
     }
 
     template <unsigned int I, typename... Args>
-    size_t SoATupleHelper<I, Args...>::spaceNeededFor(unsigned int iNElements) {
+    size_t SoATupleHelper<I, Args...>::spaceNeededFor(size_t iNElements) {
       size_t usedSoFar = NextHelper::spaceNeededFor(iNElements);
       const unsigned int boundary = AlignmentInfo::kAlignment;
-      unsigned int additionalSize = padding_needed(usedSoFar, boundary) + iNElements * sizeof(Type);
+      auto additionalSize = padding_needed(usedSoFar, boundary) + iNElements * sizeof(Type);
       return usedSoFar + additionalSize;
     }
 

--- a/FWCore/Utilities/interface/isFinite.h
+++ b/FWCore/Utilities/interface/isFinite.h
@@ -32,7 +32,7 @@ namespace edm {
 
   template <>
   constexpr bool isFinite(long double x) {
-    double xx = x;
+    double xx = static_cast<double>(x);
     return isFinite(xx);
   }
 

--- a/FWCore/Utilities/src/CPUTimer.cc
+++ b/FWCore/Utilities/src/CPUTimer.cc
@@ -113,10 +113,12 @@ CPUTimer::Times CPUTimer::calculateDeltaTime() const {
   struct timespec tp;
 
   clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &tp);
-  returnValue.cpu_ = tp.tv_sec - startCPUTime_.tv_sec + nanosecToSec * (tp.tv_nsec - startCPUTime_.tv_nsec);
+  returnValue.cpu_ =
+      double(tp.tv_sec - startCPUTime_.tv_sec) + nanosecToSec * double(tp.tv_nsec - startCPUTime_.tv_nsec);
 
   clock_gettime(CLOCK_MONOTONIC, &tp);
-  returnValue.real_ = tp.tv_sec - startRealTime_.tv_sec + nanosecToSec * (tp.tv_nsec - startRealTime_.tv_nsec);
+  returnValue.real_ =
+      double(tp.tv_sec - startRealTime_.tv_sec) + nanosecToSec * double(tp.tv_nsec - startRealTime_.tv_nsec);
 #else
   rusage theUsage;
   if (0 != getrusage(RUSAGE_SELF, &theUsage)) {

--- a/FWCore/Utilities/src/ChildrenCPUTimer.cc
+++ b/FWCore/Utilities/src/ChildrenCPUTimer.cc
@@ -76,8 +76,8 @@ double ChildrenCPUTimer::calculateDeltaTime() const {
     throw cms::Exception("CPUTimerFailed") << errno;
   }
 
-  returnValue = theUsage.ru_stime.tv_sec + theUsage.ru_utime.tv_sec - startCPUTime_.tv_sec +
-                microsecToSec * (theUsage.ru_stime.tv_usec + theUsage.ru_utime.tv_usec - startCPUTime_.tv_usec);
+  returnValue = double(theUsage.ru_stime.tv_sec + theUsage.ru_utime.tv_sec - startCPUTime_.tv_sec) +
+                microsecToSec * double(theUsage.ru_stime.tv_usec + theUsage.ru_utime.tv_usec - startCPUTime_.tv_usec);
   return returnValue;
 }
 //

--- a/FWCore/Utilities/src/Digest.cc
+++ b/FWCore/Utilities/src/Digest.cc
@@ -11,7 +11,7 @@ namespace cms {
       return val;
     }
 
-    char unhexify(char hexed) {
+    unsigned char unhexify(char hexed) {
       switch (hexed) {
         case '0':
         case '1':
@@ -23,21 +23,21 @@ namespace cms {
         case '7':
         case '8':
         case '9':
-          return hexed - '0';
+          return static_cast<unsigned char>(hexed - '0');
         case 'a':
         case 'b':
         case 'c':
         case 'd':
         case 'e':
         case 'f':
-          return hexed - 'a' + 10;
+          return static_cast<unsigned char>(hexed - 'a' + 10);
         case 'A':
         case 'B':
         case 'C':
         case 'D':
         case 'E':
         case 'F':
-          return hexed - 'A' + 10;
+          return static_cast<unsigned char>(hexed - 'A' + 10);
         default:
           throw edm::Exception(edm::errors::LogicError) << "Non-hex character in Hash "
                                                         << "Please report this to the core framework developers";
@@ -74,7 +74,7 @@ namespace cms {
 
   MD5Result::MD5Result() { set_to_default(*this); }
 
-  static const char* s_hexValues =
+  static constexpr const char* s_hexValues =
       "000102030405060708090a0b0c0d0e0f"
       "101112131415161718191a1b1c1d1e1f"
       "202122232425262728292a2b2c2d2e2f"
@@ -123,9 +123,9 @@ namespace cms {
         auto it = hexy.cbegin();
         for (size_t i = 0; i != 16; ++i) {
           // first nybble
-          bytes[i] = (unhexify(*it++) << 4);
+          bytes[i] = unhexify(*it++) << 4;
           // second nybble
-          bytes[i] += (unhexify(*it++));
+          bytes[i] += unhexify(*it++);
         }
       } break;
       default: {
@@ -170,17 +170,17 @@ namespace cms {
 
   void Digest::append(std::string const& s) {
     const md5_byte_t* data = reinterpret_cast<const md5_byte_t*>(s.data());
-    md5_append(&state_, const_cast<md5_byte_t*>(data), s.size());
+    md5_append(&state_, const_cast<md5_byte_t*>(data), static_cast<int>(s.size()));
   }
 
   void Digest::append(std::string_view v) {
     const md5_byte_t* data = reinterpret_cast<const md5_byte_t*>(v.data());
-    md5_append(&state_, const_cast<md5_byte_t*>(data), v.size());
+    md5_append(&state_, const_cast<md5_byte_t*>(data), static_cast<int>(v.size()));
   }
 
   void Digest::append(const char* s, size_t size) {
     const md5_byte_t* data = reinterpret_cast<const md5_byte_t*>(s);
-    md5_append(&state_, const_cast<md5_byte_t*>(data), size);
+    md5_append(&state_, const_cast<md5_byte_t*>(data), static_cast<int>(size));
   }
 
   MD5Result Digest::digest() {

--- a/FWCore/Utilities/src/ESInputTag.cc
+++ b/FWCore/Utilities/src/ESInputTag.cc
@@ -29,7 +29,7 @@ ESInputTag::ESInputTag(std::string moduleLabel, std::string dataLabel)
 ESInputTag::ESInputTag(const std::string& iEncodedValue) {
   // string is delimited by colons
   std::vector<std::string> tokens = tokenize(iEncodedValue, ":");
-  int nwords = tokens.size();
+  auto nwords = tokens.size();
   if (nwords > 2) {
     throw edm::Exception(errors::Configuration, "ESInputTag")
         << "ESInputTag " << iEncodedValue << " has " << nwords << " tokens but only up two 2 are allowed.";

--- a/FWCore/Utilities/src/Exception.cc
+++ b/FWCore/Utilities/src/Exception.cc
@@ -50,7 +50,7 @@ namespace cms {
   void Exception::init(std::string const& message) {
     ost_ << message;
     if (!message.empty()) {
-      unsigned sz = message.size() - 1;
+      auto sz = message.size() - 1;
       if (message[sz] != '\n' && message[sz] != ' ')
         ost_ << " ";
     }

--- a/FWCore/Utilities/src/OStreamColumn.cc
+++ b/FWCore/Utilities/src/OStreamColumn.cc
@@ -6,8 +6,8 @@ namespace edm {
 
   OStreamColumn::OStreamColumn(std::string const& t) : OStreamColumn{t, 0} {}
 
-  OStreamColumn::OStreamColumn(std::string const& t, std::size_t const w)
-      : title_{t}, width_{std::max(w, title_.size())} {}
+  OStreamColumn::OStreamColumn(std::string const& t, int const w)
+      : title_{t}, width_{std::max(w, static_cast<int>(title_.size()))} {}
 
   std::ostream& operator<<(std::ostream& t, OStreamColumn const& c) {
     t << std::setw(c.width_) << c.title_;

--- a/FWCore/Utilities/src/Parse.cc
+++ b/FWCore/Utilities/src/Parse.cc
@@ -41,7 +41,7 @@ namespace edm {
 
     if (!result.empty()) {
       // and trailing quotes
-      int lastpos = result.size() - 1;
+      auto lastpos = result.size() - 1;
       if (result[lastpos] == '"' || result[lastpos] == '\'') {
         result.erase(lastpos, 1);
       }

--- a/FWCore/Utilities/src/ReleaseVersion.cc
+++ b/FWCore/Utilities/src/ReleaseVersion.cc
@@ -40,8 +40,8 @@ namespace edm {
           }
         }
 */
-        major_ = std::stoul(parts[0]);
-        minor_ = std::stoul(parts[1]);
+        major_ = static_cast<unsigned int>(std::stoul(parts[0]));
+        minor_ = static_cast<unsigned int>(std::stoul(parts[1]));
         //        point_ = std::stoul(parts[2]);
         irregular_ = false;
       } catch (std::exception const&) {

--- a/FWCore/Utilities/src/TimeOfDay.cc
+++ b/FWCore/Utilities/src/TimeOfDay.cc
@@ -34,7 +34,7 @@ namespace edm {
     localtime_r(&tod.tv_.tv_sec, &timebuf);
     typedef std::ostreambuf_iterator<char, std::char_traits<char> > Iter;
     std::time_put<char, Iter> const& tp = std::use_facet<std::time_put<char, Iter> >(std::locale());
-    int precision = os.precision();
+    int precision = static_cast<int>(os.precision());
     Iter begin(os);
     if (precision == 0) {
       char const pattern[] = "%d-%b-%Y %H:%M:%S %Z";

--- a/FWCore/Utilities/src/WallclockTimer.cc
+++ b/FWCore/Utilities/src/WallclockTimer.cc
@@ -93,7 +93,8 @@ double WallclockTimer::calculateDeltaTime() const {
   struct timespec tp;
 
   clock_gettime(CLOCK_MONOTONIC, &tp);
-  returnValue = tp.tv_sec - startRealTime_.tv_sec + nanosecToSec * (tp.tv_nsec - startRealTime_.tv_nsec);
+  returnValue = static_cast<double>(tp.tv_sec - startRealTime_.tv_sec) +
+                nanosecToSec * static_cast<double>(tp.tv_nsec - startRealTime_.tv_nsec);
 #else
   double const microsecToSec = 1E-6;
 

--- a/FWCore/Utilities/src/typelookup.cc
+++ b/FWCore/Utilities/src/typelookup.cc
@@ -41,7 +41,7 @@ namespace {
     static constexpr size_t value = (size_t)((sizeof(size_t) == sizeof(u)) ? u : ull);
   };
 
-  constexpr size_t hash_multiplier = select_size_t_constant<2654435769U, 11400714819323198485ULL>::value;
+  constexpr auto hash_multiplier = select_size_t_constant<2654435769U, 11400714819323198485ULL>::value;
 
   struct StringHash {
     inline size_t operator()(const char* s) const {

--- a/FWCore/Utilities/test/RunningAverage_t.cpp
+++ b/FWCore/Utilities/test/RunningAverage_t.cpp
@@ -36,13 +36,13 @@ namespace test_average {
       int res[n];
       int qq[n];
       for (auto& y : qq)
-        y = std::max(0., normal_dist(e2));
+        y = static_cast<int>(std::max(0., normal_dist(e2)));
 
-      auto theLoop = [&](int i) {
+      auto theLoop = [&](size_t i) {
         kk++;
         v.reserve(res[i] = localRA.upper());
         v.resize(qq[i]);
-        localRA.update(v.size());
+        localRA.update(static_cast<unsigned int>(v.size()));
         decltype(v) t;
         swap(v, t);
       };

--- a/FWCore/Utilities/test/cputimer_t.cppunit.cpp
+++ b/FWCore/Utilities/test/cputimer_t.cppunit.cpp
@@ -89,7 +89,7 @@ void testCPUTimer::testTiming()
     getrusage(RUSAGE_SELF, &theUsage2);
     nowTime.tv_sec = theUsage2.ru_utime.tv_sec;
     nowTime.tv_usec = theUsage2.ru_utime.tv_usec;
-  } while (nowTime.tv_sec - startTime.tv_sec + 1E-6 * (nowTime.tv_usec - startTime.tv_usec) < 1);
+  } while (double(nowTime.tv_sec - startTime.tv_sec) + 1E-6 * double(nowTime.tv_usec - startTime.tv_usec) < 1);
   timer.stop();
 
   if ((timer.realTime() < 1.0) or (timer.cpuTime() < 1.0)) {

--- a/FWCore/Utilities/test/soatuple_t.cppunit.cpp
+++ b/FWCore/Utilities/test/soatuple_t.cppunit.cpp
@@ -54,32 +54,32 @@ void testSoATuple::builtinTest() {
   s.reserve(3);
   CPPUNIT_ASSERT(s.size() == 0);
 
-  s.push_back(std::make_tuple(int{1}, float{3.2}, false));
+  s.push_back(std::make_tuple(int{1}, float{3.2f}, false));
   //std::cout <<s.get<1>(0)<<std::endl;
   CPPUNIT_ASSERT(s.size() == 1);
   CPPUNIT_ASSERT(1 == s.get<0>(0));
-  CPPUNIT_ASSERT(float{3.2} == s.get<1>(0));
+  CPPUNIT_ASSERT(float{3.2f} == s.get<1>(0));
   CPPUNIT_ASSERT(false == s.get<2>(0));
 
-  s.push_back(std::make_tuple(int{2}, float{3.1415}, true));
+  s.push_back(std::make_tuple(int{2}, float{3.1415f}, true));
   CPPUNIT_ASSERT(s.size() == 2);
   CPPUNIT_ASSERT(1 == s.get<0>(0));
-  CPPUNIT_ASSERT(float{3.2} == s.get<1>(0));
+  CPPUNIT_ASSERT(float{3.2f} == s.get<1>(0));
   CPPUNIT_ASSERT(false == s.get<2>(0));
   CPPUNIT_ASSERT(2 == s.get<0>(1));
-  CPPUNIT_ASSERT(float{3.1415} == s.get<1>(1));
+  CPPUNIT_ASSERT(float{3.1415f} == s.get<1>(1));
   CPPUNIT_ASSERT(true == s.get<2>(1));
 
-  s.push_back(std::make_tuple(int{-1}, float{58.6}, true));
+  s.push_back(std::make_tuple(int{-1}, float{58.6f}, true));
   CPPUNIT_ASSERT(s.size() == 3);
   CPPUNIT_ASSERT(1 == s.get<0>(0));
-  CPPUNIT_ASSERT(float{3.2} == s.get<1>(0));
+  CPPUNIT_ASSERT(float{3.2f} == s.get<1>(0));
   CPPUNIT_ASSERT(false == s.get<2>(0));
   CPPUNIT_ASSERT(2 == s.get<0>(1));
-  CPPUNIT_ASSERT(float{3.1415} == s.get<1>(1));
+  CPPUNIT_ASSERT(float{3.1415f} == s.get<1>(1));
   CPPUNIT_ASSERT(true == s.get<2>(1));
   CPPUNIT_ASSERT(-1 == s.get<0>(2));
-  CPPUNIT_ASSERT(float{58.6} == s.get<1>(2));
+  CPPUNIT_ASSERT(float{58.6f} == s.get<1>(2));
   CPPUNIT_ASSERT(true == s.get<2>(2));
 }
 

--- a/FWCore/Utilities/test/test_catch2_Exception.cc
+++ b/FWCore/Utilities/test/test_catch2_Exception.cc
@@ -50,7 +50,7 @@ namespace {
 
   void func3() {
     double d = 1.11111;
-    float f = 2.22222;
+    float f = 2.22222f;
     unsigned int i = 75U;
     std::string s("a string");
     char* c1 = const_cast<char*>("a nonconst pointer");
@@ -90,7 +90,7 @@ namespace {
 
   void func4() {
     double d = 1.11111;
-    float f = 2.22222;
+    float f = 2.22222f;
     unsigned int i = 75U;
     std::string s("a string");
     char* c1 = const_cast<char*>("a nonconst pointer");

--- a/IOMC/RandomEngine/interface/TRandomAdaptor.h
+++ b/IOMC/RandomEngine/interface/TRandomAdaptor.h
@@ -16,7 +16,7 @@ namespace edm {
 
     // Constructors and destructor.
     TRandomAdaptor();
-    TRandomAdaptor(long seed);
+    TRandomAdaptor(unsigned int seed);
     TRandomAdaptor(int rowIndex, int colIndex);
     TRandomAdaptor(std::istream& is);
     ~TRandomAdaptor() override;

--- a/IOMC/RandomEngine/src/TRandomAdaptor.cc
+++ b/IOMC/RandomEngine/src/TRandomAdaptor.cc
@@ -15,7 +15,7 @@
 namespace edm {
 
   TRandomAdaptor::TRandomAdaptor() : trand_(new TRandom3()) { theSeed = trand_->GetSeed(); }
-  TRandomAdaptor::TRandomAdaptor(long seed) : trand_(new TRandom3(seed)) { theSeed = trand_->GetSeed(); }
+  TRandomAdaptor::TRandomAdaptor(unsigned int seed) : trand_(new TRandom3(seed)) { theSeed = trand_->GetSeed(); }
   TRandomAdaptor::TRandomAdaptor(int rowIndex, int colIndex) : trand_(new TRandom3(rowIndex * colIndex - 1)) {
     theSeed = trand_->GetSeed();
   }
@@ -96,12 +96,12 @@ namespace edm {
       return false;
     if (v[0] != CLHEP::engineIDulong<TRandomAdaptor>())
       return false;
-    int32_t numItems = v.size() - 1;
+    auto numItems = v.size() - 1;
 
     int32_t itemSize = sizeof(uint32_t);
-    TBufferFile buffer(TBuffer::kRead, numItems * itemSize + 1024);
+    TBufferFile buffer(TBuffer::kRead, static_cast<Int_t>(numItems * itemSize + 1024));
     char* bufferPtr = buffer.Buffer();
-    for (int32_t i = 0; i < numItems; ++i) {
+    for (decltype(numItems) i = 0; i < numItems; ++i) {
       *reinterpret_cast<uint32_t*>(bufferPtr + i * itemSize) = static_cast<uint32_t>(v[i + 1] & 0xffffffff);
     }
 

--- a/IOPool/Input/test/ProductInfo.h
+++ b/IOPool/Input/test/ProductInfo.h
@@ -39,8 +39,8 @@ ProductInfo::ProductInfo(const edm::Provenance &prov, TBranch &branch, edm::EDGe
 void ProductInfo::addBranchSizes(TBranch &branch, Long64_t &size) {
   size += branch.GetTotalSize();  // Includes size of branch metadata
   // Now recurse through any subbranches.
-  Long64_t nB = branch.GetListOfBranches()->GetEntries();
-  for (Long64_t i = 0; i < nB; ++i) {
+  auto nB = branch.GetListOfBranches()->GetEntries();
+  for (decltype(nB) i = 0; i < nB; ++i) {
     TBranch *btemp = (TBranch *)branch.GetListOfBranches()->At(i);
     if (btemp != nullptr) {
       addBranchSizes(*btemp, size);

--- a/IOPool/Streamer/bin/DiagStreamerFile.cpp
+++ b/IOPool/Streamer/bin/DiagStreamerFile.cpp
@@ -43,7 +43,7 @@ namespace {
   bool uncompressBuffer(unsigned char* inputBuffer,
                         unsigned int inputSize,
                         std::vector<unsigned char>& outputBuffer,
-                        unsigned int expectedFullSize);
+                        unsigned long int expectedFullSize);
   bool test_chksum(EventMsgView const* eview);
   bool test_uncompress(EventMsgView const* eview, std::vector<unsigned char>& dest);
   void readfile(std::string filename, std::string outfile);
@@ -280,9 +280,9 @@ namespace {
   bool uncompressBuffer(unsigned char* inputBuffer,
                         unsigned int inputSize,
                         std::vector<unsigned char>& outputBuffer,
-                        unsigned int expectedFullSize) {
+                        unsigned long int expectedFullSize) {
     unsigned long origSize = expectedFullSize;
-    unsigned long uncompressedSize = expectedFullSize * 1.1;
+    unsigned long uncompressedSize = static_cast<unsigned long>(static_cast<double>(expectedFullSize) * 1.1);
     outputBuffer.resize(uncompressedSize);
     int ret = uncompress(&outputBuffer[0], &uncompressedSize, inputBuffer, inputSize);
     if (ret == Z_OK) {

--- a/IOPool/Streamer/interface/EventMessage.h
+++ b/IOPool/Streamer/interface/EventMessage.h
@@ -79,7 +79,7 @@ namespace edm::streamer {
     const uint8* eventData() const { return event_start_; }
     uint8* startAddress() const { return buf_; }
     uint32 eventLength() const { return event_len_; }
-    uint32 headerSize() const { return event_start_ - buf_; }
+    uint32 headerSize() const { return static_cast<uint32>(event_start_ - buf_); }
     uint32 protocolVersion() const;
     uint32 run() const;
     uint64 event() const;

--- a/IOPool/Streamer/interface/EventMsgBuilder.h
+++ b/IOPool/Streamer/interface/EventMsgBuilder.h
@@ -27,7 +27,7 @@ namespace edm::streamer {
     void setBufAddr(uint8* buf_addr) { buf_ = buf_addr; }
     void setEventAddr(uint8* event_addr) { event_addr_ = event_addr; }
     uint8* eventAddr() const { return event_addr_; }
-    uint32 headerSize() const { return event_addr_ - buf_; }
+    uint32 headerSize() const { return static_cast<uint32>(event_addr_ - buf_); }
     uint32 size() const;
     uint32 bufferSize() const { return size_; }
 

--- a/IOPool/Streamer/interface/InitMessage.h
+++ b/IOPool/Streamer/interface/InitMessage.h
@@ -85,7 +85,7 @@ namespace edm::streamer {
     // needed for streamer file
     uint32 descLength() const { return desc_len_; }
     const uint8* descData() const { return desc_start_; }
-    uint32 headerSize() const { return desc_start_ - buf_; }
+    uint32 headerSize() const { return static_cast<uint32>(desc_start_ - buf_); }
     uint32 eventHeaderSize() const;
     uint32 adler32_chksum() const { return adler32_chksum_; }
     std::string hostName() const;

--- a/IOPool/Streamer/interface/InitMsgBuilder.h
+++ b/IOPool/Streamer/interface/InitMsgBuilder.h
@@ -24,7 +24,7 @@ namespace edm::streamer {
     uint8* startAddress() const { return buf_; }
     void setDataLength(uint32 registry_length);
     uint8* dataAddress() const { return data_addr_; }
-    uint32 headerSize() const { return data_addr_ - buf_; }
+    uint32 headerSize() const { return static_cast<uint32>(data_addr_ - buf_); }
     uint32 size() const;
     uint32 run() const; /** Required by EOF Record Builder */
     uint32 bufferSize() const { return size_; }

--- a/IOPool/Streamer/interface/MsgHeader.h
+++ b/IOPool/Streamer/interface/MsgHeader.h
@@ -5,7 +5,7 @@
 // as it is in memory of file
 namespace edm::streamer {
   struct Header {
-    Header(uint32 code, uint32 size) : code_(code) { convert(size, size_); }
+    Header(uint32 code, uint32 size) : code_(static_cast<uint8>(code)) { convert(size, size_); }
 
     uint8 code_;        // type of the message
     char_uint32 size_;  // of entire message including all headers

--- a/IOPool/Streamer/interface/MsgTools.h
+++ b/IOPool/Streamer/interface/MsgTools.h
@@ -28,45 +28,45 @@ namespace edm::streamer {
 
   inline uint32 convert32(char_uint32 v) {
     // first four bytes are code,  LSB first
-    unsigned int a = v[0], b = v[1], c = v[2], d = v[3];
+    uint32 a = v[0], b = v[1], c = v[2], d = v[3];
     a |= (b << 8) | (c << 16) | (d << 24);
     return a;
   }
 
   inline uint16 convert16(char_uint16 v) {
     // first four bytes are code,  LSB first
-    unsigned int a = v[0], b = v[1];
+    uint16 a = v[0], b = v[1];
     a |= (b << 8);
     return a;
   }
 
   inline void convert(uint32 i, char_uint32 v) {
-    v[0] = i & 0xff;
-    v[1] = (i >> 8) & 0xff;
-    v[2] = (i >> 16) & 0xff;
-    v[3] = (i >> 24) & 0xff;
+    v[0] = static_cast<unsigned char>(i & 0xff);
+    v[1] = static_cast<unsigned char>((i >> 8) & 0xff);
+    v[2] = static_cast<unsigned char>((i >> 16) & 0xff);
+    v[3] = static_cast<unsigned char>((i >> 24) & 0xff);
   }
 
   inline void convert(uint16 i, char_uint16 v) {
-    v[0] = i & 0xff;
-    v[1] = (i >> 8) & 0xff;
+    v[0] = static_cast<unsigned char>(i & 0xff);
+    v[1] = static_cast<unsigned char>((i >> 8) & 0xff);
   }
 
   inline void convert(uint64 li, char_uint64 v) {
-    v[0] = li & 0xff;
-    v[1] = (li >> 8) & 0xff;
-    v[2] = (li >> 16) & 0xff;
-    v[3] = (li >> 24) & 0xff;
-    v[4] = (li >> 32) & 0xff;
-    v[5] = (li >> 40) & 0xff;
-    v[6] = (li >> 48) & 0xff;
-    v[7] = (li >> 56) & 0xff;
+    v[0] = static_cast<unsigned char>(li & 0xff);
+    v[1] = static_cast<unsigned char>((li >> 8) & 0xff);
+    v[2] = static_cast<unsigned char>((li >> 16) & 0xff);
+    v[3] = static_cast<unsigned char>((li >> 24) & 0xff);
+    v[4] = static_cast<unsigned char>((li >> 32) & 0xff);
+    v[5] = static_cast<unsigned char>((li >> 40) & 0xff);
+    v[6] = static_cast<unsigned char>((li >> 48) & 0xff);
+    v[7] = static_cast<unsigned char>((li >> 56) & 0xff);
   }
 
   namespace MsgTools {
 
     inline uint8* fillNames(const Strings& names, uint8* pos) {
-      uint32 sz = names.size();
+      uint32 sz = static_cast<uint32>(names.size());
       convert(sz, pos);                            // save number of strings
       uint8* len_pos = pos + sizeof(char_uint32);  // area for length
       pos = len_pos + sizeof(char_uint32);         // area for full string of names

--- a/IOPool/TFileAdaptor/src/ReadRepacker.cc
+++ b/IOPool/TFileAdaptor/src/ReadRepacker.cc
@@ -61,7 +61,7 @@ int ReadRepacker::packInternal(long long int *pos, int *len, int nbuf, char *buf
   }
 
   // Handle case 1 separately to make the for-loop cleaner.
-  int iopb_offset = m_iov.size();
+  int iopb_offset = static_cast<int>(m_iov.size());
   // Because we re-use the buffer from ROOT, we are guarantee this iopb will
   // fit.
   assert(static_cast<IOSize>(len[0]) <= buffer_size);
@@ -89,7 +89,7 @@ int ReadRepacker::packInternal(long long int *pos, int *len, int nbuf, char *buf
       // This is so we can "perfectly pack" buffers consisting of only big
       // reads - in such a case, read coalescing doesn't help much.
       m_idx_to_iopb.push_back(iopb_offset);
-      m_idx_to_iopb_offset.push_back(pos[idx] - iopb.offset());
+      m_idx_to_iopb_offset.push_back(static_cast<int>(pos[idx] - iopb.offset()));
       iopb.set_size(pos[idx] + len[idx] - iopb.offset());
       buffer_used += (len[idx] + extra_bytes);
       m_extra_bytes += extra_bytes;
@@ -124,12 +124,12 @@ int ReadRepacker::packInternal(long long int *pos, int *len, int nbuf, char *buf
  */
 void ReadRepacker::unpack(char *buf) {
   char *root_result_ptr = buf;
-  int nbuf = m_idx_to_iopb.size();
-  for (int idx = 0; idx < nbuf; idx++) {
-    int iov_idx = m_idx_to_iopb[idx];
+  auto nbuf = m_idx_to_iopb.size();
+  for (decltype(nbuf) idx = 0; idx < nbuf; idx++) {
+    auto iov_idx = m_idx_to_iopb[idx];
     IOPosBuffer &iopb = m_iov[iov_idx];
-    int iopb_offset = m_idx_to_iopb_offset[idx];
-    char *io_result_ptr = static_cast<char *>(iopb.data()) + iopb_offset;
+    auto iopb_offset = m_idx_to_iopb_offset[idx];
+    auto io_result_ptr = static_cast<char *>(iopb.data()) + iopb_offset;
     // Note that we use the input buffer as a temporary where possible.
     // Hence, the source and destination can overlap; use memmove instead of memcpy.
     memmove(root_result_ptr, io_result_ptr, m_len[idx]);

--- a/IOPool/TFileAdaptor/src/TFileAdaptor.cc
+++ b/IOPool/TFileAdaptor/src/TFileAdaptor.cc
@@ -242,8 +242,8 @@ void TFileAdaptor::stats(std::ostream& o) const {
     << " Cache hint:" << cacheHint_ << '\n'
     << " Read hint:" << readHint_ << '\n'
     << "Storage statistics: " << edm::storage::StorageAccount::summaryText() << "; tfile/read=?/?/"
-    << (TFile::GetFileBytesRead() / oneMeg) << "MB/?ms/?ms/?ms"
-    << "; tfile/write=?/?/" << (TFile::GetFileBytesWritten() / oneMeg) << "MB/?ms/?ms/?ms";
+    << (static_cast<float>(TFile::GetFileBytesRead()) / oneMeg) << "MB/?ms/?ms/?ms"
+    << "; tfile/write=?/?/" << (static_cast<float>(TFile::GetFileBytesWritten()) / oneMeg) << "MB/?ms/?ms/?ms";
 }
 
 void TFileAdaptor::statsXML(std::map<std::string, std::string>& data) const {
@@ -259,8 +259,8 @@ void TFileAdaptor::statsXML(std::map<std::string, std::string>& data) const {
   edm::storage::StorageAccount::fillSummary(data);
   std::ostringstream r;
   std::ostringstream w;
-  r << (TFile::GetFileBytesRead() / oneMeg);
-  w << (TFile::GetFileBytesWritten() / oneMeg);
+  r << (static_cast<float>(TFile::GetFileBytesRead()) / oneMeg);
+  w << (static_cast<float>(TFile::GetFileBytesWritten()) / oneMeg);
   data.insert(std::make_pair("ROOT-tfile-read-totalMegabytes", r.str()));
   data.insert(std::make_pair("ROOT-tfile-write-totalMegabytes", w.str()));
 }

--- a/IOPool/TFileAdaptor/src/TStorageFactoryFile.cc
+++ b/IOPool/TFileAdaptor/src/TStorageFactoryFile.cc
@@ -395,7 +395,7 @@ Bool_t TStorageFactoryFile::ReadBuffersSync(char *buf, Long64_t *pos, Int_t *len
     pack_count = repacker.pack(
         static_cast<long long int *>(current_pos), current_len, remaining, current_buffer, remaining_buffer_size);
 
-    int real_bytes_processed = repacker.realBytesProcessed();
+    auto real_bytes_processed = repacker.realBytesProcessed();
     IOSize io_buffer_used = repacker.bufferUsed();
 
     // Issue readv, then unpack buffers.

--- a/SimDataFormats/RandomEngine/src/RandomEngineStates.cc
+++ b/SimDataFormats/RandomEngine/src/RandomEngineStates.cc
@@ -104,14 +104,14 @@ namespace edm {
       *label = state->getLabel();
 
       std::vector<uint32_t> const& seedVector = state->getSeed();
-      *seedLength = seedVector.size();
+      *seedLength = static_cast<decltype(seedLengths_)::value_type>(seedVector.size());
 
       for (std::vector<uint32_t>::const_iterator j = seedVector.begin(), jEnd = seedVector.end(); j != jEnd; ++j) {
         seedVectors_.push_back(*j);
       }
 
       std::vector<uint32_t> const& stateVector = state->getState();
-      *stateLength = stateVector.size();
+      *stateLength = static_cast<decltype(stateLengths_)::value_type>(stateVector.size());
 
       for (std::vector<uint32_t>::const_iterator j = stateVector.begin(), jEnd = stateVector.end(); j != jEnd; ++j) {
         stateVectors_.push_back(*j);

--- a/Utilities/General/test/test_precomputed_value_sort.cpp
+++ b/Utilities/General/test/test_precomputed_value_sort.cpp
@@ -60,12 +60,12 @@ int main() {
   // Create a vector with some random Points
   vector<Point> v1;
   v1.reserve(6);
-  v1.push_back(Point(-1.343, 2.445));
-  v1.push_back(Point(-1.566, 1.678));
-  v1.push_back(Point(-1.678, 1.569));
-  v1.push_back(Point(-3.138, 5.321));
-  v1.push_back(Point(-5.12, 0.321));
-  v1.push_back(Point(-5.12, -0.321));
+  v1.push_back(Point(-1.343f, 2.445f));
+  v1.push_back(Point(-1.566f, 1.678f));
+  v1.push_back(Point(-1.678f, 1.569f));
+  v1.push_back(Point(-3.138f, 5.321f));
+  v1.push_back(Point(-5.12f, 0.321f));
+  v1.push_back(Point(-5.12f, -0.321f));
 
   vector<float> r;
   r.reserve(v1.size());
@@ -73,7 +73,7 @@ int main() {
   phi.reserve(v1.size());
   for (vector<Point>::iterator i = v1.begin(); i != v1.end(); ++i) {
     r.push_back(i->r());
-    phi.push_back(i->phi());
+    phi.push_back(static_cast<float>(i->phi()));
   }
   std::sort(r.begin(), r.end());
   std::sort(phi.begin(), phi.end());


### PR DESCRIPTION
#### PR description:

Primarily did lowest level packages such as most DataFormats maintained by Core and FWCore/Utilities.

#### PR validation:

Code compiles. Doing `USER_CXXFLAGS=-Wconversion scram b` showed the changes avoid the warnings.