### PR TITLE
MTD reconstruction: TrackExtender code cleanup

### DIFF
--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -782,8 +782,10 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
   const auto& bs = ev.get(bsToken_);
 
   bool vtxConstraint(false);
-  auto const& vtxs = ev.get(vtxToken_);
+
+  VertexCollection vtxs;
   if (useVertex_) {
+    vtxs = ev.get(vtxToken_);
     if (!vtxs.empty()) {
       vtxConstraint = true;
     }


### PR DESCRIPTION
#### PR description:

This PR proposes two updates of the ```TrackExtenderWithMTD``` class:

- removal of any reference to simulated objects, a remnant of TDR time studies. Now this is a pure reconstruction module;
- update of the so far unused primary vertex constraint logic for track-hit matching. Up to now only the leading PV was considered, with a analysis-like selection of matching along z, now all PVs are used, checking the track-vertex link according to vertex reconstruction.

This second part is not used, and is not usable with the existing schedule, where the extender is an input for PV reconstruction. But it could be potentially used for a second run, or on top of the 3Dt PVs if the schedule is modified.
As the functionality is already present, it is simply adapted to a wider possible use, deferring its detailed validation though to the case this is really studied. 

#### PR validation:

Code compiles and runs on basic RelVal wfs.