### PR TITLE
Fix SoftMuonMvaRun3Estimator for NaN chi2 (PromptReco issue)

### DIFF
--- a/PhysicsTools/PatAlgos/src/SoftMuonMvaRun3Estimator.cc
+++ b/PhysicsTools/PatAlgos/src/SoftMuonMvaRun3Estimator.cc
@@ -130,7 +130,9 @@ float pat::computeSoftMvaRun3(pat::XGBooster& booster, const pat::Muon& muon) {
   booster.set("nPixels", muon.innerTrack()->hitPattern().numberOfValidPixelHits());
   booster.set("nValidHits", muon.innerTrack()->hitPattern().numberOfValidTrackerHits());
   booster.set("nLostHitsOn", muon.innerTrack()->hitPattern().numberOfLostTrackerHits(reco::HitPattern::TRACK_HITS));
-  booster.set("glbNormChi2", muon.isGlobalMuon() ? muon.globalTrack()->normalizedChi2() : 9999.);
+  booster.set(
+      "glbNormChi2",
+      muon.isGlobalMuon() && !std::isnan(muon.globalTrack()->chi2()) ? muon.globalTrack()->normalizedChi2() : 9999.);
   booster.set("trkLayers", muon.innerTrack()->hitPattern().trackerLayersWithMeasurement());
   booster.set("highPurity", muon.innerTrack()->quality(reco::Track::highPurity));
 


### PR DESCRIPTION
#### PR description:

Fix the SoftMuonMvaRun3Estimator to handle cases where a muon global track chi2 is NaN, which otherwise causes the pat::XGBooster to throw an exception as if the variable had not been initialized.

See https://github.com/cms-sw/cmssw/issues/48063

#### PR validation:

The usual code-format, code-checks, runtests, `runTheMatrix.py -l limited -i all --ibeos`.

In 15_0_6 also tested it on the exception mentioned in the github issue https://github.com/cms-sw/cmssw/issues/48063 from run 391884 and a similar one in the newer run 329112 ( https://cmsweb.cern.ch/t0_reqmon/data/jobdetail/PromptReco_Run392112_ParkingSingleMuon4 )

@24LopezR @llunerti 
