### PR TITLE
Use RNTuple output module for NanoAOD

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -732,14 +732,16 @@ class ConfigBuilder(object):
         CppType='PoolOutputModule'
         if self._options.timeoutOutput:
             CppType='TimeoutPoolOutputModule'
-        if streamType=='DQM' and tier=='DQMIO':
+        elif streamType=='DQM' and tier=='DQMIO':
             CppType='DQMRootOutputModule'
-            fileName = fileName.replace('.rntpl', '.root')
-        if not ignoreNano and "NANOAOD" in streamType : CppType='NanoAODOutputModule'
-        if self._options.rntuple_out and CppType == 'PoolOutputModule':
+        elif not ignoreNano and "NANOAOD" in streamType:
+            CppType='NanoAODRNTupleOutputModule' if self._options.rntuple_out else 'NanoAODOutputModule'
+        elif self._options.rntuple_out:
             CppType='RNTupleOutputModule'
-            if len(fileName) > 5 and fileName[-5:] == '.root':
-                fileName = fileName.replace('.root', '.rntpl')
+        if 'RNTuple' in CppType:
+            fileName = fileName.replace('.root', '.rntpl')
+        else:
+            fileName = fileName.replace('.rntpl', '.root')
         output = cms.OutputModule(CppType,
                                   eventContent.clone(),
                                   fileName = cms.untracked.string(fileName),

--- a/Configuration/Applications/test/ConfigBuilderTest.py
+++ b/Configuration/Applications/test/ConfigBuilderTest.py
@@ -215,7 +215,7 @@ if __name__=="__main__":
             options.datatier= "NANOAOD"
             options.eventcontent="NANOEDMAOD"
             _test_addOutput(self, options, process, [OutStats('NANOEDMAODoutput', 'PoolOutputModule', 'NANOAOD', 'output.root', outputCommands_)])
-            #NANOAOD & rntuple (no change)
+            #NANOAOD & rntuple
             process = cms.Process("TEST")
             outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')
             process.NANOAODEventContent = cms.PSet( outputCommands = outputCommands_)
@@ -224,7 +224,7 @@ if __name__=="__main__":
             options.datatier= "NANOAOD"
             options.eventcontent="NANOAOD"
             options.rntuple_out = True
-            _test_addOutput(self, options, process, [OutStats('NANOAODoutput','NanoAODOutputModule','NANOAOD','output.root',outputCommands_)])
+            _test_addOutput(self, options, process, [OutStats('NANOAODoutput','NanoAODRNTupleOutputModule','NANOAOD','output.rntpl',outputCommands_)])
             #NANOEDMAOD & rntuple
             process = cms.Process("TEST")
             outputCommands_ = cms.untracked.vstring('drop *', 'keep foo')


### PR DESCRIPTION
This PR adjusts the `ConfigBuilder.py` script so that `NanoAODRNTupleOutputModule` is used when the `--rntuple_out` flag is passed.

This is thanks to @makortel's help in https://github.com/cms-sw/cmssw/pull/48071#issuecomment-2902462276. I checked that this change works with https://github.com/cms-sw/cmssw/pull/48071.