### PR TITLE
fix `TrackToTrackComparisonHists` logic for cosmics

### DIFF
--- a/DQM/TrackingMonitorSource/src/TrackToTrackComparisonHists.cc
+++ b/DQM/TrackingMonitorSource/src/TrackToTrackComparisonHists.cc
@@ -120,17 +120,19 @@ void TrackToTrackComparisonHists::analyze(const edm::Event& iEvent, const edm::E
 
   edm::Handle<reco::VertexCollection> referencePVHandle;
   iEvent.getByToken(referencePVToken_, referencePVHandle);
-  if (!referencePVHandle.isValid() && !isCosmics_) {
-    edm::LogError("TrackToTrackComparisonHists") << "referencePVHandle not found, skipping event";
-    return;
+
+  reco::Vertex referencePV;
+  if (isCosmics_) {
+    referencePV = reco::Vertex(referenceBS.position(), referenceBS.rotatedCovariance3D(), 0., 0., 0);
+  } else {
+    if (!referencePVHandle.isValid() || referencePVHandle->empty()) {
+      edm::LogError("TrackToTrackComparisonHists")
+          << (!referencePVHandle.isValid() ? "referencePVHandle not found, skipping event"
+                                           : "referencePVHandle is empty, skipping event");
+      return;
+    }
+    referencePV = referencePVHandle->front();
   }
-  if (referencePVHandle->empty() && !isCosmics_) {
-    edm::LogInfo("TrackToTrackComparisonHists") << "referencePVHandle->size is 0 ";
-    return;
-  }
-  reco::Vertex referencePV = isCosmics_
-                                 ? reco::Vertex(referenceBS.position(), referenceBS.rotatedCovariance3D(), 0., 0., 0)
-                                 : referencePVHandle->at(0);
 
   //
   //  Get Monitored Track Info
@@ -154,18 +156,19 @@ void TrackToTrackComparisonHists::analyze(const edm::Event& iEvent, const edm::E
 
   edm::Handle<reco::VertexCollection> monitoredPVHandle;
   iEvent.getByToken(monitoredPVToken_, monitoredPVHandle);
-  if (!monitoredPVHandle.isValid() && !isCosmics_) {
-    edm::LogError("TrackToTrackComparisonHists")
-        << "monitoredPVHandle not found, skipping event isCosmics value:" << isCosmics_;
-    return;
+
+  reco::Vertex monitoredPV;
+  if (isCosmics_) {
+    monitoredPV = reco::Vertex(monitoredBS.position(), monitoredBS.rotatedCovariance3D(), 0., 0., 0);
+  } else {
+    if (!monitoredPVHandle.isValid() || monitoredPVHandle->empty()) {
+      edm::LogError("TrackToTrackComparisonHists")
+          << (!monitoredPVHandle.isValid() ? "monitoredPVHandle not found, skipping event"
+                                           : "monitoredPVHandle is empty, skipping event");
+      return;
+    }
+    monitoredPV = monitoredPVHandle->front();
   }
-  if (monitoredPVHandle->empty() && !isCosmics_) {
-    edm::LogInfo("TrackToTrackComparisonHists") << "monitoredPVHandle->size is 0 ";
-    return;
-  }
-  reco::Vertex monitoredPV = isCosmics_
-                                 ? reco::Vertex(monitoredBS.position(), monitoredBS.rotatedCovariance3D(), 0., 0., 0)
-                                 : monitoredPVHandle->at(0);
 
   edm::LogInfo("TrackToTrackComparisonHists")
       << "analyzing " << monitoredTrackInputTag_.process() << ":" << monitoredTrackInputTag_.label() << ":"


### PR DESCRIPTION
resolves https://github.com/cms-sw/cmssw/issues/47780

#### PR description:

This PR is meant to fix issue https://github.com/cms-sw/cmssw/issues/47780.
The crash is due to PR https://github.com/cms-sw/cmssw/pull/47663.
In cosmic data-taking there might be events without any HLT pixel vertex collection in input for the monitoring module, but it's unnecessary to check the validity of the handle, as anyway the logic of the program repurposes the beam-spot for the vertex compatibility checks.

#### PR validation:

Checked that the recipe at https://github.com/cms-sw/cmssw/issues/47780#issue-2969918678:

```console
cmsrel CMSSW_15_0_3
cd CMSSW_15_0_3/src
cmsenv
cp /afs/cern.ch/work/f/fbrivio/public/ORM_April_2025/crash_Run390254/PSet.pkl .
cp /afs/cern.ch/work/f/fbrivio/public/ORM_April_2025/crash_Run390254/PSet.py .
cmsRun PSet.py
```

runs when used in conjunction of this branch.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but will be backported to CMSSW_15_0_X for 2025 data-taking operations.
