### PR TITLE
[15_0_X] Backport of #47801 (Add the Scouting Glo-ParT inference facility)

### DIFF
--- a/PhysicsTools/NanoAOD/python/custom_run3scouting_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_run3scouting_cff.py
@@ -47,6 +47,7 @@ scoutingFatPFJetReclusterTask = cms.Task(
     scoutingPFCandidate, # translate to reco::PFCandidate, used as input
     scoutingFatPFJetRecluster, # jet clustering
     scoutingFatPFJetReclusterParticleNetJetTagInfos, scoutingFatPFJetReclusterParticleNetJetTags, # jet tagging
+    scoutingFatPFJetReclusterGlobalParticleTransformerJetTagInfos, scoutingFatPFJetReclusterGlobalParticleTransformerJetTags, # jet tagging with Global Particle Transformer
     scoutingFatPFJetReclusterSoftDrop, scoutingFatPFJetReclusterSoftDropMass, # softdrop mass
     scoutingFatPFJetReclusterParticleNetJetTagInfos, scoutingFatPFJetReclusterParticleNetMassRegressionJetTags, # regressed mass
     scoutingFatPFJetReclusterEcfNbeta1, scoutingFatPFJetReclusterNjettiness, # substructure variables

--- a/PhysicsTools/NanoAOD/python/run3scouting_cff.py
+++ b/PhysicsTools/NanoAOD/python/run3scouting_cff.py
@@ -546,6 +546,47 @@ scoutingFatPFJetReclusterParticleNetJetTags = cms.EDProducer("BoostedJetONNXJetT
     debugMode = cms.untracked.bool(False),
 )
 
+scoutingFatPFJetReclusterGlobalParticleTransformerJetTagInfos = cms.EDProducer("DeepBoostedJetTagInfoProducer",
+    jet_radius = cms.double(0.8),
+    min_jet_pt = cms.double(50),
+    max_jet_eta = cms.double(2.5),
+    min_pt_for_track_properties = cms.double(0.95),
+    min_pt_for_pfcandidates = cms.double(0.1),
+    use_puppiP4 = cms.bool(False),
+    include_neutrals = cms.bool(True),
+    sort_by_sip2dsig = cms.bool(False),
+    min_puppi_wgt = cms.double(-1.0),
+    flip_ip_sign = cms.bool(False),
+    sip3dSigMax = cms.double(-1.0),
+    use_hlt_features = cms.bool(False),
+    pf_candidates = cms.InputTag("scoutingPFCandidate"),
+    jets = cms.InputTag("scoutingFatPFJetRecluster"),
+    puppi_value_map = cms.InputTag(""),
+    use_scouting_features = cms.bool(True),
+    normchi2_value_map = cms.InputTag("scoutingPFCandidate", "normchi2"),
+    dz_value_map = cms.InputTag("scoutingPFCandidate", "dz"),
+    dxy_value_map = cms.InputTag("scoutingPFCandidate", "dxy"),
+    dzsig_value_map = cms.InputTag("scoutingPFCandidate", "dzsig"),
+    dxysig_value_map = cms.InputTag("scoutingPFCandidate", "dxysig"),
+    lostInnerHits_value_map = cms.InputTag("scoutingPFCandidate", "lostInnerHits"),
+    quality_value_map = cms.InputTag("scoutingPFCandidate", "quality"),
+    trkPt_value_map = cms.InputTag("scoutingPFCandidate", "trkPt"),
+    trkEta_value_map = cms.InputTag("scoutingPFCandidate", "trkEta"),
+    trkPhi_value_map = cms.InputTag("scoutingPFCandidate", "trkPhi"),
+)
+
+scoutingFatPFJetReclusterGlobalParticleTransformerJetTags = cms.EDProducer("BoostedJetONNXJetTagsProducer",
+    jets = cms.InputTag("scoutingFatPFJetRecluster"),
+    produceValueMap = cms.untracked.bool(True),
+    src = cms.InputTag("scoutingFatPFJetReclusterGlobalParticleTransformerJetTagInfos"),
+    preprocess_json = cms.string("RecoBTag/Combined/data/Run3Scouting/GlobalParticleTransformerAK8/General/V00/preprocess.json"),
+    model_path = cms.FileInPath("RecoBTag/Combined/data/Run3Scouting/GlobalParticleTransformerAK8/General/V00/global-part_2024.onnx"),
+    flav_names = cms.vstring([
+             "probQCD", "probXbb", "probXcc", "probXss", "probXqq", "probXbs", "probXgg", "probXee", "probXmm", "probXtauhtaue", "probXtauhtaum", "probXtauhtauh", "probXbc", "probXcs", "probXud", "massCorrGeneric", "massCorrGenericX2p", "massCorrGenericW2p", "massCorrResonance"
+     ]),
+    debugMode = cms.untracked.bool(False),
+)
+
 # AK8 jet softdrop mass
 
 scoutingFatPFJetReclusterSoftDrop = ak4PFJets.clone(
@@ -622,10 +663,27 @@ scoutingFatPFJetReclusterTable = cms.EDProducer("SimplePFJetFlatTableProducer",
         particleNet_prob_Hbb = ExtVar(cms.InputTag("scoutingFatPFJetReclusterParticleNetJetTags:probHbb"), float, doc="ParticleNet probability of Hbb", precision=10),
         particleNet_prob_Hcc = ExtVar(cms.InputTag("scoutingFatPFJetReclusterParticleNetJetTags:probHcc"), float, doc="ParticleNet probability of Hcc", precision=10),
         particleNet_prob_Hqq = ExtVar(cms.InputTag("scoutingFatPFJetReclusterParticleNetJetTags:probHqq"), float, doc="ParticleNet probability of Hqq", precision=10),
+        scoutGlobalParT_prob_QCD = ExtVar(cms.InputTag("scoutingFatPFJetReclusterGlobalParticleTransformerJetTags:probQCD"), float, doc="Mass-decorrelated Scouting GlobalParT QCD score", precision=10),
+        scoutGlobalParT_prob_Xbb = ExtVar(cms.InputTag("scoutingFatPFJetReclusterGlobalParticleTransformerJetTags:probXbb"), float, doc="Mass-decorrelated Scouting GlobalParT X->bb score", precision=10),
+        scoutGlobalParT_prob_Xcc = ExtVar(cms.InputTag("scoutingFatPFJetReclusterGlobalParticleTransformerJetTags:probXcc"), float, doc="Mass-decorrelated Scouting GlobalParT X->cc score", precision=10),
+        scoutGlobalParT_prob_Xss = ExtVar(cms.InputTag("scoutingFatPFJetReclusterGlobalParticleTransformerJetTags:probXss"), float, doc="Mass-decorrelated Scouting GlobalParT X->ss score", precision=10),
+        scoutGlobalParT_prob_Xqq = ExtVar(cms.InputTag("scoutingFatPFJetReclusterGlobalParticleTransformerJetTags:probXqq"), float, doc="Mass-decorrelated Scouting GlobalParT X->qq score", precision=10),
+        scoutGlobalParT_prob_Xbc = ExtVar(cms.InputTag("scoutingFatPFJetReclusterGlobalParticleTransformerJetTags:probXbc"), float, doc="Mass-decorrelated Scouting GlobalParT X->bc score", precision=10),
+        scoutGlobalParT_prob_Xbs = ExtVar(cms.InputTag("scoutingFatPFJetReclusterGlobalParticleTransformerJetTags:probXbs"), float, doc="Mass-decorrelated Scouting GlobalParT X->bs score", precision=10),
+        scoutGlobalParT_prob_Xcs = ExtVar(cms.InputTag("scoutingFatPFJetReclusterGlobalParticleTransformerJetTags:probXcs"), float, doc="Mass-decorrelated Scouting GlobalParT X->cs score", precision=10),
+        scoutGlobalParT_prob_Xud = ExtVar(cms.InputTag("scoutingFatPFJetReclusterGlobalParticleTransformerJetTags:probXud"), float, doc="Mass-decorrelated Scouting GlobalParT X->ud score", precision=10),
+        scoutGlobalParT_prob_Xgg = ExtVar(cms.InputTag("scoutingFatPFJetReclusterGlobalParticleTransformerJetTags:probXgg"), float, doc="Mass-decorrelated Scouting GlobalParT X->gg score", precision=10),
+        scoutGlobalParT_prob_Xtauhtaue = ExtVar(cms.InputTag("scoutingFatPFJetReclusterGlobalParticleTransformerJetTags:probXtauhtaue"), float, doc="Mass-decorrelated Scouting GlobalParT X->tauhtaue score", precision=10),
+        scoutGlobalParT_prob_Xtauhtaum = ExtVar(cms.InputTag("scoutingFatPFJetReclusterGlobalParticleTransformerJetTags:probXtauhtaum"), float, doc="Mass-decorrelated Scouting GlobalParT X->tauhtaum score", precision=10),
+        scoutGlobalParT_prob_Xtauhtauh = ExtVar(cms.InputTag("scoutingFatPFJetReclusterGlobalParticleTransformerJetTags:probXtauhtauh"), float, doc="Mass-decorrelated Scouting GlobalParT X->tauhtauh score", precision=10),
         # softdrop mass
         msoftdrop = ExtVar(cms.InputTag("scoutingFatPFJetReclusterSoftDropMass"), float, doc="Softdrop mass", precision=10),
         # regressed mass
         particleNet_mass = ExtVar(cms.InputTag("scoutingFatPFJetReclusterParticleNetMassRegressionJetTags:mass"), float, doc="ParticleNet regressed mass", precision=10),
+        scoutGlobalParT_massCorrGeneric = ExtVar(cms.InputTag("scoutingFatPFJetReclusterGlobalParticleTransformerJetTags:massCorrGeneric"), float, doc="Mass-decorrelated Scouting GlobalParT mass regression corrector with respect to the original jet mass, optimised for generic jet cases. Use (massCorrGeneric * mass) to get the regressed mass", precision=10),
+        scoutGlobalParT_massCorrGenericX2p = ExtVar(cms.InputTag("scoutingFatPFJetReclusterGlobalParticleTransformerJetTags:massCorrGenericX2p"), float, doc="Mass-decorrelated Scouting GlobalParT mass regression corrector with respect to the original jet mass, optimised for generic X2p jet cases. Use (massCorrGenericX2p * mass) to get the regressed mass", precision=10),
+        scoutGlobalParT_massCorrGenericW2p = ExtVar(cms.InputTag("scoutingFatPFJetReclusterGlobalParticleTransformerJetTags:massCorrGenericW2p"), float, doc="Mass-decorrelated Scouting GlobalParT mass regression corrector with respect to the original jet mass, optimised for generic W jet cases. Use (massCorrGenericW2p * mass) to get the regressed mass", precision=10),
+        scoutGlobalParT_massCorrResonance = ExtVar(cms.InputTag("scoutingFatPFJetReclusterGlobalParticleTransformerJetTags:massCorrResonance"), float, doc="Scouting GlobalParT mass regression corrector with respect to the original jet mass, optimised for resonance jets. Use (massCorrResonance * mass) to get the regressed mass", precision=10),
         # substructure variables    
         n2b1 = ExtVar(cms.InputTag("scoutingFatPFJetReclusterEcfNbeta1:ecfN2"), float, doc="N2 with beta=1", precision=10),
         n3b1 = ExtVar(cms.InputTag("scoutingFatPFJetReclusterEcfNbeta1:ecfN3"), float, doc="N3 with beta=1", precision=10),

--- a/RecoBTag/FeatureTools/plugins/DeepBoostedJetTagInfoProducer.cc
+++ b/RecoBTag/FeatureTools/plugins/DeepBoostedJetTagInfoProducer.cc
@@ -169,14 +169,38 @@ const std::vector<std::string> DeepBoostedJetTagInfoProducer::particle_features_
                                                                                      "jet_pfcand_puppiw",
                                                                                      "pfcand_mask"};
 
-const std::vector<std::string> DeepBoostedJetTagInfoProducer::particle_features_scouting_{
-    "pfcand_quality",       "pfcand_charge",  "pfcand_isEl",           "pfcand_isMu",
-    "pfcand_isChargedHad",  "pfcand_isGamma", "pfcand_isNeutralHad",   "pfcand_phirel",
-    "pfcand_etarel",        "pfcand_deltaR",  "pfcand_abseta",         "pfcand_ptrel_log",
-    "pfcand_erel_log",      "pfcand_pt_log",  "pfcand_normchi2",       "pfcand_dz",
-    "pfcand_dxy",           "pfcand_dxysig",  "pfcand_btagEtaRel",     "pfcand_btagPtRatio",
-    "pfcand_btagPParRatio", "pfcand_mask",    "pfcand_pt_log_nopuppi", "pfcand_dzsig",
-    "pfcand_e_log_nopuppi", "pfcand_ptrel",   "pfcand_erel",           "pfcand_lostInnerHits"};
+const std::vector<std::string> DeepBoostedJetTagInfoProducer::particle_features_scouting_{"pfcand_px",
+                                                                                          "pfcand_py",
+                                                                                          "pfcand_pz",
+                                                                                          "pfcand_energy",
+                                                                                          "pfcand_quality",
+                                                                                          "pfcand_charge",
+                                                                                          "pfcand_isEl",
+                                                                                          "pfcand_isMu",
+                                                                                          "pfcand_isChargedHad",
+                                                                                          "pfcand_isGamma",
+                                                                                          "pfcand_isNeutralHad",
+                                                                                          "pfcand_phirel",
+                                                                                          "pfcand_etarel",
+                                                                                          "pfcand_deltaR",
+                                                                                          "pfcand_abseta",
+                                                                                          "pfcand_ptrel_log",
+                                                                                          "pfcand_erel_log",
+                                                                                          "pfcand_pt_log",
+                                                                                          "pfcand_normchi2",
+                                                                                          "pfcand_dz",
+                                                                                          "pfcand_dxy",
+                                                                                          "pfcand_dxysig",
+                                                                                          "pfcand_btagEtaRel",
+                                                                                          "pfcand_btagPtRatio",
+                                                                                          "pfcand_btagPParRatio",
+                                                                                          "pfcand_mask",
+                                                                                          "pfcand_pt_log_nopuppi",
+                                                                                          "pfcand_dzsig",
+                                                                                          "pfcand_e_log_nopuppi",
+                                                                                          "pfcand_ptrel",
+                                                                                          "pfcand_erel",
+                                                                                          "pfcand_lostInnerHits"};
 
 const std::vector<std::string> DeepBoostedJetTagInfoProducer::sv_features_{"sv_mask",
                                                                            "sv_ptrel",
@@ -616,6 +640,10 @@ void DeepBoostedJetTagInfoProducer::fillParticleFeatures(DeepBoostedJetFeatures 
     auto candP3 = use_puppiP4_ ? puppi_wgt_cache.at(cand.key()) * cand->momentum() : cand->momentum();
 
     if (use_scouting_features_) {
+      fts.fill("pfcand_px", candP4.px());
+      fts.fill("pfcand_py", candP4.py());
+      fts.fill("pfcand_pz", candP4.pz());
+      fts.fill("pfcand_energy", candP4.energy());
       fts.fill("pfcand_charge", reco_cand->charge());
       fts.fill("pfcand_isEl", std::abs(reco_cand->pdgId()) == 11);
       fts.fill("pfcand_isMu", std::abs(reco_cand->pdgId()) == 13);

--- a/RecoBTag/ONNXRuntime/plugins/UnifiedParticleTransformerAK4ONNXJetTagsProducer.cc
+++ b/RecoBTag/ONNXRuntime/plugins/UnifiedParticleTransformerAK4ONNXJetTagsProducer.cc
@@ -77,7 +77,7 @@ UnifiedParticleTransformerAK4ONNXJetTagsProducer::UnifiedParticleTransformerAK4O
     : src_(consumes<TagInfoCollection>(iConfig.getParameter<edm::InputTag>("src"))),
       flav_names_(iConfig.getParameter<std::vector<std::string>>("flav_names")),
       input_names_(iConfig.getParameter<std::vector<std::string>>("input_names")),
-      use_dynamic_axes_(iConfig.getParameter<edm::FileInPath>("model_path").fullPath().find("v2.onnx") !=
+      use_dynamic_axes_(iConfig.getParameter<edm::FileInPath>("model_path").fullPath().find("V01") !=
                         std::string::npos),
       output_names_(iConfig.getParameter<std::vector<std::string>>("output_names")) {
   // get output names from flav_names
@@ -93,7 +93,7 @@ void UnifiedParticleTransformerAK4ONNXJetTagsProducer::fillDescriptions(edm::Con
   desc.add<std::vector<std::string>>(
       "input_names", {"input_1", "input_2", "input_3", "input_4", "input_5", "input_6", "input_7", "input_8"});
   desc.add<edm::FileInPath>("model_path",
-                            edm::FileInPath("RecoBTag/Combined/data/UParTAK4/PUPPI/V01/model.onnx"));
+                            edm::FileInPath("RecoBTag/Combined/data/UParTAK4/PUPPI/V01/modelfile/model.onnx"));
   desc.add<std::vector<std::string>>("output_names", {"softmax"});
   desc.add<std::vector<std::string>>(
       "flav_names",

--- a/RecoBTag/ONNXRuntime/plugins/UnifiedParticleTransformerAK4ONNXJetTagsProducer.cc
+++ b/RecoBTag/ONNXRuntime/plugins/UnifiedParticleTransformerAK4ONNXJetTagsProducer.cc
@@ -93,7 +93,7 @@ void UnifiedParticleTransformerAK4ONNXJetTagsProducer::fillDescriptions(edm::Con
   desc.add<std::vector<std::string>>(
       "input_names", {"input_1", "input_2", "input_3", "input_4", "input_5", "input_6", "input_7", "input_8"});
   desc.add<edm::FileInPath>("model_path",
-                            edm::FileInPath("RecoBTag/Combined/data/UParTAK4/PUPPI/V01/UParTAK4_v2.onnx"));
+                            edm::FileInPath("RecoBTag/Combined/data/UParTAK4/PUPPI/V01/model.onnx"));
   desc.add<std::vector<std::string>>("output_names", {"softmax"});
   desc.add<std::vector<std::string>>(
       "flav_names",


### PR DESCRIPTION
#### Please test this PR with https://github.com/cms-data/RecoBTag-Combined/pull/67

#### PR description:

This PR adds the Scouting Glo-ParT model's inference facility into CMSSW, prepared for Scouting NanoAOD official production.
Model performance details are provided in these [[slides]](https://cernbox.cern.ch/files/spaces/eos/user/y/yiyangz/public/Scouting_GloParT.pdf) (accessible via CMS). This would add 13 taggers and 4 mass regression correctors to Scouting NanoAOD.

Scouting Global Particle Transformer (Glo-ParT) is an inclusive tagging model for AK8 scouting PFjets. It functions as both a global tagger and a mass regression model for AK8 scouting PFjets and can also be utilized as a pre-trained model. Further details can be found in the slides.

#### PR validation:

The PR passed the tests listed at https://cms-sw.github.io/PRWorkflow.html

#### Backport:

Backport of PR https://github.com/cms-sw/cmssw/pull/47801