### PR TITLE
LST replace uint4 by uint[4] array Params_pLS::ArrayUxHits

### DIFF
--- a/RecoTracker/LSTCore/interface/Common.h
+++ b/RecoTracker/LSTCore/interface/Common.h
@@ -46,17 +46,6 @@ namespace lst {
   typedef float FPX;
 #endif
 
-// Needed for files that are compiled by g++ to not throw an error.
-// uint4 is defined only for CUDA, so we will have to revisit this soon when running on other backends.
-#if !defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !defined(ALPAKA_ACC_GPU_HIP_ENABLED)
-  struct uint4 {
-    unsigned int x;
-    unsigned int y;
-    unsigned int z;
-    unsigned int w;
-  };
-#endif
-
   // Defining the constant host device variables right up here
   // Currently pixel tracks treated as LSs with 2 double layers (IT layers 1+2 and 3+4) and 4 hits. To be potentially handled better in the future.
   struct Params_Modules {

--- a/RecoTracker/LSTCore/interface/PixelSegmentsSoA.h
+++ b/RecoTracker/LSTCore/interface/PixelSegmentsSoA.h
@@ -9,7 +9,7 @@
 namespace lst {
 
   GENERATE_SOA_LAYOUT(PixelSegmentsSoALayout,
-                      SOA_COLUMN(uint4, pLSHitsIdxs),
+                      SOA_COLUMN(Params_pLS::ArrayUxHits, pLSHitsIdxs),
                       SOA_COLUMN(Params_pLS::ArrayFxEmbed, plsEmbed),
                       SOA_COLUMN(char, isDup),
                       SOA_COLUMN(bool, partOfPT5),

--- a/RecoTracker/LSTCore/src/alpaka/Kernels.h
+++ b/RecoTracker/LSTCore/src/alpaka/Kernels.h
@@ -344,11 +344,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
         if (secondpass && (!pixelSeeds.isQuad()[ix] || (pixelSegments.isDup()[ix] & 1)))
           continue;
 
-        unsigned int phits1[Params_pLS::kHits];
-        phits1[0] = pixelSegments.pLSHitsIdxs()[ix].x;
-        phits1[1] = pixelSegments.pLSHitsIdxs()[ix].y;
-        phits1[2] = pixelSegments.pLSHitsIdxs()[ix].z;
-        phits1[3] = pixelSegments.pLSHitsIdxs()[ix].w;
+        auto const& phits1 = pixelSegments.pLSHitsIdxs()[ix];
         float eta_pix1 = pixelSeeds.eta()[ix];
         float phi_pix1 = pixelSeeds.phi()[ix];
 
@@ -377,11 +373,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
           else
             idxToRemove = ix;
 
-          unsigned int phits2[Params_pLS::kHits];
-          phits2[0] = pixelSegments.pLSHitsIdxs()[jx].x;
-          phits2[1] = pixelSegments.pLSHitsIdxs()[jx].y;
-          phits2[2] = pixelSegments.pLSHitsIdxs()[jx].z;
-          phits2[3] = pixelSegments.pLSHitsIdxs()[jx].w;
+          auto const& phits2 = pixelSegments.pLSHitsIdxs()[jx];
 
           int npMatched = 0;
           for (int i = 0; i < Params_pLS::kHits; i++) {

--- a/RecoTracker/LSTCore/src/alpaka/Segment.h
+++ b/RecoTracker/LSTCore/src/alpaka/Segment.h
@@ -217,7 +217,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                                               unsigned int innerMDIndex,
                                                               unsigned int outerMDIndex,
                                                               uint16_t pixelModuleIndex,
-                                                              unsigned int hitIdxs[4],
+                                                              const Params_pLS::ArrayUxHits& hitIdxs,
                                                               unsigned int innerAnchorHitIndex,
                                                               unsigned int outerAnchorHitIndex,
                                                               float dPhiChange,
@@ -235,10 +235,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     pixelSegments.isDup()[pixelSegmentArrayIndex] = false;
     pixelSegments.partOfPT5()[pixelSegmentArrayIndex] = false;
     pixelSegments.score()[pixelSegmentArrayIndex] = score;
-    pixelSegments.pLSHitsIdxs()[pixelSegmentArrayIndex].x = hitIdxs[0];
-    pixelSegments.pLSHitsIdxs()[pixelSegmentArrayIndex].y = hitIdxs[1];
-    pixelSegments.pLSHitsIdxs()[pixelSegmentArrayIndex].z = hitIdxs[2];
-    pixelSegments.pLSHitsIdxs()[pixelSegmentArrayIndex].w = hitIdxs[3];
+    pixelSegments.pLSHitsIdxs()[pixelSegmentArrayIndex] = hitIdxs;
 
     //computing circle parameters
     /*
@@ -807,11 +804,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                           (hitsBase.zs()[mds.anchorHitIndices()[outerMDIndex]]);
         score_lsq = score_lsq * score_lsq;
 
-        unsigned int hits1[Params_pLS::kHits];
-        hits1[0] = hitsBase.idxs()[mds.anchorHitIndices()[innerMDIndex]];
-        hits1[1] = hitsBase.idxs()[mds.anchorHitIndices()[outerMDIndex]];
-        hits1[2] = hitsBase.idxs()[mds.outerHitIndices()[innerMDIndex]];
-        hits1[3] = hitsBase.idxs()[mds.outerHitIndices()[outerMDIndex]];
+        const Params_pLS::ArrayUxHits hits1{{hitsBase.idxs()[mds.anchorHitIndices()[innerMDIndex]],
+                                             hitsBase.idxs()[mds.anchorHitIndices()[outerMDIndex]],
+                                             hitsBase.idxs()[mds.outerHitIndices()[innerMDIndex]],
+                                             hitsBase.idxs()[mds.outerHitIndices()[outerMDIndex]]}};
         addPixelSegmentToMemory(acc,
                                 segments,
                                 pixelSegments,

--- a/RecoTracker/LSTCore/src/alpaka/TrackCandidate.h
+++ b/RecoTracker/LSTCore/src/alpaka/TrackCandidate.h
@@ -22,7 +22,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
   ALPAKA_FN_ACC ALPAKA_FN_INLINE void addpLSTrackCandidateToMemory(TrackCandidates& cands,
                                                                    unsigned int trackletIndex,
                                                                    unsigned int trackCandidateIndex,
-                                                                   uint4 hitIndices,
+                                                                   const Params_pLS::ArrayUxHits& hitIndices,
                                                                    int pixelSeedIndex) {
     cands.trackCandidateType()[trackCandidateIndex] = LSTObjType::pLS;
     cands.directObjectIndices()[trackCandidateIndex] = trackletIndex;
@@ -31,11 +31,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     cands.objectIndices()[trackCandidateIndex][0] = trackletIndex;
     cands.objectIndices()[trackCandidateIndex][1] = trackletIndex;
 
-    cands.hitIndices()[trackCandidateIndex][0] =
-        hitIndices.x;  // Order explanation in https://github.com/SegmentLinking/TrackLooper/issues/267
-    cands.hitIndices()[trackCandidateIndex][1] = hitIndices.z;
-    cands.hitIndices()[trackCandidateIndex][2] = hitIndices.y;
-    cands.hitIndices()[trackCandidateIndex][3] = hitIndices.w;
+    // Order explanation in https://github.com/SegmentLinking/TrackLooper/issues/267
+    cands.hitIndices()[trackCandidateIndex][0] = hitIndices[0];
+    cands.hitIndices()[trackCandidateIndex][1] = hitIndices[2];
+    cands.hitIndices()[trackCandidateIndex][2] = hitIndices[1];
+    cands.hitIndices()[trackCandidateIndex][3] = hitIndices[3];
   }
 
   ALPAKA_FN_ACC ALPAKA_FN_INLINE void addTrackCandidateToMemory(TrackCandidates& cands,


### PR DESCRIPTION
technical PR to address https://github.com/cms-sw/cmssw/pull/45117#discussion_r1749241199

The only place where uint4 was used was in the (pixel track) pLS hit indexing.

I expect almost no change in technical performance (confirmed by internal LST CI timing tests).

This update also opens a bit more clearly a possibility to handle longer pixel tracks in full in the future.

