### PR TITLE
Allow use of Rntuple format in ConfigBuilder

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -573,112 +573,98 @@ class ConfigBuilder(object):
 
     def addOutput(self):
         """ Add output module to the process """
-        result=""
         if self._options.outputDefinition:
-            if self._options.datatier:
-                print("--datatier & --eventcontent options ignored")
+            return self._addOutputUsingOutputDefinition()
+        else:
+            return self._addOutputUsingTier()
+    def _addOutputUsingOutputDefinition(self):
+        result=""
+        if self._options.datatier:
+            print("--datatier & --eventcontent options ignored")
 
-            #new output convention with a list of dict
-            outList = eval(self._options.outputDefinition)
-            for (id,outDefDict) in enumerate(outList):
-                outDefDictStr=outDefDict.__str__()
-                if not isinstance(outDefDict,dict):
-                    raise Exception("--output needs to be passed a list of dict"+self._options.outputDefinition+" is invalid")
-                #requires option: tier
-                theTier=anyOf(['t','tier','dataTier'],outDefDict)
-                #optional option: eventcontent, filtername, selectEvents, moduleLabel, filename
-                ## event content
-                theStreamType=anyOf(['e','ec','eventContent','streamType'],outDefDict,theTier)
-                theFilterName=anyOf(['f','ftN','filterName'],outDefDict,'')
-                theSelectEvent=anyOf(['s','sE','selectEvents'],outDefDict,'')
-                theModuleLabel=anyOf(['l','mL','moduleLabel'],outDefDict,'')
-                theExtraOutputCommands=anyOf(['o','oC','outputCommands'],outDefDict,'')
-                # module label has a particular role
-                if not theModuleLabel:
-                    tryNames=[theStreamType.replace(theTier.replace('-',''),'')+theTier.replace('-','')+'output',
-                              theStreamType.replace(theTier.replace('-',''),'')+theTier.replace('-','')+theFilterName+'output',
-                              theStreamType.replace(theTier.replace('-',''),'')+theTier.replace('-','')+theFilterName+theSelectEvent.split(',')[0].replace(':','for').replace(' ','')+'output'
-                              ]
-                    for name in tryNames:
-                        if not hasattr(self.process,name):
-                            theModuleLabel=name
-                            break
-                if not theModuleLabel:
-                    raise Exception("cannot find a module label for specification: "+outDefDictStr)
-                if id==0:
-                    defaultFileName=self._options.outfile_name
+        #new output convention with a list of dict
+        outList = eval(self._options.outputDefinition)
+        for (id,outDefDict) in enumerate(outList):
+            outDefDictStr=outDefDict.__str__()
+            if not isinstance(outDefDict,dict):
+                raise Exception("--output needs to be passed a list of dict"+self._options.outputDefinition+" is invalid")
+            #requires option: tier
+            theTier=anyOf(['t','tier','dataTier'],outDefDict)
+            #optional option: eventcontent, filtername, selectEvents, moduleLabel, filename
+            ## event content
+            theStreamType=anyOf(['e','ec','eventContent','streamType'],outDefDict,theTier)
+            theFilterName=anyOf(['f','ftN','filterName'],outDefDict,'')
+            theSelectEvent=anyOf(['s','sE','selectEvents'],outDefDict,'')
+            theModuleLabel=anyOf(['l','mL','moduleLabel'],outDefDict,'')
+            theExtraOutputCommands=anyOf(['o','oC','outputCommands'],outDefDict,'')
+            # module label has a particular role
+            if not theModuleLabel:
+                tryNames=[theStreamType.replace(theTier.replace('-',''),'')+theTier.replace('-','')+'output',
+                          theStreamType.replace(theTier.replace('-',''),'')+theTier.replace('-','')+theFilterName+'output',
+                          theStreamType.replace(theTier.replace('-',''),'')+theTier.replace('-','')+theFilterName+theSelectEvent.split(',')[0].replace(':','for').replace(' ','')+'output'
+                          ]
+                for name in tryNames:
+                    if not hasattr(self.process,name):
+                        theModuleLabel=name
+                        break
+            if not theModuleLabel:
+                raise Exception("cannot find a module label for specification: "+outDefDictStr)
+            if id==0:
+                defaultFileName=self._options.outfile_name
+            else:
+                defaultFileName=self._options.outfile_name.replace('.root','_in'+theTier+'.root')
+
+            theFileName=self._options.dirout+anyOf(['fn','fileName'],outDefDict,defaultFileName)
+            if not theFileName.endswith('.root'):
+                theFileName+='.root'
+
+            if len(outDefDict):
+                raise Exception("unused keys from --output options: "+','.join(outDefDict.keys()))
+            if theStreamType=='DQMIO': theStreamType='DQM'
+            if theStreamType=='ALL':
+                theEventContent = cms.PSet(outputCommands = cms.untracked.vstring('keep *'))
+            else:
+                theEventContent = getattr(self.process, theStreamType+"EventContent")
+
+
+            addAlCaSelects=False
+            if theStreamType=='ALCARECO' and not theFilterName:
+                theFilterName='StreamALCACombined'
+                addAlCaSelects=True
+
+            output=self._createOutputModuleInAddOutput(tier=theTier, streamType = theStreamType, eventContent = theEventContent, fileName = theFileName, filterName = theFilterName, ignoreNano = True)
+            if theSelectEvent:
+                output.SelectEvents =cms.untracked.PSet(SelectEvents = cms.vstring(theSelectEvent))
+            else:
+                self._updateOutputSelectEvents(output, theStreamType)
+
+            if addAlCaSelects:
+                if not hasattr(output,'SelectEvents'):
+                    output.SelectEvents=cms.untracked.PSet(SelectEvents=cms.vstring())
+                for alca in self.AlCaPaths:
+                    output.SelectEvents.SelectEvents.extend(getattr(self.process,'OutALCARECO'+alca).SelectEvents.SelectEvents)
+
+
+            if hasattr(self.process,theModuleLabel):
+                raise Exception("the current process already has a module "+theModuleLabel+" defined")
+            #print "creating output module ",theModuleLabel
+            outputModule = self._addOutputModuleAndPathToProcess(output, theModuleLabel)
+
+            self._inlineOutputEventContent(outputModule, theStreamType)
+            if theExtraOutputCommands:
+                if not isinstance(theExtraOutputCommands,list):
+                    raise Exception("extra ouput command in --option must be a list of strings")
+                if hasattr(self.process,theStreamType+"EventContent"):
+                    self.executeAndRemember('process.%s.outputCommands.extend(%s)'%(theModuleLabel,theExtraOutputCommands))
                 else:
