### PR TITLE
Add IntrusiveAllocMonitor

### DIFF
--- a/FWCore/AbstractServices/interface/IntrusiveMonitorBase.h
+++ b/FWCore/AbstractServices/interface/IntrusiveMonitorBase.h
@@ -1,0 +1,39 @@
+#ifndef FWCore_AbstractServices_IntrusiveMonitorBase_h
+#define FWCore_AbstractServices_IntrusiveMonitorBase_h
+
+#include <string_view>
+
+namespace edm {
+  class IntrusiveMonitorBase {
+  public:
+    IntrusiveMonitorBase() = default;
+    IntrusiveMonitorBase(IntrusiveMonitorBase const&) = delete;
+    IntrusiveMonitorBase& operator=(IntrusiveMonitorBase const&) = delete;
+    IntrusiveMonitorBase(IntrusiveMonitorBase&&) = delete;
+    IntrusiveMonitorBase& operator=(IntrusiveMonitorBase&&) = delete;
+    virtual ~IntrusiveMonitorBase();
+
+    class Guard {
+    public:
+      Guard(IntrusiveMonitorBase& mon, std::string_view name) : monitor_(mon), name_(name) { monitor_.start(); }
+      Guard(Guard const&) = delete;
+      Guard& operator=(Guard const&) = delete;
+      Guard(Guard&&) = delete;
+      Guard& operator=(Guard&&) = delete;
+
+      ~Guard() { monitor_.stop(name_); }
+
+    private:
+      IntrusiveMonitorBase& monitor_;
+      std::string_view name_;
+    };
+
+    Guard startMonitoring(std::string_view name) { return Guard(*this, name); }
+
+  private:
+    virtual void start() = 0;
+    virtual void stop(std::string_view name) = 0;
+  };
+}  // namespace edm
+
+#endif

--- a/FWCore/AbstractServices/src/IntrusiveMonitorBase.cc
+++ b/FWCore/AbstractServices/src/IntrusiveMonitorBase.cc
@@ -1,0 +1,5 @@
+#include "FWCore/AbstractServices/interface/IntrusiveMonitorBase.h"
+
+namespace edm {
+  IntrusiveMonitorBase::~IntrusiveMonitorBase() = default;
+}

--- a/PerfTools/AllocMonitor/plugins/IntrusiveAllocMonitor.cc
+++ b/PerfTools/AllocMonitor/plugins/IntrusiveAllocMonitor.cc
@@ -1,0 +1,91 @@
+#include "FWCore/AbstractServices/interface/IntrusiveMonitorBase.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
+
+#include "PerfTools/AllocMonitor/interface/AllocMonitorBase.h"
+#include "PerfTools/AllocMonitor/interface/AllocMonitorRegistry.h"
+
+#include "ThreadAllocInfo.h"
+#include "ThreadTracker.h"
+
+namespace {
+  using namespace edm::service::moduleAlloc;
+  class MonitorAdaptor : public cms::perftools::AllocMonitorBase {
+  public:
+    static void startOnThread() { threadAllocInfo().reset(); }
+    static ThreadAllocInfo const& stopOnThread() {
+      auto& t = threadAllocInfo();
+      if (not t.active_) {
+        t.reset();
+      } else {
+        t.deactivate();
+      }
+      return t;
+    }
+
+    static ThreadAllocInfo& threadAllocInfo() {
+      using namespace cms::perftools::allocMon;
+      static ThreadAllocInfo s_info[ThreadTracker::kTotalEntries];
+      return s_info[ThreadTracker::instance().thread_index()];
+    }
+
+  private:
+    void allocCalled(size_t iRequested, size_t iActual, void const*) final {
+      auto& allocInfo = threadAllocInfo();
+      if (not allocInfo.active_) {
+        return;
+      }
+      allocInfo.nAllocations_ += 1;
+      allocInfo.requested_ += iRequested;
+
+      if (allocInfo.maxSingleAlloc_ < iRequested) {
+        allocInfo.maxSingleAlloc_ = iRequested;
+      }
+
+      allocInfo.presentActual_ += iActual;
+      if (allocInfo.presentActual_ > static_cast<long long>(allocInfo.maxActual_)) {
+        allocInfo.maxActual_ = allocInfo.presentActual_;
+      }
+    }
+    void deallocCalled(size_t iActual, void const*) final {
+      auto& allocInfo = threadAllocInfo();
+      if (not allocInfo.active_) {
+        return;
+      }
+
+      allocInfo.nDeallocations_ += 1;
+      allocInfo.presentActual_ -= iActual;
+      if (allocInfo.presentActual_ < 0) {
+        if (allocInfo.minActual_ == 0 or allocInfo.minActual_ > allocInfo.presentActual_) {
+          allocInfo.minActual_ = allocInfo.presentActual_;
+        }
+      }
+    }
+  };
+}  // namespace
+
+class IntrusiveAllocMonitor : public edm::IntrusiveMonitorBase {
+public:
+  IntrusiveAllocMonitor() {
+    (void)cms::perftools::AllocMonitorRegistry::instance().createAndRegisterMonitor<MonitorAdaptor>();
+  };
+  ~IntrusiveAllocMonitor() override = default;
+
+  void start() final { MonitorAdaptor::startOnThread(); }
+  void stop(std::string_view name) final {
+    MonitorAdaptor::stopOnThread();
+    auto& info = MonitorAdaptor::threadAllocInfo();
+    edm::LogSystem("IntrusiveAllocMonitor")
+        .format("{}: requested {} added {} max alloc {} peak {} nAlloc {} nDealloc {}",
+                name,
+                info.requested_,
+                info.presentActual_,
+                info.maxSingleAlloc_,
+                info.maxActual_,
+                info.nAllocations_,
+                info.nDeallocations_);
+  }
+};
+
+typedef edm::serviceregistry::NoArgsMaker<edm::IntrusiveMonitorBase, IntrusiveAllocMonitor> IntrusiveAllocMonitorMaker;
+DEFINE_FWK_SERVICE_MAKER(IntrusiveAllocMonitor, IntrusiveAllocMonitorMaker);

