### PR TITLE
[GCC14] Fix may be used uninitialized warnings

### DIFF
--- a/SimG4Core/CustomPhysics/src/FullModelReactionDynamics.cc
+++ b/SimG4Core/CustomPhysics/src/FullModelReactionDynamics.cc
@@ -2281,10 +2281,9 @@ G4double FullModelReactionDynamics::GenerateNBodyEvent(const G4double totalEnerg
     wtmax = std::log(std::pow(kineticEnergy, vecLen - 2) * ffq[vecLen - 1] / totalE);
   }
   lzero = true;
-  G4double pd[50];
+  G4double pd[50] = {0.0};
   //G4double *pd = new G4double [vecLen-1];
   for (i = 0; i < vecLen - 1; ++i) {
-    pd[i] = 0.0;
     if (emm[i + 1] * emm[i + 1] > 0.0) {
       G4double arg = emm[i + 1] * emm[i + 1] +
                      (emm[i] * emm[i] - mass[i + 1] * mass[i + 1]) * (emm[i] * emm[i] - mass[i + 1] * mass[i + 1]) /


### PR DESCRIPTION
This should fix the may be used uninitialized warnings for GCC 14 IBs
- https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc14/CMSSW_15_1_X_2025-03-17-2300/BigProducts/Simulation
- https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc14/CMSSW_15_1_X_2025-03-17-2300/SimG4Core/CustomPhysics

```
src/SimG4Core/CustomPhysics/src/FullModelReactionDynamics.cc: In member function 'GenerateNBodyEvent':
  [src/SimG4Core/CustomPhysics/src/FullModelReactionDynamics.cc:2307](https://github.com/cms-sw/cmssw/blob/CMSSW_15_1_X_2025-03-17-2300/SimG4Core/CustomPhysics/src/FullModelReactionDynamics.cc#L2307):19: warning: 'pd' may be used uninitialized [-Wmaybe-uninitialized]
  2307 |   pcm[1][0] = pd[0];
      |                   ^
src/SimG4Core/CustomPhysics/src/FullModelReactionDynamics.cc:2284:12: note: 'pd' declared here
 2284 |   G4double pd[50];
      |            ^
  [src/SimG4Core/CustomPhysics/src/FullModelReactionDynamics.cc:2307](https://github.com/cms-sw/cmssw/blob/CMSSW_15_1_X_2025-03-17-2300/SimG4Core/CustomPhysics/src/FullModelReactionDynamics.cc#L2307):19: warning: 'pd' may be used uninitialized [-Wmaybe-uninitialized]
  2307 |   pcm[1][0] = pd[0];
      |                   ^
src/SimG4Core/CustomPhysics/src/FullModelReactionDynamics.cc:2284:12: note: 'pd' declared here
 2284 |   G4double pd[50];
```