### PR TITLE
[ASAN][GCC14]Check iterators in CTPPSProtonReconstructionPlotter

### DIFF
--- a/Validation/CTPPS/plugins/CTPPSProtonReconstructionPlotter.cc
+++ b/Validation/CTPPS/plugins/CTPPSProtonReconstructionPlotter.cc
@@ -701,6 +701,9 @@ void CTPPSProtonReconstructionPlotter::analyze(const edm::Event &event, const ed
     if (!proton.validFit())
       continue;
 
+    if (proton.contributingLocalTracks().begin() == proton.contributingLocalTracks().end()) {
+      continue;
+    }
     CTPPSDetId rpId((*proton.contributingLocalTracks().begin())->rpId());
     unsigned int armId = rpId.arm();
     const auto &pl = multiRPPlots_[armId];


### PR DESCRIPTION
This is third time that ASAN build failed with error https://github.com/cms-sw/cmssw/issues/45991 . 
Just like https://github.com/cms-sw/cmssw/pull/46047 , is adds a check for validity of iterator in this class
