### PR TITLE
[10_6_X] Add switch for scalar sum to LHEPtFilter

### DIFF
--- a/GeneratorInterface/GenFilters/src/LHEPtFilter.cc
+++ b/GeneratorInterface/GenFilters/src/LHEPtFilter.cc
@@ -3,12 +3,12 @@
 // Package:    LHEPtFilter
 // Class:      LHEPtFilter
 //
-/* 
+/*
 
- Description: Filter to select events with pT in a given range.
+ Description: Filter to select events with pT in a given range; includes a switch for sum type (vector or scalar).
  (Based on LHEGenericFilter)
 
-     
+
 */
 //
 
@@ -27,6 +27,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h"
 
@@ -40,6 +41,7 @@ public:
   ~LHEPtFilter() override;
 
   bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
   // ----------member data ---------------------------
@@ -49,6 +51,7 @@ private:
   std::set<int> pdgIds_;  // Set of PDG Ids to include
   double ptMin_;          // number of particles required to pass filter
   double ptMax_;          // number of particles required to pass filter
+  bool isScalar_;         // true for scalar sum or false for vector sum
 };
 
 using namespace edm;
@@ -57,7 +60,8 @@ using namespace std;
 LHEPtFilter::LHEPtFilter(const edm::ParameterSet& iConfig)
     : pdgIdVec_(iConfig.getParameter<std::vector<int>>("selectedPdgIds")),
       ptMin_(iConfig.getParameter<double>("ptMin")),
-      ptMax_(iConfig.getParameter<double>("ptMax")) {
+      ptMax_(iConfig.getParameter<double>("ptMax")),
+      isScalar_(iConfig.getParameter<bool>("isScalar")) {
   //here do whatever other initialization is needed
   src_ = consumes<LHEEventProduct>(iConfig.getParameter<edm::InputTag>("src"));
   pdgIds_ = std::set<int>(pdgIdVec_.begin(), pdgIdVec_.end());
@@ -87,18 +91,38 @@ bool LHEPtFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetu
     }
   }
   double vpt_ = -1;
-  if (!cands.empty()) {
-    ROOT::Math::PxPyPzEVector tot = cands.at(0);
-    for (unsigned icand = 1; icand < cands.size(); ++icand) {
-      tot += cands.at(icand);
+  if (isScalar_) {  // do the scalar sum
+    if (!cands.empty()) {
+      double tot = cands.at(0).pt();
+      for (unsigned icand = 1; icand < cands.size(); ++icand) {
+        tot += cands.at(icand).pt();
+      }
+      vpt_ = tot;
     }
-    vpt_ = tot.pt();
+    if ((ptMax_ < 0. || vpt_ <= ptMax_) && vpt_ > ptMin_) {
+      return true;
+    } else {
+      return false;
+    }
+  } else {  // else do the vector sum
+    if (!cands.empty()) {
+      ROOT::Math::PxPyPzEVector tot = cands.at(0);
+      for (unsigned icand = 1; icand < cands.size(); ++icand) {
+        tot += cands.at(icand);
+      }
+      vpt_ = tot.pt();
+    }
+    if ((ptMax_ < 0. || vpt_ <= ptMax_) && vpt_ > ptMin_) {
+      return true;
+    } else {
+      return false;
+    }
   }
-  if ((ptMax_ < 0. || vpt_ <= ptMax_) && vpt_ > ptMin_) {
-    return true;
-  } else {
-    return false;
-  }
+}
+
+void LHEPtFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<bool>("isScalar", false);  // default is false
 }
 
 //define this as a plug-in

--- a/GeneratorInterface/GenFilters/src/LHEPtFilter.cc
+++ b/GeneratorInterface/GenFilters/src/LHEPtFilter.cc
@@ -123,6 +123,7 @@ bool LHEPtFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetu
 void LHEPtFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<bool>("isScalar", false);  // default is false
+  descriptions.addDefault(desc);
 }
 
 //define this as a plug-in


### PR DESCRIPTION
#### PR description:
Backport of #48250. The only difference is that the filter resides in the `GeneratorInterface/GenFilters/src` directory to preserve the structure in this release.

#### PR validation:

Validated through adding the filter to a MCM test script and checking the results are as expected.

The validation is presented here: https://indico.cern.ch/event/1563348/#10-new-features-in-lheptfilter

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is a backport of #48250, and it is needed for generation Run 2 UL samples.

@hatakeyamak 
