### PR TITLE
Developing offline JetMET DQM for Scouting jets: applying JetID criteria - complementary to PR #47328

### DIFF
--- a/DQMOffline/JetMET/interface/JetAnalyzer.h
+++ b/DQMOffline/JetMET/interface/JetAnalyzer.h
@@ -64,6 +64,7 @@
 #include "DataFormats/Scalers/interface/DcsStatus.h"
 #include "PhysicsTools/SelectorUtils/interface/JetIDSelectionFunctor.h"
 #include "PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h"
+#include "PhysicsTools/SelectorUtils/interface/Run3ScoutingPFJetIDSelectionFunctor.h"
 #include "DataFormats/JetReco/interface/PileupJetIdentifier.h"
 
 #include "CondFormats/L1TObjects/interface/L1GtTriggerMenuFwd.h"
@@ -173,6 +174,11 @@ private:
   PFJetIDSelectionFunctor::Version_t pfjetidversion;
 
   PFJetIDSelectionFunctor pfjetIDFunctor;
+
+  Run3ScoutingPFJetIDSelectionFunctor::Quality_t run3scoutingpfjetidquality;
+  Run3ScoutingPFJetIDSelectionFunctor::Version_t run3scoutingpfjetidversion;
+
+  Run3ScoutingPFJetIDSelectionFunctor run3scoutingpfjetIDFunctor;
 
   std::vector<std::string> folderNames_;
 

--- a/DQMOffline/JetMET/python/jetAnalyzer_cff.py
+++ b/DQMOffline/JetMET/python/jetAnalyzer_cff.py
@@ -14,7 +14,7 @@ _jetDQMAnalyzerSequenceWithPUPPI = cms.Sequence(jetDQMAnalyzerAk4CaloCleaned
                                       *jetDQMAnalyzerAk4PFCHSCleaned*jetDQMAnalizerAk4PUPPICleaned
                                    )
 
-jetDQMAnalyzerSequenceScouting = cms.Sequence(jetDQMAnalyzerAk4ScoutingUncleaned)
+jetDQMAnalyzerSequenceScouting = cms.Sequence(jetDQMAnalyzerAk4ScoutingUncleaned*jetDQMAnalyzerAk4ScoutingCleaned)
 
 jetDQMAnalyzerSequenceCosmics = cms.Sequence(jetDQMAnalyzerAk4CaloUncleaned)
 

--- a/DQMOffline/JetMET/python/jetAnalyzer_cfi.py
+++ b/DQMOffline/JetMET/python/jetAnalyzer_cfi.py
@@ -50,7 +50,7 @@ jetDQMAnalyzerAk4CaloUncleaned = DQMEDAnalyzer('JetAnalyzer',
         bypassAllPVChecks = True,
         ),
 
-    #for JPT and CaloJetID  
+    #Only for JPT and CaloJetID  -> need to define InputJetIDValueMap  
     InputJetIDValueMap         = cms.InputTag("ak4JetID"), 
     #options for Calo and JPT: LOOSE,LOOSE_AOD,TIGHT,MINIMAL
     #for PFJets: LOOSE,TIGHT
@@ -198,16 +198,12 @@ jetDQMAnalyzerAk4ScoutingUncleaned = jetDQMAnalyzerAk4CaloUncleaned.clone(
         bypassAllPVChecks = False,
         ),
 
-    #for JPT and CaloJetID  
-    #InputJetIDValueMap         = cms.untracked.InputTag("ak4JetID"), 
-    #options for Calo and JPT: LOOSE,LOOSE_AOD,TIGHT,MINIMAL
-    #for PFJets: LOOSE,TIGHT
-    ###JetIDQuality               = cms.string("LOOSE"),
-    #options for Calo and JPT: PURE09,DQM09,CRAFT08
-    #for PFJets: FIRSTDATA
-    ###JetIDVersion               = cms.string("PURE09"),
+    #for scouting PF jets: TIGHT
+    JetIDQuality               = cms.string("TIGHT"),
+    #for scouting PF jets: RUN3Scouting
+    JetIDVersion               = cms.string("RUN3Scouting"),
     #
