### PR TITLE
[15.0.X] add missing defaults to `MkFitProducer::fillDescriptions`

### DIFF
--- a/RecoTracker/MkFit/plugins/MkFitProducer.cc
+++ b/RecoTracker/MkFit/plugins/MkFitProducer.cc
@@ -113,8 +113,8 @@ void MkFitProducer::fillDescriptions(edm::ConfigurationDescriptions& description
   desc.add("clustersToSkip", edm::InputTag());
   desc.add<std::string>("buildingRoutine", "cloneEngine")
       ->setComment("Valid values are: 'bestHit', 'standard', 'cloneEngine'");
-  desc.add<edm::ESInputTag>("config")->setComment(
-      "ESProduct that has the mkFit configuration parameters for this iteration");
+  desc.add<edm::ESInputTag>("config", edm::ESInputTag(""))
+      ->setComment("ESProduct that has the mkFit configuration parameters for this iteration");
   desc.add("seedCleaning", true)->setComment("Clean seeds within mkFit");
   desc.add("removeDuplicates", true)->setComment("Run duplicate removal within mkFit");
   desc.add("backwardFitInCMSSW", false)
@@ -126,7 +126,7 @@ void MkFitProducer::fillDescriptions(edm::ConfigurationDescriptions& description
           "the module time");
 
   edm::ParameterSetDescription descCCC;
-  descCCC.add<double>("value");
+  descCCC.add<double>("value", -999.);
   desc.add("minGoodStripCharge", descCCC);
 
   descriptions.add("mkFitProducerDefault", desc);


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/47575

#### PR description:

While trying to parse in confDB the resulting menu from the customization proposed at [CMSHLT-3421](https://its.cern.ch/jira/browse/CMSHLT-3421), it was noticed that certain parameters in `MkFitProducer` were not assigned the right `cms` type.
This was analyzed as a lack of appropriate defaults in the `fillDescriptions` of the producer, which as per coding rule 6.14 [link](https://cms-sw.github.io/cms_coding_rules.html) is needed for modules used at HLT.

#### PR validation:

`cmssw` compiles

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

verbatim backport of https://github.com/cms-sw/cmssw/pull/47575  to the 2025 data-taking release.