### PR TITLE
14_1_X Backport: Make ReserveDMu skim throw exception upon mismatch in requested trigg…

### DIFF
--- a/Configuration/Skimming/python/PDWG_ReserveDMu_SD_cff.py
+++ b/Configuration/Skimming/python/PDWG_ReserveDMu_SD_cff.py
@@ -10,5 +10,4 @@ ReserveDMu.eventSetupPathsKey = 'ReserveDMu'                # Dataset-specific k
 ReserveDMu.andOr = cms.bool( True )
 # we want to intentionally throw and exception
 # in case it does not match one of the HLT Paths
-# set to False now, switch to on once matrix is updated
 ReserveDMu.throw = cms.bool( True )

--- a/Configuration/Skimming/python/PDWG_ReserveDMu_SD_cff.py
+++ b/Configuration/Skimming/python/PDWG_ReserveDMu_SD_cff.py
@@ -11,4 +11,4 @@ ReserveDMu.andOr = cms.bool( True )
 # we want to intentionally throw and exception
 # in case it does not match one of the HLT Paths
 # set to False now, switch to on once matrix is updated
-ReserveDMu.throw = cms.bool( False )
+ReserveDMu.throw = cms.bool( True )


### PR DESCRIPTION
The ongoing raw skims development, which is described in PR https://github.com/cms-sw/cmssw/pull/47525 uses the ReserveDMu skim that was previously available. The skim is not throwing exception when the corresponding Global Tag has mismatches in the requested triggers, so when using such problematic GT in replay we see empty output files. We must make sure that we get paused jobs to prevent trash data from being produced. The change in this PR aims to ensure we get paused jobs and have the ability to retry the jobs and get the desired output data.


The dummy GT was provided by AlCa, details available in [cms-talk](https://cms-talk.web.cern.ch/t/request-for-buggy-global-tag-for-deeper-testing-on-the-raw-skim-development-at-t0/122072/4). Such global tag was tested on the repacking of stream `ParkingDoubleMuonLowMass0` and we see all output files with 0 events.

This is a backport to CMSSW_14_1_X for complete availability of the new feature in the releases it already exists in. The respective Master PR is: https://github.com/cms-sw/cmssw/pull/47813