### PR TITLE
[150X, backport of 48349] Fix JMEnano workflow 11634.15

### DIFF
--- a/PhysicsTools/NanoAOD/python/custom_btv_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_btv_cff.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.NanoAOD.common_cff import Var
+from PhysicsTools.NanoAOD.nano_eras_cff import *
 from PhysicsTools.NanoAOD.jetsAK4_Puppi_cff import jetPuppiTable, jetPuppiCorrFactorsNano, updatedJetsPuppi, updatedJetsPuppiWithUserData
 from PhysicsTools.NanoAOD.jetsAK8_cff import fatJetTable, subJetTable
 from PhysicsTools.PatAlgos.tools.jetTools import updateJetCollection
@@ -67,7 +68,9 @@ def update_jets_AK4(process):
 
     # Fix ParticleNetFromMiniAOD input when slimmedTaus is updated
     from PhysicsTools.NanoAOD.nano_cff import _fixPNetInputCollection
-    _fixPNetInputCollection(process)
+    (run2_nanoAOD_106Xv2 | run3_nanoAOD_pre142X | nanoAOD_rePuppi).toModify(
+        process, lambda p: _fixPNetInputCollection(p)
+    )
 
     return process
 

--- a/PhysicsTools/NanoAOD/python/custom_jme_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_jme_cff.py
@@ -1513,7 +1513,9 @@ def PrepJMECustomNanoAOD(process):
   # Fix ParticleNetFromMiniAOD input when slimmedTaus is updated
   ###########################################################################
   from PhysicsTools.NanoAOD.nano_cff import _fixPNetInputCollection
-  _fixPNetInputCollection(process)
+  (run2_nanoAOD_106Xv2 | run3_nanoAOD_pre142X | nanoAOD_rePuppi).toModify(
+      process, lambda p: _fixPNetInputCollection(p)
+  )
 
   ###########################################################################
   # Save Maximum of Pt Hat Max


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/48349

> #### PR description:
> 
> Fixes https://github.com/cms-sw/cmssw/issues/48302.
> 
> #### PR validation:
> 
> `runTheMatrix.py --ibeos -l 11634.15,2500.334,2500.335`
> 
> #### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
> 
> To be backported to 15_0_X.