### PR TITLE
Do not run test  under asan/ubsan env; avoid asan issues with ls -l

### DIFF
--- a/Alignment/OfflineValidation/test/BuildFile.xml
+++ b/Alignment/OfflineValidation/test/BuildFile.xml
@@ -48,8 +48,12 @@
   </bin>
   <test name="DiMuonVertex" command="testingScripts/test_unitDiMuonVertex.sh"/>
   <test name="DiElectronVertex" command="testingScripts/test_unitDiElectronVertex.sh"/>
-  <test name="SubmitPVrbr" command="testingScripts/test_unitSubmitPVrbr.sh"/>
-  <test name="SubmitPVsplit" command="testingScripts/test_unitSubmitPVsplit.sh"/>
+  <test name="SubmitPVrbr" command="testingScripts/test_unitSubmitPVrbr.sh">
+    <flags NO_TEST_PREFIX="1"/>
+  </test>
+  <test name="SubmitPVsplit" command="testingScripts/test_unitSubmitPVsplit.sh">
+    <flags NO_TEST_PREFIX="1"/>
+  </test>
   <test name="EoP" command="testingScripts/test_unitEoP.sh"/>
   <bin file="testEoPPlotting.cpp" name="testEoPPlotting">
     <flags PRE_TEST="EoP"/>


### PR DESCRIPTION
Unit test `SubmitPVrbr and SubmitPVsplit` still runs `ls -l` type command whihc under ASAN env misbehave and request a lot memory which breaks the build node. This change suggest to not set ASAN env (i.e. not set `LD_PRELOAD=libasan.so`) for these unit tests.
