### PR TITLE
remove L1T legacy dependencies from pixel and strip online DQM clients

### DIFF
--- a/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
@@ -89,7 +89,7 @@ if (live):
 elif(offlineTesting):
     process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
     from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
-    process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run3_data', '')
+    process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:hltonline', '')
 
 #-----------------------
 #  Reconstruction Modules
@@ -179,6 +179,13 @@ process.hltHighLevel.throw =  False
 process.DQMmodules = cms.Sequence(process.dqmEnv* process.dqmSaver)#*process.dqmSaverPB)
 
 process.RecoForDQM_LocalReco = cms.Sequence(process.siPixelDigis*process.siStripDigis*process.gtDigis*process.trackerlocalreco)
+
+from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+# Replace gtDigis with gtStage2Digis when stage2L1Trigger is active
+stage2L1Trigger.toReplaceWith(
+  process.RecoForDQM_LocalReco,
+  cms.Sequence(process.siPixelDigis * process.siStripDigis * process.gtStage2Digis * process.trackerlocalreco)
+)
 
 ### COSMIC RUN SETTING
 if (process.runType.getRunType() == process.runType.cosmic_run or process.runType.getRunType() == process.runType.cosmic_run_stage1):

--- a/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
@@ -89,7 +89,7 @@ elif(offlineTesting):
     process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
     from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
     #you may need to set manually the GT in the line below
-    process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run3_data', '')
+    process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:hltonline', '')
 
 #--------------------------------------------
 ## Patch to avoid using Run Info information in reconstruction
@@ -232,6 +232,13 @@ if (process.runType.getRunType() == process.runType.hi_run):
     process.RecoForDQM_LocalReco     = cms.Sequence(process.siPixelDigis*process.siStripDigis*process.trackerlocalreco)
 else :
     process.RecoForDQM_LocalReco     = cms.Sequence(process.siPixelDigis*process.siStripDigis*process.gtDigis*process.trackerlocalreco)
+
+    from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+    # Replace gtDigis with gtStage2Digis when stage2L1Trigger is active
+    stage2L1Trigger.toReplaceWith(
+      process.RecoForDQM_LocalReco,
+      cms.Sequence(process.siPixelDigis * process.siStripDigis * process.gtStage2Digis * process.trackerlocalreco)
+    )
 #------------------------------------------------------
 # Switch for channel errors per FED ID trend plots.
 #------------------------------------------------------
@@ -516,6 +523,7 @@ process.ecalDigisCPU.InputLabel = rawDataCollectorLabel
 process.ecalPreshowerDigis.sourceTag = rawDataCollectorLabel
 process.gctDigis.inputLabel = rawDataCollectorLabel
 process.gtDigis.DaqGtInputTag = rawDataCollectorLabel
+process.gtStage2Digis.InputLabel = rawDataCollectorLabel
 process.hcalDigis.InputLabel = rawDataCollectorLabel
 process.muonCSCDigis.InputObjects = rawDataCollectorLabel
 process.muonDTDigis.inputLabel = rawDataCollectorLabel


### PR DESCRIPTION
#### PR description:

This is a follow-up to https://github.com/cms-sw/cmssw/pull/46716 and fixes a couple of leftovers in the Pixel and SiStrip DQM clients that are crashing now after the deletion of legacy L1T records at https://its.cern.ch/jira/browse/CMSALCAFAST-94 with:

```console
----- Begin Fatal Exception 05-Mar-2025 10:36:43 CET-----------------------
An exception of category 'NoRecord' occurred while
   [0] Processing  Event run: 387552 lumi: 1 event: 350 stream: 0
   [1] Running path 'p'
   [2] Calling method for module L1GlobalTriggerRawToDigi/'gtDigis'
Exception Message:
No "L1MuTriggerScalesRcd" record found in the EventSetup.

 Please add an ESSource or ESProducer that delivers such a record.
----- End Fatal Exception -------------------------------------------------
```

This is circumvented by using where appropriate the `stage2L1Trigger` modifier.

#### PR validation:

```
setenv CMS_PATH "/cvmfs/cms-ib.cern.ch"
setenv SITECONFIG_PATH "/cvmfs/cms-ib.cern.ch/SITECONF/local"
cd DQM/Integration/python/clients
mkdir upload
cmsRun sistrip_dqm_sourceclient-live_cfg.py unitTest=True
cmsRun pixel_dqm_sourceclient-live_cfg.py unitTest=True runkey=cosmic_run
```

runs fine in this branch.


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but will be backported to CMSSW_14_2_X for 2025 data-taking operations.

cc: @nothingface0 
