### PR TITLE
Add new line before Nano Comparison header

### DIFF
--- a/PhysicsTools/NanoAOD/test/compare_sizes_json.py
+++ b/PhysicsTools/NanoAOD/test/compare_sizes_json.py
@@ -55,6 +55,7 @@ for job in options.job:
             rmem_ref = 0
 
         if first and options.header:
+            print("\n")
             prow(headers)
             if options.fmt == "md": prow("---" for x in headers)
             first = False


### PR DESCRIPTION
#### PR description:

Fixes a bug when a new NanoAOD workflow is added. There is no extra line between the ERROR reports and the size comparison. This breaks the Markdown formatting.

Example:
![image](https://github.com/user-attachments/assets/b97584bb-ea99-4365-81c0-b273e30e43b8)



#### PR validation:

Will try to validate with the automated tests.
