### PR TITLE
[15_0_X] Backport of #47739 (Add filter to skip events without scouting objects in ScoutingNano for ScoutingPFMonitor dataset)  

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_nano.py
+++ b/Configuration/PyReleaseValidation/python/relval_nano.py
@@ -257,10 +257,7 @@ steps['jmeNANO_rePuppi_data14.0'] = merge([{'-s': 'NANO:@JMErePuppi', '-n': '100
 steps['scoutingNANO_data14.0'] = merge([{'-s': 'NANO:@Scout'},
                                         steps['NANO_data14.0']])
 
-# Process.options.TryToContinue = cms.untracked.vstring(\'ProductNotFound\') is needed here because some events in ScoutingPFMonitor in 2024 do not contain scouting objects.
-# This should be fixed in 2025 (https://its.cern.ch/jira/browse/CMSHLT-3331) so customise_commands won't be needed for 2025 workflow.
-steps['scoutingNANO_withPrompt_data14.0'] = merge([{'-s': 'NANO:@Prompt+@Scout', 
-                                                   '--customise_commands': '"process.options.TryToContinue = cms.untracked.vstring(\'ProductNotFound\')"'},
+steps['scoutingNANO_withPrompt_data14.0'] = merge([{'-s': 'NANO:@Prompt+@ScoutMonitor'}, 
                                                    steps['NANO_data14.0']])
 
 # DPG custom NANO

--- a/PhysicsTools/NanoAOD/python/autoNANO.py
+++ b/PhysicsTools/NanoAOD/python/autoNANO.py
@@ -34,6 +34,8 @@ autoNANO = {
     # Scouting nano
     'Scout' : {'sequence': 'PhysicsTools/NanoAOD/custom_run3scouting_cff.scoutingNanoSequence',
                'customize': 'PhysicsTools/NanoAOD/custom_run3scouting_cff.customiseScoutingNano'},
+    'ScoutMonitor' : {'sequence': '@Scout',
+                      'customize': '@Scout+PhysicsTools/NanoAOD/custom_run3scouting_cff.customiseScoutingNanoForScoutingPFMonitor'},
     'ScoutFromMini' : {'sequence': '@Scout',
                        'customize': '@Scout+PhysicsTools/NanoAOD/custom_run3scouting_cff.customiseScoutingNanoFromMini'},
     # JME nano

--- a/PhysicsTools/NanoAOD/python/custom_run3scouting_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_run3scouting_cff.py
@@ -1,6 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.NanoAOD.run3scouting_cff import *
-from L1Trigger.Configuration.L1TRawToDigi_cff import *
 from EventFilter.L1TRawToDigi.gtStage2Digis_cfi import gtStage2Digis
 from PhysicsTools.NanoAOD.triggerObjects_cff import l1bits
 from PhysicsTools.NanoAOD.globals_cff import puTable
@@ -123,7 +122,7 @@ scoutingNanoSequence = cms.Sequence(scoutingNanoTaskCommon)
 
 # Specific tasks which will be added to sequence during customization
 scoutingTriggerTask = prepareScoutingTriggerTask()
-scoutingTriggerSequence = cms.Sequence(L1TRawToDigi+cms.Sequence(scoutingTriggerTask))
+scoutingTriggerSequence = cms.Sequence(scoutingTriggerTask)
 scoutingNanoTaskMC = prepareScoutingNanoTaskMC()
 
 def customiseScoutingNano(process):
@@ -147,17 +146,28 @@ def customiseScoutingNano(process):
 # these function are designed to be used with --customise flag in cmsDriver.py
 # e.g. --customise PhysicsTools/NanoAOD/python/custom_run3scouting_cff.addScoutingPFCandidate
 
-# reconfigure for running with ScoutingPFMonitor/MiniAOD inputs alone
+# additional customisation for running with ScoutingPFMonitor/RAW inputs
 # should be used with default customiseScoutingNano
-def customiseScoutingNanoFromMini(process):
-    # remove L1TRawToDigi
-    process.scoutingTriggerSequence.remove(process.L1TRawToDigi)
+# this is suitable when ScoutingPFMonitor/RAW is involved, e.g. RAW, RAW-MiniAOD two-file solution, full chain RAW-MiniAOD-NanoAOD
+# when running full chain RAW-MiniAOD-NanoAOD, this ensures that gtStage2Digis, gmtStage2Digis, and caloStage2Digis are run
+def customiseScoutingNanoForScoutingPFMonitor(process):
+    process = skipEventsWithoutScouting(process)
 
-    # remove gtStage2Digis since they are already run for Mini
+    # replace gtStage2DigisScouting with standard gtStage2Digis
     process.scoutingTriggerTask.remove(process.gtStage2DigisScouting)
+    process.scoutingTriggerTask.add(process.gtStage2Digis)
 
-    # change src for l1 bits
-    process.l1bitsScouting.src = cms.InputTag("gtStage2Digis")
+    # add gmtStage2Digis
+    process.load("EventFilter.L1TRawToDigi.gmtStage2Digis_cfi")
+    process.scoutingTriggerTask.add(process.gmtStage2Digis)
+
+    # add caloStage2Digis
+    process.load("EventFilter.L1TRawToDigi.caloStage2Digis_cfi")
+    process.scoutingTriggerTask.add(process.caloStage2Digis)
+
+    # replace l1bitsScouting with standard l1bits
+    process.scoutingTriggerTask.remove(process.l1bitsScouting)
+    process.scoutingTriggerTask.add(process.l1bits)
 
     # change src for l1 objects
     process.l1MuScoutingTable.src = cms.InputTag("gmtStage2Digis", "Muon")
@@ -165,6 +175,57 @@ def customiseScoutingNanoFromMini(process):
     process.l1TauScoutingTable.src = cms.InputTag("caloStage2Digis", "Tau")
     process.l1JetScoutingTable.src = cms.InputTag("caloStage2Digis", "Jet")
     process.l1EtSumScoutingTable.src = cms.InputTag("caloStage2Digis", "EtSum")
+
+    return process
+
+# additional customisation for running with ScoutingPFMonitor/MiniAOD inputs alone
+# can also be used on MC input
+# should be used with default customiseScoutingNano and NOT with customiseScoutingNanoForScoutingPFMonitor
+def customiseScoutingNanoFromMini(process):
+    # when running on data, assume ScoutingPFMonitor/MiniAOD dataset as inputs
+    runOnData = hasattr(process,"NANOAODSIMoutput") or hasattr(process,"NANOAODoutput")
+    if runOnData:
+        process = skipEventsWithoutScouting(process)
+
+    # remove gtStage2Digis since they are already run for Mini
+    process.scoutingTriggerTask.remove(process.gtStage2DigisScouting)
+
+    # replace l1bitsScouting with standard l1bits
+    process.scoutingTriggerTask.remove(process.l1bitsScouting)
+    process.scoutingTriggerTask.add(process.l1bits)
+
+    # change src for l1 objects
+    process.l1MuScoutingTable.src = cms.InputTag("gmtStage2Digis", "Muon")
+    process.l1EGScoutingTable.src = cms.InputTag("caloStage2Digis", "EGamma")
+    process.l1TauScoutingTable.src = cms.InputTag("caloStage2Digis", "Tau")
+    process.l1JetScoutingTable.src = cms.InputTag("caloStage2Digis", "Jet")
+    process.l1EtSumScoutingTable.src = cms.InputTag("caloStage2Digis", "EtSum")
+
+    return process
+
+# skip events without scouting object products
+# this may be needed since for there are some events which do not contain scouting object products in 2022-24
+# this is fixed for 2025: https://its.cern.ch/jira/browse/CMSHLT-3331
+def skipEventsWithoutScouting(process):
+    # if scouting paths are triggered, scouting objects will be reconstructed
+    # so we select events passing scouting paths
+    import HLTrigger.HLTfilters.hltHighLevel_cfi
+
+    process.scoutingTriggerPathFilter = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone(
+            HLTPaths = cms.vstring("Dataset_ScoutingPFRun3")
+            )
+
+    process.nanoSkim_step = cms.Path(process.scoutingTriggerPathFilter)
+    process.schedule.extend([process.nanoSkim_step])
+
+    if hasattr(process, "NANOAODoutput"):
+        process.NANOAODoutput.SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring("nanoSkim_step"))
+
+    if hasattr(process, "NANOAODEDMoutput"):
+        process.NANOEDMAODoutput.SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring("nanoSkim_step"))
+
+    if hasattr(process, "write_NANOAOD"): # PromptReco
+        process.write_NANOAOD.SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring("nanoSkim_step")) 
 
     return process
 


### PR DESCRIPTION
#### PR description:

Backport of [cms-sw/cmssw#47739](https://github.com/cms-sw/cmssw/pull/47739) to 15_0_X for 2025 data-taking.

#### PR validation:

Similar validations to  [cms-sw/cmssw#47739](https://github.com/cms-sw/cmssw/pull/47739) were run. 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is a backport to 15_0_X.
