### PR TITLE
fix-Repack-RawSkim-Logic

### DIFF
--- a/Configuration/DataProcessing/python/Repack.py
+++ b/Configuration/DataProcessing/python/Repack.py
@@ -79,16 +79,22 @@ def repackProcess(**args):
 
         if rawSkim:
 
+            skim = getattr(RawSkims, rawSkim)
+            setattr(process, rawSkim, skim)
+
             selectEventsBase = [item.replace(":HLT", "") for item in selectEventsBase]
 
-            process.baseSelection = hlt.hltHighLevel.clone(
+            baseSelection = hlt.hltHighLevel.clone(
                 TriggerResultsTag = "TriggerResults::HLT",
                 HLTPaths = cms.vstring(selectEventsBase)
             )
-            skim = getattr(RawSkims, rawSkim)
-            setattr(process, rawSkim, skim)
-            path = cms.Path(skim + process.baseSelection)
-            selectEvents = f"{rawSkim}Path"
+
+            path = cms.Path(skim + baseSelection)
+            
+            baseSelectionName = output['moduleLabel'].split('_')[1] + f'_{rawSkim}'
+
+            setattr(process, baseSelectionName, baseSelection)
+            selectEvents = f"{baseSelectionName}Path"
             setattr(process, selectEvents, path)
 
         else:


### PR DESCRIPTION
#### PR description:

After validating the output of the new feature developed in https://github.com/cms-sw/cmssw/pull/47525, we identified a bug in the logic in which the raw skim outputs are overwritten in the PSet file. I will provide details now:

* When a stream is mapped to multiple PDs, it has different HLT paths in each output, one for each PD.
* To make sure that we were selecting events based on the HLT path concerning one of the possible PDs, we create the process attribute in : https://github.com/cms-sw/cmssw/blob/master/Configuration/DataProcessing/python/Repack.py#L84
* The issue is that this is in a loop for each output, so such `process.baseSelection` object gets overwritten.
* The consequence is that when we enable `ReserveDMu` raw skim for `ParkingDoubleMuonLowMass0` and `ParkingDoubleMuonLowMass1`, we get identical outputs for each raw skim dataset.

The previous behavior can be seen in the PSet section:
```
process.baseSelection = cms.EDFilter("HLTHighLevel",
    HLTPaths = cms.vstring('Dataset_ParkingDoubleMuonLowMass1'),
    TriggerResultsTag = cms.InputTag("TriggerResults","","HLT"),
    andOr = cms.bool(True),
    eventSetupPathsKey = cms.string(''),
    eventSetupPathsLabel = cms.string(''),
    mightGet = cms.optional.untracked.vstring,
    throw = cms.bool(True)
)
```

I have placed the bugged PSet and corresponding output in:
```
/eos/home-c/cmst0/public/RawSkim/bugged
```
#### PR validation:

We tested the changes in this PR locally, and now we get relevant outputs. In summary, we see the following:
* Input file: `/eos/cms/store/t0streamer/Data/ParkingDoubleMuonLowMass0/000/391/950/run391950_ls0003_streamParkingDoubleMuonLowMass0_StorageManager.dat` --> 321 events
* `ParkingDoubleMuonLowMass0_ReserveDMu_RAW` --> 56 events
* `ParkingDoubleMuonLowMass1_ReserveDMu_RAW` --> 32 events

I have placed the new PSet and corresponding output in:
```
/eos/home-c/cmst0/public/RawSkim/fixed
```

