### PR TITLE
Adapt template pixel cpe algo to better handle shortened or broken clusters

### DIFF
--- a/CondFormats/SiPixelTransient/interface/SiPixelTemplate.h
+++ b/CondFormats/SiPixelTransient/interface/SiPixelTemplate.h
@@ -285,8 +285,9 @@ public:
   // initialize the rest;
   static void postInit(std::vector<SiPixelTemplateStore>& thePixelTemp_);
 
+  // Interpolate with y Gaussian Parameter interpolation to be used with goodEdge reconstruction algorithm
   // Interpolate input alpha and beta angles to produce a working template for each individual hit.
-  bool interpolate(int id, float cotalpha, float cotbeta, float locBz, float locBx);
+  bool interpolate(int id, float cotalpha, float cotbeta, float locBz, float locBx, bool goodEdgeAlgo = false);
 
   // Interpolate input alpha and beta angles to produce a working template for each individual hit.
   bool interpolate(int id, float cotalpha, float cotbeta, float locBz);

--- a/Configuration/ProcessModifiers/python/siPixelGoodEdgeAlgo_cff.py
+++ b/Configuration/ProcessModifiers/python/siPixelGoodEdgeAlgo_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+# This modifier enables the good edge algorithm in pixel hit reconstruction that handles broken/truncated pixel cluster caused by radiation damage
+siPixelGoodEdgeAlgo = cms.Modifier()

--- a/Configuration/PyReleaseValidation/README.md
+++ b/Configuration/PyReleaseValidation/README.md
@@ -119,3 +119,4 @@ The offsets currently in use are:
 * 0.113: Activate OuterTracker inefficiency (PS-p: bias rails inefficiency; PS-s and SS: 5% bad strips)
 * 0.114: Activate OuterTracker inefficiency (PS-p: bias rails inefficiency; PS-s and SS: 10% bad strips)
 * 0.141: Activate emulation of the signal shape of the InnerTracker FE chip (CROC)
+* 0.186: Run-3 goodEdgeAlgo CPE

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -648,6 +648,34 @@ upgradeWFs['siPixelDigiMorphing'] = UpgradeWorkflow_siPixelDigiMorphing(
     offset = 0.18,
 )
 
+# pixel GoodEdgeAlgo CPE workflows
+class UpgradeWorkflow_siPixelGoodEdgeAlgo(UpgradeWorkflow):
+    def setup_(self, step, stepName, stepDict, k, properties):
+        if 'Reco' in step:
+            stepDict[stepName][k] = merge([{'--procModifiers': 'siPixelGoodEdgeAlgo'}, stepDict[step][k]])
+    def condition(self, fragment, stepList, key, hasHarvest):
+        result = (fragment=="QCD_Pt_1800_2400_14" or fragment=="TTbar_14TeV" ) and any(y in key for y in ['2025'])
+        return result
+upgradeWFs['siPixelGoodEdgeAlgo'] = UpgradeWorkflow_siPixelGoodEdgeAlgo(
+    steps = [
+        'Reco',
+        'RecoFakeHLT',
+        'RecoGlobal',
+        'RecoGlobalFakeHLT',
+        'RecoNano',
+        'RecoNanoFakeHLT',
+    ],
+    PU = [
+        'Reco',
+        'RecoFakeHLT',
+        'RecoGlobal',
+        'RecoGlobalFakeHLT',
+        'RecoNano',
+        'RecoNanoFakeHLT',
+    ],
+    suffix = '_siPixelGoodEdgeAlgo',
+    offset = 0.186,
+)
 
 #Workflow to enable displacedRegionalStep tracking iteration
 class UpgradeWorkflow_displacedRegional(UpgradeWorkflowTracking):

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEClusterRepair.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEClusterRepair.h
@@ -102,6 +102,7 @@ private:
   std::vector<SiPixelTemplateStore2D> thePixelTemp2D_;
 
   int speed_;
