### PR TITLE
update on strip approximate cluster

### DIFF
--- a/Configuration/Eras/python/Era_Run2024_approxSiStripCluster.py
+++ b/Configuration/Eras/python/Era_Run2024_approxSiStripCluster.py
@@ -4,4 +4,4 @@ from Configuration.Eras.Era_Run3_2024_cff import Run3_2024
 from Configuration.ProcessModifiers.approxSiStripClusters_cff import approxSiStripClusters
 from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
 
-Run3_pp_on_PbPb_approxSiStripClusters_2024 = cms.ModifierChain(Run3_2024.copyAndExclude([trackingNoLoopers]),  approxSiStripClusters) 
+Run3_2024_approxSiStripClusters = cms.ModifierChain(Run3_2024.copyAndExclude([trackingNoLoopers]),  approxSiStripClusters) 

--- a/Configuration/Eras/python/Era_Run2024_approxSiStripCluster.py
+++ b/Configuration/Eras/python/Era_Run2024_approxSiStripCluster.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run3_2024_cff import Run3_2024
+from Configuration.ProcessModifiers.approxSiStripClusters_cff import approxSiStripClusters
+from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
+
+Run3_pp_on_PbPb_approxSiStripClusters_2024 = cms.ModifierChain(Run3_2024.copyAndExclude([trackingNoLoopers]),  approxSiStripClusters) 

--- a/Configuration/Eras/python/Era_Run2024_approxSiStripCluster.py
+++ b/Configuration/Eras/python/Era_Run2024_approxSiStripCluster.py
@@ -1,7 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-from Configuration.Eras.Era_Run3_2024_cff import Run3_2024
-from Configuration.ProcessModifiers.approxSiStripClusters_cff import approxSiStripClusters
-from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
-
-Run3_2024_approxSiStripClusters = cms.ModifierChain(Run3_2024.copyAndExclude([trackingNoLoopers]),  approxSiStripClusters) 

--- a/Configuration/Eras/python/Era_Run3_2024_approxSiStripClusters_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2024_approxSiStripClusters_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run3_2024_cff import Run3_2024
+from Configuration.ProcessModifiers.approxSiStripClusters_cff import approxSiStripClusters
+
+Run3_2024_approxSiStripClusters = cms.ModifierChain(Run3_2024,  approxSiStripClusters) 

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -44,6 +44,7 @@ class Eras (object):
                  'Run3_pp_on_PbPb_approxSiStripClusters_2023',
                  'Run3_pp_on_PbPb_2024',
                  'Run3_pp_on_PbPb_approxSiStripClusters_2024',
+                 'Run3_2024_approxSiStripClusters',
                  'Run3_dd4hep',
                  'Run3_DDD',
                  'Run3_FastSim',

--- a/DataFormats/SiStripCluster/interface/SiStripApproximateCluster.h
+++ b/DataFormats/SiStripCluster/interface/SiStripApproximateCluster.h
@@ -28,9 +28,10 @@ public:
                                      bool peakFilter);
 
   float barycenter() const {
-    float _barycenter = compBarycenter_ * maxBarycenter_/maxRange_;
+    float _barycenter = compBarycenter_ * maxBarycenter_ / maxRange_;
     assert(_barycenter <= maxBarycenter_ && "Returning barycenter > maxBarycenter");
-    return _barycenter; }
+    return _barycenter;
+  }
   cms_uint8_t width() const { return width_; }
   cms_uint8_t avgCharge() const { return avgCharge_; }
   bool filter() const { return filter_; }
@@ -44,7 +45,7 @@ private:
   bool filter_ = false;
   bool isSaturated_ = false;
   bool peakFilter_ = false;
-  static constexpr double maxRange_ = 65535.; //16 bit
+  static constexpr double maxRange_ = 65535.;  //16 bit
   static constexpr double maxBarycenter_ = 770.;
   static constexpr double trimMaxADC_ = 30.;
   static constexpr double trimMaxFracTotal_ = .15;

--- a/DataFormats/SiStripCluster/interface/SiStripApproximateCluster.h
+++ b/DataFormats/SiStripCluster/interface/SiStripApproximateCluster.h
@@ -2,19 +2,20 @@
 #define DataFormats_SiStripCluster_SiStripApproximateCluster_h
 
 #include "FWCore/Utilities/interface/typedefs.h"
