### PR TITLE
Adding `10224.0` in the `limited` Matrix

### DIFF
--- a/Configuration/PyReleaseValidation/scripts/README.md
+++ b/Configuration/PyReleaseValidation/scripts/README.md
@@ -299,21 +299,22 @@ MC workflows for pp collisions:
 |---	|---	|---	|---	|---	|	
 | |  	|  	|  	|  	|  	
 | **Run1** 	|  	|  	|  	|  	|  	
-| |  	|  	|  	|  	|  	
-| 5.1 	|  	TTbar_8TeV_TuneCUETP8M1 | run1_mc 	|  	| *FastSim* 	|  	
-| 8 	| RelValBeamHalo 	| run1_mc 	|  	| Cosmics 	|  	
-| 9.0 	| RelValHiggs200ChargedTaus 	| run1_mc 	|  	|  	|  	
-| 25 	| RelValTTbar 	| run1_mc 	|  	|  	|  	
+| |  		|  	|  	|  	|  	
+| 5.1 		| TTbar_8TeV_TuneCUETP8M1 | run1_mc 	|  	| *FastSim* 	|  	
+| 8 		| RelValBeamHalo 	| run1_mc 	|  	| Cosmics 	|  	
+| 9.0 		| RelValHiggs200ChargedTaus 	| run1_mc 	|  	|  	|  	
+| 25 		| RelValTTbar 	| run1_mc 	|  	|  	|  	
 | 101.0 	| SingleElectronE120EHCAL 	| run1_mc 	|  	| + ECALHCAL.customise + fullMixCustomize_cff.setCrossingFrameOn 	|  	
 | |  	|  	|  	|  	|  	
 | **Run2** 	|  	|  	|  	|  	|  	
 | |  	|  	|  	|  	|  	
-| 7.3 	| UndergroundCosmicSPLooseMu 	| run2_2018 	|  	|  	|  	
+| 7.3 		| UndergroundCosmicSPLooseMu 	| run2_2018 	|  	|  	|  	
 | 1306.0 	| RelValSingleMuPt1_UP15 	| run2_mc 	| Run2_2016 	| with miniAOD 	|  	
-| 1330 	| RelValZMM_13 	| run2_mc 	| Run2_2016 	|  	|  	
+| 1330 		| RelValZMM_13 	| run2_mc 	| Run2_2016 	|  	|  	
 | 135.4 	| ZEE_13TeV_TuneCUETP8M1 	| run2_mc 	| Run2_2016 	| *FastSim* 	|  	
 | 25202.0 	| RelValTTbar_13 	| run2_mc 	| Run2_2016 	|  AVE_35_BX_25ns 	|  	
-| 250202.181 | RelValTTbar_13 (PREMIX) 	| phase1_2018_realistic 	| Run2_2018 	|  	|  	|  
+| 250202.181 	| RelValTTbar_13 (PREMIX) 	| phase1_2018_realistic 	| Run2_2018 	|  	|  	|  
+| 10224.0       | RelValTTbar_13        | phase1_2017_realistic       | Run2_2017     |  AVE_35_BX_25ns       |
 | |  	|  	|  	|  	|  	
 | **Run3** 	|  	|  	|  	|  	|  	
 | |  	|  	|  	|  	|  	

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -72,8 +72,9 @@ if __name__ == '__main__':
             1306.0,     # RelValSingleMuPt1_UP15
             1330,       # RelValZMM_13
             135.4,      # ZEE_13TeV_TuneCUETP8M1
-            25202.0,    # RelValTTbar_13                PU = AVE_35_BX_25ns
-            250202.181, # RelValTTbar_13                PREMIX
+            25202.0,    # RelValTTbar_13                2016 PU = AVE_35_BX_25ns
+            250202.181, # RelValTTbar_13                2016 PREMIX
+            10224.0,    # RelValTTbar_13                2017 PU = AVE_35_BX_25ns
 
             ###### pp Data
             ## Run1


### PR DESCRIPTION
#### PR description:

This PR proposes to add `10224.0` in the `limited` matrix since this is the [only extra workflow that is manually included in the standard PR tests not already being in the `limited` wf list.](https://github.com/cms-sw/cms-bot/blob/d4ce2a1dcd6e4431f213610bcce75e7d00013292/cmssw-pr-test-config#L17). Once this is done the bot could simply run the standard PR tests with `-l limited`. 

#### PR validation:

None
