### PR TITLE
Preliminary fixes for NanoAODRNTupleOutputModule

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/BuildFile.xml
+++ b/PhysicsTools/NanoAOD/plugins/BuildFile.xml
@@ -38,9 +38,7 @@
   <use name="roottmva"/>
   <flags EDM_PLUGIN="1"/>
 </library>
-<!-- Disable RNuple plugin: https://github.com/cms-sw/cmsdist/pull/9451#issuecomment-2393861542
 <library file="rntuple/*.cc" name="PhysicsToolsNanoAODRNuplePlugins">
   <use name="rootntuple"/>
   <flags EDM_PLUGIN="1"/>
 </library>
--->

--- a/PhysicsTools/NanoAOD/plugins/rntuple/EventStringOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/EventStringOutputFields.h
@@ -6,7 +6,7 @@
 #include "FWCore/Utilities/interface/EDGetToken.h"
 
 #include <ROOT/RNTupleModel.hxx>
-using ROOT::Experimental::RNTupleModel;
+using ROOT::RNTupleModel;
 
 #include "RNTupleFieldPtr.h"
 

--- a/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTupleOutputModule.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTupleOutputModule.cc
@@ -15,19 +15,9 @@
 
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>
-#include <ROOT/RPageStorageFile.hxx>
-using ROOT::Experimental::RNTupleModel;
-#if ROOT_VERSION_CODE < ROOT_VERSION(6, 31, 0)
-using ROOT::Experimental::RNTupleWriter;
-using ROOT::Experimental::Detail::RPageSinkFile;
-#define MakeRNTupleWriter std::make_unique<RNTupleWriter>
-#include <ROOT/RNTupleOptions.hxx>
-#else
-using ROOT::Experimental::Internal::RPageSinkFile;
-#define MakeRNTupleWriter ROOT::Experimental::Internal::CreateRNTupleWriter
+using ROOT::RNTupleModel;
 #include <ROOT/RNTupleWriteOptions.hxx>
-#endif
-using ROOT::Experimental::RNTupleWriteOptions;
+using ROOT::RNTupleWriteOptions;
 
 #include "TObjString.h"
 
@@ -210,10 +200,15 @@ void NanoAODRNTupleOutputModule::initializeNTuple(edm::EventForOutput const& iEv
     trigger.createFields(iEvent, *model);
   }
   m_evstrings.createFields(*model);
-  // TODO use Append
+
+  // Model needs to be frozen before we bind buffers
+  model->Freeze();
+
+  m_tables.bindBuffers(*model);
+
   RNTupleWriteOptions options;
   options.SetCompression(m_file->GetCompressionSettings());
-  m_ntuple = MakeRNTupleWriter(std::move(model), std::make_unique<RPageSinkFile>("Events", *m_file, options));
+  m_ntuple = RNTupleWriter::Append(std::move(model), "Events", *m_file, options);
 }
 
 void NanoAODRNTupleOutputModule::write(edm::EventForOutput const& iEvent) {

--- a/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTuples.h
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTuples.h
@@ -12,14 +12,8 @@
 
 #include "TFile.h"
 #include <ROOT/RNTuple.hxx>
-#if ROOT_VERSION_CODE < ROOT_VERSION(6, 31, 0)
-using ROOT::Experimental::RCollectionNTupleWriter;
-#else
 #include <ROOT/RNTupleWriter.hxx>
-#include <ROOT/RNTupleCollectionWriter.hxx>
-using ROOT::Experimental::RNTupleCollectionWriter;
-#endif
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::RNTupleWriter;
 
 #include "EventStringOutputFields.h"
 #include "RNTupleFieldPtr.h"
@@ -62,21 +56,9 @@ public:
   void finalizeWrite();
 
 private:
-  // TODO blocked on RNTuple std::pair support
-  // using PSetType = std::pair<edm::ParameterSetID, edm::ParameterSetBlob>;
-  // RNTupleFieldPtr<PSetType> m_pset;
+  using PSetType = std::pair<edm::ParameterSetID, edm::ParameterSetBlob>;
+  RNTupleFieldPtr<PSetType> m_pset;
   void createFields(TFile& file);
-  // TODO blocked on RNTuple typedef member field support:
-  // https://github.com/root-project/root/issues/7861
-  // RNTupleFieldPtr<edm::ParameterSetID> m_psetId;
-  // RNTupleFieldPtr<edm::ParameterSetBlob> m_psetBlob;
-#if ROOT_VERSION_CODE < ROOT_VERSION(6, 31, 0)
-  std::shared_ptr<RCollectionNTupleWriter> m_collection;
-#else
-  std::shared_ptr<RNTupleCollectionWriter> m_collection;
-#endif
-  RNTupleFieldPtr<std::string> m_psetId;
-  RNTupleFieldPtr<std::string> m_psetBlob;
   std::unique_ptr<RNTupleWriter> m_ntuple;
 };
 
