### PR TITLE
[NGT] Adding `SimDoublets` class for Pixel Tracking Validation including corresponding EDProducers and EDAnalyzers

### DIFF
--- a/Configuration/Generator/python/SingleMuPt15Eta0_0p4_cfi.py
+++ b/Configuration/Generator/python/SingleMuPt15Eta0_0p4_cfi.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+
+generator = cms.EDProducer("FlatRandomPtGunProducer",
+    PGunParameters = cms.PSet(
+        MaxPt = cms.double(15.01),
+        MinPt = cms.double(14.99),
+        PartID = cms.vint32(13),
+        MaxEta = cms.double(0.4),
+        MaxPhi = cms.double(3.14159265359),
+        MinEta = cms.double(0.),
+        MinPhi = cms.double(-3.14159265359) ## in radians
+
+    ),
+    Verbosity = cms.untracked.int32(0), ## set to 1 (or greater)  for printouts
+
+    psethack = cms.string('single mu pt 15'),
+    AddAntiParticle = cms.bool(True),
+    firstRun = cms.untracked.uint32(1)
+)

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -3346,4 +3346,5 @@ upgradeFragments = OrderedDict([
     ('Hydjet_Quenched_MinBias_5020GeV_cfi', UpgradeFragment(U2000by1,'HydjetQMinBias_5020GeV')),
     ('Hydjet_Quenched_MinBias_5362GeV_cfi', UpgradeFragment(U2000by1,'HydjetQMinBias_5362GeV')),
     ('Hydjet_Quenched_MinBias_5519GeV_cfi', UpgradeFragment(U2000by1,'HydjetQMinBias_5519GeV')),
+    ('SingleMuPt15Eta0_0p4_cfi', UpgradeFragment(Kby(9,100),'SingleMuPt15Eta0p_0p4')),
 ])

--- a/DataFormats/TrackerRecHit2D/interface/SiPixelRecHitFwd.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiPixelRecHitFwd.h
@@ -1,0 +1,13 @@
+#ifndef DataFormats_TrackerRecHit2D_SiPixelRecHitFwd_h
+#define DataFormats_TrackerRecHit2D_SiPixelRecHitFwd_h
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/RefVector.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
+
+// persistent reference to a SiPixelRecHit in a SiPixelRecHitCollection
+typedef edm::Ref<SiPixelRecHitCollection, SiPixelRecHit> SiPixelRecHitRef;
+// persistent vector of references to SiPixelRecHits in a SiPixelRecHitCollection
+typedef edm::RefVector<SiPixelRecHitCollection, SiPixelRecHit> SiPixelRecHitRefVector;
+
+#endif

--- a/DataFormats/TrackerRecHit2D/src/classes.h
+++ b/DataFormats/TrackerRecHit2D/src/classes.h
@@ -9,6 +9,7 @@
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2DCollection.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitFwd.h"
 #include "DataFormats/Common/interface/RefProd.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 #include "DataFormats/Common/interface/DetSetVector.h"

--- a/DataFormats/TrackerRecHit2D/src/classes_def.xml
+++ b/DataFormats/TrackerRecHit2D/src/classes_def.xml
@@ -71,6 +71,8 @@
  <class name="edmNew::DetSet<SiPixelRecHit>"/>
  <class name="edmNew::DetSetVector<SiStripRecHit2D>"/>
  <class name="edmNew::DetSetVector<SiStripRecHit1D>"/>
+ 
+ <class name="SiPixelRecHitRefVector"/>
 
  <class name="edm::Wrapper<edmNew::DetSetVector<SiStripRecHit2D> >"/>
  <class name="edm::Wrapper<edmNew::DetSetVector<SiStripRecHit1D> >"/>

--- a/SimDataFormats/TrackingAnalysis/interface/SimDoublets.h
+++ b/SimDataFormats/TrackingAnalysis/interface/SimDoublets.h
@@ -1,0 +1,155 @@
+#ifndef SimDataFormats_TrackingAnalysis_SimDoublets_h
+#define SimDataFormats_TrackingAnalysis_SimDoublets_h
+
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitFwd.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+/** @brief Semi-Monte Carlo truth information used for pixel-tracking opimization.
+ *
+ * SimDoublets hold references to all pixel RecHits of a simulated TrackingParticle.
+ * Ones those RecHits are sorted according to their position relative to the particle vertex
+ * by the method sortRecHits(), you can create the true doublets of RecHits that the 
+ * TrackingParticle left in the detector. These SimDoublets::Doublet objects can be used  
+ * to optimize the doublet creation in the reconstruction.
+ *
+ * The Doublets are generated as the RecHit pairs between two consecutively hit layers.
+ * I.e., if a TrackingParticle produces
+ *  - 1 hit (A) in 1st layer
+ *  - 2 hits (B, C) in 3rd layer
+ *  - 1 hit (D) in 4th layer
+ * then, the true Doublets are:
+ *  (A-B), (A-C), (B-D) and (C-D).
+ * So, neither does it matter that the 2nd layer got "skipped" as there are no hits,
+ * nor is the Doublet of (A-D) formed since there is a layer with hits in between.
+ * Doublets are not created between hits within the same layer.
+ *
+ * @author Jan Schulz (jan.gerrit.schulz@cern.ch)
+ * @date January 2025
+ */
+class SimDoublets {
+public:
+  /**
+    * Sub-class for true doublets of RecHits
+    *  - first hit = inner RecHit
+    *  - second hit = outer RecHit
+    */
+  class Doublet {
+  public:
+    // default constructor
+    Doublet() = default;
+
+    // constructor
+    Doublet(SimDoublets const&, size_t const, size_t const, const TrackerTopology*);
+
+    // method to get the layer pair
+    std::pair<uint8_t, uint8_t> layerIds() const { return layerIds_; }
+
+    // method to get the RecHit pair
+    std::pair<SiPixelRecHitRef, SiPixelRecHitRef> recHits() const { return recHitRefs_; }
+
+    // method to get the number of skipped layers
+    int8_t numSkippedLayers() const { return numSkippedLayers_; }
+
+    // method to get the layer pair ID
+    int16_t layerPairId() const { return layerPairId_; }
+
+    // method to get the inner layerId
+    uint8_t innerLayerId() const { return layerIds_.first; }
+
+    // method to get the outer layerId
+    uint8_t outerLayerId() const { return layerIds_.second; }
+
+    // method to get a reference to the inner RecHit
+    SiPixelRecHitRef innerRecHit() const { return recHitRefs_.first; }
+
+    // method to get a reference to the outer RecHit
+    SiPixelRecHitRef outerRecHit() const { return recHitRefs_.second; }
+
+    // method to get the global position of the inner RecHit
+    GlobalPoint innerGlobalPos() const;
+
+    // method to get the global position of the outer RecHit
+    GlobalPoint outerGlobalPos() const;
+
+  private:
+    TrackingParticleRef trackingParticleRef_;                   // reference to the TrackingParticle
+    std::pair<SiPixelRecHitRef, SiPixelRecHitRef> recHitRefs_;  // reference pair to RecHits of the Doublet
+    std::pair<uint8_t, uint8_t> layerIds_;                      // pair of layer IDs corresponding to the RecHits
+    int8_t numSkippedLayers_;                                   // number of layers skipped by the Doublet
+    int16_t layerPairId_;            // ID of the layer pair as defined in the reconstruction for the doublets
+    GlobalVector beamSpotPosition_;  // global position of the beam spot (needed to correct the global RecHit position)
+  };
+
+  // default contructor
+  SimDoublets() = default;
+
+  // constructor
+  SimDoublets(TrackingParticleRef const trackingParticleRef, reco::BeamSpot const& beamSpot)
+      : trackingParticleRef_(trackingParticleRef), beamSpotPosition_(beamSpot.x0(), beamSpot.y0(), beamSpot.z0()) {}
+
+  // method to add a RecHitRef with its layer
+  void addRecHit(SiPixelRecHitRef const recHitRef, uint8_t const layerId) {
+    recHitsAreSorted_ = false;  // set sorted-bool to false again
+
+    // check if the layerId is not present in the layerIdVector yet
+    if (std::find(layerIdVector_.begin(), layerIdVector_.end(), layerId) == layerIdVector_.end()) {
+      // if it does not exist, increment number of layers
+      numLayers_++;
+    }
+
+    // add recHit and layerId to the vectors
+    recHitRefVector_.push_back(recHitRef);
+    layerIdVector_.push_back(layerId);
+  }
+
+  // method to get the reference to the TrackingParticle
+  TrackingParticleRef trackingParticle() const { return trackingParticleRef_; }
+
+  // method to get the reference vector to the RecHits
+  SiPixelRecHitRefVector recHits() const { return recHitRefVector_; }
+
+  // method to get a reference to the RecHit at index i
+  SiPixelRecHitRef recHits(size_t i) const { return recHitRefVector_[i]; }
+
+  // method to get the layer id vector
+  std::vector<uint8_t> layerIds() const { return layerIdVector_; }
+
+  // method to get the layer id at index i
+  uint8_t layerIds(size_t i) const { return layerIdVector_[i]; }
+
+  // method to get the beam spot position
+  GlobalVector beamSpotPosition() const { return beamSpotPosition_; }
+
+  // method to get the number of layers
+  int numLayers() const { return numLayers_; }
+
+  // method to get number of RecHits in the SimDoublets
+  int numRecHits() const { return layerIdVector_.size(); }
+
+  // method to sort the RecHits according to the position
+  void sortRecHits();
+
+  // method to produce the SimDoublets from the RecHits
+  std::vector<Doublet> getSimDoublets(const TrackerTopology* trackerTopology = nullptr) const;
+
+private:
+  TrackingParticleRef trackingParticleRef_;  // reference to the TrackingParticle
+  SiPixelRecHitRefVector recHitRefVector_;   // reference vector to RecHits associated to the TP (sorted afer building)
+  std::vector<uint8_t> layerIdVector_;       // vector of layer IDs corresponding to the RecHits
+  GlobalVector beamSpotPosition_;  // global position of the beam spot (needed to correct the global RecHit position)
+  bool recHitsAreSorted_{false};   // true if RecHits were sorted
+  int numLayers_{0};               // number of layers hit by the TrackingParticle
+};
+
+// collection of SimDoublets
+typedef std::vector<SimDoublets> SimDoubletsCollection;
+
+#endif

