### PR TITLE
[15_0] Include CICADA v2.2.0 configuration as modification to 2025 L1T Era

### DIFF
--- a/Configuration/Eras/python/Era_Run3_2025_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2025_cff.py
@@ -3,5 +3,6 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.Eras.Era_Run3_2024_cff import Run3_2024
 from Configuration.Eras.Modifier_run3_GEM_2025_cff import run3_GEM_2025
 from Configuration.Eras.Modifier_run3_SiPixel_2025_cff import run3_SiPixel_2025
+from Configuration.Eras.Modifier_stage2L1Trigger_2025_cff import stage2L1Trigger_2025
 
-Run3_2025 = cms.ModifierChain(Run3_2024, run3_GEM_2025, run3_SiPixel_2025)
+Run3_2025 = cms.ModifierChain(Run3_2024, run3_GEM_2025, run3_SiPixel_2025, stage2L1Trigger_2025)

--- a/Configuration/Eras/python/Modifier_stage2L1Trigger_2025_cff.py
+++ b/Configuration/Eras/python/Modifier_stage2L1Trigger_2025_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+stage2L1Trigger_2025 = cms.Modifier()

--- a/L1Trigger/L1TCaloLayer1/python/simCaloStage2Layer1Summary_cfi.py
+++ b/L1Trigger/L1TCaloLayer1/python/simCaloStage2Layer1Summary_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from L1Trigger.L1TCaloLayer1.CICADATestPatterns import standardCICADATestPatterns
+from Configuration.Eras.Modifier_stage2L1Trigger_2025_cff import stage2L1Trigger_2025
 
 simCaloStage2Layer1Summary = cms.EDProducer('L1TCaloSummary_CICADA_vXp1p2',
     nPumBins = cms.uint32(18),
@@ -55,4 +56,9 @@ simCaloStage2Layer1Summary = cms.EDProducer('L1TCaloSummary_CICADA_vXp1p2',
     testPatterns = standardCICADATestPatterns,
     caloLayer1Regions = cms.InputTag("simCaloStage2Layer1Digis", ""),
     backupRegionToken = cms.InputTag("simCaloStage2Layer1Digis", "")
+)
+
+stage2L1Trigger_2025.toModify(
+    simCaloStage2Layer1Summary,
+    CICADAModelVersion = cms.string('CICADAModel_v2p2p0')
 )


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/47423

#### PR description:

> This PR updates the CICADA L1T Emulator to the proposed model version v2.2.0 for 2025 running. This PR is dependent on https://github.com/cms-sw/cmsdist/pull/9709

EDIT: I made a mistake and forgot that the CICADA external did not make it into 15_0, but 15_1. This PR is now dependent on PR: https://github.com/cms-sw/cmsdist/pull/9743

#### PR validation:

> The python pathing has been tested to work. The CICADA model has been tested locally to run and provide model accurate CICADA scores.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is a backport to 15_0 for including the proper emulator in the data-taking release, and for proper DQM.