### PR TITLE
Add treatment of HGCAL calibration and surrounding cells

### DIFF
--- a/CondFormats/HGCalObjects/interface/HGCalMappingParameterSoA.h
+++ b/CondFormats/HGCalObjects/interface/HGCalMappingParameterSoA.h
@@ -35,7 +35,7 @@ namespace hgcal {
                       SOA_COLUMN(bool, valid),
                       SOA_COLUMN(bool, isHD),
                       SOA_COLUMN(bool, iscalib),
-                      SOA_COLUMN(int, offset),
+                      SOA_COLUMN(int, caliboffset),
                       SOA_COLUMN(bool, isSiPM),
                       SOA_COLUMN(uint16_t, typeidx),
                       SOA_COLUMN(uint16_t, chip),

--- a/CondFormats/HGCalObjects/interface/HGCalMappingParameterSoA.h
+++ b/CondFormats/HGCalObjects/interface/HGCalMappingParameterSoA.h
@@ -35,6 +35,7 @@ namespace hgcal {
                       SOA_COLUMN(bool, valid),
                       SOA_COLUMN(bool, isHD),
                       SOA_COLUMN(bool, iscalib),
+                      SOA_COLUMN(int, offset),
                       SOA_COLUMN(bool, isSiPM),
                       SOA_COLUMN(uint16_t, typeidx),
                       SOA_COLUMN(uint16_t, chip),

--- a/Geometry/HGCalMapping/plugins/alpaka/HGCalMappingCellESProducer.cc
+++ b/Geometry/HGCalMapping/plugins/alpaka/HGCalMappingCellESProducer.cc
@@ -30,7 +30,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     public:
       //
       HGCalMappingCellESProducer(const edm::ParameterSet& iConfig)
-          : ESProducer(iConfig), filelist_(iConfig.getParameter<std::vector<std::string> >("filelist")) {
+          : ESProducer(iConfig),
+            filelist_(iConfig.getParameter<std::vector<std::string> >("filelist")),
+            offsetfile_(iConfig.getParameter<std::string>("offsetfile")) {
         auto cc = setWhatProduced(this);
         cellIndexTkn_ = cc.consumes(iConfig.getParameter<edm::ESInputTag>("cellindexer"));
       }
@@ -41,7 +43,39 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         desc.add<std::vector<std::string> >("filelist", std::vector<std::string>({}))
             ->setComment("list of files with the readout cells of each module");
         desc.add<edm::ESInputTag>("cellindexer", edm::ESInputTag(""))->setComment("Dense cell index tool");
+        desc.add<std::string>("offsetfile", std::string({}))
+            ->setComment("file containing the offsets between calibration and surrounding cells");
         descriptions.addWithDefaultLabel(desc);
+      }
+
+      std::map<std::tuple<std::string, int, int>, int> makeOffsetMap(std::string input_offsetfile) {
+        std::map<std::tuple<std::string, int, int>, int> offsetMap;
+        auto offsetfile = edm::FileInPath(input_offsetfile).fullPath();
+        std::ifstream stream_offsetfile(offsetfile);
+        std::string line;
+        // Skip the first line (description of column content)
+        std::getline(stream_offsetfile, line);
+        while (std::getline(stream_offsetfile, line)) {
+          std::istringstream iss(line);
+          std::string r_typecode_str, r_chip_str, r_half_str, offset_str;
+          if (!(iss >> r_typecode_str >> r_chip_str >> r_half_str >> offset_str)) {
+            std::cout << "Error reading offset file" << std::endl;
+            break;
+          }
+          try {
+            int r_chip = std::stoi(r_chip_str);
+            int r_half = std::stoi(r_half_str);
+            int offset = std::stoi(offset_str);
+            offsetMap[std::make_tuple(r_typecode_str, r_chip, r_half)] = offset;
+          } catch (const std::invalid_argument& e) {
+            std::cout << "Invalid argument: " << e.what() << std::endl;
+            break;
+          } catch (const std::out_of_range& e) {
+            std::cout << "Out of range: " << e.what() << std::endl;
+            break;
+          }
+        }
+        return offsetMap;
       }
 
       //
@@ -52,6 +86,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         HGCalMappingCellParamHost cellParams(size, cms::alpakatools::host());
         for (uint32_t i = 0; i < size; i++)
           cellParams.view()[i].valid() = false;
+
+        auto offsetMap = makeOffsetMap(offsetfile_);
 
         //loop over cell types and then over cells
         for (const auto& url : filelist_) {
@@ -113,6 +149,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
             cell.trace() = pmap.getFloatAttr("trace", row);
             cell.eleid() = HGCalElectronicsId(false, 0, 0, 0, chip * 2 + half, seq).raw();
             cell.detid() = detid;
+
+            //calibration cell-to-surrounding cell offset. Can be !=0 only for calibration cells
+            auto mapKey = std::make_tuple(typecode, chip, half);
+            int offset = (iscalib && offsetMap.find(mapKey) != offsetMap.end()) ? offsetMap[mapKey] : 0;
+            cell.offset() = offset;
+
           }  //end loop over entities
         }  //end loop over cell types
 
@@ -122,6 +164,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     private:
       edm::ESGetToken<HGCalMappingCellIndexer, HGCalElectronicsMappingRcd> cellIndexTkn_;
       const std::vector<std::string> filelist_;
+      std::string offsetfile_;
     };
 
   }  // namespace hgcal

