### PR TITLE
Fix Service type name displayed in error message [15.0.x]

### DIFF
--- a/FWCore/ServiceRegistry/interface/ServicesManager.h
+++ b/FWCore/ServiceRegistry/interface/ServicesManager.h
@@ -83,7 +83,7 @@ namespace edm {
               type2Maker_->end() == (itFoundMaker = type2Maker_->find(TypeIDBase(typeid(T))))) {
             auto demangled = typeDemangle(typeid(T).name());
             Exception::throwThis(errors::NotFound,
-                                 "Service Request unable to find requested service with compiler type name '",
+                                 "Service Request unable to find requested service with C++ type '",
                                  demangled.c_str(),
                                  "'.\n");
           } else {

--- a/FWCore/Utilities/src/EDMException.cc
+++ b/FWCore/Utilities/src/EDMException.cc
@@ -88,14 +88,14 @@ namespace edm {
                             char const* message2,
                             char const* message3,
                             char const* message4) {
-    Exception e(aCategory, std::string(message0));
-    e << message1 << message2 << message3 << message4;
+    Exception e(aCategory);
+    e << message0 << message1 << message2 << message3 << message4;
     throw e;
   }
 
   void Exception::throwThis(errors::ErrorCodes aCategory, char const* message0, int intVal, char const* message1) {
-    Exception e(aCategory, std::string(message0));
-    e << intVal << message1;
+    Exception e(aCategory);
+    e << message0 << intVal << message1;
     throw e;
   }
 

--- a/FWCore/Utilities/test/test_catch2_EDMException.cc
+++ b/FWCore/Utilities/test/test_catch2_EDMException.cc
@@ -84,10 +84,10 @@ TEST_CASE("Test edm::Exception", "[edm::Exception]") {
     REQUIRE_THROWS_WITH(edm::Exception::throwThis(edm::errors::ProductNotFound, "a", "b", "c", "d", "e"),
                         "An exception of category 'ProductNotFound' occurred.\n"
                         "Exception Message:\n"
-                        "a bcde\n");
+                        "abcde\n");
     REQUIRE_THROWS_WITH(edm::Exception::throwThis(edm::errors::ProductNotFound, "a", 1, "b"),
                         "An exception of category 'ProductNotFound' occurred.\n"
                         "Exception Message:\n"
-                        "a 1b\n");
+                        "a1b\n");
   }
 }


### PR DESCRIPTION
#### PR description:

Remove a stray white space in the error message, from
```
Service Request unable to find requested service with compiler type name ' alpaka_serial_sync::AlpakaService'.
                                                                          ^
```
to
```
Service Request unable to find requested service with C++ type 'alpaka_serial_sync::AlpakaService'.
```

#### PR validation:

None.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backported of #47670 to 15.0.x for data taking.