--- a/SimDataFormats/TrackingAnalysis/src/SimDoublets.cc
+++ b/SimDataFormats/TrackingAnalysis/src/SimDoublets.cc
@@ -1,0 +1,172 @@
+#include "SimDataFormats/TrackingAnalysis/interface/SimDoublets.h"
+
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
+#include "DataFormats/GeometryVector/interface/GlobalVector.h"
+#include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementPoint.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+
+namespace simdoublets {
+
+  // Function that gets the global position of a RecHit with respect to a reference point.
+  GlobalPoint getGlobalHitPosition(SiPixelRecHitRef const& recHit, GlobalVector const& referencePosition) {
+    return (recHit->globalPosition() - referencePosition);
+  }
+
+  // Function that determines the number of skipped layers for a given pair of RecHits.
+  int getNumSkippedLayers(std::pair<uint8_t, uint8_t> const& layerIds,
+                          std::pair<SiPixelRecHitRef, SiPixelRecHitRef> const& recHitRefs,
+                          const TrackerTopology* trackerTopology) {
+    // Possibility 0: invalid case (outer layer is not the outer one), set to -1 immediately
+    if (layerIds.first >= layerIds.second) {
+      return -1;
+    }
+
+    // get the detector Ids of the two RecHits
+    DetId innerDetId(recHitRefs.first->geographicalId());
+    DetId outerDetId(recHitRefs.second->geographicalId());
+
+    // determine where the RecHits are
+    bool innerInBarrel = (innerDetId.subdetId() == PixelSubdetector::PixelBarrel);
+    bool outerInBarrel = (outerDetId.subdetId() == PixelSubdetector::PixelBarrel);
+    bool innerInBackward = (!innerInBarrel) && (trackerTopology->pxfSide(innerDetId) == 1);
+    bool outerInBackward = (!outerInBarrel) && (trackerTopology->pxfSide(outerDetId) == 1);
+    bool innerInForward = (!innerInBarrel) && (!innerInBackward);
+    bool outerInForward = (!outerInBarrel) && (!outerInBackward);
+
+    // Possibility 1: both RecHits lie in the same detector part (barrel, forward or backward)
+    if ((innerInBarrel && outerInBarrel) || (innerInForward && outerInForward) ||
+        (innerInBackward && outerInBackward)) {
+      return (layerIds.second - layerIds.first - 1);
+    }
+    // Possibility 2: the inner RecHit is in the barrel while the outer is in either forward or backward
+    else if (innerInBarrel) {
+      return (trackerTopology->pxfDisk(outerDetId) - 1);
+    }
+    // Possibility 3: invalid case (one is forward and the other in backward), set to -1
+    else {
+      return -1;
+    }
+  }
+
+  // Function that, for a pair of two layers, gives a unique pair Id (innerLayerId * 100 + outerLayerId).
+  int getLayerPairId(std::pair<uint8_t, uint8_t> const& layerIds) {
+    // calculate the unique layer pair Id as (innerLayerId * 100 + outerLayerId)
+    return (layerIds.first * 100 + layerIds.second);
+  }
+}  // end namespace simdoublets
+
+// ------------------------------------------------------------------------------------------------------
+// SimDoublets::Doublet class member functions
+// ------------------------------------------------------------------------------------------------------
+
+// constructor
+SimDoublets::Doublet::Doublet(SimDoublets const& simDoublets,
+                              size_t const innerIndex,
+                              size_t const outerIndex,
+                              const TrackerTopology* trackerTopology)
+    : trackingParticleRef_(simDoublets.trackingParticle()), beamSpotPosition_(simDoublets.beamSpotPosition()) {
+  // fill recHits and layers
+  recHitRefs_ = std::make_pair(simDoublets.recHits(innerIndex), simDoublets.recHits(outerIndex));
+  layerIds_ = std::make_pair(simDoublets.layerIds(innerIndex), simDoublets.layerIds(outerIndex));
+
+  // determine number of skipped layers
+  numSkippedLayers_ = simdoublets::getNumSkippedLayers(layerIds_, recHitRefs_, trackerTopology);
+
+  // determine Id of the layer pair
+  layerPairId_ = simdoublets::getLayerPairId(layerIds_);
+}
+
+GlobalPoint SimDoublets::Doublet::innerGlobalPos() const {
+  // get the inner RecHit's global position
+  return simdoublets::getGlobalHitPosition(recHitRefs_.first, beamSpotPosition_);
+}
+
+GlobalPoint SimDoublets::Doublet::outerGlobalPos() const {
+  // get the outer RecHit's global position
+  return simdoublets::getGlobalHitPosition(recHitRefs_.second, beamSpotPosition_);
+}
+
+// ------------------------------------------------------------------------------------------------------
+// SimDoublets class member functions
+// ------------------------------------------------------------------------------------------------------
+
+// method to sort the RecHits according to the position
+void SimDoublets::sortRecHits() {
+  // get the production vertex of the TrackingParticle
+  const GlobalVector vertex(trackingParticleRef_->vx(), trackingParticleRef_->vy(), trackingParticleRef_->vz());
+
+  // get the vector of squared magnitudes of the global RecHit positions
+  std::vector<double> recHitMag2;
+  recHitMag2.reserve(layerIdVector_.size());
+  for (const auto& recHit : recHitRefVector_) {
+    // global RecHit position with respect to the production vertex
+    Global3DPoint globalPosition = simdoublets::getGlobalHitPosition(recHit, vertex);
+    recHitMag2.push_back(globalPosition.mag2());
+  }
+
+  // find the permutation vector that sort the magnitudes
+  std::vector<std::size_t> sortedPerm(recHitMag2.size());
+  std::iota(sortedPerm.begin(), sortedPerm.end(), 0);
+  std::sort(sortedPerm.begin(), sortedPerm.end(), [&](std::size_t i, std::size_t j) {
+    return (recHitMag2[i] < recHitMag2[j]);
+  });
+
+  // create the sorted recHitRefVector and the sorted layerIdVector accordingly
+  SiPixelRecHitRefVector sorted_recHitRefVector;
+  std::vector<uint8_t> sorted_layerIdVector;
+  sorted_recHitRefVector.reserve(sortedPerm.size());
+  sorted_layerIdVector.reserve(sortedPerm.size());
+  for (size_t i : sortedPerm) {
+    sorted_recHitRefVector.push_back(recHitRefVector_[i]);
+    sorted_layerIdVector.push_back(layerIdVector_[i]);
+  }
+
+  // swap them with the class member
+  recHitRefVector_.swap(sorted_recHitRefVector);
+  layerIdVector_.swap(sorted_layerIdVector);
+
+  // set sorted bool to true
+  recHitsAreSorted_ = true;
+}
+
+// method to produce the true doublets on the fly
+std::vector<SimDoublets::Doublet> SimDoublets::getSimDoublets(const TrackerTopology* trackerTopology) const {
+  // create output vector for the doublets
+  std::vector<SimDoublets::Doublet> doubletVector;
+
+  // confirm that the RecHits are sorted
+  assert(recHitsAreSorted_);
+
+  // check if there are at least two hits
+  if (numRecHits() < 2) {
+    return doubletVector;
+  }
+
+  // loop over the RecHits/layer Ids
+  for (size_t i = 0; i < layerIdVector_.size(); i++) {
+    uint8_t innerLayerId = layerIdVector_[i];
+    uint8_t outerLayerId{};
+    size_t outerLayerStart{layerIdVector_.size()};
+
+    // find the next layer Id + at which hit this layer starts
+    for (size_t j = i + 1; j < layerIdVector_.size(); j++) {
+      if (innerLayerId != layerIdVector_[j]) {
+        outerLayerId = layerIdVector_[j];
+        outerLayerStart = j;
+        break;
+      }
+    }
+
+    // build the doublets of the inner hit i with all outer hits in the layer outerLayerId
+    for (size_t j = outerLayerStart; j < layerIdVector_.size(); j++) {
+      // break if the hit doesn't belong to the outer layer anymore
+      if (outerLayerId != layerIdVector_[j]) {
+        break;
+      }
+
+      doubletVector.push_back(SimDoublets::Doublet(*this, i, j, trackerTopology));
+    }
+  }  // end loop over the RecHits/layer Ids
+
+  return doubletVector;
+}

--- a/SimDataFormats/TrackingAnalysis/src/classes.h
+++ b/SimDataFormats/TrackingAnalysis/src/classes.h
@@ -3,6 +3,7 @@
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingVertex.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingVertexContainer.h"
 #include "SimDataFormats/TrackingAnalysis/interface/UniqueSimTrackId.h"
+#include "SimDataFormats/TrackingAnalysis/interface/SimDoublets.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/Common/interface/AssociationMapHelpers.h"
 #include "DataFormats/Common/interface/Wrapper.h"

--- a/SimDataFormats/TrackingAnalysis/src/classes_def.xml
+++ b/SimDataFormats/TrackingAnalysis/src/classes_def.xml
@@ -40,4 +40,10 @@
   <class name="edm::Wrapper<std::unordered_map<UniqueSimTrackId, TrackingParticleRef, UniqueSimTrackIdHash>>"/>
   <class name="SimTrackToTPMap"/>
   <class name="edm::Wrapper<SimTrackToTPMap>"/>
+
+  <class name="SimDoublets" ClassVersion="3">
+   <version ClassVersion="3" checksum="2009082523"/>
+  </class>
+  <class name="std::vector<SimDoublets>"/>
+  <class name="edm::Wrapper< std::vector<SimDoublets> >"/>
 </lcgdict>

--- a/SimTracker/TrackerHitAssociation/plugins/BuildFile.xml
+++ b/SimTracker/TrackerHitAssociation/plugins/BuildFile.xml
@@ -1,5 +1,6 @@
 <use name="SimTracker/TrackerHitAssociation"/>
 <use name="SimDataFormats/TrackingAnalysis"/>
+<use name="Geometry/Records"/>
 <library file="*.cc" name="SimTrackerTrackerHitAssociationPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/SimTracker/TrackerHitAssociation/plugins/SimDoubletsProducer.cc
