### PR TITLE
Can mark Parameters as obsolete in fillDescriptions

### DIFF
--- a/FWCore/ParameterSet/interface/AllowedLabelsDescriptionBase.h
+++ b/FWCore/ParameterSet/interface/AllowedLabelsDescriptionBase.h
@@ -32,16 +32,16 @@ namespace edm {
                                     std::set<ParameterTypes>& parameterTypes,
                                     std::set<ParameterTypes>& wildcardTypes) const override;
 
-    void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, bool optional) const override;
+    void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, Modifier modifier) const override;
 
     void writeCfi_(std::ostream& os,
-                   bool optional,
+                   Modifier modifier,
                    bool& startWithComma,
                    int indentation,
                    CfiOptions&,
                    bool& wroteSomething) const override;
 
-    void print_(std::ostream& os, bool optional, bool writeToCfi, DocFormatHelper& dfh) const override;
+    void print_(std::ostream& os, Modifier modifier, bool writeToCfi, DocFormatHelper& dfh) const override;
 
     bool hasNestedContent_() const override;
 

--- a/FWCore/ParameterSet/interface/EmptyGroupDescription.h
+++ b/FWCore/ParameterSet/interface/EmptyGroupDescription.h
@@ -23,16 +23,16 @@ namespace edm {
                                     std::set<ParameterTypes>& parameterTypes,
                                     std::set<ParameterTypes>& wildcardTypes) const override;
 
-    void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, bool optional) const override;
+    void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, Modifier modifier) const override;
 
     void writeCfi_(std::ostream& os,
-                   bool optional,
+                   Modifier modifier,
                    bool& startWithComma,
                    int indentation,
                    CfiOptions&,
                    bool& wroteSomething) const override;
 
-    void print_(std::ostream& os, bool optional, bool writeToCfi, DocFormatHelper& dfh) const override;
+    void print_(std::ostream& os, Modifier modifier, bool writeToCfi, DocFormatHelper& dfh) const override;
 
     bool exists_(ParameterSet const& pset) const override;
 

--- a/FWCore/ParameterSet/interface/IfExistsDescription.h
+++ b/FWCore/ParameterSet/interface/IfExistsDescription.h
@@ -35,16 +35,16 @@ namespace edm {
                                     std::set<ParameterTypes>& parameterTypes,
                                     std::set<ParameterTypes>& wildcardTypes) const override;
 
-    void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, bool optional) const override;
+    void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, Modifier modifier) const override;
 
     void writeCfi_(std::ostream& os,
-                   bool optional,
+                   Modifier modifier,
                    bool& startWithComma,
                    int indentation,
                    CfiOptions&,
                    bool& wroteSomething) const override;
 
-    void print_(std::ostream& os, bool optional, bool writeToCfi, DocFormatHelper& dfh) const override;
+    void print_(std::ostream& os, Modifier modifier, bool writeToCfi, DocFormatHelper& dfh) const override;
 
     bool hasNestedContent_() const override { return true; }
 

--- a/FWCore/ParameterSet/interface/ParameterDescription.h
+++ b/FWCore/ParameterSet/interface/ParameterDescription.h
@@ -217,7 +217,7 @@ namespace edm {
     ParameterDescriptionNode* clone() const override { return new ParameterDescription(*this); }
 
   private:
-    void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, bool optional) const override;
+    void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, Modifier modifier) const override;
 
     void printDefault_(std::ostream& os, bool writeToCfi, DocFormatHelper& dfh) const override;
 
@@ -274,7 +274,7 @@ namespace edm {
     void setPartOfDefaultOfVPSet(bool value) { partOfDefaultOfVPSet_ = value; }
 
   private:
-    void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, bool optional) const override;
+    void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, Modifier modifier) const override;
 
     void printDefault_(std::ostream& os, bool writeToCfi, DocFormatHelper& dfh) const override;
 

--- a/FWCore/ParameterSet/interface/ParameterDescriptionBase.h
+++ b/FWCore/ParameterSet/interface/ParameterDescriptionBase.h
@@ -58,10 +58,10 @@ namespace edm {
                                     std::set<ParameterTypes>& parameterTypes,
                                     std::set<ParameterTypes>& wildcardTypes) const override;
 
