### PR TITLE
[15.0.X] remove hardcoded IP substitution for `dbproxy` option of `hltGetConfiguration`

### DIFF
--- a/HLTrigger/Configuration/python/Tools/confdbOfflineConverter.py
+++ b/HLTrigger/Configuration/python/Tools/confdbOfflineConverter.py
@@ -21,12 +21,12 @@ class OfflineConverter:
     #   CMSRAC11-V.cms, CMSRAC12-V.cms, CMSRAC21-V.cms
 
     # the possible machines and interfaces for the *offline* database are
-    #   cmsr1-s.cms, cmsr2-s.cms, cmsr3-s.cms
-    #   cmsr1-v.cms, cmsr2-v.cms, cmsr3-v.cms
+    #   cmsr1-s.cern.ch, cmsr2-s.cern.ch, cmsr3-s.cern.ch
+    #   cmsr1-v.cern.ch, cmsr2-v.cern.ch, cmsr3-v.cern.ch
     # but the -s and -v interfaces resolve to the same hosts
     # The actual machines and interfaces are
-    #   itrac50011-s.cern.ch, itrac50063-s.cern.ch, itrac50078-s.cern.ch
-    #   itrac50011-v.cern.ch, itrac50063-v.cern.ch, itrac50078-v.cern.ch
+    #   itrac5404-s.cern.ch, itrac5413-s.cern.ch, itrac5433-s.cern.ch
+    #   itrac5404-v.cern.ch, itrac5413-v.cern.ch, itrac5433-v.cern.ch
 
     databases = {}
     databases['v1'] = {}

--- a/HLTrigger/Configuration/python/Tools/confdbOfflineConverter.py
+++ b/HLTrigger/Configuration/python/Tools/confdbOfflineConverter.py
@@ -36,21 +36,12 @@ class OfflineConverter:
     databases['v1']['adg']     = ( '-t', 'oracle', '-h', 'cmsr1-s.cern.ch',        '-d', 'cms_cond.cern.ch',      '-u', 'cms_hlt_gui_r',     '-s', 'convertMe!' )
     databases['v1']['orcoff']  = databases['v1']['adg']         # for backwards compatibility
     databases['v3'] = {}
-    databases['v3']['run2'] = ( '-t', 'oracle', '-h', 'cmsr1-s.cern.ch,cmsr2-s.cern.ch,cmsr3-s.cern.ch',        '-d', 'cms_hlt.cern.ch',      '-u', 'cms_hlt_gdr_r',     '-s', 'convertMe!' )
-    databases['v3']['run3'] = ( '-t', 'oracle', '-h', 'cmsr1-s.cern.ch,cmsr2-s.cern.ch,cmsr3-s.cern.ch',        '-d', 'cms_hlt.cern.ch',      '-u', 'cms_hlt_v3_r',     '-s', 'convertMe!' )
-    databases['v3']['dev'] = ( '-t', 'oracle', '-h', 'cmsr1-s.cern.ch,cmsr2-s.cern.ch,cmsr3-s.cern.ch',        '-d', 'cms_hlt.cern.ch',      '-u', 'cms_hlt_gdrdev_r',     '-s', 'convertMe1!' )
+    databases['v3']['run2'] = ( '-t', 'oracle', '-h', 'cmsr1-v.cern.ch,cmsr2-v.cern.ch,cmsr3-v.cern.ch',        '-d', 'cms_hlt.cern.ch',      '-u', 'cms_hlt_gdr_r',     '-s', 'convertMe!' )
+    databases['v3']['run3'] = ( '-t', 'oracle', '-h', 'cmsr1-v.cern.ch,cmsr2-v.cern.ch,cmsr3-v.cern.ch',        '-d', 'cms_hlt.cern.ch',      '-u', 'cms_hlt_v3_r',     '-s', 'convertMe!' )
+    databases['v3']['dev'] = ( '-t', 'oracle', '-h', 'cmsr1-v.cern.ch,cmsr2-v.cern.ch,cmsr3-v.cern.ch',        '-d', 'cms_hlt.cern.ch',      '-u', 'cms_hlt_gdrdev_r',     '-s', 'convertMe1!' )
     databases['v3']['online']  = ( '-t', 'oracle', '-h', 'cmsonr1-s.cms',          '-d', 'cms_rcms.cern.ch',      '-u', 'cms_hlt_gdr_r',     '-s', 'convertMe!' )
-    databases['v3']['adg']     = ( '-t', 'oracle', '-h', 'cmsonr1-adg1-s.cern.ch', '-d', 'cms_orcon_adg.cern.ch', '-u', 'cms_hlt_gdr_r',     '-s', 'convertMe!' )
+    databases['v3']['adg']     = ( '-t', 'oracle', '-h', 'cmsonr1-adg-v.cern.ch,cmsonr2-adg-v.cern.ch', '-d', 'cms_orcon_adg.cern.ch', '-u', 'cms_hlt_gdr_r',     '-s', 'convertMe!' )
     
