### PR TITLE
Nano comaprison report will show the WF name and id

### DIFF
--- a/PhysicsTools/NanoAOD/test/compare_sizes_json.py
+++ b/PhysicsTools/NanoAOD/test/compare_sizes_json.py
@@ -10,7 +10,7 @@ parser.add_argument("--ref", dest="ref", default="ref/", help="path to the refer
 parser.add_argument("job", type=str, nargs='+')
 options = parser.parse_args()
 
-headers = [ 'Sample' , 'kb/ev' , 'ref kb/ev' , 'diff kb/ev' , 'ev/s/thd' , 'ref ev/s/thd' , 'diff rate' , 'mem/thd' , 'ref mem/thd' ]
+headers = [ 'workflow' , 'id' , 'kb/ev' , 'ref kb/ev' , 'diff kb/ev' , 'ev/s/thd' , 'ref ev/s/thd' , 'diff rate' , 'mem/thd' , 'ref mem/thd' ]
 start, sep, end = "", "\t", ""
 if options.fmt == "md": 
     start, sep, end = "| ", " | ", " |"
@@ -23,7 +23,14 @@ first = True
 size_pattern,timing_pattern = options.base.split(',')
 for job in options.job:
 
-    label = job
+    try:
+        wf_id = job.split("_")[0]
+        wf_name = "_".join(job.split("_")[1:])
+    # Just in case... Should never happen.
+    except IndexError:
+        wf_id = ""
+        wf_name = job
+
     size_json=size_pattern.format(job)
     size_ref_json=options.ref+'/'+size_json
     timing_json=timing_pattern.format(job)
@@ -52,7 +59,7 @@ for job in options.job:
             if options.fmt == "md": prow("---" for x in headers)
             first = False
 
-        prow([ label, '%.3f' % size_new, '%.3f' % size_ref, '%.3f ( %+.1f%% )' % (size_new - size_ref,  (size_new-size_ref)/size_ref * 100 ),
+        prow([ wf_name, wf_id, '%.3f' % size_new, '%.3f' % size_ref, '%.3f ( %+.1f%% )' % (size_new - size_ref,  (size_new-size_ref)/size_ref * 100 ),
                '%.2f'%rate_new, '%.2f'%rate_ref, '%+.1f%%'%((rate_new-rate_ref)/rate_ref*100), '%.3f'%(rmem_new/1000), '%.3f'%(rmem_ref/1000)  ])
 
     except IOError: # some file not existing


### PR DESCRIPTION
#### PR description:

Modify the NanoAOD comparison report, such that the WF and id is shown.

To be test with https://github.com/cms-sw/cms-bot/pull/2487

#### PR validation:

Running the script locally:

| workflow | id | kb/ev | ref kb/ev | diff kb/ev | ev/s/thd | ref ev/s/thd | diff rate | mem/thd | ref mem/thd |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| ABC | 123 | 2.595 | 2.501 | 0.094 ( +3.8% ) | 13.76 | 13.71 | +0.4% | 2.751 | 2.745 |



#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport.


