### PR TITLE
Backport Raw Skims CMSSW_14_2_X

### DIFF
--- a/Configuration/DataProcessing/test/RunRepack.py
+++ b/Configuration/DataProcessing/test/RunRepack.py
@@ -5,7 +5,6 @@ _RunRepack_
 Test/Debugging harness for the repack configuration builder
 
 """
-from __future__ import print_function
 
 import sys
 import getopt
@@ -19,6 +18,8 @@ class RunRepack:
         self.selectEvents = None
         self.inputLFN = None
         self.dataTier = None
+        self.rawSkim = None
+        self.globalTag= None
 
     def __call__(self):
         if self.inputLFN == None:
@@ -37,9 +38,11 @@ class RunRepack:
         if self.selectEvents != None:
             outputs[0]['selectEvents'] = self.selectEvents.split(',')
             outputs[1]['selectEvents'] = self.selectEvents.split(',')
-
+        if self.rawSkim != None:
+            outputs[0]['rawSkim'] = self.rawSkim
+            outputs[1]['rawSkim'] = None
         try:
-            process = repackProcess(outputs = outputs, dataTier = self.dataTier)
+            process = repackProcess(outputs = outputs, globalTag = self.globalTag, dataTier = self.dataTier)
         except Exception as ex:
             msg = "Error creating process for Repack:\n"
             msg += str(ex)
@@ -61,7 +64,7 @@ class RunRepack:
 
 
 if __name__ == '__main__':
-    valid = ["select-events=", "lfn=", "data-tier="]
+    valid = ["select-events=", "lfn=", "data-tier=", "raw-skim=", "global-tag="]
              
     usage = \
 """
@@ -93,6 +96,10 @@ python RunRepack.py --select-events HLT:path1,HLT:path2 --lfn /store/whatever --
             repackinator.inputLFN = arg
         if opt == "--data-tier" :
             repackinator.dataTier = arg
+        if opt == "--raw-skim":
+            repackinator.rawSkim = arg
+        if opt == "--global-tag":
+            repackinator.globalTag = arg
 
     repackinator()
 

--- a/Configuration/Skimming/python/RAWSkims_cff.py
+++ b/Configuration/Skimming/python/RAWSkims_cff.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+import HLTrigger.HLTfilters.hltHighLevel_cfi as hlt
+
+# ReserveDMu raw skim already exists, so we import it
+from Configuration.Skimming.PDWG_ReserveDMu_SD_cff import ReserveDMu
+
+# Define here another raw skim if desired
+


### PR DESCRIPTION
#### PR description:

* Changes expected in the output:
   * This is an implementation of the Reserved dataset discussed in https://its.cern.ch/jira/browse/CMSTZ-1048. The output RAW file from the Repack workflow does not contain all triggers in the HLT path `Dataset_ParkingDoubleMuonLowMass0`, in other words it is skimmed. This is a separate workflow than that of `ParkingDoubleMuonLowMass0`, so the original `ParkingDoubleMuonLowMass0/RAW` is still being created separately. The proposed implementation allows for other RAW skims to be created and used for any other dataset.
*  This new functionality is triggered when T0 inserts an output module with `rawSkims`.  Ths implies changes in T0 code and WMCore code:
   * T0: https://github.com/dmwm/T0/pull/5041
   * WMCore:  https://github.com/dmwm/WMCore/pull/12298
* Related documentation:
   * [JIRA-CMSTZ-1048](https://its.cern.ch/jira/browse/CMSTZ-1048)
   * [RAWSkims-google-docs](https://docs.google.com/presentation/d/1mL5FUriH746y8pLl0ZQymKoEPxkg-8H_-8LLGt5_akM/edit#slide=id.gc94ed6e110_0_14 )



#### PR validation:

This PR was tested locally by running the `RunRepack.py` included in this PR, which has also been modified to support the use of raw skims. The command used is:

```
#source cmsset values
source /cvmfs/cms.cern.ch/cmsset_default.sh

# define architecture
export SCRAM_ARCH "el8_amd64_gcc12"

#create the project with CMSSW version
scramv1 project CMSSW "CMSSW_14_0_15_patch1"

# Move to src folder
cd "CMSSW_14_0_15_patch1/src/" 
cmsenv
git cms-init
git cms-addpkg Configuration/DataProcessing
git cms-addpkg Configuration/Skimming

### Apply changes presented in this PR ###

# Build changes
scram b

#source cms environment variables
eval "$(scramv1 runtime -sh)"

python3 "Configuration/DataProcessing/test/RunRepack.py" \
        --select-events "Dataset_ParkingDoubleMuonLowMass0:HLT,Dataset_ParkingDoubleMuonLowMass0:HLT" \
        --lfn "file:/eos/cms/store/t0streamer/Data/ParkingDoubleMuonLowMass0/000/386/925/run386925_ls0001_streamParkingDoubleMuonLowMass0_StorageManager.dat" \
        --raw-skim "ReserveDMu" \
        --global-tag "141X_dataRun3_Prompt_v4" || { echo "Unable to create PSet"; exit 1; }

```

The `Repack.py` file takes a set of arguments `**args`. T0 provides a list of `outputs` and a `dataTier`. The `list` of `outputs` will have dictionaries, each containing relevant output modules for each dataset. This new feature requires that a `rawSkim` is provided within each `output` that requires skimming, and a new `arg` `globalTag` in order to access the paths in the selected `rawSkim`. For this test we used `rawSkim = "ReserveDMu"` and `globalTag = "141X_dataRun3_Prompt_v4"`. The workflow creates two output modules in `outputs`, one will have the `rawSkim` and the other wont. Both will take the same HLT Path `Dataset_ParkingDoubleMuonLowMass0`. The streamer file is the same, with 200 events tota: 103 events from `Dataset_ParkingDoubleMuonLowMass0` and 97 from `Dataset_ParkingDoubleMuonLowMass1`. The first output, since it has the raw skim, will filter out events out of the total 200 events. This output is a RAW file with 114 events. The second output does not have a `rawSkim`, so it will only take events from the `Dataset_ParkingDoubleMuonLowMass0`, which is 103. Such second output is as predicted, with 103 events.

For transparency, the `RunRepackCfg.py` as well as both outputs `write_PrimDS_skimmed.root` and `write_PrimDS_unskimmed.root` have been placed in
```
/eos/home-c/cmst0/public/RawSkimTest/write_PrimDS_skimmed.root
```

This is a backport to CMSSW_14_2_X. The master PR is [cms-sw/cmssw#47525](https://github.com/cms-sw/cmssw/pull/47525)
