### PR TITLE
PPS 2025 Reconstruction geometry BUG FIX

### DIFF
--- a/Geometry/VeryForwardData/data/CTPPS_2025/Stations/Reco/v1/RP_210_Left_Station.xml
+++ b/Geometry/VeryForwardData/data/CTPPS_2025/Stations/Reco/v1/RP_210_Left_Station.xml
@@ -236,14 +236,14 @@
             <rChild name="RP_Box_004:RP_box_primary_vacuum"/>
 	    <!-- <rRotation name="RP_Transformations:RP_y_180_rot" -->
 	    <rRotation name="RP_210_Left_minus_Sec_Rotation"/>
-            <Translation x="0*mm" y="[RP_Dist_Beam_Cent:RP_210_Left_Det_Dist_4]+[RP_Box:RP_Box_primary_vacuum_y]/2" z="-([RP_210_Left_Sec_Vert_z]-[RP_210_Left_Station_Length]/2)"/>
+	    <Translation x="([RP_Dist_Beam_Cent:RP_210_Left_Det_Dist_4]+[RP_Box:RP_Box_primary_vacuum_y]/2)*tan([RP_210_Left_Sec_Rot_Angle])" y="[RP_Dist_Beam_Cent:RP_210_Left_Det_Dist_4]+[RP_Box:RP_Box_primary_vacuum_y]/2" z="-([RP_210_Left_Sec_Vert_z]-[RP_210_Left_Station_Length]/2)"/>
         </PosPart>
         <PosPart copyNumber="5">
             <rParent name="RP_210_Left_Station_Vacuum_3_Far"/>
             <rChild name="RP_Box_005:RP_box_primary_vacuum"/>
-	    <!--  sformations:RP_180_z_180_y_rot -->
+	    <!--  transformations:RP_180_z_180_y_rot -->
 	    <rRotation name="RP_210_Left_180_minus_Sec_Rotation"/>	    
-            <Translation x="0*mm" y="-[RP_Dist_Beam_Cent:RP_210_Left_Det_Dist_5]-[RP_Box:RP_Box_primary_vacuum_y]/2" z="-([RP_210_Left_Sec_Vert_z]-[RP_210_Left_Station_Length]/2)"/>
+	    <Translation x="(-[RP_Dist_Beam_Cent:RP_210_Left_Det_Dist_5]-[RP_Box:RP_Box_primary_vacuum_y]/2)*tan([RP_210_Left_Sec_Rot_Angle])" y="-[RP_Dist_Beam_Cent:RP_210_Left_Det_Dist_5]-[RP_Box:RP_Box_primary_vacuum_y]/2" z="-([RP_210_Left_Sec_Vert_z]-[RP_210_Left_Station_Length]/2)"/>
         </PosPart>
     </PosPartSection>
 </DDDefinition>

--- a/Geometry/VeryForwardData/data/CTPPS_2025/Stations/Reco/v1/RP_210_Right_Station.xml
+++ b/Geometry/VeryForwardData/data/CTPPS_2025/Stations/Reco/v1/RP_210_Right_Station.xml
@@ -228,14 +228,16 @@
             <rParent name="RP_210_Right_Station_Vacuum_3_Far"/>
             <rChild name="RP_Box_104:RP_box_primary_vacuum"/>
 	    <rRotation name="RP_210_Right_minus_Sec_Rotation"/>
-            <Translation x="0*mm" y="[RP_Dist_Beam_Cent:RP_210_Right_Det_Dist_4]+[RP_Box:RP_Box_primary_vacuum_y]/2" z="[RP_210_Right_Sec_Vert_z]-[RP_210_Right_Station_Length]/2"/>
+	    <!-- x = y*tan(theta) -->
+	    <Translation x="([RP_Dist_Beam_Cent:RP_210_Right_Det_Dist_4]+[RP_Box:RP_Box_primary_vacuum_y]/2)*tan([RP_210_Right_Sec_Rot_Angle])" y="[RP_Dist_Beam_Cent:RP_210_Right_Det_Dist_4]+[RP_Box:RP_Box_primary_vacuum_y]/2" z="[RP_210_Right_Sec_Vert_z]-[RP_210_Right_Station_Length]/2"/>
         </PosPart>
         <PosPart copyNumber="105">
             <rParent name="RP_210_Right_Station_Vacuum_3_Far"/>
             <rChild name="RP_Box_105:RP_box_primary_vacuum"/>
 	    <!--   <rRotation name="RP_Transformations:RP_z_180_rot"/> -->
 	    <rRotation name="RP_210_Right_180_minus_Sec_Rotation"/>
-            <Translation x="0*mm" y="-[RP_Dist_Beam_Cent:RP_210_Right_Det_Dist_5]-[RP_Box:RP_Box_primary_vacuum_y]/2" z="[RP_210_Right_Sec_Vert_z]-[RP_210_Right_Station_Length]/2"/>
+	    <Translation x="(-[RP_Dist_Beam_Cent:RP_210_Right_Det_Dist_5]-[RP_Box:RP_Box_primary_vacuum_y]/2)*tan([RP_210_Right_Sec_Rot_Angle])" y="-[RP_Dist_Beam_Cent:RP_210_Right_Det_Dist_5]-[RP_Box:RP_Box_primary_vacuum_y]/2" z="[RP_210_Right_Sec_Vert_z]-[RP_210_Right_Station_Length]/2"/>
         </PosPart>
+
     </PosPartSection>
 </DDDefinition>


### PR DESCRIPTION
#### PR description:

Bug fix of PR #47666. An offset value was missing in vertical pots of stations 45(56)-210. 
Only Reconstruction geometry affected.

#### PR validation:

Private validation with new 2025 data.

Not a backport.