### PR TITLE
Fix the AlCaRecoTriggerBits/SecondaryDataset tag for the first IOVs in Run2 and Run3 data GT

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,7 +24,7 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'                   :    '131X_mcRun2_pA_v3',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'                    :    '141X_dataRun2_v2',
+    'run2_data'                    :    '141X_dataRun2_v3',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_HEfail'             :    '140X_dataRun2_HEfail_v1',
     # GlobalTag for Run2 HI data
@@ -37,8 +37,8 @@ autoCond = {
     'run3_data_express'            :    '150X_dataRun3_Express_frozen250122_v1',
     # GlobalTag for Run3 data relvals (prompt GT): same as 150X_dataRun3_Prompt_v1 but with snapshot at 2025-01-22 13:49:01 (UTC)
     'run3_data_prompt'             :    '150X_dataRun3_Prompt_frozen250122_v1',
-    # GlobalTag for Run3 offline data reprocessing - snapshot at 2025-03-19 17:13:09 (UTC)
-    'run3_data'                    :    '150X_dataRun3_v3',
+    # GlobalTag for Run3 offline data reprocessing - snapshot at 2025-04-10 16:45:49 (UTC)
+    'run3_data'                    :    '150X_dataRun3_v4',
     # GlobalTag for Run3 offline data reprocessing with Prompt GT, currently for 2022FG - snapshot at 2024-05-31 08:53:25 (UTC)
     'run3_data_PromptAnalysis'     :    '140X_dataRun3_PromptAnalysis_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)


### PR DESCRIPTION
#### PR description:

Fix the AlCaRecoTriggerBits/SecondaryDataset tag for the first IOVs in Run2 and Run3 data GT

Modified GTs in autoCond:

- 'run2_data'   :    [141X_dataRun2_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/141X_dataRun2_v3)
  - Difference wrt previous _v2 is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/141X_dataRun2_v2/141X_dataRun2_v3) 

- 'run3_data'   :    [150X_dataRun3_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/150X_dataRun3_v4)
  - Difference wrt previous _v3 is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/150X_dataRun3_v3/150X_dataRun3_v4) 


#### PR validation:

To be tested together with #47813 (only to verify whether the issue is fixed: it can be merged independently)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Possible backport to CMSSW_15_0_X
