### PR TITLE
[GCC14] Avoid Wdangling-reference in EcalUncalibRecHitPhase2WeightsAlgoPortable.dev.cc

### DIFF
--- a/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalUncalibRecHitPhase2WeightsAlgoPortable.dev.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalUncalibRecHitPhase2WeightsAlgoPortable.dev.cc
@@ -34,7 +34,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::ecal::weights {
       //divide the grid into uniform elements
       for (auto tx : uniform_elements(acc, nchannels)) {
         bool g1 = false;
-        const auto& digi = digisDev[tx].data();
+        // Avoid false-positive Wdangling-reference
+        const auto& digisDevTx = digisDev[tx];
+        const auto& digi = digisDevTx.data();
         auto recHit = uncalibratedRecHitsDev[tx];
         recHit.amplitude() = 0;
         recHit.jitter() = 0;


### PR DESCRIPTION
#### PR description:

Title says it all. [Build log](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc14/CMSSW_15_1_X_2025-04-23-2300/RecoLocalCalo/EcalRecProducers):

```
>> Compiling alpaka/serial scram_x86-64-v2 edm plugin src/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalMultifitConditionsHostESProducer.cc
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gcc/14.2.1-475d4640d5186beb85fe6c9d366d668f/bin/c++ -c -DCMS_MICRO_ARCH='x86-64-v2' -DGNU_GCC -D_GNU_SOURCE -DTBB_USE_GLIBCXX_VERSION=140201 -DTBB_SUPPRESS_DEPRECATED_MESSAGES -DTBB_PREVIEW_RESUMABLE_TASKS=1 -DTBB_PREVIEW_TASK_GROUP_EXTENSIONS=1 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -DBOOST_MATH_DISABLE_STD_FPCLASSIFY -DBOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX -DBOOST_MPL_IGNORE_PARENTHESES_WARNING -DDD4HEP_USE_GEANT4_UNITS=1 -DCMSSW_GIT_HASH='CMSSW_15_1_X_2025-04-23-2300' -DPROJECT_NAME='CMSSW' -DPROJECT_VERSION='CMSSW_15_1_X_2025-04-23-2300' -Isrc -Ipoison -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/cms/cmssw/CMSSW_15_1_X_2025-04-21-2300/src -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/dd4hep/v01-29-00-a7d2f3fa9698a8af208e6626d9424d74/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/alpaka/1.2.0-3e35c1de77f81c8ba5df8b88ae089955/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/pcre/8.43-fec6e6028744fb6ef466c775a44bdbc6/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/boost/1.80.0-568acc6bf98000fa1932ee81ef82c0ed/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/bz2lib/1.0.6-5144693e7a37ea5b81cd450abd20a4e3/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/clhep/2.4.7.1-f00060af34dc2ab8b3dcb35c4ceb818d/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/cuda/12.8.0-88740af71f61096948e1ccabfda70dea/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gsl/2.6-6508fb106023911bfb9f369409186e05/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/hepmc/2.06.10-f836a4b0b1d1fff3b90cdc2d904f0d85/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/libuuid/2.34-1d099d79c169c484b1c981ae6ba60d78/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/lcg/root/6.32.13-648e06eec9ef66b6ffea552d87999e71/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/tbb/v2022.0.0-9d5216d68922bb4495df90ed7ef537a5/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/cms/vdt/0.4.3-9a3e3f7b7c8090f8090c6d665bb4fb23/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/xerces-c/3.1.3-020702e21b426a03eada31f0a286a389/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/xz/5.6.4-293c8a36b5ace241306f493d5287e628/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/zlib/1.2.13-da03c076b1efafbcb159a35e20281b60/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-6bc3adf269199bc8fe27c291ef7412d8/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-6bc3adf269199bc8fe27c291ef7412d8/include/eigen3 -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/fmt/10.2.1-90400412956988d7d2f85ea6ac8b3733/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/md5/1.0.0-0eeec7a8b876f86bc41aaf0176f636dd/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/OpenBLAS/0.3.27-7afdad1f1cc07eb5a57c343e8a8a572a/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/tinyxml2/6.2.0-ef678365738ddd2833328bb954dd98c5/include -O3 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++20 -ftree-vectorize -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -Wno-error=array-bounds -Warray-bounds -fuse-ld=bfd -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-unused-parameter -Wunused -Wparentheses -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -DEIGEN_DONT_PARALLELIZE -DEIGEN_MAX_ALIGN_BYTES=64 -Wno-error=unused-variable -DALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128 -DALPAKA_DISABLE_VENDOR_RNG -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED -DBOOST_DISABLE_ASSERTS -march=x86-64-v2 -flto=auto -fipa-icf -flto-odr-type-merging -fno-fat-lto-objects -Wodr -fPIC -MMD -MF tmp/el8_amd64_gcc14/src/RecoLocalCalo/EcalRecProducers/plugins/RecoLocalCaloEcalRecProducersPluginsPortableSerialSync/scram_x86-64-v2/alpaka/EcalMultifitConditionsHostESProducer.cc.d src/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalMultifitConditionsHostESProducer.cc -o tmp/el8_amd64_gcc14/src/RecoLocalCalo/EcalRecProducers/plugins/RecoLocalCaloEcalRecProducersPluginsPortableSerialSync/scram_x86-64-v2/alpaka/EcalMultifitConditionsHostESProducer.cc.o
src/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalUncalibRecHitPhase2WeightsAlgoPortable.dev.cc: In member function 'void alpaka_serial_sync::ecal::weights::Phase2WeightsKernel::operator()(const alpaka_serial_sync::Acc1D&, const alpaka_serial_sync::EcalUncalibRecHitPhase2Weights*, PortableHostCollection<EcalDigiPhase2SoALayout<> >::ConstView, PortableHostCollection<EcalUncalibratedRecHitSoALayout<> >::View) const':
  [src/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalUncalibRecHitPhase2WeightsAlgoPortable.dev.cc:37](https://github.com/cms-sw/cmssw/blob/CMSSW_15_1_X_2025-04-23-2300/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalUncalibRecHitPhase2WeightsAlgoPortable.dev.cc#L37):21: warning: possibly dangling reference to a temporary [-Wdangling-reference]
    37 |         const auto& digi = digisDev[tx].data();
      |                     ^~~~
src/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalUncalibRecHitPhase2WeightsAlgoPortable.dev.cc:37:45: note: the temporary was destroyed at the end of the full expression 'digisDev.EcalDigiPhase2SoALayout<>::ConstViewTemplateFreeParams<128, false, true, true>::operator[](((EcalDigiPhase2SoALayout<>::ConstViewTemplateFreeParams<128, false, true, true>::size_type)tx)).EcalDigiPhase2SoALayout<>::ConstViewTemplateFreeParams<128, false, true, true>::const_element::data()'
   37 |         const auto& digi = digisDev[tx].data();
      |                            ~~~~~~~~~~~~~~~~~^~
>> Compiling alpaka/serial scram_x86-64-v2 edm plugin src/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalPhase2DigiToPortableProducer.cc
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gcc/14.2.1-475d4640d5186beb85fe6c9d366d668f/bin/c++ -c -DCMS_MICRO_ARCH='x86-64-v2' -DGNU_GCC -D_GNU_SOURCE -DTBB_USE_GLIBCXX_VERSION=140201 -DTBB_SUPPRESS_DEPRECATED_MESSAGES -DTBB_PREVIEW_RESUMABLE_TASKS=1 -DTBB_PREVIEW_TASK_GROUP_EXTENSIONS=1 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -DBOOST_MATH_DISABLE_STD_FPCLASSIFY -DBOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX -DBOOST_MPL_IGNORE_PARENTHESES_WARNING -DDD4HEP_USE_GEANT4_UNITS=1 -DCMSSW_GIT_HASH='CMSSW_15_1_X_2025-04-23-2300' -DPROJECT_NAME='CMSSW' -DPROJECT_VERSION='CMSSW_15_1_X_2025-04-23-2300' -Isrc -Ipoison -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/cms/cmssw/CMSSW_15_1_X_2025-04-21-2300/src -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/dd4hep/v01-29-00-a7d2f3fa9698a8af208e6626d9424d74/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/alpaka/1.2.0-3e35c1de77f81c8ba5df8b88ae089955/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/pcre/8.43-fec6e6028744fb6ef466c775a44bdbc6/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/boost/1.80.0-568acc6bf98000fa1932ee81ef82c0ed/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/bz2lib/1.0.6-5144693e7a37ea5b81cd450abd20a4e3/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/clhep/2.4.7.1-f00060af34dc2ab8b3dcb35c4ceb818d/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/cuda/12.8.0-88740af71f61096948e1ccabfda70dea/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gsl/2.6-6508fb106023911bfb9f369409186e05/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/hepmc/2.06.10-f836a4b0b1d1fff3b90cdc2d904f0d85/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/libuuid/2.34-1d099d79c169c484b1c981ae6ba60d78/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/lcg/root/6.32.13-648e06eec9ef66b6ffea552d87999e71/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/tbb/v2022.0.0-9d5216d68922bb4495df90ed7ef537a5/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/cms/vdt/0.4.3-9a3e3f7b7c8090f8090c6d665bb4fb23/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/xerces-c/3.1.3-020702e21b426a03eada31f0a286a389/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/xz/5.6.4-293c8a36b5ace241306f493d5287e628/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/zlib/1.2.13-da03c076b1efafbcb159a35e20281b60/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-6bc3adf269199bc8fe27c291ef7412d8/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-6bc3adf269199bc8fe27c291ef7412d8/include/eigen3 -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/fmt/10.2.1-90400412956988d7d2f85ea6ac8b3733/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/md5/1.0.0-0eeec7a8b876f86bc41aaf0176f636dd/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/OpenBLAS/0.3.27-7afdad1f1cc07eb5a57c343e8a8a572a/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/tinyxml2/6.2.0-ef678365738ddd2833328bb954dd98c5/include -O3 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++20 -ftree-vectorize -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -Wno-error=array-bounds -Warray-bounds -fuse-ld=bfd -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-unused-parameter -Wunused -Wparentheses -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -DEIGEN_DONT_PARALLELIZE -DEIGEN_MAX_ALIGN_BYTES=64 -Wno-error=unused-variable -DALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128 -DALPAKA_DISABLE_VENDOR_RNG -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED -DBOOST_DISABLE_ASSERTS -march=x86-64-v2 -flto=auto -fipa-icf -flto-odr-type-merging -fno-fat-lto-objects -Wodr -fPIC -MMD -MF tmp/el8_amd64_gcc14/src/RecoLocalCalo/EcalRecProducers/plugins/RecoLocalCaloEcalRecProducersPluginsPortableSerialSync/scram_x86-64-v2/alpaka/EcalPhase2DigiToPortableProducer.cc.d src/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalPhase2DigiToPortableProducer.cc -o tmp/el8_amd64_gcc14/src/RecoLocalCalo/EcalRecProducers/plugins/RecoLocalCaloEcalRecProducersPluginsPortableSerialSync/scram_x86-64-v2/alpaka/EcalPhase2DigiToPortableProducer.cc.o
>> Compiling alpaka/serial scram_x86-64-v2 edm plugin src/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalRecHitBuilder.dev.cc
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gcc/14.2.1-475d4640d5186beb85fe6c9d366d668f/bin/c++ -c -DCMS_MICRO_ARCH='x86-64-v2' -DGNU_GCC -D_GNU_SOURCE -DTBB_USE_GLIBCXX_VERSION=140201 -DTBB_SUPPRESS_DEPRECATED_MESSAGES -DTBB_PREVIEW_RESUMABLE_TASKS=1 -DTBB_PREVIEW_TASK_GROUP_EXTENSIONS=1 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -DBOOST_MATH_DISABLE_STD_FPCLASSIFY -DBOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX -DBOOST_MPL_IGNORE_PARENTHESES_WARNING -DDD4HEP_USE_GEANT4_UNITS=1 -DCMSSW_GIT_HASH='CMSSW_15_1_X_2025-04-23-2300' -DPROJECT_NAME='CMSSW' -DPROJECT_VERSION='CMSSW_15_1_X_2025-04-23-2300' -Isrc -Ipoison -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/cms/cmssw/CMSSW_15_1_X_2025-04-21-2300/src -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/dd4hep/v01-29-00-a7d2f3fa9698a8af208e6626d9424d74/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/alpaka/1.2.0-3e35c1de77f81c8ba5df8b88ae089955/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/pcre/8.43-fec6e6028744fb6ef466c775a44bdbc6/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/boost/1.80.0-568acc6bf98000fa1932ee81ef82c0ed/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/bz2lib/1.0.6-5144693e7a37ea5b81cd450abd20a4e3/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/clhep/2.4.7.1-f00060af34dc2ab8b3dcb35c4ceb818d/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/cuda/12.8.0-88740af71f61096948e1ccabfda70dea/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gsl/2.6-6508fb106023911bfb9f369409186e05/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/hepmc/2.06.10-f836a4b0b1d1fff3b90cdc2d904f0d85/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/libuuid/2.34-1d099d79c169c484b1c981ae6ba60d78/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/lcg/root/6.32.13-648e06eec9ef66b6ffea552d87999e71/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/tbb/v2022.0.0-9d5216d68922bb4495df90ed7ef537a5/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/cms/vdt/0.4.3-9a3e3f7b7c8090f8090c6d665bb4fb23/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/xerces-c/3.1.3-020702e21b426a03eada31f0a286a389/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/xz/5.6.4-293c8a36b5ace241306f493d5287e628/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/zlib/1.2.13-da03c076b1efafbcb159a35e20281b60/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-6bc3adf269199bc8fe27c291ef7412d8/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-6bc3adf269199bc8fe27c291ef7412d8/include/eigen3 -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/fmt/10.2.1-90400412956988d7d2f85ea6ac8b3733/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/md5/1.0.0-0eeec7a8b876f86bc41aaf0176f636dd/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/OpenBLAS/0.3.27-7afdad1f1cc07eb5a57c343e8a8a572a/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/tinyxml2/6.2.0-ef678365738ddd2833328bb954dd98c5/include -O3 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++20 -ftree-vectorize -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -Wno-error=array-bounds -Warray-bounds -fuse-ld=bfd -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-unused-parameter -Wunused -Wparentheses -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -DEIGEN_DONT_PARALLELIZE -DEIGEN_MAX_ALIGN_BYTES=64 -Wno-error=unused-variable -DALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128 -DALPAKA_DISABLE_VENDOR_RNG -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED -DBOOST_DISABLE_ASSERTS -march=x86-64-v2 -flto=auto -fipa-icf -flto-odr-type-merging -fno-fat-lto-objects -Wodr -fPIC -MMD -MF tmp/el8_amd64_gcc14/src/RecoLocalCalo/EcalRecProducers/plugins/RecoLocalCaloEcalRecProducersPluginsPortableSerialSync/scram_x86-64-v2/alpaka/EcalRecHitBuilder.dev.cc.d src/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalRecHitBuilder.dev.cc -o tmp/el8_amd64_gcc14/src/RecoLocalCalo/EcalRecProducers/plugins/RecoLocalCaloEcalRecProducersPluginsPortableSerialSync/scram_x86-64-v2/alpaka/EcalRecHitBuilder.dev.cc.o
>> Compiling alpaka/serial scram_x86-64-v2 edm plugin src/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalRecHitConditionsESProducer.cc
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gcc/14.2.1-475d4640d5186beb85fe6c9d366d668f/bin/c++ -c -DCMS_MICRO_ARCH='x86-64-v2' -DGNU_GCC -D_GNU_SOURCE -DTBB_USE_GLIBCXX_VERSION=140201 -DTBB_SUPPRESS_DEPRECATED_MESSAGES -DTBB_PREVIEW_RESUMABLE_TASKS=1 -DTBB_PREVIEW_TASK_GROUP_EXTENSIONS=1 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -DBOOST_MATH_DISABLE_STD_FPCLASSIFY -DBOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX -DBOOST_MPL_IGNORE_PARENTHESES_WARNING -DDD4HEP_USE_GEANT4_UNITS=1 -DCMSSW_GIT_HASH='CMSSW_15_1_X_2025-04-23-2300' -DPROJECT_NAME='CMSSW' -DPROJECT_VERSION='CMSSW_15_1_X_2025-04-23-2300' -Isrc -Ipoison -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/cms/cmssw/CMSSW_15_1_X_2025-04-21-2300/src -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/dd4hep/v01-29-00-a7d2f3fa9698a8af208e6626d9424d74/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/alpaka/1.2.0-3e35c1de77f81c8ba5df8b88ae089955/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/pcre/8.43-fec6e6028744fb6ef466c775a44bdbc6/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/boost/1.80.0-568acc6bf98000fa1932ee81ef82c0ed/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/bz2lib/1.0.6-5144693e7a37ea5b81cd450abd20a4e3/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/clhep/2.4.7.1-f00060af34dc2ab8b3dcb35c4ceb818d/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/cuda/12.8.0-88740af71f61096948e1ccabfda70dea/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gsl/2.6-6508fb106023911bfb9f369409186e05/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/hepmc/2.06.10-f836a4b0b1d1fff3b90cdc2d904f0d85/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/libuuid/2.34-1d099d79c169c484b1c981ae6ba60d78/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/lcg/root/6.32.13-648e06eec9ef66b6ffea552d87999e71/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/tbb/v2022.0.0-9d5216d68922bb4495df90ed7ef537a5/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/cms/vdt/0.4.3-9a3e3f7b7c8090f8090c6d665bb4fb23/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/xerces-c/3.1.3-020702e21b426a03eada31f0a286a389/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/xz/5.6.4-293c8a36b5ace241306f493d5287e628/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/zlib/1.2.13-da03c076b1efafbcb159a35e20281b60/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-6bc3adf269199bc8fe27c291ef7412d8/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-6bc3adf269199bc8fe27c291ef7412d8/include/eigen3 -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/fmt/10.2.1-90400412956988d7d2f85ea6ac8b3733/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/md5/1.0.0-0eeec7a8b876f86bc41aaf0176f636dd/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/OpenBLAS/0.3.27-7afdad1f1cc07eb5a57c343e8a8a572a/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/tinyxml2/6.2.0-ef678365738ddd2833328bb954dd98c5/include -O3 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++20 -ftree-vectorize -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -Wno-error=array-bounds -Warray-bounds -fuse-ld=bfd -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-unused-parameter -Wunused -Wparentheses -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -DEIGEN_DONT_PARALLELIZE -DEIGEN_MAX_ALIGN_BYTES=64 -Wno-error=unused-variable -DALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128 -DALPAKA_DISABLE_VENDOR_RNG -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED -DBOOST_DISABLE_ASSERTS -march=x86-64-v2 -flto=auto -fipa-icf -flto-odr-type-merging -fno-fat-lto-objects -Wodr -fPIC -MMD -MF tmp/el8_amd64_gcc14/src/RecoLocalCalo/EcalRecProducers/plugins/RecoLocalCaloEcalRecProducersPluginsPortableSerialSync/scram_x86-64-v2/alpaka/EcalRecHitConditionsESProducer.cc.d src/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalRecHitConditionsESProducer.cc -o tmp/el8_amd64_gcc14/src/RecoLocalCalo/EcalRecProducers/plugins/RecoLocalCaloEcalRecProducersPluginsPortableSerialSync/scram_x86-64-v2/alpaka/EcalRecHitConditionsESProducer.cc.o
>> Compiling alpaka/serial scram_x86-64-v2 edm plugin src/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalRecHitProducerPortable.cc
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gcc/14.2.1-475d4640d5186beb85fe6c9d366d668f/bin/c++ -c -DCMS_MICRO_ARCH='x86-64-v2' -DGNU_GCC -D_GNU_SOURCE -DTBB_USE_GLIBCXX_VERSION=140201 -DTBB_SUPPRESS_DEPRECATED_MESSAGES -DTBB_PREVIEW_RESUMABLE_TASKS=1 -DTBB_PREVIEW_TASK_GROUP_EXTENSIONS=1 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -DBOOST_MATH_DISABLE_STD_FPCLASSIFY -DBOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX -DBOOST_MPL_IGNORE_PARENTHESES_WARNING -DDD4HEP_USE_GEANT4_UNITS=1 -DCMSSW_GIT_HASH='CMSSW_15_1_X_2025-04-23-2300' -DPROJECT_NAME='CMSSW' -DPROJECT_VERSION='CMSSW_15_1_X_2025-04-23-2300' -Isrc -Ipoison -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/cms/cmssw/CMSSW_15_1_X_2025-04-21-2300/src -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/dd4hep/v01-29-00-a7d2f3fa9698a8af208e6626d9424d74/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/alpaka/1.2.0-3e35c1de77f81c8ba5df8b88ae089955/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/pcre/8.43-fec6e6028744fb6ef466c775a44bdbc6/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/boost/1.80.0-568acc6bf98000fa1932ee81ef82c0ed/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/bz2lib/1.0.6-5144693e7a37ea5b81cd450abd20a4e3/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/clhep/2.4.7.1-f00060af34dc2ab8b3dcb35c4ceb818d/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/cuda/12.8.0-88740af71f61096948e1ccabfda70dea/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gsl/2.6-6508fb106023911bfb9f369409186e05/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/hepmc/2.06.10-f836a4b0b1d1fff3b90cdc2d904f0d85/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/libuuid/2.34-1d099d79c169c484b1c981ae6ba60d78/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/lcg/root/6.32.13-648e06eec9ef66b6ffea552d87999e71/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/tbb/v2022.0.0-9d5216d68922bb4495df90ed7ef537a5/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/cms/vdt/0.4.3-9a3e3f7b7c8090f8090c6d665bb4fb23/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/xerces-c/3.1.3-020702e21b426a03eada31f0a286a389/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/xz/5.6.4-293c8a36b5ace241306f493d5287e628/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/zlib/1.2.13-da03c076b1efafbcb159a35e20281b60/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-6bc3adf269199bc8fe27c291ef7412d8/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-6bc3adf269199bc8fe27c291ef7412d8/include/eigen3 -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/fmt/10.2.1-90400412956988d7d2f85ea6ac8b3733/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/md5/1.0.0-0eeec7a8b876f86bc41aaf0176f636dd/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/OpenBLAS/0.3.27-7afdad1f1cc07eb5a57c343e8a8a572a/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/tinyxml2/6.2.0-ef678365738ddd2833328bb954dd98c5/include -O3 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++20 -ftree-vectorize -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -Wno-error=array-bounds -Warray-bounds -fuse-ld=bfd -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-unused-parameter -Wunused -Wparentheses -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -DEIGEN_DONT_PARALLELIZE -DEIGEN_MAX_ALIGN_BYTES=64 -Wno-error=unused-variable -DALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128 -DALPAKA_DISABLE_VENDOR_RNG -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED -DBOOST_DISABLE_ASSERTS -march=x86-64-v2 -flto=auto -fipa-icf -flto-odr-type-merging -fno-fat-lto-objects -Wodr -fPIC -MMD -MF tmp/el8_amd64_gcc14/src/RecoLocalCalo/EcalRecProducers/plugins/RecoLocalCaloEcalRecProducersPluginsPortableSerialSync/scram_x86-64-v2/alpaka/EcalRecHitProducerPortable.cc.d src/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalRecHitProducerPortable.cc -o tmp/el8_amd64_gcc14/src/RecoLocalCalo/EcalRecProducers/plugins/RecoLocalCaloEcalRecProducersPluginsPortableSerialSync/scram_x86-64-v2/alpaka/EcalRecHitProducerPortable.cc.o
>> Compiling alpaka/serial scram_x86-64-v2 edm plugin src/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalUncalibRecHitMultiFitAlgoPortable.dev.cc
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gcc/14.2.1-475d4640d5186beb85fe6c9d366d668f/bin/c++ -c -DCMS_MICRO_ARCH='x86-64-v2' -DGNU_GCC -D_GNU_SOURCE -DTBB_USE_GLIBCXX_VERSION=140201 -DTBB_SUPPRESS_DEPRECATED_MESSAGES -DTBB_PREVIEW_RESUMABLE_TASKS=1 -DTBB_PREVIEW_TASK_GROUP_EXTENSIONS=1 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -DBOOST_MATH_DISABLE_STD_FPCLASSIFY -DBOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX -DBOOST_MPL_IGNORE_PARENTHESES_WARNING -DDD4HEP_USE_GEANT4_UNITS=1 -DCMSSW_GIT_HASH='CMSSW_15_1_X_2025-04-23-2300' -DPROJECT_NAME='CMSSW' -DPROJECT_VERSION='CMSSW_15_1_X_2025-04-23-2300' -Isrc -Ipoison -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/cms/cmssw/CMSSW_15_1_X_2025-04-21-2300/src -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/dd4hep/v01-29-00-a7d2f3fa9698a8af208e6626d9424d74/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/alpaka/1.2.0-3e35c1de77f81c8ba5df8b88ae089955/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/pcre/8.43-fec6e6028744fb6ef466c775a44bdbc6/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/boost/1.80.0-568acc6bf98000fa1932ee81ef82c0ed/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/bz2lib/1.0.6-5144693e7a37ea5b81cd450abd20a4e3/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/clhep/2.4.7.1-f00060af34dc2ab8b3dcb35c4ceb818d/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/cuda/12.8.0-88740af71f61096948e1ccabfda70dea/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gsl/2.6-6508fb106023911bfb9f369409186e05/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/hepmc/2.06.10-f836a4b0b1d1fff3b90cdc2d904f0d85/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/libuuid/2.34-1d099d79c169c484b1c981ae6ba60d78/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/lcg/root/6.32.13-648e06eec9ef66b6ffea552d87999e71/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/tbb/v2022.0.0-9d5216d68922bb4495df90ed7ef537a5/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/cms/vdt/0.4.3-9a3e3f7b7c8090f8090c6d665bb4fb23/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/xerces-c/3.1.3-020702e21b426a03eada31f0a286a389/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/xz/5.6.4-293c8a36b5ace241306f493d5287e628/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/zlib/1.2.13-da03c076b1efafbcb159a35e20281b60/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-6bc3adf269199bc8fe27c291ef7412d8/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-6bc3adf269199bc8fe27c291ef7412d8/include/eigen3 -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/fmt/10.2.1-90400412956988d7d2f85ea6ac8b3733/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/md5/1.0.0-0eeec7a8b876f86bc41aaf0176f636dd/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/OpenBLAS/0.3.27-7afdad1f1cc07eb5a57c343e8a8a572a/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/tinyxml2/6.2.0-ef678365738ddd2833328bb954dd98c5/include -O3 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++20 -ftree-vectorize -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -Wno-error=array-bounds -Warray-bounds -fuse-ld=bfd -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-unused-parameter -Wunused -Wparentheses -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -DEIGEN_DONT_PARALLELIZE -DEIGEN_MAX_ALIGN_BYTES=64 -Wno-error=unused-variable -DALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128 -DALPAKA_DISABLE_VENDOR_RNG -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED -DBOOST_DISABLE_ASSERTS -march=x86-64-v2 -flto=auto -fipa-icf -flto-odr-type-merging -fno-fat-lto-objects -Wodr -fPIC -MMD -MF tmp/el8_amd64_gcc14/src/RecoLocalCalo/EcalRecProducers/plugins/RecoLocalCaloEcalRecProducersPluginsPortableSerialSync/scram_x86-64-v2/alpaka/EcalUncalibRecHitMultiFitAlgoPortable.dev.cc.d src/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalUncalibRecHitMultiFitAlgoPortable.dev.cc -o tmp/el8_amd64_gcc14/src/RecoLocalCalo/EcalRecProducers/plugins/RecoLocalCaloEcalRecProducersPluginsPortableSerialSync/scram_x86-64-v2/alpaka/EcalUncalibRecHitMultiFitAlgoPortable.dev.cc.o
>> Compiling alpaka/serial scram_x86-64-v2 edm plugin src/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalUncalibRecHitPhase2WeightsAlgoPortable.dev.cc
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gcc/14.2.1-475d4640d5186beb85fe6c9d366d668f/bin/c++ -c -DCMS_MICRO_ARCH='x86-64-v2' -DGNU_GCC -D_GNU_SOURCE -DTBB_USE_GLIBCXX_VERSION=140201 -DTBB_SUPPRESS_DEPRECATED_MESSAGES -DTBB_PREVIEW_RESUMABLE_TASKS=1 -DTBB_PREVIEW_TASK_GROUP_EXTENSIONS=1 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -DBOOST_MATH_DISABLE_STD_FPCLASSIFY -DBOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX -DBOOST_MPL_IGNORE_PARENTHESES_WARNING -DDD4HEP_USE_GEANT4_UNITS=1 -DCMSSW_GIT_HASH='CMSSW_15_1_X_2025-04-23-2300' -DPROJECT_NAME='CMSSW' -DPROJECT_VERSION='CMSSW_15_1_X_2025-04-23-2300' -Isrc -Ipoison -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/cms/cmssw/CMSSW_15_1_X_2025-04-21-2300/src -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/dd4hep/v01-29-00-a7d2f3fa9698a8af208e6626d9424d74/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/alpaka/1.2.0-3e35c1de77f81c8ba5df8b88ae089955/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/pcre/8.43-fec6e6028744fb6ef466c775a44bdbc6/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/boost/1.80.0-568acc6bf98000fa1932ee81ef82c0ed/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/bz2lib/1.0.6-5144693e7a37ea5b81cd450abd20a4e3/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/clhep/2.4.7.1-f00060af34dc2ab8b3dcb35c4ceb818d/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/cuda/12.8.0-88740af71f61096948e1ccabfda70dea/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gsl/2.6-6508fb106023911bfb9f369409186e05/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/hepmc/2.06.10-f836a4b0b1d1fff3b90cdc2d904f0d85/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/libuuid/2.34-1d099d79c169c484b1c981ae6ba60d78/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/lcg/root/6.32.13-648e06eec9ef66b6ffea552d87999e71/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/tbb/v2022.0.0-9d5216d68922bb4495df90ed7ef537a5/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/cms/vdt/0.4.3-9a3e3f7b7c8090f8090c6d665bb4fb23/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/xerces-c/3.1.3-020702e21b426a03eada31f0a286a389/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/xz/5.6.4-293c8a36b5ace241306f493d5287e628/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/zlib/1.2.13-da03c076b1efafbcb159a35e20281b60/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-6bc3adf269199bc8fe27c291ef7412d8/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-6bc3adf269199bc8fe27c291ef7412d8/include/eigen3 -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/fmt/10.2.1-90400412956988d7d2f85ea6ac8b3733/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/md5/1.0.0-0eeec7a8b876f86bc41aaf0176f636dd/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/OpenBLAS/0.3.27-7afdad1f1cc07eb5a57c343e8a8a572a/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/tinyxml2/6.2.0-ef678365738ddd2833328bb954dd98c5/include -O3 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++20 -ftree-vectorize -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -Wno-error=array-bounds -Warray-bounds -fuse-ld=bfd -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-unused-parameter -Wunused -Wparentheses -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -DEIGEN_DONT_PARALLELIZE -DEIGEN_MAX_ALIGN_BYTES=64 -Wno-error=unused-variable -DALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128 -DALPAKA_DISABLE_VENDOR_RNG -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED -DBOOST_DISABLE_ASSERTS -march=x86-64-v2 -flto=auto -fipa-icf -flto-odr-type-merging -fno-fat-lto-objects -Wodr -fPIC -MMD -MF tmp/el8_amd64_gcc14/src/RecoLocalCalo/EcalRecProducers/plugins/RecoLocalCaloEcalRecProducersPluginsPortableSerialSync/scram_x86-64-v2/alpaka/EcalUncalibRecHitPhase2WeightsAlgoPortable.dev.cc.d src/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalUncalibRecHitPhase2WeightsAlgoPortable.dev.cc -o tmp/el8_amd64_gcc14/src/RecoLocalCalo/EcalRecProducers/plugins/RecoLocalCaloEcalRecProducersPluginsPortableSerialSync/scram_x86-64-v2/alpaka/EcalUncalibRecHitPhase2WeightsAlgoPortable.dev.cc.o
>> Compiling alpaka/serial scram_x86-64-v2 edm plugin src/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalUncalibRecHitPhase2WeightsProducerPortable.cc
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gcc/14.2.1-475d4640d5186beb85fe6c9d366d668f/bin/c++ -c -DCMS_MICRO_ARCH='x86-64-v2' -DGNU_GCC -D_GNU_SOURCE -DTBB_USE_GLIBCXX_VERSION=140201 -DTBB_SUPPRESS_DEPRECATED_MESSAGES -DTBB_PREVIEW_RESUMABLE_TASKS=1 -DTBB_PREVIEW_TASK_GROUP_EXTENSIONS=1 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -DBOOST_MATH_DISABLE_STD_FPCLASSIFY -DBOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX -DBOOST_MPL_IGNORE_PARENTHESES_WARNING -DDD4HEP_USE_GEANT4_UNITS=1 -DCMSSW_GIT_HASH='CMSSW_15_1_X_2025-04-23-2300' -DPROJECT_NAME='CMSSW' -DPROJECT_VERSION='CMSSW_15_1_X_2025-04-23-2300' -Isrc -Ipoison -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/cms/cmssw/CMSSW_15_1_X_2025-04-21-2300/src -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/dd4hep/v01-29-00-a7d2f3fa9698a8af208e6626d9424d74/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/alpaka/1.2.0-3e35c1de77f81c8ba5df8b88ae089955/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/pcre/8.43-fec6e6028744fb6ef466c775a44bdbc6/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/boost/1.80.0-568acc6bf98000fa1932ee81ef82c0ed/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/bz2lib/1.0.6-5144693e7a37ea5b81cd450abd20a4e3/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/clhep/2.4.7.1-f00060af34dc2ab8b3dcb35c4ceb818d/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/cuda/12.8.0-88740af71f61096948e1ccabfda70dea/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gsl/2.6-6508fb106023911bfb9f369409186e05/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/hepmc/2.06.10-f836a4b0b1d1fff3b90cdc2d904f0d85/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/libuuid/2.34-1d099d79c169c484b1c981ae6ba60d78/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/lcg/root/6.32.13-648e06eec9ef66b6ffea552d87999e71/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/tbb/v2022.0.0-9d5216d68922bb4495df90ed7ef537a5/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/cms/vdt/0.4.3-9a3e3f7b7c8090f8090c6d665bb4fb23/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/xerces-c/3.1.3-020702e21b426a03eada31f0a286a389/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/xz/5.6.4-293c8a36b5ace241306f493d5287e628/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/zlib/1.2.13-da03c076b1efafbcb159a35e20281b60/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-6bc3adf269199bc8fe27c291ef7412d8/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-6bc3adf269199bc8fe27c291ef7412d8/include/eigen3 -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/fmt/10.2.1-90400412956988d7d2f85ea6ac8b3733/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/md5/1.0.0-0eeec7a8b876f86bc41aaf0176f636dd/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/OpenBLAS/0.3.27-7afdad1f1cc07eb5a57c343e8a8a572a/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/tinyxml2/6.2.0-ef678365738ddd2833328bb954dd98c5/include -O3 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++20 -ftree-vectorize -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -Wno-error=array-bounds -Warray-bounds -fuse-ld=bfd -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-unused-parameter -Wunused -Wparentheses -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -DEIGEN_DONT_PARALLELIZE -DEIGEN_MAX_ALIGN_BYTES=64 -Wno-error=unused-variable -DALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128 -DALPAKA_DISABLE_VENDOR_RNG -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED -DBOOST_DISABLE_ASSERTS -march=x86-64-v2 -flto=auto -fipa-icf -flto-odr-type-merging -fno-fat-lto-objects -Wodr -fPIC -MMD -MF tmp/el8_amd64_gcc14/src/RecoLocalCalo/EcalRecProducers/plugins/RecoLocalCaloEcalRecProducersPluginsPortableSerialSync/scram_x86-64-v2/alpaka/EcalUncalibRecHitPhase2WeightsProducerPortable.cc.d src/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalUncalibRecHitPhase2WeightsProducerPortable.cc -o tmp/el8_amd64_gcc14/src/RecoLocalCalo/EcalRecProducers/plugins/RecoLocalCaloEcalRecProducersPluginsPortableSerialSync/scram_x86-64-v2/alpaka/EcalUncalibRecHitPhase2WeightsProducerPortable.cc.o
>> Compiling alpaka/serial scram_x86-64-v2 edm plugin src/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalUncalibRecHitProducerPortable.cc
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gcc/14.2.1-475d4640d5186beb85fe6c9d366d668f/bin/c++ -c -DCMS_MICRO_ARCH='x86-64-v2' -DGNU_GCC -D_GNU_SOURCE -DTBB_USE_GLIBCXX_VERSION=140201 -DTBB_SUPPRESS_DEPRECATED_MESSAGES -DTBB_PREVIEW_RESUMABLE_TASKS=1 -DTBB_PREVIEW_TASK_GROUP_EXTENSIONS=1 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -DBOOST_MATH_DISABLE_STD_FPCLASSIFY -DBOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX -DBOOST_MPL_IGNORE_PARENTHESES_WARNING -DDD4HEP_USE_GEANT4_UNITS=1 -DCMSSW_GIT_HASH='CMSSW_15_1_X_2025-04-23-2300' -DPROJECT_NAME='CMSSW' -DPROJECT_VERSION='CMSSW_15_1_X_2025-04-23-2300' -Isrc -Ipoison -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/cms/cmssw/CMSSW_15_1_X_2025-04-21-2300/src -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/dd4hep/v01-29-00-a7d2f3fa9698a8af208e6626d9424d74/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/alpaka/1.2.0-3e35c1de77f81c8ba5df8b88ae089955/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/pcre/8.43-fec6e6028744fb6ef466c775a44bdbc6/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/boost/1.80.0-568acc6bf98000fa1932ee81ef82c0ed/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/bz2lib/1.0.6-5144693e7a37ea5b81cd450abd20a4e3/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/clhep/2.4.7.1-f00060af34dc2ab8b3dcb35c4ceb818d/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/cuda/12.8.0-88740af71f61096948e1ccabfda70dea/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gsl/2.6-6508fb106023911bfb9f369409186e05/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/hepmc/2.06.10-f836a4b0b1d1fff3b90cdc2d904f0d85/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/libuuid/2.34-1d099d79c169c484b1c981ae6ba60d78/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/lcg/root/6.32.13-648e06eec9ef66b6ffea552d87999e71/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/tbb/v2022.0.0-9d5216d68922bb4495df90ed7ef537a5/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/cms/vdt/0.4.3-9a3e3f7b7c8090f8090c6d665bb4fb23/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/xerces-c/3.1.3-020702e21b426a03eada31f0a286a389/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/xz/5.6.4-293c8a36b5ace241306f493d5287e628/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/zlib/1.2.13-da03c076b1efafbcb159a35e20281b60/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-6bc3adf269199bc8fe27c291ef7412d8/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-6bc3adf269199bc8fe27c291ef7412d8/include/eigen3 -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/fmt/10.2.1-90400412956988d7d2f85ea6ac8b3733/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/md5/1.0.0-0eeec7a8b876f86bc41aaf0176f636dd/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/OpenBLAS/0.3.27-7afdad1f1cc07eb5a57c343e8a8a572a/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/tinyxml2/6.2.0-ef678365738ddd2833328bb954dd98c5/include -O3 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++20 -ftree-vectorize -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -Wno-error=array-bounds -Warray-bounds -fuse-ld=bfd -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-unused-parameter -Wunused -Wparentheses -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -DEIGEN_DONT_PARALLELIZE -DEIGEN_MAX_ALIGN_BYTES=64 -Wno-error=unused-variable -DALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128 -DALPAKA_DISABLE_VENDOR_RNG -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED -DBOOST_DISABLE_ASSERTS -march=x86-64-v2 -flto=auto -fipa-icf -flto-odr-type-merging -fno-fat-lto-objects -Wodr -fPIC -MMD -MF tmp/el8_amd64_gcc14/src/RecoLocalCalo/EcalRecProducers/plugins/RecoLocalCaloEcalRecProducersPluginsPortableSerialSync/scram_x86-64-v2/alpaka/EcalUncalibRecHitProducerPortable.cc.d src/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalUncalibRecHitProducerPortable.cc -o tmp/el8_amd64_gcc14/src/RecoLocalCalo/EcalRecProducers/plugins/RecoLocalCaloEcalRecProducersPluginsPortableSerialSync/scram_x86-64-v2/alpaka/EcalUncalibRecHitProducerPortable.cc.o
>> Compiling alpaka/serial scram_x86-64-v2 edm plugin src/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EnergyComputationKernels.dev.cc
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gcc/14.2.1-475d4640d5186beb85fe6c9d366d668f/bin/c++ -c -DCMS_MICRO_ARCH='x86-64-v2' -DGNU_GCC -D_GNU_SOURCE -DTBB_USE_GLIBCXX_VERSION=140201 -DTBB_SUPPRESS_DEPRECATED_MESSAGES -DTBB_PREVIEW_RESUMABLE_TASKS=1 -DTBB_PREVIEW_TASK_GROUP_EXTENSIONS=1 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -DBOOST_MATH_DISABLE_STD_FPCLASSIFY -DBOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX -DBOOST_MPL_IGNORE_PARENTHESES_WARNING -DDD4HEP_USE_GEANT4_UNITS=1 -DCMSSW_GIT_HASH='CMSSW_15_1_X_2025-04-23-2300' -DPROJECT_NAME='CMSSW' -DPROJECT_VERSION='CMSSW_15_1_X_2025-04-23-2300' -Isrc -Ipoison -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/cms/cmssw/CMSSW_15_1_X_2025-04-21-2300/src -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/dd4hep/v01-29-00-a7d2f3fa9698a8af208e6626d9424d74/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/alpaka/1.2.0-3e35c1de77f81c8ba5df8b88ae089955/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/pcre/8.43-fec6e6028744fb6ef466c775a44bdbc6/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/boost/1.80.0-568acc6bf98000fa1932ee81ef82c0ed/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/bz2lib/1.0.6-5144693e7a37ea5b81cd450abd20a4e3/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/clhep/2.4.7.1-f00060af34dc2ab8b3dcb35c4ceb818d/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/cuda/12.8.0-88740af71f61096948e1ccabfda70dea/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gsl/2.6-6508fb106023911bfb9f369409186e05/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/hepmc/2.06.10-f836a4b0b1d1fff3b90cdc2d904f0d85/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/libuuid/2.34-1d099d79c169c484b1c981ae6ba60d78/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/lcg/root/6.32.13-648e06eec9ef66b6ffea552d87999e71/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/tbb/v2022.0.0-9d5216d68922bb4495df90ed7ef537a5/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/cms/vdt/0.4.3-9a3e3f7b7c8090f8090c6d665bb4fb23/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/xerces-c/3.1.3-020702e21b426a03eada31f0a286a389/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/xz/5.6.4-293c8a36b5ace241306f493d5287e628/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/zlib/1.2.13-da03c076b1efafbcb159a35e20281b60/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-6bc3adf269199bc8fe27c291ef7412d8/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-6bc3adf269199bc8fe27c291ef7412d8/include/eigen3 -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/fmt/10.2.1-90400412956988d7d2f85ea6ac8b3733/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/md5/1.0.0-0eeec7a8b876f86bc41aaf0176f636dd/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/OpenBLAS/0.3.27-7afdad1f1cc07eb5a57c343e8a8a572a/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/tinyxml2/6.2.0-ef678365738ddd2833328bb954dd98c5/include -O3 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++20 -ftree-vectorize -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -Wno-error=array-bounds -Warray-bounds -fuse-ld=bfd -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-unused-parameter -Wunused -Wparentheses -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -DEIGEN_DONT_PARALLELIZE -DEIGEN_MAX_ALIGN_BYTES=64 -Wno-error=unused-variable -DALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128 -DALPAKA_DISABLE_VENDOR_RNG -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED -DBOOST_DISABLE_ASSERTS -march=x86-64-v2 -flto=auto -fipa-icf -flto-odr-type-merging -fno-fat-lto-objects -Wodr -fPIC -MMD -MF tmp/el8_amd64_gcc14/src/RecoLocalCalo/EcalRecProducers/plugins/RecoLocalCaloEcalRecProducersPluginsPortableSerialSync/scram_x86-64-v2/alpaka/EnergyComputationKernels.dev.cc.d src/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EnergyComputationKernels.dev.cc -o tmp/el8_amd64_gcc14/src/RecoLocalCalo/EcalRecProducers/plugins/RecoLocalCaloEcalRecProducersPluginsPortableSerialSync/scram_x86-64-v2/alpaka/EnergyComputationKernels.dev.cc.o
>> Compiling alpaka/serial scram_x86-64-v2 edm plugin src/RecoLocalCalo/EcalRecProducers/plugins/alpaka/KernelHelpers.dev.cc
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gcc/14.2.1-475d4640d5186beb85fe6c9d366d668f/bin/c++ -c -DCMS_MICRO_ARCH='x86-64-v2' -DGNU_GCC -D_GNU_SOURCE -DTBB_USE_GLIBCXX_VERSION=140201 -DTBB_SUPPRESS_DEPRECATED_MESSAGES -DTBB_PREVIEW_RESUMABLE_TASKS=1 -DTBB_PREVIEW_TASK_GROUP_EXTENSIONS=1 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -DBOOST_MATH_DISABLE_STD_FPCLASSIFY -DBOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX -DBOOST_MPL_IGNORE_PARENTHESES_WARNING -DDD4HEP_USE_GEANT4_UNITS=1 -DCMSSW_GIT_HASH='CMSSW_15_1_X_2025-04-23-2300' -DPROJECT_NAME='CMSSW' -DPROJECT_VERSION='CMSSW_15_1_X_2025-04-23-2300' -Isrc -Ipoison -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/cms/cmssw/CMSSW_15_1_X_2025-04-21-2300/src -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/dd4hep/v01-29-00-a7d2f3fa9698a8af208e6626d9424d74/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/alpaka/1.2.0-3e35c1de77f81c8ba5df8b88ae089955/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/pcre/8.43-fec6e6028744fb6ef466c775a44bdbc6/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/boost/1.80.0-568acc6bf98000fa1932ee81ef82c0ed/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/bz2lib/1.0.6-5144693e7a37ea5b81cd450abd20a4e3/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/clhep/2.4.7.1-f00060af34dc2ab8b3dcb35c4ceb818d/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/cuda/12.8.0-88740af71f61096948e1ccabfda70dea/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gsl/2.6-6508fb106023911bfb9f369409186e05/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/hepmc/2.06.10-f836a4b0b1d1fff3b90cdc2d904f0d85/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/libuuid/2.34-1d099d79c169c484b1c981ae6ba60d78/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/lcg/root/6.32.13-648e06eec9ef66b6ffea552d87999e71/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/tbb/v2022.0.0-9d5216d68922bb4495df90ed7ef537a5/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/cms/vdt/0.4.3-9a3e3f7b7c8090f8090c6d665bb4fb23/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/xerces-c/3.1.3-020702e21b426a03eada31f0a286a389/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/xz/5.6.4-293c8a36b5ace241306f493d5287e628/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/zlib/1.2.13-da03c076b1efafbcb159a35e20281b60/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-6bc3adf269199bc8fe27c291ef7412d8/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-6bc3adf269199bc8fe27c291ef7412d8/include/eigen3 -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/fmt/10.2.1-90400412956988d7d2f85ea6ac8b3733/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/md5/1.0.0-0eeec7a8b876f86bc41aaf0176f636dd/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/OpenBLAS/0.3.27-7afdad1f1cc07eb5a57c343e8a8a572a/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/tinyxml2/6.2.0-ef678365738ddd2833328bb954dd98c5/include -O3 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++20 -ftree-vectorize -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -Wno-error=array-bounds -Warray-bounds -fuse-ld=bfd -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-unused-parameter -Wunused -Wparentheses -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -DEIGEN_DONT_PARALLELIZE -DEIGEN_MAX_ALIGN_BYTES=64 -Wno-error=unused-variable -DALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128 -DALPAKA_DISABLE_VENDOR_RNG -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED -DBOOST_DISABLE_ASSERTS -march=x86-64-v2 -flto=auto -fipa-icf -flto-odr-type-merging -fno-fat-lto-objects -Wodr -fPIC -MMD -MF tmp/el8_amd64_gcc14/src/RecoLocalCalo/EcalRecProducers/plugins/RecoLocalCaloEcalRecProducersPluginsPortableSerialSync/scram_x86-64-v2/alpaka/KernelHelpers.dev.cc.d src/RecoLocalCalo/EcalRecProducers/plugins/alpaka/KernelHelpers.dev.cc -o tmp/el8_amd64_gcc14/src/RecoLocalCalo/EcalRecProducers/plugins/RecoLocalCaloEcalRecProducersPluginsPortableSerialSync/scram_x86-64-v2/alpaka/KernelHelpers.dev.cc.o
src/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalUncalibRecHitPhase2WeightsAlgoPortable.dev.cc: In member function 'void alpaka_serial_sync::ecal::weights::Phase2WeightsKernel::operator()(const alpaka_serial_sync::Acc1D&, const alpaka_serial_sync::EcalUncalibRecHitPhase2Weights*, PortableHostCollection<EcalDigiPhase2SoALayout<> >::ConstView, PortableHostCollection<EcalUncalibratedRecHitSoALayout<> >::View) const':
  [src/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalUncalibRecHitPhase2WeightsAlgoPortable.dev.cc:37](https://github.com/cms-sw/cmssw/blob/CMSSW_15_1_X_2025-04-23-2300/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalUncalibRecHitPhase2WeightsAlgoPortable.dev.cc#L37):21: warning: possibly dangling reference to a temporary [-Wdangling-reference]
    37 |         const auto& digi = digisDev[tx].data();
      |                     ^~~~
src/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalUncalibRecHitPhase2WeightsAlgoPortable.dev.cc:37:45: note: the temporary was destroyed at the end of the full expression 'digisDev.EcalDigiPhase2SoALayout<>::ConstViewTemplateFreeParams<128, false, true, true>::operator[](((EcalDigiPhase2SoALayout<>::ConstViewTemplateFreeParams<128, false, true, true>::size_type)tx)).EcalDigiPhase2SoALayout<>::ConstViewTemplateFreeParams<128, false, true, true>::const_element::data()'
   37 |         const auto& digi = digisDev[tx].data();
      |                            ~~~~~~~~~~~~~~~~~^~
```

#### PR validation:

No warning when building locally.