### PR TITLE
[FULLSIM] Split Geant4 user actions between Run2,3 and Run4

### DIFF
--- a/SimG4Core/Application/interface/CMSSimEventManager.h
+++ b/SimG4Core/Application/interface/CMSSimEventManager.h
@@ -18,9 +18,9 @@ namespace edm {
 }
 
 class G4Event;
-class EventAction;
-class StackingAction;
-class TrackingAction;
+class G4UserEventAction;
+class G4UserStackingAction;
+class G4UserTrackingAction;
 class G4UserSteppingAction;
 class G4SDManager;
 class G4StateManager;
@@ -41,9 +41,9 @@ public:
   // This method aborts the processing of the current event.
   void AbortCurrentEvent();
 
-  void SetUserAction(EventAction* ptr);
-  void SetUserAction(StackingAction* ptr);
-  void SetUserAction(TrackingAction* ptr);
+  void SetUserAction(G4UserEventAction* ptr);
+  void SetUserAction(G4UserStackingAction* ptr);
+  void SetUserAction(G4UserTrackingAction* ptr);
   void SetUserAction(G4UserSteppingAction* ptr);
 
   CMSSimEventManager(const CMSSimEventManager& right) = delete;
@@ -58,9 +58,9 @@ private:
   G4PrimaryTransformer* m_primaryTransformer;
   G4Navigator* m_navigator;
 
-  EventAction* m_eventAction;
-  StackingAction* m_stackingAction;
-  TrackingAction* m_trackingAction;
+  G4UserEventAction* m_eventAction;
+  G4UserTrackingAction* m_trackingAction;
+  G4UserStackingAction* m_stackingAction;
 
   G4int trackID_{0};
   G4int verbose_;

--- a/SimG4Core/Application/interface/Phase2EventAction.h
+++ b/SimG4Core/Application/interface/Phase2EventAction.h
@@ -1,0 +1,57 @@
+#ifndef SimG4Core_Phase2EventAction_H
+#define SimG4Core_Phase2EventAction_H
+//
+// Package:     Application
+// Class  :     Phase2EventAction
+//
+// Description: Manage MC truth 
+// Created:     08.04.2025 V.Ivantchenko
+//
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "SimG4Core/Notification/interface/SimTrackManager.h"
+#include "SimG4Core/Notification/interface/TrackWithHistory.h"
+#include "SimG4Core/Notification/interface/TrackContainer.h"
+#include "SimG4Core/Notification/interface/SimActivityRegistry.h"
+
+#include "G4UserEventAction.hh"
+
+#include <vector>
+#include <string>
+
+class SimRunInterface;
+class BeginOfEvent;
+class EndOfEvent;
+class CMSSteppingVerbose;
+
+class Phase2EventAction : public G4UserEventAction {
+public:
+  explicit Phase2EventAction(const edm::ParameterSet& ps, SimRunInterface*, SimTrackManager*, CMSSteppingVerbose*);
+  ~Phase2EventAction() override = default;
+
+  void BeginOfEventAction(const G4Event* evt) override;
+  void EndOfEventAction(const G4Event* evt) override;
+
+  void abortEvent();
+
+  const TrackContainer* trackContainer() const { return m_trackManager->trackContainer(); }
+
+  TrackWithHistory* getTrackByID(int id) const { return m_trackManager->getTrackByID(id); }
+
+  SimActivityRegistry::BeginOfEventSignal m_beginOfEventSignal;
+  SimActivityRegistry::EndOfEventSignal m_endOfEventSignal;
+
+  Phase2EventAction(const Phase2EventAction&) = delete;
+  const Phase2EventAction& operator=(const Phase2EventAction&) = delete;
+  
+private:
+  SimRunInterface* m_runInterface;
+  SimTrackManager* m_trackManager;
+  CMSSteppingVerbose* m_SteppingVerbose;
+  std::string m_stopFile;
+  bool m_printRandom;
+  bool m_debug;
+};
+
+#endif

--- a/SimG4Core/Application/interface/Phase2EventAction.h
+++ b/SimG4Core/Application/interface/Phase2EventAction.h
@@ -4,7 +4,7 @@
 // Package:     Application
 // Class  :     Phase2EventAction
 //
