### PR TITLE
add fillDescriptions to several Strip modules used at HLT

### DIFF
--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripBackPlaneCorrectionDepESProducer.cc
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripBackPlaneCorrectionDepESProducer.cc
@@ -119,7 +119,7 @@ void SiStripBackPlaneCorrectionDepESProducer::fillDescriptions(edm::Configuratio
     desc.add<edm::ParameterSetDescription>("BackPlaneCorrectionDeconvMode", deconv);
   }
 
-  descriptions.addDefault(desc);
+  descriptions.addWithDefaultLabel(desc);
 }
 
 DEFINE_FWK_EVENTSETUP_MODULE(SiStripBackPlaneCorrectionDepESProducer);

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripLorentzAngleDepESProducer.cc
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripLorentzAngleDepESProducer.cc
@@ -116,7 +116,7 @@ void SiStripLorentzAngleDepESProducer::fillDescriptions(edm::ConfigurationDescri
     desc.add<edm::ParameterSetDescription>("LorentzAngleDeconvMode", deconv);
   }
 
-  descriptions.addDefault(desc);
+  descriptions.addWithDefaultLabel(desc);
 }
 
 DEFINE_FWK_EVENTSETUP_MODULE(SiStripLorentzAngleDepESProducer);

--- a/CalibTracker/SiStripESProducers/python/SiStripBackPlaneCorrectionDepESProducer_cfi.py
+++ b/CalibTracker/SiStripESProducers/python/SiStripBackPlaneCorrectionDepESProducer_cfi.py
@@ -1,18 +1,5 @@
 # -*- coding: utf-8 -*-
 import FWCore.ParameterSet.Config as cms
 
-siStripBackPlaneCorrectionDepESProducer = cms.ESProducer("SiStripBackPlaneCorrectionDepESProducer",
-   
-     LatencyRecord =   cms.PSet(
-            record = cms.string('SiStripLatencyRcd'),
-            label = cms.untracked.string('')
-            ),
-	BackPlaneCorrectionPeakMode = cms.PSet(
-            record = cms.string('SiStripBackPlaneCorrectionRcd'),
-            label = cms.untracked.string('peak')
-            ),
-        BackPlaneCorrectionDeconvMode = cms.PSet(
-            record = cms.string('SiStripBackPlaneCorrectionRcd'),
-            label = cms.untracked.string('deconvolution')
-            )
-   )
+from CalibTracker.SiStripESProducers.siStripBackPlaneCorrectionDepESProducer_cfi import siStripBackPlaneCorrectionDepESProducer as _siStripBackPlaneCorrectionDepESProducer
+siStripBackPlaneCorrectionDepESProducer = _siStripBackPlaneCorrectionDepESProducer.clone()

--- a/CalibTracker/SiStripESProducers/python/SiStripLorentzAngleDepESProducer_cfi.py
+++ b/CalibTracker/SiStripESProducers/python/SiStripLorentzAngleDepESProducer_cfi.py
@@ -1,21 +1,5 @@
 # -*- coding: utf-8 -*-
 import FWCore.ParameterSet.Config as cms
 
-siStripLorentzAngleDepESProducer = cms.ESProducer("SiStripLorentzAngleDepESProducer",
-   
-     LatencyRecord =   cms.PSet(
-            record = cms.string('SiStripLatencyRcd'),
-            label = cms.untracked.string('')
-            ),
-	LorentzAnglePeakMode = cms.PSet(
-            record = cms.string('SiStripLorentzAngleRcd'),
-            label = cms.untracked.string('peak')
-            ),
-        LorentzAngleDeconvMode = cms.PSet(
-            record = cms.string('SiStripLorentzAngleRcd'),
-            label = cms.untracked.string('deconvolution')
-            )
-        
-   )
-
-
+from CalibTracker.SiStripESProducers.siStripLorentzAngleDepESProducer_cfi import siStripLorentzAngleDepESProducer as _siStripLorentzAngleDepESProducer
+siStripLorentzAngleDepESProducer = _siStripLorentzAngleDepESProducer.clone()

--- a/RecoLocalTracker/SiStripRecHitConverter/plugins/StripCPEESProducer.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/plugins/StripCPEESProducer.cc
@@ -37,7 +37,7 @@ private:
 
 void StripCPEESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<std::string>("ComponentName", "SimpleStripCPE");
+  desc.add<std::string>("ComponentName", "stripCPE");
 
   edm::ParameterSetDescription cpeFromTrackAngleDesc;
   StripCPEfromTrackAngle::fillPSetDescription(cpeFromTrackAngleDesc);
@@ -53,7 +53,7 @@ void StripCPEESProducer::fillDescriptions(edm::ConfigurationDescriptions& descri
               edm::ParameterDescription<edm::ParameterSetDescription>("parameters", emptyDesc, true) or
           "FakeStripCPE" >> edm::EmptyGroupDescription());
 
-  descriptions.addDefault(desc);
+  descriptions.addWithDefaultLabel(desc);
 }
 
 StripCPEESProducer::StripCPEESProducer(const edm::ParameterSet& p) {

--- a/RecoLocalTracker/SiStripRecHitConverter/python/StripCPEESProducer_cfi.py
+++ b/RecoLocalTracker/SiStripRecHitConverter/python/StripCPEESProducer_cfi.py
@@ -1,7 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 
-stripCPEESProducer = cms.ESProducer("StripCPEESProducer",
-                                    ComponentName = cms.string('stripCPE'),
-                                    ComponentType = cms.string('SimpleStripCPE'),
-                                    parameters    = cms.PSet()
-)
+from RecoLocalTracker.SiStripRecHitConverter.stripCPEESProducer_cfi import stripCPEESProducer as _stripCPEESProducer
+stripCPEESProducer = _stripCPEESProducer.clone()


### PR DESCRIPTION
#### PR description:
This PR is similar in spirit to https://github.com/cms-sw/cmssw/pull/47017, https://github.com/cms-sw/cmssw/pull/47045, https://github.com/cms-sw/cmssw/pull/47079, https://github.com/cms-sw/cmssw/pull/47107, https://github.com/cms-sw/cmssw/pull/47136, etc.
It adds fillDescriptions to a few EDProducers used at HLT used by Strip modules.
  
See also this issue: https://github.com/cms-sw/cmssw/issues/47275

#### PR validation:

```addOnTests.py``` runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A
