### PR TITLE
[15.0.X] Improve `BeamSpotCompatibilityChecker` and its usage in `Alignment/OfflineValidation`

### DIFF
--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/DiMuonV_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/DiMuonV_cfg.py
@@ -188,8 +188,8 @@ process.offlinePrimaryVerticesFromRefittedTrks.TrackLabel = cms.InputTag("refitt
 ####################################################################
 from RecoVertex.BeamSpotProducer.beamSpotCompatibilityChecker_cfi import beamSpotCompatibilityChecker
 process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
-    bsFromEvent = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
-    bsFromDB = "offlineBeamSpot",           # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
+    bsFromFile = config["validation"].get("bsFromFile","offlineBeamSpot::RECO"),  # source of the event beamspot (in the ALCARECO files)
+    bsFromDB = "offlineBeamSpot::@currentProcess", # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
     dbFromEvent = True,
     warningThr = config["validation"].get("bsIncompatibleWarnThresh", 3), # significance threshold to emit a warning message
     errorThr = config["validation"].get("bsIncompatibleErrThresh", 5),    # significance threshold to abort the job

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/DiMuonV_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/DiMuonV_cfg.py
@@ -190,6 +190,7 @@ from RecoVertex.BeamSpotProducer.beamSpotCompatibilityChecker_cfi import beamSpo
 process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
     bsFromEvent = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
     bsFromDB = "offlineBeamSpot",           # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
+    dbFromEvent = True,
     warningThr = config["validation"].get("bsIncompatibleWarnThresh", 3), # significance threshold to emit a warning message
     errorThr = config["validation"].get("bsIncompatibleErrThresh", 5),    # significance threshold to abort the job
 )

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/JetHT_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/JetHT_cfg.py
@@ -296,6 +296,7 @@ from RecoVertex.BeamSpotProducer.beamSpotCompatibilityChecker_cfi import beamSpo
 process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
     bsFromEvent = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
     bsFromDB = "offlineBeamSpot",           # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
+    dbFromEvent = True,
     warningThr = configuration["validation"].get("bsIncompatibleWarnThresh", 3), # significance threshold to emit a warning message
     errorThr = configuration["validation"].get("bsIncompatibleErrThresh", 5),    # significance threshold to abort the job
 )

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/JetHT_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/JetHT_cfg.py
@@ -294,8 +294,8 @@ process.TFileService = cms.Service("TFileService",
 ###################################################################
 from RecoVertex.BeamSpotProducer.beamSpotCompatibilityChecker_cfi import beamSpotCompatibilityChecker
 process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
-    bsFromEvent = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
-    bsFromDB = "offlineBeamSpot",           # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
+    bsFromFile = configuration["validation"].get("bsFromFile","offlineBeamSpot::RECO"),  # source of the event beamspot (in the ALCARECO files)
+    bsFromDB = "offlineBeamSpot::@currentProcess", # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
     dbFromEvent = True,
     warningThr = configuration["validation"].get("bsIncompatibleWarnThresh", 3), # significance threshold to emit a warning message
     errorThr = configuration["validation"].get("bsIncompatibleErrThresh", 5),    # significance threshold to abort the job

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/PV_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/PV_cfg.py
@@ -168,6 +168,7 @@ from RecoVertex.BeamSpotProducer.beamSpotCompatibilityChecker_cfi import beamSpo
 process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
     bsFromEvent = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
     bsFromDB = "offlineBeamSpot",           # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
+    dbFromEvent = True,
     warningThr = config["validation"].get("bsIncompatibleWarnThresh", 3), # significance threshold to emit a warning message
     errorThr = config["validation"].get("bsIncompatibleErrThresh", 5),    # significance threshold to abort the job
 )
@@ -182,9 +183,9 @@ else:
      process.filterOutLowPt.runControlNumber = [runboundary]
 
 if isMC:
-     process.goodvertexSkim = cms.Sequence(process.BeamSpotChecker + process.noscraping + process.filterOutLowPt)
+     process.goodvertexSkim = cms.Sequence(process.noscraping + process.filterOutLowPt)
 else:
-     process.goodvertexSkim = cms.Sequence(process.BeamSpotChecker + process.primaryVertexFilter + process.noscraping + process.filterOutLowPt)
+     process.goodvertexSkim = cms.Sequence(process.primaryVertexFilter + process.noscraping + process.filterOutLowPt)
 
 
 ####################################################################
