### PR TITLE
[GCC14]Included header algorithm for std::max_element

### DIFF
--- a/PerfTools/AllocMonitor/plugins/monitor_file_utilities.cc
+++ b/PerfTools/AllocMonitor/plugins/monitor_file_utilities.cc
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <cassert>
+#include <algorithm>
 
 namespace {
   std::string const space{"  "};


### PR DESCRIPTION
This fixes GCC 14 build error [a]


[a] https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el9_amd64_gcc14/CMSSW_15_1_ROOT636_X_2025-06-12-1100/PerfTools/AllocMonitor
```
[src/PerfTools/AllocMonitor/plugins/monitor_file_utilities.cc:44](https://github.com/cms-sw/cmssw/blob/CMSSW_15_1_ROOT636_X_2025-06-12-1100/PerfTools/AllocMonitor/plugins/monitor_file_utilities.cc#L44):23: error: 'max_element' is not a member of 'std'; did you mean 'tuple_element'?
    44 |     auto itMax = std::max_element(iModuleLabels.begin(), iModuleLabels.end(), [](auto const& iL, auto const& iR) {
      |                       ^~~~~~~~~~~
      |                       tuple_element
  [src/PerfTools/AllocMonitor/plugins/monitor_file_utilities.cc:47](https://github.com/cms-sw/cmssw/blob/CMSSW_15_1_ROOT636_X_2025-06-12-1100/PerfTools/AllocMonitor/plugins/monitor_file_utilities.cc#L47):55: error: no matching function for call to 'edm::OStreamColumn::OStreamColumn(<brace-enclosed initializer list>)'
    47 |     OStreamColumn labelCol{iLabelHeader, itMax->size()};
```