### PR TITLE
Fixed Number of Events Data Wfs for Testing

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixUtil.py
+++ b/Configuration/PyReleaseValidation/python/MatrixUtil.py
@@ -133,12 +133,7 @@ class InputInfo(object):
         elif not self.skimEvents:
             command = "dasgoclient %s --query '%s'" % (das_options, self.queries(dataset)[0])
         elif self.skimEvents:
-            from os import getenv
-            if getenv("JENKINS_PREFIX") is not None:
-                # to be sure that whatever happens the files are only those at CERN
-                command = "das-up-to-nevents.py -d %s -e %d -pc -l lumi_ranges.txt"%(dataset,self.events)
-            else:
-                command = "das-up-to-nevents.py -d %s -e %d -l lumi_ranges.txt"%(dataset,self.events)
+            command = "das-up-to-nevents.py -d %s -e %d -l lumi_ranges.txt"%(dataset,self.events)
         # Run filter on DAS output 
         if self.ib_blacklist:
             command += " | grep -E -v "

--- a/Configuration/PyReleaseValidation/python/relval_data_highstats.py
+++ b/Configuration/PyReleaseValidation/python/relval_data_highstats.py
@@ -12,9 +12,21 @@ def run3NameMod(name):
     # ParkingDouble* PDs would end up with a too long name for the submission infrastructure
     return name.replace('ParkingDouble','Park2') 
 
+def run3HarvMod(pd):
+    ## ZeroBias, ScoutingPFMonitor and ParkingDoubleMuonLowMass 
+    ## have their own HARVESTING setup
+    if 'ZeroBias' in pd:
+        return 'ZB_'
+    elif 'ScoutingPFMonitor' in pd:
+        return 'ScoutingPFMonitor_'
+    elif 'ParkingDoubleMuonLowMass' in pd:
+        return 'HFLAV_'
+    else:
+        return ''
+
 def run3RecoMod(pd):
     ## ZeroBias and ScoutingPFMonitor have 
-    ## their own RECO and HARVESTING setup
+    ## their own RECO setup
     if 'ZeroBias' in pd:
         return 'ZB_'
     elif 'ScoutingPFMonitor' in pd:
@@ -29,36 +41,39 @@ def run3HLTMod(pd):
     else:
         return ''
     
-def addFixedEventsWfs(years, pds, eras, suffreco = None, suffhlt = None, namemod = None):
+def addFixedEventsWfs(years, pds, eras, offset = 0, suffreco = None, suffhlt = None, suffharv = None, namemod = None):
 
     for y in years:
         for era in eras:
             for pd in pds:
                 for e_key,evs in event_steps_dict.items(): 
-                    ## ZeroBias have their own HARVESTING
-                    suff = 'ZB_' if 'ZeroBias' in pd else ''
 
                     wf_number = float(y) + offset_pd * pds.index(pd)
                     wf_number = wf_number + offset_era * eras.index(era)
+                    wf_number = wf_number + offset
                     wf_number = round(wf_number + offset_events * evs, 6)
 
                     # Here we customise the steps depending on the PD name                
-                    recoharv = suffreco(pd) if suffreco is not None else ''
-                    hlt = suffhlt(pd) if suffhlt is not None else ''
+                    reco = suffreco(pd) if suffreco is not None else ''
+                    harv = suffharv(pd) if suffharv is not None else ''
+                    hlt  = suffhlt(pd) if suffhlt is not None else ''
+                    name = namemod(pd) if namemod is not None else ''
 
-                    recosetup = 'RECONANORUN3_' + recoharv + 'reHLT_2025' 
-                    harvsetup = 'HARVESTRUN3_'  + recoharv + y
+                    recosetup = 'RECONANORUN3_' + reco + 'reHLT_2025' 
+                    harvsetup = 'HARVESTRUN3_'  + harv + y
                     hltsetup  = 'HLTDR3_' + hlt + y
 
-                    step_name = 'Run' + pd.replace('ParkingDouble','Park2') + y + era + '_' + e_key 
+                    step_name = 'Run' + name  + y + era + '_' + e_key 
                     if namemod is not None:
                         step_name = namemod(step_name)
 
                     workflows[wf_number] = ['',[step_name, hltsetup, recosetup, harvsetup]]
 
-run3FixedWfs = partial(addFixedEventsWfs,suffreco = run3RecoMod, suffhlt = run3HLTMod, namemod = run3NameMod)
+    return wf_number - float(y) #to concatenate the offset
+
+run3FixedWfs = partial(addFixedEventsWfs,suffreco = run3RecoMod, suffhlt = run3HLTMod, suffharv = run3HarvMod, namemod = run3NameMod)
 run3FixedWfs(['2025'],pds_2025,eras_2025)
 run3FixedWfs(['2024'],pds_2024,eras_2024)
 run3FixedWfs(['2023'],pds_2023,eras_2023)
-run3FixedWfs(['2022'],pds_2022_2,eras_2022_2)
-run3FixedWfs(['2022'],pds_2022_1,eras_2022_1)
+offset_2022 = run3FixedWfs(['2022'],pds_2022_2,eras_2022_2)
+run3FixedWfs(['2022'],pds_2022_1,eras_2022_1,offset = offset_2022)

--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -598,11 +598,15 @@ def addFixedEventsTestingWfs(years, pds, eras):
             step_name = 'Run' + pd.replace('ParkingDouble','Park2') + y + era + "_10k"
 
             workflows[wf_number] = ['',[step_name,'HLTDR3_' + y,'RECONANORUN3_reHLT_' + y,'HARVESTRUN3_' + suff + y]]
-    
-## 2024/2025 
+
+## 2025 
+pds  = ['ZeroBias', 'JetMET0', 'EGamma0']
+eras = ['B','C','D']
+addFixedEventsTestingWfs(['2025'], pds, eras)
+## 2024 
 pds  = ['ZeroBias', 'JetMET0', 'EGamma0', 'DisplacedJet', 'ParkingDoubleMuonLowMass0', 'BTagMu', 'Muon0', 'Tau']
 eras = ['B','C','D','E','F','G','H','I']
