### PR TITLE
fix logical error when level>dim-1

### DIFF
--- a/JetMETCorrections/InterpolationTables/interface/ArrayND.h
+++ b/JetMETCorrections/InterpolationTables/interface/ArrayND.h
@@ -4289,7 +4289,7 @@ namespace npstat {
       for (unsigned ipt = 0; ipt < npt; ++ipt)
         fit[ipt] = interpolateLoop(level + 1, coords, base + (ix + ipt) * strides_[level]);
 
-    const Numeric* const v = (level == dim_ - 1 ? base + ix : fit);
+    const Numeric* const v = (level >= dim_ - 1 ? base + ix : fit);
     switch (npt) {
       case 1:
         return v[0];


### PR DESCRIPTION
In GCC14, we get warnings like [a]. Compiler is right here for `level>dim_ -1` [here](https://github.com/cms-sw/cmssw/blob/master/JetMETCorrections/InterpolationTables/interface/ArrayND.h#L4287-L4292). `fit` is only initialized for `level <dim_ -1` 

[a]
```
In function 'interpolate_linear',
    inlined from 'interpolateLoop' at src/JetMETCorrections/InterpolationTables/interface/ArrayND.h:4297:34:
  [src/JetMETCorrections/InterpolationTables/interface/interpolate.h:25](https://github.com/cms-sw/cmssw/blob/CMSSW_15_1_X_2025-02-25-2300/JetMETCorrections/InterpolationTables/interface/interpolate.h#L25):15: warning: 'fit' may be used uninitialized [-Wmaybe-uninitialized]
    25 |     return f0 * dx + f1 * static_cast<typename ProperDblFromCmpl<T>::type>(x);
      |               ^
src/JetMETCorrections/InterpolationTables/interface/ArrayND.h: In member function 'interpolateLoop':
src/JetMETCorrections/InterpolationTables/interface/ArrayND.h:4287:13: note: 'fit' declared here
 4287 |     Numeric fit[4];
```