### PR TITLE
Make BeamSpotOnlineProducer return consistent results

### DIFF
--- a/RecoVertex/BeamSpotProducer/plugins/BeamSpotOnlineProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/BeamSpotOnlineProducer.cc
@@ -31,6 +31,8 @@ ________________________________________________________________**/
 #include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/Utilities/interface/TypeDemangler.h"
 
+#include <optional>
+
 class BeamSpotOnlineProducer : public edm::stream::EDProducer<> {
 public:
   /// constructor
@@ -47,17 +49,19 @@ public:
 private:
   // helper methods
   bool shouldShout(const edm::Event& iEvent) const;
-  bool processRecords(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup, bool shoutMODE);
-  void createBeamSpotFromRecord(const BeamSpotObjects& spotDB);
+  std::optional<reco::BeamSpot> processRecords(const edm::LuminosityBlock& iLumi,
+                                               const edm::EventSetup& iSetup,
+                                               bool shoutMODE) const;
+  reco::BeamSpot createBeamSpotFromRecord(const BeamSpotObjects& spotDB) const;
   template <typename RecordType, typename TokenType>
-  const BeamSpotOnlineObjects& getBeamSpotFromRecord(const TokenType& token,
+  const BeamSpotOnlineObjects* getBeamSpotFromRecord(const TokenType& token,
                                                      const edm::LuminosityBlock& lumi,
-                                                     const edm::EventSetup& setup);
-  const BeamSpotOnlineObjects& chooseBS(const BeamSpotOnlineObjects& bs1, const BeamSpotOnlineObjects& bs2);
-  bool processScalers(const edm::Event& iEvent, bool shoutMODE);
-  void createBeamSpotFromScaler(const BeamSpotOnline& spotOnline);
+                                                     const edm::EventSetup& setup) const;
+  const BeamSpotOnlineObjects* chooseBS(const BeamSpotOnlineObjects* bs1, const BeamSpotOnlineObjects* bs2) const;
+  std::optional<reco::BeamSpot> processScalers(const edm::Event& iEvent, bool shoutMODE) const;
+  reco::BeamSpot createBeamSpotFromScaler(const BeamSpotOnline& spotOnline) const;
   bool isInvalidScaler(const BeamSpotOnline& spotOnline, bool shoutMODE) const;
-  void createBeamSpotFromDB(const edm::EventSetup& iSetup, bool shoutMODE);
+  reco::BeamSpot createBeamSpotFromDB(const edm::EventSetup& iSetup, bool shoutMODE) const;
 
   // data members
   const bool changeFrame_;
@@ -72,9 +76,8 @@ private:
   const edm::ESGetToken<BeamSpotOnlineObjects, BeamSpotOnlineLegacyObjectsRcd> beamTokenLegacy_;
   const edm::ESGetToken<BeamSpotOnlineObjects, BeamSpotOnlineHLTObjectsRcd> beamTokenHLT_;
 
-  reco::BeamSpot result;
+  std::optional<reco::BeamSpot> lumiResult_;
   const unsigned int theBeamShoutMode;
-  BeamSpotOnlineObjects fakeBS_;
 };
 
 using namespace edm;
@@ -90,13 +93,12 @@ BeamSpotOnlineProducer::BeamSpotOnlineProducer(const ParameterSet& iconf)
       scalerToken_(useBSOnlineRecords_ ? edm::EDGetTokenT<BeamSpotOnlineCollection>()
                                        : consumes<BeamSpotOnlineCollection>(iconf.getParameter<InputTag>("src"))),
       l1GtEvmReadoutRecordToken_(consumes<L1GlobalTriggerEvmReadoutRecord>(iconf.getParameter<InputTag>("gtEvmLabel"))),
