### PR TITLE
[124X] Fix for long-lived slepton simulation

### DIFF
--- a/Configuration/ProcessModifiers/python/fixLongLivedSleptonSim_cff.py
+++ b/Configuration/ProcessModifiers/python/fixLongLivedSleptonSim_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+# Designed to disable a bug affecting long lived slepton decays in HepMC-G4 interface
+fixLongLivedSleptonSim = cms.Modifier()

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -700,6 +700,6 @@ hgcaltb.toModify(g4SimHits,
 ## Fix for long-lived slepton simulation
 ##
 from Configuration.ProcessModifiers.fixLongLivedSleptonSim_cff import fixLongLivedSleptonSim
-dd4hep.toModify( g4SimHits,
-                 Generator = dict(IsSlepton = True)
+fixLongLivedSleptonSim.toModify( g4SimHits,
+                                 Generator = dict(IsSlepton = True)
 )

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -257,6 +257,7 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
         ApplyLumiMonitorCuts = cms.bool(False), ## primary for lumi monitors
         Verbosity = cms.untracked.int32(0),
         FixG4Primary = cms.bool(False),
+        IsSlepton = cms.bool(False),
         PDGselection = cms.PSet(
             PDGfilterSel = cms.bool(False),        ## filter out unwanted particles
             PDGfilter = cms.vint32(21,1,2,3,4,5,6) ## list of unwanted particles (gluons and quarks)
@@ -693,4 +694,12 @@ phase2_common.toModify(g4SimHits,
 from Configuration.Eras.Modifier_hgcaltb_cff import hgcaltb
 hgcaltb.toModify(g4SimHits,
                  OnlySDs = ['AHcalSensitiveDetector', 'HGCSensitiveDetector', 'HGCalTB1601SensitiveDetector', 'HcalTB06BeamDetector']
+)
+
+##
+## Fix for long-lived slepton simulation
+##
+from Configuration.ProcessModifiers.fixLongLivedSleptonSim_cff import fixLongLivedSleptonSim
+dd4hep.toModify( g4SimHits,
+                 Generator = dict(IsSlepton = True)
 )

--- a/SimG4Core/Generators/interface/Generator.h
+++ b/SimG4Core/Generators/interface/Generator.h
@@ -46,6 +46,7 @@ private:
   bool fPhiCuts;
   bool fFixG4Primary;
   bool fFiductialCuts;
+  bool fSlepton;
   double theMinPhiCut;
   double theMaxPhiCut;
   double theMinEtaCut;

--- a/SimG4Core/Generators/src/Generator.cc
+++ b/SimG4Core/Generators/src/Generator.cc
@@ -26,6 +26,7 @@ Generator::Generator(const ParameterSet &p)
       fEtaCuts(p.getParameter<bool>("ApplyEtaCuts")),
       fPhiCuts(p.getParameter<bool>("ApplyPhiCuts")),
       fFixG4Primary(p.getParameter<bool>("FixG4Primary")),
+      fSlepton(p.getParameter<bool>("IsSlepton")),
       theMinPhiCut(p.getParameter<double>("MinPhiCut")),  // in radians (CMS standard)
       theMaxPhiCut(p.getParameter<double>("MaxPhiCut")),
       theMinEtaCut(p.getParameter<double>("MinEtaCut")),
@@ -366,7 +367,7 @@ void Generator::HepMC2G4(const HepMC::GenEvent *evt_orig, G4Event *g4evt) {
           // Decay chain outside the fiducial cylinder defined by theRDecLenCut
           // are used for Geant4 tracking with predefined decay channel
           // In the case of decay in vacuum particle is not tracked by Geant4
-        } else if (2 == status && x2 * x2 + y2 * y2 >= theDecRCut2 && std::abs(z2) < Z_hector) {
+        } else if (2 == status && x2 * x2 + y2 * y2 >= theDecRCut2 && (fSlepton || std::abs(z2) < Z_hector)) {
           toBeAdded = true;
           if (verbose > 1)
             edm::LogVerbatim("SimG4CoreGenerator") << "GenParticle barcode = " << (*pitr)->barcode() << " passed case 2"
@@ -476,8 +477,15 @@ void Generator::particleAssignDaughters(G4PrimaryParticle *g4p, HepMC::GenPartic
       LogDebug("SimG4CoreGenerator::particleAssignDaughters")
           << "Assigning a " << (*vpdec)->pdg_id() << " as daughter of a " << vp->pdg_id() << " status=" << status;
 
+    bool isInList;
+    if (fSlepton) {
+      std::vector<int> fParticleList = {1000011, 1000013, 1000015, 2000011, 2000013, 2000015};
+      isInList = (std::find(fParticleList.begin(), fParticleList.end(), std::abs(vp->pdg_id())) != fParticleList.end());
+    } else {
+      isInList = std::abs(vp->pdg_id()) == 1000015;
+    }
     bool checkStatus = fFixG4Primary
-                           ? ((status == 23 && std::abs(vp->pdg_id()) == 1000015) || (status > 50 && status < 100))
+                           ? ((status == 23 && isInList) || (status > 50 && status < 100))
                            : status > 3;
 
     if ((status == 2 || checkStatus) && (*vpdec)->end_vertex() != nullptr) {

--- a/SimG4Core/Generators/src/Generator.cc
+++ b/SimG4Core/Generators/src/Generator.cc
@@ -484,9 +484,7 @@ void Generator::particleAssignDaughters(G4PrimaryParticle *g4p, HepMC::GenPartic
     } else {
       isInList = std::abs(vp->pdg_id()) == 1000015;
     }
-    bool checkStatus = fFixG4Primary
-                           ? ((status == 23 && isInList) || (status > 50 && status < 100))
-                           : status > 3;
+    bool checkStatus = fFixG4Primary ? ((status == 23 && isInList) || (status > 50 && status < 100)) : status > 3;
 
     if ((status == 2 || checkStatus) && (*vpdec)->end_vertex() != nullptr) {
       double x2 = (*vpdec)->end_vertex()->position().x();


### PR DESCRIPTION
#### PR description:

This PR is a backport of https://github.com/cms-sw/cmssw/pull/47165 and https://github.com/cms-sw/cmssw/pull/47197.
It fixes the simulation of gen particles in long-lived slepton signals. In particular, the handling of daughter particles in slepton decays. For more details, see [1]

[1] https://indico.cern.ch/event/1476269/#6-plan-for-displaced-dimuon-an

#### PR validation:

See original PRs. Code compilation and format has been checked for this release cycle.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is a backport of https://github.com/cms-sw/cmssw/pull/47165 and https://github.com/cms-sw/cmssw/pull/47197, and it is needed for central production of 2022 MC.

@civanch @kpedro88 