### PR TITLE
[15.0.X] backport: PPS DQM update for the beginning of 2025 data-taking

### DIFF
--- a/DQM/CTPPS/plugins/CTPPSCommonDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSCommonDQMSource.cc
@@ -43,7 +43,6 @@ protected:
 
 private:
   const unsigned int verbosity;
-  constexpr static int MAX_LUMIS = 6000;
   constexpr static int MAX_VBINS = 20;
 
   const edm::EDGetTokenT<CTPPSRecord> ctppsRecordToken;
@@ -105,7 +104,6 @@ private:
 using namespace std;
 using namespace edm;
 
-const int CTPPSCommonDQMSource::MAX_LUMIS;
 const int CTPPSCommonDQMSource::MAX_VBINS;
 
 //----------------------------------------------------------------------------------------------------
@@ -125,9 +123,9 @@ void CTPPSCommonDQMSource::GlobalPlots::Init(DQMStore::IBooker &ibooker) {
   */
   RPState = ibooker.book2D("rpstate per LS",
                            "RP State per Lumisection;Luminosity Section;",
-                           MAX_LUMIS,
+                           1000,
                            0,
-                           MAX_LUMIS,
+                           1000,
                            MAX_VBINS,
                            0.,
                            MAX_VBINS);

--- a/DQM/CTPPS/plugins/CTPPSCommonDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSCommonDQMSource.cc
@@ -121,14 +121,8 @@ void CTPPSCommonDQMSource::GlobalPlots::Init(DQMStore::IBooker &ibooker) {
      2 -> warning
      3 -> ok
   */
-  RPState = ibooker.book2D("rpstate per LS",
-                           "RP State per Lumisection;Luminosity Section;",
-                           1000,
-                           0,
-                           1000,
-                           MAX_VBINS,
-                           0.,
-                           MAX_VBINS);
+  RPState = ibooker.book2D(
+      "rpstate per LS", "RP State per Lumisection;Luminosity Section;", 1000, 0, 1000, MAX_VBINS, 0., MAX_VBINS);
   {
     TH2F *hist = RPState->getTH2F();
     hist->SetCanExtend(TH1::kAllAxes);

--- a/DQM/CTPPS/plugins/CTPPSPixelDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSPixelDQMSource.cc
@@ -65,7 +65,7 @@ private:
   static constexpr int ADCMax = 256;
   static constexpr int StationIDMAX = 4;  // possible range of ID
   static constexpr int RPotsIDMAX = 8;    // possible range of ID
-  static constexpr int NLocalTracksMAX = 20;
+  static constexpr int NLocalTracksMAX = 10;
   static constexpr int hitMultMAX = 50;   // tuned
   static constexpr int ClusMultMAX = 10;  // tuned
   static constexpr int ClusterSizeMax = 9;
@@ -471,12 +471,18 @@ void CTPPSPixelDQMSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run co
 
         ibooker.setCurrentFolder(rpd);
 
-        const float x0Maximum = 70.;
-        const float y0Maximum = 15.;
+        const float x0Minimum = -5.;
+        const float y0Minimum = -10.;
+        const float x0Maximum = 25.;
+        const float y0Maximum = 22.;
+        const float xBins_per_mm = 3; // number of x bins per mm
+        const float yBins_per_mm = 3; // number of y bins per mm
+
         string st = "track intercept point";
         string st2 = ": " + stnTitle;
         h2trackXY0[indexP] = ibooker.book2D(
-            st, st + st2 + ";x0;y0", int(x0Maximum) * 2, 0., x0Maximum, int(y0Maximum) * 4, -y0Maximum, y0Maximum);
+            st, st + st2 + ";x0;y0", int(x0Maximum - x0Minimum) * xBins_per_mm, x0Minimum, x0Maximum, 
+            int(y0Maximum-y0Minimum) * yBins_per_mm, y0Minimum, y0Maximum);
         h2trackXY0[indexP]->getTH2F()->SetOption("colz");
         st = "Error Code";
         h2ErrorCodeRP[indexP] = ibooker.book2D(st,

--- a/DQM/CTPPS/plugins/CTPPSPixelDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSPixelDQMSource.cc
@@ -72,12 +72,12 @@ private:
   static constexpr int errCodeSize = 15;
   static constexpr int minFedNumber = 1462;
   static constexpr int numberOfFeds = 2;
-  static constexpr int mapXbins = 200;
-  static constexpr int mapYbins = 240;
-  static constexpr float mapYmin = -16.;
-  static constexpr float mapYmax = 8.;
-  const float mapXmin = 0. * TMath::Cos(18.4 / 180. * TMath::Pi());
-  const float mapXmax = 30. * TMath::Cos(18.4 / 180. * TMath::Pi());
+  static constexpr float x0Minimum = -5.;
+  static constexpr float y0Minimum = -10.;
+  static constexpr float x0Maximum = 25.;
+  static constexpr float y0Maximum = 22.;
+  static constexpr float xBins_per_mm = 3;  // number of x bins per mm
+  static constexpr float yBins_per_mm = 3;  // number of y bins per mm
 
   CTPPSPixelIndices thePixIndices;
 
@@ -471,13 +471,6 @@ void CTPPSPixelDQMSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run co
 
         ibooker.setCurrentFolder(rpd);
 
-        const float x0Minimum = -5.;
-        const float y0Minimum = -10.;
-        const float x0Maximum = 25.;
-        const float y0Maximum = 22.;
-        const float xBins_per_mm = 3;  // number of x bins per mm
-        const float yBins_per_mm = 3;  // number of y bins per mm
-
         string st = "track intercept point";
         string st2 = ": " + stnTitle;
         h2trackXY0[indexP] = ibooker.book2D(st,
@@ -654,8 +647,17 @@ void CTPPSPixelDQMSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run co
 
           if (offlinePlots) {
             st = "plane efficiency";
-            h2Efficiency[indexP][p] = ibooker.bookProfile2D(
-                st, st1 + ";x0;y0", mapXbins, mapXmin, mapXmax, mapYbins, mapYmin, mapYmax, 0, 1, "");
+            h2Efficiency[indexP][p] = ibooker.bookProfile2D(st,
+                                                            st1 + ";x0;y0",
+                                                            int(x0Maximum - x0Minimum) * xBins_per_mm,
+                                                            x0Minimum,
+                                                            x0Maximum,
+                                                            int(y0Maximum - y0Minimum) * yBins_per_mm,
+                                                            y0Minimum,
+                                                            y0Maximum,
+                                                            0,
+                                                            1,
+                                                            "");
             h2Efficiency[indexP][p]->getTProfile2D()->SetOption("colz");
           }
         }  // end of for(int p=0; p<NplaneMAX;..

--- a/DQM/CTPPS/plugins/CTPPSPixelDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSPixelDQMSource.cc
@@ -475,14 +475,19 @@ void CTPPSPixelDQMSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run co
         const float y0Minimum = -10.;
         const float x0Maximum = 25.;
         const float y0Maximum = 22.;
-        const float xBins_per_mm = 3; // number of x bins per mm
-        const float yBins_per_mm = 3; // number of y bins per mm
+        const float xBins_per_mm = 3;  // number of x bins per mm
+        const float yBins_per_mm = 3;  // number of y bins per mm
 
         string st = "track intercept point";
         string st2 = ": " + stnTitle;
-        h2trackXY0[indexP] = ibooker.book2D(
-            st, st + st2 + ";x0;y0", int(x0Maximum - x0Minimum) * xBins_per_mm, x0Minimum, x0Maximum, 
-            int(y0Maximum-y0Minimum) * yBins_per_mm, y0Minimum, y0Maximum);
+        h2trackXY0[indexP] = ibooker.book2D(st,
+                                            st + st2 + ";x0;y0",
+                                            int(x0Maximum - x0Minimum) * xBins_per_mm,
+                                            x0Minimum,
+                                            x0Maximum,
+                                            int(y0Maximum - y0Minimum) * yBins_per_mm,
+                                            y0Minimum,
+                                            y0Maximum);
         h2trackXY0[indexP]->getTH2F()->SetOption("colz");
         st = "Error Code";
         h2ErrorCodeRP[indexP] = ibooker.book2D(st,


### PR DESCRIPTION
#### PR description:

This PR affects the axis range of the pixel track distributions, to match with the position that they will take because of the geometry update (#47666).

#### PR validation:

Private validation was performed by running the PPS DQM sequence with [this config file](https://github.com/AndreaBellora/AB-CMSSW-Tools/blob/CMSSW_15_0_3_patch1/test/myPPSDQMFromRAW_2025_test_geometry_cfg.py). 

- Data used: ~10k events from Run2024I/ZeroBias/RAW/v1/000/386/951/
- GT: 150X_dataRun3_Prompt_PPS_w9_v2 (candidate that applies 2025 geometry to any run)
  - Real data with the new geometry are not yet available, but the test with 2024 data, applying 2025 geometry, is equivalent 
