### PR TITLE
Implement `edm::ProductNamePattern`

### DIFF
--- a/DataFormats/Provenance/BuildFile.xml
+++ b/DataFormats/Provenance/BuildFile.xml
@@ -1,5 +1,6 @@
 <use name="FWCore/Utilities"/>
 <use name="FWCore/Reflection"/>
+<use name="boost_header"/>
 <use name="rootcore"/>
 <use name="tbb"/>
 <export>

--- a/DataFormats/Provenance/interface/ProductNamePattern.h
+++ b/DataFormats/Provenance/interface/ProductNamePattern.h
@@ -1,0 +1,67 @@
+#ifndef DataFormats_Provenance_interface_ProductNamePattern_h
+#define DataFormats_Provenance_interface_ProductNamePattern_h
+
+#include <string>
+#include <regex>
+#include <vector>
+
+#include "DataFormats/Provenance/interface/ProductDescription.h"
+
+namespace edm {
+
+  /* ProductNamePattern
+   *
+   * A ProductNamePattern is constructed from a string representing either a module label (e.g. "<module label>") or a
+   * a branch name (e.g. "<product type>_<module label>_<instance name>_<process name>").
+   *
+   * A ProductNamePattern object can be compared with a ProductDescription object using the match() method:
+   *
+   *     productPattern.match(product)
+   *
+   * .
+   * Glob expressions ("?" and "*") are supported in module labels and within the individual fields of branch names,
+   * similar to an OutputModule's "keep" statements.
+   * Use "*" to match all products of a given category.
+   *
+   * If a module label is used, it must not contain any underscores ("_"); the resulting ProductNamePattern will match all
+   * the branches prodced by a module with the given label, including those with a non-empty instance names, and those
+   * produced by the Transformer functionality (such as the implicitly copied-to-host products in case of Alpaka-based
+   * modules).
+   * If a branch name is used, all four fields must be present, separated by underscores; the resulting ProductNamePattern
+   * will match the branches matching all four fields.
+   * Only in this case and only for transient products, the module label may contain additional underscores.
+   *
+   * For example, in the case of products from an Alpaka-based producer running on a device
+   *
+   *     ProductNamePattern("module")
+   *
+   * would match all branches produced by "module", including the automatic host copy of its device products.
+   * While
+   *
+   *     ProductNamePattern( "*DeviceProduct_module_*_*" )
+   *
+   * would match only the branches corresponding to the device products.
+   */
+
+  class ProductNamePattern {
+  public:
+    explicit ProductNamePattern(std::string const& label);
+
+    bool match(edm::ProductDescription const& product) const;
+
+  private:
+    std::regex type_;
+    std::regex moduleLabel_;
+    std::regex productInstanceName_;
+    std::regex processName_;
+  };
+
+  /* productPatterns
+   *
+   * Utility function to construct a vector<edm::ProductNamePattern> from a vector<std::string>.
+   */
+  std::vector<ProductNamePattern> productPatterns(std::vector<std::string> const& labels);
+
+}  // namespace edm
+
+#endif  // DataFormats_Provenance_interface_ProductNamePattern_h

