### PR TITLE
Update TkAl PCL metadata for 2025

### DIFF
--- a/CondFormats/Common/data/SiPixelAliHGCombRcd_prod.json
+++ b/CondFormats/Common/data/SiPixelAliHGCombRcd_prod.json
@@ -1,8 +1,8 @@
 {
     "destinationDatabase": "oracle://cms_orcon_prod/CMS_CONDITIONS", 
     "destinationTags": {
-        "SiPixelAliHGCombined_PCL_v0_hlt": {}, 
-        "SiPixelAliHGCombined_PCL_v0_prompt": {}
+        "SiPixelAliHGCombined_PCL_v0_hlt": {},
+        "TrackerAlignmentHG_PCL_byRun_v2_express": {}
     }, 
     "inputTag": "SiPixelAliHGCombined_pcl", 
     "since": null, 

--- a/CondFormats/Common/data/SiPixelAliHGRcd_prod.json
+++ b/CondFormats/Common/data/SiPixelAliHGRcd_prod.json
@@ -1,8 +1,7 @@
 {
     "destinationDatabase": "oracle://cms_orcon_prod/CMS_CONDITIONS", 
     "destinationTags": {
-        "SiPixelAliHG_PCL_v0_hlt": {}, 
-        "TrackerAlignmentHG_PCL_byRun_v2_express": {}
+        "SiPixelAliHG_PCL_v0_hlt": {}
     }, 
     "inputTag": "SiPixelAliHG_pcl", 
     "since": null, 

--- a/CondFormats/Common/data/SiPixelAliRcd_prod.json
+++ b/CondFormats/Common/data/SiPixelAliRcd_prod.json
@@ -1,8 +1,7 @@
 {
     "destinationDatabase": "oracle://cms_orcon_prod/CMS_CONDITIONS", 
     "destinationTags": {
-        "SiPixelAli_PCL_v0_hlt_off": {}, 
-        "TrackerAlignment_PCL_byRun_v2_express_off": {}
+        "SiPixelAli_PCL_v0_hlt": {}
     }, 
     "inputTag": "SiPixelAli_pcl", 
     "since": null, 


### PR DESCRIPTION
#### PR description:
In this PR I'm udpating the PCL TkAl workflows metadata to reflect what was agreed in this [CMSTalk post](https://cms-talk.web.cern.ch/t/tkalignment-strategy-for-the-2025-commissioning/122523/4) and deployed for 2025 data-taking.

Bottomline is:
- All TkAl PCL workflows always write to their respective `SiPixelAli*_PCL_v0_hlt` non-production tags
- The TkAl production tag (`TrackerAlignment_PCL_byRun_v2_express`) is populated by the only “active” PCL-workflow, or not populated at all in commissioning times --> this is requested by the TkAl Conveners
- All the previously existing `_off` tags are removed to avoid confusion and operational mistakes

This workflow is summarized in the following table:
<img width="889" alt="DMD_table" src="https://github.com/user-attachments/assets/98855acc-bc0a-412c-bcd3-ae4ff41f34a3" />

In this PR I'm updating the metadata values to reflect what should be the "standard" (during collision) data-taking situation, i.e. the HG-Combined PCL workflow active and writing to the production tag

#### PR validation:
None needed

#### Backport
Not a backport, but a 15_0_X backport will be provided to ease this year data-taking operations.