### PR TITLE
Improved Event Content for the `TkAlHLT*` ALCARECO 

### DIFF
--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlHLTTracksZMuMu_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlHLTTracksZMuMu_Output_cff.py
@@ -13,6 +13,7 @@ OutALCARECOTkAlHLTTracksZMuMu_noDrop = cms.PSet(
         'keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlHLTTracksZMuMu_*_*',
         'keep L1AcceptBunchCrossings_*_*_*',
         'keep *_TriggerResults_*_*',
+        'keep *_hltPixelVertices_*_*',
 	'keep *_hltVerticesPFFilter_*_*',
         'keep *_hltOnlineBeamSpot_*_*'
     )

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlHLTTracksZMuMu_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlHLTTracksZMuMu_Output_cff.py
@@ -14,6 +14,7 @@ OutALCARECOTkAlHLTTracksZMuMu_noDrop = cms.PSet(
         'keep L1AcceptBunchCrossings_*_*_*',
         'keep *_TriggerResults_*_*',
         'keep *_hltPixelVertices_*_*',
+        'keep *_ALCARECOTkAlHLTPixelZMuMuVertexTracks_*_*',
 	'keep *_hltVerticesPFFilter_*_*',
         'keep *_hltOnlineBeamSpot_*_*'
     )

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlHLTTracksZMuMu_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlHLTTracksZMuMu_cff.py
@@ -55,6 +55,22 @@ ALCARECOTkAlHLTTracksZMuMu.TwoBodyDecaySelector.charge = 0
 ALCARECOTkAlHLTTracksZMuMu.TwoBodyDecaySelector.applyAcoplanarityFilter = False
 ALCARECOTkAlHLTTracksZMuMu.TwoBodyDecaySelector.numberOfCandidates = 1
 
-seqALCARECOTkAlHLTTracksZMuMu = cms.Sequence(ALCARECOTkAlHLTTracksZMuMuHLT+ALCARECOTkAlHLTTracksZMuMuDCSFilter+ALCARECOTkAlHLTTracksZMuMuGoodMuons+ALCARECOTkAlHLTTracksZMuMuRelCombIsoMuons+ALCARECOTkAlHLTTracksZMuMu)
+##################################################################
+# Tracks from the selected vertex
+#################################################################
+import Alignment.CommonAlignmentProducer.AlignmentTracksFromVertexSelector_cfi as _TracksFromPixelVertex
+ALCARECOTkAlHLTPixelZMuMuVertexTracks = _TracksFromPixelVertex.AlignmentTracksFromVertexSelector.clone(
+    src = 'hltPixelTracks',
+    vertices = 'hltPixelVertices',
+    leptonTracks = 'ALCARECOTkAlHLTTracksZMuMu',
+    useClosestVertexToDilepton = True,
+)
+
+seqALCARECOTkAlHLTTracksZMuMu = cms.Sequence(ALCARECOTkAlHLTTracksZMuMuHLT+
+                                             ALCARECOTkAlHLTTracksZMuMuDCSFilter+
+                                             ALCARECOTkAlHLTTracksZMuMuGoodMuons+
+                                             ALCARECOTkAlHLTTracksZMuMuRelCombIsoMuons+
+                                             ALCARECOTkAlHLTTracksZMuMu+
+                                             ALCARECOTkAlHLTPixelZMuMuVertexTracks)
 
 

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlHLTTracks_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlHLTTracks_Output_cff.py
@@ -15,7 +15,6 @@ OutALCARECOTkAlHLTTracks_noDrop = cms.PSet(
         'keep *_TriggerResults_*_*',
         'keep *_hltPixelVertices_*_*',
         'keep *_hltVerticesPFFilter_*_*',
-        'keep *_ALCARECOTkAlHLTPixelVertexTracks_*_*',
         'keep *_hltOnlineBeamSpot_*_*')
 )
 

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlHLTTracks_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlHLTTracks_Output_cff.py
@@ -13,7 +13,9 @@ OutALCARECOTkAlHLTTracks_noDrop = cms.PSet(
         'keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlHLTTracks_*_*',
         'keep L1AcceptBunchCrossings_*_*_*',
         'keep *_TriggerResults_*_*',
+        'keep *_hltPixelVertices_*_*',
         'keep *_hltVerticesPFFilter_*_*',
+        'keep *_ALCARECOTkAlHLTPixelVertexTracks_*_*',
         'keep *_hltOnlineBeamSpot_*_*')
 )
 

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlHLTTracks_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlHLTTracks_cff.py
@@ -40,15 +40,4 @@ ALCARECOTkAlHLTTracks.TwoBodyDecaySelector.applyMassrangeFilter = False
 ALCARECOTkAlHLTTracks.TwoBodyDecaySelector.applyChargeFilter = False
 ALCARECOTkAlHLTTracks.TwoBodyDecaySelector.applyAcoplanarityFilter = False
 
