### PR TITLE
Fix initialisation / deactivation of XercesC in OMTF emulator code

### DIFF
--- a/L1Trigger/L1TCommon/BuildFile.xml
+++ b/L1Trigger/L1TCommon/BuildFile.xml
@@ -1,4 +1,5 @@
 <use name="xerces-c"/>
+<use name="Utilities/Xerces"/>
 <use name="CondFormats/L1TObjects"/>
 <export>
   <lib name="1"/>

--- a/L1Trigger/L1TCommon/src/XmlConfigParser.cc
+++ b/L1Trigger/L1TCommon/src/XmlConfigParser.cc
@@ -8,6 +8,7 @@ using namespace std;
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "Utilities/Xerces/interface/XercesStrUtils.h"
+#include "Utilities/Xerces/interface/Xerces.h"
 
 #include "xercesc/util/PlatformUtils.hpp"
 
@@ -53,7 +54,7 @@ XmlConfigParser::XmlConfigParser()
       kAttrDelim(nullptr),
       kAttrModule(nullptr),
       kTypeTable("table") {
-  XMLPlatformUtils::Initialize();
+  cms::concurrency::xercesInitialize();
 
   kTagHw = XMLString::transcode("system");
   kTagAlgo = XMLString::transcode("algo");
@@ -114,7 +115,7 @@ XmlConfigParser::XmlConfigParser(DOMDocument* doc)
       kAttrDelim(nullptr),
       kAttrModule(nullptr),
       kTypeTable("table") {
-  XMLPlatformUtils::Initialize();
+  cms::concurrency::xercesInitialize();
 
   kTagHw = XMLString::transcode("system");
   kTagAlgo = XMLString::transcode("algo");
@@ -147,7 +148,7 @@ XmlConfigParser::XmlConfigParser(DOMDocument* doc)
 
 XmlConfigParser::~XmlConfigParser() {
   delete parser_;
-  XMLPlatformUtils::Terminate();
+  cms::concurrency::xercesTerminate();
 }
 
 void XmlConfigParser::readDOMFromString(const std::string& str, DOMDocument*& doc) {

--- a/L1Trigger/L1TMuonOverlap/BuildFile.xml
+++ b/L1Trigger/L1TMuonOverlap/BuildFile.xml
@@ -3,6 +3,7 @@
 </export>
 <use name="xerces-c"/>
 <use name="root"/>
+<use name="Utilities/Xerces"/>
 <use name="DataFormats/L1DTTrackFinder"/>
 <use name="L1Trigger/RPCTrigger"/>
 <use name="DataFormats/L1TMuon"/>

--- a/L1Trigger/L1TMuonOverlap/interface/XMLConfigWriter.h
+++ b/L1Trigger/L1TMuonOverlap/interface/XMLConfigWriter.h
@@ -29,6 +29,8 @@ class XMLConfigWriter {
 public:
   XMLConfigWriter(const OMTFConfiguration* aOMTFConfig);
 
+  ~XMLConfigWriter();
+
   void initialiseXMLDocument(const std::string& docName);
 
   void finaliseXMLDocument(const std::string& fName);

--- a/L1Trigger/L1TMuonOverlap/src/XMLConfigReader.cc
+++ b/L1Trigger/L1TMuonOverlap/src/XMLConfigReader.cc
@@ -12,6 +12,8 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+#include "Utilities/Xerces/interface/Xerces.h"
+
 #include "xercesc/framework/StdOutFormatTarget.hpp"
 #include "xercesc/framework/LocalFileFormatTarget.hpp"
 #include "xercesc/parsers/XercesDOMParser.hpp"
@@ -39,20 +41,11 @@ inline XMLCh *_toDOMS(std::string temp) {
 }
 ////////////////////////////////////
 ////////////////////////////////////
-XMLConfigReader::XMLConfigReader() {
-  //XMLPlatformUtils::Initialize();
-
-  ///Initialise XML parser
-  //parser = new XercesDOMParser();
-  //parser->setValidationScheme(XercesDOMParser::Val_Auto);
-  //parser->setDoNamespaces(false);
-
-  //doc = 0;
-}
+XMLConfigReader::XMLConfigReader() { cms::concurrency::xercesInitialize(); }
 
 XMLConfigReader::~XMLConfigReader() {
   //  delete parser;
-  //XMLPlatformUtils::Terminate();
+  cms::concurrency::xercesTerminate();
 }
 //////////////////////////////////////////////////
 //////////////////////////////////////////////////
@@ -134,7 +127,6 @@ unsigned int XMLConfigReader::getPatternsVersion() const {
     return 0;
 
   unsigned int version = 0;
-  XMLPlatformUtils::Initialize();
   {
     XercesDOMParser parser;
     parser.setValidationScheme(XercesDOMParser::Val_Auto);
@@ -154,7 +146,6 @@ unsigned int XMLConfigReader::getPatternsVersion() const {
     XMLString::release(&xmlVersion);
     parser.resetDocumentPool();
   }
-  XMLPlatformUtils::Terminate();
 
   return version;
 }
@@ -162,8 +153,6 @@ unsigned int XMLConfigReader::getPatternsVersion() const {
 //////////////////////////////////////////////////
 std::vector<std::shared_ptr<GoldenPattern>> XMLConfigReader::readPatterns(const L1TMuonOverlapParams &aConfig) {
   aGPs.clear();
-
-  XMLPlatformUtils::Initialize();
 
   XMLCh *xmlGP = _toDOMS("GP");
   std::array<XMLCh *, 4> xmliPt = {{_toDOMS("iPt1"), _toDOMS("iPt2"), _toDOMS("iPt3"), _toDOMS("iPt4")}};
@@ -221,8 +210,6 @@ std::vector<std::shared_ptr<GoldenPattern>> XMLConfigReader::readPatterns(const 
   XMLString::release(&xmliPt[1]);
   XMLString::release(&xmliPt[2]);
   XMLString::release(&xmliPt[3]);
-
-  XMLPlatformUtils::Terminate();
 
   return aGPs;
 }
@@ -338,7 +325,6 @@ std::vector<std::vector<int>> XMLConfigReader::readEvent(unsigned int iEvent, un
 //////////////////////////////////////////////////
 //////////////////////////////////////////////////
 void XMLConfigReader::readConfig(L1TMuonOverlapParams *aConfig) const {
-  XMLPlatformUtils::Initialize();
   {
     XercesDOMParser parser;
     parser.setValidationScheme(XercesDOMParser::Val_Auto);
@@ -632,7 +618,6 @@ void XMLConfigReader::readConfig(L1TMuonOverlapParams *aConfig) const {
     XMLString::release(&xmlnGoldenPatterns);
     XMLString::release(&xmlConnectionMap);
   }
-  XMLPlatformUtils::Terminate();
 }
 //////////////////////////////////////////////////
 //////////////////////////////////////////////////

--- a/L1Trigger/L1TMuonOverlap/src/XMLConfigWriter.cc
+++ b/L1Trigger/L1TMuonOverlap/src/XMLConfigWriter.cc
@@ -9,6 +9,8 @@
 #include "L1Trigger/L1TMuonOverlap/interface/AlgoMuon.h"
 #include "DataFormats/L1TMuon/interface/RegionalMuonCand.h"
 
+#include "Utilities/Xerces/interface/Xerces.h"
+
 #include <iostream>
 #include <sstream>
 #include <cmath>
@@ -86,13 +88,16 @@ inline XMLCh* _toDOMS(std::string temp) {
 ////////////////////////////////////
 ////////////////////////////////////
 XMLConfigWriter::XMLConfigWriter(const OMTFConfiguration* aOMTFConfig) {
-  XMLPlatformUtils::Initialize();
+  cms::concurrency::xercesInitialize();
 
   ///Initialise XML document
   domImpl = DOMImplementationRegistry::getDOMImplementation(_toDOMS("Range"));
 
   myOMTFConfig = aOMTFConfig;
 }
+////////////////////////////////////
+////////////////////////////////////
+XMLConfigWriter::~XMLConfigWriter() { cms::concurrency::xercesTerminate(); }
 //////////////////////////////////////////////////
 //////////////////////////////////////////////////
 void XMLConfigWriter::initialiseXMLDocument(const std::string& docName) {

--- a/L1Trigger/L1TMuonOverlapPhase1/BuildFile.xml
+++ b/L1Trigger/L1TMuonOverlapPhase1/BuildFile.xml
@@ -9,6 +9,7 @@
   <use name="Geometry/RPCGeometry"/>  
   <use name="root"/> 
   <use name="xerces-c"/>
+  <use name="Utilities/Xerces"/>
 </export>
 
 <flags ADD_SUBDIR="1"/>
@@ -34,3 +35,4 @@
 <use name="roofit"/>
 <use name="root"/>
 <use name="xerces-c"/>
+<use name="Utilities/Xerces"/>

--- a/L1Trigger/L1TMuonOverlapPhase1/interface/Omtf/XMLConfigWriter.h
+++ b/L1Trigger/L1TMuonOverlapPhase1/interface/Omtf/XMLConfigWriter.h
@@ -31,6 +31,8 @@ public:
                   bool writePdfThresholds = false,
                   bool writeMeanDistPhi1 = false);
 
+  ~XMLConfigWriter();
+
   void initialiseXMLDocument(const std::string& docName);
 
   void finaliseXMLDocument(const std::string& fName);

--- a/L1Trigger/L1TMuonOverlapPhase1/src/Omtf/XMLConfigReader.cc
+++ b/L1Trigger/L1TMuonOverlapPhase1/src/Omtf/XMLConfigReader.cc
@@ -7,6 +7,8 @@
 #include "CondFormats/L1TObjects/interface/L1TMuonOverlapParams.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+#include "Utilities/Xerces/interface/Xerces.h"
+
 #include <iostream>
 #include <cmath>
 #include <algorithm>
@@ -42,9 +44,9 @@ inline XMLCh *_toDOMS(std::string temp) {
 }
 ////////////////////////////////////
 ////////////////////////////////////
-XMLConfigReader::XMLConfigReader() {}
+XMLConfigReader::XMLConfigReader() { cms::concurrency::xercesInitialize(); }
 
-XMLConfigReader::~XMLConfigReader() {}
+XMLConfigReader::~XMLConfigReader() { cms::concurrency::xercesTerminate(); }
 //////////////////////////////////////////////////
 //////////////////////////////////////////////////
 void XMLConfigReader::readLUTs(std::vector<l1t::LUT *> luts,
@@ -207,7 +209,6 @@ unsigned int XMLConfigReader::getPatternsVersion() const {
     return 0;
 
   unsigned int version = 0;
-  XMLPlatformUtils::Initialize();
   {
     XercesDOMParser parser;
     parser.setValidationScheme(XercesDOMParser::Val_Auto);
@@ -227,7 +228,6 @@ unsigned int XMLConfigReader::getPatternsVersion() const {
     XMLString::release(&xmlVersion);
     parser.resetDocumentPool();
   }
-  XMLPlatformUtils::Terminate();
 
   return version;
 }
@@ -240,8 +240,6 @@ GoldenPatternVec<GoldenPatternType> XMLConfigReader::readPatterns(const L1TMuonO
                                                                   bool resetNumbering) {
   GoldenPatternVec<GoldenPatternType> aGPs;
   aGPs.clear();
-
-  XMLPlatformUtils::Initialize();
 
   if (resetNumbering) {
     iGPNumber = 0;
@@ -304,8 +302,6 @@ GoldenPatternVec<GoldenPatternType> XMLConfigReader::readPatterns(const L1TMuonO
   XMLString::release(&xmliPt[1]);
   XMLString::release(&xmliPt[2]);
   XMLString::release(&xmliPt[3]);
-
-  XMLPlatformUtils::Terminate();
 
   return aGPs;
 }
@@ -469,7 +465,6 @@ std::vector<std::vector<int> > XMLConfigReader::readEvent(unsigned int iEvent, u
 //////////////////////////////////////////////////
 //////////////////////////////////////////////////
 void XMLConfigReader::readConfig(L1TMuonOverlapParams *aConfig) const {
-  XMLPlatformUtils::Initialize();
   {
     XercesDOMParser parser;
     parser.setValidationScheme(XercesDOMParser::Val_Auto);
@@ -763,7 +758,6 @@ void XMLConfigReader::readConfig(L1TMuonOverlapParams *aConfig) const {
     XMLString::release(&xmlnGoldenPatterns);
     XMLString::release(&xmlConnectionMap);
   }
-  XMLPlatformUtils::Terminate();
 }
 //////////////////////////////////////////////////
 //////////////////////////////////////////////////

--- a/L1Trigger/L1TMuonOverlapPhase1/src/Omtf/XMLConfigWriter.cc
+++ b/L1Trigger/L1TMuonOverlapPhase1/src/Omtf/XMLConfigWriter.cc
@@ -9,6 +9,8 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/L1TMuon/interface/RegionalMuonCand.h"
 
+#include "Utilities/Xerces/interface/Xerces.h"
+
 #include <iostream>
 #include <sstream>
 #include <cmath>
@@ -87,13 +89,16 @@ inline XMLCh* _toDOMS(std::string temp) {
 ////////////////////////////////////
 XMLConfigWriter::XMLConfigWriter(const OMTFConfiguration* aOMTFConfig, bool writePdfThresholds, bool writeMeanDistPhi1)
     : writePdfThresholds(writePdfThresholds), writeMeanDistPhi1(writeMeanDistPhi1) {
-  XMLPlatformUtils::Initialize();
+  cms::concurrency::xercesInitialize();
 
   ///Initialise XML document
   domImpl = DOMImplementationRegistry::getDOMImplementation(_toDOMS("Range"));
 
   myOMTFConfig = aOMTFConfig;
 }
+//////////////////////////////////////////////////
+//////////////////////////////////////////////////
+XMLConfigWriter::~XMLConfigWriter() { cms::concurrency::xercesTerminate(); }
 //////////////////////////////////////////////////
 //////////////////////////////////////////////////
 void XMLConfigWriter::initialiseXMLDocument(const std::string& docName) {


### PR DESCRIPTION
#### PR description:

This fixes a segmentation violation issue caused by direct initialisation / deactivation of XercesC in OMTF emulator code reported in https://github.com/cms-sw/cmssw/issues/48090.
As proposed in https://github.com/cms-sw/cmssw/issues/48090 direct calls of `XMLPlatformUtils::Initialize()/Terminate()` are replaced by calls with the `cms::concurrency::xercesInitialize()/xercesTerminate()`.

#### PR validation:

Tested with WFs 145.005, 145.006 with 4 threads: `runTheMatrix.py --nThreads 4 -l 145.005,145.006 -i all --ibeos`

Should it be backported to 15_0_X (other?)