### PR TITLE
TICL Objects in HLT NanoAOD

### DIFF
--- a/HLTrigger/NGTScouting/plugins/BuildFile.xml
+++ b/HLTrigger/NGTScouting/plugins/BuildFile.xml
@@ -8,6 +8,7 @@
 <use name="DataFormats/Scouting"/>
 <use name="DataFormats/StdDictionaries"/>
 <use name="DataFormats/VertexReco"/>
+<use name="SimDataFormats/CaloAnalysis"/>
 <use name="FWCore/Common"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>

--- a/HLTrigger/NGTScouting/plugins/SimTracksterTableProducer.cc
+++ b/HLTrigger/NGTScouting/plugins/SimTracksterTableProducer.cc
@@ -1,0 +1,147 @@
+#include <algorithm>
+#include "DataFormats/NanoAOD/interface/FlatTable.h"
+#include "DataFormats/HGCalReco/interface/Trackster.h"
+#include "SimDataFormats/CaloAnalysis/interface/CaloParticle.h"
+#include "SimDataFormats/CaloAnalysis/interface/SimCluster.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+class SimTracksterTableProducer : public edm::global::EDProducer<> {
+public:
+  SimTracksterTableProducer(const edm::ParameterSet& cfg)
+      : tableName_(cfg.getParameter<std::string>("tableName")),
+        skipNonExistingSrc_(cfg.getParameter<bool>("skipNonExistingSrc")),
+        simTrackstersToken_(mayConsume<std::vector<ticl::Trackster>>(cfg.getParameter<edm::InputTag>("simTracksters"))),
+        caloParticlesToken_(mayConsume<std::vector<CaloParticle>>(cfg.getParameter<edm::InputTag>("caloParticles"))),
+        simClustersToken_(mayConsume<std::vector<SimCluster>>(cfg.getParameter<edm::InputTag>("simClusters"))),
+        caloParticleToSimClustersMap_token_(mayConsume<std::map<uint, std::vector<uint>>>(
+            cfg.getParameter<edm::InputTag>("caloParticleToSimClustersMap"))),
+        precision_(cfg.getParameter<int>("precision")) {
+    produces<nanoaod::FlatTable>(tableName_);
+  }
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<std::string>("tableName", "hltSimTrackstersTable")
+        ->setComment("Table name, needs to be the same as the main Tau table");
+    desc.add<bool>("skipNonExistingSrc", false)
+        ->setComment("whether or not to skip producing the table on absent input product");
+    desc.add<edm::InputTag>("simTracksters", edm::InputTag("hltTiclSimTracksters"));
+    desc.add<edm::InputTag>("caloParticles", edm::InputTag("mix", "MergedCaloTruth"));
+    desc.add<edm::InputTag>("simClusters", edm::InputTag("mix", "MergedCaloTruth"));
+    desc.add<edm::InputTag>("caloParticleToSimClustersMap", edm::InputTag("hltTiclSimTracksters"));
+    desc.add<int>("precision", 7);
+    descriptions.addWithDefaultLabel(desc);
+  }
+
+private:
+  void produce(edm::StreamID id, edm::Event& event, const edm::EventSetup& setup) const override {
+    const auto simTrackstersHandle = event.getHandle(simTrackstersToken_);
+    const auto& simTracksters = *simTrackstersHandle;
+    const auto caloParticlesHandle = event.getHandle(caloParticlesToken_);
+    const auto& caloParticles = *caloParticlesHandle;
+    const auto simClustersHandle = event.getHandle(simClustersToken_);
+    const auto& simClusters = *simClustersHandle;
+    const auto cpToSCMap = event.get(caloParticleToSimClustersMap_token_);
+    const size_t nSimTracksters = simTrackstersHandle.isValid() ? simTrackstersHandle->size() : 0;
+
+    static constexpr float default_value = std::numeric_limits<float>::quiet_NaN();
+
+    std::vector<float> boundaryX(nSimTracksters, default_value);
+    std::vector<float> boundaryY(nSimTracksters, default_value);
+    std::vector<float> boundaryZ(nSimTracksters, default_value);
+    std::vector<float> boundaryPx(nSimTracksters, default_value);
+    std::vector<float> boundaryPy(nSimTracksters, default_value);
+    std::vector<float> boundaryPz(nSimTracksters, default_value);
+    std::vector<float> boundaryEta(nSimTracksters, default_value);
+    std::vector<float> boundaryPhi(nSimTracksters, default_value);
+    std::vector<float> simEnergy(nSimTracksters, default_value);
+    std::vector<float> simTime(nSimTracksters, default_value);
+    std::vector<float> genPt(nSimTracksters, default_value);
+    std::vector<float> mass(nSimTracksters, default_value);
+
+    //utility lambda for filling vectors
+    auto fillVectors = [&](const auto& obj, size_t iSim, float time) {
+      const auto& simTrack = obj.g4Tracks()[0];
+      const auto caloPt = obj.pt();
+      const auto simHitSumEnergy = obj.simEnergy();
+      const auto caloMass = obj.mass();
+
+      boundaryX[iSim] = simTrack.getPositionAtBoundary().x();
+      boundaryY[iSim] = simTrack.getPositionAtBoundary().y();
+      boundaryZ[iSim] = simTrack.getPositionAtBoundary().z();
+      boundaryEta[iSim] = simTrack.getPositionAtBoundary().eta();
+      boundaryPhi[iSim] = simTrack.getPositionAtBoundary().phi();
+      boundaryPx[iSim] = simTrack.getMomentumAtBoundary().x();
+      boundaryPy[iSim] = simTrack.getMomentumAtBoundary().y();
+      boundaryPz[iSim] = simTrack.getMomentumAtBoundary().z();
+
+      simTime[iSim] = time;
+      simEnergy[iSim] = simHitSumEnergy;
+      genPt[iSim] = caloPt;
+      mass[iSim] = caloMass;
+    };
+
+    if (simTrackstersHandle.isValid() || !(this->skipNonExistingSrc_)) {
+      for (size_t iSim = 0; iSim < simTracksters.size(); ++iSim) {
+        const auto& simT = simTracksters[iSim];
+        float time = default_value;
+
+        if (simT.seedID() == caloParticlesHandle.id()) {
+          const auto& cp = caloParticles[simT.seedIndex()];
+          time = cp.simTime();
+          fillVectors(cp, iSim, time);
+        } else {
+          const auto& sc = simClusters[simT.seedIndex()];
+          //SCtoCP map not availalbe, use CPtoSC map instead
+          for (const auto& [cpIdx, scVec] : cpToSCMap) {
+            if (std::ranges::find(scVec, simT.seedIndex()) != scVec.end()) {
+              time = caloParticles[cpIdx].simTime();
+              break;  //dont need to check further
+            }
+          }
+          fillVectors(sc, iSim, time);
+        }
+      }
+    }
+    auto simTrackstersTable =
+        std::make_unique<nanoaod::FlatTable>(nSimTracksters, tableName_, /*singleton*/ false, /*extension*/ true);
+    simTrackstersTable->addColumn<float>(
+        "boundaryX", boundaryX, "CaloVolume boundary Position X [cm] of associated Simobject", precision_);
+    simTrackstersTable->addColumn<float>(
+        "boundaryY", boundaryY, "CaloVolume boundary Position Y [cm] of associated Simobject", precision_);
+    simTrackstersTable->addColumn<float>(
+        "boundaryZ", boundaryZ, "CaloVolume boundary Position Z [cm] of associated Simobject", precision_);
+    simTrackstersTable->addColumn<float>(
+        "boundaryEta", boundaryEta, "CaloVolume boundary pseudorapidity of associated Simobject", precision_);
+    simTrackstersTable->addColumn<float>(
+        "boundaryPhi", boundaryEta, "CaloVolume boundary phi of associated Simobject", precision_);
+    simTrackstersTable->addColumn<float>(
+        "boundaryPx", boundaryPx, "X component of momentum at CaloVolume boundary of associated Simobject", precision_);
+    simTrackstersTable->addColumn<float>(
+        "boundaryPy", boundaryPy, "Y component of momentum at CaloVolume boundary of associated Simobject", precision_);
+    simTrackstersTable->addColumn<float>(
+        "boundaryPz", boundaryPz, "Z component of momentum at CaloVolume boundary of associated Simobject", precision_);
+    simTrackstersTable->addColumn<float>("simTime", simTime, "Sim-Time of simulated object [ns]", precision_);
+    simTrackstersTable->addColumn<float>("genPt", genPt, "Gen-pT associated with SimObject", precision_);
+    simTrackstersTable->addColumn<float>("mass", mass, "mass associated with SimObject", precision_);
+
+    event.put(std::move(simTrackstersTable), tableName_);
+  }
+
+private:
+  const std::string tableName_;
+  const bool skipNonExistingSrc_;
+  const edm::EDGetTokenT<std::vector<ticl::Trackster>> simTrackstersToken_;
+  const edm::EDGetTokenT<std::vector<CaloParticle>> caloParticlesToken_;
+  const edm::EDGetTokenT<std::vector<SimCluster>> simClustersToken_;
+  const edm::EDGetTokenT<std::map<uint, std::vector<uint>>> caloParticleToSimClustersMap_token_;
+  const unsigned int precision_;
+};
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(SimTracksterTableProducer);

