### PR TITLE
Updates for `runTheMatrix.py`: input checks, GPUs repartition, input recycling

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixRunner.py
+++ b/Configuration/PyReleaseValidation/python/MatrixRunner.py
@@ -50,12 +50,15 @@ class MatrixRunner(object):
         wfs_to_run = self.workFlows
         withDups = False
         if testList:
-            withDups = len(check_dups(testList))>0
+            if opt.allowDuplicates: 
+                withDups = len(check_dups(testList))>0
+            else:
+                testList = set(testList)
             wfs_to_run = [wf for wf in self.workFlows if float(wf.numId) in testList for i in range(Counter(testList)[wf.numId])]
 
         for n,wf in enumerate(wfs_to_run):
 
-            if withDups and opt.nProcs > 1: # to avoid overwriting the work areas
+            if opt.allowDuplicates and withDups and opt.nProcs > 1: # to avoid overwriting the work areas 
                 njob = n
         
             item = wf.nameId

--- a/Configuration/PyReleaseValidation/python/MatrixRunner.py
+++ b/Configuration/PyReleaseValidation/python/MatrixRunner.py
@@ -1,4 +1,5 @@
 import os, sys, time
+import subprocess
 
 from collections import Counter
 
@@ -16,9 +17,23 @@ class MatrixRunner(object):
         self.threadList = []
         self.maxThreads = nThrMax
         self.nThreads = nThreads
-        self.gpu = gpu
+        self.gpus = ()
 
-        if self.gpu:
+        if gpu:
+            print("> Running with --gpu option. Checking the GPUs available.")
+            cuda = subprocess.check_output("cudaComputeCapabilities", shell=True, executable="/bin/bash").decode('utf8')
+            # Building on top of the {cuda|rocm}ComputeCapabilities 
+            # output in case of no {NVIDIA|AMD} GPU:
+            # 'no XXX-capable device is detecte'
+            if "capable device is detected" in cuda:
+                cuda = 0
+            else:   
+                print(cuda.split("\n"))
+            rocm = subprocess.check_output("rocmComputeCapabilities", shell=True, executable="/bin/bash").decode('utf8')
+            if "capable device is detected" in rocm:
+                rocm = 0
+            else:
+                print(cuda.split("\n"))
             print("Checks for GPU")
             pass
 

--- a/Configuration/PyReleaseValidation/python/MatrixRunner.py
+++ b/Configuration/PyReleaseValidation/python/MatrixRunner.py
@@ -58,7 +58,7 @@ class MatrixRunner(object):
 
             print('\nPreparing to run %s %s' % (wf.numId, item))
             sys.stdout.flush()
-            current = WorkFlowRunner(wf,noRun,dryRun,cafVeto, opt.dasOptions, opt.jobReports, opt.nThreads, opt.nStreams, opt.maxSteps, opt.nEvents)
+            current = WorkFlowRunner(wf,opt,noRun,dryRun,cafVeto)
             self.threadList.append(current)
             current.start()
             if not dryRun:

--- a/Configuration/PyReleaseValidation/python/WorkFlowRunner.py
+++ b/Configuration/PyReleaseValidation/python/WorkFlowRunner.py
@@ -7,7 +7,7 @@ from os.path import exists, basename, join
 from datetime import datetime
 
 class WorkFlowRunner(Thread):
-    def __init__(self, wf, opt, noRun=False, dryRun=False, cafVeto=True, jobNumber=None):
+    def __init__(self, wf, opt, noRun=False, dryRun=False, cafVeto=True, jobNumber=None, gpu = None):
         Thread.__init__(self)
         self.wf = wf
 
@@ -18,6 +18,8 @@ class WorkFlowRunner(Thread):
         self.noRun = noRun
         self.dryRun = dryRun
         self.cafVeto = cafVeto
+        self.gpu = gpu
+
         self.dasOptions = opt.dasOptions
         self.jobReport = opt.jobReports
         self.nThreads = opt.nThreads
