### PR TITLE
add support for `ALCARECOTkAlHLTTracks` and `ALCARECOTkAlHLTTracksZMuMu` in `trackselectionRefitting`

### DIFF
--- a/Alignment/CommonAlignment/python/tools/trackselectionRefitting.py
+++ b/Alignment/CommonAlignment/python/tools/trackselectionRefitting.py
@@ -147,7 +147,7 @@ def getSequence(process, collection,
     if collection in ("ALCARECOTkAlMinBias", "generalTracks",
                       "ALCARECOTkAlMinBiasHI", "hiGeneralTracks",
                       "ALCARECOTkAlJetHT", "ALCARECOTkAlDiMuonVertexTracks",
-                      "hltMergedTracks"):
+                      "hltMergedTracks", "ALCARECOTkAlHLTTracks"):
         options["TrackSelector"]["Alignment"].update({
                 "ptMin": 1.0,
                 "pMin": 8.,
@@ -200,7 +200,8 @@ def getSequence(process, collection,
     elif collection in ("ALCARECOTkAlZMuMu",
                         "ALCARECOTkAlZMuMuHI",
                         "ALCARECOTkAlZMuMuPA",
-                        "ALCARECOTkAlDiMuon"):
+                        "ALCARECOTkAlDiMuon",
+                        "ALCARECOTkAlHLTTracksZMuMu"):
         options["TrackSelector"]["Alignment"].update({
                 "ptMin": 15.0,
                 "etaMin": -3.0,


### PR DESCRIPTION
#### PR description:

PR https://github.com/cms-sw/cmssw/pull/46888 introduced the High Granularity Tracker Alignment Prompt Calibration Loop for HLT alignment conditions. 
In that PR two new flavours of ALCARECO were introduced `TkAlHLTTracks` and `TkAlHLTTracksZMuMu`. 
These are meant to be run over the `SteamHLTMonitor` PD at Tier0 and used by the `PromptCalibProdSiPixelAliHLTHGC` PCL flavour and for offline studies using persisted HLT tracks in ALCARECO format.
In this PR support is provided for the two track collections in order to be used in the standard trk alignment infrastructures in `trackselectionRefitting`.
Trivial no regressions expected.

#### PR validation:

Tested with a standard validation configuration file: [testHLTAlCaReco_cfg.py](https://github.com/user-attachments/files/20539979/test_PV_Validation_HLT_collections_cfg.py.txt)
Without this PR it fails at runtime with:

```
----- Begin Fatal Exception 01-Jun-2025 13:53:26 CEST-----------------------
An exception of category 'ConfigFileReadError' occurred while
   [0] Processing the python configuration file named testHLTAlCaReco_cfg.py
Exception Message:
 unknown python problem occurred.
ValueError: Unknown input track collection: ALCARECOTkAlHLTTracks

At:
  /cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02892/el9_amd64_gcc12/cms/cmssw/CMSSW_15_1_X_2025-06-01-0000/src/Alignment/CommonAlignment/python/tools/trackselectionRefitting.py(267): getSequence
  testHLTAlCaReco_cfg.py(209): <module>

----- End Fatal Exception -------------------------------------------------
```

whereas it doesn't with this PR

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, to be backported to CMSSW_15_0_X for 2025 data-taking purposes.

