### PR TITLE
Fix HLT MTV to work with singleIterPatatrack and LST procModifiers

### DIFF
--- a/Validation/RecoTrack/python/HLTmultiTrackValidator_cff.py
+++ b/Validation/RecoTrack/python/HLTmultiTrackValidator_cff.py
@@ -47,3 +47,16 @@ def _modifyForPhase2LSTTracking(trackvalidator):
 def _modifyForPhase2LSTSeeding(trackvalidator):
     trackvalidator.label = ["hltGeneralTracks", "hltPhase2PixelTracks", "hltInitialStepTrackSelectionHighPuritypTTCLST", "hltInitialStepTracksT5TCLST", "hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST"]
 (seedingLST & trackingLST).toModify(hltTrackValidator, _modifyForPhase2LSTSeeding)
+
+from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
+def _modifyForSingleIterPatatrack(trackvalidator):
+    trackvalidator.label = ["hltGeneralTracks", "hltPhase2PixelTracks", "hltInitialStepTrackSelectionHighPurity"]
+(singleIterPatatrack & ~trackingLST & ~seedingLST).toModify(hltTrackValidator, _modifyForSingleIterPatatrack)
+
+def _modifyForSingleIterPatatrackLST(trackvalidator):
+    trackvalidator.label = ["hltGeneralTracks", "hltPhase2PixelTracks", "hltInitialStepTrackSelectionHighPuritypTTCLST", "hltInitialStepTrackSelectionHighPuritypLSTCLST", "hltInitialStepTracksT5TCLST"]
+(singleIterPatatrack & ~seedingLST & trackingLST).toModify(hltTrackValidator, _modifyForSingleIterPatatrackLST)
+
+def _modifyForSingleIterPatatrackLSTSeeding(trackvalidator):
+    trackvalidator.label = ["hltGeneralTracks", "hltPhase2PixelTracks", "hltInitialStepTrackSelectionHighPuritypTTCLST", "hltInitialStepTracksT5TCLST"]
+(singleIterPatatrack & seedingLST & trackingLST).toModify(hltTrackValidator, _modifyForSingleIterPatatrackLSTSeeding)


### PR DESCRIPTION
#### PR description:

This PR fixes `cmsDriver` recipes that try to run Validation together with HLT in a single step while using the `singleIterPatatrack` `procModifer` either alone or together with `trackingLST`. Currently, recipies such as 
```bash
cmsDriver.py step2 -s L1P2GT,HLT:75e33,VALIDATION:@hltValidation \
--processName HLTX \
--conditions auto:phase2_realistic_T33 \
--datatier GEN-SIM-DIGI-RAW,DQMIO \
--eventcontent FEVTDEBUGHLT,DQMIO \
--geometry ExtendedRun4D110 \
--era Phase2C17I13M9 \
--filein file:/eos/cms/store/relval/CMSSW_15_1_0_pre2/RelValZMM_14/GEN-SIM-DIGI-RAW/PU_150X_mcRun4_realistic_v1_STD_Run4D110_PU-v1/2580000/010145a6-c5b8-48d0-b236-0b0a1c2c3c86.root \
-n 10 \
--fileout file:step2.root \
--procModifiers alpaka,singleIterPatatrack
```
or the same with added `trackingLST` among the `procModifiers`, result in the error:
```bash
----- Begin Fatal Exception 07-May-2025 13:33:16 CEST-----------------------
An exception of category 'InvalidReference' occurred while
   [0] Processing  Event run: 1 lumi: 116 event: 11501 stream: 0
   [1] Running path 'prevalidation_step'
   [2] Calling method for module MultiTrackValidator/'hltTrackValidator'
Exception Message:
ClusterTPAssociation has OmniClusterRefs with ProductIDs 3:193,3:153 but got OmniClusterRef/ProductID with ID 2:345. This is typically caused by a configuration error.
----- End Fatal Exception -------------------------------------------------
```
which does not happen anymore after the changes.

#### PR validation:

The recipe listed above runs correctly and produces the expected plots (with or without `trackingLST`). No other difference is expected

FYI @VourMa 