### PR TITLE
Add filter to skip events without scouting objects in ScoutingNano for ScoutingPFMonitor dataset

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_nano.py
+++ b/Configuration/PyReleaseValidation/python/relval_nano.py
@@ -257,10 +257,7 @@ steps['jmeNANO_rePuppi_data14.0'] = merge([{'-s': 'NANO:@JMErePuppi', '-n': '100
 steps['scoutingNANO_data14.0'] = merge([{'-s': 'NANO:@Scout'},
                                         steps['NANO_data14.0']])
 
-# Process.options.TryToContinue = cms.untracked.vstring(\'ProductNotFound\') is needed here because some events in ScoutingPFMonitor in 2024 do not contain scouting objects.
-# This should be fixed in 2025 (https://its.cern.ch/jira/browse/CMSHLT-3331) so customise_commands won't be needed for 2025 workflow.
-steps['scoutingNANO_withPrompt_data14.0'] = merge([{'-s': 'NANO:@Prompt+@Scout', 
-                                                   '--customise_commands': '"process.options.TryToContinue = cms.untracked.vstring(\'ProductNotFound\')"'},
+steps['scoutingNANO_withPrompt_data14.0'] = merge([{'-s': 'NANO:@Prompt+@ScoutMonitor'}, 
                                                    steps['NANO_data14.0']])
 
 # DPG custom NANO

--- a/PhysicsTools/NanoAOD/python/autoNANO.py
+++ b/PhysicsTools/NanoAOD/python/autoNANO.py
@@ -34,6 +34,8 @@ autoNANO = {
     # Scouting nano
     'Scout' : {'sequence': 'PhysicsTools/NanoAOD/custom_run3scouting_cff.scoutingNanoSequence',
                'customize': 'PhysicsTools/NanoAOD/custom_run3scouting_cff.customiseScoutingNano'},
+    'ScoutMonitor' : {'sequence': '@Scout',
+                      'customize': '@Scout+PhysicsTools/NanoAOD/custom_run3scouting_cff.customiseScoutingNanoForScoutingPFMonitor'},
     'ScoutFromMini' : {'sequence': '@Scout',
                        'customize': '@Scout+PhysicsTools/NanoAOD/custom_run3scouting_cff.customiseScoutingNanoFromMini'},
     # JME nano

--- a/PhysicsTools/NanoAOD/python/custom_run3scouting_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_run3scouting_cff.py
@@ -1,6 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.NanoAOD.run3scouting_cff import *
-from L1Trigger.Configuration.L1TRawToDigi_cff import *
 from EventFilter.L1TRawToDigi.gtStage2Digis_cfi import gtStage2Digis
 from PhysicsTools.NanoAOD.triggerObjects_cff import l1bits
 from PhysicsTools.NanoAOD.globals_cff import puTable
@@ -123,7 +122,7 @@ scoutingNanoSequence = cms.Sequence(scoutingNanoTaskCommon)
 
 # Specific tasks which will be added to sequence during customization
 scoutingTriggerTask = prepareScoutingTriggerTask()
-scoutingTriggerSequence = cms.Sequence(L1TRawToDigi+cms.Sequence(scoutingTriggerTask))
+scoutingTriggerSequence = cms.Sequence(scoutingTriggerTask)
 scoutingNanoTaskMC = prepareScoutingNanoTaskMC()
 
 def customiseScoutingNano(process):
@@ -147,17 +146,28 @@ def customiseScoutingNano(process):
 # these function are designed to be used with --customise flag in cmsDriver.py
 # e.g. --customise PhysicsTools/NanoAOD/python/custom_run3scouting_cff.addScoutingPFCandidate
 
-# reconfigure for running with ScoutingPFMonitor/MiniAOD inputs alone
+# additional customisation for running with ScoutingPFMonitor/RAW inputs
 # should be used with default customiseScoutingNano
-def customiseScoutingNanoFromMini(process):
-    # remove L1TRawToDigi
-    process.scoutingTriggerSequence.remove(process.L1TRawToDigi)
+# this is suitable when ScoutingPFMonitor/RAW is involved, e.g. RAW, RAW-MiniAOD two-file solution, full chain RAW-MiniAOD-NanoAOD
+# when running full chain RAW-MiniAOD-NanoAOD, this ensures that gtStage2Digis, gmtStage2Digis, and caloStage2Digis are run
+def customiseScoutingNanoForScoutingPFMonitor(process):
+    process = skipEventsWithoutScouting(process)
 
-    # remove gtStage2Digis since they are already run for Mini
+    # replace gtStage2DigisScouting with standard gtStage2Digis
     process.scoutingTriggerTask.remove(process.gtStage2DigisScouting)
+    process.scoutingTriggerTask.add(process.gtStage2Digis)
 
-    # change src for l1 bits
-    process.l1bitsScouting.src = cms.InputTag("gtStage2Digis")
+    # add gmtStage2Digis
+    process.load("EventFilter.L1TRawToDigi.gmtStage2Digis_cfi")
+    process.scoutingTriggerTask.add(process.gmtStage2Digis)
+
+    # add caloStage2Digis
+    process.load("EventFilter.L1TRawToDigi.caloStage2Digis_cfi")
+    process.scoutingTriggerTask.add(process.caloStage2Digis)
+
+    # replace l1bitsScouting with standard l1bits
+    process.scoutingTriggerTask.remove(process.l1bitsScouting)
+    process.scoutingTriggerTask.add(process.l1bits)
 
     # change src for l1 objects
     process.l1MuScoutingTable.src = cms.InputTag("gmtStage2Digis", "Muon")
@@ -165,6 +175,57 @@ def customiseScoutingNanoFromMini(process):
     process.l1TauScoutingTable.src = cms.InputTag("caloStage2Digis", "Tau")
     process.l1JetScoutingTable.src = cms.InputTag("caloStage2Digis", "Jet")
     process.l1EtSumScoutingTable.src = cms.InputTag("caloStage2Digis", "EtSum")
+
+    return process
+
+# additional customisation for running with ScoutingPFMonitor/MiniAOD inputs alone
+# can also be used on MC input
+# should be used with default customiseScoutingNano and NOT with customiseScoutingNanoForScoutingPFMonitor
+def customiseScoutingNanoFromMini(process):
+    # when running on data, assume ScoutingPFMonitor/MiniAOD dataset as inputs
+    runOnData = hasattr(process,"NANOAODSIMoutput") or hasattr(process,"NANOAODoutput")
+    if runOnData:
+        process = skipEventsWithoutScouting(process)
+
+    # remove gtStage2Digis since they are already run for Mini
+    process.scoutingTriggerTask.remove(process.gtStage2DigisScouting)
+
+    # replace l1bitsScouting with standard l1bits
+    process.scoutingTriggerTask.remove(process.l1bitsScouting)
+    process.scoutingTriggerTask.add(process.l1bits)
+
+    # change src for l1 objects
+    process.l1MuScoutingTable.src = cms.InputTag("gmtStage2Digis", "Muon")
+    process.l1EGScoutingTable.src = cms.InputTag("caloStage2Digis", "EGamma")
+    process.l1TauScoutingTable.src = cms.InputTag("caloStage2Digis", "Tau")
+    process.l1JetScoutingTable.src = cms.InputTag("caloStage2Digis", "Jet")
+    process.l1EtSumScoutingTable.src = cms.InputTag("caloStage2Digis", "EtSum")
+
+    return process
+
+# skip events without scouting object products
+# this may be needed since for there are some events which do not contain scouting object products in 2022-24
+# this is fixed for 2025: https://its.cern.ch/jira/browse/CMSHLT-3331
+def skipEventsWithoutScouting(process):
+    # if scouting paths are triggered, scouting objects will be reconstructed
+    # so we select events passing scouting paths
+    import HLTrigger.HLTfilters.hltHighLevel_cfi
+
+    process.scoutingTriggerPathFilter = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone(
+            HLTPaths = cms.vstring("Dataset_ScoutingPFRun3")
+            )
+
+    process.nanoSkim_step = cms.Path(process.scoutingTriggerPathFilter)
+    process.schedule.extend([process.nanoSkim_step])
+
+    if hasattr(process, "NANOAODoutput"):
+        process.NANOAODoutput.SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring("nanoSkim_step"))
+
+    if hasattr(process, "NANOAODEDMoutput"):
+        process.NANOEDMAODoutput.SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring("nanoSkim_step"))
+
+    if hasattr(process, "write_NANOAOD"): # PromptReco
+        process.write_NANOAOD.SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring("nanoSkim_step")) 
 
     return process
 


### PR DESCRIPTION
#### PR description:

This PR supersedes [cms-sw/cmssw#47302](https://github.com/cms-sw/cmssw/pull/47302) on filter implementation (Another part on era modifier implemented in [cms-sw/cmssw#47302](https://github.com/cms-sw/cmssw/pull/47302) will be superseded by another PR).

In 2022-24, ScoutingPFMonitor dataset consists of logical-OR of scouting and standard HLT paths. However, only scouting objects are reconstructed on scouting paths. Events passing only standard HLT paths, but not scouting paths, will not contain scouting products. This gives a proper treatment to the issue with EDFilter instead of previous solution introduced in [cms-sw/cmssw#46516](https://github.com/cms-sw/cmssw/pull/46516).

This is not an issue in 2025 following [CMSHLT-3089](https://its.cern.ch/jira/browse/CMSHLT-3089).

For more technical details,
- this PR adds customisation to add check and skip events without scouting which can be included in ```cmsDriver.py``` by adding```--customise PhysicsTools/NanoAOD/custom_run3scouting_cff.skipEventsWithoutScouting```.
- this PR adds ```@ScoutMonitor``` flavour similar to ```@Scout``` with the above customisation added.
- this PR also removes L1TRAWToDigi sequence (defined in [L1TRawToDigi_cff.py](https://github.com/cms-sw/cmssw/blob/master/L1Trigger/Configuration/python/L1TRawToDigi_cff.py)) as it contains additional modules not used by ScoutingNano.

#### PR validation:

Pass all tests from ```scram b runtests use-ibeos```.
Pass all ScoutingNano-related relval_nano workflows from 
```
runTheMatrix.py --ibeos -l 2500.131,2500.227,2500.228,2500.237,2500.238
```

In addition, several ```cmsDriver.py``` commands have been tested on data and MC samples documented in [1].
In brief, concerning data:

- ```@Scout``` works for ScoutingPFRun3 2022-24
- ```@ScoutMonitor``` works for ScoutingPFMonitor 2022-24
- ```@ScoutFromMini``` works for ScoutingPFMonitor 2024 (Scouting objects are in MiniAOD starting in Prompt 2024)
- ```@Prompt+@ScoutMonitor``` works for ScoutingPFMonitor 2023. Input 2022 fails because of Tau.
- ```@Prompt+@ScoutFromMini```works for ScoutingPFMonitor 2024 (Scouting objects are in MiniAOD starting in Prompt 2024)
Please see commands in [1]. Relevant test results (python config, root, event content, size report, log) are included in [2]. Summary of size report is in [3].

Moreover, since this might be used for prompt reconstruction, to simulate the prompt reconstruction workflow, we ran ```RunPromptReco.py``` (with modified ```n=1000```) with the following command:
```
RunPromptReco.py --scenario ppEra_Run3_2024 --reco --aod --miniaod --nanoaod --dqmio --global-tag 140X_dataRun3_Prompt_v4 --nanoFlavours=@PHYS+@L1+@ScoutMonitor --lfn=fileIn.root
```
This step reconstructs ```fileIn.root``` in RAW tier to RECO, AOD, MINIAOD, NANOAOD, and DQMIO. The output files in RECO, AOD, and MINIAOD have 1000 events while NANOAOD (in NANOAODEDM) has 986 events. This is expected since the filter is applied for NANOAOD.
Finally, merge step is run with
```
RunMerge.py --mergeNANO --input-files=output_inNANOAOD.root --output-file=output_inNANOAOD_merged.root
```
The output file is now in final NANOAOD format (TTree with all primitives) and has 986 events. The event content contains standard, L1, and scouting objects as expected (```@PHYS+@L1+@ScoutMonitor```).

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is not a backport.

[1] https://codimd.web.cern.ch/PTeusxQURcmBaS7Ilfv9GQ?view
[2] https://cernbox.cern.ch/s/J64vQTyn6J5FgRC
[3] https://docs.google.com/spreadsheets/d/10UFlWqurxMTuXy0HeulFTjbx5lUca9ZeM4CAXkC12Wo/edit?usp=sharing