### PR TITLE
New PPS geometry with rotated Roman Pots for Run3 2025

### DIFF
--- a/Geometry/VeryForwardData/data/CTPPS_2025/Cuts_Per_Region/Reco/v1/RP_Cuts_Per_Region.xml
+++ b/Geometry/VeryForwardData/data/CTPPS_2025/Cuts_Per_Region/Reco/v1/RP_Cuts_Per_Region.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../DDLSchema/DDLSchema.xsd">
+  <SpecParSection label="RP_Cuts_Per_Region.xml" eval="true">
+    <SpecPar name="RP_Silicon_Detectors_Range_Cuts">
+      <PartSelector path="//RP_Silicon_Detector"/>
+      <Parameter name="CMSCutsRegion" value="RPSiliconDetectorsCuts" eval="false"/>
+      <Parameter name="ProdCutsForElectrons" value="0.1*mm"/>
+      <Parameter name="ProdCutsForPositrons" value="0.1*mm"/>
+      <Parameter name="ProdCutsForGamma" value="0.1*mm"/>
+    </SpecPar>
+    <SpecPar name="RP_Roman_Pot_parts">
+      <PartSelector path="//RP_PCB"/>
+      <PartSelector path="//.*:RP_bottom_foil"/>
+      <PartSelector path="//.*:RP_bottom_wall_6"/>
+      <PartSelector path="//.*:RP_front_wall_6"/>
+      <PartSelector path="//.*:RP_Left_Right_Wall"/>
+      <PartSelector path="//RP_Front_Frame_3"/>
+      <PartSelector path="//RP_Back_Frame_3"/>
+      <PartSelector path="//RP_Barrette_Left"/>
+      <PartSelector path="//RP_Barrette_Right"/>
+      <Parameter name="CMSCutsRegion" value="RPRomanPotParts" eval="false"/>
+      <Parameter name="ProdCutsForElectrons" value="1*mm"/>
+      <Parameter name="ProdCutsForPositrons" value="1*mm"/>
+      <Parameter name="ProdCutsForGamma" value="10*mm"/>
+    </SpecPar>
+    <SpecPar name="RP_Other_Det_Parts_Range_Cuts">
+      <PartSelector path="//RP_Device_Vert_Corp_3"/>
+      <PartSelector path="//RP_Device_Hor_Corp_3"/>
+      <PartSelector path="//RP_220_Right_Station_Tube_5"/>
+      <PartSelector path="//RP_220_Right_Station_Tube_4"/>
+      <PartSelector path="//RP_220_Right_Station_Tube_3"/>
+      <PartSelector path="//RP_220_Right_Station_Tube_2"/>
+      <PartSelector path="//RP_220_Right_Station_Tube_1"/>
+      <PartSelector path="//RP_220_Left_Station_Tube_5"/>
+      <PartSelector path="//RP_220_Left_Station_Tube_4"/>
+      <PartSelector path="//RP_220_Left_Station_Tube_3"/>
+      <PartSelector path="//RP_220_Left_Station_Tube_2"/>
+      <PartSelector path="//RP_220_Left_Station_Tube_1"/>
+      <PartSelector path="//RP_210_Right_Station_Tube_5"/>
+      <PartSelector path="//RP_210_Right_Station_Tube_4"/>
+      <PartSelector path="//RP_210_Right_Station_Tube_3"/>
+      <PartSelector path="//RP_210_Right_Station_Tube_2"/>
+      <PartSelector path="//RP_210_Right_Station_Tube_1"/>
+      <PartSelector path="//RP_210_Left_Station_Tube_5"/>
+      <PartSelector path="//RP_210_Left_Station_Tube_4"/>
+      <PartSelector path="//RP_210_Left_Station_Tube_3"/>
+      <PartSelector path="//RP_210_Left_Station_Tube_2"/>
+      <PartSelector path="//RP_210_Left_Station_Tube_1"/>
+      <Parameter name="CMSCutsRegion" value="RPOtherDetPartsCuts" eval="false"/>
+      <Parameter name="ProdCutsForElectrons" value="10*mm"/>
+      <Parameter name="ProdCutsForPositrons" value="10*mm"/>
+      <Parameter name="ProdCutsForGamma" value="100*mm"/>
+    </SpecPar>
+    <SpecPar name="RP_Non_dense_materials_cuts">
+      <PartSelector path="//.*:RP_box_primary_vacuum"/>
+      <PartSelector path="//.*:RP_box_secondary_vacuum"/>
+      <PartSelector path="//RP_220_Right_Station_Vacuum_5"/>
+      <PartSelector path="//RP_220_Left_Station_Vacuum_5"/>
+      <PartSelector path="//RP_210_Right_Station_Vacuum_5"/>
+      <PartSelector path="//RP_210_Left_Station_Vacuum_5"/>
+      <Parameter name="CMSCutsRegion" value="RP_NonDenseMaterialsCuts" eval="false"/>
+      <Parameter name="ProdCutsForElectrons" value="50*m"/>
+      <Parameter name="ProdCutsForPositrons" value="50*m"/>
+      <Parameter name="ProdCutsForGamma" value="50*m"/>
+    </SpecPar>
+  </SpecParSection>
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/CTPPS_2025/Cuts_Per_Region/Simu/v1/CTPPS_Cuts_Per_Region.xml
+++ b/Geometry/VeryForwardData/data/CTPPS_2025/Cuts_Per_Region/Simu/v1/CTPPS_Cuts_Per_Region.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../DDLSchema/DDLSchema.xsd">
+  <SpecParSection label="RP_Cuts_Per_Region.xml" eval="true">
+    <SpecPar name="RP_Silicon_Detectors_Range_Cuts">
+      <PartSelector path="//RP_Silicon_Detector"/>
+      <Parameter name="CMSCutsRegion" value="RPSiliconDetectorsCuts" eval="false"/>
+      <Parameter name="ProdCutsForElectrons" value="0.1*mm"/>
+      <Parameter name="ProdCutsForPositrons" value="0.1*mm"/>
+      <Parameter name="ProdCutsForGamma" value="0.1*mm"/>
+    </SpecPar>
+    <SpecPar name="RP_Roman_Pot_parts">
+      <PartSelector path="//RP_PCB"/>
+      <PartSelector path="//.*:RP_bottom_foil"/>
+      <PartSelector path="//.*:RP_bottom_wall_6"/>
+      <PartSelector path="//.*:RP_front_wall_6"/>
+      <PartSelector path="//.*:RP_Left_Right_Wall"/>
+      <PartSelector path="//RP_Front_Frame_3"/>
+      <PartSelector path="//RP_Back_Frame_3"/>
+      <PartSelector path="//RP_Barrette_Left"/>
+      <PartSelector path="//RP_Barrette_Right"/>
+      <Parameter name="CMSCutsRegion" value="RPRomanPotParts" eval="false"/>
+      <Parameter name="ProdCutsForElectrons" value="1*mm"/>
+      <Parameter name="ProdCutsForPositrons" value="1*mm"/>
+      <Parameter name="ProdCutsForGamma" value="10*mm"/>
+    </SpecPar>
+    <SpecPar name="RP_Other_Det_Parts_Range_Cuts">
+      <PartSelector path="//RP_Device_Vert_Corp_3"/>
+      <PartSelector path="//RP_Device_Hor_Corp_3"/>
+      <PartSelector path="//RP_220_Right_Station_Tube_5"/>
+      <PartSelector path="//RP_220_Right_Station_Tube_4"/>
+      <PartSelector path="//RP_220_Right_Station_Tube_3a"/>
+      <PartSelector path="//RP_220_Right_Station_Tube_3b"/>
+      <PartSelector path="//RP_220_Right_Station_Tube_2"/>
+      <PartSelector path="//RP_220_Right_Station_Tube_1"/>
+      <PartSelector path="//RP_220_Left_Station_Tube_5"/>
+      <PartSelector path="//RP_220_Left_Station_Tube_4"/>
+      <PartSelector path="//RP_220_Left_Station_Tube_3a"/>
+      <PartSelector path="//RP_220_Left_Station_Tube_3b"/>
+      <PartSelector path="//RP_220_Left_Station_Tube_2"/>
+      <PartSelector path="//RP_220_Left_Station_Tube_1"/>
+      <PartSelector path="//RP_210_Right_Station_Tube_5"/>
+      <PartSelector path="//RP_210_Right_Station_Tube_4"/>
+      <PartSelector path="//RP_210_Right_Station_Tube_3"/>
+      <PartSelector path="//RP_210_Right_Station_Tube_2"/>
+      <PartSelector path="//RP_210_Right_Station_Tube_1"/>
+      <PartSelector path="//RP_210_Left_Station_Tube_5"/>
+      <PartSelector path="//RP_210_Left_Station_Tube_4"/>
+      <PartSelector path="//RP_210_Left_Station_Tube_3"/>
+      <PartSelector path="//RP_210_Left_Station_Tube_2"/>
+      <PartSelector path="//RP_210_Left_Station_Tube_1"/>
+      <Parameter name="CMSCutsRegion" value="RPOtherDetPartsCuts" eval="false"/>
+      <Parameter name="ProdCutsForElectrons" value="10*mm"/>
+      <Parameter name="ProdCutsForPositrons" value="10*mm"/>
+      <Parameter name="ProdCutsForGamma" value="100*mm"/>
+    </SpecPar>
+    <SpecPar name="RP_Non_dense_materials_cuts">
+      <PartSelector path="//.*:RP_box_primary_vacuum"/>
+      <PartSelector path="//.*:RP_box_secondary_vacuum"/>
+      <PartSelector path="//RP_220_Right_Station_Vacuum_5"/>
+      <PartSelector path="//RP_220_Left_Station_Vacuum_5"/>
+      <PartSelector path="//RP_210_Right_Station_Vacuum_5"/>
+      <PartSelector path="//RP_210_Left_Station_Vacuum_5"/>
+      <Parameter name="CMSCutsRegion" value="RP_NonDenseMaterialsCuts" eval="false"/>
+      <Parameter name="ProdCutsForElectrons" value="50*m"/>
+      <Parameter name="ProdCutsForPositrons" value="50*m"/>
+      <Parameter name="ProdCutsForGamma" value="50*m"/>
+    </SpecPar>
+  </SpecParSection>
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/CTPPS_2025/RP_Dist_Beam_Cent/Reco/v1/RP_Dist_Beam_Cent.xml
+++ b/Geometry/VeryForwardData/data/CTPPS_2025/RP_Dist_Beam_Cent/Reco/v1/RP_Dist_Beam_Cent.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../DDLSchema/DDLSchema.xsd">
+    <ConstantsSection label="RP_Dist_Beam_Cent.xml" eval="true">
+        <!-- sector 45, 210m station -->
+        <Constant name="RP_210_Left_Det_Dist_0" value="7*mm"/>
+        <Constant name="RP_210_Left_Det_Dist_1" value="7*mm"/>
+        <Constant name="RP_210_Left_Det_Dist_2" value="2*mm"/>
+        <Constant name="RP_210_Left_Det_Dist_3" value="2*mm"/>
+        <Constant name="RP_210_Left_Det_Dist_4" value="7*mm"/>
+        <Constant name="RP_210_Left_Det_Dist_5" value="7*mm"/>
+
+        <!-- sector 45, 220m station -->
+        <Constant name="RP_220_Left_Det_Dist_0" value="7*mm"/>
+        <Constant name="RP_220_Left_Det_Dist_1" value="7*mm"/>
+        <Constant name="RP_220_Left_Det_Dist_2" value="2*mm"/>
+        <Constant name="RP_220_Left_Det_Dist_3" value="2*mm"/>
+        <Constant name="RP_220_Left_Det_Dist_4" value="7*mm"/>
+        <Constant name="RP_220_Left_Det_Dist_5" value="7*mm"/>
+
+        <!-- sector 56, 210m station -->
+        <Constant name="RP_210_Right_Det_Dist_0" value="7*mm"/>
+        <Constant name="RP_210_Right_Det_Dist_1" value="7*mm"/>
+        <Constant name="RP_210_Right_Det_Dist_2" value="2*mm"/>
+        <Constant name="RP_210_Right_Det_Dist_3" value="2*mm"/>
+        <Constant name="RP_210_Right_Det_Dist_4" value="7*mm"/>
+        <Constant name="RP_210_Right_Det_Dist_5" value="7*mm"/>
+
+        <!-- sector 56, 220m station -->
+        <Constant name="RP_220_Right_Det_Dist_0" value="7*mm"/>
+        <Constant name="RP_220_Right_Det_Dist_1" value="7*mm"/>
+        <Constant name="RP_220_Right_Det_Dist_2" value="2*mm"/>
+        <Constant name="RP_220_Right_Det_Dist_3" value="2*mm"/>
+        <Constant name="RP_220_Right_Det_Dist_4" value="7*mm"/>
+        <Constant name="RP_220_Right_Det_Dist_5" value="7*mm"/>
+
+        <!-- sector 45, diamond station -->
+        <Constant name="CTPPS_45_Det_Dist" value="2*mm"/>
+
+        <!-- sector 56, diamond station -->
+        <Constant name="CTPPS_56_Det_Dist" value="2*mm"/>
+    </ConstantsSection>
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/CTPPS_2025/RP_Dist_Beam_Cent/Simu/v1/RP_Dist_Beam_Cent.xml
+++ b/Geometry/VeryForwardData/data/CTPPS_2025/RP_Dist_Beam_Cent/Simu/v1/RP_Dist_Beam_Cent.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../DDLSchema/DDLSchema.xsd">
+    <ConstantsSection label="RP_Dist_Beam_Cent.xml" eval="true">
+        <!-- sector 45, 210m station -->
+        <Constant name="RP_210_Left_Det_Dist_0" value="7*mm"/>
+        <Constant name="RP_210_Left_Det_Dist_1" value="7*mm"/>
+        <Constant name="RP_210_Left_Det_Dist_2" value="2*mm"/>
+        <Constant name="RP_210_Left_Det_Dist_3" value="2*mm"/>
+        <Constant name="RP_210_Left_Det_Dist_4" value="7*mm"/>
+        <Constant name="RP_210_Left_Det_Dist_5" value="7*mm"/>
+
+        <!-- sector 45, 220m station -->
+        <Constant name="RP_220_Left_Det_Dist_0" value="7*mm"/>
+        <Constant name="RP_220_Left_Det_Dist_1" value="7*mm"/>
+        <Constant name="RP_220_Left_Det_Dist_2" value="2*mm"/>
+        <Constant name="RP_220_Left_Det_Dist_3" value="2*mm"/>
+        <Constant name="RP_220_Left_Det_Dist_4" value="7*mm"/>
+        <Constant name="RP_220_Left_Det_Dist_5" value="7*mm"/>
+
+        <!-- sector 56, 210m station -->
+        <Constant name="RP_210_Right_Det_Dist_0" value="7*mm"/>
+        <Constant name="RP_210_Right_Det_Dist_1" value="7*mm"/>
+        <Constant name="RP_210_Right_Det_Dist_2" value="2*mm"/>
+        <Constant name="RP_210_Right_Det_Dist_3" value="2*mm"/>
+        <Constant name="RP_210_Right_Det_Dist_4" value="7*mm"/>
+        <Constant name="RP_210_Right_Det_Dist_5" value="7*mm"/>
+
+        <!-- sector 56, 220m station -->
+        <Constant name="RP_220_Right_Det_Dist_0" value="7*mm"/>
+        <Constant name="RP_220_Right_Det_Dist_1" value="7*mm"/>
+        <Constant name="RP_220_Right_Det_Dist_2" value="2*mm"/>
+        <Constant name="RP_220_Right_Det_Dist_3" value="2*mm"/>
+        <Constant name="RP_220_Right_Det_Dist_4" value="7*mm"/>
+        <Constant name="RP_220_Right_Det_Dist_5" value="7*mm"/>
+
+        <!-- sector 45, diamond station -->
+        <Constant name="CTPPS_45_Det_Dist" value="2*mm"/>
+
+        <!-- sector 56, diamond station -->
+        <Constant name="CTPPS_56_Det_Dist" value="2*mm"/>
+    </ConstantsSection>
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/CTPPS_2025/RP_Param_Beam_Region/v1/RP_Param_Beam_Region.xml
+++ b/Geometry/VeryForwardData/data/CTPPS_2025/RP_Param_Beam_Region/v1/RP_Param_Beam_Region.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+
+<ConstantsSection label="RP_Param_Beam_Region.xml" eval="true">
+ <Constant name="Dummy" value="250*m"/>
+</ConstantsSection>
+
+<SolidSection label="RP_Param_Beam_Region.xml">
+ <Polycone name="Beam_IP_150_R" startPhi="0*deg" deltaPhi="360*deg" >
+  <ZSection z="[cms:HallZ]" rMin="[cms:Rmin]" rMax="[cms:HallR]"/>
+  <ZSection z="[RP_Stations_Assembly:RP_210_Right_Station_Position_z]" rMin="[cms:Rmin]" rMax="[cms:HallR]"/>
+ </Polycone> 
+ <Polycone name="Beam_IP_150_L" startPhi="0*deg" deltaPhi="360*deg" >
+  <ZSection z="-[cms:HallZ]" rMin="[cms:Rmin]" rMax="[cms:HallR]"/>
+  <ZSection z="[RP_Stations_Assembly:RP_210_Left_Station_Position_z]" rMin="[cms:Rmin]" rMax="[cms:HallR]"/>
+ </Polycone> 
+</SolidSection>
+
+<LogicalPartSection label="RP_Param_Beam_Region.xml">
+ <LogicalPart name="Beam_IP_150_R" category="unspecified">
+  <rSolid name="Beam_IP_150_R"/>
+  <rMaterial name="materials:Vacuum"/>
+ </LogicalPart>
+ <LogicalPart name="Beam_IP_150_L" category="unspecified">
+  <rSolid name="Beam_IP_150_L"/>
+  <rMaterial name="materials:Vacuum"/>
+ </LogicalPart>
+</LogicalPartSection>
+
+<PosPartSection label="RP_Param_Beam_Region.xml">
+ <PosPart copyNumber="1">
+  <rParent name="cms:CMSE"/>
+  <rChild name="Beam_IP_150_R"/>
+ </PosPart>
+ <PosPart copyNumber="1">
+  <rParent name="cms:CMSE"/>
+  <rChild name="Beam_IP_150_L"/>
+ </PosPart>
+</PosPartSection>
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/CTPPS_2025/Stations/Reco/v1/RP_210_Left_Station.xml
+++ b/Geometry/VeryForwardData/data/CTPPS_2025/Stations/Reco/v1/RP_210_Left_Station.xml
@@ -1,0 +1,249 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../DDLSchema/DDLSchema.xsd">
+    <ConstantsSection label="RP_210_Left_Station.xml" eval="true">
+        <Constant name="RP_210_Left_Station_Length" value="-([RP_Stations_Assembly:RP_220_Left_Station_Position_z]-[RP_Stations_Assembly:RP_210_Left_Station_Position_z])"/>
+        <!--Positions calculated from the wall closer to IP point-->
+        <Constant name="RP_210_Left_Prim_Vert_z" value="608*mm"/>
+        <Constant name="RP_210_Left_Prim_Hor_z" value="1058*mm"/>
+        <Constant name="RP_210_Left_Sec_Hor_z" value="9781*mm"/>
+        <Constant name="RP_210_Left_Sec_Vert_z" value="10231*mm"/>
+
+        <Constant name="RP_210_Left_Sec_Rot_Angle" value="27*deg"/>
+        
+        <Constant name="RP_210_Left_Hor_Vac_Length" value="[RP_Device:RP_Device_Envelope_Radius]+[RP_Device:RP_Device_Length_y]/2-[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int]"/>
+    </ConstantsSection>
+
+    <RotationSection label="RP_210_Left_Station.xml">
+      <Rotation name="RP_210_Left_Sec_Rotation" 
+		phiX="[RP_210_Left_Sec_Rot_Angle]" thetaX="90*deg" 
+		phiY="90*deg+[RP_210_Left_Sec_Rot_Angle]" thetaY="90*deg"
+		phiZ="0*deg" thetaZ="0*deg"/>
+      <!--
+      <Rotation name="RP_210_Left_minus_Sec_Rotation" 
+		phiX="-[RP_210_Left_Sec_Rot_Angle]" thetaX="90*deg" 
+		phiY="90*deg-[RP_210_Left_Sec_Rot_Angle]" thetaY="90*deg"
+		phiZ="0*deg" thetaZ="0*deg"/>
+      -->
+            <Rotation name="RP_210_Left_minus_Sec_Rotation" 
+		phiX="-[RP_210_Left_Sec_Rot_Angle]" thetaX="(90+180)*deg" 
+		phiY="90*deg-[RP_210_Left_Sec_Rot_Angle]" thetaY="90*deg"
+		phiZ="0*deg" thetaZ="180*deg"/>
+      <Rotation name="RP_210_Left_180_minus_Sec_Rotation" 
+		phiX="-[RP_210_Left_Sec_Rot_Angle]" thetaX="90*deg" 
+		phiY="(-90)*deg-[RP_210_Left_Sec_Rot_Angle]" thetaY="90*deg"
+		phiZ="0*deg" thetaZ="180*deg"/>
+
+      <!-- if angle = 0 RP_Transformations:RP_y_90_rot -->
+      <Rotation name="RP_210_Left_90_y_plus_Sec_Rotation"
+		phiX="0*deg" thetaX="180*deg" 
+		phiY="90*deg+[RP_210_Left_Sec_Rot_Angle]" thetaY="90*deg" 
+		phiZ="0*deg+[RP_210_Left_Sec_Rot_Angle]" thetaZ="90*deg"/>
+
+      <!-- if angle = 0 RP_Transformations:RP_x_90_rot -->	
+      <Rotation name="RP_210_Left_90_x_plus_Sec_Rotation"
+		phiX="0*deg+[RP_210_Left_Sec_Rot_Angle]" thetaX="90*deg" 
+		phiY="0*deg" thetaY="180*deg" 
+		phiZ="90*deg+[RP_210_Left_Sec_Rot_Angle]" thetaZ="90*deg"/>
+      
+      <!-- if angle = 0 RP_Transformations:RP_x_90_rot -->
+      <Rotation name="RP_210_Left_90_x_minus_Sec_Rotation"
+		phiX="0*deg-[RP_210_Left_Sec_Rot_Angle]" thetaX="90*deg" 
+		phiY="0*deg" thetaY="180*deg" 
+		phiZ="90*deg-[RP_210_Left_Sec_Rot_Angle]" thetaZ="90*deg"/>
+    </RotationSection>
+    
+    <SolidSection label="RP_210_Left_Station.xml">  
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_Envelope_Radius]*1.1" dz="[RP_210_Left_Station_Length]/2" name="RP_210_Left_Station"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_210_Left_Prim_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2" name="RP_210_Left_Station_Tube_1"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_210_Left_Prim_Hor_z]-[RP_210_Left_Prim_Vert_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_210_Left_Station_Tube_2"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_210_Left_Sec_Hor_z]-[RP_210_Left_Prim_Hor_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_210_Left_Station_Tube_3"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_210_Left_Sec_Vert_z]-[RP_210_Left_Sec_Hor_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_210_Left_Station_Tube_4"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_210_Left_Station_Length]-[RP_210_Left_Sec_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2" name="RP_210_Left_Station_Tube_5"/>
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2" dz="[RP_210_Left_Station_Length]/2" name="RP_210_Left_Station_Vacuum_1"/>
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2" dz="[RP_Device:RP_Device_Envelope_Radius]" name="RP_210_Left_Station_Vert_Vacuum"/>
+        <UnionSolid name="RP_210_Left_Station_Vacuum_2">
+            <rSolid name="RP_210_Left_Station_Vacuum_1"/>
+            <rSolid name="RP_210_Left_Station_Vert_Vacuum"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Left_Station_Length]/2+[RP_210_Left_Prim_Vert_z])"/>
+        </UnionSolid>
+        <UnionSolid name="RP_210_Left_Station_Vacuum_3">
+            <rSolid name="RP_210_Left_Station_Vacuum_2"/>
+            <rSolid name="RP_210_Left_Station_Vert_Vacuum"/>
+	    <!-- <rRotation name="RP_210_Left_90_x_plus_Sec_Rotation"/> -->
+	    <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Left_Station_Length]/2+[RP_210_Left_Sec_Vert_z])"/>
+        </UnionSolid>
+        <Polycone name="RP_210_Left_Station_Hor_Vacuum" startPhi="0*deg" deltaPhi="360*deg" >
+            <ZSection z="-[RP_Device:RP_Device_Length_y]/2+[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int]" rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2"/>
+            <ZSection z="-[RP_Device:RP_Device_Length_y]/2+[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int] + [RP_210_Left_Hor_Vac_Length]" rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2"/>
+        </Polycone> 
+        <UnionSolid name="RP_210_Left_Station_Vacuum_4">
+            <rSolid name="RP_210_Left_Station_Vacuum_3"/>
+            <rSolid name="RP_210_Left_Station_Hor_Vacuum"/>
+            <rRotation name="RP_Transformations:RP_y_90_rot"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Left_Station_Length]/2+[RP_210_Left_Prim_Hor_z])"/>
+        </UnionSolid>
+        <UnionSolid name="RP_210_Left_Station_Vacuum_5">
+            <rSolid name="RP_210_Left_Station_Vacuum_4"/>
+            <rSolid name="RP_210_Left_Station_Hor_Vacuum"/>
+            <rRotation name="RP_210_Left_90_y_plus_Sec_Rotation"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Left_Station_Length]/2+[RP_210_Left_Sec_Hor_z])"/>
+        </UnionSolid>
+
+        <Polycone name="RP_210_Left_Station_Vacuum_1_Far" startPhi="0*deg" deltaPhi="360*deg" >
+            <ZSection z="0*mm" rMin="0*mm" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2"/>
+            <ZSection z="-([RP_210_Left_Station_Length]/2)" rMin="0*mm" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2"/>
+        </Polycone> 
+        <UnionSolid name="RP_210_Left_Station_Vacuum_2_Far">
+            <rSolid name="RP_210_Left_Station_Vacuum_1_Far"/>
+            <rSolid name="RP_210_Left_Station_Vert_Vacuum"/>
+	    <!--   <rRotation name="RP_Transformations:RP_x_90_rot"/> -->
+            <rRotation name="RP_210_Left_90_x_minus_Sec_Rotation"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Left_Station_Length]/2+[RP_210_Left_Sec_Vert_z])"/>
+        </UnionSolid>
+        <UnionSolid name="RP_210_Left_Station_Vacuum_3_Far">
+            <rSolid name="RP_210_Left_Station_Vacuum_2_Far"/>
+            <rSolid name="RP_210_Left_Station_Hor_Vacuum"/>
+            <rRotation name="RP_Transformations:RP_y_90_rot"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Left_Station_Length]/2+[RP_210_Left_Sec_Hor_z])"/>
+        </UnionSolid>
+    </SolidSection>
+    
+    <LogicalPartSection label="RP_210_Left_Station.xml">
+        <LogicalPart name="RP_210_Left_Station">
+            <rSolid name="RP_210_Left_Station"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Left_Station_Tube_1">
+            <rSolid name="RP_210_Left_Station_Tube_1"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Left_Station_Tube_2">
+            <rSolid name="RP_210_Left_Station_Tube_2"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Left_Station_Tube_3">
+            <rSolid name="RP_210_Left_Station_Tube_3"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Left_Station_Tube_4">
+            <rSolid name="RP_210_Left_Station_Tube_4"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Left_Station_Tube_5">
+            <rSolid name="RP_210_Left_Station_Tube_5"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Left_Station_Vacuum_5">
+            <rSolid name="RP_210_Left_Station_Vacuum_5"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Left_Station_Vacuum_3_Far">
+            <rSolid name="RP_210_Left_Station_Vacuum_3_Far"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    
+    <PosPartSection label="RP_210_Left_Station.xml">
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Left_Station"/>
+            <rChild name="RP_Vertical_Device:RP_Device_Vert_Corp_3"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Left_Station_Length]/2+[RP_210_Left_Prim_Vert_z])"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="RP_210_Left_Station"/>
+            <rChild name="RP_Vertical_Device:RP_Device_Vert_Corp_3"/>
+            <!-- <rRotation name="RP_210_Left_Sec_Rotation"/> -->
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Left_Station_Length]/2+[RP_210_Left_Sec_Vert_z])"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Left_Station"/>
+            <rChild name="RP_Horizontal_Device:RP_Device_Hor_Corp_3"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Left_Station_Length]/2+[RP_210_Left_Prim_Hor_z])"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="RP_210_Left_Station"/>
+            <rChild name="RP_Horizontal_Device:RP_Device_Hor_Corp_3"/>
+            <rRotation name="RP_210_Left_Sec_Rotation"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Left_Station_Length]/2+[RP_210_Left_Sec_Hor_z])"/>
+        </PosPart>
+        
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Left_Station"/>
+            <rChild name="RP_210_Left_Station_Tube_1"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Left_Station_Length]/2+([RP_210_Left_Prim_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Left_Station"/>
+            <rChild name="RP_210_Left_Station_Tube_2"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Left_Station_Length]/2+([RP_210_Left_Prim_Vert_z]+[RP_210_Left_Prim_Hor_z])/2)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Left_Station"/>
+            <rChild name="RP_210_Left_Station_Tube_3"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Left_Station_Length]/2+([RP_210_Left_Prim_Hor_z]+[RP_210_Left_Sec_Hor_z])/2)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Left_Station"/>
+            <rChild name="RP_210_Left_Station_Tube_4"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Left_Station_Length]/2+([RP_210_Left_Sec_Hor_z]+[RP_210_Left_Sec_Vert_z])/2)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Left_Station"/>
+            <rChild name="RP_210_Left_Station_Tube_5"/>
+            <Translation x="0*mm" y="0*mm" z="-([RP_210_Left_Station_Length]/2-([RP_210_Left_Station_Length]-[RP_210_Left_Sec_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Left_Station"/>
+            <rChild name="RP_210_Left_Station_Vacuum_5"/>
+        </PosPart>
+
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Left_Station_Vacuum_5"/>
+            <rChild name="RP_210_Left_Station_Vacuum_3_Far"/>
+            <rRotation name="RP_210_Left_Sec_Rotation"/>
+        </PosPart>
+        
+        <PosPart copyNumber="0">
+            <rParent name="RP_210_Left_Station_Vacuum_5"/>
+            <rChild name="RP_Box_000:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_y_180_rot"/>
+            <Translation x="0*mm" y="[RP_Dist_Beam_Cent:RP_210_Left_Det_Dist_0]+[RP_Box:RP_Box_primary_vacuum_y]/2" z="-([RP_210_Left_Prim_Vert_z]-[RP_210_Left_Station_Length]/2)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Left_Station_Vacuum_5"/>
+            <rChild name="RP_Box_001:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_180_z_180_y_rot"/>
+            <Translation x="0*mm" y="-[RP_Dist_Beam_Cent:RP_210_Left_Det_Dist_1]-[RP_Box:RP_Box_primary_vacuum_y]/2" z="-([RP_210_Left_Prim_Vert_z]-[RP_210_Left_Station_Length]/2)"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="RP_210_Left_Station_Vacuum_5"/>
+            <rChild name="RP_Box_002:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_90_z_cw_180_y_rot"/>
+            <Translation x="-(-[RP_Dist_Beam_Cent:RP_210_Left_Det_Dist_2]-[RP_Box:RP_Box_primary_vacuum_y]/2)" y="0*mm" z="-([RP_210_Left_Prim_Hor_z]-[RP_210_Left_Station_Length]/2)"/>
+        </PosPart>
+        <PosPart copyNumber="10003">
+            <rParent name="RP_210_Left_Station_Vacuum_3_Far"/>
+            <rChild name="RP_Box_003:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_90_z_cw_180_y_rot"/>
+            <Translation x="-(-[RP_Dist_Beam_Cent:RP_210_Left_Det_Dist_3]-[RP_Box:RP_Box_primary_vacuum_y]/2)" y="0*mm" z="-([RP_210_Left_Sec_Hor_z]-[RP_210_Left_Station_Length]/2)"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="RP_210_Left_Station_Vacuum_3_Far"/>
+            <rChild name="RP_Box_004:RP_box_primary_vacuum"/>
+	    <!-- <rRotation name="RP_Transformations:RP_y_180_rot" -->
+	    <rRotation name="RP_210_Left_minus_Sec_Rotation"/>
+            <Translation x="0*mm" y="[RP_Dist_Beam_Cent:RP_210_Left_Det_Dist_4]+[RP_Box:RP_Box_primary_vacuum_y]/2" z="-([RP_210_Left_Sec_Vert_z]-[RP_210_Left_Station_Length]/2)"/>
+        </PosPart>
+        <PosPart copyNumber="5">
+            <rParent name="RP_210_Left_Station_Vacuum_3_Far"/>
+            <rChild name="RP_Box_005:RP_box_primary_vacuum"/>
+	    <!--  sformations:RP_180_z_180_y_rot -->
+	    <rRotation name="RP_210_Left_180_minus_Sec_Rotation"/>	    
+            <Translation x="0*mm" y="-[RP_Dist_Beam_Cent:RP_210_Left_Det_Dist_5]-[RP_Box:RP_Box_primary_vacuum_y]/2" z="-([RP_210_Left_Sec_Vert_z]-[RP_210_Left_Station_Length]/2)"/>
+        </PosPart>
+    </PosPartSection>
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/CTPPS_2025/Stations/Reco/v1/RP_210_Right_Station.xml
+++ b/Geometry/VeryForwardData/data/CTPPS_2025/Stations/Reco/v1/RP_210_Right_Station.xml
@@ -1,0 +1,241 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../DDLSchema/DDLSchema.xsd">
+    <ConstantsSection label="RP_210_Right_Station.xml" eval="true">
+        <Constant name="RP_210_Right_Station_Length" value="[RP_Stations_Assembly:RP_220_Right_Station_Position_z]-[RP_Stations_Assembly:RP_210_Right_Station_Position_z]"/>
+        <!--Positions calculated from the wall closer to IP point-->
+        <Constant name="RP_210_Right_Prim_Vert_z" value="608*mm"/>
+        <Constant name="RP_210_Right_Prim_Hor_z" value="1058*mm"/>
+        <Constant name="RP_210_Right_Sec_Hor_z" value="9781*mm"/>
+        <Constant name="RP_210_Right_Sec_Vert_z" value="10231*mm"/>
+
+        <Constant name="RP_210_Right_Sec_Rot_Angle" value="27*deg"/>
+        
+        <Constant name="RP_210_Right_Hor_Vac_Length" value="[RP_Device:RP_Device_Envelope_Radius]+[RP_Device:RP_Device_Length_y]/2-[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int]"/>
+    </ConstantsSection>
+
+    <RotationSection label="RP_210_Right_Station.xml">
+      <Rotation name="RP_210_Right_Sec_Rotation" 
+		phiX="[RP_210_Right_Sec_Rot_Angle]" thetaX="90*deg" 
+		phiY="90*deg+[RP_210_Right_Sec_Rot_Angle]" thetaY="90*deg"
+		phiZ="0*deg" thetaZ="0*deg"/>
+      <Rotation name="RP_210_Right_minus_Sec_Rotation" 
+		phiX="-[RP_210_Right_Sec_Rot_Angle]" thetaX="90*deg" 
+		phiY="90*deg-[RP_210_Right_Sec_Rot_Angle]" thetaY="90*deg"
+		phiZ="0*deg" thetaZ="0*deg"/>
+      <Rotation name="RP_210_Right_180_minus_Sec_Rotation" 
+		phiX="180*deg-[RP_210_Right_Sec_Rot_Angle]" thetaX="90*deg" 
+		phiY="270*deg-[RP_210_Right_Sec_Rot_Angle]" thetaY="90*deg"
+		phiZ="0*deg" thetaZ="0*deg"/>
+
+      <!-- if angle = 0 RP_Transformations:RP_y_90_rot -->
+      <Rotation name="RP_210_Right_90_y_plus_Sec_Rotation"
+		phiX="0*deg" thetaX="180*deg" 
+		phiY="90*deg+[RP_210_Right_Sec_Rot_Angle]" thetaY="90*deg" 
+		phiZ="0*deg+[RP_210_Right_Sec_Rot_Angle]" thetaZ="90*deg"/>
+
+      <!-- if angle = 0 RP_Transformations:RP_x_90_rot -->	
+      <Rotation name="RP_210_Right_90_x_plus_Sec_Rotation"
+		phiX="0*deg+[RP_210_Right_Sec_Rot_Angle]" thetaX="90*deg" 
+		phiY="0*deg" thetaY="180*deg" 
+		phiZ="90*deg+[RP_210_Right_Sec_Rot_Angle]" thetaZ="90*deg"/>
+      
+      <!-- if angle = 0 RP_Transformations:RP_x_90_rot -->
+      <Rotation name="RP_210_Right_90_x_minus_Sec_Rotation"
+		phiX="0*deg-[RP_210_Right_Sec_Rot_Angle]" thetaX="90*deg" 
+		phiY="0*deg" thetaY="180*deg" 
+		phiZ="90*deg-[RP_210_Right_Sec_Rot_Angle]" thetaZ="90*deg"/>
+    </RotationSection>
+    
+    <SolidSection label="RP_210_Right_Station.xml">  
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_Envelope_Radius]*1.1" dz="[RP_210_Right_Station_Length]/2" name="RP_210_Right_Station"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_210_Right_Prim_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2" name="RP_210_Right_Station_Tube_1"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_210_Right_Prim_Hor_z]-[RP_210_Right_Prim_Vert_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_210_Right_Station_Tube_2"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_210_Right_Sec_Hor_z]-[RP_210_Right_Prim_Hor_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_210_Right_Station_Tube_3"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_210_Right_Sec_Vert_z]-[RP_210_Right_Sec_Hor_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_210_Right_Station_Tube_4"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_210_Right_Station_Length]-[RP_210_Right_Sec_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2" name="RP_210_Right_Station_Tube_5"/>
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2" dz="[RP_210_Right_Station_Length]/2" name="RP_210_Right_Station_Vacuum_1"/>
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2" dz="[RP_Device:RP_Device_Envelope_Radius]" name="RP_210_Right_Station_Vert_Vacuum"/>
+        <UnionSolid name="RP_210_Right_Station_Vacuum_2">
+            <rSolid name="RP_210_Right_Station_Vacuum_1"/>
+            <rSolid name="RP_210_Right_Station_Vert_Vacuum"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Right_Station_Length]/2+[RP_210_Right_Prim_Vert_z]"/>
+        </UnionSolid>
+        <UnionSolid name="RP_210_Right_Station_Vacuum_3">
+            <rSolid name="RP_210_Right_Station_Vacuum_2"/>
+            <rSolid name="RP_210_Right_Station_Vert_Vacuum"/>
+            <!-- <rRotation name="RP_210_Right_90_x_plus_Sec_Rotation"/> -->
+	    <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Right_Station_Length]/2+[RP_210_Right_Sec_Vert_z]"/>
+        </UnionSolid>
+        <Polycone name="RP_210_Right_Station_Hor_Vacuum" startPhi="0*deg" deltaPhi="360*deg" >
+            <ZSection z="-[RP_Device:RP_Device_Length_y]/2+[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int]" rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2"/>
+            <ZSection z="-[RP_Device:RP_Device_Length_y]/2+[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int] + [RP_210_Right_Hor_Vac_Length]" rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2"/>
+        </Polycone> 
+        <UnionSolid name="RP_210_Right_Station_Vacuum_4">
+            <rSolid name="RP_210_Right_Station_Vacuum_3"/>
+            <rSolid name="RP_210_Right_Station_Hor_Vacuum"/>
+            <rRotation name="RP_Transformations:RP_y_90_rot"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Right_Station_Length]/2+[RP_210_Right_Prim_Hor_z]"/>
+        </UnionSolid>
+        <UnionSolid name="RP_210_Right_Station_Vacuum_5">
+            <rSolid name="RP_210_Right_Station_Vacuum_4"/>
+            <rSolid name="RP_210_Right_Station_Hor_Vacuum"/>
+            <rRotation name="RP_210_Right_90_y_plus_Sec_Rotation"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Right_Station_Length]/2+[RP_210_Right_Sec_Hor_z]"/>
+        </UnionSolid>
+
+        <Polycone name="RP_210_Right_Station_Vacuum_1_Far" startPhi="0*deg" deltaPhi="360*deg" >
+            <ZSection z="0*mm" rMin="0*mm" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2"/>
+            <ZSection z="[RP_210_Right_Station_Length]/2" rMin="0*mm" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2"/>
+        </Polycone> 
+        <UnionSolid name="RP_210_Right_Station_Vacuum_2_Far">
+            <rSolid name="RP_210_Right_Station_Vacuum_1_Far"/>
+            <rSolid name="RP_210_Right_Station_Vert_Vacuum"/>
+	    <!--   <rRotation name="RP_Transformations:RP_x_90_rot"/> -->
+            <rRotation name="RP_210_Right_90_x_minus_Sec_Rotation"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Right_Station_Length]/2+[RP_210_Right_Sec_Vert_z]"/>
+        </UnionSolid>
+        <UnionSolid name="RP_210_Right_Station_Vacuum_3_Far">
+            <rSolid name="RP_210_Right_Station_Vacuum_2_Far"/>
+            <rSolid name="RP_210_Right_Station_Hor_Vacuum"/>
+            <rRotation name="RP_Transformations:RP_y_90_rot"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Right_Station_Length]/2+[RP_210_Right_Sec_Hor_z]"/>
+        </UnionSolid>
+    </SolidSection>
+    
+    <LogicalPartSection label="RP_210_Right_Station.xml">
+        <LogicalPart name="RP_210_Right_Station">
+            <rSolid name="RP_210_Right_Station"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Right_Station_Tube_1">
+            <rSolid name="RP_210_Right_Station_Tube_1"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Right_Station_Tube_2">
+            <rSolid name="RP_210_Right_Station_Tube_2"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Right_Station_Tube_3">
+            <rSolid name="RP_210_Right_Station_Tube_3"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Right_Station_Tube_4">
+            <rSolid name="RP_210_Right_Station_Tube_4"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Right_Station_Tube_5">
+            <rSolid name="RP_210_Right_Station_Tube_5"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Right_Station_Vacuum_5">
+            <rSolid name="RP_210_Right_Station_Vacuum_5"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Right_Station_Vacuum_3_Far">
+            <rSolid name="RP_210_Right_Station_Vacuum_3_Far"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    
+    <PosPartSection label="RP_210_Right_Station.xml">
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_Vertical_Device:RP_Device_Vert_Corp_3"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Right_Station_Length]/2+[RP_210_Right_Prim_Vert_z]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_Vertical_Device:RP_Device_Vert_Corp_3"/>
+	    <!-- <rRotation name="RP_210_Right_Sec_Rotation"/> -->
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Right_Station_Length]/2+[RP_210_Right_Sec_Vert_z]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_Horizontal_Device:RP_Device_Hor_Corp_3"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Right_Station_Length]/2+[RP_210_Right_Prim_Hor_z]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_Horizontal_Device:RP_Device_Hor_Corp_3"/>
+            <rRotation name="RP_210_Right_Sec_Rotation"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Right_Station_Length]/2+[RP_210_Right_Sec_Hor_z]"/>
+        </PosPart>
+        
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_210_Right_Station_Tube_1"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Right_Station_Length]/2+([RP_210_Right_Prim_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_210_Right_Station_Tube_2"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Right_Station_Length]/2+([RP_210_Right_Prim_Vert_z]+[RP_210_Right_Prim_Hor_z])/2"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_210_Right_Station_Tube_3"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Right_Station_Length]/2+([RP_210_Right_Prim_Hor_z]+[RP_210_Right_Sec_Hor_z])/2"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_210_Right_Station_Tube_4"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Right_Station_Length]/2+([RP_210_Right_Sec_Hor_z]+[RP_210_Right_Sec_Vert_z])/2"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_210_Right_Station_Tube_5"/>
+            <Translation x="0*mm" y="0*mm" z="[RP_210_Right_Station_Length]/2-([RP_210_Right_Station_Length]-[RP_210_Right_Sec_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_210_Right_Station_Vacuum_5"/>
+        </PosPart>
+
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Right_Station_Vacuum_5"/>
+            <rChild name="RP_210_Right_Station_Vacuum_3_Far"/>
+            <rRotation name="RP_210_Right_Sec_Rotation"/>
+        </PosPart>
+        
+        <PosPart copyNumber="100">
+            <rParent name="RP_210_Right_Station_Vacuum_5"/>
+            <rChild name="RP_Box_100:RP_box_primary_vacuum"/>
+            <Translation x="0*mm" y="[RP_Dist_Beam_Cent:RP_210_Right_Det_Dist_0]+[RP_Box:RP_Box_primary_vacuum_y]/2" z="[RP_210_Right_Prim_Vert_z]-[RP_210_Right_Station_Length]/2"/>
+        </PosPart>
+        <PosPart copyNumber="101">
+            <rParent name="RP_210_Right_Station_Vacuum_5"/>
+            <rChild name="RP_Box_101:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_z_180_rot"/>
+            <Translation x="0*mm" y="-[RP_Dist_Beam_Cent:RP_210_Right_Det_Dist_1]-[RP_Box:RP_Box_primary_vacuum_y]/2" z="[RP_210_Right_Prim_Vert_z]-[RP_210_Right_Station_Length]/2"/>
+        </PosPart>
+        <PosPart copyNumber="102">
+            <rParent name="RP_210_Right_Station_Vacuum_5"/>
+            <rChild name="RP_Box_102:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_90_cw_z_rot"/>
+            <Translation x="-(-[RP_Dist_Beam_Cent:RP_210_Right_Det_Dist_2]-[RP_Box:RP_Box_primary_vacuum_y]/2)" y="0*mm" z="[RP_210_Right_Prim_Hor_z]-[RP_210_Right_Station_Length]/2"/>
+        </PosPart>
+        <PosPart copyNumber="10103">
+            <rParent name="RP_210_Right_Station_Vacuum_3_Far"/>
+            <rChild name="RP_Box_103:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_90_cw_z_rot"/>
+            <Translation x="-(-[RP_Dist_Beam_Cent:RP_210_Right_Det_Dist_3]-[RP_Box:RP_Box_primary_vacuum_y]/2)" y="0*mm" z="[RP_210_Right_Sec_Hor_z]-[RP_210_Right_Station_Length]/2"/>
+        </PosPart>
+        <PosPart copyNumber="104">
+            <rParent name="RP_210_Right_Station_Vacuum_3_Far"/>
+            <rChild name="RP_Box_104:RP_box_primary_vacuum"/>
+	    <rRotation name="RP_210_Right_minus_Sec_Rotation"/>
+            <Translation x="0*mm" y="[RP_Dist_Beam_Cent:RP_210_Right_Det_Dist_4]+[RP_Box:RP_Box_primary_vacuum_y]/2" z="[RP_210_Right_Sec_Vert_z]-[RP_210_Right_Station_Length]/2"/>
+        </PosPart>
+        <PosPart copyNumber="105">
+            <rParent name="RP_210_Right_Station_Vacuum_3_Far"/>
+            <rChild name="RP_Box_105:RP_box_primary_vacuum"/>
+	    <!--   <rRotation name="RP_Transformations:RP_z_180_rot"/> -->
+	    <rRotation name="RP_210_Right_180_minus_Sec_Rotation"/>
+            <Translation x="0*mm" y="-[RP_Dist_Beam_Cent:RP_210_Right_Det_Dist_5]-[RP_Box:RP_Box_primary_vacuum_y]/2" z="[RP_210_Right_Sec_Vert_z]-[RP_210_Right_Station_Length]/2"/>
+        </PosPart>
+    </PosPartSection>
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/CTPPS_2025/Stations/Reco/v1/RP_220_Left_Station.xml
+++ b/Geometry/VeryForwardData/data/CTPPS_2025/Stations/Reco/v1/RP_220_Left_Station.xml
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../DDLSchema/DDLSchema.xsd">
+  <ConstantsSection label="RP_220_Left_Station.xml" eval="true">
+    <Constant name="RP_220_Left_Station_Length" value="6588*mm"/>
+    <!--Positions calculated from the wall closer to IP point-->
+    <Constant name="RP_220_Left_Prim_Vert_z" value="608*mm"/>
+    <Constant name="RP_220_Left_Prim_Hor_z" value="1058*mm"/>
+    <Constant name="RP_220_Left_Sec_Hor_z" value="5530*mm"/>
+    <Constant name="RP_220_Left_Sec_Vert_z" value="5980*mm"/>
+    <Constant name="RP_220_Left_Hor_Vac_Length" value="[RP_Device:RP_Device_Envelope_Radius]+[RP_Device:RP_Device_Length_y]/2-[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int]"/>
+
+    <Constant name="RP_220_Left_Rot_Angle" value="27*deg"/>
+    
+  </ConstantsSection>
+
+  <RotationSection label="RP_220_Left_Station.xml">
+    <Rotation name="RP_220_Left_Rotation" 
+	      phiX="[RP_220_Left_Rot_Angle]" thetaX="90*deg" 
+	      phiY="90*deg+[RP_220_Left_Rot_Angle]" thetaY="90*deg"
+	      phiZ="0*deg" thetaZ="0*deg"/>
+    <!-- if angle = 0 RP_Transformations:RP_90_cw_z_rot -->
+    <Rotation name="RP_220_Left_90_custom_z_cw_180_y_rot" phiX="90*deg+[RP_220_Left_Rot_Angle]" thetaX="90*deg"
+	      phiY="0*deg+[RP_220_Left_Rot_Angle]" thetaY="90*deg"
+              phiZ="0*deg" thetaZ="180*deg"/>
+  </RotationSection>
+  
+  <SolidSection label="RP_220_Left_Station.xml">
+    <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_Envelope_Radius]*1.1" dz="[RP_220_Left_Station_Length]/2" name="RP_220_Left_Station"/>
+    <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_220_Left_Prim_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2" name="RP_220_Left_Station_Tube_1"/>
+    <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_220_Left_Prim_Hor_z]-[RP_220_Left_Prim_Vert_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_220_Left_Station_Tube_2"/>
+    <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_220_Left_Sec_Hor_z]-[RP_220_Left_Prim_Hor_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_220_Left_Station_Tube_3"/>
+    <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_220_Left_Sec_Vert_z]-[RP_220_Left_Sec_Hor_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_220_Left_Station_Tube_4"/>
+    <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_220_Left_Station_Length]-[RP_220_Left_Sec_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2" name="RP_220_Left_Station_Tube_5"/>
+    <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2" dz="[RP_220_Left_Station_Length]/2" name="RP_220_Left_Station_Vacuum_1"/>
+    <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2" dz="[RP_Device:RP_Device_Envelope_Radius]" name="RP_220_Left_Station_Vert_Vacuum"/>
+    <UnionSolid name="RP_220_Left_Station_Vacuum_2">
+      <rSolid name="RP_220_Left_Station_Vacuum_1"/>
+      <rSolid name="RP_220_Left_Station_Vert_Vacuum"/>
+      <rRotation name="RP_Transformations:RP_x_90_rot"/>
+      <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Left_Station_Length]/2+[RP_220_Left_Prim_Vert_z])"/>
+    </UnionSolid>
+    <UnionSolid name="RP_220_Left_Station_Vacuum_3">
+      <rSolid name="RP_220_Left_Station_Vacuum_2"/>
+      <rSolid name="RP_220_Left_Station_Vert_Vacuum"/>
+      <rRotation name="RP_Transformations:RP_x_90_rot"/>
+      <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Left_Station_Length]/2+[RP_220_Left_Sec_Vert_z])"/>
+    </UnionSolid>
+    <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2" dz="[RP_220_Left_Hor_Vac_Length]/2" name="RP_220_Left_Station_Hor_Vacuum"/>
+    <UnionSolid name="RP_220_Left_Station_Vacuum_4">
+      <rSolid name="RP_220_Left_Station_Vacuum_3"/>
+      <rSolid name="RP_220_Left_Station_Hor_Vacuum"/>
+      <rRotation name="RP_Transformations:RP_y_90_rot"/>
+      <Translation x="-(-[RP_220_Left_Hor_Vac_Length]/2+[RP_Device:RP_Device_Length_y]/2-[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int])" y="0*mm" z="-(-[RP_220_Left_Station_Length]/2+[RP_220_Left_Prim_Hor_z])"/>
+    </UnionSolid>
+    <UnionSolid name="RP_220_Left_Station_Vacuum_5">
+      <rSolid name="RP_220_Left_Station_Vacuum_4"/>
+      <rSolid name="RP_220_Left_Station_Hor_Vacuum"/>
+      <rRotation name="RP_Transformations:RP_y_90_rot"/>
+      <Translation x="-(-[RP_220_Left_Hor_Vac_Length]/2+[RP_Device:RP_Device_Length_y]/2-[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int])" y="0*mm" z="-(-[RP_220_Left_Station_Length]/2+[RP_220_Left_Sec_Hor_z])"/>
+    </UnionSolid>
+  </SolidSection>
+  <LogicalPartSection label="RP_220_Left_Station.xml">
+    <LogicalPart name="RP_220_Left_Station">
+      <rSolid name="RP_220_Left_Station"/>
+      <rMaterial name="materials:Air"/>
+    </LogicalPart>
+    <LogicalPart name="RP_220_Left_Station_Tube_1">
+      <rSolid name="RP_220_Left_Station_Tube_1"/>
+      <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+    </LogicalPart>
+    <LogicalPart name="RP_220_Left_Station_Tube_2">
+      <rSolid name="RP_220_Left_Station_Tube_2"/>
+      <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+    </LogicalPart>
+    <LogicalPart name="RP_220_Left_Station_Tube_3">
+      <rSolid name="RP_220_Left_Station_Tube_3"/>
+      <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+    </LogicalPart>
+    <LogicalPart name="RP_220_Left_Station_Tube_4">
+      <rSolid name="RP_220_Left_Station_Tube_4"/>
+      <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+    </LogicalPart>
+    <LogicalPart name="RP_220_Left_Station_Tube_5">
+      <rSolid name="RP_220_Left_Station_Tube_5"/>
+      <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+    </LogicalPart>
+    <LogicalPart name="RP_220_Left_Station_Vacuum_5">
+      <rSolid name="RP_220_Left_Station_Vacuum_5"/>
+      <rMaterial name="materials:Vacuum"/>
+    </LogicalPart>
+  </LogicalPartSection>
+  <PosPartSection label="RP_220_Left_Station.xml">
+    <PosPart copyNumber="1">
+      <rParent name="RP_220_Left_Station"/>
+      <rChild name="RP_Vertical_Device:RP_Device_Vert_Corp_3"/>
+      <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Left_Station_Length]/2+[RP_220_Left_Prim_Vert_z])"/>
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="RP_220_Left_Station"/>
+      <rChild name="RP_Vertical_Device:RP_Device_Vert_Corp_3"/>
+      <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Left_Station_Length]/2+[RP_220_Left_Sec_Vert_z])"/>
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="RP_220_Left_Station"/>
+      <rChild name="RP_Horizontal_Device:RP_Device_Hor_Corp_3"/>
+      <!--    -->
+      <rRotation name="RP_220_Left_Rotation"/>
+      <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Left_Station_Length]/2+[RP_220_Left_Prim_Hor_z])"/>
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="RP_220_Left_Station"/>
+      <rChild name="RP_Horizontal_Device:RP_Device_Hor_Corp_3"/>
+      <!--    -->
+      <rRotation name="RP_220_Left_Rotation"/>
+      <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Left_Station_Length]/2+[RP_220_Left_Sec_Hor_z])"/>
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="RP_220_Left_Station"/>
+      <rChild name="RP_220_Left_Station_Tube_1"/>
+      <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Left_Station_Length]/2+([RP_220_Left_Prim_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2)"/>
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="RP_220_Left_Station"/>
+      <rChild name="RP_220_Left_Station_Tube_2"/>
+      <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Left_Station_Length]/2+([RP_220_Left_Prim_Vert_z]+[RP_220_Left_Prim_Hor_z])/2)"/>
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="RP_220_Left_Station"/>
+      <rChild name="RP_220_Left_Station_Tube_4"/>
+      <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Left_Station_Length]/2+([RP_220_Left_Sec_Hor_z]+[RP_220_Left_Sec_Vert_z])/2)"/>
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="RP_220_Left_Station"/>
+      <rChild name="RP_220_Left_Station_Tube_5"/>
+      <Translation x="0*mm" y="0*mm" z="-([RP_220_Left_Station_Length]/2-([RP_220_Left_Station_Length]-[RP_220_Left_Sec_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2)"/>
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="RP_220_Left_Station"/>
+      <rChild name="RP_220_Left_Station_Vacuum_5"/>
+    </PosPart>
+    <PosPart copyNumber="20">
+      <rParent name="RP_220_Left_Station_Vacuum_5"/>
+      <rChild name="RP_Box_020:RP_box_primary_vacuum"/>
+      <rRotation name="RP_Transformations:RP_y_180_rot"/>
+      <Translation x="0*mm" y="[RP_Dist_Beam_Cent:RP_220_Left_Det_Dist_0]+[RP_Box:RP_Box_primary_vacuum_y]/2" z="-([RP_220_Left_Prim_Vert_z]-[RP_220_Left_Station_Length]/2)"/>
+    </PosPart>
+    <PosPart copyNumber="21">
+      <rParent name="RP_220_Left_Station_Vacuum_5"/>
+      <rChild name="RP_Box_021:RP_box_primary_vacuum"/>
+      <rRotation name="RP_Transformations:RP_180_z_180_y_rot"/>
+      <Translation x="0*mm" y="-[RP_Dist_Beam_Cent:RP_220_Left_Det_Dist_1]-[RP_Box:RP_Box_primary_vacuum_y]/2" z="-([RP_220_Left_Prim_Vert_z]-[RP_220_Left_Station_Length]/2)"/>
+    </PosPart>
+    <PosPart copyNumber="10023">
+      <!-- the offset 10^4 indicates pixel RP -->
+      <rParent name="RP_220_Left_Station_Vacuum_5"/>
+      <rChild name="RP_Box_023:RP_box_primary_vacuum"/>
+      <rRotation name="RP_220_Left_90_custom_z_cw_180_y_rot"/>
+      <Translation x="-(-[RP_Dist_Beam_Cent:RP_220_Left_Det_Dist_3]-[RP_Box:RP_Box_primary_vacuum_y]/2)*cos([RP_220_Left_Rot_Angle])" y="-(-[RP_Dist_Beam_Cent:RP_220_Left_Det_Dist_3]-[RP_Box:RP_Box_primary_vacuum_y]/2)*sin([RP_220_Left_Rot_Angle])" z="-([RP_220_Left_Sec_Hor_z]-[RP_220_Left_Station_Length]/2)"/> 
+    </PosPart>
+    <PosPart copyNumber="24">
+      <rParent name="RP_220_Left_Station_Vacuum_5"/>
+      <rChild name="RP_Box_024:RP_box_primary_vacuum"/>
+      <rRotation name="RP_Transformations:RP_y_180_rot"/>
+      <Translation x="0*mm" y="[RP_Dist_Beam_Cent:RP_220_Left_Det_Dist_4]+[RP_Box:RP_Box_primary_vacuum_y]/2" z="-([RP_220_Left_Sec_Vert_z]-[RP_220_Left_Station_Length]/2)"/>
+    </PosPart>
+    <PosPart copyNumber="25">
+      <rParent name="RP_220_Left_Station_Vacuum_5"/>
+      <rChild name="RP_Box_025:RP_box_primary_vacuum"/>
+      <rRotation name="RP_Transformations:RP_180_z_180_y_rot"/>
+      <Translation x="0*mm" y="-[RP_Dist_Beam_Cent:RP_220_Left_Det_Dist_5]-[RP_Box:RP_Box_primary_vacuum_y]/2" z="-([RP_220_Left_Sec_Vert_z]-[RP_220_Left_Station_Length]/2)"/>
+    </PosPart>
+  </PosPartSection>
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/CTPPS_2025/Stations/Reco/v1/RP_220_Right_Station.xml
+++ b/Geometry/VeryForwardData/data/CTPPS_2025/Stations/Reco/v1/RP_220_Right_Station.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../DDLSchema/DDLSchema.xsd">
+  <ConstantsSection label="RP_220_Right_Station.xml" eval="true">
+    <Constant name="RP_220_Right_Station_Length" value="6588*mm"/>
+    <!--Positions calculated from the wall closer to IP point-->
+    <Constant name="RP_220_Right_Prim_Vert_z" value="608*mm"/>
+    <Constant name="RP_220_Right_Prim_Hor_z" value="1058*mm"/>
+    <Constant name="RP_220_Right_Sec_Hor_z" value="5530*mm"/>
+    <Constant name="RP_220_Right_Sec_Vert_z" value="5980*mm"/>
+
+    <Constant name="RP_220_Right_Rot_Angle" value="27*deg"/>
+
+    <Constant name="RP_220_Right_Hor_Vac_Length" value="[RP_Device:RP_Device_Envelope_Radius]+[RP_Device:RP_Device_Length_y]/2-[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int]"/>
+  </ConstantsSection>
+
+  <RotationSection label="RP_220_Right_Station.xml">
+    <Rotation name="RP_220_Right_Rotation" 
+	      phiX="[RP_220_Right_Rot_Angle]" thetaX="90*deg" 
+	      phiY="90*deg+[RP_220_Right_Rot_Angle]" thetaY="90*deg"
+	      phiZ="0*deg" thetaZ="0*deg"/>
+    <!-- if angle = 0 RP_Transformations:RP_90_cw_z_rot -->
+    <Rotation name="RP_220_Right_90_custom_cw_z_rot" phiX="-90*deg+[RP_220_Right_Rot_Angle]" thetaX="90*deg"
+	      phiY="0*deg+[RP_220_Right_Rot_Angle]" thetaY="90*deg"
+              phiZ="0*deg" thetaZ="0*deg"/>
+  </RotationSection>
+
+   <SolidSection label="RP_220_Right_Station.xml">
+    <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_Envelope_Radius]*1.1" dz="[RP_220_Right_Station_Length]/2" name="RP_220_Right_Station"/>
+    <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_220_Right_Prim_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2" name="RP_220_Right_Station_Tube_1"/>
+    <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_220_Right_Prim_Hor_z]-[RP_220_Right_Prim_Vert_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_220_Right_Station_Tube_2"/>
+    <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_220_Right_Sec_Hor_z]-[RP_220_Right_Prim_Hor_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_220_Right_Station_Tube_3"/>
+    <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_220_Right_Sec_Vert_z]-[RP_220_Right_Sec_Hor_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_220_Right_Station_Tube_4"/>
+    <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_220_Right_Station_Length]-[RP_220_Right_Sec_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2" name="RP_220_Right_Station_Tube_5"/>
+    <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2" dz="[RP_220_Right_Station_Length]/2" name="RP_220_Right_Station_Vacuum_1"/>
+    <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2" dz="[RP_Device:RP_Device_Envelope_Radius]" name="RP_220_Right_Station_Vert_Vacuum"/>
+    <UnionSolid name="RP_220_Right_Station_Vacuum_2">
+      <rSolid name="RP_220_Right_Station_Vacuum_1"/>
+      <rSolid name="RP_220_Right_Station_Vert_Vacuum"/>
+      <rRotation name="RP_Transformations:RP_x_90_rot"/>
+      <Translation x="0*mm" y="0*mm" z="-[RP_220_Right_Station_Length]/2+[RP_220_Right_Prim_Vert_z]"/>
+    </UnionSolid>
+    <UnionSolid name="RP_220_Right_Station_Vacuum_3">
+      <rSolid name="RP_220_Right_Station_Vacuum_2"/>
+      <rSolid name="RP_220_Right_Station_Vert_Vacuum"/>
+      <rRotation name="RP_Transformations:RP_x_90_rot"/>
+      <Translation x="0*mm" y="0*mm" z="-[RP_220_Right_Station_Length]/2+[RP_220_Right_Sec_Vert_z]"/>
+    </UnionSolid>
+    <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2" dz="[RP_220_Right_Hor_Vac_Length]/2" name="RP_220_Right_Station_Hor_Vacuum"/>
+    <UnionSolid name="RP_220_Right_Station_Vacuum_4">
+      <rSolid name="RP_220_Right_Station_Vacuum_3"/>
+      <rSolid name="RP_220_Right_Station_Hor_Vacuum"/>
+      <rRotation name="RP_Transformations:RP_y_90_rot"/>
+      <Translation x="-(-[RP_220_Right_Hor_Vac_Length]/2+[RP_Device:RP_Device_Length_y]/2-[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int])" y="0*mm" z="-[RP_220_Right_Station_Length]/2+[RP_220_Right_Prim_Hor_z]"/>
+    </UnionSolid>
+    <UnionSolid name="RP_220_Right_Station_Vacuum_5">
+      <rSolid name="RP_220_Right_Station_Vacuum_4"/>
+      <rSolid name="RP_220_Right_Station_Hor_Vacuum"/>
+      <rRotation name="RP_Transformations:RP_y_90_rot"/> 
+      <Translation x="-(-[RP_220_Right_Hor_Vac_Length]/2+[RP_Device:RP_Device_Length_y]/2-[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int])" y="0*mm" z="-[RP_220_Right_Station_Length]/2+[RP_220_Right_Sec_Hor_z]"/>
+    </UnionSolid>
+  </SolidSection>
+  <LogicalPartSection label="RP_220_Right_Station.xml">
+    <LogicalPart name="RP_220_Right_Station">
+      <rSolid name="RP_220_Right_Station"/>
+      <rMaterial name="materials:Air"/>
+    </LogicalPart>
+    <LogicalPart name="RP_220_Right_Station_Tube_1">
+      <rSolid name="RP_220_Right_Station_Tube_1"/>
+      <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+    </LogicalPart>
+    <LogicalPart name="RP_220_Right_Station_Tube_2">
+      <rSolid name="RP_220_Right_Station_Tube_2"/>
+      <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+    </LogicalPart>
+    <LogicalPart name="RP_220_Right_Station_Tube_3">
+      <rSolid name="RP_220_Right_Station_Tube_3"/>
+      <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+    </LogicalPart>
+    <LogicalPart name="RP_220_Right_Station_Tube_4">
+      <rSolid name="RP_220_Right_Station_Tube_4"/>
+      <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+    </LogicalPart>
+    <LogicalPart name="RP_220_Right_Station_Tube_5">
+      <rSolid name="RP_220_Right_Station_Tube_5"/>
+      <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+    </LogicalPart>
+    <LogicalPart name="RP_220_Right_Station_Vacuum_5">
+      <rSolid name="RP_220_Right_Station_Vacuum_5"/>
+      <rMaterial name="materials:Vacuum"/>
+    </LogicalPart>
+  </LogicalPartSection>
+  <PosPartSection label="RP_220_Right_Station.xml">
+    <PosPart copyNumber="1">
+      <rParent name="RP_220_Right_Station"/>
+      <rChild name="RP_Vertical_Device:RP_Device_Vert_Corp_3"/>
+      <Translation x="0*mm" y="0*mm" z="-[RP_220_Right_Station_Length]/2+[RP_220_Right_Prim_Vert_z]"/>
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="RP_220_Right_Station"/>
+      <rChild name="RP_Vertical_Device:RP_Device_Vert_Corp_3"/>
+      <Translation x="0*mm" y="0*mm" z="-[RP_220_Right_Station_Length]/2+[RP_220_Right_Sec_Vert_z]"/>
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="RP_220_Right_Station"/>
+      <rChild name="RP_Horizontal_Device:RP_Device_Hor_Corp_3"/>
+      <!--    -->
+      <rRotation name="RP_220_Right_Rotation"/>
+      <Translation x="0*mm" y="0*mm" z="-[RP_220_Right_Station_Length]/2+[RP_220_Right_Prim_Hor_z]"/>
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="RP_220_Right_Station"/>
+      <rChild name="RP_Horizontal_Device:RP_Device_Hor_Corp_3"/>
+      <!--    -->
+      <rRotation name="RP_220_Right_Rotation"/>
+      <Translation x="0*mm" y="0*mm" z="-[RP_220_Right_Station_Length]/2+[RP_220_Right_Sec_Hor_z]"/>
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="RP_220_Right_Station"/>
+      <rChild name="RP_220_Right_Station_Tube_1"/>
+      <Translation x="0*mm" y="0*mm" z="-[RP_220_Right_Station_Length]/2+([RP_220_Right_Prim_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2"/>
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="RP_220_Right_Station"/>
+      <rChild name="RP_220_Right_Station_Tube_2"/>
+      <Translation x="0*mm" y="0*mm" z="-[RP_220_Right_Station_Length]/2+([RP_220_Right_Prim_Vert_z]+[RP_220_Right_Prim_Hor_z])/2"/>
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="RP_220_Right_Station"/>
+      <rChild name="RP_220_Right_Station_Tube_4"/>
+      <Translation x="0*mm" y="0*mm" z="-[RP_220_Right_Station_Length]/2+([RP_220_Right_Sec_Hor_z]+[RP_220_Right_Sec_Vert_z])/2"/>
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="RP_220_Right_Station"/>
+      <rChild name="RP_220_Right_Station_Tube_5"/>
+      <Translation x="0*mm" y="0*mm" z="[RP_220_Right_Station_Length]/2-([RP_220_Right_Station_Length]-[RP_220_Right_Sec_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2"/>
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="RP_220_Right_Station"/>
+      <rChild name="RP_220_Right_Station_Vacuum_5"/>
+    </PosPart>
+    <PosPart copyNumber="120">
+      <rParent name="RP_220_Right_Station_Vacuum_5"/>
+      <rChild name="RP_Box_120:RP_box_primary_vacuum"/>
+      <Translation x="0*mm" y="[RP_Dist_Beam_Cent:RP_220_Right_Det_Dist_0]+[RP_Box:RP_Box_primary_vacuum_y]/2" z="[RP_220_Right_Prim_Vert_z]-[RP_220_Right_Station_Length]/2"/>
+    </PosPart>
+    <PosPart copyNumber="121">
+      <rParent name="RP_220_Right_Station_Vacuum_5"/>
+      <rChild name="RP_Box_121:RP_box_primary_vacuum"/>
+      <rRotation name="RP_Transformations:RP_z_180_rot"/>
+      <Translation x="0*mm" y="-[RP_Dist_Beam_Cent:RP_220_Right_Det_Dist_1]-[RP_Box:RP_Box_primary_vacuum_y]/2" z="[RP_220_Right_Prim_Vert_z]-[RP_220_Right_Station_Length]/2"/>
+    </PosPart>
+    <PosPart copyNumber="10123">
+      <!-- the offset 10^4 indicates pixel RP -->
+      <rParent name="RP_220_Right_Station_Vacuum_5"/>
+      <rChild name="RP_Box_123:RP_box_primary_vacuum"/>
+      <!-- <rRotation name="RP_Transformations:RP_90_cw_z_rot"/> -->
+      <rRotation name="RP_220_Right_90_custom_cw_z_rot"/>
+      <Translation x="-(-[RP_Dist_Beam_Cent:RP_220_Right_Det_Dist_3]-[RP_Box:RP_Box_primary_vacuum_y]/2)*cos([RP_220_Right_Rot_Angle])" y="-(-[RP_Dist_Beam_Cent:RP_220_Right_Det_Dist_3]-[RP_Box:RP_Box_primary_vacuum_y]/2)*sin([RP_220_Right_Rot_Angle])" z="[RP_220_Right_Sec_Hor_z]-[RP_220_Right_Station_Length]/2"/>
+    </PosPart>
+    <PosPart copyNumber="124">
+      <rParent name="RP_220_Right_Station_Vacuum_5"/>
+      <rChild name="RP_Box_124:RP_box_primary_vacuum"/>
+      <Translation x="0*mm" y="[RP_Dist_Beam_Cent:RP_220_Right_Det_Dist_4]+[RP_Box:RP_Box_primary_vacuum_y]/2" z="[RP_220_Right_Sec_Vert_z]-[RP_220_Right_Station_Length]/2"/>
+    </PosPart>
+    <PosPart copyNumber="125">
+      <rParent name="RP_220_Right_Station_Vacuum_5"/>
+      <rChild name="RP_Box_125:RP_box_primary_vacuum"/>
+      <rRotation name="RP_Transformations:RP_z_180_rot"/>
+      <Translation x="0*mm" y="-[RP_Dist_Beam_Cent:RP_220_Right_Det_Dist_5]-[RP_Box:RP_Box_primary_vacuum_y]/2" z="[RP_220_Right_Sec_Vert_z]-[RP_220_Right_Station_Length]/2"/>
+    </PosPart>
+  </PosPartSection>
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/CTPPS_2025/Stations/Reco/v1/RP_Stations_Assembly.xml
+++ b/Geometry/VeryForwardData/data/CTPPS_2025/Stations/Reco/v1/RP_Stations_Assembly.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../DDLSchema/DDLSchema.xsd">
+    <ConstantsSection label="RP_Stations_Assembly.xml" eval="true">
+        <!--positions of the stations from the IP5 to the first element of the station-->
+        <Constant name="RP_210_Left_Station_Position_z" value="-202769*mm"/>
+        <Constant name="RP_210_Right_Station_Position_z" value="202769*mm"/>
+        <Constant name="RP_220_Left_Station_Position_z" value="-214020*mm"/>
+        <Constant name="RP_220_Right_Station_Position_z" value="214020*mm"/>
+        <!-- +-1500 mm for the two 220 m stations outside the IP-->
+    </ConstantsSection>
+    
+    <PosPartSection label="RP_Stations_Assembly.xml">
+<!--todo if we remove this the alignment module hangs forever-->
+        <PosPart copyNumber="1">
+            <rParent name="cms:CMSE"/>
+            <rChild name="RP_220_Right_Station:RP_220_Right_Station"/>
+            <Translation x="0*mm" y="0*mm" z="[RP_220_Right_Station_Position_z]+[RP_220_Right_Station:RP_220_Right_Station_Length]/2"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="cms:CMSE"/>
+            <rChild name="RP_220_Left_Station:RP_220_Left_Station"/>
+            <Translation x="0*mm" y="0*mm" z="[RP_220_Left_Station_Position_z]-[RP_220_Left_Station:RP_220_Left_Station_Length]/2"/>
+        </PosPart>
+<!---->
+        <PosPart copyNumber="1">
+            <rParent name="cms:CMSE"/>
+            <rChild name="RP_210_Right_Station:RP_210_Right_Station"/>
+            <Translation x="0*mm" y="0*mm" z="[RP_210_Right_Station_Position_z]+[RP_210_Right_Station:RP_210_Right_Station_Length]/2"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="cms:CMSE"/>
+            <rChild name="RP_210_Left_Station:RP_210_Left_Station"/>
+            <Translation x="0*mm" y="0*mm" z="[RP_210_Left_Station_Position_z]-[RP_210_Left_Station:RP_210_Left_Station_Length]/2"/>
+        </PosPart>
+    </PosPartSection>
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/CTPPS_2025/Stations/Simu/v1/CTPPS_210_Left_Station.xml
+++ b/Geometry/VeryForwardData/data/CTPPS_2025/Stations/Simu/v1/CTPPS_210_Left_Station.xml
@@ -1,0 +1,257 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition>
+    <ConstantsSection label="CTPPS_210_Left_Station.xml" eval="true">
+        <Constant name="RP_210_Left_Station_Length" value="[CTPPS_Stations_Assembly:CTPPS_220_Left_Station_Position_z]-[CTPPS_Stations_Assembly:CTPPS_210_Left_Station_Position_z]"/>
+        <!--Positions calculated from the wall closer to IP point-->
+        <Constant name="RP_210_Left_Prim_Vert_z" value="608*mm"/>
+        <Constant name="RP_210_Left_Prim_Hor_z" value="1058*mm"/>
+        <Constant name="RP_210_Left_Sec_Hor_z" value="9781*mm"/>
+        <Constant name="RP_210_Left_Sec_Vert_z" value="10231*mm"/>
+
+        <Constant name="RP_210_Left_Sec_Rot_Angle" value="8*deg"/>
+        <Constant name="RP_210_Left_Sec_Rot_Angle_neg8" value="-8*deg"/>
+        <Constant name="RP_210_Left_Sec_Rot_Angle_tilt" value="27*deg"/>
+        <Constant name="RP_210_Left_Sec_Rot_Angle_180" value="180*deg"/>
+        <Constant name="RP_210_Left_Sec_Rot_Angle_172" value="172*deg"/>
+ 
+        <Constant name="RP_210_Left_Hor_Vac_Length" value="[RP_Device:RP_Device_Envelope_Radius]+[RP_Device:RP_Device_Length_y]/2-[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int]"/>
+    </ConstantsSection>
+
+    <RotationSection label="CTPPS_210_Left_Station.xml">
+        <Rotation name="RP_210_Left_Sec_Rotation" 
+            phiX="[RP_210_Left_Sec_Rot_Angle]" thetaX="90*deg" 
+            phiY="(90*deg+[RP_210_Left_Sec_Rot_Angle])" thetaY="90*deg"
+            phiZ="0*deg" thetaZ="0*deg"/>
+        <Rotation name="RP_210_Left_90_y_Sec_Rotation_neg8" 
+            phiX="0*deg" thetaX="180*deg" 
+            phiY="(90*deg+[RP_210_Left_Sec_Rot_Angle_neg8])" thetaY="90*deg"
+            phiZ="[RP_210_Left_Sec_Rot_Angle_neg8]" thetaZ="90*deg"/>
+        <Rotation name="RP_210_Left_90_x_Sec_Rotation" 
+            phiX="(0*deg+[RP_210_Left_Sec_Rot_Angle_neg8])" thetaX="90*deg" 
+            phiY="0*deg" thetaY="180*deg" 
+            phiZ="(90*deg+[RP_210_Left_Sec_Rot_Angle_neg8])" thetaZ="90*deg"/>
+        <Rotation name="RP_210_Left_Sec_Rotation_neg8" 
+            phiX="[RP_210_Left_Sec_Rot_Angle_neg8]" thetaX="90*deg" 
+            phiY="(90*deg+[RP_210_Left_Sec_Rot_Angle_neg8])" thetaY="90*deg"
+            phiZ="0*deg" thetaZ="0*deg"/>
+        <Rotation name="RP_210_Left_Sec_Rotation_180" 
+            phiX="[RP_210_Left_Sec_Rot_Angle_180]" thetaX="90*deg" 
+            phiY="(90*deg+[RP_210_Left_Sec_Rot_Angle_180])" thetaY="90*deg"
+            phiZ="0*deg" thetaZ="0*deg"/>
+        <Rotation name="RP_210_Left_Sec_Rotation_172" 
+            phiX="[RP_210_Left_Sec_Rot_Angle_172]" thetaX="90*deg" 
+            phiY="(90*deg+[RP_210_Left_Sec_Rot_Angle_172])" thetaY="90*deg"
+            phiZ="0*deg" thetaZ="0*deg"/>
+        <!-- tilt 27deg 2025 -->
+        <Rotation name="RP_210_Left_90_y_Sec_Rotation_tilt27" 
+            phiX="0*deg" thetaX="180*deg" 
+            phiY="(90*deg-[RP_210_Left_Sec_Rot_Angle_tilt])" thetaY="90*deg" 
+            phiZ="(0*deg-[RP_210_Left_Sec_Rot_Angle_tilt])" thetaZ="90*deg"/>
+        <Rotation name="RP_210_Left_Sec_Rotation_180_tilt27"
+            phiX="([RP_210_Left_Sec_Rot_Angle_180]-[RP_210_Left_Sec_Rot_Angle_tilt])" thetaX="90*deg"
+            phiY="(90*deg+[RP_210_Left_Sec_Rot_Angle_180]-[RP_210_Left_Sec_Rot_Angle_tilt])" thetaY="90*deg"
+            phiZ="0*deg" thetaZ="0*deg"/>
+        <Rotation name="RP_90_z_cw_180_y_rot_tilt27"
+            phiX="(90*deg-[RP_210_Left_Sec_Rot_Angle_tilt])" thetaX="90*deg"
+            phiY="(0*deg-[RP_210_Left_Sec_Rot_Angle_tilt])" thetaY="90*deg"
+            phiZ="0*deg" thetaZ="180*deg"/>
+    </RotationSection>
+    
+    <SolidSection label="CTPPS_210_Left_Station.xml">  
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_Envelope_Radius]*1.1" dz="[RP_210_Left_Station_Length]/2" name="RP_210_Left_Station"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_210_Left_Prim_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2" name="RP_210_Left_Station_Tube_1"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_210_Left_Prim_Hor_z]-[RP_210_Left_Prim_Vert_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_210_Left_Station_Tube_2"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_210_Left_Sec_Hor_z]-[RP_210_Left_Prim_Hor_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_210_Left_Station_Tube_3"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_210_Left_Sec_Vert_z]-[RP_210_Left_Sec_Hor_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_210_Left_Station_Tube_4"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_210_Left_Station_Length]-[RP_210_Left_Sec_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2" name="RP_210_Left_Station_Tube_5"/>
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2" dz="[RP_210_Left_Station_Length]/2" name="RP_210_Left_Station_Vacuum_1"/>
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2" dz="[RP_Device:RP_Device_Envelope_Radius]" name="RP_210_Left_Station_Vert_Vacuum"/>
+        <UnionSolid name="RP_210_Left_Station_Vacuum_2">
+            <rSolid name="RP_210_Left_Station_Vacuum_1"/>
+            <rSolid name="RP_210_Left_Station_Vert_Vacuum"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Left_Station_Length]/2+[RP_210_Left_Prim_Vert_z]"/>
+        </UnionSolid>
+        <UnionSolid name="RP_210_Left_Station_Vacuum_3">
+            <rSolid name="RP_210_Left_Station_Vacuum_2"/>
+            <rSolid name="RP_210_Left_Station_Vert_Vacuum"/>
+            <!--            <rRotation name="RP_210_Left_90_x_Sec_Rotation"/> -->
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Left_Station_Length]/2+[RP_210_Left_Sec_Vert_z]"/>
+        </UnionSolid>
+        <Polycone name="RP_210_Left_Station_Hor_Vacuum" startPhi="0*deg" deltaPhi="360*deg" >
+            <ZSection z="-[RP_Device:RP_Device_Length_y]/2+[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int]" rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2"/>
+            <ZSection z="-[RP_Device:RP_Device_Length_y]/2+[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int] + [RP_210_Left_Hor_Vac_Length]" rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2"/>
+        </Polycone> 
+        <UnionSolid name="RP_210_Left_Station_Vacuum_4">
+            <rSolid name="RP_210_Left_Station_Vacuum_3"/>
+            <rSolid name="RP_210_Left_Station_Hor_Vacuum"/>
+            <!-- <rRotation name="RP_Transformations:RP_y_90_rot"/> -->
+            <rRotation name="RP_210_Left_90_y_Sec_Rotation_tilt27"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Left_Station_Length]/2+[RP_210_Left_Prim_Hor_z]"/>
+        </UnionSolid>
+        <UnionSolid name="RP_210_Left_Station_Vacuum_5">
+            <rSolid name="RP_210_Left_Station_Vacuum_4"/>
+            <rSolid name="RP_210_Left_Station_Hor_Vacuum"/>
+            <!-- <rRotation name="RP_210_Left_90_y_Sec_Rotation_neg8"/> -->
+            <rRotation name="RP_210_Left_90_y_Sec_Rotation_tilt27"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Left_Station_Length]/2+[RP_210_Left_Sec_Hor_z]"/>
+        </UnionSolid>
+
+        <Polycone name="RP_210_Left_Station_Vacuum_1_Far" startPhi="0*deg" deltaPhi="360*deg" >
+            <ZSection z="0*mm" rMin="0*mm" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2"/>
+            <ZSection z="[RP_210_Left_Station_Length]/2" rMin="0*mm" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2"/>
+        </Polycone> 
+        <UnionSolid name="RP_210_Left_Station_Vacuum_2_Far">
+            <rSolid name="RP_210_Left_Station_Vacuum_1_Far"/>
+            <rSolid name="RP_210_Left_Station_Vert_Vacuum"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Left_Station_Length]/2+[RP_210_Left_Sec_Vert_z]"/>
+        </UnionSolid>
+        <UnionSolid name="RP_210_Left_Station_Vacuum_3_Far">
+            <rSolid name="RP_210_Left_Station_Vacuum_2_Far"/>
+            <rSolid name="RP_210_Left_Station_Hor_Vacuum"/>
+            <!-- <rRotation name="RP_Transformations:RP_y_90_rot"/> -->
+            <rRotation name="RP_210_Left_90_y_Sec_Rotation_tilt27"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Left_Station_Length]/2+[RP_210_Left_Sec_Hor_z]"/>
+        </UnionSolid>
+    </SolidSection>
+    
+    <LogicalPartSection label="CTPPS_210_Left_Station.xml">
+        <LogicalPart name="RP_210_Left_Station">
+            <rSolid name="RP_210_Left_Station"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Left_Station_Tube_1">
+            <rSolid name="RP_210_Left_Station_Tube_1"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Left_Station_Tube_2">
+            <rSolid name="RP_210_Left_Station_Tube_2"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Left_Station_Tube_3">
+            <rSolid name="RP_210_Left_Station_Tube_3"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Left_Station_Tube_4">
+            <rSolid name="RP_210_Left_Station_Tube_4"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Left_Station_Tube_5">
+            <rSolid name="RP_210_Left_Station_Tube_5"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Left_Station_Vacuum_5">
+            <rSolid name="RP_210_Left_Station_Vacuum_5"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Left_Station_Vacuum_3_Far">
+            <rSolid name="RP_210_Left_Station_Vacuum_3_Far"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    
+    <PosPartSection label="CTPPS_210_Left_Station.xml">
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Left_Station"/>
+            <rChild name="RP_Vertical_Device:RP_Device_Vert_Corp_3"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Left_Station_Length]/2+[RP_210_Left_Prim_Vert_z]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="RP_210_Left_Station"/>
+            <rChild name="RP_Vertical_Device:RP_Device_Vert_Corp_3"/>
+            <!--            <rRotation name="RP_210_Left_Sec_Rotation_neg8"/> -->
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Left_Station_Length]/2+[RP_210_Left_Sec_Vert_z]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Left_Station"/>
+            <rChild name="RP_Horizontal_Device:RP_Device_Hor_Corp_3"/>
+            <!-- <rRotation name="RP_210_Left_Sec_Rotation_180"/> -->
+            <rRotation name="RP_210_Left_Sec_Rotation_180_tilt27"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Left_Station_Length]/2+[RP_210_Left_Prim_Hor_z]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="RP_210_Left_Station"/>
+            <rChild name="RP_Horizontal_Device:RP_Device_Hor_Corp_3"/>
+            <!-- <rRotation name="RP_210_Left_Sec_Rotation_172"/> -->
+            <rRotation name="RP_210_Left_Sec_Rotation_180_tilt27"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Left_Station_Length]/2+[RP_210_Left_Sec_Hor_z]"/>
+        </PosPart>
+        
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Left_Station"/>
+            <rChild name="RP_210_Left_Station_Tube_1"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Left_Station_Length]/2+([RP_210_Left_Prim_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Left_Station"/>
+            <rChild name="RP_210_Left_Station_Tube_2"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Left_Station_Length]/2+([RP_210_Left_Prim_Vert_z]+[RP_210_Left_Prim_Hor_z])/2"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Left_Station"/>
+            <rChild name="RP_210_Left_Station_Tube_3"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Left_Station_Length]/2+([RP_210_Left_Prim_Hor_z]+[RP_210_Left_Sec_Hor_z])/2"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Left_Station"/>
+            <rChild name="RP_210_Left_Station_Tube_4"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_210_Left_Station_Length]/2+([RP_210_Left_Sec_Hor_z]+[RP_210_Left_Sec_Vert_z])/2"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Left_Station"/>
+            <rChild name="RP_210_Left_Station_Tube_5"/>
+            <Translation x="0*mm" y="0*mm" z="[RP_210_Left_Station_Length]/2-([RP_210_Left_Station_Length]-[RP_210_Left_Sec_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Left_Station"/>
+            <rChild name="RP_210_Left_Station_Vacuum_5"/>
+            <rRotation name="RP_210_Left_Sec_Rotation_180"/>
+            <!--<rRotation name="RP_210_Left_Sec_Rotation_180"/>-->
+        </PosPart>
+
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Left_Station_Vacuum_5"/>
+            <rChild name="RP_210_Left_Station_Vacuum_3_Far"/>
+            <!-- <rRotation name="RP_210_Left_Sec_Rotation_neg8"/> -->
+        </PosPart>
+        
+        <PosPart copyNumber="0">
+            <rParent name="RP_210_Left_Station_Vacuum_5"/>
+            <rChild name="RP_Box_000:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_z_180_rot"/>
+            <Translation x="0*mm" y="-[RP_Dist_Beam_Cent:RP_210_Left_Det_Dist_1]-[RP_Box:RP_Box_primary_vacuum_y]/2" z="[RP_210_Left_Prim_Vert_z]-[RP_210_Left_Station_Length]/2"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Left_Station_Vacuum_5"/>
+            <rChild name="RP_Box_001:RP_box_primary_vacuum"/>
+            <Translation x="0*mm" y="[RP_Dist_Beam_Cent:RP_210_Left_Det_Dist_0]+[RP_Box:RP_Box_primary_vacuum_y]/2" z="[RP_210_Left_Prim_Vert_z]-[RP_210_Left_Station_Length]/2"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="RP_210_Left_Station_Vacuum_5"/>
+            <rChild name="RP_Box_002:RP_box_primary_vacuum"/>
+            <!-- <rRotation name="RP_Transformations:RP_90_cw_z_rot"/> -->
+            <rRotation name="RP_90_z_cw_180_y_rot_tilt27"/>
+            <Translation x="-(-[RP_Dist_Beam_Cent:RP_210_Left_Det_Dist_2]-[RP_Box:RP_Box_primary_vacuum_y]/2)" y="0*mm" z="[RP_210_Left_Prim_Hor_z]-[RP_210_Left_Station_Length]/2"/>
+        </PosPart>
+        <PosPart copyNumber="10003">
+            <rParent name="RP_210_Left_Station_Vacuum_3_Far"/>
+            <rChild name="RP_Box_003:RP_box_primary_vacuum"/>
+            <!-- <rRotation name="RP_Transformations:RP_90_cw_z_rot"/> -->
+            <rRotation name="RP_90_z_cw_180_y_rot_tilt27"/>
+            <Translation x="-(-[RP_Dist_Beam_Cent:RP_210_Left_Det_Dist_3]-[RP_Box:RP_Box_primary_vacuum_y]/2)" y="0*mm" z="[RP_210_Left_Sec_Hor_z]-[RP_210_Left_Station_Length]/2"/>
+        </PosPart>
+        <PosPart copyNumber="4">
+            <rParent name="RP_210_Left_Station_Vacuum_3_Far"/>
+            <rChild name="RP_Box_004:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_z_180_rot"/>
+            <Translation x="0*mm" y="-[RP_Dist_Beam_Cent:RP_210_Left_Det_Dist_5]-[RP_Box:RP_Box_primary_vacuum_y]/2" z="[RP_210_Left_Sec_Vert_z]-[RP_210_Left_Station_Length]/2"/>
+        </PosPart>
+        <PosPart copyNumber="5">
+            <rParent name="RP_210_Left_Station_Vacuum_3_Far"/>
+            <rChild name="RP_Box_005:RP_box_primary_vacuum"/>
+            <Translation x="0*mm" y="[RP_Dist_Beam_Cent:RP_210_Left_Det_Dist_4]+[RP_Box:RP_Box_primary_vacuum_y]/2" z="[RP_210_Left_Sec_Vert_z]-[RP_210_Left_Station_Length]/2"/>
+        </PosPart>
+    </PosPartSection>
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/CTPPS_2025/Stations/Simu/v1/CTPPS_210_Right_Station.xml
+++ b/Geometry/VeryForwardData/data/CTPPS_2025/Stations/Simu/v1/CTPPS_210_Right_Station.xml
@@ -1,0 +1,259 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition>
+    <ConstantsSection label="CTPPS_210_Right_Station.xml" eval="true">
+        <Constant name="RP_210_Right_Station_Length" value="-([CTPPS_Stations_Assembly:CTPPS_220_Right_Station_Position_z]-[CTPPS_Stations_Assembly:CTPPS_210_Right_Station_Position_z])"/>
+        <!--Positions calculated from the wall closer to IP point-->
+        <Constant name="RP_210_Right_Prim_Vert_z" value="608*mm"/>
+        <Constant name="RP_210_Right_Prim_Hor_z" value="1058*mm"/>
+        <Constant name="RP_210_Right_Sec_Hor_z" value="9781*mm"/>
+        <Constant name="RP_210_Right_Sec_Vert_z" value="10231*mm"/>
+
+        <Constant name="RP_210_Right_Sec_Rot_Angle" value="0*deg"/>
+        <Constant name="RP_210_Right_Sec_Rot_Angle_neg8" value="-8*deg"/>
+        <Constant name="RP_210_Right_Sec_Rot_Angle_tilt" value="27*deg"/>
+        <Constant name="RP_210_Right_Sec_Rot_Angle_180" value="180*deg"/>
+        <Constant name="RP_210_Right_Sec_Rot_Angle_172" value="172*deg"/>
+
+        <Constant name="RP_210_Right_Hor_Vac_Length" value="[RP_Device:RP_Device_Envelope_Radius]+[RP_Device:RP_Device_Length_y]/2-[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int]"/>
+    </ConstantsSection>
+
+    <RotationSection label="CTPPS_210_Right_Station.xml">
+        <Rotation name="RP_210_Right_Sec_Rotation" 
+            phiX="[RP_210_Right_Sec_Rot_Angle]" thetaX="90*deg" 
+            phiY="(90*deg+[RP_210_Right_Sec_Rot_Angle])" thetaY="90*deg"
+            phiZ="0*deg" thetaZ="0*deg"/>
+        <Rotation name="RP_210_Right_90_y_Sec_Rotation_neg8" 
+            phiX="0*deg" thetaX="180*deg" 
+            phiY="(90*deg+[RP_210_Right_Sec_Rot_Angle_neg8])" thetaY="90*deg" 
+            phiZ="(0*deg+[RP_210_Right_Sec_Rot_Angle_neg8])" thetaZ="90*deg"/>
+        <Rotation name="RP_210_Right_90_x_Sec_Rotation_neg8" 
+            phiX="(0*deg+[RP_210_Right_Sec_Rot_Angle_neg8])" thetaX="90*deg" 
+            phiY="0*deg" thetaY="180*deg" 
+            phiZ="(90*deg+[RP_210_Right_Sec_Rot_Angle_neg8])" thetaZ="90*deg"/>
+        <Rotation name="RP_210_Right_Sec_Rotation_neg8" 
+            phiX="[RP_210_Right_Sec_Rot_Angle_neg8]" thetaX="90*deg" 
+            phiY="(90*deg+[RP_210_Right_Sec_Rot_Angle_neg8])" thetaY="90*deg"
+            phiZ="0*deg" thetaZ="0*deg"/>
+        <Rotation name="RP_210_Right_Sec_Rotation_180" 
+            phiX="[RP_210_Right_Sec_Rot_Angle_180]" thetaX="90*deg" 
+            phiY="(90*deg+[RP_210_Right_Sec_Rot_Angle_180])" thetaY="90*deg"
+            phiZ="0*deg" thetaZ="0*deg"/>
+        <Rotation name="RP_210_Right_Sec_Rotation_172" 
+            phiX="[RP_210_Right_Sec_Rot_Angle_172]" thetaX="90*deg" 
+            phiY="(90*deg+[RP_210_Right_Sec_Rot_Angle_172])" thetaY="90*deg"
+            phiZ="0*deg" thetaZ="0*deg"/>
+        <!-- tilt 27deg 2025 -->
+        <Rotation name="RP_210_Right_90_y_Sec_Rotation_tilt27" 
+            phiX="0*deg" thetaX="180*deg" 
+            phiY="(90*deg-[RP_210_Right_Sec_Rot_Angle_tilt])" thetaY="90*deg" 
+            phiZ="(0*deg-[RP_210_Right_Sec_Rot_Angle_tilt])" thetaZ="90*deg"/>
+        <Rotation name="RP_210_Right_Sec_Rotation_180_tilt27"
+            phiX="([RP_210_Right_Sec_Rot_Angle_180]-[RP_210_Right_Sec_Rot_Angle_tilt])" thetaX="90*deg"
+            phiY="(90*deg+[RP_210_Right_Sec_Rot_Angle_180]-[RP_210_Right_Sec_Rot_Angle_tilt])" thetaY="90*deg"
+            phiZ="0*deg" thetaZ="0*deg"/>
+        <Rotation name="RP_90_z_cw_180_y_rot_tilt27"
+            phiX="(90*deg-[RP_210_Right_Sec_Rot_Angle_tilt])" thetaX="90*deg"
+            phiY="(0*deg-[RP_210_Right_Sec_Rot_Angle_tilt])" thetaY="90*deg"
+            phiZ="0*deg" thetaZ="180*deg"/>
+    </RotationSection>
+
+    <SolidSection label="CTPPS_210_Right_Station.xml">  
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_Envelope_Radius]*1.1" dz="[RP_210_Right_Station_Length]/2" name="RP_210_Right_Station"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_210_Right_Prim_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2" name="RP_210_Right_Station_Tube_1"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_210_Right_Prim_Hor_z]-[RP_210_Right_Prim_Vert_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_210_Right_Station_Tube_2"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_210_Right_Sec_Hor_z]-[RP_210_Right_Prim_Hor_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_210_Right_Station_Tube_3"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_210_Right_Sec_Vert_z]-[RP_210_Right_Sec_Hor_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_210_Right_Station_Tube_4"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_210_Right_Station_Length]-[RP_210_Right_Sec_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2" name="RP_210_Right_Station_Tube_5"/>
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2" dz="[RP_210_Right_Station_Length]/2" name="RP_210_Right_Station_Vacuum_1"/>
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2" dz="[RP_Device:RP_Device_Envelope_Radius]" name="RP_210_Right_Station_Vert_Vacuum"/>
+        <UnionSolid name="RP_210_Right_Station_Vacuum_2">
+            <rSolid name="RP_210_Right_Station_Vacuum_1"/>
+            <rSolid name="RP_210_Right_Station_Vert_Vacuum"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+[RP_210_Right_Prim_Vert_z])"/>
+        </UnionSolid>
+        <UnionSolid name="RP_210_Right_Station_Vacuum_3">
+            <rSolid name="RP_210_Right_Station_Vacuum_2"/>
+            <rSolid name="RP_210_Right_Station_Vert_Vacuum"/>
+            <!--            <rRotation name="RP_210_Right_90_x_Sec_Rotation_neg8"/>-->
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+[RP_210_Right_Sec_Vert_z])"/>
+        </UnionSolid>
+        <Polycone name="RP_210_Right_Station_Hor_Vacuum" startPhi="0*deg" deltaPhi="360*deg" >
+            <ZSection z="-[RP_Device:RP_Device_Length_y]/2+[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int]" rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2"/>
+            <ZSection z="-[RP_Device:RP_Device_Length_y]/2+[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int] + [RP_210_Right_Hor_Vac_Length]" rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2"/>
+        </Polycone> 
+        <UnionSolid name="RP_210_Right_Station_Vacuum_4">
+            <rSolid name="RP_210_Right_Station_Vacuum_3"/>
+            <rSolid name="RP_210_Right_Station_Hor_Vacuum"/>
+            <!-- <rRotation name="RP_Transformations:RP_y_90_rot"/> -->
+            <rRotation name="RP_210_Right_90_y_Sec_Rotation_tilt27"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+[RP_210_Right_Prim_Hor_z])"/>
+        </UnionSolid>
+        <UnionSolid name="RP_210_Right_Station_Vacuum_5">
+            <rSolid name="RP_210_Right_Station_Vacuum_4"/>
+            <rSolid name="RP_210_Right_Station_Hor_Vacuum"/>
+            <!--            <rRotation name="RP_210_Right_90_y_Sec_Rotation_neg8"/>-->
+            <rRotation name="RP_210_Right_90_y_Sec_Rotation_tilt27"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+[RP_210_Right_Sec_Hor_z])"/>
+        </UnionSolid>
+
+        <Polycone name="RP_210_Right_Station_Vacuum_1_Far" startPhi="0*deg" deltaPhi="360*deg" >
+            <ZSection z="0*mm" rMin="0*mm" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2"/>
+            <ZSection z="-([RP_210_Right_Station_Length]/2)" rMin="0*mm" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2"/>
+        </Polycone> 
+        <UnionSolid name="RP_210_Right_Station_Vacuum_2_Far">
+            <rSolid name="RP_210_Right_Station_Vacuum_1_Far"/>
+            <rSolid name="RP_210_Right_Station_Vert_Vacuum"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+[RP_210_Right_Sec_Vert_z])"/>
+        </UnionSolid>
+        <UnionSolid name="RP_210_Right_Station_Vacuum_3_Far">
+            <rSolid name="RP_210_Right_Station_Vacuum_2_Far"/>
+            <rSolid name="RP_210_Right_Station_Hor_Vacuum"/>
+            <!--            <rRotation name="RP_Transformations:RP_y_90_rot"/> -->
+            <rRotation name="RP_210_Right_90_y_Sec_Rotation_tilt27"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+[RP_210_Right_Sec_Hor_z])"/>
+        </UnionSolid>
+    </SolidSection>
+
+    <LogicalPartSection label="CTPPS_210_Right_Station.xml">
+        <LogicalPart name="RP_210_Right_Station">
+            <rSolid name="RP_210_Right_Station"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Right_Station_Tube_1">
+            <rSolid name="RP_210_Right_Station_Tube_1"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Right_Station_Tube_2">
+            <rSolid name="RP_210_Right_Station_Tube_2"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Right_Station_Tube_3">
+            <rSolid name="RP_210_Right_Station_Tube_3"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Right_Station_Tube_4">
+            <rSolid name="RP_210_Right_Station_Tube_4"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Right_Station_Tube_5">
+            <rSolid name="RP_210_Right_Station_Tube_5"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Right_Station_Vacuum_5">
+            <rSolid name="RP_210_Right_Station_Vacuum_5"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Right_Station_Vacuum_3_Far">
+            <rSolid name="RP_210_Right_Station_Vacuum_3_Far"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+    </LogicalPartSection>
+
+    <PosPartSection label="CTPPS_210_Right_Station.xml">
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_Vertical_Device:RP_Device_Vert_Corp_3"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+[RP_210_Right_Prim_Vert_z])"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_Vertical_Device:RP_Device_Vert_Corp_3"/>
+            <!--            <rRotation name="RP_210_Right_Sec_Rotation_neg8"/> -->
+            <rRotation name="RP_210_Right_Sec_Rotation"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+[RP_210_Right_Sec_Vert_z])"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_Horizontal_Device:RP_Device_Hor_Corp_3"/>
+            <!--            <rRotation name="RP_210_Right_Sec_Rotation_180"/> -->
+            <rRotation name="RP_210_Right_Sec_Rotation_180_tilt27"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+[RP_210_Right_Prim_Hor_z])"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_Horizontal_Device:RP_Device_Hor_Corp_3"/>
+            <!--            <rRotation name="RP_210_Right_Sec_Rotation_172"/> -->
+            <rRotation name="RP_210_Right_Sec_Rotation_180_tilt27"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+[RP_210_Right_Sec_Hor_z])"/>
+        </PosPart>
+
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_210_Right_Station_Tube_1"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+([RP_210_Right_Prim_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_210_Right_Station_Tube_2"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+([RP_210_Right_Prim_Vert_z]+[RP_210_Right_Prim_Hor_z])/2)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_210_Right_Station_Tube_3"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+([RP_210_Right_Prim_Hor_z]+[RP_210_Right_Sec_Hor_z])/2)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_210_Right_Station_Tube_4"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+([RP_210_Right_Sec_Hor_z]+[RP_210_Right_Sec_Vert_z])/2)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_210_Right_Station_Tube_5"/>
+            <Translation x="0*mm" y="0*mm" z="-([RP_210_Right_Station_Length]/2-([RP_210_Right_Station_Length]-[RP_210_Right_Sec_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_210_Right_Station_Vacuum_5"/>
+            <rRotation name="RP_210_Right_Sec_Rotation_180"/>
+        </PosPart>
+
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Right_Station_Vacuum_5"/>
+            <rChild name="RP_210_Right_Station_Vacuum_3_Far"/>
+            <!--            <rRotation name="RP_210_Right_Sec_Rotation_neg8"/>-->
+        </PosPart>
+
+        <PosPart copyNumber="100">
+            <rParent name="RP_210_Right_Station_Vacuum_5"/>
+            <rChild name="RP_Box_100:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_180_z_180_y_rot"/>
+            <Translation x="0*mm" y="-[RP_Dist_Beam_Cent:RP_210_Right_Det_Dist_1]-[RP_Box:RP_Box_primary_vacuum_y]/2" z="-([RP_210_Right_Prim_Vert_z]-[RP_210_Right_Station_Length]/2)"/>
+        </PosPart>
+        <PosPart copyNumber="101">
+            <rParent name="RP_210_Right_Station_Vacuum_5"/>
+            <rChild name="RP_Box_101:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_y_180_rot"/>
+            <Translation x="0*mm" y="[RP_Dist_Beam_Cent:RP_210_Right_Det_Dist_0]+[RP_Box:RP_Box_primary_vacuum_y]/2" z="-([RP_210_Right_Prim_Vert_z]-[RP_210_Right_Station_Length]/2)"/>
+        </PosPart>
+        <PosPart copyNumber="102">
+            <rParent name="RP_210_Right_Station_Vacuum_5"/>
+            <rChild name="RP_Box_102:RP_box_primary_vacuum"/>
+            <!--            <rRotation name="RP_Transformations:RP_90_z_cw_180_y_rot"/> -->
+            <rRotation name="RP_90_z_cw_180_y_rot_tilt27"/>
+            <Translation x="-(-[RP_Dist_Beam_Cent:RP_210_Right_Det_Dist_2]-[RP_Box:RP_Box_primary_vacuum_y]/2)" y="0*mm" z="-([RP_210_Right_Prim_Hor_z]-[RP_210_Right_Station_Length]/2)"/>
+        </PosPart>
+        <PosPart copyNumber="10103">
+            <rParent name="RP_210_Right_Station_Vacuum_3_Far"/>
+            <rChild name="RP_Box_103:RP_box_primary_vacuum"/>
+            <!--            <rRotation name="RP_Transformations:RP_90_z_cw_180_y_rot"/> -->
+            <rRotation name="RP_90_z_cw_180_y_rot_tilt27"/>
+            <Translation x="-(-[RP_Dist_Beam_Cent:RP_210_Right_Det_Dist_3]-[RP_Box:RP_Box_primary_vacuum_y]/2)" y="0*mm" z="-([RP_210_Right_Sec_Hor_z]-[RP_210_Right_Station_Length]/2)"/>
+        </PosPart>
+        <PosPart copyNumber="104">
+            <rParent name="RP_210_Right_Station_Vacuum_3_Far"/>
+            <rChild name="RP_Box_104:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_180_z_180_y_rot"/>
+            <Translation x="0*mm" y="-[RP_Dist_Beam_Cent:RP_210_Right_Det_Dist_5]-[RP_Box:RP_Box_primary_vacuum_y]/2" z="-([RP_210_Right_Sec_Vert_z]-[RP_210_Right_Station_Length]/2)"/>
+        </PosPart>
+        <PosPart copyNumber="105">
+            <rParent name="RP_210_Right_Station_Vacuum_3_Far"/>
+            <rChild name="RP_Box_105:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_y_180_rot"/>
+            <Translation x="0*mm" y="[RP_Dist_Beam_Cent:RP_210_Right_Det_Dist_4]+[RP_Box:RP_Box_primary_vacuum_y]/2" z="-([RP_210_Right_Sec_Vert_z]-[RP_210_Right_Station_Length]/2)"/>
+        </PosPart>
+    </PosPartSection>
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/CTPPS_2025/Stations/Simu/v1/CTPPS_210_Right_Station.xml_bkp
+++ b/Geometry/VeryForwardData/data/CTPPS_2025/Stations/Simu/v1/CTPPS_210_Right_Station.xml_bkp
@@ -1,0 +1,263 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition>
+    <ConstantsSection label="CTPPS_210_Right_Station.xml" eval="true">
+        <Constant name="RP_210_Right_Station_Length" value="-([CTPPS_Stations_Assembly:CTPPS_220_Right_Station_Position_z]-[CTPPS_Stations_Assembly:CTPPS_210_Right_Station_Position_z])"/>
+        <!--Positions calculated from the wall closer to IP point-->
+        <Constant name="RP_210_Right_Prim_Vert_z" value="608*mm"/>
+        <Constant name="RP_210_Right_Prim_Hor_z" value="1058*mm"/>
+        <Constant name="RP_210_Right_Sec_Hor_z" value="9781*mm"/>
+        <Constant name="RP_210_Right_Sec_Vert_z" value="10231*mm"/>
+
+        <Constant name="RP_210_Right_Sec_Rot_Angle" value="8*deg"/>
+        <Constant name="RP_210_Right_Sec_Rot_Angle_neg8" value="-8*deg"/>
+        <Constant name="RP_210_Right_Sec_Rot_Angle_neg27" value="-27*deg"/>
+        <Constant name="RP_210_Right_Sec_Rot_Angle_180" value="180*deg"/>
+        <Constant name="RP_210_Right_Sec_Rot_Angle_172" value="172*deg"/>
+
+        <Constant name="RP_210_Right_Hor_Vac_Length" value="[RP_Device:RP_Device_Envelope_Radius]+[RP_Device:RP_Device_Length_y]/2-[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int]"/>
+    </ConstantsSection>
+
+    <RotationSection label="CTPPS_210_Right_Station.xml">
+        <Rotation name="RP_210_Right_Sec_Rotation" 
+            phiX="[RP_210_Right_Sec_Rot_Angle]" thetaX="90*deg" 
+            phiY="(90*deg+[RP_210_Right_Sec_Rot_Angle])" thetaY="90*deg"
+            phiZ="0*deg" thetaZ="0*deg"/>
+        <Rotation name="RP_210_Right_90_y_Sec_Rotation_neg8" 
+            phiX="0*deg" thetaX="180*deg" 
+            phiY="(90*deg+[RP_210_Right_Sec_Rot_Angle_neg8])" thetaY="90*deg" 
+            phiZ="(0*deg+[RP_210_Right_Sec_Rot_Angle_neg8])" thetaZ="90*deg"/>
+        <Rotation name="RP_210_Right_90_y_Sec_Rotation_neg27"
+            phiX="0*deg" thetaX="180*deg" 
+            phiY="(90*deg+[RP_210_Right_Sec_Rot_Angle_neg27])" thetaY="90*deg" 
+            phiZ="(0*deg+[RP_210_Right_Sec_Rot_Angle_neg27])" thetaZ="90*deg"/>
+        <Rotation name="RP_210_Right_90_x_Sec_Rotation_neg8" 
+            phiX="(0*deg+[RP_210_Right_Sec_Rot_Angle_neg8])" thetaX="90*deg" 
+            phiY="0*deg" thetaY="180*deg" 
+            phiZ="(90*deg+[RP_210_Right_Sec_Rot_Angle_neg8])" thetaZ="90*deg"/>
+         <Rotation name="RP_210_Right_90_x_Sec_Rotation_pos27"
+            phiX="(0*deg-[RP_210_Right_Sec_Rot_Angle_neg27])" thetaX="90*deg" 
+            phiY="0*deg" thetaY="180*deg" 
+            phiZ="(90*deg-[RP_210_Right_Sec_Rot_Angle_neg27])" thetaZ="90*deg"/>
+        <Rotation name="RP_210_Right_Sec_Rotation_neg8" 
+            phiX="[RP_210_Right_Sec_Rot_Angle_neg8]" thetaX="90*deg" 
+            phiY="(90*deg+[RP_210_Right_Sec_Rot_Angle_neg8])" thetaY="90*deg"
+            phiZ="0*deg" thetaZ="0*deg"/>
+        <Rotation name="RP_210_Right_180_z_180_y_rot_pos27" 
+            phiX="-[RP_210_Right_Sec_Rot_Angle_neg27]" thetaX="90*deg" 
+            phiY="(-90*deg-[RP_210_Right_Sec_Rot_Angle_neg27])" thetaY="90*deg"
+            phiZ="0*deg" thetaZ="180*deg"/>
+        <Rotation name="RP_210_Right_y_180_rot_pos27" 
+            phiX="-[RP_210_Right_Sec_Rot_Angle_neg27]" thetaX="270*deg" 
+            phiY="(90*deg-[RP_210_Right_Sec_Rot_Angle_neg27])" thetaY="90*deg"
+            phiZ="0*deg" thetaZ="180*deg"/>
+        <Rotation name="RP_210_Right_Sec_Rotation_180" 
+            phiX="[RP_210_Right_Sec_Rot_Angle_180]" thetaX="90*deg" 
+            phiY="(90*deg+[RP_210_Right_Sec_Rot_Angle_180])" thetaY="90*deg"
+            phiZ="0*deg" thetaZ="0*deg"/>
+        <Rotation name="RP_210_Right_Sec_Rotation_180_pos27"
+            phiX="([RP_210_Right_Sec_Rot_Angle_180]-[RP_210_Right_Sec_Rot_Angle_neg27])" thetaX="90*deg" 
+            phiY="(90*deg+[RP_210_Right_Sec_Rot_Angle_180]-[RP_210_Right_Sec_Rot_Angle_neg27])" thetaY="90*deg"
+            phiZ="0*deg" thetaZ="0*deg"/>
+        <Rotation name="RP_210_Right_Sec_Rotation_172" 
+            phiX="[RP_210_Right_Sec_Rot_Angle_172]" thetaX="90*deg" 
+            phiY="(90*deg+[RP_210_Right_Sec_Rot_Angle_172])" thetaY="90*deg"
+            phiZ="0*deg" thetaZ="0*deg"/>
+    </RotationSection>
+
+    <SolidSection label="CTPPS_210_Right_Station.xml">  
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_Envelope_Radius]*1.1" dz="[RP_210_Right_Station_Length]/2" name="RP_210_Right_Station"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_210_Right_Prim_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2" name="RP_210_Right_Station_Tube_1"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_210_Right_Prim_Hor_z]-[RP_210_Right_Prim_Vert_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_210_Right_Station_Tube_2"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_210_Right_Sec_Hor_z]-[RP_210_Right_Prim_Hor_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_210_Right_Station_Tube_3"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_210_Right_Sec_Vert_z]-[RP_210_Right_Sec_Hor_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_210_Right_Station_Tube_4"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_210_Right_Station_Length]-[RP_210_Right_Sec_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2" name="RP_210_Right_Station_Tube_5"/>
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2" dz="[RP_210_Right_Station_Length]/2" name="RP_210_Right_Station_Vacuum_1"/>
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2" dz="[RP_Device:RP_Device_Envelope_Radius]" name="RP_210_Right_Station_Vert_Vacuum"/>
+        <UnionSolid name="RP_210_Right_Station_Vacuum_2">
+            <rSolid name="RP_210_Right_Station_Vacuum_1"/>
+            <rSolid name="RP_210_Right_Station_Vert_Vacuum"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+[RP_210_Right_Prim_Vert_z])"/>
+        </UnionSolid>
+        <UnionSolid name="RP_210_Right_Station_Vacuum_3">
+            <rSolid name="RP_210_Right_Station_Vacuum_2"/>
+            <rSolid name="RP_210_Right_Station_Vert_Vacuum"/>
+            <!-- <rRotation name="RP_210_Right_90_x_Sec_Rotation_neg8"/> -->
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+[RP_210_Right_Sec_Vert_z])"/>
+        </UnionSolid>
+        <Polycone name="RP_210_Right_Station_Hor_Vacuum" startPhi="0*deg" deltaPhi="360*deg" >
+            <ZSection z="-[RP_Device:RP_Device_Length_y]/2+[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int]" rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2"/>
+            <ZSection z="-[RP_Device:RP_Device_Length_y]/2+[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int] + [RP_210_Right_Hor_Vac_Length]" rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2"/>
+        </Polycone> 
+        <UnionSolid name="RP_210_Right_Station_Vacuum_4">
+            <rSolid name="RP_210_Right_Station_Vacuum_3"/>
+            <rSolid name="RP_210_Right_Station_Hor_Vacuum"/>
+            <rRotation name="RP_Transformations:RP_y_90_rot"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+[RP_210_Right_Prim_Hor_z])"/>
+        </UnionSolid>
+        <UnionSolid name="RP_210_Right_Station_Vacuum_5">
+            <rSolid name="RP_210_Right_Station_Vacuum_4"/>
+            <rSolid name="RP_210_Right_Station_Hor_Vacuum"/>
+            <!--            <rRotation name="RP_210_Right_90_y_Sec_Rotation_neg8"/> -->
+            <rRotation name="RP_210_Right_90_y_Sec_Rotation_neg27"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+[RP_210_Right_Sec_Hor_z])"/>
+        </UnionSolid>
+
+        <Polycone name="RP_210_Right_Station_Vacuum_1_Far" startPhi="0*deg" deltaPhi="360*deg" >
+            <ZSection z="0*mm" rMin="0*mm" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2"/>
+            <ZSection z="-([RP_210_Right_Station_Length]/2)" rMin="0*mm" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2"/>
+        </Polycone> 
+        <UnionSolid name="RP_210_Right_Station_Vacuum_2_Far">
+            <rSolid name="RP_210_Right_Station_Vacuum_1_Far"/>
+            <rSolid name="RP_210_Right_Station_Vert_Vacuum"/>
+            <!-- <rRotation name="RP_Transformations:RP_x_90_rot"/> -->
+            <rRotation name="RP_210_Right_90_x_Sec_Rotation_pos27"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+[RP_210_Right_Sec_Vert_z])"/>
+        </UnionSolid>
+        <UnionSolid name="RP_210_Right_Station_Vacuum_3_Far">
+            <rSolid name="RP_210_Right_Station_Vacuum_2_Far"/>
+            <rSolid name="RP_210_Right_Station_Hor_Vacuum"/>
+            <rRotation name="RP_Transformations:RP_y_90_rot"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+[RP_210_Right_Sec_Hor_z])"/>
+        </UnionSolid>
+    </SolidSection>
+
+    <LogicalPartSection label="CTPPS_210_Right_Station.xml">
+        <LogicalPart name="RP_210_Right_Station">
+            <rSolid name="RP_210_Right_Station"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Right_Station_Tube_1">
+            <rSolid name="RP_210_Right_Station_Tube_1"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Right_Station_Tube_2">
+            <rSolid name="RP_210_Right_Station_Tube_2"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Right_Station_Tube_3">
+            <rSolid name="RP_210_Right_Station_Tube_3"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Right_Station_Tube_4">
+            <rSolid name="RP_210_Right_Station_Tube_4"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Right_Station_Tube_5">
+            <rSolid name="RP_210_Right_Station_Tube_5"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Right_Station_Vacuum_5">
+            <rSolid name="RP_210_Right_Station_Vacuum_5"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+        <LogicalPart name="RP_210_Right_Station_Vacuum_3_Far">
+            <rSolid name="RP_210_Right_Station_Vacuum_3_Far"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+    </LogicalPartSection>
+
+    <PosPartSection label="CTPPS_210_Right_Station.xml">
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_Vertical_Device:RP_Device_Vert_Corp_3"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+[RP_210_Right_Prim_Vert_z])"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_Vertical_Device:RP_Device_Vert_Corp_3"/>
+            <!-- <rRotation name="RP_210_Right_Sec_Rotation_neg8"/> -->
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+[RP_210_Right_Sec_Vert_z])"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_Horizontal_Device:RP_Device_Hor_Corp_3"/>
+            <rRotation name="RP_210_Right_Sec_Rotation_180"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+[RP_210_Right_Prim_Hor_z])"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_Horizontal_Device:RP_Device_Hor_Corp_3"/>
+            <rRotation name="RP_210_Right_Sec_Rotation_172"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+[RP_210_Right_Sec_Hor_z])"/>
+        </PosPart>
+
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_210_Right_Station_Tube_1"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+([RP_210_Right_Prim_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_210_Right_Station_Tube_2"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+([RP_210_Right_Prim_Vert_z]+[RP_210_Right_Prim_Hor_z])/2)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_210_Right_Station_Tube_3"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+([RP_210_Right_Prim_Hor_z]+[RP_210_Right_Sec_Hor_z])/2)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_210_Right_Station_Tube_4"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_210_Right_Station_Length]/2+([RP_210_Right_Sec_Hor_z]+[RP_210_Right_Sec_Vert_z])/2)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_210_Right_Station_Tube_5"/>
+            <Translation x="0*mm" y="0*mm" z="-([RP_210_Right_Station_Length]/2-([RP_210_Right_Station_Length]-[RP_210_Right_Sec_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Right_Station"/>
+            <rChild name="RP_210_Right_Station_Vacuum_5"/>
+            <!--            <rRotation name="RP_210_Right_Sec_Rotation_180"/>-->
+            <rRotation name="RP_210_Right_Sec_Rotation_180_pos27"/>
+        </PosPart>
+
+        <PosPart copyNumber="1">
+            <rParent name="RP_210_Right_Station_Vacuum_5"/>
+            <rChild name="RP_210_Right_Station_Vacuum_3_Far"/>
+            <!--<rRotation name="RP_210_Right_Sec_Rotation_neg8"/>-->
+        </PosPart>
+
+        <PosPart copyNumber="100">
+            <rParent name="RP_210_Right_Station_Vacuum_5"/>
+            <rChild name="RP_Box_100:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_180_z_180_y_rot"/>
+            <Translation x="0*mm" y="-[RP_Dist_Beam_Cent:RP_210_Right_Det_Dist_1]-[RP_Box:RP_Box_primary_vacuum_y]/2" z="-([RP_210_Right_Prim_Vert_z]-[RP_210_Right_Station_Length]/2)"/>
+        </PosPart>
+        <PosPart copyNumber="101">
+            <rParent name="RP_210_Right_Station_Vacuum_5"/>
+            <rChild name="RP_Box_101:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_y_180_rot"/>
+            <Translation x="0*mm" y="[RP_Dist_Beam_Cent:RP_210_Right_Det_Dist_0]+[RP_Box:RP_Box_primary_vacuum_y]/2" z="-([RP_210_Right_Prim_Vert_z]-[RP_210_Right_Station_Length]/2)"/>
+        </PosPart>
+        <PosPart copyNumber="102">
+            <rParent name="RP_210_Right_Station_Vacuum_5"/>
+            <rChild name="RP_Box_102:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_90_z_cw_180_y_rot"/>
+            <Translation x="-(-[RP_Dist_Beam_Cent:RP_210_Right_Det_Dist_2]-[RP_Box:RP_Box_primary_vacuum_y]/2)" y="0*mm" z="-([RP_210_Right_Prim_Hor_z]-[RP_210_Right_Station_Length]/2)"/>
+        </PosPart>
+        <PosPart copyNumber="10103">
+            <rParent name="RP_210_Right_Station_Vacuum_3_Far"/>
+            <rChild name="RP_Box_103:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_90_z_cw_180_y_rot"/>
+            <Translation x="-(-[RP_Dist_Beam_Cent:RP_210_Right_Det_Dist_3]-[RP_Box:RP_Box_primary_vacuum_y]/2)" y="0*mm" z="-([RP_210_Right_Sec_Hor_z]-[RP_210_Right_Station_Length]/2)"/>
+        </PosPart>
+        <PosPart copyNumber="104">
+            <rParent name="RP_210_Right_Station_Vacuum_3_Far"/>
+            <rChild name="RP_Box_104:RP_box_primary_vacuum"/>
+            <!--            <rRotation name="RP_Transformations:RP_180_z_180_y_rot"/>-->
+            <rRotation name="RP_210_Right_180_z_180_y_rot_pos27"/>
+            <Translation x="0*mm" y="-[RP_Dist_Beam_Cent:RP_210_Right_Det_Dist_5]-[RP_Box:RP_Box_primary_vacuum_y]/2" z="-([RP_210_Right_Sec_Vert_z]-[RP_210_Right_Station_Length]/2)"/>
+        </PosPart>
+        <PosPart copyNumber="105">
+            <rParent name="RP_210_Right_Station_Vacuum_3_Far"/>
+            <rChild name="RP_Box_105:RP_box_primary_vacuum"/>
+            <!--            <rRotation name="RP_Transformations:RP_y_180_rot"/>-->
+            <rRotation name="RP_210_Right_y_180_rot_pos27"/>
+            <Translation x="0*mm" y="[RP_Dist_Beam_Cent:RP_210_Right_Det_Dist_4]+[RP_Box:RP_Box_primary_vacuum_y]/2" z="-([RP_210_Right_Sec_Vert_z]-[RP_210_Right_Station_Length]/2)"/>
+        </PosPart>
+    </PosPartSection>
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/CTPPS_2025/Stations/Simu/v1/CTPPS_220_Left_Station.xml
+++ b/Geometry/VeryForwardData/data/CTPPS_2025/Stations/Simu/v1/CTPPS_220_Left_Station.xml
@@ -1,0 +1,239 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition>
+    <ConstantsSection label="CTPPS_220_Left_Station.xml" eval="true">
+        <Constant name="RP_220_Left_Station_Length" value="6588*mm"/>
+        <!--Positions calculated from the wall closer to IP point-->
+        <Constant name="RP_220_Left_Prim_Vert_z" value="608*mm"/>
+        <Constant name="RP_220_Left_Prim_Hor_z" value="1058*mm"/>
+        <Constant name="RP_220_Left_Sec_Hor_z" value="5530*mm"/>
+        <Constant name="RP_220_Left_Sec_Vert_z" value="5980*mm"/>
+        <Constant name="RP_220_Left_Timing_z" value="1680*mm"/>
+        <Constant name="RP_220_Left_Sec_Rot_Angle_tilt" value="27*deg"/>
+        <Constant name="RP_220_Left_Rot_Angle_180" value="180*deg"/>
+        <Constant name="RP_220_Left_Hor_Vac_Length" value="[RP_Device:RP_Device_Envelope_Radius]+[RP_Device:RP_Device_Length_y]/2-[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int]"/>
+    </ConstantsSection>
+
+    <RotationSection label="CTPPS_220_Left_Station.xml">
+        <Rotation name="RP_220_Left_Sec_Rotation_180" 
+            phiX="[RP_220_Left_Rot_Angle_180]" thetaX="90*deg" 
+            phiY="(90*deg+[RP_220_Left_Rot_Angle_180])" thetaY="90*deg"
+            phiZ="0*deg" thetaZ="0*deg"/>
+        <!-- tilt 27deg 2025 -->
+        <Rotation name="RP_220_Left_90_y_Sec_Rotation_tilt27"
+            phiX="0*deg" thetaX="180*deg"
+            phiY="(90*deg-[RP_220_Left_Sec_Rot_Angle_tilt])" thetaY="90*deg"
+            phiZ="(0*deg-[RP_220_Left_Sec_Rot_Angle_tilt])" thetaZ="90*deg"/>
+        <Rotation name="RP_220_Left_Sec_Rotation_180_tilt27"
+            phiX="([RP_220_Left_Rot_Angle_180]-[RP_220_Left_Sec_Rot_Angle_tilt])" thetaX="90*deg"
+            phiY="(90*deg+[RP_220_Left_Rot_Angle_180]-[RP_220_Left_Sec_Rot_Angle_tilt])" thetaY="90*deg"
+            phiZ="0*deg" thetaZ="0*deg"/>
+        <Rotation name="RP_90_z_cw_180_y_rot_tilt27"
+            phiX="(90*deg-[RP_220_Left_Sec_Rot_Angle_tilt])" thetaX="90*deg"
+            phiY="(0*deg-[RP_220_Left_Sec_Rot_Angle_tilt])" thetaY="90*deg"
+            phiZ="0*deg" thetaZ="180*deg"/>
+        <Rotation name="PPS_Timing_rot" phiX="0*deg" thetaX="0*deg" phiY="90*deg" thetaY="90*deg" phiZ="0*deg" thetaZ="270*deg"/>
+    </RotationSection>
+
+    <SolidSection label="CTPPS_220_Left_Station.xml">  
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_Envelope_Radius]*1.1" dz="[RP_220_Left_Station_Length]/2" name="RP_220_Left_Station"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_220_Left_Prim_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2" name="RP_220_Left_Station_Tube_1"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_220_Left_Prim_Hor_z]-[RP_220_Left_Prim_Vert_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_220_Left_Station_Tube_2"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_220_Left_Timing_z]-[RP_220_Left_Prim_Hor_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_220_Left_Station_Tube_3a"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_220_Left_Sec_Hor_z]-[RP_220_Left_Timing_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_220_Left_Station_Tube_3b"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_220_Left_Sec_Vert_z]-[RP_220_Left_Sec_Hor_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_220_Left_Station_Tube_4"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_220_Left_Station_Length]-[RP_220_Left_Sec_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2" name="RP_220_Left_Station_Tube_5"/>
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2" dz="[RP_220_Left_Station_Length]/2" name="RP_220_Left_Station_Vacuum_1"/>
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2" dz="[RP_Device:RP_Device_Envelope_Radius]" name="RP_220_Left_Station_Vert_Vacuum"/>
+        <!-- <Tube name="CTPPS_Timing_Positive_Station_Hor_Vacuum" rMin="0*mm" rMax="[CTPPS_Timing_Station_Parameters:Timing_Hole_Diam]/2" dz="[CTPPS_Timing_Station_Parameters:Hor_Vac_Length]/2"/> -->
+        <Polycone name="CTPPS_Timing_Positive_Station_Hor_Vacuum" startPhi="0*deg" deltaPhi="360*deg" >
+            <ZSection z="-[RP_Device:RP_Device_Length_y]/2+[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int]" rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2"/>
+            <ZSection z="-[RP_Device:RP_Device_Length_y]/2+[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int] + [CTPPS_Timing_Station_Parameters:Hor_Vac_Length]" rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2"/>
+        </Polycone>
+        <UnionSolid name="RP_220_Left_Station_Vacuum_2">
+            <rSolid name="RP_220_Left_Station_Vacuum_1"/>
+            <rSolid name="RP_220_Left_Station_Vert_Vacuum"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_220_Left_Station_Length]/2+[RP_220_Left_Prim_Vert_z]"/>
+        </UnionSolid>
+        <UnionSolid name="RP_220_Left_Station_Vacuum_3">
+            <rSolid name="RP_220_Left_Station_Vacuum_2"/>
+            <rSolid name="RP_220_Left_Station_Vert_Vacuum"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_220_Left_Station_Length]/2+[RP_220_Left_Sec_Vert_z]"/>
+        </UnionSolid>
+        <!--<Tube name="CTPPS_Timing_Positive_Station" rMin="0*mm" rMax="[CTPPS_Timing_Station_Parameters:Device_Envelope_Radius]*1.1" dz="[CTPPS_Timing_Station_Parameters:Station_Length]/2"/>-->
+        <UnionSolid name="CTPPS_Timing_Positive_Station_Vacuum_3a">
+          <rSolid name="RP_220_Left_Station_Vacuum_3"/>
+          <rSolid name="CTPPS_Timing_Positive_Station_Hor_Vacuum"/>
+            <!-- <rRotation name="CTPPS_Diamond_Transformations:y_90_rot"/> -->
+          <rRotation name="RP_220_Left_90_y_Sec_Rotation_tilt27"/>
+<!--      <rRotation name="rotations:90YX"/>-->
+<!--      <rRotation name="CTPPS_Diamond_Transformations:y90D"/>-->
+            <!-- <Translation x="[CTPPS_Timing_Station_Parameters:Hor_Vac_Length]/2-[CTPPS_Timing_Station_Parameters:Device_Length_y]/2+[CTPPS_Timing_Station_Parameters:Hor_Closed_Wall_Thick_Int]" y="0*mm" z="-[RP_220_Left_Station_Length]/2+[RP_220_Left_Timing_z]"/> -->
+           <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Right_Station_Length]/2+[RP_220_Right_Timing_z])"/>
+        </UnionSolid>
+
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2" dz="[RP_220_Left_Hor_Vac_Length]/2" name="RP_220_Left_Station_Hor_Vacuum"/>
+        <UnionSolid name="RP_220_Left_Station_Vacuum_4">
+            <rSolid name="CTPPS_Timing_Positive_Station_Vacuum_3a"/>
+            <rSolid name="RP_220_Left_Station_Hor_Vacuum"/>
+            <!-- <rRotation name="CTPPS_Diamond_Transformations:y_90_rot"/> -->
+            <rRotation name="RP_220_Left_90_y_Sec_Rotation_tilt27"/>
+            <!-- <Translation x="-(-[RP_220_Left_Hor_Vac_Length]/2+[RP_Device:RP_Device_Length_y]/2-[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int])" y="0*mm" z="-[RP_220_Left_Station_Length]/2+[RP_220_Left_Prim_Hor_z]"/> -->
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Right_Station_Length]/2+[RP_220_Right_Timing_z])"/>
+        </UnionSolid>
+        <UnionSolid name="RP_220_Left_Station_Vacuum_5">
+            <rSolid name="RP_220_Left_Station_Vacuum_4"/>
+            <rSolid name="RP_220_Left_Station_Hor_Vacuum"/>
+            <!-- <rRotation name="CTPPS_Diamond_Transformations:y_90_rot"/> -->
+            <rRotation name="RP_220_Left_90_y_Sec_Rotation_tilt27"/>
+            <!-- <Translation x="-(-[RP_220_Left_Hor_Vac_Length]/2+[RP_Device:RP_Device_Length_y]/2-[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int])" y="0*mm" z="-[RP_220_Left_Station_Length]/2+[RP_220_Left_Sec_Hor_z]"/> -->
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Right_Station_Length]/2+[RP_220_Right_Timing_z])"/>
+        </UnionSolid>
+    </SolidSection>
+    
+    <LogicalPartSection label="CTPPS_220_Left_Station.xml">
+        <LogicalPart name="RP_220_Left_Station">
+            <rSolid name="RP_220_Left_Station"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="RP_220_Left_Station_Tube_1">
+            <rSolid name="RP_220_Left_Station_Tube_1"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_220_Left_Station_Tube_2">
+            <rSolid name="RP_220_Left_Station_Tube_2"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_220_Left_Station_Tube_3a">
+            <rSolid name="RP_220_Left_Station_Tube_3a"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_220_Left_Station_Tube_3b">
+            <rSolid name="RP_220_Left_Station_Tube_3b"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_220_Left_Station_Tube_4">
+            <rSolid name="RP_220_Left_Station_Tube_4"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_220_Left_Station_Tube_5">
+            <rSolid name="RP_220_Left_Station_Tube_5"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_220_Left_Station_Vacuum_5">
+            <rSolid name="RP_220_Left_Station_Vacuum_5"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    
+    <PosPartSection label="CTPPS_220_Left_Station.xml">
+        <PosPart copyNumber="1">
+            <rParent name="RP_220_Left_Station"/>
+            <rChild name="RP_Vertical_Device:RP_Device_Vert_Corp_3"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_220_Left_Station_Length]/2+[RP_220_Left_Prim_Vert_z]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="RP_220_Left_Station"/>
+            <rChild name="RP_Vertical_Device:RP_Device_Vert_Corp_3"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_220_Left_Station_Length]/2+[RP_220_Left_Sec_Vert_z]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_220_Left_Station"/>
+            <rChild name="RP_Horizontal_Device:RP_Device_Hor_Corp_3"/>
+            <!-- <rRotation name="RP_220_Left_Sec_Rotation_180"/> -->
+            <rRotation name="RP_220_Left_Sec_Rotation_180_tilt27"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_220_Left_Station_Length]/2+[RP_220_Left_Prim_Hor_z]"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="RP_220_Left_Station"/>
+            <rChild name="RP_Horizontal_Device:RP_Device_Hor_Corp_3"/>
+            <!-- <rRotation name="RP_220_Left_Sec_Rotation_180"/> -->
+            <rRotation name="RP_220_Left_Sec_Rotation_180_tilt27"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_220_Left_Station_Length]/2+[RP_220_Left_Sec_Hor_z]"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="RP_220_Left_Station"/>
+            <rChild name="RP_Horizontal_Device:RP_Device_Hor_Corp_3"/>
+            <!-- <rRotation name="RP_220_Left_Sec_Rotation_180"/> -->
+            <rRotation name="RP_220_Left_Sec_Rotation_180_tilt27"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_220_Left_Station_Length]/2+[RP_220_Left_Timing_z]"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_220_Left_Station"/>
+            <rChild name="RP_220_Left_Station_Tube_1"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_220_Left_Station_Length]/2+([RP_220_Left_Prim_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_220_Left_Station"/>
+            <rChild name="RP_220_Left_Station_Tube_2"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_220_Left_Station_Length]/2+([RP_220_Left_Prim_Vert_z]+[RP_220_Left_Prim_Hor_z])/2"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_220_Left_Station"/>
+            <rChild name="RP_220_Left_Station_Tube_3a"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_220_Left_Station_Length]/2+([RP_220_Left_Prim_Hor_z]+[RP_220_Left_Timing_z])/2"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_220_Left_Station"/>
+            <rChild name="RP_220_Left_Station_Tube_3b"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_220_Left_Station_Length]/2+([RP_220_Left_Timing_z]+[RP_220_Left_Sec_Hor_z])/2"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_220_Left_Station"/>
+            <rChild name="RP_220_Left_Station_Tube_4"/>
+            <Translation x="0*mm" y="0*mm" z="-[RP_220_Left_Station_Length]/2+([RP_220_Left_Sec_Hor_z]+[RP_220_Left_Sec_Vert_z])/2"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_220_Left_Station"/>
+            <rChild name="RP_220_Left_Station_Tube_5"/>
+            <Translation x="0*mm" y="0*mm" z="[RP_220_Left_Station_Length]/2-([RP_220_Left_Station_Length]-[RP_220_Left_Sec_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_220_Left_Station"/>
+            <rChild name="RP_220_Left_Station_Vacuum_5"/>
+            <rRotation name="RP_220_Left_Sec_Rotation_180"/>
+        </PosPart>
+        
+        <PosPart copyNumber="20">
+            <rParent name="RP_220_Left_Station_Vacuum_5"/>
+            <rChild name="RP_Box_020:RP_box_primary_vacuum"/>
+            <Translation x="0*mm" y="[RP_Dist_Beam_Cent:RP_220_Left_Det_Dist_0]+[RP_Box:RP_Box_primary_vacuum_y]/2" z="[RP_220_Left_Prim_Vert_z]-[RP_220_Left_Station_Length]/2"/>
+        </PosPart>
+        <PosPart copyNumber="21">
+            <rParent name="RP_220_Left_Station_Vacuum_5"/>
+            <rChild name="RP_Box_021:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_z_180_rot"/>
+            <Translation x="0*mm" y="-[RP_Dist_Beam_Cent:RP_220_Left_Det_Dist_1]-[RP_Box:RP_Box_primary_vacuum_y]/2" z="[RP_220_Left_Prim_Vert_z]-[RP_220_Left_Station_Length]/2"/>
+        </PosPart>
+        <PosPart copyNumber="22">
+            <rParent name="RP_220_Left_Station_Vacuum_5"/>
+            <rChild name="RP_Box_022:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_90_cw_z_rot"/>
+            <Translation x="-(-[RP_Dist_Beam_Cent:RP_220_Left_Det_Dist_2]-[RP_Box:RP_Box_primary_vacuum_y]/2)" y="0*mm" z="[RP_220_Left_Prim_Hor_z]-[RP_220_Left_Station_Length]/2"/>
+        </PosPart>
+        <PosPart copyNumber="10023">
+            <rParent name="RP_220_Left_Station_Vacuum_5"/>
+            <rChild name="RP_Box_023:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_90_cw_z_rot"/>
+            <Translation x="-(-[RP_Dist_Beam_Cent:RP_220_Left_Det_Dist_3]-[RP_Box:RP_Box_primary_vacuum_y]/2)" y="0*mm" z="[RP_220_Left_Sec_Hor_z]-[RP_220_Left_Station_Length]/2"/>
+        </PosPart>
+        <PosPart copyNumber="24">
+            <rParent name="RP_220_Left_Station_Vacuum_5"/>
+            <rChild name="RP_Box_024:RP_box_primary_vacuum"/>
+            <Translation x="0*mm" y="[RP_Dist_Beam_Cent:RP_220_Left_Det_Dist_4]+[RP_Box:RP_Box_primary_vacuum_y]/2" z="[RP_220_Left_Sec_Vert_z]-[RP_220_Left_Station_Length]/2"/>
+        </PosPart>
+        <PosPart copyNumber="25">
+            <rParent name="RP_220_Left_Station_Vacuum_5"/>
+            <rChild name="RP_Box_025:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_z_180_rot"/>
+            <Translation x="0*mm" y="-[RP_Dist_Beam_Cent:RP_220_Left_Det_Dist_5]-[RP_Box:RP_Box_primary_vacuum_y]/2" z="[RP_220_Left_Sec_Vert_z]-[RP_220_Left_Station_Length]/2"/>
+        </PosPart>
+        <PosPart copyNumber="16">
+            <rParent name="RP_220_Left_Station_Vacuum_5"/>
+            <rChild name="CTPPS_Timing_Horizontal_Pot:Primary_Vacuum"/>
+            <rRotation name="rotations:90YX"/>
+            <Translation x="-(-([RP_Dist_Beam_Cent:CTPPS_45_Det_Dist]+[CTPPS_Timing_Horizontal_Pot:plane_length]+[CTPPS_Timing_Horizontal_Pot:cut_depth]+[CTPPS_Timing_Horizontal_Pot:thin_window_thickness])/2)" y="0*cm" z="-[RP_220_Left_Station_Length]/2+[RP_220_Left_Timing_z]"/>
+        </PosPart>
+    </PosPartSection>
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/CTPPS_2025/Stations/Simu/v1/CTPPS_220_Right_Station.xml
+++ b/Geometry/VeryForwardData/data/CTPPS_2025/Stations/Simu/v1/CTPPS_220_Right_Station.xml
@@ -1,0 +1,253 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition>
+    <ConstantsSection label="CTPPS_220_Right_Station.xml" eval="true">
+        <Constant name="RP_220_Right_Station_Length" value="6588*mm"/>
+        <!--Positions calculated from the wall closer to IP point-->
+        <Constant name="RP_220_Right_Prim_Vert_z" value="608*mm"/>
+        <Constant name="RP_220_Right_Prim_Hor_z" value="1058*mm"/>
+        <Constant name="RP_220_Right_Sec_Hor_z" value="5530*mm"/>
+        <Constant name="RP_220_Right_Sec_Vert_z" value="5980*mm"/>
+        <Constant name="RP_220_Right_Timing_z" value="1680*mm"/>
+        <Constant name="RP_220_Right_Sec_Rot_Angle_tilt" value="27*deg"/>
+        <Constant name="RP_220_Right_Rot_Angle_180" value="180*deg"/>
+        <Constant name="RP_220_Right_Hor_Vac_Length" value="[RP_Device:RP_Device_Envelope_Radius]+[RP_Device:RP_Device_Length_y]/2-[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int]"/>
+    </ConstantsSection>
+
+    <RotationSection label="CTPPS_220_Right_Station.xml">
+        <Rotation name="RP_220_Right_Sec_Rotation_180" 
+            phiX="[RP_220_Right_Rot_Angle_180]" thetaX="90*deg" 
+            phiY="(90*deg+[RP_220_Right_Rot_Angle_180])" thetaY="90*deg"
+            phiZ="0*deg" thetaZ="0*deg"/>
+        <Rotation name="PPS_Timing_rot" 
+            phiX="0*deg" thetaX="0*deg"
+            phiY="90*deg" thetaY="90*deg"
+            phiZ="0*deg" thetaZ="270*deg"/>
+        <!-- tilt 27deg 2025 -->
+        <Rotation name="RP_220_Right_90_y_Sec_Rotation_tilt27"
+            phiX="0*deg" thetaX="180*deg"
+            phiY="(90*deg-[RP_220_Right_Sec_Rot_Angle_tilt])" thetaY="90*deg"
+            phiZ="(0*deg-[RP_220_Right_Sec_Rot_Angle_tilt])" thetaZ="90*deg"/>
+        <Rotation name="RP_220_Right_Sec_Rotation_180_tilt27"
+            phiX="([RP_220_Right_Rot_Angle_180]-[RP_220_Right_Sec_Rot_Angle_tilt])" thetaX="90*deg"
+            phiY="(90*deg+[RP_220_Right_Rot_Angle_180]-[RP_220_Right_Sec_Rot_Angle_tilt])" thetaY="90*deg"
+            phiZ="0*deg" thetaZ="0*deg"/>
+        <Rotation name="RP_90_z_cw_180_y_rot_tilt27"
+            phiX="(90*deg-[RP_220_Right_Sec_Rot_Angle_tilt])" thetaX="90*deg"
+            phiY="(0*deg-[RP_220_Right_Sec_Rot_Angle_tilt])" thetaY="90*deg"
+            phiZ="0*deg" thetaZ="180*deg"/>
+    </RotationSection>
+
+    <SolidSection label="CTPPS_220_Right_Station.xml">  
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_Envelope_Radius]*1.1" dz="[RP_220_Right_Station_Length]/2" name="RP_220_Right_Station"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_220_Right_Prim_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2" name="RP_220_Right_Station_Tube_1"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_220_Right_Prim_Hor_z]-[RP_220_Right_Prim_Vert_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_220_Right_Station_Tube_2"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_220_Right_Timing_z]-[RP_220_Right_Prim_Hor_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_220_Right_Station_Tube_3a"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_220_Right_Sec_Hor_z]-[RP_220_Right_Timing_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_220_Right_Station_Tube_3b"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_220_Right_Sec_Vert_z]-[RP_220_Right_Sec_Hor_z]-[RP_Device:RP_Device_Length_z])/2" name="RP_220_Right_Station_Tube_4"/>
+        <Tube rMin="[RP_Device:RP_Device_Beam_Hole_Diam]/2" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2+[RP_Device:RP_Device_Wall_Thickness]" dz="([RP_220_Right_Station_Length]-[RP_220_Right_Sec_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2" name="RP_220_Right_Station_Tube_5"/>
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_Beam_Hole_Diam]/2" dz="[RP_220_Right_Station_Length]/2" name="RP_220_Right_Station_Vacuum_1"/>
+        <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2" dz="[RP_Device:RP_Device_Envelope_Radius]" name="RP_220_Right_Station_Vert_Vacuum"/>
+        <!--        <Tube name="CTPPS_Timing_Negative_Station_Hor_Vacuum" rMin="0*mm" rMax="[CTPPS_Timing_Station_Parameters:Timing_Hole_Diam]/2" dz="[CTPPS_Timing_Station_Parameters:Hor_Vac_Length]/2"/> -->
+        <Polycone name="CTPPS_Timing_Negative_Station_Hor_Vacuum" startPhi="0*deg" deltaPhi="360*deg" >
+            <ZSection z="-[RP_Device:RP_Device_Length_y]/2+[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int]" rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2"/>
+            <ZSection z="-[RP_Device:RP_Device_Length_y]/2+[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int] + [CTPPS_Timing_Station_Parameters:Hor_Vac_Length]" rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2"/>
+        </Polycone>
+        <UnionSolid name="RP_220_Right_Station_Vacuum_2">
+            <rSolid name="RP_220_Right_Station_Vacuum_1"/>
+            <rSolid name="RP_220_Right_Station_Vert_Vacuum"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Right_Station_Length]/2+[RP_220_Right_Prim_Vert_z])"/>
+        </UnionSolid>
+        <UnionSolid name="RP_220_Right_Station_Vacuum_3">
+            <rSolid name="RP_220_Right_Station_Vacuum_2"/>
+            <rSolid name="RP_220_Right_Station_Vert_Vacuum"/>
+            <rRotation name="RP_Transformations:RP_x_90_rot"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Right_Station_Length]/2+[RP_220_Right_Sec_Vert_z])"/>
+        </UnionSolid>
+       <UnionSolid name="CTPPS_Timing_Negative_Station_Vacuum_3a">
+          <rSolid name="RP_220_Right_Station_Vacuum_3"/>
+          <rSolid name="CTPPS_Timing_Negative_Station_Hor_Vacuum"/>
+           <!-- <rRotation name="CTPPS_Diamond_Transformations:y_90_rot"/> -->
+          <rRotation name="RP_220_Right_90_y_Sec_Rotation_tilt27"/>
+<!--      <rRotation name="rotations:90YX"/>-->
+<!--      <rRotation name="CTPPS_Diamond_Transformations:y90D"/>-->
+           <!-- <Translation x="[CTPPS_Timing_Station_Parameters:Hor_Vac_Length]/2-[CTPPS_Timing_Station_Parameters:Device_Length_y]/2+[CTPPS_Timing_Station_Parameters:Hor_Closed_Wall_Thick_Int]" y="0*mm" z="-(-[RP_220_Right_Station_Length]/2+[RP_220_Right_Timing_z])"/> -->
+           <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Right_Station_Length]/2+[RP_220_Right_Timing_z])"/>
+        </UnionSolid>
+        
+        <!-- <Tube rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2" dz="[RP_220_Right_Hor_Vac_Length]/2" name="RP_220_Right_Station_Hor_Vacuum"/> -->
+        <!-- <Tube name="RP_220_Right_Station_Hor_Vacuum"
+            rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2"
+        dz="-[RP_Device:RP_Device_Length_y]/2+[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int] + [RP_220_Right_Hor_Vac_Length]"/> -->
+        <Polycone name="RP_220_Right_Station_Hor_Vacuum" startPhi="0*deg" deltaPhi="360*deg" >
+            <ZSection z="-[RP_Device:RP_Device_Length_y]/2+[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int]" rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2"/>
+            <ZSection z="-[RP_Device:RP_Device_Length_y]/2+[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int] + [RP_220_Right_Hor_Vac_Length]" rMin="0*mm" rMax="[RP_Device:RP_Device_RP_Hole_Diam]/2"/>
+        </Polycone>
+        <UnionSolid name="RP_220_Right_Station_Vacuum_4">
+            <rSolid name="CTPPS_Timing_Negative_Station_Vacuum_3a"/>
+            <rSolid name="RP_220_Right_Station_Hor_Vacuum"/>
+            <!-- <rRotation name="CTPPS_Diamond_Transformations:y_90_rot"/> -->
+            <rRotation name="RP_220_Right_90_y_Sec_Rotation_tilt27"/>
+            <!-- FOR TUBE -->
+            <!-- <Translation x="-(-[RP_220_Right_Hor_Vac_Length]/2+[RP_Device:RP_Device_Length_y]/2-[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int])" y="0*mm" z="-(-[RP_220_Right_Station_Length]/2+[RP_220_Right_Prim_Hor_z])"/> -->
+            <!-- FOR POLY -->
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Right_Station_Length]/2+[RP_220_Right_Prim_Hor_z])"/>
+        </UnionSolid>
+        <UnionSolid name="RP_220_Right_Station_Vacuum_5">
+            <rSolid name="RP_220_Right_Station_Vacuum_4"/>
+            <rSolid name="RP_220_Right_Station_Hor_Vacuum"/>
+            <!-- <rRotation name="CTPPS_Diamond_Transformations:y_90_rot"/> -->
+            <rRotation name="RP_220_Right_90_y_Sec_Rotation_tilt27"/>
+            <!--            <Translation x="-(-[RP_220_Right_Hor_Vac_Length]/2+[RP_Device:RP_Device_Length_y]/2-[RP_Horizontal_Device:RP_Device_Hor_Closed_Wall_Thick_Int])" y="0*mm" z="-(-[RP_220_Right_Station_Length]/2+[RP_220_Right_Sec_Hor_z])"/> -->
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Right_Station_Length]/2+[RP_220_Right_Sec_Hor_z])"/>
+        </UnionSolid>
+    </SolidSection>
+    
+    <LogicalPartSection label="CTPPS_220_Right_Station.xml">
+        <LogicalPart name="RP_220_Right_Station">
+            <rSolid name="RP_220_Right_Station"/>
+            <rMaterial name="materials:Air"/>
+        </LogicalPart>
+        <LogicalPart name="RP_220_Right_Station_Tube_1">
+            <rSolid name="RP_220_Right_Station_Tube_1"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_220_Right_Station_Tube_2">
+            <rSolid name="RP_220_Right_Station_Tube_2"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_220_Right_Station_Tube_3a">
+            <rSolid name="RP_220_Right_Station_Tube_3a"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_220_Right_Station_Tube_3b">
+            <rSolid name="RP_220_Right_Station_Tube_3b"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_220_Right_Station_Tube_4">
+            <rSolid name="RP_220_Right_Station_Tube_4"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_220_Right_Station_Tube_5">
+            <rSolid name="RP_220_Right_Station_Tube_5"/>
+            <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+        </LogicalPart>
+        <LogicalPart name="RP_220_Right_Station_Vacuum_5">
+            <rSolid name="RP_220_Right_Station_Vacuum_5"/>
+            <rMaterial name="materials:Vacuum"/>
+        </LogicalPart>
+    </LogicalPartSection>
+    
+    <PosPartSection label="CTPPS_220_Right_Station.xml">
+        <PosPart copyNumber="1">
+            <rParent name="RP_220_Right_Station"/>
+            <rChild name="RP_Vertical_Device:RP_Device_Vert_Corp_3"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Right_Station_Length]/2+[RP_220_Right_Prim_Vert_z])"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="RP_220_Right_Station"/>
+            <rChild name="RP_Vertical_Device:RP_Device_Vert_Corp_3"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Right_Station_Length]/2+[RP_220_Right_Sec_Vert_z])"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_220_Right_Station"/>
+            <rChild name="RP_Horizontal_Device:RP_Device_Hor_Corp_3"/>
+            <!-- <rRotation name="RP_220_Right_Sec_Rotation_180"/> -->
+            <rRotation name="RP_220_Right_Sec_Rotation_180_tilt27"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Right_Station_Length]/2+[RP_220_Right_Prim_Hor_z])"/>
+        </PosPart>
+        <PosPart copyNumber="2">
+            <rParent name="RP_220_Right_Station"/>
+            <rChild name="RP_Horizontal_Device:RP_Device_Hor_Corp_3"/>
+            <!-- <rRotation name="RP_220_Right_Sec_Rotation_180"/> -->
+            <rRotation name="RP_220_Right_Sec_Rotation_180_tilt27"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Right_Station_Length]/2+[RP_220_Right_Sec_Hor_z])"/>
+        </PosPart>
+        <PosPart copyNumber="3">
+            <rParent name="RP_220_Right_Station"/>
+            <rChild name="RP_Horizontal_Device:RP_Device_Hor_Corp_3"/>
+            <!-- <rRotation name="RP_220_Right_Sec_Rotation_180"/> -->
+            <rRotation name="RP_220_Right_Sec_Rotation_180_tilt27"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Right_Station_Length]/2+[RP_220_Right_Timing_z])"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_220_Right_Station"/>
+            <rChild name="RP_220_Right_Station_Tube_1"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Right_Station_Length]/2+([RP_220_Right_Prim_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_220_Right_Station"/>
+            <rChild name="RP_220_Right_Station_Tube_2"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Right_Station_Length]/2+([RP_220_Right_Prim_Vert_z]+[RP_220_Right_Prim_Hor_z])/2)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_220_Right_Station"/>
+            <rChild name="RP_220_Right_Station_Tube_3a"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Right_Station_Length]/2+([RP_220_Right_Prim_Hor_z]+[RP_220_Right_Timing_z])/2)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_220_Right_Station"/>
+            <rChild name="RP_220_Right_Station_Tube_3b"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Right_Station_Length]/2+([RP_220_Right_Timing_z]+[RP_220_Right_Sec_Hor_z])/2)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_220_Right_Station"/>
+            <rChild name="RP_220_Right_Station_Tube_4"/>
+            <Translation x="0*mm" y="0*mm" z="-(-[RP_220_Right_Station_Length]/2+([RP_220_Right_Sec_Hor_z]+[RP_220_Right_Sec_Vert_z])/2)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_220_Right_Station"/>
+            <rChild name="RP_220_Right_Station_Tube_5"/>
+            <Translation x="0*mm" y="0*mm" z="-([RP_220_Right_Station_Length]/2-([RP_220_Right_Station_Length]-[RP_220_Right_Sec_Vert_z]-[RP_Device:RP_Device_Length_z]/2)/2)"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="RP_220_Right_Station"/>
+            <rChild name="RP_220_Right_Station_Vacuum_5"/>
+            <rRotation name="RP_220_Right_Sec_Rotation_180"/>
+        </PosPart>
+        
+        <PosPart copyNumber="120">
+            <rParent name="RP_220_Right_Station_Vacuum_5"/>
+            <rChild name="RP_Box_120:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_y_180_rot"/>
+            <Translation x="0*mm" y="[RP_Dist_Beam_Cent:RP_220_Right_Det_Dist_0]+[RP_Box:RP_Box_primary_vacuum_y]/2" z="-([RP_220_Right_Prim_Vert_z]-[RP_220_Right_Station_Length]/2)"/>
+        </PosPart>
+        <PosPart copyNumber="121">
+            <rParent name="RP_220_Right_Station_Vacuum_5"/>
+            <rChild name="RP_Box_121:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_180_z_180_y_rot"/>
+            <Translation x="0*mm" y="-[RP_Dist_Beam_Cent:RP_220_Right_Det_Dist_1]-[RP_Box:RP_Box_primary_vacuum_y]/2" z="-([RP_220_Right_Prim_Vert_z]-[RP_220_Right_Station_Length]/2)"/>
+        </PosPart>
+        <PosPart copyNumber="122">
+            <rParent name="RP_220_Right_Station_Vacuum_5"/>
+            <rChild name="RP_Box_122:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_90_z_cw_180_y_rot"/>
+            <Translation x="-(-[RP_Dist_Beam_Cent:RP_220_Right_Det_Dist_2]-[RP_Box:RP_Box_primary_vacuum_y]/2)" y="0*mm" z="-([RP_220_Right_Prim_Hor_z]-[RP_220_Right_Station_Length]/2)"/>
+        </PosPart>
+        <PosPart copyNumber="10123">
+            <rParent name="RP_220_Right_Station_Vacuum_5"/>
+            <rChild name="RP_Box_123:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_90_z_cw_180_y_rot"/>
+            <Translation x="-(-[RP_Dist_Beam_Cent:RP_220_Right_Det_Dist_3]-[RP_Box:RP_Box_primary_vacuum_y]/2)" y="0*mm" z="-([RP_220_Right_Sec_Hor_z]-[RP_220_Right_Station_Length]/2)"/>
+        </PosPart>
+        <PosPart copyNumber="124">
+            <rParent name="RP_220_Right_Station_Vacuum_5"/>
+            <rChild name="RP_Box_124:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_y_180_rot"/>
+            <Translation x="0*mm" y="[RP_Dist_Beam_Cent:RP_220_Right_Det_Dist_4]+[RP_Box:RP_Box_primary_vacuum_y]/2" z="-([RP_220_Right_Sec_Vert_z]-[RP_220_Right_Station_Length]/2)"/>
+        </PosPart>
+        <PosPart copyNumber="125">
+            <rParent name="RP_220_Right_Station_Vacuum_5"/>
+            <rChild name="RP_Box_125:RP_box_primary_vacuum"/>
+            <rRotation name="RP_Transformations:RP_180_z_180_y_rot"/>
+            <Translation x="0*mm" y="-[RP_Dist_Beam_Cent:RP_220_Right_Det_Dist_5]-[RP_Box:RP_Box_primary_vacuum_y]/2" z="-([RP_220_Right_Sec_Vert_z]-[RP_220_Right_Station_Length]/2)"/>
+        </PosPart>
+        <PosPart copyNumber="116">
+            <rParent name="RP_220_Right_Station_Vacuum_5"/>
+            <rChild name="CTPPS_Timing_Horizontal_Pot:Primary_Vacuum"/>
+            <!--            <rRotation name="rotations:90YX"/> -->
+            <rRotation name="RP_220_Right_90_y_Sec_Rotation_tilt27"/>
+            <Translation x="-(-([RP_Dist_Beam_Cent:CTPPS_56_Det_Dist]+[CTPPS_Timing_Horizontal_Pot:plane_length]+[CTPPS_Timing_Horizontal_Pot:cut_depth]+[CTPPS_Timing_Horizontal_Pot:thin_window_thickness])/2)" y="0*cm" z="-(-[RP_220_Right_Station_Length]/2+[RP_220_Right_Timing_z])"/>
+        </PosPart>
+    </PosPartSection>
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/CTPPS_2025/Stations/Simu/v1/CTPPS_Stations_Assembly.xml
+++ b/Geometry/VeryForwardData/data/CTPPS_2025/Stations/Simu/v1/CTPPS_Stations_Assembly.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<DDDefinition>
+    <ConstantsSection label="CTPPS_Stations_Assembly.xml" eval="true">
+        <!--positions of the stations from the IP5 to the first element of the station-->
+        <!--coordinate system is relative to CMS 1 (z>0) and 2 (z<0)-->
+        <Constant name="CTPPS_210_Left_Station_Position_z" value="202769*mm"/>
+        <Constant name="CTPPS_210_Right_Station_Position_z" value="-202769*mm"/>
+        <Constant name="CTPPS_220_Left_Station_Position_z" value="214020*mm"/>
+        <Constant name="CTPPS_220_Right_Station_Position_z" value="-214020*mm"/>
+        <!-- +-1500 mm for the two 220 m stations outside the IP-->
+    </ConstantsSection>
+    
+    <PosPartSection label="CTPPS_Stations_Assembly.xml">
+<!--todo if we remove this the alignment module hangs forever-->
+        <PosPart copyNumber="1">
+            <rParent name="cms:CMSE"/>
+            <rChild name="CTPPS_220_Right_Station:RP_220_Right_Station"/>
+            <Translation x="0*mm" y="0*mm" z="[CTPPS_220_Right_Station_Position_z]-[CTPPS_220_Right_Station:RP_220_Right_Station_Length]/2"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="cms:CMSE"/>
+            <rChild name="CTPPS_220_Left_Station:RP_220_Left_Station"/>
+            <Translation x="0*mm" y="0*mm" z="[CTPPS_220_Left_Station_Position_z]+[CTPPS_220_Left_Station:RP_220_Left_Station_Length]/2"/>
+        </PosPart>
+<!---->
+        <PosPart copyNumber="1">
+            <rParent name="cms:CMSE"/>
+            <rChild name="CTPPS_210_Right_Station:RP_210_Right_Station"/>
+            <Translation x="0*mm" y="0*mm" z="[CTPPS_210_Right_Station_Position_z]-[CTPPS_210_Right_Station:RP_210_Right_Station_Length]/2"/>
+        </PosPart>
+        <PosPart copyNumber="1">
+            <rParent name="cms:CMSE"/>
+            <rChild name="CTPPS_210_Left_Station:RP_210_Left_Station"/>
+            <Translation x="0*mm" y="0*mm" z="[CTPPS_210_Left_Station_Position_z]+[CTPPS_210_Left_Station:RP_210_Left_Station_Length]/2"/>
+        </PosPart>
+    </PosPartSection>
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/CTPPS_Timing_Negative_Station/v2/CTPPS_Timing_Negative_Station.xml
+++ b/Geometry/VeryForwardData/data/CTPPS_Timing_Negative_Station/v2/CTPPS_Timing_Negative_Station.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+
+  <ConstantSection label="CTPPS_Timing_Negative_Station.xml">
+    <Constant name="Timing_Negative_Rot_Angle" value="27*deg"/>
+  </ConstantSection>
+
+  <RotationSection label="CTPPS_Timing_Negative_Station.xml">
+    <Rotation name="Timing_Negative_Custom_Rotation"
+              phiX="0*deg" thetaX="180*deg"
+              phiY="90*deg+[Timing_Negative_Rot_Angle]" thetaY="90*deg"
+              phiZ="0*deg+[Timing_Negative_Rot_Angle]" thetaZ="90*deg"/>
+  </RotationSection>
+    
+  <SolidSection label="CTPPS_Timing_Negative_Station.xml">  
+    <Tube name="CTPPS_Timing_Negative_Station" rMin="0*mm" rMax="[CTPPS_Timing_Station_Parameters:Device_Envelope_Radius]*1.1" dz="[CTPPS_Timing_Station_Parameters:Station_Length]/2"/>
+    <Tube name="CTPPS_Timing_Negative_Station_Tube_1" rMin="[CTPPS_Timing_Station_Parameters:Beam_Hole_Diam]/2" rMax="[CTPPS_Timing_Station_Parameters:Beam_Hole_Diam]/2+[CTPPS_Timing_Station_Parameters:Wall_Thickness]" dz="([CTPPS_Timing_Station_Parameters:Station_Pipe_Length]-[RP_220_Left_Station:RP_220_Left_Prim_Hor_z]-[RP_Device:RP_Device_Length_z]/2)/2"/>
+    <Tube name="CTPPS_Timing_Negative_Station_Tube_2" rMin="[CTPPS_Timing_Station_Parameters:Beam_Hole_Diam]/2" rMax="[CTPPS_Timing_Station_Parameters:Beam_Hole_Diam]/2+[CTPPS_Timing_Station_Parameters:Wall_Thickness]" dz="[CTPPS_Timing_Station_Parameters:Station_Pipe_Length]/2"/>
+    <Tube name="CTPPS_Timing_Negative_Station_Vacuum_1" rMin="0*mm" rMax="[CTPPS_Timing_Station_Parameters:Beam_Hole_Diam]/2" dz="[CTPPS_Timing_Station_Parameters:Station_Length]/2"/>
+    <Tube name="CTPPS_Timing_Negative_Station_Hor_Vacuum" rMin="0*mm" rMax="[CTPPS_Timing_Station_Parameters:Timing_Hole_Diam]/2" dz="[CTPPS_Timing_Station_Parameters:Hor_Vac_Length]/2"/>
+    <UnionSolid name="CTPPS_Timing_Negative_Station_Vacuum_4">
+      <rSolid name="CTPPS_Timing_Negative_Station_Vacuum_1"/>
+      <rSolid name="CTPPS_Timing_Negative_Station_Hor_Vacuum"/>
+      <!-- <rRotation name="CTPPS_Diamond_Transformations:y_90_rot"/> -->
+      <rRotation name="Timing_Negative_Custom_Rotation"/>
+      <Translation x="(-(-[CTPPS_Timing_Station_Parameters:Hor_Vac_Length]/2+[CTPPS_Timing_Station_Parameters:Device_Length_y]/2-[CTPPS_Timing_Station_Parameters:Hor_Closed_Wall_Thick_Int]))*cos([Timing_Negative_Rot_Angle])" y="(-(-[CTPPS_Timing_Station_Parameters:Hor_Vac_Length]/2+[CTPPS_Timing_Station_Parameters:Device_Length_y]/2-[CTPPS_Timing_Station_Parameters:Hor_Closed_Wall_Thick_Int]))*cos([Timing_Negative_Rot_Angle])" z="0"/>
+    </UnionSolid>
+  </SolidSection>
+
+  <LogicalPartSection label="CTPPS_Timing_Negative_Station.xml">
+    <LogicalPart name="CTPPS_Timing_Negative_Station">
+      <rSolid name="CTPPS_Timing_Negative_Station"/>
+      <rMaterial name="materials:Air"/>
+    </LogicalPart>
+    <LogicalPart name="CTPPS_Timing_Negative_Station_Tube_1">
+      <rSolid name="CTPPS_Timing_Negative_Station_Tube_1"/>
+      <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+    </LogicalPart>
+    <LogicalPart name="CTPPS_Timing_Negative_Station_Tube_2">
+      <rSolid name="CTPPS_Timing_Negative_Station_Tube_2"/>
+      <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+    </LogicalPart>
+    <LogicalPart name="CTPPS_Timing_Negative_Station_Vacuum_4">
+      <rSolid name="CTPPS_Timing_Negative_Station_Vacuum_4"/>
+      <rMaterial name="materials:Vacuum"/>
+    </LogicalPart>
+  </LogicalPartSection>
+
+  <PosPartSection label="CTPPS_Timing_Negative_Station.xml">
+    <PosPart copyNumber="1">
+      <rParent name="CTPPS_Timing_Negative_Station:CTPPS_Timing_Negative_Station"/>
+      <rChild name="CTPPS_Timing_Negative_Station_Vacuum_4"/>
+      <Translation x="[CTPPS_Diamond_X_Distance:CTPPS_Diamond_Detector_X_distance]+[RP_Dist_Beam_Cent:CTPPS_56_Det_Dist]" y="0*mm" z="0*mm"/>
+      <rRotation name="rotations:180R"/>
+    </PosPart>
+    <PosPart copyNumber="16">
+      <rParent name="CTPPS_Timing_Negative_Station:CTPPS_Timing_Negative_Station_Vacuum_4"/>
+      <rChild name="CTPPS_Timing_Horizontal_Pot:Primary_Vacuum"/>
+      <!-- <rRotation name="rotations:90YX"/> -->
+      <rRotation name="Timing_Negative_Custom_Rotation"/>
+      <Translation x="([CTPPS_Timing_Horizontal_Pot:plane_length]+[CTPPS_Timing_Horizontal_Pot:bottom_wall_thickness])/2*cos([Timing_Negative_Rot_Angle])" y="([CTPPS_Timing_Horizontal_Pot:plane_length]+[CTPPS_Timing_Horizontal_Pot:bottom_wall_thickness])/2*sin([Timing_Negative_Rot_Angle])" z="0*cm"/>
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="CTPPS_Timing_Negative_Station:CTPPS_Timing_Negative_Station"/>
+      <rChild name="CTPPS_Timing_Negative_Station_Tube_1"/>
+      <rRotation name="rotations:000D"/>
+      <Translation x="0*mm" y="0*mm" z="-([CTPPS_Timing_Station_Parameters:Station_Length]/2-([CTPPS_Timing_Station_Parameters:Station_Pipe_Length]+[RP_220_Left_Station:RP_220_Left_Prim_Hor_z]+[RP_Device:RP_Device_Length_z]/2)/2)"/>
+    </PosPart>
+  </PosPartSection>
+
+</DDDefinition>

