### PR TITLE
Add protection if non-existent geometry is used

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -817,6 +817,8 @@ class ConfigBuilder(object):
         try:
             if len(self.stepMap):
                 self.loadAndRemember(self.GeometryCFF)
+                if (self.GeometryCFF == 'Configuration/StandardSequences/GeometryRecoDB_cff'):
+                    print("Warning: Default GeometryRecoDB_cff is used. It may not work with your process.")
                 if ('SIM' in self.stepMap or 'reSIM' in self.stepMap) and not self._options.fast:
                     self.loadAndRemember(self.SimGeometryCFF)
                     if self.geometryDBLabel:
@@ -1155,7 +1157,7 @@ class ConfigBuilder(object):
                 if opt in GeometryConf:
                     return GeometryConf[opt]
                 else:
-                    return opt
+                    raise Exception("Geometry "+opt+" does not exist!")
 
             geoms=self._options.geometry.split(',')
             if len(geoms)==1: geoms=inGeometryKeys(geoms[0]).split(',')

--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1157,7 +1157,7 @@ class ConfigBuilder(object):
                 if opt in GeometryConf:
                     return GeometryConf[opt]
                 else:
-                    if (opt=='SimDB'):
+                    if (opt=='SimDB' or opt.startswith('DB:')):
                         return opt
                     else:
                         raise Exception("Geometry "+opt+" does not exist!")

--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -817,8 +817,8 @@ class ConfigBuilder(object):
         try:
             if len(self.stepMap):
                 self.loadAndRemember(self.GeometryCFF)
-                if (self.GeometryCFF == 'Configuration/StandardSequences/GeometryRecoDB_cff'):
-                    print("Warning: Default GeometryRecoDB_cff is used. It may not work with your process.")
+                if (self.GeometryCFF == 'Configuration/StandardSequences/GeometryRecoDB_cff' and not self.geometryDBLabel):
+                    print("Warning: The default GeometryRecoDB_cff is being used; however, the DB geometry is not applied. You may need to verify your cmsDriver.")
                 if ('SIM' in self.stepMap or 'reSIM' in self.stepMap) and not self._options.fast:
                     self.loadAndRemember(self.SimGeometryCFF)
                     if self.geometryDBLabel:

--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1157,7 +1157,10 @@ class ConfigBuilder(object):
                 if opt in GeometryConf:
                     return GeometryConf[opt]
                 else:
-                    raise Exception("Geometry "+opt+" does not exist!")
+                    if (opt=='SimDB'):
+                        return opt
+                    else:
+                        raise Exception("Geometry "+opt+" does not exist!")
 
             geoms=self._options.geometry.split(',')
             if len(geoms)==1: geoms=inGeometryKeys(geoms[0]).split(',')


### PR DESCRIPTION
#### PR description:
This PR changes how cmsDriver handles non-existent geometry.
- **Before**: If non-existent geometry is used, but step does not include SIM, cmsDriver will dump a config file with default RECO geometry ('Configuration/StandardSequences/GeometryRecoDB_cff')
- **With this PR**:  If a non-existent geometry is used, the cmsDriver will fail with an error message indicating the non-existent geometry. Additionally, if the default RECO geometry is used but DBGeometry is not used, a warning message will be displayed.

#### PR validation:
Try to dump config files in many ways, and check.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
No need of backport.
