### PR TITLE
Use constexpr in CondDB query building

### DIFF
--- a/CondCore/CondDB/src/DbCore.h
+++ b/CondCore/CondDB/src/DbCore.h
@@ -46,6 +46,106 @@
 
 // macros for the schema definition
 
+namespace condcore_detail {
+  consteval int string_size(char const* iSize) { return std::string_view(iSize).size(); }
+
+  template <int N, int M>
+  consteval std::array<char, N + M + 2> makeFullName(const char* n, const char* m) {
+    if (std::string_view(n).size() != N) {
+      throw "makeFullName first argument incorrect size";
+    }
+    if (std::string_view(m).size() != M) {
+      throw "makeFullName second argument incorrect size";
+    }
+    std::array<char, N + M + 2> ret = {};
+    for (int i = 0; i < N; ++i) {
+      ret[i] = n[i];
+    }
+    ret[N] = '.';
+    for (int i = 0; i < M; ++i) {
+      ret[i + N + 1] = m[i];
+    }
+    return ret;
+  }
+
+  consteval void test_makeFullName() {
+    constexpr auto v = makeFullName<2, 3>("ab", "cde");
+    static_assert(v.size() == 2 + 3 + 1 + 1);
+    static_assert('a' == v[0]);
+    static_assert('b' == v[1]);
+    static_assert('.' == v[2]);
+    static_assert('c' == v[3]);
+    static_assert('d' == v[4]);
+    static_assert('e' == v[5]);
+    static_assert(0 == v[6]);
+  }
+
+  template <int N>
+  consteval std::array<char, N + 5 + 1> addMin(std::string_view n) {
+    if (n.size() != N) {
+      throw "addMin argument wrong size";
+    }
+    std::array<char, N + 5 + 1> ret = {};
+    ret[0] = 'M';
+    ret[1] = 'I';
+    ret[2] = 'N';
+    ret[3] = '(';
+    for (int i = 0; i < N; ++i) {
+      ret[4 + i] = n[i];
+    }
+    ret[N + 4] = ')';
+    return ret;
+  }
+
+  consteval void test_addMin() {
+    constexpr std::string_view foo("Foo");
+    constexpr auto addMin_ = addMin<3>(foo);
+    static_assert(addMin_.size() == 9);
+    static_assert(addMin_[0] == 'M');
+    static_assert(addMin_[1] == 'I');
+    static_assert(addMin_[2] == 'N');
+    static_assert(addMin_[3] == '(');
+    static_assert(addMin_[4] == 'F');
+    static_assert(addMin_[5] == 'o');
+    static_assert(addMin_[6] == 'o');
+    static_assert(addMin_[7] == ')');
+    static_assert(addMin_[8] == 0);
+  }
+
+  template <int N>
+  consteval std::array<char, N + 5 + 1> addMax(std::string_view n) {
+    if (n.size() != N) {
+      throw "addMax argument wrong size";
+    }
+    std::array<char, N + 5 + 1> ret = {};
+    ret[0] = 'M';
+    ret[1] = 'A';
+    ret[2] = 'X';
+    ret[3] = '(';
+    for (int i = 0; i < N; ++i) {
+      ret[4 + i] = n[i];
+    }
+    ret[N + 4] = ')';
+    return ret;
+  }
+
+  consteval void test_addMax() {
+    constexpr std::string_view foo("Foo");
+    constexpr auto addMin_ = addMax<3>(foo);
+    static_assert(addMin_.size() == 9);
+    static_assert(addMin_[0] == 'M');
+    static_assert(addMin_[1] == 'A');
+    static_assert(addMin_[2] == 'X');
+    static_assert(addMin_[3] == '(');
+    static_assert(addMin_[4] == 'F');
+    static_assert(addMin_[5] == 'o');
+    static_assert(addMin_[6] == 'o');
+    static_assert(addMin_[7] == ')');
+    static_assert(addMin_[8] == 0);
+  }
+
+}  // namespace condcore_detail
+
 // table definition
 #define conddb_table(NAME)                      \
   namespace NAME {                              \
@@ -56,13 +156,16 @@
 // implementation for the column definition:
 
 // case with 3 params
-#define FIXSIZE_COLUMN(NAME, TYPE, SIZE)                                                             \
-  struct NAME {                                                                                      \
-    static constexpr char const* name = #NAME;                                                       \
-    typedef TYPE type;                                                                               \
-    static constexpr size_t size = SIZE;                                                             \
-    static constexpr std::string_view tableName() { return std::string_view(tname); }                \
-    static std::string fullyQualifiedName() { return std::string(tname) + "." + std::string(name); } \
+#define FIXSIZE_COLUMN(NAME, TYPE, SIZE)                                                                              \
+  struct NAME {                                                                                                       \
+    static constexpr char const* name = #NAME;                                                                        \
+    typedef TYPE type;                                                                                                \
+    static constexpr size_t size = SIZE;                                                                              \
+    static constexpr std::string_view tableName() { return std::string_view(tname); }                                 \
+    static constexpr auto fullyQualifiedName_ =                                                                       \
+        condcore_detail::makeFullName<condcore_detail::string_size(tname), condcore_detail::string_size(name)>(tname, \
+                                                                                                               name); \
+    static constexpr std::string_view fullyQualifiedName() { return std::string_view(fullyQualifiedName_.data()); }   \
   };
 
 // case with 2 params
@@ -157,7 +260,7 @@ namespace cond {
       varId << Column::name << "_" << id;
       if (!whereClause.empty())
         whereClause += " AND ";
-      whereClause += Column::fullyQualifiedName() + " " + condition + " :" + varId.str() + " ";
+      whereClause += std::string(Column::fullyQualifiedName()) + " " + condition + " :" + varId.str() + " ";
       //bool init = (id == 0);
       f_add_attribute(data, varId.str(), value);
     }
@@ -429,7 +532,7 @@ namespace cond {
 
       template <typename T>
       typename T::type get() const {
-        return GetFromRow<typename T::type>()(*m_currentRow, T::fullyQualifiedName());
+        return GetFromRow<typename T::type>()(*m_currentRow, std::string(T::fullyQualifiedName()));
       }
 
       auto operator*() -> decltype(std::make_tuple(this->get<Types>()...)) { return std::make_tuple(get<Types>()...); }
@@ -530,7 +633,7 @@ namespace cond {
       template <int n, typename Arg1, typename... Args>
       void _Query() {
         addTable<Arg1>();
-        DefineQueryOutput<typename Arg1::type>::make(*m_coralQuery, Arg1::fullyQualifiedName());
+        DefineQueryOutput<typename Arg1::type>::make(*m_coralQuery, std::string(Arg1::fullyQualifiedName()));
         _Query<n + 1, Args...>();
       }
 

--- a/CondCore/CondDB/src/IOVSchema.h
+++ b/CondCore/CondDB/src/IOVSchema.h
@@ -116,7 +116,7 @@ namespace cond {
       struct SINCE_GROUP {
         typedef cond::Time_t type;
         static constexpr size_t size = 0;
-        static std::string tableName() { return SINCE::tableName(); }
+        static constexpr std::string_view tableName() { return SINCE::tableName(); }
         static std::string fullyQualifiedName() { return "MIN(" + SINCE::fullyQualifiedName() + ")"; }
         static std::string group(unsigned long long groupSize) {
           std::string sgroupSize = std::to_string(groupSize);
@@ -127,21 +127,21 @@ namespace cond {
       struct SEQUENCE_SIZE {
         typedef unsigned int type;
         static constexpr size_t size = 0;
-        static std::string tableName() { return SINCE::tableName(); }
+        static constexpr std::string_view tableName() { return SINCE::tableName(); }
         static std::string fullyQualifiedName() { return "COUNT(*)"; }
       };
 
       struct MIN_SINCE {
         typedef cond::Time_t type;
         static constexpr size_t size = 0;
-        static std::string tableName() { return SINCE::tableName(); }
+        static constexpr std::string_view tableName() { return SINCE::tableName(); }
         static std::string fullyQualifiedName() { return "MIN(" + SINCE::fullyQualifiedName() + ")"; }
       };
 
       struct MAX_SINCE {
         typedef cond::Time_t type;
         static constexpr size_t size = 0;
-        static std::string tableName() { return SINCE::tableName(); }
+        static constexpr std::string_view tableName() { return SINCE::tableName(); }
         static std::string fullyQualifiedName() { return "MAX(" + SINCE::fullyQualifiedName() + ")"; }
       };
 

--- a/CondCore/CondDB/src/IOVSchema.h
+++ b/CondCore/CondDB/src/IOVSchema.h
@@ -112,15 +112,21 @@ namespace cond {
       conddb_column(SINCE, cond::Time_t);
       conddb_column(PAYLOAD_HASH, std::string, PAYLOAD::PAYLOAD_HASH_SIZE);
       conddb_column(INSERTION_TIME, boost::posix_time::ptime);
+      static constexpr auto minSINCE_ =
+          condcore_detail::addMin<SINCE::fullyQualifiedName().size()>(SINCE::fullyQualifiedName());
+      static constexpr std::string_view minSINCE() { return std::string_view(minSINCE_.data()); }
+      static constexpr auto maxSINCE_ =
+          condcore_detail::addMax<SINCE::fullyQualifiedName().size()>(SINCE::fullyQualifiedName());
+      static constexpr std::string_view maxSINCE() { return std::string_view(maxSINCE_.data()); }
 
       struct SINCE_GROUP {
         typedef cond::Time_t type;
         static constexpr size_t size = 0;
         static constexpr std::string_view tableName() { return SINCE::tableName(); }
-        static std::string fullyQualifiedName() { return "MIN(" + SINCE::fullyQualifiedName() + ")"; }
+        static constexpr std::string_view fullyQualifiedName() { return minSINCE(); }
         static std::string group(unsigned long long groupSize) {
           std::string sgroupSize = std::to_string(groupSize);
-          return "CAST(" + SINCE::fullyQualifiedName() + "/" + sgroupSize + " AS INT )*" + sgroupSize;
+          return "CAST(" + std::string(SINCE::fullyQualifiedName()) + "/" + sgroupSize + " AS INT )*" + sgroupSize;
         }
       };
 
@@ -128,21 +134,21 @@ namespace cond {
         typedef unsigned int type;
         static constexpr size_t size = 0;
         static constexpr std::string_view tableName() { return SINCE::tableName(); }
-        static std::string fullyQualifiedName() { return "COUNT(*)"; }
+        static constexpr std::string_view fullyQualifiedName() { return "COUNT(*)"; }
       };
 
       struct MIN_SINCE {
         typedef cond::Time_t type;
         static constexpr size_t size = 0;
         static constexpr std::string_view tableName() { return SINCE::tableName(); }
-        static std::string fullyQualifiedName() { return "MIN(" + SINCE::fullyQualifiedName() + ")"; }
+        static constexpr std::string_view fullyQualifiedName() { return minSINCE(); }
       };
 
       struct MAX_SINCE {
         typedef cond::Time_t type;
         static constexpr size_t size = 0;
         static constexpr std::string_view tableName() { return SINCE::tableName(); }
-        static std::string fullyQualifiedName() { return "MAX(" + SINCE::fullyQualifiedName() + ")"; }
+        static constexpr std::string_view fullyQualifiedName() { return maxSINCE(); }
       };
 
       class Table : public IIOVTable {

--- a/CondCore/CondDB/src/RunInfoSchema.h
+++ b/CondCore/CondDB/src/RunInfoSchema.h
@@ -18,21 +18,21 @@ namespace cond {
       struct MAX_RUN_NUMBER {
         typedef cond::Time_t type;
         static constexpr size_t size = 0;
-        static std::string tableName() { return RUN_NUMBER::tableName(); }
+        static constexpr std::string_view tableName() { return RUN_NUMBER::tableName(); }
         static std::string fullyQualifiedName() { return "MAX(" + RUN_NUMBER::fullyQualifiedName() + ")"; }
       };
 
       struct MIN_RUN_NUMBER {
         typedef cond::Time_t type;
         static constexpr size_t size = 0;
-        static std::string tableName() { return RUN_NUMBER::tableName(); }
+        static constexpr std::string_view tableName() { return RUN_NUMBER::tableName(); }
         static std::string fullyQualifiedName() { return "MIN(" + RUN_NUMBER::fullyQualifiedName() + ")"; }
       };
 
       struct MIN_START_TIME {
         typedef boost::posix_time::ptime type;
         static constexpr size_t size = 0;
-        static std::string tableName() { return START_TIME::tableName(); }
+        static constexpr std::string_view tableName() { return START_TIME::tableName(); }
         static std::string fullyQualifiedName() { return "MIN(" + START_TIME::fullyQualifiedName() + ")"; }
       };
 

--- a/CondCore/CondDB/src/RunInfoSchema.h
+++ b/CondCore/CondDB/src/RunInfoSchema.h
@@ -19,21 +19,27 @@ namespace cond {
         typedef cond::Time_t type;
         static constexpr size_t size = 0;
         static constexpr std::string_view tableName() { return RUN_NUMBER::tableName(); }
-        static std::string fullyQualifiedName() { return "MAX(" + RUN_NUMBER::fullyQualifiedName() + ")"; }
+        static constexpr auto fullyQualifiedName_ =
+            condcore_detail::addMax<RUN_NUMBER::fullyQualifiedName().size()>(RUN_NUMBER::fullyQualifiedName());
+        static constexpr std::string_view fullyQualifiedName() { return std::string_view(fullyQualifiedName_.data()); }
       };
 
       struct MIN_RUN_NUMBER {
         typedef cond::Time_t type;
         static constexpr size_t size = 0;
         static constexpr std::string_view tableName() { return RUN_NUMBER::tableName(); }
-        static std::string fullyQualifiedName() { return "MIN(" + RUN_NUMBER::fullyQualifiedName() + ")"; }
+        static constexpr auto fullyQualifiedName_ =
+            condcore_detail::addMin<RUN_NUMBER::fullyQualifiedName().size()>(RUN_NUMBER::fullyQualifiedName());
+        static constexpr std::string_view fullyQualifiedName() { return std::string_view(fullyQualifiedName_.data()); }
       };
 
       struct MIN_START_TIME {
         typedef boost::posix_time::ptime type;
         static constexpr size_t size = 0;
         static constexpr std::string_view tableName() { return START_TIME::tableName(); }
-        static std::string fullyQualifiedName() { return "MIN(" + START_TIME::fullyQualifiedName() + ")"; }
+        static constexpr auto fullyQualifiedName_ =
+            condcore_detail::addMin<START_TIME::fullyQualifiedName().size()>(START_TIME::fullyQualifiedName());
+        static constexpr std::string_view fullyQualifiedName() { return std::string_view(fullyQualifiedName_.data()); }
       };
 
       class Table : public IRunInfoTable {


### PR DESCRIPTION
#### PR description:

Made various strings compile time constructions rather than runtime.

This was uncovered while looking at gcc 13 compiler failures.

#### PR validation:

Code compiles. Compile time tests pass.

resolves https://github.com/cms-sw/framework-team/issues/1426