### PR TITLE
Add pp and UPC reco eras for 2025 oxygen runs

### DIFF
--- a/Configuration/Eras/python/Era_Run3_2025_OXY_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2025_OXY_cff.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Eras.Era_Run3_2025_UPC_cff import Run3_2025_UPC
+from Configuration.Eras.Era_Run3_2025_cff import Run3_2025
+from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
 from Configuration.Eras.Modifier_run3_oxygen_cff import run3_oxygen
 
-Run3_2025_OXY = cms.ModifierChain(Run3_2025_UPC, run3_oxygen)
+Run3_2025_OXY = cms.ModifierChain(Run3_2025, run3_upc, run3_oxygen)

--- a/Configuration/Eras/python/Era_Run3_2025_UPC_OXY_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2025_UPC_OXY_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run3_2025_UPC_cff import Run3_2025_UPC
+from Configuration.Eras.Modifier_run3_oxygen_cff import run3_oxygen
+
+Run3_2025_UPC_OXY = cms.ModifierChain(Run3_2025_UPC, run3_oxygen)

--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -572,6 +572,7 @@ workflows[143.902] = ['',['RunUPC2024','RECODR3_2025_HIN','HARVESTDPROMPTR3']]
 
 ### run3-2025 (2025 HI OXY data)
 workflows[143.911] = ['',['RunUPC2024','RECODR3_2025_OXY','HARVESTDPROMPTR3']]
