### PR TITLE
Add Process name, reduced configuration ID, and ParameterSet ID to the JobReport

### DIFF
--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -534,6 +534,15 @@ namespace edm {
       processConfiguration_ = items.processConfiguration();
       processContext_.setProcessConfiguration(processConfiguration_.get());
 
+      {
+        edm::Service<edm::JobReport> jr;
+        if (jr.isAvailable()) {
+          ProcessConfiguration reduced = *processConfiguration_;
+          reduced.reduce();
+          jr->reportProcess(reduced.processName(), reduced.id(), reduced.parameterSetID());
+        }
+      }
+
       FDEBUG(2) << parameterSet << std::endl;
 
       principalCache_.setNumberOfConcurrentPrincipals(preallocations_);

--- a/FWCore/MessageLogger/interface/JobReport.h
+++ b/FWCore/MessageLogger/interface/JobReport.h
@@ -82,6 +82,8 @@ Changes Log 1: 2009/01/14 10:29:00, Natalia Garcia Nebot
 */
 
 #include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
+#include "DataFormats/Provenance/interface/ParameterSetID.h"
+#include "DataFormats/Provenance/interface/ProcessConfigurationID.h"
 #include "FWCore/Utilities/interface/InputType.h"
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
 
@@ -177,8 +179,10 @@ namespace edm {
     };
 
     struct JobReportImpl {
-      JobReportImpl& operator=(JobReportImpl const&) = delete;
       JobReportImpl(JobReportImpl const&) = delete;
+      JobReportImpl& operator=(JobReportImpl const&) = delete;
+      JobReportImpl(JobReportImpl&&) = delete;
+      JobReportImpl& operator=(JobReportImpl&&) = delete;
 
       InputFile& getInputFileForToken(InputType inputType, Token t);
       OutputFile& getOutputFileForToken(Token t);
@@ -268,6 +272,11 @@ namespace edm {
     JobReport(JobReport const&) = delete;
 
     ~JobReport();
+
+    // Insert information about the process
+    void reportProcess(std::string_view processName,
+                       ProcessConfigurationID const& reducedProcessID,
+                       ParameterSetID const& psetID);
 
     /// Report that an input file has been opened.
     /// The returned Token should be used for later identification

--- a/FWCore/MessageLogger/src/JobReport.cc
+++ b/FWCore/MessageLogger/src/JobReport.cc
@@ -351,6 +351,19 @@ namespace edm {
     temporarilyCloseXML();
   }
 
+  void JobReport::reportProcess(std::string_view processName,
+                                ProcessConfigurationID const& reducedProcessID,
+                                ParameterSetID const& psetID) {
+    if (impl_->ost_) {
+      *(impl_->ost_) << "\n<Process>\n";
+      *(impl_->ost_) << "  <Name>" << processName << "</Name>\n";
+      *(impl_->ost_) << "  <ReducedConfigurationID>" << reducedProcessID << "</ReducedConfigurationID>\n";
+      *(impl_->ost_) << "  <ParameterSetID>" << psetID << "</ParameterSetID>\n";
+      *(impl_->ost_) << "</Process>\n";
+    }
+    temporarilyCloseXML();
+  }
+
   JobReport::Token JobReport::inputFileOpened(std::string const& physicalFileName,
                                               std::string const& logicalFileName,
                                               std::string const& catalog,

--- a/FWCore/MessageService/test/BuildFile.xml
+++ b/FWCore/MessageService/test/BuildFile.xml
@@ -200,6 +200,13 @@
     <use name="FWCore/Framework"/>
   </library>
 
+  <library file="PrintProcessInformation.cc" name="MLPrintProcessInformation">
+    <flags EDM_PLUGIN="1"/>
+    <use name="DataFormats/Provenance"/>
+    <use name="FWCore/Framework"/>
+    <use name="FWCore/MessageLogger"/>
+    <use name="FWCore/ServiceRegistry"/>
+  </library>
 </environment>
 <bin file="standAloneTest.cpp" name="standAloneWithMessageLogger">
   <use name="FWCore/MessageLogger"/>
@@ -234,6 +241,7 @@
 
 <test name="unitTestsGroup_6" command="${value}.sh" foreach="u23,u27,u30,u31,u33"/>
 
+<test name="TestFWCoreMessageServiceJobReport" command="testJobReport.sh"/>
 <bin name="makeJobReport" file="makeJobReport.cpp">
   <use name="boost_program_options"/>
   <use name="FWCore/Framework"/>

--- a/FWCore/MessageService/test/PrintProcessInformation.cc
+++ b/FWCore/MessageService/test/PrintProcessInformation.cc
@@ -1,0 +1,29 @@
+#include "DataFormats/Provenance/interface/ProcessConfiguration.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
+#include "FWCore/ServiceRegistry/interface/ProcessContext.h"
+#include "FWCore/ServiceRegistry/interface/StreamContext.h"
+
+namespace edmtest {
+  class PrintProcessInformation : public edm::global::EDAnalyzer<> {
+  public:
+    explicit PrintProcessInformation(edm::ParameterSet const&) {}
+
+    void analyze(edm::StreamID, edm::Event const& e, edm::EventSetup const&) const final {
+      auto const* processConfiguration =
+          e.moduleCallingContext()->getStreamContext()->processContext()->processConfiguration();
+      assert(processConfiguration);
+      auto reduced = *processConfiguration;
+      reduced.reduce();
+      edm::LogSystem("PrintProcessInformation")
+          << "Name:" << processConfiguration->processName() << "\nReducedConfigurationID:" << reduced.id()
+          << "\nParameterSetID:" << processConfiguration->parameterSetID();
+    }
+  };
+}  // namespace edmtest
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(edmtest::PrintProcessInformation);

--- a/FWCore/MessageService/test/compareJobReportToOutput.py
+++ b/FWCore/MessageService/test/compareJobReportToOutput.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+import xml.etree.ElementTree as ET
+
+quantities = ["Name", "ReducedConfigurationID", "ParameterSetID"]
+
+def parsexml(fname):
+    root = ET.parse(fname)
+    process = root.find("Process")
+    return {q: process.find(q).text for q in quantities}
+
+def parselog(fname):
+    ret = {}
+    with open(fname) as f:
+        for line in f:
+            s = line.rstrip().split(":")
+            if len(s) == 2:
+                ret[s[0]] = s[1]
+    return ret
+
+def main(jobreport, log):
+    xmldata = parsexml(jobreport)
+    logdata = parselog(log)
+
+    ret = 0
+    for q in quantities:
+        if xmldata[q] != logdata[q]:
+            print(f"Quantity {q}: job report '{xmldata[q]}' != log '{logdata[q]}'")
+            ret = 1
+    return ret
+    
+if __name__ == "__main__":
+    import sys
+    sys.exit(main(sys.argv[1], sys.argv[2]))

--- a/FWCore/MessageService/test/filter-timestamps.sed
+++ b/FWCore/MessageService/test/filter-timestamps.sed
@@ -1,1 +1,3 @@
 s/ [0-9]?[0-9]-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-2[0-9][0-9][0-9] [0-9]?[0-9]:[0-9][0-9]:[0-9][0-9](\.[0-9][0-9][0-9])? [A-Z]?[A-Z][A-Z][A-Z]( |\t|-|$)/ {Timestamp} /
+s|<ReducedConfigurationID>.*?</ReducedConfigurationID>|<ReducedConfigurationID>{Value}</ReducedConfigurationID>|
+s|<ParameterSetID>.*?</ParameterSetID>|<ParameterSetID>{Value}</ParameterSetID>|

--- a/FWCore/MessageService/test/jobreport_cfg.py
+++ b/FWCore/MessageService/test/jobreport_cfg.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+process.maxEvents.input = 1
+process.source = cms.Source("EmptySource")
+process.a = cms.EDAnalyzer("edmtest::PrintProcessInformation")
+process.p = cms.Path(process.a)

--- a/FWCore/MessageService/test/testJobReport.sh
+++ b/FWCore/MessageService/test/testJobReport.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function die { echo $1: status $2 ;  exit $2; }
+
+cmsRun -j fwjr.xml ${SCRAM_TEST_PATH}/jobreport_cfg.py > log.txt 2>&1 || die "cmsRun jobreport_cfg.py failed" $?
+${SCRAM_TEST_PATH}/compareJobReportToOutput.py fwjr.xml log.txt || die "Job report comparison to log failed" $?
+
+               

--- a/FWCore/MessageService/test/u1.sh
+++ b/FWCore/MessageService/test/u1.sh
@@ -8,6 +8,7 @@ status=0
 rm -f u1_errors.log u1_warnings.log u1_infos.log u1_debugs.log u1_default.log u1_job_report.mxml 
 
 cmsRun -j u1_job_report.mxml ${SCRAM_TEST_PATH}/u1_cfg.py || exit $?
+edmFjrDump u1_job_report.mxml
 
 for file in u1_errors.log u1_warnings.log u1_infos.log u1_debugs.log u1_default.log u1_job_report.mxml
 do

--- a/FWCore/MessageService/test/unit_test_outputs/FrameworkJobReport.xml
+++ b/FWCore/MessageService/test/unit_test_outputs/FrameworkJobReport.xml
@@ -1,3 +1,9 @@
 <FrameworkJobReport>
+
+<Process>
+  <Name>TEST</Name>
+  <ReducedConfigurationID>{Value}</ReducedConfigurationID>
+  <ParameterSetID>{Value}</ParameterSetID>
+</Process>
 <!--                                                            -->
 </FrameworkJobReport>

--- a/FWCore/MessageService/test/unit_test_outputs/job_report.xml
+++ b/FWCore/MessageService/test/unit_test_outputs/job_report.xml
@@ -1,3 +1,9 @@
 <FrameworkJobReport>
+
+<Process>
+  <Name>TEST</Name>
+  <ReducedConfigurationID>{Value}</ReducedConfigurationID>
+  <ParameterSetID>{Value}</ParameterSetID>
+</Process>
 <!--                                                            -->
 </FrameworkJobReport>

--- a/FWCore/MessageService/test/unit_test_outputs/u10_job_report.xml
+++ b/FWCore/MessageService/test/unit_test_outputs/u10_job_report.xml
@@ -1,3 +1,9 @@
 <FrameworkJobReport>
+
+<Process>
+  <Name>TEST</Name>
+  <ReducedConfigurationID>{Value}</ReducedConfigurationID>
+  <ParameterSetID>{Value}</ParameterSetID>
+</Process>
 <!--                                                            -->
 </FrameworkJobReport>

--- a/FWCore/MessageService/test/unit_test_outputs/u14_job_report.mxml
+++ b/FWCore/MessageService/test/unit_test_outputs/u14_job_report.mxml
@@ -1,3 +1,9 @@
 <FrameworkJobReport>
+
+<Process>
+  <Name>TEST</Name>
+  <ReducedConfigurationID>{Value}</ReducedConfigurationID>
+  <ParameterSetID>{Value}</ParameterSetID>
+</Process>
 <!--                                                            -->
 </FrameworkJobReport>

--- a/FWCore/MessageService/test/unit_test_outputs/u16_job_report.mmxml
+++ b/FWCore/MessageService/test/unit_test_outputs/u16_job_report.mmxml
@@ -1,3 +1,9 @@
 <FrameworkJobReport>
+
+<Process>
+  <Name>TEST</Name>
+  <ReducedConfigurationID>{Value}</ReducedConfigurationID>
+  <ParameterSetID>{Value}</ParameterSetID>
+</Process>
 <!--                                                            -->
 </FrameworkJobReport>

--- a/FWCore/MessageService/test/unit_test_outputs/u1_job_report.mxml
+++ b/FWCore/MessageService/test/unit_test_outputs/u1_job_report.mxml
@@ -1,3 +1,9 @@
 <FrameworkJobReport>
+
+<Process>
+  <Name>TEST</Name>
+  <ReducedConfigurationID>{Value}</ReducedConfigurationID>
+  <ParameterSetID>{Value}</ParameterSetID>
+</Process>
 <!--                                                            -->
 </FrameworkJobReport>

--- a/FWCore/MessageService/test/unit_test_outputs/u1d_job_report.mxml
+++ b/FWCore/MessageService/test/unit_test_outputs/u1d_job_report.mxml
@@ -1,3 +1,9 @@
 <FrameworkJobReport>
+
+<Process>
+  <Name>TEST</Name>
+  <ReducedConfigurationID>{Value}</ReducedConfigurationID>
+  <ParameterSetID>{Value}</ParameterSetID>
+</Process>
 <!--                                                            -->
 </FrameworkJobReport>

--- a/FWCore/MessageService/test/unit_test_outputs/u27FJR.xml
+++ b/FWCore/MessageService/test/unit_test_outputs/u27FJR.xml
@@ -1,4 +1,10 @@
 <FrameworkJobReport>
+
+<Process>
+  <Name>TEST</Name>
+  <ReducedConfigurationID>{Value}</ReducedConfigurationID>
+  <ParameterSetID>{Value}</ParameterSetID>
+</Process>
 <MessageSummary>
   <Category_f_FwkReport  Value="1" />
   <Category_i_cat_A  Value="6" />

--- a/FWCore/MessageService/test/unit_test_outputs/u7_job_report.mxml
+++ b/FWCore/MessageService/test/unit_test_outputs/u7_job_report.mxml
@@ -1,3 +1,9 @@
 <FrameworkJobReport>
+
+<Process>
+  <Name>TEST</Name>
+  <ReducedConfigurationID>{Value}</ReducedConfigurationID>
+  <ParameterSetID>{Value}</ParameterSetID>
+</Process>
 <!--                                                            -->
 </FrameworkJobReport>

--- a/IOPool/Common/test/TestEdmFastMerge.sh
+++ b/IOPool/Common/test/TestEdmFastMerge.sh
@@ -40,33 +40,33 @@ cmsRun -j ${LOCAL_TMP_DIR}/TestFastMergeFJR_ancestor2.xml ${LOCAL_TEST_DIR}/Fast
 
 cmsRun -j ${LOCAL_TMP_DIR}/TestFastMergeFJRx.xml ${LOCAL_TEST_DIR}/FastMergeTest_x_cfg.py || die 'Failure using FastMergeTest_x_cfg.py' $?
 #need to filter items in job report which always change
-egrep -v "<GUID>|<PFN>|^$" $LOCAL_TEST_DIR/proper_fjrx_output > $LOCAL_TMP_DIR/proper_fjrx_output_filtered
-egrep -v "<GUID>|<PFN>|^$" $LOCAL_TMP_DIR/TestFastMergeFJRx.xml  > $LOCAL_TMP_DIR/TestFastMergeFJRx_filtered.xml
+egrep -v "<GUID>|<PFN>|<ReducedConfigurationID>|<ParameterSetID>|^$" $LOCAL_TEST_DIR/proper_fjrx_output > $LOCAL_TMP_DIR/proper_fjrx_output_filtered
+egrep -v "<GUID>|<PFN>|<ReducedConfigurationID>|<ParameterSetID>|^$" $LOCAL_TMP_DIR/TestFastMergeFJRx.xml  > $LOCAL_TMP_DIR/TestFastMergeFJRx_filtered.xml
 diff $LOCAL_TMP_DIR/proper_fjrx_output_filtered $LOCAL_TMP_DIR/TestFastMergeFJRx_filtered.xml || die 'output framework job report is wrong for proper_fjrx_output_filtered' $?
 
 #cmsRun -j ${LOCAL_TMP_DIR}/TestFastMergeFJRx_second.xml ${LOCAL_TEST_DIR}/FastMergeTest_x_second_cfg.py || die 'Failure using FastMergeTest_x_second_cfg.py' $?
 ##need to filter items in job report which always change
-#egrep -v "<GUID>|<PFN>|^$" $LOCAL_TEST_DIR/proper_fjrx_second_output > $LOCAL_TMP_DIR/proper_fjrx_second_output_filtered
-#egrep -v "<GUID>|<PFN>|^$" $LOCAL_TMP_DIR/TestFastMergeFJRx_second.xml  > $LOCAL_TMP_DIR/TestFastMergeFJRx_second_filtered.xml
+#egrep -v "<GUID>|<PFN>|<ReducedConfigurationID>|<ParameterSetID>|^$" $LOCAL_TEST_DIR/proper_fjrx_second_output > $LOCAL_TMP_DIR/proper_fjrx_second_output_filtered
+#egrep -v "<GUID>|<PFN>|<ReducedConfigurationID>|<ParameterSetID>|^$" $LOCAL_TMP_DIR/TestFastMergeFJRx_second.xml  > $LOCAL_TMP_DIR/TestFastMergeFJRx_second_filtered.xml
 #diff $LOCAL_TMP_DIR/proper_fjrx_second_output_filtered $LOCAL_TMP_DIR/TestFastMergeFJRx_second_filtered.xml || die 'output framework job report is wrong for proper_fjrx_second_output_filtered' $?
 
 
 cmsRun -j ${LOCAL_TMP_DIR}/TestFastMergeFJR.xml ${LOCAL_TEST_DIR}/FastMergeTest_cfg.py || die 'Failure using FastMergeTest_cfg.py' $?
 #need to filter items in job report which always change
-egrep -v "<GUID>|<PFN>|^$" $LOCAL_TEST_DIR/proper_fjr_output > $LOCAL_TMP_DIR/proper_fjr_output_filtered
-egrep -v "<GUID>|<PFN>|^$" $LOCAL_TMP_DIR/TestFastMergeFJR.xml  > $LOCAL_TMP_DIR/TestFastMergeFJR_filtered.xml
+egrep -v "<GUID>|<PFN>|<ReducedConfigurationID>|<ParameterSetID>|^$" $LOCAL_TEST_DIR/proper_fjr_output > $LOCAL_TMP_DIR/proper_fjr_output_filtered
+egrep -v "<GUID>|<PFN>|<ReducedConfigurationID>|<ParameterSetID>|^$" $LOCAL_TMP_DIR/TestFastMergeFJR.xml  > $LOCAL_TMP_DIR/TestFastMergeFJR_filtered.xml
 diff $LOCAL_TMP_DIR/proper_fjr_output_filtered $LOCAL_TMP_DIR/TestFastMergeFJR_filtered.xml || die 'output framework job report is wrong for proper_fjr_output_filtered' $?
 
 cmsRun -j ${LOCAL_TMP_DIR}/TestFastMergeRLFJR.xml ${LOCAL_TEST_DIR}/FastMergeTestRL_cfg.py || die 'Failure using FastMergeTestRL_cfg.py' $?
 #need to filter items in job report which always change
-egrep -v "<GUID>|<PFN>|^$" $LOCAL_TEST_DIR/proper_RLfjr_output > $LOCAL_TMP_DIR/proper_RLfjr_output_filtered
-egrep -v "<GUID>|<PFN>|^$" $LOCAL_TMP_DIR/TestFastMergeRLFJR.xml  > $LOCAL_TMP_DIR/TestFastMergeRLFJR_filtered.xml
+egrep -v "<GUID>|<PFN>|<ReducedConfigurationID>|<ParameterSetID>|^$" $LOCAL_TEST_DIR/proper_RLfjr_output > $LOCAL_TMP_DIR/proper_RLfjr_output_filtered
+egrep -v "<GUID>|<PFN>|<ReducedConfigurationID>|<ParameterSetID>|^$" $LOCAL_TMP_DIR/TestFastMergeRLFJR.xml  > $LOCAL_TMP_DIR/TestFastMergeRLFJR_filtered.xml
 diff $LOCAL_TMP_DIR/proper_RLfjr_output_filtered $LOCAL_TMP_DIR/TestFastMergeRLFJR_filtered.xml || die 'output run lumi framework job report is wrong for proper_RLfjr_output_filtered' $?
 
 cmsRun -j ${LOCAL_TMP_DIR}/TestFastMergeRFJR.xml ${LOCAL_TEST_DIR}/FastMergeTestR_cfg.py || die 'Failure using FastMergeTestR_cfg.py' $?
 #need to filter items in job report which always change
-egrep -v "<GUID>|<PFN>|^$" $LOCAL_TEST_DIR/proper_Rfjr_output > $LOCAL_TMP_DIR/proper_Rfjr_output_filtered
-egrep -v "<GUID>|<PFN>|^$" $LOCAL_TMP_DIR/TestFastMergeRFJR.xml  > $LOCAL_TMP_DIR/TestFastMergeRFJR_filtered.xml
+egrep -v "<GUID>|<PFN>|<ReducedConfigurationID>|<ParameterSetID>|^$" $LOCAL_TEST_DIR/proper_Rfjr_output > $LOCAL_TMP_DIR/proper_Rfjr_output_filtered
+egrep -v "<GUID>|<PFN>|<ReducedConfigurationID>|<ParameterSetID>|^$" $LOCAL_TMP_DIR/TestFastMergeRFJR.xml  > $LOCAL_TMP_DIR/TestFastMergeRFJR_filtered.xml
 diff $LOCAL_TMP_DIR/proper_Rfjr_output_filtered $LOCAL_TMP_DIR/TestFastMergeRFJR_filtered.xml || die 'output run framework job report is wrong for proper_Rfjr_output_filtered' $?
 
 cmsRun ${LOCAL_TEST_DIR}/ReadFastMergeTestOutput_cfg.py || die 'Failure using ReadFastMergeTestOutput_cfg.py' $?

--- a/IOPool/Common/test/proper_RLfjr_output
+++ b/IOPool/Common/test/proper_RLfjr_output
@@ -1,5 +1,9 @@
 <FrameworkJobReport>
 
+<Process>
+  <Name>TESTMERGE</Name>
+</Process>
+
 <InputFile>
 <State  Value="closed"/>
 <LFN></LFN>

--- a/IOPool/Common/test/proper_Rfjr_output
+++ b/IOPool/Common/test/proper_Rfjr_output
@@ -1,5 +1,9 @@
 <FrameworkJobReport>
 
+<Process>
+  <Name>TESTMERGE</Name>
+</Process>
+
 <InputFile>
 <State  Value="closed"/>
 <LFN></LFN>

--- a/IOPool/Common/test/proper_fjr_output
+++ b/IOPool/Common/test/proper_fjr_output
@@ -1,5 +1,9 @@
 <FrameworkJobReport>
 
+<Process>
+  <Name>TESTMERGE</Name>
+</Process>
+
 <InputFile>
 <State  Value="closed"/>
 <LFN></LFN>

--- a/IOPool/Common/test/proper_fjrx_output
+++ b/IOPool/Common/test/proper_fjrx_output
@@ -1,5 +1,9 @@
 <FrameworkJobReport>
 
+<Process>
+  <Name>TESTMERGE</Name>
+</Process>
+
 <InputFile>
 <State  Value="closed"/>
 <LFN></LFN>

--- a/IOPool/Common/test/proper_fjrx_second_output
+++ b/IOPool/Common/test/proper_fjrx_second_output
@@ -1,5 +1,9 @@
 <FrameworkJobReport>
 
+<Process>
+  <Name>TESTMERGE</Name>
+</Process>
+
 <InputFile>
 <State  Value="closed"/>
 <LFN></LFN>


### PR DESCRIPTION
#### PR description:

In the context of https://github.com/dmwm/CRABServer/issues/8953 this PR adds
```xml
<Process>
  <Name>TEST</Name>
  <ReducedConfigurationID> 783c5ab60bfe18ac97262801adef9de4 </ReducedConfigurationID>
  <ParameterSetID> 1f94f8e1ac0ae9d7dade1c99cc5862b3 </ParameterSetID>
</Process>
```
block to the framework job report. This information allows CRAB to stop relying on `edmProvDump`, after which we'll have more freedom to improve the `edmProvDump` output.

Resolves https://github.com/cms-sw/framework-team/issues/1273

#### PR validation:

Framework unit tests pass