### PR TITLE
Remove use of ROOT::Experimental namespace

### DIFF
--- a/FWIO/RNTuple/bin/edmRntupleStorage.cc
+++ b/FWIO/RNTuple/bin/edmRntupleStorage.cc
@@ -112,7 +112,7 @@ int main(int iArgc, char const* iArgv[]) {
     return 1;
   }
 
-  using namespace ROOT::Experimental;
+  using namespace ROOT;
 
   auto file = TFile::Open(vm["file"].as<std::string>().c_str(), "r");
   if (not file) {

--- a/FWIO/RNTuple/plugins/DataProductsRNTuple.cc
+++ b/FWIO/RNTuple/plugins/DataProductsRNTuple.cc
@@ -4,8 +4,7 @@
 #include "FWCore/Utilities/interface/EDMException.h"
 
 using namespace edm::input;
-using namespace ROOT::Experimental;
-
+using namespace ROOT;
 namespace {
   std::string fixName(std::string_view iName) {
     if (not iName.empty() and iName.back() == '.') {
@@ -28,7 +27,7 @@ namespace {
 DataProductsRNTuple::DataProductsRNTuple(TFile* iFile,
                                          std::string const& iName,
                                          std::string const& iAux,
-                                         ROOT::Experimental::RNTupleReadOptions const& iOps)
+                                         ROOT::RNTupleReadOptions const& iOps)
     : reader_(RNTupleReader::Open(*get_and_check_RNTuple(iFile, iName), iOps)) {
   auxDesc_ = reader_->GetDescriptor().FindFieldId(iAux);
 }
@@ -36,7 +35,7 @@ DataProductsRNTuple::DataProductsRNTuple(TFile* iFile,
 bool DataProductsRNTuple::setupToReadProductIfAvailable(ProductDescription& iProduct) {
   auto fixedName = fixName(iProduct.branchName());
   auto desc = reader_->GetDescriptor().FindFieldId(fixedName);
-  if (desc == ROOT::Experimental::kInvalidDescriptorId) {
+  if (desc == ROOT::kInvalidDescriptorId) {
     return false;
   }
   iProduct.initFromDictionary();

--- a/FWIO/RNTuple/plugins/DataProductsRNTuple.h
+++ b/FWIO/RNTuple/plugins/DataProductsRNTuple.h
@@ -18,29 +18,29 @@ namespace edm::input {
     DataProductsRNTuple(TFile*,
                         std::string const& iName,
                         std::string const& iAux,
-                        ROOT::Experimental::RNTupleReadOptions const& iOpts);
+                        ROOT::RNTupleReadOptions const& iOpts);
 
     bool setupToReadProductIfAvailable(ProductDescription&);
 
     std::shared_ptr<edm::WrapperBase> dataProduct(edm::BranchID const&, int iEntry);
 
     template <typename T>
-    ROOT::Experimental::RNTupleView<T> auxView(std::shared_ptr<T> oStorage) {
+    ROOT::RNTupleView<T> auxView(std::shared_ptr<T> oStorage) {
       return reader_->GetView(auxDesc_, std::move(oStorage));
     }
 
-    ROOT::Experimental::NTupleSize_t numberOfEntries() const { return reader_->GetNEntries(); }
+    ROOT::NTupleSize_t numberOfEntries() const { return reader_->GetNEntries(); }
 
-    ROOT::Experimental::DescriptorId_t findDescriptorID(std::string const& iFieldName) {
+    ROOT::DescriptorId_t findDescriptorID(std::string const& iFieldName) {
       return reader_->GetDescriptor().FindFieldId(iFieldName);
     }
 
     template <typename T>
-    ROOT::Experimental::RNTupleView<T> viewFor(ROOT::Experimental::DescriptorId_t iID, std::shared_ptr<T> oStorage) {
+    ROOT::RNTupleView<T> viewFor(ROOT::DescriptorId_t iID, std::shared_ptr<T> oStorage) {
       return reader_->GetView(iID, std::move(oStorage));
     }
 
-    void printInfo(std::ostream& iStream) { reader_->PrintInfo(ROOT::Experimental::ENTupleInfo::kMetrics, iStream); }
+    void printInfo(std::ostream& iStream) { reader_->PrintInfo(ROOT::ENTupleInfo::kMetrics, iStream); }
 
   private:
     struct WrapperFactory {
@@ -61,17 +61,17 @@ namespace edm::input {
     };
 
     struct ProductInfo {
-      ProductInfo(std::string const& iTypeName, ROOT::Experimental::DescriptorId_t iDesc, std::string iName)
+      ProductInfo(std::string const& iTypeName, ROOT::DescriptorId_t iDesc, std::string iName)
           : factory_(iTypeName), descriptor_(iDesc), name_(std::move(iName)) {}
       WrapperFactory factory_;
-      ROOT::Experimental::DescriptorId_t descriptor_;
+      ROOT::DescriptorId_t descriptor_;
       std::string name_;
-      std::optional<ROOT::Experimental::RNTupleView<void>> view_;
+      std::optional<ROOT::RNTupleView<void>> view_;
     };
 
-    std::unique_ptr<ROOT::Experimental::RNTupleReader> reader_;
+    std::unique_ptr<ROOT::RNTupleReader> reader_;
     std::unordered_map<edm::BranchID::value_type, ProductInfo> infos_;
-    ROOT::Experimental::DescriptorId_t auxDesc_;
+    ROOT::DescriptorId_t auxDesc_;
   };
 }  // namespace edm::input
 

--- a/FWIO/RNTuple/plugins/RNTupleInputFile.cc
+++ b/FWIO/RNTuple/plugins/RNTupleInputFile.cc
@@ -24,11 +24,11 @@
 #include <iostream>
 #include <iomanip>
 
-using namespace ROOT::Experimental;
+using namespace ROOT;
 namespace {
-  ROOT::Experimental::RNTupleReadOptions options(edm::RNTupleInputFile::Options const& iOpt) {
-    ROOT::Experimental::RNTupleReadOptions opt;
-    opt.SetMetricsEnabled(iOpt.enableMetrics_);
+  ROOT::RNTupleReadOptions options(edm::RNTupleInputFile::Options const& iOpt) {
+    ROOT::RNTupleReadOptions opt;
+    opt.SetEnableMetrics(iOpt.enableMetrics_);
     opt.SetClusterCache(iOpt.useClusterCache_ ? RNTupleReadOptions::EClusterCache::kOn
                                               : RNTupleReadOptions::EClusterCache::kOff);
     return opt;
@@ -88,7 +88,7 @@ namespace edm {
 
     retValue.reserve(parentageTuple->GetNEntries());
 
-    for (ROOT::Experimental::NTupleSize_t i = 0; i < parentageTuple->GetNEntries(); ++i) {
+    for (ROOT::NTupleSize_t i = 0; i < parentageTuple->GetNEntries(); ++i) {
       parentageTuple->LoadEntry(i, *entry);
       registry.insertMapped(parentage);
       retValue.push_back(parentage.id());
@@ -107,7 +107,7 @@ namespace edm {
 
     // Merge into the parameter set registry.
     pset::Registry& psetRegistry = *pset::Registry::instance();
-    for (ROOT::Experimental::NTupleSize_t i = 0; i < psets->GetNEntries(); ++i) {
+    for (ROOT::NTupleSize_t i = 0; i < psets->GetNEntries(); ++i) {
       psets->LoadEntry(i, *entry);
       ParameterSet pset(idToBlob.second.pset());
       pset.setID(idToBlob.first);

--- a/FWIO/RNTuple/plugins/RNTupleInputFile.h
+++ b/FWIO/RNTuple/plugins/RNTupleInputFile.h
@@ -59,9 +59,9 @@ namespace edm {
     input::DataProductsRNTuple lumis_;
     input::DataProductsRNTuple events_;
 
-    std::optional<ROOT::Experimental::RNTupleView<RunAuxiliary>> runAuxView_;
-    std::optional<ROOT::Experimental::RNTupleView<LuminosityBlockAuxiliary>> lumiAuxView_;
-    std::optional<ROOT::Experimental::RNTupleView<EventAuxiliary>> eventAuxView_;
+    std::optional<ROOT::RNTupleView<RunAuxiliary>> runAuxView_;
+    std::optional<ROOT::RNTupleView<LuminosityBlockAuxiliary>> lumiAuxView_;
+    std::optional<ROOT::RNTupleView<EventAuxiliary>> eventAuxView_;
 
     IndexIntoFile index_;
     std::optional<IndexIntoFile::IndexIntoFileItr> iter_;

--- a/FWIO/RNTuple/plugins/RNTupleOutputFile.cc
+++ b/FWIO/RNTuple/plugins/RNTupleOutputFile.cc
@@ -50,7 +50,7 @@ namespace {
   }
 }  // namespace
 
-using namespace ROOT::Experimental;
+using namespace ROOT;
 namespace edm {
   RNTupleOutputFile::RNTupleOutputFile(std::string const& iFileName,
                                        FileBlock const& iFileBlock,
@@ -90,29 +90,28 @@ This function allows one to override the default RNTuple behavior and instead st
 all bytes of a data type in one field. To do that one must find the storage type (typeName) and
 explicitly pass the correct variable to `SetColumnRepresentatives`).
      */
-    void noSplitField(ROOT::Experimental::RFieldBase& iField) {
+    void noSplitField(ROOT::RFieldBase& iField) {
       auto const& typeName = iField.GetTypeName();
       if (typeName == "std::uint16_t") {
-        iField.SetColumnRepresentatives({{ROOT::Experimental::EColumnType::kUInt16}});
+        iField.SetColumnRepresentatives({{ROOT::ENTupleColumnType::kUInt16}});
       } else if (typeName == "std::uint32_t") {
-        iField.SetColumnRepresentatives({{ROOT::Experimental::EColumnType::kUInt32}});
+        iField.SetColumnRepresentatives({{ROOT::ENTupleColumnType::kUInt32}});
       } else if (typeName == "std::uint64_t") {
-        iField.SetColumnRepresentatives({{ROOT::Experimental::EColumnType::kUInt64}});
+        iField.SetColumnRepresentatives({{ROOT::ENTupleColumnType::kUInt64}});
       } else if (typeName == "std::int16_t") {
-        iField.SetColumnRepresentatives({{ROOT::Experimental::EColumnType::kInt16}});
+        iField.SetColumnRepresentatives({{ROOT::ENTupleColumnType::kInt16}});
       } else if (typeName == "std::int32_t") {
-        iField.SetColumnRepresentatives({{ROOT::Experimental::EColumnType::kInt32}});
+        iField.SetColumnRepresentatives({{ROOT::ENTupleColumnType::kInt32}});
       } else if (typeName == "std::int64_t") {
-        iField.SetColumnRepresentatives({{ROOT::Experimental::EColumnType::kInt64}});
+        iField.SetColumnRepresentatives({{ROOT::ENTupleColumnType::kInt64}});
       } else if (typeName == "float") {
-        iField.SetColumnRepresentatives({{ROOT::Experimental::EColumnType::kReal32}});
+        iField.SetColumnRepresentatives({{ROOT::ENTupleColumnType::kReal32}});
       } else if (typeName == "double") {
-        iField.SetColumnRepresentatives({{ROOT::Experimental::EColumnType::kReal64}});
+        iField.SetColumnRepresentatives({{ROOT::ENTupleColumnType::kReal64}});
       }
     }
 
-    void findSubFieldsForNoSplitThenApply(ROOT::Experimental::RFieldBase& iField,
-                                          std::vector<std::string> const& iNoSplitFields) {
+    void findSubFieldsForNoSplitThenApply(ROOT::RFieldBase& iField, std::vector<std::string> const& iNoSplitFields) {
       for (auto const& name : iNoSplitFields) {
         if (name.starts_with(iField.GetFieldName())) {
           bool found = false;
@@ -142,9 +141,8 @@ explicitly pass the correct variable to `SetColumnRepresentatives`).
       try {
         edm::convertException::wrap([&]() {
           if (index >= iUseStreamer.size() or not iUseStreamer[index]) {
-            auto field = ROOT::Experimental::RFieldBase::Create(fixBranchName(prod.first->branchName()),
-                                                                prod.first->wrappedName())
-                             .Unwrap();
+            auto field =
+                ROOT::RFieldBase::Create(fixBranchName(prod.first->branchName()), prod.first->wrappedName()).Unwrap();
             if (noSplitSubFields) {
               //use the 'conventional' way to store fields
               for (auto& subfield : *field) {
@@ -155,8 +153,8 @@ explicitly pass the correct variable to `SetColumnRepresentatives`).
             }
             iModel.AddField(std::move(field));
           } else {
-            auto field = std::make_unique<ROOT::Experimental::RStreamerField>(fixBranchName(prod.first->branchName()),
-                                                                              prod.first->wrappedName());
+            auto field = std::make_unique<ROOT::RStreamerField>(fixBranchName(prod.first->branchName()),
+                                                                prod.first->wrappedName());
             iModel.AddField(std::move(field));
           }
           branchesWithStoredHistory_.insert(prod.first->branchID());
@@ -183,9 +181,9 @@ explicitly pass the correct variable to `SetColumnRepresentatives`).
   std::unique_ptr<RNTupleModel> RNTupleOutputFile::setupCommonModels(SelectedProducts const& iProducts,
                                                                      std::string const& iAuxName,
                                                                      std::string const& iAuxType) {
-    auto model = ROOT::Experimental::RNTupleModel::CreateBare();
+    auto model = ROOT::RNTupleModel::CreateBare();
     {
-      auto field = ROOT::Experimental::RFieldBase::Create(iAuxName, iAuxType).Unwrap();
+      auto field = ROOT::RFieldBase::Create(iAuxName, iAuxType).Unwrap();
       model->AddField(std::move(field));
     }
     const std::vector<bool> streamerNothing;
@@ -199,9 +197,9 @@ explicitly pass the correct variable to `SetColumnRepresentatives`).
     {
       auto model = setupCommonModels(iProducts, "RunAuxiliary", "edm::RunAuxiliary");
 
-      auto writeOptions = ROOT::Experimental::RNTupleWriteOptions();
+      auto writeOptions = ROOT::RNTupleWriteOptions();
       writeOptions.SetCompression(convert(iConfig.compressionAlgo), iConfig.compressionLevel);
-      runs_ = ROOT::Experimental::RNTupleWriter::Append(std::move(model), "Runs", file_, writeOptions);
+      runs_ = ROOT::RNTupleWriter::Append(std::move(model), "Runs", file_, writeOptions);
     }
     products_[InRun] = associateDataProducts(iProducts, runs_->GetModel());
     runAuxField_ = runs_->GetModel().GetToken(kRunAuxName);
@@ -211,9 +209,9 @@ explicitly pass the correct variable to `SetColumnRepresentatives`).
     {
       auto model = setupCommonModels(iProducts, "LuminosityBlockAuxiliary", "edm::LuminosityBlockAuxiliary");
 
-      auto writeOptions = ROOT::Experimental::RNTupleWriteOptions();
+      auto writeOptions = ROOT::RNTupleWriteOptions();
       writeOptions.SetCompression(convert(iConfig.compressionAlgo), iConfig.compressionLevel);
-      lumis_ = ROOT::Experimental::RNTupleWriter::Append(std::move(model), "LuminosityBlocks", file_, writeOptions);
+      lumis_ = ROOT::RNTupleWriter::Append(std::move(model), "LuminosityBlocks", file_, writeOptions);
     }
     products_[InLumi] = associateDataProducts(iProducts, lumis_->GetModel());
     lumiAuxField_ = lumis_->GetModel().GetToken(kLumiAuxName);
@@ -226,27 +224,26 @@ explicitly pass the correct variable to `SetColumnRepresentatives`).
     std::string kEventSelName = "EventSelections";
     std::string kBranchListName = "BranchListIndexes";
     {
-      auto model = ROOT::Experimental::RNTupleModel::CreateBare();
+      auto model = ROOT::RNTupleModel::CreateBare();
       {
-        auto field = ROOT::Experimental::RFieldBase::Create(kEventAuxName, "edm::EventAuxiliary").Unwrap();
+        auto field = ROOT::RFieldBase::Create(kEventAuxName, "edm::EventAuxiliary").Unwrap();
         model->AddField(std::move(field));
       }
       {
-        auto field =
-            ROOT::Experimental::RFieldBase::Create(kEventProvName, "std::vector<edm::StoredProductProvenance>").Unwrap();
+        auto field = ROOT::RFieldBase::Create(kEventProvName, "std::vector<edm::StoredProductProvenance>").Unwrap();
         model->AddField(std::move(field));
       }
       {
-        auto field = ROOT::Experimental::RFieldBase::Create(kEventSelName, "std::vector<edm::Hash<1> >").Unwrap();
+        auto field = ROOT::RFieldBase::Create(kEventSelName, "std::vector<edm::Hash<1> >").Unwrap();
         model->AddField(std::move(field));
       }
       {
-        auto field = ROOT::Experimental::RFieldBase::Create(kBranchListName, "std::vector<unsigned short>").Unwrap();
+        auto field = ROOT::RFieldBase::Create(kBranchListName, "std::vector<unsigned short>").Unwrap();
         model->AddField(std::move(field));
       }
       setupDataProducts(iProducts, iConfig.streamerProduct, iConfig.doNotSplitSubFields, *model);
 
-      auto writeOptions = ROOT::Experimental::RNTupleWriteOptions();
+      auto writeOptions = ROOT::RNTupleWriteOptions();
       writeOptions.SetCompression(convert(iConfig.compressionAlgo), iConfig.compressionLevel);
       writeOptions.SetApproxZippedClusterSize(iConfig.approxZippedClusterSize);
       writeOptions.SetMaxUnzippedClusterSize(iConfig.maxUnzippedClusterSize);
@@ -255,7 +252,7 @@ explicitly pass the correct variable to `SetColumnRepresentatives`).
       writeOptions.SetPageBufferBudget(iConfig.pageBufferBudget);
       writeOptions.SetUseBufferedWrite(iConfig.useBufferedWrite);
       writeOptions.SetUseDirectIO(iConfig.useDirectIO);
-      events_ = ROOT::Experimental::RNTupleWriter::Append(std::move(model), "Events", file_, writeOptions);
+      events_ = ROOT::RNTupleWriter::Append(std::move(model), "Events", file_, writeOptions);
     }
     products_[InEvent] = associateDataProducts(iProducts, events_->GetModel());
 
@@ -270,16 +267,15 @@ explicitly pass the correct variable to `SetColumnRepresentatives`).
     extendSelectorConfig_ = anyProductProduced || !iConfig.wantAllEvents;
   }
   void RNTupleOutputFile::setupPSets(Config const& iConfig) {
-    auto model = ROOT::Experimental::RNTupleModel::CreateBare();
+    auto model = ROOT::RNTupleModel::CreateBare();
     {
-      auto field = ROOT::Experimental::RFieldBase::Create("IdToParameterSetsBlobs",
-                                                          "std::pair<edm::Hash<1>,edm::ParameterSetBlob>")
-                       .Unwrap();
+      auto field =
+          ROOT::RFieldBase::Create("IdToParameterSetsBlobs", "std::pair<edm::Hash<1>,edm::ParameterSetBlob>").Unwrap();
       model->AddField(std::move(field));
     }
-    auto writeOptions = ROOT::Experimental::RNTupleWriteOptions();
+    auto writeOptions = ROOT::RNTupleWriteOptions();
     writeOptions.SetCompression(convert(iConfig.compressionAlgo), iConfig.compressionLevel);
-    parameterSets_ = ROOT::Experimental::RNTupleWriter::Append(std::move(model), "ParameterSets", file_, writeOptions);
+    parameterSets_ = ROOT::RNTupleWriter::Append(std::move(model), "ParameterSets", file_, writeOptions);
   }
 
   void RNTupleOutputFile::fillPSets() {
@@ -297,14 +293,14 @@ explicitly pass the correct variable to `SetColumnRepresentatives`).
   }
 
   void RNTupleOutputFile::setupParentage(Config const& iConfig) {
-    auto model = ROOT::Experimental::RNTupleModel::CreateBare();
+    auto model = ROOT::RNTupleModel::CreateBare();
     {
-      auto field = ROOT::Experimental::RFieldBase::Create("Description", "edm::Parentage").Unwrap();
+      auto field = ROOT::RFieldBase::Create("Description", "edm::Parentage").Unwrap();
       model->AddField(std::move(field));
     }
-    auto writeOptions = ROOT::Experimental::RNTupleWriteOptions();
+    auto writeOptions = ROOT::RNTupleWriteOptions();
     writeOptions.SetCompression(convert(iConfig.compressionAlgo), iConfig.compressionLevel);
-    parentage_ = ROOT::Experimental::RNTupleWriter::Append(std::move(model), "Parentage", file_, writeOptions);
+    parentage_ = ROOT::RNTupleWriter::Append(std::move(model), "Parentage", file_, writeOptions);
   }
   void RNTupleOutputFile::fillParentage() {
     ParentageRegistry& ptReg = *ParentageRegistry::instance();
@@ -324,54 +320,50 @@ explicitly pass the correct variable to `SetColumnRepresentatives`).
   }
 
   void RNTupleOutputFile::setupMetaData(Config const& iConfig) {
-    auto model = ROOT::Experimental::RNTupleModel::CreateBare();
+    auto model = ROOT::RNTupleModel::CreateBare();
     {
       //Ultimately will need a new class specific for RNTuple
-      //auto field = ROOT::Experimental::RFieldBase::Create("FileFormatVersion", "edm::FileFormatVersion").Unwrap();
+      //auto field = ROOT::RFieldBase::Create("FileFormatVersion", "edm::FileFormatVersion").Unwrap();
       //model->AddField(std::move(field));
     }
     {
-      auto field = ROOT::Experimental::RFieldBase::Create("FileIdentifier", "edm::FileID").Unwrap();
+      auto field = ROOT::RFieldBase::Create("FileIdentifier", "edm::FileID").Unwrap();
       model->AddField(std::move(field));
     }
 
     {
-      auto field = ROOT::Experimental::RFieldBase::Create("IndexIntoFile", "edm::IndexIntoFile").Unwrap();
-      model->AddField(std::move(field));
-    }
-    {
-      auto field = ROOT::Experimental::RFieldBase::Create("MergeableRunProductMetadata",
-                                                          "edm::StoredMergeableRunProductMetadata")
-                       .Unwrap();
+      auto field = ROOT::RFieldBase::Create("IndexIntoFile", "edm::IndexIntoFile").Unwrap();
       model->AddField(std::move(field));
     }
     {
       auto field =
-          ROOT::Experimental::RFieldBase::Create("ProcessHistory", "std::vector<edm::ProcessHistory>").Unwrap();
+          ROOT::RFieldBase::Create("MergeableRunProductMetadata", "edm::StoredMergeableRunProductMetadata").Unwrap();
       model->AddField(std::move(field));
     }
     {
-      auto field = ROOT::Experimental::RFieldBase::Create("ProductRegistry", "edm::ProductRegistry").Unwrap();
+      auto field = ROOT::RFieldBase::Create("ProcessHistory", "std::vector<edm::ProcessHistory>").Unwrap();
       model->AddField(std::move(field));
     }
     {
-      auto field =
-          ROOT::Experimental::RFieldBase::Create("BranchIDLists", "std::vector<std::vector<unsigned int> >").Unwrap();
+      auto field = ROOT::RFieldBase::Create("ProductRegistry", "edm::ProductRegistry").Unwrap();
       model->AddField(std::move(field));
     }
     {
-      auto field =
-          ROOT::Experimental::RFieldBase::Create("ThinnedAssociationsHelper", "edm::ThinnedAssociationsHelper").Unwrap();
+      auto field = ROOT::RFieldBase::Create("BranchIDLists", "std::vector<std::vector<unsigned int> >").Unwrap();
       model->AddField(std::move(field));
     }
     {
-      auto field = ROOT::Experimental::RFieldBase::Create("ProductDependencies", "edm::BranchChildren").Unwrap();
+      auto field = ROOT::RFieldBase::Create("ThinnedAssociationsHelper", "edm::ThinnedAssociationsHelper").Unwrap();
+      model->AddField(std::move(field));
+    }
+    {
+      auto field = ROOT::RFieldBase::Create("ProductDependencies", "edm::BranchChildren").Unwrap();
       model->AddField(std::move(field));
     }
 
-    auto writeOptions = ROOT::Experimental::RNTupleWriteOptions();
+    auto writeOptions = ROOT::RNTupleWriteOptions();
     writeOptions.SetCompression(convert(iConfig.compressionAlgo), iConfig.compressionLevel);
-    metaData_ = ROOT::Experimental::RNTupleWriter::Append(std::move(model), "MetaData", file_, writeOptions);
+    metaData_ = ROOT::RNTupleWriter::Append(std::move(model), "MetaData", file_, writeOptions);
   }
 
   void RNTupleOutputFile::fillMetaData(BranchIDLists const& iBranchIDLists,

--- a/FWIO/RNTuple/plugins/RNTupleOutputFile.h
+++ b/FWIO/RNTuple/plugins/RNTupleOutputFile.h
@@ -29,7 +29,6 @@
 #include <set>
 #include <array>
 
-using namespace ROOT::Experimental;
 namespace edm {
   namespace rntuple {
     enum class CompressionAlgos { kLZMA, kZSTD, kZLIB, kLZ4 };
@@ -71,20 +70,20 @@ namespace edm {
     void openFile(FileBlock const& fb);
 
     struct Product {
-      Product(EDGetToken iGet, ProductDescription const* iDesc, REntry::RFieldToken iField)
+      Product(EDGetToken iGet, ProductDescription const* iDesc, ROOT::RFieldToken iField)
           : get_(iGet), desc_(iDesc), field_(iField) {}
 
       EDGetToken get_;
       ProductDescription const* desc_;
-      REntry::RFieldToken field_;
+      ROOT::RFieldToken field_;
     };
 
   private:
     void setupRuns(SelectedProducts const&, Config const&);
     void setupLumis(SelectedProducts const&, Config const&);
-    std::unique_ptr<RNTupleModel> setupCommonModels(SelectedProducts const&,
-                                                    std::string const& iAuxName,
-                                                    std::string const& iAuxType);
+    std::unique_ptr<ROOT::RNTupleModel> setupCommonModels(SelectedProducts const&,
+                                                          std::string const& iAuxName,
+                                                          std::string const& iAuxType);
     void setupEvents(SelectedProducts const&, Config const&, bool anyProductProduced);
     void setupPSets(Config const&);
     void setupParentage(Config const&);
@@ -99,13 +98,13 @@ namespace edm {
     void setupDataProducts(SelectedProducts const&,
                            std::vector<bool> const&,
                            std::vector<std::string> const&,
-                           RNTupleModel&);
+                           ROOT::RNTupleModel&);
     //Can't call until the model is frozen
-    std::vector<Product> associateDataProducts(SelectedProducts const&, RNTupleModel const&);
+    std::vector<Product> associateDataProducts(SelectedProducts const&, ROOT::RNTupleModel const&);
 
     std::vector<std::unique_ptr<edm::WrapperBase>> writeDataProducts(std::vector<Product> const& iProduct,
                                                                      OccurrenceForOutput const& iOccurence,
-                                                                     REntry&);
+                                                                     ROOT::REntry&);
     std::vector<StoredProductProvenance> writeDataProductProvenance(std::vector<Product> const& iProduct,
                                                                     EventForOutput const& iEvent);
     bool insertProductProvenance(ProductProvenance const& iProv, std::set<StoredProductProvenance>& oToKeep);
@@ -113,21 +112,21 @@ namespace edm {
                                    ProductProvenanceRetriever const&,
                                    std::set<StoredProductProvenance>& oToKeep);
     TFile file_;
-    std::unique_ptr<RNTupleWriter> events_;
-    std::optional<REntry::RFieldToken> eventAuxField_;
-    std::optional<REntry::RFieldToken> eventProvField_;
-    std::optional<REntry::RFieldToken> eventSelField_;
-    std::optional<REntry::RFieldToken> branchListField_;
+    std::unique_ptr<ROOT::RNTupleWriter> events_;
+    std::optional<ROOT::RFieldToken> eventAuxField_;
+    std::optional<ROOT::RFieldToken> eventProvField_;
+    std::optional<ROOT::RFieldToken> eventSelField_;
+    std::optional<ROOT::RFieldToken> branchListField_;
 
-    std::unique_ptr<RNTupleWriter> runs_;
-    std::optional<REntry::RFieldToken> runAuxField_;
+    std::unique_ptr<ROOT::RNTupleWriter> runs_;
+    std::optional<ROOT::RFieldToken> runAuxField_;
 
-    std::unique_ptr<RNTupleWriter> lumis_;
-    std::optional<REntry::RFieldToken> lumiAuxField_;
+    std::unique_ptr<ROOT::RNTupleWriter> lumis_;
+    std::optional<ROOT::RFieldToken> lumiAuxField_;
 
-    std::unique_ptr<RNTupleWriter> parameterSets_;
-    std::unique_ptr<RNTupleWriter> parentage_;
-    std::unique_ptr<RNTupleWriter> metaData_;
+    std::unique_ptr<ROOT::RNTupleWriter> parameterSets_;
+    std::unique_ptr<ROOT::RNTupleWriter> parentage_;
+    std::unique_ptr<ROOT::RNTupleWriter> metaData_;
 
     std::map<ParentageID, unsigned int> parentageIDs_;
     ProcessHistoryRegistry processHistoryRegistry_;

--- a/FWIO/RNTuple/plugins/RNTupleOutputModule.cc
+++ b/FWIO/RNTuple/plugins/RNTupleOutputModule.cc
@@ -26,7 +26,7 @@
 #include <regex>
 #include "boost/algorithm/string.hpp"
 
-using namespace ROOT::Experimental;
+using namespace ROOT;
 
 namespace {
   edm::rntuple::CompressionAlgos convertTo(std::string const& iName) {
@@ -206,7 +206,7 @@ namespace edm {
         ->setComment(
             "Algorithm used to compress data in the ROOT output file, allowed values are ZLIB, LZMA, LZ4, and ZSTD");
     desc.addUntracked<int>("compressionLevel", 4)->setComment("ROOT compression level of output file.");
-    ROOT::Experimental::RNTupleWriteOptions ops;
+    ROOT::RNTupleWriteOptions ops;
     desc.addUntracked<unsigned long long>("approxZippedClusterSize", ops.GetApproxZippedClusterSize())
         ->setComment("Approximation of the target compressed cluster size");
     desc.addUntracked<unsigned long long>("maxUnzippedClusterSize", ops.GetMaxUnzippedClusterSize())

--- a/FWIO/RNTuple/plugins/RNTupleSource.cc
+++ b/FWIO/RNTuple/plugins/RNTupleSource.cc
@@ -56,7 +56,7 @@ namespace edm {
       std::recursive_mutex* mutex_;
       std::vector<ParentageID> const* parentageIDLookup_;
       std::vector<int>::const_iterator entryBegin_;
-      ROOT::Experimental::DescriptorId_t descriptor_;
+      ROOT::DescriptorId_t descriptor_;
     };
 
     std::set<ProductProvenance> ProvenanceReader::readProvenance(unsigned int transitionIndex) const {
@@ -161,9 +161,9 @@ namespace edm {
 
     EventToProcessBlockIndexes processBlockIndexes_;
 
-    ROOT::Experimental::DescriptorId_t eventSelectionsID_;
-    ROOT::Experimental::DescriptorId_t eventProductProvenanceID_;
-    ROOT::Experimental::DescriptorId_t eventBranchListIndexesID_;
+    ROOT::DescriptorId_t eventSelectionsID_;
+    ROOT::DescriptorId_t eventProductProvenanceID_;
+    ROOT::DescriptorId_t eventBranchListIndexesID_;
     bool enableMetrics_ = false;
     bool useClusterCache_ = true;
     bool startedFirstFile_ = false;


### PR DESCRIPTION
#### PR description:

This updates the RNTuple code to a newer version of the ROOT APIs.

#### PR validation:

This was built against CMSSW_15_1_ROOT6_X_2025-04-16-2300. This can NOT be integrated into the RNTUPLE branch until that branch has been updated to use a newer version of ROOT.

resolves https://github.com/cms-sw/framework-team/issues/1355