--- a/HLTrigger/NGTScouting/plugins/TICLCandidateExtraTableProducer.cc
+++ b/HLTrigger/NGTScouting/plugins/TICLCandidateExtraTableProducer.cc
@@ -1,0 +1,127 @@
+#ifndef HLTrigger_HLTUpgradeNano_TICLCandidateExtraTableProducer_h
+#define HLTrigger_HLTUpgradeNano_TICLCandidateExtraTableProducer_h
+
+#include "PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h"
+#include "DataFormats/HGCalReco/interface/TICLCandidate.h"
+#include "DataFormats/HGCalReco/interface/Trackster.h"
+
+//
+// One-to-many: TICLCandidate -> linked Tracksters
+// Or SimTICLCandidate --> SimTracksters
+//
+
+class TICLCandidateExtraTableProducer : public SimpleFlatTableProducerBase<TICLCandidate, std::vector<TICLCandidate>> {
+public:
+  using TProd = edm::Ptr<ticl::Trackster>;
+
+  TICLCandidateExtraTableProducer(edm::ParameterSet const& params)
+      : SimpleFlatTableProducerBase<TICLCandidate, std::vector<TICLCandidate>>(params) {
+    if (params.existsAs<edm::ParameterSet>("collectionVariables")) {
+      edm::ParameterSet const& collectionVarsPSet = params.getParameter<edm::ParameterSet>("collectionVariables");
+      for (const auto& coltablename : collectionVarsPSet.getParameterNamesForType<edm::ParameterSet>()) {
+        const auto& coltablePSet = collectionVarsPSet.getParameter<edm::ParameterSet>(coltablename);
+
+        CollectionVariableTableInfo coltable;
+        coltable.name =
+            coltablePSet.existsAs<std::string>("name") ? coltablePSet.getParameter<std::string>("name") : coltablename;
+        coltable.doc = coltablePSet.getParameter<std::string>("doc");
+        coltable.useCount = coltablePSet.getParameter<bool>("useCount");
+        coltable.useOffset = coltablePSet.getParameter<bool>("useOffset");
+
+        this->coltables_.push_back(std::move(coltable));
+        produces<nanoaod::FlatTable>(coltables_.back().name + "Table");
+      }
+    }
+  }
+
+  void produce(edm::Event& iEvent, const edm::EventSetup&) override {
+    const auto& prod = iEvent.getHandle(this->src_);
+
+    const auto& candidates = *prod;
+    const size_t table_size = candidates.size();
+
+    auto out = std::make_unique<nanoaod::FlatTable>(table_size, this->name_, /*singleton*/ false, /*extension*/ false);
+
+    unsigned int coltablesize = 0;
+    std::vector<unsigned int> counts;
+    counts.reserve(table_size);
+
+    std::vector<uint32_t> tracksterKeys;
+
+    for (const auto& cand : candidates) {
+      const auto& children = cand.tracksters();
+      counts.push_back(children.size());
+      coltablesize += children.size();
+      for (const auto& t : children) {
+        tracksterKeys.push_back(t.key());
+      }
+    }
+
+    for (const auto& coltable : this->coltables_) {
+      if (coltable.useCount) {
+        out->addColumn<uint16_t>("n" + coltable.name, counts, "Count for " + coltable.name);
+      }
+      if (coltable.useOffset) {
+        std::vector<unsigned int> offsets;
+        offsets.reserve(counts.size());
+        unsigned int offset = 0;
+        for (auto c : counts) {
+          offsets.push_back(offset);
+          offset += c;
+        }
+        out->addColumn<uint16_t>("o" + coltable.name, offsets, "Offset for " + coltable.name);
+      }
+
+      auto outcoltable = std::make_unique<nanoaod::FlatTable>(coltablesize, coltable.name, false, false);
+
+      outcoltable->addColumn<uint32_t>("tracksterIndex", tracksterKeys, "Index of associated Trackster");
+
+      outcoltable->setDoc(coltable.doc);
+      iEvent.put(std::move(outcoltable), coltable.name + "Table");
+    }
+
+    if (out->nColumns() > 0) {
+      out->setDoc(this->doc_);
+      iEvent.put(std::move(out));
+    }
+  }
+
+  std::unique_ptr<nanoaod::FlatTable> fillTable(const edm::Event&,
+                                                const edm::Handle<std::vector<TICLCandidate>>&) const override {
+    return std::make_unique<nanoaod::FlatTable>();
+  }
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc =
+        SimpleFlatTableProducerBase<TICLCandidate, std::vector<TICLCandidate>>::baseDescriptions();
+
+    edm::ParameterSetDescription coltable;
+    coltable.add<std::string>("name", "hltTiclTrackstersMerge");
+    coltable.add<std::string>("doc", "TICL Candidates");
+    coltable.add<bool>("useCount", true);
+    coltable.add<bool>("useOffset", false);
+    edm::ParameterSetDescription colvariables;  // unused here
+    coltable.add<edm::ParameterSetDescription>("variables", colvariables);
+
+    edm::ParameterSetDescription coltables;
+    coltables.addOptionalNode(
+        edm::ParameterWildcard<edm::ParameterSetDescription>("*", edm::RequireZeroOrMore, true, coltable), false);
+
+    desc.addOptional<edm::ParameterSetDescription>("collectionVariables", coltables);
+    descriptions.addWithDefaultLabel(desc);
+  }
+
+protected:
+  struct CollectionVariableTableInfo {
+    std::string name;
+    std::string doc;
+    bool useCount;
+    bool useOffset;
+  };
+  std::vector<CollectionVariableTableInfo> coltables_;
+};
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(TICLCandidateExtraTableProducer);
+
+#endif

