### PR TITLE
[UBSAN][GCC14]move large constructor code in to private member function

### DIFF
--- a/Alignment/MuonAlignmentAlgorithms/interface/MuonResidualsFromTrack.h
+++ b/Alignment/MuonAlignmentAlgorithms/interface/MuonResidualsFromTrack.h
@@ -95,6 +95,18 @@ public:
   TMatrixD choleskyCorrMatrix(DetId chamberId);
 
 private:
+  //Due to large constructor code, UBSAN with GCC14 hangs and never returns
+  //Moving large constructor code to a private function fixes this issue
+  void init(edm::ESHandle<TransientTrackingRecHitBuilder> builder,
+            edm::ESHandle<MagneticField> magneticField,
+            edm::ESHandle<GlobalTrackingGeometry> globalGeometry,
+            edm::ESHandle<DetIdAssociator> muonDetIdAssociator_,
+            edm::ESHandle<Propagator> prop,
+            const Trajectory *traj,
+            const reco::Track *recoTrack,
+            AlignableNavigator *navigator,
+            double maxResidual);
+
   TrajectoryStateCombiner m_tsoscomb;
 
   int m_tracker_numHits;

--- a/Alignment/MuonAlignmentAlgorithms/src/MuonResidualsFromTrack.cc
+++ b/Alignment/MuonAlignmentAlgorithms/src/MuonResidualsFromTrack.cc
@@ -31,6 +31,26 @@ MuonResidualsFromTrack::MuonResidualsFromTrack(edm::ESHandle<TransientTrackingRe
                                                AlignableNavigator* navigator,
                                                double maxResidual)
     : m_recoTrack(recoTrack) {
+  init(trackerRecHitBuilder,
+       magneticField,
+       globalGeometry,
+       muonDetIdAssociator_,
+       prop,
+       traj,
+       recoTrack,
+       navigator,
+       maxResidual);
+}
+
+void MuonResidualsFromTrack::init(edm::ESHandle<TransientTrackingRecHitBuilder> trackerRecHitBuilder,
+                                  edm::ESHandle<MagneticField> magneticField,
+                                  edm::ESHandle<GlobalTrackingGeometry> globalGeometry,
+                                  edm::ESHandle<DetIdAssociator> muonDetIdAssociator_,
+                                  edm::ESHandle<Propagator> prop,
+                                  const Trajectory* traj,
+                                  const reco::Track* recoTrack,
+                                  AlignableNavigator* navigator,
+                                  double maxResidual) {
   bool m_debug = false;
 
   if (m_debug) {


### PR DESCRIPTION
We noticed that UBSAN IBs with GCC14 hanged and failed to compile https://github.com/cms-sw/cmssw/blob/master/Alignment/MuonAlignmentAlgorithms/src/MuonResidualsFromTrack.cc. CMSSW_15_1_UBSAN_X_2025-05-16-2300 took over 3 days and compiler was still hanging for this file. I had to kill the compilation command to get the UBSAN IB process finish.  After some debugging I noticed that the constructor of this class was very large (over 550 lines) so just randomly moving the constructor code in to a new private member function fixed the build issue. 

Local build of UBSAN/GCC14 was also hanging without this change but finishes properly with this change.

[a]
```
pid  time rss command
2211668 00:00:00   536  \_ /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gcc/14.2.1-1220301db2ec2340427663aa9efa44a7/bin/c++ -c -DCMS_MICRO_ARCH="x86-64-v3" -DGNU_GCC -D_GNU_SOURCE -DCMS_UNDEFINED_SANITIZER -DTBB_USE_GLIBCXX_VERSION=140201 -DTBB_SUPPRESS_DEPRECATED_MESSAGES -DTBB_PREVIEW_RESUMABLE_TASKS=1 -DTBB_PREVIEW_TASK_GROUP_EXTENSIONS=1 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -DBOOST_MATH_DISABLE_STD_FPCLASSIFY -DBOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX -DBOOST_MPL_IGNORE_PARENTHESES_WARNING -DDD4HEP_USE_GEANT4_UNITS=1 -DCMSSW_GIT_HASH="CMSSW_15_1_UBSAN_X_2025-05-19-2300" -DPROJECT_NAME="CMSSW" -DPROJECT_VERSION="CMSSW_15_1_UBSAN_X_2025-05-19-2300" -Isrc -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/cms/coral/CORAL_2_3_21-326d3770dd9085e669823ec0f0f47ae8/include/LCG -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/dd4hep/v01-29-00-49ea4ff97e2f54c56c6128c6a3670a7f/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/alpaka/1.2.0-d607dc9cbb9e28436c9a080dfb7326d1/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/pcre/8.43-52402b0effcc161602d461d189372df0/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/boost/1.80.0-7d3bf675019baa0e05041724300809e2/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/bz2lib/1.0.6-05663b850418aaef1067ca19af9bd4cc/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/clhep/2.4.7.1-23f57abc9e10207d69c83f2df75a498c/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/curl/7.79.0-017301af0bc5c109ddd58a3fe7cd7268/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gsl/2.6-e53b60603b4c1f5e071d3617b6f71dc8/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/hls/2025.05-d926977c49269803af967c4d82e3fcc6/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/libuuid/2.34-818f06439fe4692b05080d84c5fcddb3/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/lcg/root/6.32.13-b035ef2778f9f8ef2bc31ba9d3015213/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/tbb/v2022.0.0-b75b1a0fc45777a1dcba1b6f5d5ec5c5/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/cms/vdt/0.4.3-5a0e0949fb77c9f869b19375bef5f90d/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/xerces-c/3.1.3-680c7033c41009979302727dd55f43c5/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/xz/5.6.4-566729597e8168a3a7ea298577ed420a/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/zlib/1.2.13-bedf1a519db641f709bf4bdb241d44a7/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-30cffe9eb486fe28b119a6933fc6f4c0/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-30cffe9eb486fe28b119a6933fc6f4c0/include/eigen3 -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/fmt/10.2.1-de038424cb3b858ec80cb56e49f7dd56/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/md5/1.0.0-06b4a271d4467cc29c48dd92a6712ba8/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/OpenBLAS/0.3.27-73350001b93a535b5ef4c243178aaf6b/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/tinyxml2/6.2.0-25c0d49c33cbdf421e28e68df971f91c/include -O3 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++20 -ftree-vectorize -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -Wno-error=array-bounds -Warray-bounds -fuse-ld=bfd -march=x86-64-v3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-unused-parameter -Wunused -Wparentheses -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -fno-omit-frame-pointer -fsanitize=undefined -fsanitize=builtin -fsanitize=pointer-overflow -DEIGEN_DONT_PARALLELIZE -DEIGEN_MAX_ALIGN_BYTES=64 -Wno-error=unused-variable -DALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128 -DALPAKA_DISABLE_VENDOR_RNG -DBOOST_DISABLE_ASSERTS -g -fPIC -MMD -MF tmp/el8_amd64_gcc14/src/Alignment/MuonAlignmentAlgorithms/src/AlignmentMuonAlignmentAlgorithms/MuonResidualsFromTrack.cc.d src/Alignment/MuonAlignmentAlgorithms/src/MuonResidualsFromTrack.cc -o tmp/el8_amd64_gcc14/src/Alignment/MuonAlignmentAlgorithms/src/AlignmentMuonAlignmentAlgorithms/MuonResidualsFromTrack.cc.o
2211669 13:05:37 647216  \_ /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gcc/14.2.1-1220301db2ec2340427663aa9efa44a7/bin/../libexec/gcc/x86_64-redhat-linux-gnu/14.2.1/cc1plus -quiet -I src -I /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/cms/coral/CORAL_2_3_21-326d3770dd9085e669823ec0f0f47ae8/include/LCG -I /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/dd4hep/v01-29-00-49ea4ff97e2f54c56c6128c6a3670a7f/include -I /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/alpaka/1.2.0-d607dc9cbb9e28436c9a080dfb7326d1/include -I /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/pcre/8.43-52402b0effcc161602d461d189372df0/include -I /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/bz2lib/1.0.6-05663b850418aaef1067ca19af9bd4cc/include -I /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/curl/7.79.0-017301af0bc5c109ddd58a3fe7cd7268/include -I /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gsl/2.6-e53b60603b4c1f5e071d3617b6f71dc8/include -I /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/libuuid/2.34-818f06439fe4692b05080d84c5fcddb3/include -I /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/cms/vdt/0.4.3-5a0e0949fb77c9f869b19375bef5f90d/include -I /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/xerces-c/3.1.3-680c7033c41009979302727dd55f43c5/include -I /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/xz/5.6.4-566729597e8168a3a7ea298577ed420a/include -I /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/zlib/1.2.13-bedf1a519db641f709bf4bdb241d44a7/include -I /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-30cffe9eb486fe28b119a6933fc6f4c0/include -I /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-30cffe9eb486fe28b119a6933fc6f4c0/include/eigen3 -I /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/fmt/10.2.1-de038424cb3b858ec80cb56e49f7dd56/include -I /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/md5/1.0.0-06b4a271d4467cc29c48dd92a6712ba8/include -I /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/OpenBLAS/0.3.27-73350001b93a535b5ef4c243178aaf6b/include -I /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/tinyxml2/6.2.0-25c0d49c33cbdf421e28e68df971f91c/include -iprefix /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gcc/14.2.1-1220301db2ec2340427663aa9efa44a7/bin/../lib/gcc/x86_64-redhat-linux-gnu/14.2.1/ -isystem /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/gcc/14.2.1-1220301db2ec2340427663aa9efa44a7/include -MMD tmp/el8_amd64_gcc14/src/Alignment/MuonAlignmentAlgorithms/src/AlignmentMuonAlignmentAlgorithms/MuonResidualsFromTrack.cc.d -MF tmp/el8_amd64_gcc14/src/Alignment/MuonAlignmentAlgorithms/src/AlignmentMuonAlignmentAlgorithms/MuonResidualsFromTrack.cc.d -MQ tmp/el8_amd64_gcc14/src/Alignment/MuonAlignmentAlgorithms/src/AlignmentMuonAlignmentAlgorithms/MuonResidualsFromTrack.cc.o -D_GNU_SOURCE -D_REENTRANT -D CMS_MICRO_ARCH="x86-64-v3" -D GNU_GCC -D _GNU_SOURCE -D CMS_UNDEFINED_SANITIZER -D TBB_USE_GLIBCXX_VERSION=140201 -D TBB_SUPPRESS_DEPRECATED_MESSAGES -D TBB_PREVIEW_RESUMABLE_TASKS=1 -D TBB_PREVIEW_TASK_GROUP_EXTENSIONS=1 -D BOOST_SPIRIT_THREADSAFE -D PHOENIX_THREADSAFE -D BOOST_MATH_DISABLE_STD_FPCLASSIFY -D BOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX -D BOOST_MPL_IGNORE_PARENTHESES_WARNING -D DD4HEP_USE_GEANT4_UNITS=1 -D CMSSW_GIT_HASH="CMSSW_15_1_UBSAN_X_2025-05-19-2300" -D PROJECT_NAME="CMSSW" -D PROJECT_VERSION="CMSSW_15_1_UBSAN_X_2025-05-19-2300" -D EIGEN_DONT_PARALLELIZE -D EIGEN_MAX_ALIGN_BYTES=64 -D ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128 -D ALPAKA_DISABLE_VENDOR_RNG -D BOOST_DISABLE_ASSERTS -isystem /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/boost/1.80.0-7d3bf675019baa0e05041724300809e2/include -isystem /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/clhep/2.4.7.1-23f57abc9e10207d69c83f2df75a498c/include -isystem /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/hls/2025.05-d926977c49269803af967c4d82e3fcc6/include -isystem /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/lcg/root/6.32.13-b035ef2778f9f8ef2bc31ba9d3015213/include -isystem /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc14/external/tbb/v2022.0.0-b75b1a0fc45777a1dcba1b6f5d5ec5c5/include src/Alignment/MuonAlignmentAlgorithms/src/MuonResidualsFromTrack.cc -quiet -dumpdir tmp/el8_amd64_gcc14/src/Alignment/MuonAlignmentAlgorithms/src/AlignmentMuonAlignmentAlgorithms/ -dumpbase MuonResidualsFromTrack.cc.cc -dumpbase-ext .cc -march=x86-64-v3 -g -O3 -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -Wno-error=array-bounds -Warray-bounds=1 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-unused-parameter -Wunused -Wparentheses -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -Wno-error=unused-variable -std=c++20 -ftree-vectorize -fvisibility-inlines-hidden -fno-math-errno -fuse-ld=bfd -felide-constructors -fmessage-length=0 -fdiagnostics-show-option -fno-omit-frame-pointer -fsanitize=undefined -fsanitize=builtin -fsanitize=pointer-overflow -fPIC --param=vect-max-version-for-alias-checks=50 -fabi-version=0 -o -
```

