### PR TITLE
Update OnlineBeamMonitor for DIP publication

### DIFF
--- a/DQM/Integration/python/clients/beamspotdip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamspotdip_dqm_sourceclient-live_cfg.py
@@ -47,10 +47,9 @@ process.GlobalTag.toGet = cms.VPSet(
 process.load("DQM.BeamMonitor.BeamSpotDipServer_cff")
 
 process.beamSpotDipServer.verbose = cms.untracked.bool(True)
-# Temporary roll-back to using default input txt file
-#process.beamSpotDipServer.sourceFile  = cms.untracked.string(
-#    "/nfshome0/dqmpro/BeamMonitorDQM/BeamFitResultsForDIP.txt"
-#)
+process.beamSpotDipServer.sourceFile  = cms.untracked.string(
+    "/nfshome0/dqmpro/BeamMonitorDQM/BeamFitResultsForDIP.txt"
+)
 
 # process customizations included here
 from DQM.Integration.config.online_customizations_cfi import *


### PR DESCRIPTION
#### PR description:
In #46613 we tried updating the source of the `beamspotdip` client (which publishes the online BeamSpot values to DIP and OMS) to read the BeamSpot result from `BeamFitResultsForDIP.txt`, which is produced by the `onlinebeammonitor` and is the result of the arbitration between the beamspot values produced by the `beam` and `beamhlt` clients.
We then had to revert it (done in  #46737) because the `BeamFitResultsForDIP.txt` file was not in the correct format for the DIP client to correctly parse it (it was missing few records).

In this PR I'm finally updating the `OnlineBeamMonitor` plugin to write the `BeamFitResultsForDIP.txt` file in the corect format and setting it to be the file that is read by `beamspotdip_dqm_sourceclient-live_cfg.py`.

#### PR validation:
Ran `scram b runtests` and verified that the output of `onlinebeammonitor_dqm_sourceclient-live_cfg` is in the expected format, i.e.:
```
Runnumber 381594
BeginTimeOfFit 2024.06.06 03:43:05 GMT 0
EndTimeOfFit 2024.06.06 03:44:58 GMT 0
LumiRange 988 - 992
Type 2
X0 0.0957226
Y0 -0.190293
Z0 -5.49297
sigmaZ0 4.98153
dxdz 8.7899e-05
dydz 9.82145e-05
BeamWidthX 0.00115646
BeamWidthY 0.00107762
Cov(0,j) 1.74165e-09 8.82035e-12 0 0 0 0 0 
Cov(1,j) 8.82035e-12 1.664e-09 0 0 0 0 0 
Cov(2,j) 0 0 0.00553555 0 0 0 0 
Cov(3,j) 0 0 0 0.00276762 0 0 0 
Cov(4,j) 0 0 0 0 4.46792e-11 -1.01635e-13 0 
Cov(5,j) 0 0 0 0 -1.01635e-13 4.37167e-11 0 
Cov(6,j) 0 0 0 0 0 0 1.12828e-09
EmittanceX 0
EmittanceY 0
BetaStar 0
events 3115
meanPV 3.1573
meanErrPV 0.03701
rmsPV 2.06561
rmsErrPV 0.02617
maxPV 11
nPV 4483
```

#### Backport:
Not a backport, but a 15_0_X backport will be opened to be used for 2025 data-taking.

-----
FYI @gennai @lguzzi @sikler @mmusich 
