### PR TITLE
Phase2-hgx364J Make modifier for V19 version of HGCal and include this in 2 ERAs for this new version of HGCal

### DIFF
--- a/Configuration/Eras/python/Era_Phase2C26I13M9_cff.py
+++ b/Configuration/Eras/python/Era_Phase2C26I13M9_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Phase2C22I13M9_cff import Phase2C22I13M9
+from Configuration.Eras.Modifier_phase2_hgcalV19_cff import phase2_hgcalV19
+
+Phase2C26I13M9 = cms.ModifierChain(Phase2C22I13M9, phase2_hgcalV19)

--- a/Configuration/Eras/python/Era_Phase2C26I13M9_noMkFit_cff.py
+++ b/Configuration/Eras/python/Era_Phase2C26I13M9_noMkFit_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Phase2C26I13M9_cff import Phase2C26I13M9
+from Configuration.Eras.ModifierChain_trackingMkFitProd_cff import trackingMkFitProdPhase2
+
+Phase2C26I13M9_noMkFit = cms.ModifierChain(Phase2C26I13M9.copyAndExclude([trackingMkFitProdPhase2]))

--- a/Configuration/Eras/python/Modifier_phase2_hgcalV19_cff.py
+++ b/Configuration/Eras/python/Modifier_phase2_hgcalV19_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+# This modifier is for HGCal V19 geometry-specific changes for sim, reco, etc.
+
+phase2_hgcalV19 =  cms.Modifier()
+


### PR DESCRIPTION
#### PR description:

Make modifier for V19 version of HGCal and include this in 2 ERAs for this new version of HGCal

#### PR validation:

Use the runTheMatrix test workflows 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special