### PR TITLE
Pixelimage morphing

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/interface/SiPixelImageDevice.h
+++ b/RecoLocalTracker/SiPixelClusterizer/interface/SiPixelImageDevice.h
@@ -1,0 +1,15 @@
+#ifndef RecoLocalTracker_SiPixelClusterizer_interface_SiPixelImageDevice_h
+#define RecoLocalTracker_SiPixelClusterizer_interface_SiPixelImageDevice_h
+
+#include "DataFormats/Portable/interface/alpaka/PortableCollection.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "RecoLocalTracker/SiPixelClusterizer/interface/SiPixelImageHost.h"
+#include "RecoLocalTracker/SiPixelClusterizer/interface/SiPixelImageSoA.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+  using SiPixelImageDevice = PortableCollection<SiPixelImageSoA>;
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+ASSERT_DEVICE_MATCHES_HOST_COLLECTION(SiPixelImageDevice, SiPixelImageHost)
+
+#endif  // RecoLocalTracker_SiPixelClusterizer_interface_SiPixelImageDevice_h

--- a/RecoLocalTracker/SiPixelClusterizer/interface/SiPixelImageHost.h
+++ b/RecoLocalTracker/SiPixelClusterizer/interface/SiPixelImageHost.h
@@ -1,0 +1,9 @@
+#ifndef RecoLocalTracker_SiPixelClusterizer_interface_SiPixelImageHost_h
+#define RecoLocalTracker_SiPixelClusterizer_interface_SiPixelImageHost_h
+
+#include "RecoLocalTracker/SiPixelClusterizer/interface/SiPixelImageSoA.h"
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+
+using SiPixelImageHost = PortableHostCollection<SiPixelImageSoA>;
+
+#endif

--- a/RecoLocalTracker/SiPixelClusterizer/interface/SiPixelImageSoA.h
+++ b/RecoLocalTracker/SiPixelClusterizer/interface/SiPixelImageSoA.h
@@ -1,0 +1,15 @@
+#ifndef RecoLocalTracker_SiPixelClusterizer_interface_SiPixelImageSoA_h
+#define RecoLocalTracker_SiPixelClusterizer_interface_SiPixelImageSoA_h
+#include <array>
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+using SiPixelImage = std::array<std::array<int32_t,160>,416>;
+GENERATE_SOA_LAYOUT(SiPixelImageLayout,
+                    //SOA_COLUMN(std::array<std::array<int,160>,416>, clus))
+                    SOA_COLUMN(SiPixelImage, clus))
+                    //SOA_COLUMN(int32_t, clus))
+
+using SiPixelImageSoA = SiPixelImageLayout<>;
+using SiPixelImageSoAView = SiPixelImageSoA::View;
+using SiPixelImageSoAConstView = SiPixelImageSoA::ConstView;
+
+#endif // RecoLocalTracker_SiPixelClusterizer_interface_SiPixelImageDevice_h

--- a/RecoLocalTracker/SiPixelClusterizer/interface/SiPixelImageSoA.h
+++ b/RecoLocalTracker/SiPixelClusterizer/interface/SiPixelImageSoA.h
@@ -2,6 +2,7 @@
 #define RecoLocalTracker_SiPixelClusterizer_interface_SiPixelImageSoA_h
 #include <array>
 #include "DataFormats/SoATemplate/interface/SoALayout.h"
