### PR TITLE
[15_0_X]: HCAL DQM - Recover HF TPs

### DIFF
--- a/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
@@ -110,7 +110,7 @@ process.emulTPDigis = process.simHcalTriggerPrimitiveDigis.clone(
    ZS_threshold = 0
 )
 
-process.emulTPDigisForZDC = process.emulTPDigis.clone(inputUpgradeLabel = cms.VInputTag("hcalDigis", "hcalDigis:ZDC")
+process.emulTPDigisForZDC = process.emulTPDigis.clone(inputUpgradeLabel = cms.VInputTag("hcalDigis", "hcalDigis:ZDC"))
 
 #inserting zdc emulator after tp digis
 process.etSumZdcProducer = cms.EDProducer('L1TZDCProducer',

--- a/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
@@ -97,22 +97,24 @@ if isHeavyIon:
 	process.castorDigis.InputLabel = rawTag
 
 process.emulTPDigis = process.simHcalTriggerPrimitiveDigis.clone(
-   inputLabel = cms.VInputTag("hcalDigis", "hcalDigis:ZDC"),
+   inputLabel = cms.VInputTag("hcalDigis", "hcalDigis"),
    FrontEndFormatError = True,
    FG_threshold = 2,
    InputTagFEDRaw = rawTag,
    upgradeHF = True,
    upgradeHE = True,
    upgradeHB = True,
-   inputUpgradeLabel = cms.VInputTag("hcalDigis", "hcalDigis:ZDC"),
+   inputUpgradeLabel = cms.VInputTag("hcalDigis", "hcalDigis"),
    # Enable ZS on emulated TPs, to match what is done in data
    RunZS = True,
    ZS_threshold = 0
 )
 
+process.emulTPDigisForZDC = process.emulTPDigis.clone(inputUpgradeLabel = cms.VInputTag("hcalDigis", "hcalDigis:ZDC")
+
 #inserting zdc emulator after tp digis
 process.etSumZdcProducer = cms.EDProducer('L1TZDCProducer',
-                                          hcalTPDigis = cms.InputTag("emulTPDigis"),
+                                          hcalTPDigis = cms.InputTag("emulTPDigisForZDC"),
                                           bxFirst = cms.int32(-2),
                                           bxLast = cms.int32(3)
 )
@@ -222,6 +224,7 @@ process.preRecoPath = cms.Path(
 		#*process.castorDigis # not in Run3
 		*process.emulTPDigis
 		*process.emulTPDigisNoTDCCut
+                *process.emulTPDigisForZDC
 		*process.L1TRawToDigi
 )
 


### PR DESCRIPTION
#### PR description:

This PR is intended to address an existing problem in the HCAL DQM that causes HF TPs to not be properly displayed. This is discussed further in https://gitlab.cern.ch/cmshcal/docs/-/issues/276.

#### PR validation:

The PR validation and testing was performed on 2024 data using the procedure described [here](https://paper.dropbox.com/doc/HF-DQM-Bug-Investigation--CnJ339OnvIBH5MdlvX5uwccpAQ-E6OyqO08Uksux0NqJw7xy).


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is a backport of https://github.com/cms-sw/cmssw/pull/48237

Tagging @akhukhun , @JHiltbrand , @salimcerci, @denizsun