@@ -254,6 +255,9 @@ process.TFileService = cms.Service("TFileService",
 ####################################################################
 # Path
 ####################################################################
-process.p = cms.Path(process.goodvertexSkim*process.seqTrackselRefit*process.PVValidation)
+process.p = cms.Path(process.goodvertexSkim*
+                     process.seqTrackselRefit*
+                     process.BeamSpotChecker*
+                     process.PVValidation)
 
 print("Done")

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/PV_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/PV_cfg.py
@@ -166,8 +166,8 @@ process.noscraping = cms.EDFilter("FilterOutScraping",
 ###################################################################
 from RecoVertex.BeamSpotProducer.beamSpotCompatibilityChecker_cfi import beamSpotCompatibilityChecker
 process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
-    bsFromEvent = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
-    bsFromDB = "offlineBeamSpot",           # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
+    bsFromFile = config["validation"].get("bsFromFile","offlineBeamSpot::RECO"),  # source of the event beamspot (in the ALCARECO files)
+    bsFromDB = "offlineBeamSpot::@currentProcess", # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
     dbFromEvent = True,
     warningThr = config["validation"].get("bsIncompatibleWarnThresh", 3), # significance threshold to emit a warning message
     errorThr = config["validation"].get("bsIncompatibleErrThresh", 5),    # significance threshold to abort the job

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/SplitV_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/SplitV_cfg.py
@@ -202,8 +202,8 @@ print("Saving the output at %s" % process.TFileService.fileName.value())
 ###################################################################
 from RecoVertex.BeamSpotProducer.beamSpotCompatibilityChecker_cfi import beamSpotCompatibilityChecker
 process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
-    bsFromEvent = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
-    bsFromDB = "offlineBeamSpot",           # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
+    bsFromFile = config["validation"].get("bsFromFile","offlineBeamSpot::RECO"),  # source of the event beamspot (in the ALCARECO files)
+    bsFromDB = "offlineBeamSpot::@currentProcess", # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
     dbFromEvent = True,
     warningThr = config["validation"].get("bsIncompatibleWarnThresh", 3), # significance threshold to emit a warning message
     errorThr = config["validation"].get("bsIncompatibleErrThresh", 5),    # significance threshold to abort the job

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/SplitV_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/SplitV_cfg.py
@@ -204,6 +204,7 @@ from RecoVertex.BeamSpotProducer.beamSpotCompatibilityChecker_cfi import beamSpo
 process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
     bsFromEvent = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
     bsFromDB = "offlineBeamSpot",           # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
+    dbFromEvent = True,
     warningThr = config["validation"].get("bsIncompatibleWarnThresh", 3), # significance threshold to emit a warning message
     errorThr = config["validation"].get("bsIncompatibleErrThresh", 5),    # significance threshold to abort the job
 )

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/Zmumu_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/Zmumu_cfg.py
@@ -199,8 +199,8 @@ if valiMode == "StandAlone":
 ###################################################################
 from RecoVertex.BeamSpotProducer.beamSpotCompatibilityChecker_cfi import beamSpotCompatibilityChecker
 process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
-    bsFromEvent = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
-    bsFromDB = "offlineBeamSpot",           # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
+    bsFromFile = config["validation"].get("bsFromFile","offlineBeamSpot::RECO"),  # source of the event beamspot (in the ALCARECO files)
+    bsFromDB = "offlineBeamSpot::@currentProcess", # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
     dbFromEvent = True,
     warningThr = config["validation"].get("bsIncompatibleWarnThresh", 3), # significance threshold to emit a warning message
     errorThr = config["validation"].get("bsIncompatibleErrThresh", 5),    # significance threshold to abort the job

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/Zmumu_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/Zmumu_cfg.py
@@ -201,6 +201,7 @@ from RecoVertex.BeamSpotProducer.beamSpotCompatibilityChecker_cfi import beamSpo
 process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
     bsFromEvent = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
     bsFromDB = "offlineBeamSpot",           # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
+    dbFromEvent = True,
     warningThr = config["validation"].get("bsIncompatibleWarnThresh", 3), # significance threshold to emit a warning message
     errorThr = config["validation"].get("bsIncompatibleErrThresh", 5),    # significance threshold to abort the job
 )

--- a/Alignment/OfflineValidation/test/PVValidation_TEMPL_cfg.py
+++ b/Alignment/OfflineValidation/test/PVValidation_TEMPL_cfg.py
@@ -171,8 +171,8 @@ process.filterOutLowPt.runControlNumber = [runboundary]
 ###################################################################
 from RecoVertex.BeamSpotProducer.beamSpotCompatibilityChecker_cfi import beamSpotCompatibilityChecker
 process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
-    bsFromEvent = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
-    bsFromDB = "offlineBeamSpot",           # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
+    bsFromFile = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
+    bsFromDB = "offlineBeamSpot::@currentProcess", # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
     dbFromEvent = True,
     warningThr = 3, # significance threshold to emit a warning message
     errorThr = 5,    # significance threshold to abort the job

--- a/Alignment/OfflineValidation/test/PVValidation_TEMPL_cfg.py
+++ b/Alignment/OfflineValidation/test/PVValidation_TEMPL_cfg.py
@@ -173,14 +173,15 @@ from RecoVertex.BeamSpotProducer.beamSpotCompatibilityChecker_cfi import beamSpo
 process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
     bsFromEvent = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
     bsFromDB = "offlineBeamSpot",           # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
+    dbFromEvent = True,
     warningThr = 3, # significance threshold to emit a warning message
     errorThr = 5,    # significance threshold to abort the job
 )
 
 if isMC:
-     process.goodvertexSkim = cms.Sequence(process.BeamSpotChecker + process.noscraping + process.filterOutLowPt)
+     process.goodvertexSkim = cms.Sequence(process.noscraping + process.filterOutLowPt)
 else:
-     process.goodvertexSkim = cms.Sequence(process.BeamSpotChecker + process.primaryVertexFilter + process.noscraping + process.filterOutLowPt)
+     process.goodvertexSkim = cms.Sequence(process.primaryVertexFilter + process.noscraping + process.filterOutLowPt)
 
 ####################################################################
 # Load and Configure Measurement Tracker Event
@@ -276,4 +277,5 @@ process.seqTrackselRefit = cms.Sequence(process.offlineBeamSpot*
 ####################################################################
 process.p = cms.Path(process.goodvertexSkim*
                      process.seqTrackselRefit*
+                     process.BeamSpotChecker*
                      process.PVValidation)

--- a/Alignment/OfflineValidation/test/PVValidation_T_cfg.py
+++ b/Alignment/OfflineValidation/test/PVValidation_T_cfg.py
@@ -167,8 +167,8 @@ process.filterOutLowPt.runControlNumber = [runboundary]
 ####################################################################
 from RecoVertex.BeamSpotProducer.beamSpotCompatibilityChecker_cfi import beamSpotCompatibilityChecker
 process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
-    bsFromEvent = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
-    bsFromDB = "offlineBeamSpot",           # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
+    bsFromFile = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
+    bsFromDB = "offlineBeamSpot::@currentProcess", # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
     dbFromEvent = True,
     warningThr = 3, # significance threshold to emit a warning message
     errorThr = 5,    # significance threshold to abort the job

--- a/Alignment/OfflineValidation/test/PVValidation_T_cfg.py
+++ b/Alignment/OfflineValidation/test/PVValidation_T_cfg.py
@@ -169,14 +169,15 @@ from RecoVertex.BeamSpotProducer.beamSpotCompatibilityChecker_cfi import beamSpo
 process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
     bsFromEvent = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
     bsFromDB = "offlineBeamSpot",           # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
+    dbFromEvent = True,
     warningThr = 3, # significance threshold to emit a warning message
     errorThr = 5,    # significance threshold to abort the job
 )
 
 if isMC:
