### PR TITLE
fix a bunch of test configuration files for invalid `PoolDBESSoure` parameters

### DIFF
--- a/CalibPPS/ESProducers/test/ppsTimingCalibrationAnalyzer_cfg.py
+++ b/CalibPPS/ESProducers/test/ppsTimingCalibrationAnalyzer_cfg.py
@@ -26,7 +26,7 @@ process.CondDB.connect = 'sqlite_file:ppsDiamondTiming_calibration.sqlite' # SQL
 
 process.PoolDBESSource = cms.ESSource('PoolDBESSource',
     process.CondDB,
-    DumpStats = cms.untracked.bool(True),
+    DumpStat = cms.untracked.bool(True),
     toGet = cms.VPSet(
         cms.PSet(
             record = cms.string('PPSTimingCalibrationRcd'),

--- a/CalibPPS/TimingCalibration/test/DiamondCalibrationWorker_cfg.py
+++ b/CalibPPS/TimingCalibration/test/DiamondCalibrationWorker_cfg.py
@@ -24,7 +24,7 @@ process.load("RecoPPS.Configuration.recoCTPPS_cff")
 #process.CondDB.connect = 'sqlite_file:ppsDiamondTiming_calibration.sqlite' # SQLite input
 #process.PoolDBESSource = cms.ESSource('PoolDBESSource',
 #        process.CondDB,
-#        DumpStats = cms.untracked.bool(True),
+#        DumpStat = cms.untracked.bool(True),
 #        toGet = cms.VPSet(
 #            cms.PSet(
 #                record = cms.string('PPSTimingCalibrationRcd'),

--- a/CalibPPS/TimingCalibration/test/DiamondSampicCalibrationHarvester_cfg.py
+++ b/CalibPPS/TimingCalibration/test/DiamondSampicCalibrationHarvester_cfg.py
@@ -48,7 +48,7 @@ process.PoolDBOutputService = cms.Service('PoolDBOutputService',
 process.CondDB.connect = 'sqlite_file:corrected_sampic.sqlite' # SQLite input
 process.PoolDBESSource = cms.ESSource('PoolDBESSource',
         process.CondDB,
-        DumpStats = cms.untracked.bool(True),
+        DumpStat = cms.untracked.bool(True),
         toGet = cms.VPSet(
             cms.PSet(
                 record = cms.string('PPSTimingCalibrationRcd'),

--- a/CalibPPS/TimingCalibration/test/DiamondSampicCalibrationWorker_cfg.py
+++ b/CalibPPS/TimingCalibration/test/DiamondSampicCalibrationWorker_cfg.py
@@ -25,7 +25,7 @@ process.load('CondCore.CondDB.CondDB_cfi')
 process.CondDB.connect = 'sqlite_file:corrected_sampic.sqlite' # SQLite input
 process.PoolDBESSource = cms.ESSource('PoolDBESSource',
         process.CondDB,
-        DumpStats = cms.untracked.bool(True),
+        DumpStat = cms.untracked.bool(True),
         toGet = cms.VPSet(
             cms.PSet(
                 record = cms.string('PPSTimingCalibrationRcd'),

--- a/CalibTracker/Configuration/python/Common/PoolDBESSource_cfi.py
+++ b/CalibTracker/Configuration/python/Common/PoolDBESSource_cfi.py
@@ -3,7 +3,6 @@ import FWCore.ParameterSet.Config as cms
 from CondCore.CondDB.CondDB_cfi import *
 poolDBESSource = cms.ESSource("PoolDBESSource",
     CondDB,
-    BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
     appendToDataLabel = cms.string(''),
     toGet = cms.VPSet(cms.PSet(
         record = cms.string('SiStripNoisesRcd'),

--- a/CondTools/CTPPS/test/ppsTimingCalibrationLUTAnalyzer_cfg.py
+++ b/CondTools/CTPPS/test/ppsTimingCalibrationLUTAnalyzer_cfg.py
@@ -26,7 +26,7 @@ process.CondDB.connect = 'sqlite_file:ppsDiamondTiming_calibrationLUT.sqlite' # 
 
 process.PoolDBESSource = cms.ESSource('PoolDBESSource',
     process.CondDB,
-    DumpStats = cms.untracked.bool(True),
+    DumpStat = cms.untracked.bool(True),
     toGet = cms.VPSet(
         cms.PSet(
             record = cms.string('PPSTimingCalibrationLUTRcd'),

--- a/CondTools/DQM/test/DQMXMLFileEventSetupAnalyzer_cfg.py
+++ b/CondTools/DQM/test/DQMXMLFileEventSetupAnalyzer_cfg.py
@@ -46,9 +46,6 @@ if options.unitTest:
 
     process.XmlRetrieval_1 = cms.ESSource("PoolDBESSource",
                                           process.CondDB,
-                                          BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
-                                          messageLevel = cms.untracked.int32(1),
-                                          timetype = cms.string('runnumber'),
                                           toGet = cms.VPSet(cms.PSet(record = cms.string('DQMXMLFileRcd'),
                                                                      tag = cms.string('XML_test'),
                                                                      label=cms.untracked.string('XML_label')

--- a/CondTools/RunInfo/test/LHCInfoPerFillAnalyzer_cfg.py
+++ b/CondTools/RunInfo/test/LHCInfoPerFillAnalyzer_cfg.py
@@ -26,7 +26,7 @@ process.CondDB.connect = 'sqlite_file:LHCInfoPerFill.sqlite' # SQLite input
 
 process.PoolDBESSource = cms.ESSource('PoolDBESSource',
     process.CondDB,
-    DumpStats = cms.untracked.bool(True),
+    DumpStat = cms.untracked.bool(True),
     toGet = cms.VPSet(
         cms.PSet(
             record = cms.string('LHCInfoPerFillRcd'),

--- a/CondTools/RunInfo/test/LHCInfoPerLSAnalyzer_cfg.py
+++ b/CondTools/RunInfo/test/LHCInfoPerLSAnalyzer_cfg.py
@@ -26,7 +26,7 @@ process.CondDB.connect = 'sqlite_file:LHCInfoPerLS.sqlite' # SQLite input
 
 process.PoolDBESSource = cms.ESSource('PoolDBESSource',
     process.CondDB,
-    DumpStats = cms.untracked.bool(True),
+    DumpStat = cms.untracked.bool(True),
     toGet = cms.VPSet(
         cms.PSet(
             record = cms.string('LHCInfoPerLSRcd'),

--- a/CondTools/SiPixel/test/SiPixelBadModuleReader_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelBadModuleReader_cfg.py
@@ -27,12 +27,10 @@ from Configuration.AlCa.autoCond import autoCond
 process.GlobalTag.globaltag = autoCond['run2_design']
 
 process.QualityReader = cms.ESSource("PoolDBESSource",
-    BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
     DBParameters = cms.PSet(
         messageLevel = cms.untracked.int32(0),
         authenticationPath = cms.untracked.string('')
     ),
-    timetype = cms.string('runnumber'),
     toGet = cms.VPSet(cms.PSet(
         record = cms.string('SiPixelQualityFromDbRcd'),
         tag = cms.string('SiPixelQuality_v07_mc')

--- a/CondTools/SiPixel/test/SiPixelCondObjAllPayloadsReader_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelCondObjAllPayloadsReader_cfg.py
@@ -63,7 +63,6 @@ process.CondDB.DBParameters.messageLevel = 2
 process.CondDB.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/conddb'
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
                                       process.CondDB,
-                                      BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
                                       toGet = cms.VPSet(#cms.PSet(record = cms.string('SiPixelGainCalibrationRcd'),
                                                         #         tag = cms.string('GainCalibTestFull')
                                                         #     ), 

--- a/CondTools/SiPixel/test/SiPixelCondObjForHLTReader_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelCondObjForHLTReader_cfg.py
@@ -35,7 +35,6 @@ process.SimpleMemoryCheck = cms.Service("SimpleMemoryCheck",
 
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
     process.CondDB,
-    BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
     toGet = cms.VPSet(cms.PSet(
         record = cms.string('SiPixelGainCalibrationForHLTRcd'),
         tag = cms.string('SiPixelGainCalibrationHLT_2009runs_express')

--- a/CondTools/SiPixel/test/SiPixelCondObjOfflineReader_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelCondObjOfflineReader_cfg.py
@@ -35,7 +35,6 @@ process.SimpleMemoryCheck = cms.Service("SimpleMemoryCheck",
 
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
     process.CondDB,
-    BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
     toGet = cms.VPSet(cms.PSet(
         record = cms.string('SiPixelGainCalibrationOfflineRcd'),
         tag = cms.string('SiPixelGainCalibration_2009runs_express')

--- a/CondTools/SiPixel/test/SiPixelGainCalibrationRejectNoisyAndDead_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelGainCalibrationRejectNoisyAndDead_cfg.py
@@ -50,7 +50,6 @@ process.source = cms.Source("EmptyIOVSource",
 
 #Input DB
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
-    BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
     DBParameters = cms.PSet(
         messageLevel = cms.untracked.int32(10),
         authenticationPath = cms.untracked.string('.')

--- a/CondTools/SiStrip/test/SiStripApvGainFromASCIIFile_cfg.py
+++ b/CondTools/SiStrip/test/SiStripApvGainFromASCIIFile_cfg.py
@@ -35,7 +35,6 @@ process.CondDB.connect='frontier://FrontierProd/CMS_CONDITIONS'
 
 process.poolDBESSource = cms.ESSource('PoolDBESSource',
                                       process.CondDB,
-                                      BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
                                       toGet = cms.VPSet( cms.PSet(record = cms.string('SiStripFedCablingRcd'),
                                                                   tag    = cms.string('SiStripFedCabling_GR10_v1_hlt')
                                                                   )
@@ -49,11 +48,9 @@ process.maxEvents = cms.untracked.PSet(
 )
 
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
-    BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
     DBParameters = cms.PSet(
         authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
     ),
-    timetype = cms.untracked.string('runnumber'),
     connect = cms.string('sqlite_file:dbfile.db'),
     toPut = cms.VPSet(cms.PSet(
         record = cms.string('SiStripApvGainRcd'),

--- a/CondTools/SiStrip/test/SiStripBadChannelPatcher_cfg.py
+++ b/CondTools/SiStrip/test/SiStripBadChannelPatcher_cfg.py
@@ -90,7 +90,6 @@ process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect='frontier://FrontierProd/CMS_CONDITIONS'
 process.CablingESSource = cms.ESSource('PoolDBESSource',
                                        process.CondDB,
-                                       BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
                                        toGet = cms.VPSet( cms.PSet(record = cms.string('SiStripFedCablingRcd'),
                                                                    tag    = cms.string('SiStripFedCabling_GR10_v1_hlt')   # real data cabling map
                                                                    #tag     = cms.string('SiStripFedCabling_Ideal_31X_v2')  # ideal cabling map
@@ -105,12 +104,10 @@ process.load("CalibTracker.SiStripESProducers.SiStripConnectivity_cfi")
 ## Input bad components
 ##
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
-                                      BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
                                       DBParameters = cms.PSet(
                                           messageLevel = cms.untracked.int32(2),
                                           authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
                                       ),
-                                      timetype = cms.string('runnumber'),
                                       toGet = cms.VPSet(cms.PSet(
                                           record = cms.string('SiStripBadStripRcd'),
                                           tag = cms.string(options.inputTag)

--- a/CondTools/SiStrip/test/SiStripBadStripReader_cfg.py
+++ b/CondTools/SiStrip/test/SiStripBadStripReader_cfg.py
@@ -19,18 +19,16 @@ process.MessageLogger = cms.Service("MessageLogger",
 process.Timing = cms.Service("Timing")
 
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
-    BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
-    DBParameters = cms.PSet(
-        messageLevel = cms.untracked.int32(2),
-        authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
-    ),
-    timetype = cms.string('runnumber'),
-    toGet = cms.VPSet(cms.PSet(
-        record = cms.string('SiStripBadStripRcd'),
-        tag = cms.string('SiStripBadChannel_v1')
-    )),
-    connect = cms.string('sqlite_file:SiStripConditionsDBFile.db')
-)
+                                      DBParameters = cms.PSet(
+                                          messageLevel = cms.untracked.int32(2),
+                                          authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
+                                      ),
+                                      toGet = cms.VPSet(cms.PSet(
+                                          record = cms.string('SiStripBadStripRcd'),
+                                          tag = cms.string('SiStripBadChannel_v1')
+                                      )),
+                                      connect = cms.string('sqlite_file:SiStripConditionsDBFile.db')
+                                      )
 
 process.prod = cms.EDAnalyzer("SiStripBadStripReader",
     printDebug = cms.untracked.bool(True)

--- a/CondTools/SiStrip/test/SiStripFedCablingReader_cfg.py
+++ b/CondTools/SiStrip/test/SiStripFedCablingReader_cfg.py
@@ -19,12 +19,10 @@ process.maxEvents = cms.untracked.PSet(
 )
 
 process.poolDBESSource = cms.ESSource("PoolDBESSource",
-   BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
    DBParameters = cms.PSet(
         messageLevel = cms.untracked.int32(2),
         authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
     ),
-    timetype = cms.untracked.string('runnumber'),
     connect = cms.string('sqlite_file:SiStripConditionsDBFile.db'),
     toGet = cms.VPSet(cms.PSet(
         record = cms.string('SiStripFedCablingRcd'),

--- a/CondTools/SiStrip/test/SiStripSummaryReader_cfg.py
+++ b/CondTools/SiStrip/test/SiStripSummaryReader_cfg.py
@@ -28,12 +28,10 @@ process.maxEvents = cms.untracked.PSet(
 )
 
 process.poolDBESSource = cms.ESSource("PoolDBESSource",
-   BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
    DBParameters = cms.PSet(
         messageLevel = cms.untracked.int32(2),
         authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
     ),
-    timetype = cms.untracked.string('runnumber'),
     connect = cms.string('sqlite_file:SiStripConditionsDBFile.db'),
     toGet = cms.VPSet(cms.PSet(
         record = cms.string('SiStripSummaryRcd'),

--- a/CondTools/SiStrip/test/SiStripThresholdReader_cfg.py
+++ b/CondTools/SiStrip/test/SiStripThresholdReader_cfg.py
@@ -27,12 +27,10 @@ process.source = cms.Source("EmptySource",
 )
 
 process.poolDBESSource = cms.ESSource("PoolDBESSource",
-   BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
    DBParameters = cms.PSet(
         messageLevel = cms.untracked.int32(2),
         authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
     ),
-    timetype = cms.untracked.string('runnumber'),
     connect = cms.string('sqlite_file:SiStripConditionsDBFile.db'),
     toGet = cms.VPSet(cms.PSet(
         record = cms.string('SiStripThresholdRcd'),

--- a/DQM/CTPPS/test/diamond_re_reco_dqm_test_cfg.py
+++ b/DQM/CTPPS/test/diamond_re_reco_dqm_test_cfg.py
@@ -71,7 +71,7 @@ process.ctppsDiamondRecHits.timingCalibrationTag="GlobalTag:PPSTestCalibration"
 #process.CondDB.connect = 'sqlite_file:ppsDiamondTiming_calibration.sqlite' # SQLite input
 #process.PoolDBESSource = cms.ESSource('PoolDBESSource',
 #        process.CondDB,
-#        DumpStats = cms.untracked.bool(True),
+#        DumpStat = cms.untracked.bool(True),
 #        toGet = cms.VPSet(
 #            cms.PSet(
 #                record = cms.string('PPSTimingCalibrationRcd'),

--- a/RecoPPS/Local/test/diamonds_reco_cfg.py
+++ b/RecoPPS/Local/test/diamonds_reco_cfg.py
@@ -23,7 +23,7 @@ elif calibrationMode == PPSTimingCalibrationModeEnum.SQLite:
     process.CondDB.connect = 'sqlite_file:ppsDiamondTiming_calibration.sqlite' # SQLite input
     process.PoolDBESSource = cms.ESSource('PoolDBESSource',
         process.CondDB,
-        DumpStats = cms.untracked.bool(True),
+        DumpStat = cms.untracked.bool(True),
         toGet = cms.VPSet(
             cms.PSet(
                 record = cms.string('PPSTimingCalibrationRcd'),

--- a/RecoPPS/Local/test/totemTiming_digiConverter_reco_cfg.py
+++ b/RecoPPS/Local/test/totemTiming_digiConverter_reco_cfg.py
@@ -102,7 +102,7 @@ process.totemTimingRecHits.mergeTimePeaks= cms.bool(False)
 #process.CondDB.connect = 'sqlite_file:ppsDiamondSampicTiming_calibration.sqlite' # SQLite input
 #process.PoolDBESSource = cms.ESSource('PoolDBESSource',
 #        process.CondDB,
-#        DumpStats = cms.untracked.bool(True),
+#        DumpStat = cms.untracked.bool(True),
 #        toGet = cms.VPSet(
 #            cms.PSet(
 #                record = cms.string('PPSTimingCalibrationRcd'),

--- a/RecoPPS/Local/test/totemTiming_reco_cfg.py
+++ b/RecoPPS/Local/test/totemTiming_reco_cfg.py
@@ -23,7 +23,7 @@ elif calibrationMode == PPSTimingCalibrationModeEnum.SQLite:
     process.CondDB.connect = 'sqlite_file:totemTiming_calibration.sqlite' # SQLite input
     process.PoolDBESSource = cms.ESSource('PoolDBESSource',
         process.CondDB,
-        DumpStats = cms.untracked.bool(True),
+        DumpStat = cms.untracked.bool(True),
         toGet = cms.VPSet(
             cms.PSet(
                 record = cms.string('PPSTimingCalibrationRcd'),


### PR DESCRIPTION
#### PR description:

The merge of PR https://github.com/cms-sw/cmssw/pull/47630 uncovered the usage of invalid parameters in the configurations of `PoolDBESSource` in a bunch of unit test configuration files, see https://github.com/cms-sw/cmssw/pull/47630#issuecomment-2747107745.
The goal of this PR is to restore the correct behavior.

#### PR validation:

`scram b runtests` works for all the packages involved.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but it will be backported together with https://github.com/cms-sw/cmssw/pull/47630 to 15.0.X for 2025 data-taking purposes, see https://github.com/cms-sw/cmssw/pull/47630#issuecomment-2747097624.
