### PR TITLE
protect `Phase2IT{OT}ValidateCluster` against missing input collections

### DIFF
--- a/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateCluster.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2ITValidateCluster.cc
@@ -153,8 +153,17 @@ void Phase2ITValidateCluster::fillITHistos(const edm::Event& iEvent,
                                            const std::map<unsigned int, SimTrack>& simTracks) {
   // Getting the clusters
   const auto& clusterHandle = iEvent.getHandle(clustersToken_);
+  if (!clusterHandle.isValid()) {
+    edm::LogWarning("Phase2ITValidateCluster") << "No SiPixelCluster Collection found in the event. Skipping!";
+    return;
+  }
+
   // Getting PixelDigiSimLinks
   const auto& pixelSimLinksHandle = iEvent.getHandle(simITLinksToken_);
+  if (!pixelSimLinksHandle.isValid()) {
+    edm::LogWarning("Phase2ITValidateCluster") << "No PixelDigiSimLinks Collection found in the event. Skipping!";
+    return;
+  }
 
   for (const auto& DSVItr : *clusterHandle) {
     // Getting the id of detector unit

--- a/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateCluster.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateCluster.cc
@@ -157,8 +157,16 @@ void Phase2OTValidateCluster::fillOTHistos(const edm::Event& iEvent,
                                            const std::map<unsigned int, SimTrack>& simTracks) {
   // Getting the clusters
   const auto& clusterHandle = iEvent.getHandle(clustersToken_);
+  if (!clusterHandle.isValid()) {
+    edm::LogWarning("Phase2OTValidateCluster") << "No Phase2TrackerCluster1D Collection found in the event. Skipping!";
+    return;
+  }
   // Getting PixelDigiSimLinks
   const auto& pixelSimLinksHandle = iEvent.getHandle(simOTLinksToken_);
+  if (!pixelSimLinksHandle.isValid()) {
+    edm::LogWarning("Phase2OTValidateCluster") << "No PixelDigiSimLinks Collection found in the event. Skipping!";
+    return;
+  }
 
   // Number of clusters
   std::map<std::string, unsigned int> nPrimarySimHits[3];


### PR DESCRIPTION
#### PR description:

Title says it all, addresses discussion at https://github.com/cms-sw/cmssw/pull/47352#issuecomment-2667155969 by including protections against missing cluster collections inputs in `Phase2IT{OT}ValidateCluster`.

#### PR validation:

`runTheMatrix.py -l 24034.0 -t 4 -j 8 --ibeos` now runs OK.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A