### PR TITLE
Modernise the interface of `ObjectWithDict`

### DIFF
--- a/FWCore/Reflection/interface/ObjectWithDict.h
+++ b/FWCore/Reflection/interface/ObjectWithDict.h
@@ -23,20 +23,26 @@ namespace edm {
     static ObjectWithDict byType(TypeWithDict const&);
 
   public:
-    ObjectWithDict();
-    explicit ObjectWithDict(TypeWithDict const&, void* address);
-    explicit ObjectWithDict(std::type_info const&, void* address);
-    explicit operator bool() const;
-    void* address() const;
-    TypeWithDict typeOf() const;
+    ObjectWithDict() : address_(nullptr) {}
+    explicit ObjectWithDict(TypeWithDict const& type, void* address) : type_(type), address_(address) {}
+    explicit ObjectWithDict(std::type_info const& type, void* address) : type_(TypeWithDict(type)), address_(address) {}
+    explicit operator bool() const { return bool(type_) && (address_ != nullptr); }
+    void* address() const { return address_; }
+    TypeWithDict const& typeOf() const { return type_; }
     TypeWithDict dynamicType() const;
     ObjectWithDict castObject(TypeWithDict const&) const;
     ObjectWithDict get(std::string const& memberName) const;
     //ObjectWithDict construct() const;
     void destruct(bool dealloc) const;
+
     template <typename T>
-    T objectCast() {
-      return *reinterpret_cast<T*>(address_);
+    T& objectCast() {
+      return *reinterpret_cast<T*>(address());
+    }
+
+    template <typename T>
+    T const& objectCast() const {
+      return *reinterpret_cast<T*>(address());
     }
   };
 

--- a/FWCore/Reflection/src/ObjectWithDict.cc
+++ b/FWCore/Reflection/src/ObjectWithDict.cc
@@ -1,12 +1,11 @@
-#include "FWCore/Reflection/interface/ObjectWithDict.h"
-
-#include "FWCore/Reflection/interface/BaseWithDict.h"
-#include "FWCore/Reflection/interface/MemberWithDict.h"
-#include "FWCore/Reflection/interface/TypeWithDict.h"
-
 #ifndef _LIBCPP_VERSION
 #include <cxxabi.h>
 #endif
+
+#include "FWCore/Reflection/interface/BaseWithDict.h"
+#include "FWCore/Reflection/interface/MemberWithDict.h"
+#include "FWCore/Reflection/interface/ObjectWithDict.h"
+#include "FWCore/Reflection/interface/TypeWithDict.h"
 
 namespace edm {
 
@@ -15,19 +14,6 @@ namespace edm {
     return obj;
   }
 
-  ObjectWithDict::ObjectWithDict() : type_(), address_(nullptr) {}
-
-  ObjectWithDict::ObjectWithDict(TypeWithDict const& type, void* address) : type_(type), address_(address) {}
-
-  ObjectWithDict::ObjectWithDict(std::type_info const& ti, void* address)
-      : type_(TypeWithDict(ti)), address_(address) {}
-
-  ObjectWithDict::operator bool() const { return bool(type_) && (address_ != nullptr); }
-
-  void* ObjectWithDict::address() const { return address_; }
-
-  TypeWithDict ObjectWithDict::typeOf() const { return type_; }
-
   class DummyVT {
   public:
     virtual ~DummyVT();
@@ -35,6 +21,7 @@ namespace edm {
 
   DummyVT::~DummyVT() {}
 
+  // FIXME improve TypeWithDict::byTypeInfo to return by const& and return by const& here
   TypeWithDict ObjectWithDict::dynamicType() const {
     if (!type_.isVirtual()) {
       return type_;


### PR DESCRIPTION
#### PR description:

Modernise the interface of `ObjectWithDict`:
  - move trivial methods into the class definition;
  - rewrite accessors to return by (const) reference instead of by value.

#### PR validation:

Unit tests pass.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 15.0.x as part of the MPI work.