### PR TITLE
Add optional regional vetos to some EcalPFClusterIsolation methods

### DIFF
--- a/RecoEgamma/EgammaIsolationAlgos/src/EcalPFClusterIsolation.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/src/EcalPFClusterIsolation.cc
@@ -37,7 +37,7 @@ EcalPFClusterIsolation<T1>::~EcalPFClusterIsolation() {}
 template <typename T1>
 bool EcalPFClusterIsolation<T1>::computedRVeto(T1Ref candRef, reco::PFClusterRef pfclu) {
   float dR2 = deltaR2(candRef->eta(), candRef->phi(), pfclu->eta(), pfclu->phi());
-  if (dR2 > (drMax_ * drMax_))
+  if (dR2 > (drMax_ * drMax_) || dR2 < drVeto2_)
     return false;
 
   if (candRef->superCluster().isNonnull()) {
@@ -108,7 +108,7 @@ double EcalPFClusterIsolation<T1>::getSum(T1Ref ref, edm::Handle<std::vector<rec
 template <typename T1>
 bool EcalPFClusterIsolation<T1>::computedRVeto(T1 cand, reco::PFClusterRef pfclu) {
   float dR2 = deltaR2(cand.eta(), cand.phi(), pfclu->eta(), pfclu->phi());
-  if (dR2 > (drMax_ * drMax_))
+  if (dR2 > (drMax_ * drMax_) || dR2 < drVeto2_)
     return false;
 
   if (cand.superCluster().isNonnull()) {


### PR DESCRIPTION
#### PR description:

The `EcalPFClusterIsolation` producer computes the ECAL isolation sum in a cone around an e/gamma object. 
It provides configurable parameters to define an inner cone and/or a constant eta strip to be removed from the calculation, as a protection against  deposits from bremmstrahlung photons. 
Several methods ( `computedRVeto`) exist to define the isolation regions but some are missing these inner cone/eta strip veto. 

This PR makes all methods consistent. This PR is needed for HLT developments for 2025. 

Thanks 

Laurent 

#### PR validation:

Passes integration tests. 