### PR TITLE
[GCC14]Fix array bound warnings

### DIFF
--- a/RecoVertex/PixelVertexFinding/plugins/BuildFile.xml
+++ b/RecoVertex/PixelVertexFinding/plugins/BuildFile.xml
@@ -42,6 +42,8 @@
   <use name="DataFormats/VertexSoA"/>
   <use name="HeterogeneousCore/AlpakaCore"/>
   <use name="HeterogeneousCore/AlpakaInterface"/>
+  <!-- work around for cms-sw/cmssw#45179 -->
+  <use name="no-array-bounds-flag" for="alpaka/serial"/>
   <flags ALPAKA_BACKENDS="1"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoVertex/PixelVertexFinding/test/BuildFile.xml
+++ b/RecoVertex/PixelVertexFinding/test/BuildFile.xml
@@ -47,12 +47,16 @@
 
 <bin file="alpaka/VertexFinder_t.cc alpaka/VertexFinder_t.dev.cc" name="deviceVertexFinderOneKernel_t">
   <use name="alpaka"/>
+  <!-- work around for cms-sw/cmssw#45179 -->
+  <use name="no-array-bounds-flag" for="alpaka/serial"/>
   <use name="HeterogeneousCore/AlpakaInterface"/>
   <flags ALPAKA_BACKENDS="1"/>
   <flags CXXFLAGS="-g -DGPU_DEBUG -DONE_KERNEL"/>
 </bin>
 
 <bin file="alpaka/VertexFinder_t.cc alpaka/VertexFinder_t.dev.cc" name="deviceVertexFinderByDensity_t">
+  <!-- work around for cms-sw/cmssw#45179 -->
+  <use name="no-array-bounds-flag" for="alpaka/serial"/>
   <use name="alpaka"/>
   <use name="HeterogeneousCore/AlpakaInterface"/>
   <flags ALPAKA_BACKENDS="1"/>


### PR DESCRIPTION
workaround to suppress the array-bound warning in LTO builds

-----------------------
This is an attempt to fix the array bound warning we get in GCC14 IBs [a].
Size of array `I m_v[S];` at https://github.com/cms-sw/cmssw/blob/master/HeterogeneousCore/AlpakaInterface/interface/FlexiStorage.h#L21 is `257` via

- https://github.com/cms-sw/cmssw/blob/master/DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsSoA.h#L14-L19
- https://github.com/cms-sw/cmssw/blob/master/HeterogeneousCore/CUDAUtilities/interface/HistoContainer.h#L94-L101

`totbins()` at https://github.com/cms-sw/cmssw/blob/master/HeterogeneousCore/CUDAUtilities/interface/HistoContainer.h#L125 return 257 and then https://github.com/cms-sw/cmssw/blob/master/RecoVertex/PixelVertexFinding/plugins/alpaka/clusterTracksByDensity.h#L61-L63  tries to initialize/access `m_v[257]` which is out of array bound.

Either `totbins()` should return `NHISTS * NBINS` instead of `NHISTS * NBINS +1` or we loop over 1 less element. 

@fwyzard, if this is not the correct fix then  feel free to propose a correct fix.

[a] https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc14/CMSSW_15_1_X_2025-03-18-2300/RecoVertex/PixelVertexFinding
```
In member function 'operator[]',
    inlined from 'clusterTracksByDensity' at src/RecoVertex/PixelVertexFinding/plugins/alpaka/clusterTracksByDensity.h:62:17,
    inlined from 'operator().isra' at src/RecoVertex/PixelVertexFinding/plugins/alpaka/clusterTracksByDensity.h:247:29:
  [src/HeterogeneousCore/AlpakaInterface/interface/FlexiStorage.h:14](https://github.com/cms-sw/cmssw/blob/CMSSW_15_1_X_2025-03-18-2300/HeterogeneousCore/AlpakaInterface/interface/FlexiStorage.h#L14):48: warning: array subscript 257 is above array bounds of 'unsigned int[257]' [-Warray-bounds=]
    14 |     constexpr I& operator[](int i) { return m_v[i]; }
      |                                                ^
src/HeterogeneousCore/AlpakaInterface/interface/FlexiStorage.h: In function 'operator().isra':
src/HeterogeneousCore/AlpakaInterface/interface/FlexiStorage.h:21:7: note: while referencing 'm_v'
   21 |     I m_v[S];
      |       ^
In member function 'operator[]',
    inlined from 'clusterTracksByDensity' at src/RecoVertex/PixelVertexFinding/plugins/alpaka/clusterTracksByDensity.h:62:17,
    inlined from 'operator().isra' at src/RecoVertex/PixelVertexFinding/plugins/alpaka/clusterTracksByDensity.h:247:29:
  [src/HeterogeneousCore/AlpakaInterface/interface/FlexiStorage.h:14](https://github.com/cms-sw/cmssw/blob/CMSSW_15_1_X_2025-03-18-2300/HeterogeneousCore/AlpakaInterface/interface/FlexiStorage.h#L14):48: warning: array subscript 257 is above array bounds of 'unsigned int[257]' [-Warray-bounds=]
    14 |     constexpr I& operator[](int i) { return m_v[i]; }
```
