### PR TITLE
use unpacked HCAL TPs for L1T-ZDC sums in `L1TReEmulFromRAW`

### DIFF
--- a/L1Trigger/Configuration/python/customiseReEmul.py
+++ b/L1Trigger/Configuration/python/customiseReEmul.py
@@ -1,7 +1,8 @@
-
 import FWCore.ParameterSet.Config as cms
+
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 from Configuration.Eras.Modifier_stage2L1Trigger_2017_cff import stage2L1Trigger_2017
+from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 
 def L1TCaloStage2ParamsForHW(process):
@@ -186,7 +187,6 @@ def L1TReEmulFromRAW2016(process):
 
 def L1TReEmulFromRAW(process):
     L1TReEmulFromRAW2016(process)
-    
 
     stage2L1Trigger_2017.toModify(process.simOmtfDigis,
         srcRPC   = 'omtfStage2Digis',
@@ -222,6 +222,10 @@ def L1TReEmulFromRAW(process):
     run3_GEM.toModify(process.simBmtfDigis,
         DTDigi_Source       = 'bmtfDigis',
         DTDigi_Theta_Source = 'bmtfDigis'
+    )
+
+    stage2L1Trigger_2021.toModify(process.l1tZDCEtSums,
+        hcalTPDigis = 'hcalDigis'
     )
 
     print("# L1TReEmul sequence:  ")


### PR DESCRIPTION
#### PR description:

This PR is a follow-up to #45712. In the latter, I did not update accordingly the customisation function `L1TReEmulFromRAW`, which is the one often used for L1T-DPG studies offline. For more context, see https://github.com/cms-sw/cmssw/issues/47925#issuecomment-2864575806.

#### PR validation:

Using the example below, one can see that without this PR the ZDC seeds do not accept any events when their results are based on the L1T re-emulation (as opposed to the trigger decisions in data from firmware). After including this PR, the trigger-accept counts of the ZDC seeds become different from zero, although in some cases they do not match exactly the decisions from firmware. This residual disagreement might be related to #43214, and fixing it is beyond the scope of this PR.

```bash
#!/bin/bash

cmsDriver.py bar \
 --no_output --no_exec --dump_python -n 1000 \
 --filein /store/group/tsg/STORM/RAW/Run2024J_HIEphemeralHLTPhysics_run387440/235844d9-333c-43a9-9c92-b1ce47ce19d1.root \
 --era Run3_2024 --data --conditions 150X_dataRun3_HLT_v1 \
 -s RAW2DIGI --python_filename l1t_L1TReEmulFromRAW_cfg.py \
 --customise L1Trigger/Configuration/customiseReEmul.L1TReEmulFromRAW

cat <<@EOF >> l1t_L1TReEmulFromRAW_cfg.py

process.options.numberOfThreads = 1
process.options.numberOfStreams = 0

process.options.wantSummary = True
process.MessageLogger.L1TGlobalSummary = cms.untracked.PSet()

process.l1tGtStage2Digis1 = cms.EDProducer( "L1TRawToDigi",
    FedIds = cms.vint32( 1404 ),
    Setup = cms.string( "stage2::GTSetup" ),
    FWId = cms.uint32( 0 ),
    DmxFWId = cms.uint32( 0 ),
    FWOverride = cms.bool( False ),
    TMTCheck = cms.bool( True ),
    CTP7 = cms.untracked.bool( False ),
    MTF7 = cms.untracked.bool( False ),
    InputLabel = cms.InputTag( "rawDataCollector::@skipCurrentProcess" ),
    lenSlinkHeader = cms.untracked.int32( 8 ),
    lenSlinkTrailer = cms.untracked.int32( 8 ),
    lenAMCHeader = cms.untracked.int32( 8 ),
    lenAMCTrailer = cms.untracked.int32( 0 ),
    lenAMC13Header = cms.untracked.int32( 8 ),
    lenAMC13Trailer = cms.untracked.int32( 8 ),
    debug = cms.untracked.bool( False ),
    MinFeds = cms.uint32( 0 )
)

process.l1tGlobalSummary1 = cms.EDAnalyzer( "L1TGlobalSummary",
    AlgInputTag = cms.InputTag( "l1tGtStage2Digis1" ),
    ExtInputTag = cms.InputTag( "l1tGtStage2Digis1" ),
    MinBx = cms.int32( 0 ),
    MaxBx = cms.int32( 0 ),
    DumpTrigResults = cms.bool( False ),
    DumpRecord = cms.bool( False ),
    DumpTrigSummary = cms.bool( True ),
    ReadPrescalesFromFile = cms.bool( False ),
    psFileName = cms.string( "" ),
    psColumn = cms.int32( 0 )
)

process.l1tGlobalSummary2 = process.l1tGlobalSummary1.clone(
    AlgInputTag = "simGtStage2Digis::@currentProcess",
    ExtInputTag = "simGtStage2Digis::@currentProcess",
)

process.L1TMonitorPath = cms.Path(
    process.l1tGtStage2Digis1
  + process.l1tGlobalSummary1
  + process.l1tGlobalSummary2
)

process.schedule.append( process.L1TMonitorPath )
@EOF

cmsRun l1t_L1TReEmulFromRAW_cfg.py &> l1t_L1TReEmulFromRAW_cfg.log
grep L1_ZDC l1t_L1TReEmulFromRAW_cfg.log
```

Output pre-PR.
```
RAW2DIGI,ENDJOB
entry /store/group/tsg/STORM/RAW/Run2024J_HIEphemeralHLTPhysics_run387440/235844d9-333c-43a9-9c92-b1ce47ce19d1.root
Warning: The default GeometryRecoDB_cff is being used; however, the DB geometry is not applied. You may need to verify your cmsDriver.
Step: RAW2DIGI Spec: 
Step: ENDJOB Spec: 
customising the process with L1TReEmulFromRAW from L1Trigger/Configuration/customiseReEmul
# L1TReEmul sequence:  
# simEcalTriggerPrimitiveDigis+simHcalTriggerPrimitiveDigis,simCaloStage2Layer1Digis,simCaloStage2Layer1Summary,simCaloStage2Digis,simMuonGEMPadDigis,simMuonGEMPadDigiClusters,simDtTriggerPrimitiveDigis,simCscTriggerPrimitiveDigis,simTwinMuxDigis,simBmtfDigis,simKBmtfStubs,simKBmtfDigis,simEmtfDigis,simOmtfDigis,simGmtCaloSumDigis,simGmtStage2Digis,simEmtfShowers,simGmtShowerDigis,simCscTriggerPrimitiveDigisRun3,simGtExtFakeStage2Digis,l1tZDCEtSums,simGtStage2Digis
# cms.Schedule(*[ process.raw2digi_step, process.endjob_step, process.L1TReEmulPath ], tasks=[process.patAlgosToolsTask])

# L1TReEmul sequence:  
# simEcalTriggerPrimitiveDigis+simHcalTriggerPrimitiveDigis,simCaloStage2Layer1Digis,simCaloStage2Layer1Summary,simCaloStage2Digis,simMuonGEMPadDigis,simMuonGEMPadDigiClusters,simDtTriggerPrimitiveDigis,simCscTriggerPrimitiveDigis,simTwinMuxDigis,simBmtfDigis,simKBmtfStubs,simKBmtfDigis,simEmtfDigis,simOmtfDigis,simGmtCaloSumDigis,simGmtStage2Digis,simEmtfShowers,simGmtShowerDigis,simCscTriggerPrimitiveDigisRun3,simGtExtFakeStage2Digis,l1tZDCEtSums,simGtStage2Digis
# cms.Schedule(*[ process.raw2digi_step, process.endjob_step, process.L1TReEmulPath ], tasks=[process.patAlgosToolsTask])

Expanded config file l1t_L1TReEmulFromRAW_cfg.py created
      67   L1_ZDC1n_OR_MinimumBiasHF1_AND_BptxAND_copy         2      2      0         0          0
      68   L1_ZDC2n_OR_MinimumBiasHF1_AND_BptxAND_copy         2      2      0         0          0
     272     L1_ZDC1n_OR_MinimumBiasHF1_AND_BptxAND         2      2      2         1          0
     273   L1_ZDC1n_Bkp1_OR_MinimumBiasHF1_AND_BptxAND         2      2      0         0          0
     274   L1_ZDC1n_Bkp2_OR_MinimumBiasHF1_AND_BptxAND         2      2      0         0          0
     275   L1_ZDC1n_Bkp3_OR_MinimumBiasHF1_AND_BptxAND         2      2      0         0          0
     276     L1_ZDC2n_OR_MinimumBiasHF1_AND_BptxAND         2      2      2         1          0
     277   L1_ZDC2n_Bkp1_OR_MinimumBiasHF1_AND_BptxAND         2      2      0         0          0
     278   L1_ZDC2n_Bkp2_OR_MinimumBiasHF1_AND_BptxAND         2      2      0         0          0
     279   L1_ZDC2n_Bkp3_OR_MinimumBiasHF1_AND_BptxAND         2      2      0         0          0
     280     L1_ZDC3n_OR_MinimumBiasHF1_AND_BptxAND         2      2      0         0          0
     281   L1_ZDC3n_Bkp1_OR_MinimumBiasHF1_AND_BptxAND         2      2      0         0          0
     282   L1_ZDC3n_Bkp2_OR_MinimumBiasHF1_AND_BptxAND         2      2      0         0          0
     283   L1_ZDC3n_Bkp3_OR_MinimumBiasHF1_AND_BptxAND         2      2      0         0          0
     284    L1_ZDC1n_AND_MinimumBiasHF1_AND_BptxAND         2      2      0         0          0
     285   L1_ZDC1n_Bkp1_AND_MinimumBiasHF1_AND_BptxAND         2      2      0         0          0
     286   L1_ZDC1n_Bkp2_AND_MinimumBiasHF1_AND_BptxAND         2      2      0         0          0
     287   L1_ZDC1n_Bkp3_AND_MinimumBiasHF1_AND_BptxAND         2      2      0         0          0
     290     L1_ZDC1n_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     291   L1_ZDC1n_Bkp1_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     292   L1_ZDC1n_Bkp2_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     293   L1_ZDC1n_Bkp3_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     294     L1_ZDC2n_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     295   L1_ZDC2n_Bkp1_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     296   L1_ZDC2n_Bkp2_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     297   L1_ZDC2n_Bkp3_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     298     L1_ZDC3n_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     299   L1_ZDC3n_Bkp1_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     300   L1_ZDC3n_Bkp2_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     301   L1_ZDC3n_Bkp3_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     302    L1_ZDC1n_AND_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     303   L1_ZDC1n_Bkp1_AND_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     304   L1_ZDC1n_Bkp2_AND_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     305   L1_ZDC1n_Bkp3_AND_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     307                        L1_ZDC1n_OR_BptxAND       171    171    171         1          0
     308                   L1_ZDC1n_Bkp1_OR_BptxAND       171    171      0         0          0
     309    L1_ZDC1n_XOR_MinimumBiasHF1_AND_BptxAND         0      0      0         1          0
     310   L1_ZDC1n_Bkp1_XOR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     311   L1_ZDC1n_Bkp2_XOR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     312   L1_ZDC1n_Bkp3_XOR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     313   L1_ZDC1n_AsymXOR_MinimumBiasHF1_AND_BptxAND         0      0      0         1          0
     314   L1_ZDC1n_Bkp1_AsymXOR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     315   L1_ZDC1n_Bkp2_AsymXOR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     316    L1_ZDC1n_XOR_MinimumBiasHF2_AND_BptxAND         0      0      0         1          0
     317   L1_ZDC1n_Bkp1_XOR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     318   L1_ZDC1n_Bkp2_XOR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     319   L1_ZDC1n_AsymXOR_MinimumBiasHF2_AND_BptxAND         0      0      0         1          0
     320   L1_ZDC1n_Bkp1_AsymXOR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     321   L1_ZDC1n_Bkp2_AsymXOR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     341                                  L1_ZDCP14        89     89      0         0          0
     342                          L1_ZDCP14_BptxAND        89     89      0         0          0
     343                                  L1_ZDCM14        96     96      0         0          0
     344                          L1_ZDCM14_BptxAND        96     96      0         0          0
     345                               L1_ZDC14_AND        14     14      0         0          0
     346                       L1_ZDC14_AND_BptxAND        14     14      0         0          0
     347                                L1_ZDC14_OR       171    171      0         0          0
     348                        L1_ZDC14_OR_BptxAND       171    171      0         0          0
     349                                  L1_ZDCP16        89     89      0         0          0
     350                          L1_ZDCP16_BptxAND        89     89      0         0          0
     351                                  L1_ZDCM16        96     96      0         0          0
     352                          L1_ZDCM16_BptxAND        96     96      0         0          0
     353                               L1_ZDC16_AND        14     14      0         0          0
     354                       L1_ZDC16_AND_BptxAND        14     14      0         0          0
     355                                L1_ZDC16_OR       171    171      0         0          0
     356                        L1_ZDC16_OR_BptxAND       171    171      0         0          0
     357                                  L1_ZDCP18        89     89      0         0          0
     358                          L1_ZDCP18_BptxAND        89     89      0         0          0
     359                                  L1_ZDCM18        96     96      0         0          0
     360                          L1_ZDCM18_BptxAND        96     96      0         0          0
     361                               L1_ZDC18_AND        14     14      0         0          0
     362                       L1_ZDC18_AND_BptxAND        14     14      0         0          0
     363                                L1_ZDC18_OR       171    171      0         0          0
     364                        L1_ZDC18_OR_BptxAND       171    171      0         0          0
     365                                  L1_ZDCP22        89     89      0         0          0
     366                          L1_ZDCP22_BptxAND        89     89      0         0          0
     367                                  L1_ZDCM22        96     96      0         0          0
     368                          L1_ZDCM22_BptxAND        96     96      0         0          0
     369                               L1_ZDC22_AND        14     14      0         0          0
     370                       L1_ZDC22_AND_BptxAND        14     14      0         0          0
     371                                L1_ZDC22_OR       171    171      0         0          0
     372                        L1_ZDC22_OR_BptxAND       171    171      0         0          0
     373                                  L1_ZDCP28        89     89      0         0          0
     374                          L1_ZDCP28_BptxAND        89     89      0         0          0
     375                                  L1_ZDCM28        96     96      0         0          0
     376                          L1_ZDCM28_BptxAND        96     96      0         0          0
     377                               L1_ZDC28_AND        14     14      0         0          0
     378                       L1_ZDC28_AND_BptxAND        14     14      0         0          0
     379                                L1_ZDC28_OR       171    171      0         0          0
     380                        L1_ZDC28_OR_BptxAND       171    171      0         0          0
     381          L1_ZDC1n_AND_AND_NotMBHF2_BptxAND        14     14     14         1          0
     382        L1_ZDC1n_AND_AND_NotMBHF2OR_BptxAND        14     14      0         0          0
     404   L1_ZDC1n_Bkp3_AsymXOR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     405   L1_ZDC1n_Bkp3_XOR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     412   L1_ZDC1n_Bkp3_AsymXOR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     502                 L1_ZDC1n_OR_RapGap_BptxAND         0      0      0         0          0
      67   L1_ZDC1n_OR_MinimumBiasHF1_AND_BptxAND_copy         0      0      0         0          0
      68   L1_ZDC2n_OR_MinimumBiasHF1_AND_BptxAND_copy         0      0      0         0          0
     272     L1_ZDC1n_OR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     273   L1_ZDC1n_Bkp1_OR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     274   L1_ZDC1n_Bkp2_OR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     275   L1_ZDC1n_Bkp3_OR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     276     L1_ZDC2n_OR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     277   L1_ZDC2n_Bkp1_OR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     278   L1_ZDC2n_Bkp2_OR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     279   L1_ZDC2n_Bkp3_OR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     280     L1_ZDC3n_OR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     281   L1_ZDC3n_Bkp1_OR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     282   L1_ZDC3n_Bkp2_OR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     283   L1_ZDC3n_Bkp3_OR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     284    L1_ZDC1n_AND_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     285   L1_ZDC1n_Bkp1_AND_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     286   L1_ZDC1n_Bkp2_AND_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     287   L1_ZDC1n_Bkp3_AND_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     290     L1_ZDC1n_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     291   L1_ZDC1n_Bkp1_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     292   L1_ZDC1n_Bkp2_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     293   L1_ZDC1n_Bkp3_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     294     L1_ZDC2n_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     295   L1_ZDC2n_Bkp1_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     296   L1_ZDC2n_Bkp2_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     297   L1_ZDC2n_Bkp3_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     298     L1_ZDC3n_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     299   L1_ZDC3n_Bkp1_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     300   L1_ZDC3n_Bkp2_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     301   L1_ZDC3n_Bkp3_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     302    L1_ZDC1n_AND_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     303   L1_ZDC1n_Bkp1_AND_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     304   L1_ZDC1n_Bkp2_AND_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     305   L1_ZDC1n_Bkp3_AND_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     307                        L1_ZDC1n_OR_BptxAND         0      0      0         0          0
     308                   L1_ZDC1n_Bkp1_OR_BptxAND         0      0      0         0          0
     309    L1_ZDC1n_XOR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     310   L1_ZDC1n_Bkp1_XOR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     311   L1_ZDC1n_Bkp2_XOR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     312   L1_ZDC1n_Bkp3_XOR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     313   L1_ZDC1n_AsymXOR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     314   L1_ZDC1n_Bkp1_AsymXOR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     315   L1_ZDC1n_Bkp2_AsymXOR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     316    L1_ZDC1n_XOR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     317   L1_ZDC1n_Bkp1_XOR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     318   L1_ZDC1n_Bkp2_XOR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     319   L1_ZDC1n_AsymXOR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     320   L1_ZDC1n_Bkp1_AsymXOR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     321   L1_ZDC1n_Bkp2_AsymXOR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     341                                  L1_ZDCP14         0      0      0         0          0
     342                          L1_ZDCP14_BptxAND         0      0      0         0          0
     343                                  L1_ZDCM14         0      0      0         0          0
     344                          L1_ZDCM14_BptxAND         0      0      0         0          0
     345                               L1_ZDC14_AND         0      0      0         0          0
     346                       L1_ZDC14_AND_BptxAND         0      0      0         0          0
     347                                L1_ZDC14_OR         0      0      0         0          0
     348                        L1_ZDC14_OR_BptxAND         0      0      0         0          0
     349                                  L1_ZDCP16         0      0      0         0          0
     350                          L1_ZDCP16_BptxAND         0      0      0         0          0
     351                                  L1_ZDCM16         0      0      0         0          0
     352                          L1_ZDCM16_BptxAND         0      0      0         0          0
     353                               L1_ZDC16_AND         0      0      0         0          0
     354                       L1_ZDC16_AND_BptxAND         0      0      0         0          0
     355                                L1_ZDC16_OR         0      0      0         0          0
     356                        L1_ZDC16_OR_BptxAND         0      0      0         0          0
     357                                  L1_ZDCP18         0      0      0         0          0
     358                          L1_ZDCP18_BptxAND         0      0      0         0          0
     359                                  L1_ZDCM18         0      0      0         0          0
     360                          L1_ZDCM18_BptxAND         0      0      0         0          0
     361                               L1_ZDC18_AND         0      0      0         0          0
     362                       L1_ZDC18_AND_BptxAND         0      0      0         0          0
     363                                L1_ZDC18_OR         0      0      0         0          0
     364                        L1_ZDC18_OR_BptxAND         0      0      0         0          0
     365                                  L1_ZDCP22         0      0      0         0          0
     366                          L1_ZDCP22_BptxAND         0      0      0         0          0
     367                                  L1_ZDCM22         0      0      0         0          0
     368                          L1_ZDCM22_BptxAND         0      0      0         0          0
     369                               L1_ZDC22_AND         0      0      0         0          0
     370                       L1_ZDC22_AND_BptxAND         0      0      0         0          0
     371                                L1_ZDC22_OR         0      0      0         0          0
     372                        L1_ZDC22_OR_BptxAND         0      0      0         0          0
     373                                  L1_ZDCP28         0      0      0         0          0
     374                          L1_ZDCP28_BptxAND         0      0      0         0          0
     375                                  L1_ZDCM28         0      0      0         0          0
     376                          L1_ZDCM28_BptxAND         0      0      0         0          0
     377                               L1_ZDC28_AND         0      0      0         0          0
     378                       L1_ZDC28_AND_BptxAND         0      0      0         0          0
     379                                L1_ZDC28_OR         0      0      0         0          0
     380                        L1_ZDC28_OR_BptxAND         0      0      0         0          0
     381          L1_ZDC1n_AND_AND_NotMBHF2_BptxAND         0      0      0         0          0
     382        L1_ZDC1n_AND_AND_NotMBHF2OR_BptxAND         0      0      0         0          0
     404   L1_ZDC1n_Bkp3_AsymXOR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     405   L1_ZDC1n_Bkp3_XOR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     412   L1_ZDC1n_Bkp3_AsymXOR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     502                 L1_ZDC1n_OR_RapGap_BptxAND         0      0      0         0          0
```

Output post-PR.
```
RAW2DIGI,ENDJOB
entry /store/group/tsg/STORM/RAW/Run2024J_HIEphemeralHLTPhysics_run387440/235844d9-333c-43a9-9c92-b1ce47ce19d1.root
Warning: The default GeometryRecoDB_cff is being used; however, the DB geometry is not applied. You may need to verify your cmsDriver.
Step: RAW2DIGI Spec: 
Step: ENDJOB Spec: 
customising the process with L1TReEmulFromRAW from L1Trigger/Configuration/customiseReEmul
# L1TReEmul sequence:  
# simEcalTriggerPrimitiveDigis+simHcalTriggerPrimitiveDigis,simCaloStage2Layer1Digis,simCaloStage2Layer1Summary,simCaloStage2Digis,simMuonGEMPadDigis,simMuonGEMPadDigiClusters,simDtTriggerPrimitiveDigis,simCscTriggerPrimitiveDigis,simTwinMuxDigis,simBmtfDigis,simKBmtfStubs,simKBmtfDigis,simEmtfDigis,simOmtfDigis,simGmtCaloSumDigis,simGmtStage2Digis,simEmtfShowers,simGmtShowerDigis,simCscTriggerPrimitiveDigisRun3,simGtExtFakeStage2Digis,l1tZDCEtSums,simGtStage2Digis
# cms.Schedule(*[ process.raw2digi_step, process.endjob_step, process.L1TReEmulPath ], tasks=[process.patAlgosToolsTask])

# L1TReEmul sequence:  
# simEcalTriggerPrimitiveDigis+simHcalTriggerPrimitiveDigis,simCaloStage2Layer1Digis,simCaloStage2Layer1Summary,simCaloStage2Digis,simMuonGEMPadDigis,simMuonGEMPadDigiClusters,simDtTriggerPrimitiveDigis,simCscTriggerPrimitiveDigis,simTwinMuxDigis,simBmtfDigis,simKBmtfStubs,simKBmtfDigis,simEmtfDigis,simOmtfDigis,simGmtCaloSumDigis,simGmtStage2Digis,simEmtfShowers,simGmtShowerDigis,simCscTriggerPrimitiveDigisRun3,simGtExtFakeStage2Digis,l1tZDCEtSums,simGtStage2Digis
# cms.Schedule(*[ process.raw2digi_step, process.endjob_step, process.L1TReEmulPath ], tasks=[process.patAlgosToolsTask])

Expanded config file l1t_L1TReEmulFromRAW_cfg.py created
      67   L1_ZDC1n_OR_MinimumBiasHF1_AND_BptxAND_copy         2      2      0         0          0
      68   L1_ZDC2n_OR_MinimumBiasHF1_AND_BptxAND_copy         2      2      0         0          0
     272     L1_ZDC1n_OR_MinimumBiasHF1_AND_BptxAND         2      2      2         1          0
     273   L1_ZDC1n_Bkp1_OR_MinimumBiasHF1_AND_BptxAND         2      2      0         0          0
     274   L1_ZDC1n_Bkp2_OR_MinimumBiasHF1_AND_BptxAND         2      2      0         0          0
     275   L1_ZDC1n_Bkp3_OR_MinimumBiasHF1_AND_BptxAND         2      2      0         0          0
     276     L1_ZDC2n_OR_MinimumBiasHF1_AND_BptxAND         2      2      2         1          0
     277   L1_ZDC2n_Bkp1_OR_MinimumBiasHF1_AND_BptxAND         2      2      0         0          0
     278   L1_ZDC2n_Bkp2_OR_MinimumBiasHF1_AND_BptxAND         2      2      0         0          0
     279   L1_ZDC2n_Bkp3_OR_MinimumBiasHF1_AND_BptxAND         2      2      0         0          0
     280     L1_ZDC3n_OR_MinimumBiasHF1_AND_BptxAND         2      2      0         0          0
     281   L1_ZDC3n_Bkp1_OR_MinimumBiasHF1_AND_BptxAND         2      2      0         0          0
     282   L1_ZDC3n_Bkp2_OR_MinimumBiasHF1_AND_BptxAND         2      2      0         0          0
     283   L1_ZDC3n_Bkp3_OR_MinimumBiasHF1_AND_BptxAND         2      2      0         0          0
     284    L1_ZDC1n_AND_MinimumBiasHF1_AND_BptxAND         2      2      0         0          0
     285   L1_ZDC1n_Bkp1_AND_MinimumBiasHF1_AND_BptxAND         2      2      0         0          0
     286   L1_ZDC1n_Bkp2_AND_MinimumBiasHF1_AND_BptxAND         2      2      0         0          0
     287   L1_ZDC1n_Bkp3_AND_MinimumBiasHF1_AND_BptxAND         2      2      0         0          0
     290     L1_ZDC1n_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     291   L1_ZDC1n_Bkp1_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     292   L1_ZDC1n_Bkp2_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     293   L1_ZDC1n_Bkp3_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     294     L1_ZDC2n_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     295   L1_ZDC2n_Bkp1_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     296   L1_ZDC2n_Bkp2_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     297   L1_ZDC2n_Bkp3_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     298     L1_ZDC3n_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     299   L1_ZDC3n_Bkp1_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     300   L1_ZDC3n_Bkp2_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     301   L1_ZDC3n_Bkp3_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     302    L1_ZDC1n_AND_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     303   L1_ZDC1n_Bkp1_AND_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     304   L1_ZDC1n_Bkp2_AND_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     305   L1_ZDC1n_Bkp3_AND_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     307                        L1_ZDC1n_OR_BptxAND       171    171    171         1          0
     308                   L1_ZDC1n_Bkp1_OR_BptxAND       171    171      0         0          0
     309    L1_ZDC1n_XOR_MinimumBiasHF1_AND_BptxAND         0      0      0         1          0
     310   L1_ZDC1n_Bkp1_XOR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     311   L1_ZDC1n_Bkp2_XOR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     312   L1_ZDC1n_Bkp3_XOR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     313   L1_ZDC1n_AsymXOR_MinimumBiasHF1_AND_BptxAND         0      0      0         1          0
     314   L1_ZDC1n_Bkp1_AsymXOR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     315   L1_ZDC1n_Bkp2_AsymXOR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     316    L1_ZDC1n_XOR_MinimumBiasHF2_AND_BptxAND         0      0      0         1          0
     317   L1_ZDC1n_Bkp1_XOR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     318   L1_ZDC1n_Bkp2_XOR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     319   L1_ZDC1n_AsymXOR_MinimumBiasHF2_AND_BptxAND         0      0      0         1          0
     320   L1_ZDC1n_Bkp1_AsymXOR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     321   L1_ZDC1n_Bkp2_AsymXOR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     341                                  L1_ZDCP14        89     89      0         0          0
     342                          L1_ZDCP14_BptxAND        89     89      0         0          0
     343                                  L1_ZDCM14        96     96      0         0          0
     344                          L1_ZDCM14_BptxAND        96     96      0         0          0
     345                               L1_ZDC14_AND        14     14      0         0          0
     346                       L1_ZDC14_AND_BptxAND        14     14      0         0          0
     347                                L1_ZDC14_OR       171    171      0         0          0
     348                        L1_ZDC14_OR_BptxAND       171    171      0         0          0
     349                                  L1_ZDCP16        89     89      0         0          0
     350                          L1_ZDCP16_BptxAND        89     89      0         0          0
     351                                  L1_ZDCM16        96     96      0         0          0
     352                          L1_ZDCM16_BptxAND        96     96      0         0          0
     353                               L1_ZDC16_AND        14     14      0         0          0
     354                       L1_ZDC16_AND_BptxAND        14     14      0         0          0
     355                                L1_ZDC16_OR       171    171      0         0          0
     356                        L1_ZDC16_OR_BptxAND       171    171      0         0          0
     357                                  L1_ZDCP18        89     89      0         0          0
     358                          L1_ZDCP18_BptxAND        89     89      0         0          0
     359                                  L1_ZDCM18        96     96      0         0          0
     360                          L1_ZDCM18_BptxAND        96     96      0         0          0
     361                               L1_ZDC18_AND        14     14      0         0          0
     362                       L1_ZDC18_AND_BptxAND        14     14      0         0          0
     363                                L1_ZDC18_OR       171    171      0         0          0
     364                        L1_ZDC18_OR_BptxAND       171    171      0         0          0
     365                                  L1_ZDCP22        89     89      0         0          0
     366                          L1_ZDCP22_BptxAND        89     89      0         0          0
     367                                  L1_ZDCM22        96     96      0         0          0
     368                          L1_ZDCM22_BptxAND        96     96      0         0          0
     369                               L1_ZDC22_AND        14     14      0         0          0
     370                       L1_ZDC22_AND_BptxAND        14     14      0         0          0
     371                                L1_ZDC22_OR       171    171      0         0          0
     372                        L1_ZDC22_OR_BptxAND       171    171      0         0          0
     373                                  L1_ZDCP28        89     89      0         0          0
     374                          L1_ZDCP28_BptxAND        89     89      0         0          0
     375                                  L1_ZDCM28        96     96      0         0          0
     376                          L1_ZDCM28_BptxAND        96     96      0         0          0
     377                               L1_ZDC28_AND        14     14      0         0          0
     378                       L1_ZDC28_AND_BptxAND        14     14      0         0          0
     379                                L1_ZDC28_OR       171    171      0         0          0
     380                        L1_ZDC28_OR_BptxAND       171    171      0         0          0
     381          L1_ZDC1n_AND_AND_NotMBHF2_BptxAND        14     14     14         1          0
     382        L1_ZDC1n_AND_AND_NotMBHF2OR_BptxAND        14     14      0         0          0
     404   L1_ZDC1n_Bkp3_AsymXOR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     405   L1_ZDC1n_Bkp3_XOR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     412   L1_ZDC1n_Bkp3_AsymXOR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     502                 L1_ZDC1n_OR_RapGap_BptxAND         0      0      0         0          0
      67   L1_ZDC1n_OR_MinimumBiasHF1_AND_BptxAND_copy         2      2      2         0          0
      68   L1_ZDC2n_OR_MinimumBiasHF1_AND_BptxAND_copy         2      2      2         0          0
     272     L1_ZDC1n_OR_MinimumBiasHF1_AND_BptxAND         2      2      2         0          0
     273   L1_ZDC1n_Bkp1_OR_MinimumBiasHF1_AND_BptxAND         2      2      2         0          0
     274   L1_ZDC1n_Bkp2_OR_MinimumBiasHF1_AND_BptxAND         2      2      2         0          0
     275   L1_ZDC1n_Bkp3_OR_MinimumBiasHF1_AND_BptxAND         2      2      2         0          0
     276     L1_ZDC2n_OR_MinimumBiasHF1_AND_BptxAND         2      2      2         0          0
     277   L1_ZDC2n_Bkp1_OR_MinimumBiasHF1_AND_BptxAND         2      2      2         0          0
     278   L1_ZDC2n_Bkp2_OR_MinimumBiasHF1_AND_BptxAND         2      2      2         0          0
     279   L1_ZDC2n_Bkp3_OR_MinimumBiasHF1_AND_BptxAND         2      2      2         0          0
     280     L1_ZDC3n_OR_MinimumBiasHF1_AND_BptxAND         2      2      2         0          0
     281   L1_ZDC3n_Bkp1_OR_MinimumBiasHF1_AND_BptxAND         2      2      2         0          0
     282   L1_ZDC3n_Bkp2_OR_MinimumBiasHF1_AND_BptxAND         2      2      2         0          0
     283   L1_ZDC3n_Bkp3_OR_MinimumBiasHF1_AND_BptxAND         2      2      2         0          0
     284    L1_ZDC1n_AND_MinimumBiasHF1_AND_BptxAND         2      2      2         0          0
     285   L1_ZDC1n_Bkp1_AND_MinimumBiasHF1_AND_BptxAND         2      2      2         0          0
     286   L1_ZDC1n_Bkp2_AND_MinimumBiasHF1_AND_BptxAND         2      2      2         0          0
     287   L1_ZDC1n_Bkp3_AND_MinimumBiasHF1_AND_BptxAND         2      2      2         0          0
     290     L1_ZDC1n_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     291   L1_ZDC1n_Bkp1_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     292   L1_ZDC1n_Bkp2_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     293   L1_ZDC1n_Bkp3_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     294     L1_ZDC2n_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     295   L1_ZDC2n_Bkp1_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     296   L1_ZDC2n_Bkp2_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     297   L1_ZDC2n_Bkp3_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     298     L1_ZDC3n_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     299   L1_ZDC3n_Bkp1_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     300   L1_ZDC3n_Bkp2_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     301   L1_ZDC3n_Bkp3_OR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     302    L1_ZDC1n_AND_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     303   L1_ZDC1n_Bkp1_AND_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     304   L1_ZDC1n_Bkp2_AND_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     305   L1_ZDC1n_Bkp3_AND_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     307                        L1_ZDC1n_OR_BptxAND       170    170    170         0          0
     308                   L1_ZDC1n_Bkp1_OR_BptxAND       170    170    170         0          0
     309    L1_ZDC1n_XOR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     310   L1_ZDC1n_Bkp1_XOR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     311   L1_ZDC1n_Bkp2_XOR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     312   L1_ZDC1n_Bkp3_XOR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     313   L1_ZDC1n_AsymXOR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     314   L1_ZDC1n_Bkp1_AsymXOR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     315   L1_ZDC1n_Bkp2_AsymXOR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     316    L1_ZDC1n_XOR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     317   L1_ZDC1n_Bkp1_XOR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     318   L1_ZDC1n_Bkp2_XOR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     319   L1_ZDC1n_AsymXOR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     320   L1_ZDC1n_Bkp1_AsymXOR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     321   L1_ZDC1n_Bkp2_AsymXOR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     341                                  L1_ZDCP14       116    116    116         0          0
     342                          L1_ZDCP14_BptxAND       116    116    116         0          0
     343                                  L1_ZDCM14        71     71     71         0          0
     344                          L1_ZDCM14_BptxAND        71     71     71         0          0
     345                               L1_ZDC14_AND        17     17     17         0          0
     346                       L1_ZDC14_AND_BptxAND        17     17     17         0          0
     347                                L1_ZDC14_OR       170    170    170         0          0
     348                        L1_ZDC14_OR_BptxAND       170    170    170         0          0
     349                                  L1_ZDCP16       116    116    116         0          0
     350                          L1_ZDCP16_BptxAND       116    116    116         0          0
     351                                  L1_ZDCM16        71     71     71         0          0
     352                          L1_ZDCM16_BptxAND        71     71     71         0          0
     353                               L1_ZDC16_AND        17     17     17         0          0
     354                       L1_ZDC16_AND_BptxAND        17     17     17         0          0
     355                                L1_ZDC16_OR       170    170    170         0          0
     356                        L1_ZDC16_OR_BptxAND       170    170    170         0          0
     357                                  L1_ZDCP18       116    116    116         0          0
     358                          L1_ZDCP18_BptxAND       116    116    116         0          0
     359                                  L1_ZDCM18        71     71     71         0          0
     360                          L1_ZDCM18_BptxAND        71     71     71         0          0
     361                               L1_ZDC18_AND        17     17     17         0          0
     362                       L1_ZDC18_AND_BptxAND        17     17     17         0          0
     363                                L1_ZDC18_OR       170    170    170         0          0
     364                        L1_ZDC18_OR_BptxAND       170    170    170         0          0
     365                                  L1_ZDCP22       116    116    116         0          0
     366                          L1_ZDCP22_BptxAND       116    116    116         0          0
     367                                  L1_ZDCM22        71     71     71         0          0
     368                          L1_ZDCM22_BptxAND        71     71     71         0          0
     369                               L1_ZDC22_AND        17     17     17         0          0
     370                       L1_ZDC22_AND_BptxAND        17     17     17         0          0
     371                                L1_ZDC22_OR       170    170    170         0          0
     372                        L1_ZDC22_OR_BptxAND       170    170    170         0          0
     373                                  L1_ZDCP28       116    116    116         0          0
     374                          L1_ZDCP28_BptxAND       116    116    116         0          0
     375                                  L1_ZDCM28        71     71     71         0          0
     376                          L1_ZDCM28_BptxAND        71     71     71         0          0
     377                               L1_ZDC28_AND        17     17     17         0          0
     378                       L1_ZDC28_AND_BptxAND        17     17     17         0          0
     379                                L1_ZDC28_OR       170    170    170         0          0
     380                        L1_ZDC28_OR_BptxAND       170    170    170         0          0
     381          L1_ZDC1n_AND_AND_NotMBHF2_BptxAND        17     17     17         0          0
     382        L1_ZDC1n_AND_AND_NotMBHF2OR_BptxAND        17     17     17         0          0
     404   L1_ZDC1n_Bkp3_AsymXOR_MinimumBiasHF1_AND_BptxAND         0      0      0         0          0
     405   L1_ZDC1n_Bkp3_XOR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     412   L1_ZDC1n_Bkp3_AsymXOR_MinimumBiasHF2_AND_BptxAND         0      0      0         0          0
     502                 L1_ZDC1n_OR_RapGap_BptxAND         0      0      0         0          0
```

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

Since #45712 was integrated in `14_1_X`, this fix should arguably be backported down to that cycle. On the other hand, I can't gauge how (un)important this fix is for L1T/HI studies, so I leave it to L1T-sw experts to decide what backports are needed (if any).