### PR TITLE
SiStrip Payload Inspector: fix swapped IoV list in comparison plots using `SiStripCondObjectRepresent`

### DIFF
--- a/CondCore/SiStripPlugins/plugins/SiStripApvGain_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripApvGain_PayloadInspector.cc
@@ -1839,14 +1839,12 @@ namespace {
     bool fill() override {
       TH1F::SetDefaultSumw2(true);
 
-      // trick to deal with the multi-ioved tag and two tag case at the same time
       auto theIOVs = PlotBase::getTag<0>().iovs;
       auto tagname1 = PlotBase::getTag<0>().name;
       std::string tagname2 = "";
       auto firstiov = theIOVs.front();
       SiStripPI::MetaData lastiov;
 
-      // we don't support (yet) comparison with more than 2 tags
       assert(this->m_plotAnnotations.ntags < 3);
 
       if (this->m_plotAnnotations.ntags == 2) {
@@ -1857,165 +1855,140 @@ namespace {
         lastiov = theIOVs.back();
       }
 
-      std::shared_ptr<SiStripApvGain> last_payload = this->fetchPayload(std::get<1>(lastiov));
-      std::shared_ptr<SiStripApvGain> first_payload = this->fetchPayload(std::get<1>(firstiov));
+      auto first_payload = this->fetchPayload(std::get<1>(firstiov));
+      auto last_payload = this->fetchPayload(std::get<1>(lastiov));
 
-      std::string lastIOVsince = std::to_string(std::get<0>(lastiov));
       std::string firstIOVsince = std::to_string(std::get<0>(firstiov));
+      std::string lastIOVsince = std::to_string(std::get<0>(lastiov));
 
-      std::vector<uint32_t> detid;
-      last_payload->getDetIds(detid);
-
-      std::map<std::pair<uint32_t, int>, float> lastmap, firstmap;
-
-      // loop on the last payload
-      for (const auto& d : detid) {
-        SiStripApvGain::Range range = last_payload->getRange(d);
-        float nAPV = 0;
-        for (int it = 0; it < range.second - range.first; ++it) {
-          nAPV += 1;
-          auto index = std::make_pair(d, nAPV);
-          lastmap[index] = last_payload->getApvGain(it, range);
-        }  // end loop on APVs
-      }  // end loop on detids
-
-      detid.clear();
-      first_payload->getDetIds(detid);
-
-      // loop on the first payload
-      for (const auto& d : detid) {
-        SiStripApvGain::Range range = first_payload->getRange(d);
-        float nAPV = 0;
-        for (int it = 0; it < range.second - range.first; ++it) {
-          nAPV += 1;
-          auto index = std::make_pair(d, nAPV);
-          firstmap[index] = last_payload->getApvGain(it, range);
-        }  // end loop on APVs
-      }  // end loop on detids
+      auto firstmap = extractApvGains(first_payload);
+      auto lastmap = extractApvGains(last_payload);
 
       TCanvas canvas("Payload comparison", "payload comparison", 1000, 1000);
       canvas.cd();
 
-      TPad pad1("pad1", "pad1", 0, 0.3, 1, 1.0);
-      pad1.SetBottomMargin(0.02);  // Upper and lower plot are joined
-      pad1.SetTopMargin(0.1);
-      pad1.SetRightMargin(0.05);
-      pad1.SetLeftMargin(0.15);
-      pad1.Draw();  // Draw the upper pad: pad1
-      pad1.cd();    // pad1 becomes the current pad
+      TPad* pad1 = createPad("pad1", 0.3, 1.0);
+      pad1->cd();
 
       auto h_firstGains = std::make_shared<TH1F>("hFirstGains", ";SiStrip APV Gains;n. APVs", 200, 0.2, 1.8);
       auto h_lastGains = std::make_shared<TH1F>("hLastGains", ";SiStrip APV Gains;n. APVs", 200, 0.2, 1.8);
 
-      for (const auto& item : firstmap) {
+      for (const auto& item : firstmap)
         h_firstGains->Fill(item.second);
-      }
-
-      for (const auto& item : lastmap) {
+      for (const auto& item : lastmap)
         h_lastGains->Fill(item.second);
-      }
 
-      SiStripPI::makeNicePlotStyle(h_lastGains.get());
       SiStripPI::makeNicePlotStyle(h_firstGains.get());
+      SiStripPI::makeNicePlotStyle(h_lastGains.get());
 
-      TH1F* hratio = (TH1F*)h_firstGains->Clone("hratio");
+      styleHistogram(h_firstGains.get(), kRed, 20);
+      styleHistogram(h_lastGains.get(), kBlue, 21);
 
-      h_firstGains->SetLineColor(kRed);
-      h_lastGains->SetLineColor(kBlue);
-
-      h_firstGains->SetMarkerColor(kRed);
-      h_lastGains->SetMarkerColor(kBlue);
-
-      h_firstGains->SetMarkerSize(1.);
-      h_lastGains->SetMarkerSize(1.);
-
-      h_firstGains->SetLineWidth(2);
-      h_lastGains->SetLineWidth(2);
-
-      h_firstGains->SetMarkerStyle(20);
-      h_lastGains->SetMarkerStyle(21);
-
-      h_firstGains->GetXaxis()->SetLabelOffset(2.);
-      h_lastGains->GetXaxis()->SetLabelOffset(2.);
-
-      float max = (h_firstGains->GetMaximum() > h_lastGains->GetMaximum()) ? h_firstGains->GetMaximum()
-                                                                           : h_lastGains->GetMaximum();
-
+      float max = std::max(h_firstGains->GetMaximum(), h_lastGains->GetMaximum());
       h_firstGains->GetYaxis()->SetRangeUser(0., std::max(0., max * 1.20));
 
       h_firstGains->Draw("HIST");
       h_lastGains->Draw("HISTsame");
 
-      TLegend legend = TLegend(0.30, 0.78, 0.95, 0.9);
-      legend.SetHeader("#font[22]{SiStrip APV Gains Comparison}", "C");  // option "C" allows to center the header
+      TLegend legend(0.30, 0.78, 0.95, 0.9);
+      legend.SetHeader("#font[22]{SiStrip APV Gains Comparison}", "C");
       legend.AddEntry(h_firstGains.get(), ("payload: #color[2]{" + std::get<1>(firstiov) + "}").c_str(), "F");
       legend.AddEntry(h_lastGains.get(), ("payload: #color[4]{" + std::get<1>(lastiov) + "}").c_str(), "F");
       legend.SetTextSize(0.025);
       legend.Draw("same");
 
-      auto ltx = TLatex();
+      TLatex ltx;
       ltx.SetTextFont(62);
       ltx.SetTextSize(0.037);
       ltx.SetTextAlign(11);
-      std::string ltxText;
-      if (this->m_plotAnnotations.ntags == 2) {
-        ltxText = fmt::sprintf(
-            "#splitline{#color[2]{%s, %s} vs}{#color[4]{%s, %s}}", tagname1, firstIOVsince, tagname2, lastIOVsince);
-      } else {
-        ltxText = fmt::sprintf(
-            "#splitline{%s}{IOV: #color[2]{%s} vs IOV: #color[4]{%s}}", tagname1, firstIOVsince, lastIOVsince);
-      }
+      std::string ltxText =
+          buildLatexAnnotation(tagname1, firstIOVsince, tagname2, lastIOVsince, this->m_plotAnnotations.ntags);
       ltx.DrawLatexNDC(gPad->GetLeftMargin(), 1 - gPad->GetTopMargin() + 0.04, ltxText.c_str());
 
-      // lower plot will be in pad
-      canvas.cd();  // Go back to the main canvas before defining pad2
-      TPad pad2("pad2", "pad2", 0, 0.005, 1, 0.3);
-      pad2.SetTopMargin(0.01);
-      pad2.SetBottomMargin(0.2);
-      pad2.SetRightMargin(0.05);
-      pad2.SetLeftMargin(0.15);
-      pad2.SetGridy();  // horizontal grid
-      pad2.Draw();
-      pad2.cd();  // pad2 becomes the current pad
+      canvas.cd();
+      TPad* pad2 = createPad("pad2", 0.005, 0.3, true);
+      pad2->cd();
 
-      // Define the ratio plot
+      TH1F* hratio = (TH1F*)h_firstGains->Clone("hratio");
       hratio->SetLineColor(kBlack);
       hratio->SetMarkerColor(kBlack);
       hratio->SetTitle("");
-      hratio->SetMinimum(0.55);  // Define Y ..
-      hratio->SetMaximum(1.55);  // .. range
-      hratio->SetStats(false);   // No statistics on lower plot
+      hratio->SetMinimum(0.55);
+      hratio->SetMaximum(1.55);
+      hratio->SetStats(false);
       hratio->Divide(h_lastGains.get());
       hratio->SetMarkerStyle(20);
-      hratio->Draw("ep");  // Draw the ratio plot
+      hratio->Draw("ep");
 
-      // Y axis ratio plot settings
       hratio->GetYaxis()->SetTitle(
           ("ratio " + std::to_string(std::get<0>(firstiov)) + " / " + std::to_string(std::get<0>(lastiov))).c_str());
-
       hratio->GetYaxis()->SetNdivisions(505);
 
       SiStripPI::makeNicePlotStyle(hratio);
-
       hratio->GetYaxis()->SetTitleSize(25);
-      hratio->GetXaxis()->SetLabelSize(25);
-
       hratio->GetYaxis()->SetTitleFont(43);
       hratio->GetYaxis()->SetTitleOffset(2.5);
-      hratio->GetYaxis()->SetLabelFont(43);  // Absolute font size in pixel (precision 3)
+      hratio->GetYaxis()->SetLabelFont(43);
       hratio->GetYaxis()->SetLabelSize(25);
 
-      // X axis ratio plot settings
       hratio->GetXaxis()->SetTitleSize(30);
       hratio->GetXaxis()->SetTitleFont(43);
       hratio->GetXaxis()->SetTitle("SiStrip APV Gains");
-      hratio->GetXaxis()->SetLabelFont(43);  // Absolute font size in pixel (precision 3)
+      hratio->GetXaxis()->SetLabelFont(43);
       hratio->GetXaxis()->SetTitleOffset(3.);
+      hratio->GetXaxis()->SetLabelSize(25);
 
-      std::string fileName(this->m_imageFileName);
-      canvas.SaveAs(fileName.c_str());
-
+      canvas.SaveAs(this->m_imageFileName.c_str());
       return true;
+    }
+
+  private:
+    std::map<std::pair<uint32_t, int>, float> extractApvGains(std::shared_ptr<SiStripApvGain> payload) {
+      std::map<std::pair<uint32_t, int>, float> gainMap;
+      std::vector<uint32_t> detids;
+      payload->getDetIds(detids);
+      for (const auto& detid : detids) {
+        auto range = payload->getRange(detid);
+        for (int it = 0; it < range.second - range.first; ++it) {
+          auto index = std::make_pair(detid, it + 1);
+          gainMap[index] = payload->getApvGain(it, range);
+        }
+      }
+      return gainMap;
+    }
+
+    void styleHistogram(TH1F* hist, int color, int markerStyle) {
+      hist->SetLineColor(color);
+      hist->SetMarkerColor(color);
+      hist->SetMarkerSize(1.);
+      hist->SetLineWidth(2);
+      hist->SetMarkerStyle(markerStyle);
+      hist->GetXaxis()->SetLabelOffset(2.);
+    }
+
+    TPad* createPad(const std::string& name, double ylow, double yhigh, bool gridy = false) {
+      auto* pad = new TPad(name.c_str(), name.c_str(), 0, ylow, 1, yhigh);
+      pad->SetTopMargin(0.1);
+      pad->SetBottomMargin(ylow == 0 ? 0.2 : 0.02);
+      pad->SetRightMargin(0.05);
+      pad->SetLeftMargin(0.15);
+      if (gridy)
+        pad->SetGridy();
+      pad->Draw();
+      return pad;
+    }
+
+    std::string buildLatexAnnotation(const std::string& tagname1,
+                                     const std::string& firstIOVsince,
+                                     const std::string& tagname2,
+                                     const std::string& lastIOVsince,
+                                     const int n_tags) {
+      if (n_tags == 2) {
+        return fmt::sprintf(
+            "#splitline{#color[2]{%s, %s} vs}{#color[4]{%s, %s}}", tagname1, firstIOVsince, tagname2, lastIOVsince);
+      }
+      return fmt::sprintf(
+          "#splitline{%s}{IOV: #color[2]{%s} vs IOV: #color[4]{%s}}", tagname1, firstIOVsince, lastIOVsince);
     }
   };
 

--- a/CondCore/SiStripPlugins/plugins/SiStripApvGain_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripApvGain_PayloadInspector.cc
@@ -142,8 +142,8 @@ namespace {
       std::shared_ptr<SiStripApvGain> last_payload = this->fetchPayload(std::get<1>(lastiov));
       std::shared_ptr<SiStripApvGain> first_payload = this->fetchPayload(std::get<1>(firstiov));
 
-      SiStripApvGainContainer* l_objContainer = new SiStripApvGainContainer(last_payload, lastiov, tagname1);
-      SiStripApvGainContainer* f_objContainer = new SiStripApvGainContainer(first_payload, firstiov, tagname2);
+      SiStripApvGainContainer* l_objContainer = new SiStripApvGainContainer(last_payload, lastiov, tagname2);
+      SiStripApvGainContainer* f_objContainer = new SiStripApvGainContainer(first_payload, firstiov, tagname1);
 
       l_objContainer->compare(f_objContainer);
 

--- a/CondCore/SiStripPlugins/plugins/SiStripLorentzAngle_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripLorentzAngle_PayloadInspector.cc
@@ -122,9 +122,9 @@ namespace {
       std::shared_ptr<SiStripLorentzAngle> last_payload = fetchPayload(std::get<1>(lastiov));
       std::shared_ptr<SiStripLorentzAngle> first_payload = fetchPayload(std::get<1>(firstiov));
 
-      SiStripLorentzAngleContainer *l_objContainer = new SiStripLorentzAngleContainer(last_payload, lastiov, tagname1);
+      SiStripLorentzAngleContainer *l_objContainer = new SiStripLorentzAngleContainer(last_payload, lastiov, tagname2);
       SiStripLorentzAngleContainer *f_objContainer =
-          new SiStripLorentzAngleContainer(first_payload, firstiov, tagname2);
+          new SiStripLorentzAngleContainer(first_payload, firstiov, tagname1);
 
       l_objContainer->compare(f_objContainer);
 

--- a/CondCore/SiStripPlugins/plugins/SiStripNoises_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripNoises_PayloadInspector.cc
@@ -101,8 +101,8 @@ namespace {
       std::shared_ptr<SiStripNoises> last_payload = this->fetchPayload(std::get<1>(lastiov));
       std::shared_ptr<SiStripNoises> first_payload = this->fetchPayload(std::get<1>(firstiov));
 
-      SiStripNoiseContainer* l_objContainer = new SiStripNoiseContainer(last_payload, lastiov, tagname1);
-      SiStripNoiseContainer* f_objContainer = new SiStripNoiseContainer(first_payload, firstiov, tagname2);
+      SiStripNoiseContainer* l_objContainer = new SiStripNoiseContainer(last_payload, lastiov, tagname2);
+      SiStripNoiseContainer* f_objContainer = new SiStripNoiseContainer(first_payload, firstiov, tagname1);
 
       l_objContainer->compare(f_objContainer);
 

--- a/CondCore/SiStripPlugins/plugins/SiStripPedestals_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripPedestals_PayloadInspector.cc
@@ -99,8 +99,8 @@ namespace {
       std::shared_ptr<SiStripPedestals> last_payload = this->fetchPayload(std::get<1>(lastiov));
       std::shared_ptr<SiStripPedestals> first_payload = this->fetchPayload(std::get<1>(firstiov));
 
-      SiStripPedestalContainer* l_objContainer = new SiStripPedestalContainer(last_payload, lastiov, tagname1);
-      SiStripPedestalContainer* f_objContainer = new SiStripPedestalContainer(first_payload, firstiov, tagname2);
+      SiStripPedestalContainer* l_objContainer = new SiStripPedestalContainer(last_payload, lastiov, tagname2);
+      SiStripPedestalContainer* f_objContainer = new SiStripPedestalContainer(first_payload, firstiov, tagname1);
 
       l_objContainer->compare(f_objContainer);
 


### PR DESCRIPTION
#### PR description:

Title says it all.
Noticed when trying to produce plots with `SiStripApvGainCompareByPartitionTwoTags` vs `SiStripApvGainsValuesComparatorTwoTags` the two sets of curves are swapped:

| `SiStripApvGainCompareByPartitionTwoTags`  | `SiStripApvGainsValuesComparatorTwoTags` |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/6b64ccd4-18bd-432e-acb2-35d8667d9d0e) |  ![image](https://github.com/user-attachments/assets/1076f5a9-ea2e-4149-b100-2b88aaefb09e) |  

I profit also to render the class `SiStripApvGainsValuesComparatorTwoTags` more modular.

#### PR validation:

Run 

```bash
#!/bin/bash -ex

getPayloadData.py  \
    --plugin pluginSiStripApvGain_PayloadInspector \
    --plot plot_SiStripApvGainCompareByPartitionTwoTags \
    --tag SiStripApvGain_Ideal_31X_v2 \
    --tagtwo SiStripApvGain2_v4_hltvalidation \
    --input_params "{}" \
    --time_type Run \
    --iovs '{"start_iov": "1", "end_iov": "1"}' \
    --iovstwo '{"start_iov": "1", "end_iov": "1"}' \
    --db Prod \
    --test;
```
and obtained the desired output image.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, no backport needed