### PR TITLE
Issue UnusedProductsForCanDeleteEarly message only once

### DIFF
--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -676,7 +676,7 @@ namespace edm {
           ++it;
         }
       }
-      if (not unusedBranches.empty()) {
+      if (not unusedBranches.empty() and streamID_.value() == 0) {
         LogWarning l("UnusedProductsForCanDeleteEarly");
         l << "The following products in the 'canDeleteEarly' list are not used in this job and will be ignored.\n"
              " If possible, remove the producer from the job.";


### PR DESCRIPTION
#### PR description:

Only have stream 0 issue the message.

#### PR validation:

Code compiles.

resolves https://github.com/cms-sw/framework-team/issues/1413