### PR TITLE
[CMSSW_14_2_X] Update a few GTs in autoCond

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -31,15 +31,15 @@ autoCond = {
     'run2_data_promptlike_hi'      :    '140X_dataRun2_PromptLike_HI_v1',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              :    '140X_dataRun2_HLT_relval_v1',
-    # GlobalTag for Run3 HLT: identical the online GT 140X_dataRun3_HLT_v4 with snapshot at 2024-11-28 13:17:51 (UTC)
+    # GlobalTag for Run3 HLT: identical the online GT 140X_dataRun3_HLT_v2 with snapshot at 2024-11-28 13:17:51 (UTC)
     'run3_hlt'                     :    '141X_dataRun3_HLT_frozen_v2',
     # GlobalTag for Run3 data relvals (express GT): same as 141X_dataRun3_Express_v4 but with snapshot at 2024-11-28 13:23:29 (UTC)
     'run3_data_express'            :    '141X_dataRun3_Express_frozen_v4',
     # GlobalTag for Run3 data relvals (prompt GT): same as 141X_dataRun3_Prompt_v4 but with snapshot at 2024-11-28 13:26:44 (UTC)
     'run3_data_prompt'             :    '141X_dataRun3_Prompt_frozen_v4',
-    # GlobalTag for Run3 offline data reprocessing - snapshot at 2024-11-12 07:39:42 (UTC)
-    'run3_data'                    :    '141X_dataRun3_v5',
-    # GlobalTag for Run3 offline data reprocessing with Prompt GT, currently for 2022FG - snapshot at 2024-02-12 12:00:00 (UTC)
+    # GlobalTag for Run3 offline data reprocessing - snapshot at 2025-02-09 15:35:33 (UTC)
+    'run3_data'                    :    '141X_dataRun3_v6',
+    # GlobalTag for Run3 offline data reprocessing with Prompt GT, currently for 2022FG - snapshot at 2024-05-31 08:53:25 (UTC)
     'run3_data_PromptAnalysis'     :    '140X_dataRun3_PromptAnalysis_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           :    '131X_mc2017_design_v3',
@@ -100,11 +100,11 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2024 detector for Heavy Ion
     'phase1_2024_realistic_hi'     :    '141X_mcRun3_2024_realistic_HI_v13',
     # GlobalTag for MC production with realistic conditions for Phase1 2024 detector for ppRef5TeV
-    'phase1_2024_realistic_ppRef5TeV'     :    '141X_mcRun3_2024_realistic_ppRef5TeV_v7',
+    'phase1_2024_realistic_ppRef5TeV' : '141X_mcRun3_2024_realistic_ppRef5TeV_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2025
-    'phase1_2025_design'           :    '140X_mcRun3_2024_design_v11',
-    # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2025_realistic'        :    '142X_mcRun3_2025_realistic_v2',
+    'phase1_2025_design'           :    '142X_mcRun3_2025_design_v1',
+    # GlobalTag for MC production with realistic conditions for Phase1 2025
+    'phase1_2025_realistic'        :    '142X_mcRun3_2025_realistic_v7',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             :    '141X_mcRun4_realistic_v3'
 }

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -74,7 +74,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2022, Strip tracker in DECO mode
     'phase1_2022_cosmics_design'   :    '140X_mcRun3_2022cosmics_design_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 detector for Heavy Ion
-    'phase1_2022_realistic_hi'     :    '140X_mcRun3_2022_realistic_HI_v3',
+    'phase1_2022_realistic_hi'     :    '140X_mcRun3_2022_realistic_HI_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2023
     'phase1_2023_design'           :    '140X_mcRun3_2023_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
@@ -88,7 +88,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2023, Strip tracker in DECO mode
     'phase1_2023_cosmics_design'   :    '140X_mcRun3_2023cosmics_design_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2023 detector for Heavy Ion
-    'phase1_2023_realistic_hi'     :    '141X_mcRun3_2023_realistic_HI_v4',
+    'phase1_2023_realistic_hi'     :    '141X_mcRun3_2023_realistic_HI_v11',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2024
     'phase1_2024_design'           :    '140X_mcRun3_2024_design_v11',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
@@ -98,7 +98,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2024, Strip tracker in DECO mode
     'phase1_2024_cosmics_design'   :    '140X_mcRun3_2024cosmics_design_deco_v11',
     # GlobalTag for MC production with realistic conditions for Phase1 2024 detector for Heavy Ion
-    'phase1_2024_realistic_hi'     :    '141X_mcRun3_2024_realistic_HI_v13',
+    'phase1_2024_realistic_hi'     :    '141X_mcRun3_2024_realistic_HI_v14',
     # GlobalTag for MC production with realistic conditions for Phase1 2024 detector for ppRef5TeV
     'phase1_2024_realistic_ppRef5TeV' : '141X_mcRun3_2024_realistic_ppRef5TeV_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2025


