### PR TITLE
Restore run2_data_HEfail in autoCond

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -25,6 +25,8 @@ autoCond = {
     'run2_mc_pa'                   :    '131X_mcRun2_pA_v3',
     # GlobalTag for Run2 data reprocessing
     'run2_data'                    :    '141X_dataRun2_v2',
+    # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
+    'run2_data_HEfail'             :    '140X_dataRun2_HEfail_v1',
     # GlobalTag for Run2 HI data
     'run2_data_promptlike_hi'      :    '140X_dataRun2_PromptLike_HI_v1',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu


### PR DESCRIPTION
#### PR description:

It fixes the [error in wf 136.8642](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc12/CMSSW_15_1_X_2025-02-19-2300/pyRelValMatrixLogs/run/136.8642_RunJetHT2018BHEfail/step3_RunJetHT2018BHEfail.log#/) that was there after the merge of #47385 since CMSSW_14_2_X_2025-02-19-2300

