### PR TITLE
Phase2-hgx362A Provide the possibility of running without a Sensitive Detector by setting OnlySD = ['NONE']

### DIFF
--- a/Geometry/HGCalCommonData/data/hgcalPassive/v18/hgcalpos.xml
+++ b/Geometry/HGCalCommonData/data/hgcalPassive/v18/hgcalpos.xml
@@ -4,52 +4,52 @@
 <PosPartSection label="hgcalpos.xml">
   <PosPart copyNumber="1">
     <rParent name="cms:CMSE"/>
-    <rChild name="hgcalPassive:HGCalEEFullAbsorber1"/>
+    <rChild name="hgcalPassive:HGCalEEPassive1"/>
     <Translation x="0.0*cm" y="0.0*cm" z="-45.0*cm"/>
   </PosPart>
   <PosPart copyNumber="1">
     <rParent name="cms:CMSE"/>
-    <rChild name="hgcalPassive:HGCalEEFullAbsorber2"/>
+    <rChild name="hgcalPassive:HGCalEEPassive2"/>
     <Translation x="0.0*cm" y="0*cm" z="-35.0*cm"/>
   </PosPart>
   <PosPart copyNumber="1">
     <rParent name="cms:CMSE"/>
-    <rChild name="hgcalPassive:HGCalEEFullAbsorber3"/>
+    <rChild name="hgcalPassive:HGCalEEPassive3"/>
     <Translation x="0.0*cm" y="0*cm" z="-25.0*cm"/>
   </PosPart>
   <PosPart copyNumber="1">
     <rParent name="cms:CMSE"/>
-    <rChild name="hgcalPassive:HGCalEEPartialAbsorber100LD1"/>
+    <rChild name="hgcalPassive:HGCalEEPassive100HD1"/>
     <Translation x="0.0*cm" y="0*cm" z="-15.0*cm"/>
   </PosPart>
   <PosPart copyNumber="1">
     <rParent name="cms:CMSE"/>
-    <rChild name="hgcalPassive:HGCalEEPartialAbsorber200LD2"/>
+    <rChild name="hgcalPassive:HGCalEEPassive200LD2"/>
     <Translation x="0.0*cm" y="0*cm" z="-5.0*cm"/>
   </PosPart>
   <PosPart copyNumber="1">
     <rParent name="cms:CMSE"/>
-    <rChild name="hgcalPassive:HGCalEEPartialAbsorber300LD3"/>
+    <rChild name="hgcalPassive:HGCalEEPassive300LD3"/>
     <Translation x="0.0*cm" y="0*cm" z="5.0*cm"/>
   </PosPart>
   <PosPart copyNumber="1">
     <rParent name="cms:CMSE"/>
-    <rChild name="hgcalPassive:HGCalEEPartialAbsorber100LD6"/>
+    <rChild name="hgcalPassive:HGCalEEPassive100LD6"/>
     <Translation x="0.0*cm" y="0*cm" z="15.0*cm"/>
   </PosPart>
   <PosPart copyNumber="1">
     <rParent name="cms:CMSE"/>
-    <rChild name="hgcalPassive:HGCalEEPartialAbsorber200HD1"/>
+    <rChild name="hgcalPassive:HGCalEEPassive200HD1"/>
     <Translation x="0.0*cm" y="0*cm" z="25.0*cm"/>
   </PosPart>
   <PosPart copyNumber="1">
     <rParent name="cms:CMSE"/>
-    <rChild name="hgcalPassive:HGCalEEPartialAbsorber300HD3"/>
+    <rChild name="hgcalPassive:HGCalEEPassive300HD3"/>
     <Translation x="0.0*cm" y="0*cm" z="35.0*cm"/>
   </PosPart>
   <PosPart copyNumber="1">
     <rParent name="cms:CMSE"/>
-    <rChild name="hgcalPassive:HGCalHEPartialSteelCover00LD4"/>
+    <rChild name="hgcalPassive:HGCalHEPassive00LD5"/>
     <Translation x="0.0*cm" y="0*cm" z="45.0*cm"/>
   </PosPart>
 </PosPartSection>

