### PR TITLE
[Backport to 15_0_X (#47974)] Adjust "hard-coded" HcalTPChannelParameters for HB TP Algorithm in Phase 2

### DIFF
--- a/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
@@ -756,10 +756,18 @@ HcalTPChannelParameter HcalDbHardcode::makeHardcodeTPChannelParameter(HcalGeneri
   // mask for channel validity and self trigger information, fine grain
   // bit information and auxiliary words
   uint32_t bitInfo = ((44 << 16) | 30);
+  int auxi1 = 0;
   int auxi2 = 0;
   if (fId.genericSubdet() == HcalGenericDetId::HcalGenZDC)
     auxi2 = 50;  // ZDC bunch spacing parameter
-  return HcalTPChannelParameter(fId.rawId(), 0, bitInfo, 0, auxi2);
+
+  // Hard code Run 3 TP algorithm for HB (OOT PU subtraction, prefire veto)
+  else if (fId.subdetId() == HcalTriggerTower) {
+    auxi1 = 120;  // OOT PU subtraction presample weighting factor (fixed-point 8-bit) (w ~ 0.47)
+    auxi2 = 0;    // For now, leave prefire veto off
+  }
+
+  return HcalTPChannelParameter(fId.rawId(), 0, bitInfo, auxi1, auxi2);
 }
 
 void HcalDbHardcode::makeHardcodeTPParameters(HcalTPParameters& tppar) const {

--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
@@ -1022,10 +1022,6 @@ std::unique_ptr<HcalTPChannelParameters> HcalHardcodeCalibrations::produceTPChan
   auto result = std::make_unique<HcalTPChannelParameters>(&topo);
   const std::vector<HcalGenericDetId>& cells = allCells(topo, zdcTopo, dbHardcode.killHE());
   for (auto cell : cells) {
-    // Thinking about Phase2 and the new FIR filter,
-    // for now, don't put TT in TPChannelParams
-    if (cell.subdetId() == HcalTriggerTower)
-      continue;
     HcalTPChannelParameter item = dbHardcode.makeHardcodeTPChannelParameter(cell);
     result->addValues(item);
   }


### PR DESCRIPTION
#### PR description:

This PR makes some small adjustments to the so-called HCAL "hard-coded" conditions, and specifically those for `HcalTPChannelParameters`. The adjustment explicitly sets the `auxi1` and `auxi2` `HcalTPChannelParameter` fields to match those currently used for Run3 Era to configure/use the OOT-PU-subtracting, prefire-vetoing trigger primitive algorithm used in HB and HE. The current HB TP algorithm being configured in Phase2 workflows is the now-legacy Run2/Run1 algorithm, which is not envisioned to be returned to in Phase2.

Additionally, the pulse containment correction "fix" is toggled on for the Phase2 Era, as it impacts HB TPs.

Changes **_are_** expected for Phase2 workflows for HB trigger primitives.

#### PR validation:



#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is a backport of #47974 to 15_0_X in order to get picked up during the next Phase 2 MC campaign.