### PR TITLE
Backport to produce 2024 and 2025 Tau Embedding samples

### DIFF
--- a/TauAnalysis/MCEmbeddingTools/python/SelectingProcedure_cff.py
+++ b/TauAnalysis/MCEmbeddingTools/python/SelectingProcedure_cff.py
@@ -1,18 +1,33 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Modifier_run2_HLTconditions_2016_cff import (
+    run2_HLTconditions_2016,
+)
+from Configuration.Eras.Modifier_run2_HLTconditions_2017_cff import (
+    run2_HLTconditions_2017,
+)
+from Configuration.Eras.Modifier_run2_HLTconditions_2018_cff import (
+    run2_HLTconditions_2018,
+)
 from Configuration.StandardSequences.PAT_cff import *
-
-from PhysicsTools.PatAlgos.producersLayer1.muonProducer_cfi import patMuons
 from HLTrigger.HLTfilters.triggerResultsFilter_cfi import *
-from Configuration.Eras.Modifier_run2_HLTconditions_2016_cff import run2_HLTconditions_2016
+from PhysicsTools.PatAlgos.producersLayer1.muonProducer_cfi import patMuons
 
 ## Trigger requirements
 doubleMuonHLTTrigger = cms.EDFilter("TriggerResultsFilter",
     hltResults = cms.InputTag("TriggerResults","","HLT"),
     l1tResults = cms.InputTag(""),
     throw = cms.bool(False),
-    triggerConditions = cms.vstring("HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v* OR HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8_v*") # from 2017 on (up to Run 3, it seems)
+    triggerConditions = cms.vstring("HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass3p8_v*") # unprescaled trigger for 2018,22,23,24 (see https://twiki.cern.ch/twiki/bin/view/CMS/MuonHLT2018, https://twiki.cern.ch/twiki/bin/view/CMS/MuonHLT2022, https://twiki.cern.ch/twiki/bin/view/CMS/MuonHLT2023, https://twiki.cern.ch/twiki/bin/view/CMS/MuonHLT2024)
 )
 
+#### change the used triggers for run2 ####
+# Use two different triggers as the Mass8 one has a higer luminosity in 2017 according to https://cmshltinfo.app.cern.ch/summary?search=HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass&year=2017&paths=true&prescaled=true&stream-types=Physics
+# probably because he was already active in earlier runs than the Mass3p8 trigger
+# Both are unprescaled
+run2_HLTconditions_2017.toModify(doubleMuonHLTTrigger,
+                                 triggerConditions = ["HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v* OR HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8_v*"])
+
+# Both are unprescaled according to https://cmshltinfo.app.cern.ch/summary?search=HLT_Mu17_TrkIsoVVL_&year=2016&paths=true&prescaled=true&stream-types=Physics
 run2_HLTconditions_2016.toModify(doubleMuonHLTTrigger,
                                  triggerConditions = ["HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v* OR HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v*"])
 

--- a/TauAnalysis/MCEmbeddingTools/test/BuildFile.xml
+++ b/TauAnalysis/MCEmbeddingTools/test/BuildFile.xml
@@ -2,4 +2,5 @@
 <test name="testTauEmbeddingWorkflow2016preVFP" command="run_2016postVFPUL_workflow_tests.sh"/>
 <test name="testTauEmbeddingWorkflow2017" command="run_2017UL_workflow_tests.sh"/>
 <test name="testTauEmbeddingWorkflow2018" command="run_2018UL_workflow_tests.sh"/>
+<test name="testTauEmbeddingWorkflow2022postEE" command="run_2022_workflow_tests.sh"/>
 

