### PR TITLE
Remove L1_ETT1600 also from the 2025 list, not only from the 2024 one, in DQM/L1TMonitor

### DIFF
--- a/DQM/L1TMonitor/python/L1TStage2uGTTiming_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGTTiming_cfi.py
@@ -84,5 +84,6 @@ from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
 
 from Configuration.Eras.Modifier_stage2L1Trigger_2025_cff import stage2L1Trigger_2025
 stage2L1Trigger_2025.toModify(l1tStage2uGTTiming,
-    unprescaledAlgoShortList = unprescaledAlgoList_2025
+    unprescaledAlgoShortList = unprescaledAlgoList_2025,
+    prescaledAlgoShortList = prescaledAlgoList_2024
 )


### PR DESCRIPTION
#### PR description:

The L1T seed "L1_ETT1600" was not removed from the `prescaledAlgoShortList` for 2025, as it was for 2024.
This resulted in error messages like
```
   Algo "L1_ETT1600" not found in the trigger menu L1Menu_Collisions2025_v1_0_0. Could not retrieve algo bit number.
```
which can be avoided by propagating, via modifier, to 2025 workflows the same fix that was already applied to 2024 ones.

#### PR validation:

I expect those warning messages disappear in the 2025 logs 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

It can be backported to CMSSW_15_0_X, in case one wants to silence those warning also in the 2025 data taking and MC production releases