### PR TITLE
Fix the python configuration for the TICLDumper

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -823,6 +823,46 @@ upgradeWFs['ticl_v5_superclustering_mustache_pf'] = UpgradeWorkflow_ticl_v5_supe
 upgradeWFs['ticl_v5_superclustering_mustache_pf'].step3 = {'--procModifiers': 'ticl_v5,ticl_superclustering_mustache_pf'}
 upgradeWFs['ticl_v5_superclustering_mustache_pf'].step4 = {'--procModifiers': 'ticl_v5,ticl_superclustering_mustache_pf'}
 
+class UpgradeWorkflow_TICLdumper(UpgradeWorkflow):
+    def setup_(self, step, stepName, stepDict, k, properties):
+        if 'RecoGlobal' in step:
+            stepDict[stepName][k] = merge([self.step3, stepDict[step][k]])
+    def condition(self, fragment, stepList, key, hasHarvest):
+        return (fragment=="TTbar_14TeV" or 'CloseByP' in fragment or 'Eta1p7_2p7' in fragment) and 'Run4' in key
+
+upgradeWFs['enableTICLdumper'] = UpgradeWorkflow_TICLdumper(
+    steps = [
+        'RecoGlobal',
+    ],
+    PU = [
+        'RecoGlobal',
+    ],
+    suffix = '_enableTICLdumper',
+    offset = 0.206,
+)
+upgradeWFs['enableTICLdumper'].step3 = {'--customise': 'RecoHGCal/TICL/customiseTICLFromReco.customiseTICLForDumper'}
+
+upgradeWFs['ticl_v5_withDumper'] = UpgradeWorkflow_ticl_v5(
+    steps = [
+        'HLTOnly',
+        'DigiTrigger',
+        'RecoGlobal',
+        'HARVESTGlobal'
+    ],
+    PU = [
+        'HLTOnly',
+        'DigiTrigger',
+        'RecoGlobal',
+        'HARVESTGlobal'
+    ],
+    suffix = '_ticl_v5_withDumper',
+    offset = 0.207,
+)
+upgradeWFs['ticl_v5_withDumper'].step2 = {'--procModifiers': 'ticl_v5'}
+upgradeWFs['ticl_v5_withDumper'].step3 = {'--procModifiers': 'ticl_v5',
+                                          '--customise': 'RecoHGCal/TICL/customiseTICLFromReco.customiseTICLForDumper'}
+upgradeWFs['ticl_v5_withDumper'].step4 = {'--procModifiers': 'ticl_v5'}
+
 # Improved L2 seeding from L1Tk Muons and L3 Tracker Muon Inside-Out reconstruction first (Phase-2 Muon default)
 class UpgradeWorkflow_phase2L2AndL3Muons(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):

--- a/RecoHGCal/TICL/plugins/TICLDumper.cc
+++ b/RecoHGCal/TICL/plugins/TICLDumper.cc
@@ -666,6 +666,9 @@ private:
   std::vector<float> simTICLCandidate_boundaryPx;
   std::vector<float> simTICLCandidate_boundaryPy;
   std::vector<float> simTICLCandidate_boundaryPz;
+  std::vector<float> simTICLCandidate_pt;
+  std::vector<float> simTICLCandidate_phi;
+  std::vector<float> simTICLCandidate_eta;
   std::vector<float> simTICLCandidate_caloParticleMass;
   std::vector<float> simTICLCandidate_time;
   std::vector<int> simTICLCandidate_pdgId;
@@ -681,6 +684,9 @@ private:
   std::vector<double> candidate_px;
   std::vector<double> candidate_py;
   std::vector<double> candidate_pz;
+  std::vector<float> candidate_pt;
+  std::vector<float> candidate_phi;
+  std::vector<float> candidate_eta;
   std::vector<float> candidate_time;
   std::vector<float> candidate_time_err;
   std::vector<std::vector<float>> candidate_id_probabilities;
@@ -715,6 +721,7 @@ private:
   std::vector<float> track_hgcal_phi;
   std::vector<float> track_hgcal_pt;
   std::vector<float> track_pt;
+  std::vector<float> track_p;
   std::vector<int> track_quality;
   std::vector<int> track_missing_outer_hits;
   std::vector<int> track_missing_inner_hits;
