### PR TITLE
Add assert to MethodSetter to trigger traceback

### DIFF
--- a/CommonTools/Utils/src/MethodSetter.cc
+++ b/CommonTools/Utils/src/MethodSetter.cc
@@ -121,6 +121,7 @@ bool MethodSetter::push(const string& name, const vector<AnyMethodArgument>& arg
     // Not a data member either, fatal error, throw.
     switch (error) {
       case reco::parser::kNameDoesNotExist: {
+        assert(false);  //HELP FIND THREAD PROBLEM WITH RNTUPLE
         Exception ex(begin);
         ex << "no method or data member named \"" << name << "\" found for type \"" << type.name() << "\"\n";
         // The following information is for temporary debugging only, intended to be removed later


### PR DESCRIPTION
#### PR description:

The exception has been happening while using RNTuple. Switch to assert to allow us to trigger cmsRun's thread tracebacks when the problem occurs.

This is meant to help us debug the threading problem seen in the IBs.

#### PR validation:
Code compiles.

resolves https://github.com/cms-sw/framework-team/issues/1393