### PR TITLE
HLT Phase2 Alpaka menu in `relval_gpu`

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_gpu.py
+++ b/Configuration/PyReleaseValidation/python/relval_gpu.py
@@ -39,13 +39,15 @@ from Configuration.PyReleaseValidation.relval_upgrade import workflows as _upgra
 #           Alpaka ECAL-only development:                       TTbar: any backend
 #           Alpaka pixel-only:                                  Single Nu E10: any backend
 #           Alpaka LST-only:                                    TTbar: TRK-only w/ 2 iterations and LST building on any backend
+#           Alpaka HLTTiming75e33:                              TTbar: any backend
+#           Alpaka HLTTiming75e33:                              Single Nu E10: any backend
 # with PU
-#           Alpaka pixel-only:                                  TTbar with PU: quadruplets any backend, any backend vs cpu validation, profiling 
+#           Alpaka pixel-only:                                  TTbar: quadruplets any backend, any backend vs cpu validation, profiling 
 #           Alpaka LST-only:                                    TTbar: TRK-only w/ 2 iterations and LST building on any backend
-
+#           Alpaka HLTTiming75e33:                              TTbar: any backend
 numWFIB = [
 
-           # 2024, Alpaka-based noPU
+           # 2025, Alpaka-based noPU
            16834.402, 16834.403, 16834.404,
            16834.406, 16834.407, 16834.408,
            16834.412, 16834.413,#16834.414,
@@ -57,7 +59,7 @@ numWFIB = [
            16850.406, 16850.407, 16850.408,
            16861.402,
 
-           # 2024 with PU, Alpaka-based
+           # 2025 with PU, Alpaka-based
            17034.402, 17034.403, 17034.404,
            17034.406, 17034.407, 17034.408,
            17034.412, 17034.413, #17034.414
@@ -70,16 +72,17 @@ numWFIB = [
            17061.402,
 
            # Run4, Alpaka-based noPU
-           29634.402, 29634.403, 29634.404, 29634.406, 29634.704,
+           29634.402, 29634.403, 29634.404, 29634.406, 
            29634.612,
            29661.402,
+           29634.704, 
+           29634.751,
+           29661.751,
 
            # Run4, Alpaka-based PU
-           29834.402, 29834.403, 29834.404, 29834.704,
-
-           #FIXME 2024 wfs, to be removed when the bot wfs are migrated
-           12834.402, 12834.403, 12834.406, 
-           12834.412, 12834.422, 12834.423
+           29834.402, 29834.403, 29834.404, 
+           29834.704,
+           29834.751,
         ]
 
 for numWF in numWFIB:

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1774,7 +1774,8 @@ class UpgradeWorkflow_HLT75e33Timing(UpgradeWorkflow):
         else:
             stepDict[stepName][k] = merge([stepDict[step][k]])
     def condition(self, fragment, stepList, key, hasHarvest):
-        return fragment=="TTbar_14TeV" and 'Run4' in key
+        fragments = ["TTbar_14","ZMM_14","ZEE_14","NuGun","SingleMu"]
+        return any(f in fragment for f in fragments) and 'Run4' in key
     
 upgradeWFs['HLTTiming75e33'] = UpgradeWorkflow_HLT75e33Timing(
     steps = [


### PR DESCRIPTION
This PR proposes to add to the wfs run in `relval_gpu` the `*.751` wfs running the Phase2 HLT Alpaka menu on TTbar (PU,noPU) and NuGun samples. I took the chance to remove also the old 2024 wfs, pending https://github.com/cms-sw/cms-bot/pull/2523.