-// Description: Manage MC truth 
+// Description: Manage MC truth
 // Created:     08.04.2025 V.Ivantchenko
 //
 
@@ -44,7 +44,7 @@ public:
 
   Phase2EventAction(const Phase2EventAction&) = delete;
   const Phase2EventAction& operator=(const Phase2EventAction&) = delete;
-  
+
 private:
   SimRunInterface* m_runInterface;
   SimTrackManager* m_trackManager;

--- a/SimG4Core/Application/interface/Phase2TrackingAction.h
+++ b/SimG4Core/Application/interface/Phase2TrackingAction.h
@@ -4,7 +4,7 @@
 // Package:     Application
 // Class  :     Phase2TrackingAction
 //
-// Description: Manage tracks 
+// Description: Manage tracks
 // Created:     08.04.2025 V.Ivantchenko
 //
 

--- a/SimG4Core/Application/interface/Phase2TrackingAction.h
+++ b/SimG4Core/Application/interface/Phase2TrackingAction.h
@@ -1,0 +1,61 @@
+#ifndef SimG4Core_Phase2TrackingAction_H
+#define SimG4Core_Phase2TrackingAction_H
+//
+// Package:     Application
+// Class  :     Phase2TrackingAction
+//
+// Description: Manage tracks 
+// Created:     08.04.2025 V.Ivantchenko
+//
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "SimG4Core/Notification/interface/SimActivityRegistry.h"
+
+#include "G4UserTrackingAction.hh"
+#include "G4Region.hh"
+
+#include <vector>
+
+class SimTrackManager;
+class CMSG4TrackInterface;
+class TrackWithHistory;
+class BeginOfTrack;
+class EndOfTrack;
+class CMSSteppingVerbose;
+class TrackInformation;
+
+class Phase2TrackingAction : public G4UserTrackingAction {
+public:
+  explicit Phase2TrackingAction(SimTrackManager*, CMSSteppingVerbose*, const edm::ParameterSet& ps);
+  ~Phase2TrackingAction() override = default;
+
+  void PreUserTrackingAction(const G4Track* aTrack) override;
+  void PostUserTrackingAction(const G4Track* aTrack) override;
+
+  inline TrackWithHistory* currentTrackWithHistory() { return currentTrack_; }
+  inline const G4Track* geant4Track() const { return g4Track_; }
+  inline G4TrackingManager* getTrackManager() { return fpTrackingManager; }
+
+  SimActivityRegistry::BeginOfTrackSignal m_beginOfTrackSignal;
+  SimActivityRegistry::EndOfTrackSignal m_endOfTrackSignal;
+
+  Phase2TrackingAction(Phase2TrackingAction&) = delete;
+  Phase2TrackingAction& operator=(const Phase2TrackingAction& right) = delete;
+
+private:
+  SimTrackManager* trackManager_;
+  CMSG4TrackInterface* trackInterface_;
+  CMSSteppingVerbose* steppingVerbose_;
+  const G4Track* g4Track_ = nullptr;
+  TrackInformation* trkInfo_ = nullptr;
+  TrackWithHistory* currentTrack_ = nullptr;
+  int endPrintTrackID_;
+  bool checkTrack_;
+  bool doFineCalo_;
+  bool saveCaloBoundaryInformation_;
+  double ekinMin_;
+  std::vector<double> ekinMinRegion_;
+  std::vector<G4Region*> ptrRegion_;
+};
+
+#endif

--- a/SimG4Core/Application/interface/RunManagerMTWorker.h
+++ b/SimG4Core/Application/interface/RunManagerMTWorker.h
@@ -36,7 +36,9 @@ class CustomUIsession;
 
 class RunAction;
 class EventAction;
+class Phase2EventAction;
 class TrackingAction;
+class Phase2TrackingAction;
 class SteppingAction;
 class Phase2SteppingAction;
 class CMSSteppingVerbose;
@@ -65,7 +67,9 @@ public:
 
   void Connect(RunAction*);
   void Connect(EventAction*);
+  void Connect(Phase2EventAction*);
   void Connect(TrackingAction*);
+  void Connect(Phase2TrackingAction*);
   void Connect(SteppingAction*);
   void Connect(Phase2SteppingAction*);
 

