### PR TITLE
[GCC14]Fix type conversion not using user defined operator warning

### DIFF
--- a/CondFormats/Serialization/interface/eos/portable_iarchive.hpp
+++ b/CondFormats/Serialization/interface/eos/portable_iarchive.hpp
@@ -409,7 +409,7 @@ namespace eos {
       // created through BOOST_STRONG_TYPEDEF(X, some unsigned int) like
       // library_version_type, collection_size_type, item_version_type,
       // class_id_type, object_id_type, version_type and tracking_type
-      load((typename boost::uint_t<sizeof(T) * CHAR_BIT>::least&)(t));
+      load(static_cast<T::base_type&>(t));
     }
   };
 


### PR DESCRIPTION
In GCC 14 IBs we have over 4K [warnings](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc14/CMSSW_15_1_X_2025-02-18-2300/CondCore/AlignmentPlugins) like
```
   2170  casting 'boost::archive::class_id_type' to 'boost::uint_t&lt;16&gt;::least&amp;' {aka 'short unsigned int&amp;'} does not use 'boost::archive::class_id_type::operator base_type&amp;()' [-Wcast-user-defined]
   2170  casting 'boost::archive::tracking_type' to 'boost::uint_t&lt;8&gt;::least&amp;' {aka 'unsigned char&amp;'} does not use 'boost::archive::tracking_type::operator bool&amp;()' [-Wcast-user-defined]
```

Boost is patched to make class::base_type public. So this PR proposes to use that which will make sure that compiler calls the user defined conversion operator