### PR TITLE
Allow temporary std::string messages for IntrusiveMonitorBase

### DIFF
--- a/PerfTools/AllocMonitor/test/test_intrusiveAllocMonitor.cc
+++ b/PerfTools/AllocMonitor/test/test_intrusiveAllocMonitor.cc
@@ -41,6 +41,19 @@ process.add_(cms.Service('IntrusiveAllocMonitor'))
 
     edm::LogPrint("Test").format("Sum {}", sum);
   }
+  {
+    auto guard = imb->startMonitoring(std::string("Vector fill again"));
+    for (int i = 0; i < 10000; ++i) {
+      vec.push_back(i * 2 - 1);
+    }
+
+    int sum = 0;
+    for (int a : vec) {
+      sum += a;
+    }
+
+    edm::LogPrint("Test").format("Sum {}", sum);
+  }
 
   return 0;
 }


### PR DESCRIPTION
#### PR description:

The present `IntrusiveMonitorBase::startMonitoring()` has `std::string_view` argument that requires the string to be owned elsewhere. While this works fine for e.g. C-string or `string_view` literals such as
```cpp
edm::Service<IntrusiveMonitorBase s;
auto guard s->startMonitoring("Some message");
```
it doesn't work for temporary `std::string`s like
```cpp
edm::Service<IntrusiveMonitorBase s;
auto guard s->startMonitoring(fmt::format("Some function for event {}", iEvent.id().event());
```

This PR adds an overload for the `startMonitoring()` that accepts only rvalue `std::string` (this part required some tricks), and forwards the ownership of the string to a specific `Guard` object.

Resolves https://github.com/cms-sw/framework-team/issues/1412

#### PR validation:

The unit test runs