### PR TITLE
[HCAL-DQM] Add Certification-Related DQM Plots and Fix FED 1118/1121 Yellow Status in DigiTask 

### DIFF
--- a/DQM/HcalTasks/interface/DigiTask.h
+++ b/DQM/HcalTasks/interface/DigiTask.h
@@ -47,10 +47,12 @@ protected:
   edm::EDGetTokenT<HODigiCollection> _tokHO;
   edm::EDGetTokenT<QIE10DigiCollection> _tokQIE10;
   edm::ESGetToken<HcalDbService, HcalDbRecord> hcalDbServiceToken_;
-
+  edm::ESGetToken<HcalChannelQuality, HcalChannelQualityRcd> _tokHcalChannelQuality;
+    
   double _cutSumQ_HBHE, _cutSumQ_HO, _cutSumQ_HF;
   double _thresh_unihf;
-
+  double _HBSumMeanofSumQForEachEvent, _HESumMeanofSumQForEachEvent, _HOSumMeanofSumQForEachEvent,
+      _HFSumMeanofSumQForEachEvent;
   //	flag vector
   std::vector<hcaldqm::flag::Flag> _vflags;
   enum DigiFlag { fDigiSize = 0, fUni = 1, fNChsHF = 2, fUnknownIds = 3, fLED = 4, fCapId = 5, nDigiFlag = 6 };
@@ -78,15 +80,19 @@ protected:
   hcaldqm::Container1D _cADC_SubdetPM;
   hcaldqm::Container1D _cfC_SubdetPM;
   hcaldqm::Container1D _cSumQ_SubdetPM;
+  hcaldqm::Container1D _cSumQ_Subdet;
   hcaldqm::ContainerProf2D _cSumQ_depth;
   hcaldqm::ContainerProf1D _cSumQvsLS_SubdetPM;
+  hcaldqm::ContainerProf1D _cAveragedSumQvsLS_Subdet;
   hcaldqm::ContainerProf1D _cSumQvsBX_SubdetPM;  // online only!
 
   // ADC, fC for HF (QIE10 has different ADC/fC)
   hcaldqm::Container1D _cADC_SubdetPM_QIE1011;
   hcaldqm::Container1D _cfC_SubdetPM_QIE1011;
   hcaldqm::Container1D _cSumQ_SubdetPM_QIE1011;
+  hcaldqm::Container1D _cSumQ_Subdet_QIE1011;
   hcaldqm::ContainerProf1D _cSumQvsLS_SubdetPM_QIE1011;
+  hcaldqm::ContainerProf1D _cAveragedSumQvsLS_Subdet_QIE1011;
   hcaldqm::ContainerProf1D _cSumQvsBX_SubdetPM_QIE1011;  // online only!
 
   //	Shape - just filling - not summary!
@@ -102,6 +108,7 @@ protected:
   hcaldqm::ContainerProf2D _cTimingCut_ElectronicsuTCA;
   hcaldqm::ContainerProf1D _cTimingCutvsLS_FED;
   hcaldqm::ContainerProf1D _cTimingCutvsLS_SubdetPM;
+  hcaldqm::ContainerProf1D _cTimingCutvsLS_depth;
   hcaldqm::ContainerProf2D _cTimingCut_depth;
   hcaldqm::ContainerProf1D _cTimingCutvsiphi_SubdetPM;  // online only!
   hcaldqm::ContainerProf1D _cTimingCutvsieta_Subdet;    // online only!
@@ -130,11 +137,12 @@ protected:
   //hcaldqm::Container2D _cOccupancyCutvsSlotvsLS_HFPM; // online only
   hcaldqm::Container2D _cOccupancyCutvsiphivsLS_SubdetPM;  // online only
 
-  //	Occupancy w/o and w/ a Cut vs BX and vs LS
+  //	Occupancy w/o and w/ a Cut and BadCapId vs BX and vs LS
   hcaldqm::ContainerProf1D _cOccupancyvsLS_Subdet;
   hcaldqm::ContainerProf1D _cOccupancyCutvsLS_Subdet;  // online only
   hcaldqm::ContainerProf1D _cOccupancyCutvsBX_Subdet;  // online only
-
+  hcaldqm::ContainerProf1D _cOccupancyBadCapidvsLS_Subdet;
+  hcaldqm::Container2D _cOccupancyBadCapidvsLS_depth;
   //	#Time Samples for a digi. Used for Summary generation
   hcaldqm::Container1D _cDigiSize_Crate;
   hcaldqm::Container1D _cDigiSize_FED;

--- a/DQM/HcalTasks/interface/DigiTask.h
+++ b/DQM/HcalTasks/interface/DigiTask.h
@@ -48,7 +48,7 @@ protected:
   edm::EDGetTokenT<QIE10DigiCollection> _tokQIE10;
   edm::ESGetToken<HcalDbService, HcalDbRecord> hcalDbServiceToken_;
   edm::ESGetToken<HcalChannelQuality, HcalChannelQualityRcd> _tokHcalChannelQuality;
-    
+
   double _cutSumQ_HBHE, _cutSumQ_HO, _cutSumQ_HF;
   double _thresh_unihf;
   double _HBSumMeanofSumQForEachEvent, _HESumMeanofSumQForEachEvent, _HOSumMeanofSumQForEachEvent,

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -5,7 +5,10 @@ using namespace hcaldqm::constants;
 using namespace hcaldqm::filter;
 
 DigiTask::DigiTask(edm::ParameterSet const& ps)
