### PR TITLE
Do not fail unit test due to undefined behavior

### DIFF
--- a/PhysicsTools/MVAComputer/test/testBitSet.cppunit.cc
+++ b/PhysicsTools/MVAComputer/test/testBitSet.cppunit.cc
@@ -52,7 +52,11 @@ void testBitSet::bitManipulationTest() {
   // so if neg != bit it is from the undefined
   // behavior
   CPPUNIT_ASSERT(bit(31) == 0x80000000);
-  CPPUNIT_ASSERT(neg(31) == 0x80000000);
+  //Print a warnings instead of failure due to undefined behavior
+  //CPPUNIT_ASSERT(neg(31) == 0x80000000);
+  if (neg(31) != 0x80000000) {
+    std::cout << "Warning: Due to undefined behavior neg(31) != 0x80000000." << std::endl;
+  }
 }
 
 void testBitSet::multiWordTest() {


### PR DESCRIPTION
Fixes https://github.com/cms-sw/cmssw/issues/47249

Due to undefined behavior `neg(31)` could be not equal to `0x80000000`. This PR proposes to not fail the unit test due to this undefined behabior instead just print a warning. See https://github.com/cms-sw/cmssw/issues/47249 for details