+  bool goodEdgeAlgo_;
 
   bool UseClusterSplitter_;
 

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPETemplateReco.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPETemplateReco.h
@@ -79,6 +79,7 @@ private:
   const std::vector<SiPixelTemplateStore> *thePixelTemp_;
 
   int speed_;
+  bool goodEdgeAlgo_;
 
   bool UseClusterSplitter_;
 

--- a/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplateReco.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplateReco.h
@@ -99,7 +99,26 @@ namespace SiPixelTemplateReco {
                       std::vector<std::pair<int, int> >& zeropix,
                       float& probQ,
                       int& nypix,
-                      int& nxpix);
+                      int& nxpix,
+                      bool goodEdgeAlgo);
+
+  int PixelTempReco1D(int id,
+                      float cotalpha,
+                      float cotbeta,
+                      float locBz,
+                      float locBx,
+                      ClusMatrix& cluster,
+                      SiPixelTemplate& templ,
+                      float& yrec,
+                      float& sigmay,
+                      float& proby,
+                      float& xrec,
+                      float& sigmax,
+                      float& probx,
+                      int& qbin,
+                      int speed,
+                      float& probQ,
+                      bool goodEdgeAlgo);
 
   int PixelTempReco1D(int id,
                       float cotalpha,

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPEClusterRepair_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPEClusterRepair_cfi.py
@@ -6,3 +6,8 @@ templates2_speed0 = _templates2_default.clone(
     ComponentName = "PixelCPEClusterRepairWithoutProbQ",
     speed = 0
 )
+
+# Enable the good edge algorithm in pixel hit reconstruction that handles broken/truncated pixel cluster caused by radiation damage
+from Configuration.ProcessModifiers.siPixelGoodEdgeAlgo_cff import siPixelGoodEdgeAlgo
+siPixelGoodEdgeAlgo.toModify(templates2, GoodEdgeAlgo = True)
+siPixelGoodEdgeAlgo.toModify(templates2_speed0, GoodEdgeAlgo = True)

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPETemplateReco_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPETemplateReco_cfi.py
@@ -3,3 +3,6 @@ import FWCore.ParameterSet.Config as cms
 from RecoLocalTracker.SiPixelRecHits._templates_default_cfi import _templates_default
 templates = _templates_default.clone()
 
+# Enable the good edge algorithm in pixel hit reconstruction that handles broken/truncated pixel cluster caused by radiation damage
+from Configuration.ProcessModifiers.siPixelGoodEdgeAlgo_cff import siPixelGoodEdgeAlgo
+siPixelGoodEdgeAlgo.toModify(templates, GoodEdgeAlgo = True)

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
@@ -75,7 +75,9 @@ PixelCPEClusterRepair::PixelCPEClusterRepair(edm::ParameterSet const& conf,
   }
 
   speed_ = conf.getParameter<int>("speed");
+  goodEdgeAlgo_ = conf.getParameter<bool>("GoodEdgeAlgo");
   LogDebug("PixelCPEClusterRepair::PixelCPEClusterRepair:") << "Template speed = " << speed_ << "\n";
+  LogDebug("PixelCPEClusterRepair::PixelCPEClusterRepair:") << "GoodEdgeAlgo = " << goodEdgeAlgo_ << "\n";
 
   // this returns the magnetic field value in kgauss (1T = 10 kgauss)
   int theMagField = mag->nominalValue();
@@ -355,7 +357,8 @@ void PixelCPEClusterRepair::callTempReco1D(DetParam const& theDetParam,
                                          zeropix,
                                          theClusterParam.probabilityQ_,
                                          nypix,
-                                         nxpix);
+                                         nxpix,
+                                         goodEdgeAlgo_);
   // ******************************************************************
 
   //--- Check exit status
@@ -549,7 +552,8 @@ void PixelCPEClusterRepair::checkRecommend2D(DetParam const& theDetParam,
   }
   // The 1d pixel template
   SiPixelTemplate templ(*thePixelTemp_);
