### PR TITLE
[15_0_X] muon system tracker bounds in theSequentialFitter

### DIFF
--- a/RecoVertex/KalmanVertexFit/interface/KalmanVertexFitter.h
+++ b/RecoVertex/KalmanVertexFit/interface/KalmanVertexFitter.h
@@ -30,10 +30,16 @@ public:
   KalmanVertexFitter(bool useSmoothing = false);
 
   /**
+   * Same as above, including a boolean for extending tracker bounds to muon system
+   * \param useMuonSystemBounds Specifies whether the tracker bounds should include the muon system or not.
+   */
+  KalmanVertexFitter(bool useSmoothing, bool useMuonSystemBounds);
+
+  /**
    * Same as above, using a ParameterSet to set the convergence criteria
    */
 
-  KalmanVertexFitter(const edm::ParameterSet& pSet, bool useSmoothing = false);
+  KalmanVertexFitter(const edm::ParameterSet& pSet, bool useSmoothing = false, bool useMuonSystemBounds = false);
 
   KalmanVertexFitter(const KalmanVertexFitter& other) : theSequentialFitter(other.theSequentialFitter->clone()) {}
 
@@ -104,11 +110,11 @@ public:
   //  edm::ParameterSet defaultParameters() const;
 
 private:
-  void setup(const edm::ParameterSet& pSet, bool useSmoothing);
+  void setup(const edm::ParameterSet& pSet, bool useSmoothing, bool useMuonSystemBounds);
 
   edm::ParameterSet defaultParameters() const;
 
-  const SequentialVertexFitter<5>* theSequentialFitter;
+  SequentialVertexFitter<5>* theSequentialFitter;
 };
 
 #endif

--- a/RecoVertex/KalmanVertexFit/src/KalmanVertexFitter.cc
+++ b/RecoVertex/KalmanVertexFit/src/KalmanVertexFitter.cc
@@ -7,14 +7,18 @@
 #include "RecoVertex/KalmanVertexFit/interface/KalmanTrackToTrackCovCalculator.h"
 #include "RecoVertex/LinearizationPointFinders/interface/FsmwLinearizationPointFinder.h"
 
-KalmanVertexFitter::KalmanVertexFitter(bool useSmoothing) {
+KalmanVertexFitter::KalmanVertexFitter(bool useSmoothing) : KalmanVertexFitter(useSmoothing, false) {}
+
+KalmanVertexFitter::KalmanVertexFitter(bool useSmoothing, bool useMuonSystemBounds) {
   edm::ParameterSet pSet = defaultParameters();
-  setup(pSet, useSmoothing);
+  setup(pSet, useSmoothing, useMuonSystemBounds);
 }
 
-KalmanVertexFitter::KalmanVertexFitter(const edm::ParameterSet& pSet, bool useSmoothing) { setup(pSet, useSmoothing); }
+KalmanVertexFitter::KalmanVertexFitter(const edm::ParameterSet& pSet, bool useSmoothing, bool useMuonSystemBounds) {
+  setup(pSet, useSmoothing, useMuonSystemBounds);
+}
 
-void KalmanVertexFitter::setup(const edm::ParameterSet& pSet, bool useSmoothing) {
+void KalmanVertexFitter::setup(const edm::ParameterSet& pSet, bool useSmoothing, bool useMuonSystemBounds) {
   if (useSmoothing) {
     KalmanVertexTrackUpdator<5> vtu;
     KalmanSmoothedVertexChi2Estimator<5> vse;
@@ -33,6 +37,8 @@ void KalmanVertexFitter::setup(const edm::ParameterSet& pSet, bool useSmoothing)
                                                         smoother,
                                                         LinearizedTrackStateFactory());
   }
+  if (useMuonSystemBounds)
+    theSequentialFitter->setMuonSystemBounds();
 }
 
 edm::ParameterSet KalmanVertexFitter::defaultParameters() const {

--- a/RecoVertex/VertexTools/interface/SequentialVertexFitter.h
+++ b/RecoVertex/VertexTools/interface/SequentialVertexFitter.h
@@ -180,6 +180,11 @@ public:
     trackerBoundsHalfLength = halfLength;
   }
 
+  void setMuonSystemBounds() {
+    trackerBoundsRadius = kMuonSystemBoundsRadius;
+    trackerBoundsHalfLength = kMuonSystemBoundsHalfLength;
+  }
+
 protected:
   /**
    *   Default constructor. Is here, as we do not want anybody to use it.
@@ -245,6 +250,8 @@ private:
   // FIXME using hard-coded tracker bounds as default instead of taking them from geometry service
   float trackerBoundsRadius{112.};
   float trackerBoundsHalfLength{273.5};
+  static constexpr float kMuonSystemBoundsRadius = 740.;
+  static constexpr float kMuonSystemBoundsHalfLength = 960.;
 
   edm::ParameterSet thePSet;
   LinearizationPointFinder* theLinP;


### PR DESCRIPTION
#### PR description:

Backport of already merged PR.
Includes the option to set tracker bounds to the muon system for the KalmanVertexFitter.h.

#### PR validation:

The code was tested on a 2023 MC sample. Using the function to extend the tracker bounds we get displaced vertices outside of the default tracker bounds.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Previous PR merged to master:
https://github.com/cms-sw/cmssw/pull/47454

This backport is meant for CMSSW_15_0_X.

Previous PR was made to CMSSW_15_1_X, but we were asked to backport it for NanoAODv15.
