### PR TITLE
[xSAN]Explicitly link against libresolv for Sanitizer IB

### DIFF
--- a/FWCore/Framework/bin/BuildFile.xml
+++ b/FWCore/Framework/bin/BuildFile.xml
@@ -29,6 +29,20 @@
 </bin>
 
 <bin name="cmsRun" file="cmsRun.cpp">
+  <!--
+    Starting with GLIBC version 2.34, the dn_expand function, previously found in libresolv.so,
+    was moved to libc.so. This function is used internally by the getaddrinfo() system call.
+    In our setup, we are using EL8 image. However, due to compatibility issues between
+    newer libasan.so in GCC 13.1 and the older images, the linker does not link with libresolv.so.
+    This results in crashes in getaddrinfo().
+    To address this, we explicitly link libresolv.so for xASAN integration builds targeting
+    el8_amd64_gcc13/14.
+  -->
+  <ifrelease name="ASAN|UBSAN">
+    <ifarchitecture name="el8_amd64_gcc1[34]">
+      <use name="resolv"/>
+    </ifarchitecture>
+  </ifrelease>
   <use name="tbb"/>
   <use name="boost"/>
   <use name="boost_program_options"/>

--- a/FWCore/Framework/bin/BuildFile.xml
+++ b/FWCore/Framework/bin/BuildFile.xml
@@ -1,3 +1,18 @@
+<!--
+  Starting with GLIBC version 2.34, the dn_expand function, previously found in libresolv.so,
+  was moved to libc.so. This function is used internally by the getaddrinfo() system call.
+  In our setup, we are using EL8 image. However, due to compatibility issues between
+  newer libasan.so in GCC 13.1 and the older images, the linker does not link with libresolv.so.
+  This results in crashes in getaddrinfo().
+  To address this, we explicitly link libresolv.so to all variants of cmsRun for
+  xASAN integration builds targeting el8_amd64_gcc13/14
+-->
+<ifrelease name="ASAN|UBSAN">
+  <ifarchitecture name="el8_amd64_gcc1[34]">
+    <use name="resolv"/>
+  </ifarchitecture>
+</ifrelease>
+
 <bin name="cmsRunGlibC" file="cmsRun.cpp">
   <use name="roothistmatrix"/>
   <use name="tbb"/>
@@ -29,20 +44,6 @@
 </bin>
 
 <bin name="cmsRun" file="cmsRun.cpp">
-  <!--
-    Starting with GLIBC version 2.34, the dn_expand function, previously found in libresolv.so,
-    was moved to libc.so. This function is used internally by the getaddrinfo() system call.
-    In our setup, we are using EL8 image. However, due to compatibility issues between
-    newer libasan.so in GCC 13.1 and the older images, the linker does not link with libresolv.so.
-    This results in crashes in getaddrinfo().
-    To address this, we explicitly link libresolv.so for xASAN integration builds targeting
-    el8_amd64_gcc13/14.
-  -->
-  <ifrelease name="ASAN|UBSAN">
-    <ifarchitecture name="el8_amd64_gcc1[34]">
-      <use name="resolv"/>
-    </ifarchitecture>
-  </ifrelease>
   <use name="tbb"/>
   <use name="boost"/>
   <use name="boost_program_options"/>


### PR DESCRIPTION
This should fix the ASAN/UBSAN runtime errors [a]. See https://github.com/llvm/llvm-project/issues/59007#issuecomment-2474131218 for details. 
```
The specific issue should only occur with older glibc versions: the call to dn_expand [was removed](https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=75b3a15e077dbfdfd8cbb3449369379e700b9972) from getanswer_r in glibc 2.26. With version 2.34, dn_expand [has been moved](https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=640bbdf71c6f10ac26252ac67a22902e26657bd8) from libresolv.so to libc.so. However, I think we should still add a link to -lresolv, if only because that's where the functions are documented to sit. And my understanding is that it's a no-op on newer systems anyway.
```

linking frontier_client library with`libresolv` does not fix the issue as looks like `libresolv` should be loaded directly by the application (e.g. `cmsRun`) and not via EdmPluginManager (dlopen)