-                    defaultFileName=self._options.outfile_name.replace('.root','_in'+theTier+'.root')
+                    outputModule.outputCommands.extend(theExtraOutputCommands)
 
-                theFileName=self._options.dirout+anyOf(['fn','fileName'],outDefDict,defaultFileName)
-                if not theFileName.endswith('.root'):
-                    theFileName+='.root'
+            result+="\nprocess."+theModuleLabel+" = "+outputModule.dumpPython()
 
-                if len(outDefDict):
-                    raise Exception("unused keys from --output options: "+','.join(outDefDict.keys()))
-                if theStreamType=='DQMIO': theStreamType='DQM'
-                if theStreamType=='ALL':
-                    theEventContent = cms.PSet(outputCommands = cms.untracked.vstring('keep *'))
-                else:
-                    theEventContent = getattr(self.process, theStreamType+"EventContent")
-
-
-                addAlCaSelects=False
-                if theStreamType=='ALCARECO' and not theFilterName:
-                    theFilterName='StreamALCACombined'
-                    addAlCaSelects=True
-
-                CppType='PoolOutputModule'
-                if self._options.timeoutOutput:
-                    CppType='TimeoutPoolOutputModule'
-                if theStreamType=='DQM' and theTier=='DQMIO': CppType='DQMRootOutputModule'
-                output = cms.OutputModule(CppType,
-                                          theEventContent.clone(),
-                                          fileName = cms.untracked.string(theFileName),
-                                          dataset = cms.untracked.PSet(
-                                             dataTier = cms.untracked.string(theTier),
-                                             filterName = cms.untracked.string(theFilterName))
-                                          )
-                if not theSelectEvent and hasattr(self.process,'generation_step') and theStreamType!='LHE':
-                    output.SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring('generation_step'))
-                if not theSelectEvent and hasattr(self.process,'filtering_step'):
-                    output.SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring('filtering_step'))
-                if theSelectEvent:
-                    output.SelectEvents =cms.untracked.PSet(SelectEvents = cms.vstring(theSelectEvent))
-
-                if addAlCaSelects:
-                    if not hasattr(output,'SelectEvents'):
-                        output.SelectEvents=cms.untracked.PSet(SelectEvents=cms.vstring())
-                    for alca in self.AlCaPaths:
-                        output.SelectEvents.SelectEvents.extend(getattr(self.process,'OutALCARECO'+alca).SelectEvents.SelectEvents)
-
-
-                if hasattr(self.process,theModuleLabel):
-                    raise Exception("the current process already has a module "+theModuleLabel+" defined")
-                #print "creating output module ",theModuleLabel
-                setattr(self.process,theModuleLabel,output)
-                outputModule=getattr(self.process,theModuleLabel)
-                setattr(self.process,theModuleLabel+'_step',cms.EndPath(outputModule))
-                path=getattr(self.process,theModuleLabel+'_step')
-                self.schedule.append(path)
-
-                if not self._options.inlineEventContent and hasattr(self.process,theStreamType+"EventContent"):
-                    def doNotInlineEventContent(instance,label = "cms.untracked.vstring(process."+theStreamType+"EventContent.outputCommands)"):
-                        return label
-                    outputModule.outputCommands.__dict__["dumpPython"] = doNotInlineEventContent
-                if theExtraOutputCommands:
-                    if not isinstance(theExtraOutputCommands,list):
-                        raise Exception("extra ouput command in --option must be a list of strings")
-                    if hasattr(self.process,theStreamType+"EventContent"):
-                        self.executeAndRemember('process.%s.outputCommands.extend(%s)'%(theModuleLabel,theExtraOutputCommands))
-                    else:
-                        outputModule.outputCommands.extend(theExtraOutputCommands)
-
-                result+="\nprocess."+theModuleLabel+" = "+outputModule.dumpPython()
-
-            ##ends the --output options model
-            return result
-
+        ##ends the --output options model
+        return result
+    def _addOutputUsingTier(self):
+        result=""
         streamTypes=self._options.eventcontent.split(',')
         tiers=self._options.datatier.split(',')
         if not self._options.outputDefinition and len(streamTypes)!=len(tiers):
@@ -704,29 +690,13 @@ class ConfigBuilder(object):
             theEventContent = getattr(self.process, eventContent+"EventContent")
             if i==0:
                 theFileName=self._options.outfile_name
-                theFilterName=self._options.filtername
             else:
                 theFileName=self._options.outfile_name.replace('.root','_in'+streamType+'.root')
