### PR TITLE
Improve BDT in L1Trigger/L1TMuonEndCap

### DIFF
--- a/L1Trigger/L1TMuonEndCap/interface/bdt/Forest.h
+++ b/L1Trigger/L1TMuonEndCap/interface/bdt/Forest.h
@@ -3,6 +3,7 @@
 #ifndef L1Trigger_L1TMuonEndCap_emtf_Forest
 #define L1Trigger_L1TMuonEndCap_emtf_Forest
 
+#include <memory>
 #include "Tree.h"
 #include "LossFunctions.h"
 #include "CondFormats/L1TObjects/interface/L1TMuonEndCapForest.h"
@@ -14,28 +15,29 @@ namespace emtf {
     // Constructor(s)/Destructor
     Forest();
     Forest(std::vector<Event*>& trainingEvents);
-    ~Forest();
+    ~Forest() = default;
 
     Forest(const Forest& forest);
     Forest& operator=(const Forest& forest);
     Forest(Forest&& forest) = default;
+    Forest& operator=(Forest&& forest) = default;
 
     // Get/Set
     void setTrainingEvents(std::vector<Event*>& trainingEvents);
     std::vector<Event*> getTrainingEvents();
 
     // Returns the number of trees in the forest.
-    unsigned int size();
+    unsigned int size() const;
 
     // Get info on variable importance.
-    void rankVariables(std::vector<int>& rank);
+    void rankVariables(std::vector<int>& rank) const;
 
     // Output the list of split values used for each variable.
-    void saveSplitValues(const char* savefilename);
+    void saveSplitValues(const char* savefilename) const;
 
     // Helpful operations
-    void listEvents(std::vector<std::vector<Event*> >& e);
-    void sortEventVectors(std::vector<std::vector<Event*> >& e);
+    void listEvents(std::vector<std::vector<Event*>>& e) const;
+    void sortEventVectors(std::vector<std::vector<Event*>>& e) const;
     void generate(int numTrainEvents, int numTestEvents, double sigma);
     void loadForestFromXML(const char* directory, unsigned int numTrees);
     void loadFromCondPayload(const L1TMuonEndCapForest::DForest& payload);
@@ -63,9 +65,9 @@ namespace emtf {
     Tree* getTree(unsigned int i);
 
   private:
-    std::vector<std::vector<Event*> > events;
-    std::vector<std::vector<Event*> > subSample;
-    std::vector<Tree*> trees;
+    std::vector<std::vector<Event*>> events;
+    std::vector<std::vector<Event*>> subSample;
+    std::vector<std::unique_ptr<Tree>> trees;
   };
 
 }  // namespace emtf

--- a/L1Trigger/L1TMuonEndCap/interface/bdt/Node.h
+++ b/L1Trigger/L1TMuonEndCap/interface/bdt/Node.h
@@ -5,6 +5,7 @@
 
 #include <string>
 #include <vector>