+++ b/SimTracker/TrackerHitAssociation/plugins/SimDoubletsProducer.cc
@@ -1,0 +1,329 @@
+// -*- C++ -*-
+//
+// Package:    SimTracker/TrackerHitAssociation
+// Class:      SimDoubletsProducer
+//
+
+// user include files
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/IndexSet.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
+
+#include "SimTracker/Common/interface/TrackingParticleSelector.h"
+#include "SimTracker/TrackerHitAssociation/interface/ClusterTPAssociation.h"
+
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "DataFormats/GeometryVector/interface/GlobalVector.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
+#include "DataFormats/TrackerRecHit2D/interface/OmniClusterRef.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
+#include "SimDataFormats/TrackingAnalysis/interface/SimDoublets.h"
+
+#include <cstddef>
+#include <utility>
+#include <vector>
+#include <memory>
+#include <typeinfo>
+
+/** Class: SimDoubletsProducer
+ * 
+ * @brief Produces SimDoublets (MC-info based PixelRecHit doublets) for selected TrackingParticles.
+ *
+ * SimDoublets represent the true doublets of RecHits that a simulated particle (TrackingParticle) 
+ * created in the pixel detector. They can be used to analyze cuts which are applied in the reconstruction
+ * when producing doublets as the first part of patatrack pixel tracking.
+ *
+ * The SimDoublets are produced in the following way:
+ * 1. We select reasonable TrackingParticles according to the criteria given in the config file as 
+ *    "TrackingParticleSelectionConfig".
+ * 2. For each selected particle, we create and append a new SimDoublets object to the SimDoubletsCollection.
+ * 3. We loop over all RecHits in the pixel tracker and check if the given RecHit is associated to one of
+ *    the selected particles (association via TP to cluster association). If it is, we add a RecHit reference
+ *    to the respective SimDoublet.
+ * 4. In the end, we sort the RecHits in each SimDoublets object according to their global position.
+ *
+ * @author Jan Schulz (jan.gerrit.schulz@cern.ch)
+ * @date January 2025
+ */
+template <typename TrackerTraits>
+class SimDoubletsProducer : public edm::stream::EDProducer<> {
+public:
+  explicit SimDoubletsProducer(const edm::ParameterSet&);
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void beginRun(const edm::Run&, const edm::EventSetup&) override;
+
+private:
+  TrackingParticleSelector trackingParticleSelector;
+  const TrackerTopology* trackerTopology_ = nullptr;
+
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topology_getToken_;
+  const edm::EDGetTokenT<ClusterTPAssociation> clusterTPAssociation_getToken_;
+  const edm::EDGetTokenT<TrackingParticleCollection> trackingParticles_getToken_;
+  const edm::EDGetTokenT<SiPixelRecHitCollection> pixelRecHits_getToken_;
+  const edm::EDGetTokenT<reco::BeamSpot> beamSpot_getToken_;
+  const edm::EDPutTokenT<SimDoubletsCollection> simDoublets_putToken_;
+};
+
+namespace simdoublets {
+  // function that determines the layerId from the detId for Phase 1 and 2
+  template <typename TrackerTraits>
+  unsigned int getLayerId(DetId const& detId, const TrackerTopology* trackerTopology) {
+    // number of barrel layers
+    constexpr unsigned int numBarrelLayers{4};
+    // number of disks per endcap
+    constexpr unsigned int numEndcapDisks = (TrackerTraits::numberOfLayers - numBarrelLayers) / 2;
+
+    // set default to 999 (invalid)
+    unsigned int layerId{999};
+
+    if (detId.subdetId() == PixelSubdetector::PixelBarrel) {
+      // subtract 1 in the barrel to get, e.g. for Phase 2, from (1,4) to (0,3)
+      layerId = trackerTopology->pxbLayer(detId) - 1;
+    } else if (detId.subdetId() == PixelSubdetector::PixelEndcap) {
+      if (trackerTopology->pxfSide(detId) == 1) {
+        // add offset in the backward endcap to get, e.g. for Phase 2, from (1,12) to (16,27)
+        layerId = trackerTopology->pxfDisk(detId) + numBarrelLayers + numEndcapDisks - 1;
+      } else {
+        // add offest in the forward endcap to get, e.g. for Phase 2, from (1,12) to (4,15)
+        layerId = trackerTopology->pxfDisk(detId) + numBarrelLayers - 1;
+      }
+    }
+    // return the determined Id
+    return layerId;
+  }
+}  // namespace simdoublets
+
+// constructor
+template <typename TrackerTraits>
+SimDoubletsProducer<TrackerTraits>::SimDoubletsProducer(const edm::ParameterSet& pSet)
+    : topology_getToken_(esConsumes<TrackerTopology, TrackerTopologyRcd>()),
+      clusterTPAssociation_getToken_(
+          consumes<ClusterTPAssociation>(pSet.getParameter<edm::InputTag>("clusterTPAssociationSrc"))),
+      trackingParticles_getToken_(consumes(pSet.getParameter<edm::InputTag>("trackingParticleSrc"))),
+      pixelRecHits_getToken_(consumes(pSet.getParameter<edm::InputTag>("pixelRecHitSrc"))),
+      beamSpot_getToken_(consumes(pSet.getParameter<edm::InputTag>("beamSpotSrc"))),
+      simDoublets_putToken_(produces<SimDoubletsCollection>()) {
+  // initialize the selector for TrackingParticles used to create SimDoublets
+  const edm::ParameterSet& pSetTPSel = pSet.getParameter<edm::ParameterSet>("TrackingParticleSelectionConfig");
+  trackingParticleSelector = TrackingParticleSelector(pSetTPSel.getParameter<double>("ptMin"),
+                                                      pSetTPSel.getParameter<double>("ptMax"),
+                                                      pSetTPSel.getParameter<double>("minRapidity"),
+                                                      pSetTPSel.getParameter<double>("maxRapidity"),
+                                                      pSetTPSel.getParameter<double>("tip"),
+                                                      pSetTPSel.getParameter<double>("lip"),
+                                                      pSetTPSel.getParameter<int>("minHit"),
+                                                      pSetTPSel.getParameter<bool>("signalOnly"),
+                                                      pSetTPSel.getParameter<bool>("intimeOnly"),
+                                                      pSetTPSel.getParameter<bool>("chargedOnly"),
+                                                      pSetTPSel.getParameter<bool>("stableOnly"),
+                                                      pSetTPSel.getParameter<std::vector<int>>("pdgId"),
+                                                      pSetTPSel.getParameter<bool>("invertRapidityCut"),
+                                                      pSetTPSel.getParameter<double>("minPhi"),
+                                                      pSetTPSel.getParameter<double>("maxPhi"));
+}
+
+// dummy fillDescription
+template <typename TrackerTraits>
+void SimDoubletsProducer<TrackerTraits>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {}
+
+// Phase 1 fillDescription
+template <>
+void SimDoubletsProducer<pixelTopology::Phase1>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+
+  // sources for cluster-TrackingParticle association, TrackingParticles, RecHits and the beamspot
+  desc.add<edm::InputTag>("clusterTPAssociationSrc", edm::InputTag("hltTPClusterProducer"));
+  desc.add<edm::InputTag>("trackingParticleSrc", edm::InputTag("mix", "MergedTrackTruth"));
+  desc.add<edm::InputTag>("pixelRecHitSrc", edm::InputTag("hltSiPixelRecHits"));
+  desc.add<edm::InputTag>("beamSpotSrc", edm::InputTag("hltOnlineBeamSpot"));
+
+  // parameter set for the selection of TrackingParticles that will be used for SimHitDoublets
+  edm::ParameterSetDescription descTPSelector;
+  descTPSelector.add<double>("ptMin", 0.9);
+  descTPSelector.add<double>("ptMax", 1e100);
+  descTPSelector.add<double>("minRapidity", -3.);
+  descTPSelector.add<double>("maxRapidity", 3.);
+  descTPSelector.add<double>("tip", 60.);
+  descTPSelector.add<double>("lip", 30.);
+  descTPSelector.add<int>("minHit", 0);
+  descTPSelector.add<bool>("signalOnly", true);
+  descTPSelector.add<bool>("intimeOnly", false);
+  descTPSelector.add<bool>("chargedOnly", true);
+  descTPSelector.add<bool>("stableOnly", false);
+  descTPSelector.add<std::vector<int>>("pdgId", {});
+  descTPSelector.add<bool>("invertRapidityCut", false);
+  descTPSelector.add<double>("minPhi", -3.2);
+  descTPSelector.add<double>("maxPhi", 3.2);
+  desc.add<edm::ParameterSetDescription>("TrackingParticleSelectionConfig", descTPSelector);
+
+  descriptions.addWithDefaultLabel(desc);
+}
+
+// Phase 2 fillDescription
+template <>
+void SimDoubletsProducer<pixelTopology::Phase2>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+
+  // sources for cluster-TrackingParticle association, TrackingParticles, RecHits and the beamspot
+  desc.add<edm::InputTag>("clusterTPAssociationSrc", edm::InputTag("hltTPClusterProducer"));
+  desc.add<edm::InputTag>("trackingParticleSrc", edm::InputTag("mix", "MergedTrackTruth"));
+  desc.add<edm::InputTag>("pixelRecHitSrc", edm::InputTag("hltSiPixelRecHits"));
+  desc.add<edm::InputTag>("beamSpotSrc", edm::InputTag("hltOnlineBeamSpot"));
+
+  // parameter set for the selection of TrackingParticles that will be used for SimHitDoublets
+  edm::ParameterSetDescription descTPSelector;
+  descTPSelector.add<double>("ptMin", 0.9);
+  descTPSelector.add<double>("ptMax", 1e100);
+  descTPSelector.add<double>("minRapidity", -4.5);
+  descTPSelector.add<double>("maxRapidity", 4.5);
+  descTPSelector.add<double>("tip", 2.);  // NOTE: differs from HLT MultiTrackValidator
+  descTPSelector.add<double>("lip", 30.);
+  descTPSelector.add<int>("minHit", 0);
+  descTPSelector.add<bool>("signalOnly", true);
+  descTPSelector.add<bool>("intimeOnly", false);
+  descTPSelector.add<bool>("chargedOnly", true);
+  descTPSelector.add<bool>("stableOnly", false);
+  descTPSelector.add<std::vector<int>>("pdgId", {});
+  descTPSelector.add<bool>("invertRapidityCut", false);
+  descTPSelector.add<double>("minPhi", -3.2);
+  descTPSelector.add<double>("maxPhi", 3.2);
+  desc.add<edm::ParameterSetDescription>("TrackingParticleSelectionConfig", descTPSelector);
+
+  descriptions.addWithDefaultLabel(desc);
+}
+
+template <typename TrackerTraits>
+void SimDoubletsProducer<TrackerTraits>::beginRun(const edm::Run& run, const edm::EventSetup& eventSetup) {}
+
+template <typename TrackerTraits>
+void SimDoubletsProducer<TrackerTraits>::produce(edm::Event& event, const edm::EventSetup& eventSetup) {
+  // get TrackerTopology
+  trackerTopology_ = &eventSetup.getData(topology_getToken_);
+
+  // get cluster to TrackingParticle association
+  ClusterTPAssociation const& clusterTPAssociation = event.get(clusterTPAssociation_getToken_);
+
+  // get the pixel RecHit collection from the event
+  edm::Handle<SiPixelRecHitCollection> hits;
+  event.getByToken(pixelRecHits_getToken_, hits);
+  if (!hits.isValid()) {
+    return;
+  }
+
+  // get TrackingParticles from the event
+  edm::Handle<TrackingParticleCollection> trackingParticles;
+  event.getByToken(trackingParticles_getToken_, trackingParticles);
+  if (!trackingParticles.isValid()) {
+    return;
+  }
+
+  // get beamspot from the event
+  edm::Handle<reco::BeamSpot> beamSpot;
+  event.getByToken(beamSpot_getToken_, beamSpot);
+  if (!beamSpot.isValid()) {
+    return;
+  }
+
+  // create collection of SimDoublets
+  // each element will correspond to one selected TrackingParticle
+  SimDoubletsCollection simDoubletsCollection;
+
+  // loop over TrackingParticles
+  for (size_t i = 0; i < trackingParticles->size(); ++i) {
+    TrackingParticle const& trackingParticle = trackingParticles->at(i);
+
+    // select reasonable TrackingParticles for the study (e.g., only signal)
+    if (trackingParticleSelector(trackingParticle)) {
+      simDoubletsCollection.push_back(SimDoublets(TrackingParticleRef(trackingParticles, i), *beamSpot));
+    }
+  }
+
+  // create a set of the keys of the selected TrackingParticles
+  edm::IndexSet selectedTrackingParticleKeys;
+  selectedTrackingParticleKeys.reserve(simDoubletsCollection.size());
+  for (const auto& simDoublets : simDoubletsCollection) {
+    TrackingParticleRef trackingParticleRef = simDoublets.trackingParticle();
+    selectedTrackingParticleKeys.insert(trackingParticleRef.key());
+  }
+
+  // initialize a couple of counters
+  int count_associatedRecHits{0}, count_RecHitsInSimDoublets{0};
+
+  // loop over pixel RecHit collections of the different pixel modules
+  for (const auto& detSet : *hits) {
+    // determine layer Id
+    unsigned int layerId = simdoublets::getLayerId<TrackerTraits>(detSet.detId(), trackerTopology_);
+
+    // loop over RecHits
+    for (auto const& hit : detSet) {
+      // find associated TrackingParticles
+      auto range = clusterTPAssociation.equal_range(OmniClusterRef(hit.cluster()));
+
+      // if the RecHit has associated TrackingParticles
+      if (range.first != range.second) {
+        for (auto assocTrackingParticleIter = range.first; assocTrackingParticleIter != range.second;
+             assocTrackingParticleIter++) {
+          const TrackingParticleRef assocTrackingParticle = (assocTrackingParticleIter->second);
+
+          // if the associated TrackingParticle is among the selected ones
+          if (selectedTrackingParticleKeys.has(assocTrackingParticle.key())) {
+            SiPixelRecHitRef hitRef = edmNew::makeRefTo(hits, &hit);
+            count_associatedRecHits++;
+            // loop over collection of SimDoublets and find the one of the associated TrackingParticle
+            for (auto& simDoublets : simDoubletsCollection) {
+              TrackingParticleRef trackingParticleRef = simDoublets.trackingParticle();
+              if (assocTrackingParticle.key() == trackingParticleRef.key()) {
+                simDoublets.addRecHit(hitRef, layerId);
+                count_RecHitsInSimDoublets++;
+              }
+            }
+          }
+        }
+      }
+    }  // end loop over RecHits
+  }  // end loop over pixel RecHit collections of the different pixel modules
+
+  // loop over collection of SimDoublets and sort the RecHits according to their position
+  for (auto& simDoublets : simDoubletsCollection) {
+    simDoublets.sortRecHits();
+  }
+
+  LogDebug("SimDoubletsProducer") << "Size of SiPixelRecHitCollection : " << hits->size() << std::endl;
+  LogDebug("SimDoubletsProducer") << count_associatedRecHits << " of " << hits->size()
+                                  << " RecHits are associated to selected TrackingParticles ("
+                                  << count_RecHitsInSimDoublets - count_associatedRecHits
+                                  << " of them were associated multiple times)." << std::endl;
+  LogDebug("SimDoubletsProducer") << "Number of selected TrackingParticles : " << simDoubletsCollection.size()
+                                  << std::endl;
+  LogDebug("SimDoubletsProducer") << "Size of TrackingParticle Collection  : " << trackingParticles->size()
+                                  << std::endl;
+
+  // put the produced SimDoublets collection in the event
+  event.emplace(simDoublets_putToken_, std::move(simDoubletsCollection));
+}
+
+// define two plugins for Phase 1 and 2
+using SimDoubletsProducerPhase1 = SimDoubletsProducer<pixelTopology::Phase1>;
+using SimDoubletsProducerPhase2 = SimDoubletsProducer<pixelTopology::Phase2>;
+
+DEFINE_FWK_MODULE(SimDoubletsProducerPhase1);
+DEFINE_FWK_MODULE(SimDoubletsProducerPhase2);

--- a/Validation/TrackingMCTruth/plugins/BuildFile.xml
+++ b/Validation/TrackingMCTruth/plugins/BuildFile.xml
@@ -3,6 +3,7 @@
 <use name="SimDataFormats/TrackingAnalysis"/>
 <use name="SimDataFormats/Track"/>
 <use name="SimDataFormats/GeneratorProducts"/>
+<use name="Geometry/Records"/>
 <use name="root"/>
 <use name="clhep"/>
 <library file="*.cc" name="ValidationTrackingMCTruthPlugins">

