### PR TITLE
typo: use correct variable name c27_

### DIFF
--- a/Geometry/HGCalCommonData/src/HGCGuardRing.cc
+++ b/Geometry/HGCalCommonData/src/HGCGuardRing.cc
@@ -22,8 +22,8 @@ HGCGuardRing::HGCGuardRing(const HGCalDDDConstants& hgc)
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HGCSim") << "Creating HGCGuardRing with wafer size " << waferSize_ << ", Offsets "
                              << sensorSizeOffset_ << ":" << guardRingOffset_ << ":" << offset_ << ":" << offsetPartial_
-                             << ", mode " << modeUV_ << ", xmax|ymax " << xmax_ << ":" << ymax_ << " and c22:c77 "
-                             << c22_ << ":" << c77_;
+                             << ", mode " << modeUV_ << ", xmax|ymax " << xmax_ << ":" << ymax_ << " and c22:c27 "
+                             << c22_ << ":" << c27_;
 #endif
 }
 


### PR DESCRIPTION
use the correct data member name `c27_`. This fixes the build error for DEBUG and clang analyzer

```
>> Analyzing  src/Geometry/HGCalCommonData/src/HGCalCellOffset.cc 
  [src/Geometry/HGCalCommonData/src/HGCGuardRing.cc:26](https://github.com/cms-sw/cmssw/blob/CMSSW_15_1_X_2025-06-01-2300/Geometry/HGCalCommonData/src/HGCGuardRing.cc#L26):48: error: use of undeclared identifier 'c77_'; did you mean 'c27_'?
    26 |                              << c22_ << ":" << c77_;
      |                                                ^~~~
      |                                                c27_
src/Geometry/HGCalCommonData/interface/HGCGuardRing.h:27:55: note: 'c27_' declared here
   27 |   double offset_, offsetPartial_, xmax_, ymax_, c22_, c27_;
      |                                                       ^
```