### PR TITLE
[UBSAN] Avoid large constructor for HDShower class

### DIFF
--- a/FastSimulation/ShowerDevelopment/interface/HDShower.h
+++ b/FastSimulation/ShowerDevelopment/interface/HDShower.h
@@ -44,6 +44,15 @@ public:
   bool compute();
 
 private:
+  //Initialization function to avoid large constructor which
+  //takes hours to compile for UBSAN IBs
+  void init(const RandomEngineAndDistribution* engine,
+            HDShowerParametrization* myParam,
+            EcalHitMaker* myGrid,
+            HcalHitMaker* myHcalHitMaker,
+            int onECAL,
+            double epart,
+            double pmip);
   // The longitudinal development ersatzt.
   double gam(double x, double a) const { return pow(x, a - 1.) * exp(-x); }
 

--- a/FastSimulation/ShowerDevelopment/src/HDShower.cc
+++ b/FastSimulation/ShowerDevelopment/src/HDShower.cc
@@ -32,6 +32,16 @@ HDShower::HDShower(const RandomEngineAndDistribution* engine,
       e(epart),
       //    pmip(pmip),
       random(engine) {
+  init(engine, myParam, myGrid, myHcalHitMaker, onECAL, epart, pmip);
+}
+
+void HDShower::init(const RandomEngineAndDistribution* engine,
+                    HDShowerParametrization* myParam,
+                    EcalHitMaker* myGrid,
+                    HcalHitMaker* myHcalHitMaker,
+                    int onECAL,
+                    double epart,
+                    double pmip) {
   // To get an access to constants read in FASTCalorimeter
   //  FASTCalorimeter * myCalorimeter= FASTCalorimeter::instance();
 


### PR DESCRIPTION
Compiling  class takes hours for UBSAN, this is known issue with large constructor and build with sanitizer flags. This Pr proposes to move the constructor code in to a separate private member function to avoid large compilation times.