### PR TITLE
add phase-2 NANO HLT workflows to `ph2_hlt` short matrix

### DIFF
--- a/Configuration/PyReleaseValidation/README.md
+++ b/Configuration/PyReleaseValidation/README.md
@@ -63,7 +63,9 @@ The offsets currently in use are:
 * 0.7561 HLT phase-2 timing menu Alpaka, trimmed tracking
 * 0.7562 HLT phase-2 timing menu Alpaka, trimmed tracking, single tracking iteration variant
 * 0.757: HLT phase-2 timing menu Alpaka, single tracking iteration, LST seeding + CKF building variant
+* 0.759: HLT phase-2 timing menu, with NANO:@Phase2HLT
 * 0.77: HLT phase-2 NGT Scouting menu
+* 0.771: HLT phase-2 NGT Scouting menu, with NANO:@NGTScouting
 * 0.777 New Phase 2 Standalone Muon seeding, streamlined L3 Tracker Muons reconstruction (Inside-Out first), HLT Muon NanoAOD
 * 0.778 New Phase 2 Standalone Muon seeding, streamlined L3 Tracker Muons reconstruction (Outside-In first), HLT Muon NanoAOD
 * 0.78: Complete L1 workflow

--- a/Configuration/PyReleaseValidation/python/relval_Run4.py
+++ b/Configuration/PyReleaseValidation/python/relval_Run4.py
@@ -67,6 +67,7 @@ numWFIB.extend([prefixDet+234.703])  #LST tracking on CPU (initialStep+HighPtTri
 #
 numWFIB.extend([24834.911]) #D98 XML, to monitor instability of DD4hep
 
+# Phase-2 HLT tests
 numWFIB.extend([prefixDet+34.751]) # HLTTiming75e33, alpaka
 numWFIB.extend([prefixDet+34.752]) # HLTTiming75e33, ticl_v5
 numWFIB.extend([prefixDet+34.753]) # HLTTiming75e33, alpaka,singleIterPatatrack
@@ -76,7 +77,9 @@ numWFIB.extend([prefixDet+34.756]) # HLTTiming75e33, phase2_hlt_vertexTrimming
 numWFIB.extend([prefixDet+34.7561])# HLTTiming75e33, alpaka,phase2_hlt_vertexTrimming
 numWFIB.extend([prefixDet+34.7562])# HLTTiming75e33, alpaka,phase2_hlt_vertexTrimming,singleIterPatatrack
 numWFIB.extend([prefixDet+34.757]) # HLTTiming75e33, alpaka,singleIterPatatrack,trackingLST,seedingLST
+numWFIB.extend([prefixDet+34.759]) # HLTTiming75e33 + NANO
 numWFIB.extend([prefixDet+34.77])  # NGTScouting
+numWFIB.extend([prefixDet+34.771]) # NGTScouting + NANO
 
 for numWF in numWFIB:
     workflows[numWF] = _upgrade_workflows[numWF]

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -160,11 +160,11 @@ if __name__ == '__main__':
                      29634.755,   # HLT phase-2 timing menu Alpaka, LST building variant
                      29634.756,   # HLT phase-2 timing menu trimmed tracking
                      29634.7561,  # HLT phase-2 timing menu Alpaka, trimmed tracking
-                     29634.7562   # HLT phase-2 timing menu Alpaka, trimmed tracking, single tracking iteration variant
-                     29834.759    # HLT phase-2 timing menu Alpaka, single tracking iteration, LST seeding + CKF building variant
+                     29634.7562,  # HLT phase-2 timing menu Alpaka, trimmed tracking, single tracking iteration variant
+                     29634.759,   # HLT phase-2 timing menu Alpaka, single tracking iteration, LST seeding + CKF building variant
                      29634.757,   # HLT phase-2 timing menu, with NANO:@Phase2HLT
                      29634.77,    # HLT phase-2 NGT Scouting menu
-                     29834.771]   # HLT phase-2 NGT Scouting menu, with NANO:@NGTScouting
+                     29634.771]   # HLT phase-2 NGT Scouting menu, with NANO:@NGTScouting
     }
 
     predefinedSet['limited'] = (

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -152,7 +152,19 @@ if __name__ == '__main__':
         'metmc' : [5.1, 15, 25, 37, 38, 39], #MC
         'muonmc' : [5.1, 124.4, 124.5, 20, 21, 22, 23, 25, 30], #MC
 
-        'ph2_hlt' : [29634.75, 29634.751, 29634.752, 29634.753, 29634.754, 29634.755, 29634.756, 29634.7561, 29634.7562, 29634.757, 29634.77]
+        'ph2_hlt' : [29634.75,    # HLT phase-2 timing menu
+                     29634.751,   # HLT phase-2 timing menu Alpaka variant
+                     29634.752,   # HLT phase-2 timing menu ticl_v5 variant
+                     29634.753,   # HLT phase-2 timing menu Alpaka, single tracking iteration variant
+                     29634.754,   # HLT phase-2 timing menu Alpaka, single tracking iteration, LST building variant
+                     29634.755,   # HLT phase-2 timing menu Alpaka, LST building variant
+                     29634.756,   # HLT phase-2 timing menu trimmed tracking
+                     29634.7561,  # HLT phase-2 timing menu Alpaka, trimmed tracking
+                     29634.7562   # HLT phase-2 timing menu Alpaka, trimmed tracking, single tracking iteration variant
+                     29834.759    # HLT phase-2 timing menu Alpaka, single tracking iteration, LST seeding + CKF building variant
+                     29634.757,   # HLT phase-2 timing menu, with NANO:@Phase2HLT
+                     29634.77,    # HLT phase-2 NGT Scouting menu
+                     29834.771]   # HLT phase-2 NGT Scouting menu, with NANO:@NGTScouting
     }
 
     predefinedSet['limited'] = (


### PR DESCRIPTION
#### PR description:

Title says it all, it's a follow-up to PRs https://github.com/cms-sw/cmssw/pull/48091 and https://github.com/cms-sw/cmssw/pull/48076/.
Add the workflows added in https://github.com/cms-sw/cmssw/pull/48091 to the `ph2_hlt` short matrix and exercise them in IBs.

#### PR validation:

`runTheMatrix.py -l ph2_hlt` runs.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A

@elenavernazza FYI