### PR TITLE
 Adapt pixel cpe algo to better handle broken clusters [15.0.X]

### DIFF
--- a/CondFormats/SiPixelTransient/interface/SiPixelTemplate.h
+++ b/CondFormats/SiPixelTransient/interface/SiPixelTemplate.h
@@ -285,6 +285,9 @@ public:
   // initialize the rest;
   static void postInit(std::vector<SiPixelTemplateStore>& thePixelTemp_);
 
+  // Interpolate with y Gaussian Parameter interpolation to be used with goodEdge reconstruction algorithm
+  bool interpolate(int id, float cotalpha, float cotbeta, float locBz, float locBx, bool goodEdgeAlgo);
+
   // Interpolate input alpha and beta angles to produce a working template for each individual hit.
   bool interpolate(int id, float cotalpha, float cotbeta, float locBz, float locBx);
 

--- a/CondFormats/SiPixelTransient/interface/SiPixelUtils.h
+++ b/CondFormats/SiPixelTransient/interface/SiPixelUtils.h
@@ -2,21 +2,23 @@
 #define CondFormats_SiPixelTransient_SiPixelUtils_h
 
 namespace siPixelUtils {
-  float generic_position_formula(int size,                    //!< Size of this projection.
-                                 int q_f,                     //!< Charge in the first pixel.
-                                 int q_l,                     //!< Charge in the last pixel.
-                                 float upper_edge_first_pix,  //!< As the name says.
-                                 float lower_edge_last_pix,   //!< As the name says.
-                                 float lorentz_shift,         //!< L-width
-                                 float theThickness,          //detector thickness
-                                 float cot_angle,             //!< cot of alpha_ or beta_
-                                 float pitch,                 //!< thePitchX or thePitchY
-                                 float pitchfraction_first,   //!< true if the first is big
-                                 float pitchfraction_last,    //!< true if the last is big
-                                 float eff_charge_cut_low,    //!< Use edge if > W_eff (in pix) &&&
-                                 float eff_charge_cut_high,   //!< Use edge if < W_eff (in pix) &&&
-                                 float size_cut               //!< Use edge when size == cuts
-  );
+  float generic_position_formula(
+      int size,                     //!< Size of this projection.
+      int q_f,                      //!< Charge in the first pixel.
+      int q_l,                      //!< Charge in the last pixel.
+      float upper_edge_first_pix,   //!< As the name says.
+      float lower_edge_last_pix,    //!< As the name says.
+      float lorentz_shift,          //!< L-width
+      float theThickness,           //detector thickness
+      float cot_angle,              //!< cot of alpha_ or beta_
+      float pitch,                  //!< thePitchX or thePitchY
+      float pitchfraction_first,    //!< true if the first is big
+      float pitchfraction_last,     //!< true if the last is big
+      float eff_charge_cut_low,     //!< Use edge if > W_eff (in pix) &&&
+      float eff_charge_cut_high,    //!< Use edge if < W_eff (in pix) &&&
+      float size_cut,               //!< Use edge when size == cuts
+      float delta_length_cut = 2.,  //!< if charge len - cls size > this (in pix), use one-sided reco
+      bool goodEdgeAlgo = false);
 }  // namespace siPixelUtils
 
 #endif

--- a/CondFormats/SiPixelTransient/src/SiPixelTemplate.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelTemplate.cc
@@ -82,6 +82,7 @@
 //  V10.21 - Address runtime issues in pushfile() for gcc 7.X due to using tempfile as char string + misc. cleanup [Petar]
 //  V10.22 - Move templateStore to the heap, fix variable name in pushfile() [Petar]
 //  V10.24 - Add sideload() + associated gymnastics [Petar and Oz]
+//  V10.25 - Restore y-residual Gaussian parameters [Morris]
 
 //  Created by Morris Swartz on 10/27/06.
 //
@@ -1324,15 +1325,18 @@ void SiPixelTemplate::postInit(std::vector<SiPixelTemplateStore>& thePixelTemp_)
 //! \param locBx - (input) the sign of this quantity is used to determine whether to flip cot(alpha/beta)<0 quantities from cot(alpha/beta)>0 (FPix only)
 //!                    for Phase 1 FPix IP-related tracks, locBx/locBz > 0 for cot(alpha) > 0 and locBx/locBz < 0 for cot(alpha) < 0
 //!                    for Phase 1 FPix IP-related tracks, locBx > 0 for cot(beta) > 0 and locBx < 0 for cot(beta) < 0
+//! \param goodEdgeAlgo - (input) Flag to turn on the y Gaussian Parameter interpolation to be used with goodEdge reconstruction algorithm
 // ************************************************************************************************************
-bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float locBz, float locBx) {
+bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float locBz, float locBx, bool goodEdgeAlgo) {
   // Interpolate for a new set of track angles
 
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
   //check for nan's
   if (!edm::isFinite(cotalpha) || !edm::isFinite(cotbeta)) {
     success_ = false;
     return success_;
   }
+#endif
 
   // Local variables
   int i, j;
@@ -1553,16 +1557,19 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
     }
 
     for (i = 0; i < 4; ++i) {
-      yavg_[i] = (1.f - yratio_) * thePixelTemp_[index_id_].enty[ilow].yavg[i] +
-                 yratio_ * thePixelTemp_[index_id_].enty[ihigh].yavg[i];
-      if (flip_y_) {
-        yavg_[i] = -yavg_[i];
-      }
       yavg_[i] = (1.f - yratio_) * enty0_->yavg[i] + yratio_ * enty1_->yavg[i];
       if (flip_y_) {
         yavg_[i] = -yavg_[i];
       }
       yrms_[i] = (1.f - yratio_) * enty0_->yrms[i] + yratio_ * enty1_->yrms[i];
+
+      if (goodEdgeAlgo) {  // restore y Gaussian Parameter interpolation
+        ygx0_[i] = (1.f - yratio_) * enty0_->ygx0[i] + yratio_ * enty1_->ygx0[i];
+        if (flip_y_) {
+          ygx0_[i] = -ygx0_[i];
+        }
+        ygsig_[i] = (1.f - yratio_) * enty0_->ygsig[i] + yratio_ * enty1_->ygsig[i];
+      }  //if(goodEdgeAlgo)
       chi2yavg_[i] = (1.f - yratio_) * enty0_->chi2yavg[i] + yratio_ * enty1_->chi2yavg[i];
       chi2ymin_[i] = (1.f - yratio_) * enty0_->chi2ymin[i] + yratio_ * enty1_->chi2ymin[i];
       chi2xavg[i] = (1.f - yratio_) * enty0_->chi2xavg[i] + yratio_ * enty1_->chi2xavg[i];
@@ -1874,6 +1881,23 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
 //! \param id - (input) index of the template to use
 //! \param cotalpha - (input) the cotangent of the alpha track angle (see CMS IN 2004/014)
 //! \param cotbeta - (input) the cotangent of the beta track angle (see CMS IN 2004/014)
+//! \param locBz - (input) the sign of this quantity is used to determine whether to flip cot(beta)<0 quantities from cot(beta)>0 (FPix only)
+//!                    for Phase 0 FPix IP-related tracks, locBz < 0 for cot(beta) > 0 and locBz > 0 for cot(beta) < 0
+//!                    for Phase 1 FPix IP-related tracks, see next comment
+//! \param locBx - (input) the sign of this quantity is used to determine whether to flip cot(alpha/beta)<0 quantities from cot(alpha/beta)>0 (FPix only)
+//!                    for Phase 1 FPix IP-related tracks, locBx/locBz > 0 for cot(alpha) > 0 and locBx/locBz < 0 for cot(alpha) < 0
+//!                    for Phase 1 FPix IP-related tracks, locBx > 0 for cot(beta) > 0 and locBx < 0 for cot(beta) < 0
+// ************************************************************************************************************
+bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float locBz, float locBx) {
+  // Interpolate for a new set of track angles, but without y Gaussian Parameter interpolation to be used with goodEdge reconstruction algorithm
+  return SiPixelTemplate::interpolate(id, cotalpha, cotbeta, locBz, locBx, false);
+}
+
+// ************************************************************************************************************
+//! Interpolate input alpha and beta angles to produce a working template for each individual hit.
+//! \param id - (input) index of the template to use
+//! \param cotalpha - (input) the cotangent of the alpha track angle (see CMS IN 2004/014)
+//! \param cotbeta - (input) the cotangent of the beta track angle (see CMS IN 2004/014)
 //! Use this for Phase 1, IP related hits
 // ************************************************************************************************************
 bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta) {
@@ -1888,7 +1912,7 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta) {
   if (cotalpha < 0.f) {
     locBz = -locBx;
   }
-  return SiPixelTemplate::interpolate(id, cotalpha, cotbeta, locBz, locBx);
+  return SiPixelTemplate::interpolate(id, cotalpha, cotbeta, locBz, locBx, false);
 }
 
 // ************************************************************************************************************
@@ -1903,7 +1927,7 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
 
   // Local variables
   float locBx = 1.f;
-  return SiPixelTemplate::interpolate(id, cotalpha, cotbeta, locBz, locBx);
+  return SiPixelTemplate::interpolate(id, cotalpha, cotbeta, locBz, locBx, false);
 }
 
 // *************************************************************************************************************************************

