### PR TITLE
Remove const_cast from DaqProvenanceHelper

### DIFF
--- a/DataFormats/Provenance/interface/BranchChildren.h
+++ b/DataFormats/Provenance/interface/BranchChildren.h
@@ -43,6 +43,8 @@ namespace edm {
     // const accessor for the data
     map_t const& childLookup() const { return childLookup_; }
 
+    map_t& mutableChildLookup() { return childLookup_; }
+
   private:
     map_t childLookup_;
 

--- a/FWCore/Sources/interface/DaqProvenanceHelper.h
+++ b/FWCore/Sources/interface/DaqProvenanceHelper.h
@@ -42,7 +42,7 @@ namespace edm {
     bool matchProcesses(ProcessConfiguration const& pc, ProcessHistory const& ph) const;
     void fixMetaData(ProcessConfigurationVector& pcv, std::vector<ProcessHistory>& phv);
     void fixMetaData(std::vector<BranchID>& branchIDs) const;
-    void fixMetaData(BranchIDLists const&) const;
+    void fixMetaData(BranchIDLists&) const;
     void fixMetaData(ProductDependencies& productDependencies) const;
     ProcessHistoryID const& mapProcessHistoryID(ProcessHistoryID const& phid);
     ParentageID const& mapParentageID(ParentageID const& phid) const;

--- a/FWCore/Sources/src/DaqProvenanceHelper.cc
+++ b/FWCore/Sources/src/DaqProvenanceHelper.cc
@@ -161,20 +161,17 @@ namespace edm {
     std::replace(branchID.begin(), branchID.end(), oldBranchID_, newBranchID_);
   }
 
-  void DaqProvenanceHelper::fixMetaData(BranchIDLists const& branchIDLists) const {
+  void DaqProvenanceHelper::fixMetaData(BranchIDLists& branchIDLists) const {
     BranchID::value_type oldID = oldBranchID_.id();
     BranchID::value_type newID = newBranchID_.id();
-    // The const_cast is ugly, but it beats the alternatives.
-    BranchIDLists& lists = const_cast<BranchIDLists&>(branchIDLists);
-    for (auto& list : lists) {
+    for (auto& list : branchIDLists) {
       std::replace(list.begin(), list.end(), oldID, newID);
     }
   }
 
   void DaqProvenanceHelper::fixMetaData(ProductDependencies& productDependencies) const {
     typedef std::map<BranchID, std::set<BranchID> > BCMap;
-    // The const_cast is ugly, but it beats the alternatives.
-    BCMap& childLookup = const_cast<BCMap&>(productDependencies.childLookup());
+    BCMap& childLookup = productDependencies.mutableChildLookup();
     // First fix any old branchID's in the key.
     {
       BCMap::iterator i = childLookup.find(oldBranchID_);

--- a/IOPool/Input/src/ProvenanceAdaptor.cc
+++ b/IOPool/Input/src/ProvenanceAdaptor.cc
@@ -92,7 +92,7 @@ namespace edm {
 
     void fillListsAndIndexes(ProductRegistry& productRegistry,
                              ProcessHistoryMap const& pHistMap,
-                             std::shared_ptr<BranchIDLists const>& branchIDLists,
+                             std::shared_ptr<BranchIDLists>& branchIDLists,
                              std::vector<BranchListIndex>& branchListIndexes) {
       OrderedProducts orderedProducts;
       std::set<std::string> processNamesThatProduced;
@@ -182,7 +182,11 @@ namespace edm {
     return it->second;
   }
 
-  std::shared_ptr<BranchIDLists const> ProvenanceAdaptor::branchIDLists() const { return branchIDLists_; }
+  std::shared_ptr<BranchIDLists> ProvenanceAdaptor::releaseBranchIDLists() {
+    auto ptr = branchIDLists_;
+    branchIDLists_.reset();
+    return ptr;
+  }
 
   void ProvenanceAdaptor::branchListIndexes(BranchListIndexes& indexes) const { indexes = branchListIndexes_; }
 }  // namespace edm

--- a/IOPool/Input/src/ProvenanceAdaptor.h
+++ b/IOPool/Input/src/ProvenanceAdaptor.h
@@ -38,7 +38,7 @@ namespace edm {
     ProvenanceAdaptor(ProvenanceAdaptor const&) = delete;             // Disallow copying and moving
     ProvenanceAdaptor& operator=(ProvenanceAdaptor const&) = delete;  // Disallow copying and moving
 
-    std::shared_ptr<BranchIDLists const> branchIDLists() const;
+    std::shared_ptr<BranchIDLists> releaseBranchIDLists();
 
     void branchListIndexes(BranchListIndexes& indexes) const;
 
@@ -51,7 +51,7 @@ namespace edm {
 
     ParameterSetIdConverter parameterSetIdConverter_;
     ProcessHistoryIdConverter processHistoryIdConverter_;
-    std::shared_ptr<BranchIDLists const> branchIDLists_;
+    std::shared_ptr<BranchIDLists> branchIDLists_;
     std::vector<BranchListIndex> branchListIndexes_;
   };  // class ProvenanceAdaptor
 }  // namespace edm


### PR DESCRIPTION
#### PR description:

A simple refactoring of the code avoids the need for the cast.

#### PR validation:

Code compiles.

resolves https://github.com/cms-sw/framework-team/issues/1424