### PR TITLE
Fix typo in g4SimHits cfg

### DIFF
--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -795,6 +795,6 @@ phase2_hgcalV18.toModify(g4SimHits,
 ## Fix for long-lived slepton simulation
 ##
 from Configuration.ProcessModifiers.fixLongLivedSleptonSim_cff import fixLongLivedSleptonSim
-dd4hep.toModify( g4SimHits,
-                 Generator = dict(IsSlepton = True)
+fixLongLivedSleptonSim.toModify( g4SimHits,
+                                 Generator = dict(IsSlepton = True)
 )


### PR DESCRIPTION
#### PR description:

This PR is related to https://github.com/cms-sw/cmssw/pull/47197 and https://github.com/cms-sw/cmssw/pull/47165. It fixes a typo in the g4SimHit configuration related to the process modifier for fixing the long lived slepton simulation.

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

Code compilation has been checked for this changes.

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR will be backported for CMSSW_15_0_X. For 12_4_X and 10_6_X the typo was already identified and fixed (https://github.com/cms-sw/cmssw/pull/47484 and https://github.com/cms-sw/cmssw/pull/47487)

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->
