### PR TITLE
Fix fillDescriptions default for LHEPtFilter

### DIFF
--- a/GeneratorInterface/GenFilters/plugins/LHEPtFilter.cc
+++ b/GeneratorInterface/GenFilters/plugins/LHEPtFilter.cc
@@ -123,6 +123,7 @@ bool LHEPtFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetu
 void LHEPtFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<bool>("isScalar", false);  // default is false
+  descriptions.addDefault(desc);
 }
 
 //define this as a plug-in


### PR DESCRIPTION
#### PR description:

This is a follow up to [#48250](https://github.com/cms-sw/cmssw/pull/48250) which provides a fix to create the intended behavior for `fillDescriptions` in the plugin.

#### PR validation:

Checked output `.cfi` after `scram b` and the config contains the intended default.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but will have a backport for the 10_6_X equivalent.

@hatakeyamak @lviliani 
