### PR TITLE
Add SimpleTrackValidation binned in eta and pt

### DIFF
--- a/Validation/RecoTrack/plugins/SimpleTrackValidation.cc
+++ b/Validation/RecoTrack/plugins/SimpleTrackValidation.cc
@@ -62,8 +62,6 @@ private:
 
   TrackingParticleSelector tpSelector;
   TTree* output_tree_;
-  TTree* output_tree_eta_;
-  TTree* output_tree_pt_;
   std::vector<double> etaBins_;
   std::vector<double> ptBins_;
 
@@ -167,8 +165,8 @@ void SimpleTrackValidation::analyze(const edm::Event& iEvent, const edm::EventSe
       }
     }
 
-    LogPrint("TrackValidator") << "Tag " << trackLabels_[0].label() << " Total simulated " << st
-                               << " Associated tracks " << at << " Total reconstructed " << rt;
+    LogInfo("TrackValidator") << "Tag " << trackLabels_[0].label() << " Total simulated " << st << " Associated tracks "
+                              << at << " Total reconstructed " << rt;
     global_rt_ += rt;
     global_st_ += st;
     global_at_ += at;
@@ -180,56 +178,57 @@ void SimpleTrackValidation::analyze(const edm::Event& iEvent, const edm::EventSe
 void SimpleTrackValidation::beginJob() {
   edm::Service<TFileService> fs;
   output_tree_ = fs->make<TTree>("output", "Simple Track Validation TTree");
-
-  // Counters used for computing the efficiency are filled with the Tracking Particle variables
-  // Counters used for computing the fake and duplicate rate are filled with the Reco Track variables
   output_tree_->Branch("rt", &global_rt_);
   output_tree_->Branch("at", &global_at_);
   output_tree_->Branch("st", &global_st_);
   output_tree_->Branch("dt", &global_dt_);
   output_tree_->Branch("ast", &global_ast_);
 
+  // Counters used for computing the efficiency are filled with the Tracking Particle variables
+  // Counters used for computing the fake and duplicate rate are filled with the Reco Track variables
+
+  TFileDirectory output_dir_eta_ = fs->mkdir("SimpleTrackValidationEtaBins");
   int n_bins_eta = etaBins_.size() - 1;
   double* v_bins_eta = etaBins_.data();
-  output_tree_eta_ = fs->make<TTree>("output_eta", "Simple Track Validation Binned in Eta TTree");
 
-  h_st_eta =
-      fs->make<TH1D>("h_st_eta", " ; Tracking Particle #eta; Number of tracking particles", n_bins_eta, v_bins_eta);
-  h_ast_eta = fs->make<TH1D>(
+  h_st_eta = output_dir_eta_.make<TH1D>(
+      "h_st_eta", " ; Tracking Particle #eta; Number of tracking particles", n_bins_eta, v_bins_eta);
+  h_ast_eta = output_dir_eta_.make<TH1D>(
       "h_ast_eta",
       " ; Tracking Particle #eta; Number of tracking particles associated to at least a reconstructed track",
       n_bins_eta,
       v_bins_eta);
-  h_rt_eta = fs->make<TH1D>("h_rt_eta", " ; Reco Track #eta; Number of reconstructed tracks", n_bins_eta, v_bins_eta);
-  h_dt_eta = fs->make<TH1D>("h_dt_eta", " ; Reco Track #eta; Number of duplicates", n_bins_eta, v_bins_eta);
-  h_at_eta = fs->make<TH1D>("h_at_eta",
-                            " ; Reco Track #eta; Number of reconstructed tracks associated to a tracking particle",
-                            n_bins_eta,
-                            v_bins_eta);
+  h_rt_eta = output_dir_eta_.make<TH1D>(
+      "h_rt_eta", " ; Reco Track #eta; Number of reconstructed tracks", n_bins_eta, v_bins_eta);
+  h_dt_eta = output_dir_eta_.make<TH1D>("h_dt_eta", " ; Reco Track #eta; Number of duplicates", n_bins_eta, v_bins_eta);
+  h_at_eta =
+      output_dir_eta_.make<TH1D>("h_at_eta",
+                                 " ; Reco Track #eta; Number of reconstructed tracks associated to a tracking particle",
+                                 n_bins_eta,
+                                 v_bins_eta);
 
+  TFileDirectory output_dir_pt_ = fs->mkdir("SimpleTrackValidationPtBins");
   int n_bins_pt = ptBins_.size() - 1;
   double* v_bins_pt = ptBins_.data();
-  output_tree_pt_ = fs->make<TTree>("output_pt", "Simple Track Validation Binned in Pt TTree");
 
-  h_st_pt = fs->make<TH1D>("h_st_pt", " ; Tracking Particle p_{T}; Number of tracking particles", n_bins_pt, v_bins_pt);
-  h_ast_pt = fs->make<TH1D>(
+  h_st_pt = output_dir_pt_.make<TH1D>(
+      "h_st_pt", " ; Tracking Particle p_{T}; Number of tracking particles", n_bins_pt, v_bins_pt);
+  h_ast_pt = output_dir_pt_.make<TH1D>(
       "h_ast_pt",
       " ; Tracking Particle p_{T}; Number of tracking particles associated to at least a reconstructed track",
       n_bins_pt,
       v_bins_pt);
-  h_rt_pt = fs->make<TH1D>("h_rt_pt", " ; Reco Track p_{T}; Number of reconstructed tracks", n_bins_pt, v_bins_pt);
-  h_at_pt = fs->make<TH1D>("h_at_pt",
-                           " ; Reco Track p_{T}; Number of reconstructed tracks associated to a tracking particle",
-                           n_bins_pt,
-                           v_bins_pt);
-  h_dt_pt = fs->make<TH1D>("h_dt_pt", " ; Reco Track p_{T}; Number of duplicates", n_bins_pt, v_bins_pt);
+  h_rt_pt =
+      output_dir_pt_.make<TH1D>("h_rt_pt", " ; Reco Track p_{T}; Number of reconstructed tracks", n_bins_pt, v_bins_pt);
+  h_at_pt =
+      output_dir_pt_.make<TH1D>("h_at_pt",
+                                " ; Reco Track p_{T}; Number of reconstructed tracks associated to a tracking particle",
+                                n_bins_pt,
+                                v_bins_pt);
+  h_dt_pt = output_dir_pt_.make<TH1D>("h_dt_pt", " ; Reco Track p_{T}; Number of duplicates", n_bins_pt, v_bins_pt);
 }
 
-void SimpleTrackValidation::endJob() {
-  output_tree_->Fill();
-  output_tree_eta_->Fill();
-  output_tree_pt_->Fill();
-}
+void SimpleTrackValidation::endJob() { output_tree_->Fill(); }
 
 void SimpleTrackValidation::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;

--- a/Validation/RecoTrack/plugins/SimpleTrackValidation.cc
+++ b/Validation/RecoTrack/plugins/SimpleTrackValidation.cc
@@ -64,6 +64,9 @@ private:
   TTree* output_tree_;
   TTree* output_tree_eta_;
   TTree* output_tree_pt_;
+  std::vector<double> etaBins_;
+  std::vector<double> ptBins_;
+
   const std::vector<edm::InputTag> trackLabels_;
   std::vector<edm::EDGetTokenT<edm::View<reco::Track>>> trackTokens_;
   const edm::EDGetTokenT<reco::TrackToTrackingParticleAssociator> trackAssociatorToken_;
@@ -94,6 +97,8 @@ SimpleTrackValidation::SimpleTrackValidation(const edm::ParameterSet& iConfig)
                                         iConfig.getParameter<bool>("invertRapidityCutTP"),
                                         iConfig.getParameter<double>("minPhiTP"),
                                         iConfig.getParameter<double>("maxPhiTP"));
+  etaBins_ = iConfig.getParameter<std::vector<double>>("etaBins");
+  ptBins_ = iConfig.getParameter<std::vector<double>>("ptBins");
 }
 
 void SimpleTrackValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
@@ -184,16 +189,8 @@ void SimpleTrackValidation::beginJob() {
   output_tree_->Branch("dt", &global_dt_);
   output_tree_->Branch("ast", &global_ast_);
 
-  // Define 3 bins in eta for negative endcap, barrel, and positive endcap
-  std::vector<double> V_bins_eta = {-4, -1.5, 1.5, 4};
-  int n_bins_eta = V_bins_eta.size() - 1;
-  double* v_bins_eta = &V_bins_eta[0];
-
-  // Define 3 bins in pt 0-3 GeV, 3-10 GeV, 10-100 GeV
-  std::vector<double> V_bins_pt = {0, 3, 10, 1000};
-  int n_bins_pt = V_bins_pt.size() - 1;
-  double* v_bins_pt = &V_bins_pt[0];
-
+  int n_bins_eta = etaBins_.size() - 1;
+  double* v_bins_eta = etaBins_.data();
   output_tree_eta_ = fs->make<TTree>("output_eta", "Simple Track Validation Binned in Eta TTree");
 
   h_st_eta =
@@ -210,6 +207,8 @@ void SimpleTrackValidation::beginJob() {
                             n_bins_eta,
                             v_bins_eta);
 
+  int n_bins_pt = ptBins_.size() - 1;
+  double* v_bins_pt = ptBins_.data();
   output_tree_pt_ = fs->make<TTree>("output_pt", "Simple Track Validation Binned in Pt TTree");
 
   h_st_pt = fs->make<TH1D>("h_st_pt", " ; Tracking Particle p_{T}; Number of tracking particles", n_bins_pt, v_bins_pt);
@@ -255,6 +254,11 @@ void SimpleTrackValidation::fillDescriptions(edm::ConfigurationDescriptions& des
   desc.add<bool>("invertRapidityCutTP", false);
   desc.add<double>("minPhiTP", -3.2);
   desc.add<double>("maxPhiTP", 3.2);
+
+  // Default bins in eta for negative endcap, barrel, and positive endcap
+  desc.add<std::vector<double>>("etaBins", {-4, -1.5, 1.5, 4});
+  // Default bins in pt 0-3 GeV, 3-10 GeV, 10-100 GeV
+  desc.add<std::vector<double>>("ptBins", {0, 3, 10, 1000});
 
   descriptions.addWithDefaultLabel(desc);
 }

--- a/Validation/RecoTrack/test/BuildFile.xml
+++ b/Validation/RecoTrack/test/BuildFile.xml
@@ -1,1 +1,2 @@
 <test name="testMakeTrackValidationPlots" command="test_makeTrackValidationPlots.sh"/>
+<test name="testSimpleTrackValidation" command="test_SimpleTrackValidation.sh"/>

--- a/Validation/RecoTrack/test/SimpleTrackValidation_cfg.py
+++ b/Validation/RecoTrack/test/SimpleTrackValidation_cfg.py
@@ -93,7 +93,9 @@ process.SimpleTrackValidation = cms.EDAnalyzer("SimpleTrackValidation",
     tipTP = cms.double(3.5),
     trackAssociator = cms.InputTag("hltTrackAssociatorByHits"),
     trackLabels = cms.VInputTag("hltPhase2PixelTracks"),
-    trackingParticles = cms.InputTag("mix","MergedTrackTruth")
+    trackingParticles = cms.InputTag("mix","MergedTrackTruth"),
+    etaBins = cms.vdouble(-4.0, -1.5, 1.5, 4.0),  # Default bins in eta for negative endcap, barrel, and positive endcap
+    ptBins = cms.vdouble(0.0, 3.0, 10.0, 1000.0)  # Default bins in pt 0-3 GeV, 3-10 GeV, 10-1000 GeV
 )
 
 ####  set up the paths

--- a/Validation/RecoTrack/test/SimpleTrackValidation_cfg.py
+++ b/Validation/RecoTrack/test/SimpleTrackValidation_cfg.py
@@ -106,7 +106,7 @@ process.simDoubletProduction = cms.Path(
 )
 
 process.options = cms.untracked.PSet(
-    numberOfThreads = cms.untracked.uint32(1),
-    numberOfStreams = cms.untracked.uint32(1),
+    numberOfThreads = cms.untracked.uint32(8),
+    numberOfStreams = cms.untracked.uint32(8),
     wantSummary = cms.untracked.bool(True)
 )

--- a/Validation/RecoTrack/test/SimpleTrackValidation_cfg.py
+++ b/Validation/RecoTrack/test/SimpleTrackValidation_cfg.py
@@ -1,0 +1,110 @@
+"""
+This script runs the SimpleTrackValidation.
+It is just meant for testing and development.
+
+To run:
+cmsRun SimpleTrackValidation_cfg.py inputFiles=file:/path/to/step2.root
+"""
+
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
+
+import FWCore.ParameterSet.VarParsing as VarParsing
+options = VarParsing.VarParsing ('analysis')
+options.inputFiles = ''
+options.parseArguments()
+
+process = cms.Process("SimpleTrackValidation",Phase2C17I13M9)
+
+# maximum number of events
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1),
+    output = cms.optional.untracked.allowed(cms.int32,cms.PSet)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    dropDescendantsOfDroppedBranches = cms.untracked.bool(False),
+    fileNames = cms.untracked.vstring(options.inputFiles),
+    inputCommands = cms.untracked.vstring(
+        'keep *',
+        'drop *_hltSiPixelRecHits_*_HLTX'   # we will reproduce them to have their local position available
+    ),
+    secondaryFileNames = cms.untracked.vstring()
+)
+
+### conditions
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T33', '')
+
+### standard includes
+process.load('Configuration/StandardSequences/Services_cff')
+process.load('Configuration.Geometry.GeometryExtendedRun4D110Reco_cff')
+
+# service to get the root file without passing through the Harvestig
+process.TFileService = cms.Service("TFileService",
+    fileName = cms.string('simple_validation.root')
+)
+
+process.hltTPClusterProducer = cms.EDProducer("ClusterTPAssociationProducer",
+    mightGet = cms.optional.untracked.vstring,
+    phase2OTClusterSrc = cms.InputTag("hltSiPhase2Clusters"),
+    phase2OTSimLinkSrc = cms.InputTag("simSiPixelDigis","Tracker"),
+    pixelClusterSrc = cms.InputTag("hltSiPixelClusters"),
+    pixelSimLinkSrc = cms.InputTag("simSiPixelDigis","Pixel"),
+    simTrackSrc = cms.InputTag("g4SimHits"),
+    stripClusterSrc = cms.InputTag("hltSiStripRawToClustersFacility"),
+    stripSimLinkSrc = cms.InputTag("simSiStripDigis"),
+    throwOnMissingCollections = cms.bool(True),
+    trackingParticleSrc = cms.InputTag("mix","MergedTrackTruth")
+)
+
+process.hltTrackAssociatorByHits = cms.EDProducer("QuickTrackAssociatorByHitsProducer",
+    AbsoluteNumberOfHits = cms.bool(False),
+    Cut_RecoToSim = cms.double(0.75),
+    PixelHitWeight = cms.double(1.0),
+    Purity_SimToReco = cms.double(0.75),
+    Quality_SimToReco = cms.double(0.5),
+    SimToRecoDenominator = cms.string('reco'),
+    ThreeHitTracksAreSpecial = cms.bool(False),
+    UseGrouped = cms.bool(False),
+    UseSplitting = cms.bool(False),
+    cluster2TPSrc = cms.InputTag("hltTPClusterProducer"),
+    useClusterTPAssociation = cms.bool(True)
+)
+
+process.SimpleTrackValidation = cms.EDAnalyzer("SimpleTrackValidation",
+    chargedOnlyTP = cms.bool(True),
+    intimeOnlyTP = cms.bool(False),
+    invertRapidityCutTP = cms.bool(False),
+    lipTP = cms.double(30.0),
+    maxPhiTP = cms.double(3.2),
+    maxRapidityTP = cms.double(2.5),
+    minHitTP = cms.int32(0),
+    minPhiTP = cms.double(-3.2),
+    minRapidityTP = cms.double(-2.5),
+    pdgIdTP = cms.vint32(),
+    ptMaxTP = cms.double(1e+100),
+    ptMinTP = cms.double(0.9),
+    signalOnlyTP = cms.bool(True),
+    stableOnlyTP = cms.bool(False),
+    tipTP = cms.double(3.5),
+    trackAssociator = cms.InputTag("hltTrackAssociatorByHits"),
+    trackLabels = cms.VInputTag("hltPhase2PixelTracks"),
+    trackingParticles = cms.InputTag("mix","MergedTrackTruth")
+)
+
+####  set up the paths
+process.simDoubletProduction = cms.Path(
+    process.hltTPClusterProducer *
+    process.hltTrackAssociatorByHits *
+    process.SimpleTrackValidation 
+)
+
+process.options = cms.untracked.PSet(
+    numberOfThreads = cms.untracked.uint32(1),
+    numberOfStreams = cms.untracked.uint32(1),
+    wantSummary = cms.untracked.bool(True)
+)

