### PR TITLE
[15.0.X] Fix in broken-line fit (mainly relevant for phase-2)

### DIFF
--- a/RecoTracker/PixelTrackFitting/interface/alpaka/BrokenLine.h
+++ b/RecoTracker/PixelTrackFitting/interface/alpaka/BrokenLine.h
@@ -495,8 +495,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::brokenline {
       vMat(2, 1) = vMat(1, 2) = hits_ge.col(i)[4];  // cov_yz
       vMat(2, 2) = hits_ge.col(i)[5];               // z errors
       auto tmp = 1. / radii.block(0, i, 2, 1).norm();
-      jacobXYZtosZ(0, 0) = radii(1, i) * tmp;
-      jacobXYZtosZ(0, 1) = -radii(0, i) * tmp;
+      jacobXYZtosZ(0, 0) = data.qCharge * radii(1, i) * tmp;
+      jacobXYZtosZ(0, 1) = -data.qCharge * radii(0, i) * tmp;
       jacobXYZtosZ(1, 2) = 1.;
       weights(i) = 1. / ((rotMat * jacobXYZtosZ * vMat * jacobXYZtosZ.transpose() * rotMat.transpose())(
                             1, 1));  // compute the orthogonal weight point by point


### PR DESCRIPTION
### PR description:

**Backport of #48401**

As per title.
This PR is meant to fix a bug in the broken-line fit implementation that is mainly relevant for phase-2, with tilted modules when pixel ntuplets are extended to the outer tracker (aka. phase-2 "CA extension").
This was reported by @JanGerritSchulz and @rovere in:
https://indico.cern.ch/event/1561539/contributions/6577957/attachments/3092112/5477051/HLTUpgradeMeeting_25-06-24.pdf

For phase-1 pixel (HLT) tracking, the impact is expected to be ~zero, and this was confirmed from private tracking validations (see below).
However, we prefer to have a consistent, correct code in the releases in use for phase-1, too.

### PR validation:

No difference (within "usual" GPU-induced fluctuations) is found:
https://uaf-10.t2.ucsd.edu/~mmasciov/TRKPOG/HLT2025/HLT_TTbarPU_fixBrokenLineFit/plots_hlt.html

FYI: @cms-sw/tracking-pog-l2 
