### PR TITLE
[15_0_X]  Optimizations for the MkFit converters

### DIFF
--- a/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitConverterAlgorithm.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitConverterAlgorithm.h
@@ -2,10 +2,13 @@
 #define SiStripRecHitConverterAlgorithm_h
 
 #include "FWCore/Utilities/interface/ESGetToken.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2DCollection.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2DCollection.h"
 #include "DataFormats/GeometryVector/interface/LocalVector.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitMatcher.h"
@@ -47,8 +50,14 @@ public:
 
   SiStripRecHitConverterAlgorithm(const edm::ParameterSet&, edm::ConsumesCollector);
   void initialize(const edm::EventSetup&);
-  void run(edm::Handle<edmNew::DetSetVector<SiStripCluster> > input, products& output);
-  void run(edm::Handle<edmNew::DetSetVector<SiStripCluster> > input, products& output, LocalVector trackdirection);
+  SiStripRecHitConverterAlgorithm initializedClone(const edm::EventSetup&) const;
+  template <typename... ExtraFillers>
+  void run(edm::Handle<edmNew::DetSetVector<SiStripCluster>> input, products& output, ExtraFillers&&... extra_fillers);
+  template <typename... ExtraFillers>
+  void run(edm::Handle<edmNew::DetSetVector<SiStripCluster>> input,
+           products& output,
+           LocalVector trackdirection,
+           ExtraFillers&&... extra_fillers);
 
   static void fillPSetDescription(edm::ParameterSetDescription& desc);
 
@@ -70,5 +79,95 @@ private:
 
   typedef SiStripRecHit2DCollection::FastFiller Collector;
 };
