### PR TITLE
Fix AlCaHcalIsoTrk_Run3 Scenario Impl

### DIFF
--- a/Configuration/DataProcessing/python/Impl/AlCaHcalIsoTrk_Run3.py
+++ b/Configuration/DataProcessing/python/Impl/AlCaHcalIsoTrk_Run3.py
@@ -9,10 +9,10 @@ Scenario supporting proton collisions for AlCa needs for AlCaHcalIsoTrk data str
 from Configuration.DataProcessing.Scenario import *
 from Configuration.DataProcessing.Utils import stepALCAPRODUCER,dictIO,gtNameAndConnect
 from Configuration.Eras.Era_Run3_cff import Run3
-from Configuration.DataProcessing.Impl.pp import pp
+from Configuration.DataProcessing.Impl.AlCa import AlCa
 import FWCore.ParameterSet.Config as cms
 
-class AlCaHcalIsoTrk_Run3(pp):
+class AlCaHcalIsoTrk_Run3(AlCa):
     def __init__(self):
         Scenario.__init__(self)
         self.eras=Run3


### PR DESCRIPTION
#### PR description:

Have the `AlCaHcalIsoTrk_Run3` scenario inherit from the `AlCa` `DataProcessing` implementation rather than the `pp` implementation. This is following up from issues seen at T0 [1] during replay.

[1] https://cms-talk.web.cern.ch/t/new-primary-dataset-for-alcahcalisotrk-hlt-menu/124762/7

#### PR validation:

Ran the `RunPromptReco.py` wrapper to process an `AlCaHcalIsoTrk` RAW file and it still completes successfully without issue. Note, the issue at T0 [1] was not observed when testing in this way for https://github.com/cms-sw/cmssw/pull/47975.

```
python3 $CMSSW_RELEASE_BASE/src/Configuration/DataProcessing/test/RunPromptReco.py --scenario=AlCaHcalIsoTrk_Run3  --global-tag  141X_dataRun3_Prompt_v3 --lfn=root://cms-xrd-global.cern.ch///store/data/Run2025C/AlCaHcalIsoTrk/RAW/v1/000/392/175/00000/00fe663a-d67a-4d3d-964b-5fe4883b85ab.root --alcarecos=HcalCalIsoTrkFromAlCaRaw
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Will need to be back-ported to 15_0_X