### PR TITLE
Add optional HardwareResourcesInformation printout to edmProvDump

### DIFF
--- a/IOPool/Input/test/testReducedProcessHistoryHardwareResources.sh
+++ b/IOPool/Input/test/testReducedProcessHistoryHardwareResources.sh
@@ -12,15 +12,15 @@ function runSuccess {
 runSuccess ${SCRAM_TEST_PATH}/testReducedProcessHistoryCreate_cfg.py --accelerators test-one --firstEvent 1 --output test-one.root
 runSuccess ${SCRAM_TEST_PATH}/testReducedProcessHistoryCreate_cfg.py --accelerators test-two --firstEvent 101 --output test-two.root
 
-edmProvDump test-one.root | grep -q "PROD.*test-one" || die "Did not find test-one from test-one.root provenance" $?
-edmProvDump test-two.root | grep -q "PROD.*test-two" || die "Did not find test-two from test-two.root provenance" $?
+edmProvDump --hardware test-one.root | grep -q "PROD.*test-one" || die "Did not find test-one from test-one.root provenance" $?
+edmProvDump --hardware test-two.root | grep -q "PROD.*test-two" || die "Did not find test-two from test-two.root provenance" $?
 
 runSuccess ${SCRAM_TEST_PATH}/test_merge_two_files.py test-one.root test-two.root
 
 runSuccess ${SCRAM_TEST_PATH}/testReducedProcessHistory_cfg.py --input merged_files.root
 
-edmProvDump merged_files.root | grep -q "PROD.*test-one" || die "Did not find test-one from merged_files.root provenance" $?
-edmProvDump merged_files.root | grep -q "PROD.*test-two" || die "Did not find test-two from merged_files.root provenance" $?
+edmProvDump --hardware merged_files.root | grep -q "PROD.*test-one" || die "Did not find test-one from merged_files.root provenance" $?
+edmProvDump --hardware merged_files.root | grep -q "PROD.*test-two" || die "Did not find test-two from merged_files.root provenance" $?
 
 
 exit 0

--- a/IOPool/Streamer/test/run_TestReducedProcessHistoryHardwareResources.sh
+++ b/IOPool/Streamer/test/run_TestReducedProcessHistoryHardwareResources.sh
@@ -15,7 +15,7 @@ CatStreamerFiles merged.dat test-one.dat test-two.dat
 
 runSuccess ${SCRAM_TEST_PATH}/testReducedProcessHistory_cfg.py --input merged.dat --output merged.root
 
-edmProvDump merged.root | grep -q "PROD.*test-one" || die "Did not find test-one from merged.root provenance" $?
-edmProvDump merged.root | grep -q "PROD.*test-two" || die "Did not find test-two from merged.root provenance" $?
+edmProvDump --hardware merged.root | grep -q "PROD.*test-one" || die "Did not find test-one from merged.root provenance" $?
+edmProvDump --hardware merged.root | grep -q "PROD.*test-two" || die "Did not find test-two from merged.root provenance" $?
 
 exit 0


### PR DESCRIPTION
#### PR description:

This PR is a quick follow-up to https://github.com/cms-sw/cmssw/pull/47473 to fix the test failures revealed in https://github.com/cms-sw/cmssw/pull/47416#issuecomment-2688964199 . It adds back the hardware provenance printout that was originally part of https://github.com/cms-sw/cmssw/pull/47355, and was reverted in https://github.com/cms-sw/cmssw/pull/47473, but as optional (via `--hardware`) in order to use it in the two tests, while keeping the default behavior such that works with CRAB.

This is a little bit of quick-and-dirty, but will be replaced with an overall better process history printout in the near future.

Resolves https://github.com/cms-sw/framework-team/issues/1274

#### PR validation:

Code compiles, the two (CPU) tests failed in https://github.com/cms-sw/cmssw/pull/47416#issuecomment-2688964199 succeed.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be included in https://github.com/cms-sw/cmssw/pull/47416