### PR TITLE
Fix endcap assignment of L1 Muon stubs

### DIFF
--- a/L1Trigger/Phase2L1GMT/src/L1TPhase2GMTEndcapStubProcessor.cc
+++ b/L1Trigger/Phase2L1GMT/src/L1TPhase2GMTEndcapStubProcessor.cc
@@ -37,7 +37,8 @@ l1t::MuonStub L1TPhase2GMTEndcapStubProcessor::buildCSCOnlyStub(const CSCDetId& 
   int eta1 = int(gp.eta() / eta1LSB_);
 
   int wheel = 0;
-  int sign = endcap == 1 ? -1 : 1;
+  // endcap: 1=forward (+Z), 2=backward(-Z) from CSCDetId
+  int sign = endcap == 2 ? -1 : 1;
 
   if (ring == 3)
     wheel = sign * 3;


### PR DESCRIPTION
#### PR description:

The title pretty much describes it, the sign used to create stubs now follows the general `CSCDetId` convention.

#### PR validation:

Tested with the usual `runTheMatrix.py -l limited -i all --ibeos` and `hltPhase2UpgradeIntegrationTests` locally. No physics output difference is expected. As far as I can tell, stubs are only directly used in .777 and .778 workflows (which do not use their endcap  assignment as a workaround before this fix)