### PR TITLE
Enable corrections for HCAL effective areas

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/plugins/HLTHcalPFClusterIsolationProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/HLTHcalPFClusterIsolationProducer.cc
@@ -98,7 +98,7 @@ HLTHcalPFClusterIsolationProducer<T1>::HLTHcalPFClusterIsolationProducer(const e
       absEtaLowEdges_(config.getParameter<std::vector<double>>("absEtaLowEdges")),
       doEffAreaCorrection_(config.getParameter<bool>("doEffAreaCorrection")),
       effectiveAreasCorr_(config.getParameter<std::vector<double>>("effectiveAreasCorr")),
-      effectiveAreasThres_(config.getParameter<std::vector<double>>("effectiveAreasThres")){
+      effectiveAreasThres_(config.getParameter<std::vector<double>>("effectiveAreasThres")) {
   if (doRhoCorrection_) {
     if (absEtaLowEdges_.size() != effectiveAreas_.size())
       throw cms::Exception("IncompatibleVects") << "absEtaLowEdges and effectiveAreas should be of the same size. \n";
@@ -213,17 +213,17 @@ void HLTHcalPFClusterIsolationProducer<T1>::produce(edm::StreamID sid,
           break;
         }
       }
-      if (doEffAreaCorrection_){
-	if (rho>effectiveAreasThres_[iEA]){
-	  sum = sum - rho * (1 + effectiveAreasCorr_[iEA]) * effectiveAreas_[iEA];
-	}else{
-	  sum = sum - rho * effectiveAreas_[iEA];
-	}
-      }else{	
-	sum = sum - rho * effectiveAreas_[iEA];
+      if (doEffAreaCorrection_) {
+        if (rho > effectiveAreasThres_[iEA]) {
+          sum = sum - rho * (1 + effectiveAreasCorr_[iEA]) * effectiveAreas_[iEA];
+        } else {
+          sum = sum - rho * effectiveAreas_[iEA];
+        }
+      } else {
+        sum = sum - rho * effectiveAreas_[iEA];
       }
     }
-    
+
     recoCandMap.insert(candRef, sum);
   }
 

--- a/RecoEgamma/EgammaHLTProducers/plugins/HLTHcalPFClusterIsolationProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/HLTHcalPFClusterIsolationProducer.cc
@@ -214,13 +214,10 @@ void HLTHcalPFClusterIsolationProducer<T1>::produce(edm::StreamID sid,
         }
       }
       if (doEffAreaCorrection_) {
-        if (rho > effectiveAreasThres_[iEA]) {
-          sum = sum - rho * (1 + effectiveAreasCorr_[iEA]) * effectiveAreas_[iEA];
-        } else {
-          sum = sum - rho * effectiveAreas_[iEA];
-        }
+        float correction = (rho > effectiveAreasThres_[iEA]) ? (1 + effectiveAreasCorr_[iEA]) : 1;
+        sum -= rho * correction * effectiveAreas_[iEA];
       } else {
-        sum = sum - rho * effectiveAreas_[iEA];
+        sum -= rho * effectiveAreas_[iEA];
       }
     }
 


### PR DESCRIPTION
#### PR description:

Enable the possibility to correct the Effective Areas, introduced to compensate the dependence of the lepton HCAL isolation with pile-up. The PR performs a small turn-around so that one can correct only for a specific `rho` subrange. 

The PR is needed to implement the changes proposed to correct the muon isolation at HLT level. [Slides for reference](https://indico.cern.ch/event/1478195/contributions/6226326/attachments/3005379/5298103/MuonPOG_250130_SergioBlanco.pdf), presented at the 2025 Trigger Review.

#### PR validation:

The `scram b code-format` and `scram b code-checks` are applied.

The performance test `runTheMatrix.py -w standard -l 145.006` is performed.
