### PR TITLE
[RNTUPLE_X] Add missing include

### DIFF
--- a/FWIO/RNTuple/plugins/RNTupleInputFile.h
+++ b/FWIO/RNTuple/plugins/RNTupleInputFile.h
@@ -3,6 +3,7 @@
 
 #include "DataFormats/Provenance/interface/IndexIntoFile.h"
 #include "DataFormats/Provenance/interface/ParentageID.h"
+#include "DataFormats/Provenance/interface/BranchIDList.h"
 #include "DataProductsRNTuple.h"
 
 #include "TFile.h"

--- a/FWIO/RNTuple/plugins/RNTupleOutputFile.h
+++ b/FWIO/RNTuple/plugins/RNTupleOutputFile.h
@@ -18,6 +18,7 @@
 #include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
 #include "DataFormats/Provenance/interface/SelectedProducts.h"
 #include "DataFormats/Provenance/interface/StoredProductProvenance.h"
+#include "DataFormats/Provenance/interface/BranchIDList.h"
 
 #include "TFile.h"
 #include "ROOT/RNTuple.hxx"


### PR DESCRIPTION
#### PR description:

Fixes compilation failures in IBs: [link](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_15_1_RNTUPLE_X_2025-03-17-2300/FWIO/RNTuple)

#### PR validation:

Code compiles