### PR TITLE
Remove split mode code path from TagProbeFitter

### DIFF
--- a/PhysicsTools/TagAndProbe/interface/TagProbeFitter.h
+++ b/PhysicsTools/TagAndProbe/interface/TagProbeFitter.h
@@ -85,11 +85,6 @@ public:
   /// suppress most of the output from RooFit and Minuit
   void setQuiet(bool quiet_ = true);
 
-  /// split mode - use it for very large input files (slower that non-split mode, which is the default)
-  ///    0 - import input TTree as a whole (non-split mode)
-  ///    non-zero value - use split reading mode and read specified number of events for each iteration
-  void setSplitMode(unsigned int nevents);
-
 protected:
   ///pointer to the input TTree Chain of data
   TChain* inputTree;
@@ -147,11 +142,6 @@ protected:
 
   /// suppress most printout
   bool quiet;
-
-  /// split mode - use it for very large input files (slower that non-split mode, which is the default)
-  ///    0 - import input TTree as a whole (non-split mode)
-  ///    non-zero value - use split reading mode and read specified number of events for each iteration
-  unsigned int split_mode;
 
   ///fix or release variables selected by user
   void varFixer(RooWorkspace* w, bool fix);

--- a/PhysicsTools/TagAndProbe/plugins/TagProbeFitTreeAnalyzer.cc
+++ b/PhysicsTools/TagAndProbe/plugins/TagProbeFitTreeAnalyzer.cc
@@ -20,22 +20,19 @@ public:
 
 private:
   TagProbeFitter fitter;
-  unsigned int split_mode;  // number of events to read per cycle (slower, but memory efficient)
 };
 
 TagProbeFitTreeAnalyzer::TagProbeFitTreeAnalyzer(const edm::ParameterSet& pset)
-    : fitter(
-          pset.getParameter<vector<string> >("InputFileNames"),
-          pset.getParameter<string>("InputDirectoryName"),
-          pset.getParameter<string>("InputTreeName"),
-          pset.getParameter<string>("OutputFileName"),
-          pset.existsAs<unsigned int>("NumCPU") ? pset.getParameter<unsigned int>("NumCPU") : 1,
-          pset.existsAs<bool>("SaveWorkspace") ? pset.getParameter<bool>("SaveWorkspace") : false,
-          pset.existsAs<bool>("floatShapeParameters") ? pset.getParameter<bool>("floatShapeParameters") : true,
-          pset.existsAs<vector<string> >("fixVars") ? pset.getParameter<vector<string> >("fixVars") : vector<string>()),
-      split_mode(pset.existsAs<unsigned int>("SplitMode") ? pset.getParameter<unsigned int>("SplitMode") : 0) {
+    : fitter(pset.getParameter<vector<string> >("InputFileNames"),
+             pset.getParameter<string>("InputDirectoryName"),
+             pset.getParameter<string>("InputTreeName"),
+             pset.getParameter<string>("OutputFileName"),
+             pset.existsAs<unsigned int>("NumCPU") ? pset.getParameter<unsigned int>("NumCPU") : 1,
+             pset.existsAs<bool>("SaveWorkspace") ? pset.getParameter<bool>("SaveWorkspace") : false,
+             pset.existsAs<bool>("floatShapeParameters") ? pset.getParameter<bool>("floatShapeParameters") : true,
+             pset.existsAs<vector<string> >("fixVars") ? pset.getParameter<vector<string> >("fixVars")
+                                                       : vector<string>()) {
   fitter.setQuiet(pset.getUntrackedParameter("Quiet", false));
-  fitter.setSplitMode(split_mode);
 
   if (pset.existsAs<bool>("binnedFit")) {
     bool binned = pset.getParameter<bool>("binnedFit");


### PR DESCRIPTION
Reading the code of the "split mode" codepath in the TagProbeFitter, I saw it has a bug: I  don't think it works with weighted data (see https://github.com/cms-sw/cmssw/pull/47388#pullrequestreview-2624196426).

This made me think that this is probably  a dead code path that is not tested or used, because weights are quite common for TnP (e.g. pileup reweighing). Someone must have noticed for sure if this "split mode" is relevant.

And indeed the "split mode" code path of the `TagAndProbeFitter` is disabled by default and not enabled in any Python config file. So it seems that this code is seemingly not used and should be removed for cleanup/bugfix/simplification.

Alternative to #47388.

Note that the split mode was introduced "only" 7 years ago:
   * https://github.com/cms-sw/cmssw/pull/22861

Is it still used by the Muon POG? Do they use weights or not? Maybe they haven't noticed or my analysis is wrong. Or the configuration files by the Muon POG circumvent the problem, by also adding the weight variable to the regular set of unbinned observables.