-    : DQTask(ps), hcalDbServiceToken_(esConsumes<HcalDbService, HcalDbRecord, edm::Transition::BeginRun>()),_tokHcalChannelQuality(esConsumes<HcalChannelQuality, HcalChannelQualityRcd, edm::Transition::BeginRun>(edm::ESInputTag("", "withTopo"))) {
+    : DQTask(ps),
+      hcalDbServiceToken_(esConsumes<HcalDbService, HcalDbRecord, edm::Transition::BeginRun>()),
+      _tokHcalChannelQuality(esConsumes<HcalChannelQuality, HcalChannelQualityRcd, edm::Transition::BeginRun>(
+          edm::ESInputTag("", "withTopo"))) {
   _tagQIE11 = ps.getUntrackedParameter<edm::InputTag>("tagHE", edm::InputTag("hcalDigis"));
   _tagHO = ps.getUntrackedParameter<edm::InputTag>("tagHO", edm::InputTag("hcalDigis"));
   _tagQIE10 = ps.getUntrackedParameter<edm::InputTag>("tagHF", edm::InputTag("hcalDigis"));
@@ -50,10 +53,10 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
   //	GET WHAT YOU NEED
   edm::ESHandle<HcalDbService> dbs = es.getHandle(hcalDbServiceToken_);
   _emap = dbs->getHcalMapping();
-  
- //    FILL _xQuality                                                                                
+
+  //    FILL _xQuality
   _xQuality.reset();
-  const HcalChannelQuality *cq = &es.getData(_tokHcalChannelQuality);
+  const HcalChannelQuality* cq = &es.getData(_tokHcalChannelQuality);
   auto _xQuality = cq;
 
   // Book LED calibration channels from emap
@@ -424,9 +427,8 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
                                          hcaldqm::hashfunctions::fSubdet,
                                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
                                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN_to8000),
-					 0);
+                                         0);
     _xBadCapid.initialize(hcaldqm::hashfunctions::fFED);
-    
   }
   //	INITIALIZE HISTOGRAMS that are only for Online
   if (_ptype == fOnline) {
@@ -489,7 +491,6 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
                                                    0);
   }
   if (_ptype == fOnline || _ptype == fOffline) {
-      
     _cOccupancyBadCapidvsLS_Subdet.initialize(_name,
                                               "CapID",
                                               hcaldqm::hashfunctions::fSubdet,
@@ -504,21 +505,21 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
                                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
                                              0);
     _cCapid_BadvsFEDvsLS.initialize(_name,
-				    "CapID",
-				    new hcaldqm::quantity::LumiSectionCoarse(_maxLS, 10),
-				    new hcaldqm::quantity::FEDQuantity(vFEDs),
-				    new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
-				    0);
-    
+                                    "CapID",
+                                    new hcaldqm::quantity::LumiSectionCoarse(_maxLS, 10),
+                                    new hcaldqm::quantity::FEDQuantity(vFEDs),
+                                    new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                    0);
+
     _cCapid_BadvsFEDvsLSmod10.initialize(_name,
-					 "CapID",
-					 new hcaldqm::quantity::LumiSection(10),
-                                           new hcaldqm::quantity::FEDQuantity(vFEDs),
-					 new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
-					 0);
+                                         "CapID",
+                                         new hcaldqm::quantity::LumiSection(10),
+                                         new hcaldqm::quantity::FEDQuantity(vFEDs),
+                                         new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                         0);
   }
   if (_ptype != fOffline) {  // hidefed2crate
-      //std::vector<int> vFEDs = hcaldqm::utilities::getFEDList(_emap);
+    //std::vector<int> vFEDs = hcaldqm::utilities::getFEDList(_emap);
     std::vector<int> vFEDsVME = hcaldqm::utilities::getFEDVMEList(_emap);
     std::vector<int> vFEDsuTCA = hcaldqm::utilities::getFEDuTCAList(_emap);
     std::vector<uint32_t> vFEDHF;
@@ -722,7 +723,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
   _cBadTDCCount_depth.book(ib, _emap, _subsystem);
 
   _cCapidMinusBXmod4_SubdetPM.book(ib, _emap, _subsystem);
-  
+
   for (int i = 0; i < 4; ++i) {
     constexpr unsigned int kSize = 32;
     char aux[kSize];
@@ -760,7 +761,6 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
     _xBadCapid.book(_emap);
     _cCapid_BadvsFEDvsLS.book(ib, _subsystem, "BadvsLS");
     _cCapid_BadvsFEDvsLSmod10.book(ib, _subsystem, "BadvsLSmod10");
-    
   }
   if (_ptype == fOnline) {
     _cQ2Q12CutvsLS_FEDHF.book(ib, _emap, _filter_FEDHF, _subsystem);

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -5,7 +5,7 @@ using namespace hcaldqm::constants;
 using namespace hcaldqm::filter;
 
 DigiTask::DigiTask(edm::ParameterSet const& ps)
-    : DQTask(ps), hcalDbServiceToken_(esConsumes<HcalDbService, HcalDbRecord, edm::Transition::BeginRun>()) {
+    : DQTask(ps), hcalDbServiceToken_(esConsumes<HcalDbService, HcalDbRecord, edm::Transition::BeginRun>()),_tokHcalChannelQuality(esConsumes<HcalChannelQuality, HcalChannelQualityRcd, edm::Transition::BeginRun>(edm::ESInputTag("", "withTopo"))) {
   _tagQIE11 = ps.getUntrackedParameter<edm::InputTag>("tagHE", edm::InputTag("hcalDigis"));
   _tagHO = ps.getUntrackedParameter<edm::InputTag>("tagHO", edm::InputTag("hcalDigis"));
   _tagQIE10 = ps.getUntrackedParameter<edm::InputTag>("tagHF", edm::InputTag("hcalDigis"));
@@ -50,6 +50,11 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
   //	GET WHAT YOU NEED
   edm::ESHandle<HcalDbService> dbs = es.getHandle(hcalDbServiceToken_);
   _emap = dbs->getHcalMapping();
+  
+ //    FILL _xQuality                                                                                
+  _xQuality.reset();
+  const HcalChannelQuality *cq = &es.getData(_tokHcalChannelQuality);
+  auto _xQuality = cq;
 
   // Book LED calibration channels from emap
   std::vector<HcalElectronicsId> eids = _emap->allElectronicsId();
@@ -122,7 +127,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
   vhash_TDC6bit.push_back(
       hcaldqm::hashfunctions::hash_did[hcaldqm::hashfunctions::fSubdetPM](HcalDetId(HcalForward, -29, 1, 1)));
   _filter_TDC6bit.initialize(filter::fPreserver, hcaldqm::hashfunctions::fSubdetPM, vhash_TDC6bit);
-
+  std::vector<int> vFEDs = hcaldqm::utilities::getFEDList(_emap);
   //	INITIALIZE FIRST
   _cADC_SubdetPM.initialize(_name,
                             "ADC",
@@ -155,7 +160,20 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
                                  new hcaldqm::quantity::LumiSection(_maxLS),
                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_10000),
                                  0);
-
+  //
+  _cSumQ_Subdet.initialize(_name,
+                           "SumQ",
+                           hcaldqm::hashfunctions::fSubdet,
+                           new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_10000),
+                           new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                           0);
+  _cAveragedSumQvsLS_Subdet.initialize(_name,
+                                       "AveragedSumQvsLS",
+                                       hcaldqm::hashfunctions::fSubdet,
+                                       new hcaldqm::quantity::LumiSection(_maxLS),
+                                       new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_10000),
+                                       0);
+  //
   _cADC_SubdetPM_QIE1011.initialize(_name,
                                     "ADC",
                                     hcaldqm::hashfunctions::fSubdetPM,
@@ -180,7 +198,20 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
                                          new hcaldqm::quantity::LumiSection(_maxLS),
                                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_400000),
                                          0);
