### PR TITLE
optimize LST T3 kernel block size and rearrange T3 kernel functions

### DIFF
--- a/RecoTracker/LSTCore/src/alpaka/LSTEvent.dev.cc
+++ b/RecoTracker/LSTCore/src/alpaka/LSTEvent.dev.cc
@@ -477,7 +477,7 @@ void LSTEvent::createTriplets() {
   auto index_gpu_buf = cms::alpakatools::make_device_buffer<uint16_t[]>(queue_, nLowerModules_);
   alpaka::memcpy(queue_, index_gpu_buf, index_buf_h, nonZeroModules);
 
-  auto const createTriplets_workDiv = cms::alpakatools::make_workdiv<Acc3D>({max_blocks, 1, 1}, {1, 16, 16});
+  auto const createTriplets_workDiv = cms::alpakatools::make_workdiv<Acc3D>({nonZeroModules, 1, 1}, {1, 16, 16});
 
   alpaka::exec<Acc3D>(queue_,
                       createTriplets_workDiv,

--- a/RecoTracker/LSTCore/src/alpaka/Triplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/Triplet.h
@@ -648,10 +648,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                                                    float& circleCenterX,
                                                                    float& circleCenterY,
                                                                    const float ptCut) {
-    //this cut reduces the number of candidates by a factor of 4, i.e., 3 out of 4 warps can end right here!
-    if (segments.mdIndices()[innerSegmentIndex][1] != segments.mdIndices()[outerSegmentIndex][0])
-      return false;
-
     unsigned int firstMDIndex = segments.mdIndices()[innerSegmentIndex][0];
     unsigned int secondMDIndex = segments.mdIndices()[outerSegmentIndex][0];
     unsigned int thirdMDIndex = segments.mdIndices()[outerSegmentIndex][1];
@@ -740,6 +736,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
           unsigned int nOuterSegments = segmentsOccupancy.nSegments()[middleLowerModuleIndex];
           for (unsigned int outerSegmentArrayIndex : cms::alpakatools::uniform_elements_x(acc, nOuterSegments)) {
             unsigned int outerSegmentIndex = ranges.segmentRanges()[middleLowerModuleIndex][0] + outerSegmentArrayIndex;
+
+            //this cut reduces the number of candidates by a factor of 4, i.e., 3 out of 4 warps can end right here!
+            if (segments.mdIndices()[innerSegmentIndex][1] != segments.mdIndices()[outerSegmentIndex][0])
+              continue;
 
             uint16_t outerOuterLowerModuleIndex = segments.outerLowerModuleIndices()[outerSegmentIndex];
 


### PR DESCRIPTION
#### PR description:
This is the study focusing on threads and blocks allocation of T3 kernels. In the original LST code, the max_blocks const is used for many block allocations. And the number of the const is set to 80, which is capable for the number of SMs of Nvidia v100 machine. The number is not optimal for other later machines. However, we can find a block allocation which is agnostic to the machine backends and have more physics motivation. The block size are now set to be the size of non-zero modules.

#### PR validation:
This PR was tested on CPU and GPU in the standalone configuration and runs without issue. Physics performance does not change. 
After the PR, the T3 kernel time is improved by ~60% on L4 machine, and overall timing improved by ~17% on single stream. Test on L40 and A30 machine, the timing also improves. 
Timing comparison on L4 is below.
<img width="820" alt="Screenshot 2025-05-14 at 5 50 08 PM" src="https://github.com/user-attachments/assets/5051d52c-0141-4f06-b33c-070c741d57c2" />
