### PR TITLE
do not apply long-distance interactions on `hltHgcalMergeLayerClusters`

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHgcalMergeLayerClusters_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHgcalMergeLayerClusters_cfi.py
@@ -10,3 +10,8 @@ hltHgcalMergeLayerClusters = cms.EDProducer("MergeClusterProducer",
     time_layerclustersHSci = cms.InputTag("hltHgcalLayerClustersHSci","timeLayerCluster"),
     time_layerclustersHSi = cms.InputTag("hltHgcalLayerClustersHSi","timeLayerCluster")
 )
+
+from Configuration.ProcessModifiers.alpaka_cff import alpaka
+alpaka.toModify(hltHgcalMergeLayerClusters,
+                layerClustersEE = cms.InputTag("hltHgCalLayerClustersFromSoAProducer"),
+                time_layerclustersEE = cms.InputTag("hltHgCalLayerClustersFromSoAProducer", "timeLayerCluster"))

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTHgcalLocalRecoSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTHgcalLocalRecoSequence_cfi.py
@@ -33,6 +33,3 @@ _HLTHgcalLocalRecoSequence_heterogeneous = cms.Sequence(
 
 from Configuration.ProcessModifiers.alpaka_cff import alpaka
 alpaka.toReplaceWith(HLTHgcalLocalRecoSequence, _HLTHgcalLocalRecoSequence_heterogeneous)
-alpaka.toModify(hltHgcalMergeLayerClusters,
-        layerClustersEE = cms.InputTag("hltHgCalLayerClustersFromSoAProducer"),
-        time_layerclustersEE = cms.InputTag("hltHgCalLayerClustersFromSoAProducer", "timeLayerCluster"))

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTHgcalTiclPFClusteringForEgammaUnseededSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTHgcalTiclPFClusteringForEgammaUnseededSequence_cfi.py
@@ -43,10 +43,6 @@ alpaka.toReplaceWith(_HgcalLocalRecoUnseededSequence,
                                   + hltHgcalMergeLayerClusters
                      ) 
 )
-alpaka.toModify(hltHgcalMergeLayerClusters,
-                layerClustersEE = cms.InputTag("hltHgCalLayerClustersFromSoAProducer"),
-                time_layerclustersEE = cms.InputTag("hltHgCalLayerClustersFromSoAProducer", "timeLayerCluster")
-)
 
 # Use EGammaSuperClusterProducer at HLT in ticl v5
 hltTiclTracksterLinksSuperclusteringDNNUnseeded = hltTiclTracksterLinks.clone(


### PR DESCRIPTION
#### PR description:

Title says it all.
The `alpaka` modifier should act *in situ* on `hltHgcalMergeLayerClusters`.

#### PR validation:

`runTheMatrix.py --what upgrade -l 29634.751` runs. 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A

Cc: @rovere 