### PR TITLE
Added macro for generating element-wise methods to the SoAs

### DIFF
--- a/DataFormats/SoATemplate/README.md
+++ b/DataFormats/SoATemplate/README.md
@@ -62,6 +62,10 @@ function of a `View` or `ConstView`. Every object contains the address of the fi
 of elements per column, and the stride for the Eigen columns. These are used to validate the columns size at run time 
 and to build a generic `View` as described in [View](#view).
 
+## Customized methods
+
+It is possible to generate methods inside the `element` and `const_element` nested structs using the `SOA_ELEMENT_METHODS` and `SOA_CONST_ELEMENT_METHODS` macros. Each of these macros can be called only once, and can define multiple methods. [An example is showed below.](#examples)
+
 ## ROOT serialization and de-serialization
 
 Layouts can be serialized and de-serialized with ROOT. In order to generate the ROOT dictionary, separate
@@ -139,6 +143,40 @@ using SoA1Layout = SoA1LayoutTemplate<>;
 using SoA1LayoutAligned = SoA1LayoutTemplate<cms::soa::CacheLineSize::defaultSize, cms::soa::AlignmentEnforcement::enforced>;
 ```
 
+It is possible to declare methods that operate on the SoA elements:
+
+```C++
+#include "DataFormats/SoALayout.h"
+
+GENERATE_SOA_LAYOUT(SoATemplate,
+  SOA_COLUMN(double, x),
+  SOA_COLUMN(double, y),
+  SOA_COLUMN(double, z),
+  
+  // methods operating on const_element
+  SOA_CONST_METHODS(
+    auto norm() const {
+      return sqrt(x()*x() + y()+y() + z()*z());
+    }
+  ),
+
+  // methods operating on element
+  SOA_METHODS(
+    void scale(float arg) {
+      x() *= arg;
+      y() *= arg;
+      z() *= arg;
+    }
+  ),
+  
+  SOA_SCALAR(int, detectorType)
+);
+
+using SoA = SoATemplate<>;
+using SoAView = SoA::View;
+using SoAConstView = SoA::ConstView;
+```
+
 The buffer of the proper size is allocated, and the layout is populated with:
 
 ```C++
@@ -211,8 +249,6 @@ template<size_t ALIGNMENT = cms::soa::CacheLineSize::defaultSize,
          bool RANGE_CHECKING = cms::soa::RangeChecking::disabled>
 struct SoA1Layout::ConstViewTemplateFreeParams;
 ```
-
-
 
 ## Current status and further improvements
 

--- a/DataFormats/SoATemplate/interface/SoALayout.h
+++ b/DataFormats/SoATemplate/interface/SoALayout.h
@@ -57,7 +57,27 @@
  */
 
 // clang-format off
-#define _DECLARE_SOA_STREAM_INFO_IMPL(VALUE_TYPE, CPP_TYPE, NAME)                                                      \
+#define _COUNT_SOA_METHODS_IMPL(VALUE_TYPE, CPP_TYPE, NAME, ARGS, DATA)                                                \
+        BOOST_PP_IF(BOOST_PP_EQUAL(VALUE_TYPE, _VALUE_TYPE_METHOD),                                                    \
+                    DATA++;,                                                                                           \
+                    BOOST_PP_EMPTY())  
+// clang-format on                         
+                   
+#define _COUNT_SOA_METHODS(R, DATA, TYPE_NAME)                                                                         \
+        BOOST_PP_EXPAND(_COUNT_SOA_METHODS_IMPL BOOST_PP_TUPLE_PUSH_BACK(TYPE_NAME, DATA))     
+
+// clang-format off
+#define _COUNT_SOA_CONST_METHODS_IMPL(VALUE_TYPE, CPP_TYPE, NAME, ARGS, DATA)                                          \
+        BOOST_PP_IF(BOOST_PP_EQUAL(VALUE_TYPE, _VALUE_TYPE_CONST_METHOD),                                              \
+                    DATA++;,                                                                                           \
+                    BOOST_PP_EMPTY())  
+// clang-format on                         
+                   
+#define _COUNT_SOA_CONST_METHODS(R, DATA, TYPE_NAME)                                                                   \
+        BOOST_PP_EXPAND(_COUNT_SOA_CONST_METHODS_IMPL BOOST_PP_TUPLE_PUSH_BACK(TYPE_NAME, DATA))  
+
+// clang-format off
+#define _DECLARE_SOA_STREAM_INFO_IMPL(VALUE_TYPE, CPP_TYPE, NAME, ARGS)                                                \
   _SWITCH_ON_TYPE(                                                                                                     \
       VALUE_TYPE,                                                                                                      \
       /* Dump scalar */                                                                                                \
@@ -88,13 +108,18 @@
   )
 // clang-format on
 
-#define _DECLARE_SOA_STREAM_INFO(R, DATA, TYPE_NAME) BOOST_PP_EXPAND(_DECLARE_SOA_STREAM_INFO_IMPL TYPE_NAME)
+// clang-format off
+#define _DECLARE_SOA_STREAM_INFO(R, DATA, TYPE_NAME)                                                                   \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, TYPE_NAME), _VALUE_LAST_COLUMN_TYPE),                            \
+              BOOST_PP_EMPTY(),                                                                                        \
+              BOOST_PP_EXPAND(_DECLARE_SOA_STREAM_INFO_IMPL TYPE_NAME))
+// clang-format on
 
 /**
  * Metadata member computing column pitch
  */
 // clang-format off
-#define _DEFINE_METADATA_MEMBERS_IMPL(VALUE_TYPE, CPP_TYPE, NAME)                                                      \
+#define _DEFINE_METADATA_MEMBERS_IMPL(VALUE_TYPE, CPP_TYPE, NAME, ARGS)                                                \
   _SWITCH_ON_TYPE(VALUE_TYPE,                                                                                          \
       /* Scalar */                                                                                                     \
       byte_size_type BOOST_PP_CAT(NAME, Pitch()) const {                                                               \
@@ -164,44 +189,58 @@
       }                                                                                                                \
 )
 // clang-format on
-#define _DEFINE_METADATA_MEMBERS(R, DATA, TYPE_NAME) _DEFINE_METADATA_MEMBERS_IMPL TYPE_NAME
 
 // clang-format off
-#define _DECLARE_MEMBER_TRIVIAL_CONSTRUCTION_IMPL(VALUE_TYPE, CPP_TYPE, NAME)                                          \
+#define _DEFINE_METADATA_MEMBERS(R, DATA, TYPE_NAME)                                                                   \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, TYPE_NAME), _VALUE_LAST_COLUMN_TYPE),                            \
+              BOOST_PP_EMPTY(),                                                                                        \
+              BOOST_PP_EXPAND(_DEFINE_METADATA_MEMBERS_IMPL TYPE_NAME))
+// clang-format on
+
+// clang-format off
+#define _DECLARE_MEMBER_TRIVIAL_CONSTRUCTION_IMPL(VALUE_TYPE, CPP_TYPE, NAME, ARGS)                                    \
   _SWITCH_ON_TYPE(VALUE_TYPE,                                                                                          \
       /* Scalar */                                                                                                     \
       (BOOST_PP_CAT(NAME, _)(nullptr)),                                                                                \
       /* Column */                                                                                                     \
       (BOOST_PP_CAT(NAME, _)(nullptr)),                                                                                \
       /* Eigen column */                                                                                               \
-      (BOOST_PP_CAT(NAME, Stride_)(0))                                                                                 \
       (BOOST_PP_CAT(NAME, ElementsWithPadding_)(0))                                                                    \
       (BOOST_PP_CAT(NAME, _)(nullptr))                                                                                 \
+      (BOOST_PP_CAT(NAME, Stride_)(0))                                                                                 \
   )
 // clang-format on
 
-#define _DECLARE_MEMBER_TRIVIAL_CONSTRUCTION(R, DATA, TYPE_NAME) \
-  BOOST_PP_EXPAND(_DECLARE_MEMBER_TRIVIAL_CONSTRUCTION_IMPL TYPE_NAME)
-
 // clang-format off
-#define _DECLARE_MEMBER_COPY_CONSTRUCTION_IMPL(VALUE_TYPE, CPP_TYPE, NAME)                                             \
+#define _DECLARE_MEMBER_TRIVIAL_CONSTRUCTION(R, DATA, TYPE_NAME)                                                       \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, TYPE_NAME), _VALUE_LAST_COLUMN_TYPE),                            \
+              BOOST_PP_EMPTY(),                                                                                        \
+              BOOST_PP_EXPAND(_DECLARE_MEMBER_TRIVIAL_CONSTRUCTION_IMPL TYPE_NAME))
+// clang-format on            
+              
+// clang-format off
+#define _DECLARE_MEMBER_COPY_CONSTRUCTION_IMPL(VALUE_TYPE, CPP_TYPE, NAME, ARGS)                                       \
   _SWITCH_ON_TYPE(VALUE_TYPE,                                                                                          \
       /* Scalar */                                                                                                     \
       (BOOST_PP_CAT(NAME, _){_soa_impl_other.BOOST_PP_CAT(NAME, _)}),                                                  \
       /* Column */                                                                                                     \
       (BOOST_PP_CAT(NAME, _){_soa_impl_other.BOOST_PP_CAT(NAME, _)}),                                                  \
       /* Eigen column */                                                                                               \
-      (BOOST_PP_CAT(NAME, Stride_){_soa_impl_other.BOOST_PP_CAT(NAME, Stride_)})                                       \
       (BOOST_PP_CAT(NAME, ElementsWithPadding_){_soa_impl_other.BOOST_PP_CAT(NAME, ElementsWithPadding_)})             \
       (BOOST_PP_CAT(NAME, _){_soa_impl_other.BOOST_PP_CAT(NAME, _)})                                                   \
+      (BOOST_PP_CAT(NAME, Stride_){_soa_impl_other.BOOST_PP_CAT(NAME, Stride_)})                                       \
   )
 // clang-format on
 
-#define _DECLARE_MEMBER_COPY_CONSTRUCTION(R, DATA, TYPE_NAME) \
-  BOOST_PP_EXPAND(_DECLARE_MEMBER_COPY_CONSTRUCTION_IMPL TYPE_NAME)
+// clang-format off
+#define _DECLARE_MEMBER_COPY_CONSTRUCTION(R, DATA, TYPE_NAME)                                                          \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, TYPE_NAME), _VALUE_LAST_COLUMN_TYPE),                            \
+              BOOST_PP_EMPTY(),                                                                                        \
+              BOOST_PP_EXPAND(_DECLARE_MEMBER_COPY_CONSTRUCTION_IMPL TYPE_NAME))
+// clang-format on
 
 // clang-format off
-#define _DECLARE_MEMBER_ASSIGNMENT_IMPL(VALUE_TYPE, CPP_TYPE, NAME)                                                    \
+#define _DECLARE_MEMBER_ASSIGNMENT_IMPL(VALUE_TYPE, CPP_TYPE, NAME, ARGS)                                              \
   _SWITCH_ON_TYPE(VALUE_TYPE,                                                                                          \
       /* Scalar */                                                                                                     \
       BOOST_PP_CAT(NAME, _) = _soa_impl_other.BOOST_PP_CAT(NAME, _);,                                                  \
@@ -214,13 +253,18 @@
   )
 // clang-format on
 
-#define _DECLARE_MEMBER_ASSIGNMENT(R, DATA, TYPE_NAME) BOOST_PP_EXPAND(_DECLARE_MEMBER_ASSIGNMENT_IMPL TYPE_NAME)
+// clang-format off
+#define _DECLARE_MEMBER_ASSIGNMENT(R, DATA, TYPE_NAME)                                                                 \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, TYPE_NAME), _VALUE_LAST_COLUMN_TYPE),                            \
+              BOOST_PP_EMPTY(),                                                                                        \
+              BOOST_PP_EXPAND(_DECLARE_MEMBER_ASSIGNMENT_IMPL TYPE_NAME))
+// clang-format on
 
 /**
  * Declare the value_element data members
  */
 // clang-format off
-#define _DEFINE_VALUE_ELEMENT_MEMBERS_IMPL(VALUE_TYPE, CPP_TYPE, NAME)                                                 \
+#define _DEFINE_VALUE_ELEMENT_MEMBERS_IMPL(VALUE_TYPE, CPP_TYPE, NAME, ARGS)                                           \
   _SWITCH_ON_TYPE(VALUE_TYPE,                                                                                          \
       /* Scalar (empty) */                                                                                             \
       ,                                                                                                                \
@@ -232,13 +276,18 @@
   )
 // clang-format on
 
-#define _DEFINE_VALUE_ELEMENT_MEMBERS(R, DATA, TYPE_NAME) _DEFINE_VALUE_ELEMENT_MEMBERS_IMPL TYPE_NAME
+// clang-format off
+#define _DEFINE_VALUE_ELEMENT_MEMBERS(R, DATA, TYPE_NAME)                                                              \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, TYPE_NAME), _VALUE_LAST_COLUMN_TYPE),                            \
+              BOOST_PP_EMPTY(),                                                                                        \
+              BOOST_PP_EXPAND(_DEFINE_VALUE_ELEMENT_MEMBERS_IMPL TYPE_NAME))
+// clang-format on
 
 /**
  * List of data members in the value_element constructor arguments
  */
 // clang-format off
-#define _VALUE_ELEMENT_CTOR_ARGS_IMPL(VALUE_TYPE, CPP_TYPE, NAME)                                                      \
+#define _VALUE_ELEMENT_CTOR_ARGS_IMPL(VALUE_TYPE, CPP_TYPE, NAME, ARGS)                                                \
   _SWITCH_ON_TYPE(VALUE_TYPE,                                                                                          \
       /* Scalar (empty) */                                                                                             \
       ,                                                                                                                \
@@ -249,13 +298,18 @@
   )
 // clang-format on
 
-#define _VALUE_ELEMENT_CTOR_ARGS(R, DATA, TYPE_NAME) BOOST_PP_EXPAND(_VALUE_ELEMENT_CTOR_ARGS_IMPL TYPE_NAME)
+// clang-format off
+#define _VALUE_ELEMENT_CTOR_ARGS(R, DATA, TYPE_NAME)                                                                   \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, TYPE_NAME), _VALUE_LAST_COLUMN_TYPE),                            \
+              BOOST_PP_EMPTY(),                                                                                        \
+              BOOST_PP_EXPAND(_VALUE_ELEMENT_CTOR_ARGS_IMPL TYPE_NAME))
+// clang-format on
 
 /**
  * List-initalise the value_element data members
  */
 // clang-format off
-#define _VALUE_ELEMENT_INITIALIZERS_IMPL(VALUE_TYPE, CPP_TYPE, NAME)                                                   \
+#define _VALUE_ELEMENT_INITIALIZERS_IMPL(VALUE_TYPE, CPP_TYPE, NAME, ARGS)                                             \
   _SWITCH_ON_TYPE(VALUE_TYPE,                                                                                          \
       /* Scalar (empty) */                                                                                             \
       ,                                                                                                                \
@@ -266,24 +320,34 @@
   )
 // clang-format on
 
-#define _VALUE_ELEMENT_INITIALIZERS(R, DATA, TYPE_NAME) BOOST_PP_EXPAND(_VALUE_ELEMENT_INITIALIZERS_IMPL TYPE_NAME)
+// clang-format off
+#define _VALUE_ELEMENT_INITIALIZERS(R, DATA, TYPE_NAME)                                                                \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, TYPE_NAME), _VALUE_LAST_COLUMN_TYPE),                            \
+              BOOST_PP_EMPTY(),                                                                                        \
+              BOOST_PP_EXPAND(_VALUE_ELEMENT_INITIALIZERS_IMPL TYPE_NAME))
+// clang-format on
 
 /**
  * Freeing of the ROOT-allocated column or scalar buffer
  */
 // clang-format off
-#define _ROOT_FREE_SOA_COLUMN_OR_SCALAR_IMPL(VALUE_TYPE, CPP_TYPE, NAME)                                               \
+#define _ROOT_FREE_SOA_COLUMN_OR_SCALAR_IMPL(VALUE_TYPE, CPP_TYPE, NAME, ARGS)                                         \
   delete[] BOOST_PP_CAT(NAME, _);                                                                                      \
-  BOOST_PP_CAT(NAME, _) = nullptr; \
-  // clang-format on
+  BOOST_PP_CAT(NAME, _) = nullptr;
+// clang-format on
 
-#define _ROOT_FREE_SOA_COLUMN_OR_SCALAR(R, DATA, TYPE_NAME) _ROOT_FREE_SOA_COLUMN_OR_SCALAR_IMPL TYPE_NAME
+// clang-format off
+#define _ROOT_FREE_SOA_COLUMN_OR_SCALAR(R, DATA, TYPE_NAME)                                                            \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, TYPE_NAME), _VALUE_LAST_COLUMN_TYPE),                            \
+              BOOST_PP_EMPTY(),                                                                                        \
+              BOOST_PP_EXPAND(_ROOT_FREE_SOA_COLUMN_OR_SCALAR_IMPL TYPE_NAME))
+// clang-format on
 
 /**
  * Computation of the column or scalar pointer location in the memory layout (at SoA construction time)
  */
 // clang-format off
-#define _ASSIGN_SOA_COLUMN_OR_SCALAR_IMPL(VALUE_TYPE, CPP_TYPE, NAME)                                                  \
+#define _ASSIGN_SOA_COLUMN_OR_SCALAR_IMPL(VALUE_TYPE, CPP_TYPE, NAME, ARGS)                                            \
   _SWITCH_ON_TYPE(VALUE_TYPE,                                                                                          \
       /* Scalar */                                                                                                     \
       BOOST_PP_CAT(NAME, _) = reinterpret_cast<CPP_TYPE*>(_soa_impl_curMem);                                           \
@@ -307,13 +371,18 @@
       throw std::runtime_error("In layout constructor: misaligned column: " #NAME);
 // clang-format on
 
-#define _ASSIGN_SOA_COLUMN_OR_SCALAR(R, DATA, TYPE_NAME) _ASSIGN_SOA_COLUMN_OR_SCALAR_IMPL TYPE_NAME
+// clang-format off
+#define _ASSIGN_SOA_COLUMN_OR_SCALAR(R, DATA, TYPE_NAME)                                                               \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, TYPE_NAME), _VALUE_LAST_COLUMN_TYPE),                            \
+              BOOST_PP_EMPTY(),                                                                                        \
+              BOOST_PP_EXPAND(_ASSIGN_SOA_COLUMN_OR_SCALAR_IMPL TYPE_NAME))
+// clang-format on
 
 /**
  * Computation of the column or scalar size for SoA size computation
  */
 // clang-format off
-#define _ACCUMULATE_SOA_ELEMENT_IMPL(VALUE_TYPE, CPP_TYPE, NAME)                                                       \
+#define _ACCUMULATE_SOA_ELEMENT_IMPL(VALUE_TYPE, CPP_TYPE, NAME, ARGS)                                                 \
   _SWITCH_ON_TYPE(VALUE_TYPE,                                                                                          \
       /* Scalar */                                                                                                     \
       _soa_impl_ret += cms::soa::alignSize(sizeof(CPP_TYPE), alignment);                                               \
@@ -327,13 +396,18 @@
   )
 // clang-format on
 
-#define _ACCUMULATE_SOA_ELEMENT(R, DATA, TYPE_NAME) _ACCUMULATE_SOA_ELEMENT_IMPL TYPE_NAME
+// clang-format off
+#define _ACCUMULATE_SOA_ELEMENT(R, DATA, TYPE_NAME)                                                                    \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, TYPE_NAME), _VALUE_LAST_COLUMN_TYPE),                            \
+              BOOST_PP_EMPTY(),                                                                                        \
+              BOOST_PP_EXPAND(_ACCUMULATE_SOA_ELEMENT_IMPL TYPE_NAME))
+// clang-format on
 
 /**
  * Direct access to column pointer and indexed access
  */
 // clang-format off
-#define _DECLARE_SOA_ACCESSOR_IMPL(VALUE_TYPE, CPP_TYPE, NAME)                                                         \
+#define _DECLARE_SOA_ACCESSOR_IMPL(VALUE_TYPE, CPP_TYPE, NAME, ARGS)                                                   \
   _SWITCH_ON_TYPE(VALUE_TYPE,                                                                                          \
       /* Scalar */                                                                                                     \
       SOA_HOST_DEVICE SOA_INLINE CPP_TYPE& NAME() { return *BOOST_PP_CAT(NAME, _); }                                   \
@@ -350,13 +424,18 @@
   )
 // clang-format on
 
-#define _DECLARE_SOA_ACCESSOR(R, DATA, TYPE_NAME) BOOST_PP_EXPAND(_DECLARE_SOA_ACCESSOR_IMPL TYPE_NAME)
+// clang-format off
+#define _DECLARE_SOA_ACCESSOR(R, DATA, TYPE_NAME)                                                                      \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, TYPE_NAME), _VALUE_LAST_COLUMN_TYPE),                            \
+              BOOST_PP_EMPTY(),                                                                                        \
+              BOOST_PP_EXPAND(_DECLARE_SOA_ACCESSOR_IMPL TYPE_NAME))
+// clang-format on
 
 /**
  * Direct access to column pointer (const) and indexed access.
  */
 // clang-format off
-#define _DECLARE_SOA_CONST_ACCESSOR_IMPL(VALUE_TYPE, CPP_TYPE, NAME)                                                   \
+#define _DECLARE_SOA_CONST_ACCESSOR_IMPL(VALUE_TYPE, CPP_TYPE, NAME, ARGS)                                             \
   _SWITCH_ON_TYPE(VALUE_TYPE,                                                                                          \
       /* Scalar */                                                                                                     \
       SOA_HOST_DEVICE SOA_INLINE CPP_TYPE NAME() const { return *(BOOST_PP_CAT(NAME, _)); }                            \
@@ -373,13 +452,18 @@
   )
 // clang-format on
 
-#define _DECLARE_SOA_CONST_ACCESSOR(R, DATA, TYPE_NAME) BOOST_PP_EXPAND(_DECLARE_SOA_CONST_ACCESSOR_IMPL TYPE_NAME)
+// clang-format off
+#define _DECLARE_SOA_CONST_ACCESSOR(R, DATA, TYPE_NAME)                                                                \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, TYPE_NAME), _VALUE_LAST_COLUMN_TYPE),                            \
+              BOOST_PP_EMPTY(),                                                                                        \
+              BOOST_PP_EXPAND(_DECLARE_SOA_CONST_ACCESSOR_IMPL TYPE_NAME))
+// clang-format on
 
 /**
  * SoA member ROOT streamer read (column pointers).
  */
 // clang-format off
-#define _STREAMER_READ_SOA_DATA_MEMBER_IMPL(VALUE_TYPE, CPP_TYPE, NAME)                                                \
+#define _STREAMER_READ_SOA_DATA_MEMBER_IMPL(VALUE_TYPE, CPP_TYPE, NAME, ARGS)                                          \
   _SWITCH_ON_TYPE(VALUE_TYPE,                                                                                          \
       /* Scalar */                                                                                                     \
       memcpy(BOOST_PP_CAT(NAME, _), onfile.BOOST_PP_CAT(NAME, _), sizeof(CPP_TYPE));                                   \
@@ -393,14 +477,18 @@
   )
 // clang-format on
 
-#define _STREAMER_READ_SOA_DATA_MEMBER(R, DATA, TYPE_NAME) \
-  BOOST_PP_EXPAND(_STREAMER_READ_SOA_DATA_MEMBER_IMPL TYPE_NAME)
+// clang-format off
+#define _STREAMER_READ_SOA_DATA_MEMBER(R, DATA, TYPE_NAME)                                                             \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, TYPE_NAME), _VALUE_LAST_COLUMN_TYPE),                            \
+              BOOST_PP_EMPTY(),                                                                                        \
+              BOOST_PP_EXPAND(_STREAMER_READ_SOA_DATA_MEMBER_IMPL TYPE_NAME))
+// clang-format on
 
 /**
  * SoA class member declaration (column pointers).
  */
 // clang-format off
-#define _DECLARE_SOA_DATA_MEMBER_IMPL(VALUE_TYPE, CPP_TYPE, NAME)                                                      \
+#define _DECLARE_SOA_DATA_MEMBER_IMPL(VALUE_TYPE, CPP_TYPE, NAME, ARGS)                                                \
   _SWITCH_ON_TYPE(VALUE_TYPE,                                                                                          \
       /* Scalar */                                                                                                     \
       CPP_TYPE* BOOST_PP_CAT(NAME, _) EDM_REFLEX_SIZE(scalar_) = nullptr;                                              \
@@ -409,15 +497,20 @@
       CPP_TYPE * BOOST_PP_CAT(NAME, _) EDM_REFLEX_SIZE(elements_) = nullptr;                                           \
       ,                                                                                                                \
       /* Eigen column */                                                                                               \
-      byte_size_type BOOST_PP_CAT(NAME, Stride_) = 0;                                                                  \
       size_type BOOST_PP_CAT(NAME, ElementsWithPadding_) = 0; /* For ROOT serialization */                             \
       CPP_TYPE::Scalar * BOOST_PP_CAT(NAME, _) EDM_REFLEX_SIZE(BOOST_PP_CAT(NAME, ElementsWithPadding_)) = nullptr;    \
+      byte_size_type BOOST_PP_CAT(NAME, Stride_) = 0;                                                                  \
   )
 // clang-format on
 
-#define _DECLARE_SOA_DATA_MEMBER(R, DATA, TYPE_NAME) BOOST_PP_EXPAND(_DECLARE_SOA_DATA_MEMBER_IMPL TYPE_NAME)
+// clang-format off
+#define _DECLARE_SOA_DATA_MEMBER(R, DATA, TYPE_NAME)                                                                   \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, TYPE_NAME), _VALUE_LAST_COLUMN_TYPE),                            \
+              BOOST_PP_EMPTY(),                                                                                        \
+              BOOST_PP_EXPAND(_DECLARE_SOA_DATA_MEMBER_IMPL TYPE_NAME))
+// clang-format on
 
-#define _COPY_VIEW_COLUMNS_IMPL(VALUE_TYPE, CPP_TYPE, NAME)                                          \
+#define _COPY_VIEW_COLUMNS_IMPL(VALUE_TYPE, CPP_TYPE, NAME, ARGS)                                    \
   _SWITCH_ON_TYPE(                                                                                   \
       VALUE_TYPE, /* Scalar */                                                                       \
       memcpy(BOOST_PP_CAT(this->metadata().addressOf_, NAME)(),                                      \
@@ -434,7 +527,10 @@
                view.metadata().size() * sizeof(CPP_TYPE::Scalar));                                   \
       })
 
-#define _COPY_VIEW_COLUMNS(R, DATA, TYPE_NAME) BOOST_PP_EXPAND(_COPY_VIEW_COLUMNS_IMPL TYPE_NAME)
+#define _COPY_VIEW_COLUMNS(R, DATA, TYPE_NAME)                                              \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, TYPE_NAME), _VALUE_LAST_COLUMN_TYPE), \
+              BOOST_PP_EMPTY(),                                                             \
+              BOOST_PP_EXPAND(_COPY_VIEW_COLUMNS_IMPL TYPE_NAME))
 
 #ifdef DEBUG
 #define _DO_RANGECHECK true
@@ -551,7 +647,7 @@
                     SOA_VIEW_LAYOUT_LIST(                                                                              \
                         SOA_VIEW_LAYOUT(BOOST_PP_CAT(CLASS, _parametrized) , BOOST_PP_CAT(instance_, CLASS))),         \
                     SOA_VIEW_VALUE_LIST(_ITERATE_ON_ALL_COMMA(                                                         \
-                    _VIEW_FIELD_FROM_LAYOUT, BOOST_PP_CAT(instance_, CLASS), __VA_ARGS__)))                            \
+                    _VIEW_FIELD_FROM_LAYOUT, BOOST_PP_CAT(instance_, CLASS), __VA_ARGS__)), __VA_ARGS__)               \
                                                                                                                        \
     template <bool RESTRICT_QUALIFY, bool RANGE_CHECKING>                                                              \
     using ConstViewTemplate = ConstViewTemplateFreeParams<ALIGNMENT, ALIGNMENT_ENFORCEMENT, RESTRICT_QUALIFY,          \
@@ -635,6 +731,24 @@
       if (mem_ + byteSize_ != _soa_impl_curMem)                                                                        \
         throw std::runtime_error("In " #CLASS "::" #CLASS ": unexpected end pointer.");                                \
     }                                                                                                                  \
+                                                                                                                       \
+    /* Helper function to compute the total number of methods */                                                       \
+    static constexpr std::pair<size_type, size_type> computeMethodsNumber() {                                          \
+      size_type _soa_methods_count = 0;                                                                                \
+      size_type _soa_const_methods_count = 0;                                                                          \
+                                                                                                                       \
+      _ITERATE_ON_ALL(_COUNT_SOA_METHODS, _soa_methods_count, __VA_ARGS__)                                             \
+      _ITERATE_ON_ALL(_COUNT_SOA_CONST_METHODS, _soa_const_methods_count, __VA_ARGS__)                                 \
+                                                                                                                       \
+      return {_soa_methods_count, _soa_const_methods_count};                                                           \
+    }                                                                                                                  \
+                                                                                                                       \
+    /* compile-time error launched if more than one macro for methods is declared */                                   \
+    static_assert(computeMethodsNumber().first <= 1,                                                                   \
+          "There can be at most one SOA_METHODS macro. Please declare all your methods inside the same macro.");       \
+                                                                                                                       \
+    static_assert(computeMethodsNumber().second <= 1,                                                                  \
+          "There can be at most one SOA_CONST_METHODS macro. Please declare all your methods inside the same macro."); \
                                                                                                                        \
     /* Data members */                                                                                                 \
     std::byte* mem_ EDM_REFLEX_TRANSIENT;                                                                              \

--- a/DataFormats/SoATemplate/test/BuildFile.xml
+++ b/DataFormats/SoATemplate/test/BuildFile.xml
@@ -27,6 +27,10 @@
   <use name="eigen"/>
 </bin>
 
+<bin file="SoACustomizedMethods_t.cc" name="SoACustomizedMethods_t">
+  <use name="boost"/>
+  <use name="catch2"/>
+</bin>
 
 <!-- This test triggers a bug in ROOT, so it's kept disabled
 <bin file="SoAStreamer_t.cpp" name="SoAStreamer_t">

--- a/DataFormats/SoATemplate/test/SoACustomizedMethods_t.cc
+++ b/DataFormats/SoATemplate/test/SoACustomizedMethods_t.cc
@@ -1,0 +1,118 @@
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+
+GENERATE_SOA_LAYOUT(SoATemplate,
+                    SOA_COLUMN(float, x),
+                    SOA_COLUMN(float, y),
+                    SOA_COLUMN(float, z),
+                    SOA_COLUMN(double, v_x),
+                    SOA_COLUMN(double, v_y),
+                    SOA_COLUMN(double, v_z),
+
+                    SOA_ELEMENT_METHODS(
+
+                        void normalise() {
+                          float norm_position = square_norm_position();
+                          if (norm_position > 0.0f) {
+                            x() /= norm_position;
+                            y() /= norm_position;
+                            z() /= norm_position;
+                          };
+                          double norm_velocity = square_norm_velocity();
+                          if (norm_velocity > 0.0f) {
+                            v_x() /= norm_velocity;
+                            v_y() /= norm_velocity;
+                            v_z() /= norm_velocity;
+                          };
+                        }),
+
+                    SOA_CONST_ELEMENT_METHODS(
+                        float square_norm_position() const { return sqrt(x() * x() + y() * y() + z() * z()); };
+
+                        double square_norm_velocity()
+                            const { return sqrt(v_x() * v_x() + v_y() * v_y() + v_z() * v_z()); };
+
+                        template <typename T1, typename T2>
+                        static auto time(T1 pos, T2 vel) {
+                          if (not(vel == 0))
+                            return pos / vel;
+                          return 0.;
+                        }),
+
+                    SOA_SCALAR(int, detectorType))
+
+using SoA = SoATemplate<>;
+using SoAView = SoA::View;
+using SoAConstView = SoA::ConstView;
+
+TEST_CASE("SoACustomizedMethods") {
+  // common number of elements for the SoAs
+  const std::size_t elems = 10;
+
+  // buffer size
+  const std::size_t bufferSize = SoA::computeDataSize(elems);
+
+  // memory buffer for the SoA
+  std::unique_ptr<std::byte, decltype(std::free) *> buffer{
+      reinterpret_cast<std::byte *>(aligned_alloc(SoA::alignment, bufferSize)), std::free};
+
+  // SoA objects
+  SoA soa{buffer.get(), elems};
+  SoAView view{soa};
+  SoAConstView const_view{soa};
+
+  // fill up
+  for (size_t i = 0; i < elems; i++) {
+    view[i].x() = static_cast<float>(i);
+    view[i].y() = static_cast<float>(i) * 2.0f;
+    view[i].z() = static_cast<float>(i) * 3.0f;
+    view[i].v_x() = static_cast<double>(i);
+    view[i].v_y() = static_cast<double>(i) * 20;
+    view[i].v_z() = static_cast<double>(i) * 30;
+  }
+  view.detectorType() = 42;
+
+  SECTION("ConstView methods") {
+    // arrays of norms
+    std::array<float, elems> position_norms;
+    std::array<double, elems> velocity_norms;
+
+    // Check for the correctness of the square_norm() functions
+    for (size_t i = 0; i < elems; i++) {
+      position_norms[i] = sqrt(const_view[i].x() * const_view[i].x() + const_view[i].y() * const_view[i].y() +
+                               const_view[i].z() * const_view[i].z());
+      velocity_norms[i] = sqrt(const_view[i].v_x() * const_view[i].v_x() + const_view[i].v_y() * const_view[i].v_y() +
+                               const_view[i].v_z() * const_view[i].v_z());
+      REQUIRE(position_norms[i] == const_view[i].square_norm_position());
+      REQUIRE(velocity_norms[i] == const_view[i].square_norm_velocity());
+    }
+  }
+
+  SECTION("View methods") {
+    // array of times
+    std::array<double, elems> times;
+
+    // Check for the correctness of the time() function
+    times[0] = 0.;
+    for (size_t i = 0; i < elems; i++) {
+      if (not(i == 0))
+        times[i] = view[i].x() / view[i].v_x();
+      REQUIRE(times[i] == SoAView::const_element::time(view[i].x(), view[i].v_x()));
+    }
+
+    // normalise the particles data
+    for (size_t i = 0; i < elems; i++) {
+      view[i].normalise();
+    }
+
+    // Check for the norm equal to 1 except for the first element
+    REQUIRE(view[0].square_norm_position() == 0.f);
+    REQUIRE(view[0].square_norm_velocity() == 0.);
+    for (size_t i = 1; i < elems; i++) {
+      REQUIRE_THAT(view[i].square_norm_position(), Catch::Matchers::WithinAbs(1.f, 1.e-6));
+      REQUIRE_THAT(view[i].square_norm_velocity(), Catch::Matchers::WithinAbs(1., 1.e-9));
+    }
+  }
+}


### PR DESCRIPTION
#### PR description:

Added two new macros: `SOA_ELEMENT_METHODS` and `SOA_CONST_ELEMENT_METHODS`. The user can declare functions with an arbitrary number of input and template arguments inside these macros. The functions will act on the elements (rows) of the SoA. A static assert has been added to ensure no multiple calls to these macros within the main macro are done.

#### PR validation:

Added a unit test that passes.

