### PR TITLE
Add missing dependence on ROOT to a few packages

### DIFF
--- a/CondFormats/GBRForest/BuildFile.xml
+++ b/CondFormats/GBRForest/BuildFile.xml
@@ -1,5 +1,6 @@
 <use name="FWCore/Utilities"/>
 <use name="CondFormats/Serialization"/>
+<use name="rootcling"/>
 <export>
   <lib name="1"/>
 </export>

--- a/CondFormats/HIObjects/BuildFile.xml
+++ b/CondFormats/HIObjects/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="CondFormats/Serialization"/>
 <use name="FWCore/Utilities"/>
 <use name="boost_serialization"/>
+<use name="rootcling"/>
 <export>
   <lib name="1"/>
 </export>

--- a/CondFormats/Luminosity/BuildFile.xml
+++ b/CondFormats/Luminosity/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="FWCore/Utilities"/>
 <use name="CondFormats/Serialization"/>
 <use name="boost_serialization"/>
+<use name="rootcling"/>
 <export>
   <lib name="1"/>
 </export>

--- a/SimDataFormats/EncodedEventId/BuildFile.xml
+++ b/SimDataFormats/EncodedEventId/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <export>
   <lib name="1"/>
 </export>


### PR DESCRIPTION
#### PR description:

These packages define dictionaries, and therefore should depend from ROOT explicitly.

These came up as part of the build log of https://github.com/cms-sw/cmsdist/pull/9816#issuecomment-2839776868

Resolves https://github.com/cms-sw/framework-team/issues/1373

#### PR validation:

None