### PR TITLE
Backport LumiList.py bugfix to CMSSW_13_2_X

### DIFF
--- a/FWCore/PythonUtilities/python/LumiList.py
+++ b/FWCore/PythonUtilities/python/LumiList.py
@@ -181,8 +181,8 @@ class LumiList(object):
 
     def __or__(self, other):
         result = {}
-        aruns = self.compactList.keys()
-        bruns = other.compactList.keys()
+        aruns = list(self.compactList.keys())
+        bruns = list(other.compactList.keys())
         runs = set(aruns + bruns)
         for run in runs:
             overlap = sorted(self.compactList.get(run, []) + other.compactList.get(run, []))
@@ -245,7 +245,7 @@ class LumiList(object):
         Return the list of pairs representation
         """
         theList = []
-        runs = self.compactList.keys()
+        runs = list(self.compactList.keys())
         runs = sorted(run, key=int)
         for run in runs:
             lumis = self.compactList[run]
@@ -270,7 +270,7 @@ class LumiList(object):
         """
 
         parts = []
-        runs = self.compactList.keys()
+        runs = list(self.compactList.keys())
         runs = sorted(runs, key=int)
         for run in runs:
             lumis = self.compactList[run]


### PR DESCRIPTION
PR description:
Addressing the issue:
https://github.com/cms-sw/cmssw/issues/47777

PR validation:
Still python3. It should work.

Origin of backport:
https://github.com/cms-sw/cmssw/pull/44201