### PR TITLE
Fixed SOA(_CONST)_ELEMENT_METHODS sintax in the README

### DIFF
--- a/DataFormats/SoATemplate/README.md
+++ b/DataFormats/SoATemplate/README.md
@@ -154,14 +154,14 @@ GENERATE_SOA_LAYOUT(SoATemplate,
   SOA_COLUMN(double, z),
   
   // methods operating on const_element
-  SOA_CONST_METHODS(
+  SOA_CONST_ELEMENT_METHODS(
     auto norm() const {
       return sqrt(x()*x() + y()+y() + z()*z());
     }
   ),
 
   // methods operating on element
-  SOA_METHODS(
+  SOA_ELEMENT_METHODS(
     void scale(float arg) {
       x() *= arg;
       y() *= arg;


### PR DESCRIPTION
#### PR description:

This PR modifies the sintax of the README's example of the feature introduced in [#47625](https://github.com/cms-sw/cmssw/pull/47625)
