### PR TITLE
[Phase-2 HLT] Add hltHpsPFTau table to HLT Nano

### DIFF
--- a/HLTrigger/NGTScouting/python/HLTNanoProducer_cff.py
+++ b/HLTrigger/NGTScouting/python/HLTNanoProducer_cff.py
@@ -29,7 +29,6 @@ hltNanoProducer = cms.Sequence(
     + hltMuonTable
     + hltPFCandidateTable
     + hltJetTable
-    + hltTauTable
 )
 
 dstNanoProducer = cms.Sequence(

--- a/HLTrigger/NGTScouting/python/HLTNanoProducer_cff.py
+++ b/HLTrigger/NGTScouting/python/HLTNanoProducer_cff.py
@@ -11,6 +11,7 @@ from HLTrigger.NGTScouting.hltElectrons_cfi import *
 from HLTrigger.NGTScouting.hltMuons_cfi import *
 from HLTrigger.NGTScouting.hltTracks_cfi import *
 from HLTrigger.NGTScouting.hltJets_cfi import *
+from HLTrigger.NGTScouting.hltTaus_cfi import *
 from HLTrigger.NGTScouting.hltTriggerAcceptFilter_cfi import hltTriggerAcceptFilter,dstTriggerAcceptFilter
 
 hltNanoProducer = cms.Sequence(
@@ -28,6 +29,7 @@ hltNanoProducer = cms.Sequence(
     + hltMuonTable
     + hltPFCandidateTable
     + hltJetTable
+    + hltTauTable
 )
 
 dstNanoProducer = cms.Sequence(
@@ -45,6 +47,7 @@ dstNanoProducer = cms.Sequence(
     + hltMuonTable
     + hltPFCandidateTable
     + hltJetTable
+    + hltTauTable
 )
 
 def hltNanoCustomize(process):

--- a/HLTrigger/NGTScouting/python/hltTaus_cfi.py
+++ b/HLTrigger/NGTScouting/python/hltTaus_cfi.py
@@ -48,6 +48,6 @@ hltTauTable = cms.EDProducer("SimplePFTauCandidateFlatTableProducer",
       externalVariables = cms.PSet(
         ## FIXME does not work despite DiMediumTau path using this! 
         ## https://github.com/cms-sw/cmssw/blob/48e0354ea37072eeacc8237a4a79e7ad34b9b0ae/HLTrigger/Configuration/python/HLT_75e33/modules/hltHpsSelectedPFTausMediumDitauWPDeepTau_cfi.py#L6
-        deepTauVSjet = ExtVar(cms.InputTag("hltHpsPFTauDeepTauProducer","VSjet"), float, doc="deeptau VSjet", precision=10),
+        # deepTauVSjet = ExtVar(cms.InputTag("hltHpsPFTauDeepTauProducer","VSjet"), float, doc="deeptau VSjet", precision=10),
       ),
 )

--- a/HLTrigger/NGTScouting/python/hltTaus_cfi.py
+++ b/HLTrigger/NGTScouting/python/hltTaus_cfi.py
@@ -30,24 +30,5 @@ hltTauTable = cms.EDProducer("SimplePFTauCandidateFlatTableProducer",
         signalConeSize = Var("signalConeSize", float, doc = "Size of signal cone"),
         # variables available in PF jets
         jetIsValid = Var("jetRef.isNonnull && jetRef.isAvailable", bool, doc = "jet is valid"),
-        # source: DataFormats/JetReco/interface/PFJet.h
-        ## FIXME below does not work - members not found 
-        # chargedHadronEnergy = Var("? jetRef.isNonnull && jetRef.isAvailable ? jetRef.chargedHadronEnergy : -999.", float, doc = "chargedHadronEnergy"),
-        # neutralHadronEnergy = Var("? jetRef.isNonnull && jetRef.isAvailable ? jetRef.neutralHadronEnergy : -999.", float, doc = "neutralHadronEnergy"),
-        # photonEnergy = Var("? jetRef.isNonnull && jetRef.isAvailable ? jetRef.photonEnergy : -999.", float, doc = "photonEnergy"),
-        # muonEnergy = Var("? jetRef.isNonnull && jetRef.isAvailable ? jetRef.muonEnergy : -999.", float, doc = "muonEnergy"),
-        # chargedHadronMultiplicity = Var("? jetRef.isNonnull && jetRef.isAvailable ? jetRef.chargedHadronMultiplicity : -999.", float, doc = "chargedHadronMultiplicity"),
-        # neutralHadronMultiplicity = Var("? jetRef.isNonnull && jetRef.isAvailable ? jetRef.neutralHadronMultiplicity : -999.", float, doc = "neutralHadronMultiplicity"),
-        # photonMultiplicity = Var("? jetRef.isNonnull && jetRef.isAvailable ? jetRef.photonMultiplicity : -999.", float, doc = "photonMultiplicity"),
-        # muonMultiplicity = Var("? jetRef.isNonnull && jetRef.isAvailable ? jetRef.muonMultiplicity : -999.", float, doc = "muonMultiplicity"),
-        # chargedMuEnergy = Var("? jetRef.isNonnull && jetRef.isAvailable ? jetRef.chargedMuEnergy : -999.", float, doc = "chargedMuEnergy"),
-        # neutralEmEnergy = Var("? jetRef.isNonnull && jetRef.isAvailable ? jetRef.neutralEmEnergy : -999.", float, doc = "neutralEmEnergy"),
-        # chargedMultiplicity = Var("? jetRef.isNonnull && jetRef.isAvailable ? jetRef.chargedMultiplicity : -999.", float, doc = "chargedMultiplicity"),
-        # neutralMultiplicity = Var("? jetRef.isNonnull && jetRef.isAvailable ? jetRef.neutralMultiplicity : -999.", float, doc = "neutralMultiplicity"),
-      ),
-      externalVariables = cms.PSet(
-        ## FIXME does not work despite DiMediumTau path using this! 
-        ## https://github.com/cms-sw/cmssw/blob/48e0354ea37072eeacc8237a4a79e7ad34b9b0ae/HLTrigger/Configuration/python/HLT_75e33/modules/hltHpsSelectedPFTausMediumDitauWPDeepTau_cfi.py#L6
-        # deepTauVSjet = ExtVar(cms.InputTag("hltHpsPFTauDeepTauProducer","VSjet"), float, doc="deeptau VSjet", precision=10),
       ),
 )

--- a/HLTrigger/NGTScouting/python/hltTaus_cfi.py
+++ b/HLTrigger/NGTScouting/python/hltTaus_cfi.py
@@ -1,0 +1,53 @@
+import FWCore.ParameterSet.Config as cms
+from PhysicsTools.NanoAOD.common_cff import *
+
+hltTauTable = cms.EDProducer("SimplePFTauCandidateFlatTableProducer",
+      src = cms.InputTag("hltHpsPFTauProducer"),
+      name = cms.string("hltHpsPFTau"),
+      cut = cms.string(""),
+      doc = cms.string("HLT HPS Taus information"),
+      singleton = cms.bool(False),
+      extension = cms.bool(False),
+      variables = cms.PSet(
+        P4Vars,
+        # taken from https://github.com/cms-sw/cmssw/blob/master/PhysicsTools/NanoAOD/python/taus_cff.py#L61 
+        leadTkPtOverTauPt = Var("?leadChargedHadrCand.isNonnull()?leadChargedHadrCand.pt/pt:1",float, doc="pt of the leading track divided by tau pt",precision=10),
+        leadTkDeltaEta = Var("?leadChargedHadrCand.isNonnull()?(leadChargedHadrCand.eta - eta):0",float, doc="eta of the leading track, minus tau eta",precision=8),
+        leadTkDeltaPhi = Var("?leadChargedHadrCand.isNonnull()?deltaPhi(leadChargedHadrCand.phi, phi):0",float, doc="phi of the leading track, minus tau phi",precision=8),
+        # taken from https://github.com/cms-tau-pog/TauMLTools/blob/00bd9416f3198d7aa19ff9799037c14f2fa14514/Production/python/customiseHLT.py#L88 
+        charge = Var("charge", int, doc="electric charge"),
+        vx = Var("vx", float, doc='x coordinate of vertex position'),
+        vy = Var("vy", float, doc='y coordinate of vertex position'),
+        vz = Var("vz", float, doc='z coordinate of vertex position'),
+        pdgId = Var("pdgId", int, doc='PDG identifier'),
+        dz = Var("? leadPFCand.trackRef.isNonnull && leadPFCand.trackRef.isAvailable ? leadPFCand.trackRef.dz : -999 ", float, doc='lead PF Candidate dz'),
+        dzError = Var("? leadPFCand.trackRef.isNonnull && leadPFCand.trackRef.isAvailable ? leadPFCand.trackRef.dzError : -999 ", float, doc='lead PF Candidate dz Error'),
+        decayMode = Var("decayMode", int, doc='tau decay mode'),
+        # # source: DataFormats/TauReco/interface/PFTau.h
+        # ## variables available in PF tau
+        emFraction = Var("emFraction", float, doc = " Ecal/Hcal Cluster Energy"),
+        hcalTotOverPLead = Var("hcalTotOverPLead", float, doc = " total Hcal Cluster E / leadPFChargedHadron P"),
+        signalConeSize = Var("signalConeSize", float, doc = "Size of signal cone"),
+        # variables available in PF jets
+        jetIsValid = Var("jetRef.isNonnull && jetRef.isAvailable", bool, doc = "jet is valid"),
+        # source: DataFormats/JetReco/interface/PFJet.h
+        ## FIXME below does not work - members not found 
+        # chargedHadronEnergy = Var("? jetRef.isNonnull && jetRef.isAvailable ? jetRef.chargedHadronEnergy : -999.", float, doc = "chargedHadronEnergy"),
+        # neutralHadronEnergy = Var("? jetRef.isNonnull && jetRef.isAvailable ? jetRef.neutralHadronEnergy : -999.", float, doc = "neutralHadronEnergy"),
+        # photonEnergy = Var("? jetRef.isNonnull && jetRef.isAvailable ? jetRef.photonEnergy : -999.", float, doc = "photonEnergy"),
+        # muonEnergy = Var("? jetRef.isNonnull && jetRef.isAvailable ? jetRef.muonEnergy : -999.", float, doc = "muonEnergy"),
+        # chargedHadronMultiplicity = Var("? jetRef.isNonnull && jetRef.isAvailable ? jetRef.chargedHadronMultiplicity : -999.", float, doc = "chargedHadronMultiplicity"),
+        # neutralHadronMultiplicity = Var("? jetRef.isNonnull && jetRef.isAvailable ? jetRef.neutralHadronMultiplicity : -999.", float, doc = "neutralHadronMultiplicity"),
+        # photonMultiplicity = Var("? jetRef.isNonnull && jetRef.isAvailable ? jetRef.photonMultiplicity : -999.", float, doc = "photonMultiplicity"),
+        # muonMultiplicity = Var("? jetRef.isNonnull && jetRef.isAvailable ? jetRef.muonMultiplicity : -999.", float, doc = "muonMultiplicity"),
+        # chargedMuEnergy = Var("? jetRef.isNonnull && jetRef.isAvailable ? jetRef.chargedMuEnergy : -999.", float, doc = "chargedMuEnergy"),
+        # neutralEmEnergy = Var("? jetRef.isNonnull && jetRef.isAvailable ? jetRef.neutralEmEnergy : -999.", float, doc = "neutralEmEnergy"),
+        # chargedMultiplicity = Var("? jetRef.isNonnull && jetRef.isAvailable ? jetRef.chargedMultiplicity : -999.", float, doc = "chargedMultiplicity"),
+        # neutralMultiplicity = Var("? jetRef.isNonnull && jetRef.isAvailable ? jetRef.neutralMultiplicity : -999.", float, doc = "neutralMultiplicity"),
+      ),
+      externalVariables = cms.PSet(
+        ## FIXME does not work despite DiMediumTau path using this! 
+        ## https://github.com/cms-sw/cmssw/blob/48e0354ea37072eeacc8237a4a79e7ad34b9b0ae/HLTrigger/Configuration/python/HLT_75e33/modules/hltHpsSelectedPFTausMediumDitauWPDeepTau_cfi.py#L6
+        deepTauVSjet = ExtVar(cms.InputTag("hltHpsPFTauDeepTauProducer","VSjet"), float, doc="deeptau VSjet", precision=10),
+      ),
+)


### PR DESCRIPTION
#### PR description:

This adds the hltHpsPFTau objects to the HLT Nano introduced in https://github.com/cms-sw/cmssw/pull/48091
This is based on the [HLT nano ntupler config from the Tau POG](https://github.com/cms-tau-pog/TauMLTools/blob/00bd9416f3198d7aa19ff9799037c14f2fa14514/Production/python/customiseHLT.py#L88) and the [central tau nano](https://github.com/cms-sw/cmssw/blob/master/PhysicsTools/NanoAOD/python/taus_cff.py#L61).

One thing I did not manage to add are the DeepTau scores. I tried the same approach as done for the [Btagging scores of PFJets](https://github.com/cms-sw/cmssw/blob/0455dbf9d25a0d3b2acdfb4c7a085db1f41e46a9/HLTrigger/NGTScouting/python/hltJets_cfi.py#L25) using `ExtVar`, but CMSSW complains it cannot find the collection `"hltHpsPFTauDeepTauProducer","VSjet"`  despite this being produced in the [HPSTau HLT path](https://github.com/cms-sw/cmssw/blob/0455dbf9d25a0d3b2acdfb4c7a085db1f41e46a9/HLTrigger/Configuration/python/HLT_75e33/modules/hltHpsSelectedPFTausMediumDitauWPDeepTau_cfi.py#L6). I left the code commented for review/testing.

Apart from the DeepTau score the rest works fine!

FYI @brallmond @kandrosov 

#### PR validation:

Tested with the HLT nano commands. 
I first produced a new FEVT file with re-run L1:
```bash
cmsDriver.py Phase2 -s L1,L1TrackTrigger \                          
    --conditions auto:phase2_realistic_T33 \
    --geometry ExtendedRun4D110 \                        
    --era Phase2C17I13M9 \                    
    --eventcontent FEVTDEBUGHLT \      
    --datatier GEN-SIM-DIGI-RAW-MINIAOD \                                                     
    --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000,Configuration/DataProcessing/Utils.addMonitoring,L1Trigger/Configuration/customisePhase2FEVTDEBUGHLT.customisePhase2FEVTDEBUGHLT,L1Trigger/Configuration/customisePhase2TTOn110.customisePhase2TTOn110 \
    --filein /store/mc/Phase2Spring24DIGIRECOMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_AllTP_140X_mcRun4_realistic_v4-v1/2560000/11d1f6f0-5f03-421e-90c7-b5815197fc85.root \
    --fileout file:output_Phase2_L1T.root \                 
    --python_filename rerunL1_cfg.py \
    --inputCommands="keep *, drop l1tPFJets_*_*_*, drop l1tTrackerMuons_l1tTkMuonsGmt*_*_HLT" \                   
    --outputCommands="drop l1tTrackerMuons_l1tTkMuonsGmt*_*_HLT" \
    --mc \                                                                  
    -n 1 --nThreads 1

```

and then ran the HLT nano:
```bash
cmsDriver.py Phase2 -s L1P2GT,HLT:NGTScouting,NANO:@NGTScouting \   
             --processName=HLTX \       
             --conditions auto:phase2_realistic_T33 \
             --geometry ExtendedRun4D110 \
             --era Phase2C17I13M9 \
             --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000 \
             --datatier NANOAODSIM \                                                                                                                                                                                                                                                
             --eventcontent NANOAODSIM \                                                                                                                                                             
             --filein=file:output_Phase2_L1T.root \
             --mc \               
             --inputCommands="keep *, drop *_hlt*_*_HLT, drop triggerTriggerFilterObjectWithRefs_l1t*_*_HLT" \
             -n -1 \                                          
             --customise_commands='process.options.wantSummary = True' \
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

No backport needed.