### PR TITLE
Update the value of pretrigger-trigger matching configuration parameter: clctPretriggerTriggerZone

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/python/params/clctParams.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/params/clctParams.py
@@ -48,7 +48,6 @@ clctPhase2 = clctPhase1.clone(
 
     # Pretrigger HS +- clctPretriggerTriggerZone sets the trigger matching zone
     # which defines how far from pretrigger HS the TMB may look for a trigger HS
-    #clctPretriggerTriggerZone = cms.uint32(5), #orig
     clctPretriggerTriggerZone = cms.uint32(224),
 )
 

--- a/L1Trigger/CSCTriggerPrimitives/python/params/clctParams.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/params/clctParams.py
@@ -48,7 +48,8 @@ clctPhase2 = clctPhase1.clone(
 
     # Pretrigger HS +- clctPretriggerTriggerZone sets the trigger matching zone
     # which defines how far from pretrigger HS the TMB may look for a trigger HS
-    clctPretriggerTriggerZone = cms.uint32(5),
+    #clctPretriggerTriggerZone = cms.uint32(5), #orig
+    clctPretriggerTriggerZone = cms.uint32(224),
 )
 
 # CLCT threshold still set to 4 for now


### PR DESCRIPTION
#### PR description:

1. Updates the configuration parameter clctPretriggerTriggerZone from 5 to 224

- To address the 5% efficiency loss observed in the EMTF efficiency performance during the Phase2Spring24 MC campaign (menu team's report https://indico.cern.ch/event/1464629/contributions/6166060/attachments/2941981/5170562/P2L1Menu%20Spring24%20MC%20Report%207%20October%202024%20(2).pdf). 

- This PR reverts the parameter to fully restore LCT and CLCT efficiency (see Validation)

#### PR validation:
 
We tested the same Phase2Spring24 MC campaign samples (both PU0 and PU200), and confirmed that reverting this parameter fully restrores LCT and CLCT efficiency. Attached are the LCT and CLCT efficiency plots for ME11. And the results are presented on the CSC weekly meeting https://indico.cern.ch/event/1533944/
<img width="826" alt="clct_me11" src="https://github.com/user-attachments/assets/a0786770-447b-4a96-9aa2-353ebd547cb5" />
<img width="853" alt="lct_me11" src="https://github.com/user-attachments/assets/185b298c-c493-43db-acd9-90e71a452eec" />


