### PR TITLE
`test_mille.py`: dump output to `stdout` instead of file

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/test/test_mille.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/test/test_mille.py
@@ -70,6 +70,20 @@ confAliProducer.setConfiguration(process,
     cosmicsZeroTesla = setupCosmicsZeroTesla)
 
 ################################################################################
+# Configure the MessageLogger service to dump information to cout (instead of alignment.log)
+# see https://github.com/cms-sw/cmssw/issues/47963 for more information
+# ------------------------------------------------------------------------------
+process.MessageLogger.destinations = cms.untracked.vstring('cout')
+process.MessageLogger.statistics = cms.untracked.vstring('cout')
+# Copy all parameters from the existing 'alignment' PSet to a new 'cout' PSet
+if hasattr(process.MessageLogger, 'alignment'):
+    alignment_pset = process.MessageLogger.alignment
+    process.MessageLogger.cout = alignment_pset
+
+    # Optionally delete the old 'alignment' PSet
+    delattr(process.MessageLogger, 'alignment')
+
+################################################################################
 # Overwrite some conditions in global tag
 # ------------------------------------------------------------------------------
 import Alignment.MillePedeAlignmentAlgorithm.alignmentsetup.SetCondition as tagwriter


### PR DESCRIPTION
resolves https://github.com/cms-sw/cmssw/issues/47963

#### PR description:

This is necessary for the cms-bot to process it and start caching the input root files, see https://github.com/cms-sw/cmssw/issues/47963#issuecomment-2846706123 for details.

#### PR validation:

`scram b runtests_test_MilleZmm` runs.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A