### PR TITLE
MTD Validation: add optional plots for track-MTD cluster matching studies

### DIFF
--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -159,7 +159,7 @@ private:
 
   edm::EDGetTokenT<edm::ValueMap<int>> trackAssocToken_;
   edm::EDGetTokenT<edm::ValueMap<float>> pathLengthToken_;
-  
+
   edm::EDGetTokenT<edm::ValueMap<float>> btlMatchTimeChi2Token_;
   edm::EDGetTokenT<edm::ValueMap<float>> etlMatchTimeChi2Token_;
   edm::EDGetTokenT<edm::ValueMap<float>> btlMatchChi2Token_;
@@ -291,7 +291,7 @@ private:
   MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocMVAQual_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocTimeRes_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocTimePull_;
-  MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocTrackOutermostHitR_; 
+  MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocTrackOutermostHitR_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocTrackChi2_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocTimeChi2_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocTimeChi2vsMVAQual_;
@@ -310,7 +310,7 @@ private:
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocSpaceChi2_;
-  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT_; 
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff_;
@@ -322,14 +322,14 @@ private:
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLength_;
-  
+
   // wrong association with reco from same TP direct hit
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocEta1_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocPt1_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocMVAQual1_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTimeRes1_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTimePull1_;
-  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT1_; 
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT1_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ1_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi1_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff1_;
@@ -349,7 +349,7 @@ private:
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocMVAQual2_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTimeRes2_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTimePull2_;
-  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT2_; 
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT2_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ2_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi2_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff2_;
@@ -369,7 +369,7 @@ private:
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocMVAQual3_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTimeRes3_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTimePull3_;
-  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT3_; 
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT3_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ3_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi3_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff3_;
@@ -385,12 +385,11 @@ private:
 
   MonitorElement* meBTLTrackMatchedTPmtdDirectNoAssocEta_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectNoAssocPt_;
-  MonitorElement* meBTLTrackMatchedTPmtdDirectNoAssocTrackOutermostHitR_; 
+  MonitorElement* meBTLTrackMatchedTPmtdDirectNoAssocTrackOutermostHitR_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectNoAssocTrackChi2_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectNoAssocTrackNdf_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectNoAssocSimClusSize_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectNoAssocRecoClusSize_;
-
 
   // - BTL TPmtd "other" hits: correct, wrong, missing association in MTD
   MonitorElement* meBTLTrackMatchedTPmtdOtherCorrectAssocEta_;
@@ -414,10 +413,10 @@ private:
   MonitorElement* meBTLTrackMatchedTPnomtdAssocMVAQual_;
   MonitorElement* meBTLTrackMatchedTPnomtdAssocTimeRes_;
   MonitorElement* meBTLTrackMatchedTPnomtdAssocTimePull_;
-  MonitorElement* meBTLTrackMatchedTPnomtdAssocTrackChi2_;		    
-  MonitorElement* meBTLTrackMatchedTPnomtdAssocTrackNdf_ ;		   
-  MonitorElement* meBTLTrackMatchedTPnomtdAssocTrackOutermostHitR_; 
-  MonitorElement* meBTLTrackMatchedTPnomtdAssocTrackIdOff_; 
+  MonitorElement* meBTLTrackMatchedTPnomtdAssocTrackChi2_;
+  MonitorElement* meBTLTrackMatchedTPnomtdAssocTrackNdf_;
+  MonitorElement* meBTLTrackMatchedTPnomtdAssocTrackOutermostHitR_;
+  MonitorElement* meBTLTrackMatchedTPnomtdAssocTrackIdOff_;
   MonitorElement* meBTLTrackMatchedTPnomtdAssocSimClusSize_;
   MonitorElement* meBTLTrackMatchedTPnomtdAssocRecoClusSize_;
   MonitorElement* meBTLTrackMatchedTPnomtdAssocTrackID_;
@@ -579,15 +578,14 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
 
   auto recoToSimH = makeValid(iEvent.getHandle(recoToSimAssociationToken_));
   r2s_ = recoToSimH.product();
-  auto geometryHandle = iSetup.getTransientHandle(mtdgeoToken_); 
+  auto geometryHandle = iSetup.getTransientHandle(mtdgeoToken_);
   const MTDGeometry* geom = geometryHandle.product();
   auto topologyHandle = iSetup.getTransientHandle(mtdtopoToken_);
-  const MTDTopology *topology = topologyHandle.product();
-  
+  const MTDTopology* topology = topologyHandle.product();
+
   mtd::MTDGeomUtil geomUtil;
   geomUtil.setGeometry(geom);
   geomUtil.setTopology(topology);
-
 
   unsigned int index = 0;
 
@@ -847,17 +845,14 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
           hasTime = true;
         }
 
-
-
         // ==  MC truth matching
-        double simClusterRef_RecoMatch_trackIdOff(-9999.); 
+        double simClusterRef_RecoMatch_trackIdOff(-9999.);
         double simClusterRef_RecoMatch_DeltaZ(-9999.);
         double simClusterRef_RecoMatch_DeltaPhi(-9999.);
         double simClusterRef_RecoMatch_DeltaT(-9999.);
         int simClusSize(-9999);
         int recoClusSize(-9999);
 
- 
         bool isTPmtdDirectBTL = false, isTPmtdOtherBTL = false, isTPmtdDirectCorrectBTL = false,
              isTPmtdOtherCorrectBTL = false, isTPmtdETLD1 = false, isTPmtdETLD2 = false, isTPmtdCorrectETLD1 = false,
              isTPmtdCorrectETLD2 = false, isFromSameTP = false;
@@ -865,7 +860,7 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
         auto simClustersRefsIt = tp2SimAssociationMap.find(*tp_info);
         const bool withMTD = (simClustersRefsIt != tp2SimAssociationMap.end());
 
-	// If there is a mtdSimLayerCluster from the tracking particle
+        // If there is a mtdSimLayerCluster from the tracking particle
         if (withMTD) {
           // -- Get the refs to MtdSimLayerClusters associated to the TP
           std::vector<edm::Ref<MtdSimLayerClusterCollection>> simClustersRefs;
@@ -903,53 +898,50 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
           }
 
           // ==  Check if the track-cluster association is correct: Track->RecoClus->SimClus == Track->TP->SimClus
