### PR TITLE
TICL trackster raw pT from position

### DIFF
--- a/DataFormats/HGCalReco/interface/Trackster.h
+++ b/DataFormats/HGCalReco/interface/Trackster.h
@@ -71,7 +71,9 @@ namespace ticl {
     inline void setRawEmEnergy(float value) { raw_em_energy_ = value; }
     inline void addToRawEmEnergy(float value) { raw_em_energy_ += value; }
     inline void setRawPt(float value) { raw_pt_ = value; }
+    inline void calculateRawPt() { raw_pt_ = raw_energy_ / std::cosh(barycenter_.eta()); }
     inline void setRawEmPt(float value) { raw_em_pt_ = value; }
+    inline void calculateRawEmPt() { raw_em_pt_ = raw_em_energy_ / std::cosh(barycenter_.eta()); }
     inline void setBarycenter(Vector value) { barycenter_ = value; }
     inline void setTrackIdx(int index) { track_idx_ = index; }
     int trackIdx() const { return track_idx_; }
@@ -123,8 +125,11 @@ namespace ticl {
       }
 
       // Now also update the pt part of the Trackster, using the PCA as direction
-      raw_pt_ = std::sqrt((eigenvectors_[0].Unit() * raw_energy_).perp2());
-      raw_em_pt_ = std::sqrt((eigenvectors_[0].Unit() * raw_em_energy_).perp2());
+      // raw_pt_ = std::sqrt((eigenvectors_[0].Unit() * raw_energy_).perp2());
+      // raw_em_pt_ = std::sqrt((eigenvectors_[0].Unit() * raw_em_energy_).perp2());
+
+      calculateRawPt();
+      calculateRawEmPt();
     }
     void zeroProbabilities() {
       for (auto &p : id_probabilities_) {
@@ -173,8 +178,8 @@ namespace ticl {
 
   private:
     Vector barycenter_;
-    float regressed_energy_;
-    float raw_energy_;
+    float regressed_energy_ = 0.f;
+    float raw_energy_ = 0.f;
     // -99, -1 if not available. ns units otherwise
     float boundTime_;
     float time_;
@@ -187,9 +192,9 @@ namespace ticl {
     // 2d objects in the global collection
     std::vector<unsigned int> vertices_;
     std::vector<float> vertex_multiplicity_;
-    float raw_pt_;
-    float raw_em_pt_;
-    float raw_em_energy_;
+    float raw_pt_ = 0.f;
+    float raw_em_pt_ = 0.f;
+    float raw_em_energy_ = 0.f;
 
     // Product ID of the seeding collection used to create the Trackster.
     // For GlobalSeeding the ProductID is set to 0. For track-based seeding
@@ -241,8 +246,6 @@ namespace ticl {
       // use getters on other
       raw_energy_ += other.raw_energy();
       raw_em_energy_ += other.raw_em_energy();
-      raw_pt_ += other.raw_pt();
-      raw_em_pt_ += other.raw_em_pt();
       // add vertices and multiplicities
       std::copy(std::begin(other.vertices()), std::end(other.vertices()), std::back_inserter(vertices_));
       std::copy(std::begin(other.vertex_multiplicity()),

--- a/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.cc
+++ b/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.cc
@@ -377,9 +377,9 @@ void GeneralInterpretationAlgo::makeCandidates(const Inputs &input,
         Trackster outTrackster;
         float regr_en = 0.f;
         bool isHadron = false;
+        outTrackster.mergeTracksters(input.tracksters, trackstersInTrackIndices[iTrack]);
         for (auto const tracksterId : trackstersInTrackIndices[iTrack]) {
           //maskTracksters[tracksterId] = 0;
-          outTrackster.mergeTracksters(input.tracksters[tracksterId]);
           regr_en += input.tracksters[tracksterId].regressed_energy();
           if (input.tracksters[tracksterId].isHadronic())
             isHadron = true;

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
@@ -247,48 +247,9 @@ void PatternRecognitionbyCA<TILES>::mergeTrackstersTRK(
   for (auto &thisSeed : seedToTracksterAssociation) {
     auto &tracksters = thisSeed.second;
     if (!tracksters.empty()) {
-      auto numberOfTrackstersInSeed = tracksters.size();
       output.emplace_back(input[tracksters[0]]);
       auto &outTrackster = output.back();
-      tracksters[0] = output.size() - 1;
-      auto updated_size = outTrackster.vertices().size();
-      for (unsigned int j = 1; j < numberOfTrackstersInSeed; ++j) {
-        auto &thisTrackster = input[tracksters[j]];
-        updated_size += thisTrackster.vertices().size();
-        if (PatternRecognitionAlgoBaseT<TILES>::algo_verbosity_ > VerbosityLevel::Basic) {
-          LogDebug("HGCPatternRecoByCA") << "Updated size: " << updated_size << std::endl;
-        }
-        outTrackster.vertices().reserve(updated_size);
-        outTrackster.vertex_multiplicity().reserve(updated_size);
-        std::copy(std::begin(thisTrackster.vertices()),
-                  std::end(thisTrackster.vertices()),
-                  std::back_inserter(outTrackster.vertices()));
-        std::copy(std::begin(thisTrackster.vertex_multiplicity()),
-                  std::end(thisTrackster.vertex_multiplicity()),
-                  std::back_inserter(outTrackster.vertex_multiplicity()));
-      }
-      tracksters.resize(1);
-
-      // Find duplicate LCs
-      auto &orig_vtx = outTrackster.vertices();
-      auto vtx_sorted{orig_vtx};
-      std::sort(std::begin(vtx_sorted), std::end(vtx_sorted));
-      for (unsigned int iLC = 1; iLC < vtx_sorted.size(); ++iLC) {
-        if (vtx_sorted[iLC] == vtx_sorted[iLC - 1]) {
-          // Clean up duplicate LCs
-          const auto lcIdx = vtx_sorted[iLC];
-          const auto firstEl = std::find(orig_vtx.begin(), orig_vtx.end(), lcIdx);
-          const auto firstPos = std::distance(std::begin(orig_vtx), firstEl);
-          auto iDup = std::find(std::next(firstEl), orig_vtx.end(), lcIdx);
-          while (iDup != orig_vtx.end()) {
-            orig_vtx.erase(iDup);
-            outTrackster.vertex_multiplicity().erase(outTrackster.vertex_multiplicity().begin() +
-                                                     std::distance(std::begin(orig_vtx), iDup));
-            outTrackster.vertex_multiplicity()[firstPos] -= 1;
-            iDup = std::find(std::next(firstEl), orig_vtx.end(), lcIdx);
-          };
-        }
-      }
+      outTrackster.mergeTracksters(input, tracksters);
     }
   }
   output.shrink_to_fit();

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyRecovery.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyRecovery.cc
@@ -47,12 +47,11 @@ void PatternRecognitionbyRecovery<TILES>::makeTracksters(
     trackster.setTimeAndError(input.layerClustersTime.get(i).first, input.layerClustersTime.get(i).second);
     trackster.setRawEnergy(lc.energy());
     trackster.setBarycenter({float(lc.x()), float(lc.y()), float(lc.z())});
-    float invcosh = 1.f / std::cosh(lc.position().eta());
-    trackster.setRawPt(lc.energy() * invcosh);
+    trackster.calculateRawPt();
 
     if (std::abs(lc.z()) <= z_limit_em) {
       trackster.setRawEmEnergy(lc.energy());
-      trackster.setRawEmPt(lc.energy() * invcosh);
+      trackster.calculateRawEmPt();
     }
 
     // Add the trackster to the result vector

--- a/RecoHGCal/TICL/plugins/TracksterLinkingbyFastJet.cc
+++ b/RecoHGCal/TICL/plugins/TracksterLinkingbyFastJet.cc
@@ -37,8 +37,8 @@ void TracksterLinkingbyFastJet::linkTracksters(
       for (const auto& constituent : jet.constituents()) {
         auto tracksterIndex = constituent.user_index();
         linkedTracksterIdToInputTracksterId[i].push_back(tracksterIndex);
-        outTrackster.mergeTracksters(input.tracksters[tracksterIndex]);
       }
+      outTrackster.mergeTracksters(input.tracksters, linkedTracksterIdToInputTracksterId[i]);
       linkedTracksters.push_back(resultTracksters.size());
       resultTracksters.push_back(outTrackster);
       // Store the linked tracksters

--- a/RecoHGCal/TICL/plugins/TracksterLinkingbySkeletons.cc
+++ b/RecoHGCal/TICL/plugins/TracksterLinkingbySkeletons.cc
@@ -559,8 +559,8 @@ void TracksterLinkingbySkeletons::linkTracksters(
     for (auto const &node : comp) {
       LogDebug("TracksterLinkingbySkeletons") << node << " ";
       linkedTracksterIdToInputTracksterId[ic].push_back(node);
-      outTrackster.mergeTracksters(input.tracksters[node]);
     }
+    outTrackster.mergeTracksters(input.tracksters, linkedTracksterIdToInputTracksterId[ic]);
     linkedTracksters.push_back(resultTracksters.size());
     LogDebug("TracksterLinkingbySkeletons") << "\nOut Trackster " << outTrackster.raw_energy() << std::endl;
     resultTracksters.push_back(outTrackster);

--- a/RecoHGCal/TICL/plugins/TrackstersPCA.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersPCA.cc
@@ -74,6 +74,9 @@ void ticl::assignPCAtoTracksters(std::vector<Trackster> &tracksters,
       barycenter *= inv_raw_energy;
     trackster.setBarycenter(ticl::Trackster::Vector(barycenter));
 
+    trackster.calculateRawPt();
+    trackster.calculateRawEmPt();
+
     LogDebug("TrackstersPCA_Eigen") << "cleaning is  :" << clean << std::endl;
 
     std::vector<unsigned> filtered_idx;  // indices of layer clusters to consider for cleaned PCA


### PR DESCRIPTION
Introduced `Trackster::calculateRawPt()` and `Trackster::calculateRawEmPt()` methods.

These methods compute `raw_pt = raw_energy / cosh(eta)` and `raw_em_pt = raw_em_energy / cosh(eta)`, using the `barycenter_.eta()` to avoid instability problems found with pT calculated from the PCA. 

Updated `PatternRecognitionbyRecovery` to use the new methods instead of duplicating the logic.

Initialized relevant member variables to avoid potential undefined behavior.
