### PR TITLE
Add reco::GenParticle collection production from HepMC3 event record

### DIFF
--- a/PhysicsTools/HepMCCandAlgos/BuildFile.xml
+++ b/PhysicsTools/HepMCCandAlgos/BuildFile.xml
@@ -3,6 +3,7 @@
 <use name="DataFormats/HepMCCandidate"/>
 <use name="CommonTools/UtilAlgos"/>
 <use name="hepmc"/>
+<use name="hepmc3"/>
 <use name="eigen"/>
 <use name="CLHEP"/>
 <export>

--- a/PhysicsTools/HepMCCandAlgos/interface/MCTruthHelper.h
+++ b/PhysicsTools/HepMCCandAlgos/interface/MCTruthHelper.h
@@ -659,8 +659,9 @@ template <typename P>
 const HepMC3::GenParticle *MCTruthHelper<P>::mother(const HepMC3::GenParticle &p, unsigned int imoth) const {
   if (numberOfMothers(p) > 0) {
     unsigned int imothi = 0;
-    for (const HepMC3::ConstGenParticlePtr& mother : (p.production_vertex())->particles_in()) {
-      if (imothi == imoth) return mother.get();
+    for (const HepMC3::ConstGenParticlePtr &mother : (p.production_vertex())->particles_in()) {
+      if (imothi == imoth)
+        return mother.get();
       imothi++;
     }
   }
@@ -702,8 +703,9 @@ template <typename P>
 const HepMC3::GenParticle *MCTruthHelper<P>::daughter(const HepMC3::GenParticle &p, unsigned int idau) const {
   if (numberOfDaughters(p) > 0) {
     unsigned int idaui = 0;
-    for (const HepMC3::ConstGenParticlePtr& daughter : (p.end_vertex())->particles_out()) {
-      if (idaui == idau) return daughter.get();
+    for (const HepMC3::ConstGenParticlePtr &daughter : (p.end_vertex())->particles_out()) {
+      if (idaui == idau)
+        return daughter.get();
       idaui++;
     }
   }

--- a/PhysicsTools/HepMCCandAlgos/interface/MCTruthHelper.h
+++ b/PhysicsTools/HepMCCandAlgos/interface/MCTruthHelper.h
@@ -659,7 +659,7 @@ template <typename P>
 const HepMC3::GenParticle *MCTruthHelper<P>::mother(const HepMC3::GenParticle &p, unsigned int imoth) const {
   if (numberOfMothers(p) > 0) {
     unsigned int imothi = 0;
-    for (HepMC3::ConstGenParticlePtr &mother : (p.production_vertex())->particles_in()) {
+    for (HepMC3::ConstGenParticlePtr& mother : (p.production_vertex())->particles_in()) {
       if(imothi == imoth) return mother.get();
       imothi++;
     }
@@ -702,7 +702,7 @@ template <typename P>
 const HepMC3::GenParticle *MCTruthHelper<P>::daughter(const HepMC3::GenParticle &p, unsigned int idau) const {
   if (numberOfDaughters(p) > 0) {
     unsigned int idaui = 0;
-    for (HepMC3::ConstGenParticlePtr &daughter : (p.end_vertex())->particles_out()) {
+    for (HepMC3::ConstGenParticlePtr& daughter : (p.end_vertex())->particles_out()) {
       if(idaui == idau) return daughter.get();
       idaui++;
     }

--- a/PhysicsTools/HepMCCandAlgos/interface/MCTruthHelper.h
+++ b/PhysicsTools/HepMCCandAlgos/interface/MCTruthHelper.h
@@ -659,7 +659,7 @@ template <typename P>
 const HepMC3::GenParticle *MCTruthHelper<P>::mother(const HepMC3::GenParticle &p, unsigned int imoth) const {
   if (numberOfMothers(p) > 0) {
     unsigned int imothi = 0;
-    for (HepMC3::ConstGenParticlePtr& mother : (p.production_vertex())->particles_in()) {
+    for (HepMC3::ConstGenParticlePtr mother : (p.production_vertex())->particles_in()) {
       if(imothi == imoth) return mother.get();
       imothi++;
     }
@@ -702,7 +702,7 @@ template <typename P>
 const HepMC3::GenParticle *MCTruthHelper<P>::daughter(const HepMC3::GenParticle &p, unsigned int idau) const {
   if (numberOfDaughters(p) > 0) {
     unsigned int idaui = 0;
-    for (HepMC3::ConstGenParticlePtr& daughter : (p.end_vertex())->particles_out()) {
+    for (HepMC3::ConstGenParticlePtr daughter : (p.end_vertex())->particles_out()) {
       if(idaui == idau) return daughter.get();
       idaui++;
     }

--- a/PhysicsTools/HepMCCandAlgos/interface/MCTruthHelper.h
+++ b/PhysicsTools/HepMCCandAlgos/interface/MCTruthHelper.h
@@ -659,8 +659,8 @@ template <typename P>
 const HepMC3::GenParticle *MCTruthHelper<P>::mother(const HepMC3::GenParticle &p, unsigned int imoth) const {
   if (numberOfMothers(p) > 0) {
     unsigned int imothi = 0;
-    for (HepMC3::ConstGenParticlePtr mother : (p.production_vertex())->particles_in()) {
-      if(imothi == imoth) return mother.get();
+    for (const HepMC3::ConstGenParticlePtr& mother : (p.production_vertex())->particles_in()) {
+      if (imothi == imoth) return mother.get();
       imothi++;
     }
   }
@@ -702,8 +702,8 @@ template <typename P>
 const HepMC3::GenParticle *MCTruthHelper<P>::daughter(const HepMC3::GenParticle &p, unsigned int idau) const {
   if (numberOfDaughters(p) > 0) {
     unsigned int idaui = 0;
-    for (HepMC3::ConstGenParticlePtr daughter : (p.end_vertex())->particles_out()) {
-      if(idaui == idau) return daughter.get();
+    for (const HepMC3::ConstGenParticlePtr& daughter : (p.end_vertex())->particles_out()) {
+      if (idaui == idau) return daughter.get();
       idaui++;
     }
   }

--- a/PhysicsTools/HepMCCandAlgos/interface/MCTruthHelper.h
+++ b/PhysicsTools/HepMCCandAlgos/interface/MCTruthHelper.h
@@ -657,9 +657,9 @@ const HepMC::GenParticle *MCTruthHelper<P>::mother(const HepMC::GenParticle &p, 
 /////////////////////////////////////////////////////////////////////////////
 template <typename P>
 const HepMC3::GenParticle *MCTruthHelper<P>::mother(const HepMC3::GenParticle &p, unsigned int imoth) const {
-  if(numberOfMothers(p) > 0) {
+  if (numberOfMothers(p) > 0) {
     unsigned int imothi = 0;
-    for (HepMC3::ConstGenParticlePtr mother : (p.production_vertex())->particles_in()) {
+    for (HepMC3::ConstGenParticlePtr &mother : (p.production_vertex())->particles_in()) {
       if(imothi == imoth) return mother.get();
       imothi++;
     }
@@ -700,9 +700,9 @@ const HepMC::GenParticle *MCTruthHelper<P>::daughter(const HepMC::GenParticle &p
 /////////////////////////////////////////////////////////////////////////////
 template <typename P>
 const HepMC3::GenParticle *MCTruthHelper<P>::daughter(const HepMC3::GenParticle &p, unsigned int idau) const {
-  if(numberOfDaughters(p) > 0) {
+  if (numberOfDaughters(p) > 0) {
     unsigned int idaui = 0;
-    for (HepMC3::ConstGenParticlePtr daughter : (p.end_vertex())->particles_out()) {
+    for (HepMC3::ConstGenParticlePtr &daughter : (p.end_vertex())->particles_out()) {
       if(idaui == idau) return daughter.get();
       idaui++;
     }

--- a/PhysicsTools/HepMCCandAlgos/interface/MCTruthHelper.h
+++ b/PhysicsTools/HepMCCandAlgos/interface/MCTruthHelper.h
@@ -6,6 +6,10 @@
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 #include "DataFormats/HepMCCandidate/interface/GenStatusFlags.h"
 
+#include "HepMC3/GenEvent.h"
+#include "HepMC3/GenParticle.h"
+#include "HepMC3/GenVertex.h"
+
 #include <iostream>
 #include <unordered_set>
 
@@ -143,11 +147,17 @@ public:
   //pdgid
   int pdgId(const HepMC::GenParticle &p) const;
 
+  //pdgid
+  int pdgId(const HepMC3::GenParticle &p) const;
+
   //abs(pdgid)
   int absPdgId(const reco::GenParticle &p) const;
 
   //abs(pdgid)
   int absPdgId(const HepMC::GenParticle &p) const;
+
+  //abs(pdgid)
+  int absPdgId(const HepMC3::GenParticle &p) const;
 
   //number of mothers
   unsigned int numberOfMothers(const reco::GenParticle &p) const;
@@ -155,11 +165,17 @@ public:
   //number of mothers
   unsigned int numberOfMothers(const HepMC::GenParticle &p) const;
 
+  //number of mothers
+  unsigned int numberOfMothers(const HepMC3::GenParticle &p) const;
+
   //mother
   const reco::GenParticle *mother(const reco::GenParticle &p, unsigned int imoth = 0) const;
 
   //mother
   const HepMC::GenParticle *mother(const HepMC::GenParticle &p, unsigned int imoth = 0) const;
+
+  //mother
+  const HepMC3::GenParticle *mother(const HepMC3::GenParticle &p, unsigned int imoth = 0) const;
 
   //number of daughters
   unsigned int numberOfDaughters(const reco::GenParticle &p) const;
@@ -167,11 +183,17 @@ public:
   //number of daughters
   unsigned int numberOfDaughters(const HepMC::GenParticle &p) const;
 
+  //number of daughters
+  unsigned int numberOfDaughters(const HepMC3::GenParticle &p) const;
+
   //ith daughter
   const reco::GenParticle *daughter(const reco::GenParticle &p, unsigned int idau) const;
 
   //ith daughter
   const HepMC::GenParticle *daughter(const HepMC::GenParticle &p, unsigned int idau) const;
+
+  //ith daughter
+  const HepMC3::GenParticle *daughter(const HepMC3::GenParticle &p, unsigned int idau) const;
 
   /////////////////////////////////////////////////////////////////////////////
   //Helper function to fill status flags
@@ -578,6 +600,12 @@ int MCTruthHelper<P>::pdgId(const HepMC::GenParticle &p) const {
 
 //////////////////////////////////////////////////////////////
 template <typename P>
+int MCTruthHelper<P>::pdgId(const HepMC3::GenParticle &p) const {
+  return p.pid();
+}
+
+//////////////////////////////////////////////////////////////
+template <typename P>
 int MCTruthHelper<P>::absPdgId(const reco::GenParticle &p) const {
   return std::abs(p.pdgId());
 }
@@ -586,6 +614,12 @@ int MCTruthHelper<P>::absPdgId(const reco::GenParticle &p) const {
 template <typename P>
 int MCTruthHelper<P>::absPdgId(const HepMC::GenParticle &p) const {
   return std::abs(p.pdg_id());
+}
+
+//////////////////////////////////////////////////////////////
+template <typename P>
+int MCTruthHelper<P>::absPdgId(const HepMC3::GenParticle &p) const {
+  return std::abs(p.pid());
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -597,6 +631,12 @@ unsigned int MCTruthHelper<P>::numberOfMothers(const reco::GenParticle &p) const
 /////////////////////////////////////////////////////////////////////////////
 template <typename P>
 unsigned int MCTruthHelper<P>::numberOfMothers(const HepMC::GenParticle &p) const {
+  return p.production_vertex() ? p.production_vertex()->particles_in_size() : 0;
+}
+
+/////////////////////////////////////////////////////////////////////////////
+template <typename P>
+unsigned int MCTruthHelper<P>::numberOfMothers(const HepMC3::GenParticle &p) const {
   return p.production_vertex() ? p.production_vertex()->particles_in_size() : 0;
 }
 
@@ -616,6 +656,19 @@ const HepMC::GenParticle *MCTruthHelper<P>::mother(const HepMC::GenParticle &p, 
 
 /////////////////////////////////////////////////////////////////////////////
 template <typename P>
+const HepMC3::GenParticle *MCTruthHelper<P>::mother(const HepMC3::GenParticle &p, unsigned int imoth) const {
+  if(numberOfMothers(p) > 0) {
+    unsigned int imothi = 0;
+    for (HepMC3::ConstGenParticlePtr mother : (p.production_vertex())->particles_in()) {
+      if(imothi == imoth) return mother.get();
+      imothi++;
+    }
+  }
+  return nullptr;
+}
+
+/////////////////////////////////////////////////////////////////////////////
+template <typename P>
 unsigned int MCTruthHelper<P>::numberOfDaughters(const reco::GenParticle &p) const {
   return p.numberOfDaughters();
 }
@@ -623,6 +676,12 @@ unsigned int MCTruthHelper<P>::numberOfDaughters(const reco::GenParticle &p) con
 /////////////////////////////////////////////////////////////////////////////
 template <typename P>
 unsigned int MCTruthHelper<P>::numberOfDaughters(const HepMC::GenParticle &p) const {
+  return p.end_vertex() ? p.end_vertex()->particles_out_size() : 0;
+}
+
+/////////////////////////////////////////////////////////////////////////////
+template <typename P>
+unsigned int MCTruthHelper<P>::numberOfDaughters(const HepMC3::GenParticle &p) const {
   return p.end_vertex() ? p.end_vertex()->particles_out_size() : 0;
 }
 
@@ -636,6 +695,19 @@ const reco::GenParticle *MCTruthHelper<P>::daughter(const reco::GenParticle &p, 
 template <typename P>
 const HepMC::GenParticle *MCTruthHelper<P>::daughter(const HepMC::GenParticle &p, unsigned int idau) const {
   return *(p.end_vertex()->particles_out_const_begin() + idau);
+}
+
+/////////////////////////////////////////////////////////////////////////////
+template <typename P>
+const HepMC3::GenParticle *MCTruthHelper<P>::daughter(const HepMC3::GenParticle &p, unsigned int idau) const {
+  if(numberOfDaughters(p) > 0) {
+    unsigned int idaui = 0;
+    for (HepMC3::ConstGenParticlePtr daughter : (p.end_vertex())->particles_out()) {
+      if(idaui == idau) return daughter.get();
+      idaui++;
+    }
+  }
+  return nullptr;
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/PhysicsTools/HepMCCandAlgos/plugins/GenParticleProducer.cc
+++ b/PhysicsTools/HepMCCandAlgos/plugins/GenParticleProducer.cc
@@ -111,15 +111,15 @@ public:
 
   bool convertParticle3(reco::GenParticle& cand, const HepMC3::GenParticle* part, const IDto3Charge& id2Charge) const;
   bool fillIndices3(const HepMC3::GenEvent* mc,
-                   std::vector<const HepMC3::GenParticle*>& particles,
-                   std::vector<int>& barCodeVector,
-                   int offset,
-                   std::unordered_map<int, size_t>& barcodes) const;
+                    std::vector<const HepMC3::GenParticle*>& particles,
+                    std::vector<int>& barCodeVector,
+                    int offset,
+                    std::unordered_map<int, size_t>& barcodes) const;
   bool fillDaughters3(reco::GenParticleCollection& cand,
-                     const HepMC3::GenParticle* part,
-                     reco::GenParticleRefProd const& ref,
-                     size_t index,
-                     std::unordered_map<int, size_t>& barcodes) const;
+                      const HepMC3::GenParticle* part,
+                      reco::GenParticleRefProd const& ref,
+                      size_t index,
+                      std::unordered_map<int, size_t>& barcodes) const;
 
 private:
   /// source collection name
@@ -210,7 +210,7 @@ void GenParticleProducer::produce(StreamID, Event& evt, const EventSetup& es) co
   MixCollection<HepMCProduct>* cfhepmcprod = nullptr;
   size_t npiles = 1;
 
-  int ivhepmc=0;
+  int ivhepmc = 0;
   if (useCF_) {
     Handle<CrossingFrame<HepMCProduct>> cf;
     evt.getByToken(mixToken_, cf);
@@ -230,19 +230,17 @@ void GenParticleProducer::produce(StreamID, Event& evt, const EventSetup& es) co
       mc = mcp->GetEvent();
       if (mc == nullptr)
         throw edm::Exception(edm::errors::InvalidReference) << "HepMC has null pointer to GenEvent" << endl;
-      totalSize = mc->particles_size();
       ivhepmc = 2;
+      totalSize = mc->particles_size();
     } else {
       Handle<HepMC3Product> mcp3;
       bool found = evt.getByToken(srcToken3_, mcp3);
       if (!found)
         throw cms::Exception("ProductAbsent") << "No HepMCProduct, tried to get HepMC3Product, but it is also absent.";
+      ivhepmc = 3;
       mc3 = new HepMC3::GenEvent();
       mc3->read_data(*mcp3->GetEvent());
       totalSize = (mc3->particles()).size();
-      ivhepmc = 3;
-      std::cout << "GenParticleProducer HepMC version 3, totalsize = " << totalSize << std::endl;
-      //totalSize = 0; // to turn off production
     }
   }
 
@@ -326,10 +324,7 @@ void GenParticleProducer::produce(StreamID, Event& evt, const EventSetup& es) co
     }
   } else {  // Normal way from HepMCProduct or HepMC3Product
 
-    std::cout << "GPProducer case 2, normal way, version of HepMC = " << ivhepmc << std::endl;
-
-    if(ivhepmc == 2) {
-
+    if (ivhepmc == 2) {
       if (totalSize) {
         auto origin = (*mc->vertices_begin())->position();
         xyz0Ptr->SetXYZ(origin.x() * mmToCm, origin.y() * mmToCm, origin.z() * mmToCm);
@@ -356,11 +351,10 @@ void GenParticleProducer::produce(StreamID, Event& evt, const EventSetup& es) co
           }
         }
       }
+    }
 
-    } else { // ivhepmc = 3
-
+    if (ivhepmc == 3) {
       if (totalSize) {
-
         for (HepMC3::GenVertexPtr v : mc3->vertices()) {
           xyz0Ptr->SetXYZ((v->position()).x() * mmToCm, (v->position()).y() * mmToCm, (v->position()).z() * mmToCm);
           *t0Ptr = (v->position()).t() * mmToNs;
@@ -386,15 +380,12 @@ void GenParticleProducer::produce(StreamID, Event& evt, const EventSetup& es) co
             cands[d].setCollisionId(0);
           }
         }
-
       }
     }
-
-
-
   }
 
-  if(ivhepmc == 3) delete mc3;
+  if (ivhepmc == 3)
+    delete mc3;
   evt.put(std::move(candsPtr));
   if (saveBarCodes_)
     evt.put(std::move(barCodeVector));
@@ -427,8 +418,8 @@ bool GenParticleProducer::convertParticle(reco::GenParticle& cand,
 }
 
 bool GenParticleProducer::convertParticle3(reco::GenParticle& cand,
-                                          const HepMC3::GenParticle* part,
-                                          IDto3Charge const& id2Charge) const {
+                                           const HepMC3::GenParticle* part,
+                                           IDto3Charge const& id2Charge) const {
   Candidate::LorentzVector p4(part->momentum());
   int pdgId = part->pdg_id();
   cand.setThreeCharge(id2Charge.chargeTimesThree(pdgId));
@@ -437,7 +428,9 @@ bool GenParticleProducer::convertParticle3(reco::GenParticle& cand,
   cand.setP4(p4);
   cand.setCollisionId(0);
   if (part->production_vertex() != nullptr) {
-    ThreeVector vtx((part->production_vertex()->position()).x(), (part->production_vertex()->position()).y(), (part->production_vertex()->position()).z());
+    ThreeVector vtx((part->production_vertex()->position()).x(),
+                    (part->production_vertex()->position()).y(),
+                    (part->production_vertex()->position()).z());
     Candidate::Point vertex(vtx.x() * mmToCm, vtx.y() * mmToCm, vtx.z() * mmToCm);
     cand.setVertex(vertex);
   } else {
@@ -467,10 +460,10 @@ bool GenParticleProducer::fillDaughters(reco::GenParticleCollection& cands,
 }
 
 bool GenParticleProducer::fillDaughters3(reco::GenParticleCollection& cands,
-                                        const HepMC3::GenParticle* part,
-                                        reco::GenParticleRefProd const& ref,
-                                        size_t index,
-                                        std::unordered_map<int, size_t>& barcodes) const {
+                                         const HepMC3::GenParticle* part,
+                                         reco::GenParticleRefProd const& ref,
+                                         size_t index,
+                                         std::unordered_map<int, size_t>& barcodes) const {
   size_t numberOfMothers = (part->production_vertex())->particles_in_size();
   if (numberOfMothers > 0) {
     for (HepMC3::ConstGenParticlePtr mother : (part->production_vertex())->particles_in()) {
@@ -503,12 +496,12 @@ bool GenParticleProducer::fillIndices(const HepMC::GenEvent* mc,
 }
 
 bool GenParticleProducer::fillIndices3(const HepMC3::GenEvent* mc,
-                                      vector<const HepMC3::GenParticle*>& particles,
-                                      vector<int>& barCodeVector,
-                                      int offset,
-                                      std::unordered_map<int, size_t>& barcodes) const {
+                                       vector<const HepMC3::GenParticle*>& particles,
+                                       vector<int>& barCodeVector,
+                                       int offset,
+                                       std::unordered_map<int, size_t>& barcodes) const {
   size_t idx = offset;
-  for (const auto &p : mc->particles()) {
+  for (const auto& p : mc->particles()) {
     const HepMC3::GenParticle* particle = p.get();
     size_t barCode_this_event = particle->id();
     size_t barCode = barCode_this_event + offset;

--- a/PhysicsTools/HepMCCandAlgos/plugins/GenParticleProducer.cc
+++ b/PhysicsTools/HepMCCandAlgos/plugins/GenParticleProducer.cc
@@ -355,7 +355,7 @@ void GenParticleProducer::produce(StreamID, Event& evt, const EventSetup& es) co
 
     if (ivhepmc == 3) {
       if (totalSize) {
-        for (HepMC3::GenVertexPtr v : mc3->vertices()) {
+        for (const HepMC3::GenVertexPtr& v : mc3->vertices()) {
           xyz0Ptr->SetXYZ((v->position()).x() * mmToCm, (v->position()).y() * mmToCm, (v->position()).z() * mmToCm);
           *t0Ptr = (v->position()).t() * mmToNs;
           break;
@@ -466,7 +466,7 @@ bool GenParticleProducer::fillDaughters3(reco::GenParticleCollection& cands,
                                          std::unordered_map<int, size_t>& barcodes) const {
   size_t numberOfMothers = (part->production_vertex())->particles_in_size();
   if (numberOfMothers > 0) {
-    for (HepMC3::ConstGenParticlePtr mother : (part->production_vertex())->particles_in()) {
+    for (const HepMC3::ConstGenParticlePtr& mother : (part->production_vertex())->particles_in()) {
       size_t m = barcodes.find(mother->id())->second;
       cands[m].addDaughter(GenParticleRef(ref, index));
       cands[index].addMother(GenParticleRef(ref, m));

--- a/PhysicsTools/HepMCCandAlgos/plugins/GenParticleProducer.cc
+++ b/PhysicsTools/HepMCCandAlgos/plugins/GenParticleProducer.cc
@@ -355,7 +355,7 @@ void GenParticleProducer::produce(StreamID, Event& evt, const EventSetup& es) co
 
     if (ivhepmc == 3) {
       if (totalSize) {
-        for (HepMC3::GenVertexPtr v : mc3->vertices()) {
+        for (HepMC3::GenVertexPtr& v : mc3->vertices()) {
           xyz0Ptr->SetXYZ((v->position()).x() * mmToCm, (v->position()).y() * mmToCm, (v->position()).z() * mmToCm);
           *t0Ptr = (v->position()).t() * mmToNs;
           break;
@@ -466,7 +466,7 @@ bool GenParticleProducer::fillDaughters3(reco::GenParticleCollection& cands,
                                          std::unordered_map<int, size_t>& barcodes) const {
   size_t numberOfMothers = (part->production_vertex())->particles_in_size();
   if (numberOfMothers > 0) {
-    for (HepMC3::ConstGenParticlePtr mother : (part->production_vertex())->particles_in()) {
+    for (HepMC3::ConstGenParticlePtr& mother : (part->production_vertex())->particles_in()) {
       size_t m = barcodes.find(mother->id())->second;
       cands[m].addDaughter(GenParticleRef(ref, index));
       cands[index].addMother(GenParticleRef(ref, m));

--- a/PhysicsTools/HepMCCandAlgos/plugins/GenParticleProducer.cc
+++ b/PhysicsTools/HepMCCandAlgos/plugins/GenParticleProducer.cc
@@ -355,7 +355,7 @@ void GenParticleProducer::produce(StreamID, Event& evt, const EventSetup& es) co
 
     if (ivhepmc == 3) {
       if (totalSize) {
-        for (HepMC3::GenVertexPtr& v : mc3->vertices()) {
+        for (HepMC3::GenVertexPtr v : mc3->vertices()) {
           xyz0Ptr->SetXYZ((v->position()).x() * mmToCm, (v->position()).y() * mmToCm, (v->position()).z() * mmToCm);
           *t0Ptr = (v->position()).t() * mmToNs;
           break;
@@ -466,7 +466,7 @@ bool GenParticleProducer::fillDaughters3(reco::GenParticleCollection& cands,
                                          std::unordered_map<int, size_t>& barcodes) const {
   size_t numberOfMothers = (part->production_vertex())->particles_in_size();
   if (numberOfMothers > 0) {
-    for (HepMC3::ConstGenParticlePtr& mother : (part->production_vertex())->particles_in()) {
+    for (HepMC3::ConstGenParticlePtr mother : (part->production_vertex())->particles_in()) {
       size_t m = barcodes.find(mother->id())->second;
       cands[m].addDaughter(GenParticleRef(ref, index));
       cands[index].addMother(GenParticleRef(ref, m));

--- a/PhysicsTools/HepMCCandAlgos/plugins/GenParticleProducer.cc
+++ b/PhysicsTools/HepMCCandAlgos/plugins/GenParticleProducer.cc
@@ -15,6 +15,7 @@
 #include "DataFormats/HepMCCandidate/interface/GenParticleFwd.h"
 #include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/HepMC3Product.h"
 #include "PhysicsTools/HepMCCandAlgos/interface/MCTruthHelper.h"
 #include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
 
@@ -29,6 +30,12 @@ namespace HepMC {
   class GenParticle;
   class GenEvent;
 }  // namespace HepMC
+
+namespace HepMC3 {
+  class GenParticle;
+  class GenVertex;
+  class GenEvent;
+}  // namespace HepMC3
 
 static constexpr int PDGCacheMax = 32768;
 
@@ -91,20 +98,33 @@ public:
   void globalEndRun(edm::Run const&, edm::EventSetup const&) const override {}
 
   bool convertParticle(reco::GenParticle& cand, const HepMC::GenParticle* part, const IDto3Charge& id2Charge) const;
-  bool fillDaughters(reco::GenParticleCollection& cand,
-                     const HepMC::GenParticle* part,
-                     reco::GenParticleRefProd const& ref,
-                     size_t index,
-                     std::unordered_map<int, size_t>& barcodes) const;
   bool fillIndices(const HepMC::GenEvent* mc,
                    std::vector<const HepMC::GenParticle*>& particles,
                    std::vector<int>& barCodeVector,
                    int offset,
                    std::unordered_map<int, size_t>& barcodes) const;
+  bool fillDaughters(reco::GenParticleCollection& cand,
+                     const HepMC::GenParticle* part,
+                     reco::GenParticleRefProd const& ref,
+                     size_t index,
+                     std::unordered_map<int, size_t>& barcodes) const;
+
+  bool convertParticle3(reco::GenParticle& cand, const HepMC3::GenParticle* part, const IDto3Charge& id2Charge) const;
+  bool fillIndices3(const HepMC3::GenEvent* mc,
+                   std::vector<const HepMC3::GenParticle*>& particles,
+                   std::vector<int>& barCodeVector,
+                   int offset,
+                   std::unordered_map<int, size_t>& barcodes) const;
+  bool fillDaughters3(reco::GenParticleCollection& cand,
+                     const HepMC3::GenParticle* part,
+                     reco::GenParticleRefProd const& ref,
+                     size_t index,
+                     std::unordered_map<int, size_t>& barcodes) const;
 
 private:
   /// source collection name
   edm::EDGetTokenT<edm::HepMCProduct> srcToken_;
+  edm::EDGetTokenT<edm::HepMC3Product> srcToken3_;
   std::vector<edm::EDGetTokenT<edm::HepMCProduct>> vectorSrcTokens_;
   edm::EDGetTokenT<CrossingFrame<edm::HepMCProduct>> mixToken_;
   edm::ESGetToken<HepPDT::ParticleDataTable, edm::DefaultRecord> particleTableToken_;
@@ -118,8 +138,9 @@ private:
   bool doSubEvent_;
   bool useCF_;
 
-  MCTruthHelper<HepMC::GenParticle> mcTruthHelper_;
   MCTruthHelper<reco::GenParticle> mcTruthHelperGenParts_;
+  MCTruthHelper<HepMC::GenParticle> mcTruthHelper_;
+  MCTruthHelper<HepMC3::GenParticle> mcTruthHelper3_;
 };
 
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
@@ -135,6 +156,10 @@ private:
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/transform.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "HepMC3/GenEvent.h"
+#include "HepMC3/GenParticle.h"
+#include "HepMC3/GenVertex.h"
 
 #include <fstream>
 #include <algorithm>
@@ -163,8 +188,10 @@ GenParticleProducer::GenParticleProducer(const ParameterSet& cfg)
   if (useCF_)
     mixToken_ =
         mayConsume<CrossingFrame<HepMCProduct>>(InputTag(cfg.getParameter<std::string>("mix"), "generatorSmeared"));
-  else
+  else {
     srcToken_ = mayConsume<HepMCProduct>(cfg.getParameter<InputTag>("src"));
+    srcToken3_ = mayConsume<HepMC3Product>(cfg.getParameter<InputTag>("src"));
+  }
 }
 
 GenParticleProducer::~GenParticleProducer() {}
@@ -179,9 +206,11 @@ void GenParticleProducer::produce(StreamID, Event& evt, const EventSetup& es) co
 
   size_t totalSize = 0;
   const GenEvent* mc = nullptr;
+  HepMC3::GenEvent* mc3 = nullptr;
   MixCollection<HepMCProduct>* cfhepmcprod = nullptr;
   size_t npiles = 1;
 
+  int ivhepmc=0;
   if (useCF_) {
     Handle<CrossingFrame<HepMCProduct>> cf;
     evt.getByToken(mixToken_, cf);
@@ -202,14 +231,25 @@ void GenParticleProducer::produce(StreamID, Event& evt, const EventSetup& es) co
       if (mc == nullptr)
         throw edm::Exception(edm::errors::InvalidReference) << "HepMC has null pointer to GenEvent" << endl;
       totalSize = mc->particles_size();
+      ivhepmc = 2;
     } else {
-      totalSize = 0;
+      Handle<HepMC3Product> mcp3;
+      bool found = evt.getByToken(srcToken3_, mcp3);
+      if (!found)
+        throw cms::Exception("ProductAbsent") << "No HepMCProduct, tried to get HepMC3Product, but it is also absent.";
+      mc3 = new HepMC3::GenEvent();
+      mc3->read_data(*mcp3->GetEvent());
+      totalSize = (mc3->particles()).size();
+      ivhepmc = 3;
+      std::cout << "GenParticleProducer HepMC version 3, totalsize = " << totalSize << std::endl;
+      //totalSize = 0; // to turn off production
     }
   }
 
   // initialise containers
   const size_t size = totalSize;
   vector<const HepMC::GenParticle*> particles(size);
+  vector<const HepMC3::GenParticle*> particles3(size);
   auto candsPtr = std::make_unique<GenParticleCollection>(size);
   auto barCodeVector = std::make_unique<vector<int>>(size);
   std::unique_ptr<math::XYZPointF> xyz0Ptr(new math::XYZPointF(0., 0., 0.));
@@ -284,34 +324,77 @@ void GenParticleProducer::produce(StreamID, Event& evt, const EventSetup& es) co
       }
       offset += num_particles;
     }
-  } else {
-    if (totalSize) {
-      auto origin = (*mc->vertices_begin())->position();
-      xyz0Ptr->SetXYZ(origin.x() * mmToCm, origin.y() * mmToCm, origin.z() * mmToCm);
-      *t0Ptr = origin.t() * mmToNs;
-      fillIndices(mc, particles, *barCodeVector, 0, barcodes);
+  } else {  // Normal way from HepMCProduct or HepMC3Product
 
-      // fill output collection and save association
-      for (size_t i = 0; i < particles.size(); ++i) {
-        const HepMC::GenParticle* part = particles[i];
-        reco::GenParticle& cand = cands[i];
-        // convert HepMC::GenParticle to new reco::GenParticle
-        convertParticle(cand, part, id2Charge);
-        cand.resetDaughters(ref.id());
+    std::cout << "GPProducer case 2, normal way, version of HepMC = " << ivhepmc << std::endl;
+
+    if(ivhepmc == 2) {
+
+      if (totalSize) {
+        auto origin = (*mc->vertices_begin())->position();
+        xyz0Ptr->SetXYZ(origin.x() * mmToCm, origin.y() * mmToCm, origin.z() * mmToCm);
+        *t0Ptr = origin.t() * mmToNs;
+        fillIndices(mc, particles, *barCodeVector, 0, barcodes);
+
+        // fill output collection and save association
+        for (size_t i = 0; i < particles.size(); ++i) {
+          const HepMC::GenParticle* part = particles[i];
+          reco::GenParticle& cand = cands[i];
+          // convert HepMC::GenParticle to new reco::GenParticle
+          convertParticle(cand, part, id2Charge);
+          cand.resetDaughters(ref.id());
+        }
+
+        // fill references to daughters
+        for (size_t d = 0; d < cands.size(); ++d) {
+          const HepMC::GenParticle* part = particles[d];
+          const GenVertex* productionVertex = part->production_vertex();
+          // search barcode map and attach daughters
+          if (productionVertex != nullptr) {
+            fillDaughters(cands, part, ref, d, barcodes);
+            cands[d].setCollisionId(0);
+          }
+        }
       }
 
-      // fill references to daughters
-      for (size_t d = 0; d < cands.size(); ++d) {
-        const HepMC::GenParticle* part = particles[d];
-        const GenVertex* productionVertex = part->production_vertex();
-        // search barcode map and attach daughters
-        if (productionVertex != nullptr)
-          fillDaughters(cands, part, ref, d, barcodes);
-        cands[d].setCollisionId(0);
+    } else { // ivhepmc = 3
+
+      if (totalSize) {
+
+        for (HepMC3::GenVertexPtr v : mc3->vertices()) {
+          xyz0Ptr->SetXYZ((v->position()).x() * mmToCm, (v->position()).y() * mmToCm, (v->position()).z() * mmToCm);
+          *t0Ptr = (v->position()).t() * mmToNs;
+          break;
+        }
+        fillIndices3(mc3, particles3, *barCodeVector, 0, barcodes);
+
+        // fill output collection and save association
+        for (size_t i = 0; i < particles3.size(); ++i) {
+          const HepMC3::GenParticle* part = particles3[i];
+          reco::GenParticle& cand = cands[i];
+          // convert HepMC::GenParticle to new reco::GenParticle
+          convertParticle3(cand, part, id2Charge);
+          cand.resetDaughters(ref.id());
+        }
+
+        // fill references to daughters
+        for (size_t d = 0; d < cands.size(); ++d) {
+          const HepMC3::GenParticle* part = particles3[d];
+          // search barcode map and attach daughters
+          if (part->production_vertex() != nullptr) {
+            fillDaughters3(cands, part, ref, d, barcodes);
+            cands[d].setCollisionId(0);
+          }
+        }
+
       }
     }
+
+
+
   }
 
+  if(ivhepmc == 3) delete mc3;
   evt.put(std::move(candsPtr));
   if (saveBarCodes_)
     evt.put(std::move(barCodeVector));
@@ -343,6 +426,27 @@ bool GenParticleProducer::convertParticle(reco::GenParticle& cand,
   return true;
 }
 
+bool GenParticleProducer::convertParticle3(reco::GenParticle& cand,
+                                          const HepMC3::GenParticle* part,
+                                          IDto3Charge const& id2Charge) const {
+  Candidate::LorentzVector p4(part->momentum());
+  int pdgId = part->pdg_id();
+  cand.setThreeCharge(id2Charge.chargeTimesThree(pdgId));
+  cand.setPdgId(pdgId);
+  cand.setStatus(part->status());
+  cand.setP4(p4);
+  cand.setCollisionId(0);
+  if (part->production_vertex() != nullptr) {
+    ThreeVector vtx((part->production_vertex()->position()).x(), (part->production_vertex()->position()).y(), (part->production_vertex()->position()).z());
+    Candidate::Point vertex(vtx.x() * mmToCm, vtx.y() * mmToCm, vtx.z() * mmToCm);
+    cand.setVertex(vertex);
+  } else {
+    cand.setVertex(Candidate::Point(0, 0, 0));
+  }
+  mcTruthHelper3_.fillGenStatusFlags(*part, cand.statusFlags());
+  return true;
+}
+
 bool GenParticleProducer::fillDaughters(reco::GenParticleCollection& cands,
                                         const HepMC::GenParticle* part,
                                         reco::GenParticleRefProd const& ref,
@@ -362,6 +466,22 @@ bool GenParticleProducer::fillDaughters(reco::GenParticleCollection& cands,
   return true;
 }
 
+bool GenParticleProducer::fillDaughters3(reco::GenParticleCollection& cands,
+                                        const HepMC3::GenParticle* part,
+                                        reco::GenParticleRefProd const& ref,
+                                        size_t index,
+                                        std::unordered_map<int, size_t>& barcodes) const {
+  size_t numberOfMothers = (part->production_vertex())->particles_in_size();
+  if (numberOfMothers > 0) {
+    for (HepMC3::ConstGenParticlePtr mother : (part->production_vertex())->particles_in()) {
+      size_t m = barcodes.find(mother->id())->second;
+      cands[m].addDaughter(GenParticleRef(ref, index));
+      cands[index].addMother(GenParticleRef(ref, m));
+    }
+  }
+  return true;
+}
+
 bool GenParticleProducer::fillIndices(const HepMC::GenEvent* mc,
                                       vector<const HepMC::GenParticle*>& particles,
                                       vector<int>& barCodeVector,
@@ -372,6 +492,25 @@ bool GenParticleProducer::fillIndices(const HepMC::GenEvent* mc,
   for (HepMC::GenEvent::particle_const_iterator p = begin; p != end; ++p) {
     const HepMC::GenParticle* particle = *p;
     size_t barCode_this_event = particle->barcode();
+    size_t barCode = barCode_this_event + offset;
+    if (barcodes.find(barCode) != barcodes.end())
+      throw cms::Exception("WrongReference") << "barcodes are duplicated! " << endl;
+    particles[idx] = particle;
+    barCodeVector[idx] = barCode;
+    barcodes.insert(make_pair(barCode_this_event, idx++));
+  }
+  return true;
+}
+
+bool GenParticleProducer::fillIndices3(const HepMC3::GenEvent* mc,
+                                      vector<const HepMC3::GenParticle*>& particles,
+                                      vector<int>& barCodeVector,
+                                      int offset,
+                                      std::unordered_map<int, size_t>& barcodes) const {
+  size_t idx = offset;
+  for (const auto &p : mc->particles()) {
+    const HepMC3::GenParticle* particle = p.get();
+    size_t barCode_this_event = particle->id();
     size_t barCode = barCode_this_event + offset;
     if (barcodes.find(barCode) != barcodes.end())
       throw cms::Exception("WrongReference") << "barcodes are duplicated! " << endl;

--- a/RecoJets/JetAnalyzers/interface/JetPlotsExample.h
+++ b/RecoJets/JetAnalyzers/interface/JetPlotsExample.h
@@ -10,6 +10,12 @@
 #include <vector>
 #include <map>
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "DataFormats/JetReco/interface/JetCollection.h"
 
 template <class Jet>
 class JetPlotsExample : public edm::one::EDAnalyzer<> {
@@ -18,6 +24,7 @@ public:
 
 private:
   typedef std::vector<Jet> JetCollection;
+  const edm::EDGetTokenT<JetCollection> JetToken_;
   void FillHist1D(const TString& histName, const Double_t& x);
   void beginJob() override;
   void analyze(edm::Event const& e, edm::EventSetup const& iSetup) override;

--- a/RecoJets/JetAnalyzers/src/JetPlotsExample.cc
+++ b/RecoJets/JetAnalyzers/src/JetPlotsExample.cc
@@ -21,7 +21,9 @@ using namespace reco;
 using namespace std;
 ////////////////////////////////////////////////////////////////////////////////////////
 template <class Jet>
-JetPlotsExample<Jet>::JetPlotsExample(edm::ParameterSet const& cfg) {
+JetPlotsExample<Jet>::JetPlotsExample(edm::ParameterSet const& cfg) :
+ JetToken_(consumes<JetCollection>(cfg.getParameter<std::string>("JetAlgorithm")))
+{
   JetAlgorithm = cfg.getParameter<std::string>("JetAlgorithm");
   HistoFileName = cfg.getParameter<std::string>("HistoFileName");
   NJets = cfg.getParameter<int>("NJets");
@@ -46,13 +48,15 @@ template <class Jet>
 void JetPlotsExample<Jet>::analyze(edm::Event const& evt, edm::EventSetup const& iSetup) {
   /////////// Get the jet collection //////////////////////
   Handle<JetCollection> jets;
-  evt.getByLabel(JetAlgorithm, jets);
+  evt.getByToken(JetToken_, jets);
+
   typename JetCollection::const_iterator i_jet;
   int index = 0;
   TString hname;
   /////////// Count the jets in the event /////////////////
   hname = "NumberOfJets";
   FillHist1D(hname, jets->size());
+
   /////////// Fill Histograms for the leading NJet jets ///
   for (i_jet = jets->begin(); i_jet != jets->end() && index < NJets; ++i_jet) {
     hname = "JetPt";

--- a/RecoJets/JetAnalyzers/src/JetPlotsExample.cc
+++ b/RecoJets/JetAnalyzers/src/JetPlotsExample.cc
@@ -21,9 +21,8 @@ using namespace reco;
 using namespace std;
 ////////////////////////////////////////////////////////////////////////////////////////
 template <class Jet>
-JetPlotsExample<Jet>::JetPlotsExample(edm::ParameterSet const& cfg) :
- JetToken_(consumes<JetCollection>(cfg.getParameter<std::string>("JetAlgorithm")))
-{
+JetPlotsExample<Jet>::JetPlotsExample(edm::ParameterSet const& cfg)
+    : JetToken_(consumes<JetCollection>(cfg.getParameter<std::string>("JetAlgorithm"))) {
   JetAlgorithm = cfg.getParameter<std::string>("JetAlgorithm");
   HistoFileName = cfg.getParameter<std::string>("HistoFileName");
   NJets = cfg.getParameter<int>("NJets");


### PR DESCRIPTION
#### PR description:

This PR adds reco::GenParticle collection production from HepMC3 event record. In addition, JetPlotsExample of RecoJets/JetAnalyzers is repared in order to test GenJets production

#### PR validation:

Validated using the full chain GEN-SIM configuration from GeneratorInterface/Pythia8Interface/test and JetPlotsExample