--- a/SimG4Core/Application/interface/StackingAction.h
+++ b/SimG4Core/Application/interface/StackingAction.h
@@ -14,10 +14,11 @@
 class TrackingAction;
 class CMSSteppingVerbose;
 class G4VProcess;
+class CMSG4TrackInterface;
 
 class StackingAction : public G4UserStackingAction {
 public:
-  explicit StackingAction(const TrackingAction*, const edm::ParameterSet& ps, const CMSSteppingVerbose*);
+  explicit StackingAction(const edm::ParameterSet& ps, const CMSSteppingVerbose*);
 
   ~StackingAction() override = default;
 
@@ -69,7 +70,7 @@ private:
   std::vector<const G4Region*> deadRegions;
 
   G4VSolid* worldSolid;
-  const TrackingAction* trackAction;
+  CMSG4TrackInterface* m_trackInterface;
   const CMSSteppingVerbose* steppingVerbose;
   const G4VProcess* m_Compton{nullptr};
 

--- a/SimG4Core/Application/src/CMSSimEventManager.cc
+++ b/SimG4Core/Application/src/CMSSimEventManager.cc
@@ -1,8 +1,5 @@
 #include "SimG4Core/Application/interface/CMSSimEventManager.h"
 #include "SimG4Core/Application/interface/RunAction.h"
-#include "SimG4Core/Application/interface/EventAction.h"
-#include "SimG4Core/Application/interface/StackingAction.h"
-#include "SimG4Core/Application/interface/TrackingAction.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -13,7 +10,10 @@
 #include "G4PrimaryTransformer.hh"
 #include "G4TrackingManager.hh"
 #include "G4TrackStatus.hh"
+#include "G4UserEventAction.hh"
+#include "G4UserTrackingAction.hh"
 #include "G4UserSteppingAction.hh"
+#include "G4UserStackingAction.hh"
 
 #include "G4SDManager.hh"
 #include "G4StateManager.hh"
@@ -98,13 +98,13 @@ void CMSSimEventManager::StackTracks(G4TrackVector* trackVector, bool IDisSet) {
   trackVector->clear();
 }
 
-void CMSSimEventManager::SetUserAction(EventAction* ptr) { m_eventAction = ptr; }
+void CMSSimEventManager::SetUserAction(G4UserEventAction* ptr) { m_eventAction = ptr; }
 
-void CMSSimEventManager::SetUserAction(StackingAction* ptr) { m_stackingAction = ptr; }
+void CMSSimEventManager::SetUserAction(G4UserStackingAction* ptr) { m_stackingAction = ptr; }
 
-void CMSSimEventManager::SetUserAction(TrackingAction* ptr) {
+void CMSSimEventManager::SetUserAction(G4UserTrackingAction* ptr) {
   m_trackingAction = ptr;
-  m_defTrackManager->SetUserAction((G4UserTrackingAction*)ptr);
+  m_defTrackManager->SetUserAction(ptr);
 }
 
 void CMSSimEventManager::SetUserAction(G4UserSteppingAction* ptr) { m_defTrackManager->SetUserAction(ptr); }

--- a/SimG4Core/Application/src/Phase2EventAction.cc
+++ b/SimG4Core/Application/src/Phase2EventAction.cc
@@ -1,0 +1,65 @@
+#include "SimG4Core/Application/interface/Phase2EventAction.h"
+#include "SimG4Core/Application/interface/SimRunInterface.h"
+#include "SimG4Core/Notification/interface/TmpSimEvent.h"
+#include "SimG4Core/Notification/interface/TmpSimVertex.h"
+#include "SimG4Core/Notification/interface/BeginOfEvent.h"
+#include "SimG4Core/Notification/interface/EndOfEvent.h"
+#include "SimG4Core/Notification/interface/CMSSteppingVerbose.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "Randomize.hh"
+
+Phase2EventAction::Phase2EventAction(const edm::ParameterSet& p,
+                                     SimRunInterface* rm,
+                                     SimTrackManager* iManager,
+                                     CMSSteppingVerbose* sv)
+    : m_runInterface(rm),
+      m_trackManager(iManager),
+      m_SteppingVerbose(sv),
+      m_stopFile(p.getParameter<std::string>("StopFile")),
+      m_printRandom(p.getParameter<bool>("PrintRandomSeed")),
+      m_debug(p.getUntrackedParameter<bool>("debug", false)) {}
+
+void Phase2EventAction::BeginOfEventAction(const G4Event* anEvent) {
+  BeginOfEvent e(anEvent);
+  m_beginOfEventSignal(&e);
+
+  if (m_printRandom) {
+    edm::LogVerbatim("SimG4CoreApplication")
+        << "BeginOfEvent " << anEvent->GetEventID() << " Random number: " << G4UniformRand();
+  }
+
+  if (nullptr != m_SteppingVerbose) {
+    m_SteppingVerbose->beginOfEvent(anEvent);
+  }
+}
+
+void Phase2EventAction::EndOfEventAction(const G4Event* anEvent) {
+  if (m_printRandom) {
+    edm::LogVerbatim("SimG4CoreApplication")
+        << "Phase2EventAction::EndOfEventAction: " << anEvent->GetEventID() << " Random number: " << G4UniformRand();
+  }
+  if (!m_stopFile.empty() && std::ifstream(m_stopFile.c_str())) {
+    edm::LogWarning("SimG4CoreApplication")
+        << "Phase2EventAction::EndOfEventAction: termination signal received at event " << anEvent->GetEventID();
+    // soft abort run
+    m_runInterface->abortRun(true);
+  }
+  if (anEvent->GetNumberOfPrimaryVertex() == 0) {
+    edm::LogWarning("SimG4CoreApplication") << "Phase2EventACtion::EndOfEventAction: event " << anEvent->GetEventID()
+                                            << " must have failed (no G4PrimaryVertices found) and will be skipped";
+    return;
+  }
+
+  m_trackManager->storeTracks();
+
+  // dispatch now end of event
+  EndOfEvent e(anEvent);
+  m_endOfEventSignal(&e);
+
+  // delete transient objects
+  m_trackManager->reset();
+}
+
+void Phase2EventAction::abortEvent() { m_runInterface->abortEvent(); }

--- a/SimG4Core/Application/src/Phase2TrackingAction.cc
+++ b/SimG4Core/Application/src/Phase2TrackingAction.cc
@@ -16,8 +16,7 @@
 
 //#define EDM_ML_DEBUG
 
-Phase2TrackingAction::Phase2TrackingAction(SimTrackManager* stm,
-					   CMSSteppingVerbose* sv, const edm::ParameterSet& p)
+Phase2TrackingAction::Phase2TrackingAction(SimTrackManager* stm, CMSSteppingVerbose* sv, const edm::ParameterSet& p)
     : trackManager_(stm),
       steppingVerbose_(sv),
       endPrintTrackID_(p.getParameter<int>("EndPrintTrackID")),
@@ -31,9 +30,8 @@ Phase2TrackingAction::Phase2TrackingAction(SimTrackManager* stm,
   if (doFineCalo_ && eth < ekinMin_) {
     ekinMin_ = eth;
   }
-  edm::LogVerbatim("SimG4CoreApplication")
-      << "Phase2TrackingAction: boundary: " << saveCaloBoundaryInformation_
-      << "; DoFineCalo: " << doFineCalo_ << "; ekinMin(MeV)=" << ekinMin_;
+  edm::LogVerbatim("SimG4CoreApplication") << "Phase2TrackingAction: boundary: " << saveCaloBoundaryInformation_
+                                           << "; DoFineCalo: " << doFineCalo_ << "; ekinMin(MeV)=" << ekinMin_;
   if (!ekinMinRegion_.empty()) {
     ptrRegion_.resize(ekinMinRegion_.size(), nullptr);
   }
@@ -84,8 +82,7 @@ void Phase2TrackingAction::PostUserTrackingAction(const G4Track* aTrack) {
   int id = aTrack->GetTrackID();
   bool ok = (trkInfo_->storeTrack() || currentTrack_->saved());
   if (trkInfo_->crossedBoundary()) {
-    currentTrack_->setCrossedBoundaryPosMom(id, trkInfo_->getPositionAtBoundary(),
-					    trkInfo_->getMomentumAtBoundary());
+    currentTrack_->setCrossedBoundaryPosMom(id, trkInfo_->getPositionAtBoundary(), trkInfo_->getMomentumAtBoundary());
     ok = (ok || saveCaloBoundaryInformation_ || doFineCalo_);
   }
   if (ok) {
@@ -99,9 +96,8 @@ void Phase2TrackingAction::PostUserTrackingAction(const G4Track* aTrack) {
 
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("Phase2TrackingAction")
-      << "Phase2TrackingAction end track=" << id << "  "
-      << aTrack->GetDefinition()->GetParticleName() << " proposed to be saved= " << ok
-      << " end point " << aTrack->GetPosition();
+      << "Phase2TrackingAction end track=" << id << "  " << aTrack->GetDefinition()->GetParticleName()
+      << " proposed to be saved= " << ok << " end point " << aTrack->GetPosition();
 #endif
 
   if (!isInHistory) {

--- a/SimG4Core/Application/src/RunManagerMT.cc
+++ b/SimG4Core/Application/src/RunManagerMT.cc
@@ -299,7 +299,7 @@ void RunManagerMT::terminateRun() {
 
 void RunManagerMT::checkVoxels() {
   const G4LogicalVolumeStore* lvs = G4LogicalVolumeStore::GetInstance();
-  int numLV = lvs->size();
+  int numLV = (int)lvs->size();
   edm::LogVerbatim("SimG4CoreApplication") << "RunManagerMT: nLV=" << numLV;
   int nvox = 0;
   int nslice = 0;
@@ -309,7 +309,7 @@ void RunManagerMT::checkVoxels() {
     auto vox = lv->GetVoxelHeader();
     auto sma = lv->GetSmartless();
     auto reg = lv->GetRegion();
-    size_t nsl = (nullptr == vox) ? 0 : vox->GetNoSlices();
+    std::size_t nsl = (nullptr == vox) ? 0 : vox->GetNoSlices();
     if (0 < nsl) {
       nslice += nsl;
       std::string rname = (nullptr != reg) ? reg->GetName() : "";

--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -439,15 +439,14 @@ void RunManagerMTWorker::initializeUserActions() {
   // different event actions for Run2,3 and Phase2
   G4UserEventAction* userEventAction;
   if (m_isPhase2) {
-    auto ptr = new Phase2EventAction(m_pEventAction, m_tls->runInterface.get(),
-				     m_tls->trackManager.get(), m_sVerbose.get());
+    auto ptr =
+        new Phase2EventAction(m_pEventAction, m_tls->runInterface.get(), m_tls->trackManager.get(), m_sVerbose.get());
     Connect(ptr);
-    userEventAction = (G4UserEventAction*)ptr; 
+    userEventAction = (G4UserEventAction*)ptr;
   } else {
-    auto ptr = new EventAction(m_pEventAction, m_tls->runInterface.get(),
-			       m_tls->trackManager.get(), m_sVerbose.get());
+    auto ptr = new EventAction(m_pEventAction, m_tls->runInterface.get(), m_tls->trackManager.get(), m_sVerbose.get());
     Connect(ptr);
-    userEventAction = (G4UserEventAction*)ptr; 
+    userEventAction = (G4UserEventAction*)ptr;
   }
 
   // different tracking actions for Run2,3 and Phase2
@@ -455,11 +454,11 @@ void RunManagerMTWorker::initializeUserActions() {
   if (m_isPhase2) {
     auto ptr = new Phase2TrackingAction(m_tls->trackManager.get(), m_sVerbose.get(), m_pTrackingAction);
     Connect(ptr);
-    userTrackingAction = (G4UserTrackingAction*)ptr; 
+    userTrackingAction = (G4UserTrackingAction*)ptr;
   } else {
     auto ptr = new TrackingAction(m_tls->trackManager.get(), m_sVerbose.get(), m_pTrackingAction);
     Connect(ptr);
-    userTrackingAction = (G4UserTrackingAction*)ptr; 
+    userTrackingAction = (G4UserTrackingAction*)ptr;
   }
 
   // different stepping actions for Run2,3 and Phase2

--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -3,8 +3,10 @@
 #include "SimG4Core/Application/interface/SimRunInterface.h"
 #include "SimG4Core/Application/interface/RunAction.h"
 #include "SimG4Core/Application/interface/EventAction.h"
+#include "SimG4Core/Application/interface/Phase2EventAction.h"
 #include "SimG4Core/Application/interface/StackingAction.h"
 #include "SimG4Core/Application/interface/TrackingAction.h"
+#include "SimG4Core/Application/interface/Phase2TrackingAction.h"
 #include "SimG4Core/Application/interface/SteppingAction.h"
 #include "SimG4Core/Application/interface/Phase2SteppingAction.h"
 #include "SimG4Core/Application/interface/CMSSimEventManager.h"
@@ -12,8 +14,8 @@
 #include "SimG4Core/Application/interface/CustomUIsessionToFile.h"
 #include "SimG4Core/Application/interface/ExceptionHandler.h"
 #include "SimG4Core/Application/interface/CMSGDMLWriteStructure.h"
-#include "SimG4Core/Physics/interface/CMSG4TrackInterface.h"
 
+#include "SimG4Core/Physics/interface/CMSG4TrackInterface.h"
 #include "SimG4Core/Geometry/interface/CustomUIsession.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -310,13 +312,16 @@ void RunManagerMTWorker::initializeG4(RunManagerMT* runManagerMaster, const edm:
   G4TransportationManager* tM = G4TransportationManager::GetTransportationManager();
   tM->SetWorldForTracking(worldPV);
 
+  // flag of Phase2
+  m_isPhase2 = runManagerMaster->isPhase2();
+
   // we need the track manager now
   int verbose = m_p.getParameter<int>("EventVerbose");
   m_tls->trackManager = std::make_unique<SimTrackManager>(&m_simEvent, verbose);
 
   // setup the magnetic field
   if (m_pUseMagneticField) {
-    const GlobalPoint g(0.f, 0.f, 0.f);
+    const GlobalPoint gg(0.f, 0.f, 0.f);
 
     sim::FieldBuilder fieldBuilder(m_pMagField, m_pField);
 
@@ -373,7 +378,6 @@ void RunManagerMTWorker::initializeG4(RunManagerMT* runManagerMaster, const edm:
 
   // Set the physics list for the worker, share from master
   PhysicsList* physicsList = runManagerMaster->physicsListForWorker();
-  m_isPhase2 = runManagerMaster->isPhase2();
 
   edm::LogVerbatim("SimG4CoreApplication")
       << "RunManagerMTWorker::InitializeG4: start initialisation of PhysicsList for the thread " << thisID;
@@ -432,21 +436,30 @@ void RunManagerMTWorker::initializeUserActions() {
   G4EventManager* eventManager = m_tls->kernel->GetEventManager();
   eventManager->SetVerboseLevel(ver);
 
-  auto userEventAction =
-      new EventAction(m_pEventAction, m_tls->runInterface.get(), m_tls->trackManager.get(), m_sVerbose.get());
-  Connect(userEventAction);
-  if (m_UseG4EventManager) {
-    eventManager->SetUserAction(userEventAction);
+  // different event actions for Run2,3 and Phase2
+  G4UserEventAction* userEventAction;
+  if (m_isPhase2) {
+    auto ptr = new Phase2EventAction(m_pEventAction, m_tls->runInterface.get(),
+				     m_tls->trackManager.get(), m_sVerbose.get());
+    Connect(ptr);
+    userEventAction = (G4UserEventAction*)ptr; 
   } else {
-    m_evtManager->SetUserAction(userEventAction);
+    auto ptr = new EventAction(m_pEventAction, m_tls->runInterface.get(),
+			       m_tls->trackManager.get(), m_sVerbose.get());
+    Connect(ptr);
+    userEventAction = (G4UserEventAction*)ptr; 
   }
 
-  auto userTrackingAction = new TrackingAction(m_tls->trackManager.get(), m_sVerbose.get(), m_pTrackingAction);
-  Connect(userTrackingAction);
-  if (m_UseG4EventManager) {
-    eventManager->SetUserAction(userTrackingAction);
+  // different tracking actions for Run2,3 and Phase2
+  G4UserTrackingAction* userTrackingAction;
+  if (m_isPhase2) {
+    auto ptr = new Phase2TrackingAction(m_tls->trackManager.get(), m_sVerbose.get(), m_pTrackingAction);
+    Connect(ptr);
+    userTrackingAction = (G4UserTrackingAction*)ptr; 
   } else {
-    m_evtManager->SetUserAction(userTrackingAction);
+    auto ptr = new TrackingAction(m_tls->trackManager.get(), m_sVerbose.get(), m_pTrackingAction);
+    Connect(ptr);
+    userTrackingAction = (G4UserTrackingAction*)ptr; 
   }
 
   // different stepping actions for Run2,3 and Phase2
@@ -461,16 +474,18 @@ void RunManagerMTWorker::initializeUserActions() {
     Connect(ptr);
     userSteppingAction = (G4UserSteppingAction*)ptr;
   }
-  if (m_UseG4EventManager) {
-    eventManager->SetUserAction(userSteppingAction);
-  } else {
-    m_evtManager->SetUserAction(userSteppingAction);
-  }
 
-  auto userStackingAction = new StackingAction(userTrackingAction, m_pStackingAction, m_sVerbose.get());
+  // staking actions and event manager
+  auto userStackingAction = new StackingAction(m_pStackingAction, m_sVerbose.get());
   if (m_UseG4EventManager) {
+    eventManager->SetUserAction(userEventAction);
+    eventManager->SetUserAction(userTrackingAction);
+    eventManager->SetUserAction(userSteppingAction);
     eventManager->SetUserAction(userStackingAction);
   } else {
+    m_evtManager->SetUserAction(userEventAction);
+    m_evtManager->SetUserAction(userTrackingAction);
+    m_evtManager->SetUserAction(userSteppingAction);
     m_evtManager->SetUserAction(userStackingAction);
   }
 }
@@ -485,7 +500,17 @@ void RunManagerMTWorker::Connect(EventAction* eventAction) {
   eventAction->m_endOfEventSignal.connect(m_tls->registry->endOfEventSignal_);
 }
 
+void RunManagerMTWorker::Connect(Phase2EventAction* eventAction) {
+  eventAction->m_beginOfEventSignal.connect(m_tls->registry->beginOfEventSignal_);
+  eventAction->m_endOfEventSignal.connect(m_tls->registry->endOfEventSignal_);
+}
+
 void RunManagerMTWorker::Connect(TrackingAction* trackingAction) {
+  trackingAction->m_beginOfTrackSignal.connect(m_tls->registry->beginOfTrackSignal_);
+  trackingAction->m_endOfTrackSignal.connect(m_tls->registry->endOfTrackSignal_);
+}
+
+void RunManagerMTWorker::Connect(Phase2TrackingAction* trackingAction) {
   trackingAction->m_beginOfTrackSignal.connect(m_tls->registry->beginOfTrackSignal_);
   trackingAction->m_endOfTrackSignal.connect(m_tls->registry->endOfTrackSignal_);
 }

--- a/SimG4Core/Application/src/StackingAction.cc
+++ b/SimG4Core/Application/src/StackingAction.cc
@@ -19,8 +19,7 @@
 #include "G4GammaGeneralProcess.hh"
 #include "G4LossTableManager.hh"
 
-StackingAction::StackingAction(const edm::ParameterSet& p, const CMSSteppingVerbose* sv)
-    : steppingVerbose(sv) {
+StackingAction::StackingAction(const edm::ParameterSet& p, const CMSSteppingVerbose* sv) : steppingVerbose(sv) {
   trackNeutrino = p.getParameter<bool>("TrackNeutrino");
   killHeavy = p.getParameter<bool>("KillHeavy");
   killGamma = p.getParameter<bool>("KillGamma");


### PR DESCRIPTION
#### PR description:
Phase2 developments for FullSim required modification of methods how to store MC truth. In the case of usage of GPU accelerators tracks will be processes independently, so old approach for MC cannot function properly. In order to provide a possibility of Phase2 developments without touch of Run2,3 MC truth it is needed split Geant4 user actions.

It is expected to have full regression in all WFs.

#### PR validation:
private

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for: NO

