### PR TITLE
Further 2025 MC GT update towards Spring25MC in autoCond - [CMSSW_15_0_X]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -104,7 +104,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2025
     'phase1_2025_design'           :    '150X_mcRun3_2025_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2025
-    'phase1_2025_realistic'        :    '150X_mcRun3_2025_realistic_v2',
+    'phase1_2025_realistic'        :    '150X_mcRun3_2025_realistic_v7',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2025, Strip tracker in DECO mode
     'phase1_2025_cosmics'          :    '150X_mcRun3_2025cosmics_realistic_deco_v2',
     # GlobalTag for MC production with realistic conditions for Phase2


### PR DESCRIPTION
#### PR description:

The GT for 2025 pp MC in autoCond is updated to [150X_mcRun3_2025_realistic_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/150X_mcRun3_2025_realistic_v7) from previous _v2.

The difference between those two GTs can be inspected [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/150X_mcRun3_2025_realistic_v7/150X_mcRun3_2025_realistic_v2).

In particular, what was updated in the GT is the following:
- new 2025 reco and sim geometry for GEM, see [cmsTalk](https://cms-talk.web.cern.ch/t/call-for-conditions-for-the-spring25-mc-global-tag/119464/6) for the details on the reco geometry tags: the sim geometry updates were provided by Sunanda Banerjee. Further infos in [this talk](https://indico.cern.ch/event/1504123/#3-muon-geometry-status), presented at the AlCaDB meeting of 31/03/2025.
- updated PF calibration and JCorr as in [cmsTalk](https://cms-talk.web.cern.ch/t/call-for-conditions-for-the-spring25-mc-global-tag/119464/8)
- ECAL tags for Spring25MC (ECAL ChannelStatus, TPGCrystal/Strip/TowerStatus, TPGFineGrainStripEE, TPGSpike from [cmsTalk](https://cms-talk.web.cern.ch/t/call-for-conditions-for-the-spring25-mc-global-tag/119464/9); EcalLaserAPDPNRatios, EcalPedestals, EcalTPGLinearizationConst, EcalTPGPedestals from [cmsTalk](https://cms-talk.web.cern.ch/t/call-for-conditions-for-the-spring25-mc-global-tag/119464/12)
-  L1TCaloParams [cmsTalk](https://cms-talk.web.cern.ch/t/call-for-conditions-for-the-spring25-mc-global-tag/119464/19)
-  SiPixel tags [cmsTalk](https://cms-talk.web.cern.ch/t/call-for-conditions-for-the-spring25-mc-global-tag/119464/20)
- Tracker Alignment [cmsTalk](https://cms-talk.web.cern.ch/t/call-for-conditions-for-the-spring25-mc-global-tag/119464/22)
-  CSC bad chambers as from 2025 [cmsTalk](https://cms-talk.web.cern.ch/t/call-for-conditions-for-the-spring25-mc-global-tag/119464/21),

#### PR validation:

It does not crash in 15_1_X IB tests (though PdmV sees some issue with larger scale tests made in CMSSW_15_1_0_pre3, which must be probably taken into account when a decision must be taken for the merging of this backport PR)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Bacport of  #48066 and #48261
