### PR TITLE
GCC14: Avoid using deprecated std::atomic_load and use std::atomic<std::shared_ptr<T>> instead

### DIFF
--- a/L1Trigger/GlobalMuonTrigger/interface/L1MuGlobalMuonTrigger.h
+++ b/L1Trigger/GlobalMuonTrigger/interface/L1MuGlobalMuonTrigger.h
@@ -100,7 +100,7 @@ public:
   L1MuGMTReadoutRecord* currentReadoutRecord() const { return m_ReadoutRingbuffer.back(); };
 
   /// for debug: return the debug block (in order to fill it)
-  L1MuGMTDebugBlock* DebugBlockForFill() const { return m_db.get(); };
+  L1MuGMTDebugBlock* DebugBlockForFill() const { return m_db.load(std::memory_order_acquire).get(); };
 
 private:
   L1MuGMTPSB* m_PSB;
@@ -116,9 +116,9 @@ private:
   bool m_writeLUTsAndRegs;
   bool m_sendMipIso;
 
-  static std::shared_ptr<L1MuGMTConfig> m_config;
+  static std::atomic<std::shared_ptr<L1MuGMTConfig>> m_config;
 
-  static std::shared_ptr<L1MuGMTDebugBlock> m_db;
+  static std::atomic<std::shared_ptr<L1MuGMTDebugBlock>> m_db;
 
   unsigned long long m_L1MuGMTScalesCacheID;
   unsigned long long m_L1MuTriggerScalesCacheID;

--- a/L1Trigger/GlobalMuonTrigger/interface/L1MuGlobalMuonTrigger.h
+++ b/L1Trigger/GlobalMuonTrigger/interface/L1MuGlobalMuonTrigger.h
@@ -100,7 +100,7 @@ public:
   L1MuGMTReadoutRecord* currentReadoutRecord() const { return m_ReadoutRingbuffer.back(); };
 
   /// for debug: return the debug block (in order to fill it)
-  L1MuGMTDebugBlock* DebugBlockForFill() const { return m_db.load(std::memory_order_acquire).get(); };
+  L1MuGMTDebugBlock* DebugBlockForFill() const { return m_db.load().get(); };
 
 private:
   L1MuGMTPSB* m_PSB;

