### PR TITLE
Fix bug in endUnfinishedLumi

### DIFF
--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -2012,8 +2012,11 @@ namespace edm {
         assert(streamLumiActive_ == preallocations_.numberOfStreams());
         streamLumiStatus_[0]->noMoreEventsInLumi();
         streamLumiStatus_[0]->setCleaningUpAfterException(cleaningUpAfterException);
-        for (unsigned int i = 0; i < preallocations_.numberOfStreams(); ++i) {
-          streamEndLumiAsync(WaitingTaskHolder{taskGroup_, &globalWaitTask}, i);
+        {
+          WaitingTaskHolder holder{taskGroup_, &globalWaitTask};
+          for (unsigned int i = 0; i < preallocations_.numberOfStreams(); ++i) {
+            streamEndLumiAsync(holder, i);
+          }
         }
         globalWaitTask.wait();
       }


### PR DESCRIPTION
#### PR description:

This fixes a concurrency problem in the function EventProcessor::endUnfinishedLumi. This problem was noticed while working on a different PR. It was not reported by a user. Conditions for the problem to occur are rare enough that it is possible that it in practice has never occurred.

First endUnfinishedLumi is only called under the following two circumstances:

1.  An unrelated exception was thrown while closing then opening an input file, after completely processing all runs/lumis/events in the preceding file but before starting runs/lumis/events in the next file. endUnfinishedLumi is called while cleaning up after the other fatal exception.
2. In a merge job when the last input file is empty, not only no events but also no runs or lumis either (which I don't think happens under normal circumstances).

Even when endUnfinishedLumi is called, an improbable order of execution of the asynchronous tasks has to occur for the problem to occur.

This PR also updates the documentation of FinalWaitingTask, both to better describe this potential problem and also because the documentation had become out of date for other reasons.

Resolves https://github.com/cms-sw/framework-team/issues/1320

#### PR validation:

Existing tests pass. Also I manually forced such an exception to occur and stepped through the function in a debugger.
