### PR TITLE
[DAQ] add back RawEventOutputModule support for FEDRawDataCollection

### DIFF
--- a/EventFilter/Utilities/plugins/DaqFakeReader.h
+++ b/EventFilter/Utilities/plugins/DaqFakeReader.h
@@ -14,25 +14,40 @@
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "DataFormats/Provenance/interface/EventID.h"
-#include "DataFormats/FEDRawData/interface/RawDataBuffer.h"
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include <algorithm>
 
 class DaqFakeReader : public edm::one::EDProducer<> {
 public:
+  //
+  // construction/destruction
+  //
   DaqFakeReader(const edm::ParameterSet& pset);
-  ~DaqFakeReader() override {}
+  ~DaqFakeReader() override;
+
+  //
+  // public member functions
+  //
 
   // Generate and fill FED raw data for a full event
-  virtual int fillRawData(edm::Event& e, RawDataBuffer*& data);
+  virtual int fillRawData(edm::Event& e, FEDRawDataCollection*& data);
+
   void produce(edm::Event&, edm::EventSetup const&) override;
+
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  void getSizes(const int, const int, float meansize, float width);
-  void fillFEDs(const int, const int, edm::EventID& eID, RawDataBuffer& data, float meansize, float width);
-  void fillTCDSFED(edm::EventID& eID, RawDataBuffer& data, uint32_t ls, timeval* now);
+  //
+  // private member functions
+  //
+  void fillFEDs(const int, const int, edm::EventID& eID, FEDRawDataCollection& data, float meansize, float width);
+  void fillTCDSFED(edm::EventID& eID, FEDRawDataCollection& data, uint32_t ls, timeval* now);
   virtual void beginLuminosityBlock(edm::LuminosityBlock const& iL, edm::EventSetup const& iE);
 
+private:
+  //
+  // member data
+  //
   edm::RunNumber_t runNum;
   edm::EventNumber_t eventNum;
   bool empty_events;
@@ -52,10 +67,6 @@ private:
   bool haveDT_ = false;
   bool haveCSC_ = false;
   bool haveRPC_ = false;
-
-  uint32_t totSize_ = 0;
-  std::vector<float> logSizes_;
-  uint16_t logSizeIndex_;
 };
 
 #endif

--- a/EventFilter/Utilities/plugins/RawEventOutputModuleForBU.h
+++ b/EventFilter/Utilities/plugins/RawEventOutputModuleForBU.h
@@ -47,9 +47,12 @@ private:
   void endLuminosityBlock(edm::LuminosityBlockForOutput const&) override;
 
   std::unique_ptr<Consumer> templateConsumer_;
+  const edm::EDGetTokenT<FEDRawDataCollection> tokenFRD_;
   const edm::EDGetTokenT<RawDataBuffer> token_;
   const unsigned int numEventsPerFile_;
   const unsigned int frdVersion_;
+  std::string rawProductName_;
+  unsigned int rawProductType_ = 0;
   std::vector<unsigned int> sourceIdList_;
   unsigned int totevents_ = 0;
   unsigned int index_ = 0;
