### PR TITLE
[15_0_X]:Add FSC to the DQM. 

### DIFF
--- a/DQM/HcalTasks/plugins/ZDCQIE10Task.cc
+++ b/DQM/HcalTasks/plugins/ZDCQIE10Task.cc
@@ -245,6 +245,37 @@ ZDCQIE10Task::ZDCQIE10Task(edm::ParameterSet const& ps)
     _cTDC_EChannel[didm()]->setAxisTitle("N", 2);
   }
 
+  // adding 6 FSC channels on z- side (labeled as EM7_minus - EM12_minus)
+  for (int channel = 7; channel < 13; channel++) {
+    // EM Minus
+    HcalZDCDetId didm(HcalZDCDetId::EM, false, channel);
+
+    histoname = "EM_M_" + std::to_string(channel);
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_perChannel");
+    _cADC_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 256, 0, 256);
+    _cADC_EChannel[didm()]->setAxisTitle("ADC", 1);
+    _cADC_EChannel[didm()]->setAxisTitle("N", 2);
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/ADC_vs_TS_perChannel");
+    _cADC_vs_TS_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 6, 0, 6);
+    _cADC_vs_TS_EChannel[didm()]->setAxisTitle("TS", 1);
+    _cADC_vs_TS_EChannel[didm()]->setAxisTitle("sum ADC", 2);
+
+    histoname = "EM_M_" + std::to_string(channel);
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/fC_perChannel");
+    _cfC_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 100, 0, 8000);
+    _cfC_EChannel[didm()]->setAxisTitle("fC", 1);
+    _cfC_EChannel[didm()]->setAxisTitle("N", 2);
+    ib.setCurrentFolder("Hcal/ZDCQIE10Task/fC_vs_TS_perChannel");
+    _cfC_vs_TS_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 6, 0, 6);
+    _cfC_vs_TS_EChannel[didm()]->setAxisTitle("TS", 1);
+    _cfC_vs_TS_EChannel[didm()]->setAxisTitle("sum fC", 2);
+
+    histoname = "EM_M_" + std::to_string(channel);
+    _cTDC_EChannel[didm()] = ib.book1DD(histoname.c_str(), histoname.c_str(), 50, 1, 50);
+    _cTDC_EChannel[didm()]->setAxisTitle("TDC", 1);
+    _cTDC_EChannel[didm()]->setAxisTitle("N", 2);
+  }
+
   for (int channel = 1; channel < 5; channel++) {
     // HAD Pos
     HcalZDCDetId didp(HcalZDCDetId::HAD, true, channel);
@@ -402,6 +433,7 @@ void ZDCQIE10Task::_process(edm::Event const& e, edm::EventSetup const& es) {
     const QIE10DataFrame digi = static_cast<const QIE10DataFrame>(*it);
 
     HcalZDCDetId const& did = digi.detid();
+    bool isFSC = (did.zside() < 0 && did.section() == 1 && did.channel() > 6);
 
     uint32_t rawid = _ehashmap.lookup(did);
     if (rawid == 0) {
@@ -439,8 +471,8 @@ void ZDCQIE10Task::_process(edm::Event const& e, edm::EventSetup const& es) {
         }
 
       }
-      // ZDC Minus
-      else {
+      // ZDC Minus (exclude FSC)
+      else if (!isFSC) {
         _cADC_PM[0]->Fill(digi[i].adc());
         _cADC_vs_TS_PM[0]->Fill(i, digi[i].adc());
         sample[0][i] = constants::adc2fC[digi[i].adc()];


### PR DESCRIPTION
#### PR description:

New DQM plots for additional channels, corresponding to Forward Shower Counters (FSC), that were introduced in June 2025 in the Heavy Ion program.

The FSC counters are treated as additional EM channels. The code automatically reads these channels once a new emap is loaded.

The code only extends the histogram booking for additional EM channels, and excludes these channels from being filled in the sums. Hence, the only change will be in the addition of the 6 EM channels to the DQM w/o modifying the content of all the rest (including sums).

#### PR validation:

This PR was validated using the procedure described in the dropbox ([here](https://paper.dropbox.com/doc/Check-of-FSC-DQM--CpS1rGdupheE5gK0JoMFoanEAQ-Gn5IVBXzUSeqxIZbiAjkK)) and using the online playback.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is a backport of https://github.com/cms-sw/cmssw/pull/48487 and is meant to be incorporated as soon as possible during the light ion data-taking. 

Also tagging colleagues from

DQM: @rseidita
HIN: @mandrenguyen
HCAL: @salimcerci, @denizsun, @abdoulline, @akhukhun
