### PR TITLE
Add storage tracer

### DIFF
--- a/FWCore/Services/src/SiteLocalConfigService.cc
+++ b/FWCore/Services/src/SiteLocalConfigService.cc
@@ -576,10 +576,12 @@ namespace edm {
               "Specify the file containing the site local config. Empty string will load from default directory.");
       desc.addOptionalUntracked<std::string>("overrideSourceCacheTempDir");
       desc.addOptionalUntracked<double>("overrideSourceCacheMinFree");
-      desc.addOptionalUntracked<std::string>("overrideSourceCacheHintDir");
+      desc.addOptionalUntracked<std::string>("overrideSourceCacheHintDir")
+          ->setComment("Set cache hint. See AdaptorConfig plugin for valid values.");
       desc.addOptionalUntracked<std::string>("overrideSourceCloneCacheHintDir")
           ->setComment("Provide an alternate cache hint for fast cloning.");
-      desc.addOptionalUntracked<std::string>("overrideSourceReadHint");
+      desc.addOptionalUntracked<std::string>("overrideSourceReadHint")
+          ->setComment("Set read hint. See AdaptorConfig plugin for valid values.");
       desc.addOptionalUntracked<std::vector<std::string> >("overrideSourceNativeProtocols");
       desc.addOptionalUntracked<unsigned int>("overrideSourceTTreeCacheSize");
       desc.addOptionalUntracked<unsigned int>("overrideSourceTimeout");

--- a/IOPool/TFileAdaptor/src/TFileAdaptor.h
+++ b/IOPool/TFileAdaptor/src/TFileAdaptor.h
@@ -44,9 +44,9 @@ private:
   std::string readHint_;
   std::string tempDir_;
   double minFree_;
+  std::vector<std::string> native_;
   unsigned int timeout_;
   unsigned int debugLevel_;
