### PR TITLE
[15.0.X] reduction of memory allocation in string manipulation in SiStrip DQM

### DIFF
--- a/DQM/SiStripCommon/interface/SiStripFolderOrganizer.h
+++ b/DQM/SiStripCommon/interface/SiStripFolderOrganizer.h
@@ -88,7 +88,7 @@ public:
   }
   // SubDetector Folder
   void getSubDetFolder(const uint32_t& detid, const TrackerTopology* tTopo, std::string& folder_name);
-  std::pair<const std::string, const char*> getSubDetFolderAndTag(const uint32_t& detid, const TrackerTopology* tTopo);
+  std::pair<std::string, std::string_view> getSubDetFolderAndTag(const uint32_t& detid, const TrackerTopology* tTopo);
 
   SiStripFolderOrganizer(const SiStripFolderOrganizer&) = delete;                   // stop default
   const SiStripFolderOrganizer& operator=(const SiStripFolderOrganizer&) = delete;  // stop default

--- a/DQM/SiStripCommon/interface/SiStripFolderOrganizer.h
+++ b/DQM/SiStripCommon/interface/SiStripFolderOrganizer.h
@@ -89,6 +89,7 @@ public:
   // SubDetector Folder
   void getSubDetFolder(const uint32_t& detid, const TrackerTopology* tTopo, std::string& folder_name);
   std::pair<std::string, std::string_view> getSubDetFolderAndTag(const uint32_t& detid, const TrackerTopology* tTopo);
+  const std::string_view getSubDetTag(const uint32_t& detid, const TrackerTopology* tTopo);
 
   SiStripFolderOrganizer(const SiStripFolderOrganizer&) = delete;                   // stop default
   const SiStripFolderOrganizer& operator=(const SiStripFolderOrganizer&) = delete;  // stop default
@@ -96,5 +97,7 @@ public:
 private:
   std::string TopFolderName;
   DQMStore* dbe_;
+
+  std::pair<std::string_view, std::string_view> getSubdetStrings(const uint32_t& detid, const TrackerTopology* tTopo);
 };
 #endif

--- a/DQM/SiStripCommon/src/SiStripFolderOrganizer.cc
+++ b/DQM/SiStripCommon/src/SiStripFolderOrganizer.cc
@@ -9,26 +9,25 @@
 // Original Author:  dkcira
 //         Created:  Thu Jan 26 23:52:43 CET 2006
 
-//
-
+// system includes
+#include <cstring>  // For strlen
 #include <iostream>
 #include <sstream>
+#include <string>
+#include <string_view>
+#include <utility>
 
-#include "FWCore/ServiceRegistry/interface/Service.h"
-
+// user includes
+#include "DQM/SiStripCommon/interface/SiStripFolderOrganizer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
 
-#include "DQMServices/Core/interface/DQMStore.h"
-
-#include "DQM/SiStripCommon/interface/SiStripFolderOrganizer.h"
 #define CONTROL_FOLDER_NAME "ControlView"
 #define MECHANICAL_FOLDER_NAME "MechanicalView"
 #define SEP "/"
