### PR TITLE
[Backport 15_0_X] Restriction of reemul fg0 in ieta16

### DIFF
--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalFinegrainBit.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalFinegrainBit.cc
@@ -96,7 +96,7 @@ std::bitset<6> HcalFinegrainBit::compute(const HcalFinegrainBit::TowerTDC& tower
   }
 
   // very delayed (001000), slightly delayed (000100), prompt (000010), depth flag (000001), 2 reserved bits (110000)
-  if (DeepEnergy > 0 && EarlyEnergy == 0)
+  if (DeepEnergy > 0 && EarlyEnergy == 0 && abs(tp_ieta) != 16)
     result[0] = true;  // 000001
   else
     result[0] = false;


### PR DESCRIPTION
#### PR description:

Based on logic in the HB uHTR firmware, the depth bit will always be 0 in abs(ieta) == 16. The depth bit is set in the emulator in file `SimCalorimetry/HcalTrigPrimAlgos/src/HcalFinegrainBit.cc`. There was no restriction on abs(ieta) == 16, causing the depth bit to be set in the emulator in this region. A restriction was added to the emulator to match the firmware. Slides explaining the issues and showing changes to the depth bit in abs(ieta) == 16 are provided below. 

[Hazelton_reemul_fix.pdf](https://github.com/user-attachments/files/18691409/Hazelton_reemul_fix.pdf)


#### PR validation:

Passed runTheMatrix.py tests. Tested in CMSSW_15_0_X_2025-02-04-2300.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backporting PR #47283 to 15_0_X to show better agreement in the HCAL DQM plot between data and emulator in early 2025 data taking. @gk199 @JHiltbrand 
