### PR TITLE
[HGCAL] Update HGCal unpacker to handle flexible fedId assignment

### DIFF
--- a/EventFilter/HGCalRawToDigi/plugins/HGCalRawToDigi.cc
+++ b/EventFilter/HGCalRawToDigi/plugins/HGCalRawToDigi.cc
@@ -104,6 +104,10 @@ void HGCalRawToDigi::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
   //serial unpacking calls
   if (doSerial_) {
     for (unsigned fedId = 0; fedId < moduleIndexer.fedCount(); ++fedId) {
+      const auto& frs = moduleIndexer.getFEDReadoutSequences()[fedId];
+      if (frs.readoutTypes_.empty()) {
+        continue;
+      }
       const auto& fed_data = raw_data.FEDData(fedId);
       fedPacketInfo.view()[fedId].FEDPayload() = fed_data.size();
       if (fed_data.size() == 0)
@@ -116,6 +120,10 @@ void HGCalRawToDigi::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
   else {
     oneapi::tbb::this_task_arena::isolate([&]() {
       oneapi::tbb::parallel_for(0U, moduleIndexer.fedCount(), [&](unsigned fedId) {
+        const auto& frs = moduleIndexer.getFEDReadoutSequences()[fedId];
+        if (frs.readoutTypes_.empty()) {
+          return;
+        }
         const auto& fed_data = raw_data.FEDData(fedId);
         fedPacketInfo.view()[fedId].FEDPayload() = fed_data.size();
         if (fed_data.size() == 0)

--- a/RecoLocalCalo/HGCalRecAlgos/plugins/HGCalConfigurationESProducer.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/plugins/HGCalConfigurationESProducer.cc
@@ -97,6 +97,7 @@ public:
     // follow indexing by HGCalMappingModuleIndexer
     // HGCalConfiguration = container class holding FED structs of ECON-D structs of eRx structs
     std::unique_ptr<HGCalConfiguration> config_ = std::make_unique<HGCalConfiguration>();
+    config_->feds.resize(moduleMap.getMaxFEDSize());
     for (std::size_t fedid = 0; fedid < moduleMap.getMaxFEDSize(); ++fedid) {
       // sanity checks
       if (moduleMap.getFEDReadoutSequences()[fedid].readoutTypes_.empty())         // check if FED exists (non-empty)
@@ -153,7 +154,7 @@ public:
         fed.econds[imod] = mod;  // add to FED's vector<HGCalECONDConfig> of ECON-D modules
       }
 
-      config_->feds.push_back(fed);  // add to config's vector of HGCalFedConfig FEDs
+      config_->feds[fedid] = fed;  // add to config's vector of HGCalFedConfig FEDs
     }
 
     // consistency check


### PR DESCRIPTION
#### PR description:

This PR updates the HGCal unpacker code to allow for flexible fedId assignment for unpacking. The fedIds can be specified in the module locator map file and then only raw data in those specified fedIds will be processed by the unpackers.

Additionally, the debugging output of HGCalUnpacker is also improved to be more clear and informative. 

#### PR validation:

Standard matrix tests.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

No backport is needed.