### PR TITLE
[NGT] Fix filling of ValueMap for DeepJet scores for NanoAOD Phase2 HLT

### DIFF
--- a/HLTrigger/NGTScouting/python/HLTNanoProducer_cff.py
+++ b/HLTrigger/NGTScouting/python/HLTNanoProducer_cff.py
@@ -91,7 +91,7 @@ def hltNanoCustomize(process):
         )
         process.NANOAODSIMoutput.SelectEvents = cms.untracked.PSet(
             SelectEvents = cms.vstring(
-                [p for p in process.paths if p.startswith('HLT_') or p.startswith('DST_')]
+                [p for p in process.paths if p.startswith('HLT_') or p.startswith('MC_') or p.startswith('DST_')]
             )
         )
 

--- a/HLTrigger/NGTScouting/python/hltTriggerAcceptFilter_cfi.py
+++ b/HLTrigger/NGTScouting/python/hltTriggerAcceptFilter_cfi.py
@@ -7,7 +7,7 @@ hltTriggerAcceptFilter = _triggerResultsFilter.clone(
     l1tResults = cms.InputTag( "" ),
     l1tIgnoreMaskAndPrescale = cms.bool( False ),
     throw = cms.bool( False ),
-    triggerConditions = cms.vstring('HLT_*')
+    triggerConditions = cms.vstring('HLT_*', 'MC_*')
 )
 
 dstTriggerAcceptFilter = _triggerResultsFilter.clone(

--- a/RecoBTag/ONNXRuntime/plugins/DeepFlavourONNXJetTagsProducer.cc
+++ b/RecoBTag/ONNXRuntime/plugins/DeepFlavourONNXJetTagsProducer.cc
@@ -153,7 +153,7 @@ void DeepFlavourONNXJetTagsProducer::produce(edm::Event& iEvent, const edm::Even
       for (std::size_t flav_n = 0; flav_n < flav_names_.size(); flav_n++) {
         (*(output_tags[flav_n]))[jet_ref] = outputs[i_output];
         if (produceValueMap_) {
-          output_scores[flav_n][jet_n] = outputs[flav_n];
+          output_scores[flav_n][jet_n] = outputs[i_output];
         }
         ++i_output;
       }


### PR DESCRIPTION
#### PR description:

This PR fixes a bug introduced in #48091 regarding the filling of ValueMaps for the DeepJet scores.
The change only affects the NanoAOD HLT format for Phase2, as it is controlled by the `produceValueMap` flag.

In the following images, the distribution of the DeepFlavour_prob_b score for 10 events of TTbar 200PU before and after the bug fix are shown.
- Before:
<img width="400" alt="Screenshot 2025-07-02 at 13 40 35" src="https://github.com/user-attachments/assets/3a151023-0d79-43a6-b446-4baca759652d" />

- After:
<img width="400" alt="Screenshot 2025-07-02 at 13 40 52" src="https://github.com/user-attachments/assets/6a79c353-c838-42a5-9f37-2f3ec2aae876" />

#### PR validation:

This PR has been tested activating the NanoAOD production in the step2. The DeepFlavour scores are filled correctly and in line with the results presented by BTV for the same model. 
```
cmsDriver.py Phase2 \
-s L1P2GT,HLT:75e33,NANO:@Phase2HLT \
--datatier GEN-SIM-DIGI-RAW,NANOAODSIM \
--conditions auto:phase2_realistic_T33 \
--geometry ExtendedRun4D110 \
--era Phase2C17I13M9 \
--eventcontent FEVTDEBUGHLT,NANOAODSIM \
--customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000 \
--filein file:step1.root \
--inputCommands='keep *, drop *_hlt*_*_HLT, drop triggerTriggerFilterObjectWithRefs_l1t*_*_HLT' \
--fileout file:step2.root \
--mc -n 10
```