### PR TITLE
[CMSSW_14_1_X] Fix the AlCaRecoTriggerBits/SecondaryDataset tag for the first IOVs in Run2 data GT

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,7 +24,7 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'                   :    '131X_mcRun2_pA_v3',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'                    :    '141X_dataRun2_v2',
+    'run2_data'                    :    '141X_dataRun2_v3',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_HEfail'             :    '140X_dataRun2_HEfail_v1',
     # GlobalTag for Run2 HI data


### PR DESCRIPTION
#### PR description:

Fix the AlCaRecoTriggerBits/SecondaryDataset tag for the first IOVs in Run2 data GT

Modified GTs in autoCond:

- 'run2_data'   :    [141X_dataRun2_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/141X_dataRun2_v3)
  - Difference wrt previous _v2 is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/141X_dataRun2_v2/141X_dataRun2_v3) 

#### PR validation:

It is expected to fixes the runtime errors of #47814, but it can also get merged alone

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Partial backport of #47839