### PR TITLE
Fix memory leaks in TStorageFactoryFile and StorageAccountProxy

### DIFF
--- a/IOPool/TFileAdaptor/interface/TStorageFactoryFile.h
+++ b/IOPool/TFileAdaptor/interface/TStorageFactoryFile.h
@@ -55,8 +55,6 @@ private:
 
   Bool_t ReadBuffersSync(char *buf, Long64_t *pos, Int_t *len, Int_t nbuf);
 
-  void releaseStorage() { get_underlying_safe(storage_).release(); }
-
   TStorageFactoryFile(void);
 
   edm::propagate_const<std::unique_ptr<edm::storage::Storage>> storage_;  //< Real underlying storage

--- a/IOPool/TFileAdaptor/src/TStorageFactoryFile.cc
+++ b/IOPool/TFileAdaptor/src/TStorageFactoryFile.cc
@@ -564,7 +564,7 @@ Int_t TStorageFactoryFile::SysClose(Int_t /* fd */) {
 
   if (storage_) {
     storage_->close();
-    releaseStorage();
+    get_underlying_safe(storage_).reset();
   }
 
   stats.tick();

--- a/Utilities/StorageFactory/interface/StorageAccountProxy.h
+++ b/Utilities/StorageFactory/interface/StorageAccountProxy.h
@@ -40,7 +40,7 @@ namespace edm::storage {
     void close(void) override;
 
   protected:
-    void releaseStorage() { get_underlying_safe(m_baseStorage).release(); }
+    void resetStorage() { get_underlying_safe(m_baseStorage).reset(); }
 
     edm::propagate_const<std::unique_ptr<Storage>> m_baseStorage;
 

--- a/Utilities/StorageFactory/src/StorageAccountProxy.cc
+++ b/Utilities/StorageFactory/src/StorageAccountProxy.cc
@@ -16,7 +16,7 @@ StorageAccountProxy::StorageAccountProxy(const std::string &storageClass, std::u
 
 StorageAccountProxy::~StorageAccountProxy() {
   StorageAccount::Stamp stats(StorageAccount::counter(m_token, StorageAccount::Operation::destruct));
-  releaseStorage();
+  resetStorage();
   stats.tick();
 }
 


### PR DESCRIPTION
#### PR description:

These memory leaks were introduced in 1f0a685286e5 of https://github.com/cms-sw/cmssw/pull/10932 when these pointers were migrated from raw pointers to smart pointers. The earlier code deleted the pointers, so `reset()` is the correct behavior here.

These came up in the context of developing storage tracing feature in the context of https://github.com/cms-sw/cmssw/issues/47750 . 

Resolves https://github.com/cms-sw/framework-team/issues/1388

#### PR validation:

In private test the destructors of the `Storage` components being held by these smart pointers get run.
