### PR TITLE
New HLT Scouting DQM Online Client

### DIFF
--- a/DQM/HLTEvF/python/ScoutingJetMonitoring_cff.py
+++ b/DQM/HLTEvF/python/ScoutingJetMonitoring_cff.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+## See DQMOffline/HLTScouting/python/HLTScoutingDqmOffline_cff.py
+
+from DQMOffline.JetMET.jetMETDQMOfflineSource_cff import *
+
+
+jetDQMOnlineAnalyzerAk4ScoutingCleaned = jetDQMAnalyzerAk4ScoutingCleaned.clone()
+jetDQMOnlineAnalyzerAk4ScoutingUncleaned = jetDQMAnalyzerAk4ScoutingUncleaned.clone()
+
+jetDQMOnlineAnalyzerSequenceScouting = cms.Sequence(jetDQMOnlineAnalyzerAk4ScoutingUncleaned*jetDQMOnlineAnalyzerAk4ScoutingCleaned)
+
+ScoutingJetMonitoring = cms.Sequence(jetPreDQMSeqScouting*
+                                      dqmAk4PFScoutingL1FastL2L3ResidualCorrectorChain*
+                                      jetDQMOnlineAnalyzerSequenceScouting)

--- a/DQM/HLTEvF/python/ScoutingJetMonitoring_cff.py
+++ b/DQM/HLTEvF/python/ScoutingJetMonitoring_cff.py
@@ -5,23 +5,23 @@ import FWCore.ParameterSet.Config as cms
 from DQMOffline.JetMET.jetMETDQMOfflineSource_cff import *
 
 jetDQMOnlineAnalyzerAk4ScoutingCleaned = jetDQMAnalyzerAk4ScoutingCleaned.clone(
-    DCSFilterForJetMonitoring = cms.PSet(
-        DetectorTypes = cms.untracked.string("ecal:hbhe:hf:pixel:sistrip:es:muon"),
-        onlineMetaDataDigisSrc =  cms.untracked.InputTag("hltOnlineMetaDataDigis"),
-        DebugOn = cms.untracked.bool(False),
-        alwaysPass = cms.untracked.bool(False)
-    )
-)
-jetDQMOnlineAnalyzerAk4ScoutingUncleaned = jetDQMAnalyzerAk4ScoutingUncleaned.clone(
-    DCSFilterForJetMonitoring = cms.PSet(
-      DetectorTypes = cms.untracked.string("ecal:hbhe:hf:pixel:sistrip:es:muon"),
-        onlineMetaDataDigisSrc =  cms.untracked.InputTag("hltOnlineMetaDataDigis"),
-        DebugOn = cms.untracked.bool(False),
-        alwaysPass = cms.untracked.bool(False)
-    )
+    JetType='scoutingOnline',
+    DCSFilterForJetMonitoring=dict(DetectorTypes = "ecal:hbhe:hf:pixel:sistrip:es:muon",
+                                   onlineMetaDataDigisSrc = cms.untracked.InputTag("hltOnlineMetaDataDigis"),
+                                   DebugOn = cms.untracked.bool(False),
+                                   alwaysPass = False)
 )
 
