### PR TITLE
[15.0.X] fix `customizeHLTfor47047` to work also on menus already customized

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -118,6 +118,8 @@ def customizeHLTfor47047(process):
         delattr(process, esProducer.label())
 
     for prod in producers_by_type(process, "HBHERecHitProducerPortable@alpaka", "alpaka_serial_sync::HBHERecHitProducerPortable"):
+        if not hasattr(prod, 'mahiPulseOffSets'):
+            continue
         pulseOffsetLabel = prod.mahiPulseOffSets.getModuleLabel()
         if hasattr(process, pulseOffsetLabel):
             esProducer = getattr(process, pulseOffsetLabel)
@@ -127,6 +129,8 @@ def customizeHLTfor47047(process):
         delattr(process, prod.label())
 
     for prod in producers_by_type(process, "PFClusterSoAProducer@alpaka", "alpaka_serial_sync::PFClusterSoAProducer"):
+        if not hasattr(prod, 'pfClusterParams'):
+            continue
         clusterParamsLabel = prod.pfClusterParams.getModuleLabel()
         if hasattr(process, clusterParamsLabel):
             esProducer = getattr(process, clusterParamsLabel)


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/47393

#### PR description:

Title says it all, addresses discussion at https://github.com/cms-sw/cmssw/pull/47047#discussion_r1959990651 .

#### PR validation:

Passes `addOnTests.py`.
Tested on a 15_0_X based menu (after re-absorbing customization functions)  with:

```bash
#!/bin/bash -ex

hltGetConfiguration /dev/CMSSW_15_0_0/GRun/V5 \
   --globaltag 142X_mcRun3_2025_realistic_v4 \
   --mc \
   --unprescale \
   --output minimal \
   --max-events 100 \
   --input /store/mc/Run3Winter25Digi/TT_TuneCP5_13p6TeV_powheg-pythia8/GEN-SIM-RAW/142X_mcRun3_2025_realistic_v7-v2/130000/eaf68a23-673f-48fa-a912-92097c37bd14.root  \
   --eras Run3_2025 --l1-emulator uGT --l1 L1Menu_Collisions2024_v1_3_0_xml \
   > hltMC.py

cmsRun hltMC.py >& hltMC.log
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatimb backport of https://github.com/cms-sw/cmssw/pull/47393 to CMSSW_15_0_X