### PR TITLE
`DQMStreamerReader`: re-throw all exceptions when run in unit test mode

### DIFF
--- a/DQMServices/StreamerIO/plugins/DQMStreamerReader.cc
+++ b/DQMServices/StreamerIO/plugins/DQMStreamerReader.cc
@@ -172,7 +172,7 @@ namespace dqmservices {
         if (unitTest_) {
           throw edm::Exception(edm::errors::FileReadError, "DQMStreamerReader::openNextFileInp")
               << std::string("Can't deserialize registry data (in open file): ") + e.what()
-              << "\n error: data file corrupted";
+              << "\n error: data file corrupted, rethrowing!";
         }
 
         fiterator_.logFileAction(std::string("Can't deserialize registry data (in open file): ") + e.what(), p);
@@ -354,6 +354,12 @@ namespace dqmservices {
 
       deserializeEvent(*eview);
     } catch (const cms::Exception& e) {
+      if (unitTest_) {
+        throw edm::Exception(edm::errors::FileReadError, "DQMStreamerReader::checkNext")
+            << std::string("Can't deserialize event or registry data: ") + e.what()
+            << "\n error: data file corrupted, rethrowing!";
+      }
+
       // try to recover from corrupted files/events
       fiterator_.logFileAction(std::string("Can't deserialize event or registry data: ") + e.what());
       closeFileImp_("data file corrupted");
@@ -435,6 +441,11 @@ namespace dqmservices {
         }
       }
     } catch (const cms::Exception& e) {
+      if (unitTest_) {
+        throw edm::Exception(edm::errors::FileReadError, "DQMStreamerReader::skip")
+            << std::string("Can't deserialize registry data: ") + e.what()
+            << "\n error: data file corrupted, rethrowing!";
+      }
       // try to recover from corrupted files/events
       fiterator_.logFileAction(std::string("Can't deserialize event data: ") + e.what());
       closeFileImp_("data file corrupted");


### PR DESCRIPTION
#### PR description:

This PR is a continuation of https://github.com/cms-sw/cmssw/pull/45231. This will allow to cover all cases of "silently" broken streamer inputs as in https://github.com/cms-sw/cmssw/issues/43108#issuecomment-1780696627, when the input streamer files layouts of the `DQM/Integration` unit tests get broken.

#### PR validation:

`cmssw` compiles

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A