### PR TITLE
[DAQ] Improved event checks (15_1_X)

### DIFF
--- a/EventFilter/Utilities/interface/DAQSource.h
+++ b/EventFilter/Utilities/interface/DAQSource.h
@@ -1,6 +1,15 @@
 #ifndef EventFilter_Utilities_DAQSource_h
 #define EventFilter_Utilities_DAQSource_h
 
+/*
+ * DAQSource - modular input source supporting multiple
+ * buffering strategies and data formats. Specific formats are included
+ * as models defined as DataMode child class.
+ * Source supports DAQ file protocol using specific input file naming schema
+ * and JSON metadata files.
+ * See doc/READHME-DTH.md for more information, including file naming formats
+ */
+
 #include <condition_variable>
 #include <cstdio>
 #include <filesystem>

--- a/EventFilter/Utilities/interface/DAQSource.h
+++ b/EventFilter/Utilities/interface/DAQSource.h
@@ -104,6 +104,7 @@ private:
   // get LS from filename instead of event header
   const bool alwaysStartFromFirstLS_;
   const bool verifyChecksum_;
+  const bool inputConsistencyChecks_;
   const bool useL1EventID_;
   const std::vector<unsigned int> testTCDSFEDRange_;
   std::vector<std::string> listFileNames_;

--- a/EventFilter/Utilities/interface/DAQSourceModels.h
+++ b/EventFilter/Utilities/interface/DAQSourceModels.h
@@ -1,6 +1,11 @@
 #ifndef EventFilter_Utilities_DAQSourceModels_h
 #define EventFilter_Utilities_DAQSourceModels_h
 
+/*
+ * Base class defining modular interface for DAQSource data models
+ * See doc/README-DTH.md for interface description
+ */
+
 #include <condition_variable>
 #include <cstdio>
 #include <filesystem>

--- a/EventFilter/Utilities/interface/DAQSourceModelsDTH.h
+++ b/EventFilter/Utilities/interface/DAQSourceModelsDTH.h
@@ -1,6 +1,17 @@
 #ifndef EventFilter_Utilities_DAQSourceModelsDTH_h
 #define EventFilter_Utilities_DAQSourceModelsDTH_h
 
+/*
+ * DAQ Source module for DTH readout
+ * Used by modular DAQSource to read files containing raw DTH orbit payload.
+ * Orbits are unpacked into individual events which are queued to the framework as FedRawDataCollection object.
+ * If more than one sourceID blocks is included they will all be unpacked, they need to be adjacent in the file
+ * for the same orbit. Exception to this is reading from multiple file sources,
+ * in that case that is only required locally in a file, but orbits need to come in the same order in all files.
+ * See test/RunBUFU.sh and test/testDTH.sh for example how to run with this module
+ * Also see documentation in doc/README=DTH.md
+*/
+
 #include <filesystem>
 #include <queue>
 #include <regex>

--- a/EventFilter/Utilities/interface/DAQSourceModelsFRD.h
+++ b/EventFilter/Utilities/interface/DAQSourceModelsFRD.h
@@ -99,7 +99,6 @@ private:
   std::unordered_set<unsigned short> fedIdSet_;
   unsigned int expectedFedsInEvent_ = 0;
   bool verifyFEDs_ = true;
-
 };
 
 /*

--- a/EventFilter/Utilities/interface/DAQSourceModelsFRD.h
+++ b/EventFilter/Utilities/interface/DAQSourceModelsFRD.h
@@ -11,6 +11,7 @@ class FEDRawDataCollection;
 
 class DataModeFRD : public DataMode {
 public:
+  DataModeFRD(DAQSource* daqSource, bool verifyFEDs) : DataMode(daqSource), verifyFEDs_(verifyFEDs) {}
   DataModeFRD(DAQSource* daqSource) : DataMode(daqSource) {}
   ~DataModeFRD() override {}
   std::vector<std::shared_ptr<const edm::DaqProvenanceHelper>>& makeDaqProvenanceHelpers() override;
@@ -82,6 +83,10 @@ private:
   uint16_t MINTCDSuTCAFEDID_ = FEDNumbering::MINTCDSuTCAFEDID;
   uint16_t MAXTCDSuTCAFEDID_ = FEDNumbering::MAXTCDSuTCAFEDID;
   bool eventCached_ = false;
+  std::unordered_set<unsigned short> fedIdSet_;
+  unsigned int expectedFedsInEvent_ = 0;
+  bool verifyFEDs_ = true;
+
 };
 
 /*
@@ -90,7 +95,7 @@ private:
 
 class DataModeFRDPreUnpack : public DataMode {
 public:
-  DataModeFRDPreUnpack(DAQSource* daqSource) : DataMode(daqSource) {}
+  DataModeFRDPreUnpack(DAQSource* daqSource, bool verifyFEDs) : DataMode(daqSource), verifyFEDs_(verifyFEDs) {}
   ~DataModeFRDPreUnpack() override {};
   std::vector<std::shared_ptr<const edm::DaqProvenanceHelper>>& makeDaqProvenanceHelpers() override;
   void readEvent(edm::EventPrincipal& eventPrincipal) override;
@@ -164,6 +169,9 @@ private:
   uint16_t MINTCDSuTCAFEDID_ = FEDNumbering::MINTCDSuTCAFEDID;
   uint16_t MAXTCDSuTCAFEDID_ = FEDNumbering::MAXTCDSuTCAFEDID;
   bool eventCached_ = false;
+  std::unordered_set<unsigned short> fedIdSet_;
+  unsigned int expectedFedsInEvent_ = 0;
+  bool verifyFEDs_ = true;
 };
 
 /* 
@@ -173,7 +181,7 @@ private:
 
 class DataModeFRDStriped : public DataMode {
 public:
-  DataModeFRDStriped(DAQSource* daqSource) : DataMode(daqSource) {}
+  DataModeFRDStriped(DAQSource* daqSource, bool verifyFEDs) : DataMode(daqSource), verifyFEDs_(verifyFEDs) {}
   ~DataModeFRDStriped() override {}
   std::vector<std::shared_ptr<const edm::DaqProvenanceHelper>>& makeDaqProvenanceHelpers() override;
   void readEvent(edm::EventPrincipal& eventPrincipal) override;
@@ -258,6 +266,9 @@ private:
   uint16_t MINTCDSuTCAFEDID_ = FEDNumbering::MINTCDSuTCAFEDID;
   uint16_t MAXTCDSuTCAFEDID_ = FEDNumbering::MAXTCDSuTCAFEDID;
   std::vector<std::filesystem::path> buPaths_;
+  std::unordered_set<unsigned short> fedIdSet_;
+  unsigned int expectedFedsInEvent_ = 0;
+  bool verifyFEDs_ = true;
 };
 
 #endif  // EventFilter_Utilities_DAQSourceModelsFRD_h

--- a/EventFilter/Utilities/interface/DAQSourceModelsFRD.h
+++ b/EventFilter/Utilities/interface/DAQSourceModelsFRD.h
@@ -1,6 +1,14 @@
 #ifndef EventFilter_Utilities_DAQSourceModelsFRD_h
 #define EventFilter_Utilities_DAQSourceModelsFRD_h
 
+/*
+* DAQSource data model classes for reading Run3 FRD format and unpacking into the FedRawDataCollection
+* FRD: standard readout of input from the event builder
+* FRDPreUNpack: variant unpacking events tns nto FedRawDataCollection class in reader threads
+* FRSStiped: more generic version able to read from multiple source
+* directories (Super-Fragmeng Builder DAQ)
+* */
+
 #include <filesystem>
 #include <queue>
 #include "oneapi/tbb/concurrent_unordered_set.h"
@@ -9,6 +17,10 @@
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 
 class FEDRawDataCollection;
+
+/*
+ * FRD unpacker equivalent to the FedRawDataInputSource
+ */
 
 class DataModeFRD : public DataMode {
 public:
@@ -91,7 +103,7 @@ private:
 };
 
 /*
- * FRD source prebuffering in reader thread
+ * FRD source prebuffering in the reader thread
  */
 
 class DataModeFRDPreUnpack : public DataMode {
@@ -176,7 +188,7 @@ private:
 };
 
 /* 
- * FRD source reading files from multiple striped destinations
+ * FRD source reading files from multiple striped destinations (Super-Fragment Builder DAQ)
  *
  * */
 

--- a/EventFilter/Utilities/interface/DAQSourceModelsFRD.h
+++ b/EventFilter/Utilities/interface/DAQSourceModelsFRD.h
@@ -102,7 +102,7 @@ public:
   void readEvent(edm::EventPrincipal& eventPrincipal) override;
 
   //non-virtual
