### PR TITLE
Change HPSTau input collection from l1tHPSPFTauProducerPF to l1tHPSPFTauProducerPuppi

### DIFF
--- a/DPGAnalysis/Phase2L1TNanoAOD/python/l1tPh2Nanotables_cff.py
+++ b/DPGAnalysis/Phase2L1TNanoAOD/python/l1tPh2Nanotables_cff.py
@@ -484,7 +484,7 @@ nnPuppiTauTable = cms.EDProducer(
 
 hpsTauTable = cms.EDProducer(
     "SimpleTriggerL1HPSPFTauFlatTableProducer",
-    src = cms.InputTag("l1tHPSPFTauProducerPF",""),
+    src = cms.InputTag("l1tHPSPFTauProducerPuppi",""),
     cut = cms.string(""),
     name = cms.string("L1hpsTau"),
     doc = cms.string("HPS Taus"),


### PR DESCRIPTION
#### PR description:

Updates the input collection for HPSTau L1 objects from `l1tHPSPFTauProducerPF` to `l1tHPSPFTauProducerPuppi`, which is a more appropriate collection for the Spring24 MC samples.

This change only affects the HPSTau objects stored in the NanoAOD output produced using the Phase2L1TNanoAOD package, which was introduced into CMSSW in #47178.

#### PR validation:

Verified that only the HPSTau L1 object collection is impacted - standard plots produced with [Phase2-L1MenuTools](https://github.com/cms-l1-dpg/Phase2-L1MenuTools) are here, comparing tau performance before and after the change:  https://roward.web.cern.ch/L1T/Phase2/menu/Validation/NewMenuTools/comparisons/V44nanovsV44nano_hpsTau/object_performance/turnons/ 