### PR TITLE
Modifying LST to create efficiency plots for jets

### DIFF
--- a/RecoTracker/LSTCore/standalone/bin/lst.cc
+++ b/RecoTracker/LSTCore/standalone/bin/lst.cc
@@ -89,6 +89,13 @@ int main(int argc, char **argv) {
 
   // A default value one
   TString TrackingNtupleDir = gSystem->Getenv("TRACKINGNTUPLEDIR");
+
+  // Added by Kasia
+  // std::cout << "\n\n\n\n" << std::endl;
+  // std::cout << TrackingNtupleDir.Data() << std::endl;
+  // std::cout << "\n\n\n\n" << std::endl;
+
+
   if (ana.input_raw_string.EqualTo("muonGun"))
     ana.input_file_list_tstring = TString::Format("%s/trackingNtuple_10mu_pt_0p5_2.root", TrackingNtupleDir.Data());
   else if (ana.input_raw_string.EqualTo("muonGun_highPt"))
@@ -97,7 +104,7 @@ int main(int argc, char **argv) {
     ana.input_file_list_tstring =
         TString::Format("%s/trackingNtuple_6pion_1k_pt_0p5_50.root", TrackingNtupleDir.Data());
   else if (ana.input_raw_string.EqualTo("PU200"))
-    ana.input_file_list_tstring = "new_tree.root"; // ana.input_file_list_tstring = TString::Format("%s/trackingNtuple_ttbar_PU200.root", TrackingNtupleDir.Data()); // Added by Kasia
+    ana.input_file_list_tstring = TString::Format("%s/trackingNtuple_ttbar_PU200.root", TrackingNtupleDir.Data()); 
   else if (ana.input_raw_string.EqualTo("PU200RelVal"))
     ana.input_file_list_tstring = TString::Format(
         "%s/RelValTTbar_14TeV_CMSSW_12_5_0_pre3/",
@@ -116,7 +123,7 @@ int main(int argc, char **argv) {
     ana.input_file_list_tstring =
         TString::Format("%s/trackingNtuple_10mu_10k_pt_0p5_50_50cm_cube.root", TrackingNtupleDir.Data());
   else {
-    ana.input_file_list_tstring = ana.input_raw_string;
+    ana.input_file_list_tstring = "new_tree.root"; // ana.input_raw_string; // Added by Kasia
   }
 
   //_______________________________________________________________________________

--- a/RecoTracker/LSTCore/standalone/bin/lst.cc
+++ b/RecoTracker/LSTCore/standalone/bin/lst.cc
@@ -97,7 +97,7 @@ int main(int argc, char **argv) {
     ana.input_file_list_tstring =
         TString::Format("%s/trackingNtuple_6pion_1k_pt_0p5_50.root", TrackingNtupleDir.Data());
   else if (ana.input_raw_string.EqualTo("PU200"))
-    ana.input_file_list_tstring = TString::Format("%s/trackingNtuple_ttbar_PU200.root", TrackingNtupleDir.Data());
+    ana.input_file_list_tstring = "new_tree.root"; // ana.input_file_list_tstring = TString::Format("%s/trackingNtuple_ttbar_PU200.root", TrackingNtupleDir.Data()); // Added by Kasia
   else if (ana.input_raw_string.EqualTo("PU200RelVal"))
     ana.input_file_list_tstring = TString::Format(
         "%s/RelValTTbar_14TeV_CMSSW_12_5_0_pre3/",

--- a/RecoTracker/LSTCore/standalone/code/core/Trktree.cc
+++ b/RecoTracker/LSTCore/standalone/code/core/Trktree.cc
@@ -3,6 +3,40 @@ Trktree trk;
 
 void Trktree::Init(TTree *tree) {
   tree->SetMakeClass(1);
+
+  // Added by Kasia --------------------------------------------------------------------
+  sim_etadiffs_branch = 0;
+  if (tree->GetBranch("sim_etadiffs") != 0) {
+    sim_etadiffs_branch = tree->GetBranch("sim_etadiffs");
+    if (sim_etadiffs_branch) { sim_etadiffs_branch->SetAddress(&sim_etadiffs_); }
+  }
+  sim_phidiffs_branch = 0;
+  if (tree->GetBranch("sim_phidiffs") != 0) {
+    sim_phidiffs_branch = tree->GetBranch("sim_phidiffs");
+    if (sim_phidiffs_branch) { sim_phidiffs_branch->SetAddress(&sim_phidiffs_); }
+  }
+  sim_rjet_branch = 0;
+  if (tree->GetBranch("sim_rjet") != 0) {
+    sim_rjet_branch = tree->GetBranch("sim_rjet");
+    if (sim_rjet_branch) { sim_rjet_branch->SetAddress(&sim_rjet_); }
+  }
+  sim_jet_eta_branch = 0;
+  if (tree->GetBranch("sim_jet_eta") != 0) {
+    sim_jet_eta_branch = tree->GetBranch("sim_jet_eta");
+    if (sim_jet_eta_branch) { sim_jet_eta_branch->SetAddress(&sim_jet_eta_); }
+  }
+  sim_jet_phi_branch = 0;
+  if (tree->GetBranch("sim_jet_phi") != 0) {
+    sim_jet_phi_branch = tree->GetBranch("sim_jet_phi");
+    if (sim_jet_phi_branch) { sim_jet_phi_branch->SetAddress(&sim_jet_phi_); }
+  }
+  sim_jet_pt_branch = 0;
+  if (tree->GetBranch("sim_jet_pt") != 0) {
+    sim_jet_pt_branch = tree->GetBranch("sim_jet_pt");
+    if (sim_jet_pt_branch) { sim_jet_pt_branch->SetAddress(&sim_jet_pt_); }
+  }
+  //------------------------------------------------------------------------------------
+
   see_stateCcov01_branch = 0;
   if (tree->GetBranch("see_stateCcov01") != 0) {
     see_stateCcov01_branch = tree->GetBranch("see_stateCcov01");
@@ -2129,6 +2163,14 @@ void Trktree::Init(TTree *tree) {
   tree->SetMakeClass(0);
 }
 void Trktree::GetEntry(unsigned int idx) {
+
+  sim_etadiffs_isLoaded = false; // Added by Kasia
+  sim_phidiffs_isLoaded = false; // Added by Kasia
+  sim_rjet_isLoaded = false; // Added by Kasia
+  sim_jet_eta_isLoaded = false; // Added by Kasia
+  sim_jet_phi_isLoaded = false; // Added by Kasia
+  sim_jet_pt_isLoaded = false; // Added by Kasia
+
   index = idx;
   see_stateCcov01_isLoaded = false;
   simhit_rod_isLoaded = false;
@@ -2435,6 +2477,14 @@ void Trktree::GetEntry(unsigned int idx) {
   see_stateTrajGlbPy_isLoaded = false;
 }
 void Trktree::LoadAllBranches() {
+
+  if (sim_etadiffs_branch != 0) sim_etadiffs(); // Added by Kasia
+  if (sim_phidiffs_branch != 0) sim_phidiffs(); // Added by Kasia
+  if (sim_rjet_branch != 0) sim_rjet(); // Added by Kasia
+  if (sim_jet_eta_branch != 0) sim_jet_eta(); // Added by Kasia
+  if (sim_jet_phi_branch != 0) sim_jet_phi(); // Added by Kasia
+  if (sim_jet_pt_branch != 0) sim_jet_pt(); // Added by Kasia
+
   if (see_stateCcov01_branch != 0)
     see_stateCcov01();
   if (simhit_rod_branch != 0)
@@ -3042,6 +3092,86 @@ void Trktree::LoadAllBranches() {
   if (see_stateTrajGlbPy_branch != 0)
     see_stateTrajGlbPy();
 }
+
+// Added by Kasia
+const std::vector<float> &Trktree::sim_etadiffs() {
+  if (not sim_etadiffs_isLoaded) {
+    if (sim_etadiffs_branch != 0) {
+      sim_etadiffs_branch->GetEntry(index);
+    } else {
+      printf("branch sim_etadiffs_branch does not exist!\n");
+      exit(1);
+    }
+    sim_etadiffs_isLoaded = true;
+  }
+  return *sim_etadiffs_;
+}
+// Added by Kasia
+const std::vector<float> &Trktree::sim_phidiffs() {
+  if (not sim_phidiffs_isLoaded) {
+    if (sim_phidiffs_branch != 0) {
+      sim_phidiffs_branch->GetEntry(index);
+    } else {
+      printf("branch sim_phidiffs_branch does not exist!\n");
+      exit(1);
+    }
+    sim_phidiffs_isLoaded = true;
+  }
+  return *sim_phidiffs_;
+}
+// Added by Kasia
+const std::vector<float> &Trktree::sim_rjet() {
+  if (not sim_rjet_isLoaded) {
+    if (sim_rjet_branch != 0) {
+      sim_rjet_branch->GetEntry(index);
+    } else {
+      printf("branch sim_rjet_branch does not exist!\n");
+      exit(1);
+    }
+    sim_rjet_isLoaded = true;
+  }
+  return *sim_rjet_;
+}
+// Added by Kasia
+const std::vector<float> &Trktree::sim_jet_eta() {
+  if (not sim_jet_eta_isLoaded) {
+    if (sim_jet_eta_branch != 0) {
+      sim_jet_eta_branch->GetEntry(index);
+    } else {
+      printf("branch sim_jet_eta_branch does not exist!\n");
+      exit(1);
+    }
+    sim_jet_eta_isLoaded = true;
+  }
+  return *sim_jet_eta_;
+}
+// Added by Kasia
+const std::vector<float> &Trktree::sim_jet_phi() {
+  if (not sim_jet_phi_isLoaded) {
+    if (sim_jet_phi_branch != 0) {
+      sim_jet_phi_branch->GetEntry(index);
+    } else {
+      printf("branch sim_jet_phi_branch does not exist!\n");
+      exit(1);
+    }
+    sim_jet_phi_isLoaded = true;
+  }
+  return *sim_jet_phi_;
+}
+// Added by Kasia
+const std::vector<float> &Trktree::sim_jet_pt() {
+  if (not sim_jet_pt_isLoaded) {
+    if (sim_jet_pt_branch != 0) {
+      sim_jet_pt_branch->GetEntry(index);
+    } else {
+      printf("branch sim_jet_pt_branch does not exist!\n");
+      exit(1);
+    }
+    sim_jet_pt_isLoaded = true;
+  }
+  return *sim_jet_pt_;
+}
+
 const std::vector<float> &Trktree::see_stateCcov01() {
   if (not see_stateCcov01_isLoaded) {
     if (see_stateCcov01_branch != 0) {

--- a/RecoTracker/LSTCore/standalone/code/core/Trktree.h
+++ b/RecoTracker/LSTCore/standalone/code/core/Trktree.h
@@ -16,6 +16,37 @@ typedef ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<float> > LorentzVector;
 class Trktree {
 private:
 protected:
+
+  // Added by Kasia
+  std::vector<float> *sim_etadiffs_;
+  TBranch *sim_etadiffs_branch;
+  bool sim_etadiffs_isLoaded;
+
+  // Added by Kasia
+  std::vector<float> *sim_phidiffs_;
+  TBranch *sim_phidiffs_branch;
+  bool sim_phidiffs_isLoaded;
+
+  // Added by Kasia
+  std::vector<float> *sim_rjet_;
+  TBranch *sim_rjet_branch;
+  bool sim_rjet_isLoaded;
+
+  // Added by Kasia
+  std::vector<float> *sim_jet_eta_;
+  TBranch *sim_jet_eta_branch;
+  bool sim_jet_eta_isLoaded;
+
+  // Added by Kasia
+  std::vector<float> *sim_jet_phi_;
+  TBranch *sim_jet_phi_branch;
+  bool sim_jet_phi_isLoaded;
+
+  // Added by Kasia
+  std::vector<float> *sim_jet_pt_;
+  TBranch *sim_jet_pt_branch;
+  bool sim_jet_pt_isLoaded;
+
   unsigned int index;
   std::vector<float> *see_stateCcov01_;
   TBranch *see_stateCcov01_branch;
@@ -931,6 +962,14 @@ public:
   void Init(TTree *tree);
   void GetEntry(unsigned int idx);
   void LoadAllBranches();
+
+  const std::vector<float> &sim_etadiffs(); // Added by Kasia
+  const std::vector<float> &sim_phidiffs(); // Added by Kasia
+  const std::vector<float> &sim_rjet(); // Added by Kasia
+  const std::vector<float> &sim_jet_eta(); // Added by Kasia
+  const std::vector<float> &sim_jet_phi(); // Added by Kasia
+  const std::vector<float> &sim_jet_pt(); // Added by Kasia
+
   const std::vector<float> &see_stateCcov01();
   const std::vector<unsigned short> &simhit_rod();
   const std::vector<float> &trk_phi();
@@ -1242,6 +1281,13 @@ extern Trktree trk;
 #endif
 
 namespace tas {
+
+  const std::vector<float> &sim_etadiffs(); // Added by Kasia
+  const std::vector<float> &sim_phidiffs(); // Added by Kasia
+  const std::vector<float> &sim_rjet(); // Added by Kasia
+  const std::vector<float> &sim_jet_eta(); // Added by Kasia
+  const std::vector<float> &sim_jet_phi(); // Added by Kasia
+  const std::vector<float> &sim_jet_pt(); // Added by Kasia
 
   const std::vector<float> &see_stateCcov01();
   const std::vector<unsigned short> &simhit_rod();

--- a/RecoTracker/LSTCore/standalone/code/core/write_lst_ntuple.cc
+++ b/RecoTracker/LSTCore/standalone/code/core/write_lst_ntuple.cc
@@ -28,6 +28,14 @@ void fillOutputBranches(LSTEvent* event) {
 //________________________________________________________________________________________________________________________________
 void createRequiredOutputBranches() {
   // Setup output TTree
+
+  ana.tx->createBranch<std::vector<float>>("sim_etadiffs"); // Added by Kasia
+  ana.tx->createBranch<std::vector<float>>("sim_phidiffs"); // Added by Kasia
+  ana.tx->createBranch<std::vector<float>>("sim_rjet"); // Added by Kasia
+  ana.tx->createBranch<std::vector<float>>("sim_jet_eta"); // Added by Kasia
+  ana.tx->createBranch<std::vector<float>>("sim_jet_phi"); // Added by Kasia
+  ana.tx->createBranch<std::vector<float>>("sim_jet_pt"); // Added by Kasia
+
   ana.tx->createBranch<std::vector<float>>("sim_pt");
   ana.tx->createBranch<std::vector<float>>("sim_eta");
   ana.tx->createBranch<std::vector<float>>("sim_phi");
@@ -248,6 +256,13 @@ void setOutputBranches(LSTEvent* event) {
     // Skip non-hard-scatter
     if (trk.sim_event()[isimtrk] != 0)
       continue;
+
+    ana.tx->pushbackToBranch<float>("sim_etadiffs", trk.sim_etadiffs()[isimtrk]); // Added by Kasia
+    ana.tx->pushbackToBranch<float>("sim_phidiffs", trk.sim_phidiffs()[isimtrk]); // Added by Kasia
+    ana.tx->pushbackToBranch<float>("sim_rjet", trk.sim_rjet()[isimtrk]); // Added by Kasia
+    ana.tx->pushbackToBranch<float>("sim_jet_eta", trk.sim_jet_eta()[isimtrk]); // Added by Kasia
+    ana.tx->pushbackToBranch<float>("sim_jet_phi", trk.sim_jet_phi()[isimtrk]); // Added by Kasia
+    ana.tx->pushbackToBranch<float>("sim_jet_pt", trk.sim_jet_pt()[isimtrk]); // Added by Kasia
 
     ana.tx->pushbackToBranch<float>("sim_pt", trk.sim_pt()[isimtrk]);
     ana.tx->pushbackToBranch<float>("sim_eta", trk.sim_eta()[isimtrk]);

--- a/RecoTracker/LSTCore/standalone/efficiency/python/lst_plot_performance.py
+++ b/RecoTracker/LSTCore/standalone/efficiency/python/lst_plot_performance.py
@@ -9,7 +9,7 @@ from math import sqrt
 
 sel_choices = ["base", "loweta", "xtr", "vtr", "none"]
 metric_choices = ["eff", "fakerate", "duplrate"]
-variable_choices = ["pt", "ptmtv", "ptlow", "eta", "phi", "dxy", "dz", "vxy"]
+variable_choices = ["pt", "ptmtv", "ptlow", "eta", "phi", "dxy", "dz", "vxy", "etadiffs", "phidiffs", "rjet"] # Last three added by Kasia
 objecttype_choices = ["TC", "pT5", "T5", "pT3", "pLS", "pT5_lower", "pT3_lower", "T5_lower"]
 #lowerObjectType = ["pT5_lower", "pT3_lower", "T5_lower"]
 
@@ -413,6 +413,12 @@ def get_chargestr(charge):
 def set_label(eff, output_name, raw_number):
     if "phi" in output_name:
         title = "#phi"
+    elif "_etadiffs" in output_name: # Added by Kasia
+        title = "#eta diffs"
+    elif "_phidiffs" in output_name: # Added by Kasia
+        title = "#phi diffs"
+    elif "_rjet" in output_name: # Added by Kasia
+        title = "r_jet"
     elif "_dz" in output_name:
         title = "z [cm]"
     elif "_dxy" in output_name:
@@ -645,7 +651,7 @@ def plot_standard_performance_plots(args):
     metrics = metric_choices
     yzooms = [False, True]
     variables = {
-            "eff": ["pt", "ptlow", "ptmtv", "eta", "phi", "dxy", "dz", "vxy"],
+            "eff": ["pt", "ptlow", "ptmtv", "eta", "phi", "dxy", "dz", "vxy", "etadiffs", "phidiffs", "rjet"], # Last three added by Kasia,
             "fakerate": ["pt", "ptlow", "ptmtv", "eta", "phi"],
             "duplrate": ["pt", "ptlow", "ptmtv", "eta", "phi"],
             }
@@ -663,6 +669,9 @@ def plot_standard_performance_plots(args):
             "dxy": [False, True],
             "vxy": [False, True],
             "dz": [False, True],
+            "etadiffs": [False, True], # Added by Kasia
+            "phidiffs": [False, True],  # Added by Kasia
+            "rjet": [False, True]  # Added by Kasia
             }
     types = objecttype_choices
     breakdowns = {

--- a/RecoTracker/LSTCore/standalone/efficiency/python/lst_plot_performance.py
+++ b/RecoTracker/LSTCore/standalone/efficiency/python/lst_plot_performance.py
@@ -9,7 +9,7 @@ from math import sqrt
 
 sel_choices = ["base", "loweta", "xtr", "vtr", "none"]
 metric_choices = ["eff", "fakerate", "duplrate"]
-variable_choices = ["pt", "ptmtv", "ptlow", "eta", "phi", "dxy", "dz", "vxy", "etadiffs", "phidiffs", "rjet"] # Last three added by Kasia
+variable_choices = ["pt", "ptmtv", "ptlow", "eta", "phi", "dxy", "dz", "vxy", "etadiffs", "phidiffs", "rjet", "jet_eta", "jet_phi", "jet_pt"] # Last six added by Kasia
 objecttype_choices = ["TC", "pT5", "T5", "pT3", "pLS", "pT5_lower", "pT3_lower", "T5_lower"]
 #lowerObjectType = ["pT5_lower", "pT3_lower", "T5_lower"]
 
@@ -419,6 +419,12 @@ def set_label(eff, output_name, raw_number):
         title = "#phi diffs"
     elif "_rjet" in output_name: # Added by Kasia
         title = "r_jet"
+    elif "_jet_eta" in output_name: # Added by Kasia
+        title = "jet #eta"
+    elif "_jet_phi" in output_name: # Added by Kasia
+        title = "jet #phi"
+    elif "_jet_pt" in output_name: # Added by Kasia
+        title = "jet pT"
     elif "_dz" in output_name:
         title = "z [cm]"
     elif "_dxy" in output_name:
@@ -486,17 +492,17 @@ def draw_label(params):
         etacutstr = "not x-reg"
     if "eff" in output_name:
         if "_pt" in output_name:
-            fiducial_label = "{etacutstr}, |Vtx_{{z}}| < 30 cm, |Vtx_{{xy}}| < 2.5 cm".format(etacutstr=etacutstr)
+            fiducial_label = "{etacutstr}, |Vtx_{{z}}| < 30 cm, |Vtx_{{xy}}| < 10 cm".format(etacutstr=etacutstr)
         elif "_eta" in output_name:
-            fiducial_label = "p_{{T}} > {pt} GeV, |Vtx_{{z}}| < 30 cm, |Vtx_{{xy}}| < 2.5 cm".format(pt=ptcut)
+            fiducial_label = "p_{{T}} > {pt} GeV, |Vtx_{{z}}| < 30 cm, |Vtx_{{xy}}| < 10 cm".format(pt=ptcut)
         elif "_dz" in output_name:
-            fiducial_label = "{etacutstr}, p_{{T}} > {pt} GeV, |Vtx_{{xy}}| < 2.5 cm".format(pt=ptcut, etacutstr=etacutstr)
+            fiducial_label = "{etacutstr}, p_{{T}} > {pt} GeV, |Vtx_{{xy}}| < 10 cm".format(pt=ptcut, etacutstr=etacutstr)
         elif "_dxy" in output_name:
             fiducial_label = "{etacutstr}, p_{{T}} > {pt} GeV, |Vtx_{{z}}| < 30 cm".format(pt=ptcut, etacutstr=etacutstr)
         elif "_vxy" in output_name:
             fiducial_label = "{etacutstr}, p_{{T}} > {pt} GeV, |Vtx_{{z}}| < 30 cm".format(pt=ptcut, etacutstr=etacutstr)
         else:
-            fiducial_label = "{etacutstr}, p_{{T}} > {pt} GeV, |Vtx_{{z}}| < 30 cm, |Vtx_{{xy}}| < 2.5 cm".format(pt=ptcut, etacutstr=etacutstr)
+            fiducial_label = "{etacutstr}, p_{{T}} > {pt} GeV, |Vtx_{{z}}| < 30 cm, |Vtx_{{xy}}| < 10 cm".format(pt=ptcut, etacutstr=etacutstr)
         particleselection = ((", Particle:" + pdgidstr) if pdgidstr else "" ) + ((", Charge:" + chargestr) if chargestr else "" )
         fiducial_label += particleselection
     # If fake rate or duplicate rate plot follow the following fiducial label rule
@@ -536,6 +542,9 @@ def draw_plot(effs, nums, dens, params):
     # Set logx
     if "_pt" in output_name:
         c1.SetLogx()
+    
+    # if "_rjet" in output_name: # Added by Kasia
+    #     c1.SetLogx()
 
     # Set title
     # print(output_name)
@@ -651,7 +660,7 @@ def plot_standard_performance_plots(args):
     metrics = metric_choices
     yzooms = [False, True]
     variables = {
-            "eff": ["pt", "ptlow", "ptmtv", "eta", "phi", "dxy", "dz", "vxy", "etadiffs", "phidiffs", "rjet"], # Last three added by Kasia,
+            "eff": ["pt", "ptlow", "ptmtv", "eta", "phi", "dxy", "dz", "vxy", "etadiffs", "phidiffs", "rjet", "jet_eta", "jet_phi", "jet_pt"], # Last six added by Kasia,
             "fakerate": ["pt", "ptlow", "ptmtv", "eta", "phi"],
             "duplrate": ["pt", "ptlow", "ptmtv", "eta", "phi"],
             }
@@ -671,7 +680,10 @@ def plot_standard_performance_plots(args):
             "dz": [False, True],
             "etadiffs": [False, True], # Added by Kasia
             "phidiffs": [False, True],  # Added by Kasia
-            "rjet": [False, True]  # Added by Kasia
+            "rjet": [False, True],  # Added by Kasia
+            "jet_eta": [False, True], # Added by Kasia
+            "jet_phi": [False, True],  # Added by Kasia
+            "jet_pt": [False, True]  # Added by Kasia
             }
     types = objecttype_choices
     breakdowns = {

--- a/RecoTracker/LSTCore/standalone/efficiency/src/LSTEff.cc
+++ b/RecoTracker/LSTCore/standalone/efficiency/src/LSTEff.cc
@@ -3,6 +3,44 @@ LSTEff lstEff;
 
 void LSTEff::Init(TTree *tree) {
   tree->SetMakeClass(1);
+
+  // Added by Kasia -------------------------------------------------------------
+  sim_etadiffs_branch = 0;
+  if (tree->GetBranch("sim_etadiffs") != 0) {
+    sim_etadiffs_branch = tree->GetBranch("sim_etadiffs");
+    if (sim_etadiffs_branch) { sim_etadiffs_branch->SetAddress(&sim_etadiffs_); }
+  }
+  sim_phidiffs_branch = 0;
+  if (tree->GetBranch("sim_phidiffs") != 0) {
+    sim_phidiffs_branch = tree->GetBranch("sim_phidiffs");
+    if (sim_phidiffs_branch) { sim_phidiffs_branch->SetAddress(&sim_phidiffs_); }
+  }
+
+  sim_rjet_branch = 0;
+  if (tree->GetBranch("sim_rjet") != 0) {
+    sim_rjet_branch = tree->GetBranch("sim_rjet");
+    if (sim_rjet_branch) { sim_rjet_branch->SetAddress(&sim_rjet_); }
+  }
+
+  sim_jet_eta_branch = 0;
+  if (tree->GetBranch("sim_jet_eta") != 0) {
+    sim_jet_eta_branch = tree->GetBranch("sim_jet_eta");
+    if (sim_jet_eta_branch) { sim_jet_eta_branch->SetAddress(&sim_jet_eta_); }
+  }
+
+  sim_jet_phi_branch = 0;
+  if (tree->GetBranch("sim_jet_phi") != 0) {
+    sim_jet_phi_branch = tree->GetBranch("sim_jet_phi");
+    if (sim_jet_phi_branch) { sim_jet_phi_branch->SetAddress(&sim_jet_phi_); }
+  }
+
+  sim_jet_pt_branch = 0;
+  if (tree->GetBranch("sim_jet_pt") != 0) {
+    sim_jet_pt_branch = tree->GetBranch("sim_jet_pt");
+    if (sim_jet_pt_branch) { sim_jet_pt_branch->SetAddress(&sim_jet_pt_); }
+  }
+  // ----------------------------------------------------------------------------
+
   pT5_occupancies_branch = 0;
   if (tree->GetBranch("pT5_occupancies") != 0) {
     pT5_occupancies_branch = tree->GetBranch("pT5_occupancies");
@@ -1028,6 +1066,15 @@ void LSTEff::Init(TTree *tree) {
   tree->SetMakeClass(0);
 }
 void LSTEff::GetEntry(unsigned int idx) {
+
+  // Added by Kasia
+  sim_etadiffs_isLoaded = false;
+  sim_phidiffs_isLoaded = false;
+  sim_rjet_isLoaded = false;
+  sim_jet_eta_isLoaded = false;
+  sim_jet_phi_isLoaded = false;
+  sim_jet_pt_isLoaded = false;
+
   index = idx;
   pT5_occupancies_isLoaded = false;
   t3_phi_isLoaded = false;
@@ -1177,6 +1224,15 @@ void LSTEff::GetEntry(unsigned int idx) {
   pT3_matched_simIdx_isLoaded = false;
 }
 void LSTEff::LoadAllBranches() {
+
+  // Added by Kasia
+  if (sim_etadiffs_branch != 0) sim_etadiffs();
+  if (sim_phidiffs_branch != 0) sim_phidiffs();
+  if (sim_rjet_branch != 0) sim_rjet();
+  if (sim_jet_eta_branch != 0) sim_jet_eta();
+  if (sim_jet_phi_branch != 0) sim_jet_phi();
+  if (sim_jet_pt_branch != 0) sim_jet_pt();
+
   if (pT5_occupancies_branch != 0)
     pT5_occupancies();
   if (t3_phi_branch != 0)
@@ -1470,6 +1526,82 @@ void LSTEff::LoadAllBranches() {
   if (pT3_matched_simIdx_branch != 0)
     pT3_matched_simIdx();
 }
+
+// Added by Kasia ----------------------------------------------------------
+const std::vector<float> &LSTEff::sim_etadiffs() {
+if (not sim_etadiffs_isLoaded) {
+  if (sim_etadiffs_branch != 0) {
+    sim_etadiffs_branch->GetEntry(index);
+  } else {
+    printf("branch sim_etadiffs_branch does not exist!\n");
+    exit(1);
+  }
+  sim_etadiffs_isLoaded = true;
+}
+return *sim_etadiffs_;
+}
+const std::vector<float> &LSTEff::sim_phidiffs() {
+if (not sim_phidiffs_isLoaded) {
+  if (sim_phidiffs_branch != 0) {
+    sim_phidiffs_branch->GetEntry(index);
+  } else {
+    printf("branch sim_phidiffs_branch does not exist!\n");
+    exit(1);
+  }
+  sim_phidiffs_isLoaded = true;
+}
+return *sim_phidiffs_;
+}
+const std::vector<float> &LSTEff::sim_rjet() {
+if (not sim_rjet_isLoaded) {
+  if (sim_rjet_branch != 0) {
+    sim_rjet_branch->GetEntry(index);
+  } else {
+    printf("branch sim_rjet_branch does not exist!\n");
+    exit(1);
+  }
+  sim_rjet_isLoaded = true;
+}
+return *sim_rjet_;
+}
+const std::vector<float> &LSTEff::sim_jet_eta() {
+  if (not sim_jet_eta_isLoaded) {
+    if (sim_jet_eta_branch != 0) {
+      sim_jet_eta_branch->GetEntry(index);
+    } else {
+      printf("branch sim_jet_eta_branch does not exist!\n");
+      exit(1);
+    }
+    sim_jet_eta_isLoaded = true;
+  }
+  return *sim_jet_eta_;
+}
+const std::vector<float> &LSTEff::sim_jet_phi() {
+  if (not sim_jet_phi_isLoaded) {
+    if (sim_jet_phi_branch != 0) {
+      sim_jet_phi_branch->GetEntry(index);
+    } else {
+      printf("branch sim_jet_phi_branch does not exist!\n");
+      exit(1);
+    }
+    sim_jet_phi_isLoaded = true;
+  }
+  return *sim_jet_phi_;
+}
+const std::vector<float> &LSTEff::sim_jet_pt() {
+  if (not sim_jet_pt_isLoaded) {
+    if (sim_jet_pt_branch != 0) {
+      sim_jet_pt_branch->GetEntry(index);
+    } else {
+      printf("branch sim_jet_pt_branch does not exist!\n");
+      exit(1);
+    }
+    sim_jet_pt_isLoaded = true;
+  }
+  return *sim_jet_pt_;
+}
+// --------------------------------------------------------------------------
+
 const int &LSTEff::pT5_occupancies() {
   if (not pT5_occupancies_isLoaded) {
     if (pT5_occupancies_branch != 0) {
@@ -3244,6 +3376,15 @@ void LSTEff::progress(int nEventsTotal, int nEventsChain) {
   }
 }
 namespace tas {
+  
+  // Added by Kasia
+  const std::vector<float> &sim_etadiffs() { return lstEff.sim_etadiffs(); }
+  const std::vector<float> &sim_phidiffs() { return lstEff.sim_phidiffs(); }
+  const std::vector<float> &sim_rjet() { return lstEff.sim_rjet(); }
+  const std::vector<float> &sim_jet_eta() { return lstEff.sim_jet_eta(); }
+  const std::vector<float> &sim_jet_phi() { return lstEff.sim_jet_phi(); }
+  const std::vector<float> &sim_jet_pt() { return lstEff.sim_jet_pt(); }
+
   const int &pT5_occupancies() { return lstEff.pT5_occupancies(); }
   const std::vector<float> &t3_phi() { return lstEff.t3_phi(); }
   const std::vector<float> &t5_score_rphisum() { return lstEff.t5_score_rphisum(); }

--- a/RecoTracker/LSTCore/standalone/efficiency/src/LSTEff.h
+++ b/RecoTracker/LSTCore/standalone/efficiency/src/LSTEff.h
@@ -16,6 +16,28 @@ typedef ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<float> > LorentzVector;
 class LSTEff {
 private:
 protected:
+
+  // Added by Kasia ------------------
+  std::vector<float> *sim_etadiffs_;
+  TBranch *sim_etadiffs_branch;
+  bool sim_etadiffs_isLoaded;
+  std::vector<float> *sim_phidiffs_;
+  TBranch *sim_phidiffs_branch;
+  bool sim_phidiffs_isLoaded;
+  std::vector<float> *sim_rjet_;
+  TBranch *sim_rjet_branch;
+  bool sim_rjet_isLoaded;
+  std::vector<float> *sim_jet_eta_;
+  TBranch *sim_jet_eta_branch;
+  bool sim_jet_eta_isLoaded;
+  std::vector<float> *sim_jet_phi_;
+  TBranch *sim_jet_phi_branch;
+  bool sim_jet_phi_isLoaded;
+  std::vector<float> *sim_jet_pt_;
+  TBranch *sim_jet_pt_branch;
+  bool sim_jet_pt_isLoaded;
+  // ------------------------------
+
   unsigned int index;
   int pT5_occupancies_;
   TBranch *pT5_occupancies_branch;
@@ -460,6 +482,16 @@ public:
   void Init(TTree *tree);
   void GetEntry(unsigned int idx);
   void LoadAllBranches();
+
+  // Added by Kasia
+  const std::vector<float> &sim_etadiffs();
+  const std::vector<float> &sim_phidiffs();
+  const std::vector<float> &sim_rjet();
+  const std::vector<float> &sim_jet_eta();
+  const std::vector<float> &sim_jet_phi();
+  const std::vector<float> &sim_jet_pt();
+  
+
   const int &pT5_occupancies();
   const std::vector<float> &t3_phi();
   const std::vector<float> &t5_score_rphisum();
@@ -614,6 +646,14 @@ extern LSTEff lstEff;
 #endif
 
 namespace tas {
+
+  // Added by Kasia
+  const std::vector<float> &sim_etadiffs();
+  const std::vector<float> &sim_phidiffs();
+  const std::vector<float> &sim_rjet();
+  const std::vector<float> &sim_jet_eta();
+  const std::vector<float> &sim_jet_phi();
+  const std::vector<float> &sim_jet_pt();
 
   const int &pT5_occupancies();
   const std::vector<float> &t3_phi();

--- a/RecoTracker/LSTCore/standalone/efficiency/src/helper.cc
+++ b/RecoTracker/LSTCore/standalone/efficiency/src/helper.cc
@@ -28,7 +28,7 @@ void parseArguments(int argc, char** argv) {
       "job_index of split jobs (--nsplit_jobs must be set. index starts from 0. i.e. 0, 1, 2, 3, etc...)",
       cxxopts::value<int>())(
       "g,pdgid", "additional pdgid filtering to use (must be comma separated)", cxxopts::value<std::string>())(
-      "p,pt_cut", "Transverse momentum cut", cxxopts::value<float>()->default_value("0.9"))(
+      "p,pt_cut", "Transverse momentum cut", cxxopts::value<float>()->default_value("50"))( // Kasia changed from 0.9
       "e,eta_cut", "Pseudorapidity cut", cxxopts::value<float>()->default_value("4.5"))(
       "d,debug", "Run debug job. i.e. overrides output option to 'debug.root' and 'recreate's the file.")("h,help",
                                                                                                           "Print help");

--- a/RecoTracker/LSTCore/standalone/efficiency/src/helper.cc
+++ b/RecoTracker/LSTCore/standalone/efficiency/src/helper.cc
@@ -28,7 +28,7 @@ void parseArguments(int argc, char** argv) {
       "job_index of split jobs (--nsplit_jobs must be set. index starts from 0. i.e. 0, 1, 2, 3, etc...)",
       cxxopts::value<int>())(
       "g,pdgid", "additional pdgid filtering to use (must be comma separated)", cxxopts::value<std::string>())(
-      "p,pt_cut", "Transverse momentum cut", cxxopts::value<float>()->default_value("50"))( // Kasia changed from 0.9
+      "p,pt_cut", "Transverse momentum cut", cxxopts::value<float>()->default_value("0.9"))(
       "e,eta_cut", "Pseudorapidity cut", cxxopts::value<float>()->default_value("4.5"))(
       "d,debug", "Run debug job. i.e. overrides output option to 'debug.root' and 'recreate's the file.")("h,help",
                                                                                                           "Print help");

--- a/RecoTracker/LSTCore/standalone/efficiency/src/performance.cc
+++ b/RecoTracker/LSTCore/standalone/efficiency/src/performance.cc
@@ -325,6 +325,87 @@ void bookEfficiencySets(std::vector<SimTrackSetDefinition>& effsets) {
 void bookEfficiencySet(SimTrackSetDefinition& effset) {
   TString category_name = TString::Format("%s_%d_%d", effset.set_name.Data(), effset.pdgid, effset.q);
 
+  // Added by Kasia -----------------------------------------------------------------------------------------
+    // Lines for etadiffs
+    ana.tx.createBranch<std::vector<float>>(category_name + "_ef_denom_etadiffs");
+    ana.histograms.addVecHistogram(category_name + "_ef_denom_etadiffs", 180 , -4.5  , 4.5  , [&, category_name]() 
+    {return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_denom_etadiffs");} );
+
+    ana.tx.createBranch<std::vector<float>>(category_name + "_ef_numer_etadiffs");
+    ana.histograms.addVecHistogram(category_name + "_ef_numer_etadiffs", 180 , -4.5  , 4.5  , [&, category_name]() 
+    {return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_numer_etadiffs");} );
+
+    ana.tx.createBranch<std::vector<float>>(category_name + "_ie_numer_etadiffs");
+    ana.histograms.addVecHistogram(category_name + "_ie_numer_etadiffs", 180 , -4.5  , 4.5  , [&, category_name]() 
+    {return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ie_numer_etadiffs");} );
+
+    // Lines for phidiffs
+    ana.tx.createBranch<std::vector<float>>(category_name + "_ef_denom_phidiffs");
+    ana.histograms.addVecHistogram(category_name + "_ef_denom_phidiffs", 180 , -4.5  , 4.5  , [&, category_name]() 
+    {return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_denom_phidiffs");} );
+
+    ana.tx.createBranch<std::vector<float>>(category_name + "_ef_numer_phidiffs");
+    ana.histograms.addVecHistogram(category_name + "_ef_numer_phidiffs", 180 , -4.5  , 4.5  , [&, category_name]() 
+    {return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_numer_phidiffs");} );
+
+    ana.tx.createBranch<std::vector<float>>(category_name + "_ie_numer_phidiffs");
+    ana.histograms.addVecHistogram(category_name + "_ie_numer_phidiffs", 180 , -4.5  , 4.5  , [&, category_name]() 
+    {return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ie_numer_phidiffs");} );
+
+    // Lines for rjet
+    ana.tx.createBranch<std::vector<float>>(category_name + "_ef_denom_rjet");
+    ana.histograms.addVecHistogram(category_name + "_ef_denom_rjet", 180 , -4.5  , 4.5  , [&, category_name]() 
+    {return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_denom_rjet");} );
+
+    ana.tx.createBranch<std::vector<float>>(category_name + "_ef_numer_rjet");
+    ana.histograms.addVecHistogram(category_name + "_ef_numer_rjet", 180 , -4.5  , 4.5  , [&, category_name]() 
+    {return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_numer_rjet");} );
+
+    ana.tx.createBranch<std::vector<float>>(category_name + "_ie_numer_rjet");
+    ana.histograms.addVecHistogram(category_name + "_ie_numer_rjet", 180 , -4.5  , 4.5  , [&, category_name]() 
+    {return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ie_numer_rjet");} );
+
+    // Lines for jet_eta
+    ana.tx.createBranch<std::vector<float>>(category_name + "_ef_denom_jet_eta");
+    ana.histograms.addVecHistogram(category_name + "_ef_denom_jet_eta", 180 , -4.5  , 4.5  , [&, category_name]() 
+    {return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_denom_jet_eta");} );
+
+    ana.tx.createBranch<std::vector<float>>(category_name + "_ef_numer_jet_eta");
+    ana.histograms.addVecHistogram(category_name + "_ef_numer_jet_eta", 180 , -4.5  , 4.5  , [&, category_name]() 
+    {return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_numer_jet_eta");} );
+
+    ana.tx.createBranch<std::vector<float>>(category_name + "_ie_numer_jet_eta");
+    ana.histograms.addVecHistogram(category_name + "_ie_numer_jet_eta", 180 , -4.5  , 4.5  , [&, category_name]() 
+    {return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ie_numer_jet_eta");} );
+
+    // Lines for jet_phi
+    ana.tx.createBranch<std::vector<float>>(category_name + "_ef_denom_jet_phi");
+    ana.histograms.addVecHistogram(category_name + "_ef_denom_jet_phi", 180 , -4.5  , 4.5  , [&, category_name]() 
+    {return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_denom_jet_phi");} );
+
+    ana.tx.createBranch<std::vector<float>>(category_name + "_ef_numer_jet_phi");
+    ana.histograms.addVecHistogram(category_name + "_ef_numer_jet_phi", 180 , -4.5  , 4.5  , [&, category_name]() 
+    {return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_numer_jet_phi");} );
+
+    ana.tx.createBranch<std::vector<float>>(category_name + "_ie_numer_jet_phi");
+    ana.histograms.addVecHistogram(category_name + "_ie_numer_jet_phi", 180 , -4.5  , 4.5  , [&, category_name]() 
+    {return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ie_numer_jet_phi");} );
+
+    // Lines for jet_pt
+    ana.tx.createBranch<std::vector<float>>(category_name + "_ef_denom_jet_pt");
+    ana.histograms.addVecHistogram(category_name + "_ef_denom_jet_pt", 180 , -4.5  , 4.5  , [&, category_name]() 
+    {return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_denom_jet_pt");} );
+
+    ana.tx.createBranch<std::vector<float>>(category_name + "_ef_numer_jet_pt");
+    ana.histograms.addVecHistogram(category_name + "_ef_numer_jet_pt", 180 , -4.5  , 4.5  , [&, category_name]() 
+    {return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_numer_jet_pt");} );
+
+    ana.tx.createBranch<std::vector<float>>(category_name + "_ie_numer_jet_pt");
+    ana.histograms.addVecHistogram(category_name + "_ie_numer_jet_pt", 180 , -4.5  , 4.5  , [&, category_name]() 
+    {return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ie_numer_jet_pt");} );
+
+    // --------------------------------------------------------------------------------------------------------
+
   // Denominator tracks' quantities
   ana.tx.createBranch<std::vector<float>>(category_name + "_ef_denom_pt");
   ana.tx.createBranch<std::vector<float>>(category_name + "_ef_denom_eta");
@@ -569,6 +650,15 @@ void fillEfficiencySet(int isimtrk, SimTrackSetDefinition& effset) {
   //     return;
   //=========================================================
 
+
+  // Added by Kasia
+  const float& etadiffs = lstEff.sim_etadiffs()[isimtrk];
+  const float& phidiffs = lstEff.sim_phidiffs()[isimtrk];
+  const float& rjet = lstEff.sim_rjet()[isimtrk];
+  const float& jet_eta = lstEff.sim_jet_eta()[isimtrk];
+  const float& jet_phi = lstEff.sim_jet_phi()[isimtrk];
+  const float& jet_pt = lstEff.sim_jet_pt()[isimtrk];
+
   const float& pt = lstEff.sim_pt()[isimtrk];
   const float& eta = lstEff.sim_eta()[isimtrk];
   const float& dz = lstEff.sim_pca_dz()[isimtrk];
@@ -606,58 +696,106 @@ void fillEfficiencySet(int isimtrk, SimTrackSetDefinition& effset) {
   const float vtx_z_thresh = 30;
   const float vtx_perp_thresh = 2.5;
 
-  // N minus eta cut
-  if (pt > ana.pt_cut and abs(vtx_z) < vtx_z_thresh and abs(vtx_perp) < vtx_perp_thresh) {
-    // vs. eta plot
-    ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_eta", eta);
-    if (pass)
-      ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_eta", eta);
-    else
-      ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_eta", eta);
-  }
-
-  // N minus pt cut
-  if (abs(eta) < ana.eta_cut and abs(vtx_z) < vtx_z_thresh and abs(vtx_perp) < vtx_perp_thresh) {
-    // vs. pt plot
-    ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_pt", pt);
-    if (pass)
-      ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_pt", pt);
-    else
-      ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_pt", pt);
-  }
-
-  // N minus dxy cut
-  if (abs(eta) < ana.eta_cut and pt > ana.pt_cut and abs(vtx_z) < vtx_z_thresh) {
-    // vs. dxy plot
-    ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_dxy", dxy);
-    ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_vxy", vtx_perp);
-    if (pass) {
-      ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_dxy", dxy);
-      ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_vxy", vtx_perp);
-    } else {
-      ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_dxy", dxy);
-      ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_vxy", vtx_perp);
+  // jet cuts added by Kasia
+  if(jet_pt > 50 && jet_eta<1.2 && jet_eta>-1.2 && rjet<1){
+    // N minus eta cut
+    if (pt > ana.pt_cut and abs(vtx_z) < vtx_z_thresh and abs(vtx_perp) < vtx_perp_thresh) {
+      // vs. eta plot
+      ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_eta", eta);
+      if (pass)
+        ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_eta", eta);
+      else
+        ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_eta", eta);
     }
-  }
 
-  // N minus dz cut
-  if (abs(eta) < ana.eta_cut and pt > ana.pt_cut and abs(vtx_perp) < vtx_perp_thresh) {
-    // vs. dz plot
-    ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_dz", dz);
-    if (pass)
-      ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_dz", dz);
-    else
-      ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_dz", dz);
-  }
+    // N minus pt cut
+    if (abs(eta) < ana.eta_cut and abs(vtx_z) < vtx_z_thresh and abs(vtx_perp) < vtx_perp_thresh) {
+      // vs. pt plot
+      ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_pt", pt);
+      if (pass)
+        ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_pt", pt);
+      else
+        ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_pt", pt);
+    }
 
-  // All phase-space cuts
-  if (abs(eta) < ana.eta_cut and pt > ana.pt_cut and abs(vtx_z) < vtx_z_thresh and abs(vtx_perp) < vtx_perp_thresh) {
-    // vs. Phi plot
-    ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_phi", phi);
-    if (pass)
-      ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_phi", phi);
-    else
-      ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_phi", phi);
+    // N minus dxy cut
+    if (abs(eta) < ana.eta_cut and pt > ana.pt_cut and abs(vtx_z) < vtx_z_thresh) {
+      // vs. dxy plot
+      ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_dxy", dxy);
+      ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_vxy", vtx_perp);
+      if (pass) {
+        ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_dxy", dxy);
+        ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_vxy", vtx_perp);
+      } else {
+        ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_dxy", dxy);
+        ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_vxy", vtx_perp);
+      }
+    }
+
+    // N minus dz cut
+    if (abs(eta) < ana.eta_cut and pt > ana.pt_cut and abs(vtx_perp) < vtx_perp_thresh) {
+      // vs. dz plot
+      ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_dz", dz);
+      if (pass)
+        ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_dz", dz);
+      else
+        ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_dz", dz);
+    }
+
+    // All phase-space cuts
+    if (abs(eta) < ana.eta_cut and pt > ana.pt_cut and abs(vtx_z) < vtx_z_thresh and abs(vtx_perp) < vtx_perp_thresh) {
+      // vs. Phi plot
+      ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_phi", phi);
+      if (pass)
+        ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_phi", phi);
+      else
+        ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_phi", phi);
+    
+
+    // Added by Kasia ---------------------------------------------------------------------------------
+      // vs. etadiffs plot
+      ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_etadiffs", etadiffs);
+      if (pass)
+          ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_etadiffs", etadiffs);
+      else
+          ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_etadiffs", etadiffs);
+
+      // vs. phidiffs plot
+      ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_phidiffs", phidiffs);
+      if (pass)
+          ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_phidiffs", phidiffs);
+      else
+          ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_phidiffs", phidiffs);
+
+      // vs. rjet plot
+      ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_rjet", rjet);
+      if (pass)
+          ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_rjet", rjet);
+      else
+          ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_rjet", rjet);
+
+      // vs. jet_eta plot
+      ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_jet_eta", jet_eta);
+      if (pass)
+          ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_jet_eta", jet_eta);
+      else
+          ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_jet_eta", jet_eta);
+
+      // vs. jet_phi plot
+      ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_jet_phi", jet_phi);
+      if (pass)
+          ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_jet_phi", jet_phi);
+      else
+          ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_jet_phi", jet_phi);
+
+      // vs. jet_pt plot
+      ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_jet_pt", jet_pt);
+      if (pass)
+          ana.tx.pushbackToBranch<float>(category_name + "_ef_numer_jet_pt", jet_pt);
+      else
+          ana.tx.pushbackToBranch<float>(category_name + "_ie_numer_jet_pt", jet_pt);
+  //---------------------------------------------------------------------------------------------------
+    }
   }
 }
 

--- a/RecoTracker/LSTCore/standalone/efficiency/src/performance.cc
+++ b/RecoTracker/LSTCore/standalone/efficiency/src/performance.cc
@@ -354,15 +354,15 @@ void bookEfficiencySet(SimTrackSetDefinition& effset) {
 
     // Lines for rjet
     ana.tx.createBranch<std::vector<float>>(category_name + "_ef_denom_rjet");
-    ana.histograms.addVecHistogram(category_name + "_ef_denom_rjet", 180 , -4.5  , 4.5  , [&, category_name]() 
+    ana.histograms.addVecHistogram(category_name + "_ef_denom_rjet", 50 , 0  , 0.1  , [&, category_name]() 
     {return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_denom_rjet");} );
 
     ana.tx.createBranch<std::vector<float>>(category_name + "_ef_numer_rjet");
-    ana.histograms.addVecHistogram(category_name + "_ef_numer_rjet", 180 , -4.5  , 4.5  , [&, category_name]() 
+    ana.histograms.addVecHistogram(category_name + "_ef_numer_rjet", 50 , 0  , 0.1  , [&, category_name]() 
     {return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_numer_rjet");} );
 
     ana.tx.createBranch<std::vector<float>>(category_name + "_ie_numer_rjet");
-    ana.histograms.addVecHistogram(category_name + "_ie_numer_rjet", 180 , -4.5  , 4.5  , [&, category_name]() 
+    ana.histograms.addVecHistogram(category_name + "_ie_numer_rjet", 50 , 0  , 0.1  , [&, category_name]() 
     {return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ie_numer_rjet");} );
 
     // Lines for jet_eta
@@ -393,21 +393,35 @@ void bookEfficiencySet(SimTrackSetDefinition& effset) {
 
     // Lines for jet_pt
     ana.tx.createBranch<std::vector<float>>(category_name + "_ef_denom_jet_pt");
-    ana.histograms.addVecHistogram(category_name + "_ef_denom_jet_pt", 180 , -4.5  , 4.5  , [&, category_name]() 
+    ana.histograms.addVecHistogram(category_name + "_ef_denom_jet_pt", 50 , 50  , 1000  , [&, category_name]() 
     {return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_denom_jet_pt");} );
 
     ana.tx.createBranch<std::vector<float>>(category_name + "_ef_numer_jet_pt");
-    ana.histograms.addVecHistogram(category_name + "_ef_numer_jet_pt", 180 , -4.5  , 4.5  , [&, category_name]() 
+    ana.histograms.addVecHistogram(category_name + "_ef_numer_jet_pt", 50 , 50  , 1000  , [&, category_name]() 
     {return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_numer_jet_pt");} );
 
     ana.tx.createBranch<std::vector<float>>(category_name + "_ie_numer_jet_pt");
-    ana.histograms.addVecHistogram(category_name + "_ie_numer_jet_pt", 180 , -4.5  , 4.5  , [&, category_name]() 
+    ana.histograms.addVecHistogram(category_name + "_ie_numer_jet_pt", 50 , 50  , 1000  , [&, category_name]() 
     {return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ie_numer_jet_pt");} );
 
+    // Moving the standard pT code up here for convenience
+    ana.tx.createBranch<std::vector<float>>(category_name + "_ef_denom_pt");
+    ana.histograms.addVecHistogram(category_name + "_ef_denom_pt", 40 , 0.9  , 2000  , [&, category_name]() { // getPtBounds(0), [&, category_name]() {
+      return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_denom_pt");
+    });
+
+    ana.tx.createBranch<std::vector<float>>(category_name + "_ef_numer_pt");
+    ana.histograms.addVecHistogram(category_name + "_ef_numer_pt", 40 , 0.9  , 2000  , [&, category_name]() { //
+      return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_numer_pt");
+    });
+
+    ana.tx.createBranch<std::vector<float>>(category_name + "_ie_numer_pt");
+    ana.histograms.addVecHistogram(category_name + "_ie_numer_pt", 40 , 0.9  , 2000  , [&, category_name]() { //
+      return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ie_numer_pt");
+    });
     // --------------------------------------------------------------------------------------------------------
 
   // Denominator tracks' quantities
-  ana.tx.createBranch<std::vector<float>>(category_name + "_ef_denom_pt");
   ana.tx.createBranch<std::vector<float>>(category_name + "_ef_denom_eta");
   ana.tx.createBranch<std::vector<float>>(category_name + "_ef_denom_dxy");
   ana.tx.createBranch<std::vector<float>>(category_name + "_ef_denom_vxy");
@@ -415,7 +429,6 @@ void bookEfficiencySet(SimTrackSetDefinition& effset) {
   ana.tx.createBranch<std::vector<float>>(category_name + "_ef_denom_phi");
 
   // Numerator tracks' quantities
-  ana.tx.createBranch<std::vector<float>>(category_name + "_ef_numer_pt");
   ana.tx.createBranch<std::vector<float>>(category_name + "_ef_numer_eta");
   ana.tx.createBranch<std::vector<float>>(category_name + "_ef_numer_dxy");
   ana.tx.createBranch<std::vector<float>>(category_name + "_ef_numer_vxy");
@@ -423,16 +436,13 @@ void bookEfficiencySet(SimTrackSetDefinition& effset) {
   ana.tx.createBranch<std::vector<float>>(category_name + "_ef_numer_phi");
 
   // Inefficiencies
-  ana.tx.createBranch<std::vector<float>>(category_name + "_ie_numer_pt");
   ana.tx.createBranch<std::vector<float>>(category_name + "_ie_numer_eta");
   ana.tx.createBranch<std::vector<float>>(category_name + "_ie_numer_dxy");
   ana.tx.createBranch<std::vector<float>>(category_name + "_ie_numer_vxy");
   ana.tx.createBranch<std::vector<float>>(category_name + "_ie_numer_dz");
   ana.tx.createBranch<std::vector<float>>(category_name + "_ie_numer_phi");
 
-  ana.histograms.addVecHistogram(category_name + "_ef_denom_pt", getPtBounds(0), [&, category_name]() {
-    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_denom_pt");
-  });
+
   ana.histograms.addVecHistogram(category_name + "_ef_denom_ptlow", getPtBounds(4), [&, category_name]() {
     return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_denom_pt");
   });
@@ -458,9 +468,6 @@ void bookEfficiencySet(SimTrackSetDefinition& effset) {
     return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_denom_phi");
   });
 
-  ana.histograms.addVecHistogram(category_name + "_ef_numer_pt", getPtBounds(0), [&, category_name]() {
-    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_numer_pt");
-  });
   ana.histograms.addVecHistogram(category_name + "_ef_numer_ptlow", getPtBounds(4), [&, category_name]() {
     return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_numer_pt");
   });
@@ -486,9 +493,6 @@ void bookEfficiencySet(SimTrackSetDefinition& effset) {
     return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ef_numer_phi");
   });
 
-  ana.histograms.addVecHistogram(category_name + "_ie_numer_pt", getPtBounds(0), [&, category_name]() {
-    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ie_numer_pt");
-  });
   ana.histograms.addVecHistogram(category_name + "_ie_numer_ptlow", getPtBounds(4), [&, category_name]() {
     return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_ie_numer_pt");
   });
@@ -694,10 +698,11 @@ void fillEfficiencySet(int isimtrk, SimTrackSetDefinition& effset) {
   // https://github.com/cms-sw/cmssw/blob/7cbdb18ec6d11d5fd17ca66c1153f0f4e869b6b0/SimTracker/Common/python/trackingParticleSelector_cfi.py
   // https://github.com/cms-sw/cmssw/blob/7cbdb18ec6d11d5fd17ca66c1153f0f4e869b6b0/SimTracker/Common/interface/TrackingParticleSelector.h#L122-L124
   const float vtx_z_thresh = 30;
-  const float vtx_perp_thresh = 2.5;
+  const float vtx_perp_thresh = 10;
 
   // jet cuts added by Kasia
-  if(jet_pt > 50 && jet_eta<1.2 && jet_eta>-1.2 && rjet<1){
+  // && (sqrt(pow(vtx_x,2) + pow(vtx_y,2)) < 100)
+  if(pt>0 && jet_eta<140 && jet_eta>-140 && (jet_eta>-999 && etadiffs>-999)){
     // N minus eta cut
     if (pt > ana.pt_cut and abs(vtx_z) < vtx_z_thresh and abs(vtx_perp) < vtx_perp_thresh) {
       // vs. eta plot

--- a/RecoTracker/LSTCore/standalone/myjets.py
+++ b/RecoTracker/LSTCore/standalone/myjets.py
@@ -14,25 +14,39 @@ import vector
 
 
 # Takes an entry from a tree and extracts lists of key parameters.
-def getLists(entry):#, pTcut=0):
+def getLists(entry, hardSc = False): #, pTcut=0):
         # This applies to the entire event
         pdgidList = entry.sim_pdgId
         evLen = len(pdgidList)
 
-        pTList = np.zeros(evLen, dtype=np.float64)
-        etaList = np.zeros(evLen, dtype=np.float64)
-        phiList = np.zeros(evLen, dtype=np.float64)
-        massList = np.zeros(evLen, dtype=np.float64)
+        # pTList = np.zeros(evLen, dtype=np.float64)
+        # etaList = np.zeros(evLen, dtype=np.float64)
+        # phiList = np.zeros(evLen, dtype=np.float64)
+        # massList = np.zeros(evLen, dtype=np.float64)
+
+        pTList = np.ones(evLen, dtype=np.float64)*-999
+        etaList = np.ones(evLen, dtype=np.float64)*-999
+        phiList = np.ones(evLen, dtype=np.float64)*-999
+        massList = np.ones(evLen, dtype=np.float64)*-999
 
         # Putting the data in the right format
-        for j in range(evLen):
-            # j is one particle within the event
-            pdgid = pdgidList[j]
-            massList[j] = (Particle.from_pdgid(pdgid).mass)/1000 # Particle gives mass in MeV, convert to GeV
+        for j in range(evLen):#range(len(simEvnp)):
+                if (hardSc and entry.sim_event[j] !=0 ): 
+                        # print(f"event != 0 {entry.sim_event[j]}")
+                        continue
+                if(entry.sim_q[j] != 0 and entry.sim_pt[j] < 0.75 ):
+                        continue
+                pdgid = pdgidList[j]
+                massList[j] = Particle.from_pdgid(pdgid).mass/1000.
 
-            pTList[j] = entry.sim_pt[j]
-            etaList[j] = entry.sim_eta[j]
-            phiList[j] = entry.sim_phi[j]
+                pTList[j] = entry.sim_pt[j]
+                etaList[j] = entry.sim_eta[j]
+                phiList[j] = entry.sim_phi[j]
+
+        massList = massList[massList != -999]
+        pTList = pTList[pTList != -999]
+        etaList = etaList[etaList != -999]
+        phiList = phiList[phiList != -999]
 
         # Perform pT cut, optional
         # if(pTcut!=0):

--- a/RecoTracker/LSTCore/standalone/myjets.py
+++ b/RecoTracker/LSTCore/standalone/myjets.py
@@ -1,0 +1,83 @@
+###############################################
+#
+#   Library of functions used when dealing 
+#   with jets, especially reformat_jets.py
+#
+###############################################
+
+from pyjet import cluster
+from particle import Particle
+import numpy as np
+
+
+# Takes an entry from a tree and extracts lists of key parameters.
+def getLists(entry, pTcut=0):
+        # This applies to the entire event
+        pdgidList = entry.sim_pdgId
+        evLen = len(pdgidList)
+
+        pTList = np.zeros(evLen, dtype=np.float64)
+        etaList = np.zeros(evLen, dtype=np.float64)
+        phiList = np.zeros(evLen, dtype=np.float64)
+        massList = np.zeros(evLen, dtype=np.float64)
+
+        # Putting the data in the right format
+        for j in range(evLen):
+            # j is one particle within the event
+            pdgid = pdgidList[j]
+            massList[j] = Particle.from_pdgid(pdgid).mass
+
+            pTList[j] = entry.sim_pt[j]
+            etaList[j] = entry.sim_eta[j]
+            phiList[j] = entry.sim_phi[j]
+
+        # Perform pT cut, optional
+        if(pTcut!=0):
+                maskList = pTList # eh I can probably use maskList = pTList>pTcut
+                pTList = pTList[maskList>pTcut]
+                etaList = etaList[maskList>pTcut]
+                phiList = phiList[maskList>pTcut]
+                massList = massList[maskList>pTcut]
+
+        return pTList, etaList, phiList, massList
+
+
+# Takes an entry from a tree and extracts particles from it. Uses
+# those particles to create jets, which it returns.
+def createJets(pTList, etaList, phiList, massList):
+
+        length = np.size(pTList)
+        vectors = np.array([],dtype=np.dtype([('pT', 'f8'), ('eta', 'f8'), 
+                                            ('phi', 'f8'), ('mass', 'f8')]))
+
+        for i in range(length):
+                vectors = np.append(vectors, np.array([(pTList[i], etaList[i], phiList[i], massList[i])], 
+                                                      dtype=vectors.dtype))
+        
+        # Actual jet step
+        sequence = cluster(vectors, R=0.4, p=-1) # p=-1 gives anti-kt
+        jets = sequence.inclusive_jets()  # list of PseudoJets
+
+        return jets
+
+def plotOneJet(jet, name):
+    const = jet.constituents_array()
+    plt.scatter(const["eta"], const["phi"], c='green')
+    plt.scatter([jet.eta], [jet.phi], c="red")
+    plt.xlabel(r'$\eta$')
+    plt.ylabel(r'$\phi$')
+    plt.savefig(name)
+    plt.clf()
+
+def matchArr(jetArr, treeArr):
+        # Convert to int so np.where() is available
+        intjetArr = (10000*jetArr).astype(int)
+        inttreeArr = (10000*treeArr).astype(int)
+
+        # Stores recovered index of particle in jet
+        indexArr = np.zeros(len(jetArr))
+        
+        for i in range(len(intjetArr)):
+                indexArr[i] = np.where(inttreeArr == intjetArr[i])[0][0]
+
+        return indexArr

--- a/RecoTracker/LSTCore/standalone/quick_run.sh
+++ b/RecoTracker/LSTCore/standalone/quick_run.sh
@@ -1,9 +1,21 @@
-# File created by Kasia so she can automate making plots a bit
-# Yes, I know about lst_run, but I have it set up how I like, ok?
+################################################################
+# File created by Kasia so she can automate making plots
+################################################################
 
+# Make room for new LSTNtuple.root and LSTNumDen.root
 rm -r LST*.root
+
+# Compile
 lst_make_tracklooper -mcC;
+
+# Takes new_tree.root as input and produces LSTNtuple.root, which includes only the relevant branches + reconstructed tracks
 lst -i PU200 -l -o LSTNtuple.root;
+
+# Creates LSTNumDen.root, a collection of all the numerator/denominator histograms
 createPerfNumDenHists -i LSTNtuple.root -o LSTNumDen.root;
+
+# Creates plots. The --indivdual tag produces the *total* efficiency plot, --pt_cut changes the label for the pt cut
 python3 efficiency/python/lst_plot_performance.py --individual --pt_cut 50 LSTNumDen.root -t "mywork022z";
+
+# Saves relevant plot to my publi html page
 # cp /mnt/data1/kk829/cmssw/RecoTracker/LSTCore/standalone/performance/mywork022z_a3119eD-PU200/mtv/var/TC_base_0_0_eff_rjet.png ~/public_html/all_rjet_1_zoom/TC_base_0_pT50_jet-pT100_etacut.png

--- a/RecoTracker/LSTCore/standalone/quick_run.sh
+++ b/RecoTracker/LSTCore/standalone/quick_run.sh
@@ -9,13 +9,14 @@ rm -r LST*.root
 lst_make_tracklooper -mcC;
 
 # Takes new_tree.root as input and produces LSTNtuple.root, which includes only the relevant branches + reconstructed tracks
-lst -i PU200 -l -o LSTNtuple.root;
+lst -i QCD1800-2400PU0 -l -o LSTNtuple.root;
 
 # Creates LSTNumDen.root, a collection of all the numerator/denominator histograms
 createPerfNumDenHists -i LSTNtuple.root -o LSTNumDen.root;
 
 # Creates plots. The --indivdual tag produces the *total* efficiency plot, --pt_cut changes the label for the pt cut
-python3 efficiency/python/lst_plot_performance.py --individual --pt_cut 50 LSTNumDen.root -t "mywork022z";
+python3 efficiency/python/lst_plot_performance.py --individual --pt_cut 0.9 LSTNumDen.root -t "myWork";
+# python3 efficiency/python/lst_plot_performance.py --pt_cut 2 LSTNumDen.root -t "mywork001";
 
-# Saves relevant plot to my publi html page
-# cp /mnt/data1/kk829/cmssw/RecoTracker/LSTCore/standalone/performance/mywork022z_a3119eD-PU200/mtv/var/TC_base_0_0_eff_rjet.png ~/public_html/all_rjet_1_zoom/TC_base_0_pT50_jet-pT100_etacut.png
+# Saves relevant plot to my public html page
+# cp /mnt/data1/kk829/cmssw/RecoTracker/LSTCore/standalone/performance/mywork001_028aa9D-PU200/mtv/var/TC_base_0_0_eff_rjet.png ~/public_html/recent/TC_base_0_0_pT09_jet-pT100_etacut.png

--- a/RecoTracker/LSTCore/standalone/quick_run.sh
+++ b/RecoTracker/LSTCore/standalone/quick_run.sh
@@ -5,5 +5,5 @@ rm -r LST*.root
 lst_make_tracklooper -mcC;
 lst -i PU200 -l -o LSTNtuple.root;
 createPerfNumDenHists -i LSTNtuple.root -o LSTNumDen.root;
-python3 efficiency/python/lst_plot_performance.py --individual --pt_cut 50 LSTNumDen.root -t "mywork021z";
-cp /mnt/data1/kk829/cmssw/RecoTracker/LSTCore/standalone/performance/mywork021z_a3119eD-PU200/mtv/var/TC_base_0_0_eff_rjet.png ~/public_html/all_rjet_1_zoom/TC_base_0_pT50_jet-pT50_etacut.png
+python3 efficiency/python/lst_plot_performance.py --individual --pt_cut 50 LSTNumDen.root -t "mywork022z";
+# cp /mnt/data1/kk829/cmssw/RecoTracker/LSTCore/standalone/performance/mywork022z_a3119eD-PU200/mtv/var/TC_base_0_0_eff_rjet.png ~/public_html/all_rjet_1_zoom/TC_base_0_pT50_jet-pT100_etacut.png

--- a/RecoTracker/LSTCore/standalone/quick_run.sh
+++ b/RecoTracker/LSTCore/standalone/quick_run.sh
@@ -1,0 +1,9 @@
+# File created by Kasia so she can automate making plots a bit
+# Yes, I know about lst_run, but I have it set up how I like, ok?
+
+rm -r LST*.root
+lst_make_tracklooper -mcC;
+lst -i PU200 -l -o LSTNtuple.root;
+createPerfNumDenHists -i LSTNtuple.root -o LSTNumDen.root;
+python3 efficiency/python/lst_plot_performance.py --individual --pt_cut 50 LSTNumDen.root -t "mywork021z";
+cp /mnt/data1/kk829/cmssw/RecoTracker/LSTCore/standalone/performance/mywork021z_a3119eD-PU200/mtv/var/TC_base_0_0_eff_rjet.png ~/public_html/all_rjet_1_zoom/TC_base_0_pT50_jet-pT50_etacut.png

--- a/RecoTracker/LSTCore/standalone/reformat_jets.py
+++ b/RecoTracker/LSTCore/standalone/reformat_jets.py
@@ -1,0 +1,148 @@
+##########################################################
+#
+# The file trackingNtuple.root has the data I need.
+# I can section it off into jets.
+# I then put these jets into a new n-tuple, 
+#
+##########################################################
+
+import matplotlib.pyplot as plt
+import ROOT
+from ROOT import TFile
+from myjets import getLists, createJets, matchArr
+import numpy as np
+
+# Possible pT cut
+pTCut = 100
+
+# Load existing tree
+file = TFile("trackingNtuple.root")
+old_tree = file["trackingNtuple"]["tree"]
+
+# Create a new ROOT file to store the new TTree
+new_file = ROOT.TFile("new_tree.root", "RECREATE")
+
+# Create a new subdirectory in the new file
+new_directory = new_file.mkdir("trackingNtuple")
+
+# Change the current directory to the new subdirectory
+new_directory.cd()
+
+# Create a new TTree with the same structure as the old one but empty
+new_tree = old_tree.CloneTree(0)  
+
+# Create a variable to hold the new leaves' data (a list of floats)
+new_leaf_etadiffs = ROOT.std.vector('float')()
+new_leaf_phidiffs = ROOT.std.vector('float')()
+new_leaf_rjet = ROOT.std.vector('float')()
+new_leaf_jet_eta = ROOT.std.vector('float')()
+new_leaf_jet_phi = ROOT.std.vector('float')()
+new_leaf_jet_pt = ROOT.std.vector('float')()
+
+
+# Create a new branch in the tree
+new_tree.Branch("sim_etadiffs", new_leaf_etadiffs)
+new_tree.Branch("sim_phidiffs", new_leaf_phidiffs)
+new_tree.Branch("sim_rjet", new_leaf_rjet)
+new_tree.Branch("sim_jet_eta", new_leaf_jet_eta)
+new_tree.Branch("sim_jet_phi", new_leaf_jet_phi)
+new_tree.Branch("sim_jet_pt", new_leaf_jet_pt)
+
+# Loop over entries in the old tree
+for i in range(old_tree.GetEntries()):
+    old_tree.GetEntry(i)
+
+    # Clear the vector to start fresh for this entry
+    new_leaf_etadiffs.clear()
+    new_leaf_phidiffs.clear()
+    new_leaf_rjet.clear()
+    new_leaf_jet_eta.clear()
+    new_leaf_jet_phi.clear()
+    new_leaf_jet_pt.clear()
+
+    # Creates the lists that will fill the leaves
+    pTList, etaList, phiList, massList = getLists(old_tree, 0)
+    jets = createJets(pTList, etaList, phiList, massList)
+    
+    jetIndex = np.array([])
+    eta_diffs = np.array([])
+    phi_diffs = np.array([])
+    rjets = np.array([])
+    jet_eta = np.array([])
+    jet_phi = np.array([])
+    jet_pt = np.array([])
+
+    for jet in jets:
+        const = jet.constituents_array()
+        # Reorder particles within jet (jet clustering does not respect original index)
+        jetIndex = np.append(jetIndex, matchArr(const["pT"], pTList)) # order restored by matching pT
+        jetIndex = jetIndex.astype(int)
+
+        # Compute the distance to jet
+        etaval = const["eta"]-jet.eta
+        phival = const["phi"]-jet.phi
+        eta_diffs = np.append(eta_diffs, etaval)
+        phi_diffs = np.append(phi_diffs, phival)
+
+        rval = np.sqrt(etaval**2 + phival**2)
+        rjets = np.append(rjets, rval)
+
+        # Save values of closest jet
+        jet_eta_val = np.ones(len(const["eta"]))*jet.eta
+        jet_eta = np.append(jet_eta, jet_eta_val)
+        jet_phi_val = np.ones(len(const["eta"]))*jet.phi
+        jet_phi = np.append(jet_phi, jet_phi_val)
+        jet_pt_val = np.ones(len(const["eta"]))*jet.pt
+        jet_pt = np.append(jet_pt, jet_pt_val)
+    
+    # print(jet_pt)
+
+    # Reorder branches appropriately
+    length = len(eta_diffs)
+    re_eta_diffs = np.zeros(length)
+    re_phi_diffs = np.zeros(length)
+    re_rjets = np.zeros(length)
+    re_jet_eta = np.zeros(length)
+    re_jet_phi = np.zeros(length)
+    re_jet_pt = np.zeros(length)
+
+    for i in range(length):
+        re_eta_diffs[jetIndex[i]] = eta_diffs[i]
+        re_phi_diffs[jetIndex[i]] = phi_diffs[i]
+        re_rjets[jetIndex[i]] = rjets[i]
+        re_jet_eta[jetIndex[i]] = jet_eta[i]
+        re_jet_phi[jetIndex[i]] = jet_phi[i]
+        re_jet_pt[jetIndex[i]] = jet_pt[i]
+
+    # Add the list elements to the vector
+    for value in re_eta_diffs:
+        new_leaf_etadiffs.push_back(value)
+    for value in re_phi_diffs:
+        new_leaf_phidiffs.push_back(value)
+    for value in re_rjets:
+        new_leaf_rjet.push_back(value)
+    for value in re_jet_eta:
+        new_leaf_jet_eta.push_back(value)
+    for value in re_jet_phi:
+        new_leaf_jet_phi.push_back(value)
+    for value in re_jet_pt:
+        new_leaf_jet_pt.push_back(value)
+
+    # Fill the tree with the new values
+    new_tree.Fill()
+
+    # break # Just for testing purposes
+
+# new_tree.Scan("sim_pt@.size():sim_jet_pt@.size()")
+
+# Write the tree back to the file
+new_tree.Write()
+
+# Debugging: print new_tree events
+# new_tree.GetEntry(0) # only look at first event
+# for i in range(3): # only look at first 3 tracks in event
+#     print(f"Track {i}: sim_phi = {new_tree.sim_phi[i]}\t sim_eta = {new_tree.sim_eta[i]} \t sim_pt = {new_tree.sim_pt[i]} \t sim_rjet = {new_tree.sim_rjet[i]}") 
+
+new_file.Close()
+file.Close()
+

--- a/RecoTracker/LSTCore/standalone/reformat_jets.py
+++ b/RecoTracker/LSTCore/standalone/reformat_jets.py
@@ -16,11 +16,11 @@ import numpy as np
 # pTCut = 100
 
 # Load existing tree
-file = TFile("trackingNtuple.root") # TFile("/data2/segmentlinking/CMSSW_12_2_0_pre2/trackingNtuple_ttbar_PU200.root")
+file =  TFile("/data2/segmentlinking/CMSSW_12_2_0_pre2/trackingNtuple_ttbar_PU200.root")
 old_tree = file["trackingNtuple"]["tree"]
 
 # Create a new ROOT file to store the new TTree
-new_file = ROOT.TFile("new_tree_ttbar.root", "RECREATE")
+new_file = ROOT.TFile("new_tree_ttbar_cut.root", "RECREATE")
 
 # Create a new subdirectory in the new file
 new_directory = new_file.mkdir("trackingNtuple")
@@ -30,6 +30,9 @@ new_directory.cd()
 
 # Create a new TTree with the same structure as the old one but empty
 new_tree = old_tree.CloneTree(0)  
+
+# Account for bug in 12_2_X branch
+new_tree.SetBranchStatus("ph2_bbxi", False) 
 
 # Create a variable to hold the new leaves' data (a list of floats)
 new_leaf_etadiffs = ROOT.std.vector('float')()


### PR DESCRIPTION
PR description:

My goal was to examine the efficiency of LST close to the center of jets. To do this, I generated a trackingNtuple.root file and clustered it into jets. The trackingNtuple.root file is too large to upload here, but the code I used to create the jets is in reformat_jets.py and myjets.py. Currently, these files are configured to read in the usual ttbar sample.

Those two files add six branches to the original trackingNtuple.root file. These branches are sim_etadiffs, sim_rjetdiffs, sim_rjet, sim_jet_eta, sim_jet_phi, and sim_jet_pt. The rjet branch is the most relevant– here "rjet" is the eta-phi distance between a track and the center of the closest jet.

In order to create efficiency plots for this, I modified the existing LST files to include my branches. This mostly involved copying lines of code and changing the relevant branch names. In a few places, I have included cuts or edits to how the efficiency plots are produced. (Everywhere I have made a change I also added a comment to the effect of "Added by Kasia", but this was only so that I could find my own changes quickly when I need them.) The only change to the original LST output under this configuration is that if a track is not part of a jet, it is not included. However, if the input root file does not contain my six custom branches, LST will not compile. This pull request is mainly to demonstrate what I have done.

Here is the indico link to the presentation I gave to the LST group on 3/18/25:
https://indico.cern.ch/event/1496305/contributions/6303105/attachments/3034297/5358002/Jet%20Efficiencies.pdf


PR validation:

No tests have been done since my edits interfere with the usual functioning of LST.
