### PR TITLE
delay read when runing PAT or NANO by itself

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1817,6 +1817,9 @@ class ConfigBuilder(object):
             self._options.customise_commands = self._options.customise_commands + "process.slimmedPatTrigger.triggerResults= cms.InputTag( 'TriggerResults::"+self._options.hltProcess+"' )\n"
             self._options.customise_commands = self._options.customise_commands + "process.patMuons.triggerResults= cms.InputTag( 'TriggerResults::"+self._options.hltProcess+"' )\n"
 
+        # cpu efficiency boost when running PAT/MINI by itself
+        if self.stepKeys[0] == 'PAT':
+            self._options.customise_commands = self._options.customise_commands + "process.source.delayReadingEventProducts = cms.untracked.bool(False)\n"
 #            self.renameHLTprocessInSequence(sequence)
 
         return
@@ -1879,7 +1882,10 @@ class ConfigBuilder(object):
             if len(self._options.customise_commands) > 1:
                 self._options.customise_commands = self._options.customise_commands + " \n"
             self._options.customise_commands = self._options.customise_commands + "process.unpackedPatTrigger.triggerResults= cms.InputTag( 'TriggerResults::"+self._options.hltProcess+"' )\n"
-
+        # cpu efficiency boost when running NANO by itself
+        #if self.stepKeys[0] == 'NANO':
+        #    self._options.customise_commands = self._options.customise_commands + "process.source.delayReadingEventProducts = cms.untracked.bool(False)\n"
+            
     def prepare_SKIM(self, stepSpec = "all"):
         ''' Enrich the schedule with skimming fragments'''
         skimConfig,sequence,_ = self.loadDefaultOrSpecifiedCFF(stepSpec,self.SKIMDefaultCFF)

--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1883,8 +1883,8 @@ class ConfigBuilder(object):
                 self._options.customise_commands = self._options.customise_commands + " \n"
             self._options.customise_commands = self._options.customise_commands + "process.unpackedPatTrigger.triggerResults= cms.InputTag( 'TriggerResults::"+self._options.hltProcess+"' )\n"
         # cpu efficiency boost when running NANO by itself
-        #if self.stepKeys[0] == 'NANO':
-        #    self._options.customise_commands = self._options.customise_commands + "process.source.delayReadingEventProducts = cms.untracked.bool(False)\n"
+        if self.stepKeys[0] == 'NANO':
+            self._options.customise_commands = self._options.customise_commands + "process.source.delayReadingEventProducts = cms.untracked.bool(False)\n"
             
     def prepare_SKIM(self, stepSpec = "all"):
         ''' Enrich the schedule with skimming fragments'''


### PR DESCRIPTION
#### PR description:

as a follow up of #47750 we can disable the delayed read when running PAT or NANO as the first step

#### PR validation:

nano matrix

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

likely to be nackported to 15.0
