### PR TITLE
Fix missing type declaration in EdmEventSize

### DIFF
--- a/PerfTools/EdmEvent/src/EdmEventSize.cc
+++ b/PerfTools/EdmEvent/src/EdmEventSize.cc
@@ -319,7 +319,7 @@ namespace perftools {
     co << "\"total\": {\n";
     co << "\"events\": " << m_nEvents << ",\n";
     auto [total_uncompressed, total_compressed] = std::accumulate(
-        m_records.begin(), m_records.end(), std::make_pair<size_t>(0, 0), [](auto sum, Record const& leaf) {
+        m_records.begin(), m_records.end(), std::make_pair<size_t, size_t>(0, 0), [](auto sum, Record const& leaf) {
           return std::make_pair(sum.first + leaf.uncompr_size, sum.second + leaf.compr_size);
         });
     co << "\"size_uncompressed\": " << total_uncompressed << ",\n";


### PR DESCRIPTION
#### PR description:

The compressed size was wrongly calculated because the type of the second element of make pair was deduced to `int` instead of `size_t`

#### PR validation:

Verified on local machine that the value is correct for large file sizes too and matches the sum of the object sizes.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport
