### PR TITLE
MTD geometry: update defaults test scenario for MTD to D121

### DIFF
--- a/Geometry/MTDCommonData/python/defaultMTDConditionsEra_cff.py
+++ b/Geometry/MTDCommonData/python/defaultMTDConditionsEra_cff.py
@@ -1,6 +1,6 @@
 import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _centralgeo
 
-MTD_DEFAULT_VERSION = "Run4D110"
+MTD_DEFAULT_VERSION = "Run4D121"
 
 def check_mtdgeo():
     if MTD_DEFAULT_VERSION != _centralgeo.DEFAULT_VERSION:


### PR DESCRIPTION
#### PR description:

Following the update of the central CMS default upgrade geometry scenario https://github.com/cms-sw/cmssw/pull/48297 and the decoupling of the MTD scenario to be used for unit tests, provided by https://github.com/cms-sw/cmssw/pull/48300 per request of the geometry conveners, this PR moves the MTD unit tests to D121.

This PR requires the corresponding update of test references in https://github.com/cms-data/Geometry-TestReference/pull/21

#### PR validation:

Test references produced with this CMSSW update.