--- a/CondFormats/SiPixelTransient/src/SiPixelUtils.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelUtils.cc
@@ -13,21 +13,23 @@ namespace siPixelUtils {
   //!  X and Y, in the interest of the simplicity of the code, all parameters
   //!  are passed by the caller.
   //-----------------------------------------------------------------------------
-  float generic_position_formula(int size,                    //!< Size of this projection.
-                                 int q_f,                     //!< Charge in the first pixel.
-                                 int q_l,                     //!< Charge in the last pixel.
-                                 float upper_edge_first_pix,  //!< As the name says.
-                                 float lower_edge_last_pix,   //!< As the name says.
-                                 float lorentz_shift,         //!< L-shift at half thickness
-                                 float theThickness,          //detector thickness
-                                 float cot_angle,             //!< cot of alpha_ or beta_
-                                 float pitch,                 //!< thePitchX or thePitchY
-                                 float pitchfraction_first,
-                                 float pitchfraction_last,
-                                 float eff_charge_cut_low,   //!< Use edge if > w_eff  &&&
-                                 float eff_charge_cut_high,  //!< Use edge if < w_eff  &&&
-                                 float size_cut              //!< Use edge when size == cuts
-  ) {
+  float generic_position_formula(
+      int size,                    //!< Size of this projection.
+      int q_f,                     //!< Charge in the first pixel.
+      int q_l,                     //!< Charge in the last pixel.
+      float upper_edge_first_pix,  //!< As the name says.
+      float lower_edge_last_pix,   //!< As the name says.
+      float lorentz_shift,         //!< L-shift at half thickness
+      float theThickness,          //detector thickness
+      float cot_angle,             //!< cot of alpha_ or beta_
+      float pitch,                 //!< thePitchX or thePitchY
+      float pitchfraction_first,
+      float pitchfraction_last,
+      float eff_charge_cut_low,   //!< Use edge if > w_eff  &&&
+      float eff_charge_cut_high,  //!< Use edge if < w_eff  &&&
+      float size_cut,             //!< Use edge when size == cuts
+      float delta_length_cut,     //!< if charge len - cls size > this (in pix), use one-sided reco
+      bool goodEdgeAlgo) {
     float geom_center = 0.5f * (upper_edge_first_pix + lower_edge_last_pix);
 
     //--- The case of only one pixel in this projection is separate.  Note that
@@ -56,11 +58,26 @@ namespace siPixelUtils {
     //--- it with an *average* effective charge width, which is the average
     //--- length of the edge pixels.
     //
-    //  bool usedEdgeAlgo = false;
     if ((size >= size_cut) || ((w_eff / pitch < eff_charge_cut_low) | (w_eff / pitch > eff_charge_cut_high))) {
       w_eff = pitch * 0.5f * sum_of_edge;  // ave. length of edge pixels (first+last) (cm)
-                                           //  usedEdgeAlgo = true;
-    }
+
+      if (goodEdgeAlgo) {
+        float delta = w_eff - 0.5 * sum_of_edge * pitch;
+        if (delta / pitch > delta_length_cut) {
+          // define the centers of the first last last pixel coordinates
+          float x1 = upper_edge_first_pix - 0.5 * pitchfraction_first * pitch;
+          float x2 = lower_edge_last_pix + 0.5 * pitchfraction_last * pitch;
+          //  observed cluster is much shorter than expected, use one-sided reco
+          if (w_pred > 0.f) {
+            float hit_pos = x1 + 0.5 * w_pred;
+            return hit_pos;
+          } else {
+            float hit_pos = x2 + 0.5 * w_pred;
+            return hit_pos;
+          }
+        }  //if (delta / pitch > delta_length_cut)
+      }  //if(goodEdgeAlgo)
+    }  //if(size >= size_cut) ||...
 
     //--- Finally, compute the position in this projection
     float q_diff = q_l - q_f;

--- a/CondFormats/SiPixelTransient/src/SiPixelUtils.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelUtils.cc
@@ -52,6 +52,7 @@ namespace siPixelUtils {
 
     //--- The `effective' charge width -- particle's path in first and last pixels only
     float w_eff = std::abs(w_pred) - w_inner;
+    float delta = w_eff - 0.5 * sum_of_edge * pitch;
 
     //--- If the observed charge width is inconsistent with the expectations
     //--- based on the track, do *not* use w_pred-w_innner.  Instead, replace
@@ -62,16 +63,15 @@ namespace siPixelUtils {
       w_eff = pitch * 0.5f * sum_of_edge;  // ave. length of edge pixels (first+last) (cm)
 
       if (goodEdgeAlgo) {
-        float delta = w_eff - 0.5 * sum_of_edge * pitch;
         if (delta / pitch > delta_length_cut) {
-          // define the centers of the first last last pixel coordinates
-          float x1 = upper_edge_first_pix - 0.5 * pitchfraction_first * pitch;
-          float x2 = lower_edge_last_pix + 0.5 * pitchfraction_last * pitch;
           //  observed cluster is much shorter than expected, use one-sided reco
           if (w_pred > 0.f) {
+            // x1,x2 are centers of the first last last pixel coordinates
+            float x1 = upper_edge_first_pix - 0.5 * pitchfraction_first * pitch;
             float hit_pos = x1 + 0.5 * w_pred;
             return hit_pos;
           } else {
+            float x2 = lower_edge_last_pix + 0.5 * pitchfraction_last * pitch;
             float hit_pos = x2 + 0.5 * w_pred;
             return hit_pos;
           }

--- a/Configuration/ProcessModifiers/python/siPixelGoodEdgeAlgo_cff.py
+++ b/Configuration/ProcessModifiers/python/siPixelGoodEdgeAlgo_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+# This modifier enables the good edge algorithm in pixel hit reconstruction that handles broken/truncated pixel cluster caused by radiation damage
+siPixelGoodEdgeAlgo = cms.Modifier()

--- a/Configuration/PyReleaseValidation/README.md
+++ b/Configuration/PyReleaseValidation/README.md
@@ -69,6 +69,7 @@ The offsets currently in use are:
 * 0.15: JME NanoAOD
 * 0.17: Run-3 deep core seeding for JetCore iteration
 * 0.18  Run-3 SiPixel Digi Morphing
+* 0.181: Run-3 SiPixel goodEdge CPE algorithm
 * 0.19: ECAL SuperClustering with DeepSC algorithm
 * 0.21: Production-like sequence
 * 0.21X1 : Production-like sequence with classical mixing PU=X (X=10,20,30,40,50,60,70,80,90,100,120,140,160,180)

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -614,6 +614,40 @@ upgradeWFs['siPixelDigiMorphing'] = UpgradeWorkflow_siPixelDigiMorphing(
     offset = 0.18,
 )
 
+# pixel GoodEdgeAlgo CPE workflows
+class UpgradeWorkflow_siPixelGoodEdgeAlgo(UpgradeWorkflow):
+    def setup_(self, step, stepName, stepDict, k, properties):
+        if 'HLTOnly'==step:
+            stepDict[stepName][k] = merge([{'--customise' : 'RecoLocalTracker/Configuration/customizeHLT.customiseFor47966'}, stepDict[step][k]])
+        if 'Reco' in step:
+            stepDict[stepName][k] = merge([{'--procModifiers': 'siPixelGoodEdgeAlgo'}, stepDict[step][k]])
+    def condition(self, fragment, stepList, key, hasHarvest):
+        result = (fragment=="QCD_Pt_1800_2400_14" or fragment=="TTbar_14TeV" ) and any(y in key for y in ['2025'])
+        return result
+upgradeWFs['siPixelGoodEdgeAlgo'] = UpgradeWorkflow_siPixelGoodEdgeAlgo(
+    steps = [
+        'HLTOnly',
+        'DigiTrigger',
+        'Reco',
+        'RecoFakeHLT',
+        'RecoGlobal',
+        'RecoGlobalFakeHLT',
+        'RecoNano',
+        'RecoNanoFakeHLT',
+    ],
+    PU = [
+        'HLTOnly',
+        'DigiTrigger',
+        'Reco',
+        'RecoFakeHLT',
+        'RecoGlobal',
+        'RecoGlobalFakeHLT',
+        'RecoNano',
+        'RecoNanoFakeHLT',
+    ],
+    suffix = '_siPixelGoodEdgeAlgo',
+    offset = 0.181,
+)
 
 #Workflow to enable displacedRegionalStep tracking iteration
 class UpgradeWorkflow_displacedRegional(UpgradeWorkflowTracking):

--- a/RecoLocalTracker/Configuration/python/customizeHLT.py
+++ b/RecoLocalTracker/Configuration/python/customizeHLT.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+# helper functions
+from HLTrigger.Configuration.common import *
+
+
+# Enable good edge CPE algorithm in pixel local reconstruction
+def customiseFor47966(process):
+    for prod in esproducers_by_type(process, 'PixelCPEGenericESProducer', 'PixelCPEFastParamsESProducerAlpakaPhase1@alpaka'):
+        if not hasattr(prod, 'GoodEdgeAlgo'):
+            prod.GoodEdgeAlgo = cms.bool(True)
+        else:
+            prod.GoodEdgeAlgo = True
+
+    return process 

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEClusterRepair.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEClusterRepair.h
@@ -102,6 +102,7 @@ private:
   std::vector<SiPixelTemplateStore2D> thePixelTemp2D_;
 
   int speed_;
+  bool goodEdgeAlgo_;
 
   bool UseClusterSplitter_;
 

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFastParamsHost.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFastParamsHost.h
@@ -26,7 +26,8 @@ public:
                          const TrackerTopology& ttopo,
                          const SiPixelLorentzAngle* lorentzAngle,
                          const SiPixelGenErrorDBObject* genErrorDBObject,
-                         const SiPixelLorentzAngle* lorentzAngleWidth);
+                         const SiPixelLorentzAngle* lorentzAngleWidth,
+                         const bool goodEdgeAlgo);
 
   // non-copyable
   PixelCPEFastParamsHost(PixelCPEFastParamsHost const&) = delete;
@@ -61,6 +62,7 @@ private:
   void fillParamsForDevice();
 
   Buffer buffer_;
+  bool goodEdgeAlgo_;
 };
 
 #endif  // RecoLocalTracker_SiPixelRecHits_interface_PixelCPEFastParamsHost_h

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGeneric.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGeneric.h
@@ -81,12 +81,14 @@ protected:
   float the_eff_charge_cut_highY;
   float the_size_cutX;
   float the_size_cutY;
+  float delta_length_cut;
 
   bool inflate_errors;
   bool inflate_all_errors_no_trk_angle;
 
   bool DoCosmics_;
   bool IrradiationBiasCorrection_;
+  bool goodEdgeAlgo_;
   bool isPhase2_;
   bool NoTemplateErrorsWhenNoTrkAngles_;
 

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPETemplateReco.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPETemplateReco.h
@@ -79,6 +79,7 @@ private:
   const std::vector<SiPixelTemplateStore> *thePixelTemp_;
 
   int speed_;
+  bool goodEdgeAlgo_;
 
   bool UseClusterSplitter_;
 

--- a/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplateReco.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplateReco.h
@@ -99,7 +99,26 @@ namespace SiPixelTemplateReco {
                       std::vector<std::pair<int, int> >& zeropix,
                       float& probQ,
                       int& nypix,
-                      int& nxpix);
+                      int& nxpix,
+                      bool goodEdgeAlgo);
+
+  int PixelTempReco1D(int id,
+                      float cotalpha,
+                      float cotbeta,
+                      float locBz,
+                      float locBx,
+                      ClusMatrix& cluster,
+                      SiPixelTemplate& templ,
+                      float& yrec,
+                      float& sigmay,
+                      float& proby,
+                      float& xrec,
+                      float& sigmax,
+                      float& probx,
+                      int& qbin,
+                      int speed,
+                      float& probQ,
+                      bool goodEdgeAlgo);
 
   int PixelTempReco1D(int id,
                       float cotalpha,

--- a/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforDevice.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforDevice.h
@@ -124,14 +124,14 @@ namespace pixelCPEforDevice {
     cotbeta = gvy * gvz;
   }
 
-  constexpr inline float check_for_short(uint16_t upper_edge_first_pix,  //!< As the name says.
-                                         uint16_t lower_edge_last_pix,   //!< As the name says.
-                                         float lorentz_shift,            //!< L-shift at half thickness
-                                         float theThickness,             //detector thickness
-                                         float cot_angle,                //!< cot of alpha_ or beta_
-                                         float pitch,                    //!< thePitchX or thePitchY
-                                         bool first_is_big,              //!< true if the first is big
-                                         bool last_is_big)               //!< true if the last is big
+  constexpr inline float updatePositionForShortCluster(uint16_t upper_edge_first_pix,  //!< As the name says.
+                                                       uint16_t lower_edge_last_pix,   //!< As the name says.
+                                                       float lorentz_shift,            //!< L-shift at half thickness
+                                                       float theThickness,             //detector thickness
+                                                       float cot_angle,                //!< cot of alpha_ or beta_
+                                                       float pitch,                    //!< thePitchX or thePitchY
+                                                       bool first_is_big,              //!< true if the first is big
+                                                       bool last_is_big)               //!< true if the last is big
   {
     //checks if the observed cluster is much shorter than expected
     //if yes, returns the position predicted using a one-sided reconstruction
@@ -151,23 +151,23 @@ namespace pixelCPEforDevice {
       pitchfraction_last += 1.0f;
 
     float sum_of_edge = pitchfraction_first + pitchfraction_last;
-    float delta = w_eff - 0.5 * sum_of_edge * pitch;
+    float delta = w_eff - 0.5f * sum_of_edge * pitch;
 
     if (delta / pitch > delta_length_cut) {
       // define the centers of the first and last pixel coordinates
-      float x1 = pitch * (upper_edge_first_pix - 0.5 * pitchfraction_first);
-      float x2 = pitch * (lower_edge_last_pix + 0.5 * pitchfraction_last);
       //  observed cluster is much shorter than expected, use one-sided reco
       if (w_pred > 0.f) {
-        float hit_pos = x1 + 0.5 * w_pred;
+        float x1 = pitch * (upper_edge_first_pix - 0.5f * pitchfraction_first);
+        float hit_pos = x1 + 0.5f * w_pred;
         return hit_pos;
       } else {
-        float hit_pos = x2 + 0.5 * w_pred;
+        float x2 = pitch * (lower_edge_last_pix + 0.5f * pitchfraction_last);
+        float hit_pos = x2 + 0.5f * w_pred;
         return hit_pos;
       }
     }  //if(delta/pitch > delta_length_cut)
     else {
-      return -999.;
+      return -999.f;
     }
   }
 
@@ -300,29 +300,29 @@ namespace pixelCPEforDevice {
 
     auto thickness = detParams.isBarrel ? comParams.theThicknessB : comParams.theThicknessE;
     if (comParams.goodEdgeAlgo_) {
-      float xPos_alt = check_for_short(llxl,
-                                       urxl,
-                                       detParams.chargeWidthX,
-                                       thickness,
-                                       cotalpha,
-                                       detParams.thePitchX,
-                                       TrackerTraits::isBigPixX(cp.minRow[ic]),
-                                       TrackerTraits::isBigPixX(cp.maxRow[ic]));
-
-      float yPos_alt = check_for_short(llyl,
-                                       uryl,
-                                       detParams.chargeWidthY,
-                                       thickness,
-                                       cotbeta,
-                                       detParams.thePitchY,
-                                       TrackerTraits::isBigPixY(cp.minCol[ic]),
-                                       TrackerTraits::isBigPixY(cp.maxCol[ic]));
-
-      if (xPos_alt != -999.) {
-        //  observed cluster is much shorter than expected, use one-sided reco
-        xPos = xPos_alt;
-      }
-      if (yPos_alt != -999.) {
+      //Even unbroken clusters are short in x, so they will not be "shorter than expected"
+      //We save time by not checking this
+      // float xPos_alt = updatePositionForShortCluster(llxl,
+      //                                  urxl,
+      //                                  detParams.chargeWidthX,
+      //                                  thickness,
+      //                                  cotalpha,
+      //                                  detParams.thePitchX,
+      //                                  TrackerTraits::isBigPixX(cp.minRow[ic]),
+      //                                  TrackerTraits::isBigPixX(cp.maxRow[ic]));
+      // if (xPos_alt != -999.f) {
+      //   //  observed cluster is much shorter than expected, use one-sided reco
+      //   xPos = xPos_alt;
+      // }
+      float yPos_alt = updatePositionForShortCluster(llyl,
+                                                     uryl,
+                                                     detParams.chargeWidthY,
+                                                     thickness,
+                                                     cotbeta,
+                                                     detParams.thePitchY,
+                                                     TrackerTraits::isBigPixY(cp.minCol[ic]),
+                                                     TrackerTraits::isBigPixY(cp.maxCol[ic]));
+      if (yPos_alt != -999.f) {
         //  observed cluster is much shorter than expected, use one-sided reco
         yPos = yPos_alt;
       }

--- a/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/PixelCPEFastParamsESProducerAlpaka.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/PixelCPEFastParamsESProducerAlpaka.cc
@@ -42,6 +42,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     edm::ParameterSet pset_;
     bool useErrorsFromTemplates_;
+    bool goodEdgeAlgo_;
   };
 
   using namespace edm;
@@ -52,6 +53,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     auto const& myname = p.getParameter<std::string>("ComponentName");
     auto const& magname = p.getParameter<edm::ESInputTag>("MagneticFieldRecord");
     useErrorsFromTemplates_ = p.getParameter<bool>("UseErrorsFromTemplates");
+    goodEdgeAlgo_ = p.getParameter<bool>("GoodEdgeAlgo");
 
     auto cc = setWhatProduced(this, myname);
     magfieldToken_ = cc.consumes(magname);
@@ -84,7 +86,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                                    iRecord.get(hTTToken_),
                                                                    &iRecord.get(lorentzAngleToken_),
                                                                    genErrorDBObjectProduct,
-                                                                   lorentzAngleWidthProduct);
+                                                                   lorentzAngleWidthProduct,
+                                                                   goodEdgeAlgo_);
   }
 
   template <typename TrackerTraits>
@@ -103,6 +106,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     desc.add<double>("EdgeClusterErrorY", 85.0);
     desc.add<bool>("UseErrorsFromTemplates", true);
     desc.add<bool>("TruncatePixelCharge", true);
+    desc.add<bool>("GoodEdgeAlgo", false);
 
     std::string name = "PixelCPEFastParams";
     name += TrackerTraits::nameModifier;

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPEClusterRepair_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPEClusterRepair_cfi.py
@@ -6,3 +6,8 @@ templates2_speed0 = _templates2_default.clone(
     ComponentName = "PixelCPEClusterRepairWithoutProbQ",
     speed = 0
 )
+
+# Enable the good edge algorithm in pixel hit reconstruction that handles broken/truncated pixel cluster caused by radiation damage
+from Configuration.ProcessModifiers.siPixelGoodEdgeAlgo_cff import siPixelGoodEdgeAlgo
+siPixelGoodEdgeAlgo.toModify(templates2, GoodEdgeAlgo = True)
+siPixelGoodEdgeAlgo.toModify(templates2_speed0, GoodEdgeAlgo = True)

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPEESProducers_cff.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPEESProducers_cff.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.ProcessModifiers.alpaka_cff import alpaka
+from Configuration.ProcessModifiers.siPixelGoodEdgeAlgo_cff import siPixelGoodEdgeAlgo
 
 #
 # Load all Pixel Cluster Position Estimator ESProducers
@@ -24,3 +25,8 @@ def _addProcessCPEsAlpaka(process):
 
 modifyConfigurationForAlpakaCPEs_ = alpaka.makeProcessModifier(_addProcessCPEsAlpaka)
 
+def _enableGoodEdgeAlgoAlpaka(process):
+    _addProcessCPEsAlpaka(process)
+    process.pixelCPEFastParamsESProducerAlpakaPhase1.GoodEdgeAlgo = True
+
+enableGoodEdgeAlgoForAlpakaCPEs_ = (alpaka & siPixelGoodEdgeAlgo).makeProcessModifier(_enableGoodEdgeAlgoAlpaka)

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
@@ -8,6 +8,10 @@ PixelCPEGenericESProducer = _generic_default.clone()
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(PixelCPEGenericESProducer, IrradiationBiasCorrection = True)
 
+# Enable the good edge algorithm in pixel hit reconstruction that handles broken/truncated pixel cluster caused by radiation damage
+from Configuration.ProcessModifiers.siPixelGoodEdgeAlgo_cff import siPixelGoodEdgeAlgo
+siPixelGoodEdgeAlgo.toModify(PixelCPEGenericESProducer, GoodEdgeAlgo = True)
+
 # customize the Pixel CPE generic producer for phase2
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(PixelCPEGenericESProducer,

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPETemplateReco_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPETemplateReco_cfi.py
@@ -3,3 +3,6 @@ import FWCore.ParameterSet.Config as cms
 from RecoLocalTracker.SiPixelRecHits._templates_default_cfi import _templates_default
 templates = _templates_default.clone()
 
+# Enable the good edge algorithm in pixel hit reconstruction that handles broken/truncated pixel cluster caused by radiation damage
+from Configuration.ProcessModifiers.siPixelGoodEdgeAlgo_cff import siPixelGoodEdgeAlgo
+siPixelGoodEdgeAlgo.toModify(templates, GoodEdgeAlgo = True)

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
@@ -75,7 +75,9 @@ PixelCPEClusterRepair::PixelCPEClusterRepair(edm::ParameterSet const& conf,
   }
 
   speed_ = conf.getParameter<int>("speed");
+  goodEdgeAlgo_ = conf.getParameter<bool>("GoodEdgeAlgo");
   LogDebug("PixelCPEClusterRepair::PixelCPEClusterRepair:") << "Template speed = " << speed_ << "\n";
+  LogDebug("PixelCPEClusterRepair::PixelCPEClusterRepair:") << "GoodEdgeAlgo = " << goodEdgeAlgo_ << "\n";
 
   // this returns the magnetic field value in kgauss (1T = 10 kgauss)
   int theMagField = mag->nominalValue();
@@ -355,7 +357,8 @@ void PixelCPEClusterRepair::callTempReco1D(DetParam const& theDetParam,
                                          zeropix,
                                          theClusterParam.probabilityQ_,
                                          nypix,
-                                         nxpix);
+                                         nxpix,
+                                         goodEdgeAlgo_);
   // ******************************************************************
 
   //--- Check exit status
@@ -549,7 +552,8 @@ void PixelCPEClusterRepair::checkRecommend2D(DetParam const& theDetParam,
   }
   // The 1d pixel template
   SiPixelTemplate templ(*thePixelTemp_);
-  if (!templ.interpolate(ID, theClusterParam.cotalpha, theClusterParam.cotbeta, theDetParam.bz, theDetParam.bx)) {
+  if (!templ.interpolate(
+          ID, theClusterParam.cotalpha, theClusterParam.cotbeta, theDetParam.bz, theDetParam.bx, goodEdgeAlgo_)) {
     //error setting up template, return false
     theClusterParam.recommended2D_ = false;
     return;
@@ -718,6 +722,7 @@ void PixelCPEClusterRepair::fillPSetDescription(edm::ParameterSetDescription& de
   desc.add<int>("forwardTemplateID", 0);
   desc.add<int>("directoryWithTemplates", 0);
   desc.add<int>("speed", -2);
+  desc.add<bool>("GoodEdgeAlgo", false);
   desc.add<bool>("UseClusterSplitter", false);
   desc.add<double>("MaxSizeMismatchInY", 0.3);
   desc.add<double>("MinChargeRatio", 0.8);

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFastParamsHost.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFastParamsHost.cc
@@ -20,7 +20,8 @@ PixelCPEFastParamsHost<TrackerTraits>::PixelCPEFastParamsHost(edm::ParameterSet 
                                                               const TrackerTopology& ttopo,
                                                               const SiPixelLorentzAngle* lorentzAngle,
                                                               const SiPixelGenErrorDBObject* genErrorDBObject,
-                                                              const SiPixelLorentzAngle* lorentzAngleWidth)
+                                                              const SiPixelLorentzAngle* lorentzAngleWidth,
+                                                              const bool goodEdgeAlgo)
     : PixelCPEGenericBase(conf, mag, geom, ttopo, lorentzAngle, genErrorDBObject, lorentzAngleWidth),
       buffer_(cms::alpakatools::make_host_buffer<pixelCPEforDevice::ParamsOnDeviceT<TrackerTraits>>()) {
   // Use errors from templates or from GenError
@@ -30,7 +31,7 @@ PixelCPEFastParamsHost<TrackerTraits>::PixelCPEFastParamsHost(edm::ParameterSet 
           << "ERROR: GenErrors not filled correctly. Check the sqlite file. Using SiPixelTemplateDBObject version "
           << (*genErrorDBObject_).version();
   }
-
+  goodEdgeAlgo_ = goodEdgeAlgo;
   fillParamsForDevice();
 }
 
@@ -43,7 +44,7 @@ void PixelCPEFastParamsHost<TrackerTraits>::fillParamsForDevice() {
   buffer_->commonParams().theThicknessB = m_DetParams.front().theThickness;
   buffer_->commonParams().theThicknessE = m_DetParams.back().theThickness;
   buffer_->commonParams().numberOfLaddersInBarrel = TrackerTraits::numberOfLaddersInBarrel;
-
+  buffer_->commonParams().goodEdgeAlgo_ = goodEdgeAlgo_;
   LogDebug("PixelCPEFastParamsHost") << "thickness " << buffer_->commonParams().theThicknessB << ' '
                                      << buffer_->commonParams().theThicknessE;
 

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
@@ -44,6 +44,7 @@ PixelCPEGeneric::PixelCPEGeneric(edm::ParameterSet const& conf,
   the_eff_charge_cut_highY = conf.getParameter<double>("eff_charge_cut_highY");
   the_size_cutX = conf.getParameter<double>("size_cutX");
   the_size_cutY = conf.getParameter<double>("size_cutY");
+  delta_length_cut = 2.0f;  //seems to be a good value, if needed, will make this externally settable
 
   // Externally settable flags to inflate errors
   inflate_errors = conf.getParameter<bool>("inflate_errors");
@@ -51,6 +52,8 @@ PixelCPEGeneric::PixelCPEGeneric(edm::ParameterSet const& conf,
 
   NoTemplateErrorsWhenNoTrkAngles_ = conf.getParameter<bool>("NoTemplateErrorsWhenNoTrkAngles");
   IrradiationBiasCorrection_ = conf.getParameter<bool>("IrradiationBiasCorrection");
+  goodEdgeAlgo_ = conf.getParameter<bool>("GoodEdgeAlgo");  //use only one edge reco if cluster seems broken
+
   DoCosmics_ = conf.getParameter<bool>("DoCosmics");
 
   isPhase2_ = conf.getParameter<bool>("isPhase2");
@@ -92,6 +95,7 @@ PixelCPEGeneric::PixelCPEGeneric(edm::ParameterSet const& conf,
   cout << "(int)useErrorsFromTemplates_ = " << (int)useErrorsFromTemplates_ << endl;
   cout << "truncatePixelCharge_         = " << (int)truncatePixelCharge_ << endl;
   cout << "IrradiationBiasCorrection_   = " << (int)IrradiationBiasCorrection_ << endl;
+  cout << "goodEdgeAlgo_                = " << (int)goodEdgeAlgo_ << endl;
   cout << "(int)DoCosmics_              = " << (int)DoCosmics_ << endl;
   cout << "(int)LoadTemplatesFromDB_    = " << (int)LoadTemplatesFromDB_ << endl;
 #endif
@@ -266,7 +270,9 @@ LocalPoint PixelCPEGeneric::localPosition(DetParam const& theDetParam, ClusterPa
       theDetParam.theTopol->pixelFractionInX(theClusterParam.theCluster->maxPixelRow()),
       the_eff_charge_cut_lowX,
       the_eff_charge_cut_highX,
-      the_size_cutX);  // cut for eff charge width &&&
+      the_size_cutX,  // cut for eff charge width &&&
+      delta_length_cut,
+      goodEdgeAlgo_);
 
   // apply the lorentz offset correction
   xPos = xPos + shiftX;
@@ -290,7 +296,9 @@ LocalPoint PixelCPEGeneric::localPosition(DetParam const& theDetParam, ClusterPa
       theDetParam.theTopol->pixelFractionInY(theClusterParam.theCluster->maxPixelCol()),
       the_eff_charge_cut_lowY,
       the_eff_charge_cut_highY,
-      the_size_cutY);  // cut for eff charge width &&&
+      the_size_cutY,  // cut for eff charge width &&&
+      delta_length_cut,
+      goodEdgeAlgo_);
 
   // apply the lorentz offset correction
   yPos = yPos + shiftY;
@@ -447,6 +455,7 @@ void PixelCPEGeneric::fillPSetDescription(edm::ParameterSetDescription& desc) {
   desc.add<bool>("UseErrorsFromTemplates", true);
   desc.add<bool>("TruncatePixelCharge", true);
   desc.add<bool>("IrradiationBiasCorrection", false);
+  desc.add<bool>("GoodEdgeAlgo", false);
   desc.add<bool>("DoCosmics", false);
   desc.add<bool>("isPhase2", false);
   desc.add<bool>("SmallPitch", false);

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
@@ -81,6 +81,7 @@ PixelCPETemplateReco::PixelCPETemplateReco(edm::ParameterSet const& conf,
           << " not loaded correctly from text file. Reconstruction will fail.\n\n";
   }
 
+  goodEdgeAlgo_ = conf.getParameter<bool>("GoodEdgeAlgo");
   speed_ = conf.getParameter<int>("speed");
   LogDebug("PixelCPETemplateReco::PixelCPETemplateReco:") << "Template speed = " << speed_ << "\n";
 
@@ -249,7 +250,8 @@ LocalPoint PixelCPETemplateReco::localPosition(DetParam const& theDetParam, Clus
                                          theClusterParam.templProbX_,
                                          theClusterParam.templQbin_,
                                          speed_,
-                                         theClusterParam.templProbQ_);
+                                         theClusterParam.templProbQ_,
+                                         goodEdgeAlgo_);
 
   // ******************************************************************
 
@@ -529,4 +531,5 @@ void PixelCPETemplateReco::fillPSetDescription(edm::ParameterSetDescription& des
   desc.add<int>("directoryWithTemplates", 0);
   desc.add<int>("speed", -2);
   desc.add<bool>("UseClusterSplitter", false);
+  desc.add<bool>("GoodEdgeAlgo", false);
 }


### PR DESCRIPTION

**Backport**
Backport of https://github.com/cms-sw/cmssw/pull/47966 to CMSSW 15.0.X to request data rereco for validation

**PR description:**

At the end of 2024, cluster breakage at high eta became significant. This caused issues when trying to improve calibrations for pixel cluster (position) parameter estimation, CPE.

This fix changes the CPE algorithms by relying on the "good" cluster edge, instead of both edges. This alternative algorithm is only used if the clusters are shorter than expected (e.g. broken). The change affects template reconstruction, and generic reconstruction both at CPU and GPU (alpaka). The fix is gated behind process modifiers for testing. The new versions of CPE algorithms require corresponding condition updates.

**PR validation:**

Undergoing runTheMatrix.py -l limited -i all --ibeos. We don't expect any workflow to be affect since the changes are protected by process modifiers. The PR was opened before the validation to allower others to comment early.
