### PR TITLE
Force use of RNTuple in RelVal workflows

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixReader.py
+++ b/Configuration/PyReleaseValidation/python/MatrixReader.py
@@ -209,6 +209,19 @@ With --checkInputs option this throws an error.
             wfName = wfInfo[0]
             stepList = wfInfo[1]
             stepOverrides=wfInfo.overrides
+            #force use of RNTuple
+            #check to see if secondfilein is begin requested, if so RNTuple doesn't
+            # support that yet so do not attempt to use rntuple for this workflow
+            use_rntuple_out = True
+            for step in stepList:
+                if self.relvalModule.steps[step] is None:
+                    continue
+                if '--secondfilein' in self.relvalModule.steps[step]:
+                    use_rntuple_out = False
+                    break
+            if use_rntuple_out:
+                stepOverrides['--rntuple_out']=''
+
             # upgrade case: workflow has basic name, key[, suffix (only special workflows)]
             wfKey = ""
             wfSuffix = ""

--- a/Configuration/PyReleaseValidation/python/WorkFlowRunner.py
+++ b/Configuration/PyReleaseValidation/python/WorkFlowRunner.py
@@ -190,6 +190,9 @@ class WorkFlowRunner(Thread):
                     # Disable input for premix stage1 to allow combined stage1+stage2 workflow
                     # Disable input for premix stage2 in FastSim to allow combined stage1+stage2 workflow (in FS, stage2 does also GEN)
                     # Ugly hack but works
+                    if '--rntuple_out' in cmd and 'premix_stage1' in cmd:
+                        #rntuple can't be used by the mixing module yet
+                        cmd = cmd.replace('--rntuple_out', '')
                     extension = '.root'
                     if '--rntuple_out' in cmd:
                         extension = '.rntpl'