-
+  //
+  _cSumQ_Subdet_QIE1011.initialize(_name,
+                                   "SumQ",
+                                   hcaldqm::hashfunctions::fSubdet,
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_400000),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                   0);
+  _cAveragedSumQvsLS_Subdet_QIE1011.initialize(_name,
+                                               "AveragedSumQvsLS",
+                                               hcaldqm::hashfunctions::fSubdet,
+                                               new hcaldqm::quantity::LumiSection(_maxLS),
+                                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10fC_400000),
+                                               0);
+  //
   _cTimingCut_SubdetPM.initialize(_name,
                                   "TimingCut",
                                   hcaldqm::hashfunctions::fSubdetPM,
@@ -206,6 +237,13 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
                                       new hcaldqm::quantity::LumiSection(_maxLS),
                                       new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
                                       0);
+
+  _cTimingCutvsLS_depth.initialize(_name,
+                                   "TimingvsLS",
+                                   hcaldqm::hashfunctions::fdepth,
+                                   new hcaldqm::quantity::LumiSection(_maxLS),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                                   0);
 
   //	Occupancy w/o a cut
   _cOccupancyvsLS_Subdet.initialize(_name,
@@ -343,6 +381,53 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
                                      0);
   }
 
+  if (_ptype == fOnline || _ptype == fOffline) {
+    _cTimingCutvsiphi_SubdetPM.initialize(_name,
+                                          "TimingCutvsiphi",
+                                          hcaldqm::hashfunctions::fSubdetPM,
+                                          new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                                          0);
+    _cTimingCutvsieta_Subdet.initialize(_name,
+                                        "TimingCutvsieta",
+                                        hcaldqm::hashfunctions::fSubdet,
+                                        new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                                        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                                        0);
+    _cOccupancyCutvsiphi_SubdetPM.initialize(_name,
+                                             "OccupancyCutvsiphi",
+                                             hcaldqm::hashfunctions::fSubdetPM,
+                                             new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                                             new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                             0);
+    _cOccupancyCutvsieta_Subdet.initialize(_name,
+                                           "OccupancyCutvsieta",
+                                           hcaldqm::hashfunctions::fSubdet,
+                                           new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                                           new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                           0);
+    _cOccupancyCutvsiphivsLS_SubdetPM.initialize(_name,
+                                                 "OccupancyCutvsiphivsLS",
+                                                 hcaldqm::hashfunctions::fSubdetPM,
+                                                 new hcaldqm::quantity::LumiSection(_maxLS),
+                                                 new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                                                 new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                                 0);
+    _cOccupancyCutvsLS_Subdet.initialize(_name,
+                                         "OccupancyCutvsLS",
+                                         hcaldqm::hashfunctions::fSubdet,
+                                         new hcaldqm::quantity::LumiSection(_maxLS),
+                                         new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN_to8000),
+                                         0);
+    _cOccupancyCutvsBX_Subdet.initialize(_name,
+                                         "OccupancyCutvsBX",
+                                         hcaldqm::hashfunctions::fSubdet,
+                                         new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
+                                         new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN_to8000),
+					 0);
+    _xBadCapid.initialize(hcaldqm::hashfunctions::fFED);
+    
+  }
   //	INITIALIZE HISTOGRAMS that are only for Online
   if (_ptype == fOnline) {
     //	Charge sharing
@@ -370,17 +455,11 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
                                   new hcaldqm::quantity::LumiSection(_maxLS),
                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fDigiSize),
                                   0);
