### PR TITLE
no delay read when runing PAT or NANO by itself [150X]

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1790,6 +1790,8 @@ class ConfigBuilder(object):
 
         # cpu efficiency boost when running PAT/MINI by itself
         if self.stepKeys[0] == 'PAT':
+            if len(self._options.customise_commands) > 1:
+                self._options.customise_commands = self._options.customise_commands + " \n"
             self._options.customise_commands = self._options.customise_commands + "process.source.delayReadingEventProducts = cms.untracked.bool(False)\n"
 #            self.renameHLTprocessInSequence(sequence)
 
@@ -1855,6 +1857,8 @@ class ConfigBuilder(object):
             self._options.customise_commands = self._options.customise_commands + "process.unpackedPatTrigger.triggerResults= cms.InputTag( 'TriggerResults::"+self._options.hltProcess+"' )\n"
         # cpu efficiency boost when running NANO by itself
         if self.stepKeys[0] == 'NANO':
+            if len(self._options.customise_commands) > 1:
+                self._options.customise_commands = self._options.customise_commands + " \n"
             self._options.customise_commands = self._options.customise_commands + "process.source.delayReadingEventProducts = cms.untracked.bool(False)\n"
             
     def prepare_SKIM(self, stepSpec = "all"):

--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1788,6 +1788,9 @@ class ConfigBuilder(object):
             self._options.customise_commands = self._options.customise_commands + "process.slimmedPatTrigger.triggerResults= cms.InputTag( 'TriggerResults::"+self._options.hltProcess+"' )\n"
             self._options.customise_commands = self._options.customise_commands + "process.patMuons.triggerResults= cms.InputTag( 'TriggerResults::"+self._options.hltProcess+"' )\n"
 
+        # cpu efficiency boost when running PAT/MINI by itself
+        if self.stepKeys[0] == 'PAT':
+            self._options.customise_commands = self._options.customise_commands + "process.source.delayReadingEventProducts = cms.untracked.bool(False)\n"
 #            self.renameHLTprocessInSequence(sequence)
 
         return
@@ -1850,7 +1853,10 @@ class ConfigBuilder(object):
             if len(self._options.customise_commands) > 1:
                 self._options.customise_commands = self._options.customise_commands + " \n"
             self._options.customise_commands = self._options.customise_commands + "process.unpackedPatTrigger.triggerResults= cms.InputTag( 'TriggerResults::"+self._options.hltProcess+"' )\n"
-
+        # cpu efficiency boost when running NANO by itself
+        #if self.stepKeys[0] == 'NANO':
+        #    self._options.customise_commands = self._options.customise_commands + "process.source.delayReadingEventProducts = cms.untracked.bool(False)\n"
+            
     def prepare_SKIM(self, stepSpec = "all"):
         ''' Enrich the schedule with skimming fragments'''
         skimConfig,sequence,_ = self.loadDefaultOrSpecifiedCFF(stepSpec,self.SKIMDefaultCFF)

--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1854,8 +1854,8 @@ class ConfigBuilder(object):
                 self._options.customise_commands = self._options.customise_commands + " \n"
             self._options.customise_commands = self._options.customise_commands + "process.unpackedPatTrigger.triggerResults= cms.InputTag( 'TriggerResults::"+self._options.hltProcess+"' )\n"
         # cpu efficiency boost when running NANO by itself
-        #if self.stepKeys[0] == 'NANO':
-        #    self._options.customise_commands = self._options.customise_commands + "process.source.delayReadingEventProducts = cms.untracked.bool(False)\n"
+        if self.stepKeys[0] == 'NANO':
+            self._options.customise_commands = self._options.customise_commands + "process.source.delayReadingEventProducts = cms.untracked.bool(False)\n"
             
     def prepare_SKIM(self, stepSpec = "all"):
         ''' Enrich the schedule with skimming fragments'''


### PR DESCRIPTION
#### PR description:

backport of #47897 

as a follow up of https://github.com/cms-sw/cmssw/issues/47750 we can disable the delayed read when running PAT or NANO as the first step
