### PR TITLE
[L1T] Fixing a bug where an empty SimVertex collection would crash the L1TrackObjectNtupleMaker (Phase2)

### DIFF
--- a/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker.cc
+++ b/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker.cc
@@ -2391,8 +2391,12 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
   }
 
   if (SimVertexHandle.isValid()) {
-    const SimVertex simPVh = *(SimVertexHandle->begin());
-    m_pv_MC->push_back(simPVh.position().z());
+    if (!SimVertexHandle->empty()) {
+      const SimVertex simPVh = *(SimVertexHandle->begin());
+      m_pv_MC->push_back(simPVh.position().z());
+    } else {
+      edm::LogWarning("MissingCollectionEntries") << "\nWarning: SimVertex collection is empty!" << std::endl;
+    }
   } else {
     edm::LogWarning("DataNotFound") << "\nWarning: SimVertexHandle not found in the event" << std::endl;
   }


### PR DESCRIPTION
#### PR description:

This PR resolves https://github.com/cms-sw/cmssw/issues/47791.

#### PR validation:
Running the L1TrackObjectNtupleMaker over 40 events of `/store/mc/Phase2Spring24DIGIRECOMiniAOD/MinBias_TuneCP5_14TeV-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200ALCA_140X_mcRun4_realistic_v4-v2/120000/004dd3c5-29c9-4283-95f3-baf57220dce2.root` would crash with something like:
```
Begin processing the 35th record. Run 1, Event 202842, LumiSection 1273 on stream 0 at 09-May-2025 21:27:06.267 CEST
A fatal system signal has occurred: segmentation violation
The following is the call stack containing the origin of the signal.
...
```
After adding this protection, now at the same event we get:
```
Begin processing the 35th record. Run 1, Event 202842, LumiSection 1273 on stream 0 at 09-May-2025 21:39:41.552 CEST
%MSG-w MissingCollectionEntries:  L1TrackObjectNtupleMaker:L1TrackNtuple  09-May-2025 21:39:44 CEST Run: 1 Event: 202842

Warning: SimVertex collection is empty!
%MSG
```


Ran:
```
scram build code-checks
scram build code-format
```