### PR TITLE
Phase-2 HLT menu: refactor `HLTL1Sequence`

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTBeginSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTBeginSequence_cfi.py
@@ -2,5 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 from ..modules.hltTriggerType_cfi import *
 from ..sequences.HLTBeamSpotSequence_cfi import *
+from ..sequences.HLTL1Sequence_cfi import *
 
-HLTBeginSequence = cms.Sequence(hltTriggerType+HLTBeamSpotSequence)
+HLTBeginSequence = cms.Sequence(hltTriggerType+HLTL1Sequence+HLTBeamSpotSequence)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTDiphoton3023IsoCaloIdL1SeededSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTDiphoton3023IsoCaloIdL1SeededSequence_cfi.py
@@ -24,12 +24,10 @@ from ..sequences.HLTDoFullUnpackingEgammaEcalL1SeededSequence_cfi import *
 from ..sequences.HLTEGammaDoLocalHcalSequence_cfi import *
 from ..sequences.HLTFastJetForEgammaSequence_cfi import *
 from ..sequences.HLTHgcalTiclPFClusteringForEgammaL1SeededSequence_cfi import *
-from ..sequences.HLTL1Sequence_cfi import *
 from ..sequences.HLTPFClusteringForEgammaL1SeededSequence_cfi import *
 from ..sequences.HLTPFHcalClusteringForEgammaSequence_cfi import *
 