-	  recoClusSize = recoClustersRefs.size();
+          recoClusSize = recoClustersRefs.size();
           for (const auto& recClusterRef : recoClustersRefs) {
             if (recClusterRef.isNonnull()) {
               auto itp = r2sAssociationMap.equal_range(recClusterRef);
-	      simClusSize = 0;
+              simClusSize = 0;
               if (itp.first != itp.second) {
                 auto& simClustersRefs_RecoMatch = (*itp.first).second;
-		
+
                 BTLDetId RecoDetId((*recClusterRef).id());
-	        simClusSize = simClustersRefs_RecoMatch.size();
-	
+                simClusSize = simClustersRefs_RecoMatch.size();
+
                 for (const auto& simClusterRef_RecoMatch : simClustersRefs_RecoMatch) {
-		  	
                   // Check if simClusterRef_RecoMatch  exists in SimClusters
                   auto simClusterIt =
                       std::find(simClustersRefs.begin(), simClustersRefs.end(), simClusterRef_RecoMatch);
-	          if (optionalPlots_ && isTPmtdDirectBTL){
-	  
-                      // simCluster matched to TP 
-		      // NB we are taking the position and id of the first hit in the cluster.
-		      auto directSimClus = *directSimClusIt;
-		      MTDDetId mtddetid = directSimClus->detIds_and_rows().front().first;
-                      BTLDetId detid(mtddetid.rawId());
-	              LocalPoint simClusLocalPos = directSimClus->hits_and_positions().front().second;
-                      GlobalPoint simClusGlobalPos = geomUtil.globalPosition(detid, simClusLocalPos);
-       
-		      // simClusterRef_RecoMatch infos
-  	              MTDDetId mtddetidRecoMatch = simClusterRef_RecoMatch->detIds_and_rows().front().first;
-                      BTLDetId detidRecoMatch(mtddetidRecoMatch.rawId());
-	              LocalPoint simClusRecoMatchLocalPos = simClusterRef_RecoMatch->hits_and_positions().front().second;
-                      GlobalPoint simClusRecoMatchGlobalPos = geomUtil.globalPosition(detidRecoMatch, simClusRecoMatchLocalPos);
+                  if (optionalPlots_ && isTPmtdDirectBTL) {
+                    // simCluster matched to TP
+                    // NB we are taking the position and id of the first hit in the cluster.
+                    auto directSimClus = *directSimClusIt;
+                    MTDDetId mtddetid = directSimClus->detIds_and_rows().front().first;
+                    BTLDetId detid(mtddetid.rawId());
+                    LocalPoint simClusLocalPos = directSimClus->hits_and_positions().front().second;
+                    GlobalPoint simClusGlobalPos = geomUtil.globalPosition(detid, simClusLocalPos);
 
-		      simClusterRef_RecoMatch_trackIdOff = simClusterRef_RecoMatch->trackIdOffset();
-                      simClusterRef_RecoMatch_DeltaZ = simClusRecoMatchGlobalPos.z() - simClusGlobalPos.z();
-                      simClusterRef_RecoMatch_DeltaPhi = simClusRecoMatchGlobalPos.phi() - simClusGlobalPos.phi();
-                      simClusterRef_RecoMatch_DeltaT = simClusterRef_RecoMatch->simLCTime() - directSimClus->simLCTime();
-      
-		    }
+                    // simClusterRef_RecoMatch infos
+                    MTDDetId mtddetidRecoMatch = simClusterRef_RecoMatch->detIds_and_rows().front().first;
+                    BTLDetId detidRecoMatch(mtddetidRecoMatch.rawId());
+                    LocalPoint simClusRecoMatchLocalPos = simClusterRef_RecoMatch->hits_and_positions().front().second;
+                    GlobalPoint simClusRecoMatchGlobalPos =
+                        geomUtil.globalPosition(detidRecoMatch, simClusRecoMatchLocalPos);
 
+                    simClusterRef_RecoMatch_trackIdOff = simClusterRef_RecoMatch->trackIdOffset();
+                    simClusterRef_RecoMatch_DeltaZ = simClusRecoMatchGlobalPos.z() - simClusGlobalPos.z();
+                    simClusterRef_RecoMatch_DeltaPhi = simClusRecoMatchGlobalPos.phi() - simClusGlobalPos.phi();
+                    simClusterRef_RecoMatch_DeltaT = simClusterRef_RecoMatch->simLCTime() - directSimClus->simLCTime();
+                  }
 
                   // SimCluster found in SimClusters
                   if (simClusterIt != simClustersRefs.end()) {
-		    isFromSameTP = true;
+                    isFromSameTP = true;
                     if (isBTL) {
                       if (directSimClusIt != simClustersRefs.end() && simClusterRef_RecoMatch == *directSimClusIt) {
                         isTPmtdDirectCorrectBTL = true;
-	              } else if (simClusterRef_RecoMatch->trackIdOffset() != 0) {
+                      } else if (simClusterRef_RecoMatch->trackIdOffset() != 0) {
                         isTPmtdOtherCorrectBTL = true;
                       }
                     }
@@ -982,20 +974,20 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
               if (isTPmtdDirectBTL) {
                 // -- Track matched to TP with sim hit (direct), correctly associated reco cluster
                 if (isTPmtdDirectCorrectBTL) {
-	          
                   if (optionalPlots_) {
-		    meBTLTrackMatchedTPmtdDirectCorrectAssocSimClusSize_->Fill(simClusSize);
+                    meBTLTrackMatchedTPmtdDirectCorrectAssocSimClusSize_->Fill(simClusSize);
                     meBTLTrackMatchedTPmtdDirectCorrectAssocRecoClusSize_->Fill(recoClusSize);
-      	            meBTLTrackMatchedTPmtdDirectCorrectAssocTrackOutermostHitR_->Fill(outermostHitPosition[trackref]);
-	            meBTLTrackMatchedTPmtdDirectCorrectAssocTrackNdf_->Fill(trackGen.ndof());
-	            meBTLTrackMatchedTPmtdDirectCorrectAssocTrackChi2_->Fill(trackGen.chi2());
+                    meBTLTrackMatchedTPmtdDirectCorrectAssocTrackOutermostHitR_->Fill(outermostHitPosition[trackref]);
+                    meBTLTrackMatchedTPmtdDirectCorrectAssocTrackNdf_->Fill(trackGen.ndof());
+                    meBTLTrackMatchedTPmtdDirectCorrectAssocTrackChi2_->Fill(trackGen.chi2());
                     meBTLTrackMatchedTPmtdDirectCorrectAssocTimeChi2_->Fill(btlMatchTimeChi2[trackref]);
-                    meBTLTrackMatchedTPmtdDirectCorrectAssocTimeChi2vsMVAQual_->Fill(btlMatchTimeChi2[trackref],  mtdQualMVA[trackref]);
+                    meBTLTrackMatchedTPmtdDirectCorrectAssocTimeChi2vsMVAQual_->Fill(btlMatchTimeChi2[trackref],
+                                                                                     mtdQualMVA[trackref]);
                     meBTLTrackMatchedTPmtdDirectCorrectAssocSpaceChi2_->Fill(btlMatchChi2[trackref]);
-                    meBTLTrackMatchedTPmtdDirectCorrectAssocTrackPathLengthvsEta_->Fill(std::abs(trackGen.eta()), pathLength[trackref]);
+                    meBTLTrackMatchedTPmtdDirectCorrectAssocTrackPathLengthvsEta_->Fill(std::abs(trackGen.eta()),
+                                                                                        pathLength[trackref]);
                     meBTLTrackMatchedTPmtdDirectCorrectAssocTrackPathLength_->Fill(pathLength[trackref]);
-
-		  }
+                  }
                   fillTrackClusterMatchingHistograms(meBTLTrackMatchedTPmtdDirectCorrectAssocEta_,
                                                      meBTLTrackMatchedTPmtdDirectCorrectAssocPt_,
                                                      meBTLTrackMatchedTPmtdDirectCorrectAssocMVAQual_,
@@ -1011,114 +1003,117 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
                 // -- Track matched to TP with sim hit (direct), incorrectly associated reco cluster
                 else {
                   if (optionalPlots_) {
-		    meBTLTrackMatchedTPmtdDirectWrongAssocSimClusSize_->Fill(simClusSize);
+                    meBTLTrackMatchedTPmtdDirectWrongAssocSimClusSize_->Fill(simClusSize);
                     meBTLTrackMatchedTPmtdDirectWrongAssocRecoClusSize_->Fill(recoClusSize);
-		    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT_->Fill(simClusterRef_RecoMatch_DeltaT);
-		    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi_->Fill(simClusterRef_RecoMatch_DeltaPhi);
-		    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ_->Fill(simClusterRef_RecoMatch_DeltaZ);
-		    meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff_->Fill(simClusterRef_RecoMatch_trackIdOff);
-		    meBTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR_->Fill(outermostHitPosition[trackref]);
+                    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT_->Fill(simClusterRef_RecoMatch_DeltaT);
+                    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi_->Fill(simClusterRef_RecoMatch_DeltaPhi);
+                    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ_->Fill(simClusterRef_RecoMatch_DeltaZ);
+                    meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff_->Fill(simClusterRef_RecoMatch_trackIdOff);
+                    meBTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR_->Fill(outermostHitPosition[trackref]);
                     meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf_->Fill(trackGen.ndof());
                     meBTLTrackMatchedTPmtdDirectWrongAssocTrackChi2_->Fill(trackGen.chi2());
-                    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR_->Fill(outermostHitPosition[trackref], simClusterRef_RecoMatch_DeltaZ);
+                    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR_->Fill(outermostHitPosition[trackref],
+                                                                            simClusterRef_RecoMatch_DeltaZ);
                     meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2_->Fill(btlMatchTimeChi2[trackref]);
-                    meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual_->Fill(btlMatchTimeChi2[trackref],  mtdQualMVA[trackref]);
+                    meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual_->Fill(btlMatchTimeChi2[trackref],
+                                                                                   mtdQualMVA[trackref]);
                     meBTLTrackMatchedTPmtdDirectWrongAssocSpaceChi2_->Fill(btlMatchChi2[trackref]);
-                    meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta_->Fill(std::abs(trackGen.eta()), pathLength[trackref]);
+                    meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta_->Fill(std::abs(trackGen.eta()),
+                                                                                      pathLength[trackref]);
                     meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLength_->Fill(pathLength[trackref]);
 
+                    if (simClusterRef_RecoMatch_trackIdOff == 0 && isFromSameTP) {
+                      fillTrackClusterMatchingHistograms(meBTLTrackMatchedTPmtdDirectWrongAssocEta1_,
+                                                         meBTLTrackMatchedTPmtdDirectWrongAssocPt1_,
+                                                         meBTLTrackMatchedTPmtdDirectWrongAssocMVAQual1_,
+                                                         meBTLTrackMatchedTPmtdDirectWrongAssocTimeRes1_,
+                                                         meBTLTrackMatchedTPmtdDirectWrongAssocTimePull1_,
+                                                         std::abs(trackGen.eta()),
+                                                         trackGen.pt(),
+                                                         mtdQualMVA[trackref],
+                                                         dT,
+                                                         pullT,
+                                                         hasTime);
 
-
-                    if (simClusterRef_RecoMatch_trackIdOff == 0 && isFromSameTP){
-
-      			    fillTrackClusterMatchingHistograms(meBTLTrackMatchedTPmtdDirectWrongAssocEta1_,
-                                     meBTLTrackMatchedTPmtdDirectWrongAssocPt1_,
-                                     meBTLTrackMatchedTPmtdDirectWrongAssocMVAQual1_,
-                                     meBTLTrackMatchedTPmtdDirectWrongAssocTimeRes1_,
-                                     meBTLTrackMatchedTPmtdDirectWrongAssocTimePull1_,
-                                     std::abs(trackGen.eta()),
-                                     trackGen.pt(),
-                                     mtdQualMVA[trackref],
-                                     dT,
-                                     pullT,
-                                     hasTime);
-        	    
-		      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT1_->Fill(simClusterRef_RecoMatch_DeltaT);
-		      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi1_->Fill(simClusterRef_RecoMatch_DeltaPhi);
-		      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ1_->Fill(simClusterRef_RecoMatch_DeltaZ);
-		      meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff1_->Fill(simClusterRef_RecoMatch_trackIdOff);
-		      meBTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR1_->Fill(outermostHitPosition[trackref]);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT1_->Fill(simClusterRef_RecoMatch_DeltaT);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi1_->Fill(simClusterRef_RecoMatch_DeltaPhi);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ1_->Fill(simClusterRef_RecoMatch_DeltaZ);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff1_->Fill(simClusterRef_RecoMatch_trackIdOff);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR1_->Fill(outermostHitPosition[trackref]);
                       meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf1_->Fill(trackGen.ndof());
                       meBTLTrackMatchedTPmtdDirectWrongAssocTrackChi21_->Fill(trackGen.chi2());
-                      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR1_->Fill(outermostHitPosition[trackref], simClusterRef_RecoMatch_DeltaZ);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR1_->Fill(outermostHitPosition[trackref],
+                                                                               simClusterRef_RecoMatch_DeltaZ);
                       meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi21_->Fill(btlMatchTimeChi2[trackref]);
-                      meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual1_->Fill(btlMatchTimeChi2[trackref],  mtdQualMVA[trackref]);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual1_->Fill(btlMatchTimeChi2[trackref],
+                                                                                      mtdQualMVA[trackref]);
                       meBTLTrackMatchedTPmtdDirectWrongAssocSpaceChi21_->Fill(btlMatchChi2[trackref]);
-                      meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta1_->Fill(std::abs(trackGen.eta()), pathLength[trackref]);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta1_->Fill(std::abs(trackGen.eta()),
+                                                                                         pathLength[trackref]);
                       meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLength1_->Fill(pathLength[trackref]);
 
-                    } else if (simClusterRef_RecoMatch_trackIdOff > 0 && isFromSameTP){
+                    } else if (simClusterRef_RecoMatch_trackIdOff > 0 && isFromSameTP) {
+                      fillTrackClusterMatchingHistograms(meBTLTrackMatchedTPmtdDirectWrongAssocEta2_,
+                                                         meBTLTrackMatchedTPmtdDirectWrongAssocPt2_,
+                                                         meBTLTrackMatchedTPmtdDirectWrongAssocMVAQual2_,
+                                                         meBTLTrackMatchedTPmtdDirectWrongAssocTimeRes2_,
+                                                         meBTLTrackMatchedTPmtdDirectWrongAssocTimePull2_,
+                                                         std::abs(trackGen.eta()),
+                                                         trackGen.pt(),
+                                                         mtdQualMVA[trackref],
+                                                         dT,
+                                                         pullT,
+                                                         hasTime);
 
-
-	            		     fillTrackClusterMatchingHistograms(meBTLTrackMatchedTPmtdDirectWrongAssocEta2_,
-                                     meBTLTrackMatchedTPmtdDirectWrongAssocPt2_,
-                                     meBTLTrackMatchedTPmtdDirectWrongAssocMVAQual2_,
-                                     meBTLTrackMatchedTPmtdDirectWrongAssocTimeRes2_,
-                                     meBTLTrackMatchedTPmtdDirectWrongAssocTimePull2_,
-                                     std::abs(trackGen.eta()),
-                                     trackGen.pt(),
-                                     mtdQualMVA[trackref],
-                                     dT,
-                                     pullT,
-                                     hasTime);
-        	    
-		      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT2_->Fill(simClusterRef_RecoMatch_DeltaT);
-		      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi2_->Fill(simClusterRef_RecoMatch_DeltaPhi);
-		      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ2_->Fill(simClusterRef_RecoMatch_DeltaZ);
-		      meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff2_->Fill(simClusterRef_RecoMatch_trackIdOff);
-		      meBTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR2_->Fill(outermostHitPosition[trackref]);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT2_->Fill(simClusterRef_RecoMatch_DeltaT);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi2_->Fill(simClusterRef_RecoMatch_DeltaPhi);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ2_->Fill(simClusterRef_RecoMatch_DeltaZ);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff2_->Fill(simClusterRef_RecoMatch_trackIdOff);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR2_->Fill(outermostHitPosition[trackref]);
                       meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf2_->Fill(trackGen.ndof());
                       meBTLTrackMatchedTPmtdDirectWrongAssocTrackChi22_->Fill(trackGen.chi2());
-                      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR2_->Fill(outermostHitPosition[trackref], simClusterRef_RecoMatch_DeltaZ);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR2_->Fill(outermostHitPosition[trackref],
+                                                                               simClusterRef_RecoMatch_DeltaZ);
                       meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi22_->Fill(btlMatchTimeChi2[trackref]);
-                      meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual2_->Fill(btlMatchTimeChi2[trackref],  mtdQualMVA[trackref]);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual2_->Fill(btlMatchTimeChi2[trackref],
+                                                                                      mtdQualMVA[trackref]);
                       meBTLTrackMatchedTPmtdDirectWrongAssocSpaceChi22_->Fill(btlMatchChi2[trackref]);
-                      meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta2_->Fill(std::abs(trackGen.eta()), pathLength[trackref]);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta2_->Fill(std::abs(trackGen.eta()),
+                                                                                         pathLength[trackref]);
                       meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLength2_->Fill(pathLength[trackref]);
 
+                    } else if (!isFromSameTP) {
+                      fillTrackClusterMatchingHistograms(meBTLTrackMatchedTPmtdDirectWrongAssocEta3_,
+                                                         meBTLTrackMatchedTPmtdDirectWrongAssocPt3_,
+                                                         meBTLTrackMatchedTPmtdDirectWrongAssocMVAQual3_,
+                                                         meBTLTrackMatchedTPmtdDirectWrongAssocTimeRes3_,
+                                                         meBTLTrackMatchedTPmtdDirectWrongAssocTimePull3_,
+                                                         std::abs(trackGen.eta()),
+                                                         trackGen.pt(),
+                                                         mtdQualMVA[trackref],
+                                                         dT,
+                                                         pullT,
+                                                         hasTime);
 
-
-                    } else if (!isFromSameTP){
-
-	            		     fillTrackClusterMatchingHistograms(meBTLTrackMatchedTPmtdDirectWrongAssocEta3_,
-                                     meBTLTrackMatchedTPmtdDirectWrongAssocPt3_,
-                                     meBTLTrackMatchedTPmtdDirectWrongAssocMVAQual3_,
-                                     meBTLTrackMatchedTPmtdDirectWrongAssocTimeRes3_,
-                                     meBTLTrackMatchedTPmtdDirectWrongAssocTimePull3_,
-                                     std::abs(trackGen.eta()),
-                                     trackGen.pt(),
-                                     mtdQualMVA[trackref],
-                                     dT,
-                                     pullT,
-                                     hasTime);
-        	    
-		      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT3_->Fill(simClusterRef_RecoMatch_DeltaT);
-		      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi3_->Fill(simClusterRef_RecoMatch_DeltaPhi);
-		      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ3_->Fill(simClusterRef_RecoMatch_DeltaZ);
-		      meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff3_->Fill(simClusterRef_RecoMatch_trackIdOff);
-		      meBTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR3_->Fill(outermostHitPosition[trackref]);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT3_->Fill(simClusterRef_RecoMatch_DeltaT);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi3_->Fill(simClusterRef_RecoMatch_DeltaPhi);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ3_->Fill(simClusterRef_RecoMatch_DeltaZ);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff3_->Fill(simClusterRef_RecoMatch_trackIdOff);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR3_->Fill(outermostHitPosition[trackref]);
                       meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf3_->Fill(trackGen.ndof());
                       meBTLTrackMatchedTPmtdDirectWrongAssocTrackChi23_->Fill(trackGen.chi2());
-                      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR3_->Fill(outermostHitPosition[trackref], simClusterRef_RecoMatch_DeltaZ);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR3_->Fill(outermostHitPosition[trackref],
+                                                                               simClusterRef_RecoMatch_DeltaZ);
                       meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi23_->Fill(btlMatchTimeChi2[trackref]);
-                      meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual3_->Fill(btlMatchTimeChi2[trackref],  mtdQualMVA[trackref]);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual3_->Fill(btlMatchTimeChi2[trackref],
+                                                                                      mtdQualMVA[trackref]);
                       meBTLTrackMatchedTPmtdDirectWrongAssocSpaceChi23_->Fill(btlMatchChi2[trackref]);
-                      meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta3_->Fill(std::abs(trackGen.eta()), pathLength[trackref]);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta3_->Fill(std::abs(trackGen.eta()),
+                                                                                         pathLength[trackref]);
                       meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLength3_->Fill(pathLength[trackref]);
-		    }
-
+                    }
                   }
-		    fillTrackClusterMatchingHistograms(meBTLTrackMatchedTPmtdDirectWrongAssocEta_,
+                  fillTrackClusterMatchingHistograms(meBTLTrackMatchedTPmtdDirectWrongAssocEta_,
                                                      meBTLTrackMatchedTPmtdDirectWrongAssocPt_,
                                                      meBTLTrackMatchedTPmtdDirectWrongAssocMVAQual_,
                                                      meBTLTrackMatchedTPmtdDirectWrongAssocTimeRes_,
@@ -1129,10 +1124,9 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
                                                      dT,
                                                      pullT,
                                                      hasTime);
-
                 }
               }
-		
+
               // -- Track matched to TP with sim hit (other), correctly associated reco cluster
               else if (isTPmtdOtherBTL) {
                 if (isTPmtdOtherCorrectBTL) {
@@ -1167,14 +1161,13 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
             // -- Track matched to TP with sim hit in MTD, missing associated reco cluster
             else {
               if (isTPmtdDirectBTL) {
-		      
                 if (optionalPlots_) {
-		  meBTLTrackMatchedTPmtdDirectNoAssocSimClusSize_->Fill(simClusSize);
+                  meBTLTrackMatchedTPmtdDirectNoAssocSimClusSize_->Fill(simClusSize);
                   meBTLTrackMatchedTPmtdDirectNoAssocRecoClusSize_->Fill(recoClusSize);
-	          meBTLTrackMatchedTPmtdDirectNoAssocTrackOutermostHitR_->Fill(outermostHitPosition[trackref]);
+                  meBTLTrackMatchedTPmtdDirectNoAssocTrackOutermostHitR_->Fill(outermostHitPosition[trackref]);
                   meBTLTrackMatchedTPmtdDirectNoAssocTrackNdf_->Fill(trackGen.ndof());
                   meBTLTrackMatchedTPmtdDirectNoAssocTrackChi2_->Fill(trackGen.chi2());
-	        }
+                }
 
                 meBTLTrackMatchedTPmtdDirectNoAssocEta_->Fill(std::abs(trackGen.eta()));
                 meBTLTrackMatchedTPmtdDirectNoAssocPt_->Fill(trackGen.pt());
@@ -1186,12 +1179,12 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
           }  // == end BTL
           // == ETL
           else {
-	    // -- Track matched to TP with reco hits (one or two) correctly matched
-	    if ((ETLdisc1 && isTPmtdCorrectETLD1) || (ETLdisc2 && isTPmtdCorrectETLD2)) {
+            // -- Track matched to TP with reco hits (one or two) correctly matched
+            if ((ETLdisc1 && isTPmtdCorrectETLD1) || (ETLdisc2 && isTPmtdCorrectETLD2)) {
               meETLTrackMatchedTPEtaMtdCorrect_->Fill(std::abs(trackGen.eta()));
-	      meETLTrackMatchedTPPtMtdCorrect_->Fill(trackGen.pt());
+              meETLTrackMatchedTPPtMtdCorrect_->Fill(trackGen.pt());
             }
-	    // -- Track matched to TP with sim hit in one etl layer
+            // -- Track matched to TP with sim hit in one etl layer
             if (isTPmtdETLD1 || isTPmtdETLD2) {  // at least one hit (D1 or D2 or both)
               meETLTrackMatchedTPmtd1Eta_->Fill(std::abs(trackGen.eta()));
               meETLTrackMatchedTPmtd1Pt_->Fill(trackGen.pt());
@@ -1209,10 +1202,11 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
                     (isTPmtdETLD2 && !isTPmtdETLD1 && ETLdisc2 && isTPmtdCorrectETLD2) ||
                     (isTPmtdETLD1 && isTPmtdETLD2 && ETLdisc1 && ETLdisc2 && isTPmtdCorrectETLD1 &&
                      isTPmtdCorrectETLD2)) {
-	          if (optionalPlots_){
-			  meETLTrackMatchedTPmtd1CorrectAssocTimeChi2_->Fill(etlMatchTimeChi2[trackref]);		
-			  meETLTrackMatchedTPmtd1CorrectAssocTimeChi2vsMVAQual_->Fill(etlMatchTimeChi2[trackref], mtdQualMVA[trackref]);
-		  }	  
+                  if (optionalPlots_) {
+                    meETLTrackMatchedTPmtd1CorrectAssocTimeChi2_->Fill(etlMatchTimeChi2[trackref]);
+                    meETLTrackMatchedTPmtd1CorrectAssocTimeChi2vsMVAQual_->Fill(etlMatchTimeChi2[trackref],
+                                                                                mtdQualMVA[trackref]);
+                  }
                   fillTrackClusterMatchingHistograms(meETLTrackMatchedTPmtd1CorrectAssocEta_,
                                                      meETLTrackMatchedTPmtd1CorrectAssocPt_,
                                                      meETLTrackMatchedTPmtd1CorrectAssocMVAQual_,
@@ -1227,11 +1221,11 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
                 }
                 // - at least one reco hit is incorrectly associated or, if two sim hits, one reco hit is missing
                 else if ((isTPmtdETLD1 && !isTPmtdCorrectETLD1) || (isTPmtdETLD2 && !isTPmtdCorrectETLD2)) {
-		  	
-	          if (optionalPlots_) {
-			  meETLTrackMatchedTPmtd1WrongAssocTimeChi2_->Fill(etlMatchTimeChi2[trackref]);		
-			  meETLTrackMatchedTPmtd1WrongAssocTimeChi2vsMVAQual_->Fill(etlMatchTimeChi2[trackref], mtdQualMVA[trackref]);
-		  }	  
+                  if (optionalPlots_) {
+                    meETLTrackMatchedTPmtd1WrongAssocTimeChi2_->Fill(etlMatchTimeChi2[trackref]);
+                    meETLTrackMatchedTPmtd1WrongAssocTimeChi2vsMVAQual_->Fill(etlMatchTimeChi2[trackref],
+                                                                              mtdQualMVA[trackref]);
+                  }
 
                   fillTrackClusterMatchingHistograms(meETLTrackMatchedTPmtd1WrongAssocEta_,
                                                      meETLTrackMatchedTPmtd1WrongAssocPt_,
@@ -1250,11 +1244,12 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
               if (isTPmtdETLD1 && isTPmtdETLD2) {
                 // - each hit correctly associated to the track
                 if (ETLdisc1 && ETLdisc2 && isTPmtdCorrectETLD1 && isTPmtdCorrectETLD2) {
-	          if (optionalPlots_){
-			  meETLTrackMatchedTPmtd2CorrectAssocTimeChi2_->Fill(etlMatchTimeChi2[trackref]);		
-			  meETLTrackMatchedTPmtd2CorrectAssocTimeChi2vsMVAQual_->Fill(etlMatchTimeChi2[trackref], mtdQualMVA[trackref]);
-		  }
-		  fillTrackClusterMatchingHistograms(meETLTrackMatchedTPmtd2CorrectAssocEta_,
+                  if (optionalPlots_) {
+                    meETLTrackMatchedTPmtd2CorrectAssocTimeChi2_->Fill(etlMatchTimeChi2[trackref]);
+                    meETLTrackMatchedTPmtd2CorrectAssocTimeChi2vsMVAQual_->Fill(etlMatchTimeChi2[trackref],
+                                                                                mtdQualMVA[trackref]);
+                  }
+                  fillTrackClusterMatchingHistograms(meETLTrackMatchedTPmtd2CorrectAssocEta_,
                                                      meETLTrackMatchedTPmtd2CorrectAssocPt_,
                                                      meETLTrackMatchedTPmtd2CorrectAssocMVAQual_,
                                                      meETLTrackMatchedTPmtd2CorrectAssocTimeRes_,
@@ -1268,10 +1263,11 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
                 }
                 // - at least one reco hit incorrectly associated or one hit missing
                 else if ((ETLdisc1 || ETLdisc2) && (!isTPmtdCorrectETLD1 || !isTPmtdCorrectETLD2)) {
-	          if (optionalPlots_){ 
-			  meETLTrackMatchedTPmtd2WrongAssocTimeChi2_->Fill(etlMatchTimeChi2[trackref]);		
-			  meETLTrackMatchedTPmtd2WrongAssocTimeChi2vsMVAQual_->Fill(etlMatchTimeChi2[trackref], mtdQualMVA[trackref]);	
-		  }	  
+                  if (optionalPlots_) {
+                    meETLTrackMatchedTPmtd2WrongAssocTimeChi2_->Fill(etlMatchTimeChi2[trackref]);
+                    meETLTrackMatchedTPmtd2WrongAssocTimeChi2vsMVAQual_->Fill(etlMatchTimeChi2[trackref],
+                                                                              mtdQualMVA[trackref]);
+                  }
                   fillTrackClusterMatchingHistograms(meETLTrackMatchedTPmtd2WrongAssocEta_,
                                                      meETLTrackMatchedTPmtd2WrongAssocPt_,
                                                      meETLTrackMatchedTPmtd2WrongAssocMVAQual_,
@@ -1309,36 +1305,35 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
             meBTLTrackMatchedTPnomtdEta_->Fill(std::abs(trackGen.eta()));
             meBTLTrackMatchedTPnomtdPt_->Fill(trackGen.pt());
             if (isBTL) {
-		    
               if (optionalPlots_) {
-	        for (const auto& recClusterRef : recoClustersRefs) { // having a look at these recos
+                for (const auto& recClusterRef : recoClustersRefs) {  // having a look at these recos
                   if (recClusterRef.isNonnull()) {
                     auto itp = r2sAssociationMap.equal_range(recClusterRef);
                     if (itp.first != itp.second) {
                       auto& simClustersRefs_RecoMatch = (*itp.first).second;
-	              simClusSize = simClustersRefs_RecoMatch.size();
+                      simClusSize = simClustersRefs_RecoMatch.size();
                       for (const auto& sc : simClustersRefs_RecoMatch) {
                         auto mytps = Sim2tpAssociationMap.find(sc);
-		        if (mytps != Sim2tpAssociationMap.end()){
-		          for (const auto& mytp : mytps->val) {
-		             if (((**tp_info).eventId().rawId() - (*mytp).eventId().rawId()) == 0 ) meBTLTrackMatchedTPnomtdAssocTrackID_->Fill(0); 
-		             else meBTLTrackMatchedTPnomtdAssocTrackID_->Fill(1);
-		          }
-		        }
-	                  meBTLTrackMatchedTPnomtdAssocTrackIdOff_->Fill(sc->trackIdOffset());
+                        if (mytps != Sim2tpAssociationMap.end()) {
+                          for (const auto& mytp : mytps->val) {
+                            if (((**tp_info).eventId().rawId() - (*mytp).eventId().rawId()) == 0)
+                              meBTLTrackMatchedTPnomtdAssocTrackID_->Fill(0);
+                            else
+                              meBTLTrackMatchedTPnomtdAssocTrackID_->Fill(1);
+                          }
+                        }
+                        meBTLTrackMatchedTPnomtdAssocTrackIdOff_->Fill(sc->trackIdOffset());
+                      }
+                    }
+                  }
+                }
 
-	                  }
-	              }
-	            }
-	          }
-
-	    
-		  meBTLTrackMatchedTPnomtdAssocSimClusSize_->Fill(simClusSize);
-		  meBTLTrackMatchedTPnomtdAssocRecoClusSize_->Fill(recoClusSize);
-                  meBTLTrackMatchedTPnomtdAssocTrackChi2_ -> Fill(trackGen.chi2());
-                  meBTLTrackMatchedTPnomtdAssocTrackNdf_ -> Fill(trackGen.ndof());		   
-	          meBTLTrackMatchedTPnomtdAssocTrackOutermostHitR_->Fill(outermostHitPosition[trackref]) ; 
-	      }
+                meBTLTrackMatchedTPnomtdAssocSimClusSize_->Fill(simClusSize);
+                meBTLTrackMatchedTPnomtdAssocRecoClusSize_->Fill(recoClusSize);
+                meBTLTrackMatchedTPnomtdAssocTrackChi2_->Fill(trackGen.chi2());
+                meBTLTrackMatchedTPnomtdAssocTrackNdf_->Fill(trackGen.ndof());
+                meBTLTrackMatchedTPnomtdAssocTrackOutermostHitR_->Fill(outermostHitPosition[trackref]);
+              }
               fillTrackClusterMatchingHistograms(meBTLTrackMatchedTPnomtdAssocEta_,
                                                  meBTLTrackMatchedTPnomtdAssocPt_,
                                                  meBTLTrackMatchedTPnomtdAssocMVAQual_,
@@ -1793,12 +1788,12 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
       ibook.book1D("ETLTrackMatchedTPEtaTot", "Eta of tracks matched to TP; track eta ", 30, 1.5, 3.0);
   meETLTrackMatchedTPEtaMtd_ = ibook.book1D(
       "ETLTrackMatchedTPEtaMtd", "Eta of tracks matched to TP with time (>=1 ETL hit); track eta ", 30, 1.5, 3.0);
-   meETLTrackMatchedTPEtaMtdCorrect_ =
-	   ibook.book1D("ETLTrackMatchedTPEtaMtdCorrect",
-                         "Eta of tracks matched to TP with time (>=1 ETL hit), correct reco match; track eta ",
-			 30,
-			 1.5,
-			 3.0);
+  meETLTrackMatchedTPEtaMtdCorrect_ =
+      ibook.book1D("ETLTrackMatchedTPEtaMtdCorrect",
+                   "Eta of tracks matched to TP with time (>=1 ETL hit), correct reco match; track eta ",
+                   30,
+                   1.5,
+                   3.0);
   meETLTrackMatchedTPEta2Mtd_ = ibook.book1D(
       "ETLTrackMatchedTPEta2Mtd", "Eta of tracks matched to TP with time (2 ETL hits); track eta ", 30, 1.5, 3.0);
   meETLTrackMatchedTPPtTot_ =
@@ -1806,11 +1801,11 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
   meETLTrackMatchedTPPtMtd_ = ibook.book1D(
       "ETLTrackMatchedTPPtMtd", "Pt of tracks matched to TP with time (>=1 ETL hit); track pt [GeV] ", 50, 0., 10.);
   meETLTrackMatchedTPPtMtdCorrect_ =
-	  ibook.book1D("ETLTrackMatchedTPPtMtdCorrect",
-			   "Pt of tracks matched to TP with time (>=1 ETL hit), correct reco match; track pt [GeV] ",
-			    50,
-			    0.,
-			    10.);
+      ibook.book1D("ETLTrackMatchedTPPtMtdCorrect",
+                   "Pt of tracks matched to TP with time (>=1 ETL hit), correct reco match; track pt [GeV] ",
+                   50,
+                   0.,
+                   10.);
   meETLTrackMatchedTPPt2Mtd_ = ibook.book1D(
       "ETLTrackMatchedTPPt2Mtd", "Pt of tracks matched to TP with time (2 ETL hits); track pt [GeV] ", 50, 0., 10.);
 
@@ -1942,405 +1937,475 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
                                                         0.1,
                                                         "s");
 
-    meBTLTrackMatchedTPmtdDirectCorrectAssocTrackNdf_ = ibook.book1D(
-       "BTLTrackMatchedTPmtdDirectCorrectAssocTrackNdf",
-       "Ndf of tracks matched to TP with sim hit in MTD (direct), correct track-MTD association; Ndof ",
-       80,
-       0.,
-       220);
-    meBTLTrackMatchedTPmtdDirectCorrectAssocTrackChi2_ = ibook.book1D(
-       "BTLTrackMatchedTPmtdDirectCorrectAssocTrackChi2",
-       "Chi2 of tracks matched to TP with sim hit in MTD (direct), correct track-MTD association; Chi2 ",
-       80,
-       0.,
-       220);
-    meBTLTrackMatchedTPmtdDirectCorrectAssocTrackOutermostHitR_ = ibook.book1D(
-       "BTLTrackMatchedTPmtdDirectCorrectAssocTrackOutermostHitR",
-       "Outermost hit position R of tracks matched to TP with sim hit in MTD (direct), correct track-MTD association; R [cm] ",
-       40,
-       0.,
-       120);
-    meBTLTrackMatchedTPmtdDirectCorrectAssocSimClusSize_ =  ibook.book1D(
-         "BTLTrackMatchedTPmtdDirectCorrectAssocSimClusSize",
-         "Size of the sim clusters associated to the reco cluster associated to the track (direct), correct track-MTD association; Number of clusters ",
-         10,
-         -5.,
-         5.);
-    meBTLTrackMatchedTPmtdDirectCorrectAssocRecoClusSize_ =  ibook.book1D(
-         "BTLTrackMatchedTPmtdDirectCorrectAssocRecoClusSize",
-         "Size of the reco cluster associated to the track (direct), correct track-MTD association; Number of clusters ",
-         10,
-         -5.,
-         5.);
-    meBTLTrackMatchedTPmtdDirectCorrectAssocTimeChi2_ = ibook.book1D(
-       "BTLTrackMatchedTPmtdDirectCorrectAssocTimeChi2",
-       "Time chi2 of tracks matched to TP with sim hit in MTD (direct), correct track-MTD association; Chi2 ",
-       200,
-       0.,
-       100);
-     meBTLTrackMatchedTPmtdDirectCorrectAssocTimeChi2vsMVAQual_ = ibook.book2D(
-       "BTLTrackMatchedTPmtdDirectCorrectAssocTimeChi2vsMVAQual", "Time chi2 vs MVA of tracks matched to TP with sim hit in MTD (direct), correct track-MTD association; Chi2; MVAQual ",
-       200, 0., 100, 100, -1, 1);
-   
-    meBTLTrackMatchedTPmtdDirectCorrectAssocSpaceChi2_ = ibook.book1D(
-       "BTLTrackMatchedTPmtdDirectCorrectAssocSpaceChi2",
-       "Space chi2 of tracks matched to TP with sim hit in MTD (direct), correct track-MTD association; Chi2 ",
-       250,
-       0.,
-       250.);
-    meBTLTrackMatchedTPmtdDirectCorrectAssocTrackPathLengthvsEta_ = ibook.book2D(
-      "BTLTrackMatchedTPmtdDirectCorrectAssocTrackPathLengthvsEta", "MTD Track pathlength vs MTD track Eta;|#eta|;Pathlength", 30, 0, 1.5, 350, 0.0, 350.0);
-    meBTLTrackMatchedTPmtdDirectCorrectAssocTrackPathLength_ = ibook.book1D(
-      "BTLTrackMatchedTPmtdDirectCorrectAssocTrackPathLength", "MTD Track pathlength ; ;Pathlength", 400, 0, 400);
-
-
-    meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf1_ = ibook.book1D(
-       "BTLTrackMatchedTPmtdDirectWrongAssocTrackNdf1",
-       "Ndf of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Ndof ",
-       80,
-       0.,
-       220);
-    meBTLTrackMatchedTPmtdDirectWrongAssocTrackChi21_ = ibook.book1D(
-       "BTLTrackMatchedTPmtdDirectWrongAssocTrackChi21",
-       "Chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Chi2 ",
-       80,
-       0.,
-       220);
-    meBTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR1_ = ibook.book1D(
-        "BTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR1",
-        "Outermost hit position R of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; R [cm]",
-        40,
-        0.,
-        120);
-    meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff1_ = ibook.book1D(
-        "BTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff1",
-        "Track Id offset of reco (wrong) cluster associated to the track (direct)  - wrong track-MTD association; trackId (wrong)",
-        6,
-        -1.,
-        5.);
-    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ1_ = ibook.book1D(
-         "BTLTrackMatchedTPmtdDirectWrongAssocDeltaZ1",
-         "Z of sim matched wrong cluster - Z of true sim cluster (direct) - wrong track-MTD association; DeltaZ (wrong - true) [cm]",
-         1000,
-         -50.,
-         50.);
-     meBTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi1_ = ibook.book1D(
-         "BTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi1",
-         "Phi of sim matched wrong cluster - Z of true sim cluster - wrong track-MTD association; DeltaPhi (wrong - true) ",
-         500,
-         -0.1,
-         0.1);
-    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT1_ = ibook.book1D(
-         "BTLTrackMatchedTPmtdDirectWrongAssocDeltaT1",
-         "Time of sim matched wrong cluster - time of true sim cluster (direct) - wrong track-MTD association; DeltaT (wrong - true) [ns]",
-         480,
-         -0.6,
-         0.6);
-    meBTLTrackMatchedTPmtdDirectWrongAssocEta1_ =
-       ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocEta1",
-                    "Eta of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association;#eta_{RECO}",
-                    30,
-                    0.,
-                    1.5);
-    meBTLTrackMatchedTPmtdDirectWrongAssocPt1_ = ibook.book1D(
-       "BTLTrackMatchedTPmtdDirectWrongAssocPt1",
-       "Pt of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association;track pt [GeV]",
-       50,
-       0.,
-       10.);
-    meBTLTrackMatchedTPmtdDirectWrongAssocMVAQual1_ =
-       ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocMVAQual1",
-                    "MVA of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; MVA score",
-                    100,
-                    -1.,
-                    1.);
-    meBTLTrackMatchedTPmtdDirectWrongAssocTimeRes1_ =
-       ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocTimeRes1",
-                    "Time resolution of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD "
-                    "association; t_{rec} - t_{sim} [ns] ",
-                    240,
-                    -0.3,
-                    0.3);
-    meBTLTrackMatchedTPmtdDirectWrongAssocTimePull1_ =
-       ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocTimePull1",
-                    "Time pull of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; "
-                    "(t_{rec}-t_{sim})/#sigma_{t}",
-                    50,
-                    -5.,
-                    5.);
-    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR1_ = ibook.book2D(
-       "BTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR1", "; Outer R [cm]; DeltaZ [cm]", 120, 0., 120., 1000, -40., 40);
-    meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta1_ = ibook.book2D(
-      "BTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta1", "MTD Track pathlength vs MTD track Eta;|#eta|;Pathlength", 30, 0, 1.5, 350, 0.0, 350.0);
-    meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLength1_ = ibook.book1D(
-      "BTLTrackMatchedTPmtdDirectWrongAssocTrackPathLength1", "MTD Track pathlength ; ;Pathlength", 400, 0, 400);
-
-
-
-    meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf2_ = ibook.book1D(
-        "BTLTrackMatchedTPmtdDirectWrongAssocTrackNdf2",
-        "Chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Ndof ",
-        80,
-        0.,
-        220);
-    meBTLTrackMatchedTPmtdDirectWrongAssocTrackChi22_ = ibook.book1D(
-        "BTLTrackMatchedTPmtdDirectWrongAssocTrackChi22",
-        "Chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Chi2 ",
-        80,
-        0.,
-        220);
-    meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi21_ = ibook.book1D(
-       "BTLTrackMatchedTPmtdDirectWrongAssocTimeChi21",
-       "Time chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Chi2 ",
-       200,
-       0.,
-       100);
-     meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual1_ = ibook.book2D(
-       "BTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual1", "Time chi2 vs MVA of tracks matched to TP with sim hit in MTD (direct), wrong track-MTD association; Chi2; MVAQual ",
-       200, 0., 100, 100, -1, 1);
-    meBTLTrackMatchedTPmtdDirectWrongAssocSpaceChi21_ = ibook.book1D(
-       "BTLTrackMatchedTPmtdDirectWrongAssocSpaceChi21",
-       "Space chi2 of tracks matched to TP with sim hit in MTD (direct), wrong track-MTD association; Chi2 ",
-       250,
-       0.,
-       250.);
-    meBTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR2_ = ibook.book1D(
-        "BTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR2",
-        "Outermost hit position R of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; R [cm]",
-        40,
-        0.,
-        120);
-    meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff2_ = ibook.book1D(
-        "BTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff2",
-        "Track Id offset of reco (wrong) cluster associated to the track (direct)  - wrong track-MTD association; trackId (wrong)",
-        6,
-        -1.,
-        5.);
-    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ2_ = ibook.book1D(
-         "BTLTrackMatchedTPmtdDirectWrongAssocDeltaZ2",
-         "Z of sim matched wrong cluster - Z of true sim cluster (direct) - wrong track-MTD association; DeltaZ (wrong - true) [cm]",
-         1000,
-         -50.,
-         50.);
-    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi2_ = ibook.book1D(
-         "BTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi2",
-         "Phi of sim matched wrong cluster - Z of true sim cluster - wrong track-MTD association; DeltaPhi (wrong - true) ",
-         500,
-         -0.1,
-         0.1);
-    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT2_ = ibook.book1D(
-         "BTLTrackMatchedTPmtdDirectWrongAssocDeltaT2",
-         "Time of sim matched wrong cluster - time of true sim cluster (direct) - wrong track-MTD association; DeltaT (wrong - true) [ns]",
-         480,
-         -0.6,
-         0.6);
-    meBTLTrackMatchedTPmtdDirectWrongAssocEta2_ =
-       ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocEta2",
-                    "Eta of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association;#eta_{RECO}",
-                    30,
-                    0.,
-                    1.5);
-    meBTLTrackMatchedTPmtdDirectWrongAssocPt2_ = ibook.book1D(
-       "BTLTrackMatchedTPmtdDirectWrongAssocPt2",
-       "Pt of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association;track pt [GeV]",
-       50,
-       0.,
-       10.);
-    meBTLTrackMatchedTPmtdDirectWrongAssocMVAQual2_ =
-       ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocMVAQual2",
-                    "MVA of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; MVA score",
-                    100,
-                    -1.,
-                    1.);
-    meBTLTrackMatchedTPmtdDirectWrongAssocTimeRes2_ =
-       ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocTimeRes2",
-                    "Time resolution of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD "
-                    "association; t_{rec} - t_{sim} [ns] ",
-                    240,
-                    -0.3,
-                    0.3);
-    meBTLTrackMatchedTPmtdDirectWrongAssocTimePull2_ =
-      ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocTimePull2",
-                   "Time pull of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; "
-                   "(t_{rec}-t_{sim})/#sigma_{t}",
-                   50,
-                   -5.,
-                   5.);
-    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR2_ = ibook.book2D(
-       "BTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR2", "; Outer R [cm]; DeltaZ [cm]", 120, 0., 120., 1000, -40., 40);
-
-     meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi22_ = ibook.book1D(
-       "BTLTrackMatchedTPmtdDirectWrongAssocTimeChi22",
-       "Time chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Chi2 ",
-       200,
-       0.,
-       100);
-     meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual2_ = ibook.book2D(
-       "BTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual2", "Time chi2 vs MVA of tracks matched to TP with sim hit in MTD (direct), wrong track-MTD association; Chi2; MVAQual ",
-       200, 0., 100, 100, -1, 1);
-     meBTLTrackMatchedTPmtdDirectWrongAssocSpaceChi22_ = ibook.book1D(
-       "BTLTrackMatchedTPmtdDirectWrongAssocSpaceChi22",
-       "Space chi2 of tracks matched to TP with sim hit in MTD (direct), wrong track-MTD association; Chi2 ",
-       250,
-       0.,
-       250.);
-      meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta2_ = ibook.book2D(
-      "BTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta2", "MTD Track pathlength vs MTD track Eta;|#eta|;Pathlength", 30, 0, 1.5,350, 0.0, 350.0);
-     meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLength2_ = ibook.book1D(
-      "BTLTrackMatchedTPmtdDirectWrongAssocTrackPathLength2", "MTD Track pathlength ; ;Pathlength", 400, 0, 400);
-
-
-
-    meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf3_ = ibook.book1D(
-       "BTLTrackMatchedTPmtdDirectWrongAssocTrackNdf3",
-       "Chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Ndof ",
-       80,
-       0.,
-       220);
-    meBTLTrackMatchedTPmtdDirectWrongAssocTrackChi23_ = ibook.book1D(
-       "BTLTrackMatchedTPmtdDirectWrongAssocTrackChi23",
-       "Chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Chi2 ",
-       80,
-       0.,
-       220);
-    meBTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR3_ = ibook.book1D(
-       "BTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR3",
-       "Outermost hit position R of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; R [cm]",
-       40,
-       0.,
-       120);
-    meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff3_ = ibook.book1D(
-        "BTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff3",
-        "Track Id offset of reco (wrong) cluster associated to the track (direct)  - wrong track-MTD association; trackId (wrong)",
-        6,
-        -1.,
-        5.);
-    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ3_ = ibook.book1D(
-         "BTLTrackMatchedTPmtdDirectWrongAssocDeltaZ3",
-         "Z of sim matched wrong cluster - Z of true sim cluster (direct) - wrong track-MTD association; DeltaZ (wrong - true) [cm]",
-         1000,
-         -50.,
-	 50.);
-    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi3_ = ibook.book1D(
-         "BTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi3",
-         "Phi of sim matched wrong cluster - Z of true sim cluster - wrong track-MTD association; DeltaPhi (wrong - true) ",
-         500,
-         -0.1,
-         0.1);
-    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT3_ = ibook.book1D(
-         "BTLTrackMatchedTPmtdDirectWrongAssocDeltaT3",
-         "Time of sim matched wrong cluster - time of true sim cluster (direct) - wrong track-MTD association; DeltaT (wrong - true) [ns]",
-         480,
-         -0.6,
-         0.6);
-    meBTLTrackMatchedTPmtdDirectWrongAssocEta3_ =
-       ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocEta3",
-                    "Eta of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association;#eta_{RECO}",
-                    30,
-                    0.,
-                    1.5);
-    meBTLTrackMatchedTPmtdDirectWrongAssocPt3_ = ibook.book1D(
-       "BTLTrackMatchedTPmtdDirectWrongAssocPt3",
-       "Pt of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association;track pt [GeV]",
-       50,
-       0.,
-       10.);
-    meBTLTrackMatchedTPmtdDirectWrongAssocMVAQual3_ =
-       ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocMVAQual3",
-                    "MVA of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; MVA score",
-                    100,
-                    -1.,
-                    1.);
-    meBTLTrackMatchedTPmtdDirectWrongAssocTimeRes3_ =
-       ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocTimeRes3",
-                    "Time resolution of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD "
-                    "association; t_{rec} - t_{sim} [ns] ",
-                    240,
-                    -0.3,
-                    0.3);
-    meBTLTrackMatchedTPmtdDirectWrongAssocTimePull3_ =
-      ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocTimePull3",
-                   "Time pull of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; "
-                   "(t_{rec}-t_{sim})/#sigma_{t}",
-                   50,
-                   -5.,
-                   5.);
-    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR3_ = ibook.book2D(
-       "BTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR3", "; Outer R [cm]; DeltaZ [cm]", 120, 0., 120., 1000, -40., 40);
-    meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi23_ = ibook.book1D(
-       "BTLTrackMatchedTPmtdDirectWrongAssocTimeChi23",
-       "Time chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Chi2 ",
-       200,
-       0.,
-       100);
-      meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual3_ = ibook.book2D(
-       "BTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual3", "Time chi2 vs MVA of tracks matched to TP with sim hit in MTD (direct), wrong track-MTD association; Chi2; MVAQual ",
-       200, 0., 100, 100, -1, 1);
-   
-
-    meBTLTrackMatchedTPmtdDirectWrongAssocSpaceChi23_ = ibook.book1D(
-       "BTLTrackMatchedTPmtdDirectWrongAssocSpaceChi23",
-       "Space chi2 of tracks matched to TP with sim hit in MTD (direct), wrong track-MTD association; Chi2 ",
-       250,
-       0.,
-       250.);
-    meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta3_ = ibook.book2D(
-      "BTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta3", "MTD Track pathlength vs MTD track Eta;|#eta|;Pathlength", 30, 0, 1.5,350, 0.0, 350.0);
-    meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLength3_ = ibook.book1D(
-      "BTLTrackMatchedTPmtdDirectWrongAssocTrackPathLength3", "MTD Track pathlength ; ;Pathlength", 400, 0, 400);
-
-
-
- 
-    meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf_ = ibook.book1D(
-       "BTLTrackMatchedTPmtdDirectWrongAssocTrackNdf",
-       "Chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Ndof ",
-       80,
-       0.,
-       220);
-    meBTLTrackMatchedTPmtdDirectWrongAssocTrackChi2_ = ibook.book1D(
-       "BTLTrackMatchedTPmtdDirectWrongAssocTrackChi2",
-       "Chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Chi2 ",
-       80,
-       0.,
-       220);
-    meBTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR_ = ibook.book1D(
-       "BTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR",
-       "Outermost hit position R of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; R [cm]",
-       40,
-       0.,
-       120);
-     meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff_ = ibook.book1D(
-        "BTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff",
-        "Track Id offset of reco (wrong) cluster associated to the track (direct)  - wrong track-MTD association; trackId (wrong)",
-        6,
-        -1.,
-        5.);
-    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ_ = ibook.book1D(
-         "BTLTrackMatchedTPmtdDirectWrongAssocDeltaZ",
-         "Z of sim matched wrong cluster - Z of true sim cluster (direct) - wrong track-MTD association; DeltaZ (wrong - true) [cm]",
-         1000,
-         -50.,
-         50.);
-   meBTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi_ = ibook.book1D(
-        "BTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi",
-        "Phi of sim matched wrong cluster - Z of true sim cluster - wrong track-MTD association; DeltaPhi (wrong - true) ",
-        500,
-        -0.1,
-        0.1);
-    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT_ = ibook.book1D(
-         "BTLTrackMatchedTPmtdDirectWrongAssocDeltaT",
-         "Time of sim matched wrong cluster - time of true sim cluster (direct) - wrong track-MTD association; DeltaT (wrong - true) [ns]",
-         480,
-         -0.6,
-         0.6);
-    meBTLTrackMatchedTPmtdDirectWrongAssocSimClusSize_ =  ibook.book1D(
-        "BTLTrackMatchedTPmtdDirectWrongAssocSimClusSize",
-        "Size of the sim clusters associated to the reco cluster associated to the track (direct) - wrong track-MTD association; Number of clusters ",
+    meBTLTrackMatchedTPmtdDirectCorrectAssocTrackNdf_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectCorrectAssocTrackNdf",
+                     "Ndf of tracks matched to TP with sim hit in MTD (direct), correct track-MTD association; Ndof ",
+                     80,
+                     0.,
+                     220);
+    meBTLTrackMatchedTPmtdDirectCorrectAssocTrackChi2_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectCorrectAssocTrackChi2",
+                     "Chi2 of tracks matched to TP with sim hit in MTD (direct), correct track-MTD association; Chi2 ",
+                     80,
+                     0.,
+                     220);
+    meBTLTrackMatchedTPmtdDirectCorrectAssocTrackOutermostHitR_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectCorrectAssocTrackOutermostHitR",
+                     "Outermost hit position R of tracks matched to TP with sim hit in MTD (direct), correct track-MTD "
+                     "association; R [cm] ",
+                     40,
+                     0.,
+                     120);
+    meBTLTrackMatchedTPmtdDirectCorrectAssocSimClusSize_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectCorrectAssocSimClusSize",
+                     "Size of the sim clusters associated to the reco cluster associated to the track (direct), "
+                     "correct track-MTD association; Number of clusters ",
+                     10,
+                     -5.,
+                     5.);
+    meBTLTrackMatchedTPmtdDirectCorrectAssocRecoClusSize_ = ibook.book1D(
+        "BTLTrackMatchedTPmtdDirectCorrectAssocRecoClusSize",
+        "Size of the reco cluster associated to the track (direct), correct track-MTD association; Number of clusters ",
         10,
         -5.,
         5.);
-    meBTLTrackMatchedTPmtdDirectWrongAssocRecoClusSize_ =  ibook.book1D(
+    meBTLTrackMatchedTPmtdDirectCorrectAssocTimeChi2_ = ibook.book1D(
+        "BTLTrackMatchedTPmtdDirectCorrectAssocTimeChi2",
+        "Time chi2 of tracks matched to TP with sim hit in MTD (direct), correct track-MTD association; Chi2 ",
+        200,
+        0.,
+        100);
+    meBTLTrackMatchedTPmtdDirectCorrectAssocTimeChi2vsMVAQual_ =
+        ibook.book2D("BTLTrackMatchedTPmtdDirectCorrectAssocTimeChi2vsMVAQual",
+                     "Time chi2 vs MVA of tracks matched to TP with sim hit in MTD (direct), correct track-MTD "
+                     "association; Chi2; MVAQual ",
+                     200,
+                     0.,
+                     100,
+                     100,
+                     -1,
+                     1);
+
+    meBTLTrackMatchedTPmtdDirectCorrectAssocSpaceChi2_ = ibook.book1D(
+        "BTLTrackMatchedTPmtdDirectCorrectAssocSpaceChi2",
+        "Space chi2 of tracks matched to TP with sim hit in MTD (direct), correct track-MTD association; Chi2 ",
+        250,
+        0.,
+        250.);
+    meBTLTrackMatchedTPmtdDirectCorrectAssocTrackPathLengthvsEta_ =
+        ibook.book2D("BTLTrackMatchedTPmtdDirectCorrectAssocTrackPathLengthvsEta",
+                     "MTD Track pathlength vs MTD track Eta;|#eta|;Pathlength",
+                     30,
+                     0,
+                     1.5,
+                     350,
+                     0.0,
+                     350.0);
+    meBTLTrackMatchedTPmtdDirectCorrectAssocTrackPathLength_ = ibook.book1D(
+        "BTLTrackMatchedTPmtdDirectCorrectAssocTrackPathLength", "MTD Track pathlength ; ;Pathlength", 400, 0, 400);
+
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf1_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocTrackNdf1",
+                     "Ndf of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Ndof ",
+                     80,
+                     0.,
+                     220);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackChi21_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocTrackChi21",
+                     "Chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Chi2 ",
+                     80,
+                     0.,
+                     220);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR1_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR1",
+                     "Outermost hit position R of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD "
+                     "association; R [cm]",
+                     40,
+                     0.,
+                     120);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff1_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff1",
+                     "Track Id offset of reco (wrong) cluster associated to the track (direct)  - wrong track-MTD "
+                     "association; trackId (wrong)",
+                     6,
+                     -1.,
+                     5.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ1_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocDeltaZ1",
+                     "Z of sim matched wrong cluster - Z of true sim cluster (direct) - wrong track-MTD association; "
+                     "DeltaZ (wrong - true) [cm]",
+                     1000,
+                     -50.,
+                     50.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi1_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi1",
+                     "Phi of sim matched wrong cluster - Z of true sim cluster - wrong track-MTD association; DeltaPhi "
+                     "(wrong - true) ",
+                     500,
+                     -0.1,
+                     0.1);
+    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT1_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocDeltaT1",
+                     "Time of sim matched wrong cluster - time of true sim cluster (direct) - wrong track-MTD "
+                     "association; DeltaT (wrong - true) [ns]",
+                     480,
+                     -0.6,
+                     0.6);
+    meBTLTrackMatchedTPmtdDirectWrongAssocEta1_ = ibook.book1D(
+        "BTLTrackMatchedTPmtdDirectWrongAssocEta1",
+        "Eta of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association;#eta_{RECO}",
+        30,
+        0.,
+        1.5);
+    meBTLTrackMatchedTPmtdDirectWrongAssocPt1_ = ibook.book1D(
+        "BTLTrackMatchedTPmtdDirectWrongAssocPt1",
+        "Pt of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association;track pt [GeV]",
+        50,
+        0.,
+        10.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocMVAQual1_ = ibook.book1D(
+        "BTLTrackMatchedTPmtdDirectWrongAssocMVAQual1",
+        "MVA of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; MVA score",
+        100,
+        -1.,
+        1.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTimeRes1_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocTimeRes1",
+                     "Time resolution of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD "
+                     "association; t_{rec} - t_{sim} [ns] ",
+                     240,
+                     -0.3,
+                     0.3);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTimePull1_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocTimePull1",
+                     "Time pull of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; "
+                     "(t_{rec}-t_{sim})/#sigma_{t}",
+                     50,
+                     -5.,
+                     5.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR1_ = ibook.book2D(
+        "BTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR1", "; Outer R [cm]; DeltaZ [cm]", 120, 0., 120., 1000, -40., 40);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta1_ =
+        ibook.book2D("BTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta1",
+                     "MTD Track pathlength vs MTD track Eta;|#eta|;Pathlength",
+                     30,
+                     0,
+                     1.5,
+                     350,
+                     0.0,
+                     350.0);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLength1_ = ibook.book1D(
+        "BTLTrackMatchedTPmtdDirectWrongAssocTrackPathLength1", "MTD Track pathlength ; ;Pathlength", 400, 0, 400);
+
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf2_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocTrackNdf2",
+                     "Chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Ndof ",
+                     80,
+                     0.,
+                     220);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackChi22_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocTrackChi22",
+                     "Chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Chi2 ",
+                     80,
+                     0.,
+                     220);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi21_ = ibook.book1D(
+        "BTLTrackMatchedTPmtdDirectWrongAssocTimeChi21",
+        "Time chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Chi2 ",
+        200,
+        0.,
+        100);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual1_ =
+        ibook.book2D("BTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual1",
+                     "Time chi2 vs MVA of tracks matched to TP with sim hit in MTD (direct), wrong track-MTD "
+                     "association; Chi2; MVAQual ",
+                     200,
+                     0.,
+                     100,
+                     100,
+                     -1,
+                     1);
+    meBTLTrackMatchedTPmtdDirectWrongAssocSpaceChi21_ = ibook.book1D(
+        "BTLTrackMatchedTPmtdDirectWrongAssocSpaceChi21",
+        "Space chi2 of tracks matched to TP with sim hit in MTD (direct), wrong track-MTD association; Chi2 ",
+        250,
+        0.,
+        250.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR2_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR2",
+                     "Outermost hit position R of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD "
+                     "association; R [cm]",
+                     40,
+                     0.,
+                     120);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff2_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff2",
+                     "Track Id offset of reco (wrong) cluster associated to the track (direct)  - wrong track-MTD "
+                     "association; trackId (wrong)",
+                     6,
+                     -1.,
+                     5.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ2_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocDeltaZ2",
+                     "Z of sim matched wrong cluster - Z of true sim cluster (direct) - wrong track-MTD association; "
+                     "DeltaZ (wrong - true) [cm]",
+                     1000,
+                     -50.,
+                     50.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi2_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi2",
+                     "Phi of sim matched wrong cluster - Z of true sim cluster - wrong track-MTD association; DeltaPhi "
+                     "(wrong - true) ",
+                     500,
+                     -0.1,
+                     0.1);
+    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT2_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocDeltaT2",
+                     "Time of sim matched wrong cluster - time of true sim cluster (direct) - wrong track-MTD "
+                     "association; DeltaT (wrong - true) [ns]",
+                     480,
+                     -0.6,
+                     0.6);
+    meBTLTrackMatchedTPmtdDirectWrongAssocEta2_ = ibook.book1D(
+        "BTLTrackMatchedTPmtdDirectWrongAssocEta2",
+        "Eta of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association;#eta_{RECO}",
+        30,
+        0.,
+        1.5);
+    meBTLTrackMatchedTPmtdDirectWrongAssocPt2_ = ibook.book1D(
+        "BTLTrackMatchedTPmtdDirectWrongAssocPt2",
+        "Pt of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association;track pt [GeV]",
+        50,
+        0.,
+        10.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocMVAQual2_ = ibook.book1D(
+        "BTLTrackMatchedTPmtdDirectWrongAssocMVAQual2",
+        "MVA of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; MVA score",
+        100,
+        -1.,
+        1.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTimeRes2_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocTimeRes2",
+                     "Time resolution of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD "
+                     "association; t_{rec} - t_{sim} [ns] ",
+                     240,
+                     -0.3,
+                     0.3);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTimePull2_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocTimePull2",
+                     "Time pull of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; "
+                     "(t_{rec}-t_{sim})/#sigma_{t}",
+                     50,
+                     -5.,
+                     5.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR2_ = ibook.book2D(
+        "BTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR2", "; Outer R [cm]; DeltaZ [cm]", 120, 0., 120., 1000, -40., 40);
+
+    meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi22_ = ibook.book1D(
+        "BTLTrackMatchedTPmtdDirectWrongAssocTimeChi22",
+        "Time chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Chi2 ",
+        200,
+        0.,
+        100);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual2_ =
+        ibook.book2D("BTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual2",
+                     "Time chi2 vs MVA of tracks matched to TP with sim hit in MTD (direct), wrong track-MTD "
+                     "association; Chi2; MVAQual ",
+                     200,
+                     0.,
+                     100,
+                     100,
+                     -1,
+                     1);
+    meBTLTrackMatchedTPmtdDirectWrongAssocSpaceChi22_ = ibook.book1D(
+        "BTLTrackMatchedTPmtdDirectWrongAssocSpaceChi22",
+        "Space chi2 of tracks matched to TP with sim hit in MTD (direct), wrong track-MTD association; Chi2 ",
+        250,
+        0.,
+        250.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta2_ =
+        ibook.book2D("BTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta2",
+                     "MTD Track pathlength vs MTD track Eta;|#eta|;Pathlength",
+                     30,
+                     0,
+                     1.5,
+                     350,
+                     0.0,
+                     350.0);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLength2_ = ibook.book1D(
+        "BTLTrackMatchedTPmtdDirectWrongAssocTrackPathLength2", "MTD Track pathlength ; ;Pathlength", 400, 0, 400);
+
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf3_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocTrackNdf3",
+                     "Chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Ndof ",
+                     80,
+                     0.,
+                     220);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackChi23_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocTrackChi23",
+                     "Chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Chi2 ",
+                     80,
+                     0.,
+                     220);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR3_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR3",
+                     "Outermost hit position R of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD "
+                     "association; R [cm]",
+                     40,
+                     0.,
+                     120);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff3_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff3",
+                     "Track Id offset of reco (wrong) cluster associated to the track (direct)  - wrong track-MTD "
+                     "association; trackId (wrong)",
+                     6,
+                     -1.,
+                     5.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ3_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocDeltaZ3",
+                     "Z of sim matched wrong cluster - Z of true sim cluster (direct) - wrong track-MTD association; "
+                     "DeltaZ (wrong - true) [cm]",
+                     1000,
+                     -50.,
+                     50.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi3_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi3",
+                     "Phi of sim matched wrong cluster - Z of true sim cluster - wrong track-MTD association; DeltaPhi "
+                     "(wrong - true) ",
+                     500,
+                     -0.1,
+                     0.1);
+    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT3_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocDeltaT3",
+                     "Time of sim matched wrong cluster - time of true sim cluster (direct) - wrong track-MTD "
+                     "association; DeltaT (wrong - true) [ns]",
+                     480,
+                     -0.6,
+                     0.6);
+    meBTLTrackMatchedTPmtdDirectWrongAssocEta3_ = ibook.book1D(
+        "BTLTrackMatchedTPmtdDirectWrongAssocEta3",
+        "Eta of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association;#eta_{RECO}",
+        30,
+        0.,
+        1.5);
+    meBTLTrackMatchedTPmtdDirectWrongAssocPt3_ = ibook.book1D(
+        "BTLTrackMatchedTPmtdDirectWrongAssocPt3",
+        "Pt of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association;track pt [GeV]",
+        50,
+        0.,
+        10.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocMVAQual3_ = ibook.book1D(
+        "BTLTrackMatchedTPmtdDirectWrongAssocMVAQual3",
+        "MVA of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; MVA score",
+        100,
+        -1.,
+        1.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTimeRes3_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocTimeRes3",
+                     "Time resolution of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD "
+                     "association; t_{rec} - t_{sim} [ns] ",
+                     240,
+                     -0.3,
+                     0.3);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTimePull3_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocTimePull3",
+                     "Time pull of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; "
+                     "(t_{rec}-t_{sim})/#sigma_{t}",
+                     50,
+                     -5.,
+                     5.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR3_ = ibook.book2D(
+        "BTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR3", "; Outer R [cm]; DeltaZ [cm]", 120, 0., 120., 1000, -40., 40);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi23_ = ibook.book1D(
+        "BTLTrackMatchedTPmtdDirectWrongAssocTimeChi23",
+        "Time chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Chi2 ",
+        200,
+        0.,
+        100);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual3_ =
+        ibook.book2D("BTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual3",
+                     "Time chi2 vs MVA of tracks matched to TP with sim hit in MTD (direct), wrong track-MTD "
+                     "association; Chi2; MVAQual ",
+                     200,
+                     0.,
+                     100,
+                     100,
+                     -1,
+                     1);
+
+    meBTLTrackMatchedTPmtdDirectWrongAssocSpaceChi23_ = ibook.book1D(
+        "BTLTrackMatchedTPmtdDirectWrongAssocSpaceChi23",
+        "Space chi2 of tracks matched to TP with sim hit in MTD (direct), wrong track-MTD association; Chi2 ",
+        250,
+        0.,
+        250.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta3_ =
+        ibook.book2D("BTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta3",
+                     "MTD Track pathlength vs MTD track Eta;|#eta|;Pathlength",
+                     30,
+                     0,
+                     1.5,
+                     350,
+                     0.0,
+                     350.0);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLength3_ = ibook.book1D(
+        "BTLTrackMatchedTPmtdDirectWrongAssocTrackPathLength3", "MTD Track pathlength ; ;Pathlength", 400, 0, 400);
+
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocTrackNdf",
+                     "Chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Ndof ",
+                     80,
+                     0.,
+                     220);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackChi2_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocTrackChi2",
+                     "Chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Chi2 ",
+                     80,
+                     0.,
+                     220);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR",
+                     "Outermost hit position R of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD "
+                     "association; R [cm]",
+                     40,
+                     0.,
+                     120);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff",
+                     "Track Id offset of reco (wrong) cluster associated to the track (direct)  - wrong track-MTD "
+                     "association; trackId (wrong)",
+                     6,
+                     -1.,
+                     5.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocDeltaZ",
+                     "Z of sim matched wrong cluster - Z of true sim cluster (direct) - wrong track-MTD association; "
+                     "DeltaZ (wrong - true) [cm]",
+                     1000,
+                     -50.,
+                     50.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi",
+                     "Phi of sim matched wrong cluster - Z of true sim cluster - wrong track-MTD association; DeltaPhi "
+                     "(wrong - true) ",
+                     500,
+                     -0.1,
+                     0.1);
+    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocDeltaT",
+                     "Time of sim matched wrong cluster - time of true sim cluster (direct) - wrong track-MTD "
+                     "association; DeltaT (wrong - true) [ns]",
+                     480,
+                     -0.6,
+                     0.6);
+    meBTLTrackMatchedTPmtdDirectWrongAssocSimClusSize_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocSimClusSize",
+                     "Size of the sim clusters associated to the reco cluster associated to the track (direct) - wrong "
+                     "track-MTD association; Number of clusters ",
+                     10,
+                     -5.,
+                     5.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocRecoClusSize_ = ibook.book1D(
         "BTLTrackMatchedTPmtdDirectWrongAssocRecoClusSize",
         "Size of the reco cluster associated to the track (direct) - wrong track-MTD association; Number of clusters ",
         10,
@@ -2349,130 +2414,175 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR_ = ibook.book2D(
         "BTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR", "; Outer R [cm]; DeltaZ [cm]", 120, 0., 120., 1000, -40., 40);
     meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2_ = ibook.book1D(
-       "BTLTrackMatchedTPmtdDirectWrongAssocTimeChi2",
-       "Time chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Chi2 ",
-       200,
-       0.,
-       100);
-     meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual_ = ibook.book2D(
-       "BTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual", "Time chi2 vs MVA of tracks matched to TP with sim hit in MTD (direct), wrong track-MTD association; Chi2; MVAQual ",
-       200, 0., 100, 100, -1, 1);
+        "BTLTrackMatchedTPmtdDirectWrongAssocTimeChi2",
+        "Time chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Chi2 ",
+        200,
+        0.,
+        100);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual_ =
+        ibook.book2D("BTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual",
+                     "Time chi2 vs MVA of tracks matched to TP with sim hit in MTD (direct), wrong track-MTD "
+                     "association; Chi2; MVAQual ",
+                     200,
+                     0.,
+                     100,
+                     100,
+                     -1,
+                     1);
 
     meBTLTrackMatchedTPmtdDirectWrongAssocSpaceChi2_ = ibook.book1D(
-       "BTLTrackMatchedTPmtdDirectWrongAssocSpaceChi2",
-       "Space chi2 of tracks matched to TP with sim hit in MTD (direct), wrong track-MTD association; Chi2 ",
-       250,
-       0.,
-       250.);
-    meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta_ = ibook.book2D(
-      "BTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta", "MTD Track pathlength vs MTD track Eta;|#eta|;Pathlength", 30, 0, 1.5,350,  0.0, 350.0);
+        "BTLTrackMatchedTPmtdDirectWrongAssocSpaceChi2",
+        "Space chi2 of tracks matched to TP with sim hit in MTD (direct), wrong track-MTD association; Chi2 ",
+        250,
+        0.,
+        250.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta_ =
+        ibook.book2D("BTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta",
+                     "MTD Track pathlength vs MTD track Eta;|#eta|;Pathlength",
+                     30,
+                     0,
+                     1.5,
+                     350,
+                     0.0,
+                     350.0);
     meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLength_ = ibook.book1D(
-      "BTLTrackMatchedTPmtdDirectWrongAssocTrackPathLength", "MTD Track pathlength ; ;Pathlength", 400, 0, 400);
+        "BTLTrackMatchedTPmtdDirectWrongAssocTrackPathLength", "MTD Track pathlength ; ;Pathlength", 400, 0, 400);
 
