### PR TITLE
[HGCAL] Fix cell types in indexer

### DIFF
--- a/CondFormats/HGCalObjects/interface/HGCalMappingModuleIndexer.h
+++ b/CondFormats/HGCalObjects/interface/HGCalMappingModuleIndexer.h
@@ -13,7 +13,6 @@
 #include "CondFormats/HGCalObjects/interface/HGCalDenseIndexerBase.h"
 #include "CondFormats/HGCalObjects/interface/HGCalMappingCellIndexer.h"
 #include "FWCore/Utilities/interface/Exception.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 /**
  * @short this structure holds the indices and types in the readout sequence
@@ -61,21 +60,10 @@ public:
   void finalize();
 
   /**
-   * @short decodes silicon or sipm type and cell type for the detector id 
-   * from the typecode string
+   * @short decode silicon or sipm type and cell type for the detector id 
+   * from the typecode string: "M[LH]-X[123]X-*" for Si, "T[LH]-L*S*[PN]" for SiPm
    */
-  static std::pair<bool, int> convertTypeCode(std::string_view typecode) {
-    if (typecode.size() < 5)
-      throw cms::Exception("InvalidHGCALTypeCode") << typecode << " is invalid for decoding readout cell type";
-    bool isSiPM = {typecode.find("TM") != std::string::npos ? true : false};
-    int celltype;
-    if (isSiPM) {
-      celltype = 0;  // assign SiPM type coarse or molded with next version of modulelocator
-    } else {
-      celltype = {typecode[4] == '1' ? 0 : typecode[4] == '2' ? 1 : 2};
-    }
-    return std::pair<bool, bool>(isSiPM, celltype);
-  }
+  static std::pair<bool, int8_t> getCellType(std::string_view typecode);
 
   /**
    * @short returns the index for the n-th module in the readout sequence of a FED
@@ -136,7 +124,7 @@ public:
   uint32_t getMaxModuleSize() const {
     return maxModulesIdx_;
   }  ///< total number of ECON-Ds (useful for setting ECON-D SoA size)
-  uint32_t getNModules(uint32_t fedid) const {
+  uint32_t getNumModules(uint32_t fedid) const {
     return fedReadoutSequences_[fedid].readoutTypes_.size();
   }  ///< number of ECON-Ds for given FED id
   uint32_t getMaxERxSize() const {
@@ -162,7 +150,7 @@ public:
   }  ///< total number of channels for a given ECON-D typecode
 
   /**
-     @short return type ECON-D Module
+   * @short return type ECON-D Module
    */
   int getTypeForModule(uint32_t fedid, uint32_t modid) const {
     return fedReadoutSequences_[fedid].readoutTypes_[modid];

--- a/CondFormats/HGCalObjects/interface/HGCalMappingParameterSoA.h
+++ b/CondFormats/HGCalObjects/interface/HGCalMappingParameterSoA.h
@@ -19,7 +19,7 @@ namespace hgcal {
                       SOA_COLUMN(int, i1),
                       SOA_COLUMN(int, i2),
                       SOA_COLUMN(uint8_t, irot),
-                      SOA_COLUMN(int, celltype),
+                      SOA_COLUMN(int8_t, celltype),
                       SOA_COLUMN(uint16_t, typeidx),
                       SOA_COLUMN(uint16_t, fedid),
                       SOA_COLUMN(uint16_t, slinkidx),

--- a/Geometry/HGCalMapping/plugins/alpaka/HGCalMappingModuleESProducer.cc
+++ b/Geometry/HGCalMapping/plugins/alpaka/HGCalMappingModuleESProducer.cc
@@ -64,7 +64,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           int typeidx = modIndexer.getTypeForModule(fedid, captureblockidx, econdidx);
           std::string typecode = pmap.getAttr("typecode", row);
 
-          auto celltypes = modIndexer.convertTypeCode(typecode);
+          auto celltypes = modIndexer.getCellType(typecode);
           bool isSiPM = celltypes.first;
           int celltype = celltypes.second;
           int zside = pmap.getIntAttr("zside", row);

--- a/RecoLocalCalo/HGCalRecAlgos/src/HGCalESProducerTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/HGCalESProducerTools.cc
@@ -28,7 +28,6 @@ namespace hgcal {
        << data.begin().key() << "'...";
     ex.addContext("Calling hgcal::search_modkey()");
     throw ex;
-    return data.begin().key();  // no matching key found in whole JSON map
   }
 
   // @short search first match to a given FED index in a JSON (following insertion order)
@@ -74,6 +73,7 @@ namespace hgcal {
       ex << "Could not find matching key for '" << fedid << "' in '" << name << "'! Returning first key '" << matchedkey
          << "'...";
       ex.addContext("Calling hgcal::search_fedkey()");
+      throw ex;
     } else {
       edm::LogInfo("search_fedkey") << "search_fedkey: Matched module='" << fedid << "' to fedkey='" << matchedkey
                                     << "'";


### PR DESCRIPTION
Use more meaningfull enums from `HGCSiliconDetId` and `HGCScintillatorDetId` for cell types (instead of magic numbers).

(Cell type was not yet used by the HGCal Raw-Data DPG, but we'll need it soon to correctly map calibrations of RecHit's energy.)