### PR TITLE
Introduce a stub of `LHCInfoPer*` Payload Inspector

### DIFF
--- a/CondCore/RunInfoPlugins/plugins/BuildFile.xml
+++ b/CondCore/RunInfoPlugins/plugins/BuildFile.xml
@@ -3,3 +3,14 @@
   <use name="CondCore/Utilities"/>
   <use name="CondCore/CondDB"/>
 </library>
+
+<library file="LHCInfoPerFill_PayloadInspector.cc" name="LHCInfoPerFill_PayloadInspector">
+  <use name="CondCore/Utilities"/>
+  <use name="CondCore/CondDB"/>
+</library>
+
+<library file="LHCInfoPerLS_PayloadInspector.cc" name="LHCInfoPerLS_PayloadInspector">
+  <use name="CondCore/Utilities"/>
+  <use name="CondCore/CondDB"/>
+</library>
+

--- a/CondCore/RunInfoPlugins/plugins/LHCInfoPerFill_PayloadInspector.cc
+++ b/CondCore/RunInfoPlugins/plugins/LHCInfoPerFill_PayloadInspector.cc
@@ -1,0 +1,51 @@
+#include "CondCore/Utilities/interface/PayloadInspectorModule.h"
+#include "CondCore/Utilities/interface/PayloadInspector.h"
+#include "CondFormats/RunInfo/interface/LHCInfoPerFill.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include <sstream>
+#include <memory>
+#include "TLatex.h"
+#include "TCanvas.h"
+
+namespace {
+
+  class LHCInfoPerFill_Display : public cond::payloadInspector::PlotImage<LHCInfoPerFill> {
+  public:
+    LHCInfoPerFill_Display()
+        : cond::payloadInspector::PlotImage<LHCInfoPerFill>("LHCInfoPerFill Inspector - Display") {}
+
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
+      std::shared_ptr<LHCInfoPerFill> payload = fetchPayload(std::get<1>(iov));
+      if (!payload) {
+        return false;
+      }
+      std::ostringstream ss;
+      ss << "LHCInfoPerFill Inspector\n\n";
+      ss << "Fill Number: " << payload->fillNumber() << "\n";
+      ss << "Beam Energy: " << payload->energy() << "\n";
+      ss << "Deliv Lumi: " << payload->delivLumi() << "\n";
+      ss << "Rec Lumi: " << payload->recLumi() << "\n";
+      ss << "Inst Lumi: " << payload->instLumi() << "\n";
+      ss << "Injection Scheme: " << payload->injectionScheme() << "\n";
+      ss << "Colliding Bunches: " << payload->collidingBunches() << "\n";
+      ss << "Target Bunches: " << payload->targetBunches() << "\n";
+      // Add more fields as needed
+
+      std::string outText = ss.str();
+      // Save as a simple image (text on white bg)
+      TCanvas canvas("c", "c", 800, 600);
+      TLatex latex;
+      latex.SetTextSize(0.03);
+      latex.DrawLatexNDC(0.05, 0.95, outText.c_str());
+      std::string fileName = "LHCInfoPerFill.png";
+      canvas.SaveAs(fileName.c_str());
+      return true;
+    }
+  };
+
+}  // namespace
+
+PAYLOAD_INSPECTOR_MODULE(LHCInfoPerFill) { PAYLOAD_INSPECTOR_CLASS(LHCInfoPerFill_Display); }

