### PR TITLE
Update 150X GTs as of 13/06/2025 in autoCond

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -31,12 +31,12 @@ autoCond = {
     'run2_data_promptlike_hi'      :    '140X_dataRun2_PromptLike_HI_v1',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              :    '140X_dataRun2_HLT_relval_v1',
-    # GlobalTag for Run3 HLT: identical the online GT 150X_dataRun3_HLT_v1 but with snapshot at 2025-01-22 13:40:56 (UTC)
-    'run3_hlt'                     :    '150X_dataRun3_HLT_frozen250122_v1',
-    # GlobalTag for Run3 data relvals (express GT): same as 150X_dataRun3_Express_v1 but with snapshot at 2025-01-22 13:46:42 (UTC)
-    'run3_data_express'            :    '150X_dataRun3_Express_frozen250122_v1',
-    # GlobalTag for Run3 data relvals (prompt GT): same as 150X_dataRun3_Prompt_v1 but with snapshot at 2025-01-22 13:49:01 (UTC)
-    'run3_data_prompt'             :    '150X_dataRun3_Prompt_frozen250122_v1',
+    # GlobalTag for Run3 HLT: identical the online GT 150X_dataRun3_HLT_v1 but with snapshot at 2025-06-13 05:00:25 (UTC)
+    'run3_hlt'                     :    '150X_dataRun3_HLT_frozen250613_v1',
+    # GlobalTag for Run3 data relvals (express GT): same as 150X_dataRun3_Express_v1 but with snapshot at 2025-06-13 05:03:22 (UTC)
+    'run3_data_express'            :    '150X_dataRun3_Express_frozen250613_v1',
+    # GlobalTag for Run3 data relvals (prompt GT): same as 150X_dataRun3_Prompt_v1 but with snapshot at 2025-06-13 05:06:05 (UTC)
+    'run3_data_prompt'             :    '150X_dataRun3_Prompt_frozen250613_v1',
     # GlobalTag for Run3 offline data reprocessing - snapshot at 2025-04-10 16:45:49 (UTC)
     'run3_data'                    :    '150X_dataRun3_v4',
     # GlobalTag for Run3 offline data reprocessing with Prompt GT, currently for 2022FG - snapshot at 2024-05-31 08:53:25 (UTC)
@@ -102,11 +102,11 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2024 detector for ppRef5TeV
     'phase1_2024_realistic_ppRef5TeV' : '141X_mcRun3_2024_realistic_ppRef5TeV_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2025
-    'phase1_2025_design'           :    '150X_mcRun3_2025_design_v2',
+    'phase1_2025_design'           :    '150X_mcRun3_2025_design_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2025
-    'phase1_2025_realistic'        :    '150X_mcRun3_2025_realistic_v7',
+    'phase1_2025_realistic'        :    '150X_mcRun3_2025_realistic_v10',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2025, Strip tracker in DECO mode
-    'phase1_2025_cosmics'          :    '150X_mcRun3_2025cosmics_realistic_deco_v2',
+    'phase1_2025_cosmics'          :    '150X_mcRun3_2025cosmics_realistic_deco_v3',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             :    '150X_mcRun4_realistic_v1'
 }

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -104,7 +104,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2025
     'phase1_2025_design'           :    '150X_mcRun3_2025_design_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2025
-    'phase1_2025_realistic'        :    '150X_mcRun3_2025_realistic_v10',
+    'phase1_2025_realistic'        :    '150X_mcRun3_2025_realistic_v11',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2025, Strip tracker in DECO mode
     'phase1_2025_cosmics'          :    '150X_mcRun3_2025cosmics_realistic_deco_v3',
     # GlobalTag for MC production with realistic conditions for Phase2

