### PR TITLE
Strip overlap check for different product ID

### DIFF
--- a/DataFormats/TrackerRecHit2D/interface/OmniClusterRef.h
+++ b/DataFormats/TrackerRecHit2D/interface/OmniClusterRef.h
@@ -65,6 +65,22 @@ public:
     return rawIndex() < lh.rawIndex();  // in principle this is enough!
   }
 
+  bool const stripOverlap(OmniClusterRef const& lh, bool includeEdges = true) const {
+    if (!isStrip())
+      return false;
+    const auto& tc = stripCluster();
+    const uint16_t tf = tc.firstStrip();
+    const uint16_t tl = tf + tc.amplitudes().size();
+    const auto& oc = lh.stripCluster();
+    const uint16_t of = oc.firstStrip();
+    const uint16_t ol = of + oc.amplitudes().size();
+    // By default, include edge overlaps
+    const auto e = includeEdges ? 1 : 0;
+    // Check that last strip of "other" cluster is within first and last strip of "this", or viceversa
+    // Edge strips are considered for determining overlap (e=1) if includeEdges = true (default)
+    return (((ol + e) > tf && ol < (tl + e)) || ((tl + e) > of && tl < (ol + e)));
+  }
+
 public:
   // edm Ref interface
   /* auto */ edm::ProductID id() const { return me.id(); }

--- a/DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h
@@ -76,10 +76,20 @@ private:
 inline bool sharesClusters(SiStripMatchedRecHit2D const& h1,
                            SiStripMatchedRecHit2D const& h2,
                            TrackingRecHit::SharedInputType what) {
-  bool mono = h1.monoClusterRef() == h2.monoClusterRef();
-  bool stereo = h1.stereoClusterRef() == h2.stereoClusterRef();
+  auto const& thisMonoClus = h1.monoClusterRef();
+  auto const& otherMonoClus = h2.monoClusterRef();
+  auto const& thisStereoClus = h1.stereoClusterRef();
+  auto const& otherStereoClus = h2.stereoClusterRef();
 
-  return (what == TrackingRecHit::all) ? (mono && stereo) : (mono || stereo);
+  if (thisMonoClus.id() == otherMonoClus.id()) {
+    const bool monoIdentity = thisMonoClus == otherMonoClus;
+    const bool stereoIdentity = thisStereoClus == otherStereoClus;
+    return (what == TrackingRecHit::all) ? (monoIdentity && stereoIdentity) : (monoIdentity || stereoIdentity);
+  } else {
+    bool monoOverlap = (h1.monoId() == h2.monoId()) ? otherMonoClus.stripOverlap(thisMonoClus) : false;
+    bool stereoOverlap = (h1.stereoId() == h2.stereoId()) ? otherStereoClus.stripOverlap(thisStereoClus) : false;
+    return (what == TrackingRecHit::all) ? (monoOverlap && stereoOverlap) : (monoOverlap || stereoOverlap);
+  }
 }
 
 #endif

--- a/DataFormats/TrackerRecHit2D/interface/TrackerSingleRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/TrackerSingleRecHit.h
@@ -68,9 +68,15 @@ public:
 
   bool sharesInput(const TrackingRecHit* other, SharedInputType what) const final;
 
-  bool sharesInput(TrackerSingleRecHit const& other) const { return cluster_ == other.cluster_; }
-
-  bool sameCluster(OmniClusterRef const& oh) const { return oh == cluster_; }
+  bool sharesInput(TrackerSingleRecHit const& other) const {
+    //auto const& otherClus = reinterpret_cast<const BaseTrackerRecHit*>(other)->firstClusterRef();
+    if (cluster_.id() == other.cluster_.id())
+      return (cluster_ == other.cluster_);
+    else {
+      const bool sameDetId = (geographicalId() == other.geographicalId());
+      return (sameDetId) ? other.cluster_.stripOverlap(cluster_) : false;
+    }
+  }
 
   std::vector<const TrackingRecHit*> recHits() const override;
   std::vector<TrackingRecHit*> recHits() override;

--- a/DataFormats/TrackerRecHit2D/src/BaseTrackerRecHit.cc
+++ b/DataFormats/TrackerRecHit2D/src/BaseTrackerRecHit.cc
@@ -1,5 +1,6 @@
 //#define DO_THROW_UNINITIALIZED
 #include "DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h"
+#include "DataFormats/TrackerRecHit2D/interface/OmniClusterRef.h"
 #include "DataFormats/TrackingRecHit/interface/KfComponentsHolder.h"
 #include "DataFormats/Math/interface/ProjectMatrix.h"
 #include "FWCore/Utilities/interface/Exception.h"