--- a/CondCore/RunInfoPlugins/plugins/LHCInfoPerFill_PayloadInspector.cc
+++ b/CondCore/RunInfoPlugins/plugins/LHCInfoPerFill_PayloadInspector.cc
@@ -22,24 +22,29 @@ namespace {
       if (!payload) {
         return false;
       }
-      std::ostringstream ss;
-      ss << "LHCInfoPerFill Inspector\n\n";
-      ss << "Fill Number: " << payload->fillNumber() << "\n";
-      ss << "Beam Energy: " << payload->energy() << "\n";
-      ss << "Deliv Lumi: " << payload->delivLumi() << "\n";
-      ss << "Rec Lumi: " << payload->recLumi() << "\n";
-      ss << "Inst Lumi: " << payload->instLumi() << "\n";
-      ss << "Injection Scheme: " << payload->injectionScheme() << "\n";
-      ss << "Colliding Bunches: " << payload->collidingBunches() << "\n";
-      ss << "Target Bunches: " << payload->targetBunches() << "\n";
-      // Add more fields as needed
 
-      std::string outText = ss.str();
-      // Save as a simple image (text on white bg)
-      TCanvas canvas("c", "c", 800, 600);
+      std::vector<std::string> lines;
+      lines.push_back("LHCInfoPerFill Inspector");
+      lines.push_back("");
+      lines.push_back("Fill Number: " + std::to_string(payload->fillNumber()));
+      lines.push_back("Beam Energy: " + std::to_string(payload->energy()));
+      lines.push_back("Deliv Lumi: " + std::to_string(payload->delivLumi()));
+      lines.push_back("Rec Lumi: " + std::to_string(payload->recLumi()));
+      lines.push_back("Inst Lumi: " + std::to_string(payload->instLumi()));
+      lines.push_back("Injection Scheme: " + payload->injectionScheme());
+      lines.push_back("Colliding Bunches: " + std::to_string(payload->collidingBunches()));
+      lines.push_back("Target Bunches: " + std::to_string(payload->targetBunches()));
+
+      TCanvas canvas("c","c",800,600);
+      canvas.cd();
       TLatex latex;
       latex.SetTextSize(0.03);
-      latex.DrawLatexNDC(0.05, 0.95, outText.c_str());
+      
+      float startY = 0.95;
+      float stepY = 0.06;
+      for (std::size_t i = 0; i < lines.size(); ++i) {
+	latex.DrawLatexNDC(0.05, startY - i * stepY, lines[i].c_str());
+      }
       std::string fileName = "LHCInfoPerFill.png";
       canvas.SaveAs(fileName.c_str());
       return true;

--- a/CondCore/RunInfoPlugins/plugins/LHCInfoPerFill_PayloadInspector.cc
+++ b/CondCore/RunInfoPlugins/plugins/LHCInfoPerFill_PayloadInspector.cc
@@ -23,30 +23,55 @@ namespace {
         return false;
       }
 
-      std::vector<std::string> lines;
-      lines.push_back("LHCInfoPerFill Inspector");
-      lines.push_back("");
-      lines.push_back("Fill Number: " + std::to_string(payload->fillNumber()));
-      lines.push_back("Beam Energy: " + std::to_string(payload->energy()));
-      lines.push_back("Deliv Lumi: " + std::to_string(payload->delivLumi()));
-      lines.push_back("Rec Lumi: " + std::to_string(payload->recLumi()));
-      lines.push_back("Inst Lumi: " + std::to_string(payload->instLumi()));
-      lines.push_back("Injection Scheme: " + payload->injectionScheme());
-      lines.push_back("Colliding Bunches: " + std::to_string(payload->collidingBunches()));
-      lines.push_back("Target Bunches: " + std::to_string(payload->targetBunches()));
+      std::vector<std::pair<std::string, std::string>> items;
+      items.push_back({"Fill Number: ", std::to_string(payload->fillNumber())});
+      items.push_back({"Beam Energy: ", std::to_string(payload->energy())});
+      items.push_back({"Deliv Lumi: ", std::to_string(payload->delivLumi())});
+      items.push_back({"Rec Lumi: ", std::to_string(payload->recLumi())});
+      items.push_back({"Inst Lumi: ", std::to_string(payload->instLumi())});
+      items.push_back({"Injection Scheme: ", payload->injectionScheme()});
+      items.push_back({"Colliding Bunches: ", std::to_string(payload->collidingBunches())});
+      items.push_back({"Target Bunches: ", std::to_string(payload->targetBunches())});
 
-      TCanvas canvas("c","c",800,600);
+      TCanvas canvas("c", "c", 800, 600);
       canvas.cd();
       TLatex latex;
       latex.SetTextSize(0.03);
-      
+
       float startY = 0.95;
       float stepY = 0.06;
-      for (std::size_t i = 0; i < lines.size(); ++i) {
-	latex.DrawLatexNDC(0.05, startY - i * stepY, lines[i].c_str());
+
+      // Print the title
+      latex.SetTextColor(kBlack);
+      latex.DrawLatexNDC(0.05, startY, "LHCInfoPerFill Inspector");
+
+      // Print the fields with values in red
+      for (std::size_t i = 0; i < items.size(); ++i) {
+        float y = startY - (i + 2) * stepY;  // +2 to skip title and add a blank line
+        // Print key in black
+        latex.SetTextColor(kBlack);
+        latex.DrawLatexNDC(0.05, y, items[i].first.c_str());
+        // Print value in red, offset to the right (adjust offset as needed)
+        latex.SetTextColor(kRed);
+        latex.DrawLatexNDC(0.30, y, items[i].second.c_str());
       }
-      std::string fileName = "LHCInfoPerFill.png";
+
+      // info
+      TLatex t1;
+      t1.SetNDC();
+      t1.SetTextAlign(12);
+      t1.SetTextSize(0.04);
+      t1.DrawLatex(0.1, 0.18, "LHCInfo parameters:");
+      t1.DrawLatex(0.1, 0.15, "payload:");
+
+      t1.SetTextFont(42);
+      t1.SetTextColor(4);
+      t1.DrawLatex(0.37, 0.182, Form("IOV %s", std::to_string(+std::get<0>(iov)).c_str()));
+      t1.DrawLatex(0.21, 0.152, Form(" %s", (std::get<1>(iov)).c_str()));
+
+      std::string fileName(m_imageFileName);
       canvas.SaveAs(fileName.c_str());
+
       return true;
     }
   };

