### PR TITLE
Monitor intermediate LST track collections at HLT

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -690,6 +690,10 @@ phase2_tracker.toModify(FEVTDEBUGHLTEventContent,
                             'keep *_hltGeneralTracks_*_*',
                             'keep *_hltInitialStepTrackSelectionHighPurity_*_*',
                             'keep *_hltHighPtTripletStepTrackSelectionHighPurity_*_*',
+                            'keep *_hltInitialStepTrackSelectionHighPuritypTTCLST_*_*',
+                            'keep *_hltInitialStepTrackSelectionHighPuritypLSTCLST_*_*',
+                            'keep *_hltInitialStepTracksT5TCLST_*_*',
+                            'keep *_hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST_*_*',
                             'keep *_hltOfflinePrimaryVertices_*_*',
                             'keep *_hltHGCalRecHit_*_*'
                         ])

--- a/DQMOffline/Trigger/python/TrackingMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/TrackingMonitoring_cff.py
@@ -132,6 +132,31 @@ iterHighPtTripletsMonitoringHLT = iterHLTTracksMonitoringHLT.clone(
     allTrackProducer = 'hltHighPtTripletStepTrackSelectionHighPurity',
 )
 
+# LST track collections
+initialSteppTTCLSTTracksMonitoringHLT = trackingMonHLT.clone(
+    FolderName       = 'HLT/Tracking/initialStepTrackSelectionHighPuritypTTCLST',
+    TrackProducer    = 'hltInitialStepTrackSelectionHighPuritypTTCLST',
+    allTrackProducer = 'hltInitialStepTrackSelectionHighPuritypTTCLST'
+)
+
+initialSteppLSTCLSTTracksMonitoringHLT = trackingMonHLT.clone(
+    FolderName       = 'HLT/Tracking/initialStepTrackSelectionHighPuritypLSTCLST',
+    TrackProducer    = 'hltInitialStepTrackSelectionHighPuritypLSTCLST',
+    allTrackProducer = 'hltInitialStepTrackSelectionHighPuritypLSTCLST'
+)
+
+initialStepT5TCLSTTracksMonitoringHLT = trackingMonHLT.clone(
+    FolderName       = 'HLT/Tracking/initialStepTracksT5TCLST',
+    TrackProducer    = 'hltInitialStepTracksT5TCLST',
+    allTrackProducer = 'hltInitialStepTracksT5TCLST'
+)
+
+highPtTripletSteppLSTCLSTTracksMonitoringHLT = trackingMonHLT.clone(
+    FolderName       = 'HLT/Tracking/highPtTripletStepTrackSelectionHighPuritypLSTCLST',
+    TrackProducer    = 'hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST',
+    allTrackProducer = 'hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST'
+)
+
 iter3TracksMonitoringHLT = trackingMonHLT.clone(
     FolderName       = 'HLT/Tracking/iter3Merged',
     TrackProducer    = 'hltIter3Merged',
@@ -264,6 +289,11 @@ trkHLTDQMSourceExtra = cms.Sequence(
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toReplaceWith(trackingMonitorHLT, cms.Sequence(pixelTracksMonitoringHLT + iterHLTTracksMonitoringHLT + doubletRecoveryHPTracksMonitoringHLT )) # + iter0HPTracksMonitoringHLT ))
 phase2_tracker.toReplaceWith(trackingMonitorHLT, cms.Sequence(pixelTracksMonitoringHLT + iterHLTTracksMonitoringHLT + iterInitialStepMonitoringHLT + iterHighPtTripletsMonitoringHLT))
+
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
+(~seedingLST & trackingLST).toReplaceWith(trackingMonitorHLT, cms.Sequence(pixelTracksMonitoringHLT + iterHLTTracksMonitoringHLT + initialSteppTTCLSTTracksMonitoringHLT + initialSteppLSTCLSTTracksMonitoringHLT + initialStepT5TCLSTTracksMonitoringHLT + iterHighPtTripletsMonitoringHLT))
+(seedingLST & trackingLST).toReplaceWith(trackingMonitorHLT, cms.Sequence(pixelTracksMonitoringHLT + iterHLTTracksMonitoringHLT + initialSteppTTCLSTTracksMonitoringHLT + initialStepT5TCLSTTracksMonitoringHLT + highPtTripletSteppLSTCLSTTracksMonitoringHLT))
 
 run3_common.toReplaceWith(trackingMonitorHLTall, cms.Sequence(pixelTracksMonitoringHLT + iter0TracksMonitoringHLT + iterHLTTracksMonitoringHLT))
 run3_common.toReplaceWith(egmTrackingMonitorHLT, cms.Sequence(gsfTracksMonitoringHLT))

--- a/Validation/RecoTrack/python/HLTmultiTrackValidator_cff.py
+++ b/Validation/RecoTrack/python/HLTmultiTrackValidator_cff.py
@@ -36,3 +36,14 @@ def _modifyForPhase2(trackvalidator):
 
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(hltTrackValidator, _modifyForPhase2)
+
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
+
+def _modifyForPhase2LSTTracking(trackvalidator):
+    trackvalidator.label = ["hltGeneralTracks", "hltPhase2PixelTracks", "hltInitialStepTrackSelectionHighPuritypTTCLST", "hltInitialStepTrackSelectionHighPuritypLSTCLST", "hltInitialStepTracksT5TCLST", "hltHighPtTripletStepTrackSelectionHighPurity"]
+(~seedingLST & trackingLST).toModify(hltTrackValidator, _modifyForPhase2LSTTracking)
+
+def _modifyForPhase2LSTSeeding(trackvalidator):
+    trackvalidator.label = ["hltGeneralTracks", "hltPhase2PixelTracks", "hltInitialStepTrackSelectionHighPuritypTTCLST", "hltInitialStepTracksT5TCLST", "hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST"]
+(seedingLST & trackingLST).toModify(hltTrackValidator, _modifyForPhase2LSTSeeding)


### PR DESCRIPTION
#### PR description:

Because the new LST track collections that run at HLT do not have the same names as the ones in the default configuration, they are actually not monitored. This PR introduces the relevant configuration changes that enables the monitoring of those collections.

The relevant track collections are retained in the EventContent. This doesn't have any effect on the default workflows, as the LST collections do not get produced there, while it recovers the lost collections in the LST workflows (i.e. no redundant info is retained in any case). At the validation step, the addition of the `trackingLST` and/or `seedingLST` procModifiers is necessary to show the proper extra columns with the plotting script.

This PR follows up on https://github.com/cms-sw/cmssw/pull/46828#discussion_r1865510343 and works toward #39362 for LST.

#### PR validation:

The code has been tested with `CMSSW_15_0_0_pre3` and the resulting plots can be found [here](https://uaf-10.t2.ucsd.edu/~evourlio/SDL/CMSSWPR154/).

<details><summary>Instructions on how to run</summary>

```sh
runTheMatrix.py -w upgrade -l 29634.755 # For testing the trackingLST config
# For testing the seedingLST config, add the seedingLST procModifier in the step2 of the workflow above

cmsDriver.py DQM -s VALIDATION:hltMultiTrackValidation \
--conditions auto:phase2_realistic_T33 \
--geometry ExtendedRun4D110 \
--era Phase2C17I13M9 \
--datatier DQMIO \
--eventcontent DQM \
--filein file:step2.root \
--fileout DQM.root \
-n 10 --procModifiers alpaka,trackingLST # Add seedingLST if testing that config

cmsDriver.py HARVEST -s HARVESTING:@trackingOnlyValidation+@trackingOnlyDQM+postProcessorHLTtrackingSequence \
--filein file:DQM.root \
--scenario pp \
--filetype DQM \
--conditions auto:phase2_realistic_T33 \
--mc -n 100

mv DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root configName.root
makeTrackValidationPlots.py configName.root -o configName
```