### PR TITLE
[15_0_X] Combined backport of #47430 and #47418

### DIFF
--- a/DQM/Integration/python/clients/onlinebeammonitor_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/onlinebeammonitor_dqm_sourceclient-live_cfg.py
@@ -26,76 +26,8 @@ unitTest = 'unitTest=True' in sys.argv
 
 #-----------------------------
 if unitTest:
-  import FWCore.ParameterSet.VarParsing as VarParsing
-  options = VarParsing.VarParsing("analysis")
-
-  options.register(
-      "runkey",
-      "pp_run",
-      VarParsing.VarParsing.multiplicity.singleton,
-      VarParsing.VarParsing.varType.string,
-      "Run Keys of CMS"
-  )
-
-  options.register('runNumber',
-                  346508,
-                  VarParsing.VarParsing.multiplicity.singleton,
-                  VarParsing.VarParsing.varType.int,
-                  "Run number. This run number has to be present in the dataset configured with the dataset option.")
-
-  options.register('dataset',
-                  '/ExpressPhysics/Commissioning2021-Express-v1/FEVT',
-                  VarParsing.VarParsing.multiplicity.singleton,
-                  VarParsing.VarParsing.varType.string,
-                  "Dataset name like '/ExpressCosmics/Commissioning2019-Express-v1/FEVT'")
-
-  options.register('maxLumi',
-                  2,
-                  VarParsing.VarParsing.multiplicity.singleton,
-                  VarParsing.VarParsing.varType.int,
-                  "Only lumisections up to maxLumi are processed.")
-
-  options.register('minLumi',
-                  1,
-                  VarParsing.VarParsing.multiplicity.singleton,
-                  VarParsing.VarParsing.varType.int,
-                  "Only lumisections starting from minLumi are processed.")
-
-  options.register('lumiPattern',
-                  '*',
-                  VarParsing.VarParsing.multiplicity.singleton,
-                  VarParsing.VarParsing.varType.string,
-                  "Only lumisections with numbers matching lumiPattern are processed.")
-
-  options.register('eventsPerLumi',
-                  100,
-                  VarParsing.VarParsing.multiplicity.singleton,
-                  VarParsing.VarParsing.varType.int,
-                  "This number of last events in each lumisection will be processed.")
-
-  # This is used only by the online clients themselves. 
-  # We need to register it here because otherwise an error occurs saying that there is an unidentified option.
-  options.register('unitTest',
-                  True,
-                  VarParsing.VarParsing.multiplicity.singleton,
-                  VarParsing.VarParsing.varType.bool,
-                  "Required to avoid the error.")
-
-  options.register('noDB',
-                  True, # default value
-                  VarParsing.VarParsing.multiplicity.singleton,
-                  VarParsing.VarParsing.varType.bool,
-                  "Don't upload the BeamSpot conditions to the DB")
-
-  options.parseArguments()
-  
-  process.source = cms.Source("EmptySource")
-  process.source.numberEventsInRun=cms.untracked.uint32(100)
-  process.source.firstRun = cms.untracked.uint32(options.runNumber)
-  process.source.firstLuminosityBlock = cms.untracked.uint32(1)
-  process.source.numberEventsInLuminosityBlock = cms.untracked.uint32(2)
-  process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(100))
-
+  process.load("DQM.Integration.config.unitteststreamerinputsource_cfi")
+  from DQM.Integration.config.unitteststreamerinputsource_cfi import options
 else:
   process.load("DQM.Integration.config.inputsource_cfi")
   from DQM.Integration.config.inputsource_cfi import options

--- a/DQM/Integration/test/BuildFile.xml
+++ b/DQM/Integration/test/BuildFile.xml
@@ -24,7 +24,7 @@
 <!-- <test name="TestDQMOnlineClient-scal_dqm_sourceclient" command="runtest.sh scal_dqm_sourceclient-live_cfg.py"/> -->
 <test name="TestDQMOnlineClient-sistrip_dqm_sourceclient" command="runtest.sh sistrip_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-sistrip_approx_dqm_sourceclient" command="runtest.sh sistrip_approx_dqm_sourceclient-live_cfg.py 362321 hi_run"/>
-<test name="TestDQMOnlineClient-onlinebeammonitor_dqm_sourceclient" command="runtest.sh onlinebeammonitor_dqm_sourceclient-live_cfg.py"/>
+<test name="TestDQMOnlineClient-onlinebeammonitor_dqm_sourceclient" command="runtest.sh onlinebeammonitor_dqm_sourceclient-live_cfg.py 381594 pp_run"/>
 <test name="TestDQMOnlineClient-ecalgpu_dqm_sourceclient" command="runtest.sh ecalgpu_dqm_sourceclient-live_cfg.py 381594"/>
 <test name="TestDQMOnlineClient-hcalgpu_dqm_sourceclient" command="runtest.sh hcalgpu_dqm_sourceclient-live_cfg.py 381594"/>
 <test name="TestDQMOnlineClient-pixelgpu_dqm_sourceclient" command="runtest.sh pixelgpu_dqm_sourceclient-live_cfg.py 381594"/>

--- a/DQMServices/StreamerIO/plugins/DQMStreamerReader.cc
+++ b/DQMServices/StreamerIO/plugins/DQMStreamerReader.cc
@@ -172,7 +172,7 @@ namespace dqmservices {
         if (unitTest_) {
           throw edm::Exception(edm::errors::FileReadError, "DQMStreamerReader::openNextFileInp")
               << std::string("Can't deserialize registry data (in open file): ") + e.what()
-              << "\n error: data file corrupted";
+              << "\n error: data file corrupted, rethrowing!";
         }
 
         fiterator_.logFileAction(std::string("Can't deserialize registry data (in open file): ") + e.what(), p);
@@ -354,6 +354,12 @@ namespace dqmservices {
 
       deserializeEvent(*eview);
     } catch (const cms::Exception& e) {
+      if (unitTest_) {
+        throw edm::Exception(edm::errors::FileReadError, "DQMStreamerReader::checkNext")
+            << std::string("Can't deserialize event or registry data: ") + e.what()
+            << "\n error: data file corrupted, rethrowing!";
+      }
+
       // try to recover from corrupted files/events
       fiterator_.logFileAction(std::string("Can't deserialize event or registry data: ") + e.what());
       closeFileImp_("data file corrupted");
@@ -435,6 +441,11 @@ namespace dqmservices {
         }
       }
     } catch (const cms::Exception& e) {
+      if (unitTest_) {
+        throw edm::Exception(edm::errors::FileReadError, "DQMStreamerReader::skip")
+            << std::string("Can't deserialize registry data: ") + e.what()
+            << "\n error: data file corrupted, rethrowing!";
+      }
       // try to recover from corrupted files/events
       fiterator_.logFileAction(std::string("Can't deserialize event data: ") + e.what());
       closeFileImp_("data file corrupted");


### PR DESCRIPTION
#### PR description:
Combined backport of:
- #47418: move unit test for `onlinebeammonitor_dqm_sourceclient-live` to use streamer files
- #47430: `DQMStreamerReader`: re-throw all exceptions when run in unit test mode

FYI @mmusich

#### PR validation:
This needs a backport of https://github.com/cms-sw/cmsdist/pull/9718 to `IB/CMSSW_15_0_X/master/` @smuzaffar should I take care of preparing it?

#### Backport:
Combined backport of #47418 and #47430