### PR TITLE
Make empty and `'*'` `debugModules` to result in all debug messages to be printed

### DIFF
--- a/FWCore/MessageService/Readme.md
+++ b/FWCore/MessageService/Readme.md
@@ -1,9 +1,10 @@
 # Useful MessageLogger Configuration Changes
 
+Note that `MessageLogger` is part of `process` by default, i.e. explicit loading of `FWCore.MessageService.MessageLogger_cfi` is not necessary.
+
 ## Turning off the end of job statistics
 This requires setting the parameter of cerr
 ```python
-process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.enableStatistics = False
 ```
 
@@ -11,7 +12,6 @@ process.MessageLogger.cerr.enableStatistics = False
 One needs to switch off cerr and switch on cout
 
 ```python
-process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.enable = False
 process.MessageLogger.cout.enable = True
 ```
@@ -20,7 +20,6 @@ process.MessageLogger.cout.enable = True
 Assuming the file you want to write is name `my_file.log` then
 
 ```python
-process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.files.my_file = dict()
 ```
 
@@ -34,14 +33,12 @@ process.MessageLogger.cerr.enable = False
 By default the `cerr` will reject all messages below `FWKINFO` (i.e. `threshold = "FWKINFO"`) and the defaut for `INFO` is set to print no output ,i.e. `limit = 0`. So to see all `INFO` messages one would do
 
 ```python
-process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.threshold = "INFO"
 process.MessageLogger.cerr.INFO.limit = -1
 ```
 
 All messages above `FWKINFO` by default are set to be displayed, that is they have `limit = -1`. You can explicitly set that by doing
 ```python
-process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.WARNING = dict(limit = -1)
 ```
 
@@ -52,7 +49,6 @@ The `MessageLogger.cerr` PSet knows that all _extra_ parameter labels must be of
 By default the `cerr` will reject all messages below `FWKINFO` (i.e. `threshold = "FWKINFO"`) and the defaut for `INFO` is set to print no output ,i.e. `limit = 0`. In order to see messages for the category 'MyCat' the threshold must be lowered and the category must be explicitly mentioned
 
 ```python
-process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.threshold = "INFO"
 process.MessageLogger.cerr.MyCat = dict()
 ```
@@ -64,7 +60,6 @@ The `MessageLogger.cerr` PSet knows that all _extra_ parameter labels must be of
 In order to supporess messages for a given category, e.g. 'MyCat', the limit should be set to 0
 
 ```python
-process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.MyCat = dict(limit = 0)
 ```
 
@@ -83,7 +78,6 @@ By default, all `LogDebug` code is actually removed at compilation time so any m
 Then in the `MessageLogger` configuration you need to lower the `threshold` to `"DEBUG"` and then say you want debug messages from the module. So if your module uses the label `myModule` in the configuration, you'd specify
 
 ```python
-process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.threshold = "DEBUG"
 process.MessageLogger.debugModules = ["myModule"]
 ```
@@ -91,7 +85,6 @@ process.MessageLogger.debugModules = ["myModule"]
 If you are not interested in a particular module but instead want to see all debug messages, you can instead set `debugModules` using `*`
 
 ```python
-process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.threshold = "DEBUG"
 process.MessageLogger.debugModules = ["*"]
 ```

--- a/FWCore/MessageService/Readme.md
+++ b/FWCore/MessageService/Readme.md
@@ -66,8 +66,8 @@ process.MessageLogger.MyCat = dict(limit = 0)
 The `MessageLogger` PSet knows that all _extra_ parameter labels must be of type `cms.untracked.PSet` so one can use a python `dict` set specific parameters for that PSet and allow all other parameters to use their default default values.
 
 
+## Have all debug messages be shown
 