-    #actually done only for PFJets at the moment
+    #Pileup JetID anf quark-gluon discrimination not exist for scouting PF jets. The following: actually done only for PFJets at the moment
     ###InputMVAPUIDDiscriminant = cms.InputTag("pileupJetIdEvaluatorDQM","fullDiscriminant"),
     ###InputCutPUIDDiscriminant = cms.InputTag("pileupJetIdEvaluatorDQM","cutbasedDiscriminant"),
     ###InputMVAPUIDValue = cms.InputTag("pileupJetIdEvaluatorDQM","fullId"),
@@ -228,10 +224,14 @@ jetDQMAnalyzerAk4ScoutingUncleaned = jetDQMAnalyzerAk4CaloUncleaned.clone(
     # DCS ### -> only used in JetMETDQMFilter.cc
     #                             
     DCSFilterForJetMonitoring = cms.PSet(
-      DetectorTypes = cms.untracked.string("ecal:hbhe:hf"),
+      DetectorTypes = cms.untracked.string("ecal:hbhe:hf:pixel:sistrip:es:muon"),
       #DebugOn = cms.untracked.bool(True),
       alwaysPass = cms.untracked.bool(False)
     )
+)
+
+jetDQMAnalyzerAk4ScoutingCleaned = jetDQMAnalyzerAk4ScoutingUncleaned.clone(
+    JetCleaningFlag = True
 )
 
 jetDQMAnalyzerAk4PFCHSUncleanedMiniAOD=jetDQMAnalyzerAk4PFUncleaned.clone(

--- a/DQMOffline/JetMET/src/JetAnalyzer.cc
+++ b/DQMOffline/JetMET/src/JetAnalyzer.cc
@@ -195,6 +195,24 @@ JetAnalyzer::JetAnalyzer(const edm::ParameterSet& pSet)
     }
     pfjetIDFunctor = PFJetIDSelectionFunctor(pfjetidversion, pfjetidquality);
   }
+
+  //Jet ID definitions for scouting PF jets
+  if (isScoutingJet_) {
+    if (JetIDVersion_ == "RUN3Scouting") {
+      run3scoutingpfjetidversion = Run3ScoutingPFJetIDSelectionFunctor::RUN3Scouting;
+    } else {
+      if (verbose_)
+        std::cout << "no valid scouting Run3ScoutinPF JetID version given" << std::endl;
+    }
+    if (JetIDQuality_ == "TIGHT") {
+      run3scoutingpfjetidquality = Run3ScoutingPFJetIDSelectionFunctor::TIGHT;
+    } else {
+      if (verbose_)
+        std::cout << "no Valid scouting Run3ScoutinPF JetID quality given" << std::endl;
+    }
+    run3scoutingpfjetIDFunctor = Run3ScoutingPFJetIDSelectionFunctor(run3scoutingpfjetidversion, run3scoutingpfjetidquality);
+    }
+
   //check later if some of those are also needed for PFJets
   leadJetFlag_ = 0;
   jetLoPass_ = 0;
