### PR TITLE
add dictionary for `std::pair<short,int>` [`15_0_X`]

### DIFF
--- a/DataFormats/StdDictionaries/src/classes_def_pair.xml
+++ b/DataFormats/StdDictionaries/src/classes_def_pair.xml
@@ -40,6 +40,7 @@
  <class name="std::pair<short,short>"/>
  <class name="std::pair<short,std::vector<short> >"/>
  <class name="std::pair<short,unsigned int>"/>
+ <class name="std::pair<short,int>"/>
  <class name="std::pair<std::basic_string<char>,bool>"/>
  <class name="std::pair<std::basic_string<char>,std::basic_string<char> >"/>
  <class name="std::pair<std::basic_string<char>,std::map<std::basic_string<char>,std::basic_string<char> > >"/>

--- a/DataFormats/StdDictionaries/src/classes_def_vector.xml
+++ b/DataFormats/StdDictionaries/src/classes_def_vector.xml
@@ -47,4 +47,7 @@
  <class name="std::vector<std::unique_ptr<int> >" />
  <class name="std::vector<std::pair<int,std::bitset<6> > >" />
  <class name="std::pair<int,std::bitset<6>>"/>
+ <class name="std::vector<std::pair<short,int>>" />
+ <class name="std::vector<std::vector<std::pair<short,int>>>" />
+ <class name="std::vector<std::vector<std::vector<std::pair<short,int>>>>" />
 </lcgdict>


### PR DESCRIPTION
backport of #47346

#### PR description:

From the description of #47346:
>This PR adds ROOT dictionaries for `std::pair<short,int>` and (nested) vectors of that data type. This is motivated by the fact that a vector of `CombinationsWithBxInCond` (which is equal to `std::pair<short,int>` ) is a data member of the `GlobalObjectMap` class (which in turn is used in `GlobalObjectMapRecord`, one of the data formats used in the RAW data tier).
>https://github.com/cms-sw/cmssw/blob/bf4d4fe891e7d94189bb86054451336cfba119c9/DataFormats/L1TGlobal/interface/GlobalObjectMap.h#L111
>
>The creation of these dictionaries was missed in #47030, and it likely led to the problem described in #47287.

#### PR validation:

None.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

#47346

Fixes a bug introduced in `CMSSW_15_0_0_pre2` via #47030.