### PR TITLE
XrdAdaptor: improve exception messages

### DIFF
--- a/Utilities/XrdAdaptor/src/XrdRequestManager.cc
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.cc
@@ -563,6 +563,14 @@ void RequestManager::getPrettyActiveSourceNames(std::vector<std::string> &source
   }
 }
 
+void RequestManager::getPrettyInactiveSourceNames(std::vector<std::string> &sources) const {
+  std::lock_guard<std::recursive_mutex> sentry(m_source_mutex);
+  sources.reserve(m_inactiveSources.size());
+  for (auto const &source : m_inactiveSources) {
+    sources.push_back(source->PrettyID());
+  }
+}
+
 void RequestManager::getDisabledSourceNames(std::vector<std::string> &sources) const {
   sources.reserve(m_disabledSourceStrings.size());
   for (auto const &source : m_disabledSourceStrings) {
@@ -575,6 +583,11 @@ void RequestManager::addConnections(cms::Exception &ex) const {
   getPrettyActiveSourceNames(sources);
   for (auto const &source : sources) {
     ex.addAdditionalInfo("Active source: " + source);
+  }
+  sources.clear();
+  getPrettyInactiveSourceNames(sources);
+  for (auto const &source : sources) {
+    ex.addAdditionalInfo("Inactive source: " + source);
   }
   sources.clear();
   getDisabledSourceNames(sources);

--- a/Utilities/XrdAdaptor/src/XrdRequestManager.cc
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.cc
@@ -213,7 +213,7 @@ void RequestManager::initialize(std::weak_ptr<RequestManager> self) {
       ex.clearMessage();
       ex.clearContext();
       ex.clearAdditionalInfo();
-      ex << "XrdCl::File::Open(name='" << m_name << "', flags=0x" << std::hex << m_flags << ", permissions=0"
+      ex << "XrdCl::File::Open(name='" << new_filename << "', flags=0x" << std::hex << m_flags << ", permissions=0"
          << std::oct << m_perms << std::dec << ") => error '" << openStatus.ToStr() << "' (errno=" << openStatus.errNo
          << ", code=" << openStatus.code << ")";
       ex.addContext("Calling XrdFile::open()");
@@ -233,7 +233,7 @@ void RequestManager::initialize(std::weak_ptr<RequestManager> self) {
       ex.clearMessage();
       ex.clearContext();
       ex.clearAdditionalInfo();
-      ex << "XrdCl::File::Open(name='" << m_name << "', flags=0x" << std::hex << m_flags << ", permissions=0"
+      ex << "XrdCl::File::Open(name='" << new_filename << "', flags=0x" << std::hex << m_flags << ", permissions=0"
          << std::oct << m_perms << std::dec << ") => error '" << status->ToStr() << "' (errno=" << status->errNo
          << ", code=" << status->code << ")";
       ex.addContext("Calling XrdFile::open()");

--- a/Utilities/XrdAdaptor/src/XrdRequestManager.h
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.h
@@ -85,6 +85,12 @@ namespace XrdAdaptor {
     void getPrettyActiveSourceNames(std::vector<std::string> &sources) const;
 
     /**
+     * Retrieve the names of the inactive sources
+     * (primarily meant to enable meaningful log messages).
+     */
+    void getPrettyInactiveSourceNames(std::vector<std::string> &sources) const;
+
+    /**
      * Retrieve the names of the disabled sources
      * (primarily meant to enable meaningful log messages).
      */


### PR DESCRIPTION
#### PR description:

This PR extends the XrdAdaptor exception messages by
* including information on inactive sources to the exceptions that include information on active and disabled sources. 
* the full new URL to the exceptions thrown from `RequestManager::initialize()`
  * the full new URL was already part of the exceptions thrown from `RequestManager::OpenHandler::open()`

These could be useful to investigate the logs of situations such as https://github.com/cms-sw/cmssw/issues/43162

Resolves https://github.com/cms-sw/framework-team/issues/1237

#### PR validation:

Code compiles

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 15_0_X