### PR TITLE
fix `throwOnMissing` logic in `ObjectSelectorBase`

### DIFF
--- a/CommonTools/UtilAlgos/interface/ObjectSelectorBase.h
+++ b/CommonTools/UtilAlgos/interface/ObjectSelectorBase.h
@@ -40,7 +40,7 @@ public:
         srcToken_(
             this->template consumes<typename Selector::collection>(cfg.template getParameter<edm::InputTag>("src"))),
         filter_(false),
-        throwOnMissing_(cfg.template getUntrackedParameter<bool>("throwOnMissing", true)),
+        throwOnMissing_(cfg.getUntrackedParameter<bool>("throwOnMissing", true)),
         selectorInit_(this->consumesCollector()),
         selector_(cfg, this->consumesCollector()),
         sizeSelector_(reco::modules::make<SizeSelector>(cfg)),
@@ -69,10 +69,13 @@ private:
   bool filter(edm::Event& evt, const edm::EventSetup& es) override {
     selectorInit_.init(selector_, evt, es);
     edm::Handle<typename Selector::collection> source;
+    evt.getByToken(srcToken_, source);
+    // if throwOnMissing is false, but the input source is not valid
+    // allow all events to pass
     if (!throwOnMissing_ && !source.isValid()) {
       return !filter_;
     }
-    evt.getByToken(srcToken_, source);
+
     StoreManager manager(source);
     selector_.select(source, evt, es);
     manager.cloneAndStore(selector_.begin(), selector_.end(), evt);


### PR DESCRIPTION
#### PR description:

This PR is a follow-up to https://github.com/cms-sw/cmssw/pull/45385.
It fixes the logic of `throwOnMissing` in `ObjectSelectorBase`. Before this PR the check at line:

https://github.com/cms-sw/cmssw/blob/365705add198add5f751c863f47a182ecab0b137/CommonTools/UtilAlgos/interface/ObjectSelectorBase.h#L72-L74

was buggy, because the `source`  was never valid (as the consumes was acted upon only after the `if` at L75):

https://github.com/cms-sw/cmssw/blob/365705add198add5f751c863f47a182ecab0b137/CommonTools/UtilAlgos/interface/ObjectSelectorBase.h#L75

in that way, if `throwOnMissing_` was `false` (since `!source.isValid()` was always `false` at that point) the filter was always doing an early return, without saving any of the products.

#### PR validation:

The PR validation done was similar to the one done for https://github.com/cms-sw/cmssw/pull/45357.

Run the following command: 
```bash
runTheMatrix.py --what upgrade -l 12842.0 -t 4 -j 8 --nEvents=100
```

to produce an input file, then analyzed with `SagittaBiasNtuplizer` (introduced back then at PR https://github.com/cms-sw/cmssw/pull/44282) by using this patch:

```diff
diff --git a/Alignment/OfflineValidation/test/SagittaBiasNtuplizer_cfg.py b/Alignment/OfflineValidation/test/SagittaBiasNtuplizer_cfg.py
index e5f08e57ebf..bfeb8c65021 100644
--- a/Alignment/OfflineValidation/test/SagittaBiasNtuplizer_cfg.py
+++ b/Alignment/OfflineValidation/test/SagittaBiasNtuplizer_cfg.py
@@ -179,18 +179,19 @@ process.refittedTracks = RecoTracker.TrackProducer.TrackRefitter_cfi.TrackRefitt
 ####################################################################
 from RecoVertex.PrimaryVertexProducer.OfflinePrimaryVertices_cfi import offlinePrimaryVertices
 process.offlinePrimaryVerticesFromRefittedTrks = offlinePrimaryVertices.clone()
-#process.offlinePrimaryVerticesFromRefittedTrks.TrackLabel = cms.InputTag("refittedVtxTracks")
-process.offlinePrimaryVerticesFromRefittedTrks.TrackLabel = cms.InputTag("refittedTracks")
+process.offlinePrimaryVerticesFromRefittedTrks.TrackLabel = cms.InputTag("refittedVtxTracks")
+#process.offlinePrimaryVerticesFromRefittedTrks.TrackLabel = cms.InputTag("refittedTracks")
 
 ###################################################################
 # The analysis modules
 ###################################################################
 process.ZtoMMNtuple = cms.EDAnalyzer("SagittaBiasNtuplizer",
-                                     #tracks = cms.InputTag('refittedMuons'),
-                                     useReco = cms.bool(True),
-                                     muons = cms.InputTag('muons'),
+                                     muonTracks = cms.InputTag('refittedMuons'),
+                                     useReco = cms.bool(False),
+                                     #muons = cms.InputTag('muons'),
                                      doGen = cms.bool(True),
-                                     tracks = cms.InputTag('refittedTracks'),
+                                     #tracks = cms.InputTag('refittedTracks'),
+                                     genParticles = cms.InputTag('TkAlDiMuonAndVertexGenMuonSelector'),
                                      vertices = cms.InputTag('offlinePrimaryVerticesFromRefittedTrks'))
 
 process.DiMuonVertexValidation = cms.EDAnalyzer("DiMuonVertexValidation",
@@ -257,9 +258,9 @@ process.TFileService = cms.Service("TFileService",
 # Path
 ###################################################################
 process.p1 = cms.Path(process.offlineBeamSpot
-                      #* process.refittedMuons
-                      #* process.refittedVtxTracks
-                      * process.refittedTracks
+                      * process.refittedMuons
+                      * process.refittedVtxTracks
+                      #* process.refittedTracks
                       * process.offlinePrimaryVerticesFromRefittedTrks
                       * process.ZtoMMNtuple) 
                       #* process.DiMuonVertexValidation
```

and analyzed with:
 
```bash
cmsRun SagittaBiasNtuplizer_cfg.py myfile=file:../../../12842.0_ZMM_13+2024/TkAlDiMuonAndVertex.root
```
 Finally the resulting output ntuple has been checked for having appropriate branches filled.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but it will be backported all the way to `CMSSW_14_0_X`.
