### PR TITLE
[GEM][backport] turning on the applyMasking for 2025 Run 3 GEM data taking [15.0.x]

### DIFF
--- a/Configuration/Eras/python/Era_Run3_2025_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2025_cff.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Run3_2024_cff import Run3_2024
+from Configuration.Eras.Modifier_run3_GEM_2025_cff import run3_GEM_2025
 
-Run3_2025 = cms.ModifierChain(Run3_2024)
+Run3_2025 = cms.ModifierChain(Run3_2024, run3_GEM_2025)

--- a/Configuration/Eras/python/Modifier_run3_GEM_2025_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_GEM_2025_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+run3_GEM_2025 =  cms.Modifier()
+

--- a/RecoLocalMuon/GEMRecHit/python/gemRecHits_cfi.py
+++ b/RecoLocalMuon/GEMRecHit/python/gemRecHits_cfi.py
@@ -12,7 +12,9 @@ gemRecHits = gemRecHitsDef.clone(
 
 
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
+from Configuration.Eras.Modifier_run3_GEM_2025_cff import run3_GEM_2025
 from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
 
-run3_GEM.toModify(gemRecHits, ge21Off=True)
-phase2_GEM.toModify(gemRecHits, ge21Off=False)
+run3_GEM.toModify(gemRecHits, ge21Off=True, applyMasking=False)
+run3_GEM_2025.toModify(gemRecHits, ge21Off=True, applyMasking=True)
+phase2_GEM.toModify(gemRecHits, ge21Off=False, applyMasking=False)


### PR DESCRIPTION
#### PR description:

* GEM strip masking was started in the middle of 2023 to avoid a high trigger rate which is caused by noisy channels
* This PR enables clustering by considering the strip masking on the local reconstruction of GEM.
* The PR couldn't be made because no `GEMDeadSrtripsRcd` and `GEMMaskedStripsRcd` existed in any global tag.
* The `GEMDeadStripsRcd` and `GEMMaskedStripsRcd` have been on the condDB recently.
* At the moment, the `GEMDeadStripsRcd` and `GEMMaskedStripsRcd` are empty. So we don't expect any changes in the result.
* The change is confined to the 2025 scenario only.

#### PR validation:

* The `scram b code-format` and `scram b code-checks` are applied.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

* This PR is a backport of the PR #47257 
