### PR TITLE
 Updated 2025 geometry in the 2025 MC GT for 151X

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -104,7 +104,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2025
     'phase1_2025_design'           :    '150X_mcRun3_2025_design_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2025
-    'phase1_2025_realistic'        :    '150X_mcRun3_2025_realistic_v11',
+    'phase1_2025_realistic'        :    '151X_mcRun3_2025_realistic_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2025, Strip tracker in DECO mode
     'phase1_2025_cosmics'          :    '150X_mcRun3_2025cosmics_realistic_deco_v3',
     # GlobalTag for MC production with realistic conditions for Phase2


### PR DESCRIPTION
#### PR description:

Add the 2025 Sim and Reco geometry updates in the 2025 MC GT in autocond.

The baseline is [150X_mcRun3_2025_realistic_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/150X_mcRun3_2025_realistic_v11) , which is the supposedly final GT for the Spring25MC campaign. On top of it, for the first 2025MC GT in the 151X serie the geometry updates listed in the presentation of Sunanda Banerjee at the AlCaDB meeting of 16th June 2025 (see [slides](https://indico.cern.ch/event/1556352/#3-new-mc-geometry-for-2025-int)) were added.

In particular, starting from the scenario description of the 2024 period, (as in all 150X MC GTs) the following changes were impleented for the 2025 Geometry in the version _v1 of the GT:
• Modification of the shielding structure in the DT region
• Several GE11 super chambers are dismounted and will be reworked
• Addition of GEM chambers in the GE21 station
• Reversal of φ-staggering patterns in RE±2, RE±3 and RE±4
• Change in the z-positions of the RPC chambers in the Endcap
• Installation of new iRPCs in the Endcap
• Modification of the PPS

Moreover, GEM reco geometry, GEM alignment and channel maps compatible with the GEM 2025 geometry, as they were originally requested in [cmsTalk](https://cms-talk.web.cern.ch/t/call-for-conditions-for-the-spring25-mc-global-tag/119464/6), were restored in the version _v3 of the GT.

The new GT added here in autocond is [151X_mcRun3_2025_realistic_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/151X_mcRun3_2025_realistic_v3)

The overall difference of that 151X GT wrt 150X_mcRun3_2025_realistic_v11 can be seen [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/151X_mcRun3_2025_realistic_v3/150X_mcRun3_2025_realistic_v11)

#### PR validation:

Tested in a couple of 2025MC workflows

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

No backport foreseen