### PR TITLE
[14_1_X] Setup tests for 2023 PbPb UPC rereco MC

### DIFF
--- a/Configuration/PyReleaseValidation/test/BuildFile.xml
+++ b/Configuration/PyReleaseValidation/test/BuildFile.xml
@@ -42,7 +42,7 @@
 
 <ifarchitecture name="el8_amd64">
   <!-- Run this test for production arch of CMSSW_13_2_14 release only -->
-  <test name="test_MC_PbPb_23_setup" command="CMSSW_MC_SETUP_TEST_CATCH_HLT=0 ${CMSSW_BASE}/src/Configuration/PyReleaseValidation/test/test_mc_setup/test_MC_setup.sh auto:phase1_2023_realistic_hi Run3_pp_on_PbPb_2023 HIon CMSSW_13_2_14 132X_mcRun3_2023_realistic_HI_v10 Realistic2023PbPbCollision Pythia8_GammaNucleus_5p36TeV_cfi Run3_2023_UPC" />
+  <test name="test_MC_PbPb_23_setup" command="${CMSSW_BASE}/src/Configuration/PyReleaseValidation/test/test_mc_setup/test_MC_setup.sh auto:phase1_2023_realistic_hi Run3_pp_on_PbPb_2023 HIon CMSSW_13_2_14 132X_mcRun3_2023_realistic_HI_v10 Realistic2023PbPbCollision Pythia8_GammaNucleus_5p36TeV_cfi Run3_2023_UPC" />
 </ifarchitecture>
 
 <!--

--- a/Configuration/PyReleaseValidation/test/BuildFile.xml
+++ b/Configuration/PyReleaseValidation/test/BuildFile.xml
@@ -32,3 +32,24 @@
 -->
 <test name="test_MC_23_crosscheck" command="CMSSW_MC_SETUP_TEST_CATCH_HLT=0 ${CMSSW_BASE}/src/Configuration/PyReleaseValidation/test/test_mc_setup/test_MC_setup.sh auto:phase1_2023_realistic Run3_2023 @relval2023 ${CMSSW_VERSION} auto:phase1_2023_realistic DBrealistic" />
 <test name="test_MC_22_crosscheck" command="CMSSW_MC_SETUP_TEST_CATCH_HLT=0 ${CMSSW_BASE}/src/Configuration/PyReleaseValidation/test/test_mc_setup/test_MC_setup.sh auto:phase1_2022_realistic Run3 @relval2022 ${CMSSW_VERSION} auto:phase1_2022_realistic DBrealistic" />
+
+<!-- Tests for MC production for 2023 PbPb UPC rereco -->
+<!--
+    By default these tests won't fail if a failure happens at
+    HLT step. If you want to catch those errors please set the
+    environment variable CMSSW_MC_SETUP_TEST_CATCH_HLT.
+-->
+
+<ifarchitecture name="el8_amd64">
+  <!-- Run this test for production arch of CMSSW_13_2_14 release only -->
+  <test name="test_MC_PbPb_23_setup" command="CMSSW_MC_SETUP_TEST_CATCH_HLT=0 ${CMSSW_BASE}/src/Configuration/PyReleaseValidation/test/test_mc_setup/test_MC_setup.sh auto:phase1_2023_realistic_hi Run3_pp_on_PbPb_2023 HIon CMSSW_13_2_14 132X_mcRun3_2023_realistic_HI_v10 Realistic2023PbPbCollision Pythia8_GammaNucleus_5p36TeV_cfi Run3_2023_UPC" />
+</ifarchitecture>
+
+<!--
+    The setups below are "standard", with everything run
+    in the same release (the current) with the same GT.
+    This is done to crosscheck that, in normal conditions,
+    everything works and ther's no bug or artifact in the
+    chain itself.
+-->
+<test name="test_MC_PbPb_23_crosscheck" command="CMSSW_MC_SETUP_TEST_CATCH_HLT=0 ${CMSSW_BASE}/src/Configuration/PyReleaseValidation/test/test_mc_setup/test_MC_setup.sh auto:phase1_2023_realistic_hi Run3_pp_on_PbPb_2023 HIon ${CMSSW_VERSION} auto:phase1_2024_realistic_hi DBrealistic Pythia8_GammaNucleus_5p36TeV_cfi Run3_2023_UPC" />

--- a/Configuration/PyReleaseValidation/test/test_mc_setup/test_MC_setup.sh
+++ b/Configuration/PyReleaseValidation/test/test_mc_setup/test_MC_setup.sh
@@ -15,6 +15,8 @@ hlt=$3
 release_hlt=$4
 gt_hlt=$5
 beamspot=$6
+fragment=$([ -n "$7" ] && echo "$7" || echo "TTbar_14TeV_TuneCP5_cfi")
+era_reco=$([ -n "$8" ] && echo "$8" || echo "$era")
 
 base_dir=$PWD
 base_cms=$CMSSW_BASE
@@ -32,6 +34,8 @@ echo '> Era          : ' $era
 echo '> BS           : ' $beamspot
 echo '> HLT          : ' $hlt
 echo '> HLT release  : ' $release_hlt
+echo '> Fragment     : ' $fragment
+echo '> Era at RECO  : ' $era_reco
 if [[ ! ("$CMSSW_VERSION" == $release_hlt) ]]; then
     echo " - at ${hlt_cmssw_path}"
 fi
@@ -45,7 +49,7 @@ echo ''
 ############################################################################################################
 # GEN SIM
 
-${scriptdir}/test_MC_setup_gen_sim.sh $CMSSW_VERSION $conditions $era $beamspot 
+${scriptdir}/test_MC_setup_gen_sim.sh $CMSSW_VERSION $conditions $era $beamspot $fragment
 
 if [ $? -ne 0 ]; then
     exit 1;
@@ -77,7 +81,7 @@ if [[ ! ("$CMSSW_BASE" == $base_cms) ]]; then
     cd $workdir
 fi
 echo $SCRAM_ARCH
-${scriptdir}/test_MC_setup_reco.sh $release_hlt $conditions $era $hlt
+${scriptdir}/test_MC_setup_reco.sh $release_hlt $conditions $era_reco
 
 if [ $? -ne 0 ]; then
     exit 1;

--- a/Configuration/PyReleaseValidation/test/test_mc_setup/test_MC_setup_gen_sim.sh
+++ b/Configuration/PyReleaseValidation/test/test_mc_setup/test_MC_setup_gen_sim.sh
@@ -7,10 +7,11 @@ release=$1
 conditions=$2
 era=$3
 beamspot=$4
+fragment=$5
 
 echo '> Running GEN,SIM + DIGI,L1,DIGI2RAW steps in ' $release
 
-cmsDriver.py TTbar_14TeV_TuneCP5_cfi --python_filename gen_sim.py \
+cmsDriver.py $fragment --python_filename gen_sim.py \
 --eventcontent RAWSIM --customise Configuration/DataProcessing/Utils.addMonitoring \
 --datatier GEN-SIM --fileout file:step1.root --conditions $conditions --beamspot $beamspot \
 --step GEN,SIM --geometry DB:Extended --era $era --mc -n 10 --no_exec


### PR DESCRIPTION
#### PR description:

This PR setup tests for the MC production of 2023 PbPb UPC rereco data.

Prepared so far only for 14_1_X release as suggested in https://github.com/cms-sw/cmssw/issues/48481#issuecomment-3045466785

#### PR validation:

Tested locally

@mandrenguyen