+#include <memory>
 #include "Event.h"
 
 namespace emtf {
@@ -13,43 +14,46 @@ namespace emtf {
   public:
     Node();
     Node(std::string cName);
-    ~Node();
+    ~Node() = default;
 
     Node(Node &&) = default;
     Node(const Node &) = delete;
     Node &operator=(const Node &) = delete;
 
-    std::string getName();
+    std::string getName() const;
     void setName(std::string sName);
 
-    double getErrorReduction();
+    double getErrorReduction() const;
     void setErrorReduction(double sErrorReduction);
 
     Node *getLeftDaughter();
-    void setLeftDaughter(Node *sLeftDaughter);
+    const Node *getLeftDaughter() const;
+    void setLeftDaughter(std::unique_ptr<Node> sLeftDaughter);
 
+    const Node *getRightDaughter() const;
     Node *getRightDaughter();
-    void setRightDaughter(Node *sLeftDaughter);
+    void setRightDaughter(std::unique_ptr<Node> sLeftDaughter);
 
     Node *getParent();
+    const Node *getParent() const;
     void setParent(Node *sParent);
 
-    double getSplitValue();
+    double getSplitValue() const;
     void setSplitValue(double sSplitValue);
 
-    int getSplitVariable();
+    int getSplitVariable() const;
     void setSplitVariable(int sSplitVar);
 
-    double getFitValue();
+    double getFitValue() const;
     void setFitValue(double sFitValue);
 
-    double getTotalError();
+    double getTotalError() const;
     void setTotalError(double sTotalError);
 
-    double getAvgError();
+    double getAvgError() const;
     void setAvgError(double sAvgError);
 
-    int getNumEvents();
+    int getNumEvents() const;
     void setNumEvents(int sNumEvents);
 
     std::vector<std::vector<Event *> > &getEvents();
@@ -64,8 +68,8 @@ namespace emtf {
   private:
     std::string name;
 
-    Node *leftDaughter;
-    Node *rightDaughter;
+    std::unique_ptr<Node> leftDaughter;
+    std::unique_ptr<Node> rightDaughter;
     Node *parent;
 
     double splitValue;

--- a/L1Trigger/L1TMuonEndCap/interface/bdt/Tree.h
+++ b/L1Trigger/L1TMuonEndCap/interface/bdt/Tree.h
@@ -4,6 +4,7 @@
 #define L1Trigger_L1TMuonEndCap_emtf_Tree
 
 #include <list>
+#include <memory>
 #include "Node.h"
 #include "TXMLEngine.h"
 #include "CondFormats/L1TObjects/interface/L1TMuonEndCapForest.h"
@@ -16,14 +17,15 @@ namespace emtf {
   public:
     Tree();
     Tree(std::vector<std::vector<Event*>>& cEvents);
-    ~Tree();
+    ~Tree() = default;
 
     Tree(const Tree& tree);
     Tree& operator=(const Tree& tree);
-    Tree(Tree&& tree) noexcept;
+    Tree(Tree&& tree) noexcept = default;
 
     void setRootNode(Node* sRootNode);
     Node* getRootNode();
+    const Node* getRootNode() const;
 
     void setTerminalNodes(std::list<Node*>& sTNodes);
     std::list<Node*>& getTerminalNodes();
@@ -48,17 +50,17 @@ namespace emtf {
                                       const L1TMuonEndCapForest::DTreeNode& node,
                                       Node* tnode);
 
-    void rankVariables(std::vector<double>& v);
-    void rankVariablesRecursive(Node* node, std::vector<double>& v);
+    void rankVariables(std::vector<double>& v) const;
+    void rankVariablesRecursive(Node* node, std::vector<double>& v) const;
 
-    void getSplitValues(std::vector<std::vector<double>>& v);
-    void getSplitValuesRecursive(Node* node, std::vector<std::vector<double>>& v);
+    void getSplitValues(std::vector<std::vector<double>>& v) const;
+    void getSplitValuesRecursive(Node* node, std::vector<std::vector<double>>& v) const;
 
     double getBoostWeight(void) const { return boostWeight; }
     void setBoostWeight(double wgt) { boostWeight = wgt; }
 
   private:
-    Node* rootNode;
+    std::unique_ptr<Node> rootNode;
     std::list<Node*> terminalNodes;
     int numTerminalNodes;
     double rmsError;
@@ -66,7 +68,7 @@ namespace emtf {
     unsigned xmlVersion;  // affects only XML loading part, save uses an old format and looses the boostWeight
 
     // this is the main recursive workhorse function that compensates for Nodes being non-copyable
-    Node* copyFrom(const Node* local_root);  // no garantees if throws in the process
+    std::unique_ptr<Node> copyFrom(const Node* local_root);  // no garantees if throws in the process
     // a dumb DFS tree traversal
     void findLeafs(Node* local_root, std::list<Node*>& tn);
   };

--- a/L1Trigger/L1TMuonEndCap/src/bdt/Node.cc
+++ b/L1Trigger/L1TMuonEndCap/src/bdt/Node.cc
@@ -54,78 +54,69 @@ Node::Node(std::string cName) {
 }
 
 //////////////////////////////////////////////////////////////////////////
-// _______________________Destructor____________________________________//
-//////////////////////////////////////////////////////////////////////////
-
-Node::~Node() {
-  // Recursively delete all nodes in the tree.
-  if (leftDaughter)
-    delete leftDaughter;
-  if (rightDaughter)
-    delete rightDaughter;
-}
-
-//////////////////////////////////////////////////////////////////////////
 // ______________________Get/Set________________________________________//
 //////////////////////////////////////////////////////////////////////////
 
 void Node::setName(std::string sName) { name = sName; }
 
-std::string Node::getName() { return name; }
+std::string Node::getName() const { return name; }
 
 // ----------------------------------------------------------------------
 
 void Node::setErrorReduction(double sErrorReduction) { errorReduction = sErrorReduction; }
 
-double Node::getErrorReduction() { return errorReduction; }
+double Node::getErrorReduction() const { return errorReduction; }
 
 // ----------------------------------------------------------------------
 
-void Node::setLeftDaughter(Node* sLeftDaughter) { leftDaughter = sLeftDaughter; }
+void Node::setLeftDaughter(std::unique_ptr<Node> sLeftDaughter) { leftDaughter = std::move(sLeftDaughter); }
 
-Node* Node::getLeftDaughter() { return leftDaughter; }
+Node* Node::getLeftDaughter() { return leftDaughter.get(); }
+const Node* Node::getLeftDaughter() const { return leftDaughter.get(); }
 
-void Node::setRightDaughter(Node* sRightDaughter) { rightDaughter = sRightDaughter; }
+void Node::setRightDaughter(std::unique_ptr<Node> sRightDaughter) { rightDaughter = std::move(sRightDaughter); }
 
-Node* Node::getRightDaughter() { return rightDaughter; }
+Node* Node::getRightDaughter() { return rightDaughter.get(); }
+const Node* Node::getRightDaughter() const { return rightDaughter.get(); }
 
 // ----------------------------------------------------------------------
 
 void Node::setParent(Node* sParent) { parent = sParent; }
 
 Node* Node::getParent() { return parent; }
+const Node* Node::getParent() const { return parent; }
 
 // ----------------------------------------------------------------------
 
 void Node::setSplitValue(double sSplitValue) { splitValue = sSplitValue; }
 
-double Node::getSplitValue() { return splitValue; }
+double Node::getSplitValue() const { return splitValue; }
 
 void Node::setSplitVariable(int sSplitVar) { splitVariable = sSplitVar; }
 
-int Node::getSplitVariable() { return splitVariable; }
+int Node::getSplitVariable() const { return splitVariable; }
 
 // ----------------------------------------------------------------------
 
 void Node::setFitValue(double sFitValue) { fitValue = sFitValue; }
 
-double Node::getFitValue() { return fitValue; }
+double Node::getFitValue() const { return fitValue; }
 
 // ----------------------------------------------------------------------
 
 void Node::setTotalError(double sTotalError) { totalError = sTotalError; }
 
-double Node::getTotalError() { return totalError; }
+double Node::getTotalError() const { return totalError; }
 
 void Node::setAvgError(double sAvgError) { avgError = sAvgError; }
 
-double Node::getAvgError() { return avgError; }
+double Node::getAvgError() const { return avgError; }
 
 // ----------------------------------------------------------------------
 
 void Node::setNumEvents(int sNumEvents) { numEvents = sNumEvents; }
 
-int Node::getNumEvents() { return numEvents; }
+int Node::getNumEvents() const { return numEvents; }
 
 // ----------------------------------------------------------------------
 
@@ -252,14 +243,12 @@ void Node::listEvents() {
 
 void Node::theMiracleOfChildBirth() {
   // Create Daughter Nodes
-  Node* left = new Node(name + " left");
-  Node* right = new Node(name + " right");
+  leftDaughter = std::make_unique<Node>(name + " left");
+  rightDaughter = std::make_unique<Node>(name + " right");
 
   // Link the Nodes Appropriately
-  leftDaughter = left;
-  rightDaughter = right;
-  left->setParent(this);
-  right->setParent(this);
+  leftDaughter->setParent(this);
+  rightDaughter->setParent(this);
 }
 
 // ----------------------------------------------------------------------
@@ -280,8 +269,8 @@ void Node::filterEventsToDaughters() {
   unsigned int sv = splitVariable;
   double sp = splitValue;
 
-  Node* left = leftDaughter;
-  Node* right = rightDaughter;
+  Node* left = leftDaughter.get();
+  Node* right = rightDaughter.get();
 
   std::vector<std::vector<Event*> > l(events.size());
   std::vector<std::vector<Event*> > r(events.size());
@@ -320,8 +309,8 @@ Node* Node::filterEventToDaughter(Event* e) {
   unsigned int sv = splitVariable;
   double sp = splitValue;
 
-  Node* left = leftDaughter;
-  Node* right = rightDaughter;
+  Node* left = leftDaughter.get();
+  Node* right = rightDaughter.get();
   Node* nextNode = nullptr;
 
   // Prevent out-of-bounds access


### PR DESCRIPTION
#### PR description:

- fixed memory corruption problems which could lead to double deletes or deletion of random memory locations
- memory handling now done via std::unique_ptr
- improved const correctness

This deletion of memory coming from an uninitialized pointer was found by gcc 14.

#### PR validation:

Code compiles and local tests pass.

resolves https://github.com/cms-sw/framework-team/issues/1307