### PR TITLE
add HLT trimmed pixel vertices monitoring in online DQM

### DIFF
--- a/DQM/HLTEvF/python/HLTPrimaryVertexMonitoring_cff.py
+++ b/DQM/HLTEvF/python/HLTPrimaryVertexMonitoring_cff.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 from DQMOffline.Trigger.PrimaryVertexMonitoring_cff import *
 
 vertexingMonitorHLTsequence = cms.Sequence(
-    hltPixelVerticesMonitoring
-    + hltVerticesPFFilterMonitoring
-#    + hltVerticesL3PFBjets
-)    
+    hltPixelVerticesMonitoring +
+    hltTrimmedPixelVerticesMonitoring +
+    hltVerticesPFFilterMonitoring
+)

--- a/DQMOffline/RecoB/plugins/PrimaryVertexMonitor.cc
+++ b/DQMOffline/RecoB/plugins/PrimaryVertexMonitor.cc
@@ -400,10 +400,15 @@ void PrimaryVertexMonitor::analyze(const edm::Event& iEvent, const edm::EventSet
   //
   // check for absent products and simply "return" in that case
   //
-  if (recVtxs.isValid() == false || beamSpotHandle.isValid() == false) {
-    edm::LogWarning("PrimaryVertexMonitor")
-        << " Some products not available in the event: VertexCollection " << vertexInputTag_ << " " << recVtxs.isValid()
-        << " BeamSpot " << beamSpotInputTag_ << " " << beamSpotHandle.isValid() << ". Skipping plots for this event";
+  if (!beamSpotHandle.isValid()) {
+    edm::LogWarning("PrimaryVertexMonitor") << " Some products not available in the event: BeamSpot ("
+                                            << beamSpotInputTag_ << "). Skipping plots for this event.";
+    return;
+  }
+
+  if (!recVtxs.isValid()) {
+    edm::LogWarning("PrimaryVertexMonitor") << " Some products not available in the event: VertexCollection ("
+                                            << vertexInputTag_ << "). Skipping plots for this event.";
     return;
   }
 

--- a/DQMOffline/Trigger/python/PrimaryVertexMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/PrimaryVertexMonitoring_cff.py
@@ -50,10 +50,9 @@ hltVerticesL3PFBjetsMonitoring = hltVerticesMonitoring.clone(
     useHPforAlignmentPlots = False
 )
 vertexingMonitorHLT = cms.Sequence(
-    hltPixelVerticesMonitoring
-    + hltTrimmedPixelVerticesMonitoring
-    + hltVerticesPFFilterMonitoring
-#    + hltVerticesL3PFBjets
-)    
+    hltPixelVerticesMonitoring +
+    hltTrimmedPixelVerticesMonitoring +
+    hltVerticesPFFilterMonitoring
+)
 
 phase2_tracker.toReplaceWith(vertexingMonitorHLT, cms.Sequence(hltPixelVerticesMonitoring + hltVerticesMonitoring))


### PR DESCRIPTION
#### PR description:

I noticed casually looking at the [online DQM](https://cmsweb.cern.ch/dqm/online/start?runnr=391685;dataset=/Global/Online/ALL;sampletype=online_data;filter=all;referencepos=overlay;referenceshow=customise;referencenorm=True;referenceobj1=refobj;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=Everything;size=M;root=HLT/Vertexing;focus=;zoom=no;) for the first 2025 13.6 TeV runs that the HLT trimmed pixel vertices monitoring is missing, despite the collection is sent to the `OnlineMonitor` PD by the HLT menu:

```python
process.hltOutputDQM = cms.OutputModule( "PoolOutputModule",
    fileName = cms.untracked.string( "outputDQM.root" ),
    compressionAlgorithm = cms.untracked.string( "ZSTD" ),
    compressionLevel = cms.untracked.int32( 3 ),
    fastCloning = cms.untracked.bool( False ),
    dataset = cms.untracked.PSet(
        filterName = cms.untracked.string( "" ),
        dataTier = cms.untracked.string( "RAW" )
    ),
    SelectEvents = cms.untracked.PSet(  SelectEvents = cms.vstring( 'Dataset_OnlineMonitor' ) ),
    outputCommands = cms.untracked.vstring( 'drop *',
      ...
      'keep *_hltTrimmedPixelVertices_*_*',
      ....
     )
)
```

This PR adds the monitoring to the HLT online client by changing the sequence `vertexingMonitorHLTsequence`
I profit of the PR to improve slightly the logging for missing collections in commit 78cc0497ffc269347a6d19323c19ae98c0c665f3.

#### PR validation:

Run:

```console
cd DQM/Integration/python/clients
mkdir upload
cmsRun hlt_dqm_sourceclient-live_cfg.py unitTest=True
```

and obtained a DQM output file with the desired monitor elements.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, to be backported to CMSSW_15_0_X.