### PR TITLE
[15_0_X]: Add protection to skip addition FSC channels.

### DIFF
--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -254,7 +254,12 @@ void HcalTriggerPrimitiveAlgo::addSignal(const QIE10DataFrame& frame) {
     }
   } else if (detId.det() == DetId::Calo && detId.subdetId() == HcalZDCDetId::SubdetectorId) {
     HcalZDCDetId detId = frame.detid();
+    // skip RPD Channels
     if (detId.section() != HcalZDCDetId::EM && detId.section() != HcalZDCDetId::HAD) {
+      return;
+    }
+    // skip FSC and dummy channels
+    if (detId.section() == HcalZDCDetId::EM && detId.channel() > 5) {
       return;
     }
 


### PR DESCRIPTION
#### PR description:

This PR adds an additional protection needed in order to skip the additional FSC channels added in the 2025 small systems run for the trigger primitive algorithm. This is done in a manner similar to how RPD channels are skipped. The PR is a fix for the problem described in the [CMS Talk](https://cms-talk.web.cern.ch/t/hlt-prompt-full-track-validation-zdc-electronicsmap-update/126390/3) and is needed in order to validate that new HCAL electronics map.

#### PR validation:

The PR was tested using the offline DQM as a test case as described in this [dropbox paper.](https://paper.dropbox.com/doc/2025-Emap-DQM-Test--CovB~lDgeyik81JJuOZqGKiyAQ-ijVWcmaCkCdQ7oGK33fyb)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is a backport of https://github.com/cms-sw/cmssw/pull/48444

Tagging @JHiltbrand @akhukhun @mandrenguyen @abdoulline so they can follow along. @perrotta this is also related to the ongoing validation of the emap.
