### PR TITLE
Get ServiceToken in TStorageFactoryFile

### DIFF
--- a/IOPool/TFileAdaptor/interface/TStorageFactoryFile.h
+++ b/IOPool/TFileAdaptor/interface/TStorageFactoryFile.h
@@ -8,6 +8,7 @@
 
 #include "Utilities/StorageFactory/interface/IOPosBuffer.h"
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
+#include "FWCore/ServiceRegistry/interface/ServiceToken.h"
 
 namespace edm::storage {
   class Storage;
@@ -58,6 +59,7 @@ private:
   TStorageFactoryFile(void);
 
   edm::propagate_const<std::unique_ptr<edm::storage::Storage>> storage_;  //< Real underlying storage
+  edm::ServiceWeakToken token_;
 };
 
 #endif  // TFILE_ADAPTOR_TSTORAGE_FACTORY_FILE_H


### PR DESCRIPTION
#### PR description:

It is possible for ROOT to call methods on different threads. The underlying storage class may need a service in order to work so we need to make sure the service system is running on that thread.

#### PR validation:

Code compiles

resolves https://github.com/cms-sw/cmssw/issues/48158
resolves https://github.com/cms-sw/framework-team/issues/1408