### PR TITLE
Phase2-HGC363C Correct the cassette shift for the scintillator tiles in HGCal V19 geometry

### DIFF
--- a/Geometry/HGCalCommonData/data/hgcalHEmix/v19/hgcalHEmix.xml
+++ b/Geometry/HGCalCommonData/data/hgcalHEmix/v19/hgcalHEmix.xml
@@ -958,7 +958,7 @@
        288,   288,   288,   288 
   </Vector>
   <Vector name="ScintRetract" type="numeric" nEntries="14">
-           4*mm,       4*mm,       4*mm,       4*mm,       8*mm,       8*mm,
+           8*mm,       8*mm,       8*mm,       8*mm,       8*mm,       8*mm,
            8*mm,       8*mm,       8*mm,       8*mm,       8*mm,       8*mm,
            8*mm,       8*mm 
   </Vector>

--- a/Geometry/HGCalCommonData/data/hgcalHEmix/v19/hgcalHEmix.xml
+++ b/Geometry/HGCalCommonData/data/hgcalHEmix/v19/hgcalHEmix.xml
@@ -23,6 +23,7 @@
     <Numeric name="SensorSeparation" value="[hgcal:SensorSeparation]"/>
     <Numeric name="Sectors"          value="36"/>
     <Numeric name="Cassettes"        value="12"/>
+    <Numeric name="TestCassetteShift" value="0"/>
     <Vector name="SlopeBottom" type="numeric" nEntries="4">
       0, 0, 0, 0</Vector>
     <Vector name="ZFrontBottom" type="numeric" nEntries="4">

--- a/Geometry/HGCalCommonData/interface/HGCalCassette.h
+++ b/Geometry/HGCalCommonData/interface/HGCalCassette.h
@@ -12,7 +12,9 @@ public:
 
   void setParameter(int cassette, const std::vector<double>& shifts, bool both = true);
   void setParameterScint(const std::vector<double>& shifts);
+  void setParameterRetract(const std::vector<double>& shifts);
   std::pair<double, double> getShift(int layer, int zside, int cassette, bool scnt = false) const;
+  std::pair<double, double> getShiftScnt(int layer, int zside, double phi) const;
   static int cassetteIndex(int det, int layer, int zside, int cassette);
   static int cassetteType(int det, int zside, int cassette);
 
@@ -21,7 +23,7 @@ private:
   static constexpr int positHE_[12] = {5, 4, 3, 2, 1, 0, 11, 10, 9, 8, 7, 6};
   int cassette_;
   bool typeHE_;
-  std::vector<double> shifts_, shiftsScnt_;
+  std::vector<double> shifts_, shiftsScnt_, retractScnt_;
   static constexpr int32_t factor_ = 100;
 };
 

