### PR TITLE
Follow up on using cms::alpakatools deltaPhi functions

### DIFF
--- a/RecoTracker/LSTCore/src/alpaka/Hit.h
+++ b/RecoTracker/LSTCore/src/alpaka/Hit.h
@@ -1,7 +1,6 @@
 #ifndef RecoTracker_LSTCore_src_alpaka_Hit_h
 #define RecoTracker_LSTCore_src_alpaka_Hit_h
 
-#include "DataFormats/Math/interface/deltaPhi.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/alpakastdAlgorithm.h"
 #include "HeterogeneousCore/AlpakaMath/interface/deltaPhi.h"

--- a/RecoTracker/LSTCore/src/alpaka/Kernels.h
+++ b/RecoTracker/LSTCore/src/alpaka/Kernels.h
@@ -163,7 +163,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
             float eta2 = __H2F(quintuplets.eta()[jx]);
             float phi2 = __H2F(quintuplets.phi()[jx]);
             float dEta = alpaka::math::abs(acc, eta1 - eta2);
-            float dPhi = reco::deltaPhi(phi1, phi2);
+            float dPhi = cms::alpakatools::deltaPhi(acc, phi1, phi2);
             float score_rphisum2 = __H2F(quintuplets.score_rphisum()[jx]);
 
             if (dEta > 0.1f)
@@ -238,7 +238,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
               float score_rphisum2 = __H2F(quintuplets.score_rphisum()[jx]);
 
               float dEta = alpaka::math::abs(acc, eta1 - eta2);
-              float dPhi = reco::deltaPhi(phi1, phi2);
+              float dPhi = cms::alpakatools::deltaPhi(acc, phi1, phi2);
 
               if (dEta > 0.1f)
                 continue;
