### PR TITLE
follow-up: reduction of memory allocation in string manipulation in SiStrip DQM

### DIFF
--- a/DQM/SiStripCommon/interface/SiStripFolderOrganizer.h
+++ b/DQM/SiStripCommon/interface/SiStripFolderOrganizer.h
@@ -89,6 +89,7 @@ public:
   // SubDetector Folder
   void getSubDetFolder(const uint32_t& detid, const TrackerTopology* tTopo, std::string& folder_name);
   std::pair<std::string, std::string_view> getSubDetFolderAndTag(const uint32_t& detid, const TrackerTopology* tTopo);
+  const std::string_view getSubDetTag(const uint32_t& detid, const TrackerTopology* tTopo);
 
   SiStripFolderOrganizer(const SiStripFolderOrganizer&) = delete;                   // stop default
   const SiStripFolderOrganizer& operator=(const SiStripFolderOrganizer&) = delete;  // stop default
@@ -96,5 +97,7 @@ public:
 private:
   std::string TopFolderName;
   DQMStore* dbe_;
+
+  std::pair<std::string_view, std::string_view> getSubdetStrings(const uint32_t& detid, const TrackerTopology* tTopo);
 };
 #endif

--- a/DQM/SiStripCommon/src/SiStripHistoId.cc
+++ b/DQM/SiStripCommon/src/SiStripHistoId.cc
@@ -13,6 +13,7 @@
 #include <iostream>
 #include <sstream>
 #include <cstdio>
+#include <fmt/format.h>
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DQM/SiStripCommon/interface/SiStripHistoId.h"
@@ -79,7 +80,7 @@ std::string SiStripHistoId::createHistoLayer(std::string description,
 }
 
 // std::string SiStripHistoId::getSubdetid(uint32_t id, const TrackerTopology* tTopo, bool flag_ring, bool flag_thickness) {
