### PR TITLE
use unpacked track-finder inputs for kBMTF in `L1REPACK:Full`

### DIFF
--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_Full_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_Full_cff.py
@@ -110,6 +110,10 @@ for b in cutlist:
 simBmtfDigis.DTDigi_Source       = "unpackBmtf"
 simBmtfDigis.DTDigi_Theta_Source = "unpackBmtf"
 
+# kBMTF
+simKBmtfStubs.srcPhi = 'unpackBmtf'
+simKBmtfStubs.srcTheta = 'unpackBmtf'
+
 # OMTF
 simOmtfDigis.srcRPC              = 'unpackRPC'
 simOmtfDigis.srcDTPh             = "unpackBmtf"


### PR DESCRIPTION
#### PR description:

This PR updates the kBMTF inputs in `L1REPACK:Full`, making use of the unpacked BMTF data rather than the re-emulated trigger primitives. This follows what is done [here](https://github.com/cms-sw/cmssw/blob/341edfe4b80256c6606d4933bd786aa836530e65/L1Trigger/Configuration/python/customiseReEmul.py#L217-L220) in `customiseReEmul.L1TReEmulFromRAW`. For more context, see https://github.com/cms-sw/cmssw/issues/47925#issuecomment-2864575806.

#### PR validation:

Used the simple example below with 2024 data to verify that, with this change, the re-emulated L1T decision of `L1_SingleMu22_BMTF` based on `L1REPACK:Full` agrees with the one in the RAW data (firmware). Without this PR, the same example shows a disagreement between the two.

In the example below, the Path `L1TMonitorPath1` (`L1TMonitorPath2`) accepts events where `L1_SingleMu22_BMTF` fired in firmware (`L1REPACK:Full`). Tested in `CMSSW_15_0_5`.
```py
#!/bin/bash

cmsDriver.py l1Ntuple -s L1REPACK:Full \
 --python_filename l1t_L1REPACK_Full_base.py --dump_python -n 1500 \
 --era Run3_2025 --data --conditions 150X_dataRun3_HLT_v1 \
 --filein /store/data/Run2024I/EphemeralHLTPhysics5/RAW/v1/000/386/593/00000/545e47b2-a41e-46d6-a9e3-8c6d26fb3ea1.root \
 --processName HLT2 --no_output --no_exec

cp l1t_L1REPACK_Full_base.py l1t_L1REPACK_Full.py

cat <<@EOF >> l1t_L1REPACK_Full.py

process.options.wantSummary = True

process.l1tGtStage2Digis1 = cms.EDProducer( "L1TRawToDigi",
    FedIds = cms.vint32( 1404 ),
    Setup = cms.string( "stage2::GTSetup" ),
    FWId = cms.uint32( 0 ),
    DmxFWId = cms.uint32( 0 ),
    FWOverride = cms.bool( False ),
    TMTCheck = cms.bool( True ),
    CTP7 = cms.untracked.bool( False ),
    MTF7 = cms.untracked.bool( False ),
    InputLabel = cms.InputTag( "rawDataCollector::@skipCurrentProcess" ),
    lenSlinkHeader = cms.untracked.int32( 8 ),
    lenSlinkTrailer = cms.untracked.int32( 8 ),
    lenAMCHeader = cms.untracked.int32( 8 ),
    lenAMCTrailer = cms.untracked.int32( 0 ),
    lenAMC13Header = cms.untracked.int32( 8 ),
    lenAMC13Trailer = cms.untracked.int32( 8 ),
    debug = cms.untracked.bool( False ),
    MinFeds = cms.uint32( 0 )
)

process.l1tMonitor1 = cms.EDFilter( "TriggerResultsFilter",
    usePathStatus = cms.bool( False ),
    hltResults = cms.InputTag( "" ),
    l1tResults = cms.InputTag( "l1tGtStage2Digis1" ),
    l1tIgnoreMaskAndPrescale = cms.bool( True ),
    throw = cms.bool( True ),
    triggerConditions = cms.vstring( 'L1_SingleMu22_BMTF' )
)

process.L1TMonitorPath1 = cms.Path(
    process.l1tGtStage2Digis1
  + process.l1tMonitor1
)

process.schedule.append( process.L1TMonitorPath1 )

process.l1tGtStage2Digis2 = process.l1tGtStage2Digis1.clone(
    InputLabel = "rawDataCollector::@currentProcess"
)

process.l1tMonitor2 = process.l1tMonitor1.clone(
    l1tResults = "l1tGtStage2Digis2"
)

process.L1TMonitorPath2 = cms.Path(
    process.rawDataCollector
  + process.l1tGtStage2Digis2
  + process.l1tMonitor2
)

process.schedule.append( process.L1TMonitorPath2 )
@EOF

cmsRun l1t_L1REPACK_Full.py &> l1t_L1REPACK_Full.log
grep MonitorPath l1t_L1REPACK_Full.log | head -2
```

Output pre-PR.
```bash
L1REPACK:Full,ENDJOB
entry /store/data/Run2024I/EphemeralHLTPhysics5/RAW/v1/000/386/593/00000/545e47b2-a41e-46d6-a9e3-8c6d26fb3ea1.root
Warning: The default GeometryRecoDB_cff is being used; however, the DB geometry is not applied. You may need to verify your cmsDriver.
Step: L1REPACK Spec: ['Full']
# L1T INFO:  L1REPACK:Full will unpack all L1T inputs, re-emulated (Stage-2), and pack uGT, uGMT, and Calo Stage-2 output.
Step: ENDJOB Spec: 
# L1T INFO:  L1REPACK:Full will unpack all L1T inputs, re-emulated (Stage-2), and pack uGT, uGMT, and Calo Stage-2 output.
Expanded config file l1t_L1REPACK_Full_base.py created
TrigReport     1    1       1500         23       1477          0 L1TMonitorPath1
TrigReport     1    2       1500          2       1498          0 L1TMonitorPath2
```

Output post-PR.
```bash
L1REPACK:Full,ENDJOB
entry /store/data/Run2024I/EphemeralHLTPhysics5/RAW/v1/000/386/593/00000/545e47b2-a41e-46d6-a9e3-8c6d26fb3ea1.root
Warning: The default GeometryRecoDB_cff is being used; however, the DB geometry is not applied. You may need to verify your cmsDriver.
Step: L1REPACK Spec: ['Full']
# L1T INFO:  L1REPACK:Full will unpack all L1T inputs, re-emulated (Stage-2), and pack uGT, uGMT, and Calo Stage-2 output.
Step: ENDJOB Spec: 
# L1T INFO:  L1REPACK:Full will unpack all L1T inputs, re-emulated (Stage-2), and pack uGT, uGMT, and Calo Stage-2 output.
Expanded config file l1t_L1REPACK_Full_base.py created
TrigReport     1    1       1500         23       1477          0 L1TMonitorPath1
TrigReport     1    2       1500         23       1477          0 L1TMonitorPath2
```

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

To be backported to `15_0_X` for trigger studies.
