### PR TITLE
Add L1TSC4NGJets to Phase2L1TNanoAOD

### DIFF
--- a/DPGAnalysis/Phase2L1TNanoAOD/plugins/L1TableProducer.cc
+++ b/DPGAnalysis/Phase2L1TNanoAOD/plugins/L1TableProducer.cc
@@ -39,6 +39,9 @@ typedef SimpleFlatTableProducer<l1t::PFTau> SimpleTriggerL1PFTauFlatTableProduce
 #include "DataFormats/L1TParticleFlow/interface/HPSPFTau.h"
 typedef SimpleFlatTableProducer<l1t::HPSPFTau> SimpleTriggerL1HPSPFTauFlatTableProducer;
 
+#include "DataFormats/L1TParticleFlow/interface/PFJet.h"
+typedef SimpleFlatTableProducer<l1t::PFJet> SimpleTriggerL1PFJetFlatTableProducer;
+
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(SimpleL1VtxWordCandidateFlatTableProducer);
 DEFINE_FWK_MODULE(P2GTAlgoBlockFlatTableProducer);
@@ -53,3 +56,4 @@ DEFINE_FWK_MODULE(SimpleTriggerL1TrackerMuonFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleTriggerL1CaloJetFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleTriggerL1PFTauFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleTriggerL1HPSPFTauFlatTableProducer);
+DEFINE_FWK_MODULE(SimpleTriggerL1PFJetFlatTableProducer);

--- a/DPGAnalysis/Phase2L1TNanoAOD/python/l1tPh2Nanotables_cff.py
+++ b/DPGAnalysis/Phase2L1TNanoAOD/python/l1tPh2Nanotables_cff.py
@@ -336,12 +336,12 @@ EMTFDisplaceMuTable = staMuTable.clone(
 )
 
 ### Jets
