### PR TITLE
apply `stage2` L1T customizations to `TrackToTrackComparisonHists`

### DIFF
--- a/DQM/TrackingMonitorSource/python/TrackToTrackComparisonHists_cfi.py
+++ b/DQM/TrackingMonitorSource/python/TrackToTrackComparisonHists_cfi.py
@@ -6,6 +6,14 @@ from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 
 TrackToTrackComparisonHists = trackToTrackComparisonHists.clone()
 
+from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+stage2L1Trigger.toModify(TrackToTrackComparisonHists,
+                         genericTriggerEventPSet = dict(stage2 = cms.bool(True),
+                                                        l1tAlgBlkInputTag = cms.InputTag("gtStage2Digis"),
+                                                        l1tExtBlkInputTag = cms.InputTag("gtStage2Digis"),
+                                                        ReadPrescalesFromFile = cms.bool(False))
+                         )
+
 run3_common.toModify(TrackToTrackComparisonHists.histoPSet, Eta_rangeMin=-3.,Eta_rangeMax =3.)
 run3_common.toModify(TrackToTrackComparisonHists.histoPSet, onlinelumi_nbin=375, onlinelumi_rangeMin=200., onlinelumi_rangeMax=25000.)
 phase2_common.toModify(TrackToTrackComparisonHists.histoPSet, Eta_rangeMin=-4.,Eta_rangeMax =4.)


### PR DESCRIPTION
#### PR description:

Title say it all, similar in spirit to https://github.com/cms-sw/cmssw/pull/37033.
See also https://github.com/cms-sw/cmssw/issues/37016.

#### PR validation:

The following script:

```bash
#!/bin/bash -ex

cmsDriver.py step2 -s HLT:@relval2025,DQM:hltToOfflineTrackValidatorSequence \
         --conditions 150X_dataRun3_HLT_v1 \
         --datatier DQMIO \
         -n 100 \
         --eventcontent DQMIO \
         --geometry DB:Extended \
         --era Run3_2025 \
         --filein file:/eos/cms/store/express/Run2025C/HLTMonitor/FEVTHLTALL/Express-v2/000/393/240/00000/04d4a103-3bea-43b3-84b0-b68954534572.root \
         --fileout file:step2.root \
         --nThreads 24 \
         --process HLTX \
         --inputCommands='keep *, drop *_hlt*_*_HLT, drop triggerTriggerFilterObjectWithRefs_l1t*_*_HLT' \
         > step2.log  2>&1

cmsDriver.py step3 -s HARVESTING:trackEfficiencyMonitoringClientHLT \
         --conditions 150X_dataRun3_HLT_v1 \
         --data \
         --geometry DB:Extended \
         --scenario pp \
         --filetype DQM \
         --era Run3_2025 \
         -n -1  \
         --filein file:step2.root \
         --fileout file:step3.root > step3.log  2>&1
```

completes successfully, while in the vanilla release it fails with:

```
----- Begin Fatal Exception 29-Jun-2025 18:26:46 CEST-----------------------
An exception of category 'NoRecord' occurred while
   [0] Processing  stream begin Run run: 393240 stream: 21
   [1] Calling method for module TrackToTrackComparisonHists/'hltEgammaGsfTracksVsOfflinePV'
Exception Message:
No "L1GtStableParametersRcd" record found in the EventSetup.

 Please add an ESSource or ESProducer that delivers such a record.
----- End Fatal Exception -------------------------------------------------
```

Now clearly in presence of the `Run3_2025` the cmsRun configuration should not request to use Legacy Stage-0/1 Global Trigger records.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but will be backported to CMSSW_15_0_X for 2025 data-taking operations.
