### PR TITLE
Included cstdint for uint64_t; fixes gcc14 header check

### DIFF
--- a/SimCalorimetry/HGCalSimAlgos/interface/HGCalECONDEmulatorInfo.h
+++ b/SimCalorimetry/HGCalSimAlgos/interface/HGCalECONDEmulatorInfo.h
@@ -3,6 +3,7 @@
 
 #include <bitset>
 #include <vector>
+#include <cstdint>
 
 class HGCalECONDEmulatorInfo {
 public:


### PR DESCRIPTION
This is needed for header consistency. For GCC 14, header consistency check fails with [error below](https://cmssdt.cern.ch/SDT/jenkins-artifacts/pull-request-integration/PR-b112ff/44604/headers_chks.log)
```
src/SimCalorimetry/HGCalSimAlgos/interface/HGCalECONDEmulatorInfo.h:11:85: error: 'uint64_t' was not declared in this scope
   11 |       bool obit, bool bbit, bool ebit, bool tbit, bool hbit, bool sbit, std::vector<uint64_t> enabled_channels = {}) {
      |                                                                                     ^~~~~~~~
src/SimCalorimetry/HGCalSimAlgos/interface/HGCalECONDEmulatorInfo.h:6:1: note: 'uint64_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
    5 | #include <vector>
  +++ |+#include <cstdint>
    6 | 
src/SimCalorimetry/HGCalSimAlgos/interface/HGCalECONDEmulatorInfo.h:11:93: error: template argument 1 is invalid
   11 |       bool obit, bool bbit, bool ebit, bool tbit, bool hbit, bool sbit, std::vector<uint64_t> enabled_channels = {}) {
      |                                                                                             ^
src/SimCalorimetry/HGCalSimAlgos/interface/HGCalECONDEmulatorInfo.h:11:93: error: template argument 2 is invalid
src/SimCalorimetry/HGCalSimAlgos/interface/HGCalECONDEmulatorInfo.h:11:73: error: 'std::enabled_channels' has not been declared
   11 |       bool obit, bool bbit, bool ebit, bool tbit, bool hbit, bool sbit, std::vector<uint64_t> enabled_channels = {}) {
      |                                                                         ^~~
src/SimCalorimetry/HGCalSimAlgos/interface/HGCalECONDEmulatorInfo.h:22:26: error: 'uint64_t' has not been declared
   22 |   void addChannelsEnable(uint64_t poi) { pois_.emplace_back(poi); }
      |                          ^~~~~~~~
src/SimCalorimetry/HGCalSimAlgos/interface/HGCalECONDEmulatorInfo.h: In constructor 'HGCalECONDEmulatorInfo::HGCalECONDEmulatorInfo(bool, bool, bool, bool, bool, bool, int)':
src/SimCalorimetry/HGCalSimAlgos/interface/HGCalECONDEmulatorInfo.h:18:30: error: 'enabled_channels' was not declared in this scope
   18 |     for (const auto& ch_en : enabled_channels)
``` 