### PR TITLE
Phase2-hgx364P2 Change the default Phase2 scenario to Run4D121 til V19 is fully active

### DIFF
--- a/Configuration/Geometry/README.md
+++ b/Configuration/Geometry/README.md
@@ -194,7 +194,7 @@ Several detector combinations have been generated:
 * D107 = T32+C17+M14+I17+O9+F8
 * D108 = T35+C19+M14+I17+O9+F8
 * D109 = T35+C24+M14+I17+O9+F8
-* D110 = T35+C18+M14+I17+O9+F8 (Current Phase-2 baseline from CMSSW_14_1_0_pre2)
+* D110 = T35+C18+M14+I17+O9+F8
 * D111 = T36+C24+M14+I17+O9+F8
 * D112 = T37+C24+M14+I17+O9+F8
 * D113 = T38+C24+M14+I17+O9+F8
@@ -205,6 +205,6 @@ Several detector combinations have been generated:
 * D118 = T35+C25+M15+I19+O10+F9
 * D119 = T35+C25+M15+I20+O10+F9
 * D120 = T35+C26+M16+I20+O10+F9
-* D121 = T35+C25+M16+I18+O10+F9
+* D121 = T35+C25+M16+I18+O10+F9  (Current Phase-2 baseline from CMSSW_15_1_0_pre4)
 * D122 = T35+C27+M16+I18+O10+F9 
 * D123 = T35+C28+M16+I18+O10+F9 

--- a/Configuration/Geometry/python/defaultPhase2ConditionsEra_cff.py
+++ b/Configuration/Geometry/python/defaultPhase2ConditionsEra_cff.py
@@ -2,7 +2,7 @@ from Configuration.PyReleaseValidation.upgradeWorkflowComponents import upgradeP
 from Configuration.AlCa.autoCond import autoCond
 from Configuration.StandardSequences.Eras import eras
 
-DEFAULT_VERSION = "Run4D110"
+DEFAULT_VERSION = "Run4D121"
 
 def get_era_and_conditions(version_key):
     """Retrieve the era and global tag for a given version key.


### PR DESCRIPTION
#### PR description:

Change the default Phase2 scenario to Run4D121 til V19 is fully active

#### PR validation:

Use the runTheMatrix test workflows

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special