--- a/PerfTools/AllocMonitor/test/BuildFile.xml
+++ b/PerfTools/AllocMonitor/test/BuildFile.xml
@@ -23,4 +23,18 @@
     <flags CXXFLAGS="-O0"/>
   </bin>
   <test name="TestPerfToolsModuleAllocMonitor" command="runModuleAlloc.sh"/>
+
+  <!-- can't be part of the catch2 tests above because of ASAN exclusion -->
+  <bin file="test_intrusiveAllocMonitor.cc" name="testIntrusiveAllocMonitor">
+    <use name="FWCore/AbstractServices"/>
+    <use name="FWCore/ParameterSet"/>
+    <use name="FWCore/ParameterSetReader"/>
+    <use name="FWCore/PluginManager"/>
+    <use name="FWCore/ServiceRegistry"/>
+    <use name="PerfTools/AllocMonitor"/>
+    <use name="PerfTools/AllocMonitorPreload"/>
+  </bin>
+  <test name="testIntrusiveAllocMonitorOutput" command="testIntrusiveAllocMonitor 2>&amp;1 | grep -q 'Vector fill: requested'">
+    <flags PRE_TEST="testIntrusiveAllocMonitor"/>
+  </test>
 </ifrelease>

--- a/PerfTools/AllocMonitor/test/test_intrusiveAllocMonitor.cc
+++ b/PerfTools/AllocMonitor/test/test_intrusiveAllocMonitor.cc
@@ -1,0 +1,46 @@
+#include "FWCore/AbstractServices/interface/IntrusiveMonitorBase.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSetReader/interface/ParameterSetReader.h"
+#include "FWCore/PluginManager/interface/PluginManager.h"
+#include "FWCore/PluginManager/interface/standard.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
+#include "FWCore/ServiceRegistry/interface/ServiceToken.h"
+
+#include <cassert>
+#include <vector>
+
+int main() {
+  edmplugin::PluginManager::configure(edmplugin::standard::config());
+
+  std::string const config = R"_(
+import FWCore.ParameterSet.Config as cms
+process = cms.Process('Test')
+process.add_(cms.Service('IntrusiveAllocMonitor'))
+)_";
+  std::unique_ptr<edm::ParameterSet> params;
+  edm::makeParameterSets(config, params);
+  auto token = edm::ServiceToken(edm::ServiceRegistry::createServicesFromConfig(std::move(params)));
+  edm::ServiceRegistry::Operate operate(token);
+
+  edm::Service<edm::IntrusiveMonitorBase> imb;
+  assert(imb.isAvailable());
+
+  std::vector<int> vec;
+  {
+    auto guard = imb->startMonitoring("Vector fill");
+    for (int i = 0; i < 10000; ++i) {
+      vec.push_back(i * 2 - 1);
+    }
+
+    int sum = 0;
+    for (int a : vec) {
+      sum += a;
+    }
+
+    edm::LogPrint("Test").format("Sum {}", sum);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
#### PR description:

This PR adds `IntrusiveAllocMonitor` Service that can be used to make memory allocation measurements by instrumenting the code. It was developed as part of the investigation of #47470 (https://github.com/cms-sw/cmssw/issues/47470#issuecomment-2695511530 in particular).

Resolves https://github.com/cms-sw/framework-team/issues/1288

#### PR validation:

Private tests, added unit test succeeds (although it doesn't test much)