### PR TITLE
Add a log message for URLs the XrdAdaptor opens

### DIFF
--- a/Utilities/XrdAdaptor/src/XrdRequestManager.cc
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.cc
@@ -406,13 +406,13 @@ bool RequestManager::compareSources(const timespec &now,
     std::string hostname_a;
     Source::getHostname(activeSources[a]->ID(), hostname_a);
     if (quality_a > 5130) {
-      edm::LogWarning("XrdAdaptorLvl3") << "Deactivating " << hostname_a << " from active sources because the quality ("
+      edm::LogFwkInfo("XrdAdaptorLvl3") << "Deactivating " << hostname_a << " from active sources because the quality ("
                                         << quality_a << ") is above 5130 and it is not the only active server";
     }
     if ((quality_a > 260) && (quality_b * 4 < quality_a)) {
       std::string hostname_b;
       Source::getHostname(activeSources[b]->ID(), hostname_b);
-      edm::LogWarning("XrdAdaptorLvl3") << "Deactivating " << hostname_a << " from active sources because its quality ("
+      edm::LogFwkInfo("XrdAdaptorLvl3") << "Deactivating " << hostname_a << " from active sources because its quality ("
                                         << quality_a
                                         << ") is higher than 260 and 4 times larger than the other active server "
                                         << hostname_b << " (" << quality_b << ") ";

--- a/Utilities/XrdAdaptor/src/XrdSource.cc
+++ b/Utilities/XrdAdaptor/src/XrdSource.cc
@@ -194,6 +194,9 @@ Source::Source(timespec now, std::unique_ptr<XrdCl::File> fh, const std::string 
 #endif
 {
   if (m_fh.get()) {
+    std::string lastUrl;
+    m_fh->GetProperty("LastURL", lastUrl);
+    edm::LogFwkInfo("XrdAdaptor") << "Opened a file at URL " << lastUrl;
     if (!m_fh->GetProperty("DataServer", m_id)) {
       edm::LogWarning("XrdFileWarning") << "Source::Source() failed to determine data server name.'";
     }


### PR DESCRIPTION
#### PR description:

Came up in https://github.com/cms-sw/cmssw/issues/47750#issuecomment-2770457306 . In addition I changed the `Deactivating ...` prinout level to FwkInfo (the severity is similar to other framework-issued information messages that are shown by default)

Resolves https://github.com/cms-sw/framework-team/issues/1326

#### PR validation:

Log has printouts along
```
%MSG-f XrdAdaptor:  (NoModuleName) 10-Apr-2025 16:13:54 CEST pre-events
Opened a file at URL root://xrootd-se33-vanderbilt.sites.opensciencegrid.org:1094//store/data/Run2024I/EGamma0/AOD/PromptReco-v1/000/386/605/00000/9ad0cdbe-0470-45a8-90fa-9ccbd0ef4087.root?tried=xrootd-se32-vanderbilt.sites.opensciencegrid.org&triedrc=resel&xrdcl.requuid=2f2222fd-a048-480d-94b9-fcebb6ba7935
%MSG
```

and
```
%MSG-f XrdAdaptorLvl3:  MuonReducedTrackExtraProducer:slimmedMuonTrackExtras  10-Apr-2025 17:09:04 CEST Run: 386605 Event: 63636387
Deactivating xrootd-se34-vanderbilt.sites.opensciencegrid.org from active sources because its quality (581) is higher than 260 and 4 times larger than the other active server xrootd-se33-vanderbilt.sites.opensciencegrid.org (138)
%MSG
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 15_0_X