### PR TITLE
fix gcc 14 warnings: use atomic_ref instead of casting

### DIFF
--- a/HeterogeneousCore/CUDAUtilities/interface/OneToManyAssoc.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/OneToManyAssoc.h
@@ -193,7 +193,7 @@ namespace cms {
 #ifdef __CUDA_ARCH__
           atomicAdd(off.data() + i, co.off[i]);
 #else
-          auto &a = (std::atomic<Counter> &)(off[i]);
+          std::atomic_ref<Counter> a{off[i]};
           a += co.off[i];
 #endif
         }
@@ -203,7 +203,7 @@ namespace cms {
 #ifdef __CUDA_ARCH__
         return atomicAdd(&x, 1);
 #else
-        auto &a = (std::atomic<Counter> &)(x);
+        std::atomic_ref<Counter> a{x};
         return a++;
 #endif
       }
@@ -212,7 +212,7 @@ namespace cms {
 #ifdef __CUDA_ARCH__
         return atomicSub(&x, 1);
 #else
-        auto &a = (std::atomic<Counter> &)(x);
+        std::atomic_ref<Counter> a{x};
         return a--;
 #endif
       }


### PR DESCRIPTION
In GCC14 IBs, we have many warning like [a]. This PR proposes to use `std::atomic_ref`. As simple test like [b] show that it works. 

FYI @fwyzard @VinInn 

[a]
```
In file included from src/HeterogeneousCore/CUDAUtilities/interface/HistoContainer.h:4,
                 from src/HeterogeneousCore/CUDAUtilities/test/HistoContainer_t.cpp:7:
src/HeterogeneousCore/CUDAUtilities/interface/OneToManyAssoc.h: In instantiation of 'static uint32_t cms::cuda::OneToManyAssoc<I, ONES, SIZE>::atomicIncrement(Counter&) [with I = unsigned int; int ONES = 129; int SIZE = -1; uint32_t = unsigned int; Counter = unsigned int]':
src/HeterogeneousCore/CUDAUtilities/interface/HistoContainer.h:141:30:   required from 'void cms::cuda::HistoContainer<T, NBINS, SIZE, S, I, NHISTS>::count(T) [with T = short int; unsigned int NBINS = 128; int SIZE = -1; unsigned int S = 16; I = unsigned int; unsigned int NHISTS = 1]'
  141 |         Base::atomicIncrement(this->off[b]);
      |         ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
src/HeterogeneousCore/CUDAUtilities/test/HistoContainer_t.cpp:68:15:   required from 'void go() [with T = short int; int NBINS = 128; int S = 16; int DELTA = 1000]'
   68 |       hr.count(v[j]);
      |       ~~~~~~~~^~~~~~
src/HeterogeneousCore/CUDAUtilities/test/HistoContainer_t.cpp:170:14:   required from here
  170 |   go<int16_t>();
      |   ~~~~~~~~~~~^~
  [src/HeterogeneousCore/CUDAUtilities/interface/OneToManyAssoc.h:206](https://github.com/cms-sw/cmssw/blob/CMSSW_15_1_X_2025-02-25-2300/HeterogeneousCore/CUDAUtilities/interface/OneToManyAssoc.h#L206):19: warning: casting 'cms::cuda::OneToManyAssoc<unsigned int, 129, -1>::Counter' {aka 'unsigned int'} to 'std::atomic<unsigned int>&' does not use 'constexpr std::atomic<unsigned int>::atomic(__integral_type)' [-Wcast-user-defined]
   206 |         auto &a = (std::atomic<Counter> &)(x);
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
src/HeterogeneousCore/CUDAUtilities/interface/OneToManyAssoc.h: In instantiation of 'static uint32_t cms::cuda::OneToManyAssoc<I, ONES, SIZE>::atomicIncrement(Counter&) [with I = unsigned int; int ONES = 129; int SIZE = 12000; uint32_t = unsigned int; Counter = unsigned int]':
src/HeterogeneousCore/CUDAUtilities/interface/HistoContainer.h:141:30:   required from 'void cms::cuda::HistoContainer<T, NBINS, SIZE, S, I, NHISTS>::count(T) [with T = short int; unsigned int NBINS = 128; int SIZE = 12000; unsigned int S = 16; I = unsigned int; unsigned int NHISTS = 1]'
  141 |         Base::atomicIncrement(this->off[b]);
      |         ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
src/HeterogeneousCore/CUDAUtilities/test/HistoContainer_t.cpp:69:14:   required from 'void go() [with T = short int; int NBINS = 128; int S = 16; int DELTA = 1000]'
   69 |       h.count(v[j]);
      |       ~~~~~~~^~~~~~
src/HeterogeneousCore/CUDAUtilities/test/HistoContainer_t.cpp:170:14:   required from here
  170 |   go<int16_t>();
      |   ~~~~~~~~~~~^~
  [src/HeterogeneousCore/CUDAUtilities/interface/OneToManyAssoc.h:206](https://github.com/cms-sw/cmssw/blob/CMSSW_15_1_X_2025-02-25-2300/HeterogeneousCore/CUDAUtilities/interface/OneToManyAssoc.h#L206):19: warning: casting 'cms::cuda::OneToManyAssoc<unsigned int, 129, 12000>::Counter' {aka 'unsigned int'} to 'std::atomic<unsigned int>&' does not use 'constexpr std::atomic<unsigned int>::atomic(__integral_type)' [-Wcast-user-defined]
   206 |         auto &a = (std::atomic<Counter> &)(x);
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
```

[b]
```
> cat test.cpp
#include <iostream>
#include <atomic>
unsigned int atomicDecrement(unsigned int &x) {
  std::atomic_ref<unsigned int> temp{x};
  return temp--;
}
int main()
{
  unsigned int i=5;
  atomicDecrement(i);
  std::cout <<"i after:"<<i<<std::endl;
  return 0;
}
> test
i after:4
```