### PR TITLE
[15_0_X] Fix ECAL DQM crash from ME formatter when there is no luminosity block

### DIFF
--- a/DQM/EcalCommon/plugins/EcalMEFormatter.cc
+++ b/DQM/EcalCommon/plugins/EcalMEFormatter.cc
@@ -43,6 +43,10 @@ void EcalMEFormatter::format_(DQMStore::IGetter &_igetter, bool _checkLumi) {
     if (_checkLumi && !mItr.second->getLumiFlag())
       continue;
     mItr.second->clear();
+
+    if (!checkElectronicsMap(false))
+      return;
+
     if (!mItr.second->retrieve(GetElectronicsMap(), _igetter, &failedPath)) {
       if (verbosity_ > 0)
         edm::LogWarning("EcalDQM") << "Could not find ME " << mItr.first << "@" << failedPath;

--- a/DQM/EcalCommon/test/BuildFile.xml
+++ b/DQM/EcalCommon/test/BuildFile.xml
@@ -1,0 +1,4 @@
+<bin file="testEcalCommon.cc" name="testEcalCommon">
+    <use name="FWCore/TestProcessor"/>
+    <use name="catch2"/>
+  </bin>

--- a/DQM/EcalCommon/test/testEcalCommon.cc
+++ b/DQM/EcalCommon/test/testEcalCommon.cc
@@ -1,0 +1,43 @@
+#include "FWCore/TestProcessor/interface/TestProcessor.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+// Function to run the catch2 tests
+//___________________________________________________________________________________________
+void runTestForAnalyzer(const std::string& baseConfig, const std::string& analyzerName) {
+  edm::test::TestProcessor::Config config{baseConfig};
+
+  SECTION(analyzerName + " base configuration is OK") { REQUIRE_NOTHROW(edm::test::TestProcessor(config)); }
+
+  SECTION("Run with no LuminosityBlocks") {
+    edm::test::TestProcessor tester(config);
+    REQUIRE_NOTHROW(tester.testRunWithNoLuminosityBlocks());
+  }
+}
+
+// Function to generate base configuration string
+//___________________________________________________________________________________________
+std::string generateBaseConfig(const std::string& cfiName, const std::string& analyzerName) {
+  // Define a raw string literal
+  constexpr const char* rawString = R"_(from FWCore.TestProcessor.TestProcess import *
+from DQM.EcalCommon.{}_cfi import {}
+process = TestProcess()
+process.harvester = {}
+process.moduleToTest(process.harvester)
+process.add_(cms.Service('MessageLogger'))
+process.add_(cms.Service('JobReportService'))
+process.add_(cms.Service('DQMStore'))
+    )_";
+
+  // Format the raw string literal using fmt::format
+  return fmt::format(rawString, cfiName, analyzerName, analyzerName);
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("EcalMEFormatter tests", "[EcalMEFormatter]") {
+  const std::string baseConfig = generateBaseConfig("EcalMEFormatter", "ecalMEFormatter");
+  runTestForAnalyzer(baseConfig, "EcalMEFormatter");
+}


### PR DESCRIPTION
#### PR description:

This PR fixes a bug from ECAL DQM ME formatter when a run has no luminosity block. For more details, see this thread: https://github.com/cms-sw/cmssw/issues/38976#issuecomment-2327757921

#### PR validation:

PR is validated by running test via `scram b runtests_testEcalCommon`, after adding the following files under `DQM/EcalCommon/test/` directory, following the recipe in the thread from: https://github.com/cms-sw/cmssw/issues/38976#issuecomment-2327757921

```
diff --git a/DQM/EcalCommon/test/BuildFile.xml b/DQM/EcalCommon/test/BuildFile.xml
new file mode 100644
index 00000000000..67518e7f759
--- /dev/null
+++ b/DQM/EcalCommon/test/BuildFile.xml
@@ -0,0 +1,4 @@
+<bin file="testEcalCommon.cc" name="testEcalCommon">
+    <use name="FWCore/TestProcessor"/>
+    <use name="catch2"/>
+  </bin>
diff --git a/DQM/EcalCommon/test/testEcalCommon.cc b/DQM/EcalCommon/test/testEcalCommon.cc
new file mode 100644
index 00000000000..d4eb9db6a08
--- /dev/null
+++ b/DQM/EcalCommon/test/testEcalCommon.cc
@@ -0,0 +1,43 @@
+#include "FWCore/TestProcessor/interface/TestProcessor.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+// Function to run the catch2 tests
+//___________________________________________________________________________________________
+void runTestForAnalyzer(const std::string& baseConfig, const std::string& analyzerName) {
+  edm::test::TestProcessor::Config config{baseConfig};
+
+  SECTION(analyzerName + " base configuration is OK") { REQUIRE_NOTHROW(edm::test::TestProcessor(config)); }
+
+  SECTION("Run with no LuminosityBlocks") {
+    edm::test::TestProcessor tester(config);
+    REQUIRE_NOTHROW(tester.testRunWithNoLuminosityBlocks());
+  }
+}
+
+// Function to generate base configuration string
+//___________________________________________________________________________________________
+std::string generateBaseConfig(const std::string& cfiName, const std::string& analyzerName) {
+  // Define a raw string literal
+  constexpr const char* rawString = R"_(from FWCore.TestProcessor.TestProcess import *
+from DQM.EcalCommon.{}_cfi import {}
+process = TestProcess()
+process.harvester = {}
+process.moduleToTest(process.harvester)
+process.add_(cms.Service('MessageLogger'))
+process.add_(cms.Service('JobReportService'))
+process.add_(cms.Service('DQMStore'))
+    )_";
+
+  // Format the raw string literal using fmt::format
+  return fmt::format(rawString, cfiName, analyzerName, analyzerName);
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("EcalMEFormatter tests", "[EcalMEFormatter]") {
+  const std::string baseConfig = generateBaseConfig("EcalMEFormatter", "ecalMEFormatter");
+  runTestForAnalyzer(baseConfig, "EcalMEFormatter");
+}
```

Test results are:
```
===== Test "testEcalCommon" ====
===============================================================================
All tests passed (2 assertions in 1 test case)


---> test testEcalCommon succeeded
TestTime:2
^^^^ End Test testEcalCommon ^^^^
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is the backport to `15_0_X`, which is currently in production for DQM. Master PR is made #48027. 