### PR TITLE
Fix resetting of collections in LST

### DIFF
--- a/RecoTracker/LSTCore/src/alpaka/LSTEvent.dev.cc
+++ b/RecoTracker/LSTCore/src/alpaka/LSTEvent.dev.cc
@@ -57,6 +57,7 @@ void LSTEvent::resetEventSync() {
   miniDoubletsDC_.reset();
   rangesDC_.reset();
   segmentsDC_.reset();
+  pixelSegmentsDC_.reset();
   tripletsDC_.reset();
   quintupletsDC_.reset();
   trackCandidatesDC_.reset();
@@ -67,6 +68,7 @@ void LSTEvent::resetEventSync() {
   rangesHC_.reset();
   miniDoubletsHC_.reset();
   segmentsHC_.reset();
+  pixelSegmentsHC_.reset();
   tripletsHC_.reset();
   quintupletsHC_.reset();
   pixelTripletsHC_.reset();


### PR DESCRIPTION
In one of our previous PRs we introduced a bug where two of the collections are not being reset at the start of each event. On CPU, this works fine since each time the device collection is being replaced and used when getting the output. However, on GPU this was an issue because when getting the output it ends up using a stale copy on the host instead of the new one that should have been copied from the device. This PR fixed the issue by resetting both collections at the start.