+
+template <typename... ExtraFillers>
+void SiStripRecHitConverterAlgorithm::run(edm::Handle<edmNew::DetSetVector<SiStripCluster>> input,
+                                          products& output,
+                                          ExtraFillers&&... extra_fillers) {
+  run(input, output, LocalVector(0., 0., 0.), std::forward<ExtraFillers>(extra_fillers)...);
+}
+
+template <typename... ExtraFillers>
+void SiStripRecHitConverterAlgorithm::run(edm::Handle<edmNew::DetSetVector<SiStripCluster>> inputhandle,
+                                          products& output,
+                                          LocalVector trackdirection,
+                                          ExtraFillers&&... extra_fillers) {
+  auto const inputID = inputhandle.id();
+  unsigned int nIDs[2]{};
+  unsigned int nCs[2]{};
+  for (auto const& DS : *inputhandle) {
+    auto id = DS.id();
+    if (!useModule(id))
+      continue;
+
+    unsigned int iStereo = StripSubdetector(id).stereo();
+    nIDs[iStereo]++;
+
+    bool bad128StripBlocks[6];
+    fillBad128StripBlocks(id, bad128StripBlocks);
+
+    for (auto const& cluster : DS) {
+      if (isMasked(cluster, bad128StripBlocks))
+        continue;
+
+      nCs[iStereo]++;
+    }
+  }
+  output.rphi->reserve(nIDs[0], nCs[0]);
+  output.stereo->reserve(nIDs[1], nCs[1]);
+
+  for (auto const& DS : *inputhandle) {
+    auto id = DS.id();
+    if (!useModule(id))
+      continue;
+
+    Collector collector = StripSubdetector(id).stereo() ? Collector(*output.stereo, id) : Collector(*output.rphi, id);
+
+    bool bad128StripBlocks[6];
+    fillBad128StripBlocks(id, bad128StripBlocks);
+
+    GeomDetUnit const& du = *(tracker->idToDetUnit(id));
+    for (auto const& cluster : DS) {
+      if (isMasked(cluster, bad128StripBlocks))
+        continue;
+
+      StripClusterParameterEstimator::LocalValues parameters = parameterestimator->localParameters(cluster, du);
+      OmniClusterRef clusterRef(inputID, &cluster, DS.makeKeyOf(&cluster));
+      collector.push_back(SiStripRecHit2D(parameters.first, parameters.second, du, clusterRef));
+
+      (..., extra_fillers.fill(*inputhandle, clusterRef.index(), collector.back(), id, du));
+    }
+
+    if (collector.empty())
+      collector.abort();
+  }
+  if (doMatching) {
+    match(output, trackdirection);
+  }
+}
+
+inline bool SiStripRecHitConverterAlgorithm::isMasked(const SiStripCluster& cluster, bool bad128StripBlocks[6]) const {
+  if (maskBad128StripBlocks) {
+    if (bad128StripBlocks[cluster.firstStrip() >> 7]) {
+      if (bad128StripBlocks[(cluster.firstStrip() + cluster.amplitudes().size()) >> 7] ||
+          bad128StripBlocks[static_cast<int32_t>(cluster.barycenter() - 0.499999) >> 7]) {
+        return true;
+      }
+    } else {
+      if (bad128StripBlocks[(cluster.firstStrip() + cluster.amplitudes().size()) >> 7] &&
+          bad128StripBlocks[static_cast<int32_t>(cluster.barycenter() - 0.499999) >> 7]) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+inline bool SiStripRecHitConverterAlgorithm::useModule(const uint32_t id) const {
+  const StripGeomDetUnit* stripdet = (const StripGeomDetUnit*)tracker->idToDetUnit(id);
+  if (stripdet == nullptr)
+    edm::LogWarning("SiStripRecHitConverter") << "Detid=" << id << " not found";
+  return stripdet != nullptr && (!useQuality || quality->IsModuleUsable(id));
+}
 
 #endif

--- a/RecoTracker/MkFit/plugins/BuildFile.xml
+++ b/RecoTracker/MkFit/plugins/BuildFile.xml
@@ -22,6 +22,7 @@
   <use name="Geometry/Records"/>
   <use name="Geometry/TrackerGeometryBuilder"/>
   <use name="PhysicsTools/TensorFlow"/>
+  <use name="RecoLocalTracker/SiStripRecHitConverter"/>
   <use name="RecoTracker/MkFit"/>
   <use name="RecoTracker/TkDetLayers"/>
   <use name="RecoTracker/TransientTrackingRecHit"/>

--- a/RecoTracker/MkFit/plugins/MkFitEventOfHitsProducer.cc
+++ b/RecoTracker/MkFit/plugins/MkFitEventOfHitsProducer.cc
@@ -45,6 +45,8 @@ private:
   const edm::EDGetTokenT<MkFitHitWrapper> stripHitsToken_;
   const edm::EDGetTokenT<std::vector<int>> pixelLayerIndexToHitToken_;
   const edm::EDGetTokenT<std::vector<int>> stripLayerIndexToHitToken_;
+  const edm::EDGetTokenT<std::vector<unsigned int>> pixelLayerSizeToken_;
+  const edm::EDGetTokenT<std::vector<unsigned int>> stripLayerSizeToken_;
   const edm::ESGetToken<MkFitGeometry, TrackerRecoGeometryRecord> mkFitGeomToken_;
   edm::ESGetToken<SiPixelQuality, SiPixelQualityRcd> pixelQualityToken_;
   edm::ESGetToken<SiStripQuality, SiStripQualityRcd> stripQualityToken_;
@@ -60,6 +62,8 @@ MkFitEventOfHitsProducer::MkFitEventOfHitsProducer(edm::ParameterSet const& iCon
       stripHitsToken_{consumes(iConfig.getParameter<edm::InputTag>("stripHits"))},
       pixelLayerIndexToHitToken_{consumes(iConfig.getParameter<edm::InputTag>("pixelHits"))},
       stripLayerIndexToHitToken_{consumes(iConfig.getParameter<edm::InputTag>("stripHits"))},
+      pixelLayerSizeToken_{consumes(iConfig.getParameter<edm::InputTag>("pixelHits"))},
+      stripLayerSizeToken_{consumes(iConfig.getParameter<edm::InputTag>("stripHits"))},
       mkFitGeomToken_{esConsumes()},
       putToken_{produces<MkFitEventOfHits>()},
       usePixelQualityDB_{iConfig.getParameter<bool>("usePixelQualityDB")},
@@ -166,6 +170,14 @@ void MkFitEventOfHitsProducer::produce(edm::StreamID iID, edm::Event& iEvent, co
       }
     }
     mkfit::StdSeq::loadDeads(*eventOfHits, deadvectors);
+  }
+
+  auto& pixelLayerSize = iEvent.get(pixelLayerSizeToken_);
+  auto& stripLayerSize = iEvent.get(stripLayerSizeToken_);
+
+  for (int iLay = 0; iLay < eventOfHits->nLayers(); iLay++) {
+    int nhits = pixelLayerSize[iLay] + stripLayerSize[iLay];
+    (*eventOfHits)[iLay].reserve(nhits);
   }
 
   fill(iEvent.get(pixelLayerIndexToHitToken_), *eventOfHits, mkFitGeom);

--- a/RecoTracker/MkFit/plugins/MkFitPhase2HitConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitPhase2HitConverter.cc
@@ -52,6 +52,7 @@ private:
   const edm::EDPutTokenT<MkFitHitWrapper> wrapperPutToken_;
   const edm::EDPutTokenT<MkFitClusterIndexToHit> clusterIndexPutToken_;
   const edm::EDPutTokenT<std::vector<int>> layerIndexPutToken_;
+  const edm::EDPutTokenT<std::vector<unsigned int>> layerSizePutToken_;
   const edm::EDPutTokenT<std::vector<float>> clusterChargePutToken_;
   const ConvertHitTraitsPhase2 convertTraits_;
 };
@@ -65,6 +66,7 @@ MkFitPhase2HitConverter::MkFitPhase2HitConverter(edm::ParameterSet const& iConfi
       wrapperPutToken_{produces()},
       clusterIndexPutToken_{produces()},
       layerIndexPutToken_{produces()},
+      layerSizePutToken_{produces()},
       clusterChargePutToken_{produces()},
       convertTraits_{} {}
 
@@ -87,6 +89,7 @@ void MkFitPhase2HitConverter::produce(edm::StreamID iID, edm::Event& iEvent, con
   MkFitClusterIndexToHit clusterIndexToHit;
   std::vector<int> layerIndexToHit;
   std::vector<float> clusterCharge;
+  std::vector<unsigned int> layerSize(mkFitGeom.trackerInfo().n_layers(), 0);
 
   edm::ProductID stripClusterID;
   const auto& phase2Hits = iEvent.get(siPhase2RecHitToken_);
@@ -98,6 +101,7 @@ void MkFitPhase2HitConverter::produce(edm::StreamID iID, edm::Event& iEvent, con
                                         hitWrapper.hits(),
                                         clusterIndexToHit.hits(),
                                         layerIndexToHit,
+                                        layerSize,
                                         dummy,
                                         ttopo,
                                         ttrhBuilder,
@@ -110,6 +114,7 @@ void MkFitPhase2HitConverter::produce(edm::StreamID iID, edm::Event& iEvent, con
   iEvent.emplace(wrapperPutToken_, std::move(hitWrapper));
   iEvent.emplace(clusterIndexPutToken_, std::move(clusterIndexToHit));
   iEvent.emplace(layerIndexPutToken_, std::move(layerIndexToHit));
+  iEvent.emplace(layerSizePutToken_, std::move(layerSize));
   iEvent.emplace(clusterChargePutToken_, std::move(clusterCharge));
 }
 

--- a/RecoTracker/MkFit/plugins/MkFitSiPixelHitConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitSiPixelHitConverter.cc
@@ -51,6 +51,7 @@ private:
   const edm::EDPutTokenT<MkFitHitWrapper> wrapperPutToken_;
   const edm::EDPutTokenT<MkFitClusterIndexToHit> clusterIndexPutToken_;
   const edm::EDPutTokenT<std::vector<int>> layerIndexPutToken_;
+  const edm::EDPutTokenT<std::vector<unsigned int>> layerSizePutToken_;
 };
 
 MkFitSiPixelHitConverter::MkFitSiPixelHitConverter(edm::ParameterSet const& iConfig)
@@ -61,7 +62,8 @@ MkFitSiPixelHitConverter::MkFitSiPixelHitConverter(edm::ParameterSet const& iCon
       mkFitGeomToken_{esConsumes()},
       wrapperPutToken_{produces()},
       clusterIndexPutToken_{produces()},
-      layerIndexPutToken_{produces()} {}
+      layerIndexPutToken_{produces()},
+      layerSizePutToken_{produces()} {}
 
 void MkFitSiPixelHitConverter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
@@ -81,6 +83,7 @@ void MkFitSiPixelHitConverter::produce(edm::StreamID iID, edm::Event& iEvent, co
   MkFitHitWrapper hitWrapper;
   MkFitClusterIndexToHit clusterIndexToHit;
   std::vector<int> layerIndexToHit;
+  std::vector<unsigned int> layerSize(mkFitGeom.trackerInfo().n_layers(), 0);
 
   std::vector<float> dummy;
   auto const& hits = iEvent.get(pixelRecHitToken_);
@@ -90,6 +93,7 @@ void MkFitSiPixelHitConverter::produce(edm::StreamID iID, edm::Event& iEvent, co
                                            hitWrapper.hits(),
                                            clusterIndexToHit.hits(),
                                            layerIndexToHit,
+                                           layerSize,
                                            dummy,
                                            ttopo,
                                            ttrhBuilder,
@@ -101,6 +105,7 @@ void MkFitSiPixelHitConverter::produce(edm::StreamID iID, edm::Event& iEvent, co
   iEvent.emplace(wrapperPutToken_, std::move(hitWrapper));
   iEvent.emplace(clusterIndexPutToken_, std::move(clusterIndexToHit));
   iEvent.emplace(layerIndexPutToken_, std::move(layerIndexToHit));
+  iEvent.emplace(layerSizePutToken_, std::move(layerSize));
 }
 
 DEFINE_FWK_MODULE(MkFitSiPixelHitConverter);

--- a/RecoTracker/MkFit/plugins/MkFitSiStripHitConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitSiStripHitConverter.cc
@@ -58,6 +58,7 @@ private:
   const edm::EDPutTokenT<MkFitHitWrapper> wrapperPutToken_;
   const edm::EDPutTokenT<MkFitClusterIndexToHit> clusterIndexPutToken_;
   const edm::EDPutTokenT<std::vector<int>> layerIndexPutToken_;
+  const edm::EDPutTokenT<std::vector<unsigned int>> layerSizePutToken_;
   const edm::EDPutTokenT<std::vector<float>> clusterChargePutToken_;
   const ConvertHitTraits convertTraits_;
 };
@@ -72,6 +73,7 @@ MkFitSiStripHitConverter::MkFitSiStripHitConverter(edm::ParameterSet const& iCon
       wrapperPutToken_{produces()},
       clusterIndexPutToken_{produces()},
       layerIndexPutToken_{produces()},
+      layerSizePutToken_{produces()},
       clusterChargePutToken_{produces()},
       convertTraits_{static_cast<float>(
           iConfig.getParameter<edm::ParameterSet>("minGoodStripCharge").getParameter<double>("value"))} {}
@@ -100,6 +102,7 @@ void MkFitSiStripHitConverter::produce(edm::StreamID iID, edm::Event& iEvent, co
   MkFitClusterIndexToHit clusterIndexToHit;
   std::vector<int> layerIndexToHit;
   std::vector<float> clusterCharge;
+  std::vector<unsigned int> layerSize(mkFitGeom.trackerInfo().n_layers(), 0);
 
   edm::ProductID stripClusterID;
   const auto& stripRphiHits = iEvent.get(stripRphiRecHitToken_);
@@ -114,6 +117,7 @@ void MkFitSiStripHitConverter::produce(edm::StreamID iID, edm::Event& iEvent, co
                               hitWrapper.hits(),
                               clusterIndexToHit.hits(),
                               layerIndexToHit,
+                              layerSize,
                               clusterCharge,
                               ttopo,
                               ttrhBuilder,
@@ -139,6 +143,7 @@ void MkFitSiStripHitConverter::produce(edm::StreamID iID, edm::Event& iEvent, co
   iEvent.emplace(wrapperPutToken_, std::move(hitWrapper));
   iEvent.emplace(clusterIndexPutToken_, std::move(clusterIndexToHit));
   iEvent.emplace(layerIndexPutToken_, std::move(layerIndexToHit));
+  iEvent.emplace(layerSizePutToken_, std::move(layerSize));
   iEvent.emplace(clusterChargePutToken_, std::move(clusterCharge));
 }
 

--- a/RecoTracker/MkFit/plugins/MkFitSiStripHitConverterFromClusters.cc
+++ b/RecoTracker/MkFit/plugins/MkFitSiStripHitConverterFromClusters.cc
@@ -1,0 +1,184 @@
+#include "FWCore/Framework/interface/global/EDProducer.h"
+
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/SiStripCluster/interface/SiStripClusterTools.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2DCollection.h"
+
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/TrackerCommon/interface/TrackerDetSide.h"
+
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+
+#include "TrackingTools/Records/interface/TransientRecHitRecord.h"
+#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
+
+#include "RecoTracker/MkFit/interface/MkFitHitWrapper.h"
+#include "RecoTracker/MkFit/interface/MkFitClusterIndexToHit.h"
+#include "RecoTracker/MkFit/interface/MkFitGeometry.h"
+#include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
+
+#include "RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitConverterAlgorithm.h"
+
+// ROOT
+#include "Math/SVector.h"
+#include "Math/SMatrix.h"
+
+// mkFit includes
+#include "RecoTracker/MkFitCore/interface/Hit.h"
+#include "RecoTracker/MkFitCore/interface/HitStructures.h"
+
+#include "convertHits.h"
+
+namespace {
+  class ConvertHitTraits {
+  public:
+    ConvertHitTraits(float minCharge) : minGoodStripCharge_(minCharge) {}
+    using Clusters = edmNew::DetSetVector<SiStripCluster>;
+    using Cluster = Clusters::data_type;
+
+    static constexpr bool applyCCC() { return true; }
+    static float chargeScale(DetId id) { return siStripClusterTools::sensorThicknessInverse(id); }
+    static const Cluster& cluster(const Clusters& prod, unsigned int index) { return prod.data()[index]; }
+    static float clusterCharge(const Cluster& clu, float scale) { return clu.charge() * scale; }
+    bool passCCC(float charge) const { return charge > minGoodStripCharge_; }
+    static void setDetails(mkfit::Hit& mhit, const Cluster& clu, int shortId, float charge) {
+      mhit.setupAsStrip(shortId, charge, clu.size());
+    }
+
+  private:
+    const float minGoodStripCharge_;
+  };
+}  // namespace
+
+class MkFitSiStripHitConverterFromClusters : public edm::global::EDProducer<> {
+public:
+  explicit MkFitSiStripHitConverterFromClusters(edm::ParameterSet const& iConfig);
+  ~MkFitSiStripHitConverterFromClusters() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
+
+  const edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster>> stripClusterToken_;
+  const edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> ttrhBuilderToken_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> ttopoToken_;
+  const edm::ESGetToken<MkFitGeometry, TrackerRecoGeometryRecord> mkFitGeomToken_;
+  const edm::EDPutTokenT<MkFitHitWrapper> wrapperPutToken_;
+  const edm::EDPutTokenT<SiStripRecHit2DCollection> rphiRecHitPutToken_;
+  const edm::EDPutTokenT<SiStripRecHit2DCollection> stereoRecHitPutToken_;
+  const edm::EDPutTokenT<MkFitClusterIndexToHit> clusterIndexPutToken_;
+  const edm::EDPutTokenT<std::vector<int>> layerIndexPutToken_;
+  const edm::EDPutTokenT<std::vector<unsigned int>> layerSizePutToken_;
+  const edm::EDPutTokenT<std::vector<float>> clusterChargePutToken_;
+  edm::EDPutTokenT<SiStripMatchedRecHit2DCollection> matchedRecHitPutToken_;
+  edm::EDPutTokenT<SiStripRecHit2DCollection> rphiUnmatchedRecHitPutToken_;
+  edm::EDPutTokenT<SiStripRecHit2DCollection> stereoUnmatchedRecHitPutToken_;
+  const ConvertHitTraits convertTraits_;
+  SiStripRecHitConverterAlgorithm recHitConverterAlgorithm_;
+  bool doMatching;
+};
+
+MkFitSiStripHitConverterFromClusters::MkFitSiStripHitConverterFromClusters(edm::ParameterSet const& iConfig)
+    : stripClusterToken_{consumes(iConfig.getParameter<edm::InputTag>("clusters"))},
+      ttrhBuilderToken_{esConsumes(iConfig.getParameter<edm::ESInputTag>("ttrhBuilder"))},
+      ttopoToken_{esConsumes()},
+      mkFitGeomToken_{esConsumes()},
+      wrapperPutToken_{produces()},
+      rphiRecHitPutToken_{produces(iConfig.getParameter<std::string>("rphiRecHits"))},
+      stereoRecHitPutToken_{produces(iConfig.getParameter<std::string>("stereoRecHits"))},
+      clusterIndexPutToken_{produces()},
+      layerIndexPutToken_{produces()},
+      layerSizePutToken_{produces()},
+      clusterChargePutToken_{produces()},
+      convertTraits_{static_cast<float>(
+          iConfig.getParameter<edm::ParameterSet>("minGoodStripCharge").getParameter<double>("value"))},
+      recHitConverterAlgorithm_{iConfig, consumesCollector()},
+      doMatching(iConfig.getParameter<bool>("doMatching")) {
+  if (doMatching) {
+    matchedRecHitPutToken_ = produces(iConfig.getParameter<std::string>("matchedRecHits"));
+    rphiUnmatchedRecHitPutToken_ = produces(iConfig.getParameter<std::string>("rphiRecHits") + "Unmatched");
+    stereoUnmatchedRecHitPutToken_ = produces(iConfig.getParameter<std::string>("stereoRecHits") + "Unmatched");
+  }
+}
+
+void MkFitSiStripHitConverterFromClusters::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+
+  desc.add("clusters", edm::InputTag{"siStripClusters"});
+  desc.add("ttrhBuilder", edm::ESInputTag{"", "WithTrackAngle"});
+
+  desc.add<std::string>("rphiRecHits", "rphiRecHit");
+  desc.add<std::string>("stereoRecHits", "stereoRecHit");
+
+  SiStripRecHitConverterAlgorithm::fillPSetDescription(desc);
+
+  edm::ParameterSetDescription descCCC;
+  descCCC.add<double>("value");
+  desc.add("minGoodStripCharge", descCCC);
+
+  descriptions.add("mkFitSiStripHitConverterFromClustersDefault", desc);
+}
+
+void MkFitSiStripHitConverterFromClusters::produce(edm::StreamID iID,
+                                                   edm::Event& iEvent,
+                                                   const edm::EventSetup& iSetup) const {
+  const auto& ttrhBuilder = iSetup.getData(ttrhBuilderToken_);
+  const auto& ttopo = iSetup.getData(ttopoToken_);
+  const auto& mkFitGeom = iSetup.getData(mkFitGeomToken_);
+
+  MkFitHitWrapper hitWrapper;
+  MkFitClusterIndexToHit clusterIndexToHit;
+  std::vector<int> layerIndexToHit;
+  std::vector<float> clusterCharge;
+  std::vector<unsigned int> layerSize(mkFitGeom.trackerInfo().n_layers(), 0);
+
+  mkfit::MkFitHitFiller filler{convertTraits_,
+                               // outputs
+                               hitWrapper.hits(),
+                               clusterIndexToHit.hits(),
+                               layerIndexToHit,
+                               layerSize,
+                               clusterCharge,
+                               // conditions
+                               ttopo,
+                               ttrhBuilder,
+                               mkFitGeom};
+
+  SiStripRecHitConverterAlgorithm::products stripRecHits;
+
+  auto clusterH = iEvent.getHandle(stripClusterToken_);
+
+  auto const size = clusterH->dataSize();
+  hitWrapper.hits().resize(size);
+  clusterIndexToHit.hits().resize(size, nullptr);
+  layerIndexToHit.resize(size, -1);
+  if constexpr (ConvertHitTraits::applyCCC()) {
+    clusterCharge.resize(size, -1.f);
+  }
+
+  auto localAlgo = recHitConverterAlgorithm_.initializedClone(iSetup);
+  localAlgo.run(clusterH, stripRecHits, filler);
+
+  hitWrapper.setClustersID(clusterH.id());
+
+  iEvent.emplace(wrapperPutToken_, std::move(hitWrapper));
+  iEvent.put(rphiRecHitPutToken_, std::move(stripRecHits.rphi));
+  iEvent.put(stereoRecHitPutToken_, std::move(stripRecHits.stereo));
+  iEvent.emplace(clusterIndexPutToken_, std::move(clusterIndexToHit));
+  iEvent.emplace(layerIndexPutToken_, std::move(layerIndexToHit));
+  iEvent.emplace(layerSizePutToken_, std::move(layerSize));
+  iEvent.emplace(clusterChargePutToken_, std::move(clusterCharge));
+
+  if (doMatching) {
+    iEvent.put(matchedRecHitPutToken_, std::move(stripRecHits.matched));
+    iEvent.put(rphiUnmatchedRecHitPutToken_, std::move(stripRecHits.rphiUnmatched));
+    iEvent.put(stereoUnmatchedRecHitPutToken_, std::move(stripRecHits.stereoUnmatched));
+  }
+}
+
+DEFINE_FWK_MODULE(MkFitSiStripHitConverterFromClusters);

--- a/RecoTracker/MkFit/plugins/convertHits.h
+++ b/RecoTracker/MkFit/plugins/convertHits.h
@@ -28,6 +28,7 @@ namespace mkfit {
                              mkfit::HitVec& mkFitHits,
                              std::vector<TrackingRecHit const*>& clusterIndexToHit,
                              std::vector<int>& layerIndexToHit,
+                             std::vector<unsigned int>& layerSize,
                              std::vector<float>& clusterChargeVec,
                              const TrackerTopology& ttopo,
                              const TransientTrackingRecHitBuilder& ttrhBuilder,
@@ -100,6 +101,7 @@ namespace mkfit {
         if constexpr (Traits::applyCCC()) {
           clusterChargeVec[clusterIndex] = charge;
         }
+        layerSize[ilay]++;
 
         traits.setDetails(mkFitHits[clusterIndex], clu, uniqueIdInLayer, charge);
       }

--- a/RecoTracker/MkFit/plugins/convertHits.h
+++ b/RecoTracker/MkFit/plugins/convertHits.h
@@ -21,6 +21,78 @@
 #include "RecoTracker/MkFitCore/interface/HitStructures.h"
 
 namespace mkfit {
+  template <typename Traits>
+  struct MkFitHitFiller {
+    MkFitHitFiller(const Traits& traits,
+                   mkfit::HitVec& mkFitHits,
+                   std::vector<TrackingRecHit const*>& clusterIndexToHit,
+                   std::vector<int>& layerIndexToHit,
+                   std::vector<unsigned int>& layerSize,
+                   std::vector<float>& clusterChargeVec,
+                   const TrackerTopology& ttopo,
+                   const TransientTrackingRecHitBuilder& ttrhBuilder,
+                   const MkFitGeometry& mkFitGeom)
+        : traits{traits},
+          mkFitHits{mkFitHits},
+          clusterIndexToHit{clusterIndexToHit},
+          layerIndexToHit{layerIndexToHit},
+          layerSize{layerSize},
+          clusterChargeVec{clusterChargeVec},
+          ttopo{ttopo},
+          ttrhBuilder{ttrhBuilder},
+          mkFitGeom{mkFitGeom} {}
+
+    template <typename Clusters, typename Hit>
+    void fill(Clusters const& clusters, unsigned int clusterIndex, Hit const& hit, DetId detid, GeomDetUnit const& du) {
+      const auto ilay = mkFitGeom.mkFitLayerNumber(detid);
+      const auto uniqueIdInLayer = mkFitGeom.uniqueIdInLayer(ilay, detid.rawId());
+      const auto chargeScale = traits.chargeScale(detid);
+      const auto& surf = du.surface();
+
+      const auto& cluster = traits.cluster(clusters, clusterIndex);
+
+      const auto charge = traits.clusterCharge(cluster, chargeScale);
+
+      if (!traits.passCCC(charge))
+        return;
+
+      const auto& gpos = surf.toGlobal(hit.localPosition());
+      SVector3 pos(gpos.x(), gpos.y(), gpos.z());
+      const auto& gerr = ErrorFrameTransformer::transform(hit.localPositionError(), surf);
+      SMatrixSym33 err{{float(gerr.cxx()),
+                        float(gerr.cyx()),
+                        float(gerr.cyy()),
+                        float(gerr.czx()),
+                        float(gerr.czy()),
+                        float(gerr.czz())}};
+
+      LogTrace("MkFitHitConverter") << "Adding hit detid " << detid.rawId() << " subdet " << detid.subdetId()
+                                    << " layer " << ttopo.layer(detid) << " isStereo " << ttopo.isStereo(detid)
+                                    << " zplus "
+                                    << " index " << clusterIndex << " ilay " << ilay;
+
+      mkFitHits[clusterIndex] = mkfit::Hit(pos, err);
+      clusterIndexToHit[clusterIndex] = &hit;
+      layerIndexToHit[clusterIndex] = ilay;
+      if constexpr (Traits::applyCCC()) {
+        clusterChargeVec[clusterIndex] = charge;
+      }
+      layerSize[ilay]++;
+
+      traits.setDetails(mkFitHits[clusterIndex], cluster, uniqueIdInLayer, charge);
+    }
+
+    const Traits& traits;
+    mkfit::HitVec& mkFitHits;
+    std::vector<TrackingRecHit const*>& clusterIndexToHit;
+    std::vector<int>& layerIndexToHit;
+    std::vector<unsigned int>& layerSize;
+    std::vector<float>& clusterChargeVec;
+    const TrackerTopology& ttopo;
+    const TransientTrackingRecHitBuilder& ttrhBuilder;
+    const MkFitGeometry& mkFitGeom;
+  };
+
   template <typename Traits, typename HitCollection, typename ClusterCollection>
   edm::ProductID convertHits(const Traits& traits,
                              const HitCollection& hits,

--- a/RecoTracker/MkFit/python/mkFitSiStripHitConverterFromClusters_cfi.py
+++ b/RecoTracker/MkFit/python/mkFitSiStripHitConverterFromClusters_cfi.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoTracker.MkFit.mkFitSiStripHitConverterFromClustersDefault_cfi import mkFitSiStripHitConverterFromClustersDefault as _mkFitSiStripHitConverterFromClustersDefault
+
+mkFitSiStripHitConverterFromClusters = _mkFitSiStripHitConverterFromClustersDefault.clone(
+    minGoodStripCharge = cms.PSet(
+        refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
+)

--- a/RecoTracker/MkFitCore/interface/HitStructures.h
+++ b/RecoTracker/MkFitCore/interface/HitStructures.h
@@ -69,6 +69,14 @@ namespace mkfit {
 
     unsigned int nHits() const { return m_n_hits; }
 
+    void reserve(int nHits) {
+      m_ext_idcs.reserve(nHits);
+      m_binnor.begin_registration(nHits);
+      if (Config::usePhiQArrays) {
+        m_hit_infos.reserve(nHits);
+      }
+    }
+
     // Bin access / queries
     //----------------------
     bin_index_t qBin(float q) const { return m_ax_eta.from_R_to_N_bin(q); }


### PR DESCRIPTION
#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

Tracking with mkFit depends on a series of converters that translate the standard CMSSW objects (e.g. tracking rechits) to the mkFit specific formats.
Given the introduction of mkFit for the tracking iteration at HLT in 2025, it's important that all these converters are as fast as possible.

This PR includes two commits:
- the first adds an output to the hit converters that details the number of hits for each layer, which can be used as an hint for allocations in further steps
- the second adds a parameter in the standard `SiStripRecHitConverterAlgorithm` that allows filling further collections and a new plugin (`MkFitSiStripHitConverterFromClusters`), which acts as drop-in replacement for both `SiStripRecHitConverter` and `MkFitSiStripHitConverter` while being faster than the sum of the two.

Only the first commit touches code that is currently being executed in release (but it amounts to a call to reserve on some vectors), while the second is fully opt in and needs to be added to sequences to be active.
To avoid touching existing code (for a faster review) there is a small amount of code repetition in `convertHits.h` that can be corrected with a future PR.

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

This change was validated on 731 TTbar MC events from the Winter25 campaign. 
The results can be found [here](https://elusiani.web.cern.ch/SiStrip/SiStripRecHitJoinedConverterHLTPR/plots_hlt.html).
No differences were observed in either of the commits.
No other code physics object depend on the modules that are being modified.

The timing improvement was measured in the HLT timing server:
- [Baseline](https://cmshlttiming.app.cern.ch/display/elusiani/CMSSW_15_0_4_CA_MkFit.20250422_105914): 477.8 ms, 540.3 +/- 3 ev/s
- [This PR](https://cmshlttiming.app.cern.ch/display/elusiani/CMSSW_15_0_4_CA_MkFit_Opt.20250422_151358): 467.3 ms, 552.9 +/- 1.7 ev/s (+2.3 +/- 0.6% throughput)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #47926 for 15_0_X

<!-- Please delete the text above after you verified all points of the checklist  -->

cc @mmasciov @kskovpen 
