### PR TITLE
[15.0.X] Update HLT MultiTrackValidator

### DIFF
--- a/DQMOffline/Trigger/python/TrackingMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/TrackingMonitoring_cff.py
@@ -165,8 +165,17 @@ trackingMonitorHLTall = cms.Sequence(
 #    + iter4TracksMonitoringHLT
 )    
 
-doubletRecoveryHPTracksMonitoringHLT = trackingMonHLT.clone(
+doubletRecoveryTracksMonitoringHLT = trackingMonHLT.clone(
     FolderName       = 'HLT/Tracking/doubletRecoveryTracks',
+    TrackProducer    = 'hltDoubletRecoveryPFlowCtfWithMaterialTracks',
+    allTrackProducer = 'hltDoubletRecoveryPFlowCtfWithMaterialTracks',
+    doEffFromHitPatternVsPU   = True,
+    doEffFromHitPatternVsBX   = False,
+    doEffFromHitPatternVsLUMI = False
+)
+
+doubletRecoveryHPTracksMonitoringHLT = trackingMonHLT.clone(
+    FolderName       = 'HLT/Tracking/doubletRecoveryTracksHP',
     TrackProducer    = 'hltDoubletRecoveryPFlowTrackSelectionHighPurity',
     allTrackProducer = 'hltDoubletRecoveryPFlowTrackSelectionHighPurity',
     doEffFromHitPatternVsPU   = True,
@@ -262,7 +271,7 @@ trkHLTDQMSourceExtra = cms.Sequence(
 )
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
-run3_common.toReplaceWith(trackingMonitorHLT, cms.Sequence(pixelTracksMonitoringHLT + iterHLTTracksMonitoringHLT + doubletRecoveryHPTracksMonitoringHLT )) # + iter0HPTracksMonitoringHLT ))
+run3_common.toReplaceWith(trackingMonitorHLT, cms.Sequence(pixelTracksMonitoringHLT + iterHLTTracksMonitoringHLT  + doubletRecoveryTracksMonitoringHLT + doubletRecoveryHPTracksMonitoringHLT))
 phase2_tracker.toReplaceWith(trackingMonitorHLT, cms.Sequence(pixelTracksMonitoringHLT + iterHLTTracksMonitoringHLT + iterInitialStepMonitoringHLT + iterHighPtTripletsMonitoringHLT))
 
 run3_common.toReplaceWith(trackingMonitorHLTall, cms.Sequence(pixelTracksMonitoringHLT + iter0TracksMonitoringHLT + iterHLTTracksMonitoringHLT))

--- a/DQMOffline/Trigger/python/TrackingMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/TrackingMonitoring_cff.py
@@ -271,8 +271,8 @@ trkHLTDQMSourceExtra = cms.Sequence(
 )
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
-run3_common.toReplaceWith(trackingMonitorHLT, cms.Sequence(pixelTracksMonitoringHLT + iterHLTTracksMonitoringHLT  + doubletRecoveryTracksMonitoringHLT + doubletRecoveryHPTracksMonitoringHLT))
+run3_common.toReplaceWith(trackingMonitorHLT, cms.Sequence(pixelTracksMonitoringHLT + iterHLTTracksMonitoringHLT + doubletRecoveryHPTracksMonitoringHLT))
 phase2_tracker.toReplaceWith(trackingMonitorHLT, cms.Sequence(pixelTracksMonitoringHLT + iterHLTTracksMonitoringHLT + iterInitialStepMonitoringHLT + iterHighPtTripletsMonitoringHLT))
 
-run3_common.toReplaceWith(trackingMonitorHLTall, cms.Sequence(pixelTracksMonitoringHLT + iter0TracksMonitoringHLT + iterHLTTracksMonitoringHLT))
+run3_common.toReplaceWith(trackingMonitorHLTall, cms.Sequence(pixelTracksMonitoringHLT + iter0TracksMonitoringHLT + iter0HPTracksMonitoringHLT + doubletRecoveryTracksMonitoringHLT + doubletRecoveryHPTracksMonitoringHLT + iterHLTTracksMonitoringHLT))
 run3_common.toReplaceWith(egmTrackingMonitorHLT, cms.Sequence(gsfTracksMonitoringHLT))

--- a/Validation/RecoTrack/python/HLTmultiTrackValidator_cff.py
+++ b/Validation/RecoTrack/python/HLTmultiTrackValidator_cff.py
@@ -26,7 +26,7 @@ hltMultiTrackValidation = cms.Sequence(
 )
 
 def _modifyForRun3(trackvalidator):
-    trackvalidator.label = ["hltPixelTracks", "hltMergedTracks", "hltDoubletRecoveryPFlowTrackSelectionHighPurity"] #, "hltIter0PFlowTrackSelectionHighPurity"]
+    trackvalidator.label = ["hltPixelTracks", "hltMergedTracks", "hltDoubletRecoveryPFlowTrackSelectionHighPurity"]
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(hltTrackValidator, _modifyForRun3)

--- a/Validation/RecoTrack/python/HLTmultiTrackValidator_cff.py
+++ b/Validation/RecoTrack/python/HLTmultiTrackValidator_cff.py
@@ -26,7 +26,7 @@ hltMultiTrackValidation = cms.Sequence(
 )
 
 def _modifyForRun3(trackvalidator):
-    trackvalidator.label = ["hltPixelTracks", "hltMergedTracks", "hltDoubletRecoveryPFlowTrackSelectionHighPurity"]
+    trackvalidator.label = ["hltPixelTracks", "hltIter0PFlowCtfWithMaterialTracks", "hltIter0PFlowTrackSelectionHighPurity", "hltDoubletRecoveryPFlowCtfWithMaterialTracks", "hltDoubletRecoveryPFlowTrackSelectionHighPurity", "hltMergedTracks"]
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(hltTrackValidator, _modifyForRun3)

--- a/Validation/RecoTrack/python/HLTmultiTrackValidator_cfi.py
+++ b/Validation/RecoTrack/python/HLTmultiTrackValidator_cfi.py
@@ -9,16 +9,7 @@ hltMultiTrackValidator.dirName = 'HLT/Tracking/ValidationWRTtp/'
 hltMultiTrackValidator.label   = ['hltPixelTracks']
 hltMultiTrackValidator.beamSpot = 'hltOnlineBeamSpot'
 hltMultiTrackValidator.ptMinTP  =  0.4
-hltMultiTrackValidator.lipTP    = 30.0
-hltMultiTrackValidator.tipTP    = 60.0
-hltMultiTrackValidator.histoProducerAlgoBlock.generalTpSelector.ptMin =  0.9
-hltMultiTrackValidator.histoProducerAlgoBlock.generalTpSelector.lip   = 30.0
-hltMultiTrackValidator.histoProducerAlgoBlock.generalTpSelector.tip   = 60.0
-hltMultiTrackValidator.histoProducerAlgoBlock.TpSelectorForEfficiencyVsEta  = hltMultiTrackValidator.histoProducerAlgoBlock.generalTpSelector.clone()
-hltMultiTrackValidator.histoProducerAlgoBlock.TpSelectorForEfficiencyVsPhi  = hltMultiTrackValidator.histoProducerAlgoBlock.generalTpSelector.clone()
-hltMultiTrackValidator.histoProducerAlgoBlock.TpSelectorForEfficiencyVsPt   = hltMultiTrackValidator.histoProducerAlgoBlock.generalTpSelector.clone(ptMin=0.4)
-hltMultiTrackValidator.histoProducerAlgoBlock.TpSelectorForEfficiencyVsVTXR = hltMultiTrackValidator.histoProducerAlgoBlock.generalTpSelector.clone()
-hltMultiTrackValidator.histoProducerAlgoBlock.TpSelectorForEfficiencyVsVTXZ = hltMultiTrackValidator.histoProducerAlgoBlock.generalTpSelector.clone()
+hltMultiTrackValidator.histoProducerAlgoBlock.TpSelectorForEfficiencyVsPt.ptMin = 0.4
 hltMultiTrackValidator.parametersDefiner = 'hltLhcParametersDefinerForTP'
 ### for fake rate vs dR ###
 hltMultiTrackValidator.calculateDrSingleCollection = False


### PR DESCRIPTION
### PR description:

backport of https://github.com/cms-sw/cmssw/pull/48361

As discussed in TSG and Tracking POG meetings, as of today the HLT MTV (multi-track validation) applies different selection wrt. offline.
This has historical (?) motivations, not necessarily meaningful.
Hence, this PR is:
- using selections in line with offline (min pT is kept at 0.4 GeV);
- introducing the possibility to monitor all HLT track collections before quality selections are applied, by storing the relevant collections in appropriate data tiers.

Related to https://its.cern.ch/jira/browse/CMSHLT-3574

### PR validation:

E.g., http://uaf-10.t2.ucsd.edu/~mmasciov/TRKPOG/HLT2025/mkFitDoubletRecovery/HLT_2025_TTbarPU_mkFitDR_updatedMTV/plots_hlt.html

Observed differences in the HLT MTV are expected and due to different selections.

FYI @cms-sw/tracking-pog-l2, @mmusich