--- a/Validation/TrackingMCTruth/plugins/SimDoubletsAnalyzer.cc
+++ b/Validation/TrackingMCTruth/plugins/SimDoubletsAnalyzer.cc
@@ -1,0 +1,850 @@
+// -*- C++ -*-
+//
+// Package:    Validation/TrackingMCTruth
+// Class:      SimDoubletsAnalyzer
+//
+
+// user include files
+#include "Validation/TrackingMCTruth/plugins/SimDoubletsAnalyzer.h"
+
+#include "DataFormats/Histograms/interface/MonitorElementCollection.h"
+#include "DataFormats/Math/interface/deltaPhi.h"
+#include "DataFormats/Math/interface/approx_atan2.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include <cstddef>
+
+namespace simdoublets {
+  // helper function that takes the layerPairId and returns two strings with the
+  // inner and outer layer id
+  std::pair<std::string, std::string> getInnerOuterLayerNames(int const layerPairId) {
+    // make a string from the Id (int)
+    std::string index = std::to_string(layerPairId);
+    // determine inner and outer layer name
+    std::string innerLayerName;
+    std::string outerLayerName;
+    if (index.size() < 3) {
+      innerLayerName = "0";
+      outerLayerName = index;
+    } else if (index.size() == 3) {
+      innerLayerName = index.substr(0, 1);
+      outerLayerName = index.substr(1, 3);
+    } else {
+      innerLayerName = index.substr(0, 2);
+      outerLayerName = index.substr(2, 4);
+    }
+    if (outerLayerName[0] == '0') {
+      outerLayerName = outerLayerName.substr(1, 2);
+    }
+
+    return {innerLayerName, outerLayerName};
+  }
+
+  // make bins logarithmic
+  void BinLogX(TH1* h) {
+    TAxis* axis = h->GetXaxis();
+    int bins = axis->GetNbins();
+
+    float from = axis->GetXmin();
+    float to = axis->GetXmax();
+    float width = (to - from) / bins;
+    std::vector<float> new_bins(bins + 1, 0);
+
+    for (int i = 0; i <= bins; i++) {
+      new_bins[i] = TMath::Power(10, from + i * width);
+    }
+    axis->Set(bins, new_bins.data());
+  }
+
+  // function to produce histogram with log scale on x (taken from MultiTrackValidator)
+  template <typename... Args>
+  dqm::reco::MonitorElement* make1DLogX(dqm::reco::DQMStore::IBooker& ibook, Args&&... args) {
+    auto h = std::make_unique<TH1F>(std::forward<Args>(args)...);
+    BinLogX(h.get());
+    const auto& name = h->GetName();
+    return ibook.book1D(name, h.release());
+  }
+
+  // function to produce profile with log scale on x (taken from MultiTrackValidator)
+  template <typename... Args>
+  dqm::reco::MonitorElement* makeProfileLogX(dqm::reco::DQMStore::IBooker& ibook, Args&&... args) {
+    auto h = std::make_unique<TProfile>(std::forward<Args>(args)...);
+    BinLogX(h.get());
+    const auto& name = h->GetName();
+    return ibook.bookProfile(name, h.release());
+  }
+
+  // function that checks if two vector share a common element
+  template <typename T>
+  bool haveCommonElement(std::vector<T> const& v1, std::vector<T> const& v2) {
+    return std::find_first_of(v1.begin(), v1.end(), v2.begin(), v2.end()) != v1.end();
+  }
+
+  // fillDescriptionsCommon: description that is identical for Phase 1 and 2
+  template <typename TrackerTraits>
+  void fillDescriptionsCommon(edm::ParameterSetDescription& desc) {
+    desc.add<std::string>("folder", "Tracking/TrackingMCTruth/SimDoublets");
+
+    // cut parameters with scalar values
+    desc.add<int>("cellMaxDYSize12", TrackerTraits::maxDYsize12)
+        ->setComment("Maximum difference in cluster size for B1/B2");
+    desc.add<int>("cellMaxDYSize", TrackerTraits::maxDYsize)->setComment("Maximum difference in cluster size");
+    desc.add<int>("cellMaxDYPred", TrackerTraits::maxDYPred)
+        ->setComment("Maximum difference between actual and expected cluster size of inner RecHit");
+  }
+}  // namespace simdoublets
+
+// -------------------------------------------------------------------------------------------------------------
+// constructors and destructor
+// -------------------------------------------------------------------------------------------------------------
+
+template <typename TrackerTraits>
+SimDoubletsAnalyzer<TrackerTraits>::SimDoubletsAnalyzer(const edm::ParameterSet& iConfig)
+    : topology_getToken_(esConsumes<TrackerTopology, TrackerTopologyRcd>()),
+      simDoublets_getToken_(consumes(iConfig.getParameter<edm::InputTag>("simDoubletsSrc"))),
+      cellMinz_(iConfig.getParameter<std::vector<double>>("cellMinz")),
+      cellMaxz_(iConfig.getParameter<std::vector<double>>("cellMaxz")),
+      cellPhiCuts_(iConfig.getParameter<std::vector<int>>("cellPhiCuts")),
+      cellMaxr_(iConfig.getParameter<std::vector<double>>("cellMaxr")),
+      cellMinYSizeB1_(iConfig.getParameter<int>("cellMinYSizeB1")),
+      cellMinYSizeB2_(iConfig.getParameter<int>("cellMinYSizeB2")),
+      cellMaxDYSize12_(iConfig.getParameter<int>("cellMaxDYSize12")),
+      cellMaxDYSize_(iConfig.getParameter<int>("cellMaxDYSize")),
+      cellMaxDYPred_(iConfig.getParameter<int>("cellMaxDYPred")),
+      cellZ0Cut_(iConfig.getParameter<double>("cellZ0Cut")),
+      cellPtCut_(iConfig.getParameter<double>("cellPtCut")),
+      folder_(iConfig.getParameter<std::string>("folder")) {
+  // get layer pairs from configuration
+  std::vector<int> layerPairs{iConfig.getParameter<std::vector<int>>("layerPairs")};
+
+  // number of configured layer pairs
+  size_t numLayerPairs = layerPairs.size() / 2;
+
+  // fill the map of layer pairs
+  for (size_t i{0}; i < numLayerPairs; i++) {
+    int layerPairId = 100 * layerPairs[2 * i] + layerPairs[2 * i + 1];
+    layerPairId2Index_.insert({layerPairId, i});
+  }
+
+  // resize all histogram vectors, so that we can fill them according to the
+  // layerPairIndex saved in the map that we just created
+  hVector_dr_.resize(numLayerPairs);
+  hVector_dphi_.resize(numLayerPairs);
+  hVector_idphi_.resize(numLayerPairs);
+  hVector_innerZ_.resize(numLayerPairs);
+  hVector_Ysize_.resize(numLayerPairs);
+  hVector_DYsize_.resize(numLayerPairs);
+  hVector_DYPred_.resize(numLayerPairs);
+  hVector_pass_dr_.resize(numLayerPairs);
+  hVector_pass_idphi_.resize(numLayerPairs);
+  hVector_pass_innerZ_.resize(numLayerPairs);
+}
+
+template <typename TrackerTraits>
+SimDoubletsAnalyzer<TrackerTraits>::~SimDoubletsAnalyzer() {}
+
+// -------------------------------------------------------------------------------------------------------------
+// member functions
+// -------------------------------------------------------------------------------------------------------------
+
+template <typename TrackerTraits>
+void SimDoubletsAnalyzer<TrackerTraits>::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {}
+
+template <typename TrackerTraits>
+void SimDoubletsAnalyzer<TrackerTraits>::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+
+  // get tracker topology
+  trackerTopology_ = &iSetup.getData(topology_getToken_);
+
+  // get simDoublets
+  SimDoubletsCollection const& simDoubletsCollection = iEvent.get(simDoublets_getToken_);
+
+  // create vectors for inner and outer RecHits of SimDoublets passing all cuts
+  std::vector<SiPixelRecHitRef> innerRecHitsPassing;
+  std::vector<SiPixelRecHitRef> outerRecHitsPassing;
+
+  // initialize a bunch of variables that we will use in the coming for loops
+  double true_pT, true_eta, inner_r, inner_z, inner_phi, outer_r, outer_z, outer_phi, dz, dr, dphi, z0, curvature, pT;
+  int numSimDoublets, pass_numSimDoublets, inner_iphi, outer_iphi, idphi, layerPairId, layerPairIdIndex,
+      innerClusterSizeY;
+  bool doubletGetsCut, subjectToYsizeB1, subjectToYsizeB2, subjectToDYsize, subjectToDYsize12, subjectToDYPred;
+
+  // loop over SimDoublets (= loop over TrackingParticles)
+  for (auto const& simDoublets : simDoubletsCollection) {
+    // get true pT of the TrackingParticle
+    true_pT = simDoublets.trackingParticle()->pt();
+    true_eta = simDoublets.trackingParticle()->eta();
+
+    // create the true RecHit doublets of the TrackingParticle
+    auto doublets = simDoublets.getSimDoublets(trackerTopology_);
+
+    // number of SimDoublets of the Tracking Particle
+    numSimDoublets = doublets.size();
+    // number of SimDoublets of the Tracking Particle passing all cuts
+    pass_numSimDoublets = 0;
+
+    // fill histograms for number of SimDoublets
+    h_numSimDoubletsPerTrackingParticle_->Fill(numSimDoublets);
+    h_numLayersPerTrackingParticle_->Fill(simDoublets.numLayers());
+
+    // fill histograms for number of TrackingParticles
+    h_numTPVsPt_->Fill(true_pT);
+    h_numTPVsEta_->Fill(true_eta);
+
+    // clear passing inner and outer RecHits
+    innerRecHitsPassing.clear();
+    outerRecHitsPassing.clear();
+
+    // loop over those doublets
+    for (auto const& doublet : doublets) {
+      // RecHit properties
+      inner_r = doublet.innerGlobalPos().perp();
+      inner_z = doublet.innerGlobalPos().z();
+      inner_phi = doublet.innerGlobalPos().barePhi();  // returns float, whereas .phi() returns phi object
+      inner_iphi = unsafe_atan2s<7>(doublet.innerGlobalPos().y(), doublet.innerGlobalPos().x());
+      outer_r = doublet.outerGlobalPos().perp();
+      outer_z = doublet.outerGlobalPos().z();
+      outer_phi = doublet.outerGlobalPos().barePhi();
+      outer_iphi = unsafe_atan2s<7>(doublet.outerGlobalPos().y(), doublet.outerGlobalPos().x());
+
+      dz = outer_z - inner_z;
+      dr = outer_r - inner_r;
+      dphi = reco::deltaPhi(inner_phi, outer_phi);
+      idphi = std::min(std::abs(int16_t(outer_iphi - inner_iphi)), std::abs(int16_t(inner_iphi - outer_iphi)));
+
+      // ----------------------------------------------------------
+      // general plots (general folder)
+      // ----------------------------------------------------------
+
+      // outer layer vs inner layer of SimDoublets
+      h_layerPairs_->Fill(doublet.innerLayerId(), doublet.outerLayerId());
+
+      // number of skipped layers by SimDoublets
+      h_numSkippedLayers_->Fill(doublet.numSkippedLayers());
+
+      // ----------------------------------------------------------
+      // layer pair independent cuts (global folder)
+      // ----------------------------------------------------------
+
+      // longitudinal impact parameter with respect to the beamspot
+      z0 = std::abs(inner_r * outer_z - inner_z * outer_r) / dr;
+      h_z0_->Fill(z0);
+
+      // radius of the circle defined by the two RecHits and the beamspot
+      curvature = 1.f / 2.f * std::sqrt((dr / dphi) * (dr / dphi) + (inner_r * outer_r));
+      h_curvatureR_->Fill(curvature);
+
+      // pT that this curvature radius corresponds to
+      pT = curvature / 87.78f;
+      h_pTFromR_->Fill(pT);
+
+      // ----------------------------------------------------------
+      // layer pair dependent cuts (sub-folders for layer pairs)
+      // ----------------------------------------------------------
+
+      // first, get layer pair Id and exclude layer pairs that are not considered
+      layerPairId = doublet.layerPairId();
+      if (layerPairId2Index_.find(layerPairId) == layerPairId2Index_.end()) {
+        continue;
+      }
+
+      // get the position of the layer pair in the vectors of histograms
+      layerPairIdIndex = layerPairId2Index_.at(layerPairId);
+
+      // dr = (outer_r - inner_r) histogram
+      hVector_dr_[layerPairIdIndex]->Fill(dr);
+
+      // dphi histogram
+      hVector_dphi_[layerPairIdIndex]->Fill(dphi);
+      hVector_idphi_[layerPairIdIndex]->Fill(idphi);
+
+      // z of the inner RecHit histogram
+      hVector_innerZ_[layerPairIdIndex]->Fill(inner_z);
+
+      // ----------------------------------------------------------
+      // cluster size cuts (global + sub-folders for layer pairs)
+      // ----------------------------------------------------------
+
+      // cluster size in local y histogram
+      innerClusterSizeY = doublet.innerRecHit()->cluster()->sizeY();
+      hVector_Ysize_[layerPairIdIndex]->Fill(innerClusterSizeY);
+
+      // create bool that indicates if the doublet gets cut
+      doubletGetsCut = false;
+      // create bools that trace if doublet is subject to any clsuter size cut
+      subjectToYsizeB1 = false;
+      subjectToYsizeB2 = false;
+      subjectToDYsize = false;
+      subjectToDYsize12 = false;
+      subjectToDYPred = false;
+
+      // apply all cuts that do not depend on the cluster size
+      // z window cut
+      if (inner_z < cellMinz_[layerPairIdIndex] || inner_z > cellMaxz_[layerPairIdIndex]) {
+        doubletGetsCut = true;
+      }
+      // z0cutoff
+      if (dr > cellMaxr_[layerPairIdIndex] || dr < 0 || z0 > cellZ0Cut_) {
+        doubletGetsCut = true;
+      }
+      // ptcut
+      if (pT < cellPtCut_) {
+        doubletGetsCut = true;
+      }
+      // iphicut
+      if (idphi > cellPhiCuts_[layerPairIdIndex]) {
+        doubletGetsCut = true;
+      }
+
+      // determine the moduleId
+      const GeomDetUnit* geomDetUnit = doublet.innerRecHit()->det();
+      const uint32_t moduleId = geomDetUnit->index();
+
+      // define bools needed to decide on cutting parameters
+      const bool innerInB1 = (doublet.innerLayerId() == 0);
+      const bool innerInB2 = (doublet.innerLayerId() == 1);
+      const bool isOuterLadder = (0 == (moduleId / 8) % 2);  // check if this even makes sense in Phase-2
+      const bool innerInBarrel = (doublet.innerLayerId() < 4);
+      const bool outerInBarrel = (doublet.outerLayerId() < 4);
+
+      // histograms for clusterCut
+      // cluster size in local y
+      if (!outerInBarrel) {
+        if (innerInB1 && isOuterLadder) {
+          subjectToYsizeB1 = true;
+          h_YsizeB1_->Fill(innerClusterSizeY);
+          // apply the cut
+          if (innerClusterSizeY < cellMinYSizeB1_) {
+            doubletGetsCut = true;
+          }
+        }
+        if (innerInB2) {
+          subjectToYsizeB2 = true;
+          h_YsizeB2_->Fill(innerClusterSizeY);
+          // apply the cut
+          if (innerClusterSizeY < cellMinYSizeB2_) {
+            doubletGetsCut = true;
+          }
+        }
+      }
+
+      // histograms for zSizeCut
+      int DYsize{0}, DYPred{0};
+      if (innerInBarrel) {
+        if (outerInBarrel) {  // onlyBarrel
+          DYsize = std::abs(innerClusterSizeY - doublet.outerRecHit()->cluster()->sizeY());
+          if (innerInB1 && isOuterLadder) {
+            subjectToDYsize12 = true;
+            hVector_DYsize_[layerPairIdIndex]->Fill(DYsize);
+            h_DYsize12_->Fill(DYsize);
+            // apply the cut
+            if (DYsize > cellMaxDYSize12_) {
+              doubletGetsCut = true;
+            }
+          } else if (!innerInB1) {
+            subjectToDYsize = true;
+            hVector_DYsize_[layerPairIdIndex]->Fill(DYsize);
+            h_DYsize_->Fill(DYsize);
+            // apply the cut
+            if (DYsize > cellMaxDYSize_) {
+              doubletGetsCut = true;
+            }
+          }
+        } else {  // not onlyBarrel
+          subjectToDYPred = true;
+          DYPred = std::abs(innerClusterSizeY - int(std::abs(dz / dr) * pixelTopology::Phase2::dzdrFact + 0.5f));
+          hVector_DYPred_[layerPairIdIndex]->Fill(DYPred);
+          h_DYPred_->Fill(DYPred);
+          // apply the cut
+          if (DYPred > cellMaxDYPred_) {
+            doubletGetsCut = true;
+          }
+        }
+      }
+
+      // ----------------------------------------------------------
+      // all kinds of plots for doublets passing all cuts
+      // ----------------------------------------------------------
+
+      // fill the number histograms
+      // histogram of all valid doublets
+      h_numVsPt_->Fill(true_pT);
+      h_numVsEta_->Fill(true_eta);
+
+      // if the doublet passes all cuts
+      if (!doubletGetsCut) {
+        // increment number of SimDoublets passing all cuts
+        pass_numSimDoublets++;
+
+        // fill histogram of doublets that pass all cuts
+        h_pass_layerPairs_->Fill(doublet.innerLayerId(), doublet.outerLayerId());
+        h_pass_numVsPt_->Fill(true_pT);
+        h_pass_numVsEta_->Fill(true_eta);
+
+        // also put the inner/outer RecHit in the respective vector
+        innerRecHitsPassing.push_back(doublet.innerRecHit());
+        outerRecHitsPassing.push_back(doublet.outerRecHit());
+
+        // fill pass_ histograms
+        h_pass_z0_->Fill(z0);
+        h_pass_pTFromR_->Fill(pT);
+        hVector_pass_dr_[layerPairIdIndex]->Fill(dr);
+        hVector_pass_idphi_[layerPairIdIndex]->Fill(idphi);
+        hVector_pass_innerZ_[layerPairIdIndex]->Fill(inner_z);
+        if (subjectToDYPred) {
+          h_pass_DYPred_->Fill(DYPred);
+        }
+        if (subjectToDYsize) {
+          h_pass_DYsize_->Fill(DYsize);
+        }
+        if (subjectToDYsize12) {
+          h_pass_DYsize12_->Fill(DYsize);
+        }
+        if (subjectToYsizeB1) {
+          h_pass_YsizeB1_->Fill(innerClusterSizeY);
+        }
+        if (subjectToYsizeB2) {
+          h_pass_YsizeB2_->Fill(innerClusterSizeY);
+        }
+      }
+    }  // end loop over those doublets
+
+    // Now check if the TrackingParticle is reconstructable by at least two conencted SimDoublets surviving the cuts
+    if (simdoublets::haveCommonElement<SiPixelRecHitRef>(innerRecHitsPassing, outerRecHitsPassing)) {
+      h_pass_numTPVsPt_->Fill(true_pT);
+      h_pass_numTPVsEta_->Fill(true_eta);
+    }
+
+    // Fill the efficiency profile per Tracking Particle only if the TP has at least one SimDoublet
+    if (numSimDoublets > 0) {
+      h_effSimDoubletsPerTPVsEta_->Fill(true_eta, pass_numSimDoublets / numSimDoublets);
+      h_effSimDoubletsPerTPVsPt_->Fill(true_pT, pass_numSimDoublets / numSimDoublets);
+    }
+  }  // end loop over SimDoublets (= loop over TrackingParticles)
+}
+
+// booking the histograms
+template <typename TrackerTraits>
+void SimDoubletsAnalyzer<TrackerTraits>::bookHistograms(DQMStore::IBooker& ibook,
+                                                        edm::Run const& run,
+                                                        edm::EventSetup const& iSetup) {
+  // set some common parameters
+  int pTNBins = 50;
+  double pTmin = log10(0.01);
+  double pTmax = log10(1000);
+  int etaNBins = 80;
+  double etamin = -4.;
+  double etamax = 4.;
+
+  // ----------------------------------------------------------
+  // booking general histograms (general folder)
+  // ----------------------------------------------------------
+
+  ibook.setCurrentFolder(folder_ + "/general");
+
+  // overview histograms and profiles
+  h_effSimDoubletsPerTPVsPt_ =
+      simdoublets::makeProfileLogX(ibook,
+                                   "efficiencyPerTP_vs_pT",
+                                   "SimDoublets efficiency per TP vs p_{T}; TP transverse momentum p_{T} [GeV]; "
+                                   "Average fraction of SimDoublets per TP passing all cuts",
+                                   pTNBins,
+                                   pTmin,
+                                   pTmax,
+                                   0,
+                                   1,
+                                   " ");
+  h_effSimDoubletsPerTPVsEta_ = ibook.bookProfile("efficiencyPerTP_vs_eta",
+                                                  "SimDoublets efficiency per TP vs #eta; TP transverse momentum #eta; "
+                                                  "Average fraction of SimDoublets per TP passing all cuts",
+                                                  etaNBins,
+                                                  etamin,
+                                                  etamax,
+                                                  0,
+                                                  1,
+                                                  " ");
+  h_layerPairs_ = ibook.book2D("layerPairs",
+                               "Layer pairs in SimDoublets; Inner layer ID; Outer layer ID",
+                               TrackerTraits::numberOfLayers,
+                               -0.5,
+                               -0.5 + TrackerTraits::numberOfLayers,
+                               TrackerTraits::numberOfLayers,
+                               -0.5,
+                               -0.5 + TrackerTraits::numberOfLayers);
+  h_pass_layerPairs_ = ibook.book2D("pass_layerPairs",
+                                    "Layer pairs in SimDoublets passing all cuts; Inner layer ID; Outer layer ID",
+                                    TrackerTraits::numberOfLayers,
+                                    -0.5,
+                                    -0.5 + TrackerTraits::numberOfLayers,
+                                    TrackerTraits::numberOfLayers,
+                                    -0.5,
+                                    -0.5 + TrackerTraits::numberOfLayers);
+  h_numSkippedLayers_ = ibook.book1D(
+      "numSkippedLayers", "Number of skipped layers; Number of skipped layers; Number of SimDoublets", 16, -1.5, 14.5);
+  h_numSimDoubletsPerTrackingParticle_ =
+      ibook.book1D("numSimDoubletsPerTrackingParticle",
+                   "Number of SimDoublets per Tracking Particle; Number of SimDoublets; Number of Tracking Particles",
+                   31,
+                   -0.5,
+                   30.5);
+  h_numLayersPerTrackingParticle_ =
+      ibook.book1D("numLayersPerTrackingParticle",
+                   "Number of layers hit by Tracking Particle; Number of layers; Number of Tracking Particles",
+                   29,
+                   -0.5,
+                   28.5);
+  h_numTPVsPt_ = simdoublets::make1DLogX(
+      ibook,
+      "numTPVsPt",
+      "Total number of TrackingParticles; True transverse momentum p_{T} [GeV]; Total number of TrackingParticles",
+      pTNBins,
+      pTmin,
+      pTmax);
+  h_pass_numTPVsPt_ = simdoublets::make1DLogX(ibook,
+                                              "pass_numTPVsPt",
+                                              "Reconstructable TrackingParticles (two or more connected SimDoublets "
+                                              "pass cuts); True transverse momentum p_{T} [GeV]; "
+                                              "Number of reconstructable TrackingParticles",
+                                              pTNBins,
+                                              pTmin,
+                                              pTmax);
+  h_numTPVsEta_ =
+      ibook.book1D("numTPVsEta",
+                   "Total number of TrackingParticles; True pseudorapidity #eta; Total number of TrackingParticles",
+                   etaNBins,
+                   etamin,
+                   etamax);
+  h_pass_numTPVsEta_ = ibook.book1D("pass_numTPVsEta",
+                                    "Reconstructable TrackingParticles (two or more connected SimDoublets "
+                                    "pass cuts); True pseudorapidity #eta; Number of reconstructable TrackingParticles",
+                                    etaNBins,
+                                    etamin,
+                                    etamax);
+  h_numVsPt_ = simdoublets::make1DLogX(
+      ibook,
+      "numVsPt",
+      "Total number of SimDoublets; True transverse momentum p_{T} [GeV]; Total number of SimDoublets",
+      pTNBins,
+      pTmin,
+      pTmax);
+  h_pass_numVsPt_ = simdoublets::make1DLogX(ibook,
+                                            "pass_numVsPt",
+                                            "Number of passing SimDoublets; True transverse momentum p_{T} [GeV]; "
+                                            "Number of SimDoublets passing all cuts",
+                                            pTNBins,
+                                            pTmin,
+                                            pTmax);
+  h_numVsEta_ = ibook.book1D("numVsEta",
+                             "Total number of SimDoublets; True pseudorapidity #eta; Total number of SimDoublets",
+                             etaNBins,
+                             etamin,
+                             etamax);
+  h_pass_numVsEta_ =
+      ibook.book1D("pass_numVsEta",
+                   "Number of SimDoublets; True pseudorapidity #eta; Number of SimDoublets passing all cuts",
+                   etaNBins,
+                   etamin,
+                   etamax);
+
+  // -------------------------------------------------------------
+  // booking layer pair independent cut histograms (global folder)
+  // -------------------------------------------------------------
+
+  ibook.setCurrentFolder(folder_ + "/cutParameters/global");
+
+  // histogram for z0cutoff  (z0Cut)
+  h_z0_ = ibook.book1D("z0", "z_{0}; Longitudinal impact parameter z_{0} [cm]; Number of SimDoublets", 51, -1, 50);
+  h_pass_z0_ = ibook.book1D(
+      "pass_z0",
+      "z_{0} of SimDoublets passing all cuts; Longitudinal impact parameter z_{0} [cm]; Number of SimDoublets",
+      51,
+      -1,
+      50);
+
+  // histograms for ptcut  (ptCut)
+  h_curvatureR_ = ibook.book1D(
+      "curvatureR", "Curvature from SimDoublet+beamspot; Curvature radius [cm] ; Number of SimDoublets", 100, 0, 1000);
+  h_pTFromR_ = simdoublets::make1DLogX(
+      ibook,
+      "pTFromR",
+      "Transverse momentum from curvature; Transverse momentum p_{T} [GeV]; Number of SimDoublets",
+      pTNBins,
+      pTmin,
+      pTmax);
+  h_pass_pTFromR_ = simdoublets::make1DLogX(ibook,
+                                            "pass_pTFromR",
+                                            "Transverse momentum from curvature of SimDoublets passing all cuts; "
+                                            "Transverse momentum p_{T} [GeV]; Number of SimDoublets",
+                                            pTNBins,
+                                            pTmin,
+                                            pTmax);
+
+  // histograms for clusterCut  (minYsizeB1 and minYsizeB2)
+  h_YsizeB1_ = ibook.book1D(
+      "YsizeB1",
+      "Cluster size along z (inner from B1); Size along z of inner cluster [num of pixels]; Number of SimDoublets",
+      51,
+      -1,
+      50);
+  h_YsizeB2_ = ibook.book1D(
+      "YsizeB2",
+      "Cluster size along z (inner not from B1); Size along z of inner cluster [num of pixels]; Number of SimDoublets",
+      51,
+      -1,
+      50);
+  h_pass_YsizeB1_ = ibook.book1D("pass_YsizeB1",
+                                 "Cluster size along z of SimDoublets passing all cuts (inner from B1); Size along z "
+                                 "of inner cluster [num of pixels]; Number of SimDoublets",
+                                 51,
+                                 -1,
+                                 50);
+  h_pass_YsizeB2_ = ibook.book1D("pass_YsizeB2",
+                                 "Cluster size along z of SimDoublets passing all cuts (inner not from B1); Size along "
+                                 "z of inner cluster [num of pixels]; Number of SimDoublets",
+                                 51,
+                                 -1,
+                                 50);
+
+  // histograms for zSizeCut  (maxDYsize12, maxDYsize and maxDYPred)
+  h_DYsize12_ =
+      ibook.book1D("DYsize12",
+                   "Difference in cluster size along z (inner from B1); Absolute difference in cluster size along z of "
+                   "the two RecHits [num of pixels]; Number of SimDoublets",
+                   31,
+                   -1,
+                   30);
+  h_DYsize_ = ibook.book1D("DYsize",
+                           "Difference in cluster size along z; Absolute difference in cluster size along z of the two "
+                           "RecHits [num of pixels]; Number of SimDoublets",
+                           31,
+                           -1,
+                           30);
+  h_DYPred_ = ibook.book1D("DYPred",
+                           "Difference between actual and predicted cluster size along z of inner cluster; Absolute "
+                           "difference [num of pixels]; Number of SimDoublets",
+                           201,
+                           -1,
+                           200);
+  h_pass_DYsize12_ = ibook.book1D("pass_DYsize12",
+                                  "Difference in cluster size along z of SimDoublets passing all cuts (inner from B1); "
+                                  "Absolute difference in cluster size along z of "
+                                  "the two RecHits [num of pixels]; Number of SimDoublets",
+                                  31,
+                                  -1,
+                                  30);
+  h_pass_DYsize_ =
+      ibook.book1D("pass_DYsize",
+                   "Difference in cluster size along z of SimDoublets passing all cuts; Absolute difference in "
+                   "cluster size along z of the two RecHits [num of pixels]; Number of SimDoublets",
+                   31,
+                   -1,
+                   30);
+  h_pass_DYPred_ =
+      ibook.book1D("pass_DYPred",
+                   "Difference between actual and predicted cluster size along z of inner cluster of SimDoublets "
+                   "passing all cuts; Absolute difference [num of pixels]; Number of SimDoublets",
+                   201,
+                   -1,
+                   200);
+
+  // -----------------------------------------------------------------------
+  // booking layer pair dependent histograms (sub-folders for layer pairs)
+  // -----------------------------------------------------------------------
+
+  // loop through valid layer pairs and add for each one booked hist per vector
+  for (auto id = layerPairId2Index_.begin(); id != layerPairId2Index_.end(); ++id) {
+    // get the position of the layer pair in the histogram vectors
+    int layerPairIdIndex = id->second;
+
+    // get layer names from the layer pair Id
+    auto layerNames = simdoublets::getInnerOuterLayerNames(id->first);
+    std::string innerLayerName = layerNames.first;
+    std::string outerLayerName = layerNames.second;
+
+    // name the sub-folder for the layer pair "lp_${innerLayerId}_${outerLayerId}"
+    std::string subFolderName = "/cutParameters/lp_" + innerLayerName + "_" + outerLayerName;
+
+    // layer mentioning in histogram titles
+    std::string layerTitle = "(layers (" + innerLayerName + "," + outerLayerName + "))";
+
+    // set folder to the sub-folder for the layer pair
+    ibook.setCurrentFolder(folder_ + subFolderName);
+
+    // histogram for z0cutoff  (maxr)
+    hVector_dr_.at(layerPairIdIndex) = ibook.book1D(
+        "dr",
+        "dr of RecHit pair " + layerTitle + "; dr between outer and inner RecHit [cm]; Number of SimDoublets",
+        31,
+        -1,
+        30);
+    hVector_pass_dr_.at(layerPairIdIndex) = ibook.book1D(
+        "pass_dr",
+        "dr of RecHit pair " + layerTitle +
+            " for SimDoublets passing all cuts; dr between outer and inner RecHit [cm]; Number of SimDoublets",
+        31,
+        -1,
+        30);
+
+    // histograms for iphicut  (phiCuts)
+    hVector_dphi_.at(layerPairIdIndex) = ibook.book1D(
+        "dphi",
+        "dphi of RecHit pair " + layerTitle + "; d#phi between outer and inner RecHit [rad]; Number of SimDoublets",
+        50,
+        -M_PI,
+        M_PI);
+    hVector_idphi_.at(layerPairIdIndex) =
+        ibook.book1D("idphi",
+                     "idphi of RecHit pair " + layerTitle +
+                         "; Absolute int d#phi between outer and inner RecHit; Number of SimDoublets",
+                     50,
+                     0,
+                     1000);
+    hVector_pass_idphi_.at(layerPairIdIndex) = ibook.book1D("pass_idphi",
+                                                            "idphi of RecHit pair " + layerTitle +
+                                                                " for SimDoublets passing all cuts; Absolute int d#phi "
+                                                                "between outer and inner RecHit; Number of SimDoublets",
+                                                            50,
+                                                            0,
+                                                            1000);
+
+    // histogram for z window  (minz and maxz)
+    hVector_innerZ_.at(layerPairIdIndex) =
+        ibook.book1D("innerZ",
+                     "z of the inner RecHit " + layerTitle + "; z of inner RecHit [cm]; Number of SimDoublets",
+                     100,
+                     -300,
+                     300);
+    hVector_pass_innerZ_.at(layerPairIdIndex) =
+        ibook.book1D("pass_innerZ",
+                     "z of the inner RecHit " + layerTitle +
+                         " for SimDoublets passing all cuts; z of inner RecHit [cm]; Number of SimDoublets",
+                     100,
+                     -300,
+                     300);
+
+    // histograms for cluster size and size differences
+    hVector_DYsize_.at(layerPairIdIndex) =
+        ibook.book1D("DYsize",
+                     "Difference in cluster size along z between outer and inner RecHit " + layerTitle +
+                         "; Absolute difference in cluster size along z of the two "
+                         "RecHits [num of pixels]; Number of SimDoublets",
+                     51,
+                     -1,
+                     50);
+    hVector_DYPred_.at(layerPairIdIndex) =
+        ibook.book1D("DYPred",
+                     "Difference between actual and predicted cluster size along z of inner cluster " + layerTitle +
+                         "; Absolute difference [num of pixels]; Number of SimDoublets",
+                     51,
+                     -1,
+                     50);
+    hVector_Ysize_.at(layerPairIdIndex) = ibook.book1D(
+        "Ysize",
+        "Cluster size along z " + layerTitle + "; Size along z of inner cluster [num of pixels]; Number of SimDoublets",
+        51,
+        -1,
+        50);
+  }
+}
+
+// -------------------------------------------------------------------------------------------------------------
+// fillDescriptions
+// -------------------------------------------------------------------------------------------------------------
+
+// dummy default fillDescription
+template <typename TrackerTraits>
+void SimDoubletsAnalyzer<TrackerTraits>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  descriptions.addWithDefaultLabel(desc);
+}
+
+// fillDescription for Phase 1
+template <>
+void SimDoubletsAnalyzer<pixelTopology::Phase1>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  simdoublets::fillDescriptionsCommon<pixelTopology::Phase1>(desc);
+
+  // input source for SimDoublets
+  desc.add<edm::InputTag>("simDoubletsSrc", edm::InputTag("simDoubletsProducerPhase1"));
+
+  // layer pairs in reconstruction
+  desc.add<std::vector<int>>(
+          "layerPairs",
+          std::vector<int>(std::begin(phase1PixelTopology::layerPairs), std::end(phase1PixelTopology::layerPairs)))
+      ->setComment(
+          "Array of length 2*NumberOfPairs where the elements at 2i and 2i+1 are the inner and outer layers of layer "
+          "pair i");
+
+  // cutting parameters
+  desc.add<int>("cellMinYSizeB1", 36)->setComment("Minimum cluster size for inner RecHit from B1");
+  desc.add<int>("cellMinYSizeB2", 28)->setComment("Minimum cluster size for inner RecHit not from B1");
+  desc.add<double>("cellZ0Cut", 12.0)->setComment("Maximum longitudinal impact parameter");
+  desc.add<double>("cellPtCut", 0.5)->setComment("Minimum tranverse momentum");
+  desc.add<std::vector<double>>(
+          "cellMinz", std::vector<double>(std::begin(phase1PixelTopology::minz), std::end(phase1PixelTopology::minz)))
+      ->setComment("Minimum z of inner RecHit for each layer pair");
+  desc.add<std::vector<double>>(
+          "cellMaxz", std::vector<double>(std::begin(phase1PixelTopology::maxz), std::end(phase1PixelTopology::maxz)))
+      ->setComment("Maximum z of inner RecHit for each layer pair");
+  desc.add<std::vector<int>>(
+          "cellPhiCuts",
+          std::vector<int>(std::begin(phase1PixelTopology::phicuts), std::end(phase1PixelTopology::phicuts)))
+      ->setComment("Cuts in delta phi for cells");
+  desc.add<std::vector<double>>(
+          "cellMaxr", std::vector<double>(std::begin(phase1PixelTopology::maxr), std::end(phase1PixelTopology::maxr)))
+      ->setComment("Cut for dr of cells");
+
+  descriptions.addWithDefaultLabel(desc);
+}
+
+// fillDescription for Phase 2
+template <>
+void SimDoubletsAnalyzer<pixelTopology::Phase2>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  simdoublets::fillDescriptionsCommon<pixelTopology::Phase2>(desc);
+
+  // input source for SimDoublets
+  desc.add<edm::InputTag>("simDoubletsSrc", edm::InputTag("simDoubletsProducerPhase2"));
+
+  // layer pairs in reconstruction
+  desc.add<std::vector<int>>(
+          "layerPairs",
+          std::vector<int>(std::begin(phase2PixelTopology::layerPairs), std::end(phase2PixelTopology::layerPairs)))
+      ->setComment(
+          "Array of length 2*NumberOfPairs where the elements at 2i and 2i+1 are the inner and outer layers of layer "
+          "pair i");
+
+  // cutting parameters
+  desc.add<int>("cellMinYSizeB1", 25)->setComment("Minimum cluster size for inner RecHit from B1");
+  desc.add<int>("cellMinYSizeB2", 15)->setComment("Minimum cluster size for inner RecHit not from B1");
+  desc.add<double>("cellZ0Cut", 7.5)->setComment("Maximum longitudinal impact parameter");
+  desc.add<double>("cellPtCut", 0.85)->setComment("Minimum tranverse momentum");
+  desc.add<std::vector<double>>(
+          "cellMinz", std::vector<double>(std::begin(phase2PixelTopology::minz), std::end(phase2PixelTopology::minz)))
+      ->setComment("Minimum z of inner RecHit for each layer pair");
+  desc.add<std::vector<double>>(
+          "cellMaxz", std::vector<double>(std::begin(phase2PixelTopology::maxz), std::end(phase2PixelTopology::maxz)))
+      ->setComment("Maximum z of inner RecHit for each layer pair");
+  desc.add<std::vector<int>>(
+          "cellPhiCuts",
+          std::vector<int>(std::begin(phase2PixelTopology::phicuts), std::end(phase2PixelTopology::phicuts)))
+      ->setComment("Cuts in delta phi for cells");
+  desc.add<std::vector<double>>(
+          "cellMaxr", std::vector<double>(std::begin(phase2PixelTopology::maxr), std::end(phase2PixelTopology::maxr)))
+      ->setComment("Cut for dr of cells");
+
+  descriptions.addWithDefaultLabel(desc);
+}
+
+// define two plugins for Phase 1 and 2
+using SimDoubletsAnalyzerPhase1 = SimDoubletsAnalyzer<pixelTopology::Phase1>;
+using SimDoubletsAnalyzerPhase2 = SimDoubletsAnalyzer<pixelTopology::Phase2>;
+
+// define this as a plug-in
+DEFINE_FWK_MODULE(SimDoubletsAnalyzerPhase1);
+DEFINE_FWK_MODULE(SimDoubletsAnalyzerPhase2);