--- a/DataFormats/Provenance/src/ProductNamePattern.cc
+++ b/DataFormats/Provenance/src/ProductNamePattern.cc
@@ -1,0 +1,106 @@
+#include <algorithm>
+#include <string>
+#include <string_view>
+#include <regex>
+#include <vector>
+
+#include <boost/algorithm/string/replace.hpp>
+
+#include "DataFormats/Provenance/interface/ProductNamePattern.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+
+namespace edm {
+
+  /* glob_to_regex
+   *
+   * Utility function to convert a shell-like glob expression to a regex.
+   */
+  static std::regex glob_to_regex(std::string pattern) {
+    boost::replace_all(pattern, "*", ".*");
+    boost::replace_all(pattern, "?", ".");
+    return std::regex(pattern);
+  }
+
+  /* ProductNamePattern
+   *
+   * A ProductNamePattern is constructed from a string representing either a module label (e.g. "<module label>") or a
+   * a branch name (e.g. "<product type>_<module label>_<instance name>_<process name>").
+   *
+   * For transient products, the module label may contain additional underscores.
+   *
+   * See DataFormats/Provenance/interface/ProductNamePattern.h for more details.
+   */
+  ProductNamePattern::ProductNamePattern(std::string const& label) {
+    static constexpr char kSeparator = '_';
+    static constexpr std::string_view kWildcard{"*"};
+    static const std::regex kAny{".*"};
+    static const std::regex kFields{"([a-zA-Z0-9*]+)_([a-zA-Z0-9_*]+)_([a-zA-Z0-9*]*)_([a-zA-Z0-9*]+)"};
+
+    // empty label
+    if (label.empty()) {
+      throw edm::Exception(edm::errors::Configuration) << "Invalid module label or branch name: \"" << label << "\"";
+    }
+
+    // wildcard
+    if (label == kWildcard) {
+      type_ = kAny;
+      moduleLabel_ = kAny;
+      productInstanceName_ = kAny;
+      processName_ = kAny;
+      return;
+    }
+
+    int underscores = std::count(label.begin(), label.end(), kSeparator);
+    if (underscores == 0) {
+      // Convert the module label into a regular expression.
+      type_ = kAny;
+      moduleLabel_ = glob_to_regex(label);
+      productInstanceName_ = kAny;
+      processName_ = kAny;
+      return;
+    }
+
+    if (underscores >= 3) {
+      // Split the branch name into <product type>_<module label>_<instance name>_<process name>
+      // and convert the glob expressions into regular expressions.
+      // Note that:
+      //   - the <instance name> may be empty;
+      //   - for non-persistable branches, <module label> may contain additional underscores.
+      std::smatch fields;
+      if (std::regex_match(label, fields, kFields)) {
+        type_ = glob_to_regex(fields[1]);
+        moduleLabel_ = glob_to_regex(fields[2]);
+        productInstanceName_ = glob_to_regex(fields[3]);
+        processName_ = glob_to_regex(fields[4]);
+        return;
+      }
+    }
+
+    // Invalid input.
+    throw edm::Exception(edm::errors::Configuration) << "Invalid module label or branch name: \"" << label << "\"";
+  }
+
+  /* ProductNamePattern::match
+   *
+   * Compare a ProductNamePattern object with a ProductDescription object.
+   */
+  bool ProductNamePattern::match(edm::ProductDescription const& product) const {
+    return (std::regex_match(product.friendlyClassName(), type_) and
+            std::regex_match(product.moduleLabel(), moduleLabel_) and
+            std::regex_match(product.productInstanceName(), productInstanceName_) and
+            std::regex_match(product.processName(), processName_));
+  }
+
+  /* productPatterns
+   *
+   * Utility function to construct a vector<edm::ProductNamePattern> from a vector<std::string>.
+   */
+  std::vector<ProductNamePattern> productPatterns(std::vector<std::string> const& labels) {
+    std::vector<ProductNamePattern> patterns;
+    patterns.reserve(labels.size());
+    for (auto const& label : labels)
+      patterns.emplace_back(label);
+    return patterns;
+  }
+
+}  // namespace edm

--- a/DataFormats/Provenance/test/BuildFile.xml
+++ b/DataFormats/Provenance/test/BuildFile.xml
@@ -3,7 +3,7 @@
 <use name="DataFormats/Provenance"/>
 </bin>
 
-<bin name="testDataFormatsProvenanceCatch2" file="ElementID_t.cpp,Parentage_t.cpp,StoredProcessBlockHelper_t.cpp,CompactHash_t.cpp,HardwareResourcesDescription_t.cpp">
+<bin name="testDataFormatsProvenanceCatch2" file="ElementID_t.cpp,Parentage_t.cpp,StoredProcessBlockHelper_t.cpp,CompactHash_t.cpp,HardwareResourcesDescription_t.cpp,ProductNamePattern_t.cpp">
   <use name="DataFormats/Provenance"/>
   <use name="catch2"/>
 </bin>

