### PR TITLE
[15.0.X] add `DQMEventInfo` instance to the sequence run `OfflineHLTMonitoring`

### DIFF
--- a/DQMOffline/Trigger/python/DQMOffline_Trigger_cosmics_cff.py
+++ b/DQMOffline/Trigger/python/DQMOffline_Trigger_cosmics_cff.py
@@ -75,5 +75,7 @@ triggerCosmicOfflineDQMSource = cms.Sequence(offlineHLTSource)
 # sequences run @tier0 on CosmicHLTMonitor PD
 OfflineHLTMonitoring = cms.Sequence(
     cosmicTrackingMonitorHLT *
-    hltToOfflineCosmicsTrackValidatorSequence
+    hltToOfflineCosmicsTrackValidatorSequence *
+    dqmEnvHLT *
+    dqmInfoHLTMon
 )


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/47907

#### PR description:

This is a follow-up to https://github.com/cms-sw/cmssw/pull/47746.
The necessary modules to display in the GUI the correct information about the global tag used as well as the events information are now added to the sequence which is actually run at Tier0.

#### PR validation:

`cmssw` compiles

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/47907 to the 2025 data-taking release.