### PR TITLE
MTD geometry: set manually the unit test geometry scenario to avoid conflicts with tests of other scenarios

### DIFF
--- a/Geometry/MTDCommonData/python/GeometryDD4hepExtendedRun4MTDDefaultReco_cff.py
+++ b/Geometry/MTDCommonData/python/GeometryDD4hepExtendedRun4MTDDefaultReco_cff.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+from Geometry.MTDCommonData.defaultMTDConditionsEra_cff import MTD_DEFAULT_VERSION
+
+reco_dd4hep_geometry_import_stmt = f"from Configuration.Geometry.GeometryDD4hepExtended{MTD_DEFAULT_VERSION}Reco_cff import *"
+exec(reco_dd4hep_geometry_import_stmt)

--- a/Geometry/MTDCommonData/python/GeometryDD4hepExtendedRun4MTDDefault_cff.py
+++ b/Geometry/MTDCommonData/python/GeometryDD4hepExtendedRun4MTDDefault_cff.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+from Geometry.MTDCommonData.defaultMTDConditionsEra_cff import MTD_DEFAULT_VERSION
+
+dd4hep_geometry_import_stmt = f"from Configuration.Geometry.GeometryDD4hepExtended{MTD_DEFAULT_VERSION}_cff import *"
+exec(dd4hep_geometry_import_stmt)

--- a/Geometry/MTDCommonData/python/GeometryExtendedRun4MTDDefaultReco_cff.py
+++ b/Geometry/MTDCommonData/python/GeometryExtendedRun4MTDDefaultReco_cff.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+from Geometry.MTDCommonData.defaultMTDConditionsEra_cff import MTD_DEFAULT_VERSION
+
+reco_geometry_import_stmt = f"from Configuration.Geometry.GeometryExtended{MTD_DEFAULT_VERSION}Reco_cff import *"
+exec(reco_geometry_import_stmt)

--- a/Geometry/MTDCommonData/python/GeometryExtendedRun4MTDDefault_cff.py
+++ b/Geometry/MTDCommonData/python/GeometryExtendedRun4MTDDefault_cff.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+from Geometry.MTDCommonData.defaultMTDConditionsEra_cff import MTD_DEFAULT_VERSION
+
+geometry_import_stmt = f"from Configuration.Geometry.GeometryExtended{MTD_DEFAULT_VERSION}_cff import *"
+exec(geometry_import_stmt)

--- a/Geometry/MTDCommonData/python/defaultMTDConditionsEra_cff.py
+++ b/Geometry/MTDCommonData/python/defaultMTDConditionsEra_cff.py
@@ -1,0 +1,7 @@
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _centralgeo
+
+MTD_DEFAULT_VERSION = "Run4D110"
+
+def check_mtdgeo():
+    if MTD_DEFAULT_VERSION != _centralgeo.DEFAULT_VERSION:
+        print("MTD test geometry scenario ",MTD_DEFAULT_VERSION," different than CMS default ",_centralgeo.DEFAULT_VERSION)

--- a/Geometry/MTDCommonData/test/testMTDinDD4hep.py
+++ b/Geometry/MTDCommonData/test/testMTDinDD4hep.py
@@ -1,7 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
 import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
-_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
+import Geometry.MTDCommonData.defaultMTDConditionsEra_cff as _mtdgeo
+_mtdgeo.check_mtdgeo()
+_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_mtdgeo.MTD_DEFAULT_VERSION)
 from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
 
 process = cms.Process("CompareGeometryTest",_PH2_ERA,dd4hep)
@@ -58,7 +60,7 @@ process.MessageLogger.files.mtdCommonDataDD4hep = cms.untracked.PSet(
 
 process.load("Geometry.MTDNumberingBuilder.mtdTopology_cfi")
 
-process.load('Configuration.Geometry.GeometryDD4hepExtendedRun4DefaultReco_cff')
+process.load('Geometry.MTDCommonData.GeometryDD4hepExtendedRun4MTDDefaultReco_cff')
 
 process.testBTL = cms.EDAnalyzer("DD4hep_TestMTDIdealGeometry",
                                  DDDetector = cms.ESInputTag('',''),

--- a/Geometry/MTDCommonData/test/testMTDinDDD.py
+++ b/Geometry/MTDCommonData/test/testMTDinDDD.py
@@ -1,7 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
 import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
-_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
+import Geometry.MTDCommonData.defaultMTDConditionsEra_cff as _mtdgeo
+_mtdgeo.check_mtdgeo()
+_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_mtdgeo.MTD_DEFAULT_VERSION)
 
 process = cms.Process("CompareGeometryTest", _PH2_ERA)
 
@@ -54,7 +56,7 @@ process.MessageLogger.files.mtdCommonDataDDD = cms.untracked.PSet(
     threshold = cms.untracked.string('INFO')
 )
 
-process.load('Configuration.Geometry.GeometryExtendedRun4Default_cff')
+process.load('Geometry.MTDCommonData.GeometryExtendedRun4MTDDefault_cff')
 
 process.testBTL = cms.EDAnalyzer("TestMTDIdealGeometry",
                                ddTopNodeName = cms.untracked.string('BarrelTimingLayer')

--- a/Geometry/MTDGeometryBuilder/test/mtd_cfg.py
+++ b/Geometry/MTDGeometryBuilder/test/mtd_cfg.py
@@ -1,7 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
 import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
-_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
+import Geometry.MTDCommonData.defaultMTDConditionsEra_cff as _mtdgeo
+_mtdgeo.check_mtdgeo()
+_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_mtdgeo.MTD_DEFAULT_VERSION)
 
 from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
 
@@ -55,7 +57,7 @@ process.MessageLogger.files.mtdGeometryDD4hep = cms.untracked.PSet(
     threshold = cms.untracked.string('INFO')
 )
 
-process.load("Configuration.Geometry.GeometryDD4hepExtendedRun4DefaultReco_cff")
+process.load("Geometry.MTDCommonData.GeometryDD4hepExtendedRun4MTDDefaultReco_cff")
 
 process.Timing = cms.Service("Timing")
 

--- a/Geometry/MTDNumberingBuilder/test/dd4hep_mtd_cfg.py
+++ b/Geometry/MTDNumberingBuilder/test/dd4hep_mtd_cfg.py
@@ -1,7 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
 import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
-_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
+import Geometry.MTDCommonData.defaultMTDConditionsEra_cff as _mtdgeo
+_mtdgeo.check_mtdgeo()
+_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_mtdgeo.MTD_DEFAULT_VERSION)
 
 from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
 