--- a/Geometry/HGCalMapping/python/hgcalmapping_cff.py
+++ b/Geometry/HGCalMapping/python/hgcalmapping_cff.py
@@ -4,7 +4,7 @@ def customise_hgcalmapper(process,
                           modules = 'Geometry/HGCalMapping/data/ModuleMaps/modulelocator_test.txt',
                           sicells = 'Geometry/HGCalMapping/data/CellMaps/WaferCellMapTraces.txt',
                           sipmcells = 'Geometry/HGCalMapping/data/CellMaps/channels_sipmontile.hgcal.txt',
-                          offsetfile = 'Geometry/HGCalMapping/data/CellMaps/offsetMap.txt'):
+                          offsetfile = 'Geometry/HGCalMapping/data/CellMaps/calibration_to_surrounding_offsetMap.txt'):
     """the following function configures the mapping producers
     NOTE: for production-targetted configs should be avoided as it checks if the process as 
     already the Accelerators sequence loaded, if not it loads it to the process"""

--- a/Geometry/HGCalMapping/python/hgcalmapping_cff.py
+++ b/Geometry/HGCalMapping/python/hgcalmapping_cff.py
@@ -3,7 +3,8 @@ import FWCore.ParameterSet.Config as cms
 def customise_hgcalmapper(process,
                           modules = 'Geometry/HGCalMapping/data/ModuleMaps/modulelocator_test.txt',
                           sicells = 'Geometry/HGCalMapping/data/CellMaps/WaferCellMapTraces.txt',
-                          sipmcells = 'Geometry/HGCalMapping/data/CellMaps/channels_sipmontile.hgcal.txt'):
+                          sipmcells = 'Geometry/HGCalMapping/data/CellMaps/channels_sipmontile.hgcal.txt',
+                          offsetfile = 'Geometry/HGCalMapping/data/CellMaps/offsetMap.txt'):
     """the following function configures the mapping producers
     NOTE: for production-targetted configs should be avoided as it checks if the process as 
     already the Accelerators sequence loaded, if not it loads it to the process"""
@@ -18,7 +19,8 @@ def customise_hgcalmapper(process,
         
     process.hgCalMappingCellESProducer = cms.ESProducer('hgcal::HGCalMappingCellESProducer@alpaka',
                                                         filelist=cms.vstring(sicells, sipmcells),
-                                                        cellindexer=cms.ESInputTag(''))
+                                                        cellindexer=cms.ESInputTag(''),
+                                                        offsetfile=cms.string(offsetfile))
     process.hgCalMappingModuleESProducer = cms.ESProducer('hgcal::HGCalMappingModuleESProducer@alpaka',
                                                           filename=cms.FileInPath(modules),
                                                           moduleindexer=cms.ESInputTag(''))

--- a/Geometry/HGCalMapping/python/hgcalmapping_cff.py
+++ b/Geometry/HGCalMapping/python/hgcalmapping_cff.py
@@ -20,7 +20,7 @@ def customise_hgcalmapper(process,
     process.hgCalMappingCellESProducer = cms.ESProducer('hgcal::HGCalMappingCellESProducer@alpaka',
                                                         filelist=cms.vstring(sicells, sipmcells),
                                                         cellindexer=cms.ESInputTag(''),
-                                                        offsetfile=cms.string(offsetfile))
+                                                        offsetfile=cms.FileInPath(offsetfile))
     process.hgCalMappingModuleESProducer = cms.ESProducer('hgcal::HGCalMappingModuleESProducer@alpaka',
                                                           filename=cms.FileInPath(modules),
                                                           moduleindexer=cms.ESInputTag(''))