--- a/Configuration/AlCa/python/autoCondModifiers.py
+++ b/Configuration/AlCa/python/autoCondModifiers.py
@@ -115,7 +115,7 @@ def autoCondRelValForRun3(autoCond):
 
     GlobalTagRelValForRun3 = {}
     L1GtTriggerMenuForRelValForRun3 =    ','.join( ['L1Menu_Collisions2015_25nsStage1_v5' , "L1GtTriggerMenuRcd",             connectionString, "", "2023-01-28 12:00:00.000"] )
-    L1TUtmTriggerMenuForRelValForRun3 =  ','.join( ['L1Menu_Collisions2025_v1_1_1_xml'    , "L1TUtmTriggerMenuRcd",           connectionString, "", "2025-05-05 12:00:00.000"] )
+    L1TUtmTriggerMenuForRelValForRun3 =  ','.join( ['L1Menu_Collisions2025_v1_2_0_xml'    , "L1TUtmTriggerMenuRcd",           connectionString, "", "2025-06-13 12:00:00.000"] )
 
     for key,val in autoCond.items():
         if 'run3_data' in key or 'run3_hlt' in key :


### PR DESCRIPTION
#### PR description:

The following GTs were updated in autocond:

- Made a frozen version of the HLT, Express, Prompt GTs with snapshots as of 13/06/2025, so that the latest appended payloads can be included in the corresponding IOVs:
  - [150X_dataRun3_HLT_frozen250613_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/150X_dataRun3_HLT_frozen250613_v1)
  - [150X_dataRun3_Express_frozen250613_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/150X_dataRun3_Express_frozen250613_v1)
  - [150X_dataRun3_Prompt_frozen250613_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/150X_dataRun3_Prompt_frozen250613_v1)

- Updated the 2025MC GT with the latest additions towards the final Spring25MC GT. The GT version put in autoCond is _v11, which includes all updates implemented in the following versions (and can be considered the final one for the Spring25MC campaign, modulo the result of its validation):
  - [150X_mcRun3_2025_realistic_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/150X_mcRun3_2025_realistic_v8)
    - Update the SiPixelQuality tag requested in https://cms-talk.web.cern.ch/t/call-for-conditions-for-the-spring25-mc-global-tag/119464/23
    - Updated L1T menu as from https://cms-talk.web.cern.ch/t/gt-mc-data-relval-update-of-the-gt-with-the-new-2025-l1t-menu-tag-l1menu-collisions2025-v1-2-0-xml/125856
  - [150X_mcRun3_2025_realistic_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/150X_mcRun3_2025_realistic_v9)
    - Revert the 2025 GEM geometry tags that were inserted in 150X_mcRun3_2025_realistic_v3, because of the issue described in https://github.com/cms-sw/cmssw/issues/48254
  - [150X_mcRun3_2025_realistic_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/150X_mcRun3_2025_realistic_v10)
    - Temporary BeamSpot tags that will be used to generate and fit the RelVals needed to measure the final 2025 Beamspot tags, see https://cms-talk.web.cern.ch/t/call-for-conditions-for-the-spring25-mc-global-tag/119464/25
   - [150X_mcRun3_2025_realistic_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/150X_mcRun3_2025_realistic_v11)
    - Final BeamSpot tags for Spring25MC, see https://cms-talk.web.cern.ch/t/call-for-conditions-for-the-spring25-mc-global-tag/119464/27
  - Difference between _v11 and _v7 (the 2025MC GT version previously in autocond) can be inspected [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/150X_mcRun3_2025_realistic_v11/150X_mcRun3_2025_realistic_v7)

- The following additional 2025MC GTs were also updated with the new L1T menu as from https://cms-talk.web.cern.ch/t/gt-mc-data-relval-update-of-the-gt-with-the-new-2025-l1t-menu-tag-l1menu-collisions2025-v1-2-0-xml/125856
  - [150X_mcRun3_2025cosmics_realistic_deco_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/150X_mcRun3_2025cosmics_realistic_deco_v3)
  - [150X_mcRun3_2025_design_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/150X_mcRun3_2025_design_v3)

#### PR validation:

Short matrix successfully run

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

It will be backported to 150X