### PR TITLE
Avoid adding .root to a file ending in .rntpl in ConfigBuilder

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -622,7 +622,7 @@ class ConfigBuilder(object):
                 defaultFileName=defaultFileName.replace('.rntpl','_in'+theTier+'.rntpl')
 
             theFileName=self._options.dirout+anyOf(['fn','fileName'],outDefDict,defaultFileName)
-            if not theFileName.endswith('.root'):
+            if not theFileName.endswith('.root') and not theFileName.endswith('.rntpl'):
                 theFileName+='.root'
 
             if len(outDefDict):


### PR DESCRIPTION
#### PR description:

This was uncovered in the RNTUPLE IBs.

#### PR validation:

Using this change in the RNTUPLE release allows workflow 138.3 to get the correct file name for step2.

resolves https://github.com/cms-sw/framework-team/issues/1352