-jetDQMOnlineAnalyzerSequenceScouting = cms.Sequence(jetDQMOnlineAnalyzerAk4ScoutingUncleaned*jetDQMOnlineAnalyzerAk4ScoutingCleaned)
+jetDQMOnlineAnalyzerAk4ScoutingUncleaned = jetDQMAnalyzerAk4ScoutingUncleaned.clone(
+    JetType='scoutingOnline',
+    DCSFilterForJetMonitoring=dict(DetectorTypes = "ecal:hbhe:hf:pixel:sistrip:es:muon",
+                                   onlineMetaDataDigisSrc = cms.untracked.InputTag("hltOnlineMetaDataDigis"),
+                                   DebugOn =  cms.untracked.bool(False),
+                                   alwaysPass = False)
+)
+
+jetDQMOnlineAnalyzerSequenceScouting = cms.Sequence(jetDQMOnlineAnalyzerAk4ScoutingUncleaned*
+                                                    jetDQMOnlineAnalyzerAk4ScoutingCleaned)
 
 ScoutingJetMonitoring = cms.Sequence(jetPreDQMSeqScouting*
                                      dqmAk4PFScoutingL1FastL2L3ResidualCorrectorChain*

--- a/DQM/HLTEvF/python/ScoutingJetMonitoring_cff.py
+++ b/DQM/HLTEvF/python/ScoutingJetMonitoring_cff.py
@@ -4,12 +4,25 @@ import FWCore.ParameterSet.Config as cms
 
 from DQMOffline.JetMET.jetMETDQMOfflineSource_cff import *
 
-
-jetDQMOnlineAnalyzerAk4ScoutingCleaned = jetDQMAnalyzerAk4ScoutingCleaned.clone()
-jetDQMOnlineAnalyzerAk4ScoutingUncleaned = jetDQMAnalyzerAk4ScoutingUncleaned.clone()
+jetDQMOnlineAnalyzerAk4ScoutingCleaned = jetDQMAnalyzerAk4ScoutingCleaned.clone(
+    DCSFilterForJetMonitoring = cms.PSet(
+        DetectorTypes = cms.untracked.string("ecal:hbhe:hf:pixel:sistrip:es:muon"),
+        onlineMetaDataDigisSrc =  cms.untracked.InputTag("hltOnlineMetaDataDigis"),
+        DebugOn = cms.untracked.bool(False),
+        alwaysPass = cms.untracked.bool(False)
+    )
+)
+jetDQMOnlineAnalyzerAk4ScoutingUncleaned = jetDQMAnalyzerAk4ScoutingUncleaned.clone(
+    DCSFilterForJetMonitoring = cms.PSet(
+      DetectorTypes = cms.untracked.string("ecal:hbhe:hf:pixel:sistrip:es:muon"),
+        onlineMetaDataDigisSrc =  cms.untracked.InputTag("hltOnlineMetaDataDigis"),
+        DebugOn = cms.untracked.bool(False),
+        alwaysPass = cms.untracked.bool(False)
+    )
+)
 
 jetDQMOnlineAnalyzerSequenceScouting = cms.Sequence(jetDQMOnlineAnalyzerAk4ScoutingUncleaned*jetDQMOnlineAnalyzerAk4ScoutingCleaned)
 
 ScoutingJetMonitoring = cms.Sequence(jetPreDQMSeqScouting*
-                                      dqmAk4PFScoutingL1FastL2L3ResidualCorrectorChain*
-                                      jetDQMOnlineAnalyzerSequenceScouting)
+                                     dqmAk4PFScoutingL1FastL2L3ResidualCorrectorChain*
+                                     jetDQMOnlineAnalyzerSequenceScouting)

--- a/DQM/HLTEvF/python/ScoutingMuonMonitoring_cff.py
+++ b/DQM/HLTEvF/python/ScoutingMuonMonitoring_cff.py
@@ -1,0 +1,13 @@
+import FWCore.ParameterSet.Config as cms
+
+## See DQMOffline/HLTScouting/python/HLTScoutingDqmOffline_cff.py
+
+from HLTriggerOffline.Scouting.ScoutingMuonTriggerAnalyzer_cfi import ScoutingMuonTriggerAnalysis_DoubleMu, ScoutingMuonTriggerAnalysis_SingleMu
+from HLTriggerOffline.Scouting.ScoutingMuonTagProbeAnalyzer_cfi import ScoutingMuonTagProbeAnalysisNoVtx, ScoutingMuonTagProbeAnalysisVtx
+
+ScoutingMuonTagProbeAnalysisNoVtxOnline = ScoutingMuonTagProbeAnalysisNoVtx.clone(OutputInternalPath = "/HLT/ScoutingOnline/Muons/NoVtx")
+ScoutingMuonTagProbeAnalysisVtxOnline = ScoutingMuonTagProbeAnalysisVtx.clone(OutputInternalPath = "/HLT/ScoutingOnline/Muons/Vtx")
+ScoutingMuonTriggerAnalysis_DoubleMu = ScoutingMuonTriggerAnalysis_DoubleMu.clone(OutputInternalPath = "/HLT/ScoutingOnline/Muons/L1Efficiency/DoubleMu")
+ScoutingMuonTriggerAnalysis_SingleMu = ScoutingMuonTriggerAnalysis_SingleMu.clone(OutputInternalPath = "/HLT/ScoutingOnline/Muons/L1Efficiency/SingleMu")
+
+ScoutingMuonMonitoring = cms.Sequence( ScoutingMuonTagProbeAnalysisNoVtxOnline + ScoutingMuonTagProbeAnalysisVtxOnline + ScoutingMuonTriggerAnalysis_DoubleMu + ScoutingMuonTriggerAnalysis_SingleMu ) 

