### PR TITLE
[15_0_X] Update 2025 L1T menu in autoCond to L1Menu_Collisions2025_v1_1_1_xml

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -102,11 +102,11 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2024 detector for ppRef5TeV
     'phase1_2024_realistic_ppRef5TeV' : '141X_mcRun3_2024_realistic_ppRef5TeV_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2025
-    'phase1_2025_design'           :    '150X_mcRun3_2025_design_v1',
+    'phase1_2025_design'           :    '150X_mcRun3_2025_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2025
-    'phase1_2025_realistic'        :    '150X_mcRun3_2025_realistic_v1',
-    # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2024, Strip tracker in DECO mode
-    'phase1_2025_cosmics'          :    '150X_mcRun3_2025cosmics_realistic_deco_v1',
+    'phase1_2025_realistic'        :    '150X_mcRun3_2025_realistic_v2',
+    # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2025, Strip tracker in DECO mode
+    'phase1_2025_cosmics'          :    '150X_mcRun3_2025cosmics_realistic_deco_v2',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             :    '150X_mcRun4_realistic_v1'
 }

--- a/Configuration/AlCa/python/autoCondModifiers.py
+++ b/Configuration/AlCa/python/autoCondModifiers.py
@@ -115,7 +115,7 @@ def autoCondRelValForRun3(autoCond):
 
     GlobalTagRelValForRun3 = {}
     L1GtTriggerMenuForRelValForRun3 =    ','.join( ['L1Menu_Collisions2015_25nsStage1_v5' , "L1GtTriggerMenuRcd",             connectionString, "", "2023-01-28 12:00:00.000"] )
-    L1TUtmTriggerMenuForRelValForRun3 =  ','.join( ['L1Menu_Collisions2025_v1_0_0_xml'    , "L1TUtmTriggerMenuRcd",           connectionString, "", "2025-04-08 12:00:00.000"] )
+    L1TUtmTriggerMenuForRelValForRun3 =  ','.join( ['L1Menu_Collisions2025_v1_1_1_xml'    , "L1TUtmTriggerMenuRcd",           connectionString, "", "2025-05-05 12:00:00.000"] )
 
     for key,val in autoCond.items():
         if 'run3_data' in key or 'run3_hlt' in key :


### PR DESCRIPTION
#### PR description:

Add  to the 2025 MC GT in autoCond the new 2025 [L1Menu_Collisions2025_v1_1_1_xml](https://github.com/cms-l1-dpg/L1MenuRun3/tree/master/development/L1Menu_Collisions2025_v1_1_1#readme)l as from [cmsTalk](https://cms-talk.web.cern.ch/t/gt-mc-data-relval-update-of-the-gt-with-the-new-2025-l1t-menu-tag-l1menu-collisions2025-v1-1-1-xml/124487)
Take also profit to remove from the GTs some obsolete HI centrality tags as from [cmsTalk](https://cms-talk.web.cern.ch/t/gt-mc-queue-request-for-a-dedicated-oxygen-run-mc-queue-in-151x/123899/4) 

New MC GTs in autoCond:
- [150X_mcRun3_2025_design_v2](https://cms-conddb.cern.ch/cmsDbBrowser/search/Prod/150X_mcRun3_2025_design_v2) (diff wrt _v1 [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/150X_mcRun3_2025_design_v2/150X_mcRun3_2025_design_v1))
- [150X_mcRun3_2025_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/search/Prod/150X_mcRun3_2025_realistic_v2) (diff wrt _v1 [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/150X_mcRun3_2025_realistic_v2/150X_mcRun3_2025_realistic_v1))
- [150X_mcRun3_2025cosmics_realistic_deco_v2](https://cms-conddb.cern.ch/cmsDbBrowser/search/Prod/150X_mcRun3_2025cosmics_realistic_deco_v2) (diff wrt _v1 [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/150X_mcRun3_2025cosmics_realistic_deco_v2/150X_mcRun3_2025cosmics_realistic_deco_v1))

#### PR validation:

Already successfully tested in master

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

backport of #48013
