### PR TITLE
[NGT] Update default Phase 2 HLT Muon sequence  to use new Standalone seeding module and streamlined Tracker Muon reconstruction

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -711,21 +711,11 @@ phase2_muon.toModify(FEVTDEBUGHLTEventContent,
         'keep *_hltL2MuonsFromL1TkMuon_*_*',
         'keep *_hltIter2Phase2L3FromL1TkMuonMerged_*_*',
         'keep *_hltPhase2L3OIMuonTrackSelectionHighPurity_*_*',
+        'keep *_hltPhase2L3MuonFilter_*_*',
         'keep *_hltPhase2L3MuonMerged_*_*',
         'keep *_hltPhase2L3GlbMuon_*_*',
         'keep *_hltPhase2L3MuonsNoID_*_*',
         'keep *_hltPhase2L3Muons_*_*'])
-
-from Configuration.ProcessModifiers.phase2L2AndL3Muons_cff import phase2L2AndL3Muons
-(phase2_muon & ~phase2L2AndL3Muons).toModify(FEVTDEBUGHLTEventContent, 
-    outputCommands = FEVTDEBUGHLTEventContent.outputCommands + [
-        'keep *_hltL2OfflineMuonSeeds_*_*'
-    ])
-
-(phase2_muon & phase2L2AndL3Muons).toModify(FEVTDEBUGHLTEventContent, 
-    outputCommands = FEVTDEBUGHLTEventContent.outputCommands + [
-        'keep *_hltPhase2L3MuonFilter_*_*'
-    ])
 
 phase2_hgcal.toModify(FEVTDEBUGHLTEventContent,
     outputCommands = FEVTDEBUGHLTEventContent.outputCommands + TICL_FEVTHLT.outputCommands)

--- a/Configuration/ProcessModifiers/python/phase2L2AndL3Muons_cff.py
+++ b/Configuration/ProcessModifiers/python/phase2L2AndL3Muons_cff.py
@@ -1,5 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-# this modifier is for enabling Phase 2 L2 Muon seeding from L1Tk Muons 
-# and the simplified L3 Tracker Muon reconstruction (Inside-Out first)
-phase2L2AndL3Muons = cms.Modifier()

--- a/Configuration/PyReleaseValidation/README.md
+++ b/Configuration/PyReleaseValidation/README.md
@@ -66,8 +66,7 @@ The offsets currently in use are:
 * 0.759: HLT phase-2 timing menu, with NANO:@Phase2HLT
 * 0.77: HLT phase-2 NGT Scouting menu
 * 0.771: HLT phase-2 NGT Scouting menu, with NANO:@NGTScouting
-* 0.777 New Phase 2 Standalone Muon seeding, streamlined L3 Tracker Muons reconstruction (Inside-Out first), HLT Muon NanoAOD
-* 0.778 New Phase 2 Standalone Muon seeding, streamlined L3 Tracker Muons reconstruction (Outside-In first), HLT Muon NanoAOD
+* 0.778 L3 Tracker Muons reconstruction Outside-In first, HLT Muon NanoAOD
 * 0.78: Complete L1 workflow
 * 0.781: Complete L1 workflow, producing FEVT and NANO output L1/P2GT objects
 * 0.782: Complete L1 workflow, producing only NANO output L1/P2GT objects

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -965,42 +965,7 @@ upgradeWFs['CPfromPU'].step2 = {'--procModifiers': 'enableCPfromPU'}
 upgradeWFs['CPfromPU'].step3 = {'--procModifiers': 'enableCPfromPU'}
 upgradeWFs['CPfromPU'].step4 = {'--procModifiers': 'enableCPfromPU'}
 