@@ -60,10 +63,18 @@ RawEventOutputModuleForBU<Consumer>::RawEventOutputModuleForBU(edm::ParameterSet
     : edm::one::OutputModuleBase::OutputModuleBase(ps),
       edm::one::OutputModule<edm::one::WatchRuns, edm::one::WatchLuminosityBlocks>(ps),
       templateConsumer_(new Consumer(ps)),
+      tokenFRD_(consumes<FEDRawDataCollection>(ps.getParameter<edm::InputTag>("source"))),
       token_(consumes<RawDataBuffer>(ps.getParameter<edm::InputTag>("source"))),
       numEventsPerFile_(ps.getParameter<unsigned int>("numEventsPerFile")),
       frdVersion_(ps.getParameter<unsigned int>("frdVersion")),
+      rawProductName_(ps.getUntrackedParameter<std::string>("rawProductName")),
       sourceIdList_(ps.getUntrackedParameter<std::vector<unsigned int>>("sourceIdList", std::vector<unsigned int>())) {
+  if (rawProductName_ == "FEDRawDataCollection")
+    rawProductType_ = 1;
+  else if (rawProductName_ == "RawDataBuffer")
+    rawProductType_ = 2;
+  else
+    throw cms::Exception("RawEventOutputModuleForBU") << "Unknown raw product specified";
   if (frdVersion_ > 0 && frdVersion_ < 5)
     throw cms::Exception("RawEventOutputModuleForBU")
         << "Generating data with FRD version " << frdVersion_ << " is no longer supported";
@@ -89,23 +100,49 @@ void RawEventOutputModuleForBU<Consumer>::write(edm::EventForOutput const& e) {
   totevents_++;
   // serialize the FEDRawDataCollection into the format that we expect for
   // FRDEventMsgView objects (may be better ways to do this)
+  edm::Handle<FEDRawDataCollection> fedBuffers;
   edm::Handle<RawDataBuffer> fedBuffer;
-  e.getByToken(token_, fedBuffer);
+
+  unsigned int usedRawType = 0;
+  if (rawProductType_ == 1) {
+    e.getByToken(tokenFRD_, fedBuffers);
+    usedRawType = 1;
+  } else if (rawProductType_ == 2) {
+    e.getByToken(token_, fedBuffer);
+    usedRawType = 2;
+  }
+  assert(usedRawType);
 
   // determine the expected size of the FRDEvent IN bytes
   int headerSize = edm::streamer::FRDHeaderVersionSize[frdVersion_];
   int expectedSize = headerSize;
-  int nFeds = FEDNumbering::lastFEDId() + 1;  //TODO!
+  //for FEDRawDataCollection
+  int nFeds = FEDNumbering::lastFEDId() + 1;
 
-  if (!sourceIdList_.empty()) {
-    for (int idx : sourceIdList_) {
-      auto singleFED = fedBuffer->fragmentData(idx);
-      expectedSize += singleFED.size();
+  if (usedRawType == 1) {
+    if (!sourceIdList_.empty()) {
+      for (int idx : sourceIdList_) {
+        auto singleFED = fedBuffers->FEDData(idx);
+        expectedSize += singleFED.size();
+      }
+    } else {
+      for (int idx = 0; idx < nFeds; ++idx) {
+        auto singleFED = fedBuffers->FEDData(idx);
+        expectedSize += singleFED.size();
+      }
     }
-  } else {
-    for (int idx = 0; idx < nFeds; ++idx) {
-      auto singleFED = fedBuffer->fragmentData(idx);
-      expectedSize += singleFED.size();
+  } else if (usedRawType == 2) {
+    if (!sourceIdList_.empty()) {
+      for (int idx : sourceIdList_) {
+        auto singleFED = fedBuffer->fragmentData(idx);
+        expectedSize += singleFED.size();
+      }
+    } else {
+      //for (int idx = 0; idx < nFeds; ++idx) {
+      for (auto it = fedBuffer->map().begin(); it != fedBuffer->map().end(); it++) {
+        auto singleFED = fedBuffer->fragmentData(it);
+        expectedSize += singleFED.size();
+      }
     }
   }
 
@@ -134,17 +171,37 @@ void RawEventOutputModuleForBU<Consumer>::write(edm::EventForOutput const& e) {
     *bufPtr++ = 0;
   }
   uint32_t* payloadPtr = bufPtr;
-  if (!sourceIdList_.empty()) {
-    for (int idx : sourceIdList_) {
-      auto singleFED = fedBuffer->fragmentData(idx);
-      memcpy(bufPtr, &singleFED.data()[0], singleFED.size());
-      bufPtr += singleFED.size() / 4;
+  if (usedRawType == 1) {
+    if (!sourceIdList_.empty()) {
+      for (int idx : sourceIdList_) {
+        FEDRawData singleFED = fedBuffers->FEDData(idx);
+        if (singleFED.size() > 0) {
+          memcpy(bufPtr, singleFED.data(), singleFED.size());
+          bufPtr += singleFED.size() / 4;
+        }
+      }
+    } else {
+      for (int idx = 0; idx < nFeds; ++idx) {
+        FEDRawData singleFED = fedBuffers->FEDData(idx);
+        if (singleFED.size() > 0) {
+          memcpy(bufPtr, singleFED.data(), singleFED.size());
+          bufPtr += singleFED.size() / 4;
+        }
+      }
     }
-  } else {
-    for (auto it = fedBuffer->map().begin(); it != fedBuffer->map().end(); it++) {
-      auto singleFED = fedBuffer->fragmentData(it);
-      memcpy(bufPtr, &singleFED.data()[0], singleFED.size());
-      bufPtr += singleFED.size() / 4;
+  } else if (usedRawType == 2) {
+    if (!sourceIdList_.empty()) {
+      for (int idx : sourceIdList_) {
+        auto singleFED = fedBuffer->fragmentData(idx);
+        memcpy(bufPtr, &singleFED.data()[0], singleFED.size());
+        bufPtr += singleFED.size() / 4;
+      }
+    } else {
+      for (auto it = fedBuffer->map().begin(); it != fedBuffer->map().end(); it++) {
+        auto singleFED = fedBuffer->fragmentData(it);
+        memcpy(bufPtr, &singleFED.data()[0], singleFED.size());
+        bufPtr += singleFED.size() / 4;
+      }
     }
   }
   if (frdVersion_) {
@@ -195,6 +252,8 @@ void RawEventOutputModuleForBU<Consumer>::fillDescriptions(edm::ConfigurationDes
   desc.add<edm::InputTag>("source", edm::InputTag("rawDataCollector"));
   desc.add<unsigned int>("numEventsPerFile", 100);
   desc.add<unsigned int>("frdVersion", 6);
+  desc.addUntracked<std::string>("rawProductName", "FEDRawDataCollection")
+      ->setComment("FEDRawDataCollection or RawDataBuffer");
   desc.addUntracked<std::vector<unsigned int>>("sourceIdList", std::vector<unsigned int>());
   Consumer::extendDescription(desc);
 

--- a/EventFilter/Utilities/test/startBU.py
+++ b/EventFilter/Utilities/test/startBU.py
@@ -171,7 +171,8 @@ elif  options.dataType == "DTH":
         numEventsPerFile = cms.uint32(options.eventsPerFile),
         frdVersion = cms.uint32(0),
         frdFileVersion = cms.uint32(0),
-        sourceIdList = cms.untracked.vuint32(66,1511)
+        sourceIdList = cms.untracked.vuint32(66,1511),
+        rawProductName = cms.untracked.string("RawDataBuffer")
     )
 
 if options.conversionTest:


### PR DESCRIPTION
#### PR description:

Fix for a problem reported in #48421, where HLTrigger/Tools test was broken.
DaqFakeReader is fully reverted to the version before #48421 (and will fill again FEDRawDataCollection), and RawEvenOutputModule is modified to support both formats via a parameter.

For Phase-2, parameter has to be specified to use the the new format in the output module.

#### PR validation:

Passes test scripts and should pass equivalent unit tests for EventFilter/Utilities using both FEDRawDataCollection and RawDataBuffer formats.
However this does not check HLTrigger/Tools and they might not run as part of test procedure.
**Question:** is there a way to trigger them with this PR?
