### PR TITLE
Fix ROCm compilation of standalone LST

### DIFF
--- a/RecoTracker/LSTCore/standalone/LST/Makefile
+++ b/RecoTracker/LSTCore/standalone/LST/Makefile
@@ -46,7 +46,7 @@ GENCODE_CUDA := -gencode arch=compute_70,code=[sm_70,compute_70] -gencode arch=c
 CXX                  = g++
 CXXFLAGS_CPU         = -march=native -mtune=native -Ofast -fno-reciprocal-math -fopenmp-simd -g -Wall -Woverloaded-virtual -fPIC -fopenmp -I..
 CXXFLAGS_CUDA        = -O3 -g --compiler-options -Wall --compiler-options -Woverloaded-virtual --compiler-options -fPIC --compiler-options -fopenmp -dc -lineinfo --ptxas-options=-v --cudart shared $(GENCODE_CUDA) --use_fast_math --default-stream per-thread -I..
-CXXFLAGS_ROCM        = -O3 -g -Wall -Woverloaded-virtual -fPIC -I${ROCM_ROOT}/include -I..
+CXXFLAGS_ROCM        = -O3 -g -Wall -Woverloaded-virtual -fPIC -isystem ${ROCM_ROOT}/include -I..
 CMSSWINCLUDE        := -I${TRACKLOOPERDIR}/../../../ -I${CMSSW_BASE}/src -I${FMT_ROOT}/include
 ifdef CMSSW_RELEASE_BASE
 CMSSWINCLUDE        := ${CMSSWINCLUDE} -I${CMSSW_RELEASE_BASE}/src
@@ -81,7 +81,7 @@ ALPAKABACKEND_CUDA   = $(ALPAKACUDA)
 COMPILE_CMD_CUDA     = $(LD_CUDA) -x cu
 
 LD_ROCM              = hipcc
-SOFLAGS_ROCM         = -g -shared -fPIC
+SOFLAGS_ROCM         = -g -shared -fPIC -L${ROCM_ROOT}/lib
 ALPAKABACKEND_ROCM   = $(ALPAKAROCM)
 COMPILE_CMD_ROCM     = $(LD_ROCM) -c
 


### PR DESCRIPTION
The new IB releases of CMSSW changed the version of ROCm, which broke the compilation of the standalone version of LST since the new headers produce some warnings that are treated as errors. This PR changes the makefile so that those headers are treated as system headers so that the warnings don't cause any issues.

c.c. @slava77 