### PR TITLE
[15_0_X] move online beam spot arbitration to the edproducer

### DIFF
--- a/Alignment/CommonAlignmentProducer/python/ALCARECOPromptCalibProdSiPixelAliHLT_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOPromptCalibProdSiPixelAliHLT_cff.py
@@ -13,10 +13,8 @@ from Alignment.CommonAlignmentProducer.LSNumberFilter_cfi import *
 
 # Ingredient: onlineBeamSpot
 import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
-onlineBeamSpot = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()
-
-import RecoVertex.BeamSpotProducer.onlineBeamSpotESProducer_cfi as _mod
-BeamSpotESProducer = _mod.onlineBeamSpotESProducer.clone(
+onlineBeamSpot = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone(
+    useBSOnlineRecords = True,
     timeThreshold = 999999 # for express allow >48h old payloads for replays. DO NOT CHANGE
 )
 

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -4,11 +4,6 @@ import FWCore.ParameterSet.Config as cms
 # common utilities
 ##############################################################################
 def _swapOfflineBSwithOnline(process):
-    import RecoVertex.BeamSpotProducer.onlineBeamSpotESProducer_cfi as _mod
-    process.BeamSpotESProducer = _mod.onlineBeamSpotESProducer.clone(
-        timeThreshold = 999999 # for express allow >48h old payloads for replays. DO NOT CHANGE
-    )
-
     from RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi import onlineBeamSpotProducer
     process.offlineBeamSpot = onlineBeamSpotProducer.clone()
     return process

--- a/Configuration/StandardSequences/python/DigiToRaw_Repack_cff.py
+++ b/Configuration/StandardSequences/python/DigiToRaw_Repack_cff.py
@@ -84,10 +84,5 @@ hltScalersRawToDigi =  cms.EDProducer( "ScalersRawToDigi",
    scalersInputTag = cms.InputTag( "rawDataRepacker" )
 )
 
-import RecoVertex.BeamSpotProducer.onlineBeamSpotESProducer_cfi as _mod
-BeamSpotESProducer = _mod.onlineBeamSpotESProducer.clone(
-    timeThreshold = 999999 # to allow using old runs in tests
-)
-
 DigiToApproxClusterRawTask = cms.Task(hltSiStripRawToDigi,siStripZeroSuppressionHLT,hltScalersRawToDigi,hltBeamSpotProducer,siStripClustersHLT,hltSiStripClusters2ApproxClusters,rawPrimeDataRepacker)
 DigiToApproxClusterRaw = cms.Sequence(DigiToApproxClusterRawTask)

--- a/DQM/BeamMonitor/plugins/OnlineBeamMonitor.h
+++ b/DQM/BeamMonitor/plugins/OnlineBeamMonitor.h
@@ -23,7 +23,6 @@
 #include "CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h"
 #include "CondFormats/DataRecord/interface/BeamSpotOnlineLegacyObjectsRcd.h"
 #include "CondFormats/DataRecord/interface/BeamSpotOnlineHLTObjectsRcd.h"
-#include "CondFormats/DataRecord/interface/BeamSpotTransientObjectsRcd.h"
 
 namespace onlinebeammonitor {
   struct BeamSpotInfo {
@@ -36,11 +35,13 @@ class OnlineBeamMonitor : public DQMOneEDAnalyzer<edm::LuminosityBlockCache<onli
 public:
   OnlineBeamMonitor(const edm::ParameterSet&);
   static void fillDescriptions(edm::ConfigurationDescriptions&);
+  void analyze(edm::Event const&, edm::EventSetup const&) override;
 
 protected:
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
   std::shared_ptr<onlinebeammonitor::BeamSpotInfo> globalBeginLuminosityBlock(
       const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup) const override;
+  void fetchBeamSpotInformation(const edm::Event& iEvent, const edm::EventSetup& iSetup);
   void globalEndLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup) override;
   void dqmEndRun(edm::Run const&, edm::EventSetup const&) override;
 
@@ -55,7 +56,7 @@ private:
 
   //Parameters
   std::string monitorName_;
-  edm::ESGetToken<BeamSpotObjects, BeamSpotTransientObjectsRcd> bsTransientToken_;
+  edm::EDGetTokenT<reco::BeamSpot> bsOnlineToken_;
   edm::ESGetToken<BeamSpotOnlineObjects, BeamSpotOnlineHLTObjectsRcd> bsHLTToken_;
   edm::ESGetToken<BeamSpotOnlineObjects, BeamSpotOnlineLegacyObjectsRcd> bsLegacyToken_;
   std::ofstream fasciiDIP;
@@ -76,6 +77,8 @@ private:
   bool appendRunTxt_;
   bool writeDIPTxt_;
   std::string outputDIPTxt_;
+
+  bool shouldReadEvent_;
 };
 
 #endif

--- a/DQM/BeamMonitor/python/AlcaBeamMonitorHeavyIons_cff.py
+++ b/DQM/BeamMonitor/python/AlcaBeamMonitorHeavyIons_cff.py
@@ -11,11 +11,6 @@ AlcaBeamMonitor.PVFitter.VertexCollection  = 'hiSelectedVertex'
 from Configuration.ProcessModifiers.dqmPerLSsaving_cff import dqmPerLSsaving
 dqmPerLSsaving.toModify(AlcaBeamMonitor, perLSsaving=True)
 
-import RecoVertex.BeamSpotProducer.onlineBeamSpotESProducer_cfi as _mod
-BeamSpotESProducer = _mod.onlineBeamSpotESProducer.clone(
-    timeThreshold = 999999 # accept even old payloads for MC/Data ReReco. DO NOT CHANGE
-)
-
 import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
 scalerBeamSpot = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()
 alcaBeamMonitor = cms.Sequence( scalerBeamSpot*AlcaBeamMonitor )

--- a/DQM/BeamMonitor/python/AlcaBeamMonitor_cff.py
+++ b/DQM/BeamMonitor/python/AlcaBeamMonitor_cff.py
@@ -5,11 +5,6 @@ from DQM.BeamMonitor.AlcaBeamMonitor_cfi import *
 from Configuration.ProcessModifiers.dqmPerLSsaving_cff import dqmPerLSsaving
 dqmPerLSsaving.toModify(AlcaBeamMonitor, perLSsaving=True)
 
-import RecoVertex.BeamSpotProducer.onlineBeamSpotESProducer_cfi as _mod
-BeamSpotESProducer = _mod.onlineBeamSpotESProducer.clone(
-    timeThreshold = 999999 # accept even old payloads for MC/Data ReReco. DO NOT CHANGE
-)
-
 import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
 scalerBeamSpot = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()
 

--- a/DQM/BeamMonitor/test/Online_BeamMonitor_file.py
+++ b/DQM/BeamMonitor/test/Online_BeamMonitor_file.py
@@ -1,19 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-import FWCore.ParameterSet.VarParsing as VarParsing
-options = VarParsing.VarParsing()
-options.register("runNumber",
-                 326479,
-                 VarParsing.VarParsing.multiplicity.singleton,
-                 VarParsing.VarParsing.varType.int,
-                 "")
-options.register("maxEvents",
-                 100,
-                 VarParsing.VarParsing.multiplicity.singleton,
-                 VarParsing.VarParsing.varType.int,
-                 "number of events to run")
-options.parseArguments()
-
 process = cms.Process("DQM")
 
 process.load("CondCore.CondDB.CondDB_cfi")
@@ -36,10 +22,8 @@ process.BeamSpotDBSource = cms.ESSource("PoolDBESSource",
                                         )
 process.BeamSpotDBSource.connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS') 
 
-import RecoVertex.BeamSpotProducer.onlineBeamSpotESProducer_cfi as _mod
-process.BeamSpotESProducer = _mod.onlineBeamSpotESProducer.clone(
-        timeThreshold = 999999 # for express allow >48h old payloads for replays. DO NOT CHANGE
-)
+process.load("DQM.Integration.config.unitteststreamerinputsource_cfi")
+from DQM.Integration.config.unitteststreamerinputsource_cfi import options
 
 # initialize MessageLogger
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
@@ -52,22 +36,18 @@ process.MessageLogger.cout = cms.untracked.PSet(
         limit = cms.untracked.int32(1)
     ),
     OnlineBeamMonitor = cms.untracked.PSet(
-        reportEvery = cms.untracked.int32(1), # every 1000th only
+        reportEvery = cms.untracked.int32(1),
  	limit = cms.untracked.int32(0)
     ))
 
