### PR TITLE
[15.0.X] provide a `fillDescriptions` method for `CondDBESSource`

### DIFF
--- a/CalibPPS/ESProducers/test/ppsTimingCalibrationAnalyzer_cfg.py
+++ b/CalibPPS/ESProducers/test/ppsTimingCalibrationAnalyzer_cfg.py
@@ -26,7 +26,7 @@ process.CondDB.connect = 'sqlite_file:ppsDiamondTiming_calibration.sqlite' # SQL
 
 process.PoolDBESSource = cms.ESSource('PoolDBESSource',
     process.CondDB,
-    DumpStats = cms.untracked.bool(True),
+    DumpStat = cms.untracked.bool(True),
     toGet = cms.VPSet(
         cms.PSet(
             record = cms.string('PPSTimingCalibrationRcd'),

--- a/CalibPPS/TimingCalibration/test/DiamondCalibrationWorker_cfg.py
+++ b/CalibPPS/TimingCalibration/test/DiamondCalibrationWorker_cfg.py
@@ -24,7 +24,7 @@ process.load("RecoPPS.Configuration.recoCTPPS_cff")
 #process.CondDB.connect = 'sqlite_file:ppsDiamondTiming_calibration.sqlite' # SQLite input
 #process.PoolDBESSource = cms.ESSource('PoolDBESSource',
 #        process.CondDB,
-#        DumpStats = cms.untracked.bool(True),
+#        DumpStat = cms.untracked.bool(True),
 #        toGet = cms.VPSet(
 #            cms.PSet(
 #                record = cms.string('PPSTimingCalibrationRcd'),

--- a/CalibPPS/TimingCalibration/test/DiamondSampicCalibrationHarvester_cfg.py
+++ b/CalibPPS/TimingCalibration/test/DiamondSampicCalibrationHarvester_cfg.py
@@ -48,7 +48,7 @@ process.PoolDBOutputService = cms.Service('PoolDBOutputService',
 process.CondDB.connect = 'sqlite_file:corrected_sampic.sqlite' # SQLite input
 process.PoolDBESSource = cms.ESSource('PoolDBESSource',
         process.CondDB,
-        DumpStats = cms.untracked.bool(True),
+        DumpStat = cms.untracked.bool(True),
         toGet = cms.VPSet(
             cms.PSet(
                 record = cms.string('PPSTimingCalibrationRcd'),

--- a/CalibPPS/TimingCalibration/test/DiamondSampicCalibrationWorker_cfg.py
+++ b/CalibPPS/TimingCalibration/test/DiamondSampicCalibrationWorker_cfg.py
@@ -25,7 +25,7 @@ process.load('CondCore.CondDB.CondDB_cfi')
 process.CondDB.connect = 'sqlite_file:corrected_sampic.sqlite' # SQLite input
 process.PoolDBESSource = cms.ESSource('PoolDBESSource',
         process.CondDB,
-        DumpStats = cms.untracked.bool(True),
+        DumpStat = cms.untracked.bool(True),
         toGet = cms.VPSet(
             cms.PSet(
                 record = cms.string('PPSTimingCalibrationRcd'),

--- a/CalibTracker/Configuration/python/Common/PoolDBESSource_cfi.py
+++ b/CalibTracker/Configuration/python/Common/PoolDBESSource_cfi.py
@@ -3,7 +3,6 @@ import FWCore.ParameterSet.Config as cms
 from CondCore.CondDB.CondDB_cfi import *
 poolDBESSource = cms.ESSource("PoolDBESSource",
     CondDB,
-    BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
     appendToDataLabel = cms.string(''),
     toGet = cms.VPSet(cms.PSet(
         record = cms.string('SiStripNoisesRcd'),

--- a/CondCore/ESSources/plugins/CondDBESSource.cc
+++ b/CondCore/ESSources/plugins/CondDBESSource.cc
@@ -763,7 +763,7 @@ void CondDBESSource::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   toGetDesc.add<unsigned long long>("refreshTime", std::numeric_limits<unsigned long long>::max());
   toGetDesc.addUntracked<std::string>("label", "");
 
-  std::vector<edm::ParameterSet> default_toGet(1);
+  std::vector<edm::ParameterSet> default_toGet;
   desc.addVPSet("toGet", toGetDesc, default_toGet);
 
   desc.addUntracked<std::string>("JsonDumpFileName", "");

--- a/CondCore/ESSources/plugins/CondDBESSource.cc
+++ b/CondCore/ESSources/plugins/CondDBESSource.cc
@@ -29,6 +29,7 @@
 #include <exception>
 
 #include <iomanip>
+#include <limits>
 
 #include <nlohmann/json.hpp>
 
@@ -123,8 +124,9 @@ namespace {
 CondDBESSource::CondDBESSource(const edm::ParameterSet& iConfig)
     : m_jsonDumpFilename(iConfig.getUntrackedParameter<std::string>("JsonDumpFileName", "")),
       m_connection(),
-      m_connectionString(""),
-      m_frontierKey(""),
+      m_connectionString(iConfig.getParameter<std::string>("connect")),
+      m_globalTag(iConfig.getParameter<std::string>("globaltag")),
+      m_frontierKey(iConfig.getUntrackedParameter<std::string>("frontierKey", "")),
       m_lastRun(0),   // for the stat
       m_lastLumi(0),  // for the stat
       m_policy(NOREFRESH),
@@ -147,69 +149,65 @@ CondDBESSource::CondDBESSource(const edm::ParameterSet& iConfig)
 
   /*parameter set parsing
    */
-  std::string globaltag("");
-  if (iConfig.exists("globaltag")) {
-    globaltag = iConfig.getParameter<std::string>("globaltag");
-    // the global tag _requires_ a connection string
-    m_connectionString = iConfig.getParameter<std::string>("connect");
-
-    if (!globaltag.empty()) {
-      edm::Service<edm::SiteLocalConfig> siteLocalConfig;
-      if (siteLocalConfig.isAvailable()) {
-        if (siteLocalConfig->useLocalConnectString()) {
-          std::string const& localConnectPrefix = siteLocalConfig->localConnectPrefix();
-          std::string const& localConnectSuffix = siteLocalConfig->localConnectSuffix();
-          m_connectionString = localConnectPrefix + globaltag + localConnectSuffix;
-        }
+  if (!m_globalTag.empty()) {
+    edm::Service<edm::SiteLocalConfig> siteLocalConfig;
+    if (siteLocalConfig.isAvailable()) {
+      if (siteLocalConfig->useLocalConnectString()) {
+        std::string const& localConnectPrefix = siteLocalConfig->localConnectPrefix();
+        std::string const& localConnectSuffix = siteLocalConfig->localConnectSuffix();
+        m_connectionString = localConnectPrefix + m_globalTag + localConnectSuffix;
       }
     }
-  } else if (iConfig.exists("connect"))  // default connection string
-    m_connectionString = iConfig.getParameter<std::string>("connect");
-
-  // frontier key
-  m_frontierKey = iConfig.getUntrackedParameter<std::string>("frontierKey", "");
+  }
 
   // snapshot
   boost::posix_time::ptime snapshotTime;
-  if (iConfig.exists("snapshotTime")) {
-    std::string snapshotTimeString = iConfig.getParameter<std::string>("snapshotTime");
-    if (!snapshotTimeString.empty())
-      snapshotTime = boost::posix_time::time_from_string(snapshotTimeString);
+  std::string snapshotTimeString = iConfig.getParameter<std::string>("snapshotTime");
+  if (!snapshotTimeString.empty()) {
+    snapshotTime = boost::posix_time::time_from_string(snapshotTimeString);
   }
 
   // connection configuration
-  if (iConfig.exists("DBParameters")) {
-    edm::ParameterSet connectionPset = iConfig.getParameter<edm::ParameterSet>("DBParameters");
-    m_connection.setParameters(connectionPset);
-  }
+  edm::ParameterSet connectionPset = iConfig.getParameter<edm::ParameterSet>("DBParameters");
+  m_connection.setParameters(connectionPset);
   m_connection.configure();
 
   // load specific record/tag info - it will overwrite the global tag ( if any )
   std::map<std::string, cond::GTEntry_t> replacements;
   std::map<std::string, boost::posix_time::ptime> specialSnapshots;
-  if (iConfig.exists("toGet")) {
-    typedef std::vector<edm::ParameterSet> Parameters;
-    Parameters toGet = iConfig.getParameter<Parameters>("toGet");
+
+  typedef std::vector<edm::ParameterSet> Parameters;
+  Parameters toGet = iConfig.getParameter<Parameters>("toGet");
+  if (!toGet.empty()) {
     for (Parameters::iterator itToGet = toGet.begin(); itToGet != toGet.end(); ++itToGet) {
       std::string recordname = itToGet->getParameter<std::string>("record");
       if (recordname.empty())
         throw cond::Exception("ESSource: The record name has not been provided in a \"toGet\" entry.");
+
       std::string labelname = itToGet->getUntrackedParameter<std::string>("label", "");
       std::string pfn("");
-      if (m_connectionString.empty() || itToGet->exists("connect"))
-        pfn = itToGet->getParameter<std::string>("connect");
-      std::string tag("");
+      const auto& recordConnection = itToGet->getParameter<std::string>("connect");
+      if (m_connectionString.empty() || !recordConnection.empty()) {
+        pfn = recordConnection;
+      }
+      std::string tag = itToGet->getParameter<std::string>("tag");
       std::string fqTag("");
-      if (itToGet->exists("tag")) {
-        tag = itToGet->getParameter<std::string>("tag");
+
+      if (!tag.empty()) {
         fqTag = cond::persistency::fullyQualifiedTag(tag, pfn);
       }
+
       boost::posix_time::ptime tagSnapshotTime =
           boost::posix_time::time_from_string(std::string(cond::time::MAX_TIMESTAMP));
-      if (itToGet->exists("snapshotTime"))
-        tagSnapshotTime = boost::posix_time::time_from_string(itToGet->getParameter<std::string>("snapshotTime"));
-      if (itToGet->exists("refreshTime")) {
-        cond::Time_t refreshTime = itToGet->getParameter<unsigned long long>("refreshTime");
+
+      const auto& snapshotTimeTagString = itToGet->getParameter<std::string>("snapshotTime");
+      if (!snapshotTimeTagString.empty()) {
+        tagSnapshotTime = boost::posix_time::time_from_string(snapshotTimeTagString);
+      }
+
+      const auto& refreshTimeTag = itToGet->getParameter<unsigned long long>("refreshTime");
+      if (refreshTimeTag != std::numeric_limits<unsigned long long>::max()) {
+        cond::Time_t refreshTime = refreshTimeTag;
         m_refreshTimeForRecord.insert(std::make_pair(recordname, std::make_pair(refreshTime, true)));
       }
 
@@ -225,10 +223,10 @@ CondDBESSource::CondDBESSource(const edm::ParameterSet& iConfig)
   std::vector<std::string> connectList;
   std::vector<std::string> pfnPrefixList;
   std::vector<std::string> pfnPostfixList;
-  if (!globaltag.empty()) {
+  if (!m_globalTag.empty()) {
     std::string pfnPrefix(iConfig.getUntrackedParameter<std::string>("pfnPrefix", ""));
     std::string pfnPostfix(iConfig.getUntrackedParameter<std::string>("pfnPostfix", ""));
-    boost::split(globaltagList, globaltag, boost::is_any_of("|"), boost::token_compress_off);
+    boost::split(globaltagList, m_globalTag, boost::is_any_of("|"), boost::token_compress_off);
     fillList(m_connectionString, connectList, globaltagList.size(), "connection");
     fillList(pfnPrefix, pfnPrefixList, globaltagList.size(), "pfnPrefix");
     fillList(pfnPostfix, pfnPostfixList, globaltagList.size(), "pfnPostfix");
@@ -739,6 +737,45 @@ void CondDBESSource::fillTagCollectionFromDB(const std::vector<std::string>& con
     }
     m_tagCollection.insert(*replacementIter);
   }
+}
+
+void CondDBESSource::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+
+  edm::ParameterSetDescription dbParams;
+  dbParams.addUntracked<std::string>("authenticationPath", "");
+  dbParams.addUntracked<int>("authenticationSystem", 0);
+  dbParams.addUntracked<std::string>("security", "");
+  dbParams.addUntracked<int>("messageLevel", 0);
+  dbParams.addUntracked<int>("connectionTimeout", 0);
+  desc.add("DBParameters", dbParams);
+
+  desc.add<std::string>("connect", std::string("frontier://FrontierProd/CMS_CONDITIONS"));
+  desc.add<std::string>("globaltag", "");
+  desc.add<std::string>("snapshotTime", "");
+  desc.addUntracked<std::string>("frontierKey", "");
+
+  edm::ParameterSetDescription toGetDesc;
+  toGetDesc.add<std::string>("record", "");
+  toGetDesc.add<std::string>("tag", "");
+  toGetDesc.add<std::string>("snapshotTime", "");
+  toGetDesc.add<std::string>("connect", "");
+  toGetDesc.add<unsigned long long>("refreshTime", std::numeric_limits<unsigned long long>::max());
+  toGetDesc.addUntracked<std::string>("label", "");
+
+  std::vector<edm::ParameterSet> default_toGet(1);
+  desc.addVPSet("toGet", toGetDesc, default_toGet);
+
+  desc.addUntracked<std::string>("JsonDumpFileName", "");
+  desc.addUntracked<bool>("DumpStat", false);
+  desc.addUntracked<bool>("ReconnectEachRun", false);
+  desc.addUntracked<bool>("RefreshAlways", false);
+  desc.addUntracked<bool>("RefreshEachRun", false);
+  desc.addUntracked<bool>("RefreshOpenIOVs", false);
+  desc.addUntracked<std::string>("pfnPostfix", "");
+  desc.addUntracked<std::string>("pfnPrefix", "");
+
+  descriptions.add("default_CondDBESource", desc);
 }
 
 // backward compatibility for configuration files

--- a/CondCore/ESSources/plugins/CondDBESSource.h
+++ b/CondCore/ESSources/plugins/CondDBESSource.h
@@ -75,6 +75,7 @@
 #include "FWCore/Framework/interface/ESProductResolverProvider.h"
 #include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
 #include "FWCore/Concurrency/interface/SerialTaskQueue.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
 namespace edm {
   class ParameterSet;
@@ -98,6 +99,8 @@ public:
   explicit CondDBESSource(const edm::ParameterSet&);
   ~CondDBESSource() override;
 
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
 protected:
   void setIntervalFor(const EventSetupRecordKey&, const edm::IOVSyncValue&, edm::ValidityInterval&) override;
 
@@ -112,6 +115,7 @@ private:
 
   cond::persistency::ConnectionPool m_connection;
   std::string m_connectionString;
+  std::string m_globalTag;
   std::string m_frontierKey;
 
   // Container of ProductResolver, implemented as multi-map keyed by records

--- a/CondCore/ESSources/python/CondDBESSource_cfi.py
+++ b/CondCore/ESSources/python/CondDBESSource_cfi.py
@@ -5,16 +5,20 @@ import FWCore.ParameterSet.Config as cms
 from CondCore.CondDB.CondDB_cfi import *
 
 CondDBConnection = CondDB.clone( connect = cms.string( 'frontier://FrontierProd/CMS_CONDITIONS' ) )
-GlobalTag = cms.ESSource( "PoolDBESSource",
-                          CondDBConnection,
-                          globaltag        = cms.string( '' ),
-                          snapshotTime     = cms.string( '' ),
-                          toGet            = cms.VPSet(),   # hook to override or add single payloads
-                          DumpStat         = cms.untracked.bool( False ),
-                          ReconnectEachRun = cms.untracked.bool( False ),
-                          RefreshAlways    = cms.untracked.bool( False ),
-                          RefreshEachRun   = cms.untracked.bool( False ),
-                          RefreshOpenIOVs  = cms.untracked.bool( False ),
-                          pfnPostfix       = cms.untracked.string( '' ),
-                          pfnPrefix        = cms.untracked.string( '' ),
-                          )
+from CondCore.ESSources.default_CondDBESource_cfi import PoolDBESSource as _PoolDBESSource
+
+GlobalTag = _PoolDBESSource(
+    CondDBConnection,
+    globaltag        = '',
+    snapshotTime     = '',
+    frontierKey      = '',
+    toGet            = [],   # hook to override or add single payloads
+    JsonDumpFileName = '',
+    DumpStat         = False,
+    ReconnectEachRun = False,
+    RefreshAlways    = False,
+    RefreshEachRun   = False,
+    RefreshOpenIOVs  = False,
+    pfnPostfix       = '',
+    pfnPrefix        = '' ,
+)

--- a/CondCore/ESSources/test/BuildFile.xml
+++ b/CondCore/ESSources/test/BuildFile.xml
@@ -38,4 +38,4 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 
-
+<test name="UnitTestLoadConditions" command="runConditionsLoadTests.sh"/>

--- a/CondCore/ESSources/test/python/load_from_globaltag_cfg.py
+++ b/CondCore/ESSources/test/python/load_from_globaltag_cfg.py
@@ -7,10 +7,10 @@ process = cms.Process("TEST")
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100) )
 
 process.source = cms.Source("EmptyIOVSource",
-                                lastValue = cms.uint64(3),
-                                timetype = cms.string('runnumber'),
-                                firstValue = cms.uint64(1),
-                                interval = cms.uint64(1)
+                            lastValue = cms.uint64(3),
+                            timetype = cms.string('runnumber'),
+                            firstValue = cms.uint64(1),
+                            interval = cms.uint64(1)
                             )
 
 from CondCore.ESSources.GlobalTag import GlobalTag

--- a/CondCore/ESSources/test/python/load_record_empty_source_cfg.py
+++ b/CondCore/ESSources/test/python/load_record_empty_source_cfg.py
@@ -133,7 +133,7 @@ if options.pfnPostfix:
 
 process.source = cms.Source( "EmptySource",
                              firstRun = cms.untracked.uint32( options.runNumber ),
-                             firstTime = cms.untracked.uint64( ( long( time.time() ) - 24 * 3600 ) << 32 ), #24 hours ago in nanoseconds
+                             firstTime = cms.untracked.uint64((int(time.time()) - 24 * 3600) << 32),  # 24 hours ago in nanoseconds
                              numberEventsInRun = cms.untracked.uint32( options.eventsPerLumi *  options.numberOfLumis ), # options.numberOfLumis lumi sections per run
                              numberEventsInLuminosityBlock = cms.untracked.uint32( options.eventsPerLumi )
                              )

--- a/CondCore/ESSources/test/python/load_records_cfg.py
+++ b/CondCore/ESSources/test/python/load_records_cfg.py
@@ -11,15 +11,15 @@ process.PoolDBESSource = cms.ESSource("PoolDBESSource",
         tag = cms.string('mytest')
     ), cms.PSet(
         record = cms.string('anotherPedestalsRcd'),
-        tag = cms.string('anothermytest')
+        tag = cms.string('mytest_1')
     )),
-    connect = cms.string('sqlite_file:test.db')
+    connect = cms.string('frontier://FrontierPrep/CMS_CONDITIONS')
 )
 
 process.source = cms.Source("EmptyIOVSource",
     lastValue = cms.uint64(3),
     timetype = cms.string('runnumber'),
-    firstValue = cms.uint64(1),
+    firstValue = cms.uint64(200000),
     interval = cms.uint64(1)
 )
 

--- a/CondCore/ESSources/test/python/load_tagcollection_cfg.py
+++ b/CondCore/ESSources/test/python/load_tagcollection_cfg.py
@@ -1,28 +1,24 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
-process.load("CondCore.DBCommon.CondDBCommon_cfi")
-process.CondDBCommon.connect = cms.string("")
-process.CondDBCommon.DBParameters.messageLevel = 0
+
+CondDBSetup = cms.PSet(DBParameters = cms.PSet(messageLevel = cms.untracked.int32(1)))
 
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
-   connect = cms.string(''),
-   DBParameters = cms.PSet(
-        messageLevel = cms.untracked.int32(0),
-        authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
-    ),
+    CondDBSetup,
+    connect = cms.string(''),
     toGet = cms.VPSet(
         cms.PSet(
-        connect = cms.untracked.string('oracle://cms_orcoff_prod/CMS_COND_20X_DT'),
-        record = cms.string('DTTtrigRcd'),
-        tag = cms.string('tTrig_GRUMM_080313_hlt'),
-        label = cms.untracked.string('t2')
+            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+            record = cms.string('DTTtrigRcd'),
+            tag = cms.string('DTTtrig_STARTUP_V01_mc'),
+            label = cms.untracked.string('t2')
         ), 
         cms.PSet(
-        connect = cms.untracked.string('sqlite_file:orconGRUMM_200p9.db'),
-        record = cms.string('DTTtrigRcd'),
-        tag = cms.string('tTrig_GRUMM_080313'),
-        label = cms.untracked.string('t1')
+            connect = cms.string('frontier://FrontierPrep/CMS_CONDITIONS'),
+            record = cms.string('DTTtrigRcd'),
+            tag = cms.string('DTTtrig_IDEAL_V02_mc'),
+            label = cms.untracked.string('t1')
         )
      )
 )

--- a/CondCore/ESSources/test/runConditionsLoadTests.sh
+++ b/CondCore/ESSources/test/runConditionsLoadTests.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+function die { echo $1: status $2 ; exit $2; }
+
+echo " testing CondCore/ESSources/test/python/load* "
+
+# List of successful configuration files
+configs=(
+    "load_records_cfg.py"                   
+    "load_modifiedglobaltag_cfg.py"
+    "loadall_from_prodglobaltag_cfg.py"     
+    "load_record_empty_source_cfg.py"
+    "loadall_from_one_record_empty_source_cfg.py"
+    "load_from_multiplesources_cfg.py"
+    "loadall_from_gt_empty_source_cfg.py"
+    "load_tagcollection_cfg.py"
+    "loadall_from_gt_cfg.py"
+    "load_from_globaltag_cfg.py"
+)
+
+# Loop through each successful configuration file and run cmsRun
+for config in "${configs[@]}";
+do
+  echo "===== Test \"cmsRun $config \" ===="
+  (cmsRun "${SCRAM_TEST_PATH}/python/"$config) || die "Failure using cmsRun $config" $?
+done

--- a/CondTools/CTPPS/test/ppsTimingCalibrationLUTAnalyzer_cfg.py
+++ b/CondTools/CTPPS/test/ppsTimingCalibrationLUTAnalyzer_cfg.py
@@ -26,7 +26,7 @@ process.CondDB.connect = 'sqlite_file:ppsDiamondTiming_calibrationLUT.sqlite' # 
 
 process.PoolDBESSource = cms.ESSource('PoolDBESSource',
     process.CondDB,
-    DumpStats = cms.untracked.bool(True),
+    DumpStat = cms.untracked.bool(True),
     toGet = cms.VPSet(
         cms.PSet(
             record = cms.string('PPSTimingCalibrationLUTRcd'),

--- a/CondTools/DQM/test/DQMXMLFileEventSetupAnalyzer_cfg.py
+++ b/CondTools/DQM/test/DQMXMLFileEventSetupAnalyzer_cfg.py
@@ -46,9 +46,6 @@ if options.unitTest:
 
     process.XmlRetrieval_1 = cms.ESSource("PoolDBESSource",
                                           process.CondDB,
-                                          BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
-                                          messageLevel = cms.untracked.int32(1),
-                                          timetype = cms.string('runnumber'),
                                           toGet = cms.VPSet(cms.PSet(record = cms.string('DQMXMLFileRcd'),
                                                                      tag = cms.string('XML_test'),
                                                                      label=cms.untracked.string('XML_label')

--- a/CondTools/RunInfo/test/LHCInfoPerFillAnalyzer_cfg.py
+++ b/CondTools/RunInfo/test/LHCInfoPerFillAnalyzer_cfg.py
@@ -26,7 +26,7 @@ process.CondDB.connect = 'sqlite_file:LHCInfoPerFill.sqlite' # SQLite input
 
 process.PoolDBESSource = cms.ESSource('PoolDBESSource',
     process.CondDB,
-    DumpStats = cms.untracked.bool(True),
+    DumpStat = cms.untracked.bool(True),
     toGet = cms.VPSet(
         cms.PSet(
             record = cms.string('LHCInfoPerFillRcd'),

--- a/CondTools/RunInfo/test/LHCInfoPerLSAnalyzer_cfg.py
+++ b/CondTools/RunInfo/test/LHCInfoPerLSAnalyzer_cfg.py
@@ -26,7 +26,7 @@ process.CondDB.connect = 'sqlite_file:LHCInfoPerLS.sqlite' # SQLite input
 
 process.PoolDBESSource = cms.ESSource('PoolDBESSource',
     process.CondDB,
-    DumpStats = cms.untracked.bool(True),
+    DumpStat = cms.untracked.bool(True),
     toGet = cms.VPSet(
         cms.PSet(
             record = cms.string('LHCInfoPerLSRcd'),

--- a/CondTools/SiPixel/test/SiPixelBadModuleReader_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelBadModuleReader_cfg.py
@@ -27,12 +27,10 @@ from Configuration.AlCa.autoCond import autoCond
 process.GlobalTag.globaltag = autoCond['run2_design']
 
 process.QualityReader = cms.ESSource("PoolDBESSource",
-    BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
     DBParameters = cms.PSet(
         messageLevel = cms.untracked.int32(0),
         authenticationPath = cms.untracked.string('')
     ),
-    timetype = cms.string('runnumber'),
     toGet = cms.VPSet(cms.PSet(
         record = cms.string('SiPixelQualityFromDbRcd'),
         tag = cms.string('SiPixelQuality_v07_mc')

--- a/CondTools/SiPixel/test/SiPixelCondObjAllPayloadsReader_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelCondObjAllPayloadsReader_cfg.py
@@ -63,7 +63,6 @@ process.CondDB.DBParameters.messageLevel = 2
 process.CondDB.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/conddb'
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
                                       process.CondDB,
-                                      BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
                                       toGet = cms.VPSet(#cms.PSet(record = cms.string('SiPixelGainCalibrationRcd'),
                                                         #         tag = cms.string('GainCalibTestFull')
                                                         #     ), 

--- a/CondTools/SiPixel/test/SiPixelCondObjForHLTReader_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelCondObjForHLTReader_cfg.py
@@ -35,7 +35,6 @@ process.SimpleMemoryCheck = cms.Service("SimpleMemoryCheck",
 
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
     process.CondDB,
-    BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
     toGet = cms.VPSet(cms.PSet(
         record = cms.string('SiPixelGainCalibrationForHLTRcd'),
         tag = cms.string('SiPixelGainCalibrationHLT_2009runs_express')

--- a/CondTools/SiPixel/test/SiPixelCondObjOfflineReader_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelCondObjOfflineReader_cfg.py
@@ -35,7 +35,6 @@ process.SimpleMemoryCheck = cms.Service("SimpleMemoryCheck",
 
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
     process.CondDB,
-    BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
     toGet = cms.VPSet(cms.PSet(
         record = cms.string('SiPixelGainCalibrationOfflineRcd'),
         tag = cms.string('SiPixelGainCalibration_2009runs_express')

--- a/CondTools/SiPixel/test/SiPixelGainCalibrationRejectNoisyAndDead_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelGainCalibrationRejectNoisyAndDead_cfg.py
@@ -50,7 +50,6 @@ process.source = cms.Source("EmptyIOVSource",
 
 #Input DB
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
-    BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
     DBParameters = cms.PSet(
         messageLevel = cms.untracked.int32(10),
         authenticationPath = cms.untracked.string('.')

--- a/CondTools/SiStrip/test/SiStripApvGainFromASCIIFile_cfg.py
+++ b/CondTools/SiStrip/test/SiStripApvGainFromASCIIFile_cfg.py
@@ -35,7 +35,6 @@ process.CondDB.connect='frontier://FrontierProd/CMS_CONDITIONS'
 
 process.poolDBESSource = cms.ESSource('PoolDBESSource',
                                       process.CondDB,
-                                      BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
                                       toGet = cms.VPSet( cms.PSet(record = cms.string('SiStripFedCablingRcd'),
                                                                   tag    = cms.string('SiStripFedCabling_GR10_v1_hlt')
                                                                   )
@@ -49,11 +48,9 @@ process.maxEvents = cms.untracked.PSet(
 )
 
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
-    BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
     DBParameters = cms.PSet(
         authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
     ),
-    timetype = cms.untracked.string('runnumber'),
     connect = cms.string('sqlite_file:dbfile.db'),
     toPut = cms.VPSet(cms.PSet(
         record = cms.string('SiStripApvGainRcd'),

--- a/CondTools/SiStrip/test/SiStripBadChannelPatcher_cfg.py
+++ b/CondTools/SiStrip/test/SiStripBadChannelPatcher_cfg.py
@@ -90,7 +90,6 @@ process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect='frontier://FrontierProd/CMS_CONDITIONS'
 process.CablingESSource = cms.ESSource('PoolDBESSource',
                                        process.CondDB,
-                                       BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
                                        toGet = cms.VPSet( cms.PSet(record = cms.string('SiStripFedCablingRcd'),
                                                                    tag    = cms.string('SiStripFedCabling_GR10_v1_hlt')   # real data cabling map
                                                                    #tag     = cms.string('SiStripFedCabling_Ideal_31X_v2')  # ideal cabling map
@@ -105,12 +104,10 @@ process.load("CalibTracker.SiStripESProducers.SiStripConnectivity_cfi")
 ## Input bad components
 ##
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
-                                      BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
                                       DBParameters = cms.PSet(
                                           messageLevel = cms.untracked.int32(2),
                                           authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
                                       ),
-                                      timetype = cms.string('runnumber'),
                                       toGet = cms.VPSet(cms.PSet(
                                           record = cms.string('SiStripBadStripRcd'),
                                           tag = cms.string(options.inputTag)

--- a/CondTools/SiStrip/test/SiStripBadStripReader_cfg.py
+++ b/CondTools/SiStrip/test/SiStripBadStripReader_cfg.py
@@ -19,18 +19,16 @@ process.MessageLogger = cms.Service("MessageLogger",
 process.Timing = cms.Service("Timing")
 
 process.PoolDBESSource = cms.ESSource("PoolDBESSource",
-    BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
-    DBParameters = cms.PSet(
-        messageLevel = cms.untracked.int32(2),
-        authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
-    ),
-    timetype = cms.string('runnumber'),
-    toGet = cms.VPSet(cms.PSet(
-        record = cms.string('SiStripBadStripRcd'),
-        tag = cms.string('SiStripBadChannel_v1')
-    )),
-    connect = cms.string('sqlite_file:SiStripConditionsDBFile.db')
-)
+                                      DBParameters = cms.PSet(
+                                          messageLevel = cms.untracked.int32(2),
+                                          authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
+                                      ),
+                                      toGet = cms.VPSet(cms.PSet(
+                                          record = cms.string('SiStripBadStripRcd'),
+                                          tag = cms.string('SiStripBadChannel_v1')
+                                      )),
+                                      connect = cms.string('sqlite_file:SiStripConditionsDBFile.db')
+                                      )
 
 process.prod = cms.EDAnalyzer("SiStripBadStripReader",
     printDebug = cms.untracked.bool(True)

--- a/CondTools/SiStrip/test/SiStripFedCablingReader_cfg.py
+++ b/CondTools/SiStrip/test/SiStripFedCablingReader_cfg.py
@@ -19,12 +19,10 @@ process.maxEvents = cms.untracked.PSet(
 )
 
 process.poolDBESSource = cms.ESSource("PoolDBESSource",
-   BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
    DBParameters = cms.PSet(
         messageLevel = cms.untracked.int32(2),
         authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
     ),
-    timetype = cms.untracked.string('runnumber'),
     connect = cms.string('sqlite_file:SiStripConditionsDBFile.db'),
     toGet = cms.VPSet(cms.PSet(
         record = cms.string('SiStripFedCablingRcd'),

--- a/CondTools/SiStrip/test/SiStripSummaryReader_cfg.py
+++ b/CondTools/SiStrip/test/SiStripSummaryReader_cfg.py
@@ -28,12 +28,10 @@ process.maxEvents = cms.untracked.PSet(
 )
 
 process.poolDBESSource = cms.ESSource("PoolDBESSource",
-   BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
    DBParameters = cms.PSet(
         messageLevel = cms.untracked.int32(2),
         authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
     ),
-    timetype = cms.untracked.string('runnumber'),
     connect = cms.string('sqlite_file:SiStripConditionsDBFile.db'),
     toGet = cms.VPSet(cms.PSet(
         record = cms.string('SiStripSummaryRcd'),

--- a/CondTools/SiStrip/test/SiStripThresholdReader_cfg.py
+++ b/CondTools/SiStrip/test/SiStripThresholdReader_cfg.py
@@ -27,12 +27,10 @@ process.source = cms.Source("EmptySource",
 )
 
 process.poolDBESSource = cms.ESSource("PoolDBESSource",
-   BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
    DBParameters = cms.PSet(
         messageLevel = cms.untracked.int32(2),
         authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
     ),
-    timetype = cms.untracked.string('runnumber'),
     connect = cms.string('sqlite_file:SiStripConditionsDBFile.db'),
     toGet = cms.VPSet(cms.PSet(
         record = cms.string('SiStripThresholdRcd'),

--- a/DQM/CTPPS/test/diamond_re_reco_dqm_test_cfg.py
+++ b/DQM/CTPPS/test/diamond_re_reco_dqm_test_cfg.py
@@ -71,7 +71,7 @@ process.ctppsDiamondRecHits.timingCalibrationTag="GlobalTag:PPSTestCalibration"
 #process.CondDB.connect = 'sqlite_file:ppsDiamondTiming_calibration.sqlite' # SQLite input
 #process.PoolDBESSource = cms.ESSource('PoolDBESSource',
 #        process.CondDB,
-#        DumpStats = cms.untracked.bool(True),
+#        DumpStat = cms.untracked.bool(True),
 #        toGet = cms.VPSet(
 #            cms.PSet(
 #                record = cms.string('PPSTimingCalibrationRcd'),

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -17,8 +17,6 @@ from HLTrigger.Configuration.common import *
 #                     pset.minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('HLTSiStripClusterChargeCutNone'))
 #     return process
 
-
-
 def customiseForOffline(process):
     # For running HLT offline and relieve the strain on Frontier so it will no longer inject a
     # transaction id which tells Frontier to add a unique "&freshkey" to many query URLs.
@@ -39,6 +37,26 @@ def customiseForOffline(process):
 
     return process
 
+def customizeHLTfor47630(process):
+    attributes_to_remove = [
+        'connectionRetrialPeriod',
+        'connectionRetrialTimeOut',
+        'connectionTimeOut',
+        'enableConnectionSharing',
+        'enablePoolAutomaticCleanUp',
+        'enableReadOnlySessionOnUpdateConnection',
+        'idleConnectionCleanupPeriod'
+    ]
+
+    for mod in modules_by_type(process, "PoolDBESSource"):
+        if hasattr(mod, 'DBParameters'):
+            pset = getattr(mod,'DBParameters')
+            for attr in attributes_to_remove:
+                if hasattr(pset, attr):
+                    delattr(mod.DBParameters, attr)
+                    
+    return process
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
@@ -46,5 +64,7 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
 
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
+    
+    process = customizeHLTfor47630(process)
     
     return process

--- a/RecoPPS/Local/test/diamonds_reco_cfg.py
+++ b/RecoPPS/Local/test/diamonds_reco_cfg.py
@@ -23,7 +23,7 @@ elif calibrationMode == PPSTimingCalibrationModeEnum.SQLite:
     process.CondDB.connect = 'sqlite_file:ppsDiamondTiming_calibration.sqlite' # SQLite input
     process.PoolDBESSource = cms.ESSource('PoolDBESSource',
         process.CondDB,
-        DumpStats = cms.untracked.bool(True),
+        DumpStat = cms.untracked.bool(True),
         toGet = cms.VPSet(
             cms.PSet(
                 record = cms.string('PPSTimingCalibrationRcd'),

--- a/RecoPPS/Local/test/totemTiming_digiConverter_reco_cfg.py
+++ b/RecoPPS/Local/test/totemTiming_digiConverter_reco_cfg.py
@@ -102,7 +102,7 @@ process.totemTimingRecHits.mergeTimePeaks= cms.bool(False)
 #process.CondDB.connect = 'sqlite_file:ppsDiamondSampicTiming_calibration.sqlite' # SQLite input
 #process.PoolDBESSource = cms.ESSource('PoolDBESSource',
 #        process.CondDB,
-#        DumpStats = cms.untracked.bool(True),
+#        DumpStat = cms.untracked.bool(True),
 #        toGet = cms.VPSet(
 #            cms.PSet(
 #                record = cms.string('PPSTimingCalibrationRcd'),

--- a/RecoPPS/Local/test/totemTiming_reco_cfg.py
+++ b/RecoPPS/Local/test/totemTiming_reco_cfg.py
@@ -23,7 +23,7 @@ elif calibrationMode == PPSTimingCalibrationModeEnum.SQLite:
     process.CondDB.connect = 'sqlite_file:totemTiming_calibration.sqlite' # SQLite input
     process.PoolDBESSource = cms.ESSource('PoolDBESSource',
         process.CondDB,
-        DumpStats = cms.untracked.bool(True),
+        DumpStat = cms.untracked.bool(True),
         toGet = cms.VPSet(
             cms.PSet(
                 record = cms.string('PPSTimingCalibrationRcd'),


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/47688
backport of https://github.com/cms-sw/cmssw/pull/47675
backport of https://github.com/cms-sw/cmssw/pull/47630

#### PR description:

This is a combined backport of https://github.com/cms-sw/cmssw/pull/47630, https://github.com/cms-sw/cmssw/pull/47675,  and https://github.com/cms-sw/cmssw/pull/47688.
   * provides a `fillDescriptions` method to  `CondDBESSource`
   * customizes the HLT menus in release for the illegal parameters present in them
   * fix related usage of `PoolDBESSource` in the configuration files used in unit tests

#### PR validation:

`scram b runtests` works for all the packages involved.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Combined verbatim backport of https://github.com/cms-sw/cmssw/pull/47630, https://github.com/cms-sw/cmssw/pull/47675,  and https://github.com/cms-sw/cmssw/pull/47688 to 15.0.X as 2025 data-taking release.
This is needed for:
   * https://github.com/cms-sw/cmssw/pull/47619
