### PR TITLE
Take uGT DQM emulation CICADA from unpacked

### DIFF
--- a/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
@@ -136,6 +136,7 @@ valGtStage2Digis = simGtStage2Digis.clone(
     JetInputTag = "gtStage2Digis:Jet",
     EtSumInputTag = "gtStage2Digis:EtSum",
     EtSumZdcInputTag = "gtStage2Digis:EtSumZDC",
+    CICADAInputTag = 'gtStage2Digis:CICADAScore',
     AlgorithmTriggersUnmasked = False,
     AlgorithmTriggersUnprescaled = False,
     EmulateBxInEvent = cms.int32(5),


### PR DESCRIPTION
#### PR description:

This PR changes DQM uGT emulation to take CICADA inputs from the unpacked CICADA score, instead of directly from CICADA emulation. Because CICADA emulation was accidentally directly feeding uGT emulation, mismatches in CICADA emulation caused mismatches and false alarms in uGT emulation.

@kbunkow FYI
@slaurila FYI, this fixes the the uGT DQM emulation mismatch seen mentioned in this week's meeting.

#### PR validation:

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not a backport, but will be backported to 15_0 for online DQM.