-## Have debug message show for a given module
 By default, all `LogDebug` code is actually removed at compilation time so any messages you want to see have to be recompiled after setting the `EDM_ML_DEBUG` compilation parameter
 
 ```bash
@@ -75,15 +75,23 @@ By default, all `LogDebug` code is actually removed at compilation time so any m
 > scram b ...
 ```
 
-Then in the `MessageLogger` configuration you need to lower the `threshold` to `"DEBUG"` and then say you want debug messages from the module. So if your module uses the label `myModule` in the configuration, you'd specify
+Then in the `MessageLogger` configuration you need to lower the `threshold` to `"DEBUG"`
+```python
+process.MessageLogger.cerr.threshold = "DEBUG"
+```
 
+The default `MessageLogger` configuration leads to all debug messages to be printed (also outside modules).
+
+
+## Have debug message show for a given module
+
+It is possible to restrict the shown debug messages to specific module(s). For example, if your module uses the label `myModule` in the configuration, you'd specify
 ```python
 process.MessageLogger.cerr.threshold = "DEBUG"
 process.MessageLogger.debugModules = ["myModule"]
 ```
 
-If you are not interested in a particular module but instead want to see all debug messages, you can instead set `debugModules` using `*`
-
+For backwards compatibility, setting `debugModules` to `*` has the same effect as setting `debugModules` empty, i.e. showing all debug messages.
 ```python
 process.MessageLogger.cerr.threshold = "DEBUG"
 process.MessageLogger.debugModules = ["*"]

--- a/FWCore/MessageService/plugins/MessageLogger.cc
+++ b/FWCore/MessageService/plugins/MessageLogger.cc
@@ -183,18 +183,19 @@ namespace edm {
       // set up for tracking whether current module is debug-enabled
       // (and info-enabled and warning-enabled)
       if (debugModules.empty()) {
-        anyDebugEnabled_ = false;                       // change log 11
-        MessageDrop::instance()->debugEnabled = false;  // change log 1
+        anyDebugEnabled_ = true;
+        everyDebugEnabled_ = true;
+        MessageDrop::instance()->debugEnabled = true;
       } else {
         anyDebugEnabled_ = true;  // change log 11
         MessageDrop::instance()->debugEnabled = false;
         // this will be over-ridden when specific modules are entered
       }
 
-      // if ( debugModules.empty()) anyDebugEnabled_ = true; // wrong; change log 11
       for (vString::const_iterator it = debugModules.begin(); it != debugModules.end(); ++it) {
         if (*it == "*") {
           everyDebugEnabled_ = true;
+          MessageDrop::instance()->debugEnabled = true;
         } else {
           debugEnabledModules_.insert(*it);
         }

--- a/FWCore/MessageService/src/ThreadSafeLogMessageLoggerScribe.cc
+++ b/FWCore/MessageService/src/ThreadSafeLogMessageLoggerScribe.cc
@@ -915,7 +915,10 @@ namespace edm {
         topDesc.addUntracked<std::vector<std::string>>("suppressFwkInfo", {});
         topDesc.addUntracked<std::vector<std::string>>("suppressWarning", {});
         topDesc.addUntracked<std::vector<std::string>>("suppressError", {});
-        topDesc.addUntracked<std::vector<std::string>>("debugModules", {});
+        topDesc.addUntracked<std::vector<std::string>>("debugModules", {})
+            ->setComment(
+                "Set to limit the DEBUG-level messages to modules with these labels. If empty or contains '*', all "
+                "DEBUG messages (also those outside modules) will be issued (if allowed by the threshold parameter).");
 
         edm::ParameterSetDescription category;
         category.addUntracked<int>("reportEvery", 1);

--- a/FWCore/MessageService/test/BuildFile.xml
+++ b/FWCore/MessageService/test/BuildFile.xml
@@ -61,6 +61,20 @@
     <use name="FWCore/Framework"/>
   </library>
 
+  <library file="UnitTestService_H.cc" name="UnitTestService_H">
+    <flags EDM_PLUGIN="1"/>
+    <use name="FWCore/MessageLogger"/>
+    <use name="FWCore/ParameterSet"/>
+    <use name="FWCore/ServiceRegistry"/>
+  </library>
+
+  <library file="UnitTestService_Hd.cc" name="UnitTestService_Hd">
+    <flags EDM_PLUGIN="1"/>
+    <use name="FWCore/MessageLogger"/>
+    <use name="FWCore/ParameterSet"/>
+    <use name="FWCore/ServiceRegistry"/>
+  </library>
+
   <library file="UnitTestClient_I.cc" name="UnitTestClient_I">
     <flags EDM_PLUGIN="1"/>
     <use name="FWCore/MessageLogger"/>

--- a/FWCore/MessageService/test/UnitTestService_H.cc
+++ b/FWCore/MessageService/test/UnitTestService_H.cc
@@ -1,0 +1,20 @@
+#ifdef EDM_ML_DEBUG
+#undef EDM_ML_DEBUG
+#endif
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+
+namespace edmtest {
+  class UnitTestService_H {
+  public:
+    UnitTestService_H(edm::ParameterSet const& iConfig, edm::ActivityRegistry& iRegistry) {
+      iRegistry.watchPreSourceNextTransition(
+          []() { LogDebug("cat_S") << "Message from watchPreSourceNextTransition"; });
+    }
+  };
+}  // namespace edmtest
+
+#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
+DEFINE_FWK_SERVICE(edmtest::UnitTestService_H);

--- a/FWCore/MessageService/test/UnitTestService_Hd.cc
+++ b/FWCore/MessageService/test/UnitTestService_Hd.cc
@@ -1,0 +1,20 @@
+#ifndef EDM_ML_DEBUG
+#define EDM_ML_DEBUG
+#endif
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+
+namespace edmtest {
+  class UnitTestService_Hd {
+  public:
+    UnitTestService_Hd(edm::ParameterSet const& iConfig, edm::ActivityRegistry& iRegistry) {
+      iRegistry.watchPreSourceNextTransition(
+          []() { LogDebug("cat_S") << "Message from watchPreSourceNextTransition"; });
+    }
+  };
+}  // namespace edmtest
+
+#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
+DEFINE_FWK_SERVICE(edmtest::UnitTestService_Hd);

--- a/FWCore/MessageService/test/u13_cfg.py
+++ b/FWCore/MessageService/test/u13_cfg.py
@@ -49,4 +49,4 @@ process.sendSomeMessages = cms.EDAnalyzer("UnitTestClient_H")
 
 process.p = cms.Path(process.sendSomeMessages)
 
-
+process.add_(cms.Service("edmtest::UnitTestService_H"))

--- a/FWCore/MessageService/test/u13d_cfg.py
+++ b/FWCore/MessageService/test/u13d_cfg.py
@@ -43,7 +43,7 @@ process.MessageLogger = cms.Service("MessageLogger",
         )
       )
     ),
-    debugModules = cms.untracked.vstring('*'),
+    debugModules = cms.untracked.vstring(),
 )
 
 process.maxEvents = cms.untracked.PSet(
@@ -56,4 +56,4 @@ process.sendSomeMessages = cms.EDAnalyzer("UnitTestClient_Hd")
 
 process.p = cms.Path(process.sendSomeMessages)
 
-
+process.add_(cms.Service("edmtest::UnitTestService_Hd"))

--- a/FWCore/MessageService/test/u1_cfg.py
+++ b/FWCore/MessageService/test/u1_cfg.py
@@ -1,7 +1,7 @@
 # Unit test configuration file for MessageLogger service:
 # threshold levels for destinations
 # limit=0 for a category (needed to avoid time stamps in files to be compared)
-# enabling all (*) LogDebug, with one destination responding
+# enabling all LogDebug, with one destination responding
 # verify that by default, the threshold for a destination is INFO
 
 import FWCore.ParameterSet.Config as cms
@@ -56,7 +56,7 @@ process.MessageLogger = cms.Service("MessageLogger",
             noTimeStamps = cms.untracked.bool(True)
         )
     ),
-    debugModules = cms.untracked.vstring('*'),
+    debugModules = cms.untracked.vstring(),
 )
 
 process.CPU = cms.Service("CPU",

--- a/FWCore/MessageService/test/u1d_cfg.py
+++ b/FWCore/MessageService/test/u1d_cfg.py
@@ -1,7 +1,7 @@
 # Unit test configuration file for MessageLogger service:
 # threshold levels for destinations
 # limit=0 for a category (needed to avoid time stamps in files to be compared)
-# enabling all (*) LogDebug, with one destination responding
+# enabling all LogDebug, with one destination responding
 # verify that by default, the threshold for a destination is INFO
 # test done with debug enabled
 
@@ -57,7 +57,7 @@ process.MessageLogger = cms.Service("MessageLogger",
           noTimeStamps = cms.untracked.bool(True)
       )
     ),
-    debugModules = cms.untracked.vstring('*')
+    debugModules = cms.untracked.vstring()
 )
 
 process.CPU = cms.Service("CPU",

--- a/FWCore/MessageService/test/unit_test_outputs/u13d_debugs.log
+++ b/FWCore/MessageService/test/unit_test_outputs/u13d_debugs.log
@@ -1,3 +1,15 @@
+%MSG-d cat_S:  AfterModBeginStream BeforeEvents UnitTestService_Hd.cc:14
+Message from watchPreSourceNextTransition
+%MSG
+%MSG-d cat_S:  PostBeginProcessBlock PostBeginProcessBlock UnitTestService_Hd.cc:14
+Message from watchPreSourceNextTransition
+%MSG
+%MSG-d cat_S:  AfterSource PostBeginProcessBlock UnitTestService_Hd.cc:14
+Message from watchPreSourceNextTransition
+%MSG
+%MSG-d cat_S:  AfterSource PostStreamBeginRun UnitTestService_Hd.cc:14
+Message from watchPreSourceNextTransition
+%MSG
 LogTrace was used to send this message
 %MSG-d cat_B:  UnitTestClient_Hd:sendSomeMessages Run: 1 Event: 1 UnitTestClient_Hd.cc:23
 LogDebug was used to send this other message
@@ -10,6 +22,9 @@ LogVerbatim was used to send this message
 %MSG-i cat_B:  UnitTestClient_Hd:sendSomeMessages Run: 1 Event: 1
 LogInfo was used to send this other message
 %MSG
+%MSG-d cat_S:  PostModuleEvent PostProcessEvent UnitTestService_Hd.cc:14
+Message from watchPreSourceNextTransition
+%MSG
 LogTrace was used to send this message
 %MSG-d cat_B:  UnitTestClient_Hd:sendSomeMessages Run: 1 Event: 2 UnitTestClient_Hd.cc:23
 LogDebug was used to send this other message
@@ -21,4 +36,7 @@ IfLogDebug was used to send this other message
 LogVerbatim was used to send this message
 %MSG-i cat_B:  UnitTestClient_Hd:sendSomeMessages Run: 1 Event: 2
 LogInfo was used to send this other message
+%MSG
+%MSG-d cat_S:  PostModuleEvent PostProcessEvent UnitTestService_Hd.cc:14
+Message from watchPreSourceNextTransition
 %MSG


### PR DESCRIPTION
#### PR description:

Previously there was no way to enable debug messages for non-module code. But we want to be able to issue debug messages e.g. from Services or framework. In addition, the empty debugModules (that is also the default value) leading to no debug messages being issued seemed now a poor choice.

Resolves https://github.com/cms-sw/cmssw/issues/48131
Resolves https://github.com/cms-sw/framework-team/issues/1415

#### PR validation:

Framework unit tests succeed.