### PR TITLE
MTD geometry: fix the topology parameters reading for ETL v10

### DIFF
--- a/Geometry/MTDGeometryBuilder/src/MTDParametersFromDD.cc
+++ b/Geometry/MTDGeometryBuilder/src/MTDParametersFromDD.cc
@@ -60,8 +60,8 @@ bool MTDParametersFromDD::build(const DDCompactView* cvp, PMTDParameters& ptp) {
   }
 
   std::vector<std::string> etlLayout;
-  if (MTDTopologyMode::etlLayoutFromTopoMode(topoMode) == MTDTopologyMode::EtlLayout::v5 ||
-      MTDTopologyMode::etlLayoutFromTopoMode(topoMode) == MTDTopologyMode::EtlLayout::v8) {
+  if (static_cast<int>(MTDTopologyMode::etlLayoutFromTopoMode(topoMode)) <=
+      static_cast<int>(MTDTopologyMode::EtlLayout::v8)) {
     etlLayout.emplace_back("StartCopyNo_Front_Left");
     etlLayout.emplace_back("StartCopyNo_Front_Right");
     etlLayout.emplace_back("StartCopyNo_Back_Left");
@@ -70,7 +70,8 @@ bool MTDParametersFromDD::build(const DDCompactView* cvp, PMTDParameters& ptp) {
     etlLayout.emplace_back("Offset_Front_Right");
     etlLayout.emplace_back("Offset_Back_Left");
     etlLayout.emplace_back("Offset_Back_Right");
-  } else if (MTDTopologyMode::etlLayoutFromTopoMode(topoMode) >= MTDTopologyMode::EtlLayout::v9) {
+  } else if (static_cast<int>(MTDTopologyMode::etlLayoutFromTopoMode(topoMode)) >
+             static_cast<int>(MTDTopologyMode::EtlLayout::v8)) {
     etlLayout.emplace_back("StartCopyNo_Front_Disc_1");
     etlLayout.emplace_back("StartCopyNo_Back_Disc_1");
     etlLayout.emplace_back("StartCopyNo_Front_Disc_2");
@@ -143,8 +144,8 @@ bool MTDParametersFromDD::build(const cms::DDCompactView* cvp, PMTDParameters& p
   }
 
   std::vector<std::string> etlLayout;
-  if (MTDTopologyMode::etlLayoutFromTopoMode(topoMode) == MTDTopologyMode::EtlLayout::v5 ||
-      MTDTopologyMode::etlLayoutFromTopoMode(topoMode) == MTDTopologyMode::EtlLayout::v8) {
+  if (static_cast<int>(MTDTopologyMode::etlLayoutFromTopoMode(topoMode)) <=
+      static_cast<int>(MTDTopologyMode::EtlLayout::v8)) {
     etlLayout.emplace_back("StartCopyNo_Front_Left");
     etlLayout.emplace_back("StartCopyNo_Front_Right");
     etlLayout.emplace_back("StartCopyNo_Back_Left");
@@ -153,7 +154,8 @@ bool MTDParametersFromDD::build(const cms::DDCompactView* cvp, PMTDParameters& p
     etlLayout.emplace_back("Offset_Front_Right");
     etlLayout.emplace_back("Offset_Back_Left");
     etlLayout.emplace_back("Offset_Back_Right");
-  } else if (MTDTopologyMode::etlLayoutFromTopoMode(topoMode) >= MTDTopologyMode::EtlLayout::v9) {
+  } else if (static_cast<int>(MTDTopologyMode::etlLayoutFromTopoMode(topoMode)) >
+             static_cast<int>(MTDTopologyMode::EtlLayout::v8)) {
     etlLayout.emplace_back("StartCopyNo_Front_Disc_1");
     etlLayout.emplace_back("StartCopyNo_Back_Disc_1");
     etlLayout.emplace_back("StartCopyNo_Front_Disc_2");


### PR DESCRIPTION
#### PR description:

This PR addresses the issue #47652 . The addition of the ETL scenario v10 (global scenario D119) was not properly accounted for in the acquisition of the input parameters to the ```MTDTopology```, and this causes the geometry navigation, performed during the tracking, to recursively call a method that allocates memory within 

https://github.com/cms-sw/cmssw/blob/2bed69b1658e4deeaef914e462741919e9183be3/RecoMTD/DetLayers/src/MTDDetSector.cc#L69

A similar problem happened during the development of #47353 . The comparison between enum class objects requires the ```static_cast<int>``` conversion to work properly, that was not correctly applied in ```MTDParametersFromDD```.

#### PR validation:

The update is clearly needed, it allows wf 33634.0 ~~to run smoothly in single threaded mode~~.
Repeated checks show that the initial commit do not solve the issue, neither in single nor in multi-threaded mode.