@@ -31,7 +33,7 @@ class WorkFlowRunner(Thread):
         self.wfDir=str(self.wf.numId)+'_'+self.wf.nameId
         if jobNumber is not None:
             self.wfDir = self.wfDir + '_job' + str(jobNumber)
-        print(self.wfDir)
+
         return
 
     def doCmd(self, cmd):
@@ -154,6 +156,9 @@ class WorkFlowRunner(Thread):
 
             else:
                 #chaining IO , which should be done in WF object already and not using stepX.root but <stepName>.root
+                if self.gpu is not None:
+                    cmd = cmd + self.gpu
+
                 cmd += com
 
                 if self.startFrom:

--- a/Configuration/PyReleaseValidation/python/WorkFlowRunner.py
+++ b/Configuration/PyReleaseValidation/python/WorkFlowRunner.py
@@ -7,7 +7,7 @@ from os.path import exists, basename, join
 from datetime import datetime
 
 class WorkFlowRunner(Thread):
-    def __init__(self, wf, opt, noRun=False, dryRun=False, cafVeto=True):
+    def __init__(self, wf, opt, noRun=False, dryRun=False, cafVeto=True, jobNumber=None):
         Thread.__init__(self)
         self.wf = wf
 
@@ -29,6 +29,9 @@ class WorkFlowRunner(Thread):
         self.recycle = opt.recycle
         
         self.wfDir=str(self.wf.numId)+'_'+self.wf.nameId
+        if jobNumber is not None:
+            self.wfDir = self.wfDir + '_job' + str(jobNumber)
+        print(self.wfDir)
         return
 
     def doCmd(self, cmd):

--- a/Configuration/PyReleaseValidation/python/relval_data_highstats.py
+++ b/Configuration/PyReleaseValidation/python/relval_data_highstats.py
@@ -59,7 +59,7 @@ for e_n,era in enumerate(eras_2022_1):
             wf_number = wf_number + offset_pd * p_n
             wf_number = wf_number + offset_events * evs
             wf_number = round(wf_number,6)
-            step_name = "Run" + pd + era.split("Run")[1] + e_key
+            step_name = "Run" + pd + era.split("Run")[1] + "_" + e_key
             y = str(int(base_wf))
             suff = "ZB_" if "ZeroBias" in step_name else ""
             workflows[wf_number] = ['',[step_name,'HLTDR3_' + y,'RECONANORUN3_' + suff + 'reHLT_'+y,'HARVESTRUN3_' + suff + y]]

--- a/Configuration/PyReleaseValidation/python/relval_data_highstats.py
+++ b/Configuration/PyReleaseValidation/python/relval_data_highstats.py
@@ -59,7 +59,7 @@ for e_n,era in enumerate(eras_2022_1):
             wf_number = wf_number + offset_pd * p_n
             wf_number = wf_number + offset_events * evs
             wf_number = round(wf_number,6)
-            step_name = "Run" + pd + era.split("Run")[1] + "_10k"
+            step_name = "Run" + pd + era.split("Run")[1] + e_key
             y = str(int(base_wf))
             suff = "ZB_" if "ZeroBias" in step_name else ""
             workflows[wf_number] = ['',[step_name,'HLTDR3_' + y,'RECONANORUN3_' + suff + 'reHLT_'+y,'HARVESTRUN3_' + suff + y]]

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1,9 +1,11 @@
+import sys
+
 from .MatrixUtil import *
 
 from Configuration.HLT.autoHLT import autoHLT
 from Configuration.AlCa.autoPCL import autoPCL
 from Configuration.Skimming.autoSkim import autoSkim
