### PR TITLE
Implement additional framework integration tests

### DIFF
--- a/DataFormats/TestObjects/interface/ThingWithDoNotSort.h
+++ b/DataFormats/TestObjects/interface/ThingWithDoNotSort.h
@@ -1,0 +1,31 @@
+#ifndef DataFormats_TestObjects_interface_ThingWithDoNotSort_h
+#define DataFormats_TestObjects_interface_ThingWithDoNotSort_h
+
+#include <stdexcept>
+#include <cstdint>
+
+#include "DataFormats/Common/interface/traits.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/typedefs.h"
+
+namespace edmtest {
+
+  class ThingWithDoNotSort : public edm::DoNotSortUponInsertion {
+  public:
+    ThingWithDoNotSort() : value_{0} {};
+    explicit ThingWithDoNotSort(cms_int32_t v) : value_{v} {}
+
+    void post_insert() {
+      throw cms::Exception("LogicError")
+          << "post_insert() called for ThingWithDoNotSort that inherits from edm::DoNotSortUponInsertion";
+    }
+
+    int32_t value() const { return value_; }
+
+  private:
+    cms_int32_t value_;
+  };
+
+}  // namespace edmtest
+
+#endif  // DataFormats_TestObjects_interface_ThingWithDoNotSort_h

--- a/DataFormats/TestObjects/interface/ThingWithPostInsert.h
+++ b/DataFormats/TestObjects/interface/ThingWithPostInsert.h
@@ -1,0 +1,28 @@
+#ifndef DataFormats_TestObjects_interface_ThingWithPostInsert_h
+#define DataFormats_TestObjects_interface_ThingWithPostInsert_h
+
+#include <cstdint>
+
+#include "FWCore/Utilities/interface/typedefs.h"
+
+namespace edmtest {
+
+  class ThingWithPostInsert {
+  public:
+    ThingWithPostInsert() : value_{0}, valid_{false} {};
+    explicit ThingWithPostInsert(cms_int32_t v) : value_{v}, valid_{false} {}
+
+    void post_insert() { valid_ = true; }
+
+    int32_t value() const { return value_; }
+
+    bool valid() const { return valid_; }
+
+  private:
+    cms_int32_t value_;
+    bool valid_;
+  };
+
+}  // namespace edmtest
+
+#endif  // DataFormats_TestObjects_interface_ThingWithPostInsert_h

--- a/DataFormats/TestObjects/src/classes.h
+++ b/DataFormats/TestObjects/src/classes.h
@@ -18,6 +18,8 @@
 #include "DataFormats/TestObjects/interface/Thing.h"
 #include "DataFormats/TestObjects/interface/ThingWithMerge.h"
 #include "DataFormats/TestObjects/interface/ThingWithIsEqual.h"
+#include "DataFormats/TestObjects/interface/ThingWithPostInsert.h"
+#include "DataFormats/TestObjects/interface/ThingWithDoNotSort.h"
 #include "DataFormats/TestObjects/interface/TrackOfThings.h"
 #include "DataFormats/TestObjects/interface/TrackOfDSVThings.h"
 

--- a/DataFormats/TestObjects/src/classes_def.xml
+++ b/DataFormats/TestObjects/src/classes_def.xml
@@ -146,6 +146,16 @@
  <class name="edm::Wrapper<std::vector<edmtest::Thing> >"/>
  <class name="edm::Wrapper<std::vector<edmtest::OtherThing> >"/>
 
+ <class name="edmtest::ThingWithPostInsert" ClassVersion="3">
+  <version ClassVersion="3" checksum="2193684721"/>
+ </class>
+ <class name="edm::Wrapper<edmtest::ThingWithPostInsert>"/>
+
+ <class name="edmtest::ThingWithDoNotSort" ClassVersion="3">
+  <version ClassVersion="3" checksum="1286605803"/>
+ </class>
+ <class name="edm::Wrapper<edmtest::ThingWithDoNotSort>"/>
+
  <class name="edmNew::DetSetVector<edmtest::Thing>"/>
  <class name="edm::Ref<edmNew::DetSetVector<edmtest::Thing>, edmtest::Thing, edmNew::DetSetVector<edmtest::Thing>::FindForDetSetVector>"/>
  <class name="edm::RefVector<edmNew::DetSetVector<edmtest::Thing>, edmtest::Thing, edmNew::DetSetVector<edmtest::Thing>::FindForDetSetVector>"/>

