### PR TITLE
Revert "speedup SiStripClusterizer(FromRaw) using ThreeThresholdAlgorithm"

### DIFF
--- a/RecoLocalTracker/SiStripClusterizer/interface/ThreeThresholdAlgorithm.h
+++ b/RecoLocalTracker/SiStripClusterizer/interface/ThreeThresholdAlgorithm.h
@@ -1,15 +1,7 @@
 #ifndef RecoLocalTracker_SiStripClusterizer_ThreeThresholdAlgorithm_h
 #define RecoLocalTracker_SiStripClusterizer_ThreeThresholdAlgorithm_h
-
-#include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
-#include "DataFormats/SiStripCluster/interface/SiStripClusterTools.h"
-#include "DataFormats/SiStripDigi/interface/SiStripDigi.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "RecoLocalTracker/SiStripClusterizer/interface/StripClusterizerAlgorithm.h"
 #include "RecoLocalTracker/SiStripClusterizer/interface/SiStripApvShotCleaner.h"
-
-#include <cmath>
-#include <numeric>
 
 class ThreeThresholdAlgorithm final : public StripClusterizerAlgorithm {
   friend class StripClusterizerAlgorithmFactory;
@@ -71,113 +63,5 @@ private:
   bool RemoveApvShots;
   float minGoodCharge;
 };
-
-template <class digiDetSet>
-inline void ThreeThresholdAlgorithm::clusterizeDetUnit_(const digiDetSet& digis, output_t::TSFastFiller& output) const {
-  const auto& cond = conditions();
-  if (cond.isModuleBad(digis.detId()))
-    return;
-
-  auto const& det = cond.findDetId(digis.detId());
-  if (!det.valid())
-    return;
-
-#ifdef EDM_ML_DEBUG
-  if (!cond.isModuleUsable(digis.detId()))
-    edm::LogWarning("ThreeThresholdAlgorithm") << " id " << digis.detId() << " not usable???" << std::endl;
-#endif
-
-  typename digiDetSet::const_iterator scan(digis.begin()), end(digis.end());
-
-  SiStripApvShotCleaner ApvCleaner;
-  if (RemoveApvShots) {
-    ApvCleaner.clean(digis, scan, end);
-  }
-
-  output.reserve(16);
-  State state(det);
-  while (scan != end) {
-    while (scan != end && !candidateEnded(state, scan->strip()))
-      addToCandidate(state, *scan++);
-    endCandidate(state, output);
-  }
-}
-
-inline bool ThreeThresholdAlgorithm::candidateEnded(State const& state, const uint16_t& testStrip) const {
-  uint16_t holes = testStrip - state.lastStrip - 1;
-  return (((!state.ADCs.empty()) &       // a candidate exists, and
-           (holes > MaxSequentialHoles)  // too many holes if not all are bad strips, and
-           ) &&
-          (holes > MaxSequentialBad ||                             // (too many bad strips anyway, or
-           !state.det().allBadBetween(state.lastStrip, testStrip)  // not all holes are bad strips)
-           ));
-}
-
-inline void ThreeThresholdAlgorithm::addToCandidate(State& state, uint16_t strip, uint8_t adc) const {
-  float Noise = state.det().noise(strip);
-  if (adc < static_cast<uint8_t>(Noise * ChannelThreshold) || state.det().bad(strip))
-    return;
-
-  if (state.candidateLacksSeed)
-    state.candidateLacksSeed = adc < static_cast<uint8_t>(Noise * SeedThreshold);
-  if (state.ADCs.empty())
-    state.lastStrip = strip - 1;  // begin candidate
-  while (++state.lastStrip < strip)
-    state.ADCs.push_back(0);  // pad holes
-
-  if (state.ADCs.size() <= MaxClusterSize)
-    state.ADCs.push_back(adc);
-  state.noiseSquared += Noise * Noise;
-}
-
-inline void ThreeThresholdAlgorithm::clusterizeDetUnit(const edmNew::DetSet<SiStripDigi>& digis,
-                                                       output_t::TSFastFiller& output) const {
-  clusterizeDetUnit_(digis, output);
-}
-
-template <class T>
-inline void ThreeThresholdAlgorithm::endCandidate(State& state, T& out) const {
-  if (candidateAccepted(state)) {
-    applyGains(state);
-    if (MaxAdjacentBad > 0)
-      appendBadNeighbors(state);
-    if (minGoodCharge <= 0 ||
-        siStripClusterTools::chargePerCM(state.det().detId, state.ADCs.begin(), state.ADCs.end()) > minGoodCharge)
-      out.push_back(std::move(SiStripCluster(firstStrip(state), state.ADCs.begin(), state.ADCs.end())));
-  }
-  clearCandidate(state);
-}
-
-inline bool ThreeThresholdAlgorithm::candidateAccepted(State const& state) const {
-  return (!state.candidateLacksSeed && state.ADCs.size() <= MaxClusterSize &&
-          state.noiseSquared * ClusterThresholdSquared <=
-              std::pow(float(std::accumulate(state.ADCs.begin(), state.ADCs.end(), int(0))), 2.f));
-}
-
-inline void ThreeThresholdAlgorithm::applyGains(State& state) const {
-  uint16_t strip = firstStrip(state);
-  for (auto& adc : state.ADCs) {
-#ifdef EDM_ML_DEBUG
-    // if(adc > 255) throw InvalidChargeException( SiStripDigi(strip,adc) );
-#endif
-    // if(adc > 253) continue; //saturated, do not scale
-    auto charge = int(float(adc) * state.det().weight(strip++) + 0.5f);  //adding 0.5 turns truncation into rounding
-    if (adc < 254)
-      adc = (charge > 1022 ? 255 : (charge > 253 ? 254 : charge));
-  }
-}
-
-inline void ThreeThresholdAlgorithm::appendBadNeighbors(State& state) const {
-  uint8_t max = MaxAdjacentBad;
-  while (0 < max--) {
-    if (state.det().bad(firstStrip(state) - 1)) {
-      state.ADCs.insert(state.ADCs.begin(), 0);
-    }
-    if (state.det().bad(state.lastStrip + 1)) {
-      state.ADCs.push_back(0);
-      state.lastStrip++;
-    }
-  }
-}
 
 #endif

