### PR TITLE
Remove SubProcess related code from FastTimerService

### DIFF
--- a/HLTrigger/Timer/interface/ProcessCallGraph.h
+++ b/HLTrigger/Timer/interface/ProcessCallGraph.h
@@ -1,15 +1,10 @@
 #ifndef HLTrigger_Timer_interface_ProcessCallGraph_h
 #define HLTrigger_Timer_interface_ProcessCallGraph_h
 
-/*
- *
- */
-
-#include <iostream>
+#include <memory>
 #include <utility>
 #include <vector>
 #include <string>
-#include <type_traits>
 
 // boost optional (used by boost graph) results in some false positives with -Wmaybe-uninitialized
 #pragma GCC diagnostic push
@@ -20,15 +15,14 @@
 #pragma GCC diagnostic pop
 
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
-#include "FWCore/ServiceRegistry/interface/PathsAndConsumesOfModulesBase.h"
-#include "FWCore/ServiceRegistry/interface/ProcessContext.h"
+#include "FWCore/ServiceRegistry/interface/ServiceRegistryfwd.h"
 #include "HLTrigger/Timer/interface/EDMModuleType.h"
 
 class ProcessCallGraph {
 public:
   struct NodeType {
     edm::ModuleDescription module_;
-    edm::EDMModuleType type_;
+    edm::EDMModuleType type_ = edm::EDMModuleType::kUnknown;
     bool scheduled_ = false;
   };
 
@@ -64,61 +58,28 @@ public:
           modules_on_path_(std::move(mop)),
           modules_and_dependencies_(std::move(mad)),
           last_dependency_of_module_(std::move(ldom)) {}
-
-    PathType(PathType const &other) = default;
-
-    PathType(PathType &&other) = default;
-
-    ~PathType() = default;
-
-    PathType &operator=(PathType const &other) = default;
   };
 
-  // store the details of each process: name, modules call subgraph, modules, paths and endpaths, subprocess pids
+  // store the details of the process: name, modules call subgraph, modules, paths and endpaths
   struct ProcessType {
     std::string name_;
     GraphType const &graph_;
     std::vector<unsigned int> modules_;
     std::vector<PathType> paths_;
     std::vector<PathType> endPaths_;
-    std::vector<unsigned int> subprocesses_;
-
-    ProcessType() = delete;
 
     ProcessType(std::string name,
                 GraphType const &graph,
                 std::vector<unsigned int> modules,
                 std::vector<PathType> paths,
-                std::vector<PathType> endPaths,
-                std::vector<unsigned int> subprocesses = {})
+                std::vector<PathType> endPaths)
         : name_(std::move(name)),
           graph_(graph),
           modules_(std::move(modules)),
           paths_(std::move(paths)),
-          endPaths_(std::move(endPaths)),
-          subprocesses_(std::move(subprocesses)) {}
-
-    ProcessType(std::string &&name,
-                GraphType const &graph,
-                std::vector<unsigned int> &&modules,
-                std::vector<PathType> &&paths,
-                std::vector<PathType> &&endPaths,
-                std::vector<unsigned int> &&subprocesses = {})
-        : name_(std::move(name)),
-          graph_(graph),
-          modules_(std::move(modules)),
-          paths_(std::move(paths)),
-          endPaths_(std::move(endPaths)),
-          subprocesses_(std::move(subprocesses)) {}
-
-    ProcessType(ProcessType const &other) = default;
-    ProcessType(ProcessType &&other) = default;
-
-    ProcessType &operator=(ProcessType const &other) = delete;
-    ProcessType &operator=(ProcessType &&other) = delete;
+          endPaths_(std::move(endPaths)) {}
   };
 
-public:
   // default c'tor
   ProcessCallGraph() = default;
 
@@ -146,27 +107,8 @@ public:
   // find the dependencies of all modules in the given path
   std::pair<std::vector<unsigned int>, std::vector<unsigned int>> dependencies(std::vector<unsigned int> const &path);
 
-  // retrieve the "process id" of a process, given its ProcessContex
-  unsigned int processId(edm::ProcessContext const &) const;
-
-  // retrieve the "process id" of a process, given its name
-  unsigned int processId(std::string const &) const;
-
-  // retrieve the processes
-  std::vector<ProcessType> const &processes() const;
-
-  // retrieve information about a process, given its "process id"
-  ProcessType const &processDescription(unsigned int) const;
-
-  // retrieve information about a process, given its ProcessContex
-  ProcessType const &processDescription(edm::ProcessContext const &) const;
-
-  // retrieve information about a process, given its name
-  ProcessType const &processDescription(std::string const &) const;
-
-private:
-  // register a (sub)process and assigns it a "process id"
-  unsigned int registerProcess(edm::ProcessContext const &);
+  // retrieve information about the process
+  ProcessType const &processDescription() const;
 
 private:
   GraphType graph_;