-# Improved L2 seeding from L1Tk Muons and L3 Tracker Muon Inside-Out reconstruction first (Phase-2 Muon default)
-class UpgradeWorkflow_phase2L2AndL3Muons(UpgradeWorkflow):
-    def setup_(self, step, stepName, stepDict, k, properties):
-        if ('Digi' in step and 'NoHLT' not in step) or ('HLTOnly' in step):
-            stepDict[stepName][k] = merge([self.step2, stepDict[step][k]])
-        if 'RecoGlobal' in step:
-            stepDict[stepName][k] = merge([self.step3, stepDict[step][k]])
-        if 'HARVESTGlobal' in step:
-            stepDict[stepName][k] = merge([self.step4, stepDict[step][k]])
-    def condition(self, fragment, stepList, key, hasHarvest):
-        return (fragment=="ZMM_14" or 'SingleMu' in fragment or 'TTbar_14' in fragment) and 'Run4' in key
-
-upgradeWFs['phase2L2AndL3Muons'] = UpgradeWorkflow_phase2L2AndL3Muons(
-    steps = [
-        'HLTOnly',
-        'DigiTrigger',
-        'RecoGlobal',
-        'HARVESTGlobal'
-    ],
-    PU = [
-        'HLTOnly',
-        'DigiTrigger',
-        'RecoGlobal',
-        'HARVESTGlobal'
-    ],
-    suffix = '_phase2L2AndL3MuonsIOFirst',
-    offset = 0.777,
-)
-upgradeWFs['phase2L2AndL3Muons'].step2 = {'-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:@relvalRun4,NANO:@MUHLT',
-                                          '--datatier':'GEN-SIM-DIGI-RAW,NANOAODSIM',
-                                          '--eventcontent':'FEVTDEBUGHLT,NANOAODSIM',
-                                          '--procModifiers':'phase2L2AndL3Muons'}
-upgradeWFs['phase2L2AndL3Muons'].step3 = {'--procModifiers':'phase2L2AndL3Muons'}
-upgradeWFs['phase2L2AndL3Muons'].step4 = {'--procModifiers':'phase2L2AndL3Muons'}
-
-# Improved L2 seeding from L1Tk Muons and L3 Tracker Muon Outside-In reconstruction first
+# L3 Tracker Muon Outside-In reconstruction first
 class UpgradeWorkflow_phase2L3MuonsOIFirst(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):
         if ('Digi' in step and 'NoHLT' not in step) or ('HLTOnly' in step):
@@ -1025,15 +990,15 @@ upgradeWFs['phase2L3MuonsOIFirst'] = UpgradeWorkflow_phase2L3MuonsOIFirst(
         'RecoGlobal',
         'HARVESTGlobal'
     ],
-    suffix = '_phase2L2AndL3MuonsOIFirst',
+    suffix = '_phase2L3MuonsOIFirst',
     offset = 0.778,
 )
 upgradeWFs['phase2L3MuonsOIFirst'].step2 = {'-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:@relvalRun4,NANO:@MUHLT',
                                             '--datatier':'GEN-SIM-DIGI-RAW,NANOAODSIM',
                                             '--eventcontent':'FEVTDEBUGHLT,NANOAODSIM',
-                                            '--procModifiers':'phase2L2AndL3Muons,phase2L3MuonsOIFirst'}
-upgradeWFs['phase2L3MuonsOIFirst'].step3 = {'--procModifiers':'phase2L2AndL3Muons,phase2L3MuonsOIFirst'}
-upgradeWFs['phase2L3MuonsOIFirst'].step4 = {'--procModifiers':'phase2L2AndL3Muons,phase2L3MuonsOIFirst'}
+                                            '--procModifiers':'phase2L3MuonsOIFirst'}
+upgradeWFs['phase2L3MuonsOIFirst'].step3 = {'--procModifiers':'phase2L3MuonsOIFirst'}
+upgradeWFs['phase2L3MuonsOIFirst'].step4 = {'--procModifiers':'phase2L3MuonsOIFirst'}
 
 # Track DNN workflows
 class UpgradeWorkflow_trackdnn(UpgradeWorkflow):

