### PR TITLE
Map unknown exit codes to PlatformStatus.PlatformNotAvailable

### DIFF
--- a/HeterogeneousCore/Common/python/PlatformStatus.py
+++ b/HeterogeneousCore/Common/python/PlatformStatus.py
@@ -7,3 +7,7 @@ class PlatformStatus(enum.IntEnum):
     PlatformNotAvailable = 1    # the platform is not available for this architecture, OS or compiler
     RuntimeNotAvailable = 2     # the runtime could not be initialised
     DevicesNotAvailable = 3     # there are no visible, usable devices
+
+    @classmethod
+    def _missing_(cls, value):
+        return cls.PlatformNotAvailable


### PR DESCRIPTION
#### PR description:

Map unknown exit codes to `PlatformStatus.PlatformNotAvailable`

For example, if the system does not have `libdrm.so.2` installed, then `rocmIsEnabled` exits with code 127 because of
```
error while loading shared libraries: libdrm.so.2: cannot open shared object file: No such file or directory
```
which leads to a Python error `ValueError: 127 is not a valid PlatformStatus`.

#### PR validation:

Local testing by temporarily moving away `libdrm.so.2`, a configuration with `RECO` autodetects accelerators.

#### PR backport:

In principle not needed (for my use case)

FYI @fwyzard as discussed