### PR TITLE
[15.0][GCC13] Fix array-bound issue for JetTaggerTableProducer

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/JetTaggerTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/JetTaggerTableProducer.cc
@@ -275,6 +275,7 @@ void JetTaggerTableProducer<T>::produce(edm::Event &iEvent, const edm::EventSetu
                 break;
             }
           }
+          ranked_sv_features.clear();
           ranked_sv_features = {highest_pT, highest_IP};
         }
       } else {


### PR DESCRIPTION
Thsi fixes the array-bound error we see for GCC 13 IBs https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc13/CMSSW_15_0_X_2025-03-26-2300/PhysicsTools/NanoAOD ( see https://github.com/cms-sw/cmssw/pull/47628#issuecomment-2757298465)