### PR TITLE
Refactor PathsAndConsumesOfModules

### DIFF
--- a/CondCore/CondHDF5ESSource/plugins/CondHDF5ESSource.cc
+++ b/CondCore/CondHDF5ESSource/plugins/CondHDF5ESSource.cc
@@ -17,6 +17,7 @@
 // user include files
 #include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
 #include "FWCore/Framework/interface/ESProductResolverProvider.h"
+#include "FWCore/Framework/interface/ESModuleProducesInfo.h"
 #include "FWCore/Framework/interface/IOVSyncValue.h"
 #include "FWCore/Framework/interface/SourceFactory.h"
 #include "FWCore/Framework/interface/ValidityInterval.h"
@@ -52,6 +53,7 @@ private:
   bool isConcurrentFinder() const final { return true; }
   void setIntervalFor(EventSetupRecordKey const&, edm::IOVSyncValue const&, edm::ValidityInterval&) final;
   KeyedResolversVector registerResolvers(EventSetupRecordKey const&, unsigned int iovIndex) final;
+  std::vector<edm::eventsetup::ESModuleProducesInfo> producesInfo() const final;
 
   edm::SerialTaskQueue queue_;
   std::mutex mutex_;
@@ -233,6 +235,22 @@ CondHDF5ESSource::KeyedResolversVector CondHDF5ESSource::registerResolvers(Event
         std::make_shared<HDF5ProductResolver>(
             &queue_, std::move(helper), &file_, filename_, compression_, &record, &dataProduct));
   }
+  return returnValue;
+}
+
+std::vector<edm::eventsetup::ESModuleProducesInfo> CondHDF5ESSource::producesInfo() const {
+  std::vector<edm::eventsetup::ESModuleProducesInfo> returnValue;
+
+  for (auto const& recInfo : records_) {
+    EventSetupRecordKey rec{edm::eventsetup::heterocontainer::HCTypeTag::findType(recInfo.name_)};
+    for (auto const& dataProduct : recInfo.dataProducts_) {
+      unsigned int index = returnValue.size();
+      edm::eventsetup::DataKey key{edm::eventsetup::heterocontainer::HCTypeTag::findType(dataProduct.type_),
+                                   dataProduct.name_.c_str()};
+      returnValue.emplace_back(rec, key, index);
+    }
+  }
+
   return returnValue;
 }
 