-
-
-    meBTLTrackMatchedTPmtdDirectNoAssocTrackNdf_ = ibook.book1D(
-        "BTLTrackMatchedTPmtdDirectNoAssocTrackNdf",
-        "Ndof of tracks matched to TP with sim hit in MTD (direct) - no track-MTD association; Ndof ",
-        80,
-        0.,
-        220);
-    meBTLTrackMatchedTPmtdDirectNoAssocTrackChi2_ = ibook.book1D(
-        "BTLTrackMatchedTPmtdDirectNoAssocTrackChi2",
-        "Chi2 of tracks matched to TP with sim hit in MTD (direct) - no track-MTD association; Chi2 ",
-        80,
-        0.,
-        220);
-    meBTLTrackMatchedTPmtdDirectNoAssocTrackOutermostHitR_ = ibook.book1D(
-        "BTLTrackMatchedTPmtdDirectNoAssocTrackOutermostHitR",
-        "Outermost hit position R of tracks matched to TP with sim hit in MTD (direct) - no track-MTD association; R [cm]",
-        40,
-        0.,
-        120);
-    meBTLTrackMatchedTPmtdDirectNoAssocSimClusSize_ =  ibook.book1D(
-           "BTLTrackMatchedTPmtdDirectNoAssocSimClusSize",
-           "Size of the sim clusters associated to the reco cluster associated to the track (direct) - no track-MTD association; Number of clusters ",
-           10,
-           -5.,
-           5.);
-    meBTLTrackMatchedTPmtdDirectNoAssocRecoClusSize_ =  ibook.book1D(
-           "BTLTrackMatchedTPmtdDirectNoAssocRecoClusSize",
-           "Size of the reco cluster associated to the track (direct) - no track-MTD association; Number of clusters ",
-           10,
-           -5.,
-           5.);
-
+    meBTLTrackMatchedTPmtdDirectNoAssocTrackNdf_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectNoAssocTrackNdf",
+                     "Ndof of tracks matched to TP with sim hit in MTD (direct) - no track-MTD association; Ndof ",
+                     80,
+                     0.,
+                     220);
+    meBTLTrackMatchedTPmtdDirectNoAssocTrackChi2_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectNoAssocTrackChi2",
+                     "Chi2 of tracks matched to TP with sim hit in MTD (direct) - no track-MTD association; Chi2 ",
+                     80,
+                     0.,
+                     220);
+    meBTLTrackMatchedTPmtdDirectNoAssocTrackOutermostHitR_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectNoAssocTrackOutermostHitR",
+                     "Outermost hit position R of tracks matched to TP with sim hit in MTD (direct) - no track-MTD "
+                     "association; R [cm]",
+                     40,
+                     0.,
+                     120);
+    meBTLTrackMatchedTPmtdDirectNoAssocSimClusSize_ =
+        ibook.book1D("BTLTrackMatchedTPmtdDirectNoAssocSimClusSize",
+                     "Size of the sim clusters associated to the reco cluster associated to the track (direct) - no "
+                     "track-MTD association; Number of clusters ",
+                     10,
+                     -5.,
+                     5.);
+    meBTLTrackMatchedTPmtdDirectNoAssocRecoClusSize_ = ibook.book1D(
+        "BTLTrackMatchedTPmtdDirectNoAssocRecoClusSize",
+        "Size of the reco cluster associated to the track (direct) - no track-MTD association; Number of clusters ",
+        10,
+        -5.,
+        5.);
 
     meBTLTrackMatchedTPnomtdAssocTrackChi2_ = ibook.book1D(
-       "BTLTrackMatchedTPnomtdAssocTrackChi2", "Chi2 of tracks matched to TP w/o sim hit in MTD; Chi2", 80, 0., 220);
-    meBTLTrackMatchedTPnomtdAssocTrackOutermostHitR_ = ibook.book1D(
-       "BTLTrackMatchedTPnomtdAssocTrackOutermostHitR", "Outermost hit position R of tracks matched to TP w/o sim hit in MTD; R [cm]", 40, 0., 120.);
+        "BTLTrackMatchedTPnomtdAssocTrackChi2", "Chi2 of tracks matched to TP w/o sim hit in MTD; Chi2", 80, 0., 220);
+    meBTLTrackMatchedTPnomtdAssocTrackOutermostHitR_ =
+        ibook.book1D("BTLTrackMatchedTPnomtdAssocTrackOutermostHitR",
+                     "Outermost hit position R of tracks matched to TP w/o sim hit in MTD; R [cm]",
+                     40,
+                     0.,
+                     120.);
     meBTLTrackMatchedTPnomtdAssocTrackNdf_ = ibook.book1D(
-       "BTLTrackMatchedTPnomtdAssocTrackNdf", "Ndf of tracks matched to TP w/o sim hit in MTD; Ndof", 80, 0., 220);
-    meBTLTrackMatchedTPnomtdAssocTrackIdOff_ = ibook.book1D(
-       "BTLTrackMatchedTPnomtdAssocTrackIdOff", "TrackIdOff of simCluster matched to the reco cluster associated to the track,  TP w/o sim hit in MTD; Track Id Off", 6, -1., 5.);
-    meBTLTrackMatchedTPnomtdAssocSimClusSize_ =  ibook.book1D(
-          "BTLTrackMatchedTPnomtdAssocSimClusSize",
-          "Size of the sim clusters associated to the reco cluster associated to the track (direct),  TP w/o sim hit in MTD; Number of clusters ",
-          10,
-          -5.,
-          5.);
-    meBTLTrackMatchedTPnomtdAssocRecoClusSize_ =  ibook.book1D(
-          "BTLTrackMatchedTPnomtdAssocRecoClusSize",
-          "Size of the reco cluster associated to the track (direct),  TP w/o sim hit in MTD; Number of clusters ",
-          10,
-          -5.,
-          5.);
-    meBTLTrackMatchedTPnomtdAssocTrackID_ = ibook.book1D(
-          "BTLTrackMatchedTPnomtdAssocTrackID", 
- 	  "Diff track raw ID, TP w/o sim hit in MTD ; diff track raw Id",
- 	  5,
-         -1., 
- 	  4.);
+        "BTLTrackMatchedTPnomtdAssocTrackNdf", "Ndf of tracks matched to TP w/o sim hit in MTD; Ndof", 80, 0., 220);
+    meBTLTrackMatchedTPnomtdAssocTrackIdOff_ =
+        ibook.book1D("BTLTrackMatchedTPnomtdAssocTrackIdOff",
+                     "TrackIdOff of simCluster matched to the reco cluster associated to the track,  TP w/o sim hit in "
+                     "MTD; Track Id Off",
+                     6,
+                     -1.,
+                     5.);
+    meBTLTrackMatchedTPnomtdAssocSimClusSize_ =
+        ibook.book1D("BTLTrackMatchedTPnomtdAssocSimClusSize",
+                     "Size of the sim clusters associated to the reco cluster associated to the track (direct),  TP "
+                     "w/o sim hit in MTD; Number of clusters ",
+                     10,
+                     -5.,
+                     5.);
+    meBTLTrackMatchedTPnomtdAssocRecoClusSize_ = ibook.book1D(
+        "BTLTrackMatchedTPnomtdAssocRecoClusSize",
+        "Size of the reco cluster associated to the track (direct),  TP w/o sim hit in MTD; Number of clusters ",
+        10,
+        -5.,
+        5.);
+    meBTLTrackMatchedTPnomtdAssocTrackID_ = ibook.book1D("BTLTrackMatchedTPnomtdAssocTrackID",
+                                                         "Diff track raw ID, TP w/o sim hit in MTD ; diff track raw Id",
+                                                         5,
+                                                         -1.,
+                                                         4.);
 
     meETLTrackMatchedTPmtd1CorrectAssocTimeChi2_ = ibook.book1D(
-       "ETLTrackMatchedTPmtd1CorrectAssocTimeChi2",
-       "Time chi2 of tracks matched to TP with sim hit in MTD (direct) - correct track-MTD association; Chi2 ",
-       200,
-       0.,
-       100);
-     meETLTrackMatchedTPmtd1CorrectAssocTimeChi2vsMVAQual_ = ibook.book2D(
-       "ETLTrackMatchedTPmtd1CorrectAssocTimeChi2vsMVAQual", "Time chi2 of tracks matched to TP with sim hit in MTD (direct) - correct track-MTD association; Chi2; MVAQual ",
-       200, 0., 100, 100, -1, 1);
+        "ETLTrackMatchedTPmtd1CorrectAssocTimeChi2",
+        "Time chi2 of tracks matched to TP with sim hit in MTD (direct) - correct track-MTD association; Chi2 ",
+        200,
+        0.,
+        100);
+    meETLTrackMatchedTPmtd1CorrectAssocTimeChi2vsMVAQual_ =
+        ibook.book2D("ETLTrackMatchedTPmtd1CorrectAssocTimeChi2vsMVAQual",
+                     "Time chi2 of tracks matched to TP with sim hit in MTD (direct) - correct track-MTD association; "
+                     "Chi2; MVAQual ",
+                     200,
+                     0.,
+                     100,
+                     100,
+                     -1,
+                     1);
 
     meETLTrackMatchedTPmtd1WrongAssocTimeChi2_ = ibook.book1D(
-       "ETLTrackMatchedTPmtd1WrongAssocTimeChi2",
-       "Time chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Chi2 ",
-       200,
-       0.,
-       100);
-     meETLTrackMatchedTPmtd1WrongAssocTimeChi2vsMVAQual_ = ibook.book2D(
-       "ETLTrackMatchedTPmtd1WrongAssocTimeChi2vsMVAQual", "Time chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Chi2; MVAQual ",
-       200, 0., 100, 100, -1, 1);
-
-
+        "ETLTrackMatchedTPmtd1WrongAssocTimeChi2",
+        "Time chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Chi2 ",
+        200,
+        0.,
+        100);
+    meETLTrackMatchedTPmtd1WrongAssocTimeChi2vsMVAQual_ = ibook.book2D(
+        "ETLTrackMatchedTPmtd1WrongAssocTimeChi2vsMVAQual",
+        "Time chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Chi2; MVAQual ",
+        200,
+        0.,
+        100,
+        100,
+        -1,
+        1);
 
     meETLTrackMatchedTPmtd2CorrectAssocTimeChi2_ = ibook.book1D(
-       "ETLTrackMatchedTPmtd2CorrectAssocTimeChi2",
-       "Time chi2 of tracks matched to TP with sim hit in MTD (direct) - correct track-MTD association; Chi2 ",
-       200,
-       0.,
-       100);
-     meETLTrackMatchedTPmtd2CorrectAssocTimeChi2vsMVAQual_ = ibook.book2D(
-       "ETLTrackMatchedTPmtd2CorrectAssocTimeChi2vsMVAQual", "Time chi2 of tracks matched to TP with sim hit in MTD (direct) - correct track-MTD association; Chi2; MVAQual ",
-       200, 0., 100, 100, -1, 1);
-
+        "ETLTrackMatchedTPmtd2CorrectAssocTimeChi2",
+        "Time chi2 of tracks matched to TP with sim hit in MTD (direct) - correct track-MTD association; Chi2 ",
+        200,
+        0.,
+        100);
+    meETLTrackMatchedTPmtd2CorrectAssocTimeChi2vsMVAQual_ =
+        ibook.book2D("ETLTrackMatchedTPmtd2CorrectAssocTimeChi2vsMVAQual",
+                     "Time chi2 of tracks matched to TP with sim hit in MTD (direct) - correct track-MTD association; "
+                     "Chi2; MVAQual ",
+                     200,
+                     0.,
+                     100,
+                     100,
+                     -1,
+                     1);
 
     meETLTrackMatchedTPmtd2WrongAssocTimeChi2_ = ibook.book1D(
-       "ETLTrackMatchedTPmtd2WrongAssocTimeChi2",
-       "Time chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Chi2 ",
-       200,
-       0.,
-       100);
-     meETLTrackMatchedTPmtd2WrongAssocTimeChi2vsMVAQual_ = ibook.book2D(
-       "ETLTrackMatchedTPmtd2WrongAssocTimeChi2vsMVAQual", "Time chi2 vs MVA of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Chi2; MVAQual ",
-       200, 0., 100, 100, -1, 1);
-
+        "ETLTrackMatchedTPmtd2WrongAssocTimeChi2",
+        "Time chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Chi2 ",
+        200,
+        0.,
+        100);
+    meETLTrackMatchedTPmtd2WrongAssocTimeChi2vsMVAQual_ =
+        ibook.book2D("ETLTrackMatchedTPmtd2WrongAssocTimeChi2vsMVAQual",
+                     "Time chi2 vs MVA of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD "
+                     "association; Chi2; MVAQual ",
+                     200,
+                     0.,
+                     100,
+                     100,
+                     -1,
+                     1);
 
   }  // end optional plots
 

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -232,7 +232,7 @@ private:
   MonitorElement* meTrackNumHits_;
   MonitorElement* meTrackNumHitsNT_;
   MonitorElement* meTrackMVAQual_;
