### PR TITLE
Fixed G4LorentzVector usage, momentum updating, and energy deposit model in FullModelHadronicProcess.cc

### DIFF
--- a/SimG4Core/CustomPhysics/interface/FullModelHadronicProcess.h
+++ b/SimG4Core/CustomPhysics/interface/FullModelHadronicProcess.h
@@ -54,12 +54,9 @@ private:
 
   void Rotate(G4FastVector<G4ReactionProduct, MYGHADLISTSIZE> &vec, G4int &vecLen);
 
-  const G4DynamicParticle *FindRhadron(G4ParticleChange *);
-
   G4ProcessHelper *theHelper;
   G4bool toyModel;
-  G4double cache;
-  G4ThreeVector what;
+  G4ThreeVector incomingCloud3Momentum;
 };
 
 #endif

--- a/SimG4Core/CustomPhysics/src/FullModelHadronicProcess.cc
+++ b/SimG4Core/CustomPhysics/src/FullModelHadronicProcess.cc
@@ -24,7 +24,6 @@ G4double FullModelHadronicProcess::GetMicroscopicCrossSection(const G4DynamicPar
                                                               G4double aTemp) {
   //Get the cross section for this particle/element combination from the ProcessHelper
   G4double InclXsec = theHelper->GetInclusiveCrossSection(aParticle, anElement);
-  //  G4cout<<"Returned cross section from helper was: "<<InclXsec/millibarn<<" millibarn"<<G4endl;
   return InclXsec;
 }
 