--- a/Geometry/HGCalMapping/test/testMappingModuleIndexer_cfg.py
+++ b/Geometry/HGCalMapping/test/testMappingModuleIndexer_cfg.py
@@ -9,6 +9,9 @@ options.register('sicells','Geometry/HGCalMapping/data/CellMaps/WaferCellMapTrac
                  info="Path to Si cell mapper. Absolute, or relative to CMSSW src directory")
 options.register('sipmcells','Geometry/HGCalMapping/data/CellMaps/channels_sipmontile.hgcal.txt',mytype=VarParsing.varType.string,
                  info="Path to SiPM-on-tile cell mapper. Absolute, or relative to CMSSW src directory")
+options.register('offsetfile','Geometry/HGCalMapping/data/CellMaps/calibration_to_surrounding_offsetMap.txt',mytype=VarParsing.varType.cms.FileInPath,
+                 info="Path to calibration-to-surrounding cell offset file. Absolute, or relative to CMSSW src directory")
+
 options.parseArguments()
 
 process.source = cms.Source('EmptySource')
@@ -22,7 +25,8 @@ from Geometry.HGCalMapping.hgcalmapping_cff import customise_hgcalmapper
 process = customise_hgcalmapper(process,
                                 modules=options.modules,
                                 sicells=options.sicells,
-                                sipmcells=options.sipmcells)
+                                sipmcells=options.sipmcells,
+                                offsetfile=options.offsetfile)
 
 #Geometry
 process.load('Configuration.Geometry.GeometryExtended2026D99Reco_cff')

--- a/RecoLocalCalo/HGCalRecAlgos/interface/alpaka/HGCalRecHitCalibrationAlgorithms.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/alpaka/HGCalRecHitCalibrationAlgorithms.h
@@ -16,11 +16,14 @@
 #include "DataFormats/HGCalRecHit/interface/alpaka/HGCalRecHitDevice.h"
 #include "CondFormats/HGCalObjects/interface/HGCalCalibrationParameterHost.h"
 #include "CondFormats/HGCalObjects/interface/alpaka/HGCalCalibrationParameterDevice.h"
+#include "CondFormats/HGCalObjects/interface/HGCalMappingParameterHost.h"
+#include "CondFormats/HGCalObjects/interface/alpaka/HGCalMappingParameterDevice.h"
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   using namespace hgcaldigi;
   using namespace hgcalrechit;
+  using namespace hgcal;
 
   class HGCalRecHitCalibrationAlgorithms {
   public:
@@ -29,7 +32,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     HGCalRecHitDevice calibrate(Queue& queue,
                                 HGCalDigiHost const& host_digis,
                                 HGCalCalibParamDevice const& device_calib,
-                                HGCalConfigParamDevice const& device_config) const;
+                                HGCalConfigParamDevice const& device_config,
+                                HGCalMappingCellParamDevice const& device_mapping,
+                                HGCalDenseIndexInfoDevice const& device_index) const;
 
   private:
     void print(HGCalDigiHost const& digis, int max = -1) const;

--- a/RecoLocalCalo/HGCalRecAlgos/plugins/alpaka/HGCalRecHitCalibrationAlgorithms.dev.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/plugins/alpaka/HGCalRecHitCalibrationAlgorithms.dev.cc
@@ -157,7 +157,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
         auto cellIndex = index[idx].cellInfoIdx();
         bool isCalibCell(maps[cellIndex].iscalib());
-        int offset = maps[cellIndex].offset();
+        int offset = maps[cellIndex].caliboffset();  //Calibration-to-surrounding cell offset
         bool is_surr_cell((offset != 0) && isAvailable && isCalibCell);
 
         //Effectively operate only on the cell that surrounds the calibration cells

--- a/RecoLocalCalo/HGCalRecAlgos/plugins/alpaka/HGCalRecHitProducers.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/plugins/alpaka/HGCalRecHitProducers.cc
@@ -177,6 +177,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                          deviceConfigParamProvider,
                                          deviceMappingCellParamProvider,
                                          deviceIndexingParamProvider);
+
 #endif
 
 #ifdef EDM_ML_DEBUG


### PR DESCRIPTION
#### PR description:

The purpose of this PR is to:

1. sum up the energy of the rechits in the HGCAL modules calibration and surrounding cells and assign the resulting value to the surrounding cell rechit;
2. define the time of the rechit in the surrounding cell as an energy-weighted average between the time of the calibration and surrounding cells (when both times are available and different from zero). If either times are zero, the plain non-zero time is chosen instead;
3. in case the flags for the rechits in the surrounding cells were invalid, set them to a valid state.

**NOTE:** Requires a txt file that contains offsets to identify the calibration-to-surrounding cell `offset` given a certain module `typecode`, `roc` and `halfroc` numbers. Such a file is being added to cms-data ([this PR](https://github.com/cms-data/Geometry-HGCalMapping/pull/3)).

#### PR validation:

As reported [here](https://indico.cern.ch/event/1524428/#2-combining-calibration-and-su).