### PR TITLE
[TrackingTools/KalmanUpdators] Add using declaration to prevent funct…

### DIFF
--- a/TrackingTools/KalmanUpdators/interface/MRHChi2MeasurementEstimator.h
+++ b/TrackingTools/KalmanUpdators/interface/MRHChi2MeasurementEstimator.h
@@ -7,6 +7,7 @@ class SiTrackerMultiRecHitUpdator;
 
 class MRHChi2MeasurementEstimator final : public Chi2MeasurementEstimatorBase {
 public:
+  using Chi2MeasurementEstimatorBase::estimate;
   /** Construct with cuts on chi2 and nSigma.
    *  The cut on Chi2 is used to define the acceptance of RecHits.
    *  The errors of the trajectory state are multiplied by nSigma 


### PR DESCRIPTION
## PR description:
Resolves compiler warning `-Woverloaded-virtual` in MRHChi2MeasurementEstimator by adding a `using` declaration to expose the base class `estimate(TrajectoryStateOnSurface, Plane)` function that was being hidden by the derived class's `estimate(TrajectoryStateOnSurface, TrackingRecHit)` implementation.

**Solution:** Added `using Chi2MeasurementEstimatorBase::estimate;` to bring the base class function back into scope, ensuring both estimate function overloads remain accessible.