### PR TITLE
Using Offline GT for 2024 Data RelVals Eras B,C,D,E

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_data_highstats.py
+++ b/Configuration/PyReleaseValidation/python/relval_data_highstats.py
@@ -4,78 +4,72 @@ from  Configuration.PyReleaseValidation.relval_steps import *
 # here only define the workflows as a combination of the steps defined above:
 workflows = Matrix()
 
-## Here we define higher (>50k events) stats data workflows
-## not to be run as default. 150k, 250k, 500k or 1M events each
+## Here we define fixed high stats data workflows
+## not to be run as default. 10k, 50k, 150k, 250k, 500k or 1M events each
 
 offset_era = 0.1 # less than 10 eras per year
 offset_pd = 0.001 # less than 100 pds per year
-offset_events = 0.0001 # less than 10 event setups (50k,150k,250k,500k)
+offset_events = 0.0001 # less than 10 event setups (10k,50k,150k,250k,500k,1M)
 
 ## 2024
 base_wf = 2024.0
 for e_n,era in enumerate(eras_2024):
     for p_n,pd in enumerate(pds_2024):
-        for e_key,evs in event_steps_dict.items():
-            if "10k" == e_key: # already defined in relval_standard
-                continue   
+        for e_key,evs in event_steps_dict.items(): 
             wf_number = base_wf
             wf_number = wf_number + offset_era * e_n
             wf_number = wf_number + offset_pd * p_n
             wf_number = wf_number + offset_events * evs 
             wf_number = round(wf_number,6)
-
-            step_name = "Run" + pd.replace("ParkingDouble","Park2") + era.split("Run")[1] + "_" + e_key
+            step_name = 'Run' + pd.replace('ParkingDouble','Park2') + era.split('Run')[1] + '_' + e_key
             y = str(int(base_wf))
-            suff = "ZB_" if "ZeroBias" in step_name else ""
+            suff = 'ZB_' if 'ZeroBias' in step_name else ''
+            # Running C,D,E with the offline GT.
+            # Could be removed once 2025 wfs are in and we'll test the online GT with them
+            recosetup = 'RECONANORUN3_' + suff + 'reHLT_2024' 
+            recosetup = recosetup if era[-1] > 'E' else recosetup + '_Offline'
             workflows[wf_number] = ['',[step_name,'HLTDR3_' + y,'RECONANORUN3_' + suff + 'reHLT_'+y,'HARVESTRUN3_' + suff + y]]
 
 ## 2023
 base_wf = 2023.0
 for e_n,era in enumerate(eras_2023):
     for p_n,pd in enumerate(pds_2023):
-        for e_key,evs in event_steps_dict.items():
-            if "10k" == e_key: # already defined in relval_standard
-                continue   
+        for e_key,evs in event_steps_dict.items():  
             wf_number = base_wf
             wf_number = wf_number + offset_era * e_n
             wf_number = wf_number + offset_pd * p_n
             wf_number = wf_number + offset_events * evs 
             wf_number = round(wf_number,6)
-
-            step_name = "Run" + pd.replace("ParkingDouble","Park2") + era.split("Run")[1] + "_" + e_key
-            y = str(int(base_wf)) + "B" if "2023B" in era else str(int(base_wf))
-            suff = "ZB_" if "ZeroBias" in step_name else ""
+            step_name = 'Run' + pd.replace('ParkingDouble','Park2') + era.split('Run')[1] + '_' + e_key
+            y = str(int(base_wf)) + 'B' if '2023B' in era else str(int(base_wf))
+            suff = 'ZB_' if 'ZeroBias' in step_name else ''
             workflows[wf_number] = ['',[step_name,'HLTDR3_' + y,'RECONANORUN3_' + suff + 'reHLT_'+y,'HARVESTRUN3_' + suff + y]]
 
 ## 2022
 base_wf = 2022.0
 for e_n,era in enumerate(eras_2022_1):
     for p_n,pd in enumerate(pds_2022_1):
-        for e_key,evs in event_steps_dict.items():
-            if "10k" == e_key: # already defined in relval_standard
-                continue   
+        for e_key,evs in event_steps_dict.items(): 
             wf_number = base_wf
             wf_number = wf_number + offset_era * e_n
             wf_number = wf_number + offset_pd * p_n
             wf_number = wf_number + offset_events * evs
             wf_number = round(wf_number,6)
-            step_name = "Run" + pd + era.split("Run")[1] + "_" + e_key
+            step_name = 'Run' + pd + era.split('Run')[1] + '_' + e_key
             y = str(int(base_wf))
