### PR TITLE
Fix typos in exception messages in PluginFactoryBase (EdmPluginRefresh to edmPluginRefresh) 

### DIFF
--- a/FWCore/PluginManager/src/PluginFactoryBase.cc
+++ b/FWCore/PluginManager/src/PluginFactoryBase.cc
@@ -72,7 +72,7 @@ namespace edmplugin {
       if (itFound == m_plugins.end()) {
         throw cms::Exception("PluginCacheError")
             << "The plugin '" << iName << "' should have been in loadable\n '" << lib
-            << "'\n but was not there.  This means the plugin cache is incorrect.  Please run 'EdmPluginRefresh " << lib
+            << "'\n but was not there.  This means the plugin cache is incorrect.  Please run 'edmPluginRefresh " << lib
             << "'";
       }
       //The item in the container can still be under construction so wait until the m_ptr has been set since that is done last
@@ -100,7 +100,7 @@ namespace edmplugin {
         if (itFound == m_plugins.end()) {
           throw cms::Exception("PluginCacheError")
               << "The plugin '" << iName << "' should have been in loadable\n '" << lib
-              << "'\n but was not there.  This means the plugin cache is incorrect.  Please run 'EdmPluginRefresh "
+              << "'\n but was not there.  This means the plugin cache is incorrect.  Please run 'edmPluginRefresh "
               << lib << "'";
         }
       }


### PR DESCRIPTION
Typo in `edmPluginRefresh` (the first letter it should be lowercase)
