### PR TITLE
Run3-Sim164X Separate HcalTestNumbering flag for signal and PU which enables signal from FullSim and PU from FastSim

### DIFF
--- a/SimCalorimetry/HcalSimAlgos/python/AddCaloSamplesAnalyzer.py
+++ b/SimCalorimetry/HcalSimAlgos/python/AddCaloSamplesAnalyzer.py
@@ -25,7 +25,7 @@ def customise(process):
         hoHamamatsu = hcaldigi.hoHamamatsu,
         # from hcalUnsuppressedDigis
         hitsProducer = hcaldigi.hitsProducer,
-        TestNumbering = hcaldigi.TestNumbering,
+        TestNumbering = hcaldigi.TestNumberingPU,
         CaloSamplesTag = cms.InputTag(cstag,"HcalSamples"),
     )
 

--- a/SimCalorimetry/HcalSimAlgos/python/AddCaloSamplesAnalyzer.py
+++ b/SimCalorimetry/HcalSimAlgos/python/AddCaloSamplesAnalyzer.py
@@ -25,7 +25,7 @@ def customise(process):
         hoHamamatsu = hcaldigi.hoHamamatsu,
         # from hcalUnsuppressedDigis
         hitsProducer = hcaldigi.hitsProducer,
-        TestNumbering = hcaldigi.TestNumberingPU,
+        TestNumbering = hcaldigi.TestNumbering,
         CaloSamplesTag = cms.InputTag(cstag,"HcalSamples"),
     )
 

--- a/SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h
+++ b/SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h
@@ -69,7 +69,8 @@ private:
                           int bunchCrossing,
                           CLHEP::HepRandomEngine *,
                           const HcalTopology *h,
-                          const ZdcTopology *z);
+                          const ZdcTopology *z,
+			  bool signal);
 
   /// some hits in each subdetector, just for testing purposes
   void fillFakeHits();
@@ -169,6 +170,7 @@ private:
 
   bool isZDC, isHCAL, zdcgeo, hbhegeo, hogeo, hfgeo;
   bool testNumbering_;
+  bool testNumberingPU_;
   bool doHFWindow_;
   bool killHE_;
   bool debugCS_;

--- a/SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h
+++ b/SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h
@@ -70,7 +70,7 @@ private:
                           CLHEP::HepRandomEngine *,
                           const HcalTopology *h,
                           const ZdcTopology *z,
-			  bool signal);
+                          bool signal);
 
   /// some hits in each subdetector, just for testing purposes
   void fillFakeHits();

--- a/SimCalorimetry/HcalSimProducers/python/hcalUnsuppressedDigis_cfi.py
+++ b/SimCalorimetry/HcalSimProducers/python/hcalUnsuppressedDigis_cfi.py
@@ -24,6 +24,7 @@ hcalSimBlock = cms.PSet(
     hitsProducerPU = cms.string('g4SimHits'),
     DelivLuminosity = cms.double(0),
     TestNumbering = cms.bool(False),
+    TestNumberingPU = cms.bool(False),
     doNeutralDensityFilter = cms.bool(True),
     HBDarkening = cms.bool(False),
     HEDarkening = cms.bool(False),
@@ -67,7 +68,11 @@ premix_stage1.toModify(hcalSimBlock,
 
 # test numbering not used in fastsim
 from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
-(run2_HCAL_2017 & ~fastSim).toModify( hcalSimBlock, TestNumbering = True )
+(run2_HCAL_2017 & ~fastSim).toModify( hcalSimBlock,
+                                      TestNumbering = True,
+                                      TestNumberingPU = True )
+(run2_HCAL_2017 & fastSimPU).toModify( hcalSimBlock,
+                                       TestNumberingPU = False )
 
 # remove HE processing for phase 2, completely put in HGCal land
 # Also inhibit ZDC digitization

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
@@ -225,7 +225,7 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet &ps, edm::ConsumesCollector
   testNumbering_ = ps.getParameter<bool>("TestNumbering");
   testNumberingPU_ = ps.getParameter<bool>("TestNumberingPU");
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HcalSim") << "Flag to see if Hit Relabeller to be initiated " << testNumbering_<< ":"
+  edm::LogVerbatim("HcalSim") << "Flag to see if Hit Relabeller to be initiated " << testNumbering_ << ":"
                               << testNumberingPU_;
 #endif
   if (testNumbering_ || testNumberingPU_)


### PR DESCRIPTION
#### PR description:

Separate HcalTestNumbering flag for signal and PU which enables signal from FullSim and PU from FastSim

#### PR validation:

Use the runTheMatrix test workflows

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special