### PR TITLE
Fix `HcalUpgradeDataFrame` dummy type

### DIFF
--- a/DataFormats/HcalDigi/src/classes.h
+++ b/DataFormats/HcalDigi/src/classes.h
@@ -16,7 +16,8 @@
 
 // dummy structs to ensure backward compatibility
 struct HcalUpgradeDataFrame {
-  typedef HcalDetId key_type;
+  using key_type = HcalDetId;
+  HcalDetId id() const { return HcalDetId(); }
 };
 struct HcalUpgradeQIESample {};
 typedef edm::SortedCollection<HcalUpgradeDataFrame> HBHEUpgradeDigiCollection;


### PR DESCRIPTION
#### PR description:

The current dummy implementation of `HcalUpgradeDataFrame`
```c++
// dummy structs to ensure backward compatibility
struct HcalUpgradeDataFrame {
  typedef HcalDetId key_type;
};
```
is fine as long as it is only used in a `typedef` or forward declaration, but brakes up if one actually tries to instantiate one of the templates declared right below it
```c++
typedef edm::SortedCollection<HcalUpgradeDataFrame> HBHEUpgradeDigiCollection;
typedef edm::SortedCollection<HcalUpgradeDataFrame> HFUpgradeDigiCollection;
```

This PR makes the template instantiation legal by adding a dummy `id()` method, that is needed by the `edm::SortedCollection` template.


#### PR validation:

Code compiles and all unit tests run.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 15.0.x as part of the "generic product" and MPI developments.