@@ -174,11 +116,8 @@ private:
   // module id of the Source
   unsigned int source_ = edm::ModuleDescription::invalidID();
 
-  // map each (sub)process name to a "process id"
-  std::unordered_map<std::string, unsigned int> process_id_;
-
-  // description of each process
-  std::vector<ProcessType> process_description_;
+  // description of the process
+  std::unique_ptr<ProcessType> process_description_;
 };
 
 #endif  // not defined HLTrigger_Timer_interface_ProcessCallGraph_h

--- a/HLTrigger/Timer/src/ProcessCallGraph.cc
+++ b/HLTrigger/Timer/src/ProcessCallGraph.cc
@@ -1,11 +1,5 @@
-/*
- *
- */
-
 #include <cassert>
-#include <iostream>
 #include <string>
-#include <type_traits>
 #include <vector>
 
 // boost optional (used by boost graph) results in some false positives with -Wmaybe-uninitialized
@@ -16,32 +10,10 @@
 
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "FWCore/Framework/interface/TriggerNamesService.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-#include "FWCore/ParameterSet/interface/Registry.h"
-#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 #include "FWCore/ServiceRegistry/interface/PathsAndConsumesOfModulesBase.h"
 #include "FWCore/ServiceRegistry/interface/ProcessContext.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-#include "FWCore/Utilities/interface/EDMException.h"
 #include "HLTrigger/Timer/interface/ProcessCallGraph.h"
-
-// adaptor to use range-based for loops with boost::graph edges(...) and vertices(...) functions
-template <typename I>
-struct iterator_pair_as_a_range : std::pair<I, I> {
-public:
-  using std::pair<I, I>::pair;
-
-  I begin() { return this->first; }
-  I end() { return this->second; }
-};
-
-template <typename I>
-iterator_pair_as_a_range<I> make_range(std::pair<I, I> p) {
-  return iterator_pair_as_a_range<I>(p);
-}
 
 void ProcessCallGraph::preSourceConstruction(edm::ModuleDescription const& module) {
   // check that the Source has not already been added
@@ -55,18 +27,13 @@ void ProcessCallGraph::preSourceConstruction(edm::ModuleDescription const& modul
   graph_.m_graph[module.id()] = {module, edm::EDMModuleType::kSource, true};
 }
 
-// FIXME
-//  - check that all module ids are valid (e.g. subprocesses are not being added in
-//    the wrong order)
 void ProcessCallGraph::lookupInitializationComplete(edm::PathsAndConsumesOfModulesBase const& pathsAndConsumes,
                                                     edm::ProcessContext const& context) {
-  unsigned int pid = registerProcess(context);
-
   // check that the Source has already been added
   assert(source_ != edm::ModuleDescription::invalidID());
 
-  // work on the full graph (for the main process) or a subgraph (for a subprocess)
-  GraphType& graph = context.isSubProcess() ? graph_.create_subgraph() : graph_.root();
+  // work on the full graph (for the main process)
+  GraphType& graph = graph_.root();
 
   // set the graph name property to the process name
   boost::get_property(graph, boost::graph_name) = context.processName();
@@ -125,14 +92,8 @@ void ProcessCallGraph::lookupInitializationComplete(edm::PathsAndConsumesOfModul
   }
 
   // store the description of process, modules and paths
-  process_description_.emplace_back(context.processName(), graph, modules, paths, endPaths);
-  assert(process_description_.size() == pid + 1);
-
-  // attach a subprocess to its parent
-  if (context.isSubProcess()) {
-    unsigned int parent_pid = processId(context.parentProcessContext());
-    process_description_[parent_pid].subprocesses_.push_back(pid);
-  }
+  process_description_ = std::make_unique<ProcessType>(
+      context.processName(), graph, std::move(modules), std::move(paths), std::move(endPaths));
 }
 
 // number of modules stored in the call graph
@@ -196,11 +157,10 @@ std::pair<std::vector<unsigned int>, std::vector<unsigned int>> ProcessCallGraph
     if (color == 0)
       ++size;
 
-  // allocate the output vectors
-  std::vector<unsigned int> dependencies(size);
-  dependencies.resize(0);
-  std::vector<unsigned int> indices(path.size());
-  indices.resize(0);
+  std::vector<unsigned int> dependencies;
+  dependencies.reserve(size);
+  std::vector<unsigned int> indices;
+  indices.reserve(path.size());
 
   // reset the color map
   for (unsigned int& color : colors)
@@ -226,67 +186,4 @@ std::pair<std::vector<unsigned int>, std::vector<unsigned int>> ProcessCallGraph
   return std::make_pair(dependencies, indices);
 }
 
