### PR TITLE
Disable ROOT automatic class parsing in ProductRegistryHelper::addToRegistry

### DIFF
--- a/FWCore/Framework/src/ProductRegistryHelper.cc
+++ b/FWCore/Framework/src/ProductRegistryHelper.cc
@@ -9,6 +9,7 @@
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "FWCore/Reflection/interface/DictionaryTools.h"
 #include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Reflection/interface/SetClassParsing.h"
 #include "FWCore/Reflection/interface/TypeWithDict.h"
 
 #include <vector>
@@ -40,6 +41,13 @@ namespace edm {
     std::vector<std::string> missingDictionaries;
     std::vector<std::string> producedTypes;
     std::set<std::tuple<BranchType, std::type_index, std::string>> registeredProducts;
+
+    // Disable ROOT automatic class parsing while registering products.
+    // This done to avoid trying to build missing dictionaries for edm::Wrapper<T>
+    // when the dictionary for T itself is present and the relevant classes.h file
+    // includes a CUDA-related header, as that causes ROOT to fail before we can
+    // issue the proper error message about missing dictionaries.
+    edm::SetClassParsing guard(false);
 
     for (TypeLabelList::const_iterator p = iBegin; p != iEnd; ++p) {
       if (p->transition_ == Transition::BeginRun && not iProd->hasAbilityToProduceInBeginRuns()) {

--- a/HeterogeneousCore/CUDATest/interface/MissingDictionaryCUDAObject.h
+++ b/HeterogeneousCore/CUDATest/interface/MissingDictionaryCUDAObject.h
@@ -1,0 +1,23 @@
+#ifndef HeterogeneousCore_CUDATest_interface_MissingDictionaryCUDAObject_h
+#define HeterogeneousCore_CUDATest_interface_MissingDictionaryCUDAObject_h
+
+#include <string>
+
+namespace edmtest {
+
+  // A simple data product used to test that the framework handles correctly the case of
+  // edm::Wrapper<T> where
+  //   - T has a dictionary
+  //   - edm::Wrapper<T> does not have a dictionary
+  //   - the corresponding classes.h file includes CUDA headers
+
+  struct MissingDictionaryCUDAObject {
+    MissingDictionaryCUDAObject() {};
+    MissingDictionaryCUDAObject(std::string s) : value(std::move(s)) {}
+
+    std::string value;
+  };
+
+}  // namespace edmtest
+
+#endif  // HeterogeneousCore_CUDATest_interface_MissingDictionaryCUDAObject_h

--- a/HeterogeneousCore/CUDATest/plugins/MissingDictionaryCUDAProducer.cc
+++ b/HeterogeneousCore/CUDATest/plugins/MissingDictionaryCUDAProducer.cc
@@ -1,0 +1,24 @@
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "HeterogeneousCore/CUDATest/interface/MissingDictionaryCUDAObject.h"
+
+namespace edmtest {
+
+  class MissingDictionaryCUDAProducer : public edm::global::EDProducer<> {
+  public:
+    explicit MissingDictionaryCUDAProducer(edm::ParameterSet const& config) : token_(produces()) {}
+
+    void produce(edm::StreamID sid, edm::Event& event, edm::EventSetup const& setup) const final {
+      event.emplace(token_);
+    }
+
+  private:
+    const edm::EDPutTokenT<MissingDictionaryCUDAObject> token_;
+  };
+
+}  // namespace edmtest
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(edmtest::MissingDictionaryCUDAProducer);

--- a/HeterogeneousCore/CUDATest/src/classes.h
+++ b/HeterogeneousCore/CUDATest/src/classes.h
@@ -1,3 +1,6 @@
-#include "DataFormats/Common/interface/Wrapper.h"
+#include <cuda_runtime.h>
+
 #include "CUDADataFormats/Common/interface/Product.h"
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "HeterogeneousCore/CUDATest/interface/MissingDictionaryCUDAObject.h"
 #include "HeterogeneousCore/CUDATest/interface/Thing.h"

--- a/HeterogeneousCore/CUDATest/src/classes_def.xml
+++ b/HeterogeneousCore/CUDATest/src/classes_def.xml
@@ -1,4 +1,16 @@
 <lcgdict>
     <class name="cms::cuda::Product<cms::cudatest::Thing>" persistent="false"/>
     <class name="edm::Wrapper<cms::cuda::Product<cms::cudatest::Thing>>" persistent="false"/>
+
+    <!--
+    A simple data product used to test that the framework handles correctly the case of
+    edm::Wrapper<T> where
+      - T has a dictionary
+      - edm::Wrapper<T> does not have a dictionary
+      - the corresponding classes.h file includes CUDA headers
+    -->
+    <class name="edmtest::MissingDictionaryCUDAObject"/>
+    <!--
+    <class name="edm::Wrapper<edmtest::MissingDictionaryCUDAObject>" splitLevel="0"/>
+    -->
 </lcgdict>

--- a/HeterogeneousCore/CUDATest/test/BuildFile.xml
+++ b/HeterogeneousCore/CUDATest/test/BuildFile.xml
@@ -12,4 +12,12 @@
   </ifrelease>
 
   <test name="testHeterogeneousCoreCUDATestWriteRead" command="testHeterogeneousCoreCUDATestWriteRead.sh"/>
+
+  <!--
+  Test that the framework handles correctly the case of edm::Wrapper<T> where
+    - T has a dictionary
+    - edm::Wrapper<T> does not have a dictionary
+    - the corresponding classes.h file includes CUDA headers
+  -->
+  <test name="testMissingDictionaryCUDA" command="testMissingDictionaryCUDA.sh"/>
 </iftool>

--- a/HeterogeneousCore/CUDATest/test/testMissingDictionaryCUDA.sh
+++ b/HeterogeneousCore/CUDATest/test/testMissingDictionaryCUDA.sh
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+function die {
+  echo -e "$1"
+  echo "exit status $2"
+  exit $2
+}
+
+LOCAL_TEST_DIR=${SCRAM_TEST_PATH:-$CMSSW_BASE/src/HeterogeneousCore/CUDATest/test}
+
+cmsRun ${LOCAL_TEST_DIR}/testMissingDictionaryCUDA_cfg.py >& testMissingDictionaryCUDA.log && die "The cmsRun test job succeeded unexpectedly" $?
+grep -q "An exception of category 'DictionaryNotFound' occurred" testMissingDictionaryCUDA.log || die "Cannot find the following string in the exception message:\nAn exception of category 'DictionaryNotFound' occurred" $?
+grep -q "edm::Wrapper<edmtest::MissingDictionaryCUDAObject>"     testMissingDictionaryCUDA.log || die "Cannot find the following string in the exception message:\nedm::Wrapper<edmtest::MissingDictionaryCUDAObject>" $?

--- a/HeterogeneousCore/CUDATest/test/testMissingDictionaryCUDA_cfg.py
+++ b/HeterogeneousCore/CUDATest/test/testMissingDictionaryCUDA_cfg.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("EmptySource")
+process.maxEvents.input = 10
+
+process.producer = cms.EDProducer("edmtest::MissingDictionaryCUDAProducer")
+
+process.path = cms.Path(process.producer)


### PR DESCRIPTION
#### PR description:

Disable ROOT automatic class parsing while registering products in `ProductRegistryHelper::addToRegistry()`.

This done to avoid trying to build missing dictionaries for `edm::Wrapper<T>` when the dictionary for `T` itself is present and the relevant `classes.h` file includes a CUDA-related header, as that causes ROOT to fail before we can issue the proper error message about missing dictionaries.

Add a new test to check that the framework handles such corner case correctly.

#### PR validation:

The new unit test passes, while it would fail without these changes.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 15.0.x