### PR TITLE
use unpacked track-finder inputs for kBMTF in `L1REPACK:Full` [`15_0_X`]

### DIFF
--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_Full_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_Full_cff.py
@@ -110,6 +110,10 @@ for b in cutlist:
 simBmtfDigis.DTDigi_Source       = "unpackBmtf"
 simBmtfDigis.DTDigi_Theta_Source = "unpackBmtf"
 
+# kBMTF
+simKBmtfStubs.srcPhi = 'unpackBmtf'
+simKBmtfStubs.srcTheta = 'unpackBmtf'
+
 # OMTF
 simOmtfDigis.srcRPC              = 'unpackRPC'
 simOmtfDigis.srcDTPh             = "unpackBmtf"


### PR DESCRIPTION
backport of #48045

#### PR description:

From the description of #48045

> This PR updates the kBMTF inputs in `L1REPACK:Full`, making use of the unpacked BMTF data rather than the re-emulated trigger primitives. This follows what is done [here](https://github.com/cms-sw/cmssw/blob/341edfe4b80256c6606d4933bd786aa836530e65/L1Trigger/Configuration/python/customiseReEmul.py#L217-L220) in `customiseReEmul.L1TReEmulFromRAW`. For more context, see https://github.com/cms-sw/cmssw/issues/47925#issuecomment-2864575806.

#### PR validation:

None beyond the validation done for #48045 (which was done using `CMSSW_15_0_5`).

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

#48045

Bugfix, useful to integrate in the production cycle for offline trigger studies (it has no direct impact on data-taking operations).