-addFixedEventsTestingWfs(['2024','2025'], pds, eras)
+addFixedEventsTestingWfs(['2024'], pds, eras)
 
 ## 2023
 pds  = ['ZeroBias', 'EGamma0', 'JetMET0']

--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -575,39 +575,47 @@ workflows[143.911] = ['',['RunUPC2024','RECODR3_2025_OXY','HARVESTDPROMPTR3']]
 workflows[143.912] = ['',['RunUPC2024','RECODR3_2025_UPC_OXY','HARVESTDPROMPTR3']]
 workflows[143.921] = ['',['RunUPC2024','RECODR3_2025_OXY_SKIMIONPHYSICS0','HARVESTDPROMPTR3']]
 
-## Lumi mask fixed 2024 wfs
-base_wf = 145.0
-offset_era = 0.1 # less than 10 eras per year (hopefully)
-offset_pd = 0.001 # less than 100 pds per year
-
-for e_n,era in enumerate(era_mask_2024):
-    for p_n,pd in enumerate(pds_2024):
-        
-        # JetMET1 PD is used to run the TeVJet skims
-        # we don't really need it here
-        # (also as is the numbering conflicts with 
-        # the scouting wf below, so if we really want to
-        # extend the pds for standar relvals for 2024 data
-        # one needs to change the 145.415 below)
-        if pd == 'JetMET1':
-            continue
-
-        wf_number = round(base_wf + offset_era * e_n + offset_pd * p_n,3)
-        dataset = '/' + pd + '/' + era + '-v1/RAW'
-
-        ## ZeroBias have their own HARVESTING
-        suff = 'ZB_' if 'ZeroBias' in step_name else ''
-
-        # Running C,D,E with the offline GT.
-        # Could be removed once 2025 wfs are in and we'll test the online GT with them
-        recosetup = 'RECONANORUN3_' + suff + 'reHLT_2024' 
-        recosetup = recosetup if era[-1] > 'E' else recosetup + '_Offline'
-
-        step_name = 'Run' + pd.replace('ParkingDouble','Park2') + era.split('Run')[1]
-        workflows[wf_number] = ['',[step_name,'HLTDR3_2024',recosetup,'HARVESTRUN3_' + suff + '2024']]
-
 ## special HLT scouting workflow (with hardcoded private input file from ScoutingPFMonitor skimmed to remove all events without scouting)
 workflows[145.415] = ['',['HLTDR3_ScoutingPFMonitor_2024','RECONANORUN3_ScoutingPFMonitor_reHLT_2024','HARVESTRUN3_ScoutingPFMonitor_2024']]