--- a/DataFormats/Provenance/test/ProductNamePattern_t.cpp
+++ b/DataFormats/Provenance/test/ProductNamePattern_t.cpp
@@ -1,0 +1,133 @@
+#include <cassert>
+#include <iostream>
+
+#include <catch.hpp>
+
+#include "DataFormats/Provenance/interface/ProductNamePattern.h"
+#include "DataFormats/Provenance/interface/ProductDescription.h"
+#include "DataFormats/TestObjects/interface/ToyProducts.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+namespace {
+
+  template <typename T>
+  edm::ProductDescription make_ProductDescription(std::string const& module,
+                                                  std::string const& instance,
+                                                  std::string const& process) {
+    edm::TypeWithDict type(typeid(T));
+    edm::ProductDescription prod(edm::InEvent, module, process, type.name(), type.friendlyClassName(), instance, type);
+    //prod.write(std::cerr);
+    return prod;
+  }
+
+}  // namespace
+
+TEST_CASE("test ProductNamePattern", "[ProductNamePattern]") {
+  // int_module__TEST
+  edm::ProductDescription prod1 = make_ProductDescription<int>("module", "", "TEST");
+  // int_other__TEST
+  edm::ProductDescription prod2 = make_ProductDescription<int>("other", "", "TEST");
+  // int_module_label_TEST
+  edm::ProductDescription prod3 = make_ProductDescription<int>("module", "label", "TEST");
+  // int_module__PROC
+  edm::ProductDescription prod4 = make_ProductDescription<int>("module", "", "PROC");
+  // double_module__TEST
+  edm::ProductDescription prod5 = make_ProductDescription<double>("module", "", "TEST");
+  // Only transient products may have additional underscores in the module label.
+  CHECK_THROWS(make_ProductDescription<bool>("transient_module", "", "TEST"));
+  // edmtestTransientIntProduct_transient_module__TEST
+  edm::ProductDescription prod6 = make_ProductDescription<edmtest::TransientIntProduct>("transient_module", "", "TEST");
+
+  SECTION("Invalid pattern \"\"") {
+    // An empty pattern is invalid.
+    CHECK_THROWS_AS(edm::ProductNamePattern(""), edm::Exception);
+  }
+
+  SECTION("Simple pattern \"module\"") {
+    // A simple pattern consisting only of a single field, without any underscores, is interpreted as a module label.
+    edm::ProductNamePattern pattern("module");
+    CHECK(pattern.match(prod1));
+    CHECK(not pattern.match(prod2));
+    CHECK(pattern.match(prod3));
+    CHECK(pattern.match(prod4));
+    CHECK(pattern.match(prod5));
+    CHECK(not pattern.match(prod6));
+  }
+
+  SECTION("Invalid pattern \"transient_module\"") {
+    // A pattern with a single underscore is invalid.
+    CHECK_THROWS_AS(edm::ProductNamePattern("transient_module"), edm::Exception);
+  }
+
+  SECTION("Invalid pattern \"transient_module_label\"") {
+    // A pattern with two underscores is invalid.
+    CHECK_THROWS_AS(edm::ProductNamePattern("transient_module_label"), edm::Exception);
+  }
+
+  SECTION("Full branch pattern \"int_module__TEST\"") {
+    // A full branch pattern must contain four fields, separated by an underscore.
+    edm::ProductNamePattern pattern("int_module__TEST");
+    CHECK(pattern.match(prod1));
+    CHECK(not pattern.match(prod2));
+    CHECK(not pattern.match(prod3));
+    CHECK(not pattern.match(prod4));
+    CHECK(not pattern.match(prod5));
+    CHECK(not pattern.match(prod6));
+  }
+
+  SECTION("Simple wildcard \"*\"") {
+    // A single * is interpreted as a wildcard that matches all branches.
+    edm::ProductNamePattern pattern("*");
+    CHECK(pattern.match(prod1));
+    CHECK(pattern.match(prod2));
+    CHECK(pattern.match(prod3));
+    CHECK(pattern.match(prod4));
+    CHECK(pattern.match(prod5));
+    CHECK(pattern.match(prod6));
+  }
+
+  SECTION("Full branch wildcard \"*_*_*_*\"") {
+    // Individual fields can be represented by a wildcard.
+    edm::ProductNamePattern pattern("*_*_*_*");
+    CHECK(pattern.match(prod1));
+    CHECK(pattern.match(prod2));
+    CHECK(pattern.match(prod3));
+    CHECK(pattern.match(prod4));
+    CHECK(pattern.match(prod5));
+    CHECK(pattern.match(prod6));
+  }
+
+  SECTION("Branch wildcard with module label \"*_module_*_*\"") {
+    // Individual fields can be represented by a wildcard.
+    edm::ProductNamePattern pattern("*_module_*_*");
+    CHECK(pattern.match(prod1));
+    CHECK(not pattern.match(prod2));
+    CHECK(pattern.match(prod3));
+    CHECK(pattern.match(prod4));
+    CHECK(pattern.match(prod5));
+    CHECK(not pattern.match(prod6));
+  }
+
+  SECTION("Branch wildcard with module label \"*_transient_module_*_*\"") {
+    // The module label may contain additional underscores.
+    edm::ProductNamePattern pattern("*_transient_module_*_*");
+    CHECK(not pattern.match(prod1));
+    CHECK(not pattern.match(prod2));
+    CHECK(not pattern.match(prod3));
+    CHECK(not pattern.match(prod4));
+    CHECK(not pattern.match(prod5));
+    CHECK(pattern.match(prod6));
+  }
+
+  SECTION("Branch wildcard with process name \"*_*_*_TEST\"") {
+    // Individual fields can be represented by a wildcard.
+    edm::ProductNamePattern pattern("*_*_*_TEST");
+    CHECK(pattern.match(prod1));
+    CHECK(pattern.match(prod2));
+    CHECK(pattern.match(prod3));
+    CHECK(not pattern.match(prod4));
+    CHECK(pattern.match(prod5));
+    CHECK(pattern.match(prod6));
+  }
+}

