### PR TITLE
Workaround for "illegal memory access" errors

### DIFF
--- a/HeterogeneousCore/AlpakaInterface/interface/debug.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/debug.h
@@ -1,0 +1,25 @@
+#ifndef HeterogeneousCore_AlpakaInterface_interface_debug_h
+#define HeterogeneousCore_AlpakaInterface_interface_debug_h
+
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE::debug {
+
+  [[nodiscard]] ALPAKA_FN_ACC inline bool always_true() {
+    volatile const bool flag = true;
+    return flag;
+  }
+
+  [[nodiscard]] ALPAKA_FN_ACC inline bool always_false() {
+    volatile const bool flag = false;
+    return flag;
+  }
+
+  ALPAKA_FN_ACC inline void do_not_optimise(const auto& arg) {
+    volatile const auto* ptr = &arg;
+    (void)*ptr;
+  }
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::debug
+
+#endif  // HeterogeneousCore_AlpakaInterface_interface_debug_h

--- a/RecoTracker/PixelSeeding/plugins/alpaka/BrokenLineFit.dev.cc
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/BrokenLineFit.dev.cc
@@ -7,6 +7,7 @@
 
 #include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsSoA.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/debug.h"
 #include "RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforDevice.h"
 #include "RecoTracker/PixelTrackFitting/interface/alpaka/BrokenLine.h"
 
@@ -182,6 +183,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                   double *__restrict__ phits,
                                   float *__restrict__ phits_ge,
                                   double *__restrict__ pfast_fit) const {
+      // workaround for #47808
+      debug::do_not_optimise(results_view);
+
       ALPAKA_ASSERT_ACC(results_view.pt());
       ALPAKA_ASSERT_ACC(results_view.eta());
       ALPAKA_ASSERT_ACC(results_view.chi2());

--- a/RecoVertex/PixelVertexFinding/plugins/alpaka/clusterTracksByDensity.h
+++ b/RecoVertex/PixelVertexFinding/plugins/alpaka/clusterTracksByDensity.h
@@ -10,6 +10,7 @@
 #include "DataFormats/VertexSoA/interface/ZVertexSoA.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/HistoContainer.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/debug.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/warpsize.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
 #include "RecoVertex/PixelVertexFinding/interface/PixelVertexWorkSpaceLayout.h"
@@ -31,6 +32,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::vertexFinder {
                                                              float errmax,  // max error to be "seed"
                                                              float chi2max  // max normalized distance to cluster
   ) {
+    // workaround for #47808
+    debug::do_not_optimise(ws);
+
     constexpr bool verbose = false;
 
     if constexpr (verbose) {

--- a/RecoVertex/PixelVertexFinding/plugins/alpaka/clusterTracksDBSCAN.h
+++ b/RecoVertex/PixelVertexFinding/plugins/alpaka/clusterTracksDBSCAN.h
@@ -10,6 +10,7 @@
 #include "DataFormats/VertexSoA/interface/ZVertexSoA.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/HistoContainer.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/debug.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
 #include "RecoVertex/PixelVertexFinding/interface/PixelVertexWorkSpaceLayout.h"
 
@@ -30,6 +31,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::vertexFinder {
                                   float errmax,  // max error to be "seed"
                                   float chi2max  // max normalized distance to cluster
     ) const {
+      // workaround for #47808
+      debug::do_not_optimise(ws);
+
       constexpr bool verbose = false;
 
       if constexpr (verbose) {


### PR DESCRIPTION
#### PR description:

This is a workaround for the "illegal memory access" errors reported in #47808.

It is based on trial and error, without any real understanding of the underlying issue nor any measurement of the impact on the kernels' performance.

#### PR validation:

Workflow 12834.402 runs.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Once a better understanding of the issue has been developed, it may be backported to 15.0.x.