### PR TITLE
Change fastjet RangeDefinition to Selector to fix warnings

### DIFF
--- a/RecoJets/JetProducers/interface/BackgroundEstimator.h
+++ b/RecoJets/JetProducers/interface/BackgroundEstimator.h
@@ -2,7 +2,7 @@
 #define __FASTJET_BACKGROUND_EXTRACTOR_HH__
 
 #include <fastjet/ClusterSequenceAreaBase.hh>
-#include <fastjet/RangeDefinition.hh>
+#include <fastjet/Selector.hh>
 #include <iostream>
 
 namespace fastjet {
@@ -43,7 +43,7 @@ namespace fastjet {
     /// default ctor
     /// \param csa      the ClusterSequenceArea to use
     /// \param range    the range over which jets will be considered
-    BackgroundEstimator(const ClusterSequenceAreaBase &csa, const RangeDefinition &range);
+    BackgroundEstimator(const ClusterSequenceAreaBase &csa, const Selector &range);
 
     /// default dtor
     ~BackgroundEstimator();
@@ -146,7 +146,7 @@ namespace fastjet {
 
     // the information needed to do the computation
     const ClusterSequenceAreaBase &_csa;    ///< cluster sequence to get jets and areas from
-    const RangeDefinition &_range;          ///< range to compute the background in
+    const Selector &_range;                 ///< range to compute the background in
     std::vector<PseudoJet> _included_jets;  ///< jets to be used
     std::vector<PseudoJet> _excluded_jets;  ///< jets to be excluded
     bool _all_from_inclusive;               ///< when true, we'll assume that the incl jets are the complete set

--- a/RecoJets/JetProducers/interface/PileUpSubtractor.h
+++ b/RecoJets/JetProducers/interface/PileUpSubtractor.h
@@ -26,7 +26,6 @@ class PileUpSubtractor {
 public:
   typedef std::shared_ptr<fastjet::ClusterSequence> ClusterSequencePtr;
   typedef std::shared_ptr<fastjet::GhostedAreaSpec> ActiveAreaSpecPtr;
-  typedef std::shared_ptr<fastjet::RangeDefinition> RangeDefPtr;
   typedef std::shared_ptr<fastjet::JetDefinition> JetDefPtr;
 
   PileUpSubtractor(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC);

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
@@ -641,7 +641,7 @@ void VirtualJetProducer::writeJets(edm::Event& iEvent, edm::EventSetup const& iS
           double eta = puCenters_[ie];
           double etamin = eta - puWidth_;
           double etamax = eta + puWidth_;
-          fastjet::RangeDefinition range_rho(etamin, etamax);
+          fastjet::Selector range_rho(fastjet::SelectorRapRange(etamin, etamax));
           fastjet::BackgroundEstimator bkgestim(*clusterSequenceWithArea, range_rho);
           bkgestim.set_excluded_jets(fjexcluded_jets);
           rhos->push_back(bkgestim.rho());

--- a/RecoJets/JetProducers/src/BackgroundEstimator.cc
+++ b/RecoJets/JetProducers/src/BackgroundEstimator.cc
@@ -21,7 +21,7 @@ using namespace std;
 // default ctor
 //  - csa      the ClusterSequenceArea to use
 //  - range    the range over which jets will be considered
-BackgroundEstimator::BackgroundEstimator(const ClusterSequenceAreaBase &csa, const RangeDefinition &range)
+BackgroundEstimator::BackgroundEstimator(const ClusterSequenceAreaBase &csa, const Selector &range)
     : _csa(csa), _range(range) {
   reset();
 }
@@ -77,7 +77,7 @@ void BackgroundEstimator::_compute() {
       excluded |= (_excluded_jets[j].cluster_hist_index() == ref_idx);
 
     // check if the jet is in the range
-    if (_range.is_in_range(current_jet)) {
+    if (_range.pass(current_jet)) {
       if (excluded) {
         // keep track of the explicitly excluded jets
         _n_jets_excluded++;


### PR DESCRIPTION
#### PR description:

This PR changes the remaining instances of fastjet::RangeDefinition to fastjet::Selector to fix the following warning message:
""
WARNING from FastJet: The use of RangeDefinition is deprecated since FastJet version 3.0 onwards. Please consider using Selector (defined in fastjet/Selector.hh) instead. There is no guarantee that support for RangeDefinition will be provided in future releases of FastJet.
""