### PR TITLE
Fix FEVDEBUGHLT event content to include all Tracksters.

### DIFF
--- a/RecoHGCal/Configuration/python/RecoHGCal_EventContent_cff.py
+++ b/RecoHGCal/Configuration/python/RecoHGCal_EventContent_cff.py
@@ -73,8 +73,7 @@ TICLv5_FEVT.outputCommands.extend(TICLv5_RECO.outputCommands)
 TICL_FEVTHLT = cms.PSet(
     outputCommands = cms.untracked.vstring(
             ['keep *_hltPfTICL_*_*',
-            'keep *_hltTiclTrackstersCLUE3D*_*_*',
-            'keep *_hltTiclTracksterLinks_*_*',
+            'keep *_hltTiclTracksters*_*_*',
             'keep *_hltTiclCandidate_*_*',
             'keep *_hltPfTICL_*_*',]
     )


### PR DESCRIPTION
#### PR description:

The event content definition for `Tracksters` for the Phase2 HLT was such that not all `Tracksters` collection were saved. Actually, the most important one was skipped.
This PR fix this issue.