### PR TITLE
Muon dxy 1D Histograms added to all Electron and Muon directories, extended range for PvMult plots for GEN-SIM-RECO AND MINIAOD directories at DQM/Physics

### DIFF
--- a/DQM/Physics/src/SingleTopTChannelLeptonDQM.cc
+++ b/DQM/Physics/src/SingleTopTChannelLeptonDQM.cc
@@ -452,8 +452,8 @@ namespace SingleTopTChannelLepton {
 
         // d_xy distribution
         if (muon->muonBestTrack().isNonnull()) {
-            double dxy = muon->muonBestTrack()->dxy(Pvertex.position());
-            fill("muonDxy_", dxy);
+          double dxy = muon->muonBestTrack()->dxy(Pvertex.position());
+          fill("muonDxy_", dxy);
         }
 
         // apply preselection

--- a/DQM/Physics/src/SingleTopTChannelLeptonDQM.cc
+++ b/DQM/Physics/src/SingleTopTChannelLeptonDQM.cc
@@ -187,7 +187,7 @@ namespace SingleTopTChannelLepton {
 
     // --- [STANDARD] --- //
     // number of selected primary vertices
-    hists_["pvMult_"] = ibooker.book1D("PvMult", "N_{good pvs}", 50, 0., 50.);
+    hists_["pvMult_"] = ibooker.book1D("PvMult", "N_{good pvs}", 50, 0., 100.);
     // pt of the leading muon
     hists_["muonPt_"] = ibooker.book1D("MuonPt", "pt(#mu TightId, TightIso)", 40, 0., 200.);
     // muon multiplicity before std isolation
@@ -260,10 +260,13 @@ namespace SingleTopTChannelLepton {
     hists_["muonDelZ_"] = ibooker.book1D("MuonDelZ", "d_{z}(#mu)", 50, -25., 25.);
     // dxy for muons (to suppress cosmics)
     hists_["muonDelXY_"] = ibooker.book2D("MuonDelXY", "d_{xy}(#mu)", 50, -0.1, 0.1, 50, -0.1, 0.1);
+    // dxy distribution for muons
+    hists_["muonDxy_"] = ibooker.book1D("MuonDxy", "d_{xy}(#mu)", 100, -0.05, 0.05);
 
     // set axes titles for dxy for muons
     hists_["muonDelXY_"]->setAxisTitle("x [cm]", 1);
     hists_["muonDelXY_"]->setAxisTitle("y [cm]", 2);
+    hists_["muonDxy_"]->setAxisTitle("d_{xy} [cm]", 1);
 
     if (verbosity_ == VERBOSE)
       return;
@@ -446,6 +449,12 @@ namespace SingleTopTChannelLepton {
       if (muon->isGlobalMuon()) {
         fill("muonDelZ_", muon->innerTrack()->vz());  // CB using inner track!
         fill("muonDelXY_", muon->innerTrack()->vx(), muon->innerTrack()->vy());
+
+        // d_xy distribution
+        if (muon->muonBestTrack().isNonnull()) {
+            double dxy = muon->muonBestTrack()->dxy(Pvertex.position());
+            fill("muonDxy_", dxy);
+        }
 
         // apply preselection
         if ((!muonSelect_ || (*muonSelect_)(*muon))) {

--- a/DQM/Physics/src/SingleTopTChannelLeptonDQM_miniAOD.cc
+++ b/DQM/Physics/src/SingleTopTChannelLeptonDQM_miniAOD.cc
@@ -517,11 +517,11 @@ namespace SingleTopTChannelLepton_miniAOD {
 
         // d_xy distribution
         if (muon->muonBestTrack().isNonnull()) {
-            double dxy = muon->dB(pat::Muon::PV2D);
-            fill("muonDxy_", dxy);
+          double dxy = muon->dB(pat::Muon::PV2D);
+          fill("muonDxy_", dxy);
 
-            double dxyError = muon->edB(pat::Muon::PV2D);
-            fill("muonDxyError_",dxyError);
+          double dxyError = muon->edB(pat::Muon::PV2D);
+          fill("muonDxyError_", dxyError);
         }
 
         // apply preselection loose muon

--- a/DQM/Physics/src/SingleTopTChannelLeptonDQM_miniAOD.cc
+++ b/DQM/Physics/src/SingleTopTChannelLeptonDQM_miniAOD.cc
@@ -176,7 +176,7 @@ namespace SingleTopTChannelLepton_miniAOD {
     // instantaneous luminosity
     //hists_["InstLumi_"] = ibooker.book1D("InstLumi", "Inst. Lumi.", 100, 0., 1.e3);
     // number of selected primary vertices
-    hists_["pvMult_"] = ibooker.book1D("PvMult", "N_{good pvs}", 50, 0., 50.);
+    hists_["pvMult_"] = ibooker.book1D("PvMult", "N_{good pvs}", 50, 0., 100.);
     // pt of the leading muon
     hists_["muonPt_"] = ibooker.book1D("MuonPt", "pt(#mu TightId, TightIso)", 40, 0., 200.);
     // muon multiplicity before std isolation
@@ -274,10 +274,16 @@ namespace SingleTopTChannelLepton_miniAOD {
     hists_["muonDelZ_"] = ibooker.book1D("MuonDelZ", "d_{z}(#mu)", 50, -25., 25.);
     // dxy for muons (to suppress cosmics)
     hists_["muonDelXY_"] = ibooker.book2D("MuonDelXY", "d_{xy}(#mu)", 50, -0.1, 0.1, 50, -0.1, 0.1);
+    // dxy distribution for muons
+    hists_["muonDxy_"] = ibooker.book1D("MuonDxy", "d_{xy}(#mu)", 100, -0.05, 0.05);
+    // muon _dxy error
+    hists_["muonDxyError_"] = ibooker.book1D("MuonDxyError", "d_{xy} Error (#mu)", 100, 0., 0.05);
 
     // set axes titles for dxy for muons
     hists_["muonDelXY_"]->setAxisTitle("x [cm]", 1);
     hists_["muonDelXY_"]->setAxisTitle("y [cm]", 2);
+    hists_["muonDxy_"]->setAxisTitle("d_{xy} [cm]", 1);
+    hists_["muonDxyError_"]->setAxisTitle("d_{xy} error [cm]", 1);
 
     if (verbosity_ == VERBOSE)
       return;
@@ -508,6 +514,15 @@ namespace SingleTopTChannelLepton_miniAOD {
       if (muon->isGlobalMuon()) {
         fill("muonDelZ_", muon->innerTrack()->vz());  // CB using inner track!
         fill("muonDelXY_", muon->innerTrack()->vx(), muon->innerTrack()->vy());
+
+        // d_xy distribution
+        if (muon->muonBestTrack().isNonnull()) {
+            double dxy = muon->dB(pat::Muon::PV2D);
+            fill("muonDxy_", dxy);
+
+            double dxyError = muon->edB(pat::Muon::PV2D);
+            fill("muonDxyError_",dxyError);
+        }
 
         // apply preselection loose muon
         if (!muonSelect_ || (*muonSelect_)(*muon)) {

--- a/DQM/Physics/src/TopSingleLeptonDQM.cc
+++ b/DQM/Physics/src/TopSingleLeptonDQM.cc
@@ -5,6 +5,7 @@
 #include "DataFormats/JetReco/interface/PFJet.h"
 #include "DataFormats/Math/interface/deltaR.h"
 #include "JetMETCorrections/Objects/interface/JetCorrectionsRecord.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
 #include <iostream>
 #include <memory>
 
@@ -187,7 +188,7 @@ namespace TopSingleLepton {
     // instantaneous luminosity
     // hists_["InstLumi_"] = ibooker.book1D("InstLumi", "Inst. Lumi.", 100, 0., 1.e3);
     // number of selected primary vertices
-    hists_["pvMult_"] = ibooker.book1D("PvMult", "N_{good pvs}", 50, 0., 50.);
+    hists_["pvMult_"] = ibooker.book1D("PvMult", "N_{good pvs}", 50, 0., 100.);
     // pt of the leading muon
     hists_["muonPt_"] = ibooker.book1D("MuonPt", "pt(#mu TightId, TightIso)", 40, 0., 200.);
     // muon multiplicity after  tight Id
@@ -271,10 +272,13 @@ namespace TopSingleLepton {
     hists_["muonDelZ_"] = ibooker.book1D("MuonDelZ", "d_{z}(#mu)", 50, -25., 25.);
     // dxy for muons (to suppress cosmics)
     hists_["muonDelXY_"] = ibooker.book2D("MuonDelXY", "d_{xy}(#mu)", 50, -0.1, 0.1, 50, -0.1, 0.1);
-
+    // dxy distribution for muons
+    hists_["muonDxy_"] = ibooker.book1D("MuonDxy", "d_{xy}(#mu)", 100, -0.05, 0.05);
+    
     // set axes titles for dxy for muons
     hists_["muonDelXY_"]->setAxisTitle("x [cm]", 1);
     hists_["muonDelXY_"]->setAxisTitle("y [cm]", 2);
+    hists_["muonDxy_"]->setAxisTitle("d_{xy} [cm]", 1);
 
     if (verbosity_ == VERBOSE)
       return;
@@ -458,6 +462,12 @@ namespace TopSingleLepton {
       if (muon->isGlobalMuon()) {
         fill("muonDelZ_", muon->innerTrack()->vz());  // CB using inner track!
         fill("muonDelXY_", muon->innerTrack()->vx(), muon->innerTrack()->vy());
+
+        // d_xy distribution
+        if (muon->muonBestTrack().isNonnull()) {
+            double dxy = muon->muonBestTrack()->dxy(Pvertex.position());
+            fill("muonDxy_", dxy);
+        }
 
         // apply preselection
         if ((!muonSelect_ || (*muonSelect_)(*muon))) {

--- a/DQM/Physics/src/TopSingleLeptonDQM.cc
+++ b/DQM/Physics/src/TopSingleLeptonDQM.cc
@@ -274,7 +274,7 @@ namespace TopSingleLepton {
     hists_["muonDelXY_"] = ibooker.book2D("MuonDelXY", "d_{xy}(#mu)", 50, -0.1, 0.1, 50, -0.1, 0.1);
     // dxy distribution for muons
     hists_["muonDxy_"] = ibooker.book1D("MuonDxy", "d_{xy}(#mu)", 100, -0.05, 0.05);
-    
+
     // set axes titles for dxy for muons
     hists_["muonDelXY_"]->setAxisTitle("x [cm]", 1);
     hists_["muonDelXY_"]->setAxisTitle("y [cm]", 2);
@@ -465,8 +465,8 @@ namespace TopSingleLepton {
 
         // d_xy distribution
         if (muon->muonBestTrack().isNonnull()) {
-            double dxy = muon->muonBestTrack()->dxy(Pvertex.position());
-            fill("muonDxy_", dxy);
+          double dxy = muon->muonBestTrack()->dxy(Pvertex.position());
+          fill("muonDxy_", dxy);
         }
 
         // apply preselection

--- a/DQM/Physics/src/TopSingleLeptonDQM_miniAOD.cc
+++ b/DQM/Physics/src/TopSingleLeptonDQM_miniAOD.cc
@@ -497,7 +497,8 @@ namespace TopSingleLepton_miniAOD {
       if (muon->isGlobalMuon()) {
         fill("muonDelZ_", muon->innerTrack()->vz());  // CB using inner track!
         fill("muonDelXY_", muon->innerTrack()->vx(), muon->innerTrack()->vy());
-
+        
+        // d_xy distribution
         if (muon->muonBestTrack().isNonnull()) {
           double dxy = muon->dB(pat::Muon::PV2D);
           fill("muonDxy_", dxy);

--- a/DQM/Physics/src/TopSingleLeptonDQM_miniAOD.cc
+++ b/DQM/Physics/src/TopSingleLeptonDQM_miniAOD.cc
@@ -497,15 +497,15 @@ namespace TopSingleLepton_miniAOD {
       if (muon->isGlobalMuon()) {
         fill("muonDelZ_", muon->innerTrack()->vz());  // CB using inner track!
         fill("muonDelXY_", muon->innerTrack()->vx(), muon->innerTrack()->vy());
-        
+
         // d_xy distribution
         if (muon->muonBestTrack().isNonnull()) {
           double dxy = muon->dB(pat::Muon::PV2D);
           fill("muonDxy_", dxy);
 
           double dxyError = muon->edB(pat::Muon::PV2D);
-          fill("muonDxyError_",dxyError);
-      }
+          fill("muonDxyError_", dxyError);
+        }
 
         // apply preselection loose muon
         if (!muonSelect_ || (*muonSelect_)(*muon)) {

--- a/DQM/Physics/src/TopSingleLeptonDQM_miniAOD.cc
+++ b/DQM/Physics/src/TopSingleLeptonDQM_miniAOD.cc
@@ -177,7 +177,7 @@ namespace TopSingleLepton_miniAOD {
     // instantaneous luminosity
     //hists_["InstLumi_"] = ibooker.book1D("InstLumi", "Inst. Lumi.", 100, 0., 1.e3);
     // number of selected primary vertices
-    hists_["pvMult_"] = ibooker.book1D("PvMult", "N_{good pvs}", 50, 0., 50.);
+    hists_["pvMult_"] = ibooker.book1D("PvMult", "N_{good pvs}", 50, 0., 100.);
     // pt of the leading muon
     hists_["muonPt_"] = ibooker.book1D("MuonPt", "pt(#mu TightId, TightIso)", 40, 0., 200.);
     // muon multiplicity before std isolation
@@ -264,10 +264,16 @@ namespace TopSingleLepton_miniAOD {
     hists_["muonDelZ_"] = ibooker.book1D("MuonDelZ", "d_{z}(#mu)", 50, -25., 25.);
     // dxy for muons (to suppress cosmics)
     hists_["muonDelXY_"] = ibooker.book2D("MuonDelXY", "d_{xy}(#mu)", 50, -0.1, 0.1, 50, -0.1, 0.1);
+    // dxy distribution for muons
+    hists_["muonDxy_"] = ibooker.book1D("MuonDxy", "d_{xy}(#mu)", 100, -0.05, 0.05);
+    // muon _dxy error
+    hists_["muonDxyError_"] = ibooker.book1D("MuonDxyError", "d_{xy} Error (#mu)", 100, 0., 0.05);
 
     // set axes titles for dxy for muons
     hists_["muonDelXY_"]->setAxisTitle("x [cm]", 1);
     hists_["muonDelXY_"]->setAxisTitle("y [cm]", 2);
+    hists_["muonDxy_"]->setAxisTitle("d_{xy} [cm]", 1);
+    hists_["muonDxyError_"]->setAxisTitle("d_{xy} error [cm]", 1);
 
     if (verbosity_ == VERBOSE)
       return;
@@ -491,6 +497,14 @@ namespace TopSingleLepton_miniAOD {
       if (muon->isGlobalMuon()) {
         fill("muonDelZ_", muon->innerTrack()->vz());  // CB using inner track!
         fill("muonDelXY_", muon->innerTrack()->vx(), muon->innerTrack()->vy());
+
+        if (muon->muonBestTrack().isNonnull()) {
+          double dxy = muon->dB(pat::Muon::PV2D);
+          fill("muonDxy_", dxy);
+
+          double dxyError = muon->edB(pat::Muon::PV2D);
+          fill("muonDxyError_",dxyError);
+      }
 
         // apply preselection loose muon
         if (!muonSelect_ || (*muonSelect_)(*muon)) {

--- a/DQM/Physics/test/topDQM_harvesting_miniAOD.py
+++ b/DQM/Physics/test/topDQM_harvesting_miniAOD.py
@@ -15,7 +15,7 @@ process.GlobalTag.globaltag = 'MCRUN2_74_V9'
 
 ## input file (adapt input file name correspondingly)
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring("file:topDQM_production.root"),
+    fileNames = cms.untracked.vstring("file:topDQM_production_MINIAOD.root"),
     processingMode = cms.untracked.string('RunsAndLumis')
 )
 
@@ -36,7 +36,7 @@ process.EDMtoMEConverter.convertOnEndRun  = True
 process.dqmSaver.saveByRun      = cms.untracked.int32( -1)
 process.dqmSaver.saveAtJobEnd   = cms.untracked.bool(True)
 process.dqmSaver.forceRunNumber = cms.untracked.int32(  1)
-process.dqmSaver.workflow       = cms.untracked.string('/TopVal/CMSSW_15_0_0_pre1/RECO') ## adapt apropriately
+process.dqmSaver.workflow       = cms.untracked.string('/TopVal/CMSSW_15_0_0_pre1/MINIAODSIM') ## adapt apropriately
 
 
 ## path definitions

--- a/DQM/Physics/test/topDQM_production_cfg.py
+++ b/DQM/Physics/test/topDQM_production_cfg.py
@@ -17,7 +17,7 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring())
 process.source.skipEvents = cms.untracked.uint32(0)
 
-process.source.fileNames = ['root://cmsxrootd.fnal.gov//store/relval/CMSSW_14_2_0_pre3/RelValTTbar_14TeV/GEN-SIM-RECO/PU_140X_mcRun3_2024_realistic_v26_STD_2024_PU-v1/2590000/3c568c90-b6ff-43be-9b24-8b4e9d862185.root']
+process.source.fileNames = ['root://cms-xrd-global.cern.ch//store/relval/CMSSW_15_0_0_pre1/RelValTTbar_14TeV/GEN-SIM-RECO/PU_142X_mcRun3_2025_realistic_v1_STD_2025_PU-v1/2590000/05925bd0-d592-435e-87c1-fd8f4bdbc726.root']
 
 ## number of events
 process.maxEvents = cms.untracked.PSet(

--- a/DQM/Physics/test/topDQM_production_miniAOD.py
+++ b/DQM/Physics/test/topDQM_production_miniAOD.py
@@ -15,7 +15,7 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 
 process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring())
 process.source.skipEvents = cms.untracked.uint32(0)
-process.source.fileNames = ['/store/relval/CMSSW_14_2_0_pre3/RelValTTbar_14TeV/MINIAODSIM/PU_140X_mcRun3_2024_realistic_v26_STD_2024_PU-v1/2590000/a102b4b1-a67d-4b75-ae76-438f4dde5deb.root']
+process.source.fileNames = ['root://cms-xrd-global.cern.ch//store/relval/CMSSW_15_0_0_pre1/RelValTTbar_14TeV/MINIAODSIM/PU_142X_mcRun3_2025_realistic_v1_STD_2025_PU-v1/2590000/9fca2393-d957-4166-8ac6-74aa08c54bcb.root']
 
 ## number of events
 process.maxEvents = cms.untracked.PSet(
@@ -30,7 +30,7 @@ process.load('Configuration/StandardSequences/Reconstruction_cff')
 
 ## output
 process.output = cms.OutputModule("PoolOutputModule",
-  fileName       = cms.untracked.string('topDQM_production.root'),
+  fileName       = cms.untracked.string('topDQM_production_MINIAOD.root'),
   outputCommands = cms.untracked.vstring(
     'drop *_*_*_*',
     'keep *_*_*_TOPDQM',


### PR DESCRIPTION
### **Description of PR**

- The main changes expected include the addition of 1D d_xy histograms for TopSingleElectronMediumDQM, TopSingleMuonMediumDQM, SingleTopElectronMediumDQM, SingleTopMuonMediumDQM and the corresponding miniAOD directories. 

1. For GEN-SIM-RECO directories the relevant histograms were booked and the following code added:

```
// d_xy distribution
if (muon->muonBestTrack().isNonnull()) {
double dxy = muon->muonBestTrack()->dxy(Pvertex.position());
fill("muonDxy_", dxy);
}
```
2. For MINOAOD directories the dB function was used to access the d_xy quantity from <pat::Muon> and since the edB function calculating the error for d_xy also exists it was added as well for completion:

```
// d_xy distribution
if (muon->muonBestTrack().isNonnull()) {
double dxy = muon->dB(pat::Muon::PV2D);
fill("muonDxy_", dxy);

double dxyError = muon->edB(pat::Muon::PV2D);
fill("muonDxyError_",dxyError);
}
```

- Also the range for PvMult plots at the same directories was extended to 100 from 50 for the x-axis.
- An additional harvesting file topDQM_harvesting_miniAOD.py was added to make the process of producing the test files easier and in parallel for miniAOD and GEM-SIM-RECO.
- The input files for topDQM_production_cfg.py and topDQM_production_miniAOD.py have been updated along with the workflows at the corresponding harvesting files.
- This work is a continuation of the updating process of Top DQM code and histograms so there is a minor dependence on previous PRs #46749 and #44299 (#44403 backport).


### **PR validation**

Changes have been made to the following files:

1. DQM/Physics/src/TopSingleLeptonDQM.cc
2. DQM/Physics/src/SingleTopTChannelLeptonDQM.cc
3. DQM/Physics/src/TopSingleLeptonDQM_miniAOD.cc
4. DQM/Physics/src/SingleTopTChannelLeptonDQM_miniAOD.cc
5. DQM/Physics/test/topDQM_harvesting_cfg.py
6. DQM/Physics/test/topDQM_production_cfg.py
7. DQM/Physics/test/topDQM_harvesting_miniAOD.py (new file)
8. DQM/Physics/test/topDQM_production_miniAOD.py

To verify the results of the aforementioned actions the files `DQM/Physics/test/topDQM_production_cfg.py` and `DQM/Physics/test/topDQM_production_miniAOD.py`  were executed with cmsRun to produce .root files that were then used as input for `DQM/Physics/test/topDQM_harvesting_cfg.py` and `DQM/Physics/test/topDQM_harvesting_miniAOD.py`  to produce  trees with the relevant histograms needed that were browsed using the TBrowser root feature. As evidence of the success of the task two of those d_xy histograms (one from TopSingleMuonMediumDQM and the other from SingleTopMuonMediumDQM_miniAOD) are attached on this PR along with one PvMult histogram with the new range.

![dxy_RECO_TopSingleMuonMediumDQM](https://github.com/user-attachments/assets/a5188d8f-8b60-4541-920d-bfbf4a71e5af)
![dxy_MINIAOD_SingleTopMuonMediumDQM](https://github.com/user-attachments/assets/a4d38554-0eb0-4dbd-8650-97c750f90e96)
![canvas](https://github.com/user-attachments/assets/be7d55b7-6d6d-4a4c-a200-8d92e368d77d)