--- a/TauAnalysis/MCEmbeddingTools/test/run_2022_workflow_tests.sh
+++ b/TauAnalysis/MCEmbeddingTools/test/run_2022_workflow_tests.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# This script runs all the steps of the embedding workflow
+# author: Christian Winter (christian.winter@cern.ch)
+# TODO: move the dataset to a more persistent and for cmssw accessible place than a private EOS user folder
+
+# print the exit status before exiting
+function die {
+    echo $1: status $2
+    exit $2
+}
+
+## This is a PRE SKIMED dataset
+dataset="root://eoscms.cern.ch//store/group/phys_tau/embedding_test_files/2022_G_RAW.root"
+
+echo "################ Selection ################"
+cmsDriver.py RECO \
+    --step RAW2DIGI,L1Reco,RECO,PAT \
+    --data \
+    --scenario pp \
+    --conditions auto:run3_data \
+    --era Run3 \
+    --eventcontent RAWRECO \
+    --datatier RAWRECO \
+    --customise TauAnalysis/MCEmbeddingTools/customisers.customiseSelecting \
+    --filein $dataset \
+    --fileout file:selection.root \
+    -n -1 \
+    --python_filename selection.py || die 'Failure during selecting step' $?
+
+echo "################ LHE production and cleaning ################"
+cmsDriver.py LHEprodandCLEAN \
+    --step RAW2DIGI,RECO,PAT \
+    --data \
+    --scenario pp \
+    --conditions auto:run3_data \
+    --era Run3 \
+    --eventcontent RAWRECO \
+    --datatier RAWRECO \
+    --customise Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018,TauAnalysis/MCEmbeddingTools/customisers.customiseLHEandCleaning \
+    --filein file:selection.root \
+    --fileout file:lhe_and_cleaned.root \
+    -n -1 \
+    --python_filename lheprodandcleaning.py || die 'Failure during LHE and Cleaning step' $?
+
+# Simulation (MC & Detector)
+echo "################ Simulation (MC & Detector) ################"
+cmsDriver.py TauAnalysis/MCEmbeddingTools/python/EmbeddingPythia8Hadronizer_cfi.py \
+    --step GEN,SIM,DIGI,L1,DIGI2RAW \
+    --mc \
+    --beamspot Realistic25ns13p6TeVEarly2022Collision \
+    --geometry DB:Extended \
+    --era Run3 \
+    --conditions auto:phase1_2022_realistic_postEE \
+    --eventcontent RAWSIM \
+    --datatier RAWSIM \
+    --customise \
+    TauAnalysis/MCEmbeddingTools/customisers.customiseGenerator_preHLT \
+    --customise_commands 'process.generator.HepMCFilter.filterParameters.MuMuCut = cms.string("(Mu.Pt > 18 && Had.Pt > 18 && Mu.Eta < 2.2 && Had.Eta < 2.4)");process.generator.HepMCFilter.filterParameters.Final_States = cms.vstring("MuHad");process.generator.nAttempts = cms.uint32(1000);' \
+    --filein file:lhe_and_cleaned.root \
+    --fileout file:simulated_and_cleaned_prehlt.root \
+    -n -1 \
+    --python_filename generator_preHLT.py || die 'Failure during MC & Detector simulation step' $?
+
+# Simulation (Trigger)
+echo "################ Simulation (Trigger) ################"
+cmsDriver.py TauAnalysis/MCEmbeddingTools/python/EmbeddingPythia8Hadronizer_cfi.py \
+    --step HLT:Fake2 \
+    --mc \
+    --beamspot Realistic25ns13p6TeVEarly2022Collision \
+    --geometry DB:Extended \
+    --era Run3 \
+    --conditions auto:phase1_2022_realistic_postEE \
+    --eventcontent RAWSIM \
+    --datatier RAWSIM \
+    --customise \
+    TauAnalysis/MCEmbeddingTools/customisers.customiseGenerator_HLT \
+    --customise_commands 'process.source.bypassVersionCheck = cms.untracked.bool(True);' \
+    --filein file:simulated_and_cleaned_prehlt.root \
+    --fileout file:simulated_and_cleaned_hlt.root \
+    -n -1 \
+    --python_filename generator_HLT.py || die 'Failure during Fake Trigger simulation step' $?
+
+# Simulation (Reconstruction)
+echo "################ Simulation (Reconstruction) ################"
+cmsDriver.py TauAnalysis/MCEmbeddingTools/python/EmbeddingPythia8Hadronizer_cfi.py \
+    --step RAW2DIGI,L1Reco,RECO,RECOSIM \
+    --mc \
+    --beamspot Realistic25ns13p6TeVEarly2022Collision \
+    --geometry DB:Extended \
+    --era Run3 \
+    --conditions auto:phase1_2022_realistic_postEE \
+    --eventcontent RAWRECOSIMHLT \
+    --datatier RAW-RECO-SIM \
+    --customise \
+    TauAnalysis/MCEmbeddingTools/customisers.customiseGenerator_postHLT \
+    --customise_commands 'process.source.bypassVersionCheck = cms.untracked.bool(True);' \
+    --filein file:simulated_and_cleaned_hlt.root \
+    --fileout file:simulated_and_cleaned_posthlt.root \
+    -n -1 \
+    --python_filename generator_postHLT.py || die 'Failure during reconstruction simulation step' $?
+
+# Merging
+echo "################ Merging ################"
+cmsDriver.py PAT \
+    --step PAT \
+    --data \
+    --scenario pp \
+    --conditions auto:run3_data \
+    --era Run3 \
+    --eventcontent MINIAODSIM \
+    --datatier USER \
+    --customise \
+    TauAnalysis/MCEmbeddingTools/customisers.customiseMerging \
+    --filein file:simulated_and_cleaned_posthlt.root \
+    --fileout file:merged.root \
+    -n -1 \
+    --python_filename merging.py || die 'Failure during the merging step' $?
+
+# NanoAOD Production
+echo "################ NanoAOD Production ################"
+cmsDriver.py \
+    --step NANO \
+    --data \
+    --conditions auto:run3_data \
+    --era Run3 \
+    --eventcontent NANOAODSIM \
+    --datatier NANOAODSIM \
+    --customise TauAnalysis/MCEmbeddingTools/customisers.customiseNanoAOD \
+    --filein file:merged.root \
+    --fileout file:merged_nano.root \
+    -n -1 \
+    --python_filename embedding_nanoAOD.py || die 'Failure during the nanoAOD step' $?


### PR DESCRIPTION
#### PR description:
This PR is a backport and is required to produce tau embedding samples with 2024 and 2025 data on official CMS resources. This backport is needed, as this CMSSW version is used in the MC production campaigns for 2024 and 2025 MC events and therefore contain all important settings like the HLT menu.

The tau embedding method is used to estimate the genuine di-tau background from data. It is a common method used in analyses with tau leptons. More information about tau embedding can be found in the paper: [https://doi.org/10.1088/1748-0221/14/06/P06032](https://doi.org/10.1088/1748-0221/14/06/P06032)  
In principle, one can split the method into 4 steps, but technically there are at least 6 steps that have to be executed.

To produce tau embedding samples, one can use the cmsDriver commands shown in this [presentation](https://indico.cern.ch/event/1508508/contributions/6347811/attachments/3007650/5301994/Christian_Winter_status_on_tau_embedding_2025_02_03.pdf#page=27).

The PR contains the following commit #47299 and doesn't influence any other code then the one used for the tau embedding method.

There are also two other similar backport PRs: #47403 and #47404

The tau embedding method and these PRs were also presented in a [PPD](https://indico.cern.ch/event/1510579/#5-tau-pog-tau-embedding-method) and [RECO](https://indico.cern.ch/event/1517184/#6-tau-embedding-method-update) meeting.
With this PR we target a new release, probably CMSSW_15_0_1 or at least the one which is used for the MC campaigns in summer 2025.