### PR TITLE
Update for Masked VFAT plots on GEM onlineDQM

### DIFF
--- a/DQM/GEM/interface/GEMDAQStatusSource.h
+++ b/DQM/GEM/interface/GEMDAQStatusSource.h
@@ -63,7 +63,6 @@ protected:
 private:
   int ProcessWithMEMap4(BookingHelper &bh, ME4IdsKey key) override;
   int ProcessWithMEMap5WithChamber(BookingHelper &bh, ME5IdsKey key) override;
-
   void SetLabelAMC13Status(MonitorElement *h2Status);
   void SetLabelAMCStatus(MonitorElement *h2Status);
   void SetLabelOHStatus(MonitorElement *h2Status);

--- a/DQM/GEM/interface/GEMDAQStatusSource.h
+++ b/DQM/GEM/interface/GEMDAQStatusSource.h
@@ -33,13 +33,13 @@
 class GEMDAQStatusSource : public GEMDQMBase {
 public:
   explicit GEMDAQStatusSource(const edm::ParameterSet &cfg);
-  ~GEMDAQStatusSource() override {}
+  ~GEMDAQStatusSource() override{};
   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 protected:
   void LoadROMap(edm::EventSetup const &iSetup);
 
-  void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override {}
+  void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override{};
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(edm::Event const &e, edm::EventSetup const &eSetup) override;
 
@@ -85,6 +85,7 @@ private:
 
   MEMap4Inf mapStatusWarnVFATPerLayer_;
   MEMap4Inf mapStatusErrVFATPerLayer_;
+  MEMap4Inf mapStatusMaskedVFATPerLayer_;
   MEMap5Inf mapStatusVFATPerCh_;
 
   MonitorElement *h2SummaryStatusAll;

--- a/DQM/GEM/interface/GEMDAQStatusSource.h
+++ b/DQM/GEM/interface/GEMDAQStatusSource.h
@@ -33,13 +33,13 @@
 class GEMDAQStatusSource : public GEMDQMBase {
 public:
   explicit GEMDAQStatusSource(const edm::ParameterSet &cfg);
-  ~GEMDAQStatusSource() override{};
+  ~GEMDAQStatusSource() override {};
   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 protected:
   void LoadROMap(edm::EventSetup const &iSetup);
 
-  void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override{};
+  void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override {};
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(edm::Event const &e, edm::EventSetup const &eSetup) override;
 
@@ -63,6 +63,7 @@ protected:
 private:
   int ProcessWithMEMap4(BookingHelper &bh, ME4IdsKey key) override;
   int ProcessWithMEMap5WithChamber(BookingHelper &bh, ME5IdsKey key) override;
+
   void SetLabelAMC13Status(MonitorElement *h2Status);
   void SetLabelAMCStatus(MonitorElement *h2Status);
   void SetLabelOHStatus(MonitorElement *h2Status);

--- a/DQM/GEM/plugins/GEMDAQStatusSource.cc
+++ b/DQM/GEM/plugins/GEMDAQStatusSource.cc
@@ -494,11 +494,8 @@ void GEMDAQStatusSource::analyze(edm::Event const &event, edm::EventSetup const 
 
       for (Int_t i = 0; i < nNumVFATPerModule; i++) {
         if ((vfatMask & (1 << i)) == 0) {
-          // -16: A sufficient large number to avoid any effect from a buggy filling
           mapStatusErrVFATPerLayer_.Fill(key4, nCh, i, -16);
-          
-          // 마스킹된 VFAT 정보만 새 히스토그램에 채우기
-          mapStatusMaskedVFATPerLayer_.Fill(key4, nCh, i, 1.0); // 마스킹된 VFAT는 1로 표시
+          mapStatusMaskedVFATPerLayer_.Fill(key4, nCh, i, 1.0);
         }
       }
 

--- a/DQM/GEM/plugins/GEMDAQStatusSource.cc
+++ b/DQM/GEM/plugins/GEMDAQStatusSource.cc
@@ -207,6 +207,8 @@ void GEMDAQStatusSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run con
       this, "vfat_statusWarnSum", "VFAT reporting warnings", 36, 0.5, 36.5, 24, -0.5, 24 - 0.5, "Chamber", "VFAT");
   mapStatusErrVFATPerLayer_ = MEMap4Inf(
       this, "vfat_statusErrSum", "VFAT reporting errors", 36, 0.5, 36.5, 24, -0.5, 24 - 0.5, "Chamber", "VFAT");
+  mapStatusMaskedVFATPerLayer_ = MEMap4Inf(
+      this, "vfat_statusMaskedSum", "VFAT reporting masked", 36, 0.5, 36.5, 24, -0.5, 24 - 0.5, "Chamber", "VFAT");
   mapStatusVFATPerCh_ =
       MEMap5Inf(this, "vfat_status", "VFAT Status", 24, -0.5, 24 - 0.5, nBitVFAT_, 0.5, nBitVFAT_ + 0.5, "VFAT");
 
@@ -214,6 +216,7 @@ void GEMDAQStatusSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run con
     mapStatusOH_.TurnOff();
     mapStatusWarnVFATPerLayer_.TurnOff();
     mapStatusErrVFATPerLayer_.TurnOff();
+    mapStatusMaskedVFATPerLayer_.TurnOff();
     mapStatusVFATPerCh_.TurnOff();
   }
 
@@ -276,6 +279,12 @@ int GEMDAQStatusSource::ProcessWithMEMap4(BookingHelper &bh, ME4IdsKey key) {
   mapStatusErrVFATPerLayer_.bookND(bh, key);
   mapStatusErrVFATPerLayer_.SetLabelForChambers(key, 1, -1, nNewMinIdxChamber);
   mapStatusErrVFATPerLayer_.SetLabelForVFATs(key, stationInfo.nNumEtaPartitions_, 2);
+
+  mapStatusMaskedVFATPerLayer_.SetBinConfX(nNewNumCh, nNewMinIdxChamber - 0.5, nNewMaxIdxChamber + 0.5);
+  mapStatusMaskedVFATPerLayer_.SetBinConfY(nNumVFATPerModule, -0.5);
+  mapStatusMaskedVFATPerLayer_.bookND(bh, key);
+  mapStatusMaskedVFATPerLayer_.SetLabelForChambers(key, 1, -1, nNewMinIdxChamber);
+  mapStatusMaskedVFATPerLayer_.SetLabelForVFATs(key, stationInfo.nNumEtaPartitions_, 2);
 
   return 0;
 }
@@ -487,6 +496,9 @@ void GEMDAQStatusSource::analyze(edm::Event const &event, edm::EventSetup const 
         if ((vfatMask & (1 << i)) == 0) {
           // -16: A sufficient large number to avoid any effect from a buggy filling
           mapStatusErrVFATPerLayer_.Fill(key4, nCh, i, -16);
+          
+          // 마스킹된 VFAT 정보만 새 히스토그램에 채우기
+          mapStatusMaskedVFATPerLayer_.Fill(key4, nCh, i, 1.0); // 마스킹된 VFAT는 1로 표시
         }
       }
 

--- a/DQM/GEM/plugins/GEMDQMHarvester.cc
+++ b/DQM/GEM/plugins/GEMDQMHarvester.cc
@@ -16,13 +16,14 @@
 #include <TFile.h>
 #include <TDirectoryFile.h>
 #include <TKey.h>
+#include <TColor.h>
 
 using namespace edm;
 
 class GEMDQMHarvester : public DQMEDHarvester {
 public:
   GEMDQMHarvester(const edm::ParameterSet &);
-  ~GEMDQMHarvester() override {}
+  ~GEMDQMHarvester() override{};
   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
   typedef std::tuple<int, int> IdChamber;
@@ -69,7 +70,7 @@ protected:
                              DQMStore::IGetter &,
                              edm::LuminosityBlock const &iLumi,
                              edm::EventSetup const &) override;
-  void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override {}  // Cannot use; it is called after dqmSaver
+  void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override{};  // Cannot use; it is called after dqmSaver
 
   void drawSummaryHistogram(edm::Service<DQMStore> &store, Int_t nLumiCurr);
   void createTableWatchingSummary();
@@ -112,6 +113,10 @@ protected:
                             NumStatus numStatusNew);
   void createLumiFuncHist(edm::Service<DQMStore> &store, std::string strSuffix, Int_t nIdxLayer, Int_t nLumiCurr);
   void createInactiveChannelFracHist(edm::Service<DQMStore> &store, std::string strSuffix, Int_t nNumChamber);