--- a/Validation/TrackingMCTruth/plugins/SimDoubletsAnalyzer.h
+++ b/Validation/TrackingMCTruth/plugins/SimDoubletsAnalyzer.h
@@ -1,0 +1,145 @@
+#ifndef Validation_TrackingMCTruth_SimDoubletsAnalyzer_h
+#define Validation_TrackingMCTruth_SimDoubletsAnalyzer_h
+
+// Package:    Validation/TrackingMCTruth
+// Class:      SimDoubletsAnalyzer
+//
+/**\class SimDoubletsAnalyzer SimDoubletsAnalyzer.cc Validation/TrackingMCTruth/plugins/SimDoubletsAnalyzer.cc
+
+ Description: DQM analyzer for true RecHit doublets (SimDoublets) of the inner tracker
+
+ Implementation:
+    This analyzer takes as input collection SimDoublets produced by the SimDoubletsProducer. Like the producer,
+    you have two versions, one for Phase 1 and one for Phase 2.
+    The analyzer's main purpose is to study the goodness of the pixel RecHit doublet creation in the patatrack
+    pixel track reconstruction. This depends on a bunch of cuts, meaning a doublet of two RecHits is only formed
+    if it passes all of those cuts. The SimDoublets represent the true and therefore ideal doublets of 
+    simulated TrackingParticles (Note that in the SimDoublet production you may apply selections on the TPs).
+    
+    For this study, the analyzer produces histograms for the variables that are cut on during the real 
+    reconstruction. Each distribution is produced twice:
+     1. for all SimDoublets (name = `{variablename}`)
+     2. for those SimDoublets which actually pass all selection cuts (name = `pass_{variablename}`)
+    The cut values can be passed in the configuration of the analyzer and should default to the ones used in 
+    reconstruction. The distributions of the cut variables can be found in the folder:
+        SimDoublets/cutParameters/
+    In there, you have one subfolder global/ where you find the cut parameters which are set globally for the 
+    entire pixel detector. Additionally, you have for each configured layer pair a subfolder with all layer-pair-
+    dependent cut parameters. Those are labeled `lp_{innerLayerId}_{outerLayerId}`.
+
+    Besides this, also general distributions can be found in 
+        SimDoublets/general/
+    These are e.g. histograms for the number of SimDoublets per layer pair or SimDoublet efficiencies depending 
+    on the cut values set in the configuration.
+
+*/
+//
+// Original Author:  Luca Ferragina, Elena Vernazza, Jan Schulz
+//         Created:  Thu, 16 Jan 2025 13:46:21 GMT
+//
+//
+
+// includes
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+
+#include "SimDataFormats/TrackingAnalysis/interface/SimDoublets.h"
+
+#include <vector>
+#include <string>
+#include <map>
+
+// -------------------------------------------------------------------------------------------------------------
+// class declaration
+// -------------------------------------------------------------------------------------------------------------
+
+template <typename TrackerTraits>
+class SimDoubletsAnalyzer : public DQMEDAnalyzer {
+public:
+  explicit SimDoubletsAnalyzer(const edm::ParameterSet&);
+  ~SimDoubletsAnalyzer() override;
+
+  void dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
+
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+  // ------------ member data ------------
+
+  const TrackerTopology* trackerTopology_ = nullptr;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topology_getToken_;
+  const edm::EDGetTokenT<SimDoubletsCollection> simDoublets_getToken_;
+
+  // map that takes the layerPairId as defined in the SimDoublets
+  // and gives the position of the histogram in the histogram vector
+  std::map<int, int> layerPairId2Index_;
+
+  // cutting parameters
+  std::vector<double> cellMinz_;
+  std::vector<double> cellMaxz_;
+  std::vector<int> cellPhiCuts_;
+  std::vector<double> cellMaxr_;
+  int cellMinYSizeB1_;
+  int cellMinYSizeB2_;
+  int cellMaxDYSize12_;
+  int cellMaxDYSize_;
+  int cellMaxDYPred_;
+  double cellZ0Cut_;
+  double cellPtCut_;
+
+  std::string folder_;  // main folder in the DQM file
+
+  // monitor elements
+  // profiles to be filled
+  MonitorElement* h_effSimDoubletsPerTPVsPt_;
+  MonitorElement* h_effSimDoubletsPerTPVsEta_;
+  // histograms to be filled
+  MonitorElement* h_layerPairs_;
+  MonitorElement* h_numSkippedLayers_;
+  MonitorElement* h_numSimDoubletsPerTrackingParticle_;
+  MonitorElement* h_numLayersPerTrackingParticle_;
+  MonitorElement* h_numTPVsPt_;
+  MonitorElement* h_pass_numTPVsPt_;
+  MonitorElement* h_numTPVsEta_;
+  MonitorElement* h_pass_numTPVsEta_;
+  MonitorElement* h_numVsPt_;
+  MonitorElement* h_pass_numVsPt_;
+  MonitorElement* h_numVsEta_;
+  MonitorElement* h_pass_numVsEta_;
+  MonitorElement* h_z0_;
+  MonitorElement* h_curvatureR_;
+  MonitorElement* h_pTFromR_;
+  MonitorElement* h_YsizeB1_;
+  MonitorElement* h_YsizeB2_;
+  MonitorElement* h_DYsize12_;
+  MonitorElement* h_DYsize_;
+  MonitorElement* h_DYPred_;
+  MonitorElement* h_pass_layerPairs_;
+  MonitorElement* h_pass_z0_;
+  MonitorElement* h_pass_pTFromR_;
+  MonitorElement* h_pass_YsizeB1_;
+  MonitorElement* h_pass_YsizeB2_;
+  MonitorElement* h_pass_DYsize12_;
+  MonitorElement* h_pass_DYsize_;
+  MonitorElement* h_pass_DYPred_;
+  // vectors of histograms (one hist per layer pair)
+  std::vector<MonitorElement*> hVector_dr_;
+  std::vector<MonitorElement*> hVector_dphi_;
+  std::vector<MonitorElement*> hVector_idphi_;
+  std::vector<MonitorElement*> hVector_innerZ_;
+  std::vector<MonitorElement*> hVector_Ysize_;
+  std::vector<MonitorElement*> hVector_DYsize_;
+  std::vector<MonitorElement*> hVector_DYPred_;
+  std::vector<MonitorElement*> hVector_pass_dr_;
+  std::vector<MonitorElement*> hVector_pass_idphi_;
+  std::vector<MonitorElement*> hVector_pass_innerZ_;
+};
+
+#endif

