### PR TITLE
Release principals in TestSourceProcessor

### DIFF
--- a/FWCore/TestProcessor/src/TestSourceProcessor.cc
+++ b/FWCore/TestProcessor/src/TestSourceProcessor.cc
@@ -259,7 +259,10 @@ namespace edm::test {
     ServiceRegistry::Operate operate(serviceToken_);
 
     //NOTE: should probably handle merging as well
+    //if there is only one principal, we need to return it to the cache first
+    runPrincipal_.reset();
     runPrincipal_ = principalCache_.getAvailableRunPrincipalPtr();
+    assert(runPrincipal_);
     runPrincipal_->possiblyUpdateAfterAddition(preg_);
     runPrincipal_->setAux(*source_->runAuxiliary());
     source_->readRun(*runPrincipal_, *historyAppender_);
@@ -276,6 +279,8 @@ namespace edm::test {
     //make the services available
     ServiceRegistry::Operate operate(serviceToken_);
 
+    //if there is only one principal, we need to return it to the cache first
+    lumiPrincipal_.reset();
     lumiPrincipal_ = principalCache_.getAvailableLumiPrincipalPtr();
     assert(lumiPrincipal_);
     lumiPrincipal_->possiblyUpdateAfterAddition(preg_);


### PR DESCRIPTION
#### PR description:

Need to release the principal before asking for one from the cache.

#### PR validation:

The problem was uncovered while updating a test to use multiple Runs. After this change the new test worked.

resolves https://github.com/cms-sw/framework-team/issues/1401