### PR TITLE
[15_0_X] Add customization for the SerialSync tracking sequence in the mkFit HLT customizer

### DIFF
--- a/RecoTracker/MkFit/python/customizeHLTIter0ToMkFit.py
+++ b/RecoTracker/MkFit/python/customizeHLTIter0ToMkFit.py
@@ -149,7 +149,30 @@ def customizeHLTIter0ToMkFit(process):
         dz_exp = cms.vint32( 4, 4, 4 )
     )
 
-    if hasattr(process, 'hltIter0PFlowTrackCutClassifierSerialSync'):
+    if hasattr(process, 'HLTIterativeTrackingIteration0SerialSync'):
+        process.hltIter0PFlowCkfTrackCandidatesMkFitSiPixelHitsSerialSync = process.hltIter0PFlowCkfTrackCandidatesMkFitSiPixelHits.clone(
+            hits = "hltSiPixelRecHitsSerialSync",
+            clusters = "hltSiPixelClustersSerialSync",
+        )
+        process.hltIter0PFlowCkfTrackCandidatesMkFitEventOfHitsSerialSync = process.hltIter0PFlowCkfTrackCandidatesMkFitEventOfHits.clone(
+            pixelHits = "hltIter0PFlowCkfTrackCandidatesMkFitSiPixelHitsSerialSync",
+        )
+        process.hltIter0PFlowCkfTrackCandidatesMkFitSeedsSerialSync = process.hltIter0PFlowCkfTrackCandidatesMkFitSeeds.clone(
+            seeds = "hltIter0PFLowPixelSeedsFromPixelTracksSerialSync",
+        )
+        process.hltIter0PFlowCkfTrackCandidatesMkFitSerialSync = process.hltIter0PFlowCkfTrackCandidatesMkFit.clone(
+            pixelHits = "hltIter0PFlowCkfTrackCandidatesMkFitSiPixelHitsSerialSync",
+            eventOfHits = "hltIter0PFlowCkfTrackCandidatesMkFitEventOfHitsSerialSync",
+            seeds = "hltIter0PFlowCkfTrackCandidatesMkFitSeedsSerialSync",
+        )
+        process.hltIter0PFlowCkfTrackCandidatesSerialSync = process.hltIter0PFlowCkfTrackCandidates.clone(
+            seeds = "hltIter0PFLowPixelSeedsFromPixelTracksSerialSync",
+            mkFitEventOfHits = "hltIter0PFlowCkfTrackCandidatesMkFitEventOfHitsSerialSync",
+            mkFitPixelHits = "hltIter0PFlowCkfTrackCandidatesMkFitSiPixelHitsSerialSync",
+            mkFitSeeds = "hltIter0PFlowCkfTrackCandidatesMkFitSeedsSerialSync",
+            tracks = "hltIter0PFlowCkfTrackCandidatesMkFitSerialSync",
+        )
+
         process.hltIter0PFlowTrackCutClassifierSerialSync.mva.maxChi2 = cms.vdouble( 999.0, 25.0, 99.0 )
         process.hltIter0PFlowTrackCutClassifierSerialSync.mva.maxChi2n = cms.vdouble( 1.2, 1.0, 999.0 )
         process.hltIter0PFlowTrackCutClassifierSerialSync.mva.dr_par = cms.PSet( 
@@ -164,6 +187,21 @@ def customizeHLTIter0ToMkFit(process):
             dz_par2 = cms.vdouble( 3.40282346639E38, 0.51, 0.51 ),
             dz_exp = cms.vint32( 4, 4, 4 )
         )
+        process.HLTDoLocalStripSequenceSerialSync += process.hltSiStripRecHits
+
+        replaceWithSerialSync = (process.hltIter0PFlowCkfTrackCandidatesMkFitSiPixelHitsSerialSync +
+                   process.hltIter0PFlowCkfTrackCandidatesMkFitSiStripHits +
+                   process.hltIter0PFlowCkfTrackCandidatesMkFitEventOfHitsSerialSync +
+                   process.hltIter0PFlowCkfTrackCandidatesMkFitSeedsSerialSync +
+                   process.hltIter0PFlowCkfTrackCandidatesMkFitSerialSync +
+                   process.hltIter0PFlowCkfTrackCandidatesSerialSync)
+
+        process.HLTIterativeTrackingIteration0SerialSync.replace(process.hltIter0PFlowCkfTrackCandidatesSerialSync, replaceWithSerialSync)
+
+        for path in process.paths_().values():
+            if not path.contains(process.HLTIterativeTrackingIteration0SerialSync) and path.contains(process.hltIter0PFlowCkfTrackCandidatesSerialSync):
+                path.replace(process.hltIter0PFlowCkfTrackCandidatesSerialSync, replaceWithSerialSync)
+
 
     return process
 


### PR DESCRIPTION
#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

The customizer to use mkFit in the iter0 tracking iteration at HLT was only modifying the standard tracking sequence, but not most of the SerialSync sequences and modules.
This PR fixes that, by adding new SerialSync modules depending on pixel SerialSync sequences and modifying the `HLTIterativeTrackingIteration0SerialSync` sequence accordingly

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

Verified that the provided customizer produces a runnable configuration. Verified that the configuration produced by the customizers matches the tracking updates recently integrated in the HLT menu.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
Backport of #47916 

cc @mmusich @mmasciov @kskovpen 