@@ -49,7 +51,7 @@ process.MessageLogger.files.mtdNumberingDD4hep = cms.untracked.PSet(
     threshold = cms.untracked.string('INFO')
 )
 
-process.load("Configuration.Geometry.GeometryDD4hepExtendedRun4DefaultReco_cff")
+process.load("Geometry.MTDCommonData.GeometryDD4hepExtendedRun4MTDDefaultReco_cff")
 
 process.prod = cms.EDAnalyzer("GeometricTimingDetAnalyzer")
 

--- a/Geometry/MTDNumberingBuilder/test/mtd_cfg.py
+++ b/Geometry/MTDNumberingBuilder/test/mtd_cfg.py
@@ -1,7 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
 import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
-_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
+import Geometry.MTDCommonData.defaultMTDConditionsEra_cff as _mtdgeo
+_mtdgeo.check_mtdgeo()
+_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_mtdgeo.MTD_DEFAULT_VERSION)
 
 process = cms.Process("GeometryTest",_PH2_ERA)
 
@@ -47,7 +49,7 @@ process.MessageLogger.files.mtdNumberingDDD = cms.untracked.PSet(
     threshold = cms.untracked.string('INFO')
 )
 
-process.load("Configuration.Geometry.GeometryExtendedRun4DefaultReco_cff")
+process.load("Geometry.MTDCommonData.GeometryExtendedRun4MTDDefaultReco_cff")
 
 process.Timing = cms.Service("Timing")
 

--- a/RecoMTD/DetLayers/test/mtd_cfg.py
+++ b/RecoMTD/DetLayers/test/mtd_cfg.py
@@ -1,7 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
 import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
-_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
+import Geometry.MTDCommonData.defaultMTDConditionsEra_cff as _mtdgeo
+_mtdgeo.check_mtdgeo()
+_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_mtdgeo.MTD_DEFAULT_VERSION)
 from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
 
 process = cms.Process("GeometryTest",_PH2_ERA,dd4hep)
@@ -56,7 +58,7 @@ process.MessageLogger.files.mtdDetLayerGeometry = cms.untracked.PSet(
     threshold = cms.untracked.string('INFO'))
 
 # Choose Tracker Geometry
-process.load("Configuration.Geometry.GeometryDD4hepExtendedRun4DefaultReco_cff")
+process.load("Geometry.MTDCommonData.GeometryDD4hepExtendedRun4MTDDefaultReco_cff")
 process.load("MagneticField.Engine.volumeBasedMagneticField_160812_cfi")
 
 process.Timing = cms.Service("Timing")

--- a/SimG4CMS/Forward/test/python/runMTDSens_DD4hep_cfg.py
+++ b/SimG4CMS/Forward/test/python/runMTDSens_DD4hep_cfg.py
@@ -1,11 +1,13 @@
 import FWCore.ParameterSet.Config as cms
 
 import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
-_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
+import Geometry.MTDCommonData.defaultMTDConditionsEra_cff as _mtdgeo
+_mtdgeo.check_mtdgeo()
+_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_mtdgeo.MTD_DEFAULT_VERSION)
 from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
 process = cms.Process('G4PrintGeometry',_PH2_ERA,dd4hep)
 
-process.load('Configuration.Geometry.GeometryDD4hepExtendedRun4DefaultReco_cff')
+process.load('Geometry.MTDCommonData.GeometryDD4hepExtendedRun4MTDDefaultReco_cff')
 process.load('FWCore.MessageService.MessageLogger_cfi')
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")

--- a/SimG4CMS/Forward/test/python/runMTDSens_cfg.py
+++ b/SimG4CMS/Forward/test/python/runMTDSens_cfg.py
@@ -1,12 +1,14 @@
 import FWCore.ParameterSet.Config as cms
 
 import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
-_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
+import Geometry.MTDCommonData.defaultMTDConditionsEra_cff as _mtdgeo
+_mtdgeo.check_mtdgeo()
+_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_mtdgeo.MTD_DEFAULT_VERSION)
 
 process = cms.Process('G4PrintGeometry', _PH2_ERA)
 
 process.load('FWCore.MessageService.MessageLogger_cfi')
-process.load('Configuration.Geometry.GeometryExtendedRun4DefaultReco_cff')
+process.load('Geometry.MTDCommonData.GeometryExtendedRun4MTDDefaultReco_cff')
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.MessageLogger.cerr.threshold = cms.untracked.string('INFO')


### PR DESCRIPTION
#### PR description:

This PR defines a MTD default geometry scenario that might differ from the CMS baseline, so as to avoid conflicts in tests of new scenarios if the references are not suitably updated. A check of the consistency of CMS and MTD defaults is performed and the results printed.

#### PR validation:

Unit tests correctly run, if the scenario is modified wrt to default a message is printed.