+
+######################################################################################################################################
+######################################################################################################################################
+
+## Run3 Fixed Events for Testing and IBs
+## (with 1k events in input, cut to 100 at step2)
+
+fixed_events_offset = 1e-7 # to have it unique
+
+def addFixedEventsTestingWfs(years, pds, eras):
+
+    for y in years:
+        for era,pd in zip(eras, pds):
+
+            ## ZeroBias have their own HARVESTING
+            suff = 'ZB_' if 'ZeroBias' in pd else ''
+
+            wf_number = round(float(y) + offset_pd * pds.index(pd) + fixed_events_offset, 7)
+            step_name = 'Run' + pd.replace('ParkingDouble','Park2') + y + era + "_10k"
+
+            workflows[wf_number] = ['',[step_name,'HLTDR3_' + y,'RECONANORUN3_reHLT_' + y,'HARVESTRUN3_' + suff + y]]
+    
+## 2024/2025 
+pds  = ['ZeroBias', 'JetMET0', 'EGamma0', 'DisplacedJet', 'ParkingDoubleMuonLowMass0', 'BTagMu', 'Muon0', 'Tau']
+eras = ['B','C','D','E','F','G','H','I']
+addFixedEventsTestingWfs(['2024','2025'], pds, eras)
+
+## 2023
+pds  = ['ZeroBias', 'EGamma0', 'JetMET0']
+eras = ['B','C','D']
+addFixedEventsTestingWfs(['2023'], pds, eras)
+
+## 2022
+pds  = ['ZeroBias', 'JetHT', 'Tau', 'BTagMu']
+eras = ['B','C','D','E']
+addFixedEventsTestingWfs(['2022'], pds, eras)
+
+######################################################################################################################################
+######################################################################################################################################
 
 ##################################################################
 ### run3 (2024) skims - Era F ###

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2340,11 +2340,11 @@ steps['HLTDR3_2023']=merge( [ {'-s':'L1REPACK:Full,HLT:@%s'%hltKey2023,},{'--con
 
 steps['HLTDR3_2023B']=merge( [ {'-s':'L1REPACK:Full,HLT:@%s'%hltKey2023,},{'--conditions':'auto:run3_hlt_relval'},{'--era' : 'Run3'},steps['HLTD'] ] )
 
-steps['HLTDR3_2024']=merge( [ {'-s':'L1REPACK:Full,HLT:@%s'%hltKey2025,},{'--conditions':'auto:run3_hlt_relval'},{'--era' : 'Run3_2024'},steps['HLTD'] ] )
+steps['HLTDR3_2024']=merge( [ {'-s':'L1REPACK:Full,HLT:@%s'%hltKey2024,},{'--conditions':'auto:run3_hlt_relval'},{'--era' : 'Run3_2024'},steps['HLTD'] ] )
 
 steps['HLTDR3_2025']=merge( [ {'-s':'L1REPACK:Full,HLT:@%s'%hltKey2025,},{'--conditions':'auto:run3_hlt_relval'},{'--era' : 'Run3_2025'},steps['HLTD'] ] )
 
-steps['HLTDR3_ScoutingPFMonitor_2024']=merge( [ {'-s':'L1REPACK:Full,HLT:@%s'%hltKey2025,},
+steps['HLTDR3_ScoutingPFMonitor_2024']=merge( [ {'-s':'L1REPACK:Full,HLT:@%s'%hltKey2024,},
                                                 {'--conditions':'auto:run3_hlt_relval'},
                                                 {'--era' : 'Run3_2024'},
                                                 {'--filein' : '/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/Scouting/Run3/ScoutingPFMonitor/300684ed-1a51-474f-8c4f-b3bf1e1f5044_skimmed.root'},

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1,4 +1,5 @@
 import sys
+from functools import partial
 
 from .MatrixUtil import *
 
@@ -51,10 +52,6 @@ step1Up2025UPCProdDefaults = merge ([{'--era':'Run3_2025_UPC'},step1Up2025HiProd
 
 steps = Steps()
 
-#### Event to runs
-event_steps = [0.01,0.05,0.1,0.15,0.25,0.5,1] #in millions
-event_steps_k = ["10k","50k","100k","150k","250k","500k","1M"] ##TODO add an helper to convert the numbers to strings
-event_steps_dict = dict(zip(event_steps_k,event_steps))
 #### Production test section ####
 steps['ProdMinBias']=merge([{'cfg':'MinBias_8TeV_pythia8_TuneCUETP8M1_cff','--relval':'9000,300'},step1Defaults])
 steps['ProdTTbar']=merge([{'cfg':'TTbar_8TeV_TuneCUETP8M1_cfi','--relval':'9000,100'},step1Defaults])
@@ -649,105 +646,105 @@ RunHI2023={375491: [[100, 100]]}
 steps['RunHIPhysicsRawPrime2023A']={'INPUT':InputInfo(dataSet='/HIPhysicsRawPrime0/HIRun2023A-v1/RAW',label='HI2023A',events=100000,location='STD', ls=RunHI2023)}
 
 steps['RunHLTMonitor2024I']={'INPUT':InputInfo(dataSet='/HLTMonitor/Run2024I-Express-v2/FEVTHLTALL',label='2024I',events=100000,location='STD', ls={386801: [[32, 111]]})}
-##################################################################
+
+####################################################################################################################################
+####################################################################################################################################
+
 ### Golden Data Steps
 # Reading good runs directly from the latest golden json 
 # in https://cms-service-dqmdc.web.cern.ch/CAF/certification/
-# or (if available) from eos. the number of events limits 
-# the files used as input
+# or (if available) from eos. The number of events limits 
+# the files used as input.
 
-###2025 
+offset_era = 0.1 # less than 10 eras per year (hopefully!)
+offset_pd = 0.001 # less than 100 pds per year
+offset_events = 0.0001 # less than 10 event setups (10k,50k,150k,250k,500k,1M)
+
+#### PDs to run
 pds_2025  = ['BTagMu', 'DisplacedJet', 'EGamma0', 'HcalNZS', 'JetMET0', 'Muon0', 'MuonEG', 'NoBPTX', 'ParkingDoubleMuonLowMass0', 'ParkingHH', 'ParkingLLP', 'ParkingSingleMuon0', 'ParkingVBF0', 'Tau', 'ZeroBias','JetMET1','ScoutingPFMonitor']
-eras_2025 = ['Run2025B', 'Run2025C','Run2025D','Run2025E', 'Run2025F','Run2025G','Run2025H','Run2025I']
-for era in eras_2025:
-    for pd in pds_2025:
-        dataset = "/" + pd + "/" + era
-        skim = ''
-
-        dataset = dataset + '-v1/RAW' 
-        
-        for e_key,evs in event_steps_dict.items():
-            step_name = "Run" + pd.replace("ParkingDouble","Park2") + era.split("Run")[1] + skim + "_" + e_key 
-            steps[step_name] = {'INPUT':InputInfo(dataSet=dataset,label=era.split("Run")[1],events=int(evs*1e6), skimEvents=True, location='STD')}
-
-
-###2024 
-## N.B. here we use JetMet0 as "starndard" PD and JetMET1 for the TeVJet skims 
 pds_2024  = ['BTagMu', 'DisplacedJet', 'EGamma0', 'HcalNZS', 'JetMET0', 'Muon0', 'MuonEG', 'NoBPTX', 'ParkingDoubleMuonLowMass0', 'ParkingHH', 'ParkingLLP', 'ParkingSingleMuon0', 'ParkingVBF0', 'Tau', 'ZeroBias','JetMET1']
-eras_2024 = ['Run2024B', 'Run2024C', 'Run2024D', 'Run2024E', 'Run2024F','Run2024G','Run2024H','Run2024I']
-for era in eras_2024:
-    for pd in pds_2024:
-        dataset = "/" + pd + "/" + era
-        skim = ''
-        
-        if pd == 'JetMET1':
-            dataset = dataset + '-TeVJet-PromptReco-v1/RAW-RECO'
-            skim = 'TeVJet'
-        else:
-            dataset = dataset + '-v1/RAW' 
-        
-        for e_key,evs in event_steps_dict.items():
-            step_name = "Run" + pd.replace("ParkingDouble","Park2") + era.split("Run")[1] + skim + "_" + e_key 
-            steps[step_name] = {'INPUT':InputInfo(dataSet=dataset,label=era.split("Run")[1],events=int(evs*1e6), skimEvents=True, location='STD')}
-
-###2023 
-
 pds_2023  = ['BTagMu', 'DisplacedJet', 'EGamma0', 'HcalNZS', 'JetMET0', 'Muon0', 'MuonEG', 'NoBPTX', 'ParkingDoubleElectronLowMass', 'ParkingDoubleMuonLowMass0', 'Tau', 'ZeroBias']
-eras_2023 = ['Run2023B', 'Run2023C', 'Run2023D']
-# 'MinimumBias' is excluded since apprently no Golden run for /MinimumBias/Run2023{B,C,D}-v1/RAW 
-for era in eras_2023:
-    for pd in pds_2023:
-        dataset = "/" + pd + "/" + era + "-v1/RAW"
-        for e_key,evs in event_steps_dict.items():
-            step_name = "Run" + pd.replace("ParkingDouble","Park2") + era.split("Run")[1] + "_" + e_key
-            steps[step_name] = {'INPUT':InputInfo(dataSet=dataset,label=era.split("Run")[1],events=int(evs*1e6), skimEvents=True, location='STD')}
-
-###2022 
-
 pds_2022_1  = ['BTagMu', 'DisplacedJet', 'DoubleMuon', 'SingleMuon', 'EGamma', 'HcalNZS', 'JetHT', 'MET', 'MinimumBias', 'MuonEG', 'NoBPTX', 'Tau', 'ZeroBias']
-eras_2022_1 = ['Run2022B', 'Run2022C']
-for era in eras_2022_1:
-    for pd in pds_2022_1:
-        dataset = "/" + pd + "/" + era + "-v1/RAW"
-        for e_key,evs in event_steps_dict.items():
-            step_name = "Run" + pd + era.split("Run")[1] + "_" + e_key
-            steps[step_name] = {'INPUT':InputInfo(dataSet=dataset,label=era.split("Run")[1],events=int(evs*1e6), skimEvents=True, location='STD')}
-
 # PD names changed during the year (!)
 pds_2022_2  = ['BTagMu', 'DisplacedJet', 'Muon', 'EGamma', 'HcalNZS', 'JetMET', 'MuonEG', 'NoBPTX', 'Tau', 'ZeroBias']
-# Note: 'MinimumBias' is excluded since apprently no Golden run for /MinimumBias/Run2022{D,E}-v1/RAW 
-eras_2022_2 = ['Run2022D', 'Run2022E']
 
-for era in eras_2022_2:
-    for pd in pds_2022_2:
-        dataset = "/" + pd + "/" + era + "-v1/RAW"
-        for e_key,evs in event_steps_dict.items():
-            step_name = "Run" + pd + era.split("Run")[1] + "_" + e_key
-            steps[step_name] = {'INPUT':InputInfo(dataSet=dataset,label=era.split("Run")[1],events=int(evs*1e6), skimEvents=True, location='STD')}
+#### Eras to run
+eras_2025 = ['B','C','D','E','F','G','H','I']
+eras_2024 = eras_2025
+eras_2023 = ['B','C','D']
+eras_2022_1 = ['B','C']
+eras_2022_2 = ['D','E']
+
+#### Event to run
+event_steps = [0.01,0.05,0.1,0.15,0.25,0.5,1] #in millions
+event_steps_k = ["10k","50k","100k","150k","250k","500k","1M"] ##TODO add an helper to convert the numbers to strings
+event_steps_dict = dict(zip(event_steps_k,event_steps))
+
+def run3SkimMod(pd):
+    ## We use JetMET1 to run the TevJet Skims
+    if pd == 'JetMET1':
+        return '-TeVJet-PromptReco-v1/RAW-RECO'
+    else:
+        return '-v1/RAW' 
 
 
+def addFixedEventsInputs(years, pds, eras, evstep = event_steps_dict, skimmod = None):
+
+    ''' Add fixed events inputs for Run3 data
+            year    : list of years to consider, strings.
+            pds     : list of PDs to consider, strings.
+            eras    : list of eras to consider, strings.
+            evstep  : dictionary of event string and number e.g. {'10k': 10000}
+            skimmod : function to modify the skim name (optional) based on the PD input:   
+                      e.g. skimmod = lambda pd:  '-TeVJet-PromptReco-v1/RAW-RECO' if pd=='JetMET1' else '-v1/RAW'
+    '''
+
+    for y in years:
+        for pd in pds:
+            pd_name = pd.replace('ParkingDouble','Park2')
+            for era in eras:
+                
+                dataset = '/' + pd + '/' + 'Run' + y + era
+
+                dataset = dataset + '-v1/RAW' if skimmod is None else dataset + skimmod(pd)
+                skim = '' if skimmod is None else skimmod(pd).split('/')[0].split('-')[0]
+                
+                for e_key,evs in event_steps_dict.items():
+                    step_name = 'Run' + pd_name + y + era + skim + '_' + e_key 
+                    steps[step_name] = {'INPUT':InputInfo(dataSet=dataset,label=pd_name+y+era,events=int(evs*1e6), skimEvents=True, location='STD')}
+            
+
+run3FixedSteps = partial(addFixedEventsInputs,evstep = event_steps_dict, skimmod = run3SkimMod)
+run3FixedSteps(['2025'],pds_2025,eras_2025)
+run3FixedSteps(['2024'],pds_2024,eras_2024)
+run3FixedSteps(['2023'],pds_2023,eras_2023)
+run3FixedSteps(['2022'],pds_2022_2,eras_2022_2)
+run3FixedSteps(['2022'],pds_2022_1,eras_2022_1)
+
+####################################################################################################################################
+### TODO: if everything works fine for testing using the fixed steps wfs, remove these
 ### 2024 single lumi mask wfs for the limited matrix only
 ### Mask chosen from golden json away from run start
 
 good_runs_2024 = [379238,379454,380360,381079,382258,383814,385889,386593]
 lumi_mask_2024 = [{ r : [[110, 111]]} for r in good_runs_2024]
-era_mask_2024  = dict(zip(eras_2024,lumi_mask_2024))
+era_mask_2024  = dict(zip(['B','C','D','E','F','G','H','I'],lumi_mask_2024))
 
 for era in era_mask_2024:
     for pd in pds_2024:
-        dataset = '/' + pd + '/' + era
+        dataset = '/' + pd + '/' + 'Run2024' + era
         lm = era_mask_2024[era]
 
         ## Here we use JetMET1 PD to run the TeVJet skims
         dataset = dataset + '-TeVJet-PromptReco-v1/RAW-RECO' if pd == 'JetMET1' else dataset + '-v1/RAW' 
         skim = 'TeVJet' if pd == 'JetMET1' else ''
+        pd_name = pd.replace('ParkingDouble','Park2')
+        step_name = 'Run' + pd_name + '2024' + era + skim
 
-        step_name = 'Run' + pd.replace('ParkingDouble','Park2') + era.split('Run')[1] + skim
-
-        steps[step_name]={'INPUT':InputInfo(dataSet=dataset,label=era.split('Run')[1],events=100000,location='STD', ls=lm)}
+        steps[step_name]={'INPUT':InputInfo(dataSet=dataset,label=pd_name+'2024'+era,events=100000,location='STD', ls=lm)}
 
 
-##################################################################
+####################################################################################################################################
 
 # Highstat HLTPhysics
 Run2015DHS=selectedLS([258712,258713,258714,258741,258742,258745,258749,258750,259626,259637,259683,259685,259686,259721,259809,259810,259818,259820,259821,259822,259862,259890,259891])
@@ -2909,7 +2906,7 @@ steps['RECODR3_2025']=merge([{'--era':'Run3_2025'},steps['RECODR3']])
 steps['RECODR3_reHLT_2022']=merge([{'--conditions':'auto:run3_data_relval', '--hltProcess':'reHLT'},steps['RECODR3']])
 steps['RECODR3_reHLT_2023']=merge([{'--conditions':'auto:run3_data_relval', '--hltProcess':'reHLT'},steps['RECODR3_2023']])
 steps['RECODR3_reHLT_2023B']=merge([{'--conditions':'auto:run3_data_relval', '--hltProcess':'reHLT'},steps['RECODR3']])
-steps['RECODR3_reHLT_2024']=merge([{'--conditions':'auto:run3_data_prompt_relval', '--hltProcess':'reHLT'},steps['RECODR3_2024']])
+steps['RECODR3_reHLT_2024']=merge([{'--conditions':'auto:run3_data_relval', '--hltProcess':'reHLT'},steps['RECODR3_2024']])
 steps['RECODR3_reHLT_2025']=merge([{'--conditions':'auto:run3_data_prompt_relval', '--hltProcess':'reHLT'},steps['RECODR3_2025']])
 # Added to run with the offline GT on few 2024 Eras.
 # Could be removed once 2025 wfs are in and we'll test the online GT with them

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -661,7 +661,7 @@ offset_pd = 0.001 # less than 100 pds per year
 offset_events = 0.0001 # less than 10 event setups (10k,50k,150k,250k,500k,1M)
 
 #### PDs to run
-pds_2025  = ['BTagMu', 'DisplacedJet', 'EGamma0', 'HcalNZS', 'JetMET0', 'Muon0', 'MuonEG', 'NoBPTX', 'ParkingDoubleMuonLowMass0', 'ParkingHH', 'ParkingLLP', 'ParkingSingleMuon0', 'ParkingVBF0', 'Tau', 'ZeroBias','JetMET1','ScoutingPFMonitor']
+pds_2025  = ['BTagMu', 'DisplacedJet', 'EGamma0', 'HcalNZS', 'JetMET0', 'Muon0', 'MuonEG', 'NoBPTX', 'ParkingDoubleMuonLowMass0', 'ParkingHH', 'ParkingLLP0', 'ParkingSingleMuon0', 'ParkingVBF0', 'Tau', 'ZeroBias','JetMET1','ScoutingPFMonitor']
 pds_2024  = ['BTagMu', 'DisplacedJet', 'EGamma0', 'HcalNZS', 'JetMET0', 'Muon0', 'MuonEG', 'NoBPTX', 'ParkingDoubleMuonLowMass0', 'ParkingHH', 'ParkingLLP', 'ParkingSingleMuon0', 'ParkingVBF0', 'Tau', 'ZeroBias','JetMET1']
 pds_2023  = ['BTagMu', 'DisplacedJet', 'EGamma0', 'HcalNZS', 'JetMET0', 'Muon0', 'MuonEG', 'NoBPTX', 'ParkingDoubleElectronLowMass', 'ParkingDoubleMuonLowMass0', 'Tau', 'ZeroBias']
 pds_2022_1  = ['BTagMu', 'DisplacedJet', 'DoubleMuon', 'SingleMuon', 'EGamma', 'HcalNZS', 'JetHT', 'MET', 'MinimumBias', 'MuonEG', 'NoBPTX', 'Tau', 'ZeroBias']
@@ -4171,13 +4171,16 @@ steps['HARVESTRUN3_2023B']=merge([{'--era':'Run3', '-s':'HARVESTING:@standardDQM
 steps['HARVESTRUN3_ZB_2023B']=merge([{'--era':'Run3', '-s':'HARVESTING:@rerecoZeroBiasFakeHLT+@miniAODDQM+@nanoAODDQM'},steps['HARVESTRUN3_2022']])
 steps['HARVESTRUN3_ZB_2023']=merge([{'--era':'Run3_2023', '-s':'HARVESTING:@rerecoZeroBiasFakeHLT+@miniAODDQM+@nanoAODDQM'},steps['HARVESTRUN3_2023']])
 steps['HARVESTRUN3_COS_2023']=merge([{'--scenario':'cosmics', '--era':'Run3_2023', '-s':'HARVESTING:dqmHarvesting'},steps['HARVESTRUN3_2022']])
+steps['HARVESTRUN3_HFLAV_2023']=merge([{'--era':'Run3_2024', '-s':'HARVESTING:@standardDQM+@miniAODDQM+@nanoAODDQM+@heavyFlavor'},steps['HARVESTDRUN3']])
 # 2024
 steps['HARVESTRUN3_ZB_2024']=merge([{'--era':'Run3_2024', '-s':'HARVESTING:@rerecoZeroBias+@miniAODDQM+@nanoAODDQM'},steps['HARVESTDRUN3']])
 steps['HARVESTRUN3_2024']=merge([{'--era':'Run3_2024', '-s':'HARVESTING:@standardDQM+@miniAODDQM+@nanoAODDQM'},steps['HARVESTDRUN3']])
+steps['HARVESTRUN3_HFLAV_2024']=merge([{'--era':'Run3_2024', '-s':'HARVESTING:@standardDQM+@miniAODDQM+@nanoAODDQM+@heavyFlavor'},steps['HARVESTDRUN3']])
 steps['HARVESTRUN3_ScoutingPFMonitor_2024']=merge([{'--era':'Run3_2024', '-s':'HARVESTING:@standardDQM+@miniAODDQM+@nanoAODDQM+@hltScouting'},steps['HARVESTDRUN3']])
 # 2025
 steps['HARVESTRUN3_ZB_2025']=merge([{'--era':'Run3_2025', '-s':'HARVESTING:@rerecoZeroBias+@miniAODDQM+@nanoAODDQM'},steps['HARVESTDRUN3']])
 steps['HARVESTRUN3_2025']=merge([{'--era':'Run3_2025', '-s':'HARVESTING:@standardDQM+@miniAODDQM+@nanoAODDQM'},steps['HARVESTDRUN3']])
+steps['HARVESTRUN3_HFLAV_2025']=merge([{'--era':'Run3_2025', '-s':'HARVESTING:@standardDQM+@miniAODDQM+@nanoAODDQM+@heavyFlavor'},steps['HARVESTDRUN3']])
 steps['HARVESTRUN3_ScoutingPFMonitor_2025']=merge([{'--era':'Run3_2025', '-s':'HARVESTING:@standardDQM+@miniAODDQM+@nanoAODDQM+@hltScouting'},steps['HARVESTDRUN3']])
 # HI
 steps['HARVESTRUN3_HI2023A']=merge([{'--era':'Run3_pp_on_PbPb_approxSiStripClusters_2023', '-s':'HARVESTING:@standardDQM+@miniAODDQM'},steps['HARVESTRUN3_2022']])

--- a/Configuration/PyReleaseValidation/scripts/README.md
+++ b/Configuration/PyReleaseValidation/scripts/README.md
@@ -367,20 +367,21 @@ pp Data reRECO workflows:
 | 2021 	|  	|  	|  	|  	|  	
 | 139.001 	| Run2021 	MinimumBias 	| run3_hlt_relval 	| Run3 	| HLT@relval2022 (Commissioning2021) |	
 | 2022 	|  	|  	|  	|  	|  	
-| 2022.002001 	| Run2022D ZeroBias 	|  	run3_hlt_relval + run3_data_relval |  	Run3 |  	HLT:@relval2022 | 
-| 2022.000001 	| Run2022D JetHT 	|  	run3_hlt_relval + run3_data_relval |  	Run3 |  	HLT:@relval2022 |  	
+| 2022.0030001 	| Run2022D JetHT 	|  	run3_hlt_relval + run3_data_relval |  	Run3 |  	HLT:@relval2022 | 
 | 2023 	|  	|  	|  	|  	|  
-| 2023.002001 	| Run2023D ZeroBias 	|  	run3_hlt_relval + run3_data_relval|  	Run3_2023 |  	HLT:@relval2023 | 
-| 2023.000001 	| Run2023D MuonEG 	|  	run3_hlt_relval + run3_data_relval|  	Run3_2023 |  	HLT:@relval2023 | 
+| 2023.0020001 	| Run2023D JetMET0 	|  	run3_hlt_relval + run3_data_relval|  	Run3_2023 |  	HLT:@relval2023 | 
 | 2024 	|  	|  	|  	|  	|
-| 145.014 	| Run2024B ZeroBias 	|  	run3_hlt_relval + run3_data_relval|  	Run3_2024 |  	HLT:@relval2025 |  
-| 145.104 	| Run2024C JetMet0 	|  	run3_hlt_relval + run3_data_relval|  	Run3_2024 |  	HLT:@relval2025 |  
-| 145.202 	| Run2024D EGamma0 	|  	run3_hlt_relval + run3_data_relval|  	Run3_2024 |  	HLT:@relval2025 |  
-| 145.301 	| Run2024E DisplacedJet 	|  	run3_hlt_relval + run3_data_prompt_relval|  	Run3_2024 |  	HLT:@relval2025 |  
-| 145.408 	| Run2024B ParkingDoubleMuonLowMass0 	|  	run3_hlt_relval + run3_data_prompt_relval|  	Run3_2024 |  	HLT:@relval2025 |  
-| 145.500 	| Run2024B BTagMu 	|  	run3_hlt_relval + run3_data_prompt_relval|  	Run3_2024 |  	HLT:@relval2025 |  
-| 145.604 	| Run2024B JetMET0 	|  	run3_hlt_relval + run3_data_prompt_relval|  	Run3_2024 |  	HLT:@relval2025 |  
-| 145.713 	| Run2024B Tau 	|  	run3_hlt_relval + run3_data_prompt_relval|  	Run3_2024 |  	HLT:@relval2025 |  
+| 2024.0000001 	| Run2024B ZeroBias 	|  	run3_hlt_relval + run3_data_relval|  	Run3_2024 |  	HLT:@relval2024 | 
+| 2024.0010001 	| Run2024C JetMET0 	|  	run3_hlt_relval + run3_data_relval|  	Run3_2024 |  	HLT:@relval2024 |  
+| 2024.0020001 	| Run2024D EGamma0 	|  	run3_hlt_relval + run3_data_relval|  	Run3_2024 |  	HLT:@relval2024 |  
+| 2024.0030001 	| Run2024E DisplacedJet 	|  	run3_hlt_relval + run3_data_relval|  	Run3_2024 |  	HLT:@relval2024 |  
+| 2024.0040001 	| Run2024F ParkingDoubleMuonLowMass0 	|  	run3_hlt_relval + run3_data_relval|  	Run3_2024 |  	HLT:@relval2024 |  
+| 2024.0050001 	| Run2024G BTagMu 	|  	run3_hlt_relval + run3_data_relval|  	Run3_2024 |  	HLT:@relval2024 |  
+| 2024.0060001 	| Run2024H Muon0 	|  	run3_hlt_relval + run3_data_relval|  	Run3_2024 |  	HLT:@relval2024 |  
+| 2024.0070001 	| Run2024I Tau 	|  	run3_hlt_relval + run3_data_relval|  	Run3_2024 |  	HLT:@relval2024 |  
+| 2025 	|  	|  	|  	|  	|
+| 2025.0000001 	| Run2024I ZeroBias 	|  	run3_hlt_relval + run3_data_prompt_relval|  	Run3_2025 |  	HLT:@relval2025 |
+| 2025.0000001 	| Run2024I JetMET0 	|  	run3_hlt_relval + run3_data_prompt_relval|  	Run3_2025 |  	HLT:@relval2025 |
 
 And Heavy Ion workflows:
 

--- a/Configuration/PyReleaseValidation/scripts/das-up-to-nevents.py
+++ b/Configuration/PyReleaseValidation/scripts/das-up-to-nevents.py
@@ -37,7 +37,6 @@ def get_lumi_ranges(i):
     return result
 
 def das_do_command(cmd):
-    print( "Running DAS command: %s"%cmd) ##TODO: remove me
     out = subprocess.check_output(cmd, shell=True, executable="/bin/bash").decode('utf8')
     return out.split("\n")
 
@@ -151,7 +150,7 @@ if __name__ == '__main__':
             json_list = os.listdir(cert_path)
             if len(json_list) == 0:
                 web_fallback == True 
-            json_list = [c for c in json_list if "golden" in c.lower() and "era" not in c.lower()]
+            json_list = [c for c in json_list if "golden" in c.lower() and "era" not in c.lower() and "ppref" not in c.lower()]
             json_list = [c for c in json_list if c.lower().startswith("cert_c") and c.endswith("json")]
         else:
             web_fallback = True
@@ -159,14 +158,13 @@ if __name__ == '__main__':
         if web_fallback:
             cert_url = base_cert_url + cert_type + "/"
             json_list = get_url_clean(cert_url).split("\n")
-            json_list = [c for c in json_list if "golden" in c.lower() and "era" not in c.lower() and "cert_c" in c.lower()]
+            json_list = [c for c in json_list if "golden" in c.lower() and "era" not in c.lower() and "cert_c" in c.lower() and "ppref" not in c.lower()]
             json_list = [[cc for cc in c.split(" ") if cc.lower().startswith("cert_c") and cc.endswith("json")][0] for c in json_list]
 
         # the larger the better, assuming file naming schema 
         # Cert_X_RunStart_RunFinish_Type.json
         # TODO if args.run keep golden only with right range
-
-        run_ranges = [int(c.split("_")[3]) - int(c.split("_")[2]) for c in json_list]
+        run_ranges = [int(c.split("_")[-2]) - int(c.split("_")[-3]) for c in json_list]
         latest_json = np.array(json_list[np.argmax(run_ranges)]).reshape(1,-1)[0].astype(str)
         best_json = str(latest_json[0])
         if not web_fallback:

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -99,7 +99,7 @@ if __name__ == '__main__':
             12846.0,    # RelValZEE_13                  2024
             13034.0,    # RelValTTbar_14TeV             2024 PU = Run3_Flat55To75_PoissonOOTPU
             16834.0,    # RelValTTbar_14TeV             2025
-            17034.0,    # RelValTTbar_14TeV		2025 PU = Run3_Flat55To75_PoissonOOTPU
+            17034.0,    # RelValTTbar_14TeV		        2025 PU = Run3_Flat55To75_PoissonOOTPU
             14034.0,    # RelValTTbar_14TeV             Run3_2023_FastSim
             14234.0,    # RelValTTbar_14TeV             Run3_2023_FastSim   PU = Run3_Flat55To75_PoissonOOTPU
             2500.3001,   # RelValTTbar_14TeV             NanoAOD from existing MINI
@@ -110,20 +110,24 @@ if __name__ == '__main__':
             139.001,    # Run2021  MinimumBias                  Commissioning2021
 
             # 2022
-            140.045,    # Run2022C JetHT
+            2022.106001,     # Run2022C JetHT
 
             # 2023
-            141.042,    # Run2023D ZeroBias
+            2023.211001,     # Run2023D ZeroBias
 
             # 2024
-            145.014,      # Run2024B ZeroBias
-            145.104,      # Run2024C JetMet0
-            145.202,      # Run2024D EGamma0
-            145.301,      # Run2024E DisplacedJet
-            145.408,      # Run2024F ParkingDoubleMuonLowMass0
-            145.500,      # Run2024G BTagMu
-            145.604,      # Run2024H JetMET0
-            145.713,      # Run2024I Tau
+            2024.014001,      # Run2024B ZeroBias
+            2024.204001,      # Run2024C JetMet0
+            2024.202001,      # Run2024D EGamma0
+            2024.301001,      # Run2024E DisplacedJet
+            2024.408001,      # Run2024F ParkingDoubleMuonLowMass0
+            2024.500001,      # Run2024G BTagMu
+            2024.504001,      # Run2024H JetMET0
+            2024.713001,      # Run2024I Tau
+
+            # 2025
+            2025.014001,     # Run2025B ZeroBias
+            2025.104001,     # Run2025C JetMet0
         ],
 
         'phase2' : [

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -99,7 +99,7 @@ if __name__ == '__main__':
             12846.0,    # RelValZEE_13                  2024
             13034.0,    # RelValTTbar_14TeV             2024 PU = Run3_Flat55To75_PoissonOOTPU
             16834.0,    # RelValTTbar_14TeV             2025
-            17034.0,    # RelValTTbar_14TeV		        2025 PU = Run3_Flat55To75_PoissonOOTPU
+            17034.0,    # RelValTTbar_14TeV             2025 PU = Run3_Flat55To75_PoissonOOTPU
             14034.0,    # RelValTTbar_14TeV             Run3_2023_FastSim
             14234.0,    # RelValTTbar_14TeV             Run3_2023_FastSim   PU = Run3_Flat55To75_PoissonOOTPU
             2500.3001,   # RelValTTbar_14TeV             NanoAOD from existing MINI
@@ -110,24 +110,24 @@ if __name__ == '__main__':
             139.001,    # Run2021  MinimumBias                  Commissioning2021
 
             # 2022
-            2022.106001,     # Run2022C JetHT
+            2022.0030001,     # Run2022C JetHT
 
             # 2023
-            2023.211001,     # Run2023D ZeroBias
+            2023.0020001,     # Run2023D JetMET0
 
             # 2024
-            2024.014001,      # Run2024B ZeroBias
-            2024.204001,      # Run2024C JetMet0
-            2024.202001,      # Run2024D EGamma0
-            2024.301001,      # Run2024E DisplacedJet
-            2024.408001,      # Run2024F ParkingDoubleMuonLowMass0
-            2024.500001,      # Run2024G BTagMu
-            2024.504001,      # Run2024H JetMET0
-            2024.713001,      # Run2024I Tau
+            2024.0000001,      # Run2024B ZeroBias
+            2024.0010001,      # Run2024C JetMET0
+            2024.0020001,      # Run2024D EGamma0
+            2024.0030001,      # Run2024E DisplacedJet
+            2024.0040001,      # Run2024F ParkingDoubleMuonLowMass0
+            2024.0050001,      # Run2024G BTagMu
+            2024.0060001,      # Run2024H Muon0
+            2024.0070001,      # Run2024I Tau
 
             # 2025
-            2025.014001,     # Run2025B ZeroBias
-            2025.104001,     # Run2025C JetMet0
+            2025.0000001,     # Run2025B ZeroBias
+            2025.0010001,     # Run2025C JetMET0
         ],
 
         'phase2' : [


### PR DESCRIPTION
#### PR description:

This PR proposes to move back the Run3 data wfs used for testing to be the the `YYYY.*` ones (with `YYYY` being the data taking year). These run the fixed number of events selection machinery. To do this the `das-up-to-nevents.py` script has been updated in order to run only two very small `dasgoclient` queries [1], instead of few big ones or many small (with `-pc`), if it's run within the PR or IBs tests (checking if the environmental variable `JENKINS_PREFIX` is set). I took also the chance to:
- clean up a bit the machinery to avoid code duplications;
- move all 2024 data wfs to use non-prompt conditions for offline;
- add `2025.*` wfs to the limited matrix;
- include the update to the hlt key in #48479 (so moving back 2024 wfs to run `HLT:@relval2024`); 
- add HFlavor DQM for ParkingDoubleMuonLowMass.

#### PR validation:

`runTheMatrix -l run3`

[1]
```
Running DAS command: dasgoclient --query='run dataset=/Muon0/Run2025B-v1/RAW  '
['391548', '391549', '391550', '391551', '391560', '391565', '391572', '391580', '391600', '391601', '391602', '391604', '391658', '391668', '391670', '391671', '391673', '391674', '391675', '391676', '391677', '391678', '391679', '391682', '391683', '391684', '391685', '391686', '391687', '391688', '391698', '391699', '391700', '391787', '391825', '391826', '391869', '391870', '391871', '391873', '391874', '391883', '391884', '391906', '391908', '391909', '391910', '391912', '391949', '391950', '391951', '391952', '391953', '392030', '392046', '392052', '392067', '392071', '392077', '392086', '392088', '392089', '392090', '392091', '392092', '392094', '392109', '392112', '']
Running DAS command: dasgoclient --query='file,lumi,run dataset=/Muon0/Run2025B-v1/RAW run=391668'
['/store/data/Run2025B/Muon0/RAW/v1/000/391/668/00000/311b85c3-fad4-488b-8209-2c7b17d0c1ec.root 391668 [30,36,37,49,53,65,66,83,85,91,94,108,117,124,127,151,155,156,158,168,172,192,193,205,208,225,227,240,246,252,254,255,257,263,266,14,16,19,32,41,43,45,58,63,74,77,78,82,105,123,134,149,152,183,197,204,207,226,250,12,15,18,20,25,42,47,54,67,69,70,80,88,98,111,116,120,125,126,141,144,147,148,179,181,194,198,202,213,217,230,231,232,234,261,264,8,10,17,27,29,40,50,52,96,103,104,112,130,131,132,133,157,161,163,166,173,175,182,184,188,189,200,235,247,248,253,258,260,262,11,21,23,26,33,38,39,51,56,57,60,64,68,84,86,99,101,106,110,113,119,137,138,139,142,143,146,154,159,164,167,195,199,218,237,238,239,241,243,244,267,13,24,28,35,59,62,71,73,118,128,162,170,171,178,190,191,196,203,206,211,212,216,219,222,229,242,256,259,265,7,9,34,46,48,55,61,79,87,92,93,95,114,115,129,136,145,150,160,165,174,176,186,187,201,209,210,221,224,228,249,22,31,44,72,75,76,81,89,90,97,100,102,107,109,121,122,135,140,153,169,177,180,185,214,215,220,223,233,236,245,251]', '']
/store/data/Run2025B/Muon0/RAW/v1/000/391/668/00000/311b85c3-fad4-488b-8209-2c7b17d0c1ec.root
```

