### PR TITLE
fix the loop range in mkFit MkFinder hit checks

### DIFF
--- a/RecoTracker/MkFitCore/src/MkFinder.cc
+++ b/RecoTracker/MkFitCore/src/MkFinder.cc
@@ -1547,7 +1547,7 @@ namespace mkfit {
                 bool hitExists = false;
                 int maxHits = m_NFoundHits(itrack, 0, 0);
                 if (layer_of_hits.is_pixel()) {
-                  for (int i = 0; i <= maxHits; ++i) {
+                  for (int i = 0; i < maxHits; ++i) {
                     if (i > 2)
                       break;
                     if (m_HoTArrs[itrack][i].layer == layer_of_hits.layer_id()) {
@@ -1758,7 +1758,7 @@ namespace mkfit {
               bool hitExists = false;
               int maxHits = m_NFoundHits(itrack, 0, 0);
               if (layer_of_hits.is_pixel()) {
-                for (int i = 0; i <= maxHits; ++i) {
+                for (int i = 0; i < maxHits; ++i) {
                   if (i > 2)
                     break;
                   if (ccand.hot(i).layer == layer_of_hits.layer_id()) {


### PR DESCRIPTION
A fix (at least a partial one) to #48443 and likely also #39803

Initially, I navigated to this from the reproducer step2 in `runTheMatrix.py -l 145.014 --ibeos` suggested in #48443
The modified loop range was the first point of the track reconstruction divergence.
The last (out of range) hit is apparently random and sometimes the "random" hit layer matches with the current layer of hits, which leads to the hit suppression and a subsequent difference in the results.
After the fix at least in the 100 events tested there are no more differences.

From Mario (thanks for the checks!):
It looks to me like the MTV output shows identity for offline tracking:
https://uaf-10.t2.ucsd.edu/~mmasciov/TRKPOG/HLT2025/mkFitDoubletRecovery/MTVOffline_2025_TTbarPU_reproducibilityFix/

At HLT, validation returns results that are consistent within sub-% (within usual fluctuations): https://uaf-10.t2.ucsd.edu/~mmasciov/TRKPOG/HLT2025/mkFitDoubletRecovery/hltMTV_2025_TTbarPU_reproducibilityFix/


@mmasciov @elusian @mmusich 
