### PR TITLE
Add Bs -> ϕ ϕ -> 4k analysis in GTT

### DIFF
--- a/DataFormats/L1Trigger/interface/TkLightMesonWord.h
+++ b/DataFormats/L1Trigger/interface/TkLightMesonWord.h
@@ -44,9 +44,8 @@ namespace l1t {
       kNtracksSize = 3,
       kIndexSize = 8,
       kUnassignedSize = 9,
-      kTkLightMesonWordSize = 
-        kValidSize + kPtSize + kGlbPhiSize + kGlbEtaSize + kZ0Size + kMassSize + kTypeSize + 
-        kNtracksSize + 2 * kIndexSize + kUnassignedSize
+      kTkLightMesonWordSize = kValidSize + kPtSize + kGlbPhiSize + kGlbEtaSize + kZ0Size + kMassSize + kTypeSize +
+                              kNtracksSize + 2 * kIndexSize + kUnassignedSize
     };
 
     enum TkLightMesonBitLocations {
@@ -74,34 +73,35 @@ namespace l1t {
       kUnassignedMSB = kUnassignedLSB + TkLightMesonBitWidths::kUnassignedSize - 1
     };
 
-    using valid_t      = ap_uint<TkLightMesonBitWidths::kValidSize>;
-    using pt_t         = ap_ufixed<TkLightMesonBitWidths::kPtSize, TkLightMesonBitWidths::kPtMagSize, AP_RND_CONV, AP_SAT>;
-    using glbphi_t     = ap_int<TkLightMesonBitWidths::kGlbPhiSize>;
-    using glbeta_t     = ap_int<TkLightMesonBitWidths::kGlbEtaSize>;
-    using z0_t         = ap_int<TkLightMesonBitWidths::kZ0Size>;     // 40cm / 0.1
-    using mass_t       = ap_ufixed<TkLightMesonBitWidths::kMassSize, TkLightMesonBitWidths::kMassMagSize, AP_RND_CONV, AP_SAT>;
-    using type_t       = ap_uint<TkLightMesonBitWidths::kTypeSize>;       //type of meson
-    using ntracks_t    = ap_uint<TkLightMesonBitWidths::kNtracksSize>;    //number of tracks
-    using index_t      = ap_uint<TkLightMesonBitWidths::kIndexSize>;      //index of track in collection
-    using unassigned_t = ap_uint<TkLightMesonBitWidths::kUnassignedSize>; // Unassigned bits
+    using valid_t = ap_uint<TkLightMesonBitWidths::kValidSize>;
+    using pt_t = ap_ufixed<TkLightMesonBitWidths::kPtSize, TkLightMesonBitWidths::kPtMagSize, AP_RND_CONV, AP_SAT>;
+    using glbphi_t = ap_int<TkLightMesonBitWidths::kGlbPhiSize>;
+    using glbeta_t = ap_int<TkLightMesonBitWidths::kGlbEtaSize>;
+    using z0_t = ap_int<TkLightMesonBitWidths::kZ0Size>;  // 40cm / 0.1
+    using mass_t =
+        ap_ufixed<TkLightMesonBitWidths::kMassSize, TkLightMesonBitWidths::kMassMagSize, AP_RND_CONV, AP_SAT>;
+    using type_t = ap_uint<TkLightMesonBitWidths::kTypeSize>;              //type of meson
+    using ntracks_t = ap_uint<TkLightMesonBitWidths::kNtracksSize>;        //number of tracks
+    using index_t = ap_uint<TkLightMesonBitWidths::kIndexSize>;            //index of track in collection
+    using unassigned_t = ap_uint<TkLightMesonBitWidths::kUnassignedSize>;  // Unassigned bits
 
     using tklightmesonword_bs_t = std::bitset<TkLightMesonBitWidths::kTkLightMesonWordSize>;
-    using tklightmesonword_t    = ap_uint<TkLightMesonBitWidths::kTkLightMesonWordSize>;
+    using tklightmesonword_t = ap_uint<TkLightMesonBitWidths::kTkLightMesonWordSize>;
 
   public:
     // ----------Constructors --------------------------
     TkLightMesonWord() {}
-    TkLightMesonWord(valid_t valid, 
-		     pt_t pt, 
-		     glbphi_t phi, 
-		     glbeta_t eta, 
-		     z0_t z0, 
-		     mass_t mass, 
-		     type_t type, 
-		     ntracks_t ntracks, 
-		     index_t firstIndex, 
-		     index_t secondIndex, 
-		     unassigned_t unassigned); 
+    TkLightMesonWord(valid_t valid,
+                     pt_t pt,
+                     glbphi_t phi,
+                     glbeta_t eta,
+                     z0_t z0,
+                     mass_t mass,
+                     type_t type,
+                     ntracks_t ntracks,
+                     index_t firstIndex,
+                     index_t secondIndex,
+                     unassigned_t unassigned);
     ~TkLightMesonWord() {}
 
     // ----------copy constructor ----------------------
@@ -115,7 +115,9 @@ namespace l1t {
 
     // ----------member functions (getters) ------------
     // These functions return arbitarary precision words (lists of bits) for each quantity
-    valid_t validWord() const { return tkLightMesonWord()(TkLightMesonBitLocations::kValidMSB, TkLightMesonBitLocations::kValidLSB); }
+    valid_t validWord() const {
+      return tkLightMesonWord()(TkLightMesonBitLocations::kValidMSB, TkLightMesonBitLocations::kValidLSB);
+    }
     pt_t ptWord() const {
       pt_t ret;
       ret.V = tkLightMesonWord()(TkLightMesonBitLocations::kPtMSB, TkLightMesonBitLocations::kPtLSB);
@@ -195,17 +197,17 @@ namespace l1t {
     unsigned int unassigned() const { return unassignedWord().to_uint(); }
 
     // ----------member functions (setters) ------------
-    void setTkLightMesonWord(valid_t valid, 
-			     pt_t pt, 
-			     glbphi_t phi,  
-			     glbeta_t eta, 
-			     z0_t z0, 
-			     mass_t mass, 
-			     type_t type, 
-			     ntracks_t ntracks, 
-			     index_t firstIndex, 
-			     index_t secondIndex, 
-			     unassigned_t unassigned);
+    void setTkLightMesonWord(valid_t valid,
+                             pt_t pt,
+                             glbphi_t phi,
+                             glbeta_t eta,
+                             z0_t z0,
+                             mass_t mass,
+                             type_t type,
+                             ntracks_t ntracks,
+                             index_t firstIndex,
+                             index_t secondIndex,
+                             unassigned_t unassigned);
 
   private:
     // ----------private member functions --------------

--- a/DataFormats/L1Trigger/interface/TkLightMesonWord.h
+++ b/DataFormats/L1Trigger/interface/TkLightMesonWord.h
@@ -1,0 +1,229 @@
+#ifndef FIRMWARE_TkLightMesonWord_h
+#define FIRMWARE_TkLightMesonWord_h
+// class to store the 96-bit track word produced by the L1 Track Trigger.  Intended to be inherited by L1 TTTrack.
+//----------------------------------------------------------------------------
+// Authors: Alexx Perloff, Pritam Palit (original version, 2021),
+//          Sweta Baradia, Suchandra Dutta, Subir Sarkar (February 2025)
+//----------------------------------------------------------------------------
+
+#include <vector>
+#include <ap_int.h>
+#include <cassert>
+#include <cmath>
+#include <bitset>
+#include <string>
+
+namespace l1t {
+
+  class TkLightMesonWord {
+  public:
+    // ----------constants, enums and typedefs ---------
+    int INTPHI_PI = 720;
+    int INTPHI_TWOPI = 2 * INTPHI_PI;
+    float INTPT_LSB = 1 >> 5;
+    static constexpr double ETAPHI_LSB = M_PI / (1 << 12);
+    static constexpr double Z0_LSB = 0.05;
+
+    // change to typed enum
+    enum TkLightMesonTypes {
+      kPhiType = 1,
+      kRhoType = 2,
+      kBsType = 3,
+    };
+
+    enum TkLightMesonBitWidths {
+      kValidSize = 1,
+      kPtSize = 16,
+      kPtMagSize = 11,
+      kGlbPhiSize = 13,
+      kGlbEtaSize = 14,
+      kZ0Size = 10,
+      kMassSize = 12,
+      kMassMagSize = 3,
+      kTypeSize = 2,
+      kNtracksSize = 3,
+      kIndexSize = 8,
+      kUnassignedSize = 9,
+      kTkLightMesonWordSize = 
+        kValidSize + kPtSize + kGlbPhiSize + kGlbEtaSize + kZ0Size + kMassSize + kTypeSize + 
+        kNtracksSize + 2 * kIndexSize + kUnassignedSize
+    };
+
+    enum TkLightMesonBitLocations {
+      kValidLSB = 0,
+      kValidMSB = kValidLSB + TkLightMesonBitWidths::kValidSize - 1,
+      kPtLSB = kValidMSB + 1,
+      kPtMSB = kPtLSB + TkLightMesonBitWidths::kPtSize - 1,
+      kGlbPhiLSB = kPtMSB + 1,
+      kGlbPhiMSB = kGlbPhiLSB + TkLightMesonBitWidths::kGlbPhiSize - 1,
+      kGlbEtaLSB = kGlbPhiMSB + 1,
+      kGlbEtaMSB = kGlbEtaLSB + TkLightMesonBitWidths::kGlbEtaSize - 1,
+      kZ0LSB = kGlbEtaMSB + 1,
+      kZ0MSB = kZ0LSB + TkLightMesonBitWidths::kZ0Size - 1,
+      kMassLSB = kZ0MSB + 1,
+      kMassMSB = kMassLSB + TkLightMesonBitWidths::kMassSize - 1,
+      kTypeLSB = kMassMSB + 1,
+      kTypeMSB = kTypeLSB + TkLightMesonBitWidths::kTypeSize - 1,
+      kNtracksLSB = kTypeMSB + 1,
+      kNtracksMSB = kNtracksLSB + TkLightMesonBitWidths::kNtracksSize - 1,
+      kFirstIndexLSB = kNtracksMSB + 1,
+      kFirstIndexMSB = kFirstIndexLSB + TkLightMesonBitWidths::kIndexSize - 1,
+      kSecondIndexLSB = kFirstIndexMSB + 1,
+      kSecondIndexMSB = kSecondIndexLSB + TkLightMesonBitWidths::kIndexSize - 1,
+      kUnassignedLSB = kSecondIndexMSB + 1,
+      kUnassignedMSB = kUnassignedLSB + TkLightMesonBitWidths::kUnassignedSize - 1
+    };
+
+    using valid_t      = ap_uint<TkLightMesonBitWidths::kValidSize>;
+    using pt_t         = ap_ufixed<TkLightMesonBitWidths::kPtSize, TkLightMesonBitWidths::kPtMagSize, AP_RND_CONV, AP_SAT>;
+    using glbphi_t     = ap_int<TkLightMesonBitWidths::kGlbPhiSize>;
+    using glbeta_t     = ap_int<TkLightMesonBitWidths::kGlbEtaSize>;
+    using z0_t         = ap_int<TkLightMesonBitWidths::kZ0Size>;     // 40cm / 0.1
+    using mass_t       = ap_ufixed<TkLightMesonBitWidths::kMassSize, TkLightMesonBitWidths::kMassMagSize, AP_RND_CONV, AP_SAT>;
+    using type_t       = ap_uint<TkLightMesonBitWidths::kTypeSize>;       //type of meson
+    using ntracks_t    = ap_uint<TkLightMesonBitWidths::kNtracksSize>;    //number of tracks
+    using index_t      = ap_uint<TkLightMesonBitWidths::kIndexSize>;      //index of track in collection
+    using unassigned_t = ap_uint<TkLightMesonBitWidths::kUnassignedSize>; // Unassigned bits
+
+    using tklightmesonword_bs_t = std::bitset<TkLightMesonBitWidths::kTkLightMesonWordSize>;
+    using tklightmesonword_t    = ap_uint<TkLightMesonBitWidths::kTkLightMesonWordSize>;
+
+  public:
+    // ----------Constructors --------------------------
+    TkLightMesonWord() {}
+    TkLightMesonWord(valid_t valid, 
+		     pt_t pt, 
+		     glbphi_t phi, 
+		     glbeta_t eta, 
+		     z0_t z0, 
+		     mass_t mass, 
+		     type_t type, 
+		     ntracks_t ntracks, 
+		     index_t firstIndex, 
+		     index_t secondIndex, 
+		     unassigned_t unassigned); 
+    ~TkLightMesonWord() {}
+
+    // ----------copy constructor ----------------------
+    TkLightMesonWord(const TkLightMesonWord& word) { tkLightMesonWord_ = word.tkLightMesonWord_; }
+
+    // ----------operators -----------------------------
+    TkLightMesonWord& operator=(const TkLightMesonWord& word) {
+      tkLightMesonWord_ = word.tkLightMesonWord_;
+      return *this;
+    }
+
+    // ----------member functions (getters) ------------
+    // These functions return arbitarary precision words (lists of bits) for each quantity
+    valid_t validWord() const { return tkLightMesonWord()(TkLightMesonBitLocations::kValidMSB, TkLightMesonBitLocations::kValidLSB); }
+    pt_t ptWord() const {
+      pt_t ret;
+      ret.V = tkLightMesonWord()(TkLightMesonBitLocations::kPtMSB, TkLightMesonBitLocations::kPtLSB);
+      return ret;
+    }
+    glbphi_t glbPhiWord() const {
+      glbphi_t ret;
+      ret.V = tkLightMesonWord()(TkLightMesonBitLocations::kGlbPhiMSB, TkLightMesonBitLocations::kGlbPhiLSB);
+      return ret;
+    }
+    glbeta_t glbEtaWord() const {
+      glbeta_t ret;
+      ret.V = tkLightMesonWord()(TkLightMesonBitLocations::kGlbEtaMSB, TkLightMesonBitLocations::kGlbEtaLSB);
+      return ret;
+    }
+    z0_t z0Word() const {
+      z0_t ret;
+      ret.V = tkLightMesonWord()(TkLightMesonBitLocations::kZ0MSB, TkLightMesonBitLocations::kZ0LSB);
+      return ret;
+    }
+    mass_t massWord() const {
+      mass_t ret;
+      ret.V = tkLightMesonWord()(TkLightMesonBitLocations::kMassMSB, TkLightMesonBitLocations::kMassLSB);
+      return ret;
+    }
+    type_t typeWord() const {
+      type_t ret;
+      ret.V = tkLightMesonWord()(TkLightMesonBitLocations::kTypeMSB, TkLightMesonBitLocations::kTypeLSB);
+      return ret;
+    }
+    ntracks_t ntracksWord() const {
+      ntracks_t ret;
+      ret.V = tkLightMesonWord()(TkLightMesonBitLocations::kNtracksMSB, TkLightMesonBitLocations::kNtracksLSB);
+      return ret;
+    }
+    index_t firstIndexWord() const {
+      index_t ret;
+      ret.V = tkLightMesonWord()(TkLightMesonBitLocations::kFirstIndexMSB, TkLightMesonBitLocations::kFirstIndexLSB);
+      return ret;
+    }
+    index_t secondIndexWord() const {
+      index_t ret;
+      ret.V = tkLightMesonWord()(TkLightMesonBitLocations::kSecondIndexMSB, TkLightMesonBitLocations::kSecondIndexLSB);
+      return ret;
+    }
+    unassigned_t unassignedWord() const {
+      return tkLightMesonWord()(TkLightMesonBitLocations::kUnassignedMSB, TkLightMesonBitLocations::kUnassignedLSB);
+    }
+    tklightmesonword_t tkLightMesonWord() const { return tklightmesonword_t(tkLightMesonWord_.to_string().c_str(), 2); }
+
+    // These functions return the packed bits in integer format for each quantity
+    // Signed quantities have the sign enconded in the left-most bit.
+    unsigned int validBits() const { return validWord().to_uint(); }
+    unsigned int ptBits() const { return ptWord().to_uint(); }
+    unsigned int glbPhiBits() const { return glbPhiWord().to_uint(); }
+    unsigned int glbEtaBits() const { return glbEtaWord().to_uint(); }
+    unsigned int z0Bits() const { return z0Word().to_uint(); }
+    unsigned int massBits() const { return massWord().to_uint(); }
+    unsigned int typeBits() const { return typeWord().to_uint(); }
+    unsigned int ntracksBits() const { return ntracksWord().to_uint(); }
+    unsigned int firstIndexBits() const { return firstIndexWord().to_uint(); }
+    unsigned int secondIndexBits() const { return secondIndexWord().to_uint(); }
+    unsigned int unassignedBits() const { return unassignedWord().to_uint(); }
+
+    // These functions return the unpacked and converted values
+    // These functions return real numbers converted from the digitized quantities by unpacking the 64-bit vertex word
+    bool valid() const { return validWord().to_bool(); }
+    double pt() const { return ptWord().to_double(); }
+    double glbphi() const { return glbPhiWord().to_double() * ETAPHI_LSB; }
+    double glbeta() const { return glbEtaWord().to_double() * ETAPHI_LSB; }
+    double z0() const { return z0Word().to_double() * Z0_LSB; }
+    double mass() const { return massWord().to_double(); }
+    unsigned int type() const { return typeWord().to_uint(); }
+    unsigned int ntracks() const { return ntracksWord().to_uint(); }
+    unsigned int firstIndex() const { return firstIndexWord().to_uint(); }
+    unsigned int secondIndex() const { return secondIndexWord().to_uint(); }
+    unsigned int unassigned() const { return unassignedWord().to_uint(); }
+
+    // ----------member functions (setters) ------------
+    void setTkLightMesonWord(valid_t valid, 
+			     pt_t pt, 
+			     glbphi_t phi,  
+			     glbeta_t eta, 
+			     z0_t z0, 
+			     mass_t mass, 
+			     type_t type, 
+			     ntracks_t ntracks, 
+			     index_t firstIndex, 
+			     index_t secondIndex, 
+			     unassigned_t unassigned);
+
+  private:
+    // ----------private member functions --------------
+    double unpackSignedValue(unsigned int bits, unsigned int nBits, double lsb) const {
+      int isign = 1;
+      unsigned int digitized_maximum = (1 << nBits) - 1;
+      if (bits & (1 << (nBits - 1))) {  // check the sign
+        isign = -1;
+        bits = (1 << (nBits + 1)) - bits;  // if negative, flip everything for two's complement encoding
+      }
+      return (double(bits & digitized_maximum) + 0.5) * lsb * isign;
+    }
+
+    // ----------member data ---------------------------
+    tklightmesonword_bs_t tkLightMesonWord_;
+  };
+
+  using TkLightMesonWordCollection = std::vector<l1t::TkLightMesonWord>;
+
+}  // namespace l1t
+#endif

--- a/DataFormats/L1Trigger/src/TkLightMesonWord.cc
+++ b/DataFormats/L1Trigger/src/TkLightMesonWord.cc
@@ -1,0 +1,97 @@
+///////
+//
+// class to store the 96-bit track word produced by the L1 Track Trigger.  Intended to be inherited by L1 TTTrack.
+// packing scheme given below.
+//----------------------------------------------------------------------------
+// Authors: Alexx Perloff, Pritam Palit (original version, 2021),
+//          Sweta Baradia, Suchandra Dutta, Subir Sarkar (February 2025)
+//----------------------------------------------------------------------------
+
+#include "DataFormats/L1Trigger/interface/TkLightMesonWord.h"
+
+namespace l1t {
+
+  TkLightMesonWord::TkLightMesonWord(valid_t valid, 
+				     pt_t pt, 
+				     glbphi_t phi, 
+				     glbeta_t eta, 
+				     z0_t z0, 
+				     mass_t mass, 
+				     type_t type, 
+				     ntracks_t ntracks, 
+				     index_t firstIndex, //Index to store the the position of first selected track from Phi (or first selected Phi) in pos track collection (Phi collection)
+				     index_t secondIndex, //Index to store the the position of second selected track from Phi (or first selected Phi) in neg track collection (Phi collection)
+				     unassigned_t unassigned) 
+  {
+    setTkLightMesonWord(valid, pt, phi, eta, z0, mass, type, ntracks, firstIndex, secondIndex, unassigned);
+  }
+  void TkLightMesonWord::setTkLightMesonWord(valid_t valid, 
+					     pt_t pt, 
+					     glbphi_t phi,  
+					     glbeta_t eta, 
+					     z0_t z0, 
+					     mass_t mass, 
+					     type_t type, 
+					     ntracks_t ntracks, 
+					     index_t firstIndex, 
+					     index_t secondIndex, 
+					     unassigned_t unassigned) 
+  {
+    // pack the TkLightMesonWord
+    unsigned int offset = 0;
+
+    for (unsigned int b = offset; b < offset + TkLightMesonBitWidths::kValidSize; b++) {
+      tkLightMesonWord_.set(b, valid[b - offset]);
+    }
+    offset += TkLightMesonBitWidths::kValidSize;
+    
+    for (unsigned int b = offset; b < offset + TkLightMesonBitWidths::kPtSize; b++) {
+      tkLightMesonWord_.set(b, pt[b - offset]);
+    }
+    offset += TkLightMesonBitWidths::kPtSize;
+    
+    for (unsigned int b = offset; b < offset + TkLightMesonBitWidths::kGlbPhiSize; b++) {
+      tkLightMesonWord_.set(b, phi[b - offset]);
+    }
+    offset += TkLightMesonBitWidths::kGlbPhiSize;
+    
+    for (unsigned int b = offset; b < offset + TkLightMesonBitWidths::kGlbEtaSize; b++) {
+      tkLightMesonWord_.set(b, eta[b - offset]);
+    }
+    offset += TkLightMesonBitWidths::kGlbEtaSize;
+    
+    for (unsigned int b = offset; b < offset + TkLightMesonBitWidths::kZ0Size; b++) {
+      tkLightMesonWord_.set(b, z0[b - offset]);
+    }
+    offset += TkLightMesonBitWidths::kZ0Size;
+    
+    for (unsigned int b = offset; b < offset + TkLightMesonBitWidths::kMassSize; b++) {
+      tkLightMesonWord_.set(b, mass[b - offset]);
+    }
+    offset += TkLightMesonBitWidths::kMassSize;
+    
+    for (unsigned int b = offset; b < offset + TkLightMesonBitWidths::kTypeSize; b++) {
+      tkLightMesonWord_.set(b, type[b - offset]);
+    }
+    offset += TkLightMesonBitWidths::kTypeSize;
+    
+    for (unsigned int b = offset; b < offset + TkLightMesonBitWidths::kNtracksSize; b++) {
+      tkLightMesonWord_.set(b, ntracks[b - offset]);
+    }
+    offset += TkLightMesonBitWidths::kNtracksSize;
+    
+    for (unsigned int b = offset; b < offset + TkLightMesonBitWidths::kIndexSize; b++) {
+      tkLightMesonWord_.set(b, firstIndex[b - offset]);
+    }
+    offset += TkLightMesonBitWidths::kIndexSize;
+
+    for (unsigned int b = offset; b < offset + TkLightMesonBitWidths::kIndexSize; b++) {
+      tkLightMesonWord_.set(b, secondIndex[b - offset]);
+    }
+    offset += TkLightMesonBitWidths::kIndexSize;
+
+    for (unsigned int b = offset; b < offset + TkLightMesonBitWidths::kUnassignedSize; b++) {
+      tkLightMesonWord_.set(b, unassigned[b - offset]);
+    }
+  }
+}  // namespace l1t

--- a/DataFormats/L1Trigger/src/TkLightMesonWord.cc
+++ b/DataFormats/L1Trigger/src/TkLightMesonWord.cc
@@ -11,32 +11,33 @@
 
 namespace l1t {
 
-  TkLightMesonWord::TkLightMesonWord(valid_t valid, 
-				     pt_t pt, 
-				     glbphi_t phi, 
-				     glbeta_t eta, 
-				     z0_t z0, 
-				     mass_t mass, 
-				     type_t type, 
-				     ntracks_t ntracks, 
-				     index_t firstIndex, //Index to store the the position of first selected track from Phi (or first selected Phi) in pos track collection (Phi collection)
-				     index_t secondIndex, //Index to store the the position of second selected track from Phi (or first selected Phi) in neg track collection (Phi collection)
-				     unassigned_t unassigned) 
-  {
+  TkLightMesonWord::TkLightMesonWord(
+      valid_t valid,
+      pt_t pt,
+      glbphi_t phi,
+      glbeta_t eta,
+      z0_t z0,
+      mass_t mass,
+      type_t type,
+      ntracks_t ntracks,
+      index_t
+          firstIndex,  //Index to store the the position of first selected track from Phi (or first selected Phi) in pos track collection (Phi collection)
+      index_t
+          secondIndex,  //Index to store the the position of second selected track from Phi (or first selected Phi) in neg track collection (Phi collection)
+      unassigned_t unassigned) {
     setTkLightMesonWord(valid, pt, phi, eta, z0, mass, type, ntracks, firstIndex, secondIndex, unassigned);
   }
-  void TkLightMesonWord::setTkLightMesonWord(valid_t valid, 
-					     pt_t pt, 
-					     glbphi_t phi,  
-					     glbeta_t eta, 
-					     z0_t z0, 
-					     mass_t mass, 
-					     type_t type, 
-					     ntracks_t ntracks, 
-					     index_t firstIndex, 
-					     index_t secondIndex, 
-					     unassigned_t unassigned) 
-  {
+  void TkLightMesonWord::setTkLightMesonWord(valid_t valid,
+                                             pt_t pt,
+                                             glbphi_t phi,
+                                             glbeta_t eta,
+                                             z0_t z0,
+                                             mass_t mass,
+                                             type_t type,
+                                             ntracks_t ntracks,
+                                             index_t firstIndex,
+                                             index_t secondIndex,
+                                             unassigned_t unassigned) {
     // pack the TkLightMesonWord
     unsigned int offset = 0;
 
@@ -44,42 +45,42 @@ namespace l1t {
       tkLightMesonWord_.set(b, valid[b - offset]);
     }
     offset += TkLightMesonBitWidths::kValidSize;
-    
+
     for (unsigned int b = offset; b < offset + TkLightMesonBitWidths::kPtSize; b++) {
       tkLightMesonWord_.set(b, pt[b - offset]);
     }
     offset += TkLightMesonBitWidths::kPtSize;
-    
+
     for (unsigned int b = offset; b < offset + TkLightMesonBitWidths::kGlbPhiSize; b++) {
       tkLightMesonWord_.set(b, phi[b - offset]);
     }
     offset += TkLightMesonBitWidths::kGlbPhiSize;
-    
+
     for (unsigned int b = offset; b < offset + TkLightMesonBitWidths::kGlbEtaSize; b++) {
       tkLightMesonWord_.set(b, eta[b - offset]);
     }
     offset += TkLightMesonBitWidths::kGlbEtaSize;
-    
+
     for (unsigned int b = offset; b < offset + TkLightMesonBitWidths::kZ0Size; b++) {
       tkLightMesonWord_.set(b, z0[b - offset]);
     }
     offset += TkLightMesonBitWidths::kZ0Size;
-    
+
     for (unsigned int b = offset; b < offset + TkLightMesonBitWidths::kMassSize; b++) {
       tkLightMesonWord_.set(b, mass[b - offset]);
     }
     offset += TkLightMesonBitWidths::kMassSize;
-    
+
     for (unsigned int b = offset; b < offset + TkLightMesonBitWidths::kTypeSize; b++) {
       tkLightMesonWord_.set(b, type[b - offset]);
     }
     offset += TkLightMesonBitWidths::kTypeSize;
-    
+
     for (unsigned int b = offset; b < offset + TkLightMesonBitWidths::kNtracksSize; b++) {
       tkLightMesonWord_.set(b, ntracks[b - offset]);
     }
     offset += TkLightMesonBitWidths::kNtracksSize;
-    
+
     for (unsigned int b = offset; b < offset + TkLightMesonBitWidths::kIndexSize; b++) {
       tkLightMesonWord_.set(b, firstIndex[b - offset]);
     }

--- a/DataFormats/L1Trigger/src/classes.h
+++ b/DataFormats/L1Trigger/src/classes.h
@@ -39,3 +39,4 @@
 #include "DataFormats/Common/interface/RefToBase.h"
 #include "DataFormats/L1Trigger/interface/P2GTCandidate.h"
 #include "DataFormats/L1Trigger/interface/P2GTAlgoBlock.h"
+#include "DataFormats/L1Trigger/interface/TkLightMesonWord.h"

--- a/DataFormats/L1Trigger/src/classes_def.xml
+++ b/DataFormats/L1Trigger/src/classes_def.xml
@@ -344,4 +344,10 @@
   <class name="edm::Wrapper<l1t::TkJetWordCollection>"/>
   <class name="std::bitset<70>"/>
 
+  <class name="l1t::TkLightMesonWord" ClassVersion="3">
+    <version ClassVersion="3" checksum="3079959913"/>
+  </class>
+  <class name="std::vector<l1t::TkLightMesonWord>"/>
+  <class name="edm::Wrapper<std::vector<l1t::TkLightMesonWord> >"/>
+
 </lcgdict>

--- a/L1Trigger/L1TTrackMatch/plugins/L1BsMesonSelectionEmulationProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1BsMesonSelectionEmulationProducer.cc
@@ -1,0 +1,241 @@
+// -*- C++ -*-
+//
+// Package:    L1Trigger/L1TTrackMatch
+// Class:      L1BsMesonSelectionEmulationProducer
+//
+/**\class L1BsMesonSelectionProducer L1BsMesonSelectionProducer.cc L1Trigger/L1TTrackMatch/plugins/L1BsMesonSelectionProducer.cc                                  
+ Description: Build Bs meson candidates from Phi collection
+ Implementation:                                                                                                                                       
+     Input:                                                                                                                                             
+         l1t::TkLightMesonWordCollection - A collection of reconstructed Phi candidates                                                                    
+     Output:                                                                                                                                 
+         l1t::TkLightMesonWordCollection - A collection of reconstructed Bs candidates                                                                        
+*/
+// ----------------------------------------------------------------------------
+// Authors: Alexx Perloff, Pritam Palit (original version, 2021),
+//          Sweta Baradia, Suchandra Dutta, Subir Sarkar (February 2025)
+//-----------------------------------------------------------------------------
+
+// system include files
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+#include <TMath.h>
+#include <cmath>
+#include <bitset>
+#include <array>
+// Xilinx HLS includes
+#include <ap_fixed.h>
+#include <ap_int.h>
+#include <stdio.h>
+#include <cassert>
+#include <cstdlib>
+
+// user include files
+#include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/RefVector.h"
+#include "DataFormats/Common/interface/RefToPtr.h"
+#include "DataFormats/L1TCorrelator/interface/TkPhiCandidate.h"
+#include "DataFormats/L1TCorrelator/interface/TkPhiCandidateFwd.h"
+#include "DataFormats/L1Trigger/interface/TkLightMesonWord.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+//#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+#include "DataFormats/Math/interface/LorentzVector.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+
+#include "L1TrackWordUnpacker.h"
+
+// class declaration
+using namespace std;
+using namespace edm;
+using namespace l1t;
+
+//class L1BsMesonSelectionEmulationProducer : public edm::one::EDProducer<edm::one::SharedResources> {
+class L1BsMesonSelectionEmulationProducer : public edm::global::EDProducer<> {
+public:
+  using L1TTTrackType            = TTTrack<Ref_Phase2TrackerDigi_>;
+  using TTTrackCollection        = std::vector<L1TTTrackType>;
+  //using TTTrackRef               = edm::Ref<TTTrackCollection>; 
+  using TTTrackRefCollection     = edm::RefVector<TTTrackCollection>;
+  using TTTrackCollectionHandle  = edm::Handle<TTTrackRefCollection>;
+  //using TTTrackRefCollectionUPtr = std::unique_ptr<TTTrackRefCollection>; 
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  explicit L1BsMesonSelectionEmulationProducer(const edm::ParameterSet&);
+  ~L1BsMesonSelectionEmulationProducer();
+  static constexpr double KaonMass = 0.493677 ;
+  size_t bsSize = 10;
+
+  double ETAPHI_LSB = M_PI / (1 << 12);
+  double Z0_LSB = 0.05;
+
+private:
+  // ----------constants, enums and typedefs --------- 
+  using TkLightMesonWordCollectionHandle = edm::Handle<TkLightMesonWordCollection>;
+  
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  //void produce(edm::Event&, const edm::EventSetup&) override;
+  
+  // ----------selectors -----------------------------
+  // Based on recommendations from https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideGenericSelectors
+  
+  // ----------member data ---------------------------
+  const edm::EDGetTokenT<TkLightMesonWordCollection> l1PhiMesonWordToken_;
+  const edm::EDGetTokenT<TTTrackRefCollection> posTrackToken_;
+  const edm::EDGetTokenT<TTTrackRefCollection> negTrackToken_;
+  const std::string outputCollectionName_;
+  int debug_;
+  const edm::ParameterSet cutSet_;
+  const double phiPairdzMax_, phiPairdRMin_, phiPairdRMax_, phiPairMMin_, phiPairMMax_, bsPtMin_;
+};
+
+//
+// constructors and destructor
+//
+L1BsMesonSelectionEmulationProducer::L1BsMesonSelectionEmulationProducer(const edm::ParameterSet& iConfig)
+  : l1PhiMesonWordToken_(consumes<TkLightMesonWordCollection>(iConfig.getParameter<edm::InputTag>("l1PhiMesonWordInputTag"))),
+    posTrackToken_(consumes<TTTrackRefCollection>(iConfig.getParameter<edm::InputTag>("posTrackInputTag"))),
+    negTrackToken_(consumes<TTTrackRefCollection>(iConfig.getParameter<edm::InputTag>("negTrackInputTag"))),
+    outputCollectionName_(iConfig.getParameter<std::string>("outputCollectionName")),
+    debug_(iConfig.getParameter<int>("debug")),
+    cutSet_(iConfig.getParameter<edm::ParameterSet>("cutSet")),
+    phiPairdzMax_(cutSet_.getParameter<double>("phiPairdzMax")),
+    phiPairdRMin_(cutSet_.getParameter<double>("phiPairdRMin")),
+    phiPairdRMax_(cutSet_.getParameter<double>("phiPairdRMax")),
+    phiPairMMin_(cutSet_.getParameter<double>("phiPairMMin")),
+    phiPairMMax_(cutSet_.getParameter<double>("phiPairMMax")),
+    bsPtMin_(cutSet_.getParameter<double>("bsPtMin"))
+{
+  produces<l1t::TkLightMesonWordCollection>(outputCollectionName_);
+}
+
+L1BsMesonSelectionEmulationProducer::~L1BsMesonSelectionEmulationProducer() {}
+//
+// member functions
+//
+// ------------ method called to produce the data  ------------
+void L1BsMesonSelectionEmulationProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+//void L1BsMesonSelectionEmulationProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)  {
+
+  auto L1BsMesonEmulationOutput = std::make_unique<l1t::TkLightMesonWordCollection>();
+
+  TkLightMesonWordCollectionHandle l1PhiMesonWordHandle;
+  iEvent.getByToken(l1PhiMesonWordToken_, l1PhiMesonWordHandle);
+  size_t nPhiMesonOutputApproximate = l1PhiMesonWordHandle->size();
+  if(nPhiMesonOutputApproximate < 2) return;
+  
+  TTTrackCollectionHandle posTrackHandle;
+  iEvent.getByToken(posTrackToken_, posTrackHandle);
+  
+  TTTrackCollectionHandle negTrackHandle;
+  iEvent.getByToken(negTrackToken_, negTrackHandle);
+
+  L1BsMesonEmulationOutput->reserve(bsSize);
+
+  for (size_t i = 0; i < nPhiMesonOutputApproximate; i++) {
+    const auto& phiMesonWord1 = l1PhiMesonWordHandle->at(i);        
+    double ptPhi1   = phiMesonWord1.pt();
+    double etaPhi1  = phiMesonWord1.glbeta();
+    double phiPhi1  = phiMesonWord1.glbphi();
+    double z0Phi1   = phiMesonWord1.z0();
+    double massPhi1 = phiMesonWord1.mass();
+
+    unsigned int pIndexPhi1 = phiMesonWord1.firstIndex();
+    unsigned int nIndexPhi1 = phiMesonWord1.secondIndex();
+
+    double pxPhi1 = ptPhi1 * cos(phiPhi1);
+    double pyPhi1 = ptPhi1 * sin(phiPhi1);
+    double pzPhi1 = ptPhi1 * sinh(etaPhi1);
+    double ePhi1  = sqrt(pow(ptPhi1, 2) + pow(pzPhi1, 2) + pow(massPhi1, 2));    
+
+    for (size_t j = i+1; j < nPhiMesonOutputApproximate; j++) {
+      const auto& phiMesonWord2 = l1PhiMesonWordHandle->at(j);
+      
+      double ptPhi2   = phiMesonWord2.pt();
+      double etaPhi2  = phiMesonWord2.glbeta();
+      double phiPhi2  = phiMesonWord2.glbphi();
+      double z0Phi2   = phiMesonWord2.z0();
+      double massPhi2 = phiMesonWord2.mass();
+
+      // Ensure that the 2 Phi mesons are made of 4 distinct tracks
+      unsigned int pIndexPhi2 = phiMesonWord2.firstIndex();
+      unsigned int nIndexPhi2 = phiMesonWord2.secondIndex();
+      if (pIndexPhi1 == pIndexPhi2 || nIndexPhi1 == nIndexPhi2) continue;
+
+      double pxPhi2 = ptPhi2 * cos(phiPhi2);
+      double pyPhi2 = ptPhi2 * sin(phiPhi2);
+      double pzPhi2 = ptPhi2 * sinh(etaPhi2);
+      double ePhi2  = sqrt(pow(ptPhi2, 2) + pow(pzPhi2, 2) + pow(massPhi2, 2));
+      
+      double pxBs = pxPhi1 + pxPhi2;
+      double pyBs = pyPhi1 + pyPhi2;
+      double pzBs = pzPhi1 + pzPhi2;
+      double eBs  = ePhi1  + ePhi2;
+
+      if (std::fabs(z0Phi1 - z0Phi2) > phiPairdzMax_) continue;
+  
+      double drPhiPair = reco::deltaR(etaPhi1, phiPhi1, etaPhi2, phiPhi2);
+      if (drPhiPair < phiPairdRMin_ || drPhiPair > phiPairdRMax_) continue;
+      
+      double massPhiPair = sqrt(pow(eBs, 2) - pow(pxBs, 2) - pow(pyBs, 2) - pow(pzBs, 2));
+      if (massPhiPair < phiPairMMin_ || massPhiPair > phiPairMMax_) continue;
+      
+      double pt = sqrt(pow(pxBs, 2) + pow(pyBs, 2));
+      if (pt < bsPtMin_) continue;
+      
+      l1t::TkLightMesonWord::valid_t validBs = phiMesonWord1.valid() && phiMesonWord2.valid();
+      l1t::TkLightMesonWord::pt_t ptBs = sqrt(pow(pxBs, 2) + pow(pyBs, 2));
+      l1t::TkLightMesonWord::glbphi_t phiBs = atan2(pyBs, pxBs) / ETAPHI_LSB;
+      l1t::TkLightMesonWord::glbeta_t etaBs = asinh(pzBs/sqrt(pow(pxBs, 2) + pow(pyBs, 2))) / ETAPHI_LSB;
+      l1t::TkLightMesonWord::z0_t z0Bs = ((z0Phi1 + z0Phi2) / Z0_LSB) * 0.5;
+      l1t::TkLightMesonWord::mass_t massBs  = sqrt(pow(eBs, 2) - pow(pxBs, 2) - pow(pyBs, 2) - pow(pzBs, 2));
+      l1t::TkLightMesonWord::type_t typeBs = l1t::TkLightMesonWord::TkLightMesonTypes::kBsType;
+      l1t::TkLightMesonWord::ntracks_t ntracksBs = 3;
+      l1t::TkLightMesonWord::index_t firstPhiIndex     = i;
+      l1t::TkLightMesonWord::index_t secondPhiIndex    = j;
+      l1t::TkLightMesonWord::unassigned_t unassignedBs = 0;
+
+      l1t::TkLightMesonWord bsWord(validBs, ptBs, phiBs, etaBs, z0Bs, massBs, typeBs, ntracksBs, firstPhiIndex, secondPhiIndex, unassignedBs); 
+      L1BsMesonEmulationOutput->push_back(bsWord);
+    }
+  }
+  // Put the outputs into the event
+  iEvent.put(std::move(L1BsMesonEmulationOutput), outputCollectionName_);
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void L1BsMesonSelectionEmulationProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("l1PhiMesonWordInputTag", edm::InputTag("l1PhiMesonSelectionEmulationProducer","Level1PhiMesonEmulationColl"));
+  desc.add<edm::InputTag>("posTrackInputTag", edm::InputTag("l1KaonTrackSelectionProducer", "Level1TTKaonTracksSelectedEmulationPositivecharge"));
+  desc.add<edm::InputTag>("negTrackInputTag", edm::InputTag("l1KaonTrackSelectionProducer", "Level1TTKaonTracksSelectedEmulationNegativecharge"));
+  desc.add<std::string>("outputCollectionName", "Level1BsHadronicEmulationColl");
+  desc.add<int>("debug", 0)->setComment("Verbosity levels: 0, 1, 2, 3");
+  {
+    edm::ParameterSetDescription descCutSet;
+    descCutSet.add<double>("phiPairdzMax", 0.5)->setComment("dz between phi pair must be less than this value, [cm]");
+    descCutSet.add<double>("phiPairdRMin", 0.2)->setComment("dR between phi pair must be greater than this value");
+    descCutSet.add<double>("phiPairdRMax", 1.0)->setComment("dR between phi pair must be less than this value");
+    descCutSet.add<double>("phiPairMMin", 5.0)->setComment("Bs mass must be greater than this value, [GeV]");
+    descCutSet.add<double>("phiPairMMax", 5.8)->setComment("Bs mass must be less than this value, [GeV]");
+    descCutSet.add<double>("bsPtMin", 13.0)->setComment("Bs pt must be greater than this value, [GeV]");
+    desc.add<edm::ParameterSetDescription>("cutSet", descCutSet);
+  }
+  descriptions.addWithDefaultLabel(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(L1BsMesonSelectionEmulationProducer);

--- a/L1Trigger/L1TTrackMatch/plugins/L1BsMesonSelectionEmulationProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1BsMesonSelectionEmulationProducer.cc
@@ -28,8 +28,8 @@
 // Xilinx HLS includes
 #include <ap_fixed.h>
 #include <ap_int.h>
-#include <stdio.h>
 #include <cassert>
+#include <cstdio>
 #include <cstdlib>
 
 // user include files
@@ -67,31 +67,31 @@ using namespace l1t;
 //class L1BsMesonSelectionEmulationProducer : public edm::one::EDProducer<edm::one::SharedResources> {
 class L1BsMesonSelectionEmulationProducer : public edm::global::EDProducer<> {
 public:
-  using L1TTTrackType            = TTTrack<Ref_Phase2TrackerDigi_>;
-  using TTTrackCollection        = std::vector<L1TTTrackType>;
-  //using TTTrackRef               = edm::Ref<TTTrackCollection>; 
-  using TTTrackRefCollection     = edm::RefVector<TTTrackCollection>;
-  using TTTrackCollectionHandle  = edm::Handle<TTTrackRefCollection>;
-  //using TTTrackRefCollectionUPtr = std::unique_ptr<TTTrackRefCollection>; 
+  using L1TTTrackType = TTTrack<Ref_Phase2TrackerDigi_>;
+  using TTTrackCollection = std::vector<L1TTTrackType>;
+  //using TTTrackRef               = edm::Ref<TTTrackCollection>;
+  using TTTrackRefCollection = edm::RefVector<TTTrackCollection>;
+  using TTTrackCollectionHandle = edm::Handle<TTTrackRefCollection>;
+  //using TTTrackRefCollectionUPtr = std::unique_ptr<TTTrackRefCollection>;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   explicit L1BsMesonSelectionEmulationProducer(const edm::ParameterSet&);
-  ~L1BsMesonSelectionEmulationProducer();
-  static constexpr double KaonMass = 0.493677 ;
+  ~L1BsMesonSelectionEmulationProducer() override;
+  static constexpr double KaonMass = 0.493677;
   size_t bsSize = 10;
 
   double ETAPHI_LSB = M_PI / (1 << 12);
   double Z0_LSB = 0.05;
 
 private:
-  // ----------constants, enums and typedefs --------- 
+  // ----------constants, enums and typedefs ---------
   using TkLightMesonWordCollectionHandle = edm::Handle<TkLightMesonWordCollection>;
-  
+
   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
   //void produce(edm::Event&, const edm::EventSetup&) override;
-  
+
   // ----------selectors -----------------------------
   // Based on recommendations from https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideGenericSelectors
-  
+
   // ----------member data ---------------------------
   const edm::EDGetTokenT<TkLightMesonWordCollection> l1PhiMesonWordToken_;
   const edm::EDGetTokenT<TTTrackRefCollection> posTrackToken_;
@@ -106,19 +106,19 @@ private:
 // constructors and destructor
 //
 L1BsMesonSelectionEmulationProducer::L1BsMesonSelectionEmulationProducer(const edm::ParameterSet& iConfig)
-  : l1PhiMesonWordToken_(consumes<TkLightMesonWordCollection>(iConfig.getParameter<edm::InputTag>("l1PhiMesonWordInputTag"))),
-    posTrackToken_(consumes<TTTrackRefCollection>(iConfig.getParameter<edm::InputTag>("posTrackInputTag"))),
-    negTrackToken_(consumes<TTTrackRefCollection>(iConfig.getParameter<edm::InputTag>("negTrackInputTag"))),
-    outputCollectionName_(iConfig.getParameter<std::string>("outputCollectionName")),
-    debug_(iConfig.getParameter<int>("debug")),
-    cutSet_(iConfig.getParameter<edm::ParameterSet>("cutSet")),
-    phiPairdzMax_(cutSet_.getParameter<double>("phiPairdzMax")),
-    phiPairdRMin_(cutSet_.getParameter<double>("phiPairdRMin")),
-    phiPairdRMax_(cutSet_.getParameter<double>("phiPairdRMax")),
-    phiPairMMin_(cutSet_.getParameter<double>("phiPairMMin")),
-    phiPairMMax_(cutSet_.getParameter<double>("phiPairMMax")),
-    bsPtMin_(cutSet_.getParameter<double>("bsPtMin"))
-{
+    : l1PhiMesonWordToken_(
+          consumes<TkLightMesonWordCollection>(iConfig.getParameter<edm::InputTag>("l1PhiMesonWordInputTag"))),
+      posTrackToken_(consumes<TTTrackRefCollection>(iConfig.getParameter<edm::InputTag>("posTrackInputTag"))),
+      negTrackToken_(consumes<TTTrackRefCollection>(iConfig.getParameter<edm::InputTag>("negTrackInputTag"))),
+      outputCollectionName_(iConfig.getParameter<std::string>("outputCollectionName")),
+      debug_(iConfig.getParameter<int>("debug")),
+      cutSet_(iConfig.getParameter<edm::ParameterSet>("cutSet")),
+      phiPairdzMax_(cutSet_.getParameter<double>("phiPairdzMax")),
+      phiPairdRMin_(cutSet_.getParameter<double>("phiPairdRMin")),
+      phiPairdRMax_(cutSet_.getParameter<double>("phiPairdRMax")),
+      phiPairMMin_(cutSet_.getParameter<double>("phiPairMMin")),
+      phiPairMMax_(cutSet_.getParameter<double>("phiPairMMax")),
+      bsPtMin_(cutSet_.getParameter<double>("bsPtMin")) {
   produces<l1t::TkLightMesonWordCollection>(outputCollectionName_);
 }
 
@@ -127,30 +127,33 @@ L1BsMesonSelectionEmulationProducer::~L1BsMesonSelectionEmulationProducer() {}
 // member functions
 //
 // ------------ method called to produce the data  ------------
-void L1BsMesonSelectionEmulationProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
-//void L1BsMesonSelectionEmulationProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)  {
+void L1BsMesonSelectionEmulationProducer::produce(edm::StreamID,
+                                                  edm::Event& iEvent,
+                                                  const edm::EventSetup& iSetup) const {
+  //void L1BsMesonSelectionEmulationProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)  {
 
   auto L1BsMesonEmulationOutput = std::make_unique<l1t::TkLightMesonWordCollection>();
 
   TkLightMesonWordCollectionHandle l1PhiMesonWordHandle;
   iEvent.getByToken(l1PhiMesonWordToken_, l1PhiMesonWordHandle);
   size_t nPhiMesonOutputApproximate = l1PhiMesonWordHandle->size();
-  if(nPhiMesonOutputApproximate < 2) return;
-  
+  if (nPhiMesonOutputApproximate < 2)
+    return;
+
   TTTrackCollectionHandle posTrackHandle;
   iEvent.getByToken(posTrackToken_, posTrackHandle);
-  
+
   TTTrackCollectionHandle negTrackHandle;
   iEvent.getByToken(negTrackToken_, negTrackHandle);
 
   L1BsMesonEmulationOutput->reserve(bsSize);
 
   for (size_t i = 0; i < nPhiMesonOutputApproximate; i++) {
-    const auto& phiMesonWord1 = l1PhiMesonWordHandle->at(i);        
-    double ptPhi1   = phiMesonWord1.pt();
-    double etaPhi1  = phiMesonWord1.glbeta();
-    double phiPhi1  = phiMesonWord1.glbphi();
-    double z0Phi1   = phiMesonWord1.z0();
+    const auto& phiMesonWord1 = l1PhiMesonWordHandle->at(i);
+    double ptPhi1 = phiMesonWord1.pt();
+    double etaPhi1 = phiMesonWord1.glbeta();
+    double phiPhi1 = phiMesonWord1.glbphi();
+    double z0Phi1 = phiMesonWord1.z0();
     double massPhi1 = phiMesonWord1.mass();
 
     unsigned int pIndexPhi1 = phiMesonWord1.firstIndex();
@@ -159,56 +162,62 @@ void L1BsMesonSelectionEmulationProducer::produce(edm::StreamID, edm::Event& iEv
     double pxPhi1 = ptPhi1 * cos(phiPhi1);
     double pyPhi1 = ptPhi1 * sin(phiPhi1);
     double pzPhi1 = ptPhi1 * sinh(etaPhi1);
-    double ePhi1  = sqrt(pow(ptPhi1, 2) + pow(pzPhi1, 2) + pow(massPhi1, 2));    
+    double ePhi1 = sqrt(pow(ptPhi1, 2) + pow(pzPhi1, 2) + pow(massPhi1, 2));
 
-    for (size_t j = i+1; j < nPhiMesonOutputApproximate; j++) {
+    for (size_t j = i + 1; j < nPhiMesonOutputApproximate; j++) {
       const auto& phiMesonWord2 = l1PhiMesonWordHandle->at(j);
-      
-      double ptPhi2   = phiMesonWord2.pt();
-      double etaPhi2  = phiMesonWord2.glbeta();
-      double phiPhi2  = phiMesonWord2.glbphi();
-      double z0Phi2   = phiMesonWord2.z0();
+
+      double ptPhi2 = phiMesonWord2.pt();
+      double etaPhi2 = phiMesonWord2.glbeta();
+      double phiPhi2 = phiMesonWord2.glbphi();
+      double z0Phi2 = phiMesonWord2.z0();
       double massPhi2 = phiMesonWord2.mass();
 
       // Ensure that the 2 Phi mesons are made of 4 distinct tracks
       unsigned int pIndexPhi2 = phiMesonWord2.firstIndex();
       unsigned int nIndexPhi2 = phiMesonWord2.secondIndex();
-      if (pIndexPhi1 == pIndexPhi2 || nIndexPhi1 == nIndexPhi2) continue;
+      if (pIndexPhi1 == pIndexPhi2 || nIndexPhi1 == nIndexPhi2)
+        continue;
 
       double pxPhi2 = ptPhi2 * cos(phiPhi2);
       double pyPhi2 = ptPhi2 * sin(phiPhi2);
       double pzPhi2 = ptPhi2 * sinh(etaPhi2);
-      double ePhi2  = sqrt(pow(ptPhi2, 2) + pow(pzPhi2, 2) + pow(massPhi2, 2));
-      
+      double ePhi2 = sqrt(pow(ptPhi2, 2) + pow(pzPhi2, 2) + pow(massPhi2, 2));
+
       double pxBs = pxPhi1 + pxPhi2;
       double pyBs = pyPhi1 + pyPhi2;
       double pzBs = pzPhi1 + pzPhi2;
-      double eBs  = ePhi1  + ePhi2;
+      double eBs = ePhi1 + ePhi2;
 
-      if (std::fabs(z0Phi1 - z0Phi2) > phiPairdzMax_) continue;
-  
+      if (std::fabs(z0Phi1 - z0Phi2) > phiPairdzMax_)
+        continue;
+
       double drPhiPair = reco::deltaR(etaPhi1, phiPhi1, etaPhi2, phiPhi2);
-      if (drPhiPair < phiPairdRMin_ || drPhiPair > phiPairdRMax_) continue;
-      
+      if (drPhiPair < phiPairdRMin_ || drPhiPair > phiPairdRMax_)
+        continue;
+
       double massPhiPair = sqrt(pow(eBs, 2) - pow(pxBs, 2) - pow(pyBs, 2) - pow(pzBs, 2));
-      if (massPhiPair < phiPairMMin_ || massPhiPair > phiPairMMax_) continue;
-      
+      if (massPhiPair < phiPairMMin_ || massPhiPair > phiPairMMax_)
+        continue;
+
       double pt = sqrt(pow(pxBs, 2) + pow(pyBs, 2));
-      if (pt < bsPtMin_) continue;
-      
+      if (pt < bsPtMin_)
+        continue;
+
       l1t::TkLightMesonWord::valid_t validBs = phiMesonWord1.valid() && phiMesonWord2.valid();
       l1t::TkLightMesonWord::pt_t ptBs = sqrt(pow(pxBs, 2) + pow(pyBs, 2));
       l1t::TkLightMesonWord::glbphi_t phiBs = atan2(pyBs, pxBs) / ETAPHI_LSB;
-      l1t::TkLightMesonWord::glbeta_t etaBs = asinh(pzBs/sqrt(pow(pxBs, 2) + pow(pyBs, 2))) / ETAPHI_LSB;
+      l1t::TkLightMesonWord::glbeta_t etaBs = asinh(pzBs / sqrt(pow(pxBs, 2) + pow(pyBs, 2))) / ETAPHI_LSB;
       l1t::TkLightMesonWord::z0_t z0Bs = ((z0Phi1 + z0Phi2) / Z0_LSB) * 0.5;
-      l1t::TkLightMesonWord::mass_t massBs  = sqrt(pow(eBs, 2) - pow(pxBs, 2) - pow(pyBs, 2) - pow(pzBs, 2));
+      l1t::TkLightMesonWord::mass_t massBs = sqrt(pow(eBs, 2) - pow(pxBs, 2) - pow(pyBs, 2) - pow(pzBs, 2));
       l1t::TkLightMesonWord::type_t typeBs = l1t::TkLightMesonWord::TkLightMesonTypes::kBsType;
       l1t::TkLightMesonWord::ntracks_t ntracksBs = 3;
-      l1t::TkLightMesonWord::index_t firstPhiIndex     = i;
-      l1t::TkLightMesonWord::index_t secondPhiIndex    = j;
+      l1t::TkLightMesonWord::index_t firstPhiIndex = i;
+      l1t::TkLightMesonWord::index_t secondPhiIndex = j;
       l1t::TkLightMesonWord::unassigned_t unassignedBs = 0;
 
-      l1t::TkLightMesonWord bsWord(validBs, ptBs, phiBs, etaBs, z0Bs, massBs, typeBs, ntracksBs, firstPhiIndex, secondPhiIndex, unassignedBs); 
+      l1t::TkLightMesonWord bsWord(
+          validBs, ptBs, phiBs, etaBs, z0Bs, massBs, typeBs, ntracksBs, firstPhiIndex, secondPhiIndex, unassignedBs);
       L1BsMesonEmulationOutput->push_back(bsWord);
     }
   }
@@ -219,9 +228,14 @@ void L1BsMesonSelectionEmulationProducer::produce(edm::StreamID, edm::Event& iEv
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void L1BsMesonSelectionEmulationProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("l1PhiMesonWordInputTag", edm::InputTag("l1PhiMesonSelectionEmulationProducer","Level1PhiMesonEmulationColl"));
-  desc.add<edm::InputTag>("posTrackInputTag", edm::InputTag("l1KaonTrackSelectionProducer", "Level1TTKaonTracksSelectedEmulationPositivecharge"));
-  desc.add<edm::InputTag>("negTrackInputTag", edm::InputTag("l1KaonTrackSelectionProducer", "Level1TTKaonTracksSelectedEmulationNegativecharge"));
+  desc.add<edm::InputTag>("l1PhiMesonWordInputTag",
+                          edm::InputTag("l1PhiMesonSelectionEmulationProducer", "Level1PhiMesonEmulationColl"));
+  desc.add<edm::InputTag>(
+      "posTrackInputTag",
+      edm::InputTag("l1KaonTrackSelectionProducer", "Level1TTKaonTracksSelectedEmulationPositivecharge"));
+  desc.add<edm::InputTag>(
+      "negTrackInputTag",
+      edm::InputTag("l1KaonTrackSelectionProducer", "Level1TTKaonTracksSelectedEmulationNegativecharge"));
   desc.add<std::string>("outputCollectionName", "Level1BsHadronicEmulationColl");
   desc.add<int>("debug", 0)->setComment("Verbosity levels: 0, 1, 2, 3");
   {

--- a/L1Trigger/L1TTrackMatch/plugins/L1BsMesonSelectionProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1BsMesonSelectionProducer.cc
@@ -14,10 +14,10 @@
          l1t::TkBsCandidateCollection - A collection of reconstructed Bs meson candidates
 
 */
-// ----------------------------------------------------------------------------                                                                                                       
+// ----------------------------------------------------------------------------
 // Authors: Alexx Perloff, Pritam Palit (original version, 2021),
 //          Sweta Baradia, Suchandra Dutta, Subir Sarkar (February 2025)
-//-----------------------------------------------------------------------------  
+//-----------------------------------------------------------------------------
 
 // system include files
 #include <algorithm>
@@ -69,19 +69,19 @@ using namespace l1t;
 class L1BsMesonSelectionProducer : public edm::one::EDProducer<edm::one::SharedResources> {
   //class L1BsMesonSelectionProducer : public edm::global::EDProducer<> {
 public:
-  using L1TTTrackType            = TTTrack<Ref_Phase2TrackerDigi_>;
-  using TTTrackCollection        = std::vector<L1TTTrackType>;
-  using TTTrackRefCollection     = edm::RefVector<TTTrackCollection>;
-  using TTTrackCollectionHandle  = edm::Handle<TTTrackRefCollection>;
+  using L1TTTrackType = TTTrack<Ref_Phase2TrackerDigi_>;
+  using TTTrackCollection = std::vector<L1TTTrackType>;
+  using TTTrackRefCollection = edm::RefVector<TTTrackCollection>;
+  using TTTrackCollectionHandle = edm::Handle<TTTrackRefCollection>;
   using L1TTStubCollection =
-    std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>>;
+      std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>>;
 
   explicit L1BsMesonSelectionProducer(const edm::ParameterSet&);
   ~L1BsMesonSelectionProducer() override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  static constexpr double KaonMass = 0.493677; // GeV
+  static constexpr double KaonMass = 0.493677;  // GeV
   size_t bsSize = 10;
-    
+
 private:
   // ----------constants, enums and typedefs ---------
   using TkPhiCandidateCollectionHandle = edm::Handle<TkPhiCandidateCollection>;
@@ -108,33 +108,32 @@ private:
 //
 L1BsMesonSelectionProducer::L1BsMesonSelectionProducer(const edm::ParameterSet& iConfig)
     : l1PhiCandToken_(consumes<TkPhiCandidateCollection>(iConfig.getParameter<edm::InputTag>("l1PhiCandInputTag"))),
-    tTopoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd>(edm::ESInputTag("", ""))),
-    posTrackToken_(consumes<TTTrackRefCollection>(iConfig.getParameter<edm::InputTag>("posTrackInputTag"))),
-    negTrackToken_(consumes<TTTrackRefCollection>(iConfig.getParameter<edm::InputTag>("negTrackInputTag"))),
-    outputCollectionName_(iConfig.getParameter<string>("outputCollectionName")),
-    debug_(iConfig.getParameter<int>("debug")),
-    cutSet_(iConfig.getParameter<edm::ParameterSet>("cutSet")),
-    phiPairdzMax_(cutSet_.getParameter<double>("phiPairdzMax")),
-    phiPairdRMin_(cutSet_.getParameter<double>("phiPairdRMin")),
-    phiPairdRMax_(cutSet_.getParameter<double>("phiPairdRMax")),
-    phiPairMMin_(cutSet_.getParameter<double>("phiPairMMin")),
-    phiPairMMax_(cutSet_.getParameter<double>("phiPairMMax")),
-    bsPtMin_(cutSet_.getParameter<double>("bsPtMin"))
-{
+      tTopoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd>(edm::ESInputTag("", ""))),
+      posTrackToken_(consumes<TTTrackRefCollection>(iConfig.getParameter<edm::InputTag>("posTrackInputTag"))),
+      negTrackToken_(consumes<TTTrackRefCollection>(iConfig.getParameter<edm::InputTag>("negTrackInputTag"))),
+      outputCollectionName_(iConfig.getParameter<string>("outputCollectionName")),
+      debug_(iConfig.getParameter<int>("debug")),
+      cutSet_(iConfig.getParameter<edm::ParameterSet>("cutSet")),
+      phiPairdzMax_(cutSet_.getParameter<double>("phiPairdzMax")),
+      phiPairdRMin_(cutSet_.getParameter<double>("phiPairdRMin")),
+      phiPairdRMax_(cutSet_.getParameter<double>("phiPairdRMax")),
+      phiPairMMin_(cutSet_.getParameter<double>("phiPairMMin")),
+      phiPairMMax_(cutSet_.getParameter<double>("phiPairMMax")),
+      bsPtMin_(cutSet_.getParameter<double>("bsPtMin")) {
   produces<TkBsCandidateCollection>(outputCollectionName_);
 }
 
 L1BsMesonSelectionProducer::~L1BsMesonSelectionProducer() {}
 // ------------ method called to produce the data  ------------
 //void L1BsMesonSelectionProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
-  void L1BsMesonSelectionProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)  {
-
+void L1BsMesonSelectionProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   auto L1BsMesonOutput = std::make_unique<TkBsCandidateCollection>();
 
   TkPhiCandidateCollectionHandle l1PhiCandHandle;
   iEvent.getByToken(l1PhiCandToken_, l1PhiCandHandle);
   size_t nPhiMeson = l1PhiCandHandle->size();
-  if (nPhiMeson < 2) return;
+  if (nPhiMeson < 2)
+    return;
 
   TTTrackCollectionHandle posTrackHandle;
   iEvent.getByToken(posTrackToken_, posTrackHandle);
@@ -142,68 +141,73 @@ L1BsMesonSelectionProducer::~L1BsMesonSelectionProducer() {}
   TTTrackCollectionHandle negTrackHandle;
   iEvent.getByToken(negTrackToken_, negTrackHandle);
 
-
   // Tracker Topology
   const TrackerTopology& tTopo = iSetup.getData(tTopoToken_);
-  
+
   L1BsMesonOutput->reserve(bsSize);
 
   for (size_t i = 0; i < nPhiMeson; i++) {
     const auto& phiCand1 = l1PhiCandHandle->at(i);
     const math::XYZTLorentzVector& phiCand1P4 = phiCand1.p4();
-    double ptPhi1   = phiCand1P4.Pt();
-    double etaPhi1  = phiCand1P4.Eta();
-    double phiPhi1  = phiCand1P4.Phi();
-    double massPhi1 = phiCand1P4.M();       
+    double ptPhi1 = phiCand1P4.Pt();
+    double etaPhi1 = phiCand1P4.Eta();
+    double phiPhi1 = phiCand1P4.Phi();
+    double massPhi1 = phiCand1P4.M();
     math::PtEtaPhiMLorentzVector phi1P4(ptPhi1, etaPhi1, phiPhi1, massPhi1);
 
     const auto& trka_p = phiCand1.trkPtr(0);
     const auto& trka_n = phiCand1.trkPtr(1);
 
-    for (size_t j = i+1; j < nPhiMeson; j++) {
-      const auto& phiCand2 = l1PhiCandHandle->at(j);      
+    for (size_t j = i + 1; j < nPhiMeson; j++) {
+      const auto& phiCand2 = l1PhiCandHandle->at(j);
       // Must ensure that the 2 Phi mesons are made of 4 distinct tracks
       // this is non-trivial if the reconstructed Phi mesons do not store reference to the parent tracks
       const auto& trkb_p = phiCand2.trkPtr(0);
       const auto& trkb_n = phiCand2.trkPtr(1);
-      if (trka_p == trkb_p || trka_n == trkb_n) continue;
+      if (trka_p == trkb_p || trka_n == trkb_n)
+        continue;
 
       const math::XYZTLorentzVector& phiCand2P4 = phiCand2.p4();
-      double ptPhi2   = phiCand2P4.Pt();
-      double etaPhi2  = phiCand2P4.Eta();
-      double phiPhi2  = phiCand2P4.Phi();
-      double massPhi2 = phiCand2P4.M();       
-      math::PtEtaPhiMLorentzVector phi2P4(ptPhi2, etaPhi2, phiPhi2, massPhi2);    
-      
+      double ptPhi2 = phiCand2P4.Pt();
+      double etaPhi2 = phiCand2P4.Eta();
+      double phiPhi2 = phiCand2P4.Phi();
+      double massPhi2 = phiCand2P4.M();
+      math::PtEtaPhiMLorentzVector phi2P4(ptPhi2, etaPhi2, phiPhi2, massPhi2);
+
       math::PtEtaPhiMLorentzVector tempP4 = phi1P4 + phi2P4;
       math::XYZTLorentzVector bsP4(tempP4.Px(), tempP4.Py(), tempP4.Pz(), tempP4.E());
-      TkBsCandidate tkBs(bsP4, phiCand1, phiCand2);      
+      TkBsCandidate tkBs(bsP4, phiCand1, phiCand2);
       double dzPhiPair = tkBs.dzPhiPair();
-  
-      if (std::fabs(dzPhiPair) > phiPairdzMax_) continue;
-        
+
+      if (std::fabs(dzPhiPair) > phiPairdzMax_)
+        continue;
+
       double drPhiPair = tkBs.dRPhiPair();
-      if (drPhiPair < phiPairdRMin_ || drPhiPair > phiPairdRMax_) continue;
-      
+      if (drPhiPair < phiPairdRMin_ || drPhiPair > phiPairdRMax_)
+        continue;
+
       double mass = tkBs.p4().M();
-      if (mass < phiPairMMin_ || mass > phiPairMMax_) continue;
-      
-      if (tkBs.p4().Pt() < bsPtMin_) continue;
-      
+      if (mass < phiPairMMin_ || mass > phiPairMMax_)
+        continue;
+
+      if (tkBs.p4().Pt() < bsPtMin_)
+        continue;
+
       L1BsMesonOutput->push_back(tkBs);
     }
   }
-  
+
   // Put the outputs into the event
   iEvent.put(std::move(L1BsMesonOutput), outputCollectionName_);
-
 }
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void L1BsMesonSelectionProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("l1PhiCandInputTag", edm::InputTag("l1PhiMesonSelectionProducer","Level1PhiMesonColl"));
-  desc.add<edm::InputTag>("posTrackInputTag", edm::InputTag("l1KaonTrackSelectionProducer","Level1TTKaonTracksSelectedPositivecharge"));
-  desc.add<edm::InputTag>("negTrackInputTag", edm::InputTag("l1KaonTrackSelectionProducer","Level1TTKaonTracksSelectedNegativecharge"));
+  desc.add<edm::InputTag>("l1PhiCandInputTag", edm::InputTag("l1PhiMesonSelectionProducer", "Level1PhiMesonColl"));
+  desc.add<edm::InputTag>("posTrackInputTag",
+                          edm::InputTag("l1KaonTrackSelectionProducer", "Level1TTKaonTracksSelectedPositivecharge"));
+  desc.add<edm::InputTag>("negTrackInputTag",
+                          edm::InputTag("l1KaonTrackSelectionProducer", "Level1TTKaonTracksSelectedNegativecharge"));
   desc.add<string>("outputCollectionName", "Level1BsHadronicColl");
   desc.add<int>("debug", 0)->setComment("Verbosity levels: 0, 1, 2, 3");
   {

--- a/L1Trigger/L1TTrackMatch/plugins/L1BsMesonSelectionProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1BsMesonSelectionProducer.cc
@@ -1,0 +1,222 @@
+// -*- C++ -*-
+//
+// Package:    L1Trigger/L1TTrackMatch
+// Class:      L1BsMesonSelectionProducer
+//
+/**\class L1BsMesonSelectionProducer L1BsMesonSelectionProducer.cc L1Trigger/L1TTrackMatch/plugins/L1BsMesonSelectionProducer.cc
+
+ Description: Build Bs meson candidates from Phi collection
+
+ Implementation:
+     Inputs:
+         l1t::TkPhiCandidateCollection - A collection of reconstructed Phi meson candidates
+     Outputs:
+         l1t::TkBsCandidateCollection - A collection of reconstructed Bs meson candidates
+
+*/
+// ----------------------------------------------------------------------------                                                                                                       
+// Authors: Alexx Perloff, Pritam Palit (original version, 2021),
+//          Sweta Baradia, Suchandra Dutta, Subir Sarkar (February 2025)
+//-----------------------------------------------------------------------------  
+
+// system include files
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+#include <TMath.h>
+#include <cmath>
+#include <array>
+
+// user include files
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/RefVector.h"
+#include "DataFormats/Common/interface/RefToPtr.h"
+#include "DataFormats/L1TCorrelator/interface/TkPhiCandidate.h"
+#include "DataFormats/L1TCorrelator/interface/TkBsCandidate.h"
+#include "DataFormats/L1TCorrelator/interface/TkPhiCandidateFwd.h"
+#include "DataFormats/L1TCorrelator/interface/TkBsCandidateFwd.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+#include "DataFormats/Math/interface/LorentzVector.h"
+
+#include "DataFormats/L1TrackTrigger/interface/TTStub.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTrack.h"
+
+//
+// class declaration
+
+//
+using namespace std;
+using namespace edm;
+using namespace l1t;
+
+class L1BsMesonSelectionProducer : public edm::one::EDProducer<edm::one::SharedResources> {
+  //class L1BsMesonSelectionProducer : public edm::global::EDProducer<> {
+public:
+  using L1TTTrackType            = TTTrack<Ref_Phase2TrackerDigi_>;
+  using TTTrackCollection        = std::vector<L1TTTrackType>;
+  using TTTrackRefCollection     = edm::RefVector<TTTrackCollection>;
+  using TTTrackCollectionHandle  = edm::Handle<TTTrackRefCollection>;
+  using L1TTStubCollection =
+    std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>>;
+
+  explicit L1BsMesonSelectionProducer(const edm::ParameterSet&);
+  ~L1BsMesonSelectionProducer() override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static constexpr double KaonMass = 0.493677; // GeV
+  size_t bsSize = 10;
+    
+private:
+  // ----------constants, enums and typedefs ---------
+  using TkPhiCandidateCollectionHandle = edm::Handle<TkPhiCandidateCollection>;
+  // ----------member functions ----------------------
+  //void produce(edm::StreamID, edm::Event&, const edm::EventSetup&)  const override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  // ----------selectors -----------------------------
+  // Based on recommendations from https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideGenericSelectors
+
+  // ----------member data ---------------------------
+  const edm::EDGetTokenT<TkPhiCandidateCollection> l1PhiCandToken_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
+  const edm::EDGetTokenT<TTTrackRefCollection> posTrackToken_;
+  const edm::EDGetTokenT<TTTrackRefCollection> negTrackToken_;
+
+  const std::string outputCollectionName_;
+  int debug_;
+  const edm::ParameterSet cutSet_;
+  const double phiPairdzMax_, phiPairdRMin_, phiPairdRMax_, phiPairMMin_, phiPairMMax_, bsPtMin_;
+};
+
+//
+// constructors and destructor
+//
+L1BsMesonSelectionProducer::L1BsMesonSelectionProducer(const edm::ParameterSet& iConfig)
+    : l1PhiCandToken_(consumes<TkPhiCandidateCollection>(iConfig.getParameter<edm::InputTag>("l1PhiCandInputTag"))),
+    tTopoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd>(edm::ESInputTag("", ""))),
+    posTrackToken_(consumes<TTTrackRefCollection>(iConfig.getParameter<edm::InputTag>("posTrackInputTag"))),
+    negTrackToken_(consumes<TTTrackRefCollection>(iConfig.getParameter<edm::InputTag>("negTrackInputTag"))),
+    outputCollectionName_(iConfig.getParameter<string>("outputCollectionName")),
+    debug_(iConfig.getParameter<int>("debug")),
+    cutSet_(iConfig.getParameter<edm::ParameterSet>("cutSet")),
+    phiPairdzMax_(cutSet_.getParameter<double>("phiPairdzMax")),
+    phiPairdRMin_(cutSet_.getParameter<double>("phiPairdRMin")),
+    phiPairdRMax_(cutSet_.getParameter<double>("phiPairdRMax")),
+    phiPairMMin_(cutSet_.getParameter<double>("phiPairMMin")),
+    phiPairMMax_(cutSet_.getParameter<double>("phiPairMMax")),
+    bsPtMin_(cutSet_.getParameter<double>("bsPtMin"))
+{
+  produces<TkBsCandidateCollection>(outputCollectionName_);
+}
+
+L1BsMesonSelectionProducer::~L1BsMesonSelectionProducer() {}
+// ------------ method called to produce the data  ------------
+//void L1BsMesonSelectionProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  void L1BsMesonSelectionProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)  {
+
+  auto L1BsMesonOutput = std::make_unique<TkBsCandidateCollection>();
+
+  TkPhiCandidateCollectionHandle l1PhiCandHandle;
+  iEvent.getByToken(l1PhiCandToken_, l1PhiCandHandle);
+  size_t nPhiMeson = l1PhiCandHandle->size();
+  if (nPhiMeson < 2) return;
+
+  TTTrackCollectionHandle posTrackHandle;
+  iEvent.getByToken(posTrackToken_, posTrackHandle);
+
+  TTTrackCollectionHandle negTrackHandle;
+  iEvent.getByToken(negTrackToken_, negTrackHandle);
+
+
+  // Tracker Topology
+  const TrackerTopology& tTopo = iSetup.getData(tTopoToken_);
+  
+  L1BsMesonOutput->reserve(bsSize);
+
+  for (size_t i = 0; i < nPhiMeson; i++) {
+    const auto& phiCand1 = l1PhiCandHandle->at(i);
+    const math::XYZTLorentzVector& phiCand1P4 = phiCand1.p4();
+    double ptPhi1   = phiCand1P4.Pt();
+    double etaPhi1  = phiCand1P4.Eta();
+    double phiPhi1  = phiCand1P4.Phi();
+    double massPhi1 = phiCand1P4.M();       
+    math::PtEtaPhiMLorentzVector phi1P4(ptPhi1, etaPhi1, phiPhi1, massPhi1);
+
+    const auto& trka_p = phiCand1.trkPtr(0);
+    const auto& trka_n = phiCand1.trkPtr(1);
+
+    for (size_t j = i+1; j < nPhiMeson; j++) {
+      const auto& phiCand2 = l1PhiCandHandle->at(j);      
+      // Must ensure that the 2 Phi mesons are made of 4 distinct tracks
+      // this is non-trivial if the reconstructed Phi mesons do not store reference to the parent tracks
+      const auto& trkb_p = phiCand2.trkPtr(0);
+      const auto& trkb_n = phiCand2.trkPtr(1);
+      if (trka_p == trkb_p || trka_n == trkb_n) continue;
+
+      const math::XYZTLorentzVector& phiCand2P4 = phiCand2.p4();
+      double ptPhi2   = phiCand2P4.Pt();
+      double etaPhi2  = phiCand2P4.Eta();
+      double phiPhi2  = phiCand2P4.Phi();
+      double massPhi2 = phiCand2P4.M();       
+      math::PtEtaPhiMLorentzVector phi2P4(ptPhi2, etaPhi2, phiPhi2, massPhi2);    
+      
+      math::PtEtaPhiMLorentzVector tempP4 = phi1P4 + phi2P4;
+      math::XYZTLorentzVector bsP4(tempP4.Px(), tempP4.Py(), tempP4.Pz(), tempP4.E());
+      TkBsCandidate tkBs(bsP4, phiCand1, phiCand2);      
+      double dzPhiPair = tkBs.dzPhiPair();
+  
+      if (std::fabs(dzPhiPair) > phiPairdzMax_) continue;
+        
+      double drPhiPair = tkBs.dRPhiPair();
+      if (drPhiPair < phiPairdRMin_ || drPhiPair > phiPairdRMax_) continue;
+      
+      double mass = tkBs.p4().M();
+      if (mass < phiPairMMin_ || mass > phiPairMMax_) continue;
+      
+      if (tkBs.p4().Pt() < bsPtMin_) continue;
+      
+      L1BsMesonOutput->push_back(tkBs);
+    }
+  }
+  
+  // Put the outputs into the event
+  iEvent.put(std::move(L1BsMesonOutput), outputCollectionName_);
+
+}
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void L1BsMesonSelectionProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("l1PhiCandInputTag", edm::InputTag("l1PhiMesonSelectionProducer","Level1PhiMesonColl"));
+  desc.add<edm::InputTag>("posTrackInputTag", edm::InputTag("l1KaonTrackSelectionProducer","Level1TTKaonTracksSelectedPositivecharge"));
+  desc.add<edm::InputTag>("negTrackInputTag", edm::InputTag("l1KaonTrackSelectionProducer","Level1TTKaonTracksSelectedNegativecharge"));
+  desc.add<string>("outputCollectionName", "Level1BsHadronicColl");
+  desc.add<int>("debug", 0)->setComment("Verbosity levels: 0, 1, 2, 3");
+  {
+    edm::ParameterSetDescription descCutSet;
+    descCutSet.add<double>("phiPairdzMax", 0.5)->setComment("dz between phi pair must be less than this value, [cm]");
+    descCutSet.add<double>("phiPairdRMin", 0.2)->setComment("dR between phi pair must be greater than this value");
+    descCutSet.add<double>("phiPairdRMax", 1.0)->setComment("dR between phi pair must be less than this value");
+    descCutSet.add<double>("phiPairMMin", 5.0)->setComment("Bs mass must be greater than this value, [GeV]");
+    descCutSet.add<double>("phiPairMMax", 5.8)->setComment("Bs mass must be less than this value, [GeV]");
+    descCutSet.add<double>("bsPtMin", 13.0)->setComment("Bs pT must be greater than this value, [GeV]");
+    desc.add<edm::ParameterSetDescription>("cutSet", descCutSet);
+  }
+  descriptions.addWithDefaultLabel(desc);
+}
+//define this as a plug-in
+DEFINE_FWK_MODULE(L1BsMesonSelectionProducer);

--- a/L1Trigger/L1TTrackMatch/plugins/L1KaonTrackSelectionProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1KaonTrackSelectionProducer.cc
@@ -17,7 +17,7 @@
 */
 //----------------------------------------------------------------------------
 // Authors: Alexx Perloff, Pritam Palit (original version, 2021),
-//          Sweta Baradia, Suchandra Dutta, Subir Sarkar (February 2025)  
+//          Sweta Baradia, Suchandra Dutta, Subir Sarkar (February 2025)
 //----------------------------------------------------------------------------
 // system include files
 #include <algorithm>
@@ -68,11 +68,11 @@ public:
 
 private:
   // ----------constants, enums and typedefs ---------
-  using L1Track                  = TTTrack<Ref_Phase2TrackerDigi_>;
-  using TTTrackCollection        = std::vector<L1Track>;
-  using TTTrackRef               = edm::Ref<TTTrackCollection>;
-  using TTTrackRefCollection     = edm::RefVector<TTTrackCollection>;
-  using TTTrackCollectionHandle  = edm::Handle<TTTrackRefCollection>;
+  using L1Track = TTTrack<Ref_Phase2TrackerDigi_>;
+  using TTTrackCollection = std::vector<L1Track>;
+  using TTTrackRef = edm::Ref<TTTrackCollection>;
+  using TTTrackRefCollection = edm::RefVector<TTTrackCollection>;
+  using TTTrackCollectionHandle = edm::Handle<TTTrackRefCollection>;
   using TTTrackRefCollectionUPtr = std::unique_ptr<TTTrackRefCollection>;
 
   // ----------meprintDebugInfomber functions ----------------------
@@ -80,13 +80,13 @@ private:
 
   // ----------selectors -----------------------------
   // Based on recommendations from https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideGenericSelectors
-  // Track charge selection 
+  // Track charge selection
 
-  bool TTTrackChargeSelector(const L1Track& t) const { return std::signbit(t.rInv()) ;}; 
+  bool TTTrackChargeSelector(const L1Track& t) const { return std::signbit(t.rInv()); };
 
-  bool TTTrackWordChargeSelector (const L1Track& t) const {
-    ap_uint<1> chargeEmulationBits = t.getTrackWord()(
-	       TTTrack_TrackWord::TrackBitLocations::kRinvMSB, TTTrack_TrackWord::TrackBitLocations::kRinvMSB);
+  bool TTTrackWordChargeSelector(const L1Track& t) const {
+    ap_uint<1> chargeEmulationBits = t.getTrackWord()(TTTrack_TrackWord::TrackBitLocations::kRinvMSB,
+                                                      TTTrack_TrackWord::TrackBitLocations::kRinvMSB);
     return chargeEmulationBits.to_uint();
   };
 
@@ -101,16 +101,16 @@ private:
 // constructors and destructor
 //
 L1KaonTrackSelectionProducer::L1KaonTrackSelectionProducer(const edm::ParameterSet& iConfig)
-  : l1TracksToken_(consumes<TTTrackRefCollection>(iConfig.getParameter<edm::InputTag>("l1TracksInputTag"))),
-    outputCollectionName_(iConfig.getParameter<std::string>("outputCollectionName")),
-    processSimulatedTracks_(iConfig.getParameter<bool>("processSimulatedTracks")),
-    processEmulatedTracks_(iConfig.getParameter<bool>("processEmulatedTracks")),
-    debug_(iConfig.getParameter<int>("debug")) {
+    : l1TracksToken_(consumes<TTTrackRefCollection>(iConfig.getParameter<edm::InputTag>("l1TracksInputTag"))),
+      outputCollectionName_(iConfig.getParameter<std::string>("outputCollectionName")),
+      processSimulatedTracks_(iConfig.getParameter<bool>("processSimulatedTracks")),
+      processEmulatedTracks_(iConfig.getParameter<bool>("processEmulatedTracks")),
+      debug_(iConfig.getParameter<int>("debug")) {
   // Ensure that the configuration makes sense
   if (!processSimulatedTracks_ && !processEmulatedTracks_) {
     throw cms::Exception("You must process at least one of the track collections (simulated or emulated).");
   }
- 
+
   // Get additional input tags and define the EDM output based on the previous configuration parameters
   if (processSimulatedTracks_) {
     produces<TTTrackRefCollection>(outputCollectionName_ + "Positivecharge");
@@ -138,16 +138,16 @@ void L1KaonTrackSelectionProducer::produce(edm::StreamID, edm::Event& iEvent, co
   TTTrackCollectionHandle l1TracksHandle;
   iEvent.getByToken(l1TracksToken_, l1TracksHandle);
   size_t nTracks = l1TracksHandle->size();
-  if (!nTracks) return;
+  if (!nTracks)
+    return;
 
-  
   if (processSimulatedTracks_) {
-    vTTPosTrackOutput->reserve(static_cast<std::size_t>(std::round(nTracks*0.6)));
-    vTTNegTrackOutput->reserve(static_cast<std::size_t>(std::round(nTracks*0.6)));
+    vTTPosTrackOutput->reserve(static_cast<std::size_t>(std::round(nTracks * 0.6)));
+    vTTNegTrackOutput->reserve(static_cast<std::size_t>(std::round(nTracks * 0.6)));
   }
   if (processEmulatedTracks_) {
-    vTTPosTrackEmulationOutput->reserve(static_cast<std::size_t>(std::round(nTracks*0.6)));
-    vTTNegTrackEmulationOutput->reserve(static_cast<std::size_t>(std::round(nTracks*0.6)));
+    vTTPosTrackEmulationOutput->reserve(static_cast<std::size_t>(std::round(nTracks * 0.6)));
+    vTTNegTrackEmulationOutput->reserve(static_cast<std::size_t>(std::round(nTracks * 0.6)));
   }
 
   for (size_t i = 0; i < nTracks; i++) {
@@ -156,15 +156,14 @@ void L1KaonTrackSelectionProducer::produce(edm::StreamID, edm::Event& iEvent, co
 
     // Select tracks based on the floating point TTTrack
     if (processSimulatedTracks_) {
-      (!TTTrackChargeSelector(track) ? vTTPosTrackOutput->push_back(trackRef)
-             	                     : vTTNegTrackOutput->push_back(trackRef));
+      (!TTTrackChargeSelector(track) ? vTTPosTrackOutput->push_back(trackRef) : vTTNegTrackOutput->push_back(trackRef));
     }
     // Select tracks based on the bitwise accurate TTTrack_TrackWord
     if (processEmulatedTracks_) {
       (!TTTrackWordChargeSelector(track) ? vTTPosTrackEmulationOutput->push_back(trackRef)
                                          : vTTNegTrackEmulationOutput->push_back(trackRef));
     }
-  }  
+  }
   // Put the outputs into the event
   if (processSimulatedTracks_) {
     iEvent.put(std::move(vTTPosTrackOutput), outputCollectionName_ + "Positivecharge");

--- a/L1Trigger/L1TTrackMatch/plugins/L1KaonTrackSelectionProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1KaonTrackSelectionProducer.cc
@@ -1,0 +1,194 @@
+// -*- C++ -*-
+//
+// Package:    L1Trigger/L1TTrackMatch
+// Class:      L1KaonTrackSelectionProducer
+//
+/**\class L1KaonTrackSelectionProducer L1KaonTrackSelectionProducer.cc L1Trigger/L1TTrackMatch/plugins/L1KaonTrackSelectionProducer.cc
+
+ Description: Selects positively and negatively charged L1Tracks which pass the Level 1 track selection criteria into two separate collections 
+
+ Implementation:
+     Inputs:
+         std::vector<TTTrack> - Each floating point TTTrack inside this collection inherits from
+                                a bit-accurate TTTrack_TrackWord, used for emulation purposes.
+     Outputs:
+         std::vector<TTTrack> - Positively and negatively charged collection of TTTracks selected from cuts on the TTTrack properties
+         std::vector<TTTrack> - Positively and negatively charged collection of TTTracks selected from cuts on the TTTrack_TrackWord properties
+*/
+//----------------------------------------------------------------------------
+// Authors: Alexx Perloff, Pritam Palit (original version, 2021),
+//          Sweta Baradia, Suchandra Dutta, Subir Sarkar (February 2025)  
+//----------------------------------------------------------------------------
+// system include files
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+
+// Xilinx HLS includes
+#include <ap_fixed.h>
+#include <ap_int.h>
+
+// user include files
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/RefVector.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+#include "DataFormats/L1Trigger/interface/Vertex.h"
+#include "DataFormats/L1Trigger/interface/VertexWord.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "CommonTools/Utils/interface/AndSelector.h"
+#include "CommonTools/Utils/interface/EtaRangeSelector.h"
+#include "CommonTools/Utils/interface/MinSelector.h"
+#include "CommonTools/Utils/interface/MinFunctionSelector.h"
+#include "CommonTools/Utils/interface/MinNumberSelector.h"
+#include "CommonTools/Utils/interface/PtMinSelector.h"
+#include "CommonTools/Utils/interface/Selection.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "L1TrackWordUnpacker.h"
+
+//
+// class declaration
+//
+class L1KaonTrackSelectionProducer : public edm::global::EDProducer<> {
+public:
+  explicit L1KaonTrackSelectionProducer(const edm::ParameterSet&);
+  ~L1KaonTrackSelectionProducer() override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  // ----------constants, enums and typedefs ---------
+  using L1Track                  = TTTrack<Ref_Phase2TrackerDigi_>;
+  using TTTrackCollection        = std::vector<L1Track>;
+  using TTTrackRef               = edm::Ref<TTTrackCollection>;
+  using TTTrackRefCollection     = edm::RefVector<TTTrackCollection>;
+  using TTTrackCollectionHandle  = edm::Handle<TTTrackRefCollection>;
+  using TTTrackRefCollectionUPtr = std::unique_ptr<TTTrackRefCollection>;
+
+  // ----------meprintDebugInfomber functions ----------------------
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+
+  // ----------selectors -----------------------------
+  // Based on recommendations from https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideGenericSelectors
+  // Track charge selection 
+
+  bool TTTrackChargeSelector(const L1Track& t) const { return std::signbit(t.rInv()) ;}; 
+
+  bool TTTrackWordChargeSelector (const L1Track& t) const {
+    ap_uint<1> chargeEmulationBits = t.getTrackWord()(
+	       TTTrack_TrackWord::TrackBitLocations::kRinvMSB, TTTrack_TrackWord::TrackBitLocations::kRinvMSB);
+    return chargeEmulationBits.to_uint();
+  };
+
+  // ----------member data ---------------------------
+  const edm::EDGetTokenT<TTTrackRefCollection> l1TracksToken_;
+  const std::string outputCollectionName_;
+  bool processSimulatedTracks_, processEmulatedTracks_;
+  int debug_;
+};
+
+//
+// constructors and destructor
+//
+L1KaonTrackSelectionProducer::L1KaonTrackSelectionProducer(const edm::ParameterSet& iConfig)
+  : l1TracksToken_(consumes<TTTrackRefCollection>(iConfig.getParameter<edm::InputTag>("l1TracksInputTag"))),
+    outputCollectionName_(iConfig.getParameter<std::string>("outputCollectionName")),
+    processSimulatedTracks_(iConfig.getParameter<bool>("processSimulatedTracks")),
+    processEmulatedTracks_(iConfig.getParameter<bool>("processEmulatedTracks")),
+    debug_(iConfig.getParameter<int>("debug")) {
+  // Ensure that the configuration makes sense
+  if (!processSimulatedTracks_ && !processEmulatedTracks_) {
+    throw cms::Exception("You must process at least one of the track collections (simulated or emulated).");
+  }
+ 
+  // Get additional input tags and define the EDM output based on the previous configuration parameters
+  if (processSimulatedTracks_) {
+    produces<TTTrackRefCollection>(outputCollectionName_ + "Positivecharge");
+    produces<TTTrackRefCollection>(outputCollectionName_ + "Negativecharge");
+  }
+  if (processEmulatedTracks_) {
+    produces<TTTrackRefCollection>(outputCollectionName_ + "EmulationPositivecharge");
+    produces<TTTrackRefCollection>(outputCollectionName_ + "EmulationNegativecharge");
+  }
+}
+
+L1KaonTrackSelectionProducer::~L1KaonTrackSelectionProducer() {}
+
+//
+// member functions
+//
+// ------------ method called to produce the data  ------------
+void L1KaonTrackSelectionProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  auto vTTPosTrackOutput = std::make_unique<TTTrackRefCollection>();
+  auto vTTPosTrackEmulationOutput = std::make_unique<TTTrackRefCollection>();
+
+  auto vTTNegTrackOutput = std::make_unique<TTTrackRefCollection>();
+  auto vTTNegTrackEmulationOutput = std::make_unique<TTTrackRefCollection>();
+
+  TTTrackCollectionHandle l1TracksHandle;
+  iEvent.getByToken(l1TracksToken_, l1TracksHandle);
+  size_t nTracks = l1TracksHandle->size();
+  if (!nTracks) return;
+
+  
+  if (processSimulatedTracks_) {
+    vTTPosTrackOutput->reserve(static_cast<std::size_t>(std::round(nTracks*0.6)));
+    vTTNegTrackOutput->reserve(static_cast<std::size_t>(std::round(nTracks*0.6)));
+  }
+  if (processEmulatedTracks_) {
+    vTTPosTrackEmulationOutput->reserve(static_cast<std::size_t>(std::round(nTracks*0.6)));
+    vTTNegTrackEmulationOutput->reserve(static_cast<std::size_t>(std::round(nTracks*0.6)));
+  }
+
+  for (size_t i = 0; i < nTracks; i++) {
+    const auto& trackRef = l1TracksHandle->at(i);
+    const auto& track = *trackRef;
+
+    // Select tracks based on the floating point TTTrack
+    if (processSimulatedTracks_) {
+      (!TTTrackChargeSelector(track) ? vTTPosTrackOutput->push_back(trackRef)
+             	                     : vTTNegTrackOutput->push_back(trackRef));
+    }
+    // Select tracks based on the bitwise accurate TTTrack_TrackWord
+    if (processEmulatedTracks_) {
+      (!TTTrackWordChargeSelector(track) ? vTTPosTrackEmulationOutput->push_back(trackRef)
+                                         : vTTNegTrackEmulationOutput->push_back(trackRef));
+    }
+  }  
+  // Put the outputs into the event
+  if (processSimulatedTracks_) {
+    iEvent.put(std::move(vTTPosTrackOutput), outputCollectionName_ + "Positivecharge");
+    iEvent.put(std::move(vTTNegTrackOutput), outputCollectionName_ + "Negativecharge");
+  }
+  if (processEmulatedTracks_) {
+    iEvent.put(std::move(vTTPosTrackEmulationOutput), outputCollectionName_ + "EmulationPositivecharge");
+    iEvent.put(std::move(vTTNegTrackEmulationOutput), outputCollectionName_ + "EmulationNegativecharge");
+  }
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void L1KaonTrackSelectionProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //L1KaonTrackSelectionProducer
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("l1TracksInputTag", edm::InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks"));
+  desc.add<std::string>("outputCollectionName", "Level1TTKaonTracksSelected");
+  desc.add<bool>("processSimulatedTracks", true)
+      ->setComment("return selected tracks after cutting on the floating point values");
+  desc.add<bool>("processEmulatedTracks", true)
+      ->setComment("return selected tracks after cutting on the bitwise emulated values");
+  desc.add<int>("debug", 4)->setComment("Verbosity levels: 0, 1, 2, 3");
+  descriptions.addWithDefaultLabel(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(L1KaonTrackSelectionProducer);

--- a/L1Trigger/L1TTrackMatch/plugins/L1PhiMesonSelectionEmulationProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1PhiMesonSelectionEmulationProducer.cc
@@ -1,0 +1,244 @@
+// -*- C++ -*-
+//
+// Package:    L1Trigger/L1TTrackMatch
+// Class:      L1PhiMesonSelectionEmulationProducer
+//
+/**\class L1PhiMesonSelectionEmulationProducer L1PhiMesonSelectionEmulationProducer.cc L1Trigger/L1TTrackMatch/plugins/L1PhiMesonSelectionEmulationProducer.cc
+
+ Description: Build Phi meson candidates from positively and negatively charged selected L1Tracks (assuming kaons)
+
+ Implementation:
+     Inputs:
+         std::vector<TTTrack> - Positively and negatively charged collection of selected L1Tracks which inherits from a bit-accurate TTTrack_TrackWord, used for emulation purposes
+     Outputs:
+         l1t::TkLightMesonWordCollection - A collection of reconstructed Phi meson candidates
+*/
+// ----------------------------------------------------------------------------                                                    
+// Authors: Alexx Perloff, Pritam Palit (original version, 2021),
+//          Sweta Baradia, Suchandra Dutta, Subir Sarkar (February 2025)
+//----------------------------------------------------------------------------- 
+
+// system include files
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+#include <TMath.h>
+#include <cmath>
+#include <bitset>
+#include <TSystem.h>
+#include <array>
+// Xilinx HLS includes
+#include <ap_fixed.h>
+#include <ap_int.h>
+#include <stdio.h>
+#include <cassert>
+#include <cstdlib>
+
+// user include files
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/RefVector.h"
+#include "DataFormats/Common/interface/RefToPtr.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/Math/interface/deltaR.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "DataFormats/Math/interface/LorentzVector.h"
+
+#include "DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+#include "L1Trigger/L1TTrackMatch/interface/L1TkEtMissEmuAlgo.h"
+#include "DataFormats/L1Trigger/interface/TkLightMesonWord.h"
+#include "L1TrackWordUnpacker.h"
+
+
+using namespace std;
+using namespace edm;
+using namespace l1t;
+
+using L1TTTrackType            = TTTrack<Ref_Phase2TrackerDigi_>;                                 
+using TTTrackCollection        = std::vector<L1TTTrackType>;                                    
+using TTTrackRef               = edm::Ref<TTTrackCollection>;                                   
+using TTTrackRefCollection     = edm::RefVector<TTTrackCollection>;                             
+using TTTrackCollectionHandle  = edm::Handle<TTTrackRefCollection>;
+using TTTrackRefCollectionUPtr = std::unique_ptr<TTTrackRefCollection>; 
+
+// Class declaration 
+class L1PhiMesonSelectionEmulationProducer : public edm::global::EDProducer<> {
+public:
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  explicit L1PhiMesonSelectionEmulationProducer(const edm::ParameterSet&);
+  ~L1PhiMesonSelectionEmulationProducer() override;
+
+  static constexpr double KaonMass = 0.493677 ;
+  static constexpr double ETAPHI_LSB = M_PI / (1 << 12);
+  static constexpr double Z0_LSB = 0.05;
+  size_t phiSize = 20;
+  
+private:
+  // ----------member functions ----------------------
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+ 
+  // ----------selectors -----------------------------
+  // Based on recommendations from https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideGenericSelectors
+  // ----------member data ---------------------------
+  const edm::EDGetTokenT<TTTrackRefCollection> posTrackToken_;
+  const edm::EDGetTokenT<TTTrackRefCollection> negTrackToken_;
+  const std::string outputCollectionName_;
+  const edm::ParameterSet cutSet_;
+  const double tkPairdzMax_, tkPairdRMax_, tkPairMMin_, tkPairMMax_;
+  
+  int debug_;
+};
+
+//
+// constructors and destructor
+//
+L1PhiMesonSelectionEmulationProducer::L1PhiMesonSelectionEmulationProducer(const edm::ParameterSet& iConfig)
+  : posTrackToken_(consumes<TTTrackRefCollection>(iConfig.getParameter<edm::InputTag>("l1PosKaonTracksInputTag"))),
+    negTrackToken_(consumes<TTTrackRefCollection>(iConfig.getParameter<edm::InputTag>("l1NegKaonTracksInputTag"))),
+    outputCollectionName_(iConfig.getParameter<std::string>("outputCollectionName")),
+    cutSet_(iConfig.getParameter<edm::ParameterSet>("cutSet")),
+    tkPairdzMax_(cutSet_.getParameter<double>("tkPairdzMax")),
+    tkPairdRMax_(cutSet_.getParameter<double>("tkPairdRMax")),
+    tkPairMMin_(cutSet_.getParameter<double>("tkPairMMin")),
+    tkPairMMax_(cutSet_.getParameter<double>("tkPairMMax")),
+    debug_(iConfig.getParameter<int>("debug")) {
+  produces<l1t::TkLightMesonWordCollection>(outputCollectionName_);
+}
+
+L1PhiMesonSelectionEmulationProducer::~L1PhiMesonSelectionEmulationProducer() {}
+
+// ------------ method called to produce the data  ------------                                                                                                    
+void L1PhiMesonSelectionEmulationProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  auto L1PhiMesonEmulationOutput = std::make_unique<l1t::TkLightMesonWordCollection>();
+
+  TTTrackCollectionHandle posTrackHandle;
+  iEvent.getByToken(posTrackToken_, posTrackHandle);
+
+  TTTrackCollectionHandle negTrackHandle;
+  iEvent.getByToken(negTrackToken_, negTrackHandle);
+
+  auto nPosKaon = posTrackHandle->size();
+  auto nNegKaon = negTrackHandle->size();
+
+  L1PhiMesonEmulationOutput->reserve(phiSize);
+  
+  ap_ufixed<64, 32> etaphi_conv = 1.0 / ETAPHI_LSB;
+  ap_ufixed<64, 32> z0_conv = 1.0 * Z0_LSB;
+  
+  for (size_t i = 0; i < nPosKaon; i++) {
+    const auto& trackPosKaonRef = posTrackHandle->at(i);
+    const auto& trackPosKaon = *trackPosKaonRef;
+
+    // bitwise emulated values for positive tracks
+    double trkptPos  = l1trackunpacker::FloatPtFromBits(trackPosKaon);
+    double trketaPos = l1trackunpacker::FloatEtaFromBits(trackPosKaon);
+    double trkphiPos = l1trackunpacker::FloatPhiFromBits(trackPosKaon);
+    double trkz0Pos  = l1trackunpacker::FloatZ0FromBits(trackPosKaon);
+
+    double trkpxPos = trkptPos * cos(trkphiPos);
+    double trkpyPos = trkptPos * sin(trkphiPos);
+    double trkpzPos = trkptPos * sinh(trketaPos);
+    double trkePos  = sqrt(pow(trkptPos, 2) + pow(trkpzPos, 2) + pow(KaonMass, 2));
+
+    for (size_t j = 0; j < nNegKaon; j++) {
+      const auto& trackNegKaonRef = negTrackHandle->at(j);
+      const auto& trackNegKaon = *trackNegKaonRef;
+
+      // bitwise emulated values for negative tracks
+      double trkptNeg  = l1trackunpacker::FloatPtFromBits(trackNegKaon);
+      double trketaNeg = l1trackunpacker::FloatEtaFromBits(trackNegKaon);
+      double trkphiNeg = l1trackunpacker::FloatPhiFromBits(trackNegKaon);
+      double trkz0Neg  = l1trackunpacker::FloatZ0FromBits(trackNegKaon);
+      
+      double trkpxNeg = trkptNeg * cos(trkphiNeg);
+      double trkpyNeg = trkptNeg * sin(trkphiNeg);
+      double trkpzNeg = trkptNeg * sinh(trketaNeg);
+      double trkeNeg  = sqrt(pow(trkptNeg, 2) + pow(trkpzNeg, 2) + pow(KaonMass, 2));
+    
+      double pxPhi = trkpxNeg + trkpxPos;
+      double pyPhi = trkpyNeg + trkpyPos;
+      double pzPhi = trkpzNeg + trkpzPos;
+      double ePhi  = trkeNeg  + trkePos;
+
+      if (std::fabs(trkz0Pos - trkz0Neg) > tkPairdzMax_) continue;
+      
+      double convdPhi = std::abs(trkphiPos - trkphiNeg);
+      if (convdPhi > M_PI) convdPhi-= 2 * M_PI;
+      double trkdrpairPhi = sqrt(pow(convdPhi,2) + pow(trketaPos - trketaNeg, 2));
+      if (trkdrpairPhi > tkPairdRMax_) continue;
+
+      double trkmasspairPhi = sqrt(pow(ePhi,2) - pow(pxPhi, 2) - pow(pyPhi, 2) - pow(pzPhi, 2)); 
+      if (trkmasspairPhi < tkPairMMin_ || trkmasspairPhi > tkPairMMax_) continue;
+      
+      l1t::TkLightMesonWord::valid_t validPhi           = trackPosKaon.getValid() && trackNegKaon.getValid();
+      l1t::TkLightMesonWord::pt_t ptPhi                 = sqrt(pow(pxPhi, 2) + pow(pyPhi, 2)); 
+      l1t::TkLightMesonWord::glbphi_t phiPhi            = atan2(pyPhi, pxPhi) / ETAPHI_LSB;
+      l1t::TkLightMesonWord::glbeta_t etaPhi            = asinh(pzPhi/sqrt(pow(pxPhi, 2) + pow(pyPhi, 2))) / ETAPHI_LSB;
+      l1t::TkLightMesonWord::z0_t z0Phi                 = ((trkz0Pos + trkz0Neg) / Z0_LSB)* 0.5;
+      l1t::TkLightMesonWord::mass_t mPhi                = sqrt(pow(ePhi, 2) - pow(pxPhi, 2) - pow(pyPhi, 2) - pow(pzPhi, 2));
+      l1t::TkLightMesonWord::type_t typePhi             = l1t::TkLightMesonWord::TkLightMesonTypes::kPhiType;
+      l1t::TkLightMesonWord::ntracks_t ntracksPhi       = 2;
+      l1t::TkLightMesonWord::index_t firstTrkIndex      = i;
+      l1t::TkLightMesonWord::index_t secondTrkIndex     = j;
+      l1t::TkLightMesonWord::unassigned_t unassignedPhi = 0;
+
+      l1t::TkLightMesonWord PhiWord(validPhi, ptPhi, phiPhi, etaPhi, z0Phi, mPhi, typePhi, ntracksPhi, firstTrkIndex, secondTrkIndex, unassignedPhi);
+
+      // Store unique phi candidates
+      bool dupl = false;
+      for (const auto& el: *L1PhiMesonEmulationOutput) {
+        double ptDiff  = el.pt()  - PhiWord.pt();
+        double etaDiff = el.glbeta() - PhiWord.glbeta();
+        double phiDiff = el.glbphi() - PhiWord.glbphi();
+        if ( fabs(etaDiff) < 1.0e-03 &&
+             fabs(phiDiff) < 1.0e-03 &&
+             fabs(ptDiff)  < 1.0e-02 )
+          {
+            dupl = true;
+            break;
+          }
+      }
+      if (!dupl) {
+	L1PhiMesonEmulationOutput->push_back(PhiWord);
+      }
+    }
+  }
+  iEvent.put(std::move(L1PhiMesonEmulationOutput), outputCollectionName_);
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void L1PhiMesonSelectionEmulationProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("l1PosKaonTracksInputTag",
+                          edm::InputTag("l1KaonTrackSelectionProducer","Level1TTKaonTracksSelectedEmulationPositivecharge"));
+  desc.add<edm::InputTag>("l1NegKaonTracksInputTag",
+                          edm::InputTag("l1KaonTrackSelectionProducer","Level1TTKaonTracksSelectedEmulationNegativecharge"));
+  desc.add<std::string>("outputCollectionName", "Level1PhiMesonEmulationColl");
+
+  {
+    edm::ParameterSetDescription descCutSet;
+    descCutSet.add<double>("tkPairdzMax", 0.5)->setComment("dz between phi track pair must be less than this value, [cm]");
+    descCutSet.add<double>("tkPairdRMax", 0.2)->setComment("dR between phi track pair must be less than this value, []");
+    descCutSet.add<double>("tkPairMMin", 1.0)->setComment("phi mass must be greater than this value, [GeV]");
+    descCutSet.add<double>("tkPairMMax", 1.03)->setComment("phi mass must be less than this value, [GeV]");
+    desc.add<edm::ParameterSetDescription>("cutSet", descCutSet);
+  }
+  desc.add<int>("debug", 0)->setComment("Verbosity levels: 0, 1, 2, 3");
+  descriptions.addWithDefaultLabel(desc);
+}
+//define this as a plug-in
+DEFINE_FWK_MODULE(L1PhiMesonSelectionEmulationProducer);

--- a/L1Trigger/L1TTrackMatch/plugins/L1PhiMesonSelectionEmulationProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1PhiMesonSelectionEmulationProducer.cc
@@ -13,10 +13,10 @@
      Outputs:
          l1t::TkLightMesonWordCollection - A collection of reconstructed Phi meson candidates
 */
-// ----------------------------------------------------------------------------                                                    
+// ----------------------------------------------------------------------------
 // Authors: Alexx Perloff, Pritam Palit (original version, 2021),
 //          Sweta Baradia, Suchandra Dutta, Subir Sarkar (February 2025)
-//----------------------------------------------------------------------------- 
+//-----------------------------------------------------------------------------
 
 // system include files
 #include <algorithm>
@@ -31,8 +31,8 @@
 // Xilinx HLS includes
 #include <ap_fixed.h>
 #include <ap_int.h>
-#include <stdio.h>
 #include <cassert>
+#include <cstdio>
 #include <cstdlib>
 
 // user include files
@@ -63,34 +63,33 @@
 #include "DataFormats/L1Trigger/interface/TkLightMesonWord.h"
 #include "L1TrackWordUnpacker.h"
 
-
 using namespace std;
 using namespace edm;
 using namespace l1t;
 
-using L1TTTrackType            = TTTrack<Ref_Phase2TrackerDigi_>;                                 
-using TTTrackCollection        = std::vector<L1TTTrackType>;                                    
-using TTTrackRef               = edm::Ref<TTTrackCollection>;                                   
-using TTTrackRefCollection     = edm::RefVector<TTTrackCollection>;                             
-using TTTrackCollectionHandle  = edm::Handle<TTTrackRefCollection>;
-using TTTrackRefCollectionUPtr = std::unique_ptr<TTTrackRefCollection>; 
+using L1TTTrackType = TTTrack<Ref_Phase2TrackerDigi_>;
+using TTTrackCollection = std::vector<L1TTTrackType>;
+using TTTrackRef = edm::Ref<TTTrackCollection>;
+using TTTrackRefCollection = edm::RefVector<TTTrackCollection>;
+using TTTrackCollectionHandle = edm::Handle<TTTrackRefCollection>;
+using TTTrackRefCollectionUPtr = std::unique_ptr<TTTrackRefCollection>;
 
-// Class declaration 
+// Class declaration
 class L1PhiMesonSelectionEmulationProducer : public edm::global::EDProducer<> {
 public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   explicit L1PhiMesonSelectionEmulationProducer(const edm::ParameterSet&);
   ~L1PhiMesonSelectionEmulationProducer() override;
 
-  static constexpr double KaonMass = 0.493677 ;
+  static constexpr double KaonMass = 0.493677;
   static constexpr double ETAPHI_LSB = M_PI / (1 << 12);
   static constexpr double Z0_LSB = 0.05;
   size_t phiSize = 20;
-  
+
 private:
   // ----------member functions ----------------------
   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
- 
+
   // ----------selectors -----------------------------
   // Based on recommendations from https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideGenericSelectors
   // ----------member data ---------------------------
@@ -99,7 +98,7 @@ private:
   const std::string outputCollectionName_;
   const edm::ParameterSet cutSet_;
   const double tkPairdzMax_, tkPairdRMax_, tkPairMMin_, tkPairMMax_;
-  
+
   int debug_;
 };
 
@@ -107,22 +106,24 @@ private:
 // constructors and destructor
 //
 L1PhiMesonSelectionEmulationProducer::L1PhiMesonSelectionEmulationProducer(const edm::ParameterSet& iConfig)
-  : posTrackToken_(consumes<TTTrackRefCollection>(iConfig.getParameter<edm::InputTag>("l1PosKaonTracksInputTag"))),
-    negTrackToken_(consumes<TTTrackRefCollection>(iConfig.getParameter<edm::InputTag>("l1NegKaonTracksInputTag"))),
-    outputCollectionName_(iConfig.getParameter<std::string>("outputCollectionName")),
-    cutSet_(iConfig.getParameter<edm::ParameterSet>("cutSet")),
-    tkPairdzMax_(cutSet_.getParameter<double>("tkPairdzMax")),
-    tkPairdRMax_(cutSet_.getParameter<double>("tkPairdRMax")),
-    tkPairMMin_(cutSet_.getParameter<double>("tkPairMMin")),
-    tkPairMMax_(cutSet_.getParameter<double>("tkPairMMax")),
-    debug_(iConfig.getParameter<int>("debug")) {
+    : posTrackToken_(consumes<TTTrackRefCollection>(iConfig.getParameter<edm::InputTag>("l1PosKaonTracksInputTag"))),
+      negTrackToken_(consumes<TTTrackRefCollection>(iConfig.getParameter<edm::InputTag>("l1NegKaonTracksInputTag"))),
+      outputCollectionName_(iConfig.getParameter<std::string>("outputCollectionName")),
+      cutSet_(iConfig.getParameter<edm::ParameterSet>("cutSet")),
+      tkPairdzMax_(cutSet_.getParameter<double>("tkPairdzMax")),
+      tkPairdRMax_(cutSet_.getParameter<double>("tkPairdRMax")),
+      tkPairMMin_(cutSet_.getParameter<double>("tkPairMMin")),
+      tkPairMMax_(cutSet_.getParameter<double>("tkPairMMax")),
+      debug_(iConfig.getParameter<int>("debug")) {
   produces<l1t::TkLightMesonWordCollection>(outputCollectionName_);
 }
 
 L1PhiMesonSelectionEmulationProducer::~L1PhiMesonSelectionEmulationProducer() {}
 
-// ------------ method called to produce the data  ------------                                                                                                    
-void L1PhiMesonSelectionEmulationProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+// ------------ method called to produce the data  ------------
+void L1PhiMesonSelectionEmulationProducer::produce(edm::StreamID,
+                                                   edm::Event& iEvent,
+                                                   const edm::EventSetup& iSetup) const {
   auto L1PhiMesonEmulationOutput = std::make_unique<l1t::TkLightMesonWordCollection>();
 
   TTTrackCollectionHandle posTrackHandle;
@@ -135,85 +136,96 @@ void L1PhiMesonSelectionEmulationProducer::produce(edm::StreamID, edm::Event& iE
   auto nNegKaon = negTrackHandle->size();
 
   L1PhiMesonEmulationOutput->reserve(phiSize);
-  
+
   ap_ufixed<64, 32> etaphi_conv = 1.0 / ETAPHI_LSB;
   ap_ufixed<64, 32> z0_conv = 1.0 * Z0_LSB;
-  
+
   for (size_t i = 0; i < nPosKaon; i++) {
     const auto& trackPosKaonRef = posTrackHandle->at(i);
     const auto& trackPosKaon = *trackPosKaonRef;
 
     // bitwise emulated values for positive tracks
-    double trkptPos  = l1trackunpacker::FloatPtFromBits(trackPosKaon);
+    double trkptPos = l1trackunpacker::FloatPtFromBits(trackPosKaon);
     double trketaPos = l1trackunpacker::FloatEtaFromBits(trackPosKaon);
     double trkphiPos = l1trackunpacker::FloatPhiFromBits(trackPosKaon);
-    double trkz0Pos  = l1trackunpacker::FloatZ0FromBits(trackPosKaon);
+    double trkz0Pos = l1trackunpacker::FloatZ0FromBits(trackPosKaon);
 
     double trkpxPos = trkptPos * cos(trkphiPos);
     double trkpyPos = trkptPos * sin(trkphiPos);
     double trkpzPos = trkptPos * sinh(trketaPos);
-    double trkePos  = sqrt(pow(trkptPos, 2) + pow(trkpzPos, 2) + pow(KaonMass, 2));
+    double trkePos = sqrt(pow(trkptPos, 2) + pow(trkpzPos, 2) + pow(KaonMass, 2));
 
     for (size_t j = 0; j < nNegKaon; j++) {
       const auto& trackNegKaonRef = negTrackHandle->at(j);
       const auto& trackNegKaon = *trackNegKaonRef;
 
       // bitwise emulated values for negative tracks
-      double trkptNeg  = l1trackunpacker::FloatPtFromBits(trackNegKaon);
+      double trkptNeg = l1trackunpacker::FloatPtFromBits(trackNegKaon);
       double trketaNeg = l1trackunpacker::FloatEtaFromBits(trackNegKaon);
       double trkphiNeg = l1trackunpacker::FloatPhiFromBits(trackNegKaon);
-      double trkz0Neg  = l1trackunpacker::FloatZ0FromBits(trackNegKaon);
-      
+      double trkz0Neg = l1trackunpacker::FloatZ0FromBits(trackNegKaon);
+
       double trkpxNeg = trkptNeg * cos(trkphiNeg);
       double trkpyNeg = trkptNeg * sin(trkphiNeg);
       double trkpzNeg = trkptNeg * sinh(trketaNeg);
-      double trkeNeg  = sqrt(pow(trkptNeg, 2) + pow(trkpzNeg, 2) + pow(KaonMass, 2));
-    
+      double trkeNeg = sqrt(pow(trkptNeg, 2) + pow(trkpzNeg, 2) + pow(KaonMass, 2));
+
       double pxPhi = trkpxNeg + trkpxPos;
       double pyPhi = trkpyNeg + trkpyPos;
       double pzPhi = trkpzNeg + trkpzPos;
-      double ePhi  = trkeNeg  + trkePos;
+      double ePhi = trkeNeg + trkePos;
 
-      if (std::fabs(trkz0Pos - trkz0Neg) > tkPairdzMax_) continue;
-      
+      if (std::fabs(trkz0Pos - trkz0Neg) > tkPairdzMax_)
+        continue;
+
       double convdPhi = std::abs(trkphiPos - trkphiNeg);
-      if (convdPhi > M_PI) convdPhi-= 2 * M_PI;
-      double trkdrpairPhi = sqrt(pow(convdPhi,2) + pow(trketaPos - trketaNeg, 2));
-      if (trkdrpairPhi > tkPairdRMax_) continue;
+      if (convdPhi > M_PI)
+        convdPhi -= 2 * M_PI;
+      double trkdrpairPhi = sqrt(pow(convdPhi, 2) + pow(trketaPos - trketaNeg, 2));
+      if (trkdrpairPhi > tkPairdRMax_)
+        continue;
 
-      double trkmasspairPhi = sqrt(pow(ePhi,2) - pow(pxPhi, 2) - pow(pyPhi, 2) - pow(pzPhi, 2)); 
-      if (trkmasspairPhi < tkPairMMin_ || trkmasspairPhi > tkPairMMax_) continue;
-      
-      l1t::TkLightMesonWord::valid_t validPhi           = trackPosKaon.getValid() && trackNegKaon.getValid();
-      l1t::TkLightMesonWord::pt_t ptPhi                 = sqrt(pow(pxPhi, 2) + pow(pyPhi, 2)); 
-      l1t::TkLightMesonWord::glbphi_t phiPhi            = atan2(pyPhi, pxPhi) / ETAPHI_LSB;
-      l1t::TkLightMesonWord::glbeta_t etaPhi            = asinh(pzPhi/sqrt(pow(pxPhi, 2) + pow(pyPhi, 2))) / ETAPHI_LSB;
-      l1t::TkLightMesonWord::z0_t z0Phi                 = ((trkz0Pos + trkz0Neg) / Z0_LSB)* 0.5;
-      l1t::TkLightMesonWord::mass_t mPhi                = sqrt(pow(ePhi, 2) - pow(pxPhi, 2) - pow(pyPhi, 2) - pow(pzPhi, 2));
-      l1t::TkLightMesonWord::type_t typePhi             = l1t::TkLightMesonWord::TkLightMesonTypes::kPhiType;
-      l1t::TkLightMesonWord::ntracks_t ntracksPhi       = 2;
-      l1t::TkLightMesonWord::index_t firstTrkIndex      = i;
-      l1t::TkLightMesonWord::index_t secondTrkIndex     = j;
+      double trkmasspairPhi = sqrt(pow(ePhi, 2) - pow(pxPhi, 2) - pow(pyPhi, 2) - pow(pzPhi, 2));
+      if (trkmasspairPhi < tkPairMMin_ || trkmasspairPhi > tkPairMMax_)
+        continue;
+
+      l1t::TkLightMesonWord::valid_t validPhi = trackPosKaon.getValid() && trackNegKaon.getValid();
+      l1t::TkLightMesonWord::pt_t ptPhi = sqrt(pow(pxPhi, 2) + pow(pyPhi, 2));
+      l1t::TkLightMesonWord::glbphi_t phiPhi = atan2(pyPhi, pxPhi) / ETAPHI_LSB;
+      l1t::TkLightMesonWord::glbeta_t etaPhi = asinh(pzPhi / sqrt(pow(pxPhi, 2) + pow(pyPhi, 2))) / ETAPHI_LSB;
+      l1t::TkLightMesonWord::z0_t z0Phi = ((trkz0Pos + trkz0Neg) / Z0_LSB) * 0.5;
+      l1t::TkLightMesonWord::mass_t mPhi = sqrt(pow(ePhi, 2) - pow(pxPhi, 2) - pow(pyPhi, 2) - pow(pzPhi, 2));
+      l1t::TkLightMesonWord::type_t typePhi = l1t::TkLightMesonWord::TkLightMesonTypes::kPhiType;
+      l1t::TkLightMesonWord::ntracks_t ntracksPhi = 2;
+      l1t::TkLightMesonWord::index_t firstTrkIndex = i;
+      l1t::TkLightMesonWord::index_t secondTrkIndex = j;
       l1t::TkLightMesonWord::unassigned_t unassignedPhi = 0;
 
-      l1t::TkLightMesonWord PhiWord(validPhi, ptPhi, phiPhi, etaPhi, z0Phi, mPhi, typePhi, ntracksPhi, firstTrkIndex, secondTrkIndex, unassignedPhi);
+      l1t::TkLightMesonWord PhiWord(validPhi,
+                                    ptPhi,
+                                    phiPhi,
+                                    etaPhi,
+                                    z0Phi,
+                                    mPhi,
+                                    typePhi,
+                                    ntracksPhi,
+                                    firstTrkIndex,
+                                    secondTrkIndex,
+                                    unassignedPhi);
 
       // Store unique phi candidates
       bool dupl = false;
-      for (const auto& el: *L1PhiMesonEmulationOutput) {
-        double ptDiff  = el.pt()  - PhiWord.pt();
+      for (const auto& el : *L1PhiMesonEmulationOutput) {
+        double ptDiff = el.pt() - PhiWord.pt();
         double etaDiff = el.glbeta() - PhiWord.glbeta();
         double phiDiff = el.glbphi() - PhiWord.glbphi();
-        if ( fabs(etaDiff) < 1.0e-03 &&
-             fabs(phiDiff) < 1.0e-03 &&
-             fabs(ptDiff)  < 1.0e-02 )
-          {
-            dupl = true;
-            break;
-          }
+        if (fabs(etaDiff) < 1.0e-03 && fabs(phiDiff) < 1.0e-03 && fabs(ptDiff) < 1.0e-02) {
+          dupl = true;
+          break;
+        }
       }
       if (!dupl) {
-	L1PhiMesonEmulationOutput->push_back(PhiWord);
+        L1PhiMesonEmulationOutput->push_back(PhiWord);
       }
     }
   }
@@ -223,16 +235,20 @@ void L1PhiMesonSelectionEmulationProducer::produce(edm::StreamID, edm::Event& iE
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void L1PhiMesonSelectionEmulationProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("l1PosKaonTracksInputTag",
-                          edm::InputTag("l1KaonTrackSelectionProducer","Level1TTKaonTracksSelectedEmulationPositivecharge"));
-  desc.add<edm::InputTag>("l1NegKaonTracksInputTag",
-                          edm::InputTag("l1KaonTrackSelectionProducer","Level1TTKaonTracksSelectedEmulationNegativecharge"));
+  desc.add<edm::InputTag>(
+      "l1PosKaonTracksInputTag",
+      edm::InputTag("l1KaonTrackSelectionProducer", "Level1TTKaonTracksSelectedEmulationPositivecharge"));
+  desc.add<edm::InputTag>(
+      "l1NegKaonTracksInputTag",
+      edm::InputTag("l1KaonTrackSelectionProducer", "Level1TTKaonTracksSelectedEmulationNegativecharge"));
   desc.add<std::string>("outputCollectionName", "Level1PhiMesonEmulationColl");
 
   {
     edm::ParameterSetDescription descCutSet;
-    descCutSet.add<double>("tkPairdzMax", 0.5)->setComment("dz between phi track pair must be less than this value, [cm]");
-    descCutSet.add<double>("tkPairdRMax", 0.2)->setComment("dR between phi track pair must be less than this value, []");
+    descCutSet.add<double>("tkPairdzMax", 0.5)
+        ->setComment("dz between phi track pair must be less than this value, [cm]");
+    descCutSet.add<double>("tkPairdRMax", 0.2)
+        ->setComment("dR between phi track pair must be less than this value, []");
     descCutSet.add<double>("tkPairMMin", 1.0)->setComment("phi mass must be greater than this value, [GeV]");
     descCutSet.add<double>("tkPairMMax", 1.03)->setComment("phi mass must be less than this value, [GeV]");
     desc.add<edm::ParameterSetDescription>("cutSet", descCutSet);

--- a/L1Trigger/L1TTrackMatch/plugins/L1PhiMesonSelectionProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1PhiMesonSelectionProducer.cc
@@ -17,7 +17,7 @@
 // ----------------------------------------------------------------------------
 // Authors: Alexx Perloff, Pritam Palit (original version, 2021),
 //          Sweta Baradia, Suchandra Dutta, Subir Sarkar (February 2025)
-//-----------------------------------------------------------------------------  
+//-----------------------------------------------------------------------------
 
 // system include files
 #include <algorithm>
@@ -60,18 +60,18 @@ using namespace l1t;
 
 class L1PhiMesonSelectionProducer : public edm::global::EDProducer<> {
 public:
-  using L1TTTrackType            = TTTrack<Ref_Phase2TrackerDigi_>;
-  using TTTrackCollectionType    = std::vector<L1TTTrackType>;
-  using TTTrackRef               = edm::Ref<TTTrackCollectionType>;
-  using TTTrackRefCollection     = edm::RefVector<TTTrackCollectionType>;
-  using TTTrackCollectionHandle  = edm::Handle<TTTrackRefCollection>;
+  using L1TTTrackType = TTTrack<Ref_Phase2TrackerDigi_>;
+  using TTTrackCollectionType = std::vector<L1TTTrackType>;
+  using TTTrackRef = edm::Ref<TTTrackCollectionType>;
+  using TTTrackRefCollection = edm::RefVector<TTTrackCollectionType>;
+  using TTTrackCollectionHandle = edm::Handle<TTTrackRefCollection>;
   using TTTrackRefCollectionUPtr = std::unique_ptr<TTTrackRefCollection>;
 
   explicit L1PhiMesonSelectionProducer(const edm::ParameterSet&);
   ~L1PhiMesonSelectionProducer() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  static constexpr double KaonMass = 0.493677; // GeV
+  static constexpr double KaonMass = 0.493677;  // GeV
   size_t phiSize = 20;
 
 private:
@@ -94,16 +94,17 @@ private:
 // constructors and destructor
 //
 L1PhiMesonSelectionProducer::L1PhiMesonSelectionProducer(const edm::ParameterSet& iConfig)
-  : l1PosKaonTracksToken_(consumes<TTTrackRefCollection>(iConfig.getParameter<edm::InputTag>("l1PosKaonTracksInputTag"))),
-    l1NegKaonTracksToken_(consumes<TTTrackRefCollection>(iConfig.getParameter<edm::InputTag>("l1NegKaonTracksInputTag"))),
-    outputCollectionName_(iConfig.getParameter<std::string>("outputCollectionName")),
-    cutSet_(iConfig.getParameter<edm::ParameterSet>("cutSet")),
-    tkPairdzMax_(cutSet_.getParameter<double>("tkPairdzMax")),
-    tkPairdRMax_(cutSet_.getParameter<double>("tkPairdRMax")),
-    tkPairMMin_(cutSet_.getParameter<double>("tkPairMMin")),
-    tkPairMMax_(cutSet_.getParameter<double>("tkPairMMax")),
-    debug_(iConfig.getParameter<int>("debug")) 
-{
+    : l1PosKaonTracksToken_(
+          consumes<TTTrackRefCollection>(iConfig.getParameter<edm::InputTag>("l1PosKaonTracksInputTag"))),
+      l1NegKaonTracksToken_(
+          consumes<TTTrackRefCollection>(iConfig.getParameter<edm::InputTag>("l1NegKaonTracksInputTag"))),
+      outputCollectionName_(iConfig.getParameter<std::string>("outputCollectionName")),
+      cutSet_(iConfig.getParameter<edm::ParameterSet>("cutSet")),
+      tkPairdzMax_(cutSet_.getParameter<double>("tkPairdzMax")),
+      tkPairdRMax_(cutSet_.getParameter<double>("tkPairdRMax")),
+      tkPairMMin_(cutSet_.getParameter<double>("tkPairMMin")),
+      tkPairMMax_(cutSet_.getParameter<double>("tkPairMMax")),
+      debug_(iConfig.getParameter<int>("debug")) {
   produces<TkPhiCandidateCollection>(outputCollectionName_);
 }
 
@@ -120,11 +121,11 @@ void L1PhiMesonSelectionProducer::produce(edm::StreamID, edm::Event& iEvent, con
 
   size_t nPosKaon = l1PosKaonTracksHandle->size();
   size_t nNegKaon = l1NegKaonTracksHandle->size();
-  L1PhiMesonOutput->reserve(phiSize);  
+  L1PhiMesonOutput->reserve(phiSize);
 
   for (size_t i = 0; i < nPosKaon; ++i) {
     const auto& trackPosKaonRef = l1PosKaonTracksHandle->at(i);
-    const auto& trackPosKaon = *trackPosKaonRef;    
+    const auto& trackPosKaon = *trackPosKaonRef;
     const edm::Ptr<L1TTTrackType>& trackPosKaonReftoPtr = edm::refToPtr(trackPosKaonRef);
 
     const GlobalVector& trackPosP = trackPosKaon.momentum();
@@ -134,43 +135,43 @@ void L1PhiMesonSelectionProducer::produce(edm::StreamID, edm::Event& iEvent, con
       const auto& trackNegKaonRef = l1NegKaonTracksHandle->at(j);
       const auto& trackNegKaon = *trackNegKaonRef;
 
-      const edm::Ptr<L1TTTrackType>& trackNegKaonReftoPtr = edm::refToPtr(trackNegKaonRef);      
+      const edm::Ptr<L1TTTrackType>& trackNegKaonReftoPtr = edm::refToPtr(trackNegKaonRef);
 
       const GlobalVector& trackNegP = trackNegKaon.momentum();
       math::PtEtaPhiMLorentzVector negKaonP4(trackNegP.perp(), trackNegP.eta(), trackNegP.phi(), KaonMass);
-      
+
       math::XYZTLorentzVector phiP4(posKaonP4.Px() + negKaonP4.Px(),
-				    posKaonP4.Py() + negKaonP4.Py(),
-				    posKaonP4.Pz() + negKaonP4.Pz(),
-				    posKaonP4.T()  + negKaonP4.T());
-    
+                                    posKaonP4.Py() + negKaonP4.Py(),
+                                    posKaonP4.Pz() + negKaonP4.Pz(),
+                                    posKaonP4.T() + negKaonP4.T());
+
       TkPhiCandidate tkPhi(phiP4, trackPosKaonReftoPtr, trackNegKaonReftoPtr);
 
       double dzTrkPair = tkPhi.dzTrkPair();
-      if (std::fabs(dzTrkPair) > tkPairdzMax_) continue;
-      
+      if (std::fabs(dzTrkPair) > tkPairdzMax_)
+        continue;
+
       double dRTrkPair = tkPhi.dRTrkPair();
-      if (dRTrkPair > tkPairdRMax_) continue;
-      
+      if (dRTrkPair > tkPairdRMax_)
+        continue;
+
       double mass = tkPhi.p4().M();
-      if (mass < tkPairMMin_ || mass > tkPairMMax_) continue;
+      if (mass < tkPairMMin_ || mass > tkPairMMax_)
+        continue;
 
       bool dupl = false;
-      for (const auto& el: *L1PhiMesonOutput) {
-	double ptDiff  = el.p4().Pt()  - tkPhi.p4().Pt();
+      for (const auto& el : *L1PhiMesonOutput) {
+        double ptDiff = el.p4().Pt() - tkPhi.p4().Pt();
         double etaDiff = el.p4().Eta() - tkPhi.p4().Eta();
         double phiDiff = el.p4().Phi() - tkPhi.p4().Phi();
-	if ( fabs(etaDiff) < 1.0e-03 &&
-             fabs(phiDiff) < 1.0e-03 &&
-             fabs(ptDiff)  < 1.0e-02 )
-          {
-            dupl = true;
-            break;
-          }
+        if (fabs(etaDiff) < 1.0e-03 && fabs(phiDiff) < 1.0e-03 && fabs(ptDiff) < 1.0e-02) {
+          dupl = true;
+          break;
+        }
       }
       if (!dupl) {
-	// Put the outputs into the event
-	L1PhiMesonOutput->push_back(tkPhi);
+        // Put the outputs into the event
+        L1PhiMesonOutput->push_back(tkPhi);
       }
     }
   }
@@ -181,12 +182,17 @@ void L1PhiMesonSelectionProducer::produce(edm::StreamID, edm::Event& iEvent, con
 void L1PhiMesonSelectionProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   //L1PhiMesonSelectionProducer
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("l1PosKaonTracksInputTag", edm::InputTag("l1KaonTrackSelectionProducer", "Level1TTKaonTracksSelectedPositivecharge"));
-  desc.add<edm::InputTag>("l1NegKaonTracksInputTag", edm::InputTag("l1KaonTrackSelectionProducer", "Level1TTKaonTracksSelectedNegativecharge"));
-  desc.add<std::string>("outputCollectionName", "Level1PhiMesonColl");  {
+  desc.add<edm::InputTag>("l1PosKaonTracksInputTag",
+                          edm::InputTag("l1KaonTrackSelectionProducer", "Level1TTKaonTracksSelectedPositivecharge"));
+  desc.add<edm::InputTag>("l1NegKaonTracksInputTag",
+                          edm::InputTag("l1KaonTrackSelectionProducer", "Level1TTKaonTracksSelectedNegativecharge"));
+  desc.add<std::string>("outputCollectionName", "Level1PhiMesonColl");
+  {
     edm::ParameterSetDescription descCutSet;
-    descCutSet.add<double>("tkPairdzMax", 0.5)->setComment("dz between opp. charged track pair must be less than this value, [cm]");
-    descCutSet.add<double>("tkPairdRMax", 0.2)->setComment("dR between opp. charged track pair must be less than this value, []");
+    descCutSet.add<double>("tkPairdzMax", 0.5)
+        ->setComment("dz between opp. charged track pair must be less than this value, [cm]");
+    descCutSet.add<double>("tkPairdRMax", 0.2)
+        ->setComment("dR between opp. charged track pair must be less than this value, []");
     descCutSet.add<double>("tkPairMMin", 1.0)->setComment("#track pair mass must be greater than this value, [GeV]");
     descCutSet.add<double>("tkPairMMax", 1.03)->setComment("track pair mass must be less than this value, [GeV]");
     desc.add<edm::ParameterSetDescription>("cutSet", descCutSet);

--- a/L1Trigger/L1TTrackMatch/plugins/L1PhiMesonSelectionProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1PhiMesonSelectionProducer.cc
@@ -1,0 +1,199 @@
+// -*- C++ -*-
+//
+// Package:    L1Trigger/L1TTrackMatch
+// Class:      L1PhiMesonSelectionProducer
+//
+/**\class L1PhiMesonSelectionProducer L1PhiMesonSelectionProducer.cc L1Trigger/L1TTrackMatch/plugins/L1PhiMesonSelectionProducer.cc
+
+ Description: Build Phi meson candidates from positively and negatively charged selected L1Tracks (assuming kaons)
+
+ Implementation:
+     Inputs:
+         std::vector<TTTrack> - Positively and negatively charged collections of selected L1Tracks
+     Outputs:
+         l1t::TkPhiCandidateCollection - A collection of reconstructed Phi meson candidates
+
+*/
+// ----------------------------------------------------------------------------
+// Authors: Alexx Perloff, Pritam Palit (original version, 2021),
+//          Sweta Baradia, Suchandra Dutta, Subir Sarkar (February 2025)
+//-----------------------------------------------------------------------------  
+
+// system include files
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+#include <TMath.h>
+#include <cmath>
+
+// user include files
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/RefVector.h"
+#include "DataFormats/Common/interface/RefToPtr.h"
+#include "DataFormats/L1TCorrelator/interface/TkPhiCandidate.h"
+#include "DataFormats/L1TCorrelator/interface/TkPhiCandidateFwd.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+#include "DataFormats/L1Trigger/interface/Vertex.h"
+#include "DataFormats/L1Trigger/interface/VertexWord.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+#include "DataFormats/Math/interface/LorentzVector.h"
+
+//
+// class declaration
+//
+
+using namespace std;
+using namespace edm;
+using namespace l1t;
+
+class L1PhiMesonSelectionProducer : public edm::global::EDProducer<> {
+public:
+  using L1TTTrackType            = TTTrack<Ref_Phase2TrackerDigi_>;
+  using TTTrackCollectionType    = std::vector<L1TTTrackType>;
+  using TTTrackRef               = edm::Ref<TTTrackCollectionType>;
+  using TTTrackRefCollection     = edm::RefVector<TTTrackCollectionType>;
+  using TTTrackCollectionHandle  = edm::Handle<TTTrackRefCollection>;
+  using TTTrackRefCollectionUPtr = std::unique_ptr<TTTrackRefCollection>;
+
+  explicit L1PhiMesonSelectionProducer(const edm::ParameterSet&);
+  ~L1PhiMesonSelectionProducer() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static constexpr double KaonMass = 0.493677; // GeV
+  size_t phiSize = 20;
+
+private:
+  // ----------member functions ----------------------
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+
+  // ----------selectors -----------------------------
+  // Based on recommendations from https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideGenericSelectors
+
+  // ----------member data ---------------------------
+  const edm::EDGetTokenT<TTTrackRefCollection> l1PosKaonTracksToken_;
+  const edm::EDGetTokenT<TTTrackRefCollection> l1NegKaonTracksToken_;
+  const std::string outputCollectionName_;
+  const edm::ParameterSet cutSet_;
+  const double tkPairdzMax_, tkPairdRMax_, tkPairMMin_, tkPairMMax_;
+  int debug_;
+};
+
+//
+// constructors and destructor
+//
+L1PhiMesonSelectionProducer::L1PhiMesonSelectionProducer(const edm::ParameterSet& iConfig)
+  : l1PosKaonTracksToken_(consumes<TTTrackRefCollection>(iConfig.getParameter<edm::InputTag>("l1PosKaonTracksInputTag"))),
+    l1NegKaonTracksToken_(consumes<TTTrackRefCollection>(iConfig.getParameter<edm::InputTag>("l1NegKaonTracksInputTag"))),
+    outputCollectionName_(iConfig.getParameter<std::string>("outputCollectionName")),
+    cutSet_(iConfig.getParameter<edm::ParameterSet>("cutSet")),
+    tkPairdzMax_(cutSet_.getParameter<double>("tkPairdzMax")),
+    tkPairdRMax_(cutSet_.getParameter<double>("tkPairdRMax")),
+    tkPairMMin_(cutSet_.getParameter<double>("tkPairMMin")),
+    tkPairMMax_(cutSet_.getParameter<double>("tkPairMMax")),
+    debug_(iConfig.getParameter<int>("debug")) 
+{
+  produces<TkPhiCandidateCollection>(outputCollectionName_);
+}
+
+L1PhiMesonSelectionProducer::~L1PhiMesonSelectionProducer() {}
+// ------------ method called to produce the data  ------------
+void L1PhiMesonSelectionProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  auto L1PhiMesonOutput = std::make_unique<l1t::TkPhiCandidateCollection>();
+
+  TTTrackCollectionHandle l1PosKaonTracksHandle;
+  iEvent.getByToken(l1PosKaonTracksToken_, l1PosKaonTracksHandle);
+
+  TTTrackCollectionHandle l1NegKaonTracksHandle;
+  iEvent.getByToken(l1NegKaonTracksToken_, l1NegKaonTracksHandle);
+
+  size_t nPosKaon = l1PosKaonTracksHandle->size();
+  size_t nNegKaon = l1NegKaonTracksHandle->size();
+  L1PhiMesonOutput->reserve(phiSize);  
+
+  for (size_t i = 0; i < nPosKaon; ++i) {
+    const auto& trackPosKaonRef = l1PosKaonTracksHandle->at(i);
+    const auto& trackPosKaon = *trackPosKaonRef;    
+    const edm::Ptr<L1TTTrackType>& trackPosKaonReftoPtr = edm::refToPtr(trackPosKaonRef);
+
+    const GlobalVector& trackPosP = trackPosKaon.momentum();
+    math::PtEtaPhiMLorentzVector posKaonP4(trackPosP.perp(), trackPosP.eta(), trackPosP.phi(), KaonMass);
+
+    for (size_t j = 0; j < nNegKaon; ++j) {
+      const auto& trackNegKaonRef = l1NegKaonTracksHandle->at(j);
+      const auto& trackNegKaon = *trackNegKaonRef;
+
+      const edm::Ptr<L1TTTrackType>& trackNegKaonReftoPtr = edm::refToPtr(trackNegKaonRef);      
+
+      const GlobalVector& trackNegP = trackNegKaon.momentum();
+      math::PtEtaPhiMLorentzVector negKaonP4(trackNegP.perp(), trackNegP.eta(), trackNegP.phi(), KaonMass);
+      
+      math::XYZTLorentzVector phiP4(posKaonP4.Px() + negKaonP4.Px(),
+				    posKaonP4.Py() + negKaonP4.Py(),
+				    posKaonP4.Pz() + negKaonP4.Pz(),
+				    posKaonP4.T()  + negKaonP4.T());
+    
+      TkPhiCandidate tkPhi(phiP4, trackPosKaonReftoPtr, trackNegKaonReftoPtr);
+
+      double dzTrkPair = tkPhi.dzTrkPair();
+      if (std::fabs(dzTrkPair) > tkPairdzMax_) continue;
+      
+      double dRTrkPair = tkPhi.dRTrkPair();
+      if (dRTrkPair > tkPairdRMax_) continue;
+      
+      double mass = tkPhi.p4().M();
+      if (mass < tkPairMMin_ || mass > tkPairMMax_) continue;
+
+      bool dupl = false;
+      for (const auto& el: *L1PhiMesonOutput) {
+	double ptDiff  = el.p4().Pt()  - tkPhi.p4().Pt();
+        double etaDiff = el.p4().Eta() - tkPhi.p4().Eta();
+        double phiDiff = el.p4().Phi() - tkPhi.p4().Phi();
+	if ( fabs(etaDiff) < 1.0e-03 &&
+             fabs(phiDiff) < 1.0e-03 &&
+             fabs(ptDiff)  < 1.0e-02 )
+          {
+            dupl = true;
+            break;
+          }
+      }
+      if (!dupl) {
+	// Put the outputs into the event
+	L1PhiMesonOutput->push_back(tkPhi);
+      }
+    }
+  }
+  iEvent.put(std::move(L1PhiMesonOutput), outputCollectionName_);
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void L1PhiMesonSelectionProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //L1PhiMesonSelectionProducer
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("l1PosKaonTracksInputTag", edm::InputTag("l1KaonTrackSelectionProducer", "Level1TTKaonTracksSelectedPositivecharge"));
+  desc.add<edm::InputTag>("l1NegKaonTracksInputTag", edm::InputTag("l1KaonTrackSelectionProducer", "Level1TTKaonTracksSelectedNegativecharge"));
+  desc.add<std::string>("outputCollectionName", "Level1PhiMesonColl");  {
+    edm::ParameterSetDescription descCutSet;
+    descCutSet.add<double>("tkPairdzMax", 0.5)->setComment("dz between opp. charged track pair must be less than this value, [cm]");
+    descCutSet.add<double>("tkPairdRMax", 0.2)->setComment("dR between opp. charged track pair must be less than this value, []");
+    descCutSet.add<double>("tkPairMMin", 1.0)->setComment("#track pair mass must be greater than this value, [GeV]");
+    descCutSet.add<double>("tkPairMMax", 1.03)->setComment("track pair mass must be less than this value, [GeV]");
+    desc.add<edm::ParameterSetDescription>("cutSet", descCutSet);
+  }
+  desc.add<int>("debug", 0)->setComment("Verbosity levels: 0, 1, 2, 3");
+  descriptions.addWithDefaultLabel(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(L1PhiMesonSelectionProducer);

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackWordUnpacker.h
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackWordUnpacker.h
@@ -1,0 +1,91 @@
+// Utilities used for unpacking the track word
+//----------------------------------------------------------------------------
+//  Authors:  Sweta Baradia, Suchandra Dutta, Subir Sarkar (February 2025)
+//----------------------------------------------------------------------------
+
+#ifndef L1Trigger_L1TTrackMatch_L1TrackWordUnpacker_HH
+#define L1Trigger_L1TTrackMatch_L1TrackWordUnpacker_HH
+
+#include <vector>
+#include <string>
+#include <iostream>
+#include <cmath>
+
+#include <ap_fixed.h>
+#include <ap_int.h>
+
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+
+namespace l1trackunpacker {
+  using L1TTTrackType = TTTrack<Ref_Phase2TrackerDigi_>;
+  
+  // For precision studies
+  const unsigned int PT_INTPART_BITS{9}; 
+  const unsigned int ETA_INTPART_BITS{3};
+  const unsigned int kExtraGlobalPhiBit{4};
+
+  using pt_intern     = ap_ufixed<TTTrack_TrackWord::TrackBitWidths::kRinvSize - 1, PT_INTPART_BITS, AP_TRN, AP_SAT>;
+  using glbeta_intern = ap_fixed<TTTrack_TrackWord::TrackBitWidths::kTanlSize, ETA_INTPART_BITS, AP_TRN, AP_SAT>;
+  using glbphi_intern = ap_int<TTTrack_TrackWord::TrackBitWidths::kPhiSize + kExtraGlobalPhiBit>;
+  using z0_intern     = ap_int<TTTrack_TrackWord::TrackBitWidths::kZ0Size>;  // 40cm / 0.1
+  using d0_intern     = ap_uint<TTTrack_TrackWord::TrackBitWidths::kD0Size>;
+  
+  inline  const unsigned int DoubleToBit(double value, unsigned int maxBits, double step) {
+    unsigned int digitized_value = std::floor(std::abs(value) / step);
+    unsigned int digitized_maximum = (1 << (maxBits - 1)) - 1;  // The remove 1 bit from nBits to account for the sign
+    
+    if (digitized_value > digitized_maximum)
+      digitized_value = digitized_maximum;
+    if (value < 0)
+      digitized_value = (1 << maxBits) - digitized_value;  // two's complement encoding
+    
+    return digitized_value;
+  }
+  inline const double BitToDouble(unsigned int bits, unsigned int maxBits, double step) {
+    int isign = 1;
+    unsigned int digitized_maximum = (1 << maxBits) - 1;
+    if (bits & (1 << (maxBits - 1))) {  // check the sign
+      
+      isign = -1;
+      bits = (1 << (maxBits + 1)) - bits;
+    }
+    return (double(bits & digitized_maximum) + 0.5) * step * isign;
+  }
+  inline const double FloatPtFromBits(const L1TTTrackType& track) {
+    ap_uint<TTTrack_TrackWord::TrackBitWidths::kRinvSize - 1> ptBits = track.getRinvWord();
+    pt_intern digipt;
+    digipt.V = ptBits.range();
+    return digipt.to_double();
+  }
+  inline const double FloatEtaFromBits(const L1TTTrackType& track) {
+    TTTrack_TrackWord::tanl_t etaBits = track.getTanlWord();
+    glbeta_intern digieta;
+    digieta.V = etaBits.range();
+    return digieta.to_double();
+  }
+  inline const double FloatPhiFromBits(const L1TTTrackType& track) {
+    int sector = track.phiSector();
+    double sector_phi_value = 0;
+    if (sector < 5) {
+      sector_phi_value = 2.0 * M_PI * sector / 9.0;
+    } else {
+      sector_phi_value = (-1.0 * M_PI + M_PI / 9.0 + (sector - 5) * 2.0 * M_PI / 9.0);
+    }
+    glbphi_intern trkphiSector = DoubleToBit(sector_phi_value, TTTrack_TrackWord::TrackBitWidths::kPhiSize + kExtraGlobalPhiBit, TTTrack_TrackWord::stepPhi0);
+    glbphi_intern local_phiBits = 0;
+    local_phiBits.V = track.getPhiWord();
+
+    glbphi_intern local_phi =
+      DoubleToBit(BitToDouble(local_phiBits, TTTrack_TrackWord::TrackBitWidths::kPhiSize, TTTrack_TrackWord::stepPhi0),
+                  TTTrack_TrackWord::TrackBitWidths::kPhiSize + l1trackunpacker::kExtraGlobalPhiBit,
+                  TTTrack_TrackWord::stepPhi0);
+    glbphi_intern digiphi = local_phi + trkphiSector;
+    return BitToDouble(digiphi, TTTrack_TrackWord::TrackBitWidths::kPhiSize + l1trackunpacker::kExtraGlobalPhiBit, TTTrack_TrackWord::stepPhi0);
+  }
+  inline const double FloatZ0FromBits(const L1TTTrackType& track) {
+    z0_intern trkZ = track.getZ0Word();
+    return BitToDouble(trkZ, TTTrack_TrackWord::TrackBitWidths::kZ0Size, TTTrack_TrackWord::stepZ0);
+  }
+}  // namespace l1trackunpacker
+
+#endif

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackWordUnpacker.h
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackWordUnpacker.h
@@ -18,34 +18,34 @@
 
 namespace l1trackunpacker {
   using L1TTTrackType = TTTrack<Ref_Phase2TrackerDigi_>;
-  
+
   // For precision studies
-  const unsigned int PT_INTPART_BITS{9}; 
+  const unsigned int PT_INTPART_BITS{9};
   const unsigned int ETA_INTPART_BITS{3};
   const unsigned int kExtraGlobalPhiBit{4};
 
-  using pt_intern     = ap_ufixed<TTTrack_TrackWord::TrackBitWidths::kRinvSize - 1, PT_INTPART_BITS, AP_TRN, AP_SAT>;
+  using pt_intern = ap_ufixed<TTTrack_TrackWord::TrackBitWidths::kRinvSize - 1, PT_INTPART_BITS, AP_TRN, AP_SAT>;
   using glbeta_intern = ap_fixed<TTTrack_TrackWord::TrackBitWidths::kTanlSize, ETA_INTPART_BITS, AP_TRN, AP_SAT>;
   using glbphi_intern = ap_int<TTTrack_TrackWord::TrackBitWidths::kPhiSize + kExtraGlobalPhiBit>;
-  using z0_intern     = ap_int<TTTrack_TrackWord::TrackBitWidths::kZ0Size>;  // 40cm / 0.1
-  using d0_intern     = ap_uint<TTTrack_TrackWord::TrackBitWidths::kD0Size>;
-  
-  inline  const unsigned int DoubleToBit(double value, unsigned int maxBits, double step) {
+  using z0_intern = ap_int<TTTrack_TrackWord::TrackBitWidths::kZ0Size>;  // 40cm / 0.1
+  using d0_intern = ap_uint<TTTrack_TrackWord::TrackBitWidths::kD0Size>;
+
+  inline const unsigned int DoubleToBit(double value, unsigned int maxBits, double step) {
     unsigned int digitized_value = std::floor(std::abs(value) / step);
     unsigned int digitized_maximum = (1 << (maxBits - 1)) - 1;  // The remove 1 bit from nBits to account for the sign
-    
+
     if (digitized_value > digitized_maximum)
       digitized_value = digitized_maximum;
     if (value < 0)
       digitized_value = (1 << maxBits) - digitized_value;  // two's complement encoding
-    
+
     return digitized_value;
   }
   inline const double BitToDouble(unsigned int bits, unsigned int maxBits, double step) {
     int isign = 1;
     unsigned int digitized_maximum = (1 << maxBits) - 1;
     if (bits & (1 << (maxBits - 1))) {  // check the sign
-      
+
       isign = -1;
       bits = (1 << (maxBits + 1)) - bits;
     }
@@ -71,16 +71,20 @@ namespace l1trackunpacker {
     } else {
       sector_phi_value = (-1.0 * M_PI + M_PI / 9.0 + (sector - 5) * 2.0 * M_PI / 9.0);
     }
-    glbphi_intern trkphiSector = DoubleToBit(sector_phi_value, TTTrack_TrackWord::TrackBitWidths::kPhiSize + kExtraGlobalPhiBit, TTTrack_TrackWord::stepPhi0);
+    glbphi_intern trkphiSector = DoubleToBit(sector_phi_value,
+                                             TTTrack_TrackWord::TrackBitWidths::kPhiSize + kExtraGlobalPhiBit,
+                                             TTTrack_TrackWord::stepPhi0);
     glbphi_intern local_phiBits = 0;
     local_phiBits.V = track.getPhiWord();
 
-    glbphi_intern local_phi =
-      DoubleToBit(BitToDouble(local_phiBits, TTTrack_TrackWord::TrackBitWidths::kPhiSize, TTTrack_TrackWord::stepPhi0),
-                  TTTrack_TrackWord::TrackBitWidths::kPhiSize + l1trackunpacker::kExtraGlobalPhiBit,
-                  TTTrack_TrackWord::stepPhi0);
+    glbphi_intern local_phi = DoubleToBit(
+        BitToDouble(local_phiBits, TTTrack_TrackWord::TrackBitWidths::kPhiSize, TTTrack_TrackWord::stepPhi0),
+        TTTrack_TrackWord::TrackBitWidths::kPhiSize + l1trackunpacker::kExtraGlobalPhiBit,
+        TTTrack_TrackWord::stepPhi0);
     glbphi_intern digiphi = local_phi + trkphiSector;
-    return BitToDouble(digiphi, TTTrack_TrackWord::TrackBitWidths::kPhiSize + l1trackunpacker::kExtraGlobalPhiBit, TTTrack_TrackWord::stepPhi0);
+    return BitToDouble(digiphi,
+                       TTTrack_TrackWord::TrackBitWidths::kPhiSize + l1trackunpacker::kExtraGlobalPhiBit,
+                       TTTrack_TrackWord::stepPhi0);
   }
   inline const double FloatZ0FromBits(const L1TTTrackType& track) {
     z0_intern trkZ = track.getZ0Word();

--- a/L1Trigger/L1TTrackMatch/python/l1BsMesonSelectionEmulationProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/l1BsMesonSelectionEmulationProducer_cfi.py
@@ -1,0 +1,17 @@
+import FWCore.ParameterSet.Config as cms
+
+l1BsMesonSelectionEmulationProducer = cms.EDProducer('L1BsMesonSelectionEmulationProducer',
+  l1PhiMesonWordInputTag = cms.InputTag("l1PhiMesonSelectionEmulationProducer","Level1PhiMesonEmulationColl"),
+  posTrackInputTag = cms.InputTag("l1KaonTrackSelectionProducer", "Level1TTKaonTracksSelectedEmulationPositivecharge"),
+  negTrackInputTag = cms.InputTag("l1KaonTrackSelectionProducer", "Level1TTKaonTracksSelectedEmulationNegativecharge"),
+  outputCollectionName = cms.string("Level1BsHadronicEmulationColl"),
+  cutSet = cms.PSet(
+      phiPairdzMax = cms.double(0.5),
+      phiPairdRMin = cms.double(0.2),
+      phiPairdRMax = cms.double(1.0),
+      phiPairMMin = cms.double(5.0),
+      phiPairMMax = cms.double(5.8),
+      bsPtMin = cms.double(13.0)
+  ),
+  debug = cms.int32(0)
+)

--- a/L1Trigger/L1TTrackMatch/python/l1BsMesonSelectionProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/l1BsMesonSelectionProducer_cfi.py
@@ -1,0 +1,16 @@
+import FWCore.ParameterSet.Config as cms
+
+l1BsMesonSelectionProducer = cms.EDProducer('L1BsMesonSelectionProducer',
+  l1PhiCandInputTag = cms.InputTag("l1PhiMesonSelectionProducer", "Level1PhiMesonColl"),
+  outputCollectionName = cms.string("Level1BsHadronicColl"),
+  cutSet = cms.PSet(
+      phiPairdzMax = cms.double(0.5),
+      phiPairdRMin = cms.double(0.2),
+      phiPairdRMax = cms.double(1.0),
+      phiPairMMin = cms.double(5.0), 
+      phiPairMMax = cms.double(5.8), 
+      bsPtMin = cms.double(13.0) 
+  ),
+  debug = cms.int32(0)
+)
+

--- a/L1Trigger/L1TTrackMatch/python/l1KaonTrackSelectionProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/l1KaonTrackSelectionProducer_cfi.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+l1KaonTrackSelectionProducer = cms.EDProducer('L1KaonTrackSelectionProducer',
+  l1TracksInputTag = cms.InputTag("l1tTrackSelectionProducer","Level1TTTracksSelected"),                                            
+  outputCollectionName = cms.string("Level1TTKaonTracksSelected"),
+  processSimulatedTracks = cms.bool(True), # return selected tracks after cutting on the floating point values
+  processEmulatedTracks = cms.bool(True), # return selected tracks after cutting on the bitwise emulated values
+  debug = cms.int32(4) # Verbosity levels: 0, 1, 2, 3, 4
+)
+

--- a/L1Trigger/L1TTrackMatch/python/l1PhiMesonSelectionEmulationProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/l1PhiMesonSelectionEmulationProducer_cfi.py
@@ -1,0 +1,14 @@
+import FWCore.ParameterSet.Config as cms
+
+l1PhiMesonSelectionEmulationProducer = cms.EDProducer('L1PhiMesonSelectionEmulationProducer',
+  l1PosKaonTracksInputTag = cms.InputTag("l1KaonTrackSelectionProducer","Level1TTKaonTracksSelectedEmulationPositivecharge"),
+  l1NegKaonTracksInputTag = cms.InputTag("l1KaonTrackSelectionProducer","Level1TTKaonTracksSelectedEmulationNegativecharge"),
+  outputCollectionName = cms.string("Level1PhiMesonEmulationColl"),
+  cutSet = cms.PSet(
+      tkPairdzMax = cms.double(0.5),
+      tkPairdRMax = cms.double(0.2),
+      tkPairMMin = cms.double(1.0), 
+      tkPairMMax = cms.double(1.03) 
+  ),
+  debug = cms.int32(0)
+)

--- a/L1Trigger/L1TTrackMatch/python/l1PhiMesonSelectionProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/l1PhiMesonSelectionProducer_cfi.py
@@ -1,0 +1,16 @@
+import FWCore.ParameterSet.Config as cms
+
+l1PhiMesonSelectionProducer = cms.EDProducer('L1PhiMesonSelectionProducer',
+  l1PosKaonTracksInputTag = cms.InputTag("l1KaonTrackSelectionProducer","Level1TTKaonTracksSelectedPositivecharge"),
+  l1NegKaonTracksInputTag = cms.InputTag("l1KaonTrackSelectionProducer","Level1TTKaonTracksSelectedNegativecharge"),
+  outputCollectionName = cms.string("Level1PhiMesonColl"),
+  cutSet = cms.PSet(
+      tkPairdzMax = cms.double(0.5),
+      tkPairdRMax = cms.double(0.2),
+      tkPairMMin = cms.double(1.0), 
+      tkPairMMax = cms.double(1.03) 
+  ),
+  debug = cms.int32(0)
+)
+
+

--- a/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker.cc
+++ b/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker.cc
@@ -209,7 +209,7 @@ private:
   //edm::InputTag TrackMETEmuExtendedInputTag;
   edm::InputTag TrackMHTExtendedInputTag;
   edm::InputTag TrackMHTEmuExtendedInputTag;
-  
+
   edm::InputTag TrackPhiCandsInputTag;
   edm::InputTag TrackBsCandsInputTag;
   edm::InputTag TrackPhiCandsEmulationInputTag;
@@ -1045,7 +1045,7 @@ void L1TrackObjectNtupleMaker::endJob() {
   delete m_trkfastjetExt_ntracks;
   delete m_trkfastjetExt_tp_sumpt;
   delete m_trkfastjetExt_truetp_sumpt;
-  
+
   delete m_phicands_eta;
   delete m_phicands_phi;
   delete m_phicands_mass;
@@ -1063,7 +1063,6 @@ void L1TrackObjectNtupleMaker::endJob() {
   delete m_bscandsemulation_phi;
   delete m_bscandsemulation_mass;
   delete m_bscandsemulation_pt;
-
 }
 
 ////////////
@@ -1336,7 +1335,7 @@ void L1TrackObjectNtupleMaker::beginJob() {
   m_trkfastjetExt_ntracks = new std::vector<int>;
   m_trkfastjetExt_tp_sumpt = new std::vector<float>;
   m_trkfastjetExt_truetp_sumpt = new std::vector<float>;
-  
+
   m_phicands_eta = new std::vector<float>;
   m_phicands_phi = new std::vector<float>;
   m_phicands_mass = new std::vector<float>;
@@ -1345,7 +1344,7 @@ void L1TrackObjectNtupleMaker::beginJob() {
   m_phicandsemulation_phi = new std::vector<float>;
   m_phicandsemulation_mass = new std::vector<float>;
   m_phicandsemulation_pt = new std::vector<float>;
-  
+
   m_bscands_eta = new std::vector<float>;
   m_bscands_phi = new std::vector<float>;
   m_bscands_mass = new std::vector<float>;
@@ -1354,7 +1353,7 @@ void L1TrackObjectNtupleMaker::beginJob() {
   m_bscandsemulation_phi = new std::vector<float>;
   m_bscandsemulation_mass = new std::vector<float>;
   m_bscandsemulation_pt = new std::vector<float>;
-  
+
   // ntuple
   eventTree = fs->make<TTree>("eventTree", "Event tree");
   if (SaveAllTracks && (Displaced == "Prompt" || Displaced == "Both")) {
@@ -1651,25 +1650,25 @@ void L1TrackObjectNtupleMaker::beginJob() {
       eventTree->Branch("trkHTEmuExt", &trkHTEmuExt, "trkHTEmuExt/F");
     }
   }
-  
+
   if (SaveTrackPhiCands) {
     eventTree->Branch("phicands_eta", &m_phicands_eta);
     eventTree->Branch("phicands_mass", &m_phicands_mass);
     eventTree->Branch("phicands_pt", &m_phicands_pt);
     eventTree->Branch("phicands_phi", &m_phicands_phi);
-    
+
     eventTree->Branch("phicandsemulation_eta", &m_phicandsemulation_eta);
     eventTree->Branch("phicandsemulation_mass", &m_phicandsemulation_mass);
     eventTree->Branch("phicandsemulation_pt", &m_phicandsemulation_pt);
     eventTree->Branch("phicandsemulation_phi", &m_phicandsemulation_phi);
   }
-  
+
   if (SaveTrackBsCands) {
     eventTree->Branch("bscands_eta", &m_bscands_eta);
     eventTree->Branch("bscands_mass", &m_bscands_mass);
     eventTree->Branch("bscands_pt", &m_bscands_pt);
     eventTree->Branch("bscands_phi", &m_bscands_phi);
-    
+
     eventTree->Branch("bscandsemulation_eta", &m_bscandsemulation_eta);
     eventTree->Branch("bscandsemulation_mass", &m_bscandsemulation_mass);
     eventTree->Branch("bscandsemulation_pt", &m_bscandsemulation_pt);
@@ -1683,8 +1682,8 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
   if (not available_)
     return;  // No ROOT file open.
 
-  if (!(MyProcess == 13 || MyProcess == 11 || MyProcess == 211 || MyProcess == 6 || MyProcess == 15 ||
-        MyProcess == 1 || MyProcess == 321)) {
+  if (!(MyProcess == 13 || MyProcess == 11 || MyProcess == 211 || MyProcess == 6 || MyProcess == 15 || MyProcess == 1 ||
+        MyProcess == 321)) {
     edm::LogVerbatim("Tracklet") << "The specified MyProcess is invalid! Exiting...";
     return;
   }
@@ -1960,13 +1959,13 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
     m_phicands_pt->clear();
     m_phicands_phi->clear();
     m_phicands_mass->clear();
-    
+
     m_phicandsemulation_eta->clear();
     m_phicandsemulation_pt->clear();
     m_phicandsemulation_phi->clear();
     m_phicandsemulation_mass->clear();
   }
-  
+
   if (SaveTrackBsCands) {
     m_bscands_eta->clear();
     m_bscands_pt->clear();
@@ -1978,7 +1977,7 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
     m_bscandsemulation_phi->clear();
     m_bscandsemulation_mass->clear();
   }
-  
+
   // -----------------------------------------------------------------------------------------------
   // retrieve various containers
   // -----------------------------------------------------------------------------------------------
@@ -2074,12 +2073,12 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
   edm::Handle<L1TrackRefCollection> TTTrackExtendedSelectedAssociatedEmulationForEtMissHandle;
   edm::Handle<L1TrackRefCollection> TTTrackExtendedSelectedForEtMissHandle;
   edm::Handle<L1TrackRefCollection> TTTrackExtendedSelectedEmulationForEtMissHandle;
-  
+
   edm::Handle<l1t::TkPhiCandidateCollection> TrackPhiCandsHandle;
   edm::Handle<l1t::TkBsCandidateCollection> TrackBsCandsHandle;
   edm::Handle<l1t::TkLightMesonWordCollection> TrackPhiCandsEmulationHandle;
   edm::Handle<l1t::TkLightMesonWordCollection> TrackBsCandsEmulationHandle;
-  
+
   L1TrackCollection::const_iterator iterL1Track;
 
   if (Displaced == "Prompt" || Displaced == "Both") {
@@ -2185,7 +2184,7 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
   } else {
     edm::LogWarning("DataNotFound") << "\nWarning: SimVertexHandle not found in the event" << std::endl;
   }
-  
+
   // ----------------------------------------------------------------------------------------------
   // loop over L1 stubs
   // ----------------------------------------------------------------------------------------------
@@ -2504,7 +2503,7 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
 
       this_l1track++;
     }  //end track loop
-  }    //end if SaveAllTracks
+  }  //end if SaveAllTracks
 
   // ----------------------------------------------------------------------------------------------
   // loop over (extended) L1 tracks
@@ -2718,7 +2717,7 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
         m_trkExt_selected_associated_emulation_foretmiss_index->push_back(this_l1track);
       this_l1track++;
     }  //end track loop
-  }    //end if SaveAllTracks (displaced)
+  }  //end if SaveAllTracks (displaced)
 
   // ----------------------------------------------------------------------------------------------
   // loop over tracking particles
@@ -2970,7 +2969,7 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
           }
 
         }  // end loop over matched L1 tracks
-      }    // end has at least 1 matched L1 track
+      }  // end has at least 1 matched L1 track
       // ----------------------------------------------------------------------------------------------
 
       float tmp_matchtrk_pt = -999;
@@ -3141,7 +3140,7 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
           }
 
         }  // end loop over matched L1 tracks
-      }    // end has at least 1 matched L1 track
+      }  // end has at least 1 matched L1 track
       // ----------------------------------------------------------------------------------------------
 
       float tmp_matchtrkExt_pt = -999;
@@ -3390,7 +3389,7 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
         m_trkjetExt_nTightDisplaced->push_back(jetIter->nTightDisptracks());
       }
     }
-  
+
     if (!TrackJetsEmuHandle.isValid() && (Displaced == "Prompt" || Displaced == "Both"))
       edm::LogWarning("DataNotFound") << "\nWarning: TrackJetsEmuHandle not found" << std::endl;
     else if (TrackJetsEmuHandle.isValid() && (Displaced == "Prompt" || Displaced == "Both")) {
@@ -3422,45 +3421,38 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
     if (TrackPhiCandsHandle.isValid()) {
       std::vector<l1t::TkPhiCandidate>::const_iterator phicandsIter;
       for (phicandsIter = TrackPhiCandsHandle->begin(); phicandsIter != TrackPhiCandsHandle->end(); ++phicandsIter) {
-        if (0) cout << "Phi Candidate: ("
-                    << phicandsIter->pt() << ", "
-                    << phicandsIter->eta() << ", "
-                    << phicandsIter->phi() << ", "
-                    << phicandsIter->mass()
-                    << ")" << endl;
+        if (0)
+          cout << "Phi Candidate: (" << phicandsIter->pt() << ", " << phicandsIter->eta() << ", " << phicandsIter->phi()
+               << ", " << phicandsIter->mass() << ")" << endl;
         m_phicands_phi->push_back(phicandsIter->phi());
         m_phicands_eta->push_back(phicandsIter->eta());
         m_phicands_pt->push_back(phicandsIter->pt());
         m_phicands_mass->push_back(phicandsIter->mass());
       }
     }
-    
+
     if (TrackPhiCandsEmulationHandle.isValid()) {
       std::vector<l1t::TkLightMesonWord>::const_iterator phicandsemulationIter;
-      for (phicandsemulationIter = TrackPhiCandsEmulationHandle->begin(); phicandsemulationIter != TrackPhiCandsEmulationHandle->end(); ++phicandsemulationIter) {
-        if (0) cout << "Emu Phi Candidate: ("
-                    << phicandsemulationIter->pt() << ", "
-                    << phicandsemulationIter->glbeta() << ", "
-                    << phicandsemulationIter->glbphi() << ", "
-                    << phicandsemulationIter->mass()
-                    << ")" << endl;
+      for (phicandsemulationIter = TrackPhiCandsEmulationHandle->begin();
+           phicandsemulationIter != TrackPhiCandsEmulationHandle->end();
+           ++phicandsemulationIter) {
+        if (0)
+          cout << "Emu Phi Candidate: (" << phicandsemulationIter->pt() << ", " << phicandsemulationIter->glbeta()
+               << ", " << phicandsemulationIter->glbphi() << ", " << phicandsemulationIter->mass() << ")" << endl;
         m_phicandsemulation_phi->push_back(phicandsemulationIter->glbphi());
-	m_phicandsemulation_eta->push_back(phicandsemulationIter->glbeta());
-	m_phicandsemulation_pt->push_back(phicandsemulationIter->pt());
-	m_phicandsemulation_mass->push_back(phicandsemulationIter->mass());
+        m_phicandsemulation_eta->push_back(phicandsemulationIter->glbeta());
+        m_phicandsemulation_pt->push_back(phicandsemulationIter->pt());
+        m_phicandsemulation_mass->push_back(phicandsemulationIter->mass());
       }
     }
-  } // end track phicands                                                                                                                                                                                                                                                                                                                                                     
+  }  // end track phicands
   if (SaveTrackBsCands) {
     if (TrackBsCandsHandle.isValid()) {
       std::vector<l1t::TkBsCandidate>::const_iterator bscandsIter;
       for (bscandsIter = TrackBsCandsHandle->begin(); bscandsIter != TrackBsCandsHandle->end(); ++bscandsIter) {
-        if (0) cout << "Bs Candidate: ("
-                    << bscandsIter->pt() << ", "
-                    << bscandsIter->eta() << ", "
-                    << bscandsIter->phi() << ", "
-                    << bscandsIter->mass()
-                    << ")" << endl;
+        if (0)
+          cout << "Bs Candidate: (" << bscandsIter->pt() << ", " << bscandsIter->eta() << ", " << bscandsIter->phi()
+               << ", " << bscandsIter->mass() << ")" << endl;
 
         m_bscands_phi->push_back(bscandsIter->phi());
         m_bscands_eta->push_back(bscandsIter->eta());
@@ -3468,26 +3460,25 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
         m_bscands_mass->push_back(bscandsIter->mass());
       }
     }
-    
+
     if (TrackBsCandsEmulationHandle.isValid()) {
       std::vector<l1t::TkLightMesonWord>::const_iterator bscandsemulationIter;
-      for (bscandsemulationIter = TrackBsCandsEmulationHandle->begin(); bscandsemulationIter != TrackBsCandsEmulationHandle->end(); ++bscandsemulationIter) {
-        if (0) cout << "Emu bs Candidate: ("
-                    << bscandsemulationIter->pt() << ", "
-                    << bscandsemulationIter->glbeta() << ", "
-                    << bscandsemulationIter->glbphi() << ", "
-                    << bscandsemulationIter->mass()
-                    << ")" << endl;
-	
+      for (bscandsemulationIter = TrackBsCandsEmulationHandle->begin();
+           bscandsemulationIter != TrackBsCandsEmulationHandle->end();
+           ++bscandsemulationIter) {
+        if (0)
+          cout << "Emu bs Candidate: (" << bscandsemulationIter->pt() << ", " << bscandsemulationIter->glbeta() << ", "
+               << bscandsemulationIter->glbphi() << ", " << bscandsemulationIter->mass() << ")" << endl;
+
         m_bscandsemulation_phi->push_back(bscandsemulationIter->glbphi());
         m_bscandsemulation_eta->push_back(bscandsemulationIter->glbeta());
         m_bscandsemulation_pt->push_back(bscandsemulationIter->pt());
         m_bscandsemulation_mass->push_back(bscandsemulationIter->mass());
       }
     }
-  } // end track bscands    
+  }  // end track bscands
   eventTree->Fill();
-} // end of analyze()
+}  // end of analyze()
 
 int L1TrackObjectNtupleMaker::getSelectedTrackIndex(const L1TrackRef& trackRef,
                                                     const edm::Handle<L1TrackRefCollection>& selectedTrackRefs) const {


### PR DESCRIPTION
**Draft PR for internal review in the GTT group.**

This PR is to merge the developed Bs -> ϕ ϕ -> 4k analysis (both simulation and emulation). The code and algorithm were presented in the last GTT meetings and are summarised in the attached slides. 
Other than addition of code dedicated for this process, **the floating bits in the GTT producer needs to be increased as discussed in the previous meetings, discussed in the attached slides and mentioned in [1]. This is crucial for improving the precision of ϕ meson reconstruction.** 

[1] https://github.com/cms-sw/cmssw/blob/master/L1Trigger/L1TTrackMatch/Readme.md#status-october-2024
[
[BsPhiPhi_Phase2GTT.pdf](https://github.com/user-attachments/files/18794636/BsPhiPhi_Phase2GTT.pdf)
](url)