### PR TITLE
Lower the muon pt threshold for nanoAOD

### DIFF
--- a/Configuration/Eras/python/Era_Run3_2025_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2025_cff.py
@@ -5,6 +5,7 @@ from Configuration.Eras.Modifier_run3_GEM_2025_cff import run3_GEM_2025
 from Configuration.Eras.Modifier_run3_CSC_2025_cff import run3_CSC_2025
 from Configuration.Eras.Modifier_stage2L1Trigger_2025_cff import stage2L1Trigger_2025
 from Configuration.Eras.Modifier_run3_SiPixel_2025_cff import run3_SiPixel_2025
+from Configuration.Eras.Modifier_run3_nanoAOD_2025_cff import run3_nanoAOD_2025
 from Configuration.ProcessModifiers.ecal_cctiming_cff import ecal_cctiming
 
-Run3_2025 = cms.ModifierChain(Run3_2024, run3_GEM_2025, stage2L1Trigger_2025, run3_SiPixel_2025, run3_CSC_2025, ecal_cctiming)
+Run3_2025 = cms.ModifierChain(Run3_2024, run3_GEM_2025, stage2L1Trigger_2025, run3_SiPixel_2025, run3_CSC_2025, run3_nanoAOD_2025, ecal_cctiming)

--- a/Configuration/Eras/python/Modifier_run3_nanoAOD_2025_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_nanoAOD_2025_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+# for 2025 data-taking (and possibly also 2026)
+run3_nanoAOD_2025 = cms.Modifier()

--- a/Configuration/Eras/python/Modifier_run3_nanoAOD_devel_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_nanoAOD_devel_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+# modifier for Run3 nanoAOD development beyond v15
+run3_nanoAOD_devel = cms.Modifier()

--- a/Configuration/PyReleaseValidation/python/relval_nano.py
+++ b/Configuration/PyReleaseValidation/python/relval_nano.py
@@ -287,9 +287,23 @@ steps['TTbar_13p6_Summer24_AOD'] = {'INPUT': InputInfo(
 steps['JetMET1_Run2024H_AOD'] = {'INPUT': InputInfo(
     location='STD', ls={385836: [[72, 166]]}, dataSet='/JetMET1/Run2024H-PromptReco-v1/AOD')}
 
-steps['NANO_mc_Summer24_reMINI'] = merge([{'--era': 'Run3', '--conditions': 'auto:phase1_2024_realistic'}, _NANO_mc])
+steps['NANO_mc_Summer24_reMINI'] = merge([{'--era': 'Run3_2024', '--conditions': 'auto:phase1_2024_realistic'}, _NANO_mc])
 
 steps['NANO_data_2024_reMINI'] = merge([{'--era': 'Run3_2024', '--conditions': 'auto:run3_data'}, _NANO_data])
+
+
+################################################################
+# Run3, 15_0_X input (for 2025 data-taking)
+# temporarily using the Summer24 samples
+steps['TTbar_13p6_Summer24_MINIAOD'] = {'INPUT': InputInfo(
+    location='STD', dataSet='/TTtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24MiniAODv6-150X_mcRun3_2024_realistic_v2-v2/MINIAODSIM')}
+
+steps['JetMET1_Run2024H_MINIAOD'] = {'INPUT': InputInfo(
+    location='STD', ls={385836: [[72, 166]]}, dataSet='/JetMET1/Run2024H-MINIv6NANOv15-v2/MINIAOD')}
+
+steps['NANO_mc15.0'] = merge([{'--era': 'Run3_2025', '--conditions': 'auto:phase1_2025_realistic'}, _NANO_mc])
+
+steps['NANO_data15.0'] = merge([{'--era': 'Run3_2025', '--conditions': 'auto:run3_data_prompt'}, _NANO_data])
 
 
 ################################################################
@@ -401,6 +415,14 @@ workflows[_wfn()] = ['NANOmc2024reMINI', ['TTbar_13p6_Summer24_AOD', 'REMINIAOD_
 
 _wfn.subnext()
 workflows[_wfn()] = ['NANOdata2024reMINI', ['JetMET1_Run2024H_AOD', 'REMINIAOD_data2024', 'NANO_data_2024_reMINI', 'HRV_NANO_data']]  # noqa
+
+# Run3, 15_0_X input (2025)
+_wfn.subnext()
+workflows[_wfn()] = ['NANOmc150X', ['TTbar_13p6_Summer24_MINIAOD', 'NANO_mc15.0', 'HRV_NANO_mc']]
+
+_wfn.subnext()
+workflows[_wfn()] = ['NANOdata150X', ['JetMET1_Run2024H_MINIAOD', 'NANO_data15.0', 'HRV_NANO_data']]
+
 
 _wfn.next(9)
 ######## 2500.9xx ########

--- a/PhysicsTools/NanoAOD/python/muons_cff.py
+++ b/PhysicsTools/NanoAOD/python/muons_cff.py
@@ -84,6 +84,13 @@ finalMuons = cms.EDFilter("PATMuonRefSelector",
     cut = cms.string("pt > 15 || (pt > 3 && (passed('CutBasedIdLoose') || passed('SoftCutBasedId') || passed('SoftMvaId') || passed('CutBasedIdGlobalHighPt') || passed('CutBasedIdTrkHighPt')))")
 )
 
+# lower the muon pt threshold to 2 GeV
+(run3_nanoAOD_2025 | run3_nanoAOD_devel).toModify(
+    finalMuons,
+    cut = cms.string("pt > 15 || (pt > 2 && (passed('CutBasedIdLoose') || passed('SoftCutBasedId') || passed('SoftMvaId') || passed('CutBasedIdGlobalHighPt') || passed('CutBasedIdTrkHighPt')))")
+)
+
+
 finalLooseMuons = cms.EDFilter("PATMuonRefSelector", # for isotrack cleaning
     src = cms.InputTag("slimmedMuonsWithUserData"),
     cut = cms.string("pt > 3 && track.isNonnull && isLooseMuon")

--- a/PhysicsTools/NanoAOD/python/nano_eras_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_eras_cff.py
@@ -19,6 +19,8 @@ from Configuration.Eras.Modifier_tracker_apv_vfp30_2016_cff import tracker_apv_v
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 from Configuration.Eras.Modifier_run3_nanoAOD_pre142X_cff import run3_nanoAOD_pre142X
 from Configuration.Eras.Modifier_run3_jme_Winter22runsBCDEprompt_cff import run3_jme_Winter22runsBCDEprompt
+from Configuration.Eras.Modifier_run3_nanoAOD_2025_cff import run3_nanoAOD_2025  # for 2025 data-taking (and possibly also 2026)
+from Configuration.Eras.Modifier_run3_nanoAOD_devel_cff import run3_nanoAOD_devel  # for development beyond v15
 
 run2_nanoAOD_ANY = (
     run2_nanoAOD_106Xv2


### PR DESCRIPTION
#### PR description:

This PR lowers the muon pt threshold for the `Muon` table in NanoAOD from 3 to 2 GeV.

To preserve the behavior of NanoAOD v15, this change is only activated using era modifiers:
 - `run3_nanoAOD_2025`: for 2025 data-taking (and possibly also 2026), part of `Run3_2025` era
 - `run3_nanoAOD_devel`: intended for Run3 nanoAOD development beyond v15

Also added two relval workflows to test this.

#### PR validation:

Standard nano relval workflows.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 15_0_X.