@@ -88,13 +70,7 @@ public:
 
 private:
   void createFields(TFile& file);
-#if ROOT_VERSION_CODE < ROOT_VERSION(6, 31, 0)
-  std::shared_ptr<RCollectionNTupleWriter> m_procHist;
-#else
-  std::shared_ptr<RNTupleCollectionWriter> m_procHist;
-#endif
-
-  RNTupleFieldPtr<std::string> m_phId;
+  RNTupleFieldPtr<edm::ProcessHistory> m_procHist;
   std::unique_ptr<RNTupleWriter> m_ntuple;
 };
 

--- a/PhysicsTools/NanoAOD/plugins/rntuple/RNTupleCollection.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/RNTupleCollection.cc
@@ -1,0 +1,128 @@
+#include "RNTupleCollection.h"
+
+#include <ROOT/RFieldBase.hxx>
+#include <ROOT/RField/RFieldRecord.hxx>
+#include <ROOT/RField/RFieldSequenceContainer.hxx>
+
+using ROOT::REntry;
+using ROOT::RFieldBase;
+using ROOT::RNTupleModel;
+using ROOT::RRecordField;
+using ROOT::RVectorField;
+
+std::string flatTableColumnTypeToString(nanoaod::FlatTable::ColumnType type) {
+  switch (type) {
+    case nanoaod::FlatTable::ColumnType::UInt8:
+      return "std::uint8_t";
+    case nanoaod::FlatTable::ColumnType::Int16:
+      return "std::int16_t";
+    case nanoaod::FlatTable::ColumnType::UInt16:
+      return "std::uint16_t";
+    case nanoaod::FlatTable::ColumnType::Int32:
+      return "std::int32_t";
+    case nanoaod::FlatTable::ColumnType::UInt32:
+      return "std::uint32_t";
+    case nanoaod::FlatTable::ColumnType::Int64:
+      return "std::int64_t";
+    case nanoaod::FlatTable::ColumnType::UInt64:
+      return "std::uint64_t";
+    case nanoaod::FlatTable::ColumnType::Bool:
+      return "bool";
+    case nanoaod::FlatTable::ColumnType::Float:
+      return "float";
+    case nanoaod::FlatTable::ColumnType::Double:
+      return "double";
+    default:
+      throw cms::Exception("LogicError", "Unsupported type");
+  }
+}
+
+std::tuple<const unsigned char*, unsigned int> getColStartAndTypeSize(edm::Handle<nanoaod::FlatTable>& table,
+                                                                      unsigned int colIdx) {
+  const unsigned char* col_start;
+  switch (table->columnType(colIdx)) {
+    case nanoaod::FlatTable::ColumnType::UInt8:
+      col_start = reinterpret_cast<const unsigned char*>(table->columnData<uint8_t>(colIdx).data());
+      return std::make_tuple(col_start, 1);
+    case nanoaod::FlatTable::ColumnType::Int16:
+      col_start = reinterpret_cast<const unsigned char*>(table->columnData<int16_t>(colIdx).data());
+      return std::make_tuple(col_start, 2);
+    case nanoaod::FlatTable::ColumnType::UInt16:
+      col_start = reinterpret_cast<const unsigned char*>(table->columnData<uint16_t>(colIdx).data());
+      return std::make_tuple(col_start, 2);
+    case nanoaod::FlatTable::ColumnType::Int32:
+      col_start = reinterpret_cast<const unsigned char*>(table->columnData<int32_t>(colIdx).data());
+      return std::make_tuple(col_start, 4);
+    case nanoaod::FlatTable::ColumnType::UInt32:
+      col_start = reinterpret_cast<const unsigned char*>(table->columnData<uint32_t>(colIdx).data());
+      return std::make_tuple(col_start, 4);
+    case nanoaod::FlatTable::ColumnType::Int64:
+      col_start = reinterpret_cast<const unsigned char*>(table->columnData<int64_t>(colIdx).data());
+      return std::make_tuple(col_start, 8);
+    case nanoaod::FlatTable::ColumnType::UInt64:
+      col_start = reinterpret_cast<const unsigned char*>(table->columnData<uint64_t>(colIdx).data());
+      return std::make_tuple(col_start, 8);
+    case nanoaod::FlatTable::ColumnType::Bool:
+      col_start = reinterpret_cast<const unsigned char*>(table->columnData<bool>(colIdx).data());
+      return std::make_tuple(col_start, 1);
+    case nanoaod::FlatTable::ColumnType::Float:
+      col_start = reinterpret_cast<const unsigned char*>(table->columnData<float>(colIdx).data());
+      return std::make_tuple(col_start, 4);
+    case nanoaod::FlatTable::ColumnType::Double:
+      col_start = reinterpret_cast<const unsigned char*>(table->columnData<double>(colIdx).data());
+      return std::make_tuple(col_start, 8);
+    default:
+      throw cms::Exception("LogicError", "Unsupported type");
+  }
+}
+
+RNTupleCollection::RNTupleCollection(const std::string& name,
+                                     const std::string& desc,
+                                     std::vector<edm::Handle<nanoaod::FlatTable>>& tables,
+                                     RNTupleModel& model)
+    : m_name(name) {
+  std::vector<std::unique_ptr<RFieldBase>> subfields;
+  for (auto& table : tables) {
+    for (unsigned int i = 0; i < table->nColumns(); i++) {
+      std::string type = flatTableColumnTypeToString(table->columnType(i));
+      auto field = RFieldBase::Create(table->columnName(i), type).Unwrap();
+      field->SetDescription(table->columnDoc(i));
+      subfields.push_back(std::move(field));
+    }
+  }
+  auto record_field = std::make_unique<RRecordField>("_0", std::move(subfields));
+  m_record_size = record_field->GetValueSize();
+  m_record_offsets = record_field->GetOffsets();
+  auto collection_field = RVectorField::CreateUntyped(name, std::move(record_field));
+  collection_field->SetDescription(desc);
+  model.AddField(std::move(collection_field));
+}
+
+void RNTupleCollection::bindBuffer(RNTupleModel& model) {
+  auto& default_entry = model.GetDefaultEntry();
+  default_entry.BindRawPtr<void>(m_name, &m_buffer);
+}
+
+void RNTupleCollection::fill(std::vector<edm::Handle<nanoaod::FlatTable>>& tables) {
+  unsigned int col_idx = 0;
+  size_t col_size = tables.empty() ? 0 : tables[0]->size();
+
+  m_buffer.resize(m_record_size * col_size);
+
+  for (auto& table : tables) {
+    if (table->size() != col_size) {
+      throw cms::Exception("LogicError",
+                           "Mismatch in number of entries between extension and main table for " + m_name);
+    }
+    for (unsigned int i = 0; i < table->nColumns(); i++) {
+      auto [col_start, type_size] = getColStartAndTypeSize(table, i);
+      size_t col_offset = m_record_offsets[col_idx];
+
+      for (unsigned int j = 0; j < col_size; j++) {
+        std::memcpy(m_buffer.data() + (j * m_record_size) + col_offset, col_start + (j * type_size), type_size);
+      }
+
+      col_idx++;
+    }
+  }
+}