+#include "assert.h"
 
 class SiStripCluster;
 class SiStripApproximateCluster {
 public:
   SiStripApproximateCluster() {}
 
-  explicit SiStripApproximateCluster(cms_uint16_t barycenter,
+  explicit SiStripApproximateCluster(cms_uint16_t compBarycenter,
                                      cms_uint8_t width,
                                      cms_uint8_t avgCharge,
                                      bool filter,
                                      bool isSaturated,
                                      bool peakFilter = false)
-      : barycenter_(barycenter),
+      : compBarycenter_(compBarycenter),
         width_(width),
         avgCharge_(avgCharge),
         filter_(filter),
@@ -26,7 +27,10 @@ public:
                                      float hitPredPos,
                                      bool peakFilter);
 
-  cms_uint16_t barycenter() const { return barycenter_; }
+  float barycenter() const {
+    float _barycenter = compBarycenter_ * maxBarycenter_/maxRange_;
+    assert(_barycenter <= maxBarycenter_ && "Returning barycenter > maxBarycenter");
+    return _barycenter; }
   cms_uint8_t width() const { return width_; }
   cms_uint8_t avgCharge() const { return avgCharge_; }
   bool filter() const { return filter_; }
@@ -34,12 +38,14 @@ public:
   bool peakFilter() const { return peakFilter_; }
 
 private:
-  cms_uint16_t barycenter_ = 0;
+  cms_uint16_t compBarycenter_ = 0;
   cms_uint8_t width_ = 0;
   cms_uint8_t avgCharge_ = 0;
   bool filter_ = false;
   bool isSaturated_ = false;
   bool peakFilter_ = false;
+  static constexpr double maxRange_ = 65535.; //16 bit
+  static constexpr double maxBarycenter_ = 770.;
   static constexpr double trimMaxADC_ = 30.;
   static constexpr double trimMaxFracTotal_ = .15;
   static constexpr double trimMaxFracNeigh_ = .25;

--- a/DataFormats/SiStripCluster/src/SiStripApproximateCluster.cc
+++ b/DataFormats/SiStripCluster/src/SiStripApproximateCluster.cc
@@ -1,18 +1,18 @@
 #include "DataFormats/SiStripCluster/interface/SiStripApproximateCluster.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 #include <algorithm>
+#include <cassert>
 #include <cmath>
-#include <assert.h>
 
 SiStripApproximateCluster::SiStripApproximateCluster(const SiStripCluster& cluster,
                                                      unsigned int maxNSat,
                                                      float hitPredPos,
                                                      bool peakFilter) {
-  compBarycenter_ = std::round(cluster.barycenter() * maxRange_/maxBarycenter_);
+  compBarycenter_ = std::round(cluster.barycenter() * maxRange_ / maxBarycenter_);
   assert(cluster.barycenter() <= maxBarycenter_ && "Got a barycenter > maxBarycenter");
   assert(compBarycenter_ <= maxRange_ && "Filling compBarycenter > maxRange");
   width_ = cluster.size();
-  avgCharge_ = (cluster.charge() + cluster.size()/2) / cluster.size();
+  avgCharge_ = (cluster.charge() + cluster.size() / 2) / cluster.size();
   filter_ = false;
   isSaturated_ = false;
   peakFilter_ = peakFilter;

--- a/DataFormats/SiStripCluster/src/SiStripApproximateCluster.cc
+++ b/DataFormats/SiStripCluster/src/SiStripApproximateCluster.cc
@@ -2,14 +2,17 @@
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 #include <algorithm>
 #include <cmath>
+#include <assert.h>
 
 SiStripApproximateCluster::SiStripApproximateCluster(const SiStripCluster& cluster,
                                                      unsigned int maxNSat,
                                                      float hitPredPos,
                                                      bool peakFilter) {
-  barycenter_ = std::round(cluster.barycenter() * 10);
+  compBarycenter_ = std::round(cluster.barycenter() * maxRange_/maxBarycenter_);
+  assert(cluster.barycenter() <= maxBarycenter_ && "Got a barycenter > maxBarycenter");
+  assert(compBarycenter_ <= maxRange_ && "Filling compBarycenter > maxRange");
   width_ = cluster.size();
-  avgCharge_ = cluster.charge() / cluster.size();
+  avgCharge_ = (cluster.charge() + cluster.size()/2) / cluster.size();
   filter_ = false;
   isSaturated_ = false;
   peakFilter_ = peakFilter;

--- a/DataFormats/SiStripCluster/src/SiStripCluster.cc
+++ b/DataFormats/SiStripCluster/src/SiStripCluster.cc
@@ -23,7 +23,7 @@ SiStripCluster::SiStripCluster(const SiStripDigiRange& range) : firstStrip_(rang
 }
 
 SiStripCluster::SiStripCluster(const SiStripApproximateCluster cluster, const uint16_t maxStrips) : error_x(-99999.9) {
-  barycenter_ = cluster.barycenter() / 10.0;
+  barycenter_ = cluster.barycenter();
   charge_ = cluster.width() * cluster.avgCharge();
   amplitudes_.resize(cluster.width(), cluster.avgCharge());
   filter_ = cluster.filter();

--- a/DataFormats/SiStripCluster/src/classes_def.xml
+++ b/DataFormats/SiStripCluster/src/classes_def.xml
@@ -1,7 +1,6 @@
 <lcgdict>
 
  <class name="SiStripCluster" ClassVersion="13">
-  <version ClassVersion="14" checksum="382853235"/>
   <version ClassVersion="13" checksum="1374720584"/>
   <version ClassVersion="12" checksum="2984011925"/>
   <version ClassVersion="11" checksum="3702468681"/>
@@ -55,7 +54,6 @@
  <class name="edm::Wrapper<edmNew::DetSetVector<edm::Ref<edmNew::DetSetVector<SiStripApproximateCluster>,SiStripApproximateCluster,edmNew::DetSetVector<SiStripApproximateCluster>::FindForDetSetVector> > >" />
 
  <class name="SiStripClustersSOA" ClassVersion="3">
-  <version ClassVersion="4" checksum="296520179"/>
   <version ClassVersion="3" checksum="2739562998"/>
  </class>
  <class name="edm::Wrapper<SiStripClustersSOA>"/>

--- a/DataFormats/SiStripCluster/src/classes_def.xml
+++ b/DataFormats/SiStripCluster/src/classes_def.xml
@@ -1,6 +1,7 @@
 <lcgdict>
 
  <class name="SiStripCluster" ClassVersion="13">
+  <version ClassVersion="14" checksum="382853235"/>
   <version ClassVersion="13" checksum="1374720584"/>
   <version ClassVersion="12" checksum="2984011925"/>
   <version ClassVersion="11" checksum="3702468681"/>
@@ -25,7 +26,8 @@
  <class name="edm::Wrapper<edmNew::DetSetVector<edm::Ref<edmNew::DetSetVector<SiStripCluster>,SiStripCluster,edmNew::DetSetVector<SiStripCluster>::FindForDetSetVector> > >" />
 
 
- <class name="SiStripApproximateCluster" ClassVersion="6">
+ <class name="SiStripApproximateCluster" ClassVersion="7">
+  <version ClassVersion="7" checksum="3059068941"/>
   <version ClassVersion="6" checksum="132211472"/>
   <version ClassVersion="5" checksum="3495825183"/>
   <version ClassVersion="4" checksum="2854791577"/>
@@ -53,6 +55,7 @@
  <class name="edm::Wrapper<edmNew::DetSetVector<edm::Ref<edmNew::DetSetVector<SiStripApproximateCluster>,SiStripApproximateCluster,edmNew::DetSetVector<SiStripApproximateCluster>::FindForDetSetVector> > >" />
 
  <class name="SiStripClustersSOA" ClassVersion="3">
+  <version ClassVersion="4" checksum="296520179"/>
   <version ClassVersion="3" checksum="2739562998"/>
  </class>
  <class name="edm::Wrapper<SiStripClustersSOA>"/>

--- a/DataFormats/SiStripCluster/test/TestReadSiStripApproximateClusterCollection.cc
+++ b/DataFormats/SiStripCluster/test/TestReadSiStripApproximateClusterCollection.cc
@@ -77,7 +77,7 @@ namespace edmtest {
       unsigned int j = 0;
       for (const auto& cluster : detClusters) {
         unsigned int iOffset = j + iEvent.id().event();
-        if (cluster.barycenter() != expectedIntegralValues_[1] + iOffset) {
+        if (std::round(cluster.barycenter() * 65535.0 / 770.0) != expectedIntegralValues_[1] + iOffset) {
           throwWithMessage("barycenter does not have expected value");
         }
         if (cluster.width() != expectedIntegralValues_[2] + iOffset) {


### PR DESCRIPTION
#### PR description:

##### Correction for Average charge in Approximated cluster

- The average charge defined as Int avgCharge = cluster.charge()/cluster.size() which doesn't return to nearest integer value in c++. The affect is shown in average charge difference between RAW and RAW' dataset.

- The bug fixes as Int avgCharge - (cluster.charge()+cluster.size()/2)/cluster.size()

- Details can found[ here slide 4](https://indico.cern.ch/event/1505968/contributions/6362526/attachments/3009026/5310942/TrackDPG_v2.pdf)

##### Compression of barycenter

- Instead of storing barycenter to 16 bit Int , choose the float variable and compress the variable using std::round(cluster.barycenter() * bit_range / maxBarycenter)

- _bit_range_ is the range of each bit value, e.g. bit range for 16 bit is 2^16 - 1 = 65535.

- _maxBarycenter_ is the maximum value of barycenter which found that is 770.0.

- Details can found [here slide 9](https://indico.cern.ch/event/1421629/contributions/6136900/attachments/2975519/5237807/NGT%20-%20Task%203.3%20-%201st%20NGT%20technical%20workshop.pdf)

##### Changing the configuration

- The  `Configuration.Eras.Era_Run2024_approxSiStripCluster` is the configuration use for run approximate cluster collection in the **RECO** step. 