### PR TITLE
Add IOTrace debug-level messages to `edm::RootTree`

### DIFF
--- a/IOPool/Input/src/RootTree.cc
+++ b/IOPool/Input/src/RootTree.cc
@@ -1,11 +1,14 @@
+#include "DataFormats/Provenance/interface/BranchType.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "IOPool/Common/interface/getWrapperBasePtr.h"
+
+#include "InputFile.h"
 #include "RootTree.h"
 #include "RootDelayedReader.h"
 #include "RootPromptReadDelayedReader.h"
-#include "FWCore/Utilities/interface/EDMException.h"
-#include "FWCore/Utilities/interface/Exception.h"
-#include "DataFormats/Provenance/interface/BranchType.h"
-#include "IOPool/Common/interface/getWrapperBasePtr.h"
-#include "InputFile.h"
+
 #include "TTree.h"
 #include "TTreeCache.h"
 #include "TLeaf.h"
@@ -437,6 +440,8 @@ namespace edm {
   }
 
   inline void RootTree::getEntryUsingCache(TBranch* branch, EntryNumber entryNumber, TTreeCache* cache) const {
+    LogTrace("IOTrace").format(
+        "RootTree::getEntryUsingCache() begin for branch {} entry {}", branch->GetName(), entryNumber);
     try {
       auto guard = filePtr_->setCacheReadTemporarily(cache, tree_);
       branch->GetEntry(entryNumber);
@@ -457,6 +462,8 @@ namespace edm {
       t.addContext(std::string("Reading branch ") + branch->GetName());
       throw t;
     }
+    LogTrace("IOTrace").format(
+        "RootTree::getEntryUsingCache() end for branch {} entry {}", branch->GetName(), entryNumber);
   }
 
   bool RootTree::skipEntries(unsigned int& offset) {

--- a/Utilities/StorageFactory/README.md
+++ b/Utilities/StorageFactory/README.md
@@ -51,8 +51,6 @@ There is an `edmStorageTracer.py` script for doing some analyses of the traces.
 The `StorageTracerProxy` also provides a way to correlate the trace entries with the rest of the framework via [MessageLogger](../../FWCore/MessageService/Readme.md) messages. These messages are issued with the DEBUG severity and `IOTrace` category. There are additional, higher-level messages as part of the `PoolSource`. To see these messages, compile the `Utilities/Storage` and `IOPool/Input` packages with `USER_CXXFLAGS="-DEDM_ML_DEBUG", and customize the MessageLogger configuration along
 ```py
 process.MessageLogger.cerr.threshold = "DEBUG"
-process.MessageLogger.debugModules = ["*"]
-process.MessageLogger.IOTrace = dict()
 ```
 
 #### `StorageAddLatencyProxy`


### PR DESCRIPTION
#### PR description:

These messages were supposed to be part of https://github.com/cms-sw/cmssw/pull/48073 but somehow I managed to leave them out.

Resolves https://github.com/cms-sw/framework-team/issues/1416

#### PR validation:

Private test shows the messages