### PR TITLE
[DBG_X] Fix trackerMaterialAnalysisPlots unit test failure

### DIFF
--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -863,8 +863,8 @@ void CaloSD::clearHits() {
     primIDSaved[k] = -99;
     cleanIndex[k] = 0;
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("CaloSim") << "CaloSD: Clears hit vector for " << GetName()
-                                << " and initialise slave: " << slave[k].get()->name();
+    edm::LogVerbatim("CaloSim") << "CaloSD: Clears hit vector for " << GetName() << " and initialise slave: "
+                                << ((nullptr != slave[k].get()) ? slave[k].get()->name() : "Unknown");
 #endif
     if (nullptr != slave[k].get())
       slave[k].get()->Initialize();


### PR DESCRIPTION
#### PR description:

Unit test log: [link](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc12/CMSSW_15_1_DBG_X_2025-06-16-2300/unitTestLogs/SimTracker/TrackerMaterialAnalysis#/8-8)

I would also like to suggest removing redirections in https://github.com/cms-sw/cmssw/blob/66cc9901c34f4ada638eb2b798d65d0f46c3e6aa/SimTracker/TrackerMaterialAnalysis/test/genTrackerPlots.sh#L6-L8 to facilitate future debugging - this will make actual error(s) visible in unit test log.

#### PR validation:

Ran test locally.