-HLTDiphoton3023IsoCaloIdL1SeededSequence = cms.Sequence(HLTL1Sequence
-                                                        +hltEGL1SeedsForDoublePhotonIsolatedFilter
+HLTDiphoton3023IsoCaloIdL1SeededSequence = cms.Sequence(hltEGL1SeedsForDoublePhotonIsolatedFilter
                                                         +HLTDoFullUnpackingEgammaEcalL1SeededSequence
                                                         +HLTPFClusteringForEgammaL1SeededSequence
                                                         +HLTHgcalTiclPFClusteringForEgammaL1SeededSequence
@@ -52,5 +50,5 @@ HLTDiphoton3023IsoCaloIdL1SeededSequence = cms.Sequence(HLTL1Sequence
                                                         +hltEgammaHGCalLayerClusterIsoL1Seeded
                                                         +hltDiEG3023IsoCaloIdHgcalIsoL1SeededFilter
                                                         +HLTPFHcalClusteringForEgammaSequence
-                                                        +hltEgammaHcalPFClusterIsoL1Seeded                                                        
+                                                        +hltEgammaHcalPFClusterIsoL1Seeded
                                                         +hltDiEG3023IsoCaloIdHcalIsoL1SeededFilter)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTDiphoton3023IsoCaloIdUnseededSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTDiphoton3023IsoCaloIdUnseededSequence_cfi.py
@@ -24,13 +24,11 @@ from ..sequences.HLTDoFullUnpackingEgammaEcalSequence_cfi import *
 from ..sequences.HLTEGammaDoLocalHcalSequence_cfi import *
 from ..sequences.HLTFastJetForEgammaSequence_cfi import *
 from ..sequences.HLTHgcalTiclPFClusteringForEgammaUnseededSequence_cfi import *
-from ..sequences.HLTL1Sequence_cfi import *
 from ..sequences.HLTPFClusteringForEgammaUnseededSequence_cfi import *
 from ..sequences.HLTPFHcalClusteringForEgammaSequence_cfi import *
 
 
-HLTDiphoton3023IsoCaloIdUnseededSequence = cms.Sequence(HLTL1Sequence
-                                                        +hltEGL1SeedsForDoublePhotonIsolatedFilter
+HLTDiphoton3023IsoCaloIdUnseededSequence = cms.Sequence(hltEGL1SeedsForDoublePhotonIsolatedFilter
                                                         +HLTDoFullUnpackingEgammaEcalSequence
                                                         +HLTPFClusteringForEgammaUnseededSequence
                                                         +HLTHgcalTiclPFClusteringForEgammaUnseededSequence

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTDoubleEle2312IsoL1SeededSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTDoubleEle2312IsoL1SeededSequence_cfi.py
@@ -6,7 +6,6 @@ from ..sequences.HLTElePixelMatchL1SeededSequence_cfi import *
 from ..sequences.HLTFastJetForEgammaSequence_cfi import *
 from ..sequences.HLTGsfElectronL1SeededSequence_cfi import *
 from ..sequences.HLTHgcalTiclPFClusteringForEgammaL1SeededSequence_cfi import *
-from ..sequences.HLTL1Sequence_cfi import *
 from ..sequences.HLTPFClusteringForEgammaL1SeededSequence_cfi import *
 from ..sequences.HLTPFHcalClusteringForEgammaSequence_cfi import *
 from ..sequences.HLTTrackingSequence_cfi import *
@@ -43,44 +42,43 @@ from ..modules.hltEgammaHGCalLayerClusterIsoL1Seeded_cfi import *
 from ..modules.hltEgammaHoverEL1Seeded_cfi import *
 
 
-HLTDoubleEle2312IsoL1SeededSequence = cms.Sequence(HLTL1Sequence
-    +hltEGL1SeedsForDoubleEleIsolatedFilter
-    +HLTDoFullUnpackingEgammaEcalL1SeededSequence
-    +HLTPFClusteringForEgammaL1SeededSequence
-    +HLTHgcalTiclPFClusteringForEgammaL1SeededSequence
-    +hltEgammaCandidatesL1Seeded
-    +hltEgammaCandidatesWrapperL1Seeded
-    +hltEG23EtL1SeededFilter
-    +hltDiEG12EtL1SeededFilter
-    +hltEgammaClusterShapeL1Seeded
-    +hltDiEG2312IsoClusterShapeL1SeededFilter
-    +hltEgammaHGCALIDVarsL1Seeded
-    +hltDiEG2312IsoClusterShapeSigmavvL1SeededFilter
-    +hltDiEG2312IsoClusterShapeSigmawwL1SeededFilter
-    +hltDiEG2312IsoHgcalHEL1SeededFilter
-    +HLTEGammaDoLocalHcalSequence
-    +HLTFastJetForEgammaSequence
-    +hltEgammaHoverEL1Seeded
-    +hltDiEG2312IsoHEL1SeededFilter
-    +hltEgammaEcalPFClusterIsoL1Seeded
-    +hltDiEG2312IsoEcalIsoL1SeededFilter
-    +hltEgammaHGCalLayerClusterIsoL1Seeded
-    +hltDiEG2312IsoHgcalIsoL1SeededFilter
-    +HLTPFHcalClusteringForEgammaSequence
-    +hltEgammaHcalPFClusterIsoL1Seeded
-    +hltDiEG2312IsoHcalIsoL1SeededFilter
-    +HLTElePixelMatchL1SeededSequence
-    +hltDiEle2312IsoPixelMatchL1SeededFilter
-    +hltDiEle2312IsoPMS2L1SeededFilter
-    +HLTGsfElectronL1SeededSequence
-    +hltDiEle2312IsoGsfOneOEMinusOneOPL1SeededFilter
-    +hltDiEle2312IsoGsfDetaL1SeededFilter
-    +hltDiEle2312IsoGsfDphiL1SeededFilter
-    +hltDiEle2312IsoBestGsfNLayerITL1SeededFilter
-    +hltDiEle2312IsoBestGsfChi2L1SeededFilter
-    +hltEgammaEleL1TrkIsoL1Seeded
-    +hltDiEle2312IsoGsfTrackIsoFromL1TracksL1SeededFilter
-    +HLTTrackingSequence
-    +hltEgammaEleGsfTrackIsoL1Seeded
-    +hltDiEle2312IsoGsfTrackIsoL1SeededFilter
-)
+HLTDoubleEle2312IsoL1SeededSequence = cms.Sequence(hltEGL1SeedsForDoubleEleIsolatedFilter
+                                                   +HLTDoFullUnpackingEgammaEcalL1SeededSequence
+                                                   +HLTPFClusteringForEgammaL1SeededSequence
+                                                   +HLTHgcalTiclPFClusteringForEgammaL1SeededSequence
+                                                   +hltEgammaCandidatesL1Seeded
+                                                   +hltEgammaCandidatesWrapperL1Seeded
+                                                   +hltEG23EtL1SeededFilter
+                                                   +hltDiEG12EtL1SeededFilter
+                                                   +hltEgammaClusterShapeL1Seeded
+                                                   +hltDiEG2312IsoClusterShapeL1SeededFilter
+                                                   +hltEgammaHGCALIDVarsL1Seeded
+                                                   +hltDiEG2312IsoClusterShapeSigmavvL1SeededFilter
+                                                   +hltDiEG2312IsoClusterShapeSigmawwL1SeededFilter
+                                                   +hltDiEG2312IsoHgcalHEL1SeededFilter
+                                                   +HLTEGammaDoLocalHcalSequence
+                                                   +HLTFastJetForEgammaSequence
+                                                   +hltEgammaHoverEL1Seeded
+                                                   +hltDiEG2312IsoHEL1SeededFilter
+                                                   +hltEgammaEcalPFClusterIsoL1Seeded
+                                                   +hltDiEG2312IsoEcalIsoL1SeededFilter
+                                                   +hltEgammaHGCalLayerClusterIsoL1Seeded
+                                                   +hltDiEG2312IsoHgcalIsoL1SeededFilter
+                                                   +HLTPFHcalClusteringForEgammaSequence
+                                                   +hltEgammaHcalPFClusterIsoL1Seeded
+                                                   +hltDiEG2312IsoHcalIsoL1SeededFilter
+                                                   +HLTElePixelMatchL1SeededSequence
+                                                   +hltDiEle2312IsoPixelMatchL1SeededFilter
+                                                   +hltDiEle2312IsoPMS2L1SeededFilter
+                                                   +HLTGsfElectronL1SeededSequence
+                                                   +hltDiEle2312IsoGsfOneOEMinusOneOPL1SeededFilter
+                                                   +hltDiEle2312IsoGsfDetaL1SeededFilter
+                                                   +hltDiEle2312IsoGsfDphiL1SeededFilter
+                                                   +hltDiEle2312IsoBestGsfNLayerITL1SeededFilter
+                                                   +hltDiEle2312IsoBestGsfChi2L1SeededFilter
+                                                   +hltEgammaEleL1TrkIsoL1Seeded
+                                                   +hltDiEle2312IsoGsfTrackIsoFromL1TracksL1SeededFilter
+                                                   +HLTTrackingSequence
+                                                   +hltEgammaEleGsfTrackIsoL1Seeded
+                                                   +hltDiEle2312IsoGsfTrackIsoL1SeededFilter
+                                                   )

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTDoubleEle25CaloIdLPMS2L1SeededSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTDoubleEle25CaloIdLPMS2L1SeededSequence_cfi.py
@@ -18,11 +18,9 @@ from ..sequences.HLTDoFullUnpackingEgammaEcalL1SeededSequence_cfi import *
 from ..sequences.HLTEGammaDoLocalHcalSequence_cfi import *
 from ..sequences.HLTElePixelMatchL1SeededSequence_cfi import *
 from ..sequences.HLTHgcalTiclPFClusteringForEgammaL1SeededSequence_cfi import *
-from ..sequences.HLTL1Sequence_cfi import *
 from ..sequences.HLTPFClusteringForEgammaL1SeededSequence_cfi import *
 
-HLTDoubleEle25CaloIdLPMS2L1SeededSequence = cms.Sequence(HLTL1Sequence
-                                                         +hltEGL1SeedsForDoubleEleNonIsolatedFilter
+HLTDoubleEle25CaloIdLPMS2L1SeededSequence = cms.Sequence(hltEGL1SeedsForDoubleEleNonIsolatedFilter
                                                          +HLTDoFullUnpackingEgammaEcalL1SeededSequence
                                                          +HLTPFClusteringForEgammaL1SeededSequence
                                                          +HLTHgcalTiclPFClusteringForEgammaL1SeededSequence

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTEle115NonIsoL1SeededSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTEle115NonIsoL1SeededSequence_cfi.py
@@ -22,12 +22,11 @@ from ..sequences.HLTEGammaDoLocalHcalSequence_cfi import *
 from ..sequences.HLTEle115NonIsoL1SeededGsfElectronL1SeededSequence_cfi import *
 from ..sequences.HLTElePixelMatchL1SeededSequence_cfi import *
 from ..sequences.HLTHgcalTiclPFClusteringForEgammaL1SeededSequence_cfi import *
-from ..sequences.HLTL1Sequence_cfi import *
 from ..sequences.HLTPFClusteringForEgammaL1SeededSequence_cfi import *
 from ..sequences.HLTFastJetForEgammaSequence_cfi import *
 
-HLTEle115NonIsoL1SeededSequence = cms.Sequence(HLTL1Sequence
-        +hltEGL1SeedsForSingleEleNonIsolatedFilter
+HLTEle115NonIsoL1SeededSequence = cms.Sequence(
+        hltEGL1SeedsForSingleEleNonIsolatedFilter
         +HLTDoFullUnpackingEgammaEcalL1SeededSequence
         +HLTPFClusteringForEgammaL1SeededSequence
         +HLTHgcalTiclPFClusteringForEgammaL1SeededSequence

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTEle26WP70L1SeededSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTEle26WP70L1SeededSequence_cfi.py
@@ -6,7 +6,6 @@ from ..sequences.HLTElePixelMatchL1SeededSequence_cfi import *
 from ..sequences.HLTFastJetForEgammaSequence_cfi import *
 from ..sequences.HLTGsfElectronL1SeededSequence_cfi import *
 from ..sequences.HLTHgcalTiclPFClusteringForEgammaL1SeededSequence_cfi import *
-from ..sequences.HLTL1Sequence_cfi import *
 from ..sequences.HLTPFClusteringForEgammaL1SeededSequence_cfi import *
 from ..sequences.HLTPFHcalClusteringForEgammaSequence_cfi import *
 from ..sequences.HLTTrackingSequence_cfi import *
@@ -41,8 +40,8 @@ from ..modules.hltEle26WP70HgcalIsoL1SeededFilter_cfi import *
 from ..modules.hltEle26WP70PixelMatchL1SeededFilter_cfi import *
 from ..modules.hltEle26WP70PMS2L1SeededFilter_cfi import *
 
-HLTEle26WP70L1SeededSequence = cms.Sequence(HLTL1Sequence
-    +hltEGL1SeedsForSingleEleIsolatedFilter
+HLTEle26WP70L1SeededSequence = cms.Sequence(
+    hltEGL1SeedsForSingleEleIsolatedFilter
     +HLTDoFullUnpackingEgammaEcalL1SeededSequence
     +HLTPFClusteringForEgammaL1SeededSequence
     +HLTHgcalTiclPFClusteringForEgammaL1SeededSequence

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTEle26WP70UnseededSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTEle26WP70UnseededSequence_cfi.py
@@ -36,13 +36,11 @@ from ..sequences.HLTElePixelMatchUnseededSequence_cfi import *
 from ..sequences.HLTFastJetForEgammaSequence_cfi import *
 from ..sequences.HLTGsfElectronUnseededSequence_cfi import *
 from ..sequences.HLTHgcalTiclPFClusteringForEgammaUnseededSequence_cfi import *
-from ..sequences.HLTL1Sequence_cfi import *
 from ..sequences.HLTPFClusteringForEgammaUnseededSequence_cfi import *
 from ..sequences.HLTPFHcalClusteringForEgammaSequence_cfi import *
 from ..sequences.HLTTrackingSequence_cfi import *
 
-HLTEle26WP70UnseededSequence = cms.Sequence(HLTL1Sequence
-                                            +hltEGL1SeedsForSingleEleIsolatedFilter
+HLTEle26WP70UnseededSequence = cms.Sequence(hltEGL1SeedsForSingleEleIsolatedFilter
                                             +HLTDoFullUnpackingEgammaEcalSequence
                                             +HLTPFClusteringForEgammaUnseededSequence
                                             +HLTHgcalTiclPFClusteringForEgammaUnseededSequence

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTEle32WPTightL1SeededSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTEle32WPTightL1SeededSequence_cfi.py
@@ -6,7 +6,6 @@ from ..sequences.HLTElePixelMatchL1SeededSequence_cfi import *
 from ..sequences.HLTFastJetForEgammaSequence_cfi import *
 from ..sequences.HLTGsfElectronL1SeededSequence_cfi import *
 from ..sequences.HLTHgcalTiclPFClusteringForEgammaL1SeededSequence_cfi import *
-from ..sequences.HLTL1Sequence_cfi import *
 from ..sequences.HLTPFClusteringForEgammaL1SeededSequence_cfi import *
 from ..sequences.HLTPFHcalClusteringForEgammaSequence_cfi import *
 from ..sequences.HLTTrackingSequence_cfi import *
@@ -42,8 +41,8 @@ from ..modules.hltEgammaClusterShapeL1Seeded_cfi import *
 from ..modules.hltEgammaHGCALIDVarsL1Seeded_cfi import *
 from ..modules.hltEgammaHoverEL1Seeded_cfi import *
 
-HLTEle32WPTightL1SeededSequence = cms.Sequence(HLTL1Sequence
-    +hltEGL1SeedsForSingleEleIsolatedFilter
+HLTEle32WPTightL1SeededSequence = cms.Sequence(
+    hltEGL1SeedsForSingleEleIsolatedFilter
     +HLTDoFullUnpackingEgammaEcalL1SeededSequence
     +HLTPFClusteringForEgammaL1SeededSequence
     +HLTHgcalTiclPFClusteringForEgammaL1SeededSequence

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTEle32WPTightUnseededSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTEle32WPTightUnseededSequence_cfi.py
@@ -6,7 +6,6 @@ from ..sequences.HLTElePixelMatchUnseededSequence_cfi import *
 from ..sequences.HLTFastJetForEgammaSequence_cfi import *
 from ..sequences.HLTGsfElectronUnseededSequence_cfi import *
 from ..sequences.HLTHgcalTiclPFClusteringForEgammaUnseededSequence_cfi import *
-from ..sequences.HLTL1Sequence_cfi import *
 from ..sequences.HLTPFClusteringForEgammaUnseededSequence_cfi import *
 from ..sequences.HLTPFHcalClusteringForEgammaSequence_cfi import *
 from ..sequences.HLTTrackingSequence_cfi import *
@@ -41,8 +40,8 @@ from ..modules.hltEle32WPTightHgcalIsoUnseededFilter_cfi import *
 from ..modules.hltEle32WPTightPixelMatchUnseededFilter_cfi import *
 from ..modules.hltEle32WPTightPMS2UnseededFilter_cfi import *
 
-HLTEle32WPTightUnseededSequence = cms.Sequence(HLTL1Sequence
-    +hltEGL1SeedsForSingleEleIsolatedFilter
+HLTEle32WPTightUnseededSequence = cms.Sequence(
+    hltEGL1SeedsForSingleEleIsolatedFilter
     +HLTDoFullUnpackingEgammaEcalSequence
     +HLTPFClusteringForEgammaUnseededSequence
     +HLTHgcalTiclPFClusteringForEgammaUnseededSequence

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTEle5OpenL1SeededSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTEle5OpenL1SeededSequence_cfi.py
@@ -37,13 +37,12 @@ from ..sequences.HLTElePixelMatchL1SeededSequence_cfi import *
 from ..sequences.HLTFastJetForEgammaSequence_cfi import *
 from ..sequences.HLTGsfElectronL1SeededSequence_cfi import *
 from ..sequences.HLTHgcalTiclPFClusteringForEgammaL1SeededSequence_cfi import *
-from ..sequences.HLTL1Sequence_cfi import *
 from ..sequences.HLTPFClusteringForEgammaL1SeededSequence_cfi import *
 from ..sequences.HLTPFHcalClusteringForEgammaSequence_cfi import *
 from ..sequences.HLTTrackingSequence_cfi import *
 
-HLTEle5OpenL1SeededSequence = cms.Sequence(HLTL1Sequence
-        +HLTDoFullUnpackingEgammaEcalL1SeededSequence
+HLTEle5OpenL1SeededSequence = cms.Sequence(
+        HLTDoFullUnpackingEgammaEcalL1SeededSequence
         +HLTPFClusteringForEgammaL1SeededSequence
         +HLTHgcalTiclPFClusteringForEgammaL1SeededSequence
         +hltEgammaCandidatesL1Seeded

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTEle5OpenUnseededSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTEle5OpenUnseededSequence_cfi.py
@@ -37,13 +37,11 @@ from ..sequences.HLTElePixelMatchUnseededSequence_cfi import *
 from ..sequences.HLTFastJetForEgammaSequence_cfi import *
 from ..sequences.HLTGsfElectronUnseededSequence_cfi import *
 from ..sequences.HLTHgcalTiclPFClusteringForEgammaUnseededSequence_cfi import *
-from ..sequences.HLTL1Sequence_cfi import *
 from ..sequences.HLTPFClusteringForEgammaUnseededSequence_cfi import *
 from ..sequences.HLTPFHcalClusteringForEgammaSequence_cfi import *
 from ..sequences.HLTTrackingSequence_cfi import *
 
-HLTEle5OpenUnseededSequence = cms.Sequence(HLTL1Sequence
-                                           +HLTDoFullUnpackingEgammaEcalSequence
+HLTEle5OpenUnseededSequence = cms.Sequence(HLTDoFullUnpackingEgammaEcalSequence
                                            +HLTEGammaDoLocalHcalSequence
                                            +HLTPFClusteringForEgammaUnseededSequence
                                            +HLTHgcalTiclPFClusteringForEgammaUnseededSequence

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTL1Sequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTL1Sequence_cfi.py
@@ -1,3 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
+#######
+# This is an empty placeholder for the L1T emulation step
+# This is currently dealt with through a separate cmsDriver step
+# The enty point for each path in the menu is through HLTBeginSequence
+
 HLTL1Sequence = cms.Sequence()

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTPhoton108EBTightIDTightIsoL1SeededSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTPhoton108EBTightIDTightIsoL1SeededSequence_cfi.py
@@ -17,12 +17,11 @@ from ..sequences.HLTDoFullUnpackingEgammaEcalL1SeededSequence_cfi import *
 from ..sequences.HLTEGammaDoLocalHcalSequence_cfi import *
 from ..sequences.HLTFastJetForEgammaSequence_cfi import *
 from ..sequences.HLTHgcalTiclPFClusteringForEgammaL1SeededSequence_cfi import *
-from ..sequences.HLTL1Sequence_cfi import *
 from ..sequences.HLTPFClusteringForEgammaL1SeededSequence_cfi import *
 from ..sequences.HLTPFHcalClusteringForEgammaSequence_cfi import *
 
-HLTPhoton108EBTightIDTightIsoL1SeededSequence = cms.Sequence(HLTL1Sequence
-        +hltEGL1SeedsForSinglePhotonIsolatedFilter
+HLTPhoton108EBTightIDTightIsoL1SeededSequence = cms.Sequence(
+        hltEGL1SeedsForSinglePhotonIsolatedFilter
         +HLTDoFullUnpackingEgammaEcalL1SeededSequence
         +HLTPFClusteringForEgammaL1SeededSequence
         +HLTHgcalTiclPFClusteringForEgammaL1SeededSequence

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTPhoton108EBTightIDTightIsoUnseededSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTPhoton108EBTightIDTightIsoUnseededSequence_cfi.py
@@ -21,8 +21,7 @@ from ..sequences.HLTL1Sequence_cfi import *
 from ..sequences.HLTPFClusteringForEgammaUnseededSequence_cfi import *
 from ..sequences.HLTPFHcalClusteringForEgammaSequence_cfi import *
 
-HLTPhoton108EBTightIDTightIsoUnseededSequence = cms.Sequence(HLTL1Sequence
-                                                             +hltEGL1SeedsForSinglePhotonIsolatedFilter
+HLTPhoton108EBTightIDTightIsoUnseededSequence = cms.Sequence(hltEGL1SeedsForSinglePhotonIsolatedFilter
                                                              +HLTDoFullUnpackingEgammaEcalSequence
                                                              +HLTPFClusteringForEgammaUnseededSequence
                                                              +HLTHgcalTiclPFClusteringForEgammaUnseededSequence

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTPhoton187L1SeededSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTPhoton187L1SeededSequence_cfi.py
@@ -12,12 +12,10 @@ from ..modules.hltEgammaHoverEL1Seeded_cfi import *
 from ..sequences.HLTDoFullUnpackingEgammaEcalL1SeededSequence_cfi import *
 from ..sequences.HLTEGammaDoLocalHcalSequence_cfi import *
 from ..sequences.HLTHgcalTiclPFClusteringForEgammaL1SeededSequence_cfi import *
-from ..sequences.HLTL1Sequence_cfi import *
 from ..sequences.HLTPFClusteringForEgammaL1SeededSequence_cfi import *
 from ..sequences.HLTFastJetForEgammaSequence_cfi import *
 
-HLTPhoton187L1SeededSequence = cms.Sequence(HLTL1Sequence
-                                            +l1tTkEmSingle51Filter
+HLTPhoton187L1SeededSequence = cms.Sequence(l1tTkEmSingle51Filter
                                             +HLTDoFullUnpackingEgammaEcalL1SeededSequence
                                             +HLTPFClusteringForEgammaL1SeededSequence
                                             +HLTHgcalTiclPFClusteringForEgammaL1SeededSequence

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTPhoton187UnseededSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTPhoton187UnseededSequence_cfi.py
@@ -12,12 +12,10 @@ from ..modules.hltEgammaHoverEUnseeded_cfi import *
 from ..sequences.HLTDoFullUnpackingEgammaEcalSequence_cfi import *
 from ..sequences.HLTEGammaDoLocalHcalSequence_cfi import *
 from ..sequences.HLTHgcalTiclPFClusteringForEgammaUnseededSequence_cfi import *
-from ..sequences.HLTL1Sequence_cfi import *
 from ..sequences.HLTPFClusteringForEgammaUnseededSequence_cfi import *
 from ..sequences.HLTFastJetForEgammaSequence_cfi import *
 
-HLTPhoton187UnseededSequence = cms.Sequence(HLTL1Sequence
-                                            +l1tTkEmSingle51Filter
+HLTPhoton187UnseededSequence = cms.Sequence(l1tTkEmSingle51Filter
                                             +HLTDoFullUnpackingEgammaEcalSequence
                                             +HLTPFClusteringForEgammaUnseededSequence
                                             +HLTHgcalTiclPFClusteringForEgammaUnseededSequence


### PR DESCRIPTION
#### PR description:

The goal of this PR is to refactor the `HLTL1Sequence` in the Phase-2 HLT menu.
Currently it's an empty sequence 

https://github.com/cms-sw/cmssw/blob/8f4b7032b5948a963a4f253662da07ac9ff5c10a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTL1Sequence_cfi.py#L3

which is plugged in directly in several HLT paths (mostly e/gamma ones). 
The original purpose of this sequence would be to host the L1T emulation module directly within the HLT menu (as opposed to an additional cmsDriver step). Once that's available it would be desirable to have that run centrally for all the paths (via `HLTBeginSequence` as currently done in the Run 3 menu) instead of letting the individual clients include it. 

#### PR validation:

Standard TSG integration tests

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A

**N.B.**: the PR is a draft PR, as it's waiting for the sign-off of the various POGs @ HLT.  