-  MonitorElement* meTrackPathLenghtvsEta_;
+  MonitorElement* meTrackPathLengthvsEta_;
   MonitorElement* meTrackOutermostHitR_;
   MonitorElement* meTrackOutermostHitZ_;
 
@@ -299,8 +299,8 @@ private:
   MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocTrackNdf_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocSimClusSize_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocRecoClusSize_;
-  MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocTrackPathLenghtvsEta_;
-  MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocTrackPathLenght_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocTrackPathLengthvsEta_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocTrackPathLength_;
 
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocEta_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocPt_;
@@ -320,8 +320,8 @@ private:
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocSimClusSize_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocRecoClusSize_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR_;
-  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenghtvsEta_;
-  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenght_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLength_;
   
   // wrong association with reco from same TP direct hit
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocEta1_;
@@ -340,8 +340,8 @@ private:
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocSpaceChi21_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf1_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR1_;
-  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenghtvsEta1_;
-  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenght1_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta1_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLength1_;
 
   // wrong association with reco from same TP other hit
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocEta2_;
@@ -360,8 +360,8 @@ private:
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocSpaceChi22_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf2_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR2_;
-  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenghtvsEta2_;
-  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenght2_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta2_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLength2_;
 
   // wrong association to reco from another TP
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocEta3_;
@@ -380,8 +380,8 @@ private:
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocSpaceChi23_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf3_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR3_;
-  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenghtvsEta3_;
-  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenght3_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta3_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLength3_;
 
   MonitorElement* meBTLTrackMatchedTPmtdDirectNoAssocEta_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectNoAssocPt_;
@@ -635,7 +635,7 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
       meTrackSigmaTofvsP_[1]->Fill(trackGen.p(), SigmaTofK[trackref] * 1e3);
       meTrackSigmaTofvsP_[2]->Fill(trackGen.p(), SigmaTofP[trackref] * 1e3);
 
-      meTrackPathLenghtvsEta_->Fill(std::abs(trackGen.eta()), pathLength[trackref]);
+      meTrackPathLengthvsEta_->Fill(std::abs(trackGen.eta()), pathLength[trackref]);
       bool MTDEtlZnegD1 = false;
       bool MTDEtlZnegD2 = false;
       bool MTDEtlZposD1 = false;
@@ -864,6 +864,8 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
 
         auto simClustersRefsIt = tp2SimAssociationMap.find(*tp_info);
         const bool withMTD = (simClustersRefsIt != tp2SimAssociationMap.end());
+
+	// If there is a mtdSimLayerCluster from the tracking particle
         if (withMTD) {
           // -- Get the refs to MtdSimLayerClusters associated to the TP
           std::vector<edm::Ref<MtdSimLayerClusterCollection>> simClustersRefs;
@@ -990,8 +992,8 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
                     meBTLTrackMatchedTPmtdDirectCorrectAssocTimeChi2_->Fill(btlMatchTimeChi2[trackref]);
                     meBTLTrackMatchedTPmtdDirectCorrectAssocTimeChi2vsMVAQual_->Fill(btlMatchTimeChi2[trackref],  mtdQualMVA[trackref]);
                     meBTLTrackMatchedTPmtdDirectCorrectAssocSpaceChi2_->Fill(btlMatchChi2[trackref]);
-                    meBTLTrackMatchedTPmtdDirectCorrectAssocTrackPathLenghtvsEta_->Fill(std::abs(trackGen.eta()), pathLength[trackref]);
-                    meBTLTrackMatchedTPmtdDirectCorrectAssocTrackPathLenght_->Fill(pathLength[trackref]);
+                    meBTLTrackMatchedTPmtdDirectCorrectAssocTrackPathLengthvsEta_->Fill(std::abs(trackGen.eta()), pathLength[trackref]);
+                    meBTLTrackMatchedTPmtdDirectCorrectAssocTrackPathLength_->Fill(pathLength[trackref]);
 
 		  }
                   fillTrackClusterMatchingHistograms(meBTLTrackMatchedTPmtdDirectCorrectAssocEta_,
@@ -1022,8 +1024,8 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
                     meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2_->Fill(btlMatchTimeChi2[trackref]);
                     meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual_->Fill(btlMatchTimeChi2[trackref],  mtdQualMVA[trackref]);
                     meBTLTrackMatchedTPmtdDirectWrongAssocSpaceChi2_->Fill(btlMatchChi2[trackref]);
-                    meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenghtvsEta_->Fill(std::abs(trackGen.eta()), pathLength[trackref]);
-                    meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenght_->Fill(pathLength[trackref]);
+                    meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta_->Fill(std::abs(trackGen.eta()), pathLength[trackref]);
+                    meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLength_->Fill(pathLength[trackref]);
 
 
 
@@ -1052,8 +1054,8 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
                       meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi21_->Fill(btlMatchTimeChi2[trackref]);
                       meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual1_->Fill(btlMatchTimeChi2[trackref],  mtdQualMVA[trackref]);
                       meBTLTrackMatchedTPmtdDirectWrongAssocSpaceChi21_->Fill(btlMatchChi2[trackref]);
-                      meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenghtvsEta1_->Fill(std::abs(trackGen.eta()), pathLength[trackref]);
-                      meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenght1_->Fill(pathLength[trackref]);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta1_->Fill(std::abs(trackGen.eta()), pathLength[trackref]);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLength1_->Fill(pathLength[trackref]);
 
                     } else if (simClusterRef_RecoMatch_trackIdOff > 0 && isFromSameTP){
 
@@ -1081,8 +1083,8 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
                       meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi22_->Fill(btlMatchTimeChi2[trackref]);
                       meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual2_->Fill(btlMatchTimeChi2[trackref],  mtdQualMVA[trackref]);
                       meBTLTrackMatchedTPmtdDirectWrongAssocSpaceChi22_->Fill(btlMatchChi2[trackref]);
-                      meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenghtvsEta2_->Fill(std::abs(trackGen.eta()), pathLength[trackref]);
-                      meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenght2_->Fill(pathLength[trackref]);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta2_->Fill(std::abs(trackGen.eta()), pathLength[trackref]);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLength2_->Fill(pathLength[trackref]);
 
 
 
@@ -1111,8 +1113,8 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
                       meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi23_->Fill(btlMatchTimeChi2[trackref]);
                       meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual3_->Fill(btlMatchTimeChi2[trackref],  mtdQualMVA[trackref]);
                       meBTLTrackMatchedTPmtdDirectWrongAssocSpaceChi23_->Fill(btlMatchChi2[trackref]);
-                      meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenghtvsEta3_->Fill(std::abs(trackGen.eta()), pathLength[trackref]);
-                      meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenght3_->Fill(pathLength[trackref]);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta3_->Fill(std::abs(trackGen.eta()), pathLength[trackref]);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLength3_->Fill(pathLength[trackref]);
 		    }
 
                   }
@@ -1725,8 +1727,8 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
   meTrackNumHitsNT_ = ibook.book1D(
       "TrackNumHitsNT", "Number of valid MTD hits per track no time associated; Number of hits", 10, -5, 5);
   meTrackMVAQual_ = ibook.book1D("TrackMVAQual", "Track MVA Quality as stored in Value Map ; MVAQual", 100, -1, 1);
-  meTrackPathLenghtvsEta_ = ibook.bookProfile(
-      "TrackPathLenghtvsEta", "MTD Track pathlength vs MTD track Eta;|#eta|;Pathlength", 100, 0, 3.2, 100.0, 400.0, "S");
+  meTrackPathLengthvsEta_ = ibook.bookProfile(
+      "TrackPathLengthvsEta", "MTD Track pathlength vs MTD track Eta;|#eta|;Pathlength", 100, 0, 3.2, 100.0, 400.0, "S");
 
   meTrackOutermostHitR_ = ibook.book1D("TrackOutermostHitR", "Track outermost hit position R; R[cm]", 40, 0, 120.);
   meTrackOutermostHitZ_ = ibook.book1D("TrackOutermostHitZ", "Track outermost hit position Z; z[cm]", 100, 0, 300.);
