### PR TITLE
Include the possibility of combining four objects in the "CandViewShallowCloneCombiner" producer

### DIFF
--- a/CommonTools/CandAlgos/interface/CandCombiner.h
+++ b/CommonTools/CandAlgos/interface/CandCombiner.h
@@ -81,7 +81,7 @@ namespace reco {
           throw edm::Exception(edm::errors::Configuration, "failed to parse \"" + decay + "\"");
 
         int lists = labels_.size();
-        if (lists != 2 && lists != 3)
+        if (lists != 2 && lists != 3 && lists != 4)
           throw edm::Exception(edm::errors::LogicError, "invalid number of collections");
         bool found;
         const string setLongLived("setLongLived");


### PR DESCRIPTION
#### PR description:

Included the possibility of using the producer “CandViewShallowCloneCombiner” to create combinations of four objects, I simply added `&& lists != 4` in:
```
if (lists != 2 && lists != 3)
```

#### PR validation:

The producer has been used with this modification to generate combinations of four muons without apparent issues in the B→4μ analysis.
P.S. This modification will not have any impact on combinations of two or three objects.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Will backport to 15_1_X and 15_0_X. 
If it is possible also to: 14_2_X, 14_1_X and 14_0_X
