### PR TITLE
Fixes for HGCal validation at HLT

### DIFF
--- a/Configuration/ProcessModifiers/python/ngtScouting_cff.py
+++ b/Configuration/ProcessModifiers/python/ngtScouting_cff.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+# This modifier is for running ngt scouting menu validation
+
+ngtScouting = cms.Modifier()

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1974,10 +1974,12 @@ upgradeWFs['NGTScouting'] = UpgradeWorkflow_NGTScouting(
 )
 upgradeWFs['NGTScouting'].step2 = {
     '-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:NGTScouting,VALIDATION:@hltValidation',
+    '--procModifiers': 'ngtScouting',
     '--datatier':'GEN-SIM-DIGI-RAW,DQMIO',
     '--eventcontent':'FEVTDEBUGHLT,DQMIO'
 }
 upgradeWFs['NGTScouting'].step3 = {
+    '--procModifiers': 'ngtScouting',
     '-s':'HARVESTING:@hltValidation'
 }
 

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/AllHitToTracksterAssociatorsProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/AllHitToTracksterAssociatorsProducer.cc
@@ -89,7 +89,7 @@ void AllHitToTracksterAssociatorsProducer::produce(edm::StreamID, edm::Event& iE
       edm::LogWarning("AllHitToTracksterAssociatorsProducer") << "Missing Tracksters for one of the hitsTokens.";
       iEvent.put(std::make_unique<ticl::AssociationMap<ticl::mapWithFraction>>(), "hitTo" + tracksterToken.first);
       iEvent.put(std::make_unique<ticl::AssociationMap<ticl::mapWithFraction>>(), tracksterToken.first + "ToHit");
-      return;
+      continue;
     }
 
     auto hitToTracksterMap = std::make_unique<ticl::AssociationMap<ticl::mapWithFraction>>(rechitManager.size());

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/AllHitToTracksterAssociatorsProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/AllHitToTracksterAssociatorsProducer.cc
@@ -53,6 +53,15 @@ void AllHitToTracksterAssociatorsProducer::produce(edm::StreamID, edm::Event& iE
   Handle<std::vector<reco::CaloCluster>> layer_clusters;
   iEvent.getByToken(layerClustersToken_, layer_clusters);
 
+  if (!layer_clusters.isValid()) {
+    edm::LogWarning("AllHitToTracksterAssociatorsProducer") << "Missing LayerCluster collection.";
+    for (const auto& tracksterToken : tracksterCollectionTokens_) {
+      iEvent.put(std::make_unique<ticl::AssociationMap<ticl::mapWithFraction>>(), "hitTo" + tracksterToken.first);
+      iEvent.put(std::make_unique<ticl::AssociationMap<ticl::mapWithFraction>>(), tracksterToken.first + "ToHit");
+    }
+    return;
+  }
+
   Handle<std::unordered_map<DetId, const unsigned int>> hitMap;
   iEvent.getByToken(hitMapToken_, hitMap);
 

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/AllTracksterToSimTracksterAssociatorsByHitsProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/AllTracksterToSimTracksterAssociatorsByHitsProducer.cc
@@ -174,7 +174,7 @@ void AllTracksterToSimTracksterAssociatorsByHitsProducer::produce(edm::StreamID,
                                                          std::vector<ticl::Trackster>>>(),
                    simTracksterToken.first + "To" + tracksterToken.first);
       }
-      return;
+      continue;
     }
 
     const auto& recoTracksters = *recoTrackstersHandle;

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/AllTracksterToSimTracksterAssociatorsByLCsProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/AllTracksterToSimTracksterAssociatorsByLCsProducer.cc
@@ -131,7 +131,7 @@ void AllTracksterToSimTracksterAssociatorsByLCsProducer::produce(edm::StreamID,
                                                          std::vector<ticl::Trackster>>>(),
                    simTracksterToken.first + "To" + tracksterToken.first);
       }
-      return;
+      continue;
     }
 
     const auto& recoTracksters = *recoTrackstersHandle;

--- a/Validation/HGCalValidation/python/HLT_TICLIterLabels_cff.py
+++ b/Validation/HGCalValidation/python/HLT_TICLIterLabels_cff.py
@@ -16,3 +16,10 @@ ticl_v5.toModify(
         ]
     })
 )
+
+## remove the L1Seeded iteration form the HLT Ticl labels
+from Configuration.ProcessModifiers.ngtScouting_cff import ngtScouting
+_ngtLabels = [label for label in hltTiclIterLabels if label != "hltTiclTrackstersCLUE3DHighL1Seeded"]
+ngtScouting.toModify(
+    globals(), lambda g: g.update({"hltTiclIterLabels": _ngtLabels})
+)