@@ -1977,7 +1979,7 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
        0.,
        100);
      meBTLTrackMatchedTPmtdDirectCorrectAssocTimeChi2vsMVAQual_ = ibook.book2D(
-       "BTLTrackMatchedTPmtdDirectCorrectAssocTimeChi2vsMVAQual", "Time chi2 of tracks matched to TP with sim hit in MTD (direct), correct track-MTD association; Chi2; MVAQual ",
+       "BTLTrackMatchedTPmtdDirectCorrectAssocTimeChi2vsMVAQual", "Time chi2 vs MVA of tracks matched to TP with sim hit in MTD (direct), correct track-MTD association; Chi2; MVAQual ",
        200, 0., 100, 100, -1, 1);
    
     meBTLTrackMatchedTPmtdDirectCorrectAssocSpaceChi2_ = ibook.book1D(
@@ -1986,10 +1988,10 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
        250,
        0.,
        250.);
-    meBTLTrackMatchedTPmtdDirectCorrectAssocTrackPathLenghtvsEta_ = ibook.book2D(
-      "BTLTrackMatchedTPmtdDirectCorrectAssocTrackPathLenghtvsEta", "MTD Track pathlength vs MTD track Eta;|#eta|;Pathlength", 30, 0, 1.5, 350, 0.0, 350.0);
-    meBTLTrackMatchedTPmtdDirectCorrectAssocTrackPathLenght_ = ibook.book1D(
-      "BTLTrackMatchedTPmtdDirectCorrectAssocTrackPathLenght", "MTD Track pathlength ; ;Pathlength", 400, 0, 400);
+    meBTLTrackMatchedTPmtdDirectCorrectAssocTrackPathLengthvsEta_ = ibook.book2D(
+      "BTLTrackMatchedTPmtdDirectCorrectAssocTrackPathLengthvsEta", "MTD Track pathlength vs MTD track Eta;|#eta|;Pathlength", 30, 0, 1.5, 350, 0.0, 350.0);
+    meBTLTrackMatchedTPmtdDirectCorrectAssocTrackPathLength_ = ibook.book1D(
+      "BTLTrackMatchedTPmtdDirectCorrectAssocTrackPathLength", "MTD Track pathlength ; ;Pathlength", 400, 0, 400);
 
 
     meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf1_ = ibook.book1D(
@@ -2068,10 +2070,10 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
                     5.);
     meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR1_ = ibook.book2D(
        "BTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR1", "; Outer R [cm]; DeltaZ [cm]", 120, 0., 120., 1000, -40., 40);
-    meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenghtvsEta1_ = ibook.book2D(
-      "BTLTrackMatchedTPmtdDirectCorrectAssocTrackPathLenghtvsEta1", "MTD Track pathlength vs MTD track Eta;|#eta|;Pathlength", 30, 0, 1.5, 350, 0.0, 350.0);
-    meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenght1_ = ibook.book1D(
-      "BTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenght1", "MTD Track pathlength ; ;Pathlength", 400, 0, 400);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta1_ = ibook.book2D(
+      "BTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta1", "MTD Track pathlength vs MTD track Eta;|#eta|;Pathlength", 30, 0, 1.5, 350, 0.0, 350.0);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLength1_ = ibook.book1D(
+      "BTLTrackMatchedTPmtdDirectWrongAssocTrackPathLength1", "MTD Track pathlength ; ;Pathlength", 400, 0, 400);
 
 
 
@@ -2094,11 +2096,11 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
        0.,
        100);
      meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual1_ = ibook.book2D(
-       "BTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual1", "Time chi2 of tracks matched to TP with sim hit in MTD (direct), correct track-MTD association; Chi2; MVAQual ",
+       "BTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual1", "Time chi2 vs MVA of tracks matched to TP with sim hit in MTD (direct), wrong track-MTD association; Chi2; MVAQual ",
        200, 0., 100, 100, -1, 1);
     meBTLTrackMatchedTPmtdDirectWrongAssocSpaceChi21_ = ibook.book1D(
        "BTLTrackMatchedTPmtdDirectWrongAssocSpaceChi21",
-       "Space chi2 of tracks matched to TP with sim hit in MTD (direct), correct track-MTD association; Chi2 ",
+       "Space chi2 of tracks matched to TP with sim hit in MTD (direct), wrong track-MTD association; Chi2 ",
        250,
        0.,
        250.);
@@ -2174,18 +2176,18 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
        0.,
        100);
      meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual2_ = ibook.book2D(
-       "BTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual2", "Time chi2 of tracks matched to TP with sim hit in MTD (direct), correct track-MTD association; Chi2; MVAQual ",
+       "BTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual2", "Time chi2 vs MVA of tracks matched to TP with sim hit in MTD (direct), wrong track-MTD association; Chi2; MVAQual ",
        200, 0., 100, 100, -1, 1);
      meBTLTrackMatchedTPmtdDirectWrongAssocSpaceChi22_ = ibook.book1D(
        "BTLTrackMatchedTPmtdDirectWrongAssocSpaceChi22",
-       "Space chi2 of tracks matched to TP with sim hit in MTD (direct), correct track-MTD association; Chi2 ",
+       "Space chi2 of tracks matched to TP with sim hit in MTD (direct), wrong track-MTD association; Chi2 ",
        250,
        0.,
        250.);
-      meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenghtvsEta2_ = ibook.book2D(
-      "BTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenghtvsEta2", "MTD Track pathlength vs MTD track Eta;|#eta|;Pathlength", 30, 0, 1.5,350, 0.0, 350.0);
-     meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenght2_ = ibook.book1D(
-      "BTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenght2", "MTD Track pathlength ; ;Pathlength", 400, 0, 400);
+      meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta2_ = ibook.book2D(
+      "BTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta2", "MTD Track pathlength vs MTD track Eta;|#eta|;Pathlength", 30, 0, 1.5,350, 0.0, 350.0);
+     meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLength2_ = ibook.book1D(
+      "BTLTrackMatchedTPmtdDirectWrongAssocTrackPathLength2", "MTD Track pathlength ; ;Pathlength", 400, 0, 400);
 
 
 
@@ -2272,20 +2274,20 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
        0.,
        100);
       meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual3_ = ibook.book2D(
-       "BTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual3", "Time chi2 of tracks matched to TP with sim hit in MTD (direct), correct track-MTD association; Chi2; MVAQual ",
+       "BTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual3", "Time chi2 vs MVA of tracks matched to TP with sim hit in MTD (direct), wrong track-MTD association; Chi2; MVAQual ",
        200, 0., 100, 100, -1, 1);
    
 
     meBTLTrackMatchedTPmtdDirectWrongAssocSpaceChi23_ = ibook.book1D(
        "BTLTrackMatchedTPmtdDirectWrongAssocSpaceChi23",
-       "Space chi2 of tracks matched to TP with sim hit in MTD (direct), correct track-MTD association; Chi2 ",
+       "Space chi2 of tracks matched to TP with sim hit in MTD (direct), wrong track-MTD association; Chi2 ",
        250,
        0.,
        250.);
-    meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenghtvsEta3_ = ibook.book2D(
-      "BTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenghtvsEta3", "MTD Track pathlength vs MTD track Eta;|#eta|;Pathlength", 30, 0, 1.5,350, 0.0, 350.0);
-    meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenght3_ = ibook.book1D(
-      "BTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenght3", "MTD Track pathlength ; ;Pathlength", 400, 0, 400);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta3_ = ibook.book2D(
+      "BTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta3", "MTD Track pathlength vs MTD track Eta;|#eta|;Pathlength", 30, 0, 1.5,350, 0.0, 350.0);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLength3_ = ibook.book1D(
+      "BTLTrackMatchedTPmtdDirectWrongAssocTrackPathLength3", "MTD Track pathlength ; ;Pathlength", 400, 0, 400);
 
 
 
@@ -2353,19 +2355,19 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
        0.,
        100);
      meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual_ = ibook.book2D(
-       "BTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual", "Time chi2 of tracks matched to TP with sim hit in MTD (direct), correct track-MTD association; Chi2; MVAQual ",
+       "BTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual", "Time chi2 vs MVA of tracks matched to TP with sim hit in MTD (direct), wrong track-MTD association; Chi2; MVAQual ",
        200, 0., 100, 100, -1, 1);
 
     meBTLTrackMatchedTPmtdDirectWrongAssocSpaceChi2_ = ibook.book1D(
        "BTLTrackMatchedTPmtdDirectWrongAssocSpaceChi2",
-       "Space chi2 of tracks matched to TP with sim hit in MTD (direct), correct track-MTD association; Chi2 ",
+       "Space chi2 of tracks matched to TP with sim hit in MTD (direct), wrong track-MTD association; Chi2 ",
        250,
        0.,
        250.);
-    meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenghtvsEta_ = ibook.book2D(
-      "BTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenghtvsEta", "MTD Track pathlength vs MTD track Eta;|#eta|;Pathlength", 30, 0, 1.5,350,  0.0, 350.0);
-    meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenght_ = ibook.book1D(
-      "BTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenght", "MTD Track pathlength ; ;Pathlength", 400, 0, 400);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta_ = ibook.book2D(
+      "BTLTrackMatchedTPmtdDirectWrongAssocTrackPathLengthvsEta", "MTD Track pathlength vs MTD track Eta;|#eta|;Pathlength", 30, 0, 1.5,350,  0.0, 350.0);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLength_ = ibook.book1D(
+      "BTLTrackMatchedTPmtdDirectWrongAssocTrackPathLength", "MTD Track pathlength ; ;Pathlength", 400, 0, 400);
 
 
 
@@ -2468,7 +2470,7 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
        0.,
        100);
      meETLTrackMatchedTPmtd2WrongAssocTimeChi2vsMVAQual_ = ibook.book2D(
-       "ETLTrackMatchedTPmtd2WrongAssocTimeChi2vsMVAQual", "Time chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Chi2; MVAQual ",
+       "ETLTrackMatchedTPmtd2WrongAssocTimeChi2vsMVAQual", "Time chi2 vs MVA of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Chi2; MVAQual ",
        200, 0., 100, 100, -1, 1);
 
 

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -145,13 +145,11 @@ private:
   edm::EDGetTokenT<reco::TrackCollection> GenRecTrackToken_;
   edm::EDGetTokenT<reco::TrackCollection> RecTrackToken_;
 
-  //edm::EDGetTokenT<MtdSimLayerClusterCollection> simClustersToken_; //simClus
-
   edm::EDGetTokenT<TrackingParticleCollection> trackingParticleCollectionToken_;
   edm::EDGetTokenT<reco::SimToRecoCollection> simToRecoAssociationToken_;
   edm::EDGetTokenT<reco::RecoToSimCollection> recoToSimAssociationToken_;
   edm::EDGetTokenT<reco::TPToSimCollectionMtd> tp2SimAssociationMapToken_;
-  edm::EDGetTokenT<reco::SimToTPCollectionMtd> Sim2tpAssociationMapToken_;//F
+  edm::EDGetTokenT<reco::SimToTPCollectionMtd> Sim2tpAssociationMapToken_;
   edm::EDGetTokenT<MtdRecoClusterToSimLayerClusterAssociationMap> r2sAssociationMapToken_;
 
   edm::EDGetTokenT<FTLRecHitCollection> btlRecHitsToken_;
@@ -161,6 +159,10 @@ private:
 
   edm::EDGetTokenT<edm::ValueMap<int>> trackAssocToken_;
   edm::EDGetTokenT<edm::ValueMap<float>> pathLengthToken_;
+  
+  edm::EDGetTokenT<edm::ValueMap<float>> btlMatchTimeChi2Token_;
+  edm::EDGetTokenT<edm::ValueMap<float>> etlMatchTimeChi2Token_;
+  edm::EDGetTokenT<edm::ValueMap<float>> btlMatchChi2Token_;
 
   edm::EDGetTokenT<edm::ValueMap<float>> tmtdToken_;
   edm::EDGetTokenT<edm::ValueMap<float>> SigmatmtdToken_;
@@ -291,17 +293,26 @@ private:
   MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocTimePull_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocTrackOutermostHitR_; 
   MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocTrackChi2_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocTimeChi2_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocTimeChi2vsMVAQual_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocSpaceChi2_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocTrackNdf_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocSimClusSize_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocRecoClusSize_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocTrackPathLenghtvsEta_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocTrackPathLenght_;
 
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocEta_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocPt_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocMVAQual_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTimeRes_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTimePull_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocSpaceChi2_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT_; 
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackChi2_;
@@ -309,6 +320,8 @@ private:
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocSimClusSize_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocRecoClusSize_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenghtvsEta_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenght_;
   
   // wrong association with reco from same TP direct hit
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocEta1_;
@@ -318,11 +331,17 @@ private:
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTimePull1_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT1_; 
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ1_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi1_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff1_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR1_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackChi21_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi21_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual1_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocSpaceChi21_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf1_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR1_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenghtvsEta1_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenght1_;
 
   // wrong association with reco from same TP other hit
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocEta2_;
@@ -332,11 +351,17 @@ private:
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTimePull2_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT2_; 
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ2_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi2_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff2_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR2_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackChi22_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi22_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual2_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocSpaceChi22_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf2_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR2_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenghtvsEta2_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenght2_;
 
   // wrong association to reco from another TP
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocEta3_;
@@ -346,12 +371,17 @@ private:
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTimePull3_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT3_; 
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ3_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi3_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff3_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR3_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackChi23_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi23_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual3_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocSpaceChi23_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf3_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR3_;
-
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenghtvsEta3_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenght3_;
 
   MonitorElement* meBTLTrackMatchedTPmtdDirectNoAssocEta_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectNoAssocPt_;
@@ -360,7 +390,6 @@ private:
   MonitorElement* meBTLTrackMatchedTPmtdDirectNoAssocTrackNdf_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectNoAssocSimClusSize_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectNoAssocRecoClusSize_;
-
 
 
   // - BTL TPmtd "other" hits: correct, wrong, missing association in MTD
@@ -407,12 +436,16 @@ private:
   MonitorElement* meETLTrackMatchedTPmtd1CorrectAssocMVAQual_;
   MonitorElement* meETLTrackMatchedTPmtd1CorrectAssocTimeRes_;
   MonitorElement* meETLTrackMatchedTPmtd1CorrectAssocTimePull_;
+  MonitorElement* meETLTrackMatchedTPmtd1CorrectAssocTimeChi2_;
+  MonitorElement* meETLTrackMatchedTPmtd1CorrectAssocTimeChi2vsMVAQual_;
 
   MonitorElement* meETLTrackMatchedTPmtd1WrongAssocEta_;
   MonitorElement* meETLTrackMatchedTPmtd1WrongAssocPt_;
   MonitorElement* meETLTrackMatchedTPmtd1WrongAssocMVAQual_;
   MonitorElement* meETLTrackMatchedTPmtd1WrongAssocTimeRes_;
   MonitorElement* meETLTrackMatchedTPmtd1WrongAssocTimePull_;
+  MonitorElement* meETLTrackMatchedTPmtd1WrongAssocTimeChi2_;
+  MonitorElement* meETLTrackMatchedTPmtd1WrongAssocTimeChi2vsMVAQual_;
 
   MonitorElement* meETLTrackMatchedTPmtd1NoAssocEta_;
   MonitorElement* meETLTrackMatchedTPmtd1NoAssocPt_;
@@ -426,12 +459,16 @@ private:
   MonitorElement* meETLTrackMatchedTPmtd2CorrectAssocMVAQual_;
   MonitorElement* meETLTrackMatchedTPmtd2CorrectAssocTimeRes_;
   MonitorElement* meETLTrackMatchedTPmtd2CorrectAssocTimePull_;
+  MonitorElement* meETLTrackMatchedTPmtd2CorrectAssocTimeChi2_;
+  MonitorElement* meETLTrackMatchedTPmtd2CorrectAssocTimeChi2vsMVAQual_;
 
   MonitorElement* meETLTrackMatchedTPmtd2WrongAssocEta_;
   MonitorElement* meETLTrackMatchedTPmtd2WrongAssocPt_;
   MonitorElement* meETLTrackMatchedTPmtd2WrongAssocMVAQual_;
   MonitorElement* meETLTrackMatchedTPmtd2WrongAssocTimeRes_;
   MonitorElement* meETLTrackMatchedTPmtd2WrongAssocTimePull_;
+  MonitorElement* meETLTrackMatchedTPmtd2WrongAssocTimeChi2_;
+  MonitorElement* meETLTrackMatchedTPmtd2WrongAssocTimeChi2vsMVAQual_;
 
   MonitorElement* meETLTrackMatchedTPmtd2NoAssocEta_;
   MonitorElement* meETLTrackMatchedTPmtd2NoAssocPt_;
@@ -457,7 +494,6 @@ MtdTracksValidation::MtdTracksValidation(const edm::ParameterSet& iConfig)
       trackMaxEtlEta_(iConfig.getParameter<double>("trackMaximumEtlEta")) {
   GenRecTrackToken_ = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("inputTagG"));
   RecTrackToken_ = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("inputTagT"));
-  //simClustersToken_ = consumes<
 
   trackingParticleCollectionToken_ =
       consumes<TrackingParticleCollection>(iConfig.getParameter<edm::InputTag>("SimTag"));
@@ -468,7 +504,7 @@ MtdTracksValidation::MtdTracksValidation(const edm::ParameterSet& iConfig)
   tp2SimAssociationMapToken_ =
       consumes<reco::TPToSimCollectionMtd>(iConfig.getParameter<edm::InputTag>("tp2SimAssociationMapTag"));
   Sim2tpAssociationMapToken_ =
-      consumes<reco::SimToTPCollectionMtd>(iConfig.getParameter<edm::InputTag>("Sim2tpAssociationMapTag"));//F
+      consumes<reco::SimToTPCollectionMtd>(iConfig.getParameter<edm::InputTag>("Sim2tpAssociationMapTag"));
   r2sAssociationMapToken_ = consumes<MtdRecoClusterToSimLayerClusterAssociationMap>(
       iConfig.getParameter<edm::InputTag>("r2sAssociationMapTag"));
   btlRecHitsToken_ = consumes<FTLRecHitCollection>(iConfig.getParameter<edm::InputTag>("btlRecHits"));
@@ -477,6 +513,9 @@ MtdTracksValidation::MtdTracksValidation(const edm::ParameterSet& iConfig)
   etlRecCluToken_ = consumes<FTLClusterCollection>(iConfig.getParameter<edm::InputTag>("recCluTagETL"));
   trackAssocToken_ = consumes<edm::ValueMap<int>>(iConfig.getParameter<edm::InputTag>("trackAssocSrc"));
   pathLengthToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("pathLengthSrc"));
+  btlMatchTimeChi2Token_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("btlMatchTimeChi2"));
+  etlMatchTimeChi2Token_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("etlMatchTimeChi2"));
+  btlMatchChi2Token_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("btlMatchChi2"));
   tmtdToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("tmtd"));
   SigmatmtdToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("sigmatmtd"));
   t0SrcToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("t0Src"));
@@ -533,11 +572,14 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
   const auto& mtdQualMVA = iEvent.get(trackMVAQualToken_);
   const auto& trackAssoc = iEvent.get(trackAssocToken_);
   const auto& pathLength = iEvent.get(pathLengthToken_);
+  const auto& btlMatchTimeChi2 = iEvent.get(btlMatchTimeChi2Token_);
+  const auto& etlMatchTimeChi2 = iEvent.get(etlMatchTimeChi2Token_);
+  const auto& btlMatchChi2 = iEvent.get(btlMatchChi2Token_);
   const auto& outermostHitPosition = iEvent.get(outermostHitPositionToken_);
 
   auto recoToSimH = makeValid(iEvent.getHandle(recoToSimAssociationToken_));
   r2s_ = recoToSimH.product();
-  auto geometryHandle = iSetup.getTransientHandle(mtdgeoToken_); // F
+  auto geometryHandle = iSetup.getTransientHandle(mtdgeoToken_); 
   const MTDGeometry* geom = geometryHandle.product();
   auto topologyHandle = iSetup.getTransientHandle(mtdtopoToken_);
   const MTDTopology *topology = topologyHandle.product();
@@ -810,6 +852,7 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
         // ==  MC truth matching
         double simClusterRef_RecoMatch_trackIdOff(-9999.); 
         double simClusterRef_RecoMatch_DeltaZ(-9999.);
+        double simClusterRef_RecoMatch_DeltaPhi(-9999.);
         double simClusterRef_RecoMatch_DeltaT(-9999.);
         int simClusSize(-9999);
         int recoClusSize(-9999);