-            suff = "ZB_" if "ZeroBias" in step_name else ""
+            suff = 'ZB_' if 'ZeroBias' in step_name else ''
             workflows[wf_number] = ['',[step_name,'HLTDR3_' + y,'RECONANORUN3_' + suff + 'reHLT_'+y,'HARVESTRUN3_' + suff + y]]
 
 # PD names changed during 2022
 for e_n,era in enumerate(eras_2022_2):
     for p_n,pd in enumerate(pds_2022_2):
-        for e_key,evs in event_steps_dict.items():
-            if "10k" == e_key: # already defined in relval_standard
-                continue   
+        for e_key,evs in event_steps_dict.items(): 
             wf_number = base_wf
             wf_number = wf_number + offset_era * (e_n + len(eras_2022_1))
             wf_number = wf_number + offset_pd * (p_n + len(pds_2022_1))
             wf_number = wf_number + offset_events * evs 
             wf_number = round(wf_number,6)
-            step_name = "Run" + pd + era.split("Run")[1] + "_" + e_key
+            step_name = 'Run' + pd + era.split('Run')[1] + '_' + e_key
             y = str(int(base_wf))
-            suff = "ZB_" if "ZeroBias" in step_name else ""
+            suff = 'ZB_' if 'ZeroBias' in step_name else ''
             workflows[wf_number] = ['',[step_name,'HLTDR3_' + y,'RECONANORUN3_' + suff + 'reHLT_'+y,'HARVESTRUN3_' + suff + y]] 

--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -582,10 +582,12 @@ offset_pd = 0.001 # less than 100 pds per year
 for e_n,era in enumerate(era_mask_2024):
     for p_n,pd in enumerate(pds_2024):
         wf_number = round(base_wf + offset_era * e_n + offset_pd * p_n,3)
