### PR TITLE
btvNano: store all PS weights

### DIFF
--- a/PhysicsTools/NanoAOD/python/btvMC_cff.py
+++ b/PhysicsTools/NanoAOD/python/btvMC_cff.py
@@ -11,6 +11,8 @@ def addGenCands(process, allPF = False, addAK4=False, addAK8=False):
     process.btvGenTask = cms.Task()
     process.schedule.associate(process.btvGenTask)
 
+    process.genWeightsTable.keepAllPSWeights = True
+
     process.finalGenParticles.select +=[
             "keep (4 <= abs(pdgId) <= 5) && statusFlags().isLastCopy()", # BTV: keep b/c quarks in their last copy
             "keep (abs(pdgId) == 310 || abs(pdgId) == 3122) && statusFlags().isLastCopy()", # BTV: keep K0s and Lambdas in their last copy


### PR DESCRIPTION
#### PR description:

Store all PS weights potentially useful for fine-grained systematics, as done in [JMENano](https://github.com/cms-sw/cmssw/blob/master/PhysicsTools/NanoAOD/python/custom_jme_cff.py#L1508) and discussed in https://gitlab.cern.ch/cms-gen/mccm/-/issues/649

Backport to 15_0 following

#### PR validation:

```
Pass    7s ... PhysicsTools/NanoAOD/testPhysicsToolsNanoAODTP                                                                                                        
Pass   63s ... PhysicsTools/NanoAOD/test-btvNano-run                                                                                                                 
Pass    4s ... PhysicsTools/NanoAOD/test-btvNano-check                         
>> Test sequence completed for CMSSW CMSSW_15_1_X_2025-04-17-1100 
```

```
Events->Scan("nPSWeight")
************************
*    Row   * nPSWeight *
************************
*        0 *        44 *
*        1 *        44 *
*        2 *        44 *
...
```