--- a/FWCore/Integration/plugins/BuildFile.xml
+++ b/FWCore/Integration/plugins/BuildFile.xml
@@ -7,8 +7,7 @@
     <use name="FWCore/Utilities"/>
   </library>
 
-  <library file="ThingProducer.cc,ThingAlgorithm.cc,TrackOfThingsProducer.cc,ThinningTestAnalyzer.cc,ThinnedRefFromTestAnalyzer.cc,DetSetVectorThingProducer.cc,TrackOfDSVThingsProducer.cc,ThinningDSVThingProducer.cc,SlimmingDSVThingProducer.cc,ThinningDSVTestAnalyzer.cc,ThingSource.cc,ThingExtSource.cc,ThingWithMergeProducer.cc,TestGetterOfProducts.cc,PutOrMergeTestSource.cc,TestGetByLabelAnalyzer.cc,ThingAnalyzer.cc,TestOutputWithGetterOfProducts.cc,TestOutputWithGetterOfProductsGlobal.cc,TestOutputWithGetterOfProductsLimited.cc"
-      name="FWCoreIntegrationTestWithThing">
+  <library file="DetSetVectorThingProducer.cc,PostInsertProducer.cc,PutOrMergeTestSource.cc,SlimmingDSVThingProducer.cc,TestGetByLabelAnalyzer.cc,TestGetterOfProducts.cc,TestOutputWithGetterOfProducts.cc,TestOutputWithGetterOfProductsGlobal.cc,TestOutputWithGetterOfProductsLimited.cc,ThingAlgorithm.cc,ThingAnalyzer.cc,ThingExtSource.cc,ThingProducer.cc,ThingSource.cc,ThingWithMergeProducer.cc,ThinnedRefFromTestAnalyzer.cc,ThinningDSVTestAnalyzer.cc,ThinningDSVThingProducer.cc,ThinningTestAnalyzer.cc,TrackOfDSVThingsProducer.cc,TrackOfThingsProducer.cc" name="FWCoreIntegrationTestWithThing">
       <flags EDM_PLUGIN="1"/>
       <use name="FWCore/Framework"/>
       <use name="FWCore/Sources"/>