--- a/HLTrigger/NGTScouting/plugins/TICLCandidateTableProducer.cc
+++ b/HLTrigger/NGTScouting/plugins/TICLCandidateTableProducer.cc
@@ -1,0 +1,7 @@
+#include "PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h"
+
+#include "DataFormats/HGCalReco/interface/TICLCandidate.h"
+typedef SimpleCollectionFlatTableProducer<TICLCandidate> TICLCandidateTableProducer;
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(TICLCandidateTableProducer);

--- a/HLTrigger/NGTScouting/plugins/TICLSuperClustersTableProducer.cc
+++ b/HLTrigger/NGTScouting/plugins/TICLSuperClustersTableProducer.cc
@@ -1,0 +1,7 @@
+#include "PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h"
+
+#include "DataFormats/EgammaReco/interface/SuperCluster.h"
+typedef SimpleCollectionFlatTableProducer<reco::SuperCluster> TICLSuperClustersTableProducer;
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(TICLSuperClustersTableProducer);

--- a/HLTrigger/NGTScouting/python/HLTNanoProducer_cff.py
+++ b/HLTrigger/NGTScouting/python/HLTNanoProducer_cff.py
@@ -21,6 +21,8 @@ from HLTrigger.NGTScouting.hltTracks_cfi import *
 from HLTrigger.NGTScouting.hltJets_cfi import *
 from HLTrigger.NGTScouting.hltTaus_cfi import *
 from HLTrigger.NGTScouting.hltTracksters_cfi import *
+from HLTrigger.NGTScouting.hltTICLCandidates_cfi import *
+from HLTrigger.NGTScouting.hltTICLSuperClusters_cfi import *
 from HLTrigger.NGTScouting.hltSums_cfi import *
 from HLTrigger.NGTScouting.hltTriggerAcceptFilter_cfi import hltTriggerAcceptFilter,dstTriggerAcceptFilter
 
