### PR TITLE
[14_2] Print diagnostics on ProductResolver's loadTag setIntervalFor and IOVProxy's fetchSequence

### DIFF
--- a/CondCore/CondDB/interface/IOVProxy.h
+++ b/CondCore/CondDB/interface/IOVProxy.h
@@ -104,7 +104,8 @@ namespace cond {
       // the only way to construct it from scratch...
       explicit IOVProxy(const std::shared_ptr<SessionImpl>& session);
 
-      //
+      // TODO This seems to violate The rule of three: why copy constructor and assignment is defined but not the descructor?
+      // Is this ctor even needed? How is it different from the implicitly defined one?
       IOVProxy(const IOVProxy& rhs);
 
       //
@@ -160,6 +161,8 @@ namespace cond {
       // maybe will be removed with a re-design of the top level interface (ESSources )
       const std::shared_ptr<SessionImpl>& session() const;
 
+      void setPrintDebug(bool printDebug) { m_printDebug = printDebug; }
+
     private:
       void checkTransaction(const std::string& ctx) const;
       void resetIOVCache();
@@ -169,6 +172,9 @@ namespace cond {
     private:
       std::shared_ptr<IOVProxyData> m_data;
       std::shared_ptr<SessionImpl> m_session;
+
+      // whether additional debug info should be printed in fetchSequence
+      bool m_printDebug = false;
     };
 
   }  // namespace persistency

--- a/CondCore/ESSources/interface/ProductResolver.h
+++ b/CondCore/ESSources/interface/ProductResolver.h
@@ -107,6 +107,8 @@ namespace cond {
     ValidityInterval setIntervalFor(Time_t target);
     TimeType timeType() const { return m_iovProxy.tagInfo().timeType; }
 
+    void setPrintDebug(bool printDebug) { m_printDebug = printDebug; }
+
   private:
     std::string m_label;
     std::string m_connString;
@@ -115,6 +117,9 @@ namespace cond {
     Iov_t m_currentIov;
     persistency::Session m_session;
     std::shared_ptr<std::vector<Iov_t>> m_requests;
+
+    // whether additional debug info should be printed in loadTag and setIntervalFor
+    bool m_printDebug = false;
   };
 }  // namespace cond
 

--- a/CondCore/ESSources/plugins/CondDBESSource.cc
+++ b/CondCore/ESSources/plugins/CondDBESSource.cc
@@ -125,6 +125,8 @@ CondDBESSource::CondDBESSource(const edm::ParameterSet& iConfig)
       m_connection(),
       m_connectionString(""),
       m_frontierKey(""),
+      m_recordsToDebug(
+          iConfig.getUntrackedParameter<std::vector<std::string>>("recordsToDebug", std::vector<std::string>())),
       m_lastRun(0),   // for the stat
       m_lastLumi(0),  // for the stat
       m_policy(NOREFRESH),
@@ -256,11 +258,20 @@ CondDBESSource::CondDBESSource(const edm::ParameterSet& iConfig)
    */
   std::vector<std::unique_ptr<cond::ProductResolverWrapperBase>> resolverWrappers(m_tagCollection.size());
   size_t ipb = 0;
+
   for (it = itBeg; it != itEnd; ++it) {
     size_t ind = ipb++;
     resolverWrappers[ind] = std::unique_ptr<cond::ProductResolverWrapperBase>{
         cond::ProductResolverFactory::get()->tryToCreate(buildName(it->second.recordName()))};
-    if (!resolverWrappers[ind].get()) {
+
+    if (resolverWrappers[ind].get()) {
+      // Enable debug if the record name is in m_recordsToDebug or if "*" is present, meaning debug for all records.
+      bool printDebug = std::find(m_recordsToDebug.begin(), m_recordsToDebug.end(), "*") != m_recordsToDebug.end() ||
+                        std::find(m_recordsToDebug.begin(), m_recordsToDebug.end(), it->second.recordName()) !=
+                            m_recordsToDebug.end();
+
+      resolverWrappers[ind]->setPrintDebug(printDebug);
+    } else {
       edm::LogWarning("CondDBESSource") << "Plugin for Record " << it->second.recordName() << " has not been found.";
     }
   }

--- a/CondCore/ESSources/plugins/CondDBESSource.h
+++ b/CondCore/ESSources/plugins/CondDBESSource.h
@@ -120,6 +120,8 @@ private:
   typedef std::map<std::string, cond::GTEntry_t> TagCollection;
   // the collections of tag, record/label used in this ESSource
   TagCollection m_tagCollection;
+  std::vector<std::string> m_recordsToDebug;
+
   std::map<std::string, std::pair<cond::Time_t, bool> > m_refreshTimeForRecord;
   std::map<std::string, std::pair<cond::persistency::Session, std::string> > m_sessionPool;
   std::map<std::string, std::pair<cond::persistency::Session, std::string> > m_sessionPoolForLumiConditions;

--- a/CondCore/ESSources/src/ProductResolverFactory.cc
+++ b/CondCore/ESSources/src/ProductResolverFactory.cc
@@ -15,6 +15,7 @@
 // user include files
 #include "CondCore/ESSources/interface/ProductResolverFactory.h"
 #include "CondCore/ESSources/interface/ProductResolver.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 cond::ProductResolverWrapperBase::ProductResolverWrapperBase() {}
 
@@ -29,17 +30,26 @@ void cond::ProductResolverWrapperBase::addInfo(std::string const& il, std::strin
 void cond::ProductResolverWrapperBase::loadTag(std::string const& tag) {
   m_session.transaction().start(true);
   m_iovProxy = m_session.readIov(tag);
+  m_iovProxy.setPrintDebug(m_printDebug);
   m_session.transaction().commit();
   m_currentIov.clear();
   m_requests = std::make_shared<std::vector<cond::Iov_t>>();
+  if (m_printDebug) {
+    edm::LogSystem("ProductResolverWrapperBase") << "loadTag executed with tag: " << tag;
+  }
 }
 
 void cond::ProductResolverWrapperBase::loadTag(std::string const& tag, boost::posix_time::ptime const& snapshotTime) {
   m_session.transaction().start(true);
   m_iovProxy = m_session.readIov(tag, snapshotTime);
+  m_iovProxy.setPrintDebug(m_printDebug);
   m_session.transaction().commit();
   m_currentIov.clear();
   m_requests = std::make_shared<std::vector<cond::Iov_t>>();
+  if (m_printDebug) {
+    edm::LogSystem("ProductResolverWrapperBase")
+        << "loadTag executed with tag: " << tag << " and snapshotTime: " << snapshotTime;
+  }
 }
 
 void cond::ProductResolverWrapperBase::reload() {
@@ -54,6 +64,11 @@ cond::ValidityInterval cond::ProductResolverWrapperBase::setIntervalFor(Time_t t
     m_session.transaction().start(true);
     m_currentIov = m_iovProxy.getInterval(time);
     m_session.transaction().commit();
+  }
+  if (m_printDebug) {
+    edm::LogSystem("ProductResolverWrapperBase")
+        << "setIntervalFor for tag:" << m_iovProxy.tagInfo().name << " executed with time: " << time << "\n"
+        << " set ValidityInterval: since: " << m_currentIov.since << " till: " << m_currentIov.till;
   }
   return cond::ValidityInterval(m_currentIov.since, m_currentIov.till);
 }


### PR DESCRIPTION
#### PR description:

Printing more diagnostics to help with investigating https://github.com/cms-sw/cmssw/issues/45555
Continuation of https://github.com/cms-sw/cmssw/pull/46395

Allows to define a list of records using `recordsToDebug` parameter of `CondDBESSource` for which additional debug information is printed:
* When loading a tag or when setting IOV interval (in ProductResolverWrapperBase)
* When fetching IOV sequence (in IOVProxy)

#### PR validation:

Tested the main PR


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be confirmed with DQM if still needed.
backport of #47171