--- a/FWCore/Integration/plugins/PostInsertProducer.cc
+++ b/FWCore/Integration/plugins/PostInsertProducer.cc
@@ -1,0 +1,83 @@
+#include "DataFormats/TestObjects/interface/ThingWithDoNotSort.h"
+#include "DataFormats/TestObjects/interface/ThingWithPostInsert.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
+
+namespace edmtest {
+
+  class PostInsertProducer : public edm::global::EDProducer<> {
+  public:
+    explicit PostInsertProducer(edm::ParameterSet const& ps);
+
+    void produce(edm::StreamID sid, edm::Event& event, edm::EventSetup const& es) const override;
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  private:
+    edm::EDPutTokenT<ThingWithPostInsert> putTokenPostInsert_;
+    edm::EDPutTokenT<ThingWithDoNotSort> putTokenDoNotSort_;
+    edm::EDPutTokenT<ThingWithPostInsert> emplaceTokenPostInsert_;
+    edm::EDPutTokenT<ThingWithDoNotSort> emplaceTokenDoNotSort_;
+  };
+
+  PostInsertProducer::PostInsertProducer(edm::ParameterSet const& iConfig)
+      : putTokenPostInsert_{produces<ThingWithPostInsert>("put")},
+        putTokenDoNotSort_{produces<ThingWithDoNotSort>("put")},
+        emplaceTokenPostInsert_{produces<ThingWithPostInsert>("emplace")},
+        emplaceTokenDoNotSort_{produces<ThingWithDoNotSort>("emplace")} {}
+
+  // Functions that gets called by framework every event
+  void PostInsertProducer::produce(edm::StreamID sid, edm::Event& event, edm::EventSetup const& es) const {
+    {
+      // Check that event.put() calls ThingWithPostInsert::post_insert().
+      auto product = std::make_unique<ThingWithPostInsert>(42);
+      assert(not product->valid());
+      assert(product->value() == 42);
+      auto handle = event.put(putTokenPostInsert_, std::move(product));
+      assert(handle->valid());
+      assert(handle->value() == 42);
+    }
+
+    {
+      // Check that event.put *does not* call ThingWithDoNotSort::post_insert(),
+      // which would throw an exception.
+      auto product = std::make_unique<ThingWithDoNotSort>(42);
+      assert(product->value() == 42);
+      auto handle = event.put(putTokenDoNotSort_, std::move(product));
+      assert(handle->value() == 42);
+    }
+
+    {
+      // Check that event.emplace() calls ThingWithPostInsert::post_insert().
+      ThingWithPostInsert product{42};
+      assert(not product.valid());
+      assert(product.value() == 42);
+      auto handle = event.emplace(emplaceTokenPostInsert_, product);
+      assert(handle->valid());
+      assert(handle->value() == 42);
+    }
+
+    {
+      // Check that event.emplace *does not* call ThingWithDoNotSort::post_insert(),
+      // which would throw an exception.
+      ThingWithDoNotSort product{42};
+      assert(product.value() == 42);
+      auto handle = event.emplace(emplaceTokenDoNotSort_, product);
+      assert(handle->value() == 42);
+    }
+  }
+
+  void PostInsertProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    descriptions.addWithDefaultLabel(desc);
+  }
+
+}  // namespace edmtest
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+using edmtest::PostInsertProducer;
+DEFINE_FWK_MODULE(PostInsertProducer);

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -42,6 +42,7 @@
   <test name="TestIntegrationExistingDictionary" command="run_TestExistingDictionary.sh"/>
   <test name="TestIntegrationEmptyRootFile" command="run_TestEmptyRootFile.sh"/>
   <test name="TestStdProducts" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/testStdProducts_cfg.py"/>
+  <test name="TestPostInsertProducer" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/testPostInsertProducer_cfg.py"/>
 
   <bin file="ProcessConfiguration_t.cpp,ProcessHistory_t.cpp" name="TestIntegrationDataFormatsProvenance">
     <use name="FWCore/ParameterSet"/>

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -41,6 +41,7 @@
   <test name="CatchCmsExceptiontest" command="CatchCmsExceptiontest.sh"/>
   <test name="TestIntegrationExistingDictionary" command="run_TestExistingDictionary.sh"/>
   <test name="TestIntegrationEmptyRootFile" command="run_TestEmptyRootFile.sh"/>
+  <test name="TestStdProducts" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/testStdProducts_cfg.py"/>
 
   <bin file="ProcessConfiguration_t.cpp,ProcessHistory_t.cpp" name="TestIntegrationDataFormatsProvenance">
     <use name="FWCore/ParameterSet"/>

--- a/FWCore/Integration/test/testPostInsertProducer_cfg.py
+++ b/FWCore/Integration/test/testPostInsertProducer_cfg.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.options.numberOfThreads = 4
+process.options.numberOfStreams = 4
+
+process.source = cms.Source("EmptySource")
+process.maxEvents.input = 10
+
+process.prod = cms.EDProducer("PostInsertProducer")
+
+process.path = cms.Path(
+    process.prod
+)

