### PR TITLE
PPS: Increase X-axis range for "RP State per Lumisection" DQM plot to 3000 LS

### DIFF
--- a/DQM/CTPPS/plugins/CTPPSCommonDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSCommonDQMSource.cc
@@ -122,7 +122,7 @@ void CTPPSCommonDQMSource::GlobalPlots::Init(DQMStore::IBooker &ibooker) {
      3 -> ok
   */
   RPState = ibooker.book2D(
-      "rpstate per LS", "RP State per Lumisection;Luminosity Section;", 1000, 0, 1000, MAX_VBINS, 0., MAX_VBINS);
+      "rpstate per LS", "RP State per Lumisection;Luminosity Section;", 3000, 0, 3000, MAX_VBINS, 0., MAX_VBINS);
   {
     TH2F *hist = RPState->getTH2F();
     hist->SetCanExtend(TH2F::kXaxis);


### PR DESCRIPTION
#### PR description:

In recent weeks, we've observed data-taking runs extending beyond 1000 lumisections (LS). This pull request addresses this by enlarging the lumisection scale to 3000 for the "rpstate per LS" plot within the CTPPS (PPS) DQM.

Previously, an attempt was made in #48201 to use `hist->SetCanExtend(TH2F::kXaxis);` to allow for an automatically extending X-axis when more than 1000 LS were recorded. However, this approach **did not work as expected**, and the X-axis remained limited to a fixed range.

This PR implements a direct increase of the X-axis range to 3000 LS, ensuring that lumisections in longer runs are properly displayed and monitored. While this is a hardcoded solution, it's crucial for us to avoid the current 1000 LS limitation. We are open to alternative solutions that offer a more dynamic or automatic axis extension in the future.

#### PR validation:

Private DQM production. 