### PR TITLE
[106X] Fix for long-lived slepton simulation

### DIFF
--- a/Configuration/ProcessModifiers/python/fixLongLivedSleptonSim_cff.py
+++ b/Configuration/ProcessModifiers/python/fixLongLivedSleptonSim_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+# Designed to disable a bug affecting long lived slepton decays in HepMC-G4 interface
+fixLongLivedSleptonSim = cms.Modifier()

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -556,6 +556,6 @@ run2_final_state_rad.toModify( g4SimHits, Generator = dict( FixOfFinalStateRadia
 ## Fix for long-lived slepton simulation
 ##
 from Configuration.ProcessModifiers.fixLongLivedSleptonSim_cff import fixLongLivedSleptonSim
-dd4hep.toModify( g4SimHits,
-                 Generator = dict(IsSlepton = True)
+fixLongLivedSleptonSim.toModify( g4SimHits,
+                                 Generator = dict(IsSlepton = True)
 )

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -182,6 +182,7 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
         ApplyLumiMonitorCuts = cms.bool(False), ## primary for lumi monitors
         FixOfFinalStateRadiation = cms.bool(False),
         Verbosity = cms.untracked.int32(0),
+        IsSlepton = cms.bool(False),
         PDGselection = cms.PSet(
             PDGfilterSel = cms.bool(False),        ## filter out unwanted particles
             PDGfilter = cms.vint32(21,1,2,3,4,5,6) ## list of unwanted particles (gluons and quarks)
@@ -550,3 +551,11 @@ phase2_timing.toModify( g4SimHits.ECalSD,
 ##
 from Configuration.ProcessModifiers.run2_final_state_rad_cff import run2_final_state_rad
 run2_final_state_rad.toModify( g4SimHits, Generator = dict( FixOfFinalStateRadiation = True ) )
+
+##
+## Fix for long-lived slepton simulation
+##
+from Configuration.ProcessModifiers.fixLongLivedSleptonSim_cff import fixLongLivedSleptonSim
+dd4hep.toModify( g4SimHits,
+                 Generator = dict(IsSlepton = True)
+)

--- a/SimG4Core/Generators/interface/Generator.h
+++ b/SimG4Core/Generators/interface/Generator.h
@@ -46,6 +46,7 @@ private:
   bool fPhiCuts;
   bool fFiductialCuts;
   bool fFinalState;
+  bool fSlepton;
   double theMinPhiCut;
   double theMaxPhiCut;
   double theMinEtaCut;

--- a/SimG4Core/Generators/src/Generator.cc
+++ b/SimG4Core/Generators/src/Generator.cc
@@ -27,6 +27,7 @@ Generator::Generator(const ParameterSet &p)
       fEtaCuts(p.getParameter<bool>("ApplyEtaCuts")),
       fPhiCuts(p.getParameter<bool>("ApplyPhiCuts")),
       fFinalState(p.getParameter<bool>("FixOfFinalStateRadiation")),
+      fSlepton(p.getParameter<bool>("IsSlepton")),
       theMinPhiCut(p.getParameter<double>("MinPhiCut")),  // in radians (CMS standard)
       theMaxPhiCut(p.getParameter<double>("MaxPhiCut")),
       theMinEtaCut(p.getParameter<double>("MinEtaCut")),
@@ -154,7 +155,8 @@ void Generator::HepMC2G4(const HepMC::GenEvent *evt_orig, G4Event *g4evt) {
         // be propagated by GEANT, so do not change their status code.
         status = 2;
       }
-      if(std::abs(pdg) == 9900015) status = 3;
+      if (std::abs(pdg) == 9900015)
+        status = 3;
 
       // Particles which are not decayed by generator
       if (status == 1) {
@@ -243,7 +245,8 @@ void Generator::HepMC2G4(const HepMC::GenEvent *evt_orig, G4Event *g4evt) {
         status = 1;
       }
       // heavy neutrino should not be propagated by Geant4
-      if(std::abs(pdg) == 9900015) status = 3;
+      if (std::abs(pdg) == 9900015)
+        status = 3;
 
       double x2 = x1;
       double y2 = y1;
@@ -350,7 +353,7 @@ void Generator::HepMC2G4(const HepMC::GenEvent *evt_orig, G4Event *g4evt) {
           // Decay chain outside the fiducial cylinder defined by theRDecLenCut
           // are used for Geant4 tracking with predefined decay channel
           // In the case of decay in vacuum particle is not tracked by Geant4
-        } else if (2 == status && x2 * x2 + y2 * y2 >= theDecRCut2 && std::abs(z2) < Z_hector) {
+        } else if (2 == status && x2 * x2 + y2 * y2 >= theDecRCut2 && (fSlepton || std::abs(z2) < Z_hector)) {
           toBeAdded = true;
           if (verbose > 2)
             LogDebug("SimG4CoreGenerator") << "GenParticle barcode = " << (*pitr)->barcode() << " passed case 2"
@@ -452,10 +455,16 @@ void Generator::particleAssignDaughters(G4PrimaryParticle *g4p, HepMC::GenPartic
     if (verbose > 2)
       LogDebug("SimG4CoreGenerator") << "Assigning a " << (*vpdec)->pdg_id() << " as daughter of a " << vp->pdg_id();
 
-    bool checkStatus = fFinalState ? (*vpdec)->status() > 3
-      : ((*vpdec)->status() == 23 && std::abs(vp->pdg_id()) == 1000015);   
-    if (((*vpdec)->status() == 2 || checkStatus) &&
-        (*vpdec)->end_vertex() != nullptr) {
+    bool isInList;
+    if (fSlepton) {
+      std::vector<int> fParticleList = {1000011, 1000013, 1000015, 2000011, 2000013, 2000015};
+      isInList = (std::find(fParticleList.begin(), fParticleList.end(), std::abs(vp->pdg_id())) != fParticleList.end());
+    } else {
+      isInList = std::abs(vp->pdg_id()) == 1000015;
+    }
+
+    bool checkStatus = fFinalState ? (*vpdec)->status() > 3 : ((*vpdec)->status() == 23 && isInList);
+    if (((*vpdec)->status() == 2 || checkStatus) && (*vpdec)->end_vertex() != nullptr) {
       double x2 = (*vpdec)->end_vertex()->position().x();
       double y2 = (*vpdec)->end_vertex()->position().y();
       double z2 = (*vpdec)->end_vertex()->position().z();


### PR DESCRIPTION
#### PR description:

This PR is a backport of https://github.com/cms-sw/cmssw/pull/47165 and https://github.com/cms-sw/cmssw/pull/47197.
It fixes the simulation of gen particles in long-lived slepton signals. In particular, the handling of daughter particles in slepton decays. For more details, see [1].

Additionally, a few lines not relevant to this PR are modified due to automatic code formatting.

[1] https://indico.cern.ch/event/1476269/#6-plan-for-displaced-dimuon-an

#### PR validation:

See original PRs. Code compilation and format has been checked for this release cycle.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is a backport of https://github.com/cms-sw/cmssw/pull/47165 and https://github.com/cms-sw/cmssw/pull/47197, and it is aimed for Run2 MC production.

@civanch @kpedro88 