--- a/Validation/HGCalValidation/python/HLT_TICLIterLabels_cff.py
+++ b/Validation/HGCalValidation/python/HLT_TICLIterLabels_cff.py
@@ -1,7 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-#hltTiclIterLabels = ["hltTiclTrackstersCLUE3DHigh", "hltTiclTrackstersCLUE3DHighL1Seeded", "hltTiclTrackstersMerge"]
-hltTiclIterLabels = ["hltTiclTrackstersCLUE3DHigh", "hltTiclTrackstersMerge"]
+hltTiclIterLabels = ["hltTiclTrackstersCLUE3DHigh", "hltTiclTrackstersCLUE3DHighL1Seeded", "hltTiclTrackstersMerge"]
 
 from Configuration.ProcessModifiers.ticl_v5_cff import ticl_v5
 ticl_v5.toModify(
@@ -9,7 +8,7 @@ ticl_v5.toModify(
     lambda g: g.update({
         "hltTiclIterLabels": [
             "hltTiclTrackstersCLUE3DHigh",
-            #"hltTiclTrackstersCLUE3DHighL1Seeded",
+            "hltTiclTrackstersCLUE3DHighL1Seeded",
             "hltTiclTracksterLinks",
             #"hltTiclTracksterLinksSuperclusteringDNNUnseeded",
             #"hltTiclTracksterLinksSuperclusteringDNNL1Seeded",


### PR DESCRIPTION
#### PR description:

This PR is a quick follow-up to https://github.com/cms-sw/cmssw/pull/47892.
In that PR the HGCal validation at HLT machinery was established, but a mistake in the logic of the association map producers was introduced, such that the code returns empty maps even if only one of the `Trackster`-s collections is missing. 
That in turn prevents to provide validation for the L1Seeded TICL iteration `hltTiclTrackstersCLUE3DHighL1Seeded`.
This PR fixes the issue and supplies validation for that TICL iteration.
In order to avoid having spurious warning messages in the NGT scouting menu about the missing `hltTiclTrackstersCLUE3DHighL1Seeded` (which is not employed in it, cf the [html dump of the NGT scouting menu](https://cms-ngt-hlt.docs.cern.ch/Task311/2025/NGTScoutingMenu/Phase2Menu_NGTScouting/)) a new process modifier `ngtScouting` is used in the validation and harvesting steps.
 
#### PR validation:

Run successfully the following runTheMatrix command:

```
runTheMatrix.py --what upgrade -l 29634.0,29634.75,29634.203,29634.752,29634.77
```

and obtained:

```
29634.0_TTbar_14TeV+Run4D110 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Sun May 18 16:26:51 2025-date Sun May 18 16:16:32 2025; exit: 0 0 0 0 0
29634.203_TTbar_14TeV+Run4D110_ticl_v5 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Sun May 18 16:26:51 2025-date Sun May 18 16:16:32 2025; exit: 0 0 0 0 0
29634.75_TTbar_14TeV+Run4D110_HLT75e33Timing Step0-PASSED Step1-PASSED Step2-PASSED  - time date Sun May 18 16:22:26 2025-date Sun May 18 16:16:33 2025; exit: 0 0 0
29634.752_TTbar_14TeV+Run4D110_HLT75e33TimingTiclV5 Step0-PASSED Step1-PASSED Step2-PASSED  - time date Sun May 18 16:22:26 2025-date Sun May 18 16:16:33 2025; exit: 0 0 0
29634.77_TTbar_14TeV+Run4D110_NGTScouting Step0-PASSED Step1-PASSED Step2-PASSED  - time date Sun May 18 16:28:09 2025-date Sun May 18 16:22:27 2025; exit: 0 0 0
5 5 5 2 2 tests passed, 0 0 0 0 0 failed
```

also validated with the following command:

```
cmsDriver.py step2 -s HLT:NGTScouting,VALIDATION:@hltValidation --conditions auto:phase2_realistic_T33 \ 
--datatier GEN-SIM-DIGI-RAW,DQMIO -n 10 --eventcontent FEVTDEBUGHLT,DQMIO \
--geometry ExtendedRun4D110 --era Phase2C17I13M9 --procModifier alpaka \
--filein file:/eos/cms/store/relval/CMSSW_15_1_0_pre2/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_150X_mcRun4_realistic_v1_STD_Run4D110_PU-v1/2580000/0346563c-5dd4-4344-8595-159ee2ba6cd4.root  \
--fileout file:step3.root --no_exec --process HLTX
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, not meant to be backported