### PR TITLE
Add L1Ntuple customisation for HLTScouting

### DIFF
--- a/L1Trigger/L1TNtuples/python/customiseL1Ntuple.py
+++ b/L1Trigger/L1TNtuples/python/customiseL1Ntuple.py
@@ -99,6 +99,27 @@ def L1NtupleNanoDST(process):
 
     return process
 
+def L1NtupleHLTSCOUT(process):
+    ''' for reading from ScoutingPFRun3 - HLTSCOUT datatier '''
+
+    L1NtupleTFileOut(process)
+
+    from EventFilter.L1TRawToDigi.gtStage2Digis_cfi import gtStage2Digis
+    process.gtStage2Digis = gtStage2Digis.clone(InputLabel="hltFEDSelectorL1")
+
+    process.load('L1Trigger.L1TNtuples.L1NtupleNanoDST_cff')
+
+    # start the sequence by unpacking the gtStage2Digis
+    process.L1NtupleNANO.insert(0, process.gtStage2Digis)
+
+    process.l1ntuplenano = cms.Path(
+        process.L1NtupleNANO
+    )
+
+    process.schedule.append(process.l1ntuplenano)
+
+    return process
+
 def L1NtupleMINI(process):
 
     L1NtupleTFileOut(process)


### PR DESCRIPTION
#### PR description:
This adds a customisation for the L1Ntuples to run on HLTSCOUT data which just stores the L1 uGT collection in it's RAW format `hltFEDSelectorL1`. I'm reusing the `L1NtupleNanoDST` setup but adding the unpacking of the `gtStage2Digis` into the sequence, hence I had to introduce a new customiser: `L1NtupleHLTSCOUT`.

#### PR validation:

Tested in `CMSSW_15_1_0_pre3` with:
```bash
cmsDriver.py l1NtupleFromHLTScout -s NONE -n 1000 --no_output \
--era=Run3 --data --conditions=150X_dataRun3_HLT_v1  \
--customise=L1Trigger/L1TNtuples/customiseL1Ntuple.L1NtupleHLTSCOUT \
--filein file:/eos/cms/tier0/store/data/Run2025C/ScoutingPFRun3/HLTSCOUT/v1/000/393/515/00000/0037f433-1c58-4071-91f0-f2ae428ba870.root 
```

Which successfully produces a `L1Ntuple.root` file with the trees being properly filled for the unpacked L1 objects and uGT decisions.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not planned, except if considered useful by the L1 DPG et al.