--- a/Validation/TrackingMCTruth/python/PostProcessorSimDoublets_cff.py
+++ b/Validation/TrackingMCTruth/python/PostProcessorSimDoublets_cff.py
@@ -1,0 +1,35 @@
+import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+
+def _addNoFlow(module):
+    _noflowSeen = set()
+    for eff in module.efficiency.value():
+        tmp = eff.split(" ")
+        if "cut" in tmp[0]:
+            continue
+        ind = -1
+        if tmp[ind] == "fake" or tmp[ind] == "simpleratio":
+            ind = -2
+        if not tmp[ind] in _noflowSeen:
+            module.noFlowDists.append(tmp[ind])
+        if not tmp[ind-1] in _noflowSeen:
+            module.noFlowDists.append(tmp[ind-1])
+
+_defaultSubdirs = ["Tracking/TrackingMCTruth/SimDoublets/general"]
+
+postProcessorSimDoublets = DQMEDHarvester("DQMGenericClient",
+    subDirs = cms.untracked.vstring(_defaultSubdirs),
+    efficiency = cms.vstring(
+        "efficiency_vs_pT 'SimDoublets efficiency vs p_{T}; TP transverse momentum p_{T} [GeV]; Total fraction of SimDoublets passing all cuts' pass_numVsPt numVsPt",
+        "efficiency_vs_eta 'SimDoublets efficiency vs #eta; TP pseudorapidity #eta; Total fraction of SimDoublets passing all cuts' pass_numVsEta numVsEta",
+        "efficiencyTP_vs_pT 'TrackingParticle efficiency (2 or more connected SimDoublets passing cuts); TP transverse momentum p_{T} [GeV]; Efficiency for TrackingParticles' pass_numTPVsPt numTPVsPt",
+        "efficiencyTP_vs_eta 'TrackingParticle efficiency (2 or more connected SimDoublets passing cuts); TP pseudorapidity #eta; Efficiency for TrackingParticles' pass_numTPVsEta numTPVsEta"
+    ),
+    resolution = cms.vstring(),
+    cumulativeDists = cms.untracked.vstring(),
+    noFlowDists = cms.untracked.vstring(),
+    outputFileName = cms.untracked.string(""),
+    makeGlobalEffienciesPlot = cms.untracked.bool(True)
+)
+
+_addNoFlow(postProcessorSimDoublets)