-     process.goodvertexSkim = cms.Sequence(process.BeamSpotChecker + process.noscraping+process.filterOutLowPt)
+     process.goodvertexSkim = cms.Sequence(process.noscraping+process.filterOutLowPt)
 else:
-     process.goodvertexSkim = cms.Sequence(process.BeamSpotChecker + process.primaryVertexFilter + process.noscraping + process.filterOutLowPt)
+     process.goodvertexSkim = cms.Sequence(process.primaryVertexFilter + process.noscraping + process.filterOutLowPt)
 
 ####################################################################
 # Load and Configure Measurement Tracker Event
@@ -337,6 +338,7 @@ process.p = cms.Path(process.goodvertexSkim*
                      # in case the common refitting sequence is removed
                      #process.offlineBeamSpot*
                      process.seqTrackselRefit*
+                     process.BeamSpotChecker*
                      # in case the navigation shool is removed
                      #process.MeasurementTrackerEvent*
                      # in case the common refitting sequence is removed

--- a/Alignment/OfflineValidation/test/PrimaryVertexResolution_cfg.py
+++ b/Alignment/OfflineValidation/test/PrimaryVertexResolution_cfg.py
@@ -203,6 +203,7 @@ from RecoVertex.BeamSpotProducer.beamSpotCompatibilityChecker_cfi import beamSpo
 process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
     bsFromEvent = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
     bsFromDB = "offlineBeamSpot",           # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
+    dbFromEvent = True,
     warningThr = 3, # significance threshold to emit a warning message
     errorThr = 5    # significance threshold to abort the job
 )

