### PR TITLE
2025 Scenario

### DIFF
--- a/Configuration/DataProcessing/python/Impl/hltScoutingEra_Run3_2025.py
+++ b/Configuration/DataProcessing/python/Impl/hltScoutingEra_Run3_2025.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""
+_hltScoutingEra_Run3_2025_
+
+Scenario supporting proton collisions with input HLT scouting data for 2025
+
+"""
+
+import os
+import sys
+
+from Configuration.Eras.Era_Run3_2025_cff import Run3_2025
+from Configuration.DataProcessing.Impl.hltScouting import hltScouting
+
+class hltScoutingEra_Run3_2025(hltScouting):
+    def __init__(self):
+        hltScouting.__init__(self)
+        self.recoSeq = ''
+        self.cbSc = 'pp'
+        self.eras = Run3_2025
+        self.promptCustoms += ['Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_2025']
+    """
+    _hltScoutingEra_Run3_2025_
+    Implement configuration building for data processing for proton
+    collision data taking with input HLT scouting data for Era_Run3_2025
+    """

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run3_2025.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run3_2025.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""
+_ppEra_Run3_2025_
+Scenario supporting proton collisions for 2025
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Era_Run3_2025_cff import Run3_2025
+
+from Configuration.DataProcessing.Impl.pp import pp
+
+class ppEra_Run3_2025(pp):
+    def __init__(self):
+        pp.__init__(self)
+        self.recoSeq=''
+        self.cbSc='pp'
+        self.eras=Run3_2025
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_2025' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_2025' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_2025' ]
+    """
+    _ppEra_Run3_2025_
+    Implement configuration building for data processing for proton
+    collision data taking for Run3_2025
+    """

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run3_2025_OXY.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run3_2025_OXY.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""
+_ppEra_Run3_2025_OXY_
+Scenario supporting OXY collisions for 2025
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Era_Run3_2025_OXY_cff import Run3_2025_OXY
+
+from Configuration.DataProcessing.Impl.pp import pp
+
+class ppEra_Run3_2025_OXY(pp):
+    def __init__(self):
+        pp.__init__(self)
+        self.recoSeq=''
+        self.cbSc='pp'
+        self.isRepacked=True
+        self.eras=Run3_2025_OXY
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_2025_OXY' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_2025_OXY' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_2025_OXY' ]
+    """
+    _ppEra_Run3_2025_OXY_
+    Implement configuration building for data processing for proton
+    collision data taking for Run3_2025
+    """

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run3_2025_UPC.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run3_2025_UPC.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""
+_ppEra_Run3_2025_UPC_
+Scenario supporting UPC collisions for 2025
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Era_Run3_2025_UPC_cff import Run3_2025_UPC
+
+from Configuration.DataProcessing.Impl.pp import pp
+
+class ppEra_Run3_2025_UPC(pp):
+    def __init__(self):
+        pp.__init__(self)
+        self.recoSeq=''
+        self.cbSc='pp'
+        self.isRepacked=True
+        self.eras=Run3_2025_UPC
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_2025_UPC' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_2025_UPC' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_2025_UPC' ]
+    """
+    _ppEra_Run3_2025_UPC_
+    Implement configuration building for data processing for proton
+    collision data taking for Run3_2025
+    """

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run3_pp_on_PbPb_2025.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run3_pp_on_PbPb_2025.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""
+_ppEra_Run3_pp_on_PbPb_2025_
+
+Scenario supporting heavy ions collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Era_Run3_pp_on_PbPb_2025_cff import Run3_pp_on_PbPb_2025
+
+from Configuration.DataProcessing.Impl.pp import pp
+
+class ppEra_Run3_pp_on_PbPb_2025(pp):
+    def __init__(self):
+        pp.__init__(self)
+        self.recoSeq=''
+        self.cbSc='pp'
+        self.isRepacked=True
+        self.eras=Run3_pp_on_PbPb_2025
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb_2025' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb_2025' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb_2025' ]
+    """
+    _ppEra_Run3_pp_on_PbPb_2025_
+
+    Implement configuration building for data processing for pp-like processing of HI
+    collision data taking for Run3
+
+    """

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2025.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2025.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""
+_ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2025_
+
+Scenario supporting heavy ions collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+from Configuration.Eras.Era_Run3_pp_on_PbPb_approxSiStripClusters_2025_cff import Run3_pp_on_PbPb_approxSiStripClusters_2025
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.DataProcessing.Impl.pp import pp
+
+class ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2025(pp):
+    def __init__(self):
+        pp.__init__(self)
+        self.recoSeq=''
+        self.cbSc='pp'
+        self.isRepacked=True
+        self.eras=Run3_pp_on_PbPb_approxSiStripClusters_2025
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb_approxSiStripClusters_2025' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb_approxSiStripClusters_2025' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb_approxSiStripClusters_2025' ]
+
+    """
+    _ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2025_
+
+    Implement configuration building for data processing for pp-like processing of HI
+    collision data taking for Run3 with approxSiStripClusters (rawprime format)
+
+    """

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -91,7 +91,12 @@ def customisePostEra_Run3_2023(process):
 
 def customisePostEra_Run3_2024(process):
     #start with a repeat of 2023
-    customisePostEra_Run3(process)
+    customisePostEra_Run3_2023(process)
+    return process
+
+def customisePostEra_Run3_2025(process):
+    #start with a repeat of 2024
+    customisePostEra_Run3_2024(process)
     return process
 
 def customisePostEra_Run3_express_trackingOnly(process):
@@ -134,6 +139,22 @@ def customisePostEra_Run3_2024_UPC(process):
 
 def customisePostEra_Run3_2024_ppRef(process):
     customisePostEra_Run3_2024(process)
+    return process
+
+def customisePostEra_Run3_pp_on_PbPb_2025(process):
+    customisePostEra_Run3_2025(process)
+    return process
+
+def customisePostEra_Run3_pp_on_PbPb_approxSiStripClusters_2025(process):
+    customisePostEra_Run3_pp_on_PbPb_2025(process)
+    return process
+
+def customisePostEra_Run3_2025_UPC(process):
+    customisePostEra_Run3_2025(process)
+    return process
+
+def customisePostEra_Run3_2025_OXY(process):
+    customisePostEra_Run3_2025(process)
     return process
 
 ##############################################################################

--- a/Configuration/Eras/python/Era_Run3_pp_on_PbPb_2025_cff.py
+++ b/Configuration/Eras/python/Era_Run3_pp_on_PbPb_2025_cff.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run3_2025_cff import Run3_2025
+from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_2024_cff import pp_on_PbPb_run3_2024
+
+Run3_pp_on_PbPb_2025 = cms.ModifierChain(Run3_2025, pp_on_AA, pp_on_PbPb_run3, pp_on_PbPb_run3_2024)

--- a/Configuration/Eras/python/Era_Run3_pp_on_PbPb_approxSiStripClusters_2025_cff.py
+++ b/Configuration/Eras/python/Era_Run3_pp_on_PbPb_approxSiStripClusters_2025_cff.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run3_2025_cff import Run3_2025
+from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA 
+from Configuration.ProcessModifiers.approxSiStripClusters_cff import approxSiStripClusters
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+
+Run3_pp_on_PbPb_approxSiStripClusters_2025 = cms.ModifierChain(Run3_2025, pp_on_AA, approxSiStripClusters, pp_on_PbPb_run3)   

--- a/Configuration/Eras/python/Modifier_pp_on_PbPb_run3_2025_cff.py
+++ b/Configuration/Eras/python/Modifier_pp_on_PbPb_run3_2025_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+pp_on_PbPb_run3_2025 =  cms.Modifier()
+

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -44,6 +44,8 @@ class Eras (object):
                  'Run3_pp_on_PbPb_approxSiStripClusters_2023',
                  'Run3_pp_on_PbPb_2024',
                  'Run3_pp_on_PbPb_approxSiStripClusters_2024',
+                 'Run3_pp_on_PbPb_2025',
+                 'Run3_pp_on_PbPb_approxSiStripClusters_2025',
                  'Run3_dd4hep',
                  'Run3_DDD',
                  'Run3_FastSim',


### PR DESCRIPTION
#### PR description:
Add 2025 scenario.
I understand that we don't need cosmicsEra_Run3_2025 because we still turn off GE2/1 demonstrator reconstruction,
[https://github.com/cms-sw/cmssw/blob/master/RecoLocalMuon/GEMRecHit/python/gemRecHits_cfi.py](https://github.com/cms-sw/cmssw/blob/master/RecoLocalMuon/GEMRecHit/python/gemRecHits_cfi.py)
`run3_GEM_2025.toModify(gemRecHits, ge21Off=True, applyMasking=True)`

#### PR validation:
none

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
Need backport to 15_0 for data taking