+//using SiPixelImage = std::array<std::array<int32_t,416>,160>;
 using SiPixelImage = std::array<std::array<int32_t,160>,416>;
 GENERATE_SOA_LAYOUT(SiPixelImageLayout,
                     //SOA_COLUMN(std::array<std::array<int,160>,416>, clus))

--- a/RecoLocalTracker/SiPixelClusterizer/interface/SiPixelImageSoA.h
+++ b/RecoLocalTracker/SiPixelClusterizer/interface/SiPixelImageSoA.h
@@ -3,7 +3,8 @@
 #include <array>
 #include "DataFormats/SoATemplate/interface/SoALayout.h"
 //using SiPixelImage = std::array<std::array<int32_t,160>,416>;
-using SiPixelImage = std::array<std::array<int32_t,162>,418>;
+//using SiPixelImage = std::array<std::array<int32_t,162>,418>;
+using SiPixelImage = std::array<std::array<int32_t,164>,420>;
 GENERATE_SOA_LAYOUT(SiPixelImageLayout,
                     //SOA_COLUMN(std::array<std::array<int,160>,416>, clus))
                     SOA_COLUMN(SiPixelImage, clus))

--- a/RecoLocalTracker/SiPixelClusterizer/interface/SiPixelImageSoA.h
+++ b/RecoLocalTracker/SiPixelClusterizer/interface/SiPixelImageSoA.h
@@ -2,8 +2,8 @@
 #define RecoLocalTracker_SiPixelClusterizer_interface_SiPixelImageSoA_h
 #include <array>
 #include "DataFormats/SoATemplate/interface/SoALayout.h"
-//using SiPixelImage = std::array<std::array<int32_t,416>,160>;
-using SiPixelImage = std::array<std::array<int32_t,160>,416>;
+//using SiPixelImage = std::array<std::array<int32_t,160>,416>;
+using SiPixelImage = std::array<std::array<int32_t,162>,418>;
 GENERATE_SOA_LAYOUT(SiPixelImageLayout,
                     //SOA_COLUMN(std::array<std::array<int,160>,416>, clus))
                     SOA_COLUMN(SiPixelImage, clus))

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/PixelClustering.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/PixelClustering.h
@@ -368,7 +368,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering {
 
 		uint16_t row = j/pixelStatus::pixelSizeY;
 		uint16_t col = j%pixelStatus::pixelSizeY;
-		if( images[module].clus()[col][row] == pixelStatus::empVal  || row >= pixelStatus::pixelSizeY - 1 || col >= pixelStatus::pixelSizeX - 1 || row<=1 || col<= 1)
+		if( images[module].clus()[col][row] == pixelStatus::empVal  || row >= pixelStatus::pixelSizeX - 1 || col >= pixelStatus::pixelSizeY - 1 || row<=1 || col<= 1)
 		{
 			//more=true;
 			continue;
@@ -408,10 +408,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering {
 		 int fpY = digi_view[i].yy();
 		 if (digi_view[i].moduleId() == ::pixelClustering::invalidModuleId)
 		   continue;
-		 if(images[module].clus()[fpY][fpX]!=digi_view[i].clus())
-		 {
-			 printf("SHITTTT %u , %u", digi_view[i].clus(),images[module].clus()[fpY][fpX]);
-		 }
 		 digi_view[i].clus() = images[module].clus()[fpY][fpX];
 
 		 //if(images[module].clus()[fpY][fpX]==digi_view[i].clus())
@@ -425,6 +421,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering {
 		// }
 		 //printf("CLUSID: %d\n",images[module].clus()[fpY][fpX]);
 	}
+
 	  alpaka::syncBlockThreads(acc);
         /*
             // check that all threads in the block have executed the same number of iterations

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/PixelClustering.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/PixelClustering.h
@@ -19,96 +19,44 @@
 #include "RecoLocalTracker/SiPixelClusterizer/interface/SiPixelImageSoA.h"
 #include "RecoLocalTracker/SiPixelClusterizer/interface/SiPixelImageDevice.h"
 
-//#define GPU_DEBUG
+// #define GPU_DEBUG
 
-namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering {
+namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering
+{
 
 #ifdef GPU_DEBUG
   DEVICE_GLOBAL uint32_t gMaxHit = 0;
 #endif
 
-  namespace pixelStatus {
+  namespace pixelStatus
+  {
     // Phase-1 pixel modules
     constexpr uint32_t pixelSizeX = pixelTopology::Phase1::numRowsInModule;
     constexpr uint32_t pixelSizeY = pixelTopology::Phase1::numColsInModule;
-    constexpr int32_t empVal = std::numeric_limits<int32_t>::max() - 2; //TODO: Move this to DataFormats/SiPixelClusterSoA/interface/ClusteringConstants.h
-    constexpr int32_t fakeVal = 9999;//std::numeric_limits<int32_t>::max() - 3; //TODO: Move this to DataFormats/SiPixelClusterSoA/interface/ClusteringConstants.h
+    constexpr int32_t empVal = std::numeric_limits<int32_t>::max() - 2;  // TODO: Move this to DataFormats/SiPixelClusterSoA/interface/ClusteringConstants.h
+    constexpr int32_t fakeVal = std::numeric_limits<int32_t>::max() - 3; // TODO: Move this to DataFormats/SiPixelClusterSoA/interface/ClusteringConstants.h
 
-    // Use 0x00, 0x01, 0x03 so each can be OR'ed on top of the previous ones
-    enum Status : uint32_t { kEmpty = 0x00, kFound = 0x01, kDuplicate = 0x03 };
-
-    constexpr uint32_t bits = 2;
-    constexpr uint32_t mask = (0x01 << bits) - 1;
-    constexpr uint32_t valuesPerWord = sizeof(uint32_t) * 8 / bits;
-    constexpr uint32_t size = pixelSizeX * pixelSizeY / valuesPerWord;
-
-    ALPAKA_FN_ACC ALPAKA_FN_INLINE constexpr uint32_t getIndex(uint16_t x, uint16_t y) {
-      return (pixelSizeX * y + x) / valuesPerWord;
-    }
-
-    ALPAKA_FN_ACC ALPAKA_FN_INLINE constexpr uint32_t getShift(uint16_t x, uint16_t y) {
-      return (x % valuesPerWord) * 2;
-    }
-
-    ALPAKA_FN_ACC ALPAKA_FN_INLINE constexpr Status getStatus(uint32_t const* __restrict__ status,
-                                                              uint16_t x,
-                                                              uint16_t y) {
-      uint32_t index = getIndex(x, y);
-      uint32_t shift = getShift(x, y);
-      return Status{(status[index] >> shift) & mask};
-    }
-
-    ALPAKA_FN_ACC ALPAKA_FN_INLINE constexpr bool isDuplicate(uint32_t const* __restrict__ status,
-                                                              uint16_t x,
-                                                              uint16_t y) {
-      return getStatus(status, x, y) == kDuplicate;
-    }
-
-    /* FIXME
-       * In the more general case (e.g. a multithreaded CPU backend) there is a potential race condition
-       * between the read of status[index] at line NNN and the atomicCas at line NNN.
-       * We should investigate:
-       *   - if `status` should be read through a `volatile` pointer (CUDA/ROCm)
-       *   - if `status` should be read with an atomic load (CPU)
-       */
-    ALPAKA_FN_ACC ALPAKA_FN_INLINE constexpr void promote(Acc1D const& acc,
-                                                          uint32_t* __restrict__ status,
-                                                          const uint16_t x,
-                                                          const uint16_t y) {
-      uint32_t index = getIndex(x, y);
-      uint32_t shift = getShift(x, y);
-      uint32_t old_word = status[index];
-      uint32_t expected = old_word;
-      do {
-        expected = old_word;
-        Status old_status{(old_word >> shift) & mask};
-        if (kDuplicate == old_status) {
-          // nothing to do
-          return;
-        }
-        Status new_status = (kEmpty == old_status) ? kFound : kDuplicate;
-        uint32_t new_word = old_word | (static_cast<uint32_t>(new_status) << shift);
-        old_word = alpaka::atomicCas(acc, &status[index], expected, new_word, alpaka::hierarchy::Blocks{});
-      } while (expected != old_word);
-    }
-
-  }  // namespace pixelStatus
+  } // namespace pixelStatus
 
   template <typename TrackerTraits>
-  struct CountModules {
-    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
+  struct CountModules
+  {
+    ALPAKA_FN_ACC void operator()(Acc1D const &acc,
                                   SiPixelDigisSoAView digi_view,
                                   SiPixelClustersSoAView clus_view,
-                                  const unsigned int numElements) const {
+                                  const unsigned int numElements) const
+    {
       // Make sure the atomicInc below does not overflow
       static_assert(TrackerTraits::numberOfModules < ::pixelClustering::maxNumModules);
 
 #ifdef GPU_DEBUG
-      if (cms::alpakatools::once_per_grid(acc)) {
+      if (cms::alpakatools::once_per_grid(acc))
+      {
         printf("Starting to count modules to set module starts:");
       }
 #endif
-      for (int32_t i : cms::alpakatools::uniform_elements(acc, numElements)) {
+      for (int32_t i : cms::alpakatools::uniform_elements(acc, numElements))
+      {
         digi_view[i].clus() = i;
         if (::pixelClustering::invalidModuleId == digi_view[i].moduleId())
           continue;
@@ -116,7 +64,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering {
         int32_t j = i - 1;
         while (j >= 0 and digi_view[j].moduleId() == ::pixelClustering::invalidModuleId)
           --j;
-        if (j < 0 or digi_view[j].moduleId() != digi_view[i].moduleId()) {
+        if (j < 0 or digi_view[j].moduleId() != digi_view[i].moduleId())
+        {
           // Found a module boundary: count the number of modules in  clus_view[0].moduleStart()
           auto loc = alpaka::atomicInc(acc,
                                        &clus_view[0].moduleStart(),
@@ -132,54 +81,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering {
     }
   };
 
-/**
   template <typename TrackerTraits>
-  struct SparseToDense {
-    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
-                                  SiPixelDigisSoAView digi_view,
-                                  SiPixelClustersSoAView clus_view,
-                                  const unsigned int numElements) const {
-      // Make sure the atomicInc below does not overflow
-      static_assert(TrackerTraits::numberOfModules < ::pixelClustering::maxNumModules);
-      auto& lastPixel = alpaka::declareSharedVar<unsigned int, __COUNTER__>(acc);
-
-      const uint32_t lastModule = clus_view[0].moduleStart();
-      for (uint32_t module : cms::alpakatools::independent_groups(acc, lastModule)) {
-        auto firstPixel = clus_view[1 + module].moduleStart();
-        uint32_t thisModuleId = digi_view[firstPixel].moduleId();
-        ALPAKA_ASSERT_ACC(thisModuleId < TrackerTraits::numberOfModules);
-        lastPixel = numElements;
-        alpaka::syncBlockThreads(acc);
-
-        // skip threads not associated to an existing pixel
-        for (uint32_t i : cms::alpakatools::independent_group_elements(acc, firstPixel, numElements)) {
-          auto id = digi_view[i].moduleId();
-          // skip invalid pixels
-          if (id == ::pixelClustering::invalidModuleId)
-            continue;
-          // find the first pixel in a different module
-          if (id != thisModuleId) {
-            alpaka::atomicMin(acc, &lastPixel, i, alpaka::hierarchy::Threads{});
-            break;
-          }
-        }
-	const unsigned int lp = *lastPixel;
-        if (cms::alpakatools::once_per_block(acc)){
-		printf("FirstPixel %u",firstPixel);
-		printf("LastPixel %u",lp);
-		for(auto i = firstPixel ; i<lastPixel ; i++)
-		{
-			printf("Pixel (%u,%u) in module %u",digi_view[i].xx(),digi_view[i].yy(),thisModuleId);
-		}
-	}
-
-}}
-};
-**/
-
-
-  template <typename TrackerTraits>
-  struct FindClus {
+  struct FindClus
+  {
     // assume that we can cover the whole module with up to 16 blockDimension-wide iterations
     static constexpr uint32_t maxIterGPU = 16;
 
@@ -187,17 +91,19 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering {
     static constexpr uint32_t maxElementsPerBlock =
         cms::alpakatools::round_up_by(TrackerTraits::maxPixInModule / maxIterGPU, 128);
 
-    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
+    ALPAKA_FN_ACC void operator()(Acc1D const &acc,
                                   SiPixelDigisSoAView digi_view,
-		    		  SiPixelImageSoAView images,
+                                  SiPixelImageSoAView images,
                                   SiPixelClustersSoAView clus_view,
-                                  const unsigned int numElements) const {
+                                  const unsigned int numElements) const
+    {
       static_assert(TrackerTraits::numberOfModules < ::pixelClustering::maxNumModules);
 
-      auto& lastPixel = alpaka::declareSharedVar<unsigned int, __COUNTER__>(acc);
+      auto &lastPixel = alpaka::declareSharedVar<unsigned int, __COUNTER__>(acc);
 
       const uint32_t lastModule = clus_view[0].moduleStart();
-      for (uint32_t module : cms::alpakatools::independent_groups(acc, lastModule)) {
+      for (uint32_t module : cms::alpakatools::independent_groups(acc, lastModule))
+      {
         auto firstPixel = clus_view[1 + module].moduleStart();
         uint32_t thisModuleId = digi_view[firstPixel].moduleId();
         ALPAKA_ASSERT_ACC(thisModuleId < TrackerTraits::numberOfModules);
@@ -215,24 +121,27 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering {
         alpaka::syncBlockThreads(acc);
 
         // skip threads not associated to an existing pixel
-        for (uint32_t i : cms::alpakatools::independent_group_elements(acc, firstPixel, numElements)) {
+        for (uint32_t i : cms::alpakatools::independent_group_elements(acc, firstPixel, numElements))
+        {
           auto id = digi_view[i].moduleId();
           // skip invalid pixels
           if (id == ::pixelClustering::invalidModuleId)
             continue;
           // find the first pixel in a different module
-          if (id != thisModuleId) {
+          if (id != thisModuleId)
+          {
             alpaka::atomicMin(acc, &lastPixel, i, alpaka::hierarchy::Threads{});
             break;
           }
         }
 
-
         ALPAKA_ASSERT_ACC((lastPixel == numElements) or
                           ((lastPixel < numElements) and (digi_view[lastPixel].moduleId() != thisModuleId)));
         // limit to maxPixInModule  (FIXME if recurrent (and not limited to simulation with low threshold) one will need to implement something cleverer)
-        if (cms::alpakatools::once_per_block(acc)) {
-          if (lastPixel - firstPixel > TrackerTraits::maxPixInModule) {
+        if (cms::alpakatools::once_per_block(acc))
+        {
+          if (lastPixel - firstPixel > TrackerTraits::maxPixInModule)
+          {
             printf("too many pixels in module %u: %u > %u\n",
                    thisModuleId,
                    lastPixel - firstPixel,
@@ -243,244 +152,186 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering {
         alpaka::syncBlockThreads(acc);
         ALPAKA_ASSERT_ACC(lastPixel - firstPixel <= TrackerTraits::maxPixInModule);
 
-	uint32_t pixsize = pixelStatus::pixelSizeX * pixelStatus::pixelSizeY;
+        uint32_t pixsize = pixelStatus::pixelSizeX * pixelStatus::pixelSizeY;
         for (uint32_t j : cms::alpakatools::independent_group_elements(acc, pixsize))
-	{
-		uint16_t row = j/pixelStatus::pixelSizeY;
-		uint16_t col = j%pixelStatus::pixelSizeY;
-		images[module].clus()[col][row] = pixelStatus::empVal;
-	}
+        {
+          uint16_t row = j / pixelStatus::pixelSizeY;
+          uint16_t col = j % pixelStatus::pixelSizeY;
+          images[module].clus()[col][row] = pixelStatus::empVal;
+        }
         alpaka::syncBlockThreads(acc);
 
         // remove duplicate pixels
         constexpr bool isPhase2 = std::is_base_of<pixelTopology::Phase2, TrackerTraits>::value;
-	for (uint32_t i : cms::alpakatools::independent_group_elements(acc, firstPixel, lastPixel))
-	{
-		 if (digi_view[i].moduleId() == ::pixelClustering::invalidModuleId)
-		   continue;
-		 int fpX = digi_view[i].xx();
-		 int fpY = digi_view[i].yy();
-		if constexpr (not isPhase2)
-		{
-			 int32_t kEmp = pixelStatus::empVal;
-			 int32_t old_value = alpaka::atomicCas(acc, &images[module].clus()[fpY][fpX],kEmp, digi_view[i].clus());
-			 if(old_value != pixelStatus::empVal)
-			 {
-				digi_view[i].moduleId() = ::pixelClustering::invalidModuleId;
-				digi_view[i].rawIdArr() = 0;
-			 }
-
-		 }
-		 else 
-		 {
-			 images[module].clus()[fpY][fpX] = digi_view[i].clus();
-		 }
-
-	}
-	alpaka::syncBlockThreads(acc);
-
-#if 0
-	if(module == 100)
-	{
-		for (uint32_t j : cms::alpakatools::independent_group_elements(acc, pixsize))
-		{
-			uint16_t row = j/pixelStatus::pixelSizeY;
-			uint16_t col = j%pixelStatus::pixelSizeY;
-			if(row<80 && col<52)
-			{
-				printf("(%u,%u):%u/",row,col,images[module].clus()[row][col]);
-			}
-		}
-		alpaka::syncBlockThreads(acc);
-		printf("\n");
-		uint32_t pixsize = pixelStatus::pixelSizeX * pixelStatus::pixelSizeY;
-		uint32_t kernal[3][3] = { {1,1,1},{1,1,1},{1,1,1} };
-		for (uint32_t j : cms::alpakatools::independent_group_elements(acc, pixsize))
-		{
-			uint16_t row = j/pixelStatus::pixelSizeY;
-			uint16_t col = j%pixelStatus::pixelSizeY;
-			auto thisPix = images[module].clus()[row][col];
-			for( int i = 0 ; i<3 && images[module].clus()[row][col] == pixelStatus::empVal ; i++)
-			{
-				for( int j = 0 ; j<3; j++)
-				{
-					if(images[module].clus()[row+i-1][col+j-1] != pixelStatus::empVal && images[module].clus()[row+i-1][col+j-1] != pixelStatus::fakeVal && kernal[i][j])
-					{
-						images[module].clus()[row][col] = pixelStatus::fakeVal;
-						break;
-					}
-				}
-			}
-
-		}
-		alpaka::syncBlockThreads(acc);
-		for (uint32_t j : cms::alpakatools::independent_group_elements(acc, pixsize))
-		{
-			uint16_t row = j/pixelStatus::pixelSizeY;
-			uint16_t col = j%pixelStatus::pixelSizeY;
-			if(row<80 && col<52)
-			{
-				printf("(%u,%u):%u/",row,col,images[module].clus()[row][col]);
-			}
-		}
-		printf("\n");
-		alpaka::syncBlockThreads(acc);
-		for (uint32_t j : cms::alpakatools::independent_group_elements(acc, pixsize))
-		{
-			uint16_t row = j/pixelStatus::pixelSizeY;
-			uint16_t col = j%pixelStatus::pixelSizeY;
-			auto thisPix = images[module].clus()[row][col];
-			for( int i = 0 ; i<3 && images[module].clus()[row][col] != pixelStatus::empVal ; i++)
-			{
-				for( int j = 0 ; j<3; j++)
-				{
-					if(images[module].clus()[row+i-1][col+j-1] == pixelStatus::empVal && kernal[i][j])
-					{
-						images[module].clus()[row][col] = pixelStatus::empVal;
-						break;
-					}
-				}
-			}
-
-		}
-		alpaka::syncBlockThreads(acc);
-		for (uint32_t j : cms::alpakatools::independent_group_elements(acc, pixsize))
-		{
-			uint16_t row = j/pixelStatus::pixelSizeY;
-			uint16_t col = j%pixelStatus::pixelSizeY;
-			if(row<80 && col<52)
-			{
-				printf("(%u,%u):%u/",row,col,images[module].clus()[row][col]);
-			}
-		}
-	}
-#endif
-
-
-        // for each pixel, look at all the pixels until the end of the module;
-        // when two valid pixels within +/- 1 in x or y are found, set their id to the minimum;
-        // after the loop, all the pixel in each cluster should have the id equeal to the lowest
-        // pixel in the cluster ( clus[i] == i ).
-        bool more = true;
-        while (alpaka::syncBlockThreadsPredicate<alpaka::BlockOr>(acc, more)) {
-          more = false;
-          for (uint32_t j : cms::alpakatools::independent_group_elements(acc, pixsize)){
-
-		uint16_t row = j/pixelStatus::pixelSizeY;
-		uint16_t col = j%pixelStatus::pixelSizeY;
-		if( images[module].clus()[col][row] == pixelStatus::empVal  || row >= pixelStatus::pixelSizeX - 1 || col >= pixelStatus::pixelSizeY - 1 || row<=1 || col<= 1)
-		{
-			//more=true;
-			continue;
-		}
-		int32_t tmp = pixelStatus::empVal ;
-
-		for (int kk = -1; kk < 2; kk++) {
-		    for (int jj = -1; jj < 2; jj++) {
-			    int32_t clus = images[module].clus()[col+kk][row+jj];
-			    tmp= alpaka::math::min(acc,tmp,clus);
-		    }
-		}
-		if(images[module].clus()[col][row] != tmp)
-		{
-			images[module].clus()[col][row] = tmp;
-			more=true;
-		}
-	}
-		
-          alpaka::syncBlockThreads(acc);
-#if 0
-          for (uint32_t j : cms::alpakatools::independent_group_elements(acc, hist.size())) {
-            auto p = hist.begin() + j;
-            auto i = *p + firstPixel;
-            auto m = digi_view[i].clus();
-            while (m != digi_view[m].clus())
-              m = digi_view[m].clus();
-            digi_view[i].clus() = m;
-          }
-#endif
-        }  // end while
-
-	alpaka::syncBlockThreads(acc);
-	for (uint32_t i : cms::alpakatools::independent_group_elements(acc, firstPixel, lastPixel))
-	{
-		 int fpX = digi_view[i].xx();
-		 int fpY = digi_view[i].yy();
-		 if (digi_view[i].moduleId() == ::pixelClustering::invalidModuleId)
-		   continue;
-		 digi_view[i].clus() = images[module].clus()[fpY][fpX];
-
-		 //if(images[module].clus()[fpY][fpX]==digi_view[i].clus())
-		// {
-		//	 digi_view[i].clus() = images[module].clus()[fpY][fpX];
-			 //printf("COOL  %u , %u", digi_view[i].clus(),images[module].clus()[fpY][fpX]);
-		//	 }
-		 //else
-		// {
-		//	 printf("SHITTTT %u , %u", digi_view[i].clus(),images[module].clus()[fpY][fpX]);
-		// }
-		 //printf("CLUSID: %d\n",images[module].clus()[fpY][fpX]);
-	}
-
-	  alpaka::syncBlockThreads(acc);
-        /*
-            // check that all threads in the block have executed the same number of iterations
-            auto& n0 = alpaka::declareSharedVar<int, __COUNTER__>(acc);
-            if (cms::alpakatools::once_per_block(acc))
-              n0 = nloops;
-            alpaka::syncBlockThreads(acc);
-            ALPAKA_ASSERT_ACC(alpaka::syncBlockThreadsPredicate<alpaka::BlockAnd>(acc, nloops == n0));
-            if (thisModuleId % 100 == 1)
-              if (cms::alpakatools::once_per_block(acc))
-                printf("# loops %d\n", nloops);
-          */
-        auto& foundClusters = alpaka::declareSharedVar<unsigned int, __COUNTER__>(acc);
-        foundClusters = 0;
-        alpaka::syncBlockThreads(acc);
-
-        // find the number of different clusters, identified by a pixels with clus[i] == i;
-        // mark these pixels with a negative id.
-        for (uint32_t i : cms::alpakatools::independent_group_elements(acc, firstPixel, lastPixel)) {
-          // skip invalid pixels
+        for (uint32_t i : cms::alpakatools::independent_group_elements(acc, firstPixel, lastPixel))
+        {
           if (digi_view[i].moduleId() == ::pixelClustering::invalidModuleId)
             continue;
-          if (digi_view[i].clus() == static_cast<int>(i)) {
-            auto old = alpaka::atomicInc(acc, &foundClusters, 0xffffffff, alpaka::hierarchy::Threads{});
-            digi_view[i].clus() = -(old + 1);
+          int fpX = digi_view[i].xx();
+          int fpY = digi_view[i].yy();
+          if constexpr (not isPhase2)
+          {
+            int32_t kEmp = pixelStatus::empVal;
+            int32_t old_value = alpaka::atomicCas(acc, &images[module].clus()[fpY][fpX], kEmp, digi_view[i].clus());
+            if (old_value != pixelStatus::empVal)
+            {
+              digi_view[i].moduleId() = ::pixelClustering::invalidModuleId;
+              digi_view[i].rawIdArr() = 0;
+            }
+          }
+          else
+          {
+            images[module].clus()[fpY][fpX] = digi_view[i].clus();
           }
         }
         alpaka::syncBlockThreads(acc);
 
-        // propagate the negative id to all the pixels in the cluster.
-        for (uint32_t i : cms::alpakatools::independent_group_elements(acc, firstPixel, lastPixel)) {
-          // skip invalid pixels
-          if (digi_view[i].moduleId() == ::pixelClustering::invalidModuleId)
+        uint32_t pixsize = pixelStatus::pixelSizeX * pixelStatus::pixelSizeY;
+        uint32_t kernal[3][3] = {{1, 1, 1}, {1, 1, 1}, {1, 1, 1}};
+        //Morphing: Dilation
+        for (uint32_t j : cms::alpakatools::independent_group_elements(acc, pixsize))
+        {
+          uint16_t row = j / pixelStatus::pixelSizeY;
+          uint16_t col = j % pixelStatus::pixelSizeY;
+          auto thisPix = images[module].clus()[row][col];
+          for (int i = 0; i < 3 && images[module].clus()[row][col] == pixelStatus::empVal; i++)
+          {
+            for (int j = 0; j < 3; j++)
+            {
+              if (images[module].clus()[row + i - 1][col + j - 1] != pixelStatus::empVal && images[module].clus()[row + i - 1][col + j - 1] != pixelStatus::fakeVal && kernal[i][j])
+              {
+                images[module].clus()[row][col] = pixelStatus::fakeVal;
+                break;
+              }
+            }
+          }
+        }
+        alpaka::syncBlockThreads(acc);
+        //Morphing: Erosion
+        for (uint32_t j : cms::alpakatools::independent_group_elements(acc, pixsize))
+        {
+          uint16_t row = j / pixelStatus::pixelSizeY;
+          uint16_t col = j % pixelStatus::pixelSizeY;
+          auto thisPix = images[module].clus()[row][col];
+          for (int i = 0; i < 3 && images[module].clus()[row][col] != pixelStatus::empVal; i++)
+          {
+            for (int j = 0; j < 3; j++)
+            {
+              if (images[module].clus()[row + i - 1][col + j - 1] == pixelStatus::empVal && kernal[i][j])
+              {
+                images[module].clus()[row][col] = pixelStatus::empVal;
+                break;
+              }
+            }
+          }
+        }
+        alpaka::syncBlockThreads(acc);
+      }
+
+      // for each pixel, look at all the pixels until the end of the module;
+      // when two valid pixels within +/- 1 in x or y are found, set their id to the minimum;
+      // after the loop, all the pixel in each cluster should have the id equeal to the lowest
+      // pixel in the cluster ( clus[i] == i ).
+      bool more = true;
+      //Clustering
+      while (alpaka::syncBlockThreadsPredicate<alpaka::BlockOr>(acc, more))
+      {
+        more = false;
+        for (uint32_t j : cms::alpakatools::independent_group_elements(acc, pixsize))
+        {
+
+          uint16_t row = j / pixelStatus::pixelSizeY;
+          uint16_t col = j % pixelStatus::pixelSizeY;
+          if (images[module].clus()[col][row] == pixelStatus::empVal || row >= pixelStatus::pixelSizeX - 1 || col >= pixelStatus::pixelSizeY - 1 || row <= 1 || col <= 1)
+          {
             continue;
-          if (digi_view[i].clus() >= 0) {
-            // mark each pixel in a cluster with the same id as the first one
-            digi_view[i].clus() = digi_view[digi_view[i].clus()].clus();
+          }
+          int32_t tmp = pixelStatus::empVal;
+
+          for (int kk = -1; kk < 2; kk++)
+          {
+            for (int jj = -1; jj < 2; jj++)
+            {
+              int32_t clus = images[module].clus()[col + kk][row + jj];
+              tmp = alpaka::math::min(acc, tmp, clus);
+            }
+          }
+          if (images[module].clus()[col][row] != tmp)
+          {
+            images[module].clus()[col][row] = tmp;
+            more = true;
           }
         }
         alpaka::syncBlockThreads(acc);
+      } // end while
 
-        // adjust the cluster id to be a positive value starting from 0
-        for (uint32_t i : cms::alpakatools::independent_group_elements(acc, firstPixel, lastPixel)) {
-          if (digi_view[i].moduleId() == ::pixelClustering::invalidModuleId) {
-            // mark invalid pixels with an invalid cluster index
-            digi_view[i].clus() = ::pixelClustering::invalidClusterId;
-          } else {
-            digi_view[i].clus() = -digi_view[i].clus() - 1;
-          }
+      alpaka::syncBlockThreads(acc);
+      for (uint32_t i : cms::alpakatools::independent_group_elements(acc, firstPixel, lastPixel))
+      {
+        int fpX = digi_view[i].xx();
+        int fpY = digi_view[i].yy();
+        if (digi_view[i].moduleId() == ::pixelClustering::invalidModuleId)
+          continue;
+        digi_view[i].clus() = images[module].clus()[fpY][fpX];
+      }
+
+      alpaka::syncBlockThreads(acc);
+      auto &foundClusters = alpaka::declareSharedVar<unsigned int, __COUNTER__>(acc);
+      foundClusters = 0;
+      alpaka::syncBlockThreads(acc);
+
+      // find the number of different clusters, identified by a pixels with clus[i] == i;
+      // mark these pixels with a negative id.
+      for (uint32_t i : cms::alpakatools::independent_group_elements(acc, firstPixel, lastPixel))
+      {
+        // skip invalid pixels
+        if (digi_view[i].moduleId() == ::pixelClustering::invalidModuleId)
+          continue;
+        if (digi_view[i].clus() == static_cast<int>(i))
+        {
+          auto old = alpaka::atomicInc(acc, &foundClusters, 0xffffffff, alpaka::hierarchy::Threads{});
+          digi_view[i].clus() = -(old + 1);
         }
-        alpaka::syncBlockThreads(acc);
-        if (cms::alpakatools::once_per_block(acc)) {
-          clus_view[thisModuleId].clusInModule() = foundClusters;
-          clus_view[module].moduleId() = thisModuleId;
+      }
+      alpaka::syncBlockThreads(acc);
+
+      // propagate the negative id to all the pixels in the cluster.
+      for (uint32_t i : cms::alpakatools::independent_group_elements(acc, firstPixel, lastPixel))
+      {
+        // skip invalid pixels
+        if (digi_view[i].moduleId() == ::pixelClustering::invalidModuleId)
+          continue;
+        if (digi_view[i].clus() >= 0)
+        {
+          // mark each pixel in a cluster with the same id as the first one
+          digi_view[i].clus() = digi_view[digi_view[i].clus()].clus();
         }
-      }  // module loop
-    }
-  };
+      }
+      alpaka::syncBlockThreads(acc);
 
-}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering
+      // adjust the cluster id to be a positive value starting from 0
+      for (uint32_t i : cms::alpakatools::independent_group_elements(acc, firstPixel, lastPixel))
+      {
+        if (digi_view[i].moduleId() == ::pixelClustering::invalidModuleId)
+        {
+          // mark invalid pixels with an invalid cluster index
+          digi_view[i].clus() = ::pixelClustering::invalidClusterId;
+        }
+        else
+        {
+          digi_view[i].clus() = -digi_view[i].clus() - 1;
+        }
+      }
+      alpaka::syncBlockThreads(acc);
+      if (cms::alpakatools::once_per_block(acc))
+      {
+        clus_view[thisModuleId].clusInModule() = foundClusters;
+        clus_view[module].moduleId() = thisModuleId;
+      }
+    } // module loop
+  }
+};
 
-#endif  // plugin_SiPixelClusterizer_alpaka_PixelClustering.h
+} // namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering
+
+#endif // plugin_SiPixelClusterizer_alpaka_PixelClustering.h

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/PixelClustering.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/PixelClustering.h
@@ -32,9 +32,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering
   {
     // Phase-1 pixel modules
     constexpr uint32_t pixelSizeX = pixelTopology::Phase1::numRowsInModule;
-    constexpr uint32_t imageSizeX = pixelTopology::Phase1::numRowsInModule + 2;
+    constexpr uint32_t imageSizeX = pixelTopology::Phase1::numRowsInModule + 4;
     constexpr uint32_t pixelSizeY = pixelTopology::Phase1::numColsInModule;
-    constexpr uint32_t imageSizeY = pixelTopology::Phase1::numColsInModule + 2;
+    constexpr uint32_t imageSizeY = pixelTopology::Phase1::numColsInModule + 4;
     constexpr int32_t empVal = std::numeric_limits<int32_t>::max() - 2;  // TODO: Move this to DataFormats/SiPixelClusterSoA/interface/ClusteringConstants.h
     constexpr int32_t fakeVal = std::numeric_limits<int32_t>::max() - 3; // TODO: Move this to DataFormats/SiPixelClusterSoA/interface/ClusteringConstants.h
   } // namespace pixelStatus
@@ -169,8 +169,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering
         {
           if (digi_view[i].moduleId() == ::pixelClustering::invalidModuleId)
             continue;
-          int fpX = digi_view[i].xx() + 1;
-          int fpY = digi_view[i].yy() + 1;
+          int fpX = digi_view[i].xx() + 2;
+          int fpY = digi_view[i].yy() + 2;
           if constexpr (not isPhase2)
           {
             int32_t kEmp = pixelStatus::empVal;
@@ -188,13 +188,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering
         }
         alpaka::syncBlockThreads(acc);
 
-#if 0
         uint32_t kernal[3][3] = {{1, 1, 1}, {1, 1, 1}, {1, 1, 1}};
         //Morphing: Dilation
         for (uint32_t j : cms::alpakatools::independent_group_elements(acc, pixsize))
         {
-          uint16_t row = j / pixelStatus::pixelSizeY;
-          uint16_t col = j % pixelStatus::pixelSizeY;
+          uint16_t row = j / pixelStatus::pixelSizeY+2;
+          uint16_t col = j % pixelStatus::pixelSizeY+2;
           for (int i = 0; i < 3 && images[module].clus()[row][col] == pixelStatus::empVal; i++)
           {
             for (int j = 0; j < 3; j++)
@@ -211,8 +210,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering
         //Morphing: Erosion
         for (uint32_t j : cms::alpakatools::independent_group_elements(acc, pixsize))
         {
-          uint16_t row = j / pixelStatus::pixelSizeY;
-          uint16_t col = j % pixelStatus::pixelSizeY;
+          uint16_t row = j / pixelStatus::pixelSizeY+2;
+          uint16_t col = j % pixelStatus::pixelSizeY+2;
           for (int i = 0; i < 3 && images[module].clus()[row][col] != pixelStatus::empVal; i++)
           {
             for (int j = 0; j < 3; j++)
@@ -225,7 +224,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering
             }
           }
         }
-#endif
         alpaka::syncBlockThreads(acc);
 
 
@@ -241,8 +239,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering
         for (uint32_t j : cms::alpakatools::independent_group_elements(acc, pixsize))
         {
 
-          uint16_t row = j / pixelStatus::pixelSizeY + 1;
-          uint16_t col = j % pixelStatus::pixelSizeY + 1;
+          uint16_t row = j / pixelStatus::pixelSizeY + 2;
+          uint16_t col = j % pixelStatus::pixelSizeY + 2;
           if (images[module].clus()[col][row] == pixelStatus::empVal )
           {
             continue;
@@ -269,8 +267,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering
       alpaka::syncBlockThreads(acc);
       for (uint32_t i : cms::alpakatools::independent_group_elements(acc, firstPixel, lastPixel))
       {
-        int fpX = digi_view[i].xx() + 1;
-        int fpY = digi_view[i].yy() + 1;
+        int fpX = digi_view[i].xx() + 2;
+        int fpY = digi_view[i].yy() + 2;
         if (digi_view[i].moduleId() == ::pixelClustering::invalidModuleId)
           continue;
         digi_view[i].clus() = images[module].clus()[fpY][fpX];

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelMorphingConfig.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelMorphingConfig.h
@@ -1,0 +1,12 @@
+#ifndef RecoLocalTracker_SiPixelClusterizer_plugins_SiPixelMorphingConfig_h
+#define RecoLocalTracker_SiPixelClusterizer_plugins_SiPixelMorphingConfig_h
+
+#include <cstdint>
+#include <vector>
+
+struct SiPixelMorphingConfig {
+    	std::array<int32_t,9> kernel1_;
+	std::array<int32_t,9> kernel2_;
+};
+
+#endif 

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToCluster.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToCluster.cc
@@ -35,6 +35,8 @@
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/stream/SynchronizingEDProducer.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "RecoLocalTracker/SiPixelClusterizer/interface/SiPixelClusterThresholds.h"
+#include "RecoLocalTracker/SiPixelClusterizer/interface/SiPixelImageSoA.h"
+#include "RecoLocalTracker/SiPixelClusterizer/interface/SiPixelImageDevice.h"
 
 #include "SiPixelRawToClusterKernel.h"
 
@@ -76,6 +78,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     const bool useQuality_;
     uint32_t nDigis_;
     const SiPixelClusterThresholds clusterThresholds_;
+    std::optional<SiPixelImageDevice> images_;
   };
 
   template <typename TrackerTraits>
@@ -242,8 +245,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     for (uint32_t i = 0; i < fedIds_.size(); ++i) {
       wordFedAppender.initializeWordFed(fedIds_[i], index[i], start[i], words[i]);
     }
+    images_ = SiPixelImageDevice(pixelTopology::Phase1::numberOfModules,iEvent.queue());
+
     Algo_.makePhase1ClustersAsync(iEvent.queue(),
                                   clusterThresholds_,
+				  images_->view(),
                                   hMap.const_view(),
                                   modulesToUnpack,
                                   dGains.const_view(),

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.dev.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.dev.cc
@@ -29,6 +29,8 @@
 #include "HeterogeneousCore/AlpakaInterface/interface/warpsize.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
 #include "RecoLocalTracker/SiPixelClusterizer/interface/SiPixelClusterThresholds.h"
+#include "RecoLocalTracker/SiPixelClusterizer/interface/SiPixelImageSoA.h"
+#include "RecoLocalTracker/SiPixelClusterizer/interface/SiPixelImageDevice.h"
 
 // local includes
 #include "CalibPixel.h"
@@ -501,6 +503,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     void SiPixelRawToClusterKernel<TrackerTraits>::makePhase1ClustersAsync(
         Queue &queue,
         const SiPixelClusterThresholds clusterThresholds,
+	SiPixelImageSoAView images_,
         const SiPixelMappingSoAConstView &cablingMap,
         const unsigned char *modToUnp,
         const SiPixelGainCalibrationForHLTSoAConstView &gains,
@@ -629,7 +632,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                   << " threadsPerBlockOrElementsPerThread\n";
 #endif
         alpaka::exec<Acc1D>(
-            queue, workDivMaxNumModules, FindClus<TrackerTraits>{}, digis_d->view(), clusters_d->view(), wordCounter);
+            queue, workDivMaxNumModules, FindClus<TrackerTraits>{}, digis_d->view(),images_, clusters_d->view(), wordCounter);
+        //alpaka::exec<Acc1D>(
+         //   queue, workDivMaxNumModules, FindClus<TrackerTraits>{}, digis_d->view(), clusters_d->view(), wordCounter);
 #ifdef GPU_DEBUG
         alpaka::wait(queue);
 #endif
@@ -717,8 +722,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       std::cout << "FindClus kernel launch with " << numberOfModules << " blocks of " << elementsPerBlockFindClus
                 << " threadsPerBlockOrElementsPerThread\n";
 #endif
-      alpaka::exec<Acc1D>(
-          queue, workDivMaxNumModules, FindClus<TrackerTraits>{}, digis_view, clusters_d->view(), numDigis);
+      //alpaka::exec<Acc1D>(
+       //   queue, workDivMaxNumModules, SparseToDense<TrackerTraits>{}, digis_view, clusters_d->view(), numDigis);
+      //alpaka::exec<Acc1D>(
+       //   queue, workDivMaxNumModules, FindClus<TrackerTraits>{}, digis_view, clusters_d->view(), numDigis);
 #ifdef GPU_DEBUG
       alpaka::wait(queue);
 #endif

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.h
@@ -23,6 +23,8 @@
 #include "DataFormats/SiPixelRawData/interface/SiPixelErrorCompact.h"
 #include "DataFormats/SiPixelRawData/interface/SiPixelFormatterErrors.h"
 #include "DataFormats/SiPixelDetId/interface/PixelChannelIdentifier.h"
+#include "RecoLocalTracker/SiPixelClusterizer/interface/SiPixelImageSoA.h"
+#include "RecoLocalTracker/SiPixelClusterizer/interface/SiPixelImageDevice.h"
 
 namespace pixelDetails {
 
@@ -152,6 +154,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
       void makePhase1ClustersAsync(Queue& queue,
                                    const SiPixelClusterThresholds clusterThresholds,
+				   SiPixelImageSoAView images_,
                                    const SiPixelMappingSoAConstView& cablingMap,
                                    const unsigned char* modToUnp,
                                    const SiPixelGainCalibrationForHLTSoAConstView& gains,

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.h
@@ -25,6 +25,7 @@
 #include "DataFormats/SiPixelDetId/interface/PixelChannelIdentifier.h"
 #include "RecoLocalTracker/SiPixelClusterizer/interface/SiPixelImageSoA.h"
 #include "RecoLocalTracker/SiPixelClusterizer/interface/SiPixelImageDevice.h"
+#include "SiPixelMorphingConfig.h"
 
 namespace pixelDetails {
 
@@ -152,9 +153,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       SiPixelRawToClusterKernel& operator=(const SiPixelRawToClusterKernel&) = delete;
       SiPixelRawToClusterKernel& operator=(SiPixelRawToClusterKernel&&) = delete;
 
+      template <typename ImageType>
       void makePhase1ClustersAsync(Queue& queue,
                                    const SiPixelClusterThresholds clusterThresholds,
-				   SiPixelImageSoAView images_,
+				   ImageType::View images_,
+				   bool doDigiMorphing,
+				   const SiPixelMorphingConfig* digiMorphingConfig,
                                    const SiPixelMappingSoAConstView& cablingMap,
                                    const unsigned char* modToUnp,
                                    const SiPixelGainCalibrationForHLTSoAConstView& gains,


### PR DESCRIPTION
**PR description:**
This PR implements a new data format for the clustering algorithm for the pixel digis. The new data format is a densely populated 2D image as compared to the 1D sparsely populated digi_view. Also this PR can optionally apply the morphing algorithm for adding fake digis before doing the clustering. This morphing feature proceeds with a dilation step followed by an erosion. In the config these kernels are defined as a 1D array which store the matrix elements for the 3x3 kernels. The following options can now be set in the EDProducer config.:
 DoDigiMorphing = cms.bool(True), #Default False
 DigiMorphing = cms.PSet(
        kernel1 = cms.vint32(1, 1, 1, 1,1,1,1,1,1),  # Example kernel values for the dilation kernel
        kernel2 = cms.vint32(0, 1, 0, 1,1,1,0,1,1),  # Example kernel values for the erosion kernel
        )


**Implementation details:**
- SiPixelMorphing.cc defined for storing configuration of morphing parameters
- Two ImageSoA’s types are now available and depending on the doDigiMorphing flag, either one is used. For no morphing, the SoA with single layer padding is used and for morphing, 2 layer padding. This saves memory consumption in case morphing is disabled
- The makePhase1ClustersAsync function is now templated with ImageType and TrackerTraits(default) and all templated function definitions are defined in SiPixelRawToClusterKernel.dev.cc file
-The templated Image is passed to the FindClus kernel which is also templated with ImageType

**PR validation:**
The code compiles. Comparisions with the legacy CPU code and the current GPU code were also made here: https://indico.cern.ch/event/1555234/contributions/6567409/attachments/3087292/5466320/digimorphing_2%20(1).pdf