-    void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, bool optional) const override;
+    void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, Modifier modifier) const override;
 
     void writeCfi_(std::ostream& os,
-                   bool optional,
+                   Modifier modifier,
                    bool& startWithComma,
                    int indentation,
                    CfiOptions&,
@@ -75,7 +75,7 @@ namespace edm {
                             bool& wroteSomething) const;
 
     void writeFullCfi(std::ostream& os,
-                      bool optional,
+                      Modifier modifier,
                       bool& startWithComma,
                       int indentation,
                       CfiOptions&,
@@ -89,7 +89,7 @@ namespace edm {
 
     virtual void writeDoc_(std::ostream& os, int indentation) const = 0;
 
-    void print_(std::ostream& os, bool optional, bool writeToCfi, DocFormatHelper& dfh) const override;
+    void print_(std::ostream& os, Modifier modifier, bool writeToCfi, DocFormatHelper& dfh) const override;
 
     virtual void printDefault_(std::ostream& os, bool writeToCfi, DocFormatHelper& dfh) const;
 

--- a/FWCore/ParameterSet/interface/ParameterSetDescription.h
+++ b/FWCore/ParameterSet/interface/ParameterSetDescription.h
@@ -51,12 +51,16 @@ namespace edm {
 
   class ParameterSetDescription {
   public:
+    using Modifier = ParameterModifier;
     class SetDescriptionEntry {
     public:
-      bool optional() const { return optional_; }
+      bool optional() const { return modifier_ == Modifier::kOptional; }
+      bool obsolete() const { return modifier_ == Modifier::kObsolete; }
+      Modifier modifier() const { return modifier_; }
       bool writeToCfi() const { return writeToCfi_; }
       edm::value_ptr<ParameterDescriptionNode> const& node() const { return node_; }
-      void setOptional(bool value) { optional_ = value; }
+
+      void setModifier(Modifier value) { modifier_ = value; }
       void setWriteToCfi(bool value) { writeToCfi_ = value; }
       ParameterDescriptionNode* setNode(std::unique_ptr<ParameterDescriptionNode> node) {
         node_ = std::move(node);
@@ -64,7 +68,7 @@ namespace edm {
       }
 
     private:
-      bool optional_;
+      Modifier modifier_;
       bool writeToCfi_;
       edm::value_ptr<ParameterDescriptionNode> node_;
     };
@@ -93,22 +97,22 @@ namespace edm {
 
     template <typename T, typename U>
     ParameterDescriptionBase* add(U const& iLabel, T const& value) {
-      return add<T, U>(iLabel, value, true, false, true);
+      return add<T, U>(iLabel, value, true, Modifier::kNone, true);
     }
 
     template <typename T, typename U>
     ParameterDescriptionBase* addUntracked(U const& iLabel, T const& value) {
-      return add<T, U>(iLabel, value, false, false, true);
+      return add<T, U>(iLabel, value, false, Modifier::kNone, true);
     }
 
     template <typename T, typename U>
     ParameterDescriptionBase* addOptional(U const& iLabel, T const& value) {
-      return add<T, U>(iLabel, value, true, true, true);
+      return add<T, U>(iLabel, value, true, Modifier::kOptional, true);
     }
 
     template <typename T, typename U>
     ParameterDescriptionBase* addOptionalUntracked(U const& iLabel, T const& value) {
-      return add<T, U>(iLabel, value, false, true, true);
+      return add<T, U>(iLabel, value, false, Modifier::kOptional, true);
     }
 
     // For the next 4 functions, there is no default so they will not get injected
@@ -116,22 +120,40 @@ namespace edm {
 
     template <typename T, typename U>
     ParameterDescriptionBase* add(U const& iLabel) {
-      return add<T, U>(iLabel, true, false, true);
+      return add<T, U>(iLabel, true, Modifier::kNone, true);
     }
 
     template <typename T, typename U>
     ParameterDescriptionBase* addUntracked(U const& iLabel) {
-      return add<T, U>(iLabel, false, false, true);
+      return add<T, U>(iLabel, false, Modifier::kNone, true);
     }
 
     template <typename T, typename U>
     ParameterDescriptionBase* addOptional(U const& iLabel) {
-      return add<T, U>(iLabel, true, true, true);
+      return add<T, U>(iLabel, true, Modifier::kOptional, true);
     }
 
     template <typename T, typename U>
     ParameterDescriptionBase* addOptionalUntracked(U const& iLabel) {
-      return add<T, U>(iLabel, false, true, true);
+      return add<T, U>(iLabel, false, Modifier::kOptional, true);
+    }
+
+    template <typename T, typename U>
+    ParameterDescriptionBase* addObsolete(U const& iLabel) {
+      if constexpr (std::is_same_v<T, edm::ParameterSetDescription>) {
+        return add<T, U>(iLabel, T(), true, Modifier::kObsolete, true);
+      } else {
+        return add<T, U>(iLabel, true, Modifier::kObsolete, true);
+      }
+    }
+
+    template <typename T, typename U>
+    ParameterDescriptionBase* addObsoleteUntracked(U const& iLabel) {
+      if constexpr (std::is_same_v<T, edm::ParameterSetDescription>) {
+        return add<T, U>(iLabel, T(), false, Modifier::kObsolete, true);
+      } else {
+        return add<T, U>(iLabel, false, Modifier::kObsolete, true);
+      }
     }
 
     // ***** Use these 8 functions for parameters of type vector<ParameterSet> *****
@@ -149,48 +171,59 @@ namespace edm {
     ParameterDescriptionBase* addVPSet(U const& iLabel,
                                        ParameterSetDescription const& validator,
                                        std::vector<ParameterSet> const& defaults) {
-      return addVPSet<U>(iLabel, validator, defaults, true, false, true);
+      return addVPSet<U>(iLabel, validator, defaults, true, Modifier::kNone, true);
     }
 
     template <typename U>
     ParameterDescriptionBase* addVPSetUntracked(U const& iLabel,
                                                 ParameterSetDescription const& validator,
                                                 std::vector<ParameterSet> const& defaults) {
-      return addVPSet<U>(iLabel, validator, defaults, false, false, true);
+      return addVPSet<U>(iLabel, validator, defaults, false, Modifier::kNone, true);
     }
 
     template <typename U>
     ParameterDescriptionBase* addVPSetOptional(U const& iLabel,
                                                ParameterSetDescription const& validator,
                                                std::vector<ParameterSet> const& defaults) {
-      return addVPSet<U>(iLabel, validator, defaults, true, true, true);
+      return addVPSet<U>(iLabel, validator, defaults, true, Modifier::kOptional, true);
     }
 
     template <typename U>
     ParameterDescriptionBase* addVPSetOptionalUntracked(U const& iLabel,
                                                         ParameterSetDescription const& validator,
                                                         std::vector<ParameterSet> const& defaults) {
-      return addVPSet<U>(iLabel, validator, defaults, false, true, true);
+      return addVPSet<U>(iLabel, validator, defaults, false, Modifier::kOptional, true);
     }
 
     template <typename U>
     ParameterDescriptionBase* addVPSet(U const& iLabel, ParameterSetDescription const& validator) {
-      return addVPSet<U>(iLabel, validator, true, false, true);
+      return addVPSet<U>(iLabel, validator, true, Modifier::kNone, true);
     }
 
     template <typename U>
     ParameterDescriptionBase* addVPSetUntracked(U const& iLabel, ParameterSetDescription const& validator) {
-      return addVPSet<U>(iLabel, validator, false, false, true);
+      return addVPSet<U>(iLabel, validator, false, Modifier::kNone, true);
     }
 
     template <typename U>
     ParameterDescriptionBase* addVPSetOptional(U const& iLabel, ParameterSetDescription const& validator) {
-      return addVPSet<U>(iLabel, validator, true, true, true);
+      return addVPSet<U>(iLabel, validator, true, Modifier::kOptional, true);
     }
 
     template <typename U>
     ParameterDescriptionBase* addVPSetOptionalUntracked(U const& iLabel, ParameterSetDescription const& validator) {
-      return addVPSet<U>(iLabel, validator, false, true, true);
+      return addVPSet<U>(iLabel, validator, false, Modifier::kOptional, true);
+    }
+
+    template <typename U>
+    ParameterDescriptionBase* addVPSetObsolete(U const& iLabel) {
+      ParameterSetDescription validator;
+      return addVPSet<U>(iLabel, validator, true, Modifier::kObsolete, true);
+    }
+    template <typename U>
+    ParameterDescriptionBase* addVPSetObsoleteUntracked(U const& iLabel) {
+      ParameterSetDescription validator;
+      return addVPSet<U>(iLabel, validator, false, Modifier::kObsolete, true);
     }
 
     // ********* Wildcards *********
@@ -219,46 +252,46 @@ namespace edm {
     template <typename T>
     ParameterDescriptionNode* ifValue(ParameterDescription<T> const& switchParameter,
                                       std::unique_ptr<ParameterDescriptionCases<T>> cases) {
-      return ifValue<T>(switchParameter, std::move(cases), false, true);
+      return ifValue<T>(switchParameter, std::move(cases), Modifier::kNone, true);
     }
 
     template <typename T>
     ParameterDescriptionNode* ifValueOptional(ParameterDescription<T> const& switchParameter,
                                               std::unique_ptr<ParameterDescriptionCases<T>> cases,
                                               bool writeToCfi) {
-      return ifValue<T>(switchParameter, std::move(cases), true, writeToCfi);
+      return ifValue<T>(switchParameter, std::move(cases), Modifier::kOptional, writeToCfi);
     }
 
     // ********* if exists ************
     ParameterDescriptionNode* ifExists(ParameterDescriptionNode const& node1, ParameterDescriptionNode const& node2) {
-      return ifExists(node1, node2, false, true);
+      return ifExists(node1, node2, Modifier::kNone, true);
     }
 
     ParameterDescriptionNode* ifExistsOptional(ParameterDescriptionNode const& node1,
                                                ParameterDescriptionNode const& node2,
                                                bool writeToCfi) {
-      return ifExists(node1, node2, true, writeToCfi);
+      return ifExists(node1, node2, Modifier::kOptional, writeToCfi);
     }
 
     // ********* for parameters that are a list of allowed labels *********
     template <typename T, typename U>
     ParameterDescriptionNode* labelsFrom(U const& iLabel) {
-      return labelsFrom<T, U>(iLabel, true, false, true);
+      return labelsFrom<T, U>(iLabel, true, Modifier::kNone, true);
     }
 
     template <typename T, typename U>
     ParameterDescriptionNode* labelsFromUntracked(U const& iLabel) {
-      return labelsFrom<T, U>(iLabel, false, false, true);
+      return labelsFrom<T, U>(iLabel, false, Modifier::kNone, true);
     }
 
     template <typename T, typename U>
     ParameterDescriptionNode* labelsFromOptional(U const& iLabel, bool writeToCfi) {
-      return labelsFrom<T, U>(iLabel, true, true, writeToCfi);
+      return labelsFrom<T, U>(iLabel, true, Modifier::kOptional, writeToCfi);
     }
 
     template <typename T, typename U>
     ParameterDescriptionNode* labelsFromOptionalUntracked(U const& iLabel, bool writeToCfi) {
-      return labelsFrom<T, U>(iLabel, false, true, writeToCfi);
+      return labelsFrom<T, U>(iLabel, false, Modifier::kOptional, writeToCfi);
     }
 
     // These next four functions only work when the template
@@ -271,22 +304,22 @@ namespace edm {
     // T must be explicitly specified by the calling function.
     template <typename T, typename U, typename V>
     ParameterDescriptionNode* labelsFrom(U const& iLabel, V const& desc) {
-      return labelsFrom<T, U, V>(iLabel, true, false, true, desc);
+      return labelsFrom<T, U, V>(iLabel, true, Modifier::kNone, true, desc);
     }
 
     template <typename T, typename U, typename V>
     ParameterDescriptionNode* labelsFromUntracked(U const& iLabel, V const& desc) {
-      return labelsFrom<T, U, V>(iLabel, false, false, true, desc);
+      return labelsFrom<T, U, V>(iLabel, false, Modifier::kNone, true, desc);
     }
 
     template <typename T, typename U, typename V>
     ParameterDescriptionNode* labelsFromOptional(U const& iLabel, bool writeToCfi, V const& desc) {
-      return labelsFrom<T, U, V>(iLabel, true, true, writeToCfi, desc);
+      return labelsFrom<T, U, V>(iLabel, true, Modifier::kOptional, writeToCfi, desc);
     }
 
     template <typename T, typename U, typename V>
     ParameterDescriptionNode* labelsFromOptionalUntracked(U const& iLabel, bool writeToCfi, V const& desc) {
-      return labelsFrom<T, U, V>(iLabel, false, true, writeToCfi, desc);
+      return labelsFrom<T, U, V>(iLabel, false, Modifier::kOptional, writeToCfi, desc);
     }
 
     bool anythingAllowed() const { return anythingAllowed_; }
@@ -311,44 +344,47 @@ namespace edm {
 
   private:
     template <typename T, typename U>
-    ParameterDescriptionBase* add(U const& iLabel, T const& value, bool isTracked, bool isOptional, bool writeToCfi);
+    ParameterDescriptionBase* add(U const& iLabel, T const& value, bool isTracked, Modifier modifier, bool writeToCfi);
 
     template <typename T, typename U>
-    ParameterDescriptionBase* add(U const& iLabel, bool isTracked, bool isOptional, bool writeToCfi);
+    ParameterDescriptionBase* add(U const& iLabel, bool isTracked, Modifier modifier, bool writeToCfi);
 
     template <typename U>
     ParameterDescriptionBase* addVPSet(U const& iLabel,
                                        ParameterSetDescription const& validator,
                                        std::vector<ParameterSet> const& defaults,
                                        bool isTracked,
-                                       bool isOptional,
+                                       Modifier modifier,
                                        bool writeToCfi);
 
     template <typename U>
     ParameterDescriptionBase* addVPSet(
-        U const& iLabel, ParameterSetDescription const& validator, bool isTracked, bool isOptional, bool writeToCfi);
+        U const& iLabel, ParameterSetDescription const& validator, bool isTracked, Modifier modifier, bool writeToCfi);
 
     template <typename T, typename U>
     ParameterWildcardBase* addWildcard(U const& pattern, bool isTracked);
 
-    ParameterDescriptionNode* addNode(std::unique_ptr<ParameterDescriptionNode> node, bool optional, bool writeToCfi);
+    ParameterDescriptionNode* addNode(std::unique_ptr<ParameterDescriptionNode> node,
+                                      Modifier modifier,
+                                      bool writeToCfi);
 
     template <typename T>
     ParameterDescriptionNode* ifValue(ParameterDescription<T> const& switchParameter,
                                       std::unique_ptr<ParameterDescriptionCases<T>> cases,
-                                      bool optional,
+                                      Modifier modifier,
                                       bool writeToCfi);
 
     ParameterDescriptionNode* ifExists(ParameterDescriptionNode const& node1,
                                        ParameterDescriptionNode const& node2,
-                                       bool optional,
+                                       Modifier modifier,
                                        bool writeToCfi);
 
     template <typename T, typename U>
-    ParameterDescriptionNode* labelsFrom(U const& iLabel, bool isTracked, bool optional, bool writeToCfi);
+    ParameterDescriptionNode* labelsFrom(U const& iLabel, bool isTracked, Modifier modifier, bool writeToCfi);
 
     template <typename T, typename U, typename V>
-    ParameterDescriptionNode* labelsFrom(U const& iLabel, bool isTracked, bool optional, bool writeToCfi, V const& desc);
+    ParameterDescriptionNode* labelsFrom(
+        U const& iLabel, bool isTracked, Modifier modifier, bool writeToCfi, V const& desc);
 
     static void validateNode(SetDescriptionEntry const& entry,
                              ParameterSet& pset,
@@ -390,20 +426,20 @@ namespace edm {
 
   template <typename T, typename U>
   ParameterDescriptionBase* ParameterSetDescription::add(
-      U const& iLabel, T const& value, bool isTracked, bool isOptional, bool writeToCfi) {
+      U const& iLabel, T const& value, bool isTracked, Modifier modifier, bool writeToCfi) {
     std::unique_ptr<ParameterDescriptionNode> node =
         std::make_unique<ParameterDescription<T>>(iLabel, value, isTracked);
-    ParameterDescriptionNode* pnode = addNode(std::move(node), isOptional, writeToCfi);
+    ParameterDescriptionNode* pnode = addNode(std::move(node), modifier, writeToCfi);
     return static_cast<ParameterDescriptionBase*>(pnode);
   }
 
   template <typename T, typename U>
   ParameterDescriptionBase* ParameterSetDescription::add(U const& iLabel,
                                                          bool isTracked,
-                                                         bool isOptional,
+                                                         Modifier modifier,
                                                          bool writeToCfi) {
     std::unique_ptr<ParameterDescriptionNode> node = std::make_unique<ParameterDescription<T>>(iLabel, isTracked);
-    ParameterDescriptionNode* pnode = addNode(std::move(node), isOptional, writeToCfi);
+    ParameterDescriptionNode* pnode = addNode(std::move(node), modifier, writeToCfi);
     return static_cast<ParameterDescriptionBase*>(pnode);
   }
 
@@ -412,20 +448,20 @@ namespace edm {
                                                               ParameterSetDescription const& validator,
                                                               std::vector<ParameterSet> const& defaults,
                                                               bool isTracked,
-                                                              bool isOptional,
+                                                              Modifier modifier,
                                                               bool writeToCfi) {
     std::unique_ptr<ParameterDescriptionNode> node =
         std::make_unique<ParameterDescription<std::vector<ParameterSet>>>(iLabel, validator, isTracked, defaults);
-    ParameterDescriptionNode* pnode = addNode(std::move(node), isOptional, writeToCfi);
+    ParameterDescriptionNode* pnode = addNode(std::move(node), modifier, writeToCfi);
     return static_cast<ParameterDescriptionBase*>(pnode);
   }
 
   template <typename U>
   ParameterDescriptionBase* ParameterSetDescription::addVPSet(
-      U const& iLabel, ParameterSetDescription const& validator, bool isTracked, bool isOptional, bool writeToCfi) {
+      U const& iLabel, ParameterSetDescription const& validator, bool isTracked, Modifier modifier, bool writeToCfi) {
     std::unique_ptr<ParameterDescriptionNode> node =
         std::make_unique<ParameterDescription<std::vector<ParameterSet>>>(iLabel, validator, isTracked);
-    ParameterDescriptionNode* pnode = addNode(std::move(node), isOptional, writeToCfi);
+    ParameterDescriptionNode* pnode = addNode(std::move(node), modifier, writeToCfi);
     return static_cast<ParameterDescriptionBase*>(pnode);
   }
 
@@ -433,35 +469,35 @@ namespace edm {
   ParameterWildcardBase* ParameterSetDescription::addWildcard(U const& pattern, bool isTracked) {
     std::unique_ptr<ParameterDescriptionNode> node =
         std::make_unique<ParameterWildcard<T>>(pattern, RequireZeroOrMore, isTracked);
-    ParameterDescriptionNode* pnode = addNode(std::move(node), true, true);
+    ParameterDescriptionNode* pnode = addNode(std::move(node), Modifier::kOptional, true);
     return static_cast<ParameterWildcardBase*>(pnode);
   }
 
   template <typename T>
   ParameterDescriptionNode* ParameterSetDescription::ifValue(ParameterDescription<T> const& switchParameter,
                                                              std::unique_ptr<ParameterDescriptionCases<T>> cases,
-                                                             bool optional,
+                                                             Modifier modifier,
                                                              bool writeToCfi) {
     std::unique_ptr<ParameterDescriptionNode> pdswitch =
         std::make_unique<ParameterSwitch<T>>(switchParameter, std::move(cases));
-    return addNode(std::move(pdswitch), optional, writeToCfi);
+    return addNode(std::move(pdswitch), modifier, writeToCfi);
   }
 
   template <typename T, typename U>
   ParameterDescriptionNode* ParameterSetDescription::labelsFrom(U const& iLabel,
                                                                 bool isTracked,
-                                                                bool optional,
+                                                                Modifier modifier,
                                                                 bool writeToCfi) {
     std::unique_ptr<ParameterDescriptionNode> pd = std::make_unique<AllowedLabelsDescription<T>>(iLabel, isTracked);
-    return addNode(std::move(pd), optional, writeToCfi);
+    return addNode(std::move(pd), modifier, writeToCfi);
   }
 
   template <typename T, typename U, typename V>
   ParameterDescriptionNode* ParameterSetDescription::labelsFrom(
-      U const& iLabel, bool isTracked, bool optional, bool writeToCfi, V const& desc) {
+      U const& iLabel, bool isTracked, Modifier modifier, bool writeToCfi, V const& desc) {
     std::unique_ptr<ParameterDescriptionNode> pd =
         std::make_unique<AllowedLabelsDescription<T>>(iLabel, desc, isTracked);
-    return addNode(std::move(pd), optional, writeToCfi);
+    return addNode(std::move(pd), modifier, writeToCfi);
   }
 }  // namespace edm
 

--- a/FWCore/ParameterSet/interface/ParameterSwitch.h
+++ b/FWCore/ParameterSet/interface/ParameterSwitch.h
@@ -60,8 +60,8 @@ namespace edm {
       }
     }
 
-    void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, bool optional) const override {
-      switch_.validate(pset, validatedLabels, optional);
+    void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, Modifier modifier) const override {
+      switch_.validate(pset, validatedLabels, modifier);
       if (switch_.exists(pset)) {
         T switchValue;
         if (switch_.isTracked()) {
@@ -71,7 +71,7 @@ namespace edm {
         }
         typename CaseMap::const_iterator selectedCase = cases_.find(switchValue);
         if (selectedCase != cases_.end()) {
-          selectedCase->second->validate(pset, validatedLabels, false);
+          selectedCase->second->validate(pset, validatedLabels, Modifier::kNone);
         } else {
           std::stringstream ss;
           ss << "The switch parameter with label \"" << switch_.label() << "\" has been assigned an illegal value.\n"
@@ -87,12 +87,12 @@ namespace edm {
     }
 
     void writeCfi_(std::ostream& os,
-                   bool optional,
+                   Modifier modifier,
                    bool& startWithComma,
                    int indentation,
                    CfiOptions& options,
                    bool& wroteSomething) const override {
-      switch_.writeCfi(os, optional, startWithComma, indentation, options, wroteSomething);
+      switch_.writeCfi(os, modifier, startWithComma, indentation, options, wroteSomething);
 
       if (std::holds_alternative<cfi::ClassFile>(options)) {
         std::set<std::string> labels;
@@ -108,13 +108,13 @@ namespace edm {
 
       typename CaseMap::const_iterator selectedCase = cases_.find(switch_.getDefaultValue());
       if (selectedCase != cases_.end()) {
-        selectedCase->second->writeCfi(os, optional, startWithComma, indentation, options, wroteSomething);
+        selectedCase->second->writeCfi(os, modifier, startWithComma, indentation, options, wroteSomething);
       }
     }
 
-    void print_(std::ostream& os, bool optional, bool writeToCfi, DocFormatHelper& dfh) const override {
+    void print_(std::ostream& os, Modifier modifier, bool writeToCfi, DocFormatHelper& dfh) const override {
       printBase(os,
-                optional,
+                modifier,
                 writeToCfi,
                 dfh,
                 switch_.label(),
@@ -126,7 +126,7 @@ namespace edm {
       DocFormatHelper new_dfh(dfh);
       printNestedContentBase(os, dfh, new_dfh, switch_.label());
 
-      switch_.print(os, optional, true, new_dfh);
+      switch_.print(os, modifierIsOptional(optional), true, new_dfh);
       for_all(cases_,
               std::bind(&ParameterSwitchBase::printCaseT<T>,
                         std::placeholders::_1,
@@ -140,7 +140,7 @@ namespace edm {
 
       new_dfh.indent(os);
       os << "switch:\n";
-      switch_.print(os, optional, true, new_dfh);
+      switch_.print(os, modifierIsOptional(optional), true, new_dfh);
       for_all(cases_,
               std::bind(&ParameterSwitchBase::printCaseT<T>,
                         std::placeholders::_1,

--- a/FWCore/ParameterSet/interface/ParameterSwitchBase.h
+++ b/FWCore/ParameterSet/interface/ParameterSwitchBase.h
@@ -35,7 +35,7 @@ namespace edm {
     void throwNoCaseForSwitchValue(std::string const& message) const;
 
     void printBase(std::ostream& os,
-                   bool optional,
+                   Modifier modifier,
                    bool writeToCfi,
                    DocFormatHelper& dfh,
                    std::string const& switchLabel,

--- a/FWCore/ParameterSet/interface/ParameterWildcard.h
+++ b/FWCore/ParameterSet/interface/ParameterWildcard.h
@@ -37,9 +37,9 @@ namespace edm {
     ParameterDescriptionNode* clone() const override { return new ParameterWildcard(*this); }
 
   private:
-    void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, bool optional) const override {
+    void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, Modifier modifier) const override {
       std::vector<std::string> parameterNames = pset.getParameterNamesForType<T>(isTracked());
-      validateMatchingNames(parameterNames, validatedLabels, optional);
+      validateMatchingNames(parameterNames, validatedLabels, modifier != Modifier::kNone);
     }
 
     bool exists_(ParameterSet const& pset) const override {
@@ -77,7 +77,7 @@ namespace edm {
 
   private:
     void writeTemplate(std::ostream& os, int indentation, CfiOptions&) const override;
-    void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, bool optional) const override;
+    void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, Modifier modifier) const override;
 
     bool hasNestedContent_() const override;
 
@@ -110,7 +110,7 @@ namespace edm {
     ParameterDescriptionNode* clone() const override;
 
   private:
-    void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, bool optional) const override;
+    void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, Modifier modifier) const override;
 
     bool hasNestedContent_() const override;
 

--- a/FWCore/ParameterSet/interface/ParameterWildcardBase.h
+++ b/FWCore/ParameterSet/interface/ParameterWildcardBase.h
@@ -42,13 +42,13 @@ namespace edm {
                                     std::set<ParameterTypes>& wildcardTypes) const override;
 
     void writeCfi_(std::ostream& os,
-                   bool optional,
+                   Modifier modifier,
                    bool& startWithComma,
                    int indentation,
                    CfiOptions&,
                    bool& wroteSomething) const override;
 
-    void print_(std::ostream& os, bool optional, bool writeToCfi, DocFormatHelper& dfh) const override;
+    void print_(std::ostream& os, Modifier modifier, bool writeToCfi, DocFormatHelper& dfh) const override;
 
     bool partiallyExists_(ParameterSet const& pset) const override;
 

--- a/FWCore/ParameterSet/interface/ParameterWildcardWithSpecifics.h
+++ b/FWCore/ParameterSet/interface/ParameterWildcardWithSpecifics.h
@@ -23,7 +23,7 @@ namespace edm {
     ParameterDescriptionNode* clone() const override;
 
   private:
-    void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, bool optional) const override;
+    void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, Modifier modifier) const override;
 
     bool hasNestedContent_() const override;
 

--- a/FWCore/ParameterSet/interface/PluginDescription.h
+++ b/FWCore/ParameterSet/interface/PluginDescription.h
@@ -124,7 +124,7 @@ namespace edm {
                                     std::set<ParameterTypes>& parameterTypes,
                                     std::set<ParameterTypes>& wildcardTypes) const final {}
 
-    void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, bool optional) const final {
+    void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, Modifier modifier) const final {
       loadDescription(findType(pset)).validate(pset);
       //all names are good
       auto n = pset.getParameterNames();
@@ -132,7 +132,7 @@ namespace edm {
     }
 
     void writeCfi_(std::ostream& os,
-                   bool optional,
+                   Modifier modifier,
                    bool& startWithComma,
                    int indentation,
                    CfiOptions& options,

--- a/FWCore/ParameterSet/src/ANDGroupDescription.cc
+++ b/FWCore/ParameterSet/src/ANDGroupDescription.cc
@@ -53,28 +53,30 @@ namespace edm {
     wildcardTypes.insert(wildcardTypesLeft.begin(), wildcardTypesLeft.end());
   }
 
-  void ANDGroupDescription::validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, bool optional) const {
-    if (partiallyExists(pset) || !optional) {
-      node_left_->validate(pset, validatedLabels, false);
-      node_right_->validate(pset, validatedLabels, false);
+  void ANDGroupDescription::validate_(ParameterSet& pset,
+                                      std::set<std::string>& validatedLabels,
+                                      Modifier modifier) const {
+    if (partiallyExists(pset) || modifier == Modifier::kNone) {
+      node_left_->validate(pset, validatedLabels, Modifier::kNone);
+      node_right_->validate(pset, validatedLabels, Modifier::kNone);
     }
   }
 
   void ANDGroupDescription::writeCfi_(std::ostream& os,
-                                      bool optional,
+                                      Modifier modifier,
                                       bool& startWithComma,
                                       int indentation,
                                       CfiOptions& options,
                                       bool& wroteSomething) const {
-    node_left_->writeCfi(os, optional, startWithComma, indentation, options, wroteSomething);
-    node_right_->writeCfi(os, optional, startWithComma, indentation, options, wroteSomething);
+    node_left_->writeCfi(os, modifier, startWithComma, indentation, options, wroteSomething);
+    node_right_->writeCfi(os, modifier, startWithComma, indentation, options, wroteSomething);
   }
 
-  void ANDGroupDescription::print_(std::ostream& os, bool optional, bool writeToCfi, DocFormatHelper& dfh) const {
+  void ANDGroupDescription::print_(std::ostream& os, Modifier modifier, bool writeToCfi, DocFormatHelper& dfh) const {
     if (dfh.parent() == DocFormatHelper::AND) {
       dfh.decrementCounter();
-      node_left_->print(os, false, true, dfh);
-      node_right_->print(os, false, true, dfh);
+      node_left_->print(os, Modifier::kNone, true, dfh);
+      node_right_->print(os, Modifier::kNone, true, dfh);
       return;
     }
 
@@ -82,9 +84,13 @@ namespace edm {
       dfh.indent(os);
       os << "AND group:";
 
+      bool const optional = (modifier == Modifier::kOptional);
+      bool const obsolete = (modifier == Modifier::kObsolete);
       if (dfh.brief()) {
         if (optional)
           os << " optional";
+        if (obsolete)
+          os << " obsolete";
 
         if (!writeToCfi)
           os << " (do not write to cfi)";
@@ -98,6 +104,8 @@ namespace edm {
 
         if (optional)
           os << "optional";
+        if (obsolete)
+          os << " obsolete";
         if (!writeToCfi)
           os << " (do not write to cfi)";
         if (optional || !writeToCfi) {
@@ -149,14 +157,14 @@ namespace edm {
     new_dfh.setIndentation(indentation + DocFormatHelper::offsetSectionContent());
     new_dfh.setParent(DocFormatHelper::AND);
 
-    node_left_->print(os, false, true, new_dfh);
-    node_right_->print(os, false, true, new_dfh);
+    node_left_->print(os, Modifier::kNone, true, new_dfh);
+    node_right_->print(os, Modifier::kNone, true, new_dfh);
 
     new_dfh.setPass(1);
     new_dfh.setCounter(0);
 
-    node_left_->print(os, false, true, new_dfh);
-    node_right_->print(os, false, true, new_dfh);
+    node_left_->print(os, Modifier::kNone, true, new_dfh);
+    node_right_->print(os, Modifier::kNone, true, new_dfh);
 
     new_dfh.setPass(2);
     new_dfh.setCounter(0);

--- a/FWCore/ParameterSet/src/ANDGroupDescription.h
+++ b/FWCore/ParameterSet/src/ANDGroupDescription.h
@@ -35,16 +35,16 @@ namespace edm {
                                     std::set<ParameterTypes>& parameterTypes,
                                     std::set<ParameterTypes>& wildcardTypes) const override;
 
-    void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, bool optional) const override;
+    void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, Modifier modifier) const override;
 
     void writeCfi_(std::ostream& os,
-                   bool optional,
+                   Modifier modifier,
                    bool& startWithComma,
                    int indentation,
                    CfiOptions&,
                    bool& wroteSomething) const override;
 
-    void print_(std::ostream& os, bool optional, bool writeToCfi, DocFormatHelper& dfh) const override;
+    void print_(std::ostream& os, Modifier modifier, bool writeToCfi, DocFormatHelper& dfh) const override;
 
     bool hasNestedContent_() const override { return true; }
 

--- a/FWCore/ParameterSet/src/AllowedLabelsDescriptionBase.cc
+++ b/FWCore/ParameterSet/src/AllowedLabelsDescriptionBase.cc
@@ -28,8 +28,8 @@ namespace edm {
 
   void AllowedLabelsDescriptionBase::validate_(ParameterSet& pset,
                                                std::set<std::string>& validatedLabels,
-                                               bool optional) const {
-    parameterHoldingLabels_.validate(pset, validatedLabels, optional);
+                                               Modifier modifier) const {
+    parameterHoldingLabels_.validate(pset, validatedLabels, modifier);
     if (parameterHoldingLabels_.exists(pset)) {
       std::vector<std::string> allowedLabels;
       if (isTracked()) {
@@ -47,16 +47,16 @@ namespace edm {
   }
 
   void AllowedLabelsDescriptionBase::writeCfi_(std::ostream& os,
-                                               bool optional,
+                                               Modifier modifier,
                                                bool& startWithComma,
                                                int indentation,
                                                CfiOptions& options,
                                                bool& wroteSomething) const {
-    parameterHoldingLabels_.writeCfi(os, optional, startWithComma, indentation, options, wroteSomething);
+    parameterHoldingLabels_.writeCfi(os, modifier, startWithComma, indentation, options, wroteSomething);
   }
 
   void AllowedLabelsDescriptionBase::print_(std::ostream& os,
-                                            bool optional,
+                                            Modifier modifier,
                                             bool writeToCfi,
                                             DocFormatHelper& dfh) const {
     if (dfh.pass() == 1) {
@@ -64,8 +64,11 @@ namespace edm {
       os << parameterHoldingLabels_.label() << " (list of allowed labels)";
 
       if (dfh.brief()) {
-        if (optional)
+        if (modifier == Modifier::kOptional)
           os << " optional";
+
+        if (modifier == Modifier::kObsolete)
+          os << " obsolete";
 
         if (!writeToCfi)
           os << " (do not write to cfi)";
@@ -77,11 +80,13 @@ namespace edm {
         os << "\n";
         dfh.indent2(os);
 
-        if (optional)
+        if (modifier == Modifier::kOptional)
           os << "optional";
+        if (modifier == Modifier::kObsolete)
+          os << "obsolete";
         if (!writeToCfi)
           os << " (do not write to cfi)";
-        if (optional || !writeToCfi) {
+        if (modifier == Modifier::kOptional || !writeToCfi) {
           os << "\n";
           dfh.indent2(os);
         }
@@ -125,7 +130,7 @@ namespace edm {
     DocFormatHelper new_dfh(dfh);
     new_dfh.init();
     new_dfh.setPass(1);
-    parameterHoldingLabels_.print(os, optional, true, new_dfh);
+    parameterHoldingLabels_.print(os, modifierIsOptional(optional), true, new_dfh);
     dfh.indent(os);
     os << "type of allowed parameters:";
     if (dfh.brief())

--- a/FWCore/ParameterSet/src/EmptyGroupDescription.cc
+++ b/FWCore/ParameterSet/src/EmptyGroupDescription.cc
@@ -14,17 +14,17 @@ namespace edm {
 
   void EmptyGroupDescription::validate_(ParameterSet&,
                                         std::set<std::string>& /*validatedLabels*/,
-                                        bool /*optional*/) const {}
+                                        Modifier /*optional*/) const {}
 
   void EmptyGroupDescription::writeCfi_(std::ostream&,
-                                        bool /*optional*/,
+                                        Modifier /*optional*/,
                                         bool& /*startWithComma*/,
                                         int /*indentation*/,
                                         CfiOptions&,
                                         bool& /*wroteSomething*/) const {}
 
   void EmptyGroupDescription::print_(std::ostream& os,
-                                     bool /*optional*/,
+                                     Modifier /*optional*/,
                                      bool /*writeToCfi*/,
                                      DocFormatHelper& dfh) const {
     if (dfh.pass() == 1) {

--- a/FWCore/ParameterSet/src/IfExistsDescription.cc
+++ b/FWCore/ParameterSet/src/IfExistsDescription.cc
@@ -53,44 +53,50 @@ namespace edm {
     wildcardTypes.insert(wildcardTypesLeft.begin(), wildcardTypesLeft.end());
   }
 
-  void IfExistsDescription::validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, bool optional) const {
+  void IfExistsDescription::validate_(ParameterSet& pset,
+                                      std::set<std::string>& validatedLabels,
+                                      Modifier modifier) const {
     bool leftExists = node_left_->exists(pset);
     bool rightExists = node_right_->exists(pset);
 
     if (!leftExists && !rightExists) {
       return;
     } else if (leftExists && rightExists) {
-      node_left_->validate(pset, validatedLabels, false);
-      node_right_->validate(pset, validatedLabels, false);
+      node_left_->validate(pset, validatedLabels, Modifier::kNone);
+      node_right_->validate(pset, validatedLabels, Modifier::kNone);
     } else if (leftExists && !rightExists) {
-      node_left_->validate(pset, validatedLabels, false);
-      if (!optional)
-        node_right_->validate(pset, validatedLabels, false);
+      node_left_->validate(pset, validatedLabels, Modifier::kNone);
+      if (modifier == Modifier::kNone)
+        node_right_->validate(pset, validatedLabels, Modifier::kNone);
     } else if (!leftExists && rightExists) {
-      node_left_->validate(pset, validatedLabels, false);
-      node_right_->validate(pset, validatedLabels, false);
+      node_left_->validate(pset, validatedLabels, Modifier::kNone);
+      node_right_->validate(pset, validatedLabels, Modifier::kNone);
     }
   }
 
   void IfExistsDescription::writeCfi_(std::ostream& os,
-                                      bool optional,
+                                      Modifier modifier,
                                       bool& startWithComma,
                                       int indentation,
                                       CfiOptions& options,
                                       bool& wroteSomething) const {
-    node_left_->writeCfi(os, optional, startWithComma, indentation, options, wroteSomething);
-    node_right_->writeCfi(os, optional, startWithComma, indentation, options, wroteSomething);
+    node_left_->writeCfi(os, modifier, startWithComma, indentation, options, wroteSomething);
+    node_right_->writeCfi(os, modifier, startWithComma, indentation, options, wroteSomething);
     parameterMustBeTyped(options);
   }
 
-  void IfExistsDescription::print_(std::ostream& os, bool optional, bool writeToCfi, DocFormatHelper& dfh) const {
+  void IfExistsDescription::print_(std::ostream& os, Modifier modifier, bool writeToCfi, DocFormatHelper& dfh) const {
     if (dfh.pass() == 1) {
       dfh.indent(os);
       os << "IfExists pair:";
 
+      const bool optional = (modifier == Modifier::kOptional);
+      const bool obsolete = (modifier == Modifier::kObsolete);
       if (dfh.brief()) {
         if (optional)
           os << " optional";
+        if (obsolete)
+          os << " obsolete";
 
         if (!writeToCfi)
           os << " (do not write to cfi)";
@@ -104,6 +110,8 @@ namespace edm {
 
         if (optional)
           os << "optional";
+        if (obsolete)
+          os << " obsolete";
         if (!writeToCfi)
           os << " (do not write to cfi)";
         if (optional || !writeToCfi) {
@@ -151,14 +159,14 @@ namespace edm {
     new_dfh.setIndentation(indentation + DocFormatHelper::offsetSectionContent());
     new_dfh.setParent(DocFormatHelper::OTHER);
 
-    node_left_->print(os, false, true, new_dfh);
-    node_right_->print(os, false, true, new_dfh);
+    node_left_->print(os, Modifier::kNone, true, new_dfh);
+    node_right_->print(os, Modifier::kNone, true, new_dfh);
 
     new_dfh.setPass(1);
     new_dfh.setCounter(0);
 
-    node_left_->print(os, false, true, new_dfh);
-    node_right_->print(os, false, true, new_dfh);
+    node_left_->print(os, Modifier::kNone, true, new_dfh);
+    node_right_->print(os, Modifier::kNone, true, new_dfh);
 
     new_dfh.setPass(2);
     new_dfh.setCounter(0);

--- a/FWCore/ParameterSet/src/ORGroupDescription.cc
+++ b/FWCore/ParameterSet/src/ORGroupDescription.cc
@@ -53,41 +53,45 @@ namespace edm {
     wildcardTypes.insert(wildcardTypesLeft.begin(), wildcardTypesLeft.end());
   }
 
-  void ORGroupDescription::validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, bool optional) const {
+  void ORGroupDescription::validate_(ParameterSet& pset,
+                                     std::set<std::string>& validatedLabels,
+                                     Modifier modifier) const {
     bool leftExists = node_left_->exists(pset);
     bool rightExists = node_right_->exists(pset);
 
     if (leftExists || rightExists) {
       if (leftExists)
-        node_left_->validate(pset, validatedLabels, false);
+        node_left_->validate(pset, validatedLabels, Modifier::kNone);
       if (rightExists)
-        node_right_->validate(pset, validatedLabels, false);
+        node_right_->validate(pset, validatedLabels, Modifier::kNone);
       return;
     }
 
-    if (optional)
+    if (modifier != Modifier::kNone)
       return;
 
-    node_left_->validate(pset, validatedLabels, false);
+    node_left_->validate(pset, validatedLabels, Modifier::kNone);
   }
 
   void ORGroupDescription::writeCfi_(std::ostream& os,
-                                     bool optional,
+                                     Modifier modifier,
                                      bool& startWithComma,
                                      int indentation,
                                      CfiOptions& options,
                                      bool& wroteSomething) const {
-    node_left_->writeCfi(os, optional, startWithComma, indentation, options, wroteSomething);
+    node_left_->writeCfi(os, modifier, startWithComma, indentation, options, wroteSomething);
   }
 
-  void ORGroupDescription::print_(std::ostream& os, bool optional, bool writeToCfi, DocFormatHelper& dfh) const {
+  void ORGroupDescription::print_(std::ostream& os, Modifier modifier, bool writeToCfi, DocFormatHelper& dfh) const {
     if (dfh.parent() == DocFormatHelper::OR) {
       dfh.decrementCounter();
-      node_left_->print(os, false, true, dfh);
-      node_right_->print(os, false, true, dfh);
+      node_left_->print(os, Modifier::kNone, true, dfh);
+      node_right_->print(os, Modifier::kNone, true, dfh);
       return;
     }
 
+    const bool optional = (modifier == Modifier::kOptional);
+    const bool obsolete = (modifier == Modifier::kObsolete);
     if (dfh.pass() == 1) {
       dfh.indent(os);
       os << "OR group:";
@@ -95,6 +99,8 @@ namespace edm {
       if (dfh.brief()) {
         if (optional)
           os << " optional";
+        if (obsolete)
+          os << " obsolete";
 
         if (!writeToCfi)
           os << " (do not write to cfi)";
@@ -108,6 +114,8 @@ namespace edm {
 
         if (optional)
           os << "optional";
+        if (obsolete)
+          os << " obsolete";
         if (!writeToCfi)
           os << " (do not write to cfi)";
         if (optional || !writeToCfi) {
@@ -162,14 +170,14 @@ namespace edm {
     new_dfh.setIndentation(indentation + DocFormatHelper::offsetSectionContent());
     new_dfh.setParent(DocFormatHelper::OR);
 
-    node_left_->print(os, false, true, new_dfh);
-    node_right_->print(os, false, true, new_dfh);
+    node_left_->print(os, Modifier::kNone, true, new_dfh);
+    node_right_->print(os, Modifier::kNone, true, new_dfh);
 
     new_dfh.setPass(1);
     new_dfh.setCounter(0);
 
-    node_left_->print(os, false, true, new_dfh);
-    node_right_->print(os, false, true, new_dfh);
+    node_left_->print(os, Modifier::kNone, true, new_dfh);
+    node_right_->print(os, Modifier::kNone, true, new_dfh);
 
     new_dfh.setPass(2);
     new_dfh.setCounter(0);

--- a/FWCore/ParameterSet/src/ORGroupDescription.h
+++ b/FWCore/ParameterSet/src/ORGroupDescription.h
@@ -33,16 +33,16 @@ namespace edm {
                                     std::set<ParameterTypes>& parameterTypes,
                                     std::set<ParameterTypes>& wildcardTypes) const override;
 
-    void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, bool optional) const override;
+    void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, Modifier modifier) const override;
 
     void writeCfi_(std::ostream& os,
-                   bool optional,
+                   Modifier modifier,
                    bool& startWithComma,
                    int indentation,
                    CfiOptions&,
                    bool& wroteSomething) const override;
 
-    void print_(std::ostream& os, bool optional, bool writeToCfi, DocFormatHelper& dfh) const override;
+    void print_(std::ostream& os, Modifier modifier, bool writeToCfi, DocFormatHelper& dfh) const override;
 
     bool hasNestedContent_() const override { return true; }
 

--- a/FWCore/ParameterSet/src/ParameterDescriptionNode.cc
+++ b/FWCore/ParameterSet/src/ParameterDescriptionNode.cc
@@ -110,11 +110,14 @@ namespace edm {
 
   void ParameterDescriptionNode::setComment(char const* value) { comment_ = value; }
 
-  void ParameterDescriptionNode::print(std::ostream& os, bool optional, bool writeToCfi, DocFormatHelper& dfh) const {
+  void ParameterDescriptionNode::print(std::ostream& os,
+                                       Modifier modifier,
+                                       bool writeToCfi,
+                                       DocFormatHelper& dfh) const {
     if (hasNestedContent()) {
       dfh.incrementCounter();
     }
-    print_(os, optional, writeToCfi, dfh);
+    print_(os, modifier, writeToCfi, dfh);
   }
 
   void ParameterDescriptionNode::printNestedContent(std::ostream& os, bool optional, DocFormatHelper& dfh) const {

--- a/FWCore/ParameterSet/src/ParameterSwitchBase.cc
+++ b/FWCore/ParameterSet/src/ParameterSwitchBase.cc
@@ -59,7 +59,7 @@ namespace edm {
   }
 
   void ParameterSwitchBase::printBase(std::ostream& os,
-                                      bool optional,
+                                      Modifier modifier,
                                       bool writeToCfi,
                                       DocFormatHelper& dfh,
                                       std::string const& switchLabel,
@@ -77,6 +77,8 @@ namespace edm {
     if (dfh.pass() == 1) {
       dfh.indent(os);
 
+      const bool optional = (Modifier::kOptional == modifier);
+      const bool obsolete = (Modifier::kObsolete == modifier);
       if (dfh.brief()) {
         std::stringstream ss;
         ss << switchLabel << " (switch)";
@@ -96,6 +98,8 @@ namespace edm {
         os << " " << std::setw(dfh.column3());
         if (optional)
           os << "optional";
+        else if (obsolete)
+          os << "obsolete";
         else
           os << "";
 
@@ -117,6 +121,8 @@ namespace edm {
 
         if (optional)
           os << "optional";
+        if (obsolete)
+          os << "obsolete";
 
         if (!writeToCfi)
           os << " (do not write to cfi)";
@@ -172,7 +178,7 @@ namespace edm {
                                       DocFormatHelper& dfh,
                                       std::string const& switchLabel) {
     if (dfh.pass() == 0) {
-      p.second->print(os, false, true, dfh);
+      p.second->print(os, Modifier::kNone, true, dfh);
     }
     if (dfh.pass() == 1) {
       dfh.indent(os);
@@ -182,7 +188,7 @@ namespace edm {
       else
         os << "False";
       os << "\n";
-      p.second->print(os, false, true, dfh);
+      p.second->print(os, Modifier::kNone, true, dfh);
     }
     if (dfh.pass() == 2) {
       p.second->printNestedContent(os, false, dfh);
@@ -195,12 +201,12 @@ namespace edm {
                                       DocFormatHelper& dfh,
                                       std::string const& switchLabel) {
     if (dfh.pass() == 0) {
-      p.second->print(os, false, true, dfh);
+      p.second->print(os, Modifier::kNone, true, dfh);
     }
     if (dfh.pass() == 1) {
       dfh.indent(os);
       os << "if " << switchLabel << " = " << p.first << "\n";
-      p.second->print(os, false, true, dfh);
+      p.second->print(os, Modifier::kNone, true, dfh);
     }
     if (dfh.pass() == 2) {
       p.second->printNestedContent(os, false, dfh);
@@ -213,12 +219,12 @@ namespace edm {
                                       DocFormatHelper& dfh,
                                       std::string const& switchLabel) {
     if (dfh.pass() == 0) {
-      p.second->print(os, false, true, dfh);
+      p.second->print(os, Modifier::kNone, true, dfh);
     }
     if (dfh.pass() == 1) {
       dfh.indent(os);
       os << "if " << switchLabel << " = \"" << p.first << "\"\n";
-      p.second->print(os, false, true, dfh);
+      p.second->print(os, Modifier::kNone, true, dfh);
     }
     if (dfh.pass() == 2) {
       p.second->printNestedContent(os, false, dfh);

--- a/FWCore/ParameterSet/src/ParameterWildcard.cc
+++ b/FWCore/ParameterSet/src/ParameterWildcard.cc
@@ -49,9 +49,9 @@ namespace edm {
 
   void ParameterWildcard<ParameterSetDescription>::validate_(ParameterSet& pset,
                                                              std::set<std::string>& validatedLabels,
-                                                             bool optional) const {
+                                                             Modifier modifier) const {
     std::vector<std::string> parameterNames = pset.getParameterNamesForType<ParameterSet>(isTracked());
-    validateMatchingNames(parameterNames, validatedLabels, optional);
+    validateMatchingNames(parameterNames, validatedLabels, modifier == Modifier::kOptional);
 
     if (psetDesc_) {
       for_all(parameterNames,
@@ -162,9 +162,9 @@ namespace edm {
 
   void ParameterWildcard<std::vector<ParameterSet> >::validate_(ParameterSet& pset,
                                                                 std::set<std::string>& validatedLabels,
-                                                                bool optional) const {
+                                                                Modifier modifier) const {
     std::vector<std::string> parameterNames = pset.getParameterNamesForType<std::vector<ParameterSet> >(isTracked());
-    validateMatchingNames(parameterNames, validatedLabels, optional);
+    validateMatchingNames(parameterNames, validatedLabels, modifier == Modifier::kOptional);
 
     if (psetDesc_) {
       for_all(parameterNames,

--- a/FWCore/ParameterSet/src/ParameterWildcardBase.cc
+++ b/FWCore/ParameterSet/src/ParameterWildcardBase.cc
@@ -61,7 +61,10 @@ namespace edm {
     wildcardTypes.insert(type());
   }
 
-  void ParameterWildcardBase::print_(std::ostream& os, bool optional, bool /*writeToCfi*/, DocFormatHelper& dfh) const {
+  void ParameterWildcardBase::print_(std::ostream& os,
+                                     Modifier modifier,
+                                     bool /*writeToCfi*/,
+                                     DocFormatHelper& dfh) const {
     if (dfh.pass() == 0) {
       dfh.setAtLeast1(11U);
       if (isTracked()) {
@@ -71,6 +74,8 @@ namespace edm {
       }
       dfh.setAtLeast3(8U);
     } else {
+      const bool optional = (Modifier::kOptional == modifier);
+      const bool obsolete = (Modifier::kObsolete == modifier);
       if (dfh.brief()) {
         dfh.indent(os);
         std::ios::fmtflags oldFlags = os.flags();
@@ -89,6 +94,8 @@ namespace edm {
         os << std::setw(dfh.column3());
         if (optional)
           os << "optional";
+        else if (obsolete)
+          os << "obsolete";
         else
           os << "";
 
@@ -121,6 +128,8 @@ namespace edm {
 
         if (optional)
           os << " optional";
+        if (obsolete)
+          os << "obsolete";
         os << "\n";
 
         dfh.indent2(os);
@@ -147,7 +156,7 @@ namespace edm {
   }
 
   void ParameterWildcardBase::writeCfi_(std::ostream& os,
-                                        bool optional,
+                                        Modifier modifier,
                                         bool& startWithComma,
                                         int indentation,
                                         CfiOptions& options,
@@ -162,8 +171,10 @@ namespace edm {
 
     os << "allowAnyLabel_ = cms.";
 
-    if (optional) {
+    if (Modifier::kOptional == modifier) {
       os << "optional.";
+    } else if (Modifier::kObsolete == modifier) {
+      os << "obsolete.";
     } else {
       os << "required.";
     }

--- a/FWCore/ParameterSet/src/ParameterWildcardWithSpecifics.cc
+++ b/FWCore/ParameterSet/src/ParameterWildcardWithSpecifics.cc
@@ -27,9 +27,9 @@ namespace edm {
 
   void ParameterWildcardWithSpecifics::validate_(ParameterSet& pset,
                                                  std::set<std::string>& validatedLabels,
-                                                 bool optional) const {
+                                                 Modifier modifier) const {
     std::vector<std::string> parameterNames = pset.getParameterNamesForType<ParameterSet>(isTracked());
-    validateMatchingNames(parameterNames, validatedLabels, optional);
+    validateMatchingNames(parameterNames, validatedLabels, modifier == Modifier::kOptional);
 
     for (auto const& name : parameterNames) {
       validateDescription(name, pset);

--- a/FWCore/ParameterSet/src/XORGroupDescription.cc
+++ b/FWCore/ParameterSet/src/XORGroupDescription.cc
@@ -47,12 +47,14 @@ namespace edm {
     wildcardTypes.insert(wildcardTypesLeft.begin(), wildcardTypesLeft.end());
   }
 
-  void XORGroupDescription::validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, bool optional) const {
+  void XORGroupDescription::validate_(ParameterSet& pset,
+                                      std::set<std::string>& validatedLabels,
+                                      Modifier modifier) const {
     int nExistLeft = node_left_->howManyXORSubNodesExist(pset);
     int nExistRight = node_right_->howManyXORSubNodesExist(pset);
     int nTotal = nExistLeft + nExistRight;
 
-    if (nTotal == 0 && optional)
+    if (nTotal == 0 && modifier != Modifier::kNone)
       return;
 
     if (nTotal > 1) {
@@ -60,11 +62,11 @@ namespace edm {
     }
 
     if (nExistLeft == 1) {
-      node_left_->validate(pset, validatedLabels, false);
+      node_left_->validate(pset, validatedLabels, Modifier::kNone);
     } else if (nExistRight == 1) {
-      node_right_->validate(pset, validatedLabels, false);
+      node_right_->validate(pset, validatedLabels, Modifier::kNone);
     } else if (nTotal == 0) {
-      node_left_->validate(pset, validatedLabels, false);
+      node_left_->validate(pset, validatedLabels, Modifier::kNone);
 
       // When missing parameters get inserted, both nodes could
       // be affected so we have to recheck both nodes.
@@ -79,19 +81,19 @@ namespace edm {
   }
 
   void XORGroupDescription::writeCfi_(std::ostream& os,
-                                      bool optional,
+                                      Modifier modifier,
                                       bool& startWithComma,
                                       int indentation,
                                       CfiOptions& options,
                                       bool& wroteSomething) const {
-    node_left_->writeCfi(os, optional, startWithComma, indentation, options, wroteSomething);
+    node_left_->writeCfi(os, modifier, startWithComma, indentation, options, wroteSomething);
   }
 
-  void XORGroupDescription::print_(std::ostream& os, bool optional, bool writeToCfi, DocFormatHelper& dfh) const {
+  void XORGroupDescription::print_(std::ostream& os, Modifier modifier, bool writeToCfi, DocFormatHelper& dfh) const {
     if (dfh.parent() == DocFormatHelper::XOR) {
       dfh.decrementCounter();
-      node_left_->print(os, false, true, dfh);
-      node_right_->print(os, false, true, dfh);
+      node_left_->print(os, Modifier::kNone, true, dfh);
+      node_right_->print(os, Modifier::kNone, true, dfh);
       return;
     }
 
@@ -99,10 +101,15 @@ namespace edm {
       dfh.indent(os);
       os << "XOR group:";
 
+      const bool optional = (modifier == Modifier::kOptional);
+      const bool obsolete = (modifier == Modifier::kObsolete);
       if (dfh.brief()) {
-        if (optional)
+        if (optional) {
           os << " optional";
-
+        }
+        if (obsolete) {
+          os << " obsolete";
+        }
         if (!writeToCfi)
           os << " (do not write to cfi)";
 
@@ -113,8 +120,12 @@ namespace edm {
         os << "\n";
         dfh.indent2(os);
 
-        if (optional)
+        if (optional) {
           os << "optional";
+        }
+        if (obsolete) {
+          os << " obsolete";
+        }
         if (!writeToCfi)
           os << " (do not write to cfi)";
         if (optional || !writeToCfi) {
@@ -166,14 +177,14 @@ namespace edm {
     new_dfh.setIndentation(indentation + DocFormatHelper::offsetSectionContent());
     new_dfh.setParent(DocFormatHelper::XOR);
 
-    node_left_->print(os, false, true, new_dfh);
-    node_right_->print(os, false, true, new_dfh);
+    node_left_->print(os, Modifier::kNone, true, new_dfh);
+    node_right_->print(os, Modifier::kNone, true, new_dfh);
 
     new_dfh.setPass(1);
     new_dfh.setCounter(0);
 
-    node_left_->print(os, false, true, new_dfh);
-    node_right_->print(os, false, true, new_dfh);
+    node_left_->print(os, Modifier::kNone, true, new_dfh);
+    node_right_->print(os, Modifier::kNone, true, new_dfh);
 
     new_dfh.setPass(2);
     new_dfh.setCounter(0);

--- a/FWCore/ParameterSet/src/XORGroupDescription.h
+++ b/FWCore/ParameterSet/src/XORGroupDescription.h
@@ -35,16 +35,16 @@ namespace edm {
                                     std::set<ParameterTypes>& parameterTypes,
                                     std::set<ParameterTypes>& wildcardTypes) const override;
 
-    void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, bool optional) const override;
+    void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, Modifier modifier) const override;
 
     void writeCfi_(std::ostream& os,
-                   bool optional,
+                   Modifier modifier,
                    bool& startWithComma,
                    int indentation,
                    CfiOptions&,
                    bool& wroteSomething) const override;
 
-    void print_(std::ostream& os, bool optional, bool writeToCfi, DocFormatHelper& dfh) const override;
+    void print_(std::ostream& os, Modifier modifier, bool writeToCfi, DocFormatHelper& dfh) const override;
 
     bool hasNestedContent_() const override { return true; }
 

--- a/FWCore/ParameterSet/test/test_catch_ParameterSetDescription.cc
+++ b/FWCore/ParameterSet/test/test_catch_ParameterSetDescription.cc
@@ -87,7 +87,7 @@ TEST_CASE("test ParameterSetDescription", "[ParameterSetDescription]") {
         bool startWithComma = false;
         bool wroteSomething = false;
         edm::CfiOptions ops = edm::cfi::Typed{};
-        w.writeCfi(os, false, startWithComma, 0, ops, wroteSomething);
+        w.writeCfi(os, edm::ParameterModifier::kNone, startWithComma, 0, ops, wroteSomething);
 
         REQUIRE_THAT(os.str(), Equals("\nallowAnyLabel_ = cms.required.int32"));
       }
@@ -110,7 +110,7 @@ TEST_CASE("test ParameterSetDescription", "[ParameterSetDescription]") {
         bool wroteSomething = false;
         edm::CfiOptions ops = edm::cfi::Typed{};
 
-        w.writeCfi(os, false, startWithComma, 0, ops, wroteSomething);
+        w.writeCfi(os, edm::ParameterModifier::kNone, startWithComma, 0, ops, wroteSomething);
 
         REQUIRE_THAT(os.str(), Equals("\nallowAnyLabel_ = cms.required.untracked.uint32"));
       }
@@ -157,7 +157,7 @@ TEST_CASE("test ParameterSetDescription", "[ParameterSetDescription]") {
         bool wroteSomething = false;
         edm::CfiOptions ops = edm::cfi::Typed{};
 
-        w.writeCfi(os, false, startWithComma, 0, ops, wroteSomething);
+        w.writeCfi(os, edm::ParameterModifier::kNone, startWithComma, 0, ops, wroteSomething);
 
         REQUIRE_THAT(os.str(), Equals("\nallowAnyLabel_ = cms.required.double"));
       }
@@ -192,7 +192,7 @@ TEST_CASE("test ParameterSetDescription", "[ParameterSetDescription]") {
         bool startWithComma = false;
         bool wroteSomething = false;
         edm::CfiOptions ops = edm::cfi::Typed{};
-        w.writeCfi(os, false, startWithComma, 0, ops, wroteSomething);
+        w.writeCfi(os, edm::ParameterModifier::kNone, startWithComma, 0, ops, wroteSomething);
 
         REQUIRE_THAT(os.str(), Equals("\nallowAnyLabel_ = cms.required.PSetTemplate()"));
       }
@@ -242,7 +242,7 @@ TEST_CASE("test ParameterSetDescription", "[ParameterSetDescription]") {
         bool startWithComma = false;
         bool wroteSomething = false;
         edm::CfiOptions ops = edm::cfi::Typed{};
-        w.writeCfi(os, false, startWithComma, 0, ops, wroteSomething);
+        w.writeCfi(os, edm::ParameterModifier::kNone, startWithComma, 0, ops, wroteSomething);
 
         REQUIRE_THAT(os.str(),
                      Equals("\nallowAnyLabel_ = cms.required.PSetTemplate(\n  n1 = cms.untracked.uint32(1)\n)"));
@@ -295,7 +295,7 @@ TEST_CASE("test ParameterSetDescription", "[ParameterSetDescription]") {
         bool startWithComma = false;
         bool wroteSomething = false;
         edm::CfiOptions ops = edm::cfi::Typed{};
-        w.writeCfi(os, false, startWithComma, 0, ops, wroteSomething);
+        w.writeCfi(os, edm::ParameterModifier::kNone, startWithComma, 0, ops, wroteSomething);
 
         REQUIRE_THAT(os.str(), Equals("\nallowAnyLabel_ = cms.required.VPSet"));
       }
@@ -1641,6 +1641,137 @@ p = dict(
     CHECK(psetDesc.isUnknown());
 
     psetDesc.validate(params);
+  }
+
+  SECTION("obsolete") {
+    SECTION("string") {
+      edm::ParameterSetDescription psetDesc;
+
+      psetDesc.add<std::string>("testname");
+      psetDesc.add<std::string>("hadDefault", "default");
+      psetDesc.addObsolete<std::string>("noLongerUsed");
+      SECTION("with obsolete") {
+        edm::ParameterSet params;
+        params.addParameter<std::string>("testname", std::string("testvalue"));
+        params.addParameter<std::string>("noLongerUsed", std::string("testvalue"));
+
+        psetDesc.validate(params);
+      }
+      SECTION("without obsolete") {
+        edm::ParameterSet params;
+        params.addParameter<std::string>("testname", std::string("testvalue"));
+        psetDesc.validate(params);
+        CHECK(not params.existsAs<std::string>("noLongerUsed"));
+      }
+      SECTION("writeCfi full") {
+        std::ostringstream s;
+        edm::CfiOptions fullOps = edm::cfi::Typed{};
+        psetDesc.writeCfi(s, false, 0, fullOps);
+        std::string expected = R"-(
+testname = cms.required.string,
+hadDefault = cms.string('default'),
+noLongerUsed = cms.obsolete.string
+)-";
+
+        CHECK(expected == s.str());
+      }
+      SECTION("writeCfi Untyped") {
+        std::ostringstream s;
+        edm::CfiOptions fullOps = edm::cfi::Untyped{edm::cfi::Paths{}};
+        psetDesc.writeCfi(s, false, 0, fullOps);
+        std::string expected = R"-(
+hadDefault = 'default'
+)-";
+        CHECK(expected == s.str());
+      }
+    }
+    SECTION("PSet") {
+      edm::ParameterSetDescription psetDesc;
+
+      psetDesc.add<std::string>("testname");
+      psetDesc.add<std::string>("hadDefault", "default");
+      psetDesc.addObsolete<edm::ParameterSetDescription>("noLongerUsed");
+      SECTION("with obsolete") {
+        edm::ParameterSet params;
+        params.addParameter<std::string>("testname", std::string("testvalue"));
+        edm::ParameterSet obs;
+        obs.addParameter<int>("something", 1);
+        params.addParameter<edm::ParameterSet>("noLongerUsed", obs);
+
+        psetDesc.validate(params);
+      }
+      SECTION("without obsolete") {
+        edm::ParameterSet params;
+        params.addParameter<std::string>("testname", std::string("testvalue"));
+        psetDesc.validate(params);
+      }
+      SECTION("writeCfi full") {
+        std::ostringstream s;
+        edm::CfiOptions fullOps = edm::cfi::Typed{};
+        psetDesc.writeCfi(s, false, 0, fullOps);
+        std::string expected = R"-(
+testname = cms.required.string,
+hadDefault = cms.string('default'),
+noLongerUsed = cms.obsolete.PSet
+)-";
+
+        CHECK(expected == s.str());
+      }
+      SECTION("writeCfi Untyped") {
+        std::ostringstream s;
+        edm::CfiOptions fullOps = edm::cfi::Untyped{edm::cfi::Paths{}};
+        psetDesc.writeCfi(s, false, 0, fullOps);
+        std::string expected = R"-(
+hadDefault = 'default'
+)-";
+        CHECK(expected == s.str());
+      }
+    }
+  }
+
+  SECTION("VPSet") {
+    edm::ParameterSetDescription psetDesc;
+
+    psetDesc.add<std::string>("testname");
+    psetDesc.add<std::string>("hadDefault", "default");
+    psetDesc.addVPSetObsolete("noLongerUsed");
+    SECTION("with obsolete") {
+      edm::ParameterSet params;
+      params.addParameter<std::string>("testname", std::string("testvalue"));
+
+      edm::ParameterSet obs;
+      obs.addParameter<int>("something", 1);
+      std::vector<edm::ParameterSet> vobs{1, obs};
+      params.addParameter<std::vector<edm::ParameterSet>>("noLongerUsed", vobs);
+
+      psetDesc.validate(params);
+    }
+    SECTION("without obsolete") {
+      edm::ParameterSet params;
+      params.addParameter<std::string>("testname", std::string("testvalue"));
+      psetDesc.validate(params);
+    }
+    SECTION("writeCfi full") {
+      std::ostringstream s;
+      edm::CfiOptions fullOps = edm::cfi::Typed{};
+      psetDesc.writeCfi(s, false, 0, fullOps);
+      std::string expected = R"-(
+testname = cms.required.string,
+hadDefault = cms.string('default'),
+noLongerUsed = cms.obsolete.VPSet
+)-";
+
+      CHECK(expected == s.str());
+    }
+    SECTION("writeCfi Untyped") {
+      std::ostringstream s;
+      edm::CfiOptions fullOps = edm::cfi::Untyped{edm::cfi::Paths{}};
+      psetDesc.writeCfi(s, false, 0, fullOps);
+      std::string expected = R"-(
+hadDefault = 'default'
+)-";
+      CHECK(expected == s.str());
+    }
   }
 
   SECTION("FileInPath") {


### PR DESCRIPTION
#### PR description:

- Obsolete parameters will cause a warning to be issued and then skipped in the validation.
- The _cfi.py files will get a cms.obsolete parameter added which allows one to still set the parameter in python but will not be passed to the C++.

#### PR validation:

Framework unit tests pass and newly added tests also pass.

resolves https://github.com/cms-sw/framework-team/issues/1317