--- a/FWCore/Integration/test/testStdProducts_cfg.py
+++ b/FWCore/Integration/test/testStdProducts_cfg.py
@@ -1,0 +1,77 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.MessageLogger.cerr.INFO.limit = 10000000
+
+process.options.numberOfThreads = 4
+process.options.numberOfStreams = 4
+
+process.source = cms.Source("EmptySource")
+process.maxEvents.input = 10
+
+# produce and validate products of type int
+intValue = 42
+
+process.produceInt = cms.EDProducer("edmtest::GlobalIntProducer",
+    value = cms.int32(intValue)
+)
+
+process.validateInt = cms.EDAnalyzer("edmtest::GlobalIntAnalyzer",
+    source = cms.InputTag("produceInt"),
+    expected = cms.int32(intValue)
+)
+
+process.taskInt = cms.Task(process.produceInt)
+
+process.pathInt = cms.Path(process.validateInt, process.taskInt)
+
+# produce and validate products of type float
+floatValue = 3.14159
+
+process.produceFloat = cms.EDProducer("edmtest::GlobalFloatProducer",
+    value = cms.double(floatValue)
+)
+
+process.validateFloat = cms.EDAnalyzer("edmtest::GlobalFloatAnalyzer",
+    source = cms.InputTag("produceFloat"),
+    expected = cms.double(floatValue)
+)
+
+process.taskFloat = cms.Task(process.produceFloat)
+
+process.pathFloat = cms.Path(process.validateFloat, process.taskFloat)
+
+# produce and validate products of type std::string
+stringValue = "Hello world"
+
+process.produceString = cms.EDProducer("edmtest::GlobalStringProducer",
+    value = cms.string(stringValue)
+)
+
+process.validateString = cms.EDAnalyzer("edmtest::GlobalStringAnalyzer",
+    source = cms.InputTag("produceString"),
+    expected = cms.string(stringValue)
+)
+
+process.taskString = cms.Task(process.produceString)
+
+process.pathString = cms.Path(process.validateString, process.taskString)
+
+# produce and validate products of type std::vector<double>
+import random
+random.seed()
+doubleValues = [ random.uniform(-10., 10.) for i in range(10) ]
+
+process.produceVector = cms.EDProducer("edmtest::GlobalVectorProducer",
+    values = cms.vdouble(doubleValues)
+)
+
+process.validateVector = cms.EDAnalyzer("edmtest::GlobalVectorAnalyzer",
+    source = cms.InputTag("produceVector"),
+    expected = cms.vdouble(doubleValues)
+)
+
+process.taskVector = cms.Task(process.produceVector)
+
+process.pathVector = cms.Path(process.validateVector, process.taskVector)

--- a/FWCore/TestModules/README.md
+++ b/FWCore/TestModules/README.md
@@ -4,6 +4,19 @@ This package contains modules that are used in framework tests, but
 are generic-enough to be usable outside of the framework as well.
 Their interfaces are intended to be relatively stable.
 
+## `edmtest::GlobalIntProducer`, `edmtest::GlobalFloatProducer`, `edmtest::GlobalStringProducer`, `edmtest::GlobalVectorProducer`
+
+These modules can be used to produce into the event plain C++ data types based
+on configurable values: a single `int`, a single `float`, a single `std::string`,
+a `vector<double>`.
+
+
+## `edmtest::GlobalIntAnalyzer`, `edmtest::GlobalFloatAnalyzer`, `edmtest::GlobalStringAnalyzer`, `edmtest::GlobalVectorAnalyzer`
+
+These modules can be used to read form the event plain C++ data types, and
+compare them with configurable expected values: a single `int`, a single `float`,
+a single `std::string`, a `vector<double>`.
+
 
 ## `edmtest::StreamIDFilter`
 