--- a/DataFormats/TrackerRecHit2D/src/SiStripMatchedRecHit2D.cc
+++ b/DataFormats/TrackerRecHit2D/src/SiStripMatchedRecHit2D.cc
@@ -19,11 +19,26 @@ bool SiStripMatchedRecHit2D::sharesInput(const TrackingRecHit* other, SharedInpu
     return false;
 
   auto const& otherClus = reinterpret_cast<const BaseTrackerRecHit*>(other)->firstClusterRef();
-  return (otherClus == stereoClusterRef()) || (otherClus == monoClusterRef());
+  if (monoClusterRef().id() == otherClus.id() || stereoClusterRef().id() == otherClus.id())
+    return (otherClus == stereoClusterRef()) || (otherClus == monoClusterRef());
+  else {
+    const bool sameDetId = (geographicalId() == other->geographicalId());
+    bool stereoOverlap = (sameDetId) ? otherClus.stripOverlap(stereoClusterRef()) : false;
+    bool monoOverlap = (sameDetId) ? otherClus.stripOverlap(monoClusterRef()) : false;
+    return (stereoOverlap || monoOverlap);
+  }
 }
 
 bool SiStripMatchedRecHit2D::sharesInput(TrackerSingleRecHit const& other) const {
-  return other.sameCluster(monoClusterRef()) || other.sameCluster(stereoClusterRef());
+  auto const& otherClus = other.firstClusterRef();
+  if (monoClusterRef().id() == otherClus.id() || stereoClusterRef().id() == otherClus.id())
+    return (otherClus == stereoClusterRef()) || (otherClus == monoClusterRef());
+  else {
+    const bool sameDetId = (geographicalId() == other.geographicalId());
+    bool stereoOverlap = (sameDetId) ? otherClus.stripOverlap(stereoClusterRef()) : false;
+    bool monoOverlap = (sameDetId) ? otherClus.stripOverlap(monoClusterRef()) : false;
+    return (stereoOverlap || monoOverlap);
+  }
 }
 
 // it does not have components anymore...

--- a/DataFormats/TrackerRecHit2D/src/VectorHit.cc
+++ b/DataFormats/TrackerRecHit2D/src/VectorHit.cc
@@ -72,14 +72,32 @@ bool VectorHit::sharesInput(const TrackingRecHit* other, SharedInputType what) c
 
   // what about multi???
   auto const& otherClus = reinterpret_cast<const BaseTrackerRecHit*>(other)->firstClusterRef();
-  return (otherClus == lowerClusterRef()) || (otherClus == upperClusterRef());
+
+  if (lowerClusterRef().id() == otherClus.id() || upperClusterRef().id() == otherClus.id())
+    return (otherClus == lowerClusterRef()) || (otherClus == upperClusterRef());
+  else {
+    bool lowerOverlap = false;
+    bool upperOverlap = false;
+    if (geographicalId() == other->geographicalId()) {
+      lowerOverlap = otherClus.stripOverlap(lowerClusterRef());
+      upperOverlap = otherClus.stripOverlap(upperClusterRef());
+    }
+    return (lowerOverlap || upperOverlap);
+  }
 }
 
 bool VectorHit::sharesClusters(VectorHit const& other, SharedInputType what) const {
-  bool lower = this->lowerClusterRef() == other.lowerClusterRef();
-  bool upper = this->upperClusterRef() == other.upperClusterRef();
-
-  return (what == TrackingRecHit::all) ? (lower && upper) : (upper || lower);
+  if (this->lowerClusterRef().id() == other.lowerClusterRef().id() ||
+      this->upperClusterRef().id() == other.upperClusterRef().id()) {
+    const bool lowerIdentity = this->lowerClusterRef() == other.lowerClusterRef();
+    const bool upperIdentity = this->upperClusterRef() == other.upperClusterRef();
+    return (what == TrackingRecHit::all) ? (lowerIdentity && upperIdentity) : (lowerIdentity || upperIdentity);
+  } else {
+    const bool sameDetId = (geographicalId() == other.geographicalId());
+    bool lowerOverlap = (sameDetId) ? other.lowerClusterRef().stripOverlap(this->lowerClusterRef()) : false;
+    bool upperOverlap = (sameDetId) ? other.upperClusterRef().stripOverlap(this->upperClusterRef()) : false;
+    return (what == TrackingRecHit::all) ? (lowerOverlap && upperOverlap) : (lowerOverlap || upperOverlap);
+  }
 }
 
 void VectorHit::getKfComponents4D(KfComponentsHolder& holder) const {


### PR DESCRIPTION
### PR description:

As per title.
The possibility to produce strip clusters with different algorithm was discussed in https://its.cern.ch/jira/browse/CMSHLT-3534 for HLT in 2025-2026.
As other developments are in the pipeline, this possibility is currently on hold.
However, it would not be technically possible without this PR.
In fact, this PR introduces the possibility to check strip overlaps for different product IDs.
This is fully transparent for the current HLT scenario, as well as for offline (see below).

**A backport to 150X will follow shortly.**

### PR validation:
HLT tracking: https://uaf-10.t2.ucsd.edu/~mmasciov/TRKPOG/HLT2025/HLT_TTbarPU_TrackListMergerTest_mkFitDR/plots_hlt.html
Offline tracking: https://uaf-10.t2.ucsd.edu/~mmasciov/TRKPOG/HLT2025/MTVOffline_TTbarPU_TrackListMergerTest/

Offline tracking timing is also NOT affected: https://uaf-10.t2.ucsd.edu/~mmasciov/TRKPOG/HLT2025/MTVOffline_TTbarPU_TrackListMergerTest/plots_timing.html

FYI, @cms-sw/tracking-pog-l2, @slava77 