### PR TITLE
Add default values for ConfDb in TemplatedSecondaryVertexProducer

### DIFF
--- a/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
@@ -1311,8 +1311,8 @@ void TemplatedSecondaryVertexProducer<IPTI, VTX>::fillDescriptions(edm::Configur
   desc.add<edm::InputTag>("extSVCollection", edm::InputTag("secondaryVertices"))
       ->setComment("InputTag for an (optional) external secondary vertex collection.");
   desc.addOptionalNode(edm::ParameterDescription<bool>("useSVClustering", false, true) and
-                           edm::ParameterDescription<std::string>("jetAlgorithm", true) and
-                           edm::ParameterDescription<double>("rParam", true),
+		       edm::ParameterDescription<std::string>("jetAlgorithm", "", true) and
+		       edm::ParameterDescription<double>("rParam", 1.0, true),
                        true)
       ->setComment("Optional ParameterSet to steer any secondary vertex reclustering.");
   desc.addOptional<bool>("useSVMomentum", false)

--- a/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
@@ -1311,8 +1311,8 @@ void TemplatedSecondaryVertexProducer<IPTI, VTX>::fillDescriptions(edm::Configur
   desc.add<edm::InputTag>("extSVCollection", edm::InputTag("secondaryVertices"))
       ->setComment("InputTag for an (optional) external secondary vertex collection.");
   desc.addOptionalNode(edm::ParameterDescription<bool>("useSVClustering", false, true) and
-		       edm::ParameterDescription<std::string>("jetAlgorithm", "", true) and
-		       edm::ParameterDescription<double>("rParam", 1.0, true),
+                           edm::ParameterDescription<std::string>("jetAlgorithm", "", true) and
+                           edm::ParameterDescription<double>("rParam", 1.0, true),
                        true)
       ->setComment("Optional ParameterSet to steer any secondary vertex reclustering.");
   desc.addOptional<bool>("useSVMomentum", false)


### PR DESCRIPTION
#### PR description:

Add default values for ConfDb in TemplatedSecondaryVertexProducer

#### PR validation:

CFI file now contains these parameters with values

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A