-    _cTimingCutvsiphi_SubdetPM.initialize(_name,
-                                          "TimingCutvsiphi",
-                                          hcaldqm::hashfunctions::fSubdetPM,
-                                          new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-                                          new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
-                                          0);
-    _cTimingCutvsieta_Subdet.initialize(_name,
-                                        "TimingCutvsieta",
+    _cOccupancyvsieta_Subdet.initialize(_name,
+                                        "Occupancyvsieta",
                                         hcaldqm::hashfunctions::fSubdet,
                                         new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-                                        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                                        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
                                         0);
     _cOccupancyvsiphi_SubdetPM.initialize(_name,
                                           "Occupancyvsiphi",
@@ -388,48 +467,12 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
                                           new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
                                           new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
                                           0);
-    _cOccupancyvsieta_Subdet.initialize(_name,
-                                        "Occupancyvsieta",
-                                        hcaldqm::hashfunctions::fSubdet,
-                                        new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-                                        new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
-                                        0);
-    _cOccupancyCutvsiphi_SubdetPM.initialize(_name,
-                                             "OccupancyCutvsiphi",
-                                             hcaldqm::hashfunctions::fSubdetPM,
-                                             new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-                                             new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
-                                             0);
-    _cOccupancyCutvsieta_Subdet.initialize(_name,
-                                           "OccupancyCutvsieta",
-                                           hcaldqm::hashfunctions::fSubdet,
-                                           new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
-                                           new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
-                                           0);
-    _cOccupancyCutvsLS_Subdet.initialize(_name,
-                                         "OccupancyCutvsLS",
-                                         hcaldqm::hashfunctions::fSubdet,
-                                         new hcaldqm::quantity::LumiSection(_maxLS),
-                                         new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN_to8000),
-                                         0);
-    _cOccupancyCutvsBX_Subdet.initialize(_name,
-                                         "OccupancyCutvsBX",
-                                         hcaldqm::hashfunctions::fSubdet,
-                                         new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fBX),
-                                         new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN_to8000),
-                                         0);
+
     //		_cOccupancyCutvsSlotvsLS_HFPM.initialize(_name,
     //			"OccupancyCutvsSlotvsLS", hcaldqm::hashfunctions::fSubdetPM,
     //			new hcaldqm::quantity::LumiSection(_maxLS),
     //			new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fSlotuTCA),
     //			new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
-    _cOccupancyCutvsiphivsLS_SubdetPM.initialize(_name,
-                                                 "OccupancyCutvsiphivsLS",
-                                                 hcaldqm::hashfunctions::fSubdetPM,
-                                                 new hcaldqm::quantity::LumiSection(_maxLS),
-                                                 new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
-                                                 new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
-                                                 0);
   }
   _cCapidMinusBXmod4_SubdetPM.initialize(_name,
                                          "CapID",
@@ -445,28 +488,39 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
                                                    new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
                                                    0);
   }