@@ -849,10 +892,8 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
             });
             // Check if TP has direct or other sim cluster for BTL
             for (const auto& simClusterRef : simClustersRefs) {
-	      //MTDDetId mtddetid = simClusterRef->detIds_and_rows().front().first;	    
               if (directSimClusIt != simClustersRefs.end() && simClusterRef == *directSimClusIt) {
                 isTPmtdDirectBTL = true;
-              //} else if (simClusterRef->trackIdOffset() != 0 && mtddetid.mtdSubDetector() == 1 ) {
               } else if (simClusterRef->trackIdOffset() != 0) {
                 isTPmtdOtherBTL = true;
               }
@@ -870,13 +911,14 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
 		
                 BTLDetId RecoDetId((*recClusterRef).id());
 	        simClusSize = simClustersRefs_RecoMatch.size();
-
+	
                 for (const auto& simClusterRef_RecoMatch : simClustersRefs_RecoMatch) {
 		  	
                   // Check if simClusterRef_RecoMatch  exists in SimClusters
                   auto simClusterIt =
                       std::find(simClustersRefs.begin(), simClustersRefs.end(), simClusterRef_RecoMatch);
 	          if (optionalPlots_ && isTPmtdDirectBTL){
+	  
                       // simCluster matched to TP 
 		      // NB we are taking the position and id of the first hit in the cluster.
 		      auto directSimClus = *directSimClusIt;
@@ -884,7 +926,7 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
                       BTLDetId detid(mtddetid.rawId());
 	              LocalPoint simClusLocalPos = directSimClus->hits_and_positions().front().second;
                       GlobalPoint simClusGlobalPos = geomUtil.globalPosition(detid, simClusLocalPos);
-
+       
 		      // simClusterRef_RecoMatch infos
   	              MTDDetId mtddetidRecoMatch = simClusterRef_RecoMatch->detIds_and_rows().front().first;
                       BTLDetId detidRecoMatch(mtddetidRecoMatch.rawId());
@@ -893,9 +935,9 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
 
 		      simClusterRef_RecoMatch_trackIdOff = simClusterRef_RecoMatch->trackIdOffset();
                       simClusterRef_RecoMatch_DeltaZ = simClusRecoMatchGlobalPos.z() - simClusGlobalPos.z();
+                      simClusterRef_RecoMatch_DeltaPhi = simClusRecoMatchGlobalPos.phi() - simClusGlobalPos.phi();
                       simClusterRef_RecoMatch_DeltaT = simClusterRef_RecoMatch->simLCTime() - directSimClus->simLCTime();
-
-
+      
 		    }
 
 
@@ -938,13 +980,19 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
               if (isTPmtdDirectBTL) {
                 // -- Track matched to TP with sim hit (direct), correctly associated reco cluster
                 if (isTPmtdDirectCorrectBTL) {
-		  
+	          
                   if (optionalPlots_) {
 		    meBTLTrackMatchedTPmtdDirectCorrectAssocSimClusSize_->Fill(simClusSize);
                     meBTLTrackMatchedTPmtdDirectCorrectAssocRecoClusSize_->Fill(recoClusSize);
       	            meBTLTrackMatchedTPmtdDirectCorrectAssocTrackOutermostHitR_->Fill(outermostHitPosition[trackref]);
 	            meBTLTrackMatchedTPmtdDirectCorrectAssocTrackNdf_->Fill(trackGen.ndof());
 	            meBTLTrackMatchedTPmtdDirectCorrectAssocTrackChi2_->Fill(trackGen.chi2());
+                    meBTLTrackMatchedTPmtdDirectCorrectAssocTimeChi2_->Fill(btlMatchTimeChi2[trackref]);
+                    meBTLTrackMatchedTPmtdDirectCorrectAssocTimeChi2vsMVAQual_->Fill(btlMatchTimeChi2[trackref],  mtdQualMVA[trackref]);
+                    meBTLTrackMatchedTPmtdDirectCorrectAssocSpaceChi2_->Fill(btlMatchChi2[trackref]);
+                    meBTLTrackMatchedTPmtdDirectCorrectAssocTrackPathLenghtvsEta_->Fill(std::abs(trackGen.eta()), pathLength[trackref]);
+                    meBTLTrackMatchedTPmtdDirectCorrectAssocTrackPathLenght_->Fill(pathLength[trackref]);
+
 		  }
                   fillTrackClusterMatchingHistograms(meBTLTrackMatchedTPmtdDirectCorrectAssocEta_,
                                                      meBTLTrackMatchedTPmtdDirectCorrectAssocPt_,
@@ -964,17 +1012,24 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
 		    meBTLTrackMatchedTPmtdDirectWrongAssocSimClusSize_->Fill(simClusSize);
                     meBTLTrackMatchedTPmtdDirectWrongAssocRecoClusSize_->Fill(recoClusSize);
 		    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT_->Fill(simClusterRef_RecoMatch_DeltaT);
+		    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi_->Fill(simClusterRef_RecoMatch_DeltaPhi);
 		    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ_->Fill(simClusterRef_RecoMatch_DeltaZ);
 		    meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff_->Fill(simClusterRef_RecoMatch_trackIdOff);
 		    meBTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR_->Fill(outermostHitPosition[trackref]);
                     meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf_->Fill(trackGen.ndof());
                     meBTLTrackMatchedTPmtdDirectWrongAssocTrackChi2_->Fill(trackGen.chi2());
                     meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR_->Fill(outermostHitPosition[trackref], simClusterRef_RecoMatch_DeltaZ);
+                    meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2_->Fill(btlMatchTimeChi2[trackref]);
+                    meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual_->Fill(btlMatchTimeChi2[trackref],  mtdQualMVA[trackref]);
+                    meBTLTrackMatchedTPmtdDirectWrongAssocSpaceChi2_->Fill(btlMatchChi2[trackref]);
+                    meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenghtvsEta_->Fill(std::abs(trackGen.eta()), pathLength[trackref]);
+                    meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenght_->Fill(pathLength[trackref]);
 
 
 
                     if (simClusterRef_RecoMatch_trackIdOff == 0 && isFromSameTP){
-		      fillTrackClusterMatchingHistograms(meBTLTrackMatchedTPmtdDirectWrongAssocEta1_,
+
+      			    fillTrackClusterMatchingHistograms(meBTLTrackMatchedTPmtdDirectWrongAssocEta1_,
                                      meBTLTrackMatchedTPmtdDirectWrongAssocPt1_,
                                      meBTLTrackMatchedTPmtdDirectWrongAssocMVAQual1_,
                                      meBTLTrackMatchedTPmtdDirectWrongAssocTimeRes1_,
@@ -987,17 +1042,23 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
                                      hasTime);
         	    
 		      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT1_->Fill(simClusterRef_RecoMatch_DeltaT);
+		      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi1_->Fill(simClusterRef_RecoMatch_DeltaPhi);
 		      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ1_->Fill(simClusterRef_RecoMatch_DeltaZ);
 		      meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff1_->Fill(simClusterRef_RecoMatch_trackIdOff);
 		      meBTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR1_->Fill(outermostHitPosition[trackref]);
                       meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf1_->Fill(trackGen.ndof());
                       meBTLTrackMatchedTPmtdDirectWrongAssocTrackChi21_->Fill(trackGen.chi2());
                       meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR1_->Fill(outermostHitPosition[trackref], simClusterRef_RecoMatch_DeltaZ);
-
-
+                      meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi21_->Fill(btlMatchTimeChi2[trackref]);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual1_->Fill(btlMatchTimeChi2[trackref],  mtdQualMVA[trackref]);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocSpaceChi21_->Fill(btlMatchChi2[trackref]);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenghtvsEta1_->Fill(std::abs(trackGen.eta()), pathLength[trackref]);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenght1_->Fill(pathLength[trackref]);
 
                     } else if (simClusterRef_RecoMatch_trackIdOff > 0 && isFromSameTP){
-	            		      fillTrackClusterMatchingHistograms(meBTLTrackMatchedTPmtdDirectWrongAssocEta2_,
+
+
+	            		     fillTrackClusterMatchingHistograms(meBTLTrackMatchedTPmtdDirectWrongAssocEta2_,
                                      meBTLTrackMatchedTPmtdDirectWrongAssocPt2_,
                                      meBTLTrackMatchedTPmtdDirectWrongAssocMVAQual2_,
                                      meBTLTrackMatchedTPmtdDirectWrongAssocTimeRes2_,
@@ -1010,16 +1071,23 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
                                      hasTime);
         	    
 		      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT2_->Fill(simClusterRef_RecoMatch_DeltaT);
+		      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi2_->Fill(simClusterRef_RecoMatch_DeltaPhi);
 		      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ2_->Fill(simClusterRef_RecoMatch_DeltaZ);
 		      meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff2_->Fill(simClusterRef_RecoMatch_trackIdOff);
 		      meBTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR2_->Fill(outermostHitPosition[trackref]);
                       meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf2_->Fill(trackGen.ndof());
                       meBTLTrackMatchedTPmtdDirectWrongAssocTrackChi22_->Fill(trackGen.chi2());
                       meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR2_->Fill(outermostHitPosition[trackref], simClusterRef_RecoMatch_DeltaZ);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi22_->Fill(btlMatchTimeChi2[trackref]);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual2_->Fill(btlMatchTimeChi2[trackref],  mtdQualMVA[trackref]);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocSpaceChi22_->Fill(btlMatchChi2[trackref]);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenghtvsEta2_->Fill(std::abs(trackGen.eta()), pathLength[trackref]);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenght2_->Fill(pathLength[trackref]);
 
 
 
                     } else if (!isFromSameTP){
+
 	            		     fillTrackClusterMatchingHistograms(meBTLTrackMatchedTPmtdDirectWrongAssocEta3_,
                                      meBTLTrackMatchedTPmtdDirectWrongAssocPt3_,
                                      meBTLTrackMatchedTPmtdDirectWrongAssocMVAQual3_,
@@ -1033,13 +1101,18 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
                                      hasTime);
         	    
 		      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT3_->Fill(simClusterRef_RecoMatch_DeltaT);
+		      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi3_->Fill(simClusterRef_RecoMatch_DeltaPhi);
 		      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ3_->Fill(simClusterRef_RecoMatch_DeltaZ);
 		      meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff3_->Fill(simClusterRef_RecoMatch_trackIdOff);
 		      meBTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR3_->Fill(outermostHitPosition[trackref]);
                       meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf3_->Fill(trackGen.ndof());
                       meBTLTrackMatchedTPmtdDirectWrongAssocTrackChi23_->Fill(trackGen.chi2());
                       meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR3_->Fill(outermostHitPosition[trackref], simClusterRef_RecoMatch_DeltaZ);
-
+                      meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi23_->Fill(btlMatchTimeChi2[trackref]);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual3_->Fill(btlMatchTimeChi2[trackref],  mtdQualMVA[trackref]);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocSpaceChi23_->Fill(btlMatchChi2[trackref]);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenghtvsEta3_->Fill(std::abs(trackGen.eta()), pathLength[trackref]);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenght3_->Fill(pathLength[trackref]);
 		    }
 
                   }
@@ -1099,7 +1172,8 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
 	          meBTLTrackMatchedTPmtdDirectNoAssocTrackOutermostHitR_->Fill(outermostHitPosition[trackref]);
                   meBTLTrackMatchedTPmtdDirectNoAssocTrackNdf_->Fill(trackGen.ndof());
                   meBTLTrackMatchedTPmtdDirectNoAssocTrackChi2_->Fill(trackGen.chi2());
-		}
+	        }
+
                 meBTLTrackMatchedTPmtdDirectNoAssocEta_->Fill(std::abs(trackGen.eta()));
                 meBTLTrackMatchedTPmtdDirectNoAssocPt_->Fill(trackGen.pt());
               } else if (isTPmtdOtherBTL) {
@@ -1133,6 +1207,10 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
                     (isTPmtdETLD2 && !isTPmtdETLD1 && ETLdisc2 && isTPmtdCorrectETLD2) ||
                     (isTPmtdETLD1 && isTPmtdETLD2 && ETLdisc1 && ETLdisc2 && isTPmtdCorrectETLD1 &&
                      isTPmtdCorrectETLD2)) {
+	          if (optionalPlots_){
+			  meETLTrackMatchedTPmtd1CorrectAssocTimeChi2_->Fill(etlMatchTimeChi2[trackref]);		
+			  meETLTrackMatchedTPmtd1CorrectAssocTimeChi2vsMVAQual_->Fill(etlMatchTimeChi2[trackref], mtdQualMVA[trackref]);
+		  }	  
                   fillTrackClusterMatchingHistograms(meETLTrackMatchedTPmtd1CorrectAssocEta_,
                                                      meETLTrackMatchedTPmtd1CorrectAssocPt_,
                                                      meETLTrackMatchedTPmtd1CorrectAssocMVAQual_,
@@ -1147,6 +1225,12 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
                 }
                 // - at least one reco hit is incorrectly associated or, if two sim hits, one reco hit is missing
                 else if ((isTPmtdETLD1 && !isTPmtdCorrectETLD1) || (isTPmtdETLD2 && !isTPmtdCorrectETLD2)) {
+		  	
+	          if (optionalPlots_) {
+			  meETLTrackMatchedTPmtd1WrongAssocTimeChi2_->Fill(etlMatchTimeChi2[trackref]);		
+			  meETLTrackMatchedTPmtd1WrongAssocTimeChi2vsMVAQual_->Fill(etlMatchTimeChi2[trackref], mtdQualMVA[trackref]);
+		  }	  
+
                   fillTrackClusterMatchingHistograms(meETLTrackMatchedTPmtd1WrongAssocEta_,
                                                      meETLTrackMatchedTPmtd1WrongAssocPt_,
                                                      meETLTrackMatchedTPmtd1WrongAssocMVAQual_,
@@ -1164,7 +1248,11 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
               if (isTPmtdETLD1 && isTPmtdETLD2) {
                 // - each hit correctly associated to the track
                 if (ETLdisc1 && ETLdisc2 && isTPmtdCorrectETLD1 && isTPmtdCorrectETLD2) {
-                  fillTrackClusterMatchingHistograms(meETLTrackMatchedTPmtd2CorrectAssocEta_,
+	          if (optionalPlots_){
+			  meETLTrackMatchedTPmtd2CorrectAssocTimeChi2_->Fill(etlMatchTimeChi2[trackref]);		
+			  meETLTrackMatchedTPmtd2CorrectAssocTimeChi2vsMVAQual_->Fill(etlMatchTimeChi2[trackref], mtdQualMVA[trackref]);
+		  }
+		  fillTrackClusterMatchingHistograms(meETLTrackMatchedTPmtd2CorrectAssocEta_,
                                                      meETLTrackMatchedTPmtd2CorrectAssocPt_,
                                                      meETLTrackMatchedTPmtd2CorrectAssocMVAQual_,
                                                      meETLTrackMatchedTPmtd2CorrectAssocTimeRes_,
@@ -1178,6 +1266,10 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
                 }
                 // - at least one reco hit incorrectly associated or one hit missing
                 else if ((ETLdisc1 || ETLdisc2) && (!isTPmtdCorrectETLD1 || !isTPmtdCorrectETLD2)) {
+	          if (optionalPlots_){ 
+			  meETLTrackMatchedTPmtd2WrongAssocTimeChi2_->Fill(etlMatchTimeChi2[trackref]);		
+			  meETLTrackMatchedTPmtd2WrongAssocTimeChi2vsMVAQual_->Fill(etlMatchTimeChi2[trackref], mtdQualMVA[trackref]);	
+		  }	  
                   fillTrackClusterMatchingHistograms(meETLTrackMatchedTPmtd2WrongAssocEta_,
                                                      meETLTrackMatchedTPmtd2WrongAssocPt_,
                                                      meETLTrackMatchedTPmtd2WrongAssocMVAQual_,
@@ -1878,6 +1970,27 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
          10,
          -5.,
          5.);
+    meBTLTrackMatchedTPmtdDirectCorrectAssocTimeChi2_ = ibook.book1D(
+       "BTLTrackMatchedTPmtdDirectCorrectAssocTimeChi2",
+       "Time chi2 of tracks matched to TP with sim hit in MTD (direct), correct track-MTD association; Chi2 ",
+       200,
+       0.,
+       100);
+     meBTLTrackMatchedTPmtdDirectCorrectAssocTimeChi2vsMVAQual_ = ibook.book2D(
+       "BTLTrackMatchedTPmtdDirectCorrectAssocTimeChi2vsMVAQual", "Time chi2 of tracks matched to TP with sim hit in MTD (direct), correct track-MTD association; Chi2; MVAQual ",
+       200, 0., 100, 100, -1, 1);
+   
+    meBTLTrackMatchedTPmtdDirectCorrectAssocSpaceChi2_ = ibook.book1D(
+       "BTLTrackMatchedTPmtdDirectCorrectAssocSpaceChi2",
+       "Space chi2 of tracks matched to TP with sim hit in MTD (direct), correct track-MTD association; Chi2 ",
+       250,
+       0.,
+       250.);
+    meBTLTrackMatchedTPmtdDirectCorrectAssocTrackPathLenghtvsEta_ = ibook.book2D(
+      "BTLTrackMatchedTPmtdDirectCorrectAssocTrackPathLenghtvsEta", "MTD Track pathlength vs MTD track Eta;|#eta|;Pathlength", 30, 0, 1.5, 350, 0.0, 350.0);
+    meBTLTrackMatchedTPmtdDirectCorrectAssocTrackPathLenght_ = ibook.book1D(
+      "BTLTrackMatchedTPmtdDirectCorrectAssocTrackPathLenght", "MTD Track pathlength ; ;Pathlength", 400, 0, 400);
+
 
     meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf1_ = ibook.book1D(
        "BTLTrackMatchedTPmtdDirectWrongAssocTrackNdf1",
@@ -1909,6 +2022,12 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
          1000,
          -50.,
          50.);
+     meBTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi1_ = ibook.book1D(
+         "BTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi1",
+         "Phi of sim matched wrong cluster - Z of true sim cluster - wrong track-MTD association; DeltaPhi (wrong - true) ",
+         500,
+         -0.1,
+         0.1);
     meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT1_ = ibook.book1D(
          "BTLTrackMatchedTPmtdDirectWrongAssocDeltaT1",
          "Time of sim matched wrong cluster - time of true sim cluster (direct) - wrong track-MTD association; DeltaT (wrong - true) [ns]",
@@ -1947,15 +2066,14 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
                     50,
                     -5.,
                     5.);
-    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR1_ = ibook.bookProfile(
-       "BTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR1",
-       "; Outer R [cm]; DeltaZ [cm]",
-       100,
-       -0.,
-       120.,
-       -40.,
-       40,
-       "s");
+    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR1_ = ibook.book2D(
+       "BTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR1", "; Outer R [cm]; DeltaZ [cm]", 120, 0., 120., 1000, -40., 40);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenghtvsEta1_ = ibook.book2D(
+      "BTLTrackMatchedTPmtdDirectCorrectAssocTrackPathLenghtvsEta1", "MTD Track pathlength vs MTD track Eta;|#eta|;Pathlength", 30, 0, 1.5, 350, 0.0, 350.0);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenght1_ = ibook.book1D(
+      "BTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenght1", "MTD Track pathlength ; ;Pathlength", 400, 0, 400);
+
+
 
     meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf2_ = ibook.book1D(
         "BTLTrackMatchedTPmtdDirectWrongAssocTrackNdf2",
@@ -1969,6 +2087,21 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
         80,
         0.,
         220);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi21_ = ibook.book1D(
+       "BTLTrackMatchedTPmtdDirectWrongAssocTimeChi21",
+       "Time chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Chi2 ",
+       200,
+       0.,
+       100);
+     meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual1_ = ibook.book2D(
+       "BTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual1", "Time chi2 of tracks matched to TP with sim hit in MTD (direct), correct track-MTD association; Chi2; MVAQual ",
+       200, 0., 100, 100, -1, 1);
+    meBTLTrackMatchedTPmtdDirectWrongAssocSpaceChi21_ = ibook.book1D(
+       "BTLTrackMatchedTPmtdDirectWrongAssocSpaceChi21",
+       "Space chi2 of tracks matched to TP with sim hit in MTD (direct), correct track-MTD association; Chi2 ",
+       250,
+       0.,
+       250.);
     meBTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR2_ = ibook.book1D(
         "BTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR2",
         "Outermost hit position R of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; R [cm]",
@@ -1987,6 +2120,12 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
          1000,
          -50.,
          50.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi2_ = ibook.book1D(
+         "BTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi2",
+         "Phi of sim matched wrong cluster - Z of true sim cluster - wrong track-MTD association; DeltaPhi (wrong - true) ",
+         500,
+         -0.1,
+         0.1);
     meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT2_ = ibook.book1D(
          "BTLTrackMatchedTPmtdDirectWrongAssocDeltaT2",
          "Time of sim matched wrong cluster - time of true sim cluster (direct) - wrong track-MTD association; DeltaT (wrong - true) [ns]",
@@ -2025,16 +2164,31 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
                    50,
                    -5.,
                    5.);
-    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR2_ = ibook.bookProfile(
-      "BTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR2",
-      "; Outer R [cm]; DeltaZ [cm]",
-      100,
-      -0.,
-      120.,
-      -40.,
-      40,
-      "s");
-    
+    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR2_ = ibook.book2D(
+       "BTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR2", "; Outer R [cm]; DeltaZ [cm]", 120, 0., 120., 1000, -40., 40);
+
+     meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi22_ = ibook.book1D(
+       "BTLTrackMatchedTPmtdDirectWrongAssocTimeChi22",
+       "Time chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Chi2 ",
+       200,
+       0.,
+       100);
+     meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual2_ = ibook.book2D(
+       "BTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual2", "Time chi2 of tracks matched to TP with sim hit in MTD (direct), correct track-MTD association; Chi2; MVAQual ",
+       200, 0., 100, 100, -1, 1);
+     meBTLTrackMatchedTPmtdDirectWrongAssocSpaceChi22_ = ibook.book1D(
+       "BTLTrackMatchedTPmtdDirectWrongAssocSpaceChi22",
+       "Space chi2 of tracks matched to TP with sim hit in MTD (direct), correct track-MTD association; Chi2 ",
+       250,
+       0.,
+       250.);
+      meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenghtvsEta2_ = ibook.book2D(
+      "BTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenghtvsEta2", "MTD Track pathlength vs MTD track Eta;|#eta|;Pathlength", 30, 0, 1.5,350, 0.0, 350.0);
+     meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenght2_ = ibook.book1D(
+      "BTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenght2", "MTD Track pathlength ; ;Pathlength", 400, 0, 400);
+
+
+
     meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf3_ = ibook.book1D(
        "BTLTrackMatchedTPmtdDirectWrongAssocTrackNdf3",
        "Chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Ndof ",
@@ -2064,7 +2218,13 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
          "Z of sim matched wrong cluster - Z of true sim cluster (direct) - wrong track-MTD association; DeltaZ (wrong - true) [cm]",
          1000,
          -50.,
-         50.);
+	 50.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi3_ = ibook.book1D(
+         "BTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi3",
+         "Phi of sim matched wrong cluster - Z of true sim cluster - wrong track-MTD association; DeltaPhi (wrong - true) ",
+         500,
+         -0.1,
+         0.1);
     meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT3_ = ibook.book1D(
          "BTLTrackMatchedTPmtdDirectWrongAssocDeltaT3",
          "Time of sim matched wrong cluster - time of true sim cluster (direct) - wrong track-MTD association; DeltaT (wrong - true) [ns]",
@@ -2103,16 +2263,33 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
                    50,
                    -5.,
                    5.);
-    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR3_ = ibook.bookProfile(
-      "BTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR3",
-      "; Outer R [cm]; DeltaZ [cm]",
-      100,
-      0.,
-      120.,
-      -40.,
-      40,
-      "s");
+    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR3_ = ibook.book2D(
+       "BTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR3", "; Outer R [cm]; DeltaZ [cm]", 120, 0., 120., 1000, -40., 40);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi23_ = ibook.book1D(
+       "BTLTrackMatchedTPmtdDirectWrongAssocTimeChi23",
+       "Time chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Chi2 ",
+       200,
+       0.,
+       100);
+      meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual3_ = ibook.book2D(
+       "BTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual3", "Time chi2 of tracks matched to TP with sim hit in MTD (direct), correct track-MTD association; Chi2; MVAQual ",
+       200, 0., 100, 100, -1, 1);
+   
 
+    meBTLTrackMatchedTPmtdDirectWrongAssocSpaceChi23_ = ibook.book1D(
+       "BTLTrackMatchedTPmtdDirectWrongAssocSpaceChi23",
+       "Space chi2 of tracks matched to TP with sim hit in MTD (direct), correct track-MTD association; Chi2 ",
+       250,
+       0.,
+       250.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenghtvsEta3_ = ibook.book2D(
+      "BTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenghtvsEta3", "MTD Track pathlength vs MTD track Eta;|#eta|;Pathlength", 30, 0, 1.5,350, 0.0, 350.0);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenght3_ = ibook.book1D(
+      "BTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenght3", "MTD Track pathlength ; ;Pathlength", 400, 0, 400);
+
+
+
+ 
     meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf_ = ibook.book1D(
        "BTLTrackMatchedTPmtdDirectWrongAssocTrackNdf",
        "Chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Ndof ",
@@ -2143,6 +2320,12 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
          1000,
          -50.,
          50.);
+   meBTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi_ = ibook.book1D(
+        "BTLTrackMatchedTPmtdDirectWrongAssocDeltaPhi",
+        "Phi of sim matched wrong cluster - Z of true sim cluster - wrong track-MTD association; DeltaPhi (wrong - true) ",
+        500,
+        -0.1,
+        0.1);
     meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT_ = ibook.book1D(
          "BTLTrackMatchedTPmtdDirectWrongAssocDeltaT",
          "Time of sim matched wrong cluster - time of true sim cluster (direct) - wrong track-MTD association; DeltaT (wrong - true) [ns]",
@@ -2161,15 +2344,30 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
         10,
         -5.,
         5.);
-    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR_ = ibook.bookProfile(
-       "BTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR",
-       "; Outer R [cm]; DeltaZ [cm]",
-       100,
-       -0.,
-       120.,
-       -40.,
-       40,
-       "s");
+    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR_ = ibook.book2D(
+        "BTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR", "; Outer R [cm]; DeltaZ [cm]", 120, 0., 120., 1000, -40., 40);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2_ = ibook.book1D(
+       "BTLTrackMatchedTPmtdDirectWrongAssocTimeChi2",
+       "Time chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Chi2 ",
+       200,
+       0.,
+       100);
+     meBTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual_ = ibook.book2D(
+       "BTLTrackMatchedTPmtdDirectWrongAssocTimeChi2vsMVAQual", "Time chi2 of tracks matched to TP with sim hit in MTD (direct), correct track-MTD association; Chi2; MVAQual ",
+       200, 0., 100, 100, -1, 1);
+
+    meBTLTrackMatchedTPmtdDirectWrongAssocSpaceChi2_ = ibook.book1D(
+       "BTLTrackMatchedTPmtdDirectWrongAssocSpaceChi2",
+       "Space chi2 of tracks matched to TP with sim hit in MTD (direct), correct track-MTD association; Chi2 ",
+       250,
+       0.,
+       250.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenghtvsEta_ = ibook.book2D(
+      "BTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenghtvsEta", "MTD Track pathlength vs MTD track Eta;|#eta|;Pathlength", 30, 0, 1.5,350,  0.0, 350.0);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenght_ = ibook.book1D(
+      "BTLTrackMatchedTPmtdDirectWrongAssocTrackPathLenght", "MTD Track pathlength ; ;Pathlength", 400, 0, 400);
+
+
 
     meBTLTrackMatchedTPmtdDirectNoAssocTrackNdf_ = ibook.book1D(
         "BTLTrackMatchedTPmtdDirectNoAssocTrackNdf",
@@ -2202,6 +2400,7 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
            -5.,
            5.);
 
+
     meBTLTrackMatchedTPnomtdAssocTrackChi2_ = ibook.book1D(
        "BTLTrackMatchedTPnomtdAssocTrackChi2", "Chi2 of tracks matched to TP w/o sim hit in MTD; Chi2", 80, 0., 220);
     meBTLTrackMatchedTPnomtdAssocTrackOutermostHitR_ = ibook.book1D(
@@ -2228,6 +2427,51 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
  	  5,
          -1., 
  	  4.);
+
+    meETLTrackMatchedTPmtd1CorrectAssocTimeChi2_ = ibook.book1D(
+       "ETLTrackMatchedTPmtd1CorrectAssocTimeChi2",
+       "Time chi2 of tracks matched to TP with sim hit in MTD (direct) - correct track-MTD association; Chi2 ",
+       200,
+       0.,
+       100);
+     meETLTrackMatchedTPmtd1CorrectAssocTimeChi2vsMVAQual_ = ibook.book2D(
+       "ETLTrackMatchedTPmtd1CorrectAssocTimeChi2vsMVAQual", "Time chi2 of tracks matched to TP with sim hit in MTD (direct) - correct track-MTD association; Chi2; MVAQual ",
+       200, 0., 100, 100, -1, 1);
+
+    meETLTrackMatchedTPmtd1WrongAssocTimeChi2_ = ibook.book1D(
+       "ETLTrackMatchedTPmtd1WrongAssocTimeChi2",
+       "Time chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Chi2 ",
+       200,
+       0.,
+       100);
+     meETLTrackMatchedTPmtd1WrongAssocTimeChi2vsMVAQual_ = ibook.book2D(
+       "ETLTrackMatchedTPmtd1WrongAssocTimeChi2vsMVAQual", "Time chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Chi2; MVAQual ",
+       200, 0., 100, 100, -1, 1);
+
+
+
+    meETLTrackMatchedTPmtd2CorrectAssocTimeChi2_ = ibook.book1D(
+       "ETLTrackMatchedTPmtd2CorrectAssocTimeChi2",
+       "Time chi2 of tracks matched to TP with sim hit in MTD (direct) - correct track-MTD association; Chi2 ",
+       200,
+       0.,
+       100);
+     meETLTrackMatchedTPmtd2CorrectAssocTimeChi2vsMVAQual_ = ibook.book2D(
+       "ETLTrackMatchedTPmtd2CorrectAssocTimeChi2vsMVAQual", "Time chi2 of tracks matched to TP with sim hit in MTD (direct) - correct track-MTD association; Chi2; MVAQual ",
+       200, 0., 100, 100, -1, 1);
+
+
+    meETLTrackMatchedTPmtd2WrongAssocTimeChi2_ = ibook.book1D(
+       "ETLTrackMatchedTPmtd2WrongAssocTimeChi2",
+       "Time chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Chi2 ",
+       200,
+       0.,
+       100);
+     meETLTrackMatchedTPmtd2WrongAssocTimeChi2vsMVAQual_ = ibook.book2D(
+       "ETLTrackMatchedTPmtd2WrongAssocTimeChi2vsMVAQual", "Time chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Chi2; MVAQual ",
+       200, 0., 100, 100, -1, 1);
+
+
   }  // end optional plots
 
   meTrackResTot_ = ibook.book1D(
@@ -2724,8 +2968,6 @@ void MtdTracksValidation::fillDescriptions(edm::ConfigurationDescriptions& descr
   desc.add<edm::InputTag>("inputTagH", edm::InputTag("generatorSmeared"));
   desc.add<edm::InputTag>("SimTag", edm::InputTag("mix", "MergedTrackTruth"));
   desc.add<edm::InputTag>("TPtoRecoTrackAssoc", edm::InputTag("trackingParticleRecoTrackAsssociation"));
-  //desc.add<edm::InputTag>("tp2SimAssociationMapTag", edm::InputTag("mtdSimLayerClusterToTPAssociation","","mtdValidation"));
-  //desc.add<edm::InputTag>("r2sAssociationMapTag", edm::InputTag("mtdRecoClusterToSimLayerClusterAssociation","","mtdValidation"));
   desc.add<edm::InputTag>("tp2SimAssociationMapTag", edm::InputTag("mtdSimLayerClusterToTPAssociation"));
   desc.add<edm::InputTag>("Sim2tpAssociationMapTag", edm::InputTag("mtdSimLayerClusterToTPAssociation"));
   desc.add<edm::InputTag>("r2sAssociationMapTag", edm::InputTag("mtdRecoClusterToSimLayerClusterAssociation"));
@@ -2740,6 +2982,9 @@ void MtdTracksValidation::fillDescriptions(edm::ConfigurationDescriptions& descr
   desc.add<edm::InputTag>("trackAssocSrc", edm::InputTag("trackExtenderWithMTD:generalTrackassoc"))
       ->setComment("Association between General and MTD Extended tracks");
   desc.add<edm::InputTag>("pathLengthSrc", edm::InputTag("trackExtenderWithMTD:generalTrackPathLength"));
+  desc.add<edm::InputTag>("btlMatchTimeChi2", edm::InputTag("trackExtenderWithMTD:btlMatchTimeChi2"));
+  desc.add<edm::InputTag>("etlMatchTimeChi2", edm::InputTag("trackExtenderWithMTD:etlMatchTimeChi2"));
+  desc.add<edm::InputTag>("btlMatchChi2", edm::InputTag("trackExtenderWithMTD:btlMatchChi2"));
   desc.add<edm::InputTag>("t0SafePID", edm::InputTag("tofPID:t0safe"));
   desc.add<edm::InputTag>("sigmat0SafePID", edm::InputTag("tofPID:sigmat0safe"));
   desc.add<edm::InputTag>("sigmat0PID", edm::InputTag("tofPID:sigmat0"));

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -43,6 +43,7 @@
 #include "RecoMTD/DetLayers/interface/MTDSectorForwardDoubleLayer.h"
 #include "RecoMTD/DetLayers/interface/MTDDetSector.h"
 #include "RecoMTD/Records/interface/MTDRecoGeometryRecord.h"
+#include "Geometry/MTDGeometryBuilder/interface/MTDGeomUtil.h"
 
 #include "TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixPropagator.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
@@ -144,10 +145,13 @@ private:
   edm::EDGetTokenT<reco::TrackCollection> GenRecTrackToken_;
   edm::EDGetTokenT<reco::TrackCollection> RecTrackToken_;
 
+  //edm::EDGetTokenT<MtdSimLayerClusterCollection> simClustersToken_; //simClus
+
   edm::EDGetTokenT<TrackingParticleCollection> trackingParticleCollectionToken_;
   edm::EDGetTokenT<reco::SimToRecoCollection> simToRecoAssociationToken_;
   edm::EDGetTokenT<reco::RecoToSimCollection> recoToSimAssociationToken_;
   edm::EDGetTokenT<reco::TPToSimCollectionMtd> tp2SimAssociationMapToken_;
+  edm::EDGetTokenT<reco::SimToTPCollectionMtd> Sim2tpAssociationMapToken_;//F
   edm::EDGetTokenT<MtdRecoClusterToSimLayerClusterAssociationMap> r2sAssociationMapToken_;
 
   edm::EDGetTokenT<FTLRecHitCollection> btlRecHitsToken_;
@@ -279,22 +283,85 @@ private:
 
   MonitorElement* meBTLTrackMatchedTPnomtdEta_;
   MonitorElement* meBTLTrackMatchedTPnomtdPt_;
-
   // - BTL TPmtd Direct hits: correct, wrong, missing association in MTD
   MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocEta_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocPt_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocMVAQual_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocTimeRes_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocTimePull_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocTrackOutermostHitR_; 
+  MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocTrackChi2_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocTrackNdf_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocSimClusSize_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectCorrectAssocRecoClusSize_;
 
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocEta_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocPt_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocMVAQual_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTimeRes_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTimePull_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT_; 
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackChi2_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocSimClusSize_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocRecoClusSize_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR_;
+  
+  // wrong association with reco from same TP direct hit
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocEta1_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocPt1_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocMVAQual1_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTimeRes1_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTimePull1_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT1_; 
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ1_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff1_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR1_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackChi21_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf1_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR1_;
+
+  // wrong association with reco from same TP other hit
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocEta2_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocPt2_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocMVAQual2_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTimeRes2_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTimePull2_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT2_; 
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ2_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff2_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR2_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackChi22_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf2_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR2_;
+
+  // wrong association to reco from another TP
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocEta3_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocPt3_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocMVAQual3_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTimeRes3_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTimePull3_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT3_; 
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ3_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff3_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR3_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackChi23_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf3_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR3_;
+
 
   MonitorElement* meBTLTrackMatchedTPmtdDirectNoAssocEta_;
   MonitorElement* meBTLTrackMatchedTPmtdDirectNoAssocPt_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectNoAssocTrackOutermostHitR_; 
+  MonitorElement* meBTLTrackMatchedTPmtdDirectNoAssocTrackChi2_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectNoAssocTrackNdf_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectNoAssocSimClusSize_;
+  MonitorElement* meBTLTrackMatchedTPmtdDirectNoAssocRecoClusSize_;
+
+
 
   // - BTL TPmtd "other" hits: correct, wrong, missing association in MTD
   MonitorElement* meBTLTrackMatchedTPmtdOtherCorrectAssocEta_;
@@ -318,6 +385,13 @@ private:
   MonitorElement* meBTLTrackMatchedTPnomtdAssocMVAQual_;
   MonitorElement* meBTLTrackMatchedTPnomtdAssocTimeRes_;
   MonitorElement* meBTLTrackMatchedTPnomtdAssocTimePull_;
+  MonitorElement* meBTLTrackMatchedTPnomtdAssocTrackChi2_;		    
+  MonitorElement* meBTLTrackMatchedTPnomtdAssocTrackNdf_ ;		   
+  MonitorElement* meBTLTrackMatchedTPnomtdAssocTrackOutermostHitR_; 
+  MonitorElement* meBTLTrackMatchedTPnomtdAssocTrackIdOff_; 
+  MonitorElement* meBTLTrackMatchedTPnomtdAssocSimClusSize_;
+  MonitorElement* meBTLTrackMatchedTPnomtdAssocRecoClusSize_;
+  MonitorElement* meBTLTrackMatchedTPnomtdAssocTrackID_;
 
   // - ETL: one, two o no sim hits
   MonitorElement* meETLTrackMatchedTPmtd1Eta_;  // -- sim hit in >=1 etl disk
@@ -383,6 +457,8 @@ MtdTracksValidation::MtdTracksValidation(const edm::ParameterSet& iConfig)
       trackMaxEtlEta_(iConfig.getParameter<double>("trackMaximumEtlEta")) {
   GenRecTrackToken_ = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("inputTagG"));
   RecTrackToken_ = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("inputTagT"));
+  //simClustersToken_ = consumes<
+
   trackingParticleCollectionToken_ =
       consumes<TrackingParticleCollection>(iConfig.getParameter<edm::InputTag>("SimTag"));
   simToRecoAssociationToken_ =
@@ -391,6 +467,8 @@ MtdTracksValidation::MtdTracksValidation(const edm::ParameterSet& iConfig)
       consumes<reco::RecoToSimCollection>(iConfig.getParameter<edm::InputTag>("TPtoRecoTrackAssoc"));
   tp2SimAssociationMapToken_ =
       consumes<reco::TPToSimCollectionMtd>(iConfig.getParameter<edm::InputTag>("tp2SimAssociationMapTag"));
+  Sim2tpAssociationMapToken_ =
+      consumes<reco::SimToTPCollectionMtd>(iConfig.getParameter<edm::InputTag>("Sim2tpAssociationMapTag"));//F
   r2sAssociationMapToken_ = consumes<MtdRecoClusterToSimLayerClusterAssociationMap>(
       iConfig.getParameter<edm::InputTag>("r2sAssociationMapTag"));
   btlRecHitsToken_ = consumes<FTLRecHitCollection>(iConfig.getParameter<edm::InputTag>("btlRecHits"));
@@ -438,6 +516,7 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
   std::unordered_map<uint32_t, std::set<unsigned long int>> m_btlTrkPerCell;
   std::unordered_map<uint32_t, std::set<unsigned long int>> m_etlTrkPerCell;
   const auto& tp2SimAssociationMap = iEvent.get(tp2SimAssociationMapToken_);
+  const auto& Sim2tpAssociationMap = iEvent.get(Sim2tpAssociationMapToken_);
   const auto& r2sAssociationMap = iEvent.get(r2sAssociationMapToken_);
 
   const auto& tMtd = iEvent.get(tmtdToken_);
@@ -458,6 +537,15 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
 
   auto recoToSimH = makeValid(iEvent.getHandle(recoToSimAssociationToken_));
   r2s_ = recoToSimH.product();
+  auto geometryHandle = iSetup.getTransientHandle(mtdgeoToken_); // F
+  const MTDGeometry* geom = geometryHandle.product();
+  auto topologyHandle = iSetup.getTransientHandle(mtdtopoToken_);
+  const MTDTopology *topology = topologyHandle.product();
+  
+  mtd::MTDGeomUtil geomUtil;
+  geomUtil.setGeometry(geom);
+  geomUtil.setTopology(topology);
+
 
   unsigned int index = 0;
 
@@ -536,7 +624,6 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
           }
         }
         meTrackNumHits_->Fill(numMTDBtlvalidhits);
-
         // --- keeping only tracks with last hit in MTD ---
         if (MTDBtl == true) {
           isBTL = true;
@@ -718,15 +805,22 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
           hasTime = true;
         }
 
+
+
         // ==  MC truth matching
+        double simClusterRef_RecoMatch_trackIdOff(-9999.); 
+        double simClusterRef_RecoMatch_DeltaZ(-9999.);
+        double simClusterRef_RecoMatch_DeltaT(-9999.);
+        int simClusSize(-9999);
+        int recoClusSize(-9999);
+
+ 
         bool isTPmtdDirectBTL = false, isTPmtdOtherBTL = false, isTPmtdDirectCorrectBTL = false,
              isTPmtdOtherCorrectBTL = false, isTPmtdETLD1 = false, isTPmtdETLD2 = false, isTPmtdCorrectETLD1 = false,
-             isTPmtdCorrectETLD2 = false;
+             isTPmtdCorrectETLD2 = false, isFromSameTP = false;
 
         auto simClustersRefsIt = tp2SimAssociationMap.find(*tp_info);
         const bool withMTD = (simClustersRefsIt != tp2SimAssociationMap.end());
-
-        // If there is a mtdSimLayerCluster from the tracking particle
         if (withMTD) {
           // -- Get the refs to MtdSimLayerClusters associated to the TP
           std::vector<edm::Ref<MtdSimLayerClusterCollection>> simClustersRefs;
@@ -741,7 +835,6 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
                 isTPmtdETLD2 = true;
             }
           }
-
           // === BTL
           // -- Sort BTL sim clusters by time
           std::vector<edm::Ref<MtdSimLayerClusterCollection>>::iterator directSimClusIt;
@@ -756,8 +849,10 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
             });
             // Check if TP has direct or other sim cluster for BTL
             for (const auto& simClusterRef : simClustersRefs) {
+	      //MTDDetId mtddetid = simClusterRef->detIds_and_rows().front().first;	    
               if (directSimClusIt != simClustersRefs.end() && simClusterRef == *directSimClusIt) {
                 isTPmtdDirectBTL = true;
+              //} else if (simClusterRef->trackIdOffset() != 0 && mtddetid.mtdSubDetector() == 1 ) {
               } else if (simClusterRef->trackIdOffset() != 0) {
                 isTPmtdOtherBTL = true;
               }
@@ -765,23 +860,52 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
           }
 
           // ==  Check if the track-cluster association is correct: Track->RecoClus->SimClus == Track->TP->SimClus
+	  recoClusSize = recoClustersRefs.size();
           for (const auto& recClusterRef : recoClustersRefs) {
             if (recClusterRef.isNonnull()) {
               auto itp = r2sAssociationMap.equal_range(recClusterRef);
+	      simClusSize = 0;
               if (itp.first != itp.second) {
                 auto& simClustersRefs_RecoMatch = (*itp.first).second;
+		
+                BTLDetId RecoDetId((*recClusterRef).id());
+	        simClusSize = simClustersRefs_RecoMatch.size();
 
                 for (const auto& simClusterRef_RecoMatch : simClustersRefs_RecoMatch) {
+		  	
                   // Check if simClusterRef_RecoMatch  exists in SimClusters
                   auto simClusterIt =
                       std::find(simClustersRefs.begin(), simClustersRefs.end(), simClusterRef_RecoMatch);
+	          if (optionalPlots_ && isTPmtdDirectBTL){
+                      // simCluster matched to TP 
+		      // NB we are taking the position and id of the first hit in the cluster.
+		      auto directSimClus = *directSimClusIt;
+		      MTDDetId mtddetid = directSimClus->detIds_and_rows().front().first;
+                      BTLDetId detid(mtddetid.rawId());
+	              LocalPoint simClusLocalPos = directSimClus->hits_and_positions().front().second;
+                      GlobalPoint simClusGlobalPos = geomUtil.globalPosition(detid, simClusLocalPos);
+
+		      // simClusterRef_RecoMatch infos
+  	              MTDDetId mtddetidRecoMatch = simClusterRef_RecoMatch->detIds_and_rows().front().first;
+                      BTLDetId detidRecoMatch(mtddetidRecoMatch.rawId());
+	              LocalPoint simClusRecoMatchLocalPos = simClusterRef_RecoMatch->hits_and_positions().front().second;
+                      GlobalPoint simClusRecoMatchGlobalPos = geomUtil.globalPosition(detidRecoMatch, simClusRecoMatchLocalPos);
+
+		      simClusterRef_RecoMatch_trackIdOff = simClusterRef_RecoMatch->trackIdOffset();
+                      simClusterRef_RecoMatch_DeltaZ = simClusRecoMatchGlobalPos.z() - simClusGlobalPos.z();
+                      simClusterRef_RecoMatch_DeltaT = simClusterRef_RecoMatch->simLCTime() - directSimClus->simLCTime();
+
+
+		    }
+
 
                   // SimCluster found in SimClusters
                   if (simClusterIt != simClustersRefs.end()) {
+		    isFromSameTP = true;
                     if (isBTL) {
                       if (directSimClusIt != simClustersRefs.end() && simClusterRef_RecoMatch == *directSimClusIt) {
                         isTPmtdDirectCorrectBTL = true;
-                      } else if (simClusterRef_RecoMatch->trackIdOffset() != 0) {
+	              } else if (simClusterRef_RecoMatch->trackIdOffset() != 0) {
                         isTPmtdOtherCorrectBTL = true;
                       }
                     }
@@ -814,6 +938,14 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
               if (isTPmtdDirectBTL) {
                 // -- Track matched to TP with sim hit (direct), correctly associated reco cluster
                 if (isTPmtdDirectCorrectBTL) {
+		  
+                  if (optionalPlots_) {
+		    meBTLTrackMatchedTPmtdDirectCorrectAssocSimClusSize_->Fill(simClusSize);
+                    meBTLTrackMatchedTPmtdDirectCorrectAssocRecoClusSize_->Fill(recoClusSize);
+      	            meBTLTrackMatchedTPmtdDirectCorrectAssocTrackOutermostHitR_->Fill(outermostHitPosition[trackref]);
+	            meBTLTrackMatchedTPmtdDirectCorrectAssocTrackNdf_->Fill(trackGen.ndof());
+	            meBTLTrackMatchedTPmtdDirectCorrectAssocTrackChi2_->Fill(trackGen.chi2());
+		  }
                   fillTrackClusterMatchingHistograms(meBTLTrackMatchedTPmtdDirectCorrectAssocEta_,
                                                      meBTLTrackMatchedTPmtdDirectCorrectAssocPt_,
                                                      meBTLTrackMatchedTPmtdDirectCorrectAssocMVAQual_,
@@ -828,7 +960,90 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
                 }
                 // -- Track matched to TP with sim hit (direct), incorrectly associated reco cluster
                 else {
-                  fillTrackClusterMatchingHistograms(meBTLTrackMatchedTPmtdDirectWrongAssocEta_,
+                  if (optionalPlots_) {
+		    meBTLTrackMatchedTPmtdDirectWrongAssocSimClusSize_->Fill(simClusSize);
+                    meBTLTrackMatchedTPmtdDirectWrongAssocRecoClusSize_->Fill(recoClusSize);
+		    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT_->Fill(simClusterRef_RecoMatch_DeltaT);
+		    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ_->Fill(simClusterRef_RecoMatch_DeltaZ);
+		    meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff_->Fill(simClusterRef_RecoMatch_trackIdOff);
+		    meBTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR_->Fill(outermostHitPosition[trackref]);
+                    meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf_->Fill(trackGen.ndof());
+                    meBTLTrackMatchedTPmtdDirectWrongAssocTrackChi2_->Fill(trackGen.chi2());
+                    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR_->Fill(outermostHitPosition[trackref], simClusterRef_RecoMatch_DeltaZ);
+
+
+
+                    if (simClusterRef_RecoMatch_trackIdOff == 0 && isFromSameTP){
+		      fillTrackClusterMatchingHistograms(meBTLTrackMatchedTPmtdDirectWrongAssocEta1_,
+                                     meBTLTrackMatchedTPmtdDirectWrongAssocPt1_,
+                                     meBTLTrackMatchedTPmtdDirectWrongAssocMVAQual1_,
+                                     meBTLTrackMatchedTPmtdDirectWrongAssocTimeRes1_,
+                                     meBTLTrackMatchedTPmtdDirectWrongAssocTimePull1_,
+                                     std::abs(trackGen.eta()),
+                                     trackGen.pt(),
+                                     mtdQualMVA[trackref],
+                                     dT,
+                                     pullT,
+                                     hasTime);
+        	    
+		      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT1_->Fill(simClusterRef_RecoMatch_DeltaT);
+		      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ1_->Fill(simClusterRef_RecoMatch_DeltaZ);
+		      meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff1_->Fill(simClusterRef_RecoMatch_trackIdOff);
+		      meBTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR1_->Fill(outermostHitPosition[trackref]);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf1_->Fill(trackGen.ndof());
+                      meBTLTrackMatchedTPmtdDirectWrongAssocTrackChi21_->Fill(trackGen.chi2());
+                      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR1_->Fill(outermostHitPosition[trackref], simClusterRef_RecoMatch_DeltaZ);
+
+
+
+                    } else if (simClusterRef_RecoMatch_trackIdOff > 0 && isFromSameTP){
+	            		      fillTrackClusterMatchingHistograms(meBTLTrackMatchedTPmtdDirectWrongAssocEta2_,
+                                     meBTLTrackMatchedTPmtdDirectWrongAssocPt2_,
+                                     meBTLTrackMatchedTPmtdDirectWrongAssocMVAQual2_,
+                                     meBTLTrackMatchedTPmtdDirectWrongAssocTimeRes2_,
+                                     meBTLTrackMatchedTPmtdDirectWrongAssocTimePull2_,
+                                     std::abs(trackGen.eta()),
+                                     trackGen.pt(),
+                                     mtdQualMVA[trackref],
+                                     dT,
+                                     pullT,
+                                     hasTime);
+        	    
+		      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT2_->Fill(simClusterRef_RecoMatch_DeltaT);
+		      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ2_->Fill(simClusterRef_RecoMatch_DeltaZ);
+		      meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff2_->Fill(simClusterRef_RecoMatch_trackIdOff);
+		      meBTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR2_->Fill(outermostHitPosition[trackref]);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf2_->Fill(trackGen.ndof());
+                      meBTLTrackMatchedTPmtdDirectWrongAssocTrackChi22_->Fill(trackGen.chi2());
+                      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR2_->Fill(outermostHitPosition[trackref], simClusterRef_RecoMatch_DeltaZ);
+
+
+
+                    } else if (!isFromSameTP){
+	            		     fillTrackClusterMatchingHistograms(meBTLTrackMatchedTPmtdDirectWrongAssocEta3_,
+                                     meBTLTrackMatchedTPmtdDirectWrongAssocPt3_,
+                                     meBTLTrackMatchedTPmtdDirectWrongAssocMVAQual3_,
+                                     meBTLTrackMatchedTPmtdDirectWrongAssocTimeRes3_,
+                                     meBTLTrackMatchedTPmtdDirectWrongAssocTimePull3_,
+                                     std::abs(trackGen.eta()),
+                                     trackGen.pt(),
+                                     mtdQualMVA[trackref],
+                                     dT,
+                                     pullT,
+                                     hasTime);
+        	    
+		      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT3_->Fill(simClusterRef_RecoMatch_DeltaT);
+		      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ3_->Fill(simClusterRef_RecoMatch_DeltaZ);
+		      meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff3_->Fill(simClusterRef_RecoMatch_trackIdOff);
+		      meBTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR3_->Fill(outermostHitPosition[trackref]);
+                      meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf3_->Fill(trackGen.ndof());
+                      meBTLTrackMatchedTPmtdDirectWrongAssocTrackChi23_->Fill(trackGen.chi2());
+                      meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR3_->Fill(outermostHitPosition[trackref], simClusterRef_RecoMatch_DeltaZ);
+
+		    }
+
+                  }
+		    fillTrackClusterMatchingHistograms(meBTLTrackMatchedTPmtdDirectWrongAssocEta_,
                                                      meBTLTrackMatchedTPmtdDirectWrongAssocPt_,
                                                      meBTLTrackMatchedTPmtdDirectWrongAssocMVAQual_,
                                                      meBTLTrackMatchedTPmtdDirectWrongAssocTimeRes_,
@@ -839,8 +1054,10 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
                                                      dT,
                                                      pullT,
                                                      hasTime);
+
                 }
               }
+		
               // -- Track matched to TP with sim hit (other), correctly associated reco cluster
               else if (isTPmtdOtherBTL) {
                 if (isTPmtdOtherCorrectBTL) {
@@ -875,6 +1092,14 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
             // -- Track matched to TP with sim hit in MTD, missing associated reco cluster
             else {
               if (isTPmtdDirectBTL) {
+		      
+                if (optionalPlots_) {
+		  meBTLTrackMatchedTPmtdDirectNoAssocSimClusSize_->Fill(simClusSize);
+                  meBTLTrackMatchedTPmtdDirectNoAssocRecoClusSize_->Fill(recoClusSize);
+	          meBTLTrackMatchedTPmtdDirectNoAssocTrackOutermostHitR_->Fill(outermostHitPosition[trackref]);
+                  meBTLTrackMatchedTPmtdDirectNoAssocTrackNdf_->Fill(trackGen.ndof());
+                  meBTLTrackMatchedTPmtdDirectNoAssocTrackChi2_->Fill(trackGen.chi2());
+		}
                 meBTLTrackMatchedTPmtdDirectNoAssocEta_->Fill(std::abs(trackGen.eta()));
                 meBTLTrackMatchedTPmtdDirectNoAssocPt_->Fill(trackGen.pt());
               } else if (isTPmtdOtherBTL) {
@@ -885,12 +1110,12 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
           }  // == end BTL
           // == ETL
           else {
-            // -- Track matched to TP with reco hits (one or two) correctly matched
-            if ((ETLdisc1 && isTPmtdCorrectETLD1) || (ETLdisc2 && isTPmtdCorrectETLD2)) {
+	    // -- Track matched to TP with reco hits (one or two) correctly matched
+	    if ((ETLdisc1 && isTPmtdCorrectETLD1) || (ETLdisc2 && isTPmtdCorrectETLD2)) {
               meETLTrackMatchedTPEtaMtdCorrect_->Fill(std::abs(trackGen.eta()));
-              meETLTrackMatchedTPPtMtdCorrect_->Fill(trackGen.pt());
+	      meETLTrackMatchedTPPtMtdCorrect_->Fill(trackGen.pt());
             }
-            // -- Track matched to TP with sim hit in one etl layer
+	    // -- Track matched to TP with sim hit in one etl layer
             if (isTPmtdETLD1 || isTPmtdETLD2) {  // at least one hit (D1 or D2 or both)
               meETLTrackMatchedTPmtd1Eta_->Fill(std::abs(trackGen.eta()));
               meETLTrackMatchedTPmtd1Pt_->Fill(trackGen.pt());
@@ -990,6 +1215,36 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
             meBTLTrackMatchedTPnomtdEta_->Fill(std::abs(trackGen.eta()));
             meBTLTrackMatchedTPnomtdPt_->Fill(trackGen.pt());
             if (isBTL) {
+		    
+              if (optionalPlots_) {
+	        for (const auto& recClusterRef : recoClustersRefs) { // having a look at these recos
+                  if (recClusterRef.isNonnull()) {
+                    auto itp = r2sAssociationMap.equal_range(recClusterRef);
+                    if (itp.first != itp.second) {
+                      auto& simClustersRefs_RecoMatch = (*itp.first).second;
+	              simClusSize = simClustersRefs_RecoMatch.size();
+                      for (const auto& sc : simClustersRefs_RecoMatch) {
+                        auto mytps = Sim2tpAssociationMap.find(sc);
+		        if (mytps != Sim2tpAssociationMap.end()){
+		          for (const auto& mytp : mytps->val) {
+		             if (((**tp_info).eventId().rawId() - (*mytp).eventId().rawId()) == 0 ) meBTLTrackMatchedTPnomtdAssocTrackID_->Fill(0); 
+		             else meBTLTrackMatchedTPnomtdAssocTrackID_->Fill(1);
+		          }
+		        }
+	                  meBTLTrackMatchedTPnomtdAssocTrackIdOff_->Fill(sc->trackIdOffset());
+
+	                  }
+	              }
+	            }
+	          }
+
+	    
+		  meBTLTrackMatchedTPnomtdAssocSimClusSize_->Fill(simClusSize);
+		  meBTLTrackMatchedTPnomtdAssocRecoClusSize_->Fill(recoClusSize);
+                  meBTLTrackMatchedTPnomtdAssocTrackChi2_ -> Fill(trackGen.chi2());
+                  meBTLTrackMatchedTPnomtdAssocTrackNdf_ -> Fill(trackGen.ndof());		   
+	          meBTLTrackMatchedTPnomtdAssocTrackOutermostHitR_->Fill(outermostHitPosition[trackref]) ; 
+	      }
               fillTrackClusterMatchingHistograms(meBTLTrackMatchedTPnomtdAssocEta_,
                                                  meBTLTrackMatchedTPnomtdAssocPt_,
                                                  meBTLTrackMatchedTPnomtdAssocMVAQual_,
@@ -1444,12 +1699,12 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
       ibook.book1D("ETLTrackMatchedTPEtaTot", "Eta of tracks matched to TP; track eta ", 30, 1.5, 3.0);
   meETLTrackMatchedTPEtaMtd_ = ibook.book1D(
       "ETLTrackMatchedTPEtaMtd", "Eta of tracks matched to TP with time (>=1 ETL hit); track eta ", 30, 1.5, 3.0);
-  meETLTrackMatchedTPEtaMtdCorrect_ =
-      ibook.book1D("ETLTrackMatchedTPEtaMtdCorrect",
-                   "Eta of tracks matched to TP with time (>=1 ETL hit), correct reco match; track eta ",
-                   30,
-                   1.5,
-                   3.0);
+   meETLTrackMatchedTPEtaMtdCorrect_ =
+	   ibook.book1D("ETLTrackMatchedTPEtaMtdCorrect",
+                         "Eta of tracks matched to TP with time (>=1 ETL hit), correct reco match; track eta ",
+			 30,
+			 1.5,
+			 3.0);
   meETLTrackMatchedTPEta2Mtd_ = ibook.book1D(
       "ETLTrackMatchedTPEta2Mtd", "Eta of tracks matched to TP with time (2 ETL hits); track eta ", 30, 1.5, 3.0);
   meETLTrackMatchedTPPtTot_ =
@@ -1457,11 +1712,11 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
   meETLTrackMatchedTPPtMtd_ = ibook.book1D(
       "ETLTrackMatchedTPPtMtd", "Pt of tracks matched to TP with time (>=1 ETL hit); track pt [GeV] ", 50, 0., 10.);
   meETLTrackMatchedTPPtMtdCorrect_ =
-      ibook.book1D("ETLTrackMatchedTPPtMtdCorrect",
-                   "Pt of tracks matched to TP with time (>=1 ETL hit), correct reco match; track pt [GeV] ",
-                   50,
-                   0.,
-                   10.);
+	  ibook.book1D("ETLTrackMatchedTPPtMtdCorrect",
+			   "Pt of tracks matched to TP with time (>=1 ETL hit), correct reco match; track pt [GeV] ",
+			    50,
+			    0.,
+			    10.);
   meETLTrackMatchedTPPt2Mtd_ = ibook.book1D(
       "ETLTrackMatchedTPPt2Mtd", "Pt of tracks matched to TP with time (2 ETL hits); track pt [GeV] ", 50, 0., 10.);
 
@@ -1592,6 +1847,387 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
                                                         -0.1,
                                                         0.1,
                                                         "s");
+
+    meBTLTrackMatchedTPmtdDirectCorrectAssocTrackNdf_ = ibook.book1D(
+       "BTLTrackMatchedTPmtdDirectCorrectAssocTrackNdf",
+       "Ndf of tracks matched to TP with sim hit in MTD (direct), correct track-MTD association; Ndof ",
+       80,
+       0.,
+       220);
+    meBTLTrackMatchedTPmtdDirectCorrectAssocTrackChi2_ = ibook.book1D(
+       "BTLTrackMatchedTPmtdDirectCorrectAssocTrackChi2",
+       "Chi2 of tracks matched to TP with sim hit in MTD (direct), correct track-MTD association; Chi2 ",
+       80,
+       0.,
+       220);
+    meBTLTrackMatchedTPmtdDirectCorrectAssocTrackOutermostHitR_ = ibook.book1D(
+       "BTLTrackMatchedTPmtdDirectCorrectAssocTrackOutermostHitR",
+       "Outermost hit position R of tracks matched to TP with sim hit in MTD (direct), correct track-MTD association; R [cm] ",
+       40,
+       0.,
+       120);
+    meBTLTrackMatchedTPmtdDirectCorrectAssocSimClusSize_ =  ibook.book1D(
+         "BTLTrackMatchedTPmtdDirectCorrectAssocSimClusSize",
+         "Size of the sim clusters associated to the reco cluster associated to the track (direct), correct track-MTD association; Number of clusters ",
+         10,
+         -5.,
+         5.);
+    meBTLTrackMatchedTPmtdDirectCorrectAssocRecoClusSize_ =  ibook.book1D(
+         "BTLTrackMatchedTPmtdDirectCorrectAssocRecoClusSize",
+         "Size of the reco cluster associated to the track (direct), correct track-MTD association; Number of clusters ",
+         10,
+         -5.,
+         5.);
+
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf1_ = ibook.book1D(
+       "BTLTrackMatchedTPmtdDirectWrongAssocTrackNdf1",
+       "Ndf of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Ndof ",
+       80,
+       0.,
+       220);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackChi21_ = ibook.book1D(
+       "BTLTrackMatchedTPmtdDirectWrongAssocTrackChi21",
+       "Chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Chi2 ",
+       80,
+       0.,
+       220);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR1_ = ibook.book1D(
+        "BTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR1",
+        "Outermost hit position R of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; R [cm]",
+        40,
+        0.,
+        120);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff1_ = ibook.book1D(
+        "BTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff1",
+        "Track Id offset of reco (wrong) cluster associated to the track (direct)  - wrong track-MTD association; trackId (wrong)",
+        6,
+        -1.,
+        5.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ1_ = ibook.book1D(
+         "BTLTrackMatchedTPmtdDirectWrongAssocDeltaZ1",
+         "Z of sim matched wrong cluster - Z of true sim cluster (direct) - wrong track-MTD association; DeltaZ (wrong - true) [cm]",
+         1000,
+         -50.,
+         50.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT1_ = ibook.book1D(
+         "BTLTrackMatchedTPmtdDirectWrongAssocDeltaT1",
+         "Time of sim matched wrong cluster - time of true sim cluster (direct) - wrong track-MTD association; DeltaT (wrong - true) [ns]",
+         480,
+         -0.6,
+         0.6);
+    meBTLTrackMatchedTPmtdDirectWrongAssocEta1_ =
+       ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocEta1",
+                    "Eta of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association;#eta_{RECO}",
+                    30,
+                    0.,
+                    1.5);
+    meBTLTrackMatchedTPmtdDirectWrongAssocPt1_ = ibook.book1D(
+       "BTLTrackMatchedTPmtdDirectWrongAssocPt1",
+       "Pt of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association;track pt [GeV]",
+       50,
+       0.,
+       10.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocMVAQual1_ =
+       ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocMVAQual1",
+                    "MVA of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; MVA score",
+                    100,
+                    -1.,
+                    1.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTimeRes1_ =
+       ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocTimeRes1",
+                    "Time resolution of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD "
+                    "association; t_{rec} - t_{sim} [ns] ",
+                    240,
+                    -0.3,
+                    0.3);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTimePull1_ =
+       ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocTimePull1",
+                    "Time pull of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; "
+                    "(t_{rec}-t_{sim})/#sigma_{t}",
+                    50,
+                    -5.,
+                    5.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR1_ = ibook.bookProfile(
+       "BTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR1",
+       "; Outer R [cm]; DeltaZ [cm]",
+       100,
+       -0.,
+       120.,
+       -40.,
+       40,
+       "s");
+
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf2_ = ibook.book1D(
+        "BTLTrackMatchedTPmtdDirectWrongAssocTrackNdf2",
+        "Chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Ndof ",
+        80,
+        0.,
+        220);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackChi22_ = ibook.book1D(
+        "BTLTrackMatchedTPmtdDirectWrongAssocTrackChi22",
+        "Chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Chi2 ",
+        80,
+        0.,
+        220);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR2_ = ibook.book1D(
+        "BTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR2",
+        "Outermost hit position R of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; R [cm]",
+        40,
+        0.,
+        120);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff2_ = ibook.book1D(
+        "BTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff2",
+        "Track Id offset of reco (wrong) cluster associated to the track (direct)  - wrong track-MTD association; trackId (wrong)",
+        6,
+        -1.,
+        5.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ2_ = ibook.book1D(
+         "BTLTrackMatchedTPmtdDirectWrongAssocDeltaZ2",
+         "Z of sim matched wrong cluster - Z of true sim cluster (direct) - wrong track-MTD association; DeltaZ (wrong - true) [cm]",
+         1000,
+         -50.,
+         50.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT2_ = ibook.book1D(
+         "BTLTrackMatchedTPmtdDirectWrongAssocDeltaT2",
+         "Time of sim matched wrong cluster - time of true sim cluster (direct) - wrong track-MTD association; DeltaT (wrong - true) [ns]",
+         480,
+         -0.6,
+         0.6);
+    meBTLTrackMatchedTPmtdDirectWrongAssocEta2_ =
+       ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocEta2",
+                    "Eta of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association;#eta_{RECO}",
+                    30,
+                    0.,
+                    1.5);
+    meBTLTrackMatchedTPmtdDirectWrongAssocPt2_ = ibook.book1D(
+       "BTLTrackMatchedTPmtdDirectWrongAssocPt2",
+       "Pt of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association;track pt [GeV]",
+       50,
+       0.,
+       10.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocMVAQual2_ =
+       ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocMVAQual2",
+                    "MVA of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; MVA score",
+                    100,
+                    -1.,
+                    1.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTimeRes2_ =
+       ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocTimeRes2",
+                    "Time resolution of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD "
+                    "association; t_{rec} - t_{sim} [ns] ",
+                    240,
+                    -0.3,
+                    0.3);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTimePull2_ =
+      ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocTimePull2",
+                   "Time pull of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; "
+                   "(t_{rec}-t_{sim})/#sigma_{t}",
+                   50,
+                   -5.,
+                   5.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR2_ = ibook.bookProfile(
+      "BTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR2",
+      "; Outer R [cm]; DeltaZ [cm]",
+      100,
+      -0.,
+      120.,
+      -40.,
+      40,
+      "s");
+    
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf3_ = ibook.book1D(
+       "BTLTrackMatchedTPmtdDirectWrongAssocTrackNdf3",
+       "Chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Ndof ",
+       80,
+       0.,
+       220);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackChi23_ = ibook.book1D(
+       "BTLTrackMatchedTPmtdDirectWrongAssocTrackChi23",
+       "Chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Chi2 ",
+       80,
+       0.,
+       220);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR3_ = ibook.book1D(
+       "BTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR3",
+       "Outermost hit position R of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; R [cm]",
+       40,
+       0.,
+       120);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff3_ = ibook.book1D(
+        "BTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff3",
+        "Track Id offset of reco (wrong) cluster associated to the track (direct)  - wrong track-MTD association; trackId (wrong)",
+        6,
+        -1.,
+        5.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ3_ = ibook.book1D(
+         "BTLTrackMatchedTPmtdDirectWrongAssocDeltaZ3",
+         "Z of sim matched wrong cluster - Z of true sim cluster (direct) - wrong track-MTD association; DeltaZ (wrong - true) [cm]",
+         1000,
+         -50.,
+         50.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT3_ = ibook.book1D(
+         "BTLTrackMatchedTPmtdDirectWrongAssocDeltaT3",
+         "Time of sim matched wrong cluster - time of true sim cluster (direct) - wrong track-MTD association; DeltaT (wrong - true) [ns]",
+         480,
+         -0.6,
+         0.6);
+    meBTLTrackMatchedTPmtdDirectWrongAssocEta3_ =
+       ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocEta3",
+                    "Eta of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association;#eta_{RECO}",
+                    30,
+                    0.,
+                    1.5);
+    meBTLTrackMatchedTPmtdDirectWrongAssocPt3_ = ibook.book1D(
+       "BTLTrackMatchedTPmtdDirectWrongAssocPt3",
+       "Pt of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association;track pt [GeV]",
+       50,
+       0.,
+       10.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocMVAQual3_ =
+       ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocMVAQual3",
+                    "MVA of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; MVA score",
+                    100,
+                    -1.,
+                    1.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTimeRes3_ =
+       ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocTimeRes3",
+                    "Time resolution of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD "
+                    "association; t_{rec} - t_{sim} [ns] ",
+                    240,
+                    -0.3,
+                    0.3);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTimePull3_ =
+      ibook.book1D("BTLTrackMatchedTPmtdDirectWrongAssocTimePull3",
+                   "Time pull of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; "
+                   "(t_{rec}-t_{sim})/#sigma_{t}",
+                   50,
+                   -5.,
+                   5.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR3_ = ibook.bookProfile(
+      "BTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR3",
+      "; Outer R [cm]; DeltaZ [cm]",
+      100,
+      0.,
+      120.,
+      -40.,
+      40,
+      "s");
+
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackNdf_ = ibook.book1D(
+       "BTLTrackMatchedTPmtdDirectWrongAssocTrackNdf",
+       "Chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Ndof ",
+       80,
+       0.,
+       220);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackChi2_ = ibook.book1D(
+       "BTLTrackMatchedTPmtdDirectWrongAssocTrackChi2",
+       "Chi2 of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; Chi2 ",
+       80,
+       0.,
+       220);
+    meBTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR_ = ibook.book1D(
+       "BTLTrackMatchedTPmtdDirectWrongAssocTrackOutermostHitR",
+       "Outermost hit position R of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association; R [cm]",
+       40,
+       0.,
+       120);
+     meBTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff_ = ibook.book1D(
+        "BTLTrackMatchedTPmtdDirectWrongAssocTrackIdOff",
+        "Track Id offset of reco (wrong) cluster associated to the track (direct)  - wrong track-MTD association; trackId (wrong)",
+        6,
+        -1.,
+        5.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZ_ = ibook.book1D(
+         "BTLTrackMatchedTPmtdDirectWrongAssocDeltaZ",
+         "Z of sim matched wrong cluster - Z of true sim cluster (direct) - wrong track-MTD association; DeltaZ (wrong - true) [cm]",
+         1000,
+         -50.,
+         50.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaT_ = ibook.book1D(
+         "BTLTrackMatchedTPmtdDirectWrongAssocDeltaT",
+         "Time of sim matched wrong cluster - time of true sim cluster (direct) - wrong track-MTD association; DeltaT (wrong - true) [ns]",
+         480,
+         -0.6,
+         0.6);
+    meBTLTrackMatchedTPmtdDirectWrongAssocSimClusSize_ =  ibook.book1D(
+        "BTLTrackMatchedTPmtdDirectWrongAssocSimClusSize",
+        "Size of the sim clusters associated to the reco cluster associated to the track (direct) - wrong track-MTD association; Number of clusters ",
+        10,
+        -5.,
+        5.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocRecoClusSize_ =  ibook.book1D(
+        "BTLTrackMatchedTPmtdDirectWrongAssocRecoClusSize",
+        "Size of the reco cluster associated to the track (direct) - wrong track-MTD association; Number of clusters ",
+        10,
+        -5.,
+        5.);
+    meBTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR_ = ibook.bookProfile(
+       "BTLTrackMatchedTPmtdDirectWrongAssocDeltaZOutR",
+       "; Outer R [cm]; DeltaZ [cm]",
+       100,
+       -0.,
+       120.,
+       -40.,
+       40,
+       "s");
+
+    meBTLTrackMatchedTPmtdDirectNoAssocTrackNdf_ = ibook.book1D(
+        "BTLTrackMatchedTPmtdDirectNoAssocTrackNdf",
+        "Ndof of tracks matched to TP with sim hit in MTD (direct) - no track-MTD association; Ndof ",
+        80,
+        0.,
+        220);
+    meBTLTrackMatchedTPmtdDirectNoAssocTrackChi2_ = ibook.book1D(
+        "BTLTrackMatchedTPmtdDirectNoAssocTrackChi2",
+        "Chi2 of tracks matched to TP with sim hit in MTD (direct) - no track-MTD association; Chi2 ",
+        80,
+        0.,
+        220);
+    meBTLTrackMatchedTPmtdDirectNoAssocTrackOutermostHitR_ = ibook.book1D(
+        "BTLTrackMatchedTPmtdDirectNoAssocTrackOutermostHitR",
+        "Outermost hit position R of tracks matched to TP with sim hit in MTD (direct) - no track-MTD association; R [cm]",
+        40,
+        0.,
+        120);
+    meBTLTrackMatchedTPmtdDirectNoAssocSimClusSize_ =  ibook.book1D(
+           "BTLTrackMatchedTPmtdDirectNoAssocSimClusSize",
+           "Size of the sim clusters associated to the reco cluster associated to the track (direct) - no track-MTD association; Number of clusters ",
+           10,
+           -5.,
+           5.);
+    meBTLTrackMatchedTPmtdDirectNoAssocRecoClusSize_ =  ibook.book1D(
+           "BTLTrackMatchedTPmtdDirectNoAssocRecoClusSize",
+           "Size of the reco cluster associated to the track (direct) - no track-MTD association; Number of clusters ",
+           10,
+           -5.,
+           5.);
+
+    meBTLTrackMatchedTPnomtdAssocTrackChi2_ = ibook.book1D(
+       "BTLTrackMatchedTPnomtdAssocTrackChi2", "Chi2 of tracks matched to TP w/o sim hit in MTD; Chi2", 80, 0., 220);
+    meBTLTrackMatchedTPnomtdAssocTrackOutermostHitR_ = ibook.book1D(
+       "BTLTrackMatchedTPnomtdAssocTrackOutermostHitR", "Outermost hit position R of tracks matched to TP w/o sim hit in MTD; R [cm]", 40, 0., 120.);
+    meBTLTrackMatchedTPnomtdAssocTrackNdf_ = ibook.book1D(
+       "BTLTrackMatchedTPnomtdAssocTrackNdf", "Ndf of tracks matched to TP w/o sim hit in MTD; Ndof", 80, 0., 220);
+    meBTLTrackMatchedTPnomtdAssocTrackIdOff_ = ibook.book1D(
+       "BTLTrackMatchedTPnomtdAssocTrackIdOff", "TrackIdOff of simCluster matched to the reco cluster associated to the track,  TP w/o sim hit in MTD; Track Id Off", 6, -1., 5.);
+    meBTLTrackMatchedTPnomtdAssocSimClusSize_ =  ibook.book1D(
+          "BTLTrackMatchedTPnomtdAssocSimClusSize",
+          "Size of the sim clusters associated to the reco cluster associated to the track (direct),  TP w/o sim hit in MTD; Number of clusters ",
+          10,
+          -5.,
+          5.);
+    meBTLTrackMatchedTPnomtdAssocRecoClusSize_ =  ibook.book1D(
+          "BTLTrackMatchedTPnomtdAssocRecoClusSize",
+          "Size of the reco cluster associated to the track (direct),  TP w/o sim hit in MTD; Number of clusters ",
+          10,
+          -5.,
+          5.);
+    meBTLTrackMatchedTPnomtdAssocTrackID_ = ibook.book1D(
+          "BTLTrackMatchedTPnomtdAssocTrackID", 
+ 	  "Diff track raw ID, TP w/o sim hit in MTD ; diff track raw Id",
+ 	  5,
+         -1., 
+ 	  4.);
   }  // end optional plots
 
   meTrackResTot_ = ibook.book1D(
@@ -1637,7 +2273,6 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
                    66,
                    0.,
                    3.3);
-  ;
   meExtraMTDfailExtenderPt_ = ibook.book1D(
       "ExtraMTDfailExtenderPt",
       "Pt of tracks associated to LV extrapolated to MTD with no track extender match to hits; track pt [GeV] ",
@@ -1715,6 +2350,7 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
                    30,
                    0.,
                    1.5);
+
   meBTLTrackMatchedTPmtdDirectWrongAssocPt_ = ibook.book1D(
       "BTLTrackMatchedTPmtdDirectWrongAssocPt",
       "Pt of tracks matched to TP with sim hit in MTD (direct) - wrong track-MTD association;track pt [GeV]",
@@ -2088,7 +2724,10 @@ void MtdTracksValidation::fillDescriptions(edm::ConfigurationDescriptions& descr
   desc.add<edm::InputTag>("inputTagH", edm::InputTag("generatorSmeared"));
   desc.add<edm::InputTag>("SimTag", edm::InputTag("mix", "MergedTrackTruth"));
   desc.add<edm::InputTag>("TPtoRecoTrackAssoc", edm::InputTag("trackingParticleRecoTrackAsssociation"));
+  //desc.add<edm::InputTag>("tp2SimAssociationMapTag", edm::InputTag("mtdSimLayerClusterToTPAssociation","","mtdValidation"));
+  //desc.add<edm::InputTag>("r2sAssociationMapTag", edm::InputTag("mtdRecoClusterToSimLayerClusterAssociation","","mtdValidation"));
   desc.add<edm::InputTag>("tp2SimAssociationMapTag", edm::InputTag("mtdSimLayerClusterToTPAssociation"));
+  desc.add<edm::InputTag>("Sim2tpAssociationMapTag", edm::InputTag("mtdSimLayerClusterToTPAssociation"));
   desc.add<edm::InputTag>("r2sAssociationMapTag", edm::InputTag("mtdRecoClusterToSimLayerClusterAssociation"));
   desc.add<edm::InputTag>("btlRecHits", edm::InputTag("mtdRecHits", "FTLBarrel"));
   desc.add<edm::InputTag>("etlRecHits", edm::InputTag("mtdRecHits", "FTLEndcap"));


### PR DESCRIPTION
#### PR description:

This PR adds optional histograms to the MtdTracksValidation class for correct, wrong, and missing associations of an MTD cluster to a track.

#### PR validation:

Code compiles, runs, and produces expected results. Tested on:
/RelValTTbar_14TeV/CMSSW_15_0_0_pre2-PU_141X_mcRun4_realistic_v3_STD_Run4D110_PU-v1/GEN-SIM-RECO

