### PR TITLE
Fix missing towerMaker collection in AOD in Run3_2025_OXY eras

### DIFF
--- a/RecoJets/Configuration/python/RecoJets_EventContent_cff.py
+++ b/RecoJets/Configuration/python/RecoJets_EventContent_cff.py
@@ -54,9 +54,10 @@ from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
 from Configuration.Eras.Modifier_ppRef_2024_cff import ppRef_2024
+from Configuration.Eras.Modifier_run3_oxygen_cff import run3_oxygen
 from Configuration.ProcessModifiers.phase2_pp_on_AA_cff import phase2_pp_on_AA
 #products from regular pp which does not fit the normal AOD
-for e in [pA_2016, peripheralPbPb, pp_on_XeXe_2017, pp_on_AA]:
+for e in [pA_2016, peripheralPbPb, pp_on_XeXe_2017, pp_on_AA, run3_oxygen]:
     e.toModify( RecoJetsAOD.outputCommands, 
                 func=lambda outputCommands: outputCommands.extend(['keep *_towerMaker_*_*'])
                 )


### PR DESCRIPTION
#### PR description:

This PR adds the towerMaker collection in the AOD event content of the Run3_2025_OXY eras, since it is needed when running the MiniAOD (PAT) step standalone from AOD.

#### PR validation:

Tested with workflow 143.911 and 143.912

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Plan to backport to 15_0_X

@abaty @loizides @mandrenguyen
