### PR TITLE
change the `jetTrigger` string list of `beamhlt_dqm_sourceclient-live` to comply with CMSHLT-3528

### DIFF
--- a/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
@@ -213,11 +213,13 @@ if (process.runType.getRunType() == process.runType.pp_run or
 
     #TriggerName for selecting pv for DIP publication, NO wildcard needed here
     #it will pick all triggers which have these strings in their name
-    process.dqmBeamMonitor.jetTrigger = cms.untracked.vstring(
-        "HLT_HT300_Beamspot", "HLT_HT300_Beamspot",
-        "HLT_PAZeroBias_v", "HLT_ZeroBias_", "HLT_QuadJet",
-        "HLT_HI",
-        "HLT_PixelClusters")
+    process.dqmBeamMonitor.jetTrigger = cms.untracked.vstring("HLT_HT300_Beamspot",
+                                                              "HLT_BeamSpot",
+                                                              "HLT_PAZeroBias_v",
+                                                              "HLT_ZeroBias_",
+                                                              "HLT_QuadJet",
+                                                              "HLT_HI",
+                                                              "HLT_PixelClusters")
 
     process.dqmBeamMonitor.hltResults = "TriggerResults::HLT"
 


### PR DESCRIPTION
#### PR description:

Title say it all, due to the foreseen renaming of the trigger path `HLT_HT300_Beamspot_PixelClusters_WP2_v` to `HLT_Beamspot_PixelClusters_WP2_v` discussed in [CMSHLT-3528](https://its.cern.ch/jira/browse/CMSHLT-3528).

#### PR validation:

`cmssw` compiles

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, it might be backported to CMSSW_15_0_X for 2025 data-taking purposes.