### PR TITLE
`L1TStage2uGTTiming`: fix `unprescaledAlgoShortList` for 2025 (removal `L1_AXO_Nominal` in favor of `L1_AXO_Medium`)

### DIFF
--- a/DQM/L1TMonitor/python/L1TStage2uGTTiming_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGTTiming_cfi.py
@@ -42,6 +42,8 @@ unprescaledAlgoList_2024.extend([
     "L1_CICADA_VTight"
 ])
 
+unprescaledAlgoList_2025 = [algo if algo != "L1_AXO_Nominal" else "L1_AXO_Medium" for algo in unprescaledAlgoList_2024]
+
 unprescaledAlgoList_PbPb = cms.untracked.vstring(unprescaledAlgoList)
 unprescaledAlgoList_PbPb.remove("L1_SingleIsoEG28er1p5")
 unprescaledAlgoList_PbPb.remove("L1_SingleTau120er2p1")
@@ -79,3 +81,8 @@ from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
 (pp_on_PbPb_run3 | run3_upc).toModify(l1tStage2uGTTiming,
                                       unprescaledAlgoShortList = unprescaledAlgoList_PbPb,
                                       prescaledAlgoShortList = prescaledAlgoList_PbPb)
+
+from Configuration.Eras.Modifier_stage2L1Trigger_2025_cff import stage2L1Trigger_2025
+stage2L1Trigger_2025.toModify(l1tStage2uGTTiming,
+    unprescaledAlgoShortList = unprescaledAlgoList_2025
+)


### PR DESCRIPTION
#### PR description:

Title says it all.
Addresses https://github.com/cms-sw/cmssw/pull/47811#issuecomment-2787009844.
This is due to the change of the L1T menu for 2025 in PR https://github.com/cms-sw/cmssw/pull/47817 from [`L1Menu_Collisions2024_v1_3_0_xml`](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/tags/L1Menu_Collisions2024_v1_3_0_xml) to [`L1Menu_Collisions2025_v1_0_0_xml`](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/tags/L1Menu_Collisions2025_v1_0_0_xml).
This removed some of the seeds used for the monitoring, see payload inspector comparison [link](https://cern.ch/c7qu3):

![image](https://github.com/user-attachments/assets/cbfbb602-b053-4c3e-b153-f44a4ab281b8)

#### PR validation:

Run worfklow 16834.0 (`Tbar_14TeV+2025`) and checked that the warning that was there before 

```
%MSG-w L1TStage2uGTTiming:   L1TStage2uGTTiming:l1tStage2uGTTiming@streamBeginRun 13-Apr-2025 13:46:04 CEST  Run: 1 Stream: 0
Algo "L1_AXO_Nominal" not found in the trigger menu L1Menu_Collisions2025_v1_0_0. Could not retrieve algo bit number.
%MSG
```

is removed using this branch.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but it will be backported to CMSSW_15_0_X for 2025 data-taking purposes if accepted.