### PR TITLE
Fix for `n_layers` Check in `CAHitNtupletAlpaka::globalBeginRun`

### DIFF
--- a/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtuplet.cc
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtuplet.cc
@@ -140,7 +140,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 #endif
 
       auto oldLayer = 0u;
-      auto layerCount = 0;
+      auto layerCount = 0u;
 
       std::vector<int> layerStarts(n_layers + 1);
       //^ why n_layers + 1? This is a cumulative sum of the number
@@ -162,7 +162,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         if (layer != oldLayer) {
           layerStarts[layerCount++] = n_modules;
 
-          if (layerCount > n_layers + 1)
+          if (layerCount >= layerStarts.size())
             break;
 
           oldLayer = layer;


### PR DESCRIPTION
This PR fixes the issue described in https://github.com/cms-sw/cmssw/issues/48473 limiting the writing in `layerStarts` to the `n_layers + 1` elements (and so up to the `n_layers`th element).

Tested successfully `16834.0` with `CMSSW_15_1_ASAN_X_2025-07-02-2300`.