-sc4JetTable = cms.EDProducer(
+jetTable = cms.EDProducer(
     "SimpleCandidateFlatTableProducer",
-    src = cms.InputTag('l1tSC4PFL1PuppiCorrectedEmulator'),
+    src = cms.InputTag('__src__'),
     cut = cms.string(""),
-    name = cms.string("L1puppiJetSC4"),
-    doc = cms.string("SeededCone 0.4 Puppi jet,  origin: Correlator"),
+    name = cms.string("__name__"),
+    doc = cms.string("__Template Jet Table__"),
     singleton = cms.bool(False), # the number of entries is variable
     variables = cms.PSet(
         l1P3Vars,
@@ -350,13 +350,33 @@ sc4JetTable = cms.EDProducer(
     )
 )
 
-sc8JetTable = sc4JetTable.clone(
+pfJetTable = cms.EDProducer(
+    "SimpleTriggerL1PFJetFlatTableProducer",
+    src = cms.InputTag('__src__'),
+    cut = cms.string(""),
+    name = cms.string("__name__"),
+    doc = cms.string("__Template PFJet Table__"),
+    singleton = cms.bool(False), # the number of entries is variable
+    variables = cms.PSet(
+        l1P3Vars,
+        et = Var("et",float),
+        # z0 = Var("vz", float, "vertex z0"), ## empty
+    )
+)
+
+sc4JetTable = pfJetTable.clone(
+    src = cms.InputTag('l1tSC4PFL1PuppiCorrectedEmulator'),
+    name = cms.string("L1puppiJetSC4"),
+    doc = cms.string("SeededCone 0.4 Puppi jet,  origin: Correlator"),
+)
+
+sc8JetTable = pfJetTable.clone(
     src = 'l1tSC8PFL1PuppiCorrectedEmulator',
     name = "L1puppiJetSC8",
     doc = "SeededCone 0.8 Puppi jet,  origin: Correlator"
 )
 
-sc4ExtJetTable = sc4JetTable.clone(
+sc4ExtJetTable = pfJetTable.clone(
     src = cms.InputTag('l1tSC4PFL1PuppiExtendedCorrectedEmulator'),
     name = cms.string("L1puppiExtJetSC4"),
     doc = cms.string("SeededCone 0.4 Puppi jet from extended Puppi,  origin: Correlator"),
@@ -366,14 +386,32 @@ sc4ExtJetTable = sc4JetTable.clone(
     ),
 )
 
-histoJetTable = sc4JetTable.clone(
+sc4NGJetTable = pfJetTable.clone(
+    src = cms.InputTag('l1tSC4NGJetProducer', 'l1tSC4NGJets'),
+    name = cms.string("L1puppiJetSC4NG"),
+    doc = cms.string("NextGeneration SeededCone 0.4 Puppi jet with multi-class tagging, origin: Correlator"),
+    variables = cms.PSet(
+        l1P3Vars,
+        et = Var("et",float),
+        udsTagScore = Var('getTagScore("uds")', float),
+        gTagScore = Var('getTagScore("g")', float),
+        bTagScore = Var('getTagScore("b")', float),
+        cTagScore = Var('getTagScore("c")', float),
+        tau_pTagScore = Var('getTagScore("tau_p")', float),
+        tau_nTagScore = Var('getTagScore("tau_n")', float),
+        eTagScore = Var('getTagScore("e")', float),
+        muTagScore = Var('getTagScore("mu")', float),
+    )
+)
+
+histoJetTable = jetTable.clone(
     src = cms.InputTag("l1tPhase1JetCalibrator9x9trimmed" ,   "Phase1L1TJetFromPfCandidates"),
     name = cms.string("L1puppiJetHisto"),
     doc = cms.string("Puppi Jets histogrammed 9x9, trimmed, origin: Correlator"),
 )
 
 
-caloJetTable = sc4JetTable.clone(
+caloJetTable = jetTable.clone(
     src = cms.InputTag("l1tPhase2CaloJetEmulator","GCTJet"),
     name = cms.string("L1caloJet"),
     doc = cms.string("Calo Jets, origin: GCT"),
@@ -423,7 +461,7 @@ histoSumsTable = sc4SumsTable.clone(
     src = cms.InputTag("l1tPhase1JetSumsProducer9x9trimmed","Sums"),
     name = cms.string("L1puppiHistoJetSums"),
     doc = cms.string("HT and MHT from histogrammed 9x9 jets, origin: Correlator"),
-)
+    )
 
 
 ### Taus
@@ -507,7 +545,6 @@ p2L1TablesTask = cms.Task(
     OMTFDisplaceMuTable,
     EMTFpromptMuTable,
     EMTFDisplaceMuTable,
-    
     ## EG
     tkEleTable,
     tkPhotonTable,
@@ -517,6 +554,7 @@ p2L1TablesTask = cms.Task(
     sc4JetTable,
     sc8JetTable,
     sc4ExtJetTable, 
+    sc4NGJetTable,
     histoJetTable,
     caloJetTable,
     # ## sums


### PR DESCRIPTION
#### PR description:

This PR adds the new `l1tSC4NGJets` collection that was introduced in #47798 to the Phase 2 L1Nano output, such that it can be used in Phase 2 L1 menu studies. I've added the `typedef SimpleFlatTableProducer<l1t::PFJet> SimpleTriggerL1PFJetFlatTableProducer` and then used it for the new table in order to access the `getTagScore` method that was introduced in #47798 to `l1t::PFJet`. 

#### PR validation:

This PR has been used to produce L1Nano ntuples and passed through the standalone menu tools to validate the PR and the object collection. Here's one example plot below, with more plots available [here](https://ssummers.web.cern.ch/CMS/TauJetsMET/V44NGJetDev/).

<img src="https://ssummers.web.cern.ch/CMS/TauJetsMET/V44NGJetDev/rates/V44NGJetDev_Online_JetDefaultRates.png" width="400" />