--- a/FWCore/TestModules/plugins/GlobalFloatAnalyzer.cc
+++ b/FWCore/TestModules/plugins/GlobalFloatAnalyzer.cc
@@ -1,0 +1,46 @@
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+namespace edmtest {
+
+  class GlobalFloatAnalyzer : public edm::global::EDAnalyzer<> {
+  public:
+    explicit GlobalFloatAnalyzer(edm::ParameterSet const& ps);
+
+    void analyze(edm::StreamID sid, edm::Event const& event, edm::EventSetup const& es) const override;
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  private:
+    edm::EDGetTokenT<float> token_;
+    float expected_;
+  };
+
+  GlobalFloatAnalyzer::GlobalFloatAnalyzer(edm::ParameterSet const& config)
+      : token_(consumes(config.getParameter<edm::InputTag>("source"))),
+        expected_(static_cast<float>(config.getParameter<double>("expected"))) {}
+
+  void GlobalFloatAnalyzer::analyze(edm::StreamID sid, edm::Event const& event, edm::EventSetup const& es) const {
+    float value = event.get(token_);
+    if (value != expected_) {
+      throw cms::Exception("LogicError") << "expected value \"" << expected_ << "\"\nreceived value \"" << value << '"';
+    }
+  }
+
+  void GlobalFloatAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<edm::InputTag>("source");
+    desc.add<double>("expected", 0.);
+    descriptions.addDefault(desc);
+  }
+
+}  // namespace edmtest
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(edmtest::GlobalFloatAnalyzer);

--- a/FWCore/TestModules/plugins/GlobalFloatProducer.cc
+++ b/FWCore/TestModules/plugins/GlobalFloatProducer.cc
@@ -1,0 +1,39 @@
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
+
+namespace edmtest {
+
+  class GlobalFloatProducer : public edm::global::EDProducer<> {
+  public:
+    explicit GlobalFloatProducer(edm::ParameterSet const& ps);
+
+    void produce(edm::StreamID sid, edm::Event& event, edm::EventSetup const& es) const override;
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  private:
+    edm::EDPutTokenT<float> token_;
+    float value_;
+  };
+
+  GlobalFloatProducer::GlobalFloatProducer(edm::ParameterSet const& config)
+      : token_(produces()), value_(static_cast<float>(config.getParameter<double>("value"))) {}
+
+  void GlobalFloatProducer::produce(edm::StreamID sid, edm::Event& event, edm::EventSetup const& es) const {
+    event.emplace(token_, value_);
+  }
+
+  void GlobalFloatProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<double>("value", 0.);
+    descriptions.addDefault(desc);
+  }
+
+}  // namespace edmtest
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(edmtest::GlobalFloatProducer);

--- a/FWCore/TestModules/plugins/GlobalIntAnalyzer.cc
+++ b/FWCore/TestModules/plugins/GlobalIntAnalyzer.cc
@@ -1,0 +1,46 @@
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+namespace edmtest {
+
+  class GlobalIntAnalyzer : public edm::global::EDAnalyzer<> {
+  public:
+    explicit GlobalIntAnalyzer(edm::ParameterSet const& ps);
+
+    void analyze(edm::StreamID sid, edm::Event const& event, edm::EventSetup const& es) const override;
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  private:
+    edm::EDGetTokenT<int> token_;
+    int expected_;
+  };
+
+  GlobalIntAnalyzer::GlobalIntAnalyzer(edm::ParameterSet const& config)
+      : token_(consumes(config.getParameter<edm::InputTag>("source"))),
+        expected_(config.getParameter<int>("expected")) {}
+
+  void GlobalIntAnalyzer::analyze(edm::StreamID sid, edm::Event const& event, edm::EventSetup const& es) const {
+    int value = event.get(token_);
+    if (value != expected_) {
+      throw cms::Exception("LogicError") << "expected value \"" << expected_ << "\"\nreceived value \"" << value << '"';
+    }
+  }
+
+  void GlobalIntAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<edm::InputTag>("source");
+    desc.add<int>("expected", 0);
+    descriptions.addDefault(desc);
+  }
+
+}  // namespace edmtest
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(edmtest::GlobalIntAnalyzer);

