### PR TITLE
[15_0_X] Update 2025 HMT shower thresholds for pp collision

### DIFF
--- a/Configuration/Eras/python/Era_Run3_2025_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2025_cff.py
@@ -2,7 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Run3_2024_cff import Run3_2024
 from Configuration.Eras.Modifier_run3_GEM_2025_cff import run3_GEM_2025
+from Configuration.Eras.Modifier_run3_CSC_2025_cff import run3_CSC_2025
 from Configuration.Eras.Modifier_run3_SiPixel_2025_cff import run3_SiPixel_2025
 from Configuration.Eras.Modifier_stage2L1Trigger_2025_cff import stage2L1Trigger_2025
 
-Run3_2025 = cms.ModifierChain(Run3_2024, run3_GEM_2025, run3_SiPixel_2025, stage2L1Trigger_2025)
+Run3_2025 = cms.ModifierChain(Run3_2024, run3_GEM_2025, run3_SiPixel_2025, stage2L1Trigger_2025, run3_CSC_2025)

--- a/Configuration/Eras/python/Modifier_run3_CSC_2025_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_CSC_2025_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+run3_CSC_2025 =  cms.Modifier()
+

--- a/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
@@ -11,7 +11,7 @@ from L1Trigger.CSCTriggerPrimitives.params.clctParams import clctPSets
 from L1Trigger.CSCTriggerPrimitives.params.tmbParams import tmbPSets
 from L1Trigger.CSCTriggerPrimitives.params.auxiliaryParams import auxPSets
 from L1Trigger.CSCTriggerPrimitives.params.gemcscParams import gemcscPSets
-from L1Trigger.CSCTriggerPrimitives.params.showerParams import showerPSet
+from L1Trigger.CSCTriggerPrimitives.params.showerParams import showerPSet,showerPSet_2025
 
 cscTriggerPrimitiveDigis = cms.EDProducer(
     "CSCTriggerPrimitivesProducer",
@@ -73,6 +73,12 @@ run3_common.toModify( cscTriggerPrimitiveDigis,
                                          runME31Up = True,
                                          runME41Up = True)
 )
+## update shower thresholds for 2025 runs
+from Configuration.Eras.Modifier_run3_CSC_2025_cff import run3_CSC_2025
+run3_CSC_2025.toModify( cscTriggerPrimitiveDigis,
+                      showerParams = showerPSet_2025.clone()
+)
+
 
 ## GEM-CSC integrated local trigger in ME1/1
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM

--- a/L1Trigger/CSCTriggerPrimitives/python/params/showerParams.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/params/showerParams.py
@@ -94,3 +94,85 @@ showerPSet = cms.PSet(
         minLayersCentralTBin = cms.uint32(5),
     )
 )
+
+showerPSet_2025 = cms.PSet(
+    ## what kind of shower triggers the logic?
+    ## 0: cathode-only (TMB/OTMB)
+    ## 1: anode-only (from ALCT board)
+    source  = cms.vuint32(
+	# ME1/1
+	1,
+	# ME1/2
+	1,
+	# ME1/3
+	1,
+	# ME2/1
+	1,
+	# ME2/2
+	1,
+	# ME3/1
+	1,
+	# ME3/2
+	1,
+	# ME4/1
+	1,
+	# ME4/2
+	1
+	),
+
+    ## settings for cathode showers (counting CSCComparatorDigi)
+    cathodeShower = cms.PSet(
+	## 10000 means to disable cathode HMT for this chamber type
+        showerThresholds = cms.vuint32(
+            # ME1/1
+            10000, 10000, 10000,
+            # ME1/2
+            10000, 10000, 10000,
+            # ME1/3
+            10000, 10000, 10000,
+            # ME2/1
+            10000, 10000, 10000,
+            # ME2/2
+            10000, 10000, 10000,
+            # ME3/1
+            10000, 10000, 10000,
+            # ME3/2
+            10000, 10000, 10000,
+            # ME4/1
+            10000, 10000, 10000,
+            # ME4/2
+            10000, 10000, 10000
+        ),
+        showerNumTBins = cms.uint32(3),# 3BX for cathode HMT
+        minLayersCentralTBin = cms.uint32(5),
+	## peack check feature is not implemented in firmware
+	## plan to upgrade in future
+	peakCheck = cms.bool(False),
+    ),
+    ## settings for anode showers (counting CSCWireDigi)
+    anodeShower = cms.PSet(
+        ## {loose, nominal, tight} thresholds for hit counters
+        showerThresholds = cms.vuint32(
+            # ME1/1
+            1000, 1000, 1000,
+            # ME1/2
+            1000, 1000, 1000,
+            # ME1/3
+            7, 14, 18,
+            # ME2/1
+            24, 76, 84,
+            # ME2/2
+            12, 34, 37,
+            # ME3/1
+            22, 67, 77,
+            # ME3/2
+            12, 21, 21,
+            # ME4/1
+            26, 80, 92,
+            # ME4/2
+            12, 23, 23
+        ),
+        showerNumTBins = cms.uint32(1),# 1BX for anode HMT
+        minLayersCentralTBin = cms.uint32(5),
+    )
+)


### PR DESCRIPTION
#### PR description:

This is a backport of #47701

This PR updates 2025 HMT shower thresholds for pp collision.
This set of thresholds will be used for 2025 initial pp collision data-taking, and will be necessary for any emulator comparison.
Details are presented in the L1 DPG meeting on March 24[1].
@santeri

[1]https://indico.cern.ch/event/1529818/contributions/6436557/attachments/3037597/5367253/MDS_L1_thresholds_2025.pdf


#### PR validation:

same as #47701

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport needed for 2025 emulation studies.