-process.source = cms.Source("EmptySource")
-process.source.numberEventsInRun=cms.untracked.uint32(100)
-process.source.firstRun = cms.untracked.uint32(options.runNumber)
-process.source.firstLuminosityBlock = cms.untracked.uint32(1)
-process.source.numberEventsInLuminosityBlock = cms.untracked.uint32(1)
-process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(options.maxEvents))
+process.maxEvents.input = cms.untracked.int32(options.maxEvents)
 
 #process.load("DQMServices.Core.DQMEDAnalyzer") 
 process.onlineBeamMonitor = cms.EDProducer("OnlineBeamMonitor",
                                            MonitorName         = cms.untracked.string("onlineBeamMonitor"),
                                            AppendRunToFileName = cms.untracked.bool(False),
                                            WriteDIPAscii       = cms.untracked.bool(True),
+                                           OnlineBeamSpotLabel = cms.untracked.InputTag("hltOnlineBeamSpot"),
                                            DIPFileName         = cms.untracked.string("BeamFitResultsForDIP.txt"))
 
 
@@ -88,7 +68,6 @@ process.options = cms.untracked.PSet(
     numberOfThreads = cms.untracked.uint32(4),
     numberOfStreams = cms.untracked.uint32 (4),
     numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(2)
-
     )
 
 #process.Tracer = cms.Service("Tracer")