@@ -53,7 +55,10 @@ hltNanoProducer = cms.Sequence(
     + hltMuonTable
     + hltPFCandidateTable
     + hltJetTable
-    + hltTrackstersTable
+    + hltTrackstersTableSequence
+    + hltTiclCandidateTable
+    + hltTiclCandidateExtraTable
+    + hltTiclSuperClustersTable
     + hltTauTable
     + hltTauExtTable
     + METTable
@@ -74,7 +79,10 @@ dstNanoProducer = cms.Sequence(
     + hltPFCandidateTable
     + hltJetTable
     + hltTauTable
-    + hltTrackstersTable
+    + hltTrackstersTableSequence
+    + hltTiclCandidateTable
+    + hltTiclCandidateExtraTable
+    + hltTiclSuperClustersTable
     + hltTauExtTable
     + METTable
     + HTTable
@@ -99,6 +107,7 @@ def hltNanoCustomize(process):
 
 def hltNanoValCustomize(process):
     if hasattr(process, "dstNanoProducer"):
-        process.dstNanoProducer += (process.hltTrackstersAssociationOneToManyTable + process.hltSimCl2CPOneToOneFlatTable)
+
+        process.dstNanoProducer += (process.hltTiclAssociationsTableSequence + process.hltSimTracksterSequence + process.hltSimTiclCandidateTable + process.hltSimTiclCandidateExtraTable )
 
     return process

--- a/HLTrigger/NGTScouting/python/hltSimTracksters_cfi.py
+++ b/HLTrigger/NGTScouting/python/hltSimTracksters_cfi.py
@@ -1,0 +1,152 @@
+import FWCore.ParameterSet.Config as cms
+from PhysicsTools.NanoAOD.common_cff import *
+from PhysicsTools.NanoAOD.nano_cff import nanoMetadata
+from Validation.HGCalValidation.HLT_TICLIterLabels_cff import hltTiclIterLabels
+
+hltUpgradeNanoTask = cms.Task(nanoMetadata)
+
+hltSimTracksterTable = cms.EDProducer(
+    "TracksterCollectionTableProducer",
+    skipNonExistingSrc=cms.bool(True),
+    src=cms.InputTag("hltTiclSimTracksters"),
+    cut=cms.string(""),
+    name=cms.string("hltTiclSimTracksters"),
+    doc=cms.string("hltTiclSimTracksters"),
+    singleton=cms.bool(False),  # the number of entries is variable
+    variables=cms.PSet(
+        raw_energy=Var("raw_energy", "float",
+                       doc="Raw Energy of the trackster [GeV]"),
+        raw_em_energy=Var("raw_em_energy", "float",
+                          doc="EM raw Energy of the trackster [GeV]"),
+        raw_pt=Var(
+            "raw_pt", "float", doc="Trackster raw pT, computed from trackster raw energy and direction [GeV]"),
+        regressed_energy=Var("regressed_energy", "float",
+                             doc="Regressed Energy of the trackster, for the SimTrackster it corresponds to the GEN-energy"),
+        barycenter_x=Var("barycenter.x", "float",
+                         doc="Trackster barycenter x [cm]"),
+        barycenter_y=Var("barycenter.y", "float",
+                         doc="Trackster barycenter y [cm]"),
+        barycenter_z=Var("barycenter.z", "float",
+                         doc="Trackster barycenter z [cm]"),
+        barycenter_eta=Var("barycenter.eta", "float",
+                           doc="Trackster barycenter pseudorapidity"),
+        barycenter_phi=Var("barycenter.phi", "float",
+                           doc="Trackster barycenter phi"),
+        EV1=Var("eigenvalues()[0]", "float",
+                doc="Trackster PCA eigenvalues 0"),
+        EV2=Var("eigenvalues()[1]", "float",
+                doc="Trackster PCA eigenvalues 1"),
+        EV3=Var("eigenvalues()[2]", "float",
+                doc="Trackster PCA eigenvalues 2"),
+        eVector0_x=Var(
+            "eigenvectors()[0].x", "float", doc="Trackster PCA principal axis, x component"),
+        eVector0_y=Var(
+            "eigenvectors()[0].z", "float", doc="Trackster PCA principal axis, y component"),
+        eVector0_z=Var(
+            "eigenvectors()[0].y", "float", doc="Trackster PCA principal axis, z component"),
+        time=Var("time", "float", doc="Trackster HGCAL time"),
+        timeError=Var("timeError", "float",
+                      doc="Trackster HGCAL time error")
+    ),
+    collectionVariables=cms.PSet(
+        tracksterVertices=cms.PSet(
+            name=cms.string(f"hltTiclSimTrackstersvertices"),
+            doc=cms.string("Vertex properties"),
+            useCount=cms.bool(True),
+            useOffset=cms.bool(True),
+            variables=cms.PSet(
+                vertices=Var("vertices", "uint",
+                             doc="Layer clusters indices."),
+                vertex_mult=Var(
+                    "vertex_multiplicity",
+                    "float",
+                    doc="Fraction of Layer cluster energy used by the Trackster.",
+                ),
+            ),
+        )
+    ),
+)
+
+hltSimTracksterFromCPsTable = cms.EDProducer(
+    "TracksterCollectionTableProducer",
+    skipNonExistingSrc=cms.bool(True),
+    src=cms.InputTag("hltTiclSimTracksters", "fromCPs"),
+    cut=cms.string(""),
+    name=cms.string("hltTiclSimTrackstersFromCPs"),
+    doc=cms.string("hltTiclSimTrackstersFromCPs"),
+    singleton=cms.bool(False),  # the number of entries is variable
+    variables=cms.PSet(
+        raw_energy=Var("raw_energy", "float",
+                       doc="Raw Energy of the trackster [GeV]"),
+        raw_em_energy=Var("raw_em_energy", "float",
+                          doc="EM raw Energy of the trackster [GeV]"),
+        raw_pt=Var(
+            "raw_pt", "float", doc="Trackster raw pT, computed from trackster raw energy and direction [GeV]"),
+        regressed_energy=Var("regressed_energy", "float",
+                             doc="Regressed Energy of the trackster, for the SimTrackster it corresponds to the GEN-energy"),
+        barycenter_x=Var("barycenter.x", "float",
+                         doc="Trackster barycenter x [cm]"),
+        barycenter_y=Var("barycenter.y", "float",
+                         doc="Trackster barycenter y [cm]"),
+        barycenter_z=Var("barycenter.z", "float",
+                         doc="Trackster barycenter z [cm]"),
+        barycenter_eta=Var("barycenter.eta", "float",
+                           doc="Trackster barycenter pseudorapidity"),
+        barycenter_phi=Var("barycenter.phi", "float",
+                           doc="Trackster barycenter phi"),
+        EV1=Var("eigenvalues()[0]", "float",
+                doc="Trackster PCA eigenvalues 0"),
+        EV2=Var("eigenvalues()[1]", "float",
+                doc="Trackster PCA eigenvalues 1"),
+        EV3=Var("eigenvalues()[2]", "float",
+                doc="Trackster PCA eigenvalues 2"),
+        eVector0_x=Var(
+            "eigenvectors()[0].x", "float", doc="Trackster PCA principal axis, x component"),
+        eVector0_y=Var(
+            "eigenvectors()[0].z", "float", doc="Trackster PCA principal axis, y component"),
+        eVector0_z=Var(
+            "eigenvectors()[0].y", "float", doc="Trackster PCA principal axis, z component"),
+        time=Var("time", "float", doc="Trackster HGCAL time"),
+        timeError=Var("timeError", "float",
+                      doc="Trackster HGCAL time error")
+    ),
+    collectionVariables=cms.PSet(
+        tracksterVertices=cms.PSet(
+            name=cms.string(f"hltTiclSimTrackstersFromCPsvertices"),
+            doc=cms.string("Vertex properties"),
+            useCount=cms.bool(True),
+            useOffset=cms.bool(True),
+            variables=cms.PSet(
+                vertices=Var("vertices", "uint",
+                             doc="Layer clusters indices."),
+                vertex_mult=Var(
+                    "vertex_multiplicity",
+                    "float",
+                    doc="Fraction of Layer cluster energy used by the Trackster.",
+                ),
+            ),
+        )
+    ),
+)
+
+# Extra tables for SimTracksters using information from SimClusters and CaloParticles 
+# Might be replaced in case we save CaloParticles and SimClusters, in that case we just need adding the corresponding SimObject indices in the SimTrackster tables
+hltTiclSimTrackstersExtraTable = cms.EDProducer("SimTracksterTableProducer",
+                                tableName = cms.string("hltTiclSimTracksters"),
+                                skipNonExistingSrc = cms.bool(True),
+                                simTracksters = cms.InputTag( "hltTiclSimTracksters" ),
+                                caloParticles = cms.InputTag( "mix", "MergedCaloTruth" ),
+                                simClusters = cms.InputTag( "mix", "MergedCaloTruth" ),
+                                caloParticleToSimClustersMap = cms.InputTag("hltTiclSimTracksters"),
+                                precision = cms.int32(7),
+                                )
+
+hltTiclSimTrackstersFromCPsExtraTable = cms.EDProducer("SimTracksterTableProducer",
+                                tableName = cms.string("hltTiclSimTrackstersFromCPs"),
+                                skipNonExistingSrc = cms.bool(True),
+                                simTracksters = cms.InputTag( "hltTiclSimTracksters", "fromCPs"),
+                                caloParticles = cms.InputTag( "mix", "MergedCaloTruth" ),
+                                simClusters = cms.InputTag( "mix", "MergedCaloTruth" ),
+                                caloParticleToSimClustersMap = cms.InputTag("hltTiclSimTracksters"),
+                                precision = cms.int32(7),
+                                )

--- a/HLTrigger/NGTScouting/python/hltTICLCandidates_cfi.py
+++ b/HLTrigger/NGTScouting/python/hltTICLCandidates_cfi.py
@@ -1,0 +1,131 @@
+import FWCore.ParameterSet.Config as cms
+from PhysicsTools.NanoAOD.common_cff import *
+from PhysicsTools.NanoAOD.nano_cff import nanoMetadata
+from Configuration.ProcessModifiers.ticl_v5_cff import ticl_v5
+
+hltUpgradeNanoTask = cms.Task(nanoMetadata)
+
+hltTiclCandidateTable = cms.EDProducer(
+    "TICLCandidateTableProducer",
+    skipNonExistingSrc=cms.bool(True),
+    src=cms.InputTag("hltTiclTrackstersMerge"),
+    cut=cms.string(""),
+    name=cms.string("hltTICLCandidates"),
+    doc=cms.string("TICLCandidates"),
+    singleton=cms.bool(False),  # the number of entries is variable
+    variables=cms.PSet(
+        raw_energy=Var("rawEnergy", "float",
+                       doc="Raw Energy of the TICLCandidate [GeV]"),
+        pt=Var(
+            "pt", "float", doc="TICLCandidate pT, computed from trackster raw energy and direction or from associated track [GeV]"),
+        p=Var(
+            "p", "float", doc="TICLCandidate momentum magnitude, computed from trackster raw energy and direction or from associated track [GeV]"),
+        px=Var(
+            "px", "float", doc="TICLCandidate x component of mementum, computed from trackster raw energy and direction or from associated track [GeV]"),
+        py=Var(
+            "py", "float", doc="TICLCandidate y component of mementum, computed from trackster raw energy and direction or from associated track [GeV]"),
+        pz=Var(
+            "pz", "float", doc="TICLCandidate z component of mementum, computed from trackster raw energy and direction or from associated track [GeV]"),
+        energy=Var("energy", "float",
+                             doc="Energy of the TICLCandidate, computed from the raw energy of the associated Trackster or from the associated track"),
+        eta=Var(
+            "eta", "float", doc="TICLCandidate pseudorapidity, derived from p4 built from associated Tracksters or from associated Track"),
+        phi=Var(
+            "phi", "float", doc="TICLCandidate phi, derived from p4 built from associated Tracksters or from associated Track"),
+        mass=Var(
+            "mass", "float", doc="TICLCandidate mass"),
+        pdgID=Var(
+            "pdgId", "int", doc="TICLCandidate assigned pdgID"),
+        charge=Var(
+            "charge", "int", doc="TICLCandidate assigned charge"),
+        time=Var("time", "float", doc="TICLCandidate time, obtained from combination HGCAL and MTD time (offline) or HGCAL only (HLT)"),
+        timeError=Var("timeError", "float",
+                      doc="Trackster HGCAL time error"),
+        MTDtime=Var("MTDtime", "float",
+                    doc="TICLCandidate associated MTDTime, meaningful only for offline reconstruction"),
+        MTDtimeError=Var("MTDtimeError", "float",
+                         doc="Trackster associated MTD time error, meaningful only for offline reconstruction"),
+        trackIdx=Var("trackPtr().key", "int",
+                     doc="Index of hltGeneralTrack associated with TICLCandidate")
+    ),
+)
+
+
+hltSimTiclCandidateTable = cms.EDProducer(
+    "TICLCandidateTableProducer",
+    skipNonExistingSrc=cms.bool(True),
+    src=cms.InputTag("hltTiclSimTracksters"),
+    cut=cms.string(""),
+    name=cms.string("hltSimTICLCandidates"),
+    doc=cms.string("SimTICLCandidates"),
+    singleton=cms.bool(False),  # the number of entries is variable
+    variables=cms.PSet(
+        raw_energy=Var("rawEnergy", "float",
+                       doc="Raw Energy of the TICLCandidate [GeV]"),
+        pt=Var(
+            "pt", "float", doc="TICLCandidate pT, computed from trackster raw energy and direction or from associated track [GeV]"),
+        p=Var(
+            "p", "float", doc="TICLCandidate momentum magnitude, computed from trackster raw energy and direction or from associated track [GeV]"),
+        px=Var(
+            "px", "float", doc="TICLCandidate x component of mementum, computed from trackster raw energy and direction or from associated track [GeV]"),
+        py=Var(
+            "py", "float", doc="TICLCandidate y component of mementum, computed from trackster raw energy and direction or from associated track [GeV]"),
+        pz=Var(
+            "pz", "float", doc="TICLCandidate z component of mementum, computed from trackster raw energy and direction or from associated track [GeV]"),
+        energy=Var("energy", "float",
+                             doc="Energy of the TICLCandidate, computed from the raw energy of the associated Trackster or from the associated track"),
+        eta=Var(
+            "eta", "float", doc="TICLCandidate pseudorapidity, derived from p4 built from associated Tracksters or from associated Track"),
+        phi=Var(
+            "phi", "float", doc="TICLCandidate phi, derived from p4 built from associated Tracksters or from associated Track"),
+        mass=Var(
+            "mass", "float", doc="TICLCandidate mass"),
+        pdgID=Var(
+            "pdgId", "int", doc="TICLCandidate assigned pdgID"),
+        charge=Var(
+            "charge", "int", doc="TICLCandidate assigned charge"),
+        time=Var("time", "float", doc="TICLCandidate time, obtained from combination HGCAL and MTD time (offline) or HGCAL only (HLT)"),
+        timeError=Var("timeError", "float",
+                      doc="Trackster HGCAL time error"),
+        MTDtime=Var("MTDtime", "float",
+                    doc="TICLCandidate associated MTDTime, meaningful only for offline reconstruction"),
+        MTDtimeError=Var("MTDtimeError", "float",
+                         doc="Trackster associated MTD time error, meaningful only for offline reconstruction"),
+        trackIdx=Var("trackPtr().key", "int",
+                     doc="Index of hltGeneralTrack associated with TICLCandidate")
+    ),
+)
+hltTiclCandidateExtraTable = cms.EDProducer(
+    "TICLCandidateExtraTableProducer",
+    src = cms.InputTag("hltTiclTrackstersMerge"),
+    name = cms.string("Candidate2Tracksters"),
+    doc = cms.string("TICLCandidates extra table with linked Tracksters"),
+    collectionVariables = cms.PSet(
+        tracksters = cms.PSet(
+            name = cms.string("Candidate2TrackstersIndices"),
+            doc = cms.string("Tracksters linked to TICLCandidates"),
+            useCount = cms.bool(True),
+            useOffset = cms.bool(False),
+            variables = cms.PSet() 
+        ),
+    ),
+)
+
+hltSimTiclCandidateExtraTable = cms.EDProducer(
+    "TICLCandidateExtraTableProducer",
+    src = cms.InputTag("hltTiclSimTracksters"),
+    name = cms.string("SimCandidate2Tracksters"),
+    doc = cms.string("TICLCandidates extra table with linked Tracksters"),
+    collectionVariables = cms.PSet(
+        tracksters = cms.PSet(
+            name = cms.string("SimCandidate2TrackstersIndices"),
+            doc = cms.string("Tracksters linked to SimTICLCandidates"),
+            useCount = cms.bool(True),
+            useOffset = cms.bool(False),
+            variables = cms.PSet() 
+        ),
+    ),
+)
+
+ticl_v5.toModify(hltTiclCandidateTable, src = cms.InputTag('hltTiclCandidate'))
+ticl_v5.toModify(hltTiclCandidateExtraTable, src = cms.InputTag('hltTiclCandidate'))

--- a/HLTrigger/NGTScouting/python/hltTICLSuperClusters_cfi.py
+++ b/HLTrigger/NGTScouting/python/hltTICLSuperClusters_cfi.py
@@ -1,0 +1,35 @@
+import FWCore.ParameterSet.Config as cms
+from PhysicsTools.NanoAOD.common_cff import *
+from PhysicsTools.NanoAOD.nano_cff import nanoMetadata
+from Validation.HGCalValidation.HLT_TICLIterLabels_cff import hltTiclIterLabels
+
+hltUpgradeNanoTask = cms.Task(nanoMetadata)
+
+# SuperClusters 
+hltTiclSuperClustersTable = cms.EDProducer(
+    "TICLSuperClustersTableProducer",
+    skipNonExistingSrc=cms.bool(True),
+    src=cms.InputTag("hltTiclEGammaSuperClusterProducerUnseeded"),
+    cut=cms.string(""),
+    name=cms.string("hltTICLSuperClusters"),
+    doc=cms.string("HLT TICL SuperClusters"),
+    singleton=cms.bool(False),  # the number of entries is variable
+    variables=cms.PSet(
+        raw_energy=Var("rawEnergy", "float",
+                       doc="Raw Energy of the SuperCluster [GeV]"),
+        energy=Var("energy", "float",
+                          doc="Regressed Energy of SuperCluster [GeV]"),
+        corrected_energy=Var(
+            "correctedEnergy", "float", doc="Corrected energy of the SuperCluster [GeV]"),
+        position_x=Var("position.x", "float",
+                         doc="SuperCluster position x [cm]"),
+        position_y=Var("position.y", "float",
+                         doc="SuperCluster position y [cm]"),
+        position_z=Var("position.z", "float",
+                         doc="SuperCluster barycenter z [cm]"),
+        position_eta=Var("position.eta", "float",
+                           doc="SuperCluster position pseudorapidity"),
+        position_phi=Var("position.phi", "float",
+                           doc="SuperCluster position phi"),
+    ),
+)

--- a/HLTrigger/NGTScouting/python/hltTracksters_cfi.py
+++ b/HLTrigger/NGTScouting/python/hltTracksters_cfi.py
@@ -1,75 +1,223 @@
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.NanoAOD.common_cff import *
 from PhysicsTools.NanoAOD.nano_cff import nanoMetadata
+from Validation.HGCalValidation.HLT_TICLIterLabels_cff import hltTiclIterLabels
 
 hltUpgradeNanoTask = cms.Task(nanoMetadata)
-
-
-### Tracksters
-hltTrackstersTable = cms.EDProducer(
-    "TracksterCollectionTableProducer",
-    skipNonExistingSrc = cms.bool(True),
-    src=cms.InputTag("hltTiclTrackstersMerge"),
-    cut=cms.string(""),
-    name=cms.string("tracksters"),
-    doc=cms.string("HLT Merged Tracksters"),
-    singleton=cms.bool(False),  # the number of entries is variable
-    variables=cms.PSet(
-        raw_energy=Var("raw_energy", "float", doc="Raw Energy of the trackster"),
-    ),
-    collectionVariables=cms.PSet(
-        tracksterVertices=cms.PSet(
-            name=cms.string("vertices"),
-            doc=cms.string("Vertex properties"),
-            useCount=cms.bool(True),
-            useOffset=cms.bool(True),
-            variables=cms.PSet(
-                vertices=Var("vertices", "uint", doc="Layer clusters indices."),
-                vertex_mult=Var(
-                    "vertex_multiplicity",
-                    "float",
-                    doc="Fraction of Layer cluster energy used by the Trackster.",
+hltSimTrackstersLabels = [
+    'hltTiclSimTracksters', 'hltTiclSimTrackstersfromCPs']
+# Tracksters
+hltTrackstersTable = []
+hltSimTrackstersTable = []
+hltTrackstersAssociationOneToManyTableProducers = []
+tracksterTableProducers = []
+for iterLabel in hltTiclIterLabels:
+    tracksterTable = cms.EDProducer(
+        "TracksterCollectionTableProducer",
+        skipNonExistingSrc=cms.bool(True),
+        src=cms.InputTag(iterLabel),
+        cut=cms.string(""),
+        name=cms.string(iterLabel),
+        doc=cms.string(iterLabel),
+        singleton=cms.bool(False),  # the number of entries is variable
+        variables=cms.PSet(
+            raw_energy=Var("raw_energy", "float",
+                           doc="Raw Energy of the trackster [GeV]"),
+            raw_em_energy=Var("raw_em_energy", "float",
+                              doc="EM raw Energy of the trackster [GeV]"),
+            raw_pt=Var(
+                "raw_pt", "float", doc="Trackster raw pT, computed from trackster raw energy and direction [GeV]"),
+            regressed_energy=Var("regressed_energy", "float",
+                                 doc="Regressed Energy of the trackster, for the SimTrackster it corresponds to the GEN-energy"),
+            barycenter_x=Var("barycenter.x", "float",
+                             doc="Trackster barycenter x [cm]"),
+            barycenter_y=Var("barycenter.y", "float",
+                             doc="Trackster barycenter y [cm]"),
+            barycenter_z=Var("barycenter.z", "float",
+                             doc="Trackster barycenter z [cm]"),
+            barycenter_eta=Var("barycenter.eta", "float",
+                               doc="Trackster barycenter pseudorapidity"),
+            barycenter_phi=Var("barycenter.phi", "float",
+                               doc="Trackster barycenter phi"),
+            EV1=Var("eigenvalues()[0]", "float",
+                    doc="Trackster PCA eigenvalues 0"),
+            EV2=Var("eigenvalues()[1]", "float",
+                    doc="Trackster PCA eigenvalues 1"),
+            EV3=Var("eigenvalues()[2]", "float",
+                    doc="Trackster PCA eigenvalues 2"),
+            eVector0_x=Var(
+                "eigenvectors()[0].x", "float", doc="Trackster PCA principal axis, x component"),
+            eVector0_y=Var(
+                "eigenvectors()[0].z", "float", doc="Trackster PCA principal axis, y component"),
+            eVector0_z=Var(
+                "eigenvectors()[0].y", "float", doc="Trackster PCA principal axis, z component"),
+            time=Var("time", "float", doc="Trackster HGCAL time"),
+            timeError=Var("timeError", "float",
+                          doc="Trackster HGCAL time error")
+        ),
+        collectionVariables=cms.PSet(
+            tracksterVertices=cms.PSet(
+                name=cms.string(f"{iterLabel}vertices"),
+                doc=cms.string("Vertex properties"),
+                useCount=cms.bool(True),
+                useOffset=cms.bool(True),
+                variables=cms.PSet(
+                    vertices=Var("vertices", "uint",
+                                 doc="Layer clusters indices."),
+                    vertex_mult=Var(
+                        "vertex_multiplicity",
+                        "float",
+                        doc="Fraction of Layer cluster energy used by the Trackster.",
+                    ),
                 ),
+            )
+        ),
+    )
+    label = f"{iterLabel}TableProducer"
+    globals()[label] = tracksterTable.clone()
+    tracksterTableProducers.append(globals()[label])
+    for iterLabelSim in hltSimTrackstersLabels:
+        CP_SC_label = "CP" if "CP" in iterLabelSim else "SC"
+        trackstersAssociationOneToManyTable = cms.EDProducer(
+            "TracksterTracksterEnergyScoreFlatTableProducer",
+            src=cms.InputTag(
+                f"hltAllTrackstersToSimTrackstersAssociationsByHits:{iterLabelSim}To{iterLabel}"
+            ),
+            name=cms.string(f"Sim{CP_SC_label}2{iterLabel}ByHits"),
+            doc=cms.string(
+                f"Association between SimTracksters and {iterLabel}, by hits."),
+            collectionVariables=cms.PSet(
+                links=cms.PSet(
+                    name=cms.string(
+                        f"Sim{CP_SC_label}2{iterLabel}ByHitsLinks"),
+                    doc=cms.string("Association links."),
+                    useCount=cms.bool(True),
+                    useOffset=cms.bool(False),
+                    variables=cms.PSet(
+                        index=Var("index", "uint",
+                                  doc="Index of the associated Trackster."),
+                        sharedEnergy=Var(
+                            "sharedEnergy",
+                            "float",
+                            doc="Shared energy with associated Trackster.",
+                        ),
+                        score=Var("score", "float", doc="Association score."),
+                    ),
+                )
             ),
         )
-    ),
-)
+        labelAssociation = f"{iterLabelSim}To{iterLabel}AssociationTableProducer"
+        globals()[labelAssociation] = trackstersAssociationOneToManyTable.clone()
+        hltTrackstersAssociationOneToManyTableProducers.append(
+            globals()[labelAssociation])
 
-### Tracksters Associators
-hltTrackstersAssociationOneToManyTable = cms.EDProducer(
-    "TracksterTracksterEnergyScoreFlatTableProducer",
-    src=cms.InputTag(
-        "hltAllTrackstersToSimTrackstersAssociationsByHits:hltTiclSimTrackstersTohltTiclTrackstersMerge"
-    ),
-    name=cms.string("SimTS2TSMergeByHits"),
-    doc=cms.string("Association between SimTracksters and tracksterMerge, by hits."),
-    collectionVariables=cms.PSet(
-        links=cms.PSet(
-            name=cms.string("SimTS2TSMergeByHitsLinks"),
-            doc=cms.string("Association links."),
-            useCount=cms.bool(True),
-            useOffset=cms.bool(False),
-            variables=cms.PSet(
-                index=Var("index", "uint", doc="Index of the associated Trackster."),
-                sharedEnergy=Var(
-                    "sharedEnergy",
-                    "float",
-                    doc="Shared energy with associated Trackster.",
+hltTrackstersTableSequence = cms.Sequence(
+    sum(tracksterTableProducers, cms.Sequence()))
+hltTiclAssociationsTableSequence = cms.Sequence(
+    sum(hltTrackstersAssociationOneToManyTableProducers, cms.Sequence()))
+simTracksterTableProducers = []
+for iterLabel in hltSimTrackstersLabels:
+    label = iterLabel
+    objName = ""
+    if ("CP" in iterLabel):
+        label, objName = iterLabel.split("hltTiclSimTracksters")
+    hltSimTracksterTable = cms.EDProducer(
+        "TracksterCollectionTableProducer",
+        skipNonExistingSrc=cms.bool(True),
+        src=cms.InputTag(f"hltTiclSimTracksters", objName),
+        cut=cms.string(""),
+        name=cms.string(f"{iterLabel}"),
+        doc=cms.string(f"{iterLabel}"),
+        singleton=cms.bool(False),  # the number of entries is variable
+        variables=cms.PSet(
+            raw_energy=Var("raw_energy", "float",
+                           doc="Raw Energy of the trackster [GeV]"),
+            raw_em_energy=Var("raw_em_energy", "float",
+                              doc="EM raw Energy of the trackster [GeV]"),
+            raw_pt=Var(
+                "raw_pt", "float", doc="Trackster raw pT, computed from trackster raw energy and direction [GeV]"),
+            regressed_energy=Var("regressed_energy", "float",
+                                 doc="Regressed Energy of the trackster, for the SimTrackster it corresponds to the GEN-energy"),
+            barycenter_x=Var("barycenter.x", "float",
+                             doc="Trackster barycenter x [cm]"),
+            barycenter_y=Var("barycenter.y", "float",
+                             doc="Trackster barycenter y [cm]"),
+            barycenter_z=Var("barycenter.z", "float",
+                             doc="Trackster barycenter z [cm]"),
+            barycenter_eta=Var("barycenter.eta", "float",
+                               doc="Trackster barycenter pseudorapidity"),
+            barycenter_phi=Var("barycenter.phi", "float",
+                               doc="Trackster barycenter phi"),
+            EV1=Var("eigenvalues()[0]", "float",
+                    doc="Trackster PCA eigenvalues 0"),
+            EV2=Var("eigenvalues()[1]", "float",
+                    doc="Trackster PCA eigenvalues 1"),
+            EV3=Var("eigenvalues()[2]", "float",
+                    doc="Trackster PCA eigenvalues 2"),
+            eVector0_x=Var(
+                "eigenvectors()[0].x", "float", doc="Trackster PCA principal axis, x component"),
+            eVector0_y=Var(
+                "eigenvectors()[0].z", "float", doc="Trackster PCA principal axis, y component"),
+            eVector0_z=Var(
+                "eigenvectors()[0].y", "float", doc="Trackster PCA principal axis, z component"),
+            time=Var("time", "float", doc="Trackster HGCAL time"),
+            timeError=Var("timeError", "float",
+                          doc="Trackster HGCAL time error")
+        ),
+        collectionVariables=cms.PSet(
+            tracksterVertices=cms.PSet(
+                name=cms.string(f"{iterLabel}vertices"),
+                doc=cms.string("Vertex properties"),
+                useCount=cms.bool(True),
+                useOffset=cms.bool(True),
+                variables=cms.PSet(
+                    vertices=Var("vertices", "uint",
+                                 doc="Layer clusters indices."),
+                    vertex_mult=Var(
+                        "vertex_multiplicity",
+                        "float",
+                        doc="Fraction of Layer cluster energy used by the Trackster.",
+                    ),
                 ),
-                score=Var("score", "float", doc="Association score."),
-            ),
-        )
-    ),
-)
+            )
+        ),
+    )
+    label = f"{iterLabel}TableProducer"
+    globals()[label] = hltSimTracksterTable.clone()
+    simTracksterTableProducers.append(globals()[label])
 
-### Tracksters Associators
+    hltTiclSimTrackstersExtraTable = cms.EDProducer("SimTracksterTableProducer",
+                                                    tableName=cms.string(
+                                                        f"{iterLabel}"),
+                                                    skipNonExistingSrc=cms.bool(
+                                                        True),
+                                                    simTracksters=cms.InputTag(
+                                                        "hltTiclSimTracksters", objName),
+                                                    caloParticles=cms.InputTag(
+                                                        "mix", "MergedCaloTruth"),
+                                                    simClusters=cms.InputTag(
+                                                        "mix", "MergedCaloTruth"),
+                                                    caloParticleToSimClustersMap=cms.InputTag(
+                                                        "hltTiclSimTracksters"),
+                                                    precision=cms.int32(7),
+                                                    )
+    labelExtra = f"{iterLabel}TableExtraProducer"
+    globals()[labelExtra] = hltTiclSimTrackstersExtraTable.clone()
+    simTracksterTableProducers.append(globals()[labelExtra])
+
+hltSimTracksterSequence = cms.Sequence(
+    sum(simTracksterTableProducers, cms.Sequence()))
+# Tracksters Associators
 hltSimCl2CPOneToOneFlatTable = cms.EDProducer(
     "SimClusterCaloParticleFractionFlatTableProducer",
-    src=cms.InputTag("SimClusterToCaloParticleAssociation:simClusterToCaloParticleMap"),
+    src=cms.InputTag(
+        "SimClusterToCaloParticleAssociation:simClusterToCaloParticleMap"),
     name=cms.string("SimCl2CPWithFraction"),
     doc=cms.string("Association between SimClusters and CaloParticles."),
     variables=cms.PSet(
         index=Var("index", "int", doc="Index of linked CaloParticle."),
-        fraction=Var("fraction", "float", doc="Fraction of linked CaloParticle."),
+        fraction=Var("fraction", "float",
+                     doc="Fraction of linked CaloParticle."),
     ),
 )
+hltTiclAssociationsTableSequence += hltSimCl2CPOneToOneFlatTable

--- a/HLTrigger/NGTScouting/test/readNano.py
+++ b/HLTrigger/NGTScouting/test/readNano.py
@@ -6,11 +6,15 @@ import sys
 
 def main():
     # Argument parsing
-    parser = argparse.ArgumentParser(description="Process a NanoAOD ROOT file.")
-    parser.add_argument("filename", help="Path to the NanoAOD ROOT file")
+    parser = argparse.ArgumentParser()
+    parser.add_argument("filename")
+    parser.add_argument("--validation", action="store_true", help="Check Sim branches")
+    parser.add_argument("--ticlv", choices=["v4", "v5"], default="v5", help="TICL version")
     args = parser.parse_args()
 
     file_path = args.filename
+    ticlVersion = args.ticlv
+    validation = args.validation
     tree_name = "Events"
 
     # Open the ROOT file and load the TTree
@@ -28,30 +32,30 @@ def main():
     # Event loop
     for i, event in enumerate(events):
         print(f"Processing event {i}")
-        print("Found {} tracksters".format(event.ntracksters))
-        for t_idx in range(event.ntracksters):
-            offset = event.tracksters_overtices[t_idx]
-            count = event.tracksters_nvertices[t_idx]
-            vertices = event.vertices_vertices[offset : offset + count]
-            vertex_multiplicity = event.vertices_vertex_mult[offset : offset + count]
+        ## CLUE3D Tracksters ##
+        print("Found {} CLUE3D Tracksters".format(event.nhltTiclTrackstersCLUE3DHigh))
+        for t_idx in range(event.nhltTiclTrackstersCLUE3DHigh):
+            offset = event.hltTiclTrackstersCLUE3DHigh_ohltTiclTrackstersCLUE3DHighvertices[t_idx]
+            count = event.hltTiclTrackstersCLUE3DHigh_nhltTiclTrackstersCLUE3DHighvertices[t_idx]
+            vertices = event.hltTiclTrackstersCLUE3DHighvertices_vertices[offset : offset + count]
+            vertex_multiplicity = event.hltTiclTrackstersCLUE3DHighvertices_vertex_mult[offset : offset + count]
             print(
                 t_idx,
                 list(zip(vertices, vertex_multiplicity)),
-                event.tracksters_raw_energy[t_idx],
+                event.hltTiclTrackstersCLUE3DHigh_raw_energy[t_idx],
             )
 
         print("Exploring connections, scores, and sharedEnergy")
-        print("Connections for {} objects".format(event.nSimTS2TSMergeByHits))
-
+        print("Connections for {} objects".format(event.nSimCP2hltTiclTrackstersCLUE3DHighByHits))
         try:  # Offset pattern
             offset = 0
-            for obj_idx in range(event.nSimTS2TSMergeByHits - 1):
-                next_offset = event.SimTS2TSMergeByHits_oSimTS2TSMergeByHitsLinks[
+            for obj_idx in range(event.nSimCP2hltTiclTrackstersCLUE3DHighByHits- 1):
+                next_offset = event.SimCP2hltTiclTrackstersCLUE3DHighByHits_oSimCP2hltTiclTrackstersCLUE3DHighByHitsLinks[
                     obj_idx + 1
                 ]
-                elements = event.SimTS2TSMergeByHitsLinks_index[offset:next_offset]
-                scores = event.SimTS2TSMergeByHitsLinks_score[offset:next_offset]
-                sharedEnergy = event.SimTS2TSMergeByHitsLinks_shardEnergy[
+                elements = event.SimCP2hltTiclTrackstersCLUE3DHighByHitsLinks_index[offset:next_offset]
+                scores = event.SimCP2hltTiclTrackstersCLUE3DHighByHitsLinks_score[offset:next_offset]
+                sharedEnergy = event.SimCP2hltTiclTrackstersCLUE3DHighByHitsLinks_sharedEnergy[
                     offset:next_offset
                 ]
                 if len(elements) > 0:
@@ -62,11 +66,11 @@ def main():
 
         try:  # Count pattern
             offset = 0
-            for obj_idx in range(event.nSimTS2TSMergeByHits):
-                count = event.SimTS2TSMergeByHits_nSimTS2TSMergeByHitsLinks[obj_idx]
-                elements = event.SimTS2TSMergeByHitsLinks_index[offset : offset + count]
-                scores = event.SimTS2TSMergeByHitsLinks_score[offset : offset + count]
-                sharedEnergy = event.SimTS2TSMergeByHitsLinks_sharedEnergy[
+            for obj_idx in range(event.nSimCP2hltTiclTrackstersCLUE3DHighByHits):
+                count = event.SimCP2hltTiclTrackstersCLUE3DHighByHits_nSimCP2hltTiclTrackstersCLUE3DHighByHitsLinks[obj_idx]
+                elements = event.SimCP2hltTiclTrackstersCLUE3DHighByHitsLinks_index[offset : offset + count]
+                scores = event.SimCP2hltTiclTrackstersCLUE3DHighByHitsLinks_score[offset : offset + count]
+                sharedEnergy = event.SimCP2hltTiclTrackstersCLUE3DHighByHitsLinks_sharedEnergy[
                     offset : offset + count
                 ]
                 if len(elements) > 0:
@@ -74,6 +78,71 @@ def main():
                 offset += count
         except AttributeError as e:
             print(f"An AttributeError occurred (Count): {e}")
+
+        ## TICLv5 Collections ##
+        if(ticlVersion == "v5"):
+            print("Found {} TICLCandidate tracksters".format(event.nhltTiclCandidate))
+            try:  # Offset pattern
+                offset = 0
+                for obj_idx in range(event.nSimCP2hltTiclCandidateByHits - 1):
+                    next_offset = event.SimSC2hltTiclCandidateByHits_oSimSC2hltTiclCandidateByHitsLinks[
+                        obj_idx + 1
+                    ]
+                    elements = event.SimCP2hltTiclTrackstersCLUE3DHighByHitsLinks_index[offset:next_offset]
+                    scores = event.SimCP2hltTiclTrackstersCLUE3DHighByHitsLinks_score[offset:next_offset]
+                    sharedEnergy = event.SimCP2hltTiclTrackstersCLUE3DHighByHitsLinks_sharedEnergy[
+                        offset:next_offset
+                    ]
+                    if len(elements) > 0:
+                        print("Offset ", obj_idx, elements, scores, sharedEnergy)
+                    offset = next_offset
+            except AttributeError as e:
+                print(f"An AttributeError occurred (Offset): {e}")
+
+            try:  # Count pattern
+                offset = 0
+                for obj_idx in range(event.nSimCP2hltTiclCandidateByHits):
+                    count = event.SimSC2hltTiclCandidateByHits_nSimSC2hltTiclCandidateByHitsLinks[obj_idx]
+                    elements = event.SimCP2hltTiclTrackstersCLUE3DHighByHitsLinks_index[offset : offset + count]
+                    scores = event.SimCP2hltTiclTrackstersCLUE3DHighByHitsLinks_score[offset : offset + count]
+                    sharedEnergy = event.SimCP2hltTiclTrackstersCLUE3DHighByHitsLinks_sharedEnergy[
+                        offset : offset + count
+                    ]
+                    if len(elements) > 0:
+                        print("Count ", obj_idx, elements, scores, sharedEnergy)
+                    offset += count
+            except AttributeError as e:
+                print(f"An AttributeError occurred (Count): {e}")
+    
+            try:  # Count pattern
+                offset = 0
+                for obj_idx in range(event.nSimCP2hltTiclCandidateByHits):
+                    count = event.SimCP2hltTiclCandidateByHits_nSimCP2hltTiclCandidateByHitsLinks[obj_idx]
+                    elements = event.SimCP2hltTiclCandidateByHitsLinks_index[offset : offset + count]
+                    scores = event.SimCP2hltTiclCandidateByHitsLinks_score[offset : offset + count]
+                    sharedEnergy = event.SimCP2hltTiclCandidateByHitsLinks_sharedEnergy[
+                        offset : offset + count
+                    ]
+                    if len(elements) > 0:
+                        print("Count ", obj_idx, elements, scores, sharedEnergy)
+                    offset += count
+            except AttributeError as e:
+                print(f"An AttributeError occurred (Count): {e}")
+
+            if(validation):
+                print("Found {} simTICLCandidates".format(event.nhltSimTICLCandidates))
+                for sim_idx in range(event.nhltSimTICLCandidates):
+                    trackIdx = event.hltSimTICLCandidates_trackIdx[sim_idx]
+                    if(trackIdx >= 0):
+                        track_pt = event.hltGeneralTrack_pt[trackIdx]
+                    else:
+                        track_pt = np.nan;
+                    print(
+                        sim_idx,
+                        trackIdx,
+                        track_pt,
+                        event.hltSimTICLCandidates_raw_energy[sim_idx],
+                    )
 
         try:
             for i in range(event.nSimCl2CPWithFraction):

--- a/PhysicsTools/NanoAOD/interface/AssociationMapFlatTableProducer.h
+++ b/PhysicsTools/NanoAOD/interface/AssociationMapFlatTableProducer.h
@@ -96,7 +96,6 @@ public:
         }
         this->coltables.push_back(std::move(coltable));
         edm::stream::EDProducer<>::produces<nanoaod::FlatTable>(coltables.back().name + "Table");
-        std::cout << "MR OneToMany will produce " << coltables.back().name + "Table" << std::endl;
       }
     }
   }


### PR DESCRIPTION
This PR adds TICL objects to the NanoAOD HLT output. Reco-objects (Tracksters, TICLCandidates, and SuperClusters) are added to the NanoAOD baseline. Sim-objects (SimTracksters, SimTICLCandidates) and association maps are added to the `hltNanoValCustomize`  only.

The `readNano.py` under `tests` has been updated for testing the new collections.

Tested on 29634.772