--- a/CondCore/RunInfoPlugins/plugins/LHCInfoPerLS_PayloadInspector.cc
+++ b/CondCore/RunInfoPlugins/plugins/LHCInfoPerLS_PayloadInspector.cc
@@ -1,0 +1,48 @@
+#include "CondCore/Utilities/interface/PayloadInspectorModule.h"
+#include "CondCore/Utilities/interface/PayloadInspector.h"
+#include "CondFormats/RunInfo/interface/LHCInfoPerLS.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include <sstream>
+#include <memory>
+#include "TLatex.h"
+#include "TCanvas.h"
+
+namespace {
+
+  class LHCInfoPerLS_Display : public cond::payloadInspector::PlotImage<LHCInfoPerLS> {
+  public:
+    LHCInfoPerLS_Display() : cond::payloadInspector::PlotImage<LHCInfoPerLS>("LHCInfoPerLS Inspector - Display") {}
+
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
+      std::shared_ptr<LHCInfoPerLS> payload = fetchPayload(std::get<1>(iov));
+      if (!payload) {
+        return false;
+      }
+      std::ostringstream ss;
+      ss << "LHCInfoPerLS Inspector\n\n";
+      ss << "LS: " << payload->lumiSection() << "\n";
+      ss << "crossingAngleX: " << payload->crossingAngleX() << "\n";
+      ss << "crossingAngleY: " << payload->crossingAngleY() << "\n";
+      ss << "betaStarX: " << payload->betaStarX() << "\n";
+      ss << "betaStarY: " << payload->betaStarY() << "\n";
+      ss << "runNumber: " << payload->runNumber() << "\n";
+      // Add more fields as needed
+
+      std::string outText = ss.str();
+      // Save as a simple image (text on white bg)
+      TCanvas canvas("c", "c", 800, 600);
+      TLatex latex;
+      latex.SetTextSize(0.03);
+      latex.DrawLatexNDC(0.05, 0.95, outText.c_str());
+      std::string fileName = "LHCInfoPerLS.png";
+      canvas.SaveAs(fileName.c_str());
+      return true;
+    }
+  };
+
+}  // namespace
+
+PAYLOAD_INSPECTOR_MODULE(LHCInfoPerLS) { PAYLOAD_INSPECTOR_CLASS(LHCInfoPerLS_Display); }

