### PR TITLE
Fix crashes in HGCAL HLT/RECO with v19 geometry

### DIFF
--- a/DataFormats/ForwardDetId/interface/HGCalTriggerDetId.h
+++ b/DataFormats/ForwardDetId/interface/HGCalTriggerDetId.h
@@ -26,6 +26,7 @@
 
 class HGCalTriggerDetId : public DetId {
 public:
+  enum waferType { HGCalHD120 = 0, HGCalLD200 = 1, HGCalLD300 = 2, HGCalHD200 = 3 };
   static const int HGCalTriggerCell = 4;
 
   /** Create a null cellid*/
@@ -46,6 +47,8 @@ public:
 
   /// get the type
   int type() const { return (id_ >> kHGCalTypeOffset) & kHGCalTypeMask; }
+  bool lowDensity() const { return ((type() == HGCalLD200) || (type() == HGCalLD300)); }
+  bool highDensity() const { return ((type() == HGCalHD120) || (type() == HGCalHD200)); }
 
   /// get the z-side of the cell (1/-1)
   int zside() const { return (((id_ >> kHGCalZsideOffset) & kHGCalZsideMask) ? -1 : 1); }

--- a/DataFormats/ForwardDetId/interface/HGCalTriggerModuleDetId.h
+++ b/DataFormats/ForwardDetId/interface/HGCalTriggerModuleDetId.h
@@ -18,6 +18,7 @@
    [19:20] Type (0 fine divisions of wafer with 120 mum thick silicon
                  1 coarse divisions of wafer with 200 mum thick silicon
                  2 coarse divisions of wafer with 300 mum thick silicon
+                 3 fine divisions of wafer with 200 mum thick silicon
                  0 fine divisions of scintillators
                  1 coarse divisions of scintillators)
 
@@ -30,6 +31,8 @@
 
 class HGCalTriggerModuleDetId : public DetId {
 public:
+  enum siliconType { HGCalHD120 = 0, HGCalLD200 = 1, HGCalLD300 = 2, HGCalHD200 = 3 };
+  enum tileGranularity { HGCalTileNormal = 0, HGCalTileFine = 1 };
   /** Create a null module id*/
   HGCalTriggerModuleDetId();
   /** Create module id from raw id (0=invalid id) */
@@ -71,6 +74,15 @@ public:
 
   /// get the scintillator panel phi
   int phi() const { return moduleV(); }
+
+  bool isSiliconLowDensity() const {
+    return (!isHScintillator() && ((type() == HGCalLD200) || (type() == HGCalLD300)));
+  }
+  bool isSiliconHighDensity() const {
+    return (!isHScintillator() && ((type() == HGCalHD120) || (type() == HGCalHD200)));
+  }
+  bool isScintillatorFine() const { return (isHScintillator() && (type() == HGCalTileFine)); }
+  bool isScintillatorCoarse() const { return (isHScintillator() && (type() == HGCalTileNormal)); }
 
   /// consistency check : no bits left => no overhead
   bool isHFNose() const { return (triggerSubdetId() == HFNoseTrigger); }

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHGCalRecHitL1Seeded_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHGCalRecHitL1Seeded_cfi.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from ..psets.hgcal_reco_constants_cfi import HGCAL_reco_constants as HGCAL_reco_constants
+from Configuration.Eras.Modifier_phase2_hgcalV19_cff import phase2_hgcalV19
 
 
 hltHGCalRecHitL1Seeded = cms.EDProducer("HGCalRecHitProducer",
@@ -60,3 +61,9 @@ hltHGCalRecHitL1Seeded = cms.EDProducer("HGCalRecHitProducer",
     thicknessCorrection = HGCAL_reco_constants.thicknessCorrection,
     thicknessNoseCorrection = cms.vdouble(1.132, 1.092, 1.084)
 )
+
+phase2_hgcalV19.toModify(hltHGCalRecHitL1Seeded, 
+                         HGCEE_fCPerMIP = cms.vdouble(HGCAL_reco_constants.fcPerMip[0:4]),
+                         HGCHEF_fCPerMIP = cms.vdouble(HGCAL_reco_constants.fcPerMip[4:8]),
+                         HGCHFNose_fCPerMIP = cms.vdouble(1.25, 2.57, 3.88, 2.57),
+                         )

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHGCalRecHitL1Seeded_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHGCalRecHitL1Seeded_cfi.py
@@ -63,7 +63,8 @@ hltHGCalRecHitL1Seeded = cms.EDProducer("HGCalRecHitProducer",
 )
 
 phase2_hgcalV19.toModify(hltHGCalRecHitL1Seeded, 
-                         HGCEE_fCPerMIP = cms.vdouble(HGCAL_reco_constants.fcPerMip[0:4]),
-                         HGCHEF_fCPerMIP = cms.vdouble(HGCAL_reco_constants.fcPerMip[4:8]),
-                         HGCHFNose_fCPerMIP = cms.vdouble(1.25, 2.57, 3.88, 2.57),
+                         HGCEE_fCPerMIP = HGCAL_reco_constants.fcPerMip[0:4],
+                         HGCHEF_fCPerMIP = HGCAL_reco_constants.fcPerMip[4:8],
+                         HGCHFNose_fCPerMIP = [1.25, 2.57, 3.88, 2.57],
+
                          )

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHGCalRecHit_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHGCalRecHit_cfi.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from ..psets.hgcal_reco_constants_cfi import HGCAL_reco_constants as HGCAL_reco_constants
+from Configuration.Eras.Modifier_phase2_hgcalV19_cff import phase2_hgcalV19
 
 hltHGCalRecHit = cms.EDProducer("HGCalRecHitProducer",
     HGCEE_cce = cms.PSet(
@@ -59,3 +60,9 @@ hltHGCalRecHit = cms.EDProducer("HGCalRecHitProducer",
     thicknessCorrection = HGCAL_reco_constants.thicknessCorrection,
     thicknessNoseCorrection = cms.vdouble(1.132, 1.092, 1.084)
 )
+
+phase2_hgcalV19.toModify(hltHGCalRecHit, 
+                         HGCEE_fCPerMIP = cms.vdouble(HGCAL_reco_constants.fcPerMip[0:4]),
+                         HGCHEF_fCPerMIP = cms.vdouble(HGCAL_reco_constants.fcPerMip[4:8]),
+                         HGCHFNose_fCPerMIP = cms.vdouble(1.25, 2.57, 3.88, 2.57),
+                         )

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHGCalRecHit_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHGCalRecHit_cfi.py
@@ -62,7 +62,7 @@ hltHGCalRecHit = cms.EDProducer("HGCalRecHitProducer",
 )
 
 phase2_hgcalV19.toModify(hltHGCalRecHit, 
-                         HGCEE_fCPerMIP = cms.vdouble(HGCAL_reco_constants.fcPerMip[0:4]),
-                         HGCHEF_fCPerMIP = cms.vdouble(HGCAL_reco_constants.fcPerMip[4:8]),
-                         HGCHFNose_fCPerMIP = cms.vdouble(1.25, 2.57, 3.88, 2.57),
+                         HGCEE_fCPerMIP = HGCAL_reco_constants.fcPerMip[0:4],
+                         HGCHEF_fCPerMIP = HGCAL_reco_constants.fcPerMip[4:8],
+                         HGCHFNose_fCPerMIP = [1.25, 2.57, 3.88, 2.57],
                          )

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHGCalUncalibRecHitL1Seeded_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHGCalUncalibRecHitL1Seeded_cfi.py
@@ -63,13 +63,13 @@ from Configuration.ProcessModifiers.ticl_v5_cff import ticl_v5
 ticl_v5.toModify(hltHGCalUncalibRecHitL1Seeded, computeLocalTime = cms.bool(True))
 
 _modifiedHGCEEConfig_v19 = hltHGCalUncalibRecHitL1Seeded.HGCEEConfig.clone(
-    fCPerMIP = cms.vdouble(HGCAL_reco_constants.fcPerMip[0:4])
+    fCPerMIP = HGCAL_reco_constants.fcPerMip[0:4]
 )
 _modifiedHGCHEFConfig_v19 = hltHGCalUncalibRecHitL1Seeded.HGCHEFConfig.clone(
-    fCPerMIP = cms.vdouble(HGCAL_reco_constants.fcPerMip[4:8])
+    fCPerMIP = HGCAL_reco_constants.fcPerMip[4:8]
 )
 _modifiedHGCHFNoseConfig_v19 = hltHGCalUncalibRecHitL1Seeded.HGCHFNoseConfig.clone(
-    fCPerMIP = cms.vdouble(1.25, 2.57, 3.88, 2.57)
+    fCPerMIP = [1.25, 2.57, 3.88, 2.57]
 )
 
 phase2_hgcalV19.toModify(

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHGCalUncalibRecHitL1Seeded_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHGCalUncalibRecHitL1Seeded_cfi.py
@@ -78,4 +78,3 @@ phase2_hgcalV19.toModify(
     HGCHEFConfig = _modifiedHGCHEFConfig_v19,
     HGCHFNoseConfig = _modifiedHGCHFNoseConfig_v19
 )
-

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHGCalUncalibRecHitL1Seeded_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHGCalUncalibRecHitL1Seeded_cfi.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from ..psets.hgcal_reco_constants_cfi import HGCAL_reco_constants as HGCAL_reco_constants
+from Configuration.Eras.Modifier_phase2_hgcalV19_cff import phase2_hgcalV19
 
 hltHGCalUncalibRecHitL1Seeded = cms.EDProducer("HGCalUncalibRecHitProducer",
     HGCEEConfig = cms.PSet(
@@ -60,3 +61,21 @@ hltHGCalUncalibRecHitL1Seeded = cms.EDProducer("HGCalUncalibRecHitProducer",
 
 from Configuration.ProcessModifiers.ticl_v5_cff import ticl_v5
 ticl_v5.toModify(hltHGCalUncalibRecHitL1Seeded, computeLocalTime = cms.bool(True))
+
+_modifiedHGCEEConfig_v19 = hltHGCalUncalibRecHitL1Seeded.HGCEEConfig.clone(
+    fCPerMIP = cms.vdouble(HGCAL_reco_constants.fcPerMip[0:4])
+)
+_modifiedHGCHEFConfig_v19 = hltHGCalUncalibRecHitL1Seeded.HGCHEFConfig.clone(
+    fCPerMIP = cms.vdouble(HGCAL_reco_constants.fcPerMip[4:8])
+)
+_modifiedHGCHFNoseConfig_v19 = hltHGCalUncalibRecHitL1Seeded.HGCHFNoseConfig.clone(
+    fCPerMIP = cms.vdouble(1.25, 2.57, 3.88, 2.57)
+)
+
+phase2_hgcalV19.toModify(
+    hltHGCalUncalibRecHitL1Seeded,
+    HGCEEConfig = _modifiedHGCEEConfig_v19,
+    HGCHEFConfig = _modifiedHGCHEFConfig_v19,
+    HGCHFNoseConfig = _modifiedHGCHFNoseConfig_v19
+)
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHGCalUncalibRecHit_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHGCalUncalibRecHit_cfi.py
@@ -80,4 +80,3 @@ phase2_hgcalV19.toModify(
     HGCHEFConfig = _modifiedHGCHEFConfig_v19,
     HGCHFNoseConfig = _modifiedHGCHFNoseConfig_v19
 )
-

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHGCalUncalibRecHit_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHGCalUncalibRecHit_cfi.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from ..psets.hgcal_reco_constants_cfi import HGCAL_reco_constants as HGCAL_reco_constants
+from Configuration.Eras.Modifier_phase2_hgcalV19_cff import phase2_hgcalV19
 
 
 hltHGCalUncalibRecHit = cms.EDProducer("HGCalUncalibRecHitProducer",
@@ -61,3 +62,22 @@ hltHGCalUncalibRecHit = cms.EDProducer("HGCalUncalibRecHitProducer",
 
 from Configuration.ProcessModifiers.ticl_v5_cff import ticl_v5
 ticl_v5.toModify(hltHGCalUncalibRecHit, computeLocalTime = cms.bool(True))
+
+
+_modifiedHGCEEConfig_v19 = hltHGCalUncalibRecHit.HGCEEConfig.clone(
+    fCPerMIP = cms.vdouble(HGCAL_reco_constants.fcPerMip[0:4])
+)
+_modifiedHGCHEFConfig_v19 = hltHGCalUncalibRecHit.HGCHEFConfig.clone(
+    fCPerMIP = cms.vdouble(HGCAL_reco_constants.fcPerMip[4:8])
+)
+_modifiedHGCHFNoseConfig_v19 = hltHGCalUncalibRecHit.HGCHFNoseConfig.clone(
+    fCPerMIP = cms.vdouble(1.25, 2.57, 3.88, 2.57)
+)
+
+phase2_hgcalV19.toModify(
+    hltHGCalUncalibRecHit,
+    HGCEEConfig = _modifiedHGCEEConfig_v19,
+    HGCHEFConfig = _modifiedHGCHEFConfig_v19,
+    HGCHFNoseConfig = _modifiedHGCHFNoseConfig_v19
+)
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHGCalUncalibRecHit_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHGCalUncalibRecHit_cfi.py
@@ -65,13 +65,13 @@ ticl_v5.toModify(hltHGCalUncalibRecHit, computeLocalTime = cms.bool(True))
 
 
 _modifiedHGCEEConfig_v19 = hltHGCalUncalibRecHit.HGCEEConfig.clone(
-    fCPerMIP = cms.vdouble(HGCAL_reco_constants.fcPerMip[0:4])
+    fCPerMIP = HGCAL_reco_constants.fcPerMip[0:4]
 )
 _modifiedHGCHEFConfig_v19 = hltHGCalUncalibRecHit.HGCHEFConfig.clone(
-    fCPerMIP = cms.vdouble(HGCAL_reco_constants.fcPerMip[4:8])
+    fCPerMIP = HGCAL_reco_constants.fcPerMip[4:8]
 )
 _modifiedHGCHFNoseConfig_v19 = hltHGCalUncalibRecHit.HGCHFNoseConfig.clone(
-    fCPerMIP = cms.vdouble(1.25, 2.57, 3.88, 2.57)
+    fCPerMIP = [1.25, 2.57, 3.88, 2.57]
 )
 
 phase2_hgcalV19.toModify(

--- a/HLTrigger/Configuration/python/HLT_75e33/psets/HGCAL_chargeCollectionEfficiencies_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/psets/HGCAL_chargeCollectionEfficiencies_cfi.py
@@ -5,4 +5,4 @@ HGCAL_chargeCollectionEfficiencies = cms.PSet(
     values = cms.vdouble(1.0, 1.0, 1.0)
 )
 
-phase2_hgcalV19.toModify(HGCAL_chargeCollectionEfficiencies, values =  cms.vdouble(1.0, 1.0,1.0,1.0))
+phase2_hgcalV19.toModify(HGCAL_chargeCollectionEfficiencies, values =  [1.0, 1.0,1.0,1.0])

--- a/HLTrigger/Configuration/python/HLT_75e33/psets/HGCAL_chargeCollectionEfficiencies_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/psets/HGCAL_chargeCollectionEfficiencies_cfi.py
@@ -1,5 +1,8 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Modifier_phase2_hgcalV19_cff import phase2_hgcalV19
 
 HGCAL_chargeCollectionEfficiencies = cms.PSet(
     values = cms.vdouble(1.0, 1.0, 1.0)
 )
+
+phase2_hgcalV19.toModify(HGCAL_chargeCollectionEfficiencies, values =  cms.vdouble(1.0, 1.0,1.0,1.0))

--- a/HLTrigger/Configuration/python/HLT_75e33/psets/HGCAL_noise_fC_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/psets/HGCAL_noise_fC_cfi.py
@@ -9,4 +9,4 @@ HGCAL_noise_fC = cms.PSet(
     values = cms.vdouble(0.32041011999999996, 0.384492144, 0.32041011999999996)
 )
 
-phase2_hgcalV19.toModify(HGCAL_noise_fC , values = cms.vdouble(0.32041011999999996, 0.384492144, 0.32041011999999996, 0.384492144))
+phase2_hgcalV19.toModify(HGCAL_noise_fC , values = [0.32041011999999996, 0.384492144, 0.32041011999999996, 0.384492144])

--- a/HLTrigger/Configuration/python/HLT_75e33/psets/HGCAL_noise_fC_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/psets/HGCAL_noise_fC_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Modifier_phase2_hgcalV19_cff import phase2_hgcalV19
 
 HGCAL_noise_fC = cms.PSet(
     doseMap = cms.string(''),
@@ -7,3 +8,5 @@ HGCAL_noise_fC = cms.PSet(
     scaleByDoseFactor = cms.double(1),
     values = cms.vdouble(0.32041011999999996, 0.384492144, 0.32041011999999996)
 )
+
+phase2_hgcalV19.toModify(HGCAL_noise_fC , values = cms.vdouble(0.32041011999999996, 0.384492144, 0.32041011999999996, 0.384492144))

--- a/HLTrigger/Configuration/python/HLT_75e33/psets/hgcal_reco_constants_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/psets/hgcal_reco_constants_cfi.py
@@ -56,6 +56,7 @@ phase2_hgcalV19.toModify(HGCAL_reco_constants,
                                  2000.0, 2400.
                              ),
                          numberOfThicknesses = cms.uint32(4),
-                         maxNumberOfThickIndices = cms.uint32(8)
+                         maxNumberOfThickIndices = cms.uint32(8),
+                         thresholdW0 = cms.vdouble(2.9, 2.9, 2.9, 2.9),
                          )
 

--- a/HLTrigger/Configuration/python/HLT_75e33/psets/hgcal_reco_constants_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/psets/hgcal_reco_constants_cfi.py
@@ -46,16 +46,16 @@ HGCAL_reco_constants = cms.PSet(
 
 
 phase2_hgcalV19.toModify(HGCAL_reco_constants, 
-                         thicknessCorrection = cms.vdouble(0.75, 0.76, 0.75, 0.76, 0.85, 0.85, 0.84, 0.85) , #CEE_12_HD, CEE_200_LD, CEE_300_LD, CEE_200_HD,CEH_12_HD, CEH_200_LD, CEH_300_LD, CEH_200_HD,
-                         fcPerMip = cms.vdouble(
-                                 2.06, 3.43, 5.15, 3.43, 2.06, 3.43,
-                                 5.15, 3.43
-                             ),
-                         noises = cms.vdouble(
-                                 2000.0, 2400.0, 2000.0, 2400.0, 2000.0, 2400.0,
-                                 2000.0, 2400.
-                             ),
-                         numberOfThicknesses = cms.uint32(4),
-                         maxNumberOfThickIndices = cms.uint32(8),
-                         thresholdW0 = cms.vdouble(2.9, 2.9, 2.9, 2.9),
+                         thicknessCorrection = [0.75, 0.76, 0.75, 0.76, 0.85, 0.85, 0.84, 0.85] , #CEE_12_HD, CEE_200_LD, CEE_300_LD, CEE_200_HD,CEH_12_HD, CEH_200_LD, CEH_300_LD, CEH_200_HD,
+                         fcPerMip = 
+                                 [2.06, 3.43, 5.15, 3.43, 2.06, 3.43,
+                                 5.15, 3.43]
+                             ,
+                         noises = 
+                                 [2000.0, 2400.0, 2000.0, 2400.0, 2000.0, 2400.0,
+                                 2000.0, 2400.]
+                             ,
+                         numberOfThicknesses = 4,
+                         maxNumberOfThickIndices = 8,
+                         thresholdW0 = [2.9, 2.9, 2.9, 2.9],
                          )

--- a/HLTrigger/Configuration/python/HLT_75e33/psets/hgcal_reco_constants_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/psets/hgcal_reco_constants_cfi.py
@@ -59,4 +59,3 @@ phase2_hgcalV19.toModify(HGCAL_reco_constants,
                          maxNumberOfThickIndices = cms.uint32(8),
                          thresholdW0 = cms.vdouble(2.9, 2.9, 2.9, 2.9),
                          )
-

--- a/HLTrigger/Configuration/python/HLT_75e33/psets/hgcal_reco_constants_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/psets/hgcal_reco_constants_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Modifier_phase2_hgcalV19_cff import phase2_hgcalV19
 
 HGCAL_reco_constants = cms.PSet(
     dEdXweights = cms.vdouble(
@@ -38,6 +39,22 @@ HGCAL_reco_constants = cms.PSet(
       referenceXtalk = cms.double(-1),
       noise_MIP = cms.double(0.01)
     ),
+    numberOfThicknesses = cms.uint32(3)
 
 )
+
+
+
+phase2_hgcalV19.toModify(HGCAL_reco_constants, 
+                         thicknessCorrection = cms.vdouble(0.75, 0.76, 0.75, 0.76, 0.85, 0.85, 0.84, 0.85) , #CEE_12_HD, CEE_200_LD, CEE_300_LD, CEE_200_HD,CEH_12_HD, CEH_200_LD, CEH_300_LD, CEH_200_HD,
+                         fcPerMip = cms.vdouble(
+                                 2.06, 3.43, 5.15, 3.43, 2.06, 3.43,
+                                 5.15, 3.43
+                             ),
+                         noises = cms.vdouble(
+                                 2000.0, 2400.0, 2000.0, 2400.0, 2000.0, 2400.0,
+                                 2000.0, 2400.
+                             ),
+                         numberOfThicknesses = cms.uint32(4)
+                         )
 

--- a/HLTrigger/Configuration/python/HLT_75e33/psets/hgcal_reco_constants_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/psets/hgcal_reco_constants_cfi.py
@@ -55,6 +55,7 @@ phase2_hgcalV19.toModify(HGCAL_reco_constants,
                                  2000.0, 2400.0, 2000.0, 2400.0, 2000.0, 2400.0,
                                  2000.0, 2400.
                              ),
-                         numberOfThicknesses = cms.uint32(4)
+                         numberOfThicknesses = cms.uint32(4),
+                         maxNumberOfThickIndices = cms.uint32(8)
                          )
 

--- a/HLTrigger/Configuration/python/HLT_75e33/psets/hgceeDigitizer_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/psets/hgceeDigitizer_cfi.py
@@ -66,4 +66,4 @@ hgceeDigitizer = cms.PSet(
     verbosity = cms.untracked.uint32(0)
 )
 
-phase2_hgcalV19.toModify(hgceeDigitizer.digiCfg.feCfg, tdcForToAOnset_fC= cms.vdouble(12.,12.,12.,12.))
+phase2_hgcalV19.toModify(hgceeDigitizer.digiCfg.feCfg, tdcForToAOnset_fC= [12.,12.,12.,12.])

--- a/HLTrigger/Configuration/python/HLT_75e33/psets/hgceeDigitizer_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/psets/hgceeDigitizer_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Modifier_phase2_hgcalV19_cff import phase2_hgcalV19
 
 hgceeDigitizer = cms.PSet(
     NoiseGeneration_Method = cms.bool(True),
@@ -64,3 +65,5 @@ hgceeDigitizer = cms.PSet(
     useAllChannels = cms.bool(True),
     verbosity = cms.untracked.uint32(0)
 )
+
+phase2_hgcalV19.toModify(hgceeDigitizer.digiCfg.feCfg, tdcForToAOnset_fC= cms.vdouble(12.,12.,12.,12.))

--- a/HLTrigger/Configuration/python/HLT_75e33/psets/hgchebackDigitizer_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/psets/hgchebackDigitizer_cfi.py
@@ -64,4 +64,4 @@ hgchebackDigitizer = cms.PSet(
     verbosity = cms.untracked.uint32(0)
 )
 
-phase2_hgcalV19.toModify(hgchebackDigitizer.digiCfg.feCfg, tdcForToAOnset_fC = cms.vdouble(12.,12.,12.,12.)) 
+phase2_hgcalV19.toModify(hgchebackDigitizer.digiCfg.feCfg, tdcForToAOnset_fC = [12.,12.,12.,12.]) 

--- a/HLTrigger/Configuration/python/HLT_75e33/psets/hgchebackDigitizer_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/psets/hgchebackDigitizer_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Modifier_phase2_hgcalV19_cff import phase2_hgcalV19
 
 hgchebackDigitizer = cms.PSet(
     NoiseGeneration_Method = cms.bool(True),
@@ -62,3 +63,5 @@ hgchebackDigitizer = cms.PSet(
     useAllChannels = cms.bool(True),
     verbosity = cms.untracked.uint32(0)
 )
+
+phase2_hgcalV19.toModify(hgchebackDigitizer.digiCfg.feCfg, tdcForToAOnset_fC = cms.vdouble(12.,12.,12.,12.)) 

--- a/HLTrigger/Configuration/python/HLT_75e33/psets/hgchefrontDigitizer_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/psets/hgchefrontDigitizer_cfi.py
@@ -65,4 +65,4 @@ hgchefrontDigitizer = cms.PSet(
     verbosity = cms.untracked.uint32(0)
 )
 
-phase2_hgcalV19.toModify(hgchefrontDigitizer.digiCfg.feCfg, tdcForToAOnset_fC = cms.vdouble(12.,12.,12.,12.))
+phase2_hgcalV19.toModify(hgchefrontDigitizer.digiCfg.feCfg, tdcForToAOnset_fC = [12.,12.,12.,12.])

--- a/HLTrigger/Configuration/python/HLT_75e33/psets/hgchefrontDigitizer_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/psets/hgchefrontDigitizer_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Modifier_phase2_hgcalV19_cff import phase2_hgcalV19
 
 hgchefrontDigitizer = cms.PSet(
     NoiseGeneration_Method = cms.bool(True),
@@ -63,3 +64,5 @@ hgchefrontDigitizer = cms.PSet(
     useAllChannels = cms.bool(True),
     verbosity = cms.untracked.uint32(0)
 )
+
+phase2_hgcalV19.toModify(hgchefrontDigitizer.digiCfg.feCfg, tdcForToAOnset_fC = cms.vdouble(12.,12.,12.,12.))

--- a/L1Trigger/L1THGCal/interface/HGCalCoarseTriggerCellMapping.h
+++ b/L1Trigger/L1THGCal/interface/HGCalCoarseTriggerCellMapping.h
@@ -26,7 +26,7 @@ private:
   static const std::map<int, int> kSplit_;
   static const std::map<int, int> kSplit_Scin_;
   static constexpr int kSTCidMaskInv_ = ~0xf;
-  static constexpr int kNThicknesses_ = 4;
+  static constexpr int kNThicknesses_ = 5;  // 4 silicon types + 1 for scintillator
   static constexpr int kNHGCalLayersMax_ = 52;
 
   static constexpr int kSplit_Coarse_ = 0;

--- a/L1Trigger/L1THGCal/interface/HGCalCoarseTriggerCellMapping.h
+++ b/L1Trigger/L1THGCal/interface/HGCalCoarseTriggerCellMapping.h
@@ -13,8 +13,11 @@ public:
   std::vector<uint32_t> getConstituentTriggerCells(uint32_t ctcId) const;
   GlobalPoint getCoarseTriggerCellPosition(uint32_t ctcId) const;
   uint32_t getCoarseTriggerCellId(uint32_t detid) const;
-  void checkSizeValidity(int ctcSize) const;
-  void setGeometry(const HGCalTriggerGeometryBase* const geom) { triggerTools_.setGeometry(geom); }
+  void checkSizeValidity() const;
+  void setGeometry(const HGCalTriggerGeometryBase* const geom) {
+    triggerTools_.setGeometry(geom);
+    checkSizeValidity();
+  }
 
   static constexpr int kCTCsizeCoarse_ = 16;
   static constexpr int kCTCsizeMid_ = 8;
@@ -26,7 +29,6 @@ private:
   static const std::map<int, int> kSplit_;
   static const std::map<int, int> kSplit_Scin_;
   static constexpr int kSTCidMaskInv_ = ~0xf;
-  static constexpr int kNThicknesses_ = 5;  // 4 silicon types + 1 for scintillator
   static constexpr int kNHGCalLayersMax_ = 52;
 
   static constexpr int kSplit_Coarse_ = 0;

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
@@ -42,6 +42,7 @@ public:
   GlobalPoint getTCPosition(const DetId& id) const;
   unsigned layers(ForwardSubdetector type) const;
   unsigned layers(DetId::Detector type) const;
+  unsigned nSiWaferTypes() const;
   unsigned layer(const DetId&) const;
   unsigned layerWithOffset(const DetId&) const;
   bool isEm(const DetId&) const;
@@ -86,8 +87,6 @@ public:
   DetId simToReco(const DetId&, const HGCalTopology&) const;
   unsigned triggerLayer(const unsigned id) const { return geom_->triggerLayer(id); }
 
-  static constexpr unsigned kScintillatorPseudoThicknessIndex_ = 4;
-
   enum SubDetectorType {
     hgcal_silicon_CEE,
     hgcal_silicon_CEH,
@@ -102,6 +101,7 @@ private:
   unsigned bhLayers_;
   unsigned noseLayers_;
   unsigned totalLayers_;
+  unsigned scintillatorPseudoThicknessIndex_;
 };
 
 #endif

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerTools.h
@@ -49,6 +49,8 @@ public:
   bool isSilicon(const DetId&) const;
   bool isScintillator(const DetId& id) const { return !isSilicon(id); }
   bool isNose(const DetId&) const;
+  bool isSiliconHighDensity(const DetId&) const;
+  bool isSiliconLowDensity(const DetId&) const;
   int zside(const DetId&) const;
   int thicknessIndex(const DetId&) const;
 
@@ -84,7 +86,7 @@ public:
   DetId simToReco(const DetId&, const HGCalTopology&) const;
   unsigned triggerLayer(const unsigned id) const { return geom_->triggerLayer(id); }
 
-  static constexpr unsigned kScintillatorPseudoThicknessIndex_ = 3;
+  static constexpr unsigned kScintillatorPseudoThicknessIndex_ = 4;
 
   enum SubDetectorType {
     hgcal_silicon_CEE,

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorCoarsenerImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorCoarsenerImpl.h
@@ -23,7 +23,6 @@ private:
   HGCalTriggerTools triggerTools_;
   bool fixedDataSizePerHGCROC_;
   HGCalCoarseTriggerCellMapping coarseTCmapping_;
-  static constexpr int kHighDensityThickness_ = 0;
 
   HGCalTriggerCellCalibration calibration_;
   HGCalVFECompressionImpl vfeCompression_;

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorProcessorSelection.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorProcessorSelection.h
@@ -33,7 +33,6 @@ private:
   bool fixedDataSizePerHGCROC_;
   bool allTrigCellsInTrigSums_;
   std::vector<unsigned> coarsenTriggerCells_;
-  static constexpr int kHighDensityThickness_ = 0;
   static constexpr int kNSubDetectors_ = 3;
 
   std::vector<SelectionType> selectionType_;

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorSuperTriggerCellImpl.h
@@ -34,7 +34,6 @@ private:
   };
 
   EnergyDivisionType energyDivisionType_;
-  static constexpr int kHighDensityThickness_ = 0;
   static constexpr int kOddNumberMask_ = 1;
 
   HGCalTriggerTools triggerTools_;

--- a/L1Trigger/L1THGCal/interface/veryfrontend/HGCalVFESummationImpl.h
+++ b/L1Trigger/L1THGCal/interface/veryfrontend/HGCalVFESummationImpl.h
@@ -14,13 +14,16 @@ class HGCalVFESummationImpl {
 public:
   HGCalVFESummationImpl(const edm::ParameterSet& conf);
 
-  void setGeometry(const HGCalTriggerGeometryBase* const geom) { triggerTools_.setGeometry(geom); }
+  void setGeometry(const HGCalTriggerGeometryBase* const geom) {
+    triggerTools_.setGeometry(geom);
+    checkSizeValidity();
+  }
+  void checkSizeValidity() const;
   void triggerCellSums(const std::vector<std::pair<DetId, uint32_t> >&, std::unordered_map<uint32_t, uint32_t>&);
 
 private:
   double lsb_silicon_fC_;
   double lsb_scintillator_MIP_;
-  uint32_t nThickness_;
   std::vector<double> thresholds_silicon_;
   double threshold_scintillator_;
 

--- a/L1Trigger/L1THGCal/interface/veryfrontend/HGCalVFESummationImpl.h
+++ b/L1Trigger/L1THGCal/interface/veryfrontend/HGCalVFESummationImpl.h
@@ -5,6 +5,7 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
 
+#include <cstdint>
 #include <vector>
 #include <utility>
 #include <unordered_map>
@@ -19,6 +20,7 @@ public:
 private:
   double lsb_silicon_fC_;
   double lsb_scintillator_MIP_;
+  uint32_t nThickness_;
   std::vector<double> thresholds_silicon_;
   double threshold_scintillator_;
 

--- a/L1Trigger/L1THGCal/plugins/concentrator/HGCalConcentratorProcessorSelection.cc
+++ b/L1Trigger/L1THGCal/plugins/concentrator/HGCalConcentratorProcessorSelection.cc
@@ -89,11 +89,11 @@ void HGCalConcentratorProcessorSelection::run(const edm::Handle<l1t::HGCalTrigge
     std::vector<l1t::HGCalTriggerSums> trigSumsVecOutput;
     std::vector<l1t::HGCalConcentratorData> ae_EncodedLayerOutput;
 
-    int thickness = triggerTools_.thicknessIndex(module_trigcell.second.at(0).detId());
+    bool isHighDensity = triggerTools_.isSiliconHighDensity(module_trigcell.second.at(0).detId());
 
     HGCalTriggerTools::SubDetectorType subdet = triggerTools_.getSubDetectorType(module_trigcell.second.at(0).detId());
 
-    if (coarsenTriggerCells_[subdet] || (fixedDataSizePerHGCROC_ && thickness > kHighDensityThickness_)) {
+    if (coarsenTriggerCells_[subdet] || (fixedDataSizePerHGCROC_ && !isHighDensity)) {
       coarsenerImpl_->coarsen(module_trigcell.second, trigCellVecCoarsened);
 
       switch (selectionType_[subdet]) {

--- a/L1Trigger/L1THGCal/plugins/veryfrontend/HGCalVFEProcessorSums.cc
+++ b/L1Trigger/L1THGCal/plugins/veryfrontend/HGCalVFEProcessorSums.cc
@@ -59,11 +59,10 @@ void HGCalVFEProcessorSums::run(const HGCalDigiCollection& digiColl,
   if (dataframes.empty())
     return;
 
-  constexpr int kHighDensityThickness = 0;
   bool isSilicon = triggerTools_.isSilicon(dataframes[0].id());
   bool isEM = triggerTools_.isEm(dataframes[0].id());
   bool isNose = triggerTools_.isNose(dataframes[0].id());
-  int thickness = triggerTools_.thicknessIndex(dataframes[0].id());
+  bool isHighDensity = triggerTools_.isSiliconHighDensity(dataframes[0].id());
   // Linearization of ADC and TOT values to the same LSB
   if (isSilicon) {
     vfeLinearizationSiImpl_->linearize(dataframes, linearized_dataframes);
@@ -73,7 +72,7 @@ void HGCalVFEProcessorSums::run(const HGCalDigiCollection& digiColl,
   // Sum of sensor cells into trigger cells
   vfeSummationImpl_->triggerCellSums(linearized_dataframes, tc_payload);
   // Compression of trigger cell charges to a floating point format
-  if (thickness == kHighDensityThickness) {
+  if (isHighDensity) {
     vfeCompressionHDMImpl_->compress(tc_payload, tc_compressed_payload);
   } else {
     vfeCompressionLDMImpl_->compress(tc_payload, tc_compressed_payload);

--- a/L1Trigger/L1THGCal/python/l1tHGCalConcentratorProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/l1tHGCalConcentratorProducer_cfi.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 import SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi as digiparam
+from Configuration.Eras.Modifier_phase2_hgcalV19_cff import phase2_hgcalV19
 
 # Digitization parameters
 adcSaturationBH_MIP = digiparam.hgchebackDigitizer.digiCfg.feCfg.adcSaturation_fC
@@ -7,11 +8,18 @@ adcNbitsBH = digiparam.hgchebackDigitizer.digiCfg.feCfg.adcNbits
 
 # MAX_LAYERS should be equal to kNHGCalLayersMax_ defined in interface/HGCalCoarseTriggerCellMapping.h
 # MAX_LAYERS can be larger than the actual number of layers
-# CTC / STC sizes vectors should have a length of 5*MAX_LAYERS, 5 = 4 different silicon thicknesses/types (HD120, LD200, LD300, HD200) + scintillator portion
+# CTC / STC sizes vectors should have a length of (N_THICKNESSES+1)*MAX_LAYERS
+# <V19: 3 different silicon thicknesses/types (HD120, LD200, LD300) + scintillator portion
+# >=V19: 4 different silicon thicknesses/types (HD120, LD200, LD300, HD200) + scintillator portion
 MAX_LAYERS = 52
-CTC_2_SIZES = cms.vuint32( [2]*(MAX_LAYERS+1)*5 )
-STC_4_AND_16_SIZES = cms.vuint32( [4]*(MAX_LAYERS+1)+ [16]*(MAX_LAYERS+1)*4 )
-STC_4_AND_8_SIZES = cms.vuint32( [4]*(MAX_LAYERS+1)+ [8]*(MAX_LAYERS+1)*4 )
+N_THICKNESSES = 3
+CTC_2_SIZES = cms.vuint32( [2]*(MAX_LAYERS+1)*(N_THICKNESSES+1) )
+STC_4_AND_16_SIZES = cms.vuint32( [4]*(MAX_LAYERS+1)+ [16]*(MAX_LAYERS+1)*N_THICKNESSES )
+STC_4_AND_8_SIZES = cms.vuint32( [4]*(MAX_LAYERS+1)+ [8]*(MAX_LAYERS+1)*N_THICKNESSES )
+N_THICKNESSES_V19 = 4
+CTC_2_SIZES_V19 = cms.vuint32( [2]*(MAX_LAYERS+1)*(N_THICKNESSES_V19+1) )
+STC_4_AND_16_SIZES_V19 = cms.vuint32( [4]*(MAX_LAYERS+1)+ [16]*(MAX_LAYERS+1)*N_THICKNESSES_V19 )
+STC_4_AND_8_SIZES_V19 = cms.vuint32( [4]*(MAX_LAYERS+1)+ [8]*(MAX_LAYERS+1)*N_THICKNESSES_V19 )
 
 threshold_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
                                Method = cms.vstring(['thresholdSelect']*3),
@@ -22,6 +30,10 @@ threshold_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorPro
                                allTrigCellsInTrigSums = cms.bool(True),
                                ctcSize = CTC_2_SIZES,
                                )
+
+phase2_hgcalV19.toModify(threshold_conc_proc, 
+                         ctcSize = CTC_2_SIZES_V19,
+                         ) 
 
 # Column is Nlinks, Row is NWafers
 # Requested size = 8(links)x8(wafers)
@@ -79,6 +91,9 @@ best_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcesso
                           superTCCalibration_nose = vfe_proc.calibrationCfg_nose.clone(),
                           ctcSize = CTC_2_SIZES,
                           )
+phase2_hgcalV19.toModify(best_conc_proc, 
+                         ctcSize = CTC_2_SIZES_V19,
+                         ) 
 
 supertc_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
                              Method = cms.vstring(['superTriggerCellSelect']*3),
@@ -95,6 +110,11 @@ supertc_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProce
                              superTCCalibration_hesc = vfe_proc.calibrationCfg_hesc.clone(),
                              superTCCalibration_nose = vfe_proc.calibrationCfg_nose.clone(),
                              )
+phase2_hgcalV19.toModify(supertc_conc_proc, 
+                         stcSize = STC_4_AND_16_SIZES_V19,
+                         ctcSize = CTC_2_SIZES_V19,
+                         ) 
+
 
 custom_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
                           Method = cms.vstring('bestChoiceSelect','superTriggerCellSelect','superTriggerCellSelect'),
@@ -114,6 +134,10 @@ custom_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProces
                           superTCCalibration_hesc = vfe_proc.calibrationCfg_hesc.clone(),
                           superTCCalibration_nose = vfe_proc.calibrationCfg_nose.clone(),
                           )
+phase2_hgcalV19.toModify(custom_conc_proc, 
+                         stcSize = STC_4_AND_16_SIZES_V19,
+                         ctcSize = CTC_2_SIZES_V19,
+                         ) 
 
 
 coarsetc_onebitfraction_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
@@ -134,6 +158,10 @@ coarsetc_onebitfraction_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcen
                              superTCCalibration_hesc = vfe_proc.calibrationCfg_hesc.clone(),
                              superTCCalibration_nose = vfe_proc.calibrationCfg_nose.clone(),
                              )
+phase2_hgcalV19.toModify(coarsetc_onebitfraction_proc, 
+                         stcSize = STC_4_AND_8_SIZES_V19,
+                         ctcSize = CTC_2_SIZES_V19,
+                         ) 
 
 
 coarsetc_equalshare_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
@@ -151,6 +179,10 @@ coarsetc_equalshare_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentrat
                              superTCCalibration_hesc = vfe_proc.calibrationCfg_hesc.clone(),
                              superTCCalibration_nose = vfe_proc.calibrationCfg_nose.clone(),
 )
+phase2_hgcalV19.toModify(coarsetc_equalshare_proc, 
+                         stcSize = STC_4_AND_8_SIZES_V19,
+                         ctcSize = CTC_2_SIZES_V19,
+                         ) 
 
 
 autoencoder_triggerCellRemap = [0,16, 32,

--- a/L1Trigger/L1THGCal/python/l1tHGCalConcentratorProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/l1tHGCalConcentratorProducer_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 import SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi as digiparam
-from Configuration.Eras.Modifier_phase2_hgcalV19_cff import phase2_hgcalV19
+from HLTrigger.Configuration.HLT_75e33.psets.hgcal_reco_constants_cfi import HGCAL_reco_constants as HGCAL_reco_constants
 
 # Digitization parameters
 adcSaturationBH_MIP = digiparam.hgchebackDigitizer.digiCfg.feCfg.adcSaturation_fC
@@ -12,14 +12,10 @@ adcNbitsBH = digiparam.hgchebackDigitizer.digiCfg.feCfg.adcNbits
 # <V19: 3 different silicon thicknesses/types (HD120, LD200, LD300) + scintillator portion
 # >=V19: 4 different silicon thicknesses/types (HD120, LD200, LD300, HD200) + scintillator portion
 MAX_LAYERS = 52
-N_THICKNESSES = 3
+N_THICKNESSES = HGCAL_reco_constants.numberOfThicknesses.value()
 CTC_2_SIZES = cms.vuint32( [2]*(MAX_LAYERS+1)*(N_THICKNESSES+1) )
 STC_4_AND_16_SIZES = cms.vuint32( [4]*(MAX_LAYERS+1)+ [16]*(MAX_LAYERS+1)*N_THICKNESSES )
 STC_4_AND_8_SIZES = cms.vuint32( [4]*(MAX_LAYERS+1)+ [8]*(MAX_LAYERS+1)*N_THICKNESSES )
-N_THICKNESSES_V19 = 4
-CTC_2_SIZES_V19 = cms.vuint32( [2]*(MAX_LAYERS+1)*(N_THICKNESSES_V19+1) )
-STC_4_AND_16_SIZES_V19 = cms.vuint32( [4]*(MAX_LAYERS+1)+ [16]*(MAX_LAYERS+1)*N_THICKNESSES_V19 )
-STC_4_AND_8_SIZES_V19 = cms.vuint32( [4]*(MAX_LAYERS+1)+ [8]*(MAX_LAYERS+1)*N_THICKNESSES_V19 )
 
 threshold_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
                                Method = cms.vstring(['thresholdSelect']*3),
@@ -31,9 +27,6 @@ threshold_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorPro
                                ctcSize = CTC_2_SIZES,
                                )
 
-phase2_hgcalV19.toModify(threshold_conc_proc, 
-                         ctcSize = CTC_2_SIZES_V19,
-                         ) 
 
 # Column is Nlinks, Row is NWafers
 # Requested size = 8(links)x8(wafers)
@@ -91,9 +84,6 @@ best_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcesso
                           superTCCalibration_nose = vfe_proc.calibrationCfg_nose.clone(),
                           ctcSize = CTC_2_SIZES,
                           )
-phase2_hgcalV19.toModify(best_conc_proc, 
-                         ctcSize = CTC_2_SIZES_V19,
-                         ) 
 
 supertc_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
                              Method = cms.vstring(['superTriggerCellSelect']*3),
@@ -110,10 +100,6 @@ supertc_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProce
                              superTCCalibration_hesc = vfe_proc.calibrationCfg_hesc.clone(),
                              superTCCalibration_nose = vfe_proc.calibrationCfg_nose.clone(),
                              )
-phase2_hgcalV19.toModify(supertc_conc_proc, 
-                         stcSize = STC_4_AND_16_SIZES_V19,
-                         ctcSize = CTC_2_SIZES_V19,
-                         ) 
 
 
 custom_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
@@ -134,10 +120,6 @@ custom_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProces
                           superTCCalibration_hesc = vfe_proc.calibrationCfg_hesc.clone(),
                           superTCCalibration_nose = vfe_proc.calibrationCfg_nose.clone(),
                           )
-phase2_hgcalV19.toModify(custom_conc_proc, 
-                         stcSize = STC_4_AND_16_SIZES_V19,
-                         ctcSize = CTC_2_SIZES_V19,
-                         ) 
 
 
 coarsetc_onebitfraction_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
@@ -158,10 +140,6 @@ coarsetc_onebitfraction_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcen
                              superTCCalibration_hesc = vfe_proc.calibrationCfg_hesc.clone(),
                              superTCCalibration_nose = vfe_proc.calibrationCfg_nose.clone(),
                              )
-phase2_hgcalV19.toModify(coarsetc_onebitfraction_proc, 
-                         stcSize = STC_4_AND_8_SIZES_V19,
-                         ctcSize = CTC_2_SIZES_V19,
-                         ) 
 
 
 coarsetc_equalshare_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
@@ -179,10 +157,6 @@ coarsetc_equalshare_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentrat
                              superTCCalibration_hesc = vfe_proc.calibrationCfg_hesc.clone(),
                              superTCCalibration_nose = vfe_proc.calibrationCfg_nose.clone(),
 )
-phase2_hgcalV19.toModify(coarsetc_equalshare_proc, 
-                         stcSize = STC_4_AND_8_SIZES_V19,
-                         ctcSize = CTC_2_SIZES_V19,
-                         ) 
 
 
 autoencoder_triggerCellRemap = [0,16, 32,

--- a/L1Trigger/L1THGCal/python/l1tHGCalConcentratorProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/l1tHGCalConcentratorProducer_cfi.py
@@ -7,11 +7,11 @@ adcNbitsBH = digiparam.hgchebackDigitizer.digiCfg.feCfg.adcNbits
 
 # MAX_LAYERS should be equal to kNHGCalLayersMax_ defined in interface/HGCalCoarseTriggerCellMapping.h
 # MAX_LAYERS can be larger than the actual number of layers
-# CTC / STC sizes vectors should have a length of 4*MAX_LAYERS, 4 = 3 different silicon thicknesses + scintillator portion
+# CTC / STC sizes vectors should have a length of 5*MAX_LAYERS, 5 = 4 different silicon thicknesses/types (HD120, LD200, LD300, HD200) + scintillator portion
 MAX_LAYERS = 52
-CTC_2_SIZES = cms.vuint32( [2]*(MAX_LAYERS+1)*4 )
-STC_4_AND_16_SIZES = cms.vuint32( [4]*(MAX_LAYERS+1)+ [16]*(MAX_LAYERS+1)*3 )
-STC_4_AND_8_SIZES = cms.vuint32( [4]*(MAX_LAYERS+1)+ [8]*(MAX_LAYERS+1)*3 )
+CTC_2_SIZES = cms.vuint32( [2]*(MAX_LAYERS+1)*5 )
+STC_4_AND_16_SIZES = cms.vuint32( [4]*(MAX_LAYERS+1)+ [16]*(MAX_LAYERS+1)*4 )
+STC_4_AND_8_SIZES = cms.vuint32( [4]*(MAX_LAYERS+1)+ [8]*(MAX_LAYERS+1)*4 )
 
 threshold_conc_proc = cms.PSet(ProcessorName  = cms.string('HGCalConcentratorProcessorSelection'),
                                Method = cms.vstring(['thresholdSelect']*3),

--- a/L1Trigger/L1THGCal/python/l1tHGCalVFEProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/l1tHGCalVFEProducer_cfi.py
@@ -4,7 +4,7 @@ import SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi as digiparam
 import RecoLocalCalo.HGCalRecProducers.HGCalUncalibRecHit_cfi as recoparam
 import RecoLocalCalo.HGCalRecProducers.HGCalRecHit_cfi as recocalibparam 
 from . import hgcalLayersCalibrationCoefficients_cfi as layercalibparam
-
+from HLTrigger.Configuration.HLT_75e33.psets.hgcal_reco_constants_cfi import HGCAL_reco_constants as HGCAL_reco_constants
 
 feCfg_si = digiparam.hgceeDigitizer.digiCfg.feCfg
 feCfg_sc = digiparam.hgchebackDigitizer.digiCfg.feCfg
@@ -71,7 +71,13 @@ thicknessCorrectionSi = recocalibparam.HGCalRecHit.thicknessCorrection
 thicknessCorrectionSc = recocalibparam.HGCalRecHit.sciThicknessCorrection
 thicknessCorrectionNose = recocalibparam.HGCalRecHit.thicknessNoseCorrection
 
-NTHICKNESS = 3
+NTHICKNESS = HGCAL_reco_constants.numberOfThicknesses.value() 
+# Silicon thickness correction in HGCalRecHit_cfi.py is in the form:
+# [CE_E_120um, CE_E_200um, CE_E_300um, CE_H_120um, CE_H_200um, CE_H_300um]
+# While here there are two different sets for CE-E and CE-H
+# Additionally there are four values for each set, in order to follow the four detid silicon types [HD120um, LD200um, LD300um, HD200um]
+# The thickness correction value for HD200um is copied from LD200um
+>>>>>>> 3135ca68949 (initial fixes with procModifier v19)
 calibration_params_ee = cms.PSet(
         lsb = cms.double(triggerCellLsbBeforeCompression_si),
         fCperMIP = fCperMIPee,

--- a/L1Trigger/L1THGCal/python/l1tHGCalVFEProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/l1tHGCalVFEProducer_cfi.py
@@ -139,15 +139,17 @@ phase2_hgcal.toModify(calibration_params_nose,
     chargeCollectionEfficiency = cms.PSet(refToPSet_ = cms.string("HGCAL_chargeCollectionEfficiencies")),
 )
 
-
-
 l1tHGCalVFEProducer = cms.EDProducer(
-        "HGCalVFEProducer",
-        eeDigis = cms.InputTag('simHGCalUnsuppressedDigis:EE'),
-        fhDigis = cms.InputTag('simHGCalUnsuppressedDigis:HEfront'),
-        bhDigis = cms.InputTag('simHGCalUnsuppressedDigis:HEback'),
-        ProcessorParameters = vfe_proc.clone()
-       )
+    "HGCalVFEProducer",
+    eeDigis = cms.InputTag('simHGCalUnsuppressedDigis:EE'),
+    fhDigis = cms.InputTag('simHGCalUnsuppressedDigis:HEfront'),
+    bhDigis = cms.InputTag('simHGCalUnsuppressedDigis:HEback'),
+    ProcessorParameters = vfe_proc.clone(
+        summationCfg = vfe_proc.summationCfg.clone(
+            numberOfThicknesses = HGCAL_reco_constants.numberOfThicknesses
+        )
+    )
+)
 
 l1tHFnoseVFEProducer = cms.EDProducer(
         "HFNoseVFEProducer",

--- a/L1Trigger/L1THGCal/python/l1tHGCalVFEProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/l1tHGCalVFEProducer_cfi.py
@@ -77,7 +77,6 @@ NTHICKNESS = HGCAL_reco_constants.numberOfThicknesses.value()
 # While here there are two different sets for CE-E and CE-H
 # Additionally there are four values for each set, in order to follow the four detid silicon types [HD120um, LD200um, LD300um, HD200um]
 # The thickness correction value for HD200um is copied from LD200um
->>>>>>> 3135ca68949 (initial fixes with procModifier v19)
 calibration_params_ee = cms.PSet(
         lsb = cms.double(triggerCellLsbBeforeCompression_si),
         fCperMIP = fCperMIPee,

--- a/L1Trigger/L1THGCal/python/l1tHGCalVFEProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/l1tHGCalVFEProducer_cfi.py
@@ -143,11 +143,7 @@ l1tHGCalVFEProducer = cms.EDProducer(
     eeDigis = cms.InputTag('simHGCalUnsuppressedDigis:EE'),
     fhDigis = cms.InputTag('simHGCalUnsuppressedDigis:HEfront'),
     bhDigis = cms.InputTag('simHGCalUnsuppressedDigis:HEback'),
-    ProcessorParameters = vfe_proc.clone(
-        summationCfg = vfe_proc.summationCfg.clone(
-            numberOfThicknesses = HGCAL_reco_constants.numberOfThicknesses
-        )
-    )
+    ProcessorParameters = vfe_proc.clone()
 )
 
 l1tHFnoseVFEProducer = cms.EDProducer(

--- a/L1Trigger/L1THGCal/src/HGCalCoarseTriggerCellMapping.cc
+++ b/L1Trigger/L1THGCal/src/HGCalCoarseTriggerCellMapping.cc
@@ -2,16 +2,7 @@
 #include "DataFormats/ForwardDetId/interface/HGCalTriggerDetId.h"
 
 HGCalCoarseTriggerCellMapping::HGCalCoarseTriggerCellMapping(const std::vector<unsigned>& ctcSize)
-    : ctcSize_(!ctcSize.empty() ? ctcSize
-                                : std::vector<unsigned>{kNHGCalLayersMax_ * kNThicknesses_, kCTCsizeVeryFine_}) {
-  if (ctcSize_.size() != (kNHGCalLayersMax_ + 1) * kNThicknesses_) {
-    throw cms::Exception("HGCTriggerParameterError")
-        << "Inconsistent size of coarse trigger cell size vector " << ctcSize_.size();
-  }
-
-  for (auto ctc : ctcSize_)
-    checkSizeValidity(ctc);
-}
+    : ctcSize_(ctcSize) {}
 
 const std::map<int, int> HGCalCoarseTriggerCellMapping::kSplit_ = {
     {kCTCsizeIndividual_, kSplit_Individual_},
@@ -29,12 +20,19 @@ const std::map<int, int> HGCalCoarseTriggerCellMapping::kSplit_Scin_ = {
     {kCTCsizeCoarse_, kSplit_Scin_Coarse_},
 };
 
-void HGCalCoarseTriggerCellMapping::checkSizeValidity(int ctcSize) const {
-  if (ctcSize != kCTCsizeFine_ && ctcSize != kCTCsizeCoarse_ && ctcSize != kCTCsizeMid_ &&
-      ctcSize != kCTCsizeVeryFine_ && ctcSize != kCTCsizeIndividual_) {
+void HGCalCoarseTriggerCellMapping::checkSizeValidity() const {
+  unsigned nThickness = triggerTools_.nSiWaferTypes() + 1;  // +1 for scintillator
+  if (ctcSize_.size() != (kNHGCalLayersMax_ + 1) * nThickness) {
     throw cms::Exception("HGCTriggerParameterError")
-        << "Coarse Trigger Cell should be of size " << kCTCsizeIndividual_ << " or " << kCTCsizeVeryFine_ << " or "
-        << kCTCsizeFine_ << " or " << kCTCsizeMid_ << " or " << kCTCsizeCoarse_;
+        << "Inconsistent size of coarse trigger cell size vector " << ctcSize_.size();
+  }
+  for (auto ctcSize : ctcSize_) {
+    if (ctcSize != kCTCsizeFine_ && ctcSize != kCTCsizeCoarse_ && ctcSize != kCTCsizeMid_ &&
+        ctcSize != kCTCsizeVeryFine_ && ctcSize != kCTCsizeIndividual_) {
+      throw cms::Exception("HGCTriggerParameterError")
+          << "Coarse Trigger Cell should be of size " << kCTCsizeIndividual_ << " or " << kCTCsizeVeryFine_ << " or "
+          << kCTCsizeFine_ << " or " << kCTCsizeMid_ << " or " << kCTCsizeCoarse_;
+    }
   }
 }
 

--- a/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
@@ -46,6 +46,7 @@ void HGCalTriggerTools::setGeometry(const HGCalTriggerGeometryBase* const geom) 
 
   bhLayers_ = geom_->hscTopology().dddConstants().layers(true);
   totalLayers_ = eeLayers_ + fhLayers_;
+  scintillatorPseudoThicknessIndex_ = nSiWaferTypes() + 1;
 }
 
 GlobalPoint HGCalTriggerTools::getTCPosition(const DetId& id) const {
@@ -104,6 +105,8 @@ unsigned HGCalTriggerTools::layers(DetId::Detector type) const {
   }
   return layers;
 }
+
+unsigned HGCalTriggerTools::nSiWaferTypes() const { return geom_->eeTopology().dddConstants().waferTypes(); }
 
 unsigned HGCalTriggerTools::layer(const DetId& id) const {
   unsigned int layer = std::numeric_limits<unsigned int>::max();
@@ -266,7 +269,7 @@ int HGCalTriggerTools::zside(const DetId& id) const {
 
 int HGCalTriggerTools::thicknessIndex(const DetId& id) const {
   if (isScintillator(id)) {
-    return kScintillatorPseudoThicknessIndex_;
+    return scintillatorPseudoThicknessIndex_;
   }
   unsigned det = id.det();
   int thickness = 0;

--- a/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerTools.cc
@@ -185,6 +185,52 @@ bool HGCalTriggerTools::isSilicon(const DetId& id) const {
   return silicon;
 }
 
+bool HGCalTriggerTools::isSiliconHighDensity(const DetId& id) const {
+  if (isScintillator(id)) {
+    return false;
+  }
+  unsigned det = id.det();
+  bool hd = false;
+  if (det == DetId::HGCalEE || det == DetId::HGCalHSi) {
+    hd = HGCSiliconDetId(id).highDensity();
+  } else if (det == DetId::Forward && id.subdetId() == ForwardSubdetector::HFNose) {
+    hd = (HFNoseDetId(id).type() == HFNoseDetId::HFNoseFine);
+  } else if (det == DetId::Forward && id.subdetId() == ForwardSubdetector::HGCTrigger) {
+    hd = HGCalTriggerModuleDetId(id).isSiliconHighDensity();
+  } else if (id.det() == DetId::HGCalTrigger &&
+             (HGCalTriggerDetId(id).subdet() == HGCalTriggerSubdetector::HGCalEETrigger ||
+              HGCalTriggerDetId(id).subdet() == HGCalTriggerSubdetector::HGCalHSiTrigger)) {
+    hd = HGCalTriggerDetId(id).highDensity();
+  } else if (id.det() == DetId::HGCalTrigger &&
+             HGCalTriggerDetId(id).subdet() == HGCalTriggerSubdetector::HFNoseTrigger) {
+    hd = (HFNoseDetId(id).type() == HFNoseDetId::HFNoseFine);
+  }
+  return hd;
+}
+
+bool HGCalTriggerTools::isSiliconLowDensity(const DetId& id) const {
+  if (isScintillator(id)) {
+    return false;
+  }
+  unsigned det = id.det();
+  bool ld = false;
+  if (det == DetId::HGCalEE || det == DetId::HGCalHSi) {
+    ld = HGCSiliconDetId(id).lowDensity();
+  } else if (det == DetId::Forward && id.subdetId() == ForwardSubdetector::HFNose) {
+    ld = (HFNoseDetId(id).type() != HFNoseDetId::HFNoseFine);
+  } else if (det == DetId::Forward && id.subdetId() == ForwardSubdetector::HGCTrigger) {
+    ld = HGCalTriggerModuleDetId(id).isSiliconLowDensity();
+  } else if (id.det() == DetId::HGCalTrigger &&
+             (HGCalTriggerDetId(id).subdet() == HGCalTriggerSubdetector::HGCalEETrigger ||
+              HGCalTriggerDetId(id).subdet() == HGCalTriggerSubdetector::HGCalHSiTrigger)) {
+    ld = HGCalTriggerDetId(id).lowDensity();
+  } else if (id.det() == DetId::HGCalTrigger &&
+             HGCalTriggerDetId(id).subdet() == HGCalTriggerSubdetector::HFNoseTrigger) {
+    ld = (HFNoseDetId(id).type() != HFNoseDetId::HFNoseFine);
+  }
+  return ld;
+}
+
 HGCalTriggerTools::SubDetectorType HGCalTriggerTools::getSubDetectorType(const DetId& id) const {
   SubDetectorType subdet;
   if (!isScintillator(id)) {

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorCoarsenerImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorCoarsenerImpl.cc
@@ -39,9 +39,9 @@ void HGCalConcentratorCoarsenerImpl::coarsen(const std::vector<l1t::HGCalTrigger
 
   // first pass, fill the coarse trigger cell information
   for (const l1t::HGCalTriggerCell& tc : trigCellVecInput) {
-    int thickness = triggerTools_.thicknessIndex(tc.detId());
+    bool isHighDensity = triggerTools_.isSiliconHighDensity(tc.detId());
 
-    if (fixedDataSizePerHGCROC_ && thickness == kHighDensityThickness_) {
+    if (fixedDataSizePerHGCROC_ && isHighDensity) {
       trigCellVecOutput.push_back(tc);
       continue;
     }

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
@@ -48,10 +48,10 @@ void HGCalConcentratorSuperTriggerCellImpl::createAllTriggerCells(
       continue;
 
     HGCalTriggerTools::SubDetectorType subdet = triggerTools_.getSubDetectorType(output_ids.at(0));
-    int thickness = (!output_ids.empty() ? triggerTools_.thicknessIndex(output_ids.at(0)) : 0);
+    bool isHighDensity = (!output_ids.empty() ? triggerTools_.isSiliconHighDensity(output_ids.at(0)) : false);
 
     for (const auto& id : output_ids) {
-      if (((fixedDataSizePerHGCROC_ && thickness > kHighDensityThickness_) || coarsenTriggerCells_[subdet]) &&
+      if (((fixedDataSizePerHGCROC_ && !isHighDensity) || coarsenTriggerCells_[subdet]) &&
           (id != coarseTCmapping_.getRepresentativeDetId(id))) {
         continue;
       }
@@ -95,14 +95,14 @@ void HGCalConcentratorSuperTriggerCellImpl::assignSuperTriggerCellEnergyAndPosit
   uint32_t compressed_value = getCompressedSTCEnergy(stc);
 
   HGCalTriggerTools::SubDetectorType subdet = triggerTools_.getSubDetectorType(c.detId());
-  int thickness = triggerTools_.thicknessIndex(c.detId());
+  bool isHighDensity = triggerTools_.isSiliconHighDensity(c.detId());
 
   bool isSilicon = triggerTools_.isSilicon(c.detId());
   bool isEM = triggerTools_.isEm(c.detId());
   bool isNose = triggerTools_.isNose(c.detId());
 
   GlobalPoint point;
-  if ((fixedDataSizePerHGCROC_ && thickness > kHighDensityThickness_) || coarsenTriggerCells_[subdet]) {
+  if ((fixedDataSizePerHGCROC_ && !isHighDensity) || coarsenTriggerCells_[subdet]) {
     point = coarseTCmapping_.getCoarseTriggerCellPosition(coarseTCmapping_.getCoarseTriggerCellId(c.detId()));
   } else {
     point = triggerTools_.getTCPosition(c.detId());

--- a/L1Trigger/L1THGCal/src/veryfrontend/HGCalVFESummationImpl.cc
+++ b/L1Trigger/L1THGCal/src/veryfrontend/HGCalVFESummationImpl.cc
@@ -1,14 +1,16 @@
 #include "L1Trigger/L1THGCal/interface/veryfrontend/HGCalVFESummationImpl.h"
+#include <cstdint>
 
 HGCalVFESummationImpl::HGCalVFESummationImpl(const edm::ParameterSet& conf)
     : lsb_silicon_fC_(conf.getParameter<double>("siliconCellLSB_fC")),
-      lsb_scintillator_MIP_(conf.getParameter<double>("scintillatorCellLSB_MIP")) {
-  constexpr unsigned nThickness = 3;
+      lsb_scintillator_MIP_(conf.getParameter<double>("scintillatorCellLSB_MIP")),
+      nThickness_(conf.getParameter<uint32_t>("numberOfThicknesses"))
+      {
   thresholds_silicon_ =
       conf.getParameter<edm::ParameterSet>("noiseSilicon").getParameter<std::vector<double>>("values");
-  if (thresholds_silicon_.size() != nThickness) {
+  if (thresholds_silicon_.size() != nThickness_) {
     throw cms::Exception("Configuration") << thresholds_silicon_.size() << " silicon thresholds are given instead of "
-                                          << nThickness << " (the number of sensor thicknesses)";
+                                          << nThickness_ << " (the number of sensor thicknesses)";
   }
   threshold_scintillator_ = conf.getParameter<edm::ParameterSet>("noiseScintillator").getParameter<double>("noise_MIP");
   const auto threshold = conf.getParameter<double>("noiseThreshold");

--- a/L1Trigger/L1THGCal/src/veryfrontend/HGCalVFESummationImpl.cc
+++ b/L1Trigger/L1THGCal/src/veryfrontend/HGCalVFESummationImpl.cc
@@ -3,14 +3,9 @@
 
 HGCalVFESummationImpl::HGCalVFESummationImpl(const edm::ParameterSet& conf)
     : lsb_silicon_fC_(conf.getParameter<double>("siliconCellLSB_fC")),
-      lsb_scintillator_MIP_(conf.getParameter<double>("scintillatorCellLSB_MIP")),
-      nThickness_(conf.getParameter<uint32_t>("numberOfThicknesses")) {
+      lsb_scintillator_MIP_(conf.getParameter<double>("scintillatorCellLSB_MIP")) {
   thresholds_silicon_ =
       conf.getParameter<edm::ParameterSet>("noiseSilicon").getParameter<std::vector<double>>("values");
-  if (thresholds_silicon_.size() != nThickness_) {
-    throw cms::Exception("Configuration") << thresholds_silicon_.size() << " silicon thresholds are given instead of "
-                                          << nThickness_ << " (the number of sensor thicknesses)";
-  }
   threshold_scintillator_ = conf.getParameter<edm::ParameterSet>("noiseScintillator").getParameter<double>("noise_MIP");
   const auto threshold = conf.getParameter<double>("noiseThreshold");
   std::transform(
@@ -18,6 +13,14 @@ HGCalVFESummationImpl::HGCalVFESummationImpl(const edm::ParameterSet& conf)
         return noise * threshold;
       });
   threshold_scintillator_ *= threshold;
+}
+
+void HGCalVFESummationImpl::checkSizeValidity() const {
+  unsigned nThickness = triggerTools_.nSiWaferTypes();
+  if (thresholds_silicon_.size() != nThickness) {
+    throw cms::Exception("Configuration") << thresholds_silicon_.size() << " silicon thresholds are given instead of "
+                                          << nThickness << " (the number of sensor thicknesses)";
+  }
 }
 
 void HGCalVFESummationImpl::triggerCellSums(const std::vector<std::pair<DetId, uint32_t>>& input_dataframes,

--- a/L1Trigger/L1THGCal/src/veryfrontend/HGCalVFESummationImpl.cc
+++ b/L1Trigger/L1THGCal/src/veryfrontend/HGCalVFESummationImpl.cc
@@ -4,8 +4,7 @@
 HGCalVFESummationImpl::HGCalVFESummationImpl(const edm::ParameterSet& conf)
     : lsb_silicon_fC_(conf.getParameter<double>("siliconCellLSB_fC")),
       lsb_scintillator_MIP_(conf.getParameter<double>("scintillatorCellLSB_MIP")),
-      nThickness_(conf.getParameter<uint32_t>("numberOfThicknesses"))
-      {
+      nThickness_(conf.getParameter<uint32_t>("numberOfThicknesses")) {
   thresholds_silicon_ =
       conf.getParameter<edm::ParameterSet>("noiseSilicon").getParameter<std::vector<double>>("values");
   if (thresholds_silicon_.size() != nThickness_) {

--- a/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_multialgo_V19_cfg.py
+++ b/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_multialgo_V19_cfg.py
@@ -1,0 +1,117 @@
+import FWCore.ParameterSet.Config as cms 
+
+from Configuration.Eras.Era_Phase2C26I13M9_cff import Phase2C26I13M9
+process = cms.Process('DIGI',Phase2C26I13M9)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.Geometry.GeometryExtendedRun4D120Reco_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedHLLHC14TeV_cfi')
+process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('Configuration.StandardSequences.SimIdeal_cff')
+process.load('Configuration.StandardSequences.Digi_cff')
+process.load('Configuration.StandardSequences.SimL1Emulator_cff')
+process.load('Configuration.StandardSequences.DigiToRaw_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(5)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+                            fileNames = cms.untracked.vstring('file:step2.root'),
+       inputCommands=cms.untracked.vstring(
+           'keep *',
+           )
+       )
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.20 $'),
+    annotation = cms.untracked.string('SingleElectronPt10_cfi nevts:10'),
+    name = cms.untracked.string('Applications')
+)
+
+# Output definition
+process.TFileService = cms.Service(
+    "TFileService",
+    fileName = cms.string("ntuple.root")
+    )
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T21', '')
+
+# load HGCAL TPG simulation
+process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff')
+process.load('L1Trigger.L1THGCalUtilities.HGC3DClusterGenMatchSelector_cff')
+process.load('L1Trigger.L1THGCalUtilities.hgcalTriggerNtuples_cff')
+from L1Trigger.L1THGCalUtilities.hgcalTriggerChains import HGCalTriggerChains
+import L1Trigger.L1THGCalUtilities.vfe as vfe
+import L1Trigger.L1THGCalUtilities.concentrator as concentrator
+import L1Trigger.L1THGCalUtilities.clustering2d as clustering2d
+import L1Trigger.L1THGCalUtilities.clustering3d as clustering3d
+import L1Trigger.L1THGCalUtilities.selectors as selectors
+import L1Trigger.L1THGCalUtilities.customNtuples as ntuple
+
+
+chains = HGCalTriggerChains()
+# Register algorithms
+## VFE
+chains.register_vfe("Floatingpoint", vfe.CreateVfe())
+## ECON
+chains.register_concentrator("Supertriggercell", concentrator.CreateSuperTriggerCell())
+chains.register_concentrator("Threshold", concentrator.CreateThreshold())
+chains.register_concentrator("Bestchoice", concentrator.CreateBestChoice())
+chains.register_concentrator("Mixed", concentrator.CreateMixedFeOptions())
+## BE1
+chains.register_backend1("Dummy", clustering2d.CreateDummy())
+## BE2
+chains.register_backend2("Histomax", clustering3d.CreateHistoMax())
+# Register selector
+chains.register_selector("Genmatch", selectors.CreateGenMatch())
+
+
+# Register ntuples
+ntuple_list = ['event', 'gen', 'multiclusters']
+chains.register_ntuple("Genclustersntuple", ntuple.CreateNtuple(ntuple_list))
+
+# Register trigger chains
+concentrator_algos = ['Supertriggercell', 'Threshold', 'Bestchoice', 'Mixed']
+backend_algos = ['Histomax']
+## Make cross product fo ECON and BE algos
+import itertools
+for cc,be in itertools.product(concentrator_algos,backend_algos):
+    chains.register_chain('Floatingpoint', cc, 'Dummy', be, 'Genmatch', 'Genclustersntuple')
+
+process = chains.create_sequences(process)
+
+# Remove towers from sequence
+process.L1THGCalTriggerPrimitives.remove(process.L1THGCalTowerMap)
+process.L1THGCalTriggerPrimitives.remove(process.L1THGCalTower)
+
+process.hgcl1tpg_step = cms.Path(process.L1THGCalTriggerPrimitives)
+process.selector_step = cms.Path(process.L1THGCalTriggerSelector)
+process.ntuple_step = cms.Path(process.L1THGCalTriggerNtuples)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.hgcl1tpg_step, process.selector_step, process.ntuple_step)
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion
+

--- a/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
@@ -222,8 +222,7 @@ std::float_t RecHitTools::getSiThickness(const DetId& id) const {
   std::float_t thick(0.37);
   if (id.det() == DetId::HGCalEE || id.det() == DetId::HGCalHSi) {
     const HGCSiliconDetId hid(id);
-    auto ddd = get_ddd(geom, hid);
-    thick = ddd->cellThickness(hid.layer(), hid.waferU(), hid.waferV());
+    thick = hid.depletion();
   } else if (id.det() == DetId::Forward && id.subdetId() == static_cast<int>(HFNose)) {
     const HFNoseDetId hid(id);
     auto ddd = get_ddd(geom, hid);

--- a/RecoLocalCalo/HGCalRecProducers/python/HGCalRecHit_cfi.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/HGCalRecHit_cfi.py
@@ -3,6 +3,7 @@ from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import *
 from RecoLocalCalo.HGCalRecProducers.HGCalUncalibRecHit_cfi import *
 
 from Configuration.Eras.Modifier_phase2_hgcalV16_cff import phase2_hgcalV16
+from Configuration.Eras.Modifier_phase2_hgcalV19_cff import phase2_hgcalV19
 
 # There is no layer zero, while no average is taken for the last layer
 dummy_weight = 0.0
@@ -212,3 +213,7 @@ phase2_hgcalV16.toModify(HGCalRecHit,
                          sciThicknessCorrection =  0.69,
                          layerWeights = dEdX_v16.weights) 
 
+phase2_hgcalV19.toModify(HGCalRecHit, 
+                         thicknessCorrection = [0.75, 0.76, 0.75, 0.76, 0.85, 0.85, 0.84, 0.85] , 
+                         sciThicknessCorrection =  0.69,
+                         layerWeights = dEdX_v16.weights) 

--- a/RecoLocalCalo/HGCalRecProducers/python/HGCalUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/HGCalUncalibRecHit_cfi.py
@@ -3,8 +3,10 @@ import FWCore.ParameterSet.Config as cms
 from RecoLocalCalo.HGCalRecProducers.HGCalUncalibRecHitProducer_cfi import HGCalUncalibRecHitProducer
 from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import hgceeDigitizer, hgchefrontDigitizer, hgchebackDigitizer, hfnoseDigitizer
 
-fCPerMIP_mpv = cms.vdouble(1.25,2.57,3.88, 2.57)  #HD120um, LD200um, LD300um, HD200um
-fCPerMIP_mean = cms.vdouble(2.06,3.43,5.15, 3.43) #HD120um, LD200um, LD300um, HD200um
+fCPerMIP_mpv = cms.vdouble(1.25,2.57,3.88)  #HD120um, LD200um, LD300um
+fCPerMIP_mean = cms.vdouble(2.06,3.43,5.15) #HD120um, LD200um, LD300um
+fCPerMIP_mpv_V19 = cms.vdouble(1.25,2.57,3.88, 2.57)  #HD120um, LD200um, LD300um, HD200um
+fCPerMIP_mean_V19 = cms.vdouble(2.06,3.43,5.15, 3.43) #HD120um, LD200um, LD300um, HD200um
 
 # HGCAL producer of rechits starting from digis
 HGCalUncalibRecHit = HGCalUncalibRecHitProducer.clone(
@@ -73,6 +75,10 @@ phase2_hgcalV10.toModify( HGCalUncalibRecHit.HGCHEFConfig , fCPerMIP = fCPerMIP_
 from Configuration.Eras.Modifier_phase2_hgcalV16_cff import phase2_hgcalV16
 phase2_hgcalV16.toModify( HGCalUncalibRecHit.HGCEEConfig , fCPerMIP = fCPerMIP_mean )
 phase2_hgcalV16.toModify( HGCalUncalibRecHit.HGCHEFConfig , fCPerMIP = fCPerMIP_mean )
+
+from Configuration.Eras.Modifier_phase2_hgcalV19_cff import phase2_hgcalV19
+phase2_hgcalV19.toModify( HGCalUncalibRecHit.HGCEEConfig , fCPerMIP = fCPerMIP_mean_V19)
+phase2_hgcalV19.toModify( HGCalUncalibRecHit.HGCHEFConfig , fCPerMIP = fCPerMIP_mean_V19)
 
 from Configuration.Eras.Modifier_phase2_hfnose_cff import phase2_hfnose
 phase2_hfnose.toModify( HGCalUncalibRecHit.HGCHFNoseConfig ,

--- a/RecoLocalCalo/HGCalRecProducers/python/HGCalUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/HGCalUncalibRecHit_cfi.py
@@ -85,6 +85,9 @@ phase2_hfnose.toModify( HGCalUncalibRecHit.HGCHFNoseConfig ,
           isSiFE = True ,
           fCPerMIP = fCPerMIP_mean
 )
+phase2_hgcalV19.toModify( HGCalUncalibRecHit.HGCHFNoseConfig ,
+          fCPerMIP = fCPerMIP_mean_V19
+)
 
 from Configuration.ProcessModifiers.ticl_v5_cff import ticl_v5
 ticl_v5.toModify(HGCalUncalibRecHit, computeLocalTime = cms.bool(True))

--- a/RecoLocalCalo/HGCalRecProducers/python/HGCalUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/HGCalUncalibRecHit_cfi.py
@@ -3,8 +3,8 @@ import FWCore.ParameterSet.Config as cms
 from RecoLocalCalo.HGCalRecProducers.HGCalUncalibRecHitProducer_cfi import HGCalUncalibRecHitProducer
 from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import hgceeDigitizer, hgchefrontDigitizer, hgchebackDigitizer, hfnoseDigitizer
 
-fCPerMIP_mpv = cms.vdouble(1.25,2.57,3.88) #120um, 200um, 300um
-fCPerMIP_mean = cms.vdouble(2.06,3.43,5.15) #120um, 200um, 300um
+fCPerMIP_mpv = cms.vdouble(1.25,2.57,3.88, 2.57)  #HD120um, LD200um, LD300um, HD200um
+fCPerMIP_mean = cms.vdouble(2.06,3.43,5.15, 3.43) #HD120um, LD200um, LD300um, HD200um
 
 # HGCAL producer of rechits starting from digis
 HGCalUncalibRecHit = HGCalUncalibRecHitProducer.clone(

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerBase.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerBase.h
@@ -21,6 +21,9 @@
 #include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
 #include "Geometry/HcalTowerAlgo/interface/HcalGeometry.h"
 
+#include "DataFormats/ForwardDetId/interface/HGCSiliconDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCScintillatorDetId.h"
+
 #include "SimCalorimetry/HGCalSimAlgos/interface/HGCalSiNoiseMap.h"
 
 namespace hgc = hgc_digi;
@@ -29,14 +32,16 @@ namespace hgc_digi_utils {
   using hgc::HGCCellInfo;
 
   inline void addCellMetadata(HGCCellInfo& info, const HGCalGeometry* geom, const DetId& detid) {
-    const auto& dddConst = geom->topology().dddConstants();
-    bool isHalf = (((dddConst.geomMode() == HGCalGeometryMode::Hexagon) ||
-                    (dddConst.geomMode() == HGCalGeometryMode::HexagonFull))
-                       ? dddConst.isHalfCell(HGCalDetId(detid).wafer(), HGCalDetId(detid).cell())
-                       : false);
-    //base time samples for each DetId, initialized to 0
-    info.size = (isHalf ? 0.5 : 1.0);
-    info.thickness = 1 + dddConst.waferType(detid, false);
+
+    if(detid.det()==DetId::HGCalHSc) {
+      HGCScintillatorDetId sipmdetid(detid);
+      info.size = sipmdetid.sipm();
+      info.thickness = sipmdetid.granularity();
+    } else {
+      HGCSiliconDetId sidetid(detid);
+      info.size = sidetid.highDensity() ? 0.5 : 1.0;
+      info.thickness = sidetid.type();
+    }
   }
 
   inline void addCellMetadata(HGCCellInfo& info, const CaloSubdetectorGeometry* geom, const DetId& detid) {

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerBase.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerBase.h
@@ -32,8 +32,7 @@ namespace hgc_digi_utils {
   using hgc::HGCCellInfo;
 
   inline void addCellMetadata(HGCCellInfo& info, const HGCalGeometry* geom, const DetId& detid) {
-
-    if(detid.det()==DetId::HGCalHSc) {
+    if (detid.det() == DetId::HGCalHSc) {
       HGCScintillatorDetId sipmdetid(detid);
       info.size = sipmdetid.sipm();
       info.thickness = sipmdetid.granularity();

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerBase.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerBase.h
@@ -80,7 +80,7 @@ public:
   float keV2fC() const { return keV2fC_; }
   bool toaModeByEnergy() const { return (myFEelectronics_->toaMode() == HGCFEElectronics<DFr>::WEIGHTEDBYE); }
   float tdcOnset() const { return myFEelectronics_->getTDCOnset(); }
-  std::array<float, 3> tdcForToAOnset() const { return myFEelectronics_->getTDCForToAOnset(); }
+  std::array<float, 4> tdcForToAOnset() const { return myFEelectronics_->getTDCForToAOnset(); }
   DetId::Detector det() const { return det_; }
   ForwardSubdetector subdet() const { return subdet_; }
 

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerBase.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerBase.h
@@ -84,7 +84,7 @@ public:
   float keV2fC() const { return keV2fC_; }
   bool toaModeByEnergy() const { return (myFEelectronics_->toaMode() == HGCFEElectronics<DFr>::WEIGHTEDBYE); }
   float tdcOnset() const { return myFEelectronics_->getTDCOnset(); }
-  std::array<float, 4> tdcForToAOnset() const { return myFEelectronics_->getTDCForToAOnset(); }
+  std::vector<float> tdcForToAOnset() const { return myFEelectronics_->getTDCForToAOnset(); }
   DetId::Detector det() const { return det_; }
   ForwardSubdetector subdet() const { return subdet_; }
 

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerBase.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerBase.h
@@ -32,15 +32,14 @@ namespace hgc_digi_utils {
   using hgc::HGCCellInfo;
 
   inline void addCellMetadata(HGCCellInfo& info, const HGCalGeometry* geom, const DetId& detid) {
-    if (detid.det() == DetId::HGCalHSc) {
-      HGCScintillatorDetId sipmdetid(detid);
-      info.size = sipmdetid.sipm();
-      info.thickness = sipmdetid.granularity();
-    } else {
-      HGCSiliconDetId sidetid(detid);
-      info.size = sidetid.highDensity() ? 0.5 : 1.0;
-      info.thickness = sidetid.type();
-    }
+    const auto& dddConst = geom->topology().dddConstants();
+    bool isHalf = (((dddConst.geomMode() == HGCalGeometryMode::Hexagon) ||
+                    (dddConst.geomMode() == HGCalGeometryMode::HexagonFull))
+                       ? dddConst.isHalfCell(HGCalDetId(detid).wafer(), HGCalDetId(detid).cell())
+                       : false);
+    //base time samples for each DetId, initialized to 0
+    info.size = (isHalf ? 0.5 : 1.0);
+    info.thickness = 1 + dddConst.waferType(detid, false);
   }
 
   inline void addCellMetadata(HGCCellInfo& info, const CaloSubdetectorGeometry* geom, const DetId& detid) {

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCFEElectronics.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCFEElectronics.h
@@ -103,7 +103,7 @@ public:
   float getMaxADC() { return adcSaturation_fC_; }
   float getMaxTDC() { return tdcSaturation_fC_; }
   float getTDCOnset() { return tdcOnset_fC_; }
-  std::array<float, 3> getTDCForToAOnset() { return tdcForToAOnset_fC_; }
+  std::array<float, 4> getTDCForToAOnset() { return tdcForToAOnset_fC_; }
   void setADClsb(float newLSB) { adcLSB_fC_ = newLSB; }
   void setTDCfsc(float newTDCfsc) {
     tdcSaturation_fC_ = newTDCfsc;
@@ -193,7 +193,7 @@ private:
   //private members
   uint32_t fwVersion_;
   hgc_digi::FEADCPulseShape adcPulse_, pulseAvgT_;
-  std::array<float, 3> tdcForToAOnset_fC_;
+  std::array<float, 4> tdcForToAOnset_fC_;
   std::vector<float> tdcChargeDrainParameterisation_;
   float adcSaturation_fC_, adcLSB_fC_, tdcLSB_fC_, tdcSaturation_fC_, adcThreshold_fC_, tdcOnset_fC_, toaLSB_ns_,
       tdcResolutionInNs_;

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCFEElectronics.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCFEElectronics.h
@@ -103,7 +103,7 @@ public:
   float getMaxADC() { return adcSaturation_fC_; }
   float getMaxTDC() { return tdcSaturation_fC_; }
   float getTDCOnset() { return tdcOnset_fC_; }
-  std::array<float, 4> getTDCForToAOnset() { return tdcForToAOnset_fC_; }
+  std::vector<float> getTDCForToAOnset() { return tdcForToAOnset_fC_; }
   void setADClsb(float newLSB) { adcLSB_fC_ = newLSB; }
   void setTDCfsc(float newTDCfsc) {
     tdcSaturation_fC_ = newTDCfsc;
@@ -193,7 +193,7 @@ private:
   //private members
   uint32_t fwVersion_;
   hgc_digi::FEADCPulseShape adcPulse_, pulseAvgT_;
-  std::array<float, 4> tdcForToAOnset_fC_;
+  std::vector<float> tdcForToAOnset_fC_;
   std::vector<float> tdcChargeDrainParameterisation_;
   float adcSaturation_fC_, adcLSB_fC_, tdcLSB_fC_, tdcSaturation_fC_, adcThreshold_fC_, tdcOnset_fC_, toaLSB_ns_,
       tdcResolutionInNs_;

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCFEElectronics.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCFEElectronics.h
@@ -198,7 +198,7 @@ private:
   float adcSaturation_fC_, adcLSB_fC_, tdcLSB_fC_, tdcSaturation_fC_, adcThreshold_fC_, tdcOnset_fC_, toaLSB_ns_,
       tdcResolutionInNs_;
   uint32_t targetMIPvalue_ADC_;
-  std::array<float, 3> jitterNoise_ns_, jitterConstant_ns_, eventTimeOffset_ns_;
+  std::vector<float> jitterNoise_ns_, jitterConstant_ns_, eventTimeOffset_ns_;
   std::vector<float> noise_fC_;
   uint32_t toaMode_;
   uint32_t tdcNbits_;

--- a/SimCalorimetry/HGCalSimProducers/plugins/HGCDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/plugins/HGCDigitizer.cc
@@ -119,7 +119,7 @@ namespace {
                                        const float minCharge,
                                        const float maxCharge,
                                        bool setIfZero,
-                                       const std::array<float, 4>& tdcForToAOnset,
+                                       const std::vector<float>& tdcForToAOnset,
                                        const bool minbiasFlag,
                                        std::unordered_map<uint32_t, bool>& hitOrder_monitor,
                                        const unsigned int thisBx) {

--- a/SimCalorimetry/HGCalSimProducers/plugins/HGCDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/plugins/HGCDigitizer.cc
@@ -119,7 +119,7 @@ namespace {
                                        const float minCharge,
                                        const float maxCharge,
                                        bool setIfZero,
-                                       const std::array<float, 3>& tdcForToAOnset,
+                                       const std::array<float, 4>& tdcForToAOnset,
                                        const bool minbiasFlag,
                                        std::unordered_map<uint32_t, bool>& hitOrder_monitor,
                                        const unsigned int thisBx) {

--- a/SimCalorimetry/HGCalSimProducers/plugins/HGCDigitizerBase.cc
+++ b/SimCalorimetry/HGCalSimProducers/plugins/HGCDigitizerBase.cc
@@ -28,8 +28,7 @@ HGCDigitizerBase::HGCDigitizerBase(const edm::ParameterSet& ps)
   }
 
   if (myCfg_.existsAs<double>("noise_fC")) {
-    noise_fC_.reserve(1);
-    noise_fC_.push_back(myCfg_.getParameter<double>("noise_fC"));
+    noise_fC_.resize(4, myCfg_.getParameter<double>("noise_fC"));
   } else if (myCfg_.existsAs<std::vector<double>>("noise_fC")) {
     const auto& noises = myCfg_.getParameter<std::vector<double>>("noise_fC");
     noise_fC_ = std::vector<float>(noises.begin(), noises.end());
@@ -47,7 +46,7 @@ HGCDigitizerBase::HGCDigitizerBase(const edm::ParameterSet& ps)
     scalHFNose_.setDoseMap(doseMapFile_, scaleByDoseAlgo);
     scalHFNose_.setFluenceScaleFactor(scaleByDoseFactor_);
   } else {
-    noise_fC_.resize(1, 1.f);
+    noise_fC_.resize(4, 1.f);
   }
   if (myCfg_.existsAs<edm::ParameterSet>("ileakParam")) {
     scal_.setIleakParam(
@@ -144,7 +143,6 @@ void HGCDigitizerBase::runSimple(std::unique_ptr<HGCDigitizerBase::DColl>& coll,
     uint32_t thrADC(std::floor(myFEelectronics_->getTargetMipValue() / 2));
     uint32_t gainIdx = 0;
     std::array<float, 6>& adcPulse = myFEelectronics_->getDefaultADCPulse();
-
     double tdcOnsetAuto = -1;
     if (scaleByDose_) {
       if (id.det() == DetId::Forward && id.subdetId() == ForwardSubdetector::HFNose) {

--- a/SimCalorimetry/HGCalSimProducers/python/hgcROCParameters_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcROCParameters_cfi.py
@@ -41,9 +41,13 @@ hgcROCSettings = cms.PSet(
         -919.13, 365.36, -14.10, 0.2,
         -21.85, 49.39,  22.21,  0.8,
         -0.28,   27.14,  43.95,
-        3.89048 )
+        3.89048 ),
+    eventTimeOffset_ns = cms.vdouble(0.2,0.2,0.2)
 )
 
 from Configuration.Eras.Modifier_phase2_hgcalV19_cff import phase2_hgcalV19
 phase2_hgcalV19.toModify(hgcROCSettings, tdcForToAOnset_fC = [12., 12., 12., 12.])
+phase2_hgcalV19.toModify(hgcROCSettings, jitterNoise_ns = [5., 5., 5., 5.])
+phase2_hgcalV19.toModify(hgcROCSettings, jitterConstant_ns = [0.2,0.2,0.2,0.2])
+phase2_hgcalV19.toModify(hgcROCSettings, eventTimeOffset_ns = [0.2,0.2,0.2,0.2])
 

--- a/SimCalorimetry/HGCalSimProducers/python/hgcROCParameters_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcROCParameters_cfi.py
@@ -43,3 +43,7 @@ hgcROCSettings = cms.PSet(
         -0.28,   27.14,  43.95,
         3.89048 )
 )
+
+from Configuration.Eras.Modifier_phase2_hgcalV19_cff import phase2_hgcalV19
+phase2_hgcalV19.toModify(hgcROCSettings, tdcForToAOnset_fC = [12., 12., 12., 12.])
+

--- a/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
@@ -2,13 +2,17 @@ import FWCore.ParameterSet.Config as cms
 
 from SimCalorimetry.HGCalSimProducers.hgcROCParameters_cfi import hgcROCSettings
 from SimCalorimetry.HGCalSimAlgos.hgcSensorOpParams_cfi import hgcSiSensorIleak,hgcSiSensorCCE
+from Configuration.Eras.Modifier_phase2_hgcalV19_cff import phase2_hgcalV19
 
 # Base configurations for HGCal digitizers
 eV_per_eh_pair = 3.62
 fC_per_ele     = 1.6020506e-4
-nonAgedCCEs    = [1.0, 1.0, 1.0]
-nonAgedNoises  = [2100.0,2100.0,1600.0] #100,200,300 um (in electrons)
-nonAgedNoises_v9 = [2000.0,2400.0,2000.0] # 120,200,300 um (in electrons)
+nonAgedCCEs    = [1.0, 1.0, 1.0]            # HD120, LD200, LD300, HD120 um (in electrons) - the last entry will be ignored for v<v19
+nonAgedCCEs_v19    = [1.0, 1.0, 1.0, 1.0]            # HD120, LD200, LD300, HD120 um (in electrons) - the last entry will be ignored for v<v19
+nonAgedNoises  = [2100.0,2100.0,1600.0]   # " " notice the noise is further scaled by the size of the cell
+nonAgedNoises_v19  = [2100.0,2100.0,1600.0,2100.0]   # " " notice the noise is further scaled by the size of the cell
+nonAgedNoises_v9 = [2000.0,2400.0,2000.0] # " "
+nonAgedNoises_v9_v19 = [2000.0,2400.0,2000.0,2400.0] # " "
 thresholdTracksMIP = True
 
 HGCAL_ileakParam_toUse    = cms.PSet(
@@ -190,7 +194,9 @@ for _m in [hgceeDigitizer, hgchefrontDigitizer, hgchebackDigitizer, hfnoseDigiti
 
 #function to set noise to aged HGCal
 endOfLifeCCEs = [0.5, 0.5, 0.7] # this is to be deprecated
-endOfLifeNoises = [2400.0,2250.0,1750.0]  #this is to be deprecated
+endOfLifeNoises = [2400.0, 2250.0, 1750.0]  #this is to be deprecated
+endOfLifeCCEs_v19 = [0.5, 0.5, 0.7, 0.5] # this is to be deprecated
+endOfLifeNoises_v19 = [2400.0, 2250.0, 1750.0, 2250.0]  #this is to be deprecated
 def HGCal_setEndOfLifeNoise(process,byDose=True,byDoseAlgo=0,byDoseAlgoSci=2,byDoseFactor=1):
     """
     includes all effects from radiation and gain choice
@@ -321,6 +327,10 @@ def HGCal_setRealisticNoiseSi(process,byDose=True,byDoseAlgo=0,byDoseMap=doseMap
     process.HGCAL_noises = cms.PSet(
         values = cms.vdouble([x for x in endOfLifeNoises])  
         )
+    phase2_hgcalV19.toModify(HGCAL_noise_fC, values = cms.vdouble( [x*fC_per_ele for x in endOfLifeNoises_v19] )) #100,200,300 um, to be deprecated
+    phase2_hgcalV19.toModify(HGCAL_noise_fC, values = cms.vdouble( [x*fC_per_ele for x in endOfLifeNoises_v19] )) #100,200,300 um, to be deprecated
+    phase2_hgcalV19.toModify(HGCAL_chargeCollectionEfficiencies, values = cms.vdouble(endOfLifeNoises_v19))
+    phase2_hgcalV19.toModify(HGCAL_noise, values = cms.vdouble([x for x in endOfLifeNoises_v19]))
 
     return process
 
@@ -333,6 +343,8 @@ def HFNose_setRealisticNoiseSi(process,byDose=True,byDoseAlgo=0,byDoseMap=doseMa
         doseMap = byDoseMap,
         values = cms.vdouble( [x*fC_per_ele for x in endOfLifeNoises] ), #100,200,300 um
         )
+
+    phase2_hgcalV19.toModify(HFNose_noise_fC, values = cms.vdouble( [x*fC_per_ele for x in endOfLifeNoises_v19] )) #100,200,300 um, to be deprecated
     return process
 
 
@@ -376,6 +388,9 @@ def HGCal_disableNoise(process):
     process.HGCAL_noises = cms.PSet(
         values = cms.vdouble(0,0,0)
     )
+
+    phase2_hgcalV19.toModify(HGCAL_noise_fC, values = cms.vdouble(0.,0.,0.,0.))
+    phase2_hgcalV19.toModify(HGCAL_noises, values = cms.vdouble(0.,0.,0.,0.))
     return process
 
 from Configuration.Eras.Modifier_phase2_hgcalV10_cff import phase2_hgcalV10
@@ -383,10 +398,11 @@ from Configuration.Eras.Modifier_phase2_hgcalV10_cff import phase2_hgcalV10
 phase2_hgcalV10.toModify(HGCAL_noise_fC, values = [x*fC_per_ele for x in nonAgedNoises_v9])
 phase2_hgcalV10.toModify(HGCAL_noises, values = [x for x in nonAgedNoises_v9])
 
-from Configuration.Eras.Modifier_phase2_hgcalV19_cff import phase2_hgcalV19
 
-phase2_hgcalV19.toModify(HGCAL_noise_fC, values = [x*fC_per_ele for x in nonAgedNoises_v9])
-phase2_hgcalV19.toModify(HGCAL_noises, values = [x for x in nonAgedNoises_v9])
+phase2_hgcalV19.toModify(HGCAL_noise_fC, values = [x*fC_per_ele for x in nonAgedNoises_v9_v19])
+phase2_hgcalV19.toModify(HFNose_noise_fC, values = [x*fC_per_ele for x in nonAgedNoises_v9_v19])
+phase2_hgcalV19.toModify(HGCAL_noises, values = [x for x in nonAgedNoises_v9_v19])
+phase2_hgcalV19.toModify(HGCAL_chargeCollectionEfficiencies, values = nonAgedCCEs_v19)
 
 def HFNose_setEndOfLifeNoise(process,byDose=True,byDoseAlgo=0,byDoseFactor=1):
     """includes all effects from radiation and gain choice"""

--- a/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
@@ -383,6 +383,11 @@ from Configuration.Eras.Modifier_phase2_hgcalV10_cff import phase2_hgcalV10
 phase2_hgcalV10.toModify(HGCAL_noise_fC, values = [x*fC_per_ele for x in nonAgedNoises_v9])
 phase2_hgcalV10.toModify(HGCAL_noises, values = [x for x in nonAgedNoises_v9])
 
+from Configuration.Eras.Modifier_phase2_hgcalV19_cff import phase2_hgcalV19
+
+phase2_hgcalV19.toModify(HGCAL_noise_fC, values = [x*fC_per_ele for x in nonAgedNoises_v9])
+phase2_hgcalV19.toModify(HGCAL_noises, values = [x for x in nonAgedNoises_v9])
+
 def HFNose_setEndOfLifeNoise(process,byDose=True,byDoseAlgo=0,byDoseFactor=1):
     """includes all effects from radiation and gain choice"""
     # byDoseAlgo is used as a collection of bits to toggle: FLUENCE, CCE, NOISE, PULSEPERGAIN, CACHEDOP (from lsb to Msb)

--- a/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
@@ -329,10 +329,10 @@ def HGCal_setRealisticNoiseSi(process,byDose=True,byDoseAlgo=0,byDoseMap=doseMap
     process.HGCAL_noises = cms.PSet(
         values = cms.vdouble([x for x in endOfLifeNoises])  
         )
-    phase2_hgcalV19.toModify(HGCAL_noise_fC, values = cms.vdouble( [x*fC_per_ele for x in endOfLifeNoises_v19] )) #100,200,300 um, to be deprecated
-    phase2_hgcalV19.toModify(HGCAL_noise_fC, values = cms.vdouble( [x*fC_per_ele for x in endOfLifeNoises_v19] )) #100,200,300 um, to be deprecated
-    phase2_hgcalV19.toModify(HGCAL_chargeCollectionEfficiencies, values = cms.vdouble(endOfLifeNoises_v19))
-    phase2_hgcalV19.toModify(HGCAL_noise, values = cms.vdouble([x for x in endOfLifeNoises_v19]))
+    phase2_hgcalV19.toModify(HGCAL_noise_fC, values = [x*fC_per_ele for x in endOfLifeNoises_v19] ) #100,200,300 um, to be deprecated
+    phase2_hgcalV19.toModify(HGCAL_noise_fC, values = [x*fC_per_ele for x in endOfLifeNoises_v19] ) #100,200,300 um, to be deprecated
+    phase2_hgcalV19.toModify(HGCAL_chargeCollectionEfficiencies, values = endOfLifeNoises_v19)
+    phase2_hgcalV19.toModify(HGCAL_noise, values = [x for x in endOfLifeNoises_v19])
 
     return process
 
@@ -346,7 +346,7 @@ def HFNose_setRealisticNoiseSi(process,byDose=True,byDoseAlgo=0,byDoseMap=doseMa
         values = cms.vdouble( [x*fC_per_ele for x in endOfLifeNoises] ), #100,200,300 um
         )
 
-    phase2_hgcalV19.toModify(HFNose_noise_fC, values = cms.vdouble( [x*fC_per_ele for x in endOfLifeNoises_v19] )) #100,200,300 um, to be deprecated
+    phase2_hgcalV19.toModify(HFNose_noise_fC, values = [x*fC_per_ele for x in endOfLifeNoises_v19]) #100,200,300 um, to be deprecated
     return process
 
 
@@ -391,8 +391,8 @@ def HGCal_disableNoise(process):
         values = cms.vdouble(0,0,0,0) #HD 120, LD 200, LD 300, HD 200
     )
 
-    phase2_hgcalV19.toModify(HGCAL_noise_fC, values = cms.vdouble(0.,0.,0.,0.))
-    phase2_hgcalV19.toModify(HGCAL_noises, values = cms.vdouble(0.,0.,0.,0.))
+    phase2_hgcalV19.toModify(HGCAL_noise_fC, values = [0.,0.,0.,0.])
+    phase2_hgcalV19.toModify(HGCAL_noises, values = [0.,0.,0.,0.])
     return process
 
 from Configuration.Eras.Modifier_phase2_hgcalV10_cff import phase2_hgcalV10
@@ -403,7 +403,7 @@ phase2_hgcalV10.toModify(HGCAL_noises, values = [x for x in nonAgedNoises_v9])
 
 phase2_hgcalV19.toModify(HGCAL_noise_fC, values = [x*fC_per_ele for x in nonAgedNoises_v9_v19])
 phase2_hgcalV19.toModify(HFNose_noise_fC, values = [x*fC_per_ele for x in nonAgedNoises_v9_v19])
-phase2_hgcalV19.toModify(hgchebackDigitizer.digiCfg.feCfg, tdcForToAOnset_fC = cms.vdouble(12.,12.,12.,12.))
+phase2_hgcalV19.toModify(hgchebackDigitizer.digiCfg.feCfg, tdcForToAOnset_fC = [12.,12.,12.,12.])
 
 
 

--- a/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
@@ -403,6 +403,9 @@ phase2_hgcalV10.toModify(HGCAL_noises, values = [x for x in nonAgedNoises_v9])
 
 phase2_hgcalV19.toModify(HGCAL_noise_fC, values = [x*fC_per_ele for x in nonAgedNoises_v9_v19])
 phase2_hgcalV19.toModify(HFNose_noise_fC, values = [x*fC_per_ele for x in nonAgedNoises_v9_v19])
+phase2_hgcalV19.toModify(hgchebackDigitizer.digiCfg.feCfg, tdcForToAOnset_fC = cms.vdouble(12.,12.,12.,12.))
+
+
 
 def HFNose_setEndOfLifeNoise(process,byDose=True,byDoseAlgo=0,byDoseFactor=1):
     """includes all effects from radiation and gain choice"""

--- a/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
@@ -53,6 +53,8 @@ HGCAL_chargeCollectionEfficiencies = cms.PSet(
 HGCAL_noises = cms.PSet(
     values = cms.vdouble([x for x in nonAgedNoises])
     )
+phase2_hgcalV19.toModify(HGCAL_noises, values = [x for x in nonAgedNoises_v9_v19])
+phase2_hgcalV19.toModify(HGCAL_chargeCollectionEfficiencies, values = nonAgedCCEs_v19)
 
 # ECAL
 hgceeDigitizer = cms.PSet(
@@ -401,8 +403,6 @@ phase2_hgcalV10.toModify(HGCAL_noises, values = [x for x in nonAgedNoises_v9])
 
 phase2_hgcalV19.toModify(HGCAL_noise_fC, values = [x*fC_per_ele for x in nonAgedNoises_v9_v19])
 phase2_hgcalV19.toModify(HFNose_noise_fC, values = [x*fC_per_ele for x in nonAgedNoises_v9_v19])
-phase2_hgcalV19.toModify(HGCAL_noises, values = [x for x in nonAgedNoises_v9_v19])
-phase2_hgcalV19.toModify(HGCAL_chargeCollectionEfficiencies, values = nonAgedCCEs_v19)
 
 def HFNose_setEndOfLifeNoise(process,byDose=True,byDoseAlgo=0,byDoseFactor=1):
     """includes all effects from radiation and gain choice"""

--- a/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
@@ -30,7 +30,7 @@ HGCAL_noise_fC = cms.PSet(
     scaleByDoseAlgo = cms.uint32(0),
     scaleByDoseFactor = cms.double(1),
     doseMap = cms.string(""),
-    values = cms.vdouble( [x*fC_per_ele for x in nonAgedNoises] ), #100,200,300 um
+    values = cms.vdouble( [x*fC_per_ele for x in nonAgedNoises] ), #HD 120, LD 200, LD 300, HD 200
     )
 
 HFNose_noise_fC = HGCAL_noise_fC.clone()
@@ -376,7 +376,7 @@ def HGCal_disableNoise(process):
         scaleByDoseAlgo = cms.uint32(0),
         scaleByDoseFactor = cms.double(1),
         doseMap = cms.string(""),
-        values = cms.vdouble(0,0,0,0), #100,200,300 um
+        values = cms.vdouble(0,0,0,0), #HD 120, LD 200, LD 300, HD 200
     )
     process.HGCAL_noise_heback = cms.PSet(
         scaleByDose = cms.bool(False),
@@ -388,7 +388,7 @@ def HGCal_disableNoise(process):
         noise_MIP = cms.double(0.), #zero noise (this is to be deprecated)
         )
     process.HGCAL_noises = cms.PSet(
-        values = cms.vdouble(0,0,0,0)
+        values = cms.vdouble(0,0,0,0) #HD 120, LD 200, LD 300, HD 200
     )
 
     phase2_hgcalV19.toModify(HGCAL_noise_fC, values = cms.vdouble(0.,0.,0.,0.))

--- a/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
@@ -376,7 +376,7 @@ def HGCal_disableNoise(process):
         scaleByDoseAlgo = cms.uint32(0),
         scaleByDoseFactor = cms.double(1),
         doseMap = cms.string(""),
-        values = cms.vdouble(0,0,0), #100,200,300 um
+        values = cms.vdouble(0,0,0,0), #100,200,300 um
     )
     process.HGCAL_noise_heback = cms.PSet(
         scaleByDose = cms.bool(False),
@@ -388,7 +388,7 @@ def HGCal_disableNoise(process):
         noise_MIP = cms.double(0.), #zero noise (this is to be deprecated)
         )
     process.HGCAL_noises = cms.PSet(
-        values = cms.vdouble(0,0,0)
+        values = cms.vdouble(0,0,0,0)
     )
 
     phase2_hgcalV19.toModify(HGCAL_noise_fC, values = cms.vdouble(0.,0.,0.,0.))

--- a/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
@@ -74,6 +74,7 @@ HGCFEElectronics<DFr>::HGCFEElectronics(const edm::ParameterSet& ps)
     tdcOnset_fC_ = ps.getParameter<double>("tdcOnset_fC");
   if (ps.exists("tdcForToAOnset_fC")) {
     auto temp = ps.getParameter<std::vector<double> >("tdcForToAOnset_fC");
+    std::cout << "temp " << temp.size() << " tdcForToaOnset " << tdcForToAOnset_fC_.size() << std::endl;
     if (temp.size() == tdcForToAOnset_fC_.size()) {
       std::copy_n(temp.begin(), temp.size(), tdcForToAOnset_fC_.begin());
     } else {

--- a/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
@@ -399,15 +399,19 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr& dataFrame,
                                 << " (raw=" << finalToA << ") ns ";
 
     //last fC (tdcOnset) are dissipated trough pulse
-    if (it + busyBxs < (int)(newCharge_.size())) {
-      const float deltaT2nextBx((busyBxs * 25 - integTime));
-      const float tdcOnsetLeakage(tdcOnset * vdt::fast_expf(-deltaT2nextBx / tdcChargeDrainParameterisation_[11]));
+    int ft = it + busyBxs;
+    constexpr size_t tdcLeakageTauIdx_ = 11;
+    if (ft > it && ft < static_cast<int>(newCharge_.size()) &&
+        tdcChargeDrainParameterisation_.size() > tdcLeakageTauIdx_) {
+      const float deltaT2nextBx((busyBxs * 25.0f - integTime));
+      const float tdcOnsetLeakage(tdcOnset *
+                                  vdt::fast_expf(-deltaT2nextBx / tdcChargeDrainParameterisation_[tdcLeakageTauIdx_]));
       if (debug)
         edm::LogVerbatim("HGCFE") << "\t Leaking remainder of TDC onset " << tdcOnset << " fC, to be dissipated in "
                                   << deltaT2nextBx << " DeltaT/tau=" << deltaT2nextBx << " / "
-                                  << tdcChargeDrainParameterisation_[11] << " ns, adds " << tdcOnsetLeakage << " fC @ "
-                                  << it + busyBxs << " bx (first free bx)";
-      newCharge_[it + busyBxs] += tdcOnsetLeakage;
+                                  << tdcChargeDrainParameterisation_[tdcLeakageTauIdx_] << " ns, adds "
+                                  << tdcOnsetLeakage << " fC @ " << it + busyBxs << " bx (first free bx)";
+      newCharge_[ft] += tdcOnsetLeakage;
     }
   }
 

--- a/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
@@ -74,7 +74,6 @@ HGCFEElectronics<DFr>::HGCFEElectronics(const edm::ParameterSet& ps)
     tdcOnset_fC_ = ps.getParameter<double>("tdcOnset_fC");
   if (ps.exists("tdcForToAOnset_fC")) {
     auto temp = ps.getParameter<std::vector<double> >("tdcForToAOnset_fC");
-    std::cout << "temp " << temp.size() << " tdcForToaOnset " << tdcForToAOnset_fC_.size() << std::endl;
     if (temp.size() == tdcForToAOnset_fC_.size()) {
       std::copy_n(temp.begin(), temp.size(), tdcForToAOnset_fC_.begin());
     } else {

--- a/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
@@ -74,6 +74,7 @@ HGCFEElectronics<DFr>::HGCFEElectronics(const edm::ParameterSet& ps)
     tdcOnset_fC_ = ps.getParameter<double>("tdcOnset_fC");
   if (ps.exists("tdcForToAOnset_fC")) {
     auto temp = ps.getParameter<std::vector<double> >("tdcForToAOnset_fC");
+    tdcForToAOnset_fC_.resize(temp.size());
     if (temp.size() == tdcForToAOnset_fC_.size()) {
       std::copy_n(temp.begin(), temp.size(), tdcForToAOnset_fC_.begin());
     } else {

--- a/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
@@ -95,18 +95,29 @@ HGCFEElectronics<DFr>::HGCFEElectronics(const edm::ParameterSet& ps)
 
   if (ps.exists("jitterNoise_ns")) {
     auto temp = ps.getParameter<std::vector<double> >("jitterNoise_ns");
+    jitterNoise_ns_.resize(temp.size());
     if (temp.size() == jitterNoise_ns_.size()) {
       std::copy_n(temp.begin(), temp.size(), jitterNoise_ns_.begin());
     } else {
-      throw cms::Exception("BadConfiguration") << " HGCFEElectronics wrong size for ToA jitterNoise ";
+      throw cms::Exception("BadConfiguration") << " HGCFEElectronics wrong size for ToA jitterNoise";
     }
   }
   if (ps.exists("jitterConstant_ns")) {
     auto temp = ps.getParameter<std::vector<double> >("jitterConstant_ns");
+    jitterConstant_ns_.resize(temp.size());
     if (temp.size() == jitterConstant_ns_.size()) {
       std::copy_n(temp.begin(), temp.size(), jitterConstant_ns_.begin());
     } else {
       throw cms::Exception("BadConfiguration") << " HGCFEElectronics wrong size for ToA jitterConstant ";
+    }
+  }
+  if (ps.exists("eventTimeOffset_ns")) {
+    auto temp = ps.getParameter<std::vector<double> >("eventTimeOffset_ns");
+    eventTimeOffset_ns_.resize(temp.size());
+    if (temp.size() == eventTimeOffset_ns_.size()) {
+      std::copy_n(temp.begin(), temp.size(), eventTimeOffset_ns_.begin());
+    } else {
+      throw cms::Exception("BadConfiguration") << " HGCFEElectronics wrong size for event time offset";
     }
   }
 }


### PR DESCRIPTION
#### PR description:
This PR should go on top of #48287 fixing the HLT and RECO part for V19 geometry.
Also in this case the PR is not ready but it would benefit from the CI/CD tests to spot additional errors in moving to the new geometry. 

####: For testing this PR:
- Include #48287
- Include #48301
- Test on V19 workflow : 34034.0 


FYI: @felicepantaleo @pfs  @jbsauvan @EmyrClement @indra-ehep @bsunanda