--- a/Geometry/VeryForwardData/data/CTPPS_Timing_Positive_Station/v2/CTPPS_Timing_Positive_Station.xml
+++ b/Geometry/VeryForwardData/data/CTPPS_Timing_Positive_Station/v2/CTPPS_Timing_Positive_Station.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+
+  <ConstantSection label="CTPPS_Timing_Positive_Station.xml">
+    <Constant name="Timing_Positive_Rot_Angle" value="27*deg"/>
+  </ConstantSection>
+
+  <RotationSection label="CTPPS_Timing_Positive_Station.xml">
+    <Rotation name="Timing_Positive_Custom_Rotation"
+              phiX="0*deg" thetaX="180*deg"
+              phiY="90*deg+[Timing_Positive_Rot_Angle]" thetaY="90*deg"
+              phiZ="0*deg+[Timing_Positive_Rot_Angle]" thetaZ="90*deg"/>
+  </RotationSection>
+    
+  <SolidSection label="CTPPS_Timing_Positive_Station.xml">  
+    <Tube name="CTPPS_Timing_Positive_Station" rMin="0*mm" rMax="[CTPPS_Timing_Station_Parameters:Device_Envelope_Radius]*1.1" dz="[CTPPS_Timing_Station_Parameters:Station_Length]/2"/>
+    <Tube name="CTPPS_Timing_Positive_Station_Tube_1" rMin="[CTPPS_Timing_Station_Parameters:Beam_Hole_Diam]/2" rMax="[CTPPS_Timing_Station_Parameters:Beam_Hole_Diam]/2+[CTPPS_Timing_Station_Parameters:Wall_Thickness]" dz="([CTPPS_Timing_Station_Parameters:Station_Pipe_Length]-[RP_220_Right_Station:RP_220_Right_Prim_Hor_z]-[RP_Device:RP_Device_Length_z]/2)/2"/>
+    <Tube name="CTPPS_Timing_Positive_Station_Tube_2" rMin="[CTPPS_Timing_Station_Parameters:Beam_Hole_Diam]/2" rMax="[CTPPS_Timing_Station_Parameters:Beam_Hole_Diam]/2+[CTPPS_Timing_Station_Parameters:Wall_Thickness]" dz="[CTPPS_Timing_Station_Parameters:Station_Pipe_Length]/2"/>
+    <Tube name="CTPPS_Timing_Positive_Station_Vacuum_1" rMin="0*mm" rMax="[CTPPS_Timing_Station_Parameters:Beam_Hole_Diam]/2" dz="[CTPPS_Timing_Station_Parameters:Station_Length]/2"/>
+    <Tube name="CTPPS_Timing_Positive_Station_Hor_Vacuum" rMin="0*mm" rMax="[CTPPS_Timing_Station_Parameters:Timing_Hole_Diam]/2" dz="[CTPPS_Timing_Station_Parameters:Hor_Vac_Length]/2"/>
+    <UnionSolid name="CTPPS_Timing_Positive_Station_Vacuum_4">
+      <rSolid name="CTPPS_Timing_Positive_Station_Vacuum_1"/>
+      <rSolid name="CTPPS_Timing_Positive_Station_Hor_Vacuum"/>
+      <!--     <rRotation name="rotations:90YX"/> -->
+      <rRotation name="Timing_Positive_Custom_Rotation"/>
+      <Translation x="([CTPPS_Timing_Station_Parameters:Hor_Vac_Length]/2-[CTPPS_Timing_Station_Parameters:Device_Length_y]/2+[CTPPS_Timing_Station_Parameters:Hor_Closed_Wall_Thick_Int])*cos([Timing_Positive_Rot_Angle])" y="([CTPPS_Timing_Station_Parameters:Hor_Vac_Length]/2-[CTPPS_Timing_Station_Parameters:Device_Length_y]/2+[CTPPS_Timing_Station_Parameters:Hor_Closed_Wall_Thick_Int])*sin([Timing_Positive_Rot_Angle])" z="0*mm"/>
+    </UnionSolid>
+  </SolidSection>
+
+  <LogicalPartSection label="CTPPS_Timing_Positive_Station.xml">
+    <LogicalPart name="CTPPS_Timing_Positive_Station">
+      <rSolid name="CTPPS_Timing_Positive_Station"/>
+      <rMaterial name="materials:Air"/>
+    </LogicalPart>
+    <LogicalPart name="CTPPS_Timing_Positive_Station_Tube_1">
+      <rSolid name="CTPPS_Timing_Positive_Station_Tube_1"/>
+      <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+    </LogicalPart>
+    <LogicalPart name="CTPPS_Timing_Positive_Station_Tube_2">
+      <rSolid name="CTPPS_Timing_Positive_Station_Tube_2"/>
+      <rMaterial name="RP_Materials:PPS_AISI-316L-Steel"/>
+    </LogicalPart>
+    <LogicalPart name="CTPPS_Timing_Positive_Station_Vacuum_4">
+      <rSolid name="CTPPS_Timing_Positive_Station_Vacuum_4"/>
+      <rMaterial name="materials:Vacuum"/>
+    </LogicalPart>
+  </LogicalPartSection>
+
+  <PosPartSection label="CTPPS_Timing_Positive_Station.xml">
+    <PosPart copyNumber="1">
+      <rParent name="CTPPS_Timing_Positive_Station:CTPPS_Timing_Positive_Station"/>
+      <rChild name="CTPPS_Timing_Positive_Station_Vacuum_4"/>
+      <Translation x="[CTPPS_Diamond_X_Distance:CTPPS_Diamond_Detector_X_distance]+[RP_Dist_Beam_Cent:CTPPS_45_Det_Dist]" y="0*mm" z="0*mm"/>
+      <rRotation name="rotations:000D"/>
+    </PosPart>
+    <PosPart copyNumber="116">
+      <rParent name="CTPPS_Timing_Positive_Station:CTPPS_Timing_Positive_Station_Vacuum_4"/>
+      <rChild name="CTPPS_Timing_Horizontal_Pot:Primary_Vacuum"/>
+      <!--     <rRotation name="rotations:90YX"/> -->
+      <rRotation name="Timing_Positive_Custom_Rotation"/>
+  <!--    <Translation x="([CTPPS_Timing_Horizontal_Pot:plane_length]+[CTPPS_Timing_Horizontal_Pot:bottom_wall_thickness])/2" y="0*cm" z="0*cm"/> -->
+ <Translation x="([CTPPS_Timing_Horizontal_Pot:plane_length]+[CTPPS_Timing_Horizontal_Pot:bottom_wall_thickness])/2*cos([Timing_Positive_Rot_Angle])" y="([CTPPS_Timing_Horizontal_Pot:plane_length]+[CTPPS_Timing_Horizontal_Pot:bottom_wall_thickness])/2*sin([Timing_Positive_Rot_Angle])" z="0*cm"/>
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="CTPPS_Timing_Positive_Station:CTPPS_Timing_Positive_Station"/>
+      <rChild name="CTPPS_Timing_Positive_Station_Tube_1"/>
+      <rRotation name="rotations:000D"/>
+      <Translation x="0*mm" y="0*mm" z="-([CTPPS_Timing_Station_Parameters:Station_Length]/2-([CTPPS_Timing_Station_Parameters:Station_Pipe_Length]+[RP_220_Right_Station:RP_220_Right_Prim_Hor_z]+[RP_Device:RP_Device_Length_z]/2)/2)"/>
+    </PosPart>
+  </PosPartSection>
+
+</DDDefinition>

