### PR TITLE
Fix TICL Energy Regression and PID Model Loading

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltTiclTrackstersCLUE3DHighL1Seeded_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltTiclTrackstersCLUE3DHighL1Seeded_cfi.py
@@ -155,5 +155,5 @@ hltTiclTrackstersCLUE3DHighL1Seeded = cms.EDProducer("TrackstersProducer",
 
 from Configuration.ProcessModifiers.ticl_v5_cff import ticl_v5
 ticl_v5.toModify(hltTiclTrackstersCLUE3DHighL1Seeded.pluginPatternRecognitionByCLUE3D, computeLocalTime = cms.bool(True))
-ticl_v5.toModify(hltTiclTrackstersCLUE3DHighL1Seeded.inferenceAlgo, type = cms.string('TracksterInferenceByPFN'))
+ticl_v5.toModify(hltTiclTrackstersCLUE3DHighL1Seeded, inferenceAlgo = cms.string('TracksterInferenceByPFN'))
 

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltTiclTrackstersCLUE3DHigh_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltTiclTrackstersCLUE3DHigh_cfi.py
@@ -156,4 +156,4 @@ hltTiclTrackstersCLUE3DHigh = cms.EDProducer("TrackstersProducer",
     
 from Configuration.ProcessModifiers.ticl_v5_cff import ticl_v5
 ticl_v5.toModify(hltTiclTrackstersCLUE3DHigh.pluginPatternRecognitionByCLUE3D, computeLocalTime = cms.bool(True))
-ticl_v5.toModify(hltTiclTrackstersCLUE3DHigh.inferenceAlgo, type = cms.string('TracksterInferenceByPFN'))
+ticl_v5.toModify(hltTiclTrackstersCLUE3DHigh, inferenceAlgo = cms.string('TracksterInferenceByPFN'))

--- a/RecoHGCal/TICL/interface/TracksterInferenceByDNN.h
+++ b/RecoHGCal/TICL/interface/TracksterInferenceByDNN.h
@@ -15,11 +15,11 @@ namespace ticl {
     static void fillPSetDescription(edm::ParameterSetDescription& iDesc);
 
   private:
+    const std::unique_ptr<cms::Ort::ONNXRuntime> onnxPIDRuntimeInstance_;
+    const std::unique_ptr<cms::Ort::ONNXRuntime> onnxEnergyRuntimeInstance_;
     const cms::Ort::ONNXRuntime* onnxPIDSession_;
     const cms::Ort::ONNXRuntime* onnxEnergySession_;
 
-    const std::string id_modelPath_;
-    const std::string en_modelPath_;
     const std::vector<std::string> inputNames_;
     const std::vector<std::string> output_en_;
     const std::vector<std::string> output_id_;

--- a/RecoHGCal/TICL/interface/TracksterInferenceByPFN.h
+++ b/RecoHGCal/TICL/interface/TracksterInferenceByPFN.h
@@ -15,11 +15,11 @@ namespace ticl {
     static void fillPSetDescription(edm::ParameterSetDescription& iDesc);
 
   private:
+    const std::unique_ptr<cms::Ort::ONNXRuntime> onnxPIDRuntimeInstance_;
+    const std::unique_ptr<cms::Ort::ONNXRuntime> onnxEnergyRuntimeInstance_;
     const cms::Ort::ONNXRuntime* onnxPIDSession_;
     const cms::Ort::ONNXRuntime* onnxEnergySession_;
 
-    const std::string id_modelPath_;
-    const std::string en_modelPath_;
     const std::vector<std::string> inputNames_;
     const std::vector<std::string> output_en_;
     const std::vector<std::string> output_id_;

--- a/RecoHGCal/TICL/plugins/TracksterInferenceByDNN.cc
+++ b/RecoHGCal/TICL/plugins/TracksterInferenceByDNN.cc
@@ -13,13 +13,13 @@ namespace ticl {
   // Constructor for TracksterInferenceByDNN
   TracksterInferenceByDNN::TracksterInferenceByDNN(const edm::ParameterSet& conf)
       : TracksterInferenceAlgoBase(conf),
-        id_modelPath_(
-            conf.getParameter<edm::FileInPath>("onnxPIDModelPath").fullPath()),  // Path to the PID model CLU3D
-        en_modelPath_(
-            conf.getParameter<edm::FileInPath>("onnxEnergyModelPath").fullPath()),  // Path to the Energy model CLU3D
-        inputNames_(conf.getParameter<std::vector<std::string>>("inputNames")),     // Define input names for inference
-        output_en_(conf.getParameter<std::vector<std::string>>("output_en")),  // Define output energy for inference
-        output_id_(conf.getParameter<std::vector<std::string>>("output_id")),  // Define output PID for inference
+        onnxPIDRuntimeInstance_(std::make_unique<cms::Ort::ONNXRuntime>(
+            conf.getParameter<edm::FileInPath>("onnxPIDModelPath").fullPath().c_str())),
+        onnxEnergyRuntimeInstance_(std::make_unique<cms::Ort::ONNXRuntime>(
+            conf.getParameter<edm::FileInPath>("onnxEnergyModelPath").fullPath().c_str())),
+        inputNames_(conf.getParameter<std::vector<std::string>>("inputNames")),  // Define input names for inference
+        output_en_(conf.getParameter<std::vector<std::string>>("output_en")),    // Define output energy for inference
+        output_id_(conf.getParameter<std::vector<std::string>>("output_id")),    // Define output PID for inference
         eidMinClusterEnergy_(conf.getParameter<double>("eid_min_cluster_energy")),  // Minimum cluster energy
         eidNLayers_(conf.getParameter<int>("eid_n_layers")),                        // Number of layers
         eidNClusters_(conf.getParameter<int>("eid_n_clusters")),                    // Number of clusters
@@ -27,12 +27,8 @@ namespace ticl {
         doRegression_(conf.getParameter<int>("doRegression"))                       // Number of clusters
   {
     // Initialize ONNX Runtime sessions for PID and Energy models
-    static std::unique_ptr<cms::Ort::ONNXRuntime> onnxPIDRuntimeInstance =
-        std::make_unique<cms::Ort::ONNXRuntime>(id_modelPath_.c_str());
-    onnxPIDSession_ = onnxPIDRuntimeInstance.get();
-    static std::unique_ptr<cms::Ort::ONNXRuntime> onnxEnergyRuntimeInstance =
-        std::make_unique<cms::Ort::ONNXRuntime>(en_modelPath_.c_str());
-    onnxEnergySession_ = onnxEnergyRuntimeInstance.get();
+    onnxPIDSession_ = onnxPIDRuntimeInstance_.get();
+    onnxEnergySession_ = onnxEnergyRuntimeInstance_.get();
   }
 
   // Method to process input data and prepare it for inference

--- a/RecoHGCal/TICL/plugins/TracksterInferenceByPFN.cc
+++ b/RecoHGCal/TICL/plugins/TracksterInferenceByPFN.cc
@@ -13,26 +13,21 @@ namespace ticl {
   // Constructor for TracksterInferenceByPFN
   TracksterInferenceByPFN::TracksterInferenceByPFN(const edm::ParameterSet& conf)
       : TracksterInferenceAlgoBase(conf),
-        id_modelPath_(
-            conf.getParameter<edm::FileInPath>("onnxPIDModelPath").fullPath()),  // Path to the PID model CLU3D
-        en_modelPath_(
-            conf.getParameter<edm::FileInPath>("onnxEnergyModelPath").fullPath()),  // Path to the Energy model CLU3D
-        inputNames_(conf.getParameter<std::vector<std::string>>("inputNames")),     // Define input names for inference
-        output_en_(conf.getParameter<std::vector<std::string>>("output_en")),  // Define output energy for inference
-        output_id_(conf.getParameter<std::vector<std::string>>("output_id")),  // Define output PID for inference
+        onnxPIDRuntimeInstance_(std::make_unique<cms::Ort::ONNXRuntime>(
+            conf.getParameter<edm::FileInPath>("onnxPIDModelPath").fullPath().c_str())),
+        onnxEnergyRuntimeInstance_(std::make_unique<cms::Ort::ONNXRuntime>(
+            conf.getParameter<edm::FileInPath>("onnxEnergyModelPath").fullPath().c_str())),
+        inputNames_(conf.getParameter<std::vector<std::string>>("inputNames")),  // Define input names for inference
+        output_en_(conf.getParameter<std::vector<std::string>>("output_en")),    // Define output energy for inference
+        output_id_(conf.getParameter<std::vector<std::string>>("output_id")),    // Define output PID for inference
         eidMinClusterEnergy_(conf.getParameter<double>("eid_min_cluster_energy")),  // Minimum cluster energy
         eidNLayers_(conf.getParameter<int>("eid_n_layers")),                        // Number of layers
         eidNClusters_(conf.getParameter<int>("eid_n_clusters")),                    // Number of clusters
         doPID_(conf.getParameter<int>("doPID")),                                    // Number of clusters
         doRegression_(conf.getParameter<int>("doRegression"))                       // Number of clusters
   {
-    // Initialize ONNX Runtime sessions for PID and Energy models
-    static std::unique_ptr<cms::Ort::ONNXRuntime> onnxPIDRuntimeInstance =
-        std::make_unique<cms::Ort::ONNXRuntime>(id_modelPath_.c_str());
-    onnxPIDSession_ = onnxPIDRuntimeInstance.get();
-    static std::unique_ptr<cms::Ort::ONNXRuntime> onnxEnergyRuntimeInstance =
-        std::make_unique<cms::Ort::ONNXRuntime>(en_modelPath_.c_str());
-    onnxEnergySession_ = onnxEnergyRuntimeInstance.get();
+    onnxPIDSession_ = onnxPIDRuntimeInstance_.get();
+    onnxEnergySession_ = onnxEnergyRuntimeInstance_.get();
   }
 
   // Method to process input data and prepare it for inference

--- a/RecoHGCal/TICL/python/CLUE3DHighStep_cff.py
+++ b/RecoHGCal/TICL/python/CLUE3DHighStep_cff.py
@@ -82,7 +82,7 @@ ticlTrackstersCLUE3DHigh = _trackstersProducer.clone(
 from Configuration.ProcessModifiers.ticl_v5_cff import ticl_v5
 ticl_v5.toModify(ticlTrackstersCLUE3DHigh.pluginPatternRecognitionByCLUE3D, computeLocalTime = cms.bool(True))
 ticl_v5.toModify(ticlTrackstersCLUE3DHigh.pluginPatternRecognitionByCLUE3D, usePCACleaning = cms.bool(True))
-ticl_v5.toModify(ticlTrackstersCLUE3DHigh.inferenceAlgo, type = cms.string('TracksterInferenceByPFN'))
+ticl_v5.toModify(ticlTrackstersCLUE3DHigh, inferenceAlgo = cms.string('TracksterInferenceByPFN'))
 
 ticlCLUE3DHighStepTask = cms.Task(ticlSeedingGlobal
     ,filteredLayerClustersCLUE3DHigh


### PR DESCRIPTION
This PR fixes an issue with energy regression and model loading in the `TracksterInferenceBy*` objects.
Previously, the models were loaded using a `static std::unique_ptr<cms::Ort::ONNXRuntime>`, which caused all instances of `TracksterInferenceBy*` to share the same model. Different producers could not load different models since the first instance determined the model used for all the other instances.
This PR resolves the issue by moving ONNXRuntime and ONNXSession as members of the `TracksterInference*` object. 

Also adds a bug fix in the TICLv5 modifier to select the correct new model introduced in  #47550
### backport 

As it is bug fix, this PR should be backported to CMSSW_15_0_X

@Moanwar