### PR TITLE
Remove SubProcess related code from Timing Service

### DIFF
--- a/FWCore/AbstractServices/interface/TimingServiceBase.h
+++ b/FWCore/AbstractServices/interface/TimingServiceBase.h
@@ -1,11 +1,11 @@
+// -*- C++ -*-
 #ifndef FWCore_AbstractServices_interface_TimingServiceBase_h
 #define FWCore_AbstractServices_interface_TimingServiceBase_h
-// -*- C++ -*-
 //
 // Package:     FWCore/AbstractServices
 // Class  :     TimingServiceBase
 //
-/**\class TimingServiceBase TimingServiceBase.h "TimingServiceBase.h"
+/**\class edm::TimingServiceBase
 
  Description: Base class for Timing Services
 
@@ -18,13 +18,8 @@
 //         Created:  Wed, 11 Jun 2014 14:50:33 GMT
 //
 
-// system include files
 #include <chrono>
 
-// user include files
-#include "FWCore/Utilities/interface/StreamID.h"
-
-// forward declarations
 namespace edm {
   class TimingServiceBase {
   public:

--- a/FWCore/AbstractServices/src/TimingServiceBase.cc
+++ b/FWCore/AbstractServices/src/TimingServiceBase.cc
@@ -10,17 +10,10 @@
 //         Created:  Wed, 11 Jun 2014 15:08:00 GMT
 //
 
-// system include files
-#include <sys/resource.h>
-#include <sys/time.h>
-
-// user include files
 #include "FWCore/AbstractServices/interface/TimingServiceBase.h"
 
 using namespace edm;
-//
-// constants, enums and typedefs
-//
+
 std::chrono::steady_clock::time_point TimingServiceBase::s_jobStartTime;
 
 void TimingServiceBase::jobStarted() {


### PR DESCRIPTION
#### PR description:

Remove SubProcess related code from Timing Service. All these changes are in the file Timing.cc.

There are a few additional modifications to fix unneeded or missing header includes, remove unnecessary comments, fix things Doxygen is looking for...

This should not affect the output of this service in any way given that earlier PRs have removed the SubProcess feature already. This is just cleanup of dead code.

#### PR validation:

Relies on existing tests.
