### PR TITLE
Run3-gex187T Make DDD-specific Era definitions for the years 2023, 2024, 2025

### DIFF
--- a/Configuration/Eras/python/Era_Run3_2023_DDD_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2023_DDD_cff.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run3_2023_cff import Run3_2023
+from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
+
+Run3_2023_DDD = Run3_2023.copyAndExclude([dd4hep])
+

--- a/Configuration/Eras/python/Era_Run3_2024_DDD_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2024_DDD_cff.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run3_2024_cff import Run3_2024
+from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
+
+Run3_2024_DDD = Run3_2024.copyAndExclude([dd4hep])
+

--- a/Configuration/Eras/python/Era_Run3_2025_DDD_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2025_DDD_cff.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run3_2025_cff import Run3_2025
+from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
+
+Run3_2025_DDD = Run3_2025.copyAndExclude([dd4hep])
+


### PR DESCRIPTION
#### PR description:

Make DDD-specific Era definitions for the years 2023, 2024, 2025

#### PR validation:

Use these ERA definitions in some specific tests

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special