+  void createMaskedVFATHist(edm::Service<DQMStore> &store, 
+                            std::string strSuffix, 
+                            MonitorElement *h2SrcStatusE,
+                            MonitorElement *&h2MaskedVFAT);
 
   Float_t fCutErr_, fCutLowErr_, fCutWarn_;
 
@@ -295,6 +300,9 @@ void GEMDQMHarvester::drawSummaryHistogram(edm::Service<DQMStore> &store, Int_t 
       h2SumVFAT->setXTitle(h2SrcVFATStatusE->getAxisTitle(1));
       h2SumVFAT->setYTitle(h2SrcVFATStatusE->getAxisTitle(2));
 
+      MonitorElement *h2MaskedVFAT = nullptr;
+      createMaskedVFATHist(store, strSuffix, h2SrcVFATStatusE, h2MaskedVFAT);
+
       createLumiFuncHist(store, strSuffix, nIdxLayer, nLumiCurr);
     }
   }
@@ -414,6 +422,38 @@ void GEMDQMHarvester::createSummaryVFAT(edm::Service<DQMStore> &store,
   Int_t nBinX = h2Src->getNbinsX(), nBinY = h2Src->getNbinsY();
   h2Sum = store->book2D("vfat_statusSummary" + strSuffix, "", nBinX, 0.5, nBinX + 0.5, nBinY, -0.5, nBinY - 0.5);
   copyLabels(h2Src, h2Sum);
+}
+
+void GEMDQMHarvester::createMaskedVFATHist(edm::Service<DQMStore> &store, 
+                                          std::string strSuffix, 
+                                          MonitorElement *h2SrcStatusE,
+                                          MonitorElement *&h2MaskedVFAT) {
+  Int_t nBinX = h2SrcStatusE->getNbinsX(), nBinY = h2SrcStatusE->getNbinsY();
+  h2MaskedVFAT = store->book2D("vfat_maskedStatus" + strSuffix, 
+                              "VFAT Masking Status" + strSuffix, 
+                              nBinX, 0.5, nBinX + 0.5, 
+                              nBinY, -0.5, nBinY - 0.5);
+  copyLabels(h2SrcStatusE, h2MaskedVFAT);
+  
+  // 마스킹된 VFAT 식별 및 값 설정
+  // 마스킹된 VFAT = 2
+  // 마스킹 안된 VFAT = 1
+  for (Int_t j = 1; j <= nBinY; j++) {
+    for (Int_t i = 1; i <= nBinX; i++) {
+      Float_t fStatusErr = h2SrcStatusE->getBinContent(i, j);
+      if (fStatusErr <= -16.0) {
+        h2MaskedVFAT->setBinContent(i, j, 2.0); // 마스킹된 VFAT
+      } else {
+        h2MaskedVFAT->setBinContent(i, j, 1.0); // 마스킹 안된 VFAT
+      }
+    }
+  }
+  
+  // Z축 타이틀 설정
+  h2MaskedVFAT->getTH2F()->GetZaxis()->SetTitle("Masked status");
+  
+  // 타이틀이 다른 곳에서 덮어씌워질 가능성에 대비해 명시적으로 다시 설정
+  h2MaskedVFAT->setTitle("VFAT reporting masked" + strSuffix);
 }
 
 Int_t GEMDQMHarvester::assessOneBin(

--- a/DQM/GEM/plugins/GEMDQMHarvester.cc
+++ b/DQM/GEM/plugins/GEMDQMHarvester.cc
@@ -435,24 +435,19 @@ void GEMDQMHarvester::createMaskedVFATHist(edm::Service<DQMStore> &store,
                               nBinY, -0.5, nBinY - 0.5);
   copyLabels(h2SrcStatusE, h2MaskedVFAT);
   
-  // 마스킹된 VFAT 식별 및 값 설정
-  // 마스킹된 VFAT = 2
-  // 마스킹 안된 VFAT = 1
   for (Int_t j = 1; j <= nBinY; j++) {
     for (Int_t i = 1; i <= nBinX; i++) {
       Float_t fStatusErr = h2SrcStatusE->getBinContent(i, j);
       if (fStatusErr <= -16.0) {
-        h2MaskedVFAT->setBinContent(i, j, 2.0); // 마스킹된 VFAT
+        h2MaskedVFAT->setBinContent(i, j, 2.0);
       } else {
-        h2MaskedVFAT->setBinContent(i, j, 1.0); // 마스킹 안된 VFAT
+        h2MaskedVFAT->setBinContent(i, j, 1.0); 
       }
     }
   }
   
-  // Z축 타이틀 설정
   h2MaskedVFAT->getTH2F()->GetZaxis()->SetTitle("Masked status");
   
-  // 타이틀이 다른 곳에서 덮어씌워질 가능성에 대비해 명시적으로 다시 설정
   h2MaskedVFAT->setTitle("VFAT reporting masked" + strSuffix);
 }
 