--- a/PhysicsTools/NanoAOD/plugins/rntuple/RNTupleCollection.h
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/RNTupleCollection.h
@@ -1,0 +1,30 @@
+#ifndef PhysicsTools_NanoAOD_RNTupleCollection_h
+#define PhysicsTools_NanoAOD_RNTupleCollection_h
+
+#include "DataFormats/NanoAOD/interface/FlatTable.h"
+#include "DataFormats/Common/interface/Handle.h"
+
+#include <ROOT/RNTupleModel.hxx>
+#include <ROOT/REntry.hxx>
+
+class RNTupleCollection {
+public:
+  RNTupleCollection() = delete;
+  RNTupleCollection(const std::string& name,
+                    const std::string& desc,
+                    std::vector<edm::Handle<nanoaod::FlatTable>>& tables,
+                    ROOT::RNTupleModel& model);
+
+  const std::string& getFieldName() const { return m_name; }
+
+  void bindBuffer(ROOT::RNTupleModel& model);
+  void fill(std::vector<edm::Handle<nanoaod::FlatTable>>& tables);
+
+private:
+  std::string m_name;
+  std::size_t m_record_size;
+  std::vector<std::size_t> m_record_offsets;
+  std::vector<unsigned char> m_buffer;
+};
+
+#endif