--- a/DQM/BeamMonitor/test/testOnlineBeamMonitor.sh
+++ b/DQM/BeamMonitor/test/testOnlineBeamMonitor.sh
@@ -3,4 +3,4 @@
 function die { echo $1: status $2 ; exit $2; }
 
 echo "TESTING OnlineBeamMonitor ..."
-cmsRun ${SCRAM_TEST_PATH}/Online_BeamMonitor_file.py maxEvents=10 || die "Failure running Online_BeamMonitor_file.py" $?
+cmsRun ${SCRAM_TEST_PATH}/Online_BeamMonitor_file.py maxEvents=10 runNumber=381594 || die "Failure running Online_BeamMonitor_file.py" $?

--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -86,13 +86,6 @@ else:
 
 #--------------------------------------------------------
 # Swap offline <-> online BeamSpot as in Express and HLT
-import RecoVertex.BeamSpotProducer.onlineBeamSpotESProducer_cfi as _mod
-process.BeamSpotESProducer = _mod.onlineBeamSpotESProducer.clone()
-
-# for running offline enhance the time validity of the online beamspot in DB
-if ((not live) or process.isDqmPlayback.value): 
-  process.BeamSpotESProducer.timeThreshold = cms.int32(int(1e6))
-
 import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
 process.offlineBeamSpot = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()
 

--- a/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
@@ -153,10 +153,6 @@ process.tcdsDigis.InputLabel                         = rawDataInputTag
 import RecoVertex.BeamSpotProducer.onlineBeamSpotESProducer_cfi as _mod
 process.BeamSpotESProducer = _mod.onlineBeamSpotESProducer.clone()
 
-# for running offline enhance the time validity of the online beamspot in DB
-if ((not live) or process.isDqmPlayback.value): 
-  process.BeamSpotESProducer.timeThreshold = cms.int32(int(1e6))
-
 import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
 process.offlineBeamSpot = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()
 

--- a/DQM/Integration/python/clients/onlinebeammonitor_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/onlinebeammonitor_dqm_sourceclient-live_cfg.py
@@ -46,10 +46,6 @@ process.dqmSaver.runNumber     = options.runNumber
 # process.dqmSaverPB.tag         = 'OnlineBeamMonitor'
 # process.dqmSaverPB.runNumber   = options.runNumber
 
-# for running offline enhance the time validity of the online beamspot in DB
-if (unitTest or process.isDqmPlayback.value):
-  process.BeamSpotESProducer.timeThreshold = cms.int32(int(1e6))
-
 #-----------------------------
 # BeamMonitor
 #-----------------------------
@@ -57,6 +53,7 @@ process.dqmOnlineBeamMonitor = cms.EDProducer("OnlineBeamMonitor",
 MonitorName         = cms.untracked.string("OnlineBeamMonitor"),
 AppendRunToFileName = cms.untracked.bool(False),
 WriteDIPAscii       = cms.untracked.bool(True),
+OnlineBeamSpotLabel = cms.untracked.InputTag("hltOnlineBeamSpot"),
 DIPFileName         = cms.untracked.string("/nfshome0/dqmpro/BeamMonitorDQM/BeamFitResultsForDIP.txt")
 )
 

