### PR TITLE
Removed Principal::adjustToNewProductRegistry

### DIFF
--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -74,8 +74,6 @@ namespace edm {
 
     ~Principal() override;
 
-    bool adjustToNewProductRegistry(ProductRegistry const& reg);
-
     void adjustIndexesAfterProductRegistryAddition();
 
     void fillPrincipal(DelayedReader* reader);

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -2034,8 +2034,6 @@ namespace edm {
   void EventProcessor::readAndMergeRun(RunProcessingStatus& iStatus) {
     RunPrincipal& runPrincipal = *iStatus.runPrincipal();
 
-    bool runOK = runPrincipal.adjustToNewProductRegistry(*preg_);
-    assert(runOK);
     runPrincipal.mergeAuxiliary(*input_->runAuxiliary());
     {
       SendSourceTerminationSignalIfException sentry(actReg_.get());
@@ -2063,8 +2061,6 @@ namespace edm {
            input_->processHistoryRegistry().reducedProcessHistoryID(lumiPrincipal.aux().processHistoryID()) ==
                input_->processHistoryRegistry().reducedProcessHistoryID(
                    input_->luminosityBlockAuxiliary()->processHistoryID()));
-    bool lumiOK = lumiPrincipal.adjustToNewProductRegistry(*preg());
-    assert(lumiOK);
     lumiPrincipal.mergeAuxiliary(*input_->luminosityBlockAuxiliary());
     {
       SendSourceTerminationSignalIfException sentry(actReg_.get());

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -149,23 +149,6 @@ namespace edm {
     return size;
   }
 
-  // adjust provenance for input products after new input file has been merged
-  bool Principal::adjustToNewProductRegistry(ProductRegistry const& reg) {
-    ProductRegistry::ProductList const& prodsList = reg.productList();
-    for (auto const& prod : prodsList) {
-      ProductDescription const& bd = prod.second;
-      if (!bd.produced() && (bd.branchType() == branchType_)) {
-        auto cbd = std::make_shared<ProductDescription const>(bd);
-        auto phb = getExistingProduct(cbd->branchID());
-        if (phb == nullptr || phb->productDescription().branchName() != cbd->branchName()) {
-          return false;
-        }
-        phb->resetProductDescription(cbd);
-      }
-    }
-    return true;
-  }
-
   void Principal::addDroppedProduct(ProductDescription const& bd) {
     addProductOrThrow(std::make_unique<DroppedDataProductResolver>(std::make_shared<ProductDescription const>(bd)));
   }

--- a/FWCore/Framework/src/PrincipalCache.cc
+++ b/FWCore/Framework/src/PrincipalCache.cc
@@ -44,8 +44,6 @@ namespace edm {
     for (auto& eventPrincipal : eventPrincipals_) {
       if (eventPrincipal) {
         eventPrincipal->adjustIndexesAfterProductRegistryAddition();
-        bool eventOK = eventPrincipal->adjustToNewProductRegistry(*reg);
-        assert(eventOK);
       }
     }
   }

--- a/IOPool/Streamer/src/StreamerInputSource.cc
+++ b/IOPool/Streamer/src/StreamerInputSource.cc
@@ -299,8 +299,6 @@ namespace edm::streamer {
   void StreamerInputSource::read(EventPrincipal& eventPrincipal) {
     if (adjustEventToNewProductRegistry_) {
       eventPrincipal.adjustIndexesAfterProductRegistryAddition();
-      bool eventOK = eventPrincipal.adjustToNewProductRegistry(productRegistry());
-      assert(eventOK);
       adjustEventToNewProductRegistry_ = false;
     }
     EventSelectionIDVector ids(sendEvent_->eventSelectionIDs());


### PR DESCRIPTION
#### PR description:

The function is used to adjust the ProductDescription coming from a new file but recent changes to that class make such a activity unnecessary (as nothing can change at that point).

#### PR validation:

Code compiles. Framework unit tests pass.

resolves https://github.com/cms-sw/framework-team/issues/1281