-from .upgradeWorkflowComponents import step3_trackingOnly
+from Configuration.PyReleaseValidation.upgradeWorkflowComponents import step3_trackingOnly,undefInput
 
 # step1 gensim: for run1
 step1Defaults = {'--relval'      : None, # need to be explicitly set
@@ -4595,13 +4597,17 @@ baseDataSetReleaseBetter={}
 for gen in upgradeFragments:
     for ds in defaultDataSets:
         key=gen[:-4]+'_'+ds
-        version='1'
+        version = "1"
+        if defaultDataSets[ds] == '' or ds =='Run4D98':
+            version = undefInput
         if key in versionOverrides:
             version = versionOverrides[key]
         baseDataSetReleaseBetter[key]=defaultDataSets[ds]+version
 
 PUDataSets={}
 for ds in defaultDataSets:
+    if "GenOnly" in ds:
+        continue
     key='MinBias_14TeV_pythia8_TuneCP5'+'_'+ds
     name=baseDataSetReleaseBetter[key]
     if '2017' in ds:
@@ -4620,7 +4626,6 @@ for ds in defaultDataSets:
 
     #PUDataSets[ds]={'-n':10,'--pileup':'AVE_50_BX_25ns','--pileup_input':'das:/RelValMinBias_13/%s/GEN-SIM'%(name,)}
     #PUDataSets[ds]={'-n':10,'--pileup':'AVE_70_BX_25ns','--pileup_input':'das:/RelValMinBias_13/%s/GEN-SIM'%(name,)}
-
 
 upgradeStepDict={}
 for specialType,specialWF in upgradeWFs.items():

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -4597,9 +4597,7 @@ baseDataSetReleaseBetter={}
 for gen in upgradeFragments:
     for ds in defaultDataSets:
         key=gen[:-4]+'_'+ds
-        version = "1"
-        if defaultDataSets[ds] == '' or ds =='Run4D98':
-            version = undefInput
+        version = undefInput if defaultDataSets[ds] == '' else '1'
         if key in versionOverrides:
             version = versionOverrides[key]
         baseDataSetReleaseBetter[key]=defaultDataSets[ds]+version

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -3,6 +3,8 @@ from collections import OrderedDict
 from .MatrixUtil import merge, Kby, Mby, check_dups
 import re
 
+undefInput = "UNDEF"
+
 U2000by1={'--relval': '2000,1'}
 
 # DON'T CHANGE THE ORDER, only append new keys. Otherwise the numbering for the runTheMatrix tests will change.
@@ -3120,6 +3122,8 @@ upgradeProperties[2017] = {
 
 # standard PU sequences
 for key in list(upgradeProperties[2017].keys()):
+    if "GenOnly" in key:
+        continue
     upgradeProperties[2017][key+'PU'] = deepcopy(upgradeProperties[2017][key])
     if 'FS' not in key:
         # update ScenToRun list
@@ -3355,6 +3359,8 @@ upgradeProperties['Run4'] = {
 
 # standard PU sequences
 for key in list(upgradeProperties['Run4'].keys()):
+    if "GenOnly" in key:
+        continue
     upgradeProperties['Run4'][key+'PU'] = deepcopy(upgradeProperties['Run4'][key])
     upgradeProperties['Run4'][key+'PU']['ScenToRun'] = ['GenSimHLBeamSpot','DigiTriggerPU','RecoGlobalPU', 'HARVESTGlobalPU']
 

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -421,7 +421,7 @@ if __name__ == '__main__':
                           help='Specify a comma-separated list of CUDA "compute capabilities", or GPU hardware architectures, that the job can use.',
                           dest='CUDACapabilities',
                           type=lambda x: x.split(','),
-                          default='6.0,6.1,6.2,7.0,7.2,7.5,8.0,8.6')
+                          default='6.0,6.1,6.2,7.0,7.2,7.5,8.0,8.6,8.7,8.9,9.0,12.0')
 
     # read the CUDA runtime version included in CMSSW
     cudart_version = None

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -30,7 +30,8 @@ def runSelected(opt):
         testSet = set(opt.testList)
         undefSet = testSet - definedSet
         if len(undefSet)>0: raise ValueError('Undefined workflows: '+', '.join(map(str,list(undefSet))))
-
+        if not opt.allowDuplicates:
+            testList = testSet
     ret = 0
     if opt.show:
         mrd.show(opt.testList, opt.extended, opt.cafVeto)
@@ -186,7 +187,13 @@ if __name__ == '__main__':
                         dest='recycle',
                         type=str,
                         default=None)
