### PR TITLE
use BX info in L1-uGT emulation of CICADA conditions

### DIFF
--- a/L1Trigger/L1TGlobal/interface/GlobalBoard.h
+++ b/L1Trigger/L1TGlobal/interface/GlobalBoard.h
@@ -174,7 +174,8 @@ namespace l1t {
     /// pointer to External data list
     inline const BXVector<const GlobalExtBlk*>* getCandL1External() const { return m_candL1External; }
 
-    inline const float getCICADAScore() const { return m_cicadaScore; }
+    /// pointer to CICADA-score data list
+    inline const BXVector<float>* getCandL1CICADAScore() const { return m_candL1CICADAScore; }
 
     /*  Drop individual EtSums for Now
     /// pointer to ETM data list
@@ -208,8 +209,6 @@ namespace l1t {
     void setResetPSCountersEachLumiSec(bool val) { m_resetPSCountersEachLumiSec = val; }
     void setSemiRandomInitialPSCounters(bool val) { m_semiRandomInitialPSCounters = val; }
 
-    void setCICADAScore(float val) { m_cicadaScore = val; }
-
   public:
     inline void setVerbosity(const int verbosity) { m_verbosity = verbosity; }
 
@@ -224,6 +223,7 @@ namespace l1t {
     BXVector<const l1t::EtSum*>* m_candL1EtSum;
     BXVector<const l1t::EtSum*>* m_candL1EtSumZdc;
     BXVector<const GlobalExtBlk*>* m_candL1External;
+    BXVector<float>* m_candL1CICADAScore;
 
     //    BXVector<const l1t::EtSum*>* m_candETM;
     //    BXVector<const l1t::EtSum*>* m_candETT;
@@ -232,8 +232,6 @@ namespace l1t {
 
     int m_bxFirst_;
     int m_bxLast_;
-
-    float m_cicadaScore = 0.0;
 
     std::bitset<GlobalAlgBlk::maxPhysicsTriggers> m_gtlAlgorithmOR;
     std::bitset<GlobalAlgBlk::maxPhysicsTriggers> m_gtlDecisionWord;

--- a/L1Trigger/L1TGlobal/src/CICADACondition.cc
+++ b/L1Trigger/L1TGlobal/src/CICADACondition.cc
@@ -40,22 +40,24 @@ l1t::CICADACondition& l1t::CICADACondition::operator=(const l1t::CICADACondition
 }
 
 const bool l1t::CICADACondition::evaluateCondition(const int bxEval) const {
-  bool condResult = false;
-  const float cicadaScore = m_uGtB->getCICADAScore();
+  auto const* cicadaScoreBXVec = m_uGtB->getCandL1CICADAScore();
+
+  int const useBx = bxEval + m_gtCICADATemplate->condRelativeBx();
+
+  if (cicadaScoreBXVec->isEmpty(useBx)) {
+    return false;
+  }
+
+  float const cicadaScore = cicadaScoreBXVec->at(useBx, 0);
 
   // This gets rid of a GT emulator convention "iCondition".
   // This usually indexes the next line, which is somewhat concerning
   // AXOL1TL operates this way, but it should be checked
   const CICADATemplate::ObjectParameter objPar = (*(m_gtCICADATemplate->objectParameter()))[0];
 
-  bool condGEqVal = m_gtCICADATemplate->condGEq();
-  bool passCondition = false;
+  bool const condGEqVal = m_gtCICADATemplate->condGEq();
 
-  passCondition = checkCut(objPar.minCICADAThreshold, cicadaScore, condGEqVal);
-
-  condResult |= passCondition;
-
-  return condResult;
+  return checkCut(objPar.minCICADAThreshold, cicadaScore, condGEqVal);
 }
 
 void l1t::CICADACondition::print(std::ostream& myCout) const {


### PR DESCRIPTION
#### PR description:

@rseidita reported that #48037 does not entirely fix the L1-uGT data-emulator discrepancies related to the CICADA seeds which are currently observed in the online DQM. It seems that, after including #48037, there are disagreements of the type "emulator fired but not data" in BXs different from the central one.

From a quick look at the L1-uGT emulator, I think this might be related to the L1-uGT emulator itself.
 - In #44222, the CICADA score was implemented as a data member of `GlobalBoard` (see `m_cicadaScore`), setting its value to the CICADA score for BX=0.
 - While this works for BX=0, I think it leads to computing the emulated CICADA decisions for BX!=0 using the CICADA score for BX=0. This may explain why the emulator fires more often than data for BX!=0 in Roberto's tests.

This PR implements the use of CICADA scores from the relevant BXs when evaluating the decisions of CICADA seeds in the L1-uGT emulator.

#### PR validation:

None from my side. Dedicated tests were done by @rseidita (I let him comment on the outcome of his checks).

_Edit_ (May-22): see https://github.com/cms-sw/cmssw/pull/48142#issuecomment-2900223633.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

To be backported to `CMSSW_15_0_X` (2025 pp data-taking cycle) to reduce L1-uGT data-emulator mismatches in online DQM.

_Note_ : the L1-uGT emulator also runs in the HLT jobs, and at T0 (e.g. offline reco), so this PR indirectly touches all those workflows as well.
