### PR TITLE
Allow RelVal workflows to use RNTuple

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -619,7 +619,7 @@ class ConfigBuilder(object):
                 defaultFileName=self._options.outfile_name
             else:
                 defaultFileName=self._options.outfile_name.replace('.root','_in'+theTier+'.root')
-                defaultFileName=self._options.outfile_name.replace('.rntpl','_in'+theTier+'.rntpl')
+                defaultFileName=defaultFileName.replace('.rntpl','_in'+theTier+'.rntpl')
 
             theFileName=self._options.dirout+anyOf(['fn','fileName'],outDefDict,defaultFileName)
             if not theFileName.endswith('.root'):
@@ -699,7 +699,7 @@ class ConfigBuilder(object):
                 theFileName=self._options.outfile_name
             else:
                 theFileName=self._options.outfile_name.replace('.root','_in'+streamType+'.root')
-                theFileName=self._options.outfile_name.replace('.rntpl','_in'+streamType+'.rntpl')
+                theFileName=theFileName.replace('.rntpl','_in'+streamType+'.rntpl')
             theFilterName=self._options.filtername
             if streamType=='ALCARECO':
                 theFilterName = 'StreamALCACombined'

--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -729,8 +729,7 @@ class ConfigBuilder(object):
             CppType='TimeoutPoolOutputModule'
         if streamType=='DQM' and tier=='DQMIO':
             CppType='DQMRootOutputModule'
-            if len(fileName) > 6 and fileName[-6:] == '.rntpl':
-                fileName = fileName.replace('.rntpl', '.root')
+            fileName = fileName.replace('.rntpl', '.root')
         if not ignoreNano and "NANOAOD" in streamType : CppType='NanoAODOutputModule'
         if self._options.rntuple_out and CppType == 'PoolOutputModule':
             CppType='RNTupleOutputModule'

--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -619,6 +619,7 @@ class ConfigBuilder(object):
                 defaultFileName=self._options.outfile_name
             else:
                 defaultFileName=self._options.outfile_name.replace('.root','_in'+theTier+'.root')
+                defaultFileName=self._options.outfile_name.replace('.rntpl','_in'+theTier+'.rntpl')
 
             theFileName=self._options.dirout+anyOf(['fn','fileName'],outDefDict,defaultFileName)
             if not theFileName.endswith('.root'):
@@ -698,6 +699,7 @@ class ConfigBuilder(object):
                 theFileName=self._options.outfile_name
             else:
                 theFileName=self._options.outfile_name.replace('.root','_in'+streamType+'.root')
+                theFileName=self._options.outfile_name.replace('.rntpl','_in'+streamType+'.rntpl')
             theFilterName=self._options.filtername
             if streamType=='ALCARECO':
                 theFilterName = 'StreamALCACombined'
@@ -725,7 +727,10 @@ class ConfigBuilder(object):
         CppType='PoolOutputModule'
         if self._options.timeoutOutput:
             CppType='TimeoutPoolOutputModule'
-        if streamType=='DQM' and tier=='DQMIO': CppType='DQMRootOutputModule'
+        if streamType=='DQM' and tier=='DQMIO':
+            CppType='DQMRootOutputModule'
+            if len(fileName) > 6 and fileName[-6:] == '.rntpl':
+                fileName = fileName.replace('.rntpl', '.root')
         if not ignoreNano and "NANOAOD" in streamType : CppType='NanoAODOutputModule'
         if self._options.rntuple_out and CppType == 'PoolOutputModule':
             CppType='RNTupleOutputModule'

--- a/Configuration/PyReleaseValidation/python/WorkFlowRunner.py
+++ b/Configuration/PyReleaseValidation/python/WorkFlowRunner.py
@@ -186,20 +186,23 @@ class WorkFlowRunner(Thread):
                     # Disable input for premix stage1 to allow combined stage1+stage2 workflow
                     # Disable input for premix stage2 in FastSim to allow combined stage1+stage2 workflow (in FS, stage2 does also GEN)
                     # Ugly hack but works
+                    extension = '.root'
+                    if '--rntuple_out' in cmd:
+                        extension = '.rntpl'
                     if istep!=1 and not '--filein' in cmd and not 'premix_stage1' in cmd and not ("--fast" in cmd and "premix_stage2" in cmd):
                         steps = cmd.split("-s ")[1].split(" ")[0] ## relying on the syntax: cmsDriver -s STEPS --otherFlags
                         if "ALCA" not in steps:
-                            cmd+=' --filein  file:step%s.root '%(istep-1,)
+                            cmd+=' --filein  file:step%s%s '%(istep-1,extension)
                         elif "ALCA" in steps and "RECO" in steps:
-                            cmd+=' --filein  file:step%s.root '%(istep-1,)
+                            cmd+=' --filein  file:step%s%s '%(istep-1,extension)
                         elif self.recoOutput:
                             cmd+=' --filein %s'%(self.recoOutput)
                         else:
-                            cmd+=' --filein  file:step%s.root '%(istep-1,)
+                            cmd+=' --filein  file:step%s%s '%(istep-1,extension)
                     if not '--fileout' in com:
-                        cmd+=' --fileout file:step%s.root '%(istep,)
+                        cmd+=' --fileout file:step%s%s '%(istep,extension)
                         if "RECO" in cmd:
-                            self.recoOutput = "file:step%d.root"%(istep)
+                            self.recoOutput = "file:step%d%s"%(istep,extension)
                 if self.jobReport:
                   cmd += ' --suffix "-j JobReport%s.xml " ' % istep
                 if (self.nThreads > 1) and ('HARVESTING' not in cmd) and ('ALCAHARVEST' not in cmd):


### PR DESCRIPTION
#### PR description:

- When building a workflow, the use of the option `--rntuple_out` will cause the default file names generated to use `.rntpl` extension
- Properly handle generating file names with `.rntpl` extension when multiple files are written by a job.

#### PR validation:

Tested workflow 1.0 and 7.0 in my own build area using CMSSW_15_1_RNTUPLE_X_2025-03-19-2300.

resolves https://github.com/cms-sw/framework-team/issues/1314