### PR TITLE
[CMSSW_14_1_X] Update MC GTs for HI and ppRef in autoCond

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -74,7 +74,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2022, Strip tracker in DECO mode
     'phase1_2022_cosmics_design'   :    '140X_mcRun3_2022cosmics_design_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 detector for Heavy Ion
-    'phase1_2022_realistic_hi'     :    '140X_mcRun3_2022_realistic_HI_v3',
+    'phase1_2022_realistic_hi'     :    '140X_mcRun3_2022_realistic_HI_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2023
     'phase1_2023_design'           :    '140X_mcRun3_2023_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
@@ -88,7 +88,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2023, Strip tracker in DECO mode
     'phase1_2023_cosmics_design'   :    '140X_mcRun3_2023cosmics_design_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2023 detector for Heavy Ion
-    'phase1_2023_realistic_hi'     :    '141X_mcRun3_2023_realistic_HI_v4',
+    'phase1_2023_realistic_hi'     :    '141X_mcRun3_2023_realistic_HI_v11',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2024
     'phase1_2024_design'           :    '140X_mcRun3_2024_design_v11',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
@@ -98,9 +98,9 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2024, Strip tracker in DECO mode
     'phase1_2024_cosmics_design'   :    '140X_mcRun3_2024cosmics_design_deco_v11',
     # GlobalTag for MC production with realistic conditions for Phase1 2024 detector for Heavy Ion
-    'phase1_2024_realistic_hi'     :    '141X_mcRun3_2024_realistic_HI_v10',
+    'phase1_2024_realistic_hi'     :    '141X_mcRun3_2024_realistic_HI_v14',
     # GlobalTag for MC production with realistic conditions for Phase1 2024 detector for ppRef5TeV
-    'phase1_2024_realistic_ppRef5TeV'     :    '141X_mcRun3_2024_realistic_ppRef5TeV_v5',
+    'phase1_2024_realistic_ppRef5TeV' : '141X_mcRun3_2024_realistic_ppRef5TeV_v7',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             :    '141X_mcRun4_realistic_v3'
 }


### PR DESCRIPTION
The following GTs have been updated in autoCond (as backport of  #47385):

-  'phase1_2022_realistic_hi'  updated to [140X_mcRun3_2022_realistic_HI_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/140X_mcRun3_2022_realistic_HI_v4)
   -  Diff with respect to previous 140X_mcRun3_2022_realistic_HI_v3 is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2022_realistic_HI_v3/140X_mcRun3_2022_realistic_HI_v4) 
   - Add the tags that allow Dead and Masked GEM strips, see [cmsTalk](https://cms-talk.web.cern.ch/t/gem-request-for-including-gts-gemmaskedstrips-gemdeadstrips/55154) 
- 'phase1_2024_realistic_ppRef5TeV' : '141X_mcRun3_2024_realistic_ppRef5TeV_v7
   -  Diff with respect to previous 141X_mcRun3_2024_realistic_ppRef5TeV_v4 is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/141X_mcRun3_2024_realistic_ppRef5TeV_v4/141X_mcRun3_2024_realistic_ppRef5TeV_v7)
   - Updates on Sub-detector Conditions for 2024 pp Ref MC in 141X, add L1TCaloParams_static_2024_v0_1_ppRef_mc, see [cmsTalk](https://cms-talk.web.cern.ch/t/mc-request-updates-on-sub-detector-conditions-for-2024-pp-ref-mc-in-141x/65435)
   
The following GTs have been updated in autoCond (as backport of  #47439):

- 'phase1_2023_realistic_hi'     :    [141X_mcRun3_2023_realistic_HI_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/141X_mcRun3_2023_realistic_HI_v11)
  - Diff with respect to previous _v5 is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/141X_mcRun3_2023_realistic_HI_v5/141X_mcRun3_2023_realistic_HI_v11)
  - Updates included:
     - Beamspot, see [cmsTalk](https://cms-talk.web.cern.ch/t/141x-rereco-and-mc-of-2023-upc-data-urgent/104239/8)
     - CSC conditions, see [cmsTalk](https://cms-talk.web.cern.ch/t/141x-rereco-and-mc-of-2023-upc-data-urgent/104239/7)
     - Muon Alignment, see [cmsTalk](https://cms-talk.web.cern.ch/t/141x-rereco-and-mc-of-2023-upc-data-urgent/104239/12) and [cmsTalk](https://cms-talk.web.cern.ch/t/141x-rereco-and-mc-of-2023-upc-data-urgent/104239/23)
     - HCAL SiPMParameters and ZSThresholds, see [cmsTalk](https://cms-talk.web.cern.ch/t/141x-rereco-and-mc-of-2023-upc-data-urgent/104239/15)
     - HCAL pedestals, see [cmsTalk](https://cms-talk.web.cern.ch/t/141x-rereco-and-mc-of-2023-upc-data-urgent/104239/24)
     - SiStripNoise, see [cmsTalk](https://cms-talk.web.cern.ch/t/141x-rereco-and-mc-of-2023-upc-data-urgent/104239/16)
     - Jet energy corrections and resolutions, see [cmsTalk](https://cms-talk.web.cern.ch/t/141x-rereco-and-mc-of-2023-upc-data-urgent/104239/20)
- 'phase1_2024_realistic_hi'     :    [141X_mcRun3_2024_realistic_HI_v14](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/141X_mcRun3_2024_realistic_HI_v14)
  - Diff with respect to previous _v13 is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/141X_mcRun3_2024_realistic_HI_v13/141X_mcRun3_2024_realistic_HI_v14)
  - Updates included:
     - SiPixel Quality and Status Scenario, see [cmsTalk](https://cms-talk.web.cern.ch/t/cal-for-conditions-for-the-2024-hi-mc/72169/10)
    
#### PR validation:

Tested in master

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #47385 and #47439