--- a/L1Trigger/GlobalMuonTrigger/src/L1MuGlobalMuonTrigger.cc
+++ b/L1Trigger/GlobalMuonTrigger/src/L1MuGlobalMuonTrigger.cc
@@ -71,7 +71,7 @@ L1MuGlobalMuonTrigger::L1MuGlobalMuonTrigger(const edm::ParameterSet& ps) {
   m_ExtendedCands.reserve(20);
 
   // set configuration parameters
-  if (!m_config.load(std::memory_order_acquire)) {
+  if (!m_config.load()) {
     auto temp = std::make_shared<L1MuGMTConfig>(ps);
     std::shared_ptr<L1MuGMTConfig> expected = nullptr;
     m_config.compare_exchange_strong(expected, temp, std::memory_order_acq_rel, std::memory_order_acquire);
@@ -122,8 +122,8 @@ L1MuGlobalMuonTrigger::L1MuGlobalMuonTrigger(const edm::ParameterSet& ps) {
     edm::LogVerbatim("GMT_info") << "creating GMT Sorter";
   m_Sorter = new L1MuGMTSorter(*this);  // barrel
 
-  if (!m_db.load(std::memory_order_acquire)) {
-    auto config = m_config.load(std::memory_order_acquire);
+  if (!m_db.load()) {
+    auto config = m_config.load();
     auto temp = std::make_shared<L1MuGMTDebugBlock>(config->getBxMin(), config->getBxMax());
     std::shared_ptr<L1MuGMTDebugBlock> expected = nullptr;
     m_db.compare_exchange_strong(expected, temp, std::memory_order_acq_rel, std::memory_order_acquire);

--- a/L1Trigger/GlobalMuonTrigger/src/L1MuGlobalMuonTrigger.cc
+++ b/L1Trigger/GlobalMuonTrigger/src/L1MuGlobalMuonTrigger.cc
@@ -54,11 +54,11 @@
 // Constructors --
 //----------------
 L1MuGlobalMuonTrigger::L1MuGlobalMuonTrigger(const edm::ParameterSet& ps) {
-  produces<std::vector<L1MuGMTCand> >();
+  produces<std::vector<L1MuGMTCand>>();
   produces<L1MuGMTReadoutCollection>();
   m_sendMipIso = ps.getUntrackedParameter<bool>("SendMipIso", false);
   if (m_sendMipIso) {
-    produces<std::vector<unsigned> >();
+    produces<std::vector<unsigned>>();
   }
 
   m_L1MuGMTScalesCacheID = 0ULL;
@@ -71,11 +71,10 @@ L1MuGlobalMuonTrigger::L1MuGlobalMuonTrigger(const edm::ParameterSet& ps) {
   m_ExtendedCands.reserve(20);
 
   // set configuration parameters
-  if (!std::atomic_load(&m_config)) {  // Atomically load m_config
+  if (!m_config.load(std::memory_order_acquire)) {
     auto temp = std::make_shared<L1MuGMTConfig>(ps);
-    std::shared_ptr<L1MuGMTConfig> empty = nullptr;  // Explicit nullptr for CAS
-    std::atomic_compare_exchange_strong_explicit(
-        &m_config, &empty, temp, std::memory_order_acq_rel, std::memory_order_acquire);
+    std::shared_ptr<L1MuGMTConfig> expected = nullptr;
+    m_config.compare_exchange_strong(expected, temp, std::memory_order_acq_rel, std::memory_order_acquire);
   }
   m_writeLUTsAndRegs = ps.getUntrackedParameter<bool>("WriteLUTsAndRegs", false);
 
@@ -123,11 +122,11 @@ L1MuGlobalMuonTrigger::L1MuGlobalMuonTrigger(const edm::ParameterSet& ps) {
     edm::LogVerbatim("GMT_info") << "creating GMT Sorter";
   m_Sorter = new L1MuGMTSorter(*this);  // barrel
 
-  if (!std::atomic_load(&m_db)) {  // Atomically load m_db
-    auto temp = std::make_shared<L1MuGMTDebugBlock>(m_config->getBxMin(), m_config->getBxMax());
-    std::shared_ptr<L1MuGMTDebugBlock> empty = nullptr;  // Explicit nullptr for CAS
-    std::atomic_compare_exchange_strong_explicit(
-        &m_db, &empty, temp, std::memory_order_acq_rel, std::memory_order_acquire);
+  if (!m_db.load(std::memory_order_acquire)) {
+    auto config = m_config.load(std::memory_order_acquire);
+    auto temp = std::make_shared<L1MuGMTDebugBlock>(config->getBxMin(), config->getBxMax());
+    std::shared_ptr<L1MuGMTDebugBlock> expected = nullptr;
+    m_db.compare_exchange_strong(expected, temp, std::memory_order_acq_rel, std::memory_order_acquire);
   }
   usesResource("L1MuGlobalMuonTrigger");
   ///EventSetup Tokens
@@ -174,34 +173,35 @@ void L1MuGlobalMuonTrigger::produce(edm::Event& e, const edm::EventSetup& es) {
   // configure from the event setup
 
   unsigned long long L1MuGMTScalesCacheID = es.get<L1MuGMTScalesRcd>().cacheIdentifier();
+  auto config = m_config.load();
   if (L1MuGMTScalesCacheID != m_L1MuGMTScalesCacheID) {
     edm::ESHandle<L1MuGMTScales> gmtscales_h = es.getHandle(m_gmtScalesToken);
-    m_config->setGMTScales(gmtscales_h.product());
+    config->setGMTScales(gmtscales_h.product());
   }
 
   unsigned long long L1MuTriggerScalesCacheID = es.get<L1MuTriggerScalesRcd>().cacheIdentifier();
   if (L1MuTriggerScalesCacheID != m_L1MuTriggerScalesCacheID) {
     edm::ESHandle<L1MuTriggerScales> trigscales_h = es.getHandle(m_trigScalesToken);
-    m_config->setTriggerScales(trigscales_h.product());
+    config->setTriggerScales(trigscales_h.product());
   }
 
   unsigned long long L1MuTriggerPtScaleCacheID = es.get<L1MuTriggerPtScaleRcd>().cacheIdentifier();
   if (L1MuTriggerPtScaleCacheID != m_L1MuTriggerPtScaleCacheID) {
     edm::ESHandle<L1MuTriggerPtScale> trigptscale_h = es.getHandle(m_trigPtScaleToken);
-    m_config->setTriggerPtScale(trigptscale_h.product());
+    config->setTriggerPtScale(trigptscale_h.product());
   }
 
   unsigned long long L1MuGMTParametersCacheID = es.get<L1MuGMTParametersRcd>().cacheIdentifier();
   if (L1MuGMTParametersCacheID != m_L1MuGMTParametersCacheID) {
     edm::ESHandle<L1MuGMTParameters> gmtparams_h = es.getHandle(m_gmtParamsToken);
-    m_config->setGMTParams(gmtparams_h.product());
-    m_config->setDefaults();
+    config->setGMTParams(gmtparams_h.product());
+    config->setDefaults();
   }
 
   unsigned long long L1MuGMTChannelMaskCacheID = es.get<L1MuGMTChannelMaskRcd>().cacheIdentifier();
   if (L1MuGMTChannelMaskCacheID != m_L1MuGMTChannelMaskCacheID) {
     edm::ESHandle<L1MuGMTChannelMask> gmtchanmask_h = es.getHandle(m_gmtChanMaskToken);
-    m_config->setGMTChanMask(gmtchanmask_h.product());
+    config->setGMTChanMask(gmtchanmask_h.product());
     if (L1MuGMTConfig::Debug(1)) {
       std::string onoff;
       const L1MuGMTChannelMask* theChannelMask = L1MuGMTConfig::getGMTChanMask();
@@ -224,10 +224,10 @@ void L1MuGlobalMuonTrigger::produce(edm::Event& e, const edm::EventSetup& es) {
   unsigned long long L1CaloGeometryCacheID = es.get<L1CaloGeometryRecord>().cacheIdentifier();
   if (L1CaloGeometryCacheID != m_L1CaloGeometryCacheID) {
     edm::ESHandle<L1CaloGeometry> caloGeom_h = es.getHandle(m_caloGeomToken);
-    m_config->setCaloGeom(caloGeom_h.product());
+    config->setCaloGeom(caloGeom_h.product());
   }
 
-  m_config->createLUTsRegs();
+  config->createLUTsRegs();
 
   // write LUTs and Regs if required
 
@@ -236,8 +236,8 @@ void L1MuGlobalMuonTrigger::produce(edm::Event& e, const edm::EventSetup& es) {
 
     mkdir(dir.c_str(), S_ISUID | S_ISGID | S_ISVTX | S_IRUSR | S_IWUSR | S_IXUSR);
 
-    m_config->dumpLUTs(dir);
-    m_config->dumpRegs(dir);
+    config->dumpLUTs(dir);
+    config->dumpRegs(dir);
   }
 
   // process the event
@@ -259,11 +259,12 @@ void L1MuGlobalMuonTrigger::produce(edm::Event& e, const edm::EventSetup& es) {
     delete (*irr);
   m_ReadoutRingbuffer.clear();
 
-  if (m_db)
-    m_db->reset();  // reset debug block
+  auto x_db = m_db.load();
+  if (x_db)
+    x_db->reset();  // reset debug block
 
   for (int bx = bx_min; bx <= bx_max; bx++) {
-    m_db->SetBX(bx);
+    x_db->SetBX(bx);
 
     // create new element in readout ring buffer
     m_ReadoutRingbuffer.push_back(new L1MuGMTReadoutRecord(bx));
@@ -376,7 +377,7 @@ void L1MuGlobalMuonTrigger::produce(edm::Event& e, const edm::EventSetup& es) {
   }
 
   // produce the output
-  std::unique_ptr<std::vector<L1MuGMTCand> > GMTCands(new std::vector<L1MuGMTCand>);
+  std::unique_ptr<std::vector<L1MuGMTCand>> GMTCands(new std::vector<L1MuGMTCand>);
   std::vector<L1MuGMTExtendedCand>::const_iterator iexc;
   for (iexc = m_ExtendedCands.begin(); iexc != m_ExtendedCands.end(); iexc++) {
     GMTCands->push_back(*iexc);
@@ -387,15 +388,15 @@ void L1MuGlobalMuonTrigger::produce(edm::Event& e, const edm::EventSetup& es) {
   e.put(std::move(GMTRRC));
 
   if (m_sendMipIso) {
-    std::unique_ptr<std::vector<unsigned> > mipiso(new std::vector<unsigned>);
+    std::unique_ptr<std::vector<unsigned>> mipiso(new std::vector<unsigned>);
     for (int i = 0; i < 32; i++) {
-      mipiso->push_back(m_db->IsMIPISO(0, i));
+      mipiso->push_back(x_db->IsMIPISO(0, i));
     }
     e.put(std::move(mipiso));
   }
 
   // delete registers and LUTs
-  m_config->clearLUTsRegs();
+  config->clearLUTsRegs();
 }
 
 //
@@ -452,5 +453,5 @@ std::unique_ptr<L1MuGMTReadoutCollection> L1MuGlobalMuonTrigger::getReadoutColle
 
 // static data members
 
-std::shared_ptr<L1MuGMTConfig> L1MuGlobalMuonTrigger::m_config;
-std::shared_ptr<L1MuGMTDebugBlock> L1MuGlobalMuonTrigger::m_db;
+std::atomic<std::shared_ptr<L1MuGMTConfig>> L1MuGlobalMuonTrigger::m_config;
+std::atomic<std::shared_ptr<L1MuGMTDebugBlock>> L1MuGlobalMuonTrigger::m_db;


### PR DESCRIPTION
This fixes the GCC 14 warrnings about deprecated  std::atomic_load  [a]


[a] https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc14/CMSSW_15_1_X_2025-05-09-2300/L1Trigger/GlobalMuonTrigger
```
src/L1Trigger/GlobalMuonTrigger/src/L1MuGlobalMuonTrigger.cc: In constructor 'L1MuGlobalMuonTrigger::L1MuGlobalMuonTrigger(const edm::ParameterSet&)':
  [src/L1Trigger/GlobalMuonTrigger/src/L1MuGlobalMuonTrigger.cc:74](https://github.com/cms-sw/cmssw/blob/CMSSW_15_1_X_2025-05-09-2300/L1Trigger/GlobalMuonTrigger/src/L1MuGlobalMuonTrigger.cc#L74):24: warning: 'std::shared_ptr<_Tp> std::atomic_load(const shared_ptr<_Tp>*) [with _Tp = L1MuGMTConfig]' is deprecated: use 'std::atomic<std::shared_ptr<T>>' instead [-Wdeprecated-declarations]
    74 |   if (!std::atomic_load(&m_config)) {  // Atomically load m_config
      |        ~~~~~~~~~~~~~~~~^~~~~~~~~~~
In file included from /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gcc/14.2.1-1220301db2ec2340427663aa9efa44a7/include/c++/14.2.1/memory:81,
                 from src/L1Trigger/GlobalMuonTrigger/interface/L1MuGlobalMuonTrigger.h:20,
                 from src/L1Trigger/GlobalMuonTrigger/src/L1MuGlobalMuonTrigger.cc:20:
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gcc/14.2.1-1220301db2ec2340427663aa9efa44a7/include/c++/14.2.1/bits/shared_ptr_atomic.h:142:5: note: declared here
  142 |     atomic_load(const shared_ptr<_Tp>* __p)
```