### PR TITLE
BTL occupancy studies

### DIFF
--- a/Validation/MtdValidation/plugins/BtlLocalRecoHarvester.cc
+++ b/Validation/MtdValidation/plugins/BtlLocalRecoHarvester.cc
@@ -37,7 +37,10 @@ private:
   const std::string folder_;
 
   // --- Histograms
+  MonitorElement* meHitOccupancyLog_;
   MonitorElement* meHitOccupancy_;
+  static constexpr int nRU_ = 6;
+  MonitorElement* meHitOccupancyRUSlice_[nRU_];
 };
 
 // ------------ constructor and destructor --------------
@@ -50,9 +53,18 @@ BtlLocalRecoHarvester::~BtlLocalRecoHarvester() {}
 void BtlLocalRecoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& igetter) {
   // --- Get the monitoring histograms
   MonitorElement* meBtlHitLogEnergy = igetter.get(folder_ + "BtlHitLogEnergy");
+  MonitorElement* meBtlHitEnergy = igetter.get(folder_ + "BtlHitEnergy");
+  MonitorElement* meBtlHitEnergyRUSlice[nRU_];
   MonitorElement* meNevents = igetter.get(folder_ + "BtlNevents");
+  bool missing_ru_slice = false;
+  for (unsigned int ihistoRU = 0; ihistoRU < nRU_; ++ihistoRU) {
+    meBtlHitEnergyRUSlice[ihistoRU] = igetter.get(folder_ + "BtlHitEnergyRUSlice" + std::to_string(ihistoRU));
+    if (!meBtlHitEnergyRUSlice[ihistoRU]) {
+      missing_ru_slice = true;
+    }
+  }
 
-  if (!meBtlHitLogEnergy || !meNevents) {
+  if (!meBtlHitLogEnergy || !meBtlHitEnergy || missing_ru_slice || !meNevents) {
     edm::LogError("BtlLocalRecoHarvester") << "Monitoring histograms not found!" << std::endl;
     return;
   }
@@ -60,21 +72,48 @@ void BtlLocalRecoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGette
   // --- Get the number of BTL crystals and the number of processed events
   const float NBtlCrystals = BTLDetId::kCrystalsBTL;
   const float Nevents = meNevents->getEntries();
-  const float scale = (Nevents > 0 ? 1. / (Nevents * NBtlCrystals) : 1.);
+  const float scale_Crystals = (Nevents > 0 ? 1. / (Nevents * NBtlCrystals) : 1.);
+  const float scale_Crystals_RU = (Nevents > 0 ? 1. / (Nevents * NBtlCrystals / nRU_) : 1.);
 
-  // --- Book the cumulative histogram
+  // --- Book the cumulative histograms
   ibook.cd(folder_);
-  meHitOccupancy_ = ibook.book1D("BtlHitOccupancy",
+  meHitOccupancyLog_ = ibook.book1D("BtlHitOccupancyLog",
                                  "BTL cell occupancy vs RECO hit energy;log_{10}(E_{RECO} [MeV]); Occupancy per event",
                                  meBtlHitLogEnergy->getNbinsX(),
                                  meBtlHitLogEnergy->getTH1()->GetXaxis()->GetXmin(),
                                  meBtlHitLogEnergy->getTH1()->GetXaxis()->GetXmax());
+  meHitOccupancy_ = ibook.book1D("BtlHitOccupancy",
+                                 "BTL cell occupancy vs RECO hit energy;E_{RECO} [MeV]; Occupancy per event",
+                                 meBtlHitEnergy->getNbinsX(),
+                                 meBtlHitEnergy->getTH1()->GetXaxis()->GetXmin(),
+                                 meBtlHitEnergy->getTH1()->GetXaxis()->GetXmax());
+  for(unsigned int ihistoRU = 0; ihistoRU < nRU_; ++ihistoRU) {
+    std::string name_Energy = "BtlHitOccupancyRUSlice" + std::to_string(ihistoRU);
+    std::string title_Energy = "BTL cell occupancy vs RECO hit energy (RU " + std::to_string(ihistoRU) + ");E_{RECO} [MeV]; Occupancy per event";
+    meHitOccupancyRUSlice_[ihistoRU] = ibook.book1D(name_Energy,
+                                                    title_Energy,
+                                                    meBtlHitEnergyRUSlice[ihistoRU]->getNbinsX(),
+                                                    meBtlHitEnergyRUSlice[ihistoRU]->getTH1()->GetXaxis()->GetXmin(),
+                                                    meBtlHitEnergyRUSlice[ihistoRU]->getTH1()->GetXaxis()->GetXmax());
+  }
 
-  // --- Calculate the cumulative histogram
-  double bin_sum = meBtlHitLogEnergy->getBinContent(meBtlHitLogEnergy->getNbinsX() + 1);
+  // --- Calculate the cumulative histograms
+  double bin_sum_log = meBtlHitLogEnergy->getBinContent(meBtlHitLogEnergy->getNbinsX() + 1);
   for (int ibin = meBtlHitLogEnergy->getNbinsX(); ibin >= 1; --ibin) {
-    bin_sum += meBtlHitLogEnergy->getBinContent(ibin);
-    meHitOccupancy_->setBinContent(ibin, scale * bin_sum);
+    bin_sum_log += meBtlHitLogEnergy->getBinContent(ibin);
+    meHitOccupancyLog_->setBinContent(ibin, scale_Crystals * bin_sum_log);
+  }
+  double bin_sum = meBtlHitEnergy->getBinContent(meBtlHitEnergy->getNbinsX() + 1);
+  for (int ibin = meBtlHitEnergy->getNbinsX(); ibin >= 1; --ibin) {
+    bin_sum += meBtlHitEnergy->getBinContent(ibin);
+    meHitOccupancy_->setBinContent(ibin, scale_Crystals * bin_sum);
+  }
+  for(unsigned int ihistoRU = 0; ihistoRU < nRU_; ++ihistoRU) {
+    double bin_sum_RUSlice = meBtlHitEnergyRUSlice[ihistoRU]->getBinContent(meBtlHitEnergyRUSlice[ihistoRU]->getNbinsX() + 1);
+    for (int ibin = meBtlHitEnergyRUSlice[ihistoRU]->getNbinsX(); ibin >= 1; --ibin) {
+      bin_sum_RUSlice += meBtlHitEnergyRUSlice[ihistoRU]->getBinContent(ibin);
+      meHitOccupancyRUSlice_[ihistoRU]->setBinContent(ibin, scale_Crystals_RU * bin_sum_RUSlice);
+    }
   }
 }
 

--- a/Validation/MtdValidation/plugins/BtlLocalRecoHarvester.cc
+++ b/Validation/MtdValidation/plugins/BtlLocalRecoHarvester.cc
@@ -77,19 +77,21 @@ void BtlLocalRecoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGette
 
   // --- Book the cumulative histograms
   ibook.cd(folder_);
-  meHitOccupancyLog_ = ibook.book1D("BtlHitOccupancyLog",
-                                 "BTL cell occupancy vs RECO hit energy;log_{10}(E_{RECO} [MeV]); Occupancy per event",
-                                 meBtlHitLogEnergy->getNbinsX(),
-                                 meBtlHitLogEnergy->getTH1()->GetXaxis()->GetXmin(),
-                                 meBtlHitLogEnergy->getTH1()->GetXaxis()->GetXmax());
+  meHitOccupancyLog_ =
+      ibook.book1D("BtlHitOccupancyLog",
+                   "BTL cell occupancy vs RECO hit energy;log_{10}(E_{RECO} [MeV]); Occupancy per event",
+                   meBtlHitLogEnergy->getNbinsX(),
+                   meBtlHitLogEnergy->getTH1()->GetXaxis()->GetXmin(),
+                   meBtlHitLogEnergy->getTH1()->GetXaxis()->GetXmax());
   meHitOccupancy_ = ibook.book1D("BtlHitOccupancy",
                                  "BTL cell occupancy vs RECO hit energy;E_{RECO} [MeV]; Occupancy per event",
                                  meBtlHitEnergy->getNbinsX(),
                                  meBtlHitEnergy->getTH1()->GetXaxis()->GetXmin(),
                                  meBtlHitEnergy->getTH1()->GetXaxis()->GetXmax());
-  for(unsigned int ihistoRU = 0; ihistoRU < nRU_; ++ihistoRU) {
+  for (unsigned int ihistoRU = 0; ihistoRU < nRU_; ++ihistoRU) {
     std::string name_Energy = "BtlHitOccupancyRUSlice" + std::to_string(ihistoRU);
-    std::string title_Energy = "BTL cell occupancy vs RECO hit energy (RU " + std::to_string(ihistoRU) + ");E_{RECO} [MeV]; Occupancy per event";
+    std::string title_Energy = "BTL cell occupancy vs RECO hit energy (RU " + std::to_string(ihistoRU) +
+                               ");E_{RECO} [MeV]; Occupancy per event";
     meHitOccupancyRUSlice_[ihistoRU] = ibook.book1D(name_Energy,
                                                     title_Energy,
                                                     meBtlHitEnergyRUSlice[ihistoRU]->getNbinsX(),
@@ -108,8 +110,9 @@ void BtlLocalRecoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGette
     bin_sum += meBtlHitEnergy->getBinContent(ibin);
     meHitOccupancy_->setBinContent(ibin, scale_Crystals * bin_sum);
   }
-  for(unsigned int ihistoRU = 0; ihistoRU < nRU_; ++ihistoRU) {
-    double bin_sum_RUSlice = meBtlHitEnergyRUSlice[ihistoRU]->getBinContent(meBtlHitEnergyRUSlice[ihistoRU]->getNbinsX() + 1);
+  for (unsigned int ihistoRU = 0; ihistoRU < nRU_; ++ihistoRU) {
+    double bin_sum_RUSlice =
+        meBtlHitEnergyRUSlice[ihistoRU]->getBinContent(meBtlHitEnergyRUSlice[ihistoRU]->getNbinsX() + 1);
     for (int ibin = meBtlHitEnergyRUSlice[ihistoRU]->getNbinsX(); ibin >= 1; --ibin) {
       bin_sum_RUSlice += meBtlHitEnergyRUSlice[ihistoRU]->getBinContent(ibin);
       meHitOccupancyRUSlice_[ihistoRU]->setBinContent(ibin, scale_Crystals_RU * bin_sum_RUSlice);

--- a/Validation/MtdValidation/plugins/BtlLocalRecoHarvester.cc
+++ b/Validation/MtdValidation/plugins/BtlLocalRecoHarvester.cc
@@ -39,7 +39,7 @@ private:
   // --- Histograms
   MonitorElement* meHitOccupancyLog_;
   MonitorElement* meHitOccupancy_;
-  static constexpr int nRU_ = 6;
+  static constexpr int nRU_ = BTLDetId::kRUPerRod;
   MonitorElement* meHitOccupancyRUSlice_[nRU_];
 };
 

--- a/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
@@ -88,7 +88,7 @@ private:
 
   MonitorElement* meNhits_;
 
-  static constexpr int nRU_ = 6;
+  static constexpr int nRU_ = BTLDetId::kRUPerRod;
 
   MonitorElement* meHitEnergy_;
   MonitorElement* meHitEnergyRUSlice_[nRU_];
@@ -399,7 +399,7 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
     const auto& global_point = thedet->toGlobal(local_point);
 
     meHitEnergy_->Fill(recHit.energy());
-    meHitEnergyRUSlice_[detId.globalRunit()-1]->Fill(recHit.energy());
+    meHitEnergyRUSlice_[detId.runit()-1]->Fill(recHit.energy());
     meHitLogEnergy_->Fill(log10(recHit.energy()));
     meHitTime_->Fill(recHit.time());
     meHitTimeError_->Fill(recHit.timeError());

--- a/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
@@ -399,7 +399,7 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
     const auto& global_point = thedet->toGlobal(local_point);
 
     meHitEnergy_->Fill(recHit.energy());
-    meHitEnergyRUSlice_[detId.runit()-1]->Fill(recHit.energy());
+    meHitEnergyRUSlice_[detId.runit() - 1]->Fill(recHit.energy());
     meHitLogEnergy_->Fill(log10(recHit.energy()));
     meHitTime_->Fill(recHit.time());
     meHitTimeError_->Fill(recHit.timeError());
@@ -963,7 +963,7 @@ void BtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
   meHitEnergy_ = ibook.book1D("BtlHitEnergy", "BTL RECO hits energy;E_{RECO} [MeV]", 100, 0., 20.);
   for (unsigned int ihistoRU = 0; ihistoRU < nRU_; ++ihistoRU) {
     std::string name_Energy = "BtlHitEnergyRUSlice" + std::to_string(ihistoRU);
-    std::string title_Energy = "BTL RECO hits energy (RU " + std::to_string(ihistoRU) +");E_{RECO} [MeV])";
+    std::string title_Energy = "BTL RECO hits energy (RU " + std::to_string(ihistoRU) + ");E_{RECO} [MeV])";
     meHitEnergyRUSlice_[ihistoRU] = ibook.book1D(name_Energy, title_Energy, 100, 0., 20.);
   }
   meHitLogEnergy_ = ibook.book1D("BtlHitLogEnergy", "BTL RECO hits energy;log_{10}(E_{RECO} [MeV])", 16, -0.1, 1.5);

--- a/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
@@ -88,7 +88,10 @@ private:
 
   MonitorElement* meNhits_;
 
+  static constexpr int nRU_ = 6;
+
   MonitorElement* meHitEnergy_;
+  MonitorElement* meHitEnergyRUSlice_[nRU_];
   MonitorElement* meHitLogEnergy_;
   MonitorElement* meHitTime_;
   MonitorElement* meHitTimeError_;
@@ -396,6 +399,7 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
     const auto& global_point = thedet->toGlobal(local_point);
 
     meHitEnergy_->Fill(recHit.energy());
+    meHitEnergyRUSlice_[detId.globalRunit()-1]->Fill(recHit.energy());
     meHitLogEnergy_->Fill(log10(recHit.energy()));
     meHitTime_->Fill(recHit.time());
     meHitTimeError_->Fill(recHit.timeError());
@@ -957,6 +961,11 @@ void BtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
   meNhits_ = ibook.book1D("BtlNhits", "Number of BTL RECO hits;log_{10}(N_{RECO})", 100, 0., 5.25);
 
   meHitEnergy_ = ibook.book1D("BtlHitEnergy", "BTL RECO hits energy;E_{RECO} [MeV]", 100, 0., 20.);
+  for (unsigned int ihistoRU = 0; ihistoRU < nRU_; ++ihistoRU) {
+    std::string name_Energy = "BtlHitEnergyRUSlice" + std::to_string(ihistoRU);
+    std::string title_Energy = "BTL RECO hits energy (RU " + std::to_string(ihistoRU) +");E_{RECO} [MeV])";
+    meHitEnergyRUSlice_[ihistoRU] = ibook.book1D(name_Energy, title_Energy, 100, 0., 20.);
+  }
   meHitLogEnergy_ = ibook.book1D("BtlHitLogEnergy", "BTL RECO hits energy;log_{10}(E_{RECO} [MeV])", 16, -0.1, 1.5);
   meHitTime_ = ibook.book1D("BtlHitTime", "BTL RECO hits ToA;ToA_{RECO} [ns]", 100, 0., 25.);
   meHitTimeError_ = ibook.book1D("BtlHitTimeError", "BTL RECO hits ToA error;#sigma^{ToA}_{RECO} [ns]", 50, 0., 0.1);

--- a/Validation/MtdValidation/plugins/BtlSimHitsHarvester.cc
+++ b/Validation/MtdValidation/plugins/BtlSimHitsHarvester.cc
@@ -40,7 +40,7 @@ private:
   MonitorElement* meHitOccupancy_;
   MonitorElement* meHitOccupancyCell_;
   MonitorElement* meHitOccupancySM_;
-  static constexpr int nRU_ = 6;
+  static constexpr int nRU_ = BTLDetId::kRUPerRod;
   MonitorElement* meHitOccupancyRUSlice_[nRU_];
   MonitorElement* meHitOccupancyCellRUSlice_[nRU_];
   MonitorElement* meHitOccupancySMRUSlice_[nRU_];
@@ -118,7 +118,7 @@ void BtlSimHitsHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter&
                                                     meBtlHitMultCellRUSlice[ihistoRU]->getTH1()->GetXaxis()->GetXmin(),
                                                     meBtlHitMultCellRUSlice[ihistoRU]->getTH1()->GetXaxis()->GetXmax());
     std::string name_SM = "BtlHitOccupancySMRUSlice" + std::to_string(ihistoRU);
-    std::string title_SM = "BTL SM occupancy vs energy threshold(RU " + std::to_string(ihistoRU) + ");log_{10}(E_{th} [MeV]); Occupancy per event";
+    std::string title_SM = "BTL SM occupancy vs energy threshold (RU " + std::to_string(ihistoRU) + ");log_{10}(E_{th} [MeV]); Occupancy per event";
     meHitOccupancySMRUSlice_[ihistoRU] = ibook.book1D(name_SM,
                                                       title_SM,
                                                       meBtlHitMultSMRUSlice[ihistoRU]->getNbinsX(),

--- a/Validation/MtdValidation/plugins/BtlSimHitsHarvester.cc
+++ b/Validation/MtdValidation/plugins/BtlSimHitsHarvester.cc
@@ -38,8 +38,11 @@ private:
 
   // --- Histograms
   MonitorElement* meHitOccupancy_;
+  MonitorElement* meHitOccupancyCell_;
+  MonitorElement* meHitOccupancySM_;
   static constexpr int nRU_ = 6;
-  MonitorElement* meHitOccupancyRUSlice_[nRU_];
+  MonitorElement* meHitOccupancyCellRUSlice_[nRU_];
+  MonitorElement* meHitOccupancySMRUSlice_[nRU_];
 };
 
 // ------------ constructor and destructor --------------
@@ -53,52 +56,89 @@ void BtlSimHitsHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter&
   // --- Get the monitoring histograms
   MonitorElement* meBtlHitLogEnergy = igetter.get(folder_ + "BtlHitLogEnergy");
   MonitorElement* meNevents = igetter.get(folder_ + "BtlNevents");
-  MonitorElement* meBtlHitLogEnergyRUSlice[nRU_];
+  MonitorElement* meBtlHitMultCell = igetter.get(folder_ + "BtlHitMultCell");
+  MonitorElement* meBtlHitMultCellRUSlice[nRU_];
+  MonitorElement* meBtlHitMultSM = igetter.get(folder_ + "BtlHitMultSM");
+  MonitorElement* meBtlHitMultSMRUSlice[nRU_];
   bool missing_ru_slice = false;
-  for(unsigned int ihistoRU = 0; ihistoRU < nRU_; ++ihistoRU) {
-    meBtlHitLogEnergyRUSlice[ihistoRU] = igetter.get(folder_ + "BtlHitLogEnergyRUSlice_" + std::to_string(ihistoRU + 1));
-    if(!meBtlHitLogEnergyRUSlice[ihistoRU]){
+  for (unsigned int ihistoRU = 0; ihistoRU < nRU_; ++ihistoRU) {
+    meBtlHitMultCellRUSlice[ihistoRU] = igetter.get(folder_ + "BtlHitMultCellRUSlice" + std::to_string(ihistoRU));
+    meBtlHitMultSMRUSlice[ihistoRU] = igetter.get(folder_ + "BtlHitMultSMRUSlice" + std::to_string(ihistoRU));
+    if (!meBtlHitMultCellRUSlice[ihistoRU] || !meBtlHitMultSMRUSlice[ihistoRU]) {
       missing_ru_slice = true;
     }
   }
-  if (!meBtlHitLogEnergy || !meNevents || missing_ru_slice) {
+  if (!meBtlHitLogEnergy || !meNevents || !meBtlHitMultCell || missing_ru_slice || !meBtlHitMultSM) {
     edm::LogError("BtlSimHitsHarvester") << "Monitoring histograms not found!" << std::endl;
     return;
   }
 
   // --- Get the number of BTL crystals and the number of processed events
   const float NBtlCrystals = BTLDetId::kCrystalsBTL;
+  const float NBtlSMs = NBtlCrystals / BTLDetId::kCrystalsPerModuleV2;
   const float Nevents = meNevents->getEntries();
-  const float scale = (Nevents > 0 ? 1. / (Nevents * NBtlCrystals) : 1.);
+  const float scale_Crystals = (Nevents > 0 ? 1. / (Nevents * NBtlCrystals) : 1.);
+  const float scale_Crystals_RU = (Nevents > 0 ? 1. / (Nevents * NBtlCrystals / nRU_) : 1.);
+  const float scale_SMs = (Nevents > 0 ? 1. / (Nevents * NBtlSMs) : 1.);
+  const float scale_SMs_RU = (Nevents > 0 ? 1. / (Nevents * NBtlSMs / nRU_) : 1.);
 
-  // --- Book the cumulative histogram
+  // --- Book histograms
   ibook.cd(folder_);
   meHitOccupancy_ = ibook.book1D("BtlHitOccupancy",
                                  "BTL cell occupancy vs hit energy;log_{10}(E_{SIM} [MeV]); Occupancy per event",
                                  meBtlHitLogEnergy->getNbinsX(),
                                  meBtlHitLogEnergy->getTH1()->GetXaxis()->GetXmin(),
                                  meBtlHitLogEnergy->getTH1()->GetXaxis()->GetXmax());
+  meHitOccupancyCell_ = ibook.book1D("BtlHitOccupancyCell",
+                                     "BTL cell occupancy vs energy threshold;log_{10}(E_{th} [MeV]); Occupancy per event",
+                                     meBtlHitMultCell->getNbinsX(),
+                                     meBtlHitMultCell->getTH1()->GetXaxis()->GetXmin(),
+                                     meBtlHitMultCell->getTH1()->GetXaxis()->GetXmax());
+  meHitOccupancySM_ = ibook.book1D("BtlHitOccupancySM",
+                                   "BTL SM occupancy vs energy threshold;log_{10}(E_{th} [MeV]); Occupancy per event",
+                                   meBtlHitMultSM->getNbinsX(),
+                                   meBtlHitMultSM->getTH1()->GetXaxis()->GetXmin(),
+                                   meBtlHitMultSM->getTH1()->GetXaxis()->GetXmax());
   for(unsigned int ihistoRU = 0; ihistoRU < nRU_; ++ihistoRU) {
-    std::string name = "BtlHitOccupancyRUSlice" + std::to_string(ihistoRU + 1);
-    std::string title = "BTL cell occupancy vs hit energy (RU " + std::to_string(ihistoRU + 1) + ");log_{10}(E_{SIM} [MeV]); Occupancy per event";
-    meHitOccupancyRUSlice_[ihistoRU] = ibook.book1D(name,
-                                                    title,
-                                                    meBtlHitLogEnergyRUSlice[ihistoRU]->getNbinsX(),
-                                                    meBtlHitLogEnergyRUSlice[ihistoRU]->getTH1()->GetXaxis()->GetXmin(),
-                                                    meBtlHitLogEnergyRUSlice[ihistoRU]->getTH1()->GetXaxis()->GetXmax());
-    }
+    std::string name_cell = "BtlHitOccupancyRUSlice" + std::to_string(ihistoRU);
+    std::string title_cell = "BTL cell occupancy vs energy threshold (RU " + std::to_string(ihistoRU) + ");log_{10}(E_{th} [MeV]); Occupancy per event";
+    meHitOccupancyCellRUSlice_[ihistoRU] = ibook.book1D(name_cell,
+                                                    title_cell,
+                                                    meBtlHitMultCellRUSlice[ihistoRU]->getNbinsX(),
+                                                    meBtlHitMultCellRUSlice[ihistoRU]->getTH1()->GetXaxis()->GetXmin(),
+                                                    meBtlHitMultCellRUSlice[ihistoRU]->getTH1()->GetXaxis()->GetXmax());
+    std::string name_SM = "BtlHitOccupancySMRUSlice" + std::to_string(ihistoRU);
+    std::string title_SM = "BTL SM occupancy vs energy threshold(RU " + std::to_string(ihistoRU) + ");log_{10}(E_{th} [MeV]); Occupancy per event";
+    meHitOccupancySMRUSlice_[ihistoRU] = ibook.book1D(name_SM,
+                                                      title_SM,
+                                                      meBtlHitMultSMRUSlice[ihistoRU]->getNbinsX(),
+                                                      meBtlHitMultSMRUSlice[ihistoRU]->getTH1()->GetXaxis()->GetXmin(),
+                                                      meBtlHitMultSMRUSlice[ihistoRU]->getTH1()->GetXaxis()->GetXmax());
+  }
 
   // --- Calculate the cumulative histogram
   double bin_sum = meBtlHitLogEnergy->getBinContent(meBtlHitLogEnergy->getNbinsX() + 1);
   for (int ibin = meBtlHitLogEnergy->getNbinsX(); ibin >= 1; --ibin) {
     bin_sum += meBtlHitLogEnergy->getBinContent(ibin);
-    meHitOccupancy_->setBinContent(ibin, scale * bin_sum);
+    meHitOccupancy_->setBinContent(ibin, scale_Crystals * bin_sum);
+  }
+  // --- Calculate the occupancy histograms
+  for (int ibin = 0; ibin < meBtlHitMultCell->getNbinsX(); ibin++) {
+    double bin_content = meBtlHitMultCell->getBinContent(ibin);
+    meHitOccupancyCell_->setBinContent(ibin, bin_content * scale_Crystals);
+  }
+  for (int ibin = 0; ibin < meBtlHitMultSM->getNbinsX(); ibin++) {
+    double bin_content = meBtlHitMultSM->getBinContent(ibin);
+    meHitOccupancySM_->setBinContent(ibin, bin_content * scale_SMs);
   }
   for(unsigned int ihistoRU = 0; ihistoRU < nRU_; ++ihistoRU) {
-    double bin_sum_RUSlice = meBtlHitLogEnergyRUSlice[ihistoRU]->getBinContent(meBtlHitLogEnergyRUSlice[ihistoRU]->getNbinsX() + 1);
-    for (int ibin = meBtlHitLogEnergyRUSlice[ihistoRU]->getNbinsX(); ibin >= 1; --ibin) {
-      bin_sum_RUSlice += meBtlHitLogEnergyRUSlice[ihistoRU]->getBinContent(ibin);
-      meHitOccupancyRUSlice_[ihistoRU]->setBinContent(ibin, scale * bin_sum_RUSlice);
+    for (int ibin = 0; ibin < meBtlHitMultCellRUSlice[ihistoRU]->getNbinsX(); ibin ++) {
+      double bin_content_RUSlice = meBtlHitMultCellRUSlice[ihistoRU]->getBinContent(ibin);
+      meHitOccupancyCellRUSlice_[ihistoRU]->setBinContent(ibin, bin_content_RUSlice * scale_Crystals_RU);
+    }
+    for (int ibin = 0; ibin < meBtlHitMultSMRUSlice[ihistoRU]->getNbinsX(); ibin++) {
+      double bin_content_RUSlice = meBtlHitMultSMRUSlice[ihistoRU]->getBinContent(ibin);
+      meHitOccupancySMRUSlice_[ihistoRU]->setBinContent(ibin, bin_content_RUSlice * scale_SMs_RU);
     }
   }
 }

--- a/Validation/MtdValidation/plugins/BtlSimHitsHarvester.cc
+++ b/Validation/MtdValidation/plugins/BtlSimHitsHarvester.cc
@@ -69,9 +69,10 @@ void BtlSimHitsHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter&
     meBtlHitMultSMRUSlice[ihistoRU] = igetter.get(folder_ + "BtlHitMultSMRUSlice" + std::to_string(ihistoRU));
     if (!meBtlHitLogEnergyRUSlice[ihistoRU] || !meBtlHitMultCellRUSlice[ihistoRU] || !meBtlHitMultSMRUSlice[ihistoRU]) {
       missing_ru_slice = true;
+      edm::LogInfo("BtlSimHitsHarvester") << "Monitoring histograms per RUSlice in optional plots!" << std::endl;
     }
   }
-  if (!meBtlHitLogEnergy || !meNevents || !meBtlHitMultCell || missing_ru_slice || !meBtlHitMultSM) {
+  if (!meBtlHitLogEnergy || !meNevents || !meBtlHitMultCell || !meBtlHitMultSM) {
     edm::LogError("BtlSimHitsHarvester") << "Monitoring histograms not found!" << std::endl;
     return;
   }
@@ -92,38 +93,47 @@ void BtlSimHitsHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter&
                                  meBtlHitLogEnergy->getNbinsX(),
                                  meBtlHitLogEnergy->getTH1()->GetXaxis()->GetXmin(),
                                  meBtlHitLogEnergy->getTH1()->GetXaxis()->GetXmax());
-  meHitOccupancyCell_ = ibook.book1D("BtlHitOccupancyCell",
-                                     "BTL cell occupancy vs energy threshold;log_{10}(E_{th} [MeV]); Occupancy per event",
-                                     meBtlHitMultCell->getNbinsX(),
-                                     meBtlHitMultCell->getTH1()->GetXaxis()->GetXmin(),
-                                     meBtlHitMultCell->getTH1()->GetXaxis()->GetXmax());
+  meHitOccupancyCell_ =
+      ibook.book1D("BtlHitOccupancyCell",
+                   "BTL cell occupancy vs energy threshold;log_{10}(E_{th} [MeV]); Occupancy per event",
+                   meBtlHitMultCell->getNbinsX(),
+                   meBtlHitMultCell->getTH1()->GetXaxis()->GetXmin(),
+                   meBtlHitMultCell->getTH1()->GetXaxis()->GetXmax());
   meHitOccupancySM_ = ibook.book1D("BtlHitOccupancySM",
                                    "BTL SM occupancy vs energy threshold;log_{10}(E_{th} [MeV]); Occupancy per event",
                                    meBtlHitMultSM->getNbinsX(),
                                    meBtlHitMultSM->getTH1()->GetXaxis()->GetXmin(),
                                    meBtlHitMultSM->getTH1()->GetXaxis()->GetXmax());
-  for(unsigned int ihistoRU = 0; ihistoRU < nRU_; ++ihistoRU) {
-    std::string name_LogEnergy = "BtlHitOccupancyRUSlice" + std::to_string(ihistoRU);
-    std::string title_LogEnergy = "BTL cell occupancy vs hit energy (RU " + std::to_string(ihistoRU) + ");log_{10}(E_{SIM} [MeV]); Occupancy per event";
-    meHitOccupancyRUSlice_[ihistoRU] = ibook.book1D(name_LogEnergy,
-                                                    title_LogEnergy,
-                                                    meBtlHitLogEnergyRUSlice[ihistoRU]->getNbinsX(),
-                                                    meBtlHitLogEnergyRUSlice[ihistoRU]->getTH1()->GetXaxis()->GetXmin(),
-                                                    meBtlHitLogEnergyRUSlice[ihistoRU]->getTH1()->GetXaxis()->GetXmax());
-    std::string name_cell = "BtlHitOccupancyCellRUSlice" + std::to_string(ihistoRU);
-    std::string title_cell = "BTL cell occupancy vs energy threshold (RU " + std::to_string(ihistoRU) + ");log_{10}(E_{th} [MeV]); Occupancy per event";
-    meHitOccupancyCellRUSlice_[ihistoRU] = ibook.book1D(name_cell,
-                                                    title_cell,
-                                                    meBtlHitMultCellRUSlice[ihistoRU]->getNbinsX(),
-                                                    meBtlHitMultCellRUSlice[ihistoRU]->getTH1()->GetXaxis()->GetXmin(),
-                                                    meBtlHitMultCellRUSlice[ihistoRU]->getTH1()->GetXaxis()->GetXmax());
-    std::string name_SM = "BtlHitOccupancySMRUSlice" + std::to_string(ihistoRU);
-    std::string title_SM = "BTL SM occupancy vs energy threshold (RU " + std::to_string(ihistoRU) + ");log_{10}(E_{th} [MeV]); Occupancy per event";
-    meHitOccupancySMRUSlice_[ihistoRU] = ibook.book1D(name_SM,
-                                                      title_SM,
-                                                      meBtlHitMultSMRUSlice[ihistoRU]->getNbinsX(),
-                                                      meBtlHitMultSMRUSlice[ihistoRU]->getTH1()->GetXaxis()->GetXmin(),
-                                                      meBtlHitMultSMRUSlice[ihistoRU]->getTH1()->GetXaxis()->GetXmax());
+  if (!missing_ru_slice) {
+    for (unsigned int ihistoRU = 0; ihistoRU < nRU_; ++ihistoRU) {
+      std::string name_LogEnergy = "BtlHitOccupancyRUSlice" + std::to_string(ihistoRU);
+      std::string title_LogEnergy = "BTL cell occupancy vs hit energy (RU " + std::to_string(ihistoRU) +
+                                    ");log_{10}(E_{SIM} [MeV]); Occupancy per event";
+      meHitOccupancyRUSlice_[ihistoRU] =
+          ibook.book1D(name_LogEnergy,
+                       title_LogEnergy,
+                       meBtlHitLogEnergyRUSlice[ihistoRU]->getNbinsX(),
+                       meBtlHitLogEnergyRUSlice[ihistoRU]->getTH1()->GetXaxis()->GetXmin(),
+                       meBtlHitLogEnergyRUSlice[ihistoRU]->getTH1()->GetXaxis()->GetXmax());
+      std::string name_cell = "BtlHitOccupancyCellRUSlice" + std::to_string(ihistoRU);
+      std::string title_cell = "BTL cell occupancy vs energy threshold (RU " + std::to_string(ihistoRU) +
+                               ");log_{10}(E_{th} [MeV]); Occupancy per event";
+      meHitOccupancyCellRUSlice_[ihistoRU] =
+          ibook.book1D(name_cell,
+                       title_cell,
+                       meBtlHitMultCellRUSlice[ihistoRU]->getNbinsX(),
+                       meBtlHitMultCellRUSlice[ihistoRU]->getTH1()->GetXaxis()->GetXmin(),
+                       meBtlHitMultCellRUSlice[ihistoRU]->getTH1()->GetXaxis()->GetXmax());
+      std::string name_SM = "BtlHitOccupancySMRUSlice" + std::to_string(ihistoRU);
+      std::string title_SM = "BTL SM occupancy vs energy threshold (RU " + std::to_string(ihistoRU) +
+                             ");log_{10}(E_{th} [MeV]); Occupancy per event";
+      meHitOccupancySMRUSlice_[ihistoRU] =
+          ibook.book1D(name_SM,
+                       title_SM,
+                       meBtlHitMultSMRUSlice[ihistoRU]->getNbinsX(),
+                       meBtlHitMultSMRUSlice[ihistoRU]->getTH1()->GetXaxis()->GetXmin(),
+                       meBtlHitMultSMRUSlice[ihistoRU]->getTH1()->GetXaxis()->GetXmax());
+    }
   }
 
   // --- Calculate the cumulative histograms
@@ -132,13 +142,17 @@ void BtlSimHitsHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter&
     bin_sum += meBtlHitLogEnergy->getBinContent(ibin);
     meHitOccupancy_->setBinContent(ibin, scale_Crystals * bin_sum);
   }
-  for(unsigned int ihistoRU = 0; ihistoRU < nRU_; ++ihistoRU) {
-    double bin_sum_RUSlice = meBtlHitLogEnergyRUSlice[ihistoRU]->getBinContent(meBtlHitLogEnergyRUSlice[ihistoRU]->getNbinsX() + 1);
-    for (int ibin = meBtlHitLogEnergyRUSlice[ihistoRU]->getNbinsX(); ibin >= 1; --ibin) {
-      bin_sum_RUSlice += meBtlHitLogEnergyRUSlice[ihistoRU]->getBinContent(ibin);
-      meHitOccupancyRUSlice_[ihistoRU]->setBinContent(ibin, scale_Crystals_RU * bin_sum_RUSlice);
+  if (!missing_ru_slice) {
+    for (unsigned int ihistoRU = 0; ihistoRU < nRU_; ++ihistoRU) {
+      double bin_sum_RUSlice =
+          meBtlHitLogEnergyRUSlice[ihistoRU]->getBinContent(meBtlHitLogEnergyRUSlice[ihistoRU]->getNbinsX() + 1);
+      for (int ibin = meBtlHitLogEnergyRUSlice[ihistoRU]->getNbinsX(); ibin >= 1; --ibin) {
+        bin_sum_RUSlice += meBtlHitLogEnergyRUSlice[ihistoRU]->getBinContent(ibin);
+        meHitOccupancyRUSlice_[ihistoRU]->setBinContent(ibin, scale_Crystals_RU * bin_sum_RUSlice);
+      }
     }
   }
+
   // --- Calculate the occupancy histograms
   for (int ibin = 0; ibin < meBtlHitMultCell->getNbinsX(); ibin++) {
     double bin_content = meBtlHitMultCell->getBinContent(ibin);
@@ -148,14 +162,16 @@ void BtlSimHitsHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter&
     double bin_content = meBtlHitMultSM->getBinContent(ibin);
     meHitOccupancySM_->setBinContent(ibin, bin_content * scale_SMs);
   }
-  for(unsigned int ihistoRU = 0; ihistoRU < nRU_; ++ihistoRU) {
-    for (int ibin = 0; ibin < meBtlHitMultCellRUSlice[ihistoRU]->getNbinsX(); ibin ++) {
-      double bin_content_RUSlice = meBtlHitMultCellRUSlice[ihistoRU]->getBinContent(ibin);
-      meHitOccupancyCellRUSlice_[ihistoRU]->setBinContent(ibin, bin_content_RUSlice * scale_Crystals_RU);
-    }
-    for (int ibin = 0; ibin < meBtlHitMultSMRUSlice[ihistoRU]->getNbinsX(); ibin++) {
-      double bin_content_RUSlice = meBtlHitMultSMRUSlice[ihistoRU]->getBinContent(ibin);
-      meHitOccupancySMRUSlice_[ihistoRU]->setBinContent(ibin, bin_content_RUSlice * scale_SMs_RU);
+  if (!missing_ru_slice) {
+    for (unsigned int ihistoRU = 0; ihistoRU < nRU_; ++ihistoRU) {
+      for (int ibin = 0; ibin < meBtlHitMultCellRUSlice[ihistoRU]->getNbinsX(); ibin++) {
+        double bin_content_RUSlice = meBtlHitMultCellRUSlice[ihistoRU]->getBinContent(ibin);
+        meHitOccupancyCellRUSlice_[ihistoRU]->setBinContent(ibin, bin_content_RUSlice * scale_Crystals_RU);
+      }
+      for (int ibin = 0; ibin < meBtlHitMultSMRUSlice[ihistoRU]->getNbinsX(); ibin++) {
+        double bin_content_RUSlice = meBtlHitMultSMRUSlice[ihistoRU]->getBinContent(ibin);
+        meHitOccupancySMRUSlice_[ihistoRU]->setBinContent(ibin, bin_content_RUSlice * scale_SMs_RU);
+      }
     }
   }
 }

--- a/Validation/MtdValidation/plugins/BtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlSimHitsValidation.cc
@@ -75,11 +75,12 @@ private:
   MonitorElement* meHitEnergy_;
 
   static constexpr int nRU_ = 6;
-  static constexpr double logE_min = -3;
+  static constexpr double logE_min = -2;
   static constexpr double logE_max = 2;
   static constexpr double n_bin_logE = 100;
 
   MonitorElement* meHitLogEnergy_;
+  MonitorElement* meHitLogEnergyRUSlice_[nRU_];
   MonitorElement* meHitMultCell_;
   MonitorElement* meHitMultCellRUSlice_[nRU_];
   MonitorElement* meHitMultSM_;
@@ -226,6 +227,8 @@ void BtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
     // --- Build a global Sensor Module Id by combining the phi-eta indices
     uint64_t globalSMId = ((uint64_t)SMIndex.first << 32) | SMIndex.second;
     modules[globalSMId].push_back(cell);
+
+    meHitLogEnergyRUSlice_[detId.globalRunit()-1]->Fill(log10(ene_tot_cell));
 
     // --- Skip cells with a total anergy less than hitMinEnergy_
     if (ene_tot_cell < hitMinEnergy_) {
@@ -425,6 +428,9 @@ void BtlSimHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
   meHitMultCellperSMvsE_ = ibook.bookProfile("BtlHitMultCellperSMvsE", "BTL cell per SM vs energy threshold;log_{10}(E_{th} [MeV]); cells per SM", n_bin_logE, logE_min, logE_max, 0, 16);
 
   for (unsigned int ihistoRU = 0; ihistoRU < nRU_; ++ihistoRU) {
+    std::string name_LogEnergy = "BtlHitLogEnergyRUSlice" + std::to_string(ihistoRU);
+    std::string title_LogEnergy = "BTL SIM hits energy (RU " + std::to_string(ihistoRU) +");log_{10}(E_{SIM} [MeV])";
+    meHitLogEnergyRUSlice_[ihistoRU] = ibook.book1D(name_LogEnergy, title_LogEnergy, 200, -6., 3.);
     std::string name_Cell = "BtlHitMultCellRUSlice" + std::to_string(ihistoRU);
     std::string title_Cell = "BTL cell multiplicity vs energy threshold (RU " + std::to_string(ihistoRU) +");log_{10}(E_{th} [MeV])";
     meHitMultCellRUSlice_[ihistoRU] = ibook.book1D(name_Cell, title_Cell, n_bin_logE, logE_min, logE_max);

--- a/Validation/MtdValidation/plugins/BtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlSimHitsValidation.cc
@@ -74,10 +74,10 @@ private:
 
   MonitorElement* meHitEnergy_;
 
-  static constexpr int nRU_ = 6;
+  static constexpr int nRU_ = BTLDetId::kRUPerRod;
   static constexpr double logE_min = -2;
   static constexpr double logE_max = 2;
-  static constexpr double n_bin_logE = 100;
+  static constexpr double n_bin_logE = 50;
 
   MonitorElement* meHitLogEnergy_;
   MonitorElement* meHitLogEnergyRUSlice_[nRU_];
@@ -228,7 +228,7 @@ void BtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
     uint64_t globalSMId = ((uint64_t)SMIndex.first << 32) | SMIndex.second;
     modules[globalSMId].push_back(cell);
 
-    meHitLogEnergyRUSlice_[detId.globalRunit()-1]->Fill(log10(ene_tot_cell));
+    meHitLogEnergyRUSlice_[detId.runit()-1]->Fill(log10(ene_tot_cell));
 
     // --- Skip cells with a total anergy less than hitMinEnergy_
     if (ene_tot_cell < hitMinEnergy_) {
@@ -388,7 +388,7 @@ void BtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
           ene_tot_cell += hit.second.energy;
         }
         BTLDetId detId(cell.first);
-        SM_globalRunit = detId.globalRunit()-1;
+        SM_globalRunit = detId.runit()-1;
         if (log10(ene_tot_cell) > th_logE) {
           SM_bool = true;
           crystal_count++;

--- a/Validation/MtdValidation/plugins/BtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlSimHitsValidation.cc
@@ -163,7 +163,7 @@ void BtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
   std::unordered_map<uint32_t, std::unordered_map<uint64_t, MTDHit>> m_btlHitsPerCell;
 
   // --- Group cells by sensor module
-  std::unordered_map<uint64_t, std::vector<std::pair<uint32_t, std::unordered_map<uint64_t, MTDHit>>>>
+  std::unordered_map<uint32_t, std::vector<std::pair<uint32_t, std::unordered_map<uint64_t, MTDHit>>>>
       modules;  // module Id and vector of cells
 
   // --- Loop over the BLT SIM hits and accumulate the hits with the same track ID in each cell

--- a/Validation/MtdValidation/plugins/BtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlSimHitsValidation.cc
@@ -223,13 +223,10 @@ void BtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
 
     meHitLogEnergy_->Fill(log10(ene_tot_cell));
 
-    // --- Groups cells with hits by sensor module using the phi and eta indices obtained from topology.btlIndex()
+    // --- Groups cells with hits by sensor module using MTDTopology
     BTLDetId detId(cell.first);
     DetId geoId = detId.geographicalId(MTDTopologyMode::crysLayoutFromTopoMode(topology->getMTDTopologyMode()));
-    std::pair<uint32_t, uint32_t> SMIndex = topology->btlIndex(geoId.rawId());  // Get phi-eta index
-    // --- Build a global Sensor Module Id by combining the phi-eta indices
-    uint64_t globalSMId = ((uint64_t)SMIndex.first << 32) | SMIndex.second;
-    modules[globalSMId].push_back(cell);
+    modules[geoId.rawId()].push_back(cell);
 
     if (optionalPlots_)
       meHitLogEnergyRUSlice_[detId.runit() - 1]->Fill(log10(ene_tot_cell));

--- a/Validation/MtdValidation/test/mtdValidation_cfg.py
+++ b/Validation/MtdValidation/test/mtdValidation_cfg.py
@@ -56,6 +56,7 @@ process.load("Validation.MtdValidation.mtdTracksValid_cfi")
 process.load("Validation.MtdValidation.mtdEleIsoValid_cfi")
 process.load("Validation.MtdValidation.vertices4DValid_cff")
 
+# process.btlSimHitsValid.optionalPlots = True
 # process.btlDigiHitsValid.optionalPlots = True
 # process.etlDigiHitsValid.optionalPlots = True
 # process.btlLocalRecoValid.optionalPlots = True

--- a/Validation/MtdValidation/test/mtdValidation_cfg.py
+++ b/Validation/MtdValidation/test/mtdValidation_cfg.py
@@ -8,11 +8,22 @@ process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.load('Configuration.EventContent.EventContent_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
-process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi') # No pileup
 
 process.load("Configuration.Geometry.GeometryExtendedRun4D110Reco_cff")
 process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+# For playback pileup mode
+# process.load('SimGeneral.MixingModule.mix_POISSON_average_cfi')
+# process.load('Configuration.StandardSequences.Services_cff')
+# Other statements
+# process.mix.input.nbPileupEvents.averageNumber = cms.double(200.000000)
+# process.mix.bunchspace = cms.int32(25)
+# process.mix.minBunch = cms.int32(-3)
+# process.mix.maxBunch = cms.int32(3)
+# process.mix.input.fileNames = cms.untracked.vstring([]) # MinBias, from step3 confif file
+
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T33', '')
 process.load('RecoLocalFastTime.FTLClusterizer.MTDCPEESProducer_cfi')
@@ -35,6 +46,10 @@ process.source = cms.Source("PoolSource",
         'file:step3.root'
     )
 )
+
+# For playback pileup mode
+# process.RandomNumberGeneratorService.restoreStateLabel=cms.untracked.string("randomEngineStateProducer")
+# process.mix.playback = True
 
 process.mix.digitizers = cms.PSet()
 for a in process.aliases: delattr(process, a)


### PR DESCRIPTION
PR description:
This PR extends SimHits and Local Reco Validation to study cell and SM occupancy with the most recent BTL geometry (changed wrt TDR studies). A documentation for this PR can be found at the Indico page https://indico.cern.ch/event/1527057/#5-update-on-btl-occupancy.
Furthermore, in mtdValidation_cfg.py, some commented lines for playback pileup mode were added.

PR validation:
The updated validation code has been tested in the CMSSW_15_1_0_pre1 release with the SingleMuPt10 and TTbar_PU200 workflows.