-// register a (sub)process and assigns it a "process id"
-// throws an exception if called with a duplicate process name
-unsigned int ProcessCallGraph::registerProcess(edm::ProcessContext const& context) {
-  // registerProcess (called by preBeginJob) must be called for the parent process before its subprocess(es)
-  if (context.isSubProcess() and process_id_.find(context.parentProcessContext().processName()) == process_id_.end()) {
-    throw edm::Exception(edm::errors::LogicError)
-        << "ProcessCallGraph::preBeginJob(): called for subprocess \"" << context.processName() << "\""
-        << " before being called for its parent process \"" << context.parentProcessContext().processName() << "\"";
-  }
-
-  // registerProcess (called by preBeginJob) should be called once or each (sub)process
-  auto id = process_id_.find(context.processName());
-  if (id != process_id_.end()) {
-    throw edm::Exception(edm::errors::LogicError)
-        << "ProcessCallGraph::preBeginJob(): called twice for the same "
-        << (context.isSubProcess() ? "subprocess" : "process") << " " << context.processName();
-  }
-
-  // this assumes that registerProcess (called by preBeginJob) is not called concurrently from different threads
-  // otherwise, process_id_.size() should be replaces with an atomic counter
-  std::tie(id, std::ignore) = process_id_.insert(std::make_pair(context.processName(), process_id_.size()));
-  return id->second;
-}
-
-// retrieve the "process id" of a process, given its ProcessContex
-// throws an exception if the (sub)process was not registered
-unsigned int ProcessCallGraph::processId(edm::ProcessContext const& context) const {
-  auto id = process_id_.find(context.processName());
-  if (id == process_id_.end())
-    throw edm::Exception(edm::errors::LogicError)
-        << "ProcessCallGraph::processId(): unexpected " << (context.isSubProcess() ? "subprocess" : "process") << " "
-        << context.processName();
-  return id->second;
-}
-
-// retrieve the "process id" of a process, given its ProcessContex
-// throws an exception if the (sub)process was not registered
-unsigned int ProcessCallGraph::processId(std::string const& processName) const {
-  auto id = process_id_.find(processName);
-  if (id == process_id_.end())
-    throw edm::Exception(edm::errors::LogicError)
-        << "ProcessCallGraph::processId(): unexpected (sub)process " << processName;
-  return id->second;
-}
-
-// retrieve the number of processes
-std::vector<ProcessCallGraph::ProcessType> const& ProcessCallGraph::processes() const { return process_description_; }
-
-// retrieve information about a process, given its "process id"
-ProcessCallGraph::ProcessType const& ProcessCallGraph::processDescription(unsigned int pid) const {
-  return process_description_.at(pid);
-}
-
-// retrieve information about a process, given its ProcessContex
-ProcessCallGraph::ProcessType const& ProcessCallGraph::processDescription(edm::ProcessContext const& context) const {
-  unsigned int pid = processId(context);
-  return process_description_[pid];
-}
-
-// retrieve information about a process, given its ProcessContex
-ProcessCallGraph::ProcessType const& ProcessCallGraph::processDescription(std::string const& processName) const {
-  unsigned int pid = processId(processName);
-  return process_description_[pid];
-}
+ProcessCallGraph::ProcessType const& ProcessCallGraph::processDescription() const { return *process_description_; }

--- a/HLTrigger/Timer/test/BuildFile.xml
+++ b/HLTrigger/Timer/test/BuildFile.xml
@@ -17,3 +17,6 @@
   <use name="jemalloc"/>
   <use name="HLTrigger/Timer"/>
 </bin>
+
+<test name="TestFastTimerService" command="cmsRun ${LOCALTOP}/src/HLTrigger/Timer/test/testFastTimerService_cfg.py"/>
+