+workflows[143.912] = ['',['RunUPC2024','RECODR3_2025_UPC_OXY','HARVESTDPROMPTR3']]
 
 
 ## Lumi mask fixed 2024 wfs

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1305,6 +1305,7 @@ hiDefaults2024_approxClusters = {'--conditions':'auto:phase1_2024_realistic_hi',
 upcDefaults2024 = {'--conditions':'auto:phase1_2024_realistic_hi', '--era':'Run3_2024_UPC'}
 upcDefaults2025 = {'--conditions':'auto:phase1_2024_realistic_hi', '--era':'Run3_2025_UPC'}
 oxyDefaults2025 = {'--conditions':'auto:phase1_2024_realistic_hi', '--era':'Run3_2025_OXY'}
+upcOxyDefaults2025 = {'--conditions':'auto:phase1_2024_realistic_hi', '--era':'Run3_2025_UPC_OXY'}
 
 steps['Hydjet2Q_MinBias_5020GeV_2018_ppReco']=merge([{'-n':1},hiDefaults2018_ppReco,gen2018hiprod('Hydjet2_Quenched_MinBias_5020GeV_cfi',U2000by1)])
 steps['HydjetQ_MinBias_XeXe_5442GeV_2017']=merge([{'-n':1},hiDefaults2017,gen2017('Hydjet_Quenched_MinBias_XeXe_5442GeV_cfi',U2000by1)])
@@ -2856,14 +2857,15 @@ steps['RECODR3_reHLT_2024']=merge([{'--conditions':'auto:run3_data_prompt_relval
 # Could be removed once 2025 wfs are in and we'll test the online GT with them
 steps['RECODR3_reHLT_2024_Offline']=merge([{'--conditions':'auto:run3_data_relval', '--hltProcess':'reHLT'},steps['RECODR3']])
 
-steps['RECODR2_2016_UPC']=merge([{'--conditions':'auto:run2_data', '--era':'Run2_2016_UPC', '-s':'RAW2DIGI,L1Reco,RECO,DQM:@commonFakeHLT+@standardDQMFakeHLT', '--repacked':''},steps['RECODR2_2016']])
-steps['RECODR3_2023_HIN']=merge([{'--conditions':'auto:run3_data_prompt', '-s':'RAW2DIGI,L1Reco,RECO,DQM:@commonFakeHLT+@standardDQMFakeHLT', '--repacked':'', '-n':1000},steps['RECODR3_2023']])
+steps['RECODR2_2016_UPC']=merge([{'--conditions':'auto:run2_data', '--era':'Run2_2016_UPC', '-s':'RAW2DIGI,L1Reco,RECO,PAT,DQM:@commonFakeHLT+@standardDQMFakeHLT', '--repacked':''},steps['RECODR2_2016']])
+steps['RECODR3_2023_HIN']=merge([{'--conditions':'auto:run3_data_prompt', '-s':'RAW2DIGI,L1Reco,RECO,PAT,DQM:@commonFakeHLT+@standardDQMFakeHLT', '--repacked':'', '-n':1000},steps['RECODR3_2023']])
 steps['RECODR3_2023_UPC']=merge([{'--conditions':'auto:run3_data', '--era':'Run3_2023_UPC'},steps['RECODR3_2023_HIN']])
-steps['RECODR3_2024_HIN']=merge([{'--conditions':'auto:run3_data_prompt', '-s':'RAW2DIGI,L1Reco,RECO,DQM:@commonFakeHLT+@standardDQMFakeHLT', '--repacked':'', '-n':1000},steps['RECODR3_2024']])
+steps['RECODR3_2024_HIN']=merge([{'--conditions':'auto:run3_data_prompt', '-s':'RAW2DIGI,L1Reco,RECO,PAT,DQM:@commonFakeHLT+@standardDQMFakeHLT', '--repacked':'', '-n':1000},steps['RECODR3_2024']])
 steps['RECODR3_2024_UPC']=merge([{'--era':'Run3_2024_UPC'},steps['RECODR3_2024_HIN']])
-steps['RECODR3_2025_HIN']=merge([{'--conditions':'auto:run3_data_prompt', '-s':'RAW2DIGI,L1Reco,RECO,DQM:@commonFakeHLT+@standardDQMFakeHLT', '--repacked':'', '-n':1000},steps['RECODR3_2025']])
+steps['RECODR3_2025_HIN']=merge([{'--conditions':'auto:run3_data_prompt', '-s':'RAW2DIGI,L1Reco,RECO,PAT,DQM:@commonFakeHLT+@standardDQMFakeHLT', '--repacked':'', '-n':1000},steps['RECODR3_2025']])
 steps['RECODR3_2025_UPC']=merge([{'--era':'Run3_2025_UPC'},steps['RECODR3_2025_HIN']])
 steps['RECODR3_2025_OXY']=merge([{'--era':'Run3_2025_OXY'},steps['RECODR3_2025_HIN']])
+steps['RECODR3_2025_UPC_OXY']=merge([{'--era':'Run3_2025_UPC_OXY'},steps['RECODR3_2025_HIN']])
 
 steps['RECODR3Splash']=merge([{'-n': 2,
                                '-s': 'RAW2DIGI,L1Reco,RECO,PAT,ALCA:SiStripCalZeroBias+SiStripCalMinBias+TkAlMinBias+EcalESAlign,DQM:@standardDQMFakeHLT+@miniAODDQM'

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -56,6 +56,7 @@ class Eras (object):
                  'Run3_2024_UPC',
                  'Run3_2025_UPC',
                  'Run3_2025_OXY',
+                 'Run3_2025_UPC_OXY',
                  'Phase2',
                  'Phase2_noMkFit',
                  'Phase2C9',

--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -157,7 +157,8 @@ _pp_on_AA_extraCommands = [
 ]
 
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
-pp_on_AA.toModify(MicroEventContent, outputCommands = MicroEventContent.outputCommands + _pp_on_AA_extraCommands)
+from Configuration.Eras.Modifier_run3_oxygen_cff import run3_oxygen
+(pp_on_AA | run3_oxygen).toModify(MicroEventContent, outputCommands = MicroEventContent.outputCommands + _pp_on_AA_extraCommands)
 
 _upc_extraCommands = [
     'keep patPackedCandidates_hiPixelTracks_*_*',
@@ -194,7 +195,7 @@ MicroEventContentMC.outputCommands += [
                                         'keep L1GtTriggerMenuLite_l1GtTriggerMenuLite__*'
                                       ]
 _pp_on_AA_MC_extraCommands = ['keep *_packedGenParticlesSignal_*_*','keep edmGenHIEvent_heavyIon_*_*']
-pp_on_AA.toModify(MicroEventContentMC, outputCommands = MicroEventContentMC.outputCommands + _pp_on_AA_MC_extraCommands)
+(pp_on_AA | run3_oxygen).toModify(MicroEventContentMC, outputCommands = MicroEventContentMC.outputCommands + _pp_on_AA_MC_extraCommands)
 
 from Configuration.Eras.Modifier_strips_vfp30_2016_cff import strips_vfp30_2016
 strips_vfp30_2016.toModify(MicroEventContentMC, outputCommands = MicroEventContentMC.outputCommands + [

--- a/PhysicsTools/PatAlgos/python/slimming/genParticles_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/genParticles_cff.py
@@ -23,4 +23,5 @@ _genParticlesHITask = genParticlesTask.copy()
 _genParticlesHITask.add(packedGenParticlesSignal)
 
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
-pp_on_AA.toReplaceWith(genParticlesTask, _genParticlesHITask)
+from Configuration.Eras.Modifier_run3_oxygen_cff import run3_oxygen
+(pp_on_AA | run3_oxygen).toReplaceWith(genParticlesTask, _genParticlesHITask)

--- a/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
@@ -124,9 +124,11 @@ _photonDRN.toReplaceWith(slimmingTask, cms.Task(slimmingTask.copy(), patPhotonsD
 from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
 from PhysicsTools.PatAlgos.modules import DeDxEstimatorRekeyer
 dedxEstimator = DeDxEstimatorRekeyer()
-from Configuration.Eras.Modifier_run3_egamma_2023_cff import run3_egamma_2023
 run3_upc.toModify(dedxEstimator, dedxEstimators = ["dedxHarmonic2", "dedxPixelHarmonic2", "dedxPixelLikelihood", "dedxStripLikelihood", "dedxAllLikelihood"])
 run3_upc.toReplaceWith(slimmingTask, cms.Task(slimmingTask.copy(), hiPixelTracks, packedPFCandidateTrackChi2, lostTrackChi2, dedxEstimator))
+
+from Configuration.Eras.Modifier_run3_oxygen_cff import run3_oxygen
+run3_oxygen.toReplaceWith(slimmingTask, cms.Task(slimmingTask.copy(), hiPixelTracks, hiEvtPlane, hiEvtPlaneFlat, packedPFCandidateTrackChi2, lostTrackChi2, centralityBin, hiHFfilters))
 
 from Configuration.Eras.Modifier_ppRef_2024_cff import ppRef_2024
 ppRef_2024.toReplaceWith(slimmingTask, cms.Task(slimmingTask.copy(), packedPFCandidateTrackChi2, lostTrackChi2))

--- a/RecoHI/HiEvtPlaneAlgos/python/HiEvtPlane_cfi.py
+++ b/RecoHI/HiEvtPlaneAlgos/python/HiEvtPlane_cfi.py
@@ -35,7 +35,8 @@ hiEvtPlane = cms.EDProducer("EvtPlaneProducer",
                             )
 
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
-pp_on_AA.toModify(hiEvtPlane,
+from Configuration.Eras.Modifier_run3_oxygen_cff import run3_oxygen
+(pp_on_AA | run3_oxygen).toModify(hiEvtPlane,
     vertexTag = "offlinePrimaryVertices",
     trackTag = "packedPFCandidates",
     caloTag = "particleFlow",

--- a/RecoHI/HiTracking/python/HILowPtConformalPixelTracks_cfi.py
+++ b/RecoHI/HiTracking/python/HILowPtConformalPixelTracks_cfi.py
@@ -167,8 +167,8 @@ hiConformalPixelTracksTaskPhase1 = cms.Task(
 
 phase1Pixel.toReplaceWith(hiConformalPixelTracksTask, hiConformalPixelTracksTaskPhase1)
 
-from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
-run3_upc.toModify(hiConformalPixelTracksPhase1TrackingRegions.RegionPSet, ptMin = 0.05)
-run3_upc.toModify(hiConformalPixelTracksPhase1Filter, ptMin = 0.05)
-run3_upc.toModify(hiTrackingRegionWithVertex.RegionPSet, VertexCollection = "offlinePrimaryVertices", ptMin = 0.05)
-run3_upc.toModify(hiConformalPixelFilter, VertexCollection = "offlinePrimaryVertices", ptMin = 0.05)
+from Configuration.Eras.Modifier_highBetaStar_cff import highBetaStar
+highBetaStar.toModify(hiConformalPixelTracksPhase1TrackingRegions.RegionPSet, ptMin = 0.05)
+highBetaStar.toModify(hiConformalPixelTracksPhase1Filter, ptMin = 0.05)
+highBetaStar.toModify(hiTrackingRegionWithVertex.RegionPSet, VertexCollection = "offlinePrimaryVertices", ptMin = 0.05)
+highBetaStar.toModify(hiConformalPixelFilter, VertexCollection = "offlinePrimaryVertices", ptMin = 0.05)

--- a/RecoTracker/TkSeedGenerator/python/trackerClusterCheck_cfi.py
+++ b/RecoTracker/TkSeedGenerator/python/trackerClusterCheck_cfi.py
@@ -36,7 +36,8 @@ egamma_lowPt_exclusive.toModify(trackerClusterCheck,
                )
 
 from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
-run3_upc.toModify(trackerClusterCheck,
+from Configuration.Eras.Modifier_highBetaStar_cff import highBetaStar
+(highBetaStar & run3_upc).toModify(trackerClusterCheck,
                doClusterCheck=True,
                cut = "strip < 30000 && pixel < 10000",
                MaxNumberOfPixelClusters = 10000,

--- a/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
+++ b/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
@@ -179,7 +179,7 @@ highBetaStar.toModify(offlinePrimaryVertices,
 )
 
 from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
-run3_upc.toModify(offlinePrimaryVertices,
+(highBetaStar & run3_upc).toModify(offlinePrimaryVertices,
     TkFilterParameters = dict(
         algorithm="filterWithThreshold",
         maxNormalizedChi2 = 80.0,

--- a/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cff.py
+++ b/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cff.py
@@ -45,7 +45,12 @@ from Configuration.Eras.Modifier_pp_on_PbPb_run3_2023_cff import pp_on_PbPb_run3
 from Configuration.Eras.Era_Run3_2023_UPC_cff import Run3_2023_UPC
 (pp_on_PbPb_run3_2023 | Run3_2023_UPC).toModify(HcalTPGCoderULUT, FG_HF_thresholds = [16, 19])
 
-#placedholder values for 2024, copied from 2023
 from Configuration.Eras.Modifier_pp_on_PbPb_run3_2024_cff import pp_on_PbPb_run3_2024
 from Configuration.Eras.Era_Run3_2024_UPC_cff import Run3_2024_UPC
 (pp_on_PbPb_run3_2024 | Run3_2024_UPC).toModify(HcalTPGCoderULUT, FG_HF_thresholds = [16, 19])
+
+#placedholder values for 2025, copied from 2024
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_2025_cff import pp_on_PbPb_run3_2025
+from Configuration.Eras.Modifier_run3_oxygen_cff import run3_oxygen
+from Configuration.Eras.Era_Run3_2025_UPC_cff import Run3_2025_UPC
+(pp_on_PbPb_run3_2025 | run3_oxygen | Run3_2025_UPC).toModify(HcalTPGCoderULUT, FG_HF_thresholds = [16, 19])

--- a/SimGeneral/Configuration/python/SimGeneral_EventContent_cff.py
+++ b/SimGeneral/Configuration/python/SimGeneral_EventContent_cff.py
@@ -36,7 +36,8 @@ SimGeneralPREMIX = cms.PSet(
 _pp_on_AA_extraCommands = ['keep CrossingFramePlaybackInfoNew_mix_*_*','keep *_heavyIon_*_*']
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
-for e in [pp_on_XeXe_2017, pp_on_AA]:
+from Configuration.Eras.Modifier_run3_oxygen_cff import run3_oxygen
+for e in [pp_on_XeXe_2017, pp_on_AA, run3_oxygen]:
     e.toModify( SimGeneralRAW, outputCommands = SimGeneralRAW.outputCommands + _pp_on_AA_extraCommands )
     e.toModify( SimGeneralFEVTDEBUG, outputCommands = SimGeneralFEVTDEBUG.outputCommands + _pp_on_AA_extraCommands )
     e.toModify( SimGeneralRECO, outputCommands = SimGeneralRECO.outputCommands + _pp_on_AA_extraCommands )


### PR DESCRIPTION
#### PR description:

This PR creates two eras for the 2025 oxygen runs, one running the standard pp tracking and egamma reconstruction (Run3_2025_OXY) and the other running the high beta star and low-pT egamma reconstruction (Run3_2025_UPC_OXY), while preserving the same event content for both eras.

@abaty @loizides @mandrenguyen 

#### PR validation:

Tested with workflow 143.911 and 143.912

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Plan to backport to 15_0_X
