### PR TITLE
Enable corrections for HCAL effective areas [`15_0_X`]

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/plugins/HLTHcalPFClusterIsolationProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/HLTHcalPFClusterIsolationProducer.cc
@@ -67,6 +67,10 @@ private:
   const double rhoScale_;
   const std::vector<double> effectiveAreas_;
   const std::vector<double> absEtaLowEdges_;
+
+  const bool doEffAreaCorrection_;
+  const std::vector<double> effectiveAreasCorr_;
+  const std::vector<double> effectiveAreasThres_;
 };
 
 template <typename T1>
@@ -91,7 +95,10 @@ HLTHcalPFClusterIsolationProducer<T1>::HLTHcalPFClusterIsolationProducer(const e
       rhoMax_(config.getParameter<double>("rhoMax")),
       rhoScale_(config.getParameter<double>("rhoScale")),
       effectiveAreas_(config.getParameter<std::vector<double>>("effectiveAreas")),
-      absEtaLowEdges_(config.getParameter<std::vector<double>>("absEtaLowEdges")) {
+      absEtaLowEdges_(config.getParameter<std::vector<double>>("absEtaLowEdges")),
+      doEffAreaCorrection_(config.getParameter<bool>("doEffAreaCorrection")),
+      effectiveAreasCorr_(config.getParameter<std::vector<double>>("effectiveAreasCorr")),
+      effectiveAreasThres_(config.getParameter<std::vector<double>>("effectiveAreasThres")) {
   if (doRhoCorrection_) {
     if (absEtaLowEdges_.size() != effectiveAreas_.size())
       throw cms::Exception("IncompatibleVects") << "absEtaLowEdges and effectiveAreas should be of the same size. \n";
@@ -149,6 +156,9 @@ void HLTHcalPFClusterIsolationProducer<T1>::fillDescriptions(edm::ConfigurationD
   desc.add<bool>("useEt", true);
   desc.add<std::vector<double>>("effectiveAreas", {0.2, 0.25});   // 2016 post-ichep sinEle default
   desc.add<std::vector<double>>("absEtaLowEdges", {0.0, 1.479});  // Barrel, Endcap
+  desc.add<bool>("doEffAreaCorrection", false);
+  desc.add<std::vector<double>>("effectiveAreasCorr", {0.0, 0.0});
+  desc.add<std::vector<double>>("effectiveAreasThres", {0.0, 0.0});
   descriptions.add(defaultModuleLabel<HLTHcalPFClusterIsolationProducer<T1>>(), desc);
 }
 
@@ -177,7 +187,6 @@ void HLTHcalPFClusterIsolationProducer<T1>::produce(edm::StreamID sid,
 
   iEvent.getByToken(recoCandidateProducer_, recoCandHandle);
   iEvent.getByToken(pfClusterProducerHCAL_, clusterHcalHandle);
-  //const reco::PFClusterCollection* forIsolationHcal = clusterHcalHandle.product();
   clusterHandles.push_back(clusterHcalHandle);
 
   if (useHF_) {
@@ -193,7 +202,6 @@ void HLTHcalPFClusterIsolationProducer<T1>::produce(edm::StreamID sid,
 
   for (unsigned int iReco = 0; iReco < recoCandHandle->size(); iReco++) {
     T1Ref candRef(recoCandHandle, iReco);
-
     float sum = isoAlgo.getSum(candRef, clusterHandles);
 
     if (doRhoCorrection_) {
@@ -205,7 +213,12 @@ void HLTHcalPFClusterIsolationProducer<T1>::produce(edm::StreamID sid,
           break;
         }
       }
-      sum = sum - rho * effectiveAreas_[iEA];
+      if (doEffAreaCorrection_) {
+        float correction = (rho > effectiveAreasThres_[iEA]) ? (1 + effectiveAreasCorr_[iEA]) : 1;
+        sum -= rho * correction * effectiveAreas_[iEA];
+      } else {
+        sum -= rho * effectiveAreas_[iEA];
+      }
     }
 
     recoCandMap.insert(candRef, sum);


### PR DESCRIPTION
Backport of https://github.com/cms-sw/cmssw/pull/47496

#### PR description:

Enable the possibility to correct the Effective Areas, introduced to compensate the dependence of the lepton HCAL isolation with pile-up. The PR performs a small turn-around so that one can correct only for a specific rho subrange.

The PR is needed to implement the changes proposed to correct the muon isolation at HLT level. [Slides for reference](https://indico.cern.ch/event/1478195/contributions/6226326/attachments/3005379/5298103/MuonPOG_250130_SergioBlanco.pdf), presented at the 2025 Trigger Review.

#### PR validation:

The `scram b code-format` and `scram b code-checks` are applied.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

https://github.com/cms-sw/cmssw/pull/47496
