### PR TITLE
XrdAdaptor: Use inactive sources first before trying to open a new source when handling a failed request

### DIFF
--- a/Utilities/XrdAdaptor/src/XrdRequestManager.cc
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.cc
@@ -839,15 +839,39 @@ void RequestManager::requestFailure(std::shared_ptr<XrdAdaptor::ClientRequest> c
   m_disabledSources.insert(source_ptr);
 
   std::unique_lock<std::recursive_mutex> sentry(m_source_mutex);
+  // Remove the failed source from the container of active sources
   if (auto found = std::ranges::find_if(
-          m_activeSources, [&source_ptr](std::shared_ptr<Source> const &src) { return src.get() == source_ptr.get(); });
+          m_activeSources, [&source_ptr](const std::shared_ptr<Source> &src) { return src.get() == source_ptr.get(); });
       found != m_activeSources.end()) {
     auto oldSources = m_activeSources;
     m_activeSources.erase(found);
     reportSiteChange(oldSources, m_activeSources);
   }
+  // Find a new source to send the request to
+  // - First, if there is another active source, use it
+  // - Then, if there are no active sources, if there are inactive
+  //   sources, use the best inactive source
+  // - Then, if there are no active or inactice sources, try to open a
+  //   new connection for a new source
   std::shared_ptr<Source> new_source;
-  if (m_activeSources.empty()) {
+  if (not m_activeSources.empty()) {
+    new_source = m_activeSources[0];
+  } else if (not m_inactiveSources.empty()) {
+    // similar logic as in checkSourcesImpl()
+    // assume the "sort open delay" doesn't matter in case of a request failure
+    auto bestInactiveSource =
+        std::min_element(m_inactiveSources.begin(),
+                         m_inactiveSources.end(),
+                         [](const std::shared_ptr<Source> &s1, const std::shared_ptr<Source> &s2) {
+                           return s1->getQuality() < s2->getQuality();
+                         });
+    new_source = *bestInactiveSource;
+
+    auto oldSources = m_activeSources;
+    m_activeSources.push_back(*bestInactiveSource);
+    m_inactiveSources.erase(bestInactiveSource);
+    reportSiteChange(oldSources, m_activeSources);
+  } else {
     std::shared_future<std::shared_ptr<Source>> future = m_open_handler->open();
     timespec now;
     GET_CLOCK_MONOTONIC(now);
@@ -891,8 +915,6 @@ void RequestManager::requestFailure(std::shared_ptr<XrdAdaptor::ClientRequest> c
     auto oldSources = m_activeSources;
     m_activeSources.push_back(new_source);
     reportSiteChange(oldSources, m_activeSources);
-  } else {
-    new_source = m_activeSources[0];
   }
   new_source->handle(c_ptr);
 }


### PR DESCRIPTION
#### PR description:

In the context of https://github.com/cms-sw/cmssw/issues/43162 and https://github.com/cms-sw/cmssw/issues/46086#issuecomment-2683002208, this PR changes the XrdAdaptor behavior for request failures. Previously, after disabling the source that resulted the request failure, it passed on the request to another active source, and if there were no active sources, it tried to open a new source. This PR changes to logic to
* Pass request to another active source
* If there are no active sources, pass the request to the best inactive source
* If there are no active or inactive sources, try to open a new source

The first commit generalizes the code where the failed source is removed from the active sources container. I found it confusing that the code checked only the first 2 active sources (even if there would only ever be at most 2 active sources). Admittedly, if there would be more than 2 active sources, the commit would change the behavior, but I would argue for the better.

Resolves https://github.com/cms-sw/framework-team/issues/1306

#### PR validation:

Code compiles.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Possibly to be backported to 15_0_X.