### PR TITLE
New BTV Monitor

### DIFF
--- a/DQMOffline/Trigger/plugins/BTVMonitor.cc
+++ b/DQMOffline/Trigger/plugins/BTVMonitor.cc
@@ -68,10 +68,10 @@ private:
 
   edm::EDGetTokenT<reco::VertexCollection> vtxToken_;
   edm::EDGetTokenT<edm::View<pat::Muon>> muoToken_;
-  edm::EDGetTokenT<edm::View<pat::Electron>> eleToken_; 
-  edm::EDGetTokenT<edm::ValueMap<bool> > elecIDToken_;
+  edm::EDGetTokenT<edm::View<pat::Electron>> eleToken_;
+  edm::EDGetTokenT<edm::ValueMap<bool>> elecIDToken_;
   edm::EDGetTokenT<pat::PhotonCollection> phoToken_;
-  edm::EDGetTokenT<edm::View<pat::Jet> > jetToken_;
+  edm::EDGetTokenT<edm::View<pat::Jet>> jetToken_;
   edm::EDGetTokenT<pat::METCollection> metToken_;
   std::vector<std::string> btagAlgos_;
   struct PVcut {
@@ -271,45 +271,45 @@ BTVMonitor::BTVMonitor(const edm::ParameterSet& iConfig)
       MHT_binning_(getHistoPSet(
           iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>("MHTPSet"))),
       met_variable_binning_(
-          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("metBinning")),
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double>>("metBinning")),
       HT_variable_binning_(
-          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("HTBinning")),
-          jetPt_variable_binning_(
-            iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("jetPtBinning")),
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double>>("HTBinning")),
+      jetPt_variable_binning_(
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double>>("jetPtBinning")),
       muPt_variable_binning_(
-          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("muPtBinning")),
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double>>("muPtBinning")),
       elePt_variable_binning_(
-          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("elePtBinning")),
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double>>("elePtBinning")),
       jetEta_variable_binning_(
-          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("jetEtaBinning")),
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double>>("jetEtaBinning")),
       muEta_variable_binning_(
-          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("muEtaBinning")),
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double>>("muEtaBinning")),
       eleEta_variable_binning_(
-          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("eleEtaBinning")),
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double>>("eleEtaBinning")),
       invMass_mumu_variable_binning_(iConfig.getParameter<edm::ParameterSet>("histoPSet")
-                                         .getParameter<std::vector<double> >("invMassVariableBinning")),
+                                         .getParameter<std::vector<double>>("invMassVariableBinning")),
       MHT_variable_binning_(
-          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("MHTVariableBinning")),
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double>>("MHTVariableBinning")),
       HT_variable_binning_2D_(
-          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("HTBinning2D")),
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double>>("HTBinning2D")),
       jetPt_variable_binning_2D_(
-          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("jetPtBinning2D")),
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double>>("jetPtBinning2D")),
       muPt_variable_binning_2D_(
-          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("muPtBinning2D")),
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double>>("muPtBinning2D")),
       elePt_variable_binning_2D_(
-          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("elePtBinning2D")),
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double>>("elePtBinning2D")),
       phoPt_variable_binning_2D_(
-          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("phoPtBinning2D")),
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double>>("phoPtBinning2D")),
       jetEta_variable_binning_2D_(
-          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("jetEtaBinning2D")),
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double>>("jetEtaBinning2D")),
       muEta_variable_binning_2D_(
-          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("muEtaBinning2D")),
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double>>("muEtaBinning2D")),
       eleEta_variable_binning_2D_(
-          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("eleEtaBinning2D")),
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double>>("eleEtaBinning2D")),
       phoEta_variable_binning_2D_(
-          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("phoEtaBinning2D")),
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double>>("phoEtaBinning2D")),
       phi_variable_binning_2D_(
-          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("phiBinning2D")),
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double>>("phiBinning2D")),
       num_genTriggerEventFlag_(new GenericTriggerEventFlag(
           iConfig.getParameter<edm::ParameterSet>("numGenericTriggerEventPSet"), consumesCollector(), *this)),
       den_genTriggerEventFlag_(new GenericTriggerEventFlag(
@@ -681,7 +681,6 @@ void BTVMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun
     bookME(ibooker, muPt_.at(iMu), histname, histtitle, muPt_variable_binning_);
     setMETitle(muPt_.at(iMu), "muon p_{T} [GeV]", "events");
 
-
     histname = "muEta_";
     histtitle = "muon #eta - ";
     histname.append(index);
@@ -866,7 +865,8 @@ void BTVMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun
     histtitle = "b-jet DeepFlavour - ";
     histname.append(index);
     histtitle.append(index);
-    bookME(ibooker, bjetDeepFlav_.at(iBJet), histname, histtitle, csv_binning_.nbins, csv_binning_.xmin, csv_binning_.xmax);
+    bookME(
+        ibooker, bjetDeepFlav_.at(iBJet), histname, histtitle, csv_binning_.nbins, csv_binning_.xmin, csv_binning_.xmax);
     setMETitle(bjetDeepFlav_.at(iBJet), "b-jet Deep Flavour", "events");
 
     histname = "bjetPNet_";
@@ -880,7 +880,8 @@ void BTVMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun
     histtitle = "b-jet UParT - ";
     histname.append(index);
     histtitle.append(index);
-    bookME(ibooker, bjetUParT_.at(iBJet), histname, histtitle, csv_binning_.nbins, csv_binning_.xmin, csv_binning_.xmax);
+    bookME(
+        ibooker, bjetUParT_.at(iBJet), histname, histtitle, csv_binning_.nbins, csv_binning_.xmin, csv_binning_.xmax);
     setMETitle(bjetUParT_.at(iBJet), "b-jet UParT", "events");
 
     if (enable2DPlots_) {
@@ -1007,7 +1008,7 @@ void BTVMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
     return;
   }
 
-  edm::Handle<edm::ValueMap<bool> > eleIDHandle;
+  edm::Handle<edm::ValueMap<bool>> eleIDHandle;
   iEvent.getByToken(elecIDToken_, eleIDHandle);
   if (!eleIDHandle.isValid() && nelectrons_ > 0) {
     edm::LogWarning("BTVMonitor") << "Electron ID handle not valid \n";
@@ -1179,9 +1180,8 @@ void BTVMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
   JetBTagMap bjets;
 
   if (nbjets_ > 0) {
-
     edm::Handle<edm::View<pat::Jet>> bjetHandle;
-    iEvent.getByToken(jetToken_, bjetHandle); 
+    iEvent.getByToken(jetToken_, bjetHandle);
     if (!bjetHandle.isValid()) {
       edm::LogWarning("BTVMonitor") << "B-Jet handle not valid, skipping event\n";
       return;
@@ -1201,29 +1201,29 @@ void BTVMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
       bool havePNet = false;
       bool haveUParT = false;
 
-      for (auto const& algoName : btagAlgos_) { // loop over all specified b-tagging algorithms
+      for (auto const& algoName : btagAlgos_) {  // loop over all specified b-tagging algorithms
         float disc = bJet.bDiscriminator(algoName);
         if (!std::isfinite(disc)) {
           continue;
         }
         if (algoName.find("DeepFlavour") != std::string::npos) {
-          deepFlavScore += disc; // Sum three deepFlavour scores
+          deepFlavScore += disc;  // Sum three deepFlavour scores
           haveDeepFlav = true;
         }
         if (algoName.find("ParticleNet") != std::string::npos) {
-          pNetScore = disc; 
+          pNetScore = disc;
           havePNet = true;
         }
         if (algoName.find("ParticleTransformer") != std::string::npos) {
-          UParTScore = disc; 
+          UParTScore = disc;
           haveUParT = true;
         }
       }
 
-      BTagScores scores; 
+      BTagScores scores;
       scores["deepFlav"] = haveDeepFlav ? deepFlavScore : std::numeric_limits<float>::quiet_NaN();
-      scores["PNet"] = havePNet    ? pNetScore    : std::numeric_limits<float>::quiet_NaN();
-      scores["UParT"] = haveUParT    ? UParTScore    : std::numeric_limits<float>::quiet_NaN();
+      scores["PNet"] = havePNet ? pNetScore : std::numeric_limits<float>::quiet_NaN();
+      scores["UParT"] = haveUParT ? UParTScore : std::numeric_limits<float>::quiet_NaN();
       bjets.insert(std::make_pair(jetRef, scores));
 
       if (bjets.size() < nbjets_) {
@@ -1380,12 +1380,12 @@ void BTVMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
   for (auto& bjet : bjets) {
     if (iBJet >= nbjets_)
       break;
-    const BTagScores &scores = bjet.second;
+    const BTagScores& scores = bjet.second;
 
     bjetPhi_.at(iBJet).fill(trg_passed, bjet.first->phi());
     bjetEta_.at(iBJet).fill(trg_passed, bjet.first->eta());
     bjetPt_.at(iBJet).fill(trg_passed, bjet.first->pt());
-    bjetDeepFlav_.at(iBJet).fill(trg_passed, scores.at("deepFlav")); 
+    bjetDeepFlav_.at(iBJet).fill(trg_passed, scores.at("deepFlav"));
     bjetPNet_.at(iBJet).fill(trg_passed, scores.at("PNet"));
     bjetUParT_.at(iBJet).fill(trg_passed, scores.at("UParT"));
     bjetPtEta_.at(iBJet).fill(trg_passed, bjet.first->pt(), bjet.first->eta());
@@ -1412,9 +1412,12 @@ void BTVMonitor::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 
   desc.add<edm::InputTag>("photons", edm::InputTag("slimmedPhotons"));
   desc.add<edm::InputTag>("jets", edm::InputTag("slimmedJetsPuppi"));
   desc.add<edm::InputTag>("met", edm::InputTag("slimmedMETs"));
-  desc.add<std::vector<std::string> >(
-      "btagAlgos", {"pfDeepFlavourJetTags:probb", "pfDeepFlavourJetTags:probbb", "pfDeepFlavourJetTags:problepb", 
-      "pfParticleNetFromMiniAODAK4PuppiCentralDiscriminatorsJetTags:BvsAll", "pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll"});
+  desc.add<std::vector<std::string>>("btagAlgos",
+                                     {"pfDeepFlavourJetTags:probb",
+                                      "pfDeepFlavourJetTags:probbb",
+                                      "pfDeepFlavourJetTags:problepb",
+                                      "pfParticleNetFromMiniAODAK4PuppiCentralDiscriminatorsJetTags:BvsAll",
+                                      "pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll"});
 
   desc.add<std::string>("metSelection", "pt > 0");
   desc.add<std::string>("jetSelection", "pt > 0");
@@ -1483,31 +1486,31 @@ void BTVMonitor::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 
   std::vector<double> bins = {0.,   20.,  40.,  60.,  80.,  90.,  100., 110., 120., 130., 140., 150., 160.,
                               170., 180., 190., 200., 220., 240., 260., 280., 300., 350., 400., 450., 1000.};
   std::vector<double> eta_bins = {-3., -2.5, -2., -1.5, -1., -.5, 0., .5, 1., 1.5, 2., 2.5, 3.};
-  histoPSet.add<std::vector<double> >("metBinning", bins);
-  histoPSet.add<std::vector<double> >("HTBinning", bins);
-  histoPSet.add<std::vector<double> >("jetPtBinning", bins);
-  histoPSet.add<std::vector<double> >("elePtBinning", bins);
-  histoPSet.add<std::vector<double> >("muPtBinning", bins);
-  histoPSet.add<std::vector<double> >("jetEtaBinning", eta_bins);
-  histoPSet.add<std::vector<double> >("eleEtaBinning", eta_bins);
-  histoPSet.add<std::vector<double> >("muEtaBinning", eta_bins);
-  histoPSet.add<std::vector<double> >("invMassVariableBinning", bins);
-  histoPSet.add<std::vector<double> >("MHTVariableBinning", bins);
+  histoPSet.add<std::vector<double>>("metBinning", bins);
+  histoPSet.add<std::vector<double>>("HTBinning", bins);
+  histoPSet.add<std::vector<double>>("jetPtBinning", bins);
+  histoPSet.add<std::vector<double>>("elePtBinning", bins);
+  histoPSet.add<std::vector<double>>("muPtBinning", bins);
+  histoPSet.add<std::vector<double>>("jetEtaBinning", eta_bins);
+  histoPSet.add<std::vector<double>>("eleEtaBinning", eta_bins);
+  histoPSet.add<std::vector<double>>("muEtaBinning", eta_bins);
+  histoPSet.add<std::vector<double>>("invMassVariableBinning", bins);
+  histoPSet.add<std::vector<double>>("MHTVariableBinning", bins);
 
   std::vector<double> bins_2D = {0., 40., 80., 100., 120., 140., 160., 180., 200., 240., 280., 350., 450., 1000.};
   std::vector<double> eta_bins_2D = {-3., -2., -1., 0., 1., 2., 3.};
   std::vector<double> phi_bins_2D = {
       -3.1415, -2.5132, -1.8849, -1.2566, -0.6283, 0, 0.6283, 1.2566, 1.8849, 2.5132, 3.1415};
-  histoPSet.add<std::vector<double> >("HTBinning2D", bins_2D);
-  histoPSet.add<std::vector<double> >("jetPtBinning2D", bins_2D);
-  histoPSet.add<std::vector<double> >("elePtBinning2D", bins_2D);
-  histoPSet.add<std::vector<double> >("muPtBinning2D", bins_2D);
-  histoPSet.add<std::vector<double> >("phoPtBinning2D", bins_2D);
-  histoPSet.add<std::vector<double> >("jetEtaBinning2D", eta_bins_2D);
-  histoPSet.add<std::vector<double> >("eleEtaBinning2D", eta_bins_2D);
-  histoPSet.add<std::vector<double> >("muEtaBinning2D", eta_bins_2D);
-  histoPSet.add<std::vector<double> >("phoEtaBinning2D", eta_bins_2D);
-  histoPSet.add<std::vector<double> >("phiBinning2D", phi_bins_2D);
+  histoPSet.add<std::vector<double>>("HTBinning2D", bins_2D);
+  histoPSet.add<std::vector<double>>("jetPtBinning2D", bins_2D);
+  histoPSet.add<std::vector<double>>("elePtBinning2D", bins_2D);
+  histoPSet.add<std::vector<double>>("muPtBinning2D", bins_2D);
+  histoPSet.add<std::vector<double>>("phoPtBinning2D", bins_2D);
+  histoPSet.add<std::vector<double>>("jetEtaBinning2D", eta_bins_2D);
+  histoPSet.add<std::vector<double>>("eleEtaBinning2D", eta_bins_2D);
+  histoPSet.add<std::vector<double>>("muEtaBinning2D", eta_bins_2D);
+  histoPSet.add<std::vector<double>>("phoEtaBinning2D", eta_bins_2D);
+  histoPSet.add<std::vector<double>>("phiBinning2D", phi_bins_2D);
 
   edm::ParameterSetDescription lsPSet;
   fillHistoLSPSetDescription(lsPSet);

--- a/DQMOffline/Trigger/plugins/BTVMonitor.cc
+++ b/DQMOffline/Trigger/plugins/BTVMonitor.cc
@@ -1044,17 +1044,19 @@ void BTVMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
 
   edm::Handle<edm::View<pat::Muon>> muoHandle;
   iEvent.getByToken(muoToken_, muoHandle);
-  if (!muoHandle.isValid() && nmuons_ > 0) {
-    edm::LogWarning("BTVMonitor") << "Muon handle not valid \n";
-    return;
-  }
-
-  if (muoHandle->size() < nmuons_) {
-    return;
-  }
 
   std::vector<pat::Muon> muons;
   if (nmuons_ > 0) {
+
+    if (!muoHandle.isValid()) {
+    	edm::LogWarning("BTVMonitor") << "Muon handle not valid \n";
+    	return;
+    }
+    
+    if (muoHandle->size() < nmuons_) {
+    	return;
+    }
+    
     for (auto const& m : *muoHandle) {
       if (muoSelection_(m)) {
         muons.push_back(m);

--- a/DQMOffline/Trigger/plugins/BTVMonitor.cc
+++ b/DQMOffline/Trigger/plugins/BTVMonitor.cc
@@ -1047,16 +1047,15 @@ void BTVMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
 
   std::vector<pat::Muon> muons;
   if (nmuons_ > 0) {
-
     if (!muoHandle.isValid()) {
-    	edm::LogWarning("BTVMonitor") << "Muon handle not valid \n";
-    	return;
+      edm::LogWarning("BTVMonitor") << "Muon handle not valid \n";
+      return;
     }
-    
+
     if (muoHandle->size() < nmuons_) {
-    	return;
+      return;
     }
-    
+
     for (auto const& m : *muoHandle) {
       if (muoSelection_(m)) {
         muons.push_back(m);

--- a/DQMOffline/Trigger/plugins/BTVMonitor.cc
+++ b/DQMOffline/Trigger/plugins/BTVMonitor.cc
@@ -1,0 +1,1527 @@
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/Registry.h"
+#include "FWCore/Utilities/interface/transform.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+#include "CommonTools/TriggerUtils/interface/GenericTriggerEventFlag.h"
+#include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
+#include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
+#include "DataFormats/EgammaCandidates/interface/Photon.h"
+#include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
+#include "DataFormats/BTauReco/interface/JetTag.h"
+#include "DataFormats/METReco/interface/PFMET.h"
+#include "DataFormats/METReco/interface/PFMETCollection.h"
+#include "DQMOffline/Trigger/plugins/TriggerDQMBase.h"
+
+#include "DataFormats/PatCandidates/interface/Jet.h"
+#include "DataFormats/PatCandidates/interface/Electron.h"
+#include "DataFormats/PatCandidates/interface/Muon.h"
+#include "DataFormats/PatCandidates/interface/MET.h"
+#include "DataFormats/PatCandidates/interface/Photon.h"
+
+#include <string>
+#include <vector>
+#include <memory>
+#include <map>
+
+class BTVMonitor : public DQMEDAnalyzer, public TriggerDQMBase {
+public:
+  typedef dqm::reco::MonitorElement MonitorElement;
+  typedef dqm::reco::DQMStore DQMStore;
+
+  BTVMonitor(const edm::ParameterSet&);
+  ~BTVMonitor() throw() override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+protected:
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
+  void analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) override;
+
+  struct JetRefCompare {
+    inline bool operator()(const edm::RefToBase<pat::Jet>& j1, const edm::RefToBase<pat::Jet>& j2) const {
+      return (j1.id() < j2.id()) || ((j1.id() == j2.id()) && (j1.key() < j2.key()));
+    }
+  };
+
+  typedef std::map<std::string, float> BTagScores;
+  typedef std::map<edm::RefToBase<pat::Jet>, BTagScores, JetRefCompare> JetBTagMap;
+
+private:
+  const std::string folderName_;
+
+  const bool requireValidHLTPaths_;
+  bool hltPathsAreValid_;
+
+  edm::EDGetTokenT<reco::VertexCollection> vtxToken_;
+  edm::EDGetTokenT<edm::View<pat::Muon>> muoToken_;
+  edm::EDGetTokenT<edm::View<pat::Electron>> eleToken_; 
+  edm::EDGetTokenT<edm::ValueMap<bool> > elecIDToken_;
+  edm::EDGetTokenT<pat::PhotonCollection> phoToken_;
+  edm::EDGetTokenT<edm::View<pat::Jet> > jetToken_;
+  edm::EDGetTokenT<pat::METCollection> metToken_;
+  std::vector<std::string> btagAlgos_;
+  struct PVcut {
+    double dxy;
+    double dz;
+  };
+
+  MEbinning met_binning_;
+  MEbinning ls_binning_;
+  MEbinning phi_binning_;
+  MEbinning pt_binning_;
+  MEbinning eta_binning_;
+  MEbinning HT_binning_;
+  MEbinning DR_binning_;
+  MEbinning csv_binning_;
+  MEbinning invMass_mumu_binning_;
+  MEbinning MHT_binning_;
+
+  std::vector<double> met_variable_binning_;
+  std::vector<double> HT_variable_binning_;
+  std::vector<double> jetPt_variable_binning_;
+  std::vector<double> muPt_variable_binning_;
+  std::vector<double> elePt_variable_binning_;
+  std::vector<double> jetEta_variable_binning_;
+  std::vector<double> muEta_variable_binning_;
+  std::vector<double> eleEta_variable_binning_;
+  std::vector<double> invMass_mumu_variable_binning_;
+  std::vector<double> MHT_variable_binning_;
+
+  std::vector<double> HT_variable_binning_2D_;
+  std::vector<double> jetPt_variable_binning_2D_;
+  std::vector<double> muPt_variable_binning_2D_;
+  std::vector<double> elePt_variable_binning_2D_;
+  std::vector<double> phoPt_variable_binning_2D_;
+  std::vector<double> jetEta_variable_binning_2D_;
+  std::vector<double> muEta_variable_binning_2D_;
+  std::vector<double> eleEta_variable_binning_2D_;
+  std::vector<double> phoEta_variable_binning_2D_;
+  std::vector<double> phi_variable_binning_2D_;
+
+  ObjME metME_;
+  ObjME metME_variableBinning_;
+  ObjME metVsLS_;
+  ObjME metPhiME_;
+
+  ObjME jetVsLS_;
+  ObjME muVsLS_;
+  ObjME eleVsLS_;
+  ObjME phoVsLS_;
+  ObjME bjetVsLS_;
+  ObjME htVsLS_;
+
+  ObjME jetEtaPhi_HEP17_;  // for HEP17 monitoring
+
+  ObjME jetMulti_;
+  ObjME eleMulti_;
+  ObjME muMulti_;
+  ObjME phoMulti_;
+  ObjME bjetMulti_;
+
+  ObjME elePt_jetPt_;
+  ObjME elePt_eventHT_;
+
+  ObjME ele1Pt_ele2Pt_;
+  ObjME ele1Eta_ele2Eta_;
+  ObjME mu1Pt_mu2Pt_;
+  ObjME mu1Eta_mu2Eta_;
+  ObjME elePt_muPt_;
+  ObjME eleEta_muEta_;
+  ObjME invMass_mumu_;
+  ObjME eventMHT_;
+  ObjME invMass_mumu_variableBinning_;
+  ObjME eventMHT_variableBinning_;
+  ObjME muPt_phoPt_;
+  ObjME muEta_phoEta_;
+
+  ObjME DeltaR_jet_Mu_;
+
+  ObjME eventHT_;
+  ObjME eventHT_variableBinning_;
+
+  std::vector<ObjME> muPhi_;
+  std::vector<ObjME> muEta_;
+  std::vector<ObjME> muPt_;
+
+  std::vector<ObjME> elePhi_;
+  std::vector<ObjME> eleEta_;
+  std::vector<ObjME> elePt_;
+
+  std::vector<ObjME> jetPhi_;
+  std::vector<ObjME> jetEta_;
+  std::vector<ObjME> jetPt_;
+
+  std::vector<ObjME> phoPhi_;
+  std::vector<ObjME> phoEta_;
+  std::vector<ObjME> phoPt_;
+
+  std::vector<ObjME> bjetPhi_;
+  std::vector<ObjME> bjetEta_;
+  std::vector<ObjME> bjetPt_;
+  std::vector<ObjME> bjetDeepFlav_;
+  std::vector<ObjME> bjetPNet_;
+  std::vector<ObjME> bjetUParT_;
+
+  // 2D distributions
+  std::vector<ObjME> jetPtEta_;
+  std::vector<ObjME> jetEtaPhi_;
+
+  std::vector<ObjME> elePtEta_;
+  std::vector<ObjME> eleEtaPhi_;
+
+  std::vector<ObjME> muPtEta_;
+  std::vector<ObjME> muEtaPhi_;
+
+  std::vector<ObjME> phoPtEta_;
+  std::vector<ObjME> phoEtaPhi_;
+
+  std::vector<ObjME> bjetPtEta_;
+  std::vector<ObjME> bjetEtaPhi_;
+  std::vector<ObjME> bjetDeepFlavHT_;
+  std::vector<ObjME> bjetPNetHT_;
+  std::vector<ObjME> bjetUParTHT_;
+
+  std::unique_ptr<GenericTriggerEventFlag> num_genTriggerEventFlag_;
+  std::unique_ptr<GenericTriggerEventFlag> den_genTriggerEventFlag_;
+
+  StringCutObjectSelector<pat::MET> metSelection_;
+  StringCutObjectSelector<pat::Jet> jetSelection_;
+  StringCutObjectSelector<pat::Electron, true> eleSelection_;
+  StringCutObjectSelector<pat::Muon> muoSelection_;
+  StringCutObjectSelector<pat::Photon> phoSelection_;
+
+  StringCutObjectSelector<pat::Jet> HTdefinition_;
+
+  StringCutObjectSelector<reco::Vertex> vtxSelection_;
+
+  StringCutObjectSelector<pat::Jet, true> bjetSelection_;
+
+  unsigned int njets_;
+  unsigned int nelectrons_;
+  unsigned int nmuons_;
+  unsigned int nphotons_;
+  double leptJetDeltaRmin_;
+  double bJetMuDeltaRmax_;
+  double bJetDeltaEtaMax_;
+  double HTcut_;
+  unsigned int nbjets_;
+  double workingpoint_;
+  PVcut lepPVcuts_;
+  bool applyLeptonPVcuts_;
+
+  bool applyMETcut_ = false;
+
+  double invMassUppercut_;
+  double invMassLowercut_;
+  bool opsign_;
+  StringCutObjectSelector<pat::Jet> MHTdefinition_;
+  double MHTcut_;
+
+  bool invMassCutInAllMuPairs_;
+
+  bool enablePhotonPlot_;
+  bool enableMETPlot_;
+  bool enable2DPlots_;
+};
+
+BTVMonitor::BTVMonitor(const edm::ParameterSet& iConfig)
+    : folderName_(iConfig.getParameter<std::string>("FolderName")),
+      requireValidHLTPaths_(iConfig.getParameter<bool>("requireValidHLTPaths")),
+      hltPathsAreValid_(false),
+      vtxToken_(mayConsume<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertices"))),
+      muoToken_(mayConsume<edm::View<pat::Muon>>(iConfig.getParameter<edm::InputTag>("muons"))),
+      eleToken_(mayConsume<edm::View<pat::Electron>>(iConfig.getParameter<edm::InputTag>("electrons"))),
+      elecIDToken_(consumes<edm::ValueMap<bool>>(iConfig.getParameter<edm::InputTag>("elecID"))),
+      phoToken_(mayConsume<pat::PhotonCollection>(iConfig.getParameter<edm::InputTag>("photons"))),
+      jetToken_(mayConsume<edm::View<pat::Jet>>(iConfig.getParameter<edm::InputTag>("jets"))),
+      metToken_(consumes<pat::METCollection>(iConfig.getParameter<edm::InputTag>("met"))),
+      btagAlgos_(iConfig.getParameter<std::vector<std::string>>("btagAlgos")),
+      met_binning_(getHistoPSet(
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>("metPSet"))),
+      ls_binning_(
+          getHistoPSet(iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>("lsPSet"))),
+      phi_binning_(getHistoPSet(
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>("phiPSet"))),
+      pt_binning_(
+          getHistoPSet(iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>("ptPSet"))),
+      eta_binning_(getHistoPSet(
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>("etaPSet"))),
+      HT_binning_(
+          getHistoPSet(iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>("htPSet"))),
+      DR_binning_(
+          getHistoPSet(iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>("DRPSet"))),
+      csv_binning_(getHistoPSet(
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>("csvPSet"))),
+      invMass_mumu_binning_(getHistoPSet(
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>("invMassPSet"))),
+      MHT_binning_(getHistoPSet(
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>("MHTPSet"))),
+      met_variable_binning_(
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("metBinning")),
+      HT_variable_binning_(
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("HTBinning")),
+          jetPt_variable_binning_(
+            iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("jetPtBinning")),
+      muPt_variable_binning_(
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("muPtBinning")),
+      elePt_variable_binning_(
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("elePtBinning")),
+      jetEta_variable_binning_(
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("jetEtaBinning")),
+      muEta_variable_binning_(
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("muEtaBinning")),
+      eleEta_variable_binning_(
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("eleEtaBinning")),
+      invMass_mumu_variable_binning_(iConfig.getParameter<edm::ParameterSet>("histoPSet")
+                                         .getParameter<std::vector<double> >("invMassVariableBinning")),
+      MHT_variable_binning_(
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("MHTVariableBinning")),
+      HT_variable_binning_2D_(
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("HTBinning2D")),
+      jetPt_variable_binning_2D_(
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("jetPtBinning2D")),
+      muPt_variable_binning_2D_(
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("muPtBinning2D")),
+      elePt_variable_binning_2D_(
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("elePtBinning2D")),
+      phoPt_variable_binning_2D_(
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("phoPtBinning2D")),
+      jetEta_variable_binning_2D_(
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("jetEtaBinning2D")),
+      muEta_variable_binning_2D_(
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("muEtaBinning2D")),
+      eleEta_variable_binning_2D_(
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("eleEtaBinning2D")),
+      phoEta_variable_binning_2D_(
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("phoEtaBinning2D")),
+      phi_variable_binning_2D_(
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("phiBinning2D")),
+      num_genTriggerEventFlag_(new GenericTriggerEventFlag(
+          iConfig.getParameter<edm::ParameterSet>("numGenericTriggerEventPSet"), consumesCollector(), *this)),
+      den_genTriggerEventFlag_(new GenericTriggerEventFlag(
+          iConfig.getParameter<edm::ParameterSet>("denGenericTriggerEventPSet"), consumesCollector(), *this)),
+      metSelection_(iConfig.getParameter<std::string>("metSelection")),
+      jetSelection_(iConfig.getParameter<std::string>("jetSelection")),
+      eleSelection_(iConfig.getParameter<std::string>("eleSelection")),
+      muoSelection_(iConfig.getParameter<std::string>("muoSelection")),
+      phoSelection_(iConfig.getParameter<std::string>("phoSelection")),
+      HTdefinition_(iConfig.getParameter<std::string>("HTdefinition")),
+      vtxSelection_(iConfig.getParameter<std::string>("vertexSelection")),
+      bjetSelection_(iConfig.getParameter<std::string>("bjetSelection")),
+      njets_(iConfig.getParameter<unsigned int>("njets")),
+      nelectrons_(iConfig.getParameter<unsigned int>("nelectrons")),
+      nmuons_(iConfig.getParameter<unsigned int>("nmuons")),
+      nphotons_(iConfig.getParameter<unsigned int>("nphotons")),
+      leptJetDeltaRmin_(iConfig.getParameter<double>("leptJetDeltaRmin")),
+      bJetMuDeltaRmax_(iConfig.getParameter<double>("bJetMuDeltaRmax")),
+      bJetDeltaEtaMax_(iConfig.getParameter<double>("bJetDeltaEtaMax")),
+      HTcut_(iConfig.getParameter<double>("HTcut")),
+      nbjets_(iConfig.getParameter<unsigned int>("nbjets")),
+      workingpoint_(iConfig.getParameter<double>("workingpoint")),
+      applyLeptonPVcuts_(iConfig.getParameter<bool>("applyLeptonPVcuts")),
+      invMassUppercut_(iConfig.getParameter<double>("invMassUppercut")),
+      invMassLowercut_(iConfig.getParameter<double>("invMassLowercut")),
+      opsign_(iConfig.getParameter<bool>("oppositeSignMuons")),
+      MHTdefinition_(iConfig.getParameter<std::string>("MHTdefinition")),
+      MHTcut_(iConfig.getParameter<double>("MHTcut")),
+      invMassCutInAllMuPairs_(iConfig.getParameter<bool>("invMassCutInAllMuPairs")),
+      enablePhotonPlot_(iConfig.getParameter<bool>("enablePhotonPlot")),
+      enableMETPlot_(iConfig.getParameter<bool>("enableMETPlot")),
+      enable2DPlots_(iConfig.getParameter<bool>("enable2DPlots")) {
+  ObjME empty;
+
+  muPhi_ = std::vector<ObjME>(nmuons_, empty);
+  muEta_ = std::vector<ObjME>(nmuons_, empty);
+  muPt_ = std::vector<ObjME>(nmuons_, empty);
+  muPtEta_ = std::vector<ObjME>(nmuons_, empty);
+  muEtaPhi_ = std::vector<ObjME>(nmuons_, empty);
+
+  elePhi_ = std::vector<ObjME>(nelectrons_, empty);
+  eleEta_ = std::vector<ObjME>(nelectrons_, empty);
+  elePt_ = std::vector<ObjME>(nelectrons_, empty);
+  elePtEta_ = std::vector<ObjME>(nelectrons_, empty);
+  eleEtaPhi_ = std::vector<ObjME>(nelectrons_, empty);
+
+  jetPhi_ = std::vector<ObjME>(njets_, empty);
+  jetEta_ = std::vector<ObjME>(njets_, empty);
+  jetPt_ = std::vector<ObjME>(njets_, empty);
+  jetPtEta_ = std::vector<ObjME>(njets_, empty);
+  jetEtaPhi_ = std::vector<ObjME>(njets_, empty);
+
+  //Menglei Sun
+  phoPhi_ = std::vector<ObjME>(nphotons_, empty);
+  phoEta_ = std::vector<ObjME>(nphotons_, empty);
+  phoPt_ = std::vector<ObjME>(nphotons_, empty);
+  phoPtEta_ = std::vector<ObjME>(nphotons_, empty);
+  phoEtaPhi_ = std::vector<ObjME>(nphotons_, empty);
+
+  // Marina
+  bjetPhi_ = std::vector<ObjME>(nbjets_, empty);
+  bjetEta_ = std::vector<ObjME>(nbjets_, empty);
+  bjetPt_ = std::vector<ObjME>(nbjets_, empty);
+  bjetDeepFlav_ = std::vector<ObjME>(nbjets_, empty);
+  bjetPNet_ = std::vector<ObjME>(nbjets_, empty);
+  bjetUParT_ = std::vector<ObjME>(nbjets_, empty);
+  bjetPtEta_ = std::vector<ObjME>(nbjets_, empty);
+  bjetEtaPhi_ = std::vector<ObjME>(nbjets_, empty);
+  bjetDeepFlavHT_ = std::vector<ObjME>(nbjets_, empty);
+  bjetPNetHT_ = std::vector<ObjME>(nbjets_, empty);
+  bjetUParTHT_ = std::vector<ObjME>(nbjets_, empty);
+
+  //Suvankar
+  lepPVcuts_.dxy = (iConfig.getParameter<edm::ParameterSet>("leptonPVcuts")).getParameter<double>("dxy");
+  lepPVcuts_.dz = (iConfig.getParameter<edm::ParameterSet>("leptonPVcuts")).getParameter<double>("dz");
+}
+
+BTVMonitor::~BTVMonitor() throw() {
+  if (num_genTriggerEventFlag_)
+    num_genTriggerEventFlag_.reset();
+  if (den_genTriggerEventFlag_)
+    den_genTriggerEventFlag_.reset();
+}
+
+void BTVMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun, edm::EventSetup const& iSetup) {
+  // Initialize the GenericTriggerEventFlag
+  if (num_genTriggerEventFlag_ && num_genTriggerEventFlag_->on())
+    num_genTriggerEventFlag_->initRun(iRun, iSetup);
+  if (den_genTriggerEventFlag_ && den_genTriggerEventFlag_->on())
+    den_genTriggerEventFlag_->initRun(iRun, iSetup);
+
+  // check if every HLT path specified in numerator and denominator has a valid match in the HLT Menu
+  hltPathsAreValid_ = (num_genTriggerEventFlag_ && den_genTriggerEventFlag_ && num_genTriggerEventFlag_->on() &&
+                       den_genTriggerEventFlag_->on() && num_genTriggerEventFlag_->allHLTPathsAreValid() &&
+                       den_genTriggerEventFlag_->allHLTPathsAreValid());
+
+  // if valid HLT paths are required,
+  // create DQM outputs only if all paths are valid
+  if (requireValidHLTPaths_ and (not hltPathsAreValid_)) {
+    return;
+  }
+
+  std::string histname, histtitle;
+
+  std::string currentFolder = folderName_;
+  ibooker.setCurrentFolder(currentFolder);
+
+  if (enableMETPlot_) {
+    histname = "met";
+    histtitle = "PFMET";
+    bookME(ibooker, metME_, histname, histtitle, met_binning_.nbins, met_binning_.xmin, met_binning_.xmax);
+    setMETitle(metME_, "PF MET [GeV]", "events / [GeV]");
+
+    histname = "metPhi";
+    histtitle = "PFMET phi";
+    bookME(ibooker, metPhiME_, histname, histtitle, phi_binning_.nbins, phi_binning_.xmin, phi_binning_.xmax);
+    setMETitle(metPhiME_, "PF MET #phi", "events / 0.1 rad");
+
+    histname = "met_variable";
+    histtitle = "PFMET";
+    bookME(ibooker, metME_variableBinning_, histname, histtitle, met_variable_binning_);
+    setMETitle(metME_variableBinning_, "PF MET [GeV]", "events / [GeV]");
+
+    histname = "metVsLS";
+    histtitle = "PFMET vs LS";
+    bookME(ibooker,
+           metVsLS_,
+           histname,
+           histtitle,
+           ls_binning_.nbins,
+           ls_binning_.xmin,
+           ls_binning_.xmax,
+           met_binning_.xmin,
+           met_binning_.xmax);
+    setMETitle(metVsLS_, "LS", "PF MET [GeV]");
+  }
+
+  if (njets_ > 0) {
+    histname = "jetVsLS";
+    histtitle = "jet pt vs LS";
+    bookME(ibooker,
+           jetVsLS_,
+           histname,
+           histtitle,
+           ls_binning_.nbins,
+           ls_binning_.xmin,
+           ls_binning_.xmax,
+           pt_binning_.xmin,
+           pt_binning_.xmax);
+    setMETitle(jetVsLS_, "LS", "jet pt [GeV]");
+
+    histname = "jetEtaPhi_HEP17";
+    histtitle = "jet #eta-#phi for HEP17";
+    bookME(ibooker, jetEtaPhi_HEP17_, histname, histtitle, 10, -2.5, 2.5, 18, -3.1415, 3.1415);  // for HEP17 monitoring
+    setMETitle(jetEtaPhi_HEP17_, "jet #eta", "jet #phi");
+
+    histname = "jetMulti";
+    histtitle = "jet multiplicity";
+    bookME(ibooker, jetMulti_, histname, histtitle, 11, -.5, 10.5);
+    setMETitle(jetMulti_, "jet multiplicity", "events");
+  }
+
+  if (nmuons_ > 0) {
+    histname = "muVsLS";
+    histtitle = "muon pt vs LS";
+    bookME(ibooker,
+           muVsLS_,
+           histname,
+           histtitle,
+           ls_binning_.nbins,
+           ls_binning_.xmin,
+           ls_binning_.xmax,
+           pt_binning_.xmin,
+           pt_binning_.xmax);
+    setMETitle(muVsLS_, "LS", "muon pt [GeV]");
+
+    histname = "muMulti";
+    histtitle = "muon multiplicity";
+    bookME(ibooker, muMulti_, histname, histtitle, 6, -.5, 5.5);
+    setMETitle(muMulti_, "muon multiplicity", "events");
+
+    if (njets_ > 0) {
+      histname = "DeltaR_jet_Mu";
+      histtitle = "#DeltaR(jet,mu)";
+      bookME(ibooker, DeltaR_jet_Mu_, histname, histtitle, DR_binning_.nbins, DR_binning_.xmin, DR_binning_.xmax);
+      setMETitle(DeltaR_jet_Mu_, "#DeltaR(jet,mu)", "events");
+    }
+  }
+
+  if (nelectrons_ > 0) {
+    histname = "eleVsLS";
+    histtitle = "electron pt vs LS";
+    bookME(ibooker,
+           eleVsLS_,
+           histname,
+           histtitle,
+           ls_binning_.nbins,
+           ls_binning_.xmin,
+           ls_binning_.xmax,
+           pt_binning_.xmin,
+           pt_binning_.xmax);
+    setMETitle(eleVsLS_, "LS", "electron pt [GeV]");
+
+    histname = "eleMulti";
+    histtitle = "electron multiplicity";
+    bookME(ibooker, eleMulti_, histname, histtitle, 6, -.5, 5.5);
+    setMETitle(eleMulti_, "electron multiplicity", "events");
+
+    if (njets_ > 0 && enable2DPlots_) {
+      histname = "elePt_jetPt";
+      histtitle = "electron pt vs jet pt";
+      bookME(ibooker, elePt_jetPt_, histname, histtitle, elePt_variable_binning_2D_, jetPt_variable_binning_2D_);
+      setMETitle(elePt_jetPt_, "leading electron pt", "leading jet pt");
+    }
+
+    if (nmuons_ > 0 && enable2DPlots_) {
+      histname = "elePt_muPt";
+      histtitle = "electron pt vs muon pt";
+      bookME(ibooker, elePt_muPt_, histname, histtitle, elePt_variable_binning_2D_, muPt_variable_binning_2D_);
+      setMETitle(elePt_muPt_, "electron pt [GeV]", "muon pt [GeV]");
+
+      histname = "eleEta_muEta";
+      histtitle = "electron #eta vs muon #eta";
+      bookME(ibooker, eleEta_muEta_, histname, histtitle, eleEta_variable_binning_2D_, muEta_variable_binning_2D_);
+      setMETitle(eleEta_muEta_, "electron #eta", "muon #eta");
+    }
+  }
+
+  //Menglei
+  if (enablePhotonPlot_) {
+    if (nphotons_ > 0) {
+      histname = "photonVsLS";
+      histtitle = "photon pt vs LS";
+      bookME(ibooker,
+             phoVsLS_,
+             histname,
+             histtitle,
+             ls_binning_.nbins,
+             ls_binning_.xmin,
+             ls_binning_.xmax,
+             pt_binning_.xmin,
+             pt_binning_.xmax);
+      setMETitle(phoVsLS_, "LS", "photon pt [GeV]");
+    }
+  }
+
+  // Marina
+  if (nbjets_ > 0) {
+    histname = "bjetVsLS";
+    histtitle = "b-jet pt vs LS";
+    bookME(ibooker,
+           bjetVsLS_,
+           histname,
+           histtitle,
+           ls_binning_.nbins,
+           ls_binning_.xmin,
+           ls_binning_.xmax,
+           pt_binning_.xmin,
+           pt_binning_.xmax);
+    setMETitle(bjetVsLS_, "LS", "b-jet pt [GeV]");
+
+    histname = "bjetMulti";
+    histtitle = "b-jet multiplicity";
+    bookME(ibooker, bjetMulti_, histname, histtitle, 6, -.5, 5.5);
+    setMETitle(bjetMulti_, "b-jet multiplicity", "events");
+  }
+
+  if (nelectrons_ > 1 && enable2DPlots_) {
+    histname = "ele1Pt_ele2Pt";
+    histtitle = "electron-1 pt vs electron-2 pt";
+    bookME(ibooker, ele1Pt_ele2Pt_, histname, histtitle, elePt_variable_binning_2D_, elePt_variable_binning_2D_);
+    setMETitle(ele1Pt_ele2Pt_, "electron-1 pt [GeV]", "electron-2 pt [GeV]");
+
+    histname = "ele1Eta_ele2Eta";
+    histtitle = "electron-1 #eta vs electron-2 #eta";
+    bookME(ibooker, ele1Eta_ele2Eta_, histname, histtitle, eleEta_variable_binning_2D_, eleEta_variable_binning_2D_);
+    setMETitle(ele1Eta_ele2Eta_, "electron-1 #eta", "electron-2 #eta");
+  }
+
+  if (nmuons_ > 1) {
+    if (enable2DPlots_) {
+      histname = "mu1Pt_mu2Pt";
+      histtitle = "muon-1 pt vs muon-2 pt";
+      bookME(ibooker, mu1Pt_mu2Pt_, histname, histtitle, muPt_variable_binning_2D_, muPt_variable_binning_2D_);
+      setMETitle(mu1Pt_mu2Pt_, "muon-1 pt [GeV]", "muon-2 pt [GeV]");
+
+      histname = "mu1Eta_mu2Eta";
+      histtitle = "muon-1 #eta vs muon-2 #eta";
+      bookME(ibooker, mu1Eta_mu2Eta_, histname, histtitle, muEta_variable_binning_2D_, muEta_variable_binning_2D_);
+      setMETitle(mu1Eta_mu2Eta_, "muon-1 #eta", "muon-2 #eta");
+    }
+    //george
+    histname = "invMass";
+    histtitle = "M mu1 mu2";
+    bookME(ibooker,
+           invMass_mumu_,
+           histname,
+           histtitle,
+           invMass_mumu_binning_.nbins,
+           invMass_mumu_binning_.xmin,
+           invMass_mumu_binning_.xmax);
+    setMETitle(invMass_mumu_, "M(mu1,mu2) [GeV]", "events");
+    histname = "invMass_variable";
+    histtitle = "M mu1 mu2 variable";
+    bookME(ibooker, invMass_mumu_variableBinning_, histname, histtitle, invMass_mumu_variable_binning_);
+    setMETitle(invMass_mumu_variableBinning_, "M(mu1,mu2) [GeV]", "events / [GeV]");
+  }
+
+  if (HTcut_ > 0) {
+    histname = "htVsLS";
+    histtitle = "event HT vs LS";
+    bookME(ibooker,
+           htVsLS_,
+           histname,
+           histtitle,
+           ls_binning_.nbins,
+           ls_binning_.xmin,
+           ls_binning_.xmax,
+           pt_binning_.xmin,
+           pt_binning_.xmax);
+    setMETitle(htVsLS_, "LS", "event HT [GeV]");
+
+    histname = "eventHT";
+    histtitle = "event HT";
+    bookME(ibooker, eventHT_variableBinning_, histname, histtitle, HT_variable_binning_);
+    setMETitle(eventHT_variableBinning_, "event HT [GeV]", "events");
+
+    if (nelectrons_ > 0 && enable2DPlots_) {
+      histname = "elePt_eventHT";
+      histtitle = "electron pt vs event HT";
+      bookME(ibooker, elePt_eventHT_, histname, histtitle, elePt_variable_binning_2D_, HT_variable_binning_2D_);
+      setMETitle(elePt_eventHT_, "leading electron pt", "event HT");
+    }
+  }
+
+  if (MHTcut_ > 0) {
+    //george
+    histname = "eventMHT";
+    histtitle = "event MHT";
+    bookME(ibooker, eventMHT_, histname, histtitle, MHT_binning_.nbins, MHT_binning_.xmin, MHT_binning_.xmax);
+    setMETitle(eventMHT_, " event MHT [GeV]", "events");
+
+    histname = "eventMHT_variable";
+    histtitle = "event MHT variable";
+    bookME(ibooker, eventMHT_variableBinning_, histname, histtitle, MHT_variable_binning_);
+    setMETitle(eventMHT_variableBinning_, "event MHT [GeV]", "events / [GeV]");
+  }
+
+  //Menglei
+  if (enablePhotonPlot_) {
+    if ((nmuons_ > 0) && (nphotons_ > 0)) {
+      histname = "muPt_phoPt", histtitle = "muon pt vs photon pt";
+      bookME(ibooker, muPt_phoPt_, histname, histtitle, muPt_variable_binning_2D_, phoPt_variable_binning_2D_);
+      setMETitle(muPt_phoPt_, "muon pt [GeV]", "photon pt [GeV]");
+
+      histname = "muEta_phoEta", histtitle = "muon #eta vs photon #eta";
+      bookME(ibooker, muEta_phoEta_, histname, histtitle, muEta_variable_binning_2D_, phoEta_variable_binning_2D_);
+      setMETitle(muEta_phoEta_, "muon #eta", "photon #eta");
+    }
+  }
+
+  for (unsigned int iMu = 0; iMu < nmuons_; ++iMu) {
+    std::string index = std::to_string(iMu + 1);
+
+    histname = "muPt_";
+    histtitle = "muon p_{T} - ";
+    histname.append(index);
+    histtitle.append(index);
+    bookME(ibooker, muPt_.at(iMu), histname, histtitle, muPt_variable_binning_);
+    setMETitle(muPt_.at(iMu), "muon p_{T} [GeV]", "events");
+
+
+    histname = "muEta_";
+    histtitle = "muon #eta - ";
+    histname.append(index);
+    histtitle.append(index);
+    bookME(ibooker, muEta_.at(iMu), histname, histtitle, muEta_variable_binning_);
+    setMETitle(muEta_.at(iMu), " muon #eta", "events");
+
+    histname = "muPhi_";
+    histtitle = "muon #phi - ";
+    histname.append(index);
+    histtitle.append(index);
+    bookME(ibooker, muPhi_.at(iMu), histname, histtitle, phi_binning_.nbins, phi_binning_.xmin, phi_binning_.xmax);
+    setMETitle(muPhi_.at(iMu), " muon #phi", "events");
+
+    if (enable2DPlots_) {
+      histname = "muPtEta_";
+      histtitle = "muon p_{T} - #eta - ";
+      histname.append(index);
+      histtitle.append(index);
+      bookME(ibooker, muPtEta_.at(iMu), histname, histtitle, muPt_variable_binning_2D_, muEta_variable_binning_2D_);
+      setMETitle(muPtEta_.at(iMu), "muon p_{T} [GeV]", "muon #eta");
+
+      histname = "muEtaPhi_";
+      histtitle = "muon #eta - #phi - ";
+      histname.append(index);
+      histtitle.append(index);
+      bookME(ibooker, muEtaPhi_.at(iMu), histname, histtitle, muEta_variable_binning_2D_, phi_variable_binning_2D_);
+      setMETitle(muEtaPhi_.at(iMu), "muon #eta", "muon #phi");
+    }
+  }
+
+  for (unsigned int iEle = 0; iEle < nelectrons_; ++iEle) {
+    std::string index = std::to_string(iEle + 1);
+
+    histname = "elePt_";
+    histtitle = "electron p_{T} - ";
+    histname.append(index);
+    histtitle.append(index);
+    bookME(ibooker, elePt_.at(iEle), histname, histtitle, elePt_variable_binning_);
+    setMETitle(elePt_.at(iEle), "electron p_{T} [GeV]", "events");
+
+    histname = "eleEta_";
+    histtitle = "electron #eta - ";
+    histname.append(index);
+    histtitle.append(index);
+    bookME(ibooker, eleEta_.at(iEle), histname, histtitle, eleEta_variable_binning_);
+    setMETitle(eleEta_.at(iEle), "electron #eta", "events");
+
+    histname = "elePhi_";
+    histtitle = "electron #phi - ";
+    histname.append(index);
+    histtitle.append(index);
+    bookME(ibooker, elePhi_.at(iEle), histname, histtitle, phi_binning_.nbins, phi_binning_.xmin, phi_binning_.xmax);
+    setMETitle(elePhi_.at(iEle), " electron #phi", "events");
+
+    if (enable2DPlots_) {
+      histname = "elePtEta_";
+      histtitle = "electron p_{T} - #eta - ";
+      histname.append(index);
+      histtitle.append(index);
+      bookME(ibooker, elePtEta_.at(iEle), histname, histtitle, elePt_variable_binning_2D_, eleEta_variable_binning_2D_);
+      setMETitle(elePtEta_.at(iEle), "electron p_{T} [GeV]", "electron #eta");
+
+      histname = "eleEtaPhi_";
+      histtitle = "electron #eta - #phi - ";
+      histname.append(index);
+      histtitle.append(index);
+      bookME(ibooker, eleEtaPhi_.at(iEle), histname, histtitle, eleEta_variable_binning_2D_, phi_variable_binning_2D_);
+      setMETitle(eleEtaPhi_.at(iEle), "electron #eta", "electron #phi");
+    }
+  }
+
+  //Menglei
+  if (enablePhotonPlot_) {
+    for (unsigned int iPho(0); iPho < nphotons_; iPho++) {
+      std::string index = std::to_string(iPho + 1);
+
+      histname = "phoPt_";
+      histtitle = "photon p_{T} - ";
+      histname.append(index);
+      histtitle.append(index);
+      bookME(ibooker, phoPt_[iPho], histname, histtitle, pt_binning_.nbins, pt_binning_.xmin, pt_binning_.xmax);
+      setMETitle(phoPt_[iPho], "photon p_{T} [GeV]", "events");
+
+      histname = "phoEta_";
+      histtitle = "photon #eta - ";
+      histname.append(index);
+      histtitle.append(index);
+      bookME(ibooker, phoEta_[iPho], histname, histtitle, eta_binning_.nbins, eta_binning_.xmin, eta_binning_.xmax);
+      setMETitle(phoEta_[iPho], "photon #eta", "events");
+
+      histname = "phoPhi_";
+      histtitle = "photon #phi - ";
+      histname.append(index);
+      histtitle.append(index);
+      bookME(ibooker, phoPhi_[iPho], histname, histtitle, phi_binning_.nbins, phi_binning_.xmin, phi_binning_.xmax);
+      setMETitle(phoPhi_[iPho], "photon #phi", "events");
+
+      histname = "phoPtEta_";
+      histtitle = "photon p_{T} - #eta - ";
+      histname.append(index);
+      histtitle.append(index);
+      bookME(ibooker, phoPtEta_[iPho], histname, histtitle, phoPt_variable_binning_2D_, phoEta_variable_binning_2D_);
+      setMETitle(phoPtEta_[iPho], "photon p_{T} [GeV]", "photon #eta");
+
+      histname = "phoEtaPhi_";
+      histtitle = "photon #eta - #phi - ";
+      histname.append(index);
+      histtitle.append(index);
+      bookME(ibooker, phoEtaPhi_[iPho], histname, histtitle, phoEta_variable_binning_2D_, phi_variable_binning_2D_);
+      setMETitle(phoEtaPhi_[iPho], "photon #eta", "photon #phi");
+    }
+  }
+
+  for (unsigned int iJet = 0; iJet < njets_; ++iJet) {
+    std::string index = std::to_string(iJet + 1);
+
+    histname = "jetPt_";
+    histtitle = "jet p_{T} - ";
+    histname.append(index);
+    histtitle.append(index);
+    bookME(ibooker, jetPt_.at(iJet), histname, histtitle, jetPt_variable_binning_);
+    setMETitle(jetPt_.at(iJet), "jet p_{T} [GeV]", "events");
+
+    histname = "jetEta_";
+    histtitle = "jet #eta - ";
+    histname.append(index);
+    histtitle.append(index);
+    bookME(ibooker, jetEta_.at(iJet), histname, histtitle, jetEta_variable_binning_);
+    setMETitle(jetEta_.at(iJet), "jet #eta", "events");
+
+    histname = "jetPhi_";
+    histtitle = "jet #phi - ";
+    histname.append(index);
+    histtitle.append(index);
+    bookME(ibooker, jetPhi_.at(iJet), histname, histtitle, phi_binning_.nbins, phi_binning_.xmin, phi_binning_.xmax);
+    setMETitle(jetPhi_.at(iJet), "jet #phi", "events");
+
+    if (enable2DPlots_) {
+      histname = "jetPtEta_";
+      histtitle = "jet p_{T} - #eta - ";
+      histname.append(index);
+      histtitle.append(index);
+      bookME(ibooker, jetPtEta_.at(iJet), histname, histtitle, jetPt_variable_binning_2D_, jetEta_variable_binning_2D_);
+      setMETitle(jetPtEta_.at(iJet), "jet p_{T} [GeV]", "jet #eta");
+
+      histname = "jetEtaPhi_";
+      histtitle = "jet #eta - #phi - ";
+      histname.append(index);
+      histtitle.append(index);
+      bookME(ibooker, jetEtaPhi_.at(iJet), histname, histtitle, jetEta_variable_binning_2D_, phi_variable_binning_2D_);
+      setMETitle(jetEtaPhi_.at(iJet), "jet #eta", "jet #phi");
+    }
+  }
+
+  // Marina
+  for (unsigned int iBJet = 0; iBJet < nbjets_; ++iBJet) {
+    std::string index = std::to_string(iBJet + 1);
+
+    histname = "bjetPt_";
+    histtitle = "b-jet p_{T} - ";
+    histname.append(index);
+    histtitle.append(index);
+    bookME(ibooker, bjetPt_.at(iBJet), histname, histtitle, jetPt_variable_binning_);
+    setMETitle(bjetPt_.at(iBJet), "b-jet p_{T} [GeV]", "events");
+
+    histname = "bjetEta_";
+    histtitle = "b-jet #eta - ";
+    histname.append(index);
+    histtitle.append(index);
+    bookME(ibooker, bjetEta_.at(iBJet), histname, histtitle, jetEta_variable_binning_);
+    setMETitle(bjetEta_.at(iBJet), "b-jet #eta", "events");
+
+    histname = "bjetPhi_";
+    histtitle = "b-jet #phi - ";
+    histname.append(index);
+    histtitle.append(index);
+    bookME(ibooker, bjetPhi_.at(iBJet), histname, histtitle, phi_binning_.nbins, phi_binning_.xmin, phi_binning_.xmax);
+    setMETitle(bjetPhi_.at(iBJet), "b-jet #phi", "events");
+
+    histname = "bjetDeepFlav_";
+    histtitle = "b-jet DeepFlavour - ";
+    histname.append(index);
+    histtitle.append(index);
+    bookME(ibooker, bjetDeepFlav_.at(iBJet), histname, histtitle, csv_binning_.nbins, csv_binning_.xmin, csv_binning_.xmax);
+    setMETitle(bjetDeepFlav_.at(iBJet), "b-jet Deep Flavour", "events");
+
+    histname = "bjetPNet_";
+    histtitle = "b-jet ParticleNet - ";
+    histname.append(index);
+    histtitle.append(index);
+    bookME(ibooker, bjetPNet_.at(iBJet), histname, histtitle, csv_binning_.nbins, csv_binning_.xmin, csv_binning_.xmax);
+    setMETitle(bjetPNet_.at(iBJet), "b-jet ParticleNet", "events");
+
+    histname = "bjetUParT_";
+    histtitle = "b-jet UParT - ";
+    histname.append(index);
+    histtitle.append(index);
+    bookME(ibooker, bjetUParT_.at(iBJet), histname, histtitle, csv_binning_.nbins, csv_binning_.xmin, csv_binning_.xmax);
+    setMETitle(bjetUParT_.at(iBJet), "b-jet UParT", "events");
+
+    if (enable2DPlots_) {
+      histname = "bjetPtEta_";
+      histtitle = "b-jet p_{T} - #eta - ";
+      histname.append(index);
+      histtitle.append(index);
+      bookME(
+          ibooker, bjetPtEta_.at(iBJet), histname, histtitle, jetPt_variable_binning_2D_, jetEta_variable_binning_2D_);
+      setMETitle(bjetPtEta_.at(iBJet), "b-jet p_{T} [GeV]", "b-jet #eta");
+
+      histname = "bjetEtaPhi_";
+      histtitle = "b-jet #eta - #phi - ";
+      histname.append(index);
+      histtitle.append(index);
+      bookME(
+          ibooker, bjetEtaPhi_.at(iBJet), histname, histtitle, jetEta_variable_binning_2D_, phi_variable_binning_2D_);
+      setMETitle(bjetEtaPhi_.at(iBJet), "b-jet #eta", "b-jet #phi");
+    }
+
+    histname = "bjetDeepFlavHT_";
+    histtitle = "HT - b-jet DeepFlavour - ";
+    histname.append(index);
+    histtitle.append(index);
+    bookME(ibooker,
+           bjetDeepFlavHT_.at(iBJet),
+           histname,
+           histtitle,
+           csv_binning_.nbins,
+           csv_binning_.xmin,
+           csv_binning_.xmax,
+           HT_binning_.nbins,
+           HT_binning_.xmin,
+           HT_binning_.xmax);
+    setMETitle(bjetDeepFlavHT_.at(iBJet), "b-jet DeepFlavour", "event HT [GeV]");
+
+    histname = "bjetPNetHT_";
+    histtitle = "HT - b-jet ParticleNet - ";
+    histname.append(index);
+    histtitle.append(index);
+    bookME(ibooker,
+           bjetPNetHT_.at(iBJet),
+           histname,
+           histtitle,
+           csv_binning_.nbins,
+           csv_binning_.xmin,
+           csv_binning_.xmax,
+           HT_binning_.nbins,
+           HT_binning_.xmin,
+           HT_binning_.xmax);
+    setMETitle(bjetPNetHT_.at(iBJet), "b-jet ParticleNet", "event HT [GeV]");
+
+    histname = "bjetUParTHT_";
+    histtitle = "HT - b-jet UParT - ";
+    histname.append(index);
+    histtitle.append(index);
+    bookME(ibooker,
+           bjetUParTHT_.at(iBJet),
+           histname,
+           histtitle,
+           csv_binning_.nbins,
+           csv_binning_.xmin,
+           csv_binning_.xmax,
+           HT_binning_.nbins,
+           HT_binning_.xmin,
+           HT_binning_.xmax);
+    setMETitle(bjetUParTHT_.at(iBJet), "b-jet UParT", "event HT [GeV]");
+  }
+}
+
+void BTVMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) {
+  // if valid HLT paths are required,
+  // analyze event only if all paths are valid
+  if (requireValidHLTPaths_ and (not hltPathsAreValid_)) {
+    return;
+  }
+
+  // Filter out events if Trigger Filtering is requested
+  if (den_genTriggerEventFlag_->on() && !den_genTriggerEventFlag_->accept(iEvent, iSetup)) {
+    return;
+  }
+
+  edm::Handle<reco::VertexCollection> primaryVertices;
+  iEvent.getByToken(vtxToken_, primaryVertices);
+  //Primary Vertex selection
+  const reco::Vertex* pv = nullptr;
+  for (auto const& v : *primaryVertices) {
+    if (!vtxSelection_(v)) {
+      continue;
+    }
+    pv = &v;
+    break;
+  }
+  if (applyLeptonPVcuts_ && (pv == nullptr)) {
+    edm::LogWarning("BTVMonitor") << "Invalid handle to reco::VertexCollection, event will be skipped";
+    return;
+  }
+
+  edm::Handle<pat::METCollection> metHandle;
+  iEvent.getByToken(metToken_, metHandle);
+  if ((not metHandle.isValid()) && enableMETPlot_) {
+    edm::LogWarning("BTVMonitor") << "MET handle not valid \n";
+    return;
+  }
+
+  double met_pt(-99.);
+  double met_phi(-99.);
+
+  if (enableMETPlot_) {
+    const pat::MET& pfmet = metHandle->front();
+
+    if (!metSelection_(pfmet)) {
+      return;
+    }
+
+    met_pt = pfmet.pt();
+    met_phi = pfmet.phi();
+  }
+
+  edm::Handle<edm::View<pat::Electron>> eleHandle;
+  iEvent.getByToken(eleToken_, eleHandle);
+  if (!eleHandle.isValid() && nelectrons_ > 0) {
+    edm::LogWarning("BTVMonitor") << "Electron handle not valid \n";
+    return;
+  }
+
+  edm::Handle<edm::ValueMap<bool> > eleIDHandle;
+  iEvent.getByToken(elecIDToken_, eleIDHandle);
+  if (!eleIDHandle.isValid() && nelectrons_ > 0) {
+    edm::LogWarning("BTVMonitor") << "Electron ID handle not valid \n";
+    return;
+  }
+
+  std::vector<pat::Electron> electrons;
+  if (nelectrons_ > 0) {
+    if (eleHandle->size() < nelectrons_) {
+      return;
+    }
+
+    for (size_t index = 0; index < eleHandle->size(); index++) {
+      const auto e = eleHandle->at(index);
+      const auto el = eleHandle->ptrAt(index);
+
+      bool pass_id = (*eleIDHandle)[el];
+
+      if (eleSelection_(e) && pass_id) {
+        electrons.push_back(e);
+      }
+
+      if (applyLeptonPVcuts_ && ((std::fabs(e.gsfTrack()->dxy(pv->position())) >= lepPVcuts_.dxy) ||
+                                 (std::fabs(e.gsfTrack()->dz(pv->position())) >= lepPVcuts_.dz))) {
+        continue;
+      }
+    }
+
+    if (electrons.size() < nelectrons_) {
+      return;
+    }
+  }
+
+  edm::Handle<edm::View<pat::Muon>> muoHandle;
+  iEvent.getByToken(muoToken_, muoHandle);
+  if (!muoHandle.isValid() && nmuons_ > 0) {
+    edm::LogWarning("BTVMonitor") << "Muon handle not valid \n";
+    return;
+  }
+
+  if (muoHandle->size() < nmuons_) {
+    return;
+  }
+
+  std::vector<pat::Muon> muons;
+  if (nmuons_ > 0) {
+    for (auto const& m : *muoHandle) {
+      if (muoSelection_(m)) {
+        muons.push_back(m);
+      }
+
+      if (applyLeptonPVcuts_ && ((std::fabs(m.muonBestTrack()->dxy(pv->position())) >= lepPVcuts_.dxy) ||
+                                 (std::fabs(m.muonBestTrack()->dz(pv->position())) >= lepPVcuts_.dz))) {
+        continue;
+      }
+    }
+
+    if (muons.size() < nmuons_) {
+      return;
+    }
+  }
+
+  double mll(-2);
+  if (nmuons_ > 1) {
+    mll = (muons[0].p4() + muons[1].p4()).M();
+
+    if ((invMassUppercut_ > -1) && (invMassLowercut_ > -1) && ((mll > invMassUppercut_) || (mll < invMassLowercut_))) {
+      return;
+    }
+    if (opsign_ && (muons[0].charge() == muons[1].charge())) {
+      return;
+    }
+  }
+
+  edm::Handle<pat::PhotonCollection> phoHandle;
+  iEvent.getByToken(phoToken_, phoHandle);
+  if (!phoHandle.isValid()) {
+    edm::LogWarning("BTVMonitor") << "Photon handle not valid \n";
+    return;
+  }
+  if (phoHandle->size() < nphotons_) {
+    return;
+  }
+
+  std::vector<pat::Photon> photons;
+  for (auto const& p : *phoHandle) {
+    if (phoSelection_(p)) {
+      photons.push_back(p);
+    }
+  }
+  if (photons.size() < nphotons_) {
+    return;
+  }
+
+  double eventHT(0.);
+  math::XYZTLorentzVector eventMHT(0., 0., 0., 0.);
+
+  edm::Handle<edm::View<pat::Jet>> jetHandle;
+  iEvent.getByToken(jetToken_, jetHandle);
+  if (!jetHandle.isValid() && njets_ > 0) {
+    edm::LogWarning("BTVMonitor") << "Jet handle not valid \n";
+    return;
+  }
+  std::vector<pat::Jet> jets;
+  if (njets_ > 0) {
+    if (jetHandle->size() < njets_)
+      return;
+    for (auto const& j : *jetHandle) {
+      if (HTdefinition_(j)) {
+        eventHT += j.pt();
+      }
+      if (MHTdefinition_(j)) {
+        eventMHT += j.p4();
+      }
+      if (jetSelection_(j)) {
+        bool isJetOverlappedWithLepton = false;
+        if (nmuons_ > 0) {
+          for (auto const& m : muons) {
+            if (deltaR(j, m) < leptJetDeltaRmin_) {
+              isJetOverlappedWithLepton = true;
+              break;
+            }
+          }
+        }
+        if (isJetOverlappedWithLepton)
+          continue;
+        if (nelectrons_ > 0) {
+          for (auto const& e : electrons) {
+            if (deltaR(j, e) < leptJetDeltaRmin_) {
+              isJetOverlappedWithLepton = true;
+              break;
+            }
+          }
+        }
+        if (isJetOverlappedWithLepton)
+          continue;
+        jets.push_back(j);
+      }
+    }
+    if (jets.size() < njets_)
+      return;
+  }
+
+  if (eventHT < HTcut_) {
+    return;
+  }
+
+  if ((MHTcut_ > 0) && (eventMHT.pt() < MHTcut_)) {
+    return;
+  }
+
+  bool allpairs = false;
+  if (nmuons_ > 2) {
+    double mumu_mass;
+    for (unsigned int idx = 0; idx < muons.size(); idx++) {
+      for (unsigned int idx2 = idx + 1; idx2 < muons.size(); idx2++) {
+        //compute inv mass of two different leptons
+        mumu_mass = (muons[idx2].p4() + muons[idx2].p4()).M();
+        if (mumu_mass < invMassLowercut_ || mumu_mass > invMassUppercut_)
+          allpairs = true;
+      }
+    }
+  }
+  //cut only if enabled and the event has a pair that failed the mll range
+  if (allpairs && invMassCutInAllMuPairs_) {
+    return;
+  }
+
+  JetBTagMap bjets;
+
+  if (nbjets_ > 0) {
+
+    edm::Handle<edm::View<pat::Jet>> bjetHandle;
+    iEvent.getByToken(jetToken_, bjetHandle); 
+    if (!bjetHandle.isValid()) {
+      edm::LogWarning("BTVMonitor") << "B-Jet handle not valid, skipping event\n";
+      return;
+    }
+
+    for (size_t i = 0; i < bjetHandle->size(); ++i) {
+      const auto& bJet = (*bjetHandle)[i];
+
+      if (!bjetSelection_(bJet)) {
+        continue;
+      }
+      edm::RefToBase<pat::Jet> jetRef(bjetHandle, i);
+      float deepFlavScore = 0.f;
+      float pNetScore = 0.f;
+      float UParTScore = 0.f;
+      bool haveDeepFlav = false;
+      bool havePNet = false;
+      bool haveUParT = false;
+
+      for (auto const& algoName : btagAlgos_) { // loop over all specified b-tagging algorithms
+        float disc = bJet.bDiscriminator(algoName);
+        if (!std::isfinite(disc)) {
+          continue;
+        }
+        if (algoName.find("DeepFlavour") != std::string::npos) {
+          deepFlavScore += disc; // Sum three deepFlavour scores
+          haveDeepFlav = true;
+        }
+        if (algoName.find("ParticleNet") != std::string::npos) {
+          pNetScore = disc; 
+          havePNet = true;
+        }
+        if (algoName.find("ParticleTransformer") != std::string::npos) {
+          UParTScore = disc; 
+          haveUParT = true;
+        }
+      }
+
+      BTagScores scores; 
+      scores["deepFlav"] = haveDeepFlav ? deepFlavScore : std::numeric_limits<float>::quiet_NaN();
+      scores["PNet"] = havePNet    ? pNetScore    : std::numeric_limits<float>::quiet_NaN();
+      scores["UParT"] = haveUParT    ? UParTScore    : std::numeric_limits<float>::quiet_NaN();
+      bjets.insert(std::make_pair(jetRef, scores));
+
+      if (bjets.size() < nbjets_) {
+        return;
+      }
+    }
+  }
+  if (nbjets_ > 1) {
+    double deltaEta = std::abs(bjets.begin()->first->eta() - (++bjets.begin())->first->eta());
+    if (deltaEta > bJetDeltaEtaMax_)
+      return;
+  }
+
+  if ((nbjets_ > 0) && (nmuons_ > 0)) {
+    bool foundMuonInsideJet = false;
+    for (auto const& bjet : bjets) {
+      for (auto const& mu : muons) {
+        double dR = deltaR(*bjet.first, mu);
+        if (dR < bJetMuDeltaRmax_) {
+          foundMuonInsideJet = true;
+          break;
+        }
+      }
+      if (foundMuonInsideJet)
+        break;
+    }
+
+    if (!foundMuonInsideJet)
+      return;
+  }
+
+  const int ls = iEvent.id().luminosityBlock();
+
+  // numerator condition
+  const bool trg_passed = (num_genTriggerEventFlag_->on() && num_genTriggerEventFlag_->accept(iEvent, iSetup));
+
+  if (enableMETPlot_) {
+    metME_.fill(trg_passed, met_pt);
+    metME_variableBinning_.fill(trg_passed, met_pt);
+    metPhiME_.fill(trg_passed, met_phi);
+    metVsLS_.fill(trg_passed, ls, met_pt);
+  }
+  if (HTcut_ > 0) {
+    eventHT_.fill(trg_passed, eventHT);
+    eventHT_variableBinning_.fill(trg_passed, eventHT);
+    htVsLS_.fill(trg_passed, ls, eventHT);
+  }
+  //george
+  if (MHTcut_ > 0) {
+    eventMHT_.fill(trg_passed, eventMHT.pt());
+    eventMHT_variableBinning_.fill(trg_passed, eventMHT.pt());
+  }
+
+  if (njets_ > 0) {
+    jetMulti_.fill(trg_passed, jets.size());
+    jetEtaPhi_HEP17_.fill(trg_passed, jets.at(0).eta(), jets.at(0).phi());  // for HEP17 monitorning
+    jetVsLS_.fill(trg_passed, ls, jets.at(0).pt());
+  }
+
+  if (enablePhotonPlot_) {
+    phoMulti_.fill(trg_passed, photons.size());
+  }
+
+  // Marina
+  if (nbjets_ > 0) {
+    bjetMulti_.fill(trg_passed, bjets.size());
+    bjetVsLS_.fill(trg_passed, ls, bjets.begin()->first->pt());
+  }
+
+  if (nmuons_ > 0) {
+    muMulti_.fill(trg_passed, muons.size());
+    muVsLS_.fill(trg_passed, ls, muons.at(0).pt());
+    if (nmuons_ > 1) {
+      mu1Pt_mu2Pt_.fill(trg_passed, muons.at(0).pt(), muons.at(1).pt());
+      mu1Eta_mu2Eta_.fill(trg_passed, muons.at(0).eta(), muons.at(1).eta());
+      invMass_mumu_.fill(trg_passed, mll);
+      invMass_mumu_variableBinning_.fill(trg_passed, mll);
+    }
+    if (njets_ > 0) {
+      DeltaR_jet_Mu_.fill(trg_passed, deltaR(jets.at(0), muons.at(0)));
+    }
+  }
+
+  if (nelectrons_ > 0) {
+    eleMulti_.fill(trg_passed, electrons.size());
+    eleVsLS_.fill(trg_passed, ls, electrons.at(0).pt());
+    if (HTcut_ > 0)
+      elePt_eventHT_.fill(trg_passed, electrons.at(0).pt(), eventHT);
+    if (njets_ > 0)
+      elePt_jetPt_.fill(trg_passed, electrons.at(0).pt(), jets.at(0).pt());
+    if (nmuons_ > 0) {
+      elePt_muPt_.fill(trg_passed, electrons.at(0).pt(), muons.at(0).pt());
+      eleEta_muEta_.fill(trg_passed, electrons.at(0).eta(), muons.at(0).eta());
+    }
+    if (nelectrons_ > 1) {
+      ele1Pt_ele2Pt_.fill(trg_passed, electrons.at(0).pt(), electrons.at(1).pt());
+      ele1Eta_ele2Eta_.fill(trg_passed, electrons.at(0).eta(), electrons.at(1).eta());
+    }
+  }
+
+  if (enablePhotonPlot_) {
+    if (nphotons_ > 0) {
+      phoVsLS_.fill(trg_passed, ls, photons.at(0).pt());
+      if (nmuons_ > 0) {
+        muPt_phoPt_.fill(trg_passed, muons.at(0).pt(), photons.at(0).pt());
+        muEta_phoEta_.fill(trg_passed, muons.at(0).eta(), photons.at(0).eta());
+      }
+    }
+  }
+
+  for (unsigned int iMu = 0; iMu < muons.size(); ++iMu) {
+    if (iMu >= nmuons_)
+      break;
+    muPhi_.at(iMu).fill(trg_passed, muons.at(iMu).phi());
+    muEta_.at(iMu).fill(trg_passed, muons.at(iMu).eta());
+    muPt_.at(iMu).fill(trg_passed, muons.at(iMu).pt());
+    muPtEta_.at(iMu).fill(trg_passed, muons.at(iMu).pt(), muons.at(iMu).eta());
+    muEtaPhi_.at(iMu).fill(trg_passed, muons.at(iMu).eta(), muons.at(iMu).phi());
+  }
+  for (unsigned int iEle = 0; iEle < electrons.size(); ++iEle) {
+    if (iEle >= nelectrons_)
+      break;
+    elePhi_.at(iEle).fill(trg_passed, electrons.at(iEle).phi());
+    eleEta_.at(iEle).fill(trg_passed, electrons.at(iEle).eta());
+    elePt_.at(iEle).fill(trg_passed, electrons.at(iEle).pt());
+    elePtEta_.at(iEle).fill(trg_passed, electrons.at(iEle).pt(), electrons.at(iEle).eta());
+    eleEtaPhi_.at(iEle).fill(trg_passed, electrons.at(iEle).eta(), electrons.at(iEle).phi());
+  }
+  //Menglei
+  if (enablePhotonPlot_) {
+    for (unsigned int iPho = 0; iPho < photons.size(); ++iPho) {
+      if (iPho >= nphotons_)
+        break;
+      phoPhi_[iPho].fill(trg_passed, photons[iPho].phi());
+      phoEta_[iPho].fill(trg_passed, photons[iPho].eta());
+      phoPt_[iPho].fill(trg_passed, photons[iPho].pt());
+      phoPtEta_[iPho].fill(trg_passed, photons[iPho].pt(), photons[iPho].eta());
+      phoEtaPhi_[iPho].fill(trg_passed, photons[iPho].eta(), photons[iPho].phi());
+    }
+  }
+
+  for (unsigned int iJet = 0; iJet < jets.size(); ++iJet) {
+    if (iJet >= njets_)
+      break;
+    jetPhi_.at(iJet).fill(trg_passed, jets.at(iJet).phi());
+    jetEta_.at(iJet).fill(trg_passed, jets.at(iJet).eta());
+    jetPt_.at(iJet).fill(trg_passed, jets.at(iJet).pt());
+    jetPtEta_.at(iJet).fill(trg_passed, jets.at(iJet).pt(), jets.at(iJet).eta());
+    jetEtaPhi_.at(iJet).fill(trg_passed, jets.at(iJet).eta(), jets.at(iJet).phi());
+  }
+
+  // Marina
+  unsigned int iBJet = 0;
+  for (auto& bjet : bjets) {
+    if (iBJet >= nbjets_)
+      break;
+    const BTagScores &scores = bjet.second;
+
+    bjetPhi_.at(iBJet).fill(trg_passed, bjet.first->phi());
+    bjetEta_.at(iBJet).fill(trg_passed, bjet.first->eta());
+    bjetPt_.at(iBJet).fill(trg_passed, bjet.first->pt());
+    bjetDeepFlav_.at(iBJet).fill(trg_passed, scores.at("deepFlav")); 
+    bjetPNet_.at(iBJet).fill(trg_passed, scores.at("PNet"));
+    bjetUParT_.at(iBJet).fill(trg_passed, scores.at("UParT"));
+    bjetPtEta_.at(iBJet).fill(trg_passed, bjet.first->pt(), bjet.first->eta());
+    bjetEtaPhi_.at(iBJet).fill(trg_passed, bjet.first->eta(), bjet.first->phi());
+    bjetDeepFlavHT_.at(iBJet).fill(trg_passed, scores.at("deepFlav"), eventHT);
+    bjetPNetHT_.at(iBJet).fill(trg_passed, scores.at("PNet"), eventHT);
+    bjetUParTHT_.at(iBJet).fill(trg_passed, scores.at("UParT"), eventHT);
+
+    iBJet++;
+  }
+}
+
+void BTVMonitor::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<std::string>("FolderName", "HLT/BTV/default");
+
+  desc.add<bool>("requireValidHLTPaths", true);
+
+  desc.add<edm::InputTag>("vertices", edm::InputTag("offlineSlimmedPrimaryVertices"));
+  desc.add<edm::InputTag>("muons", edm::InputTag("slimmedMuons"));
+  desc.add<edm::InputTag>("electrons", edm::InputTag("slimmedElectrons"));
+  desc.add<edm::InputTag>("elecID",
+                          edm::InputTag("egmGsfElectronIDsForDQM:cutBasedElectronID-RunIIIWinter22-V1-tight"));
+  desc.add<edm::InputTag>("photons", edm::InputTag("slimmedPhotons"));
+  desc.add<edm::InputTag>("jets", edm::InputTag("slimmedJetsPuppi"));
+  desc.add<edm::InputTag>("met", edm::InputTag("slimmedMETs"));
+  desc.add<std::vector<std::string> >(
+      "btagAlgos", {"pfDeepFlavourJetTags:probb", "pfDeepFlavourJetTags:probbb", "pfDeepFlavourJetTags:problepb", 
+      "pfParticleNetFromMiniAODAK4PuppiCentralDiscriminatorsJetTags:BvsAll", "pfUnifiedParticleTransformerAK4DiscriminatorsJetTags:BvsAll"});
+
+  desc.add<std::string>("metSelection", "pt > 0");
+  desc.add<std::string>("jetSelection", "pt > 0");
+  desc.add<std::string>("eleSelection", "pt > 0");
+  desc.add<std::string>("muoSelection", "pt > 0");
+  desc.add<std::string>("phoSelection", "pt > 0");
+  desc.add<std::string>("HTdefinition", "pt > 0 & abs(eta)<2.5");
+  desc.add<std::string>("vertexSelection", "!isFake");
+  desc.add<std::string>("bjetSelection", "pt > 30 & abs(eta)<2.4");
+  desc.add<unsigned int>("njets", 0);
+  desc.add<unsigned int>("nelectrons", 0);
+  desc.add<unsigned int>("nmuons", 0);
+  desc.add<unsigned int>("nphotons", 0);
+  desc.add<double>("leptJetDeltaRmin", 0);
+  desc.add<double>("bJetMuDeltaRmax", 9999.);
+  desc.add<double>("bJetDeltaEtaMax", 9999.);
+  desc.add<double>("HTcut", 0);
+
+  desc.add<unsigned int>("nbjets", 1);
+  desc.add<double>("workingpoint", -1);  // no cut applied
+  desc.add<bool>("applyLeptonPVcuts", false);
+  desc.add<double>("invMassUppercut", -1.0);
+  desc.add<double>("invMassLowercut", -1.0);
+  desc.add<bool>("oppositeSignMuons", false);
+  desc.add<std::string>("MHTdefinition", "pt > 0");
+  desc.add<double>("MHTcut", -1);
+  desc.add<bool>("invMassCutInAllMuPairs", false);
+  desc.add<bool>("enablePhotonPlot", false);
+  desc.add<bool>("enableMETPlot", false);
+  desc.add<bool>("enable2DPlots", true);
+
+  edm::ParameterSetDescription genericTriggerEventPSet;
+  GenericTriggerEventFlag::fillPSetDescription(genericTriggerEventPSet);
+  desc.add<edm::ParameterSetDescription>("numGenericTriggerEventPSet", genericTriggerEventPSet);
+  desc.add<edm::ParameterSetDescription>("denGenericTriggerEventPSet", genericTriggerEventPSet);
+
+  edm::ParameterSetDescription histoPSet;
+  edm::ParameterSetDescription metPSet;
+  edm::ParameterSetDescription phiPSet;
+  edm::ParameterSetDescription etaPSet;
+  edm::ParameterSetDescription ptPSet;
+  edm::ParameterSetDescription htPSet;
+  edm::ParameterSetDescription DRPSet;
+  edm::ParameterSetDescription csvPSet;
+  edm::ParameterSetDescription invMassPSet;
+  edm::ParameterSetDescription MHTPSet;
+  fillHistoPSetDescription(metPSet);
+  fillHistoPSetDescription(phiPSet);
+  fillHistoPSetDescription(ptPSet);
+  fillHistoPSetDescription(etaPSet);
+  fillHistoPSetDescription(htPSet);
+  fillHistoPSetDescription(DRPSet);
+  fillHistoPSetDescription(csvPSet);
+  fillHistoPSetDescription(MHTPSet);
+  fillHistoPSetDescription(invMassPSet);
+  histoPSet.add<edm::ParameterSetDescription>("metPSet", metPSet);
+  histoPSet.add<edm::ParameterSetDescription>("etaPSet", etaPSet);
+  histoPSet.add<edm::ParameterSetDescription>("phiPSet", phiPSet);
+  histoPSet.add<edm::ParameterSetDescription>("ptPSet", ptPSet);
+  histoPSet.add<edm::ParameterSetDescription>("htPSet", htPSet);
+  histoPSet.add<edm::ParameterSetDescription>("DRPSet", DRPSet);
+  histoPSet.add<edm::ParameterSetDescription>("csvPSet", csvPSet);
+  histoPSet.add<edm::ParameterSetDescription>("invMassPSet", invMassPSet);
+  histoPSet.add<edm::ParameterSetDescription>("MHTPSet", MHTPSet);
+
+  std::vector<double> bins = {0.,   20.,  40.,  60.,  80.,  90.,  100., 110., 120., 130., 140., 150., 160.,
+                              170., 180., 190., 200., 220., 240., 260., 280., 300., 350., 400., 450., 1000.};
+  std::vector<double> eta_bins = {-3., -2.5, -2., -1.5, -1., -.5, 0., .5, 1., 1.5, 2., 2.5, 3.};
+  histoPSet.add<std::vector<double> >("metBinning", bins);
+  histoPSet.add<std::vector<double> >("HTBinning", bins);
+  histoPSet.add<std::vector<double> >("jetPtBinning", bins);
+  histoPSet.add<std::vector<double> >("elePtBinning", bins);
+  histoPSet.add<std::vector<double> >("muPtBinning", bins);
+  histoPSet.add<std::vector<double> >("jetEtaBinning", eta_bins);
+  histoPSet.add<std::vector<double> >("eleEtaBinning", eta_bins);
+  histoPSet.add<std::vector<double> >("muEtaBinning", eta_bins);
+  histoPSet.add<std::vector<double> >("invMassVariableBinning", bins);
+  histoPSet.add<std::vector<double> >("MHTVariableBinning", bins);
+
+  std::vector<double> bins_2D = {0., 40., 80., 100., 120., 140., 160., 180., 200., 240., 280., 350., 450., 1000.};
+  std::vector<double> eta_bins_2D = {-3., -2., -1., 0., 1., 2., 3.};
+  std::vector<double> phi_bins_2D = {
+      -3.1415, -2.5132, -1.8849, -1.2566, -0.6283, 0, 0.6283, 1.2566, 1.8849, 2.5132, 3.1415};
+  histoPSet.add<std::vector<double> >("HTBinning2D", bins_2D);
+  histoPSet.add<std::vector<double> >("jetPtBinning2D", bins_2D);
+  histoPSet.add<std::vector<double> >("elePtBinning2D", bins_2D);
+  histoPSet.add<std::vector<double> >("muPtBinning2D", bins_2D);
+  histoPSet.add<std::vector<double> >("phoPtBinning2D", bins_2D);
+  histoPSet.add<std::vector<double> >("jetEtaBinning2D", eta_bins_2D);
+  histoPSet.add<std::vector<double> >("eleEtaBinning2D", eta_bins_2D);
+  histoPSet.add<std::vector<double> >("muEtaBinning2D", eta_bins_2D);
+  histoPSet.add<std::vector<double> >("phoEtaBinning2D", eta_bins_2D);
+  histoPSet.add<std::vector<double> >("phiBinning2D", phi_bins_2D);
+
+  edm::ParameterSetDescription lsPSet;
+  fillHistoLSPSetDescription(lsPSet);
+  histoPSet.add<edm::ParameterSetDescription>("lsPSet", lsPSet);
+
+  desc.add<edm::ParameterSetDescription>("histoPSet", histoPSet);
+
+  edm::ParameterSetDescription lPVcutPSet;
+  lPVcutPSet.add<double>("dxy", 9999.);
+  lPVcutPSet.add<double>("dz", 9999.);
+  desc.add<edm::ParameterSetDescription>("leptonPVcuts", lPVcutPSet);
+
+  descriptions.add("BTVMonitoring", desc);
+}
+
+// Define this as a plug-in
+DEFINE_FWK_MODULE(BTVMonitor);

--- a/DQMOffline/Trigger/plugins/BTVMonitor.cc
+++ b/DQMOffline/Trigger/plugins/BTVMonitor.cc
@@ -1404,7 +1404,7 @@ void BTVMonitor::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 
 
   desc.add<bool>("requireValidHLTPaths", true);
 
-  desc.add<edm::InputTag>("vertices", edm::InputTag("offlineSlimmedPrimaryVertices"));
+  desc.add<edm::InputTag>("vertices", edm::InputTag("offlinePrimaryVertices"));
   desc.add<edm::InputTag>("muons", edm::InputTag("slimmedMuons"));
   desc.add<edm::InputTag>("electrons", edm::InputTag("slimmedElectrons"));
   desc.add<edm::InputTag>("elecID",

--- a/DQMOffline/Trigger/python/BTaggingMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/BTaggingMonitor_cfi.py
@@ -1,8 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
-from DQMOffline.Trigger.topMonitoring_cfi import topMonitoring
+from DQMOffline.Trigger.BTVMonitoring_cfi import BTVMonitoring
 
-hltBTVmonitoring = topMonitoring.clone(
+
+hltBTVmonitoring = BTVMonitoring.clone(
     FolderName = 'HLT/BTV/default/',
     
     histoPSet = dict(
@@ -71,14 +72,11 @@ hltBTVmonitoring = topMonitoring.clone(
         HTBinning2D  =[0,20,40,70,100,150,200,400,700],
         phiBinning2D = [-3.1416,-1.8849,-0.6283,0.6283,1.8849,3.1416],
     ),
-    met       = "pfMet", # pfMet  
-    jets      = "ak4PFJetsPuppi", #ak4PFJetsCHS,  ak4PFJets, ak4PFJetsCHS, ak4PFJets
-    electrons = "gedGsfElectrons", # while pfIsolatedElectronsEI are reco::PFCandidate !
-    muons     = "muons", # while pfIsolatedMuonsEI are reco::PFCandidate !     
-    
-    btagAlgos = ["pfParticleNetAK4DiscriminatorsJetTagsForRECO:BvsAll"],
-    workingpoint = -1., #no cut applied
-    
+    met       = "slimmedMETs", # using all pat objects 
+    jets      = "slimmedJetsPuppi", 
+    electrons = "slimmedElectrons", 
+    muons     = "slimmedMuons",     
+
     HTdefinition = 'pt>30 & abs(eta)<2.5',
     leptJetDeltaRmin = 0.0,
     bJetMuDeltaRmax  = 9999.,

--- a/DQMOffline/Trigger/python/BTaggingMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/BTaggingMonitoring_Client_cff.py
@@ -20,13 +20,6 @@ BTVEfficiency_BTagMu_DiJet = DQMEDHarvester("DQMGenericClient",
         "effic_jetPhi_2       'efficiency vs leading jet phi; jet phi ; efficiency' jetPhi_2_numerator       jetPhi_2_denominator",
         "effic_eventHT       'efficiency vs event HT; event HT [GeV]; efficiency' eventHT_numerator       eventHT_denominator",
         "effic_jetEtaPhi_HEP17       'efficiency vs jet #eta-#phi; jet #eta; jet #phi' jetEtaPhi_HEP17_numerator       jetEtaPhi_HEP17_denominator",
-        "effic_muPt_1_variableBinning       'efficiency vs muon pt; muon pt [GeV]; efficiency' muPt_1_variableBinning_numerator       muPt_1_variableBinning_denominator",
-        "effic_muEta_1_variableBinning       'efficiency vs muon eta; muon eta ; efficiency' muEta_1_variableBinning_numerator       muEta_1_variableBinning_denominator",
-        "effic_jetPt_1_variableBinning       'efficiency vs leading jet pt; jet pt [GeV]; efficiency' jetPt_1_variableBinning_numerator       jetPt_1_variableBinning_denominator",
-        "effic_jetEta_1_variableBinning       'efficiency vs leading jet eta; jet eta ; efficiency' jetEta_1_variableBinning_numerator       jetEta_1_variableBinning_denominator",
-        "effic_jetPt_2_variableBinning       'efficiency vs leading jet pt; jet pt [GeV]; efficiency' jetPt_2_variableBinning_numerator       jetPt_2_variableBinning_denominator",
-        "effic_jetEta_2_variableBinning       'efficiency vs leading jet eta; jet eta ; efficiency' jetEta_2_variableBinning_numerator       jetEta_2_variableBinning_denominator",
-        "effic_eventHT_variableBinning       'efficiency vs event HT; event HT [GeV]; efficiency' eventHT_variableBinning_numerator       eventHT_variableBinning_denominator",
         "effic_jetMulti       'efficiency vs jet multiplicity; jet multiplicity; efficiency' jetMulti_numerator       jetMulti_denominator",
         "effic_muMulti       'efficiency vs muon multiplicity; muon multiplicity; efficiency' muMulti_numerator       muMulti_denominator",
         "effic_eleMulti       'efficiency vs electron multiplicity; electron multiplicity; efficiency' eleMulti_numerator       eleMulti_denominator",
@@ -41,9 +34,9 @@ BTVEfficiency_BTagMu_DiJet = DQMEDHarvester("DQMGenericClient",
         "effic_bjetPt_1      'efficiency vs 1st b-jet pt; bjet pt [GeV]; efficiency' bjetPt_1_numerator  bjetPt_1_denominator",
         "effic_bjetEta_1     'efficiency vs 1st b-jet eta; bjet eta ; efficiency'  bjetEta_1_numerator   bjetEta_1_denominator",
         "effic_bjetPhi_1     'efficiency vs 1st b-jet phi; bjet phi ; efficiency'  bjetPhi_1_numerator   bjetPhi_1_denominator",
-        "effic_bjetCSV_1     'efficiency vs 1st b-jet PNet Score; bjet PNet Score; efficiency' bjetCSV_1_numerator  bjetCSV_1_denominator",
-        "effic_bjetPt_1_variableBinning   'efficiency vs 1st b-jet pt; bjet pt [GeV]; efficiency' bjetPt_1_variableBinning_numerator   bjetPt_1_variableBinning_denominator",
-        "effic_bjetEta_1_variableBinning  'efficiency vs 1st b-jet eta; bjet eta ; efficiency' bjetEta_1_variableBinning_numerator     bjetEta_1_variableBinning_denominator",
+        "effic_bjetDeepFlav_1     'efficiency vs 1st b-jet DeepJet Score; bjet DeepJet Score; efficiency' bjetDeepFlav_1_numerator  bjetDeepFlav_1_denominator",
+        "effic_bjetPNet_1     'efficiency vs 1st b-jet PNet Score; bjet PNet Score; efficiency' bjetPNet_1_numerator  bjetPNet_1_denominator",
+        "effic_bjetUParT_1     'efficiency vs 1st b-jet UParT Score; bjet UParT Score; efficiency' bjetUParT_1_numerator  bjetUParT_1_denominator",
         "effic_bjetMulti      'efficiency vs b-jet multiplicity; bjet multiplicity; efficiency' bjetMulti_numerator   bjetMulti_denominator",
         "effic_bjetPtEta_1    'efficiency vs 1st b-jet pt-#eta; jet pt [GeV]; bjet #eta' bjetPtEta_1_numerator   bjetPtEta_1_denominator",
         "effic_bjetEtaPhi_1    'efficiency vs 1st b-jet #eta-#phi; bjet #eta ; bjet #phi' bjetEtaPhi_1_numerator  bjetEtaPhi_1_denominator",
@@ -51,14 +44,6 @@ BTVEfficiency_BTagMu_DiJet = DQMEDHarvester("DQMGenericClient",
     ),
 )
 
-BTVEfficiency_BTagMu_DiJet_DeepJet = DQMEDHarvester("DQMGenericClient",
-    subDirs        = cms.untracked.vstring("HLT/BTV/BTagMu_DiJet/*_DeepJet"),
-    verbose        = cms.untracked.uint32(0),
-    resolution     = cms.vstring(),
-    efficiency     = cms.vstring(
-        "effic_bjetCSV_1     'efficiency vs 1st b-jet DeepJet score; DeepJet score; efficiency' bjetCSV_1_numerator  bjetCSV_1_denominator"
-    )    
-)
 
 BTVEfficiency_BTagMu_Jet = DQMEDHarvester("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/BTV/BTagMu_Jet/*"),
@@ -73,13 +58,8 @@ BTVEfficiency_BTagMu_Jet = DQMEDHarvester("DQMGenericClient",
         "effic_jetPt_1       'efficiency vs leading jet pt; jet pt [GeV]; efficiency' jetPt_1_numerator       jetPt_1_denominator",
         "effic_jetEta_1       'efficiency vs leading jet eta; jet eta ; efficiency' jetEta_1_numerator       jetEta_1_denominator",
         "effic_jetPhi_1       'efficiency vs leading jet phi; jet phi ; efficiency' jetPhi_1_numerator       jetPhi_1_denominator",
-        "effic_eventHT       'efficiency vs event HT; event HT [GeV]; efficiency' eventHT_numerator       eventHT_denominator",
+        "effic_eventHT       'efficiency vs event HT; event HT [GeV]; efficiency' effic_muPt_1_variableBinning       'efficiency vs muon pt; muon pt [GeV]; efficiency' muPt_1_variableBinning_numerator       muPt_1_variableBinning_denominator",
         "effic_jetEtaPhi_HEP17       'efficiency vs jet #eta-#phi; jet #eta; jet #phi' jetEtaPhi_HEP17_numerator       jetEtaPhi_HEP17_denominator",
-        "effic_muPt_1_variableBinning       'efficiency vs muon pt; muon pt [GeV]; efficiency' muPt_1_variableBinning_numerator       muPt_1_variableBinning_denominator",
-        "effic_muEta_1_variableBinning       'efficiency vs muon eta; muon eta ; efficiency' muEta_1_variableBinning_numerator       muEta_1_variableBinning_denominator",
-        "effic_jetPt_1_variableBinning       'efficiency vs leading jet pt; jet pt [GeV]; efficiency' jetPt_1_variableBinning_numerator       jetPt_1_variableBinning_denominator",
-        "effic_jetEta_1_variableBinning       'efficiency vs leading jet eta; jet eta ; efficiency' jetEta_1_variableBinning_numerator       jetEta_1_variableBinning_denominator",
-        "effic_eventHT_variableBinning       'efficiency vs event HT; event HT [GeV]; efficiency' eventHT_variableBinning_numerator       eventHT_variableBinning_denominator",
         "effic_jetMulti       'efficiency vs jet multiplicity; jet multiplicity; efficiency' jetMulti_numerator       jetMulti_denominator",
         "effic_muMulti       'efficiency vs muon multiplicity; muon multiplicity; efficiency' muMulti_numerator       muMulti_denominator",
         "effic_eleMulti       'efficiency vs electron multiplicity; electron multiplicity; efficiency' eleMulti_numerator       eleMulti_denominator",
@@ -92,23 +72,14 @@ BTVEfficiency_BTagMu_Jet = DQMEDHarvester("DQMGenericClient",
         "effic_bjetPt_1      'efficiency vs 1st b-jet pt; bjet pt [GeV]; efficiency' bjetPt_1_numerator  bjetPt_1_denominator",
         "effic_bjetEta_1     'efficiency vs 1st b-jet eta; bjet eta ; efficiency'  bjetEta_1_numerator   bjetEta_1_denominator",
         "effic_bjetPhi_1     'efficiency vs 1st b-jet phi; bjet phi ; efficiency'  bjetPhi_1_numerator   bjetPhi_1_denominator",
-        "effic_bjetCSV_1     'efficiency vs 1st b-jet PNet Score; bjet PNet Score; efficiency' bjetCSV_1_numerator  bjetCSV_1_denominator",
-        "effic_bjetPt_1_variableBinning   'efficiency vs 1st b-jet pt; bjet pt [GeV]; efficiency' bjetPt_1_variableBinning_numerator   bjetPt_1_variableBinning_denominator",
-        "effic_bjetEta_1_variableBinning  'efficiency vs 1st b-jet eta; bjet eta ; efficiency' bjetEta_1_variableBinning_numerator     bjetEta_1_variableBinning_denominator",
+        "effic_bjetDeepFlav_1     'efficiency vs 1st b-jet DeepJet Score; bjet DeepJet Score; efficiency' bjetDeepFlav_1_numerator  bjetDeepFlav_1_denominator",
+        "effic_bjetPNet_1     'efficiency vs 1st b-jet PNet Score; bjet PNet Score; efficiency' bjetPNet_1_numerator  bjetPNet_1_denominator",
+        "effic_bjetUParT_1     'efficiency vs 1st b-jet UParT Score; bjet UParT Score; efficiency' bjetUParT_1_numerator  bjetUParT_1_denominator",
         "effic_bjetMulti      'efficiency vs b-jet multiplicity; bjet multiplicity; efficiency' bjetMulti_numerator   bjetMulti_denominator",
         "effic_bjetPtEta_1    'efficiency vs 1st b-jet pt-#eta; jet pt [GeV]; bjet #eta' bjetPtEta_1_numerator   bjetPtEta_1_denominator",
         "effic_bjetEtaPhi_1    'efficiency vs 1st b-jet #eta-#phi; bjet #eta ; bjet #phi' bjetEtaPhi_1_numerator  bjetEtaPhi_1_denominator",
         "effic_DeltaR_jet_Mu    'efficiency vs #DeltaR between jet and mu; #DeltaR(jet,mu) ; efficiency' DeltaR_jet_Mu_numerator  DeltaR_jet_Mu_denominator",
     ),
-)
-
-BTVEfficiency_BTagMu_Jet_DeepJet = DQMEDHarvester("DQMGenericClient",
-    subDirs        = cms.untracked.vstring("HLT/BTV/BTagMu_Jet/*_DeepJet"),
-    verbose        = cms.untracked.uint32(0),
-    resolution     = cms.vstring(),
-    efficiency     = cms.vstring(
-        "effic_bjetCSV_1     'efficiency vs 1st b-jet DeepJet score; DeepJet score; efficiency' bjetCSV_1_numerator  bjetCSV_1_denominator"
-    )
 )
 
 
@@ -130,13 +101,6 @@ BTVEfficiency_BTagDiMu_Jet = DQMEDHarvester("DQMGenericClient",
         "effic_jetPhi_1       'efficiency vs leading jet phi; jet phi ; efficiency' jetPhi_1_numerator       jetPhi_1_denominator",
         "effic_eventHT       'efficiency vs event HT; event HT [GeV]; efficiency' eventHT_numerator       eventHT_denominator",
         "effic_jetEtaPhi_HEP17       'efficiency vs jet #eta-#phi; jet #eta; jet #phi' jetEtaPhi_HEP17_numerator       jetEtaPhi_HEP17_denominator",
-        "effic_muPt_1_variableBinning       'efficiency vs muon pt; muon pt [GeV]; efficiency' muPt_1_variableBinning_numerator       muPt_1_variableBinning_denominator",
-        "effic_muEta_1_variableBinning       'efficiency vs muon eta; muon eta ; efficiency' muEta_1_variableBinning_numerator       muEta_1_variableBinning_denominator",
-        "effic_muPt_2_variableBinning       'efficiency vs muon pt; muon pt [GeV]; efficiency' muPt_2_variableBinning_numerator       muPt_2_variableBinning_denominator",
-        "effic_muEta_2_variableBinning       'efficiency vs muon eta; muon eta ; efficiency' muEta_2_variableBinning_numerator       muEta_2_variableBinning_denominator",
-        "effic_jetPt_1_variableBinning       'efficiency vs leading jet pt; jet pt [GeV]; efficiency' jetPt_1_variableBinning_numerator       jetPt_1_variableBinning_denominator",
-        "effic_jetEta_1_variableBinning       'efficiency vs leading jet eta; jet eta ; efficiency' jetEta_1_variableBinning_numerator       jetEta_1_variableBinning_denominator",
-        "effic_eventHT_variableBinning       'efficiency vs event HT; event HT [GeV]; efficiency' eventHT_variableBinning_numerator       eventHT_variableBinning_denominator",
         "effic_jetMulti       'efficiency vs jet multiplicity; jet multiplicity; efficiency' jetMulti_numerator       jetMulti_denominator",
         "effic_muMulti       'efficiency vs muon multiplicity; muon multiplicity; efficiency' muMulti_numerator       muMulti_denominator",
         "effic_eleMulti       'efficiency vs electron multiplicity; electron multiplicity; efficiency' eleMulti_numerator       eleMulti_denominator",
@@ -151,23 +115,14 @@ BTVEfficiency_BTagDiMu_Jet = DQMEDHarvester("DQMGenericClient",
         "effic_bjetPt_1      'efficiency vs 1st b-jet pt; bjet pt [GeV]; efficiency' bjetPt_1_numerator  bjetPt_1_denominator",
         "effic_bjetEta_1     'efficiency vs 1st b-jet eta; bjet eta ; efficiency'  bjetEta_1_numerator   bjetEta_1_denominator",
         "effic_bjetPhi_1     'efficiency vs 1st b-jet phi; bjet phi ; efficiency'  bjetPhi_1_numerator   bjetPhi_1_denominator",
-        "effic_bjetCSV_1     'efficiency vs 1st b-jet PNet Score; bjet PNet Score; efficiency' bjetCSV_1_numerator  bjetCSV_1_denominator",
-        "effic_bjetPt_1_variableBinning   'efficiency vs 1st b-jet pt; bjet pt [GeV]; efficiency' bjetPt_1_variableBinning_numerator   bjetPt_1_variableBinning_denominator",
-        "effic_bjetEta_1_variableBinning  'efficiency vs 1st b-jet eta; bjet eta ; efficiency' bjetEta_1_variableBinning_numerator     bjetEta_1_variableBinning_denominator",
+        "effic_bjetDeepFlav_1     'efficiency vs 1st b-jet DeepJet Score; bjet DeepJet Score; efficiency' bjetDeepFlav_1_numerator  bjetDeepFlav_1_denominator",
+        "effic_bjetPNet_1     'efficiency vs 1st b-jet PNet Score; bjet PNet Score; efficiency' bjetPNet_1_numerator  bjetPNet_1_denominator",
+        "effic_bjetUParT_1     'efficiency vs 1st b-jet UParT Score; bjet UParT Score; efficiency' bjetUParT_1_numerator  bjetUParT_1_denominator",
         "effic_bjetMulti      'efficiency vs b-jet multiplicity; bjet multiplicity; efficiency' bjetMulti_numerator   bjetMulti_denominator",
         "effic_bjetPtEta_1    'efficiency vs 1st b-jet pt-#eta; jet pt [GeV]; bjet #eta' bjetPtEta_1_numerator   bjetPtEta_1_denominator",
         "effic_bjetEtaPhi_1    'efficiency vs 1st b-jet #eta-#phi; bjet #eta ; bjet #phi' bjetEtaPhi_1_numerator  bjetEtaPhi_1_denominator",
         "effic_DeltaR_jet_Mu    'efficiency vs #DeltaR between jet and mu; #DeltaR(jet,mu) ; efficiency' DeltaR_jet_Mu_numerator  DeltaR_jet_Mu_denominator",
     ),
-)
-
-BTVEfficiency_BTagDiMu_Jet_DeepJet = DQMEDHarvester("DQMGenericClient",
-    subDirs        = cms.untracked.vstring("HLT/BTV/BTagDiMu_Jet/*_DeepJet"),
-    verbose        = cms.untracked.uint32(0),
-    resolution     = cms.vstring(),
-    efficiency     = cms.vstring(
-        "effic_bjetCSV_1     'efficiency vs 1st b-jet DeepJet score; DeepJet score; efficiency' bjetCSV_1_numerator  bjetCSV_1_denominator"
-    )
 )
 
 BTVEfficiency_PFJet = DQMEDHarvester("DQMGenericClient",
@@ -182,9 +137,6 @@ BTVEfficiency_PFJet = DQMEDHarvester("DQMGenericClient",
         "effic_jetPhi_1       'efficiency vs leading jet phi; jet phi ; efficiency' jetPhi_1_numerator       jetPhi_1_denominator",
         "effic_eventHT       'efficiency vs event HT; event HT [GeV]; efficiency' eventHT_numerator       eventHT_denominator",
         "effic_jetEtaPhi_HEP17       'efficiency vs jet #eta-#phi; jet #eta; jet #phi' jetEtaPhi_HEP17_numerator       jetEtaPhi_HEP17_denominator",
-        "effic_jetPt_1_variableBinning       'efficiency vs leading jet pt; jet pt [GeV]; efficiency' jetPt_1_variableBinning_numerator       jetPt_1_variableBinning_denominator",
-        "effic_jetEta_1_variableBinning       'efficiency vs leading jet eta; jet eta ; efficiency' jetEta_1_variableBinning_numerator       jetEta_1_variableBinning_denominator",
-        "effic_eventHT_variableBinning       'efficiency vs event HT; event HT [GeV]; efficiency' eventHT_variableBinning_numerator       eventHT_variableBinning_denominator",
         "effic_jetMulti       'efficiency vs jet multiplicity; jet multiplicity; efficiency' jetMulti_numerator       jetMulti_denominator",
         "effic_muMulti       'efficiency vs muon multiplicity; muon multiplicity; efficiency' muMulti_numerator       muMulti_denominator",
         "effic_eleMulti       'efficiency vs electron multiplicity; electron multiplicity; efficiency' eleMulti_numerator       eleMulti_denominator",
@@ -193,23 +145,14 @@ BTVEfficiency_PFJet = DQMEDHarvester("DQMGenericClient",
         "effic_bjetPt_1      'efficiency vs 1st b-jet pt; bjet pt [GeV]; efficiency' bjetPt_1_numerator  bjetPt_1_denominator",
         "effic_bjetEta_1     'efficiency vs 1st b-jet eta; bjet eta ; efficiency'  bjetEta_1_numerator   bjetEta_1_denominator",
         "effic_bjetPhi_1     'efficiency vs 1st b-jet phi; bjet phi ; efficiency'  bjetPhi_1_numerator   bjetPhi_1_denominator",
-        "effic_bjetCSV_1     'efficiency vs 1st b-jet PNet Score; bjet PNet Score; efficiency' bjetCSV_1_numerator  bjetCSV_1_denominator",
-        "effic_bjetPt_1_variableBinning   'efficiency vs 1st b-jet pt; bjet pt [GeV]; efficiency' bjetPt_1_variableBinning_numerator   bjetPt_1_variableBinning_denominator",
-        "effic_bjetEta_1_variableBinning  'efficiency vs 1st b-jet eta; bjet eta ; efficiency' bjetEta_1_variableBinning_numerator     bjetEta_1_variableBinning_denominator",
+        "effic_bjetDeepFlav_1     'efficiency vs 1st b-jet DeepJet Score; bjet DeepJet Score; efficiency' bjetDeepFlav_1_numerator  bjetDeepFlav_1_denominator",
+        "effic_bjetPNet_1     'efficiency vs 1st b-jet PNet Score; bjet PNet Score; efficiency' bjetPNet_1_numerator  bjetPNet_1_denominator",
+        "effic_bjetUParT_1     'efficiency vs 1st b-jet UParT Score; bjet UParT Score; efficiency' bjetUParT_1_numerator  bjetUParT_1_denominator",
         "effic_bjetMulti      'efficiency vs b-jet multiplicity; bjet multiplicity; efficiency' bjetMulti_numerator   bjetMulti_denominator",
         "effic_bjetPtEta_1    'efficiency vs 1st b-jet pt-#eta; jet pt [GeV]; bjet #eta' bjetPtEta_1_numerator   bjetPtEta_1_denominator",
         "effic_bjetEtaPhi_1    'efficiency vs 1st b-jet #eta-#phi; bjet #eta ; bjet #phi' bjetEtaPhi_1_numerator  bjetEtaPhi_1_denominator",
         "effic_DeltaR_jet_Mu    'efficiency vs #DeltaR between jet and mu; #DeltaR(jet,mu) ; efficiency' DeltaR_jet_Mu_numerator  DeltaR_jet_Mu_denominator",
     ),
-)
-
-BTVEfficiency_PFJet_DeepJet = DQMEDHarvester("DQMGenericClient",
-    subDirs        = cms.untracked.vstring("HLT/BTV/PFJet/*_DeepJet"),
-    verbose        = cms.untracked.uint32(0),
-    resolution     = cms.vstring(),
-    efficiency     = cms.vstring(
-        "effic_bjetCSV_1     'efficiency vs 1st b-jet DeepJet score; DeepJet score; efficiency' bjetCSV_1_numerator  bjetCSV_1_denominator"
-    )
 )
 
 BTVEfficiency_TurnOnCurves = DQMEDHarvester("DQMGenericClient",
@@ -277,9 +220,5 @@ btaggingClient = cms.Sequence(
   + BTVEfficiency_BTagMu_Jet
   + BTVEfficiency_BTagDiMu_Jet
   + BTVEfficiency_PFJet
-  + BTVEfficiency_BTagMu_DiJet_DeepJet
-  + BTVEfficiency_BTagMu_Jet_DeepJet
-  + BTVEfficiency_BTagDiMu_Jet_DeepJet
-  + BTVEfficiency_PFJet_DeepJet
   + BJetTrackToTrackEfficiencies
 )

--- a/DQMOffline/Trigger/python/BTaggingMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/BTaggingMonitoring_cff.py
@@ -15,19 +15,6 @@ BTagMu_AK4DiJet20_Mu5 = hltBTVmonitoring.clone(
     histoPSet = dict(jetPtBinning = [0,10,15,20,30,50,70,100,150,200,400,700,1000,1500,3000])
 )
 
-BTagMu_AK4DiJet20_Mu5_DeepJet = hltBTVmonitoring.clone(
-    FolderName = 'HLT/BTV/BTagMu_DiJet/AK4DiJet20_Mu5_DeepJet',
-    nmuons = 1,
-    nelectrons = 0,
-    njets = 2,
-    muoSelection = 'pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
-    jetSelection = 'pt>10 & abs(eta)<2.4',
-    bjetSelection = 'pt>5 & abs(eta)<2.4',
-    btagAlgos = ["pfDeepFlavourJetTags:probb", "pfDeepFlavourJetTags:probbb","pfDeepFlavourJetTags:problepb"],
-    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK4DiJet20_Mu5_v*']),
-    histoPSet = dict(jetPtBinning = [0,10,15,20,30,50,70,100,150,200,400,700,1000,1500,3000])
-)
-
 BTagMu_AK4DiJet40_Mu5 = hltBTVmonitoring.clone(
     FolderName = 'HLT/BTV/BTagMu_DiJet/BTagMu_AK4DiJet40_Mu5',
     nmuons = 1,
@@ -36,19 +23,6 @@ BTagMu_AK4DiJet40_Mu5 = hltBTVmonitoring.clone(
     muoSelection = 'pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
     jetSelection = 'pt>30 & abs(eta)<2.4',
     bjetSelection = 'pt>20 & abs(eta)<2.4',
-    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK4DiJet40_Mu5_v*']),
-    histoPSet = dict(jetPtBinning = [0,30,40,50,70,100,150,200,400,700,1000,1500,3000])
-)
-
-BTagMu_AK4DiJet40_Mu5_DeepJet = hltBTVmonitoring.clone(
-    FolderName = 'HLT/BTV/BTagMu_DiJet/AK4DiJet40_Mu5_DeepJet',
-    nmuons = 1,
-    nelectrons = 0,
-    njets = 2,
-    muoSelection = 'pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
-    jetSelection = 'pt>30 & abs(eta)<2.4',
-    bjetSelection = 'pt>20 & abs(eta)<2.4',
-    btagAlgos = ["pfDeepFlavourJetTags:probb", "pfDeepFlavourJetTags:probbb","pfDeepFlavourJetTags:problepb"],
     numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK4DiJet40_Mu5_v*']),
     histoPSet = dict(jetPtBinning = [0,30,40,50,70,100,150,200,400,700,1000,1500,3000])
 )
@@ -64,18 +38,6 @@ BTagMu_AK4DiJet70_Mu5 = hltBTVmonitoring.clone(
     histoPSet = dict(jetPtBinning = [0,50,60,70,80,90,100,150,200,400,700,1000,1500,3000])
 )
 
-BTagMu_AK4DiJet70_Mu5_DeepJet = hltBTVmonitoring.clone(
-    FolderName = 'HLT/BTV/BTagMu_DiJet/AK4DiJet70_Mu5_DeepJet',
-    nmuons = 1,
-    nelectrons = 0,
-    njets = 2,
-    muoSelection = 'pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
-    jetSelection = 'pt>50 & abs(eta)<2.4',
-    btagAlgos = ["pfDeepFlavourJetTags:probb", "pfDeepFlavourJetTags:probbb","pfDeepFlavourJetTags:problepb"],
-    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK4DiJet70_Mu5_v*']),
-    histoPSet = dict(jetPtBinning = [0,50,60,70,80,90,100,150,200,400,700,1000,1500,3000])
-)
-
 BTagMu_AK4DiJet110_Mu5 = hltBTVmonitoring.clone(
     FolderName = 'HLT/BTV/BTagMu_DiJet/BTagMu_AK4DiJet110_Mu5',
     nmuons = 1,
@@ -83,18 +45,6 @@ BTagMu_AK4DiJet110_Mu5 = hltBTVmonitoring.clone(
     njets = 2,
     muoSelection = 'pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
     jetSelection = 'pt>90 & abs(eta)<2.4',
-    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK4DiJet110_Mu5_v*']),
-    histoPSet = dict(jetPtBinning = [0,90,100,110,120,130,150,200,400,700,1000,1500,3000])
-)
-
-BTagMu_AK4DiJet110_Mu5_DeepJet = hltBTVmonitoring.clone(
-    FolderName = 'HLT/BTV/BTagMu_DiJet/AK4DiJet110_Mu5_DeepJet',
-    nmuons = 1,
-    nelectrons = 0,
-    njets = 2,
-    muoSelection = 'pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
-    jetSelection = 'pt>90 & abs(eta)<2.4',
-    btagAlgos = ["pfDeepFlavourJetTags:probb", "pfDeepFlavourJetTags:probbb","pfDeepFlavourJetTags:problepb"],
     numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK4DiJet110_Mu5_v*']),
     histoPSet = dict(jetPtBinning = [0,90,100,110,120,130,150,200,400,700,1000,1500,3000])
 )
@@ -110,18 +60,6 @@ BTagMu_AK4DiJet170_Mu5 = hltBTVmonitoring.clone(
     histoPSet = dict(jetPtBinning = [0,150,160,170,180,190,200,400,700,1000,1500,3000])
 )
 
-BTagMu_AK4DiJet170_Mu5_DeepJet = hltBTVmonitoring.clone(
-    FolderName = 'HLT/BTV/BTagMu_DiJet/AK4DiJet170_Mu5_DeepJet',
-    nmuons = 1,
-    nelectrons = 0,
-    njets = 2,
-    muoSelection = 'pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
-    jetSelection = 'pt>150 & abs(eta)<2.4',
-    btagAlgos = ["pfDeepFlavourJetTags:probb", "pfDeepFlavourJetTags:probbb","pfDeepFlavourJetTags:problepb"],
-    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK4DiJet170_Mu5_v*']),
-    histoPSet = dict(jetPtBinning = [0,150,160,170,180,190,200,400,700,1000,1500,3000])
-)
-
 BTagMu_AK4Jet300_Mu5 = hltBTVmonitoring.clone(
     FolderName = 'HLT/BTV/BTagMu_Jet/BTagMu_AK4Jet300_Mu5',
     nmuons = 1,
@@ -133,29 +71,16 @@ BTagMu_AK4Jet300_Mu5 = hltBTVmonitoring.clone(
     histoPSet = dict(jetPtBinning = [0,250,280,300,320,360,400,700,1000,1500,3000])
 )
 
-BTagMu_AK4Jet300_Mu5_DeepJet = hltBTVmonitoring.clone(
-    FolderName = 'HLT/BTV/BTagMu_Jet/BTagMu_AK4Jet300_Mu5_DeepJet',
-    nmuons = 1,
-    nelectrons = 0,
-    njets = 1,
-    muoSelection = 'pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
-    jetSelection = 'pt>250 & abs(eta)<2.4',
-    btagAlgos = ["pfDeepFlavourJetTags:probb", "pfDeepFlavourJetTags:probbb","pfDeepFlavourJetTags:problepb"],
-    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK4Jet300_Mu5_v*']),
-    histoPSet = dict(jetPtBinning = [0,250,280,300,320,360,400,700,1000,1500,3000])
-)
-
-
 #BTagMu AK8
 BTagMu_AK8DiJet170_Mu5 = hltBTVmonitoring.clone(
     FolderName = 'HLT/BTV/BTagMu_DiJet/BTagMu_AK8DiJet170_Mu5',
     nmuons = 1,
     nelectrons = 0,
     njets = 2,
-    jets = "ak8PFJetsPuppi",
+    jets = "slimmedJetsAK8",
     muoSelection = 'pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
     jetSelection = 'pt>150 & abs(eta)<2.4',
-    btagAlgos = ["pfMassDecorrelatedParticleNetDiscriminatorsJetTags:XbbvsQCD"],
+    btagAlgos = ["pfParticleNetFromMiniAODAK8DiscriminatorsJetTags:HbbvsQCD"],
     numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK8DiJet170_Mu5_v*']),
     histoPSet = dict(jetPtBinning = [0,150,160,170,180,190,200,400,700,1000,1500,3000])
 )
@@ -166,10 +91,10 @@ BTagMu_AK8Jet300_Mu5 = hltBTVmonitoring.clone(
     nmuons = 1,
     nelectrons = 0,
     njets = 1,
-    jets = "ak8PFJetsPuppi",
+    jets = "slimmedJetsAK8",
     muoSelection = 'pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
     jetSelection = 'pt>250 & abs(eta)<2.4',
-    btagAlgos =	["pfMassDecorrelatedParticleNetDiscriminatorsJetTags:XbbvsQCD"],
+    btagAlgos = ["pfParticleNetFromMiniAODAK8DiscriminatorsJetTags:HbbvsQCD"],
     numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK8Jet300_Mu5_v*']),
     histoPSet = dict(jetPtBinning = [0,250,280,300,320,360,400,700,1000,1500,3000])
 )
@@ -180,10 +105,10 @@ BTagMu_AK8Jet170_DoubleMu5 = hltBTVmonitoring.clone(
     nmuons = 2,
     nelectrons = 0,
     njets = 1,
-    jets = "ak8PFJetsPuppi",
+    jets = "slimmedJetsAK8",
     muoSelection = 'pt>7 & abs(eta)<2.4 & isPFMuon & isGlobalMuon & innerTrack.hitPattern.numberOfValidTrackerHits>7 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & numberOfMatchedStations>1 &globalTrack.normalizedChi2<10',
     jetSelection = 'pt>150 & abs(eta)<2.4',
-    btagAlgos =	["pfMassDecorrelatedParticleNetDiscriminatorsJetTags:XbbvsQCD"],
+    btagAlgos = ["pfParticleNetFromMiniAODAK8DiscriminatorsJetTags:HbbvsQCD"],
     numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK8Jet170_DoubleMu5_v*']),
     histoPSet = dict(jetPtBinning = [0,150,160,170,180,190,200,400,700,1000,1500,3000])
 )
@@ -200,41 +125,28 @@ BTagMonitor_PFJet40 = hltBTVmonitoring.clone(
     numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJet40_v*'])
 )
 
-BTagMonitor_PFJet40_DeepJet = hltBTVmonitoring.clone(
-    FolderName = 'HLT/BTV/PFJet/PFJet40_DeepJet',
-    nmuons = 0,
-    nelectrons = 0,
-    njets = 1,
-    jetSelection = 'pt>30 & abs(eta)<2.4',
-    bjetSelection = 'pt>20 & abs(eta)<2.4',
-    btagAlgos = ["pfDeepFlavourJetTags:probb", "pfDeepFlavourJetTags:probbb","pfDeepFlavourJetTags:problepb"],
-    histoPSet = dict(jetPtBinning = [0,30,35,40,45,50,60,70,100,150,200,400,700,1000,1500,3000]),
-    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJet40_v*'])
-)
-
 # PFJet AK8
 BTagMonitor_AK8PFJet40 = hltBTVmonitoring.clone(
     FolderName = 'HLT/BTV/PFJet/AK8PFJet40',
     nmuons = 0,
     nelectrons = 0,
     njets = 1,
-    jets = "ak8PFJetsPuppi",
+    jets = "slimmedJetsAK8",
     jetSelection = 'pt>30 & abs(eta)<2.4',
     bjetSelection = 'pt>20 & abs(eta)<2.4',
-    btagAlgos =	["pfMassDecorrelatedParticleNetDiscriminatorsJetTags:XbbvsQCD"],
+    btagAlgos = ["pfParticleNetFromMiniAODAK8DiscriminatorsJetTags:HbbvsQCD"],
     numGenericTriggerEventPSet = dict(hltPaths = ['HLT_AK8PFJet40_v*']),
     histoPSet = dict(jetPtBinning = [0,30,35,40,45,50,60,70,100,150,200,400,700,1000,1500,3000])
 )
 
 # PFJetFwd AK4
-BTagMonitor_PFJetFwd40_DeepJet = hltBTVmonitoring.clone(
-    FolderName = 'HLT/BTV/PFJet/PFJetFwd40_DeepJet',
+BTagMonitor_PFJetFwd40 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/PFJetFwd40',
     nmuons = 0,
     nelectrons = 0,
     njets = 1,
     jetSelection = 'pt>30 & abs(eta)>2.7 & abs(eta)<5.0',
     bjetSelection = 'pt>20 & abs(eta)>2.7 & abs(eta)<5.0',
-    btagAlgos = ["pfDeepFlavourJetTags:probb", "pfDeepFlavourJetTags:probbb","pfDeepFlavourJetTags:problepb"],
     numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJetFwd40_v*']),
     histoPSet = dict(
         jetPtBinning = [0,30,35,40,45,50,60,70,100,150,200,400,700,1000,1500,3000],
@@ -245,15 +157,14 @@ BTagMonitor_PFJetFwd40_DeepJet = hltBTVmonitoring.clone(
 )
 
 # PFJetFwd AK8
-BTagMonitor_AK8PFJetFwd40_DeepJet = hltBTVmonitoring.clone(
+BTagMonitor_AK8PFJetFwd40 = hltBTVmonitoring.clone(
     FolderName = 'HLT/BTV/PFJet/AK8PFJetFwd40',
     nmuons = 0,
     nelectrons = 0,
     njets = 1,
-    jets = "ak8PFJetsPuppi",
+    jets = "slimmedJetsAK8",
     jetSelection = 'pt>30 & abs(eta)>2.7 & abs(eta)<5.0',
     bjetSelection = 'pt>20 & abs(eta)>2.7 & abs(eta)<5.0',
-    btagAlgos = ["pfDeepFlavourJetTags:probb", "pfDeepFlavourJetTags:probbb","pfDeepFlavourJetTags:problepb"],
     numGenericTriggerEventPSet = dict(hltPaths = ['HLT_AK8PFJetFwd40_v*']),
     histoPSet = dict(
         jetPtBinning = [0,30,35,40,45,50,60,70,100,150,200,400,700,1000,1500,3000],
@@ -267,19 +178,13 @@ BTagMonitor_AK8PFJetFwd40_DeepJet = hltBTVmonitoring.clone(
 
 btagMonitorHLT = cms.Sequence(
     BTagMu_AK4DiJet20_Mu5
-  + BTagMu_AK4DiJet20_Mu5_DeepJet
   + BTagMu_AK4DiJet40_Mu5
-  + BTagMu_AK4DiJet40_Mu5_DeepJet
   + BTagMu_AK4DiJet70_Mu5
-  + BTagMu_AK4DiJet70_Mu5_DeepJet
   + BTagMu_AK4DiJet110_Mu5
-  + BTagMu_AK4DiJet110_Mu5_DeepJet
   + BTagMu_AK4DiJet170_Mu5
-  + BTagMu_AK4DiJet170_Mu5_DeepJet
   + BTagMu_AK8DiJet170_Mu5
   + BTagMu_AK8Jet170_DoubleMu5
   + BTagMu_AK4Jet300_Mu5
-  + BTagMu_AK4Jet300_Mu5_DeepJet
   + BTagMu_AK8Jet300_Mu5
 )
 
@@ -289,8 +194,7 @@ pp_on_PbPb_run3.toReplaceWith(btagMonitorHLT,btagMonitorHLT.copyAndExclude([BTag
 
 btvHLTDQMSourceExtra = cms.Sequence(
     BTagMonitor_PFJet40
-  + BTagMonitor_PFJet40_DeepJet
   + BTagMonitor_AK8PFJet40
-  + BTagMonitor_PFJetFwd40_DeepJet
-  + BTagMonitor_AK8PFJetFwd40_DeepJet
+  + BTagMonitor_PFJetFwd40
+  + BTagMonitor_AK8PFJetFwd40
 )


### PR DESCRIPTION
#### PR description:

This PR adds a new analyzer for BTV HLT DQM. Currently, BTV uses a clone of TopMonitor, which makes it difficult to directly make changes. The new BTVMonitor uses "pat" objects instead of "reco" objects previously so all the information can be read from miniAOD level.

Instead of having a new folder for each b-tagging algorithm (which is the case currently), we now have all the b-tagging score histograms in one folder, thus reducing duplicates. The PR also adds b-tagging scores from the UParT tagger for AK4 jets, while keeping all the previously used taggers (DeepJet and ParticleNet)

#### PR validation:

These changes pass all the basic tests suggested in  [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html). Furthermore, the changes are visible in the offline DQM GUI histograms for workflow 16834.0. 