--- a/DQM/GEM/plugins/GEMDQMHarvester.cc
+++ b/DQM/GEM/plugins/GEMDQMHarvester.cc
@@ -23,7 +23,7 @@ using namespace edm;
 class GEMDQMHarvester : public DQMEDHarvester {
 public:
   GEMDQMHarvester(const edm::ParameterSet &);
-  ~GEMDQMHarvester() override{};
+  ~GEMDQMHarvester() override {};
   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
   typedef std::tuple<int, int> IdChamber;
@@ -70,7 +70,7 @@ protected:
                              DQMStore::IGetter &,
                              edm::LuminosityBlock const &iLumi,
                              edm::EventSetup const &) override;
-  void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override{};  // Cannot use; it is called after dqmSaver
+  void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override {};  // Cannot use; it is called after dqmSaver
 
   void drawSummaryHistogram(edm::Service<DQMStore> &store, Int_t nLumiCurr);
   void createTableWatchingSummary();
@@ -113,8 +113,8 @@ protected:
                             NumStatus numStatusNew);
   void createLumiFuncHist(edm::Service<DQMStore> &store, std::string strSuffix, Int_t nIdxLayer, Int_t nLumiCurr);
   void createInactiveChannelFracHist(edm::Service<DQMStore> &store, std::string strSuffix, Int_t nNumChamber);
