### PR TITLE
[DAQ] fix input source raw file deletion deadlock (15_1_X)

### DIFF
--- a/EventFilter/Utilities/interface/FastMonitoringService.h
+++ b/EventFilter/Utilities/interface/FastMonitoringService.h
@@ -233,6 +233,7 @@ namespace evf {
     void setTMicrostate(FastMonState::Microstate m);
 
     static unsigned int getTID() { return tbb::this_task_arena::current_thread_index(); }
+    bool streamIsIdle(unsigned int i) const;
 
   private:
     void doSnapshot(const unsigned int ls, const bool isGlobalEOL);

--- a/EventFilter/Utilities/src/DAQSource.cc
+++ b/EventFilter/Utilities/src/DAQSource.cc
@@ -649,7 +649,7 @@ void DAQSource::fileDeleter() {
         for (unsigned int i = 0; i < streamFileTracker_.size(); i++) {
           if (it->first == streamFileTracker_.at(i)) {
             //only skip if LS is open
-            if (fileLSOpen) {
+            if (fileLSOpen && (!fms_ || !fms_->streamIsIdle(i))) {
               fileIsBeingProcessed = true;
               break;
             }

--- a/EventFilter/Utilities/src/FastMonitoringService.cc
+++ b/EventFilter/Utilities/src/FastMonitoringService.cc
@@ -1052,4 +1052,9 @@ namespace evf {
       fmt_->jsonMonitor_->snap(ls);
   }
 
+  bool FastMonitoringService::streamIsIdle(unsigned int i) const {
+    auto ms = microstate_.at(i);
+    return ms == getmIdle();
+  }
+
 }  //end namespace evf

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -727,7 +727,7 @@ void FedRawDataInputSource::fileDeleter() {
         for (unsigned int i = 0; i < streamFileTracker_.size(); i++) {
           if (it->first == streamFileTracker_.at(i)) {
             //only skip if LS is open
-            if (fileLSOpen) {
+            if (fileLSOpen && (!fms_ || !fms_->streamIsIdle(i))) {
               fileIsBeingProcessed = true;
               break;
             }


### PR DESCRIPTION
#### PR description:
As seen in HLT at low input rate runs, source gets stuck in fetching files because streams do not get next event and are still in status of consuming the old file. This fix checks FastMonitoringService status that no event stream is processing this file.

#### PR validation:

Tested live in emulator run in CDAQ.

