### PR TITLE
Fix crashes in HGCAL DIGI+ with v19 geometry

### DIFF
--- a/DataFormats/ForwardDetId/interface/HGCalTriggerDetId.h
+++ b/DataFormats/ForwardDetId/interface/HGCalTriggerDetId.h
@@ -26,6 +26,7 @@
 
 class HGCalTriggerDetId : public DetId {
 public:
+  enum waferType { HGCalHD120 = 0, HGCalLD200 = 1, HGCalLD300 = 2, HGCalHD200 = 3 };
   static const int HGCalTriggerCell = 4;
 
   /** Create a null cellid*/
@@ -46,6 +47,8 @@ public:
 
   /// get the type
   int type() const { return (id_ >> kHGCalTypeOffset) & kHGCalTypeMask; }
+  bool lowDensity() const { return ((type() == HGCalLD200) || (type() == HGCalLD300)); }
+  bool highDensity() const { return ((type() == HGCalHD120) || (type() == HGCalHD200)); }
 
   /// get the z-side of the cell (1/-1)
   int zside() const { return (((id_ >> kHGCalZsideOffset) & kHGCalZsideMask) ? -1 : 1); }

--- a/DataFormats/ForwardDetId/interface/HGCalTriggerModuleDetId.h
+++ b/DataFormats/ForwardDetId/interface/HGCalTriggerModuleDetId.h
@@ -18,6 +18,7 @@
    [19:20] Type (0 fine divisions of wafer with 120 mum thick silicon
                  1 coarse divisions of wafer with 200 mum thick silicon
                  2 coarse divisions of wafer with 300 mum thick silicon
+                 3 fine divisions of wafer with 200 mum thick silicon
                  0 fine divisions of scintillators
                  1 coarse divisions of scintillators)
 
@@ -30,6 +31,8 @@
 
 class HGCalTriggerModuleDetId : public DetId {
 public:
+  enum siliconType { HGCalHD120 = 0, HGCalLD200 = 1, HGCalLD300 = 2, HGCalHD200 = 3 };
+  enum tileGranularity { HGCalTileNormal = 0, HGCalTileFine = 1 };
   /** Create a null module id*/
   HGCalTriggerModuleDetId();
   /** Create module id from raw id (0=invalid id) */
@@ -71,6 +74,15 @@ public:
 
   /// get the scintillator panel phi
   int phi() const { return moduleV(); }
+
+  bool isSiliconLowDensity() const {
+    return (!isHScintillator() && ((type() == HGCalLD200) || (type() == HGCalLD300)));
+  }
+  bool isSiliconHighDensity() const {
+    return (!isHScintillator() && ((type() == HGCalHD120) || (type() == HGCalHD200)));
+  }
+  bool isScintillatorFine() const { return (isHScintillator() && (type() == HGCalTileFine)); }
+  bool isScintillatorCoarse() const { return (isHScintillator() && (type() == HGCalTileNormal)); }
 
   /// consistency check : no bits left => no overhead
   bool isHFNose() const { return (triggerSubdetId() == HFNoseTrigger); }

--- a/HLTrigger/Configuration/python/HLT_75e33/psets/HGCAL_chargeCollectionEfficiencies_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/psets/HGCAL_chargeCollectionEfficiencies_cfi.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
 HGCAL_chargeCollectionEfficiencies = cms.PSet(
-    values = cms.vdouble(1.0, 1.0, 1.0)
+    values = cms.vdouble(1.0, 1.0, 1.0, 1.0)
 )

--- a/HLTrigger/Configuration/python/HLT_75e33/psets/HGCAL_noise_fC_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/psets/HGCAL_noise_fC_cfi.py
@@ -5,5 +5,5 @@ HGCAL_noise_fC = cms.PSet(
     scaleByDose = cms.bool(False),
     scaleByDoseAlgo = cms.uint32(0),
     scaleByDoseFactor = cms.double(1),
-    values = cms.vdouble(0.32041011999999996, 0.384492144, 0.32041011999999996)
+    values = cms.vdouble(0.32041011999999996, 0.384492144, 0.32041011999999996, 0.384492144)
 )

--- a/L1Trigger/L1THGCal/interface/HGCalCoarseTriggerCellMapping.h
+++ b/L1Trigger/L1THGCal/interface/HGCalCoarseTriggerCellMapping.h
@@ -26,7 +26,7 @@ private:
   static const std::map<int, int> kSplit_;
   static const std::map<int, int> kSplit_Scin_;
   static constexpr int kSTCidMaskInv_ = ~0xf;
-  static constexpr int kNThicknesses_ = 4;
+  static constexpr int kNThicknesses_ = 5;  // 4 silicon types + 1 for scintillator
   static constexpr int kNHGCalLayersMax_ = 52;
 
   static constexpr int kSplit_Coarse_ = 0;

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
@@ -49,6 +49,8 @@ public:
   bool isSilicon(const DetId&) const;
   bool isScintillator(const DetId& id) const { return !isSilicon(id); }
   bool isNose(const DetId&) const;
+  bool isSiliconHighDensity(const DetId&) const;
+  bool isSiliconLowDensity(const DetId&) const;
   int zside(const DetId&) const;
   int thicknessIndex(const DetId&) const;
 
@@ -84,7 +86,7 @@ public:
   DetId simToReco(const DetId&, const HGCalTopology&) const;
   unsigned triggerLayer(const unsigned id) const { return geom_->triggerLayer(id); }
 
-  static constexpr unsigned kScintillatorPseudoThicknessIndex_ = 3;
+  static constexpr unsigned kScintillatorPseudoThicknessIndex_ = 4;
 
   enum SubDetectorType {
     hgcal_silicon_CEE,

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorCoarsenerImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorCoarsenerImpl.h
@@ -23,7 +23,6 @@ private:
   HGCalTriggerTools triggerTools_;
   bool fixedDataSizePerHGCROC_;
   HGCalCoarseTriggerCellMapping coarseTCmapping_;
-  static constexpr int kHighDensityThickness_ = 0;
 
   HGCalTriggerCellCalibration calibration_;
   HGCalVFECompressionImpl vfeCompression_;

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorProcessorSelection.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorProcessorSelection.h
@@ -33,7 +33,6 @@ private:
   bool fixedDataSizePerHGCROC_;
   bool allTrigCellsInTrigSums_;
   std::vector<unsigned> coarsenTriggerCells_;
-  static constexpr int kHighDensityThickness_ = 0;
   static constexpr int kNSubDetectors_ = 3;
 
   std::vector<SelectionType> selectionType_;

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
@@ -34,7 +34,6 @@ private:
   };
 
   EnergyDivisionType energyDivisionType_;
-  static constexpr int kHighDensityThickness_ = 0;
   static constexpr int kOddNumberMask_ = 1;
 
   HGCalTriggerTools triggerTools_;

--- a/L1Trigger/L1THGCal/plugins/concentrator/HGCalConcentratorProcessorSelection.cc
+++ b/L1Trigger/L1THGCal/plugins/concentrator/HGCalConcentratorProcessorSelection.cc
@@ -89,11 +89,11 @@ void HGCalConcentratorProcessorSelection::run(const edm::Handle<l1t::HGCalTrigge
     std::vector<l1t::HGCalTriggerSums> trigSumsVecOutput;
     std::vector<l1t::HGCalConcentratorData> ae_EncodedLayerOutput;
 
-    int thickness = triggerTools_.thicknessIndex(module_trigcell.second.at(0).detId());
+    bool isHighDensity = triggerTools_.isSiliconHighDensity(module_trigcell.second.at(0).detId());
 
     HGCalTriggerTools::SubDetectorType subdet = triggerTools_.getSubDetectorType(module_trigcell.second.at(0).detId());
 
-    if (coarsenTriggerCells_[subdet] || (fixedDataSizePerHGCROC_ && thickness > kHighDensityThickness_)) {
+    if (coarsenTriggerCells_[subdet] || (fixedDataSizePerHGCROC_ && !isHighDensity)) {
       coarsenerImpl_->coarsen(module_trigcell.second, trigCellVecCoarsened);
 
       switch (selectionType_[subdet]) {

--- a/L1Trigger/L1THGCal/plugins/veryfrontend/HGCalVFEProcessorSums.cc
+++ b/L1Trigger/L1THGCal/plugins/veryfrontend/HGCalVFEProcessorSums.cc
@@ -59,11 +59,10 @@ void HGCalVFEProcessorSums::run(const HGCalDigiCollection& digiColl,
   if (dataframes.empty())
     return;
 
-  constexpr int kHighDensityThickness = 0;
   bool isSilicon = triggerTools_.isSilicon(dataframes[0].id());
   bool isEM = triggerTools_.isEm(dataframes[0].id());
   bool isNose = triggerTools_.isNose(dataframes[0].id());
-  int thickness = triggerTools_.thicknessIndex(dataframes[0].id());
+  bool isHighDensity = triggerTools_.isSiliconHighDensity(dataframes[0].id());
   // Linearization of ADC and TOT values to the same LSB
   if (isSilicon) {
     vfeLinearizationSiImpl_->linearize(dataframes, linearized_dataframes);
@@ -73,7 +72,7 @@ void HGCalVFEProcessorSums::run(const HGCalDigiCollection& digiColl,
   // Sum of sensor cells into trigger cells
   vfeSummationImpl_->triggerCellSums(linearized_dataframes, tc_payload);
   // Compression of trigger cell charges to a floating point format
-  if (thickness == kHighDensityThickness) {
+  if (isHighDensity) {
     vfeCompressionHDMImpl_->compress(tc_payload, tc_compressed_payload);
   } else {
     vfeCompressionLDMImpl_->compress(tc_payload, tc_compressed_payload);

--- a/L1Trigger/L1THGCal/python/l1tHGCalConcentratorProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/l1tHGCalConcentratorProducer_cfi.py
@@ -7,11 +7,11 @@ adcNbitsBH = digiparam.hgchebackDigitizer.digiCfg.feCfg.adcNbits
 
 # MAX_LAYERS should be equal to kNHGCalLayersMax_ defined in interface/HGCalCoarseTriggerCellMapping.h
 # MAX_LAYERS can be larger than the actual number of layers
-# CTC / STC sizes vectors should have a length of 4*MAX_LAYERS, 4 = 3 different silicon thicknesses + scintillator portion
+# CTC / STC sizes vectors should have a length of 5*MAX_LAYERS, 5 = 4 different silicon thicknesses/types (HD120, LD200, LD300, HD200) + scintillator portion
 MAX_LAYERS = 52
-CTC_2_SIZES = cms.vuint32( [2]*(MAX_LAYERS+1)*4 )
-STC_4_AND_16_SIZES = cms.vuint32( [4]*(MAX_LAYERS+1)+ [16]*(MAX_LAYERS+1)*3 )
-STC_4_AND_8_SIZES = cms.vuint32( [4]*(MAX_LAYERS+1)+ [8]*(MAX_LAYERS+1)*3 )
+CTC_2_SIZES = cms.vuint32( [2]*(MAX_LAYERS+1)*5 )
+STC_4_AND_16_SIZES = cms.vuint32( [4]*(MAX_LAYERS+1)+ [16]*(MAX_LAYERS+1)*4 )
+STC_4_AND_8_SIZES = cms.vuint32( [4]*(MAX_LAYERS+1)+ [8]*(MAX_LAYERS+1)*4 )
 
 threshold_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
                                Method = cms.vstring(['thresholdSelect']*3),

--- a/L1Trigger/L1THGCal/python/l1tHGCalVFEProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/l1tHGCalVFEProducer_cfi.py
@@ -72,11 +72,17 @@ thicknessCorrectionSc = recocalibparam.HGCalRecHit.sciThicknessCorrection
 thicknessCorrectionNose = recocalibparam.HGCalRecHit.thicknessNoseCorrection
 
 NTHICKNESS = 3
+INDEX200 = 1
+# Silicon thickness correction in HGCalRecHit_cfi.py is in the form:
+# [CE_E_120um, CE_E_200um, CE_E_300um, CE_H_120um, CE_H_200um, CE_H_300um]
+# While here there are two different sets for CE-E and CE-H
+# Additionally there are four values for each set, in order to follow the four detid silicon types [HD120um, LD200um, LD300um, HD200um]
+# The thickness correction value for HD200um is copied from LD200um
 calibration_params_ee = cms.PSet(
         lsb = cms.double(triggerCellLsbBeforeCompression_si),
         fCperMIP = fCperMIPee,
         dEdXweights = layercalibparam.triggerWeights.weights,
-        thicknessCorrection = cms.vdouble(thicknessCorrectionSi[0:NTHICKNESS]),
+        thicknessCorrection = cms.vdouble(thicknessCorrectionSi[0:NTHICKNESS]+[thicknessCorrectionSi[INDEX200]]),
         chargeCollectionEfficiency = cms.PSet(),
         )
 
@@ -84,7 +90,7 @@ calibration_params_hesi = cms.PSet(
         lsb = cms.double(triggerCellLsbBeforeCompression_si),
         fCperMIP = fCperMIPhe,
         dEdXweights = layercalibparam.triggerWeights.weights,
-        thicknessCorrection = cms.vdouble(thicknessCorrectionSi[NTHICKNESS:2*NTHICKNESS]),
+        thicknessCorrection = cms.vdouble(thicknessCorrectionSi[NTHICKNESS:2*NTHICKNESS]+[thicknessCorrectionSi[NTHICKNESS+INDEX200]]),
         chargeCollectionEfficiency = cms.PSet(),
         )
 

--- a/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
@@ -185,6 +185,52 @@ bool HGCalTriggerTools::isSilicon(const DetId& id) const {
   return silicon;
 }
 
+bool HGCalTriggerTools::isSiliconHighDensity(const DetId& id) const {
+  if (isScintillator(id)) {
+    return false;
+  }
+  unsigned det = id.det();
+  bool hd = false;
+  if (det == DetId::HGCalEE || det == DetId::HGCalHSi) {
+    hd = HGCSiliconDetId(id).highDensity();
+  } else if (det == DetId::Forward && id.subdetId() == ForwardSubdetector::HFNose) {
+    hd = (HFNoseDetId(id).type() == HFNoseDetId::HFNoseFine);
+  } else if (det == DetId::Forward && id.subdetId() == ForwardSubdetector::HGCTrigger) {
+    hd = HGCalTriggerModuleDetId(id).isSiliconHighDensity();
+  } else if (id.det() == DetId::HGCalTrigger &&
+             (HGCalTriggerDetId(id).subdet() == HGCalTriggerSubdetector::HGCalEETrigger ||
+              HGCalTriggerDetId(id).subdet() == HGCalTriggerSubdetector::HGCalHSiTrigger)) {
+    hd = HGCalTriggerDetId(id).highDensity();
+  } else if (id.det() == DetId::HGCalTrigger &&
+             HGCalTriggerDetId(id).subdet() == HGCalTriggerSubdetector::HFNoseTrigger) {
+    hd = (HFNoseDetId(id).type() == HFNoseDetId::HFNoseFine);
+  }
+  return hd;
+}
+
+bool HGCalTriggerTools::isSiliconLowDensity(const DetId& id) const {
+  if (isScintillator(id)) {
+    return false;
+  }
+  unsigned det = id.det();
+  bool ld = false;
+  if (det == DetId::HGCalEE || det == DetId::HGCalHSi) {
+    ld = HGCSiliconDetId(id).lowDensity();
+  } else if (det == DetId::Forward && id.subdetId() == ForwardSubdetector::HFNose) {
+    ld = (HFNoseDetId(id).type() != HFNoseDetId::HFNoseFine);
+  } else if (det == DetId::Forward && id.subdetId() == ForwardSubdetector::HGCTrigger) {
+    ld = HGCalTriggerModuleDetId(id).isSiliconLowDensity();
+  } else if (id.det() == DetId::HGCalTrigger &&
+             (HGCalTriggerDetId(id).subdet() == HGCalTriggerSubdetector::HGCalEETrigger ||
+              HGCalTriggerDetId(id).subdet() == HGCalTriggerSubdetector::HGCalHSiTrigger)) {
+    ld = HGCalTriggerDetId(id).lowDensity();
+  } else if (id.det() == DetId::HGCalTrigger &&
+             HGCalTriggerDetId(id).subdet() == HGCalTriggerSubdetector::HFNoseTrigger) {
+    ld = (HFNoseDetId(id).type() != HFNoseDetId::HFNoseFine);
+  }
+  return ld;
+}
+
 HGCalTriggerTools::SubDetectorType HGCalTriggerTools::getSubDetectorType(const DetId& id) const {
   SubDetectorType subdet;
   if (!isScintillator(id)) {

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorCoarsenerImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorCoarsenerImpl.cc
@@ -39,9 +39,9 @@ void HGCalConcentratorCoarsenerImpl::coarsen(const std::vector<l1t::HGCalTrigger
 
   // first pass, fill the coarse trigger cell information
   for (const l1t::HGCalTriggerCell& tc : trigCellVecInput) {
-    int thickness = triggerTools_.thicknessIndex(tc.detId());
+    bool isHighDensity = triggerTools_.isSiliconHighDensity(tc.detId());
 
-    if (fixedDataSizePerHGCROC_ && thickness == kHighDensityThickness_) {
+    if (fixedDataSizePerHGCROC_ && isHighDensity) {
       trigCellVecOutput.push_back(tc);
       continue;
     }

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
@@ -48,10 +48,10 @@ void HGCalConcentratorSuperTriggerCellImpl::createAllTriggerCells(
       continue;
 
     HGCalTriggerTools::SubDetectorType subdet = triggerTools_.getSubDetectorType(output_ids.at(0));
-    int thickness = (!output_ids.empty() ? triggerTools_.thicknessIndex(output_ids.at(0)) : 0);
+    bool isHighDensity = (!output_ids.empty() ? triggerTools_.isSiliconHighDensity(output_ids.at(0)) : false);
 
     for (const auto& id : output_ids) {
-      if (((fixedDataSizePerHGCROC_ && thickness > kHighDensityThickness_) || coarsenTriggerCells_[subdet]) &&
+      if (((fixedDataSizePerHGCROC_ && !isHighDensity) || coarsenTriggerCells_[subdet]) &&
           (id != coarseTCmapping_.getRepresentativeDetId(id))) {
         continue;
       }
@@ -95,14 +95,14 @@ void HGCalConcentratorSuperTriggerCellImpl::assignSuperTriggerCellEnergyAndPosit
   uint32_t compressed_value = getCompressedSTCEnergy(stc);
 
   HGCalTriggerTools::SubDetectorType subdet = triggerTools_.getSubDetectorType(c.detId());
-  int thickness = triggerTools_.thicknessIndex(c.detId());
+  bool isHighDensity = triggerTools_.isSiliconHighDensity(c.detId());
 
   bool isSilicon = triggerTools_.isSilicon(c.detId());
   bool isEM = triggerTools_.isEm(c.detId());
   bool isNose = triggerTools_.isNose(c.detId());
 
   GlobalPoint point;
-  if ((fixedDataSizePerHGCROC_ && thickness > kHighDensityThickness_) || coarsenTriggerCells_[subdet]) {
+  if ((fixedDataSizePerHGCROC_ && !isHighDensity) || coarsenTriggerCells_[subdet]) {
     point = coarseTCmapping_.getCoarseTriggerCellPosition(coarseTCmapping_.getCoarseTriggerCellId(c.detId()));
   } else {
     point = triggerTools_.getTCPosition(c.detId());

--- a/L1Trigger/L1THGCal/src/veryfrontend/HGCalVFESummationImpl.cc
+++ b/L1Trigger/L1THGCal/src/veryfrontend/HGCalVFESummationImpl.cc
@@ -3,7 +3,7 @@
 HGCalVFESummationImpl::HGCalVFESummationImpl(const edm::ParameterSet& conf)
     : lsb_silicon_fC_(conf.getParameter<double>("siliconCellLSB_fC")),
       lsb_scintillator_MIP_(conf.getParameter<double>("scintillatorCellLSB_MIP")) {
-  constexpr unsigned nThickness = 3;
+  constexpr unsigned nThickness = 4;
   thresholds_silicon_ =
       conf.getParameter<edm::ParameterSet>("noiseSilicon").getParameter<std::vector<double>>("values");
   if (thresholds_silicon_.size() != nThickness) {

--- a/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
@@ -192,8 +192,7 @@ std::float_t RecHitTools::getSiThickness(const DetId& id) const {
   std::float_t thick(0.37);
   if (id.det() == DetId::HGCalEE || id.det() == DetId::HGCalHSi) {
     const HGCSiliconDetId hid(id);
-    auto ddd = get_ddd(geom, hid);
-    thick = ddd->cellThickness(hid.layer(), hid.waferU(), hid.waferV());
+    thick = hid.depletion();
   } else if (id.det() == DetId::Forward && id.subdetId() == static_cast<int>(HFNose)) {
     const HFNoseDetId hid(id);
     auto ddd = get_ddd(geom, hid);

--- a/RecoLocalCalo/HGCalRecProducers/python/HGCalUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/HGCalUncalibRecHit_cfi.py
@@ -3,8 +3,8 @@ import FWCore.ParameterSet.Config as cms
 from RecoLocalCalo.HGCalRecProducers.HGCalUncalibRecHitProducer_cfi import HGCalUncalibRecHitProducer
 from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import hgceeDigitizer, hgchefrontDigitizer, hgchebackDigitizer, hfnoseDigitizer
 
-fCPerMIP_mpv = cms.vdouble(1.25,2.57,3.88) #120um, 200um, 300um
-fCPerMIP_mean = cms.vdouble(2.06,3.43,5.15) #120um, 200um, 300um
+fCPerMIP_mpv = cms.vdouble(1.25,2.57,3.88, 2.57)  #HD120um, LD200um, LD300um, HD200um
+fCPerMIP_mean = cms.vdouble(2.06,3.43,5.15, 3.43) #HD120um, LD200um, LD300um, HD200um
 
 # HGCAL producer of rechits starting from digis
 HGCalUncalibRecHit = HGCalUncalibRecHitProducer.clone(

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerBase.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerBase.h
@@ -21,6 +21,9 @@
 #include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
 #include "Geometry/HcalTowerAlgo/interface/HcalGeometry.h"
 
+#include "DataFormats/ForwardDetId/interface/HGCSiliconDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCScintillatorDetId.h"
+
 #include "SimCalorimetry/HGCalSimAlgos/interface/HGCalSiNoiseMap.h"
 
 namespace hgc = hgc_digi;
@@ -29,14 +32,16 @@ namespace hgc_digi_utils {
   using hgc::HGCCellInfo;
 
   inline void addCellMetadata(HGCCellInfo& info, const HGCalGeometry* geom, const DetId& detid) {
-    const auto& dddConst = geom->topology().dddConstants();
-    bool isHalf = (((dddConst.geomMode() == HGCalGeometryMode::Hexagon) ||
-                    (dddConst.geomMode() == HGCalGeometryMode::HexagonFull))
-                       ? dddConst.isHalfCell(HGCalDetId(detid).wafer(), HGCalDetId(detid).cell())
-                       : false);
-    //base time samples for each DetId, initialized to 0
-    info.size = (isHalf ? 0.5 : 1.0);
-    info.thickness = 1 + dddConst.waferType(detid, false);
+
+    if(detid.det()==DetId::HGCalHSc) {
+      HGCScintillatorDetId sipmdetid(detid);
+      info.size = sipmdetid.sipm();
+      info.thickness = sipmdetid.granularity();
+    } else {
+      HGCSiliconDetId sidetid(detid);
+      info.size = sidetid.highDensity() ? 0.5 : 1.0;
+      info.thickness = sidetid.type();
+    }
   }
 
   inline void addCellMetadata(HGCCellInfo& info, const CaloSubdetectorGeometry* geom, const DetId& detid) {

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerBase.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerBase.h
@@ -32,8 +32,7 @@ namespace hgc_digi_utils {
   using hgc::HGCCellInfo;
 
   inline void addCellMetadata(HGCCellInfo& info, const HGCalGeometry* geom, const DetId& detid) {
-
-    if(detid.det()==DetId::HGCalHSc) {
+    if (detid.det() == DetId::HGCalHSc) {
       HGCScintillatorDetId sipmdetid(detid);
       info.size = sipmdetid.sipm();
       info.thickness = sipmdetid.granularity();

--- a/SimCalorimetry/HGCalSimProducers/plugins/HGCDigitizerBase.cc
+++ b/SimCalorimetry/HGCalSimProducers/plugins/HGCDigitizerBase.cc
@@ -28,8 +28,7 @@ HGCDigitizerBase::HGCDigitizerBase(const edm::ParameterSet& ps)
   }
 
   if (myCfg_.existsAs<double>("noise_fC")) {
-    noise_fC_.reserve(1);
-    noise_fC_.push_back(myCfg_.getParameter<double>("noise_fC"));
+    noise_fC_.resize(4, myCfg_.getParameter<double>("noise_fC"));
   } else if (myCfg_.existsAs<std::vector<double>>("noise_fC")) {
     const auto& noises = myCfg_.getParameter<std::vector<double>>("noise_fC");
     noise_fC_ = std::vector<float>(noises.begin(), noises.end());
@@ -47,7 +46,7 @@ HGCDigitizerBase::HGCDigitizerBase(const edm::ParameterSet& ps)
     scalHFNose_.setDoseMap(doseMapFile_, scaleByDoseAlgo);
     scalHFNose_.setFluenceScaleFactor(scaleByDoseFactor_);
   } else {
-    noise_fC_.resize(1, 1.f);
+    noise_fC_.resize(4, 1.f);
   }
   if (myCfg_.existsAs<edm::ParameterSet>("ileakParam")) {
     scal_.setIleakParam(
@@ -144,7 +143,6 @@ void HGCDigitizerBase::runSimple(std::unique_ptr<HGCDigitizerBase::DColl>& coll,
     uint32_t thrADC(std::floor(myFEelectronics_->getTargetMipValue() / 2));
     uint32_t gainIdx = 0;
     std::array<float, 6>& adcPulse = myFEelectronics_->getDefaultADCPulse();
-
     double tdcOnsetAuto = -1;
     if (scaleByDose_) {
       if (id.det() == DetId::Forward && id.subdetId() == ForwardSubdetector::HFNose) {

--- a/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
@@ -6,9 +6,9 @@ from SimCalorimetry.HGCalSimAlgos.hgcSensorOpParams_cfi import hgcSiSensorIleak,
 # Base configurations for HGCal digitizers
 eV_per_eh_pair = 3.62
 fC_per_ele     = 1.6020506e-4
-nonAgedCCEs    = [1.0, 1.0, 1.0]
-nonAgedNoises  = [2100.0,2100.0,1600.0] #100,200,300 um (in electrons)
-nonAgedNoises_v9 = [2000.0,2400.0,2000.0] # 120,200,300 um (in electrons)
+nonAgedCCEs    = [1.0, 1.0, 1.0, 1.0]            # HD120, LD200, LD300, HD120 um (in electrons) - the last entry will be ignored for v<v19
+nonAgedNoises  = [2100.0,2100.0,1600.0,2100.0]   # " " notice the noise is further scaled by the size of the cell
+nonAgedNoises_v9 = [2000.0,2400.0,2000.0,2400.0] # " "
 thresholdTracksMIP = True
 
 HGCAL_ileakParam_toUse    = cms.PSet(
@@ -189,8 +189,8 @@ for _m in [hgceeDigitizer, hgchefrontDigitizer, hgchebackDigitizer, hfnoseDigiti
     premix_stage1.toModify(_m, premixStage1 = True)
 
 #function to set noise to aged HGCal
-endOfLifeCCEs = [0.5, 0.5, 0.7] # this is to be deprecated
-endOfLifeNoises = [2400.0,2250.0,1750.0]  #this is to be deprecated
+endOfLifeCCEs = [0.5, 0.5, 0.7, 0.5] # this is to be deprecated
+endOfLifeNoises = [2400.0, 2250.0, 1750.0, 2250.0]  #this is to be deprecated
 def HGCal_setEndOfLifeNoise(process,byDose=True,byDoseAlgo=0,byDoseAlgoSci=2,byDoseFactor=1):
     """
     includes all effects from radiation and gain choice
@@ -362,7 +362,7 @@ def HGCal_disableNoise(process):
         scaleByDoseAlgo = cms.uint32(0),
         scaleByDoseFactor = cms.double(1),
         doseMap = cms.string(""),
-        values = cms.vdouble(0,0,0), #100,200,300 um
+        values = cms.vdouble(0,0,0,0), #100,200,300 um
     )
     process.HGCAL_noise_heback = cms.PSet(
         scaleByDose = cms.bool(False),
@@ -374,7 +374,7 @@ def HGCal_disableNoise(process):
         noise_MIP = cms.double(0.), #zero noise (this is to be deprecated)
         )
     process.HGCAL_noises = cms.PSet(
-        values = cms.vdouble(0,0,0)
+        values = cms.vdouble(0,0,0,0)
     )
     return process
 

--- a/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
@@ -6,8 +6,8 @@ from SimCalorimetry.HGCalSimAlgos.hgcSensorOpParams_cfi import hgcSiSensorIleak,
 # Base configurations for HGCal digitizers
 eV_per_eh_pair = 3.62
 fC_per_ele     = 1.6020506e-4
-nonAgedCCEs    = [1.0, 1.0, 1.0, 1.0]            # HD120, LD200, LD300, HD120 um (in electrons) - the last entry will be ignored for v<v19
-nonAgedNoises  = [2100.0,2100.0,1600.0,2100.0]   # " " notice the noise is further scaled by the size of the cell
+nonAgedCCEs    = [1.0, 1.0, 1.0, 1.0]            # HD120, LD200, LD300, HD200 um ([0-1]) - the last entry will be ignored for v<v19
+nonAgedNoises  = [2100.0,2100.0,1600.0,2100.0]   # " "  [e-] notice the noise is further scaled by the size of the cell
 nonAgedNoises_v9 = [2000.0,2400.0,2000.0,2400.0] # " "
 thresholdTracksMIP = True
 
@@ -26,7 +26,7 @@ HGCAL_noise_fC = cms.PSet(
     scaleByDoseAlgo = cms.uint32(0),
     scaleByDoseFactor = cms.double(1),
     doseMap = cms.string(""),
-    values = cms.vdouble( [x*fC_per_ele for x in nonAgedNoises] ), #100,200,300 um
+    values = cms.vdouble( [x*fC_per_ele for x in nonAgedNoises] ), #HD 120, LD 200, LD 300, HD 200
     )
 
 HFNose_noise_fC = HGCAL_noise_fC.clone()
@@ -362,7 +362,7 @@ def HGCal_disableNoise(process):
         scaleByDoseAlgo = cms.uint32(0),
         scaleByDoseFactor = cms.double(1),
         doseMap = cms.string(""),
-        values = cms.vdouble(0,0,0,0), #100,200,300 um
+        values = cms.vdouble(0,0,0,0), #HD 120, LD 200, LD 300, HD 200
     )
     process.HGCAL_noise_heback = cms.PSet(
         scaleByDose = cms.bool(False),
@@ -374,7 +374,7 @@ def HGCal_disableNoise(process):
         noise_MIP = cms.double(0.), #zero noise (this is to be deprecated)
         )
     process.HGCAL_noises = cms.PSet(
-        values = cms.vdouble(0,0,0,0)
+        values = cms.vdouble(0,0,0,0) #HD 120, LD 200, LD 300, HD 200
     )
     return process
 


### PR DESCRIPTION
#### PR description:

The new v19 geometry causes crashes in the DIGI, L1 and RECO steps [1] due to the introduction of new sensor types for HGCAL [2]. This has been traced to be caused by fixed size arrays and hardcoded constants. In this PR we fix several of these instances with the goal of unblocking the usage of v19 geometry 

[1]  https://github.com/cms-sw/cmssw/issues/47968
[2] https://indico.cern.ch/event/1529650/contributions/6435641/attachments/3039546/5368577/Phase2-Talk146.pdf

#### PR validation:

Locally we have validated this so far with 

`runTheMatrix.py -l 34034.0`

At the time of pushing the PR we haven't however finished our tests and we would like to profit from the centralized CI/CD to spot additional uncovered failures.


Tagging: @felicepantaleo @waredjeb @jbsauvan @EmyrClement @indra-ehep @bsunanda  (sorry if already tagged by the labels assigned to PR)