### PR TITLE
Phase2-hgx363N Remove the issue of cassette shift for HGCal scintillators in V19

### DIFF
--- a/Geometry/HGCalCommonData/interface/HGCalParameters.h
+++ b/Geometry/HGCalCommonData/interface/HGCalParameters.h
@@ -78,6 +78,7 @@ public:
   int scintCells(const int layer) const { return nPhiBinBH_[scintType(layer)]; }
   double scintCellSize(const int layer) const { return cellSize_[scintType(layer)]; }
   bool scintFine(int indx) const { return ((!tileRingFineR_.empty()) && (nPhiLayer_[indx] > 288)); }
+  double scintRing(int indx, int irad) const;
   int scintType(const int layer) const { return ((layer < layerFrontBH_[1]) ? 1 : 0); }
   bool scintValidRing(int indx, int irad) const {
     return (scintFine(indx) ? ((irad >= iradMinBHFine_[indx]) && (irad <= (iradMaxBHFine_[indx] + 1)))

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -1072,7 +1072,9 @@ std::pair<float, float> HGCalDDDConstants::locateCellTrap(
       auto cshift = hgcassette_.getShift(lay, -1, cassette, true);
       std::ostringstream st1;
       if (debug)
-        st1 << "Cassette " << cassette << ":" << nphi << ":" << hgpar_->nphiFineCassette_ << ":" << hgpar_->nphiCassette_ << " Layer " << lay << " Shift " << cshift.first << ":" << cshift.second << " Original " << x << ":"<< y;
+        st1 << "Cassette " << cassette << ":" << nphi << ":" << hgpar_->nphiFineCassette_ << ":"
+            << hgpar_->nphiCassette_ << " Layer " << lay << " Shift " << cshift.first << ":" << cshift.second
+            << " Original " << x << ":" << y;
       x -= cshift.first;
       y += cshift.second;
       if (debug) {

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -222,8 +222,9 @@ std::array<int, 3> HGCalDDDConstants::assignCellTrap(float x, float y, float z, 
   if (iphi == 0)
     iphi = hgpar_->scintCells(layer);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HGCalGeom") << "Layer " << layer << " iPhi " << iphi << ":" << hgpar_->scintCells(layer) << " Cassette Mode " << cassetteMode();
-#endif 
+  edm::LogVerbatim("HGCalGeom") << "Layer " << layer << " iPhi " << iphi << ":" << hgpar_->scintCells(layer)
+                                << " Cassette Mode " << cassetteMode();
+#endif
   if (cassetteMode()) {
     int nphi = (hgpar_->scintFine(indx.first)) ? hgpar_->nphiFineCassette_ : hgpar_->nphiCassette_;
     int cassette = HGCalTileIndex::tileCassette(iphi, hgpar_->phiOffset_, nphi, hgpar_->cassettes_);
@@ -1072,7 +1073,8 @@ std::pair<float, float> HGCalDDDConstants::locateCellTrap(
       auto cshift = hgcassette_.getShift(lay, -1, cassette, true);
       std::ostringstream st1;
       if (debug)
-        st1 << "Cassette " << cassette << ":" << nphi << ":" << hgpar_->nphiFineCassette_ << ":" << hgpar_->nphiCassette_ << " Shift " << cshift.first << ":" << cshift.second << " Original " << x << ":"
+        st1 << "Cassette " << cassette << ":" << nphi << ":" << hgpar_->nphiFineCassette_ << ":"
+            << hgpar_->nphiCassette_ << " Shift " << cshift.first << ":" << cshift.second << " Original " << x << ":"
             << y;
       x -= cshift.first;
       y += cshift.second;

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -222,7 +222,7 @@ std::array<int, 3> HGCalDDDConstants::assignCellTrap(float x, float y, float z, 
     iphi = hgpar_->scintCells(layer);
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HGCalGeom") << "Layer " << layer << " iPhi " << iphi << ":" << hgpar_->scintCells(layer)
-                                << " Cassette Mode " << cassetteMode();
+				<< " Cassette Mode " << cassetteMode() << " index " << indx.first;
 #endif
   if (cassetteMode()) {
     int nphi = (hgpar_->scintFine(indx.first)) ? hgpar_->nphiFineCassette_ : hgpar_->nphiCassette_;
@@ -787,6 +787,9 @@ bool HGCalDDDConstants::isValidHex8(int layer, int modU, int modV, int cellU, in
 bool HGCalDDDConstants::isValidTrap(int zside, int layer, int irad, int iphi) const {
   // Check validity for a layer|eta|phi of scintillator
   const auto& indx = getIndex(layer, true);
+#ifdef EDM_ML_DEBUG
+  edm::LogWarning("HGCalGeomT") << "isValidTrap: Layer " << layer << " indx " << indx.first << ":" << hgpar_->firstLayer_ << ":" << hgpar_->firstMixedLayer_;
+#endif
   if (indx.first < 0)
     return false;
   bool ok = ((hgpar_->scintValidRing(indx.first, irad)) && (iphi > 0) && (iphi <= hgpar_->scintCells(layer)));
@@ -1028,8 +1031,9 @@ std::pair<float, float> HGCalDDDConstants::locateCellTrap(
   const auto& indx = getIndex(lay, reco);
 #ifdef EDM_ML_DEBUG
   debug = true;
-  edm::LogVerbatim("HGCalGeom") << "locateCellTrap:: Input " << lay << ":" << irad << ":" << iphi << ":" << zside << ":"
-                                << reco << ":" << indx.first;
+  if (debug)
+    edm::LogVerbatim("HGCalGeom") << "locateCellTrap:: Input " << lay << ":" << irad << ":" << iphi << ":" << zside << ":"
+				  << reco << ":" << indx.first;
 #endif
   if (indx.first >= 0) {
     int ir = std::abs(irad);
@@ -1038,6 +1042,7 @@ std::pair<float, float> HGCalDDDConstants::locateCellTrap(
     double z = hgpar_->zLayerHex_[indx.first];
     double r = 0.5 * (hgpar_->radiusLayer_[type][ir - 1] + hgpar_->radiusLayer_[type][ir]);
     std::pair<double, double> range = rangeR(z, true);
+#ifdef EDM_ML_DEBUG
     if (debug) {
       std::ostringstream st1;
       st1 << "locateCellTrap:: Input " << lay << ":" << irad << ":" << iphi << ":" << reco << " indx " << indx.first
@@ -1051,6 +1056,7 @@ std::pair<float, float> HGCalDDDConstants::locateCellTrap(
                                     << range.second << " file " << (!trapezoidFile()) << " CassetteMode "
                                     << cassetteMode();
     }
+#endif
     if (!trapezoidFile())
       r = std::max(range.first, std::min(r, range.second));
     if (hgpar_->scintFine(indx.first)) {
@@ -1070,17 +1076,21 @@ std::pair<float, float> HGCalDDDConstants::locateCellTrap(
       int nphi = (hgpar_->scintFine(indx.first)) ? hgpar_->nphiFineCassette_ : hgpar_->nphiCassette_;
       int cassette = HGCalTileIndex::tileCassette(iphi, hgpar_->phiOffset_, nphi, hgpar_->cassettes_);
       auto cshift = hgcassette_.getShift(lay, -1, cassette, true);
+#ifdef EDM_ML_DEBUG
       std::ostringstream st1;
       if (debug)
         st1 << "Cassette " << cassette << ":" << nphi << ":" << hgpar_->nphiFineCassette_ << ":"
             << hgpar_->nphiCassette_ << " Layer " << lay << " Shift " << cshift.first << ":" << cshift.second
             << " Original " << x << ":" << y;
+#endif
       x -= cshift.first;
       y += cshift.second;
+#ifdef EDM_ML_DEBUG
       if (debug) {
         st1 << " Final " << x << ":" << y;
         edm::LogVerbatim("HGCalGeom") << st1.str();
       }
+#endif
     }
   }
   if (!reco) {

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -1,4 +1,3 @@
-
 #include "Geometry/HGCalCommonData/interface/HGCalDDDConstants.h"
 
 #include "DataFormats/Math/interface/GeantUnits.h"
@@ -1026,9 +1025,9 @@ std::pair<float, float> HGCalDDDConstants::locateCellHex(int cell, int wafer, bo
 std::pair<float, float> HGCalDDDConstants::locateCellTrap(
     int zside, int lay, int irad, int iphi, bool reco, bool debug) const {
   float x(0), y(0);
-  debug = true;
   const auto& indx = getIndex(lay, reco);
 #ifdef EDM_ML_DEBUG
+  debug = true;
   edm::LogVerbatim("HGCalGeom") << "locateCellTrap:: Input " << lay << ":" << irad << ":" << iphi << ":" << zside << ":"
                                 << reco << ":" << indx.first;
 #endif
@@ -1073,9 +1072,7 @@ std::pair<float, float> HGCalDDDConstants::locateCellTrap(
       auto cshift = hgcassette_.getShift(lay, -1, cassette, true);
       std::ostringstream st1;
       if (debug)
-        st1 << "Cassette " << cassette << ":" << nphi << ":" << hgpar_->nphiFineCassette_ << ":"
-            << hgpar_->nphiCassette_ << " Shift " << cshift.first << ":" << cshift.second << " Original " << x << ":"
-            << y;
+        st1 << "Cassette " << cassette << ":" << nphi << ":" << hgpar_->nphiFineCassette_ << ":" << hgpar_->nphiCassette_ << " Layer " << lay << " Shift " << cshift.first << ":" << cshift.second << " Original " << x << ":"<< y;
       x -= cshift.first;
       y += cshift.second;
       if (debug) {

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -222,7 +222,7 @@ std::array<int, 3> HGCalDDDConstants::assignCellTrap(float x, float y, float z, 
     iphi = hgpar_->scintCells(layer);
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HGCalGeom") << "Layer " << layer << " iPhi " << iphi << ":" << hgpar_->scintCells(layer)
-				<< " Cassette Mode " << cassetteMode() << " index " << indx.first;
+                                << " Cassette Mode " << cassetteMode() << " index " << indx.first;
 #endif
   if (cassetteMode()) {
     int nphi = (hgpar_->scintFine(indx.first)) ? hgpar_->nphiFineCassette_ : hgpar_->nphiCassette_;
@@ -788,7 +788,8 @@ bool HGCalDDDConstants::isValidTrap(int zside, int layer, int irad, int iphi) co
   // Check validity for a layer|eta|phi of scintillator
   const auto& indx = getIndex(layer, true);
 #ifdef EDM_ML_DEBUG
-  edm::LogWarning("HGCalGeomT") << "isValidTrap: Layer " << layer << " indx " << indx.first << ":" << hgpar_->firstLayer_ << ":" << hgpar_->firstMixedLayer_;
+  edm::LogWarning("HGCalGeomT") << "isValidTrap: Layer " << layer << " indx " << indx.first << ":"
+                                << hgpar_->firstLayer_ << ":" << hgpar_->firstMixedLayer_;
 #endif
   if (indx.first < 0)
     return false;
@@ -1032,8 +1033,8 @@ std::pair<float, float> HGCalDDDConstants::locateCellTrap(
 #ifdef EDM_ML_DEBUG
   debug = true;
   if (debug)
-    edm::LogVerbatim("HGCalGeom") << "locateCellTrap:: Input " << lay << ":" << irad << ":" << iphi << ":" << zside << ":"
-				  << reco << ":" << indx.first;
+    edm::LogVerbatim("HGCalGeom") << "locateCellTrap:: Input " << lay << ":" << irad << ":" << iphi << ":" << zside
+                                  << ":" << reco << ":" << indx.first;
 #endif
   if (indx.first >= 0) {
     int ir = std::abs(irad);

--- a/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
@@ -1619,8 +1619,8 @@ void HGCalGeomParameters::loadSpecParsTrapezoid(const DDFilteredView& fv, HGCalP
   php.rMinLayerBH_ = getDDDArray("RMinLayerBH", sv, 0);
   rescale(php.rMinLayerBH_, HGCalParameters::k_ScaleFromDDD);
   assert(php.nPhiBinBH_.size() > 1);
-  php.nCellsFine_ = php.nPhiBinBH_[0];
-  php.nCellsCoarse_ = php.nPhiBinBH_[1];
+  php.nCellsFine_ = php.nPhiBinBH_[1];
+  php.nCellsCoarse_ = php.nPhiBinBH_[0];
   assert(0 != php.nCellsFine_);
   assert(0 != php.nCellsCoarse_);
   php.cellSize_.emplace_back(2.0 * M_PI / php.nCellsFine_);
@@ -1686,10 +1686,12 @@ void HGCalGeomParameters::loadSpecParsTrapezoid(const DDFilteredView& fv, HGCalP
       std::vector<double> rectract = fv.vector("ScintRetract");
       rescale(rectract, HGCalParameters::k_ScaleFromDDD);
       double dphi = M_PI / php.cassettes_;
-      for (int k = 0; k < php.cassettes_; ++k) {
-        double phi = (2 * k + 1) * dphi;
-        cassetteShift.emplace_back(rectract[k] * cos(phi));
-        cassetteShift.emplace_back(rectract[k] * sin(phi));
+      for (unsigned int k1 = 0; k1 < rectract.size(); ++k1) {
+	for (int k2 = 0; k2 < php.cassettes_; ++k2) {
+	  double phi = (2 * k2 + 1) * dphi;
+	  cassetteShift.emplace_back(rectract[k1] * cos(phi));
+	  cassetteShift.emplace_back(rectract[k1] * sin(phi));
+	}
       }
     } else if (php.waferMaskMode_ == scintillatorCassette) {
       if (php.cassettes_ > 0)
@@ -1744,8 +1746,8 @@ void HGCalGeomParameters::loadSpecParsTrapezoid(const cms::DDFilteredView& fv,
   php.rMinLayerBH_ = fv.get<std::vector<double> >(sdTag1, "RMinLayerBH");
   rescale(php.rMinLayerBH_, HGCalParameters::k_ScaleFromDD4hep);
   assert(php.nPhiBinBH_.size() > 1);
-  php.nCellsFine_ = php.nPhiBinBH_[0];
-  php.nCellsCoarse_ = php.nPhiBinBH_[1];
+  php.nCellsFine_ = php.nPhiBinBH_[1];
+  php.nCellsCoarse_ = php.nPhiBinBH_[0];
   assert(0 != php.nCellsFine_);
   assert(0 != php.nCellsCoarse_);
   php.cellSize_.emplace_back(2.0 * M_PI / php.nCellsFine_);
@@ -1844,10 +1846,12 @@ void HGCalGeomParameters::loadSpecParsTrapezoid(const cms::DDFilteredView& fv,
           for (const auto& i : it.second)
             rectract.emplace_back(i);
           double dphi = M_PI / php.cassettes_;
-          for (int k = 0; k < php.cassettes_; ++k) {
-            double phi = (2 * k + 1) * dphi;
-            cassetteShift.emplace_back(rectract[k] * cos(phi));
-            cassetteShift.emplace_back(rectract[k] * sin(phi));
+	  for (unsigned int k1 = 0; k1 < rectract.size(); ++k1) {
+	    for (int k2 = 0; k2 < php.cassettes_; ++k2) {
+	      double phi = (2 * k2 + 1) * dphi;
+	      cassetteShift.emplace_back(rectract[k1] * cos(phi));
+	      cassetteShift.emplace_back(rectract[k1] * sin(phi));
+	    }
           }
         }
       }
@@ -2365,7 +2369,7 @@ void HGCalGeomParameters::loadCellTrapezoid(HGCalParameters& php) {
                                   << ":" << php.tileRingR_.size();
 #endif
     for (unsigned int k = 0; k < 2; ++k) {
-      bool fine = ((k == 0) && (php.mode_ == HGCalGeometryMode::TrapezoidFineCell));
+      bool fine = ((k == 1) && (php.mode_ == HGCalGeometryMode::TrapezoidFineCell));
       unsigned int sizeR = (fine) ? php.tileRingFineR_.size() : php.tileRingR_.size();
       for (unsigned int kk = 0; kk < sizeR; ++kk) {
         if (fine)

--- a/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
@@ -2525,7 +2525,7 @@ void HGCalGeomParameters::loadCellTrapezoid(HGCalParameters& php) {
   for (unsigned int k = 0; k < 2; ++k) {
     edm::LogVerbatim("HGCalGeom") << "Type " << k << " with " << php.radiusLayer_[k].size() << " radii";
     for (unsigned int kk = 0; kk < php.radiusLayer_[k].size(); ++kk)
-      edm::LogVerbatim("HGCalGeom") << "Ring[" << k << "]["<< kk << "] " << php.radiusLayer_[k][kk];
+      edm::LogVerbatim("HGCalGeom") << "Ring[" << k << "][" << kk << "] " << php.radiusLayer_[k][kk];
   }
 #endif
 
@@ -2557,7 +2557,8 @@ void HGCalGeomParameters::loadCellTrapezoid(HGCalParameters& php) {
       double rmin = php.radiusLayer_[kk][std::max((irad - 1), 0)];
       double rmax = php.radiusLayer_[kk][std::min(irad, irm)];
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "irad " << irad << ":" << php.radiusLayer_[kk].size() << " R " << rmin << ":" << rmax;
+      edm::LogVerbatim("HGCalGeom") << "irad " << irad << ":" << php.radiusLayer_[kk].size() << " R " << rmin << ":"
+                                    << rmax;
 #endif
       mytr.bl = 0.5 * rmin * php.scintCellSize(mytr.lay);
       mytr.tl = 0.5 * rmax * php.scintCellSize(mytr.lay);

--- a/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
@@ -1685,6 +1685,12 @@ void HGCalGeomParameters::loadSpecParsTrapezoid(const DDFilteredView& fv, HGCalP
       php.nphiFineCassette_ = php.nCellsFine_ / php.cassettes_;
       std::vector<double> rectract = fv.vector("ScintRetract");
       rescale(rectract, HGCalParameters::k_ScaleFromDDD);
+      int n = 2 * php.cassettes_ * (php.firstLayer_ - 1);
+      for (int k1 = 0; k1 < n; ++ k1)
+	cassetteShift.emplace_back(0.);
+#ifdef EDM_ML_DEBUG      
+      edm::LogVerbatim("HGCalGeom") << "First Layer " << php.firstLayer_ << " Rett size " << rectract.size() << " N " << n;
+#endif
       double dphi = M_PI / php.cassettes_;
       for (unsigned int k1 = 0; k1 < rectract.size(); ++k1) {
         for (int k2 = 0; k2 < php.cassettes_; ++k2) {
@@ -1845,6 +1851,12 @@ void HGCalGeomParameters::loadSpecParsTrapezoid(const cms::DDFilteredView& fv,
         } else if (dd4hep::dd::compareEqual(dd4hep::dd::noNamespace(it.first), "ScintRetract")) {
           for (const auto& i : it.second)
             rectract.emplace_back(i);
+	  int n = 2 * php.cassettes_ * (php.firstLayer_ - 1);
+	  for (int k1 = 0; k1 < n; ++ k1)
+	    cassetteShift.emplace_back(0.);
+#ifdef EDM_ML_DEBUG      
+	  edm::LogVerbatim("HGCalGeom") << "First Layer " << php.firstLayer_ << " Rett size " << rectract.size() << " N " << n;
+#endif
           double dphi = M_PI / php.cassettes_;
           for (unsigned int k1 = 0; k1 < rectract.size(); ++k1) {
             for (int k2 = 0; k2 < php.cassettes_; ++k2) {
@@ -2398,12 +2410,20 @@ void HGCalGeomParameters::loadCellTrapezoid(HGCalParameters& php) {
     unsigned int k1(0), k2(0);
     for (unsigned int k = 0; k < php.zLayerHex_.size(); ++k) {
       if (!php.tileRingFineRange_.empty()) {
-        php.iradMinBHFine_.emplace_back(1 + php.tileRingFineRange_[k1].first);
-        php.iradMaxBHFine_.emplace_back(1 + php.tileRingFineRange_[k1].second);
+	unsigned int k0 = (k1 < (php.tileRingFineRange_.size() - 1)) ? k1 : (php.tileRingFineRange_.size() - 1);
+#ifdef EDM_ML_DEBUG
+	edm::LogVerbatim("HGCalGeom") << "Layer " << k << " Fine " << k1 << ":" << k0 << ":" << php.tileRingFineRange_.size();
+#endif
+        php.iradMinBHFine_.emplace_back(1 + php.tileRingFineRange_[k0].first);
+        php.iradMaxBHFine_.emplace_back(1 + php.tileRingFineRange_[k0].second);
       }
       if (!php.tileRingRange_.empty()) {
-        php.iradMinBH_.emplace_back(1 + php.tileRingRange_[k2].first);
-        php.iradMaxBH_.emplace_back(1 + php.tileRingRange_[k2].second);
+	unsigned int k0 = (k2 < (php.tileRingRange_.size() - 1)) ? k2 : (php.tileRingRange_.size() - 1);
+#ifdef EDM_ML_DEBUG
+	edm::LogVerbatim("HGCalGeom") << "Layer " << k << " Coarse " << k2 << ":" << k0 << ":" << php.tileRingRange_.size();
+#endif
+        php.iradMinBH_.emplace_back(1 + php.tileRingRange_[k0].first);
+        php.iradMaxBH_.emplace_back(1 + php.tileRingRange_[k0].second);
       }
       if (php.nPhiLayer_[k] > 288) {
         ++k1;

--- a/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
@@ -1687,11 +1687,11 @@ void HGCalGeomParameters::loadSpecParsTrapezoid(const DDFilteredView& fv, HGCalP
       rescale(rectract, HGCalParameters::k_ScaleFromDDD);
       double dphi = M_PI / php.cassettes_;
       for (unsigned int k1 = 0; k1 < rectract.size(); ++k1) {
-	for (int k2 = 0; k2 < php.cassettes_; ++k2) {
-	  double phi = (2 * k2 + 1) * dphi;
-	  cassetteShift.emplace_back(rectract[k1] * cos(phi));
-	  cassetteShift.emplace_back(rectract[k1] * sin(phi));
-	}
+        for (int k2 = 0; k2 < php.cassettes_; ++k2) {
+          double phi = (2 * k2 + 1) * dphi;
+          cassetteShift.emplace_back(rectract[k1] * cos(phi));
+          cassetteShift.emplace_back(rectract[k1] * sin(phi));
+        }
       }
     } else if (php.waferMaskMode_ == scintillatorCassette) {
       if (php.cassettes_ > 0)
@@ -1846,12 +1846,12 @@ void HGCalGeomParameters::loadSpecParsTrapezoid(const cms::DDFilteredView& fv,
           for (const auto& i : it.second)
             rectract.emplace_back(i);
           double dphi = M_PI / php.cassettes_;
-	  for (unsigned int k1 = 0; k1 < rectract.size(); ++k1) {
-	    for (int k2 = 0; k2 < php.cassettes_; ++k2) {
-	      double phi = (2 * k2 + 1) * dphi;
-	      cassetteShift.emplace_back(rectract[k1] * cos(phi));
-	      cassetteShift.emplace_back(rectract[k1] * sin(phi));
-	    }
+          for (unsigned int k1 = 0; k1 < rectract.size(); ++k1) {
+            for (int k2 = 0; k2 < php.cassettes_; ++k2) {
+              double phi = (2 * k2 + 1) * dphi;
+              cassetteShift.emplace_back(rectract[k1] * cos(phi));
+              cassetteShift.emplace_back(rectract[k1] * sin(phi));
+            }
           }
         }
       }

--- a/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
@@ -2405,7 +2405,7 @@ void HGCalGeomParameters::loadCellTrapezoid(HGCalParameters& php) {
     }
     // Minimum and maximum radius index for each layer
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HGCalGeom") << "Till Ring Range size " << php.tileRingFineRange_.size() << ":"
+    edm::LogVerbatim("HGCalGeom") << "Tile Ring Range size " << php.tileRingFineRange_.size() << ":"
                                   << php.tileRingRange_.size() << ":" << php.nPhiBinBH_.size() << ":"
                                   << php.zLayerHex_.size() << ":" << php.nPhiLayer_.size();
 #endif
@@ -2525,7 +2525,7 @@ void HGCalGeomParameters::loadCellTrapezoid(HGCalParameters& php) {
   for (unsigned int k = 0; k < 2; ++k) {
     edm::LogVerbatim("HGCalGeom") << "Type " << k << " with " << php.radiusLayer_[k].size() << " radii";
     for (unsigned int kk = 0; kk < php.radiusLayer_[k].size(); ++kk)
-      edm::LogVerbatim("HGCalGeom") << "Ring[" << kk << "] " << php.radiusLayer_[k][kk];
+      edm::LogVerbatim("HGCalGeom") << "Ring[" << k << "]["<< kk << "] " << php.radiusLayer_[k][kk];
   }
 #endif
 
@@ -2542,7 +2542,7 @@ void HGCalGeomParameters::loadCellTrapezoid(HGCalParameters& php) {
       if (php.iradMaxBH_[k] > php.tileUVMax_)
         php.tileUVMax_ = php.iradMaxBH_[k];
     }
-    int kk = (php.nPhiLayer_[k] > 288) ? 0 : 1;
+    int kk = (php.nPhiLayer_[k] > 288) ? 1 : 0;
     int irm = php.radiusLayer_[kk].size() - 1;
     int irmin = (php.nPhiLayer_[k] > 288) ? php.iradMinBHFine_[k] : php.iradMinBH_[k];
     int irmax = (php.nPhiLayer_[k] > 288) ? php.iradMaxBHFine_[k] : php.iradMaxBH_[k];
@@ -2550,12 +2550,15 @@ void HGCalGeomParameters::loadCellTrapezoid(HGCalParameters& php) {
     double rmin = php.radiusLayer_[kk][std::max((irmin - 1), 0)];
     double rmax = php.radiusLayer_[kk][std::min(irmax, irm)];
     edm::LogVerbatim("HGCalGeom") << "Layer " << php.firstLayer_ + k << ":" << kk << " Radius range " << irmin << ":"
-                                  << irmax << ":" << rmin << ":" << rmax;
+                                  << irmax << ":" << rmin << ":" << rmax << " Size " << php.radiusLayer_[kk].size();
 #endif
     mytr.lay = php.firstLayer_ + k;
     for (int irad = irmin; irad <= irmax; ++irad) {
       double rmin = php.radiusLayer_[kk][std::max((irad - 1), 0)];
       double rmax = php.radiusLayer_[kk][std::min(irad, irm)];
+#ifdef EDM_ML_DEBUG
+      edm::LogVerbatim("HGCalGeom") << "irad " << irad << ":" << php.radiusLayer_[kk].size() << " R " << rmin << ":" << rmax;
+#endif
       mytr.bl = 0.5 * rmin * php.scintCellSize(mytr.lay);
       mytr.tl = 0.5 * rmax * php.scintCellSize(mytr.lay);
       mytr.h = 0.5 * (rmax - rmin);

--- a/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
@@ -1686,10 +1686,11 @@ void HGCalGeomParameters::loadSpecParsTrapezoid(const DDFilteredView& fv, HGCalP
       std::vector<double> rectract = fv.vector("ScintRetract");
       rescale(rectract, HGCalParameters::k_ScaleFromDDD);
       int n = 2 * php.cassettes_ * (php.firstLayer_ - 1);
-      for (int k1 = 0; k1 < n; ++ k1)
-	cassetteShift.emplace_back(0.);
-#ifdef EDM_ML_DEBUG      
-      edm::LogVerbatim("HGCalGeom") << "First Layer " << php.firstLayer_ << " Rett size " << rectract.size() << " N " << n;
+      for (int k1 = 0; k1 < n; ++k1)
+        cassetteShift.emplace_back(0.);
+#ifdef EDM_ML_DEBUG
+      edm::LogVerbatim("HGCalGeom") << "First Layer " << php.firstLayer_ << " Rett size " << rectract.size() << " N "
+                                    << n;
 #endif
       double dphi = M_PI / php.cassettes_;
       for (unsigned int k1 = 0; k1 < rectract.size(); ++k1) {
@@ -1851,11 +1852,12 @@ void HGCalGeomParameters::loadSpecParsTrapezoid(const cms::DDFilteredView& fv,
         } else if (dd4hep::dd::compareEqual(dd4hep::dd::noNamespace(it.first), "ScintRetract")) {
           for (const auto& i : it.second)
             rectract.emplace_back(i);
-	  int n = 2 * php.cassettes_ * (php.firstLayer_ - 1);
-	  for (int k1 = 0; k1 < n; ++ k1)
-	    cassetteShift.emplace_back(0.);
-#ifdef EDM_ML_DEBUG      
-	  edm::LogVerbatim("HGCalGeom") << "First Layer " << php.firstLayer_ << " Rett size " << rectract.size() << " N " << n;
+          int n = 2 * php.cassettes_ * (php.firstLayer_ - 1);
+          for (int k1 = 0; k1 < n; ++k1)
+            cassetteShift.emplace_back(0.);
+#ifdef EDM_ML_DEBUG
+          edm::LogVerbatim("HGCalGeom") << "First Layer " << php.firstLayer_ << " Rett size " << rectract.size()
+                                        << " N " << n;
 #endif
           double dphi = M_PI / php.cassettes_;
           for (unsigned int k1 = 0; k1 < rectract.size(); ++k1) {
@@ -2410,17 +2412,19 @@ void HGCalGeomParameters::loadCellTrapezoid(HGCalParameters& php) {
     unsigned int k1(0), k2(0);
     for (unsigned int k = 0; k < php.zLayerHex_.size(); ++k) {
       if (!php.tileRingFineRange_.empty()) {
-	unsigned int k0 = (k1 < (php.tileRingFineRange_.size() - 1)) ? k1 : (php.tileRingFineRange_.size() - 1);
+        unsigned int k0 = (k1 < (php.tileRingFineRange_.size() - 1)) ? k1 : (php.tileRingFineRange_.size() - 1);
 #ifdef EDM_ML_DEBUG
-	edm::LogVerbatim("HGCalGeom") << "Layer " << k << " Fine " << k1 << ":" << k0 << ":" << php.tileRingFineRange_.size();
+        edm::LogVerbatim("HGCalGeom") << "Layer " << k << " Fine " << k1 << ":" << k0 << ":"
+                                      << php.tileRingFineRange_.size();
 #endif
         php.iradMinBHFine_.emplace_back(1 + php.tileRingFineRange_[k0].first);
         php.iradMaxBHFine_.emplace_back(1 + php.tileRingFineRange_[k0].second);
       }
       if (!php.tileRingRange_.empty()) {
-	unsigned int k0 = (k2 < (php.tileRingRange_.size() - 1)) ? k2 : (php.tileRingRange_.size() - 1);
+        unsigned int k0 = (k2 < (php.tileRingRange_.size() - 1)) ? k2 : (php.tileRingRange_.size() - 1);
 #ifdef EDM_ML_DEBUG
-	edm::LogVerbatim("HGCalGeom") << "Layer " << k << " Coarse " << k2 << ":" << k0 << ":" << php.tileRingRange_.size();
+        edm::LogVerbatim("HGCalGeom") << "Layer " << k << " Coarse " << k2 << ":" << k0 << ":"
+                                      << php.tileRingRange_.size();
 #endif
         php.iradMinBH_.emplace_back(1 + php.tileRingRange_[k0].first);
         php.iradMaxBH_.emplace_back(1 + php.tileRingRange_[k0].second);

--- a/Geometry/HGCalCommonData/src/HGCalParameters.cc
+++ b/Geometry/HGCalCommonData/src/HGCalParameters.cc
@@ -166,6 +166,14 @@ std::array<int, 4> HGCalParameters::getID(unsigned int k) const {
   return std::array<int, 4>{{zp, lay, sec, subsec}};
 }
 
+double HGCalParameters::scintRing(int indx, int irad) const {
+  double r(0);
+  if (scintValidRing(indx, irad)) {
+    r = 0.5 * (radiusLayer_[scintType(indx + 1)][irad - 1] + radiusLayer_[scintType(indx + 1)][irad]);
+  }
+  return r;
+}
+
 #include "FWCore/Utilities/interface/typelookup.h"
 
 TYPELOOKUP_DATA_REG(HGCalParameters);

--- a/Geometry/HGCalGeometry/test/HGCalSizeTester.cc
+++ b/Geometry/HGCalGeometry/test/HGCalSizeTester.cc
@@ -129,6 +129,20 @@ void HGCalSizeTester::doTestScint(const HGCalGeometry* geom, DetId::Detector det
             auto icell1 = geom->getGeometry(id1);
             GlobalPoint global1 = geom->getPosition(id1);
             DetId idc1 = geom->getClosestCell(global1);
+	    std::pair<int, int> typm = geom->topology().dddConstants().tileType(layer, ieta, iphi);
+	    if (typm.first >= 0) {
+	      HGCScintillatorDetId detId(id1);
+	      detId.setType(typm.first);
+	      detId.setSiPM(typm.second);
+	      id1 = static_cast<DetId>(detId);
+	    }
+	    HGCScintillatorDetId detId(idc1);
+	    typm = geom->topology().dddConstants().tileType(detId.layer(), detId.ring(), detId.iphi());
+	    if (typm.first >= 0) {
+	      detId.setType(typm.first);
+	      detId.setSiPM(typm.second);
+	      idc1 = static_cast<DetId>(detId);
+	    }
             std::string cherr = (id1.rawId() != idc1.rawId()) ? "***** ERROR *****" : "";
             edm::LogVerbatim("HGCalGeomX")
                 << "DetId (" << det << ":" << zside << ":" << type << ":" << layer << ":" << ieta << ":" << iphi

--- a/Geometry/HGCalGeometry/test/HGCalSizeTester.cc
+++ b/Geometry/HGCalGeometry/test/HGCalSizeTester.cc
@@ -129,20 +129,20 @@ void HGCalSizeTester::doTestScint(const HGCalGeometry* geom, DetId::Detector det
             auto icell1 = geom->getGeometry(id1);
             GlobalPoint global1 = geom->getPosition(id1);
             DetId idc1 = geom->getClosestCell(global1);
-	    std::pair<int, int> typm = geom->topology().dddConstants().tileType(layer, ieta, iphi);
-	    if (typm.first >= 0) {
-	      HGCScintillatorDetId detId(id1);
-	      detId.setType(typm.first);
-	      detId.setSiPM(typm.second);
-	      id1 = static_cast<DetId>(detId);
-	    }
-	    HGCScintillatorDetId detId(idc1);
-	    typm = geom->topology().dddConstants().tileType(detId.layer(), detId.ring(), detId.iphi());
-	    if (typm.first >= 0) {
-	      detId.setType(typm.first);
-	      detId.setSiPM(typm.second);
-	      idc1 = static_cast<DetId>(detId);
-	    }
+            std::pair<int, int> typm = geom->topology().dddConstants().tileType(layer, ieta, iphi);
+            if (typm.first >= 0) {
+              HGCScintillatorDetId detId(id1);
+              detId.setType(typm.first);
+              detId.setSiPM(typm.second);
+              id1 = static_cast<DetId>(detId);
+            }
+            HGCScintillatorDetId detId(idc1);
+            typm = geom->topology().dddConstants().tileType(detId.layer(), detId.ring(), detId.iphi());
+            if (typm.first >= 0) {
+              detId.setType(typm.first);
+              detId.setSiPM(typm.second);
+              idc1 = static_cast<DetId>(detId);
+            }
             std::string cherr = (id1.rawId() != idc1.rawId()) ? "***** ERROR *****" : "";
             edm::LogVerbatim("HGCalGeomX")
                 << "DetId (" << det << ":" << zside << ":" << type << ":" << layer << ":" << ieta << ":" << iphi


### PR DESCRIPTION
#### PR description:

Remove the issue of cassette shift for HGCal scintillators in V19

#### PR validation:

Use the runTheMatrix test workflows

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special