### PR TITLE
[15_0] Print diagnostics on ProductResolver's loadTag setIntervalFor and IOVProxy's fetchSequence

### DIFF
--- a/CondCore/CondDB/interface/IOVProxy.h
+++ b/CondCore/CondDB/interface/IOVProxy.h
@@ -98,17 +98,10 @@ namespace cond {
     // value semantics. to be used WITHIN the parent session transaction ( therefore the session should be kept alive ).
     class IOVProxy {
     public:
-      //
-      IOVProxy();
+      IOVProxy() = default;
 
       // the only way to construct it from scratch...
       explicit IOVProxy(const std::shared_ptr<SessionImpl>& session);
-
-      //
-      IOVProxy(const IOVProxy& rhs);
-
-      //
-      IOVProxy& operator=(const IOVProxy& rhs);
 
       IOVArray selectAll();
       IOVArray selectAll(const boost::posix_time::ptime& snapshottime);
@@ -160,6 +153,8 @@ namespace cond {
       // maybe will be removed with a re-design of the top level interface (ESSources )
       const std::shared_ptr<SessionImpl>& session() const;
 
+      void setPrintDebug(bool printDebug) { m_printDebug = printDebug; }
+
     private:
       void checkTransaction(const std::string& ctx) const;
       void resetIOVCache();
@@ -169,6 +164,9 @@ namespace cond {
     private:
       std::shared_ptr<IOVProxyData> m_data;
       std::shared_ptr<SessionImpl> m_session;
+
+      // whether additional debug info should be printed in fetchSequence
+      bool m_printDebug = false;
     };
 
   }  // namespace persistency

--- a/CondCore/CondDB/interface/Time.h
+++ b/CondCore/CondDB/interface/Time.h
@@ -54,7 +54,14 @@ namespace cond {
 
     Time_t tillTimeForIOV(Time_t since, unsigned int iovSize, TimeType timeType);
 
-    Time_t lumiTime(unsigned int run, unsigned int lumiId);
+    // LumiNr is the number of the luminosity block (LumiSection) in a run.
+    // LumiTime also called LumiId is an unique identifier for a luminosity block,
+    // being a combination of run number and LumiNr
+    Time_t lumiTime(unsigned int run, unsigned int lumiNr);
+
+    Time_t lumiIdToRun(Time_t lumiId);
+
+    Time_t lumiIdToLumiNr(Time_t lumiId);
 
     // conversion from framework types
     edm::IOVSyncValue toIOVSyncValue(cond::Time_t time, TimeType timetype, bool startOrStop);

--- a/CondCore/CondDB/src/Time.cc
+++ b/CondCore/CondDB/src/Time.cc
@@ -63,7 +63,11 @@ namespace cond {
       }
     }
 
-    Time_t lumiTime(unsigned int run, unsigned int lumiId) { return cond::time::pack(std::make_pair(run, lumiId)); }
+    Time_t lumiTime(unsigned int run, unsigned int lumiNr) { return cond::time::pack(std::make_pair(run, lumiNr)); }
+
+    Time_t lumiIdToRun(Time_t lumiId) { return cond::time::unpack(lumiId).first; }
+
+    Time_t lumiIdToLumiNr(Time_t lumiId) { return cond::time::unpack(lumiId).second; }
 
     Time_t sinceGroupSize(TimeType tp) {
       if (tp == TIMESTAMP)

--- a/CondCore/ESSources/interface/ProductResolver.h
+++ b/CondCore/ESSources/interface/ProductResolver.h
@@ -107,6 +107,8 @@ namespace cond {
     ValidityInterval setIntervalFor(Time_t target);
     TimeType timeType() const { return m_iovProxy.tagInfo().timeType; }
 
+    void setPrintDebug(bool printDebug) { m_printDebug = printDebug; }
+
   private:
     std::string m_label;
     std::string m_connString;
@@ -115,6 +117,9 @@ namespace cond {
     Iov_t m_currentIov;
     persistency::Session m_session;
     std::shared_ptr<std::vector<Iov_t>> m_requests;
+
+    // whether additional debug info should be printed in loadTag and setIntervalFor
+    bool m_printDebug = false;
   };
 }  // namespace cond
 

--- a/CondCore/ESSources/plugins/CondDBESSource.h
+++ b/CondCore/ESSources/plugins/CondDBESSource.h
@@ -124,6 +124,8 @@ private:
   typedef std::map<std::string, cond::GTEntry_t> TagCollection;
   // the collections of tag, record/label used in this ESSource
   TagCollection m_tagCollection;
+  std::vector<std::string> m_recordsToDebug;
+
   std::map<std::string, std::pair<cond::Time_t, bool> > m_refreshTimeForRecord;
   std::map<std::string, std::pair<cond::persistency::Session, std::string> > m_sessionPool;
   std::map<std::string, std::pair<cond::persistency::Session, std::string> > m_sessionPoolForLumiConditions;

--- a/CondCore/ESSources/python/CondDBESSource_cfi.py
+++ b/CondCore/ESSources/python/CondDBESSource_cfi.py
@@ -20,5 +20,6 @@ GlobalTag = _PoolDBESSource(
     RefreshEachRun   = False,
     RefreshOpenIOVs  = False,
     pfnPostfix       = '',
-    pfnPrefix        = '' ,
+    pfnPrefix        = '',
+    recordsToDebug   = [],
 )

--- a/CondCore/ESSources/src/ProductResolverFactory.cc
+++ b/CondCore/ESSources/src/ProductResolverFactory.cc
@@ -15,6 +15,7 @@
 // user include files
 #include "CondCore/ESSources/interface/ProductResolverFactory.h"
 #include "CondCore/ESSources/interface/ProductResolver.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 cond::ProductResolverWrapperBase::ProductResolverWrapperBase() {}
 
@@ -29,17 +30,26 @@ void cond::ProductResolverWrapperBase::addInfo(std::string const& il, std::strin
 void cond::ProductResolverWrapperBase::loadTag(std::string const& tag) {
   m_session.transaction().start(true);
   m_iovProxy = m_session.readIov(tag);
+  m_iovProxy.setPrintDebug(m_printDebug);
   m_session.transaction().commit();
   m_currentIov.clear();
   m_requests = std::make_shared<std::vector<cond::Iov_t>>();
+  if (m_printDebug) {
+    edm::LogSystem("ProductResolverWrapperBase") << "loadTag executed with tag: " << tag;
+  }
 }
 
 void cond::ProductResolverWrapperBase::loadTag(std::string const& tag, boost::posix_time::ptime const& snapshotTime) {
   m_session.transaction().start(true);
   m_iovProxy = m_session.readIov(tag, snapshotTime);
+  m_iovProxy.setPrintDebug(m_printDebug);
   m_session.transaction().commit();
   m_currentIov.clear();
   m_requests = std::make_shared<std::vector<cond::Iov_t>>();
+  if (m_printDebug) {
+    edm::LogSystem("ProductResolverWrapperBase")
+        << "loadTag executed with tag: " << tag << " and snapshotTime: " << snapshotTime;
+  }
 }
 
 void cond::ProductResolverWrapperBase::reload() {
@@ -54,6 +64,11 @@ cond::ValidityInterval cond::ProductResolverWrapperBase::setIntervalFor(Time_t t
     m_session.transaction().start(true);
     m_currentIov = m_iovProxy.getInterval(time);
     m_session.transaction().commit();
+  }
+  if (m_printDebug) {
+    edm::LogSystem("ProductResolverWrapperBase")
+        << "setIntervalFor for tag:" << m_iovProxy.tagInfo().name << " executed with time: " << time << "\n"
+        << " set ValidityInterval: since: " << m_currentIov.since << " till: " << m_currentIov.till;
   }
   return cond::ValidityInterval(m_currentIov.since, m_currentIov.till);
 }


### PR DESCRIPTION
#### PR description:

Printing more diagnostics to help with investigating https://github.com/cms-sw/cmssw/issues/45555
Continuation of https://github.com/cms-sw/cmssw/pull/46395

Allows to define a list of records using `recordsToDebug` parameter of `CondDBESSource` for which additional debug information is printed:
* When loading a tag or when setting IOV interval (in ProductResolverWrapperBase)
* When fetching IOV sequence (in IOVProxy)

#### PR validation:

Tested with:

```
#!/bin/bash -ex

hltGetConfiguration /dev/CMSSW_15_0_0/GRun \
   --globaltag 150X_dataRun3_HLT_v1 \
   --data \
   --unprescale \
   --output minimal \
   --max-events 10 \
   --eras Run3_2024 --l1-emulator uGT --l1 L1Menu_Collisions2024_v1_3_0_xml \
   --input /store/data/Run2024I/EphemeralHLTPhysics0/RAW/v1/000/386/593/00000/91a08676-199e-404c-9957-f72772ef1354.root \
   > hlt.py


cat <<@EOF >> hlt.py
process.options.wantSummary = True
process.options.numberOfThreads = 1
process.options.numberOfStreams = 0
@EOF
```

Now the hlt.py produced by above code was edited to provide the list of records to debug:
add `recordsToDebug = cms.untracked.vstring("BeamSpotOnlineHLTObjectsRcd")`
to the parameters of `PoolDBESSource`:
```
process.GlobalTag = cms.ESSource( "PoolDBESSource",
    ...
    pfnPrefix = cms.untracked.string( "" ),
    recordsToDebug = cms.untracked.vstring("BeamSpotOnlineHLTObjectsRcd")
)
```

Now it can be run by:
```
cmsRun hlt.py &> hlt.log
```


Additionally tested on CMSSW_14_0_11 with a scenario directly from #45555:
```
#!/bin/bash -ex

# originally on CMSSW_14_0_11_MULTIARCHS

hltGetConfiguration run:383631 \
--globaltag 140X_dataRun3_HLT_v3 \
--data \
--no-prescale \
--no-output \
--max-events -1 \
--input '/store/group/tsg/FOG/error_stream_root/run383631/run383631_ls0444_index000423_fu-c2b14-43-01_pid675389.root,/store/group/tsg/FOG/error_stream_root/run383631/run383631_ls0445_index000025_fu-c2b14-43-01_pid675389.root,/store/group/tsg/FOG/error_stream_root/run383631/run383631_ls0666_index000047_fu-c2b14-43-01_pid675067.root,/store/group/tsg/FOG/error_stream_root/run383631/run383631_ls0445_index000002_fu-c2b14-43-01_pid675389.root,/store/group/tsg/FOG/error_stream_root/run383631/run383631_ls0666_index000027_fu-c2b14-43-01_pid675067.root,/store/group/tsg/FOG/error_stream_root/run383631/run383631_ls0666_index000065_fu-c2b14-43-01_pid675067.root' > hlt.py

cat <<@EOF >> hlt.py
process.options.wantSummary = True
process.options.numberOfThreads = 1
process.options.numberOfStreams = 0
@EOF
```


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

backport of #47171