--- a/CondCore/CondHDF5ESSource/plugins/CondHDF5ESSource.cc
+++ b/CondCore/CondHDF5ESSource/plugins/CondHDF5ESSource.cc
@@ -240,6 +240,11 @@ CondHDF5ESSource::KeyedResolversVector CondHDF5ESSource::registerResolvers(Event
 
 std::vector<edm::eventsetup::ESModuleProducesInfo> CondHDF5ESSource::producesInfo() const {
   std::vector<edm::eventsetup::ESModuleProducesInfo> returnValue;
+  auto size = 0;
+  for (auto const& recInfo : records_) {
+    size += recInfo.dataProducts_.size();
+  }
+  returnValue.reserve(size);
 
   for (auto const& recInfo : records_) {
     EventSetupRecordKey rec{edm::eventsetup::heterocontainer::HCTypeTag::findType(recInfo.name_)};

--- a/CondCore/ESSources/plugins/CondDBESSource.cc
+++ b/CondCore/ESSources/plugins/CondDBESSource.cc
@@ -651,6 +651,7 @@ edm::eventsetup::ESProductResolverProvider::KeyedResolversVector CondDBESSource:
 
 std::vector<edm::eventsetup::ESModuleProducesInfo> CondDBESSource::producesInfo() const {
   std::vector<edm::eventsetup::ESModuleProducesInfo> returnValue;
+  returnValue.reserve(m_resolvers.size());
 
   for (auto const& recToResolver : m_resolvers) {
     unsigned int index = returnValue.size();

--- a/CondCore/ESSources/plugins/CondDBESSource.cc
+++ b/CondCore/ESSources/plugins/CondDBESSource.cc
@@ -22,6 +22,7 @@
 #include "CondCore/ESSources/interface/ProductResolver.h"
 
 #include "CondCore/CondDB/interface/PayloadProxy.h"
+#include "FWCore/Framework/interface/ESModuleProducesInfo.h"
 #include "FWCore/Catalog/interface/SiteLocalConfig.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -646,6 +647,22 @@ edm::eventsetup::ESProductResolverProvider::KeyedResolversVector CondDBESSource:
     }
   }
   return keyedResolversVector;
+}
+
+std::vector<edm::eventsetup::ESModuleProducesInfo> CondDBESSource::producesInfo() const {
+  std::vector<edm::eventsetup::ESModuleProducesInfo> returnValue;
+
+  for (auto const& recToResolver : m_resolvers) {
+    unsigned int index = returnValue.size();
+
+    EventSetupRecordKey rec{edm::eventsetup::TypeTag::findType(recToResolver.first)};
+
+    edm::eventsetup::TypeTag type = recToResolver.second->type();
+    DataKey key(type, edm::eventsetup::IdTags(recToResolver.second->label().c_str()));
+    returnValue.emplace_back(rec, key, index);
+  }
+
+  return returnValue;
 }
 
 void CondDBESSource::initConcurrentIOVs(const EventSetupRecordKey& key, unsigned int nConcurrentIOVs) {

--- a/CondCore/ESSources/plugins/CondDBESSource.h
+++ b/CondCore/ESSources/plugins/CondDBESSource.h
@@ -106,6 +106,8 @@ protected:
 
   KeyedResolversVector registerResolvers(const EventSetupRecordKey&, unsigned int iovIndex) override;
 
+  std::vector<edm::eventsetup::ESModuleProducesInfo> producesInfo() const override;
+
   void initConcurrentIOVs(const EventSetupRecordKey& key, unsigned int nConcurrentIOVs) override;
 
   bool isConcurrentFinder() const override { return true; }

--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -37,6 +37,7 @@
 #include "FWCore/Framework/interface/HCTypeTag.h"
 #include "FWCore/Framework/interface/DataKey.h"
 #include "FWCore/Framework/interface/data_default_record_trait.h"
+#include "FWCore/Framework/interface/ModuleConsumesMinimalESInfo.h"
 #include "FWCore/ServiceRegistry/interface/ServiceRegistryfwd.h"
 #include "FWCore/Utilities/interface/BranchType.h"
 #include "FWCore/Utilities/interface/ESIndices.h"
@@ -114,20 +115,12 @@ namespace edm {
     typedef ProductLabels Labels;
     void labelsForToken(EDGetToken iToken, Labels& oLabels) const;
 
-    void modulesWhoseProductsAreConsumed(std::array<std::vector<ModuleDescription const*>*, NumBranchTypes>& modulesAll,
-                                         ProductRegistry const& preg,
-                                         std::map<std::string, ModuleDescription const*> const& labelsToDesc,
-                                         std::string const& processName) const;
-
-    void esModulesWhoseProductsAreConsumed(
-        std::array<std::vector<eventsetup::ComponentDescription const*>*, kNumberOfEventSetupTransitions>& esModules,
-        eventsetup::ESRecordsToProductResolverIndices const&) const;
-
     /// Convert "@currentProcess" in InputTag process names to the actual current process name.
     void convertCurrentProcessAlias(std::string const& processName);
 
     std::vector<ModuleConsumesInfo> moduleConsumesInfos() const;
-    std::vector<ModuleConsumesESInfo> moduleConsumesESInfos(eventsetup::ESRecordsToProductResolverIndices const&) const;
+    ///This can only be called before the end of beginJob (after that the underlying data has been deleted)
+    std::vector<ModuleConsumesMinimalESInfo> moduleConsumesMinimalESInfos() const;
 
     ESResolverIndex const* esGetTokenIndices(edm::Transition iTrans) const {
       if (iTrans < edm::Transition::NumberOfEventSetupTransitions) {
@@ -232,6 +225,20 @@ namespace edm {
       return ESGetTokenGeneric(static_cast<unsigned int>(Tr), index, iRecord.type());
     }
 
+    /**The passed functor must take the following signature
+     *  F( ModuleConsumesInfo const& )
+     * The functor will be called for each consumed EDProduct registered for the module
+     */
+    template <typename F>
+    void consumedProducts(F&& iFunc) const;
+
+    /**The passed functor must take the following signature
+     * F(edm::ModuleConsumesMinimalESInfo const& )
+     * The functor will be called for each consumed ESProduct registered for the module
+     */
+    template <typename F>
+    void consumedESProducts(F&& iFunct) const;
+
   private:
     virtual void extendUpdateLookup(BranchType iBranchType, ProductResolverIndexHelper const&);
     virtual void registerLateConsumes(eventsetup::ESRecordsToProductResolverIndices const&) {}
@@ -325,6 +332,47 @@ namespace edm {
     bool frozen_;
     bool containsCurrentProcessAlias_;
   };
+
+  template <typename F>
+  void EDConsumerBase::consumedProducts(F&& iFunc) const {
+    auto itKind = m_tokenInfo.begin<kKind>();
+    auto itLabels = m_tokenInfo.begin<kLabels>();
+    auto itAlways = m_tokenInfo.begin<kAlwaysGets>();
+    for (auto itInfo = m_tokenInfo.begin<kLookupInfo>(), itEnd = m_tokenInfo.end<kLookupInfo>(); itInfo != itEnd;
+         ++itInfo, ++itKind, ++itLabels, ++itAlways) {
+      auto labels = *itLabels;
+      unsigned int start = labels.m_startOfModuleLabel;
+      auto module = &(m_tokenLabels[start]);
+      auto productInstance = module + labels.m_deltaToProductInstance;
+      auto process = module + labels.m_deltaToProcessName;
+
+      iFunc(ModuleConsumesInfo(itInfo->m_type,
+                               module,
+                               productInstance,
+                               process,
+                               itInfo->m_branchType,
+                               *itKind,
+                               *itAlways,
+                               itInfo->m_index.skipCurrentProcess()));
+    }
+  }
+
+  template <typename F>
+  void EDConsumerBase::consumedESProducts(F&& iFunc) const {
+    unsigned int index = 0;
+    auto itResolverIndex = esTokenLookupInfoContainer().begin<kESResolverIndex>();
+    for (auto it = esTokenLookupInfoContainer().begin<kESLookupInfo>();
+         it != esTokenLookupInfoContainer().end<kESLookupInfo>();
+         ++it, ++index, ++itResolverIndex) {
+      //NOTE: memory for it->m_key is passed on to call via the ModuleConsumesMinimalESInfo constructor
+      // this avoids a copy and avoids code later in the call chain accidently using deleted memory
+      iFunc(ModuleConsumesMinimalESInfo(static_cast<Transition>(consumesIndexConverter()[index].first),
+                                        it->m_record,
+                                        it->m_key,
+                                        &(m_tokenLabels[it->m_startOfComponentName]),
+                                        *itResolverIndex));
+    }
+  }
 
   template <Transition TR>
   class EDConsumerBaseESAdaptor {

--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -121,6 +121,8 @@ namespace edm {
 
     std::vector<ModuleConsumesInfo> moduleConsumesInfos() const;
     ///This can only be called before the end of beginJob (after that the underlying data has been deleted)
+    /// The pointers held by ModuleConsumesMinimalESInfo will also be invalid at that time so copies of
+    /// that class should not be held beyond the end of beginJob.
     std::vector<ModuleConsumesMinimalESInfo> moduleConsumesMinimalESInfos() const;
 
     ESResolverIndex const* esGetTokenIndices(edm::Transition iTrans) const {

--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -39,6 +39,7 @@
 #include "FWCore/Framework/interface/data_default_record_trait.h"
 #include "FWCore/Framework/interface/ModuleConsumesMinimalESInfo.h"
 #include "FWCore/ServiceRegistry/interface/ServiceRegistryfwd.h"
+#include "FWCore/ServiceRegistry/interface/ModuleConsumesInfo.h"
 #include "FWCore/Utilities/interface/BranchType.h"
 #include "FWCore/Utilities/interface/ESIndices.h"
 #include "FWCore/Utilities/interface/TypeID.h"

--- a/FWCore/Framework/interface/ESModuleConsumesMinimalInfo.h
+++ b/FWCore/Framework/interface/ESModuleConsumesMinimalInfo.h
@@ -1,0 +1,38 @@
+#ifndef FWCore_Framework_ESModuleConsumesMinimalInfo_h
+#define FWCore_Framework_ESModuleConsumesMinimalInfo_h
+
+// -*- C++ -*-
+// Package:     FWCore/Framework
+// Class  :     ESModuleConsumesMinimalInfo
+// Minimal information about the consumes call for an EventSetup product by an ESModule
+
+#include "FWCore/Utilities/interface/ESIndices.h"
+#include "FWCore/Framework/interface/EventSetupRecordKey.h"
+#include "FWCore/Framework/interface/DataKey.h"
+#include <string_view>
+
+namespace edm::eventsetup {
+  struct ESModuleConsumesMinimalInfo {
+    ESModuleConsumesMinimalInfo(unsigned int iProduceMethodID,
+                                eventsetup::EventSetupRecordKey const& iRecord,
+                                eventsetup::DataKey const& iDataKey,
+                                std::string_view iComponentLabel)
+        : recordForDataKey_(iRecord),
+          dataKey_(iDataKey.type(), iDataKey.name(), eventsetup::DataKey::DoNotCopyMemory()),
+          componentLabel_(iComponentLabel),
+          produceMethodID_(iProduceMethodID) {}
+    ESModuleConsumesMinimalInfo() = default;
+    ESModuleConsumesMinimalInfo(ESModuleConsumesMinimalInfo&&) = default;
+    ESModuleConsumesMinimalInfo& operator=(ESModuleConsumesMinimalInfo&&) = default;
+
+    // avoid accidentally copying data key as the strings would be copied instead of shared
+    ESModuleConsumesMinimalInfo(ESModuleConsumesMinimalInfo const&) = delete;
+    ESModuleConsumesMinimalInfo& operator=(ESModuleConsumesMinimalInfo const&) = delete;
+
+    eventsetup::EventSetupRecordKey recordForDataKey_;
+    eventsetup::DataKey dataKey_;
+    std::string_view componentLabel_;
+    unsigned int produceMethodID_ = 0;
+  };
+}  // namespace edm::eventsetup
+#endif  // FWCore_Framework_ESModuleConsumesMinimalInfo_h

--- a/FWCore/Framework/interface/ESModuleProducesInfo.h
+++ b/FWCore/Framework/interface/ESModuleProducesInfo.h
@@ -1,0 +1,29 @@
+#ifndef FWCore_Framework_ESModuleProducesInfo_h
+#define FWCore_Framework_ESModuleProducesInfo_h
+// -*- C++ -*-
+
+// Package:     Framework
+// Class  :     ESModuleProducesInfo
+//
+// Description: Contains information about which products
+// a module declares it will produce from the EventSetup.
+
+#include "FWCore/Framework/interface/DataKey.h"
+#include "FWCore/Framework/interface/EventSetupRecordKey.h"
+namespace edm::eventsetup {
+  class ESModuleProducesInfo {
+  public:
+    ESModuleProducesInfo(EventSetupRecordKey const& iRecord, DataKey const& iDataKey, unsigned int iProduceMethodID)
+        : record_(iRecord), dataKey_(iDataKey), produceMethodID_(iProduceMethodID) {}
+
+    EventSetupRecordKey const& record() const { return record_; }
+    DataKey const& dataKey() const { return dataKey_; }
+    unsigned int produceMethodID() const { return produceMethodID_; }
+
+  private:
+    EventSetupRecordKey record_;
+    DataKey dataKey_;
+    unsigned int produceMethodID_;
+  };
+}  // namespace edm::eventsetup
+#endif

--- a/FWCore/Framework/interface/ESProducer.h
+++ b/FWCore/Framework/interface/ESProducer.h
@@ -95,7 +95,7 @@ namespace edm {
   namespace eventsetup {
     struct ComponentDescription;
     class ESRecordsToProductResolverIndices;
-    class ESModuleConsumesMinimalInfo;
+    struct ESModuleConsumesMinimalInfo;
 
     //used by ESProducer to create the proper Decorator based on the
     //  argument type passed.  The default it to just 'pass through'

--- a/FWCore/Framework/interface/ESProducer.h
+++ b/FWCore/Framework/interface/ESProducer.h
@@ -95,6 +95,7 @@ namespace edm {
   namespace eventsetup {
     struct ComponentDescription;
     class ESRecordsToProductResolverIndices;
+    class ESModuleConsumesMinimalInfo;
 
     //used by ESProducer to create the proper Decorator based on the
     //  argument type passed.  The default it to just 'pass through'
@@ -158,11 +159,13 @@ namespace edm {
 
     SerialTaskQueueChain& queue() { return acquirer_.serialQueueChain(); }
 
-    void esModulesWhoseProductsAreConsumed(std::vector<eventsetup::ComponentDescription const*>& esModules,
-                                           eventsetup::ESRecordsToProductResolverIndices const&) const;
-
     std::vector<std::vector<ESModuleConsumesInfo>> esModuleConsumesInfos(
         eventsetup::ESRecordsToProductResolverIndices const&) const;
+
+    /** Returns a vector of ESModuleConsumesMinimalInfo.
+        Each entry contains minimal information about the products that a method consumes.
+    */
+    std::vector<eventsetup::ESModuleConsumesMinimalInfo> esModuleConsumesMinimalInfos() const;
 
   protected:
     /** Specify the names of the shared resources used by this ESProducer */

--- a/FWCore/Framework/interface/ESProductResolverArgumentFactoryTemplate.h
+++ b/FWCore/Framework/interface/ESProductResolverArgumentFactoryTemplate.h
@@ -65,6 +65,8 @@ namespace edm {
         return DataKey(DataKey::makeTypeTag<typename ResolverType::ValueType>(), iName.c_str());
       }
 
+      unsigned int produceMethodID() const override { return callback_->second->produceMethodID(); }
+
     private:
       std::shared_ptr<std::pair<unsigned int, std::shared_ptr<CallbackType>>> callback_;
     };

--- a/FWCore/Framework/interface/ESProductResolverFactoryBase.h
+++ b/FWCore/Framework/interface/ESProductResolverFactoryBase.h
@@ -40,6 +40,8 @@ namespace edm {
       virtual std::unique_ptr<ESProductResolver> makeResolver(unsigned int iovIndex) = 0;
 
       virtual DataKey makeKey(const std::string& iName) const = 0;
+
+      virtual unsigned int produceMethodID() const = 0;
     };
   }  // namespace eventsetup
 }  // namespace edm

--- a/FWCore/Framework/interface/ESProductResolverFactoryProducer.h
+++ b/FWCore/Framework/interface/ESProductResolverFactoryProducer.h
@@ -83,6 +83,8 @@ namespace edm {
 
     ~ESProductResolverFactoryProducer() noexcept(false) override;
 
+    std::vector<eventsetup::ESModuleProducesInfo> producesInfo() const override;
+
   protected:
     using EventSetupRecordKey = eventsetup::EventSetupRecordKey;
 

--- a/FWCore/Framework/interface/ESProductResolverProvider.h
+++ b/FWCore/Framework/interface/ESProductResolverProvider.h
@@ -60,6 +60,7 @@ namespace edm {
   namespace eventsetup {
     class ESProductResolver;
     class ESRecordsToProductResolverIndices;
+    class ESModuleProducesInfo;
 
     class ESProductResolverProvider {
     public:
@@ -161,6 +162,10 @@ namespace edm {
       void fillRecordsNotAllowingConcurrentIOVs(std::set<EventSetupRecordKey>& recordsNotAllowingConcurrentIOVs) const {
         productResolverContainer_.fillRecordsNotAllowingConcurrentIOVs(recordsNotAllowingConcurrentIOVs);
       }
+      /// @brief Provides information about each product that this module produces.
+      /// If the value of produceMethodID is same for different infos it means they are produced by the same call.
+      /// @return the vector of ESModuleProducesInfo objects, one for each product produced by this module.
+      virtual std::vector<ESModuleProducesInfo> producesInfo() const = 0;
 
       virtual void initConcurrentIOVs(EventSetupRecordKey const& key, unsigned int nConcurrentIOVs) {}
 

--- a/FWCore/Framework/interface/ESTagGetter.h
+++ b/FWCore/Framework/interface/ESTagGetter.h
@@ -10,7 +10,9 @@
  Description: Used with mayConsume option of ESConsumesCollector
 
  Usage:
-    <usage>
+    This contains a cache of data about all Resolvers which are
+    associated with data produces which are in the Record and which
+    are of the proper type.
 
 */
 //

--- a/FWCore/Framework/interface/EventSetupProvider.h
+++ b/FWCore/Framework/interface/EventSetupProvider.h
@@ -122,6 +122,7 @@ namespace edm {
       void fillKeys(std::set<EventSetupRecordKey>& keys) const;
 
       EventSetupRecordProvider* tryToGetRecordProvider(const EventSetupRecordKey& iKey);
+      EventSetupRecordProvider const* tryToGetRecordProvider(const EventSetupRecordKey& iKey) const;
 
       void fillAllESProductResolverProviders(std::vector<ESProductResolverProvider const*>&) const;
 

--- a/FWCore/Framework/interface/EventSetupRecord.h
+++ b/FWCore/Framework/interface/EventSetupRecord.h
@@ -140,7 +140,7 @@ namespace edm {
       unsigned int iovIndex() const { return impl_->iovIndex(); }
 
       ///clears the oToFill vector and then fills it with the keys for all registered data keys
-      void fillRegisteredDataKeys(std::vector<DataKey>& oToFill) const { impl_->fillRegisteredDataKeys(oToFill); }
+      void fillRegisteredDataKeys(std::vector<DataKey>& oToFill) const { oToFill = impl_->registeredDataKeys(); }
 
       ///Classes that derive from EventSetupRecord can redefine this with a false value
       static constexpr bool allowConcurrentIOVs_ = true;

--- a/FWCore/Framework/interface/EventSetupRecordImpl.h
+++ b/FWCore/Framework/interface/EventSetupRecordImpl.h
@@ -113,8 +113,8 @@ namespace edm {
 
       unsigned int iovIndex() const { return iovIndex_; }
 
-      ///clears the oToFill vector and then fills it with the keys for all registered data keys
-      void fillRegisteredDataKeys(std::vector<DataKey>& oToFill) const;
+      ///keys for all registered data keys
+      std::vector<DataKey> const& registeredDataKeys() const;
       ///there is a 1-to-1 correspondence between elements returned and the elements returned from fillRegisteredDataKey.
       std::vector<ComponentDescription const*> componentsForRegisteredDataKeys() const;
 

--- a/FWCore/Framework/interface/EventSetupRecordProvider.h
+++ b/FWCore/Framework/interface/EventSetupRecordProvider.h
@@ -79,7 +79,7 @@ namespace edm {
       std::set<ComponentDescription> resolverProviderDescriptions() const;
 
       /// The available DataKeys in the Record. The order can be used to request the data by index
-      std::vector<DataKey> registeredDataKeys() const;
+      std::vector<DataKey> const& registeredDataKeys() const;
 
       std::vector<ComponentDescription const*> componentsForRegisteredDataKeys() const;
       std::vector<unsigned int> produceMethodIDsForRegisteredDataKeys() const;

--- a/FWCore/Framework/interface/ModuleConsumesMinimalESInfo.h
+++ b/FWCore/Framework/interface/ModuleConsumesMinimalESInfo.h
@@ -1,0 +1,41 @@
+#ifndef FWCore_Framework_ModuleConsumesMinimalESInfo_h
+#define FWCore_Framework_ModuleConsumesMinimalESInfo_h
+
+// -*- C++ -*-
+// Package:     FWCore/Framework
+// Class  :     ModuleConsumesMinimalESInfo
+// Minimal information about the consumes call for an EventSetup product
+// requested from an ED module
+
+#include "FWCore/Utilities/interface/Transition.h"
+#include "FWCore/Utilities/interface/ESIndices.h"
+#include "FWCore/Framework/interface/EventSetupRecordKey.h"
+#include "FWCore/Framework/interface/DataKey.h"
+#include <string_view>
+
+namespace edm {
+  struct ModuleConsumesMinimalESInfo {
+    ModuleConsumesMinimalESInfo(Transition iTransition,
+                                eventsetup::EventSetupRecordKey const& iRecord,
+                                eventsetup::DataKey const& iDataKey,
+                                std::string_view iComponentLabel,
+                                ESResolverIndex iIndex)
+        : transition_(iTransition),
+          record_(iRecord),
+          dataKey_(iDataKey.type(), iDataKey.name(), eventsetup::DataKey::DoNotCopyMemory()),
+          componentLabel_(iComponentLabel) {}
+    ModuleConsumesMinimalESInfo() = default;
+    ModuleConsumesMinimalESInfo(ModuleConsumesMinimalESInfo&&) = default;
+    ModuleConsumesMinimalESInfo& operator=(ModuleConsumesMinimalESInfo&&) = default;
+
+    //want to avoid accidently copying dataKey_
+    ModuleConsumesMinimalESInfo(ModuleConsumesMinimalESInfo const&) = delete;
+    ModuleConsumesMinimalESInfo& operator=(ModuleConsumesMinimalESInfo const&) = delete;
+
+    edm::Transition transition_;
+    eventsetup::EventSetupRecordKey record_;
+    eventsetup::DataKey dataKey_;
+    std::string_view componentLabel_;
+  };
+}  // namespace edm
+#endif  // FWCore_Framework_ModuleConsumesMinimalESInfo_h

--- a/FWCore/Framework/interface/PathsAndConsumesOfModules.h
+++ b/FWCore/Framework/interface/PathsAndConsumesOfModules.h
@@ -24,6 +24,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <map>
 
 namespace edm {
 
@@ -43,11 +44,17 @@ namespace edm {
     ~PathsAndConsumesOfModules() override = default;
 
     void initialize(Schedule const*, std::shared_ptr<ProductRegistry const>);
-    void initializeForEventSetup(eventsetup::ESRecordsToProductResolverIndices&&,
-                                 eventsetup::EventSetupProvider const&);
+    void initializeForEventSetup(eventsetup::EventSetupProvider const&);
     void checkEventSetupInitialization() const;
 
     void removeModules(std::vector<ModuleDescription const*> const& modules);
+
+    struct ESProductInfo {
+      eventsetup::ComponentDescription const* componentDescription_ = nullptr;
+      unsigned int produceMethodID_ = std::numeric_limits<unsigned int>::max();
+    };
+    using ProducedByESModule =
+        std::map<edm::eventsetup::EventSetupRecordKey, std::map<edm::eventsetup::DataKey, ESProductInfo>>;
 
   private:
     std::vector<std::string> const& doPaths() const override;
@@ -107,7 +114,7 @@ namespace edm {
     std::vector<std::vector<eventsetup::ComponentDescription const*>> esModulesWhoseProductsAreConsumedByESModule_;
 
     Schedule const* schedule_ = nullptr;
-    eventsetup::ESRecordsToProductResolverIndices esRecordsToProductResolverIndices_;
+    ProducedByESModule producedByESModule_;
     std::shared_ptr<ProductRegistry const> preg_;
     bool eventSetupInfoInitialized_ = false;
   };

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -245,16 +245,6 @@ namespace edm {
                                      std::vector<ModuleDescription const*>& descriptions,
                                      unsigned int hint) const;
 
-    void fillModuleAndConsumesInfo(std::vector<ModuleDescription const*>& allModuleDescriptions,
-                                   std::vector<std::pair<unsigned int, unsigned int>>& moduleIDToIndex,
-                                   std::array<std::vector<std::vector<ModuleDescription const*>>, NumBranchTypes>&
-                                       modulesWhoseProductsAreConsumedBy,
-                                   ProductRegistry const& preg) const;
-
-    void fillESModuleAndConsumesInfo(std::array<std::vector<std::vector<eventsetup::ComponentDescription const*>>,
-                                                kNumberOfEventSetupTransitions>& esModulesWhoseProductsAreConsumedBy,
-                                     eventsetup::ESRecordsToProductResolverIndices const&) const;
-
     /// Return the number of events this Schedule has tried to process
     /// (inclues both successes and failures, including failures due
     /// to exceptions during processing).

--- a/FWCore/Framework/interface/maker/Worker.h
+++ b/FWCore/Framework/interface/maker/Worker.h
@@ -30,6 +30,7 @@ the worker is reset().
 #include "FWCore/Framework/interface/ModuleContextSentry.h"
 #include "FWCore/Framework/interface/OccurrenceTraits.h"
 #include "FWCore/Framework/interface/ProductResolverIndexAndSkipBit.h"
+#include "FWCore/Framework/interface/ModuleConsumesMinimalESInfo.h"
 #include "FWCore/Concurrency/interface/WaitingTask.h"
 #include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 #include "FWCore/Concurrency/interface/WaitingTaskList.h"
@@ -218,20 +219,10 @@ namespace edm {
         std::unordered_multimap<std::string, std::tuple<TypeID const*, const char*, edm::ProductResolverIndex>> const&
             iIndicies) = 0;
 
-    virtual void modulesWhoseProductsAreConsumed(
-        std::array<std::vector<ModuleDescription const*>*, NumBranchTypes>& modules,
-        ProductRegistry const& preg,
-        std::map<std::string, ModuleDescription const*> const& labelsToDesc) const = 0;
-
-    virtual void esModulesWhoseProductsAreConsumed(
-        std::array<std::vector<eventsetup::ComponentDescription const*>*, kNumberOfEventSetupTransitions>& esModules,
-        eventsetup::ESRecordsToProductResolverIndices const&) const = 0;
-
     virtual void convertCurrentProcessAlias(std::string const& processName) = 0;
 
     virtual std::vector<ModuleConsumesInfo> moduleConsumesInfos() const = 0;
-    virtual std::vector<ModuleConsumesESInfo> moduleConsumesESInfos(
-        eventsetup::ESRecordsToProductResolverIndices const&) const = 0;
+    virtual std::vector<ModuleConsumesMinimalESInfo> moduleConsumesMinimalESInfos() const = 0;
 
     virtual Types moduleType() const = 0;
     virtual ConcurrencyTypes moduleConcurrencyType() const = 0;

--- a/FWCore/Framework/interface/maker/WorkerT.h
+++ b/FWCore/Framework/interface/maker/WorkerT.h
@@ -127,26 +127,14 @@ namespace edm {
     std::string workerType() const override;
     TaskQueueAdaptor serializeRunModule() override;
 
-    void modulesWhoseProductsAreConsumed(
-        std::array<std::vector<ModuleDescription const*>*, NumBranchTypes>& modules,
-        ProductRegistry const& preg,
-        std::map<std::string, ModuleDescription const*> const& labelsToDesc) const override {
-      module_->modulesWhoseProductsAreConsumed(modules, preg, labelsToDesc, module_->moduleDescription().processName());
-    }
-
-    void esModulesWhoseProductsAreConsumed(
-        std::array<std::vector<eventsetup::ComponentDescription const*>*, kNumberOfEventSetupTransitions>& esModules,
-        eventsetup::ESRecordsToProductResolverIndices const& iPI) const override {
-      module_->esModulesWhoseProductsAreConsumed(esModules, iPI);
-    }
-
     void convertCurrentProcessAlias(std::string const& processName) override {
       module_->convertCurrentProcessAlias(processName);
     }
 
     std::vector<ModuleConsumesInfo> moduleConsumesInfos() const override;
-    std::vector<ModuleConsumesESInfo> moduleConsumesESInfos(
-        eventsetup::ESRecordsToProductResolverIndices const& iPI) const override;
+    std::vector<ModuleConsumesMinimalESInfo> moduleConsumesMinimalESInfos() const final {
+      return module_->moduleConsumesMinimalESInfos();
+    }
 
     void itemsToGet(BranchType branchType, std::vector<ProductResolverIndexAndSkipBit>& indexes) const override {
       module_->itemsToGet(branchType, indexes);

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
@@ -50,6 +50,7 @@ namespace edm {
   class ActivityRegistry;
   class ThinnedAssociationsHelper;
   class SignallingProductRegistryFiller;
+  struct ModuleConsumesMinimalESInfo;
 
   namespace maker {
     template <typename T>
@@ -120,21 +121,10 @@ namespace edm {
 
       const EDConsumerBase* consumer() const;
 
-      void modulesWhoseProductsAreConsumed(std::array<std::vector<ModuleDescription const*>*, NumBranchTypes>& modules,
-                                           ProductRegistry const& preg,
-                                           std::map<std::string, ModuleDescription const*> const& labelsToDesc,
-                                           std::string const& processName) const;
-
-      void esModulesWhoseProductsAreConsumed(
-          std::array<std::vector<eventsetup::ComponentDescription const*>*, kNumberOfEventSetupTransitions>& esModules,
-          eventsetup::ESRecordsToProductResolverIndices const&) const;
-
       void convertCurrentProcessAlias(std::string const& processName);
 
       std::vector<ModuleConsumesInfo> moduleConsumesInfos() const;
-      std::vector<ModuleConsumesESInfo> moduleConsumesESInfos(
-          eventsetup::ESRecordsToProductResolverIndices const&) const;
-
+      std::vector<ModuleConsumesMinimalESInfo> moduleConsumesMinimalESInfos() const;
       void deleteModulesEarly();
 
     private:

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
@@ -57,6 +57,7 @@ namespace edm {
   class WaitingTaskHolder;
   class ServiceWeakToken;
   class SignallingProductRegistryFiller;
+  struct ModuleConsumesMinimalESInfo;
 
   namespace maker {
     template <typename T>
@@ -112,20 +113,10 @@ namespace edm {
       void releaseMemoryPostLookupSignal();
       virtual void selectInputProcessBlocks(ProductRegistry const&, ProcessBlockHelperBase const&) = 0;
 
-      void modulesWhoseProductsAreConsumed(std::array<std::vector<ModuleDescription const*>*, NumBranchTypes>& modules,
-                                           ProductRegistry const& preg,
-                                           std::map<std::string, ModuleDescription const*> const& labelsToDesc,
-                                           std::string const& processName) const;
-
-      void esModulesWhoseProductsAreConsumed(
-          std::array<std::vector<eventsetup::ComponentDescription const*>*, kNumberOfEventSetupTransitions>& esModules,
-          eventsetup::ESRecordsToProductResolverIndices const&) const;
-
       void convertCurrentProcessAlias(std::string const& processName);
 
       std::vector<ModuleConsumesInfo> moduleConsumesInfos() const;
-      std::vector<ModuleConsumesESInfo> moduleConsumesESInfos(
-          eventsetup::ESRecordsToProductResolverIndices const&) const;
+      std::vector<ModuleConsumesMinimalESInfo> moduleConsumesMinimalESInfos() const;
 
       using ModuleToResolverIndicies =
           std::unordered_multimap<std::string, std::tuple<edm::TypeID const*, const char*, edm::ProductResolverIndex>>;

--- a/FWCore/Framework/src/EDConsumerBase.cc
+++ b/FWCore/Framework/src/EDConsumerBase.cc
@@ -24,7 +24,6 @@
 #include "FWCore/Framework/interface/ComponentDescription.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/ModuleConsumesInfo.h"
-#include "FWCore/ServiceRegistry/interface/ModuleConsumesESInfo.h"
 #include "FWCore/Utilities/interface/Likely.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "DataFormats/Provenance/interface/ProductResolverIndexHelper.h"
@@ -393,138 +392,6 @@ void EDConsumerBase::throwESConsumesInProcessBlock() const {
 
 void EDConsumerBase::doSelectInputProcessBlocks(ProductRegistry const&, ProcessBlockHelperBase const&) {}
 
-namespace {
-  struct CharStarComp {
-    bool operator()(const char* iLHS, const char* iRHS) const { return strcmp(iLHS, iRHS) < 0; }
-  };
-}  // namespace
-
-namespace {
-  void insertFoundModuleLabel(edm::KindOfType consumedTypeKind,
-                              edm::TypeID consumedType,
-                              const char* consumedModuleLabel,
-                              const char* consumedProductInstance,
-                              std::vector<ModuleDescription const*>& modules,
-                              std::set<std::string>& alreadyFound,
-                              std::map<std::string, ModuleDescription const*> const& labelsToDesc,
-                              ProductRegistry const& preg) {
-    // Convert from label string to module description, eliminate duplicates,
-    // then insert into the vector of modules
-    if (auto it = labelsToDesc.find(consumedModuleLabel); it != labelsToDesc.end()) {
-      if (alreadyFound.insert(consumedModuleLabel).second) {
-        modules.push_back(it->second);
-      }
-      return;
-    }
-    // Deal with EDAlias's by converting to the original module label first
-    if (auto aliasToModuleLabels =
-            preg.aliasToModules(consumedTypeKind, consumedType, consumedModuleLabel, consumedProductInstance);
-        not aliasToModuleLabels.empty()) {
-      bool foundInLabelsToDesc = false;
-      for (auto const& label : aliasToModuleLabels) {
-        if (auto it = labelsToDesc.find(label); it != labelsToDesc.end()) {
-          if (alreadyFound.insert(label).second) {
-            modules.push_back(it->second);
-          }
-          foundInLabelsToDesc = true;
-        } else {
-          if (label == "source") {
-            foundInLabelsToDesc = true;
-          }
-        }
-      }
-      if (foundInLabelsToDesc) {
-        return;
-      }
-    }
-    // Ignore the source products, we are only interested in module products.
-    // As far as I know, it should never be anything else so throw if something
-    // unknown gets passed in.
-    if (std::string_view(consumedModuleLabel) != "source") {
-      throw cms::Exception("EDConsumerBase", "insertFoundModuleLabel")
-          << "Couldn't find ModuleDescription for the consumed product type: '" << consumedType.className()
-          << "' module label: '" << consumedModuleLabel << "' product instance name: '" << consumedProductInstance
-          << "'";
-    }
-  }
-}  // namespace
-
-void EDConsumerBase::modulesWhoseProductsAreConsumed(
-    std::array<std::vector<ModuleDescription const*>*, NumBranchTypes>& modulesAll,
-    ProductRegistry const& preg,
-    std::map<std::string, ModuleDescription const*> const& labelsToDesc,
-    std::string const& processName) const {
-  std::set<std::string> alreadyFound;
-
-  auto itKind = m_tokenInfo.begin<kKind>();
-  auto itLabels = m_tokenInfo.begin<kLabels>();
-  for (auto itInfo = m_tokenInfo.begin<kLookupInfo>(), itEnd = m_tokenInfo.end<kLookupInfo>(); itInfo != itEnd;
-       ++itInfo, ++itKind, ++itLabels) {
-    ProductResolverIndexHelper const& helper = *preg.productLookup(itInfo->m_branchType);
-    std::vector<ModuleDescription const*>& modules = *modulesAll[itInfo->m_branchType];
-
-    const unsigned int labelStart = itLabels->m_startOfModuleLabel;
-    const char* const consumedModuleLabel = &(m_tokenLabels[labelStart]);
-    const char* const consumedProductInstance = consumedModuleLabel + itLabels->m_deltaToProductInstance;
-    const char* const consumedProcessName = consumedModuleLabel + itLabels->m_deltaToProcessName;
-
-    if (not itInfo->m_index.skipCurrentProcess()) {
-      assert(*consumedModuleLabel != '\0');  // consumesMany used to create empty labels before we removed consumesMany
-      if (*consumedProcessName != '\0') {    // process name is specified in consumes call
-        if (helper.index(*itKind, itInfo->m_type, consumedModuleLabel, consumedProductInstance, consumedProcessName) !=
-            ProductResolverIndexInvalid) {
-          if (processName == consumedProcessName) {
-            insertFoundModuleLabel(*itKind,
-                                   itInfo->m_type,
-                                   consumedModuleLabel,
-                                   consumedProductInstance,
-                                   modules,
-                                   alreadyFound,
-                                   labelsToDesc,
-                                   preg);
-          }
-        }
-      } else {  // process name was empty
-        auto matches = helper.relatedIndexes(*itKind, itInfo->m_type, consumedModuleLabel, consumedProductInstance);
-        for (unsigned int j = 0; j < matches.numberOfMatches(); ++j) {
-          if (processName == matches.processName(j)) {
-            insertFoundModuleLabel(*itKind,
-                                   itInfo->m_type,
-                                   consumedModuleLabel,
-                                   consumedProductInstance,
-                                   modules,
-                                   alreadyFound,
-                                   labelsToDesc,
-                                   preg);
-          }
-        }
-      }
-    }
-  }
-}
-
-void EDConsumerBase::esModulesWhoseProductsAreConsumed(
-    std::array<std::vector<eventsetup::ComponentDescription const*>*, kNumberOfEventSetupTransitions>& esModules,
-    eventsetup::ESRecordsToProductResolverIndices const& iPI) const {
-  std::array<std::set<std::string>, kNumberOfEventSetupTransitions> alreadyFound;
-
-  unsigned int index = 0;
-  auto itResolver = esTokenLookupInfoContainer().begin<kESResolverIndex>();
-  for (auto it = esTokenLookupInfoContainer().begin<kESLookupInfo>();
-       it != esTokenLookupInfoContainer().end<kESLookupInfo>();
-       ++it, ++itResolver, ++index) {
-    auto [componentDescription, produceMethodID] = iPI.componentAndProduceMethodID(it->m_record, *itResolver);
-    if (componentDescription) {
-      std::string const& moduleLabel =
-          componentDescription->label_.empty() ? componentDescription->type_ : componentDescription->label_;
-      ESResolverIndexContainer::size_type transitionIndex = consumesIndexConverter()[index].first;
-      if (alreadyFound[transitionIndex].insert(moduleLabel).second) {
-        esModules[transitionIndex]->push_back(componentDescription);
-      }
-    }
-  }
-}
-
 void EDConsumerBase::convertCurrentProcessAlias(std::string const& processName) {
   frozen_ = true;
 
@@ -573,69 +440,17 @@ void EDConsumerBase::convertCurrentProcessAlias(std::string const& processName) 
 
 std::vector<ModuleConsumesInfo> EDConsumerBase::moduleConsumesInfos() const {
   std::vector<ModuleConsumesInfo> result;
-  auto itAlways = m_tokenInfo.begin<kAlwaysGets>();
-  auto itKind = m_tokenInfo.begin<kKind>();
-  auto itLabels = m_tokenInfo.begin<kLabels>();
-  for (auto itInfo = m_tokenInfo.begin<kLookupInfo>(), itEnd = m_tokenInfo.end<kLookupInfo>(); itInfo != itEnd;
-       ++itInfo, ++itKind, ++itLabels, ++itAlways) {
-    const unsigned int labelStart = itLabels->m_startOfModuleLabel;
-    const char* consumedModuleLabel = &(m_tokenLabels[labelStart]);
-    const char* consumedInstance = consumedModuleLabel + itLabels->m_deltaToProductInstance;
-    const char* consumedProcessName = consumedModuleLabel + itLabels->m_deltaToProcessName;
-
-    assert(*consumedModuleLabel != '\0');
-
-    // Just copy the information into the ModuleConsumesInfo data structure
-    result.emplace_back(itInfo->m_type,
-                        consumedModuleLabel,
-                        consumedInstance,
-                        consumedProcessName,
-                        itInfo->m_branchType,
-                        *itKind,
-                        *itAlways,
-                        itInfo->m_index.skipCurrentProcess());
-  }
+  result.reserve(m_tokenInfo.size());
+  consumedProducts([&](ModuleConsumesInfo const& info) {
+    assert(not info.label().empty());
+    result.push_back(info);
+  });
   return result;
 }
 
-std::vector<ModuleConsumesESInfo> EDConsumerBase::moduleConsumesESInfos(
-    eventsetup::ESRecordsToProductResolverIndices const& iPI) const {
-  std::vector<ModuleConsumesESInfo> result;
-
-  ModuleConsumesESInfo info;
-
-  unsigned int index = 0;
-  auto itResolver = esTokenLookupInfoContainer().begin<kESResolverIndex>();
-  for (auto it = esTokenLookupInfoContainer().begin<kESLookupInfo>();
-       it != esTokenLookupInfoContainer().end<kESLookupInfo>();
-       ++it, ++itResolver, ++index) {
-    info.eventSetupRecordType_ = it->m_record.name();
-    info.productType_ = it->m_key.type().name();
-    info.productLabel_ = it->m_key.name().value();
-    info.requestedModuleLabel_ = &(m_tokenLabels[it->m_startOfComponentName]);
-    info.transitionOfConsumer_ = static_cast<Transition>(consumesIndexConverter()[index].first);
-    info.moduleLabelMismatch_ = *itResolver == ESResolverIndex::moduleLabelDoesNotMatch();
-
-    // Initial values used in the case where there isn't an EventSetup
-    // module to produce the requested data. Test whether moduleType
-    // is empty to identify this case because it will be empty if and
-    // only if this is true.
-    info.moduleType_ = {};
-    info.moduleLabel_ = {};
-    info.produceMethodIDOfProducer_ = 0;
-    info.isSource_ = false;
-    info.isLooper_ = false;
-
-    auto [componentDescription, produceMethodID] = iPI.componentAndProduceMethodID(it->m_record, *itResolver);
-    if (componentDescription) {
-      info.moduleType_ = componentDescription->type_;
-      info.moduleLabel_ =
-          componentDescription->label_.empty() ? componentDescription->type_ : componentDescription->label_;
-      info.produceMethodIDOfProducer_ = produceMethodID;
-      info.isSource_ = componentDescription->isSource_;
-      info.isLooper_ = componentDescription->isLooper_;
-    }
-    result.push_back(info);
-  }
+std::vector<ModuleConsumesMinimalESInfo> EDConsumerBase::moduleConsumesMinimalESInfos() const {
+  std::vector<ModuleConsumesMinimalESInfo> result;
+  result.reserve(esTokenLookupInfoContainer().size());
+  consumedESProducts([&](ModuleConsumesMinimalESInfo&& minInfo) mutable { result.emplace_back(std::move(minInfo)); });
   return result;
 }

--- a/FWCore/Framework/src/ESProductResolverFactoryProducer.cc
+++ b/FWCore/Framework/src/ESProductResolverFactoryProducer.cc
@@ -17,6 +17,7 @@
 // user include files
 #include "FWCore/Framework/interface/ESProductResolverFactoryProducer.h"
 #include "FWCore/Framework/interface/ESProductResolverFactoryBase.h"
+#include "FWCore/Framework/interface/ESModuleProducesInfo.h"
 
 #include "FWCore/Framework/interface/ESProductResolver.h"
 
@@ -30,6 +31,14 @@ namespace edm {
   ESProductResolverFactoryProducer::ESProductResolverFactoryProducer() : record2Factories_() {}
 
   ESProductResolverFactoryProducer::~ESProductResolverFactoryProducer() noexcept(false) {}
+
+  std::vector<ESModuleProducesInfo> ESProductResolverFactoryProducer::producesInfo() const {
+    std::vector<ESModuleProducesInfo> producesInfo;
+    for (auto const& it : record2Factories_) {
+      producesInfo.emplace_back(it.first, it.second.key_, it.second.factory_->produceMethodID());
+    }
+    return producesInfo;
+  }
 
   ESProductResolverProvider::KeyedResolversVector ESProductResolverFactoryProducer::registerResolvers(
       const EventSetupRecordKey& iRecord, unsigned int iovIndex) {

--- a/FWCore/Framework/src/ESTagGetter.cc
+++ b/FWCore/Framework/src/ESTagGetter.cc
@@ -14,7 +14,6 @@
 
 // user include files
 #include "FWCore/Framework/interface/ESTagGetter.h"
-#include "FWCore/Framework/interface/ESRecordsToProductResolverIndices.h"
 #include "FWCore/Framework/interface/ComponentDescription.h"
 
 using namespace edm;

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -716,7 +716,7 @@ namespace edm {
     if (firstException) {
       std::rethrow_exception(firstException);
     }
-    pathsAndConsumesOfModules.initializeForEventSetup(std::move(esRecordsToProductResolverIndices), *esp_);
+    pathsAndConsumesOfModules.initializeForEventSetup(*esp_);
     actReg_->lookupInitializationCompleteSignal_(pathsAndConsumesOfModules, processContext_);
     schedule_->releaseMemoryPostLookupSignal();
 

--- a/FWCore/Framework/src/EventSetupProvider.cc
+++ b/FWCore/Framework/src/EventSetupProvider.cc
@@ -76,6 +76,15 @@ namespace edm {
       return recordProviders_[index].get();
     }
 
+    EventSetupRecordProvider const* EventSetupProvider::tryToGetRecordProvider(const EventSetupRecordKey& iKey) const {
+      auto lb = std::lower_bound(recordKeys_.begin(), recordKeys_.end(), iKey);
+      if (lb == recordKeys_.end() || iKey != *lb) {
+        return nullptr;
+      }
+      auto index = std::distance(recordKeys_.begin(), lb);
+      return recordProviders_[index].get();
+    }
+
     void EventSetupProvider::fillAllESProductResolverProviders(
         std::vector<ESProductResolverProvider const*>& allESProductResolverProviders) const {
       std::unordered_set<unsigned int> componentIDs;

--- a/FWCore/Framework/src/EventSetupRecordImpl.cc
+++ b/FWCore/Framework/src/EventSetupRecordImpl.cc
@@ -254,9 +254,7 @@ namespace edm {
       return nullptr;
     }
 
-    void EventSetupRecordImpl::fillRegisteredDataKeys(std::vector<DataKey>& oToFill) const {
-      oToFill = keysForResolvers_;
-    }
+    std::vector<DataKey> const& EventSetupRecordImpl::registeredDataKeys() const { return keysForResolvers_; }
 
     void EventSetupRecordImpl::addTraceInfoToCmsException(cms::Exception& iException,
                                                           const char* iName,

--- a/FWCore/Framework/src/EventSetupRecordProvider.cc
+++ b/FWCore/Framework/src/EventSetupRecordProvider.cc
@@ -235,8 +235,8 @@ namespace edm {
 
     void EventSetupRecordProvider::fillReferencedDataKeys(
         std::map<DataKey, ComponentDescription const*>& referencedDataKeys) const {
-      std::vector<DataKey> keys;
-      firstRecordImpl().fillRegisteredDataKeys(keys);
+      std::vector<DataKey> const& keys = firstRecordImpl().registeredDataKeys();
+
       std::vector<ComponentDescription const*> components = firstRecordImpl().componentsForRegisteredDataKeys();
       auto itComponents = components.begin();
       for (auto const& k : keys) {
@@ -316,10 +316,8 @@ namespace edm {
       }
     }
 
-    std::vector<DataKey> EventSetupRecordProvider::registeredDataKeys() const {
-      std::vector<DataKey> ret;
-      firstRecordImpl().fillRegisteredDataKeys(ret);
-      return ret;
+    std::vector<DataKey> const& EventSetupRecordProvider::registeredDataKeys() const {
+      return firstRecordImpl().registeredDataKeys();
     }
 
     std::vector<ComponentDescription const*> EventSetupRecordProvider::componentsForRegisteredDataKeys() const {

--- a/FWCore/Framework/src/PathsAndConsumesOfModules.cc
+++ b/FWCore/Framework/src/PathsAndConsumesOfModules.cc
@@ -507,7 +507,7 @@ namespace edm {
           }
         }
       }
-      result.emplace_back(std::move(info));
+      result.emplace_back(info);
     };
     return result;
   }

--- a/FWCore/Framework/src/PathsAndConsumesOfModules.cc
+++ b/FWCore/Framework/src/PathsAndConsumesOfModules.cc
@@ -91,8 +91,8 @@ namespace edm {
         auto const& typeID = consumesInfo.type();
 
         if (not consumesInfo.skipCurrentProcess()) {
-          assert(*consumedModuleLabel.data() !=
-                 '\0');  // consumesMany used to create empty labels before we removed consumesMany
+          // consumesMany used to create empty labels before we removed consumesMany
+          assert(*consumedModuleLabel.data() != '\0');
           if (*consumedProcessName.data() != '\0') {  // process name is specified in consumes call
             if (helper.index(kind,
                              typeID,

--- a/FWCore/Framework/src/PathsAndConsumesOfModules.cc
+++ b/FWCore/Framework/src/PathsAndConsumesOfModules.cc
@@ -4,17 +4,174 @@
 #include "FWCore/Framework/interface/EventSetupProvider.h"
 #include "FWCore/Framework/interface/Schedule.h"
 #include "FWCore/Framework/interface/maker/Worker.h"
+#include "FWCore/Framework/interface/ESModuleProducesInfo.h"
+#include "FWCore/Framework/interface/ESModuleConsumesMinimalInfo.h"
 #include "FWCore/ServiceRegistry/interface/ESModuleConsumesInfo.h"
 #include "FWCore/ServiceRegistry/interface/ModuleConsumesESInfo.h"
 #include "FWCore/ServiceRegistry/interface/ModuleConsumesInfo.h"
 #include "FWCore/Utilities/interface/EDMException.h"
+#include "DataFormats/Provenance/interface/ProductResolverIndexHelper.h"
 
 #include <algorithm>
 #include <limits>
 #include <unordered_set>
 #include <utility>
 
+#include <iostream>  // for debugging
+
 namespace edm {
+
+  namespace {
+    void insertFoundModuleLabel(edm::KindOfType consumedTypeKind,
+                                edm::TypeID consumedType,
+                                const char* consumedModuleLabel,
+                                const char* consumedProductInstance,
+                                std::vector<ModuleDescription const*>& modules,
+                                std::set<std::string>& alreadyFound,
+                                std::map<std::string, ModuleDescription const*> const& labelsToDesc,
+                                ProductRegistry const& preg) {
+      // Convert from label string to module description, eliminate duplicates,
+      // then insert into the vector of modules
+      if (auto it = labelsToDesc.find(consumedModuleLabel); it != labelsToDesc.end()) {
+        if (alreadyFound.insert(consumedModuleLabel).second) {
+          modules.push_back(it->second);
+        }
+        return;
+      }
+      // Deal with EDAlias's by converting to the original module label first
+      if (auto aliasToModuleLabels =
+              preg.aliasToModules(consumedTypeKind, consumedType, consumedModuleLabel, consumedProductInstance);
+          not aliasToModuleLabels.empty()) {
+        bool foundInLabelsToDesc = false;
+        for (auto const& label : aliasToModuleLabels) {
+          if (auto it = labelsToDesc.find(label); it != labelsToDesc.end()) {
+            if (alreadyFound.insert(label).second) {
+              modules.push_back(it->second);
+            }
+            foundInLabelsToDesc = true;
+          } else {
+            if (label == "source") {
+              foundInLabelsToDesc = true;
+            }
+          }
+        }
+        if (foundInLabelsToDesc) {
+          return;
+        }
+      }
+      // Ignore the source products, we are only interested in module products.
+      // As far as I know, it should never be anything else so throw if something
+      // unknown gets passed in.
+      if (std::string_view(consumedModuleLabel) != "source") {
+        throw cms::Exception("EDConsumerBase", "insertFoundModuleLabel")
+            << "Couldn't find ModuleDescription for the consumed product type: '" << consumedType.className()
+            << "' module label: '" << consumedModuleLabel << "' product instance name: '" << consumedProductInstance
+            << "'";
+      }
+    }
+
+    void modulesWhoseProductsAreConsumed(Worker* iWorker,
+                                         std::array<std::vector<ModuleDescription const*>*, NumBranchTypes>& modulesAll,
+                                         ProductRegistry const& preg,
+                                         std::map<std::string, ModuleDescription const*> const& labelsToDesc,
+                                         std::string const& processName) {
+      std::set<std::string> alreadyFound;
+
+      for (ModuleConsumesInfo const& consumesInfo : iWorker->moduleConsumesInfos()) {
+        ProductResolverIndexHelper const& helper = *preg.productLookup(consumesInfo.branchType());
+        std::vector<ModuleDescription const*>& modules = *modulesAll[consumesInfo.branchType()];
+
+        auto consumedModuleLabel = consumesInfo.label();
+        auto consumedProductInstance = consumesInfo.instance();
+        auto consumedProcessName = consumesInfo.process();
+        auto kind = consumesInfo.kindOfType();
+        auto const& typeID = consumesInfo.type();
+
+        if (not consumesInfo.skipCurrentProcess()) {
+          assert(*consumedModuleLabel.data() !=
+                 '\0');  // consumesMany used to create empty labels before we removed consumesMany
+          if (*consumedProcessName.data() != '\0') {  // process name is specified in consumes call
+            if (helper.index(kind,
+                             typeID,
+                             consumedModuleLabel.data(),
+                             consumedProductInstance.data(),
+                             consumedProcessName.data()) != ProductResolverIndexInvalid) {
+              if (processName == consumedProcessName) {
+                insertFoundModuleLabel(kind,
+                                       typeID,
+                                       consumedModuleLabel.data(),
+                                       consumedProductInstance.data(),
+                                       modules,
+                                       alreadyFound,
+                                       labelsToDesc,
+                                       preg);
+              }
+            }
+          } else {  // process name was empty
+            auto matches =
+                helper.relatedIndexes(kind, typeID, consumedModuleLabel.data(), consumedProductInstance.data());
+            for (unsigned int j = 0; j < matches.numberOfMatches(); ++j) {
+              if (processName == matches.processName(j)) {
+                insertFoundModuleLabel(kind,
+                                       typeID,
+                                       consumedModuleLabel.data(),
+                                       consumedProductInstance.data(),
+                                       modules,
+                                       alreadyFound,
+                                       labelsToDesc,
+                                       preg);
+              }
+            }
+          }
+        }
+      };
+    }
+    void fillModuleAndConsumesInfo(Schedule::AllWorkers const& allWorkers,
+                                   std::vector<ModuleDescription const*>& allModuleDescriptions,
+                                   std::vector<std::pair<unsigned int, unsigned int>>& moduleIDToIndex,
+                                   std::array<std::vector<std::vector<ModuleDescription const*>>, NumBranchTypes>&
+                                       modulesWhoseProductsAreConsumedBy,
+                                   ProductRegistry const& preg) {
+      allModuleDescriptions.clear();
+      moduleIDToIndex.clear();
+      for (auto iBranchType = 0U; iBranchType < NumBranchTypes; ++iBranchType) {
+        modulesWhoseProductsAreConsumedBy[iBranchType].clear();
+      }
+
+      allModuleDescriptions.reserve(allWorkers.size());
+      moduleIDToIndex.reserve(allWorkers.size());
+      for (auto iBranchType = 0U; iBranchType < NumBranchTypes; ++iBranchType) {
+        modulesWhoseProductsAreConsumedBy[iBranchType].resize(allWorkers.size());
+      }
+
+      std::map<std::string, ModuleDescription const*> labelToDesc;
+      unsigned int i = 0;
+      for (auto const& worker : allWorkers) {
+        ModuleDescription const* p = worker->description();
+        allModuleDescriptions.push_back(p);
+        moduleIDToIndex.push_back(std::pair<unsigned int, unsigned int>(p->id(), i));
+        labelToDesc[p->moduleLabel()] = p;
+        ++i;
+      }
+      sort_all(moduleIDToIndex);
+
+      i = 0;
+      for (auto const& worker : allWorkers) {
+        std::array<std::vector<ModuleDescription const*>*, NumBranchTypes> modules;
+        for (auto iBranchType = 0U; iBranchType < NumBranchTypes; ++iBranchType) {
+          modules[iBranchType] = &modulesWhoseProductsAreConsumedBy[iBranchType].at(i);
+        }
+        try {
+          modulesWhoseProductsAreConsumed(worker, modules, preg, labelToDesc, worker->description()->processName());
+        } catch (cms::Exception& ex) {
+          ex.addContext("Calling Worker::modulesWhoseProductsAreConsumed() for module " +
+                        worker->description()->moduleLabel());
+          throw;
+        }
+        ++i;
+      }
+    }
+  }  // namespace
 
   void PathsAndConsumesOfModules::initialize(Schedule const* schedule, std::shared_ptr<ProductRegistry const> preg) {
     schedule_ = schedule;
@@ -46,16 +203,144 @@ namespace edm {
       ++i;
     }
 
-    schedule->fillModuleAndConsumesInfo(
-        allModuleDescriptions_, moduleIDToIndex_, modulesWhoseProductsAreConsumedBy_, *preg);
+    fillModuleAndConsumesInfo(
+        schedule_->allWorkers(), allModuleDescriptions_, moduleIDToIndex_, modulesWhoseProductsAreConsumedBy_, *preg);
   }
 
-  void PathsAndConsumesOfModules::initializeForEventSetup(
-      eventsetup::ESRecordsToProductResolverIndices&& esRecordsToProductResolverIndices,
-      eventsetup::EventSetupProvider const& eventSetupProvider) {
-    esRecordsToProductResolverIndices_ = std::move(esRecordsToProductResolverIndices);
-    schedule_->fillESModuleAndConsumesInfo(esModulesWhoseProductsAreConsumedBy_, esRecordsToProductResolverIndices_);
+  namespace {}  // namespace
+  using ProducedByESModule = PathsAndConsumesOfModules::ProducedByESModule;
+  namespace {
+    void esModulesWhoseProductsAreConsumed(
+        Worker* worker,
+        std::array<std::vector<eventsetup::ComponentDescription const*>*, kNumberOfEventSetupTransitions>& esModules,
+        ProducedByESModule const& producedByESModule) {
+      std::array<std::set<std::string>, kNumberOfEventSetupTransitions> alreadyFound;
+
+      for (auto const& info : worker->moduleConsumesMinimalESInfos()) {
+        auto const& recordInfo = producedByESModule.find(info.record_);
+        if (recordInfo != producedByESModule.end()) {
+          auto itFound = recordInfo->second.find(info.dataKey_);
+          if (itFound != recordInfo->second.end()) {
+            auto const& componentDescription = itFound->second.componentDescription_;
+            if (componentDescription) {
+              std::string const& moduleLabel =
+                  componentDescription->label_.empty() ? componentDescription->type_ : componentDescription->label_;
+              //check for matching labels if required
+              if (info.componentLabel_.empty() || info.componentLabel_ == moduleLabel) {
+                auto transitionIndex = static_cast<unsigned int>(info.transition_);
+                if (alreadyFound[transitionIndex].insert(moduleLabel).second) {
+                  esModules[transitionIndex]->push_back(componentDescription);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    std::array<std::vector<std::vector<eventsetup::ComponentDescription const*>>, kNumberOfEventSetupTransitions>
+    esModulesWhoseProductsAreConsumedByCreate(Schedule::AllWorkers const& allWorkers,
+                                              ProducedByESModule const& producedByESModule) {
+      std::array<std::vector<std::vector<eventsetup::ComponentDescription const*>>, kNumberOfEventSetupTransitions>
+          esModulesWhoseProductsAreConsumedBy;
+
+      for (auto& item : esModulesWhoseProductsAreConsumedBy) {
+        item.resize(allWorkers.size());
+      }
+
+      for (unsigned int i = 0; auto const& worker : allWorkers) {
+        std::array<std::vector<eventsetup::ComponentDescription const*>*, kNumberOfEventSetupTransitions> esModules;
+        for (auto transition = 0U; transition < kNumberOfEventSetupTransitions; ++transition) {
+          esModules[transition] = &esModulesWhoseProductsAreConsumedBy[transition].at(i);
+        }
+        try {
+          esModulesWhoseProductsAreConsumed(worker, esModules, producedByESModule);
+        } catch (cms::Exception& ex) {
+          ex.addContext("Calling Worker::esModulesWhoseProductsAreConsumed() for module " +
+                        worker->description()->moduleLabel());
+          throw;
+        }
+        ++i;
+      }
+      return esModulesWhoseProductsAreConsumedBy;
+    }
+
+    ProducedByESModule fillProducedByESModule(
+        std::vector<const eventsetup::ESProductResolverProvider*> const& allESProductResolverProviders) {
+      ProducedByESModule producedByESModule;
+
+      for (auto const& provider : allESProductResolverProviders) {
+        auto const& producesInfo = provider->producesInfo();
+        for (auto const& info : producesInfo) {
+          auto const& recordKey = info.record();
+          auto const& dataKey = info.dataKey();
+          auto const& componentDescription = provider->description();
+          producedByESModule[recordKey][dataKey] = {&componentDescription, info.produceMethodID()};
+        }
+      }
+      return producedByESModule;
+    }
+
+    std::vector<std::vector<eventsetup::ComponentDescription const*>> esModulesWhoseProductsAreConsumedByESModuleCreate(
+        std::vector<const eventsetup::ESProductResolverProvider*> const& allESProductResolverProviders,
+        ProducedByESModule const& producedByESModule) {
+      std::vector<std::vector<eventsetup::ComponentDescription const*>> retValue;
+
+      retValue.resize(allESProductResolverProviders.size());
+      auto it = retValue.begin();
+      for (auto& provider : allESProductResolverProviders) {
+        ESProducer const* esProducer = dynamic_cast<ESProducer const*>(provider);
+        if (esProducer) {
+          std::set<unsigned int> alreadyFound;
+          auto const& consumesInfo = esProducer->esModuleConsumesMinimalInfos();
+          for (auto const& info : consumesInfo) {
+            auto const& recordKey = info.recordForDataKey_;
+            auto const& dataKey = info.dataKey_;
+            auto itFound = producedByESModule.find(recordKey);
+            if (itFound != producedByESModule.end()) {
+              if (dataKey.name() == "@mayConsume") {
+                // This is a "may consume" case, we need to find all components that may produce this dataKey
+                for (auto const& [dataKey, produceInfo] : itFound->second) {
+                  auto componentDescription = produceInfo.componentDescription_;
+                  if (dataKey.type() == info.dataKey_.type()) {
+                    if (componentDescription and alreadyFound.find(componentDescription->id_) == alreadyFound.end()) {
+                      alreadyFound.insert(componentDescription->id_);
+                      it->push_back(componentDescription);
+                    }
+                  }
+                }
+              } else {
+                // This is a normal case, we need to find the specific component that produces this dataKey
+                auto itDataKey = itFound->second.find(dataKey);
+                if (itDataKey != itFound->second.end()) {
+                  eventsetup::ComponentDescription const* componentDescription =
+                      itDataKey->second.componentDescription_;
+                  if (componentDescription and alreadyFound.find(componentDescription->id_) == alreadyFound.end()) {
+                    //an empty label matches any label, else we need an exact match
+                    if (info.componentLabel_.empty() || info.componentLabel_ == componentDescription->label_) {
+                      alreadyFound.insert(componentDescription->id_);
+                      it->push_back(componentDescription);
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        ++it;
+      }
+      return retValue;
+    }
+
+  }  // namespace
+
+  void PathsAndConsumesOfModules::initializeForEventSetup(eventsetup::EventSetupProvider const& eventSetupProvider) {
     eventSetupProvider.fillAllESProductResolverProviders(allESProductResolverProviders_);
+
+    producedByESModule_ = fillProducedByESModule(allESProductResolverProviders_);
+
+    esModulesWhoseProductsAreConsumedBy_ =
+        esModulesWhoseProductsAreConsumedByCreate(schedule_->allWorkers(), producedByESModule_);
 
     for (unsigned int i = 0; i < allESProductResolverProviders_.size(); ++i) {
       eventsetup::ComponentDescription const& componentDescription = allESProductResolverProviders_[i]->description();
@@ -64,15 +349,8 @@ namespace edm {
     }
     sort_all(esModuleIDToIndex_);
 
-    esModulesWhoseProductsAreConsumedByESModule_.resize(allESProductResolverProviders_.size());
-    auto it = esModulesWhoseProductsAreConsumedByESModule_.begin();
-    for (auto& provider : allESProductResolverProviders_) {
-      ESProducer const* esProducer = dynamic_cast<ESProducer const*>(provider);
-      if (esProducer) {
-        esProducer->esModulesWhoseProductsAreConsumed(*it, esRecordsToProductResolverIndices_);
-      }
-      ++it;
-    }
+    esModulesWhoseProductsAreConsumedByESModule_ =
+        esModulesWhoseProductsAreConsumedByESModuleCreate(allESProductResolverProviders_, producedByESModule_);
     eventSetupInfoInitialized_ = true;
   }
 
@@ -171,10 +449,67 @@ namespace edm {
     return worker->moduleConsumesInfos();
   }
 
+  auto const& labelForComponentDescription(eventsetup::ComponentDescription const* description) {
+    if (description->label_.empty()) {
+      return description->type_;
+    }
+    return description->label_;
+  }
+
   std::vector<ModuleConsumesESInfo> PathsAndConsumesOfModules::doModuleConsumesESInfos(unsigned int moduleID) const {
     checkEventSetupInitialization();
     Worker const* worker = schedule_->allWorkers().at(moduleIndex(moduleID));
-    return worker->moduleConsumesESInfos(esRecordsToProductResolverIndices_);
+    auto const& minConsumesESInfos = worker->moduleConsumesMinimalESInfos();
+    std::vector<ModuleConsumesESInfo> result;
+    result.reserve(minConsumesESInfos.size());
+    for (auto const& minInfo : minConsumesESInfos) {
+      ModuleConsumesESInfo info;
+      info.eventSetupRecordType_ = minInfo.record_.name();
+      info.productType_ = minInfo.dataKey_.type().name();
+      //Moving this to a string_view is safe as the minInfo.dataKey_ does not own the memory
+      info.productLabel_ = minInfo.dataKey_.name().value();
+      info.requestedModuleLabel_ = minInfo.componentLabel_;
+      info.transitionOfConsumer_ = minInfo.transition_;
+      if (not info.requestedModuleLabel_.empty()) {
+        auto itRec = producedByESModule_.find(minInfo.record_);
+        if (itRec != producedByESModule_.end()) {
+          auto itDataKeyInfo = itRec->second.find(minInfo.dataKey_);
+          if (itDataKeyInfo != itRec->second.end()) {
+            info.moduleLabelMismatch_ =
+                labelForComponentDescription(itDataKeyInfo->second.componentDescription_) != info.requestedModuleLabel_;
+          }
+        }
+      }
+
+      // Initial values used in the case where there isn't an EventSetup
+      // module to produce the requested data. Test whether moduleType
+      // is empty to identify this case because it will be empty if and
+      // only if this is true.
+      info.moduleType_ = {};
+      info.moduleLabel_ = {};
+      info.produceMethodIDOfProducer_ = 0;
+      info.isSource_ = false;
+      info.isLooper_ = false;
+
+      auto itRec = producedByESModule_.find(minInfo.record_);
+      if (itRec != producedByESModule_.end()) {
+        auto itDataKeyInfo = itRec->second.find(minInfo.dataKey_);
+        if (itDataKeyInfo != itRec->second.end()) {
+          auto produceMethodID = itDataKeyInfo->second.produceMethodID_;
+          auto componentDescription = itDataKeyInfo->second.componentDescription_;
+          if (componentDescription) {
+            info.moduleType_ = componentDescription->type_;
+            info.moduleLabel_ =
+                componentDescription->label_.empty() ? componentDescription->type_ : componentDescription->label_;
+            info.produceMethodIDOfProducer_ = produceMethodID;
+            info.isSource_ = componentDescription->isSource_;
+            info.isLooper_ = componentDescription->isLooper_;
+          }
+        }
+      }
+      result.emplace_back(std::move(info));
+    };
+    return result;
   }
 
   unsigned int PathsAndConsumesOfModules::doLargestModuleID() const {
@@ -198,6 +533,119 @@ namespace edm {
     return esModulesWhoseProductsAreConsumedByESModule_;
   }
 
+  namespace {
+    std::vector<std::vector<ESModuleConsumesInfo>> esModuleConsumesInfosCreate(
+        ESProducer const& esProducer, ProducedByESModule const& producedByESModule) {
+      auto const& consumesInfos = esProducer.esModuleConsumesMinimalInfos();
+      std::vector<std::vector<ESModuleConsumesInfo>> result;
+      // The outer vector has an entry per produce method ID
+      unsigned int largestProduceMethodID = 0;
+      for (auto const& produced : esProducer.producesInfo()) {
+        if (produced.produceMethodID() > largestProduceMethodID) {
+          largestProduceMethodID = produced.produceMethodID();
+        }
+      }
+      result.resize(largestProduceMethodID + 1);
+      if (consumesInfos.empty()) {
+        return result;
+      }
+      result.resize(consumesInfos.back().produceMethodID_ + 1);
+
+      for (auto const& esConsumesInfo : consumesInfos) {
+        auto& resultForTransition = result[esConsumesInfo.produceMethodID_];
+
+        ESModuleConsumesInfo info;
+        info.produceMethodIDOfConsumer_ = esConsumesInfo.produceMethodID_;
+        info.eventSetupRecordType_ = esConsumesInfo.recordForDataKey_.name();
+        info.productType_ = esConsumesInfo.dataKey_.type().name();
+        info.moduleType_ = {};
+        info.moduleLabel_ = {};
+        info.produceMethodIDOfProducer_ = 0;
+        info.isSource_ = false;
+        info.isLooper_ = false;
+        info.moduleLabelMismatch_ = false;
+
+        // If there is a chooser this is the special case of a "may consumes"
+        if (esConsumesInfo.dataKey_.name() == "@mayConsume") {
+          info.requestedModuleLabel_ = {};
+          info.mayConsumes_ = true;
+          info.mayConsumesFirstEntry_ = true;
+
+          //look for matches
+          auto itRec = producedByESModule.find(esConsumesInfo.recordForDataKey_);
+          if (itRec == producedByESModule.end()) {
+            // No producers for this record, so no products can be consumed
+            info.productLabel_ = {};
+            info.mayConsumesNoProducts_ = true;
+            resultForTransition.push_back(info);
+            continue;
+          }
+          // In the "may consumes" case, we iterate over all the possible data products
+          // the EventSetup can produce with matching record type and product type.
+          // With the current design of the mayConsumes feature, there is no way to
+          // know in advance which productLabel or moduleLabel will be requested.
+          // Maybe none will be. requestedModuleLabel and moduleLabelMismatch
+          // are meaningless for "may consumes" cases.
+
+          auto const nPreMayConsumes = resultForTransition.size();
+          for (auto const& products : itRec->second) {
+            if (products.first.type() == esConsumesInfo.dataKey_.type()) {
+              // This is a "may consume" case, we need to find all components that may produce this dataKey
+              auto const& componentDescription = products.second.componentDescription_;
+              if (componentDescription) {
+                info.productLabel_ = products.first.name().value();
+                info.moduleType_ = componentDescription->type_;
+                info.moduleLabel_ = labelForComponentDescription(componentDescription);
+                info.mayConsumesNoProducts_ = false;
+
+                info.produceMethodIDOfProducer_ = products.second.produceMethodID_;
+                info.isSource_ = componentDescription->isSource_;
+                info.isLooper_ = componentDescription->isLooper_;
+                resultForTransition.push_back(info);
+                info.mayConsumesFirstEntry_ = false;
+              }
+            }
+          }
+          if (resultForTransition.size() == nPreMayConsumes) {
+            // No products can be consumed, so we add an empty entry
+            // to indicate that this is a "may consumes" case with no products
+            info.productLabel_ = {};
+            info.mayConsumesNoProducts_ = true;
+            resultForTransition.push_back(info);
+          }
+          // Handle cases not involving "may consumes"
+        } else {
+          //look for matches
+          info.productLabel_ = esConsumesInfo.dataKey_.name().value();
+          info.requestedModuleLabel_ = esConsumesInfo.componentLabel_;
+          auto itRec = producedByESModule.find(esConsumesInfo.recordForDataKey_);
+          if (itRec != producedByESModule.end()) {
+            auto itProduceInfo = itRec->second.find(esConsumesInfo.dataKey_);
+            if (itProduceInfo != itRec->second.end()) {
+              auto const componentDescription = itProduceInfo->second.componentDescription_;
+              info.moduleLabelMismatch_ =
+                  ((componentDescription) and (not esConsumesInfo.componentLabel_.empty()) and
+                   esConsumesInfo.componentLabel_ != labelForComponentDescription(componentDescription));
+              info.mayConsumes_ = false;
+              info.mayConsumesFirstEntry_ = false;
+              info.mayConsumesNoProducts_ = false;
+
+              if (componentDescription) {
+                info.moduleType_ = componentDescription->type_;
+                info.moduleLabel_ = labelForComponentDescription(componentDescription);
+                info.produceMethodIDOfProducer_ = itProduceInfo->second.produceMethodID_;
+                info.isSource_ = componentDescription->isSource_;
+                info.isLooper_ = componentDescription->isLooper_;
+              }
+            }
+          }
+          resultForTransition.push_back(info);
+        }
+      }
+      return result;
+    }
+
+  }  // namespace
   std::vector<std::vector<ESModuleConsumesInfo>> PathsAndConsumesOfModules::doESModuleConsumesInfos(
       unsigned int esModuleID) const {
     checkEventSetupInitialization();
@@ -205,7 +653,7 @@ namespace edm {
         allESProductResolverProviders_.at(esModuleIndex(esModuleID));
     ESProducer const* esProducer = dynamic_cast<ESProducer const*>(provider);
     if (esProducer) {
-      return esProducer->esModuleConsumesInfos(esRecordsToProductResolverIndices_);
+      return esModuleConsumesInfosCreate(*esProducer, producedByESModule_);
     }
     return {};
   }

--- a/FWCore/Framework/src/WorkerT.cc
+++ b/FWCore/Framework/src/WorkerT.cc
@@ -20,7 +20,6 @@
 #include "FWCore/Framework/interface/limited/OutputModuleBase.h"
 
 #include "FWCore/ServiceRegistry/interface/ModuleConsumesInfo.h"
-#include "FWCore/ServiceRegistry/interface/ModuleConsumesESInfo.h"
 
 #include <type_traits>
 
@@ -928,12 +927,6 @@ namespace edm {
   template <typename T>
   std::vector<ModuleConsumesInfo> WorkerT<T>::moduleConsumesInfos() const {
     return module_->moduleConsumesInfos();
-  }
-
-  template <typename T>
-  std::vector<ModuleConsumesESInfo> WorkerT<T>::moduleConsumesESInfos(
-      eventsetup::ESRecordsToProductResolverIndices const& iPI) const {
-    return module_->moduleConsumesESInfos(iPI);
   }
 
   //Explicitly instantiate our needed templates to avoid having the compiler

--- a/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
@@ -24,7 +24,6 @@
 #include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
 #include "FWCore/Framework/interface/RunPrincipal.h"
 #include "FWCore/ServiceRegistry/interface/ESParentContext.h"
-#include "FWCore/ServiceRegistry/interface/ModuleConsumesESInfo.h"
 #include "FWCore/ServiceRegistry/interface/ModuleConsumesInfo.h"
 
 #include "FWCore/Framework/interface/PreallocationConfiguration.h"
@@ -139,22 +138,6 @@ void EDAnalyzerAdaptorBase::releaseMemoryPostLookupSignal() {
 
 const edm::EDConsumerBase* EDAnalyzerAdaptorBase::consumer() const { return m_streamModules[0]; }
 
-void EDAnalyzerAdaptorBase::modulesWhoseProductsAreConsumed(
-    std::array<std::vector<ModuleDescription const*>*, NumBranchTypes>& modules,
-    ProductRegistry const& preg,
-    std::map<std::string, ModuleDescription const*> const& labelsToDesc,
-    std::string const& processName) const {
-  assert(not m_streamModules.empty());
-  return m_streamModules[0]->modulesWhoseProductsAreConsumed(modules, preg, labelsToDesc, processName);
-}
-
-void EDAnalyzerAdaptorBase::esModulesWhoseProductsAreConsumed(
-    std::array<std::vector<eventsetup::ComponentDescription const*>*, kNumberOfEventSetupTransitions>& esModules,
-    eventsetup::ESRecordsToProductResolverIndices const& iPI) const {
-  assert(not m_streamModules.empty());
-  return m_streamModules[0]->esModulesWhoseProductsAreConsumed(esModules, iPI);
-}
-
 void EDAnalyzerAdaptorBase::convertCurrentProcessAlias(std::string const& processName) {
   for (auto mod : m_streamModules) {
     mod->convertCurrentProcessAlias(processName);
@@ -166,10 +149,9 @@ std::vector<edm::ModuleConsumesInfo> EDAnalyzerAdaptorBase::moduleConsumesInfos(
   return m_streamModules[0]->moduleConsumesInfos();
 }
 
-std::vector<edm::ModuleConsumesESInfo> EDAnalyzerAdaptorBase::moduleConsumesESInfos(
-    eventsetup::ESRecordsToProductResolverIndices const& iPI) const {
+std::vector<edm::ModuleConsumesMinimalESInfo> EDAnalyzerAdaptorBase::moduleConsumesMinimalESInfos() const {
   assert(not m_streamModules.empty());
-  return m_streamModules[0]->moduleConsumesESInfos(iPI);
+  return m_streamModules[0]->moduleConsumesMinimalESInfos();
 }
 
 bool EDAnalyzerAdaptorBase::doEvent(EventTransitionInfo const& info,

--- a/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
@@ -23,8 +23,8 @@
 #include "FWCore/Framework/interface/PreallocationConfiguration.h"
 #include "FWCore/Framework/interface/TransitionInfoTypes.h"
 #include "FWCore/Framework/interface/EventForTransformer.h"
+#include "FWCore/Framework/interface/ModuleConsumesMinimalESInfo.h"
 #include "FWCore/ServiceRegistry/interface/ESParentContext.h"
-#include "FWCore/ServiceRegistry/interface/ModuleConsumesESInfo.h"
 #include "FWCore/ServiceRegistry/interface/ModuleConsumesInfo.h"
 
 //
@@ -130,24 +130,6 @@ namespace edm {
     }
 
     template <typename T>
-    void ProducingModuleAdaptorBase<T>::modulesWhoseProductsAreConsumed(
-        std::array<std::vector<ModuleDescription const*>*, NumBranchTypes>& modules,
-        ProductRegistry const& preg,
-        std::map<std::string, ModuleDescription const*> const& labelsToDesc,
-        std::string const& processName) const {
-      assert(not m_streamModules.empty());
-      return m_streamModules[0]->modulesWhoseProductsAreConsumed(modules, preg, labelsToDesc, processName);
-    }
-
-    template <typename T>
-    void ProducingModuleAdaptorBase<T>::esModulesWhoseProductsAreConsumed(
-        std::array<std::vector<eventsetup::ComponentDescription const*>*, kNumberOfEventSetupTransitions>& esModules,
-        eventsetup::ESRecordsToProductResolverIndices const& iPI) const {
-      assert(not m_streamModules.empty());
-      return m_streamModules[0]->esModulesWhoseProductsAreConsumed(esModules, iPI);
-    }
-
-    template <typename T>
     void ProducingModuleAdaptorBase<T>::convertCurrentProcessAlias(std::string const& processName) {
       for (auto mod : m_streamModules) {
         mod->convertCurrentProcessAlias(processName);
@@ -161,10 +143,9 @@ namespace edm {
     }
 
     template <typename T>
-    std::vector<edm::ModuleConsumesESInfo> ProducingModuleAdaptorBase<T>::moduleConsumesESInfos(
-        eventsetup::ESRecordsToProductResolverIndices const& iPI) const {
+    std::vector<edm::ModuleConsumesMinimalESInfo> ProducingModuleAdaptorBase<T>::moduleConsumesMinimalESInfos() const {
       assert(not m_streamModules.empty());
-      return m_streamModules[0]->moduleConsumesESInfos(iPI);
+      return m_streamModules[0]->moduleConsumesMinimalESInfos();
     }
 
     template <typename T>

--- a/FWCore/Framework/test/DummyESProductResolverProvider.h
+++ b/FWCore/Framework/test/DummyESProductResolverProvider.h
@@ -27,6 +27,7 @@
 
 #include "FWCore/Framework/interface/ESProductResolverTemplate.h"
 #include "FWCore/Framework/interface/ESProductResolverProvider.h"
+#include "FWCore/Framework/interface/ESModuleProducesInfo.h"
 
 // forward declarations
 namespace edm::eventsetup::test {
@@ -47,6 +48,15 @@ namespace edm::eventsetup::test {
     DummyESProductResolverProvider(const DummyData& iData = DummyData()) : dummy_(iData) { usingRecord<DummyRecord>(); }
 
     void incrementData() { ++dummy_.value_; }
+
+    std::vector<eventsetup::ESModuleProducesInfo> producesInfo() const override {
+      return std::vector<eventsetup::ESModuleProducesInfo>(
+          1,
+          eventsetup::ESModuleProducesInfo(
+              edm::eventsetup::EventSetupRecordKey::makeKey<DummyRecord>(),
+              edm::eventsetup::DataKey(edm::eventsetup::DataKey::makeTypeTag<DummyData>(), ""),
+              0));
+    }
 
   protected:
     KeyedResolversVector registerResolvers(const EventSetupRecordKey&, unsigned int /* iovIndex */) override {

--- a/FWCore/Framework/test/ESProductResolverFactoryTemplate.h
+++ b/FWCore/Framework/test/ESProductResolverFactoryTemplate.h
@@ -46,6 +46,7 @@ namespace edm {
       DataKey makeKey(const std::string& iName) const override {
         return DataKey(DataKey::makeTypeTag<typename T::value_type>(), iName.c_str());
       }
+      unsigned int produceMethodID() const override { return 0; }
     };
   }  // namespace eventsetup
 }  // namespace edm

--- a/FWCore/Framework/test/dependentrecord_t.cppunit.cc
+++ b/FWCore/Framework/test/dependentrecord_t.cppunit.cc
@@ -27,6 +27,7 @@
 #include "FWCore/Framework/src/SynchronousEventSetupsController.h"
 #include "FWCore/Framework/interface/NoRecordException.h"
 #include "FWCore/Framework/test/print_eventsetup_record_dependencies.h"
+#include "FWCore/Framework/interface/ESModuleProducesInfo.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 #include "FWCore/ServiceRegistry/interface/ESParentContext.h"
@@ -128,6 +129,9 @@ namespace {
     KeyedResolversVector registerResolvers(const EventSetupRecordKey&, unsigned int /* iovIndex */) override {
       return KeyedResolversVector();
     }
+    std::vector<edm::eventsetup::ESModuleProducesInfo> producesInfo() const override {
+      return std::vector<edm::eventsetup::ESModuleProducesInfo>();
+    }
   };
 
   class DepRecordResolverProvider : public edm::eventsetup::ESProductResolverProvider {
@@ -137,6 +141,9 @@ namespace {
   protected:
     KeyedResolversVector registerResolvers(const EventSetupRecordKey&, unsigned int /* iovIndex */) override {
       return KeyedResolversVector();
+    }
+    std::vector<edm::eventsetup::ESModuleProducesInfo> producesInfo() const override {
+      return std::vector<edm::eventsetup::ESModuleProducesInfo>();
     }
   };
 
@@ -168,6 +175,14 @@ namespace {
       keyedResolversVector.emplace_back(dataKey, pResolver);
       return keyedResolversVector;
     }
+    std::vector<edm::eventsetup::ESModuleProducesInfo> producesInfo() const override {
+      return std::vector<edm::eventsetup::ESModuleProducesInfo>(
+          1,
+          edm::eventsetup::ESModuleProducesInfo(
+              edm::eventsetup::EventSetupRecordKey::makeKey<DepRecord>(),
+              edm::eventsetup::DataKey(edm::eventsetup::DataKey::makeTypeTag<edm::eventsetup::test::DummyData>(), ""),
+              0));
+    }
 
   private:
     edm::eventsetup::test::DummyData dummy_;
@@ -180,6 +195,9 @@ namespace {
   protected:
     KeyedResolversVector registerResolvers(const EventSetupRecordKey&, unsigned int /* iovIndex */) override {
       return KeyedResolversVector();
+    }
+    std::vector<edm::eventsetup::ESModuleProducesInfo> producesInfo() const override {
+      return std::vector<edm::eventsetup::ESModuleProducesInfo>();
     }
   };
 

--- a/FWCore/Framework/test/esproducer_t.cppunit.cc
+++ b/FWCore/Framework/test/esproducer_t.cppunit.cc
@@ -661,7 +661,7 @@ namespace {
       auto cc = setWhatProduced(this, "produced");
       cc.setMayConsume(
           token_,
-          [this](auto& get, edm::ESTransientHandle<edm::eventsetup::test::DummyData> const& handle) {
+          [](auto& get, edm::ESTransientHandle<edm::eventsetup::test::DummyData> const& handle) {
             return get.nothing();
           },
           edm::ESProductTag<edm::eventsetup::test::DummyData, DummyRecord>("", ""));

--- a/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
@@ -254,8 +254,7 @@ namespace {
       }
 
       ESRecordsToProductResolverIndices resolverIndices({iKey});
-      std::vector<DataKey> dataKeys;
-      dummyRecordImpl.fillRegisteredDataKeys(dataKeys);
+      std::vector<DataKey> const& dataKeys = dummyRecordImpl.registeredDataKeys();
 
       (void)resolverIndices.dataKeysInRecord(0,
                                              iKey,
@@ -562,8 +561,7 @@ void testEventsetupRecord::introspectionTest() {
 
   const DataKey dummyDataKey(DataKey::makeTypeTag<FailingDummyResolver::value_type>(), "");
 
-  std::vector<edm::eventsetup::DataKey> keys;
-  dummyRecordImpl.fillRegisteredDataKeys(keys);
+  std::vector<edm::eventsetup::DataKey> keys = dummyRecordImpl.registeredDataKeys();
   CPPUNIT_ASSERT(keys.empty());
 
   DummyRecord dummyRecord;
@@ -574,8 +572,7 @@ void testEventsetupRecord::introspectionTest() {
   dummyRecordImpl.getESProducers(esproducers);
   CPPUNIT_ASSERT(esproducers.empty());
 
-  std::vector<DataKey> referencedDataKeys;
-  dummyRecordImpl.fillRegisteredDataKeys(referencedDataKeys);
+  std::vector<DataKey> referencedDataKeys = dummyRecordImpl.registeredDataKeys();
   auto referencedComponents = dummyRecordImpl.componentsForRegisteredDataKeys();
   CPPUNIT_ASSERT(referencedDataKeys.empty());
   CPPUNIT_ASSERT(referencedComponents.empty());
@@ -589,7 +586,7 @@ void testEventsetupRecord::introspectionTest() {
   CPPUNIT_ASSERT(esproducers.size() == 1);
   CPPUNIT_ASSERT(esproducers[0] == &cd1);
 
-  dummyRecordImpl.fillRegisteredDataKeys(referencedDataKeys);
+  referencedDataKeys = dummyRecordImpl.registeredDataKeys();
   referencedComponents = dummyRecordImpl.componentsForRegisteredDataKeys();
   CPPUNIT_ASSERT(referencedDataKeys.size() == 1);
   CPPUNIT_ASSERT(referencedComponents.size() == 1);
@@ -616,7 +613,7 @@ void testEventsetupRecord::introspectionTest() {
   dummyRecordImpl.getESProducers(esproducers);
   CPPUNIT_ASSERT(esproducers.size() == 1);
 
-  dummyRecordImpl.fillRegisteredDataKeys(referencedDataKeys);
+  referencedDataKeys = dummyRecordImpl.registeredDataKeys();
   referencedComponents = dummyRecordImpl.componentsForRegisteredDataKeys();
   CPPUNIT_ASSERT(referencedDataKeys.size() == 2);
   CPPUNIT_ASSERT(referencedComponents.size() == 2);
@@ -639,7 +636,7 @@ void testEventsetupRecord::introspectionTest() {
   dummyRecordImpl.getESProducers(esproducers);
   CPPUNIT_ASSERT(esproducers.size() == 1);
 
-  dummyRecordImpl.fillRegisteredDataKeys(referencedDataKeys);
+  referencedDataKeys = dummyRecordImpl.registeredDataKeys();
   referencedComponents = dummyRecordImpl.componentsForRegisteredDataKeys();
   CPPUNIT_ASSERT(referencedDataKeys.size() == 3);
   CPPUNIT_ASSERT(referencedComponents.size() == 3);
@@ -663,7 +660,7 @@ void testEventsetupRecord::introspectionTest() {
   CPPUNIT_ASSERT(esproducers.size() == 2);
   CPPUNIT_ASSERT(esproducers[1] == &cd4);
 
-  dummyRecordImpl.fillRegisteredDataKeys(referencedDataKeys);
+  referencedDataKeys = dummyRecordImpl.registeredDataKeys();
   referencedComponents = dummyRecordImpl.componentsForRegisteredDataKeys();
   CPPUNIT_ASSERT(referencedDataKeys.size() == 4);
   CPPUNIT_ASSERT(referencedComponents.size() == 4);

--- a/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
@@ -25,6 +25,7 @@
 
 #include "FWCore/Framework/interface/ESProductResolverTemplate.h"
 #include "FWCore/Framework/interface/ESProductResolverProvider.h"
+#include "FWCore/Framework/interface/ESModuleProducesInfo.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ESValidHandle.h"
@@ -154,6 +155,12 @@ public:
   WorkingDummyProvider(const edm::eventsetup::DataKey& iKey, std::shared_ptr<WorkingDummyResolver> iResolver)
       : m_key(iKey), m_resolver(iResolver) {
     usingRecord<DummyRecord>();
+  }
+
+  std::vector<edm::eventsetup::ESModuleProducesInfo> producesInfo() const override {
+    return std::vector<edm::eventsetup::ESModuleProducesInfo>(
+        1,
+        edm::eventsetup::ESModuleProducesInfo(edm::eventsetup::EventSetupRecordKey::makeKey<DummyRecord>(), m_key, 0));
   }
 
 protected:

--- a/FWCore/Integration/plugins/ESTestProducers.cc
+++ b/FWCore/Integration/plugins/ESTestProducers.cc
@@ -3,6 +3,7 @@
 #include "FWCore/Framework/interface/ESProductResolverTemplate.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/Framework/interface/ESProductHost.h"
+#include "FWCore/Framework/interface/ESModuleProducesInfo.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -107,6 +108,8 @@ namespace edmtest {
 
     static void fillDescriptions(edm::ConfigurationDescriptions&);
 
+    std::vector<edm::eventsetup::ESModuleProducesInfo> producesInfo() const override;
+
   private:
     KeyedResolversVector registerResolvers(const edm::eventsetup::EventSetupRecordKey&, unsigned int iovIndex) override;
 
@@ -135,6 +138,14 @@ namespace edmtest {
     edm::eventsetup::DataKey dataKey(edm::eventsetup::DataKey::makeTypeTag<ESTestDataJ>(), "");
     keyedResolversVector.emplace_back(dataKey, resolvers_[iovIndex]);
     return keyedResolversVector;
+  }
+
+  std::vector<edm::eventsetup::ESModuleProducesInfo> ESTestESProductResolverProviderJ::producesInfo() const {
+    std::vector<edm::eventsetup::ESModuleProducesInfo> producesInfo;
+    producesInfo.emplace_back(edm::eventsetup::EventSetupRecordKey::makeKey<ESTestRecordJ>(),
+                              edm::eventsetup::DataKey(edm::eventsetup::DataKey::makeTypeTag<ESTestDataJ>(), ""),
+                              0);
+    return producesInfo;
   }
 }  // namespace edmtest
 

--- a/FWCore/Integration/plugins/TestESConcurrentSource.cc
+++ b/FWCore/Integration/plugins/TestESConcurrentSource.cc
@@ -20,6 +20,7 @@
 #include "FWCore/Framework/interface/IOVSyncValue.h"
 #include "FWCore/Framework/interface/SourceFactory.h"
 #include "FWCore/Framework/interface/ValidityInterval.h"
+#include "FWCore/Framework/interface/ESModuleProducesInfo.h"
 #include "FWCore/Integration/interface/ESTestRecords.h"
 #include "FWCore/Integration/interface/IOVTestInfo.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -74,6 +75,8 @@ namespace edmtest {
     std::atomic<unsigned int> maxCount_;
     std::atomic<unsigned int> count_setIntervalFor_;
     std::atomic<unsigned int> count_initializeForNewIOV_;
+
+    std::vector<edm::eventsetup::ESModuleProducesInfo> producesInfo() const override;
 
   private:
     bool isConcurrentFinder() const override { return true; }
@@ -193,6 +196,17 @@ namespace edmtest {
     }
     iov = edm::ValidityInterval(*(itFound.first), endOfInterval);
     --count_;
+  }
+
+  std::vector<edm::eventsetup::ESModuleProducesInfo> TestESConcurrentSource::producesInfo() const {
+    std::vector<edm::eventsetup::ESModuleProducesInfo> producesInfo;
+    producesInfo.emplace_back(ESTestRecordI::keyForClass(),
+                              edm::eventsetup::DataKey(edm::eventsetup::DataKey::makeTypeTag<IOVTestInfo>(), ""),
+                              0);
+    producesInfo.emplace_back(ESTestRecordI::keyForClass(),
+                              edm::eventsetup::DataKey(edm::eventsetup::DataKey::makeTypeTag<IOVTestInfo>(), "other"),
+                              1);
+    return producesInfo;
   }
 
   edm::eventsetup::ESProductResolverProvider::KeyedResolversVector TestESConcurrentSource::registerResolvers(

--- a/FWCore/Integration/plugins/TestESSource.cc
+++ b/FWCore/Integration/plugins/TestESSource.cc
@@ -20,6 +20,7 @@
 #include "FWCore/Framework/interface/IOVSyncValue.h"
 #include "FWCore/Framework/interface/SourceFactory.h"
 #include "FWCore/Framework/interface/ValidityInterval.h"
+#include "FWCore/Framework/interface/ESModuleProducesInfo.h"
 #include "FWCore/Integration/interface/ESTestRecords.h"
 #include "FWCore/Integration/interface/IOVTestInfo.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -68,6 +69,8 @@ namespace edmtest {
     std::atomic<unsigned int> count2_;
     edm::SerialTaskQueue queue_;
     std::mutex mutex_;
+
+    std::vector<edm::eventsetup::ESModuleProducesInfo> producesInfo() const override;
 
   private:
     bool isConcurrentFinder() const override { return true; }
@@ -193,6 +196,14 @@ namespace edmtest {
     }
     iov = edm::ValidityInterval(*(itFound.first), endOfInterval);
     --count_;
+  }
+
+  std::vector<edm::eventsetup::ESModuleProducesInfo> TestESSource::producesInfo() const {
+    std::vector<edm::eventsetup::ESModuleProducesInfo> producesInfo;
+    producesInfo.emplace_back(ESTestRecordI::keyForClass(),
+                              edm::eventsetup::DataKey(edm::eventsetup::DataKey::makeTypeTag<IOVTestInfo>(), ""),
+                              0);
+    return producesInfo;
   }
 
   edm::eventsetup::ESProductResolverProvider::KeyedResolversVector TestESSource::registerResolvers(

--- a/FWCore/Services/plugins/tracer_setupFile.cc
+++ b/FWCore/Services/plugins/tracer_setupFile.cc
@@ -25,8 +25,8 @@
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 
 #include "FWCore/Framework/interface/IOVSyncValue.h"
+#include "FWCore/Framework/interface/EventSetupRecordKey.h"
 #include "FWCore/Framework/interface/ESRecordsToProductResolverIndices.h"
-
 #include "FWCore/AbstractServices/interface/TimingServiceBase.h"
 
 using namespace edm::service::monitor_file_utilities;

--- a/FWCore/TestProcessor/interface/EventSetupTestHelper.h
+++ b/FWCore/TestProcessor/interface/EventSetupTestHelper.h
@@ -41,6 +41,8 @@ namespace edm {
 
       void resetAllResolvers();
 
+      std::vector<eventsetup::ESModuleProducesInfo> producesInfo() const final;
+
     protected:
       void setIntervalFor(const eventsetup::EventSetupRecordKey&, const IOVSyncValue&, ValidityInterval&) final;
 

--- a/FWCore/TestProcessor/src/EventSetupTestHelper.cc
+++ b/FWCore/TestProcessor/src/EventSetupTestHelper.cc
@@ -75,6 +75,7 @@ namespace edm {
 
     std::vector<eventsetup::ESModuleProducesInfo> EventSetupTestHelper::producesInfo() const {
       std::vector<eventsetup::ESModuleProducesInfo> producesInfo;
+      producesInfo.reserve(resolvers_.size());
       for (auto const& p : resolvers_) {
         producesInfo.emplace_back(p.recordKey_, p.dataKey_, p.resolver_->produceMethodID());
       }

--- a/FWCore/TestProcessor/src/EventSetupTestHelper.cc
+++ b/FWCore/TestProcessor/src/EventSetupTestHelper.cc
@@ -15,6 +15,7 @@
 // user include files
 #include "FWCore/TestProcessor/interface/EventSetupTestHelper.h"
 #include "FWCore/Framework/interface/ESProductResolver.h"
+#include "FWCore/Framework/interface/ESModuleProducesInfo.h"
 
 namespace edm {
   namespace test {
@@ -70,6 +71,14 @@ namespace edm {
 
     std::shared_ptr<eventsetup::ESProductResolver> EventSetupTestHelper::getResolver(unsigned int iIndex) {
       return resolvers_[iIndex].resolver_;
+    }
+
+    std::vector<eventsetup::ESModuleProducesInfo> EventSetupTestHelper::producesInfo() const {
+      std::vector<eventsetup::ESModuleProducesInfo> producesInfo;
+      for (auto const& p : resolvers_) {
+        producesInfo.emplace_back(p.recordKey_, p.dataKey_, p.resolver_->produceMethodID());
+      }
+      return producesInfo;
     }
 
     void EventSetupTestHelper::resetAllResolvers() {


### PR DESCRIPTION
#### PR description:

- moved complex logic for creating the internal data structures to the class itself
- can now ask an ESProducer what is produces
- provide a mechanism to get minimal information about what ES products are being consumed

#### PR validation:

Framework unit tests pass.

resolves https://github.com/cms-sw/framework-team/issues/1368