-      beamToken_(esConsumes<BeamSpotObjects, BeamSpotObjectsRcd>()),
+      beamToken_(esConsumes<BeamSpotObjects, BeamSpotObjectsRcd, edm::Transition::BeginLuminosityBlock>()),
       beamTokenLegacy_(
           esConsumes<BeamSpotOnlineObjects, BeamSpotOnlineLegacyObjectsRcd, edm::Transition::BeginLuminosityBlock>()),
       beamTokenHLT_(
           esConsumes<BeamSpotOnlineObjects, BeamSpotOnlineHLTObjectsRcd, edm::Transition::BeginLuminosityBlock>()),
       theBeamShoutMode(iconf.getUntrackedParameter<unsigned int>("beamMode", 11)) {
-  fakeBS_.setType(reco::BeamSpot::Fake);
   theMaxR2 = iconf.getParameter<double>("maxRadius");
   theMaxR2 *= theMaxR2;
 
@@ -122,29 +124,29 @@ void BeamSpotOnlineProducer::fillDescriptions(edm::ConfigurationDescriptions& iD
 void BeamSpotOnlineProducer::beginLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup& setup) {
   /// fetch online records only at the beginning of a lumisection
   if (useBSOnlineRecords_) {
-    processRecords(lumi, setup, true);
+    lumiResult_ = processRecords(lumi, setup, true);
+    if (lumiResult_)
+      return;
   }
+  lumiResult_ = createBeamSpotFromDB(setup, true);
 }
 
 void BeamSpotOnlineProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // Determine if we should "shout" based on the beam mode
   bool shoutMODE = shouldShout(iEvent);
-  bool fallBackToDB{false};
 
-  // Use online records if enabled
-  if (useBSOnlineRecords_) {
-    fallBackToDB = result.type() != reco::BeamSpot::Tracker;
-  } else {
+  std::unique_ptr<reco::BeamSpot> toput;
+  if (not useBSOnlineRecords_) {
     // Process online beam spot scalers
-    fallBackToDB = processScalers(iEvent, shoutMODE);
+    auto bs = processScalers(iEvent, shoutMODE);
+    if (bs) {
+      toput = std::make_unique<reco::BeamSpot>(std::move(*bs));
+    }
   }
-
-  // Fallback to DB if necessary
-  if (fallBackToDB) {
-    createBeamSpotFromDB(iSetup, shoutMODE);
+  if (not toput) {
+    assert(lumiResult_);
+    toput = std::make_unique<reco::BeamSpot>(*lumiResult_);
   }
-
-  std::unique_ptr<reco::BeamSpot> toput = std::make_unique<reco::BeamSpot>(result);
   iEvent.put(std::move(toput));
 }
 
@@ -156,80 +158,82 @@ bool BeamSpotOnlineProducer::shouldShout(const edm::Event& iEvent) const {
   return true;  // Default to "shout" if the record is missing
 }
 
-bool BeamSpotOnlineProducer::processRecords(const edm::LuminosityBlock& iLumi,
-                                            const edm::EventSetup& iSetup,
-                                            bool shoutMODE) {
-  auto const& spotDBLegacy = getBeamSpotFromRecord<BeamSpotOnlineLegacyObjectsRcd>(beamTokenLegacy_, iLumi, iSetup);
-  auto const& spotDBHLT = getBeamSpotFromRecord<BeamSpotOnlineHLTObjectsRcd>(beamTokenHLT_, iLumi, iSetup);
-  auto const& spotDB = chooseBS(spotDBLegacy, spotDBHLT);
+std::optional<reco::BeamSpot> BeamSpotOnlineProducer::processRecords(const edm::LuminosityBlock& iLumi,
+                                                                     const edm::EventSetup& iSetup,
+                                                                     bool shoutMODE) const {
+  auto const* spotDBLegacy = getBeamSpotFromRecord<BeamSpotOnlineLegacyObjectsRcd>(beamTokenLegacy_, iLumi, iSetup);
+  auto const* spotDBHLT = getBeamSpotFromRecord<BeamSpotOnlineHLTObjectsRcd>(beamTokenHLT_, iLumi, iSetup);
+  auto const* spotDB = chooseBS(spotDBLegacy, spotDBHLT);
 
-  if (spotDB.beamType() != reco::BeamSpot::Tracker) {
+  if (not spotDB) {
     if (shoutMODE) {
       edm::LogWarning("BeamSpotOnlineProducer") << "None of the online records holds a valid beam spot. The Online "
                                                    "Beam Spot producer falls back to the PCL value.";
     }
-    return true;  // Trigger fallback to DB
+    return {};  // Trigger fallback to DB
   }
 
   // Create BeamSpot from transient record
-  createBeamSpotFromRecord(spotDB);
-  return false;  // No fallback needed
+  return createBeamSpotFromRecord(*spotDB);
 }
 
 template <typename RecordType, typename TokenType>
-const BeamSpotOnlineObjects& BeamSpotOnlineProducer::getBeamSpotFromRecord(const TokenType& token,
+const BeamSpotOnlineObjects* BeamSpotOnlineProducer::getBeamSpotFromRecord(const TokenType& token,
                                                                            const LuminosityBlock& lumi,
-                                                                           const EventSetup& setup) {
+                                                                           const EventSetup& setup) const {
   auto const bsRecord = setup.tryToGet<RecordType>();
-  const auto& recordTypeName = edm::typeDemangle(typeid(RecordType).name());
   if (!bsRecord) {
+    const auto& recordTypeName = edm::typeDemangle(typeid(RecordType).name());
     edm::LogWarning("BeamSpotOnlineProducer") << "No " << recordTypeName << " found in the EventSetup";
-    return fakeBS_;
+    return nullptr;
   }
   const auto& bsHandle = setup.getHandle(token);
   if (bsHandle.isValid()) {
     const auto& bs = *bsHandle;
     if (bs.sigmaZ() < sigmaZThreshold_ || bs.beamWidthX() < sigmaXYThreshold_ || bs.beamWidthY() < sigmaXYThreshold_ ||
         bs.beamType() != reco::BeamSpot::Tracker) {
+      const auto& recordTypeName = edm::typeDemangle(typeid(RecordType).name());
       edm::LogWarning("BeamSpotOnlineProducer")
           << "The beam spot record does not pass the fit sanity checks (record: " << recordTypeName << ")" << std::endl
           << "sigmaZ: " << bs.sigmaZ() << std::endl
           << "sigmaX: " << bs.beamWidthX() << std::endl
           << "sigmaY: " << bs.beamWidthY() << std::endl
           << "type: " << bs.beamType();
-      return fakeBS_;
+      return nullptr;
     }
     auto lumitime = std::chrono::seconds(lumi.beginTime().unixTime());
     auto bstime = std::chrono::microseconds(bs.creationTime());
     auto threshold = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::hours(timeThreshold_)).count();
     if ((lumitime - bstime).count() > threshold) {
+      const auto& recordTypeName = edm::typeDemangle(typeid(RecordType).name());
       edm::LogWarning("BeamSpotOnlineProducer")
           << "The beam spot record is too old. (record: " << recordTypeName << ")" << std::endl
           << " record creation time: " << std::chrono::duration_cast<std::chrono::seconds>(bstime).count()
           << " lumi block time: " << std::chrono::duration_cast<std::chrono::seconds>(lumitime).count();
-      return fakeBS_;
+      return nullptr;
     }
-    return bs;
+    return &bs;
   } else {
+    const auto& recordTypeName = edm::typeDemangle(typeid(RecordType).name());
     edm::LogWarning("BeamSpotOnlineProducer") << "Invalid online beam spot handle for the record: " << recordTypeName;
-    return fakeBS_;
+    return nullptr;
   }
 }
 
-const BeamSpotOnlineObjects& BeamSpotOnlineProducer::chooseBS(const BeamSpotOnlineObjects& bs1,
-                                                              const BeamSpotOnlineObjects& bs2) {
-  if (bs1.beamType() == reco::BeamSpot::Tracker && bs2.beamType() == reco::BeamSpot::Tracker) {
-    return bs1.sigmaZ() > bs2.sigmaZ() ? bs1 : bs2;
-  } else if (bs1.beamType() == reco::BeamSpot::Tracker) {
+const BeamSpotOnlineObjects* BeamSpotOnlineProducer::chooseBS(const BeamSpotOnlineObjects* bs1,
+                                                              const BeamSpotOnlineObjects* bs2) const {
+  if (bs1 and bs2 and bs1->beamType() == reco::BeamSpot::Tracker && bs2->beamType() == reco::BeamSpot::Tracker) {
+    return bs1->sigmaZ() > bs2->sigmaZ() ? bs1 : bs2;
+  } else if (bs1 and bs1->beamType() == reco::BeamSpot::Tracker) {
     return bs1;
-  } else if (bs2.beamType() == reco::BeamSpot::Tracker) {
+  } else if (bs2 and bs2->beamType() == reco::BeamSpot::Tracker) {
     return bs2;
   } else {
-    return fakeBS_;
+    return nullptr;
   }
 }
 
-void BeamSpotOnlineProducer::createBeamSpotFromRecord(const BeamSpotObjects& spotDB) {
+reco::BeamSpot BeamSpotOnlineProducer::createBeamSpotFromRecord(const BeamSpotObjects& spotDB) const {
   double f = changeFrame_ ? -1.0 : 1.0;
   reco::BeamSpot::Point apoint(f * spotDB.x(), f * spotDB.y(), f * spotDB.z());
 
@@ -241,15 +245,16 @@ void BeamSpotOnlineProducer::createBeamSpotFromRecord(const BeamSpotObjects& spo
   }
 
   double sigmaZ = (theSetSigmaZ > 0) ? theSetSigmaZ : spotDB.sigmaZ();
-  result = reco::BeamSpot(apoint, sigmaZ, spotDB.dxdz(), spotDB.dydz(), spotDB.beamWidthX(), matrix);
+  reco::BeamSpot result(apoint, sigmaZ, spotDB.dxdz(), spotDB.dydz(), spotDB.beamWidthX(), matrix);
   result.setBeamWidthY(spotDB.beamWidthY());
   result.setEmittanceX(spotDB.emittanceX());
   result.setEmittanceY(spotDB.emittanceY());
   result.setbetaStar(spotDB.betaStar());
   result.setType(reco::BeamSpot::Tracker);
+  return result;
 }
 
-bool BeamSpotOnlineProducer::processScalers(const edm::Event& iEvent, bool shoutMODE) {
+std::optional<reco::BeamSpot> BeamSpotOnlineProducer::processScalers(const edm::Event& iEvent, bool shoutMODE) const {
   edm::Handle<BeamSpotOnlineCollection> handleScaler;
   iEvent.getByToken(scalerToken_, handleScaler);
 
@@ -258,21 +263,19 @@ bool BeamSpotOnlineProducer::processScalers(const edm::Event& iEvent, bool shout
       edm::LogWarning("BeamSpotOnlineProducer") << " Scalers handle is empty. The Online "
                                                    "Beam Spot producer falls back to the PCL value.";
     }
-    return true;  // Fallback to DB if scaler collection is empty
+    return {};
   }
 
   // Extract data from scaler
   BeamSpotOnline spotOnline = *(handleScaler->begin());
-  createBeamSpotFromScaler(spotOnline);
-
   // Validate the scaler data
   if (isInvalidScaler(spotOnline, shoutMODE)) {
-    return true;  // Trigger fallback to DB
+    return {};  // Trigger fallback to DB
   }
-  return false;  // No fallback needed
+  return createBeamSpotFromScaler(spotOnline);
 }
 
-void BeamSpotOnlineProducer::createBeamSpotFromScaler(const BeamSpotOnline& spotOnline) {
+reco::BeamSpot BeamSpotOnlineProducer::createBeamSpotFromScaler(const BeamSpotOnline& spotOnline) const {
   double f = changeFrame_ ? -1.0 : 1.0;
   reco::BeamSpot::Point apoint(f * spotOnline.x(), spotOnline.y(), f * spotOnline.z());
 
@@ -283,12 +286,13 @@ void BeamSpotOnlineProducer::createBeamSpotFromScaler(const BeamSpotOnline& spot
   matrix(3, 3) = spotOnline.err_sigma_z() * spotOnline.err_sigma_z();
 
   double sigmaZ = (theSetSigmaZ > 0) ? theSetSigmaZ : spotOnline.sigma_z();
-  result = reco::BeamSpot(apoint, sigmaZ, spotOnline.dxdz(), f * spotOnline.dydz(), spotOnline.width_x(), matrix);
+  reco::BeamSpot result(apoint, sigmaZ, spotOnline.dxdz(), f * spotOnline.dydz(), spotOnline.width_x(), matrix);
   result.setBeamWidthY(spotOnline.width_y());
   result.setEmittanceX(0.0);
   result.setEmittanceY(0.0);
   result.setbetaStar(0.0);
   result.setType(reco::BeamSpot::LHC);
+  return result;
 }
 
 bool BeamSpotOnlineProducer::isInvalidScaler(const BeamSpotOnline& spotOnline, bool shoutMODE) const {
@@ -313,7 +317,7 @@ bool BeamSpotOnlineProducer::isInvalidScaler(const BeamSpotOnline& spotOnline, b
   return false;
 }
 
-void BeamSpotOnlineProducer::createBeamSpotFromDB(const edm::EventSetup& iSetup, bool shoutMODE) {
+reco::BeamSpot BeamSpotOnlineProducer::createBeamSpotFromDB(const edm::EventSetup& iSetup, bool shoutMODE) const {
   edm::ESHandle<BeamSpotObjects> beamhandle = iSetup.getHandle(beamToken_);
   const BeamSpotObjects* spotDB = beamhandle.product();
 
@@ -326,7 +330,7 @@ void BeamSpotOnlineProducer::createBeamSpotFromDB(const edm::EventSetup& iSetup,
     }
   }
 
-  result = reco::BeamSpot(apoint, spotDB->sigmaZ(), spotDB->dxdz(), spotDB->dydz(), spotDB->beamWidthX(), matrix);
+  reco::BeamSpot result(apoint, spotDB->sigmaZ(), spotDB->dxdz(), spotDB->dydz(), spotDB->beamWidthX(), matrix);
   result.setBeamWidthY(spotDB->beamWidthY());
   result.setEmittanceX(spotDB->emittanceX());
   result.setEmittanceY(spotDB->emittanceY());
@@ -337,6 +341,7 @@ void BeamSpotOnlineProducer::createBeamSpotFromDB(const edm::EventSetup& iSetup,
   if ((bse.cxx() <= 0.0) || (bse.cyy() <= 0.0) || (bse.czz() <= 0.0)) {
     edm::LogError("UnusableBeamSpot") << "Beamspot from DB fallback has invalid errors: " << result.covariance();
   }
+  return result;
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"


### PR DESCRIPTION
#### PR description:

Now reset how the beam spot is calculated each LuminosityBlock in case the available EventSetup data products change. This avoids getting different results depending on the order in which LuminosityBlocks are seen in a job.

#### PR validation:

Code compiles. Examples from #48280 now return consistent results.

resolves https://github.com/cms-sw/framework-team/issues/1428