### PR TITLE
[NGT] add e-gamma sequences to NGT scouting menu

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/paths/DST_PFScouting_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/DST_PFScouting_cfi.py
@@ -14,6 +14,7 @@ from ..modules.hltParticleFlowClusterECALUncorrectedUnseeded_cfi import *
 from ..modules.hltParticleFlowClusterECALUnseeded_cfi import *
 from ..modules.hltParticleFlowRecHitECALUnseeded_cfi import *
 from ..modules.hltPhase2L3MuonCandidates_cfi import *
+from ..modules.hltEgammaEleL1TrkIsoUnseeded_cfi import *
 from ..sequences.HLTAK4PFJetsReconstruction_cfi import *
 from ..sequences.HLTAK4PFPuppiJetsReconstruction_cfi import *
 from ..sequences.HLTBeginSequence_cfi import *
@@ -22,14 +23,16 @@ from ..sequences.HLTBtagDeepFlavourSequencePFPuppi_cfi import *
 from ..sequences.HLTEndSequence_cfi import *
 from ..sequences.HLTHPSDeepTauPFTauSequence_cfi import *
 from ..sequences.HLTHgcalLocalRecoSequence_cfi import *
-from ..sequences.HLTHgcalTiclPFClusteringForEgamma_cfi import *
-from ..sequences.HLTJMESequence_cfi import *
+from ..sequences.HLTHgcalTiclPFClusteringForEgammaUnseededSequence_cfi import *
 from ..sequences.HLTLocalrecoSequence_cfi import *
 from ..sequences.HLTMuonsSequence_cfi import *
 from ..sequences.HLTPFPuppiMETReconstruction_cfi import *
 from ..sequences.HLTPFTauHPS_cfi import *
 from ..sequences.HLTParticleFlowSequence_cfi import *
+from ..sequences.HLTElePixelMatchUnseededSequence_cfi import *
+from ..sequences.HLTGsfElectronUnseededSequence_cfi import *
 from ..sequences.HLTPhase2L3MuonGeneralTracksSequence_cfi import *
+from ..sequences.HLTPFClusteringForEgammaUnseededSequence_cfi import *
 from ..sequences.HLTRawToDigiSequence_cfi import *
 from ..sequences.HLTTrackingSequence_cfi import *
 from ..sequences.HLTEndSequence_cfi import *
@@ -43,21 +46,24 @@ DST_PFScouting = cms.Path(
     + HLTTrackingSequence
     + HLTMuonsSequence
     + HLTParticleFlowSequence
-    + HLTHgcalTiclPFClusteringForEgamma
     + hltParticleFlowRecHitECALUnseeded
     + hltParticleFlowClusterECALUncorrectedUnseeded
     + hltParticleFlowClusterECALUnseeded
+    + HLTHgcalTiclPFClusteringForEgammaUnseededSequence
+    + HLTPFClusteringForEgammaUnseededSequence
     + hltFixedGridRhoFastjetAllCaloForEGamma
+    + HLTElePixelMatchUnseededSequence
+    + HLTGsfElectronUnseededSequence
+    + hltEgammaEleL1TrkIsoUnseeded
     + hltPhase2L3MuonCandidates
     + HLTPhase2L3MuonGeneralTracksSequence
     + HLTAK4PFJetsReconstruction
     + hltAK4PFJetsForTaus
     + HLTPFTauHPS
     + HLTHPSDeepTauPFTauSequence
-    + HLTJMESequence
+    + HLTAK4PFPuppiJetsReconstruction
     + hltPFPuppiHT
     + hltPFPuppiMHT
-    + HLTAK4PFPuppiJetsReconstruction
     + HLTBtagDeepCSVSequencePFPuppi
     + HLTBtagDeepFlavourSequencePFPuppi
     + HLTEndSequence


### PR DESCRIPTION
#### PR description:

After the integration of PR https://github.com/cms-sw/cmssw/pull/47901 and the subsequent check of the timing of the NGT scouting menu (integrated back in https://github.com/cms-sw/cmssw/pull/47434) it became apparent that none of the e-gamma related parts of the pie were being executed, see e.g. for reference [here](https://cmssdt.cern.ch/circles/web/piechart.php?local=false&dataset=CMSSW_15_1_X_2025-04-18-1100%2Fel8_amd64_gcc12%2FPhase2Timing_resources_NGT&resource=time_real&colours=default&groups=hlt&filter=CMSSW_15_1_X_2025-04-18-1100&data_name=hlt-p2-timing&show_labels=true&threshold=0):

![Screenshot from 2025-04-23 08-16-16](https://github.com/user-attachments/assets/80143d6e-2ae1-41ed-ba63-2cb932e79302)

The goal of this PR is to introduce said sequences in order to generate the event products foreseen for the NGT scouting. 
 
#### PR validation:

Run successfully the workflow: `runTheMatrix.py --what upgrade -l 29634.77 -t 4 -j 8`.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, not to be backported.

Cc: @rovere 