@@ -767,6 +774,9 @@ void TICLDumper::clearVariables() {
   simTICLCandidate_boundaryPx.clear();
   simTICLCandidate_boundaryPy.clear();
   simTICLCandidate_boundaryPz.clear();
+  simTICLCandidate_pt.clear();
+  simTICLCandidate_phi.clear();
+  simTICLCandidate_eta.clear();
   simTICLCandidate_time.clear();
   simTICLCandidate_caloParticleMass.clear();
   simTICLCandidate_pdgId.clear();
@@ -781,6 +791,9 @@ void TICLDumper::clearVariables() {
   candidate_px.clear();
   candidate_py.clear();
   candidate_pz.clear();
+  candidate_pt.clear();
+  candidate_phi.clear();
+  candidate_eta.clear();
   candidate_time.clear();
   candidate_time_err.clear();
   candidate_id_probabilities.clear();
@@ -818,6 +831,7 @@ void TICLDumper::clearVariables() {
   track_hgcal_pt.clear();
   track_quality.clear();
   track_pt.clear();
+  track_p.clear();
   track_missing_outer_hits.clear();
   track_missing_inner_hits.clear();
   track_charge.clear();
@@ -969,6 +983,9 @@ void TICLDumper::beginJob() {
     candidate_tree_->Branch("candidate_px", &candidate_px);
     candidate_tree_->Branch("candidate_py", &candidate_py);
     candidate_tree_->Branch("candidate_pz", &candidate_pz);
+    candidate_tree_->Branch("candidate_pt", &candidate_pt);
+    candidate_tree_->Branch("candidate_phi", &candidate_phi);
+    candidate_tree_->Branch("candidate_eta", &candidate_eta);
     candidate_tree_->Branch("track_in_candidate", &track_in_candidate);
     candidate_tree_->Branch("tracksters_in_candidate", &tracksters_in_candidate);
   }
@@ -1013,6 +1030,7 @@ void TICLDumper::beginJob() {
     tracks_tree_->Branch("track_hgcal_phi", &track_hgcal_phi);
     tracks_tree_->Branch("track_hgcal_pt", &track_hgcal_pt);
     tracks_tree_->Branch("track_pt", &track_pt);
+    tracks_tree_->Branch("track_p", &track_p);
     tracks_tree_->Branch("track_missing_outer_hits", &track_missing_outer_hits);
     tracks_tree_->Branch("track_missing_inner_hits", &track_missing_inner_hits);
     tracks_tree_->Branch("track_quality", &track_quality);
@@ -1041,6 +1059,9 @@ void TICLDumper::beginJob() {
     simTICLCandidate_tree->Branch("simTICLCandidate_boundaryPx", &simTICLCandidate_boundaryPx);
     simTICLCandidate_tree->Branch("simTICLCandidate_boundaryPy", &simTICLCandidate_boundaryPy);
     simTICLCandidate_tree->Branch("simTICLCandidate_boundaryPz", &simTICLCandidate_boundaryPz);
+    simTICLCandidate_tree->Branch("simTICLCandidate_pt", &simTICLCandidate_pt);
+    simTICLCandidate_tree->Branch("simTICLCandidate_phi", &simTICLCandidate_phi);
+    simTICLCandidate_tree->Branch("simTICLCandidate_eta", &simTICLCandidate_eta);
     simTICLCandidate_tree->Branch("simTICLCandidate_time", &simTICLCandidate_time);
     simTICLCandidate_tree->Branch("simTICLCandidate_caloParticleMass", &simTICLCandidate_caloParticleMass);
     simTICLCandidate_tree->Branch("simTICLCandidate_pdgId", &simTICLCandidate_pdgId);
@@ -1185,6 +1206,9 @@ void TICLDumper::analyze(const edm::Event& event, const edm::EventSetup& setup) 
     simTICLCandidate_pdgId.push_back(cand.pdgId());
     simTICLCandidate_charge.push_back(cand.charge());
     simTICLCandidate_time.push_back(cand.time());
+    simTICLCandidate_pt.push_back(cand.pt());
+    simTICLCandidate_phi.push_back(cand.phi());
+    simTICLCandidate_eta.push_back(cand.eta());
     std::vector<int> tmpIdxVec;
     for (auto const& simTS : cand.tracksters()) {
       auto trackster_idx = simTS.get() - (edm::Ptr<ticl::Trackster>(simTrackstersSC_h, 0)).get();
@@ -1265,6 +1289,9 @@ void TICLDumper::analyze(const edm::Event& event, const edm::EventSetup& setup) 
     candidate_px.push_back(candidate.px());
     candidate_py.push_back(candidate.py());
     candidate_pz.push_back(candidate.pz());
+    candidate_pt.push_back(candidate.pt());
+    candidate_phi.push_back(candidate.phi());
+    candidate_eta.push_back(candidate.eta());
     candidate_time.push_back(candidate.time());
     candidate_time_err.push_back(candidate.timeError());
     std::vector<float> id_probs;
@@ -1316,6 +1343,7 @@ void TICLDumper::analyze(const edm::Event& event, const edm::EventSetup& setup) 
       track_hgcal_pz.push_back(globalMom.z());
       track_hgcal_pt.push_back(globalMom.perp());
       track_pt.push_back(track.pt());
+      track_p.push_back(track.p());
       track_quality.push_back(track.quality(reco::TrackBase::highPurity));
       track_missing_outer_hits.push_back(track.missingOuterHits());
       track_missing_inner_hits.push_back(track.missingInnerHits());

--- a/RecoHGCal/TICL/python/ticlDumper_cff.py
+++ b/RecoHGCal/TICL/python/ticlDumper_cff.py
@@ -39,13 +39,13 @@ ticlDumper = ticlDumper_.clone(
             tracksterType=cms.string("SimTracksterCP")
         ),
     ],
-    
+
     associators=dumperAssociators.copy(),
     saveSuperclustering = cms.bool(False)
 )
 
 ticl_v5.toModify(ticlDumper, ticlcandidates = cms.InputTag("ticlCandidate"), recoSuperClusters_sourceTracksterCollection=cms.InputTag("ticlCandidate"))
-ticl_v5.toModify(ticlDumper, saveSuperclustering = cms.bool(True))
+ticl_v5.toModify(ticlDumper, saveSuperclustering = cms.bool(True), trackstersInCand=cms.InputTag("ticlCandidate"))
 
 
 


### PR DESCRIPTION
#### PR description:

When using the TICLDumper with the `ticl_v5` process modifier, the wrong collection of trackster was used. This PR fixes this.
In addition, workflows that run also the dumper have been added.

#### PR validation:

dumped and ran the new workflows with `runTheMatrix.py -w upgrade -l 29688.206,29688.207`

FYI @felicepantaleo @waredjeb @Moanwar 
