### PR TITLE
Adding 2024 `SKIM` Wfs

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -589,7 +589,20 @@ for e_n,era in enumerate(era_mask_2024):
 
 ## special HLT scouting workflow (with hardcoded private input file from ScoutingPFMonitor skimmed to remove all events without scouting)
 workflows[145.415] = ['',['HLTDR3_ScoutingPFMonitor_2024','RECONANORUN3_ScoutingPFMonitor_reHLT_2024','HARVESTRUN3_ScoutingPFMonitor_2024']]
+
 ##################################################################
+### run3 (2024) skims - Era F ###
+workflows[146.101] = ['',['RunZeroBias2024F','HLTDR3_2024','SKIMZEROBIASRUN3_reHLT_2024','HARVESTRUN3_ZB_2024']]
+workflows[146.102] = ['',['RunBTagMu2024F','HLTDR3_2024','SKIMBTAGMURUN3_reHLT_2024','HARVESTRUN3_2024']]
+workflows[146.103] = ['',['RunJetMET02024F','HLTDR3_2024','SKIMJETMET0RUN3_reHLT_2024','HARVESTRUN3_2024']]
+workflows[146.104] = ['',['RunDisplacedJet2024F','HLTDR3_2024','SKIMDISPLACEDJETRUN3_reHLT_2024','HARVESTRUN3_2024']]
+workflows[146.105] = ['',['RunEGamma02024F','HLTDR3_2024','SKIMEGAMMA0RUN3_reHLT_2024','HARVESTRUN3_2024']]
+workflows[146.106] = ['',['RunTau2024F','HLTDR3_2024','SKIMTAURUN3_reHLT_2024','HARVESTRUN3_2024']]
+workflows[146.107] = ['',['RunMuon02024F','HLTDR3_2024','SKIMMUON0RUN3_reHLT_2024','HARVESTRUN3_2024']]
+workflows[146.108] = ['',['RunMuonEG2024F','HLTDR3_2024','SKIMMUONEGRUN3_reHLT_2024','HARVESTRUN3_2024']]
+workflows[146.109] = ['',['RunNoBPTX2024F','HLTDR3_2024','SKIMNOBPTXRUN3_reHLT_2024','HARVESTRUN3_2024']]
+workflows[146.110] = ['',['RunHcalNZS2024F','HLTDR3_2024','SKIMHCALNZSRUN3_reHLT_2024','HARVESTRUN3_2024']]
+workflows[146.111] = ['',['RunPark2MuonLowMass02024F','HLTDR3_2024','SKIMPARKINGDOUBLEMUONLOWMASS0RUN3_reHLT_2024','HARVESTRUN3_2024']]
 
 ### fastsim ###
 workflows[5.1] = ['TTbarFS', ['TTbarFS','HARVESTFS']]

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -3284,11 +3284,21 @@ for s in autoSkim.keys():
 for s in autoSkim.keys():
 
     if 'ZeroBias' in s:
-        steps['SKIM'+s.upper()+'RUN3_reHLT_2023'] = merge([{'-s':'RAW2DIGI,L1Reco,RECO,SKIM:%s,PAT,NANO,DQM:@rerecoZeroBias+@miniAODDQM+@nanoAODDQM'%(autoSkim[s])},steps['RECONANORUN3_reHLT_2023']])
+        steps['SKIM'+s.upper()+'RUN3_reHLT_2023'] = merge([{'-s':'RAW2DIGI,L1Reco,RECO,SKIM:%s,PAT,NANO,DQM:@rerecoZeroBiasFakeHLT+@miniAODDQM+@nanoAODDQM'%(autoSkim[s])},steps['RECONANORUN3_reHLT_2023']])
     elif 'Cosmics' in s:
         steps['SKIM'+s.upper()+'RUN3_reHLT_2023'] = merge([{'--scenario':'cosmics', '-s':'RAW2DIGI,L1Reco,RECO,SKIM:%s,DQM'%(autoSkim[s]), '--datatier':'RECO,DQMIO', '--eventcontent':'RECO,DQM'},steps['RECONANORUN3_reHLT_2023']])
     else:
