### PR TITLE
Fix bugs and logic in ibeos das client

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixReader.py
+++ b/Configuration/PyReleaseValidation/python/MatrixReader.py
@@ -322,6 +322,8 @@ With --checkInputs option this throws an error.
                     if self.wm and self.revertDqmio=='yes':
                         cmd=cmd.replace('DQMIO','DQM')
                         cmd=cmd.replace('--filetype DQM','')
+                    if os.getenv("CMSSW_USE_IBEOS","false")=="true":
+                        cmd="export CMSSW_USE_IBEOS=true; "+cmd
                 commands.append(cmd)
                 ranStepList.append(stepName)
                 stepIndex+=1

--- a/Utilities/General/ibeos/das_client
+++ b/Utilities/General/ibeos/das_client
@@ -66,7 +66,7 @@ if [ "${FORMAT}" = "json" ]  ; then
   fi
 else
   QUERY_RESULTS=$((curl -f -L -s "${QUERY_URL}" || true) | grep /store/ | sed 's| ||g;s|"||g;s|,||g')
-  [ $((get_parent_cmds $$ 0 2>&1 || true) | grep '/cmsDriver.py' | wc -l) -gt 0 ] && LIMIT_RESULTS="YES"
+  [ $((get_parent_cmds $$ 0 2>&1 || true) | grep -a '/cmsDriver.py' | wc -l) -gt 0 ] && LIMIT_RESULTS="YES"
   if [ "${QUERY_RESULTS}" = "" ] ; then
     ${ORIG_DAS_CLIENT} "$@" > ${DAS_QUERY_DIR}/${QUERY_SHA_HASH}.out
   else

--- a/Utilities/General/ibeos/das_client
+++ b/Utilities/General/ibeos/das_client
@@ -34,7 +34,7 @@ done
 ORIG_DAS_CLIENT=""
 for DAS_CLIENT in $(echo $PATH | tr ':' '\n' | sed "s|\$|/${CMD_NAME}|") ; do
  [ -e ${DAS_CLIENT} ] || continue
- if [ $(head -2 ${DAS_CLIENT} | grep 'CMSSDT_DAS_CLIENT_SIGN' | wc -l) -eq 0 ] ; then ORIG_DAS_CLIENT=${DAS_CLIENT}; break; fi
+ if ! head -2 ${DAS_CLIENT} | grep -q 'CMSSDT_DAS_CLIENT_SIGN'; then ORIG_DAS_CLIENT=${DAS_CLIENT}; break; fi
 done
 
 if [ "X${ORIG_DAS_CLIENT}" = "X" ] ; then
@@ -67,7 +67,9 @@ if [ "${FORMAT}" = "json" ]  ; then
 else
   QUERY_RESULTS=$((curl -f -L -s "${QUERY_URL}" || true) | grep /store/ | sed 's| ||g;s|"||g;s|,||g')
   export CMSSW_LIMIT_RESULTS="-0"
-  [ $((get_parent_cmds $$ 0 2>&1 || true) | grep -a '/cmsDriver.py' | wc -l) -gt 0 ] && export CMSSW_LIMIT_RESULTS="20"
+  if (get_parent_cmds $$ 0 2>&1 || true) | grep -aq '/cmsDriver.py'; then
+    export CMSSW_LIMIT_RESULTS="20"
+  fi
   if [ "${QUERY_RESULTS}" = "" ] ; then
     ${ORIG_DAS_CLIENT} "$@" > ${DAS_QUERY_DIR}/${QUERY_SHA_HASH}.out
   else

--- a/Utilities/General/ibeos/das_client
+++ b/Utilities/General/ibeos/das_client
@@ -15,14 +15,14 @@ function get_parent_cmds ()
   get_parent_cmds "$XPID" "$DEPTH"
 }
 
+export CMSSW_LIMIT_RESULTS="-0"
 CMD_NAME=$(basename $0)
-LIMIT_RESULTS="NO"
 QUERY=
 FORMAT="plain"
 HELP=
 for ((i=1; i<=$#; i++)); do
   next=$((i+1))
-  case  ${!i} in
+  case ${!i} in
     --query=* | -query=* ) QUERY="${!i#*=}" ;;
     --query | -query ) QUERY=${!next} ;;
     --format=* | -format=* ) FORMAT="${!i#*=}" ;;