-    #ip addresses, there is a bug where we cant do dns over the socks server, sigh
-    ips_for_proxy = {
-        'cmsr1-s.cern.ch' : '10.116.96.89',
-        'cmsr2-s.cern.ch' : '10.116.96.139',
-        'cmsr3-s.cern.ch' : '10.116.96.105',
-        'cmsonr1-adg1-s.cern.ch' : '10.116.96.109',
-        'cmsonr1-s.cms' : '10.176.84.78'
-    }
-
     databases['v3-beta'] = dict(databases['v3'])
     databases['v3-test'] = dict(databases['v3'])
     databases['v2'] = dict(databases['v3'])
@@ -111,8 +102,6 @@ class OfflineConverter:
             self.proxy_connect_args = ('--dbproxy', '--dbproxyport', self.proxyPort, '--dbproxyhost', self.proxyHost)
             temp_connect = []
             for entry in self.connect:
-                for key,item in self.ips_for_proxy.items():
-                    entry = entry.replace(key,item)
                 temp_connect.append(entry.replace(key,item))
             self.connect  = tuple(temp_connect)
         else:

--- a/HLTrigger/Configuration/python/Tools/confdbOfflineConverter.py
+++ b/HLTrigger/Configuration/python/Tools/confdbOfflineConverter.py
@@ -39,7 +39,7 @@ class OfflineConverter:
     databases['v3']['run2'] = ( '-t', 'oracle', '-h', 'cmsr1-v.cern.ch,cmsr2-v.cern.ch,cmsr3-v.cern.ch',        '-d', 'cms_hlt.cern.ch',      '-u', 'cms_hlt_gdr_r',     '-s', 'convertMe!' )
     databases['v3']['run3'] = ( '-t', 'oracle', '-h', 'cmsr1-v.cern.ch,cmsr2-v.cern.ch,cmsr3-v.cern.ch',        '-d', 'cms_hlt.cern.ch',      '-u', 'cms_hlt_v3_r',     '-s', 'convertMe!' )
     databases['v3']['dev'] = ( '-t', 'oracle', '-h', 'cmsr1-v.cern.ch,cmsr2-v.cern.ch,cmsr3-v.cern.ch',        '-d', 'cms_hlt.cern.ch',      '-u', 'cms_hlt_gdrdev_r',     '-s', 'convertMe1!' )
-    databases['v3']['online']  = ( '-t', 'oracle', '-h', 'cmsonr1-s.cms',          '-d', 'cms_rcms.cern.ch',      '-u', 'cms_hlt_gdr_r',     '-s', 'convertMe!' )
+    databases['v3']['online']  = ( '-t', 'oracle', '-h', 'cmsonr1-v.cms',          '-d', 'cms_rcms.cern.ch',      '-u', 'cms_hlt_gdr_r',     '-s', 'convertMe!' )
     databases['v3']['adg']     = ( '-t', 'oracle', '-h', 'cmsonr1-adg-v.cern.ch,cmsonr2-adg-v.cern.ch', '-d', 'cms_orcon_adg.cern.ch', '-u', 'cms_hlt_gdr_r',     '-s', 'convertMe!' )
     
     databases['v3-beta'] = dict(databases['v3'])


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/47704

#### PR description:

As per details at [INC4361156](https://cern.service-now.com/service-portal?id=ticket&table=incident&n=INC4361156), this PR implements the changes needed to comply with the recommendation of the oracle-DB experts, following up to the relocation of the databases queried by TSG tools (DB to a new cluster implies that IP numbers do change).

> On the other hand, the problem as you can guess, is that with every change of HW.. these IP numbers do change (as expected). So we have created the new IP aliases that point to the different hostname-v values... These new IP aliases should remain constant, easing and making the change of HW transparent. These IP values are
> 
> cmsr1-v.cern.ch
> cmsr2-v.cern.ch
> cmsr3-v.cern.ch
> 


(see also cms-sw/hlt-confdb#106)

#### PR validation:

I tested connection to the `run3` DB on `lxplus` via:

```
 hltGetConfiguration /dev/CMSSW_15_0_0/GRun --globaltag 150X_dataRun3_HLT_v1 --input file:/scratch/sdonato/data/Run2024I_ScoutingPFMonitor_RAW_Run386924_LS35_f0729acd-1b20-4ddf-9da2-24cf1a52be20.root --max-events 100 --output none --eras Run3_2025 --l1-emulator uGT --l1 L1Menu_Collisions2024_v1_3_0_xml --paths 'ScoutingPFOutput,DST_PFScouting_*,Dataset_ScoutingPFRun3' --dbproxyhost localhost --dbproxyport 10121 > hlt.py
 ```
and connection to the `adg` DB on `lxplus` via:

```
 hltGetConfiguration v3/adg:/cdaq/physics/Run2022/2e34/v1.5.0/HLT/V13 --dbproxyhost localhost --dbproxyport 10121 
```

(somewhat random parameters for the menu and other attributes are chosen).

The online DB connection was tested on a hilton machine in the P5 .cms network via:

```
https_proxy="http://cmsproxy.cms:3128/" hltConfigFromDB --online --configName /cdaq/cosmic/commissioning2025/v0.1.1/HLT/V1 
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/47704 to the 2025 data-taking cycle.