@@ -50,544 +49,283 @@ G4double FullModelHadronicProcess::GetMeanFreePath(const G4Track& aTrack, G4doub
 }
 
 G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack, const G4Step& aStep) {
-  //  G4cout<<"**** Entering FullModelHadronicProcess::PostStepDoIt       ******"<<G4endl;
   const G4TouchableHandle& thisTouchable(aTrack.GetTouchableHandle());
 
-  // A little setting up
+  // Initialize parameters
   aParticleChange.Initialize(aTrack);
-  const G4DynamicParticle* IncidentRhadron = aTrack.GetDynamicParticle();
-  CustomParticle* CustomIncident = static_cast<CustomParticle*>(IncidentRhadron->GetDefinition());
-  const G4ThreeVector& aPosition = aTrack.GetPosition();
-  //  G4cout<<"G: "<<aStep.GetStepLength()/cm<<G4endl;
-  const G4int theIncidentPDG = IncidentRhadron->GetDefinition()->GetPDGEncoding();
+  const G4DynamicParticle* incomingRhadron = aTrack.GetDynamicParticle();
+  CustomParticle* customIncomingRhadron = static_cast<CustomParticle*>(incomingRhadron->GetDefinition()); // This is used to get the cloud particle
+  const G4ThreeVector& aPosition = aTrack.GetPosition(); // Position of the track
+  const G4int incomingRhadronPDG = incomingRhadron->GetDefinition()->GetPDGEncoding();
   G4ParticleTable* theParticleTable = G4ParticleTable::GetParticleTable();
-  std::vector<G4ParticleDefinition*> theParticleDefinitions;
-  G4bool IncidentSurvives = false;
+  G4bool incomingRhadronSurvives = false;
   G4bool TargetSurvives = false;
   G4Nucleus targetNucleus(aTrack.GetMaterial());
-  G4ParticleDefinition* outgoingRhadron = nullptr;
-  G4ParticleDefinition* outgoingCloud = nullptr;
-  G4ParticleDefinition* outgoingTarget = nullptr;
 
-  G4ThreeVector p_0 = IncidentRhadron->GetMomentum();
-  G4double e_kin_0 = IncidentRhadron->GetKineticEnergy();
-  //  G4cout<<e_kin_0/GeV<<G4endl;
+  G4ParticleDefinition* outgoingRhadronDefinition = nullptr;
+  G4ParticleDefinition* outgoingCloudDefinition = nullptr;
+  G4ParticleDefinition* outgoingTargetDefinition = nullptr;
 
+  // Declare the quark cloud as a G4DynamicParticle. Throw an error if the cloud definition is not available
   G4DynamicParticle* cloudParticle = new G4DynamicParticle();
-  /*
-  if(CustomPDGParser::s_isRMeson(theIncidentPDG))
-    G4cout<<"Rmeson"<<G4endl;
-  if(CustomPDGParser::s_isRBaryon(theIncidentPDG)) 
-    G4cout<<"Rbaryon"<<G4endl;
-  */
-  cloudParticle->SetDefinition(CustomIncident->GetCloud());
-
+  cloudParticle->SetDefinition(customIncomingRhadron->GetCloud());
   if (cloudParticle->GetDefinition() == nullptr) {
-    G4cout << "FullModelHadronicProcess::PostStepDoIt  Definition of particle cloud not available!!" << G4endl;
+    G4cerr << "FullModelHadronicProcess::PostStepDoIt  Definition of particle cloud not available!" << G4endl;
+    exit(EXIT_FAILURE);
   }
-  /*
-  G4cout<<"Incoming particle was "<<IncidentRhadron->GetDefinition()->GetParticleName()
-  <<". Corresponding cloud is "<<cloudParticle->GetDefinition()->GetParticleName()<<G4endl;
-  G4cout<<"Kinetic energy was: "<<IncidentRhadron->GetKineticEnergy()/GeV<<" GeV"<<G4endl;
-  */
-  double scale = cloudParticle->GetDefinition()->GetPDGMass() / IncidentRhadron->GetDefinition()->GetPDGMass();
-  //  G4cout<<"Mass ratio: "<<scale<<G4endl;
-  G4LorentzVector cloudMomentum(IncidentRhadron->GetMomentum() * scale, cloudParticle->GetDefinition()->GetPDGMass());
-  G4LorentzVector gluinoMomentum(IncidentRhadron->GetMomentum() * (1. - scale),
-                                 CustomIncident->GetSpectator()->GetPDGMass());
 
-  //These two for getting CMS transforms later (histogramming purposes...)
-  G4LorentzVector FullRhadron4Momentum = IncidentRhadron->Get4Momentum();
-  const G4LorentzVector& Cloud4Momentum = cloudMomentum;
-
+  // Define the gluino and quark cloud G4LorentzVector (momentum, total energy) based on the momentum of the R-hadron and the ratio of the masses
+  double scale = cloudParticle->GetDefinition()->GetPDGMass() / incomingRhadron->GetDefinition()->GetPDGMass();
+  G4LorentzVector cloudMomentum(incomingRhadron->GetMomentum() * scale, std::sqrt(incomingRhadron->GetMomentum().mag() * scale * incomingRhadron->GetMomentum().mag() * scale + cloudParticle->GetDefinition()->GetPDGMass() * cloudParticle->GetDefinition()->GetPDGMass()));
   cloudParticle->Set4Momentum(cloudMomentum);
+  G4LorentzVector gluinoMomentum(incomingRhadron->GetMomentum() * (1. - scale), incomingRhadron->GetTotalEnergy() - cloudParticle->GetTotalEnergy());
 
-  G4DynamicParticle* OrgPart = cloudParticle;
+  // Update the cloud kinetic energy based on the target nucleus and evaporative effects
+  G4double cloudKineticEnergy = cloudParticle->GetKineticEnergy(); 
+  G4double initialCloudEnergy = cloudParticle->GetTotalEnergy();
+  cloudKineticEnergy += targetNucleus.Cinema(cloudKineticEnergy);
+  cloudKineticEnergy -= targetNucleus.EvaporationEffects(cloudKineticEnergy);
 
-  /*
-  G4cout<<"Original momentum: "<<IncidentRhadron->Get4Momentum().v().mag()/GeV
-  <<" GeV, corresponding to gamma: "
-  <<IncidentRhadron->GetTotalEnergy()/IncidentRhadron->GetDefinition()->GetPDGMass()<<G4endl;
-  
-  G4cout<<"Cloud momentum: "<<cloudParticle->Get4Momentum().v().mag()/GeV
-  <<" GeV, corresponding to gamma: "
-  <<cloudParticle->GetTotalEnergy()/cloudParticle->GetDefinition()->GetPDGMass()<<G4endl;
-  */
+  G4ThreeVector cloud3MomentumDirection = cloudParticle->GetMomentum().unit();
+  G4double cloud3MomentumMagnitudeAfterEvaporativeEffects = std::sqrt(cloudKineticEnergy * (cloudKineticEnergy + 2. * cloudParticle->GetDefinition()->GetPDGMass()));
 
-  double E_0 = IncidentRhadron->GetKineticEnergy();
-  G4double ek = OrgPart->GetKineticEnergy();
-  G4double amas = OrgPart->GetDefinition()->GetPDGMass();
-  G4ThreeVector dir = (OrgPart->GetMomentum()).unit();
-  G4double tkin = targetNucleus.Cinema(ek);
-  ek += tkin;
-
-  // calculate black track energies
-  tkin = targetNucleus.EvaporationEffects(ek);
-  ek -= tkin;
-
-  if (ek + gluinoMomentum.e() - gluinoMomentum.m() <= 0.1 * MeV || ek <= 0.) {
-    //Very rare event...
-    G4cout << "Kinetic energy is sick" << G4endl;
-    G4cout << "Full R-hadron: " << (ek + gluinoMomentum.e() - gluinoMomentum.m()) / MeV << " MeV" << G4endl;
-    G4cout << "Quark system: " << ek / MeV << " MeV" << G4endl;
-    aParticleChange.ProposeTrackStatus(fStopButAlive);  // AR_NEWCODE_IMPORT
+  // If the R-hadron kinetic energy is less than 0.1 MeV, or the cloud kinetic energy is less than or equal to 0, stop the track but keep it alive. This should be very rare.
+  if (cloudKineticEnergy + gluinoMomentum.e() - gluinoMomentum.m() <= 0.1 * MeV || cloudKineticEnergy <= 0.) {
+    aParticleChange.ProposeTrackStatus(fStopButAlive);
     return &aParticleChange;
   }
-  OrgPart->SetKineticEnergy(ek);
-  G4double p = std::sqrt(ek * (ek + 2 * amas));
-  OrgPart->SetMomentum(dir * p);
 
-  //Get the final state particles
+  cloudParticle->SetKineticEnergy(cloudKineticEnergy);
+  cloudParticle->SetMomentum(cloud3MomentumMagnitudeAfterEvaporativeEffects * cloud3MomentumDirection);
+
+  //Get the final state particles. reactionProduct is a vector of integer PDGIDs. Not to be confused with G4ReactionProduct
   G4ParticleDefinition* aTarget;
-  ReactionProduct rp = theHelper->GetFinalState(aTrack, aTarget);
-  G4bool force2to2 = false;
-  //  G4cout<<"Trying to get final state..."<<G4endl;
-  while (rp.size() != 2 && force2to2) {
-    rp = theHelper->GetFinalState(aTrack, aTarget);
-  }
-  G4int NumberOfSecondaries = rp.size();
-  //  G4cout<<"Multiplicity of selected final state: "<<rp.size()<<G4endl;
+  ReactionProduct reactionProduct = theHelper->GetFinalState(aTrack, aTarget);
+  G4int reactionProductSize = reactionProduct.size();
 
-  //Getting CMS transforms. Boosting is done at histogram filling
-  G4LorentzVector Target4Momentum(0., 0., 0., aTarget->GetPDGMass());
+  //Process outgoing particles from reactions
+  std::vector<G4ParticleDefinition*> outgoingParticleDefinitions;
+  for (ReactionProduct::iterator it = reactionProduct.begin(); it != reactionProduct.end(); ++it) {
+    G4ParticleDefinition* finalStateParticle = theParticleTable->FindParticle(*it);
+    CustomParticle* finalStateCustomParticle = dynamic_cast<CustomParticle*>(finalStateParticle);
 
-  G4LorentzVector psum_full = FullRhadron4Momentum + Target4Momentum;
-  G4LorentzVector psum_cloud = Cloud4Momentum + Target4Momentum;
-  G4ThreeVector trafo_full_cms = (-1) * psum_full.boostVector();
-  G4ThreeVector trafo_cloud_cms = (-1) * psum_cloud.boostVector();
-
-  // OK Let's make some particles :-)
-  // We're not using them for anything yet, I know, but let's make sure the machinery is there
-  for (ReactionProduct::iterator it = rp.begin(); it != rp.end(); ++it) {
-    G4ParticleDefinition* tempDef = theParticleTable->FindParticle(*it);
-    CustomParticle* tempCust = dynamic_cast<CustomParticle*>(tempDef);
-    if (tempDef == aTarget)
+    if (finalStateParticle == aTarget) {
       TargetSurvives = true;
+    }
 
-    //      if (tempDef->GetParticleType()=="rhadron")
-    if (tempCust != nullptr) {
-      outgoingRhadron = tempDef;
-      //Setting outgoing cloud definition
-      outgoingCloud = tempCust->GetCloud();
-      if (outgoingCloud == nullptr) {
-        G4cout << "FullModelHadronicProcess::PostStepDoIt  Definition of outgoing particle cloud not available!"
-               << G4endl;
+    if (finalStateParticle->GetParticleType()=="rhadron") {
+      outgoingRhadronDefinition = finalStateParticle;
+      outgoingCloudDefinition = finalStateCustomParticle->GetCloud();
+      if (outgoingCloudDefinition == nullptr) {
+        G4cerr << "FullModelHadronicProcess::PostStepDoIt  Definition of outgoing particle cloud not available!" << G4endl;
+        exit(EXIT_FAILURE);
       }
-      /*
-	G4cout<<"Outgoing Rhadron is: "<<outgoingRhadron->GetParticleName()<<G4endl;
-	G4cout<<"Outgoing cloud is: "<<outgoingCloud->GetParticleName()<<G4endl;
-      */
     }
 
-    if (tempDef == G4Proton::Proton() || tempDef == G4Neutron::Neutron())
-      outgoingTarget = tempDef;
-    if (tempCust == nullptr && rp.size() == 2)
-      outgoingTarget = tempDef;
-    if (tempDef->GetPDGEncoding() == theIncidentPDG) {
-      IncidentSurvives = true;
+    if (finalStateParticle == G4Proton::Proton() || finalStateParticle == G4Neutron::Neutron()) outgoingTargetDefinition = finalStateParticle;
+    if (finalStateCustomParticle == nullptr && reactionProduct.size() == 2) outgoingTargetDefinition = finalStateParticle;
+    if (finalStateParticle->GetPDGEncoding() == incomingRhadronPDG) {
+      incomingRhadronSurvives = true;
     } else {
-      theParticleDefinitions.push_back(tempDef);
+      outgoingParticleDefinitions.push_back(finalStateParticle);
     }
   }
 
-  if (outgoingTarget == nullptr)
-    outgoingTarget = theParticleTable->FindParticle(rp[1]);
+  //If no reaction occured, set the outgoingTargetDefinition to the original target definition
+  if (outgoingTargetDefinition == nullptr)
+    outgoingTargetDefinition = theParticleTable->FindParticle(reactionProduct[1]);
 
-  // A little debug information
-  /*
-  G4cout<<"The particles coming out of this reaction will be: ";
-  for (std::vector<G4DynamicParticle*>::iterator it = theDynamicParticles.begin();
-       it != theDynamicParticles.end();
-       it++){
-    G4cout<< (*it)->GetDefinition()->GetParticleName()<<" ";
+  //If the incident particle survives, decrement the number of secondaries
+  if (incomingRhadronSurvives)
+    reactionProductSize--;
+  aParticleChange.SetNumberOfSecondaries(reactionProductSize);
+
+  //Create G4DynamicParticle and G4ReactionProduct objects for the outgoing target particle
+  G4DynamicParticle* outgoingTargetG4Dynamic = new G4DynamicParticle;
+  G4ReactionProduct outgoingTargetG4Reaction;
+  if (TargetSurvives) {
+    outgoingTargetG4Dynamic->SetDefinition(aTarget);
+    outgoingTargetG4Reaction = G4ReactionProduct(aTarget);
   }
-  G4cout<<G4endl;
-  */
-  // If the incident particle survives it is not a "secondary", although
-  // it would probably be easier to fStopAndKill the track every time.
-  if (IncidentSurvives)
-    NumberOfSecondaries--;
-  aParticleChange.SetNumberOfSecondaries(NumberOfSecondaries);
+  else {
+    outgoingTargetG4Dynamic->SetDefinition(outgoingTargetDefinition);
+    outgoingTargetG4Reaction = G4ReactionProduct(outgoingTargetDefinition);
+  }
 
-  // ADAPTED FROM G4LEPionMinusInelastic::ApplyYourself
-  // It is bloody ugly, but such is the way of cut 'n' paste
+  //Calculate the Lorentz boost of the cloud particle to the lab frame
+  G4HadProjectile* incomingCloudG4HadProjectile = new G4HadProjectile(*cloudParticle);
+  G4LorentzRotation cloudParticleToLabFrameRotation = incomingCloudG4HadProjectile->GetTrafoToLab();
 
-  // Set up the incident
-  // This is where rotation to z-axis is done
-  const G4HadProjectile* originalIncident = new G4HadProjectile(*OrgPart);
+  //Create a G4ReactionProduct object for the outgoing cloud
+  G4ReactionProduct outgoingCloudG4Reaction(const_cast<G4ParticleDefinition*>(incomingCloudG4HadProjectile->GetDefinition()));
+  outgoingCloudG4Reaction.SetMomentum(incomingCloudG4HadProjectile->Get4Momentum().vect());
+  outgoingCloudG4Reaction.SetTotalEnergy(incomingCloudG4HadProjectile->GetTotalEnergy());
+  if (!incomingRhadronSurvives) {
+    outgoingCloudG4Reaction.SetDefinitionAndUpdateE(outgoingCloudDefinition);
+  }
 
-  //Maybe I need to calculate trafo from R-hadron... Bollocks! Labframe does not move. CMS does.
-  G4HadProjectile* org2 = new G4HadProjectile(*OrgPart);
-  G4LorentzRotation trans = org2->GetTrafoToLab();
-  delete org2;
+  G4ReactionProduct modifiedoutgoingCloudG4Reaction = outgoingCloudG4Reaction;
 
-  // create the target particle
-
-  G4DynamicParticle* originalTarget = new G4DynamicParticle;
-  originalTarget->SetDefinition(aTarget);
-
-  G4ReactionProduct targetParticle(aTarget);
-
-  G4ReactionProduct currentParticle(const_cast<G4ParticleDefinition*>(originalIncident->GetDefinition()));
-  currentParticle.SetMomentum(originalIncident->Get4Momentum().vect());
-  currentParticle.SetKineticEnergy(originalIncident->GetKineticEnergy());
-
-  /*
-  G4cout<<"After creation:"<<G4endl;
-  G4cout<<"currentParticle: "<<currentParticle.GetMomentum()/GeV<<" GeV vs. "<<OrgPart->Get4Momentum()/GeV<<" GeV"<<G4endl;
-  G4cout<<"targetParticle: "<<targetParticle.GetMomentum()/GeV<<" GeV"<<G4endl;
-  G4cout<<"Fourmomentum from originalIncident: "<<originalIncident->Get4Momentum()<<" vs "<<OrgPart->Get4Momentum()<<G4endl;
-  */
-
-  G4ReactionProduct modifiedOriginal = currentParticle;
-
-  currentParticle.SetSide(1);  // incident always goes in forward hemisphere
-  targetParticle.SetSide(-1);  // target always goes in backward hemisphere
-  G4bool incidentHasChanged = false;
-  if (!IncidentSurvives)
-    incidentHasChanged = true;  //I wonder if I am supposed to do this...
-  G4bool targetHasChanged = false;
-  if (!TargetSurvives)
-    targetHasChanged = true;  //Ditto here
+  //Set the hemisphere of the current and target particles. Initialize an empty vector for the secondary particles
+  outgoingCloudG4Reaction.SetSide(1);  // incident always goes in forward hemisphere
+  outgoingTargetG4Reaction.SetSide(-1);  // target always goes in backward hemisphere
   G4bool quasiElastic = false;
-  if (rp.size() == 2)
-    quasiElastic = true;                                //Oh well...
-  G4FastVector<G4ReactionProduct, MYGHADLISTSIZE> vec;  // vec will contain the secondary particles
-  G4int vecLen = 0;
-  vec.Initialize(0);
+  if (reactionProduct.size() == 2)
+    quasiElastic = true;
+  G4FastVector<G4ReactionProduct, MYGHADLISTSIZE> secondaryParticleVector;
+  G4int secondaryParticleVectorLen = 0;
+  secondaryParticleVector.Initialize(0);
 
-  // I hope my understanding of "secondary" is correct here
-  // I think that it entails only what is not a surviving incident of target
-
-  for (G4int i = 0; i != NumberOfSecondaries; i++) {
-    if (theParticleDefinitions[i] != aTarget && theParticleDefinitions[i] != originalIncident->GetDefinition() &&
-        theParticleDefinitions[i] != outgoingRhadron && theParticleDefinitions[i] != outgoingTarget) {
-      G4ReactionProduct* pa = new G4ReactionProduct;
-      pa->SetDefinition(theParticleDefinitions[i]);
-      (G4UniformRand() < 0.5) ? pa->SetSide(-1) : pa->SetSide(1);
-      vec.SetElement(vecLen++, pa);
+  //Fill the vector with the secondary particles
+  for (G4int i = 0; i != reactionProductSize; i++) {
+    if (outgoingParticleDefinitions[i] != aTarget && outgoingParticleDefinitions[i] != incomingCloudG4HadProjectile->GetDefinition() &&
+        outgoingParticleDefinitions[i] != outgoingRhadronDefinition && outgoingParticleDefinitions[i] != outgoingTargetDefinition) {
+      G4ReactionProduct* secondaryReactionProduct = new G4ReactionProduct;
+      secondaryReactionProduct->SetDefinition(outgoingParticleDefinitions[i]);
+      (G4UniformRand() < 0.5) ? secondaryReactionProduct->SetSide(-1) : secondaryReactionProduct->SetSide(1); //Here we randomly determine the hemisphere of the secondary particle
+      secondaryParticleVector.SetElement(secondaryParticleVectorLen++, secondaryReactionProduct);
     }
   }
 
-  if (incidentHasChanged)
-    currentParticle.SetDefinitionAndUpdateE(outgoingCloud);
-  if (incidentHasChanged)
-    modifiedOriginal.SetDefinition(
-        outgoingCloud);  //Is this correct? It solves the "free energy" checking in ReactionDynamics
-  if (targetHasChanged)
-    targetParticle.SetDefinitionAndUpdateE(outgoingTarget);
+  //Store the outgoing Cloud 4-momentum for energy deposit calculation that occurs after change in momemta has been calculated
+  G4LorentzVector outgoingCloudp4(outgoingCloudG4Reaction.GetMomentum(), outgoingCloudG4Reaction.GetTotalEnergy());
+  outgoingCloudp4 *= cloudParticleToLabFrameRotation;
 
-  //  G4cout<<"Calling CalculateMomenta... "<<G4endl;
-  /*
-  G4cout<<"Current particle starts as: "<<currentParticle.GetDefinition()->GetParticleName()<<G4endl;
-  G4cout<<"with momentum: "<<currentParticle.GetMomentum()/GeV<<" GeV"<<G4endl;
-  G4cout<<"May be killed?: "<<currentParticle.GetMayBeKilled()<<G4endl;
-  */
-
-  CalculateMomenta(vec,
-                   vecLen,
-                   originalIncident,
-                   originalTarget,
-                   modifiedOriginal,
+  G4bool incomingRhadronHasChanged = !incomingRhadronSurvives;
+  G4bool targetHasChanged = !TargetSurvives;
+  CalculateMomenta(secondaryParticleVector,
+                   secondaryParticleVectorLen,
+                   incomingCloudG4HadProjectile,
+                   outgoingTargetG4Dynamic,
+                   modifiedoutgoingCloudG4Reaction,
                    targetNucleus,
-                   currentParticle,
-                   targetParticle,
-                   incidentHasChanged,
+                   outgoingCloudG4Reaction,
+                   outgoingTargetG4Reaction,
+                   incomingRhadronHasChanged,
                    targetHasChanged,
                    quasiElastic);
 
-  //  G4cout <<"Cloud loss: "<<(e_temp-currentParticle.GetKineticEnergy())/GeV<<" GeV"<<G4endl;
+  //Declare the Cloud 4-momentum after the interaction and propose an energy deposit of the difference between the incoming and outgoing quark cloud energies
+  G4LorentzVector outgoingCloudp4Prime(outgoingCloudG4Reaction.GetMomentum(), outgoingCloudG4Reaction.GetTotalEnergy()); 
+  outgoingCloudp4Prime *= cloudParticleToLabFrameRotation;
+  G4double proposedEnergyDeposit = initialCloudEnergy - outgoingCloudG4Reaction.GetTotalEnergy();
 
-  G4String cPname = currentParticle.GetDefinition()->GetParticleName();
-
-  //  if(cPname!="rhadronmesoncloud"&&cPname!="rhadronbaryoncloud")
-  //    {
-  /*
-  G4cout<<"Current particle is now: "<<cPname <<G4endl;
-  G4cout<<"with momentum: "<<currentParticle.GetMomentum()/GeV<<" GeV"<<G4endl;
-  G4cout<<"and kinetic energy: "<<currentParticle.GetKineticEnergy()/GeV<<" GeV"<<G4endl;
-  G4cout<<"May be killed?: "<<currentParticle.GetMayBeKilled()<<G4endl;
-  G4cout<<"Modified original is: "<<modifiedOriginal.GetDefinition()->GetParticleName()<<G4endl;
-  G4cout<<"with momentum: "<<modifiedOriginal.GetMomentum()/GeV<<" GeV"<<G4endl;
-  G4cout<<"and kinetic energy: "<<modifiedOriginal.GetKineticEnergy()/GeV<<" GeV"<<G4endl;
-  G4cout<<"May be killed?: "<<modifiedOriginal.GetMayBeKilled()<<G4endl;
-  G4cout<<"Target particle is: "<<targetParticle.GetDefinition()->GetParticleName()<<G4endl;
-  G4cout<<"with momentum: "<<targetParticle.GetMomentum()/GeV<<" GeV"<<G4endl;
-  G4cout<<"and kinetic energy: "<<targetParticle.GetKineticEnergy()/GeV<<" GeV"<<G4endl;
-  G4cout<<"May be killed?: "<<targetParticle.GetMayBeKilled()<<G4endl;
-  G4cout<<"incidentHasChanged: "<<incidentHasChanged<<G4endl;
-  G4cout<<"targetHasChanged: "<<targetHasChanged<<G4endl;
-  G4cout<<"Particles in vec:"<<G4endl;
-  for(int i=0; i<vecLen; ++i )
-    {
-      G4cout<< vec[i]->GetDefinition()->GetParticleName()<<G4endl;
-    }
-  */
-  // G4cout<<"Done!"<<G4endl;
-
-  aParticleChange.SetNumberOfSecondaries(vecLen + NumberOfSecondaries);
-  G4double e_kin = 0;
-  G4LorentzVector cloud_p4_new;  //Cloud 4-momentum in lab after collision
-  //  n++;
-  //  G4cout << n << G4endl;
-  /*
-  if(cPname!="rhadronmesoncloud"&&cPname!="rhadronbaryoncloud") {
-    G4cout<<"Cloud deleted!!! AAARRRRGGGHHH!!!"<<G4endl;
-    G4cout<<"Cloud name: "<<cPname<<G4endl;
-    G4cout<<"E_kin_0: "<<e_kin_0/GeV<<" GeV"<<G4endl;
-    //    G4cout<<"n: "<<n<<G4endl;
-    //    n=0;
+  if (proposedEnergyDeposit > 0) {
+    aParticleChange.ProposeLocalEnergyDeposit(proposedEnergyDeposit);
   }
-  */
-  cloud_p4_new.setVectM(currentParticle.GetMomentum(), currentParticle.GetMass());
-  cloud_p4_new *= trans;
 
-  G4LorentzVector cloud_p4_old_full = Cloud4Momentum;  //quark system in CMS BEFORE collision
-  cloud_p4_old_full.boost(trafo_full_cms);
-  G4LorentzVector cloud_p4_old_cloud = Cloud4Momentum;  //quark system in cloud CMS BEFORE collision
-  cloud_p4_old_cloud.boost(trafo_cloud_cms);
-  G4LorentzVector cloud_p4_full = cloud_p4_new;  //quark system in CMS AFTER collision
-  cloud_p4_full.boost(trafo_full_cms);
-  G4LorentzVector cloud_p4_cloud = cloud_p4_new;  //quark system in cloud CMS AFTER collision
-  cloud_p4_cloud.boost(trafo_cloud_cms);
+  //Update the number of secondaries to the correct value
+  aParticleChange.SetNumberOfSecondaries(secondaryParticleVectorLen + reactionProductSize);
 
-  G4LorentzVector p_g_cms = gluinoMomentum;  //gluino in CMS BEFORE collision
-  p_g_cms.boost(trafo_full_cms);
+  //If the incident particle does not survive, update the outgoing track to be the new R-Hadron with the proper momentum, time, and position
+  G4DynamicParticle* dynamicOutgoingRhadron = new G4DynamicParticle;
+  if (!incomingRhadronSurvives) {
+    dynamicOutgoingRhadron->SetDefinition(outgoingRhadronDefinition);
+    dynamicOutgoingRhadron->SetMomentum(gluinoMomentum.vect() + outgoingCloudp4Prime.vect());
 
-  G4LorentzVector p4_new(cloud_p4_new.v() + gluinoMomentum.v(), outgoingRhadron->GetPDGMass());
-  //  G4cout<<"P4-diff: "<<(p4_new-cloud_p4_new-gluinoMomentum)/GeV<<", magnitude: "
-  // <<(p4_new-cloud_p4_new-gluinoMomentum).m()/MeV<<" MeV" <<G4endl;
+    G4Track* outgoingRhadronTrack = new G4Track(dynamicOutgoingRhadron, aTrack.GetGlobalTime(), aPosition);
+    outgoingRhadronTrack->SetTouchableHandle(thisTouchable);
+    aParticleChange.AddSecondary(outgoingRhadronTrack);
 
-  G4ThreeVector p_new = p4_new.vect();
-
-  aParticleChange.ProposeLocalEnergyDeposit((p4_new - cloud_p4_new - gluinoMomentum).m());
-
-  if (incidentHasChanged) {
-    G4DynamicParticle* p0 = new G4DynamicParticle;
-    p0->SetDefinition(outgoingRhadron);
-    p0->SetMomentum(p_new);
-
-    // May need to run SetDefinitionAndUpdateE here...
-    G4Track* Track0 = new G4Track(p0, aTrack.GetGlobalTime(), aPosition);
-    Track0->SetTouchableHandle(thisTouchable);
-    aParticleChange.AddSecondary(Track0);
-    /*
-      G4cout<<"Adding a particle "<<p0->GetDefinition()->GetParticleName()<<G4endl;
-      G4cout<<"with momentum: "<<p0->GetMomentum()/GeV<<" GeV"<<G4endl;
-      G4cout<<"and kinetic energy: "<<p0->GetKineticEnergy()/GeV<<" GeV"<<G4endl;
-      */
-    if (p0->GetKineticEnergy() > e_kin_0) {
-      G4cout << "ALAAAAARM!!! (incident changed from " << IncidentRhadron->GetDefinition()->GetParticleName() << " to "
-             << p0->GetDefinition()->GetParticleName() << ")" << G4endl;
-      G4cout << "Energy loss: " << (e_kin_0 - p0->GetKineticEnergy()) / GeV << " GeV (should be positive)" << G4endl;
-      //Turns out problem is only in 2 -> 3 (Won't fix 2 -> 2 energy deposition)
-      if (rp.size() != 3)
-        G4cout << "DOUBLE ALAAAAARM!!!" << G4endl;
-    } /*else {
-	G4cout<<"NO ALAAAAARM!!!"<<G4endl;
-	}*/
-    if (std::abs(p0->GetKineticEnergy() - e_kin_0) > 100 * GeV) {
-      G4cout << "Diff. too big" << G4endl;
-    }
+    //Stop the old track
     aParticleChange.ProposeTrackStatus(fStopAndKill);
-  } else {
-    G4double p = p_new.mag();
-    if (p > DBL_MIN)
-      aParticleChange.ProposeMomentumDirection(p_new.x() / p, p_new.y() / p, p_new.z() / p);
+  } 
+
+  //If the incident particle survives update its momentum direction. Includes error handling for when the momentum is zero
+  else {
+    dynamicOutgoingRhadron->SetDefinition(incomingRhadron->GetDefinition());
+    dynamicOutgoingRhadron->SetMomentum(gluinoMomentum.vect() + outgoingCloudp4Prime.vect());
+    if (dynamicOutgoingRhadron->GetMomentum().mag() > DBL_MIN)
+      aParticleChange.ProposeMomentumDirection(dynamicOutgoingRhadron->GetMomentum().x() / dynamicOutgoingRhadron->GetMomentum().mag(), dynamicOutgoingRhadron->GetMomentum().y() / dynamicOutgoingRhadron->GetMomentum().mag(), dynamicOutgoingRhadron->GetMomentum().z() / dynamicOutgoingRhadron->GetMomentum().mag());
     else
       aParticleChange.ProposeMomentumDirection(1.0, 0.0, 0.0);
+    aParticleChange.ProposeEnergy(dynamicOutgoingRhadron->GetKineticEnergy());
   }
 
-  //    return G4VDiscreteProcess::PostStepDoIt( aTrack, aStep);
-  if (targetParticle.GetMass() > 0.0)  // targetParticle can be eliminated in TwoBody
+  //Update the momenta of the target track
+  G4DynamicParticle* targetParticleG4DynamicAfterInteraction = new G4DynamicParticle;
+  if (outgoingTargetG4Reaction.GetMass() > 0.0)  // outgoingTargetG4Reaction can be eliminated in TwoBody
   {
-    G4DynamicParticle* p1 = new G4DynamicParticle;
-    p1->SetDefinition(targetParticle.GetDefinition());
-    //G4cout<<"Target secondary: "<<targetParticle.GetDefinition()->GetParticleName()<<G4endl;
-    G4ThreeVector momentum = targetParticle.GetMomentum();
-    momentum = momentum.rotate(cache, what);
-    p1->SetMomentum(momentum);
-    p1->SetMomentum((trans * p1->Get4Momentum()).vect());
-    G4Track* Track1 = new G4Track(p1, aTrack.GetGlobalTime(), aPosition);
-    Track1->SetTouchableHandle(thisTouchable);
-    aParticleChange.AddSecondary(Track1);
-  }
-  G4DynamicParticle* pa;
-  /*
-    G4cout<<"vecLen: "<<vecLen<<G4endl;
-    G4cout<<"#sec's: "<<aParticleChange.GetNumberOfSecondaries()<<G4endl;
-  */
-
-  for (int i = 0; i < vecLen; ++i) {
-    pa = new G4DynamicParticle();
-    pa->SetDefinition(vec[i]->GetDefinition());
-    pa->SetMomentum(vec[i]->GetMomentum());
-    pa->Set4Momentum(trans * (pa->Get4Momentum()));
-    G4ThreeVector pvec = pa->GetMomentum();
-    G4Track* Trackn = new G4Track(pa, aTrack.GetGlobalTime(), aPosition);
-    Trackn->SetTouchableHandle(thisTouchable);
-    aParticleChange.AddSecondary(Trackn);
-
-    delete vec[i];
+    targetParticleG4DynamicAfterInteraction->SetDefinition(outgoingTargetG4Reaction.GetDefinition());
+    targetParticleG4DynamicAfterInteraction->SetMomentum(outgoingTargetG4Reaction.GetMomentum().rotate(2. * pi * G4UniformRand(), incomingCloud3Momentum)); // rotate(const G4double angle, const ThreeVector &axis) const;
+    targetParticleG4DynamicAfterInteraction->SetMomentum((cloudParticleToLabFrameRotation * targetParticleG4DynamicAfterInteraction->Get4Momentum()).vect());
+    G4Track* targetTrackAfterInteraction = new G4Track(targetParticleG4DynamicAfterInteraction, aTrack.GetGlobalTime(), aPosition);
+    targetTrackAfterInteraction->SetTouchableHandle(thisTouchable);
+    aParticleChange.AddSecondary(targetTrackAfterInteraction);
   }
 
-  // Histogram filling
-  const G4DynamicParticle* theRhadron = FindRhadron(&aParticleChange);
+  // Update the momenta of the remaining secondary tracks
+  for (int i = 0; i < secondaryParticleVectorLen; ++i) {
+    G4DynamicParticle* secondaryParticleAfterInteraction = new G4DynamicParticle();
+    secondaryParticleAfterInteraction->SetDefinition(secondaryParticleVector[i]->GetDefinition());
+    secondaryParticleAfterInteraction->SetMomentum(secondaryParticleVector[i]->GetMomentum());
+    secondaryParticleAfterInteraction->SetMomentum((cloudParticleToLabFrameRotation * secondaryParticleAfterInteraction->Get4Momentum()).vect());
+    G4Track* secondaryTrackAfterInteraction = new G4Track(secondaryParticleAfterInteraction, aTrack.GetGlobalTime(), aPosition);
+    secondaryTrackAfterInteraction->SetTouchableHandle(thisTouchable);
+    aParticleChange.AddSecondary(secondaryTrackAfterInteraction);
 
-  if (theRhadron != nullptr || IncidentSurvives) {
-    double E_new;
-    if (IncidentSurvives) {
-      E_new = e_kin;
-    } else {
-      E_new = theRhadron->GetKineticEnergy();
-      if (CustomPDGParser::s_isRMeson(theRhadron->GetDefinition()->GetPDGEncoding()) !=
-              CustomPDGParser::s_isRMeson(theIncidentPDG) ||
-          CustomPDGParser::s_isMesonino(theRhadron->GetDefinition()->GetPDGEncoding()) !=
-              CustomPDGParser::s_isMesonino(theIncidentPDG)) {
-        G4cout << "Rm: " << CustomPDGParser::s_isRMeson(theRhadron->GetDefinition()->GetPDGEncoding())
-               << " vs: " << CustomPDGParser::s_isRMeson(theIncidentPDG) << G4endl;
-        G4cout << "Sm: " << CustomPDGParser::s_isMesonino(theRhadron->GetDefinition()->GetPDGEncoding())
-               << " vs: " << CustomPDGParser::s_isMesonino(theIncidentPDG) << G4endl;
-      }
-    }
-
-    //Calculating relevant scattering angles.
-    G4LorentzVector p4_old_full = FullRhadron4Momentum;  //R-hadron in CMS BEFORE collision
-    p4_old_full.boost(trafo_full_cms);
-    G4LorentzVector p4_old_cloud = FullRhadron4Momentum;  //R-hadron in cloud CMS BEFORE collision
-    p4_old_cloud.boost(trafo_cloud_cms);
-    G4LorentzVector p4_full = p4_new;  //R-hadron in CMS AFTER collision
-    //      G4cout<<p4_full.v()/GeV<<G4endl;
-    p4_full = p4_full.boost(trafo_full_cms);
-    // G4cout<<p4_full.m()<<" / "<<(cloud_p4_new+gluinoMomentum).boost(trafo_full_cms).m()<<G4endl;
-    G4LorentzVector p4_cloud = p4_new;  //R-hadron in cloud CMS AFTER collision
-    p4_cloud.boost(trafo_cloud_cms);
-
-    G4double AbsDeltaE = E_0 - E_new;
-    //      G4cout <<"Energy loss: "<<AbsDeltaE/GeV<<G4endl;
-    if (AbsDeltaE > 10 * GeV) {
-      G4cout << "Energy loss larger than 10 GeV..." << G4endl;
-      G4cout << "E_0: " << E_0 / GeV << " GeV" << G4endl;
-      G4cout << "E_new: " << E_new / GeV << " GeV" << G4endl;
-      G4cout << "Gamma: " << IncidentRhadron->GetTotalEnergy() / IncidentRhadron->GetDefinition()->GetPDGMass()
-             << G4endl;
-      G4cout << "x: " << aPosition.x() / cm << " cm" << G4endl;
-    }
+    delete secondaryParticleVector[i];
   }
-  delete originalIncident;
-  delete originalTarget;
-  //  aParticleChange.DumpInfo();
-  //  G4cout << "Exiting FullModelHadronicProcess::PostStepDoIt"<<G4endl;
 
-  //clear interaction length
+  delete incomingCloudG4HadProjectile;
+  delete outgoingTargetG4Dynamic;
+  //aParticleChange.DumpInfo();
   ClearNumberOfInteractionLengthLeft();
 
   return &aParticleChange;
 }
 
 void FullModelHadronicProcess::CalculateMomenta(
-    G4FastVector<G4ReactionProduct, MYGHADLISTSIZE>& vec,
-    G4int& vecLen,
-    const G4HadProjectile* originalIncident,  // the original incident particle
-    const G4DynamicParticle* originalTarget,
-    G4ReactionProduct& modifiedOriginal,  // Fermi motion and evap. effects included
-    G4Nucleus& targetNucleus,
-    G4ReactionProduct& currentParticle,
-    G4ReactionProduct& targetParticle,
-    G4bool& incidentHasChanged,
-    G4bool& targetHasChanged,
-    G4bool quasiElastic) {
+    G4FastVector<G4ReactionProduct, MYGHADLISTSIZE>& secondaryParticleVector, //Vector of secondary particles
+    G4int& secondaryParticleVectorLen, //Length of the secondary particle vector
+    const G4HadProjectile* incomingCloudG4HadProjectile,  //The incoming cloud projectile
+    const G4DynamicParticle* outgoingTargetG4Dynamic, //The original target particle
+    G4ReactionProduct& modifiedoutgoingCloudG4Reaction,  //Fermi motion and evap. effects included
+    G4Nucleus& targetNucleus, //The target nucleus
+    G4ReactionProduct& outgoingCloudG4Reaction, //The outgoing cloud G4 Reaction
+    G4ReactionProduct& outgoingTargetG4Reaction, //The outgoing particle previously defined as original target
+    G4bool& incomingRhadronHasChanged, //True if the R-Hadron type has changed
+    G4bool& targetHasChanged, //True if the target particle has changed
+    G4bool quasiElastic) //True if the reaction product size equals 2, false otherwise
+{
   FullModelReactionDynamics theReactionDynamics;
+  incomingCloud3Momentum = incomingCloudG4HadProjectile->Get4Momentum().v(); //Use this for rotations later
 
-  cache = 0;
-  what = originalIncident->Get4Momentum().vect();
-
+  //If the reaction is quasi-elastic, use the TwoBody method to calculate the momenta of the outgoing particles.
   if (quasiElastic) {
-    //      G4cout<<"We are calling TwoBody..."<<G4endl;
-    theReactionDynamics.TwoBody(
-        vec, vecLen, modifiedOriginal, originalTarget, currentParticle, targetParticle, targetNucleus, targetHasChanged);
-
+    theReactionDynamics.TwoBody(secondaryParticleVector, secondaryParticleVectorLen, modifiedoutgoingCloudG4Reaction, outgoingTargetG4Dynamic, outgoingCloudG4Reaction, outgoingTargetG4Reaction, targetNucleus, targetHasChanged);
     return;
   }
 
-  //If ProduceStrangeParticlePairs is commented out, let's cut this one as well
+  //If the reaction is not quasi-elastic, update the outgoing particles momenta based on effects detailed in the functions below. Then call the TwoBody method afterwards
   G4ReactionProduct leadingStrangeParticle;
-  G4bool leadFlag = MarkLeadingStrangeParticle(currentParticle, targetParticle, leadingStrangeParticle);
-
-  //
-  // Note: the number of secondaries can be reduced in GenerateXandPt and TwoCluster
-  //
-  G4bool finishedGenXPt = false;
-  G4bool annihilation = false;
-  if (originalIncident->GetDefinition()->GetPDGEncoding() < 0 && currentParticle.GetMass() == 0.0 &&
-      targetParticle.GetMass() == 0.0) {
-    // original was an anti-particle and annihilation has taken place
-    annihilation = true;
-    G4double ekcor = 1.0;
-    G4double ek = originalIncident->GetKineticEnergy();
-    G4double ekOrg = ek;
-
-    const G4double tarmas = originalTarget->GetDefinition()->GetPDGMass();
-    if (ek > 1.0 * GeV)
-      ekcor = 1. / (ek / GeV);
-    const G4double atomicWeight = G4double(targetNucleus.GetN_asInt());
-    ek = 2 * tarmas + ek * (1. + ekcor / atomicWeight);
-
-    G4double tkin = targetNucleus.Cinema(ek);
-    //ek += tkin;
-    ekOrg += tkin;
-    modifiedOriginal.SetKineticEnergy(ekOrg);
-  }
-
-  const G4double twsup[] = {1.0, 0.7, 0.5, 0.3, 0.2, 0.1};
-  G4double rand1 = G4UniformRand();
-  G4double rand2 = G4UniformRand();
-  if ((annihilation || (vecLen >= 6) || (modifiedOriginal.GetKineticEnergy() / GeV >= 1.0)) &&
-      (((originalIncident->GetDefinition() == G4KaonPlus::KaonPlus()) ||
-        (originalIncident->GetDefinition() == G4KaonMinus::KaonMinus()) ||
-        (originalIncident->GetDefinition() == G4KaonZeroLong::KaonZeroLong()) ||
-        (originalIncident->GetDefinition() == G4KaonZeroShort::KaonZeroShort())) &&
-       ((rand1 < 0.5) || (rand2 > twsup[vecLen]))))
-    finishedGenXPt = theReactionDynamics.GenerateXandPt(vec,
-                                                        vecLen,
-                                                        modifiedOriginal,
-                                                        originalIncident,
-                                                        currentParticle,
-                                                        targetParticle,
-                                                        targetNucleus,
-                                                        incidentHasChanged,
-                                                        targetHasChanged,
-                                                        leadFlag,
-                                                        leadingStrangeParticle);
-  if (finishedGenXPt) {
-    Rotate(vec, vecLen);
-    return;
-  }
-
+  G4bool leadFlag = MarkLeadingStrangeParticle(outgoingCloudG4Reaction, outgoingTargetG4Reaction, leadingStrangeParticle);
   G4bool finishedTwoClu = false;
-  if (modifiedOriginal.GetTotalMomentum() / MeV < 1.0) {
-    for (G4int i = 0; i < vecLen; i++)
-      delete vec[i];
-    vecLen = 0;
-  } else {
-    theReactionDynamics.SuppressChargedPions(vec,
-                                             vecLen,
-                                             modifiedOriginal,
-                                             currentParticle,
-                                             targetParticle,
+  if (modifiedoutgoingCloudG4Reaction.GetTotalMomentum() / MeV < 1.0) {
+    for (G4int i = 0; i < secondaryParticleVectorLen; i++) {
+      delete secondaryParticleVector[i];
+    }
+    secondaryParticleVectorLen = 0;
+  } 
+  else {
+    theReactionDynamics.SuppressChargedPions(secondaryParticleVector,
+                                             secondaryParticleVectorLen,
+                                             modifiedoutgoingCloudG4Reaction,
+                                             outgoingCloudG4Reaction,
+                                             outgoingTargetG4Reaction,
                                              targetNucleus,
-                                             incidentHasChanged,
+                                             incomingRhadronHasChanged,
                                              targetHasChanged);
 
     try {
-      finishedTwoClu = theReactionDynamics.TwoCluster(vec,
-                                                      vecLen,
-                                                      modifiedOriginal,
-                                                      originalIncident,
-                                                      currentParticle,
-                                                      targetParticle,
+      finishedTwoClu = theReactionDynamics.TwoCluster(secondaryParticleVector,
+                                                      secondaryParticleVectorLen,
+                                                      modifiedoutgoingCloudG4Reaction,
+                                                      incomingCloudG4HadProjectile,
+                                                      outgoingCloudG4Reaction,
+                                                      outgoingTargetG4Reaction,
                                                       targetNucleus,
-                                                      incidentHasChanged,
+                                                      incomingRhadronHasChanged,
                                                       targetHasChanged,
                                                       leadFlag,
                                                       leadingStrangeParticle);
@@ -597,76 +335,39 @@ void FullModelHadronicProcess::CalculateMomenta(
       G4Exception("FullModelHadronicProcess::CalculateMomenta", "had066", FatalException, ed);
     }
   }
+
   if (finishedTwoClu) {
-    Rotate(vec, vecLen);
+    Rotate(secondaryParticleVector, secondaryParticleVectorLen);
     return;
   }
 
-  //
-  // PNBlackTrackEnergy is the kinetic energy available for
-  //   proton/neutron black track particles [was enp(1) in fortran code]
-  // DTABlackTrackEnergy is the kinetic energy available for
-  //   deuteron/triton/alpha particles      [was enp(3) in fortran code]
-  // the atomic weight of the target nucleus is >= 1.5            AND
-  //   neither the incident nor the target particles have changed  AND
-  //     there is no kinetic energy available for either proton/neutron
-  //     or for deuteron/triton/alpha black track particles
-  // For diffraction scattering on heavy nuclei use elastic routines instead
-
-  theReactionDynamics.TwoBody(
-      vec, vecLen, modifiedOriginal, originalTarget, currentParticle, targetParticle, targetNucleus, targetHasChanged);
+  theReactionDynamics.TwoBody(secondaryParticleVector, secondaryParticleVectorLen, modifiedoutgoingCloudG4Reaction, outgoingTargetG4Dynamic, outgoingCloudG4Reaction, outgoingTargetG4Reaction, targetNucleus, targetHasChanged);
 }
 
-G4bool FullModelHadronicProcess::MarkLeadingStrangeParticle(const G4ReactionProduct& currentParticle,
-                                                            const G4ReactionProduct& targetParticle,
+G4bool FullModelHadronicProcess::MarkLeadingStrangeParticle(const G4ReactionProduct& outgoingCloudG4Reaction,
+                                                            const G4ReactionProduct& outgoingTargetG4Reaction,
                                                             G4ReactionProduct& leadParticle) {
-  // the following was in GenerateXandPt and TwoCluster
-  // add a parameter to the GenerateXandPt function telling it about the strange particle
-  //
-  // assumes that the original particle was a strange particle
-  //
+  //Here we check to see if the current or target particle is more massive than the Kaon, not a proton, and not a neutron. If so, we set the lead particle to the strange particle
   G4bool lead = false;
-  if ((currentParticle.GetMass() >= G4KaonPlus::KaonPlus()->GetPDGMass()) &&
-      (currentParticle.GetDefinition() != G4Proton::Proton()) &&
-      (currentParticle.GetDefinition() != G4Neutron::Neutron())) {
+  if ((outgoingCloudG4Reaction.GetMass() >= G4KaonPlus::KaonPlus()->GetPDGMass()) &&
+      (outgoingCloudG4Reaction.GetDefinition() != G4Proton::Proton()) &&
+      (outgoingCloudG4Reaction.GetDefinition() != G4Neutron::Neutron())) {
     lead = true;
-    leadParticle = currentParticle;  //  set lead to the incident particle
-  } else if ((targetParticle.GetMass() >= G4KaonPlus::KaonPlus()->GetPDGMass()) &&
-             (targetParticle.GetDefinition() != G4Proton::Proton()) &&
-             (targetParticle.GetDefinition() != G4Neutron::Neutron())) {
+    leadParticle = outgoingCloudG4Reaction;
+  } else if ((outgoingTargetG4Reaction.GetMass() >= G4KaonPlus::KaonPlus()->GetPDGMass()) &&
+             (outgoingTargetG4Reaction.GetDefinition() != G4Proton::Proton()) &&
+             (outgoingTargetG4Reaction.GetDefinition() != G4Neutron::Neutron())) {
     lead = true;
-    leadParticle = targetParticle;  //   set lead to the target particle
+    leadParticle = outgoingTargetG4Reaction;
   }
   return lead;
 }
 
-void FullModelHadronicProcess::Rotate(G4FastVector<G4ReactionProduct, MYGHADLISTSIZE>& vec, G4int& vecLen) {
-  G4double rotation = 2. * pi * G4UniformRand();
-  cache = rotation;
+void FullModelHadronicProcess::Rotate(G4FastVector<G4ReactionProduct, MYGHADLISTSIZE>& secondaryParticleVector, G4int& secondaryParticleVectorLen) {
   G4int i;
-  for (i = 0; i < vecLen; ++i) {
-    G4ThreeVector momentum = vec[i]->GetMomentum();
-    momentum = momentum.rotate(rotation, what);
-    vec[i]->SetMomentum(momentum);
+  for (i = 0; i < secondaryParticleVectorLen; ++i) {
+    G4ThreeVector momentum = secondaryParticleVector[i]->GetMomentum();
+    momentum = momentum.rotate(2. * pi * G4UniformRand(), incomingCloud3Momentum);
+    secondaryParticleVector[i]->SetMomentum(momentum);
   }
-}
-
-const G4DynamicParticle* FullModelHadronicProcess::FindRhadron(G4ParticleChange* aParticleChange) {
-  G4int nsec = aParticleChange->GetNumberOfSecondaries();
-  if (nsec == 0)
-    return nullptr;
-  int i = 0;
-  G4bool found = false;
-  while (i != nsec && !found) {
-    //    G4cout<<"Checking "<<aParticleChange->GetSecondary(i)->GetDynamicParticle()->GetDefinition()->GetParticleName()<<G4endl;
-    //    if (aParticleChange->GetSecondary(i)->GetDynamicParticle()->GetDefinition()->GetParticleType()=="rhadron") found = true;
-    if (dynamic_cast<CustomParticle*>(aParticleChange->GetSecondary(i)->GetDynamicParticle()->GetDefinition()) !=
-        nullptr)
-      found = true;
-    i++;
-  }
-  i--;
-  if (found)
-    return aParticleChange->GetSecondary(i)->GetDynamicParticle();
-  return nullptr;
 }

--- a/SimG4Core/CustomPhysics/src/FullModelHadronicProcess.cc
+++ b/SimG4Core/CustomPhysics/src/FullModelHadronicProcess.cc
@@ -67,13 +67,9 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
   G4ParticleDefinition* outgoingCloudDefinition = nullptr;
   G4ParticleDefinition* outgoingTargetDefinition = nullptr;
 
-  // Declare the quark cloud as a G4DynamicParticle. Throw an error if the cloud definition is not available
+  // Declare the quark cloud as a G4DynamicParticle
   G4DynamicParticle* cloudParticle = new G4DynamicParticle();
   cloudParticle->SetDefinition(customIncomingRhadron->GetCloud());
-  if (cloudParticle->GetDefinition() == nullptr) {
-    G4cerr << "FullModelHadronicProcess::PostStepDoIt  Definition of particle cloud not available!" << G4endl;
-    exit(EXIT_FAILURE);
-  }
 
   // Define the gluino and quark cloud G4LorentzVector (momentum, total energy) based on the momentum of the R-hadron and the ratio of the masses
   double scale = cloudParticle->GetDefinition()->GetPDGMass() / incomingRhadron->GetDefinition()->GetPDGMass();
@@ -122,11 +118,6 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
     if (finalStateParticle->GetParticleType() == "rhadron") {
       outgoingRhadronDefinition = finalStateParticle;
       outgoingCloudDefinition = finalStateCustomParticle->GetCloud();
-      if (outgoingCloudDefinition == nullptr) {
-        G4cerr << "FullModelHadronicProcess::PostStepDoIt  Definition of outgoing particle cloud not available!"
-               << G4endl;
-        exit(EXIT_FAILURE);
-      }
     }
 
     if (finalStateParticle == G4Proton::Proton() || finalStateParticle == G4Neutron::Neutron())
@@ -249,10 +240,7 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
     dynamicOutgoingRhadron->SetDefinition(incomingRhadron->GetDefinition());
     dynamicOutgoingRhadron->SetMomentum(gluinoMomentum.vect() + outgoingCloudp4Prime.vect());
     if (dynamicOutgoingRhadron->GetMomentum().mag() > DBL_MIN)
-      aParticleChange.ProposeMomentumDirection(
-          dynamicOutgoingRhadron->GetMomentum().x() / dynamicOutgoingRhadron->GetMomentum().mag(),
-          dynamicOutgoingRhadron->GetMomentum().y() / dynamicOutgoingRhadron->GetMomentum().mag(),
-          dynamicOutgoingRhadron->GetMomentum().z() / dynamicOutgoingRhadron->GetMomentum().mag());
+      aParticleChange.ProposeMomentumDirection(dynamicOutgoingRhadron->GetMomentumDirection());
     else
       aParticleChange.ProposeMomentumDirection(1.0, 0.0, 0.0);
     aParticleChange.ProposeEnergy(dynamicOutgoingRhadron->GetKineticEnergy());

--- a/SimG4Core/CustomPhysics/src/FullModelHadronicProcess.cc
+++ b/SimG4Core/CustomPhysics/src/FullModelHadronicProcess.cc
@@ -54,8 +54,9 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
   // Initialize parameters
   aParticleChange.Initialize(aTrack);
   const G4DynamicParticle* incomingRhadron = aTrack.GetDynamicParticle();
-  CustomParticle* customIncomingRhadron = static_cast<CustomParticle*>(incomingRhadron->GetDefinition()); // This is used to get the cloud particle
-  const G4ThreeVector& aPosition = aTrack.GetPosition(); // Position of the track
+  CustomParticle* customIncomingRhadron =
+      static_cast<CustomParticle*>(incomingRhadron->GetDefinition());  // This is used to get the cloud particle
+  const G4ThreeVector& aPosition = aTrack.GetPosition();               // Position of the track
   const G4int incomingRhadronPDG = incomingRhadron->GetDefinition()->GetPDGEncoding();
   G4ParticleTable* theParticleTable = G4ParticleTable::GetParticleTable();
   G4bool incomingRhadronSurvives = false;
@@ -76,18 +77,23 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
 
   // Define the gluino and quark cloud G4LorentzVector (momentum, total energy) based on the momentum of the R-hadron and the ratio of the masses
   double scale = cloudParticle->GetDefinition()->GetPDGMass() / incomingRhadron->GetDefinition()->GetPDGMass();
-  G4LorentzVector cloudMomentum(incomingRhadron->GetMomentum() * scale, std::sqrt(incomingRhadron->GetMomentum().mag() * scale * incomingRhadron->GetMomentum().mag() * scale + cloudParticle->GetDefinition()->GetPDGMass() * cloudParticle->GetDefinition()->GetPDGMass()));
+  G4LorentzVector cloudMomentum(
+      incomingRhadron->GetMomentum() * scale,
+      std::sqrt(incomingRhadron->GetMomentum().mag() * scale * incomingRhadron->GetMomentum().mag() * scale +
+                cloudParticle->GetDefinition()->GetPDGMass() * cloudParticle->GetDefinition()->GetPDGMass()));
   cloudParticle->Set4Momentum(cloudMomentum);
-  G4LorentzVector gluinoMomentum(incomingRhadron->GetMomentum() * (1. - scale), incomingRhadron->GetTotalEnergy() - cloudParticle->GetTotalEnergy());
+  G4LorentzVector gluinoMomentum(incomingRhadron->GetMomentum() * (1. - scale),
+                                 incomingRhadron->GetTotalEnergy() - cloudParticle->GetTotalEnergy());
 
   // Update the cloud kinetic energy based on the target nucleus and evaporative effects
-  G4double cloudKineticEnergy = cloudParticle->GetKineticEnergy(); 
+  G4double cloudKineticEnergy = cloudParticle->GetKineticEnergy();
   G4double initialCloudEnergy = cloudParticle->GetTotalEnergy();
   cloudKineticEnergy += targetNucleus.Cinema(cloudKineticEnergy);
   cloudKineticEnergy -= targetNucleus.EvaporationEffects(cloudKineticEnergy);
 
   G4ThreeVector cloud3MomentumDirection = cloudParticle->GetMomentum().unit();
-  G4double cloud3MomentumMagnitudeAfterEvaporativeEffects = std::sqrt(cloudKineticEnergy * (cloudKineticEnergy + 2. * cloudParticle->GetDefinition()->GetPDGMass()));
+  G4double cloud3MomentumMagnitudeAfterEvaporativeEffects =
+      std::sqrt(cloudKineticEnergy * (cloudKineticEnergy + 2. * cloudParticle->GetDefinition()->GetPDGMass()));
 
   // If the R-hadron kinetic energy is less than 0.1 MeV, or the cloud kinetic energy is less than or equal to 0, stop the track but keep it alive. This should be very rare.
   if (cloudKineticEnergy + gluinoMomentum.e() - gluinoMomentum.m() <= 0.1 * MeV || cloudKineticEnergy <= 0.) {
@@ -113,17 +119,20 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
       TargetSurvives = true;
     }
 
-    if (finalStateParticle->GetParticleType()=="rhadron") {
+    if (finalStateParticle->GetParticleType() == "rhadron") {
       outgoingRhadronDefinition = finalStateParticle;
       outgoingCloudDefinition = finalStateCustomParticle->GetCloud();
       if (outgoingCloudDefinition == nullptr) {
-        G4cerr << "FullModelHadronicProcess::PostStepDoIt  Definition of outgoing particle cloud not available!" << G4endl;
+        G4cerr << "FullModelHadronicProcess::PostStepDoIt  Definition of outgoing particle cloud not available!"
+               << G4endl;
         exit(EXIT_FAILURE);
       }
     }
 
-    if (finalStateParticle == G4Proton::Proton() || finalStateParticle == G4Neutron::Neutron()) outgoingTargetDefinition = finalStateParticle;
-    if (finalStateCustomParticle == nullptr && reactionProduct.size() == 2) outgoingTargetDefinition = finalStateParticle;
+    if (finalStateParticle == G4Proton::Proton() || finalStateParticle == G4Neutron::Neutron())
+      outgoingTargetDefinition = finalStateParticle;
+    if (finalStateCustomParticle == nullptr && reactionProduct.size() == 2)
+      outgoingTargetDefinition = finalStateParticle;
     if (finalStateParticle->GetPDGEncoding() == incomingRhadronPDG) {
       incomingRhadronSurvives = true;
     } else {
@@ -146,8 +155,7 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
   if (TargetSurvives) {
     outgoingTargetG4Dynamic->SetDefinition(aTarget);
     outgoingTargetG4Reaction = G4ReactionProduct(aTarget);
-  }
-  else {
+  } else {
     outgoingTargetG4Dynamic->SetDefinition(outgoingTargetDefinition);
     outgoingTargetG4Reaction = G4ReactionProduct(outgoingTargetDefinition);
   }
@@ -157,7 +165,8 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
   G4LorentzRotation cloudParticleToLabFrameRotation = incomingCloudG4HadProjectile->GetTrafoToLab();
 
   //Create a G4ReactionProduct object for the outgoing cloud
-  G4ReactionProduct outgoingCloudG4Reaction(const_cast<G4ParticleDefinition*>(incomingCloudG4HadProjectile->GetDefinition()));
+  G4ReactionProduct outgoingCloudG4Reaction(
+      const_cast<G4ParticleDefinition*>(incomingCloudG4HadProjectile->GetDefinition()));
   outgoingCloudG4Reaction.SetMomentum(incomingCloudG4HadProjectile->Get4Momentum().vect());
   outgoingCloudG4Reaction.SetTotalEnergy(incomingCloudG4HadProjectile->GetTotalEnergy());
   if (!incomingRhadronSurvives) {
@@ -167,7 +176,7 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
   G4ReactionProduct modifiedoutgoingCloudG4Reaction = outgoingCloudG4Reaction;
 
   //Set the hemisphere of the current and target particles. Initialize an empty vector for the secondary particles
-  outgoingCloudG4Reaction.SetSide(1);  // incident always goes in forward hemisphere
+  outgoingCloudG4Reaction.SetSide(1);    // incident always goes in forward hemisphere
   outgoingTargetG4Reaction.SetSide(-1);  // target always goes in backward hemisphere
   G4bool quasiElastic = false;
   if (reactionProduct.size() == 2)
@@ -178,11 +187,15 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
 
   //Fill the vector with the secondary particles
   for (G4int i = 0; i != reactionProductSize; i++) {
-    if (outgoingParticleDefinitions[i] != aTarget && outgoingParticleDefinitions[i] != incomingCloudG4HadProjectile->GetDefinition() &&
-        outgoingParticleDefinitions[i] != outgoingRhadronDefinition && outgoingParticleDefinitions[i] != outgoingTargetDefinition) {
+    if (outgoingParticleDefinitions[i] != aTarget &&
+        outgoingParticleDefinitions[i] != incomingCloudG4HadProjectile->GetDefinition() &&
+        outgoingParticleDefinitions[i] != outgoingRhadronDefinition &&
+        outgoingParticleDefinitions[i] != outgoingTargetDefinition) {
       G4ReactionProduct* secondaryReactionProduct = new G4ReactionProduct;
       secondaryReactionProduct->SetDefinition(outgoingParticleDefinitions[i]);
-      (G4UniformRand() < 0.5) ? secondaryReactionProduct->SetSide(-1) : secondaryReactionProduct->SetSide(1); //Here we randomly determine the hemisphere of the secondary particle
+      (G4UniformRand() < 0.5)
+          ? secondaryReactionProduct->SetSide(-1)
+          : secondaryReactionProduct->SetSide(1);  //Here we randomly determine the hemisphere of the secondary particle
       secondaryParticleVector.SetElement(secondaryParticleVectorLen++, secondaryReactionProduct);
     }
   }
@@ -206,7 +219,7 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
                    quasiElastic);
 
   //Declare the Cloud 4-momentum after the interaction and propose an energy deposit of the difference between the incoming and outgoing quark cloud energies
-  G4LorentzVector outgoingCloudp4Prime(outgoingCloudG4Reaction.GetMomentum(), outgoingCloudG4Reaction.GetTotalEnergy()); 
+  G4LorentzVector outgoingCloudp4Prime(outgoingCloudG4Reaction.GetMomentum(), outgoingCloudG4Reaction.GetTotalEnergy());
   outgoingCloudp4Prime *= cloudParticleToLabFrameRotation;
   G4double proposedEnergyDeposit = initialCloudEnergy - outgoingCloudG4Reaction.GetTotalEnergy();
 
@@ -229,14 +242,17 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
 
     //Stop the old track
     aParticleChange.ProposeTrackStatus(fStopAndKill);
-  } 
+  }
 
   //If the incident particle survives update its momentum direction. Includes error handling for when the momentum is zero
   else {
     dynamicOutgoingRhadron->SetDefinition(incomingRhadron->GetDefinition());
     dynamicOutgoingRhadron->SetMomentum(gluinoMomentum.vect() + outgoingCloudp4Prime.vect());
     if (dynamicOutgoingRhadron->GetMomentum().mag() > DBL_MIN)
-      aParticleChange.ProposeMomentumDirection(dynamicOutgoingRhadron->GetMomentum().x() / dynamicOutgoingRhadron->GetMomentum().mag(), dynamicOutgoingRhadron->GetMomentum().y() / dynamicOutgoingRhadron->GetMomentum().mag(), dynamicOutgoingRhadron->GetMomentum().z() / dynamicOutgoingRhadron->GetMomentum().mag());
+      aParticleChange.ProposeMomentumDirection(
+          dynamicOutgoingRhadron->GetMomentum().x() / dynamicOutgoingRhadron->GetMomentum().mag(),
+          dynamicOutgoingRhadron->GetMomentum().y() / dynamicOutgoingRhadron->GetMomentum().mag(),
+          dynamicOutgoingRhadron->GetMomentum().z() / dynamicOutgoingRhadron->GetMomentum().mag());
     else
       aParticleChange.ProposeMomentumDirection(1.0, 0.0, 0.0);
     aParticleChange.ProposeEnergy(dynamicOutgoingRhadron->GetKineticEnergy());
@@ -247,9 +263,13 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
   if (outgoingTargetG4Reaction.GetMass() > 0.0)  // outgoingTargetG4Reaction can be eliminated in TwoBody
   {
     targetParticleG4DynamicAfterInteraction->SetDefinition(outgoingTargetG4Reaction.GetDefinition());
-    targetParticleG4DynamicAfterInteraction->SetMomentum(outgoingTargetG4Reaction.GetMomentum().rotate(2. * pi * G4UniformRand(), incomingCloud3Momentum)); // rotate(const G4double angle, const ThreeVector &axis) const;
-    targetParticleG4DynamicAfterInteraction->SetMomentum((cloudParticleToLabFrameRotation * targetParticleG4DynamicAfterInteraction->Get4Momentum()).vect());
-    G4Track* targetTrackAfterInteraction = new G4Track(targetParticleG4DynamicAfterInteraction, aTrack.GetGlobalTime(), aPosition);
+    targetParticleG4DynamicAfterInteraction->SetMomentum(outgoingTargetG4Reaction.GetMomentum().rotate(
+        2. * pi * G4UniformRand(),
+        incomingCloud3Momentum));  // rotate(const G4double angle, const ThreeVector &axis) const;
+    targetParticleG4DynamicAfterInteraction->SetMomentum(
+        (cloudParticleToLabFrameRotation * targetParticleG4DynamicAfterInteraction->Get4Momentum()).vect());
+    G4Track* targetTrackAfterInteraction =
+        new G4Track(targetParticleG4DynamicAfterInteraction, aTrack.GetGlobalTime(), aPosition);
     targetTrackAfterInteraction->SetTouchableHandle(thisTouchable);
     aParticleChange.AddSecondary(targetTrackAfterInteraction);
   }
@@ -259,8 +279,10 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
     G4DynamicParticle* secondaryParticleAfterInteraction = new G4DynamicParticle();
     secondaryParticleAfterInteraction->SetDefinition(secondaryParticleVector[i]->GetDefinition());
     secondaryParticleAfterInteraction->SetMomentum(secondaryParticleVector[i]->GetMomentum());
-    secondaryParticleAfterInteraction->SetMomentum((cloudParticleToLabFrameRotation * secondaryParticleAfterInteraction->Get4Momentum()).vect());
-    G4Track* secondaryTrackAfterInteraction = new G4Track(secondaryParticleAfterInteraction, aTrack.GetGlobalTime(), aPosition);
+    secondaryParticleAfterInteraction->SetMomentum(
+        (cloudParticleToLabFrameRotation * secondaryParticleAfterInteraction->Get4Momentum()).vect());
+    G4Track* secondaryTrackAfterInteraction =
+        new G4Track(secondaryParticleAfterInteraction, aTrack.GetGlobalTime(), aPosition);
     secondaryTrackAfterInteraction->SetTouchableHandle(thisTouchable);
     aParticleChange.AddSecondary(secondaryTrackAfterInteraction);
 
@@ -276,38 +298,45 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
 }
 
 void FullModelHadronicProcess::CalculateMomenta(
-    G4FastVector<G4ReactionProduct, MYGHADLISTSIZE>& secondaryParticleVector, //Vector of secondary particles
-    G4int& secondaryParticleVectorLen, //Length of the secondary particle vector
-    const G4HadProjectile* incomingCloudG4HadProjectile,  //The incoming cloud projectile
-    const G4DynamicParticle* outgoingTargetG4Dynamic, //The original target particle
-    G4ReactionProduct& modifiedoutgoingCloudG4Reaction,  //Fermi motion and evap. effects included
-    G4Nucleus& targetNucleus, //The target nucleus
-    G4ReactionProduct& outgoingCloudG4Reaction, //The outgoing cloud G4 Reaction
-    G4ReactionProduct& outgoingTargetG4Reaction, //The outgoing particle previously defined as original target
-    G4bool& incomingRhadronHasChanged, //True if the R-Hadron type has changed
-    G4bool& targetHasChanged, //True if the target particle has changed
-    G4bool quasiElastic) //True if the reaction product size equals 2, false otherwise
+    G4FastVector<G4ReactionProduct, MYGHADLISTSIZE>& secondaryParticleVector,  //Vector of secondary particles
+    G4int& secondaryParticleVectorLen,                                         //Length of the secondary particle vector
+    const G4HadProjectile* incomingCloudG4HadProjectile,                       //The incoming cloud projectile
+    const G4DynamicParticle* outgoingTargetG4Dynamic,                          //The original target particle
+    G4ReactionProduct& modifiedoutgoingCloudG4Reaction,                        //Fermi motion and evap. effects included
+    G4Nucleus& targetNucleus,                                                  //The target nucleus
+    G4ReactionProduct& outgoingCloudG4Reaction,                                //The outgoing cloud G4 Reaction
+    G4ReactionProduct& outgoingTargetG4Reaction,  //The outgoing particle previously defined as original target
+    G4bool& incomingRhadronHasChanged,            //True if the R-Hadron type has changed
+    G4bool& targetHasChanged,                     //True if the target particle has changed
+    G4bool quasiElastic)                          //True if the reaction product size equals 2, false otherwise
 {
   FullModelReactionDynamics theReactionDynamics;
-  incomingCloud3Momentum = incomingCloudG4HadProjectile->Get4Momentum().v(); //Use this for rotations later
+  incomingCloud3Momentum = incomingCloudG4HadProjectile->Get4Momentum().v();  //Use this for rotations later
 
   //If the reaction is quasi-elastic, use the TwoBody method to calculate the momenta of the outgoing particles.
   if (quasiElastic) {
-    theReactionDynamics.TwoBody(secondaryParticleVector, secondaryParticleVectorLen, modifiedoutgoingCloudG4Reaction, outgoingTargetG4Dynamic, outgoingCloudG4Reaction, outgoingTargetG4Reaction, targetNucleus, targetHasChanged);
+    theReactionDynamics.TwoBody(secondaryParticleVector,
+                                secondaryParticleVectorLen,
+                                modifiedoutgoingCloudG4Reaction,
+                                outgoingTargetG4Dynamic,
+                                outgoingCloudG4Reaction,
+                                outgoingTargetG4Reaction,
+                                targetNucleus,
+                                targetHasChanged);
     return;
   }
 
   //If the reaction is not quasi-elastic, update the outgoing particles momenta based on effects detailed in the functions below. Then call the TwoBody method afterwards
   G4ReactionProduct leadingStrangeParticle;
-  G4bool leadFlag = MarkLeadingStrangeParticle(outgoingCloudG4Reaction, outgoingTargetG4Reaction, leadingStrangeParticle);
+  G4bool leadFlag =
+      MarkLeadingStrangeParticle(outgoingCloudG4Reaction, outgoingTargetG4Reaction, leadingStrangeParticle);
   G4bool finishedTwoClu = false;
   if (modifiedoutgoingCloudG4Reaction.GetTotalMomentum() / MeV < 1.0) {
     for (G4int i = 0; i < secondaryParticleVectorLen; i++) {
       delete secondaryParticleVector[i];
     }
     secondaryParticleVectorLen = 0;
-  } 
-  else {
+  } else {
     theReactionDynamics.SuppressChargedPions(secondaryParticleVector,
                                              secondaryParticleVectorLen,
                                              modifiedoutgoingCloudG4Reaction,
@@ -341,7 +370,14 @@ void FullModelHadronicProcess::CalculateMomenta(
     return;
   }
 
-  theReactionDynamics.TwoBody(secondaryParticleVector, secondaryParticleVectorLen, modifiedoutgoingCloudG4Reaction, outgoingTargetG4Dynamic, outgoingCloudG4Reaction, outgoingTargetG4Reaction, targetNucleus, targetHasChanged);
+  theReactionDynamics.TwoBody(secondaryParticleVector,
+                              secondaryParticleVectorLen,
+                              modifiedoutgoingCloudG4Reaction,
+                              outgoingTargetG4Dynamic,
+                              outgoingCloudG4Reaction,
+                              outgoingTargetG4Reaction,
+                              targetNucleus,
+                              targetHasChanged);
 }
 
 G4bool FullModelHadronicProcess::MarkLeadingStrangeParticle(const G4ReactionProduct& outgoingCloudG4Reaction,
@@ -363,7 +399,8 @@ G4bool FullModelHadronicProcess::MarkLeadingStrangeParticle(const G4ReactionProd
   return lead;
 }
 
-void FullModelHadronicProcess::Rotate(G4FastVector<G4ReactionProduct, MYGHADLISTSIZE>& secondaryParticleVector, G4int& secondaryParticleVectorLen) {
+void FullModelHadronicProcess::Rotate(G4FastVector<G4ReactionProduct, MYGHADLISTSIZE>& secondaryParticleVector,
+                                      G4int& secondaryParticleVectorLen) {
   G4int i;
   for (i = 0; i < secondaryParticleVectorLen; ++i) {
     G4ThreeVector momentum = secondaryParticleVector[i]->GetMomentum();


### PR DESCRIPTION


#### PR description:

#### This PR is a result of continued work from the [previous FullModelHadronic.cc PR.](https://github.com/cms-sw/cmssw/pull/46728) In an attempt to check if other bugs existed, we first had to understand how the file simulated hadronic interactions. This led to many quality changes such as the removal of unneeded blocks of code and the changing of variable names. The final result was the discovery of three minor bugs, whose impact is thankfully no where near the magnitude of the bug from the aforementioned previous PR. A talk on this matter will be given during the [June 27th long-lived exotica meeting.](https://indico.cern.ch/event/1558290/#17-update-on-r-hadron-g4-inter)

#### We would like for a new release to be cut.

- **Bug fix:** Corrected the usage of G4LorentzVector from (p, m) to (p, E)
    - Lines 79, 81 in update
- **Bug fix:** Corrected the energy deposit magnitude to be the total change in energy of the cloud particle
    - Line 211 in update
- **Bug fix:** Corrected the momentum to update in magnitude, not just direction, when the custom particle does not change in type
    - Line 242 in update
- **Quality change:** Removed unneeded lines of code, notably:
    - Lines 434 through 476 in previous version. It mentions histogram filling, however no histograms are actually filled and all of the variables are unused. Removing this section also removes unnecessary variables defined earlier in the code.
    - Lines 654 through 672 in previous version. The `FindRhadron` function is only used in the aforementioned histogram filling section. It is not used anywhere else in CMSSW and so this function was removed too.
    - Lines 517 through 540 in previous version.  The `if` statement at line 522 does not check for annihilation properly, as expected from the comment in line 524. Additionally, in 10,000 gluino R-Hadron events this if statement never passed.
    - Lines 541 through 566 in previous version. Again, this `if` statement never passed in 10,000 gluino R-Hadron events. The complicated and infrequent nature of this block of code led us to remove it.
- **Quality change:** Cleaned up the code format and variable names for ease of understanding in the future

#### PR validation:

Verified that the PR passes the basic test procedure suggested below with the following output:

```bash
4.22_RunCosmics2011A Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Tue Jun 24 02:56:36 2025-date Tue Jun 24 02:49:59 2025; exit: 0 0 0 0 0
4.53_RunPhoton2012B Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Tue Jun 24 03:02:42 2025-date Tue Jun 24 02:49:59 2025; exit: 0 0 0 0
5.1_TTbarFS Step0-PASSED Step1-PASSED  - time date Tue Jun 24 03:00:54 2025-date Tue Jun 24 02:50:00 2025; exit: 0 0
7.3_CosmicsSPLoose2018 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Tue Jun 24 02:56:36 2025-date Tue Jun 24 02:50:00 2025; exit: 0 0 0 0 0
8.0_BeamHalo Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Tue Jun 24 03:00:27 2025-date Tue Jun 24 02:56:36 2025; exit: 0 0 0 0 0
9.0_Higgs200ChargedTaus Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Tue Jun 24 03:04:53 2025-date Tue Jun 24 02:56:37 2025; exit: 0 0 0 0
25.0_TTbar Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Tue Jun 24 03:10:20 2025-date Tue Jun 24 03:00:27 2025; exit: 0 0 0 0 0
135.4_ZEEFS_13 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Tue Jun 24 03:06:17 2025-date Tue Jun 24 03:00:55 2025; exit: 0 0 0 0
136.731_RunSinglePh2016B Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Tue Jun 24 03:12:56 2025-date Tue Jun 24 03:02:42 2025; exit: 0 0 0 0
136.7611_RunJetHT2016EreMINIAOD Step0-PASSED Step1-PASSED Step2-PASSED  - time date Tue Jun 24 03:08:19 2025-date Tue Jun 24 03:04:54 2025; exit: 0 0 0
136.793_RunDoubleEG2017C Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Tue Jun 24 03:19:23 2025-date Tue Jun 24 03:06:17 2025; exit: 0 0 0 0
136.8311_RunJetHT2017FreMINIAOD Step0-PASSED Step1-PASSED Step2-PASSED  - time date Tue Jun 24 03:11:47 2025-date Tue Jun 24 03:08:20 2025; exit: 0 0 0
136.874_RunEGamma2018C Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Tue Jun 24 03:25:41 2025-date Tue Jun 24 03:10:20 2025; exit: 0 0 0 0
136.88811_RunJetHT2018DreMINIAODUL Step0-PASSED Step1-PASSED Step2-PASSED  - time date Tue Jun 24 03:15:09 2025-date Tue Jun 24 03:11:48 2025; exit: 0 0 0
139.001_RunMinimumBias2021 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Tue Jun 24 03:18:20 2025-date Tue Jun 24 03:12:56 2025; exit: 0 0 0 0
140.023_RunZeroBias2022B Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Tue Jun 24 03:24:20 2025-date Tue Jun 24 03:15:10 2025; exit: 0 0 0 0
140.043_RunZeroBias2022C Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Tue Jun 24 03:28:34 2025-date Tue Jun 24 03:18:21 2025; exit: 0 0 0 0
140.063_RunZeroBias2022D Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Tue Jun 24 03:31:19 2025-date Tue Jun 24 03:19:24 2025; exit: 0 0 0 0
140.56_RunHI2018 Step0-PASSED Step1-PASSED Step2-PASSED  - time date Tue Jun 24 03:37:46 2025-date Tue Jun 24 03:24:20 2025; exit: 0 0 0
141.042_RunZeroBias2023D Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Tue Jun 24 03:42:55 2025-date Tue Jun 24 03:25:42 2025; exit: 0 0 0 0
141.044_RunJetMET2023D Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Tue Jun 24 03:54:05 2025-date Tue Jun 24 03:28:34 2025; exit: 0 0 0 0
141.046_RunEGamma2023D Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Tue Jun 24 03:55:51 2025-date Tue Jun 24 03:31:20 2025; exit: 0 0 0 0
158.01_HydjetQB12ppRECOin2018reMINIAOD Step0-PASSED Step1-PASSED Step2-PASSED  - time date Tue Jun 24 03:40:32 2025-date Tue Jun 24 03:37:47 2025; exit: 0 0 0
1306.0_SingleMuPt1_UP15 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Tue Jun 24 03:44:34 2025-date Tue Jun 24 03:40:33 2025; exit: 0 0 0 0
1330.0_ZMM_13 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Tue Jun 24 03:47:55 2025-date Tue Jun 24 03:42:56 2025; exit: 0 0 0 0 0
101.0_SingleElectronE120EHCAL Step0-PASSED  - time date Tue Jun 24 03:45:32 2025-date Tue Jun 24 03:44:34 2025; exit: 0
312.0_Pyquen_ZeemumuJets_pt10_2760GeV_2022 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Tue Jun 24 03:51:01 2025-date Tue Jun 24 03:45:32 2025; exit: 0 0 0 0
25202.0_TTbar_13 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Tue Jun 24 03:55:46 2025-date Tue Jun 24 03:47:56 2025; exit: 0 0 0 0 0
1000.0_RunMinBias2011A Step0-PASSED Step1-PASSED Step2-FAILED Step3-NOTRUN Step4-NOTRUN  - time date Tue Jun 24 03:54:41 2025-date Tue Jun 24 03:51:02 2025; exit: 0 0 22016 0 0
1001.0_RunMinBias2011A Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED Step5-PASSED Step6-PASSED Step7-PASSED Step8-PASSED Step9-PASSED Step10-PASSED  - time date Tue Jun 24 04:02:30 2025-date Tue Jun 24 03:54:06 2025; exit: 0 0 0 0 0 0 0 0 0 0 0
11634.0_TTbar_14TeV+2021 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Tue Jun 24 04:00:19 2025-date Tue Jun 24 03:54:41 2025; exit: 0 0 0 0 0
12434.0_TTbar_14TeV+2023 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Tue Jun 24 04:01:15 2025-date Tue Jun 24 03:55:47 2025; exit: 0 0 0 0 0
12834.0_TTbar_14TeV+2024 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Tue Jun 24 04:03:02 2025-date Tue Jun 24 03:55:51 2025; exit: 0 0 0 0 0
12834.7_TTbar_14TeV+2024_trackingMkFit Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Tue Jun 24 04:07:19 2025-date Tue Jun 24 04:00:19 2025; exit: 0 0 0 0
12846.0_ZEE_14+2024 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Tue Jun 24 04:08:50 2025-date Tue Jun 24 04:01:16 2025; exit: 0 0 0 0 0
13034.0_TTbar_14TeV+2024PU Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Tue Jun 24 04:17:19 2025-date Tue Jun 24 04:02:30 2025; exit: 0 0 0 0
13234.0_TTbar_14TeV+2021FS Step0-PASSED Step1-PASSED Step2-PASSED  - time date Tue Jun 24 04:09:08 2025-date Tue Jun 24 04:03:03 2025; exit: 0 0 0
14034.0_TTbar_14TeV+2023FS Step0-PASSED Step1-PASSED Step2-PASSED  - time date Tue Jun 24 04:13:29 2025-date Tue Jun 24 04:07:20 2025; exit: 0 0 0
14234.0_TTbar_14TeV+2023FSPU Step0-PASSED Step1-PASSED Step2-PASSED  - time date Tue Jun 24 04:18:07 2025-date Tue Jun 24 04:08:50 2025; exit: 0 0 0
23234.0_TTbar_14TeV+2026D94 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Tue Jun 24 04:25:07 2025-date Tue Jun 24 04:09:09 2025; exit: 0 0 0 0 0
24834.0_TTbar_14TeV+2026D98 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Tue Jun 24 04:25:08 2025-date Tue Jun 24 04:13:30 2025; exit: 0 0 0 0 0
24834.911_TTbar_14TeV+2026D98_DD4hep Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Tue Jun 24 04:43:20 2025-date Tue Jun 24 04:17:19 2025; exit: 0 0 0 0 0
24896.0_CloseByPGun_CE_E_Front_120um+2026D98 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Tue Jun 24 04:26:35 2025-date Tue Jun 24 04:18:08 2025; exit: 0 0 0 0 0
24900.0_CloseByPGun_CE_H_Coarse_Scint+2026D98 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Tue Jun 24 04:33:25 2025-date Tue Jun 24 04:25:07 2025; exit: 0 0 0 0 0
25034.999_TTbar_14TeV+2026D98PU_PMXS1S2PR Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Tue Jun 24 04:40:23 2025-date Tue Jun 24 04:25:08 2025; exit: 0 0 0 0 0
250202.181_TTbar13TeVPUppmx2018 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Tue Jun 24 04:44:11 2025-date Tue Jun 24 04:26:35 2025; exit: 0 0 0 0 0
2500.4_NANOmc132X Step0-PASSED Step1-PASSED Step2-PASSED  - time date Tue Jun 24 04:44:35 2025-date Tue Jun 24 04:33:26 2025; exit: 0 0 0
47 46 44 35 18 1 1 1 1 1 1 tests passed, 0 0 1 0 0 0 0 0 0 0 0 failed
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

<!-- Please delete the text above after you verified all points of the checklist  -->
