### PR TITLE
Adding GEM MEs to per-LS scope in Offline DQM (backport to 15_0_X)

### DIFF
--- a/DQMServices/Core/python/nanoDQMIO_perLSoutput_cff.py
+++ b/DQMServices/Core/python/nanoDQMIO_perLSoutput_cff.py
@@ -66,6 +66,15 @@ nanoDQMIO_perLSoutput = cms.PSet(
     "CSC/CSCOfflineMonitor/recHits/hRHGlobalp3",
     "CSC/CSCOfflineMonitor/recHits/hRHGlobalp4",
 
+    "GEM/RecHits/occ_xy_GE11-M-L1",
+    "GEM/RecHits/occ_xy_GE11-M-L2",
+    "GEM/RecHits/occ_xy_GE11-P-L1",
+    "GEM/RecHits/occ_xy_GE11-P-L2",
+    "GEM/Digis/occ_GE11-M-L1",
+    "GEM/Digis/occ_GE11-M-L2",
+    "GEM/Digis/occ_GE11-P-L1",
+    "GEM/Digis/occ_GE11-P-L2",
+
     "HLT/Vertexing/hltPixelVertices/hltPixelVertices/goodvtxNbr",
     "HLT/Tracking/ValidationWRTOffline/hltMergedWrtHighPurityPV/mon_eta",
     "HLT/Tracking/ValidationWRTOffline/hltMergedWrtHighPurityPV/mon_hits",


### PR DESCRIPTION
#### PR description:
Note: This PR is a backport of [#47690](https://github.com/cms-sw/cmssw/pull/47690) to CMSSW_15_0_X

Adding the following GEMs MEs to per-LS scope in Offline DQM:

```
GEM/RecHits/occ_xy_GE11-M-L1
GEM/RecHits/occ_xy_GE11-M-L2
GEM/RecHits/occ_xy_GE11-P-L1
GEM/RecHits/occ_xy_GE11-P-L2,
GEM/Digis/occ_GE11-M-L1
GEM/Digis/occ_GE11-M-L2
GEM/Digis/occ_GE11-P-L1
GEM/Digis/occ_GE11-P-L2
```
#### PR validation:

This PR was validated by running the DQMIO production from RAW locally, and the output is as expected. We also checked the impact on the size of the produced DQMIO files, but the impact of adding these monitoring elements is negligible.
