### PR TITLE
Mark more classes with rntupleStreamerMode

### DIFF
--- a/DataFormats/CTPPSReco/src/classes_def.xml
+++ b/DataFormats/CTPPSReco/src/classes_def.xml
@@ -60,7 +60,8 @@
   <class name="std::vector<edm::DetSet<TotemRPLocalTrack> >"/>
   <class name="edm::DetSetVector<TotemRPLocalTrack>"/>
   <class name="edm::Wrapper<edm::DetSetVector<TotemRPLocalTrack>>"/>
-  <class name="TotemRPLocalTrack::FittedRecHit" ClassVersion="3">
+  <!-- FittedRecHit holds a TVector3 which RNTuple can not handle -->
+  <class name="TotemRPLocalTrack::FittedRecHit" ClassVersion="3" rntupleStreamerMode="true">
     <version ClassVersion="3" checksum="839012906"/>
   </class>
   <class name="edm::DetSet<TotemRPLocalTrack::FittedRecHit>"/>

--- a/SimDataFormats/TrackingAnalysis/src/classes_def.xml
+++ b/SimDataFormats/TrackingAnalysis/src/classes_def.xml
@@ -38,7 +38,7 @@
   <class name="std::pair<UniqueSimTrackId, edm::Ref<std::vector<TrackingParticle>, TrackingParticle, edm::refhelper::FindUsingAdvance<std::vector<TrackingParticle>, TrackingParticle> > >"/>
   <class name="std::unordered_map<UniqueSimTrackId, TrackingParticleRef, UniqueSimTrackIdHash>"/>
   <class name="edm::Wrapper<std::unordered_map<UniqueSimTrackId, TrackingParticleRef, UniqueSimTrackIdHash>>"/>
-  <class name="SimTrackToTPMap"/>
+  <class name="SimTrackToTPMap" rntupleStreamerMode="true"/>
   <class name="edm::Wrapper<SimTrackToTPMap>"/>
 
   <class name="SimDoublets" ClassVersion="3">


### PR DESCRIPTION
#### PR description:

These types can't be handled fully by RNTuple so must be serialized using the streamer mode.

#### PR validation:

Code compiles. Tests using the RNTUPLE IB showed these changes were effective.

resolves https://github.com/cms-sw/framework-team/issues/1345