@@ -66,7 +66,6 @@ if [ "${FORMAT}" = "json" ]  ; then
   fi
 else
   QUERY_RESULTS=$((curl -f -L -s "${QUERY_URL}" || true) | grep /store/ | sed 's| ||g;s|"||g;s|,||g')
-  export CMSSW_LIMIT_RESULTS="-0"
   if (get_parent_cmds $$ 0 2>&1 || true) | grep -aq '/cmsDriver.py'; then
     export CMSSW_LIMIT_RESULTS="20"
   fi

--- a/Utilities/General/ibeos/das_client
+++ b/Utilities/General/ibeos/das_client
@@ -64,6 +64,8 @@ if [ "${FORMAT}" = "json" ]  ; then
   else
     echo "${QUERY_RESULTS}" > ${DAS_QUERY_DIR}/${QUERY_SHA_HASH}.out
   fi
+  cat ${DAS_QUERY_DIR}/${QUERY_SHA_HASH}.out
+  return
 else
   QUERY_RESULTS=$((curl -f -L -s "${QUERY_URL}" || true) | grep /store/ | sed 's| ||g;s|"||g;s|,||g')
   if (get_parent_cmds $$ 0 2>&1 || true) | grep -aq '/cmsDriver.py'; then

--- a/Utilities/General/ibeos/das_client
+++ b/Utilities/General/ibeos/das_client
@@ -65,7 +65,7 @@ if [ "${FORMAT}" = "json" ]  ; then
     echo "${QUERY_RESULTS}" > ${DAS_QUERY_DIR}/${QUERY_SHA_HASH}.out
   fi
   cat ${DAS_QUERY_DIR}/${QUERY_SHA_HASH}.out
-  return
+  exit 0
 else
   QUERY_RESULTS=$((curl -f -L -s "${QUERY_URL}" || true) | grep /store/ | sed 's| ||g;s|"||g;s|,||g')
   if (get_parent_cmds $$ 0 2>&1 || true) | grep -aq '/cmsDriver.py'; then

--- a/Utilities/General/ibeos/das_client
+++ b/Utilities/General/ibeos/das_client
@@ -66,17 +66,14 @@ if [ "${FORMAT}" = "json" ]  ; then
   fi
 else
   QUERY_RESULTS=$((curl -f -L -s "${QUERY_URL}" || true) | grep /store/ | sed 's| ||g;s|"||g;s|,||g')
-  [ $((get_parent_cmds $$ 0 2>&1 || true) | grep -a '/cmsDriver.py' | wc -l) -gt 0 ] && LIMIT_RESULTS="YES"
+  export CMSSW_LIMIT_RESULTS="-0"
+  [ $((get_parent_cmds $$ 0 2>&1 || true) | grep -a '/cmsDriver.py' | wc -l) -gt 0 ] && export CMSSW_LIMIT_RESULTS="20"
   if [ "${QUERY_RESULTS}" = "" ] ; then
     ${ORIG_DAS_CLIENT} "$@" > ${DAS_QUERY_DIR}/${QUERY_SHA_HASH}.out
   else
     echo "${QUERY_RESULTS}" > ${DAS_QUERY_DIR}/${QUERY_SHA_HASH}.out
   fi
 fi
-echo $LIMIT_RESULTS >> ${DAS_QUERY_DIR}/${QUERY_SHA_HASH}.info
-if [ "$LIMIT_RESULTS" = "YES" ] ; then
-  cat ${DAS_QUERY_DIR}/${QUERY_SHA_HASH}.out | ibeos-lfn-sort > ${DAS_QUERY_DIR}/${QUERY_SHA_HASH}.selected
-  cat ${DAS_QUERY_DIR}/${QUERY_SHA_HASH}.selected
-else
-  cat ${DAS_QUERY_DIR}/${QUERY_SHA_HASH}.out
-fi
+echo $CMSSW_LIMIT_RESULTS >> ${DAS_QUERY_DIR}/${QUERY_SHA_HASH}.info
+cat ${DAS_QUERY_DIR}/${QUERY_SHA_HASH}.out | ibeos-lfn-sort > ${DAS_QUERY_DIR}/${QUERY_SHA_HASH}.selected
+cat ${DAS_QUERY_DIR}/${QUERY_SHA_HASH}.selected

