### PR TITLE
Port recent changes from Pythia8Hadronizer to Pythia8HepMC3Hadronizer

### DIFF
--- a/GeneratorInterface/Pythia8Interface/plugins/Pythia8HepMC3Hadronizer.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Pythia8HepMC3Hadronizer.cc
@@ -17,8 +17,9 @@ using namespace Pythia8;
 
 #include "GeneratorInterface/Pythia8Interface/interface/Py8HMC3InterfaceBase.h"
 
-#include "GeneratorInterface/Pythia8Interface/plugins/ReweightUserHooks.h"
+#include "ReweightUserHooks.h"
 #include "GeneratorInterface/Pythia8Interface/interface/CustomHook.h"
+#include "TopRecoilHook.h"
 
 // PS matchning prototype
 //
@@ -149,6 +150,9 @@ private:
 
   //Generic customized hooks vector
   std::shared_ptr<UserHooksVector> fCustomHooksVector;
+
+  //RecoilToTop userhook
+  std::shared_ptr<TopRecoilHook> fTopRecoilHook;
 
   int EV1_nFinal;
   bool EV1_vetoOn;
@@ -412,6 +416,14 @@ bool Pythia8HepMC3Hadronizer::initializeForInternalPartons() {
     (fUserHooksVector->hooks).push_back(fPowhegHooksBB4L);
   }
 
+  bool TopRecoilHook1 = fMasterGen->settings.flag("TopRecoilHook:doTopRecoilIn");
+  if (TopRecoilHook1) {
+    edm::LogInfo("Pythia8Interface") << "Turning on RecoilToTop hook from Pythia8Interface";
+    if (!fTopRecoilHook.get())
+      fTopRecoilHook.reset(new TopRecoilHook());
+    (fUserHooksVector->hooks).push_back(fTopRecoilHook);
+  }
+
   //adapted from main89.cc in pythia8 examples
   bool internalMatching = fMasterGen->settings.flag("JetMatching:merge");
   bool internalMerging = !(fMasterGen->settings.word("Merging:Process") == "void");
@@ -569,6 +581,14 @@ bool Pythia8HepMC3Hadronizer::initializeForExternalPartons() {
     if (!fPowhegHooksBB4L.get())
       fPowhegHooksBB4L = std::make_shared<PowhegHooksBB4L>();
     (fUserHooksVector->hooks).push_back(fPowhegHooksBB4L);
+  }
+
+  bool TopRecoilHook1 = fMasterGen->settings.flag("TopRecoilHook:doTopRecoilIn");
+  if (TopRecoilHook1) {
+    edm::LogInfo("Pythia8Interface") << "Turning on RecoilToTop hook from Pythia8Interface";
+    if (!fTopRecoilHook.get())
+      fTopRecoilHook.reset(new TopRecoilHook());
+    (fUserHooksVector->hooks).push_back(fTopRecoilHook);
   }
 
   //adapted from main89.cc in pythia8 examples

