### PR TITLE
Add plugins that create HepMC3 products to Herwig7Interface

### DIFF
--- a/GeneratorInterface/Herwig7Interface/BuildFile.xml
+++ b/GeneratorInterface/Herwig7Interface/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="GeneratorInterface/Core"/>
 <use name="boost"/>
 <use name="hepmc"/>
+<use name="hepmc3"/>
 <use name="thepeg"/>
 <use name="herwig7"/>
 <export>

--- a/GeneratorInterface/Herwig7Interface/interface/HepMC3Converter.h
+++ b/GeneratorInterface/Herwig7Interface/interface/HepMC3Converter.h
@@ -1,0 +1,197 @@
+// -*- C++ -*-
+//
+// HepMCConverter.h is a part of ThePEG - Toolkit for HEP Event Generation
+// Copyright (C) 1999-2019 Leif Lonnblad
+//
+// ThePEG is licenced under version 3 of the GPL, see COPYING for details.
+// Please respect the MCnet academic guidelines, see GUIDELINES for details.
+//
+#ifndef ThePEG_HepMCConverter_H
+#define ThePEG_HepMCConverter_H
+// This is the declaration of the HepMCConverter class.
+
+#include "ThePEG/Config/ThePEG.h"
+#include "ThePEG/EventRecord/Event.h"
+#include "GeneratorInterface/Herwig7Interface/interface/HepMC3Traits.h"
+
+namespace ThePEG {
+
+  template <typename HepMCEventT, typename Traits = HepMCTraits<HepMCEventT> >
+  class HepMCConverter {
+  public:
+    struct HepMCConverterException : public Exception {};
+
+    struct Vertex {
+      /** Particles going in to the vertex. */
+      tcParticleSet in;
+      /** Particles going out of the vertex. */
+      tcParticleSet out;
+    };
+
+    /** Forward typedefs from Traits class. */
+    typedef typename Traits::ParticleT GenParticle;
+    /** Forward typedefs from Traits class. */
+    typedef typename Traits::ParticlePtrT GenParticlePtrT;
+    /** Forward typedefs from Traits class. */
+    typedef typename Traits::EventT GenEvent;
+    /** Forward typedefs from Traits class. */
+    typedef typename Traits::VertexT GenVertex;
+    /** Forward typedefs from Traits class. */
+    typedef typename Traits::VertexPtrT GenVertexPtrT;
+    /** Forward typedefs from Traits class. */
+    typedef typename Traits::PdfInfoT PdfInfo;
+    /** Map ThePEG particles to HepMC particles. */
+    typedef map<tcPPtr, GenParticlePtrT> ParticleMap;
+    /** Map ThePEG colour lines to HepMC colour indices. */
+    typedef map<tcColinePtr, long> FlowMap;
+    /** Map ThePEG particles to vertices. */
+    typedef map<tcPPtr, Vertex *> VertexMap;
+    /** Map vertices to GenVertex */
+    typedef map<const Vertex *, GenVertexPtrT> GenVertexMap;
+
+  public:
+    /**
+     * Convert a ThePEG::Event to a HepMC::GenEvent. The caller is
+     * responsible for deleting the constructed GenEvent object. If \a
+     * nocopies is true, only final copies of particles connected with
+     * Particle::previous() and Particle::next() will be entered in the
+     * HepMC::GenEvent. In the GenEvent object, the energy/momentum
+     * variables will be in units of \a eunit and lengths variables in
+     * units of \a lunit.
+     */
+    static GenEvent *convert(const Event &ev,
+                             bool nocopies = false,
+                             Energy eunit = Traits::defaultEnergyUnit(),
+                             Length lunit = Traits::defaultLengthUnit());
+
+    /**
+     * Convert a ThePEG::Event to a HepMC::GenEvent. The caller supplies
+     * a GenEvent object, \a gev, which will be filled. If \a nocopies
+     * is true, only final copies of particles connected with
+     * Particle::previous() and Particle::next() will be entered in the
+     * HepMC::GenEvent. In the GenEvent object, the energy/momentum
+     * variables will be in units of \a eunit and lengths variables in
+     * units of \a lunit.
+     */
+    static void convert(const Event &ev, GenEvent &gev, bool nocopies, Energy eunit, Length lunit);
+
+    /**
+     * Convert a ThePEG::Event to a HepMC::GenEvent. The caller supplies
+     * a GenEvent object, \a gev, which will be filled. If \a nocopies
+     * is true, only final copies of particles connected with
+     * Particle::previous() and Particle::next() will be entered in the
+     * HepMC::GenEvent. In the GenEvent object, the energy/momentum
+     * variables will be in units of \a eunit and lengths variables in
+     * units of \a lunit.
+     */
+    static void convert(const Event &ev, GenEvent &gev, bool nocopies = false);
+
+  private:
+    /**
+     * The proper constructors are private. The class is only
+     * instantiated within the convert method.
+     */
+    HepMCConverter(const Event &ev, bool nocopies, Energy eunit, Length lunit);
+
+    /**
+     * The proper constructors are private. The class is only
+     * instantiated within the convert method.
+     */
+    HepMCConverter(const Event &ev, GenEvent &gev, bool nocopies, Energy eunit, Length lunit);
+
+    /**
+     * Common init function used by the constructors.
+     */
+    void init(const Event &ev, bool nocopies);
+
+    /**
+     * Default constructor is unimplemented and private and should never be used.
+     */
+    HepMCConverter() = delete;
+
+    /**
+     * Copy constructor is unimplemented and private and should never be used.
+     */
+    HepMCConverter(const HepMCConverter &) = delete;
+
+    /**
+     * Assignment is unimplemented and private and should never be used.
+     */
+    HepMCConverter &operator=(const HepMCConverter &) = delete;
+
+  private:
+    /**
+     * Create a GenParticle from a ThePEG Particle.
+     */
+    GenParticlePtrT createParticle(tcPPtr p) const;
+
+    /**
+     * Join the decay vertex of the parent with the decay vertex of the
+     * child.
+     */
+    void join(tcPPtr parent, tcPPtr child);
+
+    /**
+     * Create a GenVertex from a temporary Vertex.
+     */
+    GenVertexPtrT createVertex(Vertex *v);
+
+    /**
+     * Create and set a PdfInfo object for the event
+     */
+    void setPdfInfo(const Event &e);
+
+  private:
+    /**
+     * The constructed GenEvent.
+     */
+    GenEvent *geneve;
+
+    /**
+     * The translation table between the ThePEG particles and the
+     * GenParticles.
+     */
+    ParticleMap pmap;
+
+    /**
+     * The translation table between ThePEG ColourLine objects and HepMC
+     * Flow indices.
+     */
+    FlowMap flowmap;
+
+    /**
+     * All temporary vertices created.
+     */
+    vector<Vertex> vertices;
+
+    /**
+     * The mapping of particles to their production vertices.
+     */
+    VertexMap prov;
+
+    /**
+     * The mapping of particles to their decy vertices.
+     */
+    VertexMap decv;
+
+    /**
+     * The mapping between temporary vertices and the created GenVertex Objects.
+     */
+    GenVertexMap vmap;
+
+    /**
+     * The energy unit to be used in the GenEvent.
+     */
+    Energy energyUnit;
+
+    /**
+     * The length unit to be used in the GenEvent.
+     */
+    Length lengthUnit;
+  };
+
+}  // namespace ThePEG
+
+#include "ThePEG/Vectors/HepMCConverter.tcc"
+
+#endif /* ThePEG_HepMCConverter_H */

--- a/GeneratorInterface/Herwig7Interface/interface/HepMC3Converter.h
+++ b/GeneratorInterface/Herwig7Interface/interface/HepMC3Converter.h
@@ -6,8 +6,8 @@
 // ThePEG is licenced under version 3 of the GPL, see COPYING for details.
 // Please respect the MCnet academic guidelines, see GUIDELINES for details.
 //