-  void createMaskedVFATHist(edm::Service<DQMStore> &store, 
-                            std::string strSuffix, 
+  void createMaskedVFATHist(edm::Service<DQMStore> &store,
+                            std::string strSuffix,
                             MonitorElement *h2SrcStatusE,
                             MonitorElement *&h2MaskedVFAT);
 
@@ -416,38 +416,38 @@ void GEMDQMHarvester::createSummaryVFAT(edm::Service<DQMStore> &store,
                                         MonitorElement *h2Src,
                                         std::string strSuffix,
                                         MonitorElement *&h2Sum) {
-  //store->setCurrentFolder(strDirStatus_);
-  //store->setCurrentFolder(strDirSummary_);
-
   Int_t nBinX = h2Src->getNbinsX(), nBinY = h2Src->getNbinsY();
   h2Sum = store->book2D("vfat_statusSummary" + strSuffix, "", nBinX, 0.5, nBinX + 0.5, nBinY, -0.5, nBinY - 0.5);
   copyLabels(h2Src, h2Sum);
 }
 
-void GEMDQMHarvester::createMaskedVFATHist(edm::Service<DQMStore> &store, 
-                                          std::string strSuffix, 
-                                          MonitorElement *h2SrcStatusE,
-                                          MonitorElement *&h2MaskedVFAT) {
+void GEMDQMHarvester::createMaskedVFATHist(edm::Service<DQMStore> &store,
+                                           std::string strSuffix,
+                                           MonitorElement *h2SrcStatusE,
+                                           MonitorElement *&h2MaskedVFAT) {
   Int_t nBinX = h2SrcStatusE->getNbinsX(), nBinY = h2SrcStatusE->getNbinsY();
-  h2MaskedVFAT = store->book2D("vfat_maskedStatus" + strSuffix, 
-                              "VFAT Masking Status" + strSuffix, 
-                              nBinX, 0.5, nBinX + 0.5, 
-                              nBinY, -0.5, nBinY - 0.5);
+  h2MaskedVFAT = store->book2D("vfat_maskedStatus" + strSuffix,
+                               "VFAT Masking Status" + strSuffix,
+                               nBinX,
+                               0.5,
+                               nBinX + 0.5,
+                               nBinY,
+                               -0.5,
+                               nBinY - 0.5);
   copyLabels(h2SrcStatusE, h2MaskedVFAT);
-  
+
   for (Int_t j = 1; j <= nBinY; j++) {
     for (Int_t i = 1; i <= nBinX; i++) {
       Float_t fStatusErr = h2SrcStatusE->getBinContent(i, j);
       if (fStatusErr <= -16.0) {
         h2MaskedVFAT->setBinContent(i, j, 2.0);
       } else {
-        h2MaskedVFAT->setBinContent(i, j, 1.0); 
+        h2MaskedVFAT->setBinContent(i, j, 1.0);
       }
     }
   }
-  
+
   h2MaskedVFAT->getTH2F()->GetZaxis()->SetTitle("Masked status");
-  
   h2MaskedVFAT->setTitle("VFAT reporting masked" + strSuffix);
 }
 


### PR DESCRIPTION
#### PR description:

In this PR, GEM onlineDQM plots for Masked VFAT plots have been implemented

#### PR validation:

Tests are done with cmsRun $CMSSW_RELEASE_BASE/src/DQM/Integration/python/clients/gem_dqm_sourceclient-live_cfg.py unitTest=True runNumber=387696 dataset=/ExpressPhysics/Run2024J-Express-v1/FEVT minLumi=19 maxLumi=21 and runTheMatrix.py -l limited -i all --ibeos since it makes effects on P5 and reconstruction

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Since this year's data taking is on the 15_0_X version so I will backport to 15_0_X and create a separate backport PR as well.

@jshlee @watson-ij @quark2 @Dongwoon77 