--- a/FWIO/RNTuple/bin/edmRntupleStorage.cc
+++ b/FWIO/RNTuple/bin/edmRntupleStorage.cc
@@ -116,16 +116,20 @@ int main(int iArgc, char const* iArgv[]) {
 
   auto file = TFile::Open(vm["file"].as<std::string>().c_str(), "r");
   if (not file) {
-    std::cout <<"failed to open "<<vm["file"].as<std::string>()<<std::endl;
+    std::cout << "failed to open " << vm["file"].as<std::string>() << std::endl;
     return 1;
   }
-  
-  auto events = std::unique_ptr<ROOT::RNTuple>(file->Get<ROOT::RNTuple>("Events"));
-  if(not events) {
-    std::cout <<"failed to get 'Events' as an RNTuple"<<std::endl;
+  std::string tupleToRead = "Events";
+  if (vm.count("rntuple")) {
+    tupleToRead = vm["rntuple"].as<std::string>();
+  }
+
+  auto ntpl = std::unique_ptr<ROOT::RNTuple>(file->Get<ROOT::RNTuple>(tupleToRead.c_str()));
+  if (not ntpl) {
+    std::cout << "failed to get '" << tupleToRead << "' as an RNTuple" << std::endl;
     return 1;
   }
-  auto ntuple = RNTupleReader::Open(*events);
+  auto ntuple = RNTupleReader::Open(*ntpl);
 
   if (vm.count("printProductDetails")) {
     ntuple->PrintInfo(ENTupleInfo::kStorageDetails, std::cout);

--- a/FWIO/RNTuple/plugins/RNTupleInputFile.cc
+++ b/FWIO/RNTuple/plugins/RNTupleInputFile.cc
@@ -152,6 +152,65 @@ namespace edm {
     return iter_->getEntryType();
   }
 
+  int RNTupleInputFile::skipEvents(int offset) {
+    while (offset > 0 && *iter_ != iterEnd_) {
+      int phIndexOfSkippedEvent = IndexIntoFile::invalidIndex;
+      RunNumber_t runOfSkippedEvent = IndexIntoFile::invalidRun;
+      LuminosityBlockNumber_t lumiOfSkippedEvent = IndexIntoFile::invalidLumi;
+      IndexIntoFile::EntryNumber_t skippedEventEntry = IndexIntoFile::invalidEntry;
+
+      iter_->skipEventForward(phIndexOfSkippedEvent, runOfSkippedEvent, lumiOfSkippedEvent, skippedEventEntry);
+
+      // At the end of the file and there were no more events to skip
+      if (skippedEventEntry == IndexIntoFile::invalidEntry)
+        break;
+      /* once we add this feature we will need this code
+      if (eventSkipperByID_ && eventSkipperByID_->somethingToSkip()) {
+        auto const evtAux = fillEventAuxiliary(skippedEventEntry);
+        if (eventSkipperByID_->skipIt(runOfSkippedEvent, lumiOfSkippedEvent, evtAux.id().event())) {
+          continue;
+        }
+      }
+      if (duplicateChecker_ && !duplicateChecker_->checkDisabled() && !duplicateChecker_->noDuplicatesInFile()) {
+        auto const evtAux = fillEventAuxiliary(skippedEventEntry);
+        if (duplicateChecker_->isDuplicateAndCheckActive(
+                phIndexOfSkippedEvent, runOfSkippedEvent, lumiOfSkippedEvent, evtAux.id().event(), file_)) {
+          continue;
+        }
+      }
+      */
+      --offset;
+    }
+    while (offset < 0) {
+      /*
+      if (duplicateChecker_) {
+        duplicateChecker_->disable();
+      }
+      */
+
+      int phIndexOfEvent = IndexIntoFile::invalidIndex;
+      RunNumber_t runOfEvent = IndexIntoFile::invalidRun;
+      LuminosityBlockNumber_t lumiOfEvent = IndexIntoFile::invalidLumi;
+      IndexIntoFile::EntryNumber_t eventEntry = IndexIntoFile::invalidEntry;
+
+      iter_->skipEventBackward(phIndexOfEvent, runOfEvent, lumiOfEvent, eventEntry);
+
+      if (eventEntry == IndexIntoFile::invalidEntry)
+        break;
+      /* once we add this feature we will need this code
+      if (eventSkipperByID_ && eventSkipperByID_->somethingToSkip()) {
+        auto const evtAux = fillEventAuxiliary(eventEntry);
+        if (eventSkipperByID_->skipIt(runOfEvent, lumiOfEvent, evtAux.id().event())) {
+          continue;
+        }
+      }
+      */
+      ++offset;
+    }
+
+    return offset;
+  }
+
   IndexIntoFile::EntryNumber_t RNTupleInputFile::readLuminosityBlock() {
     assert(*iter_ != *iterEnd_);
     assert(iter_->getEntryType() == IndexIntoFile::kLumi);

--- a/FWIO/RNTuple/plugins/RNTupleInputFile.h
+++ b/FWIO/RNTuple/plugins/RNTupleInputFile.h
@@ -41,6 +41,7 @@ namespace edm {
 
     void readMeta(ProductRegistry&, ProcessHistoryRegistry&, BranchIDLists& iBranchIDLists);
     std::vector<ParentageID> readParentage();
+    void readParameterSets();
 
     input::DataProductsRNTuple* runProducts() { return &runs_; }
     input::DataProductsRNTuple* luminosityBlockProducts() { return &lumis_; }

--- a/FWIO/RNTuple/plugins/RNTupleInputFile.h
+++ b/FWIO/RNTuple/plugins/RNTupleInputFile.h
@@ -49,6 +49,9 @@ namespace edm {
 
     void printInfoForEvent(std::ostream& iOStream) { events_.printInfo(iOStream); }
 
+    //returns actual number skipped
+    int skipEvents(int);
+
   private:
     std::unique_ptr<TFile> file_;
 

--- a/FWIO/RNTuple/plugins/RNTupleOutputFile.cc
+++ b/FWIO/RNTuple/plugins/RNTupleOutputFile.cc
@@ -558,8 +558,9 @@ explicitly pass the correct variable to `SetColumnRepresentatives`).
   void RNTupleOutputFile::writeLuminosityBlock(LuminosityBlockForOutput const& iLumi) {
     {
       auto rentry = lumis_->CreateEntry();
-      rentry->BindRawPtr(*lumiAuxField_,
-                         const_cast<void*>(static_cast<void const*>(&(iLumi.luminosityBlockAuxiliary()))));
+      auto lumiAux = iLumi.luminosityBlockAuxiliary();
+      lumiAux.setProcessHistoryID(iLumi.processHistoryID());
+      rentry->BindRawPtr(*lumiAuxField_, static_cast<void*>(&lumiAux));
       auto dummies = writeDataProducts(products_[InLumi], iLumi, *rentry);
       lumis_->Fill(*rentry);
     }
@@ -567,14 +568,17 @@ explicitly pass the correct variable to `SetColumnRepresentatives`).
     // Store the reduced ID in the IndexIntoFile
     ProcessHistoryID reducedPHID = processHistoryRegistry_.reducedProcessHistoryID(iLumi.processHistoryID());
     // Add lumi to index.
-    indexIntoFile_.addEntry(reducedPHID, iLumi.run(), iLumi.luminosityBlock(), 0U, lumiEntryNumber_);
+    indexIntoFile_.addEntry(
+        reducedPHID, iLumi.run(), iLumi.luminosityBlock(), IndexIntoFile::invalidEvent, lumiEntryNumber_);
     ++lumiEntryNumber_;
   }
 
   void RNTupleOutputFile::writeRun(RunForOutput const& iRun) {
     {
       auto rentry = runs_->CreateEntry();
-      rentry->BindRawPtr(*runAuxField_, const_cast<void*>(static_cast<void const*>(&(iRun.runAuxiliary()))));
+      auto runAux = iRun.runAuxiliary();
+      runAux.setProcessHistoryID(iRun.processHistoryID());
+      rentry->BindRawPtr(*runAuxField_, static_cast<void*>(&runAux));
       auto dummies = writeDataProducts(products_[InRun], iRun, *rentry);
       runs_->Fill(*rentry);
     }
@@ -582,7 +586,8 @@ explicitly pass the correct variable to `SetColumnRepresentatives`).
     // Store the reduced ID in the IndexIntoFile
     ProcessHistoryID reducedPHID = processHistoryRegistry_.reducedProcessHistoryID(iRun.processHistoryID());
     // Add run to index.
-    indexIntoFile_.addEntry(reducedPHID, iRun.run(), 0U, 0U, runEntryNumber_);
+    indexIntoFile_.addEntry(
+        reducedPHID, iRun.run(), IndexIntoFile::invalidLumi, IndexIntoFile::invalidEvent, runEntryNumber_);
     ++runEntryNumber_;
   }
 

--- a/FWIO/RNTuple/plugins/RNTupleOutputModule.cc
+++ b/FWIO/RNTuple/plugins/RNTupleOutputModule.cc
@@ -208,7 +208,8 @@ namespace edm {
                                              "recoGsfElectrons",
                                              "TotemRPLocalTrackedmDetSetVector",
                                              "edmTriggerResults",
-                                             "GlobalAlgBlkBXVector"};
+                                             "GlobalAlgBlkBXVector",
+                                             "SimTrackToTPMap"};
       std::vector<edm::ParameterSet> retValue;
       for (auto const& t : types) {
         edm::ParameterSet p;

--- a/FWIO/RNTuple/plugins/RNTupleOutputModule.cc
+++ b/FWIO/RNTuple/plugins/RNTupleOutputModule.cc
@@ -198,27 +198,6 @@ namespace edm {
 
   void RNTupleOutputModule::writeRun(RunForOutput const& iRun) { file_->writeRun(iRun); }
 
-  namespace {
-    std::vector<edm::ParameterSet> defaultStreamerOverrides() {
-      std::vector<std::string_view> types = {"LHEEventProduct",
-                                             "recoJetIDedmValueMap",
-                                             "recoPhotons",
-                                             "recoGsfElectrons",
-                                             "recoMuons",
-                                             "recoGsfElectrons",
-                                             "TotemRPLocalTrackedmDetSetVector",
-                                             "edmTriggerResults",
-                                             "GlobalAlgBlkBXVector",
-                                             "SimTrackToTPMap"};
-      std::vector<edm::ParameterSet> retValue;
-      for (auto const& t : types) {
-        edm::ParameterSet p;
-        p.addUntrackedParameter<std::string>("product", std::string(t) + "_*_*_*");
-        retValue.emplace_back(std::move(p));
-      }
-      return retValue;
-    }
-  }  // namespace
   void RNTupleOutputModule::fillDescriptions(ConfigurationDescriptions& descriptions) {
     ParameterSetDescription desc;
     desc.setComment("Outputs event information into an RNTuple container.");
@@ -270,7 +249,7 @@ namespace edm {
           "Name of data product needing a special split setting. The name can contain wildcards '*' and '?'");
       specialStreamer.addUntracked<bool>("useStreamer", true)
           ->setComment("Explicitly set if should or should not use streamer (default is to use streamer)");
-      desc.addVPSetUntracked("overrideDataProductStreamer", specialStreamer, defaultStreamerOverrides());
+      desc.addVPSetUntracked("overrideDataProductStreamer", specialStreamer, {});
     }
 
     OutputModule::fillDescription(desc);

--- a/FWIO/RNTuple/plugins/RNTupleSource.cc
+++ b/FWIO/RNTuple/plugins/RNTupleSource.cc
@@ -183,6 +183,9 @@ namespace edm {
     if (files.empty()) {
       throw cms::Exception("NoInputFiles");
     }
+    if (files.size() > 1) {
+      throw edm::Exception(edm::errors::Configuration)<<"RNTupleSource presently only support reading 1 file";
+    }
     file_ = std::make_unique<RNTupleInputFile>(files[0], ops);
 
     BranchIDLists branchIDLists;
@@ -236,8 +239,7 @@ namespace edm {
     desc.addUntracked<bool>("enableMetrics", false);
     desc.addUntracked<bool>("useClusterCache", true);
 
-    //make interface compatible with PoolSource. Some will be marked obsolete once available
-
+    //make interface compatible with PoolSource.
     desc.addOptionalUntracked<std::vector<std::string>>("secondaryFileNames");
     desc.addOptionalUntracked<bool>("needSecondaryFileNames");
     desc.addOptionalUntracked<std::string>("overrideCatalog");
@@ -328,6 +330,8 @@ namespace edm {
     auto& reader = runReaders_[runPrincipal.index()];
     reader.setEntry(entry);
     runPrincipal.fillRunPrincipal(processHistoryRegistry(), &reader);
+    //In the future, when this code can skip runs we will need to
+    // set this value.
     //runPrincipal.setShouldWriteRun(RunPrincipal::kNo);
   }
 

--- a/FWIO/RNTuple/plugins/RNTupleSource.cc
+++ b/FWIO/RNTuple/plugins/RNTupleSource.cc
@@ -179,11 +179,16 @@ namespace edm {
     RNTupleInputFile::Options ops;
     ops.enableMetrics_ = enableMetrics_;
     ops.useClusterCache_ = useClusterCache_;
-    file_ = std::make_unique<RNTupleInputFile>(pset.getUntrackedParameter<std::string>("fileName"), ops);
+    auto files = pset.getUntrackedParameter<std::vector<std::string>>("fileNames");
+    if (files.empty()) {
+      throw cms::Exception("NoInputFiles");
+    }
+    file_ = std::make_unique<RNTupleInputFile>(files[0], ops);
 
     BranchIDLists branchIDLists;
     file_->readMeta(productRegistryUpdate(), processHistoryRegistryForUpdate(), branchIDLists);
     branchIDListHelper()->updateFromInput(branchIDLists);
+    file_->readParameterSets();
 
     runReaders_.reserve(desc.allocations_->numberOfRuns());
     for (unsigned int i = 0; i < desc.allocations_->numberOfRuns(); ++i) {
@@ -227,9 +232,25 @@ namespace edm {
 
   void RNTupleSource::fillDescriptions(ConfigurationDescriptions& descriptions) {
     ParameterSetDescription desc;
-    desc.addUntracked<std::string>("fileName");
+    desc.addUntracked<std::vector<std::string>>("fileNames")->setComment("only the first file will be used for now");
     desc.addUntracked<bool>("enableMetrics", false);
     desc.addUntracked<bool>("useClusterCache", true);
+
+    //make interface compatible with PoolSource. Some will be marked obsolete once available
+
+    desc.addOptionalUntracked<std::vector<std::string>>("secondaryFileNames");
+    desc.addOptionalUntracked<bool>("needSecondaryFileNames");
+    desc.addOptionalUntracked<std::string>("overrideCatalog");
+    desc.addOptionalUntracked<bool>("skipBadFiles");
+    desc.addOptionalUntracked<bool>("bypassVersionCheck");
+    desc.addObsoleteUntracked<int>("treeMaxVirtualSize");
+    desc.addOptionalUntracked<bool>("dropDescendantsOfDroppedBranches");
+    desc.addOptionalUntracked<bool>("labelRawDataLikeMC");
+    desc.addOptionalUntracked<bool>("delayReadingEventProducts");
+    ProductSelectorRules::fillDescription(desc, "inputCommands");
+    InputSource::fillDescription(desc);
+    //RootPrimaryFileSequence::fillDescription(desc);
+    //RunHelperBase::fillDescription(desc);
 
     descriptions.addDefault(desc);
   }
@@ -261,6 +282,9 @@ namespace edm {
     auto& reader = lumiReaders_[lumiPrincipal.index()];
     reader.setEntry(entry);
     lumiPrincipal.fillLuminosityBlockPrincipal(history, &reader);
+    // Read in all the products now.
+    lumiPrincipal.readAllFromSourceAndMergeImmediately();
+    lumiPrincipal.setShouldWriteLumi(LuminosityBlockPrincipal::kYes);
   }
   std::shared_ptr<LuminosityBlockAuxiliary> RNTupleSource::readLuminosityBlockAuxiliary_() {
     return file_->readLuminosityBlockAuxiliary();
@@ -304,7 +328,7 @@ namespace edm {
     auto& reader = runReaders_[runPrincipal.index()];
     reader.setEntry(entry);
     runPrincipal.fillRunPrincipal(processHistoryRegistry(), &reader);
-    runPrincipal.setShouldWriteRun(RunPrincipal::kNo);
+    //runPrincipal.setShouldWriteRun(RunPrincipal::kNo);
   }
 
   std::pair<SharedResourcesAcquirer*, std::recursive_mutex*> RNTupleSource::resourceSharedWithDelayedReader_() {

--- a/FWIO/RNTuple/plugins/RNTupleSource.cc
+++ b/FWIO/RNTuple/plugins/RNTupleSource.cc
@@ -133,6 +133,8 @@ namespace edm {
     static void fillDescriptions(ConfigurationDescriptions& descriptions);
 
   private:
+    void skip(int offset) override;
+
     ItemTypeInfo getNextItemType() override;
     void readLuminosityBlock_(LuminosityBlockPrincipal& lumiPrincipal) override;
     std::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_() override;
@@ -184,7 +186,7 @@ namespace edm {
       throw cms::Exception("NoInputFiles");
     }
     if (files.size() > 1) {
-      throw edm::Exception(edm::errors::Configuration)<<"RNTupleSource presently only support reading 1 file";
+      throw edm::Exception(edm::errors::Configuration) << "RNTupleSource presently only support reading 1 file";
     }
     file_ = std::make_unique<RNTupleInputFile>(files[0], ops);
 
@@ -256,6 +258,8 @@ namespace edm {
 
     descriptions.addDefault(desc);
   }
+
+  void RNTupleSource::skip(int offset) { file_->skipEvents(offset); }
 
   InputSource::ItemTypeInfo RNTupleSource::getNextItemType() {
     if (not startedFirstFile_) {

--- a/FWIO/RNTuple/test/test_catch2_output2input.cc
+++ b/FWIO/RNTuple/test/test_catch2_output2input.cc
@@ -18,7 +18,7 @@ namespace {
 
   std::string setInputFile(std::string const& iConfig, std::string const& iFileName) {
     using namespace std::string_literals;
-    return iConfig + "\nprocess.source.fileName = 'file:"s + iFileName + "'\n";
+    return iConfig + "\nprocess.source.fileNames = ['file:"s + iFileName + "']\n";
   }
 }  // namespace
 TEST_CASE("Tests of RNTupleOuput -> RNTupleSource", s_tag) {
@@ -37,7 +37,7 @@ process.moduleToTest(process.out)
   const std::string baseSourceConfig{
       R"_(from FWCore.TestProcessor.TestSourceProcess import *
 process = TestSourceProcess()
-process.source = cms.Source("RNTupleSource", fileName = cms.untracked.string(''))
+process.source = cms.Source("RNTupleSource", fileNames = cms.untracked.vstring())
 process.add_(cms.Service("InitRootHandlers"))
 process.add_(cms.Service("SiteLocalConfigService"))
 process.add_(cms.Service("JobReportService"))


### PR DESCRIPTION
#### PR description:

- added obsolete/optional parameters to make RNTuple modules be able to accept the same parameters as their equivalent Pool modules.
- Fixed some issues with reading information from the files.
- Fixed ProcessHistory handling
- Made necessary changes to components called by runTheMatrix.py to accommodate the use of RNTuple. 

#### PR validation:

Did runTheMatrix.py for workflows 1.0, 7.0 and 11834.99.

resolves https://github.com/cms-sw/framework-team/issues/1315, https://github.com/cms-sw/framework-team/issues/1314