-                theFilterName=self._options.filtername
-            CppType='PoolOutputModule'
-            if self._options.timeoutOutput:
-                CppType='TimeoutPoolOutputModule'
-            if streamType=='DQM' and tier=='DQMIO': CppType='DQMRootOutputModule'
-            if "NANOAOD" in streamType : CppType='NanoAODOutputModule'
-            output = cms.OutputModule(CppType,
-                                      theEventContent,
-                                      fileName = cms.untracked.string(theFileName),
-                                      dataset = cms.untracked.PSet(dataTier = cms.untracked.string(tier),
-                                                                   filterName = cms.untracked.string(theFilterName)
-                                                                   )
-                                      )
-            if hasattr(self.process,"generation_step") and streamType!='LHE':
-                output.SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring('generation_step'))
-            if hasattr(self.process,"filtering_step"):
-                output.SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring('filtering_step'))
-
+            theFilterName=self._options.filtername
             if streamType=='ALCARECO':
-                output.dataset.filterName = cms.untracked.string('StreamALCACombined')
+                theFilterName = 'StreamALCACombined'
+            output = self._createOutputModuleInAddOutput(tier=tier, streamType=streamType, eventContent=theEventContent, fileName = theFileName, filterName = theFilterName, ignoreNano = False)
+            self._updateOutputSelectEvents(output, streamType)
 
             if "MINIAOD" in streamType:
                 ## we should definitely get rid of this customization by now
@@ -734,28 +704,52 @@ class ConfigBuilder(object):
                 miniAOD_customizeOutput(output)
 
             outputModuleName=streamType+streamQualifier+'output'
-            setattr(self.process,outputModuleName,output)
-            outputModule=getattr(self.process,outputModuleName)
-            setattr(self.process,outputModuleName+'_step',cms.EndPath(outputModule))
-            path=getattr(self.process,outputModuleName+'_step')
-            self.schedule.append(path)
+            outputModule = self._addOutputModuleAndPathToProcess(output, outputModuleName)
 
             if self._options.outputCommands and streamType!='DQM':
                 for evct in self._options.outputCommands.split(','):
                     if not evct: continue
                     self.executeAndRemember("process.%s.outputCommands.append('%s')"%(outputModuleName,evct.strip()))
 
-            if not self._options.inlineEventContent:
-                tmpstreamType=streamType
-                if "NANOEDM" in tmpstreamType :
-                    tmpstreamType=tmpstreamType.replace("NANOEDM","NANO")
-                def doNotInlineEventContent(instance,label = "process."+tmpstreamType+"EventContent.outputCommands"):
-                    return label
-                outputModule.outputCommands.__dict__["dumpPython"] = doNotInlineEventContent
-
+            self._inlineOutputEventContent(outputModule, streamType)
             result+="\nprocess."+outputModuleName+" = "+outputModule.dumpPython()
 
         return result
