### PR TITLE
[NGT] Introduce HGCal validation at HLT

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -695,11 +695,12 @@ phase2_tracker.toModify(FEVTDEBUGHLTEventContent,
                             'keep *_hltInitialStepTracksT5TCLST_*_*',
                             'keep *_hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST_*_*',
                             'keep *_hltOfflinePrimaryVertices_*_*',
-                            'keep *_hltHGCalRecHit_*_*'
                         ])
 
 phase2_common.toModify(FEVTDEBUGHLTEventContent,
                        outputCommands = FEVTDEBUGHLTEventContent.outputCommands+[
+                           'keep *_hltHGCalRecHit_*_*',
+                           'keep *_hltHgcalMergeLayerClusters_*_*',
                            'keep *_hltEgammaGsfTracksL1Seeded_*_*',
                        ])
 

--- a/HLTriggerOffline/Common/python/HLTValidationHarvest_cff.py
+++ b/HLTriggerOffline/Common/python/HLTValidationHarvest_cff.py
@@ -15,6 +15,7 @@ from Validation.RecoVertex.HLTpostProcessorVertex_cfi import *
 from HLTriggerOffline.Common.HLTValidationQT_cff import *
 from HLTriggerOffline.Btag.HltBtagPostValidation_cff import *
 from HLTriggerOffline.Egamma.HLTpostProcessorGsfTracker_cfi import *