-        dataset = "/" + pd + "/" + era + "-v1/RAW"
-        step_name = "Run" + pd.replace("ParkingDouble","Park2") + era.split("Run")[1]
-        suff = "ZB_" if "ZeroBias" in step_name else ""
-        workflows[wf_number] = ['',[step_name,'HLTDR3_2024','RECONANORUN3_' + suff + 'reHLT_2024','HARVESTRUN3_' + suff + '2024']]
+        dataset = '/' + pd + '/' + era + '-v1/RAW'
+        step_name = 'Run' + pd.replace('ParkingDouble','Park2') + era.split('Run')[1]
+        suff = 'ZB_' if 'ZeroBias' in step_name else ''
+        recosetup = 'RECONANORUN3_' + suff + 'reHLT_2024' 
+        recosetup = recosetup if era[-1] > 'E' else recosetup + '_Offline'
+        workflows[wf_number] = ['',[step_name,'HLTDR3_2024',recosetup,'HARVESTRUN3_' + suff + '2024']]
 
 ## special HLT scouting workflow (with hardcoded private input file from ScoutingPFMonitor skimmed to remove all events without scouting)
 workflows[145.415] = ['',['HLTDR3_ScoutingPFMonitor_2024','RECONANORUN3_ScoutingPFMonitor_reHLT_2024','HARVESTRUN3_ScoutingPFMonitor_2024']]

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2852,6 +2852,9 @@ steps['RECODR3_reHLT_2022']=merge([{'--conditions':'auto:run3_data_relval', '--h
 steps['RECODR3_reHLT_2023']=merge([{'--conditions':'auto:run3_data_relval', '--hltProcess':'reHLT'},steps['RECODR3_2023']])
 steps['RECODR3_reHLT_2023B']=merge([{'--conditions':'auto:run3_data_relval', '--hltProcess':'reHLT'},steps['RECODR3']])
 steps['RECODR3_reHLT_2024']=merge([{'--conditions':'auto:run3_data_prompt_relval', '--hltProcess':'reHLT'},steps['RECODR3']])
+# Added to run with the offline GT on few 2024 Eras.
+# Could be removed once 2025 wfs are in and we'll test the online GT with them
+steps['RECODR3_reHLT_2024_Offline']=merge([{'--conditions':'auto:run3_data_relval', '--hltProcess':'reHLT'},steps['RECODR3']])
 
 steps['RECODR2_2016_UPC']=merge([{'--conditions':'auto:run2_data', '--era':'Run2_2016_UPC', '-s':'RAW2DIGI,L1Reco,RECO,DQM:@commonFakeHLT+@standardDQMFakeHLT', '--repacked':''},steps['RECODR2_2016']])
 steps['RECODR3_2023_HIN']=merge([{'--conditions':'auto:run3_data_prompt', '-s':'RAW2DIGI,L1Reco,RECO,DQM:@commonFakeHLT+@standardDQMFakeHLT', '--repacked':'', '-n':1000},steps['RECODR3_2023']])
@@ -3257,6 +3260,10 @@ steps['RECOHIRUN3_reHLT_2023']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,DQM:@stand
 
 steps['RECONANORUN3_reHLT_2024']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,NANO,DQM:@standardDQM+@miniAODDQM+@nanoAODDQM','--datatier':'RECO,MINIAOD,NANOAOD,DQMIO','--eventcontent':'RECO,MINIAOD,NANOEDMAOD,DQM'},steps['RECODR3_reHLT_2024']])
 steps['RECONANORUN3_ZB_reHLT_2024']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,NANO,DQM:@rerecoZeroBias+@miniAODDQM+@nanoAODDQM'},steps['RECONANORUN3_reHLT_2024']])
+
+steps['RECONANORUN3_reHLT_2024_Offline']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,NANO,DQM:@standardDQM+@miniAODDQM+@nanoAODDQM','--datatier':'RECO,MINIAOD,NANOAOD,DQMIO','--eventcontent':'RECO,MINIAOD,NANOEDMAOD,DQM'},steps['RECODR3_reHLT_2024_Offline']])
+steps['RECONANORUN3_ZB_reHLT_2024_Offline']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,NANO,DQM:@rerecoZeroBias+@miniAODDQM+@nanoAODDQM'},steps['RECONANORUN3_reHLT_2024_Offline']])
+
 steps['RECONANORUN3_ScoutingPFMonitor_reHLT_2024']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,NANO,DQM:@standardDQM+@miniAODDQM+@nanoAODDQM+@hltScouting'},steps['RECONANORUN3_reHLT_2024']])
 
 steps['AODNANORUN3_reHLT_2024']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,NANO,DQM:@standardDQM+@miniAODDQM+@nanoAODDQM','--datatier':'AOD,MINIAOD,NANOAOD,DQMIO','--eventcontent':'AOD,MINIAOD,NANOEDMAOD,DQM'},steps['RECODR3_reHLT_2024']])

--- a/Configuration/PyReleaseValidation/scripts/README.md
+++ b/Configuration/PyReleaseValidation/scripts/README.md
@@ -372,9 +372,9 @@ pp Data reRECO workflows:
 | 2023.002001 	| Run2023D ZeroBias 	|  	run3_hlt_relval + run3_data_relval|  	Run3_2023 |  	HLT:@relval2023 | 
 | 2023.000001 	| Run2023D MuonEG 	|  	run3_hlt_relval + run3_data_relval|  	Run3_2023 |  	HLT:@relval2023 | 
 | 2024 	|  	|  	|  	|  	|
-| 145.014 	| Run2024B ZeroBias 	|  	run3_hlt_relval + run3_data_prompt_relval|  	Run3_2024 |  	HLT:@relval2025 |  
-| 145.104 	| Run2024C JetMet0 	|  	run3_hlt_relval + run3_data_prompt_relval|  	Run3_2024 |  	HLT:@relval2025 |  
-| 145.202 	| Run2024D EGamma0 	|  	run3_hlt_relval + run3_data_prompt_relval|  	Run3_2024 |  	HLT:@relval2025 |  
+| 145.014 	| Run2024B ZeroBias 	|  	run3_hlt_relval + run3_data_relval|  	Run3_2024 |  	HLT:@relval2025 |  
+| 145.104 	| Run2024C JetMet0 	|  	run3_hlt_relval + run3_data_relval|  	Run3_2024 |  	HLT:@relval2025 |  
+| 145.202 	| Run2024D EGamma0 	|  	run3_hlt_relval + run3_data_relval|  	Run3_2024 |  	HLT:@relval2025 |  
 | 145.301 	| Run2024E DisplacedJet 	|  	run3_hlt_relval + run3_data_prompt_relval|  	Run3_2024 |  	HLT:@relval2025 |  
 | 145.408 	| Run2024B ParkingDoubleMuonLowMass0 	|  	run3_hlt_relval + run3_data_prompt_relval|  	Run3_2024 |  	HLT:@relval2025 |  
 | 145.500 	| Run2024B BTagMu 	|  	run3_hlt_relval + run3_data_prompt_relval|  	Run3_2024 |  	HLT:@relval2025 |  


### PR DESCRIPTION
This PR proposes to move the GT to be the offline one `run3_data_relval` for data wfs for 2024 for Eras B,C,D,E. This is (also) a way to test the 2024 ReReco GTs continuously in the IBs and in the tests. Once we will have the 2025 data to test the online GT, all 2024 eras may be moved to the offline GT (dropping this distinction). 

I took the chance to do some cleaning here and there.