### PR TITLE
Use standard PV reco in Run3_2025_UPC_OXY

### DIFF
--- a/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
+++ b/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
@@ -88,7 +88,8 @@ from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 )
 
 from Configuration.Eras.Modifier_highBetaStar_cff import highBetaStar
-highBetaStar.toModify(offlinePrimaryVertices,
+from Configuration.Eras.Modifier_run3_oxygen_cff import run3_oxygen
+(highBetaStar & ~run3_oxygen).toModify(offlinePrimaryVertices,
     TkClusParameters = dict(
         TkDAClusParameters = dict(
             Tmin = 4.0,
@@ -162,7 +163,7 @@ from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
                )
 )
 
-highBetaStar.toModify(offlinePrimaryVertices,
+(highBetaStar & ~run3_oxygen).toModify(offlinePrimaryVertices,
      TkFilterParameters = dict(
          maxNormalizedChi2 = 80.0,
          minPixelLayersWithHits = 1,
@@ -179,7 +180,7 @@ highBetaStar.toModify(offlinePrimaryVertices,
 )
 
 from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
-(highBetaStar & run3_upc).toModify(offlinePrimaryVertices,
+(highBetaStar & run3_upc & ~run3_oxygen).toModify(offlinePrimaryVertices,
     TkFilterParameters = dict(
         algorithm="filterWithThreshold",
         maxNormalizedChi2 = 80.0,


### PR DESCRIPTION
#### PR description:

This PR changes the PV reconstruction of the Run3_2025_UPC_OXY era to use the standard pp reconstruction that has shown reliable results in the presence of pileup in OO simulations.

#### PR validation:

Tested with workflow 143.911 and 143.912

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->
Plan to backport to 15_0_X

@abaty @loizides @mandrenguyen
