### PR TITLE
Improve TkAl Offline DQM

### DIFF
--- a/DQMOffline/Alignment/python/ALCARECOTkAlDQM_cff.py
+++ b/DQMOffline/Alignment/python/ALCARECOTkAlDQM_cff.py
@@ -384,6 +384,7 @@ ALCARECOTkAlHLTTracksTrackingDQM = ALCARECOTkAlZMuMuTrackingDQM.clone(
 
 ALCARECOTkAlHLTTracksTkAlDQM = ALCARECOTkAlZMuMuTkAlDQM.clone(
     #names and desigantions
+    ReferenceTrackProducer= "hltMergedTracks",
     TrackProducer = 'ALCARECO'+__selectionName,
     AlgoName = 'ALCARECO'+__selectionName,
     FolderName = "AlCaReco/"+__selectionName,
@@ -416,18 +417,33 @@ ALCARECOTkAlHLTTracksZMuMuTrackingDQM = ALCARECOTkAlZMuMuTrackingDQM.clone(
 
 ALCARECOTkAlHLTTracksZMuMuTkAlDQM = ALCARECOTkAlZMuMuTkAlDQM.clone(
     #names and desigantions
+    ReferenceTrackProducer= "hltMergedTracks",
     TrackProducer = 'ALCARECO'+__selectionName,
     AlgoName = 'ALCARECO'+__selectionName,
     FolderName = "AlCaReco/"+__selectionName,
     # margins and settings
-    fillInvariantMass = False,
-    TrackPtMax = 30,
+    fillInvariantMass = True,
+    MassBin = 80,
+    MassMin = 80.0,
+    MassMax = 120.0,
+    TrackPtMax = 100,
     SumChargeBin = 101,
     SumChargeMin = -50.5,
     SumChargeMax = 50.5
 )
 
-ALCARECOTkAlHLTTracksZMuMuDQM = cms.Sequence( ALCARECOTkAlHLTTracksZMuMuTrackingDQM  + ALCARECOTkAlHLTTracksZMuMuTkAlDQM )
+ALCARECOTkAlHLTTracksZMuMuVtxDQM = ALCARECOTkAlDiMuonAndVertexVtxDQM.clone(
+    muonTracks = 'ALCARECO'+__selectionName,
+    vertices = 'hltPixelVertices',
+    FolderName = "AlCaReco/"+__selectionName,
+)
+
+ALCARECOTkAlHLTTracksZMuMuMassBiasDQM = ALCARECOTkAlDiMuonMassBiasDQM.clone(
+    muonTracks = 'ALCARECO'+__selectionName,
+    FolderName = "AlCaReco/"+__selectionName,
+)
+
+ALCARECOTkAlHLTTracksZMuMuDQM = cms.Sequence( ALCARECOTkAlHLTTracksZMuMuTrackingDQM  + ALCARECOTkAlHLTTracksZMuMuTkAlDQM + ALCARECOTkAlHLTTracksZMuMuVtxDQM + ALCARECOTkAlHLTTracksZMuMuMassBiasDQM)
 
 ########################################################
 #############---  TkAlKshorts ---#######################
@@ -456,7 +472,10 @@ ALCARECOTkAlKShortTracksTkAlDQM = ALCARECOTkAlZMuMuTkAlDQM.clone(
     AlgoName = 'ALCARECO'+__selectionName,
     FolderName = "AlCaReco/"+__selectionName,
     # margins and settings
-    fillInvariantMass = False,
+    fillInvariantMass = True,
+    MassBin = 100,
+    MassMin = 0.4,
+    MassMax = 0.6,
     TrackPtMax = 30,
     SumChargeBin = 101,
     SumChargeMin = -50.5,
@@ -501,7 +520,10 @@ ALCARECOTkAlLambdaTracksTkAlDQM = ALCARECOTkAlZMuMuTkAlDQM.clone(
     AlgoName = 'ALCARECO'+__selectionName,
     FolderName = "AlCaReco/"+__selectionName,
     # margins and settings
-    fillInvariantMass = False,
+    fillInvariantMass = True,
+    MassBin = 100,
+    MassMin = 1.050,
+    MassMax = 1.250,
     TrackPtMax = 30,
     SumChargeBin = 101,
     SumChargeMin = -50.5,


### PR DESCRIPTION
#### PR description:

Title says it all:
- change source collections for `ALCARECOTkAlHLTTracksZMuMu` and `ALCARECOTkAlHLTTracks` to `hltMergedTracks`;
- fill invariant mass plots for resonance-based ALCARECO producers;
- add DiMuon Vertex and DiMuon Bias monitoring to `ALCARECOTkAlHLTTracksZMuMu`;
- adjust binnings and pT max for `ALCARECOTkAlHLTTracksZMuMu`;

#### PR validation:

Run successfully: `runTheMatrix.py -l 1002.5 -t 4 -j 8 --ibeos`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, will be backported to CMSSW_15_0_X for data-taking purposes