### PR TITLE
Added std::span support to make_device_view and make_host_view

### DIFF
--- a/HeterogeneousCore/AlpakaInterface/README.md
+++ b/HeterogeneousCore/AlpakaInterface/README.md
@@ -357,6 +357,10 @@ These helper functions instantiate zero-dimensional (scalars) and one-dimensiona
     instantiates a one-dimensional view over an array starting at `data` with
     `size` elements in host memory;
 
+  - `auto make_host_view<T[]>(std::span<T> span)`
+    instantiates a one-dimensional view over an array starting at `span.data()` with
+    `span.size()` elements in host memory;
+
 
 ## Device memory views
 
@@ -393,6 +397,10 @@ These helper functions instantiate zero-dimensional (scalars) and one-dimensiona
     instantiates a one-dimensional view over an array starting at `data` with
     `size` elements in device global memory.
 
+  - `auto make_device_view<T[]>(device, std::span<T> span)`
+    instantiates a one-dimensional view over an array starting at `span.data()` with
+    `span.size()` elements in device global memory.
+
 The `make_device_view` functions can also accept as a first argument a `queue`
 instead of a `device`:
 
@@ -407,6 +415,10 @@ instead of a `device`:
   - `auto make_device_view<T[]>(queue, T* data, size)`
     instantiates a one-dimensional view over an array starting at `data` with
     `size` elements in device global memory.
+
+  - `auto make_device_view<T[]>(queue, std::span<T> span)`
+    instantiates a one-dimensional view over an array starting at `span.data()` with
+    `span.size()` elements in device global memory.  
 
 These functions use the device associated to the given `queue`. These operations
 are otherwise identical to those that take a `device` as their first argument.


### PR DESCRIPTION
#### PR description:

This PR extends `make_device_view` and `make_host_view` functions to take a `std::span<T>` as input, instead of a pointer and a size.