--- a/PhysicsTools/NanoAOD/plugins/rntuple/RNTupleFieldPtr.h
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/RNTupleFieldPtr.h
@@ -2,14 +2,14 @@
 #define PhysicsTools_NanoAOD_RNTupleFieldPtr_h
 
 #include <ROOT/RNTupleModel.hxx>
-using ROOT::Experimental::RNTupleModel;
+#include <ROOT/REntry.hxx>
 
 template <typename T>
 class RNTupleFieldPtr {
 public:
   RNTupleFieldPtr() = default;
-  explicit RNTupleFieldPtr(const std::string& name, const std::string& desc, RNTupleModel& model) : m_name(name) {
-    m_field = model.MakeField<T>({m_name, desc});
+  explicit RNTupleFieldPtr(const std::string& name, const std::string& desc, ROOT::RNTupleModel& model) : m_name(name) {
+    m_field = model.MakeField<T>(m_name, desc);
   }
   void fill(const T& value) { *m_field = value; }
   const std::string& getFieldName() const { return m_name; }

--- a/PhysicsTools/NanoAOD/plugins/rntuple/SummaryTableOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/SummaryTableOutputFields.cc
@@ -1,12 +1,13 @@
 #include "SummaryTableOutputFields.h"
 
+using ROOT::RNTupleModel;
+
 template <typename T, typename Col>
 std::vector<RNTupleFieldPtr<T>> SummaryTableOutputFields::makeFields(const std::vector<Col> &tabcols,
                                                                      RNTupleModel &model) {
   std::vector<RNTupleFieldPtr<T>> fields;
   fields.reserve(tabcols.size());
   for (const auto &col : tabcols) {
-    // TODO field description
     fields.emplace_back(RNTupleFieldPtr<T>(col.name, col.doc, model));
   }
   return fields;
@@ -26,6 +27,7 @@ void SummaryTableOutputFields::fillScalarFields(const std::vector<Col> &tabcols,
   }
 }
 
+// TODO: maybe we can unify with the function above since now it's the same
 template <typename T, typename Col>
 void SummaryTableOutputFields::fillVectorFields(const std::vector<Col> &tabcols,
                                                 std::vector<RNTupleFieldPtr<T>> fields) {
@@ -36,22 +38,17 @@ void SummaryTableOutputFields::fillVectorFields(const std::vector<Col> &tabcols,
     if (tabcols[i].name != fields[i].getFieldName()) {
       throw cms::Exception("LogicError", "Mismatch in table columns");
     }
-    auto data = tabcols[i].values;
-    // TODO remove this awful hack when std::int64_t is supported
-    // -- turns std::vector<int64_t> into std::vector<uint64_t>
-    T casted_data(data.begin(), data.end());
-    fields[i].fill(casted_data);
+    fields[i].fill(tabcols[i].values);
   }
 }
 
 SummaryTableOutputFields::SummaryTableOutputFields(const nanoaod::MergeableCounterTable &tab, RNTupleModel &model) {
-  // TODO use std::int64_t when supported
-  m_intFields = makeFields<std::uint64_t>(tab.intCols(), model);
-  m_floatFields = makeFields<double>(tab.floatCols(), model);
-  m_floatWithNormFields = makeFields<double>(tab.floatWithNormCols(), model);
-  m_vintFields = makeFields<std::vector<std::uint64_t>>(tab.vintCols(), model);
-  m_vfloatFields = makeFields<std::vector<double>>(tab.vfloatCols(), model);
-  m_vfloatWithNormFields = makeFields<std::vector<double>>(tab.vfloatWithNormCols(), model);
+  m_intFields = makeFields<int_accumulator>(tab.intCols(), model);
+  m_floatFields = makeFields<float_accumulator>(tab.floatCols(), model);
+  m_floatWithNormFields = makeFields<float_accumulator>(tab.floatWithNormCols(), model);
+  m_vintFields = makeFields<std::vector<int_accumulator>>(tab.vintCols(), model);
+  m_vfloatFields = makeFields<std::vector<float_accumulator>>(tab.vfloatCols(), model);
+  m_vfloatWithNormFields = makeFields<std::vector<float_accumulator>>(tab.vfloatWithNormCols(), model);
 }
 
 void SummaryTableOutputFields::fill(const nanoaod::MergeableCounterTable &tab) {

--- a/PhysicsTools/NanoAOD/plugins/rntuple/SummaryTableOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/SummaryTableOutputFields.h
@@ -8,23 +8,26 @@
 class SummaryTableOutputFields {
 public:
   SummaryTableOutputFields() = default;
-  SummaryTableOutputFields(const nanoaod::MergeableCounterTable &tab, RNTupleModel &model);
+  SummaryTableOutputFields(const nanoaod::MergeableCounterTable &tab, ROOT::RNTupleModel &model);
   void fill(const nanoaod::MergeableCounterTable &tab);
 
 private:
   template <typename T, typename Col>
-  std::vector<RNTupleFieldPtr<T>> makeFields(const std::vector<Col> &tabcols, RNTupleModel &model);
+  std::vector<RNTupleFieldPtr<T>> makeFields(const std::vector<Col> &tabcols, ROOT::RNTupleModel &model);
   template <typename T, typename Col>
   static void fillScalarFields(const std::vector<Col> &tabcols, std::vector<RNTupleFieldPtr<T>> fields);
   template <typename T, typename Col>
   static void fillVectorFields(const std::vector<Col> &tabcols, std::vector<RNTupleFieldPtr<T>> fields);
 
-  std::vector<RNTupleFieldPtr<std::uint64_t>> m_intFields;
-  std::vector<RNTupleFieldPtr<double>> m_floatFields;
-  std::vector<RNTupleFieldPtr<double>> m_floatWithNormFields;
-  std::vector<RNTupleFieldPtr<std::vector<double>>> m_vfloatFields;
-  std::vector<RNTupleFieldPtr<std::vector<double>>> m_vfloatWithNormFields;
-  std::vector<RNTupleFieldPtr<std::vector<std::uint64_t>>> m_vintFields;
+  using int_accumulator = nanoaod::MergeableCounterTable::int_accumulator;
+  using float_accumulator = nanoaod::MergeableCounterTable::float_accumulator;
+
+  std::vector<RNTupleFieldPtr<int_accumulator>> m_intFields;
+  std::vector<RNTupleFieldPtr<float_accumulator>> m_floatFields;
+  std::vector<RNTupleFieldPtr<float_accumulator>> m_floatWithNormFields;
+  std::vector<RNTupleFieldPtr<std::vector<float_accumulator>>> m_vfloatFields;
+  std::vector<RNTupleFieldPtr<std::vector<float_accumulator>>> m_vfloatWithNormFields;
+  std::vector<RNTupleFieldPtr<std::vector<int_accumulator>>> m_vintFields;
 };
 
 #endif

--- a/PhysicsTools/NanoAOD/plugins/rntuple/TableOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/TableOutputFields.h
@@ -2,6 +2,7 @@
 #define PhysicsTools_NanoAOD_TableOutputFields_h
 
 #include "RNTupleFieldPtr.h"
+#include "RNTupleCollection.h"
 
 #include "FWCore/Framework/interface/EventForOutput.h"
 #include "DataFormats/NanoAOD/interface/FlatTable.h"
@@ -11,14 +12,8 @@
 
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>
-#if ROOT_VERSION_CODE < ROOT_VERSION(6, 31, 0)
-using ROOT::Experimental::RCollectionNTupleWriter;
-#else
-#include <ROOT/RNTupleCollectionWriter.hxx>
-using ROOT::Experimental::RNTupleCollectionWriter;
-#endif
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriter;
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriter;
 
 template <typename T>
 class FlatTableField {
@@ -73,6 +68,7 @@ public:
   void createFields(const edm::EventForOutput& event, RNTupleModel& model);
   void fillEntry(const nanoaod::FlatTable& table, std::size_t i);
   const edm::EDGetToken& getToken() const;
+  const edm::Handle<nanoaod::FlatTable> getTable(const edm::EventForOutput& event) const;
 
 private:
   edm::EDGetToken m_token;
@@ -108,6 +104,7 @@ public:
   // * m_main not null
   // * m_collectionName not empty
   void createFields(const edm::EventForOutput& event, RNTupleModel& eventModel);
+  void bindBuffer(RNTupleModel& eventModel);
   void fill(const edm::EventForOutput& event);
   void print() const;
   bool hasMainTable();
@@ -115,11 +112,7 @@ public:
 
 private:
   std::string m_collectionName;
-#if ROOT_VERSION_CODE < ROOT_VERSION(6, 31, 0)
-  std::shared_ptr<RCollectionNTupleWriter> m_collection;
-#else
-  std::shared_ptr<RNTupleCollectionWriter> m_collection;
-#endif
+  std::unique_ptr<RNTupleCollection> m_collection;
   TableOutputFields m_main;
   std::vector<TableOutputFields> m_extensions;
 };
@@ -128,6 +121,7 @@ class TableCollectionSet {
 public:
   void add(const edm::EDGetToken& table_token, const nanoaod::FlatTable& table);
   void createFields(const edm::EventForOutput& event, RNTupleModel& eventModel);
+  void bindBuffers(RNTupleModel& eventModel);
   void fill(const edm::EventForOutput& event);
   void print() const;
 

--- a/PhysicsTools/NanoAOD/plugins/rntuple/TriggerOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/TriggerOutputFields.cc
@@ -13,6 +13,8 @@
 
 #include <algorithm>
 
+using ROOT::RNTupleModel;
+
 namespace {
 
   void trimVersionSuffix(std::string& trigger_name) {
@@ -121,19 +123,14 @@ void TriggerOutputFields::updateTriggerFields(const edm::TriggerResults& trigger
   }
 }
 
-void TriggerOutputFields::makeUniqueFieldName(RNTupleModel& model, std::string& name) {
-  // Could also use a cache of names in a higher-level object, don't ask the RNTupleModel each time
-#if ROOT_VERSION_CODE < ROOT_VERSION(6, 31, 0)
-  auto existing_field = model.Get<bool>(name);
-#else
-  auto existing_field = model.GetDefaultEntry().GetPtr<bool>(name);
-#endif
-  if (!existing_field) {
+void TriggerOutputFields::makeUniqueFieldName(const RNTupleModel& model, std::string& name) {
+  bool already_exists = model.GetFieldNames().contains(name);
+
+  if (!already_exists) {
     return;
   }
-  edm::LogWarning("TriggerOutputFields") << "Found a branch with name " << name
-                                         << " already present. Will add suffix _p" << m_processName
-                                         << " to the new branch.\n";
+  edm::LogWarning("TriggerOutputFields") << "Found a field with name " << name << " already present. Will add suffix _p"
+                                         << m_processName << " to the new field.\n";
   name += std::string("_p") + m_processName;
 }
 

--- a/PhysicsTools/NanoAOD/plugins/rntuple/TriggerOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/TriggerOutputFields.h
@@ -13,7 +13,7 @@ namespace edm {
 class TriggerFieldPtr {
 public:
   TriggerFieldPtr() = default;
-  TriggerFieldPtr(std::string name, int index, std::string fieldName, std::string fieldDesc, RNTupleModel& model);
+  TriggerFieldPtr(std::string name, int index, std::string fieldName, std::string fieldDesc, ROOT::RNTupleModel& model);
   void fill(const edm::TriggerResults& triggers);
   const std::string& getTriggerName() const { return m_triggerName; }
   void setIndex(int newIndex) { m_triggerIndex = newIndex; }
@@ -30,14 +30,14 @@ public:
   TriggerOutputFields() = default;
   explicit TriggerOutputFields(const std::string& processName, const edm::EDGetToken& token)
       : m_token(token), m_lastRun(-1), m_processName(processName) {}
-  void createFields(const edm::EventForOutput& event, RNTupleModel& model);
+  void createFields(const edm::EventForOutput& event, ROOT::RNTupleModel& model);
   void fill(const edm::EventForOutput& event);
 
 private:
   static std::vector<std::string> getTriggerNames(const edm::TriggerResults& triggerResults);
   // Update trigger field information on run boundaries
   void updateTriggerFields(const edm::TriggerResults& triggerResults);
-  void makeUniqueFieldName(/*const*/ RNTupleModel& model, std::string& name);
+  void makeUniqueFieldName(const ROOT::RNTupleModel& model, std::string& name);
 
   edm::EDGetToken m_token;
   long m_lastRun;


### PR DESCRIPTION
This PR fixes `NanoAODRNTupleOutputModule` so that it can be compiled with the new version of ROOT used in the RNTuple branch (6.35).

It also starts the discussion of how RNTuple NanoAODs should be re-structured to take advantage of the new features available in RNTuple. For now NanoAOD tables relating to objects (Jets, Electrons, Photons, etc.) are grouped into untyped collections instead of having all of the fields be at the top level. It would be ideal to do something similar for trigger flags so that they can be grouped into untyped records, but the fact that trigger fields can be added midway through writing complicates things. We will continue discussions about this to reach a restructuring that is convenient, but that hopefully doesn't break backwards compatibility. This PR will be merged before all of this is done so that the CI doesn't continue to fail for other PRs, but we will continue to develop this code in a future PR.