### PR TITLE
Do not use command ls with -lh option: Fixes unit test for ASAN IB

### DIFF
--- a/CondCore/Utilities/test/test_uploadConditions.sh
+++ b/CondCore/Utilities/test/test_uploadConditions.sh
@@ -32,7 +32,7 @@ cat <<EOF >> BasicPayload_v0_ref.txt
 }
 EOF
 
-echo "Content of the directory is:" `ls -lh . | grep db`
+#echo "Content of the directory is:" `ls -lh . | grep db`
 echo -ne '\n\n'
 
 if test -f "BasicPayload_v0.txt"; then

--- a/CondCore/Utilities/test/test_uploadConditions.sh
+++ b/CondCore/Utilities/test/test_uploadConditions.sh
@@ -32,7 +32,7 @@ cat <<EOF >> BasicPayload_v0_ref.txt
 }
 EOF
 
-#echo "Content of the directory is:" `ls -lh . | grep db`
+echo "Content of the directory is:" `ls . | grep db`
 echo -ne '\n\n'
 
 if test -f "BasicPayload_v0.txt"; then


### PR DESCRIPTION
Looks like `ls -lh` under ASAN IB environment is misbehaving and allocates a lot memory ( see https://github.com/cms-sw/cmssw/issues/47744#issuecomment-2794048311 ). This PR changes `ls -lh` to `ls` ( i.e. without `-lh` options) which fixes the unit test to run under ASAN env

fixes #47744