### PR TITLE
Add a unit test for alpaka types' friendly class names

### DIFF
--- a/HeterogeneousCore/AlpakaCore/test/BuildFile.xml
+++ b/HeterogeneousCore/AlpakaCore/test/BuildFile.xml
@@ -1,3 +1,10 @@
 <test name="testAlpakaBackendFilter" command="cmsRun ${LOCALTOP}/src/HeterogeneousCore/AlpakaCore/test/testAlpakaBackendFilter.py">
   <flags ALPAKA_BACKENDS="1"/>
 </test>
+
+<bin name="testAlpakaFriendlyClassNames" file="alpaka/testFriendlyClassNames.cc">
+  <use name="alpaka"/>
+  <use name="catch2"/>
+  <use name="FWCore/Utilities"/>
+  <flags ALPAKA_BACKENDS="1"/>
+</bin>

--- a/HeterogeneousCore/AlpakaCore/test/alpaka/testFriendlyClassNames.cc
+++ b/HeterogeneousCore/AlpakaCore/test/alpaka/testFriendlyClassNames.cc
@@ -1,0 +1,40 @@
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
+#include <alpaka/alpaka.hpp>
+
+#include "FWCore/Utilities/interface/FriendlyName.h"
+#include "FWCore/Utilities/interface/TypeDemangler.h"
+
+namespace {
+
+  template <typename T>
+  std::string getFriendlyName() {
+    return edm::friendlyname::friendlyName(edm::typeDemangle(typeid(T).name()));
+  }
+
+}  // namespace
+
+TEST_CASE("Test edm::friendlyname::friendlyName for alpaka types ", "edm::friendlyname::friendlyName") {
+  SECTION("CPU") {
+    REQUIRE(getFriendlyName<alpaka::DevCpu>() == "alpakaDevCpu");
+    REQUIRE(getFriendlyName<alpaka::QueueCpuBlocking>() == "alpakaQueueCpuBlocking");
+    REQUIRE(getFriendlyName<alpaka::QueueCpuNonBlocking>() == "alpakaQueueCpuNonBlocking");
+  }
+
+#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+  SECTION("CUDA") {
+    REQUIRE(getFriendlyName<alpaka::DevCudaRt>() == "alpakaDevCudaRt");
+    REQUIRE(getFriendlyName<alpaka::QueueCudaRtBlocking>() == "alpakaQueueCudaRtBlocking");
+    REQUIRE(getFriendlyName<alpaka::QueueCudaRtNonBlocking>() == "alpakaQueueCudaRtNonBlocking");
+  }
+#endif
+
+#ifdef ALPAKA_ACC_GPU_HIP_ENABLED
+  SECTION("ROCm") {
+    REQUIRE(getFriendlyName<alpaka::DevHipRt>() == "alpakaDevHipRt");
+    REQUIRE(getFriendlyName<alpaka::QueueHipRtBlocking>() == "alpakaQueueHipRtBlocking");
+    REQUIRE(getFriendlyName<alpaka::QueueHipRtNonBlocking>() == "alpakaQueueHipRtNonBlocking");
+  }
+#endif
+}


### PR DESCRIPTION
#### PR description:

Implement a unit test for alpaka types' friendly class names.

Addresses https://github.com/cms-sw/cmssw/issues/47668.

#### PR validation:

The new unit test passes.