-                        
+
+    parser.add_argument('--allowDuplicates',
+                        help='Allow to have duplicate workflow numbers in the list',
+                        dest='allowDuplicates',
+                        default=False,
+                        action='store_true')
+
     parser.add_argument('--addMemPerCore',
                         help='increase of memory per each n > 1 core:  memory(n_core) = memoryOffset + (n_core-1) * memPerCore',
                         dest='memPerCore',

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -450,32 +450,42 @@ if __name__ == '__main__':
                           default='')
 
     opt = parser.parse_args()
-
     opt.selected_gpus = None
-    if opt.gpu:
+    
+    if opt.gpu != 'forbidden':
 
         print(">> Running with --gpu option. Checking the available and supported GPUs.")
         gpus = cleanComputeCapabilities("cuda")
         gpus = gpus + cleanComputeCapabilities("rocm", len(gpus))
         available_gpus = gpus
 
-        print("> GPUs Available:")
-        [print(f) for f in available_gpus]
-
-        # Filtering ONLY CUDA GPUs on capability
-        gpus = [g for g in gpus if not g.isCUDA() or (g.isCUDA() and g.capability in opt.CUDACapabilities)]
-
-        # Filtering by name (if parsed)
-        if len(opt.GPUName) > 0:
-            gpus = [g for g in gpus if g.name == opt.GPUName]
-
-        if available_gpus != gpus:
-            print(">> Selected:")   
-            [print(f) for f in gpus]
+        if len(available_gpus) == 0:
+            print(">> No GPU available!")
+            opt.gpu = 'forbidden'
         else:
-            print(">> All selected!")
-        
-        opt.selected_gpus = cycle(gpus)
+            print(">> GPUs available:")
+            [print(f) for f in available_gpus]
+
+            # Filtering ONLY CUDA GPUs on capability
+            gpus = [g for g in gpus if not g.isCUDA() or (g.isCUDA() and g.capability in opt.CUDACapabilities)]
+
+            # Filtering by name (if parsed)
+            if len(opt.GPUName) > 0:
+                gpus = [g for g in gpus if g.name == opt.GPUName]
+
+            if available_gpus != gpus:
+                if len(gpus) > 0:
+                    print(">> GPUs selected:")   
+                    [print(f) for f in gpus]
+                else:
+                    print(">> No GPU selected!")
+            else:
+                print(">> All selected!")
+
+            if len(gpus) > 0:
+                opt.selected_gpus = cycle(gpus)
+            else:
+                opt.gpu = 'forbidden'
     
     if opt.command: opt.command = ' '.join(opt.command)
     os.environ["CMSSW_DAS_QUERY_SITES"]=opt.dasSites

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -28,8 +28,6 @@ def runSelected(opt):
         testSet = set(opt.testList)
         undefSet = testSet - definedSet
         if len(undefSet)>0: raise ValueError('Undefined workflows: '+', '.join(map(str,list(undefSet))))
-        duplicates = [wf for wf in testSet if definedWf.count(wf)>1 ]
-        if len(duplicates)>0: raise ValueError('Duplicated workflows: '+', '.join(map(str,list(duplicates))))
 
     ret = 0
     if opt.show:
@@ -497,7 +495,7 @@ if __name__ == '__main__':
                 except:
                     print(entry,'is not a possible selected entry')
 
-        opt.testList = list(set(testList))
+        opt.testList = list(testList)
 
     if opt.wmcontrol:
         performInjectionOptionTest(opt)

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -459,7 +459,7 @@ if __name__ == '__main__':
     opt = parser.parse_args()
     opt.selected_gpus = None
     
-    if opt.gpu != 'forbidden':
+    if not opt.wmcontrol and opt.gpu != 'forbidden':
 
         print(">> Running with --gpu option. Checking the available and supported GPUs.")
         gpus = cleanComputeCapabilities("cuda")
@@ -467,8 +467,9 @@ if __name__ == '__main__':
         available_gpus = gpus
 
         if len(available_gpus) == 0:
