### PR TITLE
[15_0_X]: Change of HF threshold of OO era.

### DIFF
--- a/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cff.py
+++ b/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cff.py
@@ -53,4 +53,4 @@ from Configuration.Eras.Era_Run3_2024_UPC_cff import Run3_2024_UPC
 from Configuration.Eras.Modifier_pp_on_PbPb_run3_2025_cff import pp_on_PbPb_run3_2025
 from Configuration.Eras.Modifier_run3_oxygen_cff import run3_oxygen
 from Configuration.Eras.Era_Run3_2025_UPC_cff import Run3_2025_UPC
-(pp_on_PbPb_run3_2025 | run3_oxygen | Run3_2025_UPC).toModify(HcalTPGCoderULUT, FG_HF_thresholds = [16, 19])
+(pp_on_PbPb_run3_2025 | run3_oxygen | Run3_2025_UPC).toModify(HcalTPGCoderULUT, FG_HF_thresholds = [14, 16])


### PR DESCRIPTION
#### PR description:

This PR changes the HF energy sum thresholds in order to synchronize with the thresholds used during the light ion run.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is a backport of https://github.com/cms-sw/cmssw/pull/48483 and is intended to be used for light ion era. 

Tagging HIN colleagues: @boundino @stahlleiton @mandrenguyen @Cristian-Baldenegro
Tagging HCAL colleagues: @JHiltbrand @abdoulline @akhukhun
