### PR TITLE
[L1T] Fix Phase2L1DPGwithGen option in integrated Phase2-L1Nano tool and include HPS Taus in output (Phase2)

### DIFF
--- a/DPGAnalysis/Phase2L1TNanoAOD/python/l1tPh2Nanotables_cff.py
+++ b/DPGAnalysis/Phase2L1TNanoAOD/python/l1tPh2Nanotables_cff.py
@@ -528,7 +528,7 @@ p2L1TablesTask = cms.Task(
     caloTauTable,
     nnCaloTauTable,
     nnPuppiTauTable,
-    # hpsTauTable,
+    hpsTauTable,
     # GTT
     vtxTable,
     pvtxTable,

--- a/PhysicsTools/NanoAOD/python/autoNANO.py
+++ b/PhysicsTools/NanoAOD/python/autoNANO.py
@@ -57,7 +57,7 @@ autoNANO = {
                         #  'DPGAnalysis/Phase2L1TNanoAOD/l1tPh2Nano_cff.addGenObjects', # <- not included here as requires reco vertices and cannot be run in workflows w/o MINIAOD
                          ])},
     'Phase2L1DPGwithGen' : {'sequence': '@Phase2L1DPG',
-                            'customize': 'Phase2L1DPG+DPGAnalysis/Phase2L1TNanoAOD/l1tPh2Nano_cff.addGenObjects',},
+                            'customize': '@Phase2L1DPG+DPGAnalysis/Phase2L1TNanoAOD/l1tPh2Nano_cff.addGenObjects',},
     # Muon POG flavours : add tables through customize, supposed to be combined with PHYS
     'MUPOG': {'sequence': '@PHYS',
               'customize': '@PHYS+PhysicsTools/NanoAOD/custom_muon_cff.PrepMuonCustomNanoAOD'},


### PR DESCRIPTION
#### PR description:

Addresses two bugs found when testing the Phase2-L1Nano package, which was included in CMSSW (via PR #47178) starting from the release `CMSSW_15_1_0_pre2`:
- Fixes `NANO:@Phase2L1DPGwithGen` cmsDriver step, which adds in the generator-level information to the output nanoAOD: this is equivalent to using the `NANO:@Phase2L1DPG` step with `DPGAnalysis/Phase2L1TNanoAOD/l1tPh2Nano_cff.addGenObjects` appended to the customisations
- Adds HPSTau objects into the Phase2-L1NanoAOD output: the input collection was fixed previously in PR #47723  but their inclusion in the output was mistakenly commented out

#### PR validation:

Used the following CMS Driver command from a `CMSSW_15_1_0_pre2` setup for local testing, and verified that the `Phase2L1DPGwithGen` option worked, and that the `Gen*`, `nL1hpsTau` and `L1hpsTau_*` branches were in the nanoAOD output: 

```
cmsDriver.py l1nanoPhase2 -s L1TrackTrigger,L1,L1P2GT,NANO:@Phase2L1DPGwithGen --conditions auto:phase2_realistic_T33 --geometry ExtendedRun4D110 --era Phase2C17I13M9 --eventcontent NANOAOD --datatier GEN-SIM-DIGI-RAW-MINIAOD --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000,Configuration/DataProcessing/Utils.addMonitoring,L1Trigger/Configuration/customisePhase2TTOn110.customisePhase2TTOn110 --filein /store/mc/Phase2Spring24DIGIRECOMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_AllTP_140X_mcRun4_realistic_v4-v1/2560000/11d1f6f0-5f03-421e-90c7-b5815197fc85.root --fileout file:output_Phase2_L1T.root --python_filename v45_rerunL1wTT_cfg.py --inputCommands="keep *, drop l1tPFJets_*_*_*, drop l1tTrackerMuons_l1tTkMuonsGmt*_*_HLT" --mc -n 1 --nThreads 4
```

Ran over the Spring24 VBF_HToTauTau 200PU samples with the above recipe to verify with larger statistics that the other tau object collections are not impacted by this change, and that the HPS taus are included successfully. Example plots showing the matching efficiency vs pT in the barrel are shown here to show the inclusion of hpsTaus in the corrected version in this PR, as well as a comparison with default 151pre2 showing that the other L1 tau objects are not impacted: 

![image](https://github.com/user-attachments/assets/f0d2c48e-01ed-4bde-a774-0814325ac290)
![image](https://github.com/user-attachments/assets/737d2e3c-ac1b-4fbe-bcfb-60b13eb0b75f)
