### PR TITLE
Fix needed for boost 1.87.0

### DIFF
--- a/EventFilter/HGCalRawToDigi/src/UnpackerTools.cc
+++ b/EventFilter/HGCalRawToDigi/src/UnpackerTools.cc
@@ -2,6 +2,7 @@
 #include "DataFormats/HGCalDigi/interface/HGCalRawDataDefinitions.h"
 #include <boost/crc.hpp>
 #include <vector>
+#include <algorithm>
 #include <iostream>
 //
 //

--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -283,10 +283,9 @@ namespace evf {
     //json parser
     jsoncollector::DataPointDefinition* dpd_;
 
-    boost::asio::io_service io_service_;
+    boost::asio::io_context io_service_;
     std::unique_ptr<boost::asio::ip::tcp::resolver> resolver_;
-    std::unique_ptr<boost::asio::ip::tcp::resolver::query> query_;
-    std::unique_ptr<boost::asio::ip::tcp::resolver::iterator> endpoint_iterator_;
+    std::unique_ptr<boost::asio::ip::tcp::resolver::results_type> endpoint_iterator_;
     std::unique_ptr<boost::asio::ip::tcp::socket> socket_;
 
     std::string input_throttled_file_;

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -116,8 +116,7 @@ namespace evf {
             << "fileBrokerHostFromCfg must be set to true if fileBrokerHost parameter is not valid or empty";
 
       resolver_ = std::make_unique<boost::asio::ip::tcp::resolver>(io_service_);
-      query_ = std::make_unique<boost::asio::ip::tcp::resolver::query>(fileBrokerHost_, fileBrokerPort_);
-      endpoint_iterator_ = std::make_unique<boost::asio::ip::tcp::resolver::iterator>(resolver_->resolve(*query_));
+      endpoint_iterator_ = std::make_unique<boost::asio::ip::tcp::resolver::results_type>(resolver_->resolve(fileBrokerHost_, fileBrokerPort_));
       socket_ = std::make_unique<boost::asio::ip::tcp::socket>(io_service_);
     }
 

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -116,7 +116,8 @@ namespace evf {
             << "fileBrokerHostFromCfg must be set to true if fileBrokerHost parameter is not valid or empty";
 
       resolver_ = std::make_unique<boost::asio::ip::tcp::resolver>(io_service_);
-      endpoint_iterator_ = std::make_unique<boost::asio::ip::tcp::resolver::results_type>(resolver_->resolve(fileBrokerHost_, fileBrokerPort_));
+      endpoint_iterator_ = std::make_unique<boost::asio::ip::tcp::resolver::results_type>(
+          resolver_->resolve(fileBrokerHost_, fileBrokerPort_));
       socket_ = std::make_unique<boost::asio::ip::tcp::socket>(io_service_);
     }
 

--- a/IOPool/TFileAdaptor/test/tfileTest.cpp
+++ b/IOPool/TFileAdaptor/test/tfileTest.cpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <iostream>
 
+#include "boost/system/system_error.hpp"
 #include "boost/filesystem/operations.hpp"
 
 #include "FWCore/PluginManager/interface/PluginManager.h"


### PR DESCRIPTION
these changes are needed for boost 1.87.0 but should work for existing boost 1.80.0 too
- Added missing includes
  - `boost/system/system_error.hpp` needed for `boost:system::system_error` 
  - `algorithm` for `std::transform` used here https://github.com/cms-sw/cmssw/blob/master/EventFilter/HGCalRawToDigi/src/UnpackerTools.cc#L27
- Use `boost::asio::io_context` instead of deprecated `boost::asio::io_service` (https://github.com/boostorg/asio/issues/110)
- Drop deprecated `boost::asio::ip::tcp::resolver::query`