### PR TITLE
[15_0_X, backport of #48104] NanoAODv15-Lite setup for Run2UL and 2022/2023

### DIFF
--- a/Configuration/ProcessModifiers/python/nanoAOD_rePuppi_cff.py
+++ b/Configuration/ProcessModifiers/python/nanoAOD_rePuppi_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+nanoAOD_rePuppi = cms.Modifier()

--- a/PhysicsTools/NanoAOD/python/boostedTaus_cff.py
+++ b/PhysicsTools/NanoAOD/python/boostedTaus_cff.py
@@ -12,10 +12,6 @@ finalBoostedTaus = cms.EDFilter("PATTauRefSelector",
     src = cms.InputTag("slimmedTausBoosted"),
     cut = cms.string("pt > 25 && tauID('decayModeFindingNewDMs') && (tauID('byVVLooseIsolationMVArun2DBoldDMwLT') || tauID('byVVLooseIsolationMVArun2DBnewDMwLT') || tauID('byBoostedDeepTau20161718v2p0VSjetraw') > {})".format(0.82))
 )
-run2_nanoAOD_106Xv2.toModify(
-    finalBoostedTaus,
-    cut = "pt > 25 && tauID('decayModeFindingNewDMs') && (tauID('byVVLooseIsolationMVArun2DBoldDMwLT') || tauID('byVVLooseIsolationMVArun2DBoldDMdR0p3wLT') || tauID('byVVLooseIsolationMVArun2DBnewDMwLT') || tauID('byBoostedDeepTau20161718v2p0VSjetraw') > {})".format(0.82)
-)
 
 boostedTauTable = simplePATTauFlatTableProducer.clone(
     src = cms.InputTag("linkedObjects", "boostedTaus"),
@@ -70,17 +66,6 @@ boostedTauTable.variables = cms.PSet(
     _boostedTauVarsMVAIso,
     _boostedTauVarsAntiEleMVA,
     _boostedDeepTauRunIIv2p0Vars
-)
-_boostedTauVarsWithDr03 = cms.PSet(
-    _boostedTauVarsBase,
-    _boostedTauVarsMVAIso,
-    _boostedTauVarsMVAIsoDr03,
-    _boostedTauVarsAntiEleMVA,
-    _boostedDeepTauRunIIv2p0Vars
-)
-run2_nanoAOD_106Xv2.toModify(
-    boostedTauTable,
-    variables = _boostedTauVarsWithDr03
 )
 
 boostedTausMCMatchLepTauForTable = tausMCMatchLepTauForTable.clone(

--- a/PhysicsTools/NanoAOD/python/custom_btv_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_btv_cff.py
@@ -65,8 +65,10 @@ def update_jets_AK4(process):
     process.updatedPatJetsTransientCorrectedPuppiWithDeepInfo.tagInfoSources.append(cms.InputTag("pfUnifiedParticleTransformerAK4TagInfosPuppiWithDeepInfo"))
     process.updatedPatJetsTransientCorrectedPuppiWithDeepInfo.addTagInfos = cms.bool(True)
 
-    
-    
+    # Fix ParticleNetFromMiniAOD input when slimmedTaus is updated
+    from PhysicsTools.NanoAOD.nano_cff import _fixPNetInputCollection
+    _fixPNetInputCollection(process)
+
     return process
 
 def update_jets_AK8(process):

--- a/PhysicsTools/NanoAOD/python/custom_jme_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_jme_cff.py
@@ -1392,10 +1392,6 @@ def RecomputePuppiWeightsMETAK8(proc):
     )
   )
 
-  run3_nanoAOD_pre142X.toModify(btagDiscriminatorsAK8Subjets,
-    names = cms.vstring('pfDeepCSVJetTags:probb','pfDeepCSVJetTags:probbb')
-  )
-
   from PhysicsTools.PatAlgos.tools.puppiJetMETReclusteringFromMiniAOD_cff import setupPuppiAK4AK8METReclustering
   proc = setupPuppiAK4AK8METReclustering(proc, runOnMC=runOnMC, useExistingWeights=False,
     reclusterAK4MET=False, # Already setup to recluster AK4 Puppi jets and PuppiMET

--- a/PhysicsTools/NanoAOD/python/custom_jme_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_jme_cff.py
@@ -1510,6 +1510,12 @@ def PrepJMECustomNanoAOD(process):
   )
 
   ###########################################################################
+  # Fix ParticleNetFromMiniAOD input when slimmedTaus is updated
+  ###########################################################################
+  from PhysicsTools.NanoAOD.nano_cff import _fixPNetInputCollection
+  _fixPNetInputCollection(process)
+
+  ###########################################################################
   # Save Maximum of Pt Hat Max
   ###########################################################################
   if runOnMC:

--- a/PhysicsTools/NanoAOD/python/electrons_cff.py
+++ b/PhysicsTools/NanoAOD/python/electrons_cff.py
@@ -540,5 +540,5 @@ _electronTask_Run2.add(calibratedPatElectronsNano)
 run2_egamma.toReplaceWith(electronTask, _electronTask_Run2)
 
 # Revert back to AK4 CHS jets for Run2 inputs
-run2_nanoAOD_ANY.toModify(
+run2_egamma.toModify(
     ptRatioRelForEle,srcJet="updatedJets")

--- a/PhysicsTools/NanoAOD/python/jetsAK4_CHS_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_CHS_cff.py
@@ -498,6 +498,7 @@ jetForMETTask =  cms.Task(basicJetsForMetForT1METNano,corrT1METJetTable)
 jetUserDataTask = cms.Task(bJetVars,qgtagger,jercVars,pileupJetIdNano)
 
 #before cross linking
+chsJetUpdateTask = cms.Task(jetCorrFactorsNano,updatedJets)
 jetTask = cms.Task(jetCorrFactorsNano,updatedJets,jetUserDataTask,updatedJetsWithUserData,finalJets)
 
 #after cross linkining

--- a/PhysicsTools/NanoAOD/python/jetsAK4_CHS_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_CHS_cff.py
@@ -366,14 +366,18 @@ def nanoAOD_addDeepInfoAK4CHS(process,addDeepBTag,addDeepFlavour,addParticleNet,
     print("Will recalculate the following discriminators: "+", ".join(_btagDiscriminators))
     updateJetCollection(
         process,
-        jetSource = cms.InputTag('slimmedJets'),
+        jetSource = cms.InputTag('slimmedJets', processName=cms.InputTag.skipCurrentProcess()),
         jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute','L2L3Residual']), 'None'),
         btagDiscriminators = _btagDiscriminators,
         postfix = 'WithDeepInfo',
     )
     process.load("Configuration.StandardSequences.MagneticField_cff")
-    process.jetCorrFactorsNano.src="selectedUpdatedPatJetsWithDeepInfo"
-    process.updatedJets.jetSource="selectedUpdatedPatJetsWithDeepInfo"
+
+    from PhysicsTools.PatAlgos.tools.helpers import getPatAlgosToolsTask, addToProcessAndTask
+    task = getPatAlgosToolsTask(process)
+    addToProcessAndTask("slimmedJets", process.selectedUpdatedPatJetsWithDeepInfo.clone(), process, task)
+    del process.selectedUpdatedPatJetsWithDeepInfo
+
     return process
 
 nanoAOD_addDeepInfoAK4CHS_switch = cms.PSet(

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -116,12 +116,6 @@ jetPuppiTable = simplePATJetFlatTableProducer.clone(
     )
 )
 
-run3_nanoAOD_pre142X.toModify(
-    jetPuppiTable.variables,
-    puIdDisc = None,
-)
-
-
 #jets are not as precise as muons
 jetPuppiTable.variables.pt.precision=10
 

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -26,7 +26,6 @@ updatedJetsPuppi = updatedPatJets.clone(
     jetCorrFactorsSource=cms.VInputTag(cms.InputTag("jetPuppiCorrFactorsNano") ),
 )
 
-
 #HF shower shape recomputation
 from RecoJets.JetProducers.hfJetShowerShape_cfi import hfJetShowerShape
 hfJetPuppiShowerShapeforNanoAOD = hfJetShowerShape.clone(jets="updatedJetsPuppi",vertices="offlineSlimmedPrimaryVertices")
@@ -147,14 +146,18 @@ def nanoAOD_addDeepInfoAK4(process,addParticleNet,addRobustParTAK4=False,addUnif
     print("Will recalculate the following discriminators: "+", ".join(_btagDiscriminators))
     updateJetCollection(
         process,
-        jetSource = cms.InputTag('slimmedJetsPuppi'),
+        jetSource = cms.InputTag('slimmedJetsPuppi', processName=cms.InputTag.skipCurrentProcess()),
         jetCorrections = ('AK4PFPuppi', cms.vstring(['L2Relative', 'L3Absolute']), 'None'),
         btagDiscriminators = _btagDiscriminators,
         postfix = 'PuppiWithDeepInfo',
     )
     process.load("Configuration.StandardSequences.MagneticField_cff")
-    process.jetPuppiCorrFactorsNano.src = "selectedUpdatedPatJetsPuppiWithDeepInfo"
-    process.updatedJetsPuppi.jetSource = "selectedUpdatedPatJetsPuppiWithDeepInfo"
+
+    from PhysicsTools.PatAlgos.tools.helpers import getPatAlgosToolsTask, addToProcessAndTask
+    task = getPatAlgosToolsTask(process)
+    addToProcessAndTask("slimmedJetsPuppi", process.selectedUpdatedPatJetsPuppiWithDeepInfo.clone(), process, task)
+    del process.selectedUpdatedPatJetsPuppiWithDeepInfo
+
     return process
 
 nanoAOD_addDeepInfoAK4_switch = cms.PSet(

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -116,14 +116,6 @@ jetPuppiTable = simplePATJetFlatTableProducer.clone(
     )
 )
 
-run2_nanoAOD_ANY.toModify(
-    jetPuppiTable.variables,
-    btagCSVV2 = Var("bDiscriminator('pfCombinedInclusiveSecondaryVertexV2BJetTags')",float,doc=" pfCombinedInclusiveSecondaryVertexV2 b-tag discriminator (aka CSVV2)",precision=10),
-    btagDeepB = Var("?(bDiscriminator('pfDeepCSVJetTags:probb')+bDiscriminator('pfDeepCSVJetTags:probbb'))>=0?bDiscriminator('pfDeepCSVJetTags:probb')+bDiscriminator('pfDeepCSVJetTags:probbb'):-1",float,doc="DeepCSV b+bb tag discriminator",precision=10),
-    btagDeepCvL = Var("?bDiscriminator('pfDeepCSVJetTags:probc')>=0?bDiscriminator('pfDeepCSVJetTags:probc')/(bDiscriminator('pfDeepCSVJetTags:probc')+bDiscriminator('pfDeepCSVJetTags:probudsg')):-1", float,doc="DeepCSV c vs udsg discriminator",precision=10),
-    btagDeepCvB = Var("?bDiscriminator('pfDeepCSVJetTags:probc')>=0?bDiscriminator('pfDeepCSVJetTags:probc')/(bDiscriminator('pfDeepCSVJetTags:probc')+bDiscriminator('pfDeepCSVJetTags:probb')+bDiscriminator('pfDeepCSVJetTags:probbb')):-1",float,doc="DeepCSV c vs b+bb discriminator",precision=10)
-)
-
 run3_nanoAOD_pre142X.toModify(
     jetPuppiTable.variables,
     puIdDisc = None,

--- a/PhysicsTools/NanoAOD/python/jetsAK8_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK8_cff.py
@@ -127,45 +127,6 @@ fatJetTable = simplePATJetFlatTableProducer.clone(
     )
 )
 
-run2_nanoAOD_ANY.toModify(
-    fatJetTable.variables,
-    btagCSVV2 = Var("bDiscriminator('pfCombinedInclusiveSecondaryVertexV2BJetTags')",float,doc=" pfCombinedInclusiveSecondaryVertexV2 b-tag discriminator (aka CSVV2)",precision=10),
-    # Remove for V9
-    chMultiplicity = None,
-    neMultiplicity = None,
-    chHEF = None,
-    neHEF = None,
-    chEmEF = None,
-    neEmEF = None,
-    muEF = None
-)
-
-(run2_nanoAOD_106Xv2).toModify(
-    fatJetTable.variables,
-    # Restore taggers that were decommisionned for Run-3
-    btagDeepB = Var("?(bDiscriminator('pfDeepCSVJetTags:probb')+bDiscriminator('pfDeepCSVJetTags:probbb'))>=0?bDiscriminator('pfDeepCSVJetTags:probb')+bDiscriminator('pfDeepCSVJetTags:probbb'):-1",float,doc="DeepCSV b+bb tag discriminator",precision=10),
-    btagHbb = Var("bDiscriminator('pfBoostedDoubleSecondaryVertexAK8BJetTags')",float,doc="Higgs to BB tagger discriminator",precision=10),
-    btagDDBvLV2 = Var("bDiscriminator('pfMassIndependentDeepDoubleBvLV2JetTags:probHbb')",float,doc="DeepDoubleX V2(mass-decorrelated) discriminator for H(Z)->bb vs QCD",precision=10),
-    btagDDCvLV2 = Var("bDiscriminator('pfMassIndependentDeepDoubleCvLV2JetTags:probHcc')",float,doc="DeepDoubleX V2 (mass-decorrelated) discriminator for H(Z)->cc vs QCD",precision=10),
-    btagDDCvBV2 = Var("bDiscriminator('pfMassIndependentDeepDoubleCvBV2JetTags:probHcc')",float,doc="DeepDoubleX V2 (mass-decorrelated) discriminator for H(Z)->cc vs H(Z)->bb",precision=10),
-    deepTag_TvsQCD = Var("bDiscriminator('pfDeepBoostedDiscriminatorsJetTags:TvsQCD')",float,doc="DeepBoostedJet tagger top vs QCD discriminator",precision=10),
-    deepTag_WvsQCD = Var("bDiscriminator('pfDeepBoostedDiscriminatorsJetTags:WvsQCD')",float,doc="DeepBoostedJet tagger W vs QCD discriminator",precision=10),
-    deepTag_ZvsQCD = Var("bDiscriminator('pfDeepBoostedDiscriminatorsJetTags:ZvsQCD')",float,doc="DeepBoostedJet tagger Z vs QCD discriminator",precision=10),
-    deepTag_H = Var("bDiscriminator('pfDeepBoostedJetTags:probHbb')+bDiscriminator('pfDeepBoostedJetTags:probHcc')+bDiscriminator('pfDeepBoostedJetTags:probHqqqq')",float,doc="DeepBoostedJet tagger H(bb,cc,4q) sum",precision=10),
-    deepTag_QCD = Var("bDiscriminator('pfDeepBoostedJetTags:probQCDbb')+bDiscriminator('pfDeepBoostedJetTags:probQCDcc')+bDiscriminator('pfDeepBoostedJetTags:probQCDb')+bDiscriminator('pfDeepBoostedJetTags:probQCDc')+bDiscriminator('pfDeepBoostedJetTags:probQCDothers')",float,doc="DeepBoostedJet tagger QCD(bb,cc,b,c,others) sum",precision=10),
-    deepTag_QCDothers = Var("bDiscriminator('pfDeepBoostedJetTags:probQCDothers')",float,doc="DeepBoostedJet tagger QCDothers value",precision=10),
-    deepTagMD_TvsQCD = Var("bDiscriminator('pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:TvsQCD')",float,doc="Mass-decorrelated DeepBoostedJet tagger top vs QCD discriminator",precision=10),
-    deepTagMD_WvsQCD = Var("bDiscriminator('pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:WvsQCD')",float,doc="Mass-decorrelated DeepBoostedJet tagger W vs QCD discriminator",precision=10),
-    deepTagMD_ZvsQCD = Var("bDiscriminator('pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:ZvsQCD')",float,doc="Mass-decorrelated DeepBoostedJet tagger Z vs QCD discriminator",precision=10),
-    deepTagMD_ZHbbvsQCD = Var("bDiscriminator('pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:ZHbbvsQCD')",float,doc="Mass-decorrelated DeepBoostedJet tagger Z/H->bb vs QCD discriminator",precision=10),
-    deepTagMD_ZbbvsQCD = Var("bDiscriminator('pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:ZbbvsQCD')",float,doc="Mass-decorrelated DeepBoostedJet tagger Z->bb vs QCD discriminator",precision=10),
-    deepTagMD_HbbvsQCD = Var("bDiscriminator('pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:HbbvsQCD')",float,doc="Mass-decorrelated DeepBoostedJet tagger H->bb vs QCD discriminator",precision=10),
-    deepTagMD_ZHccvsQCD = Var("bDiscriminator('pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:ZHccvsQCD')",float,doc="Mass-decorrelated DeepBoostedJet tagger Z/H->cc vs QCD discriminator",precision=10),
-    deepTagMD_H4qvsQCD = Var("bDiscriminator('pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:H4qvsQCD')",float,doc="Mass-decorrelated DeepBoostedJet tagger H->4q vs QCD discriminator",precision=10),
-    deepTagMD_bbvsLight = Var("bDiscriminator('pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:bbvsLight')",float,doc="Mass-decorrelated DeepBoostedJet tagger Z/H/gluon->bb vs light flavour discriminator",precision=10),
-    deepTagMD_ccvsLight = Var("bDiscriminator('pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:ccvsLight')",float,doc="Mass-decorrelated DeepBoostedJet tagger Z/H/gluon->cc vs light flavour discriminator",precision=10),
-)
-
 ##############################################################
 ## DeepInfoAK8:Start
 ## - To be used in nanoAOD_customizeCommon() in nano_cff.py
@@ -232,16 +193,6 @@ nanoAOD_addDeepInfoAK8_switch = cms.PSet(
     jecPayload = cms.untracked.string('AK8PFPuppi')
 )
 
-
-# ParticleNet legacy jet tagger is already in 106Xv2 MINIAOD,
-# add ParticleNet legacy mass regression, new combined tagger + mass regression, and GlobalParT
-run2_nanoAOD_106Xv2.toModify(
-    nanoAOD_addDeepInfoAK8_switch,
-    nanoAOD_addParticleNetMassLegacy_switch = True,
-    nanoAOD_addParticleNet_switch = True,
-    nanoAOD_addGlobalParT_switch = True,
-)
-
 ################################################
 ## DeepInfoAK8:End
 #################################################
@@ -268,22 +219,6 @@ subJetTable = simplePATJetFlatTableProducer.clone(
         n2b1 = Var("userFloat('nb1AK8PuppiSoftDropSubjets:ecfN2')", float, doc="N2 with beta=1", precision=10),
         n3b1 = Var("userFloat('nb1AK8PuppiSoftDropSubjets:ecfN3')", float, doc="N3 with beta=1", precision=10),
     )
-)
-
-run2_nanoAOD_ANY.toModify(
-    subJetTable.variables,
-    btagCSVV2 = Var("bDiscriminator('pfCombinedInclusiveSecondaryVertexV2BJetTags')",float,doc=" pfCombinedInclusiveSecondaryVertexV2 b-tag discriminator (aka CSVV2)",precision=10)
-)
-
-(run2_nanoAOD_106Xv2).toModify(
-    subJetTable.variables,
-    area = None,
-    UParTAK4RegPtRawCorr = None,
-    UParTAK4RegPtRawCorrNeutrino = None,
-    UParTAK4RegPtRawRes = None,
-    UParTAK4V1RegPtRawCorr = None,
-    UParTAK4V1RegPtRawCorrNeutrino = None,
-    UParTAK4V1RegPtRawRes = None,
 )
 
 run3_nanoAOD_pre142X.toModify(

--- a/PhysicsTools/NanoAOD/python/jetsAK8_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK8_cff.py
@@ -221,19 +221,6 @@ subJetTable = simplePATJetFlatTableProducer.clone(
     )
 )
 
-run3_nanoAOD_pre142X.toModify(
-    subJetTable.variables,
-    btagDeepFlavB = None,
-    btagUParTAK4B = None,
-    UParTAK4RegPtRawCorr = None,
-    UParTAK4RegPtRawCorrNeutrino = None,
-    UParTAK4RegPtRawRes = None,
-    UParTAK4V1RegPtRawCorr = None,
-    UParTAK4V1RegPtRawCorrNeutrino = None,
-    UParTAK4V1RegPtRawRes = None,
-    btagDeepB = Var("bDiscriminator('pfDeepCSVJetTags:probb')+bDiscriminator('pfDeepCSVJetTags:probbb')",float,doc="DeepCSV b+bb tag discriminator",precision=10),
-)
-
 #jets are not as precise as muons
 fatJetTable.variables.pt.precision=10
 subJetTable.variables.pt.precision=10

--- a/PhysicsTools/NanoAOD/python/muons_cff.py
+++ b/PhysicsTools/NanoAOD/python/muons_cff.py
@@ -15,6 +15,12 @@ slimmedMuonsUpdated = cms.EDProducer("PATMuonUpdater",
     pfCandsForMiniIso = cms.InputTag("packedPFCandidates"),
     miniIsoParams = PhysicsTools.PatAlgos.producersLayer1.muonProducer_cfi.patMuons.miniIsoParams, # so they're in sync
     recomputeMuonBasicSelectors = cms.bool(False),
+    recomputeSoftMuonMvaRun3 = cms.bool(False),
+    softMvaRun3Model = PhysicsTools.PatAlgos.producersLayer1.muonProducer_cfi.patMuons.softMvaRun3Model,
+)
+
+(run2_nanoAOD_106Xv2 | run3_nanoAOD_pre142X).toModify(
+    slimmedMuonsUpdated, recomputeMuonBasicSelectors=True, recomputeSoftMuonMvaRun3=True,
 )
 
 isoForMu = cms.EDProducer("MuonIsoValueMapProducer",
@@ -305,7 +311,7 @@ muonTable.variables.phi.precision = 16
 
 
 # Revert back to AK4 CHS jets for Run 2
-run2_nanoAOD_ANY.toModify(
+run2_muon.toModify(
     ptRatioRelForMu,srcJet="updatedJets"
 )
 

--- a/PhysicsTools/NanoAOD/python/nanoDQM_cff.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cff.py
@@ -188,43 +188,6 @@ _Jet_Run2_plots.extend([
     Plot1D('btagDeepCvB', 'btagDeepCvB', 20, -1, 1, 'DeepCSV c vs b+bb discriminator'),
     Plot1D('btagDeepCvL', 'btagDeepCvL', 20, -1, 1, 'DeepCSV c vs udsg discriminator')
 ])
-_Jet_pre142X_plots = cms.VPSet()
-for plot in nanoDQM.vplots.Jet.plots:
-    if 'puIdDisc' not in plot.name.value():
-        _Jet_pre142X_plots.append(plot)
-
-_SubJet_Run2_plots = cms.VPSet()
-for plot in nanoDQM.vplots.SubJet.plots:
-    _SubJet_Run2_plots.append(plot)
-_SubJet_Run2_plots.extend([
-    Plot1D('btagCSVV2', 'btagCSVV2', 20, -1, 1, ' pfCombinedInclusiveSecondaryVertexV2 b-tag discriminator (aka CSVV2)'),
-])
-
-_SubJet_pre142X_plots = cms.VPSet()
-for plot in nanoDQM.vplots.SubJet.plots:
-    if ('btagDeepFlavB' not in plot.name.value()) and ('btagUParTAK4B' not in plot.name.value()) and ('UParTAK4Reg' not in plot.name.value()):
-        _SubJet_pre142X_plots.append(plot)
-_SubJet_pre142X_plots.extend([
-    Plot1D('btagDeepB', 'btagDeepB', 20, -1, 1, 'Deep B+BB btag discriminator'),
-])
-
-run2_nanoAOD_ANY.toModify(
-    nanoDQM.vplots.FatJet,
-    plots = _FatJet_Run2_plots
-).toModify(
-    nanoDQM.vplots.Jet,
-    plots = _Jet_Run2_plots
-).toModify(
-    nanoDQM.vplots.SubJet,
-    plots = _SubJet_Run2_plots
-)
-run3_nanoAOD_pre142X.toModify(
-    nanoDQM.vplots.Jet,
-    plots = _Jet_pre142X_plots
-).toModify(
-    nanoDQM.vplots.SubJet,
-    plots = _SubJet_pre142X_plots
-)
 
 _Pileup_pre13X_plots = cms.VPSet()
 for plot in nanoDQM.vplots.Pileup.plots:

--- a/PhysicsTools/NanoAOD/python/nanoDQM_cff.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cff.py
@@ -5,19 +5,6 @@ from PhysicsTools.NanoAOD.nanoDQM_cfi import nanoDQM
 from PhysicsTools.NanoAOD.nanoDQM_tools_cff import *
 from PhysicsTools.NanoAOD.nano_eras_cff import *
 
-_boostedTauPlotsV10 = cms.VPSet()
-for plot in nanoDQM.vplots.boostedTau.plots:
-    _boostedTauPlotsV10.append(plot)
-_boostedTauPlotsV10.extend([
-    Plot1D('idMVAoldDMdR032017v2', 'idMVAoldDMdR032017v2', 11, -0.5, 10.5, 'IsolationMVArun2017v2DBoldDMdR0p3wLT ID working point (2017v2): int 1 = VVLoose, 2 = VLoose, 3 = Loose, 4 = Medium, 5 = Tight, 6 = VTight, 7 = VVTight'),
-    Plot1D('rawMVAoldDMdR032017v2', 'rawMVAoldDMdR032017v2', 20, -1, 1, 'byIsolationMVArun2017v2DBoldDMdR0p3wLT raw output discriminator (2017v2)')
-])
-
-(run2_nanoAOD_106Xv2).toModify(
-    nanoDQM.vplots.boostedTau,
-    plots = _boostedTauPlotsV10
-)
-
 ## EGamma custom nano
 _Electron_extra_plots = nanoDQM.vplots.Electron.plots.copy()
 _Electron_extra_plots.extend([

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -93,6 +93,14 @@ nanoSequenceMC = nanoSequenceFS.copy()
 nanoSequenceMC.insert(nanoSequenceFS.index(nanoSequenceCommon)+1,nanoSequenceOnlyFullSim)
 
 
+def _fixPNetInputCollection(process):
+    # fix circular module dependency in ParticleNetFromMiniAOD TagInfos when slimmedTaus is updated
+    if hasattr(process, 'slimmedTaus'):
+        for mod in process.producers.keys():
+            if 'ParticleNetFromMiniAOD' in mod and 'TagInfos' in mod:
+                getattr(process, mod).taus = 'slimmedTaus::@skipCurrentProcess'
+
+
 # modifier which adds new tauIDs
 import RecoTauTag.RecoTau.tools.runTauIdMVA as tauIdConfig
 def nanoAOD_addTauIds(process, idsToRun=[], addPNetCHS=False, addUParTPuppi=False):
@@ -173,11 +181,7 @@ def nanoAOD_addTauIds(process, idsToRun=[], addPNetCHS=False, addUParTPuppi=Fals
         process.slimmedTaus = getattr(process, updatedTauName).clone()
         process.tauTask.replace(getattr(process, updatedTauName), process.slimmedTaus)
         delattr(process, updatedTauName)
-
-        # fix circular module dependency in :
-        for mod in process.producers.keys():
-            if 'ParticleNetFromMiniAOD' in mod and 'TagInfos' in mod:
-                getattr(process, mod).taus = 'slimmedTaus::@skipCurrentProcess'
+        _fixPNetInputCollection(process)
 
     return process
 

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -208,7 +208,7 @@ def nanoAOD_customizeCommon(process):
     process = nanoAOD_activateVID(process)
 
     # recompute Puppi weights and remake AK4, AK8 Puppi jets and PuppiMET
-    run2_nanoAOD_106Xv2.toModify(
+    (run2_nanoAOD_106Xv2 | run3_nanoAOD_pre142X).toModify(
         process, lambda p: RecomputePuppiWeightsALL(p)
     )
 
@@ -255,13 +255,8 @@ def nanoAOD_customizeCommon(process):
         process, lambda p : nanoAOD_addTauIds(p, nanoAOD_tau_switch.idsToAdd.value())
     )
 
-    # Add Unified Tagger for Run 2 era
-    (run2_nanoAOD_106Xv2).toModify(
-        nanoAOD_tau_switch, addPNet = True, addUParTInfo = True
-    )
-    # Add Unified Taggers for Run 3 pre 142X (pre v15) era (Unified taggers 
-    # are already added to slimmedTaus in miniAOD for newer eras)
-    run3_nanoAOD_pre142X.toModify(
+    # Add Unified Tagger for Run2 and Run3 pre-142X
+    (run2_nanoAOD_106Xv2 | run3_nanoAOD_pre142X).toModify(
         nanoAOD_tau_switch, addPNet = True, addUParTInfo = True
     )
     
@@ -273,8 +268,8 @@ def nanoAOD_customizeCommon(process):
 
     # Add Unified Tagger For PUPPI Jets (UParT 2024)
     nanoAOD_addUTagToTaus(process,
-                        addUTagInfo = nanoAOD_tau_switch.addUParTInfo.value(),
-                        usePUPPIjets = True
+                          addUTagInfo = nanoAOD_tau_switch.addUParTInfo.value(),
+                          usePUPPIjets = True
     )
 
     nanoAOD_boostedTau_switch = cms.PSet(

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -67,6 +67,11 @@ nanoTableTaskCommon = cms.Task(
     isoTrackTablesTask,softActivityTablesTask
 )
 
+(run2_muon | run2_egamma).toReplaceWith(
+    nanoTableTaskCommon,
+    nanoTableTaskCommon.copyAndAdd(chsJetUpdateTask)
+)
+
 nanoSequenceCommon = cms.Sequence(nanoTableTaskCommon)
 
 nanoSequenceOnlyFullSim = cms.Sequence(triggerObjectTablesTask)
@@ -132,7 +137,7 @@ def nanoAOD_addTauIds(process, idsToRun=[], addPNetCHS=False, addUParTPuppi=Fals
             addGenJetMatch=False,
             genJetMatch=""
         ))
-        process.tauTask.add(process.jetTask, getattr(process, updatedTauName))
+        process.tauTask.add(process.chsJetUpdateTask, getattr(process, updatedTauName))
         originalTauName = updatedTauName
 
     if addUParTPuppi:

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -88,203 +88,214 @@ nanoSequenceMC = nanoSequenceFS.copy()
 nanoSequenceMC.insert(nanoSequenceFS.index(nanoSequenceCommon)+1,nanoSequenceOnlyFullSim)
 
 
-def RecomputePuppiWeightsALL(proc):
-  """
-  Recompute Puppi weights and PuppiMET and rebuild slimmedJetsPuppi and slimmedJetsAK8.
-  """
-  runOnMC = True
-  if hasattr(proc, "NANOEDMAODoutput") or hasattr(proc, "NANOAODoutput"):
-    runOnMC = False
-
-  from PhysicsTools.PatAlgos.tools.puppiJetMETReclusteringFromMiniAOD_cff import puppiJetMETReclusterFromMiniAOD
-  proc = puppiJetMETReclusterFromMiniAOD(proc, runOnMC=runOnMC, useExistingWeights=False,
-                                         reclusterAK4MET=True,
-                                         reclusterAK8=True,
-                                         )
-
-  return proc
-
-
 # modifier which adds new tauIDs
 import RecoTauTag.RecoTau.tools.runTauIdMVA as tauIdConfig
-def nanoAOD_addTauIds(process, idsToRun=[]):
-    if idsToRun: #no-empty list of tauIDs to run
-        updatedTauName = "slimmedTausUpdated"
-        tauIdEmbedder = tauIdConfig.TauIDEmbedder(process, debug = False,
-                                                  updatedTauName = updatedTauName,
-                                                  postfix = "ForNano",
-            toKeep = idsToRun)
+def nanoAOD_addTauIds(process, idsToRun=[], addPNetCHS=False, addUParTPuppi=False):
+    originalTauName = 'slimmedTaus::@skipCurrentProcess'
+    updatedTauName = None
+
+    if idsToRun:  # no-empty list of tauIDs to run
+        updatedTauName = 'slimmedTausUpdated'
+        tauIdEmbedder = tauIdConfig.TauIDEmbedder(process, debug=False,
+                                                  originalTauName=originalTauName,
+                                                  updatedTauName=updatedTauName,
+                                                  postfix="ForNano",
+                                                  toKeep=idsToRun)
         tauIdEmbedder.runTauID()
-        process.finalTaus.src = updatedTauName
-        #remember to adjust the selection and tables with added IDs
+        process.tauTask.add(process.rerunMvaIsolationTaskForNano, getattr(process, updatedTauName))
+        originalTauName = updatedTauName
 
-        process.tauTask.add( process.rerunMvaIsolationTaskForNano, getattr(process, updatedTauName) )
-
-    return process
-
-def nanoAOD_addBoostedTauIds(process, idsToRun=[]):
-    if idsToRun: #no-empty list of tauIDs to run
-        updatedBoostedTauName = "slimmedTausBoostedNewID"
-        boostedTauIdEmbedder = tauIdConfig.TauIDEmbedder(process, debug = False,
-                                                         originalTauName = "slimmedTausBoosted",
-                                                         updatedTauName = updatedBoostedTauName,
-                                                         postfix = "BoostedForNano",
-                                                         toKeep = idsToRun)
-        boostedTauIdEmbedder.runTauID()
-        process.finalBoostedTaus.src = updatedBoostedTauName
-        #remember to adjust the selection and tables with added IDs
-
-        process.boostedTauTask.add( process.rerunMvaIsolationTaskBoostedForNano, getattr(process, updatedBoostedTauName))
-
-    return process
-
-def nanoAOD_addUTagToTaus(process, addUTagInfo=False, usePUPPIjets=False):
-    
-    if addUTagInfo:
-        originalTauName = process.finalTaus.src.value()
-        
-        if usePUPPIjets: # option to use PUPPI jets   
-            jetCollection = "updatedJetsPuppi"
-            TagName = "pfUnifiedParticleTransformerAK4JetTags"
-            tag_prefix = "byUTagPUPPI"
-            updatedTauName = originalTauName+'WithUTagPUPPI'
-            # Unified ParT Tagger used for PUPPI jets
-            from RecoBTag.ONNXRuntime.pfUnifiedParticleTransformerAK4JetTags_cfi import pfUnifiedParticleTransformerAK4JetTags
-            Discriminators = [TagName+":"+tag for tag in pfUnifiedParticleTransformerAK4JetTags.flav_names.value()]
-        else: # use CHS jets by default
-            jetCollection = "updatedJets"
-            TagName = "pfParticleNetFromMiniAODAK4CHSCentralJetTags"
-            tag_prefix = "byUTagCHS"
-            updatedTauName = originalTauName+'WithUTagCHS'
-            # PNet tagger used for CHS jets
-            from RecoBTag.ONNXRuntime.pfParticleNetFromMiniAODAK4_cff import pfParticleNetFromMiniAODAK4CHSCentralJetTags
-            Discriminators = [TagName+":"+tag for tag in pfParticleNetFromMiniAODAK4CHSCentralJetTags.flav_names.value()]
+    from PhysicsTools.PatAlgos.patTauHybridProducer_cfi import patTauHybridProducer
+    if addPNetCHS:
+        jetCollection = "updatedJets"
+        TagName = "pfParticleNetFromMiniAODAK4CHSCentralJetTags"
+        tag_prefix = "byUTagCHS"
+        updatedTauName = originalTauName.split(':')[0] + 'WithPNetCHS'
+        # PNet tagger used for CHS jets
+        from RecoBTag.ONNXRuntime.pfParticleNetFromMiniAODAK4_cff import pfParticleNetFromMiniAODAK4CHSCentralJetTags
+        Discriminators = [TagName + ":" + tag for tag in pfParticleNetFromMiniAODAK4CHSCentralJetTags.flav_names.value()]
 
         # Define "hybridTau" producer
-        from PhysicsTools.PatAlgos.patTauHybridProducer_cfi import patTauHybridProducer
         setattr(process, updatedTauName, patTauHybridProducer.clone(
-            src = originalTauName,
-            jetSource = jetCollection,
-            dRMax = 0.4,
-            jetPtMin = 15,
-            jetEtaMax = 2.5,
-            UTagLabel = TagName,
-            UTagScoreNames = Discriminators,
-            tagPrefix = tag_prefix,
-            tauScoreMin = -1,
-            vsJetMin = 0.05,
-            checkTauScoreIsBest = False,
-            chargeAssignmentProbMin = 0.2,
-            addGenJetMatch = False,
-            genJetMatch = ""
+            src=originalTauName,
+            jetSource=jetCollection,
+            dRMax=0.4,
+            jetPtMin=15,
+            jetEtaMax=2.5,
+            UTagLabel=TagName,
+            UTagScoreNames=Discriminators,
+            tagPrefix=tag_prefix,
+            tauScoreMin=-1,
+            vsJetMin=0.05,
+            checkTauScoreIsBest=False,
+            chargeAssignmentProbMin=0.2,
+            addGenJetMatch=False,
+            genJetMatch=""
         ))
-        process.finalTaus.src = updatedTauName
-
-        #remember to adjust the selection and tables with added IDs
-
         process.tauTask.add(process.jetTask, getattr(process, updatedTauName))
+        originalTauName = updatedTauName
+
+    if addUParTPuppi:
+        jetCollection = "updatedJetsPuppi"
+        TagName = "pfUnifiedParticleTransformerAK4JetTags"
+        tag_prefix = "byUTagPUPPI"
+        updatedTauName = originalTauName.split(':')[0] + 'WithUParTPuppi'
+        # Unified ParT Tagger used for PUPPI jets
+        from RecoBTag.ONNXRuntime.pfUnifiedParticleTransformerAK4JetTags_cfi import pfUnifiedParticleTransformerAK4JetTags
+        Discriminators = [TagName + ":" + tag for tag in pfUnifiedParticleTransformerAK4JetTags.flav_names.value()]
+
+        # Define "hybridTau" producer
+        setattr(process, updatedTauName, patTauHybridProducer.clone(
+            src=originalTauName,
+            jetSource=jetCollection,
+            dRMax=0.4,
+            jetPtMin=15,
+            jetEtaMax=2.5,
+            UTagLabel=TagName,
+            UTagScoreNames=Discriminators,
+            tagPrefix=tag_prefix,
+            tauScoreMin=-1,
+            vsJetMin=0.05,
+            checkTauScoreIsBest=False,
+            chargeAssignmentProbMin=0.2,
+            addGenJetMatch=False,
+            genJetMatch=""
+        ))
+        process.tauTask.add(getattr(process, updatedTauName))
+        originalTauName = updatedTauName
+
+    if updatedTauName is not None:
+        process.slimmedTaus = getattr(process, updatedTauName).clone()
+        process.tauTask.replace(getattr(process, updatedTauName), process.slimmedTaus)
+        delattr(process, updatedTauName)
+
+        # fix circular module dependency in :
+        for mod in process.producers.keys():
+            if 'ParticleNetFromMiniAOD' in mod and 'TagInfos' in mod:
+                getattr(process, mod).taus = 'slimmedTaus::@skipCurrentProcess'
 
     return process
+
+
+def nanoAOD_addBoostedTauIds(process, idsToRun=[]):
+    if idsToRun:  # no-empty list of tauIDs to run
+        boostedTauIdEmbedder = tauIdConfig.TauIDEmbedder(process, debug=False,
+                                                         originalTauName="slimmedTausBoosted::@skipCurrentProcess",
+                                                         updatedTauName="slimmedTausBoostedNewID",
+                                                         postfix="BoostedForNano",
+                                                         toKeep=idsToRun)
+        boostedTauIdEmbedder.runTauID()
+
+        process.slimmedTausBoosted = process.slimmedTausBoostedNewID.clone()
+        del process.slimmedTausBoostedNewID
+        process.boostedTauTask.add(process.rerunMvaIsolationTaskBoostedForNano, process.slimmedTausBoosted)
+
+    return process
+
 
 from PhysicsTools.SelectorUtils.tools.vid_id_tools import *
 def nanoAOD_activateVID(process):
 
-    switchOnVIDElectronIdProducer(process,DataFormat.MiniAOD,electronTask)
+    switchOnVIDElectronIdProducer(process, DataFormat.MiniAOD, electronTask)
     for modname in electron_id_modules_WorkingPoints_nanoAOD.modules:
-        setupAllVIDIdsInModule(process,modname,setupVIDElectronSelection)
+        setupAllVIDIdsInModule(process, modname, setupVIDElectronSelection)
 
-    process.electronTask.add( process.egmGsfElectronIDTask )
+    process.electronTask.add(process.egmGsfElectronIDTask)
 
-    switchOnVIDPhotonIdProducer(process,DataFormat.MiniAOD,photonTask) # do not call this to avoid resetting photon IDs in VID, if called before inside makePuppiesFromMiniAOD
+    # do not call this to avoid resetting photon IDs in VID, if called before inside makePuppiesFromMiniAOD
+    switchOnVIDPhotonIdProducer(process, DataFormat.MiniAOD, photonTask)
     for modname in photon_id_modules_WorkingPoints_nanoAOD.modules:
-        setupAllVIDIdsInModule(process,modname,setupVIDPhotonSelection)
+        setupAllVIDIdsInModule(process, modname, setupVIDPhotonSelection)
 
-    process.photonTask.add( process.egmPhotonIDTask )
+    process.photonTask.add(process.egmPhotonIDTask)
 
     return process
+
 
 def nanoAOD_customizeCommon(process):
 
     process = nanoAOD_activateVID(process)
 
-    # recompute Puppi weights and remake AK4, AK8 Puppi jets and PuppiMET
-    (run2_nanoAOD_106Xv2 | run3_nanoAOD_pre142X).toModify(
-        process, lambda p: RecomputePuppiWeightsALL(p)
+    nanoAOD_rePuppi_switch = cms.PSet(
+        useExistingWeights=cms.bool(False),
+        reclusterAK4MET=cms.bool(False),
+        reclusterAK8=cms.bool(False),
     )
+
+    # recompute Puppi weights, and remake AK4, AK8 Puppi jets and PuppiMET
+    (run2_nanoAOD_106Xv2 | run3_nanoAOD_pre142X | nanoAOD_rePuppi).toModify(
+        nanoAOD_rePuppi_switch, useExistingWeights=False, reclusterAK4MET=True, reclusterAK8=True
+    )
+
+    runOnMC = True
+    if hasattr(process, "NANOEDMAODoutput") or hasattr(process, "NANOAODoutput"):
+        runOnMC = False
+    from PhysicsTools.PatAlgos.tools.puppiJetMETReclusteringFromMiniAOD_cff import puppiJetMETReclusterFromMiniAOD
+    puppiJetMETReclusterFromMiniAOD(process,
+                                    runOnMC=runOnMC,
+                                    useExistingWeights=nanoAOD_rePuppi_switch.useExistingWeights.value(),
+                                    reclusterAK4MET=nanoAOD_rePuppi_switch.reclusterAK4MET.value(),
+                                    reclusterAK8=nanoAOD_rePuppi_switch.reclusterAK8.value(),
+                                    )
 
     # This function is defined in jetsAK4_Puppi_cff.py
     process = nanoAOD_addDeepInfoAK4(process,
-        addParticleNet=nanoAOD_addDeepInfoAK4_switch.nanoAOD_addParticleNet_switch,
-        addRobustParTAK4=nanoAOD_addDeepInfoAK4_switch.nanoAOD_addRobustParTAK4Tag_switch,
-        addUnifiedParTAK4=nanoAOD_addDeepInfoAK4_switch.nanoAOD_addUnifiedParTAK4Tag_switch
-    )
+                                     addParticleNet=nanoAOD_addDeepInfoAK4_switch.nanoAOD_addParticleNet_switch,
+                                     addRobustParTAK4=nanoAOD_addDeepInfoAK4_switch.nanoAOD_addRobustParTAK4Tag_switch,
+                                     addUnifiedParTAK4=nanoAOD_addDeepInfoAK4_switch.nanoAOD_addUnifiedParTAK4Tag_switch
+                                     )
 
-    # Add PNet for Tau
+    # Needs to run PNet on CHS jets to update the tau collections
     run2_nanoAOD_106Xv2.toModify(
         nanoAOD_addDeepInfoAK4CHS_switch, nanoAOD_addParticleNet_switch=True,
     )
     # This function is defined in jetsAK4_CHS_cff.py
-    process = nanoAOD_addDeepInfoAK4CHS(process,
-        addDeepBTag=nanoAOD_addDeepInfoAK4CHS_switch.nanoAOD_addDeepBTag_switch,
+    process = nanoAOD_addDeepInfoAK4CHS(
+        process, addDeepBTag=nanoAOD_addDeepInfoAK4CHS_switch.nanoAOD_addDeepBTag_switch,
         addDeepFlavour=nanoAOD_addDeepInfoAK4CHS_switch.nanoAOD_addDeepFlavourTag_switch,
         addParticleNet=nanoAOD_addDeepInfoAK4CHS_switch.nanoAOD_addParticleNet_switch,
         addRobustParTAK4=nanoAOD_addDeepInfoAK4CHS_switch.nanoAOD_addRobustParTAK4Tag_switch,
-        addUnifiedParTAK4=nanoAOD_addDeepInfoAK4CHS_switch.nanoAOD_addUnifiedParTAK4Tag_switch
-    )
+        addUnifiedParTAK4=nanoAOD_addDeepInfoAK4CHS_switch.nanoAOD_addUnifiedParTAK4Tag_switch)
 
     # This function is defined in jetsAK8_cff.py
-    process = nanoAOD_addDeepInfoAK8(process,
-        addDeepBTag=nanoAOD_addDeepInfoAK8_switch.nanoAOD_addDeepBTag_switch,
+    process = nanoAOD_addDeepInfoAK8(
+        process, addDeepBTag=nanoAOD_addDeepInfoAK8_switch.nanoAOD_addDeepBTag_switch,
         addDeepBoostedJet=nanoAOD_addDeepInfoAK8_switch.nanoAOD_addDeepBoostedJet_switch,
         addDeepDoubleX=nanoAOD_addDeepInfoAK8_switch.nanoAOD_addDeepDoubleX_switch,
         addDeepDoubleXV2=nanoAOD_addDeepInfoAK8_switch.nanoAOD_addDeepDoubleXV2_switch,
         addParticleNetMassLegacy=nanoAOD_addDeepInfoAK8_switch.nanoAOD_addParticleNetMassLegacy_switch,
+        addParticleNetLegacy=nanoAOD_addDeepInfoAK8_switch.nanoAOD_addParticleNetLegacy_switch,
         addParticleNet=nanoAOD_addDeepInfoAK8_switch.nanoAOD_addParticleNet_switch,
         addGlobalParT=nanoAOD_addDeepInfoAK8_switch.nanoAOD_addGlobalParT_switch,
-        jecPayload=nanoAOD_addDeepInfoAK8_switch.jecPayload
-    )
+        jecPayload=nanoAOD_addDeepInfoAK8_switch.jecPayload)
 
     nanoAOD_tau_switch = cms.PSet(
-        idsToAdd = cms.vstring(),
-        addUParTInfo = cms.bool(False),
-        addPNet = cms.bool(False)
+        idsToAdd=cms.vstring(),
+        addPNetCHS=cms.bool(False),
+        addUParTPuppi=cms.bool(False)
     )
     (run2_nanoAOD_106Xv2).toModify(
-        nanoAOD_tau_switch, idsToAdd = ["deepTau2018v2p5"]
-    ).toModify(
-        process, lambda p : nanoAOD_addTauIds(p, nanoAOD_tau_switch.idsToAdd.value())
+        nanoAOD_tau_switch, idsToAdd=["deepTau2018v2p5"]
     )
-
-    # Add Unified Tagger for Run2 and Run3 pre-142X
     (run2_nanoAOD_106Xv2 | run3_nanoAOD_pre142X).toModify(
-        nanoAOD_tau_switch, addPNet = True, addUParTInfo = True
+        nanoAOD_tau_switch, addPNetCHS=True, addUParTPuppi=True,
     )
-    
-    # Add Unified Tagger For CHS Jets (PNet 2023)
-    nanoAOD_addUTagToTaus(process,
-                          addUTagInfo = nanoAOD_tau_switch.addPNet.value(),
-                          usePUPPIjets = False
-    )
-
-    # Add Unified Tagger For PUPPI Jets (UParT 2024)
-    nanoAOD_addUTagToTaus(process,
-                          addUTagInfo = nanoAOD_tau_switch.addUParTInfo.value(),
-                          usePUPPIjets = True
-    )
+    nanoAOD_addTauIds(process,
+                      idsToRun=nanoAOD_tau_switch.idsToAdd.value(),
+                      addPNetCHS=nanoAOD_tau_switch.addPNetCHS.value(),
+                      addUParTPuppi=nanoAOD_tau_switch.addUParTPuppi.value(),
+                      )
 
     nanoAOD_boostedTau_switch = cms.PSet(
-        idsToAdd = cms.vstring()
+        idsToAdd=cms.vstring()
     )
     run2_nanoAOD_106Xv2.toModify(
-        nanoAOD_boostedTau_switch, idsToAdd = ["mvaIso", "mvaIsoNewDM", "mvaIsoDR0p3", "againstEle", "boostedDeepTauRunIIv2p0"]
-    ).toModify(
-        process, lambda p : nanoAOD_addBoostedTauIds(p, nanoAOD_boostedTau_switch.idsToAdd.value())
-    )
+        nanoAOD_boostedTau_switch,
+        idsToAdd=["mvaIso", "mvaIsoNewDM", "mvaIsoDR0p3", "againstEle", "boostedDeepTauRunIIv2p0"])
     run3_nanoAOD_pre142X.toModify(
-        nanoAOD_boostedTau_switch, idsToAdd = ["boostedDeepTauRunIIv2p0"]
-    ).toModify(
-        process, lambda p : nanoAOD_addBoostedTauIds(p, nanoAOD_boostedTau_switch.idsToAdd.value())
+        nanoAOD_boostedTau_switch, idsToAdd=["boostedDeepTauRunIIv2p0"]
     )
+    nanoAOD_addBoostedTauIds(process, nanoAOD_boostedTau_switch.idsToAdd.value())
 
     # Add lepton time-life info
     from PhysicsTools.NanoAOD.leptonTimeLifeInfo_common_cff import addTimeLifeInfoBase

--- a/PhysicsTools/NanoAOD/python/nano_eras_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_eras_cff.py
@@ -22,6 +22,8 @@ from Configuration.Eras.Modifier_run3_jme_Winter22runsBCDEprompt_cff import run3
 from Configuration.Eras.Modifier_run3_nanoAOD_2025_cff import run3_nanoAOD_2025  # for 2025 data-taking (and possibly also 2026)
 from Configuration.Eras.Modifier_run3_nanoAOD_devel_cff import run3_nanoAOD_devel  # for development beyond v15
 
+from Configuration.ProcessModifiers.nanoAOD_rePuppi_cff import nanoAOD_rePuppi
+
 run2_nanoAOD_ANY = (
     run2_nanoAOD_106Xv2
 )

--- a/PhysicsTools/NanoAOD/python/nano_eras_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_eras_cff.py
@@ -24,8 +24,13 @@ from Configuration.Eras.Modifier_run3_nanoAOD_devel_cff import run3_nanoAOD_deve
 
 from Configuration.ProcessModifiers.nanoAOD_rePuppi_cff import nanoAOD_rePuppi
 
+# [General Note]
+# use `runX_nanoAOD_YYY` only for input-dataset-specific changes
+# (e.g., run2_nanoAOD_106Xv2 for 106X MiniAODv2, run3_nanoAOD_pre142X for pre-142X Run3 MiniAODs)
 run2_nanoAOD_ANY = (
     run2_nanoAOD_106Xv2
 )
 
+# use other modifiers for intrinsic era-dependent changes
 run2_egamma = (run2_egamma_2016 | run2_egamma_2017 | run2_egamma_2018)
+run2_muon = (run2_muon_2016 | run2_muon_2017 | run2_muon_2018)

--- a/PhysicsTools/PatAlgos/plugins/BuildFile.xml
+++ b/PhysicsTools/PatAlgos/plugins/BuildFile.xml
@@ -18,6 +18,7 @@
   <use name="DataFormats/HeavyIonEvent"/>
   <use name="DataFormats/HepMCCandidate"/>
   <use name="PhysicsTools/PatUtils"/>
+  <use name="PhysicsTools/XGBoost"/>
   <use name="CondFormats/JetMETObjects"/>
   <use name="CondFormats/HcalObjects"/>
   <use name="CondFormats/DataRecord"/>


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/48104


> #### PR description:
> 
> This PR sets up a `NanoAODv15-Lite` configuration to produce v15-like NANO directly from Run2UL MiniAODv2 and Run3 2022/2023 130X MiniAOD, by:
>  - recompute the Puppi weights, the PuppiMET, and recluster AK4 and AK8 Puppi jets (along with all the new taggers)
>  - update the tau and boostedTau collections to add the new IDs
>  - updating the muon IDs and add the missing `Muon_softMvaRun3` on-the-fly
> 
> From some quick comparison to a reMINI+reNANO workflow, overall reasonable agreement was observed, however small differences exist here and there (some are expected due to the precision differences between reco::PFCandidate and pat::packedCandidate).
> 
> TODOs:
> - [ ] Need to check the JERC tags for the GTs.
> - [x] A notable difference is in the `LowPtElectron` collection -- comments are welcome. 
>   - likely due to https://github.com/cms-sw/cmssw/pull/32391 and not fully recoverable -- propose to leave it as is.
> - [x] `Muon_softMvaRun3` is not filled -- Fixed by re-running the MVA on-the-fly.
> 
> #### PR validation:
> 
> Standard NANO workflows.
> 
> #### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
> 
> To be backported to 15_0_X.