-        steps['SKIM'+s.upper()+'RUN3_reHLT_2023'] = merge([{'-s':'RAW2DIGI,L1Reco,RECO,SKIM:%s,PAT,NANO,DQM:@standardDQM+@miniAODDQM+@nanoAODDQM'%(autoSkim[s])},steps['RECONANORUN3_reHLT_2023']])
+        steps['SKIM'+s.upper()+'RUN3_reHLT_2023'] = merge([{'-s':'RAW2DIGI,L1Reco,RECO,SKIM:%s,PAT,NANO,DQM:@standardDQMFakeHLT+@miniAODDQM+@nanoAODDQM'%(autoSkim[s])},steps['RECONANORUN3_reHLT_2023']])
+
+# Run-3 2024 skim
+for s in autoSkim.keys():
+
+    if 'ZeroBias' in s:
+        steps['SKIM'+s.upper()+'RUN3_reHLT_2024'] = merge([{'-s':'RAW2DIGI,L1Reco,RECO,SKIM:%s,PAT,NANO,DQM:@rerecoZeroBias+@miniAODDQM+@nanoAODDQM'%(autoSkim[s])},steps['RECONANORUN3_reHLT_2024']])
+    elif 'Cosmics' in s:
+        steps['SKIM'+s.upper()+'RUN3_reHLT_2024'] = merge([{'--scenario':'cosmics', '-s':'RAW2DIGI,L1Reco,RECO,SKIM:%s,DQM'%(autoSkim[s]), '--datatier':'RECO,DQMIO', '--eventcontent':'RECO,DQM'},steps['RECONANORUN3_reHLT_2024']])
+    else:
+        steps['SKIM'+s.upper()+'RUN3_reHLT_2024'] = merge([{'-s':'RAW2DIGI,L1Reco,RECO,SKIM:%s,PAT,NANO,DQM:@standardDQM+@miniAODDQM+@nanoAODDQM'%(autoSkim[s])},steps['RECONANORUN3_reHLT_2024']])
 
 # mask away - to be removed once we'll migrate the matrix to be fully unscheduled for RECO step
 #steps['RECOmAOD']=merge([step3DefaultsUnsch])


### PR DESCRIPTION
#### PR description:

This PR proposes to add 2024 data `SKIM`s wfs adding also the relevant RelVal steps. 

```python
workflows[146.101] = ['',['RunZeroBias2024F','HLTDR3_2024','SKIMZEROBIASRUN3_reHLT_2024','HARVESTRUN3_ZB_2024']]
workflows[146.102] = ['',['RunBTagMu2024F','HLTDR3_2024','SKIMBTAGMURUN3_reHLT_2024','HARVESTRUN3_2024']]
workflows[146.103] = ['',['RunJetMET02024F','HLTDR3_2024','SKIMJETMET0RUN3_reHLT_2024','HARVESTRUN3_2024']]
workflows[146.104] = ['',['RunDisplacedJet2024F','HLTDR3_2024','SKIMDISPLACEDJETRUN3_reHLT_2024','HARVESTRUN3_2024']]
workflows[146.105] = ['',['RunEGamma02024F','HLTDR3_2024','SKIMEGAMMA0RUN3_reHLT_2024','HARVESTRUN3_2024']]
workflows[146.106] = ['',['RunTau2024F','HLTDR3_2024','SKIMTAURUN3_reHLT_2024','HARVESTRUN3_2024']]
workflows[146.107] = ['',['RunMuon02024F','HLTDR3_2024','SKIMMUON0RUN3_reHLT_2024','HARVESTRUN3_2024']]
workflows[146.108] = ['',['RunMuonEG2024F','HLTDR3_2024','SKIMMUONEGRUN3_reHLT_2024','HARVESTRUN3_2024']]
workflows[146.109] = ['',['RunNoBPTX2024F','HLTDR3_2024','SKIMNOBPTXRUN3_reHLT_2024','HARVESTRUN3_2024']]
workflows[146.110] = ['',['RunHcalNZS2024F','HLTDR3_2024','SKIMHCALNZSRUN3_reHLT_2024','HARVESTRUN3_2024']]
workflows[146.111] = ['',['RunPark2MuonLowMass02024F','HLTDR3_2024','SKIMPARKINGDOUBLEMUONLOWMASS0RUN3_reHLT_2024','HARVESTRUN3_2024']]
```

The 2023 SKIM wfs are also fixed to use the right `*FakeHLT` sequences.

#### PR validation:

Running (e.g.) `146.110` wfs.