--- a/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
@@ -4,7 +4,6 @@
 #include "RecoLocalTracker/SiStripZeroSuppression/interface/SiStripRawProcessingFactory.h"
 
 #include "RecoLocalTracker/SiStripClusterizer/interface/StripClusterizerAlgorithm.h"
-#include "RecoLocalTracker/SiStripClusterizer/interface/ThreeThresholdAlgorithm.h"
 #include "RecoLocalTracker/SiStripZeroSuppression/interface/SiStripRawProcessingAlgorithms.h"
 
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
@@ -90,11 +89,10 @@ namespace {
     return buffer;
   }
 
-  template <class AlgoT>
   class ClusterFiller final : public StripClusterizerAlgorithm::output_t::Getter {
   public:
     ClusterFiller(const FEDRawDataCollection& irawColl,
-                  const AlgoT& iclusterizer,
+                  StripClusterizerAlgorithm& iclusterizer,
                   SiStripRawProcessingAlgorithms& irawAlgos,
                   bool idoAPVEmulatorCheck,
                   bool legacy,
@@ -121,7 +119,7 @@ namespace {
 
     const FEDRawDataCollection& rawColl;
 
-    const AlgoT& clusterizer;
+    StripClusterizerAlgorithm& clusterizer;
     const SiStripClusterizerConditions& conditions;
     SiStripRawProcessingAlgorithms& rawAlgos;
 
@@ -183,7 +181,7 @@ public:
         legacy_(conf.getParameter<bool>("LegacyUnpacker")),
         hybridZeroSuppressed_(conf.getParameter<bool>("HybridZeroSuppressed")) {
     productToken_ = consumes<FEDRawDataCollection>(conf.getParameter<edm::InputTag>("ProductLabel"));
-    produces<edmNew::DetSetVector<SiStripCluster>>();
+    produces<edmNew::DetSetVector<SiStripCluster> >();
     assert(clusterizer_.get());
     assert(rawAlgos_.get());
   }
@@ -195,23 +193,12 @@ public:
     edm::Handle<FEDRawDataCollection> rawData;
     ev.getByToken(productToken_, rawData);
 
-    const ThreeThresholdAlgorithm* clusterizer3 = dynamic_cast<const ThreeThresholdAlgorithm*>(clusterizer_.get());
-    std::unique_ptr<edmNew::DetSetVector<SiStripCluster>> output;
-    if (onDemand) {
-      if (clusterizer3 == nullptr)
-        output = std::make_unique<edmNew::DetSetVector<SiStripCluster>>(edmNew::DetSetVector<SiStripCluster>(
-            std::shared_ptr<edmNew::DetSetVector<SiStripCluster>::Getter>(
-                std::make_shared<ClusterFiller<StripClusterizerAlgorithm>>(
-                    *rawData, *clusterizer_, *rawAlgos_, doAPVEmulatorCheck_, legacy_, hybridZeroSuppressed_)),
-            clusterizer_->conditions().allDetIds()));
-      else
-        output = std::make_unique<edmNew::DetSetVector<SiStripCluster>>(edmNew::DetSetVector<SiStripCluster>(
-            std::shared_ptr<edmNew::DetSetVector<SiStripCluster>::Getter>(
-                std::make_shared<ClusterFiller<ThreeThresholdAlgorithm>>(
-                    *rawData, *clusterizer3, *rawAlgos_, doAPVEmulatorCheck_, legacy_, hybridZeroSuppressed_)),
-            clusterizer_->conditions().allDetIds()));
-    } else
-      output = std::make_unique<edmNew::DetSetVector<SiStripCluster>>(edmNew::DetSetVector<SiStripCluster>());
+    std::unique_ptr<edmNew::DetSetVector<SiStripCluster> > output(
+        onDemand ? new edmNew::DetSetVector<SiStripCluster>(
+                       std::shared_ptr<edmNew::DetSetVector<SiStripCluster>::Getter>(std::make_shared<ClusterFiller>(
+                           *rawData, *clusterizer_, *rawAlgos_, doAPVEmulatorCheck_, legacy_, hybridZeroSuppressed_)),
+                       clusterizer_->conditions().allDetIds())
+                 : new edmNew::DetSetVector<SiStripCluster>());
 
     if (onDemand)
       assert(output->onDemand());
@@ -279,38 +266,20 @@ void SiStripClusterizerFromRaw::initialize(const edm::EventSetup& es) {
 }
 
 void SiStripClusterizerFromRaw::run(const FEDRawDataCollection& rawColl, edmNew::DetSetVector<SiStripCluster>& output) {
-  const ThreeThresholdAlgorithm* clusterizer3 = dynamic_cast<const ThreeThresholdAlgorithm*>(clusterizer_.get());
-  if (clusterizer3 == nullptr) {
-    ClusterFiller<StripClusterizerAlgorithm> filler(
-        rawColl, *clusterizer_, *rawAlgos_, doAPVEmulatorCheck_, legacy_, hybridZeroSuppressed_);
+  ClusterFiller filler(rawColl, *clusterizer_, *rawAlgos_, doAPVEmulatorCheck_, legacy_, hybridZeroSuppressed_);
 
-    // loop over good det in cabling
-    for (auto idet : clusterizer_->conditions().allDetIds()) {
-      StripClusterizerAlgorithm::output_t::TSFastFiller record(output, idet);
+  // loop over good det in cabling
+  for (auto idet : clusterizer_->conditions().allDetIds()) {
+    StripClusterizerAlgorithm::output_t::TSFastFiller record(output, idet);
 
-      filler.fill(record);
+    filler.fill(record);
 
-      if (record.empty())
-        record.abort();
-    }  // end loop over dets
-  } else {
-    ClusterFiller<ThreeThresholdAlgorithm> filler(
-        rawColl, *clusterizer3, *rawAlgos_, doAPVEmulatorCheck_, legacy_, hybridZeroSuppressed_);
-
-    // loop over good det in cabling
-    for (auto idet : clusterizer_->conditions().allDetIds()) {
-      StripClusterizerAlgorithm::output_t::TSFastFiller record(output, idet);
-
-      filler.fill(record);
-
-      if (record.empty())
-        record.abort();
-    }  // end loop over dets
-  }
+    if (record.empty())
+      record.abort();
+  }  // end loop over dets
 }
 
 namespace {
-  template <class AlgoT>
   class StripByStripAdder {
   public:
     typedef std::output_iterator_tag iterator_category;
@@ -319,7 +288,7 @@ namespace {
     typedef void pointer;
     typedef void reference;
 
-    StripByStripAdder(const AlgoT& clusterizer,
+    StripByStripAdder(StripClusterizerAlgorithm& clusterizer,
                       StripClusterizerAlgorithm::State& state,
                       StripClusterizerAlgorithm::output_t::TSFastFiller& record)
         : clusterizer_(clusterizer), state_(state), record_(record) {}
@@ -334,7 +303,7 @@ namespace {
     StripByStripAdder& operator++(int) { return *this; }
 
   private:
-    const AlgoT& clusterizer_;
+    StripClusterizerAlgorithm& clusterizer_;
     StripClusterizerAlgorithm::State& state_;
     StripClusterizerAlgorithm::output_t::TSFastFiller& record_;
   };
@@ -357,8 +326,7 @@ namespace {
   };
 }  // namespace
 
-template <class AlgoT>
-void ClusterFiller<AlgoT>::fill(StripClusterizerAlgorithm::output_t::TSFastFiller& record) const {
+void ClusterFiller::fill(StripClusterizerAlgorithm::output_t::TSFastFiller& record) const {
   try {  // edmNew::CapacityExaustedException
     incReady();
 
@@ -425,7 +393,7 @@ void ClusterFiller<AlgoT>::fill(StripClusterizerAlgorithm::output_t::TSFastFille
 
       using namespace sistrip;
       if LIKELY (fedchannelunpacker::isZeroSuppressed(mode, legacy_, lmode)) {
-        auto perStripAdder = StripByStripAdder<AlgoT>(clusterizer, state, record);
+        auto perStripAdder = StripByStripAdder(clusterizer, state, record);
         const auto isNonLite = fedchannelunpacker::isNonLiteZS(mode, legacy_, lmode);
         const uint8_t pCode = (isNonLite ? buffer->packetCode(legacy_, fedCh) : 0);
         auto st_ch = fedchannelunpacker::StatusCode::SUCCESS;

--- a/RecoLocalTracker/SiStripClusterizer/src/ThreeThresholdAlgorithm.cc
+++ b/RecoLocalTracker/SiStripClusterizer/src/ThreeThresholdAlgorithm.cc
@@ -1,4 +1,11 @@
 #include "RecoLocalTracker/SiStripClusterizer/interface/ThreeThresholdAlgorithm.h"
+#include "DataFormats/SiStripDigi/interface/SiStripDigi.h"
+#include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
+#include <cmath>
+#include <numeric>
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "DataFormats/SiStripCluster/interface/SiStripClusterTools.h"
 
 ThreeThresholdAlgorithm::ThreeThresholdAlgorithm(
     const edm::ESGetToken<SiStripClusterizerConditions, SiStripClusterizerConditionsRcd>& conditionsToken,
@@ -22,7 +29,114 @@ ThreeThresholdAlgorithm::ThreeThresholdAlgorithm(
       RemoveApvShots(removeApvShots),
       minGoodCharge(minGoodCharge) {}
 
+template <class digiDetSet>
+inline void ThreeThresholdAlgorithm::clusterizeDetUnit_(const digiDetSet& digis, output_t::TSFastFiller& output) const {
+  const auto& cond = conditions();
+  if (cond.isModuleBad(digis.detId()))
+    return;
+
+  auto const& det = cond.findDetId(digis.detId());
+  if (!det.valid())
+    return;
+
+#ifdef EDM_ML_DEBUG
+  if (!cond.isModuleUsable(digis.detId()))
+    edm::LogWarning("ThreeThresholdAlgorithm") << " id " << digis.detId() << " not usable???" << std::endl;
+#endif
+
+  typename digiDetSet::const_iterator scan(digis.begin()), end(digis.end());
+
+  SiStripApvShotCleaner ApvCleaner;
+  if (RemoveApvShots) {
+    ApvCleaner.clean(digis, scan, end);
+  }
+
+  output.reserve(16);
+  State state(det);
+  while (scan != end) {
+    while (scan != end && !candidateEnded(state, scan->strip()))
+      addToCandidate(state, *scan++);
+    endCandidate(state, output);
+  }
+}
+
+inline bool ThreeThresholdAlgorithm::candidateEnded(State const& state, const uint16_t& testStrip) const {
+  uint16_t holes = testStrip - state.lastStrip - 1;
+  return (((!state.ADCs.empty()) &       // a candidate exists, and
+           (holes > MaxSequentialHoles)  // too many holes if not all are bad strips, and
+           ) &&
+          (holes > MaxSequentialBad ||                             // (too many bad strips anyway, or
+           !state.det().allBadBetween(state.lastStrip, testStrip)  // not all holes are bad strips)
+           ));
+}
+
+inline void ThreeThresholdAlgorithm::addToCandidate(State& state, uint16_t strip, uint8_t adc) const {
+  float Noise = state.det().noise(strip);
+  if (adc < static_cast<uint8_t>(Noise * ChannelThreshold) || state.det().bad(strip))
+    return;
+
+  if (state.candidateLacksSeed)
+    state.candidateLacksSeed = adc < static_cast<uint8_t>(Noise * SeedThreshold);
+  if (state.ADCs.empty())
+    state.lastStrip = strip - 1;  // begin candidate
+  while (++state.lastStrip < strip)
+    state.ADCs.push_back(0);  // pad holes
+
+  if (state.ADCs.size() <= MaxClusterSize)
+    state.ADCs.push_back(adc);
+  state.noiseSquared += Noise * Noise;
+}
+
+template <class T>
+inline void ThreeThresholdAlgorithm::endCandidate(State& state, T& out) const {
+  if (candidateAccepted(state)) {
+    applyGains(state);
+    if (MaxAdjacentBad > 0)
+      appendBadNeighbors(state);
+    if (minGoodCharge <= 0 ||
+        siStripClusterTools::chargePerCM(state.det().detId, state.ADCs.begin(), state.ADCs.end()) > minGoodCharge)
+      out.push_back(std::move(SiStripCluster(firstStrip(state), state.ADCs.begin(), state.ADCs.end())));
+  }
+  clearCandidate(state);
+}
+
+inline bool ThreeThresholdAlgorithm::candidateAccepted(State const& state) const {
+  return (!state.candidateLacksSeed && state.ADCs.size() <= MaxClusterSize &&
+          state.noiseSquared * ClusterThresholdSquared <=
+              std::pow(float(std::accumulate(state.ADCs.begin(), state.ADCs.end(), int(0))), 2.f));
+}
+
+inline void ThreeThresholdAlgorithm::applyGains(State& state) const {
+  uint16_t strip = firstStrip(state);
+  for (auto& adc : state.ADCs) {
+#ifdef EDM_ML_DEBUG
+    // if(adc > 255) throw InvalidChargeException( SiStripDigi(strip,adc) );
+#endif
+    // if(adc > 253) continue; //saturated, do not scale
+    auto charge = int(float(adc) * state.det().weight(strip++) + 0.5f);  //adding 0.5 turns truncation into rounding
+    if (adc < 254)
+      adc = (charge > 1022 ? 255 : (charge > 253 ? 254 : charge));
+  }
+}
+
+inline void ThreeThresholdAlgorithm::appendBadNeighbors(State& state) const {
+  uint8_t max = MaxAdjacentBad;
+  while (0 < max--) {
+    if (state.det().bad(firstStrip(state) - 1)) {
+      state.ADCs.insert(state.ADCs.begin(), 0);
+    }
+    if (state.det().bad(state.lastStrip + 1)) {
+      state.ADCs.push_back(0);
+      state.lastStrip++;
+    }
+  }
+}
+
 void ThreeThresholdAlgorithm::clusterizeDetUnit(const edm::DetSet<SiStripDigi>& digis,
+                                                output_t::TSFastFiller& output) const {
+  clusterizeDetUnit_(digis, output);
+}
+void ThreeThresholdAlgorithm::clusterizeDetUnit(const edmNew::DetSet<SiStripDigi>& digis,
                                                 output_t::TSFastFiller& output) const {
   clusterizeDetUnit_(digis, output);
 }


### PR DESCRIPTION
Reverts cms-sw/cmssw#47061

https://github.com/cms-sw/cmssw/pull/47061#issuecomment-2784812601

Following the TSG timing checks of the full unpacking/clustering showing possible slow down (initially reported late Jan/early Feb), I rechecked the impact and (unfortunately) confirm on data inputs (full menu based on /dev/CMSSW_14_2_0/GRun/V12 data from run 386593, 10K events, single thread test, in a configuration with mkFit and full strip unpacking and max cluster size set to 8):

- valgrind callgrind still shows a speed up of around 25%
- FastTimerService shows around 10% slowdown in `hltSiStripRawToClustersFacility`

I can speculate that callgrind is so slow that the underlying hardware memory access costs are mis-represented

I tried to measure the impact of individual contributions
- changes in template/inline of ThreeThresholdAlgorithm have almost negligible impact on timing 
- precomputed qualityBits and rawNoises lead to most of the slowdown based on `FastTimerService`

The timing tests were done in CMSSW_14_2_1

@mmasciov 
@elusian 