### PR TITLE
Code updates to mix FastSim PileUp events with FullSim Signal events

### DIFF
--- a/Configuration/ProcessModifiers/python/fastSimPU_cff.py
+++ b/Configuration/ProcessModifiers/python/fastSimPU_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+fastSimPU =  cms.Modifier()

--- a/SimCalorimetry/EcalSimProducers/interface/EcalDigiProducer.h
+++ b/SimCalorimetry/EcalSimProducers/interface/EcalDigiProducer.h
@@ -43,9 +43,9 @@
 #include "SimDataFormats/CaloHit/interface/PCaloHit.h"
 #include <vector>
 
-typedef EcalTDigitizer<EBDigitizerTraits> EBDigitizer;
-typedef EcalTDigitizer<EEDigitizerTraits> EEDigitizer;
-typedef CaloTDigitizer<ESOldDigitizerTraits> ESOldDigitizer;
+using EBDigitizer = EcalTDigitizer<EBDigitizerTraits>;
+using EEDigitizer = EcalTDigitizer<EEDigitizerTraits>;
+using ESOldDigitizer = CaloTDigitizer<ESOldDigitizerTraits>;
 
 class ESDigitizer;
 
@@ -99,7 +99,7 @@ private:
   virtual void cacheEBDigis(const EBDigiCollection *ebDigiPtr) const {}
   virtual void cacheEEDigis(const EEDigiCollection *eeDigiPtr) const {}
 
