### PR TITLE
Fix Jacobian for linefit in Brokenline.

### DIFF
--- a/RecoTracker/PixelTrackFitting/interface/alpaka/BrokenLine.h
+++ b/RecoTracker/PixelTrackFitting/interface/alpaka/BrokenLine.h
@@ -495,8 +495,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::brokenline {
       vMat(2, 1) = vMat(1, 2) = hits_ge.col(i)[4];  // cov_yz
       vMat(2, 2) = hits_ge.col(i)[5];               // z errors
       auto tmp = 1. / radii.block(0, i, 2, 1).norm();
-      jacobXYZtosZ(0, 0) = radii(1, i) * tmp;
-      jacobXYZtosZ(0, 1) = -radii(0, i) * tmp;
+      jacobXYZtosZ(0, 0) = data.qCharge * radii(1, i) * tmp;
+      jacobXYZtosZ(0, 1) = -data.qCharge * radii(0, i) * tmp;
       jacobXYZtosZ(1, 2) = 1.;
       weights(i) = 1. / ((rotMat * jacobXYZtosZ * vMat * jacobXYZtosZ.transpose() * rotMat.transpose())(
                             1, 1));  // compute the orthogonal weight point by point


### PR DESCRIPTION
#### PR description:

As per title.
This PR is meant to fix a bug in the broken-line fit implementation that is mainly relevant for phase-2, with tilted modules in the Outer Tracker when pixel ntuplets are extended there (phase-2 "CA extension").
This was reported by @JanGerritSchulz and @rovere in [this presentation](https://indico.cern.ch/event/1561539/contributions/6577957/attachments/3092112/5477051/HLTUpgradeMeeting_25-06-24.pdf)

For phase-1 pixel (HLT) tracking, the impact is expected to be ~zero, and this was confirmed from private tracking validations (see below).
However, we prefer to have a consistent, correct code in the releases in use for phase-1, too.
There might be a follow-up to include the fix also for the Riemann-fit case (that is not used in production in any scenario).

#### PR validation:

[here](https://musich.web.cern.ch/NGT/Task-3.1.1/plots_brokenLineFix_hightStat/) there is a high statistics comparison w.r.t. the current master branch done using:

```bash
#!/bin/bash -ex

cmsDriver.py step2 -s HLT:@relval2025,VALIDATION:hltMultiTrackValidation \
         --conditions auto:phase1_2025_realistic \
         --datatier DQMIO \
         -n 1000 \
         --eventcontent DQMIO \
         --geometry DB:Extended \
         --era Run3_2025 \
         --filein file:/eos/cms/store/relval/CMSSW_15_1_0_pre3/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_150X_mcRun3_2025_realistic_v3_STD_2025_PU-v3/2590000/04cc6ed0-e6aa-4e4a-b232-05e10f57e6ab.root  \
         --fileout file:step2.root \
         --nThreads 24 \
         --process HLTX \
         --inputCommands='keep *, drop *_hlt*_*_HLT, drop triggerTriggerFilterObjectWithRefs_l1t*_*_HLT' \
         > step2.log  2>&1

cmsDriver.py step3 -s HARVESTING:postProcessorHLTtrackingSequence \
         --conditions auto:phase1_2025_realistic  \
         --mc \
         --geometry DB:Extended \
         --scenario pp \
         --filetype DQM \
         --era Run3_2025 \
         -n 1000  \
         --filein file:step2.root \
         --fileout file:step3.root > step3.log  2>&1
```
and comparing the resulting DQM files in outputs.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, it will be backported to CMSSW_15_0_X for data-taking purposes.