### PR TITLE
Phase2-hgx363T Make phi-dependent cassette shift for all scintillator tiles in the V19 version

### DIFF
--- a/Geometry/HGCalCommonData/interface/HGCalParameters.h
+++ b/Geometry/HGCalCommonData/interface/HGCalParameters.h
@@ -220,6 +220,7 @@ public:
   int phiOffset_ = 0;
   std::vector<double> cassetteShift_;
   std::vector<double> cassetteShiftTile_;
+  std::vector<double> cassetteRetractTile_;
   double calibCellRHD_ = 0.;
   std::vector<int> calibCellFullHD_;
   std::vector<int> calibCellPartHD_;

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -228,7 +228,8 @@ std::array<int, 3> HGCalDDDConstants::assignCellTrap(float x, float y, float z, 
   if (cassetteMode()) {
     int nphi = (hgpar_->scintFine(indx.first)) ? hgpar_->nphiFineCassette_ : hgpar_->nphiCassette_;
     int cassette = HGCalTileIndex::tileCassette(iphi, hgpar_->phiOffset_, nphi, hgpar_->cassettes_);
-    auto cshift = (mode_ == HGCalGeometryMode::TrapezoidFineCell) ?  hgcassette_.getShiftScnt((indx.first + 1), -1, phi) : hgcassette_.getShift(layer, -1, cassette, true);
+    auto cshift = (mode_ == HGCalGeometryMode::TrapezoidFineCell) ? hgcassette_.getShiftScnt((indx.first + 1), -1, phi)
+                                                                  : hgcassette_.getShift(layer, -1, cassette, true);
 #ifdef EDM_ML_DEBUG
     std::ostringstream st1;
     st1 << "Cassette " << cassette << " Shift " << cshift.first << ":" << cshift.second << " Original " << xx << ":"
@@ -1035,7 +1036,8 @@ std::pair<float, float> HGCalDDDConstants::locateCellTrap(
   debug = true;
   if (debug)
     edm::LogVerbatim("HGCalGeom") << "locateCellTrap:: Input " << lay << ":" << irad << ":" << iphi << ":" << zside
-                                  << ":" << reco << ":" << indx.first << " First Layer " << hgpar_->firstLayer_ << ":" << hgpar_->firstMixedLayer_;
+                                  << ":" << reco << ":" << indx.first << " First Layer " << hgpar_->firstLayer_ << ":"
+                                  << hgpar_->firstMixedLayer_;
 #endif
   if (indx.first >= 0) {
     int ir = std::abs(irad);
@@ -1077,7 +1079,9 @@ std::pair<float, float> HGCalDDDConstants::locateCellTrap(
     if (cassetteMode()) {
       int nphi = (hgpar_->scintFine(indx.first)) ? hgpar_->nphiFineCassette_ : hgpar_->nphiCassette_;
       int cassette = HGCalTileIndex::tileCassette(iphi, hgpar_->phiOffset_, nphi, hgpar_->cassettes_);
-      auto cshift = (mode_ == HGCalGeometryMode::TrapezoidFineCell) ?  hgcassette_.getShiftScnt((indx.first + 1), -1, phi) : hgcassette_.getShift(lay, -1, cassette, true);
+      auto cshift = (mode_ == HGCalGeometryMode::TrapezoidFineCell)
+                        ? hgcassette_.getShiftScnt((indx.first + 1), -1, phi)
+                        : hgcassette_.getShift(lay, -1, cassette, true);
 #ifdef EDM_ML_DEBUG
       std::ostringstream st1;
       if (debug)

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -58,6 +58,7 @@ HGCalDDDConstants::HGCalDDDConstants(const HGCalParameters* hp, const std::strin
     if (mode_ == HGCalGeometryMode::TrapezoidFineCell) {
       hgcassette_.setParameter(hgpar_->cassettes_, hgpar_->cassetteShift_, false);
       hgcassette_.setParameterScint(hgpar_->cassetteShiftTile_);
+      hgcassette_.setParameterRetract(hgpar_->cassetteRetractTile_);
     } else {
       hgcassette_.setParameter(hgpar_->cassettes_, hgpar_->cassetteShift_, true);
     }
@@ -227,7 +228,7 @@ std::array<int, 3> HGCalDDDConstants::assignCellTrap(float x, float y, float z, 
   if (cassetteMode()) {
     int nphi = (hgpar_->scintFine(indx.first)) ? hgpar_->nphiFineCassette_ : hgpar_->nphiCassette_;
     int cassette = HGCalTileIndex::tileCassette(iphi, hgpar_->phiOffset_, nphi, hgpar_->cassettes_);
-    auto cshift = hgcassette_.getShift(layer, -1, cassette, true);
+    auto cshift = (mode_ == HGCalGeometryMode::TrapezoidFineCell) ?  hgcassette_.getShiftScnt((indx.first + 1), -1, phi) : hgcassette_.getShift(layer, -1, cassette, true);
 #ifdef EDM_ML_DEBUG
     std::ostringstream st1;
     st1 << "Cassette " << cassette << " Shift " << cshift.first << ":" << cshift.second << " Original " << xx << ":"
@@ -1034,7 +1035,7 @@ std::pair<float, float> HGCalDDDConstants::locateCellTrap(
   debug = true;
   if (debug)
     edm::LogVerbatim("HGCalGeom") << "locateCellTrap:: Input " << lay << ":" << irad << ":" << iphi << ":" << zside
-                                  << ":" << reco << ":" << indx.first;
+                                  << ":" << reco << ":" << indx.first << " First Layer " << hgpar_->firstLayer_ << ":" << hgpar_->firstMixedLayer_;
 #endif
   if (indx.first >= 0) {
     int ir = std::abs(irad);
@@ -1076,7 +1077,7 @@ std::pair<float, float> HGCalDDDConstants::locateCellTrap(
     if (cassetteMode()) {
       int nphi = (hgpar_->scintFine(indx.first)) ? hgpar_->nphiFineCassette_ : hgpar_->nphiCassette_;
       int cassette = HGCalTileIndex::tileCassette(iphi, hgpar_->phiOffset_, nphi, hgpar_->cassettes_);
-      auto cshift = hgcassette_.getShift(lay, -1, cassette, true);
+      auto cshift = (mode_ == HGCalGeometryMode::TrapezoidFineCell) ?  hgcassette_.getShiftScnt((indx.first + 1), -1, phi) : hgcassette_.getShift(lay, -1, cassette, true);
 #ifdef EDM_ML_DEBUG
       std::ostringstream st1;
       if (debug)

--- a/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
@@ -1686,9 +1686,9 @@ void HGCalGeomParameters::loadSpecParsTrapezoid(const DDFilteredView& fv, HGCalP
       std::vector<double> rectract = fv.vector("ScintRetract");
       rescale(rectract, HGCalParameters::k_ScaleFromDDD);
       for (unsigned int k1 = 0; k1 < rectract.size(); ++k1) {
-	php.cassetteRetractTile_.emplace_back(rectract[k1]);
+        php.cassetteRetractTile_.emplace_back(rectract[k1]);
 #ifdef EDM_ML_DEBUG
-	edm::LogVerbatim("HGCalGeom") << "cassetteRetractTile_[" << k1 << "] " << rectract[k1];
+        edm::LogVerbatim("HGCalGeom") << "cassetteRetractTile_[" << k1 << "] " << rectract[k1];
 #endif
       }
       int n = 2 * php.cassettes_ * (php.firstLayer_ - 1);
@@ -1859,12 +1859,12 @@ void HGCalGeomParameters::loadSpecParsTrapezoid(const cms::DDFilteredView& fv,
           for (const auto& i : it.second)
             rectract.emplace_back(i);
           rescale(rectract, HGCalParameters::k_ScaleFromDDD);
-	  for (unsigned int k1 = 0; k1 < rectract.size(); ++k1) {
-	    php.cassetteRetractTile_.emplace_back(rectract[k1]);
+          for (unsigned int k1 = 0; k1 < rectract.size(); ++k1) {
+            php.cassetteRetractTile_.emplace_back(rectract[k1]);
 #ifdef EDM_ML_DEBUG
-	    edm::LogVerbatim("HGCalGeom") << "cassetteRetractTile_[" << k1 << "] " << rectract[k1];
+            edm::LogVerbatim("HGCalGeom") << "cassetteRetractTile_[" << k1 << "] " << rectract[k1];
 #endif
-	  }
+          }
           int n = 2 * php.cassettes_ * (php.firstLayer_ - 1);
           for (int k1 = 0; k1 < n; ++k1)
             cassetteShift.emplace_back(0.);

--- a/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
@@ -1685,6 +1685,12 @@ void HGCalGeomParameters::loadSpecParsTrapezoid(const DDFilteredView& fv, HGCalP
       php.nphiFineCassette_ = php.nCellsFine_ / php.cassettes_;
       std::vector<double> rectract = fv.vector("ScintRetract");
       rescale(rectract, HGCalParameters::k_ScaleFromDDD);
+      for (unsigned int k1 = 0; k1 < rectract.size(); ++k1) {
+	php.cassetteRetractTile_.emplace_back(rectract[k1]);
+#ifdef EDM_ML_DEBUG
+	edm::LogVerbatim("HGCalGeom") << "cassetteRetractTile_[" << k1 << "] " << rectract[k1];
+#endif
+      }
       int n = 2 * php.cassettes_ * (php.firstLayer_ - 1);
       for (int k1 = 0; k1 < n; ++k1)
         cassetteShift.emplace_back(0.);
@@ -1852,6 +1858,13 @@ void HGCalGeomParameters::loadSpecParsTrapezoid(const cms::DDFilteredView& fv,
         } else if (dd4hep::dd::compareEqual(dd4hep::dd::noNamespace(it.first), "ScintRetract")) {
           for (const auto& i : it.second)
             rectract.emplace_back(i);
+          rescale(rectract, HGCalParameters::k_ScaleFromDDD);
+	  for (unsigned int k1 = 0; k1 < rectract.size(); ++k1) {
+	    php.cassetteRetractTile_.emplace_back(rectract[k1]);
+#ifdef EDM_ML_DEBUG
+	    edm::LogVerbatim("HGCalGeom") << "cassetteRetractTile_[" << k1 << "] " << rectract[k1];
+#endif
+	  }
           int n = 2 * php.cassettes_ * (php.firstLayer_ - 1);
           for (int k1 = 0; k1 < n; ++k1)
             cassetteShift.emplace_back(0.);

--- a/Geometry/HGCalCommonData/test/HGCalParameterTester.cc
+++ b/Geometry/HGCalCommonData/test/HGCalParameterTester.cc
@@ -169,6 +169,8 @@ void HGCalParameterTester::analyze(const edm::Event& iEvent, const edm::EventSet
     myPrint("CalibCellFullLD", phgp->calibCellFullLD_, 12);
     myPrint("CalibCellPartLD", phgp->calibCellPartLD_, 12);
     myPrint("cassetteShift", phgp->cassetteShift_, 8);
+    myPrint("cassetteShiftTile", phgp->cassetteShiftTile_, 8);
+    myPrint("cassetteRetractTile", phgp->cassetteRetractTile_, 8);
 
     edm::LogVerbatim("HGCalGeom") << "MaskMode: " << phgp->waferMaskMode_;
     if (phgp->waferMaskMode_ > 1) {


### PR DESCRIPTION
#### PR description:

Make phi-dependent cassette shift for all scintillator tiles in the V19 version

#### PR validation:

Use the runTheMatrix test workflows

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special