@@ -395,7 +395,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
           }
           if (secondpass) {
             float dEta = alpaka::math::abs(acc, eta_pix1 - eta_pix2);
-            float dPhi = reco::deltaPhi(phi_pix1, phi_pix2);
+            float dPhi = cms::alpakatools::deltaPhi(acc, phi_pix1, phi_pix2);
 
             float dR2 = dEta * dEta + dPhi * dPhi;
             if ((npMatched >= 1) || (dR2 < 1e-5f)) {

--- a/RecoTracker/LSTCore/src/alpaka/NeuralNetwork.h
+++ b/RecoTracker/LSTCore/src/alpaka/NeuralNetwork.h
@@ -1,8 +1,8 @@
 #ifndef RecoTracker_LSTCore_src_alpaka_NeuralNetwork_h
 #define RecoTracker_LSTCore_src_alpaka_NeuralNetwork_h
 
-#include "DataFormats/Math/interface/deltaPhi.h"
 #include "FWCore/Utilities/interface/CMSUnrollLoop.h"
+#include "HeterogeneousCore/AlpakaMath/interface/deltaPhi.h"
 
 #include "RecoTracker/LSTCore/interface/alpaka/Common.h"
 #include "RecoTracker/LSTCore/interface/MiniDoubletsSoA.h"
@@ -85,25 +85,25 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst::t5dnn {
         z1 / kZ_max,                               // inner T3: First hit z normalized
         r1 / kR_max,                               // inner T3: First hit r normalized
 
-        eta2 - eta1,                             // inner T3: Difference in eta between hit 2 and 1
-        reco::deltaPhi(phi2, phi1) / kPhi_norm,  // inner T3: Difference in phi between hit 2 and 1
-        (z2 - z1) / kZ_max,                      // inner T3: Difference in z between hit 2 and 1 normalized
-        (r2 - r1) / kR_max,                      // inner T3: Difference in r between hit 2 and 1 normalized
+        eta2 - eta1,                                              // inner T3: Difference in eta between hit 2 and 1
+        cms::alpakatools::deltaPhi(acc, phi2, phi1) / kPhi_norm,  // inner T3: Difference in phi between hit 2 and 1
+        (z2 - z1) / kZ_max,  // inner T3: Difference in z between hit 2 and 1 normalized
+        (r2 - r1) / kR_max,  // inner T3: Difference in r between hit 2 and 1 normalized
 
-        eta3 - eta2,                             // inner T3: Difference in eta between hit 3 and 2
-        reco::deltaPhi(phi3, phi2) / kPhi_norm,  // inner T3: Difference in phi between hit 3 and 2
-        (z3 - z2) / kZ_max,                      // inner T3: Difference in z between hit 3 and 2 normalized
-        (r3 - r2) / kR_max,                      // inner T3: Difference in r between hit 3 and 2 normalized
+        eta3 - eta2,                                              // inner T3: Difference in eta between hit 3 and 2
+        cms::alpakatools::deltaPhi(acc, phi3, phi2) / kPhi_norm,  // inner T3: Difference in phi between hit 3 and 2
+        (z3 - z2) / kZ_max,  // inner T3: Difference in z between hit 3 and 2 normalized
+        (r3 - r2) / kR_max,  // inner T3: Difference in r between hit 3 and 2 normalized
 
-        eta4 - eta3,                             // outer T3: Difference in eta between hit 4 and 3
-        reco::deltaPhi(phi4, phi3) / kPhi_norm,  // inner T3: Difference in phi between hit 4 and 3
-        (z4 - z3) / kZ_max,                      // outer T3: Difference in z between hit 4 and 3 normalized
-        (r4 - r3) / kR_max,                      // outer T3: Difference in r between hit 4 and 3 normalized
+        eta4 - eta3,                                              // outer T3: Difference in eta between hit 4 and 3
+        cms::alpakatools::deltaPhi(acc, phi4, phi3) / kPhi_norm,  // inner T3: Difference in phi between hit 4 and 3
+        (z4 - z3) / kZ_max,  // outer T3: Difference in z between hit 4 and 3 normalized
+        (r4 - r3) / kR_max,  // outer T3: Difference in r between hit 4 and 3 normalized
 
-        eta5 - eta4,                             // outer T3: Difference in eta between hit 5 and 4
-        reco::deltaPhi(phi5, phi4) / kPhi_norm,  // inner T3: Difference in phi between hit 5 and 4
-        (z5 - z4) / kZ_max,                      // outer T3: Difference in z between hit 5 and 4 normalized
-        (r5 - r4) / kR_max,                      // outer T3: Difference in r between hit 5 and 4 normalized
+        eta5 - eta4,                                              // outer T3: Difference in eta between hit 5 and 4
+        cms::alpakatools::deltaPhi(acc, phi5, phi4) / kPhi_norm,  // inner T3: Difference in phi between hit 5 and 4
+        (z5 - z4) / kZ_max,  // outer T3: Difference in z between hit 5 and 4 normalized
+        (r5 - r4) / kR_max,  // outer T3: Difference in r between hit 5 and 4 normalized
 
         alpaka::math::log10(acc, innerRadius),   // T5 inner radius (t5_innerRadius)
         alpaka::math::log10(acc, bridgeRadius),  // T5 bridge radius (t5_bridgeRadius)

--- a/RecoTracker/LSTCore/src/alpaka/TrackCandidate.h
+++ b/RecoTracker/LSTCore/src/alpaka/TrackCandidate.h
@@ -132,7 +132,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
           float eta2 = pixelSegments.eta()[pLS_jx - prefix];
           float phi2 = pixelSegments.phi()[pLS_jx - prefix];
           float dEta = alpaka::math::abs(acc, (eta1 - eta2));
-          float dPhi = reco::deltaPhi(phi1, phi2);
+          float dPhi = cms::alpakatools::deltaPhi(acc, phi1, phi2);
 
           float dR2 = dEta * dEta + dPhi * dPhi;
           if (dR2 < 1e-5f)
@@ -179,7 +179,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
             }
 
             float dEta = alpaka::math::abs(acc, eta1 - eta2);
-            float dPhi = reco::deltaPhi(phi1, phi2);
+            float dPhi = cms::alpakatools::deltaPhi(acc, phi1, phi2);
 
             float dR2 = dEta * dEta + dPhi * dPhi;
             if (dR2 < 1e-3f)
@@ -221,7 +221,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
             float eta2 = __H2F(quintuplets.eta()[quintupletIndex]);
             float phi2 = __H2F(quintuplets.phi()[quintupletIndex]);
             float dEta = alpaka::math::abs(acc, eta1 - eta2);
-            float dPhi = reco::deltaPhi(phi1, phi2);
+            float dPhi = cms::alpakatools::deltaPhi(acc, phi1, phi2);
 
             float dR2 = dEta * dEta + dPhi * dPhi;
             if (dR2 < 1e-3f)
@@ -237,7 +237,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
             float eta2 = __H2F(pixelTriplets.eta_pix()[pT3Index]);
             float phi2 = __H2F(pixelTriplets.phi_pix()[pT3Index]);
             float dEta = alpaka::math::abs(acc, eta1 - eta2);
-            float dPhi = reco::deltaPhi(phi1, phi2);
+            float dPhi = cms::alpakatools::deltaPhi(acc, phi1, phi2);
 
             float dR2 = dEta * dEta + dPhi * dPhi;
             if (dR2 < 0.000001f)
@@ -253,7 +253,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
             float eta2 = pixelSegments.eta()[pLSIndex - prefix];
             float phi2 = pixelSegments.phi()[pLSIndex - prefix];
             float dEta = alpaka::math::abs(acc, eta1 - eta2);
-            float dPhi = reco::deltaPhi(phi1, phi2);
+            float dPhi = cms::alpakatools::deltaPhi(acc, phi1, phi2);
 
             float dR2 = dEta * dEta + dPhi * dPhi;
             if (dR2 < 0.000001f)


### PR DESCRIPTION
This is a follow up to PR #47208, where I missed moving some of the LST functions to the newly introduced `cms::alpakatools` deltaPhi functions. This PR takes care of those.

The code has been tested locally: it compiles and gives the identical results (on CPU) for LST.