### PR TITLE
[15.0.X] Follow-up to add HLT tracking monitoring in cosmics

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -3164,7 +3164,7 @@ steps['RECOCOS_UP21']=merge([{'--conditions':'auto:phase1_2022_cosmics','-s':'RA
 steps['RECOCOS_UP21_0T']=merge([{'--magField':'0T','--conditions':'auto:phase1_2022_cosmics_0T'},steps['RECOCOS_UP21']])
 steps['RECOCOSPEAK_UP17']=merge([{'--conditions':'auto:phase1_2017_cosmics_peak','-s':'RAW2DIGI,L1Reco,RECO,ALCA:MuAlGlobalCosmics,DQM','--scenario':'cosmics','--era':'Run2_2017'},step3Up2015Hal])
 steps['RECOCOSPEAK_UP18']=merge([{'--conditions':'auto:phase1_2018_cosmics_peak','-s':'RAW2DIGI,L1Reco,RECO,ALCA:MuAlGlobalCosmics,DQM','--scenario':'cosmics','--era':'Run2_2018'},step3Up2015Hal])
-steps['RECOCOS_UP25']=merge([{'--conditions':'auto:phase1_2025_cosmics','-s':'RAW2DIGI,L1Reco,RECO,ALCA:MuAlGlobalCosmics,DQM','--scenario':'cosmics','--era':'Run3_2025'},step3Up2015Hal])
+steps['RECOCOS_UP25']=merge([{'--conditions':'auto:phase1_2025_cosmics','-s':'RAW2DIGI,L1Reco,RECO,ALCA:MuAlGlobalCosmics,DQM:@HLTMon','--scenario':'cosmics','--era':'Run3_2025'},step3Up2015Hal])
 
 steps['RECOCOS_Phase2']=merge([{'--conditions': phase2CosInfo['GT'],
                                 '-s':'RAW2DIGI,L1Reco,RECO,ALCA:MuAlGlobalCosmics',
@@ -4147,7 +4147,7 @@ steps['HARVESTCOS_UP21']={'-s'          :'HARVESTING:dqmHarvesting',
                           '--era' : 'Run3'
                           }
 
-steps['HARVESTCOS_UP25']={'-s'          :'HARVESTING:dqmHarvesting',
+steps['HARVESTCOS_UP25']={'-s'          :'HARVESTING:@HLTMon',
                           '--conditions':'auto:phase1_2024_cosmics',
                           '--mc'        :'',
                           '--filein'    :'file:step3_inDQM.root',

--- a/DQM/TrackingMonitorSource/interface/TrackToTrackComparisonHists.h
+++ b/DQM/TrackingMonitorSource/interface/TrackToTrackComparisonHists.h
@@ -103,6 +103,7 @@ protected:
 
 private:
   //  edm::ParameterSet conf_;
+  const bool isCosmics_;
   std::string topDirName_;
   double dRmin_;
   double pTCutForPlateau_;

--- a/DQM/TrackingMonitorSource/src/TrackToTrackComparisonHists.cc
+++ b/DQM/TrackingMonitorSource/src/TrackToTrackComparisonHists.cc
@@ -17,6 +17,7 @@
 TrackToTrackComparisonHists::TrackToTrackComparisonHists(const edm::ParameterSet& iConfig)
     : monitoredTrackInputTag_(iConfig.getParameter<edm::InputTag>("monitoredTrack")),
       referenceTrackInputTag_(iConfig.getParameter<edm::InputTag>("referenceTrack")),
+      isCosmics_(iConfig.getParameter<bool>("isCosmics")),
       topDirName_(iConfig.getParameter<std::string>("topDirName")),
       dRmin_(iConfig.getParameter<double>("dRmin")),
       pTCutForPlateau_(iConfig.getParameter<double>("pTCutForPlateau")),
@@ -119,15 +120,17 @@ void TrackToTrackComparisonHists::analyze(const edm::Event& iEvent, const edm::E
 
   edm::Handle<reco::VertexCollection> referencePVHandle;
   iEvent.getByToken(referencePVToken_, referencePVHandle);
-  if (!referencePVHandle.isValid()) {
+  if (!referencePVHandle.isValid() && !isCosmics_) {
     edm::LogError("TrackToTrackComparisonHists") << "referencePVHandle not found, skipping event";
     return;
   }
-  if (referencePVHandle->empty()) {
+  if (referencePVHandle->empty() && !isCosmics_) {
     edm::LogInfo("TrackToTrackComparisonHists") << "referencePVHandle->size is 0 ";
     return;
   }
-  reco::Vertex referencePV = referencePVHandle->at(0);
+  reco::Vertex referencePV = isCosmics_
+                                 ? reco::Vertex(referenceBS.position(), referenceBS.rotatedCovariance3D(), 0., 0., 0)
+                                 : referencePVHandle->at(0);
 
   //
   //  Get Monitored Track Info
@@ -151,15 +154,18 @@ void TrackToTrackComparisonHists::analyze(const edm::Event& iEvent, const edm::E
 
   edm::Handle<reco::VertexCollection> monitoredPVHandle;
   iEvent.getByToken(monitoredPVToken_, monitoredPVHandle);
-  if (!monitoredPVHandle.isValid()) {
-    edm::LogError("TrackToTrackComparisonHists") << "monitoredPVHandle not found, skipping event";
+  if (!monitoredPVHandle.isValid() && !isCosmics_) {
+    edm::LogError("TrackToTrackComparisonHists")
+        << "monitoredPVHandle not found, skipping event isCosmics value:" << isCosmics_;
     return;
   }
-  if (monitoredPVHandle->empty()) {
+  if (monitoredPVHandle->empty() && !isCosmics_) {
     edm::LogInfo("TrackToTrackComparisonHists") << "monitoredPVHandle->size is 0 ";
     return;
   }
-  reco::Vertex monitoredPV = monitoredPVHandle->at(0);
+  reco::Vertex monitoredPV = isCosmics_
+                                 ? reco::Vertex(monitoredBS.position(), monitoredBS.rotatedCovariance3D(), 0., 0., 0)
+                                 : monitoredPVHandle->at(0);
 
   edm::LogInfo("TrackToTrackComparisonHists")
       << "analyzing " << monitoredTrackInputTag_.process() << ":" << monitoredTrackInputTag_.label() << ":"
@@ -306,6 +312,7 @@ void TrackToTrackComparisonHists::fillDescriptions(edm::ConfigurationDescription
   edm::ParameterSetDescription desc;
 
   desc.add<bool>("requireValidHLTPaths", true);
+  desc.add<bool>("isCosmics", false);
 
   desc.add<edm::InputTag>("monitoredTrack", edm::InputTag("hltMergedTracks"));
   desc.add<edm::InputTag>("monitoredBeamSpot", edm::InputTag("hltOnlineBeamSpot"));

--- a/DQMOffline/Configuration/python/DQMOfflineCosmics_SecondStep_cff.py
+++ b/DQMOffline/Configuration/python/DQMOfflineCosmics_SecondStep_cff.py
@@ -95,3 +95,6 @@ DQMOfflineCosmics_SecondStep = cms.Sequence(
 DQMOfflineCosmics_SecondStep_FakeHLT = cms.Sequence(DQMOfflineCosmics_SecondStep )
 DQMOfflineCosmics_SecondStep_FakeHLT.remove( DQMOfflineCosmics_SecondStepTrigger )
 
+from DQMOffline.Trigger.TrackingMonitoringCosmics_Client_cff import *
+
+HLTMonitoringClient = cms.Sequence(trackingMonitorCosmicsClientHLT * trackEfficiencyMonitoringCosmicsClientHLT )

--- a/DQMOffline/Configuration/python/DQMOfflineCosmics_cff.py
+++ b/DQMOffline/Configuration/python/DQMOfflineCosmics_cff.py
@@ -112,4 +112,6 @@ DQMOfflineCosmics = cms.Sequence( DQMOfflineCosmicsPreDPG *
                                   DQMOfflineCosmicsPrePOG *
                                   DQMMessageLogger )
 
+HLTMonitoring = cms.Sequence( OfflineHLTMonitoring )
+
 PostDQMOffline = cms.Sequence()

--- a/DQMOffline/Trigger/python/DQMOffline_Trigger_cosmics_cff.py
+++ b/DQMOffline/Trigger/python/DQMOffline_Trigger_cosmics_cff.py
@@ -69,3 +69,9 @@ offlineHLTSource = cms.Sequence(
 
 #triggerCosmicOfflineDQMSource = cms.Sequence(onlineHLTSource*offlineHLTSource)
 triggerCosmicOfflineDQMSource = cms.Sequence(offlineHLTSource)
+
+# sequences run @tier0 on CosmicHLTMonitor PD
+OfflineHLTMonitoring = cms.Sequence(
+    cosmicTrackingMonitorHLT *
+    hltToOfflineCosmicsTrackValidatorSequence
+)

--- a/DQMOffline/Trigger/python/TrackToTrackMonitoringCosmics_cff.py
+++ b/DQMOffline/Trigger/python/TrackToTrackMonitoringCosmics_cff.py
@@ -11,7 +11,17 @@ hltCtfWithMaterialTracksP5_2_ctfWithMaterialTracksP5 = TrackToTrackComparisonHis
     referenceBeamSpot        = "offlineBeamSpot",
     topDirName               = "HLT/Tracking/ValidationWRTOffline/hltCtfWithMaterialTracksP5",
     referencePrimaryVertices = "offlinePrimaryVertices",
-    monitoredPrimaryVertices = "hltVerticesPFSelector"
+    monitoredPrimaryVertices = "hltPixelVertices",
+    isCosmics                = cms.bool(True),
+    dxyCutForPlateau         = 1e6,
+    histoPSet                = dict(
+        Dxy_rangeMin = -60,
+        Dxy_rangeMax = 60,
+        Dxy_nbin = 120,
+        Dz_rangeMin = -250,
+        Dz_rangeMax =  250,
+        Dz_nbin = 250,
+    ) 
 )
 
 hltToOfflineCosmicsTrackValidatorSequence = cms.Sequence(hltCtfWithMaterialTracksP5_2_ctfWithMaterialTracksP5)

--- a/DQMOffline/Trigger/python/TrackingMonitoringCosmics_Client_cff.py
+++ b/DQMOffline/Trigger/python/TrackingMonitoringCosmics_Client_cff.py
@@ -1,0 +1,48 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+
+from DQM.TrackingMonitorClient.TrackingEffFromHitPatternClientConfig_cff import trackingEffFromHitPattern
+
+trackingCosmicsEffFromHitPatternHLT = trackingEffFromHitPattern.clone(
+    subDirs = ["HLT/Tracking/hltCtfWithMaterialTracksP5/HitEffFromHitPattern*"]
+)
+# Sequence
+trackingMonitorCosmicsClientHLT = cms.Sequence(
+    trackingCosmicsEffFromHitPatternHLT
+)
+
+CosmicsTrackToTrackEfficiencies = DQMEDHarvester("DQMGenericClient",
+    subDirs        = cms.untracked.vstring(
+        "HLT/Tracking/ValidationWRTOffline/hltCtfWithMaterialTracksP5",
+    ),
+    verbose        = cms.untracked.uint32(0),
+    resolution     = cms.vstring(),
+    efficiency     = cms.vstring(
+        "Eff_pt              'Relative Efficiency vs Pt;#P_T;relative efficiency'               ref_matched_pt          ref_pt          eff",
+        "Eff_eta             'Relative Efficiency vs Eta;#eta;relative efficiency'              ref_matched_eta         ref_eta         eff",
+        "Eff_phi             'Relative Efficiency vs Phi;#phi;relative efficiency'              ref_matched_phi         ref_phi         eff",
+        "Eff_dxy             'Relative Efficiency vs dxy;d_{xy};relative efficiency'            ref_matched_dxy         ref_dxy         eff",
+        "Eff_dz              'Relative Efficiency vs dz;d_{z};relative efficiency'              ref_matched_dz          ref_dz          eff",
+        "Eff_dxyWRTpv        'Relative Efficiency vs dxyWRTpv;d_{xy};relative efficiency'       ref_matched_dxyWRTpv    ref_dxyWRTpv    eff",
+        "Eff_dzWRTpv         'Relative Efficiency vs dzWRTpv;d_{z};relative efficiency'         ref_matched_dzWRTpv     ref_dzWRTpv     eff",
+        "Eff_charge          'Relative Efficiency vs charge;charge;relative efficiency'         ref_matched_charge      ref_charge      eff",
+        "Eff_hits            'Relative Efficiency vs hits;number of hits;relative efficiency'   ref_matched_hits        ref_hits        eff",
+        "Eff_LS              'Relative Efficiency vs LS;LS;relative efficiency'                 ref_matched_ls          ref_ls          eff",
+
+        "FakeRate_pt         'Relative Fake Rate vs Pt;#P_T;relative fake rate'                 mon_unMatched_pt        mon_pt          eff",
+        "FakeRate_eta        'Relative Fake Rate vs Eta;#eta;relative fake rate'                mon_unMatched_eta       mon_eta         eff",
+        "FakeRate_phi        'Relative Fake Rate vs Phi;#phi;relative fake rate'                mon_unMatched_phi       mon_phi         eff",
+        "FakeRate_dxy        'Relative Fake Rate vs dxy;d_{xy};relative fake rate'              mon_unMatched_dxy       mon_dxy         eff",
+        "FakeRate_dz         'Relative Fake Rate vs dz;d_{z};relative fake rate'                mon_unMatched_dz        mon_dz          eff",
+        "FakeRate_dxyWRTpv   'Relative Fake Rate vs dxyWRTpv;d_{xy};relative fake rate'         mon_unMatched_dxyWRTpv  mon_dxyWRTpv    eff",
+        "FakeRate_dzWRTpv    'Relative Fake Rate vs dzWRTpv;d_{z};relative fake rate'           mon_unMatched_dzWRTpv   mon_dzWRTpv     eff",
+        "FakeRate_charge     'Relative Fake Rate vs charge;charge;relative fake rate'           mon_unMatched_charge    mon_charge      eff",
+        "FakeRate_hits       'Relative Fake Rate vs hits;number of hits;relative fake rate'     mon_unMatched_hits      mon_hits        eff",
+        "FakeRate_LS         'Relative Fake Rate vs LS;LS;relative fake rate'                   mon_unMatched_ls        mon_ls          eff",
+    ),
+)
+
+trackEfficiencyMonitoringCosmicsClientHLT = cms.Sequence(
+    CosmicsTrackToTrackEfficiencies
+)

--- a/DQMOffline/Trigger/python/TrackingMonitoringCosmics_cff.py
+++ b/DQMOffline/Trigger/python/TrackingMonitoringCosmics_cff.py
@@ -4,8 +4,8 @@ import FWCore.ParameterSet.Config as cms
 from DQM.TrackingMonitor.TrackerCosmicsTrackingMonitor_cfi import *
 TrackMon_cosmicTkHLT = TrackerCosmicTrackMon.clone(
     TrackProducer = 'hltCtfWithMaterialTracksP5',
-    AlgoName = 'CKFTk',
-    FolderName = 'HLT/Tracking/TrackParameters',
+    AlgoName = 'CtfWithMaterialTracksP5',
+    FolderName = 'HLT/Tracking/hltCtfWithMaterialTracksP5',
     doSeedParameterHistos = True
 )
 


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/47663

#### PR description:

This is a follow-up to PR https://github.com/cms-sw/cmssw/pull/47568 and integrates the (tracking) HLT monitoring during cosmics in the DQM Offline sequences used at Tier0 when the cosmics scenario is selected. 
This resolves issue https://github.com/cms-sw/cmssw/issues/47662.
In addition wf 7.25 that was introduced at https://github.com/cms-sw/cmssw/pull/47542 is enhanced in order to actually test the same setup that is foreseen to be used at Tier0.

#### PR validation:

Run the command:

```
runTheMatrix.py -l 7.25 -t 4 -j 8 --nEvents 100000
```

successfully and observed filled DQM plots in the output file.
Also run the following commands:

```console
cmsDriver.py step3 -s RAW2DIGI,L1Reco,RECO,ALCA:MuAlGlobalCosmics,DQM:@HLTMon --conditions 150X_dataRun3_Express_v1 --datatier GEN-SIM-RECO,DQMIO --eventcontent RECOSIM,DQM -n 1000 --era Run3_2025 --scenario cosmics --filein root://eoscms.cern.ch://eos/cms/tier0/store/data/Commissioning2025/CosmicHLTMonitor/RAW/v1/000/389/873/00000/3ea592ff-5490-47ed-8242-fff796875a01.root

cmsDriver.py step5 -s HARVESTING:@HLTMon --conditions 150X_dataRun3_Express_v1 --filein file:step3_RAW2DIGI_L1Reco_RECO_ALCA_DQM_inDQM.root --scenario cosmics --filetype DQM --era Run3_2025 -n 1000
```

and obtained the following DQM output file: https://cernbox.cern.ch/s/ez9ceBBuCEkjFr2

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport https://github.com/cms-sw/cmssw/pull/47663 of for 2025 data-taking purposes.