### PR TITLE
[FULLSIM] Set enable EM physics library G4HepEM by default

### DIFF
--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -181,7 +181,7 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
         #        please select "SimG4Core/Physics/DummyPhysics" for type
         #        and turn ON DummyEMPhysics
         #
-        type = cms.string('SimG4Core/Physics/FTFP_BERT_EMM'),
+        type = cms.string('SimG4Core/Physics/FTFP_BERT_EMH'),
         DummyEMPhysics = cms.bool(False),
         # 1 will print cuts as they get set from DD
         # 2 will do as 1 + will dump Geant4 table of cuts


### PR DESCRIPTION
#### PR description:
A new version of the G4HepEm library provides very close results for the e+-, gamma transport as the Geant4 default but give a significant benefit in CPU (for ttbar events 14% for Run3, 21% for Run4) (https://indico.cern.ch/event/1517500/contributions/6395941/attachments/3025573/5339700/m_novak_G4HepEm_in-CMS.pdf). In this PR we enable this library to be used as the default. This will allow more wide testing without needs to redo PF and other calibrations. 

There may be some differences in regression, which may be seen or not depending of WF. 

#### PR validation:
private


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for: NO

