### PR TITLE
Lowered cluster charge threshold for pixel L1

### DIFF
--- a/Configuration/Eras/python/Era_Run3_2025_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2025_cff.py
@@ -3,5 +3,6 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.Eras.Era_Run3_2024_cff import Run3_2024
 from Configuration.Eras.Modifier_run3_GEM_2025_cff import run3_GEM_2025
 from Configuration.Eras.Modifier_stage2L1Trigger_2025_cff import stage2L1Trigger_2025
+from Configuration.Eras.Modifier_run3_SiPixel_2025_cff import run3_SiPixel_2025
 
-Run3_2025 = cms.ModifierChain(Run3_2024, run3_GEM_2025, stage2L1Trigger_2025)
+Run3_2025 = cms.ModifierChain(Run3_2024, run3_GEM_2025, stage2L1Trigger_2025, run3_SiPixel_2025)

--- a/Configuration/Eras/python/Modifier_run3_SiPixel_2025_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_SiPixel_2025_cff.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+# This modifier is for SiPixel-specific changes
+
+run3_SiPixel_2025 =  cms.Modifier()

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -100,6 +100,7 @@ class Eras (object):
                            'run2_HF_2017', 'run2_HCAL_2017', 'run2_HEPlan1_2017', 'run2_HB_2018','run2_HE_2018',
                            'run3_HB', 'run3_HFSL', 'run3_common', 'run3_RPC',
                            'phase1Pixel', 'run3_GEM', 'run2_GEM_2017',
+                           'run3_SiPixel_2025',
                            'run2_CSC_2018',
                            'phase2_common', 'phase2_tracker',
                            'phase2_muon', 'phase2_GEM', 'phase2_GE0',

--- a/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
+++ b/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
@@ -27,6 +27,12 @@ run3_common.toModify(siPixelClusters,
   ClusterThreshold_L1     = 4000
 )
 
+# lowered L1 cluster charge threshold to cope with reduced charge collection efficiency in the sensor caused by radiation damage
+from Configuration.Eras.Modifier_run3_SiPixel_2025_cff import run3_SiPixel_2025
+run3_SiPixel_2025.toModify(siPixelClusters,
+  ClusterThreshold_L1 = 2000
+)
+
 # Need these until phase2 pixel templates are used
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 from SimTracker.SiPhase2Digitizer.phase2TrackerDigitizer_cfi import PixelDigitizerAlgorithmCommon

--- a/RecoLocalTracker/SiPixelClusterizer/python/siPixelClustersPreSplitting_cff.py
+++ b/RecoLocalTracker/SiPixelClusterizer/python/siPixelClustersPreSplitting_cff.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 from HeterogeneousCore.AlpakaCore.functions import *
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
+from Configuration.Eras.Modifier_run3_SiPixel_2025_cff import run3_SiPixel_2025
 from Configuration.ProcessModifiers.alpaka_cff import alpaka
 
 # HIon Modifiers
@@ -43,6 +44,10 @@ siPixelClustersPreSplittingAlpaka = _siPixelRawToClusterAlpaka.clone()
     VCaltoElectronGain_L1   = 1,
     VCaltoElectronOffset    = 0,
     VCaltoElectronOffset_L1 = 0)
+
+(alpaka & run3_SiPixel_2025).toModify(siPixelClustersPreSplittingAlpaka,
+    # lowered L1 cluster charge threshold to cope with reduced charge collection efficiency in the sensor caused by radiation damage
+    clusterThreshold_layer1 = 2000)
 
 from RecoLocalTracker.SiPixelClusterizer.siPixelPhase2DigiToCluster_cfi import siPixelPhase2DigiToCluster as _siPixelPhase2DigiToCluster
 


### PR DESCRIPTION
#### PR description:

This PR lowers the cluster charge threshold in pixel layer 1 from 4000 to 2000 electrons for era Run3_2025. The change is motivated by results presented in https://indico.cern.ch/event/1492109/#118-radiation-damage-projectio during the January 2025 Tracker Week. While the mentioned change is undergoing TSG and the tracking POG validation, this PR is being created to already start its validation. More info about the ongoing validation will be added here as it become available.

#### PR validation:

Only configuration-level changes so made sure that `scram b` works and checked that the correct changes are picked up in the following example cmsDriver commands
```
cmsDriver.py SingleMuPt10_pythia8_cfi -s GEN,SIM,DIGI,L1,DIGI2RAW,RAW2DIGI,RECO --python_filename=test_2025.py -n 100 --no_exec --era Run3_2025 --nThreads=4 --conditions auto:phase1_2024_realistic

cmsDriver.py SingleMuPt10_pythia8_cfi -s GEN,SIM,DIGI,L1,DIGI2RAW,RAW2DIGI,RECO --python_filename=test_Alpaka_2025.py -n 100 --no_exec --era Run3_2025 --nThreads=4 --conditions auto:phase1_2024_realistic --procModifiers alpaka
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport to CMSSW_15_0_X for 2025 data taking will be needed.