--- a/HLTrigger/Timer/test/testFastTimerService_cfg.py
+++ b/HLTrigger/Timer/test/testFastTimerService_cfg.py
@@ -1,0 +1,134 @@
+# The purpose of this unit test is to execute the code
+# in the FastTimerService and at least verify that it
+# runs without crashing. There is output in the log
+# file and also a json file.
+
+# The output times and memory usage values may vary from
+# one job to the next. We do not want a test that can
+# occasionally fail and require investigation when
+# nothing is wrong, so we choose not to require certain
+# values in the output.
+
+# Besides the FastTimerService, the rest of the
+# configuration is of no significance. This is
+# just copied from another test configuration.
+# We just needed some modules and paths to run
+# in order to exercise the service.
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("PROD1")
+
+process.load('DQMServices.Core.DQMStore_cfi')
+
+from HLTrigger.Timer.FastTimerService_cfi import *
+
+process.FastTimerService = FastTimerService
+
+process.FastTimerService.printEventSummary = True
+process.FastTimerService.writeJSONSummary = True
+process.FastTimerService.dqmTimeRange = 2000
+process.FastTimerService.enableDQM = True
+process.FastTimerService.enableDQMTransitions = True
+process.FastTimerService.enableDQMbyLumiSection = True
+process.FastTimerService.enableDQMbyModule = True
+process.FastTimerService.enableDQMbyPath = True
+process.FastTimerService.enableDQMbyProcesses = True
+
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        FastReport = cms.untracked.PSet(
+            limit = cms.untracked.int32(1000000)
+        ),
+        threshold  = cms.untracked.string('INFO')
+    )
+)
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(1)
+)
+
+process.source = cms.Source("IntSource")
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testFastTimerService.root')
+)
+
+process.dqmOutput = cms.OutputModule('DQMRootOutputModule',
+    fileName = cms.untracked.string('dqmOutput.root')
+)
+
+process.busy1 = cms.EDProducer("BusyWaitIntProducer",ivalue = cms.int32(1), iterations = cms.uint32(10*1000*1000))
+
+process.a1 = cms.EDAnalyzer("TestFindProduct",
+  inputTags = cms.untracked.VInputTag( cms.InputTag("source") ),
+  expectedSum = cms.untracked.int32(530021),
+  inputTagsNotFound = cms.untracked.VInputTag(
+    cms.InputTag("source", processName=cms.InputTag.skipCurrentProcess()),
+    cms.InputTag("intProducer", processName=cms.InputTag.skipCurrentProcess()),
+    cms.InputTag("intProducerU", processName=cms.InputTag.skipCurrentProcess())
+  ),
+  inputTagsBeginProcessBlock = cms.untracked.VInputTag(
+    cms.InputTag("intProducerBeginProcessBlock"),
+  ),
+  inputTagsEndProcessBlock = cms.untracked.VInputTag(
+    cms.InputTag("intProducerEndProcessBlock"),
+  ),
+  inputTagsEndProcessBlock2 = cms.untracked.VInputTag(
+    cms.InputTag("intProducerEndProcessBlock", "two"),
+  ),
+  inputTagsEndProcessBlock3 = cms.untracked.VInputTag(
+    cms.InputTag("intProducerEndProcessBlock", "three"),
+  ),
+  inputTagsEndProcessBlock4 = cms.untracked.VInputTag(
+    cms.InputTag("intProducerEndProcessBlock", "four"),
+  ),
+  testGetterOfProducts = cms.untracked.bool(True)
+)
+
+process.a2 = cms.EDAnalyzer("TestFindProduct",
+  inputTags = cms.untracked.VInputTag( cms.InputTag("intProducerA") ),
+  expectedSum = cms.untracked.int32(300)
+)
+
+process.intProducer = cms.EDProducer("IntProducer", ivalue = cms.int32(1))
+
+process.intProducerDeleted = cms.EDProducer("IntProducer", ivalue = cms.int32(10))
+
+process.intProducerU = cms.EDProducer("IntProducer", ivalue = cms.int32(10))
+
+process.intProducerA = cms.EDProducer("IntProducer", ivalue = cms.int32(100))
+
+process.intVectorProducer = cms.EDProducer("IntVectorProducer",
+  count = cms.int32(9),
+  ivalue = cms.int32(11)
+)
+
+process.intProducerB = cms.EDProducer("IntProducer", ivalue = cms.int32(1000))
+
+process.thingProducer = cms.EDProducer("ThingProducer")
+
+process.intProducerBeginProcessBlock = cms.EDProducer("IntProducerBeginProcessBlock", ivalue = cms.int32(10000))
+
+process.intProducerEndProcessBlock = cms.EDProducer("IntProducerEndProcessBlock", ivalue = cms.int32(100000))
+
+process.t = cms.Task(process.intProducerDeleted,
+                     process.intProducerU,
+                     process.intProducerA,
+                     process.intProducerB,
+                     process.intVectorProducer,
+                     process.intProducerBeginProcessBlock,
+                     process.intProducerEndProcessBlock
+)
+
+process.p1 = cms.Path(process.intProducer * process.a1 * process.a2, process.t)
+
+process.p2 = cms.Path(process.busy1 * process.thingProducer)
+
+#process.e = cms.EndPath(process.out * process.dqmOutput)
+


### PR DESCRIPTION
#### PR description:

Remove SubProcess related code from FastTimerService. This was implemented so that the output should not change at all (given that the SubProcess feature was already removed, there already can't be any SubProcesses).

I couldn't resist adding some minor code cleanup to simplify things a little. Nothing that should affect the behavior.

#### PR validation:

I'm hoping that FastTimerService experts can take a look and verify nothing changes. I don't see any unit tests that exercise this. I will enable the hlt_p2_timing option to ensure the PR tests run the service.

resolves https://github.com/cms-sw/framework-team/issues/1383
