### PR TITLE
use `Run3_2025` Era in L1T online-DQM clients [`15_0_X`]

### DIFF
--- a/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 import sys
-from Configuration.Eras.Era_Run3_2024_cff import Run3_2024
-process = cms.Process("L1TStage2DQM", Run3_2024)
+from Configuration.Eras.Era_Run3_2025_cff import Run3_2025
+process = cms.Process("L1TStage2DQM", Run3_2025)
 
 unitTest = False
 if 'unitTest=True' in sys.argv:

--- a/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 import sys
-from Configuration.Eras.Era_Run3_2024_cff import Run3_2024
-process = cms.Process("L1TStage2EmulatorDQM", Run3_2024)
+from Configuration.Eras.Era_Run3_2025_cff import Run3_2025
+process = cms.Process("L1TStage2EmulatorDQM", Run3_2025)
 
 unitTest = False
 if 'unitTest=True' in sys.argv:


### PR DESCRIPTION
backport of #47491

#### PR description:

This PR updates the "Era" used in two of the L1T online-DQM clients to the latest Run-3 Era, i.e. `Run3_2025`.

FYI: @cms-sw/l1-l2

#### PR validation:

None.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

#47491

Update of two online-DQM clients for 2025 data-taking.