--- a/FWCore/TestModules/plugins/GlobalIntProducer.cc
+++ b/FWCore/TestModules/plugins/GlobalIntProducer.cc
@@ -1,0 +1,39 @@
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
+
+namespace edmtest {
+
+  class GlobalIntProducer : public edm::global::EDProducer<> {
+  public:
+    explicit GlobalIntProducer(edm::ParameterSet const& ps);
+
+    void produce(edm::StreamID sid, edm::Event& event, edm::EventSetup const& es) const override;
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  private:
+    edm::EDPutTokenT<int> token_;
+    int value_;
+  };
+
+  GlobalIntProducer::GlobalIntProducer(edm::ParameterSet const& config)
+      : token_(produces()), value_(config.getParameter<int>("value")) {}
+
+  void GlobalIntProducer::produce(edm::StreamID sid, edm::Event& event, edm::EventSetup const& es) const {
+    event.emplace(token_, value_);
+  }
+
+  void GlobalIntProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<int>("value", 0);
+    descriptions.addDefault(desc);
+  }
+
+}  // namespace edmtest
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(edmtest::GlobalIntProducer);

--- a/FWCore/TestModules/plugins/GlobalStringAnalyzer.cc
+++ b/FWCore/TestModules/plugins/GlobalStringAnalyzer.cc
@@ -1,0 +1,48 @@
+#include <string>
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+namespace edmtest {
+
+  class GlobalStringAnalyzer : public edm::global::EDAnalyzer<> {
+  public:
+    explicit GlobalStringAnalyzer(edm::ParameterSet const& ps);
+
+    void analyze(edm::StreamID sid, edm::Event const& event, edm::EventSetup const& es) const override;
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  private:
+    edm::EDGetTokenT<std::string> token_;
+    std::string expected_;
+  };
+
+  GlobalStringAnalyzer::GlobalStringAnalyzer(edm::ParameterSet const& config)
+      : token_(consumes(config.getParameter<edm::InputTag>("source"))),
+        expected_(config.getParameter<std::string>("expected")) {}
+
+  void GlobalStringAnalyzer::analyze(edm::StreamID sid, edm::Event const& event, edm::EventSetup const& es) const {
+    std::string const& value = event.get(token_);
+    if (value != expected_) {
+      throw cms::Exception("LogicError") << "expected value \"" << expected_ << "\"\nreceived value \"" << value << '"';
+    }
+  }
+
+  void GlobalStringAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<edm::InputTag>("source");
+    desc.add<std::string>("expected", "");
+    descriptions.addDefault(desc);
+  }
+
+}  // namespace edmtest
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(edmtest::GlobalStringAnalyzer);

--- a/FWCore/TestModules/plugins/GlobalStringProducer.cc
+++ b/FWCore/TestModules/plugins/GlobalStringProducer.cc
@@ -1,0 +1,41 @@
+#include <string>
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
+
+namespace edmtest {
+
+  class GlobalStringProducer : public edm::global::EDProducer<> {
+  public:
+    explicit GlobalStringProducer(edm::ParameterSet const& ps);
+
+    void produce(edm::StreamID sid, edm::Event& event, edm::EventSetup const& es) const override;
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  private:
+    edm::EDPutTokenT<std::string> token_;
+    std::string value_;
+  };
+
+  GlobalStringProducer::GlobalStringProducer(edm::ParameterSet const& config)
+      : token_(produces()), value_(config.getParameter<std::string>("value")) {}
+
+  void GlobalStringProducer::produce(edm::StreamID sid, edm::Event& event, edm::EventSetup const& es) const {
+    event.emplace(token_, value_);
+  }
+
+  void GlobalStringProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<std::string>("value", "");
+    descriptions.addDefault(desc);
+  }
+
+}  // namespace edmtest
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(edmtest::GlobalStringProducer);

