### PR TITLE
Fix orphan sim clusters

### DIFF
--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/SimTauCPLinkProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/SimTauCPLinkProducer.cc
@@ -69,8 +69,9 @@ void SimTauProducer::buildSimTau(SimTauCPLink& t,
   bool is_leaf = (daughters.empty());
 
   if (is_leaf) {
-    LogDebug("SimTauProducer").format(" TO BE SAVED {} ", resonance_idx);
     auto const& gen_particle_barcode = gen_particle_barcodes[gen_particle_key];
+    LogDebug("SimTauProducer")
+        .format(" TO BE SAVED {}, key {}, barcode {}", resonance_idx, gen_particle_key, gen_particle_barcode);
     auto const& found_in_caloparticles = std::find_if(caloPartVec.begin(), caloPartVec.end(), [&](const auto& p) {
       return p.g4Tracks()[0].genpartIndex() == gen_particle_barcode;
     });
@@ -87,13 +88,13 @@ void SimTauProducer::buildSimTau(SimTauCPLink& t,
   } else if (generation != 0) {
     t.resonances.push_back({gen_particle.pdgId(), resonance_idx});
     resonance_idx = t.resonances.size() - 1;
-    LogDebug("SimTauProducer").format(" RESONANCE/INTERMEDIATE {} ", resonance_idx);
+    LogDebug("SimTauProducer").format(" RESONANCE/INTERMEDIATE {}", resonance_idx);
   }
 
   ++generation;
   for (auto daughter = daughters.begin(); daughter != daughters.end(); ++daughter) {
     int gen_particle_key = (*daughter).key();
-    LogDebug("SimTauProducer").format(" gen {} {} {} ", generation, gen_particle_key, (*daughter)->pdgId());
+    LogDebug("SimTauProducer").format(" gen {} {} {}", generation, gen_particle_key, (*daughter)->pdgId());
     buildSimTau(t, generation, resonance_idx, *(*daughter), gen_particle_key, calo_particle_h, gen_particle_barcodes);
   }
 }

--- a/SimDataFormats/CaloAnalysis/interface/SimTauCPLink.h
+++ b/SimDataFormats/CaloAnalysis/interface/SimTauCPLink.h
@@ -31,31 +31,38 @@ public:
 
   enum decayModes {
     kNull = -1,
-    kOneProng0PiZero,
-    kOneProng1PiZero,
-    kOneProng2PiZero,
-    kOneProng3PiZero,
-    kOneProngNPiZero,
-    kTwoProng0PiZero,
-    kTwoProng1PiZero,
-    kTwoProng2PiZero,
-    kTwoProng3PiZero,
-    kTwoProngNPiZero,
-    kThreeProng0PiZero,
-    kThreeProng1PiZero,
-    kThreeProng2PiZero,
-    kThreeProng3PiZero,
-    kThreeProngNPiZero,
-    kRareDecayMode,
-    kElectron,
-    kMuon
+    kOneProng0PiZero,    // 0
+    kOneProng1PiZero,    // 1
+    kOneProng2PiZero,    // 2
+    kOneProng3PiZero,    // 3
+    kOneProngNPiZero,    // 4
+    kTwoProng0PiZero,    // 5
+    kTwoProng1PiZero,    // 6
+    kTwoProng2PiZero,    // 7
+    kTwoProng3PiZero,    // 8
+    kTwoProngNPiZero,    // 9
+    kThreeProng0PiZero,  // 10
+    kThreeProng1PiZero,  // 11
+    kThreeProng2PiZero,  // 12
+    kThreeProng3PiZero,  // 13
+    kThreeProngNPiZero,  // 14
+    kRareDecayMode,      // 15
+    kElectron,           // 16
+    kMuon                // 17
   };
 
   void dump(void) const {
+    LogDebug("SimTauProducer")
+        .format("Decay mode: {} ", buildDecayModes())
+        .format("Leaves: {} ", leaves.size())
+        .format("Resonances: {}", resonances.size());
     for (auto const &l : leaves) {
       LogDebug("SimTauProducer")
-          .format(
-              "L {} {} CP: {} GenP idx: {}", l.pdgId(), l.resonance_idx(), l.calo_particle_idx(), l.gen_particle_idx());
+          .format("L {} {} CP: {} GenP idx: {}",
+                  l.pdgId(),
+                  l.resonance_idx(),
+                  (int)((l.calo_particle_idx() == -1) ? -1 : calo_particle_leaves[l.calo_particle_idx()].key()),
+                  l.gen_particle_idx());
     }
     for (auto const &r : resonances) {
       LogDebug("SimTauProducer").format("R {} {}", r.first, r.second);
@@ -78,7 +85,7 @@ public:
     }
   }
 
-  int buildDecayModes() {
+  int buildDecayModes() const {
     int numElectrons = 0;
     int numMuons = 0;
     int numHadrons = 0;

--- a/SimGeneral/Debugging/python/caloParticleDebugger_cfg.py
+++ b/SimGeneral/Debugging/python/caloParticleDebugger_cfg.py
@@ -2,43 +2,51 @@ import FWCore.ParameterSet.Config as cms
 
 # The line below always has to be included to make VarParsing work
 from FWCore.ParameterSet.VarParsing import VarParsing
-options = VarParsing ('analysis')
+
+options = VarParsing("analysis")
 options.parseArguments()
 
 process = cms.Process("Demo")
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
-process.load('Configuration.Geometry.GeometryExtended2026D96_cff')
-process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+process.load("Configuration.Geometry.GeometryExtendedRun4D110Reco_cff")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T21', '')
 
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+process.GlobalTag = GlobalTag(process.GlobalTag, "auto:phase2_realistic_T21", "")
+
+process.maxEvents = cms.untracked.PSet(input=cms.untracked.int32(-1))
 
 
-input_filename = 'default.root' if len(options.inputFiles) == 0 else options.inputFiles[0]
-#input_filename='step2SingleElectronPt15Eta1p7_2p7_SimTracksters.root'
-#input_filename='step2FineCaloSingleElectronPt15Eta1p7_2p7_SimTracksters.root'
-#input_filename='step2SingleElectronPt15Eta1p7_2p7_CBWEAndSimTracksters.root'
-#input_filename='step2FineCaloSingleElectronPt15Eta1p7_2p7_CBWEAndSimTracksters.root'
+input_filename = (
+    "default.root" if len(options.inputFiles) == 0 else options.inputFiles[0]
+)
+# input_filename='step2SingleElectronPt15Eta1p7_2p7_SimTracksters.root'
+# input_filename='step2FineCaloSingleElectronPt15Eta1p7_2p7_SimTracksters.root'
+# input_filename='step2SingleElectronPt15Eta1p7_2p7_CBWEAndSimTracksters.root'
+# input_filename='step2FineCaloSingleElectronPt15Eta1p7_2p7_CBWEAndSimTracksters.root'
 
-process.source = cms.Source("PoolSource",
-    inputCommands = cms.untracked.vstring(['keep *',
-                                           'drop l1tEMTFHit2016Extras_simEmtfDigis_CSC_HLT',
-                                           'drop l1tEMTFHit2016Extras_simEmtfDigis_RPC_HLT',
-                                           'drop l1tEMTFHit2016s_simEmtfDigis__HLT',
-                                           'drop l1tEMTFTrack2016Extras_simEmtfDigis__HLT',
-                                           'drop l1tEMTFTrack2016s_simEmtfDigis__HLT']),
+process.source = cms.Source(
+    "PoolSource",
+    inputCommands=cms.untracked.vstring(
+        [
+            "keep *",
+            "drop l1tEMTFHit2016Extras_simEmtfDigis_CSC_HLT",
+            "drop l1tEMTFHit2016Extras_simEmtfDigis_RPC_HLT",
+            "drop l1tEMTFHit2016s_simEmtfDigis__HLT",
+            "drop l1tEMTFTrack2016Extras_simEmtfDigis__HLT",
+            "drop l1tEMTFTrack2016s_simEmtfDigis__HLT",
+        ]
+    ),
     # replace 'myfile.root' with the source file you want to use
-    fileNames = cms.untracked.vstring(
-#      'file:/data/rovere/HGCAL/study/CMSSW_9_4_0/src/SimGeneral/Debugging/test/20800.0_FourMuPt1_200+FourMuPt_1_200_pythia8_2023D20_GenSimHLBeamSpotFull+DigiFull_2023D20+RecoFullGlobal_2023D20+HARVESTFullGlobal_2023D20/step2.root'
-#        'file:/data/rovere/HGCAL/study/CMSSW_9_4_0/src/SimGeneral/Debugging/test/20824.0_TTbar_13+TTbar_13TeV_TuneCUETP8M1_2023D20_GenSimHLBeamSpotFull+DigiFull_2023D20+RecoFullGlobal_2023D20+HARVESTFullGlobal_2023D20/step2.root'
-#        'file:/data/rovere/HGCAL/study/CMSSW_9_4_0/src/SimGeneral/Debugging/test/20002.0_SingleElectronPt35+SingleElectronPt35_pythia8_2023D17_GenSimHLBeamSpotFull+DigiFullTrigger_2023D17+RecoFullGlobal_2023D17+HARVESTFullGlobal_2023D17/step2.root'
-#        'file:/data/rovere/HGCAL/study/CMSSW_9_4_0/src/SimGeneral/Debugging/test/20016.0_SingleGammaPt35Extended+DoubleGammaPt35Extended_pythia8_2023D17_GenSimHLBeamSpotFull+DigiFullTrigger_2023D17+RecoFullGlobal_2023D17+HARVESTFullGlobal_2023D17/step2.root'
-#        'file:/data/rovere/HGCAL/study/CMSSW_9_4_0/src/SimGeneral/Debugging/test/20088.0_SinglePiPt25Eta1p7_2p7+SinglePiPt25Eta1p7_2p7_2023D17_GenSimHLBeamSpotFull+DigiFullTrigger_2023D17+RecoFullGlobal_2023D17+HARVESTFullGlobal_2023D17/step2.root'
-         'file:%s'%input_filename
-
-    )
+    fileNames=cms.untracked.vstring(
+        #      'file:/data/rovere/HGCAL/study/CMSSW_9_4_0/src/SimGeneral/Debugging/test/20800.0_FourMuPt1_200+FourMuPt_1_200_pythia8_2023D20_GenSimHLBeamSpotFull+DigiFull_2023D20+RecoFullGlobal_2023D20+HARVESTFullGlobal_2023D20/step2.root'
+        #        'file:/data/rovere/HGCAL/study/CMSSW_9_4_0/src/SimGeneral/Debugging/test/20824.0_TTbar_13+TTbar_13TeV_TuneCUETP8M1_2023D20_GenSimHLBeamSpotFull+DigiFull_2023D20+RecoFullGlobal_2023D20+HARVESTFullGlobal_2023D20/step2.root'
+        #        'file:/data/rovere/HGCAL/study/CMSSW_9_4_0/src/SimGeneral/Debugging/test/20002.0_SingleElectronPt35+SingleElectronPt35_pythia8_2023D17_GenSimHLBeamSpotFull+DigiFullTrigger_2023D17+RecoFullGlobal_2023D17+HARVESTFullGlobal_2023D17/step2.root'
+        #        'file:/data/rovere/HGCAL/study/CMSSW_9_4_0/src/SimGeneral/Debugging/test/20016.0_SingleGammaPt35Extended+DoubleGammaPt35Extended_pythia8_2023D17_GenSimHLBeamSpotFull+DigiFullTrigger_2023D17+RecoFullGlobal_2023D17+HARVESTFullGlobal_2023D17/step2.root'
+        #        'file:/data/rovere/HGCAL/study/CMSSW_9_4_0/src/SimGeneral/Debugging/test/20088.0_SinglePiPt25Eta1p7_2p7+SinglePiPt25Eta1p7_2p7_2023D17_GenSimHLBeamSpotFull+DigiFullTrigger_2023D17+RecoFullGlobal_2023D17+HARVESTFullGlobal_2023D17/step2.root'
+        "file:%s" % input_filename
+    ),
 )
 
 process.load("SimGeneral.Debugging.caloParticleDebugger_cfi")
@@ -46,16 +54,23 @@ process.load("SimGeneral.Debugging.caloParticleDebugger_cfi")
 # MessageLogger customizations
 process.MessageLogger.cerr.enable = False
 process.MessageLogger.cout.enable = False
-labels = ['SimTracks', 'SimVertices', 'GenParticles', 'TrackingParticles', 'CaloParticles', 'SimClusters']
+labels = [
+    "SimTracks",
+    "SimVertices",
+    "GenParticles",
+    "TrackingParticles",
+    "CaloParticles",
+    "SimClusters",
+]
 messageLogger = dict()
 for category in labels:
-    main_key = '%sMessageLogger'%(category)
-    category_key = 'CaloParticleDebugger%s'%(category)
+    main_key = "%sMessageLogger" % (category)
+    category_key = "CaloParticleDebugger%s" % (category)
     messageLogger[main_key] = dict(
-            filename = '%s_%s.log' % (input_filename.replace('.root',''), category),
-            threshold = 'INFO',
-            default = dict(limit=0)
-            )
+        filename="%s_%s.log" % (input_filename.replace(".root", ""), category),
+        threshold="INFO",
+        default=dict(limit=0),
+    )
     messageLogger[main_key][category_key] = dict(limit=-1)
     # First create defaults
     setattr(process.MessageLogger.files, category, dict())

--- a/SimGeneral/MixingModule/interface/DecayGraph.h
+++ b/SimGeneral/MixingModule/interface/DecayGraph.h
@@ -103,7 +103,10 @@ namespace {
   std::string graphviz_vertex(const VertexProperty &v) {
     std::ostringstream oss;
     oss << "{id: " << (v.simTrack ? v.simTrack->trackId() : 0) << ",\\ntype: " << (v.simTrack ? v.simTrack->type() : 0)
-        << ",\\nchits: " << v.cumulative_simHits << "}";
+        << ",\\nPVtxIdx?: " << (v.simTrack ? v.simTrack->vertIndex() : -1)
+        << ",\\nPrim?: " << (v.simTrack ? v.simTrack->isPrimary() : -1)
+        << ",\\nXB?: " << (v.simTrack ? v.simTrack->crossedBoundary() : -1) << ",\\nchits: " << v.cumulative_simHits
+        << "}";
     return oss.str();
   }
 


### PR DESCRIPTION
#### PR description:

Previously, `SimClusters` were saved regardless of whether the associated
`CaloParticle` passed the selector criteria. This happened because the `DFS`
traversal and `SimCluster` population occurred without checking the
selector status of the current `CaloParticle`. As a result, `SimClusters`
belonging to rejected `CaloParticles` were still saved. This fix ensures
that `SimClusters` are only saved if their corresponding `CaloParticle` has
passed the selection.


#### PR validation:

Checked on some `runTheMatrix` workflows and there are no more orphan `SimClusters`.

