### PR TITLE
Update ROOT counters in TStorageFactoryFile read functions

### DIFF
--- a/IOPool/TFileAdaptor/src/TStorageFactoryFile.cc
+++ b/IOPool/TFileAdaptor/src/TStorageFactoryFile.cc
@@ -303,6 +303,13 @@ Bool_t TStorageFactoryFile::ReadBuffer(char *buf, Int_t len) {
           GetRelOffset(),
           GetSize());
   }
+
+  // Update ROOT's statistics
+  fBytesRead += n;
+  fgBytesRead += n;
+  fReadCalls++;
+  fgReadCalls++;
+
   return n ? kFALSE : kTRUE;
 }
 
@@ -409,6 +416,12 @@ Bool_t TStorageFactoryFile::ReadBuffersSync(char *buf, Long64_t *pos, Int_t *len
     }
     xstats.tick(io_buffer_used);
     repacker.unpack(current_buffer);
+
+    // Update ROOT's statistics
+    fBytesRead += result;
+    fgBytesRead += result;
+    fReadCalls++;
+    fgReadCalls++;
 
     // Update the location of the unused part of the input buffer.
     remaining_buffer_size -= real_bytes_processed;


### PR DESCRIPTION
#### PR description:

While investigating the `TTreeCache` behavior in the  context of https://github.com/cms-sw/cmssw/issues/47750, we noticed that `TTreeCache::Print("a")` printout reported zero reads. Further investigation showed that these counters are incremented in `TFile`'s read functions, but our `TStorageFactoryFile` didn't touch those counters. Updating the `TStorageFactoryFile`'s read functions to update ROOT's counters made the `TTreeCache::Print("a")` to show non-zero numbers.

Resolves https://github.com/cms-sw/framework-team/issues/1392

#### PR validation:

`TTreeCache::Print("a")` shows non-zero values in private tests.