### PR TITLE
Let RNTuple auto-adjust page buffer budget

### DIFF
--- a/FWIO/RNTuple/plugins/RNTupleOutputModule.cc
+++ b/FWIO/RNTuple/plugins/RNTupleOutputModule.cc
@@ -216,7 +216,7 @@ namespace edm {
         ->setComment("Initially, columns start with a page of this size (bytes).");
     desc.addUntracked<unsigned long long>("maxUnzippedPageSize", ops.GetMaxUnzippedPageSize())
         ->setComment("Pages can grow only to the given limit (bytes).");
-    desc.addUntracked<unsigned long long>("pageBufferBudget", ops.GetPageBufferBudget())
+    desc.addUntracked<unsigned long long>("pageBufferBudget", 0)
         ->setComment(
             "The maximum size that the sum of all page buffers used for writing into a persistent sink are allowed to "
             "use."


### PR DESCRIPTION
#### PR description:

Change the default to 0 so the value is determined based on the configured approximate zipped cluster size, instead of using the value based on the default `approxZippedClusterSize` (128 MiB).

#### PR validation:

Local check of the adjusted page buffer budget.

FYI @Dr15Jones @makortel