+from Validation.HGCalValidation.HLTHGCalPostProcessor_cff import *
 
 hltpostvalidation = cms.Sequence( 
     postProcessorHLTtrackingSequence
@@ -39,22 +40,25 @@ from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 
 # Temporary Phase-2 configuration
 # Exclude everything except JetMET for now
+_phase2_hltpostvalidation =  hltpostvalidation.copyAndExclude([HLTTauPostVal,
+                                                               EgammaPostVal,
+                                                               postProcessorHLTgsfTrackingSequence,
+                                                               heavyFlavorValidationHarvestingSequence,
+                                                               #JetMETPostVal,
+                                                               #HLTAlCaPostVal,
+                                                               SusyExoPostVal,
+                                                               #ExamplePostVal,
+                                                               hltvalidationqt,
+                                                               HLTHiggsPostVal,
+                                                               hltExoticaPostProcessors,
+                                                               b2gHLTriggerValidationHarvest,
+                                                               HLTSMPPostVal,
+                                                               HltBTagPostVal])
+# Add HGCal validation
+_phase2_hltpostvalidation += hltHcalValidatorPostProcessor
+
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
-phase2_common.toReplaceWith(hltpostvalidation, hltpostvalidation.copyAndExclude([HLTTauPostVal,
-                                                                                 EgammaPostVal,
-                                                                                 postProcessorHLTgsfTrackingSequence,
-                                                                                 heavyFlavorValidationHarvestingSequence,
-                                                                                 #JetMETPostVal,
-                                                                                 #HLTAlCaPostVal,
-                                                                                 SusyExoPostVal,
-                                                                                 #ExamplePostVal,
-                                                                                 hltvalidationqt,
-                                                                                 HLTHiggsPostVal,
-                                                                                 hltExoticaPostProcessors,
-                                                                                 b2gHLTriggerValidationHarvest,
-                                                                                 HLTSMPPostVal,
-                                                                                 HltBTagPostVal])
-)
+phase2_common.toReplaceWith(hltpostvalidation, _phase2_hltpostvalidation)
 
 # fastsim customs
 from Configuration.Eras.Modifier_fastSim_cff import fastSim

--- a/HLTriggerOffline/Common/python/HLTValidation_cff.py
+++ b/HLTriggerOffline/Common/python/HLTValidation_cff.py
@@ -31,6 +31,10 @@ hgcalHitCalibrationHLT = _hgcalHitCalibrationDefault.clone(
     photons = "None"
 )
 
+# HGCAL validation
+from Validation.HGCalValidation.HLTHGCalValidator_cff import *
+from RecoHGCal.TICL.HLTSimTracksters_cff import *
+
 # offline dqm:
 # from DQMOffline.Trigger.DQMOffline_Trigger_cff.py import *
 from DQMOffline.Trigger.HLTTauDQMOffline_cff import *
@@ -63,6 +67,9 @@ _phase2_hltassociation = hltassociation.copyAndExclude([
 
 # Add hltTrackerphase2ValidationSource to the sequence
 _phase2_hltassociation += hltTrackerphase2ValidationSource
+
+# Add HGCal SimTracksters
+_phase2_hltassociation += hltTiclSimTrackstersSeq
 
 # Apply the modification
 phase2_common.toReplaceWith(hltassociation, _phase2_hltassociation)
@@ -107,6 +114,7 @@ _hltvalidationWithMC_Phase2 = hltvalidationWithMC.copyAndExclude([#HLTMuonVal,
   hltHCALRecoAnalyzer,
   hltHCALNoiseRates])
 _hltvalidationWithMC_Phase2.insert(-1, hgcalHitCalibrationHLT)
+_hltvalidationWithMC_Phase2.insert(-1, hltHgcalValidator)
 phase2_common.toReplaceWith(hltvalidationWithMC, _hltvalidationWithMC_Phase2)
 
 hltvalidationWithData = cms.Sequence(

--- a/RecoHGCal/TICL/plugins/FilteredLayerClustersProducer.cc
+++ b/RecoHGCal/TICL/plugins/FilteredLayerClustersProducer.cc
@@ -77,6 +77,17 @@ void FilteredLayerClustersProducer::produce(edm::Event& evt, const edm::EventSet
   edm::Handle<std::vector<float>> inputClustersMaskHandle;
   evt.getByToken(clusters_token_, clusterHandle);
   evt.getByToken(clustersMask_token_, inputClustersMaskHandle);
+
+  // Protection against missing input collections
+  if (!clusterHandle.isValid() || !inputClustersMaskHandle.isValid()) {
+    edm::LogWarning("FilteredLayerClustersProducer") << "Missing input collections. Producing an empty mask.";
+
+    // Produce an empty mask and exit
+    auto emptyMask = std::make_unique<std::vector<float>>();
+    evt.put(std::move(emptyMask), iteration_label_);
+    return;
+  }
+
   const auto& inputClusterMask = *inputClustersMaskHandle;
 
   // Transfer input mask in output

--- a/RecoHGCal/TICL/python/HLTSimTracksters_cff.py
+++ b/RecoHGCal/TICL/python/HLTSimTracksters_cff.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoHGCal.TICL.simTrackstersProducer_cfi import simTrackstersProducer as _simTrackstersProducer
+from RecoHGCal.TICL.filteredLayerClustersProducer_cfi import filteredLayerClustersProducer as _filteredLayerClustersProducer
+from Validation.RecoTrack.associators_cff import hltTrackAssociatorByHits, tpToHLTpixelTrackAssociation
+from SimGeneral.TrackingAnalysis.simHitTPAssociation_cfi import simHitTPAssocProducer
+
+# CA - PATTERN RECOGNITION
+
+hltFilteredLayerClustersSimTracksters = _filteredLayerClustersProducer.clone(
+    LayerClusters = cms.InputTag("hltHgcalMergeLayerClusters"),
+    LayerClustersInputMask = cms.InputTag("hltHgcalMergeLayerClusters","InitialLayerClustersMask"),
+    clusterFilter = "ClusterFilterByAlgoAndSize",
+    min_cluster_size = 0, # inclusive
+    iteration_label = "hltTiclSimTracksters"
+)
+
+tpToHltGeneralTrackAssociation = tpToHLTpixelTrackAssociation.clone(
+    label_tr = "hltGeneralTracks"
+)
+
+hltTiclSimTracksters = _simTrackstersProducer.clone(
+    layerClusterCaloParticleAssociator = cms.InputTag("hltLayerClusterCaloParticleAssociationProducer"),
+    layerClusterSimClusterAssociator = cms.InputTag("hltLayerClusterSimClusterAssociationProducer"),
+    filtered_mask = cms.InputTag("hltFilteredLayerClustersSimTracksters","hltTiclSimTracksters"),
+    layer_clusters = cms.InputTag("hltHgcalMergeLayerClusters"),
+    time_layerclusters = cms.InputTag("hltHgcalMergeLayerClusters","timeLayerCluster"),
+    simTrackToTPMap = cms.InputTag("simHitTPAssocProducer","simTrackToTP"),
+    recoTracks = cms.InputTag("hltGeneralTracks"),
+    simclusters = cms.InputTag("mix","MergedCaloTruth"),
+    tpToTrack = cms.InputTag("tpToHltGeneralTrackAssociation"),
+    computeLocalTime = cms.bool(False)
+)
+
+from Validation.Configuration.hltHGCalSimValid_cff import *
+
+hltTiclSimTrackstersTask = cms.Task(hltTrackAssociatorByHits,
+                                    tpToHltGeneralTrackAssociation,
+                                    simHitTPAssocProducer,
+                                    hltHgcalAssociatorsTask,
+                                    hltFilteredLayerClustersSimTracksters,
+                                    hltTiclSimTracksters)
+
+hltTiclSimTrackstersSeq = cms.Sequence(
+    hltTiclSimTrackstersTask
+)

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/AllHitToTracksterAssociatorsProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/AllHitToTracksterAssociatorsProducer.cc
@@ -60,12 +60,37 @@ void AllHitToTracksterAssociatorsProducer::produce(edm::StreamID, edm::Event& iE
   for (const auto& token : hitsTokens_) {
     Handle<HGCRecHitCollection> hitsHandle;
     iEvent.getByToken(token, hitsHandle);
+
+    // Protection against missing HGCRecHitCollection
+    if (!hitsHandle.isValid()) {
+      edm::LogWarning("AllHitToTracksterAssociatorsProducer")
+          << "Missing HGCRecHitCollection for one of the hitsTokens.";
+      continue;
+    }
     rechitManager.addVector(*hitsHandle);
+  }
+
+  // Check if rechitManager is empty
+  if (rechitManager.size() == 0) {
+    edm::LogWarning("HitToSimClusterCaloParticleAssociatorProducer")
+        << "No valid HGCRecHitCollections found. Association maps will be empty.";
+    for (const auto& tracksterToken : tracksterCollectionTokens_) {
+      iEvent.put(std::make_unique<ticl::AssociationMap<ticl::mapWithFraction>>(), "hitTo" + tracksterToken.first);
+      iEvent.put(std::make_unique<ticl::AssociationMap<ticl::mapWithFraction>>(), tracksterToken.first + "ToHit");
+    }
+    return;
   }
 
   for (const auto& tracksterToken : tracksterCollectionTokens_) {
     Handle<std::vector<ticl::Trackster>> tracksters;
     iEvent.getByToken(tracksterToken.second, tracksters);
+
+    if (!tracksters.isValid()) {
+      edm::LogWarning("AllHitToTracksterAssociatorsProducer") << "Missing Tracksters for one of the hitsTokens.";
+      iEvent.put(std::make_unique<ticl::AssociationMap<ticl::mapWithFraction>>(), "hitTo" + tracksterToken.first);
+      iEvent.put(std::make_unique<ticl::AssociationMap<ticl::mapWithFraction>>(), tracksterToken.first + "ToHit");
+      return;
+    }
 
     auto hitToTracksterMap = std::make_unique<ticl::AssociationMap<ticl::mapWithFraction>>(rechitManager.size());
     auto tracksterToHitMap = std::make_unique<ticl::AssociationMap<ticl::mapWithFraction>>(tracksters->size());

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/HitToSimClusterCaloParticleAssociatorProducer.h
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/HitToSimClusterCaloParticleAssociatorProducer.h
@@ -23,17 +23,18 @@
 class HitToSimClusterCaloParticleAssociatorProducer : public edm::global::EDProducer<> {
 public:
   explicit HitToSimClusterCaloParticleAssociatorProducer(const edm::ParameterSet &);
-  ~HitToSimClusterCaloParticleAssociatorProducer() override;
+  ~HitToSimClusterCaloParticleAssociatorProducer() override = default;
 
   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 private:
   void produce(edm::StreamID, edm::Event &, const edm::EventSetup &) const override;
 
-  edm::EDGetTokenT<std::vector<SimCluster>> simClusterToken_;
-  edm::EDGetTokenT<std::vector<CaloParticle>> caloParticleToken_;
+  const edm::EDGetTokenT<std::vector<SimCluster>> simClusterToken_;
+  const edm::EDGetTokenT<std::vector<CaloParticle>> caloParticleToken_;
 
-  edm::EDGetTokenT<std::unordered_map<DetId, const unsigned int>> hitMapToken_;
+  const edm::EDGetTokenT<std::unordered_map<DetId, const unsigned int>> hitMapToken_;
+  const std::vector<edm::InputTag> hitsTags_;
   std::vector<edm::EDGetTokenT<HGCRecHitCollection>> hitsTokens_;
 };
 

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToCPAssociatorByEnergyScoreProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToCPAssociatorByEnergyScoreProducer.cc
@@ -36,6 +36,14 @@ void LCToCPAssociatorByEnergyScoreProducer<HIT>::produce(edm::StreamID,
     for (auto &token : hgcal_hits_token_) {
       edm::Handle<HGCRecHitCollection> hits_handle;
       iEvent.getByToken(token, hits_handle);
+
+      // Check handle validity
+      if (!hits_handle.isValid()) {
+        edm::LogWarning("LCToCPAssociatorByEnergyScoreProducer")
+            << "Hit collection not available for token. Skipping this collection.";
+        continue;  // Skip invalid handle
+      }
+
       for (const auto &hit : *hits_handle) {
         hits.push_back(&hit);
       }
@@ -44,6 +52,14 @@ void LCToCPAssociatorByEnergyScoreProducer<HIT>::produce(edm::StreamID,
     for (auto &token : hits_token_) {
       edm::Handle<std::vector<HIT>> hits_handle;
       iEvent.getByToken(token, hits_handle);
+
+      // Check handle validity
+      if (!hits_handle.isValid()) {
+        edm::LogWarning("LCToCPAssociatorByEnergyScoreProducer")
+            << "Hit collection not available for token. Skipping this collection.";
+        continue;  // Skip invalid handle
+      }
+
       for (const auto &hit : *hits_handle) {
         hits.push_back(&hit);
       }

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToCPAssociatorEDProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToCPAssociatorEDProducer.cc
@@ -74,6 +74,20 @@ void LCToCPAssociatorEDProducer::produce(edm::StreamID, edm::Event &iEvent, cons
   Handle<reco::CaloClusterCollection> LCCollection;
   iEvent.getByToken(LCCollectionToken_, LCCollection);
 
+  // Protection against missing CaloCluster collection
+  if (!LCCollection.isValid()) {
+    edm::LogWarning("LCToCPAssociatorEDProducer")
+        << "CaloCluster collection is unavailable. Producing empty associations.";
+
+    // Return empty collections
+    auto emptyRecSimColl = std::make_unique<ticl::RecoToSimCollection>();
+    auto emptySimRecColl = std::make_unique<ticl::SimToRecoCollection>();
+
+    iEvent.put(std::move(emptyRecSimColl));
+    iEvent.put(std::move(emptySimRecColl));
+    return;
+  }
+
   // associate LC and CP
   LogTrace("AssociatorValidator") << "Calling associateRecoToSim method\n";
   ticl::RecoToSimCollection recSimColl = theAssociator->associateRecoToSim(LCCollection, CPCollection);

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorByEnergyScoreProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorByEnergyScoreProducer.cc
@@ -36,6 +36,14 @@ void LCToSCAssociatorByEnergyScoreProducer<HIT>::produce(edm::StreamID,
     for (auto &token : hgcal_hits_token_) {
       edm::Handle<HGCRecHitCollection> hits_handle;
       iEvent.getByToken(token, hits_handle);
+
+      // Check handle validity
+      if (!hits_handle.isValid()) {
+        edm::LogWarning("LCToSCAssociatorByEnergyScoreProducer")
+            << "Hit collection not available for token. Skipping this collection.";
+        continue;  // Skip invalid handle
+      }
+
       for (const auto &hit : *hits_handle) {
         hits.push_back(&hit);
       }
@@ -44,6 +52,14 @@ void LCToSCAssociatorByEnergyScoreProducer<HIT>::produce(edm::StreamID,
     for (auto &token : hits_token_) {
       edm::Handle<std::vector<HIT>> hits_handle;
       iEvent.getByToken(token, hits_handle);
+
+      // Check handle validity
+      if (!hits_handle.isValid()) {
+        edm::LogWarning("LCToSCAssociatorByEnergyScoreProducer")
+            << "Hit collection not available for token. Skipping this collection.";
+        continue;  // Skip invalid handle
+      }
+
       for (const auto &hit : *hits_handle) {
         hits.push_back(&hit);
       }

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorEDProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorEDProducer.cc
@@ -9,21 +9,16 @@
 #include <string>
 
 // user include files
-#include "FWCore/Framework/interface/global/EDProducer.h"
-
+#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-
-#include "FWCore/Framework/interface/ESHandle.h"
-
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-#include "SimDataFormats/Associations/interface/LayerClusterToSimClusterAssociator.h"
-
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
-
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
+#include "SimDataFormats/Associations/interface/LayerClusterToSimClusterAssociator.h"
 
 //
 // class decleration
@@ -32,7 +27,9 @@
 class LCToSCAssociatorEDProducer : public edm::global::EDProducer<> {
 public:
   explicit LCToSCAssociatorEDProducer(const edm::ParameterSet &);
-  ~LCToSCAssociatorEDProducer() override;
+  ~LCToSCAssociatorEDProducer() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 private:
   void produce(edm::StreamID, edm::Event &, const edm::EventSetup &) const override;
@@ -51,8 +48,6 @@ LCToSCAssociatorEDProducer::LCToSCAssociatorEDProducer(const edm::ParameterSet &
   associatorToken_ = consumes<ticl::LayerClusterToSimClusterAssociator>(pset.getParameter<edm::InputTag>("associator"));
 }
 
-LCToSCAssociatorEDProducer::~LCToSCAssociatorEDProducer() {}
-
 //
 // member functions
 //
@@ -70,6 +65,20 @@ void LCToSCAssociatorEDProducer::produce(edm::StreamID, edm::Event &iEvent, cons
   Handle<reco::CaloClusterCollection> LCCollection;
   iEvent.getByToken(LCCollectionToken_, LCCollection);
 
+  // Protection against missing CaloCluster collection
+  if (!LCCollection.isValid()) {
+    edm::LogWarning("LCToSCAssociatorEDProducer")
+        << "CaloCluster collection is unavailable. Producing empty associations.";
+
+    // Return empty collections
+    auto emptyRecSimColl = std::make_unique<ticl::RecoToSimCollectionWithSimClusters>();
+    auto emptySimRecColl = std::make_unique<ticl::SimToRecoCollectionWithSimClusters>();
+
+    iEvent.put(std::move(emptyRecSimColl));
+    iEvent.put(std::move(emptySimRecColl));
+    return;
+  }
+
   // associate LC and SC
   LogTrace("AssociatorValidator") << "Calling associateRecoToSim method\n";
   ticl::RecoToSimCollectionWithSimClusters recSimColl = theAssociator->associateRecoToSim(LCCollection, SCCollection);
@@ -82,6 +91,14 @@ void LCToSCAssociatorEDProducer::produce(edm::StreamID, edm::Event &iEvent, cons
 
   iEvent.put(std::move(rts));
   iEvent.put(std::move(str));
+}
+
+void LCToSCAssociatorEDProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("label_scl", edm::InputTag("scAssocByEnergyScoreProducer"));
+  desc.add<edm::InputTag>("label_lcl", edm::InputTag("mix", "MergedCaloTruth"));
+  desc.add<edm::InputTag>("associator", edm::InputTag("hgcalMergeLayerClusters"));
+  descriptions.addWithDefaultLabel(desc);
 }
 
 // define this as a plug-in

--- a/Validation/Configuration/python/hltHGCalSimValid_cff.py
+++ b/Validation/Configuration/python/hltHGCalSimValid_cff.py
@@ -1,0 +1,113 @@
+import FWCore.ParameterSet.Config as cms
+
+from SimCalorimetry.HGCalSimProducers.hgcHitAssociation_cfi import lcAssocByEnergyScoreProducer as _lcAssocByEnergyScoreProducer
+from SimCalorimetry.HGCalSimProducers.hgcHitAssociation_cfi import scAssocByEnergyScoreProducer as _scAssocByEnergyScoreProducer
+from SimCalorimetry.HGCalAssociatorProducers.LCToSCAssociation_cfi import layerClusterSimClusterAssociation as _layerClusterSimClusterAssociationProducer
+from SimCalorimetry.HGCalAssociatorProducers.LCToCPAssociation_cfi import layerClusterCaloParticleAssociation as _layerClusterCaloParticleAssociationProducer
+
+from SimCalorimetry.HGCalAssociatorProducers.SimClusterToCaloParticleAssociation_cfi import SimClusterToCaloParticleAssociation
+from SimCalorimetry.HGCalAssociatorProducers.TSToSimTSAssociation_cfi import  allTrackstersToSimTrackstersAssociationsByLCs as _allTrackstersToSimTrackstersAssociationsByLCs
+from SimCalorimetry.HGCalAssociatorProducers.hitToSimClusterCaloParticleAssociator_cfi import hitToSimClusterCaloParticleAssociator as _hitToSimClusterCaloParticleAssociator
+
+from Validation.HGCalValidation.HLT_TICLIterLabels_cff import hltTiclIterLabels as _hltTiclIterLabels
+
+from RecoLocalCalo.HGCalRecProducers.recHitMapProducer_cfi import recHitMapProducer as _recHitMapProducer
+hltRecHitMapProducer = _recHitMapProducer.clone(
+    BHInput = cms.InputTag("hltHGCalRecHit","HGCHEBRecHits"),
+    EBInput = cms.InputTag("hltParticleFlowRecHitECALUnseeded"),
+    EEInput = cms.InputTag("hltHGCalRecHit","HGCEERecHits"),
+    FHInput = cms.InputTag("hltHGCalRecHit","HGCHEFRecHits"),
+    HBInput = cms.InputTag("hltParticleFlowRecHitHBHE"),
+    HOInput = cms.InputTag("hltParticleFlowRecHitHO"),
+    hgcalOnly = cms.bool(True),
+)
+
+hltLcAssocByEnergyScoreProducer = _lcAssocByEnergyScoreProducer.clone(
+    hits = cms.VInputTag("hltHGCalRecHit:HGCEERecHits", "hltHGCalRecHit:HGCHEFRecHits", "hltHGCalRecHit:HGCHEBRecHits"),
+    hitMapTag = cms.InputTag("hltRecHitMapProducer","hgcalRecHitMap"),
+)
+
+hltScAssocByEnergyScoreProducer = _scAssocByEnergyScoreProducer.clone(
+    hits = cms.VInputTag("hltHGCalRecHit:HGCEERecHits", "hltHGCalRecHit:HGCHEFRecHits", "hltHGCalRecHit:HGCHEBRecHits"),
+    hitMapTag = cms.InputTag("hltRecHitMapProducer","hgcalRecHitMap"),
+)
+
+hltLayerClusterCaloParticleAssociationProducer = _layerClusterCaloParticleAssociationProducer.clone(
+    associator = cms.InputTag("hltLcAssocByEnergyScoreProducer"),
+    label_lc = cms.InputTag("hltHgcalMergeLayerClusters")
+)
+
+hltLayerClusterSimClusterAssociationProducer = _layerClusterSimClusterAssociationProducer.clone(
+    associator = cms.InputTag("hltScAssocByEnergyScoreProducer"),
+    label_lcl = cms.InputTag("hltHgcalMergeLayerClusters")
+)
+
+from SimCalorimetry.HGCalAssociatorProducers.AllLayerClusterToTracksterAssociatorsProducer_cfi import AllLayerClusterToTracksterAssociatorsProducer as _AllLayerClusterToTracksterAssociatorsProducer
+
+hltAllLayerClusterToTracksterAssociations = _AllLayerClusterToTracksterAssociatorsProducer.clone(
+    layer_clusters = cms.InputTag("hltHgcalMergeLayerClusters"),
+    tracksterCollections = cms.VInputTag(
+        *[cms.InputTag(label) for label in _hltTiclIterLabels],
+        cms.InputTag("hltTiclSimTracksters"),
+        cms.InputTag("hltTiclSimTracksters", "fromCPs"),
+    )
+)
+
+hltAllTrackstersToSimTrackstersAssociationsByLCs = _allTrackstersToSimTrackstersAssociationsByLCs.clone(
+    allLCtoTSAccoc =  cms.string("hltAllLayerClusterToTracksterAssociations"),
+    layerClusters = cms.InputTag("hltHgcalMergeLayerClusters"),
+    tracksterCollections = cms.VInputTag(
+        *[cms.InputTag(label) for label in _hltTiclIterLabels]
+    ),
+    simTracksterCollections = cms.VInputTag(
+      cms.InputTag('hltTiclSimTracksters'),
+      cms.InputTag('hltTiclSimTracksters','fromCPs')
+    ),
+)
+
+from SimCalorimetry.HGCalAssociatorProducers.AllTracksterToSimTracksterAssociatorsByHitsProducer_cfi import AllTracksterToSimTracksterAssociatorsByHitsProducer as _AllTracksterToSimTracksterAssociatorsByHitsProducer
+
+hltHitToSimClusterCaloParticleAssociator = _hitToSimClusterCaloParticleAssociator.clone(
+    hitMap = cms.InputTag("hltRecHitMapProducer","hgcalRecHitMap"),
+    hits = cms.VInputTag("hltHGCalRecHit:HGCEERecHits", "hltHGCalRecHit:HGCHEFRecHits", "hltHGCalRecHit:HGCHEBRecHits")
+)
+
+from SimCalorimetry.HGCalAssociatorProducers.AllHitToTracksterAssociatorsProducer_cfi import AllHitToTracksterAssociatorsProducer as _AllHitToTracksterAssociatorsProducer
+
+hltAllHitToTracksterAssociations =  _AllHitToTracksterAssociatorsProducer.clone(
+    hitMapTag = cms.InputTag("hltRecHitMapProducer","hgcalRecHitMap"),
+    hits = cms.VInputTag("hltHGCalRecHit:HGCEERecHits", "hltHGCalRecHit:HGCHEFRecHits", "hltHGCalRecHit:HGCHEBRecHits"),
+    layerClusters = cms.InputTag("hltHgcalMergeLayerClusters"),
+    tracksterCollections = cms.VInputTag(
+        *[cms.InputTag(label) for label in _hltTiclIterLabels],
+        cms.InputTag("hltTiclSimTracksters"),
+        cms.InputTag("hltTiclSimTracksters", "fromCPs"),
+    )
+)
+
+hltAllTrackstersToSimTrackstersAssociationsByHits = _AllTracksterToSimTracksterAssociatorsByHitsProducer.clone(
+    allHitToTSAccoc = cms.string("hltAllHitToTracksterAssociations"),
+    hitToCaloParticleMap = cms.InputTag("hltHitToSimClusterCaloParticleAssociator","hitToCaloParticleMap"),
+    hitToSimClusterMap = cms.InputTag("hltHitToSimClusterCaloParticleAssociator","hitToSimClusterMap"),
+    hits = cms.VInputTag("hltHGCalRecHit:HGCEERecHits", "hltHGCalRecHit:HGCHEFRecHits", "hltHGCalRecHit:HGCHEBRecHits"),
+    tracksterCollections = cms.VInputTag(
+        *[cms.InputTag(label) for label in _hltTiclIterLabels]
+    ),
+    simTracksterCollections = cms.VInputTag(
+      'hltTiclSimTracksters',
+      'hltTiclSimTracksters:fromCPs'
+    ),
+)
+
+hltHgcalAssociatorsTask = cms.Task(hltRecHitMapProducer,
+                                   hltLcAssocByEnergyScoreProducer,
+                                   hltScAssocByEnergyScoreProducer,
+                                   SimClusterToCaloParticleAssociation,
+                                   hltLayerClusterCaloParticleAssociationProducer,
+                                   hltLayerClusterSimClusterAssociationProducer,
+                                   hltAllLayerClusterToTracksterAssociations,
+                                   hltAllTrackstersToSimTrackstersAssociationsByLCs,
+                                   hltAllHitToTracksterAssociations,
+                                   hltHitToSimClusterCaloParticleAssociator,
+                                   hltAllTrackstersToSimTrackstersAssociationsByHits
+                                   )

--- a/Validation/HGCalValidation/python/HLTHGCalPostProcessor_cff.py
+++ b/Validation/HGCalValidation/python/HLTHGCalPostProcessor_cff.py
@@ -1,0 +1,54 @@
+import FWCore.ParameterSet.Config as cms
+
+from Validation.HGCalValidation.PostProcessorHGCAL_cfi import postProcessorHGCALlayerclusters as _postProcessorHGCALlayerclusters
+from Validation.HGCalValidation.PostProcessorHGCAL_cfi import postProcessorHGCALsimclusters as _postProcessorHGCALsimclusters
+from Validation.HGCalValidation.PostProcessorHGCAL_cfi import postProcessorHGCALTracksters as _postProcessorHGCALTracksters
+from Validation.HGCalValidation.PostProcessorHGCAL_cfi import postProcessorHGCALCandidates as _postProcessorHGCALCandidates 
+
+from Validation.HGCalValidation.HLT_TICLIterLabels_cff import hltTiclIterLabels as _hltTiclIterLabels
+from Validation.HGCalValidation.HLTHGCalValidator_cff import hltHgcalValidator as _hltHgcalValidator
+
+hltPrefix = 'HLT/HGCAL/HGCalValidator/'
+hltTracksterLabels = _hltTiclIterLabels.copy()
+hltTracksterLabels.extend(['hltTiclSimTracksters', 'hltTiclSimTracksters_fromCPs'])
+
+hltLcToCP_linking = _hltHgcalValidator.label_LCToCPLinking._InputTag__moduleLabel
+hltPostProcessorHGCALlayerclusters = _postProcessorHGCALlayerclusters.clone(
+    subDirs = cms.untracked.vstring(hltPrefix + _hltHgcalValidator.label_layerClusterPlots._InputTag__moduleLabel + '/' + hltLcToCP_linking),
+)
+
+hltSubdirsSim = [hltPrefix + _hltHgcalValidator.label_SimClusters._InputTag__moduleLabel + '/'+iteration+'/' for iteration in hltTracksterLabels]
+hltPostProcessorHGCALsimclusters = _postProcessorHGCALsimclusters.clone(
+    subDirs = cms.untracked.vstring(hltSubdirsSim)
+)
+
+hltTSbyHits_CP = _hltHgcalValidator.label_TSbyHitsCP.value()
+hltSubdirsTracksters = [hltPrefix+iteration+'/'+hltTSbyHits_CP for iteration in hltTracksterLabels]
+
+hltTSbyLCs = _hltHgcalValidator.label_TSbyLCs.value()
+hltSubdirsTracksters.extend(hltPrefix+iteration+'/'+hltTSbyLCs for iteration in hltTracksterLabels)
+
+hltTSbyLCs_CP = _hltHgcalValidator.label_TSbyLCsCP.value()
+hltSubdirsTracksters.extend(hltPrefix+iteration+'/'+hltTSbyLCs_CP for iteration in hltTracksterLabels)
+
+hltTSbyHits = _hltHgcalValidator.label_TSbyHits.value()
+hltSubdirsTracksters.extend(hltPrefix+iteration+'/'+hltTSbyHits for iteration in hltTracksterLabels)
+
+hltPostProcessorHGCALTracksters = _postProcessorHGCALTracksters.clone(
+    subDirs = cms.untracked.vstring(hltSubdirsTracksters)
+)
+
+hltNeutrals = ["photons", "neutral_pions", "neutral_hadrons"]
+hltCharged = ["electrons", "muons", "charged_hadrons"]
+hltSubDirsCandidates = [hltPrefix + _hltHgcalValidator.ticlCandidates.value() + "/" + c for cands in (hltNeutrals, hltCharged) for c in cands]
+
+hltPostProcessorHGCALCandidates = _postProcessorHGCALCandidates.clone(
+    subDirs = cms.untracked.vstring(hltSubDirsCandidates)
+)
+
+hltHcalValidatorPostProcessor = cms.Sequence(
+    hltPostProcessorHGCALlayerclusters+
+    hltPostProcessorHGCALsimclusters+
+    hltPostProcessorHGCALTracksters+
+    hltPostProcessorHGCALCandidates        
+)

--- a/Validation/HGCalValidation/python/HLTHGCalValidator_cff.py
+++ b/Validation/HGCalValidation/python/HLTHGCalValidator_cff.py
@@ -1,0 +1,48 @@
+import FWCore.ParameterSet.Config as cms
+
+from Validation.HGCalValidation.hgcalValidator_cfi import hgcalValidator as _hgcalValidator
+from Validation.HGCalValidation.HLT_TICLIterLabels_cff import hltTiclIterLabels as _hltTiclIterLabels
+
+hltAssociatorInstances = []
+
+for labelts in _hltTiclIterLabels:
+    for labelsts in ['hltTiclSimTracksters', 'hltTiclSimTrackstersfromCPs']:
+        hltAssociatorInstances.append(labelts+'To'+labelsts)
+        hltAssociatorInstances.append(labelsts+'To'+labelts)
+
+hltHgcalValidator = _hgcalValidator.clone(
+    LayerClustersInputMask = cms.VInputTag("hltTiclTrackstersCLUE3DHigh", "hltTiclSimTracksters:fromCPs", "hltTiclSimTracksters"),
+    label_tst = cms.VInputTag(*[cms.InputTag(label) for label in _hltTiclIterLabels] + [cms.InputTag("hltTiclSimTracksters", "fromCPs"), cms.InputTag("hltTiclSimTracksters")]),
+    allTracksterTracksterAssociatorsLabels = cms.VInputTag( *[cms.InputTag('hltAllTrackstersToSimTrackstersAssociationsByLCs:'+associator) for associator in hltAssociatorInstances] ),
+    allTracksterTracksterByHitsAssociatorsLabels = cms.VInputTag( *[cms.InputTag('hltAllTrackstersToSimTrackstersAssociationsByHits:'+associator) for associator in hltAssociatorInstances] ),
+    associator = cms.untracked.InputTag("hltLayerClusterCaloParticleAssociationProducer"),
+    associatorSim = cms.untracked.InputTag("hltLayerClusterSimClusterAssociationProducer"),
+    dirName = cms.string('HLT/HGCAL/HGCalValidator/'),
+    hits = cms.VInputTag("hltHGCalRecHit:HGCEERecHits", "hltHGCalRecHit:HGCHEFRecHits", "hltHGCalRecHit:HGCHEBRecHits"),
+    hitMap = cms.InputTag("hltRecHitMapProducer","hgcalRecHitMap"),
+    simTrackstersMap = cms.InputTag("hltTiclSimTracksters"),
+    label_layerClusterPlots = cms.InputTag("hltHgcalMergeLayerClusters"),
+    label_lcl = cms.InputTag("hltHgcalMergeLayerClusters"),
+    label_simTS = cms.InputTag("hltTiclSimTracksters"),
+    label_simTSFromCP = cms.InputTag("hltTiclSimTracksters","fromCPs"),
+    recoTracks = cms.InputTag("hltGeneralTracks"),
+    simClustersToCaloParticlesMap = cms.InputTag("SimClusterToCaloParticleAssociation","simClusterToCaloParticleMap"),
+    simTiclCandidates = cms.InputTag("hltTiclSimTracksters"),
+    ticlCandidates = cms.string('hltTiclCandidate'),
+    ticlTrackstersMerge = cms.InputTag("hltTiclTrackstersMerge"),
+    mergeRecoToSimAssociator = cms.InputTag("hltAllTrackstersToSimTrackstersAssociationsByLCs","hltTiclTrackstersMergeTohltTiclSimTrackstersfromCPs"),
+    mergeSimToRecoAssociator = cms.InputTag("hltAllTrackstersToSimTrackstersAssociationsByLCs","hltTiclSimTrackstersfromCPsTohltTiclTrackstersMerge"),
+)
+
+from Configuration.ProcessModifiers.ticl_v5_cff import ticl_v5
+
+lcInputMask_v5  = ["hltTiclTrackstersCLUE3DHigh"]
+lcInputMask_v5.extend([cms.InputTag("hltTiclSimTracksters", "fromCPs"), cms.InputTag("hltTiclSimTracksters")])
+
+ticl_v5.toModify(hltHgcalValidator,
+                 LayerClustersInputMask = cms.VInputTag(lcInputMask_v5),
+                 ticlTrackstersMerge = cms.InputTag("hltTiclCandidate"),
+                 isticlv5 = cms.untracked.bool(True),
+                 mergeSimToRecoAssociator = cms.InputTag("hltAllTrackstersToSimTrackstersAssociationsByLCs:hltTiclSimTrackstersfromCPsTohltTiclCandidate"),
+                 mergeRecoToSimAssociator = cms.InputTag("hltAllTrackstersToSimTrackstersAssociationsByLCs:hltTiclCandidateTohltTiclSimTrackstersfromCPs"),
+                 )

--- a/Validation/HGCalValidation/python/HLT_TICLIterLabels_cff.py
+++ b/Validation/HGCalValidation/python/HLT_TICLIterLabels_cff.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+
+#hltTiclIterLabels = ["hltTiclTrackstersCLUE3DHigh", "hltTiclTrackstersCLUE3DHighL1Seeded", "hltTiclTrackstersMerge"]
+hltTiclIterLabels = ["hltTiclTrackstersCLUE3DHigh", "hltTiclTrackstersMerge"]
+
+from Configuration.ProcessModifiers.ticl_v5_cff import ticl_v5
+ticl_v5.toModify(
+    globals(),
+    lambda g: g.update({
+        "hltTiclIterLabels": [
+            "hltTiclTrackstersCLUE3DHigh",
+            #"hltTiclTrackstersCLUE3DHighL1Seeded",
+            "hltTiclTracksterLinks",
+            #"hltTiclTracksterLinksSuperclusteringDNNUnseeded",
+            #"hltTiclTracksterLinksSuperclusteringDNNL1Seeded",
+            "hltTiclCandidate"
+        ]
+    })
+)

--- a/Validation/HGCalValidation/src/TICLCandidateValidator.cc
+++ b/Validation/HGCalValidation/src/TICLCandidateValidator.cc
@@ -279,7 +279,13 @@ void TICLCandidateValidator::bookCandidatesHistos(DQMStore::IBooker& ibook,
 void TICLCandidateValidator::fillCandidateHistos(const edm::Event& event,
                                                  const Histograms& histograms,
                                                  edm::Handle<ticl::TracksterCollection> simTrackstersCP_h) const {
-  auto TICLCandidates = event.get(TICLCandidatesToken_);
+  auto TICLCandidatesHandle = event.getHandle(TICLCandidatesToken_);
+  if (!TICLCandidatesHandle.isValid()) {
+    edm::LogError("TICLCandidatesError") << "Failed to retrieve TICL candidates.";
+    return;  // Handle error appropriately
+  }
+
+  auto TICLCandidates = *TICLCandidatesHandle;
 
   edm::Handle<std::vector<TICLCandidate>> simTICLCandidates_h;
   event.getByToken(simTICLCandidatesToken_, simTICLCandidates_h);


### PR DESCRIPTION
#### PR description:

The goal of this PR is to introduce the HGCal validation for the Phase-2 HLT menu.
In order to do so a new validation chain has been added, starting from the existing offline one, and plugged in the Phase-2 HLT validation infrastructure. 
The new code supports both the TICL v4 (current default in the phase-2 HLT menu) and TICL v5 (which will become the new default after full validation from the various POGs at HLT). The list of TICL iterations to run upon is based on the process modifier.
In order to cope with the fact that at HLT not all the events have all the collections produced, several producer needed to be patched in order to be protected against missing input.

#### PR validation:

Run the following set of workflows:

```
runTheMatrix.py --what upgrade -l 29634.0,29634.75,29634.752,29634.77
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, it will not be backported.

N.B.: opening in draft mode for now, some clean-up is still in order.