--- a/Geometry/VeryForwardGeometry/data/dd4hep/v5/geometryRPFromDD_2025.xml
+++ b/Geometry/VeryForwardGeometry/data/dd4hep/v5/geometryRPFromDD_2025.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0"?>
+<DDDefinition>
+  <open_geometry/>
+  <close_geometry/>
+  
+  <IncludeSection>
+    # common and strip files
+    <Include ref="Geometry/CMSCommonData/data/materials.xml"/>
+    <Include ref="Geometry/CMSCommonData/data/rotations.xml"/>
+    <Include ref="Geometry/CMSCommonData/data/extend/cmsextent.xml"/>
+    <Include ref="Geometry/CMSCommonData/data/cms/2017/v1/cms.xml"/>
+    <Include ref="Geometry/CMSCommonData/data/beampipe/2017/v1/beampipe.xml"/>
+    <Include ref="Geometry/CMSCommonData/data/cmsBeam.xml"/>
+    <Include ref="Geometry/CMSCommonData/data/cmsMother.xml"/>
+    <Include ref="Geometry/CMSCommonData/data/mgnt.xml"/>
+    <Include ref="Geometry/TrackerCommonData/data/trackermaterial/2021/v1/trackermaterial.xml"/>
+    <Include ref="Geometry/TrackerCommonData/data/pixfwdMaterials/2021/v2/pixfwdMaterials.xml"/>
+    <Include ref="Geometry/ForwardCommonData/data/forward.xml"/>
+    <Include ref="Geometry/ForwardCommonData/data/totemRotations.xml"/>
+    <Include ref="Geometry/ForwardCommonData/data/totemMaterials.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_000.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_001.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_002.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_003.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_004.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_005.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_020.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_021.xml"/>
+    <!--<Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_022.xml"/>-->
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_023.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_024.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_025.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_100.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_101.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_102.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_103.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_104.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_105.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_120.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_121.xml"/>
+    <!--<Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_122.xml"/>-->
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_123.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_124.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_125.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Hybrid/v2/RP_Hybrid.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Materials/v5/RP_Materials.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Transformations.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Detectors_Assembly.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_000.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_001.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_002.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_004.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_005.xml"/>
+    <!--<Include ref="Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_022.xml"/>-->
+    <Include ref="Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_024.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_025.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_100.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_101.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_102.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_104.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_105.xml"/>
+    <!--<Include ref="Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_122.xml"/>-->
+    <Include ref="Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_124.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_125.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Device.xml"/>
+
+    <Include ref="Geometry/VeryForwardData/data/RP_Vertical_Device/2021/Reco/v2/RP_Vertical_Device.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Horizontal_Device/2021/Reco/v2/RP_Horizontal_Device.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_2025/Stations/Reco/v1/RP_220_Right_Station.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_2025/Stations/Reco/v1/RP_210_Right_Station.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_2025/Stations/Reco/v1/RP_220_Left_Station.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_2025/Stations/Reco/v1/RP_210_Left_Station.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_2025/Stations/Reco/v1/RP_Stations_Assembly.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/RP_Sensitive_Dets.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_2025/Cuts_Per_Region/Reco/v1/RP_Cuts_Per_Region.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_2025/RP_Param_Beam_Region/v1/RP_Param_Beam_Region.xml"/>
+
+    # diamond files
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_Materials.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_Transformations.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_X_Distance.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_Parameters.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Timing_Station_Parameters.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Timing_Horizontal_Pot/v2/CTPPS_Timing_Horizontal_Pot.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Timing_Positive_Station/v2/CTPPS_Timing_Positive_Station.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Timing_Negative_Station/v2/CTPPS_Timing_Negative_Station.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_2021/Reco/v1/CTPPS_Timing_Stations_Assembly.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern1_Segment1.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern2_Segment1.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern2_Segment2.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern3_Segment1.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern3_Segment2.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern3_Segment3.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern3_Segment4.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern4_Segment1.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern4_Segment2.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern4_Segment3.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern4_Segment4.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern4_Segment5.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_2021/CTPPS_Diamond_Planes/CTPPS_Diamond_Plane1.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_2021/CTPPS_Diamond_Planes/CTPPS_Diamond_Plane2.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_2021/CTPPS_Diamond_Planes/CTPPS_Diamond_Plane3.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_2021/CTPPS_Diamond_Planes/CTPPS_Diamond_Plane4.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Diamond_2021/CTPPS_Diamond_Detector_Assembly/v1/CTPPS_Diamond_Detector_Assembly.xml"/>
+
+    # Totem Timing files
+    <Include ref="Geometry/VeryForwardData/data/TotemTiming/TotemTiming_Dist_Beam_Cent.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/TotemTiming/TotemTiming_DetectorAssembly.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/TotemTiming/TotemTiming_Parameters.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/TotemTiming/TotemTiming_Plane.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/TotemTiming/v1/TotemTiming_Station.xml"/>
+
+    # pixel files
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Modules/v3/PPS_Pixel_Module_2x2_Run3.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Modules/v2/PPS_Pixel_Sens.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Assembly/v2/CTPPS_Pixel_Assembly_Box_Real_003.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Assembly/v2/CTPPS_Pixel_Assembly_Box_Real_023.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Assembly/v2/CTPPS_Pixel_Assembly_Box_Real_103.xml"/>
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Assembly/v2/CTPPS_Pixel_Assembly_Box_Real_123.xml"/>
+
+    # RP distance
+    <Include ref="Geometry/VeryForwardData/data/CTPPS_2021/RP_Dist_Beam_Cent/Reco/v1/RP_Dist_Beam_Cent.xml"/>    
+            
+  </IncludeSection>
+</DDDefinition> 

