### PR TITLE
Regionally applied pixel digi morphing

### DIFF
--- a/RecoLocalTracker/SiPixelDigiReProducers/plugins/BuildFile.xml
+++ b/RecoLocalTracker/SiPixelDigiReProducers/plugins/BuildFile.xml
@@ -5,6 +5,8 @@
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/PluginManager"/>
 <use name="DataFormats/SiPixelDigi"/>
+<use name="DataFormats/TrackerCommon"/>
+<use name="Geometry/Records"/>
 <library file="*.cc" name="RecoLocalTrackerSiPixelDigiReProducersPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>


### PR DESCRIPTION
#### PR description:

This PR implements the possibility of applying pixel digi morphing regionally. With this PR it is now completely disabled in FPix and enabled only in L1 (2 farthest rings from the center on each side) and L2 (the farthest ring from the center on each side).

#### PR validation:

The code compiles. The pixel digi morhing (enabled using `--procModifiers siPixelDigiMorphing`) is disabled by default so no impact is expected on reconstructed quantities.  With this change in place, further testing and validation will be done.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR will be backported to CMSSW_15_0_X.

@veszpv 
