### PR TITLE
Reduce size of dEdx information in UPC and oxygen eras

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
@@ -128,7 +128,8 @@ run3_upc.toModify(dedxEstimator, dedxEstimators = ["dedxHarmonic2", "dedxPixelHa
 run3_upc.toReplaceWith(slimmingTask, cms.Task(slimmingTask.copy(), hiPixelTracks, packedPFCandidateTrackChi2, lostTrackChi2, dedxEstimator))
 
 from Configuration.Eras.Modifier_run3_oxygen_cff import run3_oxygen
-run3_oxygen.toReplaceWith(slimmingTask, cms.Task(slimmingTask.copy(), hiPixelTracks, hiEvtPlane, hiEvtPlaneFlat, packedPFCandidateTrackChi2, lostTrackChi2, centralityBin, hiHFfilters))
+run3_oxygen.toModify(dedxEstimator, dedxEstimators = ["dedxPixelLikelihood", "dedxStripLikelihood", "dedxAllLikelihood"])
+run3_oxygen.toReplaceWith(slimmingTask, cms.Task(slimmingTask.copy(), hiPixelTracks, hiEvtPlane, hiEvtPlaneFlat, packedPFCandidateTrackChi2, lostTrackChi2, centralityBin))
 
 from Configuration.Eras.Modifier_ppRef_2024_cff import ppRef_2024
 ppRef_2024.toReplaceWith(slimmingTask, cms.Task(slimmingTask.copy(), packedPFCandidateTrackChi2, lostTrackChi2))

--- a/RecoJets/Configuration/python/RecoJets_EventContent_cff.py
+++ b/RecoJets/Configuration/python/RecoJets_EventContent_cff.py
@@ -54,10 +54,9 @@ from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
 from Configuration.Eras.Modifier_ppRef_2024_cff import ppRef_2024
-from Configuration.Eras.Modifier_run3_oxygen_cff import run3_oxygen
 from Configuration.ProcessModifiers.phase2_pp_on_AA_cff import phase2_pp_on_AA
 #products from regular pp which does not fit the normal AOD
-for e in [pA_2016, peripheralPbPb, pp_on_XeXe_2017, pp_on_AA, run3_oxygen]:
+for e in [pA_2016, peripheralPbPb, pp_on_XeXe_2017, pp_on_AA]:
     e.toModify( RecoJetsAOD.outputCommands, 
                 func=lambda outputCommands: outputCommands.extend(['keep *_towerMaker_*_*'])
                 )

--- a/RecoTracker/DeDx/python/dedxEstimators_cff.py
+++ b/RecoTracker/DeDx/python/dedxEstimators_cff.py
@@ -91,13 +91,15 @@ run3_common.toModify(dedxHitInfo,
 )
 
 # dEdx for Run-3 UPC
+dedxAllHitInfo = dedxHitInfo.clone(minTrackPt = 0)
 from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
-run3_upc.toModify(dedxHitInfo, minTrackPt = 0, storeMomentumAtHit = True)
+run3_upc.toModify(dedxHitInfo, lowPtTracksPrescalePass = 50, lowPtTracksPrescaleFail = 50, minTrackPtPrescale = 0, usePixelForPrescales = True, storeMomentumAtHit = True)
 
 from RecoTracker.DeDx.dedxHitCalibrator_cfi import dedxHitCalibrator as _dedxHitCalibrator
 from SimGeneral.MixingModule.SiStripSimParameters_cfi import SiStripSimBlock as _SiStripSimBlock
 from RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizer_cfi import siPixelClusters as _siPixelClusters
 dedxHitCalibrator = _dedxHitCalibrator.clone(
+    dedxHitInfo = 'dedxAllHitInfo',
     MeVPerElectron = 1000*_SiStripSimBlock.GevPerElectron.value(),
     VCaltoElectronGain = _siPixelClusters.VCaltoElectronGain,
     VCaltoElectronGain_L1 = _siPixelClusters.VCaltoElectronGain_L1,
@@ -116,4 +118,4 @@ dedxPixelLikelihood = dedxAllLikelihood.clone(UseStrip = False, UsePixel = True)
 dedxStripLikelihood = dedxAllLikelihood.clone(UseStrip = True,  UsePixel = False)
 
 from Configuration.Eras.Modifier_run3_egamma_2023_cff import run3_egamma_2023
-run3_upc.toReplaceWith(doAlldEdXEstimatorsTask, cms.Task(doAlldEdXEstimatorsTask.copy(), dedxHitCalibrator, dedxStripLikelihood, dedxPixelLikelihood, dedxAllLikelihood))
+run3_upc.toReplaceWith(doAlldEdXEstimatorsTask, cms.Task(doAlldEdXEstimatorsTask.copy(), dedxAllHitInfo, dedxHitCalibrator, dedxStripLikelihood, dedxPixelLikelihood, dedxAllLikelihood))


### PR DESCRIPTION
#### PR description:

This PR reduces the size of the dEdx hit info collection in the UPC and OXY eras by using a prescale of 50 for storing hit information of low pT tracks.

@mandrenguyen 

#### PR validation:

Tested with workflow 143.911 and 143.912

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 15_0_X


