### PR TITLE
LST pixelSeeds Eta Name Correction

### DIFF
--- a/RecoTracker/LSTCore/src/alpaka/PixelTriplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/PixelTriplet.h
@@ -793,7 +793,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                               pixelRadius,
                                               pixelRadiusError,
                                               rzChiSquared,
-                                              pixelSegments.eta()[pixelSegmentArrayIndex],
+                                              pixelSeeds.eta()[pixelSegmentArrayIndex],
                                               pixelSegmentPt)) {
       return false;
     }


### PR DESCRIPTION
#### PR description:

Small naming correction PR to (https://github.com/cms-sw/cmssw/pull/47995) since (https://github.com/cms-sw/cmssw/pull/47793) was merged in shortly before my PR  and changed eta to the pixelSeeds SoA from the pixelSegments SoA.

#### PR validation:

I verified that this PR fixes a compilation error for LST that says pixelSegments does not have a field eta due to a naming change in a previous PR. The code compiles in the standalone config now and runs as expected.