### PR TITLE
update BPH MuMu branch

### DIFF
--- a/PhysicsTools/BPHNano/python/MuMu_cff.py
+++ b/PhysicsTools/BPHNano/python/MuMu_cff.py
@@ -9,6 +9,7 @@ MuMu = cms.EDProducer(
     transientTracksSrc = cms.InputTag('muonBPH', 'SelectedTransientMuons'),
     lep1Selection = cms.string('pt > 4.0 && abs(eta) < 2.4 && isLooseMuon && isGlobalMuon'),
     lep2Selection = cms.string('pt > 3.0 && abs(eta) < 2.4 && isLooseMuon && isGlobalMuon'),
+    beamSpot = cms.InputTag("offlineBeamSpot"),
     preVtxSelection  = cms.string('abs(userCand("l1").vz - userCand("l2").vz) <= 1.'
                                   '&& 0 < mass() && mass() < 15.0 '
                                   '&& charge() == 0'
@@ -35,10 +36,16 @@ MuMuTable = cms.EDProducer("SimpleCompositeCandidateFlatTableProducer",
     variables = cms.PSet(CandVars,
           fitted_mass = Var("userFloat('fitted_mass')", float, doc="Fitted dilepton mass"),
           svprob = Var("userFloat('sv_prob')", float, doc="Vtx fit probability"),
+          sv_ndof         = Var("userFloat('sv_ndof')", float, doc=""),
+          sv_chi2         = Var("userFloat('sv_chi2')", float, doc=""),
           vtx_x =Var("userFloat('vtx_x')", float, doc="Vtx position in x"),
           vtx_y = Var("userFloat('vtx_y')", float, doc="Vtx position in y"),
           vtx_z = Var("userFloat('vtx_z')", float, doc="Vtx position in y"),
-
+          mu1_index = Var("userInt('l1_idx')",int, doc="Index of Mu1"),
+          mu2_index = Var("userInt('l2_idx')",int, doc="Index of Mu2"),
+          l_xy        = Var("userFloat('l_xy')", float, doc="lxy"),
+          l_xy_unc        = Var("userFloat('l_xy_unc')", float, doc="lxy uncertainty"),
+          cos_theta_2D    = Var("userFloat('fitted_cos_theta_2D')", float, doc="cos pointing angle in 2D"),
     )
 )
 


### PR DESCRIPTION
#### PR description:
This is to add additional needed variable to MuMu (dimuon) branch for BPHnano, including pointing angle (cos2D), decay radius and its uncertainty, corresponding mu1/mu2 index. 

#### PR validation:

The test is conducted with the BPH nano production example for both data and MC case, generated from the following cmsDriver.py command:

 --conditions 140X_dataRun3_Prompt_v4 --datatier NANOAOD --data --era Run3,run3_nanoAOD_pre142X --eventcontent NANOAOD --filein root://cms-xrd-global.cern.ch//store/data/Run2024C/ParkingDoubleMuonLowMass0/MINIAOD/PromptReco-v1/000/379/415/00000/b40397b5-61c6-4887-8f4e-025e8ca925ee.root --fileout file:BPH_test_data.root -n 4500 --no_exec --python_filename BPH_test.py --scenario pp --step NANO:@BPH

--conditions 130X_mcRun3_2023_realistic_v14 --datatier NANOAOD --era Run3_2023,run3_nanoAOD_pre142X --eventcontent NANOAODSIM --filein root://cms-xrd-global.cern.ch//store/mc/Run3Summer23MiniAODv4/B0ToJpsiK0s_JpsiFilter_MuFilter_K0sFilter_TuneCP5_13p6TeV_pythia8-evtgen/MINIAODSIM/130X_mcRun3_2023_realistic_v14-v3/2820000/04373614-95f7-402d-aca1-b3329eebc3ca.root --fileout file:BPH_mc.root --nThreads 4 -n -1 --no_exec --python_filename BPH_MC.py --scenario pp --step NANO:@BPH --mc

The production example looks all good. 

The PR is intented for CMSSW_15_1_X. 

