### PR TITLE
MTD reconstruction and validation: update TkFilterParameters in MTD use with Phase2 settings

### DIFF
--- a/RecoMTD/TimingIDTools/python/mvaTrainingNtuple_cff.py
+++ b/RecoMTD/TimingIDTools/python/mvaTrainingNtuple_cff.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoMTD.TimingIDTools.mvaTrainingNtuple_cfi import *
+from RecoVertex.Configuration.RecoVertex_cff import unsortedOfflinePrimaryVertices4D
+
+# higher eta cut for the phase 2 tracker
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(mvaTrainingNtuple, TkFilterParameters = cms.PSet(unsortedOfflinePrimaryVertices4D.TkFilterParameters.clone()))

--- a/RecoMTD/TimingIDTools/test/mvaTrainingSaveNtuple_cfg.py
+++ b/RecoMTD/TimingIDTools/test/mvaTrainingSaveNtuple_cfg.py
@@ -1,12 +1,13 @@
-
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("SaveNtuple")
+from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
+
+process = cms.Process("SaveNtuple",Phase2C17I13M9)
 
 process.load('Configuration.StandardSequences.Services_cff')
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load('Configuration.EventContent.EventContent_cff')
-process.load('Configuration.Geometry.GeometryExtended2026D110Reco_cff')
+process.load('Configuration.Geometry.GeometryExtendedRun4D110Reco_cff')
 process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.StandardSequences.Reconstruction_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
@@ -27,7 +28,7 @@ process.source = cms.Source("PoolSource",
                             )
 )
 
-from RecoMTD.TimingIDTools.mvaTrainingNtuple_cfi import mvaTrainingNtuple
+from RecoMTD.TimingIDTools.mvaTrainingNtuple_cff import mvaTrainingNtuple
 
 process.mvaTrainingNtuple = mvaTrainingNtuple
 

--- a/Validation/Configuration/python/mtdSimValid_cff.py
+++ b/Validation/Configuration/python/mtdSimValid_cff.py
@@ -19,7 +19,7 @@ from Validation.MtdValidation.etlLocalRecoValid_cfi import etlLocalRecoValid
 from Validation.MtdValidation.etlSimHitsValid_cfi import etlSimHitsValid
 from Validation.MtdValidation.etlDigiHitsValid_cfi import etlDigiHitsValid
 from Validation.MtdValidation.mtdTracksValid_cfi import mtdTracksValid
-from Validation.MtdValidation.vertices4DValid_cfi import vertices4DValid
+from Validation.MtdValidation.vertices4DValid_cff import vertices4DValid
 
 mtdSimValid  = cms.Sequence(btlSimHitsValid  + etlSimHitsValid )
 mtdDigiValid = cms.Sequence(btlDigiHitsValid + etlDigiHitsValid)

--- a/Validation/MtdValidation/python/vertices4DValid_cff.py
+++ b/Validation/MtdValidation/python/vertices4DValid_cff.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+from Validation.MtdValidation.vertices4DValid_cfi import vertices4DValid
+from RecoVertex.Configuration.RecoVertex_cff import unsortedOfflinePrimaryVertices4D
+
+# higher eta cut for the phase 2 tracker
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(vertices4DValid, TkFilterParameters = cms.PSet(unsortedOfflinePrimaryVertices4D.TkFilterParameters.clone()))

--- a/Validation/MtdValidation/test/mtdValidation_cfg.py
+++ b/Validation/MtdValidation/test/mtdValidation_cfg.py
@@ -54,7 +54,7 @@ etlValidation = cms.Sequence(process.etlSimHitsValid + process.etlDigiHitsValid 
 # --- Global Validation
 process.load("Validation.MtdValidation.mtdTracksValid_cfi")
 process.load("Validation.MtdValidation.mtdEleIsoValid_cfi")
-process.load("Validation.MtdValidation.vertices4DValid_cfi")
+process.load("Validation.MtdValidation.vertices4DValid_cff")
 
 # process.btlDigiHitsValid.optionalPlots = True
 # process.etlDigiHitsValid.optionalPlots = True


### PR DESCRIPTION
#### PR description:

Both the producer of root-ples to train MVA models for MTD, in ```RecoMTD/TimingIDTools```, and the ```Primary4DVerticesValidation``` class in ```Validation/MtdValidation``` import the ```TkFilterParameters``` PSet from ```RecoVertex/PrimaryVertexProducer```.  It needs to be used in its Phase2 setting, in particular enlarging the eta acceptance.

This PR fixes the missing customisation in both cases.

#### PR validation:

Expanded config files produced with this update produce the desired configuration. Standalone cfg configurations for both ```mvaTrainingSaveNtuple_cfg.py``` and ```mtdValidation_cfg.py``` are updated accordingly.