### PR TITLE
FullModelReactionDynamics.cc: silence maybe-uninitialized warning

### DIFF
--- a/SimG4Core/CustomPhysics/src/FullModelReactionDynamics.cc
+++ b/SimG4Core/CustomPhysics/src/FullModelReactionDynamics.cc
@@ -2304,7 +2304,10 @@ G4double FullModelReactionDynamics::GenerateNBodyEvent(const G4double totalEnerg
 
   G4double bang, cb, sb, s0, s1, s2, c, s, esys, a, b, gama, beta;
   pcm[0][0] = 0.0;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
   pcm[1][0] = pd[0];
+#pragma GCC diagnostic pop
   pcm[2][0] = 0.0;
   for (i = 1; i < vecLen; ++i) {
     pcm[0][i] = 0.0;


### PR DESCRIPTION
#### PR description:

This is the reported warning: https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc14/CMSSW_15_1_X_2025-02-20-1100/BigProducts/Simulation

Notice that if vecLen is big enough, the code at line 2287 (2289) could be accessing memory outside of pd array, so maybe it's worth adding a check for that, or making sure `pd` is big enough (as it seems it was - see line 2285)?

#### PR validation:

Bot tests