### PR TITLE
add fillDescriptions to several BTV plugins used at HLT

### DIFF
--- a/RecoBTag/Combined/plugins/BTagProbabilityToDiscriminator.cc
+++ b/RecoBTag/Combined/plugins/BTagProbabilityToDiscriminator.cc
@@ -171,6 +171,7 @@ void BTagProbabilityToDiscriminator::fillDescriptions(edm::ConfigurationDescript
   edm::ParameterSetDescription desc;
   {
     edm::ParameterSetDescription vpsd1;
+    vpsd1.setAllowAnything();  // Allow any string-to-string mappings
     vpsd1.add<std::vector<edm::InputTag>>("denominator", {});
     vpsd1.add<std::vector<edm::InputTag>>("numerator",
                                           {
@@ -178,51 +179,55 @@ void BTagProbabilityToDiscriminator::fillDescriptions(edm::ConfigurationDescript
                                               edm::InputTag("pfDeepCSVJetTags", "probbb"),
                                           });
     vpsd1.add<std::string>("name", "BvsAll");
-    std::vector<edm::ParameterSet> temp1;
-    temp1.reserve(3);
+    std::vector<edm::ParameterSet> vectorOfDiscriminators;
+    vectorOfDiscriminators.reserve(3);
     {
-      edm::ParameterSet temp2;
-      temp2.addParameter<std::vector<edm::InputTag>>("denominator", {});
-      temp2.addParameter<std::vector<edm::InputTag>>("numerator",
-                                                     {
-                                                         edm::InputTag("pfDeepCSVJetTags", "probb"),
-                                                         edm::InputTag("pfDeepCSVJetTags", "probbb"),
-                                                     });
-      temp2.addParameter<std::string>("name", "BvsAll");
-      temp1.push_back(temp2);
+      edm::ParameterSet tempDiscriminator;
+      tempDiscriminator.addParameter<std::vector<edm::InputTag>>("denominator", {});
+      tempDiscriminator.addParameter<std::vector<edm::InputTag>>("numerator",
+                                                                 {
+                                                                     edm::InputTag("pfDeepCSVJetTags", "probb"),
+                                                                     edm::InputTag("pfDeepCSVJetTags", "probbb"),
+                                                                 });
+      tempDiscriminator.addParameter<std::string>("name", "BvsAll");
+      vectorOfDiscriminators.push_back(tempDiscriminator);
     }
     {
-      edm::ParameterSet temp2;
-      temp2.addParameter<std::vector<edm::InputTag>>("denominator",
-                                                     {
-                                                         edm::InputTag("pfDeepCSVJetTags", "probc"),
-                                                         edm::InputTag("pfDeepCSVJetTags", "probb"),
-                                                         edm::InputTag("pfDeepCSVJetTags", "probbb"),
-                                                     });
-      temp2.addParameter<std::vector<edm::InputTag>>("numerator",
-                                                     {
-                                                         edm::InputTag("pfDeepCSVJetTags", "probc"),
-                                                     });
-      temp2.addParameter<std::string>("name", "CvsB");
-      temp1.push_back(temp2);
+      edm::ParameterSet tempDiscriminator;
+      tempDiscriminator.addParameter<std::vector<edm::InputTag>>("denominator",
+                                                                 {
+                                                                     edm::InputTag("pfDeepCSVJetTags", "probc"),
+                                                                     edm::InputTag("pfDeepCSVJetTags", "probb"),
+                                                                     edm::InputTag("pfDeepCSVJetTags", "probbb"),
+                                                                 });
+      tempDiscriminator.addParameter<std::vector<edm::InputTag>>("numerator",
+                                                                 {
+                                                                     edm::InputTag("pfDeepCSVJetTags", "probc"),
+                                                                 });
+      tempDiscriminator.addParameter<std::string>("name", "CvsB");
+      vectorOfDiscriminators.push_back(tempDiscriminator);
     }
     {
-      edm::ParameterSet temp2;
-      temp2.addParameter<std::vector<edm::InputTag>>("denominator",
-                                                     {
-                                                         edm::InputTag("pfDeepCSVJetTags", "probudsg"),
-                                                         edm::InputTag("pfDeepCSVJetTags", "probc"),
-                                                     });
-      temp2.addParameter<std::vector<edm::InputTag>>("numerator",
-                                                     {
-                                                         edm::InputTag("pfDeepCSVJetTags", "probc"),
-                                                     });
-      temp2.addParameter<std::string>("name", "CvsL");
-      temp1.push_back(temp2);
+      edm::ParameterSet tempDiscriminator;
+      tempDiscriminator.addParameter<std::vector<edm::InputTag>>("denominator",
+                                                                 {
+                                                                     edm::InputTag("pfDeepCSVJetTags", "probudsg"),
+                                                                     edm::InputTag("pfDeepCSVJetTags", "probc"),
+                                                                 });
+      tempDiscriminator.addParameter<std::vector<edm::InputTag>>("numerator",
+                                                                 {
+                                                                     edm::InputTag("pfDeepCSVJetTags", "probc"),
+                                                                 });
+      tempDiscriminator.addParameter<std::string>("name", "CvsL");
+      vectorOfDiscriminators.push_back(tempDiscriminator);
     }
-    desc.addVPSet("discriminators", vpsd1, temp1);
+    desc.addVPSet("discriminators", vpsd1, vectorOfDiscriminators)
+        ->setComment(
+            "List of ParameterSets to create new ratio-based neural network discriminants. "
+            "Each entry is a ParameterSet where 'name' is the new name of the variable, and 'numerator' and "
+            "'denominator' are vector of InputTags of the pure neural network scores to be used in the calculation.");
   }
-  descriptions.addDefault(desc);
+  descriptions.addWithDefaultLabel(desc);
 }
 
 // define this as a plug-in

--- a/RecoBTag/ImpactParameter/plugins/IPProducer.h
+++ b/RecoBTag/ImpactParameter/plugins/IPProducer.h
@@ -443,21 +443,30 @@ template <>
 inline void IPProducer<reco::TrackRefVector, reco::JTATagInfo, IPProducerHelpers::FromJTA>::fillDescriptions(
     edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<double>("maximumTransverseImpactParameter", 0.2);
-  desc.add<int>("minimumNumberOfHits", 8);
-  desc.add<double>("minimumTransverseMomentum", 1.0);
-  desc.add<edm::InputTag>("primaryVertex", edm::InputTag("offlinePrimaryVertices"));
-  desc.add<double>("maximumLongitudinalImpactParameter", 17.0);
-  desc.add<bool>("computeGhostTrack", true);
-  desc.add<double>("ghostTrackPriorDeltaR", 0.03);
-  desc.add<edm::InputTag>("jetTracks", edm::InputTag("ak4JetTracksAssociatorAtVertexPF"));
-  desc.add<bool>("jetDirectionUsingGhostTrack", false);
-  desc.add<int>("minimumNumberOfPixelHits", 2);
-  desc.add<bool>("jetDirectionUsingTracks", false);
-  desc.add<bool>("computeProbabilities", true);
-  desc.add<bool>("useTrackQuality", false);
-  desc.add<double>("maximumChiSquared", 5.0);
-  descriptions.addDefault(desc);
+  desc.add<double>("maximumTransverseImpactParameter", 0.2)
+      ->setComment("Set upper threshold for the track transverse impact parameter.");
+  desc.add<int>("minimumNumberOfHits", 8)->setComment("Set lower threshold for the number of valid hits per track.");
+  desc.add<double>("minimumTransverseMomentum", 1.0)
+      ->setComment("Set lower threshold for the minimum track transverse momentum.");
+  desc.add<edm::InputTag>("primaryVertex", edm::InputTag("offlinePrimaryVertices"))
+      ->setComment("InputTag for the primary vertex collection.");
+  desc.add<double>("maximumLongitudinalImpactParameter", 17.0)
+      ->setComment("Set upper threshold for the track transverse impact parameter.");
+  desc.add<bool>("computeGhostTrack", true)->setComment("Flag to produce ghost track collection.");
+  desc.add<double>("ghostTrackPriorDeltaR", 0.03)->setComment("Set cone radius for the ghost track fit.");
+  desc.add<edm::InputTag>("jetTracks", edm::InputTag("ak4JetTracksAssociatorAtVertexPF"))
+      ->setComment("InputTag for the jet-track association collection.");
+  desc.add<bool>("jetDirectionUsingGhostTrack", false)
+      ->setComment("Flag to build the jet momentum using ghost tracks.");
+  desc.add<int>("minimumNumberOfPixelHits", 2)
+      ->setComment("Set lower threshold for the number of valid pixel hits per track.");
+  desc.add<bool>("jetDirectionUsingTracks", false)
+      ->setComment("Flag to include the track momentum into the jet momentum.");
+  desc.add<bool>("computeProbabilities", true)
+      ->setComment("Flag to produce output probabilities for the tracks to originate from the PV.");
+  desc.add<bool>("useTrackQuality", false)->setComment("Flag to use the track quality in the probability calculation.");
+  desc.add<double>("maximumChiSquared", 5.0)->setComment("Set upper threshold for the track normalized chi2.");
+  descriptions.addWithDefaultLabel(desc);
 }
 
 template <>
@@ -465,24 +474,34 @@ inline void
 IPProducer<std::vector<reco::CandidatePtr>, reco::JetTagInfo, IPProducerHelpers::FromJetAndCands>::fillDescriptions(
     edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<double>("maximumTransverseImpactParameter", 0.2);
-  desc.add<int>("minimumNumberOfHits", 8);
-  desc.add<double>("minimumTransverseMomentum", 1.0);
-  desc.add<edm::InputTag>("primaryVertex", edm::InputTag("offlinePrimaryVertices"));
-  desc.add<double>("maximumLongitudinalImpactParameter", 17.0);
-  desc.add<bool>("computeGhostTrack", true);
-  desc.add<double>("maxDeltaR", 0.4);
-  desc.add<edm::InputTag>("candidates", edm::InputTag("particleFlow"));
-  desc.add<bool>("jetDirectionUsingGhostTrack", false);
-  desc.add<int>("minimumNumberOfPixelHits", 2);
-  desc.add<bool>("jetDirectionUsingTracks", false);
-  desc.add<bool>("computeProbabilities", true);
-  desc.add<bool>("useTrackQuality", false);
-  desc.add<edm::InputTag>("jets", edm::InputTag("ak4PFJetsCHS"));
-  desc.add<double>("ghostTrackPriorDeltaR", 0.03);
-  desc.add<double>("maximumChiSquared", 5.0);
-  desc.addOptional<bool>("explicitJTA", false);
-  descriptions.addDefault(desc);
+  desc.add<double>("maximumTransverseImpactParameter", 0.2)
+      ->setComment("Set upper threshold for the track transverse impact parameter.");
+  desc.add<int>("minimumNumberOfHits", 8)->setComment("Set lower threshold for the number of valid hits per track.");
+  desc.add<double>("minimumTransverseMomentum", 1.0)
+      ->setComment("Set lower threshold for the minimum track transverse momentum.");
+  desc.add<edm::InputTag>("primaryVertex", edm::InputTag("offlinePrimaryVertices"))
+      ->setComment("InputTag for the primary vertex collection.");
+  desc.add<double>("maximumLongitudinalImpactParameter", 17.0)
+      ->setComment("Set upper threshold for the track transverse impact parameter.");
+  desc.add<bool>("computeGhostTrack", true)->setComment("Flag to produce ghost track collection.");
+  desc.add<double>("maxDeltaR", 0.4)
+      ->setComment("Set upper threshold for the maximum distance between tracks and jets.");
+  desc.add<edm::InputTag>("candidates", edm::InputTag("particleFlow"))
+      ->setComment("InputTag for the particle flow candidate collection.");
+  desc.add<bool>("jetDirectionUsingGhostTrack", false)
+      ->setComment("Flag to build the jet momentum using ghost tracks.");
+  desc.add<int>("minimumNumberOfPixelHits", 2)
+      ->setComment("Set lower threshold for the number of valid pixel hits per track.");
+  desc.add<bool>("jetDirectionUsingTracks", false)
+      ->setComment("Flag to include the track momentum into the jet momentum.");
+  desc.add<bool>("computeProbabilities", true)
+      ->setComment("Flag to produce output probabilities for the tracks to originate from the PV.");
+  desc.add<bool>("useTrackQuality", false)->setComment("Flag to use the track quality in the probability calculation.");
+  desc.add<edm::InputTag>("jets", edm::InputTag("ak4PFJetsCHS"))->setComment("InputTag for the jet collection.");
+  desc.add<double>("ghostTrackPriorDeltaR", 0.03)->setComment("Set cone radius for the ghost track fit.");
+  desc.add<double>("maximumChiSquared", 5.0)->setComment("Set upper threshold for the track normalized chi2.");
+  desc.addOptional<bool>("explicitJTA", false)->setComment("Flag to explicitly assign jets to tracks.");
+  descriptions.addWithDefaultLabel(desc);
 }
 
 #endif

--- a/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
@@ -1215,8 +1215,10 @@ void TemplatedSecondaryVertexProducer<IPTI, VTX>::matchSubjets(const edm::Handle
 template <class IPTI, class VTX>
 void TemplatedSecondaryVertexProducer<IPTI, VTX>::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<double>("extSVDeltaRToJet", 0.3);
-  desc.add<edm::InputTag>("beamSpotTag", edm::InputTag("offlineBeamSpot"));
+  desc.add<double>("extSVDeltaRToJet", 0.3)
+      ->setComment("Minimum distance between jets and external secondary vertex collection, if provided.");
+  desc.add<edm::InputTag>("beamSpotTag", edm::InputTag("offlineBeamSpot"))
+      ->setComment("InputTag for the beamspot collection.");
   {
     edm::ParameterSetDescription vertexReco;
     vertexReco.add<double>("primcut", 1.8);
@@ -1231,15 +1233,21 @@ void TemplatedSecondaryVertexProducer<IPTI, VTX>::fillDescriptions(edm::Configur
             edm::ParameterDescription<double>("mergeThreshold", 3.0, true) and
             edm::ParameterDescription<std::string>("fitType", "RefitGhostTrackWithVertices", true),
         true);
-    desc.add<edm::ParameterSetDescription>("vertexReco", vertexReco);
+    desc.add<edm::ParameterSetDescription>("vertexReco", vertexReco)
+        ->setComment("ParameterSet to steer the secondary vertex reconstruction parameters.");
   }
   {
     edm::ParameterSetDescription vertexSelection;
     vertexSelection.add<std::string>("sortCriterium", "dist3dError");
-    desc.add<edm::ParameterSetDescription>("vertexSelection", vertexSelection);
+    desc.add<edm::ParameterSetDescription>("vertexSelection", vertexSelection)
+        ->setComment("ParameterSet steering the secondary vertex sorting.");
   }
-  desc.add<std::string>("constraint", "BeamSpot");
-  desc.add<edm::InputTag>("trackIPTagInfos", edm::InputTag("impactParameterTagInfos"));
+  desc.add<std::string>("constraint", "BeamSpot")
+      ->setComment(
+          "Option to set any constraint for the SV fit. Options are 'None', 'BeamSpot' (default), "
+          "'BeamSpot+PVPosition', 'BeamSpotZ+PVErrorScaledXY', 'PVErrorScaled', and 'BeamSpot+PVTracksInFit'.");
+  desc.add<edm::InputTag>("trackIPTagInfos", edm::InputTag("impactParameterTagInfos"))
+      ->setComment("InputTag for the track impact parameter information collection.");
   {
     edm::ParameterSetDescription vertexCuts;
     vertexCuts.add<double>("distSig3dMax", 99999.9);
@@ -1261,11 +1269,13 @@ void TemplatedSecondaryVertexProducer<IPTI, VTX>::fillDescriptions(edm::Configur
     vertexCuts.add<double>("distVal3dMin", -99999.9);
     vertexCuts.add<double>("massMax", 6.5);
     vertexCuts.add<double>("distSig3dMin", -99999.9);
-    desc.add<edm::ParameterSetDescription>("vertexCuts", vertexCuts);
+    desc.add<edm::ParameterSetDescription>("vertexCuts", vertexCuts)
+        ->setComment("ParameterSet steering the secondary vertex selection.");
   }
-  desc.add<bool>("useExternalSV", false);
-  desc.add<double>("minimumTrackWeight", 0.5);
-  desc.add<bool>("usePVError", true);
+  desc.add<bool>("useExternalSV", false)
+      ->setComment("Flag to consider an external secondary vertex collection as input.");
+  desc.add<double>("minimumTrackWeight", 0.5)->setComment("Setting a lower threshold for the track weight.");
+  desc.add<bool>("usePVError", true)->setComment("Flag to consider the error on the PV.");
   {
     edm::ParameterSetDescription trackSelection;
     trackSelection.add<double>("b_pT", 0.3684);
@@ -1294,21 +1304,35 @@ void TemplatedSecondaryVertexProducer<IPTI, VTX>::fillDescriptions(edm::Configur
     trackSelection.add<double>("sip3dSigMax", 99999.9);
     trackSelection.add<double>("sip2dSigMin", -99999.9);
     trackSelection.add<double>("b_dR", 0.6263);
-    desc.add<edm::ParameterSetDescription>("trackSelection", trackSelection);
+    desc.add<edm::ParameterSetDescription>("trackSelection", trackSelection)
+        ->setComment("ParameterSet steering the track selection.");
   }
-  desc.add<std::string>("trackSort", "sip3dSig");
-  desc.add<edm::InputTag>("extSVCollection", edm::InputTag("secondaryVertices"));
+  desc.add<std::string>("trackSort", "sip3dSig")->setComment("Set the sorting of the tracks, default is 'sip3dSig'.");
+  desc.add<edm::InputTag>("extSVCollection", edm::InputTag("secondaryVertices"))
+      ->setComment("InputTag for an (optional) external secondary vertex collection.");
   desc.addOptionalNode(edm::ParameterDescription<bool>("useSVClustering", false, true) and
                            edm::ParameterDescription<std::string>("jetAlgorithm", true) and
                            edm::ParameterDescription<double>("rParam", true),
-                       true);
-  desc.addOptional<bool>("useSVMomentum", false);
-  desc.addOptional<double>("ghostRescaling", 1e-18);
-  desc.addOptional<double>("relPtTolerance", 1e-03);
-  desc.addOptional<edm::InputTag>("fatJets");
-  desc.addOptional<edm::InputTag>("groomedFatJets");
-  desc.add<edm::InputTag>("weights", edm::InputTag(""));
-  descriptions.addDefault(desc);
+                       true)
+      ->setComment("Optional ParameterSet to steer any secondary vertex reclustering.");
+  desc.addOptional<bool>("useSVMomentum", false)
+      ->setComment(
+          "Flag to consider the secondary vertex momentum instead of the direction only for the ghost clustering.");
+  desc.addOptional<double>("ghostRescaling", 1e-18)
+      ->setComment("Parameter to scale down the secondary vertex momentum for the ghost clustering.");
+  desc.addOptional<double>("relPtTolerance", 1e-03)
+      ->setComment("Tolerance for relative difference in transverse momentum for the ghost clustering.");
+  desc.addOptional<double>("pvErrorScaling", 1.0)
+      ->setComment(
+          "Scaling of the primary vertex error if 'PVErrorScaled' or 'BeamSpotZ+PVErrorScaledXY' is set for the "
+          "constraint.");
+  desc.addOptional<edm::InputTag>("fatJets")->setComment(
+      "InputTag for any fatjet collection to cluster secondary vertices.");
+  desc.addOptional<edm::InputTag>("groomedFatJets")
+      ->setComment("InputTag for any groomed fatjet collection to cluster secondary vertices.");
+  desc.add<edm::InputTag>("weights", edm::InputTag(""))
+      ->setComment("InputTag for any weight collection, e.g., from PUPPI.");
+  descriptions.addWithDefaultLabel(desc);
 }
 
 //define this as a plug-in

--- a/RecoBTag/SoftLepton/plugins/SoftLepton.cc
+++ b/RecoBTag/SoftLepton/plugins/SoftLepton.cc
@@ -509,16 +509,16 @@ double SoftLepton::boostedPPar(const math::XYZVector &vector, const math::XYZVec
 // ------------ method fills 'descriptions' with the allowed parameters for the module ------------
 void SoftLepton::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<unsigned int>("muonSelection", 1);
-  desc.add<edm::InputTag>("leptons", edm::InputTag("muons"));
-  desc.add<edm::InputTag>("primaryVertex", edm::InputTag("offlinePrimaryVertices"));
-  desc.add<edm::InputTag>("leptonCands", edm::InputTag());
-  desc.add<edm::InputTag>("leptonId", edm::InputTag());
-  desc.add<unsigned int>("refineJetAxis", 0);
-  desc.add<edm::InputTag>("jets", edm::InputTag("ak4PFJetsCHS"));
-  desc.add<double>("leptonDeltaRCut", 0.4);
-  desc.add<double>("leptonChi2Cut", 9999.0);
-  descriptions.addDefault(desc);
+  desc.add<unsigned int>("muonSelection", 1)->setComment("Specify the muon SelectionType, default is 'AllGlobalMuons'.");
+  desc.add<edm::InputTag>("leptons", edm::InputTag("muons"))->setComment("InputTag for the lepton collection.");
+  desc.add<edm::InputTag>("primaryVertex", edm::InputTag("offlinePrimaryVertices"))->setComment("InputTag for the primary vertex collection.");
+  desc.add<edm::InputTag>("leptonCands", edm::InputTag())->setComment("InputTag for the lepton candidates collection, optional.");
+  desc.add<edm::InputTag>("leptonId", edm::InputTag())->setComment("InputTag for the lepton ID collection, optional.");
+  desc.add<unsigned int>("refineJetAxis", 0)->setComment("Specify if a modified jet axis is to be used. See SoftLepton::AxisType for details.");
+  desc.add<edm::InputTag>("jets", edm::InputTag("ak4PFJetsCHS"))->setComment("InputTag for the jet collection.");
+  desc.add<double>("leptonDeltaRCut", 0.4)->setComment("Specify the maximum allowed value for the distance in DeltaR between the lepton and the jet axis.");
+  desc.add<double>("leptonChi2Cut", 9999.0)->setComment("Specify the maximum allowed value for the normalized chi2 of the lepton.");
+  descriptions.addWithDefaultLabel(desc);
 }
 
 DEFINE_FWK_MODULE(SoftLepton);

--- a/RecoBTag/SoftLepton/plugins/SoftLepton.cc
+++ b/RecoBTag/SoftLepton/plugins/SoftLepton.cc
@@ -509,15 +509,21 @@ double SoftLepton::boostedPPar(const math::XYZVector &vector, const math::XYZVec
 // ------------ method fills 'descriptions' with the allowed parameters for the module ------------
 void SoftLepton::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<unsigned int>("muonSelection", 1)->setComment("Specify the muon SelectionType, default is 'AllGlobalMuons'.");
+  desc.add<unsigned int>("muonSelection", 1)
+      ->setComment("Specify the muon SelectionType, default is 'AllGlobalMuons'.");
   desc.add<edm::InputTag>("leptons", edm::InputTag("muons"))->setComment("InputTag for the lepton collection.");
-  desc.add<edm::InputTag>("primaryVertex", edm::InputTag("offlinePrimaryVertices"))->setComment("InputTag for the primary vertex collection.");
-  desc.add<edm::InputTag>("leptonCands", edm::InputTag())->setComment("InputTag for the lepton candidates collection, optional.");
+  desc.add<edm::InputTag>("primaryVertex", edm::InputTag("offlinePrimaryVertices"))
+      ->setComment("InputTag for the primary vertex collection.");
+  desc.add<edm::InputTag>("leptonCands", edm::InputTag())
+      ->setComment("InputTag for the lepton candidates collection, optional.");
   desc.add<edm::InputTag>("leptonId", edm::InputTag())->setComment("InputTag for the lepton ID collection, optional.");
-  desc.add<unsigned int>("refineJetAxis", 0)->setComment("Specify if a modified jet axis is to be used. See SoftLepton::AxisType for details.");
+  desc.add<unsigned int>("refineJetAxis", 0)
+      ->setComment("Specify if a modified jet axis is to be used. See SoftLepton::AxisType for details.");
   desc.add<edm::InputTag>("jets", edm::InputTag("ak4PFJetsCHS"))->setComment("InputTag for the jet collection.");
-  desc.add<double>("leptonDeltaRCut", 0.4)->setComment("Specify the maximum allowed value for the distance in DeltaR between the lepton and the jet axis.");
-  desc.add<double>("leptonChi2Cut", 9999.0)->setComment("Specify the maximum allowed value for the normalized chi2 of the lepton.");
+  desc.add<double>("leptonDeltaRCut", 0.4)
+      ->setComment("Specify the maximum allowed value for the distance in DeltaR between the lepton and the jet axis.");
+  desc.add<double>("leptonChi2Cut", 9999.0)
+      ->setComment("Specify the maximum allowed value for the normalized chi2 of the lepton.");
   descriptions.addWithDefaultLabel(desc);
 }
 

--- a/RecoBTau/JetTagComputer/plugins/JetTagProducer.cc
+++ b/RecoBTau/JetTagComputer/plugins/JetTagProducer.cc
@@ -171,16 +171,17 @@ void JetTagProducer::produce(StreamID, Event &iEvent, const EventSetup &iSetup) 
 // ------------ method fills 'descriptions' with the allowed parameters for the module ------------
 void JetTagProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<std::string>("jetTagComputer", "combinedMVAComputer");
+  desc.add<std::string>("jetTagComputer", "combinedMVAComputer")->setComment("InputTag for the jet-tag computer.");
   {
     std::vector<edm::InputTag> tagInfos;
     tagInfos.push_back(edm::InputTag("impactParameterTagInfos"));
     tagInfos.push_back(edm::InputTag("inclusiveSecondaryVertexFinderTagInfos"));
     tagInfos.push_back(edm::InputTag("softPFMuonsTagInfos"));
     tagInfos.push_back(edm::InputTag("softPFElectronsTagInfos"));
-    desc.add<std::vector<edm::InputTag> >("tagInfos", tagInfos);
+    desc.add<std::vector<edm::InputTag> >("tagInfos", tagInfos)
+        ->setComment("InputTag for the list of InputTags for the TagInfos to be used.");
   }
-  descriptions.addDefault(desc);
+  descriptions.addWithDefaultLabel(desc);
 }
 
 // define it as plugin


### PR DESCRIPTION
**PR description:**

This PR is similar in spirit to https://github.com/cms-sw/cmssw/pull/47017, https://github.com/cms-sw/cmssw/pull/47045, https://github.com/cms-sw/cmssw/pull/47079, https://github.com/cms-sw/cmssw/pull/47107, https://github.com/cms-sw/cmssw/pull/47136, https://github.com/cms-sw/cmssw/pull/47191, and https://github.com/cms-sw/cmssw/pull/47224. It adds fillDescriptions (and applies light modification to modernize the source code) to a few EDProducers used at HLT for both Run 3 and Phase 2 used (among others) by the BTV POG.

See also this issue: https://github.com/cms-sw/cmssw/issues/47275.

**PR validation:**

- `runTheMatrix.py -l limited` runs fine.

If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A