-##################################################################
-# Tracks from the selected vertex
-#################################################################
-import Alignment.CommonAlignmentProducer.AlignmentTracksFromVertexSelector_cfi as TracksFromPixelVertex
-ALCARECOTkAlHLTPixelVertexTracks = TracksFromPixelVertex.AlignmentTracksFromVertexSelector.clone(
-    src = 'hltPixelTracks',
-    vertices = 'hltPixelVertices',
-    useClosestVertexToDilepton = False,
-    vertexIndex = 0,
-)
-
-seqALCARECOTkAlHLTTracks = cms.Sequence(ALCARECOTkAlHLTTracksHLT+ALCARECOTkAlHLTTracksDCSFilter+ALCARECOTkAlHLTTracks+ALCARECOTkAlHLTPixelVertexTracks)
+seqALCARECOTkAlHLTTracks = cms.Sequence(ALCARECOTkAlHLTTracksHLT+ALCARECOTkAlHLTTracksDCSFilter+ALCARECOTkAlHLTTracks)

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlHLTTracks_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlHLTTracks_cff.py
@@ -40,4 +40,15 @@ ALCARECOTkAlHLTTracks.TwoBodyDecaySelector.applyMassrangeFilter = False
 ALCARECOTkAlHLTTracks.TwoBodyDecaySelector.applyChargeFilter = False
 ALCARECOTkAlHLTTracks.TwoBodyDecaySelector.applyAcoplanarityFilter = False
 
-seqALCARECOTkAlHLTTracks = cms.Sequence(ALCARECOTkAlHLTTracksHLT+ALCARECOTkAlHLTTracksDCSFilter+ALCARECOTkAlHLTTracks)
+##################################################################
+# Tracks from the selected vertex
+#################################################################
+import Alignment.CommonAlignmentProducer.AlignmentTracksFromVertexSelector_cfi as TracksFromPixelVertex
+ALCARECOTkAlHLTPixelVertexTracks = TracksFromPixelVertex.AlignmentTracksFromVertexSelector.clone(
+    src = 'hltPixelTracks',
+    vertices = 'hltPixelVertices',
+    useClosestVertexToDilepton = False,
+    vertexIndex = 0,
+)
+
+seqALCARECOTkAlHLTTracks = cms.Sequence(ALCARECOTkAlHLTTracksHLT+ALCARECOTkAlHLTTracksDCSFilter+ALCARECOTkAlHLTTracks+ALCARECOTkAlHLTPixelVertexTracks)

--- a/Alignment/CommonAlignmentProducer/src/AlignmentTracksFromVertexSelector.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentTracksFromVertexSelector.cc
@@ -78,15 +78,14 @@ AlignmentTrackFromVertexSelector::Tracks AlignmentTrackFromVertexSelector::selec
   // get collection of reconstructed vertices from event
   edm::Handle<reco::VertexCollection> vertexHandle = evt.getHandle(vertexToken_);
 
-  // get collection of the di-lepton traxks
-  const auto& leptonTracks = evt.get(diLeptonToken_);
-
   // fill the vector of keys
   if (vertexHandle.isValid()) {
     const reco::VertexCollection* vertices = vertexHandle.product();
     const reco::Vertex* theVtx = nullptr;
 
     if (useClosestVertex_) {
+      // get collection of the di-lepton traxks
+      const auto& leptonTracks = evt.get(diLeptonToken_);
       theVtx = findClosestVertex(leptonTracks, vertices, setup);
     } else {
       if ((*vertices).at(vertexIndex_).isValid()) {


### PR DESCRIPTION
#### PR description:

This PR is a follow-up to PR https://github.com/cms-sw/cmssw/pull/46888 which introduced the High Granularity Tracker Alignment Prompt Calibration Loop for HLT alignment conditions. In that PR two new flavours of ALCARECO were introduced `TkAlHLTTracks` and `TkAlHLTTracksZMuMu`. 
I add in this PR the `hltPixelVertices` collection to the list of HLT products saved in both ALCARECO flavours.
Then I profit of the existing machinery from `AlignmentTracksFromVertexSelector` in order to save also all the pixel tracks associated to the `hltPixelVertex` closest in space to the di-muon decay vertex selected by `TkAlHLTTracksZMuMu` (not necessarily the hardest in the event).
In this way it would be possible to recompute offline the vertex with different calibration constants and measure the impact of that. 
I profit of this PR to introduce in commit 757f9c7d3c5054ff54624ae87425fb199516f702 a small bug-fix in order to consume an intermediated collection only when it's needed. 

#### PR validation:

Run successfully the following command :

```bash
#!/bin/bash -ex

cmsDriver.py testReAlCaHLT \
	     -s ALCA:TkAlHLTTracks+TkAlHLTTracksZMuMu  \
	     --conditions 150X_dataRun3_HLT_v1 \
	     --scenario pp \
	     --data \
	     --era Run3_2025 \
	     --datatier ALCARECO \
	     --eventcontent ALCARECO \
	     --processName=ReAlCa \
	     -n 10000 \
	     --dasquery='file dataset=/HLTMonitor/Run2025C-Express-v2/FEVTHLTALL site=T2_CH_CERN' \
	     --nThreads 4 >& ReAlCa.log
```

on 10k input events:
 - 9900 events are selected by `ALCA:TkAlHLTTracks`. The size of the output file `TkAlHLTTracks.root` goes form `348M` to `362M` (i.e. a **+4.02%** increase)
 - 706 events are selected by `ALCA:TkAlHLTTracksZMuMu`. The size of the output file `TkAlHLTTracksZMuMu.root` goes from `4.2M` to `7.9M` (i.e. a **+88%** increase -- though the event size per event remains fairly small 11kB/event).

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but it will be backported to CMSSW_15_0_X for data-taking operations.