--- a/FWCore/TestModules/plugins/GlobalVectorAnalyzer.cc
+++ b/FWCore/TestModules/plugins/GlobalVectorAnalyzer.cc
@@ -1,0 +1,71 @@
+#include <vector>
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+namespace {
+
+  template <typename T>
+  T& operator<<(T& out, std::vector<double> const& values) {
+    if (values.empty()) {
+      out << "{}";
+      return out;
+    }
+
+    auto it = values.begin();
+    out << "{ " << *it;
+    ++it;
+    while (it != values.end()) {
+      out << ", " << *it;
+      ++it;
+    }
+    out << " }";
+    return out;
+  }
+
+}  // namespace
+
+namespace edmtest {
+
+  class GlobalVectorAnalyzer : public edm::global::EDAnalyzer<> {
+  public:
+    explicit GlobalVectorAnalyzer(edm::ParameterSet const& ps);
+
+    void analyze(edm::StreamID sid, edm::Event const& event, edm::EventSetup const& es) const override;
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  private:
+    edm::EDGetTokenT<std::vector<double>> token_;
+    std::vector<double> expected_;
+  };
+
+  GlobalVectorAnalyzer::GlobalVectorAnalyzer(edm::ParameterSet const& config)
+      : token_(consumes(config.getParameter<edm::InputTag>("source"))),
+        expected_(config.getParameter<std::vector<double>>("expected")) {}
+
+  void GlobalVectorAnalyzer::analyze(edm::StreamID sid, edm::Event const& event, edm::EventSetup const& es) const {
+    std::vector<double> const& values = event.get(token_);
+    if (values != expected_) {
+      throw cms::Exception("LogicError") << "expected values \"" << expected_ << "\"\nreceived values \"" << values
+                                         << '"';
+    }
+  }
+
+  void GlobalVectorAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<edm::InputTag>("source");
+    desc.add<std::vector<double>>("expected", {});
+    descriptions.addDefault(desc);
+  }
+
+}  // namespace edmtest
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(edmtest::GlobalVectorAnalyzer);

--- a/FWCore/TestModules/plugins/GlobalVectorProducer.cc
+++ b/FWCore/TestModules/plugins/GlobalVectorProducer.cc
@@ -1,0 +1,41 @@
+#include <vector>
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
+
+namespace edmtest {
+
+  class GlobalVectorProducer : public edm::global::EDProducer<> {
+  public:
+    explicit GlobalVectorProducer(edm::ParameterSet const& ps);
+
+    void produce(edm::StreamID sid, edm::Event& event, edm::EventSetup const& es) const override;
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  private:
+    edm::EDPutTokenT<std::vector<double>> token_;
+    std::vector<double> values_;
+  };
+
+  GlobalVectorProducer::GlobalVectorProducer(edm::ParameterSet const& config)
+      : token_(produces()), values_(config.getParameter<std::vector<double>>("values")) {}
+
+  void GlobalVectorProducer::produce(edm::StreamID sid, edm::Event& event, edm::EventSetup const& es) const {
+    event.emplace(token_, values_);
+  }
+
+  void GlobalVectorProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<std::vector<double>>("values", {});
+    descriptions.addDefault(desc);
+  }
+
+}  // namespace edmtest
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(edmtest::GlobalVectorProducer);


### PR DESCRIPTION
#### PR description:

Implement integration tests for standard types:
  - an `edm::global::EDProducer` that produces an `int`;
  - an `edm::global::EDAnalyzer` that consumes an `int` and compares it with the expected value;
  - an `edm::global::EDProducer` that produces a `float`;
  - an `edm::global::EDAnalyzer` that consumes a `float` and compares it with the expected value;
  - an `edm::global::EDProducer` that produces a `std::string`;
  - an `edm::global::EDAnalyzer` that consumes a `std::string` and compares it with the expected value;
  - an `edm::global::EDProducer` that produces a `std::vector<double>`;
  - an `edm::global::EDAnalyzer` that consumes a `std::vector<double>` and compares it with the expected values.

Implement integration tests for the `post_insert()` functionality.

#### PR validation:

The new integration tests pass.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 15.0.x as part of the MPI work.