-  typedef edm::Handle<std::vector<PCaloHit>> HitsHandle;
+  using HitsHandle = edm::Handle<std::vector<PCaloHit>>;
   void accumulateCaloHits(HitsHandle const &ebHandle,
                           HitsHandle const &eeHandle,
                           HitsHandle const &esHandle,
@@ -121,10 +121,10 @@ private:
   const std::string m_EEdigiCollection;
   const std::string m_ESdigiCollection;
   const std::string m_hitsProducerTag;
-
-  const edm::EDGetTokenT<std::vector<PCaloHit>> m_HitsEBToken_;
-  const edm::EDGetTokenT<std::vector<PCaloHit>> m_HitsEEToken_;
-  const edm::EDGetTokenT<std::vector<PCaloHit>> m_HitsESToken_;
+  const std::string m_hitsProducerTagPU;
+  edm::EDGetTokenT<std::vector<PCaloHit>> m_HitsEBToken_;
+  edm::EDGetTokenT<std::vector<PCaloHit>> m_HitsEEToken_;
+  edm::EDGetTokenT<std::vector<PCaloHit>> m_HitsESToken_;
 
   const edm::ESGetToken<EcalPedestals, EcalPedestalsRcd> m_pedestalsToken;
   const edm::ESGetToken<EcalIntercalibConstantsMC, EcalIntercalibConstantsMCRcd> m_icalToken;
@@ -188,9 +188,9 @@ private:
   std::unique_ptr<EBDigitizer> m_BarrelDigitizer;
   std::unique_ptr<EEDigitizer> m_EndcapDigitizer;
 
-  typedef CaloTSamples<float, 10> EcalSamples;
+  using EcalSamples = CaloTSamples<float, 10>;
 
-  typedef EcalElectronicsSim<EcalCoder, EcalSamples, EcalDataFrame> EcalElectronicsSim_Ph1;
+  using EcalElectronicsSim_Ph1 = EcalElectronicsSim<EcalCoder, EcalSamples, EcalDataFrame>;
   std::unique_ptr<EcalElectronicsSim_Ph1> m_ElectronicsSim;
   std::unique_ptr<EcalCoder> m_Coder;
 

--- a/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
+++ b/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
@@ -185,20 +185,14 @@ EcalDigiProducer::EcalDigiProducer(const edm::ParameterSet &params, edm::Consume
   // mixMod.produces<EBDigiCollection>(m_EBdigiCollection);
   // mixMod.produces<EEDigiCollection>(m_EEdigiCollection);
   // mixMod.produces<ESDigiCollection>(m_ESdigiCollection);
-  const std::set<std::string> producers = {m_hitsProducerTag, m_hitsProducerTagPU};
   std::vector<edm::EDGetTokenT<std::vector<PCaloHit>>> eb_list, ee_list, es_list;
-  for (auto const &prod : producers) {
+  for (const auto &prod : {m_hitsProducerTag, m_hitsProducerTagPU}) {
     if (m_doEB)
       eb_list.push_back(iC.consumes<std::vector<PCaloHit>>(edm::InputTag(prod, "EcalHitsEB")));
     if (m_doEE)
       ee_list.push_back(iC.consumes<std::vector<PCaloHit>>(edm::InputTag(prod, "EcalHitsEE")));
-    if (m_doES) {
+    if (m_doES)
       es_list.push_back(iC.consumes<std::vector<PCaloHit>>(edm::InputTag(prod, "EcalHitsES")));
-      m_esGainToken = iC.esConsumes();
-      m_esMIPToGeVToken = iC.esConsumes();
-      m_esPedestalsToken = iC.esConsumes();
-      m_esMIPsToken = iC.esConsumes();
-    }
   }
   if (m_doEB)
     m_HitsEBToken_ = eb_list[0];
@@ -206,6 +200,13 @@ EcalDigiProducer::EcalDigiProducer(const edm::ParameterSet &params, edm::Consume
     m_HitsEEToken_ = ee_list[0];
   if (m_doES)
     m_HitsESToken_ = es_list[0];
+
+  if (m_doES) {
+    m_esGainToken = iC.esConsumes();
+    m_esMIPToGeVToken = iC.esConsumes();
+    m_esPedestalsToken = iC.esConsumes();
+    m_esMIPsToken = iC.esConsumes();
+  }
 
   const std::vector<double> ebCorMatG12 = params.getParameter<std::vector<double>>("EBCorrNoiseMatrixG12");
   const std::vector<double> eeCorMatG12 = params.getParameter<std::vector<double>>("EECorrNoiseMatrixG12");
@@ -402,7 +403,7 @@ void EcalDigiProducer::accumulate(edm::Event const &e, edm::EventSetup const &ev
     esHandle = e.getHandle(m_HitsESToken_);
   }
 #ifdef EDM_ML_DEBUG
-  std::cout << " EcalDigiProducer::accumulate Signal Hits with Tag " << m_hitsProducerTag << std::endl;
+  edm::LogVerbatim("EcalDigiProducer") << "Accumulate Signal Hits with Tag " << m_hitsProducerTag;
 #endif
   accumulateCaloHits(ebHandle, eeHandle, esHandle, 0);
 }
@@ -430,7 +431,7 @@ void EcalDigiProducer::accumulate(PileUpEventPrincipal const &e,
   }
 
 #ifdef EDM_ML_DEBUG
-  std::cout << " EcalDigiProducer::accumulate PU Hits with Tag " << m_hitsProducerTagPU << std::endl;
+  edm::LogVerbatim("EcalDigiProducer") << "Accumulate PU Hits with Tag " << m_hitsProducerTagPU;
 #endif
   accumulateCaloHits(ebHandle, eeHandle, esHandle, e.bunchCrossing());
 }

--- a/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
+++ b/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
@@ -185,8 +185,9 @@ EcalDigiProducer::EcalDigiProducer(const edm::ParameterSet &params, edm::Consume
   // mixMod.produces<EBDigiCollection>(m_EBdigiCollection);
   // mixMod.produces<EEDigiCollection>(m_EEdigiCollection);
   // mixMod.produces<ESDigiCollection>(m_ESdigiCollection);
+  const std::set<std::string> producers = {m_hitsProducerTag, m_hitsProducerTagPU};
   std::vector<edm::EDGetTokenT<std::vector<PCaloHit>>> eb_list, ee_list, es_list;
-  for (const auto &prod : {m_hitsProducerTag, m_hitsProducerTagPU}) {
+  for (const auto &prod : producers) {
     if (m_doEB)
       eb_list.push_back(iC.consumes<std::vector<PCaloHit>>(edm::InputTag(prod, "EcalHitsEB")));
     if (m_doEE)

--- a/SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h
+++ b/SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h
@@ -103,12 +103,12 @@ private:
   const HcalDDDRecConstants *theRecNumber;
 
   /** Reconstruction algorithm*/
-  typedef CaloTDigitizer<HBHEDigitizerTraits, CaloTDigitizerQIE8Run> HBHEDigitizer;
-  typedef CaloTDigitizer<HODigitizerTraits, CaloTDigitizerQIE8Run> HODigitizer;
-  typedef CaloTDigitizer<HFDigitizerTraits, CaloTDigitizerQIE8Run> HFDigitizer;
-  typedef CaloTDigitizer<ZDCDigitizerTraits, CaloTDigitizerQIE8Run> ZDCDigitizer;
-  typedef CaloTDigitizer<HcalQIE10DigitizerTraits, CaloTDigitizerQIE1011Run> QIE10Digitizer;
-  typedef CaloTDigitizer<HcalQIE11DigitizerTraits, CaloTDigitizerQIE1011Run> QIE11Digitizer;
+  using HBHEDigitizer = CaloTDigitizer<HBHEDigitizerTraits, CaloTDigitizerQIE8Run>;
+  using HODigitizer = CaloTDigitizer<HODigitizerTraits, CaloTDigitizerQIE8Run>;
+  using HFDigitizer = CaloTDigitizer<HFDigitizerTraits, CaloTDigitizerQIE8Run>;
+  using ZDCDigitizer = CaloTDigitizer<ZDCDigitizerTraits, CaloTDigitizerQIE8Run>;
+  using QIE10Digitizer = CaloTDigitizer<HcalQIE10DigitizerTraits, CaloTDigitizerQIE1011Run>;
+  using QIE11Digitizer = CaloTDigitizer<HcalQIE11DigitizerTraits, CaloTDigitizerQIE1011Run>;
 
   HcalSimParameterMap theParameterMap;
   HcalShapes theShapes;
@@ -176,6 +176,7 @@ private:
   bool injectTestHits_;
 
   std::string hitsProducer_;
+  std::string hitsProducerPU_;
 
   int theHOSiPMCode;
 

--- a/SimCalorimetry/HcalSimProducers/python/hcalUnsuppressedDigis_cfi.py
+++ b/SimCalorimetry/HcalSimProducers/python/hcalUnsuppressedDigis_cfi.py
@@ -53,7 +53,6 @@ fastSim.toModify(hcalSimBlock,
 
 from Configuration.ProcessModifiers.fastSimPU_cff import fastSimPU
 fastSimPU.toModify(hcalSimBlock,
-                   hitsProducer   = cms.string('g4SimHits'),                     
                    hitsProducerPU = cms.string('fastSimProducer') )
 
 from Configuration.ProcessModifiers.premix_stage1_cff import premix_stage1

--- a/SimCalorimetry/HcalSimProducers/python/hcalUnsuppressedDigis_cfi.py
+++ b/SimCalorimetry/HcalSimProducers/python/hcalUnsuppressedDigis_cfi.py
@@ -21,6 +21,7 @@ hcalSimBlock = cms.PSet(
     doTimeSlew = cms.bool(True),
     doHFWindow = cms.bool(False),
     hitsProducer = cms.string('g4SimHits'),
+    hitsProducerPU = cms.string('g4SimHits'),
     DelivLuminosity = cms.double(0),
     TestNumbering = cms.bool(False),
     doNeutralDensityFilter = cms.bool(True),
@@ -46,7 +47,14 @@ hcalSimBlock = cms.PSet(
 )
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-fastSim.toModify( hcalSimBlock, hitsProducer = "fastSimProducer" )
+fastSim.toModify(hcalSimBlock,
+                 hitsProducer   = cms.string('fastSimProducer'), 
+                 hitsProducerPU = cms.string('fastSimProducer') )
+
+from Configuration.ProcessModifiers.fastSimPU_cff import fastSimPU
+fastSimPU.toModify(hcalSimBlock,
+                   hitsProducer   = cms.string('g4SimHits'),                     
+                   hitsProducerPU = cms.string('fastSimProducer') )
 
 from Configuration.ProcessModifiers.premix_stage1_cff import premix_stage1
 premix_stage1.toModify(hcalSimBlock,

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
@@ -96,12 +96,11 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet &ps, edm::ConsumesCollector
       ignoreTime_(ps.getParameter<bool>("ignoreGeantTime")),
       injectTestHits_(ps.getParameter<bool>("injectTestHits")),
       hitsProducer_(ps.getParameter<std::string>("hitsProducer")),
+      hitsProducerPU_(ps.getParameter<std::string>("hitsProducerPU")),
       theHOSiPMCode(ps.getParameter<edm::ParameterSet>("ho").getParameter<int>("siPMCode")),
       deliveredLumi(0.),
       agingFlagHB(ps.getParameter<bool>("HBDarkening")),
       agingFlagHE(ps.getParameter<bool>("HEDarkening")),
-      zdcToken_(iC.consumes(edm::InputTag(hitsProducer_, "ZDCHITS"))),
-      hcalToken_(iC.consumes(edm::InputTag(hitsProducer_, "HcalHits"))),
       m_HBDarkening(nullptr),
       m_HEDarkening(nullptr),
       m_HFRecalibration(nullptr),
@@ -117,6 +116,15 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet &ps, edm::ConsumesCollector
   if (theHOSiPMCode == 2) {
     mcParamsToken_ = iC.esConsumes();
   }
+
+  const std::set<std::string> producers = {hitsProducer_, hitsProducerPU_};
+  std::vector<edm::EDGetTokenT<std::vector<PCaloHit>>> zdc_list, hcal_list;
+  for (auto const &prod : producers) {
+    zdc_list.push_back(iC.consumes<std::vector<PCaloHit>>(edm::InputTag(prod, "ZDCHITS")));
+    hcal_list.push_back(iC.consumes<std::vector<PCaloHit>>(edm::InputTag(prod, "HcalHits")));
+  }
+  zdcToken_ = zdc_list[0];
+  hcalToken_ = hcal_list[0];
 
   bool doNoise = ps.getParameter<bool>("doNoise");
 
@@ -467,6 +475,9 @@ void HcalDigitizer::accumulate(edm::Event const &e, edm::EventSetup const &event
   const HcalTopology *htopoP = &eventSetup.getData(topoToken_);
   const ZdcTopology *ztopoP = &eventSetup.getData(topoZToken_);
 
+#ifdef EDM_ML_DEBUG
+  std::cout << " HcalDigitizer::accumulate Signal Hits with Tag " << hitsProducer_ << std::endl;
+#endif
   accumulateCaloHits(hcalHandle, zdcHandle, 0, engine, htopoP, ztopoP);
 }
 
@@ -474,12 +485,12 @@ void HcalDigitizer::accumulate(PileUpEventPrincipal const &e,
                                edm::EventSetup const &eventSetup,
                                CLHEP::HepRandomEngine *engine) {
   // Step A: Get Inputs
-  edm::InputTag zdcTag(hitsProducer_, "ZDCHITS");
+  edm::InputTag zdcTag(hitsProducerPU_, "ZDCHITS");
   edm::Handle<std::vector<PCaloHit>> zdcHandle;
   e.getByLabel(zdcTag, zdcHandle);
   isZDC = zdcHandle.isValid();
 
-  edm::InputTag hcalTag(hitsProducer_, "HcalHits");
+  edm::InputTag hcalTag(hitsProducerPU_, "HcalHits");
   edm::Handle<std::vector<PCaloHit>> hcalHandle;
   e.getByLabel(hcalTag, hcalHandle);
   isHCAL = hcalHandle.isValid();
@@ -492,18 +503,19 @@ void HcalDigitizer::accumulate(PileUpEventPrincipal const &e,
 
 void HcalDigitizer::finalizeEvent(edm::Event &e, const edm::EventSetup &eventSetup, CLHEP::HepRandomEngine *engine) {
   // Step B: Create empty output
-  std::unique_ptr<HBHEDigiCollection> hbheResult(new HBHEDigiCollection());
-  std::unique_ptr<HODigiCollection> hoResult(new HODigiCollection());
-  std::unique_ptr<HFDigiCollection> hfResult(new HFDigiCollection());
-  std::unique_ptr<ZDCDigiCollection> zdcResult(new ZDCDigiCollection());
-  std::unique_ptr<QIE10DigiCollection> hfQIE10Result(new QIE10DigiCollection(
+  auto hbheResult = std::make_unique<HBHEDigiCollection>();
+  auto hoResult = std::make_unique<HODigiCollection>();
+  auto hfResult = std::make_unique<HFDigiCollection>();
+  auto zdcResult = std::make_unique<ZDCDigiCollection>();
+
+  auto hfQIE10Result = std::make_unique<QIE10DigiCollection>(
       !theHFQIE10DetIds.empty() ? theHFQIE10Response.get()->getReadoutFrameSize(theHFQIE10DetIds[0])
-                                : QIE10DigiCollection::MAXSAMPLES));
-  std::unique_ptr<QIE11DigiCollection> hbheQIE11Result(new QIE11DigiCollection(
+                                : QIE10DigiCollection::MAXSAMPLES);
+  auto hbheQIE11Result = std::make_unique<QIE11DigiCollection>(
       !theHBHEQIE11DetIds.empty() ? theHBHESiPMResponse.get()->getReadoutFrameSize(theHBHEQIE11DetIds[0]) :
                                   //      theParameterMap->simParameters(theHBHEQIE11DetIds[0]).readoutFrameSize()
           //      :
-          QIE11DigiCollection::MAXSAMPLES));
+          QIE11DigiCollection::MAXSAMPLES);
 
   // Step C: Invoke the algorithm, getting back outputs.
   if (isHCAL && hbhegeo) {
@@ -553,7 +565,7 @@ void HcalDigitizer::finalizeEvent(edm::Event &e, const edm::EventSetup &eventSet
   e.put(std::move(hbheQIE11Result), "HBHEQIE11DigiCollection");
 
   if (debugCS_) {
-    std::unique_ptr<CaloSamplesCollection> csResult(new CaloSamplesCollection());
+    auto csResult = std::make_unique<CaloSamplesCollection>();
     // smush together all the results
     if (theHBHEDigitizer)
       csResult->insert(
@@ -581,7 +593,7 @@ void HcalDigitizer::finalizeEvent(edm::Event &e, const edm::EventSetup &eventSet
   }
 
   if (injectTestHits_) {
-    std::unique_ptr<edm::PCaloHitContainer> pcResult(new edm::PCaloHitContainer());
+    auto pcResult = std::make_unique<edm::PCaloHitContainer>();
     pcResult->insert(pcResult->end(), injectedHits_.begin(), injectedHits_.end());
     e.put(std::move(pcResult), "HcalHits");
   }

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
@@ -117,9 +117,8 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet &ps, edm::ConsumesCollector
     mcParamsToken_ = iC.esConsumes();
   }
 
-  const std::set<std::string> producers = {hitsProducer_, hitsProducerPU_};
   std::vector<edm::EDGetTokenT<std::vector<PCaloHit>>> zdc_list, hcal_list;
-  for (auto const &prod : producers) {
+  for (const auto &prod : {hitsProducer_, hitsProducerPU_}) {
     zdc_list.push_back(iC.consumes<std::vector<PCaloHit>>(edm::InputTag(prod, "ZDCHITS")));
     hcal_list.push_back(iC.consumes<std::vector<PCaloHit>>(edm::InputTag(prod, "HcalHits")));
   }
@@ -476,7 +475,7 @@ void HcalDigitizer::accumulate(edm::Event const &e, edm::EventSetup const &event
   const ZdcTopology *ztopoP = &eventSetup.getData(topoZToken_);
 
 #ifdef EDM_ML_DEBUG
-  std::cout << " HcalDigitizer::accumulate Signal Hits with Tag " << hitsProducer_ << std::endl;
+  edm::LogVerbatim("HcalDigitizer") << "Accumulate Signal Hits with Tag " << hitsProducer_;
 #endif
   accumulateCaloHits(hcalHandle, zdcHandle, 0, engine, htopoP, ztopoP);
 }

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
@@ -117,8 +117,9 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet &ps, edm::ConsumesCollector
     mcParamsToken_ = iC.esConsumes();
   }
 
+  const std::set<std::string> producers = {hitsProducer_, hitsProducerPU_};
   std::vector<edm::EDGetTokenT<std::vector<PCaloHit>>> zdc_list, hcal_list;
-  for (const auto &prod : {hitsProducer_, hitsProducerPU_}) {
+  for (const auto &prod : producers) {
     zdc_list.push_back(iC.consumes<std::vector<PCaloHit>>(edm::InputTag(prod, "ZDCHITS")));
     hcal_list.push_back(iC.consumes<std::vector<PCaloHit>>(edm::InputTag(prod, "HcalHits")));
   }

--- a/SimGeneral/MixingModule/plugins/MixingModule.cc
+++ b/SimGeneral/MixingModule/plugins/MixingModule.cc
@@ -77,6 +77,10 @@ namespace edm {
       skipSignal_ = ps_mix.getParameter<bool>("skipSignal");
     }
 
+    skipProductCheck_ = false;
+    if (ps_mix.exists("skipProductCheck")) {
+      skipProductCheck_ = ps_mix.getParameter<bool>("skipProductCheck");
+    }
     ParameterSet ps = ps_mix.getParameter<ParameterSet>("mixObjects");
     std::vector<std::string> names = ps.getParameterNames();
     for (std::vector<std::string>::iterator it = names.begin(); it != names.end(); ++it) {
@@ -310,14 +314,14 @@ namespace edm {
   void MixingModule::checkSignal(const edm::Event& e) {
     if (adjusters_.empty()) {
       for (auto const& adjuster : adjustersObjects_) {
-        if (skipSignal_ or adjuster->checkSignal(e)) {
+        if (skipSignal_ or skipProductCheck_ or adjuster->checkSignal(e)) {
           adjusters_.push_back(adjuster);
         }
       }
     }
     if (workers_.empty()) {
       for (auto const& worker : workersObjects_) {
-        if (skipSignal_ or worker->checkSignal(e)) {
+        if (skipSignal_ or skipProductCheck_ or worker->checkSignal(e)) {
           workers_.push_back(worker);
         }
       }
@@ -349,10 +353,9 @@ namespace edm {
   }
 
   void MixingModule::addSignals(const edm::Event& e, const edm::EventSetup& setup) {
-    // FIXME: temporary fix for the process type fastSimPU. Better solution needed
-    /*    if (skipSignal_) {
+    if (skipSignal_) {
       return;
-      }*/
+    }
 
     LogDebug("MixingModule") << "===============> adding signals for " << e.id();
 

--- a/SimGeneral/MixingModule/plugins/MixingModule.cc
+++ b/SimGeneral/MixingModule/plugins/MixingModule.cc
@@ -109,11 +109,6 @@ namespace edm {
 
         LogInfo("MixingModule") << "Will mix " << object << "s with InputTag= " << tag.encode() << ", label will be "
                                 << label;
-#ifdef EDM_ML_DEBUG
-        std::cout << "Will mix " << object << "s with InputTag " << tag.encode() << ", label will be " << label
-                  << std::endl;
-#endif
-
       } else if (object == "RecoTrack") {
         InputTag tag;
         if (!tags.empty())
@@ -134,11 +129,6 @@ namespace edm {
 
         LogInfo("MixingModule") << "Will mix " << object << "s with InputTag= " << tag.encode() << ", label will be "
                                 << label;
-#ifdef EDM_ML_DEBUG
-        std::cout << "Will mix " << object << "s with InputTag= " << tag.encode() << ", label will be " << label
-                  << std::endl;
-#endif
-
       } else if (object == "SimVertex") {
         InputTag tag;
         if (!tags.empty())
@@ -157,11 +147,6 @@ namespace edm {
 
         LogInfo("MixingModule") << "Will mix " << object << "s with InputTag " << tag.encode() << ", label will be "
                                 << label;
-#ifdef EDM_ML_DEBUG
-        std::cout << "Will mix " << object << "s with InputTag " << tag.encode() << ", label will be " << label
-                  << std::endl;
-#endif
-
       } else if (object == "HepMCProduct") {
         InputTag tag;
         if (!tags.empty())
@@ -179,10 +164,6 @@ namespace edm {
 
         LogInfo("MixingModule") << "Will mix " << object << "s with InputTag= " << tag.encode() << ", label will be "
                                 << label;
-#ifdef EDM_ML_DEBUG
-        std::cout << "Will mix " << object << "s with InputTag= " << tag.encode() << ", label will be " << label
-                  << std::endl;
-#endif
         for (size_t i = 1; i < tags.size(); ++i) {
           InputTag fallbackTag = tags[i];
           std::string fallbackLabel;
@@ -215,24 +196,13 @@ namespace edm {
 
           LogInfo("MixingModule") << "Will mix " << object << "s with InputTag= " << tag.encode() << ", label will be "
                                   << label;
-#ifdef EDM_ML_DEBUG
-          std::cout << "Will mix " << object << "s with InputTag= " << tag.encode() << ", label will be " << label
-                    << std::endl;
-#endif
         }
 
       } else if (object == "PSimHit") {
-#ifdef EDM_ML_DEBUG
-        std::cout << " MixingModule Constructor for PSimHit " << std::endl;
-#endif
         std::vector<std::string> subdets = pset.getParameter<std::vector<std::string> >("subdets");
         std::vector<std::string> crossingFrames =
             pset.getUntrackedParameter<std::vector<std::string> >("crossingFrames", std::vector<std::string>());
         sort_all(crossingFrames);
-#ifdef EDM_ML_DEBUG
-        for (auto const& xframes : crossingFrames)
-          std::cout << " MixingModule::MixingModule object ==  PSimHit ==> Crossing Frames " << xframes << std::endl;
-#endif
         std::vector<std::string> pcrossingFrames =
             pset.getUntrackedParameter<std::vector<std::string> >("pcrossingFrames", std::vector<std::string>());
         sort_all(pcrossingFrames);
@@ -247,9 +217,6 @@ namespace edm {
           branchesActivate(TypeID(typeid(std::vector<PSimHit>)).friendlyClassName(), subdets[ii], tag, label);
           adjustersObjects_.push_back(new Adjuster<std::vector<PSimHit> >(tag, consumesCollector(), wrapLongTimes_));
           if (binary_search_all(crossingFrames, tag.instance())) {
-#ifdef EDM_ML_DEBUG
-            std::cout << " Binary Search Result " << tag.instance() << " tags[ii] " << tags[ii] << std::endl;
-#endif
             bool makePCrossingFrame = binary_search_all(pcrossingFrames, tag.instance());
             workersObjects_.push_back(new MixingWorker<PSimHit>(minBunch_,
                                                                 maxBunch_,
@@ -261,14 +228,6 @@ namespace edm {
                                                                 tag,
                                                                 tagCF,
                                                                 makePCrossingFrame));
-#ifdef EDM_ML_DEBUG
-            std::cout << " Creating MixingWorker with "
-                      << " minBunch_ " << minBunch_ << " maxBunch_ " << maxBunch_ << " bunchSpace_ " << bunchSpace_
-                      << " subdets[ii] " << subdets[ii] << " label " << label << " labelCF " << labelCF
-                      << " maxNbSources_ " << maxNbSources_ << " tag " << tag << " tagCF " << tagCF
-                      << " makePCrossingFrame " << makePCrossingFrame << std::endl;
-#endif
-
             produces<CrossingFrame<PSimHit> >(label);
             if (makePCrossingFrame) {
               produces<PCrossingFrame<PSimHit> >(label);
@@ -278,14 +237,7 @@ namespace edm {
 
           LogInfo("MixingModule") << "Will mix " << object << "s with InputTag= " << tag.encode() << ", label will be "
                                   << label;
-#ifdef EDM_ML_DEBUG
-          std::cout << "Will mix " << object << "s with InputTag= " << tag.encode() << ", label will be " << label
-                    << " and LabelCF " << labelCF << std::endl;
-#endif
         }
-#ifdef EDM_ML_DEBUG
-        std::cout << " Worker Objects Size " << workersObjects_.size() << std::endl;
-#endif
       } else {
         LogWarning("MixingModule")
             << "You have asked to mix an unknown type of object(" << object
@@ -345,11 +297,6 @@ namespace edm {
                                       const std::string& subdet,
                                       InputTag& tag,
                                       std::string& label) {
-#ifdef EDM_ML_DEBUG
-    std::cout << " MixingModule::branchesActivate "
-              << " friendlyName " << friendlyName << " subdet " << subdet << " tag " << tag << " label " << label
-              << std::endl;
-#endif
     label = tag.label() + tag.instance();
     wantedBranches_.push_back(friendlyName + '_' + tag.label() + '_' + tag.instance());
 
@@ -370,16 +317,8 @@ namespace edm {
     }
     if (workers_.empty()) {
       for (auto const& worker : workersObjects_) {
-#ifdef EDM_ML_DEBUG
-        std::cout << " MixingModule::checkSignal " << std::boolalpha << " skipSignal_: " << skipSignal_
-                  << ", MixingWorker:checkSignal: " << worker->checkSignal(e) << std::endl;
-#endif
         if (skipSignal_ or worker->checkSignal(e)) {
           workers_.push_back(worker);
-#ifdef EDM_ML_DEBUG
-          std::cout << " MixingModule::checkSignal "
-                    << " Worker with InputTag " << worker->getInputTag() << " stored " << std::endl;
-#endif
         }
       }
     }
@@ -416,10 +355,6 @@ namespace edm {
       }*/
 
     LogDebug("MixingModule") << "===============> adding signals for " << e.id();
-#ifdef EDM_ML_DEBUG
-    std::cout << "MixingModule::addSignals "
-              << "===============> adding signals for " << e.id() << std::endl;
-#endif
 
     accumulateEvent(e, setup);
     // fill in signal part of CrossingFrame
@@ -451,9 +386,6 @@ namespace edm {
 
     for (auto const& worker : workers_) {
       LogDebug("MixingModule") << " merging Event:  id " << eventPrincipal.id();
-#ifdef EDM_ML_DEBUG
-      std::cout << "pileAllWorkers merging Event:  id " << eventPrincipal.id() << std::endl;
-#endif
       worker->addPileups(eventPrincipal, &moduleCallingContext, eventId);
     }
 
@@ -556,13 +488,6 @@ namespace edm {
       (*accItr)->StorePileupInformation(
           bunchCrossingList, numInteractionList, TrueInteractionList, eventInfoList, bunchSpace_);
     }
-
-#ifdef EDM_ML_DEBUG
-    for (int bunchIdx = minBunch_; bunchIdx <= maxBunch_; ++bunchIdx) {
-      std::cout << " bunch ID, Pileup, True " << bunchIdx << " " << PileupList[bunchIdx - minBunch_] << " "
-                << TrueNumInteractions_[bunchIdx - minBunch_] << std::endl;
-    }
-#endif
 
     for (int bunchIdx = minBunch_; bunchIdx <= maxBunch_; ++bunchIdx) {
       for (size_t setBcrIdx = 0; setBcrIdx < workers_.size(); ++setBcrIdx) {

--- a/SimGeneral/MixingModule/plugins/MixingModule.cc
+++ b/SimGeneral/MixingModule/plugins/MixingModule.cc
@@ -109,7 +109,10 @@ namespace edm {
 
         LogInfo("MixingModule") << "Will mix " << object << "s with InputTag= " << tag.encode() << ", label will be "
                                 << label;
-        //            std::cout <<"Will mix "<<object<<"s with InputTag= "<<tag.encode()<<", label will be "<<label<<std::endl;
+#ifdef EDM_ML_DEBUG
+        std::cout << "Will mix " << object << "s with InputTag " << tag.encode() << ", label will be " << label
+                  << std::endl;
+#endif
 
       } else if (object == "RecoTrack") {
         InputTag tag;
@@ -131,7 +134,10 @@ namespace edm {
 
         LogInfo("MixingModule") << "Will mix " << object << "s with InputTag= " << tag.encode() << ", label will be "
                                 << label;
-        //std::cout <<"Will mix "<<object<<"s with InputTag= "<<tag.encode()<<", label will be "<<label<<std::endl;
+#ifdef EDM_ML_DEBUG
+        std::cout << "Will mix " << object << "s with InputTag= " << tag.encode() << ", label will be " << label
+                  << std::endl;
+#endif
 
       } else if (object == "SimVertex") {
         InputTag tag;
@@ -151,7 +157,10 @@ namespace edm {
 
         LogInfo("MixingModule") << "Will mix " << object << "s with InputTag " << tag.encode() << ", label will be "
                                 << label;
-        //            std::cout <<"Will mix "<<object<<"s with InputTag "<<tag.encode()<<", label will be "<<label<<std::endl;
+#ifdef EDM_ML_DEBUG
+        std::cout << "Will mix " << object << "s with InputTag " << tag.encode() << ", label will be " << label
+                  << std::endl;
+#endif
 
       } else if (object == "HepMCProduct") {
         InputTag tag;
@@ -170,7 +179,10 @@ namespace edm {
 
         LogInfo("MixingModule") << "Will mix " << object << "s with InputTag= " << tag.encode() << ", label will be "
                                 << label;
-        //            std::cout <<"Will mix "<<object<<"s with InputTag= "<<tag.encode()<<", label will be "<<label<<std::endl;
+#ifdef EDM_ML_DEBUG
+        std::cout << "Will mix " << object << "s with InputTag= " << tag.encode() << ", label will be " << label
+                  << std::endl;
+#endif
         for (size_t i = 1; i < tags.size(); ++i) {
           InputTag fallbackTag = tags[i];
           std::string fallbackLabel;
@@ -203,14 +215,24 @@ namespace edm {
 
           LogInfo("MixingModule") << "Will mix " << object << "s with InputTag= " << tag.encode() << ", label will be "
                                   << label;
-          //              std::cout <<"Will mix "<<object<<"s with InputTag= "<<tag.encode()<<", label will be "<<label<<std::endl;
+#ifdef EDM_ML_DEBUG
+          std::cout << "Will mix " << object << "s with InputTag= " << tag.encode() << ", label will be " << label
+                    << std::endl;
+#endif
         }
 
       } else if (object == "PSimHit") {
+#ifdef EDM_ML_DEBUG
+        std::cout << " MixingModule Constructor for PSimHit " << std::endl;
+#endif
         std::vector<std::string> subdets = pset.getParameter<std::vector<std::string> >("subdets");
         std::vector<std::string> crossingFrames =
             pset.getUntrackedParameter<std::vector<std::string> >("crossingFrames", std::vector<std::string>());
         sort_all(crossingFrames);
+#ifdef EDM_ML_DEBUG
+        for (auto const& xframes : crossingFrames)
+          std::cout << " MixingModule::MixingModule object ==  PSimHit ==> Crossing Frames " << xframes << std::endl;
+#endif
         std::vector<std::string> pcrossingFrames =
             pset.getUntrackedParameter<std::vector<std::string> >("pcrossingFrames", std::vector<std::string>());
         sort_all(pcrossingFrames);
@@ -225,6 +247,9 @@ namespace edm {
           branchesActivate(TypeID(typeid(std::vector<PSimHit>)).friendlyClassName(), subdets[ii], tag, label);
           adjustersObjects_.push_back(new Adjuster<std::vector<PSimHit> >(tag, consumesCollector(), wrapLongTimes_));
           if (binary_search_all(crossingFrames, tag.instance())) {
+#ifdef EDM_ML_DEBUG
+            std::cout << " Binary Search Result " << tag.instance() << " tags[ii] " << tags[ii] << std::endl;
+#endif
             bool makePCrossingFrame = binary_search_all(pcrossingFrames, tag.instance());
             workersObjects_.push_back(new MixingWorker<PSimHit>(minBunch_,
                                                                 maxBunch_,
@@ -236,6 +261,14 @@ namespace edm {
                                                                 tag,
                                                                 tagCF,
                                                                 makePCrossingFrame));
+#ifdef EDM_ML_DEBUG
+            std::cout << " Creating MixingWorker with "
+                      << " minBunch_ " << minBunch_ << " maxBunch_ " << maxBunch_ << " bunchSpace_ " << bunchSpace_
+                      << " subdets[ii] " << subdets[ii] << " label " << label << " labelCF " << labelCF
+                      << " maxNbSources_ " << maxNbSources_ << " tag " << tag << " tagCF " << tagCF
+                      << " makePCrossingFrame " << makePCrossingFrame << std::endl;
+#endif
+
             produces<CrossingFrame<PSimHit> >(label);
             if (makePCrossingFrame) {
               produces<PCrossingFrame<PSimHit> >(label);
@@ -245,8 +278,14 @@ namespace edm {
 
           LogInfo("MixingModule") << "Will mix " << object << "s with InputTag= " << tag.encode() << ", label will be "
                                   << label;
-          //              std::cout <<"Will mix "<<object<<"s with InputTag= "<<tag.encode()<<", label will be "<<label<<std::endl;
+#ifdef EDM_ML_DEBUG
+          std::cout << "Will mix " << object << "s with InputTag= " << tag.encode() << ", label will be " << label
+                    << " and LabelCF " << labelCF << std::endl;
+#endif
         }
+#ifdef EDM_ML_DEBUG
+        std::cout << " Worker Objects Size " << workersObjects_.size() << std::endl;
+#endif
       } else {
         LogWarning("MixingModule")
             << "You have asked to mix an unknown type of object(" << object
@@ -306,6 +345,11 @@ namespace edm {
                                       const std::string& subdet,
                                       InputTag& tag,
                                       std::string& label) {
+#ifdef EDM_ML_DEBUG
+    std::cout << " MixingModule::branchesActivate "
+              << " friendlyName " << friendlyName << " subdet " << subdet << " tag " << tag << " label " << label
+              << std::endl;
+#endif
     label = tag.label() + tag.instance();
     wantedBranches_.push_back(friendlyName + '_' + tag.label() + '_' + tag.instance());
 
@@ -326,8 +370,16 @@ namespace edm {
     }
     if (workers_.empty()) {
       for (auto const& worker : workersObjects_) {
+#ifdef EDM_ML_DEBUG
+        std::cout << " MixingModule::checkSignal " << std::boolalpha << " skipSignal_: " << skipSignal_
+                  << ", MixingWorker:checkSignal: " << worker->checkSignal(e) << std::endl;
+#endif
         if (skipSignal_ or worker->checkSignal(e)) {
           workers_.push_back(worker);
+#ifdef EDM_ML_DEBUG
+          std::cout << " MixingModule::checkSignal "
+                    << " Worker with InputTag " << worker->getInputTag() << " stored " << std::endl;
+#endif
         }
       }
     }
@@ -358,11 +410,16 @@ namespace edm {
   }
 
   void MixingModule::addSignals(const edm::Event& e, const edm::EventSetup& setup) {
-    if (skipSignal_) {
+    // FIXME: temporary fix for the process type fastSimPU. Better solution needed
+    /*    if (skipSignal_) {
       return;
-    }
+      }*/
 
     LogDebug("MixingModule") << "===============> adding signals for " << e.id();
+#ifdef EDM_ML_DEBUG
+    std::cout << "MixingModule::addSignals "
+              << "===============> adding signals for " << e.id() << std::endl;
+#endif
 
     accumulateEvent(e, setup);
     // fill in signal part of CrossingFrame
@@ -394,8 +451,9 @@ namespace edm {
 
     for (auto const& worker : workers_) {
       LogDebug("MixingModule") << " merging Event:  id " << eventPrincipal.id();
-      //      std::cout <<"PILEALLWORKERS merging Event:  id " << eventPrincipal.id() << std::endl;
-
+#ifdef EDM_ML_DEBUG
+      std::cout << "pileAllWorkers merging Event:  id " << eventPrincipal.id() << std::endl;
+#endif
       worker->addPileups(eventPrincipal, &moduleCallingContext, eventId);
     }
 
@@ -499,9 +557,12 @@ namespace edm {
           bunchCrossingList, numInteractionList, TrueInteractionList, eventInfoList, bunchSpace_);
     }
 
-    //    for (int bunchIdx = minBunch_; bunchIdx <= maxBunch_; ++bunchIdx) {
-    //  std::cout << " bunch ID, Pileup, True " << bunchIdx << " " << PileupList[bunchIdx-minBunch_] << " " <<  TrueNumInteractions_[bunchIdx-minBunch_] << std::endl;
-    //}
+#ifdef EDM_ML_DEBUG
+    for (int bunchIdx = minBunch_; bunchIdx <= maxBunch_; ++bunchIdx) {
+      std::cout << " bunch ID, Pileup, True " << bunchIdx << " " << PileupList[bunchIdx - minBunch_] << " "
+                << TrueNumInteractions_[bunchIdx - minBunch_] << std::endl;
+    }
+#endif
 
     for (int bunchIdx = minBunch_; bunchIdx <= maxBunch_; ++bunchIdx) {
       for (size_t setBcrIdx = 0; setBcrIdx < workers_.size(); ++setBcrIdx) {

--- a/SimGeneral/MixingModule/plugins/MixingModule.h
+++ b/SimGeneral/MixingModule/plugins/MixingModule.h
@@ -109,6 +109,7 @@ namespace edm {
     bool useCurrentProcessOnly_;
     bool wrapLongTimes_;
     bool skipSignal_;
+    bool skipProductCheck_;
 
     // Digi-producing algorithms
     Accumulators digiAccumulators_;

--- a/SimGeneral/MixingModule/plugins/MixingWorker.cc
+++ b/SimGeneral/MixingModule/plugins/MixingWorker.cc
@@ -52,6 +52,12 @@ namespace edm {
         InputTag t = InputTag(tag.label(), tag.instance());
         LogInfo("MixingModule") << " Will create a CrossingFrame for HepMCProduct with "
                                 << " with InputTag= " << t.encode();
+#ifdef EDM_ML_DEBUG
+        std::cout << " MixingWorker::checkSignal"
+                  << " Will create a CrossingFrame for HepMCProduct with "
+                  << " with InputTag= " << t.encode() << std::endl;
+#endif
+
         break;
       }
     }

--- a/SimGeneral/MixingModule/plugins/MixingWorker.cc
+++ b/SimGeneral/MixingModule/plugins/MixingWorker.cc
@@ -52,11 +52,6 @@ namespace edm {
         InputTag t = InputTag(tag.label(), tag.instance());
         LogInfo("MixingModule") << " Will create a CrossingFrame for HepMCProduct with "
                                 << " with InputTag= " << t.encode();
-#ifdef EDM_ML_DEBUG
-        std::cout << " MixingWorker::checkSignal"
-                  << " Will create a CrossingFrame for HepMCProduct with "
-                  << " with InputTag= " << t.encode() << std::endl;
-#endif
 
         break;
       }

--- a/SimGeneral/MixingModule/plugins/MixingWorker.h
+++ b/SimGeneral/MixingModule/plugins/MixingWorker.h
@@ -121,11 +121,6 @@ namespace edm {
       if (got)
         LogInfo("MixingModule") << " Will create a CrossingFrame for " << typeid(T).name()
                                 << " with InputTag= " << t.encode();
-#ifdef EDM_ML_DEBUG
-      std::cout << "MixingModule "
-                << " Will create a CrossingFrame for " << typeid(T).name() << " with InputTag= " << t.encode()
-                << etd::endl;
-#endif
       return got;
     }
 
@@ -158,11 +153,6 @@ namespace edm {
       }
       e.put(std::move(crFrame_), label_);
       LogDebug("MixingModule") << " CF was put for type " << typeid(T).name() << " with " << label_;
-#ifdef EDM_ML_DEBUG
-      std::cout << "MixingModule "
-                << " CF was put for type " << typeid(T).name() << " with " << label_ << " #of Signal "
-                << crFrame_->getNrSignals() << " #of PU " << crFrame_->getNrPileups() << std::endl;
-#endif
     }
 
     // When using mixed secondary source

--- a/SimGeneral/MixingModule/plugins/MixingWorker.h
+++ b/SimGeneral/MixingModule/plugins/MixingWorker.h
@@ -121,7 +121,11 @@ namespace edm {
       if (got)
         LogInfo("MixingModule") << " Will create a CrossingFrame for " << typeid(T).name()
                                 << " with InputTag= " << t.encode();
-
+#ifdef EDM_ML_DEBUG
+      std::cout << "MixingModule "
+                << " Will create a CrossingFrame for " << typeid(T).name() << " with InputTag= " << t.encode()
+                << etd::endl;
+#endif
       return got;
     }
 
@@ -154,11 +158,17 @@ namespace edm {
       }
       e.put(std::move(crFrame_), label_);
       LogDebug("MixingModule") << " CF was put for type " << typeid(T).name() << " with " << label_;
+#ifdef EDM_ML_DEBUG
+      std::cout << "MixingModule "
+                << " CF was put for type " << typeid(T).name() << " with " << label_ << " #of Signal "
+                << crFrame_->getNrSignals() << " #of PU " << crFrame_->getNrPileups() << std::endl;
+#endif
     }
 
     // When using mixed secondary source
     // Copy the data from the PCrossingFrame to the CrossingFrame
     virtual void copyPCrossingFrame(const PCrossingFrame<T> *PCF);
+    InputTag getInputTag() const override { return tag_; }
 
   private:
     int minBunch_;

--- a/SimGeneral/MixingModule/plugins/MixingWorkerBase.h
+++ b/SimGeneral/MixingModule/plugins/MixingWorkerBase.h
@@ -43,6 +43,7 @@ namespace edm {
     virtual void setTof() = 0;
     virtual void put(edm::Event &e) = 0;
     virtual void reload(int minBunch, int maxBunch, int bunchSpace) {}
+    virtual InputTag getInputTag() const = 0;
   };
 }  // namespace edm
 

--- a/SimGeneral/MixingModule/python/SiPixelSimParameters_cfi.py
+++ b/SimGeneral/MixingModule/python/SiPixelSimParameters_cfi.py
@@ -63,6 +63,11 @@ SiPixelSimBlock = cms.PSet(
         'TrackerHitsPixelBarrelHighTof', 
         'TrackerHitsPixelEndcapLowTof', 
         'TrackerHitsPixelEndcapHighTof'),
+    RoutListPU = cms.vstring(
+        'TrackerHitsPixelBarrelLowTof', 
+        'TrackerHitsPixelBarrelHighTof', 
+        'TrackerHitsPixelEndcapLowTof', 
+        'TrackerHitsPixelEndcapHighTof'),
     OffsetSmearing = cms.double(0.0),
     ThresholdInElectrons_FPix = cms.double(3000.0), 
     ThresholdInElectrons_BPix = cms.double(3500.0),
@@ -140,6 +145,14 @@ premix_stage1.toModify(SiPixelSimBlock,
     KillBadFEDChannels = False, #done in second step
     killModules = False #done in second step
 )
+# when FastSim events as PileUP events during mixing
+from Configuration.ProcessModifiers.fastSimPU_cff import fastSimPU
+fastSimPU.toModify(SiPixelSimBlock,
+                   RoutListPU = cms.vstring('TrackerHits'))
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+fastSim.toModify(SiPixelSimBlock,
+                   RoutList = cms.vstring('TrackerHits'),
+                   RoutListPU = cms.vstring('TrackerHits'))
 
 # Threshold in electrons are the Official CRAFT09 numbers:
 # FPix(smearing)/BPix(smearing) = 2480(160)/2730(200)

--- a/SimGeneral/MixingModule/python/SiStripSimParameters_cfi.py
+++ b/SimGeneral/MixingModule/python/SiStripSimParameters_cfi.py
@@ -87,6 +87,10 @@ SiStripSimBlock = cms.PSet(
                           "TrackerHitsTIDLowTof","TrackerHitsTIDHighTof",
                           "TrackerHitsTOBLowTof","TrackerHitsTOBHighTof",
                           "TrackerHitsTECLowTof","TrackerHitsTECHighTof"),
+    ROUListPU = cms.vstring("TrackerHitsTIBLowTof","TrackerHitsTIBHighTof",
+                          "TrackerHitsTIDLowTof","TrackerHitsTIDHighTof",
+                          "TrackerHitsTOBLowTof","TrackerHitsTOBHighTof",
+                          "TrackerHitsTECLowTof","TrackerHitsTECHighTof"),
     GeometryType               = cms.string('idealForDigi'),
     TrackerConfigurationFromDB = cms.bool(False),
     ZeroSuppression            = cms.bool(True),
@@ -156,3 +160,11 @@ run2_common.toModify(SiStripSimBlock,
                      CouplingConstantsRunIIDecW = True,  #for TID and TEC
                      APVShapeDecoFile =cms.FileInPath("SimTracker/SiStripDigitizer/data/APVShapeDeco_320.txt")
                      )
+# when FastSim events as PileUP events during mixing
+from Configuration.ProcessModifiers.fastSimPU_cff import fastSimPU
+fastSimPU.toModify(SiStripSimBlock,
+                   ROUListPU = cms.vstring('TrackerHits'))
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+fastSim.toModify(SiStripSimBlock,
+                   ROUList = cms.vstring('TrackerHits'),
+                   ROUListPU = cms.vstring('TrackerHits'))

--- a/SimGeneral/MixingModule/python/ecalDigitizer_cfi.py
+++ b/SimGeneral/MixingModule/python/ecalDigitizer_cfi.py
@@ -32,7 +32,6 @@ fastSim.toModify(ecalDigitizer,
 
 from Configuration.ProcessModifiers.fastSimPU_cff import fastSimPU
 fastSimPU.toModify(ecalDigitizer,
-                   hitsProducer = cms.string('g4SimHits'),
                  hitsProducerPU = cms.string('fastSimProducer'))
 
 ecalDigitizer.doEB = cms.bool(True)

--- a/SimGeneral/MixingModule/python/ecalDigitizer_cfi.py
+++ b/SimGeneral/MixingModule/python/ecalDigitizer_cfi.py
@@ -20,13 +20,21 @@ ecalDigitizer = cms.PSet(
     ecal_notCont_sim,
     es_electronics_sim,
     hitsProducer = cms.string('g4SimHits'),
+    hitsProducerPU = cms.string('g4SimHits'),    
     accumulatorType = cms.string("EcalDigiProducer"),
     makeDigiSimLinks = cms.untracked.bool(False)
 )
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-fastSim.toModify(ecalDigitizer, hitsProducer = "fastSimProducer")
-    
+fastSim.toModify(ecalDigitizer,
+                 hitsProducer = cms.string('fastSimProducer'),
+               hitsProducerPU = cms.string('fastSimProducer'))
+
+from Configuration.ProcessModifiers.fastSimPU_cff import fastSimPU
+fastSimPU.toModify(ecalDigitizer,
+                   hitsProducer = cms.string('g4SimHits'),
+                 hitsProducerPU = cms.string('fastSimProducer'))
+
 ecalDigitizer.doEB = cms.bool(True)
 ecalDigitizer.doEE = cms.bool(True)
 ecalDigitizer.doES = cms.bool(True)

--- a/SimGeneral/MixingModule/python/mixObjects_cfi.py
+++ b/SimGeneral/MixingModule/python/mixObjects_cfi.py
@@ -70,7 +70,21 @@ fastSim.toModify(mixSimHits,
                'MuonRPCHits', 
                'TrackerHits']
 )
-
+from Configuration.ProcessModifiers.fastSimPU_cff import fastSimPU
+fastSimPU.toModify(mixSimHits,
+    input =  mixSimHits.input +
+                   [ cms.InputTag("MuonSimHits","MuonCSCHits"),
+                     cms.InputTag("MuonSimHits","MuonDTHits"), 
+                     cms.InputTag("MuonSimHits","MuonRPCHits"),
+                     cms.InputTag("MuonSimHits","MuonGEMHits"),                                  
+                     cms.InputTag("fastSimProducer","TrackerHits")],
+   subdets = mixSimHits.subdets +
+                   ['MuonCSCHits', 
+                    'MuonDTHits', 
+                    'MuonRPCHits',
+                    'MuonGEMHits',                                 
+                    'TrackerHits']
+)
 mixCaloHits = cms.PSet(
     input = cms.VInputTag(  # note that this list needs to be in the same order as the subdets
         #cms.InputTag("g4SimHits","CaloHitsTk"), cms.InputTag("g4SimHits","CastorBU"), cms.InputTag("g4SimHits","CastorPL"), cms.InputTag("g4SimHits","CastorTU"), 
@@ -107,6 +121,19 @@ fastSim.toModify(mixCaloHits,
                'EcalHitsES',
                'HcalHits']
 )
+# fastsimPU customs
+fastSimPU.toModify(mixCaloHits,
+    input = mixCaloHits.input +
+                    ["fastSimProducer:EcalHitsEB",
+                     "fastSimProducer:EcalHitsEE",
+                     "fastSimProducer:EcalHitsES",
+                     "fastSimProducer:HcalHits"],
+    subdets = mixCaloHits.subdets +
+                    ['EcalHitsEB',
+                     'EcalHitsEE',
+                     'EcalHitsES',
+                     'HcalHits']
+)
 
 
 mixSimTracks = cms.PSet(
@@ -123,6 +150,8 @@ mixSimVertices = cms.PSet(
 # fastsim customs
 fastSim.toModify(mixSimTracks, input = ["fastSimProducer"])
 fastSim.toModify(mixSimVertices, input = ["fastSimProducer"])
+fastSimPU.toModify(mixSimTracks, input = mixSimTracks.input + ["fastSimProducer"])
+fastSimPU.toModify(mixSimVertices, input = mixSimVertices.input + ["fastSimProducer"])
     
 mixHepMCProducts = cms.PSet(
     makeCrossingFrame = cms.untracked.bool(True),
@@ -155,7 +184,7 @@ theMixObjects = cms.PSet(
 )
 
 # fastsim customs
-fastSim.toModify(theMixObjects, mixRecoTracks = cms.PSet(mixReconstructedTracks))
+(fastSim | fastSimPU).toModify(theMixObjects, mixRecoTracks = cms.PSet(mixReconstructedTracks))
     
 mixPCFSimHits = cms.PSet(
     input = cms.VInputTag(cms.InputTag("CFWriter","g4SimHitsBSCHits"), cms.InputTag("CFWriter","g4SimHitsBCM1FHits"), cms.InputTag("CFWriter","g4SimHitsPLTHits"), cms.InputTag("CFWriter","g4SimHitsFP420SI"), cms.InputTag("CFWriter","g4SimHitsMuonCSCHits"), cms.InputTag("CFWriter","g4SimHitsMuonDTHits"), cms.InputTag("CFWriter","g4SimHitsMuonRPCHits"), 

--- a/SimGeneral/MixingModule/python/mix_probFunction_25ns_PoissonOOTPU_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_probFunction_25ns_PoissonOOTPU_cfi.py
@@ -52,5 +52,5 @@ mix = cms.EDProducer("MixingModule",
     mixObjects = cms.PSet(theMixObjects)
 )
 
-
-
+from Configuration.ProcessModifiers.fastSimPU_cff import fastSimPU
+fastSimPU.toModify(mix, skipProductCheck = cms.bool(True))

--- a/SimGeneral/MixingModule/python/pixelDigitizer_cfi.py
+++ b/SimGeneral/MixingModule/python/pixelDigitizer_cfi.py
@@ -6,6 +6,7 @@ pixelDigitizer = cms.PSet(
     SiPixelSimBlock,
     accumulatorType = cms.string("SiPixelDigitizer"),
     hitsProducer = cms.string('g4SimHits'),
+    hitsProducerPU = cms.string('g4SimHits'),    
     makeDigiSimLinks = cms.untracked.bool(True)
 )
 from Configuration.ProcessModifiers.premix_stage1_cff import premix_stage1
@@ -56,4 +57,12 @@ from Configuration.ProcessModifiers.runDependentForPixelVal_cff import runDepend
          AdcFullScale = 1023,
          MissCalibrate = False
 )
+# when FastSim events as PileUP events during mixing
+from Configuration.ProcessModifiers.fastSimPU_cff import fastSimPU
+fastSimPU.toModify(pixelDigitizer,
+                   hitsProducerPU = cms.string('fastSimProducer'))
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+fastSim.toModify(pixelDigitizer,
+                   hitsProducer = cms.string('fastSimProducer'),
+                   hitsProducerPU = cms.string('fastSimProducer'))
 

--- a/SimGeneral/MixingModule/python/stripDigitizer_cfi.py
+++ b/SimGeneral/MixingModule/python/stripDigitizer_cfi.py
@@ -7,6 +7,7 @@ stripDigitizer = cms.PSet(
     SiStripSimBlock,
     accumulatorType = cms.string("SiStripDigitizer"),
     hitsProducer = cms.string('g4SimHits'),
+    hitsProducerPU = cms.string('g4SimHits'),    
     makeDigiSimLinks = cms.untracked.bool(True)
     )
 
@@ -30,4 +31,12 @@ from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify( stripDigitizer, ROUList = ["g4SimHitsTrackerHitsPixelBarrelLowTof",
                                                          "g4SimHitsTrackerHitsPixelEndcapLowTof"]
 )
+# when FastSim events as PileUP events during mixing
+from Configuration.ProcessModifiers.fastSimPU_cff import fastSimPU
+fastSimPU.toModify(stripDigitizer,
+                   hitsProducerPU = cms.string('fastSimProducer'))
 
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+fastSim.toModify(stripDigitizer,
+                   hitsProducer = cms.string('fastSimProducer'),
+                   hitsProducerPU = cms.string('fastSimProducer'))

--- a/SimGeneral/MixingModule/python/trackingTruthProducer_cfi.py
+++ b/SimGeneral/MixingModule/python/trackingTruthProducer_cfi.py
@@ -21,12 +21,14 @@ trackingParticles = cms.PSet(
 			cms.InputTag('g4SimHits','TrackerHitsTECLowTof'),
 			cms.InputTag('g4SimHits','TrackerHitsTECHighTof') ),
 		pixel = cms.VInputTag(cms.InputTag( 'g4SimHits','TrackerHitsPixelBarrelLowTof'),
-        	cms.InputTag('g4SimHits','TrackerHitsPixelBarrelHighTof'),
-        	cms.InputTag('g4SimHits','TrackerHitsPixelEndcapLowTof'),
-        	cms.InputTag('g4SimHits','TrackerHitsPixelEndcapHighTof') )
+          	        cms.InputTag('g4SimHits','TrackerHitsPixelBarrelHighTof'),
+                      	cms.InputTag('g4SimHits','TrackerHitsPixelEndcapLowTof'),
+        	        cms.InputTag('g4SimHits','TrackerHitsPixelEndcapHighTof') )
 	),
 	simTrackCollection = cms.InputTag('g4SimHits'),
 	simVertexCollection = cms.InputTag('g4SimHits'),
+	simTrackCollectionPU = cms.InputTag('g4SimHits'),
+	simVertexCollectionPU = cms.InputTag('g4SimHits'),
 	genParticleCollection = cms.InputTag('genParticles'),
 	removeDeadModules = cms.bool(False), # currently not implemented
 	volumeRadius = cms.double(120.0),
@@ -48,9 +50,41 @@ fastSim.toModify(trackingParticles,
                               cms.InputTag('MuonSimHits','MuonRPCHits') ),
         trackerAndPixel = cms.VInputTag( cms.InputTag('fastSimProducer','TrackerHits') )
     ),
-    simTrackCollection = 'fastSimProducer',
-    simVertexCollection = 'fastSimProducer'
+     simTrackCollection    = cms.InputTag('fastSimProducer'),
+     simVertexCollection   = cms.InputTag('fastSimProducer'),
+     simTrackCollectionPU  = cms.InputTag('fastSimProducer'),
+     simVertexCollectionPU = cms.InputTag('fastSimProducer')
 )
+
+from Configuration.ProcessModifiers.fastSimPU_cff import fastSimPU
+fastSimPU.toModify(trackingParticles,
+    simHitCollections = cms.PSet(
+		muon = cms.VInputTag(
+                        cms.InputTag('g4SimHits','MuonDTHits'),
+			cms.InputTag('g4SimHits','MuonCSCHits'),
+			cms.InputTag('g4SimHits','MuonRPCHits'),
+                        cms.InputTag('MuonSimHits','MuonDTHits'),
+                        cms.InputTag('MuonSimHits','MuonCSCHits'),
+                        cms.InputTag('MuonSimHits','MuonRPCHits') ),
+		tracker = cms.VInputTag(
+                        cms.InputTag('g4SimHits','TrackerHitsTIBLowTof'),
+			cms.InputTag('g4SimHits','TrackerHitsTIBHighTof'),
+			cms.InputTag('g4SimHits','TrackerHitsTIDLowTof'),
+			cms.InputTag('g4SimHits','TrackerHitsTIDHighTof'),
+			cms.InputTag('g4SimHits','TrackerHitsTOBLowTof'),
+			cms.InputTag('g4SimHits','TrackerHitsTOBHighTof'),
+			cms.InputTag('g4SimHits','TrackerHitsTECLowTof'),
+			cms.InputTag('g4SimHits','TrackerHitsTECHighTof')),
+		pixel = cms.VInputTag(
+                        cms.InputTag('g4SimHits','TrackerHitsPixelBarrelLowTof'),
+           	        cms.InputTag('g4SimHits','TrackerHitsPixelBarrelHighTof'),
+        	        cms.InputTag('g4SimHits','TrackerHitsPixelEndcapLowTof'),
+           	        cms.InputTag('g4SimHits','TrackerHitsPixelEndcapHighTof')),
+        trackerAndPixel = cms.VInputTag( cms.InputTag('fastSimProducer','TrackerHits') ) 
+    ),        
+     simTrackCollectionPU = cms.InputTag('fastSimProducer'),
+     simVertexCollectionPU = cms.InputTag('fastSimProducer')
+)                   
 
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
 run2_GEM_2017.toModify(trackingParticles, simHitCollections = dict(

--- a/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc
+++ b/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc
@@ -348,16 +348,7 @@ TrackingTruthAccumulator::TrackingTruthAccumulator(const edm::ParameterSet &conf
   std::vector<std::string> parameterNames = simHitCollectionConfig.getParameterNames();
 
   for (const auto &parameterName : parameterNames) {
-#ifdef EDM_ML_DEBUG
-    std::cout << " Detector Type " << parameterName.c_str() << std::endl;
-#endif
-
     std::vector<edm::InputTag> tags = simHitCollectionConfig.getParameter<std::vector<edm::InputTag>>(parameterName);
-#ifdef EDM_ML_DEBUG
-    for (const auto &tagName : tags)
-      std::cout << "    " << tagName << std::endl;
-#endif
-
     collectionTags_.insert(collectionTags_.end(), tags.begin(), tags.end());
   }
 
@@ -407,8 +398,8 @@ void TrackingTruthAccumulator::accumulate(edm::Event const &event, edm::EventSet
   simVertexLabel_ = simVertexLabelSig_;
 
 #ifdef EDM_ML_DEBUG
-  std::cout << " TrackingTruthAccumulator::accumulate for Signal "
-            << " SimVertex " << simVertexLabel_ << " SimTrack " << simTrackLabel_ << std::endl;
+  edm::LogVerbatim("TrackingTruthAccumulator") << "accumulate for Signal "
+                                               << " SimVertex " << simVertexLabel_ << " SimTrack " << simTrackLabel_;
 #endif
   accumulateEvent(event, setup, hepmc);
 }
@@ -429,8 +420,8 @@ void TrackingTruthAccumulator::accumulate(PileUpEventPrincipal const &event,
     simVertexLabel_ = simVertexLabelPU_;
 
 #ifdef EDM_ML_DEBUG
-    std::cout << " TrackingTruthAccumulator::accumulate for PU "
-              << " SimVertex " << simVertexLabel_ << " SimTrack " << simTrackLabel_ << std::endl;
+    edm::LogVerbatim("TrackingTruthAccumulator") << "accumulate for PU "
+                                                 << " SimVertex " << simVertexLabel_ << " SimTrack " << simTrackLabel_;
 #endif
 
     accumulateEvent(event, setup, hepmc);
@@ -607,8 +598,8 @@ void TrackingTruthAccumulator::fillSimHits(std::vector<const PSimHit *> &returnV
       continue;
       // TODO - implement removing the dead modules
 #ifdef EDM_ML_DEBUG
-    std::cout << " TrackingTruthAccumulator::fillSimHits " << collectionTag << " SimHit Size " << hSimHits->size()
-              << std::endl;
+    edm::LogVerbatim("TrackingTruthAccumulator")
+        << "fillSimHits " << collectionTag << " SimHit Size " << hSimHits->size();
 #endif
     for (const auto &simHit : *hSimHits) {
       returnValue.push_back(&simHit);
@@ -1063,10 +1054,6 @@ namespace  // Unnamed namespace for things only used in this file
               "parent.");
       }
     }  // end of loop over decay vertices
-
-#ifdef EDM_ML_DEBUG
-    std::cout << "TrackingTruthAccumulator.cc integrityCheck() completed successfully" << std::endl;
-#endif
   }  // end of ::DecayChain::integrityCheck()
 #endif
 

--- a/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.h
+++ b/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.h
@@ -137,8 +137,12 @@ private:
 
   /// As of 11/Feb/2013 this option hasn't been implemented yet.
   const bool removeDeadModules_;
-  const edm::InputTag simTrackLabel_;
-  const edm::InputTag simVertexLabel_;
+  edm::InputTag simTrackLabel_;
+  edm::InputTag simVertexLabel_;
+  edm::InputTag simTrackLabelSig_;
+  edm::InputTag simVertexLabelSig_;
+  edm::InputTag simTrackLabelPU_;
+  edm::InputTag simVertexLabelPU_;
   std::vector<edm::InputTag> collectionTags_;
   edm::InputTag genParticleLabel_;
   /// Needed to add HepMC::GenVertex to SimVertex

--- a/SimMuon/CSCDigitizer/python/muonCSCDigis_cfi.py
+++ b/SimMuon/CSCDigitizer/python/muonCSCDigis_cfi.py
@@ -97,7 +97,6 @@ fastSim.toModify(simMuonCSCDigis,
 
 from Configuration.ProcessModifiers.fastSimPU_cff import fastSimPU
 fastSimPU.toModify(simMuonCSCDigis,
-                   InputCollection   = cms.string('g4SimHitsMuonCSCHits'),
                    InputCollectionPU = cms.string('MuonSimHitsMuonCSCHits'))
 
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2

--- a/SimMuon/CSCDigitizer/python/muonCSCDigis_cfi.py
+++ b/SimMuon/CSCDigitizer/python/muonCSCDigis_cfi.py
@@ -74,6 +74,7 @@ simMuonCSCDigis = cms.EDProducer("CSCDigiProducer",
    
     mixLabel = cms.string("mix"),
     InputCollection = cms.string("g4SimHitsMuonCSCHits"),
+    InputCollectionPU = cms.string('g4SimHitsMuonCSCHits'),                                 
 
     stripConditions = cms.string('Database'),
     GeometryType = cms.string('idealForDigi'),                            
@@ -90,7 +91,14 @@ run2_common.toModify( simMuonCSCDigis.strips, bunchTimingOffsets=[0.0, 37.53, 37
 run2_common.toModify( simMuonCSCDigis.wires, bunchTimingOffsets=[0.0, 22.88, 22.55, 29.28, 30.0, 30.0, 30.5, 31.0, 29.5, 29.1, 29.88] )
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-fastSim.toModify(simMuonCSCDigis, InputCollection = 'MuonSimHitsMuonCSCHits')
+fastSim.toModify(simMuonCSCDigis,
+                 InputCollection   = cms.string('MuonSimHitsMuonCSCHits'),
+                 InputCollectionPU = cms.string('MuonSimHitsMuonCSCHits'))
+
+from Configuration.ProcessModifiers.fastSimPU_cff import fastSimPU
+fastSimPU.toModify(simMuonCSCDigis,
+                   InputCollection   = cms.string('g4SimHitsMuonCSCHits'),
+                   InputCollectionPU = cms.string('MuonSimHitsMuonCSCHits'))
 
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
 premix_stage2.toModify(simMuonCSCDigis, mixLabel = "mixData")

--- a/SimMuon/CSCDigitizer/src/CSCDigiProducer.cc
+++ b/SimMuon/CSCDigitizer/src/CSCDigiProducer.cc
@@ -48,8 +48,9 @@ CSCDigiProducer::CSCDigiProducer(const edm::ParameterSet &ps) : theDigitizer(ps)
   }
 
   const std::string &mix = ps.getParameter<std::string>("mixLabel");
-  for (const auto &cname :
-       {ps.getParameter<std::string>("InputCollection"), ps.getParameter<std::string>("InputCollectionPU")}) {
+  const std::set<std::string> collections_for_XF{ps.getParameter<std::string>("InputCollection"),
+                                                 ps.getParameter<std::string>("InputCollectionPU")};
+  for (const auto &cname : collections_for_XF) {
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("CSCDigiProducer") << "Creating CrossingFrame Consumers for InputTag " << mix << ":" << cname;
 #endif
@@ -73,7 +74,6 @@ void CSCDigiProducer::produce(edm::Event &ev, const edm::EventSetup &eventSetup)
     } else
       edm::LogWarning("CSCDigitizer") << "Input Source not Valid !!";
   }
-
   auto hits = std::make_unique<MixCollection<PSimHit>>(cf_list);
 
   // Create empty output

--- a/SimMuon/CSCDigitizer/src/CSCDigiProducer.cc
+++ b/SimMuon/CSCDigitizer/src/CSCDigiProducer.cc
@@ -47,15 +47,13 @@ CSCDigiProducer::CSCDigiProducer(const edm::ParameterSet &ps) : theDigitizer(ps)
                                              "in the configuration file or remove the modules that require it.";
   }
 
-  const std::string mix_ = ps.getParameter<std::string>("mixLabel");
-  const std::set<std::string> collections_ = {ps.getParameter<std::string>("InputCollection"),
-                                              ps.getParameter<std::string>("InputCollectionPU")};
-  for (auto const &cname : collections_) {
+  const std::string &mix = ps.getParameter<std::string>("mixLabel");
+  for (const auto &cname :
+       {ps.getParameter<std::string>("InputCollection"), ps.getParameter<std::string>("InputCollectionPU")}) {
 #ifdef EDM_ML_DEBUG
-    std::cout << " CSCDigiProducer::Creating CrossingFrame Consumers for InputTag " << mix_ << ":" << cname
-              << std::endl;
+    edm::LogVerbatim("CSCDigiProducer") << "Creating CrossingFrame Consumers for InputTag " << mix << ":" << cname;
 #endif
-    cf_tokens.push_back(consumes<CrossingFrame<PSimHit>>(edm::InputTag(mix_, cname)));
+    cf_tokens.push_back(consumes<CrossingFrame<PSimHit>>(edm::InputTag(mix, cname)));
   }
 }
 
@@ -68,12 +66,12 @@ void CSCDigiProducer::produce(edm::Event &ev, const edm::EventSetup &eventSetup)
   CLHEP::HepRandomEngine *engine = &rng->getEngine(ev.streamID());
 
   std::vector<const CrossingFrame<PSimHit> *> cf_list;
-  for (auto const &token : cf_tokens) {
+  for (const auto &token : cf_tokens) {
     const auto &handle = ev.getHandle(token);
     if (handle.isValid()) {
       cf_list.emplace_back(handle.product());
     } else
-      edm::LogInfo("CSCDigitizer") << " Input Source not Valid !!";
+      edm::LogWarning("CSCDigitizer") << "Input Source not Valid !!";
   }
 
   auto hits = std::make_unique<MixCollection<PSimHit>>(cf_list);

--- a/SimMuon/CSCDigitizer/src/CSCDigiProducer.h
+++ b/SimMuon/CSCDigitizer/src/CSCDigiProducer.h
@@ -28,7 +28,7 @@ private:
   CSCDigitizer theDigitizer;
   CSCStripConditions *theStripConditions;
 
-  edm::EDGetTokenT<CrossingFrame<PSimHit>> cf_token;
+  std::vector<edm::EDGetTokenT<CrossingFrame<PSimHit>>> cf_tokens;
   edm::ESGetToken<CSCGeometry, MuonGeometryRecord> geom_Token;
   edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magfield_Token;
   edm::ESGetToken<ParticleDataTable, edm::DefaultRecord> pdt_Token;

--- a/SimMuon/DTDigitizer/python/muonDTDigis_cfi.py
+++ b/SimMuon/DTDigitizer/python/muonDTDigis_cfi.py
@@ -22,6 +22,7 @@ simMuonDTDigis = cms.EDProducer("DTDigitizer",
     #Name of Collection used for create the XF 
     mixLabel = cms.string('mix'),                                
     InputCollection = cms.string('g4SimHitsMuonDTHits'),
+    InputCollectionPU = cms.string('g4SimHitsMuonDTHits'),                                
     debug = cms.untracked.bool(False),
     # Its parameters
     pset = cms.PSet(
@@ -41,7 +42,14 @@ simMuonDTDigis = cms.EDProducer("DTDigitizer",
 
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-fastSim.toModify(simMuonDTDigis, InputCollection = 'MuonSimHitsMuonDTHits')
+fastSim.toModify(simMuonDTDigis,
+                 InputCollection   = cms.string('MuonSimHitsMuonDTHits'),
+                 InputCollectionPU = cms.string('MuonSimHitsMuonDTHits'))
     
+from Configuration.ProcessModifiers.fastSimPU_cff import fastSimPU
+fastSimPU.toModify(simMuonDTDigis,
+                   InputCollection   = cms.string('g4SimHitsMuonDTHits'),
+                   InputCollectionPU = cms.string('MuonSimHitsMuonDTHits'))
+
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
 premix_stage2.toModify(simMuonDTDigis, mixLabel = "mixData")

--- a/SimMuon/DTDigitizer/python/muonDTDigis_cfi.py
+++ b/SimMuon/DTDigitizer/python/muonDTDigis_cfi.py
@@ -48,7 +48,6 @@ fastSim.toModify(simMuonDTDigis,
     
 from Configuration.ProcessModifiers.fastSimPU_cff import fastSimPU
 fastSimPU.toModify(simMuonDTDigis,
-                   InputCollection   = cms.string('g4SimHitsMuonDTHits'),
                    InputCollectionPU = cms.string('MuonSimHitsMuonDTHits'))
 
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2

--- a/SimMuon/DTDigitizer/src/DTDigitizer.cc
+++ b/SimMuon/DTDigitizer/src/DTDigitizer.cc
@@ -115,14 +115,13 @@ DTDigitizer::DTDigitizer(const ParameterSet &conf_)
   LinksTimeWindow = conf_.getParameter<double>("LinksTimeWindow");  // (10 ns)
 
   // Name of Collection used for create the XF
-  const std::string mix_ = conf_.getParameter<std::string>("mixLabel");
-  const std::set<std::string> collections_for_XF = {conf_.getParameter<std::string>("InputCollection"),
-                                                    conf_.getParameter<std::string>("InputCollectionPU")};
-  for (auto const &cname : collections_for_XF) {
+  const std::string &mix = conf_.getParameter<std::string>("mixLabel");
+  for (const auto &cname :
+       {conf_.getParameter<std::string>("InputCollection"), conf_.getParameter<std::string>("InputCollectionPU")}) {
 #ifdef EDM_ML_DEBUG
-    std::cout << " DTDigiProducer::Creating CrossingFrame Consumers for InputTag " << mix_ << ":" << cname << std::endl;
+    edm::LogVerbatim("DTDigiProducer") << "Creating CrossingFrame Consumers for InputTag " << mix << ":" << cname;
 #endif
-    cf_tokens.push_back(consumes<CrossingFrame<PSimHit>>(edm::InputTag(mix_, cname)));
+    cf_tokens.push_back(consumes<CrossingFrame<PSimHit>>(edm::InputTag(mix, cname)));
   }
 
   magnField_token = esConsumes<MagneticField, IdealMagneticFieldRecord>();
@@ -148,13 +147,13 @@ void DTDigitizer::produce(Event &iEvent, const EventSetup &iSetup) {
 
   // use MixCollection instead of the previous
   std::vector<const CrossingFrame<PSimHit> *> cf_list;
-  for (auto const &token : cf_tokens) {
+  for (const auto &token : cf_tokens) {
     const auto &handle = iEvent.getHandle(token);
     if (handle.isValid()) {
       cf_list.emplace_back(handle.product());
 
     } else
-      edm::LogInfo("DTDigitizer") << " Input Source not Valid !!";
+      edm::LogWarning("DTDigitizer") << "Input Source not Valid !!";
   }
   auto simHits = std::make_unique<MixCollection<PSimHit>>(cf_list);
 

--- a/SimMuon/DTDigitizer/src/DTDigitizer.cc
+++ b/SimMuon/DTDigitizer/src/DTDigitizer.cc
@@ -116,8 +116,9 @@ DTDigitizer::DTDigitizer(const ParameterSet &conf_)
 
   // Name of Collection used for create the XF
   const std::string &mix = conf_.getParameter<std::string>("mixLabel");
-  for (const auto &cname :
-       {conf_.getParameter<std::string>("InputCollection"), conf_.getParameter<std::string>("InputCollectionPU")}) {
+  const std::set<std::string> collections_for_XF{conf_.getParameter<std::string>("InputCollection"),
+                                                 conf_.getParameter<std::string>("InputCollectionPU")};
+  for (const auto &cname : collections_for_XF) {
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("DTDigiProducer") << "Creating CrossingFrame Consumers for InputTag " << mix << ":" << cname;
 #endif

--- a/SimMuon/DTDigitizer/src/DTDigitizer.cc
+++ b/SimMuon/DTDigitizer/src/DTDigitizer.cc
@@ -115,9 +115,16 @@ DTDigitizer::DTDigitizer(const ParameterSet &conf_)
   LinksTimeWindow = conf_.getParameter<double>("LinksTimeWindow");  // (10 ns)
 
   // Name of Collection used for create the XF
-  mix_ = conf_.getParameter<std::string>("mixLabel");
-  collection_for_XF = conf_.getParameter<std::string>("InputCollection");
-  cf_token = consumes<CrossingFrame<PSimHit>>(edm::InputTag(mix_, collection_for_XF));
+  const std::string mix_ = conf_.getParameter<std::string>("mixLabel");
+  const std::set<std::string> collections_for_XF = {conf_.getParameter<std::string>("InputCollection"),
+                                                    conf_.getParameter<std::string>("InputCollectionPU")};
+  for (auto const &cname : collections_for_XF) {
+#ifdef EDM_ML_DEBUG
+    std::cout << " DTDigiProducer::Creating CrossingFrame Consumers for InputTag " << mix_ << ":" << cname << std::endl;
+#endif
+    cf_tokens.push_back(consumes<CrossingFrame<PSimHit>>(edm::InputTag(mix_, cname)));
+  }
+
   magnField_token = esConsumes<MagneticField, IdealMagneticFieldRecord>();
 
   // String to choose between ideal (the default) and (mis)aligned geometry
@@ -140,15 +147,21 @@ void DTDigitizer::produce(Event &iEvent, const EventSetup &iSetup) {
   //  iEvent.getByLabel("g4SimHits","MuonDTHits",simHits);
 
   // use MixCollection instead of the previous
-  Handle<CrossingFrame<PSimHit>> xFrame;
-  iEvent.getByToken(cf_token, xFrame);
+  std::vector<const CrossingFrame<PSimHit> *> cf_list;
+  for (auto const &token : cf_tokens) {
+    const auto &handle = iEvent.getHandle(token);
+    if (handle.isValid()) {
+      cf_list.emplace_back(handle.product());
 
-  unique_ptr<MixCollection<PSimHit>> simHits(new MixCollection<PSimHit>(xFrame.product()));
+    } else
+      edm::LogInfo("DTDigitizer") << " Input Source not Valid !!";
+  }
+  auto simHits = std::make_unique<MixCollection<PSimHit>>(cf_list);
 
   // create the pointer to the Digi container
-  unique_ptr<DTDigiCollection> output(new DTDigiCollection());
+  auto output = std::make_unique<DTDigiCollection>();
   // pointer to the DigiSimLink container
-  unique_ptr<DTDigiSimLinkCollection> outputLinks(new DTDigiSimLinkCollection());
+  auto outputLinks = std::make_unique<DTDigiSimLinkCollection>();
 
   // Muon Geometry
   ESHandle<DTGeometry> muonGeom = iSetup.getHandle(muonGeom_token);

--- a/SimMuon/DTDigitizer/src/DTDigitizer.h
+++ b/SimMuon/DTDigitizer/src/DTDigitizer.h
@@ -129,11 +129,7 @@ private:
   bool MultipleLinks;
   float LinksTimeWindow;
 
-  // Name of Collection use for create the XF
-  std::string mix_;
-  std::string collection_for_XF;
-
-  edm::EDGetTokenT<CrossingFrame<PSimHit>> cf_token;
+  std::vector<edm::EDGetTokenT<CrossingFrame<PSimHit>>> cf_tokens;
   edm::ESGetToken<DTGeometry, MuonGeometryRecord> muonGeom_token;
   edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magnField_token;
 };

--- a/SimMuon/GEMDigitizer/plugins/GEMDigiProducer.cc
+++ b/SimMuon/GEMDigitizer/plugins/GEMDigiProducer.cc
@@ -69,15 +69,13 @@ GEMDigiProducer::GEMDigiProducer(const edm::ParameterSet& ps) : gemDigiModule_(s
         << "Add the service in the configuration file or remove the modules that require it.";
   }
 
-  const std::string mix_ = ps.getParameter<std::string>("mixLabel");
-  const std::set<std::string> collectionNames = {ps.getParameter<std::string>("inputCollection"),
-                                                 ps.getParameter<std::string>("inputCollectionPU")};
-  for (auto const& cname : collectionNames) {
+  const std::string& mix = ps.getParameter<std::string>("mixLabel");
+  for (const auto& cname :
+       {ps.getParameter<std::string>("inputCollection"), ps.getParameter<std::string>("inputCollectionPU")}) {
 #ifdef EDM_ML_DEBUG
-    std::cout << " GEMDigiProducer::Creating CrossingFrame Consumers for InputTag " << mix_ << ":" << cname
-              << std::endl;
+    edm::LogVerbatim("GEMDigiProducer") << "Creating CrossingFrame Consumers for InputTag " << mix << ":" << cname;
 #endif
-    cf_tokens_.push_back(consumes<CrossingFrame<PSimHit>>(edm::InputTag(mix_, cname)));
+    cf_tokens_.push_back(consumes<CrossingFrame<PSimHit>>(edm::InputTag(mix, cname)));
   }
   geom_token_ = esConsumes<GEMGeometry, MuonGeometryRecord, edm::Transition::BeginRun>();
 }
@@ -121,7 +119,9 @@ void GEMDigiProducer::fillDescriptions(edm::ConfigurationDescriptions& descripti
   // referecne inst. luminosity 5E+34 cm^-2s^-1
   desc.add<double>("resolutionX", 0.03);
 
-  // The follwing parameters are needed to model the background contribution The parameters have been obtained after the fit of th perdicted by FLUKA By default the backgroundmodeling with these parameters should be disabled
+  // The follwing parameters are needed to model the background contribution
+  // The parameters have been obtained after the fit of th perdicted by FLUKA
+  // By default the backgroundmodeling with these parameters should be disabled
   // with the 9_2_X release setting simulateBkgNoise = false
   desc.add<double>("GE11ModNeuBkgParam0", 5710.23);
   desc.add<double>("GE11ModNeuBkgParam1", -43.3928);

--- a/SimMuon/GEMDigitizer/plugins/GEMDigiProducer.cc
+++ b/SimMuon/GEMDigitizer/plugins/GEMDigiProducer.cc
@@ -70,8 +70,9 @@ GEMDigiProducer::GEMDigiProducer(const edm::ParameterSet& ps) : gemDigiModule_(s
   }
 
   const std::string& mix = ps.getParameter<std::string>("mixLabel");
-  for (const auto& cname :
-       {ps.getParameter<std::string>("inputCollection"), ps.getParameter<std::string>("inputCollectionPU")}) {
+  const std::set<std::string> collections_for_XF{ps.getParameter<std::string>("inputCollection"),
+                                                 ps.getParameter<std::string>("inputCollectionPU")};
+  for (const auto& cname : collections_for_XF) {
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("GEMDigiProducer") << "Creating CrossingFrame Consumers for InputTag " << mix << ":" << cname;
 #endif

--- a/SimMuon/GEMDigitizer/python/muonGEMDigis_cfi.py
+++ b/SimMuon/GEMDigitizer/python/muonGEMDigis_cfi.py
@@ -14,3 +14,8 @@ run3_common.toModify( simMuonGEMDigis, instLumi = 2.0)
 
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 phase2_common.toModify( simMuonGEMDigis, instLumi = 5)
+
+from Configuration.ProcessModifiers.fastSimPU_cff import fastSimPU
+fastSimPU.toModify(simMuonGEMDigis,
+                   inputCollection   = cms.string('g4SimHitsMuonGEMHits'),
+                   inputCollectionPU = cms.string('MuonSimHitsMuonGEMHits'))

--- a/SimMuon/GEMDigitizer/python/muonGEMDigis_cfi.py
+++ b/SimMuon/GEMDigitizer/python/muonGEMDigis_cfi.py
@@ -17,5 +17,4 @@ phase2_common.toModify( simMuonGEMDigis, instLumi = 5)
 
 from Configuration.ProcessModifiers.fastSimPU_cff import fastSimPU
 fastSimPU.toModify(simMuonGEMDigis,
-                   inputCollection   = cms.string('g4SimHitsMuonGEMHits'),
                    inputCollectionPU = cms.string('MuonSimHitsMuonGEMHits'))

--- a/SimMuon/RPCDigitizer/python/muonRPCDigis_cfi.py
+++ b/SimMuon/RPCDigitizer/python/muonRPCDigis_cfi.py
@@ -29,12 +29,20 @@ simMuonRPCDigis = cms.EDProducer("RPCDigiProducer",
     Signal = cms.bool(True),
     mixLabel = cms.string('mix'),                                 
     InputCollection = cms.string('g4SimHitsMuonRPCHits'),
+    InputCollectionPU = cms.string('g4SimHitsMuonRPCHits'),                                 
     digiModel = cms.string('RPCSimAsymmetricCls')
 )
 
 #the digitizer for PhaseII muon upgrade is RPCSimModelTiming and for the moment is based on  RPCSimAverageNoiseEffCls
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-fastSim.toModify(simMuonRPCDigis, InputCollection = 'MuonSimHitsMuonRPCHits')
+fastSim.toModify(simMuonRPCDigis,
+                 InputCollection = cms.string('MuonSimHitsMuonRPCHits'),
+                 InputCollectionPU = cms.string('MuonSimHitsMuonRPCHits'))                 
+
+from Configuration.ProcessModifiers.fastSimPU_cff import fastSimPU
+fastSimPU.toModify(simMuonRPCDigis,
+                 InputCollection = cms.string('g4SimHitsMuonRPCHits'),
+                 InputCollectionPU = cms.string('MuonSimHitsMuonRPCHits'))
 
 _simMuonRPCDigisPhaseII = cms.EDProducer("RPCandIRPCDigiProducer",
     Noise = cms.bool(True),

--- a/SimMuon/RPCDigitizer/python/muonRPCDigis_cfi.py
+++ b/SimMuon/RPCDigitizer/python/muonRPCDigis_cfi.py
@@ -41,7 +41,6 @@ fastSim.toModify(simMuonRPCDigis,
 
 from Configuration.ProcessModifiers.fastSimPU_cff import fastSimPU
 fastSimPU.toModify(simMuonRPCDigis,
-                 InputCollection = cms.string('g4SimHitsMuonRPCHits'),
                  InputCollectionPU = cms.string('MuonSimHitsMuonRPCHits'))
 
 _simMuonRPCDigisPhaseII = cms.EDProducer("RPCandIRPCDigiProducer",

--- a/SimMuon/RPCDigitizer/src/RPCDigiProducer.cc
+++ b/SimMuon/RPCDigitizer/src/RPCDigiProducer.cc
@@ -37,15 +37,13 @@ RPCDigiProducer::RPCDigiProducer(const edm::ParameterSet& ps) {
   produces<RPCDigitizerSimLinks>("RPCDigiSimLink");
 
   //Name of Collection used for create the XF
-  const std::string mix_ = ps.getParameter<std::string>("mixLabel");
-  const std::set<std::string> collections_for_XF = {ps.getParameter<std::string>("InputCollection"),
-                                                    ps.getParameter<std::string>("InputCollectionPU")};
-  for (auto const& cname : collections_for_XF) {
+  const std::string& mix = ps.getParameter<std::string>("mixLabel");
+  for (const auto& cname :
+       {ps.getParameter<std::string>("InputCollection"), ps.getParameter<std::string>("InputCollectionPU")}) {
 #ifdef EDM_ML_DEBUG
-    std::cout << " RPCDigiProducer::CreatingCrossing Frame Consumers for InputTag " << mix_ << ":" << cname
-              << std::endl;
+    edm::LogVerbatim("RPCDigiProducer") << "Creating CrossingFrame Consumers for InputTag " << mix << ":" << cname;
 #endif
-    crossingFrameTokens.push_back(consumes<CrossingFrame<PSimHit>>(edm::InputTag(mix_, cname)));
+    crossingFrameTokens.push_back(consumes<CrossingFrame<PSimHit>>(edm::InputTag(mix, cname)));
   }
 
   edm::Service<edm::RandomNumberGenerator> rng;
@@ -96,11 +94,9 @@ void RPCDigiProducer::produce(edm::Event& e, const edm::EventSetup& eventSetup) 
       << "[RPCDigiProducer::produce] to activate the test go in RPCDigiProducer.cc and uncomment the line below";
   // LogDebug ("RPCDigiProducer")<<"[RPCDigiProducer::produce] Fired RandFlat :: "<<CLHEP::RandFlat::shoot(engine);
 
-  // Obsolate code, based on getByLabel
-  //  e.getByLabel(mix_, collection_for_XF, cf);
   //New code, based on tokens
   std::vector<const CrossingFrame<PSimHit>*> cf_list;
-  for (auto const& token : crossingFrameTokens) {
+  for (const auto& token : crossingFrameTokens) {
     const auto& handle = e.getHandle(token);
     if (handle.isValid()) {
       cf_list.emplace_back(handle.product());

--- a/SimMuon/RPCDigitizer/src/RPCDigiProducer.cc
+++ b/SimMuon/RPCDigitizer/src/RPCDigiProducer.cc
@@ -38,8 +38,9 @@ RPCDigiProducer::RPCDigiProducer(const edm::ParameterSet& ps) {
 
   //Name of Collection used for create the XF
   const std::string& mix = ps.getParameter<std::string>("mixLabel");
-  for (const auto& cname :
-       {ps.getParameter<std::string>("InputCollection"), ps.getParameter<std::string>("InputCollectionPU")}) {
+  const std::set<std::string> collections_for_XF{ps.getParameter<std::string>("InputCollection"),
+                                                 ps.getParameter<std::string>("InputCollectionPU")};
+  for (const auto& cname : collections_for_XF) {
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("RPCDigiProducer") << "Creating CrossingFrame Consumers for InputTag " << mix << ":" << cname;
 #endif

--- a/SimMuon/RPCDigitizer/src/RPCDigiProducer.h
+++ b/SimMuon/RPCDigitizer/src/RPCDigiProducer.h
@@ -38,12 +38,8 @@ private:
   RPCDigitizer* theDigitizer;
   RPCSimSetUp* theRPCSimSetUp;
 
-  //Name of Collection used for create the XF
-  std::string mix_;
-  std::string collection_for_XF;
-
   //Token for accessing data
-  edm::EDGetTokenT<CrossingFrame<PSimHit>> crossingFrameToken;
+  std::vector<edm::EDGetTokenT<CrossingFrame<PSimHit>>> crossingFrameTokens;
 
   //EventSetup Tokens
   edm::ESGetToken<RPCGeometry, MuonGeometryRecord> geomToken;

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
@@ -120,9 +120,8 @@ namespace cms {
       producesCollector.produces<edm::DetSetVector<PixelSimHitExtraInfoLite>>().setBranchAlias(
           alias + "siPixelExtraSimHitLite");
 
-    std::map<std::string, std::vector<std::string>> pmap = {{hitsProducer, trackerContainers},
-                                                            {hitsProducerPU, trackerContainersPU}};
-
+    const std::map<std::string, std::vector<std::string>> pmap = {{hitsProducer, trackerContainers},
+                                                                  {hitsProducerPU, trackerContainersPU}};
     for (auto const& ip : pmap) {
       for (auto const& ic : ip.second) {
         iC.consumes<std::vector<PSimHit>>(edm::InputTag(ip.first, ic));
@@ -230,8 +229,8 @@ namespace cms {
       if (!simHits.isValid())
         continue;
 #ifdef EDM_ML_DEBUG
-      std::cout << " SiPixelDigitizer::accumulate "
-                << " Accumulating SimHits for Signals with InputTag " << tag << std::endl;
+      edm::LogVerbatim("SiPixelDigitizer") << "accumulate "
+                                           << " Accumulating SimHits for Signals with InputTag " << tag;
 #endif
       unsigned int tofBin = PixelDigiSimLink::LowTof;
       if ((*i).find(std::string("HighTof")) != std::string::npos)
@@ -241,7 +240,6 @@ namespace cms {
       // the global counter. Next time accumulateStripHits() is called it will count the sim hits
       // as though they were on the end of this collection.
       // Note that this is only used for creating digi-sim links (if configured to do so).
-      //       std::cout << "index offset, current hit count = " << crossingSimHitIndexOffset_[tag.encode()] << ", " << simHits->size() << std::endl;
       if (simHits.isValid())
         crossingSimHitIndexOffset_[tag.encode()] += simHits->size();
     }
@@ -260,8 +258,9 @@ namespace cms {
       if (!simHits.isValid())
         continue;
 #ifdef EDM_ML_DEBUG
-      std::cout << " SiPixelDigitizer::accumulate "
-                << " Accumulating SimHits for PUs with InputTag " << tag << std::endl;
+    edm:;
+      LogVerbatim("SiPixelDigitizer") << "accumulate "
+                                      << " Accumulating SimHits for PUs with InputTag " << tag;
 #endif
 
       unsigned int tofBin = PixelDigiSimLink::LowTof;
@@ -272,7 +271,6 @@ namespace cms {
       // the global counter. Next time accumulateStripHits() is called it will count the sim hits
       // as though they were on the end of this collection.
       // Note that this is only used for creating digi-sim links (if configured to do so).
-      //       std::cout << "index offset, current hit count = " << crossingSimHitIndexOffset_[tag.encode()] << ", " << simHits->size() << std::endl;
       if (simHits.isValid())
         crossingSimHitIndexOffset_[tag.encode()] += simHits->size();
     }
@@ -424,9 +422,7 @@ namespace cms {
         std::make_unique<edm::DetSetVector<PixelSimHitExtraInfo>>(theExtraSimHitInfoVector);
     std::unique_ptr<edm::DetSetVector<PixelSimHitExtraInfoLite>> outputExtraSimLite =
         std::make_unique<edm::DetSetVector<PixelSimHitExtraInfoLite>>(theExtraSimHitInfoLiteVector);
-#ifdef EDM_ML_DEBUG
-    std::cout << " SiPixelDigitizer::finalize  Size of Digis " << totalDigis << std::endl;
-#endif
+
     // Step D: write output to file
     iEvent.put(std::move(output));
     iEvent.put(std::move(outputlink));

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
@@ -166,17 +166,6 @@ namespace cms {
         assert(pixdet != nullptr);
         if (pixdet && pixdet->type().isTrackerPixel()) {
           if (detIds.insert(detId).second) {
-            // The insert succeeded, so this detector element has not yet been processed.
-            //          assert(detectorUnits[detId]);
-            //          if (detectorUnits[detId] &&
-            //              detectorUnits[detId]
-            //                  ->type()
-            //                  .isTrackerPixel()) {  // this test could be avoided and changed into a check of pixdet!=0
-            //            std::map<unsigned int, PixelGeomDetUnit const*>::iterator itDet = detectorUnits.find(detId);
-            //            if (itDet == detectorUnits.end())
-            //              continue;
-            //            auto pixdet = itDet->second;
-            //            assert(pixdet != nullptr);
             //access to magnetic field in global coordinates
             GlobalVector bfield = pSetup->inTesla(pixdet->surface().position());
             LogDebug("PixelDigitizer ") << "B-field(T) at " << pixdet->surface().position()

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
@@ -97,7 +97,9 @@ namespace cms {
                                              : false),
         _pixeldigialgo(),
         hitsProducer(iConfig.getParameter<std::string>("hitsProducer")),
-        trackerContainers(iConfig.getParameter<std::vector<std::string> >("RoutList")),
+        hitsProducerPU(iConfig.getParameter<std::string>("hitsProducerPU")),
+        trackerContainers(iConfig.getParameter<std::vector<std::string>>("RoutList")),
+        trackerContainersPU(iConfig.getParameter<std::vector<std::string>>("RoutListPU")),
         pilotBlades(iConfig.exists("enablePilotBlades") ? iConfig.getParameter<bool>("enablePilotBlades") : false),
         NumberOfEndcapDisks(iConfig.exists("NumPixelEndcap") ? iConfig.getParameter<int>("NumPixelEndcap") : 2),
         tTopoToken_(iC.esConsumes()),
@@ -109,18 +111,22 @@ namespace cms {
 
     const std::string alias("simSiPixelDigis");
 
-    producesCollector.produces<edm::DetSetVector<PixelDigi> >().setBranchAlias(alias);
-    producesCollector.produces<edm::DetSetVector<PixelDigiSimLink> >().setBranchAlias(alias + "siPixelDigiSimLink");
+    producesCollector.produces<edm::DetSetVector<PixelDigi>>().setBranchAlias(alias);
+    producesCollector.produces<edm::DetSetVector<PixelDigiSimLink>>().setBranchAlias(alias + "siPixelDigiSimLink");
     if (store_SimHitEntryExitPoints_)
-      producesCollector.produces<edm::DetSetVector<PixelSimHitExtraInfo> >().setBranchAlias(alias +
-                                                                                            "siPixelExtraSimHit");
+      producesCollector.produces<edm::DetSetVector<PixelSimHitExtraInfo>>().setBranchAlias(alias +
+                                                                                           "siPixelExtraSimHit");
     if (store_SimHitEntryExitPointsLite_)
-      producesCollector.produces<edm::DetSetVector<PixelSimHitExtraInfoLite> >().setBranchAlias(
+      producesCollector.produces<edm::DetSetVector<PixelSimHitExtraInfoLite>>().setBranchAlias(
           alias + "siPixelExtraSimHitLite");
 
-    for (auto const& trackerContainer : trackerContainers) {
-      edm::InputTag tag(hitsProducer, trackerContainer);
-      iC.consumes<std::vector<PSimHit> >(edm::InputTag(hitsProducer, trackerContainer));
+    std::map<std::string, std::vector<std::string>> pmap = {{hitsProducer, trackerContainers},
+                                                            {hitsProducerPU, trackerContainersPU}};
+
+    for (auto const& ip : pmap) {
+      for (auto const& ic : ip.second) {
+        iC.consumes<std::vector<PSimHit>>(edm::InputTag(ip.first, ic));
+      }
     }
     edm::Service<edm::RandomNumberGenerator> rng;
     if (!rng.isAvailable()) {
@@ -141,7 +147,7 @@ namespace cms {
   // member functions
   //
 
-  void SiPixelDigitizer::accumulatePixelHits(edm::Handle<std::vector<PSimHit> > hSimHits,
+  void SiPixelDigitizer::accumulatePixelHits(edm::Handle<std::vector<PSimHit>> hSimHits,
                                              size_t globalSimHitIndex,
                                              const unsigned int tofBin,
                                              edm::EventSetup const& iSetup) {
@@ -153,18 +159,24 @@ namespace cms {
       for (std::vector<PSimHit>::const_iterator it = simHits.begin(), itEnd = simHits.end(); it != itEnd;
            ++it, ++globalSimHitIndex) {
         unsigned int detId = (*it).detUnitId();
-        if (detIds.insert(detId).second) {
-          // The insert succeeded, so this detector element has not yet been processed.
-          assert(detectorUnits[detId]);
-          if (detectorUnits[detId] &&
-              detectorUnits[detId]
-                  ->type()
-                  .isTrackerPixel()) {  // this test could be avoided and changed into a check of pixdet!=0
-            std::map<unsigned int, PixelGeomDetUnit const*>::iterator itDet = detectorUnits.find(detId);
-            if (itDet == detectorUnits.end())
-              continue;
-            auto pixdet = itDet->second;
-            assert(pixdet != nullptr);
+        auto itDet = detectorUnits.find(detId);
+        if (itDet == detectorUnits.end())
+          continue;
+        auto pixdet = itDet->second;
+        assert(pixdet != nullptr);
+        if (pixdet && pixdet->type().isTrackerPixel()) {
+          if (detIds.insert(detId).second) {
+            // The insert succeeded, so this detector element has not yet been processed.
+            //          assert(detectorUnits[detId]);
+            //          if (detectorUnits[detId] &&
+            //              detectorUnits[detId]
+            //                  ->type()
+            //                  .isTrackerPixel()) {  // this test could be avoided and changed into a check of pixdet!=0
+            //            std::map<unsigned int, PixelGeomDetUnit const*>::iterator itDet = detectorUnits.find(detId);
+            //            if (itDet == detectorUnits.end())
+            //              continue;
+            //            auto pixdet = itDet->second;
+            //            assert(pixdet != nullptr);
             //access to magnetic field in global coordinates
             GlobalVector bfield = pSetup->inTesla(pixdet->surface().position());
             LogDebug("PixelDigitizer ") << "B-field(T) at " << pixdet->surface().position()
@@ -222,10 +234,16 @@ namespace cms {
   void SiPixelDigitizer::accumulate(edm::Event const& iEvent, edm::EventSetup const& iSetup) {
     // Step A: Get Inputs
     for (vstring::const_iterator i = trackerContainers.begin(), iEnd = trackerContainers.end(); i != iEnd; ++i) {
-      edm::Handle<std::vector<PSimHit> > simHits;
+      edm::Handle<std::vector<PSimHit>> simHits;
       edm::InputTag tag(hitsProducer, *i);
 
       iEvent.getByLabel(tag, simHits);
+      if (!simHits.isValid())
+        continue;
+#ifdef EDM_ML_DEBUG
+      std::cout << " SiPixelDigitizer::accumulate "
+                << " Accumulating SimHits for Signals with InputTag " << tag << std::endl;
+#endif
       unsigned int tofBin = PixelDigiSimLink::LowTof;
       if ((*i).find(std::string("HighTof")) != std::string::npos)
         tofBin = PixelDigiSimLink::HighTof;
@@ -244,11 +262,19 @@ namespace cms {
                                     edm::EventSetup const& iSetup,
                                     edm::StreamID const& streamID) {
     // Step A: Get Inputs
-    for (vstring::const_iterator i = trackerContainers.begin(), iEnd = trackerContainers.end(); i != iEnd; ++i) {
-      edm::Handle<std::vector<PSimHit> > simHits;
-      edm::InputTag tag(hitsProducer, *i);
+    for (vstring::const_iterator i = trackerContainersPU.begin(), iEnd = trackerContainersPU.end(); i != iEnd; ++i) {
+      edm::Handle<std::vector<PSimHit>> simHits;
+      edm::InputTag tag(hitsProducerPU, *i);
 
       iEvent.getByLabel(tag, simHits);
+
+      if (!simHits.isValid())
+        continue;
+#ifdef EDM_ML_DEBUG
+      std::cout << " SiPixelDigitizer::accumulate "
+                << " Accumulating SimHits for PUs with InputTag " << tag << std::endl;
+#endif
+
       unsigned int tofBin = PixelDigiSimLink::LowTof;
       if ((*i).find(std::string("HighTof")) != std::string::npos)
         tofBin = PixelDigiSimLink::HighTof;
@@ -267,10 +293,10 @@ namespace cms {
   void SiPixelDigitizer::finalizeEvent(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     const TrackerTopology* tTopo = &iSetup.getData(tTopoToken_);
 
-    std::vector<edm::DetSet<PixelDigi> > theDigiVector;
-    std::vector<edm::DetSet<PixelDigiSimLink> > theDigiLinkVector;
-    std::vector<edm::DetSet<PixelSimHitExtraInfo> > theExtraSimHitInfoVector;
-    std::vector<edm::DetSet<PixelSimHitExtraInfoLite> > theExtraSimHitInfoLiteVector;
+    std::vector<edm::DetSet<PixelDigi>> theDigiVector;
+    std::vector<edm::DetSet<PixelDigiSimLink>> theDigiLinkVector;
+    std::vector<edm::DetSet<PixelSimHitExtraInfo>> theExtraSimHitInfoVector;
+    std::vector<edm::DetSet<PixelSimHitExtraInfoLite>> theExtraSimHitInfoLiteVector;
 
     if (firstFinalizeEvent_) {
       _pixeldigialgo->init_DynIneffDB(iSetup);
@@ -286,7 +312,7 @@ namespace cms {
       }
       iEvent.put(std::move(PixelFEDChannelCollection_));
     }
-
+    int totalDigis = 0;
     for (const auto& iu : pDD->detUnits()) {
       if (iu->type().isTrackerPixel()) {
         //
@@ -384,6 +410,7 @@ namespace cms {
         }
 
         if (!collector.data.empty()) {
+          totalDigis += collector.data.size();
           theDigiVector.push_back(std::move(collector));
         }
         if (!linkcollector.data.empty()) {
@@ -400,14 +427,17 @@ namespace cms {
     _pixeldigialgo->resetSimHitMaps();
 
     // Step C: create collection with the cache vector of DetSet
-    std::unique_ptr<edm::DetSetVector<PixelDigi> > output(new edm::DetSetVector<PixelDigi>(theDigiVector));
-    std::unique_ptr<edm::DetSetVector<PixelDigiSimLink> > outputlink(
-        new edm::DetSetVector<PixelDigiSimLink>(theDigiLinkVector));
-    std::unique_ptr<edm::DetSetVector<PixelSimHitExtraInfo> > outputExtraSim(
-        new edm::DetSetVector<PixelSimHitExtraInfo>(theExtraSimHitInfoVector));
-    std::unique_ptr<edm::DetSetVector<PixelSimHitExtraInfoLite> > outputExtraSimLite(
-        new edm::DetSetVector<PixelSimHitExtraInfoLite>(theExtraSimHitInfoLiteVector));
-
+    std::unique_ptr<edm::DetSetVector<PixelDigi>> output =
+        std::make_unique<edm::DetSetVector<PixelDigi>>(theDigiVector);
+    std::unique_ptr<edm::DetSetVector<PixelDigiSimLink>> outputlink =
+        std::make_unique<edm::DetSetVector<PixelDigiSimLink>>(theDigiLinkVector);
+    std::unique_ptr<edm::DetSetVector<PixelSimHitExtraInfo>> outputExtraSim =
+        std::make_unique<edm::DetSetVector<PixelSimHitExtraInfo>>(theExtraSimHitInfoVector);
+    std::unique_ptr<edm::DetSetVector<PixelSimHitExtraInfoLite>> outputExtraSimLite =
+        std::make_unique<edm::DetSetVector<PixelSimHitExtraInfoLite>>(theExtraSimHitInfoLiteVector);
+#ifdef EDM_ML_DEBUG
+    std::cout << " SiPixelDigitizer::finalize  Size of Digis " << totalDigis << std::endl;
+#endif
     // Step D: write output to file
     iEvent.put(std::move(output));
     iEvent.put(std::move(outputlink));

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.h
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.h
@@ -89,9 +89,11 @@ namespace cms {
 * The key is the name of the sim hit collection. */
     std::map<std::string, size_t> crossingSimHitIndexOffset_;
 
-    typedef std::vector<std::string> vstring;
+    using vstring = std::vector<std::string>;
     const std::string hitsProducer;
+    const std::string hitsProducerPU;
     const vstring trackerContainers;
+    const vstring trackerContainersPU;
     const TrackerGeometry* pDD = nullptr;
     const MagneticField* pSetup = nullptr;
     std::map<unsigned int, PixelGeomDetUnit const*> detectorUnits;

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.cc
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.cc
@@ -98,8 +98,8 @@ SiStripDigitizer::SiStripDigitizer(const edm::ParameterSet& conf,
   producesCollector.produces<std::vector<std::pair<int, std::bitset<6>>>>("AffectedAPVList")
       .setBranchAlias(alias + "AffectedAPV");
 
-  std::map<std::string, std::vector<std::string>> pmap = {{hitsProducer, trackerContainers},
-                                                          {hitsProducerPU, trackerContainersPU}};
+  const std::map<std::string, std::vector<std::string>> pmap = {{hitsProducer, trackerContainers},
+                                                                {hitsProducerPU, trackerContainersPU}};
   for (auto const& ip : pmap) {
     for (auto const& ic : ip.second) {
       iC.consumes<std::vector<PSimHit>>(edm::InputTag(ip.first, ic));
@@ -169,8 +169,8 @@ void SiStripDigitizer::accumulate(edm::Event const& iEvent, edm::EventSetup cons
     if (!simHits.isValid())
       continue;
 #ifdef EDM_ML_DEBUG
-    std::cout << " SiStripDigitizer::accumulate "
-              << " Accumulating SimHits for Signals with InputTag " << tag << std::endl;
+    edm::LogVerbatim("SiStripDigitizer") << "accumulate "
+                                         << " Accumulating SimHits for Signals with InputTag " << tag;
 #endif
     accumulateStripHits(simHits, tTopo, crossingSimHitIndexOffset_[tag.encode()], tofBin);
     // Now that the hits have been processed, I'll add the amount of hits in this crossing on to
@@ -202,8 +202,8 @@ void SiStripDigitizer::accumulate(PileUpEventPrincipal const& iEvent,
     if (!simHits.isValid())
       continue;
 #ifdef EDM_ML_DEBUG
-    std::cout << " SiStripDigitizer::accumulate "
-              << " Accumulating SimHits for PUs with InputTag " << tag << std::endl;
+    edm::LogVerbatim("SiStripDigitizer") << "accumulate "
+                                         << " Accumulating SimHits for PUs with InputTag " << tag;
 #endif
 
     accumulateStripHits(simHits, tTopo, crossingSimHitIndexOffset_[tag.encode()], tofBin);
@@ -349,9 +349,6 @@ void SiStripDigitizer::finalizeEvent(edm::Event& iEvent, edm::EventSetup const& 
     }
   }
   if (zeroSuppression) {
-#ifdef EDM_ML_DEBUG
-    std::cout << " SiStripDigitizer::finalize  Size of Digis " << totalDigis << std::endl;
-#endif
     // Step C: create output collection
     std::unique_ptr<edm::DetSetVector<SiStripRawDigi>> output_virginraw =
         std::make_unique<edm::DetSetVector<SiStripRawDigi>>();

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.cc
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.cc
@@ -140,10 +140,6 @@ void SiStripDigitizer::accumulateStripHits(edm::Handle<std::vector<PSimHit>> hSi
       assert(stripdet);
       if (stripdet->type().isTrackerStrip()) {
         if (detIds.insert(detId).second) {
-          // The insert succeeded, so this detector element has not yet been processed.
-          //// The insert succeeded, so this detector element has not yet been processed.
-          //	//        assert(detectorUnits[detId]);
-          //if (detectorUnits[detId]->type().isTrackerStrip()) {  // this test can be removed and replaced by stripdet!=0
           //access to magnetic field in global coordinates
           GlobalVector bfield = pSetup->inTesla(stripdet->surface().position());
           LogDebug("Digitizer ") << "B-field(T) at " << stripdet->surface().position()

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.h
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.h
@@ -82,12 +82,14 @@ private:
                            size_t globalSimHitIndex,
                            const unsigned int tofBin);
 
-  typedef std::vector<std::string> vstring;
-  typedef std::map<unsigned int, std::vector<std::pair<const PSimHit*, int>>, std::less<unsigned int>> simhit_map;
-  typedef simhit_map::iterator simhit_map_iterator;
+  using vstring = std::vector<std::string>;
+  using simhit_map = std::map<unsigned int, std::vector<std::pair<const PSimHit*, int>>, std::less<unsigned int>>;
+  using simhit_map_iterator = simhit_map::iterator;
 
   const std::string hitsProducer;
+  const std::string hitsProducerPU;
   const vstring trackerContainers;
+  const vstring trackerContainersPU;
   const std::string ZSDigi;
   const std::string SCDigi;
   const std::string VRDigi;


### PR DESCRIPTION

#### PR description:
In this Pull Request we propose update of code relevant for mixing of FastSim PileUp events with FullSim Signal events (hybrid mixing) through MixingModule  during digitization step. The main changes are in the configuration of MixingModule to make sure InputSource(s) of both FullSim and FastSim SimHits/SimTrack/SimVertex  are specified and read independently. Similar changes are propagated into digitizers of individual subsystems and TrackingTruthAccumulator. 

We want a high statistics validation of default FullSim (Full Sim PU with FullSim Signal) and default FastSim digitization.  Once that is done and the results are found to be consistent with the release,  the validation should be done for the hybrid case with high statistics. For the hybrid case a subtle change in the MixingModule will be required, the **_skipSignal_**  parameter should be set to  **_True_**. This is a temporary fix and a better solution will be needed in future.

#### PR validation:

Validation of Strip/Pixel and Ecal/Hcal digis were done using privately produced low statistics samples.

#### References:
- Motivation  [1](https://indico.cern.ch/event/1473390/contributions/6339653/attachments/3009322/5305390/Pileup%20Mixing%20Update%20feb%202025.pdf), [2](https://indico.cern.ch/event/1460070/contributions/6190298/attachments/2956387/5198603/Pileup%20Mixing%20Alternatives.pdf) 
- Description of code update  [3](https://indico.cern.ch/event/1525493/contributions/6418592/attachments/3032315/5353722/FastSimPUMixing_Status_14032025.pdf)
- Validation results [4](https://indico.cern.ch/event/1541483/contributions/6487750/attachments/3056975/5404812/FastSimPUMixing_Status_25042025.pdf)

@subirsarkar @bsunanda 