### PR TITLE
Fix memory leak in GenHFHadronMatcher

### DIFF
--- a/PhysicsTools/JetMCAlgos/plugins/GenHFHadronMatcher.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/GenHFHadronMatcher.cc
@@ -53,7 +53,8 @@
 class GenHFHadronMatcher : public edm::global::EDProducer<> {
 public:
   explicit GenHFHadronMatcher(const edm::ParameterSet &);
-  ~GenHFHadronMatcher() override;
+
+  ~GenHFHadronMatcher() override = default;
 
   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
@@ -71,12 +72,13 @@ private:
                                   std::vector<int> &hadFlavour,
                                   std::vector<int> &hadFromTopWeakDecay,
                                   std::vector<int> &hadBHadronId) const;
+
   int analyzeMothers(const reco::Candidate *thisParticle,
                      int &topDaughterQId,
                      int &topBarDaughterQId,
                      std::vector<const reco::Candidate *> &hadMothers,
                      std::vector<std::vector<int>> &hadMothersIndices,
-                     std::set<const reco::Candidate *> *analyzedParticles,
+                     std::set<const reco::Candidate *> &analyzedParticles,
                      const int prevPartIndex) const;
   bool putMotherIndex(std::vector<std::vector<int>> &hadMothersIndices, int partIndex, int mothIndex) const;
   bool isHadron(const int flavour, const reco::Candidate *thisParticle) const;
@@ -202,8 +204,6 @@ GenHFHadronMatcher::GenHFHadronMatcher(const edm::ParameterSet &cfg)
   // Hadron matching products
 }
 
-GenHFHadronMatcher::~GenHFHadronMatcher() {}
-
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 /**
 * @brief description of the run-time parameters
@@ -237,7 +237,7 @@ void GenHFHadronMatcher::produce(edm::StreamID, edm::Event &evt, const edm::Even
   edm::Handle<reco::JetFlavourInfoMatchingCollection> jetFlavourInfos;
   evt.getByToken(jetFlavourInfosToken_, jetFlavourInfos);
 
-  // Defining adron matching variables
+  // Defining hadron matching variables
   std::vector<reco::GenParticle> hadMothers;
   std::vector<std::vector<int>> hadMothersIndices;
   std::vector<int> hadIndex;
@@ -331,12 +331,13 @@ std::vector<int> GenHFHadronMatcher::findHadronJets(const reco::GenParticleColle
       if (hasHadronDaughter(flavour_, (reco::Candidate *)(&**hadron)))
         continue;
       // Scanning the chain starting from the hadron
+      std::set<const reco::Candidate *> analyzedParticles;
       int hadronIndex = analyzeMothers((reco::Candidate *)(&**hadron),
                                        topDaughterQId,
                                        topBarDaughterQId,
                                        hadMothersCand,
                                        hadMothersIndices,
-                                       nullptr,
+                                       analyzedParticles,
                                        -1);
       // Storing the index of the hadron to the list
       hadIndex.push_back(hadronIndex);
@@ -357,8 +358,9 @@ std::vector<int> GenHFHadronMatcher::findHadronJets(const reco::GenParticleColle
         continue;
 
       // Scanning the chain starting from the hadron
+      std::set<const reco::Candidate *> analyzedParticles;
       int hadronIndex = analyzeMothers(
-          thisParticle, topDaughterQId, topBarDaughterQId, hadMothersCand, hadMothersIndices, nullptr, -1);
+          thisParticle, topDaughterQId, topBarDaughterQId, hadMothersCand, hadMothersIndices, analyzedParticles, -1);
       // Storing the index of the hadron to the list
       hadIndex.push_back(hadronIndex);
       hadJetIndex.push_back(-1);  // Jet index undefined
@@ -728,7 +730,7 @@ int GenHFHadronMatcher::analyzeMothers(const reco::Candidate *thisParticle,
                                        int &topBarDaughterQId,
                                        std::vector<const reco::Candidate *> &hadMothers,
                                        std::vector<std::vector<int>> &hadMothersIndices,
-                                       std::set<const reco::Candidate *> *analyzedParticles,
+                                       std::set<const reco::Candidate *> &analyzedParticles,
                                        const int prevPartIndex) const {
   // Getting the index of the particle which is a hadron in the first call
   int hadronIndex = -1;  // Index of the hadron that is returned by this function
@@ -745,11 +747,8 @@ int GenHFHadronMatcher::analyzeMothers(const reco::Candidate *thisParticle,
 
   // Checking whether this particle is already in the chain of analyzed particles in order to identify a loop
   bool isLoop = false;
-  if (!analyzedParticles) {
-    analyzedParticles = new std::set<const reco::Candidate *>;
-  }
-  for (unsigned int i = 0; i < analyzedParticles->size(); i++) {
-    if (analyzedParticles->count(thisParticle) <= 0) {
+  for (unsigned int i = 0; i < analyzedParticles.size(); i++) {
+    if (analyzedParticles.count(thisParticle) <= 0) {
       continue;
     }
     isLoop = true;
@@ -763,7 +762,7 @@ int GenHFHadronMatcher::analyzeMothers(const reco::Candidate *thisParticle,
     }
     return hadronIndex;  // Stopping further processing of the current chain
   }
-  analyzedParticles->insert(thisParticle);
+  analyzedParticles.insert(thisParticle);
 
   // Putting the mothers to the list of mothers
   for (size_t iMother = 0; iMother < thisParticle->numberOfMothers(); ++iMother) {
@@ -801,7 +800,7 @@ int GenHFHadronMatcher::analyzeMothers(const reco::Candidate *thisParticle,
     }  // If the mother is a top quark and hadron has been found
   }  // End of loop over mothers
 
-  analyzedParticles->erase(thisParticle);  // Removing current particle from the current chain that is being analyzed
+  analyzedParticles.erase(thisParticle);  // Removing current particle from the current chain that is being analyzed
 
   if (partIndex < 0) {
     return hadronIndex;  // Safety check


### PR DESCRIPTION
#### PR description:

Resolves the (ancient) issue of https://github.com/cms-sw/cmssw/issues/23525

#### PR validation:

Code compiles. Not sure what wf uses this, the original "This adds up to about 250 bytes/event in wf 1325.7" doesnt exists anymore.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport and no backport is needed