### PR TITLE
Revert "Add HardwareResourcesInformation printout to edmProvDump"

### DIFF
--- a/IOPool/Common/bin/EdmProvDump.cc
+++ b/IOPool/Common/bin/EdmProvDump.cc
@@ -79,18 +79,9 @@ namespace {
     const_iterator end() const { return children_.end(); }
 
     void print(std::ostream& os) const {
-      auto const& hwresources = config_.hardwareResourcesDescription();
+      // TODO: add printout of HardwareResourcesDescription
       os << config_.processName() << " '" << config_.releaseVersion() << "' [" << simpleId_ << "]  ("
-         << config_.parameterSetID() << ")"
-         << "  (" << hwresources.microarchitecture;
-      if (not hwresources.selectedAccelerators.empty()) {
-        os << "; " << hwresources.selectedAccelerators.front();
-        for (auto it = hwresources.selectedAccelerators.begin() + 1; it != hwresources.selectedAccelerators.end();
-             ++it) {
-          os << "," << *it;
-        }
-      }
-      os << ")" << std::endl;
+         << config_.parameterSetID() << ")" << std::endl;
     }
 
     void printHistory(std::string const& iIndent = std::string("  ")) const;


### PR DESCRIPTION
#### PR description:

This PR reverts the commit 4ef88f732030789b4b607ffcd52e33842a381a70 from https://github.com/cms-sw/cmssw/pull/47355 following the discovery in https://github.com/cms-sw/cmssw/pull/47355#discussion_r1973412363. I'm reverting the commit temporarily in order to
- confirm that this change alone is sufficient for CRAB, so that the 15_0_X backport https://github.com/cms-sw/cmssw/pull/47416 can be merged without breaking CRAB (so that we can start recording the hardware information)
- we have more time to figure out how to really fix the situation

Resolves https://github.com/cms-sw/framework-team/issues/1272

#### PR validation:

Code compiles