--- a/GeneratorInterface/Pythia8Interface/plugins/Pythia8HepMC3Hadronizer.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Pythia8HepMC3Hadronizer.cc
@@ -76,6 +76,49 @@ namespace CLHEP {
 
 using namespace gen;
 
+//Insert class for use w/ PDFPtr for proton-photon flux
+//parameters hardcoded according to main70.cc in PYTHIA8 v3.10
+class Nucleus2gamma2 : public Pythia8::PDF {
+private:
+  double radius;
+  int z;
+
+public:
+  // Constructor.
+  Nucleus2gamma2(int idBeamIn, double R = -1.0, int Z = -1) : Pythia8::PDF(idBeamIn), radius(R), z(Z) {}
+
+  void xfUpdate(int, double x, double) override {
+    if (z == -1) {
+      // lead
+      if (idBeam == 1000822080)
+        z = 82;
+    }
+    if (radius == -1) {
+      // lead
+      if (idBeam == 1000822080)
+        radius = 6.636;
+    }
+
+    if (z < 0 || radius < 0)
+      throw edm::Exception(edm::errors::Configuration, "Pythia8Interface")
+          << " Invalid photon flux input parameters: beam ID= " << idBeam << " , radius= " << radius << " , z= " << z
+          << "\n";
+
+    // Minimum impact parameter (~2*radius) [fm].
+    double bmin = 2 * radius;
+
+    // Per-nucleon mass for lead.
+    double m2 = pow2(0.9314);
+    double alphaEM = 0.007297353080;
+    double hbarc = 0.197;
+    double xi = x * sqrt(m2) * bmin / hbarc;
+    double bK0 = besselK0(xi);
+    double bK1 = besselK1(xi);
+    double intB = xi * bK1 * bK0 - 0.5 * pow2(xi) * (pow2(bK1) - pow2(bK0));
+    xgamma = 2. * alphaEM * pow2(z) / M_PI * intB;
+  }
+};
+
 class Pythia8HepMC3Hadronizer : public Py8HMC3InterfaceBase {
 public:
   Pythia8HepMC3Hadronizer(const edm::ParameterSet &params);
@@ -112,6 +155,10 @@ private:
 
   double fBeam1PZ;
   double fBeam2PZ;
+
+  //PDFPtr for the photonFlux
+  //Following main70.cc example in PYTHIA8 v3.10
+  edm::ParameterSet photonFluxParams;
 
   //helper class to allow multiple user hooks simultaneously
   std::shared_ptr<UserHooksVector> fUserHooksVector;
@@ -216,6 +263,10 @@ Pythia8HepMC3Hadronizer::Pythia8HepMC3Hadronizer(const edm::ParameterSet &params
 
   // avoid filling weights twice (from v8.30x)
   toHepMC.set_store_weights(false);
+
+  if (params.exists("PhotonFlux")) {
+    photonFluxParams = params.getParameter<edm::ParameterSet>("PhotonFlux");
+  }
 
   // Reweight user hook
   //
@@ -366,6 +417,20 @@ bool Pythia8HepMC3Hadronizer::initializeForInternalPartons() {
   } else {
     fMasterGen->settings.mode("Beams:frameType", 4);
     fMasterGen->settings.word("Beams:LHEF", lheFile_);
+  }
+
+  if (!photonFluxParams.empty()) {
+    const auto &beamTypeA = photonFluxParams.getParameter<int>("beamTypeA");
+    const auto &beamTypeB = photonFluxParams.getParameter<int>("beamTypeB");
+    const auto &radiusA = photonFluxParams.getUntrackedParameter<double>("radiusA", -1.0);
+    const auto &radiusB = photonFluxParams.getUntrackedParameter<double>("radiusB", -1.0);
+    const auto &zA = photonFluxParams.getUntrackedParameter<int>("zA", -1);
+    const auto &zB = photonFluxParams.getUntrackedParameter<int>("zB", -1);
+    Pythia8::PDFPtr photonFluxA =
+        fMasterGen->settings.flag("PDF:beamA2gamma") ? make_shared<Nucleus2gamma2>(beamTypeA, radiusA, zA) : nullptr;
+    Pythia8::PDFPtr photonFluxB =
+        fMasterGen->settings.flag("PDF:beamB2gamma") ? make_shared<Nucleus2gamma2>(beamTypeB, radiusB, zB) : nullptr;
+    fMasterGen->setPhotonFluxPtr(photonFluxA, photonFluxB);
   }
 
   if (!fUserHooksVector.get())

--- a/GeneratorInterface/Pythia8Interface/plugins/Pythia8HepMC3Hadronizer.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Pythia8HepMC3Hadronizer.cc
@@ -485,7 +485,7 @@ bool Pythia8HepMC3Hadronizer::initializeForInternalPartons() {
   if (TopRecoilHook1) {
     edm::LogInfo("Pythia8Interface") << "Turning on RecoilToTop hook from Pythia8Interface";
     if (!fTopRecoilHook.get())
-      fTopRecoilHook.reset(new TopRecoilHook());
+      fTopRecoilHook = std::make_shared<TopRecoilHook>();
     (fUserHooksVector->hooks).push_back(fTopRecoilHook);
   }
 
@@ -652,7 +652,7 @@ bool Pythia8HepMC3Hadronizer::initializeForExternalPartons() {
   if (TopRecoilHook1) {
     edm::LogInfo("Pythia8Interface") << "Turning on RecoilToTop hook from Pythia8Interface";
     if (!fTopRecoilHook.get())
-      fTopRecoilHook.reset(new TopRecoilHook());
+      fTopRecoilHook = std::make_shared<TopRecoilHook>();
     (fUserHooksVector->hooks).push_back(fTopRecoilHook);
   }
 

--- a/GeneratorInterface/Pythia8Interface/src/Py8HMC3InterfaceBase.cc
+++ b/GeneratorInterface/Pythia8Interface/src/Py8HMC3InterfaceBase.cc
@@ -112,18 +112,14 @@ namespace gen {
     //add settings for powheg resonance scale calculation
     fMasterGen->settings.addFlag("POWHEGres:calcScales", false);
     fMasterGen->settings.addFlag("POWHEG:bb4l", false);
-    fMasterGen->settings.addFlag("POWHEG:bb4l:FSREmission:onlyDistance1", false);
     fMasterGen->settings.addFlag("POWHEG:bb4l:FSREmission:veto", false);
-    fMasterGen->settings.addFlag("POWHEG:bb4l:FSREmission:dryRun", false);
-    fMasterGen->settings.addFlag("POWHEG:bb4l:FSREmission:vetoAtPL", false);
     fMasterGen->settings.addFlag("POWHEG:bb4l:FSREmission:vetoQED", false);
-    fMasterGen->settings.addFlag("POWHEG:bb4l:PartonLevel:veto", false);
-    fMasterGen->settings.addFlag("POWHEG:bb4l:PartonLevel:excludeFSRConflicting", false);
     fMasterGen->settings.addFlag("POWHEG:bb4l:DEBUG", false);
     fMasterGen->settings.addFlag("POWHEG:bb4l:ScaleResonance:veto", false);
     fMasterGen->settings.addFlag("POWHEG:bb4l:FSREmission:vetoDipoleFrame", false);
     fMasterGen->settings.addFlag("POWHEG:bb4l:FSREmission:pTpythiaVeto", false);
     fMasterGen->settings.addParm("POWHEG:bb4l:pTminVeto", 10.0, true, true, 0.0, 10.);
+    fMasterGen->settings.addFlag("POWHEG:bb4l:vetoAllRadtypes", false);
 
     fMasterGen->setRndmEnginePtr(p8RndmEngine_);
     fDecayer->setRndmEnginePtr(p8RndmEngine_);

--- a/GeneratorInterface/Pythia8Interface/src/Py8HMC3InterfaceBase.cc
+++ b/GeneratorInterface/Pythia8Interface/src/Py8HMC3InterfaceBase.cc
@@ -70,9 +70,15 @@ namespace gen {
   }
 
   bool Py8HMC3InterfaceBase::readSettings(int) {
+    //Pythia 8's default value for first argument to constructor
+    const string xmlDir = "../share/Pythia8/xmldoc";
+    bool printBanner = true;
+    if (fParameters.exists("printBanner")) {
+      printBanner = fParameters.getUntrackedParameter<bool>("printBanner");
+    }
     if (!fMasterGen.get())
-      fMasterGen = std::make_unique<Pythia>();
-    fDecayer = std::make_unique<Pythia>();
+      fMasterGen = std::make_unique<Pythia>(xmlDir, printBanner);
+    fDecayer = std::make_unique<Pythia>(xmlDir, printBanner);
 
     //add settings for resonance decay filter
     fMasterGen->settings.addFlag("BiasedTauDecayer:filter", false);

--- a/GeneratorInterface/Pythia8Interface/src/Py8HMC3InterfaceBase.cc
+++ b/GeneratorInterface/Pythia8Interface/src/Py8HMC3InterfaceBase.cc
@@ -98,6 +98,11 @@ namespace gen {
     fMasterGen->settings.addParm("PTFilter:quarkRapidity", 10.0, true, true, 0.0, 10.);
     fMasterGen->settings.addParm("PTFilter:quarkPt", -.1, true, true, -.1, 100.);
 
+    //add settings for RecoilToTop tool
+    fMasterGen->settings.addFlag("TopRecoilHook:doTopRecoilIn", false);
+    fMasterGen->settings.addFlag("TopRecoilHook:useOldDipoleIn", false);
+    fMasterGen->settings.addFlag("TopRecoilHook:doListIn", false);
+
     //add settings for powheg resonance scale calculation
     fMasterGen->settings.addFlag("POWHEGres:calcScales", false);
     fMasterGen->settings.addFlag("POWHEG:bb4l", false);


### PR DESCRIPTION
#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

This is a part of the project (https://github.com/cms-sw/cmssw/issues/36662) involving migration from HepMC2 to HepMC3, coordinated by @mkirsano. This PR syncs the new `Pythia8HepMC3Hadronizer` class with the currently used `Pythia8Hadronizer` by porting its recent changes:
1. TopRecoilHook and its usage added
2. Nucleus2gamma2 class and its usage added

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

Code compiles, basic unit tests run successfully.



<!-- Please delete the text above after you verified all points of the checklist  -->
