### PR TITLE
[GCC13] Fix array-bound issue for JetTaggerTableProducer

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/JetTaggerTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/JetTaggerTableProducer.cc
@@ -275,6 +275,7 @@ void JetTaggerTableProducer<T>::produce(edm::Event &iEvent, const edm::EventSetu
                 break;
             }
           }
+          ranked_sv_features.clear();
           ranked_sv_features = {highest_pT, highest_IP};
         }
       } else {


### PR DESCRIPTION
This fixes the compilation warnings we get for [gcc13](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc13/CMSSW_15_0_X_2025-03-26-2300/PhysicsTools/NanoAOD) and [gcc14](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc14/CMSSW_15_0_X_2025-03-26-2300/PhysicsTools/NanoAOD) IB

```
  /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc13/external/gcc/13.3.1-92b2d78dc343ed2bc93c8eb414ddc9ff/include/c++/13.3.1/bits/stl_algobase.h:398:17: error: array subscript 'const struct SecondaryVertexFeatures * const[1]' is partly outside array bounds of 'const struct SecondaryVertexFeatures * const[2]' [-Werror=array-bounds=]
   398 |         { *__to = *__from; }
      |                 ^
src/PhysicsTools/NanoAOD/plugins/JetTaggerTableProducer.cc: In member function 'produce':
src/PhysicsTools/NanoAOD/plugins/JetTaggerTableProducer.cc:278:30: note: at offset [9, 15] into object '<anonymous>' of size 16
  278 |           ranked_sv_features = {highest_pT, highest_IP};

```