### PR TITLE
Run3_sim164 Create separate flags for HcalTestNumbering for signal and PU samples to enable different sources for these 2 types of samples

### DIFF
--- a/SimCalorimetry/HcalSimAlgos/python/AddCaloSamplesAnalyzer.py
+++ b/SimCalorimetry/HcalSimAlgos/python/AddCaloSamplesAnalyzer.py
@@ -25,7 +25,7 @@ def customise(process):
         hoHamamatsu = hcaldigi.hoHamamatsu,
         # from hcalUnsuppressedDigis
         hitsProducer = hcaldigi.hitsProducer,
-        TestNumbering = hcaldigi.TestNumbering,
+        TestNumbering = hcaldigi.TestNumberingPU,
         CaloSamplesTag = cms.InputTag(cstag,"HcalSamples"),
     )
 

--- a/SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h
+++ b/SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h
@@ -69,7 +69,8 @@ private:
                           int bunchCrossing,
                           CLHEP::HepRandomEngine *,
                           const HcalTopology *h,
-                          const ZdcTopology *z);
+                          const ZdcTopology *z,
+			  bool signal);
 
   /// some hits in each subdetector, just for testing purposes
   void fillFakeHits();
@@ -169,6 +170,7 @@ private:
 
   bool isZDC, isHCAL, zdcgeo, hbhegeo, hogeo, hfgeo;
   bool testNumbering_;
+  bool testNumberingPU_;
   bool doHFWindow_;
   bool killHE_;
   bool debugCS_;

--- a/SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h
+++ b/SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h
@@ -70,7 +70,7 @@ private:
                           CLHEP::HepRandomEngine *,
                           const HcalTopology *h,
                           const ZdcTopology *z,
-			  bool signal);
+                          bool signal);
 
   /// some hits in each subdetector, just for testing purposes
   void fillFakeHits();

--- a/SimCalorimetry/HcalSimProducers/python/hcalUnsuppressedDigis_cfi.py
+++ b/SimCalorimetry/HcalSimProducers/python/hcalUnsuppressedDigis_cfi.py
@@ -23,6 +23,7 @@ hcalSimBlock = cms.PSet(
     hitsProducer = cms.string('g4SimHits'),
     DelivLuminosity = cms.double(0),
     TestNumbering = cms.bool(False),
+    TestNumberingPU = cms.bool(False),
     doNeutralDensityFilter = cms.bool(True),
     HBDarkening = cms.bool(False),
     HEDarkening = cms.bool(False),
@@ -60,7 +61,9 @@ premix_stage1.toModify(hcalSimBlock,
 
 # test numbering not used in fastsim
 from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
-(run2_HCAL_2017 & ~fastSim).toModify( hcalSimBlock, TestNumbering = True )
+(run2_HCAL_2017 & ~fastSim).toModify( hcalSimBlock,
+                                      TestNumbering = True,
+                                      TestNumberingPU = True )
 
 # remove HE processing for phase 2, completely put in HGCal land
 # Also inhibit ZDC digitization

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
@@ -218,7 +218,8 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet &ps, edm::ConsumesCollector
   testNumbering_ = ps.getParameter<bool>("TestNumbering");
   testNumberingPU_ = ps.getParameter<bool>("TestNumberingPU");
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HcalSim") << "Flag to see if Hit Relabeller to be initiated " << testNumbering_ << ":" << testNumberingPU_;
+  edm::LogVerbatim("HcalSim") << "Flag to see if Hit Relabeller to be initiated " << testNumbering_ << ":"
+                              << testNumberingPU_;
 #endif
   if (testNumbering_ || testNumberingPU_)
     theRelabeller = std::make_unique<HcalHitRelabeller>(ps.getParameter<bool>("doNeutralDensityFilter"));
@@ -361,7 +362,7 @@ void HcalDigitizer::accumulateCaloHits(edm::Handle<std::vector<PCaloHit>> const 
                                        CLHEP::HepRandomEngine *engine,
                                        const HcalTopology *htopoP,
                                        const ZdcTopology *ztopoP,
-				       bool signal) {
+                                       bool signal) {
   // Step A: pass in inputs, and accumulate digis
   if (isHCAL) {
     std::vector<PCaloHit> hcalHitsOrig = *hcalHandle.product();


### PR DESCRIPTION
#### PR description:

Create separate flags for HcalTestNumbering for signal and PU samples to enable different sources for these 2 types of samples

#### PR validation:

Use the runTheMatrix test workflows

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Need to go to the build for special mixing