--- a/Geometry/VeryForwardGeometry/python/dd4hep/v5/geometryRPFromDD_2025_cfi.py
+++ b/Geometry/VeryForwardGeometry/python/dd4hep/v5/geometryRPFromDD_2025_cfi.py
@@ -1,0 +1,18 @@
+import FWCore.ParameterSet.Config as cms
+
+DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
+                                            confGeomXMLFiles = cms.FileInPath('Geometry/VeryForwardGeometry/data/dd4hep/v5/geometryRPFromDD_2025.xml'),
+                                            appendToDataLabel = cms.string('XMLIdealGeometryESSource_CTPPS')
+)
+
+DDCompactViewESProducer = cms.ESProducer("DDCompactViewESProducer",
+                                            appendToDataLabel = cms.string('XMLIdealGeometryESSource_CTPPS')
+)
+
+ctppsGeometryESModule = cms.ESProducer("CTPPSGeometryESModule",
+    fromDD4hep = cms.untracked.bool(True),
+    isRun2 = cms.bool(False),
+    verbosity = cms.untracked.uint32(1),
+    compactViewTag = cms.string('XMLIdealGeometryESSource_CTPPS')
+)
+

--- a/Geometry/VeryForwardGeometry/python/geometryRPFromDD_2025_cfi.py
+++ b/Geometry/VeryForwardGeometry/python/geometryRPFromDD_2025_cfi.py
@@ -1,0 +1,1 @@
+from Geometry.VeryForwardGeometry.v3.geometryRPFromDD_2025_cfi import *

