### PR TITLE
Further 2025 MC GT update towards Spring25MC in autoCond

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -104,7 +104,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2025
     'phase1_2025_design'           :    '150X_mcRun3_2025_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2025
-    'phase1_2025_realistic'        :    '150X_mcRun3_2025_realistic_v3',
+    'phase1_2025_realistic'        :    '150X_mcRun3_2025_realistic_v7',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2025, Strip tracker in DECO mode
     'phase1_2025_cosmics'          :    '150X_mcRun3_2025cosmics_realistic_deco_v2',
     # GlobalTag for MC production with realistic conditions for Phase2


### PR DESCRIPTION
#### PR description:

The GT for 2025 pp MC in autoCond is updated to [150X_mcRun3_2025_realistic_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/150X_mcRun3_2025_realistic_v7) from previous _v3.

The difference between those two GTs can be inspected [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/150X_mcRun3_2025_realistic_v7/150X_mcRun3_2025_realistic_v3).

In particular, what was updated in the GT is the following:
- updated PF calibration and JCorr as in [cmsTalk](https://cms-talk.web.cern.ch/t/call-for-conditions-for-the-spring25-mc-global-tag/119464/8)
- ECAL tags for Spring25MC (ECAL ChannelStatus, TPGCrystal/Strip/TowerStatus, TPGFineGrainStripEE, TPGSpike from [cmsTalk](https://cms-talk.web.cern.ch/t/call-for-conditions-for-the-spring25-mc-global-tag/119464/9); EcalLaserAPDPNRatios, EcalPedestals, EcalTPGLinearizationConst, EcalTPGPedestals from [cmsTalk](https://cms-talk.web.cern.ch/t/call-for-conditions-for-the-spring25-mc-global-tag/119464/12)
-  L1TCaloParams [cmsTalk](https://cms-talk.web.cern.ch/t/call-for-conditions-for-the-spring25-mc-global-tag/119464/19)
-  SiPixel tags [cmsTalk](https://cms-talk.web.cern.ch/t/call-for-conditions-for-the-spring25-mc-global-tag/119464/20)
- Tracker Alignment [cmsTalk](https://cms-talk.web.cern.ch/t/call-for-conditions-for-the-spring25-mc-global-tag/119464/22)
-  CSC bad chambers as from 2025 [cmsTalk](https://cms-talk.web.cern.ch/t/call-for-conditions-for-the-spring25-mc-global-tag/119464/21),

#### PR validation:

2025 MC workflows in the short matrix were run succesfully:
```
runTheMatrix.py -l 16834,17034
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

It will be backported to CMSSW_15_0_X

<!-- Please delete the text above after you verified all points of the checklist  -->