--- a/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
@@ -132,13 +132,6 @@ if (process.runType.getRunType() == process.runType.cosmic_run or process.runTyp
 else:
     process.load("Configuration.StandardSequences.Reconstruction_cff")
 
-import RecoVertex.BeamSpotProducer.onlineBeamSpotESProducer_cfi as _mod
-process.BeamSpotESProducer = _mod.onlineBeamSpotESProducer.clone()
-
-# for running offline enhance the time validity of the online beamspot in DB
-if ((not live) or process.isDqmPlayback.value): 
-  process.BeamSpotESProducer.timeThreshold = cms.int32(int(1e6))
-
 import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
 process.offlineBeamSpot = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()
 

--- a/DQM/Integration/python/clients/sistrip_approx_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/sistrip_approx_dqm_sourceclient-live_cfg.py
@@ -107,13 +107,6 @@ process.siStripQualityESProducer.ListOfRecordToMerge = cms.VPSet(
 process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
 process.load("Configuration.StandardSequences.Reconstruction_cff")
 
-import RecoVertex.BeamSpotProducer.onlineBeamSpotESProducer_cfi as _mod
-process.BeamSpotESProducer = _mod.onlineBeamSpotESProducer.clone()
-
-# for running offline enhance the time validity of the online beamspot in DB
-if ((not live) or process.isDqmPlayback.value): 
-  process.BeamSpotESProducer.timeThreshold = cms.int32(int(1e6))
-
 import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
 process.offlineBeamSpot = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()
 

--- a/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
@@ -117,13 +117,6 @@ if (process.runType.getRunType() == process.runType.cosmic_run or process.runTyp
 else:
     process.load("Configuration.StandardSequences.Reconstruction_cff")
 
-import RecoVertex.BeamSpotProducer.onlineBeamSpotESProducer_cfi as _mod
-process.BeamSpotESProducer = _mod.onlineBeamSpotESProducer.clone()
-
-# for running offline enhance the time validity of the online beamspot in DB
-if ((not live) or process.isDqmPlayback.value): 
-  process.BeamSpotESProducer.timeThreshold = cms.int32(int(1e6))
-
 import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
 process.offlineBeamSpot = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()
 

--- a/HLTrigger/Configuration/python/HLT_75e33/eventsetup/hltOnlineBeamSpotESProducer_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/eventsetup/hltOnlineBeamSpotESProducer_cfi.py
@@ -1,7 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-hltOnlineBeamSpotESProducer = cms.ESProducer("OnlineBeamSpotESProducer",
-    timeThreshold = cms.int32( int(1e6) ),   # we do want to read the DB even if it's old
-    sigmaZThreshold = cms.double( 2.0 ),
-    sigmaXYThreshold = cms.double( 4.0 )
-)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltOnlineBeamSpot_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltOnlineBeamSpot_cfi.py
@@ -6,5 +6,8 @@ hltOnlineBeamSpot = cms.EDProducer("BeamSpotOnlineProducer",
     maxRadius = cms.double(2.0),
     maxZ = cms.double(40.0),
     setSigmaZ = cms.double(0.0),
-    useTransientRecord = cms.bool(True)
+    useBSOnlineRecords = cms.bool(True),
+    timeThreshold = cms.int32(48),
+    sigmaZThreshold = cms.double( 2.0 ),
+    sigmaXYThreshold = cms.double( 4.0 )
 )

--- a/HLTrigger/Configuration/python/HLT_75e33_cff.py
+++ b/HLTrigger/Configuration/python/HLT_75e33_cff.py
@@ -56,7 +56,6 @@ fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/highPtTripletStepTra
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/muonSeededTrajectoryCleanerBySharedHits_cfi")
 
 ### Mostly comes from HLT-like configuration, not RECO-like configuration
-fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltOnlineBeamSpotESProducer_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPBwdElectronPropagator_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPChi2ChargeMeasurementEstimator2000_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPChi2ChargeMeasurementEstimator30_cfi")

--- a/HLTrigger/Configuration/python/HLT_75e33_timing_cff.py
+++ b/HLTrigger/Configuration/python/HLT_75e33_timing_cff.py
@@ -61,7 +61,6 @@ fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/highPtTripletStepTra
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/muonSeededTrajectoryCleanerBySharedHits_cfi")
 
 ### Mostly comes from HLT-like configuration, not RECO-like configuration
-fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltOnlineBeamSpotESProducer_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPBwdElectronPropagator_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPChi2ChargeMeasurementEstimator2000_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPChi2ChargeMeasurementEstimator30_cfi")

--- a/RecoVertex/BeamSpotProducer/plugins/BeamSpotOnlineProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/BeamSpotOnlineProducer.cc
@@ -12,14 +12,15 @@ ________________________________________________________________**/
 
 #include "CondFormats/BeamSpotObjects/interface/BeamSpotObjects.h"
 #include "CondFormats/DataRecord/interface/BeamSpotObjectsRcd.h"
-#include "CondFormats/DataRecord/interface/BeamSpotTransientObjectsRcd.h"
+#include "CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h"
+#include "CondFormats/DataRecord/interface/BeamSpotOnlineHLTObjectsRcd.h"
+#include "CondFormats/DataRecord/interface/BeamSpotOnlineLegacyObjectsRcd.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/GlobalError.h"
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerEvmReadoutRecord.h"
 #include "DataFormats/Scalers/interface/BeamSpotOnline.h"
 #include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/ESWatcher.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
@@ -28,11 +29,14 @@ ________________________________________________________________**/
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
+#include "FWCore/Utilities/interface/TypeDemangler.h"
 
 class BeamSpotOnlineProducer : public edm::stream::EDProducer<> {
 public:
   /// constructor
   explicit BeamSpotOnlineProducer(const edm::ParameterSet& iConf);
+
+  void beginLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup& setup) override;
 
   /// produce a beam spot class
   void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
@@ -43,27 +47,34 @@ public:
 private:
   // helper methods
   bool shouldShout(const edm::Event& iEvent) const;
-  bool processTransientRecord(const edm::EventSetup& iSetup, reco::BeamSpot& result, bool shoutMODE);
-  void createBeamSpotFromTransient(const BeamSpotObjects& spotDB, reco::BeamSpot& result) const;
-  bool processScalers(const edm::Event& iEvent, reco::BeamSpot& result, bool shoutMODE);
-  void createBeamSpotFromScaler(const BeamSpotOnline& spotOnline, reco::BeamSpot& result) const;
+  bool processRecords(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup, bool shoutMODE);
+  void createBeamSpotFromRecord(const BeamSpotObjects& spotDB);
+  template <typename RecordType, typename TokenType>
+  const BeamSpotOnlineObjects& getBeamSpotFromRecord(const TokenType& token,
+                                                     const edm::LuminosityBlock& lumi,
+                                                     const edm::EventSetup& setup);
+  const BeamSpotOnlineObjects& chooseBS(const BeamSpotOnlineObjects& bs1, const BeamSpotOnlineObjects& bs2);
+  bool processScalers(const edm::Event& iEvent, bool shoutMODE);
+  void createBeamSpotFromScaler(const BeamSpotOnline& spotOnline);
   bool isInvalidScaler(const BeamSpotOnline& spotOnline, bool shoutMODE) const;
-  void createBeamSpotFromDB(const edm::EventSetup& iSetup, reco::BeamSpot& result, bool shoutMODE) const;
+  void createBeamSpotFromDB(const edm::EventSetup& iSetup, bool shoutMODE);
 
   // data members
   const bool changeFrame_;
   const double theMaxZ, theSetSigmaZ;
   double theMaxR2;
-  const bool useTransientRecord_;
+  const int timeThreshold_;
+  const double sigmaZThreshold_, sigmaXYThreshold_;
+  const bool useBSOnlineRecords_;
   const edm::EDGetTokenT<BeamSpotOnlineCollection> scalerToken_;
   const edm::EDGetTokenT<L1GlobalTriggerEvmReadoutRecord> l1GtEvmReadoutRecordToken_;
   const edm::ESGetToken<BeamSpotObjects, BeamSpotObjectsRcd> beamToken_;
-  const edm::ESGetToken<BeamSpotObjects, BeamSpotTransientObjectsRcd> beamTransientToken_;
+  const edm::ESGetToken<BeamSpotOnlineObjects, BeamSpotOnlineLegacyObjectsRcd> beamTokenLegacy_;
+  const edm::ESGetToken<BeamSpotOnlineObjects, BeamSpotOnlineHLTObjectsRcd> beamTokenHLT_;
 
-  // watch IOV transition to emit warnings
-  edm::ESWatcher<BeamSpotTransientObjectsRcd> beamTransientRcdESWatcher_;
-
+  reco::BeamSpot result;
   const unsigned int theBeamShoutMode;
+  BeamSpotOnlineObjects fakeBS_;
 };
 
 using namespace edm;
@@ -72,13 +83,20 @@ BeamSpotOnlineProducer::BeamSpotOnlineProducer(const ParameterSet& iconf)
     : changeFrame_(iconf.getParameter<bool>("changeToCMSCoordinates")),
       theMaxZ(iconf.getParameter<double>("maxZ")),
       theSetSigmaZ(iconf.getParameter<double>("setSigmaZ")),
-      useTransientRecord_(iconf.getParameter<bool>("useTransientRecord")),
-      scalerToken_(useTransientRecord_ ? edm::EDGetTokenT<BeamSpotOnlineCollection>()
+      timeThreshold_(iconf.getParameter<int>("timeThreshold")),
+      sigmaZThreshold_(iconf.getParameter<double>("sigmaZThreshold")),
+      sigmaXYThreshold_(iconf.getParameter<double>("sigmaXYThreshold") * 1E-4),
+      useBSOnlineRecords_(iconf.getParameter<bool>("useBSOnlineRecords")),
+      scalerToken_(useBSOnlineRecords_ ? edm::EDGetTokenT<BeamSpotOnlineCollection>()
                                        : consumes<BeamSpotOnlineCollection>(iconf.getParameter<InputTag>("src"))),
       l1GtEvmReadoutRecordToken_(consumes<L1GlobalTriggerEvmReadoutRecord>(iconf.getParameter<InputTag>("gtEvmLabel"))),
       beamToken_(esConsumes<BeamSpotObjects, BeamSpotObjectsRcd>()),
-      beamTransientToken_(esConsumes<BeamSpotObjects, BeamSpotTransientObjectsRcd>()),
+      beamTokenLegacy_(
+          esConsumes<BeamSpotOnlineObjects, BeamSpotOnlineLegacyObjectsRcd, edm::Transition::BeginLuminosityBlock>()),
+      beamTokenHLT_(
+          esConsumes<BeamSpotOnlineObjects, BeamSpotOnlineHLTObjectsRcd, edm::Transition::BeginLuminosityBlock>()),
       theBeamShoutMode(iconf.getUntrackedParameter<unsigned int>("beamMode", 11)) {
+  fakeBS_.setType(reco::BeamSpot::Fake);
   theMaxR2 = iconf.getParameter<double>("maxRadius");
   theMaxR2 *= theMaxR2;
 
@@ -94,31 +112,40 @@ void BeamSpotOnlineProducer::fillDescriptions(edm::ConfigurationDescriptions& iD
   ps.addOptional<InputTag>("src", InputTag("hltScalersRawToDigi"))->setComment("SCAL decommissioned after Run 2");
   ps.add<InputTag>("gtEvmLabel", InputTag(""));
   ps.add<double>("maxRadius", 2.0);
-  ps.add<bool>("useTransientRecord", false);
+  ps.add<bool>("useBSOnlineRecords", false);
+  ps.add<int>("timeThreshold", 48)->setComment("hours");
+  ps.add<double>("sigmaZThreshold", 2.)->setComment("cm");
+  ps.add<double>("sigmaXYThreshold", 4.)->setComment("um");
   iDesc.addWithDefaultLabel(ps);
 }
 
-void BeamSpotOnlineProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  auto result = std::make_unique<reco::BeamSpot>();
+void BeamSpotOnlineProducer::beginLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup& setup) {
+  /// fetch online records only at the beginning of a lumisection
+  if (useBSOnlineRecords_) {
+    processRecords(lumi, setup, true);
+  }
+}
 
+void BeamSpotOnlineProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // Determine if we should "shout" based on the beam mode
   bool shoutMODE = shouldShout(iEvent);
   bool fallBackToDB{false};
 
-  // Use transient record if enabled
-  if (useTransientRecord_) {
-    fallBackToDB = processTransientRecord(iSetup, *result, shoutMODE);
+  // Use online records if enabled
+  if (useBSOnlineRecords_) {
+    fallBackToDB = result.type() != reco::BeamSpot::Tracker;
   } else {
     // Process online beam spot scalers
-    fallBackToDB = processScalers(iEvent, *result, shoutMODE);
+    fallBackToDB = processScalers(iEvent, shoutMODE);
   }
 
   // Fallback to DB if necessary
   if (fallBackToDB) {
-    createBeamSpotFromDB(iSetup, *result, shoutMODE);
+    createBeamSpotFromDB(iSetup, shoutMODE);
   }
 
-  iEvent.put(std::move(result));
+  std::unique_ptr<reco::BeamSpot> toput = std::make_unique<reco::BeamSpot>(result);
+  iEvent.put(std::move(toput));
 }
 
 bool BeamSpotOnlineProducer::shouldShout(const edm::Event& iEvent) const {
@@ -129,25 +156,80 @@ bool BeamSpotOnlineProducer::shouldShout(const edm::Event& iEvent) const {
   return true;  // Default to "shout" if the record is missing
 }
 
-bool BeamSpotOnlineProducer::processTransientRecord(const edm::EventSetup& iSetup,
-                                                    reco::BeamSpot& result,
-                                                    bool shoutMODE) {
-  auto const& spotDB = iSetup.getData(beamTransientToken_);
+bool BeamSpotOnlineProducer::processRecords(const edm::LuminosityBlock& iLumi,
+                                            const edm::EventSetup& iSetup,
+                                            bool shoutMODE) {
+  auto const& spotDBLegacy = getBeamSpotFromRecord<BeamSpotOnlineLegacyObjectsRcd>(beamTokenLegacy_, iLumi, iSetup);
+  auto const& spotDBHLT = getBeamSpotFromRecord<BeamSpotOnlineHLTObjectsRcd>(beamTokenHLT_, iLumi, iSetup);
+  auto const& spotDB = chooseBS(spotDBLegacy, spotDBHLT);
 
-  if (spotDB.beamType() != 2) {
-    if (shoutMODE && beamTransientRcdESWatcher_.check(iSetup)) {
-      edm::LogWarning("BeamSpotOnlineProducer")
-          << "Online Beam Spot producer falls back to DB value due to fake beamspot in transient record.";
+  if (spotDB.beamType() != reco::BeamSpot::Tracker) {
+    if (shoutMODE) {
+      edm::LogWarning("BeamSpotOnlineProducer") << "None of the online records holds a valid beam spot. The Online "
+                                                   "Beam Spot producer falls back to the PCL value.";
     }
     return true;  // Trigger fallback to DB
   }
 
   // Create BeamSpot from transient record
-  createBeamSpotFromTransient(spotDB, result);
+  createBeamSpotFromRecord(spotDB);
   return false;  // No fallback needed
 }
 
-void BeamSpotOnlineProducer::createBeamSpotFromTransient(const BeamSpotObjects& spotDB, reco::BeamSpot& result) const {
+template <typename RecordType, typename TokenType>
+const BeamSpotOnlineObjects& BeamSpotOnlineProducer::getBeamSpotFromRecord(const TokenType& token,
+                                                                           const LuminosityBlock& lumi,
+                                                                           const EventSetup& setup) {
+  auto const bsRecord = setup.tryToGet<RecordType>();
+  const auto& recordTypeName = edm::typeDemangle(typeid(RecordType).name());
+  if (!bsRecord) {
+    edm::LogWarning("BeamSpotOnlineProducer") << "No " << recordTypeName << " found in the EventSetup";
+    return fakeBS_;
+  }
+  const auto& bsHandle = setup.getHandle(token);
+  if (bsHandle.isValid()) {
+    const auto& bs = *bsHandle;
+    if (bs.sigmaZ() < sigmaZThreshold_ || bs.beamWidthX() < sigmaXYThreshold_ || bs.beamWidthY() < sigmaXYThreshold_ ||
+        bs.beamType() != reco::BeamSpot::Tracker) {
+      edm::LogWarning("BeamSpotOnlineProducer")
+          << "The beam spot record does not pass the fit sanity checks (record: " << recordTypeName << ")" << std::endl
+          << "sigmaZ: " << bs.sigmaZ() << std::endl
+          << "sigmaX: " << bs.beamWidthX() << std::endl
+          << "sigmaY: " << bs.beamWidthY() << std::endl
+          << "type: " << bs.beamType();
+      return fakeBS_;
+    }
+    auto lumitime = std::chrono::seconds(lumi.beginTime().unixTime());
+    auto bstime = std::chrono::microseconds(bs.creationTime());
+    auto threshold = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::hours(timeThreshold_)).count();
+    if ((lumitime - bstime).count() > threshold) {
+      edm::LogWarning("BeamSpotOnlineProducer")
+          << "The beam spot record is too old. (record: " << recordTypeName << ")" << std::endl
+          << "record creation time: " << std::chrono::duration_cast<std::chrono::seconds>(bstime).count()
+          << "lumi block time: " << std::chrono::duration_cast<std::chrono::seconds>(lumitime).count();
+      return fakeBS_;
+    }
+    return bs;
+  } else {
+    edm::LogWarning("BeamSpotOnlineProducer") << "Invalid online beam spot handle for the record: " << recordTypeName;
+    return fakeBS_;
+  }
+}
+
+const BeamSpotOnlineObjects& BeamSpotOnlineProducer::chooseBS(const BeamSpotOnlineObjects& bs1,
+                                                              const BeamSpotOnlineObjects& bs2) {
+  if (bs1.beamType() == reco::BeamSpot::Tracker && bs2.beamType() == reco::BeamSpot::Tracker) {
+    return bs1.sigmaZ() > bs2.sigmaZ() ? bs1 : bs2;
+  } else if (bs1.beamType() == reco::BeamSpot::Tracker) {
+    return bs1;
+  } else if (bs2.beamType() == reco::BeamSpot::Tracker) {
+    return bs2;
+  } else {
+    return fakeBS_;
+  }
+}
+
+void BeamSpotOnlineProducer::createBeamSpotFromRecord(const BeamSpotObjects& spotDB) {
   double f = changeFrame_ ? -1.0 : 1.0;
   reco::BeamSpot::Point apoint(f * spotDB.x(), f * spotDB.y(), f * spotDB.z());
 
@@ -167,7 +249,7 @@ void BeamSpotOnlineProducer::createBeamSpotFromTransient(const BeamSpotObjects& 
   result.setType(reco::BeamSpot::Tracker);
 }
 
-bool BeamSpotOnlineProducer::processScalers(const edm::Event& iEvent, reco::BeamSpot& result, bool shoutMODE) {
+bool BeamSpotOnlineProducer::processScalers(const edm::Event& iEvent, bool shoutMODE) {
   edm::Handle<BeamSpotOnlineCollection> handleScaler;
   iEvent.getByToken(scalerToken_, handleScaler);
 
@@ -177,7 +259,7 @@ bool BeamSpotOnlineProducer::processScalers(const edm::Event& iEvent, reco::Beam
 
   // Extract data from scaler
   BeamSpotOnline spotOnline = *(handleScaler->begin());
-  createBeamSpotFromScaler(spotOnline, result);
+  createBeamSpotFromScaler(spotOnline);
 
   // Validate the scaler data
   if (isInvalidScaler(spotOnline, shoutMODE)) {
@@ -186,7 +268,7 @@ bool BeamSpotOnlineProducer::processScalers(const edm::Event& iEvent, reco::Beam
   return false;  // No fallback needed
 }
 
-void BeamSpotOnlineProducer::createBeamSpotFromScaler(const BeamSpotOnline& spotOnline, reco::BeamSpot& result) const {
+void BeamSpotOnlineProducer::createBeamSpotFromScaler(const BeamSpotOnline& spotOnline) {
   double f = changeFrame_ ? -1.0 : 1.0;
   reco::BeamSpot::Point apoint(f * spotOnline.x(), spotOnline.y(), f * spotOnline.z());
 
@@ -227,9 +309,7 @@ bool BeamSpotOnlineProducer::isInvalidScaler(const BeamSpotOnline& spotOnline, b
   return false;
 }
 
-void BeamSpotOnlineProducer::createBeamSpotFromDB(const edm::EventSetup& iSetup,
-                                                  reco::BeamSpot& result,
-                                                  bool shoutMODE) const {
+void BeamSpotOnlineProducer::createBeamSpotFromDB(const edm::EventSetup& iSetup, bool shoutMODE) {
   edm::ESHandle<BeamSpotObjects> beamhandle = iSetup.getHandle(beamToken_);
   const BeamSpotObjects* spotDB = beamhandle.product();
 

--- a/RecoVertex/BeamSpotProducer/python/BeamSpotOnline_cfi.py
+++ b/RecoVertex/BeamSpotProducer/python/BeamSpotOnline_cfi.py
@@ -7,4 +7,4 @@ onlineBeamSpotProducer = _mod.beamSpotOnlineProducer.clone(
 )
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
-run3_common.toModify(onlineBeamSpotProducer, useTransientRecord = True)
+run3_common.toModify(onlineBeamSpotProducer, useBSOnlineRecords = True, timeThreshold = 48, sigmaZThreshold = 2, sigmaXYThreshold = 4)

--- a/RecoVertex/BeamSpotProducer/python/BeamSpot_cfi.py
+++ b/RecoVertex/BeamSpotProducer/python/BeamSpot_cfi.py
@@ -4,14 +4,6 @@ import RecoVertex.BeamSpotProducer.Modifiers as mods
 
 offlineBeamSpot = cms.EDProducer("BeamSpotProducer")
 
-def _loadOnlineBeamSpotESProducer(process):
-    import RecoVertex.BeamSpotProducer.onlineBeamSpotESProducer_cfi as _mod
-    process.BeamSpotESProducer = _mod.onlineBeamSpotESProducer.clone(
-        timeThreshold = 999999 # for express allow >48h old payloads for replays. DO NOT CHANGE
-    )
-
 import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
 _onlineBeamSpotProducer = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()
 mods.offlineToOnlineBeamSpotSwap.toReplaceWith(offlineBeamSpot, _onlineBeamSpotProducer)
-
-applyOnlineBSESProducer = mods.offlineToOnlineBeamSpotSwap.makeProcessModifier(_loadOnlineBeamSpotESProducer)


### PR DESCRIPTION
#### PR description:
backport of https://github.com/cms-sw/cmssw/pull/47378/ 
This backport is a cherry-pick.

#### PR validation:

The PR has been validated in the 15_0_X cycle with the standard commands:
```
scram b distclean 
git cms-checkdeps -a -A
scram b -j 8
scram b runtests use-ibeos
```
```
runTheMatrix.py -l limited -i all --ibeos
```
```
addOnTests.py
```
with no failures.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

backport of https://github.com/cms-sw/cmssw/pull/47378/ to 15_0_X
