### PR TITLE
Create new main ProductRegistry if input products change

### DIFF
--- a/FWCore/Framework/interface/OccurrenceForOutput.h
+++ b/FWCore/Framework/interface/OccurrenceForOutput.h
@@ -64,6 +64,7 @@ namespace edm {
     Handle<PROD> getHandle(EDGetTokenT<PROD> token) const;
 
     Provenance getProvenance(BranchID const& theID) const;
+    StableProvenance const& getStableProvenance(BranchID const& ithID) const;
 
     void getAllProvenance(std::vector<Provenance const*>& provenances) const;
 

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -74,7 +74,8 @@ namespace edm {
 
     ~Principal() override;
 
-    void adjustIndexesAfterProductRegistryAddition();
+    //This should only be called when this Principal is not being actively used
+    void possiblyUpdateAfterAddition(std::shared_ptr<ProductRegistry const>);
 
     void fillPrincipal(DelayedReader* reader);
     void fillPrincipal(ProcessHistoryID const& hist, ProcessHistory const* phr, DelayedReader* reader);
@@ -213,6 +214,8 @@ namespace edm {
     }
 
   private:
+    void adjustIndexesAfterProductRegistryAddition();
+
     //called by adjustIndexesAfterProductRegistryAddition only if an index actually changed
     virtual void changedIndexes_() {}
 

--- a/FWCore/Framework/interface/PrincipalCache.h
+++ b/FWCore/Framework/interface/PrincipalCache.h
@@ -53,7 +53,7 @@ namespace edm {
 
     void adjustEventsToNewProductRegistry(std::shared_ptr<ProductRegistry const>);
 
-    void adjustIndexesAfterProductRegistryAddition();
+    void adjustIndexesAfterProductRegistryAddition(std::shared_ptr<ProductRegistry const>);
 
   private:
     std::unique_ptr<ProcessBlockPrincipal> processBlockPrincipal_;

--- a/FWCore/Framework/src/OccurrenceForOutput.cc
+++ b/FWCore/Framework/src/OccurrenceForOutput.cc
@@ -29,6 +29,10 @@ namespace edm {
     return provRecorder_.principal().getProvenance(bid);
   }
 
+  StableProvenance const& OccurrenceForOutput::getStableProvenance(BranchID const& bid) const {
+    return provRecorder_.principal().getStableProvenance(bid);
+  }
+
   void OccurrenceForOutput::getAllProvenance(std::vector<Provenance const*>& provenances) const {
     provRecorder_.principal().getAllProvenance(provenances);
   }

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -31,7 +31,6 @@
 #include <stdexcept>
 #include <typeinfo>
 #include <atomic>
-
 namespace edm {
 
   static ProcessHistory const s_emptyProcessHistory;
@@ -147,6 +146,13 @@ namespace edm {
       }
     }
     return size;
+  }
+
+  void Principal::possiblyUpdateAfterAddition(std::shared_ptr<ProductRegistry const> iProd) {
+    if (iProd.get() != preg_.get()) {
+      preg_ = iProd;
+      adjustIndexesAfterProductRegistryAddition();
+    }
   }
 
   void Principal::addDroppedProduct(ProductDescription const& bd) {

--- a/FWCore/Framework/src/PrincipalCache.cc
+++ b/FWCore/Framework/src/PrincipalCache.cc
@@ -43,22 +43,22 @@ namespace edm {
   void PrincipalCache::adjustEventsToNewProductRegistry(std::shared_ptr<ProductRegistry const> reg) {
     for (auto& eventPrincipal : eventPrincipals_) {
       if (eventPrincipal) {
-        eventPrincipal->adjustIndexesAfterProductRegistryAddition();
+        eventPrincipal->possiblyUpdateAfterAddition(reg);
       }
     }
   }
 
-  void PrincipalCache::adjustIndexesAfterProductRegistryAddition() {
+  void PrincipalCache::adjustIndexesAfterProductRegistryAddition(std::shared_ptr<ProductRegistry const> iReg) {
     //Need to temporarily hold all the runs to clear out the runHolder_
     std::vector<std::shared_ptr<RunPrincipal>> tempRunPrincipals;
     while (auto p = runHolder_.tryToGet()) {
-      p->adjustIndexesAfterProductRegistryAddition();
+      p->possiblyUpdateAfterAddition(iReg);
       tempRunPrincipals.emplace_back(std::move(p));
     }
     //Need to temporarily hold all the lumis to clear out the lumiHolder_
     std::vector<std::shared_ptr<LuminosityBlockPrincipal>> tempLumiPrincipals;
     while (auto p = lumiHolder_.tryToGet()) {
-      p->adjustIndexesAfterProductRegistryAddition();
+      p->possiblyUpdateAfterAddition(iReg);
       tempLumiPrincipals.emplace_back(std::move(p));
     }
   }

--- a/FWCore/Framework/test/stubs/ToyIntProducers.cc
+++ b/FWCore/Framework/test/stubs/ToyIntProducers.cc
@@ -458,6 +458,12 @@ namespace edmtest {
       for (auto const& label : labels) {
         tokens_.emplace_back(consumes(label));
       }
+      {
+        auto const& labels = p.getUntrackedParameter<std::vector<edm::InputTag>>("untrackedLabels");
+        for (auto const& label : labels) {
+          tokens_.emplace_back(consumes(label));
+        }
+      }
     }
     void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
 
@@ -465,6 +471,10 @@ namespace edmtest {
       edm::ParameterSetDescription desc;
       desc.addUntracked<unsigned int>("onlyGetOnEvent", 0u);
       desc.add<std::vector<edm::InputTag>>("labels");
+      desc.addUntracked<std::vector<edm::InputTag>>("untrackedLabels", {})
+          ->setComment(
+              "Using this can change the stored ProductRegistry for the same ProcessHistory if this is the only module "
+              "that depends on these labels.");
       descriptions.addDefault(desc);
     }
 

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -43,6 +43,7 @@
   <test name="TestIntegrationEmptyRootFile" command="run_TestEmptyRootFile.sh"/>
   <test name="TestStdProducts" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/testStdProducts_cfg.py"/>
   <test name="TestPostInsertProducer" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/testPostInsertProducer_cfg.py"/>
+  <test name="TestFWCoreIntegrationProvenance" command ="provenance_test.sh"/>
 
   <bin file="ProcessConfiguration_t.cpp,ProcessHistory_t.cpp" name="TestIntegrationDataFormatsProvenance">
     <use name="FWCore/ParameterSet"/>

--- a/FWCore/Integration/test/provenance_check_cfg.py
+++ b/FWCore/Integration/test/provenance_check_cfg.py
@@ -1,0 +1,13 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("READ")
+
+from IOPool.Input.modules import PoolSource
+
+process.source = PoolSource(fileNames = ["file:prov.root", "file:prov_extra.root"])
+
+from FWCore.Modules.modules import ProvenanceCheckerOutputModule, AsciiOutputModule
+process.out = ProvenanceCheckerOutputModule()
+process.prnt = AsciiOutputModule(verbosity = 2, allProvenance=True)
+
+process.e = cms.EndPath(process.out+process.prnt)

--- a/FWCore/Integration/test/provenance_prod_cfg.py
+++ b/FWCore/Integration/test/provenance_prod_cfg.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+from argparse import ArgumentParser
+
+parser = ArgumentParser(description='Write streamer output file for provenance read test')
+parser.add_argument("--consumeProd2", help="add an extra producer to the job and drop on output", action="store_true")
+args = parser.parse_args()
+
+
+process = cms.Process("OUTPUT")
+
+from FWCore.Modules.modules import EmptySource
+
+runNumber = 1
+eventNumber = 1
+if args.consumeProd2:
+    eventNumber = 2
+
+process.source = EmptySource(firstRun = runNumber, firstEvent = eventNumber )
+
+from FWCore.Framework.modules import AddIntsProducer, IntProducer
+
+process.one = IntProducer(ivalue=1)
+process.two = IntProducer(ivalue=2)
+process.sum = AddIntsProducer(labels=['one'])
+process.t = cms.Task(process.one, process.two, process.sum)
+
+baseOutFileName = "prov"
+if args.consumeProd2 :
+    process.sum.untrackedLabels = ['two']
+    baseOutFileName += "_extra"
+
+
+from IOPool.Output.modules import PoolOutputModule
+
+process.out = PoolOutputModule(fileName = baseOutFileName+".root",
+                               outputCommands = ["drop *", "keep *_sum_*_*"])
+
+from FWCore.Modules.modules import AsciiOutputModule
+process.prnt = AsciiOutputModule(verbosity = 2, allProvenance = True)
+process.e = cms.EndPath(process.out+process.prnt, process.t)
+process.maxEvents.input = 1

--- a/FWCore/Integration/test/provenance_test.sh
+++ b/FWCore/Integration/test/provenance_test.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+
+function die { echo $1: status $2 ;  exit $2; }
+
+#The two jobs will have different ProductRegistries in their output files but have the same ProcessHistory.
+# The ProductRegistry just differ because the internal dependencies between the data products is different
+# and PoolOutputModule only stores provenance of 'dropped' data products IFF they are parents of a kept product. 
+# The check makes sure the provenance in the ProductRegistry is properly updated when the new file is read
+cmsRun ${SCRAM_TEST_PATH}/provenance_prod_cfg.py || die 'Failed in provenance_prod_cfg.py' $?
+cmsRun ${SCRAM_TEST_PATH}/provenance_prod_cfg.py  --consumeProd2 || die 'Failed in provenance_prod_cfg.py  --consumeProd2' $?
+cmsRun ${SCRAM_TEST_PATH}/provenance_check_cfg.py || die 'Failed test of provenance' $?

--- a/FWCore/TestProcessor/src/TestSourceProcessor.cc
+++ b/FWCore/TestProcessor/src/TestSourceProcessor.cc
@@ -229,7 +229,7 @@ namespace edm::test {
     const size_t size = preg_->size();
     preg_->merge(source_->productRegistry(), fb_ ? fb_->fileName() : std::string());
     if (size < preg_->size()) {
-      principalCache_.adjustIndexesAfterProductRegistryAddition();
+      principalCache_.adjustIndexesAfterProductRegistryAddition(preg_);
     }
     principalCache_.adjustEventsToNewProductRegistry(preg_);
 


### PR DESCRIPTION
#### PR description:

Instead of having one ProductRegistry shared by many objects, now if the ProductRegistry used by the Source adds new entries (which can only happen when reading a new file and the job which made the file has different dropped products) we make a new ProductRegistry and explicitly tell all Principals to update. 

This would make it possible in the future to have multiple concurrent files open (open a new one while the last events in the previous file are finishing) where different Principals were using different ProductRegistries.

#### PR validation:

All framework unit tests pass and newly added unit test also passes.

resolves https://github.com/cms-sw/framework-team/issues/1304