### PR TITLE
Remove excessive includes in DataFormats/Provenance

### DIFF
--- a/DataFormats/Provenance/interface/BranchDescription.h
+++ b/DataFormats/Provenance/interface/BranchDescription.h
@@ -9,8 +9,6 @@ This description also applies to every product instance on the branch.
 ----------------------------------------------------------------------*/
 #include "DataFormats/Provenance/interface/BranchID.h"
 #include "DataFormats/Provenance/interface/BranchType.h"
-#include "DataFormats/Provenance/interface/ParameterSetID.h"
-#include "DataFormats/Provenance/interface/ProductID.h"
 #include "DataFormats/Provenance/interface/ProvenanceFwd.h"
 #include "FWCore/Utilities/interface/TypeID.h"
 #include "FWCore/Reflection/interface/TypeWithDict.h"

--- a/DataFormats/Provenance/interface/ProvenanceFwd.h
+++ b/DataFormats/Provenance/interface/ProvenanceFwd.h
@@ -31,12 +31,5 @@ namespace cms {
   class Exception;  // In FWCore/Utilities
 }
 
-#include "DataFormats/Provenance/interface/BranchIDList.h"
-#include "DataFormats/Provenance/interface/BranchListIndex.h"
-#include "DataFormats/Provenance/interface/ParentageID.h"
-#include "DataFormats/Provenance/interface/PassID.h"
-#include "DataFormats/Provenance/interface/ReleaseVersion.h"
-#include "DataFormats/Provenance/interface/ProcessHistoryID.h"
-#include "DataFormats/Provenance/interface/ProcessConfigurationID.h"
 #include "DataFormats/Provenance/interface/ProductDescriptionFwd.h"
 #endif

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -58,6 +58,7 @@
 */
 
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
+#include "DataFormats/Provenance/interface/BranchIDList.h"
 #include "FWCore/Common/interface/FWCoreCommonFwd.h"
 #include "FWCore/Framework/interface/ExceptionActions.h"
 #include "FWCore/Framework/interface/ExceptionHelpers.h"

--- a/FWCore/Framework/interface/one/EDFilterBase.h
+++ b/FWCore/Framework/interface/one/EDFilterBase.h
@@ -26,6 +26,7 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/SharedResourcesAcquirer.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
+#include "DataFormats/Provenance/interface/ParentageID.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 #include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 

--- a/FWCore/Framework/interface/one/EDProducerBase.h
+++ b/FWCore/Framework/interface/one/EDProducerBase.h
@@ -26,6 +26,7 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/SharedResourcesAcquirer.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
+#include "DataFormats/Provenance/interface/ParentageID.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 #include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 

--- a/FWCore/Framework/src/ProductResolversFactory.cc
+++ b/FWCore/Framework/src/ProductResolversFactory.cc
@@ -1,6 +1,7 @@
 #include "FWCore/Framework/interface/ProductResolversFactory.h"
 #include "FWCore/Framework/interface/ProductResolverBase.h"
 #include "DataFormats/Provenance/interface/ProductResolverIndexHelper.h"
+#include "DataFormats/Provenance/interface/BranchIDList.h"
 #include "ProductResolvers.h"
 #include "DroppedDataProductResolver.h"
 

--- a/FWCore/Sources/interface/DaqProvenanceHelper.h
+++ b/FWCore/Sources/interface/DaqProvenanceHelper.h
@@ -13,6 +13,7 @@
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
 #include "DataFormats/Provenance/interface/ProductProvenance.h"
 #include "DataFormats/Provenance/interface/BranchID.h"
+#include "DataFormats/Provenance/interface/BranchIDList.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 namespace edm {

--- a/IOPool/Input/src/RootFile.h
+++ b/IOPool/Input/src/RootFile.h
@@ -21,6 +21,7 @@ RootFile.h // used by ROOT input sources
 #include "DataFormats/Provenance/interface/FileID.h"
 #include "DataFormats/Provenance/interface/History.h"
 #include "DataFormats/Provenance/interface/IndexIntoFile.h"
+#include "DataFormats/Provenance/interface/ParentageID.h"
 #include "DataFormats/Provenance/interface/ProvenanceFwd.h"
 #include "FWCore/Common/interface/FWCoreCommonFwd.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"


### PR DESCRIPTION
#### PR description:

- DataFormats/Provenance/interface/BranchDescription.h includes headers that are no longer needed
- DataFormats/Provenance/interface/ProvenanceFwd.h includes several headers that are not actually forward declarations

Since these headers are widely referenced (as a cms-checkdeps will show), it seems worthwhile to remove unneeded dependencies and limit ProvenanceFwd.h to actual forward declarations.

#### PR validation:

Compiles, purely technical update.  Only impact should be a small speedup in compilation time.

Resolves https://github.com/cms-sw/framework-team/issues/1301