### PR TITLE
Add transactionId as optional parameter of CondDBESSource

### DIFF
--- a/CondCore/ESSources/plugins/CondDBESSource.cc
+++ b/CondCore/ESSources/plugins/CondDBESSource.cc
@@ -759,6 +759,10 @@ void CondDBESSource::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   dbParams.addUntracked<std::string>("security", "");
   dbParams.addUntracked<int>("messageLevel", 0);
   dbParams.addUntracked<int>("connectionTimeout", 0);
+  dbParams.addObsoleteUntracked<std::string>("transactionId")
+      ->setComment(
+          "This parameter is not strictly needed by PoolDBESSource, but the WMCore infrastructure requires it. "
+          "Candidate for deletion");
   desc.add("DBParameters", dbParams);
 
   desc.add<std::string>("connect", std::string("frontier://FrontierProd/CMS_CONDITIONS"));


### PR DESCRIPTION
#### PR description:
The CMSSW_15_0_4 replay (see [CMStalk](https://cms-talk.web.cern.ch/t/replay-for-cmssw-15-0-4/122732)) is currently failing with the following  error:
```
An exception of category 'Configuration' occurred while
   [0] Constructing the EventProcessor
   [1] Constructing ESSource: class=PoolDBESSource label='GlobalTag'
   [2] Validating configuration of ESSource of type PoolDBESSource with label: 'GlobalTag'
Exception Message:
Illegal parameter found in configuration.  The parameter is named:
 'transactionId'
You could be trying to use a parameter name that is not
allowed for this plugin or it could be misspelled.
```
This is due to the fact that in the Tier0 code ([here](https://github.com/dmwm/T0/blob/master/src/python/T0/RunConfig/RunConfigAPI.py#L641)) an additional parameter (`transactionId`) is set and later passed to WMCore [here](https://github.com/dmwm/WMCore/blob/14f171a388bec9c254c817f3c8edbdf93b71f04e/src/python/PSetTweaks/WMTweak.py#L398), resulting in 
```
process.GlobalTag = cms.ESSource("PoolDBESSource",
    DBParameters = cms.PSet(
        authenticationPath = cms.untracked.string(''),
    authenticationSystem = cms.untracked.int32(0),
    connectionTimeout = cms.untracked.int32(0),
        messageLevel = cms.untracked.int32(0),
        security = cms.untracked.string(''),
        transactionId = cms.untracked.string('Express_390094')
    ),
    DumpStat = cms.untracked.bool(False),
    JsonDumpFileName = cms.untracked.string(''),
...
```

This error only surfaced now because with the merging of https://github.com/cms-sw/cmssw/pull/47676 we are now explicitly validating the `CondDBESSource` parameter sets.

While this parameter doesn't seem to be strictly necessary for `cmsRun`, it's not clear why it is explicitly set in Tier0 and WMCore. And while WMCore/T0 experts are investigating this 13-year-old piece of code, we can "patch" CMSSW by making this parameter optional as suggested by @Dr15Jones and @mmusich (thanks!!).

#### PR validation:
Just checked that the code compiles for now.

#### Backport:
Not a backport, but a 15_0_X backport will be provided soon.