### PR TITLE
Phase2-hgx363H Correct the dd4hep version of the mixed layer algorithm to be used for V19 versison of HGCal

### DIFF
--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalMixRotatedFineCassette.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalMixRotatedFineCassette.cc
@@ -307,10 +307,9 @@ struct HGCalMixRotatedFineCassette {
     if (testCassette != 0)
       testCassetteShift();
 
-
-    ////////////////////////////////////////////////////////////////////
-    // DDHGCalMixRotatedFineCassette methods...
-    ////////////////////////////////////////////////////////////////////
+      ////////////////////////////////////////////////////////////////////
+      // DDHGCalMixRotatedFineCassette methods...
+      ////////////////////////////////////////////////////////////////////
 
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("HGCalGeom") << "==>> Constructing DDHGCalMixRotatedFineCassette...";
@@ -471,7 +470,7 @@ struct HGCalMixRotatedFineCassette {
         int ii = layerTypeTop_[ly];
         int copy = copyNumberTop_[ii];
         int layer = (fine) ? (copy - firstFineLayer_) : (copy - firstCoarseLayer_);
-	int layer0 = (copy - std::min(firstFineLayer_, firstCoarseLayer_) + 1);
+        int layer0 = (copy - std::min(firstFineLayer_, firstCoarseLayer_) + 1);
         double hthickl = 0.5 * layerThickTop_[ii];
         thickTot += layerThickTop_[ii];
         zpos += hthickl;
@@ -485,11 +484,11 @@ struct HGCalMixRotatedFineCassette {
                                      ? tileCoarseLayerStart_[layer + 1]
                                      : static_cast<int>(tileCoarseIndex_.size()));
 #ifdef EDM_ML_DEBUG
-        edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: Layer " << ly << ":" << ii << ":" << layer << ":" << layer0
-                                      << " Copy " << copy << " Tiles " << firstTile << ":" << lastTile << " Size "
-                                      << tileFineIndex_.size() << ":" << tileCoarseIndex_.size() << " Fine " << fine
-                                      << " absType " << absType;
-	int cassette;
+        edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: Layer " << ly << ":" << ii << ":" << layer
+                                      << ":" << layer0 << " Copy " << copy << " Tiles " << firstTile << ":" << lastTile
+                                      << " Size " << tileFineIndex_.size() << ":" << tileCoarseIndex_.size() << " Fine "
+                                      << fine << " absType " << absType;
+        int cassette;
 #endif
         for (int ti = firstTile; ti < lastTile; ++ti) {
           double r1, r2;
@@ -522,19 +521,19 @@ struct HGCalMixRotatedFineCassette {
 #endif
           double phi1 = dphi * (fimin - 1);
           double phi2 = dphi * (fimax - fimin + 1);
-	  r1 += retract_[layer0 - 1];
-	  r2 += retract_[layer0 - 1];
+          r1 += retract_[layer0 - 1];
+          r2 += retract_[layer0 - 1];
 #ifdef EDM_ML_DEBUG
-	  double phi = phi1 + 0.5 * phi2;
-	  edm::LogVerbatim("HGCalGeom") << "1Layer " << ly << ":" << ii << ":" << copy << ":" << layer0 << " phi " << phi
-					<< " shift " << retract_[layer0 - 1];
+          double phi = phi1 + 0.5 * phi2;
+          edm::LogVerbatim("HGCalGeom") << "1Layer " << ly << ":" << ii << ":" << copy << ":" << layer0 << " phi "
+                                        << phi << " shift " << retract_[layer0 - 1];
           int cassette0 = HGCalCassette::cassetteType(2, 1, cassette);  //
           int ir1 = (fine) ? std::get<1>(HGCalTileIndex::tileUnpack(tileFineIndex_[ti]))
                            : std::get<1>(HGCalTileIndex::tileUnpack(tileCoarseIndex_[ti]));
           int ir2 = (fine) ? std::get<2>(HGCalTileIndex::tileUnpack(tileFineIndex_[ti]))
                            : std::get<2>(HGCalTileIndex::tileUnpack(tileCoarseIndex_[ti]));
-          edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: Layer " << copy << ":" << layer0
-                                        << " iR " << ir1 << ":" << ir2 << " R " << cms::convert2mm(r1) << ":"
+          edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: Layer " << copy << ":" << layer0 << " iR "
+                                        << ir1 << ":" << ir2 << " R " << cms::convert2mm(r1) << ":"
                                         << cms::convert2mm(r2) << " Thick " << cms::convert2mm(2.0 * hthickl) << " phi "
                                         << fimin << ":" << fimax << ":" << convertRadToDeg(phi1) << ":"
                                         << convertRadToDeg(phi2) << " cassette " << cassette << ":" << cassette0
@@ -556,7 +555,8 @@ struct HGCalMixRotatedFineCassette {
           glog.placeVolume(glog1, copy, tran);
 #ifdef EDM_ML_DEBUG
           edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: Position " << glog1.name() << " number "
-                                        << copy << " in " << glog.name() << " at (0,0," << cms::convert2mm(zpos) << ") with no rotation";
+                                        << copy << " in " << glog.name() << " at (0,0," << cms::convert2mm(zpos)
+                                        << ") with no rotation";
 #endif
         }
         ++copyNumberTop_[ii];
@@ -590,7 +590,10 @@ struct HGCalMixRotatedFineCassette {
                                    ? tileCoarseLayerStart_[layer + 1]
                                    : static_cast<int>(tileCoarseIndex_.size()));
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: TOP Layer " << ii << ":" << layer << ":" << layer0 << " Copy " << copy << " Tiles " << firstTile << ":" << lastTile << " Size " << tileFineIndex_.size() << ":" << tileCoarseIndex_.size() << " Fine " << fine << " absType " << absType;
+      edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: TOP Layer " << ii << ":" << layer << ":"
+                                    << layer0 << " Copy " << copy << " Tiles " << firstTile << ":" << lastTile
+                                    << " Size " << tileFineIndex_.size() << ":" << tileCoarseIndex_.size() << " Fine "
+                                    << fine << " absType " << absType;
       int cassette;
 #endif
       for (int ti = firstTile; ti < lastTile; ++ti) {
@@ -624,22 +627,23 @@ struct HGCalMixRotatedFineCassette {
 #endif
         double phi1 = dphi * (fimin - 1);
         double phi2 = dphi * (fimax - fimin + 1);
-	r1 += retract_[layer0 - 1];
-	r2 += retract_[layer0 - 1];
+        r1 += retract_[layer0 - 1];
+        r2 += retract_[layer0 - 1];
 #ifdef EDM_ML_DEBUG
-	double phi = phi1 + 0.5 * phi2;
-	edm::LogVerbatim("HGCalGeom") << "2Layer " << ii << ":" << copy << ":" << layer << ":" << layer0 << " phi " << phi
-				      << " shift " << retract_[layer0 - 1];
+        double phi = phi1 + 0.5 * phi2;
+        edm::LogVerbatim("HGCalGeom") << "2Layer " << ii << ":" << copy << ":" << layer << ":" << layer0 << " phi "
+                                      << phi << " shift " << retract_[layer0 - 1];
         int cassette0 = HGCalCassette::cassetteType(2, 1, cassette);  //
         int ir1 = (fine) ? std::get<1>(HGCalTileIndex::tileUnpack(tileFineIndex_[ti]))
                          : std::get<1>(HGCalTileIndex::tileUnpack(tileCoarseIndex_[ti]));
         int ir2 = (fine) ? std::get<2>(HGCalTileIndex::tileUnpack(tileFineIndex_[ti]))
                          : std::get<2>(HGCalTileIndex::tileUnpack(tileCoarseIndex_[ti]));
-        edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: Layer " << copy << ":" << (layer + 1) << ":" << layer0 << " iR "
-                                      << ir1 << ":" << ir2 << " R " << cms::convert2mm(r1) << ":" << cms::convert2mm(r2)
-                                      << " Thick " << cms::convert2mm(2.0 * hthickl) << " phi " << fimin << ":" << fimax
-                                      << ":" << convertRadToDeg(phi1) << ":" << convertRadToDeg(phi2) << " cassette "
-                                      << cassette << ":" << cassette0 << " Shift " << cms::convert2mm(retract_[layer0 - 1]);
+        edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: Layer " << copy << ":" << (layer + 1) << ":"
+                                      << layer0 << " iR " << ir1 << ":" << ir2 << " R " << cms::convert2mm(r1) << ":"
+                                      << cms::convert2mm(r2) << " Thick " << cms::convert2mm(2.0 * hthickl) << " phi "
+                                      << fimin << ":" << fimax << ":" << convertRadToDeg(phi1) << ":"
+                                      << convertRadToDeg(phi2) << " cassette " << cassette << ":" << cassette0
+                                      << " Shift " << cms::convert2mm(retract_[layer0 - 1]);
 #endif
         std::string name = namesTop_[ii] + "L" + std::to_string(copy) + "F" + std::to_string(k);
         ++k;
@@ -668,7 +672,8 @@ struct HGCalMixRotatedFineCassette {
     int layer = (copyM - firstFineLayer_);
     int layer0 = (copyM - std::min(firstFineLayer_, firstCoarseLayer_) + 1);
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: Start bottom section for layer " << (layer + 1) << ":" << layer0 << " absType " << absType;
+    edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: Start bottom section for layer " << (layer + 1)
+                                  << ":" << layer0 << " absType " << absType;
 #endif
     if (absType > 0) {
 #ifdef EDM_ML_DEBUG
@@ -678,8 +683,8 @@ struct HGCalMixRotatedFineCassette {
         int cassette = k + 1;
         auto cshift = cassette_.getShift(layer0, -1, cassette);
 #ifdef EDM_ML_DEBUG
-	edm::LogVerbatim("HGCalGeom") << "3Layer " << layer << ":" << layer0 << " Cassette " << cassette << " shift "
-				      << cms::convert2mm(cshift.first) << ":" << cms::convert2mm(cshift.second);
+        edm::LogVerbatim("HGCalGeom") << "3Layer " << layer << ":" << layer0 << " Cassette " << cassette << " shift "
+                                      << cms::convert2mm(cshift.first) << ":" << cms::convert2mm(cshift.second);
 #endif
         double xpos = -cshift.first;
         double ypos = cshift.second;
@@ -821,18 +826,18 @@ struct HGCalMixRotatedFineCassette {
     for (unsigned int k = 0; k < layers_.size(); ++k) {
       int layer = k + 1;
       for (int l = 0; l < cassettes_; ++l) {
-	int cassette = l + 1;
-	auto cf1 = cassette_.getShift(layer, 1, cassette, false);
-	auto cf2 = cassette_.getShift(layer, 1, cassette, true);
-	auto cf3 = cassette_.getShift(layer, -1, cassette, false);
-	auto cf4 = cassette_.getShift(layer, -1, cassette, true);
-	edm::LogVerbatim("HGCalGeom") << "Layer " << layer << " Cassette " << cassette << " x for z+ " << cf1.first << ":"
-				      << cf2.first << " y for z+ " << cf1.second << ":" << cf2.second << " x for z- "
-				      << cf3.first << ":" << cf4.first << " y for z- " << cf3.second << ":" << cf4.second;
+        int cassette = l + 1;
+        auto cf1 = cassette_.getShift(layer, 1, cassette, false);
+        auto cf2 = cassette_.getShift(layer, 1, cassette, true);
+        auto cf3 = cassette_.getShift(layer, -1, cassette, false);
+        auto cf4 = cassette_.getShift(layer, -1, cassette, true);
+        edm::LogVerbatim("HGCalGeom") << "Layer " << layer << " Cassette " << cassette << " x for z+ " << cf1.first
+                                      << ":" << cf2.first << " y for z+ " << cf1.second << ":" << cf2.second
+                                      << " x for z- " << cf3.first << ":" << cf4.first << " y for z- " << cf3.second
+                                      << ":" << cf4.second;
       }
     }
   }
-
 
   HGCalGeomTools geomTools_;
   HGCalCassette cassette_;

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalMixRotatedFineCassette.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalMixRotatedFineCassette.cc
@@ -282,12 +282,12 @@ struct HGCalMixRotatedFineCassette {
                                     << std::get<1>(HGCalTileIndex::tileUnpack(tileCoarsePhis_[k])) << ":"
                                     << std::get<2>(HGCalTileIndex::tileUnpack(tileCoarsePhis_[k]));
 #endif
-    std::vector<double> retract = args.value<std::vector<double>>("ScintRetract");
+    retract_ = args.value<std::vector<double>>("ScintRetract");
     double dphi = M_PI / cassettes_;
     for (int k = 0; k < cassettes_; ++k) {
       double phi = (2 * k + 1) * dphi;
-      cassetteShiftScnt_.emplace_back(retract[k] * cos(phi));
-      cassetteShiftScnt_.emplace_back(retract[k] * sin(phi));
+      cassetteShiftScnt_.emplace_back(retract_[k] * cos(phi));
+      cassetteShiftScnt_.emplace_back(retract_[k] * sin(phi));
     }
 #ifdef EDM_ML_DEBUG
     unsigned int j2max = cassetteShiftScnt_.size();
@@ -301,6 +301,12 @@ struct HGCalMixRotatedFineCassette {
 #endif
     cassette_.setParameter(cassettes_, cassetteShift_, false);
     cassette_.setParameterScint(cassetteShiftScnt_);
+    cassette_.setParameterRetract(retract_);
+
+    int testCassette = args.value<int>("TestCassetteShift");
+    if (testCassette != 0)
+      testCassetteShift();
+
 
     ////////////////////////////////////////////////////////////////////
     // DDHGCalMixRotatedFineCassette methods...
@@ -465,6 +471,7 @@ struct HGCalMixRotatedFineCassette {
         int ii = layerTypeTop_[ly];
         int copy = copyNumberTop_[ii];
         int layer = (fine) ? (copy - firstFineLayer_) : (copy - firstCoarseLayer_);
+	int layer0 = (copy - std::min(firstFineLayer_, firstCoarseLayer_) + 1);
         double hthickl = 0.5 * layerThickTop_[ii];
         thickTot += layerThickTop_[ii];
         zpos += hthickl;
@@ -478,14 +485,15 @@ struct HGCalMixRotatedFineCassette {
                                      ? tileCoarseLayerStart_[layer + 1]
                                      : static_cast<int>(tileCoarseIndex_.size()));
 #ifdef EDM_ML_DEBUG
-        edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: Layer " << ly << ":" << ii << ":" << layer
+        edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: Layer " << ly << ":" << ii << ":" << layer << ":" << layer0
                                       << " Copy " << copy << " Tiles " << firstTile << ":" << lastTile << " Size "
                                       << tileFineIndex_.size() << ":" << tileCoarseIndex_.size() << " Fine " << fine
                                       << " absType " << absType;
+	int cassette;
 #endif
         for (int ti = firstTile; ti < lastTile; ++ti) {
           double r1, r2;
-          int cassette, fimin, fimax;
+          int fimin, fimax;
 #ifdef EDM_ML_DEBUG
           edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: ti " << ti << ":" << fine << " index "
                                         << tileFineIndex_.size() << ":" << tileCoarseIndex_.size() << " Phis "
@@ -494,13 +502,17 @@ struct HGCalMixRotatedFineCassette {
           if (fine) {
             r1 = tileFineRMin_[std::get<1>(HGCalTileIndex::tileUnpack(tileFineIndex_[ti])) - 1];
             r2 = tileFineRMax_[std::get<2>(HGCalTileIndex::tileUnpack(tileFineIndex_[ti])) - 1];
+#ifdef EDM_ML_DEBUG
             cassette = std::get<0>(HGCalTileIndex::tileUnpack(tileFinePhis_[ti]));
+#endif
             fimin = std::get<1>(HGCalTileIndex::tileUnpack(tileFinePhis_[ti]));
             fimax = std::get<2>(HGCalTileIndex::tileUnpack(tileFinePhis_[ti]));
           } else {
             r1 = tileCoarseRMin_[std::get<1>(HGCalTileIndex::tileUnpack(tileCoarseIndex_[ti])) - 1];
             r2 = tileCoarseRMax_[std::get<2>(HGCalTileIndex::tileUnpack(tileCoarseIndex_[ti])) - 1];
+#ifdef EDM_ML_DEBUG
             cassette = std::get<0>(HGCalTileIndex::tileUnpack(tileCoarsePhis_[ti]));
+#endif
             fimin = std::get<1>(HGCalTileIndex::tileUnpack(tileCoarsePhis_[ti]));
             fimax = std::get<2>(HGCalTileIndex::tileUnpack(tileCoarsePhis_[ti]));
           }
@@ -510,20 +522,23 @@ struct HGCalMixRotatedFineCassette {
 #endif
           double phi1 = dphi * (fimin - 1);
           double phi2 = dphi * (fimax - fimin + 1);
-          auto cshift = cassette_.getShift(layer + 1, 1, cassette, true);
+	  r1 += retract_[layer0 - 1];
+	  r2 += retract_[layer0 - 1];
 #ifdef EDM_ML_DEBUG
+	  double phi = phi1 + 0.5 * phi2;
+	  edm::LogVerbatim("HGCalGeom") << "1Layer " << ly << ":" << ii << ":" << copy << ":" << layer0 << " phi " << phi
+					<< " shift " << retract_[layer0 - 1];
           int cassette0 = HGCalCassette::cassetteType(2, 1, cassette);  //
           int ir1 = (fine) ? std::get<1>(HGCalTileIndex::tileUnpack(tileFineIndex_[ti]))
                            : std::get<1>(HGCalTileIndex::tileUnpack(tileCoarseIndex_[ti]));
           int ir2 = (fine) ? std::get<2>(HGCalTileIndex::tileUnpack(tileFineIndex_[ti]))
                            : std::get<2>(HGCalTileIndex::tileUnpack(tileCoarseIndex_[ti]));
-          edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: Layer " << copy << ":" << (layer + 1)
+          edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: Layer " << copy << ":" << layer0
                                         << " iR " << ir1 << ":" << ir2 << " R " << cms::convert2mm(r1) << ":"
                                         << cms::convert2mm(r2) << " Thick " << cms::convert2mm(2.0 * hthickl) << " phi "
                                         << fimin << ":" << fimax << ":" << convertRadToDeg(phi1) << ":"
                                         << convertRadToDeg(phi2) << " cassette " << cassette << ":" << cassette0
-                                        << " Shift " << cms::convert2mm(cshift.first) << ":"
-                                        << cms::convert2mm(cshift.second);
+                                        << " Shift " << cms::convert2mm(retract_[layer0 - 1]);
 #endif
           std::string name = namesTop_[ii] + "L" + std::to_string(copy) + "F" + std::to_string(k);
           ++k;
@@ -537,13 +552,11 @@ struct HGCalMixRotatedFineCassette {
                                         << cms::convert2mm(r2) << ", " << cms::convert2mm(hthickl) << ", "
                                         << convertRadToDeg(phi1) << ", " << convertRadToDeg(phi2);
 #endif
-          dd4hep::Position tran(-cshift.first, cshift.second, zpos);
+          dd4hep::Position tran(0, 0, zpos);
           glog.placeVolume(glog1, copy, tran);
 #ifdef EDM_ML_DEBUG
           edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: Position " << glog1.name() << " number "
-                                        << copy << " in " << glog.name() << " at (" << cms::convert2mm(cshift.first)
-                                        << ", " << cms::convert2mm(cshift.second) << ", " << cms::convert2mm(zpos)
-                                        << ") with no rotation";
+                                        << copy << " in " << glog.name() << " at (0,0," << cms::convert2mm(zpos) << ") with no rotation";
 #endif
         }
         ++copyNumberTop_[ii];
@@ -564,6 +577,7 @@ struct HGCalMixRotatedFineCassette {
       int ii = coverTypeTop_;
       int copy = copyNumberCoverTop_[absType - 1];
       int layer = (fine) ? (copy - firstFineLayer_) : (copy - firstCoarseLayer_);
+      int layer0 = (copy - std::min(firstFineLayer_, firstCoarseLayer_) + 1);
       double hthickl = 0.5 * layerThickTop_[ii];
       zpos += hthickl;
       dd4hep::Material matter1 = ns.material(materialTop_[ii]);
@@ -576,14 +590,12 @@ struct HGCalMixRotatedFineCassette {
                                    ? tileCoarseLayerStart_[layer + 1]
                                    : static_cast<int>(tileCoarseIndex_.size()));
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: TOP Layer " << ii << ":" << layer << " Copy "
-                                    << copy << " Tiles " << firstTile << ":" << lastTile << " Size "
-                                    << tileFineIndex_.size() << ":" << tileCoarseIndex_.size() << " Fine " << fine
-                                    << " absType " << absType;
+      edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: TOP Layer " << ii << ":" << layer << ":" << layer0 << " Copy " << copy << " Tiles " << firstTile << ":" << lastTile << " Size " << tileFineIndex_.size() << ":" << tileCoarseIndex_.size() << " Fine " << fine << " absType " << absType;
+      int cassette;
 #endif
       for (int ti = firstTile; ti < lastTile; ++ti) {
         double r1, r2;
-        int cassette, fimin, fimax;
+        int fimin, fimax;
 #ifdef EDM_ML_DEBUG
         edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: ti " << ti << ":" << fine << " index "
                                       << tileFineIndex_.size() << ":" << tileCoarseIndex_.size() << " Phis "
@@ -592,13 +604,17 @@ struct HGCalMixRotatedFineCassette {
         if (fine) {
           r1 = tileFineRMin_[std::get<1>(HGCalTileIndex::tileUnpack(tileFineIndex_[ti])) - 1];
           r2 = tileFineRMax_[std::get<2>(HGCalTileIndex::tileUnpack(tileFineIndex_[ti])) - 1];
+#ifdef EDM_ML_DEBUG
           cassette = std::get<0>(HGCalTileIndex::tileUnpack(tileFinePhis_[ti]));
+#endif
           fimin = std::get<1>(HGCalTileIndex::tileUnpack(tileFinePhis_[ti]));
           fimax = std::get<2>(HGCalTileIndex::tileUnpack(tileFinePhis_[ti]));
         } else {
           r1 = tileCoarseRMin_[std::get<1>(HGCalTileIndex::tileUnpack(tileCoarseIndex_[ti])) - 1];
           r2 = tileCoarseRMax_[std::get<2>(HGCalTileIndex::tileUnpack(tileCoarseIndex_[ti])) - 1];
+#ifdef EDM_ML_DEBUG
           cassette = std::get<0>(HGCalTileIndex::tileUnpack(tileCoarsePhis_[ti]));
+#endif
           fimin = std::get<1>(HGCalTileIndex::tileUnpack(tileCoarsePhis_[ti]));
           fimax = std::get<2>(HGCalTileIndex::tileUnpack(tileCoarsePhis_[ti]));
         }
@@ -608,19 +624,22 @@ struct HGCalMixRotatedFineCassette {
 #endif
         double phi1 = dphi * (fimin - 1);
         double phi2 = dphi * (fimax - fimin + 1);
-        auto cshift = cassette_.getShift(layer + 1, 1, cassette, true);
+	r1 += retract_[layer0 - 1];
+	r2 += retract_[layer0 - 1];
 #ifdef EDM_ML_DEBUG
+	double phi = phi1 + 0.5 * phi2;
+	edm::LogVerbatim("HGCalGeom") << "2Layer " << ii << ":" << copy << ":" << layer << ":" << layer0 << " phi " << phi
+				      << " shift " << retract_[layer0 - 1];
         int cassette0 = HGCalCassette::cassetteType(2, 1, cassette);  //
         int ir1 = (fine) ? std::get<1>(HGCalTileIndex::tileUnpack(tileFineIndex_[ti]))
                          : std::get<1>(HGCalTileIndex::tileUnpack(tileCoarseIndex_[ti]));
         int ir2 = (fine) ? std::get<2>(HGCalTileIndex::tileUnpack(tileFineIndex_[ti]))
                          : std::get<2>(HGCalTileIndex::tileUnpack(tileCoarseIndex_[ti]));
-        edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: Layer " << copy << ":" << (layer + 1) << " iR "
+        edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: Layer " << copy << ":" << (layer + 1) << ":" << layer0 << " iR "
                                       << ir1 << ":" << ir2 << " R " << cms::convert2mm(r1) << ":" << cms::convert2mm(r2)
                                       << " Thick " << cms::convert2mm(2.0 * hthickl) << " phi " << fimin << ":" << fimax
                                       << ":" << convertRadToDeg(phi1) << ":" << convertRadToDeg(phi2) << " cassette "
-                                      << cassette << ":" << cassette0 << " Shift " << cms::convert2mm(cshift.first)
-                                      << ":" << cms::convert2mm(cshift.second);
+                                      << cassette << ":" << cassette0 << " Shift " << cms::convert2mm(retract_[layer0 - 1]);
 #endif
         std::string name = namesTop_[ii] + "L" + std::to_string(copy) + "F" + std::to_string(k);
         ++k;
@@ -634,12 +653,11 @@ struct HGCalMixRotatedFineCassette {
                                       << cms::convert2mm(r2) << ", " << cms::convert2mm(hthickl) << ", "
                                       << convertRadToDeg(phi1) << ", " << convertRadToDeg(phi2);
 #endif
-        dd4hep::Position tran(-cshift.first, cshift.second, zpos);
+        dd4hep::Position tran(0, 0, zpos);
         glog.placeVolume(glog1, copy, tran);
 #ifdef EDM_ML_DEBUG
         edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: Position " << glog1.name() << " number "
-                                      << copy << " in " << glog.name() << " at (" << cms::convert2mm(-cshift.first)
-                                      << ", " << cms::convert2mm(cshift.second) << ", " << cms::convert2mm(zpos)
+                                      << copy << " in " << glog.name() << " at (0,0," << cms::convert2mm(zpos)
                                       << ") with no rotation";
 #endif
       }
@@ -648,9 +666,9 @@ struct HGCalMixRotatedFineCassette {
 
     // Make the bottom part next
     int layer = (copyM - firstFineLayer_);
+    int layer0 = (copyM - std::min(firstFineLayer_, firstCoarseLayer_) + 1);
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: Start bottom section for layer " << layer
-                                  << " absType " << absType;
+    edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: Start bottom section for layer " << (layer + 1) << ":" << layer0 << " absType " << absType;
 #endif
     if (absType > 0) {
 #ifdef EDM_ML_DEBUG
@@ -658,7 +676,11 @@ struct HGCalMixRotatedFineCassette {
 #endif
       for (int k = 0; k < cassettes_; ++k) {
         int cassette = k + 1;
-        auto cshift = cassette_.getShift(layer + 1, -1, cassette);
+        auto cshift = cassette_.getShift(layer0, -1, cassette);
+#ifdef EDM_ML_DEBUG
+	edm::LogVerbatim("HGCalGeom") << "3Layer " << layer << ":" << layer0 << " Cassette " << cassette << " shift "
+				      << cms::convert2mm(cshift.first) << ":" << cms::convert2mm(cshift.second);
+#endif
         double xpos = -cshift.first;
         double ypos = cshift.second;
         int i = layer * cassettes_ + k;
@@ -728,7 +750,7 @@ struct HGCalMixRotatedFineCassette {
             << k << waferProperty_[k] << ":" << layertype << ":" << type << ":" << part << ":" << orien << ":"
             << cassette << ":" << place;
 #endif
-        auto cshift = cassette_.getShift(layer + 1, -1, cassette, false);
+        auto cshift = cassette_.getShift(layer0, -1, cassette, false);
         double xpos = xyoff.first - cshift.first + nc * delx;
         double ypos = xyoff.second + cshift.second + nr * dy;
 #ifdef EDM_ML_DEBUG
@@ -795,6 +817,23 @@ struct HGCalMixRotatedFineCassette {
     }
   }
 
+  void testCassetteShift() {
+    for (unsigned int k = 0; k < layers_.size(); ++k) {
+      int layer = k + 1;
+      for (int l = 0; l < cassettes_; ++l) {
+	int cassette = l + 1;
+	auto cf1 = cassette_.getShift(layer, 1, cassette, false);
+	auto cf2 = cassette_.getShift(layer, 1, cassette, true);
+	auto cf3 = cassette_.getShift(layer, -1, cassette, false);
+	auto cf4 = cassette_.getShift(layer, -1, cassette, true);
+	edm::LogVerbatim("HGCalGeom") << "Layer " << layer << " Cassette " << cassette << " x for z+ " << cf1.first << ":"
+				      << cf2.first << " y for z+ " << cf1.second << ":" << cf2.second << " x for z- "
+				      << cf3.first << ":" << cf4.first << " y for z- " << cf3.second << ":" << cf4.second;
+      }
+    }
+  }
+
+
   HGCalGeomTools geomTools_;
   HGCalCassette cassette_;
 
@@ -857,6 +896,7 @@ struct HGCalMixRotatedFineCassette {
   std::vector<int> tileCoarseIndex_;       // Index of tile (layer/start|end coarse ring)
   std::vector<int> tileCoarsePhis_;        // Tile phi range for each index in coarse ring
   std::vector<int> tileCoarseLayerStart_;  // Start index of tiles in each coarse layer
+  std::vector<double> retract_;            // Radial retraction of he tiles
   std::vector<double> cassetteShiftScnt_;  // Shifts of the cassetes for scintillators
   std::string nameSpace_;                  // Namespace of this and ALL sub-parts
   std::unordered_set<int> copies_;         // List of copy #'s


### PR DESCRIPTION
#### PR description:

Correct the dd4hep version of the mixed layer algorithm to be used for V19 versison of HGCal

#### PR validation:

Compared the results from the DDD and DD4hep versions

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special