### PR TITLE
[15_0_X] Updating Online DQM Info client to correctly display beam energy status

### DIFF
--- a/DQMServices/Components/plugins/DQMProvInfo.cc
+++ b/DQMServices/Components/plugins/DQMProvInfo.cc
@@ -110,7 +110,7 @@ private:
   // time to time a value of the beam momentum slightly below the nominal values,
   // even during stable collisions: in this way, we provide a correct information
   // at the cost of not requiring the exact momentum being measured by BST.
-  const static int MOMENTUM_OFFSET = 1;
+  const static int MOMENTUM_OFFSET = 2;
 
   // Process parameters
   std::string subsystemname_;


### PR DESCRIPTION
#### PR description:

Fixes the "13.6 TeV" status bit in the "DCS HV Status and Beam Status per Lumisection" plot in the online DQM land page. The actual momentum returned by `tcdsData->getBST().getBeamMomentum()` [here](https://github.com/cms-sw/cmssw/blob/3273c07d7ab524f52f19bf86079695a74ee0dce8/DQMServices/Components/plugins/DQMProvInfo.cc#L374) is 6798, thus failing the check [here](https://github.com/cms-sw/cmssw/blob/3273c07d7ab524f52f19bf86079695a74ee0dce8/DQMServices/Components/plugins/DQMProvInfo.cc#L387) with the currently allowed offset of 1.

#### PR validation:

Tested in playback in P5 online DQM machines on streamers from run 392301

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #48120 
