### PR TITLE
Miscellaneous updates for modules targeting CDC reconstruction at HLT

### DIFF
--- a/RecoTracker/SpecialSeedGenerators/python/outInSeedsFromStandaloneMuons_cfi.py
+++ b/RecoTracker/SpecialSeedGenerators/python/outInSeedsFromStandaloneMuons_cfi.py
@@ -7,26 +7,27 @@ hitCollectorForOutInMuonSeeds = TrackingTools.KalmanUpdators.Chi2MeasurementEsti
     nSigma        = 4.,    ## was 3  ## TO BE TUNED 
 )
 
-outInSeedsFromStandaloneMuons = cms.EDProducer('OutsideInMuonSeeder',
+from RecoTracker.SpecialSeedGenerators.outsideInMuonSeeder_cfi import outsideInMuonSeeder
+outInSeedsFromStandaloneMuons = outsideInMuonSeeder.clone(
     ## Input collection of muons, and selection. outerTrack.isNonnull is implicit.
-    src = cms.InputTag('muons'),
-    cut = cms.string('pt > 10 && outerTrack.hitPattern.muonStationsWithValidHits >= 2'),
-    layersToTry = cms.int32(3), # try up to 3 layers where at least one seed is found
-    hitsToTry = cms.int32(3),   # use at most 3 hits from the same layer
+    src = 'muons',
+    cut = 'pt > 10 && outerTrack.hitPattern.muonStationsWithValidHits >= 2',
+    layersToTry = 3, # try up to 3 layers where at least one seed is found
+    hitsToTry = 3,   # use at most 3 hits from the same layer
     ## Use as state the muon updated ad vertex (True) or the innermost state of the standalone track (False)
-    fromVertex = cms.bool(True),
+    fromVertex = True,
     ## Propagator to go from muon state to TOB/TEC.
-    muonPropagator = cms.string('SteppingHelixPropagatorAlong'),
+    muonPropagator = 'SteppingHelixPropagatorAlong',
     ## Propagator used searching for hits..
-    trackerPropagator  = cms.string('PropagatorWithMaterial'),
+    trackerPropagator  = 'PropagatorWithMaterial',
     ## How much to rescale the standalone muon uncertainties beforehand
-    errorRescaleFactor = cms.double(2.0),
+    errorRescaleFactor = 2.0,
     ## Chi2MeasurementEstimator used to select hits
-    hitCollector = cms.string('hitCollectorForOutInMuonSeeds'),
+    hitCollector = 'hitCollectorForOutInMuonSeeds',
     ## Eta ranges to search for TOB and TEC
-    maxEtaForTOB = cms.double(1.8),
-    minEtaForTEC = cms.double(0.7),
+    maxEtaForTOB = 1.8,
+    minEtaForTEC = 0.7,
     #### Turn on verbose debugging (to be removed at the end)
-    debug = cms.untracked.bool(False),
+    debug = False
 )
 

--- a/RecoTracker/TkNavigation/plugins/CosmicNavigationSchool.cc
+++ b/RecoTracker/TkNavigation/plugins/CosmicNavigationSchool.cc
@@ -370,17 +370,16 @@ SkippingLayerCosmicNavigationSchoolESProducer::ReturnType SkippingLayerCosmicNav
 
 void SkippingLayerCosmicNavigationSchoolESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<std::string>("ComponentName");
-  desc.add<bool>("noPXB");
-  desc.add<bool>("noPXF");
-  desc.add<bool>("noTIB");
-  desc.add<bool>("noTID");
-  desc.add<bool>("noTOB");
-  desc.add<bool>("noTEC");
-  desc.add<bool>("selfSearch");
-  desc.add<bool>("allSelf");
-
-  descriptions.addDefault(desc);
+  desc.add<std::string>("ComponentName", "CosmicNavigationSchool");
+  desc.add<bool>("noPXB", false);
+  desc.add<bool>("noPXF", false);
+  desc.add<bool>("noTIB", false);
+  desc.add<bool>("noTID", false);
+  desc.add<bool>("noTOB", false);
+  desc.add<bool>("noTEC", false);
+  desc.add<bool>("selfSearch", true);
+  desc.add<bool>("allSelf", true);
+  descriptions.addWithDefaultLabel(desc);
 }
 
 #include "FWCore/PluginManager/interface/ModuleDef.h"

--- a/RecoTracker/TkNavigation/python/CosmicsNavigationSchoolESProducer_cfi.py
+++ b/RecoTracker/TkNavigation/python/CosmicsNavigationSchoolESProducer_cfi.py
@@ -5,16 +5,17 @@ import FWCore.ParameterSet.Config as cms
 #    ComponentName = cms.string('CosmicNavigationSchool')
 #)
 
-cosmicsNavigationSchoolESProducer = cms.ESProducer("SkippingLayerCosmicNavigationSchoolESProducer",
-                                                   ComponentName = cms.string('CosmicNavigationSchool'),
-                                                   noPXB = cms.bool(False),
-                                                   noPXF = cms.bool(False),
-                                                   noTIB = cms.bool(False),
-                                                   noTID = cms.bool(False),
-                                                   noTOB = cms.bool(False),
-                                                   noTEC = cms.bool(False),
-                                                   selfSearch = cms.bool(True),
-                                                   allSelf = cms.bool(True)
-                                                   )
+from RecoTracker.TkNavigation.skippingLayerCosmicNavigationSchoolESProducer_cfi import skippingLayerCosmicNavigationSchoolESProducer as _skippingLayerCosmicNavigationSchoolESProducer
+cosmicsNavigationSchoolESProducer = _skippingLayerCosmicNavigationSchoolESProducer.clone(
+    ComponentName = 'CosmicNavigationSchool',
+    noPXB = False,
+    noPXF = False,
+    noTIB = False,
+    noTID = False,
+    noTOB = False,
+    noTEC = False,
+    selfSearch = True,
+    allSelf = True
+)
 
 


### PR DESCRIPTION
#### PR description:

This update provides a couple of minor changes to modules used in the Cosmics During Collisions (CDC) chain offline, such that they can be used also in the online HLT menu (add `fillDescriptions`, make all parameters configurable).
Trivial, no regressions expected.

#### PR validation:

`cmssw` compiles

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, will be backported to CMSSW_15_0_X for 2025 data-taking purposes.

Cc:
@henriettepetersen @TomasKello