### PR TITLE
Handle multi-file ALCA switch to RNTUPLE

### DIFF
--- a/Configuration/PyReleaseValidation/python/WorkFlowRunner.py
+++ b/Configuration/PyReleaseValidation/python/WorkFlowRunner.py
@@ -220,6 +220,10 @@ class WorkFlowRunner(Thread):
                             m = re.search(expression, cmd)
                             if m:
                                 cmd = re.sub(expression,r'--filein file:\1.rntpl',cmd)
+                            expression = '--filein\s+file:([a-zA-Z0-9_]+)*\.[a-z]+, *file:([a-zA-Z0-9_]+)*\.[a-z]+'
+                            m = re.search(expression, cmd)
+                            if m:
+                                cmd = re.sub(expression,r'--filein file:\1.rntpl,file:\2.rntpl',cmd)
                     if not '--fileout' in com:
                         cmd+=' --fileout file:step%s%s '%(istep,extension)
                         if "RECO" in cmd:


### PR DESCRIPTION
#### PR description:

One workflow uses two files in the `--filein` command line. This change handles that case when replacing `.root` with `.rntpl`.

#### PR validation:

Ran on the failing workflow. The file extensions are properly changed. The workflow still fails, for now, because RNTupleSource does not presently support reading more than one file. When that changes this PR will allow this workflow to run properly.

resolves https://github.com/cms-sw/framework-team/issues/1422