### PR TITLE
[EGM Scouting DQM] Update DoubleEG L1 seed for 2025 (Follow-up PR for #47889)

### DIFF
--- a/HLTriggerOffline/Scouting/python/PatElectronTagProbeAnalyzer_cfi.py
+++ b/HLTriggerOffline/Scouting/python/PatElectronTagProbeAnalyzer_cfi.py
@@ -5,7 +5,10 @@ DoubleEGL1 = [
   "L1_DoubleEG_LooseIso16_LooseIso12_er1p5",
   "L1_DoubleEG_LooseIso18_LooseIso12_er1p5",
   "L1_DoubleEG_LooseIso20_LooseIso12_er1p5",
-  "L1_DoubleEG_LooseIso22_LooseIso12_er1p5"
+  "L1_DoubleEG_LooseIso22_LooseIso12_er1p5",
+  "L1_DoubleEG15_11_er1p2_dR_Max0p6",
+  "L1_DoubleEG16_11_er1p2_dR_Max0p6",
+  "L1_DoubleEG17_11_er1p2_dR_Max0p6"
 ]
 
 SinglePhotonL1 = [

--- a/HLTriggerOffline/Scouting/python/PatElectronTagProbeAnalyzer_cfi.py
+++ b/HLTriggerOffline/Scouting/python/PatElectronTagProbeAnalyzer_cfi.py
@@ -5,8 +5,7 @@ DoubleEGL1 = [
   "L1_DoubleEG_LooseIso16_LooseIso12_er1p5",
   "L1_DoubleEG_LooseIso18_LooseIso12_er1p5",
   "L1_DoubleEG_LooseIso20_LooseIso12_er1p5",
-  "L1_DoubleEG_LooseIso22_LooseIso12_er1p5",
-  "L1_DoubleEG11_er1p2_dR_Max0p6"
+  "L1_DoubleEG_LooseIso22_LooseIso12_er1p5"
 ]
 
 SinglePhotonL1 = [

--- a/HLTriggerOffline/Scouting/python/ScoutingEGammaCollectionMonitoring_cfi.py
+++ b/HLTriggerOffline/Scouting/python/ScoutingEGammaCollectionMonitoring_cfi.py
@@ -6,7 +6,9 @@ DoubleEGL1 = [
   "L1_DoubleEG_LooseIso18_LooseIso12_er1p5",
   "L1_DoubleEG_LooseIso20_LooseIso12_er1p5",
   "L1_DoubleEG_LooseIso22_LooseIso12_er1p5",
-  "L1_DoubleEG11_er1p2_dR_Max0p6"
+  "L1_DoubleEG15_11_er1p2_dR_Max0p6",
+  "L1_DoubleEG16_11_er1p2_dR_Max0p6",
+  "L1_DoubleEG17_11_er1p2_dR_Max0p6"
 ]
 
 SinglePhotonL1 = [


### PR DESCRIPTION
#### PR description:

Replace L1T seed `DoubleEG11` for 2025 data-taking according to https://its.cern.ch/jira/browse/CMSHLT-3488

This is a follow-up PR for [Include HLT(DST) + L1 seed information in Scouting Offline DQM for EGM #47889](https://github.com/cms-sw/cmssw/pull/47889)

#### Description of the current changes:

The updates include:
- replacing `DoubleEG11` to `DoubleEG{15,16,17}_11`


#### PR validation:

Validation done for [Include HLT(DST) + L1 seed information in Scouting Offline DQM for EGM #47889](https://github.com/cms-sw/cmssw/pull/47889). Minor changes for this PR, so didn't run through dedicated validation.

The PR has been prepared starting from CMSSW_15_1_0_pre1:
```
cmsrel CMSSW_15_1_0_pre1
cd CMSSW_15_1_0_pre1/src
cmsenv
git cms-init
git cms-addpkg HLTriggerOffline
scram b && scram b code-checks && scram b code-format && scram b
```

We used the same testing workflows as the previous PR: [Scouting Offline DQM for 2025 data-taking (EGM+MUO+autoDQM)](https://github.com/cms-sw/cmssw/pull/47235#top) 

```
[1]: input: RAW file from ScoutingPFMonitor dataset (Run2024F, [Fill9852](https://cmsoms.cern.ch/cms/fills/report?cms_fill=9852), run382686)

[2]: cmsDriver.py step2  --process reHLT -s L1REPACK:Full,HLT:@relval2025 --conditions auto:run3_hlt_relval --data  --eventcontent FEVTDEBUGHLT --datatier FEVTDEBUGHLT --era Run3_2024 -n 500 --filein  file:/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/Scouting/Run3/ScoutingPFMonitor/300684ed-1a51-474f-8c4f-b3bf1e1f5044_skimmed.root

[3]: cmsDriver.py step3  --conditions auto:run3_data_prompt_relval -s RAW2DIGI,L1Reco,RECO,PAT,NANO,DQM:@hltScouting --datatier RECO,MINIAOD,NANOAOD,DQMIO --eventcontent RECO,MINIAOD,NANOEDMAOD,DQM --data  --process reRECO --scenario pp --era Run3_2024 --customise Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_2024 -n 500 --filein file:step2_L1REPACK_HLT.root

[4]: cmsDriver.py step4 -s HARVESTING:@hltScouting --conditions auto:run3_data --data  --filetype DQM --scenario pp --era Run3_2024 -n 500 --filein file:step3_RAW2DIGI_L1Reco_RECO_PAT_NANO_DQM_inDQM.root
```
Also picked another workflow to validate
```
 runTheMatrix.py -l 145.314
```

[cc: @silviodonato @elfontan @mmusich  ]