--- a/Alignment/OfflineValidation/test/PrimaryVertexResolution_cfg.py
+++ b/Alignment/OfflineValidation/test/PrimaryVertexResolution_cfg.py
@@ -201,8 +201,8 @@ process.TFileService = cms.Service("TFileService",
 ###################################################################
 from RecoVertex.BeamSpotProducer.beamSpotCompatibilityChecker_cfi import beamSpotCompatibilityChecker
 process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
-    bsFromEvent = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
-    bsFromDB = "offlineBeamSpot",           # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
+    bsFromFile = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
+    bsFromDB = "offlineBeamSpot::@currentProcess", # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
     dbFromEvent = True,
     warningThr = 3, # significance threshold to emit a warning message
     errorThr = 5    # significance threshold to abort the job

--- a/Alignment/OfflineValidation/test/PrimaryVertexResolution_templ_cfg.py
+++ b/Alignment/OfflineValidation/test/PrimaryVertexResolution_templ_cfg.py
@@ -189,8 +189,8 @@ process.TFileService = cms.Service("TFileService",
 ###################################################################
 from RecoVertex.BeamSpotProducer.beamSpotCompatibilityChecker_cfi import beamSpotCompatibilityChecker
 process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
-    bsFromEvent = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
-    bsFromDB = "offlineBeamSpot",           # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
+    bsFromFile = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
+    bsFromDB = "offlineBeamSpot::@currentProcess", # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
     dbFromEvent = True,
     warningThr = 3, # significance threshold to emit a warning message
     errorThr = 5    # significance threshold to abort the job

--- a/Alignment/OfflineValidation/test/PrimaryVertexResolution_templ_cfg.py
+++ b/Alignment/OfflineValidation/test/PrimaryVertexResolution_templ_cfg.py
@@ -191,6 +191,7 @@ from RecoVertex.BeamSpotProducer.beamSpotCompatibilityChecker_cfi import beamSpo
 process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
     bsFromEvent = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
     bsFromDB = "offlineBeamSpot",           # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
+    dbFromEvent = True,
     warningThr = 3, # significance threshold to emit a warning message
     errorThr = 5    # significance threshold to abort the job
 )
@@ -198,9 +199,9 @@ process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
 ###################################################################
 # Path
 ###################################################################
-process.p = cms.Path(process.BeamSpotChecker                        +
-                     process.seqTrackselRefit                       +
+process.p = cms.Path(process.seqTrackselRefit                       +
                      #process.offlineBeamSpot                       +
                      #process.TrackRefitter                         +
+                     process.BeamSpotChecker                        +
                      process.offlinePrimaryVerticesFromRefittedTrks +
                      process.PrimaryVertexResolution)

--- a/Alignment/OfflineValidation/test/testPrimaryVertexRelatedValidations_cfg.py
+++ b/Alignment/OfflineValidation/test/testPrimaryVertexRelatedValidations_cfg.py
@@ -222,14 +222,15 @@ from RecoVertex.BeamSpotProducer.beamSpotCompatibilityChecker_cfi import beamSpo
 process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
      bsFromEvent = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
      bsFromDB = "offlineBeamSpot",           # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
+     dbFromEvent = True,
      warningThr = 5, # significance threshold to emit a warning message
      errorThr = 10,  # significance threshold to abort the job
 )
 
 if _isMC:
-     process.goodvertexSkim = cms.Sequence(process.BeamSpotChecker + process.noscraping)
+     process.goodvertexSkim = cms.Sequence(process.noscraping)
 else:
-     process.goodvertexSkim = cms.Sequence(process.BeamSpotChecker + process.primaryVertexFilter + process.noscraping + process.noslowpt)
+     process.goodvertexSkim = cms.Sequence(process.primaryVertexFilter + process.noscraping + process.noslowpt)
 
 
 if(_theRefitter == RefitType.COMMON):
@@ -363,6 +364,7 @@ process.PVValidation = cms.EDAnalyzer("PrimaryVertexValidation",
 ####################################################################
 process.p = cms.Path(process.goodvertexSkim*
                      process.seqTrackselRefit*
+                     process.BeamSpotChecker*
                      process.PVValidation)
 
 ## PV refit part
@@ -436,6 +438,7 @@ process.PrimaryVertexResolution = cms.EDAnalyzer('SplitVertexResolution',
 
 process.p2 = cms.Path(process.HLTFilter                               +
                       process.seqTrackselRefit                        +
+                      process.BeamSpotChecker                         +
                       process.offlinePrimaryVerticesFromRefittedTrks  +
                       process.PrimaryVertexResolution                 +
                       process.trackanalysis                           +

--- a/Alignment/OfflineValidation/test/testPrimaryVertexRelatedValidations_cfg.py
+++ b/Alignment/OfflineValidation/test/testPrimaryVertexRelatedValidations_cfg.py
@@ -220,8 +220,8 @@ process.noslowpt = cms.EDFilter("FilterOutLowPt",
 ####################################################################
 from RecoVertex.BeamSpotProducer.beamSpotCompatibilityChecker_cfi import beamSpotCompatibilityChecker
 process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
-     bsFromEvent = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
-     bsFromDB = "offlineBeamSpot",           # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
+     bsFromFile = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
+     bsFromDB = "offlineBeamSpot::@currentProcess", # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
      dbFromEvent = True,
      warningThr = 5, # significance threshold to emit a warning message
      errorThr = 10,  # significance threshold to abort the job

--- a/Alignment/OfflineValidation/test/test_all_Phase2_cfg.py
+++ b/Alignment/OfflineValidation/test/test_all_Phase2_cfg.py
@@ -185,11 +185,11 @@ process.noslowpt = cms.EDFilter("FilterOutLowPt",
 ####################################################################
 from RecoVertex.BeamSpotProducer.beamSpotCompatibilityChecker_cfi import beamSpotCompatibilityChecker
 process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
-    bsFromEvent = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
-    bsFromDB = "offlineBeamSpot",           # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
+     bsFromFile = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
+     bsFromDB = "offlineBeamSpot::@currentProcess", # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
      dbFromEvent = True,
-    warningThr = 3, # significance threshold to emit a warning message
-    errorThr = 5,    # significance threshold to abort the job
+     warningThr = 3, # significance threshold to emit a warning message
+     errorThr = 5,    # significance threshold to abort the job
 )
 
 if isMC:

--- a/Alignment/OfflineValidation/test/test_all_Phase2_cfg.py
+++ b/Alignment/OfflineValidation/test/test_all_Phase2_cfg.py
@@ -187,14 +187,15 @@ from RecoVertex.BeamSpotProducer.beamSpotCompatibilityChecker_cfi import beamSpo
 process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
     bsFromEvent = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
     bsFromDB = "offlineBeamSpot",           # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
+     dbFromEvent = True,
     warningThr = 3, # significance threshold to emit a warning message
     errorThr = 5,    # significance threshold to abort the job
 )
 
 if isMC:
-     process.goodvertexSkim = cms.Sequence(process.BeamSpotChecker + process.noscraping)
+     process.goodvertexSkim = cms.Sequence(process.noscraping)
 else:
-     process.goodvertexSkim = cms.Sequence(process.BeamSpotChecker + process.primaryVertexFilter + process.noscraping + process.noslowpt)
+     process.goodvertexSkim = cms.Sequence(process.primaryVertexFilter + process.noscraping + process.noslowpt)
 
 
 if(theRefitter == RefitType.COMMON):
@@ -318,6 +319,7 @@ process.PVValidation = cms.EDAnalyzer("PrimaryVertexValidation",
 ####################################################################
 process.p = cms.Path(process.goodvertexSkim*
                      process.seqTrackselRefit*
+                     process.BeamSpotChecker*
                      process.PVValidation)
 
 ## PV refit part
@@ -370,6 +372,7 @@ process.PrimaryVertexResolution = cms.EDAnalyzer('SplitVertexResolution',
 
 process.p2 = cms.Path(process.HLTFilter                               +
                       process.seqTrackselRefit                        +
+                      process.BeamSpotChecker                         +
                       process.offlinePrimaryVerticesFromRefittedTrks  +
                       process.PrimaryVertexResolution                 +
                       process.myanalysis)

--- a/Alignment/OfflineValidation/test/test_all_cfg.py
+++ b/Alignment/OfflineValidation/test/test_all_cfg.py
@@ -185,14 +185,15 @@ from RecoVertex.BeamSpotProducer.beamSpotCompatibilityChecker_cfi import beamSpo
 process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
     bsFromEvent = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
     bsFromDB = "offlineBeamSpot",           # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
+    dbFromEvent = True,  
     warningThr = 3, # significance threshold to emit a warning message
     errorThr = 5,    # significance threshold to abort the job
 )
 
 if isMC:
-     process.goodvertexSkim = cms.Sequence(process.BeamSpotChecker + process.noscraping)
+     process.goodvertexSkim = cms.Sequence(process.noscraping)
 else:
-     process.goodvertexSkim = cms.Sequence(process.BeamSpotChecker + process.primaryVertexFilter + process.noscraping + process.noslowpt)
+     process.goodvertexSkim = cms.Sequence(process.primaryVertexFilter + process.noscraping + process.noslowpt)
 
 
 if(theRefitter == RefitType.COMMON):
@@ -311,6 +312,7 @@ process.PVValidation = cms.EDAnalyzer("PrimaryVertexValidation",
 ####################################################################
 process.p = cms.Path(process.goodvertexSkim*
                      process.seqTrackselRefit*
+                     process.BeamSpotChecker*
                      process.PVValidation)
 
 ## PV refit part
@@ -361,6 +363,7 @@ process.PrimaryVertexResolution = cms.EDAnalyzer('SplitVertexResolution',
 
 process.p2 = cms.Path(process.HLTFilter                               +
                       process.seqTrackselRefit                        +
+                      process.BeamSpotChecker                         +
                       process.offlinePrimaryVerticesFromRefittedTrks  +
                       process.PrimaryVertexResolution                 +
                       process.myanalysis

--- a/Alignment/OfflineValidation/test/test_all_cfg.py
+++ b/Alignment/OfflineValidation/test/test_all_cfg.py
@@ -183,8 +183,8 @@ process.noslowpt = cms.EDFilter("FilterOutLowPt",
 ####################################################################
 from RecoVertex.BeamSpotProducer.beamSpotCompatibilityChecker_cfi import beamSpotCompatibilityChecker
 process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
-    bsFromEvent = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
-    bsFromDB = "offlineBeamSpot",           # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
+    bsFromFile = "offlineBeamSpot::RECO",  # source of the event beamspot (in the ALCARECO files)
+    bsFromDB = "offlineBeamSpot::@currentProcess", # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
     dbFromEvent = True,  
     warningThr = 3, # significance threshold to emit a warning message
     errorThr = 5,    # significance threshold to abort the job

--- a/DQM/BeamMonitor/python/AlcaBeamMonitor_cff.py
+++ b/DQM/BeamMonitor/python/AlcaBeamMonitor_cff.py
@@ -5,8 +5,8 @@ from DQM.BeamMonitor.AlcaBeamMonitor_cfi import *
 from Configuration.ProcessModifiers.dqmPerLSsaving_cff import dqmPerLSsaving
 dqmPerLSsaving.toModify(AlcaBeamMonitor, perLSsaving=True)
 
-import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
-scalerBeamSpot = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()
+from RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi import onlineBeamSpotProducer as _onlineBeamSpotProducer
+scalerBeamSpot = _onlineBeamSpotProducer.clone()
 
 alcaBeamMonitor = cms.Sequence( scalerBeamSpot*AlcaBeamMonitor )
 

--- a/RecoVertex/BeamSpotProducer/plugins/BeamSpotCompatibilityChecker.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/BeamSpotCompatibilityChecker.cc
@@ -206,7 +206,7 @@ void BeamSpotCompatibilityChecker::analyze(edm::StreamID sid,
     if (sig > throwingThreshold_) {
       edm::LogError("BeamSpotCompatibilityChecker") << msg.c_str() << std::endl;
       throw cms::Exception("BeamSpotCompatibilityChecker")
-          << "[" << __PRETTY_FUNCTION__ << "] \n DB-Event BeamSpot " << labels.at(i) << " distance sigificance " << sig
+          << "[" << __PRETTY_FUNCTION__ << "] \n DB-Event BeamSpot " << labels.at(i) << " distance significance " << sig
           << ", exceeds the threshold of " << throwingThreshold_ << "!" << std::endl;
     } else if (sig > warningThreshold_) {
       edm::LogWarning("BeamSpotCompatibilityChecker") << msg.c_str() << std::endl;

--- a/RecoVertex/BeamSpotProducer/plugins/BeamSpotOnlineProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/BeamSpotOnlineProducer.cc
@@ -205,8 +205,8 @@ const BeamSpotOnlineObjects& BeamSpotOnlineProducer::getBeamSpotFromRecord(const
     if ((lumitime - bstime).count() > threshold) {
       edm::LogWarning("BeamSpotOnlineProducer")
           << "The beam spot record is too old. (record: " << recordTypeName << ")" << std::endl
-          << "record creation time: " << std::chrono::duration_cast<std::chrono::seconds>(bstime).count()
-          << "lumi block time: " << std::chrono::duration_cast<std::chrono::seconds>(lumitime).count();
+          << " record creation time: " << std::chrono::duration_cast<std::chrono::seconds>(bstime).count()
+          << " lumi block time: " << std::chrono::duration_cast<std::chrono::seconds>(lumitime).count();
       return fakeBS_;
     }
     return bs;
@@ -254,6 +254,10 @@ bool BeamSpotOnlineProducer::processScalers(const edm::Event& iEvent, bool shout
   iEvent.getByToken(scalerToken_, handleScaler);
 
   if (handleScaler->empty()) {
+    if (shoutMODE && iEvent.isRealData()) {
+      edm::LogWarning("BeamSpotOnlineProducer") << " Scalers handle is empty. The Online "
+                                                   "Beam Spot producer falls back to the PCL value.";
+    }
     return true;  // Fallback to DB if scaler collection is empty
   }
 

--- a/RecoVertex/BeamSpotProducer/test/testBeamSpotCompatibility.cc
+++ b/RecoVertex/BeamSpotProducer/test/testBeamSpotCompatibility.cc
@@ -43,7 +43,7 @@ TEST_CASE("BeamSpot Compatibility Checker", "[compareBS]") {
   pset.addParameter<double>("warningThr", 1.0);
   pset.addParameter<double>("errorThr", 2.0);
   pset.addParameter<edm::InputTag>("bsFromFile", edm::InputTag(""));
-  pset.addParameter<bool>("dbFromEvent", false);
+  pset.addParameter<bool>("dbFromEvent", true);
   pset.addParameter<edm::InputTag>("bsFromDB", edm::InputTag(""));
 
   BeamSpotCompatibilityChecker checker(pset);

--- a/RecoVertex/BeamSpotProducer/test/testBeamSpotCompatibility.cc
+++ b/RecoVertex/BeamSpotProducer/test/testBeamSpotCompatibility.cc
@@ -42,7 +42,7 @@ TEST_CASE("BeamSpot Compatibility Checker", "[compareBS]") {
   edm::ParameterSet pset;
   pset.addParameter<double>("warningThr", 1.0);
   pset.addParameter<double>("errorThr", 2.0);
-  pset.addParameter<edm::InputTag>("bsFromEvent", edm::InputTag(""));
+  pset.addParameter<edm::InputTag>("bsFromFile", edm::InputTag(""));
   pset.addParameter<bool>("dbFromEvent", false);
   pset.addParameter<edm::InputTag>("bsFromDB", edm::InputTag(""));
 

--- a/RecoVertex/BeamSpotProducer/test/testBeamSpotCompatibility_cfg.py
+++ b/RecoVertex/BeamSpotProducer/test/testBeamSpotCompatibility_cfg.py
@@ -86,12 +86,13 @@ process.GlobalTag = GlobalTag(process.GlobalTag, "140X_dataRun3_v4")  ## DO NOT 
 process.BeamSpotChecker = cms.EDAnalyzer("BeamSpotCompatibilityChecker",
                                          bsFromFile = cms.InputTag("offlineBeamSpot::RECO"),  # source of the event beamspot (in the ALCARECO files)
                                          #bsFromFile = cms.InputTag("offlineBeamSpot"),       # source of the event beamspot (in the ALCARECO files)
-                                         bsFromDB = cms.InputTag("offlineBeamSpot::@currentProcess"), # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
-                                         dbFromEvent = cms.bool(options.dbFromEvent),          # take the DB beamspot from the event
-                                         warningThr = cms.double(options.warningThreshold),    # significance threshold to emit a warning message
-                                         errorThr = cms.double(options.errorThreshold),        # significance threshold to abort the job
-                                         verbose = cms.untracked.bool(False)                   # verbose mode
+                                         dbFromEvent = cms.bool(options.dbFromEvent),         # take the DB beamspot from the event
+                                         warningThr = cms.double(options.warningThreshold),   # significance threshold to emit a warning message
+                                         errorThr = cms.double(options.errorThreshold),       # significance threshold to abort the job
+                                         verbose = cms.untracked.bool(True)                   # verbose mode
                                          )
+if(options.dbFromEvent):
+    process.BeamSpotChecker.bsFromDB = cms.InputTag("offlineBeamSpot::@currentProcess"), # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
 
 process.p = cms.Path(
     #process.myOfflineBeamSpot*

--- a/RecoVertex/BeamSpotProducer/test/testBeamSpotCompatibility_cfg.py
+++ b/RecoVertex/BeamSpotProducer/test/testBeamSpotCompatibility_cfg.py
@@ -84,9 +84,9 @@ from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, "140X_dataRun3_v4")  ## DO NOT CHANGE (it will change the behaviour of the test)!
 
 process.BeamSpotChecker = cms.EDAnalyzer("BeamSpotCompatibilityChecker",
-                                         bsFromEvent = cms.InputTag("offlineBeamSpot::RECO"),  # source of the event beamspot (in the ALCARECO files)
-                                         #bsFromEvent = cms.InputTag("offlineBeamSpot"),       # source of the event beamspot (in the ALCARECO files)
-                                         bsFromDB = cms.InputTag("offlineBeamSpot"),         # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
+                                         bsFromFile = cms.InputTag("offlineBeamSpot::RECO"),  # source of the event beamspot (in the ALCARECO files)
+                                         #bsFromFile = cms.InputTag("offlineBeamSpot"),       # source of the event beamspot (in the ALCARECO files)
+                                         bsFromDB = cms.InputTag("offlineBeamSpot::@currentProcess"), # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
                                          dbFromEvent = cms.bool(options.dbFromEvent),          # take the DB beamspot from the event
                                          warningThr = cms.double(options.warningThreshold),    # significance threshold to emit a warning message
                                          errorThr = cms.double(options.errorThreshold),        # significance threshold to abort the job


### PR DESCRIPTION
#### PR description:

This PR is a follow-up to PR https://github.com/cms-sw/cmssw/pull/45589 and https://github.com/cms-sw/cmssw/pull/47044, introducing several improvements.
Profiting of the operational experience in 2025 from the tracker alignment group, this PR introduces the following:
  * add support for `BeamSpotTransientObjectsRcd`
  * improve readability of the outputs;
  * improve variable naming and usage in test configurations;
  * add a conditional `fillDescriptions` to `BeamSpotCompatibilityChecker` to take the "event Beam Spot" either from the `EventSetup` or the `Event`;
  * in `Alignment/OfflineConfiguration` configuration files take by default the "DB Beam Spot" from the `Event` (via `BeamSpotProducer`) 
     * in the PV-related configurations, move  `BeamSpotCompatibilityChecker` after the track refit sequence (to avoid framework deadlocks when taking the Beam Spot from the `Event`).

#### PR validation:

Run the packages unit tests with: `scram b runtests`.

In addition I have run the following script with `cmsRun PV_cfg.py config=validation.json` in a variety of settings to make sure the results are as expected.

<details>

<summary> Scripts used for cross-checks </summary>

### PV_cfg.py

```python
import FWCore.ParameterSet.Config as cms
import FWCore.PythonUtilities.LumiList as LumiList
from Alignment.OfflineValidation.TkAlAllInOneTool.defaultInputFiles_cff import filesDefaultData_HLTPhys2024I

from FWCore.ParameterSet.VarParsing import VarParsing

from Alignment.OfflineValidation.TkAlAllInOneTool.utils import _byteify
import json
import os

##Define process
import FWCore.ParameterSet.Config as cms
from Configuration.Eras.Era_Run3_2025_cff import Run3_2025
process = cms.Process('PrimaryVertexValidation',Run3_2025)

##Argument parsing
options = VarParsing()
options.register("config", "", VarParsing.multiplicity.singleton, VarParsing.varType.string , "AllInOne config")

options.parseArguments()

##Read in AllInOne config in JSON format
if options.config == "":
    config = {"validation": {},
              "alignment": {}}
else:
    with open(options.config, "r") as configFile:
        config = json.load(configFile)

isDA = config["validation"].get("isda", True)
isMC = config["validation"].get("ismc", True)

runboundary = config["validation"].get("runboundary", 1)

##Read filenames from given TXT file and define input source
readFiles = []

if "dataset" in config["validation"]:
    with open(config["validation"]["dataset"], "r") as datafiles:
        for fileName in datafiles.readlines():
            readFiles.append(fileName.replace("\n", ""))

    process.source = cms.Source("PoolSource",
                                fileNames = cms.untracked.vstring(readFiles),
                                skipEvents = cms.untracked.uint32(0)
                            )
else:
    print(">>>>>>>>>> PV_cfg.py: msg%-i: config not specified! Loading default dataset -> filesDefaultData_HLTPhys2024I!")
    process.source = cms.Source("PoolSource",
                                fileNames = filesDefaultData_HLTPhys2024I,
                                skipEvents = cms.untracked.uint32(0)
                            )

##Get good lumi section and load data or handle MC
if "goodlumi" in config["validation"]:
    if os.path.isfile(config["validation"]["goodlumi"]):
        goodLumiSecs = cms.untracked.VLuminosityBlockRange(LumiList.LumiList(filename = config["validation"]["goodlumi"]).getCMSSWString().split(','))
        
    else:
        print("Does not exist: {}. Continue without good lumi section file.")
        goodLumiSecs = cms.untracked.VLuminosityBlockRange()

else:
    goodLumiSecs = cms.untracked.VLuminosityBlockRange()

if isMC:
     print(">>>>>>>>>> PV_cfg.py: msg%-i: This is simulation!")
     runboundary = 1
else:
     process.source.lumisToProcess = goodLumiSecs

isMultipleRuns=False
if(isinstance(runboundary, (list, tuple))):
     isMultipleRuns=True
     print("Multiple Runs are selected")       
if(isMultipleRuns):
     process.source.firstRun = cms.untracked.uint32(runboundary[0])
else:
     process.source.firstRun = cms.untracked.uint32(runboundary)

##default set to 1 for unit tests
process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(config["validation"].get("maxevents", 1)))

##Bookeeping
process.options = cms.untracked.PSet(
   wantSummary = cms.untracked.bool(False),
   Rethrow = cms.untracked.vstring("ProductNotFound"),
   fileMode  =  cms.untracked.string('NOMERGE'),
)

process.load("FWCore.MessageLogger.MessageLogger_cfi")
process.MessageLogger = cms.Service("MessageLogger",
                                    destinations   = cms.untracked.vstring('cerr'),
                                    cerr       = cms.untracked.PSet(threshold = cms.untracked.string('INFO'))
                                   )

##Basic modules
process.load("RecoVertex.BeamSpotProducer.BeamSpot_cff")
process.load("Configuration.Geometry.GeometryRecoDB_cff") #or process.load("Configuration.Geometry.GeometryDB_cff")?????
process.load('Configuration.StandardSequences.Services_cff')
process.load("Configuration.StandardSequences.MagneticField_cff")

####################################################################
# Produce the Transient Track Record in the event
####################################################################
process.load("TrackingTools.TransientTrack.TransientTrackBuilder_cfi")

####################################################################
# Load and Configure Common Track Selection and refitting sequence
####################################################################
import Alignment.CommonAlignment.tools.trackselectionRefitting as trackselRefit
process.seqTrackselRefit = trackselRefit.getSequence(process,
                                                     config["validation"].get("trackcollection", "ALCARECOTkAlMinBias"),
                                                     isPVValidation=True,
                                                     TTRHBuilder=config["validation"].get("tthrbuilder", "WithAngleAndTemplate"),
                                                     usePixelQualityFlag=config["validation"].get("usePixelQualityFlag", True),
                                                     openMassWindow=False,
                                                     cosmicsDecoMode=True,
                                                     cosmicsZeroTesla=config["validation"].get("cosmicsZeroTesla", False),                                                     
                                                     momentumConstraint=None,
                                                     cosmicTrackSplitting=False,
                                                     use_d0cut=False,
                                                     )

#Global tag
process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
from Configuration.AlCa.GlobalTag import GlobalTag
process.GlobalTag = GlobalTag(process.GlobalTag, config["alignment"].get("globaltag", "140X_dataRun3_Prompt_v4"))

##Load conditions if wished
if "conditions" in config["alignment"]:
    from CalibTracker.Configuration.Common.PoolDBESSource_cfi import poolDBESSource

    for condition in config["alignment"]["conditions"]:
        setattr(process, "conditionsIn{}".format(condition), poolDBESSource.clone(
             connect = cms.string(str(config["alignment"]["conditions"][condition]["connect"])),
             toGet = cms.VPSet(
                        cms.PSet(
                                 record = cms.string(str(condition)),
                                 tag = cms.string(str(config["alignment"]["conditions"][condition]["tag"]))
                        )
                     )
            )
        )

        setattr(process, "prefer_conditionsIn{}".format(condition), cms.ESPrefer("PoolDBESSource", "conditionsIn{}".format(condition)))

####################################################################
# Load and Configure event selection
####################################################################
process.primaryVertexFilter = cms.EDFilter("VertexSelector",
                                           src = cms.InputTag(config["validation"].get("vertexcollection", "offlinePrimaryVertices")),
                                           cut = cms.string("!isFake && ndof > 4 && abs(z) <= 24 && position.Rho <= 2"),
                                           filter = cms.bool(True)
                                           )

process.noscraping = cms.EDFilter("FilterOutScraping",
                                  applyfilter = cms.untracked.bool(True),
                                  src = cms.untracked.InputTag(config["validation"].get("trackcollection", "ALCARECOTkAlMinBias")),
                                  debugOn = cms.untracked.bool(False),
                                  numtrack = cms.untracked.uint32(10),
                                  thresh = cms.untracked.double(0.25)
                                  )

###################################################################
# Beamspot compatibility check
###################################################################
#from RecoVertex.BeamSpotProducer.beamSpotCompatibilityChecker_cfi import beamSpotCompatibilityChecker
#process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
process.BeamSpotChecker = cms.EDAnalyzer('BeamSpotCompatibilityChecker',   
    #bsFromFile = config["validation"].get("bsFromFile","offlineBeamSpot::RECO"),  # source of the event beamspot (in the ALCARECO files)
    bsFromFile = cms.InputTag(config["validation"].get("bsFromFile","hltOnlineBeamSpot::HLT")),  # source of the event beamspot (in the ALCARECO files)
    bsFromDB = cms.InputTag("offlineBeamSpot::@currentProcess"), # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
    #bsFromDB = cms.InputTag("offlineBeamSpot::pippo"), # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
    dbFromEvent = cms.bool(True),    
    warningThr = cms.double(config["validation"].get("bsIncompatibleWarnThresh", 3)), # significance threshold to emit a warning message
    errorThr = cms.double(config["validation"].get("bsIncompatibleErrThresh", 5)),    # significance threshold to abort the job
    verbose = cms.untracked.bool(False)
)

process.load("Alignment.CommonAlignment.filterOutLowPt_cfi")
process.filterOutLowPt.src = cms.untracked.InputTag(config["validation"].get("trackcollection", "ALCARECOTkAlMinBias"))
process.filterOutLowPt.ptmin = cms.untracked.double(config["validation"].get("ptCut", 3.))
process.filterOutLowPt.runControl = False
if(isMultipleRuns):
     process.filterOutLowPt.runControlNumber.extend((runboundary))
else:
     process.filterOutLowPt.runControlNumber = [runboundary]

if isMC:
     process.goodvertexSkim = cms.Sequence(process.noscraping + process.filterOutLowPt)
else:
     process.goodvertexSkim = cms.Sequence(process.primaryVertexFilter + process.noscraping + process.filterOutLowPt)


####################################################################
# Imports of parameters
####################################################################
from RecoVertex.PrimaryVertexProducer.OfflinePrimaryVertices_cfi import offlinePrimaryVertices
## modify the parameters which differ
FilteringParams = offlinePrimaryVertices.TkFilterParameters.clone(
     maxNormalizedChi2 = 5.0,  # chi2ndof < 5
     maxD0Significance = 5.0,  # fake cut (requiring 1 PXB hit)
     maxEta = 5.0,             # as per recommendation in PR #18330
)

## MM 04.05.2017 (use settings as in: https://github.com/cms-sw/cmssw/pull/18330)
from RecoVertex.PrimaryVertexProducer.OfflinePrimaryVertices_cfi import DA_vectParameters
DAClusterizationParams = DA_vectParameters.clone()

GapClusterizationParams = cms.PSet(algorithm   = cms.string('gap'),
                                   TkGapClusParameters = cms.PSet(zSeparation = cms.double(0.2))  # 0.2 cm max separation betw. clusters
                                   )

####################################################################
# Deterministic annealing clustering or Gap clustering
####################################################################
def switchClusterizerParameters(da):
     if da:
          print(">>>>>>>>>> testPVValidation_cfg.py: msg%-i: Running DA Algorithm!")
          return DAClusterizationParams
     else:
          print(">>>>>>>>>> testPVValidation_cfg.py: msg%-i: Running GAP Algorithm!")
          return GapClusterizationParams

####################################################################
# Configure the PVValidation Analyzer module
####################################################################
from Alignment.OfflineValidation.primaryVertexValidation_cfi import primaryVertexValidation  as _primaryVertexValidation
process.PVValidation = _primaryVertexValidation.clone(
    TrackCollectionTag = "FinalTrackRefitter",
    VertexCollectionTag = config["validation"].get("vertexcollection", "offlinePrimaryVertices"),
    Debug = False,
    storeNtuple = False,
    useTracksFromRecoVtx = False,
    isLightNtuple = True,
    askFirstLayerHit = False,
    forceBeamSpot = config["validation"].get("forceBeamSpot", False),
    probePt = config["validation"].get("ptCut", 3),
    probeEta  = config["validation"].get("etaCut", 2.5),
    minPt  = config["validation"].get("minPt", 1.),
    maxPt  = config["validation"].get("maxPt", 30.),
    doBPix = config["validation"].get("doBPix", True),
    doFPix = config["validation"].get("doFPix", True),
    numberOfBins = config["validation"].get("numberOfBins", 48),
    runControl = config["validation"].get("runControl", False),
    runControlNumber = [runboundary],
    TkFilterParameters = FilteringParams,
    TkClusParameters = switchClusterizerParameters(isDA)
)

####################################################################
# Output file
####################################################################
process.TFileService = cms.Service("TFileService",
            fileName = cms.string("{}/PVValidation_{}_{}.root".format(config.get("output", os.getcwd()), config["alignment"].get("name", ""), config["validation"].get("IOV", 1.))),
            closeFileFast = cms.untracked.bool(True),
    )


process.load("RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi")
from RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi import onlineBeamSpotProducer as _onlineBeamSpotProducer
process.offlineBeamSpot = _onlineBeamSpotProducer.clone()

####################################################################
# Path
####################################################################
process.p = cms.Path(process.goodvertexSkim*
                     process.seqTrackselRefit*
                     process.BeamSpotChecker*
                     process.PVValidation)

print("Done")
```

### validation.json

```json
{
    "output": ".",
    "alignment": {
        "color": 1,
        "style": 1,
        "globaltag": "150X_dataRun3_HLT_v1",
        "title": "HLT GT",
        "name": "GT"
    },
    "validation": {
        "maxevents": 100,
        "isda": true,
        "ismc": false,
        "vertexcollection": "offlinePrimaryVertices",
        "trackcollection": "hltMergedTracks",
        "tthrbuilder": "WithTrackAngle",
        "usePixelQualityFlag": false,
        "IOV": 1,
        "dataset": "/afs/cern.ch/cms/CAF/CMSALCA/ALCA_TRACKERALIGN/data/commonValidation/alignmentObjects/hpeterse/13p6TeVCommissioning/filelists/HLTMonitor_Run2025B-Express-v1_FEVTHLTALL/HLTMonitor_Run2025B-Express-v1_FEVTHLTALL_since391884.txt",
        "goodlumi": "/afs/cern.ch/cms/CAF/CMSALCA/ALCA_TRACKERALIGN/MP/MPproduction/datasetfiles/Collisions2025/120525/Collisions25_13p6TeV_391658_391953_DCSOnly_TkPx.json"
    }
}
```

</details>

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/48111 for CMSSW_15_0_X meant for 2025 data-taking operations.