+    def _createOutputModuleInAddOutput(self, tier, streamType, eventContent, fileName, filterName, ignoreNano):
+        CppType='PoolOutputModule'
+        if self._options.timeoutOutput:
+            CppType='TimeoutPoolOutputModule'
+        if streamType=='DQM' and tier=='DQMIO': CppType='DQMRootOutputModule'
+        if not ignoreNano and "NANOAOD" in streamType : CppType='NanoAODOutputModule'
+        output = cms.OutputModule(CppType,
+                                  eventContent.clone(),
+                                  fileName = cms.untracked.string(fileName),
+                                  dataset = cms.untracked.PSet(
+                                     dataTier = cms.untracked.string(tier),
+                                     filterName = cms.untracked.string(filterName))
+                                  )
+        return output
+    def _updateOutputSelectEvents(self, output, streamType):
+        if hasattr(self.process,"generation_step") and streamType!='LHE':
+            output.SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring('generation_step'))
+        if hasattr(self.process,"filtering_step"):
+            output.SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring('filtering_step'))
+    def _inlineOutputEventContent(self, outputModule, streamType):
+        if not self._options.inlineEventContent:
+            tmpstreamType=streamType
+            if "NANOEDM" in tmpstreamType :
+                tmpstreamType=tmpstreamType.replace("NANOEDM","NANO")
+            if hasattr(self.process,tmpstreamType+"EventContent"):
+                def doNotInlineEventContent(instance,label = "process."+tmpstreamType+"EventContent.outputCommands"):
+                    return label
+                outputModule.outputCommands.__dict__["dumpPython"] = doNotInlineEventContent
+    def _addOutputModuleAndPathToProcess(self, output, name):
+        setattr(self.process,name,output)
+        outputModule=getattr(self.process,name)
+        setattr(self.process,name+'_step',cms.EndPath(outputModule))
+        path=getattr(self.process,name+'_step')
+        self.schedule.append(path)
+        return outputModule   
 
     def addStandardSequences(self):
         """

--- a/Configuration/Applications/python/Options.py
+++ b/Configuration/Applications/python/Options.py
@@ -52,12 +52,18 @@ parser.add_argument("--fileout",
                     type=str,
                     dest="fileout")
 
+parser.add_argument("--rntuple_out",
+                    help="If possible, use RNTuple format for output.",
+                    action="store_true",
+                    default=defaultOptions.rntuple_out,
+                    dest="rntuple_out")
+
 parser.add_argument("--filetype",
                     help="The type of the infile",
                     default=defaultOptions.filetype,
                     type=str,
                     dest="filetype",
-                    choices=['EDM','DAT','LHE','MDCB','DQM','DQMDAQ']
+                    choices=['EDM','DAT','LHE','MDCB','DQM','DQMDAQ', 'EDM_RNTUPLE']
                   )
 
 parser.add_argument("-n", "--number",

--- a/Configuration/Applications/python/cmsDriverOptions.py
+++ b/Configuration/Applications/python/cmsDriverOptions.py
@@ -143,10 +143,12 @@ def OptionsFromItems(items):
             print("This is a deprecated way of selecting lhe files from article number. Please use lhe:article argument to --filein")
             options.filein=options.filein.replace('mcdb:','lhe:')
             options.filetype="LHE"
+        elif options.filein.lower().endswith(".rntpl"):
+            options.filetype="EDM_RNTUPLE"
         else:
             options.filetype="EDM"
 
-    filesuffix = {"LHE": "lhe", "EDM": "root", "MCDB": "", "DQM":"root"}[options.filetype]
+    filesuffix = {"LHE": "lhe", "EDM": "root", "MCDB": "", "DQM":"root", "EDM_RNTUPLE":"rntpl"}[options.filetype]
 
     if options.filein=="" and not (first_step in ("ALL","GEN","LHE","SIM_CHAIN")):
         options.dirin="file:"+options.dirin.replace('file:','')

--- a/Configuration/Applications/test/ConfigBuilderTest.py
+++ b/Configuration/Applications/test/ConfigBuilderTest.py
@@ -23,6 +23,31 @@ def prepareDQMSequenceOrder():
     process.ps4 = cms.Sequence()
     return (options, process)
 
+class OutStats(object):
+    def __init__(self, name, type_, tier, fileName, commands):
+        self.name = name
+        self.type_ = type_
+        self.tier = tier
+        self.fileName = fileName
+        self.commands = commands
+def _test_addOutput(tester, options, process, outStats, modifier = None):
+    cb = ConfigBuilder(options, process)
+    if modifier:
+        modifier(cb)
+    cb.addOutput()
+    tester.assertEqual(len(process.outputModules_()), len(outStats))
+    outs = []
+#    print(process.outputModules_())
+    for stat in outStats:
+        tester.assertTrue( stat.name in process.outputModules_() )
+        r = process.outputModules_()[stat.name]
+        tester.assertEqual(r.type_(), stat.type_)
+        tester.assertEqual(r.dataset.dataTier.value(), stat.tier)
+        tester.assertEqual(r.fileName.value(), stat.fileName)
+        tester.assertEqual(r.outputCommands, stat.commands)
+        outs.append(r)
+    return outs
+
 if __name__=="__main__":
     import unittest
 
@@ -77,4 +102,334 @@ if __name__=="__main__":
             autoDQM.clear()
             autoDQM.update(autoDQM_orig)
 
+        def testOutputFormatWithEventContent(self):
+            #RECO
+            process = cms.Process("TEST")
+            outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
+            process.RECOEventContent = cms.PSet( outputCommands = outputCommands_)
+            options = copy.deepcopy(defaultOptions)
+            options.scenario = "TEST"
+            options.datatier= "RECO"
+            options.eventcontent="RECO"
+            _test_addOutput(self, options, process, [OutStats('RECOoutput','PoolOutputModule','RECO','output.root',outputCommands_)])
+            #AOD
+            process = cms.Process("TEST")
+            outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
+            process.AODEventContent = cms.PSet( outputCommands = outputCommands_)
+            options = copy.deepcopy(defaultOptions)
+            options.scenario = "TEST"
+            options.datatier= "AOD"
+            options.eventcontent="AOD"
+            _test_addOutput(self, options, process, [OutStats('AODoutput','PoolOutputModule','AOD','output.root',outputCommands_)])
+            #MINIAOD
+            process = cms.Process("TEST")
+            outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
+            process.MINIAODEventContent = cms.PSet( outputCommands = outputCommands_)
+            options = copy.deepcopy(defaultOptions)
+            options.scenario = "TEST"
+            options.datatier= "MINIAOD"
+            options.eventcontent="MINIAOD"
+            _test_addOutput(self, options, process, [OutStats('MINIAODoutput','PoolOutputModule','MINIAOD','output.root',outputCommands_)])
+            #MINIAOD1 [NOTE notiation not restricted to MINIAOD]
+            #NOT SUPPORTED BY outputDefinition
+            process = cms.Process("TEST")
+            outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
+            process.MINIAODEventContent = cms.PSet( outputCommands = outputCommands_)
+            options = copy.deepcopy(defaultOptions)
+            options.scenario = "TEST"
+            options.datatier= "MINIAOD"
+            options.eventcontent="MINIAOD1"
+            _test_addOutput(self, options, process, [OutStats('MINIAOD1output','PoolOutputModule','MINIAOD','output.root',outputCommands_)])
+            #DQMIO
+            process = cms.Process("TEST")
+            outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
+            process.DQMEventContent = cms.PSet( outputCommands = outputCommands_)
+            options = copy.deepcopy(defaultOptions)
+            options.scenario = "TEST"
+            options.datatier= "DQMIO"
+            options.eventcontent="DQM"
+            _test_addOutput(self, options, process, [OutStats('DQMoutput','DQMRootOutputModule','DQMIO','output.root',outputCommands_)])
+            #DQMIO&DQMIO
+            process = cms.Process("TEST")
+            outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
+            process.DQMEventContent = cms.PSet( outputCommands = outputCommands_)
+            options = copy.deepcopy(defaultOptions)
+            options.scenario = "TEST"
+            options.datatier= "DQMIO"
+            options.eventcontent="DQMIO"
+            _test_addOutput(self, options, process, [OutStats('DQMoutput','DQMRootOutputModule','DQMIO','output.root',outputCommands_)])
+            #DQM, not DQMIO (decided by datatier)
+            process = cms.Process("TEST")
+            outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
+            process.DQMEventContent = cms.PSet( outputCommands = outputCommands_)
+            options = copy.deepcopy(defaultOptions)
+            options.scenario = "TEST"
+            options.datatier= "DQM"
+            options.eventcontent="DQM"
+            _test_addOutput(self, options, process, [OutStats('DQMoutput','PoolOutputModule','DQM','output.root',outputCommands_)])
+            #NANOAOD
+            process = cms.Process("TEST")
+            outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
+            process.NANOAODEventContent = cms.PSet( outputCommands = outputCommands_)
+            options = copy.deepcopy(defaultOptions)
+            options.scenario = "TEST"
+            options.datatier= "NANOAOD"
+            options.eventcontent="NANOAOD"
+            _test_addOutput(self, options, process, [OutStats('NANOAODoutput','NanoAODOutputModule','NANOAOD','output.root',outputCommands_)])
+            #NANOEDMAOD
+            process = cms.Process("TEST")
+            outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
+            process.NANOAODEventContent = cms.PSet( outputCommands = outputCommands_)
+            options = copy.deepcopy(defaultOptions)
+            options.scenario = "TEST"
+            options.datatier= "NANOAOD"
+            options.eventcontent="NANOEDMAOD"
+            _test_addOutput(self, options, process, [OutStats('NANOEDMAODoutput', 'PoolOutputModule', 'NANOAOD', 'output.root', outputCommands_)])
+            #ALCARECO empty
+            process = cms.Process("TEST")
+            options.scenario = "TEST"
+            options.datatier= "ALCARECO"
+            options.eventcontent="ALCARECO"
+            _test_addOutput(self, options, process, [])
+            #ALCARECO present
+            process = cms.Process("TEST")
+            outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
+            process.ALCARECOEventContent = cms.PSet( outputCommands = outputCommands_)
+            options = copy.deepcopy(defaultOptions)
+            options.scenario = "TEST"
+            options.datatier= "ALCARECO"
+            options.eventcontent="ALCARECO"
+            options.step = 'ALCAPRODUCER'
+            outs = _test_addOutput(self, options, process, [OutStats('ALCARECOoutput', 'PoolOutputModule', 'ALCARECO', 'output.root', outputCommands_)])
+            self.assertEqual(outs[0].dataset.filterName, cms.untracked.string('StreamALCACombined'))
+            #AOD+MINIAOD
+            process = cms.Process("TEST")
+            outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
+            process.AODEventContent = cms.PSet( outputCommands = outputCommands_)
+            process.MINIAODEventContent = cms.PSet( outputCommands = outputCommands_)
+            options = copy.deepcopy(defaultOptions)
+            options.fileout = 'stepN.root'
+            options.scenario = "TEST"
+            options.datatier= "AOD,MINIAOD"
+            options.eventcontent="AOD,MINIAOD"
+            _test_addOutput(self, options, process, [OutStats('AODoutput','PoolOutputModule','AOD','stepN.root',outputCommands_), OutStats('MINIAODoutput','PoolOutputModule','MINIAOD','stepN_inMINIAOD.root',outputCommands_)])
+            #MINIAOD & generation_step
+            process = cms.Process("TEST")
+            outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
+            process.MINIAODEventContent = cms.PSet( outputCommands = outputCommands_)
+            process.generation_step = cms.Path()
+            options = copy.deepcopy(defaultOptions)
+            options.fileout = 'stepN.root'
+            options.scenario = "TEST"
+            options.datatier= "MINIAOD"
+            options.eventcontent="MINIAOD"
+            out = _test_addOutput(self, options, process, [OutStats('MINIAODoutput','PoolOutputModule','MINIAOD','stepN.root',outputCommands_)])
+            self.assertEqual(out[0].SelectEvents.SelectEvents, cms.vstring('generation_step'))
+            #MINIAOD & filtering_step
+            process = cms.Process("TEST")
+            outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
+            process.MINIAODEventContent = cms.PSet( outputCommands = outputCommands_)
+            process.filtering_step = cms.Path()
+            options = copy.deepcopy(defaultOptions)
+            options.fileout = 'stepN.root'
+            options.scenario = "TEST"
+            options.datatier= "MINIAOD"
+            options.eventcontent="MINIAOD"
+            out = _test_addOutput(self, options, process, [OutStats('MINIAODoutput','PoolOutputModule','MINIAOD','stepN.root',outputCommands_)])
+            self.assertEqual(out[0].SelectEvents.SelectEvents, cms.vstring('filtering_step'))
+            #LHE & generation_step
+            process = cms.Process("TEST")
+            outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
+            process.LHEEventContent = cms.PSet( outputCommands = outputCommands_)
+            process.generation_step = cms.Path()
+            options = copy.deepcopy(defaultOptions)
+            options.fileout = 'stepN.root'
+            options.scenario = "TEST"
+            options.datatier= "LHE"
+            options.eventcontent="LHE"
+            out = _test_addOutput(self, options, process, [OutStats('LHEoutput','PoolOutputModule','LHE','stepN.root',outputCommands_)])
+            self.assertFalse(hasattr(out[0],"SelectEvents"))
+
+        def testOutputFormatWith_outputDefinition(self):
+            #RECO
+            process = cms.Process("TEST")
+            outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
+            process.RECOEventContent = cms.PSet( outputCommands = outputCommands_)
+            options = copy.deepcopy(defaultOptions)
+            options.scenario = "TEST"            
+            options.outputDefinition = str([dict(tier='RECO'),])
+            _test_addOutput(self, options, process, [OutStats('RECOoutput','PoolOutputModule','RECO','output.root',outputCommands_)])
+            #RECO & moduleLabel
+            process = cms.Process("TEST")
+            outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
+            process.RECOEventContent = cms.PSet( outputCommands = outputCommands_)
+            options = copy.deepcopy(defaultOptions)
+            options.scenario = "TEST"            
+            options.outputDefinition = str([dict(tier='RECO',moduleLabel='RECOoutputOther'),])
+            _test_addOutput(self, options, process, [OutStats('RECOoutputOther','PoolOutputModule','RECO','output.root',outputCommands_)])
+            #RECO & fileName
+            process = cms.Process("TEST")
+            outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
+            process.RECOEventContent = cms.PSet( outputCommands = outputCommands_)
+            options = copy.deepcopy(defaultOptions)
+            options.scenario = "TEST"            
+            options.outputDefinition = str([dict(tier='RECO',fileName='other.root'),])
+            _test_addOutput(self, options, process, [OutStats('RECOoutput','PoolOutputModule','RECO','other.root',outputCommands_)])
+            #RECO & eventContent
+            process = cms.Process("TEST")
+            outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
+            process.RECOSIMEventContent = cms.PSet( outputCommands = outputCommands_)
+            options = copy.deepcopy(defaultOptions)
+            options.scenario = "TEST"            
+            options.outputDefinition = str([dict(tier='RECO',eventContent='RECOSIM'),])
+            _test_addOutput(self, options, process, [OutStats('SIMRECOoutput','PoolOutputModule','RECO','output.root',outputCommands_)])
+            #RECO & selectEvents
+            process = cms.Process("TEST")
+            outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
+            process.RECOEventContent = cms.PSet( outputCommands = outputCommands_)
+            options = copy.deepcopy(defaultOptions)
+            options.scenario = "TEST"            
+            options.outputDefinition = str([dict(tier='RECO',selectEvents='select'),])
+            out = _test_addOutput(self, options, process, [OutStats('RECOoutput','PoolOutputModule','RECO','output.root',outputCommands_)])
+            self.assertEqual(out[0].SelectEvents.SelectEvents, cms.vstring('select'))
+            #RECO & outputCommands
+            process = cms.Process("TEST")
+            outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
+            process.RECOEventContent = cms.PSet( outputCommands = outputCommands_)
+            options = copy.deepcopy(defaultOptions)
+            options.scenario = "TEST"            
+            options.outputDefinition = str([dict(tier='RECO',outputCommands=cms.untracked.vstring('keep bar')),])
+            fullOutputCommands = cms.untracked.vstring('drop *', 'keep foo', 'keep bar')
+            _test_addOutput(self, options, process, [OutStats('RECOoutput','PoolOutputModule','RECO','output.root',fullOutputCommands)])
+            #AOD
+            process = cms.Process("TEST")
+            outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
+            process.AODEventContent = cms.PSet( outputCommands = outputCommands_)
+            options = copy.deepcopy(defaultOptions)
+            options.scenario = "TEST"
+            options.outputDefinition = str([dict(tier='AOD'),])
+            _test_addOutput(self, options, process, [OutStats('AODoutput','PoolOutputModule','AOD','output.root',outputCommands_)])
+            #MINIAOD
+            process = cms.Process("TEST")
+            outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
+            process.MINIAODEventContent = cms.PSet( outputCommands = outputCommands_)
+            options = copy.deepcopy(defaultOptions)
+            options.scenario = "TEST"
+            options.outputDefinition = str([dict(tier='MINIAOD'),])
+            _test_addOutput(self, options, process, [OutStats('MINIAODoutput','PoolOutputModule','MINIAOD','output.root',outputCommands_)])
+            #DQMIO&DQM
+            process = cms.Process("TEST")
+            outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
+            process.DQMEventContent = cms.PSet( outputCommands = outputCommands_)
+            options = copy.deepcopy(defaultOptions)
+            options.scenario = "TEST"
+            options.outputDefinition = str([dict(tier='DQMIO', eventContent='DQM'),])
+            #NOTE: THE MODULE LABEL IS DIFFERENT FROM THE OTHER CASE
+            #_test_addOutput(self, options, process, [OutStats('DQMIOoutput','DQMRootOutputModule','DQMIO','output.root',outputCommands_)])
+            _test_addOutput(self, options, process, [OutStats('DQMDQMIOoutput','DQMRootOutputModule','DQMIO','output.root',outputCommands_)])
+            #DQMIO&DQMIO
+            process = cms.Process("TEST")
+            outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
+            process.DQMEventContent = cms.PSet( outputCommands = outputCommands_)
+            options = copy.deepcopy(defaultOptions)
+            options.scenario = "TEST"
+            options.outputDefinition = str([dict(tier='DQMIO', eventContent='DQMIO'),])
+            _test_addOutput(self, options, process, [OutStats('DQMIOoutput','DQMRootOutputModule','DQMIO','output.root',outputCommands_)])
+            #DQM, not DQMIO (decided by datatier)
+            process = cms.Process("TEST")
+            outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
+            process.DQMEventContent = cms.PSet( outputCommands = outputCommands_)
+            options = copy.deepcopy(defaultOptions)
+            options.scenario = "TEST"
+            options.outputDefinition = str([dict(tier='DQM', eventContent='DQM'),])
+            _test_addOutput(self, options, process, [OutStats('DQMoutput','PoolOutputModule','DQM','output.root',outputCommands_)])
+            #NANOAOD
+            process = cms.Process("TEST")
+            outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
+            process.NANOAODEventContent = cms.PSet( outputCommands = outputCommands_)
+            options = copy.deepcopy(defaultOptions)
+            options.scenario = "TEST"
+            options.outputDefinition = str([dict(tier='NANOAOD', eventContent='NANOAOD'),])
+            #NOTE: Does not use NanoAODOuputModule (this code path is not capable of making that type)
+            #_test_addOutput(self, options, process, [OutStats('NANOAODoutput','NanoAODOutputModule','NANOAOD','output.root',outputCommands_)])
+            _test_addOutput(self, options, process, [OutStats('NANOAODoutput','PoolOutputModule','NANOAOD','output.root',outputCommands_)])
+            #NANOEDMAOD
+            process = cms.Process("TEST")
+            outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
+            #USES A DIFFERENT EVENT CONTENT (which we do not define)
+            #process.NANOAODEventContent = cms.PSet( outputCommands = outputCommands_)
+            process.NANOEDMAODEventContent = cms.PSet( outputCommands = outputCommands_)
+            options = copy.deepcopy(defaultOptions)
+            options.scenario = "TEST"
+            options.outputDefinition = str([dict(tier='NANOAOD', eventContent='NANOEDMAOD'),])
+            #GENERATES A DIFFERENT NAME
+            #_test_addOutput(self, options, process, [OutStats('NANOEDMAODoutput', 'PoolOutputModule', 'NANOAOD', 'output.root', outputCommands_)])
+            _test_addOutput(self, options, process, [OutStats('NANOEDMAODNANOAODoutput', 'PoolOutputModule', 'NANOAOD', 'output.root', outputCommands_)])
+            #ALCARECO empty
+            #THIS DOES NOT STOP THE ADDITION LIKE THE OTHER BRANCH
+            process = cms.Process("TEST")
+            options.scenario = "TEST"
+            options.datatier= "ALCARECO"
+            options.eventcontent="ALCARECO"
+            options.outputDefinition = str([dict(tier='ALCARECO', eventContent='ALCARECO'),])
+            #OTHER BRANCH DOES NOT NEED THE FOLLOWING
+            outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
+            process.ALCARECOEventContent = cms.PSet( outputCommands = outputCommands_)
+            #_test_addOutput(self, options, process, [])
+            outs = _test_addOutput(self, options, process, [OutStats('ALCARECOoutput', 'PoolOutputModule', 'ALCARECO', 'output.root', outputCommands_)], lambda cb: setattr(cb, 'AlCaPaths',[]))
+            #ALCARECO present
+            process = cms.Process("TEST")
+            outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
+            process.ALCARECOEventContent = cms.PSet( outputCommands = outputCommands_)
+            options = copy.deepcopy(defaultOptions)
+            options.scenario = "TEST"
+            options.outputDefinition = str([dict(tier='ALCARECO', eventContent='ALCARECO'),])
+            options.step = 'ALCAPRODUCER'
+            outs = _test_addOutput(self, options, process, [OutStats('ALCARECOoutput', 'PoolOutputModule', 'ALCARECO', 'output.root', outputCommands_)], lambda cb: setattr(cb, 'AlCaPaths', []))
+            self.assertEqual(outs[0].dataset.filterName, cms.untracked.string('StreamALCACombined'))
+            #AOD+MINIAOD
+            process = cms.Process("TEST")
+            outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
+            process.AODEventContent = cms.PSet( outputCommands = outputCommands_)
+            process.MINIAODEventContent = cms.PSet( outputCommands = outputCommands_)
+            options = copy.deepcopy(defaultOptions)
+            options.fileout = 'stepN.root'
+            options.scenario = "TEST"
+            options.outputDefinition = str([dict(tier='AOD'),dict(tier='MINIAOD')])
+            _test_addOutput(self, options, process, [OutStats('AODoutput','PoolOutputModule','AOD','stepN.root',outputCommands_), OutStats('MINIAODoutput','PoolOutputModule','MINIAOD','stepN_inMINIAOD.root',outputCommands_)])
+            #MINIAOD & generation_step
+            process = cms.Process("TEST")
+            outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
+            process.MINIAODEventContent = cms.PSet( outputCommands = outputCommands_)
+            process.generation_step = cms.Path()
+            options = copy.deepcopy(defaultOptions)
+            options.fileout = 'stepN.root'
+            options.scenario = "TEST"
+            options.outputDefinition = str([dict(tier='MINIAOD'),])
+            out = _test_addOutput(self, options, process, [OutStats('MINIAODoutput','PoolOutputModule','MINIAOD','stepN.root',outputCommands_)])
+            self.assertEqual(out[0].SelectEvents.SelectEvents, cms.vstring('generation_step'))
+            #MINIAOD & filtering_step
+            process = cms.Process("TEST")
+            outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
+            process.MINIAODEventContent = cms.PSet( outputCommands = outputCommands_)
+            process.filtering_step = cms.Path()
+            options = copy.deepcopy(defaultOptions)
+            options.fileout = 'stepN.root'
+            options.scenario = "TEST"
+            options.outputDefinition = str([dict(tier='MINIAOD'),])
+            out = _test_addOutput(self, options, process, [OutStats('MINIAODoutput','PoolOutputModule','MINIAOD','stepN.root',outputCommands_)])
+            self.assertEqual(out[0].SelectEvents.SelectEvents, cms.vstring('filtering_step'))
+            #LHE & generation_step
+            process = cms.Process("TEST")
+            outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
+            process.LHEEventContent = cms.PSet( outputCommands = outputCommands_)
+            process.generation_step = cms.Path()
+            options = copy.deepcopy(defaultOptions)
+            options.fileout = 'stepN.root'
+            options.scenario = "TEST"
+            options.outputDefinition = str([dict(tier='LHE'),])
+            out = _test_addOutput(self, options, process, [OutStats('LHEoutput','PoolOutputModule','LHE','stepN.root',outputCommands_)])
+            self.assertFalse(hasattr(out[0],"SelectEvents"))
+
     unittest.main()
+

--- a/Configuration/Applications/test/ConfigBuilderTest.py
+++ b/Configuration/Applications/test/ConfigBuilderTest.py
@@ -130,6 +130,16 @@ if __name__=="__main__":
             options.datatier= "MINIAOD"
             options.eventcontent="MINIAOD"
             _test_addOutput(self, options, process, [OutStats('MINIAODoutput','PoolOutputModule','MINIAOD','output.root',outputCommands_)])
+            #MINIAOD w/ RNTuple
+            process = cms.Process("TEST")
+            outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
+            process.MINIAODEventContent = cms.PSet( outputCommands = outputCommands_)
+            options = copy.deepcopy(defaultOptions)
+            options.scenario = "TEST"
+            options.datatier= "MINIAOD"
+            options.eventcontent="MINIAOD"
+            options.rntuple_out = True
+            _test_addOutput(self, options, process, [OutStats('MINIAODoutput','RNTupleOutputModule','MINIAOD','output.rntpl',outputCommands_)])
             #MINIAOD1 [NOTE notiation not restricted to MINIAOD]
             #NOT SUPPORTED BY outputDefinition
             process = cms.Process("TEST")
@@ -149,6 +159,16 @@ if __name__=="__main__":
             options.datatier= "DQMIO"
             options.eventcontent="DQM"
             _test_addOutput(self, options, process, [OutStats('DQMoutput','DQMRootOutputModule','DQMIO','output.root',outputCommands_)])
+            #DQMIO & rntuple (will not change)
+            process = cms.Process("TEST")
+            outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
+            process.DQMEventContent = cms.PSet( outputCommands = outputCommands_)
+            options = copy.deepcopy(defaultOptions)
+            options.scenario = "TEST"
+            options.datatier= "DQMIO"
+            options.eventcontent="DQM"
+            options.rntuple_out = True
+            _test_addOutput(self, options, process, [OutStats('DQMoutput','DQMRootOutputModule','DQMIO','output.root',outputCommands_)])
             #DQMIO&DQMIO
             process = cms.Process("TEST")
             outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
@@ -157,6 +177,16 @@ if __name__=="__main__":
             options.scenario = "TEST"
             options.datatier= "DQMIO"
             options.eventcontent="DQMIO"
+            _test_addOutput(self, options, process, [OutStats('DQMoutput','DQMRootOutputModule','DQMIO','output.root',outputCommands_)])
+            #DQMIO&DQMIO & rntuple (will not change)
+            process = cms.Process("TEST")
+            outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
+            process.DQMEventContent = cms.PSet( outputCommands = outputCommands_)
+            options = copy.deepcopy(defaultOptions)
+            options.scenario = "TEST"
+            options.datatier= "DQMIO"
+            options.eventcontent="DQMIO"
+            options.rntuple_out = True
             _test_addOutput(self, options, process, [OutStats('DQMoutput','DQMRootOutputModule','DQMIO','output.root',outputCommands_)])
             #DQM, not DQMIO (decided by datatier)
             process = cms.Process("TEST")
@@ -185,6 +215,26 @@ if __name__=="__main__":
             options.datatier= "NANOAOD"
             options.eventcontent="NANOEDMAOD"
             _test_addOutput(self, options, process, [OutStats('NANOEDMAODoutput', 'PoolOutputModule', 'NANOAOD', 'output.root', outputCommands_)])
+            #NANOAOD & rntuple (no change)
+            process = cms.Process("TEST")
+            outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
+            process.NANOAODEventContent = cms.PSet( outputCommands = outputCommands_)
+            options = copy.deepcopy(defaultOptions)
+            options.scenario = "TEST"
+            options.datatier= "NANOAOD"
+            options.eventcontent="NANOAOD"
+            options.rntuple_out = True
+            _test_addOutput(self, options, process, [OutStats('NANOAODoutput','NanoAODOutputModule','NANOAOD','output.root',outputCommands_)])
+            #NANOEDMAOD & rntuple
+            process = cms.Process("TEST")
+            outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
+            process.NANOAODEventContent = cms.PSet( outputCommands = outputCommands_)
+            options = copy.deepcopy(defaultOptions)
+            options.scenario = "TEST"
+            options.datatier= "NANOAOD"
+            options.eventcontent="NANOEDMAOD"
+            options.rntuple_out = True
+            _test_addOutput(self, options, process, [OutStats('NANOEDMAODoutput', 'RNTupleOutputModule', 'NANOAOD', 'output.rntpl', outputCommands_)])
             #ALCARECO empty
             process = cms.Process("TEST")
             options.scenario = "TEST"


### PR DESCRIPTION
#### PR description:

- extended unit test for checking of output handling
- extended --filetype to accept 'EDM_RNTUPLE'
- added --rntuple_out to switch output to use RNTupleOutputModule when possible

#### PR validation:

- New unit tests pass
- A few runs of `cmsDriver.py` with `--no_exec` and new command line options appear to generate correct configurations.

NOTE: this change is purely technical and is not supposed to cause any behavioral change to the present use of ConfigBuilder.py and cmsDriver.py.

resolves https://github.com/cms-sw/framework-team/issues/1257