### PR TITLE
[15_1_X] Remove trailing blanks in the ECAL DQM histogram naming that cause error in ROOT636 and ROOT6 IBs

### DIFF
--- a/DQM/EcalMonitorTasks/python/TrigPrimTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/TrigPrimTask_cfi.py
@@ -273,7 +273,7 @@ ecalTrigPrimTask = cms.untracked.PSet(
             description = cms.untracked.string('Distribution of the trigger primitive Et.')
         ),
         EtRealSpikeMatched = cms.untracked.PSet(
-            path = cms.untracked.string('%(subdet)s/%(prefix)sTriggerTowerTask/%(prefix)sTTT Et spectrum Real Digis matched to spikes %(suffix)s'),
+            path = cms.untracked.string('%(subdet)s/%(prefix)sTriggerTowerTask/%(prefix)sTTT Et spectrum Real Digis matched to spikes%(suffix)s'),
             kind = cms.untracked.string('TH1F'),
             otype = cms.untracked.string('Ecal3P'),
             xaxis = cms.untracked.PSet(


### PR DESCRIPTION
#### PR description:

This PR fixes an error from ECAL DQM that comes from trailing blank in the histogram name when running relval in ROOT636 and ROOT6 IBs, where the error reported was the following (see the thread from #48278): 

```
[#0] ERROR:Minimization -- RooMinimizer::calculateHessErrors() Error when calculating Hessian
[#0] ERROR:Minimization -- RooMinimizer::calculateHessErrors() Error when calculating Hessian
[#0] ERROR:Minimization -- RooMinimizer::calculateHessErrors() Error when calculating Hessian
DQMFileSaver::globalEndRun()
----- Begin Fatal Exception 12-Jun-2025 20:53:54 CEST-----------------------
An exception of category 'FatalRootError' occurred while
   [0] Processing end ProcessBlock
   [1] Calling method for module DQMFileSaver/'dqmSaver'
   Additional Info:
      [a] Fatal Root Error: @SUB=TDirectoryFile::WriteTObject
The key name 'EBTTT Et spectrum Real Digis matched to spikes ' will be stored in file without the trailing blanks.

----- End Fatal Exception -------------------------------------------------
```

#### PR validation:

This PR is validated by running test with the following commands:
```
# To run the test
cmssw-el8
scram project  CMSSW_15_1_ROOT6_X_2025-06-12-2300
cd CMSSW_15_1_ROOT6_X_2025-06-12-2300
cmsenv
runTheMatrix.py -i all -l 4.17 --ibeos
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is the master PR. Backport to `15_0_X` is made in #48313.