### PR TITLE
Adding TeVJet RelVal 2024 Wfs

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_data_highstats.py
+++ b/Configuration/PyReleaseValidation/python/relval_data_highstats.py
@@ -7,7 +7,7 @@ workflows = Matrix()
 ## Here we define fixed high stats data workflows
 ## not to be run as default. 10k, 50k, 150k, 250k, 500k or 1M events each
 
-offset_era = 0.1 # less than 10 eras per year
+offset_era = 0.1 # less than 10 eras per year (hopefully!)
 offset_pd = 0.001 # less than 100 pds per year
 offset_events = 0.0001 # less than 10 event setups (10k,50k,150k,250k,500k,1M)
 
@@ -21,13 +21,20 @@ for e_n,era in enumerate(eras_2024):
             wf_number = wf_number + offset_pd * p_n
             wf_number = wf_number + offset_events * evs 
             wf_number = round(wf_number,6)
-            step_name = 'Run' + pd.replace('ParkingDouble','Park2') + era.split('Run')[1] + '_' + e_key
-            y = str(int(base_wf))
-            suff = 'ZB_' if 'ZeroBias' in step_name else ''
+
+            ## Here we use JetMET1 PD to run the TeVJet skims
+            skim = 'TeVJet' if pd == 'JetMET1' else ''
+
+            ## ZeroBias have their own HARVESTING
+            suff = 'ZB_' if 'ZeroBias' in pd else ''
+
             # Running C,D,E with the offline GT.
             # Could be removed once 2025 wfs are in and we'll test the online GT with them
             recosetup = 'RECONANORUN3_' + suff + 'reHLT_2024' 
             recosetup = recosetup if era[-1] > 'E' else recosetup + '_Offline'
+            
+            y = str(int(base_wf))
+            step_name = 'Run' + pd.replace('ParkingDouble','Park2') + era.split('Run')[1] + skim + '_' + e_key
             workflows[wf_number] = ['',[step_name,'HLTDR3_' + y,'RECONANORUN3_' + suff + 'reHLT_'+y,'HARVESTRUN3_' + suff + y]]
 
 ## 2023

--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -581,12 +581,28 @@ offset_pd = 0.001 # less than 100 pds per year
 
 for e_n,era in enumerate(era_mask_2024):
     for p_n,pd in enumerate(pds_2024):
+        
+        # JetMET1 PD is used to run the TeVJet skims
+        # we don't really need it here
+        # (also as is the numbering conflicts with 
+        # the scouting wf below, so if we really want to
+        # extend the pds for standar relvals for 2024 data
+        # one needs to change the 145.415 below)
+        if pd == 'JetMET1':
+            continue
+
         wf_number = round(base_wf + offset_era * e_n + offset_pd * p_n,3)
         dataset = '/' + pd + '/' + era + '-v1/RAW'
-        step_name = 'Run' + pd.replace('ParkingDouble','Park2') + era.split('Run')[1]
+
+        ## ZeroBias have their own HARVESTING
         suff = 'ZB_' if 'ZeroBias' in step_name else ''
+
+        # Running C,D,E with the offline GT.
+        # Could be removed once 2025 wfs are in and we'll test the online GT with them
         recosetup = 'RECONANORUN3_' + suff + 'reHLT_2024' 
         recosetup = recosetup if era[-1] > 'E' else recosetup + '_Offline'
+
+        step_name = 'Run' + pd.replace('ParkingDouble','Park2') + era.split('Run')[1]
         workflows[wf_number] = ['',[step_name,'HLTDR3_2024',recosetup,'HARVESTRUN3_' + suff + '2024']]
 
 ## special HLT scouting workflow (with hardcoded private input file from ScoutingPFMonitor skimmed to remove all events without scouting)

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -655,14 +655,22 @@ steps['RunHLTMonitor2024I']={'INPUT':InputInfo(dataSet='/HLTMonitor/Run2024I-Exp
 # the files used as input
 
 ###2024 
-
-pds_2024  = ['BTagMu', 'DisplacedJet', 'EGamma0', 'HcalNZS', 'JetMET0', 'Muon0', 'MuonEG', 'NoBPTX', 'ParkingDoubleMuonLowMass0', 'ParkingHH', 'ParkingLLP', 'ParkingSingleMuon0', 'ParkingVBF0', 'Tau', 'ZeroBias']
+## N.B. here we use JetMet0 as "starndard" PD and JetMET1 for the TeVJet skims 
+pds_2024  = ['BTagMu', 'DisplacedJet', 'EGamma0', 'HcalNZS', 'JetMET0', 'Muon0', 'MuonEG', 'NoBPTX', 'ParkingDoubleMuonLowMass0', 'ParkingHH', 'ParkingLLP', 'ParkingSingleMuon0', 'ParkingVBF0', 'Tau', 'ZeroBias','JetMET1']
 eras_2024 = ['Run2024B', 'Run2024C', 'Run2024D', 'Run2024E', 'Run2024F','Run2024G','Run2024H','Run2024I']
 for era in eras_2024:
     for pd in pds_2024:
-        dataset = "/" + pd + "/" + era + "-v1/RAW"
+        dataset = "/" + pd + "/" + era
+        skim = ''
+        
+        if pd == 'JetMET1':
+            dataset = dataset + '-TeVJet-PromptReco-v1/RAW-RECO'
+            skim = 'TeVJet'
+        else:
+            dataset = dataset + '-v1/RAW' 
+        
         for e_key,evs in event_steps_dict.items():
-            step_name = "Run" + pd.replace("ParkingDouble","Park2") + era.split("Run")[1] + "_" + e_key
+            step_name = "Run" + pd.replace("ParkingDouble","Park2") + era.split("Run")[1] + skim + "_" + e_key 
             steps[step_name] = {'INPUT':InputInfo(dataSet=dataset,label=era.split("Run")[1],events=int(evs*1e6), skimEvents=True, location='STD')}
 
 ###2023 
@@ -710,10 +718,16 @@ era_mask_2024  = dict(zip(eras_2024,lumi_mask_2024))
 
 for era in era_mask_2024:
     for pd in pds_2024:
-        dataset = "/" + pd + "/" + era + "-v1/RAW"
+        dataset = '/' + pd + '/' + era
         lm = era_mask_2024[era]
-        step_name = "Run" + pd.replace("ParkingDouble","Park2") + era.split("Run")[1]
-        steps[step_name]={'INPUT':InputInfo(dataSet=dataset,label=era.split("Run")[1],events=100000,location='STD', ls=lm)}
+
+        ## Here we use JetMET1 PD to run the TeVJet skims
+        dataset = dataset + '-TeVJet-PromptReco-v1/RAW-RECO' if pd == 'JetMET1' else dataset + '-v1/RAW' 
+        skim = 'TeVJet' if pd == 'JetMET1' else ''
+
+        step_name = 'Run' + pd.replace('ParkingDouble','Park2') + era.split('Run')[1] + skim
+
+        steps[step_name]={'INPUT':InputInfo(dataSet=dataset,label=era.split('Run')[1],events=100000,location='STD', ls=lm)}
 
 
 ##################################################################


### PR DESCRIPTION
#### PR description:

This PR proposes to add a few workflows for TeVJet Skims on 2024 data from era `B` to `I` with the `JetMET1` PD.

#### PR validation:

Running the `2024.715*` wfs with `-w data_highstats`. 