### PR TITLE
[150X, backport of #48152] Update NANO relval workflows

### DIFF
--- a/Configuration/ProcessModifiers/python/nanoAOD_rePuppi_cff.py
+++ b/Configuration/ProcessModifiers/python/nanoAOD_rePuppi_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+nanoAOD_rePuppi = cms.Modifier()

--- a/Configuration/PyReleaseValidation/python/relval_nano.py
+++ b/Configuration/PyReleaseValidation/python/relval_nano.py
@@ -179,26 +179,20 @@ steps['TTbarMINIAOD14.0'] = {'INPUT': InputInfo(
 steps['NANO_mc14.0'] = merge([{'--era': 'Run3,run3_nanoAOD_pre142X', '--conditions': 'auto:phase1_2024_realistic'},
                               _NANO_mc])
 
-steps['BPHNANO_mc14.0'] = merge([{'-s': 'NANO:@BPH', '-n': '1000'},
-                                 steps['NANO_mc14.0']])
-
 steps['muPOGNANO_mc14.0'] = merge([{'-s': 'NANO:@MUPOG,DQM:@nanoAODDQM', '-n': '1000'},
                                    steps['NANO_mc14.0']])
 
 steps['EGMNANO_mc14.0'] = merge([{'-s': 'NANO:@EGM,DQM:@nanoAODDQM', '-n': '1000'},
                                  steps['NANO_mc14.0']])
 
-steps['BTVNANO_mc14.0'] = merge([{'-s': 'NANO:@BTV', '-n': '1000'},
+steps['BTVNANO_mc14.0'] = merge([{'-s': 'NANO:@BTV,DQM:@nanoAODDQM', '-n': '1000'},
                                  steps['NANO_mc14.0']])
 
 steps['lepTrackInfoNANO_mc14.0'] = merge([{'-s': 'NANO:@LepTrackInfo,DQM:@nanoAODDQM', '-n': '1000'},
                                           steps['NANO_mc14.0']])
 
-steps['jmeNANO_mc14.0'] = merge([{'-s': 'NANO:@JME ', '-n': '1000'},
+steps['jmeNANO_mc14.0'] = merge([{'-s': 'NANO:@JME,DQM:@nanojmeDQM', '-n': '1000'},
                                  steps['NANO_mc14.0']])
-
-steps['jmeNANO_rePuppi_mc14.0'] = merge([{'-s': 'NANO:@JMErePuppi ', '-n': '1000'},
-                                         steps['NANO_mc14.0']])
 
 steps['scoutingNANO_mc14.0'] = merge([{'-s': 'NANO:@Scout'},
                                       steps['NANO_mc14.0']])
@@ -239,31 +233,25 @@ steps['NANO_data14.0'] = merge([{'--era': 'Run3_2024,run3_nanoAOD_pre142X', '--c
 steps['NANO_data14.0_prompt'] = merge([{'-s': 'NANO:@Prompt,DQM:@nanoAODDQM', '-n': '1000'},
                                        steps['NANO_data14.0']])
 
-steps['BPHNANO_data14.0'] = merge([{'-s': 'NANO:@BPH', '-n': '1000'},
-                                   steps['NANO_data14.0']])
-
 steps['muPOGNANO_data14.0'] = merge([{'-s': 'NANO:@MUPOG,DQM:@nanoAODDQM', '-n': '1000'},
                                      steps['NANO_data14.0']])
 
 steps['EGMNANO_data14.0'] = merge([{'-s': 'NANO:@EGM,DQM:@nanoAODDQM', '-n': '1000'},
                                    steps['NANO_data14.0']])
 
-steps['BTVNANO_data14.0'] = merge([{'-s': 'NANO:@BTV', '-n': '1000'},
+steps['BTVNANO_data14.0'] = merge([{'-s': 'NANO:@BTV,DQM:@nanoAODDQM', '-n': '1000'},
                                    steps['NANO_data14.0']])
 
 steps['lepTrackInfoNANO_data14.0'] = merge([{'-s': 'NANO:@LepTrackInfo,DQM:@nanoAODDQM', '-n': '1000'},
                                            steps['NANO_data14.0']])
 
-steps['jmeNANO_data14.0'] = merge([{'-s': 'NANO:@JME', '-n': '1000'},
+steps['jmeNANO_data14.0'] = merge([{'-s': 'NANO:@JME,DQM:@nanojmeDQM', '-n': '1000'},
                                    steps['NANO_data14.0']])
-
-steps['jmeNANO_rePuppi_data14.0'] = merge([{'-s': 'NANO:@JMErePuppi', '-n': '1000'},
-                                          steps['NANO_data14.0']])
 
 steps['scoutingNANO_data14.0'] = merge([{'-s': 'NANO:@Scout'},
                                         steps['NANO_data14.0']])
 
-steps['scoutingNANO_withPrompt_data14.0'] = merge([{'-s': 'NANO:@Prompt+@ScoutMonitor'}, 
+steps['scoutingNANO_withPrompt_data14.0'] = merge([{'-s': 'NANO:@Prompt+@ScoutMonitor'},
                                                    steps['NANO_data14.0']])
 
 # DPG custom NANO
@@ -287,10 +275,10 @@ steps['l1DPGNANO_data14.0'] = merge([{'-s': 'RAW2DIGI,NANO:@L1DPG', '-n': '100'}
 
 ################################################################
 # Run3 re-MINI/NANOv15 in 15.0
-steps['TTbar_13p6_Summer24_AOD'] = {'INPUT': InputInfo(
+steps['TTbar_13p6_Summer24_AOD_140X'] = {'INPUT': InputInfo(
     location='STD', dataSet='/TTtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24DRPremix-140X_mcRun3_2024_realistic_v26-v2/AODSIM')}
 
-steps['JetMET1_Run2024H_AOD'] = {'INPUT': InputInfo(
+steps['JetMET1_Run2024H_AOD_140X'] = {'INPUT': InputInfo(
     location='STD', ls={385836: [[72, 166]]}, dataSet='/JetMET1/Run2024H-PromptReco-v1/AOD')}
 
 steps['NANO_mc_Summer24_reMINI'] = merge([{'--era': 'Run3_2024', '--conditions': 'auto:phase1_2024_realistic'}, _NANO_mc])
@@ -301,16 +289,81 @@ steps['NANO_data_2024_reMINI'] = merge([{'--era': 'Run3_2024', '--conditions': '
 ################################################################
 # Run3, 15_0_X input (for 2025 data-taking)
 # temporarily using the Summer24 samples
-steps['TTbar_13p6_Summer24_MINIAOD'] = {'INPUT': InputInfo(
+steps['TTbar_13p6_Summer24_MINIAOD_150X'] = {'INPUT': InputInfo(
     location='STD', dataSet='/TTtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24MiniAODv6-150X_mcRun3_2024_realistic_v2-v2/MINIAODSIM')}
-
-steps['JetMET1_Run2024H_MINIAOD'] = {'INPUT': InputInfo(
-    location='STD', ls={385836: [[72, 166]]}, dataSet='/JetMET1/Run2024H-MINIv6NANOv15-v2/MINIAOD')}
 
 steps['NANO_mc15.0'] = merge([{'--era': 'Run3_2025', '--conditions': 'auto:phase1_2025_realistic'}, _NANO_mc])
 
+steps['BPHNANO_mc15.0'] = merge([{'-s': 'NANO:@BPH,DQM:@nanoAODDQM'},
+                                 steps['NANO_mc15.0']])
+
+steps['muPOGNANO_mc15.0'] = merge([{'-s': 'NANO:@MUPOG,DQM:@nanoAODDQM', '-n': '1000'},
+                                   steps['NANO_mc15.0']])
+
+steps['EGMNANO_mc15.0'] = merge([{'-s': 'NANO:@EGM,DQM:@nanoAODDQM', '-n': '1000'},
+                                 steps['NANO_mc15.0']])
+
+steps['BTVNANO_mc15.0'] = merge([{'-s': 'NANO:@BTV,DQM:@nanoAODDQM', '-n': '1000'},
+                                 steps['NANO_mc15.0']])
+
+steps['lepTrackInfoNANO_mc15.0'] = merge([{'-s': 'NANO:@LepTrackInfo,DQM:@nanoAODDQM', '-n': '1000'},
+                                          steps['NANO_mc15.0']])
+
+steps['jmeNANO_mc15.0'] = merge([{'-s': 'NANO:@JME,DQM:@nanojmeDQM', '-n': '1000'},
+                                 steps['NANO_mc15.0']])
+
+steps['jmeNANO_rePuppi_mc15.0'] = merge([{'-s': 'NANO:@JMErePuppi,DQM:@nanojmeDQM', '-n': '1000'},
+                                         steps['NANO_mc15.0']])
+
+steps['scoutingNANO_mc15.0'] = merge([{'-s': 'NANO:@Scout'},
+                                      steps['NANO_mc15.0']])
+
+steps['scoutingNANO_withPrompt_mc15.0'] = merge([{'-s': 'NANO:@Prompt+@Scout'},
+                                                 steps['NANO_mc15.0']])
+
+# ====== DATA ======
+lumis_Run2025C = {392175: [[95, 542]]}
+
+steps['JetMET1_Run2025C_MINIAOD_150X'] = {'INPUT': InputInfo(
+    location='STD', ls=lumis_Run2025C, dataSet='/JetMET1/Run2025C-PromptReco-v1/MINIAOD')}
+
+steps['ScoutingPFRun3_Run2025C_HLTSCOUT_150X'] = {'INPUT': InputInfo(location='STD', ls=lumis_Run2025C,
+                                                         dataSet='/ScoutingPFRun3/Run2025C-v1/HLTSCOUT')}
+
+steps['ScoutingPFMonitor_Run2025C_MINIAOD_150X'] = {'INPUT': InputInfo(
+    location='STD', ls=lumis_Run2025C, dataSet='/ScoutingPFMonitor/Run2025C-PromptReco-v1/MINIAOD')}
+
 steps['NANO_data15.0'] = merge([{'--era': 'Run3_2025', '--conditions': 'auto:run3_data_prompt'}, _NANO_data])
 
+steps['NANO_data15.0_prompt'] = merge([{'-s': 'NANO:@Prompt,DQM:@nanoAODDQM', '-n': '1000'},
+                                       steps['NANO_data15.0']])
+
+steps['BPHNANO_data15.0'] = merge([{'-s': 'NANO:@BPH,DQM:@nanoAODDQM'},
+                                   steps['NANO_data15.0']])
+
+steps['muPOGNANO_data15.0'] = merge([{'-s': 'NANO:@MUPOG,DQM:@nanoAODDQM', '-n': '1000'},
+                                     steps['NANO_data15.0']])
+
+steps['EGMNANO_data15.0'] = merge([{'-s': 'NANO:@EGM,DQM:@nanoAODDQM', '-n': '1000'},
+                                   steps['NANO_data15.0']])
+
+steps['BTVNANO_data15.0'] = merge([{'-s': 'NANO:@BTV,DQM:@nanoAODDQM', '-n': '1000'},
+                                   steps['NANO_data15.0']])
+
+steps['lepTrackInfoNANO_data15.0'] = merge([{'-s': 'NANO:@LepTrackInfo,DQM:@nanoAODDQM', '-n': '1000'},
+                                           steps['NANO_data15.0']])
+
+steps['jmeNANO_data15.0'] = merge([{'-s': 'NANO:@JME,DQM:@nanojmeDQM', '-n': '1000'},
+                                   steps['NANO_data15.0']])
+
+steps['jmeNANO_rePuppi_data15.0'] = merge([{'-s': 'NANO:@JMErePuppi,DQM:@nanojmeDQM', '-n': '1000'},
+                                          steps['NANO_data15.0']])
+
+steps['scoutingNANO_data15.0'] = merge([{'-s': 'NANO:@Scout'},
+                                        steps['NANO_data15.0']])
+
+steps['scoutingNANO_withPrompt_data15.0'] = merge([{'-s': 'NANO:@Prompt+@ScoutMonitor'},
+                                                   steps['NANO_data15.0']])
 
 ################################################################
 # NANOGEN
@@ -356,7 +409,6 @@ workflows[_wfn()] = ['NANOmc130X', ['TTbarMINIAOD13.0', 'NANO_mc13.0', 'HRV_NANO
 
 _wfn.subnext()
 workflows[_wfn()] = ['NANOdata130Xrun3', ['MuonEG2023MINIAOD13.0', 'NANO_data13.0', 'HRV_NANO_data']]
-workflows[_wfn()] = ['NANOdata130Xrun3', ['MuonEG2023MINIAOD13.0', 'NANO_data13.0_prompt', 'HRV_NANO_data']]
 
 # POG/PAG custom NANOs, MC
 _wfn.subnext()
@@ -370,12 +422,11 @@ _wfn.subnext()
 
 _wfn.next(2)
 ######## 2500.2xx ########
-# Run3, 14_0_X input
-workflows[_wfn()] = ['NANOmc140X', ['TTbarMINIAOD14.0', 'NANO_mc14.0', 'HRV_NANO_mc']]
+# Run3, 14_0_X input (2024 RAW/AOD)
+# Standard NANO, MC
 
+# Standard NANO, data
 _wfn.subnext()
-workflows[_wfn()] = ['NANOdata140Xrun3', ['MuonEG2024MINIAOD14.0', 'NANO_data14.0', 'HRV_NANO_data']]
-workflows[_wfn()] = ['NANOdata140Xrun3', ['MuonEG2024MINIAOD14.0', 'NANO_data14.0_prompt', 'HRV_NANO_data']]
 
 # POG/PAG custom NANOs, MC
 _wfn.subnext()
@@ -383,11 +434,10 @@ workflows[_wfn()] = ['muPOGNANOmc140X', ['TTbarMINIAOD14.0', 'muPOGNANO_mc14.0']
 workflows[_wfn()] = ['EGMNANOmc140X', ['TTbarMINIAOD14.0', 'EGMNANO_mc14.0']]
 workflows[_wfn()] = ['BTVNANOmc140X', ['TTbarMINIAOD14.0', 'BTVNANO_mc14.0']]
 workflows[_wfn()] = ['jmeNANOmc140X', ['TTbarMINIAOD14.0', 'jmeNANO_mc14.0']]
-workflows[_wfn()] = ['jmeNANOrePuppimc140X', ['TTbarMINIAOD14.0', 'jmeNANO_rePuppi_mc14.0']]
+_wfn() # workflows[_wfn()] = ['jmeNANOrePuppimc140X', ['TTbarMINIAOD14.0', 'jmeNANO_rePuppi_mc14.0']]
 workflows[_wfn()] = ['lepTrackInfoNANOmc140X', ['TTbarMINIAOD14.0', 'lepTrackInfoNANO_mc14.0']]
 workflows[_wfn()] = ['ScoutingNANOmc140X', ['TTbarMINIAOD14.0', 'scoutingNANO_mc14.0']]
 workflows[_wfn()] = ['ScoutingNANOwithPromptmc140X', ['TTbarMINIAOD14.0', 'scoutingNANO_withPrompt_mc14.0']]
-workflows[_wfn()] = ['BPHNANOmc140X', ['TTbarMINIAOD14.0', 'BPHNANO_mc14.0']]
 
 # POG/PAG custom NANOs, data
 _wfn.subnext()
@@ -395,11 +445,10 @@ workflows[_wfn()] = ['muPOGNANO140Xrun3', ['MuonEG2024MINIAOD14.0', 'muPOGNANO_d
 workflows[_wfn()] = ['EGMNANOdata140Xrun3', ['MuonEG2024MINIAOD14.0', 'EGMNANO_data14.0']]
 workflows[_wfn()] = ['BTVNANOdata140Xrun3', ['MuonEG2024MINIAOD14.0', 'BTVNANO_data14.0']]
 workflows[_wfn()] = ['jmeNANOdata140Xrun3', ['MuonEG2024MINIAOD14.0', 'jmeNANO_data14.0']]
-workflows[_wfn()] = ['jmeNANOrePuppidata140Xrun3', ['MuonEG2024MINIAOD14.0', 'jmeNANO_rePuppi_data14.0']]
+_wfn()  # workflows[_wfn()] = ['jmeNANOrePuppidata140Xrun3', ['MuonEG2024MINIAOD14.0', 'jmeNANO_rePuppi_data14.0']]
 workflows[_wfn()] = ['lepTrackInfoNANOdata140Xrun3', ['MuonEG2024MINIAOD14.0', 'lepTrackInfoNANO_data14.0']]
 workflows[_wfn()] = ['ScoutingNANOdata140Xrun3', ['ScoutingPFRun32024RAW14.0', 'scoutingNANO_data14.0']]
 workflows[_wfn()] = ['ScoutingNANOwithPromptdata140Xrun3', ['ScoutingPFMonitor2024MINIAOD14.0', 'scoutingNANO_withPrompt_data14.0']]
-workflows[_wfn()] = ['BPHNANOdata140Xrun3', ['MuonEG2024MINIAOD14.0', 'BPHNANO_data14.0']]
 
 # DPG custom NANOs, data
 _wfn.subnext()
@@ -416,20 +465,54 @@ workflows[_wfn()] = ['hcalDPGMCNANO140Xrun3', ['SinglePionRAW14.0', 'hcalDPGNANO
 # but I keep the 14.0 label for now since it's consistent with those ones
 # let me know if I should change this
 
+# MINIv6+NANOv15, MC
+_wfn.subnext()
+workflows[_wfn()] = ['NANOmc2024reMINI', ['TTbar_13p6_Summer24_AOD_140X', 'REMINIAOD_mc2024', 'NANO_mc_Summer24_reMINI', 'HRV_NANO_mc']]  # noqa
+
+# MINIv6+NANOv15, data
+_wfn.subnext()
+workflows[_wfn()] = ['NANOdata2024reMINI', ['JetMET1_Run2024H_AOD_140X', 'REMINIAOD_data2024', 'NANO_data_2024_reMINI', 'HRV_NANO_data']]  # noqa
+
 _wfn.next(3)
 ######## 2500.3xx ########
-# Run3 re-MINI/NANOv15 in 15_0_X
-workflows[_wfn()] = ['NANOmc2024reMINI', ['TTbar_13p6_Summer24_AOD', 'REMINIAOD_mc2024', 'NANO_mc_Summer24_reMINI', 'HRV_NANO_mc']]  # noqa
+# Run3, 15_0_X input (2024 MINIv6+NANOv15 & 2025 data-taking)
+# Standard NANO, MC
+workflows[_wfn()] = ['NANOmc150X', ['TTbar_13p6_Summer24_MINIAOD_150X', 'NANO_mc15.0', 'HRV_NANO_mc']]
 
+# Standard NANO, data
 _wfn.subnext()
-workflows[_wfn()] = ['NANOdata2024reMINI', ['JetMET1_Run2024H_AOD', 'REMINIAOD_data2024', 'NANO_data_2024_reMINI', 'HRV_NANO_data']]  # noqa
+workflows[_wfn()] = ['NANOdata150X', ['JetMET1_Run2025C_MINIAOD_150X', 'NANO_data15.0', 'HRV_NANO_data']]
+workflows[_wfn()] = ['NANOdata150X', ['JetMET1_Run2025C_MINIAOD_150X', 'NANO_data15.0_prompt', 'HRV_NANO_data']]
 
-# Run3, 15_0_X input (2025)
+# POG/PAG custom NANOs, MC
 _wfn.subnext()
-workflows[_wfn()] = ['NANOmc150X', ['TTbar_13p6_Summer24_MINIAOD', 'NANO_mc15.0', 'HRV_NANO_mc']]
+workflows[_wfn()] = ['muPOGNANOmc150X', ['TTbar_13p6_Summer24_MINIAOD_150X', 'muPOGNANO_mc15.0']]
+workflows[_wfn()] = ['EGMNANOmc150X', ['TTbar_13p6_Summer24_MINIAOD_150X', 'EGMNANO_mc15.0']]
+workflows[_wfn()] = ['BTVNANOmc150X', ['TTbar_13p6_Summer24_MINIAOD_150X', 'BTVNANO_mc15.0']]
+workflows[_wfn()] = ['jmeNANOmc150X', ['TTbar_13p6_Summer24_MINIAOD_150X', 'jmeNANO_mc15.0']]
+workflows[_wfn()] = ['jmeNANOrePuppimc150X', ['TTbar_13p6_Summer24_MINIAOD_150X', 'jmeNANO_rePuppi_mc15.0']]
+workflows[_wfn()] = ['lepTrackInfoNANOmc150X', ['TTbar_13p6_Summer24_MINIAOD_150X', 'lepTrackInfoNANO_mc15.0']]
+workflows[_wfn()] = ['ScoutingNANOmc150X', ['TTbar_13p6_Summer24_MINIAOD_150X', 'scoutingNANO_mc15.0']]
+workflows[_wfn()] = ['ScoutingNANOwithPromptmc150X', ['TTbar_13p6_Summer24_MINIAOD_150X', 'scoutingNANO_withPrompt_mc15.0']]
+workflows[_wfn()] = ['BPHNANOmc150X', ['TTbar_13p6_Summer24_MINIAOD_150X', 'BPHNANO_mc15.0']]
 
+# POG/PAG custom NANOs, data
 _wfn.subnext()
-workflows[_wfn()] = ['NANOdata150X', ['JetMET1_Run2024H_MINIAOD', 'NANO_data15.0', 'HRV_NANO_data']]
+workflows[_wfn()] = ['muPOGNANO150Xrun3', ['JetMET1_Run2025C_MINIAOD_150X', 'muPOGNANO_data15.0']]
+workflows[_wfn()] = ['EGMNANOdata150Xrun3', ['JetMET1_Run2025C_MINIAOD_150X', 'EGMNANO_data15.0']]
+workflows[_wfn()] = ['BTVNANOdata150Xrun3', ['JetMET1_Run2025C_MINIAOD_150X', 'BTVNANO_data15.0']]
+workflows[_wfn()] = ['jmeNANOdata150Xrun3', ['JetMET1_Run2025C_MINIAOD_150X', 'jmeNANO_data15.0']]
+workflows[_wfn()] = ['jmeNANOrePuppidata150Xrun3', ['JetMET1_Run2025C_MINIAOD_150X', 'jmeNANO_rePuppi_data15.0']]
+workflows[_wfn()] = ['lepTrackInfoNANOdata150Xrun3', ['JetMET1_Run2025C_MINIAOD_150X', 'lepTrackInfoNANO_data15.0']]
+workflows[_wfn()] = ['ScoutingNANOdata150Xrun3', ['ScoutingPFRun3_Run2025C_HLTSCOUT_150X', 'scoutingNANO_data15.0']]
+workflows[_wfn()] = ['ScoutingNANOwithPromptdata150Xrun3', ['ScoutingPFMonitor_Run2025C_MINIAOD_150X', 'scoutingNANO_withPrompt_data15.0']]  # noqa
+workflows[_wfn()] = ['BPHNANOdata150Xrun3', ['JetMET1_Run2025C_MINIAOD_150X', 'BPHNANO_data15.0']]
+
+# DPG custom NANOs, data
+_wfn.subnext()
+
+# DPG custom NANOs, MC
+_wfn.subnext()
 
 
 _wfn.next(9)

--- a/Configuration/PyReleaseValidation/scripts/README.md
+++ b/Configuration/PyReleaseValidation/scripts/README.md
@@ -328,7 +328,7 @@ MC workflows for pp collisions:
 | 16834.0 	| RelValTTbar_14TeV 	| phase1_2025_realistic 	| Run3_2025 	|  	| 
 | 14034.0 	| RelValTTbar_14TeV 	| phase1_2023_realistic 	| Run3_2023_FastSim 	|  	*FastSim* |  	
 | 14234.0 	| RelValTTbar_14TeV 	| phase1_2023_realistic 	| Run3_2023_FastSim 	| *FastSim*  Run3_Flat55To75_PoissonOOTPU 	|  	
-| 2500.201 	| RelValTTbar_14TeV 	| phase1_2022_realistic 	| Run3 	| NanoAOD from existing MINI 	|  	
+| 2500.301 	| RelValTTbar_14TeV 	| phase1_2025_realistic 	| Run3_2025 	| NanoAOD from existing MINI 	|  	
 | | | | | | 
 | **Phase2** 	|  	|  	|  	|  	**Geometry** |  	
 | |  	|  	|  	|  	|  	

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -101,7 +101,7 @@ if __name__ == '__main__':
             17034.0,    # RelValTTbar_14TeV		2025 PU = Run3_Flat55To75_PoissonOOTPU
             14034.0,    # RelValTTbar_14TeV             Run3_2023_FastSim
             14234.0,    # RelValTTbar_14TeV             Run3_2023_FastSim   PU = Run3_Flat55To75_PoissonOOTPU
-            2500.201,   # RelValTTbar_14TeV             NanoAOD from existing MINI
+            2500.301,   # RelValTTbar_14TeV             NanoAOD from existing MINI
 
             ###### pp Data
             ## Run3

--- a/PhysicsTools/NanoAOD/python/btvMC_cff.py
+++ b/PhysicsTools/NanoAOD/python/btvMC_cff.py
@@ -58,22 +58,6 @@ def addGenCands(process, allPF = False, addAK4=False, addAK8=False):
         )
         process.btvGenTask.add(process.btvAK4JetExtTable)
 
-    if addAK8:
-        process.btvSubJetMCExtTable = cms.EDProducer(
-            "SimplePATJetFlatTableProducer",
-            src = subJetTable.src,
-            cut = subJetTable.cut,
-            name = subJetTable.name,
-            doc=subJetTable.doc,
-            singleton = cms.bool(False),
-            extension = cms.bool(True),
-            variables = cms.PSet(
-                subGenJetAK8Idx = Var("?genJetFwdRef().backRef().isNonnull()?genJetFwdRef().backRef().key():-1",
-                int, doc="index of matched gen Sub jet"),
-            )
-        )
-        process.btvGenTask.add(process.btvSubJetMCExtTable)
-
     if addAK4:
         process.genJetsAK4Constituents = cms.EDProducer("GenJetPackedConstituentPtrSelector",
             src = cms.InputTag("slimmedGenJets"),

--- a/PhysicsTools/NanoAOD/python/custom_muon_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_muon_cff.py
@@ -14,6 +14,7 @@ def Custom_Muon_Task(process):
     process.nanoTableTaskCommon.remove(process.boostedTauTablesTask)
     process.nanoTableTaskCommon.remove(process.jetPuppiTablesTask)
     process.nanoTableTaskCommon.remove(process.jetAK8TablesTask)
+    process.nanoTableTaskCommon.remove(process.jetConstituentsTablesTask)
 
     process.nanoTableTaskFS.remove(process.electronMCTask)
     process.nanoTableTaskFS.remove(process.lowPtElectronMCTask)
@@ -24,7 +25,8 @@ def Custom_Muon_Task(process):
     process.nanoTableTaskFS.remove(process.metMCTable)
     process.nanoTableTaskFS.remove(process.ttbarCatMCProducersTask)
     process.nanoTableTaskFS.remove(process.ttbarCategoryTableTask)
-    
+    process.nanoTableTaskFS.remove(process.tauSpinnerTableTask)
+
     return process
 
 def AddPFTracks(proc):

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnRealData_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnRealData_cff.py
@@ -2,7 +2,6 @@ import FWCore.ParameterSet.Config as cms
 from Validation.RecoTau.RecoTauValidation_cfi import *
 import copy
 
-from RecoJets.Configuration.RecoPFJets_cff import *
 import PhysicsTools.PatAlgos.tools.helpers as helpers
 
 kinematicSelectedPFJets = cms.EDFilter(

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnRealElectronsData_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnRealElectronsData_cff.py
@@ -2,7 +2,6 @@ import FWCore.ParameterSet.Config as cms
 from Validation.RecoTau.RecoTauValidation_cfi import *
 import copy
 
-from RecoJets.Configuration.RecoPFJets_cff import *
 import PhysicsTools.PatAlgos.tools.helpers as helpers
 
 ElPrimaryVertexFilter = cms.EDFilter(

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnRealMuonsData_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnRealMuonsData_cff.py
@@ -2,7 +2,6 @@ import FWCore.ParameterSet.Config as cms
 from Validation.RecoTau.RecoTauValidation_cfi import *
 import copy
 
-from RecoJets.Configuration.RecoPFJets_cff import *
 import PhysicsTools.PatAlgos.tools.helpers as helpers
 
 MuPrimaryVertexFilter = cms.EDFilter(


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/48152

> #### PR description:
> 
> Update NANO relval workflows to include using 150X data and MC as inputs.
> 
> This factorizes out the needed relval updates in https://github.com/cms-sw/cmssw/pull/48104.
> 
> #### PR validation:
> 
> `runTheMatrix.py -w nano --ibeos`
> 
> #### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
> 
> to be backported to 150X