### PR TITLE
Revert "Add assert to MethodSetter to trigger traceback"

### DIFF
--- a/CommonTools/Utils/src/MethodSetter.cc
+++ b/CommonTools/Utils/src/MethodSetter.cc
@@ -121,7 +121,6 @@ bool MethodSetter::push(const string& name, const vector<AnyMethodArgument>& arg
     // Not a data member either, fatal error, throw.
     switch (error) {
       case reco::parser::kNameDoesNotExist: {
-        assert(false);  //HELP FIND THREAD PROBLEM WITH RNTUPLE
         Exception ex(begin);
         ex << "no method or data member named \"" << name << "\" found for type \"" << type.name() << "\"\n";
         // The following information is for temporary debugging only, intended to be removed later


### PR DESCRIPTION
Reverts cms-sw/cmssw#48078

Since adding the ROOT fix, we are no longer triggering this assert. As the assert was only meant to help catch the race condition, we can now remove it.