--- a/Validation/RecoTrack/test/test_SimpleTrackValidation.sh
+++ b/Validation/RecoTrack/test/test_SimpleTrackValidation.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+function die { echo $1: status $2; exit $2; }
+
+echo "TESTING SimpleTrackValidation"
+
+TEST_FILE="/store/relval/CMSSW_15_1_0_pre3/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_150X_mcRun4_realistic_v1_STD_Run4D110_PU-v1/2590000/ff561068-7e39-413b-8906-9f63338bf01c.root"
+
+cmsRun $SCRAM_TEST_PATH/SimpleTrackValidation_cfg.py inputFiles=$TEST_FILE || die "Failure running test SimpleTrackValidation" $?


### PR DESCRIPTION
#### PR description:

This PR builds on top of #47370. It integrates the validation module `SimpleTrackValidation.cc` with two methods to compute the track efficiency and fake rates in bins of pt and eta. The binning can be specified from the configuration. It can be used for the optimization of PixelTracks and GeneralTracks when interfaced with

https://github.com/cms-patatrack/The-Optimizer
https://github.com/cms-ngt-hlt/cms-reco-optimizer

#### PR validation:

The scripts can be validated by running the python configuration file available in the test folder:
`Validation/RecoTrack/test/SimpleTrackValidation_cfg.py`