### PR TITLE
[15_0_X] [L1T] Implementing sector based mode 7 promotion in EMTF for Run 3 2025

### DIFF
--- a/L1Trigger/L1TMuonEndCap/interface/PtAssignment.h
+++ b/L1Trigger/L1TMuonEndCap/interface/PtAssignment.h
@@ -23,6 +23,7 @@ public:
                  bool bugGMTPhi,
                  bool promoteMode7,
                  int modeQualVer,
+                 std::vector<int> promoteMode7Sectors,
                  std::string pbFileName);
 
   void process(EMTFTrackCollection& best_tracks);
@@ -38,6 +39,7 @@ private:
 
   bool bugGMTPhi_, promoteMode7_;
   int modeQualVer_;
+  std::vector<int> promoteMode7Sectors_;
 };
 
 #endif

--- a/L1Trigger/L1TMuonEndCap/interface/VersionControl.h
+++ b/L1Trigger/L1TMuonEndCap/interface/VersionControl.h
@@ -57,6 +57,7 @@ private:
   bool readPtLUTFile_, fixMode15HighPt_;
   bool bug9BitDPhi_, bugMode7CLCT_, bugNegPt_, bugGMTPhi_, promoteMode7_;
   int modeQualVer_;
+  std::vector<int> promoteMode7Sectors_;  // Sectors to promote mode 7 tracks in Run 2 and Run 3, -1 for all sectors
   std::string pbFileName_;
 };
 

--- a/L1Trigger/L1TMuonEndCap/python/simEmtfDigis_cfi.py
+++ b/L1Trigger/L1TMuonEndCap/python/simEmtfDigis_cfi.py
@@ -125,7 +125,7 @@ simEmtfDigisMC = cms.EDProducer("L1TMuonEndCapTrackProducer",
         BugGMTPhi       = cms.bool(False), # Some drift in uGMT phi conversion, off by up to a few degrees
         PromoteMode7    = cms.bool(False), # Assign station 2-3-4 tracks with |eta| > 1.6 SingleMu quality
         ModeQualVer     = cms.int32(2),    # Version 2 contains modified mode-quality mapping for 2018
-
+        PromoteMode7Sectors = cms.vint32(-1), # Sectors to promote mode 7 tracks in Run 2 and Run 3, -1 for all sectors
         ProtobufFileName = cms.string('model_graph.displ.16.pb'), # Protobuf file name to be used by NN based pT assignment NNv16 is online since 26.06.2023
     ),
 
@@ -165,3 +165,7 @@ stage2L1Trigger_2018.toModify(simEmtfDigis, RPCEnable = True, Era = 'Run2_2018')
 ## Era: Run3_2021
 from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
 stage2L1Trigger_2021.toModify(simEmtfDigis, RPCEnable = True, UseRun3CCLUT_OTMB = True, Era = 'Run3_2021')
+
+## Era: Run3_2025
+from Configuration.Eras.Modifier_stage2L1Trigger_2025_cff import stage2L1Trigger_2025
+stage2L1Trigger_2025.toModify(simEmtfDigis, RPCEnable = True, UseRun3CCLUT_OTMB = True, spPAParams16 = dict(PromoteMode7Sectors = {+3, +4}), Era = 'Run3_2025')