--- a/DPGAnalysis/MuonTools/python/nano_mu_hlt_cff.py
+++ b/DPGAnalysis/MuonTools/python/nano_mu_hlt_cff.py
@@ -156,7 +156,11 @@ l2SeedFromL1TkMuonTable = cms.EDProducer(
     extension = cms.bool(False),
     variables = cms.PSet(
         pt = Var("startingState().pt()", "float", doc = "p_T (GeV)"),
-        nHits = Var("nHits()", "int16", doc = ""),
+        nHits = Var(
+            "nHits()", "int16", doc = "number of DT/CSC segments propagated to the seed"
+        ),
+        eta = Var("l1TkMu().phEta()", "float", doc = "associated L1TkMu #eta"),
+        phi = Var("l1TkMu().phPhi()", "float", doc = "associated L1TkMu #phi"),
         localX = Var(
             "startingState().parameters().position().x()",
             "float",
@@ -268,25 +272,8 @@ l3TkOIFilteredTable = l2MuTable.clone(
     doc = cms.string("L3 Tracker Muons Outside-In filtered (quality cuts and match with L1TkMu)")
 )
 
-# The muon trigger producers sequence
+# Default Phase 2 HLT muon ntuples producers sequence (Inside-Out first)
 hltMuonTriggerProducers = cms.Sequence(
-    recoMuonValidationHLT_seq
-    + hltLocalRecoMuon_seq
-    + l1TkMuTable
-    + l2SeedTable
-    + l2SeedFromL1TkMuonTable
-    + l2MuTable
-    + l2MuTableVtx
-    + l3TkIOTable
-    + l3TkOITable
-    + l3TkMergedTable
-    + l3GlbMuTable
-    + l3MuTkNoIdTable
-    + l3MuTkIdTable
-)
-
-# The Phase-2 IO first muon trigger producers sequence
-hltMuonTriggerProducersIOFirst = cms.Sequence(
     recoMuonValidationHLT_seq
     + hltLocalRecoMuon_seq
     + l1TkMuTable
@@ -303,8 +290,8 @@ hltMuonTriggerProducersIOFirst = cms.Sequence(
     + l3MuTkIdTable
 )
 
-# The Phase-2 OI first muon trigger producers sequence
-hltMuonTriggerProducersOIFirst = cms.Sequence(
+# Phase 2 HLT muon ntuples producers sequence (Outside-In first)
+_hltMuonTriggerProducersOIFirst = cms.Sequence(
     recoMuonValidationHLT_seq
     + hltLocalRecoMuon_seq
     + l1TkMuTable
@@ -321,56 +308,6 @@ hltMuonTriggerProducersOIFirst = cms.Sequence(
     + l3MuTkIdTable
 )
 
-from Configuration.ProcessModifiers.phase2L2AndL3Muons_cff import phase2L2AndL3Muons
-
-phase2L2AndL3Muons.toModify(
-    l2SeedFromL1TkMuonTable,
-    variables = cms.PSet(
-        pt = Var("startingState().pt()", "float", doc = "p_T (GeV)"),
-        nHits = Var(
-            "nHits()", "int16", doc = "number of DT/CSC segments propagated to the seed"
-        ),
-        eta = Var("l1TkMu().phEta()", "float", doc = "associated L1TkMu #eta"),
-        phi = Var("l1TkMu().phPhi()", "float", doc = "associated L1TkMu #phi"),
-        localX = Var(
-            "startingState().parameters().position().x()",
-            "float",
-            doc = "local x of the seed",
-        ),
-        localY = Var(
-            "startingState().parameters().position().y()",
-            "float",
-            doc = "local y of the seed",
-        )
-    )
-)
-phase2L2AndL3Muons.toReplaceWith(
-    hltMuonTriggerProducers, hltMuonTriggerProducersIOFirst
-)
-
 from Configuration.ProcessModifiers.phase2L3MuonsOIFirst_cff import phase2L3MuonsOIFirst
+phase2L3MuonsOIFirst.toReplaceWith(hltMuonTriggerProducers, _hltMuonTriggerProducersOIFirst)
 
-(phase2L2AndL3Muons & phase2L3MuonsOIFirst).toModify(
-    l2SeedFromL1TkMuonTable,
-    variables = cms.PSet(
-        pt = Var("startingState().pt()", "float", doc = "p_T (GeV)"),
-        nHits = Var(
-            "nHits()", "int16", doc = "number of DT/CSC segments propagated to the seed"
-        ),
-        eta = Var("l1TkMu().phEta()", "float", doc = "associated L1TkMu #eta"),
-        phi = Var("l1TkMu().phPhi()", "float", doc = "associated L1TkMu #phi"),
-        localX = Var(
-            "startingState().parameters().position().x()",
-            "float",
-            doc = "local x of the seed",
-        ),
-        localY = Var(
-            "startingState().parameters().position().y()",
-            "float",
-            doc = "local y of the seed",
-        )
-    )
-)
-(phase2L2AndL3Muons & phase2L3MuonsOIFirst).toReplaceWith(
-    hltMuonTriggerProducers, hltMuonTriggerProducersOIFirst
-)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltIter2Phase2L3FromL1TkMuonPixelSeedsFiltered_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltIter2Phase2L3FromL1TkMuonPixelSeedsFiltered_cfi.py
@@ -34,9 +34,8 @@ hltIter2Phase2L3FromL1TkMuonPixelSeedsFiltered = cms.EDProducer("MuonHLTSeedMVAC
     src = cms.InputTag("hltIter2Phase2L3FromL1TkMuonPixelSeeds")
 )
 
-from Configuration.ProcessModifiers.phase2L2AndL3Muons_cff import phase2L2AndL3Muons
 from Configuration.ProcessModifiers.phase2L3MuonsOIFirst_cff import phase2L3MuonsOIFirst
-(phase2L2AndL3Muons & phase2L3MuonsOIFirst).toModify(
+phase2L3MuonsOIFirst.toModify(
     hltIter2Phase2L3FromL1TkMuonPixelSeedsFiltered, 
     L1TkMu = "hltPhase2L3MuonFilter:L1TkMuToReuse"
 )

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltL2MuonSeedsFromL1TkMuon_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltL2MuonSeedsFromL1TkMuon_cfi.py
@@ -1,27 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-hltL2MuonSeedsFromL1TkMuon = cms.EDProducer("L2MuonSeedGeneratorFromL1TkMu",
-    EtaMatchingBins = cms.vdouble(0.0, 2.5),
-    InputObjects = cms.InputTag("l1tTkMuonsGmt"),
-    L1MaxEta = cms.double(2.5),
-    L1MinPt = cms.double(0.0),
-    MatchDR = cms.vdouble(0.3),
-    MinPL1Tk = cms.double(3.5),
-    MinPtL1TkBarrel = cms.double(3.5),
-    OfflineSeedLabel = cms.untracked.InputTag("hltL2OfflineMuonSeeds"),
-    Propagator = cms.string('SteppingHelixPropagatorAny'),
-    ServiceParameters = cms.PSet(
-        Propagators = cms.untracked.vstring('SteppingHelixPropagatorAny'),
-        RPCLayers = cms.bool(True),
-        UseMuonNavigation = cms.untracked.bool(True)
-    ),
-    SetMinPtBarrelTo = cms.double(3.5),
-    SetMinPtEndcapTo = cms.double(1.0),
-    UseOfflineSeed = cms.untracked.bool(True),
-    UseUnassociatedL1 = cms.bool(False)
-)
-
-phase2HltL2MuonSeedsFromL1TkMuon = cms.EDProducer('Phase2L2MuonSeedCreator',
+hltL2MuonSeedsFromL1TkMuon = cms.EDProducer('Phase2L2MuonSeedCreator',
     inputObjects = cms.InputTag('l1tTkMuonsGmt'),
     cscRecSegmentLabel = cms.InputTag('hltCscSegments'),
     dtRecSegmentLabel = cms.InputTag('hltDt4DSegments'),
@@ -42,8 +21,3 @@ phase2HltL2MuonSeedsFromL1TkMuon = cms.EDProducer('Phase2L2MuonSeedCreator',
     estimatorMaxChi2 = cms.double(1000.0)
 )   
 
-from Configuration.ProcessModifiers.phase2L2AndL3Muons_cff import phase2L2AndL3Muons
-phase2L2AndL3Muons.toReplaceWith(
-    hltL2MuonSeedsFromL1TkMuon,
-    phase2HltL2MuonSeedsFromL1TkMuon
-    )

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2L3FromL1TkMuonPixelTracksTrackingRegions_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2L3FromL1TkMuonPixelTracksTrackingRegions_cfi.py
@@ -23,9 +23,8 @@ hltPhase2L3FromL1TkMuonPixelTracksTrackingRegions = cms.EDProducer("CandidateSee
     )
 )
 
-from Configuration.ProcessModifiers.phase2L2AndL3Muons_cff import phase2L2AndL3Muons
 from Configuration.ProcessModifiers.phase2L3MuonsOIFirst_cff import phase2L3MuonsOIFirst
-(phase2L2AndL3Muons & phase2L3MuonsOIFirst).toModify(
+phase2L3MuonsOIFirst.toModify(
     hltPhase2L3FromL1TkMuonPixelTracksTrackingRegions.RegionPSet,
     input = "hltPhase2L3MuonFilter:L1TkMuToReuse"
 )

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2L3MuonFilter_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2L3MuonFilter_cfi.py
@@ -15,9 +15,8 @@ hltPhase2L3MuonFilter = cms.EDProducer("Phase2HLTMuonSelectorForL3",
     MaxPtDifference = cms.double(999.0),
 )
 
-from Configuration.ProcessModifiers.phase2L2AndL3Muons_cff import phase2L2AndL3Muons
 from Configuration.ProcessModifiers.phase2L3MuonsOIFirst_cff import phase2L3MuonsOIFirst
-(phase2L2AndL3Muons & phase2L3MuonsOIFirst).toModify(
+phase2L3MuonsOIFirst.toModify(
     hltPhase2L3MuonFilter,
     l3Tracks = "hltPhase2L3OIMuonTrackSelectionHighPurity",
     IOFirst = False,

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2L3MuonMerged_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2L3MuonMerged_cfi.py
@@ -10,7 +10,7 @@ hltPhase2L3MuonMerged = cms.EDProducer("TrackListMerger",
     ShareFrac = cms.double(0.19),
     TrackProducers = cms.VInputTag(
         "hltPhase2L3OIMuonTrackSelectionHighPurity",
-        "hltIter2Phase2L3FromL1TkMuonMerged",
+        "hltPhase2L3MuonFilter:L3IOTracksFiltered",
     ),
     allowFirstHitShare = cms.bool(True),
     copyExtras = cms.untracked.bool(True),
@@ -20,28 +20,15 @@ hltPhase2L3MuonMerged = cms.EDProducer("TrackListMerger",
     newQuality = cms.string("confirmed"),
     selectedTrackQuals = cms.VInputTag(
         "hltPhase2L3OIMuonTrackSelectionHighPurity",
-        "hltIter2Phase2L3FromL1TkMuonMerged",
+        "hltPhase2L3MuonFilter:L3IOTracksFiltered",
     ),
     setsToMerge = cms.VPSet(cms.PSet(pQual = cms.bool(False), tLists = cms.vint32(0, 1))),
     trackAlgoPriorityOrder = cms.string("hltESPTrackAlgoPriorityOrder"),
     writeOnlyTrkQuals = cms.bool(False),
 )
 
-from Configuration.ProcessModifiers.phase2L2AndL3Muons_cff import phase2L2AndL3Muons
-phase2L2AndL3Muons.toModify(
-    hltPhase2L3MuonMerged,
-    TrackProducers = cms.VInputTag(
-        "hltPhase2L3OIMuonTrackSelectionHighPurity",
-        "hltPhase2L3MuonFilter:L3IOTracksFiltered",
-    ),
-    selectedTrackQuals = cms.VInputTag(
-        "hltPhase2L3OIMuonTrackSelectionHighPurity",
-        "hltPhase2L3MuonFilter:L3IOTracksFiltered",
-    ),
-)
-
 from Configuration.ProcessModifiers.phase2L3MuonsOIFirst_cff import phase2L3MuonsOIFirst
-(phase2L2AndL3Muons & phase2L3MuonsOIFirst).toModify(
+phase2L3MuonsOIFirst.toModify(
     hltPhase2L3MuonMerged,
     TrackProducers = cms.VInputTag(
         "hltPhase2L3MuonFilter:L3OITracksFiltered",

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2L3OISeedsFromL2Muons_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2L3OISeedsFromL2Muons_cfi.py
@@ -35,19 +35,13 @@ hltPhase2L3OISeedsFromL2Muons = cms.EDProducer("TSGForOIFromL2",
     pT2 = cms.double(30.0),
     pT3 = cms.double(70.0),
     propagatorName = cms.string('PropagatorWithMaterialParabolicMf'),
-    src = cms.InputTag("hltL2MuonsFromL1TkMuon","UpdatedAtVtx"),
+    src = cms.InputTag("hltPhase2L3MuonFilter:L2MuToReuse"),
     tsosDiff1 = cms.double(0.2),
     tsosDiff2 = cms.double(0.02)
 )
 
-from Configuration.ProcessModifiers.phase2L2AndL3Muons_cff import phase2L2AndL3Muons
-phase2L2AndL3Muons.toModify(
-    hltPhase2L3OISeedsFromL2Muons,
-    src = "hltPhase2L3MuonFilter:L2MuToReuse"
-)
-
 from Configuration.ProcessModifiers.phase2L3MuonsOIFirst_cff import phase2L3MuonsOIFirst
-(phase2L2AndL3Muons & phase2L3MuonsOIFirst).toModify(
+phase2L3MuonsOIFirst.toModify(
     hltPhase2L3OISeedsFromL2Muons,
     src ="hltL2MuonsFromL1TkMuon:UpdatedAtVtx"
 )

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTL2MuonsFromL1TkSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTL2MuonsFromL1TkSequence_cfi.py
@@ -7,14 +7,7 @@ from ..sequences.HLTMuonlocalrecoSequence_cfi import *
 
 HLTL2MuonsFromL1TkSequence = cms.Sequence(
     HLTMuonlocalrecoSequence
-    + hltL2OfflineMuonSeeds
     + hltL2MuonSeedsFromL1TkMuon
     + hltL2MuonsFromL1TkMuon
 )
 
-from Configuration.ProcessModifiers.phase2L2AndL3Muons_cff import phase2L2AndL3Muons
-
-phase2L2AndL3Muons.toReplaceWith(
-    HLTL2MuonsFromL1TkSequence,
-    HLTL2MuonsFromL1TkSequence.copyAndExclude([hltL2OfflineMuonSeeds]),
-)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTMuonsSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTMuonsSequence_cfi.py
@@ -6,20 +6,10 @@ from ..sequences.HLTL2MuonsFromL1TkSequence_cfi import *
 from ..sequences.HLTPhase2L3FromL1TkSequence_cfi import *
 from ..sequences.HLTPhase2L3MuonsSequence_cfi import *
 from ..sequences.HLTPhase2L3OISequence_cfi import *
-
-HLTMuonsSequence = cms.Sequence(
-    HLTL2MuonsFromL1TkSequence
-    + HLTPhase2L3OISequence
-    + HLTPhase2L3FromL1TkSequence
-    + HLTIter0Phase2L3FromL1TkSequence
-    + HLTIter2Phase2L3FromL1TkSequence
-    + HLTPhase2L3MuonsSequence
-)
-
 from ..modules.hltPhase2L3MuonFilter_cfi import *
 
-# The IO first HLT Muons sequence
-Phase2HLTMuonsSequenceIOFirst = cms.Sequence(
+# The default HLT Muons sequence (Inside-Out first)
+HLTMuonsSequence = cms.Sequence(
     HLTL2MuonsFromL1TkSequence
     + HLTPhase2L3FromL1TkSequence
     + HLTIter0Phase2L3FromL1TkSequence
@@ -28,8 +18,9 @@ Phase2HLTMuonsSequenceIOFirst = cms.Sequence(
     + HLTPhase2L3OISequence
     + HLTPhase2L3MuonsSequence
 )
-# The OI first HLT Muons sequence
-Phase2HLTMuonsSequenceOIFirst = cms.Sequence(
+
+# Outside-In first HLT Muons sequence
+_HLTMuonsSequenceOIFirst = cms.Sequence(
     HLTL2MuonsFromL1TkSequence
     + HLTPhase2L3OISequence
     + hltPhase2L3MuonFilter
@@ -38,13 +29,7 @@ Phase2HLTMuonsSequenceOIFirst = cms.Sequence(
     + HLTIter2Phase2L3FromL1TkSequence
     + HLTPhase2L3MuonsSequence
 )
-
-from Configuration.ProcessModifiers.phase2L2AndL3Muons_cff import phase2L2AndL3Muons
-
-phase2L2AndL3Muons.toReplaceWith(HLTMuonsSequence, Phase2HLTMuonsSequenceIOFirst)
 
 from Configuration.ProcessModifiers.phase2L3MuonsOIFirst_cff import phase2L3MuonsOIFirst
+phase2L3MuonsOIFirst.toReplaceWith(HLTMuonsSequence, _HLTMuonsSequenceOIFirst)
 
-(phase2L2AndL3Muons & phase2L3MuonsOIFirst).toReplaceWith(
-    HLTMuonsSequence, Phase2HLTMuonsSequenceOIFirst
-)

--- a/Validation/RecoMuon/python/associators_cff.py
+++ b/Validation/RecoMuon/python/associators_cff.py
@@ -430,19 +430,7 @@ muonAssociationReduced_seq = cms.Sequence(
     +tpToDisplacedGlbMuonAssociation
 )
 
-_muonAssociationHLT_seq = cms.Sequence(
-    hltPhase2L2MuonSeedTracks+Phase2tpToL2SeedAssociation
-    +Phase2tpToL2MuonAssociation+Phase2tpToL2MuonUpdAssociation
-    +Phase2tpToL3IOTkAssociation+Phase2tpToL3OITkAssociation
-    +Phase2tpToL3TkMergedAssociation+Phase2tpToL3GlbMuonMergedAssociation
-    +hltPhase2L3MuonNoIdTracks+Phase2tpToL3MuonNoIdAssociation
-    +hltPhase2L3MuonIdTracks+Phase2tpToL3MuonIdAssociation
-)
-
-from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
-phase2_muon.toReplaceWith(muonAssociationHLT_seq, _muonAssociationHLT_seq)
-
-# Inside-Out first
+# Phase 2 HLT association sequence, L3 Inside-Out first
 _muonAssociationHLT_seq_IO_first = cms.Sequence(
     hltPhase2L2MuonSeedTracks+Phase2tpToL2SeedAssociation
     +Phase2tpToL2MuonAssociation+Phase2tpToL2MuonUpdAssociation
@@ -452,7 +440,10 @@ _muonAssociationHLT_seq_IO_first = cms.Sequence(
     +hltPhase2L3MuonNoIdTracks+Phase2tpToL3MuonNoIdAssociation
     +hltPhase2L3MuonIdTracks+Phase2tpToL3MuonIdAssociation
 )
-# Outside-In first
+from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
+phase2_muon.toReplaceWith(muonAssociationHLT_seq, _muonAssociationHLT_seq_IO_first)
+
+# Phase 2 L3 Outside-In first
 _muonAssociationHLT_seq_OI_first = cms.Sequence(
     hltPhase2L2MuonSeedTracks+Phase2tpToL2SeedAssociation
     +Phase2tpToL2MuonAssociation+Phase2tpToL2MuonUpdAssociation
@@ -462,12 +453,8 @@ _muonAssociationHLT_seq_OI_first = cms.Sequence(
     +hltPhase2L3MuonNoIdTracks+Phase2tpToL3MuonNoIdAssociation
     +hltPhase2L3MuonIdTracks+Phase2tpToL3MuonIdAssociation
 )
-
-from Configuration.ProcessModifiers.phase2L2AndL3Muons_cff import phase2L2AndL3Muons
-phase2L2AndL3Muons.toReplaceWith(muonAssociationHLT_seq, _muonAssociationHLT_seq_IO_first)
-
 from Configuration.ProcessModifiers.phase2L3MuonsOIFirst_cff import phase2L3MuonsOIFirst
-(phase2L2AndL3Muons & phase2L3MuonsOIFirst).toReplaceWith(muonAssociationHLT_seq, _muonAssociationHLT_seq_OI_first)
+phase2L3MuonsOIFirst.toReplaceWith(muonAssociationHLT_seq, _muonAssociationHLT_seq_OI_first)
 
 # fastsim has no hlt specific dt hit collection
 from Configuration.Eras.Modifier_fastSim_cff import fastSim

--- a/Validation/RecoMuon/python/muonValidationHLT_cff.py
+++ b/Validation/RecoMuon/python/muonValidationHLT_cff.py
@@ -102,10 +102,6 @@ _hltMuonMultiTrackValidator = MTVhlt.clone(
     )
 )
 
-# Customization for Inside-Out / Outside-In first approaches
-from Configuration.ProcessModifiers.phase2L2AndL3Muons_cff import phase2L2AndL3Muons
-from Configuration.ProcessModifiers.phase2L3MuonsOIFirst_cff import phase2L3MuonsOIFirst
-
 def _modify_for_IO_first(validator):
     validator.associatormap += ['Phase2tpToL2MuonToReuseAssociation', 'Phase2tpToL3IOTkFilteredAssociation']
     validator.label += ['hltPhase2L3MuonFilter:L2MuToReuse', 'hltPhase2L3MuonFilter:L3IOTracksFiltered']
@@ -115,9 +111,11 @@ def _modify_for_OI_first(validator):
     validator.associatormap += ['Phase2tpToL3OITkFilteredAssociation']
     validator.label += ['hltPhase2L3MuonFilter:L3OITracksFiltered']
     validator.muonHistoParameters.extend([trkMuonHistoParameters])
-    
-(phase2L2AndL3Muons & ~phase2L3MuonsOIFirst).toModify(_hltMuonMultiTrackValidator, _modify_for_IO_first)
-(phase2L2AndL3Muons & phase2L3MuonsOIFirst).toModify(_hltMuonMultiTrackValidator, _modify_for_OI_first)
+
+# Customization for Inside-Out / Outside-In first approaches
+from Configuration.ProcessModifiers.phase2L3MuonsOIFirst_cff import phase2L3MuonsOIFirst
+(~phase2L3MuonsOIFirst).toModify(_hltMuonMultiTrackValidator, _modify_for_IO_first)
+phase2L3MuonsOIFirst.toModify(_hltMuonMultiTrackValidator, _modify_for_OI_first)
 
 # Check that the associators and labels are consistent
 # All MTV clones are DQMEDAnalyzers


### PR DESCRIPTION
#### PR description:
This PR changes the default Phase 2 HLT Muon reconstruction to the previous `.777` workflow. As such it includes:
- new Standalone Muon seeding module from L1TkMuons
- streamlined Tracker Muons reconstruction performing the Inside-Out pass first

As part of the integration, the `phase2L2AndL3Muons` procModifiers has been removed. The other related procModifer `phase2L3MuonsOIFirst` remains as a quick way to assess the performance of the Outside-In first approach in Tracker Muon reconstruction. The latter procModifier is also enabled by default in `.778` workflows (as before)

Slight differences in timing and HLT Muons' physics performance are expected, with slightly higher Standalone performance in the barrel and slightly lower in the endcaps, as seen in the PR that implemented these changes #46897 first. 

#### PR validation:
The PR was tested locally on the standard test suite and a few `.778` workflows, such as `29704.778`