### PR TITLE
Add dictionary for GEMSubDetId needed by RNTuple

### DIFF
--- a/DataFormats/MuonDetId/src/classes.h
+++ b/DataFormats/MuonDetId/src/classes.h
@@ -11,3 +11,4 @@
 #include "DataFormats/MuonDetId/interface/DTSectCollId.h"
 #include "DataFormats/MuonDetId/interface/GEMDetId.h"
 #include "DataFormats/MuonDetId/interface/ME0DetId.h"
+#include "DataFormats/MuonDetId/interface/GEMSubDetId.h"

--- a/DataFormats/MuonDetId/src/classes_def.xml
+++ b/DataFormats/MuonDetId/src/classes_def.xml
@@ -49,6 +49,9 @@
     ]]>
    </ioread>
   </class>
+  <class name="GEMSubDetId" ClassVersion="3">
+    <version ClassVersion="3" checksum="6356029"/>
+  </class>
   <class name="ME0DetId" ClassVersion="11">
    <version ClassVersion="11" checksum="1292662416"/>
    <version ClassVersion="10" checksum="388194174"/>


### PR DESCRIPTION
#### PR description:

This fixes problems seen in workflow 7.5 and 29634.402 when using multiple threads.

#### PR validation:

Running workflow 7.5 multithreaded in RNTUPLE release now succeeds.

resolves https://github.com/cms-sw/framework-team/issues/1353