### PR TITLE
update an estimate vertex smearing parameters for 2025 OO MC

### DIFF
--- a/Configuration/StandardSequences/python/VtxSmeared.py
+++ b/Configuration/StandardSequences/python/VtxSmeared.py
@@ -75,5 +75,6 @@ VtxSmeared = {
     'Realistic2023PbPbCollision' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic2023PbPbCollision_cfi',
     'Realistic2024ppRefCollision' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic2024ppRefCollision_cfi',
     'Realistic2024PbPbCollision' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic2024PbPbCollision_cfi',
+    'Nominal2025OOCollision' : 'IOMC.EventVertexGenerators.VtxSmearedNominal2025OOCollision_cfi',
 }
 VtxSmearedDefaultKey='DBrealistic'

--- a/IOMC/EventVertexGenerators/python/VtxSmearedNominal2025OOCollision_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedNominal2025OOCollision_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Nominal2025OOCollisionVtxSmearingParameters,VtxSmearedCommon
+VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
+    Nominal2025OOCollisionVtxSmearingParameters,
+    VtxSmearedCommon
+)

--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -1097,6 +1097,19 @@ Realistic2024PbPbCollisionVtxSmearingParameters = cms.PSet(
     Z0 = cms.double(0.2290316)
 )
 
+# Estimate for the 2025 OO beam conditions, based on the 2024 PbPb beam width parameters from Realistic2024PbPbCollisionVtxSmearingParameters with the pp beam centroid from runs 392109 and 392112
+Nominal2025OOCollisionVtxSmearingParameters = cms.PSet(
+    Phi = cms.double(0.0),
+    BetaStar = cms.double(50),
+    Emittance = cms.double(6.684e-08),
+    Alpha = cms.double(0.0),
+    SigmaZ = cms.double(4.9068349),
+    TimeOffset = cms.double(0.0),
+    X0 = cms.double(0.0184194),
+    Y0 = cms.double(-0.0141852),
+    Z0 = cms.double(0.3423956)
+)
+
 # Parameters for HL-LHC operation at 13TeV
 HLLHCVtxSmearingParameters = cms.PSet(
     MeanXIncm = cms.double(0.),


### PR DESCRIPTION
#### PR description:

- This PR adds an estimate vertex smearing for 2025 OO MC before data-taking. The estimation is based on the 2024 PbPb beam width parameters and emittance from Realistic2024PbPbCollisionVtxSmearingParameters with the pp beam centroid from runs 392109 and 392112, BPIX barycentre location obtained from [TrackerAlignment_PCL_byRun_v2_express](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/tags/TrackerAlignment_PCL_byRun_v2_express)

#### PR validation:

- This PR has been modeled after a similar PR from 2022, 2023, and 2024: https://github.com/cms-sw/cmssw/pull/40496, https://github.com/cms-sw/cmssw/pull/43217, https://github.com/cms-sw/cmssw/pull/46639, https://github.com/cms-sw/cmssw/pull/46723

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

- We need a backport for 15_0_X

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

<!-- Please delete the text above after you verified all points of the checklist  -->
