### PR TITLE
add `dqmInfoHLTMon` to `offlineHLTSource` in `DQMOffline_Trigger_cosmics` and enable `showHLTGlobalTag`

### DIFF
--- a/DQMOffline/Trigger/python/DQMOffline_Trigger_cosmics_cff.py
+++ b/DQMOffline/Trigger/python/DQMOffline_Trigger_cosmics_cff.py
@@ -25,10 +25,6 @@ import FWCore.ParameterSet.Config as cms
 # *hltMonJetMET makes a log file, need to learn how to turn it off
 # *hltMonEleBits causes SegmentFaults in HARVESTING(step3) in inlcuded in step2
 
-#import DQMServices.Components.DQMEnvironment_cfi
-#dqmEnvHLTOnline = DQMServices.Components.DQMEnvironment_cfi.dqmEnv.clone()
-#dqmEnvHLTOnline.subSystemFolder = 'HLT'
-
 #onlineHLTSource = cms.Sequence(EcalPi0Mon*EcalPhiSymMon*hltMonEleBits*hltMonMuBits*hltMonTauReco*hltMonBTagIPSource*hltMonBTagMuSource*dqmEnvHLTOnline)
 #onlineHLTSource = cms.Sequence(EcalPi0Mon*EcalPhiSymMon*hltMonMuBits*dqmEnvHLTOnline)
 
@@ -53,8 +49,13 @@ from DQMOffline.Trigger.TrackingMonitoringCosmics_cff import *
 
 import DQMServices.Components.DQMEnvironment_cfi
 dqmEnvHLT= DQMServices.Components.DQMEnvironment_cfi.dqmEnv.clone(
-    subSystemFolder = 'HLT'
-)
+    subSystemFolder = 'HLT',
+    showHLTGlobalTag = True)
+
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+dqmInfoHLTMon = DQMEDAnalyzer('DQMEventInfo',
+                              subSystemFolder = cms.untracked.string('HLT'),
+                              showHLTGlobalTag =  cms.untracked.bool(True))
 
 offlineHLTSource = cms.Sequence(
     cosmicTrackingMonitorHLT *
@@ -64,7 +65,8 @@ offlineHLTSource = cms.Sequence(
     hltMuonOfflineAnalyzers *
     HLTTauDQMOffline *
     jetMETHLTOfflineSource *
-    dqmEnvHLT
+    dqmEnvHLT *
+    dqmInfoHLTMon
 )
 
 #triggerCosmicOfflineDQMSource = cms.Sequence(onlineHLTSource*offlineHLTSource)


### PR DESCRIPTION
#### PR description:

Title says it all, trivial follow-up to https://github.com/cms-sw/cmssw/pull/47663.
Adds the necessary modules to display in the GUI the correct information about the global tag used as well as the events information which is currently empty after `CMSSW_15_0_3` went in production on Mar 31st, 2025, following to the successful replay https://github.com/dmwm/T0/pull/5052.

![Screenshot from 2025-04-01 21-11-39](https://github.com/user-attachments/assets/814f2152-92b8-4bc0-8099-b7e9c126b3e3)

#### PR validation:

Run the following command:

```
runTheMatrix.py -l 7.25 -t 4 -j 8 --nEvents 100000
```

without issues.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but will be backported to CMSSW_15_0_X for 2025 data-taking operations.