### PR TITLE
[TkAlignment] Add DiMuon bias analysis macros

### DIFF
--- a/Alignment/OfflineValidation/macros/analyzeDiMuonBiases.C
+++ b/Alignment/OfflineValidation/macros/analyzeDiMuonBiases.C
@@ -148,7 +148,7 @@ std::pair<TH1F*, TH1F*> makeProfileVsEta(TH2F* h2) {
   h_prof->GetXaxis()->SetTitle(h2->GetXaxis()->GetTitle());
   h_prof->GetYaxis()->SetTitle(updateTitle(h2->GetZaxis()->GetTitle(), TitleFormatType::MEAN));
   for (int i = 1; i <= nBinsX; i++) {
-    std::cout << i << " = " << average[i - 1] << std::endl;
+    //std::cout << i << " = " << average[i - 1] << std::endl;
     h_prof->SetBinContent(i, average[i - 1]);
     h_prof->SetBinError(i, RMS[i - 1] / nBinsY);
   }
@@ -157,7 +157,7 @@ std::pair<TH1F*, TH1F*> makeProfileVsEta(TH2F* h2) {
   h_RMS->GetXaxis()->SetTitle(h2->GetXaxis()->GetTitle());
   h_RMS->GetYaxis()->SetTitle(updateTitle(h2->GetZaxis()->GetTitle(), TitleFormatType::RMS));
   for (int i = 1; i <= nBinsX; i++) {
-    std::cout << i << " = " << average[i - 1] << std::endl;
+    //std::cout << i << " = " << average[i - 1] << std::endl;
     h_RMS->SetBinContent(i, RMS[i - 1]);
     h_RMS->SetBinError(i, RMS[i - 1] / std::sqrt(2 * (nBinsY - 1)));
   }
@@ -198,7 +198,7 @@ std::pair<TH1F*, TH1F*> makeProfileVsPhi(TH2F* h2) {
   h_prof->GetXaxis()->SetTitle(h2->GetYaxis()->GetTitle());
   h_prof->GetYaxis()->SetTitle(updateTitle(h2->GetZaxis()->GetTitle(), TitleFormatType::MEAN));
   for (int i = 1; i <= nBinsY; i++) {
-    std::cout << i << " = " << average[i - 1] << std::endl;
+    //std::cout << i << " = " << average[i - 1] << std::endl;
     h_prof->SetBinContent(i, average[i - 1]);
     h_prof->SetBinError(i, RMS[i - 1] / nBinsX);
   }
@@ -207,7 +207,7 @@ std::pair<TH1F*, TH1F*> makeProfileVsPhi(TH2F* h2) {
   h_RMS->GetXaxis()->SetTitle(h2->GetYaxis()->GetTitle());
   h_RMS->GetYaxis()->SetTitle(updateTitle(h2->GetZaxis()->GetTitle(), TitleFormatType::RMS));
   for (int i = 1; i <= nBinsY; i++) {
-    std::cout << i << " = " << average[i - 1] << std::endl;
+    //std::cout << i << " = " << average[i - 1] << std::endl;
     h_RMS->SetBinContent(i, RMS[i - 1]);
     h_RMS->SetBinError(i, RMS[i - 1] / std::sqrt(2 * (nBinsX - 1)));
   }

--- a/Alignment/OfflineValidation/macros/analyzeDiMuonBiases.C
+++ b/Alignment/OfflineValidation/macros/analyzeDiMuonBiases.C
@@ -1,0 +1,856 @@
+#include <TCanvas.h>
+#include <TF1.h>
+#include <TFile.h>
+#include <TH1D.h>
+#include <TH1F.h>
+#include <TH2F.h>
+#include <TLorentzVector.h>
+#include <TMath.h>
+#include <TProfile.h>
+#include <TRegexp.h>
+#include <TStopwatch.h>
+#include <TString.h>
+#include <TTree.h>
+#include <iomanip>  // Include the header for setw
+#include <map>
+#include <string>
+#include <iostream>
+
+// analysis types
+enum anaKind { sagitta_t = 0, d0_t = 1, dz_t = 2 };
+
+// number of bins for the correction map
+unsigned int k_NBINS = 48;
+
+// maximum number of iterations
+int k_MAXITERATIONS = 30;
+
+static constexpr const char* const analysis_types[] = {
+    "sagitta",  //  0 - sagitta bias
+    "d0",       //  1 - transverse IP bias
+    "dz",       //  2 - longitudinal IP bias
+};
+
+// physics constants
+static constexpr double k_muMass = 0.105658;  // GeV
+static constexpr double MZ_PDG = 91.1876;     // in GeV
+
+// ansatz from eq. 5 of https://arxiv.org/pdf/2212.07338.pdf
+//________________________________________________________________
+double pTcorrector(const double& unCorrPt, const double& delta, const float& charge) {
+  return unCorrPt / (1 - charge * delta * unCorrPt);
+}
+
+//________________________________________________________________
+float calcDeltaSagitta(float charge, float frac, float avgSagitta, float thisTrackPt) {
+  return (-charge * 0.5 * frac * ((1 + charge * thisTrackPt * avgSagitta) / thisTrackPt));
+}
+
+//________________________________________________________________
+std::pair<int, int> findEtaPhiBin(const TH2* h2, const float& eta, const float& phi) {
+  const auto& etaBin = h2->GetXaxis()->FindBin(eta) - 1;
+  const auto& phiBin = h2->GetYaxis()->FindBin(phi) - 1;
+
+  if (etaBin < 0 || etaBin > int(k_NBINS - 1)) {
+    std::cout << "etaBin: " << etaBin << " eta: " << eta << std::endl;
+    return {-1., -1.};
+  }
+
+  if (phiBin < 0 || phiBin > int(k_NBINS - 1)) {
+    std::cout << "phiBin: " << phiBin << " phi: " << phi << std::endl;
+    return {-1., -1.};
+  }
+  return std::make_pair(etaBin, phiBin);
+}
+
+//________________________________________________________________
+float updateSagittaMap(TTree* tree,
+                       std::map<std::pair<int, int>, float>& theMap,
+                       TH2F*& hSagitta,
+                       const int iteration,
+                       float oldMaxCorrection);
+
+//________________________________________________________________
+float updateIPMap(
+    TTree* tree, std::map<std::pair<int, int>, float>& theMap, TH2F*& hIP, const int iteration, anaKind type);
+
+// Enum to specify the formatting type
+enum TitleFormatType { MEAN, RMS };
+
+//________________________________________________________________
+TString updateTitle(const TString& title, TitleFormatType formatType) {
+  // Regular expression to match units in square brackets
+  TRegexp re("\\[.*\\]");
+  TString units;
+  TString cleanTitle = title;
+
+  // Check if units are present and extract them
+  if (cleanTitle.Index(re) != kNPOS) {
+    units = cleanTitle(re);                         // Extract the unit part
+    cleanTitle(re) = "";                            // Remove the unit from the cleanTitle
+    cleanTitle = cleanTitle.Strip(TString::kBoth);  // Remove extra spaces
+  }
+
+  // Construct the new title based on the formatType
+  TString newTitle;
+  switch (formatType) {
+    case MEAN:
+      if (!units.IsNull()) {
+        newTitle = TString::Format("#LT%s#GT %s", cleanTitle.Data(), units.Data());
+      } else {
+        newTitle = TString::Format("#LT%s#GT", cleanTitle.Data());
+      }
+      break;
+    case RMS:
+      if (!units.IsNull()) {
+        newTitle = TString::Format("RMS (%s) %s", cleanTitle.Data(), units.Data());
+      } else {
+        newTitle = TString::Format("RMS (%s)", cleanTitle.Data());
+      }
+      break;
+  }
+
+  // Set the new title to the x-axis of h_prof
+  return newTitle;
+}
+
+//________________________________________________________________
+std::pair<TH1F*, TH1F*> makeProfileVsEta(TH2F* h2) {
+  const auto& nBinsX = h2->GetNbinsX();
+  const auto& nBinsY = h2->GetNbinsY();
+
+  float xmin = h2->GetXaxis()->GetXmin();
+  float xmax = h2->GetXaxis()->GetXmax();
+
+  std::vector<float> average;
+  std::vector<float> RMS;
+  std::vector<float> errorOnRMS;
+
+  for (int i = 1; i <= nBinsX; i++) {
+    float avgInY{0.};
+    for (int j = 1; j <= nBinsY; j++) {
+      avgInY += h2->GetBinContent(i, j);
+    }
+    avgInY /= nBinsY;
+    average.push_back(avgInY);
+  }
+
+  for (int i = 1; i <= nBinsX; i++) {
+    float RMSInY{0.};
+    for (int j = 1; j <= nBinsY; j++) {
+      RMSInY += std::pow((h2->GetBinContent(i, j) - average[i - 1]), 2);
+    }
+    RMSInY /= nBinsY;
+    RMS.push_back(std::sqrt(RMSInY));
+  }
+
+  TH1F* h_prof = new TH1F("avgInEta", "profile vs #eta", nBinsX, xmin, xmax);
+  h_prof->GetXaxis()->SetTitle(h2->GetXaxis()->GetTitle());
+  h_prof->GetYaxis()->SetTitle(updateTitle(h2->GetZaxis()->GetTitle(), TitleFormatType::MEAN));
+  for (int i = 1; i <= nBinsX; i++) {
+    std::cout << i << " = " << average[i - 1] << std::endl;
+    h_prof->SetBinContent(i, average[i - 1]);
+    h_prof->SetBinError(i, RMS[i - 1] / nBinsY);
+  }
+
+  TH1F* h_RMS = new TH1F("RMSInEta", "RMS vs #eta", nBinsX, xmin, xmax);
+  h_RMS->GetXaxis()->SetTitle(h2->GetXaxis()->GetTitle());
+  h_RMS->GetYaxis()->SetTitle(updateTitle(h2->GetZaxis()->GetTitle(), TitleFormatType::RMS));
+  for (int i = 1; i <= nBinsX; i++) {
+    std::cout << i << " = " << average[i - 1] << std::endl;
+    h_RMS->SetBinContent(i, RMS[i - 1]);
+    h_RMS->SetBinError(i, RMS[i - 1] / std::sqrt(2 * (nBinsY - 1)));
+  }
+
+  return std::make_pair(h_prof, h_RMS);
+}
+
+//________________________________________________________________
+std::pair<TH1F*, TH1F*> makeProfileVsPhi(TH2F* h2) {
+  const auto& nBinsX = h2->GetNbinsX();
+  const auto& nBinsY = h2->GetNbinsY();
+
+  float ymin = h2->GetYaxis()->GetXmin();
+  float ymax = h2->GetYaxis()->GetXmax();
+
+  std::vector<float> average;
+  std::vector<float> RMS;
+
+  for (int j = 1; j <= nBinsY; j++) {
+    float avgInX{0.};
+    for (int i = 1; i <= nBinsX; i++) {
+      avgInX += h2->GetBinContent(i, j);
+    }
+    avgInX /= nBinsX;
+    average.push_back(avgInX);
+  }
+
+  for (int j = 1; j <= nBinsY; j++) {
+    float RMSInX{0.};
+    for (int i = 1; i <= nBinsX; i++) {
+      RMSInX += std::pow((h2->GetBinContent(i, j) - average[j - 1]), 2);
+    }
+    RMSInX /= nBinsX;
+    RMS.push_back(std::sqrt(RMSInX));
+  }
+
+  TH1F* h_prof = new TH1F("avgInPhi", "profile vs #phi", nBinsY, ymin, ymax);
+  h_prof->GetXaxis()->SetTitle(h2->GetYaxis()->GetTitle());
+  h_prof->GetYaxis()->SetTitle(updateTitle(h2->GetZaxis()->GetTitle(), TitleFormatType::MEAN));
+  for (int i = 1; i <= nBinsY; i++) {
+    std::cout << i << " = " << average[i - 1] << std::endl;
+    h_prof->SetBinContent(i, average[i - 1]);
+    h_prof->SetBinError(i, RMS[i - 1] / nBinsX);
+  }
+
+  TH1F* h_RMS = new TH1F("RMSInPhi", "RMS vs #phi", nBinsY, ymin, ymax);
+  h_RMS->GetXaxis()->SetTitle(h2->GetYaxis()->GetTitle());
+  h_RMS->GetYaxis()->SetTitle(updateTitle(h2->GetZaxis()->GetTitle(), TitleFormatType::RMS));
+  for (int i = 1; i <= nBinsY; i++) {
+    std::cout << i << " = " << average[i - 1] << std::endl;
+    h_RMS->SetBinContent(i, RMS[i - 1]);
+    h_RMS->SetBinError(i, RMS[i - 1] / std::sqrt(2 * (nBinsX - 1)));
+  }
+
+  return std::make_pair(h_prof, h_RMS);
+}
+
+//________________________________________________________________
+void analyzeDiMuonBiases(const char* inputFile, anaKind type) {
+  TStopwatch timer;
+  timer.Start();
+
+  std::cout << "I AM GOING TO PERFORM THE " << analysis_types[type] << " analysis!" << std::endl;
+
+  TFile* file = TFile::Open(inputFile);
+  //TTree* tree = dynamic_cast<TTree*>(file->Get("myanalysis/tree"));
+  TTree* tree = dynamic_cast<TTree*>(file->Get("ZtoMMNtuple/tree"));
+
+  if (tree) {
+    tree->ls();
+  } else {
+    std::cout << "could not open the input tree from file.\n exiting";
+    exit(EXIT_FAILURE);
+  }
+  // prepare the output file name
+  std::string outputString(inputFile);
+  std::string oldSubstring = "ZmmNtuple_";
+  std::string newSubstring = "histos_";
+  outputString.replace(outputString.find(oldSubstring), oldSubstring.length(), newSubstring);
+  std::size_t pos = outputString.find(".root");
+
+  // If ".root" is found, inject the given const char*
+  TString toInject = TString::Format("__%s", analysis_types[type]);
+  if (pos != std::string::npos) {
+    outputString.insert(pos, toInject.Data());
+  }
+
+  // one for iteration
+
+  TFile* outputFile = TFile::Open(outputString.c_str(), "RECREATE");
+  TH1F* hMass = new TH1F("hMass", "mass;m_{#mu#mu} [GeV];events", 80, 70., 110.);
+  TH1F* hPt = new TH1F("hPt", ";muon p_{T} [GeV];events", 100, 0., 200.);
+  TH1F* hZPt = new TH1F("hZPt", ";di-muon system p_{T} [GeV];events", 100, 0., 200.);
+
+  TH1F* hPtPlus = new TH1F("hPtPlus", ";positive muon p_{T} [GeV];events", 100, 0., 200.);
+  TH1F* hPtMinus = new TH1F("hPtMinus", ";negative muon p_{T} [GeV];events", 100, 0., 200.);
+
+  TH1F* hPtCorr = new TH1F("hPtCorr", ";corrected muon p_{T} [GeV];events", 100, 0., 200.);
+  TH1F* hPtPlusCorr = new TH1F("hPtPlusCorr", ";corrected positive muon p_{T} [GeV];events", 100, 0., 200.);
+  TH1F* hPtMinusCorr = new TH1F("hPtMinusCorr", ";corrected negative muon p_{T} [GeV];events", 100, 0., 200.);
+
+  TH1F* hMassCorr = new TH1F("hMassCorr", "corrected mass;corrected m_{#mu#mu} [GeV];events", 80, 70., 110.);
+  TH1F* hDeltaMassCorr = new TH1F(
+      "hDeltaMassCorr",
+      "#Delta Mass (corrected - corrected) ;#Delta m_{#mu#mu} (m^{corr}_{#mu#mu} - m^{uncorr}_{#mu#mu}) [GeV];events",
+      100,
+      -10.,
+      10.);
+  TH1F* hDeltaPtCorr =
+      new TH1F("hDeltaPtCorr", "#Delta p_{T};#Delta p_{T} (p^{corr}_{T}-p^{uncorr}_{T}) [GeV];events", 100, -10., 10.);
+
+  TH1F* hEta = new TH1F("hEta", ";muon #eta;events", 100, -3.0, 3.0);
+
+  TH1F* hDeltaD0 = new TH1F("hDeltaD0", ";#Deltad_{0} [cm];events", 100, -0.01, 0.01);
+  TH1F* hDeltaDz = new TH1F("hDeltaDz", ";#Deltad_{z} [cm];events", 100, -0.1, 0.1);
+
+  TH1F* hDeltaD0Corr = new TH1F("hDeltaD0Corr", ";corrected #Deltad_{0} [cm];events", 100, -0.01, 0.01);
+  TH1F* hDeltaDzCorr = new TH1F("hDeltaDzCorr", ";corrected #Deltad_{z} [cm];events", 100, -0.1, 0.1);
+
+  TH1F* hAbsDeltaD0 = new TH1F("hAbsDeltaD0", ";|#Deltad_{0}| [cm];events", 100, 0., 0.01);
+  TH1F* hAbsDeltaDz = new TH1F("hAbsDeltaDz", ";|#Deltad_{z}| [cm];events", 100, 0., 0.1);
+
+  TH1F* hAbsDeltaD0Corr = new TH1F("hAbsDeltaD0Corr", ";corrected |#Deltad_{0}| [cm];events", 100, 0., 0.01);
+  TH1F* hAbsDeltaDzCorr = new TH1F("hAbsDeltaDzCorr", ";corrected |#Deltad_{z}| [cm];events", 100, 0., 0.1);
+
+  TH1F* hD0 = new TH1F("hD0", ";d_{0}(PV) [cm];events", 100, -0.01, 0.01);
+  TH1F* hDz = new TH1F("hDz", ";d_{z}(PV) [cm];events", 100, -0.1, 0.1);
+
+  TH1F* hD0Corr = new TH1F("hD0Corr", ";corrected d_{0}(PV) [cm];events", 100, -0.01, 0.01);
+  TH1F* hDzCorr = new TH1F("hDzCorr", ";corrected d_{z}(PV) [cm];events", 100, -0.1, 0.1);
+
+  TH1F* hPhi = new TH1F("hPhi", ";muon #phi;events", 100, -TMath::Pi(), TMath::Pi());
+  TH1F* hCorrection = new TH1F(
+      "hCorrection",
+      TString::Format("largest correction vs iteration;iteration number; #delta_{%s} correction ", analysis_types[type])
+          .Data(),
+      k_MAXITERATIONS,
+      0.,
+      k_MAXITERATIONS);
+
+  TH2F* hSagitta = new TH2F("hSagitta",
+                            "#delta_{sagitta};muon #eta;muon #phi;#delta_{sagitta} [TeV^{-1}]",
+                            k_NBINS,
+                            -2.5,
+                            2.5,
+                            k_NBINS,
+                            -TMath::Pi(),
+                            TMath::Pi());
+
+  const char* IPtype = (type == anaKind::d0_t) ? "d_{0}" : "d_{z}";
+  TH2F* hIP = new TH2F("hIP",
+                       TString::Format("#delta_{%s};muon #eta;muon #phi;#delta_{%s} [#mum]", IPtype, IPtype).Data(),
+                       k_NBINS,
+                       -2.47,
+                       2.47,
+                       k_NBINS,
+                       -TMath::Pi(),
+                       TMath::Pi());
+
+  std::map<std::pair<int, int>, float> sagittaCorrections;
+  std::map<std::pair<int, int>, float> IPCorrections;
+  //sagittaCorrections.reserve(k_NBINS * k_NBINS);
+
+  // initialize the map
+  for (unsigned int i = 0; i < k_NBINS; i++) {
+    for (unsigned int j = 0; j < k_NBINS; j++) {
+      const auto& index = std::make_pair(i, j);
+      //sagittaCorrections[index] = 3.435/10e3 ; // from GEN-SIM
+      sagittaCorrections[index] = 0.f;
+      IPCorrections[index] = 0.f;
+    }
+  }
+
+  float maxCorrection{1.f};
+  int iteration = 0;
+  float threshold = (type == sagitta_t) ? 1e-10 : 1e-10;
+
+  while ((std::abs(maxCorrection) > threshold) && iteration < k_MAXITERATIONS) {
+    float oldMaxCorrection = maxCorrection;
+    if (type == sagitta_t) {
+      maxCorrection = updateSagittaMap(tree, sagittaCorrections, hSagitta, iteration, oldMaxCorrection);
+    } else {
+      maxCorrection = updateIPMap(tree, IPCorrections, hIP, iteration, type);
+    }
+
+    std::cout << "iteration: " << iteration << " maxCorrection: " << maxCorrection << std::endl;
+    hCorrection->SetBinContent(iteration, maxCorrection);
+    iteration++;
+  }
+
+  Float_t posTrackEta, negTrackEta, posTrackPhi, negTrackPhi, posTrackPt, negTrackPt;
+  Float_t posTrackDz, negTrackDz, posTrackD0, negTrackD0;
+
+  tree->SetBranchAddress("posTrackEta", &posTrackEta);
+  tree->SetBranchAddress("negTrackEta", &negTrackEta);
+  tree->SetBranchAddress("posTrackPhi", &posTrackPhi);
+  tree->SetBranchAddress("negTrackPhi", &negTrackPhi);
+  tree->SetBranchAddress("posTrackPt", &posTrackPt);
+  tree->SetBranchAddress("negTrackPt", &negTrackPt);
+  tree->SetBranchAddress("posTrackDz", &posTrackDz);
+  tree->SetBranchAddress("negTrackDz", &negTrackDz);
+  tree->SetBranchAddress("posTrackD0", &posTrackD0);
+  tree->SetBranchAddress("negTrackD0", &negTrackD0);
+
+  Float_t invMass;
+
+  // Fill control histograms
+  for (Long64_t i = 0; i < tree->GetEntries(); i++) {
+    tree->GetEntry(i);
+
+    TLorentzVector posTrack, negTrack, mother;
+    posTrack.SetPtEtaPhiM(posTrackPt, posTrackEta, posTrackPhi, k_muMass);  // assume muon mass for tracks
+    negTrack.SetPtEtaPhiM(negTrackPt, negTrackEta, negTrackPhi, k_muMass);
+    mother = posTrack + negTrack;
+
+    hDeltaD0->Fill(posTrackD0 - negTrackD0);
+    hDeltaDz->Fill(posTrackDz - negTrackDz);
+
+    hAbsDeltaD0->Fill(std::abs(posTrackD0 - negTrackD0));
+    hAbsDeltaDz->Fill(std::abs(posTrackDz - negTrackDz));
+
+    hD0->Fill(posTrackD0);
+    hD0->Fill(negTrackD0);
+
+    hDz->Fill(posTrackDz);
+    hDz->Fill(negTrackDz);
+
+    hPt->Fill(posTrackPt);
+    hPt->Fill(negTrackPt);
+
+    hPtPlus->Fill(posTrackPt);
+    hPtMinus->Fill(negTrackPt);
+
+    hEta->Fill(posTrackEta);
+    hEta->Fill(negTrackEta);
+
+    hPhi->Fill(posTrackPhi);
+    hPhi->Fill(negTrackPhi);
+
+    invMass = mother.M();
+    hMass->Fill(invMass);
+    hZPt->Fill(mother.Pt());
+
+    const auto& indexPlus = findEtaPhiBin(hSagitta, posTrackEta, posTrackPhi);
+    float deltaPlus = sagittaCorrections[indexPlus];
+
+    const auto& indexMinus = findEtaPhiBin(hSagitta, negTrackEta, negTrackPhi);
+    float deltaMinus = sagittaCorrections[indexMinus];
+
+    float deltaIPplus = IPCorrections[indexPlus];
+    float deltaIPminus = IPCorrections[indexMinus];
+
+    if (type == anaKind::d0_t) {
+      hDeltaD0Corr->Fill((posTrackD0 + deltaIPplus) - (negTrackD0 + deltaIPminus));
+      hDeltaDzCorr->Fill(posTrackDz - negTrackDz);
+
+      hAbsDeltaD0Corr->Fill(std::abs((posTrackD0 + deltaIPplus) - (negTrackD0 + deltaIPminus)));
+      hAbsDeltaDzCorr->Fill(std::abs(posTrackDz - negTrackDz));
+
+      hD0Corr->Fill(posTrackD0 - deltaIPplus);
+      hD0Corr->Fill(negTrackD0 - deltaIPminus);
+
+      hDzCorr->Fill(posTrackDz);
+      hDzCorr->Fill(negTrackDz);
+    } else {
+      hDeltaD0Corr->Fill(posTrackD0 - negTrackD0);
+      hDeltaDzCorr->Fill((posTrackDz + deltaIPplus) - (negTrackDz + deltaIPminus));
+
+      hAbsDeltaD0Corr->Fill(std::abs(posTrackD0 - negTrackD0));
+      hAbsDeltaDzCorr->Fill(std::abs((posTrackDz + deltaIPplus) - (negTrackDz + deltaIPminus)));
+
+      hD0Corr->Fill(posTrackD0);
+      hD0Corr->Fill(negTrackD0);
+
+      hDzCorr->Fill(posTrackDz + deltaIPplus);
+      hDzCorr->Fill(negTrackDz + deltaIPminus);
+    }
+
+    TLorentzVector posTrackCorr, negTrackCorr, motherCorr;
+    //posTrackCorr.SetPtEtaPhiM(posTrackPt/(1+posTrackPt*deltaPlus), posTrackEta, posTrackPhi, k_muMass);  // assume muon mass for tracks
+    //negTrackCorr.SetPtEtaPhiM(negTrackPt/(1-negTrackPt*deltaMinus), negTrackEta, negTrackPhi, k_muMass);
+
+    posTrackCorr.SetPtEtaPhiM(
+        pTcorrector(posTrackPt, deltaPlus, 1.), posTrackEta, posTrackPhi, k_muMass);  // assume muon mass for tracks
+    negTrackCorr.SetPtEtaPhiM(pTcorrector(negTrackPt, deltaMinus, -1.), negTrackEta, negTrackPhi, k_muMass);
+
+    hPtPlusCorr->Fill(posTrackCorr.Pt());
+    hPtMinusCorr->Fill(negTrackCorr.Pt());
+
+    hDeltaPtCorr->Fill(posTrackCorr.Pt() - posTrackPt);
+    hDeltaPtCorr->Fill(negTrackCorr.Pt() - negTrackPt);
+
+    //std::cout << "original pT: " << posTrackPt << " corrected pT: " << posTrackPt / (1+posTrackPt*deltaPlus)  << std::endl;
+    //std::cout << "original pT: " << negTrackPt << " corrected pT: " << negTrackPt / (1-negTrackPt*deltaMinus) << std::endl;
+
+    motherCorr = posTrackCorr + negTrackCorr;
+
+    hMassCorr->Fill(motherCorr.M());
+    hDeltaMassCorr->Fill(mother.M() - motherCorr.M());
+    hPtCorr->Fill(posTrackCorr.Pt());
+    hPtCorr->Fill(negTrackCorr.Pt());
+  }
+
+  //for (unsigned int iteration = 0; iteration < 1; iteration++) {
+  //float max = updateSagittaMap(tree, sagittaCorrections, hSagitta, 0);  // zero-th iteration
+  // std::cout << "maximal correction update is: " << max << std::endl;
+  // }
+  //updateSagittaMap(tree,sagittaCorrections,hSagitta,1); // first iteration
+  //updateSagittaMap(tree,sagittaCorrections,hSagitta,2); // second iteration
+  //updateSagittaMap(tree,sagittaCorrections,hSagitta,3); // third iteration
+
+  for (unsigned int i = 0; i < k_NBINS; i++) {
+    for (unsigned int j = 0; j < k_NBINS; j++) {
+      const auto& index = std::make_pair(i, j);
+      if (type == sagitta_t) {
+        hSagitta->SetBinContent(i + 1, j + 1, sagittaCorrections[index] * 10e3);  // 1/GeV = 1000/TeV
+      } else {
+        hIP->SetBinContent(i + 1, j + 1, IPCorrections[index] * 10e4);  // 1cm = 10e4um
+      }
+    }
+  }
+
+  // The first argument is the name of the new TProfile,
+  // the second argument is the first bin to include (1 in this case, to skip underflow),
+  // the third argument is the last bin to include (-1 in this case, to skip overflow),
+  // and the fourth argument is an option "s" to compute the profile using weights from the bin contents.
+
+  //TH1D* projVsEta = hSagitta->ProjectionX("projVsEta", 1, k_NBINS);
+  //projVsEta->GetYaxis()->SetTitle("#delta_{sagitta} [TeV^{-1}]");
+  //TH1D* projVsPhi = hSagitta->ProjectionY("projVsPhi", 1, k_NBINS);
+  //projVsPhi->GetYaxis()->SetTitle("#delta_{sagitta} [TeV^{-1}]");
+  //TProfile* profVsEta = hSagitta->ProfileX("_pfx",1,47,"s");
+  //TProfile* profVsPhi = hSagitta->ProfileY("_pfy",1,47,"s");
+
+  //const auto& momVsEta = makeProfileVsEta(hSagitta);
+  //const auto& momVsPhi = makeProfileVsPhi(hSagitta);
+
+  std::pair<TH1F*, TH1F*> momVsEta = std::make_pair(nullptr, nullptr);
+  std::pair<TH1F*, TH1F*> momVsPhi = std::make_pair(nullptr, nullptr);
+  if (type == sagitta_t) {
+    momVsEta = makeProfileVsEta(hSagitta);
+    momVsPhi = makeProfileVsPhi(hSagitta);
+  } else {
+    momVsEta = makeProfileVsEta(hIP);
+    momVsPhi = makeProfileVsPhi(hIP);
+  }
+
+  hDeltaD0->Write();
+  hDeltaDz->Write();
+
+  hMass->Write();
+  hPt->Write();
+  hPtPlus->Write();
+  hPtMinus->Write();
+
+  hZPt->Write();
+
+  hEta->Write();
+  hPhi->Write();
+
+  if (type == anaKind::sagitta_t) {
+    hMassCorr->Write();
+    hPtCorr->Write();
+    hPtPlusCorr->Write();
+    hPtMinusCorr->Write();
+    hDeltaMassCorr->Write();
+    hDeltaPtCorr->Write();
+  } else if (type == anaKind::d0_t) {
+    hD0Corr->Write();
+    hDeltaD0Corr->Write();
+    hAbsDeltaD0Corr->Write();
+  } else if (type == anaKind::dz_t) {
+    hDzCorr->Write();
+    hDeltaDzCorr->Write();
+    hAbsDeltaDzCorr->Write();
+  }
+
+  if (type == sagitta_t) {
+    hMassCorr->Write();
+    hPtCorr->Write();
+    hPtPlusCorr->Write();
+    hPtMinusCorr->Write();
+    hDeltaMassCorr->Write();
+    hDeltaPtCorr->Write();
+  }
+
+  hCorrection->Write();
+
+  if (type == sagitta_t) {
+    hSagitta->SetOption("colz");
+    hSagitta->Write();
+  } else {
+    hIP->SetOption("colz");
+    hIP->Write();
+  }
+
+  momVsEta.first->Write();
+  momVsPhi.first->Write();
+  momVsEta.second->Write();
+  momVsPhi.second->Write();
+
+  //projVsEta->Write();
+  //projVsPhi->Write();
+  //profVsEta->Write();
+  //profVsPhi->Write();
+
+  outputFile->Close();
+  file->Close();
+
+  timer.Stop();
+  timer.Print();
+}
+
+//________________________________________________________________
+float fitResiduals(TH1* histogram) {
+  TF1* gaussianFunc = new TF1("gaussianFunc", "gaus", 0, 100);
+  // Perform an initial fit to get the mean (μ) and width (σ) of the Gaussian
+  histogram->Fit(gaussianFunc, "Q");
+
+  double prevMean = gaussianFunc->GetParameter(1);   // Mean of the previous iteration
+  double prevSigma = gaussianFunc->GetParameter(2);  // Sigma of the previous iteration
+
+  int maxIterations = 10;    // Set a maximum number of iterations
+  double tolerance = 0.001;  // Define a tolerance to check for convergence
+
+  for (int iteration = 0; iteration < maxIterations; ++iteration) {
+    // Set the fit range to 1.5 σ of the previous iteration
+    double lowerLimit = prevMean - 1.5 * prevSigma;
+    double upperLimit = prevMean + 1.5 * prevSigma;
+    gaussianFunc->SetRange(lowerLimit, upperLimit);
+
+    // Perform the fit within the restricted range
+    histogram->Fit(gaussianFunc, "Q");
+
+    // Get the fit results for this iteration
+    double currentMean = gaussianFunc->GetParameter(1);
+    double currentSigma = gaussianFunc->GetParameter(2);
+
+    // Check for convergence
+    if (std::abs(currentMean - prevMean) < tolerance && std::abs(currentSigma - prevSigma) < tolerance) {
+      //cout << "Converged after " << iteration + 1 << " iterations." << endl;
+      break;
+    }
+
+    prevMean = currentMean;
+    prevSigma = currentSigma;
+  }
+
+  return prevMean;
+}
+
+//________________________________________________________________
+float updateSagittaMap(TTree* tree,
+                       std::map<std::pair<int, int>, float>& theMap,
+                       TH2F*& hSagitta,
+                       const int iteration,
+                       float oldMaxCorrection) {
+  std::cout << "calling the updateSagittaMap" << std::endl;
+
+  std::map<std::pair<int, int>, float> deltaCorrection;
+  //deltaCorrection.reserve(k_NBINS * k_NBINS);
+  std::map<std::pair<int, int>, float> countsPerBin;
+  //countsPerBin.reserve(k_NBINS * k_NBINS);
+  std::map<std::pair<int, int>, TH1F*> deltaInBin;
+
+  //float maxRange = (iteration == 0) ? 1. : 1./std::pow(2,iteration);
+  float maxRange = 0.01;
+
+  for (unsigned int i = 0; i < k_NBINS; i++) {
+    for (unsigned int j = 0; j < k_NBINS; j++) {
+      const auto& index = std::make_pair(i, j);
+      deltaCorrection[index] = 0.f;
+      countsPerBin[index] = 0.f;
+      deltaInBin[index] = new TH1F(
+          Form("delta_iter_%i_%i_%i", iteration, i, j),
+          Form("iteration %i : #delta_%i_%i;estimated #delta_{s} -true #delta_{s} [GeV^{-1}];n.muons", iteration, i, j),
+          100,
+          -maxRange,
+          maxRange);
+      //deltaInBin[index]->GetXaxis()->SetCanExtend(kTRUE);
+    }
+  }
+
+  Float_t posTrackEta, negTrackEta, posTrackPhi, negTrackPhi, posTrackPt, negTrackPt, invMass;
+  Float_t genPosMuonEta, genNegMuonEta, genPosMuonPhi, genNegMuonPhi, genPosMuonPt, genNegMuonPt;  // gen info
+
+  tree->SetBranchAddress("posTrackEta", &posTrackEta);
+  tree->SetBranchAddress("negTrackEta", &negTrackEta);
+  tree->SetBranchAddress("posTrackPhi", &posTrackPhi);
+  tree->SetBranchAddress("negTrackPhi", &negTrackPhi);
+  tree->SetBranchAddress("posTrackPt", &posTrackPt);
+  tree->SetBranchAddress("negTrackPt", &negTrackPt);
+
+  // gen info
+  tree->SetBranchAddress("genPosMuonEta", &genPosMuonEta);
+  tree->SetBranchAddress("genNegMuonEta", &genNegMuonEta);
+  tree->SetBranchAddress("genPosMuonPhi", &genPosMuonPhi);
+  tree->SetBranchAddress("genNegMuonPhi", &genNegMuonPhi);
+  tree->SetBranchAddress("genPosMuonPt", &genPosMuonPt);
+  tree->SetBranchAddress("genNegMuonPt", &genNegMuonPt);
+
+  for (Long64_t i = 0; i < tree->GetEntries(); i++) {
+    tree->GetEntry(i);
+    TLorentzVector posTrack, negTrack, mother;
+    posTrack.SetPtEtaPhiM(posTrackPt, posTrackEta, posTrackPhi, k_muMass);  // assume muon mass for tracks
+    negTrack.SetPtEtaPhiM(negTrackPt, negTrackEta, negTrackPhi, k_muMass);
+    mother = posTrack + negTrack;
+    invMass = mother.M();
+
+    //std::cout << "invmass:" << invMass << std::endl;
+
+    //now deal with positive muon
+    const auto& indexPlus = findEtaPhiBin(hSagitta, posTrackEta, posTrackPhi);
+    float deltaSagittaPlus = theMap[indexPlus];
+
+    //now deal with negative muon
+    const auto& indexMinus = findEtaPhiBin(hSagitta, negTrackEta, negTrackPhi);
+    float deltaSagittaMinus = theMap[indexMinus];
+
+    if (indexPlus == std::make_pair(-1, -1) || indexMinus == std::make_pair(-1, -1)) {
+      continue;
+    }
+
+    /*
+    float deltaMass{0.f};
+    if (iteration == 0) {
+      deltaMass = invMass * invMass - (MZ_PDG * MZ_PDG);
+    } else {
+      deltaMass = MZ_PDG * (posTrackPt * deltaSagittaPlus - negTrackPt * deltaSagittaMinus);
+    }
+    
+    float deltaDeltaSagittaPlus =
+        -(deltaMass / (2 * MZ_PDG)) * ((1 + posTrackPt * deltaSagittaPlus) / posTrackPt);
+    float deltaDeltaSagittaMinus =
+        (deltaMass / (2 * MZ_PDG)) * ((1 - negTrackPt * deltaSagittaMinus) / negTrackPt);
+
+    */
+
+    float frac;
+    if (iteration != 0) {
+      frac = (posTrackPt * deltaSagittaPlus - negTrackPt * deltaSagittaMinus);
+    } else {
+      frac = (invMass - MZ_PDG) / MZ_PDG;
+    }
+
+    /*
+    TLorentzVector posTrackCorr, negTrackCorr, motherCorr;
+    posTrackCorr.SetPtEtaPhiM(pTcorrector(posTrackPt,deltaSagittaPlus,1.), posTrackEta, posTrackPhi, k_muMass);  // assume muon mass for tracks
+    negTrackCorr.SetPtEtaPhiM(pTcorrector(negTrackPt,deltaSagittaMinus,-1.), negTrackEta, negTrackPhi, k_muMass);
+    motherCorr = posTrackCorr + negTrackCorr;
+    
+    float frac = (motherCorr.M() - MZ_PDG) / MZ_PDG;
+    */
+
+    float deltaDeltaSagittaPlus = calcDeltaSagitta(1., frac, deltaSagittaPlus, posTrackPt);
+    float deltaDeltaSagittaMinus = calcDeltaSagitta(-1., frac, deltaSagittaMinus, negTrackPt);
+
+    // inverting equation 5 of https://arxiv.org/pdf/2212.07338.pdf
+    double trueDeltaSagittaPlus = (genPosMuonPt - posTrackPt) / (genPosMuonPt * posTrackPt);
+    double trueDeltaSagittaMinus = (negTrackPt - genNegMuonPt) / (genNegMuonPt * negTrackPt);
+
+    //std::cout << "deltaMass: " << std::setw(10) << frac
+    //<< " DeltaDeltaSag(+)-true: " << (deltaSagittaPlus + deltaDeltaSagittaPlus)   - trueDeltaSagittaPlus
+    //	      << " DeltaDeltaSag(-)-true: " << (deltaSagittaMinus + deltaDeltaSagittaMinus) - trueDeltaSagittaMinus << std::endl;
+
+    deltaCorrection[indexPlus] += deltaDeltaSagittaPlus;
+    deltaCorrection[indexMinus] += deltaDeltaSagittaMinus;
+
+    deltaInBin[indexPlus]->Fill((deltaSagittaPlus + deltaDeltaSagittaPlus) - trueDeltaSagittaPlus);
+    deltaInBin[indexMinus]->Fill((deltaSagittaMinus + deltaDeltaSagittaMinus) - trueDeltaSagittaMinus);
+
+    countsPerBin[indexPlus] += 1.;
+    countsPerBin[indexMinus] += 1.;
+  }
+
+  //TFile* iterFile = TFile::Open(Form("iteration_%i.root",iteration), "RECREATE");
+
+  for (unsigned int i = 0; i < k_NBINS; i++) {
+    for (unsigned int j = 0; j < k_NBINS; j++) {
+      const auto& index = std::make_pair(i, j);
+      //std::cout << index.first << ", " << index.second << " value: " << deltaCorrection[index] << " / " << countsPerBin[index];
+      deltaCorrection[index] /= countsPerBin[index];
+      //deltaCorrection[index] = fitResiduals(deltaInBin[index]);
+      deltaInBin[index]->Write();
+      //std::cout << " =  " << deltaCorrection[index] << std::endl;
+    }
+  }
+
+  //iterFile->Close();
+
+  std::cout << " ================================ iteration: " << iteration << std::endl;
+  for (unsigned int i = 0; i < k_NBINS; i++) {
+    for (unsigned int j = 0; j < k_NBINS; j++) {
+      const auto& index = std::make_pair(i, j);
+      //std::cout << i << ", " << j << " initial: " << theMap[index] << " correction: " << deltaCorrection[index]
+      //          << std::endl;
+      theMap[index] += deltaCorrection[index];
+    }
+  }
+
+  // find the largest element of the correction of this iteration
+  auto maxIter = std::max_element(deltaCorrection.begin(), deltaCorrection.end(), [](const auto& a, const auto& b) {
+    return std::abs(a.second) < std::abs(b.second);
+  });
+
+  return maxIter->second;
+}
+
+//________________________________________________________________
+float updateIPMap(
+    TTree* tree, std::map<std::pair<int, int>, float>& theMap, TH2F*& hIP, const int iteration, anaKind type) {
+  std::cout << "calling the updateIPMap" << std::endl;
+
+  std::map<std::pair<int, int>, float> deltaCorrection;
+  //deltaCorrection.reserve(k_NBINS * k_NBINS);
+  std::map<std::pair<int, int>, float> countsPerBin;
+  //countsPerBin.reserve(k_NBINS * k_NBINS);
+
+  for (unsigned int i = 0; i < k_NBINS; i++) {
+    for (unsigned int j = 0; j < k_NBINS; j++) {
+      const auto& index = std::make_pair(i, j);
+      deltaCorrection[index] = 0.f;
+      countsPerBin[index] = 0.f;
+    }
+  }
+
+  float posTrackEta, negTrackEta, posTrackPhi, negTrackPhi, posTrackIP, negTrackIP;
+  tree->SetBranchAddress("posTrackEta", &posTrackEta);
+  tree->SetBranchAddress("negTrackEta", &negTrackEta);
+  tree->SetBranchAddress("posTrackPhi", &posTrackPhi);
+  tree->SetBranchAddress("negTrackPhi", &negTrackPhi);
+  if (type == d0_t) {
+    tree->SetBranchAddress("posTrackD0", &posTrackIP);
+    tree->SetBranchAddress("negTrackD0", &negTrackIP);
+  } else if (type == dz_t) {
+    tree->SetBranchAddress("posTrackDz", &posTrackIP);
+    tree->SetBranchAddress("negTrackDz", &negTrackIP);
+  } else {
+    std::cout << "error, you have been calling this script with the wrong settings!";
+    exit(EXIT_FAILURE);
+  }
+
+  for (Long64_t i = 0; i < tree->GetEntries(); i++) {
+    tree->GetEntry(i);
+
+    // deal with the positive muon
+    const auto& indexPlus = findEtaPhiBin(hIP, posTrackEta, posTrackPhi);
+    float deltaIPPlus = theMap[indexPlus];
+
+    //now deal with negative muon
+    const auto& indexMinus = findEtaPhiBin(hIP, negTrackEta, negTrackPhi);
+    float deltaIPMinus = theMap[indexMinus];
+
+    float IPdistance = std::abs(((posTrackIP + deltaIPPlus) - (negTrackIP + deltaIPMinus)));
+
+    //this converges
+    float deltaDeltaIPPlus =
+        (posTrackIP + deltaIPPlus) < (negTrackIP + deltaIPMinus) ? IPdistance / 2. : -IPdistance / 2.;
+    float deltaDeltaIPMinus =
+        (posTrackIP + deltaIPPlus) < (negTrackIP + deltaIPMinus) ? -IPdistance / 2. : IPdistance / 2.;
+
+    //std::cout << "deltaMass: " << deltaMass << " DeltaDeltaSagPlus: " <<   deltaDeltaIPPlus << " DeltaDeltaSagMinus: " << deltaDeltaIPMinus << std::endl;
+
+    deltaCorrection[indexPlus] += deltaDeltaIPPlus;
+    deltaCorrection[indexMinus] += deltaDeltaIPMinus;
+
+    countsPerBin[indexPlus] += 1.;
+    countsPerBin[indexMinus] += 1.;
+  }
+
+  for (unsigned int i = 0; i < k_NBINS; i++) {
+    for (unsigned int j = 0; j < k_NBINS; j++) {
+      const auto& index = std::make_pair(i, j);
+      //std::cout << index.first << ", " << index.second << " value: " << deltaCorrection[index] << " / " << countsPerBin[index];
+      deltaCorrection[index] /= countsPerBin[index];
+      //std::cout << " =  " << deltaCorrection[index] << std::endl;
+    }
+  }
+
+  std::cout << " ================================ iteration: " << iteration << std::endl;
+  for (unsigned int i = 0; i < k_NBINS; i++) {
+    for (unsigned int j = 0; j < k_NBINS; j++) {
+      const auto& index = std::make_pair(i, j);
+      //std::cout << i << ", " << j << " initial: " << theMap[index] << " correction: " << deltaCorrection[index]
+      //          << std::endl;
+      theMap[index] += deltaCorrection[index];
+    }
+  }
+
+  // find the largest element of the correction of this iteration
+  auto maxIter = std::max_element(deltaCorrection.begin(), deltaCorrection.end(), [](const auto& a, const auto& b) {
+    return std::abs(a.second) < std::abs(b.second);
+  });
+
+  return maxIter->second;
+}

--- a/Alignment/OfflineValidation/macros/analyzeDiMuonBiases_fast.C
+++ b/Alignment/OfflineValidation/macros/analyzeDiMuonBiases_fast.C
@@ -1,0 +1,1053 @@
+#include <ROOT/RDataFrame.hxx>
+#include <ROOT/RVec.hxx>
+#include <TCanvas.h>
+#include <TF1.h>
+#include <TFile.h>
+#include <TH1D.h>
+#include <TH1F.h>
+#include <TH2F.h>
+#include <TLorentzVector.h>
+#include <TMath.h>
+#include <TProfile.h>
+#include <TRegexp.h>
+#include <TStopwatch.h>
+#include <TString.h>
+#include <TTree.h>
+#include <algorithm>
+#include <cmath>
+#include <iomanip>  // Include the header for setw
+#include <iostream>
+#include <map>
+#include <string>
+
+// analysis types
+enum anaKind { sagitta_t = 0, d0_t = 1, dz_t = 2 };
+
+// number of bins for the correction map
+unsigned int k_NBINS = 48;
+
+// maximum number of iterations
+int k_MAXITERATIONS = 30;
+
+static constexpr const char* const analysis_types[] = {
+    "sagitta",  //  0 - sagitta bias
+    "d0",       //  1 - transverse IP bias
+    "dz",       //  2 - longitudinal IPbias
+};
+
+// physics constants
+static constexpr double k_muMass = 0.105658;  // GeV
+static constexpr double MZ_PDG = 91.1876;     // in GeV
+
+// ansatz from eq. 5 of https://arxiv.org/pdf/2212.07338.pdf
+//________________________________________________________________
+double pTcorrector(const double& unCorrPt, const double& delta, const float& charge) {
+  return unCorrPt / (1 - charge * delta * unCorrPt);
+}
+
+//________________________________________________________________
+float calcDeltaSagitta(float charge, float frac, float avgSagitta, float thisTrackPt) {
+  return (-charge * 0.5 * frac * ((1 + charge * thisTrackPt * avgSagitta) / thisTrackPt));
+}
+
+//________________________________________________________________
+std::pair<int, int> findEtaPhiBin(const TH2* h2, const float& eta, const float& phi) {
+  const auto& etaBin = h2->GetXaxis()->FindBin(eta) - 1;
+  const auto& phiBin = h2->GetYaxis()->FindBin(phi) - 1;
+
+  if (etaBin < 0 || etaBin > int(k_NBINS - 1)) {
+    std::cout << "etaBin: " << etaBin << " eta: " << eta << std::endl;
+    return {-1., -1.};
+  }
+
+  if (phiBin < 0 || phiBin > int(k_NBINS - 1)) {
+    std::cout << "phiBin: " << phiBin << " phi: " << phi << std::endl;
+    return {-1., -1.};
+  }
+  return std::make_pair(etaBin, phiBin);
+}
+
+//________________________________________________________________
+float updateSagittaMap(TTree* tree,
+                       std::map<std::pair<int, int>, float>& theMap,
+                       TH2F*& hSagitta,
+                       const int iteration,
+                       float oldMaxCorrection);
+
+//________________________________________________________________
+float updateSagittaMapFast(TTree* tree,
+                           std::map<std::pair<int, int>, float>& theMap,
+                           TH2F*& hSagitta,
+                           const int iteration,
+                           float oldMaxCorrection);
+
+//________________________________________________________________
+float updateIPMap(
+    TTree* tree, std::map<std::pair<int, int>, float>& theMap, TH2F*& hIP, const int iteration, anaKind type);
+
+//_______________________________________________________________
+float updateIPMapFast(
+    TTree* tree, std::map<std::pair<int, int>, float>& theMap, TH2F*& hIP, const int iteration, anaKind type);
+
+// Enum to specify the formatting type
+enum TitleFormatType { MEAN, RMS };
+
+//________________________________________________________________
+TString updateTitle(const TString& title, TitleFormatType formatType) {
+  // Regular expression to match units in square brackets
+  TRegexp re("\\[.*\\]");
+  TString units;
+  TString cleanTitle = title;
+
+  // Check if units are present and extract them
+  if (cleanTitle.Index(re) != kNPOS) {
+    units = cleanTitle(re);                         // Extract the unit part
+    cleanTitle(re) = "";                            // Remove the unit from the cleanTitle
+    cleanTitle = cleanTitle.Strip(TString::kBoth);  // Remove extra spaces
+  }
+
+  // Construct the new title based on the formatType
+  TString newTitle;
+  switch (formatType) {
+    case MEAN:
+      if (!units.IsNull()) {
+        newTitle = TString::Format("#LT%s#GT %s", cleanTitle.Data(), units.Data());
+      } else {
+        newTitle = TString::Format("#LT%s#GT", cleanTitle.Data());
+      }
+      break;
+    case RMS:
+      if (!units.IsNull()) {
+        newTitle = TString::Format("RMS (%s) %s", cleanTitle.Data(), units.Data());
+      } else {
+        newTitle = TString::Format("RMS (%s)", cleanTitle.Data());
+      }
+      break;
+  }
+
+  // Set the new title to the x-axis of h_prof
+  return newTitle;
+}
+
+//________________________________________________________________
+std::pair<TH1F*, TH1F*> makeProfileVsEta(TH2F* h2) {
+  const auto& nBinsX = h2->GetNbinsX();
+  const auto& nBinsY = h2->GetNbinsY();
+
+  float xmin = h2->GetXaxis()->GetXmin();
+  float xmax = h2->GetXaxis()->GetXmax();
+
+  std::vector<float> average;
+  std::vector<float> RMS;
+  std::vector<float> errorOnRMS;
+
+  for (int i = 1; i <= nBinsX; i++) {
+    float avgInY{0.};
+    for (int j = 1; j <= nBinsY; j++) {
+      avgInY += h2->GetBinContent(i, j);
+    }
+    avgInY /= nBinsY;
+    average.push_back(avgInY);
+  }
+
+  for (int i = 1; i <= nBinsX; i++) {
+    float RMSInY{0.};
+    for (int j = 1; j <= nBinsY; j++) {
+      RMSInY += std::pow((h2->GetBinContent(i, j) - average[i - 1]), 2);
+    }
+    RMSInY /= nBinsY;
+    RMS.push_back(std::sqrt(RMSInY));
+  }
+
+  TH1F* h_prof = new TH1F("avgInEta", "profile vs #eta", nBinsX, xmin, xmax);
+  h_prof->GetXaxis()->SetTitle(h2->GetXaxis()->GetTitle());
+  h_prof->GetYaxis()->SetTitle(updateTitle(h2->GetZaxis()->GetTitle(), TitleFormatType::MEAN));
+  for (int i = 1; i <= nBinsX; i++) {
+    std::cout << i << " = " << average[i - 1] << std::endl;
+    h_prof->SetBinContent(i, average[i - 1]);
+    h_prof->SetBinError(i, RMS[i - 1] / nBinsY);
+  }
+
+  TH1F* h_RMS = new TH1F("RMSInEta", "RMS vs #eta", nBinsX, xmin, xmax);
+  h_RMS->GetXaxis()->SetTitle(h2->GetXaxis()->GetTitle());
+  h_RMS->GetYaxis()->SetTitle(updateTitle(h2->GetZaxis()->GetTitle(), TitleFormatType::RMS));
+  for (int i = 1; i <= nBinsX; i++) {
+    std::cout << i << " = " << average[i - 1] << std::endl;
+    h_RMS->SetBinContent(i, RMS[i - 1]);
+    h_RMS->SetBinError(i, RMS[i - 1] / std::sqrt(2 * (nBinsY - 1)));
+  }
+
+  return std::make_pair(h_prof, h_RMS);
+}
+
+//________________________________________________________________
+std::pair<TH1F*, TH1F*> makeProfileVsPhi(TH2F* h2) {
+  const auto& nBinsX = h2->GetNbinsX();
+  const auto& nBinsY = h2->GetNbinsY();
+
+  float ymin = h2->GetYaxis()->GetXmin();
+  float ymax = h2->GetYaxis()->GetXmax();
+
+  std::vector<float> average;
+  std::vector<float> RMS;
+
+  for (int j = 1; j <= nBinsY; j++) {
+    float avgInX{0.};
+    for (int i = 1; i <= nBinsX; i++) {
+      avgInX += h2->GetBinContent(i, j);
+    }
+    avgInX /= nBinsX;
+    average.push_back(avgInX);
+  }
+
+  for (int j = 1; j <= nBinsY; j++) {
+    float RMSInX{0.};
+    for (int i = 1; i <= nBinsX; i++) {
+      RMSInX += std::pow((h2->GetBinContent(i, j) - average[j - 1]), 2);
+    }
+    RMSInX /= nBinsX;
+    RMS.push_back(std::sqrt(RMSInX));
+  }
+
+  TH1F* h_prof = new TH1F("avgInPhi", "profile vs #phi", nBinsY, ymin, ymax);
+  h_prof->GetXaxis()->SetTitle(h2->GetYaxis()->GetTitle());
+  h_prof->GetYaxis()->SetTitle(updateTitle(h2->GetZaxis()->GetTitle(), TitleFormatType::MEAN));
+  for (int i = 1; i <= nBinsY; i++) {
+    std::cout << i << " = " << average[i - 1] << std::endl;
+    h_prof->SetBinContent(i, average[i - 1]);
+    h_prof->SetBinError(i, RMS[i - 1] / nBinsX);
+  }
+
+  TH1F* h_RMS = new TH1F("RMSInPhi", "RMS vs #phi", nBinsY, ymin, ymax);
+  h_RMS->GetXaxis()->SetTitle(h2->GetYaxis()->GetTitle());
+  h_RMS->GetYaxis()->SetTitle(updateTitle(h2->GetZaxis()->GetTitle(), TitleFormatType::RMS));
+  for (int i = 1; i <= nBinsY; i++) {
+    std::cout << i << " = " << average[i - 1] << std::endl;
+    h_RMS->SetBinContent(i, RMS[i - 1]);
+    h_RMS->SetBinError(i, RMS[i - 1] / std::sqrt(2 * (nBinsX - 1)));
+  }
+
+  return std::make_pair(h_prof, h_RMS);
+}
+
+//________________________________________________________________
+void analyzeDiMuonBiases_fast(const char* inputFile, anaKind type) {
+  TStopwatch timer;
+  timer.Start();
+
+  std::cout << "I AM GOING TO PERFORM THE " << analysis_types[type] << " analysis!" << std::endl;
+
+  ROOT::EnableImplicitMT();  // Enable multi-threading
+
+  TFile* file = TFile::Open(inputFile);
+  //TTree* tree = dynamic_cast<TTree*>(file->Get("myanalysis/tree"));
+  TTree* tree = dynamic_cast<TTree*>(file->Get("ZtoMMNtuple/tree"));
+
+  if (tree) {
+    tree->ls();
+  } else {
+    std::cout << "could not open the input tree from file.\n exiting";
+    exit(EXIT_FAILURE);
+  }
+  // prepare the output file name
+  std::string outputString(inputFile);
+  std::string oldSubstring = "ZmmNtuple_";
+  std::string newSubstring = "histos_";
+  outputString.replace(outputString.find(oldSubstring), oldSubstring.length(), newSubstring);
+  std::size_t pos = outputString.find(".root");
+
+  // If ".root" is found, inject the given const char*
+  TString toInject = TString::Format("__%s", analysis_types[type]);
+  if (pos != std::string::npos) {
+    outputString.insert(pos, toInject.Data());
+  }
+
+  // one for iteration
+
+  TFile* outputFile = TFile::Open(outputString.c_str(), "RECREATE");
+  TH1F* hMass = new TH1F("hMass", "mass;m_{#mu#mu} [GeV];events", 80, 70., 110.);
+  TH1F* hPt = new TH1F("hPt", ";muon p_{T} [GeV];events", 100, 0., 200.);
+  TH1F* hZPt = new TH1F("hZPt", ";di-muon system p_{T} [GeV];events", 100, 0., 200.);
+
+  TH1F* hPtPlus = new TH1F("hPtPlus", ";positive muon p_{T} [GeV];events", 100, 0., 200.);
+  TH1F* hPtMinus = new TH1F("hPtMinus", ";negative muon p_{T} [GeV];events", 100, 0., 200.);
+
+  TH1F* hPtCorr = new TH1F("hPtCorr", ";corrected muon p_{T} [GeV];events", 100, 0., 200.);
+  TH1F* hPtPlusCorr = new TH1F("hPtPlusCorr", ";corrected positive muon p_{T} [GeV];events", 100, 0., 200.);
+  TH1F* hPtMinusCorr = new TH1F("hPtMinusCorr", ";corrected negative muon p_{T} [GeV];events", 100, 0., 200.);
+
+  TH1F* hMassCorr = new TH1F("hMassCorr", "corrected mass;corrected m_{#mu#mu} [GeV];events", 80, 70., 110.);
+  TH1F* hDeltaMassCorr = new TH1F(
+      "hDeltaMassCorr",
+      "#Delta Mass (corrected - corrected) ;#Delta m_{#mu#mu} (m^{corr}_{#mu#mu} - m^{uncorr}_{#mu#mu}) [GeV];events",
+      100,
+      -10.,
+      10.);
+  TH1F* hDeltaPtCorr =
+      new TH1F("hDeltaPtCorr", "#Delta p_{T};#Delta p_{T} (p^{corr}_{T}-p^{uncorr}_{T}) [GeV];events", 100, -10., 10.);
+
+  TH1F* hEta = new TH1F("hEta", ";muon #eta;events", 100, -3.0, 3.0);
+
+  TH1F* hDeltaD0 = new TH1F("hDeltaD0", ";#Deltad_{0} [cm];events", 100, -0.01, 0.01);
+  TH1F* hDeltaDz = new TH1F("hDeltaDz", ";#Deltad_{z} [cm];events", 100, -0.1, 0.1);
+
+  TH1F* hPhi = new TH1F("hPhi", ";muon #phi;events", 100, -TMath::Pi(), TMath::Pi());
+  TH1F* hCorrection = new TH1F(
+      "hCorrection",
+      TString::Format("largest correction vs iteration;iteration number; #delta_{%s} correction ", analysis_types[type])
+          .Data(),
+      k_MAXITERATIONS,
+      0.,
+      k_MAXITERATIONS);
+
+  TH2F* hSagitta = new TH2F("hSagitta",
+                            "#delta_{sagitta};muon #eta;muon #phi;#delta_{sagitta} [TeV^{-1}]",
+                            k_NBINS,
+                            -2.5,
+                            2.5,
+                            k_NBINS,
+                            -TMath::Pi(),
+                            TMath::Pi());
+
+  const char* IPtype = (type == anaKind::d0_t) ? "d_{0}" : "d_{z}";
+  TH2F* hIP = new TH2F("hIP",
+                       TString::Format("#delta_{%s};muon #eta;muon #phi;#delta_{%s} [#mum]", IPtype, IPtype).Data(),
+                       k_NBINS,
+                       -2.47,
+                       2.47,
+                       k_NBINS,
+                       -TMath::Pi(),
+                       TMath::Pi());
+
+  std::map<std::pair<int, int>, float> sagittaCorrections;
+  std::map<std::pair<int, int>, float> IPCorrections;
+  //sagittaCorrections.reserve(k_NBINS * k_NBINS);
+
+  // initialize the map
+  for (unsigned int i = 0; i < k_NBINS; i++) {
+    for (unsigned int j = 0; j < k_NBINS; j++) {
+      const auto& index = std::make_pair(i, j);
+      //sagittaCorrections[index] = 3.435/10e3 ; // from GEN-SIM
+      sagittaCorrections[index] = 0.f;
+      IPCorrections[index] = 0.f;
+    }
+  }
+
+  float maxCorrection{1.f};
+  int iteration = 0;
+  float threshold = (type == sagitta_t) ? 1e-10 : 1e-10;
+
+  while ((std::abs(maxCorrection) > threshold) && iteration < k_MAXITERATIONS) {
+    float oldMaxCorrection = maxCorrection;
+    if (type == sagitta_t) {
+      maxCorrection = updateSagittaMapFast(tree, sagittaCorrections, hSagitta, iteration, oldMaxCorrection);
+    } else {
+      maxCorrection = updateIPMapFast(tree, IPCorrections, hIP, iteration, type);
+    }
+
+    std::cout << "iteration: " << iteration << " maxCorrection: " << maxCorrection << std::endl;
+    hCorrection->SetBinContent(iteration, maxCorrection);
+    iteration++;
+  }
+
+  Float_t posTrackEta, negTrackEta, posTrackPhi, negTrackPhi, posTrackPt, negTrackPt;
+  Float_t posTrackDz, negTrackDz, posTrackD0, negTrackD0;
+
+  tree->SetBranchAddress("posTrackEta", &posTrackEta);
+  tree->SetBranchAddress("negTrackEta", &negTrackEta);
+  tree->SetBranchAddress("posTrackPhi", &posTrackPhi);
+  tree->SetBranchAddress("negTrackPhi", &negTrackPhi);
+  tree->SetBranchAddress("posTrackPt", &posTrackPt);
+  tree->SetBranchAddress("negTrackPt", &negTrackPt);
+  tree->SetBranchAddress("posTrackDz", &posTrackDz);
+  tree->SetBranchAddress("negTrackDz", &negTrackDz);
+  tree->SetBranchAddress("posTrackD0", &posTrackD0);
+  tree->SetBranchAddress("negTrackD0", &negTrackD0);
+
+  Float_t invMass;
+
+  // Fill control histograms
+  for (Long64_t i = 0; i < tree->GetEntries(); i++) {
+    tree->GetEntry(i);
+
+    TLorentzVector posTrack, negTrack, mother;
+    posTrack.SetPtEtaPhiM(posTrackPt, posTrackEta, posTrackPhi, k_muMass);  // assume muon mass for tracks
+    negTrack.SetPtEtaPhiM(negTrackPt, negTrackEta, negTrackPhi, k_muMass);
+    mother = posTrack + negTrack;
+
+    hDeltaD0->Fill(posTrackD0 - negTrackD0);
+    hDeltaDz->Fill(posTrackDz - negTrackDz);
+
+    hPt->Fill(posTrackPt);
+    hPt->Fill(negTrackPt);
+
+    hPtPlus->Fill(posTrackPt);
+    hPtMinus->Fill(negTrackPt);
+
+    hEta->Fill(posTrackEta);
+    hEta->Fill(negTrackEta);
+
+    hPhi->Fill(posTrackPhi);
+    hPhi->Fill(negTrackPhi);
+
+    invMass = mother.M();
+    hMass->Fill(invMass);
+    hZPt->Fill(mother.Pt());
+
+    const auto& indexPlus = findEtaPhiBin(hSagitta, posTrackEta, posTrackPhi);
+    float deltaPlus = sagittaCorrections[indexPlus];
+
+    const auto& indexMinus = findEtaPhiBin(hSagitta, negTrackEta, negTrackPhi);
+    float deltaMinus = sagittaCorrections[indexMinus];
+
+    TLorentzVector posTrackCorr, negTrackCorr, motherCorr;
+    //posTrackCorr.SetPtEtaPhiM(posTrackPt/(1+posTrackPt*deltaPlus), posTrackEta, posTrackPhi, k_muMass);  // assume muon mass for tracks
+    //negTrackCorr.SetPtEtaPhiM(negTrackPt/(1-negTrackPt*deltaMinus), negTrackEta, negTrackPhi, k_muMass);
+
+    posTrackCorr.SetPtEtaPhiM(
+        pTcorrector(posTrackPt, deltaPlus, 1.), posTrackEta, posTrackPhi, k_muMass);  // assume muon mass for tracks
+    negTrackCorr.SetPtEtaPhiM(pTcorrector(negTrackPt, deltaMinus, -1.), negTrackEta, negTrackPhi, k_muMass);
+
+    hPtPlusCorr->Fill(posTrackCorr.Pt());
+    hPtMinusCorr->Fill(negTrackCorr.Pt());
+
+    hDeltaPtCorr->Fill(posTrackCorr.Pt() - posTrackPt);
+    hDeltaPtCorr->Fill(negTrackCorr.Pt() - negTrackPt);
+
+    //std::cout << "original pT: " << posTrackPt << " corrected pT: " << posTrackPt / (1+posTrackPt*deltaPlus)  << std::endl;
+    //std::cout << "original pT: " << negTrackPt << " corrected pT: " << negTrackPt / (1-negTrackPt*deltaMinus) << std::endl;
+
+    motherCorr = posTrackCorr + negTrackCorr;
+
+    hMassCorr->Fill(motherCorr.M());
+    hDeltaMassCorr->Fill(mother.M() - motherCorr.M());
+    hPtCorr->Fill(posTrackCorr.Pt());
+    hPtCorr->Fill(negTrackCorr.Pt());
+  }
+
+  //for (unsigned int iteration = 0; iteration < 1; iteration++) {
+  //float max = updateSagittaMap(tree, sagittaCorrections, hSagitta, 0);  // zero-th iteration
+  // std::cout << "maximal correction update is: " << max << std::endl;
+  // }
+  //updateSagittaMap(tree,sagittaCorrections,hSagitta,1); // first iteration
+  //updateSagittaMap(tree,sagittaCorrections,hSagitta,2); // second iteration
+  //updateSagittaMap(tree,sagittaCorrections,hSagitta,3); // third iteration
+
+  for (unsigned int i = 0; i < k_NBINS; i++) {
+    for (unsigned int j = 0; j < k_NBINS; j++) {
+      const auto& index = std::make_pair(i, j);
+      if (type == sagitta_t) {
+        hSagitta->SetBinContent(i + 1, j + 1, sagittaCorrections[index] * 10e3);  // 1/GeV = 1000/TeV
+      } else {
+        hIP->SetBinContent(i + 1, j + 1, IPCorrections[index] * 10e4);  // 1cm = 10e4um
+      }
+    }
+  }
+
+  // The first argument is the name of the new TProfile,
+  // the second argument is the first bin to include (1 in this case, to skip underflow),
+  // the third argument is the last bin to include (-1 in this case, to skip overflow),
+  // and the fourth argument is an option "s" to compute the profile using weights from the bin contents.
+
+  //TH1D* projVsEta = hSagitta->ProjectionX("projVsEta", 1, k_NBINS);
+  //projVsEta->GetYaxis()->SetTitle("#delta_{sagitta} [TeV^{-1}]");
+  //TH1D* projVsPhi = hSagitta->ProjectionY("projVsPhi", 1, k_NBINS);
+  //projVsPhi->GetYaxis()->SetTitle("#delta_{sagitta} [TeV^{-1}]");
+  //TProfile* profVsEta = hSagitta->ProfileX("_pfx",1,47,"s");
+  //TProfile* profVsPhi = hSagitta->ProfileY("_pfy",1,47,"s");
+
+  //const auto& momVsEta = makeProfileVsEta(hSagitta);
+  //const auto& momVsPhi = makeProfileVsPhi(hSagitta);
+
+  std::pair<TH1F*, TH1F*> momVsEta = std::make_pair(nullptr, nullptr);
+  std::pair<TH1F*, TH1F*> momVsPhi = std::make_pair(nullptr, nullptr);
+  if (type == sagitta_t) {
+    momVsEta = makeProfileVsEta(hSagitta);
+    momVsPhi = makeProfileVsPhi(hSagitta);
+  } else {
+    momVsEta = makeProfileVsEta(hIP);
+    momVsPhi = makeProfileVsPhi(hIP);
+  }
+
+  hDeltaD0->Write();
+  hDeltaDz->Write();
+
+  hMass->Write();
+  hPt->Write();
+  hPtPlus->Write();
+  hPtMinus->Write();
+
+  hZPt->Write();
+
+  hEta->Write();
+  hPhi->Write();
+
+  if (type == sagitta_t) {
+    hMassCorr->Write();
+    hPtCorr->Write();
+    hPtPlusCorr->Write();
+    hPtMinusCorr->Write();
+    hDeltaMassCorr->Write();
+    hDeltaPtCorr->Write();
+  }
+
+  hCorrection->Write();
+  if (type == sagitta_t) {
+    hSagitta->SetOption("colz");
+    hSagitta->Write();
+  } else {
+    hIP->SetOption("colz");
+    hIP->Write();
+  }
+
+  momVsEta.first->Write();
+  momVsPhi.first->Write();
+  momVsEta.second->Write();
+  momVsPhi.second->Write();
+
+  //projVsEta->Write();
+  //projVsPhi->Write();
+  //profVsEta->Write();
+  //profVsPhi->Write();
+
+  outputFile->Close();
+  file->Close();
+
+  timer.Stop();
+  timer.Print();
+}
+
+//________________________________________________________________
+float fitResiduals(TH1* histogram) {
+  TF1* gaussianFunc = new TF1("gaussianFunc", "gaus", 0, 100);
+  // Perform an initial fit to get the mean (μ) and width (σ) of the Gaussian
+  histogram->Fit(gaussianFunc, "Q");
+
+  double prevMean = gaussianFunc->GetParameter(1);   // Mean of the previous iteration
+  double prevSigma = gaussianFunc->GetParameter(2);  // Sigma of the previous iteration
+
+  int maxIterations = 10;    // Set a maximum number of iterations
+  double tolerance = 0.001;  // Define a tolerance to check for convergence
+
+  for (int iteration = 0; iteration < maxIterations; ++iteration) {
+    // Set the fit range to 1.5 σ of the previous iteration
+    double lowerLimit = prevMean - 1.5 * prevSigma;
+    double upperLimit = prevMean + 1.5 * prevSigma;
+    gaussianFunc->SetRange(lowerLimit, upperLimit);
+
+    // Perform the fit within the restricted range
+    histogram->Fit(gaussianFunc, "Q");
+
+    // Get the fit results for this iteration
+    double currentMean = gaussianFunc->GetParameter(1);
+    double currentSigma = gaussianFunc->GetParameter(2);
+
+    // Check for convergence
+    if (abs(currentMean - prevMean) < tolerance && abs(currentSigma - prevSigma) < tolerance) {
+      //cout << "Converged after " << iteration + 1 << " iterations." << endl;
+      break;
+    }
+
+    prevMean = currentMean;
+    prevSigma = currentSigma;
+  }
+
+  return prevMean;
+}
+
+//________________________________________________________________
+float updateSagittaMap(TTree* tree,
+                       std::map<std::pair<int, int>, float>& theMap,
+                       TH2F*& hSagitta,
+                       const int iteration,
+                       float oldMaxCorrection) {
+  std::cout << "calling the updateSagittaMap" << std::endl;
+
+  std::map<std::pair<int, int>, float> deltaCorrection;
+  //deltaCorrection.reserve(k_NBINS * k_NBINS);
+  std::map<std::pair<int, int>, float> countsPerBin;
+  //countsPerBin.reserve(k_NBINS * k_NBINS);
+  std::map<std::pair<int, int>, TH1F*> deltaInBin;
+
+  //float maxRange = (iteration == 0) ? 1. : 1./std::pow(2,iteration);
+  float maxRange = 0.01;
+
+  for (unsigned int i = 0; i < k_NBINS; i++) {
+    for (unsigned int j = 0; j < k_NBINS; j++) {
+      const auto& index = std::make_pair(i, j);
+      deltaCorrection[index] = 0.f;
+      countsPerBin[index] = 0.f;
+      deltaInBin[index] = new TH1F(
+          Form("delta_iter_%i_%i_%i", iteration, i, j),
+          Form("iteration %i : #delta_%i_%i;estimated #delta_{s} -true #delta_{s} [GeV^{-1}];n.muons", iteration, i, j),
+          100,
+          -maxRange,
+          maxRange);
+      //deltaInBin[index]->GetXaxis()->SetCanExtend(kTRUE);
+    }
+  }
+
+  Float_t posTrackEta, negTrackEta, posTrackPhi, negTrackPhi, posTrackPt, negTrackPt, invMass;
+  Float_t genPosMuonEta, genNegMuonEta, genPosMuonPhi, genNegMuonPhi, genPosMuonPt, genNegMuonPt;  // gen info
+
+  tree->SetBranchAddress("posTrackEta", &posTrackEta);
+  tree->SetBranchAddress("negTrackEta", &negTrackEta);
+  tree->SetBranchAddress("posTrackPhi", &posTrackPhi);
+  tree->SetBranchAddress("negTrackPhi", &negTrackPhi);
+  tree->SetBranchAddress("posTrackPt", &posTrackPt);
+  tree->SetBranchAddress("negTrackPt", &negTrackPt);
+
+  // gen info
+  tree->SetBranchAddress("genPosMuonEta", &genPosMuonEta);
+  tree->SetBranchAddress("genNegMuonEta", &genNegMuonEta);
+  tree->SetBranchAddress("genPosMuonPhi", &genPosMuonPhi);
+  tree->SetBranchAddress("genNegMuonPhi", &genNegMuonPhi);
+  tree->SetBranchAddress("genPosMuonPt", &genPosMuonPt);
+  tree->SetBranchAddress("genNegMuonPt", &genNegMuonPt);
+
+  for (Long64_t i = 0; i < tree->GetEntries(); i++) {
+    tree->GetEntry(i);
+    TLorentzVector posTrack, negTrack, mother;
+    posTrack.SetPtEtaPhiM(posTrackPt, posTrackEta, posTrackPhi, k_muMass);  // assume muon mass for tracks
+    negTrack.SetPtEtaPhiM(negTrackPt, negTrackEta, negTrackPhi, k_muMass);
+    mother = posTrack + negTrack;
+    invMass = mother.M();
+
+    //std::cout << "invmass:" << invMass << std::endl;
+
+    //now deal with positive muon
+    const auto& indexPlus = findEtaPhiBin(hSagitta, posTrackEta, posTrackPhi);
+    float deltaSagittaPlus = theMap[indexPlus];
+
+    //now deal with negative muon
+    const auto& indexMinus = findEtaPhiBin(hSagitta, negTrackEta, negTrackPhi);
+    float deltaSagittaMinus = theMap[indexMinus];
+
+    if (indexPlus == std::make_pair(-1, -1) || indexMinus == std::make_pair(-1, -1)) {
+      continue;
+    }
+
+    /*
+    float deltaMass{0.f};
+    if (iteration == 0) {
+      deltaMass = invMass * invMass - (MZ_PDG * MZ_PDG);
+    } else {
+      deltaMass = MZ_PDG * (posTrackPt * deltaSagittaPlus - negTrackPt * deltaSagittaMinus);
+    }
+    
+    float deltaDeltaSagittaPlus =
+        -(deltaMass / (2 * MZ_PDG)) * ((1 + posTrackPt * deltaSagittaPlus) / posTrackPt);
+    float deltaDeltaSagittaMinus =
+        (deltaMass / (2 * MZ_PDG)) * ((1 - negTrackPt * deltaSagittaMinus) / negTrackPt);
+
+    */
+
+    float frac;
+    if (iteration != 0) {
+      frac = (posTrackPt * deltaSagittaPlus - negTrackPt * deltaSagittaMinus);
+    } else {
+      frac = (invMass - MZ_PDG) / MZ_PDG;
+    }
+
+    /*
+    TLorentzVector posTrackCorr, negTrackCorr, motherCorr;
+    posTrackCorr.SetPtEtaPhiM(pTcorrector(posTrackPt,deltaSagittaPlus,1.), posTrackEta, posTrackPhi, k_muMass);  // assume muon mass for tracks
+    negTrackCorr.SetPtEtaPhiM(pTcorrector(negTrackPt,deltaSagittaMinus,-1.), negTrackEta, negTrackPhi, k_muMass);
+    motherCorr = posTrackCorr + negTrackCorr;
+    
+    float frac = (motherCorr.M() - MZ_PDG) / MZ_PDG;
+    */
+
+    float deltaDeltaSagittaPlus = calcDeltaSagitta(1., frac, deltaSagittaPlus, posTrackPt);
+    float deltaDeltaSagittaMinus = calcDeltaSagitta(-1., frac, deltaSagittaMinus, negTrackPt);
+
+    // inverting equation 5 of https://arxiv.org/pdf/2212.07338.pdf
+    double trueDeltaSagittaPlus = (genPosMuonPt - posTrackPt) / (genPosMuonPt * posTrackPt);
+    double trueDeltaSagittaMinus = (negTrackPt - genNegMuonPt) / (genNegMuonPt * negTrackPt);
+
+    //std::cout << "deltaMass: " << std::setw(10) << frac
+    //<< " DeltaDeltaSag(+)-true: " << (deltaSagittaPlus + deltaDeltaSagittaPlus)   - trueDeltaSagittaPlus
+    //	      << " DeltaDeltaSag(-)-true: " << (deltaSagittaMinus + deltaDeltaSagittaMinus) - trueDeltaSagittaMinus << std::endl;
+
+    deltaCorrection[indexPlus] += deltaDeltaSagittaPlus;
+    deltaCorrection[indexMinus] += deltaDeltaSagittaMinus;
+
+    deltaInBin[indexPlus]->Fill((deltaSagittaPlus + deltaDeltaSagittaPlus) - trueDeltaSagittaPlus);
+    deltaInBin[indexMinus]->Fill((deltaSagittaMinus + deltaDeltaSagittaMinus) - trueDeltaSagittaMinus);
+
+    countsPerBin[indexPlus] += 1.;
+    countsPerBin[indexMinus] += 1.;
+  }
+
+  //TFile* iterFile = TFile::Open(Form("iteration_%i.root",iteration), "RECREATE");
+
+  for (unsigned int i = 0; i < k_NBINS; i++) {
+    for (unsigned int j = 0; j < k_NBINS; j++) {
+      const auto& index = std::make_pair(i, j);
+      //std::cout << index.first << ", " << index.second << " value: " << deltaCorrection[index] << " / " << countsPerBin[index];
+      deltaCorrection[index] /= countsPerBin[index];
+      //deltaCorrection[index] = fitResiduals(deltaInBin[index]);
+      deltaInBin[index]->Write();
+      //std::cout << " =  " << deltaCorrection[index] << std::endl;
+    }
+  }
+
+  //iterFile->Close();
+
+  std::cout << " ================================ iteration: " << iteration << std::endl;
+  for (unsigned int i = 0; i < k_NBINS; i++) {
+    for (unsigned int j = 0; j < k_NBINS; j++) {
+      const auto& index = std::make_pair(i, j);
+      //std::cout << i << ", " << j << " initial: " << theMap[index] << " correction: " << deltaCorrection[index]
+      //          << std::endl;
+      theMap[index] += deltaCorrection[index];
+    }
+  }
+
+  // find the largest element of the correction of this iteration
+  auto maxIter = std::max_element(deltaCorrection.begin(), deltaCorrection.end(), [](const auto& a, const auto& b) {
+    return std::abs(a.second) < std::abs(b.second);
+  });
+
+  return maxIter->second;
+}
+
+float updateSagittaMapFast(TTree* tree,
+                           std::map<std::pair<int, int>, float>& theMap,
+                           TH2F*& hSagitta,
+                           const int iteration,
+                           float oldMaxCorrection) {
+  std::cout << "Calling updateSagittaMap with RDataFrame" << std::endl;
+
+  ROOT::RDataFrame df(*tree);
+
+  // Initialize maps for delta correction and counts per bin
+  std::map<std::pair<int, int>, float> deltaCorrection;
+  std::map<std::pair<int, int>, float> countsPerBin;
+
+  /*
+  std::map<std::pair<int, int>, TH1F*> deltaInBin;
+
+  float maxRange = 0.01;
+
+  for (unsigned int i = 0; i < k_NBINS; i++) {
+    for (unsigned int j = 0; j < k_NBINS; j++) {
+      const auto& index = std::make_pair(i, j);
+      deltaCorrection[index] = 0.f;
+      countsPerBin[index] = 0.f;
+      deltaInBin[index] = new TH1F(
+          Form("delta_iter_%i_%i_%i", iteration, i, j),
+          Form("iteration %i : #delta_%i_%i;estimated #delta_{s} -true #delta_{s} [GeV^{-1}];n.muons", iteration, i, j),
+          100,
+          -maxRange,
+          maxRange);
+    }
+  }
+  */
+
+  const double mZfromPDG = 91.1876;  // in GeV
+
+  // Define necessary columns
+  auto df2 =
+      df.Define("posTrack",
+                [](float pt, float eta, float phi) -> TLorentzVector {
+                  TLorentzVector v;
+                  v.SetPtEtaPhiM(pt, eta, phi, k_muMass);
+                  return v;
+                },
+                {"posTrackPt", "posTrackEta", "posTrackPhi"})
+          .Define("negTrack",
+                  [](float pt, float eta, float phi) -> TLorentzVector {
+                    TLorentzVector v;
+                    v.SetPtEtaPhiM(pt, eta, phi, k_muMass);
+                    return v;
+                  },
+                  {"negTrackPt", "negTrackEta", "negTrackPhi"})
+          .Define("mother",
+                  [](const TLorentzVector& posTrack, const TLorentzVector& negTrack) -> TLorentzVector {
+                    return posTrack + negTrack;
+                  },
+                  {"posTrack", "negTrack"})
+          .Define("invMass", [](const TLorentzVector& mother) -> float { return mother.M(); }, {"mother"})
+          .Define("indexPlus",
+                  [hSagitta](float eta, float phi) -> std::pair<int, int> { return findEtaPhiBin(hSagitta, eta, phi); },
+                  {"posTrackEta", "posTrackPhi"})
+          .Define("indexMinus",
+                  [hSagitta](float eta, float phi) -> std::pair<int, int> { return findEtaPhiBin(hSagitta, eta, phi); },
+                  {"negTrackEta", "negTrackPhi"})
+          .Define("deltaSagittaPlus",
+                  [&theMap](const std::pair<int, int>& index) -> float { return theMap.at(index); },
+                  {"indexPlus"})
+          .Define("deltaSagittaMinus",
+                  [&theMap](const std::pair<int, int>& index) -> float { return theMap.at(index); },
+                  {"indexMinus"});
+
+  auto df3 = df2.Filter(
+                    [](const std::pair<int, int>& indexPlus, const std::pair<int, int>& indexMinus) {
+                      return indexPlus != std::make_pair(-1, -1) && indexMinus != std::make_pair(-1, -1);
+                    },
+                    {"indexPlus", "indexMinus"})
+                 .Define("frac",
+                         [iteration, mZfromPDG](float invMass,
+                                                float posTrackPt,
+                                                float deltaSagittaPlus,
+                                                float negTrackPt,
+                                                float deltaSagittaMinus) -> float {
+                           return (iteration != 0) ? (posTrackPt * deltaSagittaPlus - negTrackPt * deltaSagittaMinus)
+                                                   : (invMass - mZfromPDG) / mZfromPDG;
+                         },
+                         {"invMass", "posTrackPt", "deltaSagittaPlus", "negTrackPt", "deltaSagittaMinus"})
+                 .Define("deltaDeltaSagittaPlus",
+                         [](float frac, float deltaSagittaPlus, float posTrackPt) -> float {
+                           return calcDeltaSagitta(1.f, frac, deltaSagittaPlus, posTrackPt);
+                         },
+                         {"frac", "deltaSagittaPlus", "posTrackPt"})
+                 .Define("deltaDeltaSagittaMinus",
+                         [](float frac, float deltaSagittaMinus, float negTrackPt) -> float {
+                           return calcDeltaSagitta(-1.f, frac, deltaSagittaMinus, negTrackPt);
+                         },
+                         {"frac", "deltaSagittaMinus", "negTrackPt"});
+  // .Define("trueDeltaSagittaPlus", [](float genPt, float trackPt) -> double {
+  //       return (genPt - trackPt) / (genPt * trackPt);
+  //     }, {"genPosMuonPt", "posTrackPt"})
+  // .Define("trueDeltaSagittaMinus", [](float trackPt, float genPt) -> double {
+  //       return (trackPt - genPt) / (genPt * trackPt);
+  //     }, {"negTrackPt", "genNegMuonPt"});
+
+  // Accumulate corrections
+  df3.Foreach(
+      [&](const std::pair<int, int>& indexPlus,
+          float deltaDeltaSagittaPlus,
+          float deltaSagittaPlus,
+          const std::pair<int, int>& indexMinus,
+          float deltaDeltaSagittaMinus,
+          float deltaSagittaMinus) {
+#pragma omp critical
+        {
+          deltaCorrection[indexPlus] += deltaDeltaSagittaPlus;
+          deltaCorrection[indexMinus] += deltaDeltaSagittaMinus;
+          //deltaInBin[indexPlus]->Fill((deltaSagittaPlus + deltaDeltaSagittaPlus) - trueDeltaSagittaPlus);
+          //deltaInBin[indexMinus]->Fill((deltaSagittaMinus + deltaDeltaSagittaMinus) - trueDeltaSagittaMinus);
+          countsPerBin[indexPlus] += 1.f;
+          countsPerBin[indexMinus] += 1.f;
+        }
+      },
+      {"indexPlus",
+       "deltaDeltaSagittaPlus",
+       "deltaSagittaPlus",
+       "indexMinus",
+       "deltaDeltaSagittaMinus",
+       "deltaSagittaMinus"});
+
+  // Normalize corrections
+  for (unsigned int i = 0; i < k_NBINS; i++) {
+    for (unsigned int j = 0; j < k_NBINS; j++) {
+      const auto& index = std::make_pair(i, j);
+      deltaCorrection[index] /= countsPerBin[index];
+      //deltaInBin[index]->Write();
+    }
+  }
+
+  std::cout << " ================================ iteration: " << iteration << std::endl;
+  for (unsigned int i = 0; i < k_NBINS; i++) {
+    for (unsigned int j = 0; j < k_NBINS; j++) {
+      const auto& index = std::make_pair(i, j);
+      theMap[index] += deltaCorrection[index];
+    }
+  }
+
+  // Find the largest element of the correction for this iteration
+  auto maxIter = std::max_element(deltaCorrection.begin(), deltaCorrection.end(), [](const auto& a, const auto& b) {
+    return std::abs(a.second) < std::abs(b.second);
+  });
+
+  return maxIter->second;
+}
+
+//________________________________________________________________
+float updateIPMap(
+    TTree* tree, std::map<std::pair<int, int>, float>& theMap, TH2F*& hIP, const int iteration, anaKind type) {
+  std::cout << "calling the updateIPMap" << std::endl;
+
+  std::map<std::pair<int, int>, float> deltaCorrection;
+  //deltaCorrection.reserve(k_NBINS * k_NBINS);
+  std::map<std::pair<int, int>, float> countsPerBin;
+  //countsPerBin.reserve(k_NBINS * k_NBINS);
+
+  for (unsigned int i = 0; i < k_NBINS; i++) {
+    for (unsigned int j = 0; j < k_NBINS; j++) {
+      const auto& index = std::make_pair(i, j);
+      deltaCorrection[index] = 0.f;
+      countsPerBin[index] = 0.f;
+    }
+  }
+
+  float posTrackEta, negTrackEta, posTrackPhi, negTrackPhi, posTrackIP, negTrackIP, invMass;
+  tree->SetBranchAddress("posTrackEta", &posTrackEta);
+  tree->SetBranchAddress("negTrackEta", &negTrackEta);
+  tree->SetBranchAddress("posTrackPhi", &posTrackPhi);
+  tree->SetBranchAddress("negTrackPhi", &negTrackPhi);
+  if (type == d0_t) {
+    tree->SetBranchAddress("posTrackD0", &posTrackIP);
+    tree->SetBranchAddress("negTrackD0", &negTrackIP);
+  } else if (type == dz_t) {
+    tree->SetBranchAddress("posTrackDz", &posTrackIP);
+    tree->SetBranchAddress("negTrackDz", &negTrackIP);
+  } else {
+    std::cout << "error, you have been calling this script with the wrong settings!";
+    exit(EXIT_FAILURE);
+  }
+
+  for (Long64_t i = 0; i < tree->GetEntries(); i++) {
+    tree->GetEntry(i);
+
+    // deal with the positive muon
+    const auto& indexPlus = findEtaPhiBin(hIP, posTrackEta, posTrackPhi);
+    float deltaIPPlus = theMap[indexPlus];
+
+    //now deal with negative muon
+    const auto& indexMinus = findEtaPhiBin(hIP, negTrackEta, negTrackPhi);
+    float deltaIPMinus = theMap[indexMinus];
+
+    float IPdistance = std::abs(((posTrackIP + deltaIPPlus) - (negTrackIP + deltaIPMinus)));
+
+    //this converges
+    float deltaDeltaIPPlus =
+        (posTrackIP + deltaIPPlus) < (negTrackIP + deltaIPMinus) ? IPdistance / 2. : -IPdistance / 2.;
+    float deltaDeltaIPMinus =
+        (posTrackIP + deltaIPPlus) < (negTrackIP + deltaIPMinus) ? -IPdistance / 2. : IPdistance / 2.;
+
+    //std::cout << "deltaMass: " << deltaMass << " DeltaDeltaSagPlus: " <<   deltaDeltaIPPlus << " DeltaDeltaSagMinus: " << deltaDeltaIPMinus << std::endl;
+
+    deltaCorrection[indexPlus] += deltaDeltaIPPlus;
+    deltaCorrection[indexMinus] += deltaDeltaIPMinus;
+
+    countsPerBin[indexPlus] += 1.;
+    countsPerBin[indexMinus] += 1.;
+  }
+
+  for (unsigned int i = 0; i < k_NBINS; i++) {
+    for (unsigned int j = 0; j < k_NBINS; j++) {
+      const auto& index = std::make_pair(i, j);
+      //std::cout << index.first << ", " << index.second << " value: " << deltaCorrection[index] << " / " << countsPerBin[index];
+      deltaCorrection[index] /= countsPerBin[index];
+      //std::cout << " =  " << deltaCorrection[index] << std::endl;
+    }
+  }
+
+  std::cout << " ================================ iteration: " << iteration << std::endl;
+  for (unsigned int i = 0; i < k_NBINS; i++) {
+    for (unsigned int j = 0; j < k_NBINS; j++) {
+      const auto& index = std::make_pair(i, j);
+      //std::cout << i << ", " << j << " initial: " << theMap[index] << " correction: " << deltaCorrection[index]
+      //          << std::endl;
+      theMap[index] += deltaCorrection[index];
+    }
+  }
+
+  // find the largest element of the correction of this iteration
+  auto maxIter = std::max_element(deltaCorrection.begin(), deltaCorrection.end(), [](const auto& a, const auto& b) {
+    return std::abs(a.second) < std::abs(b.second);
+  });
+
+  return maxIter->second;
+}
+
+float updateIPMapFast(
+    TTree* tree, std::map<std::pair<int, int>, float>& theMap, TH2F*& hIP, const int iteration, anaKind type) {
+  std::cout << "Calling updateIPMap with RDataFrame" << std::endl;
+
+  ROOT::RDataFrame df(*tree);
+
+  std::map<std::pair<int, int>, float> deltaCorrection;
+  std::map<std::pair<int, int>, float> countsPerBin;
+  for (unsigned int i = 0; i < k_NBINS; i++) {
+    for (unsigned int j = 0; j < k_NBINS; j++) {
+      const auto& index = std::make_pair(i, j);
+      deltaCorrection[index] = 0.f;
+      countsPerBin[index] = 0.f;
+    }
+  }
+
+  // Define the necessary columns based on anaKind
+  auto columns = type == d0_t ? df.Define("posTrackIP", [](float d0) -> float { return d0; }, {"posTrackD0"})
+                                    .Define("negTrackIP", [](float d0) -> float { return d0; }, {"negTrackD0"})
+                              : df.Define("posTrackIP", [](float dz) -> float { return dz; }, {"posTrackDz"})
+                                    .Define("negTrackIP", [](float dz) -> float { return dz; }, {"negTrackDz"});
+
+  auto result =
+      columns
+          .Define("indexPlus",
+                  [hIP](float posTrackEta, float posTrackPhi) -> std::pair<int, int> {
+                    return findEtaPhiBin(hIP, posTrackEta, posTrackPhi);
+                  },
+                  {"posTrackEta", "posTrackPhi"})
+          .Define("indexMinus",
+                  [hIP](float negTrackEta, float negTrackPhi) -> std::pair<int, int> {
+                    return findEtaPhiBin(hIP, negTrackEta, negTrackPhi);
+                  },
+                  {"negTrackEta", "negTrackPhi"})
+          .Define("deltaIPPlus",
+                  [theMap](const std::pair<int, int>& indexPlus) -> float { return theMap.at(indexPlus); },
+                  {"indexPlus"})
+          .Define("deltaIPMinus",
+                  [theMap](const std::pair<int, int>& indexMinus) -> float { return theMap.at(indexMinus); },
+                  {"indexMinus"})
+          .Define("IPdistance",
+                  [](float posTrackIP, float deltaIPPlus, float negTrackIP, float deltaIPMinus) -> float {
+                    return std::abs((posTrackIP + deltaIPPlus) - (negTrackIP + deltaIPMinus));
+                  },
+                  {"posTrackIP", "deltaIPPlus", "negTrackIP", "deltaIPMinus"})
+          .Define(
+              "deltaDeltaIPPlus",
+              [](float posTrackIP, float deltaIPPlus, float negTrackIP, float deltaIPMinus, float IPdistance) -> float {
+                return (posTrackIP + deltaIPPlus) < (negTrackIP + deltaIPMinus) ? IPdistance / 2. : -IPdistance / 2.;
+              },
+              {"posTrackIP", "deltaIPPlus", "negTrackIP", "deltaIPMinus", "IPdistance"})
+          .Define(
+              "deltaDeltaIPMinus",
+              [](float posTrackIP, float deltaIPPlus, float negTrackIP, float deltaIPMinus, float IPdistance) -> float {
+                return (posTrackIP + deltaIPPlus) < (negTrackIP + deltaIPMinus) ? -IPdistance / 2. : IPdistance / 2.;
+              },
+              {"posTrackIP", "deltaIPPlus", "negTrackIP", "deltaIPMinus", "IPdistance"});
+
+  // Update the corrections in parallel
+  result.Foreach(
+      [&](const std::pair<int, int>& indexPlus,
+          float deltaDeltaIPPlus,
+          const std::pair<int, int>& indexMinus,
+          float deltaDeltaIPMinus) {
+#pragma omp critical
+        {
+          deltaCorrection[indexPlus] += deltaDeltaIPPlus;
+          deltaCorrection[indexMinus] += deltaDeltaIPMinus;
+          countsPerBin[indexPlus] += 1.f;
+          countsPerBin[indexMinus] += 1.f;
+        }
+      },
+      {"indexPlus", "deltaDeltaIPPlus", "indexMinus", "deltaDeltaIPMinus"});
+
+  // Normalize the corrections
+  for (unsigned int i = 0; i < k_NBINS; i++) {
+    for (unsigned int j = 0; j < k_NBINS; j++) {
+      const auto& index = std::make_pair(i, j);
+      deltaCorrection[index] /= countsPerBin[index];
+    }
+  }
+
+  // Update the map with the new corrections
+  std::cout << " ================================ iteration: " << iteration << std::endl;
+  for (unsigned int i = 0; i < k_NBINS; i++) {
+    for (unsigned int j = 0; j < k_NBINS; j++) {
+      const auto& index = std::make_pair(i, j);
+      theMap[index] += deltaCorrection[index];
+    }
+  }
+
+  // Find the largest correction in this iteration
+  auto maxIter = std::max_element(deltaCorrection.begin(), deltaCorrection.end(), [](const auto& a, const auto& b) {
+    return std::abs(a.second) < std::abs(b.second);
+  });
+
+  return maxIter->second;
+}

--- a/Alignment/OfflineValidation/macros/overlayDiMuonBiases.C
+++ b/Alignment/OfflineValidation/macros/overlayDiMuonBiases.C
@@ -1,0 +1,331 @@
+#include <TFile.h>
+#include <TLatex.h>
+#include <TCanvas.h>
+#include <TLegend.h>
+#include <TStyle.h>
+#include <TGaxis.h>
+#include <string>
+#include <map>
+#include <TH1.h>
+#include <TH2.h>
+#include <TKey.h>
+#include <iostream>
+
+/*--------------------------------------------------------------------*/
+void cmsPrel(const TCanvas* canvas, float correction = 0.) {
+  /*--------------------------------------------------------------------*/
+
+  // Create and draw the CMS text
+  TLatex* latexCMS = new TLatex(canvas->GetLeftMargin(), 1.01 - canvas->GetTopMargin(), "#bf{CMS} #it{Preliminary}");
+  latexCMS->SetNDC(kTRUE);
+  latexCMS->SetTextFont(42);
+  latexCMS->SetTextSize(0.042);
+  latexCMS->Draw();
+
+  // Create and draw the Internal (13 TeV) text
+  TLatex* latexInternal = new TLatex(
+      1 - canvas->GetRightMargin() - correction, 1.01 - canvas->GetTopMargin(), "pp collisions (2022) 13.6 TeV");
+  latexInternal->SetNDC(kTRUE);
+  latexInternal->SetTextAlign(31);
+  latexInternal->SetTextFont(42);
+  latexInternal->SetTextSize(0.042);
+  latexInternal->Draw();
+}
+
+/*--------------------------------------------------------------------*/
+void adjustCanvasMargins(TCanvas* canvas) {
+  /*--------------------------------------------------------------------*/
+  canvas->SetLeftMargin(0.14);
+  canvas->SetRightMargin(0.04);
+  canvas->SetTopMargin(0.06);
+  canvas->SetBottomMargin(0.12);
+}
+
+/*--------------------------------------------------------------------*/
+void adjustCanvasMargins2D(TCanvas* canvas) {
+  /*--------------------------------------------------------------------*/
+  canvas->SetLeftMargin(0.10);
+  canvas->SetRightMargin(0.185);
+  canvas->SetTopMargin(0.06);
+  canvas->SetBottomMargin(0.12);
+}
+
+// Function to modify axis title if it contains "phi"
+/*--------------------------------------------------------------------*/
+void modifyAxisTitle(TH1* hist, const TString& axisName)
+/*--------------------------------------------------------------------*/
+{
+  // Get the current axis title
+  TString axisTitle;
+  if (axisName == "X") {
+    axisTitle = hist->GetXaxis()->GetTitle();
+  } else if (axisName == "Y") {
+    axisTitle = hist->GetYaxis()->GetTitle();
+  } else {
+    std::cerr << "Invalid axis name: " << axisName << ". Use 'X' or 'Y'." << std::endl;
+    return;
+  }
+
+  // Convert to lower case for case-insensitive comparison
+  TString axisTitleLower = axisTitle;
+  axisTitleLower.ToLower();
+
+  // Check if "phi" is in the axis title
+  if (axisTitleLower.Contains("phi")) {
+    // Append " [rad]" if "phi" is found
+    axisTitle += " [rad]";
+    if (axisName == "X") {
+      hist->GetXaxis()->SetTitle(axisTitle);
+    } else if (axisName == "Y") {
+      hist->GetYaxis()->SetTitle(axisTitle);
+    }
+    std::cout << "Updated " << axisName << "-axis title to: " << axisTitle << std::endl;
+  }
+}
+
+/*--------------------------------------------------------------------*/
+void makeNicePlotStyle(TH1* hist, int color, int markerStyle)
+/*--------------------------------------------------------------------*/
+{
+  hist->SetStats(kFALSE);
+  hist->SetLineWidth(2);
+  hist->SetLineColor(color);
+  hist->SetMarkerColor(color);
+  hist->SetMarkerStyle(markerStyle);
+  //hist->GetXaxis()->CenterTitle(true);
+  //hist->GetYaxis()->CenterTitle(true);
+  hist->GetXaxis()->SetTitleFont(42);
+  hist->GetYaxis()->SetTitleFont(42);
+  hist->GetXaxis()->SetTitleSize(0.05);
+  hist->GetYaxis()->SetTitleSize(0.05);
+  hist->GetZaxis()->SetTitleSize(0.05);
+  hist->GetXaxis()->SetTitleOffset(1.2);
+  if (hist->InheritsFrom("TH2")) {
+    hist->GetYaxis()->SetTitleOffset(1.0);
+  } else {
+    hist->GetYaxis()->SetTitleOffset(1.3);
+  }
+  hist->GetZaxis()->SetTitleOffset(1.3);
+  hist->GetXaxis()->SetLabelFont(42);
+  hist->GetYaxis()->SetLabelFont(42);
+  hist->GetYaxis()->SetLabelSize(.05);
+  hist->GetXaxis()->SetLabelSize(.05);
+  hist->GetZaxis()->SetLabelSize(.05);
+
+  // Modify the axis titles if they contain "phi"
+  modifyAxisTitle(hist, "X");
+  modifyAxisTitle(hist, "Y");
+
+  TGaxis::SetExponentOffset(-0.1, 0.01, "y");  // Y offset
+}
+
+/*--------------------------------------------------------------------*/
+std::pair<Double_t, Double_t> getExtrema(TObjArray* array)
+/*--------------------------------------------------------------------*/
+{
+  Double_t theMaximum = (static_cast<TH1*>(array->At(0)))->GetMaximum();
+  Double_t theMinimum = (static_cast<TH1*>(array->At(0)))->GetMinimum();
+  for (Int_t i = 0; i < array->GetSize(); i++) {
+    if ((static_cast<TH1*>(array->At(i)))->GetMaximum() > theMaximum) {
+      theMaximum = (static_cast<TH1*>(array->At(i)))->GetMaximum();
+    }
+    if ((static_cast<TH1*>(array->At(i)))->GetMinimum() < theMinimum) {
+      theMinimum = (static_cast<TH1*>(array->At(i)))->GetMinimum();
+    }
+  }
+  return std::make_pair(theMinimum, theMaximum);
+}
+
+void overlayHistograms(const std::vector<std::string>& fileNames,
+                       const std::vector<string>& labels,
+                       const std::string& type) {
+  gStyle->SetOptTitle(0);
+
+  // Create a new canvas for each histogram
+  TCanvas* c = nullptr;
+
+  std::vector<int> colors = {kBlack, kRed, kBlue, kGreen, kAzure, kYellow};
+  std::vector<int> markers = {20, 21, 22, 23, 24, 25};
+
+  // Map to store histograms with the same name
+  std::map<std::string, std::vector<TH1*>> histMap;
+  std::map<std::string, std::vector<TH2*>> hist2DMap;
+
+  // Loop over all the input files
+  for (const auto& fileName : fileNames) {
+    // Open the input file
+    TFile* file = TFile::Open(fileName.c_str());
+    if (!file || file->IsZombie()) {
+      std::cerr << "Could not open file " << fileName << std::endl;
+      continue;
+    }
+
+    // Loop over all histograms in the directory
+    TIter nexthist(file->GetListOfKeys());
+    TKey* key = nullptr;
+    while ((key = static_cast<TKey*>(nexthist()))) {
+      TObject* obj = key->ReadObj();
+      if (obj->InheritsFrom(TH1::Class())) {
+        TH1* hist = static_cast<TH1*>(obj);
+        std::string histName = hist->GetName();
+        std::cout << "pushing back: " << histName << std::endl;
+        if (!obj->InheritsFrom(TH2::Class())) {
+          histMap[histName].push_back(hist);
+        } else {
+          TH2* hist = static_cast<TH2*>(obj);
+          hist2DMap[histName].push_back(hist);
+        }
+      }
+    }
+  }
+  // Close the input file
+  //file->Close();
+
+  // Loop over the histograms in the map
+  for (const auto& histPair : histMap) {
+    const std::string& histName = histPair.first;
+    const std::vector<TH1*>& histVec = histPair.second;
+
+    if (histName.find("delta_iter_") != std::string::npos)
+      continue;
+
+    // Create a new canvas for the histogram
+    c = new TCanvas((histName + type).c_str(), histName.c_str(), 800, 800);
+
+    //if(histName.find("Delta") != std::string::npos) {
+    //  c->SetLogy();
+    //}
+
+    adjustCanvasMargins(c);
+
+    TObjArray* array = new TObjArray(histVec.size());
+    for (const auto& histo : histVec) {
+      array->Add(histo);
+    }
+    std::pair<Double_t, Double_t> extrema = getExtrema(array);
+    const auto& DELTA = std::abs(extrema.second - extrema.first);
+    delete array;
+
+    // Draw the first histogram
+    histVec[0]->Draw();
+    makeNicePlotStyle(histVec[0], kBlack, 20);
+
+    if ((histName.find("avg") != std::string::npos)) {
+      histVec[0]->SetMinimum(extrema.first - DELTA / 3.);
+      histVec[0]->SetMaximum(extrema.second + DELTA / 3.);
+    } else if (histName.find("RMS") != std::string::npos) {
+      histVec[0]->SetMinimum(0.);
+      histVec[0]->SetMaximum(extrema.second + DELTA / 3.);
+    } else if (histName.find("Correction") != std::string::npos) {
+      histVec[0]->SetMinimum(extrema.first - DELTA / 3.);
+      histVec[0]->SetMaximum(extrema.second + DELTA / 3.);
+    } else {
+      histVec[0]->SetMaximum(extrema.second + DELTA / 3.);
+    }
+
+    // Loop over the remaining histograms and overlay them
+    for (size_t i = 1; i < histVec.size(); ++i) {
+      histVec[i]->Draw("SAME");
+      makeNicePlotStyle(histVec[i], colors[i], markers[i]);
+    }
+
+    // Draw the legend
+    TLegend* infoBox = new TLegend(0.44, 0.80, 0.94, 0.93, "");
+    infoBox->SetShadowColor(0);  // 0 = transparent
+    infoBox->SetBorderSize(0);   // 0 = transparent
+    infoBox->SetFillColor(kWhite);
+    infoBox->SetTextSize(0.035);
+
+    for (unsigned int i = 0; i < histVec.size(); i++) {
+      infoBox->AddEntry(histVec[i], labels[i].c_str(), "PL");
+    }
+    infoBox->Draw("same");
+
+    TLatex* latex = new TLatex();
+    latex->SetTextAlign(22);
+    latex->SetTextSize(0.045);
+
+    //latex->DrawLatexNDC(0.75, 0.85, "Z^{0} #rightarrow#mu^{+}#mu^{-}");
+    cmsPrel(c);
+
+    // Update the canvas
+    c->Update();
+    c->SaveAs((histName + "_" + type + ".png").c_str());
+    c->SaveAs((histName + "_" + type + ".pdf").c_str());
+    c->SaveAs((histName + "_" + type + ".eps").c_str());
+    c->SaveAs((histName + "_" + type + ".root").c_str());
+  }
+
+  //gStyle->SetPalette(kRainbow);
+  //gStyle->SetPalette(kWaterMelon);
+  gStyle->SetPalette(kTemperatureMap);
+  //gStyle->SetPalette(kViridis);
+
+  // Loop over the 2D histograms in the map
+  for (const auto& entry : hist2DMap) {
+    const std::string& histName = entry.first;
+    const std::vector<TH2*>& histList = entry.second;
+
+    if (histList.empty()) {
+      std::cerr << "No histograms found for " << histName << std::endl;
+      continue;
+    }
+
+    TObjArray* array = new TObjArray(histList.size());
+    for (const auto& histo : histList) {
+      array->Add(histo);
+    }
+
+    std::pair<Double_t, Double_t> extrema = getExtrema(array);
+    delete array;
+
+    TCanvas* c = new TCanvas((histName + type).c_str(), histName.c_str(), 900 * histList.size(), 800);
+    c->Divide(histList.size(), 1);
+
+    for (size_t i = 0; i < histList.size(); ++i) {
+      c->cd(i + 1);
+      auto current_pad = static_cast<TCanvas*>(gPad);
+      adjustCanvasMargins2D(current_pad);
+      makeNicePlotStyle(histList[i], kWhite, 0);
+      histList[i]->SetMinimum(extrema.first);
+      histList[i]->SetMaximum(extrema.second);
+      histList[i]->Draw("COLZ");
+      cmsPrel(current_pad, -0.062);
+    }
+
+    // Update the canvas
+    c->Update();
+    c->SaveAs((histName + "_" + type + "_side_by_side.png").c_str());
+    c->SaveAs((histName + "_" + type + "_side_by_side.pdf").c_str());
+    c->SaveAs((histName + "_" + type + "_side_by_side.eps").c_str());
+    c->SaveAs((histName + "_" + type + "_side_by_side.root").c_str());
+
+    for (size_t i = 0; i < histList.size(); ++i) {
+      TCanvas* c2 = new TCanvas((histName + type + labels[i]).c_str(), histName.c_str(), 900, 800);
+      c2->cd();
+      auto current_pad = static_cast<TCanvas*>(gPad);
+      adjustCanvasMargins2D(current_pad);
+      makeNicePlotStyle(histList[i], kWhite, 0);
+      histList[i]->Draw("COLZ");
+      cmsPrel(c2, -0.050);
+      std::string result = labels[i];
+      std::replace(result.begin(), result.end(), ' ', '_');
+      c2->SaveAs((histName + "_" + type + "_" + result + ".png").c_str());
+      c2->SaveAs((histName + "_" + type + "_" + result + ".pdf").c_str());
+      c2->SaveAs((histName + "_" + type + "_" + result + ".eps").c_str());
+      c2->SaveAs((histName + "_" + type + "_" + result + ".root").c_str());
+    }
+  }
+}
+
+void overlayDiMuonBiases() {
+  std::vector<std::string> fileNames = {"histos_asInDataTaking_DiMuonAnalysisResults_Run2022D-v1__d0__FINE.root",
+                                        "histos_Run3ReReco_DiMuonAnalysisResults_Run2022D-v1__d0.root"};
+  std::vector<std::string> labels = {"fine", "fast"};  // Add your ROOT file names here
+
+  overlayHistograms(fileNames, labels, "d0");
+
+  //fileNames.clear();
+  //fileNames = {"histos_asInDataTaking_DiMuonAnalysisResults_Run2022__dz.root","histos_Run3ReReco_DiMuonAnalysisResults_Run2022__dz.root"};
+  //overlayHistograms(fileNames,labels,"dz");
+}

--- a/Alignment/OfflineValidation/test/BuildFile.xml
+++ b/Alignment/OfflineValidation/test/BuildFile.xml
@@ -60,4 +60,11 @@
   </bin>
   <test name="Miscellanea" command="testingScripts/test_unitMiscellanea.sh"/>
   <test name="SagittaBiasNtuplizer" command="testingScripts/test_unitSagittaBiasNtuplizer.sh"/>
+  <bin file="testanalyzeDiMuonBiases.cpp" name="testDiMuonBiasesPlotting">
+    <flags PRE_TEST="SagittaBiasNtuplizer"/>
+    <use name="rootmath"/>
+    <use name="roothistmatrix"/>
+    <use name="rootgraphics"/>
+    <use name="Alignment/OfflineValidation"/>
+  </bin>
 </environment>

--- a/Alignment/OfflineValidation/test/BuildFile.xml
+++ b/Alignment/OfflineValidation/test/BuildFile.xml
@@ -59,4 +59,5 @@
     <use name="Alignment/OfflineValidation"/>
   </bin>
   <test name="Miscellanea" command="testingScripts/test_unitMiscellanea.sh"/>
+  <test name="SagittaBiasNtuplizer" command="testingScripts/test_unitSagittaBiasNtuplizer.sh"/>
 </environment>

--- a/Alignment/OfflineValidation/test/SagittaBiasNtuplizer_cfg.py
+++ b/Alignment/OfflineValidation/test/SagittaBiasNtuplizer_cfg.py
@@ -13,7 +13,7 @@ options.register('scenario',
                  "Name of input misalignment scenario")
 
 options.register('globalTag',
-                 "'auto:phase1_2022_realistic", # default value
+                 "125X_mcRun3_2022_design_v6", # default value
                  VarParsing.multiplicity.singleton, # singleton or list
                  VarParsing.varType.string, # string, int, or float
                  "name of the input Global Tag")
@@ -23,6 +23,12 @@ options.register ('myfile',
                   VarParsing.multiplicity.singleton,
                   VarParsing.varType.string,
                   "file name")
+
+options.register ('fromRECO',
+                  True, # default value
+                  VarParsing.multiplicity.singleton,
+                  VarParsing.varType.bool,
+                  "start from RECO data-tier, if False it will use TkAlDiMuonAndVertex ALCARECO")
 
 options.register ('FileList',
                   '', # default value
@@ -93,7 +99,7 @@ process.load('TrackingTools.TrackAssociator.DetIdAssociatorESProducer_cff')
 ####################################################################
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag,"125X_mcRun3_2022_design_v6", '')
+process.GlobalTag = GlobalTag(process.GlobalTag, options.globalTag, '')
 if (options.scenario=='null'):
     print("null scenario, do nothing")
     pass
@@ -179,28 +185,33 @@ process.refittedTracks = RecoTracker.TrackProducer.TrackRefitter_cfi.TrackRefitt
 ####################################################################
 from RecoVertex.PrimaryVertexProducer.OfflinePrimaryVertices_cfi import offlinePrimaryVertices
 process.offlinePrimaryVerticesFromRefittedTrks = offlinePrimaryVertices.clone()
-#process.offlinePrimaryVerticesFromRefittedTrks.TrackLabel = cms.InputTag("refittedVtxTracks")
-process.offlinePrimaryVerticesFromRefittedTrks.TrackLabel = cms.InputTag("refittedTracks")
+process.offlinePrimaryVerticesFromRefittedTrks.TrackLabel = "refittedTracks" if options.fromRECO else "refittedVtxTracks"
 
 ###################################################################
 # The analysis modules
 ###################################################################
 process.ZtoMMNtuple = cms.EDAnalyzer("SagittaBiasNtuplizer",
-                                     #tracks = cms.InputTag('refittedMuons'),
-                                     useReco = cms.bool(True),
-                                     muons = cms.InputTag('muons'),
+                                     useReco = cms.bool(options.fromRECO),
                                      doGen = cms.bool(True),
-                                     tracks = cms.InputTag('refittedTracks'),
-                                     vertices = cms.InputTag('offlinePrimaryVerticesFromRefittedTrks'))
+                                     vertices = cms.InputTag('offlinePrimaryVerticesFromRefittedTrks'),
+                                     **({
+                                         "muons": cms.InputTag('muons'),
+                                         "tracks": cms.InputTag('refittedTracks')
+                                     } if options.fromRECO else {
+                                         "muonTracks": cms.InputTag('refittedMuons'),
+                                         "genParticles": cms.InputTag('TkAlDiMuonAndVertexGenMuonSelector')
+                                     }))
 
 process.DiMuonVertexValidation = cms.EDAnalyzer("DiMuonVertexValidation",
-                                                useReco = cms.bool(False),
-                                                ## the two parameters below are mutually exclusive,
-                                                ## depending if RECO or ALCARECO is used
-                                                #muons  = cms.InputTag(''),
-                                                muonTracks = cms.InputTag('refittedMuons'),
-                                                tracks = cms.InputTag(''),
-                                                vertices = cms.InputTag('offlinePrimaryVerticesFromRefittedTrks'))
+                                                useReco = cms.bool(options.fromRECO),
+                                                vertices = cms.InputTag('offlinePrimaryVerticesFromRefittedTrks'),
+                                                **({
+                                                    "muons": cms.InputTag('muons'),
+                                                    "tracks" : cms.InputTag("generalTracks")
+                                                } if options.fromRECO else {
+                                                    "muonTracks": cms.InputTag('refittedMuons'),
+                                                    "tracks": cms.InputTag('')
+                                                }))
                                     
 from Alignment.OfflineValidation.diMuonValidation_cfi import diMuonValidation as _diMuonValidation
 process.DiMuonMassValidation = _diMuonValidation.clone(
@@ -256,11 +267,11 @@ process.TFileService = cms.Service("TFileService",
 ###################################################################
 # Path
 ###################################################################
-process.p1 = cms.Path(process.offlineBeamSpot
-                      #* process.refittedMuons
-                      #* process.refittedVtxTracks
-                      * process.refittedTracks
-                      * process.offlinePrimaryVerticesFromRefittedTrks
-                      * process.ZtoMMNtuple) 
-                      #* process.DiMuonVertexValidation
-                      #* process.DiMuonMassValidation)
+process.p1 = cms.Path(
+    process.offlineBeamSpot *
+    (process.refittedTracks if options.fromRECO else process.refittedMuons * process.refittedVtxTracks) *
+    process.offlinePrimaryVerticesFromRefittedTrks *
+    process.ZtoMMNtuple *
+    process.DiMuonVertexValidation *
+    (process.DiMuonMassValidation if not options.fromRECO else cms.Sequence())
+)

--- a/Alignment/OfflineValidation/test/testanalyzeDiMuonBiases.cpp
+++ b/Alignment/OfflineValidation/test/testanalyzeDiMuonBiases.cpp
@@ -1,0 +1,15 @@
+#include <iostream>
+#include <sstream>
+#include <TSystem.h>
+#include "Alignment/OfflineValidation/macros/analyzeDiMuonBiases.C"
+
+int main(int argc, char** argv) {
+  std::cout << "\n==== Executing muon d0 analysis plotting \n" << std::endl;
+  analyzeDiMuonBiases("ZmmNtuple_MC_GEN-SIM_null.root", anaKind::d0_t);
+
+  std::cout << "\n==== Executing muon dz analysis plotting \n" << std::endl;
+  analyzeDiMuonBiases("ZmmNtuple_MC_GEN-SIM_null.root", anaKind::dz_t);
+
+  std::cout << "\n==== Executing muon sagitta analysis plotting \n" << std::endl;
+  analyzeDiMuonBiases("ZmmNtuple_MC_GEN-SIM_null.root", anaKind::sagitta_t);
+}

--- a/Alignment/OfflineValidation/test/testingScripts/test_unitMiscellanea.sh
+++ b/Alignment/OfflineValidation/test/testingScripts/test_unitMiscellanea.sh
@@ -16,8 +16,5 @@ cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/python/TkAlAllInOneTool/Pix
 echo "TESTING CosmicTrackSplitting Analyser ..."
 cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/testSplitterValidation_cfg.py unitTest=True || die "Failure running testSplitterValidation_cfg.py" $?
 
-echo "TESTING SagittaBiasNtuplizer Analyser ..."
-cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/SagittaBiasNtuplizer_cfg.py || die "Failure running SagittaBiasNtuplizer_cfg.py" $?
-
 echo "TESTING TkAlV0sAnalyzer Analyser ..."
 cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/TkAlV0sAnalyzer_cfg.py unitTest=True || die "Failure running TkAlV0sAnalyzer_cfg.py" $?

--- a/Alignment/OfflineValidation/test/testingScripts/test_unitSagittaBiasNtuplizer.sh
+++ b/Alignment/OfflineValidation/test/testingScripts/test_unitSagittaBiasNtuplizer.sh
@@ -6,5 +6,3 @@ cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/SagittaBiasNtuplizer_c
 
 echo "TESTING SagittaBiasNtuplizer Analyser with ALCARECO input..."
 cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/SagittaBiasNtuplizer_cfg.py globalTag=142X_mcRun3_2025_realistic_v7 fromRECO=False  myfile=/store/relval/CMSSW_15_1_0_pre1/RelValZMM_14/ALCARECO/TkAlDiMuonAndVertex-142X_mcRun3_2025_realistic_v7_STD_RegeneratedGS_2025_noPU-v1/2580000/b5e3fc09-7b77-42b8-9d69-d37e6fcfb5b8.root || die "Failure running SagittaBiasNtuplizer_cfg.py (with ALCARECO input)" $?
-
-

--- a/Alignment/OfflineValidation/test/testingScripts/test_unitSagittaBiasNtuplizer.sh
+++ b/Alignment/OfflineValidation/test/testingScripts/test_unitSagittaBiasNtuplizer.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+function die { echo $1: status $2 ; exit $2; }
+
+echo "TESTING SagittaBiasNtuplizer Analyser with RECO input..."
+cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/SagittaBiasNtuplizer_cfg.py || die "Failure running SagittaBiasNtuplizer_cfg.py (with RECO input)" $?
+
+echo "TESTING SagittaBiasNtuplizer Analyser with ALCARECO input..."
+cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/SagittaBiasNtuplizer_cfg.py globalTag=142X_mcRun3_2025_realistic_v7 fromRECO=False  myfile=/store/relval/CMSSW_15_1_0_pre1/RelValZMM_14/ALCARECO/TkAlDiMuonAndVertex-142X_mcRun3_2025_realistic_v7_STD_RegeneratedGS_2025_noPU-v1/2580000/b5e3fc09-7b77-42b8-9d69-d37e6fcfb5b8.root || die "Failure running SagittaBiasNtuplizer_cfg.py (with ALCARECO input)" $?
+
+


### PR DESCRIPTION
#### PR description:

The main goal of this PR is add to `cmssw` the analysis macros used to produce the following public plots [link](https://twiki.cern.ch/twiki/bin/view/CMSPublic/TkAlignmentPerformanceRun3Reprocessing#Impact_Parameter_Bias_in_Z).
The following files are modified:

```bash
.
`-- Alignment
    `-- OfflineValidation
        |-- macros
        |   |-- analyzeDiMuonBiases.C
        |   |-- analyzeDiMuonBiases_fast.C
        |   `-- overlayDiMuonBiases.C
        `-- test
            |-- BuildFile.xml
            |-- SagittaBiasNtuplizer_cfg.py
            |-- testanalyzeDiMuonBiases.cpp
            `-- testingScripts
                |-- test_unitMiscellanea.sh
                `-- test_unitSagittaBiasNtuplizer.sh
```

The files in `macros` are the main goal of this PR.
The file `SagittaBiasNtuplizer_cfg.py` is modified in order to support testing on `GEN-SIM-RECO` files as well as `ALCARECO` files (of the flavour `TkAlDiMuonAndVertex`)
The other files modified are infrastructural changes to introduce unit tests for the new code.

#### PR validation:

`scram b runtests_testDiMuonBiasesPlotting use-ibeos` runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A