### PR TITLE
Fix compilation of TagProbeFitter with ROOT master

### DIFF
--- a/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc
+++ b/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc
@@ -373,7 +373,7 @@ string TagProbeFitter::calculateEfficiency(string dirName,
                                *copyTree,
                                /*selExpr=*/"",
                                /*wgtVarName=*/(weightVar.empty() ? nullptr : weightVar.c_str()));
-        for (unsigned int i = 0; i < store.GetEntries(); ++i) {
+        for (unsigned int i = 0; i < copyTree->GetEntries(); ++i) {
           store.get(i);
           if (allCats.getIndex() == iCat) {
             data_bin->add(dataVars, weightVar.empty() ? 1.0 : dataVars.getRealValue(weightVar.c_str()));


### PR DESCRIPTION
The `RooTreeDataStore` interface was changed, because it's in principle an internal class.

I don't know what's the good solution to replace the usage of the `RooTreeDataStore` for now. I'm missing some context because the TagAndProbe tools are mainly used by the POGs outside of CMSSW production.

So for now, let's maybe do the minimal fix possible to compile again with ROOT master.