-  void unpackEvent(edm::streamer::FRDEventMsgView* eview, UnpackedRawEventWrapper* ec);
+  void unpackEvent(edm::streamer::FRDEventMsgView* eview, UnpackedRawEventWrapper* ec, unsigned int ls);
   void unpackFile(RawInputFile*) override;
   edm::Timestamp fillFEDRawDataCollection(edm::streamer::FRDEventMsgView* eview,
                                           FEDRawDataCollection& rawData,

--- a/EventFilter/Utilities/interface/DAQSourceModelsFRD.h
+++ b/EventFilter/Utilities/interface/DAQSourceModelsFRD.h
@@ -3,6 +3,7 @@
 
 #include <filesystem>
 #include <queue>
+#include "oneapi/tbb/concurrent_unordered_set.h"
 
 #include "EventFilter/Utilities/interface/DAQSourceModels.h"
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
@@ -169,8 +170,8 @@ private:
   uint16_t MINTCDSuTCAFEDID_ = FEDNumbering::MINTCDSuTCAFEDID;
   uint16_t MAXTCDSuTCAFEDID_ = FEDNumbering::MAXTCDSuTCAFEDID;
   bool eventCached_ = false;
-  std::unordered_set<unsigned short> fedIdSet_;
-  unsigned int expectedFedsInEvent_ = 0;
+  oneapi::tbb::concurrent_unordered_set<unsigned short> fedIdSet_;
+  std::atomic<unsigned int> expectedFedsInEvent_ = 0;
   bool verifyFEDs_ = true;
 };
 

--- a/EventFilter/Utilities/interface/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/interface/FedRawDataInputSource.h
@@ -185,7 +185,7 @@ private:
 
   std::map<unsigned int, unsigned int> sourceEventsReport_;
   std::mutex monlock_;
-  expectedFedsInEvent_ = 0;
+  unsigned int expectedFedsInEvent_ = 0;
 };
 
 #endif  // EventFilter_Utilities_FedRawDataInputSource_h

--- a/EventFilter/Utilities/interface/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/interface/FedRawDataInputSource.h
@@ -185,6 +185,7 @@ private:
 
   std::map<unsigned int, unsigned int> sourceEventsReport_;
   std::mutex monlock_;
+  expectedFedsInEvent_ = 0;
 };
 
 #endif  // EventFilter_Utilities_FedRawDataInputSource_h

