### PR TITLE
update a vertex smearing parameters for 2025 pO MC

### DIFF
--- a/Configuration/StandardSequences/python/VtxSmeared.py
+++ b/Configuration/StandardSequences/python/VtxSmeared.py
@@ -76,5 +76,6 @@ VtxSmeared = {
     'Realistic2024ppRefCollision' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic2024ppRefCollision_cfi',
     'Realistic2024PbPbCollision' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic2024PbPbCollision_cfi',
     'Nominal2025OOCollision' : 'IOMC.EventVertexGenerators.VtxSmearedNominal2025OOCollision_cfi',
+    'Realistic2025pOCollision' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic2025pOCollision_cfi',
 }
 VtxSmearedDefaultKey='DBrealistic'

--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -1110,6 +1110,19 @@ Nominal2025OOCollisionVtxSmearingParameters = cms.PSet(
     Z0 = cms.double(0.3423956)
 )
 
+# From 2025 pO data runs 393975-394007)
+Realistic2025pOCollisionVtxSmearingParameters = cms.PSet(
+    Phi = cms.double(0.0),
+    BetaStar = cms.double(100),
+    Emittance = cms.double(3.835e-08),
+    Alpha = cms.double(0.0),
+    SigmaZ = cms.double(4.855060),
+    TimeOffset = cms.double(0.0),
+    X0 = cms.double(0.041049),
+    Y0 = cms.double(-0.008035),
+    Z0 = cms.double(0.569058)
+)
+
 # Parameters for HL-LHC operation at 13TeV
 HLLHCVtxSmearingParameters = cms.PSet(
     MeanXIncm = cms.double(0.),

--- a/IOMC/EventVertexGenerators/python/VtxSmearedRealistic2025pOCollision_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedRealistic2025pOCollision_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Realistic2025pOCollisionVtxSmearingParameters,VtxSmearedCommon
+VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
+    Realistic2025pOCollisionVtxSmearingParameters,
+    VtxSmearedCommon
+)


### PR DESCRIPTION
#### PR description:
- This PR adds a vertex smearing for 2025 pO MC. Beamspot position derived from runs 393975 to 394007, BPIX barycentre location obtained from [TrackerAlignment_PCL_byRun_v2_express](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/tags/TrackerAlignment_PCL_byRun_v2_express), official BPIX value was provided by Tracker Alignment Group ([cmsTalk](https://cms-talk.web.cern.ch/t/bpix-barycentre-for-2025-po-mc/126704))

#### PR validation:

- This PR has been modeled after similar PRs from 2022, 2023, and 2024: https://github.com/cms-sw/cmssw/pull/40496, https://github.com/cms-sw/cmssw/pull/43217, https://github.com/cms-sw/cmssw/pull/46639, https://github.com/cms-sw/cmssw/pull/46723

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
- We will need a backport for CMSSW_15_0_X
