### PR TITLE
remove empty `cms.PSet()` from auto-generated `default_CondDBESource_cfi` file

### DIFF
--- a/CondCore/ESSources/plugins/CondDBESSource.cc
+++ b/CondCore/ESSources/plugins/CondDBESSource.cc
@@ -763,7 +763,7 @@ void CondDBESSource::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   toGetDesc.add<unsigned long long>("refreshTime", std::numeric_limits<unsigned long long>::max());
   toGetDesc.addUntracked<std::string>("label", "");
 
-  std::vector<edm::ParameterSet> default_toGet(1);
+  std::vector<edm::ParameterSet> default_toGet;
   desc.addVPSet("toGet", toGetDesc, default_toGet);
 
   desc.addUntracked<std::string>("JsonDumpFileName", "");


### PR DESCRIPTION
#### PR description:

Addresses the discussion at https://github.com/cms-sw/cmssw/pull/47630#discussion_r2010229848, by removing the `toGet = cms.VPSet(cms.PSet())` being generated by default (and injected in the configuration validation if the `toGet` parameter is missing). 

#### PR validation:

With this PR:

```console
$ python3 -i -m CondCore.ESSources.default_CondDBESource_cfi
>>> default_CondDBESource.toGet
cms.VPSet(template = cms.PSetTemplate(
    connect = cms.string(''),
    label = cms.untracked.string(''),
    record = cms.string(''),
    refreshTime = cms.uint64(18446744073709551615),
    snapshotTime = cms.string(''),
    tag = cms.string('')
))
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

It will be backported at https://github.com/cms-sw/cmssw/pull/47676