-#ifndef ThePEG_HepMCConverter_H
-#define ThePEG_HepMCConverter_H
+#ifndef ThePEG_HepMC3Converter_H
+#define ThePEG_HepMC3Converter_H
 // This is the declaration of the HepMCConverter class.
 
 #include "ThePEG/Config/ThePEG.h"

--- a/GeneratorInterface/Herwig7Interface/interface/HepMC3Helper.h
+++ b/GeneratorInterface/Herwig7Interface/interface/HepMC3Helper.h
@@ -1,0 +1,133 @@
+// -*- C++ -*-
+//
+// HepMCHelper_HepMC.h is a part of ThePEG - A multi-purpose Monte Carlo event generator
+// Copyright (C) 2002-2019 The Herwig Collaboration
+//
+// ThePEG is licenced under version 3 of the GPL, see COPYING for details.
+// Please respect the MCnet academic guidelines, see GUIDELINES for details.
+//
+//
+// This is a helper header to implement HepMC conversions
+//
+#include "ThePEG/Vectors/HepMCTraits.h"
+#include "HepMC3/GenEvent.h"
+#include "HepMC3/GenVertex.h"
+#include "HepMC3/GenParticle.h"
+#include "HepMC3/Version.h"
+#include "HepMC3/WriterAscii.h"
+#include "HepMC3/WriterHEPEVT.h"
+#include "HepMC3/WriterAsciiHepMC2.h"
+#ifdef HAVE_HEPMC3_WRITERROOT_H
+#include "HepMC3/WriterRoot.h"
+#endif
+#ifdef HAVE_HEPMC3_WRITERROOTTREE_H
+#include "HepMC3/WriterRootTree.h"
+#endif
+namespace HepMC3 {
+  using Polarization = std::pair<double, double>;
+}
+namespace ThePEG {
+  /**
+   * Struct for HepMC conversion
+   */
+  // This is version 3!
+  template <>
+  struct HepMCTraits<HepMC3::GenEvent> : public HepMCTraitsBase<HepMC3::GenEvent,
+                                                                HepMC3::GenParticle,
+                                                                HepMC3::GenParticlePtr,
+                                                                HepMC3::GenVertex,
+                                                                HepMC3::GenVertexPtr,
+                                                                HepMC3::Polarization,
+                                                                HepMC3::GenPdfInfo> {
+    /** Create an event object with number \a evno and \a weight. */
+    static EventT *newEvent(long evno, double weight, const map<string, double> &optionalWeights) {
+      EventT *e = new EventT(HepMC3::Units::GEV, HepMC3::Units::MM);
+      e->set_event_number(evno);
+      e->set_event_number(evno);
+      //std::vector<std::string> wnames;
+      std::vector<double> wvalues;
+
+      //wnames.push_back("Default");
+      wvalues.push_back(weight);
+      for (map<string, double>::const_iterator w = optionalWeights.begin(); w != optionalWeights.end(); ++w) {
+        //wnames.push_back(w->first);
+        wvalues.push_back(w->second);
+      }
+      //e->run_info()->set_weight_names(wnames);
+      e->weights() = wvalues;
+      return e;
+    }
+
+    /** Create a new vertex. */
+    static VertexPtrT newVertex() { return std::make_shared<VertexT>(VertexT()); }
+
+    /** Set the \a scale, \f$\alpha_S\f$ (\a aS) and \f$\alpha_{EM}\f$
+     (\a aEM) for the event \a e. The scale will be scaled with \a
+     unit before given to the GenEvent. */
+    static void setScaleAndAlphas(EventT &e, Energy2 scale, double aS, double aEM, Energy unit) {
+      e.add_attribute("event_scale", std::make_shared<HepMC3::DoubleAttribute>(sqrt(scale) / unit));
+      e.add_attribute("mpi",
+                      std::make_shared<HepMC3::IntAttribute>(-1));  //Please fix it later, once ThePEG authors respond
+      e.add_attribute("signal_process_id",
+                      std::make_shared<HepMC3::IntAttribute>(0));  //Please fix it later, once ThePEG authors respond
+      e.add_attribute("alphaQCD", std::make_shared<HepMC3::DoubleAttribute>(aS));
+      e.add_attribute("alphaQED", std::make_shared<HepMC3::DoubleAttribute>(aEM));
+    }
+
+    /** Set the colour line (with index \a indx) to \a coline for
+     particle \a p. */
+    static void setColourLine(ParticleT &p, int indx, int coline) {
+      p.add_attribute("flow" + std::to_string(indx), std::make_shared<HepMC3::IntAttribute>(coline));
+    }
+
+    /** Add an incoming particle, \a p, to the vertex, \a v. */
+    static void addIncoming(VertexT &v, ParticlePtrT p) { v.add_particle_in(p); }
+
+    /** Add an outgoing particle, \a p, to the vertex, \a v. */
+    static void addOutgoing(VertexT &v, ParticlePtrT p) { v.add_particle_out(p); }
+
+    /** Set the primary vertex, \a v, for the event \a e. */
+    static void setSignalProcessVertex(EventT &e, VertexPtrT v) {
+      e.add_vertex(v);
+      e.add_attribute("signal_process_vertex", std::make_shared<HepMC3::IntAttribute>(v->id()));
+    }
+
+    /** Set a vertex, \a v, for the event \a e. */
+    static void addVertex(EventT &e, VertexPtrT v) { e.add_vertex(v); }
+
+    /** Set the beam particles for the event.*/
+    static void setBeamParticles(EventT &e, ParticlePtrT p1, ParticlePtrT p2) {
+      //e.set_beam_particles(p1,p2);
+      p1->set_status(4);
+      p2->set_status(4);
+      e.set_beam_particles(p1, p2);
+    }
+
+    /** Create a new particle object with momentum \a p, PDG number \a
+     id and status code \a status. The momentum will be scaled with
+     \a unit which according to the HepMC documentation should be
+     GeV. */
+    static ParticlePtrT newParticle(const Lorentz5Momentum &p, long id, int status, Energy unit) {
+      // Note that according to the documentation the momentum is stored in a
+      // HepLorentzVector in GeV (event though the CLHEP standard is MeV).
+      HepMC3::FourVector p_scalar(p.x() / unit, p.y() / unit, p.z() / unit, p.e() / unit);
+      ParticlePtrT genp = std::make_shared<ParticleT>(ParticleT(p_scalar, id, status));
+      genp->set_generated_mass(p.mass() / unit);
+      return genp;
+    }
+
+    /** Set the polarization directions, \a the and \a phi, for particle
+     \a p. */
+    static void setPolarization(ParticleT &genp, double the, double phi) {
+      genp.add_attribute("theta", std::make_shared<HepMC3::DoubleAttribute>(the));
+      genp.add_attribute("phi", std::make_shared<HepMC3::DoubleAttribute>(phi));
+    }
+
+    /** Set the position \a p for the vertex, \a v. The length will be
+     scaled with \a unit which normally should be millimeters. */
+    static void setPosition(VertexT &v, const LorentzPoint &p, Length unit) {
+      HepMC3::FourVector v_scaled(p.x() / unit, p.y() / unit, p.z() / unit, p.e() / unit);
+      v.set_position(v_scaled);
+    }
+  };
+}  // namespace ThePEG

--- a/GeneratorInterface/Herwig7Interface/interface/HepMC3Helper.h
+++ b/GeneratorInterface/Herwig7Interface/interface/HepMC3Helper.h
@@ -9,7 +9,7 @@
 //
 // This is a helper header to implement HepMC conversions
 //
-#include "ThePEG/Vectors/HepMCTraits.h"
+#include "GeneratorInterface/Herwig7Interface/interface/HepMC3Traits.h"
 #include "HepMC3/GenEvent.h"
 #include "HepMC3/GenVertex.h"
 #include "HepMC3/GenParticle.h"
