### PR TITLE
Add `L1P2GT` for Default Inputs

### DIFF
--- a/Configuration/Applications/python/cmsDriverOptions.py
+++ b/Configuration/Applications/python/cmsDriverOptions.py
@@ -84,6 +84,7 @@ def OptionsFromItems(items):
                  "DIGI":"SIM",
                  "reDIGI":"DIGI",
                  "L1REPACK":"RAW",
+                 "L1P2GT":"RAW",
                  "HLT":"RAW",
                  "RECO":"DIGI",
                  "ALCA":"RECO",


### PR DESCRIPTION
#### PR description:

As is now the `L1P2GT` step has no default input name defined in `prec_step` so that when running a `cmsDriver` with `-s L1P2GT` and no `--filein` we hit:

```
Traceback (most recent call last):
  File "/cvmfs/cms.cern.ch/el8_amd64_gcc12/cms/cmssw/CMSSW_15_1_0_pre3/bin/el8_amd64_gcc12/cmsDriver.py", line 40, in <module>
    run()
  File "/cvmfs/cms.cern.ch/el8_amd64_gcc12/cms/cmssw/CMSSW_15_1_0_pre3/bin/el8_amd64_gcc12/cmsDriver.py", line 11, in run
    options = OptionsFromCommandLine()
  File "/cvmfs/cms.cern.ch/el8_amd64_gcc12/cms/cmssw/CMSSW_15_1_0_pre3/src/Configuration/Applications/python/cmsDriverOptions.py", line 36, in OptionsFromCommandLine
    options=OptionsFromItems(sys.argv[1:])
  File "/cvmfs/cms.cern.ch/el8_amd64_gcc12/cms/cmssw/CMSSW_15_1_0_pre3/src/Configuration/Applications/python/cmsDriverOptions.py", line 155, in OptionsFromItems
    options.filein=trimmedEvtType+"_"+prec_step[first_step]+"."+filesuffix
KeyError: 'L1P2GT'
```

This PR proposes a small fix for that.