### PR TITLE
Fix CA cell hardCurvCut, to apply absolute value

### DIFF
--- a/RecoTracker/PixelSeeding/plugins/GPUCACell.h
+++ b/RecoTracker/PixelSeeding/plugins/GPUCACell.h
@@ -208,7 +208,7 @@ public:
 
     CircleEq<float> eq(x1, y1, x2, y2, x3, y3);
 
-    if (eq.curvature() > maxCurv)
+    if (std::abs(eq.curvature()) > maxCurv)
       return false;
 
     return std::abs(eq.dca0()) < region_origin_radius_plus_tolerance * std::abs(eq.curvature());
@@ -224,7 +224,7 @@ public:
                                                  const float maxCurv) {
     CircleEq<float> eq(x1, y1, x2, y2, x3, y3);
 
-    if (eq.curvature() > maxCurv)
+    if (std::abs(eq.curvature()) > maxCurv)
       return false;
 
     return std::abs(eq.dca0()) < region_origin_radius_plus_tolerance * std::abs(eq.curvature());

--- a/RecoTracker/PixelSeeding/plugins/alpaka/CACell.h
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CACell.h
@@ -213,7 +213,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
       CircleEq<float> eq(x1, y1, x2, y2, x3, y3);
 
-      if (eq.curvature() > maxCurv)
+      if (std::abs(eq.curvature()) > maxCurv)
         return false;
 
       return std::abs(eq.dca0()) < region_origin_radius_plus_tolerance * std::abs(eq.curvature());
@@ -230,7 +230,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         const float maxCurv) {
       CircleEq<float> eq(x1, y1, x2, y2, x3, y3);
 
-      if (eq.curvature() > maxCurv)
+      if (std::abs(eq.curvature()) > maxCurv)
         return false;
 
       return std::abs(eq.dca0()) < region_origin_radius_plus_tolerance * std::abs(eq.curvature());


### PR DESCRIPTION
### PR description:

As per title.
This bug was found and reported by @JanGerritSchulz (FYI @rovere, @mmusich, @VourMa) in https://indico.cern.ch/event/1559352/contributions/6568097/subcontributions/556117/attachments/3088038/5468336/NGT_Updates_25-06-17.pdf

### PR validation:

As the affected cut for Run-3 is virtually fully relaxed (corresponding to 20 MeV), there's no visible difference for HLT tracking in 2025:
http://uaf-10.t2.ucsd.edu/~mmasciov/TRKPOG/HLT2025/mkFitDoubletRecovery/HLT_2025_TTbarPU_mkFitDR_updatedMTV_withCAfix/plots_hlt_hltMerged/effandfakePtEtaPhi.pdf

A backport to 150X will follow.

FYI: @cms-sw/tracking-pog-l2, @missirol, @mtosi 