+            if opt.gpu == 'required':
+                raise Exception('Launched with --gpu required and no GPU available!')
             print(">> No GPU available!")
-            opt.gpu = 'forbidden'
         else:
             print(">> GPUs available:")
             [print(f) for f in available_gpus]
@@ -485,6 +486,8 @@ if __name__ == '__main__':
                     print(">> GPUs selected:")   
                     [print(f) for f in gpus]
                 else:
+                    if opt.gpu == 'required':
+                        raise Exception('Launched with --gpu required and no GPU selected (among those available)!')
                     print(">> No GPU selected!")
             else:
                 print(">> All selected!")
@@ -492,7 +495,9 @@ if __name__ == '__main__':
             if len(gpus) > 0:
                 opt.selected_gpus = cycle(gpus)
             else:
-                opt.gpu = 'forbidden'
+                error_str = 'No GPU selected'
+                if opt.gpu == 'required':
+                    raise Exception('Launched with --gpu required and no GPU available (among those available)!')
     
     if opt.command: opt.command = ' '.join(opt.command)
     os.environ["CMSSW_DAS_QUERY_SITES"]=opt.dasSites

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -173,7 +173,20 @@ if __name__ == '__main__':
                         dest='memoryOffset',
                         type=int,
                         default=3000)
+    
+    parser.add_argument('--startFrom',
+                        help='Start from a specific step (e.g. GEN,SIM,DIGI,RECO)',
+                        dest='startFrom',
+                        type=str,
+                        default=None)
 
+    parser.add_argument('--recycle',
+                        help='Input file to recycle. To be used if the first step is an input step or togehter with --startFrom. '
+                        'N.B.: runTheMatrix.py will create its own workdirectory so if yo use a relative path, be careful.',
+                        dest='recycle',
+                        type=str,
+                        default=None)
+                        
     parser.add_argument('--addMemPerCore',
                         help='increase of memory per each n > 1 core:  memory(n_core) = memoryOffset + (n_core-1) * memPerCore',
                         dest='memPerCore',
@@ -216,6 +229,12 @@ if __name__ == '__main__':
                         default=False,
                         action='store_true')
 
+    parser.add_argument('-c','--checkInputs',
+                        help='Check if the default inputs are well defined. To be used with --show',
+                        dest='checkInputs',
+                        default=False,
+                        action='store_true')
+    
     parser.add_argument('-e','--extended',
                         help='Show details of workflows, used with --show',
                         dest='extended',


### PR DESCRIPTION
#### PR description:

This PR proposes a few modifications to `runTheMatrix.py` and correlated packages. It would add the possibility to:

1. check if the default samples for the workflows requested are actually defined. This is done via the `-c`/`--checkInputs` flag. This should solve https://github.com/cms-sw/cmssw/issues/46910 if in the routine PR tests one runs `runTheMatrix.py -n -c`;

2. have a workflow start from a specific step (`GEN`, `SIM`, `DIGI`, ...) with the option `--startFrom STEP`. This will remove all the steps before the one with a `cmsDriver.py` with `-s STEP, [...]`;

3. use a different file as input with `--recycle`. This is intended to be used either together with `--startFrom` either on wfs that, as first step, use a pre-existing input;

4.  have duplicate wfs in input with option `-l WF, WF, WF [...]` with `--allowDuplicates`. Each wf would run in a different job (if specified) and `_jobX` is appended to the work area to avoid using the same folder;

And when running with the `-gpu` option and multiple jobs with `-j N` now each job would be assigned to a different GPU. Available GPUs may be also selected on the basis of the compute capability (only for NVIDIA) with the already existing `--cuda-capabilities` or by name with the already existing `--force-gpu-name`. If more jobs than available GPUs are requested, the job to GPU assignment will restart from the first GPU available until completion. So, e.g., with 8 jobs and 3 GPUs:

- GPU 0 -> jobs  `[0, 3, 6]`  
- GPU 1 -> jobs `[1, 4,  7]`
- GPU 2 -> jobs `[2, 5]`

This should solve https://github.com/cms-sw/cmssw/issues/47337