### PR TITLE
[15_0_X] Add spike killer monitoring plots for ECAL DQM

### DIFF
--- a/DQM/EcalMonitorTasks/interface/TrigPrimTask.h
+++ b/DQM/EcalMonitorTasks/interface/TrigPrimTask.h
@@ -16,6 +16,9 @@
 #include "CondFormats/DataRecord/interface/EcalTPGTowerStatusRcd.h"
 #include "CondFormats/DataRecord/interface/EcalTPGStripStatusRcd.h"
 
+#include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgo.h"
+#include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgoRcd.h"
+
 namespace ecaldqm {
 
   class TrigPrimTask : public DQWorkerTask {
@@ -34,10 +37,13 @@ namespace ecaldqm {
     void runOnEmulTPs(EcalTrigPrimDigiCollection const&);
     template <typename DigiCollection>
     void runOnDigis(DigiCollection const&);
-
+    void runOnRecHits(EcalRecHitCollection const&, Collections); 
+    
     void setTokens(edm::ConsumesCollector&) override;
 
     enum Constants { nBXBins = 15 };
+
+    void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
   private:
     void setParams(edm::ParameterSet const&) override;
@@ -56,6 +62,9 @@ namespace ecaldqm {
     double bxBin_;
     double bxBinFine_;
 
+    double etSum_;
+    double etSpikeMatchSum_;
+
     std::map<uint32_t, unsigned> towerReadouts_;
 
     edm::ESGetToken<EcalTPGTowerStatus, EcalTPGTowerStatusRcd> TTStatusRcd_;
@@ -65,10 +74,21 @@ namespace ecaldqm {
 
     edm::InputTag lhcStatusInfoCollectionTag_;
     edm::EDGetTokenT<TCDSRecord> lhcStatusInfoRecordToken_;
+  
+    std::map<EcalTrigTowerDetId, float> mapTowerMaxRecHitEnergy_;
+    std::map<EcalTrigTowerDetId, int> mapTowerOfflineSpikes_;
+    edm::ESGetToken<EcalSeverityLevelAlgo, EcalSeverityLevelAlgoRcd> severityToken_;
+    const EcalSeverityLevelAlgo* sevLevel;
   };
 
   inline bool TrigPrimTask::analyze(void const* _p, Collections _collection) {
     switch (_collection) {
+      case kEBRecHit:
+      case kEERecHit:
+        if (_p)
+          runOnRecHits(*static_cast<EcalRecHitCollection const*>(_p), _collection);
+        return true;
+        break;
       case kTrigPrimDigi:
         if (_p)
           runOnRealTPs(*static_cast<EcalTrigPrimDigiCollection const*>(_p));
@@ -89,7 +109,7 @@ namespace ecaldqm {
           runOnDigis(*static_cast<EEDigiCollection const*>(_p));
         return true;
         break;
-      default:
+     default:
         break;
     }
     return false;

--- a/DQM/EcalMonitorTasks/python/TrigPrimTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/TrigPrimTask_cfi.py
@@ -213,6 +213,13 @@ ecalTrigPrimTask = cms.untracked.PSet(
             btype = cms.untracked.string('TriggerTower'),
             description = cms.untracked.string('')
         ),
+        TTSpikeOffline = cms.untracked.PSet(
+            path = cms.untracked.string('%(subdet)s/%(prefix)sSelectiveReadoutTask/%(prefix)sSRT TT LUT for Offline Spikes%(suffix)s'),
+            kind = cms.untracked.string('TH2F'),
+            otype = cms.untracked.string('Ecal3P'),
+            btype = cms.untracked.string('TriggerTower'),
+            description = cms.untracked.string('')
+        ),
         EtSummary = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sSummaryClient/%(prefix)sTTT%(suffix)s Et trigger tower summary'),
             kind = cms.untracked.string('TProfile2D'),
@@ -257,13 +264,65 @@ ecalTrigPrimTask = cms.untracked.PSet(
             kind = cms.untracked.string('TH1F'),
             otype = cms.untracked.string('Ecal3P'),
             xaxis = cms.untracked.PSet(
-                high = cms.untracked.double(256.0),
+                high = cms.untracked.double(128.0),
                 nbins = cms.untracked.int32(128),
                 low = cms.untracked.double(0.0),
-                title = cms.untracked.string('TP Et')
+                title = cms.untracked.string('Et threshold (GeV)')
             ),
             btype = cms.untracked.string('User'),
             description = cms.untracked.string('Distribution of the trigger primitive Et.')
+        ),
+        EtRealSpikeMatched = cms.untracked.PSet(
+            path = cms.untracked.string('%(subdet)s/%(prefix)sTriggerTowerTask/%(prefix)sTTT Et spectrum Real Digis matched to spikes %(suffix)s'),
+            kind = cms.untracked.string('TH1F'),
+            otype = cms.untracked.string('Ecal3P'),
+            xaxis = cms.untracked.PSet(
+                high = cms.untracked.double(128.0),
+                nbins = cms.untracked.int32(128),
+                low = cms.untracked.double(0.0),
+                title = cms.untracked.string('Et threshold (GeV)')
+            ),
+            btype = cms.untracked.string('User'),
+            description = cms.untracked.string('Distribution of the trigger primitive Et. for TT matched to spikes')
+        ),
+        EffSpikeMatch = cms.untracked.PSet(
+            path = cms.untracked.string('%(subdet)s/%(prefix)sTriggerTowerTask/%(prefix)sTTT Efficiency of spike killer matching%(suffix)s'),
+            kind = cms.untracked.string('TH1F'),
+            otype = cms.untracked.string('Ecal3P'),
+            xaxis = cms.untracked.PSet(
+                high = cms.untracked.double(128.0),
+                nbins = cms.untracked.int32(128),
+                low = cms.untracked.double(0.0),
+                title = cms.untracked.string('Et threshold (GeV)')
+            ),
+            btype = cms.untracked.string('User'),
+            description = cms.untracked.string('Efficiency of spike killer matching')
+        ), 
+        EtRealIntVsThres = cms.untracked.PSet(
+            path = cms.untracked.string('%(subdet)s/%(prefix)sTriggerTowerTask/%(prefix)sTTT Rate of TP with Et above threshold vs Et threshold%(suffix)s'),
+            kind = cms.untracked.string('TH1F'),
+            otype = cms.untracked.string('Ecal3P'),
+            xaxis = cms.untracked.PSet(
+                high = cms.untracked.double(128.0),
+                nbins = cms.untracked.int32(128),
+                low = cms.untracked.double(0.0),
+                title = cms.untracked.string('Et threshold (GeV)'),
+            ),
+            btype = cms.untracked.string('User'),
+            description = cms.untracked.string('Rate (TP Et > threshold)')
+        ),
+        EtRealSpikeMatchedIntVsThres = cms.untracked.PSet(
+            path = cms.untracked.string('%(subdet)s/%(prefix)sTriggerTowerTask/%(prefix)sTTT Rate of TP with Et above threshold (spike matched) vs Et threshold%(suffix)s'),
+            kind = cms.untracked.string('TH1F'),
+            otype = cms.untracked.string('Ecal3P'),
+            xaxis = cms.untracked.PSet(
+                high = cms.untracked.double(128.0),
+                nbins = cms.untracked.int32(128),
+                low = cms.untracked.double(0.0),
+                title = cms.untracked.string('Et threshold (GeV)'),
+            ),
+            btype = cms.untracked.string('User'),
+            description = cms.untracked.string('Rate (TP Et > threshold) for spike matched')
         ),
         RealvEmulEt = cms.untracked.PSet(
             kind = cms.untracked.string('TH2F'),
@@ -283,6 +342,20 @@ ecalTrigPrimTask = cms.untracked.PSet(
             btype = cms.untracked.string('User'),
             path = cms.untracked.string('%(subdet)s/%(prefix)sTriggerTowerTask/%(prefix)sTTT Real vs Emulated TP Et%(suffix)s'),
             description = cms.untracked.string('Real data VS emulated TP Et (in-time)')
+        ),
+        TrendEtSum = cms.untracked.PSet(
+            path = cms.untracked.string('Ecal/Trends/TriggerTowerTask Et sum of TPs above threshold'),
+            kind = cms.untracked.string('TProfile'),
+            otype = cms.untracked.string('Ecal2P'),
+            btype = cms.untracked.string('Trend'),
+            description = cms.untracked.string('Trend of Et sum of TPs with Et > 30 GeV.')
+        ),
+        TrendEtSpikeMatchSum = cms.untracked.PSet(
+            path = cms.untracked.string('Ecal/Trends/TriggerTowerTask Et sum of TPs above threshold (Spike Matched)'),
+            kind = cms.untracked.string('TProfile'),
+            otype = cms.untracked.string('Ecal2P'),
+            btype = cms.untracked.string('Trend'),
+            description = cms.untracked.string('Trend of Et sum of TPs (spike-matched) with Et > 30 GeV.')
         ),
         LHCStatusByLumi = cms.untracked.PSet(
             path = cms.untracked.string('Ecal/Trends/LHC status by lumi'),

--- a/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
+++ b/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
@@ -35,6 +35,7 @@ namespace ecaldqm {
       MEs_.erase(std::string("FGEmulError"));
       MEs_.erase(std::string("RealvEmulEt"));
     }
+
     lhcStatusInfoCollectionTag_ = _params.getUntrackedParameter<edm::InputTag>(
         "lhcStatusInfoCollectionTag", edm::InputTag("tcdsDigis", "tcdsRecord"));
     bxBinEdges_ = _params.getUntrackedParameter<std::vector<int> >("bxBins");
@@ -61,12 +62,14 @@ namespace ecaldqm {
     using namespace std;
 
     towerReadouts_.clear();
+    mapTowerOfflineSpikes_.clear();
+    mapTowerMaxRecHitEnergy_.clear();
 
     if (ByLumiResetSwitch) {
       MEs_.at("EtSummaryByLumi").reset(GetElectronicsMap());
       MEs_.at("TTFlags4ByLumi").reset(GetElectronicsMap());
-      MEs_.at("LHCStatusByLumi").reset(GetElectronicsMap(), -1);
-    }
+      MEs_.at("LHCStatusByLumi").reset(GetElectronicsMap(), -1);      
+   }
 
     if (!lhcStatusSet) {
       // Update LHC status once each LS
@@ -111,6 +114,8 @@ namespace ecaldqm {
         meTTMaskMap.fill(getEcalDQMSetupObjects(), stid, 1);
       }  //masked
     }  //loop on pseudo-strips
+
+    sevLevel = &_es.getData(severityToken_);
 
     //     if(HLTCaloPath_.size() || HLTMuonPath_.size()){
     //       edm::TriggerResultsByName results(_evt.triggerResultsByName("HLT"));
@@ -180,11 +185,16 @@ namespace ecaldqm {
     lhcStatusInfoRecordToken_ = _collector.consumes<TCDSRecord>(lhcStatusInfoCollectionTag_);
     TTStatusRcd_ = _collector.esConsumes<edm::Transition::BeginRun>();
     StripStatusRcd_ = _collector.esConsumes<edm::Transition::BeginRun>();
+    severityToken_ = _collector.esConsumes();
   }
 
   void TrigPrimTask::runOnRealTPs(EcalTrigPrimDigiCollection const& _tps) {
     MESet& meEtVsBx(MEs_.at("EtVsBx"));
     MESet& meEtReal(MEs_.at("EtReal"));
+    MESet& meEtRealIntVsThres(MEs_.at("EtRealIntVsThres"));
+    MESet& meEtRealSpikeMatched(MEs_.at("EtRealSpikeMatched"));
+    MESet& meEtRealSpikeMatchedIntVsThres(MEs_.at("EtRealSpikeMatchedIntVsThres"));
+    MESet& meEffSpikeMatch(MEs_.at("EffSpikeMatch"));
     MESet& meEtRealMap(MEs_.at("EtRealMap"));
     MESet& meEtSummary(MEs_.at("EtSummary"));
     MESet& meEtSummaryByLumi(MEs_.at("EtSummaryByLumi"));
@@ -220,6 +230,15 @@ namespace ecaldqm {
       meEtRealMap.fill(getEcalDQMSetupObjects(), ttid, et);
       meEtSummary.fill(getEcalDQMSetupObjects(), ttid, et);
       meEtSummaryByLumi.fill(getEcalDQMSetupObjects(), ttid, et);
+
+      if (et > 30) etSum_ += et;
+      
+      if (ttid.subDet() == EcalBarrel) {
+	if (mapTowerOfflineSpikes_[ttid] == 1) {
+          meEtRealSpikeMatched.fill(getEcalDQMSetupObjects(), ttid, et);
+          if (et > 30) etSpikeMatchSum_ += et;
+        }
+      }
 
       int interest(tpItr->ttFlag() & 0x3);
 
@@ -279,6 +298,21 @@ namespace ecaldqm {
         meTTMaskMapAll.setBinContent(getEcalDQMSetupObjects(), ttid, 1);  // PseudoStrip is masked
     }  // PseudoStrips
 
+    // Integrate Et with Et > thres with threshold scan : FIXME -> more efficienct way?
+    int nThresEtBin = 128;
+    
+    for (int thres=1; thres<=nThresEtBin; thres++) {
+      int nFiltered = 0;
+      int nFilteredSpikeMatched = 0;
+      for (int iBin=thres; iBin<=nThresEtBin; iBin++) {
+	nFiltered += meEtReal.getBinContent(getEcalDQMSetupObjects(), EcalBarrel, iBin);
+        nFilteredSpikeMatched += meEtRealSpikeMatched.getBinContent(getEcalDQMSetupObjects(), EcalBarrel, iBin);
+      }
+      meEtRealIntVsThres.setBinContent(getEcalDQMSetupObjects(), EcalBarrel, thres, nFiltered);
+      meEtRealSpikeMatchedIntVsThres.setBinContent(getEcalDQMSetupObjects(), EcalBarrel, thres, nFilteredSpikeMatched);
+      if (nFiltered != 0)
+        meEffSpikeMatch.setBinContent(getEcalDQMSetupObjects(), EcalBarrel, thres, double(nFilteredSpikeMatched)/nFiltered);
+    }
   }  // TrigPrimTask::runOnRealTPs()
 
   void TrigPrimTask::runOnEmulTPs(EcalTrigPrimDigiCollection const& _tps) {
@@ -376,6 +410,34 @@ namespace ecaldqm {
       if (!matchFG)
         meFGEmulError.fill(getEcalDQMSetupObjects(), ttid);
     }
+  }
+
+  void TrigPrimTask::runOnRecHits(EcalRecHitCollection const& _hits, Collections _collection) {
+    int iSubdet(_collection == kEBRecHit ? EcalBarrel : EcalEndcap);
+    std::for_each(_hits.begin(), _hits.end(), [&](EcalRecHitCollection::value_type const& hit) {
+      DetId id(hit.id());
+
+      bool isEB = iSubdet == EcalBarrel;
+      if (isEB) {
+        EcalTrigTowerDetId ttid = EBDetId(id).tower();
+        if (hit.energy() >= mapTowerMaxRecHitEnergy_[ttid]) {
+          mapTowerMaxRecHitEnergy_[ttid] = hit.energy();
+	  int bitSeverity = sevLevel->severityLevel(EBDetId(id), _hits);
+          mapTowerOfflineSpikes_[ttid] = ((bitSeverity == 3) || (bitSeverity == 4));
+        }
+      } // For spike-killer related plots
+    });
+  }
+
+  void TrigPrimTask::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {
+    MESet& meTrendEtSum(MEs_.at("TrendEtSum"));
+    MESet& meTrendEtSpikeMatchSum(MEs_.at("TrendEtSpikeMatchSum"));
+
+    meTrendEtSum.fill(getEcalDQMSetupObjects(), EcalBarrel, double(timestamp_.iLumi), etSum_);
+    meTrendEtSpikeMatchSum.fill(getEcalDQMSetupObjects(), EcalBarrel, double(timestamp_.iLumi), etSpikeMatchSum_);
+    
+    etSum_ = 0.;
+    etSpikeMatchSum_ = 0.;
   }
 
   DEFINE_ECALDQM_WORKER(TrigPrimTask);


### PR DESCRIPTION
#### PR description:

This PR adds spike-killer monitoring plots to ECAL DQM Layouts.

#### PR validation:

PR is validated by running the ECAL online DQM configuration and verifying the plots on a test DQM GUI.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is the backport to `15_0_X`, which is currently used for production. Master PR is made in #48278.