### PR TITLE
[L1T] Add Displaced Vertices into the default running of the P2 L1T Emulator (Phase 2)

### DIFF
--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -152,6 +152,7 @@ from L1Trigger.L1TTrackMatch.l1tGTTInputProducer_cfi import *
 from L1Trigger.L1TTrackMatch.l1tTrackSelectionProducer_cfi import *
 from L1Trigger.L1TTrackMatch.l1tTrackVertexAssociationProducer_cfi import *
 from L1Trigger.VertexFinder.l1tVertexProducer_cfi import *
+from L1Trigger.L1TTrackMatch.DisplacedVertexProducer_cfi import *
 
 # Track Conversion, Track Selection, Vertex Finding
 _phase2_siml1emulator.add(l1tGTTInputProducer)
@@ -161,6 +162,7 @@ _phase2_siml1emulator.add(l1tTrackSelectionProducerExtended)
 _phase2_siml1emulator.add(l1tVertexFinder)
 _phase2_siml1emulator.add(l1tVertexProducer)
 _phase2_siml1emulator.add(l1tVertexFinderEmulator)
+_phase2_siml1emulator.add(DisplacedVertexProducer) #Should rename to l1tDisplacedVertexProducer
 
 # Emulated GMT Muons (Tk + Stub, Tk + MuonTFT, StandaloneMuon)
 # ########################################################################


### PR DESCRIPTION
#### PR description:

This PR adds in displaced vertices into the default running of the P2 L1T Emulator.

#### PR validation:

(After including #48326:) Ran the following command with and without this PR:
```
cmsDriver.py -s L1TrackTrigger,L1,L1P2GT,NANO:@Phase2L1DPGwithGen \
--conditions auto:phase2_realistic_T33 \
--geometry ExtendedRun4D110 \
--era Phase2C17I13M9 \
--eventcontent NANOAOD \
--datatier GEN-SIM-DIGI-RAW-MINIAOD \
--customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000,Configuration/DataProcessing/Utils.addMonitoring,L1Trigger/Configuration/customisePhase2TTOn110.customisePhase2TTOn110 \
--filein /store/mc/Phase2Spring24DIGIRECOMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_AllTP_140X_mcRun4_realistic_v4-v1/2560000/11d1f6f0-5f03-421e-90c7-b5815197fc85.root \
--fileout file:output_Phase2_L1T.root \
--python_filename rerunL1_cfg.py \
--inputCommands="keep *, drop l1tPFJets_*_*_*, drop l1tTrackerMuons_l1tTkMuonsGmt*_*_HLT" \
--mc \
-n 10 --nThreads 4
```
With this PR we then see the displaced vertices are being created and stored in the L1Nano as expected.