### PR TITLE
Remove Redundant Condition Check in HCAL TP Algorithm Setup Code

### DIFF
--- a/SimCalorimetry/HcalTrigPrimProducers/plugins/HcalTrigPrimDigiProducer.cc
+++ b/SimCalorimetry/HcalTrigPrimProducers/plugins/HcalTrigPrimDigiProducer.cc
@@ -180,9 +180,6 @@ void HcalTrigPrimDigiProducer::beginRun(const edm::Run& run, const edm::EventSet
       continue;
 
     int aieta = std::abs(hcalTTDetId.ieta());
-    // Do not let ieta 29 in the map
-    if (aieta >= lastHERing)
-      continue;
 
     // Filter weight represented in fixed point 8 bit
     int fixedPointWeight = 255;


### PR DESCRIPTION
#### PR description:

This PR removes a small conditional check in the HCAL trigger primitive algorithm setup code. The removed conditional check is redundant with nearby logic, and causes issues in Phase2 workflows when `lastHERing` is `0`, whereby the legacy, $\leq$ Run2 algorithm is always selected, regardless of `HcalTPChannelParameters` content. No changes are expected for < Phase2 workflows, and non-trivial changes _are_ expected for Phase2 workflows.

#### PR validation:

Compiles and a private Phase2 workflow runs without issue.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
