### PR TITLE
Activate ECAL CC timing algorithm for Run3_2025 era - 15_0_X

### DIFF
--- a/Configuration/Eras/python/Era_Run3_2025_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2025_cff.py
@@ -5,5 +5,6 @@ from Configuration.Eras.Modifier_run3_GEM_2025_cff import run3_GEM_2025
 from Configuration.Eras.Modifier_run3_CSC_2025_cff import run3_CSC_2025
 from Configuration.Eras.Modifier_run3_SiPixel_2025_cff import run3_SiPixel_2025
 from Configuration.Eras.Modifier_stage2L1Trigger_2025_cff import stage2L1Trigger_2025
+from Configuration.ProcessModifiers.ecal_cctiming_cff import ecal_cctiming
 
-Run3_2025 = cms.ModifierChain(Run3_2024, run3_GEM_2025, run3_SiPixel_2025, stage2L1Trigger_2025, run3_CSC_2025)
+Run3_2025 = cms.ModifierChain(Run3_2024, run3_GEM_2025, run3_SiPixel_2025, stage2L1Trigger_2025, run3_CSC_2025, ecal_cctiming)


### PR DESCRIPTION
#### PR description:

This PR adds the `ecal_cctiming` modifier to the Run3_2025 era to re-activate the CC timing algorithm after it had been deactivated with era 2024F.

#### PR validation:

The validation of the fixed algorithm has been tracked in [cms-ppd-matters#13](https://gitlab.cern.ch/cms-ppd/cms-ppd-matters/-/issues/13) and a final validation campaign is performed now and documented in [ValDB](https://cms-pdmv-prod.web.cern.ch/valdb/campaigns/15_0_0_pre2_ECAL_CCTiming).
Pending green light from the RelVal this PR can be merged to activate the new algorithm.

Backport of #47776 for 2025 data taking.