### PR TITLE
DuplicateTrackMerger: fix relvals 29634.703,29834.703 failing in DBG_X IBs

### DIFF
--- a/RecoTracker/FinalTrackSelectors/plugins/DuplicateTrackMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/DuplicateTrackMerger.cc
@@ -286,7 +286,17 @@ namespace {
       const auto ev = iEvent.id().event();
       const auto aOriAlgo = a->originalAlgo();
       const auto bOriAlgo = b->originalAlgo();
+      const auto aSeedRef = a->seedRef();
+      if (!aSeedRef) {
+        LogDebug("DuplicateTrackMerger") << "aSeedRef is null!";
+        return false;
+      }
       const auto aSeed = a->seedRef().key();
+      const auto bSeedRef = b->seedRef();
+      if (!bSeedRef) {
+        LogDebug("DuplicateTrackMerger") << "bSeedRef is null!";
+        return false;
+      }
       const auto bSeed = b->seedRef().key();
       return ((ev == 6903 && ((aOriAlgo == 23 && aSeed == 695 && bOriAlgo == 5 && bSeed == 652) ||
                               (aOriAlgo == 23 && aSeed == 400 && bOriAlgo == 7 && bSeed == 156) ||


### PR DESCRIPTION
Fixes https://github.com/cms-sw/cmssw/issues/47176

#### PR description:

Title says it all. 

#### PR validation:

Relval 29634.703 step 3 ran without errors