--- a/Geometry/VeryForwardGeometry/python/v3/geometryRPFromDD_2025_cfi.py
+++ b/Geometry/VeryForwardGeometry/python/v3/geometryRPFromDD_2025_cfi.py
@@ -1,0 +1,141 @@
+import FWCore.ParameterSet.Config as cms
+
+# common and strip files
+totemGeomXMLFiles = cms.vstring(
+    'Geometry/CMSCommonData/data/materials.xml',
+    'Geometry/CMSCommonData/data/rotations.xml',
+    'Geometry/CMSCommonData/data/extend/cmsextent.xml',
+    'Geometry/CMSCommonData/data/cms/2017/v1/cms.xml',
+    'Geometry/CMSCommonData/data/beampipe/2017/v1/beampipe.xml',
+    'Geometry/CMSCommonData/data/cmsBeam.xml',
+    'Geometry/CMSCommonData/data/cmsMother.xml',
+    'Geometry/CMSCommonData/data/mgnt.xml',
+    'Geometry/TrackerCommonData/data/trackermaterial/2021/v1/trackermaterial.xml',
+    'Geometry/TrackerCommonData/data/pixfwdMaterials/2021/v2/pixfwdMaterials.xml',
+    'Geometry/ForwardCommonData/data/forward.xml',
+    'Geometry/ForwardCommonData/data/totemRotations.xml',
+    'Geometry/ForwardCommonData/data/totemMaterials.xml',
+    'Geometry/VeryForwardData/data/RP_Box.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_000.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_001.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_002.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_003.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_004.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_005.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_020.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_021.xml',
+#    'Geometry/VeryForwardData/data/RP_Boxv3//RP_Box_022.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_023.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_024.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_025.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_100.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_101.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_102.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_103.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_104.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_105.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_120.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_121.xml',
+#    'Geometry/VeryForwardData/data/RP_Boxv3//RP_Box_122.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_123.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_124.xml',
+    'Geometry/VeryForwardData/data/RP_Box/v3/RP_Box_125.xml',
+    'Geometry/VeryForwardData/data/RP_Hybrid/v2/RP_Hybrid.xml',
+    'Geometry/VeryForwardData/data/RP_Materials/v5/RP_Materials.xml',
+    'Geometry/VeryForwardData/data/RP_Transformations.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_000.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_001.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_002.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_004.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_005.xml',
+#    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_022.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_024.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_025.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_100.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_101.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_102.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_104.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_105.xml',
+#    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_122.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_124.xml',
+    'Geometry/VeryForwardData/data/RP_Detectors_Assembly/RP_Detectors_Assembly_125.xml',
+    'Geometry/VeryForwardData/data/RP_Device.xml',
+    'Geometry/VeryForwardData/data/RP_Vertical_Device/2021/Reco/v2/RP_Vertical_Device.xml',
+    'Geometry/VeryForwardData/data/RP_Horizontal_Device/2021/Reco/v2/RP_Horizontal_Device.xml',
+    'Geometry/VeryForwardData/data/CTPPS_2025/Stations/Reco/v1/RP_220_Right_Station.xml',
+    'Geometry/VeryForwardData/data/CTPPS_2025/Stations/Reco/v1/RP_210_Right_Station.xml',
+    'Geometry/VeryForwardData/data/CTPPS_2025/Stations/Reco/v1/RP_220_Left_Station.xml',
+    'Geometry/VeryForwardData/data/CTPPS_2025/Stations/Reco/v1/RP_210_Left_Station.xml',
+    'Geometry/VeryForwardData/data/CTPPS_2025/Stations/Reco/v1/RP_Stations_Assembly.xml',
+
+    'Geometry/VeryForwardData/data/RP_Sensitive_Dets.xml',
+    'Geometry/VeryForwardData/data/CTPPS_2025/Cuts_Per_Region/Reco/v1/RP_Cuts_Per_Region.xml',
+
+    'Geometry/VeryForwardData/data/CTPPS_2025/RP_Param_Beam_Region/v1/RP_Param_Beam_Region.xml'
+    )
+
+# diamond files
+ctppsDiamondGeomXMLFiles = cms.vstring(
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Materials.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Transformations.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_X_Distance.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Parameters.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Timing_Station_Parameters.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Timing_Horizontal_Pot/v2/CTPPS_Timing_Horizontal_Pot.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Timing_Positive_Station/v2/CTPPS_Timing_Positive_Station.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Timing_Negative_Station/v2/CTPPS_Timing_Negative_Station.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_2021/Reco/v1/CTPPS_Timing_Stations_Assembly.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern1_Segment1.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern2_Segment1.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern2_Segment2.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern3_Segment1.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern3_Segment2.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern3_Segment3.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern3_Segment4.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern4_Segment1.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern4_Segment2.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern4_Segment3.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern4_Segment4.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_Segments/CTPPS_Diamond_Pattern4_Segment5.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_2021/CTPPS_Diamond_Planes/CTPPS_Diamond_Plane1.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_2021/CTPPS_Diamond_Planes/CTPPS_Diamond_Plane2.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_2021/CTPPS_Diamond_Planes/CTPPS_Diamond_Plane3.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_2021/CTPPS_Diamond_Planes/CTPPS_Diamond_Plane4.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Diamond_2021/CTPPS_Diamond_Detector_Assembly/v1/CTPPS_Diamond_Detector_Assembly.xml'
+    )
+
+
+# Totem Timing files
+totemTimingGeomXMLFiles = cms.vstring(
+    # UFSDetectors
+    'Geometry/VeryForwardData/data/TotemTiming/TotemTiming_Dist_Beam_Cent.xml',
+    'Geometry/VeryForwardData/data/TotemTiming/TotemTiming_DetectorAssembly.xml',
+    'Geometry/VeryForwardData/data/TotemTiming/TotemTiming_Parameters.xml',
+    'Geometry/VeryForwardData/data/TotemTiming/TotemTiming_Plane.xml',
+    'Geometry/VeryForwardData/data/TotemTiming/v1/TotemTiming_Station.xml',
+    )
+
+# pixel files
+ctppsPixelGeomXMLFiles = cms.vstring(
+    'Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Modules/v3/PPS_Pixel_Module_2x2_Run3.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Modules/v2/PPS_Pixel_Sens.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Assembly/v2/CTPPS_Pixel_Assembly_Box_Real_003.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Assembly/v2/CTPPS_Pixel_Assembly_Box_Real_023.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Assembly/v2/CTPPS_Pixel_Assembly_Box_Real_103.xml',
+    'Geometry/VeryForwardData/data/CTPPS_Pixel_2021/Assembly/v2/CTPPS_Pixel_Assembly_Box_Real_123.xml'
+    )
+
+XMLIdealGeometryESSource_CTPPS = cms.ESSource("XMLIdealGeometryESSource",
+                                              geomXMLFiles = totemGeomXMLFiles + ctppsDiamondGeomXMLFiles + totemTimingGeomXMLFiles + ctppsPixelGeomXMLFiles,
+                                              rootNodeName = cms.string('cms:CMSE')
+                                              )
+
+# position of RPs
+XMLIdealGeometryESSource_CTPPS.geomXMLFiles.append("Geometry/VeryForwardData/data/CTPPS_2021/RP_Dist_Beam_Cent/Reco/v1/RP_Dist_Beam_Cent.xml")
+
+ctppsGeometryESModule = cms.ESProducer("CTPPSGeometryESModule",
+    verbosity = cms.untracked.uint32(1),
+    isRun2 = cms.bool(False),
+    compactViewTag = cms.string('XMLIdealGeometryESSource_CTPPS')
+)


### PR DESCRIPTION
#### PR description:

This PR applies a rotation on the PPS Roman Pots for Run3 2025 in view of different beam crossing. Both Reco and Simulation geometries changed with these rotations.

#### PR validation:
49 47 43 38 18 1 1 1 1 1 1 tests passed, 0 0 0 0 0 0 0 0 0 0 0 failed

Not a backport.

FIY @fabferro @AndreaBellora @forthommel @bsunanda 