--- a/Utilities/General/ibeos/das_client
+++ b/Utilities/General/ibeos/das_client
@@ -23,11 +23,11 @@ HELP=
 for ((i=1; i<=$#; i++)); do
   next=$((i+1))
   case  ${!i} in
-    --query=*  ) QUERY=$(echo ${!i} | sed 's|.*=||') ;;
-    --query    ) QUERY=${!next} ;;
-    --format=* ) FORMAT=$(echo ${!i} | sed 's|.*=||') ;;
-    --format   ) FORMAT=${!next} ;;
-    -h|--help  ) HELP=YES ;;
+    --query=* | -query=* ) QUERY="${!i#*=}" ;;
+    --query | -query ) QUERY=${!next} ;;
+    --format=* | -format=* ) FORMAT="${!i#*=}" ;;
+    --format | -format ) FORMAT=${!next} ;;
+    -h | --help | -help  ) HELP=YES ;;
   esac
 done
 

--- a/Utilities/General/scripts/ibeos-lfn-sort
+++ b/Utilities/General/scripts/ibeos-lfn-sort
@@ -47,5 +47,7 @@ else
     esac
   done
 fi
-echo $(echo $IBEOS_FILES | tr ' ' '\n' | sort -u) $(echo $NON_IBEOS_FILES | tr ' ' '\n' | sort -u) | tr ' ' '\n' | grep '/store' | head -n 20
-
+if [ -z "$CMSSW_LIMIT_RESULTS" ]; then
+  CMSSW_LIMIT_RESULTS=20
+fi
+echo $(echo $IBEOS_FILES | tr ' ' '\n' | sort -u) $(echo $NON_IBEOS_FILES | tr ' ' '\n' | sort -u) | tr ' ' '\n' | grep '/store' | head -n $CMSSW_LIMIT_RESULTS


### PR DESCRIPTION
#### PR description:

Bugs:
1. The file of parent process information sometimes gets detected as a binary file by grep (maybe OS- or version-dependent) because of some unicode symbols. This means the check for `/cmsDriver.py` could fail. Using `-a` tells grep to treat it like a text file. Further, the grep checks can be simplified (just using the exit code instead of explicitly counting matches).
2. `das_client` was written before `dasgoclient`. The latter uses single-dash long options, which were not handled correctly in the `das_client` command line parsing. Also, the regex to match the `=` sign did not handle the presence of multiple `=` signs properly (e.g. in `-query="file dataset=/x/y/z"`).

Logic:
1. The file list returned by `das_client` was only processed by `ibeos-lfn-sort` when `das_client` was called by `cmsDriver.py`. However, the logic in `Utilities/General/scripts/dasgoclient` specifies that `das_client` will be used only when `CMSSW_USE_IBEOS` is enabled (see #46114). Therefore, the use of `das_client` implies the desire to use all `ibeos` functionality, so the `ibeos` location should always be prepended. Returning a limited set of results is still only done in the `cmsDriver.py` case, by modifying the meaning/usage of the `CMSSW_LIMIT_RESULTS` variable (now with a more specific name). The new scheme exploits the fact that `head` with a negative value for the `-n` argument prints all but the last n values, and `-0` is a valid argument.
2. Correspondingly, `runTheMatrix.py` is modified so that it activates `CMSSW_USE_IBEOS` for every command when the flag is provided.

The logic changes are especially useful to read pileup inputs from old relvals that have long since been deleted from disk, but are still cached in the ibeos location. (Somehow the bot manages this when running IB/PR tests, but I do not understand how. Users running the same commands could not achieve the same behavior, which was reported and led to this PR.)

@smuzaffar please let me know if any of the changes here will interfere with the bot.

#### PR validation:

Checked how the scripts ran with various cases using `set -x`.

Ran workflow 250202.181 successfully with the `--ibeos` option.

Also checked 136.731 (used to test #46114).

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport. May be backported to 15_0_X or older cycles if requested.

attn: @jhakala 