### PR TITLE
Restore branchless 'and' operations

### DIFF
--- a/CommonTools/RecoAlgos/BuildFile.xml
+++ b/CommonTools/RecoAlgos/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="SimGeneral/HepPDTRecord"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
+<use name="DataFormats/Math"/>
 <use name="DataFormats/TrackReco"/>
 <use name="DataFormats/MuonReco"/>
 <use name="DataFormats/TrackingRecHit"/>

--- a/CommonTools/RecoAlgos/interface/KDTreeLinkerAlgo.h
+++ b/CommonTools/RecoAlgos/interface/KDTreeLinkerAlgo.h
@@ -1,6 +1,8 @@
 #ifndef KDTreeLinkerAlgoTemplated_h
 #define KDTreeLinkerAlgoTemplated_h
 
+#include "DataFormats/Math/interface/logic.h"
+
 #include <cassert>
 #include <vector>
 #include <array>
@@ -229,7 +231,7 @@ void KDTreeLinkerAlgo<DATA, DIM>::recSearch(int current, const KDTreeBox<DIM> &t
       bool isInside = true;
       for (unsigned i = 0; i < DIM; ++i) {
         float dimCurr = nodePool_.dims[i][current];
-        isInside &= (dimCurr >= trackBox.dimmin[i]) && (dimCurr <= trackBox.dimmax[i]);
+        isInside &= reco::branchless_and(dimCurr >= trackBox.dimmin[i], dimCurr <= trackBox.dimmax[i]);
       }
       if (isInside) {
         closestNeighbour->push_back(nodePool_.data[current]);

--- a/DataFormats/Math/interface/logic.h
+++ b/DataFormats/Math/interface/logic.h
@@ -1,0 +1,13 @@
+#ifndef DataFormats_Math_logic_h
+#define DataFormats_Math_logic_h
+
+namespace reco {
+  // this function can be called with any boolean expressions as the parameters
+  // this forces the evaluation of both expressions (faster if the expressions are simple)
+  // and applying && to two bools avoids branching (jump instruction)
+  // whereas applying && to the two original expressions may cause branching
+  // this is an alternative to using the bitwise and operator (&), which never short-circuits
+  bool branchless_and(bool a, bool b) { return a && b; }
+}  // namespace reco
+
+#endif

--- a/DataFormats/Math/interface/logic.h
+++ b/DataFormats/Math/interface/logic.h
@@ -7,7 +7,7 @@ namespace reco {
   // and applying && to two bools avoids branching (jump instruction)
   // whereas applying && to the two original expressions may cause branching
   // this is an alternative to using the bitwise and operator (&), which never short-circuits
-  bool branchless_and(bool a, bool b) { return a && b; }
+  inline bool branchless_and(bool a, bool b) { return a && b; }
 }  // namespace reco
 
 #endif

--- a/RecoTracker/MeasurementDet/BuildFile.xml
+++ b/RecoTracker/MeasurementDet/BuildFile.xml
@@ -4,6 +4,7 @@
 <use name="TrackingTools/GeomPropagators"/>
 <use name="CalibFormats/SiStripObjects"/>
 <use name="DataFormats/Common"/>
+<use name="DataFormats/Math"/>
 <use name="DataFormats/SiPixelCluster"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>

--- a/RecoTracker/MeasurementDet/plugins/doubleMatch.icc
+++ b/RecoTracker/MeasurementDet/plugins/doubleMatch.icc
@@ -46,6 +46,7 @@ namespace {
 #include "RecHitPropagator.h"
 #include "DataFormats/GeometrySurface/interface/RectangularPlaneBounds.h"
 #include "DataFormats/GeometrySurface/interface/LocalError.h"
+#include "DataFormats/Math/interface/logic.h"
 
 namespace {
   inline void print(const char* where, const TrajectoryStateOnSurface& t1, const TrajectoryStateOnSurface& t2) {
@@ -128,7 +129,7 @@ void TkGluedMeasurementDet::doubleMatch(const TrajectoryStateOnSurface& ts,
     return;
   }
 
-  if ((!monoHits.empty()) && (!stereoHits.empty())) {
+  if (reco::branchless_and(!monoHits.empty(), !stereoHits.empty())) {
     const GluedGeomDet* gluedDet = &specificGeomDet();
     LocalVector trdir = (ts.isValid() ? ts.localDirection() : surface().toLocal(position() - GlobalPoint(0, 0, 0)));
 


### PR DESCRIPTION
#### PR description:

I noticed recently that #40611 may have caused performance regressions by changing bitwise & to logical &&, which was noted to cause branching in some cases. Branching can be avoided by forcing the evaluation of both expressions, so a new function is introduced to accomplish this. Two cases found in #40611 are addressed.

#### PR validation:

Absence of jump instructions is confirmed via godbolt (see discussion in #40611). Code compiles.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Intended to be backported to every open release since #40611 was merged. According to the ORP spreadsheet, these are:
13_0_X
13_2_X
14_0_X
14_1_X
14_2_X
15_0_X

I will wait for any review to conclude before preparing and submitting backports.

