### PR TITLE
Add the jet mass to the SC8 L1Nano table

### DIFF
--- a/DPGAnalysis/Phase2L1TNanoAOD/python/l1tPh2Nanotables_cff.py
+++ b/DPGAnalysis/Phase2L1TNanoAOD/python/l1tPh2Nanotables_cff.py
@@ -373,7 +373,11 @@ sc4JetTable = pfJetTable.clone(
 sc8JetTable = pfJetTable.clone(
     src = 'l1tSC8PFL1PuppiCorrectedEmulator',
     name = "L1puppiJetSC8",
-    doc = "SeededCone 0.8 Puppi jet,  origin: Correlator"
+    doc = "SeededCone 0.8 Puppi jet,  origin: Correlator",
+    variables = cms.PSet(
+        pfJetTable.variables.clone(),
+        mass = Var("mass", float)
+    )
 )
 
 sc4ExtJetTable = pfJetTable.clone(


### PR DESCRIPTION
#### PR description:

This PR adds the jet mass to Phase 2 L1Nano tables. Jet mass emulation for SC8 jets was introduced in #47792 .

#### PR validation:

I made a small test running a configuration to produce a L1Nano ntuple and verified that the mass field is written and filled, adding `L1puppiJetSC8_mass` branch to the ntuple.