-  std::vector<std::string> native_;
 };
 
 namespace edm {

--- a/Utilities/DCacheAdaptor/plugins/DCacheStorageMaker.cc
+++ b/Utilities/DCacheAdaptor/plugins/DCacheStorageMaker.cc
@@ -41,8 +41,7 @@ namespace edm::storage {
       else
         mode |= IOFlags::OpenUnbuffered;
 
-      auto file = std::make_unique<DCacheFile>(normalise(proto, path), mode);
-      return f->wrapNonLocalFile(std::move(file), proto, std::string(), mode);
+      return std::make_unique<DCacheFile>(normalise(proto, path), mode);
     }
 
     void stagein(const std::string &proto, const std::string &path, const AuxSettings &aux) const override {
@@ -76,6 +75,8 @@ namespace edm::storage {
 
       return true;
     }
+
+    UseLocalFile usesLocalFile() const override { return UseLocalFile::kNo; }
 
   private:
     void setTimeout(unsigned int timeout) const {

--- a/Utilities/DavixAdaptor/plugins/DavixStorageMaker.cc
+++ b/Utilities/DavixAdaptor/plugins/DavixStorageMaker.cc
@@ -15,10 +15,8 @@ namespace edm::storage {
                                   const std::string &path,
                                   int mode,
                                   AuxSettings const &aux) const override {
-      const StorageFactory *f = StorageFactory::get();
       std::string newurl((proto == "web" ? "http" : proto) + ":" + path);
-      auto file = std::make_unique<DavixFile>(newurl, mode);
-      return f->wrapNonLocalFile(std::move(file), proto, std::string(), mode);
+      return std::make_unique<DavixFile>(newurl, mode);
     }
 
     bool check(const std::string &proto,
@@ -43,6 +41,8 @@ namespace edm::storage {
       }
       return true;
     }
+
+    UseLocalFile usesLocalFile() const override { return UseLocalFile::kNo; }
   };
 }  // namespace edm::storage
 

--- a/Utilities/StorageFactory/BuildFile.xml
+++ b/Utilities/StorageFactory/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="FWCore/ParameterSet"/>
 <use name="FWCore/PluginManager"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>

--- a/Utilities/StorageFactory/README.md
+++ b/Utilities/StorageFactory/README.md
@@ -11,7 +11,7 @@ Factory interface for constructing `edm::storage::Storage` instances. Also provi
 `StorageFactory` provides two implementations of `edm::storage::Storage` classes which can be used to wrap around any other `Storage` object.
 
 ###  `edm::storage::LocalCacheFile`
-Does memory mapped caching of the wrapped `Storage` object.  This is only applied if `CACHE_HINT_LAZY_DOWNLOAD` is set for `cacheHint` or the protocol handling code explicit passes `IOFlags::OpenWrap` to `StorageFactory::wrapNonLocalFile`. The wrapping does not happen if the Storage is open for writing nor if the Storage is associated with a file on the local file system.
+Does memory mapped caching of the wrapped `Storage` object.  This is only applied if `CACHE_HINT_LAZY_DOWNLOAD` is set for `cacheHint` or the protocol handling code explicit passes `IOFlags::OpenWrap` to `StorageFactory::wrapNonLocalFile`. The wrapping does not happen if the Storage is open for writing nor if the Storage is associated with a file on the local file system. Note that files using the `file:` protocol _can_ end up using `LocalCacheFile` if the path is determined to be on a non-local file system.
 
 ### `edm::storage::StorageAccountProxy`
 This wraps the `Storage` object and provides per protocol accounting information (e.g. number of bytes read) to `edm::storage::StorageAccount`. This is only used if `StorageFactory::accounting()` returns `true`.
@@ -27,16 +27,66 @@ A singleton used to aggragate statistics about all storage calls for each protoc
 ### `edm::storage::StorageAccount::StorageClassToken`
 Each protocol is associated to a token for quick lookup.
 
+
+## Generic storage proxies
+
+This facility resembles the `edm::storage::LocalCacheFile` and `edm::storage::StorageAccountProxy` in the way that `edm::storage::Storage` objects constructed by the concrete `edm::storage::StorageMaker` are wrapped into other `edm::storage::Storage` objects.
+
+The proxies are configured via `TFileAdaptor`'s `storageProxies` `VPSet` configuration parameter. The proxies are wrapped in the order they are specified in the `VPSet`, i.e. the first element wraps the concrete `edm::storage::Storage`, second element wraps the first element etc. The `edm::storage::StorageAccountProxy` and `edm::storage::LocalCacheFile` wrap the last storage proxy according to their usual behavior.
+
+Each concrete proxy comes with two classes, the proxy class itself (inheriting from the `edm::storage::StorageProxyBase`) and a maker class (inheriting from the `edm::storage::StorageProxyMaker`). This "factory of factories" pattern is used because a maker is created once per job (in `TFileAdaptor`), and the maker object is used to create a proxy object for each file.
+
+### Concrete proxy classes
+
+The convention is to use the proxy class name as the plugin name for the maker, as the proxy is really what the user would care for. The headings of the subsections correspond to the plugin names.
+
+#### `StorageTracerProxy`
+
+The `edm::storage::StorageTracerProxy` (and the corresponding `edm::storage::StorageTracerProxyMaker`) produces a text file with a trace of all IO operations at the `StorageFactory` level. The behavior of each concrete `Storage` object (such as further splitting of read requests in `XrdAdaptor`) is not captured in these tracers. The structure of the trace file is described in a preamble in the trace file.
+
+The plugin has a configuration parameter for a pattern for the trace files. The pattern must contain at least one `%I`. The maker has an atomic counter for the files, and all occurrences of `%I` are replaced with the value of that counter for the given file.
+
+There is an `edmStorageTracer.py` script for doing some analyses of the traces.
+
+The `StorageTracerProxy` also provides a way to correlate the trace entries with the rest of the framework via [MessageLogger](../../FWCore/MessageService/Readme.md) messages. These messages are issued with the DEBUG severity and `IOTrace` category. There are additional, higher-level messages as part of the `PoolSource`. To see these messages, compile the `Utilities/Storage` and `IOPool/Input` packages with `USER_CXXFLAGS="-DEDM_ML_DEBUG", and customize the MessageLogger configuration along
+```py
+process.MessageLogger.cerr.threshold = "DEBUG"
+process.MessageLogger.debugModules = ["*"]
+process.MessageLogger.IOTrace = dict()
+```
+
+#### `StorageAddLatencyProxy`
+
+The `edm::storage::StorageAddLatencyProxy` (and the corresponding `edm::storage::StorageAddLatencyProxyMaker`) can be used to add artifical latency to the IO operations. The plugin has configuration parameters for latencies of singular reads, vector reads, singular writes, and vector writes.
+
+If used together with `StorageTracerProxy` to e.g. simulate the behavior of high-latency storage systems with e.g. local files, the `storageProxies` `VPSet` should have `StorageAddLatencyProxy` first, followed by `StorageTracerProxy`.
+
+### Other components
+
+#### `edm::storage::StorageProxyBase`
+
+Inherits from `edm::storage::Storage` and is the base class for the proxy classes.
+
+#### `edm::storage::StorageProxyMaker`
+
+Base class for the proxy makers.
+
+
 ## Related classes in other packages
 
 ### TStorageFactoryFile
 Inherits from `TFile` but uses `edm::storage::Storage` instances when doing the actual read/write operations. The class explicitly uses `"tstoragefile"` when communicating with `edm::storage::StorageAccount`.
 
-### TFileAdaptor
-TFileAdaptor is a cmsRun Service. It explicitly registers the use of `TStorageFactoryFile` with ROOT's `TFile::Open` system. The parameters passed to `TFileAdaptor` are relayed to `edm::storage::StorageFactory` to setup the defaults for the job.
+### `TFileAdaptor`
 
-### CondorStatusService
+`TFileAdaptor` is a cmsRun Service (with a plugin name of `AdaptorConfig`, see [IOPool/TFileAdaptor/README.md](../../IOPool/TFileAdaptor/README.md)). It explicitly registers the use of `TStorageFactoryFile` with ROOT's `TFile::Open` system. The parameters passed to `TFileAdaptor` are relayed to `edm::storage::StorageFactory` to setup the defaults for the job.
+
+### `CondorStatusService`
 Sends condor _Chirp_ messages periodically from cmsRun. These include the most recent aggregated `edm::storage::StorageAccount` information for all protocols being used except for the `"tstoragefile"` protocol.
 
-### StatisticsSenderService
+### `StatisticsSenderService`
 A cmsRun Service which sends out UDP packets about the state of the system. The information is sent when a primary file closes and includes the recent aggregated `edm::storage::StorageAccount` information for all protocols being used except for the `"tstoragefile"` protocol.
+
+### `XrdAdaptor`
+
+A `edm::storage::Storage` implementation for xrootd (see [Utilities/XrdAdaptor/README.md](../../Utilities/XrdAdaptor/README.md)).

--- a/Utilities/StorageFactory/interface/StorageFactory.h
+++ b/Utilities/StorageFactory/interface/StorageFactory.h
@@ -5,8 +5,11 @@
 #include "Utilities/StorageFactory/interface/LocalFileSystem.h"
 #include "Utilities/StorageFactory/interface/IOTypes.h"
 #include "Utilities/StorageFactory/interface/IOFlags.h"
-#include <string>
+
 #include <memory>
+#include <string>
+#include <tuple>
+
 #include "oneapi/tbb/concurrent_unordered_map.h"
 
 namespace edm::storage {
@@ -50,13 +53,8 @@ namespace edm::storage {
     double tempMinFree(void) const;
 
     void stagein(const std::string &url) const;
-    std::unique_ptr<Storage> open(const std::string &url, int mode = IOFlags::OpenRead) const;
+    std::unique_ptr<Storage> open(const std::string &url, const int mode = IOFlags::OpenRead) const;
     bool check(const std::string &url, IOOffset *size = nullptr) const;
-
-    std::unique_ptr<Storage> wrapNonLocalFile(std::unique_ptr<Storage> s,
-                                              const std::string &proto,
-                                              const std::string &path,
-                                              int mode) const;
 
   private:
     typedef oneapi::tbb::concurrent_unordered_map<std::string, std::shared_ptr<StorageMaker>> MakerTable;
@@ -64,6 +62,14 @@ namespace edm::storage {
     StorageFactory(void);
     StorageMaker *getMaker(const std::string &proto) const;
     StorageMaker *getMaker(const std::string &url, std::string &protocol, std::string &rest) const;
+
+    // Returns
+    // - Storage 's' possibly wrapped in LocalCacheFile
+    // - bool telling if LocalCacheFile is used
+    std::tuple<std::unique_ptr<Storage>, bool> wrapNonLocalFile(std::unique_ptr<Storage> s,
+                                                                const std::string &proto,
+                                                                const std::string &path,
+                                                                const int mode) const;
 
     mutable MakerTable m_makers;
     CacheHint m_cacheHint;

--- a/Utilities/StorageFactory/interface/StorageFactory.h
+++ b/Utilities/StorageFactory/interface/StorageFactory.h
@@ -20,6 +20,10 @@ namespace edm::storage {
     static const StorageFactory *get(void);
     static StorageFactory *getToModify(void);
 
+    // in GB
+    static double defaultMinTempFree() { return 4.; }
+    static std::string defaultTempDir();
+
     ~StorageFactory(void);
 
     // implicit copy constructor

--- a/Utilities/StorageFactory/interface/StorageFactory.h
+++ b/Utilities/StorageFactory/interface/StorageFactory.h
@@ -14,6 +14,7 @@
 
 namespace edm::storage {
   class Storage;
+  class StorageProxyMaker;
   class StorageFactory {
   public:
     enum CacheHint { CACHE_HINT_APPLICATION, CACHE_HINT_STORAGE, CACHE_HINT_LAZY_DOWNLOAD, CACHE_HINT_AUTO_DETECT };
@@ -82,6 +83,7 @@ namespace edm::storage {
     unsigned int m_timeout;
     unsigned int m_debugLevel;
     LocalFileSystem m_lfs;
+    std::vector<std::unique_ptr<StorageProxyMaker>> m_storageProxyMakers_;
     static StorageFactory s_instance;
   };
 }  // namespace edm::storage

--- a/Utilities/StorageFactory/interface/StorageFactory.h
+++ b/Utilities/StorageFactory/interface/StorageFactory.h
@@ -53,6 +53,8 @@ namespace edm::storage {
     std::string tempPath(void) const;
     double tempMinFree(void) const;
 
+    void setStorageProxyMakers(std::vector<std::unique_ptr<StorageProxyMaker>> makers);
+
     void stagein(const std::string &url) const;
     std::unique_ptr<Storage> open(const std::string &url, const int mode = IOFlags::OpenRead) const;
     bool check(const std::string &url, IOOffset *size = nullptr) const;

--- a/Utilities/StorageFactory/interface/StorageMaker.h
+++ b/Utilities/StorageFactory/interface/StorageMaker.h
@@ -24,6 +24,8 @@ namespace edm::storage {
       }
     };
 
+    enum class UseLocalFile { kYes, kCheckFromPath, kNo };
+
     StorageMaker() = default;
     virtual ~StorageMaker() = default;
     // implicit copy constructor
@@ -38,6 +40,9 @@ namespace edm::storage {
                        const std::string &path,
                        const AuxSettings &aux,
                        IOOffset *size = nullptr) const;
+
+    // If the file being read in the end is a local file or not
+    virtual UseLocalFile usesLocalFile() const = 0;
   };
 }  // namespace edm::storage
 #endif  // STORAGE_FACTORY_STORAGE_MAKER_H

--- a/Utilities/StorageFactory/interface/StorageProxyMaker.h
+++ b/Utilities/StorageFactory/interface/StorageProxyMaker.h
@@ -1,0 +1,19 @@
+#ifndef Utilities_StorageFactory_StorageProxyMaker_h
+#define Utilities_StorageFactory_StorageProxyMaker_h
+
+#include <memory>
+
+namespace edm::storage {
+  class Storage;
+
+  // Base class for makers of generic Storage proxies
+  class StorageProxyMaker {
+  public:
+    StorageProxyMaker() = default;
+    virtual ~StorageProxyMaker();
+
+    virtual std::unique_ptr<Storage> wrap(std::unique_ptr<Storage> storage) = 0;
+  };
+}  // namespace edm::storage
+
+#endif

--- a/Utilities/StorageFactory/interface/StorageProxyMaker.h
+++ b/Utilities/StorageFactory/interface/StorageProxyMaker.h
@@ -2,6 +2,7 @@
 #define Utilities_StorageFactory_StorageProxyMaker_h
 
 #include <memory>
+#include <string>
 
 namespace edm::storage {
   class Storage;
@@ -12,7 +13,7 @@ namespace edm::storage {
     StorageProxyMaker() = default;
     virtual ~StorageProxyMaker();
 
-    virtual std::unique_ptr<Storage> wrap(std::unique_ptr<Storage> storage) = 0;
+    virtual std::unique_ptr<Storage> wrap(std::string const& url, std::unique_ptr<Storage> storage) const = 0;
   };
 }  // namespace edm::storage
 

--- a/Utilities/StorageFactory/interface/StorageProxyMakerFactory.h
+++ b/Utilities/StorageFactory/interface/StorageProxyMakerFactory.h
@@ -1,0 +1,14 @@
+#ifndef Utilities_StorageFactory_StorageProxyMakerFactory_h
+#define Utilities_StorageFactory_StorageProxyMakerFactory_h
+
+#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+#include "FWCore/PluginManager/interface/PluginFactory.h"
+
+#include <memory>
+
+namespace edm::storage {
+  class StorageProxyMaker;
+  using StorageProxyMakerFactory = edmplugin::PluginFactory<StorageProxyMaker*(edm::ParameterSet const&)>;
+};  // namespace edm::storage
+
+#endif

--- a/Utilities/StorageFactory/plugins/BuildFile.xml
+++ b/Utilities/StorageFactory/plugins/BuildFile.xml
@@ -3,3 +3,14 @@
   <flags EDM_PLUGIN="1"/>
   <flags cppflags="-D_FILE_OFFSET_BITS=64"/>
 </library>
+
+<library file="StorageTracerProxy.cc" name="UtilitiesStorageFactoryProxyPlugins">
+  <use name="FWCore/Concurrency"/>
+  <use name="FWCore/MessageLogger"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="Utilities/StorageFactory"/>
+  <use name="boost"/>
+  <use name="fmt"/>
+  <flags EDM_PLUGIN="1"/>
+  <flags cppflags="-D_FILE_OFFSET_BITS=64"/>
+</library>

--- a/Utilities/StorageFactory/plugins/BuildFile.xml
+++ b/Utilities/StorageFactory/plugins/BuildFile.xml
@@ -4,7 +4,7 @@
   <flags cppflags="-D_FILE_OFFSET_BITS=64"/>
 </library>
 
-<library file="StorageTracerProxy.cc" name="UtilitiesStorageFactoryProxyPlugins">
+<library file="StorageTracerProxy.cc StorageAddLatencyProxy.cc" name="UtilitiesStorageFactoryProxyPlugins">
   <use name="FWCore/Concurrency"/>
   <use name="FWCore/MessageLogger"/>
   <use name="FWCore/ParameterSet"/>

--- a/Utilities/StorageFactory/plugins/HttpStorageMaker.cc
+++ b/Utilities/StorageFactory/plugins/HttpStorageMaker.cc
@@ -18,6 +18,8 @@ namespace edm::storage {
 
       return RemoteFile::get(localfd, temp, (char **)curlopts, mode);
     }
+
+    UseLocalFile usesLocalFile() const override { return UseLocalFile::kYes; }
   };
 }  // namespace edm::storage
 

--- a/Utilities/StorageFactory/plugins/LocalStorageMaker.cc
+++ b/Utilities/StorageFactory/plugins/LocalStorageMaker.cc
@@ -24,8 +24,7 @@ namespace edm::storage {
       else
         mode |= IOFlags::OpenUnbuffered;
 
-      auto file = std::make_unique<File>(path, mode);
-      return f->wrapNonLocalFile(std::move(file), proto, path, mode);
+      return std::make_unique<File>(path, mode);
     }
 
     bool check(const std::string & /*proto*/,
@@ -41,6 +40,8 @@ namespace edm::storage {
 
       return true;
     }
+
+    UseLocalFile usesLocalFile() const override { return UseLocalFile::kCheckFromPath; }
   };
 }  // namespace edm::storage
 

--- a/Utilities/StorageFactory/plugins/StorageAddLatencyProxy.cc
+++ b/Utilities/StorageFactory/plugins/StorageAddLatencyProxy.cc
@@ -1,0 +1,130 @@
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/transform.h"
+#include "Utilities/StorageFactory/interface/Storage.h"
+#include "Utilities/StorageFactory/interface/StorageProxyMaker.h"
+
+#include <chrono>
+#include <regex>
+#include <thread>
+
+namespace edm::storage {
+  class StorageAddLatencyProxy : public Storage {
+  public:
+    struct LatencyConfig {
+      unsigned int read;
+      unsigned int readv;
+      unsigned int write;
+      unsigned int writev;
+    };
+
+    StorageAddLatencyProxy(LatencyConfig latency, std::unique_ptr<Storage> storage)
+        : latency_(latency), baseStorage_(std::move(storage)) {}
+
+    IOSize read(void* into, IOSize n) override {
+      auto const result = baseStorage_->read(into, n);
+      std::this_thread::sleep_for(std::chrono::microseconds(latency_.read));
+      return result;
+    }
+
+    IOSize read(void* into, IOSize n, IOOffset pos) override {
+      auto const result = baseStorage_->read(into, n, pos);
+      std::this_thread::sleep_for(std::chrono::microseconds(latency_.read));
+      return result;
+    }
+
+    IOSize readv(IOBuffer* into, IOSize n) override {
+      auto const result = baseStorage_->readv(into, n);
+      std::this_thread::sleep_for(std::chrono::microseconds(latency_.readv));
+      return result;
+    }
+
+    IOSize readv(IOPosBuffer* into, IOSize n) override {
+      auto const result = baseStorage_->readv(into, n);
+      std::this_thread::sleep_for(std::chrono::microseconds(latency_.readv));
+      return result;
+    }
+
+    IOSize write(const void* from, IOSize n) override {
+      auto const result = baseStorage_->write(from, n);
+      std::this_thread::sleep_for(std::chrono::microseconds(latency_.write));
+      return result;
+    }
+
+    IOSize write(const void* from, IOSize n, IOOffset pos) override {
+      auto const result = baseStorage_->write(from, n, pos);
+      std::this_thread::sleep_for(std::chrono::microseconds(latency_.write));
+      return result;
+    }
+
+    IOSize writev(const IOBuffer* from, IOSize n) override {
+      auto const result = baseStorage_->writev(from, n);
+      std::this_thread::sleep_for(std::chrono::microseconds(latency_.writev));
+      return result;
+    }
+
+    IOSize writev(const IOPosBuffer* from, IOSize n) override {
+      auto const result = baseStorage_->writev(from, n);
+      std::this_thread::sleep_for(std::chrono::microseconds(latency_.writev));
+      return result;
+    }
+
+    IOOffset position(IOOffset offset, Relative whence) override { return baseStorage_->position(offset, whence); }
+
+    void resize(IOOffset size) override { return baseStorage_->resize(size); }
+
+    void flush() override { return baseStorage_->flush(); }
+
+    void close() override { return baseStorage_->close(); }
+
+    bool prefetch(const IOPosBuffer* what, IOSize n) override { return baseStorage_->prefetch(what, n); }
+
+  private:
+    LatencyConfig latency_;
+    std::unique_ptr<Storage> baseStorage_;
+  };
+
+  class StorageAddLatencyProxyMaker : public StorageProxyMaker {
+  public:
+    StorageAddLatencyProxyMaker(edm::ParameterSet const& pset)
+        : latency_{.read = pset.getUntrackedParameter<unsigned int>("read"),
+                   .readv = pset.getUntrackedParameter<unsigned int>("readv"),
+                   .write = pset.getUntrackedParameter<unsigned int>("write"),
+                   .writev = pset.getUntrackedParameter<unsigned int>("writev")},
+          exclude_(vector_transform(pset.getUntrackedParameter<std::vector<std::string>>("exclude"),
+                                    [](std::string const& pattern) { return std::regex(pattern); })) {}
+
+    static void fillPSetDescription(edm::ParameterSetDescription& iDesc) {
+      iDesc.addUntracked<unsigned int>("read", 0)->setComment(
+          "Add this many microseconds of latency to singular reads");
+      iDesc.addUntracked<unsigned int>("readv", 0)->setComment("Add this many microseconds of latency to vector reads");
+      iDesc.addUntracked<unsigned int>("write", 0)
+          ->setComment("Add this many microseconds of latency to singular writes");
+      iDesc.addUntracked<unsigned int>("writev", 0)
+          ->setComment("Add this many microseconds of latency to vector writes");
+      iDesc.addUntracked<std::vector<std::string>>("exclude", {})
+          ->setComment(
+              "Latency is not added to the operations on the files whose URLs have a part that matches to any of the "
+              "regexes in this parameter");
+    }
+
+    std::unique_ptr<Storage> wrap(std::string const& url, std::unique_ptr<Storage> storage) const override {
+      for (auto const& pattern : exclude_) {
+        if (std::regex_search(url, pattern)) {
+          return storage;
+        }
+      }
+      return std::make_unique<StorageAddLatencyProxy>(latency_, std::move(storage));
+    }
+
+  private:
+    StorageAddLatencyProxy::LatencyConfig const latency_;
+    std::vector<std::regex> const exclude_;
+  };
+}  // namespace edm::storage
+
+#include "FWCore/ParameterSet/interface/ValidatedPluginMacros.h"
+#include "Utilities/StorageFactory/interface/StorageProxyMakerFactory.h"
+DEFINE_EDM_VALIDATED_PLUGIN(edm::storage::StorageProxyMakerFactory,
+                            edm::storage::StorageAddLatencyProxyMaker,
+                            "StorageAddLatencyProxy");

--- a/Utilities/StorageFactory/plugins/StorageTracerProxy.cc
+++ b/Utilities/StorageFactory/plugins/StorageTracerProxy.cc
@@ -1,0 +1,261 @@
+#include "FWCore/Concurrency/interface/ThreadSafeOutputFileStream.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "Utilities/StorageFactory/interface/Storage.h"
+#include "Utilities/StorageFactory/interface/StorageProxyMaker.h"
+
+#include <atomic>
+#include <chrono>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <type_traits>
+
+#include <boost/algorithm/string.hpp>
+#include <fmt/format.h>
+
+namespace edm::storage {
+  class StorageTracerProxy : public Storage {
+    static constexpr std::string_view kOpen = "o";
+    static constexpr std::string_view kRead = "r";
+    static constexpr std::string_view kReadv = "rv";
+    static constexpr std::string_view kReadvElement = "rve";
+    static constexpr std::string_view kWrite = "w";
+    static constexpr std::string_view kWritev = "wv";
+    static constexpr std::string_view kWritevElement = "wve";
+    static constexpr std::string_view kPosition = "s";
+    static constexpr std::string_view kPrefetch = "p";
+    static constexpr std::string_view kPrefetchElement = "pe";
+    static constexpr std::string_view kResize = "rsz";
+    static constexpr std::string_view kFlush = "f";
+    static constexpr std::string_view kClose = "c";
+
+  public:
+    StorageTracerProxy(unsigned id,
+                       std::string const& tracefile,
+                       std::string const& storageUrl,
+                       std::unique_ptr<Storage> storage)
+        : file_(tracefile), baseStorage_(std::move(storage)), traceId_(id) {
+      using namespace std::literals::string_literals;
+      file_.write(
+          "# Format\n"s + "# --------\n"s + "# prefixes\n"s + "# #: comment\n"s +
+          fmt::format("# {}: file open\n", kOpen) + fmt::format("# {}: singular read\n", kRead) +
+          fmt::format("# {}: vector read\n", kReadv) +
+          fmt::format("# {}: vector read element of the preceding '{}' line\n", kReadvElement, kReadv) +
+          fmt::format("# {}: singular write\n", kWrite) + fmt::format("# {}: vector write\n", kWritev) +
+          fmt::format("# {}: vector write element of the preceding '{}' line\n", kWritevElement, kWritev) +
+          fmt::format("# {}: position (seek)\n", kPosition) + fmt::format("# {}: prefetch\n", kPrefetch) +
+          fmt::format("# {}: prefetch element of the preceding '{}' line\n", kPrefetch, kPrefetchElement) +
+          fmt::format("# {}: resize\n", kResize) + fmt::format("# {}: flush\n", kFlush) +
+          fmt::format("# {}: close\n", kClose) + "# --------\n"s + "# line formats\n"s +
+          fmt::format("# {} <id> <timestamp ms> <file name>\n", kOpen) +
+          fmt::format("# {} <id> <timestamp ms> <duration us> <offset B> <requested B> <actual B>\n", kRead) +
+          fmt::format(
+              "# {} <id> <timestamp ms> <duration us> <requested total B> <actual total B> <number of elements>\n",
+              kReadv) +
+          fmt::format("# {} <index> <offset B> <requested B>\n", kReadvElement) +
+          fmt::format("# {} <id> <timestamp ms> <duration us> <offset B> <requested B> <actual B>\n", kWrite) +
+          fmt::format(
+              "# {} <id> <timestamp ms> <duration us> <requested total B> <actual total B> <number of elements>\n",
+              kWritev) +
+          fmt::format("# {} <index> <offset B> <requested B>\n", kWritevElement) +
+          fmt::format("# {} <id> <timestamp ms> <duration us> <offset B> <whence>\n", kPosition) +
+          fmt::format("# {} <id> <timestamp ms> <duration us> <requested total B> <number of elements> <supported?>\n",
+                      kPrefetch) +
+          fmt::format("# {} <index> <offset B> <requested B>\n", kPrefetchElement) +
+          fmt::format("# {} <id> <timestamp ms> <duration us> <size B>\n", kResize) +
+          fmt::format("# {} <id> <timestamp ms> <duration us>\n", kFlush) +
+          fmt::format("# {} <id> <timestamp ms> <duration us>\n", kClose) + "# --------\n"s);
+      auto const entryId = idCounter_.fetch_add(1);
+      file_.write(fmt::format("{} {} {} {}\n",
+                              kOpen,
+                              entryId,
+                              std::chrono::round<std::chrono::milliseconds>(now().time_since_epoch()).count(),
+                              storageUrl));
+      LogTrace("IOTrace").format("IOTrace {} id {}", traceId_, entryId);
+    }
+
+    IOSize read(void* into, IOSize n) override {
+      auto const offset = baseStorage_->position();
+      auto const [result, message] = operate([this, into, n]() { return baseStorage_->read(into, n); });
+      file_.write(fmt::format("{} {} {} {} {}\n", kRead, message, offset, n, result));
+      return result;
+    }
+
+    IOSize read(void* into, IOSize n, IOOffset pos) override {
+      auto const [result, message] = operate([this, into, n, pos]() { return baseStorage_->read(into, n, pos); });
+      file_.write(fmt::format("{} {} {} {} {}\n", kRead, message, pos, n, result));
+      return result;
+    }
+
+    IOSize readv(IOBuffer* into, IOSize n) override {
+      auto offset = baseStorage_->position();
+      auto const [result, message] = operate([this, into, n]() { return baseStorage_->readv(into, n); });
+      std::string elements;
+      IOSize total = 0;
+      for (IOSize i = 0; i < n; ++i) {
+        elements += fmt::format("{} {} {} {}\n", kReadvElement, i, offset, into[i].size());
+        total += into[i].size();
+        offset += into[i].size();
+      }
+      file_.write(fmt::format("{} {} {} {} {}\n", kReadv, message, total, result, n) + elements);
+      return result;
+    }
+
+    IOSize readv(IOPosBuffer* into, IOSize n) override {
+      auto const [result, message] = operate([this, into, n]() { return baseStorage_->readv(into, n); });
+      std::string elements;
+      IOSize total = 0;
+      for (IOSize i = 0; i < n; ++i) {
+        elements += fmt::format("{} {} {} {}\n", kReadvElement, i, into[i].offset(), into[i].size());
+        total += into[i].size();
+      }
+      file_.write(fmt::format("{} {} {} {} {}\n", kReadv, message, total, result, n) + elements);
+      return result;
+    }
+
+    IOSize write(const void* from, IOSize n) override {
+      auto const offset = baseStorage_->position();
+      auto const [result, message] = operate([this, from, n]() { return baseStorage_->write(from, n); });
+      file_.write(fmt::format("{} {} {} {} {}\n", kWrite, message, offset, n, result));
+      return result;
+    }
+
+    IOSize write(const void* from, IOSize n, IOOffset pos) override {
+      auto const [result, message] = operate([this, from, n, pos]() { return baseStorage_->write(from, n, pos); });
+      file_.write(fmt::format("{} {} {} {} {}\n", kWrite, message, pos, n, result));
+      return result;
+    }
+
+    IOSize writev(const IOBuffer* from, IOSize n) override {
+      auto offset = baseStorage_->position();
+      auto const [result, message] = operate([this, from, n]() { return baseStorage_->writev(from, n); });
+      std::string elements;
+      IOSize total = 0;
+      for (IOSize i = 0; i < n; ++i) {
+        elements += fmt::format("{} {} {} {}\n", kWritevElement, i, offset, from[i].size());
+        total += from[i].size();
+        offset += from[i].size();
+      }
+      file_.write(fmt::format("{} {} {} {} {}\n", kWritev, message, total, result, n) + elements);
+      return result;
+    }
+
+    IOSize writev(const IOPosBuffer* from, IOSize n) override {
+      auto const [result, message] = operate([this, from, n]() { return baseStorage_->writev(from, n); });
+      std::string elements;
+      IOSize total = 0;
+      for (IOSize i = 0; i < n; ++i) {
+        elements += fmt::format("{} {} {} {}\n", kWritevElement, i, from[i].offset(), from[i].size());
+        total += from[i].size();
+      }
+      file_.write(fmt::format("{} {} {} {} {}\n", kWritev, message, total, result, n) + elements);
+      return result;
+    }
+
+    IOOffset position(IOOffset offset, Relative whence) override {
+      auto const [result, message] =
+          operate([this, offset, whence]() { return baseStorage_->position(offset, whence); });
+      file_.write(fmt::format("{} {} {} {}\n", kPosition, message, offset, static_cast<int>(whence)));
+      return result;
+    }
+
+    void resize(IOOffset size) override {
+      auto const message = operate([this, size]() { return baseStorage_->resize(size); });
+      file_.write(fmt::format("{} {} {}\n", kResize, message, size));
+    }
+
+    void flush() override {
+      auto const message = operate([this]() { return baseStorage_->flush(); });
+      file_.write(fmt::format("{} {}\n", kFlush, message));
+    }
+
+    void close() override {
+      auto const message = operate([this]() { return baseStorage_->close(); });
+      file_.write(fmt::format("{} {}\n", kClose, message));
+    }
+
+    bool prefetch(const IOPosBuffer* what, IOSize n) override {
+      auto const [value, message] = operate([this, what, n]() { return baseStorage_->prefetch(what, n); });
+      std::string elements;
+      IOSize total = 0;
+      for (IOSize i = 0; i < n; ++i) {
+        elements += fmt::format("{} {} {} {}\n", kPrefetchElement, i, what[i].offset(), what[i].size());
+        total += what[i].size();
+      }
+      file_.write(fmt::format("{} {} {} {} {}\n", kPrefetch, message, total, n, value) + elements);
+      return value;
+    }
+
+  private:
+    template <typename F>
+    auto operate(F&& func) -> std::tuple<decltype(func()), std::string> {
+      auto const id = idCounter_.fetch_add(1);
+      auto const begin = now();
+      auto const result = func();
+      auto const end = now();
+      LogTrace("IOTrace").format("IOTrace {} id {}", traceId_, id);
+      return std::tuple(result,
+                        fmt::format("{} {} {}",
+                                    id,
+                                    std::chrono::round<std::chrono::milliseconds>(begin.time_since_epoch()).count(),
+                                    std::chrono::round<std::chrono::microseconds>(end - begin).count()));
+    }
+
+    template <typename F>
+      requires std::is_same_v<std::invoke_result_t<F>, void>
+    auto operate(F&& func) -> std::string {
+      auto const id = idCounter_.fetch_add(1);
+      auto const begin = now();
+      func();
+      auto const end = now();
+      LogTrace("IOTrace").format("IOTrace {} id {}", traceId_, id);
+      return fmt::format("{} {} {}",
+                         id,
+                         std::chrono::round<std::chrono::milliseconds>(begin.time_since_epoch()).count(),
+                         std::chrono::round<std::chrono::microseconds>(end - begin).count());
+    }
+
+    static std::chrono::time_point<std::chrono::steady_clock> now() { return std::chrono::steady_clock::now(); }
+
+    ThreadSafeOutputFileStream file_;
+    std::unique_ptr<Storage> baseStorage_;
+    std::atomic<unsigned int> idCounter_{0};
+    unsigned int const traceId_;
+  };
+
+  class StorageTracerProxyMaker : public StorageProxyMaker {
+  public:
+    StorageTracerProxyMaker(edm::ParameterSet const& pset)
+        : filenamePattern_(pset.getUntrackedParameter<std::string>("traceFilePattern")) {
+      if (filenamePattern_.find("%I") == std::string::npos) {
+        throw edm::Exception(edm::errors::Configuration) << "traceFilePattern did not contain '%I'";
+      }
+    }
+
+    static void fillPSetDescription(edm::ParameterSetDescription& iDesc) {
+      iDesc.addUntracked<std::string>("traceFilePattern", "trace_%I.txt")
+          ->setComment(
+              "Pattern for the output trace file names. Must contain '%I' for the counter of different files.");
+    }
+
+    std::unique_ptr<Storage> wrap(std::string const& url, std::unique_ptr<Storage> storage) const override {
+      auto value = fileCounter_.fetch_add(1);
+      std::string fname = filenamePattern_;
+      boost::replace_all(fname, "%I", std::to_string(value));
+      return std::make_unique<StorageTracerProxy>(value, fname, url, std::move(storage));
+    }
+
+  private:
+    mutable std::atomic<unsigned int> fileCounter_{0};
+    std::string const filenamePattern_;
+  };
+}  // namespace edm::storage
+
+#include "FWCore/ParameterSet/interface/ValidatedPluginMacros.h"
+#include "Utilities/StorageFactory/interface/StorageProxyMakerFactory.h"
+DEFINE_EDM_VALIDATED_PLUGIN(edm::storage::StorageProxyMakerFactory,
+                            edm::storage::StorageTracerProxyMaker,
+                            "StorageTracerProxy");

--- a/Utilities/StorageFactory/scripts/edmStorageTrace.py
+++ b/Utilities/StorageFactory/scripts/edmStorageTrace.py
@@ -1,0 +1,466 @@
+#!/usr/bin/env python3
+
+import argparse
+from collections import namedtuple
+
+class Entries:
+    common = ["id", "timestamp"]
+    Open = namedtuple("Open", common+["filename"])
+    common.append("duration")
+    Read = namedtuple("Read", common + ["offset", "requested", "actual"])
+    Readv = namedtuple("Readv", common + ["requested", "actual", "elements"])
+    ReadvElement = namedtuple("ReadvElements", ["index", "offset", "requested"])
+    Write = namedtuple("Write", common + ["offset", "requested", "actual"])
+    Writev = namedtuple("Writev", common + ["requested", "actual", "elements"])
+    WritevElement = namedtuple("WritevElements", ["index", "offset", "requested"])
+    Position = namedtuple("Position", common + ["offset", "whence"])
+    Prefetch = namedtuple("Prefech", common + ["requested", "elements", "supported"])
+    PrefetchElement = namedtuple("PrefetchElements", ["index", "offset", "requested"])
+    Resize = namedtuple("Resize", common+["size"])
+    Flush = namedtuple("Flush", common)
+    Close = namedtuple("Close", common)
+
+    nameToType = dict(
+        o = Open,
+        r = Read,
+        rv = Readv,
+        rve = ReadvElement,
+        w = Write,
+        wv = Writev,
+        wve = WritevElement,
+        s = Position,
+        p = Prefetch,
+        pe = PrefetchElement,
+        rsz = Resize,
+        f = Flush,
+        c = Close
+    )
+
+    @staticmethod
+    def make(name, args):
+        def convert(x):
+            try:
+                return int(x)
+            except ValueError:
+                if x == "true" or x == "false":
+                    return bool(x)
+                return x
+        return Entries.nameToType.get(name)._make([convert(x) for x in args])
+
+    @staticmethod
+    def isVector(obj):
+        return isinstance(obj, Entries.Readv) or isinstance(obj, Entries.Writev) or isinstance(obj, Entries.Prefetch)
+    @staticmethod
+    def isVectorElement(obj):
+        return isinstance(obj, Entries.ReadvElement) or isinstance(obj, Entries.WritevElement) or isinstance(obj, Entries.PrefetchElement)
+
+Chunk = namedtuple("Chunk", ("begin", "end"))
+
+def readlog(f):
+    ret = []
+    vectorOp = None
+    vectorOpElements = []
+    for line in f:
+        line = line.strip().rstrip()
+        if len(line) == 0:
+            continue
+        if line[0] == "#":
+            continue
+        content = line.split(" ")
+        entry = Entries.make(content[0], content[1:])
+
+        # Collect elements of vector operations into the vector operation objects
+        if Entries.isVectorElement(entry):
+            if vectorOp is None:
+                raise Exception("vectorOp should not have been None")
+            vectorOpElements.append(entry)
+            continue
+        if vectorOp is not None:
+            if vectorOp.elements != len(vectorOpElements):
+                raise Exception(f"Vector operation {vectorOp} should have {vectorOp.elements} elements, but {len(vectorOpElements)} were found from the trace log")
+            ret.append(vectorOp._replace(elements = vectorOpElements))
+            vectorOp = None
+            vectorOpElements = []
+        if Entries.isVector(entry):
+            if vectorOp is not None:
+                raise Exception(f"vectorOp should have been None, was {vectorOp}")
+            if len(vectorOpElements) != 0:
+                raise Exception("vectorOpElements should have been empty")
+            vectorOp = entry
+            continue
+
+        # Non-vector entries
+        ret.append(entry)
+    # last vector op, if there is one
+    if vectorOp is not None:
+        ret.append(vectorOp._replace(elements = vectorOpElements))
+
+    if len(ret) == 0:
+        raise Exception("Trace is empty")
+    if not isinstance(ret[-1], Entries.Close):
+        raise Exception(f"Last trace entry was {ret[-1].__class__.__name__} instead of Close, the trace is likely incomplete")
+
+    return ret
+
+def format_bytes(num):
+    for unit in ["B", "kB", "MB", "GB"]:
+        if num < 1024.0:
+            return f"{num:3.2f} {unit}"
+        num /= 1024.0
+    return f"{num:.2f} TB"
+
+def format_duration(num, unit):
+    if unit == "us":
+        units = ["us", "ms"]
+    elif unit == "ms":
+        units = ["ms"]
+    else:
+        raise Exception(f"Unknown time unit {unit}")
+
+    for unit in units:
+        if num < 1000.0:
+            return f"{num:3.2f} {unit}"
+        num /= 1000.0
+
+    if num < 60.0:
+        return f"{num:.1f} s"
+
+    minutes, seconds = divmod(num, 60)
+    if minutes < 60.0:
+        return f"{minutes:.0f} min {seconds:.1f} s ({num:.1f} s)"
+    hours, minutes = divmod(minutes, 60)
+    return f"{hours:.0f} h {minutes:.0f} min {seconds:.1f} s ({num:.1f} s)"
+
+####################
+# Read order analysis
+####################
+def analyzeReadOrder(logEntries):
+    read_total = 0
+    read_backward = 0
+    readv_total = 0
+    readv_backward = 0
+    prevOffset = 0
+    for entry in logEntries:
+        if isinstance(entry, Entries.Read):
+            read_total += 1
+            if entry.offset < prevOffset:
+                read_backward += 1
+            prevOffset = entry.offset + entry.requested
+        elif isinstance(entry, Entries.Readv):
+            readv_total += 1
+            if entry.elements[0].offset < prevOffset:
+                readv_backward += 1
+            prevOffset = entry.elements[-1].offset + entry.elements[-1].requested
+    print(f"Read order analysis")
+    if read_total > 0:
+        print(f"Singular reads")
+        print(f" All reads {read_total}")
+        print(f" Reads with smaller offset than previous {read_backward}")
+        print(f" Backward fraction {read_backward/float(read_total)*100} %")
+    if readv_total > 0:
+        print(f"Vector reads")
+        print(f" All reads {readv_total}")
+        print(f" Reads with smaller offset than previous {readv_backward}")
+        print(f" Backward fraction {readv_backward/float(readv_total)*100} %")
+
+####################
+# Read overlaps analysis
+####################
+def processReadOverlaps(read_chunks):
+    """Takes a list of Chunks
+
+    Returns an OverlapResult, that has the following members
+    - total_bytes: Total number of bytes read
+    - overlap_bytes: Number of bytes that whose reading could theoretically be avoided
+    - total_count: Number of singular reads plus number of vector read elements
+    - overlap_count: Number of reads that could theoretically be avoided
+
+    The unique amount of bytes read can be obtained as total_bytes - overlap_bytes
+
+    N reads that overlap with each other, total_count is increased by N,
+    and overlap_count by N-1.
+    """
+    # smallest begin first, and among them, largest end first
+    read_chunks.sort(key=lambda x: (x.begin, -x.end))
+
+    read_total_bytes = 0
+    read_unique_bytes = 0
+
+    prev = read_chunks[0]
+    read_total_bytes = prev.end-prev.begin
+    read_total_count = 1
+
+    read_unique_bytes = 0
+    read_overlap_count = 0
+
+    for chunk in read_chunks[1:]:
+        read_total_bytes += chunk.end-chunk.begin
+        read_total_count += 1
+        if chunk.begin >= prev.end:
+            read_unique_bytes += prev.end-prev.begin
+            prev = chunk
+        else:
+            read_overlap_count += 1
+            if chunk.end > prev.end:
+                prev = Chunk(prev.begin, chunk.end)
+    read_unique_bytes += prev.end-prev.begin
+
+    OverlapResult = namedtuple("OverlapResult", ("total_bytes", "overlap_bytes", "total_count", "overlap_count"))
+    return OverlapResult(read_total_bytes, read_total_bytes-read_unique_bytes, read_total_count, read_overlap_count)
+
+def analyzeReadOverlaps(logEntries, args):
+    read_chunks = []
+    for entry in logEntries:
+        if isinstance(entry, Entries.Read):
+            read_chunks.append(Chunk(entry.offset, entry.offset+entry.requested))
+        elif isinstance(entry, Entries.Readv):
+            for element in entry.elements:
+                read_chunks.append(Chunk(element.offset, element.offset+element.requested))
+
+    result = processReadOverlaps(read_chunks)
+    print(f"Analysis of overlapping reads")
+    print(f"Total")
+    print(f" Number of reads (singular or vector elements) {result.total_count}")
+    print(f" Bytes read {format_bytes(result.total_bytes)}")
+    print(f"Overlaps")
+    print(f" Number of reads that could overlapped with another read {result.overlap_count}")
+    print(f"  Fraction of all reads {result.overlap_count/float(result.total_count)*100} %")
+    print(f" Bytes read that had been already read {format_bytes(result.overlap_bytes)}")
+    print(f"  Fraction of all bytes {result.overlap_bytes/float(result.total_bytes)*100} %")
+
+####################
+# Summary
+####################
+class Counter(object):
+    def __init__(self, typ):
+        self._type = typ
+        self.count = 0
+        self.duration = 0
+        self.requested = 0
+        self.actual = 0
+        self.elements = 0
+
+    def type(self):
+        return self._type
+
+    def accumulate(self, entry):
+        if isinstance(entry, self._type):
+            self.count += 1
+            for f in ["duration", "requested", "actual"]:
+                if hasattr(entry, f):
+                    setattr(self, f, getattr(self, f) + getattr(entry, f))
+            if hasattr(entry, "elements"):
+                self.elements += len(entry.elements)
+
+def print_summary(header, counter):
+    if counter.count == 0:
+        return
+
+    print(header)
+    print(f" Number            {counter.count}")
+    if hasattr(counter.type(), "elements"):
+        print(f" Elements          {counter.elements}")
+    if hasattr(counter.type(), "requested"):
+        print(f" Requested         {format_bytes(counter.requested)}")
+        if hasattr(counter.type(), "actual"):
+            print(f" Actual            {format_bytes(counter.actual)}")
+
+    print(f" Duration          {format_duration(counter.duration, 'us')}")
+
+    if hasattr(counter.type(), "requested"):
+        print(f" Average size      {format_bytes(counter.requested/float(counter.count))}")
+        print(f" Average bandwidth {format_bytes(counter.requested/(counter.duration/float(1000000)))}/s")
+
+    print(f" Average latency   {format_duration(counter.duration/float(counter.count), 'us')}")
+
+
+def summary(logEntries):
+    quantities = [
+        ("Singular reads", Counter(Entries.Read)),
+        ("Vector reads", Counter(Entries.Readv)),
+        ("Singular writes", Counter(Entries.Write)),
+        ("Vector writes", Counter(Entries.Writev)),
+        ("Seeks", Counter(Entries.Position)),
+        ("Prefetches", Counter(Entries.Prefetch)),
+        ("Flushes", Counter(Entries.Flush))
+    ]
+    for entry in logEntries:
+        if isinstance(entry, Entries.Open):
+            print(f"Summary for file {entry.filename}")
+
+        for h, q in quantities:
+            q.accumulate(entry)
+
+    for h, q in quantities:
+        print_summary(h, q)
+
+####################
+# Main function
+####################
+def main(logEntries, args):
+    if args.summary:
+        summary(logEntries)
+        print()
+    if args.readOrder:
+        analyzeReadOrder(logEntries)
+        print()
+    if args.readOverlaps:
+        analyzeReadOverlaps(logEntries, args)
+        print()
+    pass
+
+####################
+# Unit tests
+####################
+import unittest
+class TestHelper(unittest.TestCase):
+    def test_format_bytes(self):
+        self.assertEqual(format_bytes(10), "10.00 B")
+        self.assertEqual(format_bytes(1023), "1023.00 B")
+        self.assertEqual(format_bytes(1024), "1.00 kB")
+        self.assertEqual(format_bytes(1024*1023), "1023.00 kB")
+        self.assertEqual(format_bytes(1024*1024), "1.00 MB")
+        self.assertEqual(format_bytes(1024*1024*1023), "1023.00 MB")
+        self.assertEqual(format_bytes(1024*1024*1024), "1.00 GB")
+
+    def test_format_duration(self):
+        self.assertEqual(format_duration(10, "us"), "10.00 us")
+        self.assertEqual(format_duration(999, "us"), "999.00 us")
+        self.assertEqual(format_duration(1000, "us"), "1.00 ms")
+        self.assertEqual(format_duration(1, "ms"), "1.00 ms")
+        self.assertEqual(format_duration(999, "ms"), "999.00 ms")
+        self.assertEqual(format_duration(1000, "ms"), "1.0 s")
+        self.assertEqual(format_duration(59*1000, "ms"), "59.0 s")
+        self.assertEqual(format_duration(60*1000, "ms"), "1 min 0.0 s (60.0 s)")
+        self.assertEqual(format_duration(59*60*1000, "ms"), "59 min 0.0 s (3540.0 s)")
+        self.assertEqual(format_duration(60*60*1000, "ms"), "1 h 0 min 0.0 s (3600.0 s)")
+        self.assertEqual(format_duration(90*60*1000, "ms"), "1 h 30 min 0.0 s (5400.0 s)")
+        self.assertEqual(format_duration(90*60*1000+345, "ms"), "1 h 30 min 0.3 s (5400.3 s)")
+
+    def test_processReadOverlaps(self):
+        chunks = [
+            Chunk(0, 5),
+            Chunk(5, 10),
+        ]
+        result = processReadOverlaps(chunks)
+        self.assertEqual(result.total_bytes, 10)
+        self.assertEqual(result.overlap_bytes, 0)
+        self.assertEqual(result.total_count, 2)
+        self.assertEqual(result.overlap_count, 0)
+
+        chunks = [
+            Chunk(0, 10),
+            Chunk(5, 10),
+        ]
+        result = processReadOverlaps(chunks)
+        self.assertEqual(result.total_bytes, 15)
+        self.assertEqual(result.overlap_bytes, 5)
+        self.assertEqual(result.total_count, 2)
+        self.assertEqual(result.overlap_count, 1)
+
+        chunks = [
+            Chunk(0, 10),
+            Chunk(5, 10),
+            Chunk(0, 5),
+        ]
+        result = processReadOverlaps(chunks)
+        self.assertEqual(result.total_bytes, 20)
+        self.assertEqual(result.overlap_bytes, 10)
+        self.assertEqual(result.total_count, 3)
+        self.assertEqual(result.overlap_count, 2)
+
+        chunks = [
+            Chunk(0, 10),
+            Chunk(5, 15),
+        ]
+        result = processReadOverlaps(chunks)
+        self.assertEqual(result.total_bytes, 20)
+        self.assertEqual(result.overlap_bytes, 5)
+        self.assertEqual(result.total_count, 2)
+        self.assertEqual(result.overlap_count, 1)
+
+        chunks = [
+            Chunk(0, 5),
+            Chunk(2, 10),
+            Chunk(9, 12),
+        ]
+        result = processReadOverlaps(chunks)
+        self.assertEqual(result.total_bytes, 16)
+        self.assertEqual(result.overlap_bytes, 4)
+        self.assertEqual(result.total_count, 3)
+        self.assertEqual(result.overlap_count, 2)
+
+        chunks = [
+            Chunk(0, 5),
+            Chunk(2, 10),
+            Chunk(9, 12),
+            Chunk(5, 7),
+            Chunk(12, 13),
+        ]
+        result = processReadOverlaps(chunks)
+        self.assertEqual(result.total_bytes, 19)
+        self.assertEqual(result.overlap_bytes, 6)
+        self.assertEqual(result.total_count, 5)
+        self.assertEqual(result.overlap_count, 3)
+
+        chunks = [
+            Chunk(2, 4),
+            Chunk(6, 8),
+            Chunk(10, 12),
+            Chunk(0, 20),
+        ]
+        result = processReadOverlaps(chunks)
+        self.assertEqual(result.total_bytes, 26)
+        self.assertEqual(result.overlap_bytes, 6)
+        self.assertEqual(result.total_count, 4)
+        self.assertEqual(result.overlap_count, 3)
+
+        chunks = [
+            Chunk(0, 20),
+            Chunk(19, 21),
+            Chunk(20, 25),
+        ]
+        result = processReadOverlaps(chunks)
+        self.assertEqual(result.total_bytes, 27)
+        self.assertEqual(result.overlap_bytes, 2)
+        self.assertEqual(result.total_count, 3)
+        # Value 2 here is debatable
+        self.assertEqual(result.overlap_count, 2)
+
+def test():
+    import sys
+    unittest.main(argv=sys.argv[:1])
+
+####################
+# Command line arguments
+####################
+def printHelp():
+    return """The storage traces can be obtained by adding StorageTracerProxy to
+the storage proxies of the AdaptorConfig Service, for example as
+----
+process.add_(cms.Service("AdaptorConfig",
+    storageProxies = cms.untracked.VPSet(
+        cms.PSet(type = cms.untracked.string("StorageTracerProxy"))
+))
+----
+"""
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Analyze storage trace",
+                                     formatter_class=argparse.RawDescriptionHelpFormatter,
+                                    epilog=printHelp())
+    parser.add_argument("filename", type=str, nargs="?", default=None, help="file to process")
+    parser.add_argument("--summary", action="store_true", help="Print high-level summary of storage operations")
+    parser.add_argument("--readOrder", action="store_true", help="Analyze ordering of reads")
+    parser.add_argument("--readOverlaps", action="store_true", help="Analyze overlaps of reads")
+    parser.add_argument("--test", action="store_true", help="Run internal tests")
+
+    args = parser.parse_args()
+    if args.test:
+        test()
+    else:
+        if args.filename is None:
+            parser.error("filename argument is missing")
+        with open(args.filename) as f:
+            logEntries = readlog(f)
+        main(logEntries, args)

--- a/Utilities/StorageFactory/src/StorageFactory.cc
+++ b/Utilities/StorageFactory/src/StorageFactory.cc
@@ -98,6 +98,10 @@ std::string StorageFactory::tempPath(void) const { return m_temppath; }
 
 double StorageFactory::tempMinFree(void) const { return m_tempfree; }
 
+void StorageFactory::setStorageProxyMakers(std::vector<std::unique_ptr<StorageProxyMaker>> makers) {
+  m_storageProxyMakers_ = std::move(makers);
+}
+
 StorageMaker *StorageFactory::getMaker(const std::string &proto) const {
   auto itFound = m_makers.find(proto);
   if (itFound != m_makers.end()) {
@@ -143,7 +147,7 @@ std::unique_ptr<Storage> StorageFactory::open(const std::string &url, const int 
         // Inject proxy wrappers at the lowest level, in the order
         // specified in the configuration
         for (auto const &proxyMaker : m_storageProxyMakers_) {
-          ret = proxyMaker->wrap(std::move(ret));
+          ret = proxyMaker->wrap(url, std::move(ret));
         }
 
         // Wrap the storage to LocalCacheFile if storage backend is

--- a/Utilities/StorageFactory/src/StorageFactory.cc
+++ b/Utilities/StorageFactory/src/StorageFactory.cc
@@ -18,8 +18,8 @@ StorageFactory::StorageFactory(void)
     : m_cacheHint(CACHE_HINT_AUTO_DETECT),
       m_readHint(READ_HINT_AUTO),
       m_accounting(false),
-      m_tempfree(4.),  // GB
-      m_temppath(".:$TMPDIR"),
+      m_tempfree(defaultMinTempFree()),
+      m_temppath(defaultTempDir()),
       m_timeout(0U),
       m_debugLevel(0U) {
   setTempDir(m_temppath, m_tempfree);
@@ -30,6 +30,8 @@ StorageFactory::~StorageFactory(void) {}
 const StorageFactory *StorageFactory::get(void) { return &s_instance; }
 
 StorageFactory *StorageFactory::getToModify(void) { return &s_instance; }
+
+std::string StorageFactory::defaultTempDir() { return ".:$TMPDIR"; }
 
 bool StorageFactory::enableAccounting(bool enabled) {
   bool old = m_accounting;

--- a/Utilities/StorageFactory/src/StorageProxyMaker.cc
+++ b/Utilities/StorageFactory/src/StorageProxyMaker.cc
@@ -1,0 +1,5 @@
+#include "Utilities/StorageFactory/interface/StorageProxyMaker.h"
+
+namespace edm::storage {
+  StorageProxyMaker::~StorageProxyMaker() = default;
+}

--- a/Utilities/StorageFactory/src/StorageProxyMakerFactory.cc
+++ b/Utilities/StorageFactory/src/StorageProxyMakerFactory.cc
@@ -1,0 +1,6 @@
+#include "FWCore/ParameterSet/interface/ValidatedPluginFactoryMacros.h"
+#include "Utilities/StorageFactory/interface/StorageProxyMakerFactory.h"
+
+using namespace edm::storage;
+
+EDM_REGISTER_VALIDATED_PLUGINFACTORY(StorageProxyMakerFactory, "CMS Storage Proxy Maker");

--- a/Utilities/StorageFactory/test/BuildFile.xml
+++ b/Utilities/StorageFactory/test/BuildFile.xml
@@ -41,3 +41,5 @@ It's not that hard guard accesses to the PluginManager, but per Chris Jones, we 
 to wait until the framework decides on a threading model to implement a fix.
 file="threadsafe.cpp" name="test_StorageFactory_threadsafe"
 -->
+
+<test name="test_StorageFactory_edmStorageTrace" command="python3 ${LOCALTOP}/src/Utilities/StorageFactory/scripts/edmStorageTrace.py --test"/>

--- a/Utilities/StorageFactory/test/BuildFile.xml
+++ b/Utilities/StorageFactory/test/BuildFile.xml
@@ -42,4 +42,6 @@ to wait until the framework decides on a threading model to implement a fix.
 file="threadsafe.cpp" name="test_StorageFactory_threadsafe"
 -->
 
+<test name="test_StorageFactory_StorageProxies" command="test_storageproxies.sh"/>
+
 <test name="test_StorageFactory_edmStorageTrace" command="python3 ${LOCALTOP}/src/Utilities/StorageFactory/scripts/edmStorageTrace.py --test"/>

--- a/Utilities/StorageFactory/test/test_storageproxies.sh
+++ b/Utilities/StorageFactory/test/test_storageproxies.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Pass in name and status
+function die { echo $1: status $2 ;  exit $2; }
+
+cmsRun ${SCRAM_TEST_PATH}/test_storageproxy_make_file_cfg.py || die "cmsRun test_storageproxy_make_file_cfg.py failed" $?
+
+cmsRun ${SCRAM_TEST_PATH}/test_storageproxy_test_cfg.py || die "cmsRun test_storageproxy_test_cfg.py failed" $?
+
+cmsRun ${SCRAM_TEST_PATH}/test_storageproxy_test_cfg.py --latencyRead || die "cmsRun test_storageproxy_test_cfg.py --latencyRead failed" $?
+cmsRun ${SCRAM_TEST_PATH}/test_storageproxy_test_cfg.py --latencyWrite || die "cmsRun test_storageproxy_test_cfg.py --latencyWrite failed" $?
+
+cmsRun ${SCRAM_TEST_PATH}/test_storageproxy_test_cfg.py --trace || die "cmsRun test_storageproxy_test_cfg.py --trace failed" $?
+grep -q "o .* test.root" trace_0.txt || die "File open entry missing in trace_0.txt" $?
+grep -q "r " trace_0.txt || die "No read entries in trace_0.txt" $?
+grep -q "o .* output.root" trace_1.txt || die "File open entry missing in trace_1.txt" $?
+grep -q "w " trace_1.txt || die "No write entries in trace_0.txt" $?
+
+edmStorageTrace.py --summary trace_0.txt | grep -q "Singular reads" || die "No reads in summary for trace_0.txt" $?
+edmStorageTrace.py --summary trace_1.txt | grep -q "Singular writes" || die "No reads in summary for trace_1.txt" $?
+
+
+cmsRun ${SCRAM_TEST_PATH}/test_storageproxy_test_cfg.py --trace --latencyRead || die "cmsRun test_storageproxy_test_cfg.py --trace --latencyRead failed" $?
+edmStorageTrace.py --summary trace_0.txt | grep -q "Duration .* ms" || die "Read duration has non-ms units in trace_1.txt" $?
+
+cmsRun ${SCRAM_TEST_PATH}/test_storageproxy_test_cfg.py --trace --latencyWrite || die "cmsRun test_storageproxy_test_cfg.py --trace --latencyWrite failed" $?
+edmStorageTrace.py --summary trace_1.txt | grep -q "Duration .* ms" || die "Write duration has non-ms trace_1.txt" $?

--- a/Utilities/StorageFactory/test/test_storageproxy_make_file_cfg.py
+++ b/Utilities/StorageFactory/test/test_storageproxy_make_file_cfg.py
@@ -1,0 +1,16 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("MAKE")
+
+process.source = cms.Source("EmptySource")
+process.maxEvents.input = 10
+
+process.out = cms.OutputModule("PoolOutputModule", fileName = cms.untracked.string("test.root"))
+
+process.Thing = cms.EDProducer("ThingProducer")
+process.OtherThing = cms.EDProducer("OtherThingProducer")
+process.EventNumber = cms.EDProducer("EventNumberIntProducer")
+
+
+process.o = cms.EndPath(process.out, cms.Task(process.Thing, process.OtherThing, process.EventNumber))
+

--- a/Utilities/StorageFactory/test/test_storageproxy_test_cfg.py
+++ b/Utilities/StorageFactory/test/test_storageproxy_test_cfg.py
@@ -1,0 +1,40 @@
+import FWCore.ParameterSet.Config as cms
+
+import argparse
+
+parser = argparse.ArgumentParser(description="Test storage proxies")
+parser.add_argument("--trace", action="store_true", help="Enable StorageTraceProxy")
+parser.add_argument("--latencyRead", action="store_true", help="Add read latency")
+parser.add_argument("--latencyWrite", action="store_true", help="Add write latency")
+args = parser.parse_args()
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring("file:test.root")
+)
+
+process.out = cms.OutputModule("PoolOutputModule", fileName = cms.untracked.string("output.root"))
+
+adaptor = cms.Service("AdaptorConfig", storageProxies = cms.untracked.VPSet())
+if args.latencyRead:
+    adaptor.storageProxies.append(cms.PSet(
+        type = cms.untracked.string("StorageAddLatencyProxy"),
+        read = cms.untracked.uint32(100),
+        readv = cms.untracked.uint32(100),
+    ))
+if args.latencyWrite:
+    adaptor.storageProxies.append(cms.PSet(
+        type = cms.untracked.string("StorageAddLatencyProxy"),
+        write = cms.untracked.uint32(100),
+        writev = cms.untracked.uint32(100),
+    ))
+if args.trace:
+    adaptor.storageProxies.append(cms.PSet(
+        type = cms.untracked.string("StorageTracerProxy"),
+        traceFilePattern = cms.untracked.string("trace_%I.txt"),
+    ))
+
+process.add_(adaptor)
+
+process.ep = cms.EndPath(process.out)

--- a/Utilities/XrdAdaptor/plugins/XrdStorageMaker.cc
+++ b/Utilities/XrdAdaptor/plugins/XrdStorageMaker.cc
@@ -89,8 +89,7 @@ namespace edm::storage {
         mode |= IOFlags::OpenUnbuffered;
 
       std::string fullpath(proto + ":" + path);
-      auto file = std::make_unique<XrdFile>(fullpath, mode);
-      return f->wrapNonLocalFile(std::move(file), proto, std::string(), mode);
+      return std::make_unique<XrdFile>(fullpath, mode);
     }
 
     void stagein(const std::string &proto, const std::string &path, const AuxSettings &aux) const override {
@@ -124,6 +123,8 @@ namespace edm::storage {
         *size = stat->GetSize();
       return true;
     }
+
+    UseLocalFile usesLocalFile() const override { return UseLocalFile::kNo; }
 
     void setDebugLevel(unsigned int level) const {
       auto oldLevel = m_lastDebugLevel.load();


### PR DESCRIPTION
#### PR description:

The context of this PR is the investigation in https://github.com/cms-sw/cmssw/issues/47750.

First this PR adds capability for generic storage proxies (after improving `TFileAdaptor` `fillDescriptions()` and refactoring the way `StorageFactory` wraps `edm::storage::Storage` objects into `LocalCacheFile`). These proxies are components that implement the `Storage` API and hold a another `Storage` object. The proxies are implemented as validated plugins, and they are configured bia the `TFileAdaptor` (i.e. `AdaptorConfig` Service).

This PR implements two such proxy components
* `StorageTracerProxy` for tracing the operations, including a script to do some analysis on the trace
* `StorageAddLatencyProxy` for adding artificial latency to the operations

Resolves https://github.com/cms-sw/framework-team/issues/1361
Resolves https://github.com/cms-sw/framework-team/issues/1391

#### PR validation:

The tracer and latency addition code were extensively used when studying https://github.com/cms-sw/cmssw/issues/47750