@@ -23,6 +23,7 @@
 #ifdef HAVE_HEPMC3_WRITERROOTTREE_H
 #include "HepMC3/WriterRootTree.h"
 #endif
+#include <string>
 namespace HepMC3 {
   using Polarization = std::pair<double, double>;
 }

--- a/GeneratorInterface/Herwig7Interface/interface/HepMC3Traits.h
+++ b/GeneratorInterface/Herwig7Interface/interface/HepMC3Traits.h
@@ -9,7 +9,11 @@
 #ifndef ThePEG_HepMC3Traits_H
 #define ThePEG_HepMC3Traits_H
 
+#include <string>
+#include <map>
 #include "HepMC3/GenEvent.h"
+#include "HepMC3/Units.h"
+#include "ThePEG/Config/ThePEG.h"
 namespace HepMC3 {
   class GenParticle;
   class GenVertex;

--- a/GeneratorInterface/Herwig7Interface/interface/HepMC3Traits.h
+++ b/GeneratorInterface/Herwig7Interface/interface/HepMC3Traits.h
@@ -11,13 +11,19 @@
 
 #include <string>
 #include <map>
+#include <memory>
+
 #include "HepMC3/GenEvent.h"
 #include "HepMC3/Units.h"
+#include <HepMC3/GenParticle.h>
+#include <HepMC3/GenPdfInfo.h>
+
 #include "ThePEG/Config/ThePEG.h"
+#include <ThePEG/Repository/EventGenerator.h>
+#include <ThePEG/EventRecord/Event.h>
+
 namespace HepMC3 {
-  class GenParticle;
   class GenVertex;
-  class GenPdfInfo;
 }  // namespace HepMC3
 
 namespace ThePEG {

--- a/GeneratorInterface/Herwig7Interface/interface/HepMC3Traits.h
+++ b/GeneratorInterface/Herwig7Interface/interface/HepMC3Traits.h
@@ -1,0 +1,289 @@
+// -*- C++ -*-
+//
+// HepMCTraits.h is a part of ThePEG - Toolkit for HEP Event Generation
+// Copyright (C) 1999-2019 Leif Lonnblad
+//
+// ThePEG is licenced under version 3 of the GPL, see COPYING for details.
+// Please respect the MCnet academic guidelines, see GUIDELINES for details.
+//
+#ifndef ThePEG_HepMCTraits_H
+#define ThePEG_HepMCTraits_H
+
+#include "HepMC3/GenEvent.h"
+namespace HepMC3 {
+  class GenParticle;
+  class GenVertex;
+  class GenPdfInfo;
+}  // namespace HepMC3
+
+namespace ThePEG {
+
+  /**
+   * HepMCTraitsBase is a convenient base class for specializing the
+   * HepMCTraits class to deal with different flavours of HepMC in the
+   * HepMCConverter class. The default version will work for the CLHEP
+   * implementation of HepMC. To use the HepMCConverter class for any
+   * flavour of HepMC you have to specialize the HepMCTraits class
+   * accordingly, possibly inheriting the functionality from the
+   * HepMCTraitsBase class and only overriding the functions and
+   * typedefs which are different. For the CLHEP flavour of HepMC you
+   * only need to do <code>template&lt;&gt; struct
+   * HepMCTraits&lt;HepMC::GenEvent&gt;: public
+   * HepMCTraitsBase&lt;HepMC::GenEvent,HepMC::GenParticle,HepMC::GenVertex,
+   * HepMC::Polarization&gt; {};</code> somewhere inside the ThePEG
+   * namespace.  The boolean template argument determines whether the
+   * HepMC implementation is specifying units or not.
+   */
+  template <typename HepMCEventT,
+            typename HepMCParticleT,
+            typename HepMCParticlePtrT,
+            typename HepMCVertexT,
+            typename HepMCVertexPtrT,
+            typename HepMCPolarizationT,
+            typename HepMCPdfInfoT>
+
+  struct HepMCTraitsBase {
+    /** Typedef of the particle class. */
+    typedef HepMCParticleT ParticleT;
+
+    /** Typedef of the event class. */
+    typedef HepMCEventT EventT;
+
+    /** Typedef of the vertex class. */
+    typedef HepMCVertexT VertexT;
+
+    /** Typedef of the polarization class. */
+    typedef HepMCPolarizationT PolarizationT;
+
+    /** Typedef of the PdfInfo class. */
+    typedef HepMCPdfInfoT PdfInfoT;
+
+    /** Typedef of a particle pointer */
+    typedef HepMCParticlePtrT ParticlePtrT;
+
+    /** Typedef of a vertex pointer */
+    typedef HepMCVertexPtrT VertexPtrT;
+
+    /** Create an event object with number \a evno and \a weight. */
+    static EventT* newEvent(long evno, double weight, const map<string, double>& optionalWeights) {
+      EventT* e = new EventT();
+      e->set_event_number(evno);
+      std::vector<std::string> wnames;
+      std::vector<double> wvalues;
+
+      wnames.push_back("Default");
+      wvalues.push_back(weight);
+      for (map<string, double>::const_iterator w = optionalWeights.begin(); w != optionalWeights.end(); ++w) {
+        wnames.push_back(w->first);
+        wvalues.push_back(w->second);
+      }
+      e->run_info()->set_weight_names(wnames);
+      e->weights() = wvalues;
+
+#ifdef HEPMC_HAS_NAMED_WEIGHTS
+      for (size_t i = 0; i < wnames.size(); i++)
+        e->weights()[wnames[i]] = wvalues[i];
+#else
+      e->weights() = wvalues;
+#endif
+
+      return e;
+    }
+
+    /** Reset event weight and number of a re-used GenEvent. */
+    static void resetEvent(EventT* e, long evno, double weight, const map<string, double>& optionalWeights) {
+      e->set_event_number(evno);
+      e->weights().clear();
+      std::vector<std::string> wnames;
+      std::vector<double> wvalues;
+
+      wnames.push_back("Default");
+      wvalues.push_back(weight);
+      for (map<string, double>::const_iterator w = optionalWeights.begin(); w != optionalWeights.end(); ++w) {
+        wnames.push_back(w->first);
+        wvalues.push_back(w->second);
+      }
+      e->run_info()->set_weight_names(wnames);
+      e->weights() = wvalues;
+
+#ifdef HEPMC_HAS_NAMED_WEIGHTS
+      for (size_t i = 0; i < wnames.size(); i++)
+        e->weights()[wnames[i]] = wvalues[i];
+#else
+      e->weights() = wvalues;
+#endif
+    }
+
+    /**
+     * Return true if this version of HepMC accept user-defined units.
+     */
+    static bool hasUnits() {
+#ifdef HEPMC_HAS_UNITS
+      return true;
+#else
+      return false;
+#endif
+    }
+
+    /**
+     * Return the energy unit used in the installed version of HepMC.
+     */
+    static Energy defaultEnergyUnit() {
+#ifndef HEPMC_HAS_UNITS
+      return GeV;
+#else
+      return HepMC3::Units::default_momentum_unit() == HepMC3::Units::GEV ? GeV : MeV;
+#endif
+    }
+
+    /**
+     * Return the length unit used in the installed version of HepMC.
+     */
+    static Length defaultLengthUnit() {
+#ifndef HEPMC_HAS_UNITS
+      return millimeter;
+#else
+      return HepMC3::Units::default_length_unit() == HepMC3::Units::MM ? millimeter : 10.0 * millimeter;
+#endif
+    }
+
+    /**
+     * Return the momentum unit used by a given GenEvent object. If
+     * HepMC does not support units this must return GeV.
+     */
+    static Energy momentumUnit(const EventT& e) {
+#ifdef HEPMC_HAS_UNITS
+      return e.momentum_unit() == HepMC3::Units::MEV ? MeV : GeV;
+#else
+      return GeV;
+#endif
+    }
+
+    /**
+     * Return the length unit used by a given GenEvent object. If
+     * HepMC does not support units this must return millimeter.
+     */
+    static Length lengthUnit(const EventT& e) {
+#ifdef HEPMC_HAS_UNITS
+      return e.length_unit() == HepMC3::Units::CM ? centimeter : millimeter;
+#else
+      return millimeter;
+#endif
+    }
+
+    /**
+     * Set the units to be used by the given GenEvent object. If
+     * HepMC does not support units this should be a no-op.
+     */
+#ifdef HEPMC_HAS_UNITS
+    static void setUnits(EventT& e, Energy momu, Length lenu) {
+      e.use_units(momu == MeV ? HepMC3::Units::MEV : HepMC3::Units::GEV,
+                  lenu == centimeter ? HepMC3::Units::CM : HepMC3::Units::MM);
+    }
+#else
+    static void setUnits(EventT&, Energy, Length) {}
+#endif
+
+    /** Set the \a scale, \f$\alpha_S\f$ (\a aS) and \f$\alpha_{EM}\f$
+     (\a aEM) for the event \a e. The scale will be scaled with \a
+     unit before given to the GenEvent. */
+    static void setScaleAndAlphas(EventT& e, Energy2 scale, double aS, double aEM, Energy unit) {
+      e.set_event_scale(sqrt(scale) / unit);
+      e.set_alphaQCD(aS);
+      e.set_alphaQED(aEM);
+    }
+
+    /** Set the primary vertex, \a v, for the event \a e. */
+    static void setSignalProcessVertex(EventT& e, VertexPtrT v) { e.set_signal_process_vertex(v); }
+
+    /** Set a vertex, \a v, for the event \a e. */
+    static void addVertex(EventT& e, VertexPtrT v) { e.add_vertex(v); }
+
+    /** Create a new particle object with momentum \a p, PDG number \a
+     id and status code \a status. The momentum will be scaled with
+     \a unit which according to the HepMC documentation should be
+     GeV. */
+    static ParticlePtrT newParticle(const Lorentz5Momentum& p, long id, int status, Energy unit) {
+      // Note that according to the documentation the momentum is stored in a
+      // HepLorentzVector in GeV (event though the CLHEP standard is MeV).
+      LorentzVector<double> p_scalar = p / unit;
+      ParticlePtrT genp = new ParticleT(p_scalar, id, status);
+      genp->setGeneratedMass(p.mass() / unit);
+      return genp;
+    }
+
+    /** Set the polarization directions, \a the and \a phi, for particle
+     \a p. */
+    static void setPolarization(ParticleT& genp, double the, double phi) {
+      genp.set_polarization(PolarizationT(the, phi));
+    }
+
+    /** Set the colour line (with index \a indx) to \a coline for
+     particle \a p. */
+    static void setColourLine(ParticleT& p, int indx, int coline) { p.set_flow(indx, coline); }
+
+    /** Create a new vertex. */
+    static VertexPtrT newVertex() { return new VertexT(); }
+
+    /** Add an incoming particle, \a p, to the vertex, \a v. */
+    static void addIncoming(VertexT& v, ParticlePtrT p) { v.add_particle_in(p); }
+
+    /** Add an outgoing particle, \a p, to the vertex, \a v. */
+    static void addOutgoing(VertexT& v, ParticlePtrT p) { v.add_particle_out(p); }
+
+    /** Set the position \a p for the vertex, \a v. The length will be
+     scaled with \a unit which normally should be millimeters. */
+    static void setPosition(VertexT& v, const LorentzPoint& p, Length unit) {
+      LorentzVector<double> p_scaled = p / unit;
+      v.set_position(p_scaled);
+    }
+
+    /** Set the beam particles for the event.*/
+    static void setBeamParticles(EventT& e, ParticlePtrT p1, ParticlePtrT p2) {
+      e.set_beam_particles(p1, p2);
+      p1->set_status(4);
+      p2->set_status(4);
+    }
+
+    /** Set the PDF info for the event. */
+#ifdef HEPMC_HAS_PDF_INFO
+    static void setPdfInfo(EventT& e, int id1, int id2, double x1, double x2, double scale, double xf1, double xf2) {
+      HepMC::GenPdfInfoPtr pdfinfo = std::make_shared<HepMC::GenPdfInfo>();
+      pdfinfo->set(id1, id2, x1, x2, scale, xf1, xf2);
+      e.set_pdf_info(pdfinfo);
+    }
+#else
+    static void setPdfInfo(EventT&, int, int, double, double, double, double, double) {}
+#endif
+
+    /** Set the cross section info for the event. */
+#ifdef HEPMC_HAS_CROSS_SECTION
+    static void setCrossSection(EventT& ev, double xs, double xserr) {
+      std::shared_ptr<HepMC::GenCrossSection> x = std::make_shared<HepMC::GenCrossSection>();
+      x->set_cross_section(xs, xserr);
+      ev.set_cross_section(x);
+    }
+#else
+    static void setCrossSection(EventT&, double, double) {}
+#endif
+  };
+
+  /**
+   * The HepMCTraits class is used to deal with different flavours of
+   * HepMC in the HepMCConverter class. To use the HepMCConverter class
+   * for any flavour of HepMC you have to specialize the
+   * HepMCTraits class accordingly, possibly inheriting the
+   * functionality from the HepMCTraitsBase class and only overriding
+   * the functions and typedefs which are different. For the CLHEP
+   * flavour of HepMC you only need to do <code>template&lt;&gt; struct
+   * HepMCTraits&lt;HepMC::GenEvent&gt;: public
+   * HepMCTraitsBase&lt;HepMC::GenEvent,HepMC::GenParticle,HepMC::GenVertex,
+   * HepMC::Polarization,HepMC::PdfInfo&gt; {};</code> somewhere inside the ThePEG
+   * namespace.
+   */
+  template <typename HepMCEventT>
+  struct HepMCTraits {};
+
+}  // namespace ThePEG
+
+#endif

--- a/GeneratorInterface/Herwig7Interface/interface/HepMC3Traits.h
+++ b/GeneratorInterface/Herwig7Interface/interface/HepMC3Traits.h
@@ -6,8 +6,8 @@
 // ThePEG is licenced under version 3 of the GPL, see COPYING for details.
 // Please respect the MCnet academic guidelines, see GUIDELINES for details.
 //
-#ifndef ThePEG_HepMCTraits_H
-#define ThePEG_HepMCTraits_H
+#ifndef ThePEG_HepMC3Traits_H
+#define ThePEG_HepMC3Traits_H
 
 #include "HepMC3/GenEvent.h"
 namespace HepMC3 {
@@ -129,22 +129,22 @@ namespace ThePEG {
      * Return the energy unit used in the installed version of HepMC.
      */
     static Energy defaultEnergyUnit() {
-#ifndef HEPMC_HAS_UNITS
+//#ifndef HEPMC_HAS_UNITS
       return GeV;
-#else
-      return HepMC3::Units::default_momentum_unit() == HepMC3::Units::GEV ? GeV : MeV;
-#endif
+//#else
+//      return HepMC3::Units::default_momentum_unit() == HepMC3::Units::GEV ? GeV : MeV;
+//#endif
     }
 
     /**
      * Return the length unit used in the installed version of HepMC.
      */
     static Length defaultLengthUnit() {
-#ifndef HEPMC_HAS_UNITS
+//#ifndef HEPMC_HAS_UNITS
       return millimeter;
-#else
-      return HepMC3::Units::default_length_unit() == HepMC3::Units::MM ? millimeter : 10.0 * millimeter;
-#endif
+//#else
+//      return HepMC3::Units::default_length_unit() == HepMC3::Units::MM ? millimeter : 10.0 * millimeter;
+//#endif
     }
 
     /**
@@ -248,7 +248,7 @@ namespace ThePEG {
     /** Set the PDF info for the event. */
 #ifdef HEPMC_HAS_PDF_INFO
     static void setPdfInfo(EventT& e, int id1, int id2, double x1, double x2, double scale, double xf1, double xf2) {
-      HepMC::GenPdfInfoPtr pdfinfo = std::make_shared<HepMC::GenPdfInfo>();
+      HepMC3::GenPdfInfoPtr pdfinfo = std::make_shared<HepMC3::GenPdfInfo>();
       pdfinfo->set(id1, id2, x1, x2, scale, xf1, xf2);
       e.set_pdf_info(pdfinfo);
     }
@@ -259,7 +259,7 @@ namespace ThePEG {
     /** Set the cross section info for the event. */
 #ifdef HEPMC_HAS_CROSS_SECTION
     static void setCrossSection(EventT& ev, double xs, double xserr) {
-      std::shared_ptr<HepMC::GenCrossSection> x = std::make_shared<HepMC::GenCrossSection>();
+      std::shared_ptr<HepMC3::GenCrossSection> x = std::make_shared<HepMC3::GenCrossSection>();
       x->set_cross_section(xs, xserr);
       ev.set_cross_section(x);
     }

--- a/GeneratorInterface/Herwig7Interface/interface/HepMC3Traits.h
+++ b/GeneratorInterface/Herwig7Interface/interface/HepMC3Traits.h
@@ -129,22 +129,22 @@ namespace ThePEG {
      * Return the energy unit used in the installed version of HepMC.
      */
     static Energy defaultEnergyUnit() {
-//#ifndef HEPMC_HAS_UNITS
+      //#ifndef HEPMC_HAS_UNITS
       return GeV;
-//#else
-//      return HepMC3::Units::default_momentum_unit() == HepMC3::Units::GEV ? GeV : MeV;
-//#endif
+      //#else
+      //      return HepMC3::Units::default_momentum_unit() == HepMC3::Units::GEV ? GeV : MeV;
+      //#endif
     }
 
     /**
      * Return the length unit used in the installed version of HepMC.
      */
     static Length defaultLengthUnit() {
-//#ifndef HEPMC_HAS_UNITS
+      //#ifndef HEPMC_HAS_UNITS
       return millimeter;
-//#else
-//      return HepMC3::Units::default_length_unit() == HepMC3::Units::MM ? millimeter : 10.0 * millimeter;
-//#endif
+      //#else
+      //      return HepMC3::Units::default_length_unit() == HepMC3::Units::MM ? millimeter : 10.0 * millimeter;
+      //#endif
     }
 
     /**

--- a/GeneratorInterface/Herwig7Interface/interface/Herwig7HepMC3Interface.h
+++ b/GeneratorInterface/Herwig7Interface/interface/Herwig7HepMC3Interface.h
@@ -1,0 +1,77 @@
+/**
+Marco A. Harrendorf
+**/
+
+#ifndef GeneratorInterface_Herwig7Interface_Herwig7HepMC3Interface_h
+#define GeneratorInterface_Herwig7Interface_Herwig7HepMC3Interface_h
+
+#include <memory>
+#include <string>
+
+#include <HepMC/GenEvent.h>
+#include <HepMC/PdfInfo.h>
+#include <HepMC/IO_BaseClass.h>
+
+#include <HepMC3/GenEvent.h>
+#include <HepMC3/GenParticle.h>
+#include <HepMC3/GenPdfInfo.h>
+
+#include <ThePEG/Repository/EventGenerator.h>
+#include <ThePEG/EventRecord/Event.h>
+#include <GeneratorInterface/Herwig7Interface/interface/HepMC3Helper.h>
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "GeneratorInterface/Herwig7Interface/interface/RandomEngineGlue.h"
+#include "GeneratorInterface/Herwig7Interface/interface/HerwigUIProvider.h"
+
+namespace CLHEP {
+  class HepRandomEngine;
+}
+
+class Herwig7HepMC3Interface {
+public:
+  Herwig7HepMC3Interface(const edm::ParameterSet &params);
+  ~Herwig7HepMC3Interface() noexcept;
+
+  void setPEGRandomEngine(CLHEP::HepRandomEngine *);
+
+  ThePEG::EGPtr eg_;
+
+protected:
+  void initRepository(const edm::ParameterSet &params);
+  bool initGenerator();
+  void flushRandomNumberGenerator();
+
+  static std::unique_ptr<HepMC3::GenEvent> convert(const ThePEG::EventPtr &event);
+
+  static double pthat(const ThePEG::EventPtr &event);
+
+  //std::unique_ptr<HepMC::IO_BaseClass> iobc_;
+
+  // HerwigUi contains settings piped to Herwig7
+  std::shared_ptr<Herwig::HerwigUIProvider> HwUI_;
+
+  /**
+        * Function calls Herwig event generator via API
+	*
+	* According to the run mode different steps of event generation are done
+	**/
+  void callHerwigGenerator();
+
+  // The Inputfile ist created according to the parameter set
+  void createInputFile(const edm::ParameterSet &params);
+
+private:
+  std::shared_ptr<ThePEG::RandomEngineGlue::Proxy> randomEngineGlueProxy_;
+
+  const std::string dataLocation_;
+  const std::string generator_;
+  const std::string run_;
+  // File name containing Herwig input config
+  std::string dumpConfig_;
+  const unsigned int skipEvents_;
+  CLHEP::HepRandomEngine *randomEngine;
+};
+
+#endif  // GeneratorInterface_Herwig7Interface_Herwig7HepMC3Interface_h

--- a/GeneratorInterface/Herwig7Interface/plugins/BuildFile.xml
+++ b/GeneratorInterface/Herwig7Interface/plugins/BuildFile.xml
@@ -8,3 +8,11 @@
   <use name="thepeg"/>
   <flags EDM_PLUGIN="1"/>
 </library>
+
+<library name="GeneratorInterfaceHerwig7HepMC3HadronizerPlugins" file="Herwig7HepMC3Hadronizer.cc">
+  <use name="GeneratorInterface/Core"/>
+  <use name="GeneratorInterface/ExternalDecays"/>
+  <use name="boost"/>
+  <use name="thepeg"/>
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/GeneratorInterface/Herwig7Interface/plugins/Herwig7HepMC3Hadronizer.cc
+++ b/GeneratorInterface/Herwig7Interface/plugins/Herwig7HepMC3Hadronizer.cc
@@ -1,0 +1,250 @@
+#include <memory>
+#include <sstream>
+#include <fstream>
+
+#include <HepMC3/GenEvent.h>
+//#include <HepMC/IO_BaseClass.h>
+#include "HepMC3/Print.h"
+
+#include <ThePEG/Repository/Repository.h>
+#include <ThePEG/EventRecord/Event.h>
+#include <ThePEG/Config/ThePEG.h>
+#include <ThePEG/LesHouches/LesHouchesReader.h>
+
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "SimDataFormats/GeneratorProducts/interface/HepMC3Product.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct3.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenRunInfoProduct.h"
+
+#include "GeneratorInterface/Core/interface/BaseHadronizer.h"
+#include "GeneratorInterface/Core/interface/GeneratorFilter.h"
+#include "GeneratorInterface/Core/interface/HadronizerFilter.h"
+
+#include "GeneratorInterface/LHEInterface/interface/LHEProxy.h"
+
+#include "GeneratorInterface/Herwig7Interface/interface/Herwig7HepMC3Interface.h"
+
+#include <Herwig/API/HerwigAPI.h>
+#include "CLHEP/Random/RandomEngine.h"
+
+namespace CLHEP {
+  class HepRandomEngine;
+}
+
+class Herwig7HepMC3Hadronizer : public Herwig7HepMC3Interface, public gen::BaseHadronizer {
+public:
+  Herwig7HepMC3Hadronizer(const edm::ParameterSet& params);
+  ~Herwig7HepMC3Hadronizer() override;
+
+  bool readSettings(int) { return true; }
+  bool initializeForInternalPartons();
+  bool initializeForExternalPartons();
+  bool declareStableParticles(const std::vector<int>& pdgIds);
+  bool declareSpecialSettings(const std::vector<std::string>) { return true; }
+
+  void statistics();
+
+  bool generatePartonsAndHadronize();
+  bool hadronize();
+  bool decay();
+  bool residualDecay();
+  void finalizeEvent();
+
+  const char* classname() const { return "Herwig7HepMC3Hadronizer"; }
+  std::unique_ptr<GenLumiInfoHeader> getGenLumiInfoHeader() const override;
+  void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
+  void randomizeIndex(edm::LuminosityBlock const& lumi, CLHEP::HepRandomEngine* rengine);
+
+private:
+  void doSetRandomEngine(CLHEP::HepRandomEngine* v) override { setPEGRandomEngine(v); }
+
+  unsigned int eventsToPrint;
+
+  ThePEG::EventPtr thepegEvent;
+  bool haveEvt = false;
+
+  std::shared_ptr<lhef::LHEProxy> proxy_;
+  const std::string handlerDirectory_;
+  edm::ParameterSet paramSettings;
+  const std::string runFileName;
+
+  unsigned int firstLumiBlock = 0;
+  unsigned int currentLumiBlock = 0;
+};
+
+Herwig7HepMC3Hadronizer::Herwig7HepMC3Hadronizer(const edm::ParameterSet& pset)
+    : Herwig7HepMC3Interface(pset),
+      BaseHadronizer(pset),
+      eventsToPrint(pset.getUntrackedParameter<unsigned int>("eventsToPrint", 0)),
+      handlerDirectory_(pset.getParameter<std::string>("eventHandlers")),
+      runFileName(pset.getParameter<std::string>("run")) {
+  ivhepmc = 3;
+  initRepository(pset);
+  paramSettings = pset;
+}
+
+Herwig7HepMC3Hadronizer::~Herwig7HepMC3Hadronizer() {}
+
+bool Herwig7HepMC3Hadronizer::initializeForInternalPartons() {
+  if (currentLumiBlock == firstLumiBlock) {
+    std::ifstream runFile(runFileName + ".run");
+    if (runFile.fail())  //required for showering of LHE files
+    {
+      initRepository(paramSettings);
+    }
+    if (!initGenerator()) {
+      edm::LogInfo("Generator|Herwig7HepMC3Hadronizer") << "No run step for Herwig chosen. Program will be aborted.";
+      exit(0);
+    }
+  }
+  return true;
+}
+
+bool Herwig7HepMC3Hadronizer::initializeForExternalPartons() {
+  if (currentLumiBlock == firstLumiBlock) {
+    std::ifstream runFile(runFileName + ".run");
+    if (runFile.fail())  //required for showering of LHE files
+    {
+      initRepository(paramSettings);
+    }
+    if (!initGenerator()) {
+      edm::LogInfo("Generator|Herwig7HepMC3Hadronizer") << "No run step for Herwig chosen. Program will be aborted.";
+      exit(0);
+    }
+  }
+  return true;
+}
+
+bool Herwig7HepMC3Hadronizer::declareStableParticles(const std::vector<int>& pdgIds) { return false; }
+
+void Herwig7HepMC3Hadronizer::statistics() {
+  if (eg_) {
+    runInfo().setInternalXSec(
+        GenRunInfoProduct::XSec(eg_->integratedXSec() / ThePEG::picobarn, eg_->integratedXSecErr() / ThePEG::picobarn));
+  }
+}
+
+bool Herwig7HepMC3Hadronizer::generatePartonsAndHadronize() {
+  edm::LogInfo("Generator|Herwig7HepMC3Hadronizer") << "Start production";
+
+  try {
+    thepegEvent = eg_->shoot();
+  } catch (std::exception& exc) {
+    edm::LogWarning("Generator|Herwig7HepMC3Hadronizer")
+        << "EGPtr::shoot() thrown an exception, event skipped: " << exc.what();
+    return false;
+  }
+
+  if (!thepegEvent) {
+    edm::LogWarning("Generator|Herwig7HepMC3Hadronizer") << "thepegEvent not initialized";
+    return false;
+  }
+
+  event3() = convert(thepegEvent);
+  if (!event3().get()) {
+    edm::LogWarning("Generator|Herwig7HepMC3Hadronizer") << "genEvent not initialized";
+    return false;
+  }
+
+  return true;
+}
+
+bool Herwig7HepMC3Hadronizer::hadronize() {
+  if (!haveEvt) {
+    try {
+      thepegEvent = eg_->shoot();
+      haveEvt = true;
+    } catch (std::exception& exc) {
+      edm::LogWarning("Generator|Herwig7HepMC3Hadronizer")
+          << "EGPtr::shoot() thrown an exception, event skipped: " << exc.what();
+      return false;
+    }
+  }
+  int evtnum = lheEvent()->evtnum();
+  if (evtnum == -1) {
+    edm::LogError("Generator|Herwig7HepMC3Hadronizer")
+        << "Event number not set in lhe file, needed for correctly aligning Herwig and LHE events!";
+    return false;
+  }
+  if (thepegEvent->number() < evtnum) {
+    edm::LogError("Herwig7 interface") << "Herwig does not seem to be generating events in order, did you set "
+                                          "/Herwig/EventHandlers/FxFxLHReader:AllowedToReOpen Yes?";
+    return false;
+  } else if (thepegEvent->number() == evtnum) {
+    haveEvt = false;
+    if (!thepegEvent) {
+      edm::LogWarning("Generator|Herwig7HepMC3Hadronizer") << "thepegEvent not initialized";
+      return false;
+    }
+
+    event3() = convert(thepegEvent);
+    if (!event3().get()) {
+      edm::LogWarning("Generator|Herwig7HepMC3Hadronizer") << "genEvent not initialized";
+      return false;
+    }
+    return true;
+  }
+  edm::LogWarning("Generator|Herwig7HepMC3Hadronizer")
+      << "Event " << evtnum << " not generated (likely skipped in merging)";
+  return false;
+}
+
+void Herwig7HepMC3Hadronizer::finalizeEvent() {
+  eventInfo3() = std::make_unique<GenEventInfoProduct3>(event3().get());
+  eventInfo3()->setBinningValues(std::vector<double>(1, pthat(thepegEvent)));
+
+  if (eventsToPrint) {
+    eventsToPrint--;
+    //event3()->print();
+    HepMC3::Print::listing(*(event3().get()));
+  }
+
+  //  if (iobc_.get())
+  //    iobc_->write_event(event().get());
+
+  edm::LogInfo("Generator|Herwig7HepMC3Hadronizer") << "Event produced";
+}
+
+bool Herwig7HepMC3Hadronizer::decay() { return true; }
+
+bool Herwig7HepMC3Hadronizer::residualDecay() { return true; }
+
+std::unique_ptr<GenLumiInfoHeader> Herwig7HepMC3Hadronizer::getGenLumiInfoHeader() const {
+  auto genLumiInfoHeader = BaseHadronizer::getGenLumiInfoHeader();
+
+  if (thepegEvent) {
+    int weights_number = thepegEvent->optionalWeights().size();
+
+    if (weights_number > 1) {
+      genLumiInfoHeader->weightNames().reserve(weights_number + 1);
+      genLumiInfoHeader->weightNames().push_back("nominal");
+      std::map<std::string, double> weights_map = thepegEvent->optionalWeights();
+      for (std::map<std::string, double>::iterator it = weights_map.begin(); it != weights_map.end(); it++) {
+        genLumiInfoHeader->weightNames().push_back(it->first);
+      }
+    }
+  }
+
+  return genLumiInfoHeader;
+}
+
+void Herwig7HepMC3Hadronizer::randomizeIndex(edm::LuminosityBlock const& lumi, CLHEP::HepRandomEngine* rengine) {
+  BaseHadronizer::randomizeIndex(lumi, rengine);
+
+  if (firstLumiBlock == 0) {
+    firstLumiBlock = lumi.id().luminosityBlock();
+  }
+  currentLumiBlock = lumi.id().luminosityBlock();
+}
+
+#include "GeneratorInterface/ExternalDecays/interface/ExternalDecayDriver.h"
+
+typedef edm::GeneratorFilter<Herwig7HepMC3Hadronizer, gen::ExternalDecayDriver> Herwig7HepMC3GeneratorFilter;
+DEFINE_FWK_MODULE(Herwig7HepMC3GeneratorFilter);
+
+typedef edm::HadronizerFilter<Herwig7HepMC3Hadronizer, gen::ExternalDecayDriver> Herwig7HepMC3HadronizerFilter;
+DEFINE_FWK_MODULE(Herwig7HepMC3HadronizerFilter);

--- a/GeneratorInterface/Herwig7Interface/src/Herwig7HepMC3Interface.cc
+++ b/GeneratorInterface/Herwig7Interface/src/Herwig7HepMC3Interface.cc
@@ -1,0 +1,313 @@
+/** \class Herwig7Interface
+ *
+ *  Marco A. Harrendorf marco.harrendorf@cern.ch
+ *  Dominik Beutel dominik.beutel@cern.ch
+ */
+
+#include <cmath>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <sstream>
+
+#include <algorithm>
+
+#include <HepMC3/GenEvent.h>
+
+#include <Herwig/API/HerwigAPI.h>
+
+#include <ThePEG/Utilities/DynamicLoader.h>
+#include <ThePEG/Repository/Repository.h>
+#include <ThePEG/Handlers/EventHandler.h>
+#include <ThePEG/Handlers/XComb.h>
+#include <ThePEG/EventRecord/Event.h>
+#include <ThePEG/EventRecord/Particle.h>
+#include <ThePEG/EventRecord/Collision.h>
+#include <ThePEG/EventRecord/TmpTransform.h>
+#include <ThePEG/Config/ThePEG.h>
+#include <ThePEG/PDF/PartonExtractor.h>
+#include <ThePEG/PDF/PDFBase.h>
+#include <ThePEG/Utilities/UtilityBase.h>
+
+#include <GeneratorInterface/Herwig7Interface/interface/HepMC3Converter.h>
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "GeneratorInterface/Core/interface/ParameterCollector.h"
+
+#include "GeneratorInterface/Herwig7Interface/interface/Proxy.h"
+#include "GeneratorInterface/Herwig7Interface/interface/RandomEngineGlue.h"
+#include "GeneratorInterface/Herwig7Interface/interface/Herwig7HepMC3Interface.h"
+
+#include "CLHEP/Random/RandomEngine.h"
+
+using namespace std;
+using namespace gen;
+
+Herwig7HepMC3Interface::Herwig7HepMC3Interface(const edm::ParameterSet &pset)
+    : randomEngineGlueProxy_(ThePEG::RandomEngineGlue::Proxy::create()),
+      dataLocation_(ParameterCollector::resolve(pset.getParameter<string>("dataLocation"))),
+      generator_(pset.getParameter<string>("generatorModule")),
+      run_(pset.getParameter<string>("run")),
+      dumpConfig_(pset.getUntrackedParameter<string>("dumpConfig", "HerwigConfig.in")),
+      skipEvents_(pset.getUntrackedParameter<unsigned int>("skipEvents", 0)) {
+  // Write events in hepmc ascii format for debugging purposes
+#if 0
+  string dumpEvents = pset.getUntrackedParameter<string>("dumpEvents", "");
+  if (!dumpEvents.empty()) {
+    iobc_ = std::make_unique<HepMC::IO_GenEvent>(dumpEvents, ios::out);
+    edm::LogInfo("ThePEGSource") << "Event logging switched on (=> " << dumpEvents << ")";
+  }
+#endif
+  // Clear dumpConfig target
+  if (!dumpConfig_.empty())
+    ofstream cfgDump(dumpConfig_.c_str(), ios_base::trunc);
+}
+
+Herwig7HepMC3Interface::~Herwig7HepMC3Interface() noexcept {
+  if (eg_)
+    eg_->finalize();
+  edm::LogInfo("Herwig7HepMC3Interface") << "Event generator finalized";
+}
+
+void Herwig7HepMC3Interface::setPEGRandomEngine(CLHEP::HepRandomEngine *v) {
+  randomEngineGlueProxy_->setRandomEngine(v);
+  randomEngine = v;
+  ThePEG::RandomEngineGlue *rnd = randomEngineGlueProxy_->getInstance();
+  if (rnd) {
+    rnd->setRandomEngine(v);
+  }
+}
+
+void Herwig7HepMC3Interface::initRepository(const edm::ParameterSet &pset) {
+  std::string runModeTemp = pset.getUntrackedParameter<string>("runModeList", "read,run");
+
+  // To Lower
+  std::transform(runModeTemp.begin(), runModeTemp.end(), runModeTemp.begin(), ::tolower);
+
+  while (!runModeTemp.empty()) {
+    // Split first part of List
+    std::string choice;
+    size_t pos = runModeTemp.find(',');
+    if (std::string::npos == pos)
+      choice = runModeTemp;
+    else
+      choice = runModeTemp.substr(0, pos);
+
+    if (pos == std::string::npos)
+      runModeTemp.erase();
+    else
+      runModeTemp.erase(0, pos + 1);
+
+    HwUI_ = std::make_shared<Herwig::HerwigUIProvider>(pset, dumpConfig_, Herwig::RunMode::READ);
+    edm::LogInfo("Herwig7HepMC3Interface")
+        << "HerwigUIProvider object with run mode " << HwUI_->runMode() << " created.\n";
+
+    // Chose run mode
+    if (choice == "read") {
+      createInputFile(pset);
+      HwUI_->setRunMode(Herwig::RunMode::READ, pset, dumpConfig_);
+      edm::LogInfo("Herwig7HepMC3Interface")
+          << "Input file " << dumpConfig_ << " will be passed to Herwig for the read step.\n";
+      callHerwigGenerator();
+    } else if (choice == "build") {
+      createInputFile(pset);
+      HwUI_->setRunMode(Herwig::RunMode::BUILD, pset, dumpConfig_);
+      edm::LogInfo("Herwig7HepMC3Interface")
+          << "Input file " << dumpConfig_ << " will be passed to Herwig for the build step.\n";
+      callHerwigGenerator();
+
+    } else if (choice == "integrate") {
+      std::string runFileName = run_ + ".run";
+      edm::LogInfo("Herwig7HepMC3Interface")
+          << "Run file " << runFileName << " will be passed to Herwig for the integrate step.\n";
+      HwUI_->setRunMode(Herwig::RunMode::INTEGRATE, pset, runFileName);
+      callHerwigGenerator();
+
+    } else if (choice == "run") {
+      std::string runFileName = run_ + ".run";
+      edm::LogInfo("Herwig7HepMC3Interface")
+          << "Run file " << runFileName << " will be passed to Herwig for the run step.\n";
+      HwUI_->setRunMode(Herwig::RunMode::RUN, pset, runFileName);
+    } else {
+      edm::LogInfo("Herwig7HepMC3Interface") << "Cannot recognize \"" << choice << "\".\n"
+                                             << "Trying to skip step.\n";
+      continue;
+    }
+  }
+}
+
+void Herwig7HepMC3Interface::callHerwigGenerator() {
+  try {
+    edm::LogInfo("Herwig7HepMC3Interface")
+        << "callHerwigGenerator function invoked with run mode " << HwUI_->runMode() << ".\n";
+
+    // Call program switches according to runMode
+    switch (HwUI_->runMode()) {
+      case Herwig::RunMode::INIT:
+        Herwig::API::init(*HwUI_);
+        break;
+      case Herwig::RunMode::READ:
+        Herwig::API::read(*HwUI_);
+        break;
+      case Herwig::RunMode::BUILD:
+        Herwig::API::build(*HwUI_);
+        break;
+      case Herwig::RunMode::INTEGRATE:
+        Herwig::API::integrate(*HwUI_);
+        break;
+      case Herwig::RunMode::MERGEGRIDS:
+        Herwig::API::mergegrids(*HwUI_);
+        break;
+      case Herwig::RunMode::RUN: {
+        HwUI_->setSeed(randomEngine->getSeed());
+        eg_ = Herwig::API::prepareRun(*HwUI_);
+        break;
+      }
+      case Herwig::RunMode::ERROR:
+        edm::LogError("Herwig7HepMC3Interface") << "Error during read in of command line parameters.\n"
+                                                << "Program execution will stop now.";
+        return;
+      default:
+        HwUI_->quitWithHelp();
+    }
+
+    return;
+
+  } catch (ThePEG::Exception &e) {
+    edm::LogError("Herwig7HepMC3Interface") << ": ThePEG::Exception caught.\n"
+                                            << e.what() << '\n'
+                                            << "See logfile for details.\n";
+    return;
+  } catch (std::exception &e) {
+    edm::LogError("Herwig7HepMC3Interface") << ": " << e.what() << '\n';
+    return;
+  } catch (const char *what) {
+    edm::LogError("Herwig7HepMC3Interface") << ": caught exception: " << what << "\n";
+    return;
+  }
+}
+
+bool Herwig7HepMC3Interface::initGenerator() {
+  if (HwUI_->runMode() == Herwig::RunMode::RUN) {
+    edm::LogInfo("Herwig7HepMC3Interface") << "Starting EventGenerator initialization";
+    callHerwigGenerator();
+    edm::LogInfo("Herwig7HepMC3Interface") << "EventGenerator initialized";
+
+    // Skip events
+    for (unsigned int i = 0; i < skipEvents_; i++) {
+      flushRandomNumberGenerator();
+      eg_->shoot();
+      edm::LogInfo("Herwig7HepMC3Interface") << "Event discarded";
+    }
+
+    return true;
+
+  } else {
+    edm::LogInfo("Herwig7HepMC3Interface") << "Stopped EventGenerator due to missing run mode.";
+    return false;
+    /*
+		throw cms::Exception("Herwig7HepMC3Interface")
+			<< "EventGenerator could not be initialized due to wrong run mode!" << endl;
+*/
+  }
+}
+
+void Herwig7HepMC3Interface::flushRandomNumberGenerator() {
+  /*ThePEG::RandomEngineGlue *rnd = randomEngineGlueProxy_->getInstance();
+
+	if (!rnd)
+		edm::LogWarning("ProxyMissing")
+			<< "ThePEG not initialised with RandomEngineGlue.";
+	else
+		rnd->flush();
+      */
+}
+
+unique_ptr<HepMC3::GenEvent> Herwig7HepMC3Interface::convert(const ThePEG::EventPtr &event) {
+  return std::unique_ptr<HepMC3::GenEvent>(ThePEG::HepMCConverter<HepMC3::GenEvent>::convert(*event));
+}
+
+double Herwig7HepMC3Interface::pthat(const ThePEG::EventPtr &event) {
+  using namespace ThePEG;
+
+  if (!event->primaryCollision())
+    return -1.0;
+
+  tSubProPtr sub = event->primaryCollision()->primarySubProcess();
+  TmpTransform<tSubProPtr> tmp(sub, Utilities::getBoostToCM(sub->incoming()));
+
+  double pthat = (*sub->outgoing().begin())->momentum().perp() / ThePEG::GeV;
+  for (PVector::const_iterator it = sub->outgoing().begin(); it != sub->outgoing().end(); ++it)
+    pthat = std::min<double>(pthat, (*it)->momentum().perp() / ThePEG::GeV);
+
+  return pthat;
+}
+
+void Herwig7HepMC3Interface::createInputFile(const edm::ParameterSet &pset) {
+  /* Initialize the input config for Herwig from
+	 * 1. the Herwig7 config files
+	 * 2. the CMSSW config blocks
+	 * Writes them to an output file which is read by Herwig
+	*/
+
+  stringstream logstream;
+
+  // Contains input config passed to Herwig
+  stringstream herwiginputconfig;
+
+  // Define output file to which input config is written, too, if dumpConfig parameter is set.
+  // Otherwise use default file HerwigConfig.in which is read in by Herwig
+  ofstream cfgDump;
+  cfgDump.open(dumpConfig_.c_str(), ios_base::app);
+
+  // Read Herwig config files as input
+  vector<string> configFiles = pset.getParameter<vector<string> >("configFiles");
+  // Loop over the config files
+  for (const auto &iter : configFiles) {
+    // Open external config file
+    ifstream externalConfigFile(iter);
+    if (externalConfigFile.is_open()) {
+      edm::LogInfo("Herwig7HepMC3Interface") << "Reading config file (" << iter << ")" << endl;
+      stringstream configFileStream;
+      configFileStream << externalConfigFile.rdbuf();
+      string configFileContent = configFileStream.str();
+
+      // Comment out occurence of saverun in config file since it is set later considering run and generator option
+      string searchKeyword("saverun");
+      if (configFileContent.find(searchKeyword) != std::string::npos) {
+        edm::LogInfo("Herwig7HepMC3Interface")
+            << "Commented out saverun command in external input config file(" << iter << ")" << endl;
+        configFileContent.insert(configFileContent.find(searchKeyword), "#");
+      }
+      herwiginputconfig << "# Begin Config file input" << endl
+                        << configFileContent << endl
+                        << "# End Config file input";
+      edm::LogInfo("Herwig7HepMC3Interface") << "Finished reading config file (" << iter << ")" << endl;
+    } else {
+      edm::LogWarning("Herwig7HepMC3Interface") << "Could not read config file (" << iter << ")" << endl;
+    }
+  }
+
+  edm::LogInfo("Herwig7HepMC3Interface") << "Start with processing CMSSW config" << endl;
+  // Read CMSSW config file parameter sets starting from "parameterSets"
+  ParameterCollector collector(pset);
+  ParameterCollector::const_iterator iter;
+  iter = collector.begin();
+  herwiginputconfig << endl << "# Begin Parameter set input\n" << endl;
+  for (; iter != collector.end(); ++iter) {
+    herwiginputconfig << *iter << endl;
+  }
+
+  // Add some additional necessary lines to the Herwig input config
+  herwiginputconfig << "saverun " << run_ << " " << generator_ << endl;
+  // write the ProxyID for the RandomEngineGlue to fill its pointer in
+  ostringstream ss;
+  ss << randomEngineGlueProxy_->getID();
+  //herwiginputconfig << "set " << generator_ << ":RandomNumberGenerator:ProxyID " << ss.str() << endl;
+
+  // Dump Herwig input config to file, so that it can be read by Herwig
+  cfgDump << herwiginputconfig.str() << endl;
+  cfgDump.close();
+}

--- a/GeneratorInterface/Herwig7Interface/test/DYToLL_TuneCH3_13TeV_herwig7_hepmc3_cfg.py
+++ b/GeneratorInterface/Herwig7Interface/test/DYToLL_TuneCH3_13TeV_herwig7_hepmc3_cfg.py
@@ -89,7 +89,7 @@ process.genstepfilter.triggerConditions=cms.vstring("generation_step")
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
 
-process.generator = cms.EDFilter("Herwig7GeneratorFilter",
+process.generator = cms.EDFilter("Herwig7HepMC3GeneratorFilter",
     configFiles = cms.vstring(),
     eventsToPrint = cms.untracked.uint32(1),
     crossSection = cms.untracked.double(-1),


### PR DESCRIPTION
#### PR description:

This PR adds plugins Herwig7HepMC3GeneratorFilter and Herwig7HepMC3HadronizerFilter that create HepMC3 products to Herwig7Interface.

#### PR validation:

Tested with configurations from /test : DYToLL_TuneCH3_13TeV_herwig7_cfg.py and DYToLL_TuneCH3_13TeV_herwig7_hepmc3_cfg.py