### PR TITLE
improve / fix Phase2 OT rechits validation for HLT

### DIFF
--- a/Validation/SiTrackerPhase2V/interface/Phase2OTValidateRecHitBase.h
+++ b/Validation/SiTrackerPhase2V/interface/Phase2OTValidateRecHitBase.h
@@ -71,10 +71,17 @@ protected:
     MonitorElement* deltaX_S = nullptr;
     MonitorElement* deltaY_P = nullptr;
     MonitorElement* deltaY_S = nullptr;
+
+    MonitorElement* errX_P = nullptr;
+    MonitorElement* errX_S = nullptr;
+    MonitorElement* errY_P = nullptr;
+    MonitorElement* errY_S = nullptr;
+
     MonitorElement* pullX_P = nullptr;
     MonitorElement* pullX_S = nullptr;
     MonitorElement* pullY_P = nullptr;
     MonitorElement* pullY_S = nullptr;
+
     MonitorElement* deltaX_eta_P = nullptr;
     MonitorElement* deltaX_eta_S = nullptr;
     MonitorElement* deltaY_eta_P = nullptr;
@@ -83,10 +90,25 @@ protected:
     MonitorElement* deltaX_phi_S = nullptr;
     MonitorElement* deltaY_phi_P = nullptr;
     MonitorElement* deltaY_phi_S = nullptr;
+
+    /*
+      As the error is a constant these for now are not needed
+
+      MonitorElement* errX_eta_P = nullptr;
+      MonitorElement* errX_eta_S = nullptr;
+      MonitorElement* errY_eta_P = nullptr;
+      MonitorElement* errY_eta_S = nullptr;
+      MonitorElement* errX_phi_P = nullptr;
+      MonitorElement* errX_phi_S = nullptr;
+      MonitorElement* errY_phi_P = nullptr;
+      MonitorElement* errY_phi_S = nullptr;
+    */
+
     MonitorElement* pullX_eta_P = nullptr;
     MonitorElement* pullX_eta_S = nullptr;
     MonitorElement* pullY_eta_P = nullptr;
     MonitorElement* pullY_eta_S = nullptr;
+
     //For rechits matched to simhits from highPT tracks
     MonitorElement* pullX_primary_P;
     MonitorElement* pullX_primary_S;

--- a/Validation/SiTrackerPhase2V/python/HLTPhase2TrackerValidationFirstStep_cff.py
+++ b/Validation/SiTrackerPhase2V/python/HLTPhase2TrackerValidationFirstStep_cff.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 from Validation.SiTrackerPhase2V.Phase2ITValidateCluster_cff import *
 from Validation.SiTrackerPhase2V.Phase2OTValidateCluster_cff import *
 from Validation.SiTrackerPhase2V.Phase2ITValidateRecHit_cff import *
+from Validation.SiTrackerPhase2V.Phase2OTValidateRecHit_cff import *
 from Validation.SiTrackerPhase2V.Phase2ITValidateTrackingRecHit_cff import *
 from Validation.SiTrackerPhase2V.Phase2OTValidateTrackingRecHit_cff import *
 
@@ -20,6 +21,11 @@ hltRechitValidIT = rechitValidIT.clone(
     TopFolderName = 'HLT/TrackerPhase2ITRecHitV',
 )
 
+hltRechitValidOT = rechitValidOT.clone(
+    rechitsSrc = "hltSiPhase2RecHits",
+    TopFolderName = 'HLT/TrackerPhase2OTRecHitV',
+)
+
 hltTrackingRechitValidIT = trackingRechitValidIT.clone(
     tracksSrc = "hltGeneralTracks",
     TopFolderName = 'HLT/TrackerPhase2ITTrackingRecHitV'
@@ -35,3 +41,12 @@ hltTrackerphase2ValidationSource = cms.Sequence(hltClusterValidIT +
                                                 hltRechitValidIT  +
                                                 hltTrackingRechitValidIT +
                                                 hltTrackingRechitValidOT)
+
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
+
+# Conditionally add hltRechitValidOT if either trackingLST or seedingLST is active
+(trackingLST | seedingLST).toModify(
+    hltTrackerphase2ValidationSource,
+    lambda s: s.__iadd__(hltRechitValidOT)
+)

--- a/Validation/SiTrackerPhase2V/python/Phase2OTValidateRecHit_cff.py
+++ b/Validation/SiTrackerPhase2V/python/Phase2OTValidateRecHit_cff.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+from Validation.SiTrackerPhase2V.Phase2OTValidateRecHit_cfi import * 
+
+rechitValidOT = Phase2OTValidateRecHit.clone()
+
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+premix_stage2.toModify(rechitValidOT,
+    phase2TrackerSimLinkSrc = "mixData:Phase2OTDigiSimLink",
+)


### PR DESCRIPTION
#### PR description:

The goal of this PR is multiple:
   * fix-up wrong filling / booking of Strip and macro-pixel rechit pull plots
   * add local errors histograms (profiles vs eta / phi commented for now, until the error is constant)
   * run the OT Rechit validation in presence of the `trackingLST` and `seedingLST` modifiers.

#### PR validation:

`runTheMatrix.py -l ph2_hlt` runs fine.
I checked explicitly that e.g.:
   * the DQM file of 29634.754 `TTbar_14TeV+Run4D110_HLT75e33TimingAlpakaSingleIterLST` has the recHits plots
   * the DQM file of 29634.75 `TTbar_14TeV+Run4D110_HLT75e33Timing` has not.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, not to be backported