### PR TITLE
[15_0_X] Add transactionId as optional parameter of CondDBESSource

### DIFF
--- a/CondCore/ESSources/plugins/CondDBESSource.cc
+++ b/CondCore/ESSources/plugins/CondDBESSource.cc
@@ -759,7 +759,7 @@ void CondDBESSource::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   dbParams.addUntracked<std::string>("security", "");
   dbParams.addUntracked<int>("messageLevel", 0);
   dbParams.addUntracked<int>("connectionTimeout", 0);
-  dbParams.addOptionalUntracked<std::string>("transactionId", "");
+  dbParams.addOptionalUntracked<std::string>("transactionId", "")->setComment("This parameter is not strictly needed by PoolDBESSource, but the WMCore infrastructure requires it.");
   desc.add("DBParameters", dbParams);
 
   desc.add<std::string>("connect", std::string("frontier://FrontierProd/CMS_CONDITIONS"));

--- a/CondCore/ESSources/plugins/CondDBESSource.cc
+++ b/CondCore/ESSources/plugins/CondDBESSource.cc
@@ -759,6 +759,7 @@ void CondDBESSource::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   dbParams.addUntracked<std::string>("security", "");
   dbParams.addUntracked<int>("messageLevel", 0);
   dbParams.addUntracked<int>("connectionTimeout", 0);
+  dbParams.addOptionalUntracked<std::string>("transactionId", "");
   desc.add("DBParameters", dbParams);
 
   desc.add<std::string>("connect", std::string("frontier://FrontierProd/CMS_CONDITIONS"));


### PR DESCRIPTION
#### PR description:
Verbatim backport of #47822

Adding `transactionId` as optional parameter of CondDBESSource.

#### PR validation:
See master PR

#### Backport:
Backport of #47822