### PR TITLE
[DAQ] fix for raw generator creating incorrect raw files in Hilton (15_1_X)

### DIFF
--- a/EventFilter/Utilities/plugins/RawEventOutputModuleForBU.h
+++ b/EventFilter/Utilities/plugins/RawEventOutputModuleForBU.h
@@ -54,7 +54,6 @@ private:
   std::vector<unsigned int> sourceIdList_;
   unsigned int totevents_ = 0;
   unsigned int index_ = 0;
-  bool firstLumi_ = true;
 };
 
 template <class Consumer>
@@ -184,11 +183,8 @@ void RawEventOutputModuleForBU<Consumer>::beginLuminosityBlock(edm::LuminosityBl
   std::string destinationDir = edm::Service<evf::EvFDaqDirector>()->buBaseRunDir();
   int run = edm::Service<evf::EvFDaqDirector>()->getRunNumber();
   std::cout << " writing to destination dir " << destinationDir << " name: " << filename << std::endl;
+  totevents_ = 0;
   templateConsumer_->initialize(destinationDir, filename, run, ls.id().luminosityBlock());
-  if (!firstLumi_) {
-    totevents_ = 0;
-    firstLumi_ = false;
-  }
 }
 
 template <class Consumer>


### PR DESCRIPTION
#### PR description:

Fixes incorrect condition that causes counter to never be reset at the start of a lumisection `RawEventOutputModuleForBU`.
Result is that with large input event samples, it can with certain probability cause raw files to have only file header and no events.
This impacted tests in Hilton where some tests failed.
This is only used in Hilton scripts and not production HLT and affecting only tests with many events, so the impact is low.

cc: @missirol 

#### PR validation:
Tested that with Hilton scripts that proper raw files are generated with this fix.