### PR TITLE
Add '22+'23 Scouting Glo-ParT Inference Facility

### DIFF
--- a/PhysicsTools/NanoAOD/python/run3scouting_cff.py
+++ b/PhysicsTools/NanoAOD/python/run3scouting_cff.py
@@ -580,11 +580,16 @@ scoutingFatPFJetReclusterGlobalParticleTransformerJetTags = cms.EDProducer("Boos
     produceValueMap = cms.untracked.bool(True),
     src = cms.InputTag("scoutingFatPFJetReclusterGlobalParticleTransformerJetTagInfos"),
     preprocess_json = cms.string("RecoBTag/Combined/data/Run3Scouting/GlobalParticleTransformerAK8/General/V00/preprocess.json"),
-    model_path = cms.FileInPath("RecoBTag/Combined/data/Run3Scouting/GlobalParticleTransformerAK8/General/V00/global-part_2024.onnx"),
+    model_path = cms.FileInPath("RecoBTag/Combined/data/Run3Scouting/GlobalParticleTransformerAK8/General/V00/global-part_2022to2023.onnx"),
     flav_names = cms.vstring([
              "probQCD", "probXbb", "probXcc", "probXss", "probXqq", "probXbs", "probXgg", "probXee", "probXmm", "probXtauhtaue", "probXtauhtaum", "probXtauhtauh", "probXbc", "probXcs", "probXud", "massCorrGeneric", "massCorrGenericX2p", "massCorrGenericW2p", "massCorrResonance"
      ]),
     debugMode = cms.untracked.bool(False),
+)
+
+run3_scouting_nanoAOD_2024.toModify(
+    scoutingFatPFJetReclusterGlobalParticleTransformerJetTags,
+    model_path = cms.FileInPath("RecoBTag/Combined/data/Run3Scouting/GlobalParticleTransformerAK8/General/V00/global-part_2024.onnx")
 )
 
 # AK8 jet softdrop mass


### PR DESCRIPTION
#### PR description:

#### Please test this PR with https://github.com/cms-data/RecoBTag-Combined/pull/68.

This PR adds the '22+'23 Scouting Glo-ParT model's inference facility into CMSSW, prepared for Scouting NanoAOD official production of 2022 and 2023.
Model performance details are provided in these [[slides]](https://cernbox.cern.ch/s/U68JRc7Tp1iivFJ) (accessible via CMS). This would mainly add a era modifier to decide which Scouting Glo-ParT to use.

Scouting Global Particle Transformer (Glo-ParT) is an inclusive tagging model for AK8 scouting PFjets. It functions as both a global tagger and a mass regression model for AK8 scouting PFjets and can also be utilized as a pre-trained model. Further details can be found in the slides.

#### PR validation:

The PR passed the tests listed at https://cms-sw.github.io/PRWorkflow.html.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Will be backported to CMSSW_15_0_X: https://github.com/cms-sw/cmssw/pull/47989