--- a/Geometry/HGCalCommonData/test/python/g4OverlapCheckPassive_cfg.py
+++ b/Geometry/HGCalCommonData/test/python/g4OverlapCheckPassive_cfg.py
@@ -1,0 +1,84 @@
+###############################################################################
+# Way to use this:
+#   cmsRun g4OverlapCheckPassive_cfg.py geometry=V18 tol=0.01
+#
+#   Options for geometry V18, V19, V19c
+#
+###############################################################################
+import FWCore.ParameterSet.Config as cms
+import os, sys, importlib, re
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+####################################################################
+### SETUP OPTIONS
+options = VarParsing.VarParsing('standard')
+options.register('geometry',
+                 "V19",
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,
+                  "type of operations: V18, V19, V19c")
+options.register('tol',
+                 0.01,
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.float,
+                 "Tolerance for checking overlaps: 0.0, 0.01, 0.1, 1.0")
+
+### get and parse the command line arguments
+options.parseArguments()
+print(options)
+
+from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
+process = cms.Process('OverlapCheck',Phase2C17I13M9)
+#from Configuration.Eras.Modifier_hgcaltb_cff import hgcaltb
+#process = cms.Process('OverlapCheck',Phase2C17I13M9,hgcaltb)
+
+####################################################################
+# Use the options
+
+geomFile = "Geometry.HGCalCommonData.testHGCalPassive" + options.geometry + "XML_cfi"
+outFile = "hgcal" + options.geometry + str(options.tol)
+
+print("Geometry file: ", geomFile)
+print("Output file:   ", outFile)
+
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load(geomFile)
+#process.load('Geometry.HGCalCommonData.hgcalParametersInitialization_cfi')
+#process.load('Geometry.HGCalCommonData.hgcalNumberingInitialization_cfi')
+
+if hasattr(process,'MessageLogger'):
+#    process.MessageLogger.SimG4CoreGeometry=dict()
+#    process.MessageLogger.SimG4CoreApplication=dict()
+     process.MessageLogger.HGCalGeom=dict()
+
+from SimG4Core.PrintGeomInfo.g4TestGeometry_cfi import *
+process = checkOverlap(process)
+
+# enable Geant4 overlap check 
+process.g4SimHits.CheckGeometry = True
+process.g4SimHits.OnlySDs = ["NONE"]
+process.g4SimHits.CaloHits = []
+process.g4SimHits.TrackHits = []
+
+# Geant4 geometry check 
+process.g4SimHits.G4CheckOverlap.OutputBaseName = outFile
+process.g4SimHits.G4CheckOverlap.OverlapFlag = True
+process.g4SimHits.G4CheckOverlap.Tolerance  = options.tol
+process.g4SimHits.G4CheckOverlap.Resolution = 10000
+process.g4SimHits.G4CheckOverlap.Depth      = -1
+# tells if NodeName is G4Region or G4PhysicalVolume
+process.g4SimHits.G4CheckOverlap.RegionFlag = False
+# list of names
+process.g4SimHits.G4CheckOverlap.NodeNames  = ['OCMS']
+# enable dump gdml file 
+process.g4SimHits.G4CheckOverlap.gdmlFlag   = False
+# if defined a G4PhysicsVolume info is printed
+process.g4SimHits.G4CheckOverlap.PVname     = ''
+# if defined a list of daughter volumes is printed
+process.g4SimHits.G4CheckOverlap.LVname     = ''
+
+# extra output files, created if a name is not empty
+process.g4SimHits.FileNameField   = ''
+process.g4SimHits.FileNameGDML    = ''
+process.g4SimHits.FileNameRegions = ''
+#

--- a/SimG4Core/SensitiveDetector/src/sensitiveDetectorMakers.cc
+++ b/SimG4Core/SensitiveDetector/src/sensitiveDetectorMakers.cc
@@ -34,6 +34,7 @@ namespace sim {
           retValue[info.name_] = SensitiveDetectorPluginFactory::get()->create(info.name_, pset, cc);
         }
       }
+    } else if ((chosenMakers.size() == 1) && (chosenMakers[0] == "NONE")) {
     } else {
       for (auto const& name : chosenMakers) {
         retValue[name] = SensitiveDetectorPluginFactory::get()->create(name, pset, cc);


### PR DESCRIPTION
#### PR description:

Provide the possibility of running without a Sensitive Detector by setting OnlySD = ['NONE']. It is used to run the Geant4 overlap tool for a scenario with no sensitive detector. The step shows no overlap but a whole set of warnings.

#### PR validation:

It does not affect any normal SIM job and tested with a specific test script

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special