### PR TITLE
[15_0_X] Plugin to obtain the best track index for Run3ScoutingElectron

### DIFF
--- a/PhysicsTools/Scouting/plugins/BuildFile.xml
+++ b/PhysicsTools/Scouting/plugins/BuildFile.xml
@@ -1,5 +1,13 @@
 <use name="fastjet"/>
 <use name="fastjet-contrib"/>
+
+<use name="FWCore/Framework"/>
+<use name="FWCore/ParameterSet"/>
+<use name="FWCore/PluginManager"/>
+
+<use name="DataFormats/Math"/>
+<use name="DataFormats/Scouting"/>
+
 <use name="PhysicsTools/PatAlgos"/>
 <library file="*.cc" name="PhysicsToolsScoutingPlugins">
   <flags EDM_PLUGIN="1"/>

--- a/PhysicsTools/Scouting/plugins/Run3ScoutingElectronBestTrack.cc
+++ b/PhysicsTools/Scouting/plugins/Run3ScoutingElectronBestTrack.cc
@@ -1,0 +1,216 @@
+// -*- C++ -*-
+//
+// Package:    PhysicsTools/Scouting
+// Class:      Run3ScoutingElectronBestTrackProducer
+//
+/**
+ Description: Choose the most suitable track for a given scouting electron
+ Implementation:
+     Allows for ID selections on the tracks before associating them to the electrons
+*/
+//
+// Original Author:  Abanti Ranadhir Sahasransu and Patin Inkaew
+//         Created:  Fri, 31 Jan 2025 14:43:20 GMT
+//
+//
+
+// system include files
+#include <limits>
+#include <memory>
+#include <vector>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/Math/interface/LorentzVector.h"
+#include "DataFormats/Math/interface/deltaPhi.h"
+#include "DataFormats/Scouting/interface/Run3ScoutingElectron.h"
+
+//
+// class declaration
+//
+
+class Run3ScoutingElectronBestTrackProducer : public edm::stream::EDProducer<> {
+public:
+  explicit Run3ScoutingElectronBestTrackProducer(const edm::ParameterSet&);
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+  template <typename T>
+  void putValueMap(edm::Event&, edm::Handle<Run3ScoutingElectronCollection>&, const std::vector<T>&, const std::string&);
+
+  const edm::EDGetTokenT<std::vector<Run3ScoutingElectron>> run3ScoutingElectronToken_;
+  std::vector<double> trackPtMin_;
+  std::vector<double> trackChi2OverNdofMax_;
+  std::vector<double> relativeEnergyDifferenceMax_;
+  std::vector<double> deltaPhiMax_;
+};
+
+//
+// constructors and destructor
+//
+Run3ScoutingElectronBestTrackProducer::Run3ScoutingElectronBestTrackProducer(const edm::ParameterSet& iConfig)
+    : run3ScoutingElectronToken_(
+          consumes<std::vector<Run3ScoutingElectron>>(iConfig.getParameter<edm::InputTag>("Run3ScoutingElectron"))) {
+  trackPtMin_ = iConfig.getParameter<std::vector<double>>("TrackPtMin");
+  trackChi2OverNdofMax_ = iConfig.getParameter<std::vector<double>>("TrackChi2OverNdofMax");
+  relativeEnergyDifferenceMax_ = iConfig.getParameter<std::vector<double>>("RelativeEnergyDifferenceMax");
+  deltaPhiMax_ = iConfig.getParameter<std::vector<double>>("DeltaPhiMax");
+
+  if (trackPtMin_.size() != 2) {
+    throw cms::Exception("Run3ScoutingElectronBestTrackProducer")
+        << "TrackPtMin must have exactly 2 elements for EB and EE respectively!";
+  }
+  if (trackChi2OverNdofMax_.size() != 2) {
+    throw cms::Exception("Run3ScoutingElectronBestTrackProducer")
+        << "TrackChi2OverNdofMax must have exactly 2 elements for EB and EE respectively!";
+  }
+  if (relativeEnergyDifferenceMax_.size() != 2) {
+    throw cms::Exception("Run3ScoutingElectronBestTrackProducer")
+        << "RelativeEnergyDifferenceMax must have exactly 2 elements for EB and EE respectively!";
+  }
+  if (deltaPhiMax_.size() != 2) {
+    throw cms::Exception("Run3ScoutingElectronBestTrackProducer")
+        << "DeltaPhiMax must have exactly 2 elements for EB and EE respectively!";
+  }
+
+  produces<edm::ValueMap<int>>("Run3ScoutingElectronBestTrackIndex");
+  produces<edm::ValueMap<float>>("Run3ScoutingElectronTrackd0");
+  produces<edm::ValueMap<float>>("Run3ScoutingElectronTrackdz");
+  produces<edm::ValueMap<float>>("Run3ScoutingElectronTrackpt");
+  produces<edm::ValueMap<float>>("Run3ScoutingElectronTracketa");
+  produces<edm::ValueMap<float>>("Run3ScoutingElectronTrackphi");
+  produces<edm::ValueMap<float>>("Run3ScoutingElectronTrackpMode");
+  produces<edm::ValueMap<float>>("Run3ScoutingElectronTracketaMode");
+  produces<edm::ValueMap<float>>("Run3ScoutingElectronTrackphiMode");
+  produces<edm::ValueMap<float>>("Run3ScoutingElectronTrackqoverpModeError");
+  produces<edm::ValueMap<float>>("Run3ScoutingElectronTrackchi2overndf");
+  produces<edm::ValueMap<int>>("Run3ScoutingElectronTrackcharge");
+}
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+void Run3ScoutingElectronBestTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  edm::Handle<std::vector<Run3ScoutingElectron>> run3ScoutingElectronHandle;
+  iEvent.getByToken(run3ScoutingElectronToken_, run3ScoutingElectronHandle);
+
+  if (!run3ScoutingElectronHandle.isValid()) {
+    // Handle the absence as a warning
+    edm::LogWarning("Run3ScoutingElectronBestTrackProducer")
+        << "No Run3ScoutingElectron collection found in the event!";
+    return;
+  }
+
+  const size_t num_electrons = run3ScoutingElectronHandle->size();
+  std::vector<int> besttrk_idx(num_electrons, -1);
+  std::vector<float> besttrk_d0s(num_electrons, std::numeric_limits<float>::max());
+  std::vector<float> besttrk_dzs(num_electrons, std::numeric_limits<float>::max());
+  std::vector<float> besttrk_pts(num_electrons, std::numeric_limits<float>::max());
+  std::vector<float> besttrk_etas(num_electrons, std::numeric_limits<float>::max());
+  std::vector<float> besttrk_phis(num_electrons, std::numeric_limits<float>::max());
+  std::vector<float> besttrk_pModes(num_electrons, std::numeric_limits<float>::max());
+  std::vector<float> besttrk_etaModes(num_electrons, std::numeric_limits<float>::max());
+  std::vector<float> besttrk_phiModes(num_electrons, std::numeric_limits<float>::max());
+  std::vector<float> besttrk_qoverpModeErrors(num_electrons, std::numeric_limits<float>::max());
+  std::vector<float> besttrk_chi2overndfs(num_electrons, std::numeric_limits<float>::max());
+  std::vector<int> besttrk_charges(num_electrons, std::numeric_limits<int>::max());
+
+  for (size_t iElectron = 0; iElectron < num_electrons; ++iElectron) {
+    const Run3ScoutingElectron& electron = run3ScoutingElectronHandle->at(iElectron);
+    const math::PtEtaPhiMLorentzVector cluster(electron.pt(), electron.eta(), electron.phi(), 0.0005);
+
+    double besttrack_ediff = std::numeric_limits<double>::max();
+
+    for (unsigned int i = 0; i < electron.trkpt().size(); ++i) {
+      const unsigned int eta_idx = (std::abs(electron.trketa()[i]) < 1.479) ? 0 : 1;
+      if (electron.trkpt()[i] < trackPtMin_[eta_idx])
+        continue;
+      if (electron.trkchi2overndf()[i] > trackChi2OverNdofMax_[eta_idx])
+        continue;
+
+      const math::PtEtaPhiMLorentzVector gsftrack(
+          electron.trkpt()[i], electron.trketa()[i], electron.trkphi()[i], 0.0005);
+
+      if (deltaPhi(cluster.phi(), gsftrack.phi()) > deltaPhiMax_[eta_idx])
+        continue;
+
+      const double track_ediff = std::abs((cluster.energy() - gsftrack.energy()) / cluster.energy());
+      if (track_ediff > relativeEnergyDifferenceMax_[eta_idx])
+        continue;
+
+      if (track_ediff < besttrack_ediff) {
+        besttrack_ediff = track_ediff;
+        besttrk_idx[iElectron] = i;
+      }
+    }
+
+    if (besttrk_idx[iElectron] >= 0) {
+      besttrk_d0s[iElectron] = electron.trkd0()[besttrk_idx[iElectron]];
+      besttrk_dzs[iElectron] = electron.trkdz()[besttrk_idx[iElectron]];
+      besttrk_pts[iElectron] = electron.trkpt()[besttrk_idx[iElectron]];
+      besttrk_etas[iElectron] = electron.trketa()[besttrk_idx[iElectron]];
+      besttrk_phis[iElectron] = electron.trkphi()[besttrk_idx[iElectron]];
+      if (!electron.trkpMode().empty()) {
+        besttrk_pModes[iElectron] = electron.trkpMode()[besttrk_idx[iElectron]];
+        besttrk_etaModes[iElectron] = electron.trketaMode()[besttrk_idx[iElectron]];
+        besttrk_phiModes[iElectron] = electron.trkphiMode()[besttrk_idx[iElectron]];
+        besttrk_qoverpModeErrors[iElectron] = electron.trkqoverpModeError()[besttrk_idx[iElectron]];
+      }
+      besttrk_chi2overndfs[iElectron] = electron.trkchi2overndf()[besttrk_idx[iElectron]];
+      besttrk_charges[iElectron] = electron.trkcharge()[besttrk_idx[iElectron]];
+    }
+  }
+
+  putValueMap<int>(iEvent, run3ScoutingElectronHandle, besttrk_idx, "Run3ScoutingElectronBestTrackIndex");
+  putValueMap<float>(iEvent, run3ScoutingElectronHandle, besttrk_d0s, "Run3ScoutingElectronTrackd0");
+  putValueMap<float>(iEvent, run3ScoutingElectronHandle, besttrk_dzs, "Run3ScoutingElectronTrackdz");
+  putValueMap<float>(iEvent, run3ScoutingElectronHandle, besttrk_pts, "Run3ScoutingElectronTrackpt");
+  putValueMap<float>(iEvent, run3ScoutingElectronHandle, besttrk_etas, "Run3ScoutingElectronTracketa");
+  putValueMap<float>(iEvent, run3ScoutingElectronHandle, besttrk_phis, "Run3ScoutingElectronTrackphi");
+  putValueMap<float>(iEvent, run3ScoutingElectronHandle, besttrk_pModes, "Run3ScoutingElectronTrackpMode");
+  putValueMap<float>(iEvent, run3ScoutingElectronHandle, besttrk_etaModes, "Run3ScoutingElectronTracketaMode");
+  putValueMap<float>(iEvent, run3ScoutingElectronHandle, besttrk_phiModes, "Run3ScoutingElectronTrackphiMode");
+  putValueMap<float>(
+      iEvent, run3ScoutingElectronHandle, besttrk_qoverpModeErrors, "Run3ScoutingElectronTrackqoverpModeError");
+  putValueMap<float>(iEvent, run3ScoutingElectronHandle, besttrk_chi2overndfs, "Run3ScoutingElectronTrackchi2overndf");
+  putValueMap<int>(iEvent, run3ScoutingElectronHandle, besttrk_charges, "Run3ScoutingElectronTrackcharge");
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void Run3ScoutingElectronBestTrackProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>(("Run3ScoutingElectron"), edm::InputTag("hltScoutingEgammaPacker"));
+  desc.add<std::vector<double>>(("TrackPtMin"), {0.0, 0.0});
+  desc.add<std::vector<double>>(("TrackChi2OverNdofMax"), {9999.0, 9999.0});
+  desc.add<std::vector<double>>(("RelativeEnergyDifferenceMax"), {9999.0, 9999.0});
+  desc.add<std::vector<double>>(("DeltaPhiMax"), {9999.0, 9999.0});
+  descriptions.add("Run3ScoutingElectronBestTrackProducer", desc);
+}
+
+// ------------ method template for putting value maps into the event  ------------
+template <typename T>
+void Run3ScoutingElectronBestTrackProducer::putValueMap(edm::Event& iEvent,
+                                                        edm::Handle<Run3ScoutingElectronCollection>& handle,
+                                                        const std::vector<T>& values,
+                                                        const std::string& label) {
+  std::unique_ptr<edm::ValueMap<T>> valuemap(new edm::ValueMap<T>());
+  typename edm::ValueMap<T>::Filler filler(*valuemap);
+  filler.insert(handle, values.begin(), values.end());
+  filler.fill();
+  iEvent.put(std::move(valuemap), label);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(Run3ScoutingElectronBestTrackProducer);

--- a/PhysicsTools/Scouting/test/BuildFile.xml
+++ b/PhysicsTools/Scouting/test/BuildFile.xml
@@ -1,0 +1,1 @@
+<test name="TestRun3ScoutingBestTrackPluginRun" command="test_Run3ScoutingElectronBestTrack.sh"/>

--- a/PhysicsTools/Scouting/test/ref_Run3ScoutingElectronBestTrack_outputevtctnt.txt
+++ b/PhysicsTools/Scouting/test/ref_Run3ScoutingElectronBestTrack_outputevtctnt.txt
@@ -1,0 +1,14 @@
+Type                      Module                      Label             Process   
+----------------------------------------------------------------------------------
+edm::ValueMap<float>      "run3ScoutingElectronBestTrack"   "Run3ScoutingElectronTrackchi2overndf"   "Demo"    
+edm::ValueMap<float>      "run3ScoutingElectronBestTrack"   "Run3ScoutingElectronTrackd0"   "Demo"    
+edm::ValueMap<float>      "run3ScoutingElectronBestTrack"   "Run3ScoutingElectronTrackdz"   "Demo"    
+edm::ValueMap<float>      "run3ScoutingElectronBestTrack"   "Run3ScoutingElectronTracketa"   "Demo"    
+edm::ValueMap<float>      "run3ScoutingElectronBestTrack"   "Run3ScoutingElectronTracketaMode"   "Demo"    
+edm::ValueMap<float>      "run3ScoutingElectronBestTrack"   "Run3ScoutingElectronTrackpMode"   "Demo"    
+edm::ValueMap<float>      "run3ScoutingElectronBestTrack"   "Run3ScoutingElectronTrackphi"   "Demo"    
+edm::ValueMap<float>      "run3ScoutingElectronBestTrack"   "Run3ScoutingElectronTrackphiMode"   "Demo"    
+edm::ValueMap<float>      "run3ScoutingElectronBestTrack"   "Run3ScoutingElectronTrackpt"   "Demo"    
+edm::ValueMap<float>      "run3ScoutingElectronBestTrack"   "Run3ScoutingElectronTrackqoverpModeError"   "Demo"    
+edm::ValueMap<int>        "run3ScoutingElectronBestTrack"   "Run3ScoutingElectronBestTrackIndex"   "Demo"    
+edm::ValueMap<int>        "run3ScoutingElectronBestTrack"   "Run3ScoutingElectronTrackcharge"   "Demo"    

--- a/PhysicsTools/Scouting/test/test_Run3ScoutingElectronBestTrack.sh
+++ b/PhysicsTools/Scouting/test/test_Run3ScoutingElectronBestTrack.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Pass in name and status
+function die { echo $1: status $2 ;  exit $2; }
+
+F1=${CMSSW_BASE}/src/PhysicsTools/Scouting/test/test_Run3ScoutingElectronBestTrack_cfg.py
+(cmsRun $F1 ) || die "Failure runnning $F1" $?
+
+# If the above test passes, test the content of the output ROOT Failure
+echo "Testing the content of the output ROOT file"
+edmDumpEventContent output_file.root > output_evtctnt.txt
+diff output_evtctnt.txt ${CMSSW_BASE}/src/PhysicsTools/Scouting/test/ref_Run3ScoutingElectronBestTrack_outputevtctnt.txt || die "Failure comparing edmDumpEventContent" $?

--- a/PhysicsTools/Scouting/test/test_Run3ScoutingElectronBestTrack_cfg.py
+++ b/PhysicsTools/Scouting/test/test_Run3ScoutingElectronBestTrack_cfg.py
@@ -1,0 +1,48 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("Demo")
+
+# Load standard configurations
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
+process.load("Configuration.StandardSequences.MagneticField_cff")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+
+# Set the global tag
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, '140X_dataRun3_HLT_v3', '')
+
+# Configure the MessageLogger
+process.MessageLogger.cerr.FwkReport.reportEvery = 100
+
+# Input source
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+        '/store/data/Run2024I/ScoutingPFRun3/HLTSCOUT/v1/000/386/478/00000/0100d00a-69a6-4710-931f-b1c660f87675.root'  # Replace with your input file
+    )
+)
+
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1000))
+
+# ScoutingElectronBestTrack producer
+process.run3ScoutingElectronBestTrack = cms.EDProducer('Run3ScoutingElectronBestTrackProducer',
+    Run3ScoutingElectron = cms.InputTag('hltScoutingEgammaPacker'),
+    TrackPtMin = cms.vdouble(12.0, 12.0),
+    TrackChi2OverNdofMax = cms.vdouble(3.0, 2.0),
+    RelativeEnergyDifferenceMax = cms.vdouble(1.0, 1.0),
+    DeltaPhiMax = cms.vdouble(0.06, 0.06)
+)
+
+# Output definition
+process.output = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('output_file.root'),  # Replace with your output file
+    outputCommands = cms.untracked.vstring('drop *',
+                                           'keep *_run3ScoutingElectronBestTrack_*_*')
+)
+
+# Path and EndPath definitions
+process.p = cms.Path(process.run3ScoutingElectronBestTrack)
+process.e = cms.EndPath(process.output)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.p, process.e)


### PR DESCRIPTION
#### PR description:

The new plugin returns the best track index and other associated variables as value maps for use in NanoAOD creation for HLTSCOUT dataset. Discussed extensively in Scouting meeting. Relevant slides are linked below.
- https://indico.cern.ch/event/1527339/#10-technical-implementation-of
- slide 4 of https://indico.cern.ch/event/1527339/#9-towards-the-scouting-nano-pr

Also includes a test functionality in the test directory to manually verify the sensibility of the code output.


#### PR validation:

 - Standard set of checks including conventions as described in https://cms-sw.github.io/cms_coding_rules.html. 
 - Followed by code corrections from 
```
scram b code-checks
scram b code-format
scram b runtests
```
 - Cross-checked the output of code tests/run_Run3ScoutingElectronBestTrack_cfg.py. The values of the edmValueMaps in the root file are sensible.

#### Backport:

- Backport of PR #47726 .