### PR TITLE
MTD DetId: add static methods to MTDDetId to test whether it is BTL or ETL

### DIFF
--- a/DataFormats/ForwardDetId/interface/MTDDetId.h
+++ b/DataFormats/ForwardDetId/interface/MTDDetId.h
@@ -26,12 +26,17 @@ public:
   /** Enumerated type for MTD sub-deteector systems. */
   enum MTDType { typeUNKNOWN = 0, BTL = 1, ETL = 2 };
 
+  static const uint32_t kMTDOffset = 25;
   static const uint32_t kMTDsubdOffset = 23;
   static const uint32_t kMTDsubdMask = 0x3;
   static const uint32_t kZsideOffset = 22;
   static const uint32_t kZsideMask = 0x1;
   static const uint32_t kRodRingOffset = 16;
   static const uint32_t kRodRingMask = 0x3F;
+
+  static constexpr uint32_t kMTDMask = 0x31;  // DetId::Detector::Forward && MTDDetId::SubDetector::FastTime
+  static constexpr uint32_t kBTLMask = 0xc5;  // isMTD && MTDDetId::MTDType::BTL
+  static constexpr uint32_t kETLMask = 0xc6;  // isMTD && MTDDetId::MTDType::ETL
 
   // ---------- Constructors, enumerated types ----------
 
@@ -54,6 +59,16 @@ public:
 
   /** Returns enumerated type specifying MTD sub-detector, i.e. BTL or ETL. */
   inline int mtdSubDetector() const { return (id_ >> kMTDsubdOffset) & kMTDsubdMask; }
+
+  static inline bool const testForMTD(const DetId& id) {
+    return (id.rawId() >> MTDDetId::kMTDOffset) == MTDDetId::kMTDMask;
+  }
+  static inline bool const testForBTL(const DetId& id) {
+    return (id.rawId() >> MTDDetId::kMTDsubdOffset) == MTDDetId::kBTLMask;
+  }
+  static inline bool const testForETL(const DetId& id) {
+    return (id.rawId() >> MTDDetId::kMTDsubdOffset) == MTDDetId::kETLMask;
+  }
 
   /** Returns MTD side, i.e. Z-=0 or Z+=1. */
   inline int mtdSide() const { return (id_ >> kZsideOffset) & kZsideMask; }

--- a/DataFormats/ForwardDetId/test/BuildFile.xml
+++ b/DataFormats/ForwardDetId/test/BuildFile.xml
@@ -4,3 +4,6 @@
 
 <bin file="testHFNoseDetId.cc">
 </bin>
+
+<bin file="testMTD.cc">
+</bin>

--- a/DataFormats/ForwardDetId/test/testMTD.cc
+++ b/DataFormats/ForwardDetId/test/testMTD.cc
@@ -1,0 +1,35 @@
+#include "DataFormats/ForwardDetId/interface/MTDDetId.h"
+#include "DataFormats/ForwardDetId/interface/BTLDetId.h"
+#include "DataFormats/ForwardDetId/interface/ETLDetId.h"
+#include "DataFormats/DetId/interface/DetId.h"
+
+#include <iostream>
+#include <iomanip>
+#include <bitset>
+
+int main() {
+  DetId id;
+  BTLDetId btlid;
+  ETLDetId etlid;
+
+  auto printBits = [&](const uint32_t& id) {
+    std::stringstream ss;
+    ss << std::bitset<4>((id >> 28) & 0xF).to_string() << " " << std::bitset<4>((id >> 24) & 0xF).to_string() << " "
+       << std::bitset<4>((id >> 20) & 0xF).to_string() << " " << std::bitset<4>((id >> 16) & 0xF).to_string() << " "
+       << std::bitset<4>((id >> 12) & 0xF).to_string() << " " << std::bitset<4>((id >> 8) & 0xF).to_string() << " "
+       << std::bitset<4>((id >> 4) & 0xF).to_string() << " " << std::bitset<4>(id & 0xF).to_string();
+    return ss.str();
+  };
+
+  std::cout << "DetId    " << std::setw(20) << id.rawId() << std::setw(40) << printBits(id.rawId()) << " mask "
+            << std::setw(40) << printBits(MTDDetId::kMTDMask) << " isMTD " << MTDDetId::testForMTD(id) << " isBTL "
+            << MTDDetId::testForBTL(id) << " isETL " << MTDDetId::testForETL(id) << std::endl;
+  std::cout << "BTLDetId " << std::setw(20) << btlid.rawId() << std::setw(40) << printBits(btlid.rawId()) << " mask "
+            << std::setw(40) << printBits(MTDDetId::kBTLMask) << " isMTD " << MTDDetId::testForMTD(btlid) << " isBTL "
+            << MTDDetId::testForBTL(btlid) << " isETL " << MTDDetId::testForETL(btlid) << std::endl;
+  std::cout << "ETLDetId " << std::setw(20) << etlid.rawId() << std::setw(40) << printBits(etlid.rawId()) << " mask "
+            << std::setw(40) << printBits(MTDDetId::kETLMask) << " isMTD " << MTDDetId::testForMTD(etlid) << " isBTL "
+            << MTDDetId::testForBTL(etlid) << " isETL " << MTDDetId::testForETL(etlid) << std::endl;
+
+  return 0;
+}


### PR DESCRIPTION
#### PR description:

```MTDDetId``` is instrumented with static methods useful to test whether a generic ```DetId``` is ```MTDDetId```, ```BTLDetId``` or ```ETLDetId```. These methods may help in making cleaner code manipulating MTD-related detids.

#### PR validation:

A simple test code is added to show the correct behaviour of the methods:

```
DetId                       0 0000 0000 0000 0000 0000 0000 0000 0000 mask  0000 0000 0000 0000 0000 0000 0011 0001 isMTD 0 isBTL 0 isETL 0
BTLDetId           1652555776 0110 0010 1000 0000 0000 0000 0000 0000 mask  0000 0000 0000 0000 0000 0000 1100 0101 isMTD 1 isBTL 1 isETL 0
ETLDetId           1660944385 0110 0011 0000 0000 0000 0000 0000 0001 mask  0000 0000 0000 0000 0000 0000 1100 0110 isMTD 1 isBTL 0 isETL 1
```