### PR TITLE
Adding optional deltaR cuts to HLTPMMassFilter

### DIFF
--- a/HLTrigger/Egamma/plugins/HLTPMMassFilter.cc
+++ b/HLTrigger/Egamma/plugins/HLTPMMassFilter.cc
@@ -42,7 +42,7 @@ void HLTPMMassFilter::fillDescriptions(edm::ConfigurationDescriptions& descripti
   desc.add<edm::InputTag>("beamSpot", edm::InputTag("hltOfflineBeamSpot"));
   desc.add<double>("lowerMassCut", 8.0);
   desc.add<double>("upperMassCut", 11.0);
-  desc.add<double>("lowerdRCut", -1.0);
+  desc.add<double>("lowerdRCut", 0.0);
   desc.add<double>("upperdRCut", 9999.0);
   desc.add<int>("nZcandcut", 1);
   desc.addUntracked<bool>("reqOppCharge", true);

--- a/HLTrigger/Egamma/plugins/HLTPMMassFilter.cc
+++ b/HLTrigger/Egamma/plugins/HLTPMMassFilter.cc
@@ -22,8 +22,8 @@ HLTPMMassFilter::HLTPMMassFilter(const edm::ParameterSet& iConfig) : HLTFilter(i
   upperMassCut_ = iConfig.getParameter<double>("upperMassCut");
   lowerdRCut_ = iConfig.getParameter<double>("lowerdRCut");
   upperdRCut_ = iConfig.getParameter<double>("upperdRCut");
-  lowerdR2Cut_ = lowerdRCut_ * lowerdRCut_;
-  upperdR2Cut_ = upperdRCut_ * upperdRCut_;
+  lowerdR2Cut_ = lowerdRCut_ >= 0 ? lowerdRCut_ * lowerdRCut_ : 0;
+  upperdR2Cut_ = upperdRCut_ >= 0 ? upperdRCut_ * upperdRCut_ : 99999;
   nZcandcut_ = iConfig.getParameter<int>("nZcandcut");
   reqOppCharge_ = iConfig.getUntrackedParameter<bool>("reqOppCharge", false);
   isElectron1_ = iConfig.getUntrackedParameter<bool>("isElectron1", true);

--- a/HLTrigger/Egamma/plugins/HLTPMMassFilter.cc
+++ b/HLTrigger/Egamma/plugins/HLTPMMassFilter.cc
@@ -22,6 +22,8 @@ HLTPMMassFilter::HLTPMMassFilter(const edm::ParameterSet& iConfig) : HLTFilter(i
   upperMassCut_ = iConfig.getParameter<double>("upperMassCut");
   lowerdRCut_ = iConfig.getParameter<double>("lowerdRCut");
   upperdRCut_ = iConfig.getParameter<double>("upperdRCut");
+  lowerdR2Cut_ = lowerdRCut_ * lowerdRCut_;
+  upperdR2Cut_ = upperdRCut_ * upperdRCut_;
   nZcandcut_ = iConfig.getParameter<int>("nZcandcut");
   reqOppCharge_ = iConfig.getUntrackedParameter<bool>("reqOppCharge", false);
   isElectron1_ = iConfig.getUntrackedParameter<bool>("isElectron1", true);
@@ -161,9 +163,9 @@ bool HLTPMMassFilter::isGoodPair(TLorentzVector const& v1, TLorentzVector const&
     return false;
 
   auto const mass = (v1 + v2).M();
-  auto const dr = v1.DeltaR(v2);
+  auto const dr2 = reco::deltaR2(v1.Eta(), v1.Phi(), v2.Eta(), v2.Phi());
 
-  return (mass >= lowerMassCut_ and mass <= upperMassCut_ and dr >= lowerdRCut_ and dr <= upperdRCut_);
+  return (mass >= lowerMassCut_ and mass <= upperMassCut_ and dr2 >= lowerdR2Cut_ and dr2 <= upperdR2Cut_);
 }
 
 TLorentzVector HLTPMMassFilter::approxMomAtVtx(const MagneticField& magField,

--- a/HLTrigger/Egamma/plugins/HLTPMMassFilter.cc
+++ b/HLTrigger/Egamma/plugins/HLTPMMassFilter.cc
@@ -20,6 +20,8 @@ HLTPMMassFilter::HLTPMMassFilter(const edm::ParameterSet& iConfig) : HLTFilter(i
 
   lowerMassCut_ = iConfig.getParameter<double>("lowerMassCut");
   upperMassCut_ = iConfig.getParameter<double>("upperMassCut");
+  lowerdRCut_ = iConfig.getParameter<double>("lowerdRCut");
+  upperdRCut_ = iConfig.getParameter<double>("upperdRCut");
   nZcandcut_ = iConfig.getParameter<int>("nZcandcut");
   reqOppCharge_ = iConfig.getUntrackedParameter<bool>("reqOppCharge", false);
   isElectron1_ = iConfig.getUntrackedParameter<bool>("isElectron1", true);
@@ -38,6 +40,8 @@ void HLTPMMassFilter::fillDescriptions(edm::ConfigurationDescriptions& descripti
   desc.add<edm::InputTag>("beamSpot", edm::InputTag("hltOfflineBeamSpot"));
   desc.add<double>("lowerMassCut", 8.0);
   desc.add<double>("upperMassCut", 11.0);
+  desc.add<double>("lowerdRCut", -1.0);
+  desc.add<double>("upperdRCut", 9999.0);
   desc.add<int>("nZcandcut", 1);
   desc.addUntracked<bool>("reqOppCharge", true);
   desc.addUntracked<bool>("isElectron1", false);
@@ -157,7 +161,9 @@ bool HLTPMMassFilter::isGoodPair(TLorentzVector const& v1, TLorentzVector const&
     return false;
 
   auto const mass = (v1 + v2).M();
-  return (mass >= lowerMassCut_ and mass <= upperMassCut_);
+  auto const dr = v1.DeltaR(v2);
+
+  return (mass >= lowerMassCut_ and mass <= upperMassCut_ and dr >= lowerdRCut_ and dr <= upperdRCut_);
 }
 
 TLorentzVector HLTPMMassFilter::approxMomAtVtx(const MagneticField& magField,

--- a/HLTrigger/Egamma/plugins/HLTPMMassFilter.h
+++ b/HLTrigger/Egamma/plugins/HLTPMMassFilter.h
@@ -15,6 +15,7 @@
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
 #include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
 #include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
+#include "DataFormats/Math/interface/deltaR.h"
 #include "DataFormats/Math/interface/Point3D.h"
 #include "DataFormats/RecoCandidate/interface/RecoEcalCandidate.h"
 #include "DataFormats/RecoCandidate/interface/RecoEcalCandidateFwd.h"
@@ -54,6 +55,8 @@ private:
   double upperMassCut_;
   double lowerdRCut_;
   double upperdRCut_;
+  double lowerdR2Cut_;
+  double upperdR2Cut_;
   int nZcandcut_;  // number of Z candidates required
   bool reqOppCharge_;
 

--- a/HLTrigger/Egamma/plugins/HLTPMMassFilter.h
+++ b/HLTrigger/Egamma/plugins/HLTPMMassFilter.h
@@ -52,6 +52,8 @@ private:
   edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
   double lowerMassCut_;
   double upperMassCut_;
+  double lowerdRCut_;
+  double upperdRCut_;
   int nZcandcut_;  // number of Z candidates required
   bool reqOppCharge_;
 


### PR DESCRIPTION
#### PR description:

This pull requests adds an optional deltaR condition to a double object HLT filter. Such a change is needed for HLT developments in 2025. 

#### PR validation:
A private HLT path is being developed on top of this PR and works as expected. 
The default cut values are confirmed to lead to no change for existing HLT paths. 

FYI @missirol 
