### PR TITLE
Update FastSim 2024 Era, add 2025 workflow

### DIFF
--- a/Configuration/Eras/python/Era_Run3_2024_FastSim_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2024_FastSim_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run3_2024_cff import Run3_2024
+from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
+
+Run3_2024_FastSim = Run3_2024.copyAndExclude([run3_GEM])

--- a/Configuration/Eras/python/Era_Run3_2025_FastSim_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2025_FastSim_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run3_2025_cff import Run3_2025
+from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
+
+Run3_2025_FastSim = Run3_2025.copyAndExclude([run3_GEM])

--- a/Configuration/PyReleaseValidation/python/relval_2017.py
+++ b/Configuration/PyReleaseValidation/python/relval_2017.py
@@ -51,10 +51,11 @@ from Configuration.PyReleaseValidation.relval_upgrade import workflows as _upgra
 #   2024 (TTbar, TTbar PU, TTbar PU premix, TTbar PU prod-like)
 #        (TTbar trackingMkFit)
 #        (Alpaka Pixel Only, Alpaka ECal only)
-#        (TTbar FastSim, TTbar FastSim PU, MinBiasFS for mixing))
+#        (TTbar FastSim, TTbar FastSim PU, MinBiasFS for mixing)
 #        (ZEE)
 #        (Nu Gun)
 #   2025 (TTbar, TTbar PU)
+#        (TTbar FastSim, TTbar FastSim PU, MinBiasFS for mixing)
 
 numWFIB = [10001.0,10002.0,10003.0,10004.0,10005.0,10006.0,10007.0,10008.0,10009.0,10059.0,10071.0,
            10042.0,10024.0,10025.0,10026.0,10023.0,10224.0,10225.0,10424.0,
@@ -104,7 +105,9 @@ numWFIB = [10001.0,10002.0,10003.0,10004.0,10005.0,10006.0,10007.0,10008.0,10009
            12846.0,
            12861.0,
            # 2025
-           16834.0, 17034.0,]
+           16834.0, 17034.0,
+           18034.0, 18234.0, 18040.303,
+]
 
 for numWF in numWFIB:
     if not numWF in _upgrade_workflows:

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -4606,6 +4606,7 @@ defaultDataSets['2025']='CMSSW_15_0_0_pre1-142X_mcRun3_2025_realistic_v1_STD_Reg
 defaultDataSets['2024HLTOnDigi'] = defaultDataSets["2024SimOnGen"] = defaultDataSets['2024']
 defaultDataSets["2025HLTOnDigi"] = defaultDataSets["2025SimOnGen"] = defaultDataSets['2025']
 defaultDataSets['2024FS']='CMSSW_13_0_11-130X_mcRun3_2023_realistic_withEarly2023BS_v1_FastSim-v' #To replace with new dataset
+defaultDataSets['2025FS']='CMSSW_13_0_11-130X_mcRun3_2023_realistic_withEarly2023BS_v1_FastSim-v' #To replace with new dataset
 defaultDataSets['Run4D49']='CMSSW_12_0_0_pre4-113X_mcRun4_realistic_v7_2026D49noPU-v'
 defaultDataSets['Run4D76']='CMSSW_12_0_0_pre4-113X_mcRun4_realistic_v7_2026D76noPU-v'
 defaultDataSets['Run4D77']='CMSSW_12_1_0_pre2-113X_mcRun4_realistic_v7_2026D77noPU-v'

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -50,6 +50,8 @@ upgradeKeys[2017] = [
     '2025HLTOnDigiPU',
     '2025SimOnGen',
     '2025GenOnly',
+    '2025FS',
+    '2025FSPU',
 ]
 
 upgradeKeys['Run4'] = [
@@ -3270,7 +3272,14 @@ upgradeProperties[2017] = {
         'BeamSpot': 'DBrealistic',
         'ScenToRun' : ['Gen','Sim','Digi','RecoNano','HARVESTNano','ALCA'],
     },
-    
+    '2025FS' : {
+        'Geom' : 'DB:Extended',
+        'GT' : 'auto:phase1_2025_realistic',
+        'HLTmenu': '@relval2025',
+        'Era' : 'Run3_2025_FastSim',
+        'BeamSpot': 'DBrealistic',
+        'ScenToRun' : ['Gen','FastSimRun3','HARVESTFastRun3'],
+    },
 }
 
 # standard PU sequences

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -3234,7 +3234,7 @@ upgradeProperties[2017] = {
         'Geom' : 'DB:Extended',
         'GT' : 'auto:phase1_2024_realistic',
         'HLTmenu': '@relval2024',
-        'Era' : 'Run3_FastSim',
+        'Era' : 'Run3_2024_FastSim',
         'BeamSpot': 'DBrealistic',
         'ScenToRun' : ['Gen','FastSimRun3','HARVESTFastRun3'],
     },

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -58,6 +58,7 @@ class Eras (object):
                  'Run3_2025_UPC',
                  'Run3_2025_OXY',
                  'Run3_2025_UPC_OXY',
+                 'Run3_2025_FastSim',
                  'Phase2',
                  'Phase2_noMkFit',
                  'Phase2C9',

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -54,6 +54,7 @@ class Eras (object):
                  'Run3_2023_UPC',
                  'Run3_2024_ppRef',
                  'Run3_2024_UPC',
+                 'Run3_2024_FastSim',
                  'Run3_2025_UPC',
                  'Run3_2025_OXY',
                  'Run3_2025_UPC_OXY',


### PR DESCRIPTION
#### PR description:

Follow up to fix an oversight in #46068 for 2024 FastSim and add the corresponding 2025 workflow.

#### PR validation:

Tested the new workflows, which run successfully.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport.

First commit (2024) will be backported to 15_0 and 14_2 to ensure correct 2024 workflows in active releases. Second commit (2025) does not need to be backported as far as I know.