### PR TITLE
[15_0_X] Update on GEM offlineDQM Cluster plots to backport 15_0_X

### DIFF
--- a/DQM/GEM/plugins/GEMRecHitSource.cc
+++ b/DQM/GEM/plugins/GEMRecHitSource.cc
@@ -84,11 +84,6 @@ void GEMRecHitSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
   mapCLSPerCh_ = MEMap4Inf(
       this, "cls", "Cluster size of RecHits", nCLSMax_, 0.5, nCLSMax_ + 0.5, 1, 0.5, 1.5, "Cluster size", "iEta");
 
-  if (nRunType_ == GEMDQM_RUNTYPE_OFFLINE) {
-    mapCLSOver5_.TurnOff();
-    mapCLSPerCh_.TurnOff();
-  }
-
   if (nRunType_ == GEMDQM_RUNTYPE_RELVAL) {
     mapRecHitXY_layer_.TurnOff();
     mapCLSAverage_.TurnOff();


### PR DESCRIPTION
#### PR description:

In this PR, GEM offlineDQM plots for Clustersize and Occupancy of largeCluster have been implemented

#### PR validation:

Tests are done with runTheMatrix.py -w upgrade -l 12850.0 with an additional run (386679) and runTheMatrix.py -l limited -i all —ibeos. since it makes effects on P5 and reconstruction

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is a backport of https://github.com/cms-sw/cmssw/pull/47724 to 15_0_X

@jshlee @watson-ij @quark2
