### PR TITLE
Reduce LogError noise when using (E)EoR3 CPE conditions

### DIFF
--- a/CondFormats/SiPixelTransient/src/SiPixelTemplate.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelTemplate.cc
@@ -107,15 +107,16 @@
 #include "FWCore/Utilities/interface/FileInPath.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/isFinite.h"
+#define LOGDEBUG(x) LogDebug(x)
 #define LOGERROR(x) LogError(x)
 #define LOGINFO(x) LogInfo(x)
-#define LOGWARNING(x) LogWarning(x)
 #define ENDL " "
 #include "FWCore/Utilities/interface/Exception.h"
 using namespace edm;
 #else
 #include "SiPixelTemplate.h"
 #include "SimplePixel.h"
+#define LOGDEBUG(x) std::cout << x << ": "
 #define LOGERROR(x) std::cout << x << ": "
 #define LOGINFO(x) std::cout << x << ": "
 #define ENDL std::endl
@@ -2180,7 +2181,7 @@ void SiPixelTemplate::ysigma2(int fypix, int lypix, float sythr, float ysum[25],
         ysig2[i] = 1.e8;
       }
       if (ysig2[i] <= 0.f) {
-        LOGERROR("SiPixelTemplate") << "neg y-error-squared, id = " << id_current_ << ", index = " << index_id_
+        LOGDEBUG("SiPixelTemplate") << "neg y-error-squared, id = " << id_current_ << ", index = " << index_id_
                                     << ", cot(alpha) = " << cota_current_ << ", cot(beta) = " << cotb_current_
                                     << ", sigi = " << sigi << ENDL;
       }
@@ -2253,7 +2254,7 @@ void SiPixelTemplate::ysigma2(float qpixel, int index, float& ysig2)
   }
   ysig2 = qscale * err2;
   if (ysig2 <= 0.f) {
-    LOGERROR("SiPixelTemplate") << "neg y-error-squared, id = " << id_current_ << ", index = " << index_id_
+    LOGDEBUG("SiPixelTemplate") << "neg y-error-squared, id = " << id_current_ << ", index = " << index_id_
                                 << ", cot(alpha) = " << cota_current_ << ", cot(beta) = " << cotb_current_
                                 << ", sigi = " << sigi << ENDL;
   }
@@ -2373,7 +2374,7 @@ void SiPixelTemplate::xsigma2(int fxpix, int lxpix, float sxthr, float xsum[BXSI
         xsig2[i] = 1.e8;
       }
       if (xsig2[i] <= 0.f) {
-        LOGERROR("SiPixelTemplate") << "neg x-error-squared, id = " << id_current_ << ", index = " << index_id_
+        LOGDEBUG("SiPixelTemplate") << "neg x-error-squared, id = " << id_current_ << ", index = " << index_id_
                                     << ", cot(alpha) = " << cota_current_ << ", cot(beta) = " << cotb_current_
                                     << ", sigi = " << sigi << ENDL;
       }
@@ -4065,7 +4066,7 @@ void SiPixelTemplate::vavilov_pars(double& mpv, double& sigma, double& kappa)
 
   //Avoid rounding difference between floats and doubles causing issues later
   if (kappavav_ <= 0.01f) {
-    LOGERROR("SiPixelTemplate") << "Vavilov kappa value is " << kappavav_ << " changing it to be above 0.01" << ENDL;
+    LOGDEBUG("SiPixelTemplate") << "Vavilov kappa value is " << kappavav_ << " changing it to be above 0.01" << ENDL;
     kappavav_ = 0.01f + 0.0000001f;
   }
 

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco.cc
@@ -802,7 +802,7 @@ int SiPixelTemplateReco::PixelTempReco1D(int id,
         }
         rat = ssa / ss2;
         if (rat <= 0.f) {
-          LOGERROR("SiPixelTemplateReco") << "illegal chi2ymin normalization (1) = " << rat << ENDL;
+          LOGDEBUG("SiPixelTemplateReco") << "illegal chi2ymin normalization (1) = " << rat << ENDL;
           rat = 1.;
         }
         chi2ybin[j] = ss2 - 2.f * ssa / rat + sa2 / (rat * rat);
@@ -923,7 +923,7 @@ int SiPixelTemplateReco::PixelTempReco1D(int id,
     // Do goodness of fit test in y
 
     if (rnorm <= 0.) {
-      LOGERROR("SiPixelTemplateReco") << "illegal chi2y normalization (2) = " << rnorm << ENDL;
+      LOGDEBUG("SiPixelTemplateReco") << "illegal chi2y normalization (2) = " << rnorm << ENDL;
       rnorm = 1.;
     }
     chi2y = ss2 - 2. / rnorm * ssa - 2. / rnorm * rat * ssba +
@@ -1016,7 +1016,7 @@ int SiPixelTemplateReco::PixelTempReco1D(int id,
         //			 std::cout << std::endl;
         rat = ssa / ss2;
         if (rat <= 0.f) {
-          LOGERROR("SiPixelTemplateReco") << "illegal chi2xmin normalization (1) = " << rat << ENDL;
+          LOGDEBUG("SiPixelTemplateReco") << "illegal chi2xmin normalization (1) = " << rat << ENDL;
           rat = 1.;
         }
         chi2xbin[j] = ss2 - 2.f * ssa / rat + sa2 / (rat * rat);
@@ -1135,7 +1135,7 @@ int SiPixelTemplateReco::PixelTempReco1D(int id,
     // Do goodness of fit test in x
 
     if (rnorm <= 0.) {
-      LOGERROR("SiPixelTemplateReco") << "illegal chi2x normalization (2) = " << rnorm << ENDL;
+      LOGDEBUG("SiPixelTemplateReco") << "illegal chi2x normalization (2) = " << rnorm << ENDL;
       rnorm = 1.;
     }
     chi2x = ss2 - 2. / rnorm * ssa - 2. / rnorm * rat * ssba +


### PR DESCRIPTION
#### PR description:

This PR addressed the issue reported in https://github.com/cms-sw/cmssw/issues/47857

#### PR validation:

The code compiles and has been tested with a private cmsRun job that was producing a storm of LogErrors. No change in physics performance expected.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport to CMSSW_15_0_X
