### PR TITLE
Pythia8 ResonanceDecayFilter Fix

### DIFF
--- a/GeneratorInterface/Core/interface/BaseHadronizer.h
+++ b/GeneratorInterface/Core/interface/BaseHadronizer.h
@@ -87,6 +87,7 @@ namespace gen {
     void generateLHE(edm::LuminosityBlock const& lumi, CLHEP::HepRandomEngine* rengine, unsigned int ncpu);
     void cleanLHE();
     unsigned int getVHepMC() { return ivhepmc; }
+    virtual int getOverrideHEPIDWTUP() { return -999; }
 
   protected:
     unsigned int ivhepmc = 2;

--- a/GeneratorInterface/Core/interface/HadronizerFilter.h
+++ b/GeneratorInterface/Core/interface/HadronizerFilter.h
@@ -471,6 +471,10 @@ namespace edm {
     }
     std::unique_ptr<GenLumiInfoProduct> genLumiInfo(new GenLumiInfoProduct());
     genLumiInfo->setHEPIDWTUP(lheRunInfo->getHEPRUP()->IDWTUP);
+    int overrideHEPID = hadronizer_.getOverrideHEPIDWTUP();
+    if (overrideHEPID != -999) {
+      genLumiInfo->setHEPIDWTUP(overrideHEPID);
+    }
     genLumiInfo->setProcessInfo(GenLumiProcess);
 
     lumi.put(std::move(genLumiInfo));

--- a/GeneratorInterface/Core/plugins/GenFilterEfficiencyProducer.cc
+++ b/GeneratorInterface/Core/plugins/GenFilterEfficiencyProducer.cc
@@ -27,6 +27,7 @@
 
 #include "SimDataFormats/GeneratorProducts/interface/GenFilterInfo.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+#include "GeneratorInterface/Pythia8Interface/interface/ResonanceDecayFilterCounter.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 namespace genFilterEff {
@@ -120,6 +121,10 @@ void GenFilterEfficiencyProducer::produce(edm::StreamID, edm::Event& iEvent, con
     return;
   double weight = genEventScale->weight();
 
+  int eventCounterValue = ResonanceDecayFilterCounter::getInstance().getFilterBool()
+                              ? ResonanceDecayFilterCounter::getInstance().getEventCounter()
+                              : 1;
+
   auto sums = luminosityBlockCache(iEvent.getLuminosityBlock().index());
 
   unsigned int nSize = (*trigR).size();
@@ -131,8 +136,8 @@ void GenFilterEfficiencyProducer::produce(edm::StreamID, edm::Event& iEvent, con
       atomic_sum_double(sums->sumpass_w_, weight);
       atomic_sum_double(sums->sumpass_w2_, weight * weight);
 
-      atomic_sum_double(sums->sumtotal_w_, weight);
-      atomic_sum_double(sums->sumtotal_w2_, weight * weight);
+      atomic_sum_double(sums->sumtotal_w_, weight * eventCounterValue);
+      atomic_sum_double(sums->sumtotal_w2_, weight * weight * eventCounterValue);
 
       if (weight > 0) {
         sums->numEventsPassPos_++;
@@ -144,8 +149,8 @@ void GenFilterEfficiencyProducer::produce(edm::StreamID, edm::Event& iEvent, con
 
     } else  // if fail the filter
     {
-      atomic_sum_double(sums->sumtotal_w_, weight);
-      atomic_sum_double(sums->sumtotal_w2_, weight * weight);
+      atomic_sum_double(sums->sumtotal_w_, weight * eventCounterValue);
+      atomic_sum_double(sums->sumtotal_w2_, weight * weight * eventCounterValue);
 
       if (weight > 0)
         sums->numEventsTotalPos_++;

--- a/GeneratorInterface/Core/plugins/GenXSecAnalyzer.cc
+++ b/GeneratorInterface/Core/plugins/GenXSecAnalyzer.cc
@@ -25,6 +25,7 @@
 #include "SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenFilterInfo.h"
 #include "SimDataFormats/GeneratorProducts/interface/LHERunInfoProduct.h"
+#include "GeneratorInterface/Pythia8Interface/interface/ResonanceDecayFilterCounter.h"
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
@@ -332,8 +333,9 @@ void GenXSecAnalyzer::globalEndRun(edm::Run const &iRun, edm::EventSetup const &
   double thisGenFilterErr = 0;
 
   if (runC->filterOnlyEffRun_.sumWeights2() > 0) {
-    thisGenFilterEff = runC->filterOnlyEffRun_.filterEfficiency(hepidwtup_);
-    thisGenFilterErr = runC->filterOnlyEffRun_.filterEfficiencyError(hepidwtup_);
+    int input_genfilter_efficiency = ResonanceDecayFilterCounter::getInstance().getFilterBool() ? 1 : hepidwtup_.load();
+    thisGenFilterEff = runC->filterOnlyEffRun_.filterEfficiency(input_genfilter_efficiency);
+    thisGenFilterErr = runC->filterOnlyEffRun_.filterEfficiencyError(input_genfilter_efficiency);
     if (thisGenFilterEff < 0) {
       thisGenFilterEff = 1;
       thisGenFilterErr = 0;

--- a/GeneratorInterface/Pythia8Interface/interface/ResonanceDecayFilterCounter.h
+++ b/GeneratorInterface/Pythia8Interface/interface/ResonanceDecayFilterCounter.h
@@ -1,0 +1,25 @@
+#ifndef GeneratorInterface_Pythia8Interface_ResonanceDecayFilterCounter_h
+#define GeneratorInterface_Pythia8Interface_ResonanceDecayFilterCounter_h
+
+class ResonanceDecayFilterCounter {
+public:
+  static ResonanceDecayFilterCounter& getInstance() {
+    static ResonanceDecayFilterCounter instance;
+    return instance;
+  }
+
+  void setEventCounter(int eventCounter) { eventCounter_ = eventCounter; }
+
+  void setFilterBool(bool filterBool) { filterBool_ = filterBool; }
+
+  int getEventCounter() const { return eventCounter_; }
+
+  bool getFilterBool() const { return filterBool_; }
+
+private:
+  ResonanceDecayFilterCounter() : eventCounter_(0), filterBool_(false) {}
+  int eventCounter_;
+  bool filterBool_;
+};
+
+#endif  // GeneratorInterface_Pythia8Interface_ResonanceDecayFilterCounter_h

--- a/GeneratorInterface/Pythia8Interface/interface/ResonanceDecayFilterHook.h
+++ b/GeneratorInterface/Pythia8Interface/interface/ResonanceDecayFilterHook.h
@@ -9,25 +9,33 @@ public:
 
   //--------------------------------------------------------------------------
 
+  int idCat(int id);
   bool initAfterBeams() override;
   bool canVetoResonanceDecays() override { return true; }
   bool doVetoResonanceDecays(Pythia8::Event& process) override { return checkVetoResonanceDecays(process); }
   bool checkVetoResonanceDecays(const Pythia8::Event& process);
+  unsigned long int returnEventCounter() { return counter_event_; };
+  void resetEventCounter();
 
   //--------------------------------------------------------------------------
 
 private:
   bool filter_;
   bool exclusive_;
+  bool matching_;
   bool eMuAsEquivalent_;
   bool eMuTauAsEquivalent_;
   bool allNuAsEquivalent_;
   bool udscAsEquivalent_;
   bool udscbAsEquivalent_;
   bool wzAsEquivalent_;
+  unsigned long int counter_event_;
   std::set<int> mothers_;
   std::vector<int> daughters_;
+  std::vector<std::string> matchedDecays_;
 
   std::map<int, int> requestedDaughters_;
   std::map<int, int> observedDaughters_;
+  std::multiset<std::pair<int, int>> requestedDecays_;
+  std::multiset<std::pair<int, int>> remainingDecays_;
 };

--- a/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
@@ -274,8 +274,8 @@ Pythia8Hadronizer::Pythia8Hadronizer(const edm::ParameterSet &params)
   if (params.exists("reweightGen")) {
     edm::LogInfo("Pythia8Interface") << "Start setup for reweightGen";
     edm::ParameterSet rgParams = params.getParameter<edm::ParameterSet>("reweightGen");
-    fReweightUserHook = std::make_shared<PtHatReweightUserHook>(
-        rgParams.getParameter<double>("pTRef"), rgParams.getParameter<double>("power"));
+    fReweightUserHook = std::make_shared<PtHatReweightUserHook>(rgParams.getParameter<double>("pTRef"),
+                                                                rgParams.getParameter<double>("power"));
     edm::LogInfo("Pythia8Interface") << "End setup for reweightGen";
   }
   if (params.exists("reweightGenEmp")) {
@@ -292,22 +292,23 @@ Pythia8Hadronizer::Pythia8Hadronizer(const edm::ParameterSet &params)
     edm::LogInfo("Pythia8Interface") << "Start setup for reweightGenRap";
     edm::ParameterSet rgrParams = params.getParameter<edm::ParameterSet>("reweightGenRap");
     fReweightRapUserHook = std::make_shared<RapReweightUserHook>(rgrParams.getParameter<std::string>("yLabSigmaFunc"),
-                                                       rgrParams.getParameter<double>("yLabPower"),
-                                                       rgrParams.getParameter<std::string>("yCMSigmaFunc"),
-                                                       rgrParams.getParameter<double>("yCMPower"),
-                                                       rgrParams.getParameter<double>("pTHatMin"),
-                                                       rgrParams.getParameter<double>("pTHatMax"));
-    edm::LogInfo("Pythia8Interface") << "End setup for reweightGenRap";
-  }
-  if (params.exists("reweightGenPtHatRap")) {
-    edm::LogInfo("Pythia8Interface") << "Start setup for reweightGenPtHatRap";
-    edm::ParameterSet rgrParams = params.getParameter<edm::ParameterSet>("reweightGenPtHatRap");
-    fReweightPtHatRapUserHook = std::make_shared<PtHatRapReweightUserHook>(rgrParams.getParameter<std::string>("yLabSigmaFunc"),
                                                                  rgrParams.getParameter<double>("yLabPower"),
                                                                  rgrParams.getParameter<std::string>("yCMSigmaFunc"),
                                                                  rgrParams.getParameter<double>("yCMPower"),
                                                                  rgrParams.getParameter<double>("pTHatMin"),
                                                                  rgrParams.getParameter<double>("pTHatMax"));
+    edm::LogInfo("Pythia8Interface") << "End setup for reweightGenRap";
+  }
+  if (params.exists("reweightGenPtHatRap")) {
+    edm::LogInfo("Pythia8Interface") << "Start setup for reweightGenPtHatRap";
+    edm::ParameterSet rgrParams = params.getParameter<edm::ParameterSet>("reweightGenPtHatRap");
+    fReweightPtHatRapUserHook =
+        std::make_shared<PtHatRapReweightUserHook>(rgrParams.getParameter<std::string>("yLabSigmaFunc"),
+                                                   rgrParams.getParameter<double>("yLabPower"),
+                                                   rgrParams.getParameter<std::string>("yCMSigmaFunc"),
+                                                   rgrParams.getParameter<double>("yCMPower"),
+                                                   rgrParams.getParameter<double>("pTHatMin"),
+                                                   rgrParams.getParameter<double>("pTHatMax"));
     edm::LogInfo("Pythia8Interface") << "End setup for reweightGenPtHatRap";
   }
 
@@ -361,16 +362,16 @@ Pythia8Hadronizer::Pythia8Hadronizer(const edm::ParameterSet &params)
     if (params.exists("EV1_nFinalMode"))
       EV1_nFinalMode = params.getParameter<int>("EV1_nFinalMode");
     fEmissionVetoHook1 = std::make_shared<EmissionVetoHook1>(EV1_nFinal,
-                                                   EV1_vetoOn,
-                                                   EV1_maxVetoCount,
-                                                   EV1_pThardMode,
-                                                   EV1_pTempMode,
-                                                   EV1_emittedMode,
-                                                   EV1_pTdefMode,
-                                                   EV1_MPIvetoOn,
-                                                   EV1_QEDvetoMode,
-                                                   EV1_nFinalMode,
-                                                   0);
+                                                             EV1_vetoOn,
+                                                             EV1_maxVetoCount,
+                                                             EV1_pThardMode,
+                                                             EV1_pTempMode,
+                                                             EV1_emittedMode,
+                                                             EV1_pTdefMode,
+                                                             EV1_MPIvetoOn,
+                                                             EV1_QEDvetoMode,
+                                                             EV1_nFinalMode,
+                                                             0);
   }
 
   if (params.exists("UserCustomization")) {

--- a/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
@@ -41,6 +41,7 @@ using namespace Pythia8;
 
 //decay filter hook
 #include "GeneratorInterface/Pythia8Interface/interface/ResonanceDecayFilterHook.h"
+#include "GeneratorInterface/Pythia8Interface/interface/ResonanceDecayFilterCounter.h"
 
 //decay filter hook
 #include "GeneratorInterface/Pythia8Interface/interface/PTFilterHook.h"
@@ -531,6 +532,7 @@ bool Pythia8Hadronizer::initializeForInternalPartons() {
   }
 
   bool resonanceDecayFilter = fMasterGen->settings.flag("ResonanceDecayFilter:filter");
+  ResonanceDecayFilterCounter::getInstance().setFilterBool(resonanceDecayFilter);
   if (resonanceDecayFilter) {
     fResonanceDecayFilterHook = std::make_shared<ResonanceDecayFilterHook>();
     (fUserHooksVector->hooks).push_back(fResonanceDecayFilterHook);
@@ -698,6 +700,7 @@ bool Pythia8Hadronizer::initializeForExternalPartons() {
   }
 
   bool resonanceDecayFilter = fMasterGen->settings.flag("ResonanceDecayFilter:filter");
+  ResonanceDecayFilterCounter::getInstance().setFilterBool(resonanceDecayFilter);
   if (resonanceDecayFilter) {
     fResonanceDecayFilterHook = std::make_shared<ResonanceDecayFilterHook>();
     (fUserHooksVector->hooks).push_back(fResonanceDecayFilterHook);
@@ -969,6 +972,12 @@ bool Pythia8Hadronizer::hadronize() {
       double wgt = fMasterGen->info.weight(i);
       event()->weights().push_back(wgt);
     }
+  }
+
+  if (fMasterGen->settings.flag("ResonanceDecayFilter:filter")) {
+    int eventCounterValue = fResonanceDecayFilterHook->returnEventCounter();
+    ResonanceDecayFilterCounter::getInstance().setEventCounter(eventCounterValue);
+    fResonanceDecayFilterHook->resetEventCounter();
   }
 
   return true;

--- a/GeneratorInterface/Pythia8Interface/src/Py8HMC3InterfaceBase.cc
+++ b/GeneratorInterface/Pythia8Interface/src/Py8HMC3InterfaceBase.cc
@@ -88,6 +88,7 @@ namespace gen {
     //add settings for resonance decay filter
     fMasterGen->settings.addFlag("ResonanceDecayFilter:filter", false);
     fMasterGen->settings.addFlag("ResonanceDecayFilter:exclusive", false);
+    fMasterGen->settings.addFlag("ResonanceDecayFilter:matching", false);
     fMasterGen->settings.addFlag("ResonanceDecayFilter:eMuAsEquivalent", false);
     fMasterGen->settings.addFlag("ResonanceDecayFilter:eMuTauAsEquivalent", false);
     fMasterGen->settings.addFlag("ResonanceDecayFilter:allNuAsEquivalent", false);
@@ -96,6 +97,7 @@ namespace gen {
     fMasterGen->settings.addFlag("ResonanceDecayFilter:wzAsEquivalent", false);
     fMasterGen->settings.addMVec("ResonanceDecayFilter:mothers", std::vector<int>(), false, false, 0, 0);
     fMasterGen->settings.addMVec("ResonanceDecayFilter:daughters", std::vector<int>(), false, false, 0, 0);
+    fMasterGen->settings.addWVec("ResonanceDecayFilter:matchedDecays", std::vector<std::string>());
 
     //add settings for PT filter
     fMasterGen->settings.addFlag("PTFilter:filter", false);

--- a/GeneratorInterface/Pythia8Interface/src/Py8InterfaceBase.cc
+++ b/GeneratorInterface/Pythia8Interface/src/Py8InterfaceBase.cc
@@ -93,6 +93,7 @@ namespace gen {
     //add settings for resonance decay filter
     fMasterGen->settings.addFlag("ResonanceDecayFilter:filter", false);
     fMasterGen->settings.addFlag("ResonanceDecayFilter:exclusive", false);
+    fMasterGen->settings.addFlag("ResonanceDecayFilter:matching", false);
     fMasterGen->settings.addFlag("ResonanceDecayFilter:eMuAsEquivalent", false);
     fMasterGen->settings.addFlag("ResonanceDecayFilter:eMuTauAsEquivalent", false);
     fMasterGen->settings.addFlag("ResonanceDecayFilter:allNuAsEquivalent", false);
@@ -101,6 +102,7 @@ namespace gen {
     fMasterGen->settings.addFlag("ResonanceDecayFilter:wzAsEquivalent", false);
     fMasterGen->settings.addMVec("ResonanceDecayFilter:mothers", std::vector<int>(), false, false, 0, 0);
     fMasterGen->settings.addMVec("ResonanceDecayFilter:daughters", std::vector<int>(), false, false, 0, 0);
+    fMasterGen->settings.addWVec("ResonanceDecayFilter:matchedDecays", std::vector<std::string>());
 
     //add settings for PT filter
     fMasterGen->settings.addFlag("PTFilter:filter", false);

--- a/GeneratorInterface/Pythia8Interface/src/ResonanceDecayFilterHook.cc
+++ b/GeneratorInterface/Pythia8Interface/src/ResonanceDecayFilterHook.cc
@@ -4,9 +4,28 @@
 using namespace Pythia8;
 
 //--------------------------------------------------------------------------
+int ResonanceDecayFilterHook::idCat(int id) {
+  id = abs(id);
+  if (id == 13 && (eMuAsEquivalent_ || eMuTauAsEquivalent_))
+    id = 11;
+  else if (id == 15 && eMuTauAsEquivalent_)
+    id = 11;
+  else if ((id == 14 || id == 16) && allNuAsEquivalent_)
+    id = 12;
+  else if ((id == 2 || id == 3 || id == 4) && udscAsEquivalent_)
+    id = 1;
+  else if ((id == 2 || id == 3 || id == 4 || id == 5) && udscbAsEquivalent_)
+    id = 1;
+  else if ((id == 23 || id == 24) && wzAsEquivalent_)
+    id = 23;
+  return id;
+}
+
 bool ResonanceDecayFilterHook::initAfterBeams() {
+  counter_event_ = 0;
   filter_ = settingsPtr->flag("ResonanceDecayFilter:filter");
   exclusive_ = settingsPtr->flag("ResonanceDecayFilter:exclusive");
+  matching_ = settingsPtr->flag("ResonanceDecayFilter:matching");
   eMuAsEquivalent_ = settingsPtr->flag("ResonanceDecayFilter:eMuAsEquivalent");
   eMuTauAsEquivalent_ = settingsPtr->flag("ResonanceDecayFilter:eMuTauAsEquivalent");
   allNuAsEquivalent_ = settingsPtr->flag("ResonanceDecayFilter:allNuAsEquivalent");
@@ -17,31 +36,44 @@ bool ResonanceDecayFilterHook::initAfterBeams() {
   mothers_.clear();
   mothers_.insert(mothers.begin(), mothers.end());
   daughters_ = settingsPtr->mvec("ResonanceDecayFilter:daughters");
+  matchedDecays_ = settingsPtr->wvec("ResonanceDecayFilter:matchedDecays");
 
   requestedDaughters_.clear();
 
   for (int id : daughters_) {
-    int did = std::abs(id);
-    if (did == 13 && (eMuAsEquivalent_ || eMuTauAsEquivalent_)) {
-      did = 11;
-    }
-    if (did == 15 && eMuTauAsEquivalent_) {
-      did = 11;
-    }
-    if ((did == 14 || did == 16) && allNuAsEquivalent_) {
-      did = 12;
-    }
-    if ((did == 2 || did == 3 || did == 4) && udscAsEquivalent_) {
-      did = 1;
-    }
-    if ((did == 2 || did == 3 || did == 4 || did == 5) && udscbAsEquivalent_) {
-      did = 1;
-    }
-    if ((did == 23 || did == 24) && wzAsEquivalent_) {
-      did = 23;
+    int did = ResonanceDecayFilterHook::idCat(id);
+    ++requestedDaughters_[std::abs(did)];
+  }
+
+  requestedDecays_.clear();
+
+  if (matching_) {
+    if (matchedDecays_.empty()) {
+      std::cerr << "You must indicate a non-empty matched decays list for matching mode." << std::endl;
     }
 
-    ++requestedDaughters_[std::abs(did)];
+    for (const std::string &decayStr : matchedDecays_) {
+      size_t colonPos = decayStr.find(':');
+      if (colonPos == std::string::npos) {
+        std::cerr << "Malformed decay string (no colon): " << decayStr << std::endl;
+        continue;
+      }
+      std::string motherStr = decayStr.substr(0, colonPos);
+      std::string daughtersStr = decayStr.substr(colonPos + 1);
+
+      int motherID = std::abs(std::stoi(motherStr));
+
+      std::istringstream iss(daughtersStr);
+      std::string token;
+      while (iss >> token) {
+        try {
+          int daughterID = ResonanceDecayFilterHook::idCat(std::stoi(token));
+          requestedDecays_.insert({motherID, daughterID});
+        } catch (const std::invalid_argument &e) {
+          std::cerr << "Invalid daughter ID in decay string: " << decayStr << std::endl;
+        }
+      }
+    }
   }
 
   return true;
@@ -52,39 +84,37 @@ bool ResonanceDecayFilterHook::checkVetoResonanceDecays(const Event &process) {
   if (!filter_)
     return false;
 
+  //count the number of times hook is called.
+  counter_event_++;
+
   observedDaughters_.clear();
+
+  remainingDecays_.clear();
+  if (matching_) {
+    remainingDecays_ = requestedDecays_;
+  }
 
   //count decay products
   for (int i = 0; i < process.size(); ++i) {
     const Particle &p = process[i];
 
-    int did = std::abs(p.id());
-
-    if (did == 13 && (eMuAsEquivalent_ || eMuTauAsEquivalent_)) {
-      did = 11;
-    }
-    if (did == 15 && eMuTauAsEquivalent_) {
-      did = 11;
-    }
-    if ((did == 14 || did == 16) && allNuAsEquivalent_) {
-      did = 12;
-    }
-    if ((did == 2 || did == 3 || did == 4) && udscAsEquivalent_) {
-      did = 1;
-    }
-    if ((did == 2 || did == 3 || did == 4 || did == 5) && udscbAsEquivalent_) {
-      did = 1;
-    }
-    if ((did == 23 || did == 24) && wzAsEquivalent_) {
-      did = 23;
-    }
+    int did = ResonanceDecayFilterHook::idCat(p.id());
 
     int mid = p.mother1() > 0 ? std::abs(process[p.mother1()].id()) : 0;
 
     //if no list of mothers is provided, then all particles
     //in hard process and resonance decays are counted together
-    if (mothers_.empty() || mothers_.count(mid) || mothers_.count(-mid))
+    if (mothers_.empty() || mothers_.count(mid) || mothers_.count(-mid)) {
       ++observedDaughters_[did];
+    }
+
+    if (matching_) {
+      std::pair<int, int> decayPair = {mid, did};
+      auto found = remainingDecays_.find(decayPair);
+      if (found != remainingDecays_.end()) {
+        remainingDecays_.erase(found);
+      }
+    }
   }
 
   //check if criteria is satisfied
@@ -114,6 +144,12 @@ bool ResonanceDecayFilterHook::checkVetoResonanceDecays(const Event &process) {
       return true;
   }
 
+  if (matching_ && !remainingDecays_.empty()) {
+    return true;
+  }
+
   //all criteria satisfied, don't veto
   return false;
 }
+
+void ResonanceDecayFilterHook::resetEventCounter() { counter_event_ = 0; }


### PR DESCRIPTION
#### PR description:

This pull request proposes a solution to the issue outlined in https://gitlab.cern.ch/cms-gen/gen_tasklist/-/issues/9. The ResonanceDecayFilter was not correctly accounting for the total number of tried events, leading to an incorrect cross section calculation (as the branching ratio was omitted). To address this, I introduced a counter in ResonanceDecayFilterHook.h to track the number of events vetoed by the filter, along with a function to reset the counter after each event. This data is then passed from Pythia8Hadronizer.cc to GenFilterEfficiencyProducer.cc using an object of the class ResonanceDecayFilterCounter I created.

The counter is applied only to the weight counts and not to the event counts, as requested by PDMV, to ensure the event-level GenFilter efficiency excludes the ResonanceDecayFilter information. This exclusion allows PDMV to accurately determine the number of LHE events required to generate a specific number of Gen events.

Additionally, I introduced the input_genfilter_efficiency variable in GenXsecAnalyzer.cc to ensure that when the ResonanceDecayFilter is enabled, the filter efficiency is always calculated using weight counts (where the filter information is stored) instead of event counts. Also added a way to override the HEPIDWTUP value to make sure that in LO processes the modified weights are used. This adjustments ensure consistent efficiency calculations for both LO and NLO processes and includes the filter’s contribution.

Furthermore, now it is possible to use matching between mother and daughter particles like:
'ResonanceDecayFilter:matching = on'
To indicate the matched decays, it is possible to use just one vector
'ResonanceDecayFilter:matchedDecays = {m1: dau11 dau12, m2: dau21 dau22,…, mN: dauN1 … dauNM}'
or “split” into small vectors
'ResonanceDecayFilter:matchedDecays = {m1: dau11 dau12}',
'ResonanceDecayFilter:matchedDecays += {m2: dau21 dau22}',
'ResonanceDecayFilter:matchedDecays += {mN: dauN1 … dauNM}' # N-body decays are allowed

Expected changes to the output are as follows:
1. In the GenFilter luminosity block of the final root file, the sumtotal_w and sumtotal_w2 values now incorporate the ResonanceDecayFilter information, reflecting the true total number of tried events.
2. In GenXsecAnalyzer.cc, the "Filter efficiency (taking into account weights)" now includes this filter’s contribution, which accounts for the branching ratio. Consequently, the final cross section and equivalent luminosity are calculated correctly, incorporating the branching ratio.
3. In Pythia8Hadronizer.cc, added a couple of warning messages. The first one informs that the HEPIDWTUP value has been changed. The second warns that if particle properties were modified (e.g. 'onIfMatch') and the filter was used, one has to be careful because the filter efficiency and the branching ratio may not be the same thing.

#### PR validation:

To verify the correctness of the cross section calculation, I used the LO Radion_GF_HH_M300_narrow gridpack (as referenced in https://gitlab.cern.ch/cms-gen/gen_tasklist/-/issues/9) and a simple NLO ttbar custom gridpack that I generated for testing. In both cases, the resulting cross section was calculated correctly.

I also performed the checks outlined in https://cms-sw.github.io/PRWorkflow.html. I executed the runTheMatrix suite of tests. The mistakes obtained by the tests were "No such file or directory" caused by missing root files. . To investigate further, I ran the same runTheMatrix tests using an unmodified version of CMSSW and observed identical errors. This strongly indicates that the issues are unrelated to my modifications.

This PR replaces the PR #46725 (Fix cross section when using ResonanceDecayFilter) because there were some issues related to code-checks (the patches given by the bot were impossible to implement).

