### PR TITLE
Fix use-after-move LLVM analyzer warning in PFClusterEMEnergyCorrector

### DIFF
--- a/CalibCalorimetry/EcalTPGTools/interface/EcalReadoutTools.h
+++ b/CalibCalorimetry/EcalTPGTools/interface/EcalReadoutTools.h
@@ -16,7 +16,7 @@ private:
 
 public:
   struct ESGetTokens {
-    ESGetTokens(const edm::ParameterSet&, edm::ConsumesCollector&& iC)
+    ESGetTokens(const edm::ParameterSet&, edm::ConsumesCollector iC)
         : ecalTrigTowerConstituentsMapToken{iC.esConsumes()}, ecalElectronicsMappingToken{iC.esConsumes()} {}
     edm::ESGetToken<EcalTrigTowerConstituentsMap, IdealGeometryRecord> const ecalTrigTowerConstituentsMapToken;
     edm::ESGetToken<EcalElectronicsMapping, EcalMappingRcd> const ecalElectronicsMappingToken;

--- a/RecoParticleFlow/PFClusterProducer/src/PFClusterEMEnergyCorrector.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/PFClusterEMEnergyCorrector.cc
@@ -12,9 +12,7 @@ namespace {
 }  // namespace
 
 PFClusterEMEnergyCorrector::PFClusterEMEnergyCorrector(const edm::ParameterSet &conf, edm::ConsumesCollector &&cc)
-    : ecalClusterToolsESGetTokens_{std::move(cc)},
-      ecalReadoutToolsESGetTokens_{conf, std::move(cc)},
-      calibrator_(new PFEnergyCalibration) {
+    : ecalClusterToolsESGetTokens_{cc}, ecalReadoutToolsESGetTokens_{conf, cc}, calibrator_(new PFEnergyCalibration) {
   applyCrackCorrections_ = conf.getParameter<bool>("applyCrackCorrections");
   applyMVACorrections_ = conf.getParameter<bool>("applyMVACorrections");
   srfAwareCorrection_ = conf.getParameter<bool>("srfAwareCorrection");


### PR DESCRIPTION
#### PR description:

As suggested in https://github.com/cms-sw/cmssw/issues/46155#issuecomment-2383267342. Similar fix in https://github.com/cms-sw/cmssw/pull/46276 [link](https://github.com/cms-sw/cmssw/commit/8d11cbb8cbfd5aaec7684b737bc1575a4088dbae#diff-bcdf596b8b859dd2a3e92d3b48535675174c00912d5c2f4f43e574a307a650baR19). Change to `EсalReadoutTools::ESGetTokens` is similar to https://github.com/cms-sw/cmssw/commit/a1693428569e90fd7f042b8961e367cd42ca37c1

#### PR validation:

Bot tests