### PR TITLE
Fix for PR #47067

### DIFF
--- a/DataFormats/L1TrackTrigger/interface/TTBV.h
+++ b/DataFormats/L1TrackTrigger/interface/TTBV.h
@@ -389,8 +389,8 @@ private:
 
   // check if value fits into binary BV
   void checkU(unsigned long long int value) {
-    if (size_ == 0)
-      return;
+    if (size_ <= 0 || size_ > S_)
+      throwSize();
     if (value < iMax())
       return;
     cms::Exception exception("RunTimeError.");
@@ -401,8 +401,6 @@ private:
 
   // check if value fits into twos's complement BV
   void checkT(int value) {
-    if (size_ == 0)
-      return;
     static const std::array<double, S_ + 1> lut = powersOfTwo();
     auto abs = [](int val) { return val < 0 ? std::abs(val) - 1 : val; };
     if (abs(value) < std::round(lut[size_ - 1]))
@@ -415,8 +413,8 @@ private:
 
   // check if value fits into twos complement / binary BV
   void checkI(int value) {
-    if (size_ == 0)
-      return;
+    if (size_ <= 0 || size_ > S_)
+      throwSize();
     if (twos_)
       checkT(value);
     else if (value < 0) {
@@ -426,6 +424,13 @@ private:
       throw exception;
     } else
       checkU(value);
+  }
+
+  // nonsensical bitwith of smaller equal 0 or unsupported size, bigger 64, deteced
+  void throwSize() const {
+    cms::Exception exception("RunTimeError.");
+    exception << "TTBV constructor called with bad bit width (" << size_ << ").";
+    throw exception;
   }
 };
 

--- a/L1Trigger/TrackFindingTracklet/interface/DataFormats.h
+++ b/L1Trigger/TrackFindingTracklet/interface/DataFormats.h
@@ -198,7 +198,7 @@ namespace trklet {
     // converts ntuple of variables to bits
     template <typename... Ts>
     void convertStub(Process p, const std::tuple<Ts...>& data, tt::Frame& bv) const {
-      TTBV ttBV(1, numUnusedBitsStubs_[+p]);
+      TTBV ttBV(1, 1 + numUnusedBitsStubs_[+p]);
       attachStub(p, data, ttBV);
       bv = ttBV.bs();
     }
@@ -211,7 +211,7 @@ namespace trklet {
     // converts ntuple of variables to bits
     template <typename... Ts>
     void convertTrack(Process p, const std::tuple<Ts...>& data, tt::Frame& bv) const {
-      TTBV ttBV(1, numUnusedBitsTracks_[+p]);
+      TTBV ttBV(1, 1 + numUnusedBitsTracks_[+p]);
       attachTrack(p, data, ttBV);
       bv = ttBV.bs();
     }

--- a/L1Trigger/TrackFindingTracklet/test/HybridTracksNewKF_cfg.py
+++ b/L1Trigger/TrackFindingTracklet/test/HybridTracksNewKF_cfg.py
@@ -19,7 +19,7 @@ process.load( 'Configuration.StandardSequences.FrontierConditions_GlobalTag_cff'
 process.load( 'L1Trigger.TrackTrigger.TrackTrigger_cff' )
 
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto::phase2_realistic', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 
 # load code that associates stubs with mctruth
 process.load( 'SimTracker.TrackTriggerAssociation.StubAssociator_cff' )
@@ -58,7 +58,7 @@ options = VarParsing.VarParsing( 'analysis' )
 #from MCsamples.Scripts.getCMSlocaldata_cfi import *
 #from MCsamples.RelVal_1260_D88.PU200_TTbar_14TeV_cfi import *
 #inputMC = getCMSdataFromCards()
-Samples = [""]
+Samples = ["/store/mc/Phase2Spring24DIGIRECOMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_Trk1GeV_140X_mcRun4_realistic_v4-v2/130000/00c7f40e-b44e-4eea-a86b-def8f7d82b0e.root"]
 options.register( 'inputMC', Samples, VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.string, "Files to be processed" )
 # specify number of events to process.
 options.register( 'Events',100,VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.int, "Number of Events to analyze" )

--- a/L1Trigger/TrackTrigger/plugins/ProducerSetup.cc
+++ b/L1Trigger/TrackTrigger/plugins/ProducerSetup.cc
@@ -66,6 +66,7 @@ namespace tt {
     iConfig_.tbWidthsR_ = pSetHybrid.getParameter<std::vector<int>>("WidthsRTB");
     const edm::ParameterSet& pSetFW = iConfig.getParameter<edm::ParameterSet>("Firmware");
     iConfig_.enableTruncation_ = pSetFW.getParameter<bool>("EnableTruncation");
+    iConfig_.useHybrid_ = pSetFW.getParameter<bool>("UseHybrid");
     iConfig_.widthDSPa_ = pSetFW.getParameter<int>("WidthDSPa");
     iConfig_.widthDSPb_ = pSetFW.getParameter<int>("WidthDSPb");
     iConfig_.widthDSPc_ = pSetFW.getParameter<int>("WidthDSPc");

--- a/L1Trigger/TrackTrigger/src/Setup.cc
+++ b/L1Trigger/TrackTrigger/src/Setup.cc
@@ -54,6 +54,7 @@ namespace tt {
         tbWidthsR_(iConfig.tbWidthsR_),
         // Fimrware specific Parameter
         enableTruncation_(iConfig.enableTruncation_),
+        useHybrid_(iConfig.useHybrid_),
         widthDSPa_(iConfig.widthDSPa_),
         widthDSPb_(iConfig.widthDSPb_),
         widthDSPc_(iConfig.widthDSPc_),

--- a/L1Trigger/TrackerDTC/src/Stub.cc
+++ b/L1Trigger/TrackerDTC/src/Stub.cc
@@ -149,17 +149,18 @@ namespace trackerDTC {
     double phi = phi_ - (region - .5) * setup_->baseRegion() + setup_->hybridRangePhi() / 2.;
     // convert stub variables into bit vectors
     const bool twosR = type == tt::SensorModule::BarrelPS || type == tt::SensorModule::Barrel2S;
-    const TTBV hwR(r_, setup_->hybridBaseR(type), setup_->hybridWidthR(type), twosR);
-    const TTBV hwPhi(phi, setup_->hybridBasePhi(type), setup_->hybridWidthPhi(type));
-    const TTBV hwZ(z_, setup_->hybridBaseZ(type), setup_->hybridWidthZ(type), true);
-    const TTBV hwAlpha(row_, setup_->hybridBaseAlpha(type), setup_->hybridWidthAlpha(type), true);
-    const TTBV hwBend(bend_, setup_->hybridWidthBend(type), true);
-    const TTBV hwLayer(decodedLayerId, setup_->hybridWidthLayerId());
-    const TTBV hwGap(0, setup_->hybridNumUnusedBits(type));
-    const TTBV hwValid(1, 1);
+    const bool noAlpha = type != tt::SensorModule::Disk2S;
+    const std::string hwR = TTBV(r_, setup_->hybridBaseR(type), setup_->hybridWidthR(type), twosR).str();
+    const std::string hwPhi = TTBV(phi, setup_->hybridBasePhi(type), setup_->hybridWidthPhi(type)).str();
+    const std::string hwZ = TTBV(z_, setup_->hybridBaseZ(type), setup_->hybridWidthZ(type), true).str();
+    const std::string hwAlpha =
+        noAlpha ? "" : TTBV(row_, setup_->hybridBaseAlpha(type), setup_->hybridWidthAlpha(type), true).str();
+    const std::string hwBend = TTBV(bend_, setup_->hybridWidthBend(type), true).str();
+    const std::string hwLayer = TTBV(decodedLayerId, setup_->hybridWidthLayerId()).str();
+    const std::string hwGap = TTBV(0, setup_->hybridNumUnusedBits(type)).str();
+    const std::string hwValid = TTBV(1, 1).str();
     // assemble final bitset
-    return tt::Frame(hwGap.str() + hwR.str() + hwZ.str() + hwPhi.str() + hwAlpha.str() + hwBend.str() + hwLayer.str() +
-                     hwValid.str());
+    return tt::Frame(hwGap + hwR + hwZ + hwPhi + hwAlpha + hwBend + hwLayer + hwValid);
   }
 
   tt::Frame Stub::formatTMTT(int region) const {

--- a/L1Trigger/TrackerTFP/interface/DataFormats.h
+++ b/L1Trigger/TrackerTFP/interface/DataFormats.h
@@ -317,7 +317,7 @@ namespace trackerTFP {
     // converts ntuple of variables to bits
     template <typename... Ts>
     void convertStub(Process p, const std::tuple<Ts...>& data, tt::Frame& bv) const {
-      TTBV ttBV(1, numUnusedBitsStubs_[+p]);
+      TTBV ttBV(1, 1 + numUnusedBitsStubs_[+p]);
       attachStub(p, data, ttBV);
       bv = ttBV.bs();
     }
@@ -330,7 +330,7 @@ namespace trackerTFP {
     // converts ntuple of variables to bits
     template <typename... Ts>
     void convertTrack(Process p, const std::tuple<Ts...>& data, tt::Frame& bv) const {
-      TTBV ttBV(1, numUnusedBitsTracks_[+p]);
+      TTBV ttBV(1, 1 + numUnusedBitsTracks_[+p]);
       attachTrack(p, data, ttBV);
       bv = ttBV.bs();
     }


### PR DESCRIPTION
This PR includes a missing data member initialization accidentally introduced during review. Additionally I added a check during TTBV construction for nonsensical bit widths. That will prevent invalid array indices currently seen as UBSAN runtime errors.