### PR TITLE
[NANOAOD] Add missing trigger filter bits

### DIFF
--- a/DataFormats/NanoAOD/interface/FlatTable.h
+++ b/DataFormats/NanoAOD/interface/FlatTable.h
@@ -44,6 +44,8 @@ namespace nanoaod {
       UInt16,
       Int32,
       UInt32,
+      Int64,
+      UInt64,
       Bool,
       Float,
       Double,
@@ -158,6 +160,10 @@ namespace nanoaod {
         return ColumnType::Int32;
       else if constexpr (std::is_same<T, uint32_t>())
         return ColumnType::UInt32;
+      else if constexpr (std::is_same<T, int64_t>())
+        return ColumnType::Int64;
+      else if constexpr (std::is_same<T, uint64_t>())
+        return ColumnType::UInt64;
       else if constexpr (std::is_same<T, bool>())
         return ColumnType::Bool;
       else if constexpr (std::is_same<T, float>())
@@ -211,6 +217,10 @@ namespace nanoaod {
         return table.int32s_;
       else if constexpr (std::is_same<StorageT, uint32_t>())
         return table.uint32s_;
+      else if constexpr (std::is_same<StorageT, int64_t>())
+        return table.int64s_;
+      else if constexpr (std::is_same<StorageT, uint64_t>())
+        return table.uint64s_;
       else if constexpr (std::is_same<StorageT, float>())
         return table.floats_;
       else if constexpr (std::is_same<StorageT, double>())
@@ -228,6 +238,8 @@ namespace nanoaod {
     std::vector<uint16_t> uint16s_;
     std::vector<int32_t> int32s_;
     std::vector<uint32_t> uint32s_;
+    std::vector<int64_t> int64s_;
+    std::vector<uint64_t> uint64s_;
     std::vector<float> floats_;
     std::vector<double> doubles_;
   };

--- a/DataFormats/NanoAOD/src/FlatTable.cc
+++ b/DataFormats/NanoAOD/src/FlatTable.cc
@@ -28,6 +28,12 @@ void nanoaod::FlatTable::addExtension(const nanoaod::FlatTable& other) {
       case ColumnType::UInt32:
         addColumn<uint32_t>(other.columnName(i), other.columnData<uint32_t>(i), other.columnDoc(i));
         break;
+      case ColumnType::Int64:
+        addColumn<int64_t>(other.columnName(i), other.columnData<int64_t>(i), other.columnDoc(i));
+        break;
+      case ColumnType::UInt64:
+        addColumn<uint64_t>(other.columnName(i), other.columnData<uint64_t>(i), other.columnDoc(i));
+        break;
       case ColumnType::Bool:
         addColumn<bool>(other.columnName(i), other.columnData<bool>(i), other.columnDoc(i));
         break;
@@ -57,6 +63,10 @@ double nanoaod::FlatTable::getAnyValue(unsigned int row, unsigned int column) co
       return *(beginData<int32_t>(column) + row);
     case ColumnType::UInt32:
       return *(beginData<uint32_t>(column) + row);
+    case ColumnType::Int64:
+      return *(beginData<int64_t>(column) + row);
+    case ColumnType::UInt64:
+      return *(beginData<uint64_t>(column) + row);
     case ColumnType::Bool:
       return *(beginData<bool>(column) + row);
     case ColumnType::Float:

--- a/DataFormats/NanoAOD/src/classes_def.xml
+++ b/DataFormats/NanoAOD/src/classes_def.xml
@@ -3,7 +3,8 @@
         <version ClassVersion="3" checksum="3066258528"/>
     </class>
     <class name="std::vector<nanoaod::FlatTable::Column>" />
-    <class name="nanoaod::FlatTable" ClassVersion="7">
+    <class name="nanoaod::FlatTable" ClassVersion="8">
+     <version ClassVersion="8" checksum="62213496"/>
      <version ClassVersion="7" checksum="4155557494"/>
      <version ClassVersion="6" checksum="70963850"/>
      <version ClassVersion="5" checksum="4251670483"/>

--- a/PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h
+++ b/PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h
@@ -228,6 +228,10 @@ public:
         vars_.push_back(std::make_unique<IntVar>(vname, varPSet));
       else if (type == "uint")
         vars_.push_back(std::make_unique<UIntVar>(vname, varPSet));
+      else if (type == "int64")
+        vars_.push_back(std::make_unique<Int64Var>(vname, varPSet));
+      else if (type == "uint64")
+        vars_.push_back(std::make_unique<UInt64Var>(vname, varPSet));
       else if (type == "float")
         vars_.push_back(std::make_unique<FloatVar>(vname, varPSet));
       else if (type == "double")
@@ -264,10 +268,10 @@ public:
     variable.add<std::string>("doc")->setComment("few words description of the branch content");
     variable.addUntracked<bool>("lazyEval", false)
         ->setComment("if true, can use methods of inheriting classes in `expr`. Can cause problems with threading.");
-    variable.ifValue(
-        edm::ParameterDescription<std::string>(
-            "type", "int", true, edm::Comment("the c++ type of the branch in the flat table")),
-        edm::allowedValues<std::string>("int", "uint", "float", "double", "uint8", "int16", "uint16", "bool"));
+    variable.ifValue(edm::ParameterDescription<std::string>(
+                         "type", "int", true, edm::Comment("the c++ type of the branch in the flat table")),
+                     edm::allowedValues<std::string>(
+                         "int", "uint", "int64", "uint64", "float", "double", "uint8", "int16", "uint16", "bool"));
     variable.addOptionalNode(
         edm::ParameterDescription<int>(
             "precision", true, edm::Comment("the precision with which to store the value in the flat table")) xor
@@ -306,6 +310,8 @@ protected:
 
   typedef FuncVariable<T, StringObjectFunction<T>, int32_t> IntVar;
   typedef FuncVariable<T, StringObjectFunction<T>, uint32_t> UIntVar;
+  typedef FuncVariable<T, StringObjectFunction<T>, int64_t> Int64Var;
+  typedef FuncVariable<T, StringObjectFunction<T>, uint64_t> UInt64Var;
   typedef FuncVariable<T, StringObjectFunction<T>, float> FloatVar;
   typedef FuncVariable<T, StringObjectFunction<T>, double> DoubleVar;
   typedef FuncVariable<T, StringObjectFunction<T>, uint8_t> UInt8Var;
@@ -336,6 +342,12 @@ public:
         else if (type == "uint")
           extvars_.push_back(
               std::make_unique<UIntExtVar>(vname, varPSet, this->consumesCollector(), this->skipNonExistingSrc_));
+        else if (type == "int64")
+          extvars_.push_back(
+              std::make_unique<Int64ExtVar>(vname, varPSet, this->consumesCollector(), this->skipNonExistingSrc_));
+        else if (type == "uint64")
+          extvars_.push_back(
+              std::make_unique<UInt64ExtVar>(vname, varPSet, this->consumesCollector(), this->skipNonExistingSrc_));
         else if (type == "float")
           extvars_.push_back(
               std::make_unique<FloatExtVar>(vname, varPSet, this->consumesCollector(), this->skipNonExistingSrc_));
@@ -382,10 +394,10 @@ public:
     edm::ParameterSetDescription extvariable;
     extvariable.add<edm::InputTag>("src")->setComment("valuemap input collection to fill the flat table");
     extvariable.add<std::string>("doc")->setComment("few words description of the branch content");
-    extvariable.ifValue(
-        edm::ParameterDescription<std::string>(
-            "type", "int", true, edm::Comment("the c++ type of the branch in the flat table")),
-        edm::allowedValues<std::string>("int", "uint", "float", "double", "uint8", "int16", "uint16", "bool"));
+    extvariable.ifValue(edm::ParameterDescription<std::string>(
+                            "type", "int", true, edm::Comment("the c++ type of the branch in the flat table")),
+                        edm::allowedValues<std::string>(
+                            "int", "uint", "int64", "uint64", "float", "double", "uint8", "int16", "uint16", "bool"));
     extvariable.addOptionalNode(
         edm::ParameterDescription<int>(
             "precision", true, edm::Comment("the precision with which to store the value in the flat table")) xor
@@ -447,6 +459,8 @@ protected:
 
   typedef ValueMapVariable<T, int32_t> IntExtVar;
   typedef ValueMapVariable<T, uint32_t> UIntExtVar;
+  typedef ValueMapVariable<T, int64_t> Int64ExtVar;
+  typedef ValueMapVariable<T, uint64_t> UInt64ExtVar;
   typedef ValueMapVariable<T, float> FloatExtVar;
   typedef ValueMapVariable<T, double, float> DoubleExtVar;
   typedef ValueMapVariable<T, bool> BoolExtVar;
@@ -471,6 +485,12 @@ public:
       else if (type == "uint")
         this->typedextvars_.push_back(
             std::make_unique<UIntTypedExtVar>(vname, varPSet, this->consumesCollector(), this->skipNonExistingSrc_));
+      else if (type == "int64")
+        this->typedextvars_.push_back(
+            std::make_unique<Int64TypedExtVar>(vname, varPSet, this->consumesCollector(), this->skipNonExistingSrc_));
+      else if (type == "uint64")
+        this->typedextvars_.push_back(
+            std::make_unique<UInt64TypedExtVar>(vname, varPSet, this->consumesCollector(), this->skipNonExistingSrc_));
       else if (type == "float")
         this->typedextvars_.push_back(
             std::make_unique<FloatTypedExtVar>(vname, varPSet, this->consumesCollector(), this->skipNonExistingSrc_));
@@ -528,6 +548,8 @@ public:
 protected:
   typedef TypedValueMapVariable<T, V, StringObjectFunction<V>, int32_t> IntTypedExtVar;
   typedef TypedValueMapVariable<T, V, StringObjectFunction<V>, uint32_t> UIntTypedExtVar;
+  typedef TypedValueMapVariable<T, V, StringObjectFunction<V>, int64_t> Int64TypedExtVar;
+  typedef TypedValueMapVariable<T, V, StringObjectFunction<V>, uint64_t> UInt64TypedExtVar;
   typedef TypedValueMapVariable<T, V, StringObjectFunction<V>, float> FloatTypedExtVar;
   typedef TypedValueMapVariable<T, V, StringObjectFunction<V>, double> DoubleTypedExtVar;
   typedef TypedValueMapVariable<T, V, StringCutObjectSelector<V>, bool> BoolTypedExtVar;
@@ -559,6 +581,10 @@ public:
             coltable.colvars.push_back(std::make_unique<IntVectorVar>(colvarname, colvarPSet));
           else if (type == "uint")
             coltable.colvars.push_back(std::make_unique<UIntVectorVar>(colvarname, colvarPSet));
+          else if (type == "int64")
+            coltable.colvars.push_back(std::make_unique<Int64VectorVar>(colvarname, colvarPSet));
+          else if (type == "uint64")
+            coltable.colvars.push_back(std::make_unique<UInt64VectorVar>(colvarname, colvarPSet));
           else if (type == "float")
             coltable.colvars.push_back(std::make_unique<FloatVectorVar>(colvarname, colvarPSet));
           else if (type == "double")
@@ -700,6 +726,8 @@ protected:
 
   using IntVectorVar = VectorVar<int32_t>;
   using UIntVectorVar = VectorVar<uint32_t>;
+  using Int64VectorVar = VectorVar<int64_t>;
+  using UInt64VectorVar = VectorVar<uint64_t>;
   using FloatVectorVar = VectorVar<float>;
   using DoubleVectorVar = VectorVar<double>;
   using UInt8VectorVar = VectorVar<uint8_t>;

--- a/PhysicsTools/NanoAOD/plugins/NanoAODDQM.cc
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODDQM.cc
@@ -119,6 +119,12 @@ private:
         case FlatTable::ColumnType::UInt32:
           vfill<uint32_t>(table, icol, rowsel);
           break;
+        case FlatTable::ColumnType::Int64:
+          vfill<int64_t>(table, icol, rowsel);
+          break;
+        case FlatTable::ColumnType::UInt64:
+          vfill<uint64_t>(table, icol, rowsel);
+          break;
         case FlatTable::ColumnType::Bool:
           vfill<bool>(table, icol, rowsel);
           break;

--- a/PhysicsTools/NanoAOD/plugins/TableOutputBranches.cc
+++ b/PhysicsTools/NanoAOD/plugins/TableOutputBranches.cc
@@ -29,6 +29,12 @@ void TableOutputBranches::defineBranchesFromFirstEvent(const nanoaod::FlatTable 
       case nanoaod::FlatTable::ColumnType::UInt32:
         m_uint32Branches.emplace_back(var, tab.columnDoc(i), "i");
         break;
+      case nanoaod::FlatTable::ColumnType::Int64:
+        m_int64Branches.emplace_back(var, tab.columnDoc(i), "L");
+        break;
+      case nanoaod::FlatTable::ColumnType::UInt64:
+        m_uint64Branches.emplace_back(var, tab.columnDoc(i), "l");
+        break;
       case nanoaod::FlatTable::ColumnType::Bool:
         m_uint8Branches.emplace_back(var, tab.columnDoc(i), "O");
         break;
@@ -67,6 +73,8 @@ void TableOutputBranches::branch(TTree &tree) {
                                                 &m_uint16Branches,
                                                 &m_int32Branches,
                                                 &m_uint32Branches,
+                                                &m_int64Branches,
+                                                &m_uint64Branches,
                                                 &m_floatBranches,
                                                 &m_doubleBranches}) {
     for (auto &pair : *branches) {
@@ -121,6 +129,10 @@ void TableOutputBranches::fill(const edm::OccurrenceForOutput &iWhatever, TTree 
     fillColumn<int32_t>(pair, tab);
   for (auto &pair : m_uint32Branches)
     fillColumn<uint32_t>(pair, tab);
+  for (auto &pair : m_int64Branches)
+    fillColumn<int64_t>(pair, tab);
+  for (auto &pair : m_uint64Branches)
+    fillColumn<uint64_t>(pair, tab);
   for (auto &pair : m_floatBranches)
     fillColumn<float>(pair, tab);
   for (auto &pair : m_doubleBranches)

--- a/PhysicsTools/NanoAOD/plugins/TableOutputBranches.h
+++ b/PhysicsTools/NanoAOD/plugins/TableOutputBranches.h
@@ -47,6 +47,8 @@ private:
   std::vector<NamedBranchPtr> m_uint16Branches;
   std::vector<NamedBranchPtr> m_int32Branches;
   std::vector<NamedBranchPtr> m_uint32Branches;
+  std::vector<NamedBranchPtr> m_int64Branches;
+  std::vector<NamedBranchPtr> m_uint64Branches;
   std::vector<NamedBranchPtr> m_floatBranches;
   std::vector<NamedBranchPtr> m_doubleBranches;
   bool m_branchesBooked;

--- a/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
@@ -981,7 +981,9 @@ nanoDQM = DQMEDAnalyzer("NanoAODDQM",
                 MHT = cms.string('id == 4'),
                 Muon = cms.string('id == 13'),
                 Photon = cms.string('id == 22'),
-                Tau = cms.string('id == 15')
+                Tau = cms.string('id == 15'),
+                FatJet = cms.string('id == 6'),
+                BoostedTau = cms.string('id == 1515'),
             ),
             plots = cms.VPSet(
                 Count1D('_size', 28, -0.5, 27.5),

--- a/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
@@ -986,7 +986,7 @@ nanoDQM = DQMEDAnalyzer("NanoAODDQM",
             plots = cms.VPSet(
                 Count1D('_size', 28, -0.5, 27.5),
                 Plot1D('eta', 'eta', 20, -5, 5, 'eta'),
-                Plot1D('filterBits', 'filterBits', 31, 0, 31, 'extra bits of associated information, object- and era-dependent: see branch documentation', bitset=True),
+                Plot1D('filterBits', 'filterBits', 64, 0, 64, 'extra bits of associated information, object- and era-dependent: see branch documentation', bitset=True),
                 Plot1D('id', 'id', 20, 0, 30, 'ID of the object: 11 = Electron (PixelMatched e/gamma), 22 = Photon (PixelMatch-vetoed e/gamma), 13 = Muon, 14 = Tau, 1 = Jet, 2 = MET, 3 = HT, 4 = MHT'),
                 Plot1D('l1charge', 'l1charge', 3, -1.5, 1.5, 'charge of associated L1 seed'),
                 Plot1D('l1iso', 'l1iso', 4, -0.5, 3.5, 'iso of associated L1 seed'),

--- a/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
+++ b/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
@@ -77,7 +77,8 @@ triggerObjectTable = triggerObjectTableProducer.clone(
                 mksel("filter('hltEle*CaloIdLMWPMS2Filter')","2e (CaloIdL_MW seeded)"),
                 mksel("filter('hltDiEle*CaloIdLMWPMS2UnseededFilter')","2e (CaloIdL_MW unseeded)"),
                 mksel("filter('hlt*OverlapFilterIsoEle*ETau*PNet*Tau*')", "1e-1tau PNet"),
-                mksel("filter('hltEle30WPTightGsfTrackIsoFilter')","1e (HLT30WPTightGSfTrackIso)")
+                mksel("filter('hltEle30WPTightGsfTrackIsoFilter')","1e (HLT30WPTightGSfTrackIso)"),
+                mksel("filter('hltEle*erWPTightGsfTrackIsoFilterNoRhoCorrectionForVBF')", "WPTightGsfTrackIso for VBF"),
                 )
         ),
         Photon = cms.PSet(
@@ -104,7 +105,8 @@ triggerObjectTable = triggerObjectTableProducer.clone(
                 mksel("filter('hltEG22Iso60CaloId15b35eHE12R9Id50b80eTrackIsoUnseededLastFilter')","hltEG22Iso60CaloId15b35eHE12R9Id50b80eTrackIsoUnseededLastFilter"),
                 mksel("filter('hltEG22R9Id85b90eHE12R9Id50b80eR9UnseededLastFilter')","hltEG22R9Id85b90eHE12R9Id50b80eR9UnseededLastFilter"),
                 mksel("filter('hltEG30Iso60CaloId15b35eR9Id50b90eHE12b10eR9Id50b80eEcalIsoFilter')","hltEG30Iso60CaloId15b35eR9Id50b90eHE12b10eR9Id50b80eEcalIsoFilter"),
-                mksel("filter('hltEG18TrackIso60Iso60CaloId15b35eR9Id50b90eHE12b10eR9Id50b80eTrackIsoUnseededFilter')","hltEG18TrackIso60Iso60CaloId15b35eR9Id50b90eHE12b10eR9Id50b80eTrackIsoUnseededFilter")
+                mksel("filter('hltEG18TrackIso60Iso60CaloId15b35eR9Id50b90eHE12b10eR9Id50b80eTrackIsoUnseededFilter')","hltEG18TrackIso60Iso60CaloId15b35eR9Id50b90eHE12b10eR9Id50b80eTrackIsoUnseededFilter"),
+                mksel("filter('hltEG*L1VBFLooseIsoEGHEFilter')", "hltEG*L1VBFLooseIsoEGHEFilter"),
             )
         ),
         Muon = cms.PSet(
@@ -172,13 +174,14 @@ triggerObjectTable = triggerObjectTableProducer.clone(
         ),
         BoostedTau = cms.PSet(
             id = cms.int32(1515),
-            sel = cms.string("type(85) && pt > 120 && coll('hltAK8PFJetsCorrected') && filter('hltAK8SinglePFJets*SoftDropMass40*ParticleNetTauTau')"),
+            sel = cms.string("type(85) && pt > 120 && filter('*TauTau*')"),
             l1seed = cms.string("type(-99)"), l1deltaR = cms.double(0.3),
             l2seed = cms.string("type(85)  && coll('hltAK8CaloJetsCorrectedIDPassed')"),  l2deltaR = cms.double(0.3),
             skipObjectsNotPassingQualityBits = cms.bool(True),
             qualityBits = cms.VPSet(
-                mksel("filter('hltAK8SinglePFJets*SoftDropMass40*ParticleNetTauTau')","HLT_AK8PFJetX_SoftDropMass40_PFAK8ParticleNetTauTau0p30"),
-                mksel(["hltAK8SinglePFJets230SoftDropMass40PNetTauTauTag0p03"])
+                mksel("filter('hltAK8SinglePFJets*SoftDropMass*ParticleNetTauTau0p30')","HLT_AK8PFJetX_SoftDropMassY_PFAK8ParticleNetTauTau0p30"),
+                mksel("filter('hltAK8SinglePFJets*SoftDropMass*PNetTauTauTag0p03')","HLT_AK8PFJetX_SoftDropMassY_PNetTauTau0p03"),
+                mksel("filter('hltAK8SinglePFJets*SoftDropMass*PNetTauTauTag0p05')","HLT_AK8PFJetX_SoftDropMassY_PNetTauTau0p05"),
             )
         ),
         Jet = cms.PSet(
@@ -219,6 +222,17 @@ triggerObjectTable = triggerObjectTableProducer.clone(
                 mksel(["hlt2PFCentralJetTightIDPt30","hltPF2CentralJetTightIDPt30"]), # 28
                 mksel(["hlt1PFCentralJetTightIDPt60"]), # 29
                 mksel(["hltPF2CentralJetPt30PNet2BTagMean0p50"]), # 30
+                mksel(["hlt4PFCentralJetPt25"]),  # 31, for HLT_PFHT250_QuadPFJet25_PNet1BTag0p20_PNet1Tauh0p50_v
+                mksel(["hltPFCentralJetNoIDPt25PNet1BTag0p20"]),  # 32, for HLT_PFHT250_QuadPFJet25_PNet1BTag0p20_PNet1Tauh0p50_v
+                mksel(["hltPFCentralJetNoIDPt25PNet1TauHTag0p50"]),  # 33, for HLT_PFHT250_QuadPFJet25_PNet1BTag0p20_PNet1Tauh0p50_v
+                mksel(["hlt4PFCentralJetTightIDPt25"]),  # 34, for HLT_PFHT250_QuadPFJet25_PNet2BTagMean0p55_v
+                mksel(["hltPFCentralJetPt25PNet2BTagMean0p55"]),  # 35, for HLT_PFHT250_QuadPFJet25_PNet2BTagMean0p55_v
+                mksel(["hltL1PFJetCategoriesVBFinclLoose", "hltL1PFJetCategoriesVBFinclLooseTripleJet", "hltL1PFJetCategoriesVBFinclTight1050"]),  # 36, for VBF inclusive
+                mksel(["hltL1PFJetCategoriesVBFdijetQuadjet", "hltL1PFJetCategoriesVBFdijetFivejets", "hltL1PFJetCategoriesVBFdijetSixjets", "hltL1PFJetCategoriesVBFdijetTightQuadjet800"]),  # 37, for VBF+dijet
+                mksel(["hltL1PFJetCategoriesVBFMET", "hltL1PFJetCategoriesVBFMETTripleJet", "hltL1PFJetCategoriesVBFMETTight650"]),  # 38, for VBF+MET
+                mksel(["hltL1PFJetCategoriesVBFMu", "hltL1PFJetCategoriesVBFMuTripleJet", "hltL1PFJetCategoriesVBFMuTight750"]),  # 39, for VBF+mu
+                mksel(["hltOverlapFilterDoublePFJet45Photon12", "hltOverlapFilterDoublePFJet45Photon17", "hltDiPFJet50Photon22OverlapFilter"]),  # 40, for VBF+gamma
+                mksel(["hltOverlapFilterDoublePFJet45Ele12", "hltOverlapFilterDoublePFJet45Ele17", "hltDiPFJet50Ele22OverlapFilter"]),  # 41, for VBF+e
             ),
         ),
         FatJet = cms.PSet(
@@ -236,6 +250,7 @@ triggerObjectTable = triggerObjectTableProducer.clone(
                        "hltAK8SinglePFJets275SoftDropMass40BTagParticleNetBB0p35"]), # 12 if nothing below is fired, #28 if also "hltAK8DoublePFJetSDModMass30", #60 if also "hltAK8DoublePFJetSDModMass50"
                 mksel(["hltAK8DoublePFJetSDModMass30"]), # 16 if onthing else (except #1), 20 if also #4, 28 if also #12
                 mksel(["hltAK8DoublePFJetSDModMass50"]), # 48 if also (obviously) "hltAK8DoublePFJetSDModMass30", 52 if also #4, #60 if all above
+                mksel(["hltAK8SinglePFJets*SoftDropMass*PNetBBTag0p06"]),
                 )
         ),
         MET = cms.PSet(

--- a/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
+++ b/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
@@ -54,7 +54,7 @@ triggerObjectTable = triggerObjectTableProducer.clone(
         Electron = cms.PSet(
             doc = cms.string("PixelMatched e/gamma"), # this may also select photons!
             id = cms.int32(11),
-            sel = cms.string("type(92) && pt > 7 && (coll('hltEgammaCandidates') || coll('hltEgammaCandidatesUnseeded')) && (filter('*PixelMatchFilter') || filter('*PixelMatchUnseededFilter'))"),
+            sel = cms.string("type(92) && pt > 7 && (coll('hltEgammaCandidates') || coll('hltEgammaCandidatesUnseeded')) && (filter('*PixelMatchFilter*') || filter('*PixelMatchUnseededFilter'))"),
             l1seed = cms.string("type(-98)"),  l1deltaR = cms.double(0.3),
             #l2seed = cms.string("type(92) && coll('')"),  l2deltaR = cms.double(0.5),
             skipObjectsNotPassingQualityBits = cms.bool(True),

--- a/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
+++ b/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
@@ -233,6 +233,10 @@ triggerObjectTable = triggerObjectTableProducer.clone(
                 mksel(["hltL1PFJetCategoriesVBFMu", "hltL1PFJetCategoriesVBFMuTripleJet", "hltL1PFJetCategoriesVBFMuTight750"]),  # 39, for VBF+mu
                 mksel(["hltOverlapFilterDoublePFJet45Photon12", "hltOverlapFilterDoublePFJet45Photon17", "hltDiPFJet50Photon22OverlapFilter"]),  # 40, for VBF+gamma
                 mksel(["hltOverlapFilterDoublePFJet45Ele12", "hltOverlapFilterDoublePFJet45Ele17", "hltDiPFJet50Ele22OverlapFilter"]),  # 41, for VBF+e
+                mksel("min(path('HLT_PFJet*_v*'),filter('hltSinglePFJet*'))", "SinglePFJetX"),  # 42
+                mksel("min(path('HLT_PFJetFwd*_v*'),filter('hltSinglePFFwdJet*'))", "SinglePFJetFwdX"),  # 43
+                mksel("min(path('HLT_DiPFJetAve*_v*'),filter('hltDiPFJetAve*'))", "DiPFJetAveX"),  # 44
+                mksel("min(path('HLT_DiPFJetAve*_HFJEC_v*'),filter('hltDiPFJetAve*ForHFJEC*'))", "DiPFJetAveX_HFJEC"),  # 45
             ),
         ),
         FatJet = cms.PSet(


### PR DESCRIPTION
#### PR description:

This PR adds missing trigger filter bits (mostly for the `ParkingVBF` and `ParkingHH` HLT paths) in 2024 datasets, based on the report from https://cms-talk.web.cern.ch/t/additional-nanoaod-trigger-filter-bits/118040. 

To be able to store more than 32 filter bits, the data type of `TrigObj_filterBits` is changed from `Int_t` to `ULong64_t`.

Further updates:
 - added more filterBits for `Jet` trigobjs needed by JME
 - fixed the selection for `Electron` trigobjs as reported on https://cms-talk.web.cern.ch/t/additional-nanoaod-trigger-filter-bits/118040/9

#### PR validation:

`runTheMatrix.py -w nano --ibeos -l 2500.311`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 15_0_X for MiniAODv6+NanoAODv15 campaign.