### PR TITLE
[15_0_X] Update for Masked VFAT plots on GEM onlineDQM to backport 15_0_X

### DIFF
--- a/DQM/GEM/interface/GEMDAQStatusSource.h
+++ b/DQM/GEM/interface/GEMDAQStatusSource.h
@@ -33,13 +33,13 @@
 class GEMDAQStatusSource : public GEMDQMBase {
 public:
   explicit GEMDAQStatusSource(const edm::ParameterSet &cfg);
-  ~GEMDAQStatusSource() override {}
+  ~GEMDAQStatusSource() override {};
   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 protected:
   void LoadROMap(edm::EventSetup const &iSetup);
 
-  void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override {}
+  void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override {};
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(edm::Event const &e, edm::EventSetup const &eSetup) override;
 
@@ -85,6 +85,7 @@ private:
 
   MEMap4Inf mapStatusWarnVFATPerLayer_;
   MEMap4Inf mapStatusErrVFATPerLayer_;
+  MEMap4Inf mapStatusMaskedVFATPerLayer_;
   MEMap5Inf mapStatusVFATPerCh_;
 
   MonitorElement *h2SummaryStatusAll;

--- a/DQM/GEM/plugins/GEMDAQStatusSource.cc
+++ b/DQM/GEM/plugins/GEMDAQStatusSource.cc
@@ -207,6 +207,8 @@ void GEMDAQStatusSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run con
       this, "vfat_statusWarnSum", "VFAT reporting warnings", 36, 0.5, 36.5, 24, -0.5, 24 - 0.5, "Chamber", "VFAT");
   mapStatusErrVFATPerLayer_ = MEMap4Inf(
       this, "vfat_statusErrSum", "VFAT reporting errors", 36, 0.5, 36.5, 24, -0.5, 24 - 0.5, "Chamber", "VFAT");
+  mapStatusMaskedVFATPerLayer_ = MEMap4Inf(
+      this, "vfat_statusMaskedSum", "VFAT reporting masked", 36, 0.5, 36.5, 24, -0.5, 24 - 0.5, "Chamber", "VFAT");
   mapStatusVFATPerCh_ =
       MEMap5Inf(this, "vfat_status", "VFAT Status", 24, -0.5, 24 - 0.5, nBitVFAT_, 0.5, nBitVFAT_ + 0.5, "VFAT");
 
@@ -214,6 +216,7 @@ void GEMDAQStatusSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run con
     mapStatusOH_.TurnOff();
     mapStatusWarnVFATPerLayer_.TurnOff();
     mapStatusErrVFATPerLayer_.TurnOff();
+    mapStatusMaskedVFATPerLayer_.TurnOff();
     mapStatusVFATPerCh_.TurnOff();
   }
 
@@ -276,6 +279,12 @@ int GEMDAQStatusSource::ProcessWithMEMap4(BookingHelper &bh, ME4IdsKey key) {
   mapStatusErrVFATPerLayer_.bookND(bh, key);
   mapStatusErrVFATPerLayer_.SetLabelForChambers(key, 1, -1, nNewMinIdxChamber);
   mapStatusErrVFATPerLayer_.SetLabelForVFATs(key, stationInfo.nNumEtaPartitions_, 2);
+
+  mapStatusMaskedVFATPerLayer_.SetBinConfX(nNewNumCh, nNewMinIdxChamber - 0.5, nNewMaxIdxChamber + 0.5);
+  mapStatusMaskedVFATPerLayer_.SetBinConfY(nNumVFATPerModule, -0.5);
+  mapStatusMaskedVFATPerLayer_.bookND(bh, key);
+  mapStatusMaskedVFATPerLayer_.SetLabelForChambers(key, 1, -1, nNewMinIdxChamber);
+  mapStatusMaskedVFATPerLayer_.SetLabelForVFATs(key, stationInfo.nNumEtaPartitions_, 2);
 
   return 0;
 }
@@ -485,8 +494,8 @@ void GEMDAQStatusSource::analyze(edm::Event const &event, edm::EventSetup const 
 
       for (Int_t i = 0; i < nNumVFATPerModule; i++) {
         if ((vfatMask & (1 << i)) == 0) {
-          // -16: A sufficient large number to avoid any effect from a buggy filling
           mapStatusErrVFATPerLayer_.Fill(key4, nCh, i, -16);
+          mapStatusMaskedVFATPerLayer_.Fill(key4, nCh, i, 1.0);
         }
       }
 


### PR DESCRIPTION
#### PR description:

In this PR, GEM onlineDQM plots for Masked VFAT plots have been implemented 

#### PR validation:

Tests are done with cmsRun $CMSSW_RELEASE_BASE/src/DQM/Integration/python/clients/gem_dqm_sourceclient-live_cfg.py unitTest=True runNumber=387696 dataset=/ExpressPhysics/Run2024J-Express-v1/FEVT minLumi=19 maxLumi=21 and runTheMatrix.py -l limited -i all --ibeos since it makes effects on P5 and reconstruction

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is a backport of https://github.com/cms-sw/cmssw/pull/47993 to 15_0_X

@jshlee @watson-ij @Dongwoon77
