### PR TITLE
Small modification on CRC compuation for HGCAL unpacker

### DIFF
--- a/EventFilter/HGCalRawToDigi/src/UnpackerTools.cc
+++ b/EventFilter/HGCalRawToDigi/src/UnpackerTools.cc
@@ -10,7 +10,7 @@
 bool hgcal::econdCRCAnalysis(const uint64_t *header, const uint32_t pos, const uint32_t payloadLength) {
   //there needs to be at least the CRC word otherwise it can't be checked
   if (payloadLength == 0)
-    return false;
+    return true;
 
   int index = 0;
   std::vector<uint32_t> data32b;  //  reading 32-bit words, input is 64b


### PR DESCRIPTION
#### PR description:

After discussion (@pfs, @IzaakWN), we prefer to have the CRC valid flag set to true when the payload length is 0. 

#### PR validation:

All usual checks passed. Including formatting. 

