### PR TITLE
[150X] Fix typo in g4SimHits cfg

### DIFF
--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -795,6 +795,6 @@ phase2_hgcalV18.toModify(g4SimHits,
 ## Fix for long-lived slepton simulation
 ##
 from Configuration.ProcessModifiers.fixLongLivedSleptonSim_cff import fixLongLivedSleptonSim
-dd4hep.toModify( g4SimHits,
-                 Generator = dict(IsSlepton = True)
+fixLongLivedSleptonSim.toModify( g4SimHits,
+                                 Generator = dict(IsSlepton = True)
 )


### PR DESCRIPTION
#### PR description:

This PR is a plain backport of https://github.com/cms-sw/cmssw/pull/47544. It fixes a typo in the g4SimHit configuration related to the process modifier for fixing the long lived slepton simulation (introduced in https://github.com/cms-sw/cmssw/pull/47197).

#### PR validation:

Code compilation has been checked for this changes.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is a backport of https://github.com/cms-sw/cmssw/pull/47544.
