### PR TITLE
[DRAFT] minimum changes to produce wf diffs seen in PR#47966

### DIFF
--- a/CondFormats/SiPixelTransient/src/SiPixelTemplate.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelTemplate.cc
@@ -1563,6 +1563,7 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
       }
       yrms_[i] = (1.f - yratio_) * enty0_->yrms[i] + yratio_ * enty1_->yrms[i];
 
+      assert(!goodEdgeAlgo && "goodEdgeAlgo triggered unexpectedly");
       if (goodEdgeAlgo) {  // restore y Gaussian Parameter interpolation
         ygx0_[i] = (1.f - yratio_) * enty0_->ygx0[i] + yratio_ * enty1_->ygx0[i];
         if (flip_y_) {

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco.cc
@@ -158,20 +158,22 @@ int SiPixelTemplateReco::PixelTempReco1D(int id,
                                          bool goodEdgeAlgo)
 
 {
-
-
   // Local variables
   int i = 0, j = 0, k = 0, minbin = -1, binl = 0, binh = 0, binq = 0, midpix = 0, fypix = -1, lypix = 0, logypx = 0;
   int fxpix = -1, lxpix = 0, logxpx = 0, shifty = 0, shiftx = 0, nyzero[TYSIZE] = {};
-  int nclusx= 0, nclusy= 0;
+  int nclusx = 0, nclusy = 0;
   int deltaj = 0, jmin = 0, jmax = 0, fxbin = 3, lxbin = 37, fybin = 3, lybin = 37, djy = 1, djx = 1;
   //int fypix2D, lypix2D, fxpix2D, lxpix2D;
-  float sythr = 0.f, sxthr = 0.f, rnorm = 0.f, delta = 0.f, sigma = 0.f, sigavg = 0.f, pseudopix = 0.f, qscale = 0.f, q50 = 0.f;
-  float ss2 = 0.f, ssa = 0.f, sa2 = 0.f, ssba = 0.f, saba = 0.f, sba2 = 0.f, rat = 0.f, fq = 0.f, qtotal = 0.f, qpixel = 1.f, fbin[3] = {0.f, 0.f, 0.f};
-  float originx = 0.f, originy = 0.f, qfy = 0.f, qly = 0.f, qfx = 0.f, qlx = 0.f, bias = 0.f, maxpix = 0.f, minmax = 0.f;
+  float sythr = 0.f, sxthr = 0.f, rnorm = 0.f, delta = 0.f, sigma = 0.f, sigavg = 0.f, pseudopix = 0.f, qscale = 0.f,
+        q50 = 0.f;
+  float ss2 = 0.f, ssa = 0.f, sa2 = 0.f, ssba = 0.f, saba = 0.f, sba2 = 0.f, rat = 0.f, fq = 0.f, qtotal = 0.f,
+        qpixel = 1.f, fbin[3] = {0.f, 0.f, 0.f};
+  float originx = 0.f, originy = 0.f, qfy = 0.f, qly = 0.f, qfx = 0.f, qlx = 0.f, bias = 0.f, maxpix = 0.f,
+        minmax = 0.f;
   double chi2x = 0., meanx = 0., chi2y = 0., meany = 0., chi2ymin = 1.e15, chi2xmin = 1.e15, chi21max = 1.e15;
   double hchi2 = 0., hndof = 0., prvav = 0., mpv = 0., sigmaQ = 0., kappa = 0., xvav = 0., beta2 = 1.;
-  float ytemp[41][BYSIZE] = {}, xtemp[41][BXSIZE] = {}, ysum[BYSIZE] = {}, xsum[BXSIZE] = {}, ysort[BYSIZE] = {}, xsort[BXSIZE] = {};
+  float ytemp[41][BYSIZE] = {}, xtemp[41][BXSIZE] = {}, ysum[BYSIZE] = {}, xsum[BXSIZE] = {}, ysort[BYSIZE] = {},
+        xsort[BXSIZE] = {};
   float chi2ybin[41] = {}, chi2xbin[41] = {}, ysig2[BYSIZE] = {}, xsig2[BXSIZE] = {};
   float yw2[BYSIZE] = {}, xw2[BXSIZE] = {}, ysw[BYSIZE] = {}, xsw[BXSIZE] = {};
   bool yd[BYSIZE] = {}, xd[BXSIZE] = {}, anyyd = false, anyxd = false, calc_probQ = false, use_VVIObj = false;

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco.cc
@@ -158,22 +158,24 @@ int SiPixelTemplateReco::PixelTempReco1D(int id,
                                          bool goodEdgeAlgo)
 
 {
+
+
   // Local variables
-  int i, j, k, minbin, binl, binh, binq, midpix, fypix, lypix, logypx;
-  int fxpix, lxpix, logxpx, shifty, shiftx, nyzero[TYSIZE];
-  int nclusx, nclusy;
-  int deltaj, jmin, jmax, fxbin, lxbin, fybin, lybin, djy, djx;
+  int i = 0, j = 0, k = 0, minbin = -1, binl = 0, binh = 0, binq = 0, midpix = 0, fypix = -1, lypix = 0, logypx = 0;
+  int fxpix = -1, lxpix = 0, logxpx = 0, shifty = 0, shiftx = 0, nyzero[TYSIZE] = {};
+  int nclusx= 0, nclusy= 0;
+  int deltaj = 0, jmin = 0, jmax = 0, fxbin = 3, lxbin = 37, fybin = 3, lybin = 37, djy = 1, djx = 1;
   //int fypix2D, lypix2D, fxpix2D, lxpix2D;
-  float sythr, sxthr, rnorm, delta, sigma, sigavg, pseudopix, qscale, q50;
-  float ss2, ssa, sa2, ssba, saba, sba2, rat, fq, qtotal, qpixel, fbin[3];
-  float originx, originy, qfy, qly, qfx, qlx, bias, maxpix, minmax;
-  double chi2x, meanx, chi2y, meany, chi2ymin, chi2xmin, chi21max;
-  double hchi2, hndof, prvav, mpv, sigmaQ, kappa, xvav, beta2;
-  float ytemp[41][BYSIZE], xtemp[41][BXSIZE], ysum[BYSIZE], xsum[BXSIZE], ysort[BYSIZE], xsort[BXSIZE];
-  float chi2ybin[41], chi2xbin[41], ysig2[BYSIZE], xsig2[BXSIZE];
-  float yw2[BYSIZE], xw2[BXSIZE], ysw[BYSIZE], xsw[BXSIZE];
-  bool yd[BYSIZE], xd[BXSIZE], anyyd, anyxd, calc_probQ, use_VVIObj;
-  float ysize, xsize;
+  float sythr = 0.f, sxthr = 0.f, rnorm = 0.f, delta = 0.f, sigma = 0.f, sigavg = 0.f, pseudopix = 0.f, qscale = 0.f, q50 = 0.f;
+  float ss2 = 0.f, ssa = 0.f, sa2 = 0.f, ssba = 0.f, saba = 0.f, sba2 = 0.f, rat = 0.f, fq = 0.f, qtotal = 0.f, qpixel = 1.f, fbin[3] = {0.f, 0.f, 0.f};
+  float originx = 0.f, originy = 0.f, qfy = 0.f, qly = 0.f, qfx = 0.f, qlx = 0.f, bias = 0.f, maxpix = 0.f, minmax = 0.f;
+  double chi2x = 0., meanx = 0., chi2y = 0., meany = 0., chi2ymin = 1.e15, chi2xmin = 1.e15, chi21max = 1.e15;
+  double hchi2 = 0., hndof = 0., prvav = 0., mpv = 0., sigmaQ = 0., kappa = 0., xvav = 0., beta2 = 1.;
+  float ytemp[41][BYSIZE] = {}, xtemp[41][BXSIZE] = {}, ysum[BYSIZE] = {}, xsum[BXSIZE] = {}, ysort[BYSIZE] = {}, xsort[BXSIZE] = {};
+  float chi2ybin[41] = {}, chi2xbin[41] = {}, ysig2[BYSIZE] = {}, xsig2[BXSIZE] = {};
+  float yw2[BYSIZE] = {}, xw2[BXSIZE] = {}, ysw[BYSIZE] = {}, xsw[BXSIZE] = {};
+  bool yd[BYSIZE] = {}, xd[BXSIZE] = {}, anyyd = false, anyxd = false, calc_probQ = false, use_VVIObj = false;
+  float ysize = 0.f, xsize = 0.f;
   const float probmin = {1.110223e-16};
   const float probQmin = {1.e-5};
 


### PR DESCRIPTION
[PR#47966](https://github.com/cms-sw/cmssw/pull/47966) shows unexpected widely distributed small differences in test workflows. The minimal changes in this draft produce the same number of differences on a single workflow, 140.045, as the PR. This draft is created to allow the cms bot to run tests to check if the same happens in other workflows.