--- a/EventFilter/Utilities/plugins/DaqFakeReader.cc
+++ b/EventFilter/Utilities/plugins/DaqFakeReader.cc
@@ -43,19 +43,26 @@ DaqFakeReader::DaqFakeReader(const edm::ParameterSet& pset)
       modulo_error_events(injected_errors_per_million_events ? 1000000 / injected_errors_per_million_events
                                                              : 0xffffffff),
       subsystems_(pset.getUntrackedParameter<std::vector<std::string>>("subsystems")) {
-
   for (auto const& subsystem : subsystems_) {
-    if (subsystem == "TCDS") haveTCDS_ = true;
-    else if (subsystem == "SiPixel") haveSiPixel_ = true;
-    else if (subsystem == "SiStrip") haveSiStrip_ = true;
-    else if (subsystem == "ECAL") haveECAL_ = true;
-    else if (subsystem == "HCAL") haveHCAL_ = true;
-    else if (subsystem == "DT") haveDT_ = true;
-    else if (subsystem == "CSC") haveCSC_ = true;
-    else if (subsystem == "RPC") haveRPC_ = true;
+    if (subsystem == "TCDS")
+      haveTCDS_ = true;
+    else if (subsystem == "SiPixel")
+      haveSiPixel_ = true;
+    else if (subsystem == "SiStrip")
+      haveSiStrip_ = true;
+    else if (subsystem == "ECAL")
+      haveECAL_ = true;
+    else if (subsystem == "HCAL")
+      haveHCAL_ = true;
+    else if (subsystem == "DT")
+      haveDT_ = true;
+    else if (subsystem == "CSC")
+      haveCSC_ = true;
+    else if (subsystem == "RPC")
+      haveRPC_ = true;
   }
   // mean = pset.getParameter<float>("mean");
-  if ( haveTCDS_ && tcdsFEDID_ < FEDNumbering::MINTCDSuTCAFEDID)
+  if (haveTCDS_ && tcdsFEDID_ < FEDNumbering::MINTCDSuTCAFEDID)
     throw cms::Exception("DaqFakeReader::DaqFakeReader")
         << " TCDS FED ID lower than " << FEDNumbering::MINTCDSuTCAFEDID;
   if (fillRandom_) {
@@ -215,6 +222,8 @@ void DaqFakeReader::fillDescriptions(edm::ConfigurationDescriptions& description
   desc.addUntracked<unsigned int>("width", 1024);
   desc.addUntracked<unsigned int>("injectErrPpm", 1024);
   desc.addUntracked<unsigned int>("tcdsFEDID", 1024);
-  desc.addUntracked<std::vector<std::string>>("subsystems", std::initializer_list<std::string>({"TCDS", "SiPixel", "SiStrip", "ECAL", "HCAL", "DT", "CSC", "RPC"}));
+  desc.addUntracked<std::vector<std::string>>(
+      "subsystems",
+      std::initializer_list<std::string>({"TCDS", "SiPixel", "SiStrip", "ECAL", "HCAL", "DT", "CSC", "RPC"}));
   descriptions.add("DaqFakeReader", desc);
 }

--- a/EventFilter/Utilities/plugins/DaqFakeReader.cc
+++ b/EventFilter/Utilities/plugins/DaqFakeReader.cc
@@ -41,9 +41,21 @@ DaqFakeReader::DaqFakeReader(const edm::ParameterSet& pset)
       injected_errors_per_million_events(pset.getUntrackedParameter<unsigned int>("injectErrPpm", 0)),
       tcdsFEDID_(pset.getUntrackedParameter<unsigned int>("tcdsFEDID", 1024)),
       modulo_error_events(injected_errors_per_million_events ? 1000000 / injected_errors_per_million_events
-                                                             : 0xffffffff) {
+                                                             : 0xffffffff),
+      subsystems_(pset.getUntrackedParameter<std::vector<std::string>>("subsystems")) {
+
+  for (auto const& subsystem : subsystems_) {
+    if (subsystem == "TCDS") haveTCDS_ = true;
+    else if (subsystem == "SiPixel") haveSiPixel_ = true;
+    else if (subsystem == "SiStrip") haveSiStrip_ = true;
+    else if (subsystem == "ECAL") haveECAL_ = true;
+    else if (subsystem == "HCAL") haveHCAL_ = true;
+    else if (subsystem == "DT") haveDT_ = true;
+    else if (subsystem == "CSC") haveCSC_ = true;
+    else if (subsystem == "RPC") haveRPC_ = true;
+  }
   // mean = pset.getParameter<float>("mean");
-  if (tcdsFEDID_ < FEDNumbering::MINTCDSuTCAFEDID)
+  if ( haveTCDS_ && tcdsFEDID_ < FEDNumbering::MINTCDSuTCAFEDID)
     throw cms::Exception("DaqFakeReader::DaqFakeReader")
         << " TCDS FED ID lower than " << FEDNumbering::MINTCDSuTCAFEDID;
   if (fillRandom_) {
@@ -74,17 +86,25 @@ int DaqFakeReader::fillRawData(Event& e, FEDRawDataCollection*& data) {
     eventNum++;
     // FIXME:
 
-    fillFEDs(FEDNumbering::MINSiPixelFEDID, FEDNumbering::MAXSiPixelFEDID, eID, *data, meansize, width);
-    fillFEDs(FEDNumbering::MINSiStripFEDID, FEDNumbering::MAXSiStripFEDID, eID, *data, meansize, width);
-    fillFEDs(FEDNumbering::MINDTFEDID, FEDNumbering::MAXDTFEDID, eID, *data, meansize, width);
-    fillFEDs(FEDNumbering::MINCSCFEDID, FEDNumbering::MAXCSCFEDID, eID, *data, meansize, width);
-    fillFEDs(FEDNumbering::MINRPCFEDID, FEDNumbering::MAXRPCFEDID, eID, *data, meansize, width);
-    fillFEDs(FEDNumbering::MINECALFEDID, FEDNumbering::MAXECALFEDID, eID, *data, meansize, width);
-    fillFEDs(FEDNumbering::MINHCALFEDID, FEDNumbering::MAXHCALFEDID, eID, *data, meansize, width);
+    if (haveSiPixel_)
+      fillFEDs(FEDNumbering::MINSiPixelFEDID, FEDNumbering::MAXSiPixelFEDID, eID, *data, meansize, width);
+    if (haveSiStrip_)
+      fillFEDs(FEDNumbering::MINSiStripFEDID, FEDNumbering::MAXSiStripFEDID, eID, *data, meansize, width);
+    if (haveECAL_)
+      fillFEDs(FEDNumbering::MINECALFEDID, FEDNumbering::MAXECALFEDID, eID, *data, meansize, width);
+    if (haveHCAL_)
+      fillFEDs(FEDNumbering::MINHCALFEDID, FEDNumbering::MAXHCALFEDID, eID, *data, meansize, width);
+    if (haveDT_)
+      fillFEDs(FEDNumbering::MINDTFEDID, FEDNumbering::MAXDTFEDID, eID, *data, meansize, width);
+    if (haveCSC_)
+      fillFEDs(FEDNumbering::MINCSCFEDID, FEDNumbering::MAXCSCFEDID, eID, *data, meansize, width);
+    if (haveRPC_)
+      fillFEDs(FEDNumbering::MINRPCFEDID, FEDNumbering::MAXRPCFEDID, eID, *data, meansize, width);
 
     timeval now;
     gettimeofday(&now, nullptr);
-    fillTCDSFED(eID, *data, ls, &now);
+    if (haveTCDS_)
+      fillTCDSFED(eID, *data, ls, &now);
   }
   return 1;
 }
@@ -195,5 +215,6 @@ void DaqFakeReader::fillDescriptions(edm::ConfigurationDescriptions& description
   desc.addUntracked<unsigned int>("width", 1024);
   desc.addUntracked<unsigned int>("injectErrPpm", 1024);
   desc.addUntracked<unsigned int>("tcdsFEDID", 1024);
+  desc.addUntracked<std::vector<std::string>>("subsystems", std::initializer_list<std::string>({"TCDS", "SiPixel", "SiStrip", "ECAL", "HCAL", "DT", "CSC", "RPC"}));
   descriptions.add("DaqFakeReader", desc);
 }

--- a/EventFilter/Utilities/plugins/DaqFakeReader.h
+++ b/EventFilter/Utilities/plugins/DaqFakeReader.h
@@ -58,6 +58,15 @@ private:
   unsigned int tcdsFEDID_;
   unsigned int modulo_error_events;
   unsigned int fakeLs_ = 0;
+  std::vector<std::string> subsystems_;
+  bool haveTCDS_ = false;
+  bool haveSiPixel_ = false;
+  bool haveSiStrip_ = false;
+  bool haveECAL_ = false;
+  bool haveHCAL_ = false;
+  bool haveDT_ = false;
+  bool haveCSC_ = false;
+  bool haveRPC_ = false;
 };
 
 #endif

--- a/EventFilter/Utilities/src/DAQSource.cc
+++ b/EventFilter/Utilities/src/DAQSource.cc
@@ -43,6 +43,7 @@ DAQSource::DAQSource(edm::ParameterSet const& pset, edm::InputSourceDescription 
       maxBufferedFiles_(pset.getUntrackedParameter<unsigned int>("maxBufferedFiles")),
       alwaysStartFromFirstLS_(pset.getUntrackedParameter<bool>("alwaysStartFromFirstLS", false)),
       verifyChecksum_(pset.getUntrackedParameter<bool>("verifyChecksum")),
+      inputConsistencyChecks_(pset.getUntrackedParameter<bool>("inputConsistencyChecks")),
       useL1EventID_(pset.getUntrackedParameter<bool>("useL1EventID")),
       testTCDSFEDRange_(pset.getUntrackedParameter<std::vector<unsigned int>>("testTCDSFEDRange")),
       listFileNames_(pset.getUntrackedParameter<std::vector<std::string>>("fileNames")),
@@ -83,11 +84,11 @@ DAQSource::DAQSource(edm::ParameterSet const& pset, edm::InputSourceDescription 
 
   //load mode class based on parameter
   if (dataModeConfig_ == "FRD") {
-    dataMode_ = std::make_shared<DataModeFRD>(this);
+    dataMode_ = std::make_shared<DataModeFRD>(this, inputConsistencyChecks_);
   } else if (dataModeConfig_ == "FRDPreUnpack") {
-    dataMode_ = std::make_shared<DataModeFRDPreUnpack>(this);
+    dataMode_ = std::make_shared<DataModeFRDPreUnpack>(this, inputConsistencyChecks_);
   } else if (dataModeConfig_ == "FRDStriped") {
-    dataMode_ = std::make_shared<DataModeFRDStriped>(this);
+    dataMode_ = std::make_shared<DataModeFRDStriped>(this, inputConsistencyChecks_);
   } else if (dataModeConfig_ == "ScoutingRun3") {
     dataMode_ = std::make_shared<DataModeScoutingRun3>(this);
   } else if (dataModeConfig_ == "DTH") {
@@ -259,6 +260,8 @@ void DAQSource::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
       ->setComment("Force source to start from LS 1 if server provides higher lumisection number");
   desc.addUntracked<bool>("verifyChecksum", true)
       ->setComment("Verify event CRC-32C checksum of FRDv5 and higher or Adler32 with v3 and v4");
+  desc.addUntracked<bool>("inputConsistencyChecks", true)
+      ->setComment("Additional consistency checks such as checking that the FED ID set is the same in all events");
   desc.addUntracked<bool>("useL1EventID", false)
       ->setComment("Use L1 event ID from FED header if true or from TCDS FED if false");
   desc.addUntracked<std::vector<unsigned int>>("testTCDSFEDRange", std::vector<unsigned int>())

--- a/EventFilter/Utilities/src/DAQSourceModelsFRD.cc
+++ b/EventFilter/Utilities/src/DAQSourceModelsFRD.cc
@@ -204,7 +204,7 @@ void DataModeFRDPreUnpack::unpackEvent(edm::streamer::FRDEventMsgView* eview, Un
     ec->setError(errmsg);
   } else if (daqSource_->useL1EventID()) {
     //filelist mode run override not available with this model currently (source sets it too late)
-    edm::EventID eventID = edm::EventID(ec->run(), ls, L1EventID);
+    edm::EventID eventID = edm::EventID(eview->run(), ls, L1EventID);
     ec->setAux(new edm::EventAuxiliary(
         eventID, daqSource_->processGUID(), tstamp, eview->isRealData(), edm::EventAuxiliary::PhysicsTrigger));
     ec->aux()->setProcessHistoryID(daqSource_->processHistoryID());
@@ -217,7 +217,7 @@ void DataModeFRDPreUnpack::unpackEvent(edm::streamer::FRDEventMsgView* eview, Un
     tcds::Raw_v1 const* tcds = reinterpret_cast<tcds::Raw_v1 const*>(tcds_pointer + FEDHeader::length);
     edm::EventAuxiliary* aux = new edm::EventAuxiliary();  //allocate empty aux
     *aux = evf::evtn::makeEventAuxiliary(tcds,
-                                         ec->run(),
+                                         eview->run(),
                                          ls,
                                          eview->isRealData(),
                                          static_cast<edm::EventAuxiliary::ExperimentType>(fedHeader.triggerType()),

--- a/EventFilter/Utilities/src/DAQSourceModelsFRD.cc
+++ b/EventFilter/Utilities/src/DAQSourceModelsFRD.cc
@@ -115,7 +115,8 @@ edm::Timestamp DataModeFRD::fillFEDRawDataCollection(FEDRawDataCollection& rawDa
     if (verifyFEDs_ || !expectedFedsInEvent_) {
       if (fedIdSet_.find(fedId) == fedIdSet_.end()) {
         if (expectedFedsInEvent_)
-          throw cms::Exception("DataModeFRDPreUnpack:::fillFRDCollection") << "FED Id: " << fedId << " was not found in previous events";
+          throw cms::Exception("DataModeFRDPreUnpack:::fillFRDCollection")
+              << "FED Id: " << fedId << " was not found in previous events";
         else
           fedIdSet_.insert(fedId);
       }
@@ -125,16 +126,16 @@ edm::Timestamp DataModeFRD::fillFEDRawDataCollection(FEDRawDataCollection& rawDa
 
   if (!fedsInEvent)
     throw cms::Exception("DataModeFRDPreUnpack:::fillFRDCollection")
-      << "Event " << event_->event() << " does not contain any FEDs";
+        << "Event " << event_->event() << " does not contain any FEDs";
   else if (!expectedFedsInEvent_) {
     expectedFedsInEvent_ = fedsInEvent;
     if (fedIdSet_.size() != fedsInEvent)
       throw cms::Exception("DataModeFRDPreUnpack:::fillFRDCollection")
-        << "First received event: " << event_->event() << " contains duplicate FEDs";
-  }
-  else if (fedsInEvent != expectedFedsInEvent_)
+          << "First received event: " << event_->event() << " contains duplicate FEDs";
+  } else if (fedsInEvent != expectedFedsInEvent_)
     throw cms::Exception("DataModeFRDPreUnpack:::fillFRDCollection")
-      << "Event " << event_->event() << " does not contain same number of FEDs as previous: " << fedsInEvent << "/" << expectedFedsInEvent_;
+        << "Event " << event_->event() << " does not contain same number of FEDs as previous: " << fedsInEvent << "/"
+        << expectedFedsInEvent_;
 
   return tstamp;
 }
@@ -189,7 +190,9 @@ std::string DataModeFRD::getChecksumError() const {
  * FRD preRead
  */
 
-void DataModeFRDPreUnpack::unpackEvent(edm::streamer::FRDEventMsgView* eview, UnpackedRawEventWrapper* ec, unsigned int ls) {
+void DataModeFRDPreUnpack::unpackEvent(edm::streamer::FRDEventMsgView* eview,
+                                       UnpackedRawEventWrapper* ec,
+                                       unsigned int ls) {
   //TODO: also walk the file and build checksum
   FEDRawDataCollection* rawData = new FEDRawDataCollection;
   bool tcdsInRange;
@@ -315,8 +318,7 @@ edm::Timestamp DataModeFRDPreUnpack::fillFEDRawDataCollection(edm::streamer::FRD
       const FEDHeader fedHeader(event + eventSize);
       const uint16_t fedId = fedHeader.sourceID();
       if (fedId > FEDNumbering::MAXFEDID)
-        throw cms::Exception("DataModeFRDPreUnpack:::fillFRDCollection")
-          << "Out of range FED ID : " << fedId;
+        throw cms::Exception("DataModeFRDPreUnpack:::fillFRDCollection") << "Out of range FED ID : " << fedId;
       else if (fedId >= MINTCDSuTCAFEDID_ && fedId <= MAXTCDSuTCAFEDID_) {
         if (!selectedTCDSFed) {
           selectedTCDSFed = fedId;
@@ -326,7 +328,7 @@ edm::Timestamp DataModeFRDPreUnpack::fillFEDRawDataCollection(edm::streamer::FRD
           }
         } else
           throw cms::Exception("DataModeFRDPreUnpack:::fillFRDCollection")
-            << "Second TCDS FED ID " << fedId << " found. First ID: " << selectedTCDSFed;
+              << "Second TCDS FED ID " << fedId << " found. First ID: " << selectedTCDSFed;
       }
       //take event ID from GTPE FED
       FEDRawData& fedData = rawData.FEDData(fedId);
@@ -337,7 +339,8 @@ edm::Timestamp DataModeFRDPreUnpack::fillFEDRawDataCollection(edm::streamer::FRD
       if (verifyFEDs_ || !expectedFedsInEvent_) {
         if (fedIdSet_.find(fedId) == fedIdSet_.end()) {
           if (expectedFedsInEvent_)
-            throw cms::Exception("DataModeFRDPreUnpack:::fillFRDCollection") << "FEDID " << fedId << " was not found in previous events";
+            throw cms::Exception("DataModeFRDPreUnpack:::fillFRDCollection")
+                << "FEDID " << fedId << " was not found in previous events";
           else
             fedIdSet_.insert(fedId);
         }
@@ -347,18 +350,18 @@ edm::Timestamp DataModeFRDPreUnpack::fillFEDRawDataCollection(edm::streamer::FRD
 
     if (!fedsInEvent)
       throw cms::Exception("DataModeFRDPreUnpack:::fillFRDCollection")
-        << "Event " << event_->event() << " does not contain any FEDs";
+          << "Event " << event_->event() << " does not contain any FEDs";
     else if (!expectedFedsInEvent_) {
       expectedFedsInEvent_ = fedsInEvent;
       if (fedIdSet_.size() != fedsInEvent)
         throw cms::Exception("DataModeFRDPreUnpack:::fillFRDCollection")
-          << "First received event: " << event_->event() << " contains duplicate FEDs";
-    }
-    else if (fedsInEvent != expectedFedsInEvent_)
+            << "First received event: " << event_->event() << " contains duplicate FEDs";
+    } else if (fedsInEvent != expectedFedsInEvent_)
       throw cms::Exception("DataModeFRDPreUnpack:::fillFRDCollection")
-        << "Event " << event_->event() << " does not contain same number of FEDs as previous: " << fedsInEvent << "/" << expectedFedsInEvent_;
+          << "Event " << event_->event() << " does not contain same number of FEDs as previous: " << fedsInEvent << "/"
+          << expectedFedsInEvent_;
 
-  } catch (cms::Exception &e) {
+  } catch (cms::Exception& e) {
     err = true;
     errmsg = e.what();
   }
@@ -509,7 +512,8 @@ edm::Timestamp DataModeFRDStriped::fillFRDCollection(FEDRawDataCollection& rawDa
         if (fedIdSet_.find(fedId) == fedIdSet_.end()) {
           if (expectedFedsInEvent_)
             throw cms::Exception("DataModeFRDStriped:::fillFRDCollection")
-              << "FEDID " << fedId << " from the file at index " << (uint64_t)index << " was not found in previous events";
+                << "FEDID " << fedId << " from the file at index " << (uint64_t)index
+                << " was not found in previous events";
           else
             fedIdSet_.insert(fedId);
         }
@@ -525,13 +529,12 @@ edm::Timestamp DataModeFRDStriped::fillFRDCollection(FEDRawDataCollection& rawDa
     expectedFedsInEvent_ = fedsInEvent;
     if (fedIdSet_.size() != fedsInEvent) {
       throw cms::Exception("DataModeFRDStriped:::fillFRDCollection")
-        << "First received event: " << events_.at(0)->event() << " contains duplicate FEDs";
-     }
-  }
-  else if (fedsInEvent != expectedFedsInEvent_)
+          << "First received event: " << events_.at(0)->event() << " contains duplicate FEDs";
+    }
+  } else if (fedsInEvent != expectedFedsInEvent_)
     throw cms::Exception("DataModeFRDStriped:::fillFRDCollection")
-        << "Event " << events_.at(0)->event() << " does not contain same number of FEDs as previous: "
-        << fedsInEvent << "/" << expectedFedsInEvent_;
+        << "Event " << events_.at(0)->event() << " does not contain same number of FEDs as previous: " << fedsInEvent
+        << "/" << expectedFedsInEvent_;
 
   return tstamp;
 }
@@ -643,9 +646,10 @@ bool DataModeFRDStriped::makeEvents() {
 
     if (testEvtId == 0)
       testEvtId = events_[i]->event();
-    else if (testEvtId !=  events_[i]->event())
+    else if (testEvtId != events_[i]->event())
       throw cms::Exception("DAQSource::getNextEvent")
-          << " event id mismatch:" << events_[i]->event() << " while in previously parsed RDEventMsgView (other file):" << testEvtId;
+          << " event id mismatch:" << events_[i]->event()
+          << " while in previously parsed RDEventMsgView (other file):" << testEvtId;
 
     if (dataBlockAddrs_[i] + events_[i]->size() > dataBlockMaxAddrs_[i])
       throw cms::Exception("DAQSource::getNextEvent")

--- a/EventFilter/Utilities/src/DAQSourceModelsFRD.cc
+++ b/EventFilter/Utilities/src/DAQSourceModelsFRD.cc
@@ -83,6 +83,7 @@ edm::Timestamp DataModeFRD::fillFEDRawDataCollection(FEDRawDataCollection& rawDa
   tcds_pointer = nullptr;
   tcdsInRange = false;
   uint16_t selectedTCDSFed = 0;
+  unsigned int fedsInEvent = 0;
   while (eventSize > 0) {
     assert(eventSize >= FEDTrailer::length);
     eventSize -= FEDTrailer::length;
@@ -109,8 +110,31 @@ edm::Timestamp DataModeFRD::fillFEDRawDataCollection(FEDRawDataCollection& rawDa
     FEDRawData& fedData = rawData.FEDData(fedId);
     fedData.resize(fedSize);
     memcpy(fedData.data(), event + eventSize, fedSize);
+
+    fedsInEvent++;
+    if (verifyFEDs_ || !expectedFedsInEvent_) {
+      if (fedIdSet_.find(fedId) == fedIdSet_.end()) {
+        if (expectedFedsInEvent_)
+          throw cms::Exception("DataModeFRDPreUnpack:::fillFRDCollection") << "FED Id: " << fedId << " was not found in previous events";
+        else
+          fedIdSet_.insert(fedId);
+      }
+    }
   }
   assert(eventSize == 0);
+
+  if (!fedsInEvent)
+    throw cms::Exception("DataModeFRDPreUnpack:::fillFRDCollection")
+      << "Event " << event_->event() << " does not contain any FEDs";
+  else if (!expectedFedsInEvent_) {
+    expectedFedsInEvent_ = fedsInEvent;
+    if (fedIdSet_.size() != fedsInEvent)
+      throw cms::Exception("DataModeFRDPreUnpack:::fillFRDCollection")
+        << "First received event: " << event_->event() << " contains duplicate FEDs";
+  }
+  else if (fedsInEvent != expectedFedsInEvent_)
+    throw cms::Exception("DataModeFRDPreUnpack:::fillFRDCollection")
+      << "Event " << event_->event() << " does not contain same number of FEDs as previous: " << fedsInEvent << "/" << expectedFedsInEvent_;
 
   return tstamp;
 }
@@ -273,48 +297,72 @@ edm::Timestamp DataModeFRDPreUnpack::fillFEDRawDataCollection(edm::streamer::FRD
   time = (time << 32) + stv.tv_usec;
   edm::Timestamp tstamp(time);
 
-  uint32_t eventSize = eview->eventSize();
-  unsigned char* event = (unsigned char*)eview->payload();
-  tcds_pointer = nullptr;
-  tcdsInRange = false;
-  uint16_t selectedTCDSFed = 0;
-  while (eventSize > 0) {
-    assert(eventSize >= FEDTrailer::length);
-    eventSize -= FEDTrailer::length;
-    const FEDTrailer fedTrailer(event + eventSize);
-    const uint32_t fedSize = fedTrailer.fragmentLength() << 3;  //trailer length counts in 8 bytes
-    assert(eventSize >= fedSize - FEDHeader::length);
-    eventSize -= (fedSize - FEDHeader::length);
-    const FEDHeader fedHeader(event + eventSize);
-    const uint16_t fedId = fedHeader.sourceID();
-    if (fedId > FEDNumbering::MAXFEDID) {
-      err = true;
-      std::stringstream str;
-      str << "Out of range FED ID : " << fedId;
-      errmsg = str.str();
-      return tstamp;
-    } else if (fedId >= MINTCDSuTCAFEDID_ && fedId <= MAXTCDSuTCAFEDID_) {
-      if (!selectedTCDSFed) {
-        selectedTCDSFed = fedId;
-        tcds_pointer = event + eventSize;
-        if (fedId >= FEDNumbering::MINTCDSuTCAFEDID && fedId <= FEDNumbering::MAXTCDSuTCAFEDID) {
-          tcdsInRange = true;
+  try {
+    uint32_t eventSize = eview->eventSize();
+    unsigned char* event = (unsigned char*)eview->payload();
+    tcds_pointer = nullptr;
+    tcdsInRange = false;
+    uint16_t selectedTCDSFed = 0;
+    unsigned int fedsInEvent = 0;
+    while (eventSize > 0) {
+      assert(eventSize >= FEDTrailer::length);
+      eventSize -= FEDTrailer::length;
+      const FEDTrailer fedTrailer(event + eventSize);
+      const uint32_t fedSize = fedTrailer.fragmentLength() << 3;  //trailer length counts in 8 bytes
+      assert(eventSize >= fedSize - FEDHeader::length);
+      eventSize -= (fedSize - FEDHeader::length);
+      const FEDHeader fedHeader(event + eventSize);
+      const uint16_t fedId = fedHeader.sourceID();
+      if (fedId > FEDNumbering::MAXFEDID)
+        throw cms::Exception("DataModeFRDPreUnpack:::fillFRDCollection")
+          << "Out of range FED ID : " << fedId;
+      else if (fedId >= MINTCDSuTCAFEDID_ && fedId <= MAXTCDSuTCAFEDID_) {
+        if (!selectedTCDSFed) {
+          selectedTCDSFed = fedId;
+          tcds_pointer = event + eventSize;
+          if (fedId >= FEDNumbering::MINTCDSuTCAFEDID && fedId <= FEDNumbering::MAXTCDSuTCAFEDID) {
+            tcdsInRange = true;
+          }
+        } else
+          throw cms::Exception("DataModeFRDPreUnpack:::fillFRDCollection")
+            << "Second TCDS FED ID " << fedId << " found. First ID: " << selectedTCDSFed;
+      }
+    //take event ID from GTPE FED
+      FEDRawData& fedData = rawData.FEDData(fedId);
+      fedData.resize(fedSize);
+      memcpy(fedData.data(), event + eventSize, fedSize);
+
+      fedsInEvent++;
+      if (verifyFEDs_ || !expectedFedsInEvent_) {
+        if (fedIdSet_.find(fedId) == fedIdSet_.end()) {
+          if (expectedFedsInEvent_)
+            throw cms::Exception("DataModeFRDPreUnpack:::fillFRDCollection") << "FEDID " << fedId << " was not found in previous events";
+          else
+            fedIdSet_.insert(fedId);
         }
-      } else {
-        err = true;
-        std::stringstream str;
-        str << "Second TCDS FED ID " << fedId << " found. First ID: " << selectedTCDSFed;
-        errmsg = str.str();
-        return tstamp;
       }
     }
-    //take event ID from GTPE FED
-    FEDRawData& fedData = rawData.FEDData(fedId);
-    fedData.resize(fedSize);
-    memcpy(fedData.data(), event + eventSize, fedSize);
-  }
-  assert(eventSize == 0);
+    assert(eventSize == 0);
 
+    if (!fedsInEvent)
+      throw cms::Exception("DataModeFRDPreUnpack:::fillFRDCollection")
+        << "Event " << event_->event() << " does not contain any FEDs";
+    else if (!expectedFedsInEvent_) {
+      expectedFedsInEvent_ = fedsInEvent;
+      if (fedIdSet_.size() != fedsInEvent)
+        throw cms::Exception("DataModeFRDPreUnpack:::fillFRDCollection")
+          << "First received event: " << event_->event() << " contains duplicate FEDs";
+    }
+    else if (fedsInEvent != expectedFedsInEvent_)
+      throw cms::Exception("DataModeFRDPreUnpack:::fillFRDCollection")
+        << "Event " << event_->event() << " does not contain same number of FEDs as previous: " << fedsInEvent << "/" << expectedFedsInEvent_;
+
+  } catch (cms::Exception &e) {
+    err = true;
+    errmsg = e.what();
+    //std::cout << " DEBUG: " << errmsg << std::endl << std::flush;
+    //assert(0);
+  }
   return tstamp;
 }
 
@@ -425,6 +473,7 @@ edm::Timestamp DataModeFRDStriped::fillFRDCollection(FEDRawDataCollection& rawDa
   tcdsInRange = false;
   uint16_t selectedTCDSFed = 0;
   int selectedTCDSFileIndex = -1;
+  unsigned int fedsInEvent = 0;
   for (size_t index = 0; index < events_.size(); index++) {
     uint32_t eventSize = events_[index]->eventSize();
     unsigned char* event = (unsigned char*)events_[index]->payload();
@@ -449,15 +498,41 @@ edm::Timestamp DataModeFRDStriped::fillFRDCollection(FEDRawDataCollection& rawDa
           }
         } else if (!testing_)
           throw cms::Exception("DataModeFRDStriped:::fillFRDCollection")
-              << "Second TCDS FED ID " << fedId << " found in file " << selectedTCDSFileIndex
-              << ". First ID: " << selectedTCDSFed << " in file " << index;
+              << "Second TCDS FED ID " << fedId << " found in file at index" << selectedTCDSFileIndex
+              << ". First ID: " << selectedTCDSFed << " found in file at index " << (uint64_t)index;
       }
       FEDRawData& fedData = rawData.FEDData(fedId);
       fedData.resize(fedSize);
       memcpy(fedData.data(), event + eventSize, fedSize);
+
+      fedsInEvent++;
+      if (verifyFEDs_ || !expectedFedsInEvent_) {
+        if (fedIdSet_.find(fedId) == fedIdSet_.end()) {
+          if (expectedFedsInEvent_)
+            throw cms::Exception("DataModeFRDStriped:::fillFRDCollection")
+              << "FEDID " << fedId << " from the file at index " << (uint64_t)index << " was not found in previous events";
+          else
+            fedIdSet_.insert(fedId);
+        }
+      }
     }
     assert(eventSize == 0);
   }
+
+  if (!fedsInEvent)
+    throw cms::Exception("DataModeFRDStriped:::fillFRDCollection")
+        << "Event " << events_.at(0)->event() << " does not contain any FEDs";
+  else if (!expectedFedsInEvent_) {
+    expectedFedsInEvent_ = fedsInEvent;
+    if (fedIdSet_.size() != fedsInEvent) {
+      throw cms::Exception("DataModeFRDStriped:::fillFRDCollection")
+        << "First received event: " << events_.at(0)->event() << " contains duplicate FEDs";
+     }
+  }
+  else if (fedsInEvent != expectedFedsInEvent_)
+    throw cms::Exception("DataModeFRDStriped:::fillFRDCollection")
+        << "Event " << events_.at(0)->event() << " does not contain same number of FEDs as previous: "
+        << fedsInEvent << "/" << expectedFedsInEvent_;
 
   return tstamp;
 }
@@ -469,20 +544,6 @@ std::vector<std::shared_ptr<const edm::DaqProvenanceHelper>>& DataModeFRDStriped
       edm::TypeID(typeid(FEDRawDataCollection)), "FEDRawDataCollection", "FEDRawDataCollection", "DAQSource"));
   return daqProvenanceHelpers_;
 }
-
-/* TODO: adapt to multi-fils
-bool DataModeFRD::nextEventView() {
-  if (eventCached_) return true;
-  event_ = std::make_unique<FRDEventMsgView>(dataBlockAddr_);
-  if (event_->size() > dataBlockMax_) {
-    throw cms::Exception("DAQSource::getNextEvent")
-      << " event id:" << event_->event() << " lumi:" << event_->lumi() << " run:" << event_->run()
-      << " of size:" << event_->size() << " bytes does not fit into a chunk of size:" << dataBlockMax_
-      << " bytes";
-  }
-  return true;
-}
-*/
 
 bool DataModeFRDStriped::checksumValid() {
   bool status = true;
@@ -567,6 +628,7 @@ bool DataModeFRDStriped::makeEvents() {
   events_.clear();
   assert(!blockCompleted_);
   int completed = 0;
+  uint64_t testEvtId = 0;
 
   for (int i = 0; i < numFiles_; i++) {
     if (dataBlockAddrs_[i] >= dataBlockMaxAddrs_[i]) {
@@ -579,6 +641,13 @@ bool DataModeFRDStriped::makeEvents() {
     if (blockCompleted_)
       continue;
     events_.emplace_back(std::make_unique<FRDEventMsgView>(dataBlockAddrs_[i]));
+
+    if (testEvtId == 0)
+      testEvtId = events_[i]->event();
+    else if (testEvtId !=  events_[i]->event())
+      throw cms::Exception("DAQSource::getNextEvent")
+          << " event id mismatch:" << events_[i]->event() << " while in previously parsed RDEventMsgView (other file):" << testEvtId;
+
     if (dataBlockAddrs_[i] + events_[i]->size() > dataBlockMaxAddrs_[i])
       throw cms::Exception("DAQSource::getNextEvent")
           << " event id:" << events_[i]->event() << " lumi:" << events_[i]->lumi() << " run:" << events_[i]->run()

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -2033,11 +2033,8 @@ namespace evf {
           std::filesystem::create_directory(bu_run_dir_ + fileprefix);
         }
         std::filesystem::path p = name;
-        auto nextFileRawTmp = fmt::format("{}{}{}{}",
-                                          bu_run_dir_,
-                                          fileprefix,
-                                          p.stem().string(),
-                                          p.extension().string());
+        auto nextFileRawTmp =
+            fmt::format("{}{}{}{}", bu_run_dir_, fileprefix, p.stem().string(), p.extension().string());
         try {
           //grab file if possible
           std::filesystem::rename(rawpath, nextFileRawTmp);

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -2033,12 +2033,10 @@ namespace evf {
           std::filesystem::create_directory(bu_run_dir_ + fileprefix);
         }
         std::filesystem::path p = name;
-        auto nextFileRawTmp = fmt::format("{}{}{}_{}_pid{}{}",
+        auto nextFileRawTmp = fmt::format("{}{}{}{}",
                                           bu_run_dir_,
                                           fileprefix,
                                           p.stem().string(),
-                                          hostname_,
-                                          getpid(),
                                           p.extension().string());
         try {
           //grab file if possible

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -706,8 +706,8 @@ edm::Timestamp FedRawDataInputSource::fillFEDRawDataCollection(FEDRawDataCollect
 
   if (fedsInEvent != expectedFedsInEvent_ && expectedFedsInEvent_)
     edm::LogWarning("DataModeFRDStriped:::fillFRDCollection")
-        << "Event " << event_->event() << " does not contain same number of FEDs as previous: "
-        << fedsInEvent << "/" << expectedFedsInEvent_;
+        << "Event " << event_->event() << " does not contain same number of FEDs as previous: " << fedsInEvent << "/"
+        << expectedFedsInEvent_;
 
   return tstamp;
 }

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -658,7 +658,7 @@ edm::Timestamp FedRawDataInputSource::fillFEDRawDataCollection(FEDRawDataCollect
   tcds_pointer_ = nullptr;
   tcdsInRange = false;
   uint16_t selectedTCDSFed = 0;
-  fedsInEvent = 0;
+  unsigned int fedsInEvent = 0;
   while (eventSize > 0) {
     assert(eventSize >= FEDTrailer::length);
     eventSize -= FEDTrailer::length;
@@ -706,7 +706,7 @@ edm::Timestamp FedRawDataInputSource::fillFEDRawDataCollection(FEDRawDataCollect
 
   if (fedsInEvent != expectedFedsInEvent_ && expectedFedsInEvent_)
     edm::LogWarning("DataModeFRDStriped:::fillFRDCollection")
-        << "Event " << events_.at(0)->event() << " does not contain same number of FEDs as previous: "
+        << "Event " << event_->event() << " does not contain same number of FEDs as previous: "
         << fedsInEvent << "/" << expectedFedsInEvent_;
 
   return tstamp;

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -658,6 +658,7 @@ edm::Timestamp FedRawDataInputSource::fillFEDRawDataCollection(FEDRawDataCollect
   tcds_pointer_ = nullptr;
   tcdsInRange = false;
   uint16_t selectedTCDSFed = 0;
+  fedsInEvent = 0;
   while (eventSize > 0) {
     assert(eventSize >= FEDTrailer::length);
     eventSize -= FEDTrailer::length;
@@ -696,11 +697,17 @@ edm::Timestamp FedRawDataInputSource::fillFEDRawDataCollection(FEDRawDataCollect
         GTPEventID_ = evf::evtn::gtpe_get(event + eventSize);
       }
     }
+    fedsInEvent++;
     FEDRawData& fedData = rawData.FEDData(fedId);
     fedData.resize(fedSize);
     memcpy(fedData.data(), event + eventSize, fedSize);
   }
   assert(eventSize == 0);
+
+  if (fedsInEvent != expectedFedsInEvent_ && expectedFedsInEvent_)
+    edm::LogWarning("DataModeFRDStriped:::fillFRDCollection")
+        << "Event " << events_.at(0)->event() << " does not contain same number of FEDs as previous: "
+        << fedsInEvent << "/" << expectedFedsInEvent_;
 
   return tstamp;
 }

--- a/EventFilter/Utilities/test/RunBUFU.sh
+++ b/EventFilter/Utilities/test/RunBUFU.sh
@@ -161,24 +161,13 @@ ${CMDLINE_STARTFU}  > out_2_fu.log 2>&1 || diefu "${CMDLINE_STARTFU}" $? $OUTDIR
 #no failures, clean up everything including logs if there are no errors
 rm -rf $OUTDIR/{ramdisk,data,*.log}
 
-echo "running DAQSource test with full event FRD"
-CMDLINE_STARTBU="cmsRun startBU.py runNumber=${runnumber} fffBaseDir=${OUTDIR} maxLS=2 fedMeanSize=128 eventsPerFile=20 eventsPerLS=35 frdFileVersion=2"
-CMDLINE_STARTFU="cmsRun startFU_daqsource.py daqSourceMode=FRDStriped runNumber=${runnumber} fffBaseDir=${OUTDIR}"
+echo "running DAQSource test with striped event FRD"
+CMDLINE_STARTBU="cmsRun startBU.py runNumber=${runnumber} fffBaseDir=${OUTDIR} maxLS=2 fedMeanSize=128 eventsPerFile=20 eventsPerLS=35 frdFileVersion=2 buBaseDir=ramdisk1 subsystems=TCDS,SiPixel,ECAL,RPC"
+${CMDLINE_STARTBU}  > out_2_bu.log 2>&1 || diebu "${CMDLINE_STARTBU}" $? $OUTDIR
+CMDLINE_STARTBU="cmsRun startBU.py runNumber=${runnumber} fffBaseDir=${OUTDIR} maxLS=2 fedMeanSize=128 eventsPerFile=20 eventsPerLS=35 frdFileVersion=2 buBaseDir=ramdisk2 subsystems=SiStrip,HCAL,DT,CSC"
 ${CMDLINE_STARTBU}  > out_2_bu.log 2>&1 || diebu "${CMDLINE_STARTBU}" $? $OUTDIR
 #run reader
-${CMDLINE_STARTFU}  > out_2_fu.log 2>&1 || diefu "${CMDLINE_STARTFU}" $? $OUTDIR out_2_fu.log
-rm -rf $OUTDIR/{ramdisk,data,*.log}
-
-echo "running DAQSource test with striped FRD"
-CMDLINE_STARTBU="cmsRun startBU.py runNumber=${runnumber} fffBaseDir=${OUTDIR} maxLS=2 fedMeanSize=128 eventsPerFile=20 eventsPerLS=35 frdFileVersion=2"
-CMDLINE_STARTFU="cmsRun unittest_FU_daqsource.py daqSourceMode=FRDStriped runNumber=${runnumber} fffBaseDir=${OUTDIR}"
-${CMDLINE_STARTBU}  > out_2_bu.log 2>&1 || diebu "${CMDLINE_STARTBU}" $? $OUTDIR
-#duplicate files
-cp ramdisk/run${runnumber}/run${runnumber}_ls0001_index000000.raw ramdisk/run${runnumber}/run${runnumber}_ls0001_index000000.raw_1
-cp ramdisk/run${runnumber}/run${runnumber}_ls0001_index000001.raw ramdisk/run${runnumber}/run${runnumber}_ls0001_index000001.raw_1
-cp ramdisk/run${runnumber}/run${runnumber}_ls0002_index000000.raw ramdisk/run${runnumber}/run${runnumber}_ls0002_index000000.raw_1
-cp ramdisk/run${runnumber}/run${runnumber}_ls0002_index000001.raw ramdisk/run${runnumber}/run${runnumber}_ls0002_index000001.raw_1
-#run reader
+CMDLINE_STARTFU="cmsRun startFU_daqsource.py daqSourceMode=FRDStriped runNumber=${runnumber} fffBaseDir=${OUTDIR} numRamdisks=2"
 ${CMDLINE_STARTFU}  > out_2_fu.log 2>&1 || diefu "${CMDLINE_STARTFU}" $? $OUTDIR out_2_fu.log
 rm -rf $OUTDIR/{ramdisk,data,*.log}
 

--- a/EventFilter/Utilities/test/RunBUFU.sh
+++ b/EventFilter/Utilities/test/RunBUFU.sh
@@ -171,7 +171,7 @@ CMDLINE_STARTFU="cmsRun startFU_daqsource.py daqSourceMode=FRDStriped runNumber=
 ${CMDLINE_STARTFU}  > out_2_fu.log 2>&1 || diefu "${CMDLINE_STARTFU}" $? $OUTDIR out_2_fu.log
 rm -rf $OUTDIR/{ramdisk,data,*.log}
 
-echo "running DAQSource test with FRDPreUnpack"
+echo "running DAQSource test with unpacking in reader threads"
 CMDLINE_STARTBU="cmsRun startBU.py runNumber=${runnumber} fffBaseDir=${OUTDIR} maxLS=2 fedMeanSize=128 eventsPerFile=20 eventsPerLS=35 frdFileVersion=1"
 CMDLINE_STARTFU="cmsRun startFU_daqsource.py daqSourceMode=FRDPreUnpack runNumber=${runnumber} fffBaseDir=${OUTDIR}"
 ${CMDLINE_STARTBU}  > out_2_bu.log 2>&1 || diebu "${CMDLINE_STARTBU}" $? $OUTDIR

--- a/EventFilter/Utilities/test/RunBUFU.sh
+++ b/EventFilter/Utilities/test/RunBUFU.sh
@@ -161,7 +161,7 @@ ${CMDLINE_STARTFU}  > out_2_fu.log 2>&1 || diefu "${CMDLINE_STARTFU}" $? $OUTDIR
 #no failures, clean up everything including logs if there are no errors
 rm -rf $OUTDIR/{ramdisk,data,*.log}
 
-echo "running DAQSource test with striped event FRD"
+echo "running DAQSource test with striped event FRD (SFB)"
 CMDLINE_STARTBU="cmsRun startBU.py runNumber=${runnumber} fffBaseDir=${OUTDIR} maxLS=2 fedMeanSize=128 eventsPerFile=20 eventsPerLS=35 frdFileVersion=2 buBaseDir=ramdisk1 subsystems=TCDS,SiPixel,ECAL,RPC"
 ${CMDLINE_STARTBU}  > out_2_bu.log 2>&1 || diebu "${CMDLINE_STARTBU}" $? $OUTDIR
 CMDLINE_STARTBU="cmsRun startBU.py runNumber=${runnumber} fffBaseDir=${OUTDIR} maxLS=2 fedMeanSize=128 eventsPerFile=20 eventsPerLS=35 frdFileVersion=2 buBaseDir=ramdisk2 subsystems=SiStrip,HCAL,DT,CSC"
@@ -171,7 +171,7 @@ CMDLINE_STARTFU="cmsRun startFU_daqsource.py daqSourceMode=FRDStriped runNumber=
 ${CMDLINE_STARTFU}  > out_2_fu.log 2>&1 || diefu "${CMDLINE_STARTFU}" $? $OUTDIR out_2_fu.log
 rm -rf $OUTDIR/{ramdisk,data,*.log}
 
-echo "running DAQSource test with unpacking in reader threads"
+echo "running DAQSource test with unpacking in reader threads (FRDPreUnpack)"
 CMDLINE_STARTBU="cmsRun startBU.py runNumber=${runnumber} fffBaseDir=${OUTDIR} maxLS=2 fedMeanSize=128 eventsPerFile=20 eventsPerLS=35 frdFileVersion=1"
 CMDLINE_STARTFU="cmsRun startFU_daqsource.py daqSourceMode=FRDPreUnpack runNumber=${runnumber} fffBaseDir=${OUTDIR}"
 ${CMDLINE_STARTBU}  > out_2_bu.log 2>&1 || diebu "${CMDLINE_STARTBU}" $? $OUTDIR

--- a/EventFilter/Utilities/test/hlt_dir_example.py
+++ b/EventFilter/Utilities/test/hlt_dir_example.py
@@ -1,0 +1,132 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+import os
+
+options = VarParsing.VarParsing ('analysis')
+
+#cmsRun runNumber=X ...
+options.register ('runNumber',
+                  18, # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.int,
+                  "Run Number")
+
+options.register ('daqSourceMode',
+                  'DTH', # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,
+                  "DAQ source data mode")
+
+options.register ('buBaseDir',
+                  'ramdisk', # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,
+                  "BU base directory")
+
+options.register ('fuBaseDir',
+                  'data', # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,
+                  "BU base directory")
+
+options.register ('fffBaseDir',
+                  '.', # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,
+                  "FFF base directory")
+
+options.register ('numThreads',
+                  3,
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.int,
+                  "Number of CMSSW threads")
+
+options.register ('numFwkStreams',
+                  2,
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.int,
+                  "Number of CMSSW streams")
+
+options.parseArguments()
+
+process = cms.Process("DTHDEMO")
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+process.options = cms.untracked.PSet(
+    numberOfThreads = cms.untracked.uint32(options.numThreads),
+    numberOfStreams = cms.untracked.uint32(options.numFwkStreams),
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(1)
+)
+process.MessageLogger = cms.Service("MessageLogger",
+    cout = cms.untracked.PSet(threshold = cms.untracked.string( "INFO" )),
+    destinations = cms.untracked.vstring( 'cout' )
+)
+
+process.EvFDaqDirector = cms.Service("EvFDaqDirector",
+    useFileBroker = cms.untracked.bool(True),
+    fileBrokerHostFromCfg = cms.untracked.bool(False),
+    fileBrokerHost = cms.untracked.string("htcp40.cern.ch"),
+    runNumber = cms.untracked.uint32(options.runNumber),
+    baseDir = cms.untracked.string(options.fffBaseDir+"/"+options.fuBaseDir),
+    buBaseDir = cms.untracked.string(options.fffBaseDir+"/"+options.buBaseDir),
+    directorIsBU = cms.untracked.bool(False),
+
+    #read data from single or multiple directories
+    buBaseDirsAll = cms.untracked.vstring(options.fffBaseDir+"/"+options.buBaseDir),
+
+    #number of sources read per each directory e.g. (2,4,1)
+    buBaseDirsNumStreams = cms.untracked.vint32(1),
+
+    #list of sources for each directory above in the same order (e.g. 1230,1231, 1255,1256,1257,1258, 1350)
+    buBaseDirsStreamIDs = cms.untracked.vint32(1230),
+
+    #naming convetion of the file (source, sourceid, fb, fbid, etc. or <empty> for non-DTH mode)
+    sourceIdentifier = cms.untracked.string("source")
+
+    #example for multiple sources in single directory:
+    #buBaseDirsNumStreams = cms.untracked.vint32(3),
+    #buBaseDirsStreamIDs = cms.untracked.vint32(1230),
+    #buBaseDirsStreamIDs = cms.untracked.vint32(1232),
+    #buBaseDirsStreamIDs = cms.untracked.vint32(1233),
+
+)
+
+process.FastMonitoringService = cms.Service("FastMonitoringService",
+    sleepTime = cms.untracked.int32(1)
+)
+
+try:
+  os.makedirs(options.fffBaseDir+"/"+options.fuBaseDir+"/run"+str(options.runNumber).zfill(6))
+except Exception as ex:
+  print(str(ex))
+  pass
+
+process.source = cms.Source("DAQSource",
+    fileDiscoveryMode = cms.untracked.bool(True),
+    fileListMode = cms.untracked.bool(False),
+    fileNames = cms.untracked.vstring(),
+    #testing = cms.untracked.bool(True),
+    dataMode = cms.untracked.string(options.daqSourceMode),
+    verifyChecksum = cms.untracked.bool(True if options.daqSourceMode != "DTH" else False),
+    useL1EventID = cms.untracked.bool(False),
+    eventChunkBlock = cms.untracked.uint32(2),
+    eventChunkSize = cms.untracked.uint32(3),
+    maxChunkSize = cms.untracked.uint32(10),
+    numBuffers = cms.untracked.uint32(3),
+    maxBufferedFiles = cms.untracked.uint32(2),
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string(f'file:DTH_dump{options.runNumber}.root'),
+    outputCommands = cms.untracked.vstring(
+        "keep *",
+    ),
+    compressionAlgorithm = cms.untracked.string("ZSTD"),
+    compressionLevel = cms.untracked.int32(4),
+)
+
+process.ep = cms.EndPath(
+  process.out
+)

--- a/EventFilter/Utilities/test/startBU.py
+++ b/EventFilter/Utilities/test/startBU.py
@@ -64,6 +64,12 @@ options.register ('dataType',
                   VarParsing.VarParsing.varType.string,          # string, int, or float
                   "Choice between FRD or raw DTH data generation")
 
+options.register ('subsystems',
+                  "",
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,          # string, int, or float
+                  "List of generated subsystem FEDs. Empty means all.")
+
 
 
 
@@ -135,6 +141,9 @@ if  options.dataType == "FRD":
                                tcdsFEDID = cms.untracked.uint32(1024),
                                injectErrPpm = cms.untracked.uint32(0)
                                )
+    if options.subsystems:
+        #set FED filering
+        process.s.subsystems = cms.untracked.vstring(tuple(options.subsystems.split(',')))
 
     process.out = cms.OutputModule("RawStreamFileWriterForBU",
         source = cms.InputTag("s"),

--- a/EventFilter/Utilities/test/startFU_daqsource.py
+++ b/EventFilter/Utilities/test/startFU_daqsource.py
@@ -22,6 +22,12 @@ options.register ('buBaseDir',
                   VarParsing.VarParsing.varType.string,          # string, int, or float
                   "BU base directory")
 
+options.register ('numRamdisks',
+                  0, # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.int,            # string, int, or float
+                  "Is data split into subdirectories")
+
 options.register ('fuBaseDir',
                   'data', # default value
                   VarParsing.VarParsing.multiplicity.singleton,
@@ -76,9 +82,10 @@ process.EvFDaqDirector = cms.Service("EvFDaqDirector",
     fileBrokerHost = cms.untracked.string("htcp40.cern.ch"),
     runNumber = cms.untracked.uint32(options.runNumber),
     baseDir = cms.untracked.string(options.fffBaseDir+"/"+options.fuBaseDir),
-    buBaseDir = cms.untracked.string(options.fffBaseDir+"/"+options.buBaseDir),
+    #buBaseDir = cms.untracked.string(options.fffBaseDir+"/"+options.buBaseDir),
+    buBaseDir = cms.untracked.string(options.fffBaseDir+"/"+options.buBaseDir + ("1" if options.numRamdisks > 0 else "")),
+    buBaseDirsAll = cms.untracked.vstring(tuple([(options.fffBaseDir+"/"+options.buBaseDir + str(i)) for i in range(1, options.numRamdisks + 1)])),
     directorIsBU = cms.untracked.bool(False),
-    #buBaseDirsAll = cms.untracked.vstring(options.fffBaseDir+"/"+options.buBaseDir),
     #buBaseDirsNumStreams = cms.untracked.vint32(1),
     #buBaseDirsStreamIDs = cms.untracked.vint32(1),
     #sourceIdentifier = cms.untracked.string("source")

--- a/EventFilter/Utilities/test/startFU_daqsource.py
+++ b/EventFilter/Utilities/test/startFU_daqsource.py
@@ -165,8 +165,12 @@ process.streamC = cms.OutputModule("GlobalEvFOutputModule",
     SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring( 'p2' ))
 )
 
-process.streamD = cms.OutputModule("GlobalEvFOutputModule",
-    SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring( 'p2' ))
+process.outRootFile = cms.OutputModule("PoolOutputModule",
+    SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring( 'p1', 'p2' )),
+    fileName = cms.untracked.string('file:dth_output.root'),
+    outputCommands = cms.untracked.vstring(
+        'keep *'
+    )
 )
 
 process.hltJson = cms.EDAnalyzer("HLTriggerJSONMonitoring")
@@ -189,7 +193,7 @@ process.ep = cms.EndPath(
   process.streamA
   + process.streamB
   + process.streamC
-# + process.streamD
+  + process.outRootFile
   + process.hltJson
   + process.daqHistoTest
   + process.hltDQMFileSaver

--- a/EventFilter/Utilities/test/unittest_FU_daqsource.py
+++ b/EventFilter/Utilities/test/unittest_FU_daqsource.py
@@ -161,8 +161,12 @@ process.streamC = cms.OutputModule("GlobalEvFOutputModule",
     SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring( 'p2' ))
 )
 
-process.streamD = cms.OutputModule("GlobalEvFOutputModule",
-    SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring( 'p2' ))
+process.outRootFile = cms.OutputModule("PoolOutputModule",
+    SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring( 'p1', 'p2' )),
+    fileName = cms.untracked.string('file:dth_output.root'),
+    outputCommands = cms.untracked.vstring(
+        'keep *'
+    )
 )
 
 process.hltJson = cms.EDAnalyzer("HLTriggerJSONMonitoring")
@@ -185,7 +189,7 @@ process.ep = cms.EndPath(
   process.streamA
   + process.streamB
   + process.streamC
-# + process.streamD
+  + process.outRootFile
   + process.hltJson
   + process.daqHistoTest
   + process.hltDQMFileSaver


### PR DESCRIPTION
#### PR description:

- consistency checks for FED fragments, requirement to have same number of fragments in all events (warning).
- DASource implements stricter checks for striped mode, used for SFB
- improved unit test for multi-file source case
- fix to fileDiscoverymode

#### PR validation:

Tested in emulator runs in CDAQ and daq3val