-  if (!templ.interpolate(ID, theClusterParam.cotalpha, theClusterParam.cotbeta, theDetParam.bz, theDetParam.bx)) {
+  if (!templ.interpolate(
+          ID, theClusterParam.cotalpha, theClusterParam.cotbeta, theDetParam.bz, theDetParam.bx, goodEdgeAlgo_)) {
     //error setting up template, return false
     theClusterParam.recommended2D_ = false;
     return;
@@ -718,6 +722,7 @@ void PixelCPEClusterRepair::fillPSetDescription(edm::ParameterSetDescription& de
   desc.add<int>("forwardTemplateID", 0);
   desc.add<int>("directoryWithTemplates", 0);
   desc.add<int>("speed", -2);
+  desc.add<bool>("GoodEdgeAlgo", false);
   desc.add<bool>("UseClusterSplitter", false);
   desc.add<double>("MaxSizeMismatchInY", 0.3);
   desc.add<double>("MinChargeRatio", 0.8);

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
@@ -81,6 +81,7 @@ PixelCPETemplateReco::PixelCPETemplateReco(edm::ParameterSet const& conf,
           << " not loaded correctly from text file. Reconstruction will fail.\n\n";
   }
 
+  goodEdgeAlgo_ = conf.getParameter<bool>("GoodEdgeAlgo");
   speed_ = conf.getParameter<int>("speed");
   LogDebug("PixelCPETemplateReco::PixelCPETemplateReco:") << "Template speed = " << speed_ << "\n";
 
@@ -249,7 +250,8 @@ LocalPoint PixelCPETemplateReco::localPosition(DetParam const& theDetParam, Clus
                                          theClusterParam.templProbX_,
                                          theClusterParam.templQbin_,
                                          speed_,
-                                         theClusterParam.templProbQ_);
+                                         theClusterParam.templProbQ_,
+                                         goodEdgeAlgo_);
 
   // ******************************************************************
 
@@ -529,4 +531,5 @@ void PixelCPETemplateReco::fillPSetDescription(edm::ParameterSetDescription& des
   desc.add<int>("directoryWithTemplates", 0);
   desc.add<int>("speed", -2);
   desc.add<bool>("UseClusterSplitter", false);
+  desc.add<bool>("GoodEdgeAlgo", false);
 }


### PR DESCRIPTION
#### PR description:

While validating [PR#47966](https://github.com/cms-sw/cmssw/pull/47966), it was found that the proposed changes to generic CPE algorithm are not beneficial. This PR contains only the proposed changes to the template CPE algorithm that are simpler, and beneficial for long clusters in heavily irradiated pixel sensors (right-most columns in [slides 23 onwards](https://indico.cern.ch/event/1554785/contributions/6550922/attachments/3081344/5455226/20250605_TOO-PixelCalibAndLocalReco.pdf)). The proposed changes to the algorithm are gated behind a process modifier.


#### PR validation:
The following two plots are showing the RecHit-SimHit distribution in extended-end-of-run-3 muon gun simulation. As expected, the effect is more pronounced in the high eta region.

![recHitYResLayer1_tracking_central_Template](https://github.com/user-attachments/assets/bb0b6368-7d64-41c4-a382-522404a3d1ff)
![recHitYResLayer1_tracking_forward_Template](https://github.com/user-attachments/assets/91eaa333-e4d1-4227-86cd-283276875186)

Although the logic of the code does not change when the `goodEdgeAlgo` flag is set to false, minute differences w.r.t reference were observed in many workflows. We hypothesize it originates from the changed footprint of the `SiPixelTemplate` class. This [draft PR](https://github.com/cms-sw/cmssw/pull/48146/files) contains minimum edit that produces similar differences.

PR passes the basic battery of tests
```
50 49 48 42 21 1 1 1 1 1 1 tests passed, 0 0 0 0 0 0 0 0 0 0 0 failed
```

#### Backport
To be backported to 15.0.X. 
