### PR TITLE
Add an option to edmFileUtil to print detailed basket information for a given branch

### DIFF
--- a/IOPool/Common/bin/CollUtil.cc
+++ b/IOPool/Common/bin/CollUtil.cc
@@ -151,7 +151,7 @@ namespace edm {
       bool isAligned_ = true;
     };
 
-    std::vector<BranchBasketBytes> makeBranchBasketBytes(TBranch *branch, bool isEventsTree) {
+    std::vector<BranchBasketBytes> makeBranchBasketBytes(TBranch *branch) {
       std::vector<BranchBasketBytes> ret;
 
       TObjArray *subBranches = branch->GetListOfBranches();
@@ -159,7 +159,7 @@ namespace edm {
         // process sub-branches if there are any
         auto const nbranches = subBranches->GetEntries();
         for (Long64_t iBranch = 0; iBranch < nbranches; ++iBranch) {
-          auto vec = makeBranchBasketBytes(dynamic_cast<TBranch *>(subBranches->At(iBranch)), isEventsTree);
+          auto vec = makeBranchBasketBytes(dynamic_cast<TBranch *>(subBranches->At(iBranch)));
           ret.insert(ret.end(), std::make_move_iterator(vec.begin()), std::make_move_iterator(vec.end()));
         }
       } else {
@@ -169,7 +169,7 @@ namespace edm {
     }
   }  // namespace
 
-  void clusterPrint(TTree *tr, bool isEventsTree) {
+  void clusterPrint(TTree *tr) {
     TTree::TClusterIterator clusterIter = tr->GetClusterIterator(0);
     Long64_t const nentries = tr->GetEntries();
 
@@ -180,18 +180,13 @@ namespace edm {
       TObjArray *branches = tr->GetListOfBranches();
       Long64_t const nbranches = branches->GetEntries();
       for (Long64_t iBranch = 0; iBranch < nbranches; ++iBranch) {
-        auto vec = makeBranchBasketBytes(dynamic_cast<TBranch *>(branches->At(iBranch)), isEventsTree);
+        auto vec = makeBranchBasketBytes(dynamic_cast<TBranch *>(branches->At(iBranch)));
         processors.insert(processors.end(), std::make_move_iterator(vec.begin()), std::make_move_iterator(vec.end()));
       }
     }
 
     std::cout << "Printing cluster boundaries in terms of tree entries of the tree " << tr->GetName()
               << ". Note that end boundary is exclusive." << std::endl;
-    if (isEventsTree) {
-      std::cout << "For the Events tree the metadata branches are excluded from this calculation, "
-                   "because their basket boundaries do not necessarily align with the cluster boundaries."
-                << std::endl;
-    }
     std::cout << std::setw(15) << "Begin" << std::setw(15) << "End" << std::setw(15) << "Entries" << std::setw(15)
               << "Max baskets" << std::setw(15) << "Bytes" << std::endl;
     // Record branches whose baskets do not align with cluster boundaires

--- a/IOPool/Common/bin/CollUtil.cc
+++ b/IOPool/Common/bin/CollUtil.cc
@@ -18,6 +18,7 @@
 
 #include <iomanip>
 #include <iostream>
+#include <ranges>
 
 namespace edm {
 
@@ -109,6 +110,8 @@ namespace edm {
 
       bool isAlignedWithClusterBoundaries() const { return isAligned_; }
 
+      std::string_view name() const { return branchName_; }
+
       // Processes "next cluster" for the branch, calculating the
       // number of bytes and baskets in the cluster
       //
@@ -167,55 +170,116 @@ namespace edm {
       }
       return ret;
     }
+
+    template <typename T>
+    void processClusters(TTree *tr, T printer, const std::string &limitToBranch = "") {
+      TTree::TClusterIterator clusterIter = tr->GetClusterIterator(0);
+      Long64_t const nentries = tr->GetEntries();
+
+      // Keep the state of each branch basket index so that we don't
+      // have to iterate through everything on every cluster
+      std::vector<BranchBasketBytes> processors;
+      {
+        TObjArray *branches = tr->GetListOfBranches();
+        Long64_t const nbranches = branches->GetEntries();
+        for (Long64_t iBranch = 0; iBranch < nbranches; ++iBranch) {
+          auto branch = dynamic_cast<TBranch *>(branches->At(iBranch));
+          if (limitToBranch.empty() or
+              std::string_view(branch->GetName()).find(limitToBranch) != std::string_view::npos) {
+            auto vec = makeBranchBasketBytes(branch);
+            processors.insert(
+                processors.end(), std::make_move_iterator(vec.begin()), std::make_move_iterator(vec.end()));
+          }
+        }
+      }
+
+      printer.header(tr, processors);
+      // Record branches whose baskets do not align with cluster boundaries
+      std::set<std::string_view> nonAlignedBranches;
+      {
+        Long64_t clusterBegin;
+        while ((clusterBegin = clusterIter()) < nentries) {
+          Long64_t clusterEnd = clusterIter.GetNextEntry();
+          printer.beginCluster(clusterBegin, clusterEnd);
+          for (auto &p : processors) {
+            if (p.isAlignedWithClusterBoundaries()) {
+              auto const [bytes, baskets] = p.bytesInNextCluster(clusterBegin, clusterEnd, nonAlignedBranches);
+              printer.processBranch(bytes, baskets);
+            }
+          }
+          printer.endCluster();
+        }
+      }
+
+      if (not nonAlignedBranches.empty()) {
+        std::cout << "\nThe following branches had baskets whose entry boundaries did not align with the cluster "
+                     "boundaries. Their baskets are excluded from the cluster size calculation above starting from the "
+                     "first basket that did not align with a cluster boundary."
+                  << std::endl;
+        for (auto &name : nonAlignedBranches) {
+          std::cout << "  " << name << std::endl;
+        }
+      }
+    }
   }  // namespace
 
   void clusterPrint(TTree *tr) {
-    TTree::TClusterIterator clusterIter = tr->GetClusterIterator(0);
-    Long64_t const nentries = tr->GetEntries();
-
-    // Keep the state of each branch basket index so that we don't
-    // have to iterate through everything on every cluster
-    std::vector<BranchBasketBytes> processors;
-    {
-      TObjArray *branches = tr->GetListOfBranches();
-      Long64_t const nbranches = branches->GetEntries();
-      for (Long64_t iBranch = 0; iBranch < nbranches; ++iBranch) {
-        auto vec = makeBranchBasketBytes(dynamic_cast<TBranch *>(branches->At(iBranch)));
-        processors.insert(processors.end(), std::make_move_iterator(vec.begin()), std::make_move_iterator(vec.end()));
+    struct ClusterPrinter {
+      void header(TTree const *tr, std::vector<BranchBasketBytes> const &branchProcessors) const {
+        std::cout << "Printing cluster boundaries in terms of tree entries of the tree " << tr->GetName()
+                  << ". Note that the end boundary is exclusive." << std::endl;
+        std::cout << std::setw(15) << "Begin" << std::setw(15) << "End" << std::setw(15) << "Entries" << std::setw(15)
+                  << "Max baskets" << std::setw(15) << "Bytes" << std::endl;
       }
-    }
 
-    std::cout << "Printing cluster boundaries in terms of tree entries of the tree " << tr->GetName()
-              << ". Note that end boundary is exclusive." << std::endl;
-    std::cout << std::setw(15) << "Begin" << std::setw(15) << "End" << std::setw(15) << "Entries" << std::setw(15)
-              << "Max baskets" << std::setw(15) << "Bytes" << std::endl;
-    // Record branches whose baskets do not align with cluster boundaires
-    std::set<std::string_view> nonAlignedBranches;
-    Long64_t clusterBegin;
-    while ((clusterBegin = clusterIter()) < nentries) {
-      Long64_t clusterEnd = clusterIter.GetNextEntry();
-      Long64_t bytes = 0;
-      unsigned int maxbaskets = 0;
-      for (auto &p : processors) {
-        if (p.isAlignedWithClusterBoundaries()) {
-          auto const [byt, bas] = p.bytesInNextCluster(clusterBegin, clusterEnd, nonAlignedBranches);
-          bytes += byt;
-          maxbaskets = std::max(bas, maxbaskets);
+      void beginCluster(Long64_t clusterBegin, Long64_t clusterEnd) {
+        bytes_ = 0;
+        maxbaskets_ = 0;
+        std::cout << std::setw(15) << clusterBegin << std::setw(15) << clusterEnd << std::setw(15)
+                  << (clusterEnd - clusterBegin);
+      }
+
+      void processBranch(Long64_t bytes, unsigned int baskets) {
+        bytes_ += bytes;
+        maxbaskets_ = std::max(baskets, maxbaskets_);
+      }
+
+      void endCluster() const { std::cout << std::setw(15) << maxbaskets_ << std::setw(15) << bytes_ << std::endl; }
+
+      Long64_t bytes_ = 0;
+      unsigned int maxbaskets_ = 0;
+    };
+    processClusters(tr, ClusterPrinter{});
+  }
+
+  void basketPrint(TTree *tr, const std::string &branchName) {
+    struct BasketPrinter {
+      void header(TTree const *tr, std::vector<BranchBasketBytes> const &branchProcessors) const {
+        std::cout << "Printing cluster boundaries in terms of tree entries of the tree " << tr->GetName()
+                  << ". Note that the end boundary is exclusive." << std::endl;
+        std::cout << "\nBranches for which number of baskets in each cluster are printed\n";
+        for (int i = 0; auto const &p : branchProcessors) {
+          std::cout << "[" << i << "] " << p.name() << std::endl;
+          ++i;
         }
+        std::cout << "\n"
+                  << std::setw(15) << "Begin" << std::setw(15) << "End" << std::setw(15) << "Entries" << std::setw(15);
+        for (auto i : std::views::iota(0U, branchProcessors.size())) {
+          std::cout << std::setw(5) << (std::string("[") + std::to_string(i) + "]");
+        }
+        std::cout << std::endl;
       }
-      std::cout << std::setw(15) << clusterBegin << std::setw(15) << clusterEnd << std::setw(15)
-                << (clusterEnd - clusterBegin) << std::setw(15) << maxbaskets << std::setw(15) << bytes << std::endl;
-    }
 
-    if (not nonAlignedBranches.empty()) {
-      std::cout << "\nThe following branches had baskets whose entry boundaries did not align with the cluster "
-                   "boundaries. Their baskets are excluded from the cluster size calculation above starting from the "
-                   "first basket that did not align with a cluster boundary."
-                << std::endl;
-      for (auto &name : nonAlignedBranches) {
-        std::cout << "  " << name << std::endl;
+      void beginCluster(Long64_t clusterBegin, Long64_t clusterEnd) const {
+        std::cout << std::setw(15) << clusterBegin << std::setw(15) << clusterEnd << std::setw(15)
+                  << (clusterEnd - clusterBegin);
       }
-    }
+
+      void processBranch(Long64_t bytes, unsigned int baskets) const { std::cout << std::setw(5) << baskets; }
+
+      void endCluster() const { std::cout << std::endl; }
+    };
+    processClusters(tr, BasketPrinter{}, branchName);
   }
 
   std::string getUuid(TTree *uuidTree) {

--- a/IOPool/Common/bin/CollUtil.h
+++ b/IOPool/Common/bin/CollUtil.h
@@ -16,6 +16,7 @@ namespace edm {
   void printBranchNames(TTree *tree);
   void longBranchPrint(TTree *tr);
   void clusterPrint(TTree *tr);
+  void basketPrint(TTree *tr, const std::string &branchName);
   std::string getUuid(TTree *uuidTree);
   void printUuids(TTree *uuidTree);
   void printEventLists(TFile *tfl);

--- a/IOPool/Common/bin/CollUtil.h
+++ b/IOPool/Common/bin/CollUtil.h
@@ -15,7 +15,7 @@ namespace edm {
   Long64_t numEntries(TFile *hdl, const std::string &trname);
   void printBranchNames(TTree *tree);
   void longBranchPrint(TTree *tr);
-  void clusterPrint(TTree *tr, bool isEventsTree);
+  void clusterPrint(TTree *tr);
   std::string getUuid(TTree *uuidTree);
   void printUuids(TTree *uuidTree);
   void printEventLists(TFile *tfl);

--- a/IOPool/Common/bin/EdmFileUtil.cpp
+++ b/IOPool/Common/bin/EdmFileUtil.cpp
@@ -42,10 +42,13 @@ int main(int argc, char* argv[]) {
       "JSON,j", "JSON output format.  Any arguments listed below are ignored")("ls,l", "list file content")(
       "map,m", "Print TFile::Map(\"extended\"). The output can be HUGE.")("print,P", "Print all")(
       "verbose,v", "Verbose printout")("printBranchDetails,b", "Call Print()sc for all branches")(
+      "printBaskets",
+      boost::program_options::value<std::string>(),
+      "Print detailed information about baskets and clusters for the given branch")(
       "printClusters", "Print detailed information about baskets and clusters for all branches")(
       "tree,t",
       boost::program_options::value<std::string>(),
-      "Select tree used with -P, -b, and --printClusters options")(
+      "Select tree used with -P, -b, --printClusters, and --printBaskets options")(
       "events,e",
       "Print list of all Events, Runs, and LuminosityBlocks in the file sorted by run number, luminosity block number, "
       "and event number.  Also prints the entry numbers and whether it is possible to use fast copy with the file.")(
@@ -114,6 +117,7 @@ int main(int argc, char* argv[]) {
     bool print = more && (vm.count("print") > 0 ? true : false);
     bool printBranchDetails = more && (vm.count("printBranchDetails") > 0 ? true : false);
     bool printClusters = more && (vm.count("printClusters") > 0 ? true : false);
+    std::string printBaskets = (vm.count("printBaskets") ? vm["printBaskets"].as<std::string>() : std::string());
     bool onlyDecodeLFN =
         decodeLFN && !(uuid || adler32 || allowRecovery || json || events || tree || ls || print || printBranchDetails);
     std::string selectedTree = tree ? vm["tree"].as<std::string>() : edm::poolNames::eventTreeName();
@@ -257,35 +261,29 @@ int main(int argc, char* argv[]) {
         tfile->Map("extended");
       }
 
-      // Print out each tree
-      if (print) {
+      if (print or printBranchDetails or printClusters or not printBaskets.empty()) {
         TTree* printTree = (TTree*)tfile->Get(selectedTree.c_str());
         if (printTree == nullptr) {
           std::cout << "Tree " << selectedTree << " appears to be missing. Could not find it in the file.\n";
           std::cout << "Exiting\n";
           return 1;
         }
-        edm::printBranchNames(printTree);
-      }
+        // Print out each tree
+        if (print) {
+          edm::printBranchNames(printTree);
+        }
 
-      if (printBranchDetails) {
-        TTree* printTree = (TTree*)tfile->Get(selectedTree.c_str());
-        if (printTree == nullptr) {
-          std::cout << "Tree " << selectedTree << " appears to be missing. Could not find it in the file.\n";
-          std::cout << "Exiting\n";
-          return 1;
+        if (printBranchDetails) {
+          edm::longBranchPrint(printTree);
         }
-        edm::longBranchPrint(printTree);
-      }
 
-      if (printClusters) {
-        TTree* printTree = (TTree*)tfile->Get(selectedTree.c_str());
-        if (printTree == nullptr) {
-          std::cout << "Tree " << selectedTree << " appears to be missing. Could not find it in the file.\n";
-          std::cout << "Exiting\n";
-          return 1;
+        if (printClusters) {
+          edm::clusterPrint(printTree);
         }
-        edm::clusterPrint(printTree);
+
+        if (not printBaskets.empty()) {
+          edm::basketPrint(printTree, printBaskets);
+        }
       }
 
       // Print out event lists

--- a/IOPool/Common/bin/EdmFileUtil.cpp
+++ b/IOPool/Common/bin/EdmFileUtil.cpp
@@ -279,14 +279,13 @@ int main(int argc, char* argv[]) {
       }
 
       if (printClusters) {
-        bool const isEventsTree = (selectedTree == edm::BranchTypeToProductTreeName(edm::InEvent));
         TTree* printTree = (TTree*)tfile->Get(selectedTree.c_str());
         if (printTree == nullptr) {
           std::cout << "Tree " << selectedTree << " appears to be missing. Could not find it in the file.\n";
           std::cout << "Exiting\n";
           return 1;
         }
-        edm::clusterPrint(printTree, isEventsTree);
+        edm::clusterPrint(printTree);
       }
 
       // Print out event lists


### PR DESCRIPTION
#### PR description:

This PR adds `--printBaskets` option to `edmFileUtil` to print the number of baskets for each cluster for each sub-branch of the given branch (really for any branch that contains the argument as a substring). This ability was useful to understand the TFile/TTree structure in the context of https://github.com/cms-sw/cmssw/issues/47750

The earlier ability to print cluster information (from https://github.com/cms-sw/cmssw/pull/48044) turned out to be straightforward to generalize a bit. The first commit of this PR is a cleanup that should have been part of https://github.com/cms-sw/cmssw/pull/48044, but I didn't realize at the time.

Resolves https://github.com/cms-sw/framework-team/issues/1410

#### PR validation:

The added option works in a private test