### PR TITLE
silence `SiPixelRawToCluster` verbose ROC and FED error printouts

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToCluster.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToCluster.cc
@@ -74,6 +74,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     const bool includeErrors_;
     const bool useQuality_;
+    const bool verbose_;
     uint32_t nDigis_;
     const SiPixelClusterThresholds clusterThresholds_;
   };
@@ -90,6 +91,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
             edm::ESInputTag("", iConfig.getParameter<std::string>("CablingMapLabel")))),
         includeErrors_(iConfig.getParameter<bool>("IncludeErrors")),
         useQuality_(iConfig.getParameter<bool>("UseQualityInfo")),
+        verbose_(iConfig.getParameter<bool>("verbose")),
         clusterThresholds_{iConfig.getParameter<int32_t>("clusterThreshold_layer1"),
                            iConfig.getParameter<int32_t>("clusterThreshold_otherLayers"),
                            static_cast<float>(iConfig.getParameter<double>("VCaltoElectronGain")),
@@ -112,6 +114,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     edm::ParameterSetDescription desc;
     desc.add<bool>("IncludeErrors", true);
     desc.add<bool>("UseQualityInfo", false);
+    desc.add<bool>("verbose", false)->setComment("verbose FED / ROC errors output");
     // Note: this parameter is obsolete: it is ignored and will have no effect.
     // It is kept to avoid breaking older configurations, and will not be printed in the generated cfi.py file.
     desc.addOptionalNode(edm::ParameterDescription<uint32_t>("MaxFEDWords", 0, true), false)
@@ -252,7 +255,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                   fedCounter,
                                   useQuality_,
                                   includeErrors_,
-                                  edm::MessageDrop::instance()->debugEnabled);
+                                  verbose_);
   }
 
   template <typename TrackerTraits>


### PR DESCRIPTION
#### PR description:

Title says it all, solves https://github.com/cms-sw/cmssw/issues/48458 as per suggestion at https://github.com/cms-sw/cmssw/issues/48458#issuecomment-3046401594.

#### PR validation:

Run `addOnTests.py -t hlt_data_GRun` and checked that the output of step2 doesn't contain printouts related to the pixel local reconstruction.
 
#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A (not needed)