### PR TITLE
Add module types to ModuleAllocMonitor output

### DIFF
--- a/PerfTools/AllocMonitor/plugins/moduleAlloc_setupFile.cc
+++ b/PerfTools/AllocMonitor/plugins/moduleAlloc_setupFile.cc
@@ -365,10 +365,13 @@ namespace edm::service::moduleAlloc {
 
     auto esModuleLabelsPtr = std::make_shared<std::vector<std::string>>();
     auto& esModuleLabels = *esModuleLabelsPtr;
+    auto esModuleTypesPtr = std::make_shared<std::vector<std::string>>();
+    auto& esModuleTypes = *esModuleTypesPtr;
     //acquire names for all the ED and ES modules
-    iRegistry.watchPostESModuleRegistration([&esModuleLabels](auto const& iDescription) {
+    iRegistry.watchPostESModuleRegistration([&esModuleLabels, &esModuleTypes](auto const& iDescription) {
       if (esModuleLabels.size() <= iDescription.id_ + 1) {
         esModuleLabels.resize(iDescription.id_ + 2);
+        esModuleTypes.resize(iDescription.id_ + 2);
       }
       //NOTE: we want the id to start at 1 not 0
       if (not iDescription.label_.empty()) {
@@ -376,22 +379,28 @@ namespace edm::service::moduleAlloc {
       } else {
         esModuleLabels[iDescription.id_ + 1] = iDescription.type_;
       }
+      esModuleTypes[iDescription.id_ + 1] = iDescription.type_;
     });
     auto moduleCtrDtrPtr = std::make_shared<std::vector<ModuleCtrDtr>>();
     auto& moduleCtrDtr = *moduleCtrDtrPtr;
     auto moduleLabelsPtr = std::make_shared<std::vector<std::string>>();
+    auto moduleTypesPtr = std::make_shared<std::vector<std::string>>();
     auto& moduleLabels = *moduleLabelsPtr;
+    auto& moduleTypes = *moduleTypesPtr;
     iRegistry.watchPreModuleConstruction(
-        [&moduleLabels, &moduleCtrDtr, beginTime, iFilter](ModuleDescription const& md) {
+        [&moduleLabels, &moduleTypes, &moduleCtrDtr, beginTime, iFilter](ModuleDescription const& md) {
           auto const t = duration_cast<duration_t>(now() - beginTime).count();
 
           auto const mid = md.id();
           if (mid < moduleLabels.size()) {
             moduleLabels[mid] = md.moduleLabel();
+            moduleTypes[mid] = md.moduleName();
             moduleCtrDtr[mid].beginConstruction = t;
           } else {
             moduleLabels.resize(mid + 1);
             moduleLabels.back() = md.moduleLabel();
+            moduleTypes.resize(mid + 1);
+            moduleTypes.back() = md.moduleName();
             moduleCtrDtr.resize(mid + 1);
             moduleCtrDtr.back().beginConstruction = t;
           }
@@ -481,7 +490,9 @@ namespace edm::service::moduleAlloc {
     iRegistry.watchPreBeginJob([logFile,
                                 iFilter,
                                 moduleLabelsPtr,
+                                moduleTypesPtr,
                                 esModuleLabelsPtr,
+                                esModuleTypesPtr,
                                 moduleCtrDtrPtr,
                                 sourceCtrPtr,
                                 beginTime,
@@ -490,15 +501,19 @@ namespace edm::service::moduleAlloc {
       *addDataInDtr = true;
       {
         std::ostringstream oss;
-        moduleIdToLabel(oss, *moduleLabelsPtr, 'M', "EDModule ID", "Module label");
+        moduleIdToLabelAndType(
+            oss, *moduleLabelsPtr, *moduleTypesPtr, 'M', "EDModule ID", "Module label", "Module type");
         logFile->write(oss.str());
         moduleLabelsPtr.reset();
+        moduleTypesPtr.reset();
       }
       {
         std::ostringstream oss;
-        moduleIdToLabel(oss, *esModuleLabelsPtr, 'N', "ESModule ID", "ESModule label");
+        moduleIdToLabelAndType(
+            oss, *esModuleLabelsPtr, *esModuleTypesPtr, 'N', "ESModule ID", "ESModule label", "ESModule type");
         logFile->write(oss.str());
         esModuleLabelsPtr.reset();
+        esModuleTypesPtr.reset();
       }
       {
         auto const moduleAllocStart = duration_cast<duration_t>(beginModuleAlloc - beginTime).count();

--- a/PerfTools/AllocMonitor/plugins/monitor_file_utilities.cc
+++ b/PerfTools/AllocMonitor/plugins/monitor_file_utilities.cc
@@ -2,6 +2,7 @@
 #include "FWCore/Utilities/interface/OStreamColumn.h"
 
 #include <vector>
+#include <cassert>
 
 namespace {
   std::string const space{"  "};
@@ -25,6 +26,37 @@ namespace edm::moduleAlloc::monitor_file_utilities {
       if (not label.empty()) {
         oStream << '#' << moduleIdSymbol << ' ' << std::setw(width) << std::left << col0(i) << space << std::left
                 << label << '\n';
+      }
+    }
+    oStream << '\n';
+  }
+
+  void moduleIdToLabelAndType(std::ostream& oStream,
+                              std::vector<std::string> const& iModuleLabels,
+                              std::vector<std::string> const& iModuleTypes,
+                              char moduleIdSymbol,
+                              std::string const& iIDHeader,
+                              std::string const& iLabelHeader,
+                              std::string const& iTypeHeader) {
+    assert(iModuleLabels.size() == iModuleTypes.size());
+    std::size_t const width{std::to_string(iModuleLabels.size()).size()};
+    OStreamColumn col0{iIDHeader, width};
+    auto itMax = std::max_element(iModuleLabels.begin(), iModuleLabels.end(), [](auto const& iL, auto const& iR) {
+      return iL.size() < iR.size();
+    });
+    OStreamColumn labelCol{iLabelHeader, itMax->size()};
+    std::string const& typeCol = iTypeHeader;
+
+    oStream << "\n#  " << col0 << space << labelCol << space << typeCol << '\n';
+    oStream << "#  " << std::string(col0.width() + space.size() + labelCol.width() + space.size() + typeCol.size(), '-')
+            << '\n';
+
+    for (std::size_t i{}; i < iModuleLabels.size(); ++i) {
+      auto const& label = iModuleLabels[i];
+      auto const& type = iModuleTypes[i];
+      if (not label.empty()) {
+        oStream << '#' << moduleIdSymbol << ' ' << std::setw(width) << std::left << col0(i) << space
+                << std::setw(itMax->size()) << std::left << labelCol(label) << space << std::left << type << '\n';
       }
     }
     oStream << '\n';

--- a/PerfTools/AllocMonitor/plugins/monitor_file_utilities.h
+++ b/PerfTools/AllocMonitor/plugins/monitor_file_utilities.h
@@ -39,5 +39,13 @@ namespace edm::moduleAlloc::monitor_file_utilities {
                        char moduleIdSymbol,
                        std::string const& iIDHeader,
                        std::string const& iLabelHeader);
+  void moduleIdToLabelAndType(std::ostream&,
+                              std::vector<std::string> const& iModules,
+                              std::vector<std::string> const& iTypes,
+                              char moduleIdSymbol,
+                              std::string const& iIDHeader,
+                              std::string const& iLabelHeader,
+                              std::string const& iTypeHeader);
+
 }  // namespace edm::moduleAlloc::monitor_file_utilities
 #endif

--- a/PerfTools/AllocMonitor/scripts/edmModuleAllocMonitorAnalyze.py
+++ b/PerfTools/AllocMonitor/scripts/edmModuleAllocMonitorAnalyze.py
@@ -961,11 +961,11 @@ class ModuleAllocCompactFileParser(object):
                 if s > numStreamsFromSource:
                   numStreamsFromSource = s
             if len(l) > 5 and l[0:2] == "#M":
-                (id,name)=tuple(l[2:].split())
+                (id,name,mType)=tuple(l[2:].split())
                 moduleNames[int(id)] = name
                 continue
             if len(l) > 5 and l[0:2] == "#N":
-                (id,name)=tuple(l[2:].split())
+                (id,name,mType)=tuple(l[2:].split())
                 esModuleNames[int(id)] = name
                 continue
             if len(l) > 5 and l[0:2] == "#R":
@@ -1315,8 +1315,8 @@ class TestModuleCommand(unittest.TestCase):
         
         self.tracerFile.extend([
             '#R 1 Record',
-            '#M 1 Module',
-            '#N 1 ESModule',
+            '#M 1 Module ModuleType',
+            '#N 1 ESModule ESModuleType',
              f'F {Phase.startTracing} 0 0 0 0 {incr(t)}',
              f'S {Phase.construction} 0 {incr(t)}',
              f's {Phase.construction} 0 {incr(t)} 1 1 10 0 10 10',


### PR DESCRIPTION
#### PR description:

This is needed for new monitoring plots.

#### PR validation:

Code compiles, unit tests pass.

resolves https://github.com/cms-sw/framework-team/issues/1418