-
-#include <cstring>
 
 SiStripFolderOrganizer::SiStripFolderOrganizer() {
   TopFolderName = "SiStrip";
@@ -406,8 +405,8 @@ void SiStripFolderOrganizer::setLayerFolder(uint32_t rawdetid,
 void SiStripFolderOrganizer::getSubDetFolder(const uint32_t& detid,
                                              const TrackerTopology* tTopo,
                                              std::string& folder_name) {
-  std::pair<std::string, std::string> subdet_and_tag = getSubDetFolderAndTag(detid, tTopo);
-  folder_name = subdet_and_tag.first;
+  auto subdet_and_tag = getSubDetFolderAndTag(detid, tTopo);
+  folder_name = std::string(subdet_and_tag.first);
 }
 //
 // -- Get the name of Subdetector Layer folder
@@ -472,10 +471,11 @@ void SiStripFolderOrganizer::getLayerFolderName(std::stringstream& ss,
 //
 // -- Get Subdetector Folder name and the Tag
 //
-std::pair<const std::string, const char*> SiStripFolderOrganizer::getSubDetFolderAndTag(const uint32_t& detid,
-                                                                                        const TrackerTopology* tTopo) {
-  const char* subdet_folder = "";
-  const char* tag = "";
+std::pair<std::string, std::string_view> SiStripFolderOrganizer::getSubDetFolderAndTag(const uint32_t& detid,
+                                                                                       const TrackerTopology* tTopo) {
+  std::string_view subdet_folder;
+  std::string_view tag;
+
   switch (StripSubdetector::SubDetector(StripSubdetector(detid).subdetId())) {
     case StripSubdetector::TIB:
       subdet_folder = "TIB";
@@ -503,15 +503,14 @@ std::pair<const std::string, const char*> SiStripFolderOrganizer::getSubDetFolde
         tag = "TEC__MINUS";
       }
       break;
-    default: {
+    default:
       edm::LogWarning("SiStripCommon") << "WARNING!!! this detid does not belong to tracker" << std::endl;
       subdet_folder = "";
-    }
+      tag = "";
   }
 
-  std::string folder;
-  folder.reserve(TopFolderName.size() + strlen(SEP MECHANICAL_FOLDER_NAME SEP) + strlen(subdet_folder) + 1);
-  folder = TopFolderName + SEP MECHANICAL_FOLDER_NAME SEP + subdet_folder;
+  // Concatenate the folder path
+  std::string folder = std::string(TopFolderName) + SEP + MECHANICAL_FOLDER_NAME + SEP + std::string(subdet_folder);
 
-  return std::pair<const std::string, const char*>(folder, tag);
+  return {folder, tag};
 }

--- a/DQM/SiStripCommon/src/SiStripHistoId.cc
+++ b/DQM/SiStripCommon/src/SiStripHistoId.cc
@@ -13,6 +13,7 @@
 #include <iostream>
 #include <sstream>
 #include <cstdio>
+#include <fmt/format.h>
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DQM/SiStripCommon/interface/SiStripHistoId.h"
@@ -79,7 +80,7 @@ std::string SiStripHistoId::createHistoLayer(std::string description,
 }
 
 // std::string SiStripHistoId::getSubdetid(uint32_t id, const TrackerTopology* tTopo, bool flag_ring, bool flag_thickness) {
-std::string SiStripHistoId::getSubdetid(uint32_t id, const TrackerTopology *tTopo, bool flag_ring) {
+std::string SiStripHistoId::getSubdetid(uint32_t id, const TrackerTopology* tTopo, bool flag_ring) {
   StripSubdetector subdet(id);
 
   if (subdet.subdetId() == StripSubdetector::TIB) {
@@ -87,30 +88,30 @@ std::string SiStripHistoId::getSubdetid(uint32_t id, const TrackerTopology *tTop
     return "TIB__layer__" + std::to_string(tTopo->tibLayer(id));
   } else if (subdet.subdetId() == StripSubdetector::TID) {
     // ---------------------------  TID  --------------------------- //
-    std::string side = (tTopo->tidSide(id) == 1) ? "MINUS" : "PLUS";
+    const char* side = (tTopo->tidSide(id) == 1) ? "MINUS" : "PLUS";
 
     if (flag_ring)
-      return "TID__" + side + "__ring__" + std::to_string(tTopo->tidRing(id));
+      return fmt::format("TID__{}__ring__{}", side, tTopo->tidRing(id));
     else
-      return "TID__" + side + "__wheel__" + std::to_string(tTopo->tidWheel(id));
+      return fmt::format("TID__{}__wheel__{}", side, tTopo->tidWheel(id));
   } else if (subdet.subdetId() == StripSubdetector::TOB) {
     // ---------------------------  TOB  --------------------------- //
     return "TOB__layer__" + std::to_string(tTopo->tobLayer(id));
   } else if (subdet.subdetId() == StripSubdetector::TEC) {
     // ---------------------------  TEC  --------------------------- //
-    std::string side = (tTopo->tecSide(id) == 1) ? "MINUS" : "PLUS";
+    const char* side = (tTopo->tecSide(id) == 1) ? "MINUS" : "PLUS";
 
     if (flag_ring) {
-      return "TEC__" + side + "__ring__" + std::to_string(tTopo->tecRing(id));
+      return fmt::format("TEC__{}__ring__{}", side, tTopo->tecRing(id));
     } else {
       /*
       if (flag_thickness) {
         uint32_t ring = tTopo->tecRing(id);
         std::string thickness = (ring >= 1 && ring <= 4) ? "__THIN" : "__THICK";
-        return "TEC__" + side + "__wheel__" + std::to_string(tTopo->tecWheel(id)) + thickness;
+	return fmt::format("TEC__{}__wheel__{}{}", side, tTopo->tecWheel(id), thickness);
       } else
       */
-      return "TEC__" + side + "__wheel__" + std::to_string(tTopo->tecWheel(id));
+      return fmt::format("TEC__{}__wheel__{}", side, tTopo->tecWheel(id));
     }
   } else {
     // ---------------------------  ???  --------------------------- //

--- a/DQM/SiStripCommon/src/SiStripHistoId.cc
+++ b/DQM/SiStripCommon/src/SiStripHistoId.cc
@@ -78,66 +78,46 @@ std::string SiStripHistoId::createHistoLayer(std::string description,
   return local_histo_id;
 }
 
-//std::string SiStripHistoId::getSubdetid(uint32_t id, const TrackerTopology* tTopo, bool flag_ring, bool flag_thickness){
+// std::string SiStripHistoId::getSubdetid(uint32_t id, const TrackerTopology* tTopo, bool flag_ring, bool flag_thickness) {
 std::string SiStripHistoId::getSubdetid(uint32_t id, const TrackerTopology *tTopo, bool flag_ring) {
-  const int buf_len = 50;
-  char temp_str[buf_len];
-
   StripSubdetector subdet(id);
+
   if (subdet.subdetId() == StripSubdetector::TIB) {
     // ---------------------------  TIB  --------------------------- //
-
-    snprintf(temp_str, buf_len, "TIB__layer__%i", tTopo->tibLayer(id));
+    return "TIB__layer__" + std::to_string(tTopo->tibLayer(id));
   } else if (subdet.subdetId() == StripSubdetector::TID) {
     // ---------------------------  TID  --------------------------- //
-
-    const char *side = "";
-    if (tTopo->tidSide(id) == 1)
-      side = "MINUS";
-    else if (tTopo->tidSide(id) == 2)
-      side = "PLUS";
+    std::string side = (tTopo->tidSide(id) == 1) ? "MINUS" : "PLUS";
 
     if (flag_ring)
-      snprintf(temp_str, buf_len, "TID__%s__ring__%i", side, tTopo->tidRing(id));
+      return "TID__" + side + "__ring__" + std::to_string(tTopo->tidRing(id));
     else
-      snprintf(temp_str, buf_len, "TID__%s__wheel__%i", side, tTopo->tidWheel(id));
-
+      return "TID__" + side + "__wheel__" + std::to_string(tTopo->tidWheel(id));
   } else if (subdet.subdetId() == StripSubdetector::TOB) {
     // ---------------------------  TOB  --------------------------- //
-
-    snprintf(temp_str, buf_len, "TOB__layer__%i", tTopo->tobLayer(id));
+    return "TOB__layer__" + std::to_string(tTopo->tobLayer(id));
   } else if (subdet.subdetId() == StripSubdetector::TEC) {
     // ---------------------------  TEC  --------------------------- //
+    std::string side = (tTopo->tecSide(id) == 1) ? "MINUS" : "PLUS";
 
-    const char *side = "";
-    if (tTopo->tecSide(id) == 1)
-      side = "MINUS";
-    else if (tTopo->tecSide(id) == 2)
-      side = "PLUS";
-
-    if (flag_ring)
-      snprintf(temp_str, buf_len, "TEC__%s__ring__%i", side, tTopo->tecRing(id));
-    else {
+    if (flag_ring) {
+      return "TEC__" + side + "__ring__" + std::to_string(tTopo->tecRing(id));
+    } else {
       /*
       if (flag_thickness) {
-	uint32_t ring = tTopo->tecRing(id);
-	if ( ring >= 1 && ring <= 4 )
-	  snprintf(temp_str, buf_len, "TEC__%s__wheel__%i__THIN", side.c_str(), tTopo->tecWheel(id));       
-	else 
-	  snprintf(temp_str, buf_len, "TEC__%s__wheel__%i__THICK", side.c_str(), tTopo->tecWheel(id));       
-      }
-      else
-*/
-      snprintf(temp_str, buf_len, "TEC__%s__wheel__%i", side, tTopo->tecWheel(id));
+        uint32_t ring = tTopo->tecRing(id);
+        std::string thickness = (ring >= 1 && ring <= 4) ? "__THIN" : "__THICK";
+        return "TEC__" + side + "__wheel__" + std::to_string(tTopo->tecWheel(id)) + thickness;
+      } else
+      */
+      return "TEC__" + side + "__wheel__" + std::to_string(tTopo->tecWheel(id));
     }
   } else {
     // ---------------------------  ???  --------------------------- //
     edm::LogError("SiStripTkDQM|WrongInput")
-        << "no such subdetector type :" << subdet.subdetId() << " no folder set!" << std::endl;
-    snprintf(temp_str, 0, "%s", "");
+        << "no such subdetector type: " << subdet.subdetId() << " no folder set!" << std::endl;
+    return "";  // Return an empty string on error
   }
-
-  return std::string(temp_str);
 }
 
 uint32_t SiStripHistoId::getComponentId(std::string histoid) {

--- a/DQM/SiStripMonitorCluster/interface/SiStripMonitorCluster.h
+++ b/DQM/SiStripMonitorCluster/interface/SiStripMonitorCluster.h
@@ -132,7 +132,7 @@ private:
   void createMEs(const edm::EventSetup& es, DQMStore::IBooker& ibooker);
   void createLayerMEs(std::string label, int ndets, DQMStore::IBooker& ibooker);
   void createModuleMEs(ModMEs& mod_single, uint32_t detid, DQMStore::IBooker& ibooker, const SiStripDetCabling&);
-  void createSubDetMEs(std::string label, DQMStore::IBooker& ibooker);
+  void createSubDetMEs(std::string_view label, DQMStore::IBooker& ibooker);
   int FindRegion(int nstrip, int npixel);
   void fillModuleMEs(ModMEs& mod_mes, ClusterProperties& cluster);
   void fillLayerMEs(LayerMEs&, ClusterProperties& cluster);
@@ -163,7 +163,7 @@ private:
   std::map<uint32_t, ModMEs> ModuleMEsMap;
   std::map<std::string, LayerMEs> LayerMEsMap;
   std::map<std::string, std::vector<uint32_t> > LayerDetMap;
-  std::map<std::string, SubDetMEs> SubDetMEsMap;
+  std::map<std::string_view, SubDetMEs> SubDetMEsMap;
   std::map<std::string, std::string> SubDetPhasePartMap;
 
   // flags

--- a/DQM/SiStripMonitorDigi/interface/SiStripMonitorDigi.h
+++ b/DQM/SiStripMonitorDigi/interface/SiStripMonitorDigi.h
@@ -120,7 +120,7 @@ private:
 
   void createModuleMEs(DQMStore::IBooker& ibooker, ModMEs& mod_single, uint32_t detid);
   void createLayerMEs(DQMStore::IBooker& ibooker, std::string label, int ndet);
-  void createSubDetMEs(DQMStore::IBooker& ibooker, std::string label);
+  void createSubDetMEs(DQMStore::IBooker& ibooker, std::string_view label);
   void createSubDetTH2(DQMStore::IBooker& ibooker, std::string label);
   int getDigiSourceIndex(uint32_t id);
   void AddApvShotsToSubDet(const std::vector<APVShot>&, std::vector<APVShot>&);
@@ -137,7 +137,7 @@ private:
 
   std::map<std::string, std::vector<uint32_t>> LayerDetMap;
   std::map<std::string, LayerMEs> LayerMEsMap;
-  std::map<std::string, SubDetMEs> SubDetMEsMap;
+  std::map<std::string_view, SubDetMEs> SubDetMEsMap;
   std::map<std::string, std::string> SubDetPhasePartMap;
   DigiFailureMEs digiFailureMEs;
 

--- a/DQM/SiStripMonitorDigi/src/SiStripMonitorDigi.cc
+++ b/DQM/SiStripMonitorDigi/src/SiStripMonitorDigi.cc
@@ -604,10 +604,9 @@ void SiStripMonitorDigi::analyze(const edm::Event& iEvent, const edm::EventSetup
   }
 
   // initialise # of clusters to zero
-  for (std::map<std::string, SubDetMEs>::iterator iSubdet = SubDetMEsMap.begin(); iSubdet != SubDetMEsMap.end();
-       iSubdet++) {
-    iSubdet->second.totNDigis = 0;
-    iSubdet->second.SubDetApvShots.clear();
+  for (auto& iSubdet : SubDetMEsMap) {
+    iSubdet.second.totNDigis = 0;
+    iSubdet.second.SubDetApvShots.clear();
   }
 
   std::map<int, int> FEDID_v_digisum;
@@ -635,7 +634,7 @@ void SiStripMonitorDigi::analyze(const edm::Event& iEvent, const edm::EventSetup
 
     uint16_t iDet = 0;
 
-    std::string subdet_label = "";
+    std::string_view subdet_label = "";
 
     // loop over all modules in the layer
     for (std::vector<uint32_t>::const_iterator iterDets = layer_dets.begin(); iterDets != layer_dets.end();
@@ -804,7 +803,7 @@ void SiStripMonitorDigi::analyze(const edm::Event& iEvent, const edm::EventSetup
         fillTrend(local_layermes.LayerADCsCoolestStripTrend, smallest_adc_layer, iOrbitVar);
     }
 
-    std::map<std::string, SubDetMEs>::iterator iSubdet = SubDetMEsMap.find(subdet_label);
+    auto iSubdet = SubDetMEsMap.find(subdet_label);
     if (iSubdet != SubDetMEsMap.end()) {
       iSubdet->second.totNDigis += ndigi_layer;
       //std::cout << " totDigis" <<  iSubdet->second.totNDigis << " in "  << subdet_label << std::endl;
@@ -829,42 +828,40 @@ void SiStripMonitorDigi::analyze(const edm::Event& iEvent, const edm::EventSetup
       isStableBeams = true;
   }
 
-  for (std::map<std::string, SubDetMEs>::iterator it = SubDetMEsMap.begin(); it != SubDetMEsMap.end(); it++) {
+  for (auto& it : SubDetMEsMap) {
     if (subdetswitchtotdigifailureon) {
-      if (strcmp(it->first.c_str(), "TEC__MINUS") == 0) {
-        digiFailureMEs.SubDetTotDigiProfLS->Fill(1, it->second.totNDigis);
-      } else if (strcmp(it->first.c_str(), "TEC__PLUS") == 0) {
-        digiFailureMEs.SubDetTotDigiProfLS->Fill(2, it->second.totNDigis);
-      } else if (strcmp(it->first.c_str(), "TIB") == 0) {
-        digiFailureMEs.SubDetTotDigiProfLS->Fill(3, it->second.totNDigis);
-      } else if (strcmp(it->first.c_str(), "TID__MINUS") == 0) {
-        digiFailureMEs.SubDetTotDigiProfLS->Fill(4, it->second.totNDigis);
-      } else if (strcmp(it->first.c_str(), "TID__PLUS") == 0) {
-        digiFailureMEs.SubDetTotDigiProfLS->Fill(5, it->second.totNDigis);
-      } else if (strcmp(it->first.c_str(), "TOB") == 0) {
-        digiFailureMEs.SubDetTotDigiProfLS->Fill(6, it->second.totNDigis);
+      if (strcmp(it.first.data(), "TEC__MINUS") == 0) {
+        digiFailureMEs.SubDetTotDigiProfLS->Fill(1, it.second.totNDigis);
+      } else if (strcmp(it.first.data(), "TEC__PLUS") == 0) {
+        digiFailureMEs.SubDetTotDigiProfLS->Fill(2, it.second.totNDigis);
+      } else if (strcmp(it.first.data(), "TIB") == 0) {
+        digiFailureMEs.SubDetTotDigiProfLS->Fill(3, it.second.totNDigis);
+      } else if (strcmp(it.first.data(), "TID__MINUS") == 0) {
+        digiFailureMEs.SubDetTotDigiProfLS->Fill(4, it.second.totNDigis);
+      } else if (strcmp(it.first.data(), "TID__PLUS") == 0) {
+        digiFailureMEs.SubDetTotDigiProfLS->Fill(5, it.second.totNDigis);
+      } else if (strcmp(it.first.data(), "TOB") == 0) {
+        digiFailureMEs.SubDetTotDigiProfLS->Fill(6, it.second.totNDigis);
       }
     }
 
     if (globalsummaryapvshotson) {
-      if (strcmp(it->first.c_str(), "TEC__MINUS") == 0) {
-        NApvShotsGlobalProf->Fill(1, it->second.SubDetApvShots.size());
-      } else if (strcmp(it->first.c_str(), "TEC__PLUS") == 0) {
-        NApvShotsGlobalProf->Fill(2, it->second.SubDetApvShots.size());
-      } else if (strcmp(it->first.c_str(), "TIB") == 0) {
-        NApvShotsGlobalProf->Fill(3, it->second.SubDetApvShots.size());
-      } else if (strcmp(it->first.c_str(), "TID__MINUS") == 0) {
-        NApvShotsGlobalProf->Fill(4, it->second.SubDetApvShots.size());
-      } else if (strcmp(it->first.c_str(), "TID__PLUS") == 0) {
-        NApvShotsGlobalProf->Fill(5, it->second.SubDetApvShots.size());
-      } else if (strcmp(it->first.c_str(), "TOB") == 0) {
-        NApvShotsGlobalProf->Fill(6, it->second.SubDetApvShots.size());
+      if (strcmp(it.first.data(), "TEC__MINUS") == 0) {
+        NApvShotsGlobalProf->Fill(1, it.second.SubDetApvShots.size());
+      } else if (strcmp(it.first.data(), "TEC__PLUS") == 0) {
+        NApvShotsGlobalProf->Fill(2, it.second.SubDetApvShots.size());
+      } else if (strcmp(it.first.data(), "TIB") == 0) {
+        NApvShotsGlobalProf->Fill(3, it.second.SubDetApvShots.size());
+      } else if (strcmp(it.first.data(), "TID__MINUS") == 0) {
+        NApvShotsGlobalProf->Fill(4, it.second.SubDetApvShots.size());
+      } else if (strcmp(it.first.data(), "TID__PLUS") == 0) {
+        NApvShotsGlobalProf->Fill(5, it.second.SubDetApvShots.size());
+      } else if (strcmp(it.first.data(), "TOB") == 0) {
+        NApvShotsGlobalProf->Fill(6, it.second.SubDetApvShots.size());
       }
     }
 
-    SubDetMEs subdetmes = it->second;
-    std::string subdet = it->first;
-
+    SubDetMEs subdetmes = it.second;
     // Fill APV shots histograms for SubDet
 
     uint ShotsSize = subdetmes.SubDetApvShots.size();
@@ -924,10 +921,10 @@ void SiStripMonitorDigi::analyze(const edm::Event& iEvent, const edm::EventSetup
       !apv_phase_collection.failedToGet()) {
     long long tbx = event_history->absoluteBX();
 
-    for (std::map<std::string, SubDetMEs>::iterator it = SubDetMEsMap.begin(); it != SubDetMEsMap.end(); it++) {
+    for (auto& it : SubDetMEsMap) {
       SubDetMEs subdetmes;
-      std::string subdet = it->first;
-      subdetmes = it->second;
+      const auto& subdet = std::string(it.first);
+      subdetmes = it.second;
 
       int the_phase = APVCyclePhaseCollection::invalid;
       long long tbx_corr = tbx;
@@ -1162,15 +1159,16 @@ void SiStripMonitorDigi::createLayerMEs(DQMStore::IBooker& ibooker, std::string 
 //
 // -- Create SubDetector MEs
 //
-void SiStripMonitorDigi::createSubDetMEs(DQMStore::IBooker& ibooker, std::string label) {
+void SiStripMonitorDigi::createSubDetMEs(DQMStore::IBooker& ibooker, std::string_view label) {
   SubDetMEs subdetMEs;
 
   std::string HistoName;
+  std::string slabel = std::string(label);
 
   // Total Number of Digi - Profile
   if (subdetswitchtotdigiprofon) {
     edm::ParameterSet Parameters = conf_.getParameter<edm::ParameterSet>("TProfTotalNumberOfDigis");
-    HistoName = "TotalNumberOfDigiProfile__" + label;
+    HistoName = "TotalNumberOfDigiProfile__" + slabel;
     subdetMEs.SubDetTotDigiProf = ibooker.bookProfile(HistoName,
                                                       HistoName,
                                                       Parameters.getParameter<int32_t>("Nbins"),
@@ -1189,7 +1187,7 @@ void SiStripMonitorDigi::createSubDetMEs(DQMStore::IBooker& ibooker, std::string
   // Number of Digi vs Bx - Profile
   if (subdetswitchapvcycleprofon) {
     edm::ParameterSet Parameters = conf_.getParameter<edm::ParameterSet>("TProfDigiApvCycle");
-    HistoName = "Digi_vs_ApvCycle__" + label;
+    HistoName = "Digi_vs_ApvCycle__" + slabel;
     subdetMEs.SubDetDigiApvProf = ibooker.bookProfile(HistoName,
                                                       HistoName,
                                                       Parameters.getParameter<int32_t>("Nbins"),
@@ -1205,18 +1203,18 @@ void SiStripMonitorDigi::createSubDetMEs(DQMStore::IBooker& ibooker, std::string
   // Number of Digi vs Bx - TH2
   if (subdetswitchapvcycleth2on) {
     edm::ParameterSet Parameters = conf_.getParameter<edm::ParameterSet>("TH2DigiApvCycle");
-    //dqmStore_->setCurrentFolder("SiStrip/MechanicalView/"+label);
-    HistoName = "Digi_vs_ApvCycle_2D__" + label;
+    //dqmStore_->setCurrentFolder("SiStrip/MechanicalView/"+slabel);
+    HistoName = "Digi_vs_ApvCycle_2D__" + slabel;
     // Adjusting the scale for 2D histogram
     double h2ymax = 9999.0;
     double yfact = Parameters.getParameter<double>("yfactor");
-    if (label.find("TIB") != std::string::npos)
+    if (slabel.find("TIB") != std::string::npos)
       h2ymax = (6984. * 256.) * yfact;
-    else if (label.find("TID") != std::string::npos)
+    else if (slabel.find("TID") != std::string::npos)
       h2ymax = (2208. * 256.) * yfact;
-    else if (label.find("TOB") != std::string::npos)
+    else if (slabel.find("TOB") != std::string::npos)
       h2ymax = (12906. * 256.) * yfact;
-    else if (label.find("TEC") != std::string::npos)
+    else if (slabel.find("TEC") != std::string::npos)
       h2ymax = (7552. * 2. * 256.) * yfact;
     subdetMEs.SubDetDigiApvTH2 =
         ibooker.book2D(HistoName,
@@ -1233,8 +1231,8 @@ void SiStripMonitorDigi::createSubDetMEs(DQMStore::IBooker& ibooker, std::string
   //Number of APV Shots
   if (subdetswitchnapvshotson) {
     edm::ParameterSet Parameters = conf_.getParameter<edm::ParameterSet>("TH1NApvShots");
-    //dqmStore_->setCurrentFolder("SiStrip/MechanicalView/"+label);
-    HistoName = "Number_of_Apv_Shots_" + label;
+    //dqmStore_->setCurrentFolder("SiStrip/MechanicalView/"+slabel);
+    HistoName = "Number_of_Apv_Shots_" + slabel;
     subdetMEs.SubDetNApvShotsTH1 = ibooker.book1D(HistoName,
                                                   HistoName,
                                                   Parameters.getParameter<int32_t>("Nbins"),
@@ -1246,8 +1244,8 @@ void SiStripMonitorDigi::createSubDetMEs(DQMStore::IBooker& ibooker, std::string
   //Strip multiplicity of APV Shots
   if (subdetswitchnstripsapvshotson) {
     edm::ParameterSet Parameters = conf_.getParameter<edm::ParameterSet>("TH1NStripsApvShots");
-    //dqmStore_->setCurrentFolder("SiStrip/MechanicalView/"+label);
-    HistoName = "Number_of_Strips_in_Apv_Shots_" + label;
+    //dqmStore_->setCurrentFolder("SiStrip/MechanicalView/"+slabel);
+    HistoName = "Number_of_Strips_in_Apv_Shots_" + slabel;
     subdetMEs.SubDetNStripsApvShotsTH1 = ibooker.book1D(HistoName,
                                                         HistoName,
                                                         Parameters.getParameter<int32_t>("Nbins"),
@@ -1259,8 +1257,8 @@ void SiStripMonitorDigi::createSubDetMEs(DQMStore::IBooker& ibooker, std::string
   //Charge median of APV Shots
   if (subdetswitchchargemedianapvshotson) {
     edm::ParameterSet Parameters = conf_.getParameter<edm::ParameterSet>("TH1ChargeMedianApvShots");
-    //dqmStore_->setCurrentFolder("SiStrip/MechanicalView/"+label);
-    HistoName = "Apv_Shots_Charge_Median_" + label;
+    //dqmStore_->setCurrentFolder("SiStrip/MechanicalView/"+slabel);
+    HistoName = "Apv_Shots_Charge_Median_" + slabel;
     subdetMEs.SubDetChargeMedianApvShotsTH1 = ibooker.book1D(HistoName,
                                                              HistoName,
                                                              Parameters.getParameter<int32_t>("Nbins"),
@@ -1271,8 +1269,8 @@ void SiStripMonitorDigi::createSubDetMEs(DQMStore::IBooker& ibooker, std::string
 
   if (subdetswitchchargemedianapvshotson) {
     edm::ParameterSet Parameters = conf_.getParameter<edm::ParameterSet>("TH1ApvNumApvShots");
-    //dqmStore_->setCurrentFolder("SiStrip/MechanicalView/"+label);
-    HistoName = "Apv_Shots_Apv_Number_" + label;
+    //dqmStore_->setCurrentFolder("SiStrip/MechanicalView/"+slabel);
+    HistoName = "Apv_Shots_Apv_Number_" + slabel;
     subdetMEs.SubDetNApvShotsNApvTH1 = ibooker.book1D(HistoName,
                                                       HistoName,
                                                       Parameters.getParameter<int32_t>("Nbins"),
@@ -1284,7 +1282,7 @@ void SiStripMonitorDigi::createSubDetMEs(DQMStore::IBooker& ibooker, std::string
   //APV Shots number Vs time
   if (subdetswitchapvshotsonprof) {
     edm::ParameterSet Parameters = conf_.getParameter<edm::ParameterSet>("TProfNShotsVsTime");
-    HistoName = "NApv_Shots_vs_Time_" + label;
+    HistoName = "NApv_Shots_vs_Time_" + slabel;
     subdetMEs.SubDetNApvShotsProf = ibooker.bookProfile(HistoName,
                                                         HistoName,
                                                         Parameters.getParameter<int32_t>("Nbins"),

--- a/DQM/SiStripMonitorDigi/src/SiStripMonitorDigi.cc
+++ b/DQM/SiStripMonitorDigi/src/SiStripMonitorDigi.cc
@@ -830,33 +830,33 @@ void SiStripMonitorDigi::analyze(const edm::Event& iEvent, const edm::EventSetup
 
   for (auto& it : SubDetMEsMap) {
     if (subdetswitchtotdigifailureon) {
-      if (strcmp(it.first.data(), "TEC__MINUS") == 0) {
+      if (it.first == "TEC__MINUS") {
         digiFailureMEs.SubDetTotDigiProfLS->Fill(1, it.second.totNDigis);
-      } else if (strcmp(it.first.data(), "TEC__PLUS") == 0) {
+      } else if (it.first == "TEC__PLUS") {
         digiFailureMEs.SubDetTotDigiProfLS->Fill(2, it.second.totNDigis);
-      } else if (strcmp(it.first.data(), "TIB") == 0) {
+      } else if (it.first == "TIB") {
         digiFailureMEs.SubDetTotDigiProfLS->Fill(3, it.second.totNDigis);
-      } else if (strcmp(it.first.data(), "TID__MINUS") == 0) {
+      } else if (it.first == "TID__MINUS") {
         digiFailureMEs.SubDetTotDigiProfLS->Fill(4, it.second.totNDigis);
-      } else if (strcmp(it.first.data(), "TID__PLUS") == 0) {
+      } else if (it.first == "TID__PLUS") {
         digiFailureMEs.SubDetTotDigiProfLS->Fill(5, it.second.totNDigis);
-      } else if (strcmp(it.first.data(), "TOB") == 0) {
+      } else if (it.first == "TOB") {
         digiFailureMEs.SubDetTotDigiProfLS->Fill(6, it.second.totNDigis);
       }
     }
 
     if (globalsummaryapvshotson) {
-      if (strcmp(it.first.data(), "TEC__MINUS") == 0) {
+      if (it.first == "TEC__MINUS") {
         NApvShotsGlobalProf->Fill(1, it.second.SubDetApvShots.size());
-      } else if (strcmp(it.first.data(), "TEC__PLUS") == 0) {
+      } else if (it.first == "TEC__PLUS") {
         NApvShotsGlobalProf->Fill(2, it.second.SubDetApvShots.size());
-      } else if (strcmp(it.first.data(), "TIB") == 0) {
+      } else if (it.first == "TIB") {
         NApvShotsGlobalProf->Fill(3, it.second.SubDetApvShots.size());
-      } else if (strcmp(it.first.data(), "TID__MINUS") == 0) {
+      } else if (it.first == "TID__MINUS") {
         NApvShotsGlobalProf->Fill(4, it.second.SubDetApvShots.size());
-      } else if (strcmp(it.first.data(), "TID__PLUS") == 0) {
+      } else if (it.first == "TID__PLUS") {
         NApvShotsGlobalProf->Fill(5, it.second.SubDetApvShots.size());
-      } else if (strcmp(it.first.data(), "TOB") == 0) {
+      } else if (it.first == "TOB") {
         NApvShotsGlobalProf->Fill(6, it.second.SubDetApvShots.size());
       }
     }
@@ -922,9 +922,8 @@ void SiStripMonitorDigi::analyze(const edm::Event& iEvent, const edm::EventSetup
     long long tbx = event_history->absoluteBX();
 
     for (auto& it : SubDetMEsMap) {
-      SubDetMEs subdetmes;
       const auto& subdet = std::string(it.first);
-      subdetmes = it.second;
+      SubDetMEs& subdetmes = it.second;
 
       int the_phase = APVCyclePhaseCollection::invalid;
       long long tbx_corr = tbx;

--- a/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
+++ b/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
@@ -83,7 +83,7 @@ private:
   void bookRing(DQMStore::IBooker&, const uint32_t, std::string&);
   MonitorElement* handleBookMEs(DQMStore::IBooker&, std::string&, std::string&, std::string&, std::string&);
   void bookRingMEs(DQMStore::IBooker&, const uint32_t, std::string&);
-  void bookSubDetMEs(DQMStore::IBooker&, std::string& name);
+  void bookSubDetMEs(DQMStore::IBooker&, std::string_view& name);
   MonitorElement* bookME1D(DQMStore::IBooker&, const char*, const char*);
   MonitorElement* bookME2D(DQMStore::IBooker&, const char*, const char*);
   MonitorElement* bookME3D(DQMStore::IBooker&, const char*, const char*);
@@ -258,7 +258,7 @@ private:
   std::map<std::string, ModMEs> ModMEsMap;
   std::map<std::string, LayerMEs> LayerMEsMap;
   std::map<std::string, RingMEs> RingMEsMap;
-  std::map<std::string, SubDetMEs> SubDetMEsMap;
+  std::map<std::string_view, SubDetMEs> SubDetMEsMap;
 
   struct Det2MEs {
     struct LayerMEs* iLayer;

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -115,12 +115,11 @@ void SiStripMonitorTrack::analyze(const edm::Event& e, const edm::EventSetup& iS
   iLumisection = e.orbitNumber() / 262144.0;
 
   // initialise # of clusters
-  for (std::map<std::string, SubDetMEs>::iterator iSubDet = SubDetMEsMap.begin(); iSubDet != SubDetMEsMap.end();
-       iSubDet++) {
-    iSubDet->second.totNClustersOnTrack = 0;
-    iSubDet->second.totNClustersOffTrack = 0;
-    iSubDet->second.totNClustersOnTrackMono = 0;
-    iSubDet->second.totNClustersOnTrackStereo = 0;
+  for (auto& iSubDet : SubDetMEsMap) {
+    iSubDet.second.totNClustersOnTrack = 0;
+    iSubDet.second.totNClustersOffTrack = 0;
+    iSubDet.second.totNClustersOnTrackMono = 0;
+    iSubDet.second.totNClustersOnTrackStereo = 0;
   }
 
   trackerTopology_ = &iSetup.getData(trackerTopologyEventToken_);
@@ -141,8 +140,6 @@ void SiStripMonitorTrack::analyze(const edm::Event& e, const edm::EventSetup& iS
   }
 
   if (Trend_On_) {
-    // for (std::map<std::string, SubDetMEs>::iterator iSubDet = SubDetMEsMap.begin(), iterEnd=SubDetMEsMaps.end();
-    //      iSubDet != iterEnd; ++iSubDet) {
     for (auto const& iSubDet : SubDetMEsMap) {
       SubDetMEs subdet_mes = iSubDet.second;
       if (subdet_mes.totNClustersOnTrack > 0) {
@@ -256,7 +253,7 @@ void SiStripMonitorTrack::book(DQMStore::IBooker& ibooker, const TrackerTopology
       }
 
       // book sub-detector plots
-      std::pair<std::string, std::string> sdet_pair = folder_organizer.getSubDetFolderAndTag(detid, tTopo);
+      auto sdet_pair = folder_organizer.getSubDetFolderAndTag(detid, tTopo);
       if (SubDetMEsMap.find(sdet_pair.second) == SubDetMEsMap.end()) {
         ibooker.setCurrentFolder(sdet_pair.first);
         bookSubDetMEs(ibooker, sdet_pair.second);
@@ -306,7 +303,7 @@ void SiStripMonitorTrack::book(DQMStore::IBooker& ibooker, const TrackerTopology
       }
 
       // book sub-detector plots
-      std::pair<std::string, std::string> sdet_pair = folder_organizer.getSubDetFolderAndTag(detid, tTopo);
+      auto sdet_pair = folder_organizer.getSubDetFolderAndTag(detid, tTopo);
       if (SubDetMEsMap.find(sdet_pair.second) == SubDetMEsMap.end()) {
         ibooker.setCurrentFolder(sdet_pair.first);
         bookSubDetMEs(ibooker, sdet_pair.second);
@@ -704,9 +701,10 @@ void SiStripMonitorTrack::bookRingMEs(DQMStore::IBooker& ibooker, const uint32_t
 //
 // -- Book Histograms at Sub-Detector Level
 //
-void SiStripMonitorTrack::bookSubDetMEs(DQMStore::IBooker& ibooker, std::string& name) {
+void SiStripMonitorTrack::bookSubDetMEs(DQMStore::IBooker& ibooker, std::string_view& name) {
   std::string subdet_tag;
-  subdet_tag = "__" + name;
+  auto sname = std::string(name);
+  subdet_tag = "__" + sname;
   std::string completeName;
   std::string axisName;
 
@@ -714,38 +712,38 @@ void SiStripMonitorTrack::bookSubDetMEs(DQMStore::IBooker& ibooker, std::string&
 
   // TotalNumber of Cluster OnTrack
   completeName = "Summary_TotalNumberOfClusters_OnTrack" + subdet_tag;
-  axisName = "Number of on-track clusters in " + name;
+  axisName = "Number of on-track clusters in " + sname;
   theSubDetMEs.nClustersOnTrack = bookME1D(ibooker, "TH1nClustersOn", completeName.c_str());
   theSubDetMEs.nClustersOnTrack->setAxisTitle(axisName);
   theSubDetMEs.nClustersOnTrack->setStatOverflows(kTRUE);
 
   // TotalNumber of Cluster OnTrack
   completeName = "Summary_TotalNumberOfClusters_OnTrackStereo" + subdet_tag;
-  axisName = "Number of on-track stereo clusters in " + name;
+  axisName = "Number of on-track stereo clusters in " + sname;
   theSubDetMEs.nClustersOnTrackStereo = bookME1D(ibooker, "TH1nClustersOnStereo", completeName.c_str());
   theSubDetMEs.nClustersOnTrackStereo->setAxisTitle(axisName);
   theSubDetMEs.nClustersOnTrackStereo->setStatOverflows(kTRUE);
 
   // TotalNumber of Cluster OffTrack
   completeName = "Summary_TotalNumberOfClusters_OffTrack" + subdet_tag;
-  axisName = "Number of off-track clusters in " + name;
+  axisName = "Number of off-track clusters in " + sname;
   theSubDetMEs.nClustersOffTrack = bookME1D(ibooker, "TH1nClustersOff", completeName.c_str());
   theSubDetMEs.nClustersOffTrack->setAxisTitle(axisName);
 
   double xmaximum = 0;
-  if (name.find("TIB") != std::string::npos) {
+  if (sname.find("TIB") != std::string::npos) {
     xmaximum = 40000.0;
     theSubDetMEs.nClustersOffTrack->setAxisRange(0.0, xmaximum, 1);
   }
-  if (name.find("TOB") != std::string::npos) {
+  if (sname.find("TOB") != std::string::npos) {
     xmaximum = 40000.0;
     theSubDetMEs.nClustersOffTrack->setAxisRange(0.0, xmaximum, 1);
   }
-  if (name.find("TID") != std::string::npos) {
+  if (sname.find("TID") != std::string::npos) {
     xmaximum = 10000.0;
     theSubDetMEs.nClustersOffTrack->setAxisRange(0.0, xmaximum, 1);
   }
-  if (name.find("TEC") != std::string::npos) {
+  if (sname.find("TEC") != std::string::npos) {
     xmaximum = 40000.0;
     theSubDetMEs.nClustersOffTrack->setAxisRange(0.0, xmaximum, 1);
   }
@@ -1336,7 +1334,7 @@ SiStripMonitorTrack::Det2MEs SiStripMonitorTrack::findMEs(const TrackerTopology*
 
   std::string layer_id = hidmanager1.getSubdetid(detid, tTopo, false);
   std::string ring_id = hidmanager1.getSubdetid(detid, tTopo, true);
-  std::string sdet_tag = folderOrganizer_.getSubDetFolderAndTag(detid, tTopo).second;
+  std::string_view sdet_tag = folderOrganizer_.getSubDetFolderAndTag(detid, tTopo).second;
 
   Det2MEs me;
   me.iLayer = nullptr;
@@ -1353,7 +1351,7 @@ SiStripMonitorTrack::Det2MEs SiStripMonitorTrack::findMEs(const TrackerTopology*
     me.iRing = &(iRing->second);
   }
 
-  std::map<std::string, SubDetMEs>::iterator iSubdet = SubDetMEsMap.find(sdet_tag);
+  auto iSubdet = SubDetMEsMap.find(sdet_tag);
   if (iSubdet != SubDetMEsMap.end()) {
     me.iSubdet = &(iSubdet->second);
   }

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -731,19 +731,19 @@ void SiStripMonitorTrack::bookSubDetMEs(DQMStore::IBooker& ibooker, std::string_
   theSubDetMEs.nClustersOffTrack->setAxisTitle(axisName);
 
   double xmaximum = 0;
-  if (sname.find("TIB") != std::string::npos) {
+  if (sname.find("TIB") != std::string_view::npos) {
     xmaximum = 40000.0;
     theSubDetMEs.nClustersOffTrack->setAxisRange(0.0, xmaximum, 1);
   }
-  if (sname.find("TOB") != std::string::npos) {
+  if (sname.find("TOB") != std::string_view::npos) {
     xmaximum = 40000.0;
     theSubDetMEs.nClustersOffTrack->setAxisRange(0.0, xmaximum, 1);
   }
-  if (sname.find("TID") != std::string::npos) {
+  if (sname.find("TID") != std::string_view::npos) {
     xmaximum = 10000.0;
     theSubDetMEs.nClustersOffTrack->setAxisRange(0.0, xmaximum, 1);
   }
-  if (sname.find("TEC") != std::string::npos) {
+  if (sname.find("TEC") != std::string_view::npos) {
     xmaximum = 40000.0;
     theSubDetMEs.nClustersOffTrack->setAxisRange(0.0, xmaximum, 1);
   }
@@ -1334,7 +1334,7 @@ SiStripMonitorTrack::Det2MEs SiStripMonitorTrack::findMEs(const TrackerTopology*
 
   std::string layer_id = hidmanager1.getSubdetid(detid, tTopo, false);
   std::string ring_id = hidmanager1.getSubdetid(detid, tTopo, true);
-  std::string_view sdet_tag = folderOrganizer_.getSubDetFolderAndTag(detid, tTopo).second;
+  const std::string_view sdet_tag = folderOrganizer_.getSubDetTag(detid, tTopo);
 
   Det2MEs me;
   me.iLayer = nullptr;

--- a/Validation/TrackerRecHits/src/SiStripRecHitsValid.cc
+++ b/Validation/TrackerRecHits/src/SiStripRecHitsValid.cc
@@ -577,7 +577,7 @@ void SiStripRecHitsValid::createMEs(DQMStore::IBooker& ibooker, const edm::Event
     }
     // book sub-detector plots
     if (SubDetMEsMap.find(det_layer_pair.first) == SubDetMEsMap.end()) {
-      auto sdet_pair = folder_organizer.getSubDetFolderAndTag(detid, tTopo);
+      const auto& sdet_pair = folder_organizer.getSubDetFolderAndTag(detid, tTopo);
       ibooker.setCurrentFolder(sdet_pair.first);
       createSubDetMEs(ibooker, det_layer_pair.first);
     }


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/48050
backport of https://github.com/cms-sw/cmssw/pull/48026

#### PR description:

The goal of this PR is to address https://github.com/cms-sw/cmssw/issues/46498, by reducing memory allocation per event in string manipulations.

#### PR validation:

`runTheMatrix.py -l Run3` runs without errors: `22 22 22 18 5 tests passed, 0 0 0 0 0 failed`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/48050 and https://github.com/cms-sw/cmssw/pull/48026 to the 2025 data-taking release.