### PR TITLE
remove obsolete parameter `transactionId` from `CondDBESSource`

### DIFF
--- a/CondCore/ESSources/plugins/CondDBESSource.cc
+++ b/CondCore/ESSources/plugins/CondDBESSource.cc
@@ -777,10 +777,6 @@ void CondDBESSource::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   dbParams.addUntracked<std::string>("security", "");
   dbParams.addUntracked<int>("messageLevel", 0);
   dbParams.addUntracked<int>("connectionTimeout", 0);
-  dbParams.addObsoleteUntracked<std::string>("transactionId")
-      ->setComment(
-          "This parameter is not strictly needed by PoolDBESSource, but the WMCore infrastructure requires it. "
-          "Candidate for deletion");
   desc.add("DBParameters", dbParams);
 
   desc.add<std::string>("connect", std::string("frontier://FrontierProd/CMS_CONDITIONS"));


### PR DESCRIPTION
resolves https://github.com/cms-sw/cmssw/issues/47936

#### PR description:

Title says it all, undoes https://github.com/cms-sw/cmssw/pull/47822, see https://github.com/cms-sw/cmssw/issues/47936 for a more complete discussion.

#### PR validation:

None. `cmssw` compiles

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, might be backported in CMSSW_15_0_X for 2025 data-taking purposes.
