### PR TITLE
[NGT] Fix HLT Muon paths for Phase 2 Validation

### DIFF
--- a/HLTriggerOffline/Muon/python/hltMuonValidator_cfi.py
+++ b/HLTriggerOffline/Muon/python/hltMuonValidator_cfi.py
@@ -12,18 +12,17 @@ hltMuonValidator = DQMEDAnalyzer('HLTMuonValidator',
         "HLT_Dimuon13_Jpsi_Barrel(_v[0-9]*)?$",
         ),
 
-    genParticleLabel = cms.string("genParticles"       ),
-        recMuonLabel = cms.string("muons"              ),
+    genParticleLabel = cms.string("genParticles"),
+        recMuonLabel = cms.string("muons"),
 
-    parametersTurnOn = cms.vdouble(0,
-                                   1,  2,  3,  4,  5,  6,  7,  8,  9, 10,
+    parametersTurnOn = cms.vdouble(0, 1,  2,  3,  4,  5,  6,  7,  8,  9, 10,
                                    11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
                                    22, 24, 26, 28, 30, 32, 34, 36, 38, 40,
-                                   45, 50, 55, 60, 65, 70,
-                                   80, 100, 200, 500, 1000, 2000,
+                                   45, 50, 55, 60, 65, 70, 80, 100, 200, 
+                                   500, 1000, 2000
                                    ), 
-    parametersEta      = cms.vdouble(48, -2.400, 2.400),
-    parametersPhi      = cms.vdouble(50, -3.142, 3.142),
+    parametersEta = cms.vdouble(48, -2.400, 2.400),
+    parametersPhi = cms.vdouble(50, -3.142, 3.142),
 
     # set criteria for matching at L1, L2, L3
     cutsDr = cms.vdouble(0.4, 0.4, 0.015),
@@ -41,15 +40,17 @@ hltMuonValidator = DQMEDAnalyzer('HLTMuonValidator',
     propagatorAny = cms.ESInputTag("", "SteppingHelixPropagatorAny"),
     propagatorOpposite = cms.ESInputTag("", "hltESPSteppingHelixPropagatorOpposite"),
     # set cuts on generated and reconstructed muons
-    genMuonCut  = cms.string("abs(pdgId) == 13 && status == 1"),
-    recMuonCut  = cms.string("isGlobalMuon"),
+    genMuonCut = cms.string("abs(pdgId) == 13 && status == 1"),
+    recMuonCut = cms.string("isGlobalMuon"),
 )
 
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 phase2_common.toModify(hltMuonValidator,
                        hltPathsToCheck = [
-                           "HLT_Mu[0-9]+_TrkIso[A-Z]+_Mu[0-9]+_TrkIso[A-Z]+_DZ_FromL1TkMuon(_v[0-9]+)?$",
-                           "HLT_Mu[0-9]+_Mu[0-9]+_FromL1TkMuon(_v[0-9]+)?$",
                            "HLT_Mu[0-9]+_FromL1TkMuon(_v[0-9]+)?$",
+                           "HLT_IsoMu[0-9]+_FromL1TkMuon(_v[0-9]+)?$",
+                           "HLT_Mu[0-9]+_Mu[0-9]+_FromL1TkMuon(_v[0-9]+)?$",
+                           "HLT_Mu[0-9]+_TrkIso[A-Z]+_Mu[0-9]+_TrkIso[A-Z]+_DZ_FromL1TkMuon(_v[0-9]+)?$",
+                           "HLT_TriMu_[0-9]+_[0-9]+_[0-9]+_DZ_FromL1TkMuon(_v[0-9]+)?$"
                        ]
 )


### PR DESCRIPTION
#### PR description:

This PR changes the list of HLT Muon paths checked during validation. It should fix the [#39362 (comment)](https://github.com/cms-sw/cmssw/issues/39362#issuecomment-2666480839) from the CMSSW side (we still have a bunch of folders with no plots under `HLT/Muon/Efficiency_Layout`, but those are produced by the DQM GUI). 
No physics changes are expected, in Phase 2 DQM files there should be one folder for each HLT Muon path currently present in the menu under `HLT/Muon/Distributions`

#### PR validation:

I've produced a DQM file with 200 events from workflow 29850 (ZMM 200PU) to verify that the `Distributions` plots are filled correctly. The file is available [here](https://cernbox.cern.ch/s/K1fzE6AcW5p2law).

FYI @mtosi @BlancoFS 