### PR TITLE
[HLTrigger/Egamma] fix swapped eta parameter for photons in Diphoton XGBoost MVA filter (15_1_X)

### DIFF
--- a/HLTrigger/Egamma/plugins/HLTEgammaDoubleXGBoostCombFilter.cc
+++ b/HLTrigger/Egamma/plugins/HLTEgammaDoubleXGBoostCombFilter.cc
@@ -87,27 +87,27 @@ bool HLTEgammaDoubleXGBoostCombFilter::hltFilter(edm::Event& event,
   for (size_t i = 0; i < recCollection->size(); i++) {
     edm::Ref<reco::RecoEcalCandidateCollection> refi(recCollection, i);
     float EtaSCi = refi->eta();
-    int eta1 = (std::abs(EtaSCi) < 1.5) ? 0 : 1;
+    int etai = (std::abs(EtaSCi) < 1.5) ? 0 : 1;
     float mvaScorei = (*mvaMap).find(refi)->val;
     math::XYZTLorentzVector p4i = refi->p4();
     for (size_t j = i + 1; j < recCollection->size(); j++) {
       edm::Ref<reco::RecoEcalCandidateCollection> refj(recCollection, j);
       float EtaSCj = refj->eta();
-      int eta2 = (std::abs(EtaSCj) < 1.5) ? 0 : 1;
+      int etaj = (std::abs(EtaSCj) < 1.5) ? 0 : 1;
       float mvaScorej = (*mvaMap).find(refj)->val;
       math::XYZTLorentzVector p4j = refj->p4();
       math::XYZTLorentzVector pairP4 = p4i + p4j;
       double mass = pairP4.M();
       if (mass >= highMassCut_) {
-        if (mvaScorei >= mvaScorej && ((mvaScorei > leadCutHighMass1_[eta1] && mvaScorej > subCutHighMass1_[eta2]) ||
-                                       (mvaScorei > leadCutHighMass2_[eta1] && mvaScorej > subCutHighMass2_[eta2]) ||
-                                       (mvaScorei > leadCutHighMass3_[eta1] && mvaScorej > subCutHighMass3_[eta2]))) {
+        if (mvaScorei >= mvaScorej && ((mvaScorei > leadCutHighMass1_[etai] && mvaScorej > subCutHighMass1_[etaj]) ||
+                                       (mvaScorei > leadCutHighMass2_[etai] && mvaScorej > subCutHighMass2_[etaj]) ||
+                                       (mvaScorei > leadCutHighMass3_[etai] && mvaScorej > subCutHighMass3_[etaj]))) {
           accept = true;
         }  //if scoreI > scoreJ
         else if (mvaScorej > mvaScorei &&
-                 ((mvaScorej > leadCutHighMass1_[eta1] && mvaScorei > subCutHighMass1_[eta2]) ||
-                  (mvaScorej > leadCutHighMass2_[eta1] && mvaScorei > subCutHighMass2_[eta2]) ||
-                  (mvaScorej > leadCutHighMass3_[eta1] && mvaScorei > subCutHighMass3_[eta2]))) {
+                 ((mvaScorej > leadCutHighMass1_[etaj] && mvaScorei > subCutHighMass1_[etai]) ||
+                  (mvaScorej > leadCutHighMass2_[etaj] && mvaScorei > subCutHighMass2_[etai]) ||
+                  (mvaScorej > leadCutHighMass3_[etaj] && mvaScorei > subCutHighMass3_[etai]))) {
           accept = true;
         }  // if scoreJ > scoreI
       }  //If high mass

--- a/HLTrigger/Egamma/plugins/HLTEgammaDoubleXGBoostCombFilter.cc
+++ b/HLTrigger/Egamma/plugins/HLTEgammaDoubleXGBoostCombFilter.cc
@@ -73,48 +73,48 @@ void HLTEgammaDoubleXGBoostCombFilter::fillDescriptions(edm::ConfigurationDescri
 bool HLTEgammaDoubleXGBoostCombFilter::hltFilter(edm::Event& event,
                                                  const edm::EventSetup& setup,
                                                  trigger::TriggerFilterObjectWithRefs& filterproduct) const {
-  //producer collection (hltEgammaCandidates(Unseeded))
   const auto& recCollection = event.getHandle(candToken_);
-
-  //get hold of photon MVA association map
   const auto& mvaMap = event.getHandle(mvaToken_);
 
-  std::vector<math::XYZTLorentzVector> p4s(recCollection->size());
-  std::vector<bool> isTight(recCollection->size());
+  // Lambda to evaluate pair cuts
+  auto passesHighMassCuts = [&](float leadScore, float subScore, int leadEta, int subEta) {
+    return (leadScore > leadCutHighMass1_[leadEta] && subScore > subCutHighMass1_[subEta]) ||
+           (leadScore > leadCutHighMass2_[leadEta] && subScore > subCutHighMass2_[subEta]) ||
+           (leadScore > leadCutHighMass3_[leadEta] && subScore > subCutHighMass3_[subEta]);
+  };
 
-  bool accept = false;
-
-  for (size_t i = 0; i < recCollection->size(); i++) {
-    edm::Ref<reco::RecoEcalCandidateCollection> refi(recCollection, i);
-    float EtaSCi = refi->eta();
-    int etai = (std::abs(EtaSCi) < 1.5) ? 0 : 1;
+  // Lambda to evaluate a candidate pair
+  auto evaluatePair = [&](const edm::Ref<reco::RecoEcalCandidateCollection>& refi,
+                          const edm::Ref<reco::RecoEcalCandidateCollection>& refj) {
     float mvaScorei = (*mvaMap).find(refi)->val;
-    math::XYZTLorentzVector p4i = refi->p4();
-    for (size_t j = i + 1; j < recCollection->size(); j++) {
+    float mvaScorej = (*mvaMap).find(refj)->val;
+
+    int etai = (std::abs(refi->eta()) < 1.5) ? 0 : 1;
+    int etaj = (std::abs(refj->eta()) < 1.5) ? 0 : 1;
+
+    double mass = (refi->p4() + refj->p4()).M();
+    if (mass < highMassCut_)
+      return false;
+
+    if (mvaScorei >= mvaScorej) {
+      return passesHighMassCuts(mvaScorei, mvaScorej, etai, etaj);
+    } else {
+      return passesHighMassCuts(mvaScorej, mvaScorei, etaj, etai);
+    }
+  };
+
+  // Loop through candidates
+  for (size_t i = 0; i < recCollection->size(); ++i) {
+    edm::Ref<reco::RecoEcalCandidateCollection> refi(recCollection, i);
+    for (size_t j = i + 1; j < recCollection->size(); ++j) {
       edm::Ref<reco::RecoEcalCandidateCollection> refj(recCollection, j);
-      float EtaSCj = refj->eta();
-      int etaj = (std::abs(EtaSCj) < 1.5) ? 0 : 1;
-      float mvaScorej = (*mvaMap).find(refj)->val;
-      math::XYZTLorentzVector p4j = refj->p4();
-      math::XYZTLorentzVector pairP4 = p4i + p4j;
-      double mass = pairP4.M();
-      if (mass >= highMassCut_) {
-        if (mvaScorei >= mvaScorej && ((mvaScorei > leadCutHighMass1_[etai] && mvaScorej > subCutHighMass1_[etaj]) ||
-                                       (mvaScorei > leadCutHighMass2_[etai] && mvaScorej > subCutHighMass2_[etaj]) ||
-                                       (mvaScorei > leadCutHighMass3_[etai] && mvaScorej > subCutHighMass3_[etaj]))) {
-          accept = true;
-        }  //if scoreI > scoreJ
-        else if (mvaScorej > mvaScorei &&
-                 ((mvaScorej > leadCutHighMass1_[etaj] && mvaScorei > subCutHighMass1_[etai]) ||
-                  (mvaScorej > leadCutHighMass2_[etaj] && mvaScorei > subCutHighMass2_[etai]) ||
-                  (mvaScorej > leadCutHighMass3_[etaj] && mvaScorei > subCutHighMass3_[etai]))) {
-          accept = true;
-        }  // if scoreJ > scoreI
-      }  //If high mass
-    }  //j loop
-  }  //i loop
-  return accept;
-}  //Definition
+      if (evaluatePair(refi, refj)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(HLTEgammaDoubleXGBoostCombFilter);


### PR DESCRIPTION
#### PR description:

Bugfix for a wrong barrel/eta cut chosen for photon pair when photons are in barrel and endcap and leading Et photon in the EGamma collection taken for the combination does not have higher MVA score than the second one.
Variables are renamed to etai, etaj for clarity.

#### PR validation:

Tested on full `/dev/CMSSW_15_0_0/GRun/V23` menu extended with additional 60 GeV mass cut paths `/users/smorovic/2025_GRun_V23/V4` .
On 100k EphemeralHLTPhysics (`/Run2024I/EphemeralHLTPhysics0/RAW/v1/000/386/593/`) events, there is no change in number of accepted events, which are between 27 and 83 events depending on the path, in any paths using the filter.

One case where difference was observed was with a simplified case of all MVA cuts set to flat >0.4 EB and >0.3 EE and no mass cut (set to 0),  on 10k EphemeralHLTPhysics events, where 4 (5) events passed in the two 90 GeV DiphotonMVA paths and 3(4) with the fix applied.
