### PR TITLE
Remove the use of deprecated MPI C++ bindings [15.0.x]

### DIFF
--- a/GeneratorInterface/SherpaInterface/src/SherpaHadronizer.cc
+++ b/GeneratorInterface/SherpaInterface/src/SherpaHadronizer.cc
@@ -205,14 +205,17 @@ SherpaHadronizer::SherpaHadronizer(const edm::ParameterSet &params)
   isInitialized = false;
   //initialization of Sherpa moved to initializeForInternalPartons
 #ifdef USING__MPI
-  MPI::Init();
+  // FIXME this should be replaced with a call to the MPIService
+  int argc = 0;
+  char **argv = nullptr;
+  MPI_Init(&argc, &argv);
 #endif
 }
 
 SherpaHadronizer::~SherpaHadronizer() {
   Generator->~Sherpa();
 #ifdef USING__MPI
-  MPI::Finalize();
+  MPI_Finalize();
 #endif
 }
 

--- a/HeterogeneousCore/CUDACore/test/mpiCudaGeneric.cu
+++ b/HeterogeneousCore/CUDACore/test/mpiCudaGeneric.cu
@@ -237,7 +237,7 @@ int main(int argc, char *argv[]) {
 
   if (help) {
     printHelp();
-    MPI::Finalize();
+    MPI_Finalize();
     exit(0);
   }
   setupMPIAndVectors(mpiData, user);
@@ -276,7 +276,7 @@ int main(int argc, char *argv[]) {
   if (!mpiData.rank)
     printTable(allTiming, printStander);
 
-  MPI::Finalize();
+  MPI_Finalize();
   return 0;
 }
 const std::vector<int> chooseFunction(int toInteger) {
@@ -341,8 +341,8 @@ void randomGenerator(float *vect) {
   }
 }
 void setupMPIAndVectors(MPIData &mpiData, UserChoises &user) {
-  mpiData.num_procs = MPI::COMM_WORLD.Get_size();  //get total size of processes.
-  mpiData.rank = MPI::COMM_WORLD.Get_rank();       //get each process number.
+  MPI_Comm_size(MPI_COMM_WORLD, &mpiData.num_procs);
+  MPI_Comm_rank(MPI_COMM_WORLD, &mpiData.rank);
 
   user.sizeVectorBytes = sizeVector * sizeof(float);  //get size in byte for vectors.
 
@@ -1298,7 +1298,9 @@ bool saveToFile(const std::string &name, const Timing &timing) {
   return 1;
 }
 void printHelp(void) {
-  int rank = MPI::COMM_WORLD.Get_rank();
+  int rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
   if (!rank) {
     std::cout << "\n\n\t**************************************\n";
     std::cout << "\t* This is a Help for Command Opitions*";

--- a/HeterogeneousCore/MPICore/test/testMPI.cc
+++ b/HeterogeneousCore/MPICore/test/testMPI.cc
@@ -151,9 +151,9 @@ int main(int argc, char* argv[]) {
 
   MPIData mpiInputs;  //greate object from structur to pass into MPI functios.
 
-  MPI_Init(&argc, &argv);                            //initialize communicator environment.
-  mpiInputs.num_procs = MPI::COMM_WORLD.Get_size();  //get total size of processes.
-  mpiInputs.rank = MPI::COMM_WORLD.Get_rank();       //get each process number.
+  MPI_Init(&argc, &argv);                               //initialize communicator environment.
+  MPI_Comm_rank(MPI_COMM_WORLD, &mpiInputs.rank);       //get each process number.
+  MPI_Comm_size(MPI_COMM_WORLD, &mpiInputs.num_procs);  //get total size of processes.
 
   mpiInputs.input1.resize(size);  //initialize size.
   mpiInputs.input2.resize(size);
@@ -212,7 +212,7 @@ int main(int argc, char* argv[]) {
     compare(timing, choices, userChoices, runNumber);
   }
 
-  MPI::Finalize();
+  MPI_Finalize();
 
   return 0;
 }


### PR DESCRIPTION
#### PR description:

C++ bindings were deprecated in MPI 2.2 and removed in MPI 3.
Open MPI still supports them up to Open MPI 4.1, but has removed them in Open MPI 5.0.


#### PR validation:

None.


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #47994 to CMSSW 15.0.x to support different MPI implementations.