### PR TITLE
[15.0.X] Improve shortened track monitoring 

### DIFF
--- a/Alignment/OfflineValidation/test/BuildFile.xml
+++ b/Alignment/OfflineValidation/test/BuildFile.xml
@@ -30,6 +30,7 @@
   <test name="Genericall" command="testingScripts/test_unitGeneric.sh">
     <flags PRE_TEST="validateAlignments"/>
   </test>
+  <test name="PVValidation" command="testingScripts/test_unitPVValidation.sh"/>
   <bin file="testTrackAnalyzers.cc" name="testTrackAnalysis">
     <use name="FWCore/TestProcessor"/>
     <use name="catch2"/>
@@ -59,6 +60,7 @@
     <use name="Alignment/OfflineValidation"/>
   </bin>
   <test name="Miscellanea" command="testingScripts/test_unitMiscellanea.sh"/>
+  <test name="ShortTrackValidation" command="testingScripts/test_unitShortTrackValidation.sh"/>
   <test name="SagittaBiasNtuplizer" command="testingScripts/test_unitSagittaBiasNtuplizer.sh"/>
   <bin file="testanalyzeDiMuonBiases.cpp" name="testDiMuonBiasesPlotting">
     <flags PRE_TEST="SagittaBiasNtuplizer"/>

--- a/Alignment/OfflineValidation/test/testShortenedTrackValidation_cfg.py
+++ b/Alignment/OfflineValidation/test/testShortenedTrackValidation_cfg.py
@@ -46,7 +46,7 @@ process.MeasurementTrackerEvent.inactivePixelDetectorLabels = cms.VInputTag()
 process.MeasurementTrackerEvent.inactiveStripDetectorLabels = cms.VInputTag()
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(1000000)
+    input = cms.untracked.int32(options.maxEvents)
 )
 
 #####################################################################

--- a/Alignment/OfflineValidation/test/test_all_Phase2_cfg.py
+++ b/Alignment/OfflineValidation/test/test_all_Phase2_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 import sys
 from enum import Enum
-from Alignment.OfflineValidation.TkAlAllInOneTool.defaultInputFiles_cff import filesDefaultMC_MinBiasPUPhase2RECO
+from Alignment.OfflineValidation.TkAlAllInOneTool.defaultInputFiles_cff import filesDefaultMC_TTbarPhase2RECO
 
 class RefitType(Enum):
      STANDARD = 1
@@ -27,7 +27,7 @@ process.options.numberOfThreads = 8
 # Event source and run selection
 ###################################################################
 process.source = cms.Source("PoolSource",
-                            fileNames = filesDefaultMC_MinBiasPUPhase2RECO,
+                            fileNames = filesDefaultMC_TTbarPhase2RECO,
                             duplicateCheckMode = cms.untracked.string('checkAllFilesOpened')
                             )
 

--- a/Alignment/OfflineValidation/test/test_all_cfg.py
+++ b/Alignment/OfflineValidation/test/test_all_cfg.py
@@ -91,7 +91,7 @@ process.load("RecoVertex.BeamSpotProducer.BeamSpot_cff")
 ####################################################################
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2022_realistic', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, '125X_mcRun3_2022_realistic_v3', '')
 
 if allFromGT:
      print("############ testPVValidation_cfg.py: msg%-i: All is taken from GT")

--- a/Alignment/OfflineValidation/test/testingScripts/testPVValidation.sh
+++ b/Alignment/OfflineValidation/test/testingScripts/testPVValidation.sh
@@ -1,6 +1,0 @@
-#! /bin/bash
-
-function die { echo $1: status $2 ; exit $2; }
-
-echo "TESTING Alignment/OfflineValidation ..."
-cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/test_all_cfg.py || die "Failure running test_all_cfg.py" $?

--- a/Alignment/OfflineValidation/test/testingScripts/test_unitPVValidation.sh
+++ b/Alignment/OfflineValidation/test/testingScripts/test_unitPVValidation.sh
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+function die { echo $1: status $2 ; exit $2; }
+
+echo "TESTING Alignment/OfflineValidation/test/test_all_cfg.py ..."
+cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/test_all_cfg.py || die "Failure running test_all_cfg.py" $?
+
+echo "TESTING Alignment/OfflineValidation/test/test_all_Phase2_cfg.py ..."
+cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/test_all_Phase2_cfg.py || die "Failure running test_all_Phase2_cfg.py" $?

--- a/Alignment/OfflineValidation/test/testingScripts/test_unitShortTrackValidation.sh
+++ b/Alignment/OfflineValidation/test/testingScripts/test_unitShortTrackValidation.sh
@@ -1,0 +1,6 @@
+#! /bin/bash
+
+function die { echo $1: status $2 ; exit $2; }
+
+echo "TESTING Short Track Validation..."
+cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/testShortenedTrackValidation_cfg.py maxEvents=1000 || die "Failure running testShortenedTrackValidation_cfg.py" $?


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/48276

#### PR description:

This PR is a follow-up to https://github.com/cms-sw/cmssw/pull/43613 and https://github.com/cms-sw/cmssw/pull/43729.
   * 6ba097cf521 add more monitoring histograms to shortened track resolution
   * 4f7244bcddb improve `beginJob` method of `ShortenedTrackValidation`
   * c9876973af8  add a unit test for `ShortenedTrackValidation`

In addition I profit of this PR to add this commit:
   * e23bc9ccfa8 re-introduce a unit test for PV Validation

#### PR validation:

`scram b runtests` runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/48276 to the 2025 data-taking release cycle.