### PR TITLE
Remove false positve in `scram b check-headers`

### DIFF
--- a/DataFormats/Provenance/interface/BranchChildren.h
+++ b/DataFormats/Provenance/interface/BranchChildren.h
@@ -6,7 +6,8 @@
 BranchChildren: Dependency information between branches.
 
 ----------------------------------------------------------------------*/
-#if !defined(DataFormats_Provenance_ProductDependencies_h)
+#if (not defined __INCLUDE_LEVEL__ or __INCLUDE_LEVEL__ > 0) and \
+    not defined(DataFormats_Provenance_ProductDependencies_h)
 #error The name BranchChildren is deprecated, please use ProductDependencies instead.
 #endif
 

--- a/DataFormats/Provenance/interface/BranchDescription.h
+++ b/DataFormats/Provenance/interface/BranchDescription.h
@@ -20,7 +20,8 @@ This description also applies to every product instance on the branch.
 #include <set>
 #include <string>
 
-#if !defined(DataFormats_Provenance_ProductDescription_h)
+#if (not defined __INCLUDE_LEVEL__ or __INCLUDE_LEVEL__ > 0) and \
+    not defined(DataFormats_Provenance_ProductDescription_h)
 #error The name BranchDescription is deprecated, please use ProductDescription instead.
 #endif
 /*


### PR DESCRIPTION
#### PR description:

Warn about deprecated includes only when the header file is actually being included, not when it is compiled explicitly with `g++ -fsyntax-only`.

#### PR validation:

None.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 15.0.x to silence the false positive check.