### PR TITLE
mkFit: technical fix, remove unused function from standalone build

### DIFF
--- a/RecoTracker/MkFitCMS/standalone/mkFit.cc
+++ b/RecoTracker/MkFitCMS/standalone/mkFit.cc
@@ -562,7 +562,6 @@ int main(int argc, const char* argv[]) {
           "\n"
           " **Additional options for building\n"
           "  --use-phiq-arr           use phi-Q arrays in select hit indices (def: %s)\n"
-          "  --kludge-cms-hit-errors  make sure err(xy) > 15 mum, err(z) > 30 mum (def: %s)\n"
           "  --backward-fit           perform backward fit during building (def: %s)\n"
           "  --no-backward-search     do not do backward search after backward fit\n"
           "                           (def: do search if backward-fit is enabled and available in given iteration)\n"
@@ -711,7 +710,6 @@ int main(int argc, const char* argv[]) {
           b2a(Config::useDeadModules),
 
           b2a(Config::usePhiQArrays),
-          b2a(Config::kludgeCmsHitErrors),
           b2a(Config::backwardFit),
           b2a(Config::includePCA),
           int(Config::usePropToPlane),
@@ -882,8 +880,6 @@ int main(int argc, const char* argv[]) {
       Config::useHitsForDuplicates = false;
     } else if (*i == "--use-dead-modules") {
       Config::useDeadModules = true;
-    } else if (*i == "--kludge-cms-hit-errors") {
-      Config::kludgeCmsHitErrors = true;
     } else if (*i == "--backward-fit") {
       Config::backwardFit = true;
     } else if (*i == "--no-backward-search") {

--- a/RecoTracker/MkFitCore/standalone/ConfigStandalone.cc
+++ b/RecoTracker/MkFitCore/standalone/ConfigStandalone.cc
@@ -53,7 +53,6 @@ namespace mkfit {
     int cmsSelMinLayers = 12;
     int nMinFoundHits = 10;
 
-    bool kludgeCmsHitErrors = false;
     bool backwardFit = false;
     bool backwardSearch = true;
 

--- a/RecoTracker/MkFitCore/standalone/ConfigStandalone.h
+++ b/RecoTracker/MkFitCore/standalone/ConfigStandalone.h
@@ -151,7 +151,6 @@ namespace mkfit {
 
     extern bool dumpForPlots;
 
-    extern bool kludgeCmsHitErrors;
     extern bool backwardFit;
     extern bool backwardSearch;
 

--- a/RecoTracker/MkFitCore/standalone/Event.cc
+++ b/RecoTracker/MkFitCore/standalone/Event.cc
@@ -405,10 +405,6 @@ namespace mkfit {
       fread(&beamSpot_, sizeof(BeamSpot), 1, fp);
     }
 
-    if (Config::kludgeCmsHitErrors) {
-      kludge_cms_hit_errors();
-    }
-
     if (!Config::silent)
       printf("Read complete, %d simtracks on file.\n", nt);
   }
@@ -468,41 +464,6 @@ namespace mkfit {
   void Event::setInputFromCMSSW(std::vector<HitVec> hits, TrackVec seeds) {
     layerHits_ = std::move(hits);
     seedTracks_ = std::move(seeds);
-  }
-
-  //------------------------------------------------------------------------------
-
-  void Event::kludge_cms_hit_errors() {
-    // Enforce Vxy on all layers, Vz on pixb only.
-
-    const float Exy = 15 * 1e-4, Vxy = Exy * Exy;
-    const float Ez = 30 * 1e-4, Vz = Ez * Ez;
-
-    int nl = layerHits_.size();
-
-    int cnt = 0;
-
-    for (int il = 0; il < nl; il++) {
-      if (layerHits_[il].empty())
-        continue;
-
-      for (Hit &h : layerHits_[il]) {
-        SVector6 &c = h.error_nc();
-
-        float vxy = c[0] + c[2];
-        if (vxy < Vxy) {
-          c[0] *= Vxy / vxy;
-          c[2] *= Vxy / vxy;
-          ++cnt;
-        }
-        if (il < 4 && c[5] < Vz) {
-          c[5] = Vz;
-          ++cnt;
-        }
-      }
-    }
-
-    printf("Event::kludge_cms_hit_errors processed %d layers, kludged %d entries.\n", nl, cnt);
   }
 
   //------------------------------------------------------------------------------

--- a/RecoTracker/MkFitCore/standalone/Event.h
+++ b/RecoTracker/MkFitCore/standalone/Event.h
@@ -31,8 +31,6 @@ namespace mkfit {
 
     void setInputFromCMSSW(std::vector<HitVec> hits, TrackVec seeds);
 
-    void kludge_cms_hit_errors();
-
     int use_seeds_from_cmsswtracks();  //special mode --> use only seeds which generated cmssw reco track
     int clean_cms_simtracks();
     int clean_cms_seedtracks(


### PR DESCRIPTION
Remove a function no longer needed for mkFit standalone build, together with all references to it. No implications for CMSSW performance.