### PR TITLE
`AlpakaServiceSerialSync` should always be available

### DIFF
--- a/HeterogeneousCore/AlpakaCore/python/ProcessAcceleratorAlpaka.py
+++ b/HeterogeneousCore/AlpakaCore/python/ProcessAcceleratorAlpaka.py
@@ -83,19 +83,10 @@ class ProcessAcceleratorAlpaka(cms.ProcessAccelerator):
         if not hasattr(process.MessageLogger, "AlpakaService"):
             process.MessageLogger.AlpakaService = cms.untracked.PSet()
 
-        # Check if the CPU backend is available
-        try:
-            if not "cpu" in accelerators:
-                raise False
+        # The CPU backend is effectively always available, ensure the AlpakaServiceSerialSync is loaded
+        if not hasattr(process, "AlpakaServiceSerialSync"):
             from HeterogeneousCore.AlpakaServices.AlpakaServiceSerialSync_cfi import AlpakaServiceSerialSync
-        except:
-            # the CPU backend is not available, do not load the AlpakaServiceSerialSync
-            if hasattr(process, "AlpakaServiceSerialSync"):
-                del process.AlpakaServiceSerialSync
-        else:
-            # the CPU backend is available, ensure the AlpakaServiceSerialSync is loaded
-            if not hasattr(process, "AlpakaServiceSerialSync"):
-                process.add_(AlpakaServiceSerialSync)
+            process.add_(AlpakaServiceSerialSync)
 
         # Check if CUDA is available, and if the system has at least one usable NVIDIA GPU
         try:


### PR DESCRIPTION
#### PR description:

The `AlpakaServiceSerialSync` should always be available, even if the `"cpu"` accelerator is not listed in `process.options.accelerators`.

#### PR validation:

The workflows 141.044407 and 141.044483 were failing due to the missing `AlpakaServiceSerialSync` in step3.
With these changes they run successfully.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 15.0.x for data taking.