### PR TITLE
[UBSAN] added deps on TrackerRecHit2D for BaseTrackerRecHit

### DIFF
--- a/SimDataFormats/TrackingAnalysis/BuildFile.xml
+++ b/SimDataFormats/TrackingAnalysis/BuildFile.xml
@@ -2,6 +2,7 @@
 <use name="DataFormats/Math"/>
 <use name="DataFormats/TrackReco"/>
 <use name="DataFormats/HepMCCandidate"/>
+<use name="DataFormats/TrackerRecHit2D"/>
 <use name="SimDataFormats/EncodedEventId"/>
 <use name="SimDataFormats/GeneratorProducts"/>
 <use name="SimDataFormats/Track"/>


### PR DESCRIPTION
Fixes UBSAN link error [a] which was introduced after https://github.com/cms-sw/cmssw/pull/47441 intergation

[a] https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_15_1_UBSAN_X_2025-03-07-2300/SimDataFormats/TrackingAnalysis
```
 ld.bfd: tmp/el8_amd64_gcc12/src/SimDataFormats/TrackingAnalysis/src/SimDataFormatsTrackingAnalysis/SimDoublets.cc.o:(.data.rel+0x758): undefined reference to `typeinfo for BaseTrackerRecHit'
```