--- a/L1Trigger/L1TMuonEndCap/src/EMTFSetup.cc
+++ b/L1Trigger/L1TMuonEndCap/src/EMTFSetup.cc
@@ -21,10 +21,9 @@ EMTFSetup::EMTFSetup(const edm::ParameterSet& iConfig, edm::ConsumesCollector iC
   // Set pt assignment engine according to Era
   if (era() == "Run2_2016") {
     pt_assign_engine_ = std::make_unique<PtAssignmentEngine2016>();
-  } else if (era() == "Run2_2017" || era() == "Run2_2018") {
+  } else if (era() == "Run2_2017" || era() == "Run2_2018" || era() == "Run3_2021" || era() == "Run3_2023" ||
+             era() == "Run3_2024" || era() == "Run3_2025") {
     pt_assign_engine_ = std::make_unique<PtAssignmentEngine2017>();
-  } else if (era() == "Run3_2021") {
-    pt_assign_engine_ = std::make_unique<PtAssignmentEngine2017>();  //TODO - implement ver 2021
   } else {
     throw cms::Exception("L1TMuonEndCap") << "Cannot recognize the era option: " << era();
   }

--- a/L1Trigger/L1TMuonEndCap/src/PtAssignment.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PtAssignment.cc
@@ -17,6 +17,7 @@ void PtAssignment::configure(PtAssignmentEngine* pt_assign_engine,
                              bool bugGMTPhi,
                              bool promoteMode7,
                              int modeQualVer,
+                             std::vector<int> promoteMode7Sectors,
                              std::string pbFileName) {
   emtf_assert(pt_assign_engine != nullptr);
   emtf_assert(pt_assign_engine_dxy != nullptr);
@@ -37,6 +38,17 @@ void PtAssignment::configure(PtAssignmentEngine* pt_assign_engine,
   bugGMTPhi_ = bugGMTPhi;
   promoteMode7_ = promoteMode7;
   modeQualVer_ = modeQualVer;
+  promoteMode7Sectors_ = promoteMode7Sectors;
+
+  int es = endcap_ == 1 ? sector_ : -1 * sector_;  // Endcap sign and sector number
+
+  if (promoteMode7_ &&
+      (promoteMode7Sectors_.at(0) == -1 ||
+       std::find(promoteMode7Sectors_.begin(), promoteMode7Sectors_.end(), es) != promoteMode7Sectors_.end())) {
+    promoteMode7_ = true;  // Assign station 2-3-4 tracks with |eta| > 1.6 SingleMu quality in a given sector
+  } else {
+    promoteMode7_ = false;  // Do not promote mode 7 tracks of other sectors
+  }
 }
 
 void PtAssignment::process(EMTFTrackCollection& best_tracks) {

--- a/L1Trigger/L1TMuonEndCap/src/SectorProcessor.cc
+++ b/L1Trigger/L1TMuonEndCap/src/SectorProcessor.cc
@@ -168,6 +168,7 @@ void SectorProcessor::process_single_bx(int bx,
                       cfg.bugGMTPhi_,
                       cfg.promoteMode7_,
                       cfg.modeQualVer_,
+                      cfg.promoteMode7Sectors_,
                       cfg.pbFileName_);
 
   std::map<int, TriggerPrimitiveCollection> selected_dt_map;

--- a/L1Trigger/L1TMuonEndCap/src/VersionControl.cc
+++ b/L1Trigger/L1TMuonEndCap/src/VersionControl.cc
@@ -63,6 +63,7 @@ VersionControl::VersionControl(const edm::ParameterSet& iConfig) : config_(iConf
   bugGMTPhi_ = spPAParams16.getParameter<bool>("BugGMTPhi");
   promoteMode7_ = spPAParams16.getParameter<bool>("PromoteMode7");
   modeQualVer_ = spPAParams16.getParameter<int>("ModeQualVer");
+  promoteMode7Sectors_ = spPAParams16.getParameter<std::vector<int> >("PromoteMode7Sectors");
   pbFileName_ = spPAParams16.getParameter<std::string>("ProtobufFileName");
 }
 
@@ -76,7 +77,6 @@ void VersionControl::configure_by_fw_version(unsigned fw_version) {
   // For now, no switches later than FW version 47864 (end-of-year 2016)
   // Beggining in late 2016, "fw_version" in O2O populated with timestamp, rather than FW version
   // tm fw_time = gmtime(fw_version);  (See https://linux.die.net/man/3/gmtime, https://www.epochconverter.com)
-
   /////////////////////////////////////////////////////////////////////////////////
   ///  Settings for 2018 (by default just use settings in simEmtfDigis_cfi.py)  ///
   /////////////////////////////////////////////////////////////////////////////////
@@ -120,7 +120,6 @@ void VersionControl::configure_by_fw_version(unsigned fw_version) {
     // ---------------------------------------------------------------------------------
     modeQualVer_ = 2;       // Version 2 contains modified mode-quality mapping for 2018
     promoteMode7_ = false;  // Assign station 2-3-4 tracks with |eta| > 1.6 SingleMu quality
-
     // ___________________________________________________________________________
     // Versions in 2018 - no external documentation
     // As of the beginning of 2018 EMTF O2O was broken, not updating the database with online conditions
@@ -132,6 +131,11 @@ void VersionControl::configure_by_fw_version(unsigned fw_version) {
       twoStationSameBX_ = false;    // Requires the hits in two-station tracks to have the same BX
       modeQualVer_ = 1;             // Version 2 contains modified mode-quality mapping for 2018
       promoteMode7_ = true;         // Assign station 2-3-4 tracks with |eta| > 1.6 SingleMu quality
+    }
+
+    // Promote Mode 7 settings for 2025. Implemented here since all the rest of the settings are the same as in 2018.
+    if (fw_version >= 1747996116) {  // May 23, 2025
+      promoteMode7_ = true;          // Assign station 2-3-4 tracks with |eta| > 1.6 SingleMu quality
     }
 
     return;


### PR DESCRIPTION
#### PR description:

This PR implements the new sector based quality promotion of mode 7 tracks. The firmware was deployed On June 6th, the first run with this firmware is 393039. The JIRA is here: https://its.cern.ch/jira/browse/CMSLITOPS-511

This change in the emulator is required to keep the emulator in line with the firmware. This is not critical for data taking, but it's used in DQM data-emulator comparisons and also in MC production.

#### PR validation:

Validated with running on data from before/after run 393039 and also with MC. Works as expected.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is the backport of https://github.com/cms-sw/cmssw/pull/48423