### PR TITLE
[Phase-2 L1T] fixing out of bound indices in Phase2L1CaloPFClusterEmulator

### DIFF
--- a/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloPFClusterEmulator.h
+++ b/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloPFClusterEmulator.h
@@ -165,7 +165,7 @@ namespace gctpf {
 
   inline GCTint_t getPeakPositionHF(const RegionHF_t& region) {
     GCTEtaHFStripPeak_t etaPeak;
-    for (int i = 0; i < nHfPhi / 6; i++) {
+    for (int i = 0; i < nHfEta; i++) {
       etaPeak.p[i] = getPeakOfHFStrip(region.s[i]);
     }
     GCTint_t max = getPeakBinHF(etaPeak);

--- a/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloPFClusterEmulator.cc
+++ b/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloPFClusterEmulator.cc
@@ -150,7 +150,7 @@ void Phase2L1CaloPFClusterEmulator::produce(edm::Event& iEvent, const edm::Event
     if (k % 2 == 0)
       etaoffset = 0;
     else
-      etaoffset = 17;
+      etaoffset = nTowerEta / 2 - 2;
     if (k > 1 && k % 2 == 0)
       phioffset = phioffset + 4;
 


### PR DESCRIPTION
#### PR description:

Fixing error described in https://github.com/cms-sw/cmssw/issues/48368

#### PR validation:

Ran local checks using the following instructions:
```
cmssw-el8
scram project CMSSW_15_1_CLANG_X_2025-06-29-2300
cd CMSSW_15_1_CLANG_X_2025-06-29-2300/src
cmsenv
runTheMatrix.py -i all -t 4 -l 29634.755 --ibeos
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport
