### PR TITLE
Replace standard library functions with their Alpaka equivalents 

### DIFF
--- a/HeterogeneousCore/AlpakaInterface/interface/HistoContainer.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/HistoContainer.h
@@ -97,11 +97,11 @@ namespace cms::alpakatools {
   }
 
   // iteratate over N bins left and right of the one containing "v"
-  template <typename Hist, typename V, typename Func>
-  ALPAKA_FN_ACC ALPAKA_FN_INLINE void forEachInBins(Hist const &hist, V value, int n, Func func) {
+  template <typename TAcc, typename Hist, typename V, typename Func>
+  ALPAKA_FN_ACC ALPAKA_FN_INLINE void forEachInBins(const TAcc &acc, Hist const &hist, V value, int n, Func func) {
     int bs = Hist::bin(value);
-    int be = std::min(int(Hist::nbins() - 1), bs + n);
-    bs = std::max(0, bs - n);
+    int be = alpaka::math::min(acc, int(Hist::nbins() - 1), bs + n);
+    bs = alpaka::math::max(acc, 0, bs - n);
     ALPAKA_ASSERT_ACC(be >= bs);
     for (auto pj = hist.begin(bs); pj < hist.end(be); ++pj) {
       func(*pj);

--- a/HeterogeneousCore/AlpakaInterface/interface/prefixScan.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/prefixScan.h
@@ -155,7 +155,7 @@ namespace cms::alpakatools {
       // first each block does a scan
       [[maybe_unused]] int off = elementsPerBlock * blockIdx;
       if (size - off > 0) {
-        blockPrefixScan(acc, ci + off, co + off, std::min(elementsPerBlock, size - off), ws);
+        blockPrefixScan(acc, ci + off, co + off, alpaka::math::min(acc, elementsPerBlock, size - off), ws);
       }
 
       // count blocks that finished

--- a/HeterogeneousCore/AlpakaInterface/interface/workdivision.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/workdivision.h
@@ -19,6 +19,9 @@ namespace cms::alpakatools {
   // Return the integer division of the first argument by the second argument, rounded up to the next integer
   inline constexpr Idx divide_up_by(Idx value, Idx divisor) { return (value + divisor - 1) / divisor; }
 
+  // Return the minimum of two values:
+  inline constexpr Idx idx_min(Idx const x, Idx const y) { return (y > x) ? x : y; }
+
   // Trait describing whether or not the accelerator expects the threads-per-block and elements-per-thread to be swapped
   template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
   struct requires_single_thread_per_block : public std::true_type {};
@@ -186,9 +189,9 @@ namespace cms::alpakatools {
             : elements_{elements},
               stride_{stride},
               extent_{extent},
-              first_{std::min(first, extent)},
+              first_{idx_min(first, extent)},
               index_{first_},
-              range_{std::min(first + elements, extent)} {}
+              range_{idx_min(first + elements, extent)} {}
 
       public:
         ALPAKA_FN_ACC inline Idx operator*() const { return index_; }
@@ -205,7 +208,7 @@ namespace cms::alpakatools {
           // increment the thread index with the grid stride
           first_ += stride_;
           index_ = first_;
-          range_ = std::min(first_ + elements_, extent_);
+          range_ = idx_min(first_ + elements_, extent_);
           if (index_ < extent_)
             return *this;
 
@@ -506,7 +509,7 @@ namespace cms::alpakatools {
             overflow = true;
           }
           index_[I] = first_[I];
-          range_[I] = std::min(first_[I] + loop_->elements_[I], loop_->extent_[I]);
+          range_[I] = idx_min(first_[I] + loop_->elements_[I], loop_->extent_[I]);
           return overflow;
         }
 
@@ -662,7 +665,7 @@ namespace cms::alpakatools {
         friend class UniformGroupsAlong;
 
         ALPAKA_FN_ACC inline const_iterator(Idx stride, Idx extent, Idx first)
-            : stride_{stride}, extent_{extent}, first_{std::min(first, extent)} {}
+            : stride_{stride}, extent_{extent}, first_{idx_min(first, extent)} {}
 
       public:
         ALPAKA_FN_ACC inline Idx operator*() const { return first_; }
@@ -866,10 +869,10 @@ namespace cms::alpakatools {
 
       ALPAKA_FN_ACC inline UniformGroupElementsAlong(TAcc const& acc, Idx block, Idx extent)
           : first_{block * alpaka::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[Dim]},
-            local_{std::min(extent - first_,
-                            alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc)[Dim] *
-                                alpaka::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[Dim])},
-            range_{std::min(extent - first_, local_ + alpaka::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[Dim])} {}
+            local_{idx_min(extent - first_,
+                           alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc)[Dim] *
+                               alpaka::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[Dim])},
+            range_{idx_min(extent - first_, local_ + alpaka::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[Dim])} {}
 
       class const_iterator;
       using iterator = const_iterator;
@@ -1086,7 +1089,7 @@ namespace cms::alpakatools {
         friend class IndependentGroupsAlong;
 
         ALPAKA_FN_ACC inline const_iterator(Idx stride, Idx extent, Idx first)
-            : stride_{stride}, extent_{extent}, first_{std::min(first, extent)} {}
+            : stride_{stride}, extent_{extent}, first_{idx_min(first, extent)} {}
 
       public:
         ALPAKA_FN_ACC inline Idx operator*() const { return first_; }
@@ -1257,9 +1260,9 @@ namespace cms::alpakatools {
             : elements_{elements},
               stride_{stride},
               extent_{extent},
-              first_{std::min(first, extent)},
+              first_{idx_min(first, extent)},
               index_{first_},
-              range_{std::min(first + elements, extent)} {}
+              range_{idx_min(first + elements, extent)} {}
 
       public:
         ALPAKA_FN_ACC inline Idx operator*() const { return index_; }
@@ -1276,7 +1279,7 @@ namespace cms::alpakatools {
           // increment the thread index with the block stride
           first_ += stride_;
           index_ = first_;
-          range_ = std::min(first_ + elements_, extent_);
+          range_ = idx_min(first_ + elements_, extent_);
           if (index_ < extent_)
             return *this;
 

--- a/HeterogeneousCore/AlpakaInterface/test/alpaka/testOneHistoContainer.dev.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/alpaka/testOneHistoContainer.dev.cc
@@ -109,10 +109,10 @@ struct mykernel {
       auto vm = int(v[j]) - DELTA;
       auto vp = int(v[j]) + DELTA;
       constexpr int vmax = NBINS != 128 ? NBINS * 2 - 1 : std::numeric_limits<T>::max();
-      vm = std::max(vm, 0);
-      vm = std::min(vm, vmax);
-      vp = std::min(vp, vmax);
-      vp = std::max(vp, 0);
+      vm = alpaka::math::max(acc, vm, 0);
+      vm = alpaka::math::min(acc, vm, vmax);
+      vp = alpaka::math::min(acc, vp, vmax);
+      vp = alpaka::math::max(acc, vp, 0);
       ALPAKA_ASSERT_ACC(vp >= vm);
       forEachInWindow(hist, vm, vp, ftest);
 #ifndef NDEBUG

--- a/RecoVertex/PixelVertexFinding/plugins/alpaka/clusterTracksByDensity.h
+++ b/RecoVertex/PixelVertexFinding/plugins/alpaka/clusterTracksByDensity.h
@@ -85,8 +85,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::vertexFinder {
       // Equivalent of iz = std::clamp(iz, INT8_MIN, INT8_MAX)
       // which doesn't compile with gcc14 due to reference to __glibcxx_assert
       // See https://github.com/llvm/llvm-project/issues/95183
-      int tmp_max = std::max<int>(iz, INT8_MIN);
-      iz = std::min<int>(tmp_max, INT8_MAX);
+      int tmp_max = alpaka::math::max(acc, iz, INT8_MIN);
+      iz = alpaka::math::min(acc, tmp_max, INT8_MAX);
       ALPAKA_ASSERT_ACC(iz - INT8_MIN >= 0);
       ALPAKA_ASSERT_ACC(iz - INT8_MIN < 256);
       izt[i] = iz - INT8_MIN;
@@ -110,10 +110,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::vertexFinder {
     for (auto i : cms::alpakatools::uniform_elements(acc, nt)) {
       if (ezt2[i] > errmax2)
         continue;
-      cms::alpakatools::forEachInBins(hist, izt[i], 1, [&](uint32_t j) {
+      cms::alpakatools::forEachInBins(acc, hist, izt[i], 1, [&](uint32_t j) {
         if (i == j)
           return;
-        auto dist = std::abs(zt[i] - zt[j]);
+        auto dist = alpaka::math::abs(acc, zt[i] - zt[j]);
         if (dist > eps)
           return;
         if (dist * dist > chi2max * (ezt2[i] + ezt2[j]))
@@ -126,12 +126,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::vertexFinder {
     // find closest above me .... (we ignore the possibility of two j at same distance from i)
     for (auto i : cms::alpakatools::uniform_elements(acc, nt)) {
       float mdist = eps;
-      cms::alpakatools::forEachInBins(hist, izt[i], 1, [&](uint32_t j) {
+      cms::alpakatools::forEachInBins(acc, hist, izt[i], 1, [&](uint32_t j) {
         if (nn[j] < nn[i])
           return;
         if (nn[j] == nn[i] && zt[j] >= zt[i])
           return;  // if equal use natural order...
-        auto dist = std::abs(zt[i] - zt[j]);
+        auto dist = alpaka::math::abs(acc, zt[i] - zt[j]);
         if (dist > mdist)
           return;
         if (dist * dist > chi2max * (ezt2[i] + ezt2[j]))
@@ -173,12 +173,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::vertexFinder {
     for (auto i : cms::alpakatools::uniform_elements(acc, nt)) {
       auto minJ = i;
       auto mdist = eps;
-      cms::alpakatools::forEachInBins(hist, izt[i], 1, [&](uint32_t j) {
+      cms::alpakatools::forEachInBins(acc, hist, izt[i], 1, [&](uint32_t j) {
         if (nn[j] < nn[i])
           return;
         if (nn[j] == nn[i] && zt[j] >= zt[i])
           return;  // if equal use natural order...
-        auto dist = std::abs(zt[i] - zt[j]);
+        auto dist = alpaka::math::abs(acc, zt[i] - zt[j]);
         if (dist > mdist)
           return;
         if (dist * dist > chi2max * (ezt2[i] + ezt2[j]))

--- a/RecoVertex/PixelVertexFinding/plugins/alpaka/clusterTracksDBSCAN.h
+++ b/RecoVertex/PixelVertexFinding/plugins/alpaka/clusterTracksDBSCAN.h
@@ -83,8 +83,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::vertexFinder {
         // Equivalent of iz = std::clamp(iz, INT8_MIN, INT8_MAX)
         // which doesn't compile with gcc14 due to reference to __glibcxx_assert
         // See https://github.com/llvm/llvm-project/issues/95183
-        int tmp_max = std::max<int>(iz, INT8_MIN);
-        iz = std::min<int>(tmp_max, INT8_MAX);
+        int tmp_max = alpaka::math::max<Acc1D, int>(acc, iz, INT8_MIN);
+        iz = alpaka::math::min<Acc1D, int>(acc, tmp_max, INT8_MAX);
         izt[i] = iz - INT8_MIN;
         ALPAKA_ASSERT_ACC(iz - INT8_MIN >= 0);
         ALPAKA_ASSERT_ACC(iz - INT8_MIN < 256);
@@ -108,10 +108,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::vertexFinder {
       for (auto i : cms::alpakatools::uniform_elements(acc, nt)) {
         if (ezt2[i] > errmax2)
           continue;
-        cms::alpakatools::forEachInBins(hist, izt[i], 1, [&](uint32_t j) {
+        cms::alpakatools::forEachInBins(acc, hist, izt[i], 1, [&](uint32_t j) {
           if (i == j)
             return;
-          auto dist = std::abs(zt[i] - zt[j]);
+          auto dist = alpaka::math::abs(acc, zt[i] - zt[j]);
           if (dist > eps)
             return;
           nn[i]++;
@@ -124,12 +124,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::vertexFinder {
         if (nn[i] < minT)
           continue;  // DBSCAN core rule
         float mz = zt[i];
-        cms::alpakatools::forEachInBins(hist, izt[i], 1, [&](uint32_t j) {
+        cms::alpakatools::forEachInBins(acc, hist, izt[i], 1, [&](uint32_t j) {
           if (zt[j] >= mz)
             return;
           if (nn[j] < minT)
             return;  // DBSCAN core rule
-          auto dist = std::abs(zt[i] - zt[j]);
+          auto dist = alpaka::math::abs(acc, zt[i] - zt[j]);
           if (dist > eps)
             return;
           mz = zt[j];
@@ -171,10 +171,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::vertexFinder {
         if (nn[i] < minT)
           continue;  // DBSCAN core rule
         ALPAKA_ASSERT_ACC(zt[iv[i]] <= zt[i]);
-        cms::alpakatools::forEachInBins(hist, izt[i], 1, [&](uint32_t j) {
+        cms::alpakatools::forEachInBins(acc, hist, izt[i], 1, [&](uint32_t j) {
           if (nn[j] < minT)
             return;  // DBSCAN core rule
-          auto dist = std::abs(zt[i] - zt[j]);
+          auto dist = alpaka::math::abs(acc, zt[i] - zt[j]);
           if (dist > eps)
             return;
           // they should belong to the same cluster, isn't it?
@@ -194,10 +194,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::vertexFinder {
         if (nn[i] >= minT)
           continue;  // DBSCAN edge rule
         float mdist = eps;
-        cms::alpakatools::forEachInBins(hist, izt[i], 1, [&](uint32_t j) {
+        cms::alpakatools::forEachInBins(acc, hist, izt[i], 1, [&](uint32_t j) {
           if (nn[j] < minT)
             return;  // DBSCAN core rule
-          auto dist = std::abs(zt[i] - zt[j]);
+          auto dist = alpaka::math::abs(acc, zt[i] - zt[j]);
           if (dist > mdist)
             return;
           if (dist * dist > chi2max * (ezt2[i] + ezt2[j]))

--- a/RecoVertex/PixelVertexFinding/plugins/alpaka/clusterTracksIterative.h
+++ b/RecoVertex/PixelVertexFinding/plugins/alpaka/clusterTracksIterative.h
@@ -79,8 +79,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::vertexFinder {
         // Equivalent of iz = std::clamp(iz, INT8_MIN, INT8_MAX)
         // which doesn't compile with gcc14 due to reference to __glibcxx_assert
         // See https://github.com/llvm/llvm-project/issues/95183
-        int tmp_max = std::max<int>(iz, INT8_MIN);
-        iz = std::min<int>(tmp_max, INT8_MAX);
+        int tmp_max = alpaka::math::max<Acc1D, int>(acc, iz, INT8_MIN);
+        iz = alpaka::math::min<Acc1D, int>(acc, tmp_max, INT8_MAX);
         izt[i] = iz - INT8_MIN;
         ALPAKA_ASSERT_ACC(iz - INT8_MIN >= 0);
         ALPAKA_ASSERT_ACC(iz - INT8_MIN < 256);
@@ -104,7 +104,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::vertexFinder {
       for (auto i : cms::alpakatools::uniform_elements(acc, nt)) {
         if (ezt2[i] > errmax2)
           continue;
-        cms::alpakatools::forEachInBins(hist, izt[i], 1, [&](uint32_t j) {
+        cms::alpakatools::forEachInBins(acc, hist, izt[i], 1, [&](uint32_t j) {
           if (i == j)
             return;
           auto dist = std::abs(zt[i] - zt[j]);
@@ -138,13 +138,13 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::vertexFinder {
             ++p;
             if (nn[i] < minT)
               continue;  // DBSCAN core rule
-            auto be = std::min(Hist::bin(izt[i]) + 1, int(hist.nbins() - 1));
+            auto be = alpaka::math::min(acc, Hist::bin(izt[i]) + 1, int(hist.nbins() - 1));
             for (; p < hist.end(be); ++p) {
               uint32_t j = *p;
               ALPAKA_ASSERT_ACC(i != j);
               if (nn[j] < minT)
                 continue;  // DBSCAN core rule
-              auto dist = std::abs(zt[i] - zt[j]);
+              auto dist = alpaka::math::abs(acc, zt[i] - zt[j]);
               if (dist > eps)
                 continue;
               if (dist * dist > chi2max * (ezt2[i] + ezt2[j]))
@@ -168,10 +168,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::vertexFinder {
         if (nn[i] >= minT)
           continue;  // DBSCAN edge rule
         float mdist = eps;
-        cms::alpakatools::forEachInBins(hist, izt[i], 1, [&](int j) {
+        cms::alpakatools::forEachInBins(acc, hist, izt[i], 1, [&](int j) {
           if (nn[j] < minT)
             return;  // DBSCAN core rule
-          auto dist = std::abs(zt[i] - zt[j]);
+          auto dist = alpaka::math::abs(acc, zt[i] - zt[j]);
           if (dist > mdist)
             return;
           if (dist * dist > chi2max * (ezt2[i] + ezt2[j]))


### PR DESCRIPTION
#### PR description:

This pull request replaces the standard library functions in the Alpaka interface with their Alpaka-equivalent implementations.
The changes primarily affect the workdivision.h header file, aligning the interface more closely with Alpaka cross-platform design.

Resolves https://github.com/cms-sw/framework-team/issues/1432