### PR TITLE
[106X] Fix for long-lived slepton simulation

### DIFF
--- a/Configuration/ProcessModifiers/python/fixLongLivedSleptonSim_cff.py
+++ b/Configuration/ProcessModifiers/python/fixLongLivedSleptonSim_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+# Designed to disable a bug affecting long lived slepton decays in HepMC-G4 interface
+fixLongLivedSleptonSim = cms.Modifier()

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -181,6 +181,7 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
         MaxPhiCut = cms.double(3.14159265359),  ## according to CMS conventions
         ApplyLumiMonitorCuts = cms.bool(False), ## primary for lumi monitors
         Verbosity = cms.untracked.int32(0),
+        IsSlepton = cms.bool(False),
         PDGselection = cms.PSet(
             PDGfilterSel = cms.bool(False),        ## filter out unwanted particles
             PDGfilter = cms.vint32(21,1,2,3,4,5,6) ## list of unwanted particles (gluons and quarks)
@@ -544,3 +545,11 @@ from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
 phase2_timing.toModify( g4SimHits.ECalSD,
                              StoreLayerTimeSim = cms.untracked.bool(True),
                              TimeSliceUnit = cms.double(0.001) )
+
+##
+## Fix for long-lived slepton simulation
+##
+from Configuration.ProcessModifiers.fixLongLivedSleptonSim_cff import fixLongLivedSleptonSim
+dd4hep.toModify( g4SimHits,
+                 Generator = dict(IsSlepton = True)
+)

--- a/SimG4Core/Generators/interface/Generator.h
+++ b/SimG4Core/Generators/interface/Generator.h
@@ -45,6 +45,7 @@ private:
   bool fEtaCuts;
   bool fPhiCuts;
   bool fFiductialCuts;
+  bool fSlepton;
   double theMinPhiCut;
   double theMaxPhiCut;
   double theMinEtaCut;


### PR DESCRIPTION
#### PR description:

This PR is a backport of https://github.com/cms-sw/cmssw/pull/47165 and https://github.com/cms-sw/cmssw/pull/47197.
It fixes the simulation of gen particles in long-lived slepton signals. In particular, the handling of daughter particles in slepton decays. For more details, see [1].

Additionally, a few lines not relevant to this PR are modified due to automatic code formatting.

[1] https://indico.cern.ch/event/1476269/#6-plan-for-displaced-dimuon-an

#### PR validation:

See original PRs. Code compilation and format has been checked for this release cycle.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is a backport of https://github.com/cms-sw/cmssw/pull/47165 and https://github.com/cms-sw/cmssw/pull/47197, and it is aimed for Run2 MC production.

@civanch @kpedro88 