### PR TITLE
Update on GEM offlineDQM Cluster plots

### DIFF
--- a/DQM/GEM/plugins/GEMRecHitSource.cc
+++ b/DQM/GEM/plugins/GEMRecHitSource.cc
@@ -83,12 +83,7 @@ void GEMRecHitSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
 
   mapCLSPerCh_ = MEMap4Inf(
       this, "cls", "Cluster size of RecHits", nCLSMax_, 0.5, nCLSMax_ + 0.5, 1, 0.5, 1.5, "Cluster size", "iEta");
-   /*
-  if (nRunType_ == GEMDQM_RUNTYPE_OFFLINE) {
-    mapCLSOver5_.TurnOff();
-    mapCLSPerCh_.TurnOff();
-  }
-  */
+  
   if (nRunType_ == GEMDQM_RUNTYPE_RELVAL) {
     mapRecHitXY_layer_.TurnOff();
     mapCLSAverage_.TurnOff();

--- a/DQM/GEM/plugins/GEMRecHitSource.cc
+++ b/DQM/GEM/plugins/GEMRecHitSource.cc
@@ -83,7 +83,7 @@ void GEMRecHitSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
 
   mapCLSPerCh_ = MEMap4Inf(
       this, "cls", "Cluster size of RecHits", nCLSMax_, 0.5, nCLSMax_ + 0.5, 1, 0.5, 1.5, "Cluster size", "iEta");
-  
+
   if (nRunType_ == GEMDQM_RUNTYPE_RELVAL) {
     mapRecHitXY_layer_.TurnOff();
     mapCLSAverage_.TurnOff();

--- a/DQM/GEM/plugins/GEMRecHitSource.cc
+++ b/DQM/GEM/plugins/GEMRecHitSource.cc
@@ -83,12 +83,12 @@ void GEMRecHitSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
 
   mapCLSPerCh_ = MEMap4Inf(
       this, "cls", "Cluster size of RecHits", nCLSMax_, 0.5, nCLSMax_ + 0.5, 1, 0.5, 1.5, "Cluster size", "iEta");
-
+   /*
   if (nRunType_ == GEMDQM_RUNTYPE_OFFLINE) {
     mapCLSOver5_.TurnOff();
     mapCLSPerCh_.TurnOff();
   }
-
+  */
   if (nRunType_ == GEMDQM_RUNTYPE_RELVAL) {
     mapRecHitXY_layer_.TurnOff();
     mapCLSAverage_.TurnOff();


### PR DESCRIPTION
PR description:

In this PR, GEM offlineDQM plots for Clustersize and Occupancy of largeCluster have been implemented

comments fixed

PR validation:

Tests are done with runTheMatrix.py -w upgrade -l 12850.0 with an additional run (386679) and runTheMatrix.py -l limited -i all —ibeos. since it makes effects on P5 and reconstruction

@jshlee @watson-ij @quark2