--- a/FWCore/Modules/src/GenericConsumer.cc
+++ b/FWCore/Modules/src/GenericConsumer.cc
@@ -34,86 +34,13 @@
 #include <boost/algorithm/string/replace.hpp>
 
 #include "DataFormats/Provenance/interface/ProductDescription.h"
+#include "DataFormats/Provenance/interface/ProductNamePattern.h"
 #include "FWCore/Framework/interface/global/EDAnalyzer.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterDescriptionNode.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-
-namespace {
-  struct ProductBranch {
-  public:
-    ProductBranch(std::string const& label) {
-      static const char kSeparator = '_';
-      static const char kWildcard = '*';
-      static const std::regex kAny{".*"};
-
-      // wildcard
-      if (label == kWildcard) {
-        type_ = kAny;
-        moduleLabel_ = kAny;
-        productInstanceName_ = kAny;
-        processName_ = kAny;
-        return;
-      }
-
-      int fields = std::count(label.begin(), label.end(), kSeparator) + 1;
-      if (fields == 1) {
-        // convert the module label into a regular expression
-        type_ = kAny;
-        moduleLabel_ = glob_to_regex(label);
-        productInstanceName_ = kAny;
-        processName_ = kAny;
-      } else if (fields == 4) {
-        // split the branch name into <product type>_<module label>_<instance name>_<process name>
-        // and convert the glob expressions into regular expressions
-        size_t first = 0, last = 0;
-        last = label.find(kSeparator, first);
-        type_ = glob_to_regex(label.substr(first, last - first));
-        first = last + 1;
-        last = label.find(kSeparator, first);
-        moduleLabel_ = glob_to_regex(label.substr(first, last - first));
-        first = last + 1;
-        last = label.find(kSeparator, first);
-        productInstanceName_ = glob_to_regex(label.substr(first, last - first));
-        first = last + 1;
-        last = label.find(kSeparator, first);
-        processName_ = glob_to_regex(label.substr(first, last - first));
-      } else {
-        // invalid input
-        throw edm::Exception(edm::errors::Configuration) << "Invalid module label or branch name: \"" << label << "\"";
-      }
-    }
-
-    bool match(edm::ProductDescription const& branch) const {
-      return (std::regex_match(branch.friendlyClassName(), type_) and
-              std::regex_match(branch.moduleLabel(), moduleLabel_) and
-              std::regex_match(branch.productInstanceName(), productInstanceName_) and
-              std::regex_match(branch.processName(), processName_));
-    }
-
-  private:
-    static std::regex glob_to_regex(std::string pattern) {
-      boost::replace_all(pattern, "*", ".*");
-      boost::replace_all(pattern, "?", ".");
-      return std::regex(pattern);
-    }
-
-    std::regex type_;
-    std::regex moduleLabel_;
-    std::regex productInstanceName_;
-    std::regex processName_;
-  };
-
-  std::vector<ProductBranch> make_patterns(std::vector<std::string> const& labels) {
-    std::vector<ProductBranch> patterns;
-    patterns.reserve(labels.size());
-    for (auto const& label : labels)
-      patterns.emplace_back(label);
-    return patterns;
-  }
-}  // namespace
 
 namespace edm {
   class GenericConsumer : public edm::global::EDAnalyzer<> {
@@ -126,19 +53,20 @@ namespace edm {
     static void fillDescriptions(ConfigurationDescriptions& descriptions);
 
   private:
-    std::vector<ProductBranch> eventProducts_;
-    std::vector<ProductBranch> lumiProducts_;
-    std::vector<ProductBranch> runProducts_;
-    std::vector<ProductBranch> processProducts_;
+    std::vector<edm::ProductNamePattern> eventProducts_;
+    std::vector<edm::ProductNamePattern> lumiProducts_;
+    std::vector<edm::ProductNamePattern> runProducts_;
+    std::vector<edm::ProductNamePattern> processProducts_;
     std::string label_;
     bool verbose_;
   };
 
   GenericConsumer::GenericConsumer(ParameterSet const& config)
-      : eventProducts_(make_patterns(config.getUntrackedParameter<std::vector<std::string>>("eventProducts"))),
-        lumiProducts_(make_patterns(config.getUntrackedParameter<std::vector<std::string>>("lumiProducts"))),
-        runProducts_(make_patterns(config.getUntrackedParameter<std::vector<std::string>>("runProducts"))),
-        processProducts_(make_patterns(config.getUntrackedParameter<std::vector<std::string>>("processProducts"))),
+      : eventProducts_(edm::productPatterns(config.getUntrackedParameter<std::vector<std::string>>("eventProducts"))),
+        lumiProducts_(edm::productPatterns(config.getUntrackedParameter<std::vector<std::string>>("lumiProducts"))),
+        runProducts_(edm::productPatterns(config.getUntrackedParameter<std::vector<std::string>>("runProducts"))),
+        processProducts_(
+            edm::productPatterns(config.getUntrackedParameter<std::vector<std::string>>("processProducts"))),
         label_(config.getParameter<std::string>("@module_label")),
         verbose_(config.getUntrackedParameter<bool>("verbose")) {
     callWhenNewProductsRegistered([this](edm::ProductDescription const& branch) {


### PR DESCRIPTION
#### PR description:

Implement `edm::ProductNamePattern`, a type that can be used to match product names based on their friendly type, module name, instance label and process name.

Implement a unit test for `edm::ProductNamePattern`.

Refactor `edm::GenericConsumer` to use `edm::ProductNamePattern`.

#### PR validation:

Unit tests pass.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 15.0.x as part of the MPI work.