### PR TITLE
[MiniAOD] Update TauID selection for METUncertainties calculation, add pileup Id & UParTv1 for puppiJetMETReclustering

### DIFF
--- a/PhysicsTools/PatAlgos/python/tools/puppiJetMETReclusteringFromMiniAOD_cff.py
+++ b/PhysicsTools/PatAlgos/python/tools/puppiJetMETReclusteringFromMiniAOD_cff.py
@@ -25,6 +25,7 @@ def puppiJetMETReclusterFromMiniAOD(process, runOnMC, useExistingWeights=False, 
   from RecoBTag.ONNXRuntime.pfParticleNetFromMiniAODAK4_cff import _pfParticleNetFromMiniAODAK4PuppiCentralJetTagsAll as pfParticleNetFromMiniAODAK4PuppiCentralJetTagsAll
   from RecoBTag.ONNXRuntime.pfParticleNetFromMiniAODAK4_cff import _pfParticleNetFromMiniAODAK4PuppiForwardJetTagsAll as pfParticleNetFromMiniAODAK4PuppiForwardJetTagsAll
   from RecoBTag.ONNXRuntime.pfUnifiedParticleTransformerAK4_cff import _pfUnifiedParticleTransformerAK4JetTagsAll as pfUnifiedParticleTransformerAK4JetTagsAll
+  from RecoBTag.ONNXRuntime.pfUnifiedParticleTransformerAK4V1_cff import _pfUnifiedParticleTransformerAK4V1JetTagsAll as pfUnifiedParticleTransformerAK4V1JetTagsAll
 
   btagDiscriminatorsAK4 = cms.PSet(
    names=cms.vstring(
@@ -37,6 +38,7 @@ def puppiJetMETReclusterFromMiniAOD(process, runOnMC, useExistingWeights=False, 
     + pfParticleNetFromMiniAODAK4PuppiCentralJetTagsAll
     + pfParticleNetFromMiniAODAK4PuppiForwardJetTagsAll
     + pfUnifiedParticleTransformerAK4JetTagsAll
+    + pfUnifiedParticleTransformerAK4V1JetTagsAll
   )
 
   # AK8 taggers

--- a/PhysicsTools/PatAlgos/python/tools/puppiJetMETReclusteringTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/puppiJetMETReclusteringTools.py
@@ -77,6 +77,13 @@ def puppiAK4METReclusterFromMiniAOD(process, runOnMC, useExistingWeights, btagDi
   if hasattr(process,"patJetFlavourAssociationPuppi"):
     process.patJetFlavourAssociationPuppi.weights = cms.InputTag(puppiLabel)
 
+  process.load("RecoJets.JetProducers.PileupJetID_cfi")
+  task.add(process.pileUpJetIDPuppiTask)
+  process.pileupJetIdPuppi.srcConstituentWeights = puppiLabel
+  process.pileupJetIdPuppi.vertexes = pvLabel
+  process.patJetsPuppi.userData.userFloats.src += [cms.InputTag("pileupJetIdPuppi:fullDiscriminant")]
+  process.patJetsPuppi.userData.userInts.src += [cms.InputTag("pileupJetIdPuppi:fullId")]
+
   #=============================================
   #
   # Update the selectedPatJet collection.

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -943,7 +943,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         #---------
         pfTaus = cms.EDFilter("PATTauRefSelector",
                               src = tauCollection,
-                              cut = cms.string('pt > 18.0 & abs(eta) < 2.6 & tauID("decayModeFinding") > 0.5 & isPFTau')
+                              cut = cms.string('pt > 18.0 & abs(eta) < 2.6 & tauID("decayModeFindingNewDMs") > 0.5 & isPFTau')
                               )
         addToProcessAndTask("pfTaus"+postfix, pfTaus, process, getMETUncertainties_task)
         #---------------------------------------------------------------------

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -943,7 +943,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         #---------
         pfTaus = cms.EDFilter("PATTauRefSelector",
                               src = tauCollection,
-                              cut = cms.string('pt > 18.0 & abs(eta) < 2.6 & tauID("decayModeFindingNewDMs") > 0.5 & isPFTau')
+                              cut = cms.string('pt > 18.0 & abs(eta) < 2.6 & (? isTauIDAvailable("decayModeFinding") ? tauID("decayModeFinding") : -1) > 0.5 & isPFTau')
                               )
         addToProcessAndTask("pfTaus"+postfix, pfTaus, process, getMETUncertainties_task)
         #---------------------------------------------------------------------


### PR DESCRIPTION
#### PR description:

This PR makes the following changes

1) Add a check of `decayModeFinding` tauID when selecting taus in `getMETUncertainties()` function. The `decayModeFinding` tauID is not in `slimmedTaus` in the latest MiniAOD and that collection is used
to recalculate MET uncertainties.
2) Add Pileup Jet Id and UParTv1 in helper functions used for reclustering AK4, AK8 Puppi jets and PuppiMET.


 
#### PR validation:

passes the usual runTheMatrix test: `runTheMatrix.py -l limited -i all --ibeos`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to `15_0_X` for MiniAODv6+NanoAODv15 campaign