### PR TITLE
fixes for vector size handling and spurious wakeups in TimeStudyModules

### DIFF
--- a/FWCore/Modules/src/TimeStudyModules.cc
+++ b/FWCore/Modules/src/TimeStudyModules.cc
@@ -232,12 +232,13 @@ namespace timestudy {
         return true;
       }
       //every running stream is now waiting
-      return waitingStreams_.size() == activeStreams_;
+      return waitingStreams_.size() > 0 and waitingStreams_.size() == activeStreams_;
     }
 
     void threadWork() {
       while (not stopProcessing_.load()) {
         std::vector<int> streamsToProcess;
+        streamsToProcess.reserve(waitingStreams_.capacity());
         {
           std::unique_lock<std::mutex> lk(mutex_);
           condition_.wait(lk, [this]() { return readyToDoSomething(); });
@@ -266,6 +267,7 @@ namespace timestudy {
         }
       }
       waitingTaskPerStream_.clear();
+      waitingTaskPerStream_.resize(waitingTaskPerStream_.capacity());
     }
     const unsigned int nWaitingEvents_;
     std::unique_ptr<std::thread> serverThread_;

--- a/FWCore/Modules/src/TimeStudyModules.cc
+++ b/FWCore/Modules/src/TimeStudyModules.cc
@@ -232,7 +232,7 @@ namespace timestudy {
         return true;
       }
       //every running stream is now waiting
-      return waitingStreams_.size() > 0 and waitingStreams_.size() == activeStreams_;
+      return !waitingStreams_.empty() and waitingStreams_.size() == activeStreams_;
     }
 
     void threadWork() {

--- a/FWCore/Modules/src/TimeStudyModules.cc
+++ b/FWCore/Modules/src/TimeStudyModules.cc
@@ -215,7 +215,7 @@ namespace timestudy {
     void asyncWork(
         edm::StreamID id, edm::WaitingTaskWithArenaHolder iTask, long initTime, long workTime, long finishTime) {
       waitTimesPerStream_[id.value()] = {{initTime, workTime, finishTime}};
-      waitingTaskPerStream_[id.value()] = std::move(iTask);
+      waitingTaskPerStream_.at(id.value()) = std::move(iTask);
       {
         std::lock_guard<std::mutex> lk{mutex_};
         waitingStreams_.push_back(id.value());
@@ -231,14 +231,15 @@ namespace timestudy {
       if (waitingStreams_.size() >= nWaitingEvents_) {
         return true;
       }
-      //every running stream is now waiting
+      //every running stream is now waiting but guard against spurious wakeups
       return !waitingStreams_.empty() and waitingStreams_.size() == activeStreams_;
     }
 
     void threadWork() {
       while (not stopProcessing_.load()) {
         std::vector<int> streamsToProcess;
-        streamsToProcess.reserve(waitingStreams_.capacity());
+        // preallocate to fixed size so there are no resizes
+        streamsToProcess.reserve(waitTimesPerStream_.size());
         {
           std::unique_lock<std::mutex> lk(mutex_);
           condition_.wait(lk, [this]() { return readyToDoSomething(); });


### PR DESCRIPTION
#### PR description:

TestFWCoreModules in FWCore/Modules has a rare failure mode, most recently seen in CMSSW_15_1_UBSAN_X_2025-03-26-2300, with UBSAN warnings
```
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/stl_iterator.h:1096:17: runtime error: reference binding to null pointer of type 'int'
    #0 0x14b729a4d6ca in __gnu_cxx::__normal_iterator<int*, std::vector<int, std::allocator<int> > >::operator*() const /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/stl_iterator.h:1096
    #1 0x14b729a4d6ca in timestudy::SleepingServer::threadWork() src/FWCore/Modules/src/TimeStudyModules.cc:246
    #2 0x14b7386d8a72 in execute_native_thread_routine ../../../../../libstdc++-v3/src/c++11/thread.cc:82
    #3 0x14b737c061c9 in start_thread (/lib64/libpthread.so.0+0x81c9)
    #4 0x14b7382638d2 in __GI___clone (/lib64/libc.so.6+0x398d2)

src/FWCore/Modules/src/TimeStudyModules.cc:246:23: runtime error: load of null pointer of type 'int'
    #0 0x14b729a4d742 in timestudy::SleepingServer::threadWork() src/FWCore/Modules/src/TimeStudyModules.cc:246
    #1 0x14b7386d8a72 in execute_native_thread_routine ../../../../../libstdc++-v3/src/c++11/thread.cc:82
    #2 0x14b737c061c9 in start_thread (/lib64/libpthread.so.0+0x81c9)
    #3 0x14b7382638d2 in __GI___clone (/lib64/libc.so.6+0x398d2)
```
followed by a segmentation violation.  This PR corrects two issues (found by code inspection) where the vector size or capacity wasn't being correctly maintained, and one issue (found through additional debugging) where spurious wakeups could be triggered when there were no waiting streams to process.

Resolves https://github.com/cms-sw/framework-team/issues/1321

#### PR validation:

Technical fix.  Without the change, the crash was moderately reproducible.  With these modifications, no test failures have been observed.