--- a/Geometry/HGCalCommonData/plugins/DDHGCalMixRotatedFineCassette.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalMixRotatedFineCassette.cc
@@ -623,11 +623,11 @@ void DDHGCalMixRotatedFineCassette::positionMix(const DDLogicalPart& glog,
 #endif
         double phi1 = dphi * (fimin - 1) + 0.5 * tol0_;
         double phi2 = dphi * (fimax - fimin + 1) - tol0_;
-	double phi = phi1 + 0.5 * phi2;
+        double phi = phi1 + 0.5 * phi2;
         auto cshift = cassette_.getShiftScnt(layer0, -1, phi);
 #ifdef EDM_ML_DEBUG
-        edm::LogVerbatim("HGCalGeom") << "1Layer " << ly << ":" << ii << ":" << copy << ":" << layer0 << " phi "
-                                      << phi << " shift " << cshift.first << ":" << cshift.second;
+        edm::LogVerbatim("HGCalGeom") << "1Layer " << ly << ":" << ii << ":" << copy << ":" << layer0 << " phi " << phi
+                                      << " shift " << cshift.first << ":" << cshift.second;
         int cassette0 = HGCalCassette::cassetteType(2, 1, cassette);  //
         int ir1 = (fine) ? std::get<1>(HGCalTileIndex::tileUnpack(tileFineIndex_[ti]))
                          : std::get<1>(HGCalTileIndex::tileUnpack(tileCoarseIndex_[ti]));
@@ -726,8 +726,8 @@ void DDHGCalMixRotatedFineCassette::positionMix(const DDLogicalPart& glog,
       double phi = phi1 + 0.5 * phi2;
       auto cshift = cassette_.getShiftScnt(layer0, -1, phi);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "2Layer " << ii << ":" << copy << ":" << layer << ":" << layer0 << " phi "
-                                    << phi << " shift " << cshift.first << ":" << cshift.second;
+      edm::LogVerbatim("HGCalGeom") << "2Layer " << ii << ":" << copy << ":" << layer << ":" << layer0 << " phi " << phi
+                                    << " shift " << cshift.first << ":" << cshift.second;
       int cassette0 = HGCalCassette::cassetteType(2, 1, cassette);  //
       int ir1 = (fine) ? std::get<1>(HGCalTileIndex::tileUnpack(tileFineIndex_[ti]))
                        : std::get<1>(HGCalTileIndex::tileUnpack(tileCoarseIndex_[ti]));

--- a/Geometry/HGCalCommonData/plugins/DDHGCalMixRotatedFineCassette.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalMixRotatedFineCassette.cc
@@ -624,8 +624,8 @@ void DDHGCalMixRotatedFineCassette::positionMix(const DDLogicalPart& glog,
 #endif
         double phi1 = dphi * (fimin - 1);
         double phi2 = dphi * (fimax - fimin + 1);
-	r1 += retract_[layer0 - 1];
-	r2 += retract_[layer0 - 1];
+        r1 += retract_[layer0 - 1];
+        r2 += retract_[layer0 - 1];
 #ifdef EDM_ML_DEBUG
         double phi = phi1 + 0.5 * phi2;
         edm::LogVerbatim("HGCalGeom") << "1Layer " << ly << ":" << ii << ":" << copy << ":" << layer0 << " phi " << phi

--- a/Geometry/HGCalCommonData/plugins/DDHGCalMixRotatedFineCassette.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalMixRotatedFineCassette.cc
@@ -404,6 +404,7 @@ void DDHGCalMixRotatedFineCassette::initialize(const DDNumericArguments& nArgs,
 #endif
   cassette_.setParameter(cassettes_, cassetteShift_, false);
   cassette_.setParameterScint(cassetteShiftScnt_);
+  cassette_.setParameterRetract(retract);
 
   int testCassette = static_cast<int>(nArgs["TestCassetteShift"]);
   if (testCassette != 0)
@@ -589,10 +590,11 @@ void DDHGCalMixRotatedFineCassette::positionMix(const DDLogicalPart& glog,
                                     << layer0 << " Copy " << copy << " Tiles " << firstTile << ":" << lastTile
                                     << " Size " << tileFineIndex_.size() << ":" << tileCoarseIndex_.size() << " Fine "
                                     << fine << " absType " << absType;
+      int cassette;
 #endif
       for (int ti = firstTile; ti < lastTile; ++ti) {
         double r1, r2;
-        int cassette, fimin, fimax;
+        int fimin, fimax;
 #ifdef EDM_ML_DEBUG
         edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: ti " << ti << ":" << fine << " index "
                                       << tileFineIndex_.size() << ":" << tileCoarseIndex_.size() << " Phis "
@@ -601,13 +603,17 @@ void DDHGCalMixRotatedFineCassette::positionMix(const DDLogicalPart& glog,
         if (fine) {
           r1 = tileFineRMin_[std::get<1>(HGCalTileIndex::tileUnpack(tileFineIndex_[ti])) - 1];
           r2 = tileFineRMax_[std::get<2>(HGCalTileIndex::tileUnpack(tileFineIndex_[ti])) - 1];
+#ifdef EDM_ML_DEBUG
           cassette = std::get<0>(HGCalTileIndex::tileUnpack(tileFinePhis_[ti]));
+#endif
           fimin = std::get<1>(HGCalTileIndex::tileUnpack(tileFinePhis_[ti]));
           fimax = std::get<2>(HGCalTileIndex::tileUnpack(tileFinePhis_[ti]));
         } else {
           r1 = tileCoarseRMin_[std::get<1>(HGCalTileIndex::tileUnpack(tileCoarseIndex_[ti])) - 1];
           r2 = tileCoarseRMax_[std::get<2>(HGCalTileIndex::tileUnpack(tileCoarseIndex_[ti])) - 1];
+#ifdef EDM_ML_DEBUG
           cassette = std::get<0>(HGCalTileIndex::tileUnpack(tileCoarsePhis_[ti]));
+#endif
           fimin = std::get<1>(HGCalTileIndex::tileUnpack(tileCoarsePhis_[ti]));
           fimax = std::get<2>(HGCalTileIndex::tileUnpack(tileCoarsePhis_[ti]));
         }
@@ -615,12 +621,13 @@ void DDHGCalMixRotatedFineCassette::positionMix(const DDLogicalPart& glog,
         edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: Casstee|Fimin|Fimax " << cassette << ":"
                                       << fimin << ":" << fimax;
 #endif
-        double phi1 = dphi * (fimin - 1);
+        double phi1 = dphi * (fimin - 1) + 0.5 * tol0_;
         double phi2 = dphi * (fimax - fimin + 1) - tol0_;
-        auto cshift = cassette_.getShift(layer0, -1, cassette, true);
+	double phi = phi1 + 0.5 * phi2;
+        auto cshift = cassette_.getShiftScnt(layer0, -1, phi);
 #ifdef EDM_ML_DEBUG
-        edm::LogVerbatim("HGCalGeom") << "1Layer " << ly << ":" << ii << ":" << copy << ":" << layer0 << " Cassette "
-                                      << cassette << " shift " << cshift.first << ":" << cshift.second;
+        edm::LogVerbatim("HGCalGeom") << "1Layer " << ly << ":" << ii << ":" << copy << ":" << layer0 << " phi "
+                                      << phi << " shift " << cshift.first << ":" << cshift.second;
         int cassette0 = HGCalCassette::cassetteType(2, 1, cassette);  //
         int ir1 = (fine) ? std::get<1>(HGCalTileIndex::tileUnpack(tileFineIndex_[ti]))
                          : std::get<1>(HGCalTileIndex::tileUnpack(tileCoarseIndex_[ti]));
@@ -686,22 +693,27 @@ void DDHGCalMixRotatedFineCassette::positionMix(const DDLogicalPart& glog,
 #endif
     for (int ti = firstTile; ti < lastTile; ++ti) {
       double r1, r2;
-      int cassette, fimin, fimax;
+      int fimin, fimax;
 #ifdef EDM_ML_DEBUG
       edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: ti " << ti << ":" << fine << " index "
                                     << tileFineIndex_.size() << ":" << tileCoarseIndex_.size() << " Phis "
                                     << tileFinePhis_.size() << ":" << tileCoarsePhis_.size();
+      int cassette;
 #endif
       if (fine) {
         r1 = tileFineRMin_[std::get<1>(HGCalTileIndex::tileUnpack(tileFineIndex_[ti])) - 1];
         r2 = tileFineRMax_[std::get<2>(HGCalTileIndex::tileUnpack(tileFineIndex_[ti])) - 1];
+#ifdef EDM_ML_DEBUG
         cassette = std::get<0>(HGCalTileIndex::tileUnpack(tileFinePhis_[ti]));
+#endif
         fimin = std::get<1>(HGCalTileIndex::tileUnpack(tileFinePhis_[ti]));
         fimax = std::get<2>(HGCalTileIndex::tileUnpack(tileFinePhis_[ti]));
       } else {
         r1 = tileCoarseRMin_[std::get<1>(HGCalTileIndex::tileUnpack(tileCoarseIndex_[ti])) - 1];
         r2 = tileCoarseRMax_[std::get<2>(HGCalTileIndex::tileUnpack(tileCoarseIndex_[ti])) - 1];
+#ifdef EDM_ML_DEBUG
         cassette = std::get<0>(HGCalTileIndex::tileUnpack(tileCoarsePhis_[ti]));
+#endif
         fimin = std::get<1>(HGCalTileIndex::tileUnpack(tileCoarsePhis_[ti]));
         fimax = std::get<2>(HGCalTileIndex::tileUnpack(tileCoarsePhis_[ti]));
       }
@@ -709,12 +721,13 @@ void DDHGCalMixRotatedFineCassette::positionMix(const DDLogicalPart& glog,
       edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: Casstee|Fimin|Fimax " << cassette << ":" << fimin
                                     << ":" << fimax;
 #endif
-      double phi1 = dphi * (fimin - 1);
-      double phi2 = dphi * (fimax - fimin + 1);
-      auto cshift = cassette_.getShift(layer0, -1, cassette, true);
+      double phi1 = dphi * (fimin - 1) + 0.5 * tol0_;
+      double phi2 = dphi * (fimax - fimin + 1) - tol0_;
+      double phi = phi1 + 0.5 * phi2;
+      auto cshift = cassette_.getShiftScnt(layer0, -1, phi);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "2Layer " << ii << ":" << copy << ":" << layer << ":" << layer0 << " Cassette "
-                                    << cassette << " shift " << cshift.first << ":" << cshift.second;
+      edm::LogVerbatim("HGCalGeom") << "2Layer " << ii << ":" << copy << ":" << layer << ":" << layer0 << " phi "
+                                    << phi << " shift " << cshift.first << ":" << cshift.second;
       int cassette0 = HGCalCassette::cassetteType(2, 1, cassette);  //
       int ir1 = (fine) ? std::get<1>(HGCalTileIndex::tileUnpack(tileFineIndex_[ti]))
                        : std::get<1>(HGCalTileIndex::tileUnpack(tileCoarseIndex_[ti]));
@@ -758,7 +771,7 @@ void DDHGCalMixRotatedFineCassette::positionMix(const DDLogicalPart& glog,
 #endif
     for (int k = 0; k < cassettes_; ++k) {
       int cassette = k + 1;
-      auto cshift = cassette_.getShift(layer0, -1, cassette);
+      auto cshift = cassette_.getShift(layer0, -1, cassette, false);
 #ifdef EDM_ML_DEBUG
       edm::LogVerbatim("HGCalGeom") << "3Layer " << layer << ":" << layer0 << " Cassette " << cassette << " shift "
                                     << cshift.first << ":" << cshift.second;

--- a/Geometry/HGCalCommonData/plugins/DDHGCalMixRotatedFineCassette.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalMixRotatedFineCassette.cc
@@ -570,6 +570,7 @@ void DDHGCalMixRotatedFineCassette::positionMix(const DDLogicalPart& glog,
       int ii = layerTypeTop_[ly];
       int copy = copyNumberTop_[ii];
       int layer = (fine) ? (copy - firstFineLayer_) : (copy - firstCoarseLayer_);
+      int layer0 = (copy - std::min(firstFineLayer_, firstCoarseLayer_) + 1);
       double hthickl = 0.5 * layerThickTop_[ii];
       thickTot += layerThickTop_[ii];
       zpos += hthickl;
@@ -584,7 +585,7 @@ void DDHGCalMixRotatedFineCassette::positionMix(const DDLogicalPart& glog,
                                    ? tileCoarseLayerStart_[layer + 1]
                                    : static_cast<int>(tileCoarseIndex_.size()));
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: Layer " << ly << ":" << ii << ":" << layer
+      edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: Layer " << ly << ":" << ii << ":" << layer << ":" << layer0
                                     << " Copy " << copy << " Tiles " << firstTile << ":" << lastTile << " Size "
                                     << tileFineIndex_.size() << ":" << tileCoarseIndex_.size() << " Fine " << fine
                                     << " absType " << absType;
@@ -616,16 +617,16 @@ void DDHGCalMixRotatedFineCassette::positionMix(const DDLogicalPart& glog,
 #endif
         double phi1 = dphi * (fimin - 1);
         double phi2 = dphi * (fimax - fimin + 1) - tol0_;
-        auto cshift = cassette_.getShift(layer + 1, 1, cassette, true);
+        auto cshift = cassette_.getShift(layer0, -1, cassette, true);
 #ifdef EDM_ML_DEBUG
-        edm::LogVerbatim("HGCalGeom") << "1Layer " << ly << ":" << ii << ":" << copy << ":" << layer << " Cassette "
+        edm::LogVerbatim("HGCalGeom") << "1Layer " << ly << ":" << ii << ":" << copy << ":" << layer0 << " Cassette "
                                       << cassette << " shift " << cshift.first << ":" << cshift.second;
         int cassette0 = HGCalCassette::cassetteType(2, 1, cassette);  //
         int ir1 = (fine) ? std::get<1>(HGCalTileIndex::tileUnpack(tileFineIndex_[ti]))
                          : std::get<1>(HGCalTileIndex::tileUnpack(tileCoarseIndex_[ti]));
         int ir2 = (fine) ? std::get<2>(HGCalTileIndex::tileUnpack(tileFineIndex_[ti]))
                          : std::get<2>(HGCalTileIndex::tileUnpack(tileCoarseIndex_[ti]));
-        edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: Layer " << copy << ":" << (layer + 1) << " iR "
+        edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: Layer " << copy << ":" << layer0 << " iR "
                                       << ir1 << ":" << ir2 << " R " << r1 << ":" << r2 << " Thick " << (2.0 * hthickl)
                                       << " phi " << fimin << ":" << fimax << ":" << convertRadToDeg(phi1) << ":"
                                       << convertRadToDeg(phi2) << " cassette " << cassette << ":" << cassette0
@@ -664,6 +665,7 @@ void DDHGCalMixRotatedFineCassette::positionMix(const DDLogicalPart& glog,
     int ii = coverTypeTop_;
     int copy = copyNumberCoverTop_[absType - 1];
     int layer = (fine) ? (copy - firstFineLayer_) : (copy - firstCoarseLayer_);
+    int layer0 = (copy - std::min(firstFineLayer_, firstCoarseLayer_) + 1);
     double hthickl = 0.5 * layerThickTop_[ii];
     zpos += hthickl;
     DDName matName(DDSplit(materialTop_[ii]).first, DDSplit(materialTop_[ii]).second);
@@ -677,7 +679,7 @@ void DDHGCalMixRotatedFineCassette::positionMix(const DDLogicalPart& glog,
                       ? tileCoarseLayerStart_[layer + 1]
                       : static_cast<int>(tileCoarseIndex_.size()));
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: TOP Layer " << ii << ":" << layer << " Copy "
+    edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: TOP Layer " << ii << ":" << layer << ":" << layer0 << " Copy "
                                   << copy << " Tiles " << firstTile << ":" << lastTile << " Size "
                                   << tileFineIndex_.size() << ":" << tileCoarseIndex_.size() << " Fine " << fine
                                   << " absType " << absType;
@@ -709,16 +711,16 @@ void DDHGCalMixRotatedFineCassette::positionMix(const DDLogicalPart& glog,
 #endif
       double phi1 = dphi * (fimin - 1);
       double phi2 = dphi * (fimax - fimin + 1);
-      auto cshift = cassette_.getShift(layer + 1, 1, cassette, true);
+      auto cshift = cassette_.getShift(layer0, -1, cassette, true);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "2Layer " << ii << ":" << copy << ":" << layer << " Cassette " << cassette
+      edm::LogVerbatim("HGCalGeom") << "2Layer " << ii << ":" << copy << ":" << layer << ":" << layer0 << " Cassette " << cassette
                                     << " shift " << cshift.first << ":" << cshift.second;
       int cassette0 = HGCalCassette::cassetteType(2, 1, cassette);  //
       int ir1 = (fine) ? std::get<1>(HGCalTileIndex::tileUnpack(tileFineIndex_[ti]))
                        : std::get<1>(HGCalTileIndex::tileUnpack(tileCoarseIndex_[ti]));
       int ir2 = (fine) ? std::get<2>(HGCalTileIndex::tileUnpack(tileFineIndex_[ti]))
                        : std::get<2>(HGCalTileIndex::tileUnpack(tileCoarseIndex_[ti]));
-      edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: Layer " << copy << ":" << (layer + 1) << " iR "
+      edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: Layer " << copy << ":" << (layer + 1) << ":" << layer0 << " iR "
                                     << ir1 << ":" << ir2 << " R " << r1 << ":" << r2 << " Thick " << (2.0 * hthickl)
                                     << " phi " << fimin << ":" << fimax << ":" << convertRadToDeg(phi1) << ":"
                                     << convertRadToDeg(phi2) << " cassette " << cassette << ":" << cassette0
@@ -745,9 +747,9 @@ void DDHGCalMixRotatedFineCassette::positionMix(const DDLogicalPart& glog,
 
   // Make the bottom part next
   int layer = (copyM - firstFineLayer_);
+  int layer0 = (copyM - std::min(firstFineLayer_, firstCoarseLayer_) + 1);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: Start bottom section for layer " << layer
-                                << " absType " << absType;
+  edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: Start bottom section for layer " << (layer + 1) << ":" << layer0 << " absType " << absType;
 #endif
   if (absType > 0) {
 #ifdef EDM_ML_DEBUG
@@ -755,10 +757,9 @@ void DDHGCalMixRotatedFineCassette::positionMix(const DDLogicalPart& glog,
 #endif
     for (int k = 0; k < cassettes_; ++k) {
       int cassette = k + 1;
-      auto cshift = cassette_.getShift(layer + 1, 1, cassette);
+      auto cshift = cassette_.getShift(layer0, -1, cassette);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "3Layer " << layer << " Cassette " << cassette << " shift " << cshift.first
-                                    << ":" << cshift.second;
+      edm::LogVerbatim("HGCalGeom") << "3Layer " << layer << ":" << layer0 << " Cassette " << cassette << " shift " << cshift.first << ":" << cshift.second;
 #endif
       double xpos = -cshift.first;
       double ypos = cshift.second;
@@ -827,10 +828,9 @@ void DDHGCalMixRotatedFineCassette::positionMix(const DDLogicalPart& glog,
           << ":" << waferProperty_[k] << ":" << layertype << ":" << type << ":" << part << ":" << orien << ":"
           << cassette << ":" << place;
 #endif
-      auto cshift = cassette_.getShift(layer + 1, 1, cassette, false);
+      auto cshift = cassette_.getShift(layer0, -1, cassette, false);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "Layer " << layer << " Cassette " << cassette << " shift " << cshift.first << ":"
-                                    << cshift.second;
+      edm::LogVerbatim("HGCalGeom") << "Layer " << (layer + 1) << ":" << layer0 << " Cassette " << cassette << " shift " << cshift.first << ":"  << cshift.second;
 #endif
       double xpos = xyoff.first - cshift.first + nc * delx;
       double ypos = xyoff.second + cshift.second + nr * dy;
@@ -838,7 +838,7 @@ void DDHGCalMixRotatedFineCassette::positionMix(const DDLogicalPart& glog,
       double xorig = xyoff.first + nc * delx;
       double yorig = xyoff.second + nr * dy;
       double angle = std::atan2(yorig, xorig);
-      edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette::Wafer: layer " << layer + 1 << " cassette "
+      edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette::Wafer: layer " << layer + 1 << ":" << layer0 << " cassette "
                                     << cassette << " Shift " << cshift.first << ":" << cshift.second << " Original "
                                     << xorig << ":" << yorig << ":" << convertRadToDeg(angle) << " Final " << xpos
                                     << ":" << ypos;

--- a/Geometry/HGCalCommonData/plugins/DDHGCalMixRotatedFineCassette.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalMixRotatedFineCassette.cc
@@ -618,7 +618,8 @@ void DDHGCalMixRotatedFineCassette::positionMix(const DDLogicalPart& glog,
         double phi2 = dphi * (fimax - fimin + 1) - tol0_;
         auto cshift = cassette_.getShift(layer + 1, 1, cassette, true);
 #ifdef EDM_ML_DEBUG
-	edm::LogVerbatim("HGCalGeom") << "1Layer " << ly << ":" << ii << ":" << copy << ":" << layer << " Cassette " << cassette << " shift " << cshift.first << ":" << cshift.second;
+        edm::LogVerbatim("HGCalGeom") << "1Layer " << ly << ":" << ii << ":" << copy << ":" << layer << " Cassette "
+                                      << cassette << " shift " << cshift.first << ":" << cshift.second;
         int cassette0 = HGCalCassette::cassetteType(2, 1, cassette);  //
         int ir1 = (fine) ? std::get<1>(HGCalTileIndex::tileUnpack(tileFineIndex_[ti]))
                          : std::get<1>(HGCalTileIndex::tileUnpack(tileCoarseIndex_[ti]));
@@ -710,7 +711,8 @@ void DDHGCalMixRotatedFineCassette::positionMix(const DDLogicalPart& glog,
       double phi2 = dphi * (fimax - fimin + 1);
       auto cshift = cassette_.getShift(layer + 1, 1, cassette, true);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "2Layer " << ii << ":" << copy << ":" << layer << " Cassette " << cassette << " shift " << cshift.first << ":" << cshift.second;
+      edm::LogVerbatim("HGCalGeom") << "2Layer " << ii << ":" << copy << ":" << layer << " Cassette " << cassette
+                                    << " shift " << cshift.first << ":" << cshift.second;
       int cassette0 = HGCalCassette::cassetteType(2, 1, cassette);  //
       int ir1 = (fine) ? std::get<1>(HGCalTileIndex::tileUnpack(tileFineIndex_[ti]))
                        : std::get<1>(HGCalTileIndex::tileUnpack(tileCoarseIndex_[ti]));
@@ -755,7 +757,8 @@ void DDHGCalMixRotatedFineCassette::positionMix(const DDLogicalPart& glog,
       int cassette = k + 1;
       auto cshift = cassette_.getShift(layer + 1, 1, cassette);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "3Layer " << layer << " Cassette " << cassette << " shift " << cshift.first << ":" << cshift.second;
+      edm::LogVerbatim("HGCalGeom") << "3Layer " << layer << " Cassette " << cassette << " shift " << cshift.first
+                                    << ":" << cshift.second;
 #endif
       double xpos = -cshift.first;
       double ypos = cshift.second;
@@ -826,7 +829,8 @@ void DDHGCalMixRotatedFineCassette::positionMix(const DDLogicalPart& glog,
 #endif
       auto cshift = cassette_.getShift(layer + 1, 1, cassette, false);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "Layer " << layer << " Cassette " << cassette << " shift " << cshift.first << ":" << cshift.second;
+      edm::LogVerbatim("HGCalGeom") << "Layer " << layer << " Cassette " << cassette << " shift " << cshift.first << ":"
+                                    << cshift.second;
 #endif
       double xpos = xyoff.first - cshift.first + nc * delx;
       double ypos = xyoff.second + cshift.second + nr * dy;
@@ -900,9 +904,11 @@ void DDHGCalMixRotatedFineCassette::testCassetteShift() {
       int cassette = l + 1;
       auto cf1 = cassette_.getShift(layer, 1, cassette, false);
       auto cf2 = cassette_.getShift(layer, 1, cassette, true);
-      auto cf3 = cassette_.getShift(layer,-1, cassette, false);
-      auto cf4 = cassette_.getShift(layer,-1, cassette, true);
-      edm::LogVerbatim("HGCalGeom") << "Layer " << layer << " Cassette " << cassette << " x for z+ " << cf1.first << ":" << cf2.first << " y for z+ " << cf1.second << ":" << cf2.second  << " x for z- " << cf3.first << ":" << cf4.first << " y for z- " << cf3.second << ":" << cf4.second;
+      auto cf3 = cassette_.getShift(layer, -1, cassette, false);
+      auto cf4 = cassette_.getShift(layer, -1, cassette, true);
+      edm::LogVerbatim("HGCalGeom") << "Layer " << layer << " Cassette " << cassette << " x for z+ " << cf1.first << ":"
+                                    << cf2.first << " y for z+ " << cf1.second << ":" << cf2.second << " x for z- "
+                                    << cf3.first << ":" << cf4.first << " y for z- " << cf3.second << ":" << cf4.second;
     }
   }
 }

--- a/Geometry/HGCalCommonData/plugins/DDHGCalMixRotatedFineCassette.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalMixRotatedFineCassette.cc
@@ -585,10 +585,10 @@ void DDHGCalMixRotatedFineCassette::positionMix(const DDLogicalPart& glog,
                                    ? tileCoarseLayerStart_[layer + 1]
                                    : static_cast<int>(tileCoarseIndex_.size()));
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: Layer " << ly << ":" << ii << ":" << layer << ":" << layer0
-                                    << " Copy " << copy << " Tiles " << firstTile << ":" << lastTile << " Size "
-                                    << tileFineIndex_.size() << ":" << tileCoarseIndex_.size() << " Fine " << fine
-                                    << " absType " << absType;
+      edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: Layer " << ly << ":" << ii << ":" << layer << ":"
+                                    << layer0 << " Copy " << copy << " Tiles " << firstTile << ":" << lastTile
+                                    << " Size " << tileFineIndex_.size() << ":" << tileCoarseIndex_.size() << " Fine "
+                                    << fine << " absType " << absType;
 #endif
       for (int ti = firstTile; ti < lastTile; ++ti) {
         double r1, r2;
@@ -679,8 +679,8 @@ void DDHGCalMixRotatedFineCassette::positionMix(const DDLogicalPart& glog,
                       ? tileCoarseLayerStart_[layer + 1]
                       : static_cast<int>(tileCoarseIndex_.size()));
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: TOP Layer " << ii << ":" << layer << ":" << layer0 << " Copy "
-                                  << copy << " Tiles " << firstTile << ":" << lastTile << " Size "
+    edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: TOP Layer " << ii << ":" << layer << ":" << layer0
+                                  << " Copy " << copy << " Tiles " << firstTile << ":" << lastTile << " Size "
                                   << tileFineIndex_.size() << ":" << tileCoarseIndex_.size() << " Fine " << fine
                                   << " absType " << absType;
 #endif
@@ -713,18 +713,18 @@ void DDHGCalMixRotatedFineCassette::positionMix(const DDLogicalPart& glog,
       double phi2 = dphi * (fimax - fimin + 1);
       auto cshift = cassette_.getShift(layer0, -1, cassette, true);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "2Layer " << ii << ":" << copy << ":" << layer << ":" << layer0 << " Cassette " << cassette
-                                    << " shift " << cshift.first << ":" << cshift.second;
+      edm::LogVerbatim("HGCalGeom") << "2Layer " << ii << ":" << copy << ":" << layer << ":" << layer0 << " Cassette "
+                                    << cassette << " shift " << cshift.first << ":" << cshift.second;
       int cassette0 = HGCalCassette::cassetteType(2, 1, cassette);  //
       int ir1 = (fine) ? std::get<1>(HGCalTileIndex::tileUnpack(tileFineIndex_[ti]))
                        : std::get<1>(HGCalTileIndex::tileUnpack(tileCoarseIndex_[ti]));
       int ir2 = (fine) ? std::get<2>(HGCalTileIndex::tileUnpack(tileFineIndex_[ti]))
                        : std::get<2>(HGCalTileIndex::tileUnpack(tileCoarseIndex_[ti]));
-      edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: Layer " << copy << ":" << (layer + 1) << ":" << layer0 << " iR "
-                                    << ir1 << ":" << ir2 << " R " << r1 << ":" << r2 << " Thick " << (2.0 * hthickl)
-                                    << " phi " << fimin << ":" << fimax << ":" << convertRadToDeg(phi1) << ":"
-                                    << convertRadToDeg(phi2) << " cassette " << cassette << ":" << cassette0
-                                    << " Shift " << cshift.first << ":" << cshift.second;
+      edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: Layer " << copy << ":" << (layer + 1) << ":"
+                                    << layer0 << " iR " << ir1 << ":" << ir2 << " R " << r1 << ":" << r2 << " Thick "
+                                    << (2.0 * hthickl) << " phi " << fimin << ":" << fimax << ":"
+                                    << convertRadToDeg(phi1) << ":" << convertRadToDeg(phi2) << " cassette " << cassette
+                                    << ":" << cassette0 << " Shift " << cshift.first << ":" << cshift.second;
 #endif
       std::string name = namesTop_[ii] + "L" + std::to_string(copy) + "F" + std::to_string(k);
       ++k;
@@ -749,7 +749,8 @@ void DDHGCalMixRotatedFineCassette::positionMix(const DDLogicalPart& glog,
   int layer = (copyM - firstFineLayer_);
   int layer0 = (copyM - std::min(firstFineLayer_, firstCoarseLayer_) + 1);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: Start bottom section for layer " << (layer + 1) << ":" << layer0 << " absType " << absType;
+  edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: Start bottom section for layer " << (layer + 1)
+                                << ":" << layer0 << " absType " << absType;
 #endif
   if (absType > 0) {
 #ifdef EDM_ML_DEBUG
@@ -759,7 +760,8 @@ void DDHGCalMixRotatedFineCassette::positionMix(const DDLogicalPart& glog,
       int cassette = k + 1;
       auto cshift = cassette_.getShift(layer0, -1, cassette);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "3Layer " << layer << ":" << layer0 << " Cassette " << cassette << " shift " << cshift.first << ":" << cshift.second;
+      edm::LogVerbatim("HGCalGeom") << "3Layer " << layer << ":" << layer0 << " Cassette " << cassette << " shift "
+                                    << cshift.first << ":" << cshift.second;
 #endif
       double xpos = -cshift.first;
       double ypos = cshift.second;
@@ -830,7 +832,8 @@ void DDHGCalMixRotatedFineCassette::positionMix(const DDLogicalPart& glog,
 #endif
       auto cshift = cassette_.getShift(layer0, -1, cassette, false);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "Layer " << (layer + 1) << ":" << layer0 << " Cassette " << cassette << " shift " << cshift.first << ":"  << cshift.second;
+      edm::LogVerbatim("HGCalGeom") << "Layer " << (layer + 1) << ":" << layer0 << " Cassette " << cassette << " shift "
+                                    << cshift.first << ":" << cshift.second;
 #endif
       double xpos = xyoff.first - cshift.first + nc * delx;
       double ypos = xyoff.second + cshift.second + nr * dy;
@@ -838,10 +841,10 @@ void DDHGCalMixRotatedFineCassette::positionMix(const DDLogicalPart& glog,
       double xorig = xyoff.first + nc * delx;
       double yorig = xyoff.second + nr * dy;
       double angle = std::atan2(yorig, xorig);
-      edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette::Wafer: layer " << layer + 1 << ":" << layer0 << " cassette "
-                                    << cassette << " Shift " << cshift.first << ":" << cshift.second << " Original "
-                                    << xorig << ":" << yorig << ":" << convertRadToDeg(angle) << " Final " << xpos
-                                    << ":" << ypos;
+      edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette::Wafer: layer " << layer + 1 << ":" << layer0
+                                    << " cassette " << cassette << " Shift " << cshift.first << ":" << cshift.second
+                                    << " Original " << xorig << ":" << yorig << ":" << convertRadToDeg(angle)
+                                    << " Final " << xpos << ":" << ypos;
 #endif
       std::string wafer;
       int i(999);

--- a/Geometry/HGCalCommonData/src/HGCalCassette.cc
+++ b/Geometry/HGCalCommonData/src/HGCalCassette.cc
@@ -98,11 +98,13 @@ std::pair<double, double> HGCalCassette::getShiftScnt(int layer, int zside, doub
   int loc = (layer - 1);
   double fac = (zside < 0) ? 1.0 : -1.0;
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HGCalGeom") << "HGCalCassette::getShiftScnt: layer|zside|phi " << layer << ":" << zside << ":" << phi << " loc " << loc << " size " << retractScnt_.size();
+  edm::LogVerbatim("HGCalGeom") << "HGCalCassette::getShiftScnt: layer|zside|phi " << layer << ":" << zside << ":"
+                                << phi << " loc " << loc << " size " << retractScnt_.size();
 #endif
   std::pair<double, double> xy = std::make_pair(fac * retractScnt_[loc] * cos(phi), retractScnt_[loc] * sin(phi));
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HGCalGeom") << "HGCalCassette::getShiftScnt: Layer " << layer << " zside " << zside << " Loc " << loc << " fac " << fac << " shift " << xy.first << ":" << xy.second;
+  edm::LogVerbatim("HGCalGeom") << "HGCalCassette::getShiftScnt: Layer " << layer << " zside " << zside << " Loc "
+                                << loc << " fac " << fac << " shift " << xy.first << ":" << xy.second;
 #endif
   return xy;
 }

--- a/Geometry/HGCalCommonData/src/HGCalCassette.cc
+++ b/Geometry/HGCalCommonData/src/HGCalCassette.cc
@@ -39,7 +39,6 @@ void HGCalCassette::setParameter(int cassette, const std::vector<double>& shifts
 }
 
 void HGCalCassette::setParameterScint(const std::vector<double>& shifts) {
-  //  shifts_.insert(shifts_.end(), shifts.begin(), shifts.end());
   shiftsScnt_.insert(shiftsScnt_.end(), shifts.begin(), shifts.end());
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HGCalGeom") << "HGCalCassette::setParameterScint with Size " << shifts.size();
@@ -49,6 +48,25 @@ void HGCalCassette::setParameterScint(const std::vector<double>& shifts) {
       st1 << " ShiftsScnt:";
     } else {
       st1 << "            ";
+    }
+    uint32_t j2 = std::min((j1 + 12), static_cast<uint32_t>(shifts.size()));
+    for (uint32_t j = j1; j < j2; ++j)
+      st1 << ":" << shifts[j];
+    edm::LogVerbatim("HGCalGeom") << st1.str();
+  }
+#endif
+}
+
+void HGCalCassette::setParameterRetract(const std::vector<double>& shifts) {
+  retractScnt_.insert(retractScnt_.end(), shifts.begin(), shifts.end());
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HGCalGeom") << "HGCalCassette::setParameterRetract with Size " << shifts.size();
+  for (uint32_t j1 = 0; j1 < shifts.size(); j1 += 12) {
+    std::ostringstream st1;
+    if (j1 == 0) {
+      st1 << " RetractScnt:";
+    } else {
+      st1 << "             ";
     }
     uint32_t j2 = std::min((j1 + 12), static_cast<uint32_t>(shifts.size()));
     for (uint32_t j = j1; j < j2; ++j)
@@ -72,6 +90,19 @@ std::pair<double, double> HGCalCassette::getShift(int layer, int zside, int cass
   edm::LogVerbatim("HGCalGeom") << "HGCalCassette::getShift: Layer " << layer << " zside " << zside << " type "
                                 << typeHE_ << " cassette " << cassette << " Loc " << locc << ":" << loc << " shift "
                                 << xy.first << ":" << xy.second;
+#endif
+  return xy;
+}
+
+std::pair<double, double> HGCalCassette::getShiftScnt(int layer, int zside, double phi) const {
+  int loc = (layer - 1);
+  double fac = (zside < 0) ? 1.0 : -1.0;
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HGCalGeom") << "HGCalCassette::getShiftScnt: layer|zside|phi " << layer << ":" << zside << ":" << phi << " loc " << loc << " size " << retractScnt_.size();
+#endif
+  std::pair<double, double> xy = std::make_pair(fac * retractScnt_[loc] * cos(phi), retractScnt_[loc] * sin(phi));
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HGCalGeom") << "HGCalCassette::getShiftScnt: Layer " << layer << " zside " << zside << " Loc " << loc << " fac " << fac << " shift " << xy.first << ":" << xy.second;
 #endif
   return xy;
 }

--- a/Geometry/HGCalCommonData/src/HGCalCassette.cc
+++ b/Geometry/HGCalCommonData/src/HGCalCassette.cc
@@ -9,7 +9,7 @@ void HGCalCassette::setParameter(int cassette, const std::vector<double>& shifts
   cassette_ = cassette;
   typeHE_ = (cassette_ >= 12);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HGCalGeom") << "HGCalCassette::setParameter Cassette" << cassette << " Both " << both << " Size "
+  edm::LogVerbatim("HGCalGeom") << "HGCalCassette::setParameter Cassette " << cassette << " Both " << both << " Size "
                                 << shifts.size();
 #endif
   shifts_.insert(shifts_.end(), shifts.begin(), shifts.end());
@@ -26,7 +26,7 @@ void HGCalCassette::setParameter(int cassette, const std::vector<double>& shifts
         st1 << " Shifts:";
     } else {
       if (both)
-        st1 << "                  ";
+        st1 << "                   ";
       else
         st1 << "        ";
     }
@@ -42,6 +42,7 @@ void HGCalCassette::setParameterScint(const std::vector<double>& shifts) {
   //  shifts_.insert(shifts_.end(), shifts.begin(), shifts.end());
   shiftsScnt_.insert(shiftsScnt_.end(), shifts.begin(), shifts.end());
 #ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HGCalGeom") << "HGCalCassette::setParameterScint with Size " << shifts.size();
   for (uint32_t j1 = 0; j1 < shifts.size(); j1 += 12) {
     std::ostringstream st1;
     if (j1 == 0) {


### PR DESCRIPTION
#### PR description:

Correct the cassette shift for the scintillator tiles in HGCal V19 geometry

#### PR validation:

Tested using the built-in testing code of DDHGCalMixRotatedFineCassette

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special