### PR TITLE
Changed openmpi to mpi in HeterogeneousCore packages

### DIFF
--- a/HeterogeneousCore/CUDACore/test/BuildFile.xml
+++ b/HeterogeneousCore/CUDACore/test/BuildFile.xml
@@ -24,7 +24,7 @@
 
   <bin name="mpiCudaGeneric" file="mpiCudaGeneric.cu">
     <use name="cuda"/>
-    <use name="openmpi"/>
+    <use name="mpi"/>
     <use name="HeterogeneousCore/CUDAUtilities"/>
     <flags TEST_RUNNER_CMD="cudaIsEnabled &amp;&amp; cmsenv_mpirun -np 2 mpiCudaGeneric -t100 -a10 -s200000 -p123 || echo 'Failed to initialise the CUDA runtime, the test will be skipped.'"/>
   </bin>

--- a/HeterogeneousCore/MPICore/test/BuildFile.xml
+++ b/HeterogeneousCore/MPICore/test/BuildFile.xml
@@ -1,5 +1,5 @@
 <bin name="testMPI" file="testMPI.cc">
-    <use name="openmpi"/>
+    <use name="mpi"/>
     <flags TEST_RUNNER_CMD="mpirun -np 4 testMPI -s 1000 -r 12345 -n 10"/>
 </bin>
 

--- a/HeterogeneousCore/MPIServices/BuildFile.xml
+++ b/HeterogeneousCore/MPIServices/BuildFile.xml
@@ -1,4 +1,4 @@
-<use name="openmpi"/>
+<use name="mpi"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/ServiceRegistry"/>
 <export>

--- a/HeterogeneousCore/MPIServices/plugins/BuildFile.xml
+++ b/HeterogeneousCore/MPIServices/plugins/BuildFile.xml
@@ -1,4 +1,4 @@
-<use name="openmpi"/>
+<use name="mpi"/>
 <use name="FWCore/ServiceRegistry"/>
 <use name="HeterogeneousCore/MPIServices"/>
 <flags EDM_PLUGIN="1"/>


### PR DESCRIPTION
#### PR description:

For compatibility with the next version of CMSSW this pr changes BuildFile.xml in HeteroheneousCore packages to use name mpi instead of openmpi

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

<!-- Please delete the text above after you verified all points of the checklist  -->
