### PR TITLE
Access PathsAndConsumesOfModules from new signal

### DIFF
--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -37,7 +37,6 @@ class GlobalContext;
 class StreamID;
 
 namespace edm {
-  class PathsAndConsumesOfModulesBase;
   class ProcessContext;
 }  // namespace edm
 

--- a/EventFilter/Utilities/interface/FastMonitoringService.h
+++ b/EventFilter/Utilities/interface/FastMonitoringService.h
@@ -13,8 +13,6 @@
 
 #include <filesystem>
 
-#include "EventFilter/Utilities/interface/FastMonitoringService.h"
-
 #include <string>
 #include <vector>
 #include <map>
@@ -181,7 +179,7 @@ namespace evf {
 
     void preallocate(edm::service::SystemBounds const&);
     void jobFailure();
-    void preBeginJob(edm::PathsAndConsumesOfModulesBase const&, edm::ProcessContext const& pc);
+    void preBeginJob(edm::ProcessContext const& pc);
 
     void preModuleBeginJob(edm::ModuleDescription const&);
     void postBeginJob();

--- a/EventFilter/Utilities/src/FastMonitoringService.cc
+++ b/EventFilter/Utilities/src/FastMonitoringService.cc
@@ -15,7 +15,6 @@
 #include "FWCore/Utilities/interface/UnixSignalHandlers.h"
 
 #include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
-#include "FWCore/ServiceRegistry/interface/PathsAndConsumesOfModulesBase.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
@@ -318,7 +317,7 @@ namespace evf {
     //start concurrency tracking
   }
 
-  void FastMonitoringService::preBeginJob(edm::PathsAndConsumesOfModulesBase const&, edm::ProcessContext const& pc) {
+  void FastMonitoringService::preBeginJob(edm::ProcessContext const& pc) {
     // FIND RUN DIRECTORY
     // The run dir should be set via the configuration of EvFDaqDirector
     if (tbbConcurrencyTracker_)

--- a/FWCore/Framework/interface/GlobalSchedule.h
+++ b/FWCore/Framework/interface/GlobalSchedule.h
@@ -77,7 +77,6 @@ namespace edm {
     void beginJob(ProductRegistry const&,
                   eventsetup::ESRecordsToProductResolverIndices const&,
                   ProcessBlockHelperBase const&,
-                  PathsAndConsumesOfModulesBase const&,
                   ProcessContext const&);
     void endJob(ExceptionCollector& collector);
 

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -174,7 +174,6 @@ namespace edm {
     void beginJob(ProductRegistry const&,
                   eventsetup::ESRecordsToProductResolverIndices const&,
                   ProcessBlockHelperBase const&,
-                  PathsAndConsumesOfModulesBase const&,
                   ProcessContext const&);
     void endJob(ExceptionCollector& collector);
     void sendFwkSummaryToMessageLogger() const;

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -748,8 +748,7 @@ namespace edm {
     // after they all complete.
     std::exception_ptr firstException;
     CMS_SA_ALLOW try {
-      schedule_->beginJob(
-          *preg_, esRecordsToProductResolverIndices, *processBlockHelper_, pathsAndConsumesOfModules, processContext_);
+      schedule_->beginJob(*preg_, esRecordsToProductResolverIndices, *processBlockHelper_, processContext_);
     } catch (...) {
       firstException = std::current_exception();
     }

--- a/FWCore/Framework/src/GlobalSchedule.cc
+++ b/FWCore/Framework/src/GlobalSchedule.cc
@@ -98,7 +98,6 @@ namespace edm {
   void GlobalSchedule::beginJob(ProductRegistry const& iRegistry,
                                 eventsetup::ESRecordsToProductResolverIndices const& iESIndices,
                                 ProcessBlockHelperBase const& processBlockHelperBase,
-                                PathsAndConsumesOfModulesBase const& pathsAndConsumesOfModules,
                                 ProcessContext const& processContext) {
     GlobalContext globalContext(GlobalContext::Transition::kBeginJob, processContext_);
     unsigned int const managerIndex =
@@ -107,9 +106,7 @@ namespace edm {
     std::exception_ptr exceptionPtr;
     CMS_SA_ALLOW try {
       try {
-        convertException::wrap([this, &pathsAndConsumesOfModules, &processContext]() {
-          actReg_->preBeginJobSignal_(pathsAndConsumesOfModules, processContext);
-        });
+        convertException::wrap([this, &processContext]() { actReg_->preBeginJobSignal_(processContext); });
       } catch (cms::Exception& ex) {
         exceptionContext(ex, globalContext, "Handling pre signal, likely in a service function");
         throw;

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -1191,9 +1191,8 @@ namespace edm {
   void Schedule::beginJob(ProductRegistry const& iRegistry,
                           eventsetup::ESRecordsToProductResolverIndices const& iESIndices,
                           ProcessBlockHelperBase const& processBlockHelperBase,
-                          PathsAndConsumesOfModulesBase const& pathsAndConsumesOfModules,
                           ProcessContext const& processContext) {
-    globalSchedule_->beginJob(iRegistry, iESIndices, processBlockHelperBase, pathsAndConsumesOfModules, processContext);
+    globalSchedule_->beginJob(iRegistry, iESIndices, processBlockHelperBase, processContext);
   }
 
   void Schedule::beginStream(unsigned int streamID) {

--- a/FWCore/Framework/src/SubProcess.cc
+++ b/FWCore/Framework/src/SubProcess.cc
@@ -332,8 +332,7 @@ namespace edm {
 
     std::exception_ptr firstException;
     CMS_SA_ALLOW try {
-      schedule_->beginJob(
-          *preg_, esp_->recordsToResolverIndices(), *processBlockHelper_, *pathsAndConsumesOfModules_, processContext_);
+      schedule_->beginJob(*preg_, esp_->recordsToResolverIndices(), *processBlockHelper_, processContext_);
     } catch (...) {
       firstException = std::current_exception();
     }

--- a/FWCore/Integration/plugins/PathsAndConsumesOfModulesTestService.cc
+++ b/FWCore/Integration/plugins/PathsAndConsumesOfModulesTestService.cc
@@ -14,7 +14,8 @@ namespace edmtest {
   public:
     PathsAndConsumesOfModulesTestService(edm::ParameterSet const& pset, edm::ActivityRegistry& iRegistry)
         : modulesConsumes_(pset.getParameter<decltype(modulesConsumes_)>("modulesAndConsumes")) {
-      iRegistry.watchPreBeginJob(this, &PathsAndConsumesOfModulesTestService::preBeginJob);
+      iRegistry.watchLookupInitializationComplete(this,
+                                                  &PathsAndConsumesOfModulesTestService::lookupInitializationComplete);
     }
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -29,7 +30,8 @@ namespace edmtest {
       descriptions.setComment("This service is intended to be used in framework tests.");
     }
 
-    void preBeginJob(edm::PathsAndConsumesOfModulesBase const& pathsAndConsumes, edm::ProcessContext const&) const {
+    void lookupInitializationComplete(edm::PathsAndConsumesOfModulesBase const& pathsAndConsumes,
+                                      edm::ProcessContext const&) const {
       auto const& allModules = pathsAndConsumes.allModules();
       for (auto const& moduleToCheck : modulesConsumes_) {
         auto found =

--- a/FWCore/Integration/plugins/TestServiceOne.cc
+++ b/FWCore/Integration/plugins/TestServiceOne.cc
@@ -142,7 +142,7 @@ namespace edmtest {
     descriptions.add("TestServiceOne", desc);
   }
 
-  void TestServiceOne::preBeginJob(edm::PathsAndConsumesOfModulesBase const&, edm::ProcessContext const&) {
+  void TestServiceOne::preBeginJob(edm::ProcessContext const&) {
     ++nPreBeginJob_;
     if (verbose_) {
       edm::LogAbsolute out("TestServiceOne");

--- a/FWCore/Integration/plugins/TestServiceOne.h
+++ b/FWCore/Integration/plugins/TestServiceOne.h
@@ -29,7 +29,7 @@ namespace edmtest {
 
     static void fillDescriptions(edm::ConfigurationDescriptions&);
 
-    void preBeginJob(edm::PathsAndConsumesOfModulesBase const&, edm::ProcessContext const&);
+    void preBeginJob(edm::ProcessContext const&);
     void postBeginJob();
     void preEndJob();
     void postEndJob();

--- a/FWCore/PrescaleService/interface/PrescaleService.h
+++ b/FWCore/PrescaleService/interface/PrescaleService.h
@@ -12,7 +12,6 @@
 namespace edm {
   class ActivityRegistry;
   class ConfigurationDescriptions;
-  class PathsAndConsumesOfModulesBase;
   class ProcessContext;
 
   namespace service {
@@ -46,7 +45,7 @@ namespace edm {
       //
       // private member functions
       //
-      void preBeginJob(PathsAndConsumesOfModulesBase const&, ProcessContext const&);
+      void preBeginJob(ProcessContext const&);
       void postBeginJob();
 
       //

--- a/FWCore/PrescaleService/src/PrescaleService.cc
+++ b/FWCore/PrescaleService/src/PrescaleService.cc
@@ -57,7 +57,7 @@ namespace edm {
 
     // member functions
 
-    void PrescaleService::preBeginJob(PathsAndConsumesOfModulesBase const&, ProcessContext const& processContext) {
+    void PrescaleService::preBeginJob(ProcessContext const& processContext) {
       if (!processParameterSetID_.isValid()) {
         processParameterSetID_ = processContext.parameterSetID();
       }

--- a/FWCore/ServiceRegistry/interface/ActivityRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ActivityRegistry.h
@@ -167,12 +167,12 @@ namespace edm {
     }
     AR_WATCH_USING_METHOD_2(watchEventSetupConfiguration)
 
-    typedef signalslot::Signal<void(PathsAndConsumesOfModulesBase const&, ProcessContext const&)> PreBeginJob;
+    typedef signalslot::Signal<void(ProcessContext const&)> PreBeginJob;
     ///signal is emitted before all modules have gotten their beginJob called
     PreBeginJob preBeginJobSignal_;
     ///convenience function for attaching to signal
     void watchPreBeginJob(PreBeginJob::slot_type const& iSlot) { preBeginJobSignal_.connect(iSlot); }
-    AR_WATCH_USING_METHOD_2(watchPreBeginJob)
+    AR_WATCH_USING_METHOD_1(watchPreBeginJob)
 
     typedef signalslot::Signal<void()> PostBeginJob;
     ///signal is emitted after all modules have gotten their beginJob called

--- a/FWCore/Services/plugins/CheckTransitions.cc
+++ b/FWCore/Services/plugins/CheckTransitions.cc
@@ -50,7 +50,6 @@ namespace edm {
 
       void preallocate(service::SystemBounds const&);
 
-      void preBeginJob(PathsAndConsumesOfModulesBase const&, ProcessContext const&);
       void postEndJob();
 
       void preOpenFile(std::string const&);

--- a/FWCore/Services/plugins/CondorStatusUpdater.cc
+++ b/FWCore/Services/plugins/CondorStatusUpdater.cc
@@ -59,7 +59,7 @@ namespace edm {
       void eventPost(StreamContext const &iContext);
       void lumiPost(GlobalContext const &);
       void runPost(GlobalContext const &);
-      void beginPre(PathsAndConsumesOfModulesBase const &, ProcessContext const &processContext);
+      void beginPre(ProcessContext const &processContext);
       void beginPost();
       void endPost();
       void filePost(std::string const &);
@@ -150,7 +150,7 @@ void CondorStatusService::filePost(std::string const & /*lfn*/) {
   update();
 }
 
-void CondorStatusService::beginPre(PathsAndConsumesOfModulesBase const &, ProcessContext const &processContext) {
+void CondorStatusService::beginPre(ProcessContext const &processContext) {
   secondUpdate();
   if (!m_processParameterSetID.isValid()) {
     m_processParameterSetID = processContext.parameterSetID();

--- a/FWCore/Services/plugins/Timing.cc
+++ b/FWCore/Services/plugins/Timing.cc
@@ -58,7 +58,7 @@ namespace edm {
       double getTotalCPU() const override;
 
     private:
-      void preBeginJob(PathsAndConsumesOfModulesBase const&, ProcessContext const&);
+      void preBeginJob(ProcessContext const&);
       void beginProcessing();
       void postEndJob();
 
@@ -437,7 +437,7 @@ namespace edm {
       descriptions.setComment("This service reports the time it takes to run each module in a job.");
     }
 
-    void Timing::preBeginJob(PathsAndConsumesOfModulesBase const& pathsAndConsumes, ProcessContext const& pc) {
+    void Timing::preBeginJob(ProcessContext const& pc) {
       if (pc.isSubProcess()) {
         ++nSubProcesses_;
       } else {

--- a/FWCore/Services/plugins/Tracer.cc
+++ b/FWCore/Services/plugins/Tracer.cc
@@ -67,7 +67,7 @@ namespace edm {
 
       void preallocate(service::SystemBounds const&);
 
-      void preBeginJob(PathsAndConsumesOfModulesBase const&, ProcessContext const&);
+      void preBeginJob(ProcessContext const&);
       void postBeginJob();
       void preEndJob();
       void postEndJob();
@@ -546,7 +546,7 @@ void Tracer::preallocate(service::SystemBounds const& bounds) {
                         << bounds.maxNumberOfStreams() << " streams";
 }
 
-void Tracer::preBeginJob(PathsAndConsumesOfModulesBase const& pathsAndConsumes, ProcessContext const& pc) {
+void Tracer::preBeginJob(ProcessContext const& pc) {
   LogAbsolute out("Tracer");
   out << TimeStamper(printTimestamps_) << indention_ << " starting: begin job";
 }

--- a/FWCore/Services/plugins/tracer_setupFile.cc
+++ b/FWCore/Services/plugins/tracer_setupFile.cc
@@ -404,7 +404,7 @@ namespace edm::service::tracer {
                                 moduleCtrDtrPtr,
                                 sourceCtrPtr,
                                 beginTime,
-                                beginTracer](auto&, auto&) mutable {
+                                beginTracer](auto&) mutable {
       {
         std::ostringstream oss;
         moduleIdToLabel(oss, *moduleLabelsPtr, 'M', "EDModule ID", "Module label");

--- a/FWCore/TestProcessor/src/TestProcessor.cc
+++ b/FWCore/TestProcessor/src/TestProcessor.cc
@@ -23,7 +23,6 @@
 #include "FWCore/Framework/interface/ProcessBlockPrincipal.h"
 #include "FWCore/Framework/interface/ExceptionActions.h"
 #include "FWCore/Framework/interface/HistoryAppender.h"
-#include "FWCore/Framework/interface/PathsAndConsumesOfModules.h"
 #include "FWCore/Framework/interface/RunPrincipal.h"
 #include "FWCore/Framework/interface/ESRecordsToProductResolverIndices.h"
 #include "FWCore/Framework/interface/EventSetupsController.h"
@@ -430,19 +429,11 @@ namespace edm {
                                    preallocations_.numberOfThreads());
       actReg_->preallocateSignal_(bounds);
       schedule_->convertCurrentProcessAlias(processConfiguration_->processName());
-      PathsAndConsumesOfModules pathsAndConsumesOfModules;
-
-      //The code assumes only modules make data in the current process
-      // Since the test os also allowed to do so, it can lead to problems.
-      //pathsAndConsumesOfModules.initialize(schedule_.get(), preg_);
 
       espController_->finishConfiguration();
       actReg_->eventSetupConfigurationSignal_(esp_->recordsToResolverIndices(), processContext_);
-      //NOTE: this may throw
-      //checkForModuleDependencyCorrectness(pathsAndConsumesOfModules, false);
 
-      schedule_->beginJob(
-          *preg_, esp_->recordsToResolverIndices(), *processBlockHelper_, pathsAndConsumesOfModules, processContext_);
+      schedule_->beginJob(*preg_, esp_->recordsToResolverIndices(), *processBlockHelper_, processContext_);
 
       for (unsigned int i = 0; i < preallocations_.numberOfStreams(); ++i) {
         schedule_->beginStream(i);

--- a/HLTrigger/Timer/interface/ProcessCallGraph.h
+++ b/HLTrigger/Timer/interface/ProcessCallGraph.h
@@ -125,8 +125,8 @@ public:
   // to be called from preSourceConstruction(...)
   void preSourceConstruction(edm::ModuleDescription const &);
 
-  // to be called from preBeginJob(...)
-  void preBeginJob(edm::PathsAndConsumesOfModulesBase const &, edm::ProcessContext const &);
+  // to be called from lookupInitializationComplete(...)
+  void lookupInitializationComplete(edm::PathsAndConsumesOfModulesBase const &, edm::ProcessContext const &);
 
   // number of modules stored in the call graph
   unsigned int size() const;

--- a/HLTrigger/Timer/plugins/FastTimerService.cc
+++ b/HLTrigger/Timer/plugins/FastTimerService.cc
@@ -822,8 +822,7 @@ FastTimerService::FastTimerService(const edm::ParameterSet& config, edm::Activit
 
   // register EDM call backs
   registry.watchPreallocate(this, &FastTimerService::preallocate);
-  registry.watchPreBeginJob(this, &FastTimerService::preBeginJob);
-  registry.watchPostBeginJob(this, &FastTimerService::postBeginJob);
+  registry.watchLookupInitializationComplete(this, &FastTimerService::lookupInitializationComplete);
   registry.watchPostEndJob(this, &FastTimerService::postEndJob);
   registry.watchPreGlobalBeginRun(this, &FastTimerService::preGlobalBeginRun);
   //registry.watchPostGlobalBeginRun(         this, & FastTimerService::postGlobalBeginRun );
@@ -990,12 +989,9 @@ void FastTimerService::preSourceConstruction(edm::ModuleDescription const& modul
   callgraph_.preSourceConstruction(module);
 }
 
-void FastTimerService::preBeginJob(edm::PathsAndConsumesOfModulesBase const& pathsAndConsumes,
-                                   edm::ProcessContext const& context) {
-  callgraph_.preBeginJob(pathsAndConsumes, context);
-}
-
-void FastTimerService::postBeginJob() {
+void FastTimerService::lookupInitializationComplete(edm::PathsAndConsumesOfModulesBase const& pathsAndConsumes,
+                                                    edm::ProcessContext const& context) {
+  callgraph_.lookupInitializationComplete(pathsAndConsumes, context);
   unsigned int modules = callgraph_.size();
 
   // module highlights

--- a/HLTrigger/Timer/plugins/FastTimerService.h
+++ b/HLTrigger/Timer/plugins/FastTimerService.h
@@ -65,8 +65,7 @@ private:
 
   void preallocate(edm::service::SystemBounds const&);
 
-  void preBeginJob(edm::PathsAndConsumesOfModulesBase const&, edm::ProcessContext const&);
-  void postBeginJob();
+  void lookupInitializationComplete(edm::PathsAndConsumesOfModulesBase const&, edm::ProcessContext const&);
 
   void postEndJob();
 

--- a/HLTrigger/Timer/src/ProcessCallGraph.cc
+++ b/HLTrigger/Timer/src/ProcessCallGraph.cc
@@ -58,8 +58,8 @@ void ProcessCallGraph::preSourceConstruction(edm::ModuleDescription const& modul
 // FIXME
 //  - check that all module ids are valid (e.g. subprocesses are not being added in
 //    the wrong order)
-void ProcessCallGraph::preBeginJob(edm::PathsAndConsumesOfModulesBase const& pathsAndConsumes,
-                                   edm::ProcessContext const& context) {
+void ProcessCallGraph::lookupInitializationComplete(edm::PathsAndConsumesOfModulesBase const& pathsAndConsumes,
+                                                    edm::ProcessContext const& context) {
   unsigned int pid = registerProcess(context);
 
   // check that the Source has already been added

--- a/HeterogeneousCore/SonicTriton/interface/TritonService.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonService.h
@@ -18,7 +18,6 @@
 namespace edm {
   class ActivityRegistry;
   class ConfigurationDescriptions;
-  class PathsAndConsumesOfModulesBase;
   class ProcessContext;
   class ModuleDescription;
   namespace service {
@@ -123,7 +122,7 @@ private:
   void preModuleConstruction(edm::ModuleDescription const&);
   void postModuleConstruction(edm::ModuleDescription const&);
   void preModuleDestruction(edm::ModuleDescription const&);
-  void preBeginJob(edm::PathsAndConsumesOfModulesBase const&, edm::ProcessContext const&);
+  void preBeginJob(edm::ProcessContext const&);
   void postEndJob();
 
   //helper

--- a/HeterogeneousCore/SonicTriton/src/TritonService.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonService.cc
@@ -243,7 +243,7 @@ TritonService::Server TritonService::serverInfo(const std::string& model, const 
   return server;
 }
 
-void TritonService::preBeginJob(edm::PathsAndConsumesOfModulesBase const&, edm::ProcessContext const&) {
+void TritonService::preBeginJob(edm::ProcessContext const&) {
   //only need fallback if there are unserved models
   if (!fallbackOpts_.enable or unservedModels_.empty())
     return;

--- a/IOMC/RandomEngine/plugins/RandomNumberGeneratorService.cc
+++ b/IOMC/RandomEngine/plugins/RandomNumberGeneratorService.cc
@@ -428,9 +428,7 @@ namespace edm {
       }
     }
 
-    void RandomNumberGeneratorService::preBeginJob(PathsAndConsumesOfModulesBase const&, ProcessContext const&) {
-      beginJobEndJobActive_ = true;
-    }
+    void RandomNumberGeneratorService::preBeginJob(ProcessContext const&) { beginJobEndJobActive_ = true; }
 
     void RandomNumberGeneratorService::postBeginJob() { beginJobEndJobActive_ = false; }
 

--- a/IOMC/RandomEngine/plugins/RandomNumberGeneratorService.h
+++ b/IOMC/RandomEngine/plugins/RandomNumberGeneratorService.h
@@ -93,7 +93,7 @@ namespace edm {
       void setLumiCache(LuminosityBlockIndex, std::vector<RandomEngineState> const& iStates) override;
       void setEventCache(StreamID, std::vector<RandomEngineState> const& iStates) override;
 
-      void preBeginJob(PathsAndConsumesOfModulesBase const&, ProcessContext const&);
+      void preBeginJob(ProcessContext const&);
       void postBeginJob();
       void preEndJob();
       void postEndJob();

--- a/PerfTools/AllocMonitor/plugins/ModuleEventAllocMonitor.cc
+++ b/PerfTools/AllocMonitor/plugins/ModuleEventAllocMonitor.cc
@@ -270,7 +270,7 @@ public:
       });
     }
     iAR.watchPreallocate([this](auto const& alloc) { nStreams_ = alloc.maxNumberOfStreams(); });
-    iAR.watchPreBeginJob([this](auto const&, auto const&) {
+    iAR.watchPreBeginJob([this](auto const&) {
       streamModuleAllocs_.resize(nStreams_ * nModules_);
       streamModuleInAcquire_ = std::vector<std::atomic<bool>>(nStreams_ * nModules_);
       streamModuleFinishOrder_ = std::vector<int>(nStreams_ * nModules_);

--- a/PerfTools/AllocMonitor/plugins/moduleAlloc_setupFile.cc
+++ b/PerfTools/AllocMonitor/plugins/moduleAlloc_setupFile.cc
@@ -486,7 +486,7 @@ namespace edm::service::moduleAlloc {
                                 sourceCtrPtr,
                                 beginTime,
                                 beginModuleAlloc,
-                                addDataInDtr](auto&, auto&) mutable {
+                                addDataInDtr](auto&) mutable {
       *addDataInDtr = true;
       {
         std::ostringstream oss;


### PR DESCRIPTION
#### PR description:

Use the new LookupInitializationComplete signal to get access to the PathsAndConsumesOfModules object that is available to Services. Previously the PreBeginJob signal was used for this purpose, but since PR #46929 was merged, the object is only partially filled at preBeginJob. When the new signal is emitted it is fully filled. PathsAndConsumesOfModules now includes information related to EventSetup modules that previously did not exist. That is the part that is not filled at preBeginJob.

This shouldn't affect the output of anything (except DependencyGraph service used with SubProcesses, see below).

This PR removes the argument from the preBeginJob signal interface. For several of the services modified in this PR, that argument is not used and the PR just deletes it from the argument list. These changes are trivial and the fact that those services compile should be a sufficient test.

This PR modifies other affected services to use the new signal.

- A few services are used in Framework unit tests and those test pass with the changes in this PR.
- DependencyGraph runs and produces a graph successfully. If one modifies it to run without SubProcesses, the output .gv file is identical before and after this PR. (Note that with SubProcesses the version of DependencyGraph before this PR has a bug that is fixed with the changes in this PR. The old version assumes the PostBeginRun signal is a "local" signal" in ActivityRegistry but it is "global" so none of the SubProcess info is included in the .gv file that is output in the old version.)
- FastTimerService is moved to the new signal and it looks like nothing should change in the output. There are many references to FastTimerService in CMSSW, but I don't see any unit test devoted to testing it. Is there an existing test of FastTimerService somewhere that I could run? Or is there an expert willing to test this? It is probably just a matter of running and checking the output is reasonable. Nothing should change.

There is one Service where the changes are more complex. That is the NVProfilerService. The PathsAndConsumesOfModules object is used to size some vectors at PreBeginJob. Not only is this case more complicated but the current implementation appears to be incorrect. There is a bug that could cause out of bounds vector access. The size of the ProcessCallGraph was being used to size the vectors, but that size could be incorrect if modules are deleted. The framework will delete unused modules. The ID from the ModuleDescription is incremented for every module constructed, including ones that are later deleted. This ID is not modified when a module is deleted. The index used to access the vector is the ID from the ModuleDescription, but in the old version the size is a count of undeleted modules from PathsAndConsumesOfModules and that does have deleted modules removed. This is fixed in the new version where the size is derived from the number of modules constructed and it counts the ones that later get deleted.

Note that there are no tests in the CMSSW repository of NVProfilerService. In fact there are no references to it at all in CMSSW. Is there a test of NVProfilerService somewhere that I could run? Or is there an expert willing to test this?

Should I develop tests for these two services? If necessary, this could be accomplished in a separate PR...

Resolves https://github.com/cms-sw/framework-team/issues/1194

#### PR validation:

Relied on existing unit tests which all pass.
