### PR TITLE
Improve SoA out-of-bounds error message

### DIFF
--- a/DataFormats/SoATemplate/BuildFile.xml
+++ b/DataFormats/SoATemplate/BuildFile.xml
@@ -1,3 +1,4 @@
 <use name="boost_header"/>
+<use name="fmt"/>
 <use name="FWCore/Reflection" source_only="1"/>
 <use name="FWCore/Utilities" source_only="1"/>

--- a/DataFormats/SoATemplate/interface/SoACommon.h
+++ b/DataFormats/SoATemplate/interface/SoACommon.h
@@ -10,10 +10,13 @@
 #include <cstring>
 #include <memory>
 #include <ostream>
+#include <sstream>
 #include <tuple>
 #include <type_traits>
 
 #include <boost/preprocessor.hpp>
+
+#include <fmt/format.h>
 
 #include "FWCore/Utilities/interface/typedefs.h"
 
@@ -32,20 +35,20 @@
 
 // Exception throwing (or willful crash in kernels)
 #if defined(__CUDACC__) && defined(__CUDA_ARCH__)
-#define SOA_THROW_OUT_OF_RANGE(A) \
-  {                               \
-    printf("%s\n", (A));          \
-    __trap();                     \
+#define SOA_THROW_OUT_OF_RANGE(A, I, R)                      \
+  {                                                          \
+    printf("%s: index %d out of range %d\n", (A), (I), (R)); \
+    __trap();                                                \
   }
 #elif defined(__HIPCC__) && defined(__HIP_DEVICE_COMPILE__)
-#define SOA_THROW_OUT_OF_RANGE(A) \
-  {                               \
-    printf("%s\n", (A));          \
-    abort();                      \
+#define SOA_THROW_OUT_OF_RANGE(A, I, R)                      \
+  {                                                          \
+    printf("%s: index %d out of range %d\n", (A), (I), (R)); \
+    abort();                                                 \
   }
 #else
-#define SOA_THROW_OUT_OF_RANGE(A) \
-  { throw std::out_of_range(A); }
+#define SOA_THROW_OUT_OF_RANGE(A, I, R) \
+  { throw std::out_of_range(fmt::format("{}: index {} out of range {}", (A), (I), (R))); }
 #endif
 
 /* declare "scalars" (one value shared across the whole SoA) and "columns" (one value per element) */

--- a/DataFormats/SoATemplate/interface/SoAView.h
+++ b/DataFormats/SoATemplate/interface/SoAView.h
@@ -400,7 +400,8 @@ namespace cms::soa {
   LOCAL_NAME(size_type _soa_impl_index) {                                                                              \
     if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                                 \
       if (_soa_impl_index >= base_type::elements_ or _soa_impl_index < 0)                                              \
-        SOA_THROW_OUT_OF_RANGE("Out of range index in mutable " #LOCAL_NAME "(size_type index)")                       \
+        SOA_THROW_OUT_OF_RANGE("Out of range index in mutable " #LOCAL_NAME "(size_type index)",                       \
+          _soa_impl_index, base_type::elements_)                                                                       \
     }                                                                                                                  \
     return typename cms::soa::SoAAccessors<typename BOOST_PP_CAT(Metadata::TypeOf_, LOCAL_NAME)>::                     \
         template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, LOCAL_NAME)>::template AccessType<                   \
@@ -438,7 +439,8 @@ namespace cms::soa {
   LOCAL_NAME(size_type _soa_impl_index) const {                                                                        \
     if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                                 \
       if (_soa_impl_index >= elements_ or _soa_impl_index < 0)                                                         \
-        SOA_THROW_OUT_OF_RANGE("Out of range index in const " #LOCAL_NAME "(size_type index)")                         \
+        SOA_THROW_OUT_OF_RANGE("Out of range index in const " #LOCAL_NAME "(size_type index)",                         \
+          _soa_impl_index, elements_)                                                                                  \
     }                                                                                                                  \
     return typename cms::soa::SoAAccessors<typename BOOST_PP_CAT(Metadata::TypeOf_, LOCAL_NAME)>::                     \
         template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, LOCAL_NAME)>::template AccessType<                   \
@@ -784,7 +786,7 @@ namespace cms::soa {
     element operator[](size_type _soa_impl_index) {                                                                    \
       if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                               \
         if (_soa_impl_index >= base_type::elements_ or _soa_impl_index < 0)                                            \
-          SOA_THROW_OUT_OF_RANGE("Out of range index in " #VIEW "::operator[]")                                        \
+          SOA_THROW_OUT_OF_RANGE("Out of range index in " #VIEW "::operator[]", _soa_impl_index, base_type::elements_) \
       }                                                                                                                \
       return element{_soa_impl_index, _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_ELEMENT_CONSTR_CALL, ~, VALUE_LIST)};        \
     }                                                                                                                  \
@@ -969,7 +971,7 @@ namespace cms::soa {
     const_element operator[](size_type _soa_impl_index) const {                                                        \
       if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                               \
         if (_soa_impl_index >= elements_ or _soa_impl_index < 0)                                                       \
-          SOA_THROW_OUT_OF_RANGE("Out of range index in " #CONST_VIEW "::operator[]")                                  \
+          SOA_THROW_OUT_OF_RANGE("Out of range index in " #CONST_VIEW "::operator[]", _soa_impl_index, elements_)      \
       }                                                                                                                \
       return const_element{                                                                                            \
         _soa_impl_index, _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_CONST_ELEMENT_CONSTR_CALL, ~, VALUE_LIST)                 \

--- a/DataFormats/SoATemplate/test/BuildFile.xml
+++ b/DataFormats/SoATemplate/test/BuildFile.xml
@@ -3,6 +3,7 @@
     <use name="boost"/>
     <use name="cuda"/>
     <use name="eigen"/>
+    <use name="DataFormats/SoATemplate"/>
     <use name="HeterogeneousCore/CUDAUtilities"/>
   </bin>
 </iftool>
@@ -12,6 +13,7 @@
     <use name="boost"/>
     <use name="eigen"/>
     <use name="rocm"/>
+    <use name="DataFormats/SoATemplate"/>
     <use name="HeterogeneousCore/ROCmUtilities"/>
   </bin>
 </iftool>
@@ -19,22 +21,26 @@
 <bin file="SoAUnitTests.cc" name="SoAUnitTests">
   <use name="boost"/>
   <use name="catch2"/>
+  <use name="DataFormats/SoATemplate"/>
 </bin>
 
 <bin file="SoAGenericView_t.cc" name="SoAGenericView_t">
   <use name="boost"/>
   <use name="catch2"/>
   <use name="eigen"/>
+  <use name="DataFormats/SoATemplate"/>
 </bin>
 
 <bin file="SoACustomizedMethods_t.cc" name="SoACustomizedMethods_t">
   <use name="boost"/>
   <use name="catch2"/>
+  <use name="DataFormats/SoATemplate"/>
 </bin>
 
 <!-- This test triggers a bug in ROOT, so it's kept disabled
 <bin file="SoAStreamer_t.cpp" name="SoAStreamer_t">
   <use name="root"/>
+  <use name="DataFormats/SoATemplate"/>
 </bin>
 -->
 


### PR DESCRIPTION
#### PR description:

Improve the message printed in case of an out-of-bounds access to an SoA column.

#### PR validation:

None.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 15.0.x.