### PR DESCRIPTION
#### PR description:

The following GTs have been updated in autoCond (as backport of  #47385):

-  'run3_data' updated to [141X_dataRun3_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/141X_dataRun3_v6)
   - It includes the specific updates for 2023 HI data taking, without touching the IOVs corresponding to the pp data taking periods,  see [cmsTalk](https://cms-talk.web.cern.ch/t/141x-rereco-and-mc-of-2023-upc-data-urgent/104239) 
   - Diff with respect to previous 141X_dataRun3_v5 is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/141X_dataRun3_v5/141X_dataRun3_v6)
- phase1_2025_design updated to [142X_mcRun3_2025_design_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/142X_mcRun3_2025_design_v1)
   - Initial possible GT for mcRun3_2025_design, based on 140X_mcRun3_2024_design_v11 plus the dedx and GEM tags specific for the releases above CMSSW_14_0_X and for 2025 data/MC
   - Diff with respect to previous 140X_mcRun3_2024_design_v11 is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2024_design_v11/142X_mcRun3_2025_design_v1)
- phase1_2025_realistic updated to [142X_mcRun3_2025_realistic_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/142X_mcRun3_2025_realistic_v7)
   - **GT for Winter 2025 MC Production**, “mostly” MOY conditions, so EOY Tracker + EOY Ecal ZS/SR settings + 2024 ECAL PFRecHit thresholds + HCAL realistic PF Cuts + MOY for all other conditions, see [cmsTalk](https://cms-talk.web.cern.ch/t/call-for-run3winter25-mc-conditions-in-142x/55993/25)
   - Diff with respect to previous 142X_mcRun3_2025_realistic_v5 is [here ](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/142X_mcRun3_2025_realistic_v5/142X_mcRun3_2025_realistic_v7)
-  'phase1_2022_realistic_hi'  updated to [140X_mcRun3_2022_realistic_HI_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/140X_mcRun3_2022_realistic_HI_v4)
   - Add the tags that allow Dead and Masked GEM strips, see [cmsTalk](https://cms-talk.web.cern.ch/t/gem-request-for-including-gts-gemmaskedstrips-gemdeadstrips/55154) 
   -  Diff with respect to previous 140X_mcRun3_2022_realistic_HI_v3 is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2022_realistic_HI_v3/140X_mcRun3_2022_realistic_HI_v4) 

The following GTs have been updated in autoCond (as backport of  #47439):

- 'phase1_2023_realistic_hi'     :    [141X_mcRun3_2023_realistic_HI_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/141X_mcRun3_2023_realistic_HI_v11)
  - Diff with respect to previous _v5 is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/141X_mcRun3_2023_realistic_HI_v5/141X_mcRun3_2023_realistic_HI_v11)
  - Updates included:
     - Beamspot, see [cmsTalk](https://cms-talk.web.cern.ch/t/141x-rereco-and-mc-of-2023-upc-data-urgent/104239/8)
     - CSC conditions, see [cmsTalk](https://cms-talk.web.cern.ch/t/141x-rereco-and-mc-of-2023-upc-data-urgent/104239/7)
     - Muon Alignment, see [cmsTalk](https://cms-talk.web.cern.ch/t/141x-rereco-and-mc-of-2023-upc-data-urgent/104239/12) and [cmsTalk](https://cms-talk.web.cern.ch/t/141x-rereco-and-mc-of-2023-upc-data-urgent/104239/23)
     - HCAL SiPMParameters and ZSThresholds, see [cmsTalk](https://cms-talk.web.cern.ch/t/141x-rereco-and-mc-of-2023-upc-data-urgent/104239/15)
     - HCAL pedestals, see [cmsTalk](https://cms-talk.web.cern.ch/t/141x-rereco-and-mc-of-2023-upc-data-urgent/104239/24)
     - SiStripNoise, see [cmsTalk](https://cms-talk.web.cern.ch/t/141x-rereco-and-mc-of-2023-upc-data-urgent/104239/16)
     - Jet energy corrections and resolutions, see [cmsTalk](https://cms-talk.web.cern.ch/t/141x-rereco-and-mc-of-2023-upc-data-urgent/104239/20)
- 'phase1_2024_realistic_hi'     :    [141X_mcRun3_2024_realistic_HI_v14](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/141X_mcRun3_2024_realistic_HI_v14)
  - Diff with respect to previous _v13 is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/141X_mcRun3_2024_realistic_HI_v13/141X_mcRun3_2024_realistic_HI_v14)
  - Updates included:
     - SiPixel Quality and Status Scenario, see [cmsTalk](https://cms-talk.web.cern.ch/t/cal-for-conditions-for-the-2024-hi-mc/72169/10)
    
#### PR validation:

Tested in master

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #47385 and #47439