-std::string SiStripHistoId::getSubdetid(uint32_t id, const TrackerTopology *tTopo, bool flag_ring) {
+std::string SiStripHistoId::getSubdetid(uint32_t id, const TrackerTopology* tTopo, bool flag_ring) {
   StripSubdetector subdet(id);
 
   if (subdet.subdetId() == StripSubdetector::TIB) {
@@ -87,30 +88,30 @@ std::string SiStripHistoId::getSubdetid(uint32_t id, const TrackerTopology *tTop
     return "TIB__layer__" + std::to_string(tTopo->tibLayer(id));
   } else if (subdet.subdetId() == StripSubdetector::TID) {
     // ---------------------------  TID  --------------------------- //
-    std::string side = (tTopo->tidSide(id) == 1) ? "MINUS" : "PLUS";
+    const char* side = (tTopo->tidSide(id) == 1) ? "MINUS" : "PLUS";
 
     if (flag_ring)
-      return "TID__" + side + "__ring__" + std::to_string(tTopo->tidRing(id));
+      return fmt::format("TID__{}__ring__{}", side, tTopo->tidRing(id));
     else
-      return "TID__" + side + "__wheel__" + std::to_string(tTopo->tidWheel(id));
+      return fmt::format("TID__{}__wheel__{}", side, tTopo->tidWheel(id));
   } else if (subdet.subdetId() == StripSubdetector::TOB) {
     // ---------------------------  TOB  --------------------------- //
     return "TOB__layer__" + std::to_string(tTopo->tobLayer(id));
   } else if (subdet.subdetId() == StripSubdetector::TEC) {
     // ---------------------------  TEC  --------------------------- //
-    std::string side = (tTopo->tecSide(id) == 1) ? "MINUS" : "PLUS";
+    const char* side = (tTopo->tecSide(id) == 1) ? "MINUS" : "PLUS";
 
     if (flag_ring) {
-      return "TEC__" + side + "__ring__" + std::to_string(tTopo->tecRing(id));
+      return fmt::format("TEC__{}__ring__{}", side, tTopo->tecRing(id));
     } else {
       /*
       if (flag_thickness) {
         uint32_t ring = tTopo->tecRing(id);
         std::string thickness = (ring >= 1 && ring <= 4) ? "__THIN" : "__THICK";
-        return "TEC__" + side + "__wheel__" + std::to_string(tTopo->tecWheel(id)) + thickness;
+	return fmt::format("TEC__{}__wheel__{}{}", side, tTopo->tecWheel(id), thickness);
       } else
       */
-      return "TEC__" + side + "__wheel__" + std::to_string(tTopo->tecWheel(id));
+      return fmt::format("TEC__{}__wheel__{}", side, tTopo->tecWheel(id));
     }
   } else {
     // ---------------------------  ???  --------------------------- //

--- a/DQM/SiStripMonitorDigi/src/SiStripMonitorDigi.cc
+++ b/DQM/SiStripMonitorDigi/src/SiStripMonitorDigi.cc
@@ -830,33 +830,33 @@ void SiStripMonitorDigi::analyze(const edm::Event& iEvent, const edm::EventSetup
 
   for (auto& it : SubDetMEsMap) {
     if (subdetswitchtotdigifailureon) {
-      if (strcmp(it.first.data(), "TEC__MINUS") == 0) {
+      if (it.first == "TEC__MINUS") {
         digiFailureMEs.SubDetTotDigiProfLS->Fill(1, it.second.totNDigis);
-      } else if (strcmp(it.first.data(), "TEC__PLUS") == 0) {
+      } else if (it.first == "TEC__PLUS") {
         digiFailureMEs.SubDetTotDigiProfLS->Fill(2, it.second.totNDigis);
-      } else if (strcmp(it.first.data(), "TIB") == 0) {
+      } else if (it.first == "TIB") {
         digiFailureMEs.SubDetTotDigiProfLS->Fill(3, it.second.totNDigis);
-      } else if (strcmp(it.first.data(), "TID__MINUS") == 0) {
+      } else if (it.first == "TID__MINUS") {
         digiFailureMEs.SubDetTotDigiProfLS->Fill(4, it.second.totNDigis);
-      } else if (strcmp(it.first.data(), "TID__PLUS") == 0) {
+      } else if (it.first == "TID__PLUS") {
         digiFailureMEs.SubDetTotDigiProfLS->Fill(5, it.second.totNDigis);
-      } else if (strcmp(it.first.data(), "TOB") == 0) {
+      } else if (it.first == "TOB") {
         digiFailureMEs.SubDetTotDigiProfLS->Fill(6, it.second.totNDigis);
       }
     }
 
     if (globalsummaryapvshotson) {
-      if (strcmp(it.first.data(), "TEC__MINUS") == 0) {
+      if (it.first == "TEC__MINUS") {
         NApvShotsGlobalProf->Fill(1, it.second.SubDetApvShots.size());
-      } else if (strcmp(it.first.data(), "TEC__PLUS") == 0) {
+      } else if (it.first == "TEC__PLUS") {
         NApvShotsGlobalProf->Fill(2, it.second.SubDetApvShots.size());
-      } else if (strcmp(it.first.data(), "TIB") == 0) {
+      } else if (it.first == "TIB") {
         NApvShotsGlobalProf->Fill(3, it.second.SubDetApvShots.size());
-      } else if (strcmp(it.first.data(), "TID__MINUS") == 0) {
+      } else if (it.first == "TID__MINUS") {
         NApvShotsGlobalProf->Fill(4, it.second.SubDetApvShots.size());
-      } else if (strcmp(it.first.data(), "TID__PLUS") == 0) {
+      } else if (it.first == "TID__PLUS") {
         NApvShotsGlobalProf->Fill(5, it.second.SubDetApvShots.size());
-      } else if (strcmp(it.first.data(), "TOB") == 0) {
+      } else if (it.first == "TOB") {
         NApvShotsGlobalProf->Fill(6, it.second.SubDetApvShots.size());
       }
     }
@@ -922,9 +922,8 @@ void SiStripMonitorDigi::analyze(const edm::Event& iEvent, const edm::EventSetup
     long long tbx = event_history->absoluteBX();
 
     for (auto& it : SubDetMEsMap) {
-      SubDetMEs subdetmes;
       const auto& subdet = std::string(it.first);
-      subdetmes = it.second;
+      SubDetMEs& subdetmes = it.second;
 
       int the_phase = APVCyclePhaseCollection::invalid;
       long long tbx_corr = tbx;

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -731,19 +731,19 @@ void SiStripMonitorTrack::bookSubDetMEs(DQMStore::IBooker& ibooker, std::string_
   theSubDetMEs.nClustersOffTrack->setAxisTitle(axisName);
 
   double xmaximum = 0;
-  if (sname.find("TIB") != std::string::npos) {
+  if (sname.find("TIB") != std::string_view::npos) {
     xmaximum = 40000.0;
     theSubDetMEs.nClustersOffTrack->setAxisRange(0.0, xmaximum, 1);
   }
-  if (sname.find("TOB") != std::string::npos) {
+  if (sname.find("TOB") != std::string_view::npos) {
     xmaximum = 40000.0;
     theSubDetMEs.nClustersOffTrack->setAxisRange(0.0, xmaximum, 1);
   }
-  if (sname.find("TID") != std::string::npos) {
+  if (sname.find("TID") != std::string_view::npos) {
     xmaximum = 10000.0;
     theSubDetMEs.nClustersOffTrack->setAxisRange(0.0, xmaximum, 1);
   }
-  if (sname.find("TEC") != std::string::npos) {
+  if (sname.find("TEC") != std::string_view::npos) {
     xmaximum = 40000.0;
     theSubDetMEs.nClustersOffTrack->setAxisRange(0.0, xmaximum, 1);
   }
@@ -1334,7 +1334,7 @@ SiStripMonitorTrack::Det2MEs SiStripMonitorTrack::findMEs(const TrackerTopology*
 
   std::string layer_id = hidmanager1.getSubdetid(detid, tTopo, false);
   std::string ring_id = hidmanager1.getSubdetid(detid, tTopo, true);
-  std::string_view sdet_tag = folderOrganizer_.getSubDetFolderAndTag(detid, tTopo).second;
+  const std::string_view sdet_tag = folderOrganizer_.getSubDetTag(detid, tTopo);
 
   Det2MEs me;
   me.iLayer = nullptr;


### PR DESCRIPTION
#### PR description:

This is a follow-up to https://github.com/cms-sw/cmssw/pull/48026, in particular to the review at https://github.com/cms-sw/cmssw/pull/48026#pullrequestreview-2822371547, addressing the remaining comments.

#### PR validation:

`runTheMatrix.py -l 11634.0 -t 4 -j 8` runs fine

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but if accepted it will be backported together with https://github.com/cms-sw/cmssw/pull/48026 to 15.0.X for 2025 data-taking purposes