### PR TITLE
Monitor quality of unpacked FED data with a dedicated SoA

### DIFF
--- a/DataFormats/HGCalDigi/interface/HGCalECONDPacketInfoSoA.h
+++ b/DataFormats/HGCalDigi/interface/HGCalECONDPacketInfoSoA.h
@@ -20,16 +20,20 @@ namespace hgcaldigi {
   }  // namespace ECONDFlag
 
   // functions to parse ECONDFlag
-  inline bool truncatedFlag(uint8_t econdFlag) { return ((econdFlag >> hgcaldigi::ECONDFlag::BITT_POS) & 0b1); }
-  inline bool matchFlag(uint8_t econdFlag) { return ((econdFlag >> hgcaldigi::ECONDFlag::BITM_POS) & 0b1); }
-  inline uint8_t eboFlag(uint8_t econdFlag) {
+  inline constexpr bool truncatedFlag(uint8_t econdFlag) {
+    return ((econdFlag >> hgcaldigi::ECONDFlag::BITT_POS) & 0b1);
+  }
+  inline constexpr bool matchFlag(uint8_t econdFlag) { return ((econdFlag >> hgcaldigi::ECONDFlag::BITM_POS) & 0b1); }
+  inline constexpr uint8_t eboFlag(uint8_t econdFlag) {
     return ((econdFlag >> hgcaldigi::ECONDFlag::EBO_POS) & hgcaldigi::ECONDFlag::EBO_MASK);
   }
-  inline uint8_t htFlag(uint8_t econdFlag) {
+  inline constexpr uint8_t htFlag(uint8_t econdFlag) {
     return ((econdFlag >> hgcaldigi::ECONDFlag::HT_POS) & hgcaldigi::ECONDFlag::HT_MASK);
   }
-  inline bool expectedFlag(uint8_t econdFlag) { return ((econdFlag >> hgcaldigi::ECONDFlag::BITE_POS) & 0b1); }
-  inline bool StatFlag(uint8_t econdFlag) { return ((econdFlag >> hgcaldigi::ECONDFlag::BITS_POS) & 0b1); }
+  inline constexpr bool expectedFlag(uint8_t econdFlag) {
+    return ((econdFlag >> hgcaldigi::ECONDFlag::BITE_POS) & 0b1);
+  }
+  inline constexpr bool StatFlag(uint8_t econdFlag) { return ((econdFlag >> hgcaldigi::ECONDFlag::BITS_POS) & 0b1); }
 
   // generate structure of arrays (SoA) layout with Digi dataformat
   GENERATE_SOA_LAYOUT(HGCalECONDPacketInfoSoALayout,

--- a/DataFormats/HGCalDigi/interface/HGCalFEDPacketInfoHost.h
+++ b/DataFormats/HGCalDigi/interface/HGCalFEDPacketInfoHost.h
@@ -1,0 +1,13 @@
+#ifndef DataFormats_HGCalDigi_interface_HGCalFEDPacketInfoHost_h
+#define DataFormats_HGCalDigi_interface_HGCalFEDPacketInfoHost_h
+
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+#include "DataFormats/HGCalDigi/interface/HGCalFEDPacketInfoSoA.h"
+
+namespace hgcaldigi {
+
+  using HGCalFEDPacketInfoHost = PortableHostCollection<HGCalFEDPacketInfoSoA>;
+
+}  // namespace hgcaldigi
+
+#endif

--- a/DataFormats/HGCalDigi/interface/HGCalFEDPacketInfoSoA.h
+++ b/DataFormats/HGCalDigi/interface/HGCalFEDPacketInfoSoA.h
@@ -1,0 +1,66 @@
+#ifndef DataFormats_HGCalDigi_interface_HGCalFEDPacketInfoSoA_h
+#define DataFormats_HGCalDigi_interface_HGCalFEDPacketInfoSoA_h
+
+#include <cstdint>  // for uint8_t
+
+#include <Eigen/Core>
+
+#include "DataFormats/SoATemplate/interface/SoACommon.h"
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+#include "DataFormats/SoATemplate/interface/SoAView.h"
+
+namespace hgcaldigi {
+
+  namespace FEDUnpackingFlags {
+    constexpr uint8_t NormalUnpacking = 0, GenericUnpackError = 1, ErrorSLinkHeader = 2, ErrorPayload = 3,
+                      ErrorCaptureBlockHeader = 4, ActiveCaptureBlockFlags = 5, ErrorECONDHeader = 6,
+                      ECONDPayloadLengthOverflow = 7, ECONDPayloadLengthMismatch = 8, ErrorSLinkTrailer = 9,
+                      EarlySLinkEnd = 10;
+  }  // namespace FEDUnpackingFlags
+
+  inline constexpr bool isNotNormalFED(uint16_t fedUnpackingFlag) {
+    return !((fedUnpackingFlag >> FEDUnpackingFlags::NormalUnpacking) & 0x1);
+  }
+  inline constexpr bool hasGenericUnpackError(uint16_t fedUnpackingFlag) {
+    return ((fedUnpackingFlag >> FEDUnpackingFlags::GenericUnpackError) & 0x1);
+  }
+  inline constexpr bool hasHeaderUnpackError(uint16_t fedUnpackingFlag) {
+    return ((fedUnpackingFlag >> FEDUnpackingFlags::ErrorSLinkHeader) & 0x1);
+  }
+  inline constexpr bool hasPayloadUnpackError(uint16_t fedUnpackingFlag) {
+    return ((fedUnpackingFlag >> FEDUnpackingFlags::ErrorPayload) & 0x1);
+  }
+  inline constexpr bool hasCBHeaderError(uint16_t fedUnpackingFlag) {
+    return ((fedUnpackingFlag >> FEDUnpackingFlags::ErrorCaptureBlockHeader) & 0x1);
+  }
+  inline constexpr bool hasCBActiveFlags(uint16_t fedUnpackingFlag) {
+    return ((fedUnpackingFlag >> FEDUnpackingFlags::ActiveCaptureBlockFlags) & 0x1);
+  }
+  inline constexpr bool hasErrorECONDHeader(uint16_t fedUnpackingFlag) {
+    return ((fedUnpackingFlag >> FEDUnpackingFlags::ErrorECONDHeader) & 0x1);
+  }
+  inline constexpr bool hasECONDPayloadLengthOverflow(uint16_t fedUnpackingFlag) {
+    return ((fedUnpackingFlag >> FEDUnpackingFlags::ECONDPayloadLengthOverflow) & 0x1);
+  }
+  inline constexpr bool hasECONDPayloadLengthMismatch(uint16_t fedUnpackingFlag) {
+    return ((fedUnpackingFlag >> FEDUnpackingFlags::ECONDPayloadLengthMismatch) & 0x1);
+  }
+  inline constexpr bool hasErrorSLinkTrailer(uint16_t fedUnpackingFlag) {
+    return ((fedUnpackingFlag >> FEDUnpackingFlags::ErrorSLinkTrailer) & 0x1);
+  }
+  inline constexpr bool hasEarlySLinkEnd(uint16_t fedUnpackingFlag) {
+    return ((fedUnpackingFlag >> FEDUnpackingFlags::EarlySLinkEnd) & 0x1);
+  }
+
+  GENERATE_SOA_LAYOUT(HGCalFEDPacketInfoSoALayout,
+                      //FED unpacking flag
+                      // bit 0 : unable to unpack headers
+                      // bit 1 : unable to unpack data
+                      // bit 2 : at least one capture block has active flags
+                      SOA_COLUMN(uint16_t, FEDUnpackingFlag),
+                      SOA_COLUMN(uint32_t, FEDPayload))  //number of words (char)
+
+  using HGCalFEDPacketInfoSoA = HGCalFEDPacketInfoSoALayout<>;
+}  // namespace hgcaldigi
+
+#endif

--- a/DataFormats/HGCalDigi/interface/HGCalRawDataDefinitions.h
+++ b/DataFormats/HGCalDigi/interface/HGCalRawDataDefinitions.h
@@ -56,20 +56,6 @@ namespace hgcal {
         // flag for digi not in raw data
         NotAvailable = 0xFFFF;
   }  // namespace DIGI_FLAG
-  namespace UNPACKER_STAT {
-    //This aligns with the definitons in HGCalECONDPacketInfoSoA
-    // 0: Normal
-    // 1: Wrong S-Link header marker
-    // 2: Wrong Capture block header marker
-    // 3: Wrong ECON-D header marker
-    // 4: ECON-D payload length overflow(>469)
-    // 5: unpacked ECON-D length and payload length not match
-    // 6: S-Link trailer location error
-    // 7: S-Link End earlier
-    constexpr uint8_t Normal = 0, WrongSLinkHeader = 1, WrongCaptureBlockHeader = 2, WrongECONDHeader = 3,
-                      ECONDPayloadLengthOverflow = 4, ECONDPayloadLengthMismatch = 5, WrongSLinkTrailer = 6,
-                      EarlySLinkEnd = 7;
-  }  // namespace UNPACKER_STAT
 
 }  // namespace hgcal
 

--- a/DataFormats/HGCalDigi/interface/alpaka/HGCalFEDPacketInfoDevice.h
+++ b/DataFormats/HGCalDigi/interface/alpaka/HGCalFEDPacketInfoDevice.h
@@ -1,0 +1,23 @@
+#ifndef DataFormats_HGCalDigi_interface_alpaka_HGCalFEDPacketInfoDevice_h
+#define DataFormats_HGCalDigi_interface_alpaka_HGCalFEDPacketInfoDevice_h
+
+#include "DataFormats/Portable/interface/alpaka/PortableCollection.h"
+#include "DataFormats/HGCalDigi/interface/HGCalFEDPacketInfoSoA.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  namespace hgcaldigi {
+
+    // make the names from the top-level hgcaldigi namespace visible for unqualified lookup
+    // inside the ALPAKA_ACCELERATOR_NAMESPACE::hgcaldigi namespace
+    using namespace ::hgcaldigi;
+
+    // SoA in device global memory
+    using HGCalFEDPacketInfoDevice = PortableCollection<HGCalFEDPacketInfoSoA>;
+
+  }  // namespace hgcaldigi
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+#endif

--- a/DataFormats/HGCalDigi/src/alpaka/classes_cuda.h
+++ b/DataFormats/HGCalDigi/src/alpaka/classes_cuda.h
@@ -4,3 +4,5 @@
 #include "DataFormats/HGCalDigi/interface/alpaka/HGCalDigiDevice.h"
 #include "DataFormats/HGCalDigi/interface/HGCalECONDPacketInfoSoA.h"
 #include "DataFormats/HGCalDigi/interface/alpaka/HGCalECONDPacketInfoDevice.h"
+#include "DataFormats/HGCalDigi/interface/HGCalFEDPacketInfoSoA.h"
+#include "DataFormats/HGCalDigi/interface/alpaka/HGCalFEDPacketInfoDevice.h"

--- a/DataFormats/HGCalDigi/src/alpaka/classes_cuda_def.xml
+++ b/DataFormats/HGCalDigi/src/alpaka/classes_cuda_def.xml
@@ -5,4 +5,7 @@
   <class name="alpaka_cuda_async::hgcaldigi::HGCalECONDPacketInfoDevice" persistent="false"/>
   <class name="edm::DeviceProduct<alpaka_cuda_async::hgcaldigi::HGCalECONDPacketInfoDevice>" persistent="false"/>
   <class name="edm::Wrapper<edm::DeviceProduct<alpaka_cuda_async::hgcaldigi::HGCalECONDPacketInfoDevice>>" persistent="false"/>
+  <class name="alpaka_cuda_async::hgcaldigi::HGCalFEDPacketInfoDevice" persistent="false"/>
+  <class name="edm::DeviceProduct<alpaka_cuda_async::hgcaldigi::HGCalFEDPacketInfoDevice>" persistent="false"/>
+  <class name="edm::Wrapper<edm::DeviceProduct<alpaka_cuda_async::hgcaldigi::HGCalFEDPacketInfoDevice>>" persistent="false"/>
 </lcgdict>

--- a/DataFormats/HGCalDigi/src/alpaka/classes_rocm.h
+++ b/DataFormats/HGCalDigi/src/alpaka/classes_rocm.h
@@ -4,3 +4,5 @@
 #include "DataFormats/HGCalDigi/interface/alpaka/HGCalDigiDevice.h"
 #include "DataFormats/HGCalDigi/interface/HGCalECONDPacketInfoSoA.h"
 #include "DataFormats/HGCalDigi/interface/alpaka/HGCalECONDPacketInfoDevice.h"
+#include "DataFormats/HGCalDigi/interface/HGCalFEDPacketInfoSoA.h"
+#include "DataFormats/HGCalDigi/interface/alpaka/HGCalFEDPacketInfoDevice.h"

--- a/DataFormats/HGCalDigi/src/alpaka/classes_rocm_def.xml
+++ b/DataFormats/HGCalDigi/src/alpaka/classes_rocm_def.xml
@@ -5,4 +5,7 @@
   <class name="alpaka_rocm_async::hgcaldigi::HGCalECONDPacketInfoDevice" persistent="false"/>
   <class name="edm::DeviceProduct<alpaka_rocm_async::hgcaldigi::HGCalECONDPacketInfoDevice>" persistent="false"/>
   <class name="edm::Wrapper<edm::DeviceProduct<alpaka_rocm_async::hgcaldigi::HGCalECONDPacketInfoDevice>>" persistent="false"/>
+  <class name="alpaka_rocm_async::hgcaldigi::HGCalFEDPacketInfoDevice" persistent="false"/>
+  <class name="edm::DeviceProduct<alpaka_rocm_async::hgcaldigi::HGCalFEDPacketInfoDevice>" persistent="false"/>
+  <class name="edm::Wrapper<edm::DeviceProduct<alpaka_rocm_async::hgcaldigi::HGCalFEDPacketInfoDevice>>" persistent="false"/>
 </lcgdict>

--- a/DataFormats/HGCalDigi/src/classes.cc
+++ b/DataFormats/HGCalDigi/src/classes.cc
@@ -1,6 +1,8 @@
 #include "DataFormats/Portable/interface/PortableHostCollectionReadRules.h"
 #include "DataFormats/HGCalDigi/interface/HGCalDigiHost.h"
 #include "DataFormats/HGCalDigi/interface/HGCalECONDPacketInfoHost.h"
+#include "DataFormats/HGCalDigi/interface/HGCalFEDPacketInfoHost.h"
 
 SET_PORTABLEHOSTCOLLECTION_READ_RULES(hgcaldigi::HGCalDigiHost);
 SET_PORTABLEHOSTCOLLECTION_READ_RULES(hgcaldigi::HGCalECONDPacketInfoHost);
+SET_PORTABLEHOSTCOLLECTION_READ_RULES(hgcaldigi::HGCalFEDPacketInfoHost);

--- a/DataFormats/HGCalDigi/src/classes.h
+++ b/DataFormats/HGCalDigi/src/classes.h
@@ -9,3 +9,5 @@
 #include "DataFormats/HGCalDigi/interface/HGCalDigiSoA.h"
 #include "DataFormats/HGCalDigi/interface/HGCalECONDPacketInfoHost.h"
 #include "DataFormats/HGCalDigi/interface/HGCalECONDPacketInfoSoA.h"
+#include "DataFormats/HGCalDigi/interface/HGCalFEDPacketInfoHost.h"
+#include "DataFormats/HGCalDigi/interface/HGCalFEDPacketInfoSoA.h"

--- a/DataFormats/HGCalDigi/src/classes_def.xml
+++ b/DataFormats/HGCalDigi/src/classes_def.xml
@@ -56,4 +56,9 @@
   <class name="hgcaldigi::HGCalECONDPacketInfoHost"/>
   <class name="edm::Wrapper<hgcaldigi::HGCalECONDPacketInfoHost>" splitLevel="0"/>
 
+  <class name="hgcaldigi::HGCalFEDPacketInfoSoA"/>
+  <class name="hgcaldigi::HGCalFEDPacketInfoSoA::View"/>
+  <class name="hgcaldigi::HGCalFEDPacketInfoHost"/>
+  <class name="edm::Wrapper<hgcaldigi::HGCalFEDPacketInfoHost>" splitLevel="0"/>
+
 </lcgdict>

--- a/EventFilter/HGCalRawToDigi/interface/HGCalUnpacker.h
+++ b/EventFilter/HGCalRawToDigi/interface/HGCalUnpacker.h
@@ -32,13 +32,13 @@ public:
   // define what is needed as `config`
   // HGCalUnpacker(HGCalUnpackerConfig config);
 
-  uint8_t parseFEDData(unsigned fedId,
-                       const FEDRawData& fed_data,
-                       const HGCalMappingModuleIndexer& moduleIndexer,
-                       const HGCalConfiguration& config,
-                       hgcaldigi::HGCalDigiHost& digis,
-                       hgcaldigi::HGCalECONDPacketInfoHost& econdPacketInfo,
-                       bool headerOnlyMode = false);
+  uint16_t parseFEDData(unsigned fedId,
+                        const FEDRawData& fed_data,
+                        const HGCalMappingModuleIndexer& moduleIndexer,
+                        const HGCalConfiguration& config,
+                        hgcaldigi::HGCalDigiHost& digis,
+                        hgcaldigi::HGCalECONDPacketInfoHost& econdPacketInfo,
+                        bool headerOnlyMode = false);
 
 private:
   constexpr static uint8_t tctp_[16] = {

--- a/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
+++ b/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
@@ -151,10 +151,8 @@ uint16_t HGCalUnpacker::parseFEDData(unsigned fedId,
       const auto econd_payload_length = ((econd_headers[0] >> ECOND_FRAME::PAYLOAD_POS) & ECOND_FRAME::PAYLOAD_MASK);
 
       // sanity check
-      // econd_payload_length must contain at least 1 word (CRC) otherwise it's corrupted
       if (((econd_headers[0] >> ECOND_FRAME::HEADER_POS) & ECOND_FRAME::HEADER_MASK) !=
-              fedConfig.econds[globalECONDIdx].headerMarker ||
-          econd_payload_length == 0) {
+          fedConfig.econds[globalECONDIdx].headerMarker) {
         econdPacketInfo.view()[ECONDdenseIdx].exception() = 3;
         edm::LogWarning("[HGCalUnpacker]")
             << "Expected a ECON-D header at word " << std::dec << (uint32_t)(ptr - header) << "/0x" << std::hex
@@ -204,7 +202,6 @@ uint16_t HGCalUnpacker::parseFEDData(unsigned fedId,
       //quality check for ECON-D (check econd_pkt_status here for error in trailer CRC)
       if ((((econd_headers[0] >> ECOND_FRAME::HT_POS) & ECOND_FRAME::HT_MASK) >= 0b10) ||
           (((econd_headers[0] >> ECOND_FRAME::EBO_POS) & ECOND_FRAME::EBO_MASK) >= 0b10) ||
-          (((econd_headers[0] >> ECOND_FRAME::BITM_POS) & 0b1) == 0) ||
           (((econd_headers[0] >> ECOND_FRAME::BITM_POS) & 0b1) == 0) || econd_payload_length == 0 ||
           econd_pkt_status == backend::ECONDPacketStatus::OfflinePayloadCRCError ||
           econd_pkt_status == backend::ECONDPacketStatus::InactiveECOND || headerOnlyMode) {

--- a/EventFilter/HGCalRawToDigi/src/UnpackerTools.cc
+++ b/EventFilter/HGCalRawToDigi/src/UnpackerTools.cc
@@ -2,12 +2,15 @@
 #include "DataFormats/HGCalDigi/interface/HGCalRawDataDefinitions.h"
 #include <boost/crc.hpp>
 #include <vector>
-#include <algorithm>
 #include <iostream>
 //
 //
 
 bool hgcal::econdCRCAnalysis(const uint64_t *header, const uint32_t pos, const uint32_t payloadLength) {
+  //there needs to be at least the CRC word otherwise it can't be checked
+  if (payloadLength == 0)
+    return false;
+
   int index = 0;
   std::vector<uint32_t> data32b;  //  reading 32-bit words, input is 64b
 


### PR DESCRIPTION
#### PR description:

In recent data taking with HGCAL system validation we have experienced data corruption at FED level. While this may be somehow expected in this early stage of commissioning / construction it's worthwhile having in release some monitoring for when this happens.
In addition the HGCAL unpacker was already filling a series of "quality flags" which were not propagated elsewhere and could not be monitored. 
In this PR we introduce a new SoA `DataFormats/HGCalDigi/interface/HGCalFEDPacketInfoSoA.h` which is filled with basic flags that indicate whether the data is normal or as errors. The SoA is expected to be furthermore useful in developing a fast error DQM for HGCAL system validation setups


#### PR validation:

This PR has been validated with real data acquired with a six module stand. Should not have any impact on the CMSSW simulation or data workflows for the time being.

@IzaakWN @yulunmiao @hqucms 