### PR TITLE
Add ability to output JetTagClass to std::ostream

### DIFF
--- a/DataFormats/L1TParticleFlow/interface/jets.h
+++ b/DataFormats/L1TParticleFlow/interface/jets.h
@@ -35,14 +35,11 @@ namespace l1ct {
     static const std::unordered_map<std::string, JetTagClassValue> labels_;
 
     friend std::ostream &operator<<(std::ostream &ost, const l1ct::JetTagClass &jtc) {
-      std::string res = "";
       auto it = std::find_if(
           std::begin(jtc.labels_), std::end(jtc.labels_), [&jtc](auto &&p) { return p.second == jtc.value_; });
       if (it != std::end(jtc.labels_)) {
-        res = it->first;
+        ost << it->first;
       }
-
-      ost << res;
       return ost;
     }
 

--- a/DataFormats/L1TParticleFlow/interface/jets.h
+++ b/DataFormats/L1TParticleFlow/interface/jets.h
@@ -5,6 +5,7 @@
 #include "DataFormats/L1TParticleFlow/interface/gt_datatypes.h"
 #include "DataFormats/L1TParticleFlow/interface/bit_encoding.h"
 #include <array>
+#include <algorithm>
 #include <cstdint>
 #include <vector>
 #include <unordered_map>
@@ -32,6 +33,18 @@ namespace l1ct {
   private:
     JetTagClassValue value_;
     static const std::unordered_map<std::string, JetTagClassValue> labels_;
+
+    friend std::ostream &operator<<(std::ostream &ost, const l1ct::JetTagClass &jtc) {
+      std::string res = "";
+      auto it = std::find_if(
+          std::begin(jtc.labels_), std::end(jtc.labels_), [&jtc](auto &&p) { return p.second == jtc.value_; });
+      if (it != std::end(jtc.labels_)) {
+        res = it->first;
+      }
+
+      ost << res;
+      return ost;
+    }
 
   };  // JetTagClass
 


### PR DESCRIPTION
#### PR description:

Compilation of CMSSW_15_1_DBG_X_2025-05-05-2300 failed:

```
  src/FWCore/MessageLogger/interface/ErrorObj.icc:28:10: error: no match for 'operator<<' (operand types are 'std::ostringstream' {aka 'std::__cxx11::basic_ostringstream<char>'} and 'const l1ct::JetTagClass')
    28 |     myOs << t;
      |     ~~~~~^~~~
```

This PR fixes that.

#### PR validation:

Code compiles