### PR TITLE
Add an option to edmFileUtil to print information on clusters

### DIFF
--- a/IOPool/Common/bin/CollUtil.h
+++ b/IOPool/Common/bin/CollUtil.h
@@ -15,6 +15,7 @@ namespace edm {
   Long64_t numEntries(TFile *hdl, const std::string &trname);
   void printBranchNames(TTree *tree);
   void longBranchPrint(TTree *tr);
+  void clusterPrint(TTree *tr, bool isEventsTree);
   std::string getUuid(TTree *uuidTree);
   void printUuids(TTree *uuidTree);
   void printEventLists(TFile *tfl);


### PR DESCRIPTION
#### PR description:

This PR adds `--printClusters` command line option to `edmFileUtil`. The information on the cluster boundaries, number of entries per cluster, and the total size of baskets in a cluster was useful in the investigation of https://github.com/cms-sw/cmssw/issues/47750.

Resolves https://github.com/cms-sw/framework-team/issues/1386

#### PR validation:

Cluster information is getting printed on a random AOD file.