--- a/Validation/TrackingMCTruth/test/simDoubletsPhase1_HARVESTING.py
+++ b/Validation/TrackingMCTruth/test/simDoubletsPhase1_HARVESTING.py
@@ -1,0 +1,59 @@
+"""
+This script runs the harvesting step on top of the file `simDoublets_DQMIO.root` produced when running the
+simDoubletsPhase1_TEST.py script. To harvest simply run:
+
+cmsRun simDoubletsPhase1_HARVESTING.py
+
+This will produce a DQM file with all SimDoublets histograms.
+"""
+
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run3_2025_cff import Run3_2025
+
+process = cms.Process('HARVESTING',Run3_2025)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.DQMSaverAtRunEnd_cff')
+process.load('Configuration.StandardSequences.Harvesting_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring('file:simDoublets_DQMIO.root')
+)
+
+process.options = cms.untracked.PSet(
+    Rethrow = cms.untracked.vstring('ProductNotFound'),
+    fileMode = cms.untracked.string('FULLMERGE')
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.19 $'),
+    annotation = cms.untracked.string('step4 nevts:100'),
+    name = cms.untracked.string('Applications')
+)
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, '142X_mcRun3_2025_realistic_v4', '')
+
+# Path and EndPath definitions
+process.load('Validation.TrackingMCTruth.PostProcessorSimDoublets_cff')  # load harvesting config for SimDoublets
+process.harvesting_step = cms.Path(process.postProcessorSimDoublets)
+process.dqmsave_step = cms.Path(process.DQMSaver)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.harvesting_step,process.dqmsave_step)