--- a/CondCore/RunInfoPlugins/plugins/LHCInfoPerLS_PayloadInspector.cc
+++ b/CondCore/RunInfoPlugins/plugins/LHCInfoPerLS_PayloadInspector.cc
@@ -21,22 +21,28 @@ namespace {
       if (!payload) {
         return false;
       }
-      std::ostringstream ss;
-      ss << "LHCInfoPerLS Inspector\n\n";
-      ss << "LS: " << payload->lumiSection() << "\n";
-      ss << "crossingAngleX: " << payload->crossingAngleX() << "\n";
-      ss << "crossingAngleY: " << payload->crossingAngleY() << "\n";
-      ss << "betaStarX: " << payload->betaStarX() << "\n";
-      ss << "betaStarY: " << payload->betaStarY() << "\n";
-      ss << "runNumber: " << payload->runNumber() << "\n";
+      // Prepare lines for printing
+      std::vector<std::string> lines;
+      lines.push_back("LHCInfoPerLS Inspector");
+      lines.push_back("");
+      lines.push_back("LS: " + std::to_string(payload->lumiSection()));
+      lines.push_back("crossingAngleX: " + std::to_string(payload->crossingAngleX()));
+      lines.push_back("crossingAngleY: " + std::to_string(payload->crossingAngleY()));
+      lines.push_back("betaStarX: " + std::to_string(payload->betaStarX()));
+      lines.push_back("betaStarY: " + std::to_string(payload->betaStarY()));
+      lines.push_back("runNumber: " + std::to_string(payload->runNumber()));
       // Add more fields as needed
 
-      std::string outText = ss.str();
-      // Save as a simple image (text on white bg)
-      TCanvas canvas("c", "c", 800, 600);
+      TCanvas canvas("c","c",800,600);
+      canvas.cd();
       TLatex latex;
       latex.SetTextSize(0.03);
-      latex.DrawLatexNDC(0.05, 0.95, outText.c_str());
+      
+      float startY = 0.95;
+      float stepY = 0.06;
+      for (std::size_t i = 0; i < lines.size(); ++i) {
+	latex.DrawLatexNDC(0.05, startY - i * stepY, lines[i].c_str());
+      }
       std::string fileName = "LHCInfoPerLS.png";
       canvas.SaveAs(fileName.c_str());
       return true;

--- a/CondCore/RunInfoPlugins/plugins/LHCInfoPerLS_PayloadInspector.cc
+++ b/CondCore/RunInfoPlugins/plugins/LHCInfoPerLS_PayloadInspector.cc
@@ -21,30 +21,57 @@ namespace {
       if (!payload) {
         return false;
       }
-      // Prepare lines for printing
-      std::vector<std::string> lines;
-      lines.push_back("LHCInfoPerLS Inspector");
-      lines.push_back("");
-      lines.push_back("LS: " + std::to_string(payload->lumiSection()));
-      lines.push_back("crossingAngleX: " + std::to_string(payload->crossingAngleX()));
-      lines.push_back("crossingAngleY: " + std::to_string(payload->crossingAngleY()));
-      lines.push_back("betaStarX: " + std::to_string(payload->betaStarX()));
-      lines.push_back("betaStarY: " + std::to_string(payload->betaStarY()));
-      lines.push_back("runNumber: " + std::to_string(payload->runNumber()));
+
+      // Prepare label-value pairs for printing
+      std::vector<std::pair<std::string, std::string>> items;
+      items.push_back({"LS: ", std::to_string(payload->lumiSection())});
+      items.push_back({"crossingAngleX: ", std::to_string(payload->crossingAngleX())});
+      items.push_back({"crossingAngleY: ", std::to_string(payload->crossingAngleY())});
+      items.push_back({"betaStarX: ", std::to_string(payload->betaStarX())});
+      items.push_back({"betaStarY: ", std::to_string(payload->betaStarY())});
+      items.push_back({"runNumber: ", std::to_string(payload->runNumber())});
       // Add more fields as needed
 
-      TCanvas canvas("c","c",800,600);
+      TCanvas canvas("c", "c", 800, 600);
       canvas.cd();
       TLatex latex;
       latex.SetTextSize(0.03);
-      
+
       float startY = 0.95;
       float stepY = 0.06;
-      for (std::size_t i = 0; i < lines.size(); ++i) {
-	latex.DrawLatexNDC(0.05, startY - i * stepY, lines[i].c_str());
+
+      // Print the title
+      latex.SetTextColor(kBlack);
+      latex.DrawLatexNDC(0.05, startY, "LHCInfoPerLS Inspector");
+
+      // Leave a blank line under the title
+      std::size_t offset = 2;
+
+      // Print each item: label in black, value in red
+      for (std::size_t i = 0; i < items.size(); ++i) {
+        float y = startY - (i + offset) * stepY;
+        latex.SetTextColor(kBlack);
+        latex.DrawLatexNDC(0.05, y, items[i].first.c_str());
+        latex.SetTextColor(kRed);
+        latex.DrawLatexNDC(0.30, y, items[i].second.c_str());
       }
-      std::string fileName = "LHCInfoPerLS.png";
+
+      // info
+      TLatex t1;
+      t1.SetNDC();
+      t1.SetTextAlign(12);
+      t1.SetTextSize(0.04);
+      t1.DrawLatex(0.1, 0.18, "LHCInfo parameters:");
+      t1.DrawLatex(0.1, 0.15, "payload:");
+
+      t1.SetTextFont(42);
+      t1.SetTextColor(4);
+      t1.DrawLatex(0.37, 0.182, Form("IOV %s", std::to_string(+std::get<0>(iov)).c_str()));
+      t1.DrawLatex(0.21, 0.152, Form(" %s", (std::get<1>(iov)).c_str()));
+
+      std::string fileName(m_imageFileName);
       canvas.SaveAs(fileName.c_str());
+
       return true;
     }
   };

--- a/CondCore/RunInfoPlugins/test/testRunInfoPayloadInspector.cpp
+++ b/CondCore/RunInfoPlugins/test/testRunInfoPayloadInspector.cpp
@@ -2,7 +2,8 @@
 #include <sstream>
 #include "CondCore/Utilities/interface/PayloadInspector.h"
 #include "CondCore/RunInfoPlugins/plugins/RunInfo_PayloadInspector.cc"
-
+#include "CondCore/RunInfoPlugins/plugins/LHCInfoPerFill_PayloadInspector.cc"
+#include "CondCore/RunInfoPlugins/plugins/LHCInfoPerLS_PayloadInspector.cc"
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
@@ -38,5 +39,26 @@ int main(int argc, char** argv) {
   RunInfoBFieldHistory histo2;
   histo2.process(connectionString, PI::mk_input(tag, start, end));
   std::cout << histo2.data() << std::endl;
+
+  std::cout << "## LHCInfoPerFill testing" << std::endl;
+
+  tag = "LHCInfoPerFill_duringFill_hlt_v1";
+  start = static_cast<unsigned long long>(1686852700471354);
+  end = static_cast<unsigned long long>(1686852700471354);
+
+  LHCInfoPerFill_Display histo3;
+  histo3.process(connectionString, PI::mk_input(tag, end, end));
+  std::cout << histo3.data() << std::endl;
+
+  std::cout << "## LHCInfoPerLS testing" << std::endl;
+
+  tag = "LHCInfoPerLS_duringFill_hlt_v1";
+  start = static_cast<unsigned long long>(1690138350452868);
+  end = static_cast<unsigned long long>(1690138350452868);
+
+  LHCInfoPerLS_Display histo4;
+  histo4.process(connectionString, PI::mk_input(tag, end, end));
+  std::cout << histo4.data() << std::endl;
+
   Py_Finalize();
 }

--- a/CondCore/RunInfoPlugins/test/testRunInfoPayloadInspector.sh
+++ b/CondCore/RunInfoPlugins/test/testRunInfoPayloadInspector.sh
@@ -27,3 +27,12 @@ mv *.png $W_DIR/plots/fake_payload.png
 
 getPayloadData.py --plugin pluginRunInfo_PayloadInspector --plot plot_RunInfoParameters --tag runinfo_31X_hlt --time_type Run --iovs '{"start_iov": "312259", "end_iov": "312259"}' --db Prod --test ;
 mv *.png $W_DIR/plots/OK_payload.png
+
+####################
+# Test LHCInfo
+####################
+getPayloadData.py --plugin pluginLHCInfoPerLS_PayloadInspector --plot plot_LHCInfoPerLS_Display --tag LHCInfoPerLS_duringFill_hlt_v1 --time_type LS --iovs '{"start_iov": "1690138350452868", "end_iov": "1690138350452868"}' --db Prod --test ;
+mv *.png  $W_DIR/plots/LHCInfoPerLS.png
+
+getPayloadData.py --plugin pluginLHCInfoPerFill_PayloadInspector --plot plot_LHCInfoPerFill_Display --tag LHCInfoPerFill_duringFill_hlt_v1 --time_type LS --iovs '{"start_iov": "1686852700471354", "end_iov": "1686852700471354"}' --db Prod --test ;
+mv *.png  $W_DIR/plots/LHCInfoPerFill.png


### PR DESCRIPTION
#### PR description:

This PR is a first step follow-up to https://github.com/cms-AlCaDB/AlCaTools/issues/103. 
Introduces two simple payload inspector classes `LHCInfoPerFill_Display` and `LHCInfoPerLS_Display` to show most salient parameters of the respective payload types.
More parameters and view might be added in follow-up PRs
 
#### PR validation:

Relies on the (augmented) unit tests of this package.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, not to be backported.