### PR TITLE
Updated to use __getitem__

### DIFF
--- a/DQMServices/Demo/test/dqmiodumpentries.py
+++ b/DQMServices/Demo/test/dqmiodumpentries.py
@@ -30,7 +30,7 @@ treenames = {
 }
 
 f = ROOT.TFile.Open(args.inputfile)
-idxtree = getattr(f, "Indices")
+idxtree = f["Indices"]
 
 summary = defaultdict(lambda: 0)
 
@@ -42,7 +42,7 @@ for i in range(idxtree.GetEntries()):
 
     # inclusive range -- for 0 entries, row is left out
     firstidx, lastidx = idxtree.FirstIndex, idxtree.LastIndex
-    metree = getattr(f, treenames[metype])
+    metree = f[treenames[metype]]
     # this GetEntry is only to make sure the TTree is initialized correctly
     metree.GetEntry(0)
     metree.SetBranchStatus("*",0)

--- a/DQMServices/FwkIO/test/check_guid_file1.py
+++ b/DQMServices/FwkIO/test/check_guid_file1.py
@@ -8,7 +8,8 @@ fname_report = "dqm_file1_jobreport.xml"
 kCmsGuid = "cms::edm::GUID"
 
 f = ROOT.TFile.Open(fname_root)
-guid_file = getattr(f, kCmsGuid)
+guid_file = f[kCmsGuid]
+
 f.Close()
 
 guid_report = None


### PR DESCRIPTION
This PR replaces the legacy Pythonization of TDirectory via __getattr__, which allowed object access like my_file.my_tree. As of ROOT 6.32, this behavior has been deprecated in favor of explicit item-getting using __getitem__, e.g., my_file["my_tree"].
https://github.com/root-project/root/pull/19096