### PR TITLE
in run3_oxygen eras use triggerResultsFilterFromDB instead of HLTHigh…

### DIFF
--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMinBias_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMinBias_cff.py
@@ -49,6 +49,7 @@ seqALCARECOTkAlMinBias = cms.Sequence(ALCARECOTkAlMinBiasHLT*~ALCARECOTkAlMinBia
 ## customizations for the pp_on_AA eras
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
+from Configuration.Eras.Modifier_run3_oxygen_cff import run3_oxygen
 (pp_on_XeXe_2017 | pp_on_AA).toModify(ALCARECOTkAlMinBias,
                                     trackQualities = cms.vstring("highPurity")
 )
@@ -66,7 +67,7 @@ ALCARECOTkAlMinBiasTriggerResultsHI = HLTrigger.HLTfilters.triggerResultsFilterF
 )
 
 seqALCARECOTkAlMinBiasHI = cms.Sequence(ALCARECOTkAlMinBiasTriggerResultsHI*~ALCARECOTkAlMinBiasNOTHLT+ALCARECOTkAlMinBiasDCSFilter+ALCARECOTkAlMinBias)
-pp_on_AA.toReplaceWith(seqALCARECOTkAlMinBias,seqALCARECOTkAlMinBiasHI)
+(pp_on_AA | run3_oxygen).toReplaceWith(seqALCARECOTkAlMinBias,seqALCARECOTkAlMinBiasHI)
 
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(ALCARECOTkAlMinBias, etaMin = -4, etaMax = 4)

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalMinBias_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalMinBias_cff.py
@@ -46,6 +46,7 @@ pp_on_XeXe_2017.toModify(ALCARECOSiStripCalMinBiasHLT,
                          eventSetupPathsKey='SiStripCalMinBiasHI')
 
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
+from Configuration.Eras.Modifier_run3_oxygen_cff import run3_oxygen
 import HLTrigger.HLTfilters.triggerResultsFilterFromDB_cfi
 ALCARECOSiStripCalMinBiasTriggerResultsHI = HLTrigger.HLTfilters.triggerResultsFilterFromDB_cfi.triggerResultsFilterFromDB.clone(
     eventSetupPathsKey = 'SiStripCalMinBiasHI',
@@ -56,4 +57,4 @@ ALCARECOSiStripCalMinBiasTriggerResultsHI = HLTrigger.HLTfilters.triggerResultsF
 )
 
 seqALCARECOSiStripCalMinBiasHI = cms.Sequence(ALCARECOSiStripCalMinBiasTriggerResultsHI*DCSStatusForSiStripCalMinBias*ALCARECOSiStripCalMinBias)
-pp_on_AA.toReplaceWith(seqALCARECOSiStripCalMinBias,seqALCARECOSiStripCalMinBiasHI)
+(pp_on_AA | run3_oxygen).toReplaceWith(seqALCARECOSiStripCalMinBias,seqALCARECOSiStripCalMinBiasHI)


### PR DESCRIPTION

The changes are made to use prescale for upcoming Oxy run in case we have more trigger rate for TkAlMinbias and SiStripCalMinBias.