--- a/Validation/TrackingMCTruth/test/simDoubletsPhase1_TEST.py
+++ b/Validation/TrackingMCTruth/test/simDoubletsPhase1_TEST.py
@@ -1,0 +1,91 @@
+"""
+This script runs the SimDoubletsProducer and SimDoubletsAnalyzer for Run3.
+
+To run it, you first have to produce or get the output root file from a step 2 that runs the HLT.
+The input file is expected to be named `step2.root` by default, but you can also rename it below.
+Then you can simply run the config using:
+
+cmsRun simDoubletsPhase1_TEST.py
+
+It will produce one DQMIO output file named `simDoublets_DQMIO.root`. 
+This can be further processed in the harvesting step by running the simDoubletsPhase1_HARVESTING.py script.
+"""
+inputFile = "step2.root"
+
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run3_2025_cff import Run3_2025
+
+process = cms.Process("SIMDOUBLETS",Run3_2025)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1),
+    output = cms.optional.untracked.allowed(cms.int32,cms.PSet)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    dropDescendantsOfDroppedBranches = cms.untracked.bool(False),
+    fileNames = cms.untracked.vstring('file:%s' % inputFile),
+    inputCommands = cms.untracked.vstring(
+        'keep *',
+        'drop *_hltSiPixelRecHits_*_*'   # we will reproduce the PixelRecHits to have their local position available
+    ),
+    secondaryFileNames = cms.untracked.vstring()
+)
+
+### conditions
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, '142X_mcRun3_2025_realistic_v4', '')
+
+### standard includes
+process.load('Configuration/StandardSequences/Services_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load("Configuration.StandardSequences.RawToDigi_cff")
+process.load("Configuration.EventContent.EventContent_cff")
+process.load("Configuration.StandardSequences.MagneticField_cff")
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+
+### load HLTDoLocalPixelSequence
+process.load('HLTrigger.Configuration.HLT_GRun_cff')
+### load hltTPClusterProducer
+process.load("Validation.RecoTrack.associators_cff")
+### load the new EDProducer "SimDoubletsProducerPhase1"
+process.load("SimTracker.TrackerHitAssociation.simDoubletsProducerPhase1_cfi")
+### load the new DQM EDAnalyzer "SimDoubletsAnalyzerPhase1"
+process.load("Validation.TrackingMCTruth.simDoubletsAnalyzerPhase1_cfi")
+
+####  set up the path
+process.simDoubletPath = cms.Path(
+    process.HLTDoLocalPixelSequence *   # reproduce the SiPixelRecHits
+    process.hltTPClusterProducer *      # run the cluster to TrackingParticle association
+    process.simDoubletsProducerPhase1 * # produce the SimDoublets
+    process.simDoubletsAnalyzerPhase1   # analyze the SimDoublets
+)
+
+# Output definition
+process.DQMoutput = cms.OutputModule("DQMRootOutputModule",
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('DQMIO'),
+        filterName = cms.untracked.string('')
+    ),
+    fileName = cms.untracked.string('file:simDoublets_DQMIO.root'),
+    outputCommands = process.DQMEventContent.outputCommands,
+    splitLevel = cms.untracked.int32(0)
+)
+
+
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.DQMoutput_step = cms.EndPath(process.DQMoutput)
+
+
+process.schedule = cms.Schedule(
+      process.simDoubletPath,process.endjob_step,process.DQMoutput_step
+)
+
+process.options = cms.untracked.PSet(
+    numberOfThreads = cms.untracked.uint32(1),
+    numberOfStreams = cms.untracked.uint32(1),
+    wantSummary = cms.untracked.bool(True)
+)

--- a/Validation/TrackingMCTruth/test/simDoubletsPhase2_HARVESTING.py
+++ b/Validation/TrackingMCTruth/test/simDoubletsPhase2_HARVESTING.py
@@ -1,0 +1,59 @@
+"""
+This script runs the harvesting step on top of the file `simDoublets_DQMIO.root` produced when running the
+simDoubletsPhase2_TEST.py script. To harvest simply run:
+
+cmsRun simDoubletsPhase2_HARVESTING.py
+
+This will produce a DQM file with all SimDoublets histograms.
+"""
+
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
+
+process = cms.Process('HARVESTING',Phase2C17I13M9)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.Geometry.GeometryExtendedRun4D110Reco_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.DQMSaverAtRunEnd_cff')
+process.load('Configuration.StandardSequences.Harvesting_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+# Input source
+process.source = cms.Source("DQMRootSource",
+    fileNames = cms.untracked.vstring('file:simDoublets_DQMIO.root')
+)
+
+process.options = cms.untracked.PSet(
+    Rethrow = cms.untracked.vstring('ProductNotFound'),
+    fileMode = cms.untracked.string('FULLMERGE')
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.19 $'),
+    annotation = cms.untracked.string('step4 nevts:100'),
+    name = cms.untracked.string('Applications')
+)
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T33', '')
+
+# Path and EndPath definitions
+process.load('Validation.TrackingMCTruth.PostProcessorSimDoublets_cff')  # load harvesting config for SimDoublets
+process.harvesting_step = cms.Path(process.postProcessorSimDoublets)
+process.dqmsave_step = cms.Path(process.DQMSaver)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.harvesting_step,process.dqmsave_step)

--- a/Validation/TrackingMCTruth/test/simDoubletsPhase2_TEST.py
+++ b/Validation/TrackingMCTruth/test/simDoubletsPhase2_TEST.py
@@ -1,0 +1,92 @@
+"""
+This script runs the SimDoubletsProducer and SimDoubletsAnalyzer for Phase2.
+
+To run it, you first have to produce or get the output root file from a step 2 that runs the HLT.
+The input file is expected to be named `step2.root` by default, but you can also rename it below.
+Then you can simply run the config using:
+
+cmsRun simDoubletsPhase2_TEST.py
+
+It will produce one DQMIO output file named `simDoublets_DQMIO.root`. 
+This can be further processed in the harvesting step by running the simDoubletsPhase2_HARVESTING.py script.
+"""
+inputFile = "step2.root"
+
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
+
+process = cms.Process("SIMDOUBLETS",Phase2C17I13M9)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1),
+    output = cms.optional.untracked.allowed(cms.int32,cms.PSet)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    dropDescendantsOfDroppedBranches = cms.untracked.bool(False),
+    fileNames = cms.untracked.vstring('file:%s' % inputFile),
+    inputCommands = cms.untracked.vstring(
+        'keep *',
+        'drop *_hltSiPixelRecHits_*_*'   # we will reproduce the PixelRecHits to have their local position available
+    ),
+    secondaryFileNames = cms.untracked.vstring()
+)
+
+### conditions
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T33', '')
+
+### standard includes
+process.load('Configuration/StandardSequences/Services_cff')
+process.load('Configuration.Geometry.GeometryExtendedRun4D110Reco_cff')
+process.load("Configuration.StandardSequences.RawToDigi_cff")
+process.load("Configuration.StandardSequences.Reconstruction_cff")
+process.load("Configuration.EventContent.EventContent_cff")
+process.load("Configuration.StandardSequences.MagneticField_cff")
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+
+### load hltSiPixelRecHits
+process.load("HLTrigger.Configuration.HLT_75e33.modules.hltSiPixelRecHits_cfi")
+### load hltTPClusterProducer
+process.load("Validation.RecoTrack.associators_cff")
+### load the new EDProducer "SimDoubletsProducerPhase2"
+process.load("SimTracker.TrackerHitAssociation.simDoubletsProducerPhase2_cfi")
+### load the new DQM EDAnalyzer "SimDoubletsAnalyzerPhase2"
+process.load("Validation.TrackingMCTruth.simDoubletsAnalyzerPhase2_cfi")
+
+####  set up the paths
+process.simDoubletPath = cms.Path(
+    process.hltSiPixelRecHits *         # reproduce the SiPixelRecHits
+    process.hltTPClusterProducer *      # run the cluster to TrackingParticle association
+    process.simDoubletsProducerPhase2 * # produce the SimDoublets
+    process.simDoubletsAnalyzerPhase2   # analyze the SimDoublets
+)
+
+# Output definition
+process.DQMoutput = cms.OutputModule("DQMRootOutputModule",
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('DQMIO'),
+        filterName = cms.untracked.string('')
+    ),
+    fileName = cms.untracked.string('file:simDoublets_DQMIO.root'),
+    outputCommands = process.DQMEventContent.outputCommands,
+    splitLevel = cms.untracked.int32(0)
+)
+
+
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.DQMoutput_step = cms.EndPath(process.DQMoutput)
+
+
+process.schedule = cms.Schedule(
+      process.simDoubletPath,process.endjob_step,process.DQMoutput_step
+)
+
+process.options = cms.untracked.PSet(
+    numberOfThreads = cms.untracked.uint32(1),
+    numberOfStreams = cms.untracked.uint32(1),
+    wantSummary = cms.untracked.bool(True)
+)


### PR DESCRIPTION
### PR description:
This PR proposes the addition of a new class of truth information for Pixel Tracking called `SimDoublets`. 

#### Description of the class `SimDoublets`
The purpose of `SimDoublets` is to improve the validation of Patatrack Pixel Tracking and to facilitate its optimization. The focus lies on the first step of Patatrack Pixel Tracking which is connecting Pixel RecHits from close by layers to form doublets of compatible hits. The compatibility of two RecHits is defined by a number of cuts on $\phi$, $z$ and cluster sizes. Each of those cuts has one cut parameter that should be tuned for achieving optimal performance. The new `SimDoublets` are the true doublets of RecHits coming from the same TrackingParticle and, therefore in this context, represent the ideal target outcome of the doublet creation. Hence, having the `SimDoublets` at hand, one can plot the distributions of all variables that are cut on during the doublet creation and apply those cuts on the true doublets alone. This enables efficiency determination on the doublet level, helping quantifying the performance and optimizing the cut values according to the true distributions.
*Additional material:* [Presentation on SimDoublets](https://indico.cern.ch/event/1498184/contributions/6361871/attachments/3012989/5313856/AlpakaPixelTrackingPhase2_TrackingPOG.pdf).

#### Proposed code changes
In order to implement this new class of `SimDoublets`, we propose the following changes:
1. **Addition of a persistent reference to `SiPixelRecHit` in `SiPixelRecHitFwd.h`:**
   Since the `SimDoublets` are essentially pairs of `SiPixelRecHit`s, we would like to store two persistent references to the RecHit objects in the `SiPixelRecHitCollection`. The reason why we prefer RecHits over clusters is that this is what is used in the Patatrack reconstruction.
2. **New class `SimDoublets` under `SimDataFormats/TrackingAnalysis` including EDProducer and EDAnalyzer:**
   The new class that stores references to the RecHits of a TrackingParticle and is able to produce of vector of RecHit doublets on the fly. The class comes alongside its own EDProducer (under `SimTracker/TrackerHitAssociation`) and DQM EDAnalyzer (under `Validation/TrackingMCTruth`). There is one producer and one analyzer for Phase 1 and Phase 2 respectively. We also added respective config files for testing the developments in `Validation/TrackingMCTruth/test`.
3. **Adding a `SingleMuPt15Eta0_0p4_cfi` workflow:**
   For testing purposes, we added this useful workflow to produce a pair of back-to-back muons of $p_T=15$ GeV in the barrel region of the Pixel Tracker with up to $|\eta|<0.4$.

#### Expected output changes
- No changes in output expected since `SimDoublets` are not part of any sequence or workflow.

#### Dependencies
- This PR does not depend on other PRs or externals.

### PR validation:
The following tests were performed succesfully.

#### 1. SimDoublets
The added test files in `Validation/TrackingMCTruth/test` were used to validate the `SimDoublets` code. For this the used data files were step-2 output files for `SingleMu` and `TTbar`. You can test the e.g. by producing `TTbar` samples with:
```bash
runTheMatrix.py --what upgrade -l 29634.0 --nThreads 10 --nEvents 10
```
Afterwards, go in `cd 29634.0_TTbar_14TeV+Run4D110` and run first:
```bash
cmsRun PathToCMSSW/src/Validation/TrackingMCTruth/test/simDoubletsPhase2_TEST.py
```
And then:
```bash
cmsRun PathToCMSSW/src/Validation/TrackingMCTruth/test/simDoubletsPhase2_HARVESTING.py
```

#### 2. Single muons workflow
Generate a `step1.root` file with the new `SingleMuPt15Eta0_0p4_cfi` workflow:
```bash
cmsDriver.py SingleMuPt15Eta0_0p4_cfi -s GEN,SIM -n 10 --conditions auto:phase2_realistic_T33 --beamspot DBrealisticHLLHC --datatier GEN-SIM --eventcontent FEVTDEBUG --geometry ExtendedRun4D110 --era Phase2C17I13M9 --relval 9000,100 --fileout file:step1.root 
```

#### Credits:
Authored together with with [@elenavernazza](https://github.com/elenavernazza), [@Parsifal-2045](https://github.com/Parsifal-2045) and [@mmusich](https://github.com/mmusich).

