### PR TITLE
remove `hltOnlineBeamSpotESProducer_cfi` from NGT scouting menu

### DIFF
--- a/HLTrigger/Configuration/python/HLT_NGTScouting_cff.py
+++ b/HLTrigger/Configuration/python/HLT_NGTScouting_cff.py
@@ -60,7 +60,6 @@ fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/highPtTripletStepTra
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/muonSeededTrajectoryCleanerBySharedHits_cfi")
 
 ### Mostly comes from HLT-like configuration, not RECO-like configuration
-fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltOnlineBeamSpotESProducer_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPBwdElectronPropagator_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPChi2ChargeMeasurementEstimator2000_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPChi2ChargeMeasurementEstimator30_cfi")


### PR DESCRIPTION
#### PR description:

This is a quick follow-up to https://github.com/cms-sw/cmssw/pull/47378.
Remove `hltOnlineBeamSpotESProducer_cfi` inclusion from the NGT scouting menu (overlooked in that PR).

#### PR validation:

 `runTheMatrix.py --what upgrade -l 29634.77 -t 4 -j 8` runs.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A