@@ -293,7 +311,10 @@ JetAnalyzer::~JetAnalyzer() {
 // ***********************************************************
 void JetAnalyzer::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun, edm::EventSetup const&) {
   if (isScoutingJet_) {
-    if (!jetCleaningFlag_) {
+    if (jetCleaningFlag_) {
+      ibooker.setCurrentFolder("HLT/ScoutingOffline/Jet/Cleaned" + mInputCollection_.label());
+      DirName = "HLT/ScoutingOffline/Jet/Cleaned" + mInputCollection_.label();
+    } else {
       ibooker.setCurrentFolder("HLT/ScoutingOffline/Jet/Uncleaned" + mInputCollection_.label());
       DirName = "HLT/ScoutingOffline/Jet/Uncleaned" + mInputCollection_.label();
     }
@@ -2592,7 +2613,9 @@ void JetAnalyzer::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetu
 void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   //set general folders first --> change later on for different folders
   if (isScoutingJet_) {
-    if (!jetCleaningFlag_) {
+    if (jetCleaningFlag_) {
+      DirName = "HLT/ScoutingOffline/Jet/Cleaned" + mInputCollection_.label();
+    } else {
       DirName = "HLT/ScoutingOffline/Jet/Uncleaned" + mInputCollection_.label();
     }
   } else {
@@ -2900,12 +2923,12 @@ void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
   if (isMiniAODJet_)
     jetCollectionIsValid = patJets.isValid();
 
-  if (jetCleaningFlag_ && (!jetCollectionIsValid || !bPrimaryVertex || !dcsDecision))  // why "jetCleaningFlag_ &&" ???
-    return;
-
   if (isScoutingJet_) {
     if (!scoutingJets.isValid())
       return;
+  } else {
+  if (jetCleaningFlag_ && (!jetCollectionIsValid || !bPrimaryVertex || !dcsDecision))  // why "jetCleaningFlag_ &&" ???
+    return;
   }
 
   unsigned int collSize = -1;
@@ -3036,12 +3059,19 @@ void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
     //remove the continue line, for physics selections we might losen the pt-thresholds as we care only about leading jets
 
     numofscoutingjets++;
+    bool jetpassidScouting = true;
+    bool ThiscleanedScouting = true;
     if (isScoutingJet_) {
       jetEnergy = (*scoutingJets)[ijet].chargedHadronEnergy() + (*scoutingJets)[ijet].neutralHadronEnergy() +
                   (*scoutingJets)[ijet].electronEnergy() + (*scoutingJets)[ijet].photonEnergy() +
                   (*scoutingJets)[ijet].muonEnergy() + (*scoutingJets)[ijet].HFEMEnergy();
 
-      if (pass_uncorrected) {
+      jetpassidScouting = run3scoutingpfjetIDFunctor((*scoutingJets)[ijet]);
+      if (jetCleaningFlag_) {
+        ThiscleanedScouting = jetpassidScouting;
+      }
+
+      if (ThiscleanedScouting && pass_uncorrected) {
         mPt_uncor = map_of_MEs[DirName + "/" + "Pt_uncor"];
         if (mPt_uncor && mPt_uncor->getRootObject())
           mPt_uncor->Fill((*scoutingJets)[ijet].pt());
@@ -3056,7 +3086,7 @@ void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
           mJetArea_uncor->Fill((*scoutingJets)[ijet].jetArea());
       }
 
-      if (pass_corrected) {
+      if (ThiscleanedScouting && pass_corrected) {
         mPt = map_of_MEs[DirName + "/" + "Pt"];
         if (mPt && mPt->getRootObject())
           mPt->Fill(correctedJet.pt());
@@ -3069,7 +3099,6 @@ void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
         mJetArea = map_of_MEs[DirName + "/" + "JetArea"];
         if (mJetArea && mJetArea->getRootObject())
           mJetArea->Fill(correctedJet.jetArea());
-        //if (fabs((*scoutingJets)[ijet].eta()) <= 0.5 && 30 <= (*scoutingJets)[ijet].pt() <= 50) {
         mJetEnergyCorr = map_of_MEs[DirName + "/" + "JetEnergyCorr"];
         if (mJetEnergyCorr && mJetEnergyCorr->getRootObject())
           mJetEnergyCorr->Fill(correctedJet.pt() / (*scoutingJets)[ijet].pt());
@@ -3079,8 +3108,36 @@ void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
         mJetEnergyCorrVSPt = map_of_MEs[DirName + "/" + "JetEnergyCorrVSPt"];
         if (mJetEnergyCorrVSPt && mJetEnergyCorrVSPt->getRootObject())
           mJetEnergyCorrVSPt->Fill(correctedJet.pt(), correctedJet.pt() / (*scoutingJets)[ijet].pt());
-        //}
       }
+
+      if (!runcosmics_ && pass_corrected) {
+        if (jetpassidScouting) {
+          mLooseJIDPassFractionVSeta = map_of_MEs[DirName + "/" + "JetIDPassFractionVSeta"];
+          if (mLooseJIDPassFractionVSeta && mLooseJIDPassFractionVSeta->getRootObject())
+            mLooseJIDPassFractionVSeta->Fill(correctedJet.eta(), 1.);
+          mLooseJIDPassFractionVSpt = map_of_MEs[DirName + "/" + "JetIDPassFractionVSpt"];
+          if (mLooseJIDPassFractionVSpt && mLooseJIDPassFractionVSpt->getRootObject())
+            mLooseJIDPassFractionVSpt->Fill(correctedJet.pt(), 1.);
+          if (fabs(correctedJet.eta()) < 3.0) {
+            mLooseJIDPassFractionVSptNoHF = map_of_MEs[DirName + "/" + "JetIDPassFractionVSptNoHF"];
+            if (mLooseJIDPassFractionVSptNoHF && mLooseJIDPassFractionVSptNoHF->getRootObject())
+              mLooseJIDPassFractionVSptNoHF->Fill(correctedJet.pt(), 1.);
+          }
+        } else {
+          mLooseJIDPassFractionVSeta = map_of_MEs[DirName + "/" + "JetIDPassFractionVSeta"];
+          if (mLooseJIDPassFractionVSeta && mLooseJIDPassFractionVSeta->getRootObject())
+            mLooseJIDPassFractionVSeta->Fill(correctedJet.eta(), 0.);
+          mLooseJIDPassFractionVSpt = map_of_MEs[DirName + "/" + "JetIDPassFractionVSpt"];
+          if (mLooseJIDPassFractionVSpt && mLooseJIDPassFractionVSpt->getRootObject())
+            mLooseJIDPassFractionVSpt->Fill(correctedJet.pt(), 0.);
+          if (fabs(correctedJet.eta()) < 3.0) {
+            mLooseJIDPassFractionVSptNoHF = map_of_MEs[DirName + "/" + "JetIDPassFractionVSptNoHF"];
+            if (mLooseJIDPassFractionVSptNoHF && mLooseJIDPassFractionVSptNoHF->getRootObject())
+              mLooseJIDPassFractionVSptNoHF->Fill(correctedJet.pt(), 0.);
+          }
+        }
+      }
+
       //mConstituents = map_of_MEs[DirName + "/" + "Constituents"];
       //if (mConstituents && mConstituents->getRootObject())
       //  mConstituents->Fill((*scoutingJets)[ijet].constituents());
@@ -4686,7 +4743,7 @@ void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
     }
     //after jettype specific variables are filled -> perform histograms for all jets
     //fill JetID efficiencies if uncleaned selection is chosen
-    if (!runcosmics_ && pass_corrected) {
+    if (!runcosmics_ && !isScoutingJet_ && pass_corrected) {
       if (jetpassid) {
         mLooseJIDPassFractionVSeta = map_of_MEs[DirName + "/" + "JetIDPassFractionVSeta"];
         if (mLooseJIDPassFractionVSeta && mLooseJIDPassFractionVSeta->getRootObject())

--- a/DQMOffline/JetMET/src/JetAnalyzer.cc
+++ b/DQMOffline/JetMET/src/JetAnalyzer.cc
@@ -210,8 +210,9 @@ JetAnalyzer::JetAnalyzer(const edm::ParameterSet& pSet)
       if (verbose_)
         std::cout << "no Valid scouting Run3ScoutinPF JetID quality given" << std::endl;
     }
-    run3scoutingpfjetIDFunctor = Run3ScoutingPFJetIDSelectionFunctor(run3scoutingpfjetidversion, run3scoutingpfjetidquality);
-    }
+    run3scoutingpfjetIDFunctor =
+        Run3ScoutingPFJetIDSelectionFunctor(run3scoutingpfjetidversion, run3scoutingpfjetidquality);
+  }
 
   //check later if some of those are also needed for PFJets
   leadJetFlag_ = 0;
@@ -2927,8 +2928,9 @@ void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
     if (!scoutingJets.isValid())
       return;
   } else {
-  if (jetCleaningFlag_ && (!jetCollectionIsValid || !bPrimaryVertex || !dcsDecision))  // why "jetCleaningFlag_ &&" ???
-    return;
+    if (jetCleaningFlag_ &&
+        (!jetCollectionIsValid || !bPrimaryVertex || !dcsDecision))  // why "jetCleaningFlag_ &&" ???
+      return;
   }
 
   unsigned int collSize = -1;

--- a/PhysicsTools/SelectorUtils/interface/Run3ScoutingPFJetIDSelectionFunctor.h
+++ b/PhysicsTools/SelectorUtils/interface/Run3ScoutingPFJetIDSelectionFunctor.h
@@ -25,10 +25,7 @@
 
 class Run3ScoutingPFJetIDSelectionFunctor {
 public:  // interface
-  enum Version_t {
-    RUN3Scouting,
-    N_VERSIONS
-  };
+  enum Version_t { RUN3Scouting, N_VERSIONS };
   enum Quality_t { TIGHT, TIGHTLEPVETO, N_QUALITY };
 
   Run3ScoutingPFJetIDSelectionFunctor() {}
@@ -45,17 +42,19 @@ public:  // interface
     if (versionStr == "RUN3Scouting")
       version_ = RUN3Scouting;
     else {
-      std::cout <<  "JetID version not specified -- setting default to RUN3Scouting" << std::endl;
-      version_ = RUN3Scouting;    //set RUN3Scouting as default //this is extremely unsafe --> similarly it's done in PFJetIDSelectionFunctor.h
+      edm::LogWarning("BadJetIDQuality") << "JetID quality not specified -- setting default to RUN3Scouting";
+      version_ =
+          RUN3Scouting;  //set RUN3Scouting as default //this is extremely unsafe --> similarly it's done in PFJetIDSelectionFunctor.h
     }
-          
+
     if (qualityStr == "TIGHT")
       quality_ = TIGHT;
     else if (qualityStr == "TIGHTLEPVETO")
       quality_ = TIGHTLEPVETO;
     else {
-      edm::LogWarning("BadJetIDQuality") << "JetID quality not specified -- setting default to RUN3Scouting";
-      quality_ = TIGHT;       //set TIGHT as default //this is extremely unsafe --> similarly it's done in PFJetIDSelectionFunctor.h
+      edm::LogWarning("BadJetIDQuality") << "JetID quality not specified -- setting default to TIGHT";
+      quality_ =
+          TIGHT;  //set TIGHT as default //this is extremely unsafe --> similarly it's done in PFJetIDSelectionFunctor.h
     }
 
     initCuts();
@@ -72,18 +71,17 @@ public:  // interface
     edm::ParameterSetDescription desc;
 
     desc.ifValue(
-        edm::ParameterDescription<std::string>("version", "RUN3Scouting", true, edm::Comment("")), //default "version"
-        edm::allowedValues<std::string>("RUN3Scouting")); //more options about "version"
-    desc.ifValue(edm::ParameterDescription<std::string>("quality", "TIGHT", true, edm::Comment("")), //default "quality"
-                 edm::allowedValues<std::string>("TIGHT", "TIGHTLEPVETO")); //more options about "quality"
+        edm::ParameterDescription<std::string>("version", "RUN3Scouting", true, edm::Comment("")),  //default "version"
+        edm::allowedValues<std::string>("RUN3Scouting"));  //more options about "version"
+    desc.ifValue(
+        edm::ParameterDescription<std::string>("quality", "TIGHT", true, edm::Comment("")),  //default "quality"
+        edm::allowedValues<std::string>("TIGHT", "TIGHTLEPVETO"));  //more options about "quality"
     desc.addOptional<std::vector<std::string>>("cutsToIgnore")->setComment("");
 
     return desc;
   }
 
- 
   bool operator()(const Run3ScoutingPFJet &jet) {
-
     // cache some variables
     //float pt = 0.0;
     float eta = 0.0;
@@ -107,8 +105,8 @@ public:  // interface
       eta = scoutingpfjet->eta();
       //phi = scoutingpfjet->phi();
       double jetEnergyUncorrected = scoutingpfjet->chargedHadronEnergy() + scoutingpfjet->neutralHadronEnergy() +
-                                    scoutingpfjet->photonEnergy() + scoutingpfjet->electronEnergy() + scoutingpfjet->muonEnergy() +
-                                    scoutingpfjet->HFEMEnergy();
+                                    scoutingpfjet->photonEnergy() + scoutingpfjet->electronEnergy() +
+                                    scoutingpfjet->muonEnergy() + scoutingpfjet->HFEMEnergy();
       if (jetEnergyUncorrected > 0.) {
         chf = scoutingpfjet->chargedHadronEnergy() / jetEnergyUncorrected;
         nhf = scoutingpfjet->neutralHadronEnergy() / jetEnergyUncorrected;
@@ -116,9 +114,11 @@ public:  // interface
         nef = (scoutingpfjet->photonEnergy() + scoutingpfjet->HFEMEnergy()) / jetEnergyUncorrected;
         muf = scoutingpfjet->muonEnergy() / jetEnergyUncorrected;
       }
-      
+
       nch = scoutingpfjet->chargedHadronMultiplicity() + scoutingpfjet->electronMultiplicity();
-      nconstituents = scoutingpfjet->chargedHadronMultiplicity() + scoutingpfjet->electronMultiplicity() + scoutingpfjet->neutralHadronMultiplicity() + scoutingpfjet->photonMultiplicity() + scoutingpfjet->HFEMMultiplicity();
+      nconstituents = scoutingpfjet->chargedHadronMultiplicity() + scoutingpfjet->electronMultiplicity() +
+                      scoutingpfjet->neutralHadronMultiplicity() + scoutingpfjet->photonMultiplicity() +
+                      scoutingpfjet->HFEMMultiplicity();
       //nneutrals = scoutingpfjet->neutralHadronMultiplicity() + scoutingpfjet->photonMultiplicity() + scoutingpfjet->HFEMMultiplicity();
     }
 
@@ -159,7 +159,6 @@ public:  // interface
   }
 
 private:  // member variables
-
   int nConstituents_ = 0;
   double CHF_ = 0.0;
   double NHF_ = 0.0;
@@ -170,7 +169,7 @@ private:  // member variables
   double MUF_TR_ = 0.0;
   double NEF_EC_ = 0.0;
   double NEF_FW_ = 0.0;
-  
+
   void initCuts() {
     if (quality_ == TIGHT) {
       if (version_ == RUN3Scouting) {
@@ -200,10 +199,8 @@ private:  // member variables
     }
   }
 
-
   Version_t version_;
   Quality_t quality_;
-
 };
 
 #endif

--- a/PhysicsTools/SelectorUtils/interface/Run3ScoutingPFJetIDSelectionFunctor.h
+++ b/PhysicsTools/SelectorUtils/interface/Run3ScoutingPFJetIDSelectionFunctor.h
@@ -54,7 +54,7 @@ public:  // interface
     else if (qualityStr == "TIGHTLEPVETO")
       quality_ = TIGHTLEPVETO;
     else {
-      std::cout <<  "JetID quality not specified -- setting default to RUN3Scouting" << std::endl;
+      edm::LogWarning("BadJetIDQuality") << "JetID quality not specified -- setting default to RUN3Scouting";
       quality_ = TIGHT;       //set TIGHT as default //this is extremely unsafe --> similarly it's done in PFJetIDSelectionFunctor.h
     }
 

--- a/PhysicsTools/SelectorUtils/interface/Run3ScoutingPFJetIDSelectionFunctor.h
+++ b/PhysicsTools/SelectorUtils/interface/Run3ScoutingPFJetIDSelectionFunctor.h
@@ -1,0 +1,209 @@
+#ifndef PhysicsTools_SelectorUtils_interface_Run3ScoutingPFJetIDSelectionFunctor_h
+#define PhysicsTools_SelectorUtils_interface_Run3ScoutingPFJetIDSelectionFunctor_h
+
+/**
+  \class    Run3ScoutingPFJetIDSelectionFunctor Run3ScoutingPFJetIDSelectionFunctor.h "PhysicsTools/SelectorUtils/interface/Run3ScoutingPFJetIDSelectionFunctor.h"
+  \brief    Run3ScoutingPF Jet selector for pat::Jets
+
+  Selector functor for pat::Jets that implements quality cuts based on
+  studies of noise patterns.
+
+  Please see https://twiki.cern.ch/twiki/bin/view/CMS/SWGuidePATSelectors
+  for a general overview of the selectors.
+*/
+
+#ifndef __GCCXML__
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#endif
+#include "DataFormats/Scouting/interface/Run3ScoutingPFJet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/allowedValues.h"
+
+#include <TMath.h>
+
+class Run3ScoutingPFJetIDSelectionFunctor {
+public:  // interface
+  enum Version_t {
+    RUN3Scouting,
+    N_VERSIONS
+  };
+  enum Quality_t { TIGHT, TIGHTLEPVETO, N_QUALITY };
+
+  Run3ScoutingPFJetIDSelectionFunctor() {}
+
+#ifndef __GCCXML__
+  Run3ScoutingPFJetIDSelectionFunctor(edm::ParameterSet const &params, edm::ConsumesCollector &iC)
+      : Run3ScoutingPFJetIDSelectionFunctor(params) {}
+#endif
+
+  Run3ScoutingPFJetIDSelectionFunctor(edm::ParameterSet const &params) {
+    std::string versionStr = params.getParameter<std::string>("version");
+    std::string qualityStr = params.getParameter<std::string>("quality");
+
+    if (versionStr == "RUN3Scouting")
+      version_ = RUN3Scouting;
+    else {
+      std::cout <<  "JetID version not specified -- setting default to RUN3Scouting" << std::endl;
+      version_ = RUN3Scouting;    //set RUN3Scouting as default //this is extremely unsafe --> similarly it's done in PFJetIDSelectionFunctor.h
+    }
+          
+    if (qualityStr == "TIGHT")
+      quality_ = TIGHT;
+    else if (qualityStr == "TIGHTLEPVETO")
+      quality_ = TIGHTLEPVETO;
+    else {
+      std::cout <<  "JetID quality not specified -- setting default to RUN3Scouting" << std::endl;
+      quality_ = TIGHT;       //set TIGHT as default //this is extremely unsafe --> similarly it's done in PFJetIDSelectionFunctor.h
+    }
+
+    initCuts();
+  }
+
+  Run3ScoutingPFJetIDSelectionFunctor(Version_t version, Quality_t quality) : version_(version), quality_(quality) {
+    initCuts();
+  }
+
+  //
+  // give a configuration description for derived class
+  //
+  static edm::ParameterSetDescription getDescription() {
+    edm::ParameterSetDescription desc;
+
+    desc.ifValue(
+        edm::ParameterDescription<std::string>("version", "RUN3Scouting", true, edm::Comment("")), //default "version"
+        edm::allowedValues<std::string>("RUN3Scouting")); //more options about "version"
+    desc.ifValue(edm::ParameterDescription<std::string>("quality", "TIGHT", true, edm::Comment("")), //default "quality"
+                 edm::allowedValues<std::string>("TIGHT", "TIGHTLEPVETO")); //more options about "quality"
+    desc.addOptional<std::vector<std::string>>("cutsToIgnore")->setComment("");
+
+    return desc;
+  }
+
+ 
+  bool operator()(const Run3ScoutingPFJet &jet) {
+
+    // cache some variables
+    //float pt = 0.0;
+    float eta = 0.0;
+    //float phi = 0.0;
+
+    double chf = 0.0;
+    double nhf = 0.0;
+    //double cef = 0.0;
+    double nef = 0.0;
+    double muf = 0.0;
+
+    int nch = 0;
+    int nconstituents = 0;
+    //int nneutrals = 0;
+
+    Run3ScoutingPFJet const *scoutingpfjet = dynamic_cast<Run3ScoutingPFJet const *>(&jet);
+
+    if (scoutingpfjet != nullptr) {
+      // CV: need to compute energy fractions in a way that works for corrected as well as for uncorrected PFJets
+      //pt = scoutingpfjet->pt();
+      eta = scoutingpfjet->eta();
+      //phi = scoutingpfjet->phi();
+      double jetEnergyUncorrected = scoutingpfjet->chargedHadronEnergy() + scoutingpfjet->neutralHadronEnergy() +
+                                    scoutingpfjet->photonEnergy() + scoutingpfjet->electronEnergy() + scoutingpfjet->muonEnergy() +
+                                    scoutingpfjet->HFEMEnergy();
+      if (jetEnergyUncorrected > 0.) {
+        chf = scoutingpfjet->chargedHadronEnergy() / jetEnergyUncorrected;
+        nhf = scoutingpfjet->neutralHadronEnergy() / jetEnergyUncorrected;
+        //cef= scoutingpfjet->electronEnergy() / jetEnergyUncorrected;  // for now: electron energy is 0, since HLT scouting jets by construction don't contain electrons
+        nef = (scoutingpfjet->photonEnergy() + scoutingpfjet->HFEMEnergy()) / jetEnergyUncorrected;
+        muf = scoutingpfjet->muonEnergy() / jetEnergyUncorrected;
+      }
+      
+      nch = scoutingpfjet->chargedHadronMultiplicity() + scoutingpfjet->electronMultiplicity();
+      nconstituents = scoutingpfjet->chargedHadronMultiplicity() + scoutingpfjet->electronMultiplicity() + scoutingpfjet->neutralHadronMultiplicity() + scoutingpfjet->photonMultiplicity() + scoutingpfjet->HFEMMultiplicity();
+      //nneutrals = scoutingpfjet->neutralHadronMultiplicity() + scoutingpfjet->photonMultiplicity() + scoutingpfjet->HFEMMultiplicity();
+    }
+
+    if (version_ == RUN3Scouting) {
+      if (std::abs(eta) <= 2.6) {
+        if ((chf > CHF_) && (nch > NCH_) && (nef < NEF_) && (nhf < NHF_) && (nconstituents > nConstituents_))
+          return true;
+        if (quality_ == TIGHTLEPVETO) {
+          if (muf < MUF_)
+            return true;
+        }
+      }
+
+      // Cuts for 2.6 <= |eta| <= 2.7
+      if ((std::abs(eta) > 2.6) && (std::abs(eta) <= 2.7)) {
+        if (nef < NEF_TR_)
+          return true;
+        if (quality_ == TIGHTLEPVETO) {
+          if (muf < MUF_TR_)
+            return true;
+        }
+      }
+
+      // Cuts for 2.7 < |eta| <= 3.0
+      if ((std::abs(eta) > 2.7) && (std::abs(eta) <= 3.0)) {
+        if (nef < NEF_EC_)
+          return true;
+      }
+
+      // Cuts for |eta| > 3.0
+      if (std::abs(eta) > 3.0) {
+        if (nef < NEF_FW_)
+          return true;
+      }
+    }
+
+    return false;
+  }
+
+private:  // member variables
+
+  int nConstituents_ = 0;
+  double CHF_ = 0.0;
+  double NHF_ = 0.0;
+  double NEF_ = 0.0;
+  double MUF_ = 0.0;
+  double NCH_ = 0.0;
+  double NEF_TR_ = 0.0;
+  double MUF_TR_ = 0.0;
+  double NEF_EC_ = 0.0;
+  double NEF_FW_ = 0.0;
+  
+  void initCuts() {
+    if (quality_ == TIGHT) {
+      if (version_ == RUN3Scouting) {
+        nConstituents_ = 1;
+        CHF_ = 0.01;
+        NHF_ = 0.99;
+        NEF_ = 0.9;
+        NCH_ = 0.0;
+        NEF_TR_ = 0.9;
+        NEF_EC_ = 0.9;
+        NEF_FW_ = 0.2;
+      }
+    } else if (quality_ == TIGHTLEPVETO) {
+      if (version_ == RUN3Scouting) {
+        CHF_ = 0.01;
+        nConstituents_ = 1;
+        CHF_ = 0.01;
+        NHF_ = 0.99;
+        NEF_ = 0.9;
+        NCH_ = 0.0;
+        MUF_ = 0.8;
+        NEF_TR_ = 0.9;
+        MUF_TR_ = 0.8;
+        NEF_EC_ = 0.9;
+        NEF_FW_ = 0.2;
+      }
+    }
+  }
+
+
+  Version_t version_;
+  Quality_t quality_;
+
+};
+
+#endif


### PR DESCRIPTION
#### PR description:

This PR is complementary to [cmssw/#47328](https://github.com/cms-sw/cmssw/pull/47328)  (and [cmssw/#47212](https://github.com/cms-sw/cmssw/pull/47212)) to add JetID criteria for Scouting jets.

#### PR validation:

This PR has been prepared starting from CMSSW_15_1_0_pre1:
cmsrel CMSSW_15_1_0_pre1
cd CMSSW_15_1_0_pre1/src
cmsenv 
git cms-init
git cms-addpkg PhysicsTools/SelectorUtils
scram b
scram build code-checks
scram build code-format



#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR should also be backported to CMSSW_15_0_X releases so that the Offline Scouting DQM developments are linked and complete in all these releases.

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)


