### PR TITLE
replace HLT menu to `@fake2` for wf 281.0

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2074,7 +2074,7 @@ steps['DIGIUP17_PU25']=merge([PU25UP17,step2Upg2017Defaults])
 steps['DIGIUP18_PU25']=merge([PU25UP18,step2Upg2018Defaults])
 
 # for Run2 PPb MC workflows
-steps['DIGIUP15_PPb']=merge([{'-s':'DIGI:pdigi_valid,L1,DIGI2RAW,HLT:PIon','--conditions':'auto:run2_mc_pa', '--era':'Run2_2016_pA'}, steps['DIGIUP15']])
+steps['DIGIUP15_PPb']=merge([{'-s':'DIGI:pdigi_valid,L1,DIGI2RAW,HLT:@fake2','--conditions':'auto:run2_mc_pa', '--era':'Run2_2016_pA'}, steps['DIGIUP15']])
 
 # PU25 for high stats workflows
 steps['DIGIUP15_PU25HS']=merge([PU25HS,step2Upg2015Defaults])


### PR DESCRIPTION
#### PR description:

Title say it all.
I noticed that after the merge of https://github.com/cms-sw/cmssw/pull/48375, wf 281 (`EPOS_PPb_8160GeV_MinimumBias`, a p-Pb Run2 workflow), started failing in all IBs, (see [log](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el9_amd64_gcc12/CMSSW_15_1_X_2025-06-20-2300/pyRelValMatrixLogs/run/281.0_EPOS_PPb_8160GeV_MinimumBias/step2_EPOS_PPb_8160GeV_MinimumBias.log#/25)) with error:

```
----- Begin Fatal Exception 21-Jun-2025 06:41:02 CEST-----------------------
An exception of category 'NoRecord' occurred while
   [0] Processing global begin Run run: 1
   [1] Calling method for module GEMRawToDigiModule/'hltMuonGEMDigis'
Exception Message:
No "GEMChMapRcd" record found in the EventSetup.

 Please add an ESSource or ESProducer that delivers such a record.
----- End Fatal Exception -------------------------------------------------
```

This is due to the fact that the Run-3 GEM local reconstruction is required in the `PIon` menu (re-purposed to cater the needs of the 2025 pO,OO,NeNe run) and the default Run2 GT doesn't have the necessary records.
I propose simply to run the fake menu for this workflow (I see no reason to exercise the HLT for Run2 workflow).

#### PR validation:

```
runTheMatrix.py -l 281 --ibeos
```

runs without issue.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Will be backported once https://github.com/cms-sw/cmssw/pull/48376 is merged.