### PR TITLE
[CMSSW_15_0_X] Update autoCond for the first L1T menu of 2025

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -102,11 +102,11 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2024 detector for ppRef5TeV
     'phase1_2024_realistic_ppRef5TeV' : '141X_mcRun3_2024_realistic_ppRef5TeV_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2025
-    'phase1_2025_design'           :    '142X_mcRun3_2025_design_v1',
+    'phase1_2025_design'           :    '150X_mcRun3_2025_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2025
-    'phase1_2025_realistic'        :    '142X_mcRun3_2025_realistic_v7',
+    'phase1_2025_realistic'        :    '150X_mcRun3_2025_realistic_v1',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2024, Strip tracker in DECO mode
-    'phase1_2025_cosmics'          :    '142X_mcRun3_2025cosmics_realistic_deco_v1',
+    'phase1_2025_cosmics'          :    '150X_mcRun3_2025cosmics_realistic_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             :    '150X_mcRun4_realistic_v1'
 }

--- a/Configuration/AlCa/python/autoCondModifiers.py
+++ b/Configuration/AlCa/python/autoCondModifiers.py
@@ -115,7 +115,7 @@ def autoCondRelValForRun3(autoCond):
 
     GlobalTagRelValForRun3 = {}
     L1GtTriggerMenuForRelValForRun3 =    ','.join( ['L1Menu_Collisions2015_25nsStage1_v5' , "L1GtTriggerMenuRcd",             connectionString, "", "2023-01-28 12:00:00.000"] )
-    L1TUtmTriggerMenuForRelValForRun3 =  ','.join( ['L1Menu_Collisions2024_v1_3_0_xml'    , "L1TUtmTriggerMenuRcd",           connectionString, "", "2024-07-03 12:00:00.000"] )
+    L1TUtmTriggerMenuForRelValForRun3 =  ','.join( ['L1Menu_Collisions2025_v1_0_0_xml'    , "L1TUtmTriggerMenuRcd",           connectionString, "", "2025-04-08 12:00:00.000"] )
 
     for key,val in autoCond.items():
         if 'run3_data' in key or 'run3_hlt' in key :


### PR DESCRIPTION
#### PR description:

New GTs in 150X which include the first L1T menu prepared for the 2025 data taking, as in https://cms-talk.web.cern.ch/t/gt-mc-data-relval-update-of-the-gt-with-the-2025-l1t-menu-tag-l1menu-collisions2025-v1-0-0-xml/122657

The following GTs have been updated in autoCond.py:

- 'phase1_2025_design'   :   [150X_mcRun3_2025_design_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/150X_mcRun3_2025_design_v1)
  - Same as 142X_mcRun3_2025_design_v1, with the first L1T menu for 2025 as from https://cms-talk.web.cern.ch/t/gt-mc-data-relval-update-of-the-gt-with-the-2025-l1t-menu-tag-l1menu-collisions2025-v1-0-0-xml/122657
  - Diff wrt previous 142X_mcRun3_2025_design_v1 is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/150X_mcRun3_2025_design_v1/142X_mcRun3_2025_design_v1)

- 'phase1_2025_realistic'   :   [150X_mcRun3_2025_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/150X_mcRun3_2025_realistic_v1)
  - Same as 142X_mcRun3_2025_realistic_v7, with the first L1T menu for 2025 as from https://cms-talk.web.cern.ch/t/gt-mc-data-relval-update-of-the-gt-with-the-2025-l1t-menu-tag-l1menu-collisions2025-v1-0-0-xml/122657
  - Diff wrt previous 142X_mcRun3_2025_design_v1 is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/150X_mcRun3_2025_realistic_v1/142X_mcRun3_2025_realistic_v7)

- 'phase1_2025_cosmics'   :   [150X_mcRun3_2025cosmics_realistic_deco_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/150X_mcRun3_2025cosmics_realistic_deco_v1)
  - Same as 142X_mcRun3_2025cosmics_realistic_deco_v1, with the first L1T menu for 2025 as from https://cms-talk.web.cern.ch/t/gt-mc-data-relval-update-of-the-gt-with-the-2025-l1t-menu-tag-l1menu-collisions2025-v1-0-0-xml/122657
  - Diff wrt previous 142X_mcRun3_2025cosmics_realistic_deco_v1 is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/150X_mcRun3_2025cosmics_realistic_deco_v1/142X_mcRun3_2025cosmics_realistic_deco_v1)


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport in CMSSW_15_0_X of #47817

