### PR TITLE
[15_0_X] Update OnlineBeamMonitor for DIP publication

### DIFF
--- a/DQM/Integration/python/clients/beamspotdip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamspotdip_dqm_sourceclient-live_cfg.py
@@ -47,10 +47,9 @@ process.GlobalTag.toGet = cms.VPSet(
 process.load("DQM.BeamMonitor.BeamSpotDipServer_cff")
 
 process.beamSpotDipServer.verbose = cms.untracked.bool(True)
-# Temporary roll-back to using default input txt file
-#process.beamSpotDipServer.sourceFile  = cms.untracked.string(
-#    "/nfshome0/dqmpro/BeamMonitorDQM/BeamFitResultsForDIP.txt"
-#)
+process.beamSpotDipServer.sourceFile  = cms.untracked.string(
+    "/nfshome0/dqmpro/BeamMonitorDQM/BeamFitResultsForDIP.txt"
+)
 
 # process customizations included here
 from DQM.Integration.config.online_customizations_cfi import *


### PR DESCRIPTION
#### PR description:
Verbatim backport of #47539.

> In #46613 we tried updating the source of the `beamspotdip` client (which publishes the online BeamSpot values to DIP and OMS) to read the BeamSpot result from `BeamFitResultsForDIP.txt`, which is produced by the `onlinebeammonitor` and is the result of the arbitration between the beamspot values produced by the `beam` and `beamhlt` clients.
We then had to revert it (done in  #46737) because the `BeamFitResultsForDIP.txt` file was not in the correct format for the DIP client to correctly parse it (it was missing few records).
> 
> In this PR I'm finally updating the `OnlineBeamMonitor` plugin to write the `BeamFitResultsForDIP.txt` file in the corect format and setting it to be the file that is read by `beamspotdip_dqm_sourceclient-live_cfg.py`.

#### PR validation:
See master PR for validation

#### Backport:
Backport of #47539
