### PR TITLE
[GCC14] Silence array-bounds warning in KalmanUtilsMPlex.cc

### DIFF
--- a/RecoTracker/MkFitCore/BuildFile.xml
+++ b/RecoTracker/MkFitCore/BuildFile.xml
@@ -6,6 +6,7 @@
 <flags CXXFLAGS="-fopenmp-simd"/>
 <flags ADD_SUBDIR="1"/>
 <flags REM_CXXFLAGS="-Ofast" FILE="IterationConfig.cc"/>
+<use name="no-array-bounds-flag"/>
 <export>
   <lib name="RecoTrackerMkFitCore"/>
 </export>


### PR DESCRIPTION
#### PR description:

GCC14 emits multiple array-bounds warnings:

```
>> Building scram_x86-64-v2 shared library tmp/el8_amd64_gcc14/src/RecoTracker/MkFitCore/src/RecoTrackerMkFitCore/scram_x86-64-v2/libRecoTrackerMkFitCore.so
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gcc/14.2.1-475d4640d5186beb85fe6c9d366d668f/bin/c++ -O3 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++20 -ftree-vectorize -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -Wno-error=array-bounds -Warray-bounds -fuse-ld=bfd -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-unused-parameter -Wunused -Wparentheses -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -fno-reciprocal-math -mrecip=none -DBOOST_DISABLE_ASSERTS -march=x86-64-v2 -fopenmp-simd -flto=auto -fipa-icf -flto-odr-type-merging -fno-fat-lto-objects -Wodr -shared -Wl,-E    -Wl,-z,defs     tmp/el8_amd64_gcc14/src/RecoTracker/MkFitCore/src/RecoTrackerMkFitCore/scram_x86-64-v2/CandCloner.cc.o tmp/el8_amd64_gcc14/src/RecoTracker/MkFitCore/src/RecoTrackerMkFitCore/scram_x86-64-v2/Config.cc.o tmp/el8_amd64_gcc14/src/RecoTracker/MkFitCore/src/RecoTrackerMkFitCore/scram_x86-64-v2/Debug.cc.o tmp/el8_amd64_gcc14/src/RecoTracker/MkFitCore/src/RecoTrackerMkFitCore/scram_x86-64-v2/FindingFoos.cc.o tmp/el8_amd64_gcc14/src/RecoTracker/MkFitCore/src/RecoTrackerMkFitCore/scram_x86-64-v2/Hit.cc.o tmp/el8_amd64_gcc14/src/RecoTracker/MkFitCore/src/RecoTrackerMkFitCore/scram_x86-64-v2/HitStructures.cc.o tmp/el8_amd64_gcc14/src/RecoTracker/MkFitCore/src/RecoTrackerMkFitCore/scram_x86-64-v2/IterationConfig.cc.o tmp/el8_amd64_gcc14/src/RecoTracker/MkFitCore/src/RecoTrackerMkFitCore/scram_x86-64-v2/KalmanUtilsMPlex.cc.o tmp/el8_amd64_gcc14/src/RecoTracker/MkFitCore/src/RecoTrackerMkFitCore/scram_x86-64-v2/Matriplex/MatriplexCommon.cc.o tmp/el8_amd64_gcc14/src/RecoTracker/MkFitCore/src/RecoTrackerMkFitCore/scram_x86-64-v2/MiniPropagators.cc.o tmp/el8_amd64_gcc14/src/RecoTracker/MkFitCore/src/RecoTrackerMkFitCore/scram_x86-64-v2/MkBuilder.cc.o tmp/el8_amd64_gcc14/src/RecoTracker/MkFitCore/src/RecoTrackerMkFitCore/scram_x86-64-v2/MkBuilderWrapper.cc.o tmp/el8_amd64_gcc14/src/RecoTracker/MkFitCore/src/RecoTrackerMkFitCore/scram_x86-64-v2/MkFinder.cc.o tmp/el8_amd64_gcc14/src/RecoTracker/MkFitCore/src/RecoTrackerMkFitCore/scram_x86-64-v2/MkFitter.cc.o tmp/el8_amd64_gcc14/src/RecoTracker/MkFitCore/src/RecoTrackerMkFitCore/scram_x86-64-v2/PropagationMPlex.cc.o tmp/el8_amd64_gcc14/src/RecoTracker/MkFitCore/src/RecoTrackerMkFitCore/scram_x86-64-v2/PropagationMPlexCommon.cc.o tmp/el8_amd64_gcc14/src/RecoTracker/MkFitCore/src/RecoTrackerMkFitCore/scram_x86-64-v2/PropagationMPlexEndcap.cc.o tmp/el8_amd64_gcc14/src/RecoTracker/MkFitCore/src/RecoTrackerMkFitCore/scram_x86-64-v2/PropagationMPlexPlane.cc.o tmp/el8_amd64_gcc14/src/RecoTracker/MkFitCore/src/RecoTrackerMkFitCore/scram_x86-64-v2/Track.cc.o tmp/el8_amd64_gcc14/src/RecoTracker/MkFitCore/src/RecoTrackerMkFitCore/scram_x86-64-v2/TrackStructures.cc.o tmp/el8_amd64_gcc14/src/RecoTracker/MkFitCore/src/RecoTrackerMkFitCore/scram_x86-64-v2/TrackerInfo.cc.o tmp/el8_amd64_gcc14/src/RecoTracker/MkFitCore/src/RecoTrackerMkFitCore/scram_x86-64-v2/radix_sort.cc.o  -o tmp/el8_amd64_gcc14/src/RecoTracker/MkFitCore/src/RecoTrackerMkFitCore/scram_x86-64-v2/libRecoTrackerMkFitCore.so -Wl,-E -Wl,--hash-style=gnu -Wl,--as-needed -Wl,-z,noexecstack -L/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/223c41a66d13e70c72c2ec946ac907e0/opt/cmssw/el8_amd64_gcc14/cms/cmssw/CMSSW_15_1_X_2025-03-31-2300/biglib/el8_amd64_gcc14 -L/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/223c41a66d13e70c72c2ec946ac907e0/opt/cmssw/el8_amd64_gcc14/cms/cmssw/CMSSW_15_1_X_2025-03-31-2300/lib/el8_amd64_gcc14 -L/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/223c41a66d13e70c72c2ec946ac907e0/opt/cmssw/el8_amd64_gcc14/cms/cmssw/CMSSW_15_1_X_2025-03-31-2300/external/el8_amd64_gcc14/lib -L/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/223c41a66d13e70c72c2ec946ac907e0/opt/cmssw/el8_amd64_gcc14/cms/cmssw/CMSSW_15_1_X_2025-03-31-2300/static/el8_amd64_gcc14 -lSmatrix -lCore -lpcre -lbz2 -ltbb -llzma -lz -lcrypt -ldl -lrt
In function 'RotateResidualsOnPlane',
    inlined from 'kalmanOperationPlane' at src/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc:2031:27:
  [src/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc:413](https://github.com/cms-sw/cmssw/blob/CMSSW_15_1_X_2025-03-31-2300/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc#L413):31: warning: array subscript 'const struct Matriplex[0]' is partly outside array bounds of 'struct MPlex2H[1]' [-Warray-bounds=]
   413 |       B(n, 0, 0) = R(n, 0, 0) * A(n, 0, 0) + R(n, 0, 1) * A(n, 1, 0) + R(n, 0, 2) * A(n, 2, 0);
      |                               ^
src/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc: In function 'kalmanOperationPlane':
src/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc:2014:13: note: object 'prj' of size 96
 2014 |     MPlex2H prj;
      |             ^
```

[Full log](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc14/CMSSW_15_1_X_2025-03-31-2300/RecoTracker/MkFitCore)

#### PR validation:

Bot tests