### PR TITLE
add back HLT e/gamma GSF Tracking validation in Phase-2

### DIFF
--- a/HLTriggerOffline/Common/python/HLTValidationHarvest_cff.py
+++ b/HLTriggerOffline/Common/python/HLTValidationHarvest_cff.py
@@ -42,7 +42,6 @@ from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 # Exclude everything except JetMET for now
 _phase2_hltpostvalidation =  hltpostvalidation.copyAndExclude([HLTTauPostVal,
                                                                EgammaPostVal,
-                                                               postProcessorHLTgsfTrackingSequence,
                                                                heavyFlavorValidationHarvestingSequence,
                                                                #JetMETPostVal,
                                                                #HLTAlCaPostVal,

--- a/HLTriggerOffline/Common/python/HLTValidation_cff.py
+++ b/HLTriggerOffline/Common/python/HLTValidation_cff.py
@@ -62,7 +62,6 @@ from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 _phase2_hltassociation = hltassociation.copyAndExclude([
     egammaSelectors,
     ExoticaValidationProdSeq,
-    hltMultiTrackValidationGsfTracks
 ])
 
 # Add hltTrackerphase2ValidationSource to the sequence

--- a/HLTriggerOffline/Egamma/python/HLTmultiTrackValidatorGsfTracks_cff.py
+++ b/HLTriggerOffline/Egamma/python/HLTmultiTrackValidatorGsfTracks_cff.py
@@ -22,6 +22,12 @@ hltGsfTrackValidator = hltMultiTrackValidator.clone(
     minRapidityTP = -3.0,
 )
 
+def _modifyForPhase2(trackvalidator):
+    trackvalidator.label = ["hltEgammaGsfTracksL1Seeded", "hltEgammaGsfTracksUnseeded"]
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(hltGsfTrackValidator, _modifyForPhase2)
+
 from Validation.RecoTrack.TrackValidation_cff import trackingParticlesElectron
 hltMultiTrackValidationGsfTracksTask = cms.Task(
    hltTPClusterProducer


### PR DESCRIPTION
#### PR description:

Title says it all.

#### PR validation:

Run the following test:

```bash
#!/bin/bash -ex

xrdfs root://eosuser.cern.ch ls \
/eos/cms/store/relval/CMSSW_15_1_0_pre3/RelValZEE_14/GEN-SIM-DIGI-RAW/150X_mcRun4_realistic_v1_STD_RegeneratedGS_Run4D110_noPU-v1/2590000/ \
| grep '\.root$' \
| sed 's|^|file:|' \
| paste -sd, - > input_files.txt

echo "Input files:"
cat input_files.txt | tr ',' '\n'

cmsDriver.py step2 -s L1P2GT,HLT:75e33,DQM:egmTrackingMonitorHLT,VALIDATION:@hltValidation \
         --conditions auto:phase2_realistic_T33 \
         --datatier DQMIO \
         -n -1 \
         --eventcontent DQMIO \
         --geometry ExtendedRun4D110 \
         --era Phase2C17I13M9 \
         --procModifier alpaka \
         --filein file:$(cat input_files.txt) \
         --fileout file:step2.root \
         --nThreads 24 \
         --process HLTX \
         --inputCommands='keep *, drop *_hlt*_*_HLT, drop triggerTriggerFilterObjectWithRefs_l1t*_*_HLT' \
         > step2.log  2>&1

cmsDriver.py step3 -s HARVESTING:@hlt+@hltValidation \
         --conditions auto:phase2_realistic_T33 \
         --mc \
         --geometry ExtendedRun4D110 \
         --scenario pp \
         --filetype DQM \
         --era Phase2C17I13M9 \
         -n -1  \
         --filein file:step2.root \
         --fileout file:step3.root > step3.log  2>&1
```

and observed validation plots in output.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A