### PR TITLE
[10_6_X] Reduce memory usage in NANO merge jobs

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/NanoAODOutputModule.cc
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODOutputModule.cc
@@ -250,7 +250,7 @@ NanoAODOutputModule::writeRun(edm::RunForOutput const& iRun) {
         if (hstring->str() != tos->GetString()) throw cms::Exception("LogicError", "Inconsistent nanoMetadata " + p.first + " (" + hstring->str() +")");
     } else {
         auto ostr = std::make_unique<TObjString>(hstring->str().c_str());
-        m_file->WriteTObject(ostr.release(), p.first.c_str()); 
+        m_file->WriteTObject(ostr.get(), p.first.c_str());
     }
   }
 

--- a/PhysicsTools/NanoAOD/plugins/SummaryTableOutputBranches.cc
+++ b/PhysicsTools/NanoAOD/plugins/SummaryTableOutputBranches.cc
@@ -10,7 +10,7 @@ void SummaryTableOutputBranches::makeScalarBranches(const std::vector<Col> &tabc
           return x.name == col.name;
         }) == branches.end()) {
       T backFillValue = 0;
-      auto *br = tree.Branch(col.name.c_str(), &backFillValue, (col.name + "/" + rootType).c_str());
+      auto *br = tree.Branch(col.name.c_str(), &backFillValue, (col.name + "/" + rootType).c_str(), /*bufsize=*/1024);
       br->SetTitle(col.doc.c_str());
       for (unsigned long i = 0; i < m_fills; i++)
         br->Fill();


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/47729

> #### PR description:
> 
> This PR reduces the memory usage in the NANO merge step for samples with a large number of GEN parameter configurations, e.g., the pMSSM scan, by reducing the buffer size (from the default 32000 to 1024 bytes) of the TTree branches storing the sum gen weights in the `Runs` tree (which is typically just a single entry, but the `Runs` tree will contain one branch for each GEN parameter, which could then leads to O(10k) branches in these large scans). 
> 
> Also fixed a minor memory leak reported in https://github.com/cms-sw/cmssw/issues/47713.
> 
> This should fix https://github.com/cms-sw/cmssw/issues/47711 and https://github.com/cms-sw/cmssw/issues/47713.
> 
> #### PR validation:
> 
> For the merge of the 115 files in https://github.com/cms-sw/cmssw/issues/47711, the peak PSS is reduced from ~9GB to 3.5GB. 
> 
> #### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
> 
> I suppose this needs to be backported to 15_0_X and 10_6_X, but any other releases in between?