--- a/DQM/HLTEvF/python/ScoutingMuonMonitoring_cff.py
+++ b/DQM/HLTEvF/python/ScoutingMuonMonitoring_cff.py
@@ -10,4 +10,4 @@ ScoutingMuonTagProbeAnalysisVtxOnline = ScoutingMuonTagProbeAnalysisVtx.clone(Ou
 ScoutingMuonTriggerAnalysis_DoubleMu = ScoutingMuonTriggerAnalysis_DoubleMu.clone(OutputInternalPath = "/HLT/ScoutingOnline/Muons/L1Efficiency/DoubleMu")
 ScoutingMuonTriggerAnalysis_SingleMu = ScoutingMuonTriggerAnalysis_SingleMu.clone(OutputInternalPath = "/HLT/ScoutingOnline/Muons/L1Efficiency/SingleMu")
 
-ScoutingMuonMonitoring = cms.Sequence( ScoutingMuonTagProbeAnalysisNoVtxOnline + ScoutingMuonTagProbeAnalysisVtxOnline + ScoutingMuonTriggerAnalysis_DoubleMu + ScoutingMuonTriggerAnalysis_SingleMu ) 
+ScoutingMuonMonitoring = cms.Sequence( ScoutingMuonTagProbeAnalysisNoVtxOnline + ScoutingMuonTagProbeAnalysisVtxOnline + ScoutingMuonTriggerAnalysis_DoubleMu + ScoutingMuonTriggerAnalysis_SingleMu )

--- a/DQM/Integration/python/clients/scouting_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/scouting_dqm_sourceclient-live_cfg.py
@@ -1,0 +1,56 @@
+import FWCore.ParameterSet.Config as cms
+
+import sys
+if 'runkey=hi_run' in sys.argv:
+  from Configuration.Eras.Era_Run3_pp_on_PbPb_approxSiStripClusters_cff import Run3_pp_on_PbPb_approxSiStripClusters
+  process = cms.Process("DQM", Run3_pp_on_PbPb_approxSiStripClusters)
+else:
+  from Configuration.Eras.Era_Run3_2025_cff import Run3_2025
+  process = cms.Process("DQM", Run3_2025)
+
+unitTest = False
+if 'unitTest=True' in sys.argv:
+	unitTest=True
+
+if unitTest:
+  process.load("DQM.Integration.config.unittestinputsource_cfi")
+  from DQM.Integration.config.unittestinputsource_cfi import options
+else:
+  process.load("DQM.Integration.config.inputsource_cfi")
+  from DQM.Integration.config.inputsource_cfi import options
+
+  if not options.inputFiles:
+      process.source.streamLabel = "streamDQMOnlineScouting"
+
+process.load("DQM.Integration.config.environment_cfi")
+
+process.dqmEnv.subSystemFolder = 'ScoutingDQM'
+process.dqmSaver.tag = 'ScoutingDQM'
+process.dqmSaver.runNumber = options.runNumber
+# process.dqmSaverPB.tag = 'ScoutingDQM'
+# process.dqmSaverPB.runNumber = options.runNumber
+
+process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
+process.load("Configuration.StandardSequences.MagneticField_cff")
+
+#---- for P5 (online) DB access
+process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
+# Condition for lxplus: change and possibly customise the GT
+#from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
+#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run3_data', '')
+
+
+### for pp collisions
+process.load("DQM.HLTEvF.ScoutingCollectionMonitor_cfi")
+process.scoutingCollectionMonitor.topfoldername = "ScoutingDQM/"
+process.scoutingCollectionMonitor.onlyScouting = True
+process.dqmcommon = cms.Sequence(process.dqmEnv
+                               * process.dqmSaver)#*process.dqmSaverPB)
+
+process.p = cms.Path(process.dqmcommon * process.scoutingCollectionMonitor)
+
+### process customizations included here
+from DQM.Integration.config.online_customizations_cfi import *
+process = customise(process)
+print("Global Tag used:", process.GlobalTag.globaltag.value())
+print("Final Source settings:", process.source)

--- a/DQM/Integration/python/clients/scouting_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/scouting_dqm_sourceclient-live_cfg.py
@@ -13,8 +13,9 @@ if 'unitTest=True' in sys.argv:
 	unitTest=True
 
 if unitTest:
-  process.load("DQM.Integration.config.unittestinputsource_cfi")
-  from DQM.Integration.config.unittestinputsource_cfi import options
+  process.load("DQM.Integration.config.unitteststreamerinputsource_cfi")
+  from DQM.Integration.config.unitteststreamerinputsource_cfi import options
+  process.source.streamLabel = 'streamDQMOnlineScouting'
 else:
   process.load("DQM.Integration.config.inputsource_cfi")
   from DQM.Integration.config.inputsource_cfi import options

--- a/DQM/Integration/python/clients/scouting_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/scouting_dqm_sourceclient-live_cfg.py
@@ -43,7 +43,7 @@ process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 
 ### for pp collisions
 process.load("DQM.HLTEvF.ScoutingCollectionMonitor_cfi")
-process.scoutingCollectionMonitor.topfoldername = "ScoutingDQM/"
+process.scoutingCollectionMonitor.topfoldername = "HLT/ScoutingOnline/Miscellaneous"
 process.scoutingCollectionMonitor.onlyScouting = True
 process.scoutingCollectionMonitor.rho = ["hltScoutingPFPacker", "rho"]
 process.dqmcommon = cms.Sequence(process.dqmEnv

--- a/DQM/Integration/python/clients/scouting_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/scouting_dqm_sourceclient-live_cfg.py
@@ -44,10 +44,22 @@ process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 process.load("DQM.HLTEvF.ScoutingCollectionMonitor_cfi")
 process.scoutingCollectionMonitor.topfoldername = "ScoutingDQM/"
 process.scoutingCollectionMonitor.onlyScouting = True
+process.scoutingCollectionMonitor.rho = ["hltScoutingPFPacker", "rho"]
 process.dqmcommon = cms.Sequence(process.dqmEnv
                                * process.dqmSaver)#*process.dqmSaverPB)
 
-process.p = cms.Path(process.dqmcommon * process.scoutingCollectionMonitor)
+process.load("DQM.HLTEvF.ScoutingMuonMonitoring_cff")
+process.load("DQM.HLTEvF.ScoutingJetMonitoring_cff")
+
+## Run-1 L1TGT required by ScoutingJetMonitoring https://github.com/cms-sw/cmssw/blob/master/DQMOffline/JetMET/src/JetAnalyzer.cc#L2603-L2611
+process.GlobalTag.toGet.append(
+ cms.PSet(
+ record = cms.string("L1GtTriggerMenuRcd"),
+ tag = cms.string('L1GtTriggerMenu_CRAFT09_hlt'),
+ )
+)
+
+process.p = cms.Path(process.dqmcommon * process.scoutingCollectionMonitor * process.ScoutingMuonMonitoring * process.ScoutingJetMonitoring)
 
 ### process customizations included here
 from DQM.Integration.config.online_customizations_cfi import *

--- a/DQM/Integration/python/config/unittestinputsource_cfi.py
+++ b/DQM/Integration/python/config/unittestinputsource_cfi.py
@@ -122,6 +122,8 @@ source = cms.Source ("PoolSource",
                        'drop *',
                        'keep FEDRawDataCollection_rawDataCollector_*_*',
                        'keep GlobalObjectMapRecord_hltGtStage2ObjectMap_*_*',
+                       'keep Run3Scouting*_*_*_*',
+                       'keep double_hltScoutingPFPacker_*_*',
                        'keep edmTriggerResults_TriggerResults_*_*'
                      ),
                      dropDescendantsOfDroppedBranches = cms.untracked.bool(True)

--- a/DQM/Integration/test/BuildFile.xml
+++ b/DQM/Integration/test/BuildFile.xml
@@ -14,7 +14,7 @@
 <test name="TestDQMOnlineClient-hlt_dqm_clientPB" command="runtest.sh hlt_dqm_clientPB-live_cfg.py"/>
 <test name="TestDQMOnlineClient-hlt_dqm_sourceclient" command="runtest.sh hlt_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-ngt_dqm_sourceclient" command="runtest.sh ngt_dqm_sourceclient-live_cfg.py"/>
-<test name="TestDQMOnlineClient-scouting_dqm_sourceclient" command="runtest.sh scouting_dqm_sourceclient-live_cfg.py"/>
+<test name="TestDQMOnlineClient-scouting_dqm_sourceclient" command="runtest.sh scouting_dqm_sourceclient-live_cfg.py 392642"/>
 <test name="TestDQMOnlineClient-info_dqm_sourceclient" command="runtest.sh info_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-l1tstage2_dqm_sourceclient" command="runtest.sh l1tstage2_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-l1tstage2emulator_dqm_sourceclient" command="runtest.sh l1tstage2emulator_dqm_sourceclient-live_cfg.py"/>

--- a/DQM/Integration/test/BuildFile.xml
+++ b/DQM/Integration/test/BuildFile.xml
@@ -14,6 +14,7 @@
 <test name="TestDQMOnlineClient-hlt_dqm_clientPB" command="runtest.sh hlt_dqm_clientPB-live_cfg.py"/>
 <test name="TestDQMOnlineClient-hlt_dqm_sourceclient" command="runtest.sh hlt_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-ngt_dqm_sourceclient" command="runtest.sh ngt_dqm_sourceclient-live_cfg.py"/>
+<test name="TestDQMOnlineClient-scouting_dqm_sourceclient" command="runtest.sh scouting_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-info_dqm_sourceclient" command="runtest.sh info_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-l1tstage2_dqm_sourceclient" command="runtest.sh l1tstage2_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-l1tstage2emulator_dqm_sourceclient" command="runtest.sh l1tstage2emulator_dqm_sourceclient-live_cfg.py"/>

--- a/DQMOffline/JetMET/interface/JetAnalyzer.h
+++ b/DQMOffline/JetMET/interface/JetAnalyzer.h
@@ -937,6 +937,8 @@ private:
   bool isPUPPIJet_;
   bool isScoutingJet_;
 
+  bool isOnlineDQM_;
+
   bool fill_jet_high_level_histo;
 
   bool fill_CHS_histos;

--- a/DQMOffline/JetMET/interface/JetMETDQMDCSFilter.h
+++ b/DQMOffline/JetMET/interface/JetMETDQMDCSFilter.h
@@ -18,7 +18,8 @@
 class JetMETDQMDCSFilter {
 public:
   JetMETDQMDCSFilter(const edm::ParameterSet&, edm::ConsumesCollector&);
-  JetMETDQMDCSFilter(const std::string& detectorTypes,
+  JetMETDQMDCSFilter(const edm::ParameterSet&,
+                     const std::string& detectorTypes,
                      edm::ConsumesCollector&,
                      const bool verbose = false,
                      const bool alwaysPass = false);
@@ -35,6 +36,8 @@ private:
   bool verbose_;
   bool filter_;
   bool detectorOn_;
+  edm::InputTag scalersSrc_;
+  edm::InputTag onlineMetaDataDigiSrc_;
   std::string detectorTypes_;
   std::map<std::string, std::vector<int>> associationMap_;
   std::map<std::string, bool> passPerDet_;

--- a/DQMOffline/JetMET/src/JetAnalyzer.cc
+++ b/DQMOffline/JetMET/src/JetAnalyzer.cc
@@ -238,7 +238,8 @@ JetAnalyzer::JetAnalyzer(const edm::ParameterSet& pSet)
   // ==========================================================
   edm::ConsumesCollector iC = consumesCollector();
   DCSFilterForJetMonitoring_ = new JetMETDQMDCSFilter(pSet.getParameter<ParameterSet>("DCSFilterForJetMonitoring"), iC);
-  DCSFilterForDCSMonitoring_ = new JetMETDQMDCSFilter("ecal:hbhe:hf:ho:pixel:sistrip:es:muon", iC);
+  DCSFilterForDCSMonitoring_ = new JetMETDQMDCSFilter(
+      pSet.getParameter<ParameterSet>("DCSFilterForJetMonitoring"), "ecal:hbhe:hf:ho:pixel:sistrip:es:muon", iC);
 
   //Trigger selectoin
   edm::ParameterSet highptjetparms = pSet.getParameter<edm::ParameterSet>("highPtJetTrigger");

--- a/DQMOffline/JetMET/src/JetAnalyzer.cc
+++ b/DQMOffline/JetMET/src/JetAnalyzer.cc
@@ -82,9 +82,11 @@ JetAnalyzer::JetAnalyzer(const edm::ParameterSet& pSet)
   //isJPTJet_  = (std::string("jpt") ==jetType_);
   isPFJet_ = (std::string("pf") == jetType_);
   isPUPPIJet_ = (std::string("puppi") == jetType_);
-  isScoutingJet_ = (std::string("scouting") == jetType_);
+  isScoutingJet_ = (jetType_.find("scouting") != std::string::npos);
   isMiniAODJet_ = (std::string("miniaod") == jetType_);
   jetCorrectorTag_ = pSet.getParameter<edm::InputTag>("JetCorrections");
+
+  isOnlineDQM_ = (jetType_.find("Online") != std::string::npos);
 
   if (!isMiniAODJet_) {  //in MiniAOD jet is already corrected
     jetCorrectorToken_ = consumes<reco::JetCorrector>(jetCorrectorTag_);
@@ -313,12 +315,14 @@ JetAnalyzer::~JetAnalyzer() {
 // ***********************************************************
 void JetAnalyzer::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun, edm::EventSetup const&) {
   if (isScoutingJet_) {
+    std::string baseDir = isOnlineDQM_ ? "HLT/ScoutingOnline/Jet/" : "HLT/ScoutingOffline/Jet/";
+
     if (jetCleaningFlag_) {
-      ibooker.setCurrentFolder("HLT/ScoutingOffline/Jet/Cleaned" + mInputCollection_.label());
-      DirName = "HLT/ScoutingOffline/Jet/Cleaned" + mInputCollection_.label();
+      ibooker.setCurrentFolder(baseDir + "Cleaned" + mInputCollection_.label());
+      DirName = baseDir + "Cleaned" + mInputCollection_.label();
     } else {
-      ibooker.setCurrentFolder("HLT/ScoutingOffline/Jet/Uncleaned" + mInputCollection_.label());
-      DirName = "HLT/ScoutingOffline/Jet/Uncleaned" + mInputCollection_.label();
+      ibooker.setCurrentFolder(baseDir + "Uncleaned" + mInputCollection_.label());
+      DirName = baseDir + "Uncleaned" + mInputCollection_.label();
     }
   } else {
     if (jetCleaningFlag_) {
@@ -2615,10 +2619,12 @@ void JetAnalyzer::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetu
 void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   //set general folders first --> change later on for different folders
   if (isScoutingJet_) {
+    std::string baseDir = isOnlineDQM_ ? "HLT/ScoutingOnline/Jet/" : "HLT/ScoutingOffline/Jet/";
+
     if (jetCleaningFlag_) {
-      DirName = "HLT/ScoutingOffline/Jet/Cleaned" + mInputCollection_.label();
+      DirName = baseDir + "Cleaned" + mInputCollection_.label();
     } else {
-      DirName = "HLT/ScoutingOffline/Jet/Uncleaned" + mInputCollection_.label();
+      DirName = baseDir + "Uncleaned" + mInputCollection_.label();
     }
   } else {
     if (jetCleaningFlag_) {

--- a/DQMOffline/JetMET/src/JetMETDQMDCSFilter.cc
+++ b/DQMOffline/JetMET/src/JetMETDQMDCSFilter.cc
@@ -15,30 +15,41 @@ JetMETDQMDCSFilter::JetMETDQMDCSFilter(const edm::ParameterSet& pset, edm::Consu
   verbose_ = pset.getUntrackedParameter<bool>("DebugOn", false);
   detectorTypes_ = pset.getUntrackedParameter<std::string>("DetectorTypes", "ecal:hcal");
   filter_ = !pset.getUntrackedParameter<bool>("alwaysPass", false);
-  scalarsToken_ = iC.consumes<DcsStatusCollection>(std::string("scalersRawToDigi"));
-  dcsRecordToken_ = iC.consumes<DCSRecord>(std::string("onlineMetaDataDigis"));
+  scalersSrc_ = pset.getUntrackedParameter<edm::InputTag>("scalerSrc", edm::InputTag("scalersRawToDigi"));
+  onlineMetaDataDigiSrc_ =
+      pset.getUntrackedParameter<edm::InputTag>("onlineMetaDataDigisSrc", edm::InputTag("onlineMetaDataDigis"));
+  scalarsToken_ = iC.consumes<DcsStatusCollection>(scalersSrc_);
+  dcsRecordToken_ = iC.consumes<DCSRecord>(onlineMetaDataDigiSrc_);
 
   detectorOn_ = false;
   if (verbose_)
-    edm::LogPrint("JetMETDQMDCSFilter") << " constructor: " << detectorTypes_ << std::endl;
+    edm::LogPrint("JetMETDQMDCSFilter") << " constructor: " << detectorTypes_
+                                        << " onlineMetaDataSource: " << onlineMetaDataDigiSrc_.encode() << std::endl;
 
   // initialize variables
   initializeVars();
 }
 
-JetMETDQMDCSFilter::JetMETDQMDCSFilter(const std::string& detectorTypes,
+JetMETDQMDCSFilter::JetMETDQMDCSFilter(const edm::ParameterSet& pset,
+                                       const std::string& detectorTypes,
                                        edm::ConsumesCollector& iC,
                                        const bool verbose,
                                        const bool alwaysPass) {
   verbose_ = verbose;
   detectorTypes_ = detectorTypes;
   filter_ = !alwaysPass;
-  scalarsToken_ = iC.consumes<DcsStatusCollection>(std::string("scalersRawToDigi"));
-  dcsRecordToken_ = iC.consumes<DCSRecord>(std::string("onlineMetaDataDigis"));
+
+  scalersSrc_ = pset.getUntrackedParameter<edm::InputTag>("scalerSrc", edm::InputTag("scalersRawToDigi"));
+  onlineMetaDataDigiSrc_ =
+      pset.getUntrackedParameter<edm::InputTag>("onlineMetaDataDigisSrc", edm::InputTag("onlineMetaDataDigis"));
+
+  scalarsToken_ = iC.consumes<DcsStatusCollection>(scalersSrc_);
+  dcsRecordToken_ = iC.consumes<DCSRecord>(onlineMetaDataDigiSrc_);
 
   detectorOn_ = false;
   if (verbose_)
-    edm::LogPrint("JetMETDQMDCSFilter") << " constructor: " << detectorTypes_ << std::endl;
+    edm::LogPrint("JetMETDQMDCSFilter") << " constructor with no pset: " << detectorTypes_
+                                        << " onlineMetaDataSource: " << onlineMetaDataDigiSrc_.encode() << std::endl;
 
   // initialize variables
   initializeVars();


### PR DESCRIPTION
#### PR description:

Following the discussion at [CMSHLT-3571](https://its.cern.ch/jira/browse/CMSHLT-3571) and last weeks [HLT Scouting meeting ](https://indico.cern.ch/event/1557799/contributions/6560416/attachments/3089825/5471885/ScoutingMeeting_2025June19.pdf), we are introducing a new HLT Scouting DQM online client to include the new `DQMOnlineScouting`stream. We are adding the client and adapting BuildFile.xml to include unit testing for the new client as well.

#### PR validation:

This PR has been prepared starting from `CMSSW_15_1_X_2025-06-23-2300 `:
```
cmsrel CMSSW_15_1_X_2025-06-23-2300 
cd CMSSW_15_1_X_2025-06-23-2300/src
cmsenv
git cms-init
git cms-addpkg DQM/Integration DQM/HLTEvF
```

Running `git cms-checkdeps -a -A` shows that there are no further dependencies. For validation, I ran:
```
scram b
scram b code-checks
scram b code-format
scram b
```

What is left to do is to validate the online DQM client by running it on a `DQMOnlineScouting` file from the new stream !



This is not backport but it will be backported to 15.0.X for 2025 data taking operations.