-
+  if (_ptype == fOnline || _ptype == fOffline) {
+      
+    _cOccupancyBadCapidvsLS_Subdet.initialize(_name,
+                                              "CapID",
+                                              hcaldqm::hashfunctions::fSubdet,
+                                              new hcaldqm::quantity::LumiSection(_maxLS),
+                                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                              0);
+    _cOccupancyBadCapidvsLS_depth.initialize(_name,
+                                             "CapID",
+                                             hcaldqm::hashfunctions::fdepth,
+                                             new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                                             new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                                             new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                             0);
+    _cCapid_BadvsFEDvsLS.initialize(_name,
+				    "CapID",
+				    new hcaldqm::quantity::LumiSectionCoarse(_maxLS, 10),
+				    new hcaldqm::quantity::FEDQuantity(vFEDs),
+				    new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+				    0);
+    
+    _cCapid_BadvsFEDvsLSmod10.initialize(_name,
+					 "CapID",
+					 new hcaldqm::quantity::LumiSection(10),
+                                           new hcaldqm::quantity::FEDQuantity(vFEDs),
+					 new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+					 0);
+  }
   if (_ptype != fOffline) {  // hidefed2crate
-    std::vector<int> vFEDs = hcaldqm::utilities::getFEDList(_emap);
+      //std::vector<int> vFEDs = hcaldqm::utilities::getFEDList(_emap);
     std::vector<int> vFEDsVME = hcaldqm::utilities::getFEDVMEList(_emap);
     std::vector<int> vFEDsuTCA = hcaldqm::utilities::getFEDuTCAList(_emap);
-
-    if (_ptype == fOnline) {
-      _cCapid_BadvsFEDvsLS.initialize(_name,
-                                      "CapID",
-                                      new hcaldqm::quantity::LumiSectionCoarse(_maxLS, 10),
-                                      new hcaldqm::quantity::FEDQuantity(vFEDs),
-                                      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
-                                      0);
-
-      _cCapid_BadvsFEDvsLSmod10.initialize(_name,
-                                           "CapID",
-                                           new hcaldqm::quantity::LumiSection(10),
-                                           new hcaldqm::quantity::FEDQuantity(vFEDs),
-                                           new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
-                                           0);
-    }
-
     std::vector<uint32_t> vFEDHF;
     vFEDHF.push_back(HcalElectronicsId(22, SLOT_uTCA_MIN, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
     vFEDHF.push_back(HcalElectronicsId(22, SLOT_uTCA_MIN + 6, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
@@ -572,7 +626,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
       _xDigiSize.initialize(hcaldqm::hashfunctions::fFED);
       _xNChs.initialize(hcaldqm::hashfunctions::fFED);
       _xNChsNominal.initialize(hcaldqm::hashfunctions::fFED);
-      _xBadCapid.initialize(hcaldqm::hashfunctions::fFED);
+      //_xBadCapid.initialize(hcaldqm::hashfunctions::fFED);
     }
   }
   if (_ptype != fLocal) {
@@ -612,9 +666,18 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
   _cfC_SubdetPM_QIE1011.book(ib, _emap, _filter_QIE1011, _subsystem);
   _cSumQ_SubdetPM.book(ib, _emap, _filter_QIE8, _subsystem);
   _cSumQ_SubdetPM_QIE1011.book(ib, _emap, _filter_QIE1011, _subsystem);
+
+  _cSumQ_Subdet.book(ib, _emap, _subsystem);
+  _cSumQ_Subdet_QIE1011.book(ib, _emap, _subsystem);
+
   _cSumQ_depth.book(ib, _emap, _subsystem);
+
   _cSumQvsLS_SubdetPM.book(ib, _emap, _filter_QIE8, _subsystem);
   _cSumQvsLS_SubdetPM_QIE1011.book(ib, _emap, _filter_QIE1011, _subsystem);
+
+  _cAveragedSumQvsLS_Subdet.book(ib, _emap, _subsystem);
+  _cAveragedSumQvsLS_Subdet_QIE1011.book(ib, _emap, _subsystem);
+
   _cADCvsTS_SubdetPM.book(ib, _emap, _filter_QIE8, _subsystem);
   _cADCvsTS_SubdetPM_QIE1011.book(ib, _emap, _filter_QIE1011, _subsystem);
 
@@ -637,10 +700,13 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
   _cTimingCut_SubdetPM.book(ib, _emap, _subsystem);
   _cTimingCutHTH_SubdetPM.book(ib, _emap, _subsystem);
   _cTimingCut_depth.book(ib, _emap, _subsystem);
+
   _cTimingCutvsLS_SubdetPM.book(ib, _emap, _subsystem);
+  _cTimingCutvsLS_depth.book(ib, _emap, _subsystem);
 
   _cOccupancyvsLS_Subdet.book(ib, _emap, _subsystem);
   _cOccupancyCut_depth.book(ib, _emap, _subsystem);
+  _cOccupancyCutvsLS_Subdet.book(ib, _emap, _subsystem);
 
   _cLETDCTimevsADC_SubdetPM.book(ib, _emap, _subsystem);
   _cLETDCvsADC_2bit_SubdetPM.book(ib, _emap, _filter_TDC2bit, _subsystem);
@@ -656,10 +722,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
   _cBadTDCCount_depth.book(ib, _emap, _subsystem);
 
   _cCapidMinusBXmod4_SubdetPM.book(ib, _emap, _subsystem);
-  if (_ptype == fOnline) {
-    _cCapid_BadvsFEDvsLS.book(ib, _subsystem, "BadvsLS");
-    _cCapid_BadvsFEDvsLSmod10.book(ib, _subsystem, "BadvsLSmod10");
-  }
+  
   for (int i = 0; i < 4; ++i) {
     constexpr unsigned int kSize = 32;
     char aux[kSize];
@@ -684,21 +747,28 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
     _cOccupancy_CrateSlot.book(ib, _emap, _subsystem);
   }
 
+  if (_ptype == fOnline || _ptype == fOffline) {
+    _cOccupancyCutvsiphi_SubdetPM.book(ib, _emap, _subsystem);
+    _cOccupancyCutvsieta_Subdet.book(ib, _emap, _subsystem);
+    _cOccupancyCutvsLS_Subdet.book(ib, _emap, _subsystem);
+    _cOccupancyCutvsiphivsLS_SubdetPM.book(ib, _emap, _subsystem);
+    _cOccupancyCutvsBX_Subdet.book(ib, _emap, _subsystem);
+    _cTimingCutvsiphi_SubdetPM.book(ib, _emap, _subsystem);
+    _cTimingCutvsieta_Subdet.book(ib, _emap, _subsystem);
+    _cOccupancyBadCapidvsLS_Subdet.book(ib, _emap, _subsystem);
+    _cOccupancyBadCapidvsLS_depth.book(ib, _emap, _subsystem);
+    _xBadCapid.book(_emap);
+    _cCapid_BadvsFEDvsLS.book(ib, _subsystem, "BadvsLS");
+    _cCapid_BadvsFEDvsLSmod10.book(ib, _subsystem, "BadvsLSmod10");
+    
+  }
   if (_ptype == fOnline) {
     _cQ2Q12CutvsLS_FEDHF.book(ib, _emap, _filter_FEDHF, _subsystem);
     _cSumQvsBX_SubdetPM.book(ib, _emap, _filter_QIE8, _subsystem);
     _cSumQvsBX_SubdetPM_QIE1011.book(ib, _emap, _filter_QIE1011, _subsystem);
     _cDigiSizevsLS_FED.book(ib, _emap, _subsystem);
-    _cTimingCutvsiphi_SubdetPM.book(ib, _emap, _subsystem);
-    _cTimingCutvsieta_Subdet.book(ib, _emap, _subsystem);
-    _cOccupancyCutvsLS_Subdet.book(ib, _emap, _subsystem);
-    _cOccupancyCutvsBX_Subdet.book(ib, _emap, _subsystem);
     _cOccupancyvsiphi_SubdetPM.book(ib, _emap, _subsystem);
     _cOccupancyvsieta_Subdet.book(ib, _emap, _subsystem);
-    _cOccupancyCutvsiphi_SubdetPM.book(ib, _emap, _subsystem);
-    _cOccupancyCutvsieta_Subdet.book(ib, _emap, _subsystem);
-    //		_cOccupancyCutvsSlotvsLS_HFPM.book(ib, _emap, _filter_QIE1011, _subsystem);
-    _cOccupancyCutvsiphivsLS_SubdetPM.book(ib, _emap, _subsystem);
     _cSummaryvsLS_FED.book(ib, _emap, _subsystem);
     _cSummaryvsLS.book(ib, _subsystem);
 
@@ -707,7 +777,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
     _xNChsNominal.book(_emap);
     _xUni.book(_emap);
     _xDigiSize.book(_emap);
-    _xBadCapid.book(_emap);
+    // _xBadCapid.book(_emap);
 
     // just PER HF FED RECORD THE #CHANNELS
     // ONLY WAY TO DO THAT AUTOMATICALLY AND W/O HARDCODING 1728
@@ -717,9 +787,10 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
       if (!it->isHcalDetId())
         continue;
       HcalDetId did(it->rawId());
-      if (_xQuality.exists(did)) {
-        HcalChannelStatus cs(it->rawId(), _xQuality.get(HcalDetId(*it)));
+      if (_xQuality->exists(did)) {
+        HcalChannelStatus cs(it->rawId(), _xQuality->getValues(HcalDetId(*it))->getValue());
         if (cs.isBitSet(HcalChannelStatus::HcalCellMask) || cs.isBitSet(HcalChannelStatus::HcalCellDead))
+
           continue;
       }
       HcalElectronicsId eid = HcalElectronicsId(_ehashmap.lookup(did));
@@ -800,12 +871,21 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
   uint32_t rawidHBValid = 0;
   uint32_t rawidHEValid = 0;
 
+  // Reset at the beginning of each new LS
+  if (lumiCache->EvtCntLS == 1) {
+    _HBSumMeanofSumQForEachEvent = 0;
+    _HESumMeanofSumQForEachEvent = 0;
+    _HOSumMeanofSumQForEachEvent = 0;
+    _HFSumMeanofSumQForEachEvent = 0;
+  }
+
   //	HB collection
   int numChs = 0;
   int numChsCut = 0;
   int numChsHE = 0;
   int numChsCutHE = 0;
-
+  int numChsHBBadCapid = 0;
+  int numChsHEBadCapid = 0;
   // HB+HE QIE11 collection
   for (QIE11DigiCollection::const_iterator it = c_QIE11->begin(); it != c_QIE11->end(); ++it) {
     const QIE11DataFrame digi = static_cast<const QIE11DataFrame>(*it);
@@ -881,7 +961,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
     }
 
     // (capid - BX) % 4
-    if (_ptype == fOnline) {
+    if (_ptype == fOnline || _ptype == fOffline) {
       short soi = -1;
       for (int i = 0; i < digi.samples(); i++) {
         if (digi[i].soi()) {
@@ -897,6 +977,9 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
       bool good_capidmbx = (_capidmbx[did.subdet()] == this_capidmbx);
       if (!good_capidmbx) {
         _xBadCapid.get(eid)++;
+        did.subdet() == HcalBarrel ? numChsHBBadCapid++ : numChsHEBadCapid++;
+        if (numChsHBBadCapid != 0 || numChsHEBadCapid != 0)
+          _cOccupancyBadCapidvsLS_depth.fill(did);
         _cCapid_BadvsFEDvsLS.fill(eid, _currentLS);
         _cCapid_BadvsFEDvsLSmod10.fill(eid, _currentLS % 10);
       }
@@ -909,6 +992,16 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
     double sumQ = hcaldqm::utilities::sumQDB<QIE11DataFrame>(_dbService, digi_fC, did, digi, 0, digi.samples() - 1);
 
     _cSumQ_SubdetPM_QIE1011.fill(did, sumQ);
+    // from CMT plot
+    if (did.subdet() == HcalBarrel) {
+      if (sumQ > _cutSumQ_HBHE)
+        _cSumQ_Subdet_QIE1011.fill(did, sumQ);
+    }
+    if (did.subdet() == HcalEndcap) {
+      if (sumQ > _cutSumQ_HBHE)
+        _cSumQ_Subdet_QIE1011.fill(did, sumQ);
+    }
+    //
     _cOccupancy_depth.fill(did);
     if (_ptype == fOnline || _ptype == fLocal) {
       _cOccupancy_Crate.fill(eid);
@@ -987,6 +1080,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
       _cTimingCut_depth.fill(did, timing);
       _cOccupancyCut_depth.fill(did);
       _cTimingCutvsLS_SubdetPM.fill(did, _currentLS, timing);
+      _cTimingCutvsLS_depth.fill(did, _currentLS, timing);
       if (_ptype != fOffline) {  // hidefed2crate
         _cTimingCutvsLS_FED.fill(eid, _currentLS, timing);
       }
@@ -994,6 +1088,8 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
       _cSumQvsLS_SubdetPM_QIE1011.fill(did, _currentLS, sumQ);
       if (_ptype == fOnline) {
         _cSumQvsBX_SubdetPM_QIE1011.fill(did, bx, sumQ);
+      }
+      if (_ptype == fOnline || _ptype == fOffline) {
         _cTimingCutvsiphi_SubdetPM.fill(did, timing);
         _cTimingCutvsieta_Subdet.fill(did, timing);
         _cOccupancyCutvsiphi_SubdetPM.fill(did);
@@ -1014,20 +1110,28 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
   }
 
   if (rawidHBValid != 0 && rawidHEValid != 0) {
+    _HBSumMeanofSumQForEachEvent += _cSumQ_Subdet_QIE1011.getMean(HcalDetId(rawidHBValid));
+    _HESumMeanofSumQForEachEvent += _cSumQ_Subdet_QIE1011.getMean(HcalDetId(rawidHEValid));
+
     _cOccupancyvsLS_Subdet.fill(HcalDetId(rawidHBValid), _currentLS, numChs);
     _cOccupancyvsLS_Subdet.fill(HcalDetId(rawidHEValid), _currentLS, numChsHE);
-    //	ONLINE ONLY!
-    if (_ptype == fOnline) {
-      _cOccupancyCutvsLS_Subdet.fill(HcalDetId(rawidHBValid), _currentLS, numChsCut);
+
+    //ONLINE & OFFLINE ONLY!
+    if (_ptype == fOnline || _ptype == fOffline) {
       _cOccupancyCutvsBX_Subdet.fill(HcalDetId(rawidHBValid), bx, numChsCut);
-      _cOccupancyCutvsLS_Subdet.fill(HcalDetId(rawidHEValid), _currentLS, numChsCutHE);
       _cOccupancyCutvsBX_Subdet.fill(HcalDetId(rawidHEValid), bx, numChsCutHE);
+      _cOccupancyCutvsLS_Subdet.fill(HcalDetId(rawidHBValid), _currentLS, numChsCut);
+      _cOccupancyCutvsLS_Subdet.fill(HcalDetId(rawidHEValid), _currentLS, numChsCutHE);
+      if (numChsHBBadCapid != 0)
+        _cOccupancyBadCapidvsLS_Subdet.fill(HcalDetId(rawidHBValid), _currentLS, numChsHBBadCapid);
+      if (numChsHEBadCapid != 0)
+        _cOccupancyBadCapidvsLS_Subdet.fill(HcalDetId(rawidHEValid), _currentLS, numChsHEBadCapid);
     }
-    //	^^^ONLINE ONLY!
+    //  ^^^ONLINE & OFFLINE ONLY!
   }
   numChs = 0;
   numChsCut = 0;
-
+  int numChsHOBadCapid = 0;
   //	reset
   rawidValid = 0;
 
@@ -1081,7 +1185,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
         continue;
     }
 
-    if (_ptype == fOnline) {
+    if (_ptype == fOnline || _ptype == fOffline) {
       short this_capidmbx = (it->sample(it->presamples()).capid() - bx) % 4;
       if (this_capidmbx < 0) {
         this_capidmbx += 4;
@@ -1090,9 +1194,14 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
       bool good_capidmbx = (_capidmbx[did.subdet()] == this_capidmbx);
       if (!good_capidmbx) {
         _xBadCapid.get(eid)++;
+        if (did.subdet() == HcalOuter)
+          numChsHOBadCapid++;
+        if (numChsHOBadCapid != 0)
+          _cOccupancyBadCapidvsLS_depth.fill(did);
         _cCapid_BadvsFEDvsLS.fill(eid, _currentLS);
         _cCapid_BadvsFEDvsLSmod10.fill(eid, _currentLS % 10);
       }
+
       if (!eid.isVMEid()) {
         _cCapidMinusBXmod4_CrateSlotuTCA[this_capidmbx].fill(eid);
       }
@@ -1103,6 +1212,13 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
     double sumQ = hcaldqm::utilities::sumQDB<HODataFrame>(_dbService, digi_fC, did, *it, 0, it->size() - 1);
 
     _cSumQ_SubdetPM.fill(did, sumQ);
+
+    // from CMT plot
+
+    if (sumQ > _cutSumQ_HO)
+      _cSumQ_Subdet.fill(did, sumQ);
+
+    //
     _cOccupancy_depth.fill(did);
     if (_ptype == fOnline) {
       _cDigiSizevsLS_FED.fill(eid, _currentLS, it->size());
@@ -1117,8 +1233,8 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
         _cOccupancy_FEDuTCA.fill(eid);
         _cOccupancy_ElectronicsuTCA.fill(eid);
         /*
-				if (!it->validate(0, it->size()))
-					_cCapIdRots_FEDuTCA.fill(eid, 1);*/
+	  if (!it->validate(0, it->size()))
+	  _cCapIdRots_FEDuTCA.fill(eid, 1);*/
       }
     }
 
@@ -1146,11 +1262,14 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
             did, hcaldqm::utilities::aveTSDB<HODataFrame>(_dbService, digi_fC, did, *it, 0, it->size() - 1));
       _cTimingCut_depth.fill(did, timing);
       _cTimingCutvsLS_SubdetPM.fill(did, _currentLS, timing);
+      _cTimingCutvsLS_depth.fill(did, _currentLS, timing);
       if (_ptype != fOffline) {  // hidefed2crate
         _cTimingCutvsLS_FED.fill(eid, _currentLS, timing);
       }
       if (_ptype == fOnline) {
         _cSumQvsBX_SubdetPM.fill(did, bx, sumQ);
+      }
+      if (_ptype == fOnline || _ptype == fOffline) {
         _cTimingCutvsiphi_SubdetPM.fill(did, timing);
         _cTimingCutvsieta_Subdet.fill(did, timing);
         _cOccupancyCutvsiphi_SubdetPM.fill(did);
@@ -1171,16 +1290,19 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
   }
 
   if (rawidValid != 0) {
-    _cOccupancyvsLS_Subdet.fill(HcalDetId(rawidValid), _currentLS, numChs);
+    _HOSumMeanofSumQForEachEvent += _cSumQ_Subdet.getMean(HcalDetId(rawidValid));
 
-    if (_ptype == fOnline) {
+    _cOccupancyvsLS_Subdet.fill(HcalDetId(rawidValid), _currentLS, numChs);
+    if (_ptype == fOnline || _ptype == fOffline) {
       _cOccupancyCutvsLS_Subdet.fill(HcalDetId(rawidValid), _currentLS, numChsCut);
       _cOccupancyCutvsBX_Subdet.fill(HcalDetId(rawidValid), bx, numChsCut);
+      if (numChsHOBadCapid != 0)
+        _cOccupancyBadCapidvsLS_Subdet.fill(HcalDetId(rawidValid), _currentLS, numChsHOBadCapid);
     }
   }
   numChs = 0;
   numChsCut = 0;
-
+  int numChsHFBadCapid = 0;
   //	reset
   rawidValid = 0;
 
@@ -1239,7 +1361,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
       }
 
       // (capid - BX) % 4
-      if (_ptype == fOnline) {
+      if (_ptype == fOnline || _ptype == fOffline) {
         short soi = -1;
         for (int i = 0; i < digi.samples(); i++) {
           if (digi[i].soi()) {
@@ -1255,6 +1377,10 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
         bool good_capidmbx = (_capidmbx[did.subdet()] == this_capidmbx);
         if (!good_capidmbx) {
           _xBadCapid.get(eid)++;
+          if (did.subdet() == HcalForward)
+            numChsHFBadCapid++;
+          if (numChsHFBadCapid != 0)
+            _cOccupancyBadCapidvsLS_depth.fill(did);
           _cCapid_BadvsFEDvsLS.fill(eid, _currentLS);
           _cCapid_BadvsFEDvsLSmod10.fill(eid, _currentLS % 10);
         }
@@ -1269,6 +1395,12 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
 
       //if (!_filter_QIE1011.filter(did)) {
       _cSumQ_SubdetPM_QIE1011.fill(did, sumQ);
+
+      // from CMT plot
+      if (did.subdet() == HcalForward) {
+        if (sumQ > _cutSumQ_HF)
+          _cSumQ_Subdet_QIE1011.fill(did, sumQ);
+      }
       //}
 
       _cOccupancy_depth.fill(did);
@@ -1334,6 +1466,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
           _cTimingCutHTH_SubdetPM.fill(did, timing);
         _cTimingCut_depth.fill(did, timing);
         _cTimingCutvsLS_SubdetPM.fill(did, _currentLS, timing);
+        _cTimingCutvsLS_depth.fill(did, _currentLS, timing);
         if (_ptype == fOnline) {
           //if (!_filter_QIE1011.filter(did)) {
           _cSumQvsBX_SubdetPM_QIE1011.fill(did, bx, sumQ);
@@ -1345,6 +1478,13 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
           _cOccupancyCutvsiphivsLS_SubdetPM.fill(did, _currentLS);
           //				_cOccupancyCutvsSlotvsLS_HFPM.fill(did, _currentLS);
           _xUniHF.get(eid)++;
+        }
+        if (_ptype == fOnline || _ptype == fOffline) {
+          _cTimingCutvsiphi_SubdetPM.fill(did, timing);
+          _cTimingCutvsieta_Subdet.fill(did, timing);
+          _cOccupancyCutvsiphi_SubdetPM.fill(did);
+          _cOccupancyCutvsieta_Subdet.fill(did);
+          _cOccupancyCutvsiphivsLS_SubdetPM.fill(did, _currentLS);
         }
         if (_ptype != fOffline) {  // hidefed2crate
           _cTimingCutvsLS_FED.fill(eid, _currentLS, timing);
@@ -1366,13 +1506,16 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
       numChs++;
     }
   }
-
   if (rawidValid != 0) {
+    _HFSumMeanofSumQForEachEvent += _cSumQ_Subdet_QIE1011.getMean(HcalDetId(rawidValid));
+
     _cOccupancyvsLS_Subdet.fill(HcalDetId(rawidValid), _currentLS, numChs);
 
-    if (_ptype == fOnline) {
+    if (_ptype == fOnline || _ptype == fOffline) {
       _cOccupancyCutvsLS_Subdet.fill(HcalDetId(rawidValid), _currentLS, numChsCut);
       _cOccupancyCutvsBX_Subdet.fill(HcalDetId(rawidValid), bx, numChsCut);
+      if (numChsHFBadCapid != 0)
+        _cOccupancyBadCapidvsLS_Subdet.fill(HcalDetId(rawidValid), _currentLS, numChsHFBadCapid);
     }
   }
 }
@@ -1406,12 +1549,25 @@ std::shared_ptr<hcaldqm::Cache> DigiTask::globalBeginLuminosityBlock(edm::Lumino
     }
   }
 
+  if (_ptype == fOffline || _ptype == fOnline) {
+    HcalDetId did_HB(hcaldqm::hashfunctions::hash_Subdet(HcalDetId(HcalBarrel, 1, 1, 1)));
+    HcalDetId did_HE(hcaldqm::hashfunctions::hash_Subdet(HcalDetId(HcalEndcap, 16, 1, 1)));
+    HcalDetId did_HF(hcaldqm::hashfunctions::hash_Subdet(HcalDetId(HcalForward, 29, 1, 1)));
+    HcalDetId did_HO(hcaldqm::hashfunctions::hash_Subdet(HcalDetId(HcalOuter, 1, 1, 1)));
+    _cAveragedSumQvsLS_Subdet_QIE1011.fill(did_HB, _currentLS, (_HBSumMeanofSumQForEachEvent / _evsPerLS));
+    _cAveragedSumQvsLS_Subdet_QIE1011.fill(did_HE, _currentLS, (_HESumMeanofSumQForEachEvent / _evsPerLS));
+    _cAveragedSumQvsLS_Subdet_QIE1011.fill(did_HF, _currentLS, (_HFSumMeanofSumQForEachEvent / _evsPerLS));
+    _cAveragedSumQvsLS_Subdet.fill(did_HO, _currentLS, (_HOSumMeanofSumQForEachEvent / _evsPerLS));
+  }
+
   if (_ptype != fOffline) {  // hidefed2crate
+
     for (std::vector<uint32_t>::const_iterator it = _vhashFEDs.begin(); it != _vhashFEDs.end(); ++it) {
       hcaldqm::flag::Flag fSum("DIGI");
       HcalElectronicsId eid = HcalElectronicsId(*it);
 
       std::vector<uint32_t>::const_iterator cit = std::find(_vcdaqEids.begin(), _vcdaqEids.end(), *it);
+
       if (cit == _vcdaqEids.end()) {
         //	not @cDAQ
         for (uint32_t iflag = 0; iflag < _vflags.size(); iflag++)
@@ -1493,6 +1649,7 @@ std::shared_ptr<hcaldqm::Cache> DigiTask::globalBeginLuminosityBlock(edm::Lumino
         //	reset!
         ft->reset();
       }
+
       _cSummaryvsLS.setBinContent(eid, _currentLS, fSum._state);
     }
   }


### PR DESCRIPTION
#### PR description:

- We have added useful figures to the DQM for data certification. Detailed information can be found in the corresponding [GitLab issue#258](https://gitlab.cern.ch/cmshcal/docs/-/issues/258)
- The plots are shown in the [slides](https://indico.cern.ch/event/1532808/contributions/6500798/attachments/3060049/5410904/HCAL_DQM_CMSWeek_08042025_.pdf).
- In recent global runs with stable beams, the DQM summary plot for the DigiTask consistently showed FEDs 1118 and 1121 in yellow. This issue has now been resolved. More details are available in [issue #275](https://gitlab.cern.ch/cmshcal/docs/-/issues/275).

#### PR Validation:
- runTheMatrix test has been completed.

#### Backport:
- This is not a backport PR.
