### PR TITLE
Fix reading Run products in RNTupleSource

### DIFF
--- a/FWIO/RNTuple/plugins/RNTupleInputFile.cc
+++ b/FWIO/RNTuple/plugins/RNTupleInputFile.cc
@@ -122,7 +122,7 @@ namespace edm {
         } else if (prod.branchType() == InLumi) {
           prod.setDropped(not lumis_.setupToReadProductIfAvailable(prod));
         } else if (prod.branchType() == InRun) {
-          prod.setDropped(runs_.setupToReadProductIfAvailable(prod));
+          prod.setDropped(not runs_.setupToReadProductIfAvailable(prod));
         }
       }
     }

--- a/FWIO/RNTuple/plugins/RNTupleSource.cc
+++ b/FWIO/RNTuple/plugins/RNTupleSource.cc
@@ -334,9 +334,11 @@ namespace edm {
     auto& reader = runReaders_[runPrincipal.index()];
     reader.setEntry(entry);
     runPrincipal.fillRunPrincipal(processHistoryRegistry(), &reader);
+    // Read in all the products now.
+    runPrincipal.readAllFromSourceAndMergeImmediately();
     //In the future, when this code can skip runs we will need to
     // set this value.
-    //runPrincipal.setShouldWriteRun(RunPrincipal::kNo);
+    runPrincipal.setShouldWriteRun(RunPrincipal::kYes);
   }
 
   std::pair<SharedResourcesAcquirer*, std::recursive_mutex*> RNTupleSource::resourceSharedWithDelayedReader_() {


### PR DESCRIPTION
#### PR description:

Fixed a typo and added additional calls in order to make reading Run products work.

#### PR validation:

Workflow 136.901 now gets the Run product (but fails later when processing the Events).

resolves https://github.com/cms-sw/framework-team/issues/1354