### PR TITLE
Add PU related plots for ECAL Spike Killer monitoring

### DIFF
--- a/DQM/EcalMonitorTasks/interface/TrigPrimTask.h
+++ b/DQM/EcalMonitorTasks/interface/TrigPrimTask.h
@@ -62,8 +62,8 @@ namespace ecaldqm {
     double bxBin_;
     double bxBinFine_;
 
-    double etSum_;
-    double etSpikeMatchSum_;
+    std::vector<double> etSum_ = {0., 0., 0.};  // when using 13, 20, 30 GeV thresholds
+    std::vector<double> etSpikeMatchSum_ = {0., 0., 0.};
 
     std::map<uint32_t, unsigned> towerReadouts_;
 

--- a/DQM/EcalMonitorTasks/python/TrigPrimTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/TrigPrimTask_cfi.py
@@ -343,19 +343,47 @@ ecalTrigPrimTask = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sTriggerTowerTask/%(prefix)sTTT Real vs Emulated TP Et%(suffix)s'),
             description = cms.untracked.string('Real data VS emulated TP Et (in-time)')
         ),
-        TrendEtSum = cms.untracked.PSet(
-            path = cms.untracked.string('Ecal/Trends/TriggerTowerTask Et sum of TPs above threshold'),
+        TrendEtSum13 = cms.untracked.PSet(
+            path = cms.untracked.string('Ecal/Trends/TriggerTowerTask Et sum of TPs in EB above 13 GeV'),
             kind = cms.untracked.string('TProfile'),
             otype = cms.untracked.string('Ecal2P'),
             btype = cms.untracked.string('Trend'),
-            description = cms.untracked.string('Trend of Et sum of TPs with Et > 30 GeV.')
+            description = cms.untracked.string('Trend of Et sum of TPs in EB with Et > 13 GeV.')
         ),
-        TrendEtSpikeMatchSum = cms.untracked.PSet(
-            path = cms.untracked.string('Ecal/Trends/TriggerTowerTask Et sum of TPs above threshold (Spike Matched)'),
+        TrendEtSum20 = cms.untracked.PSet(
+            path = cms.untracked.string('Ecal/Trends/TriggerTowerTask Et sum of TPs in EB above 20 GeV'),
             kind = cms.untracked.string('TProfile'),
             otype = cms.untracked.string('Ecal2P'),
             btype = cms.untracked.string('Trend'),
-            description = cms.untracked.string('Trend of Et sum of TPs (spike-matched) with Et > 30 GeV.')
+            description = cms.untracked.string('Trend of Et sum of TPs in EB with Et > 20 GeV.')
+        ),
+        TrendEtSum30 = cms.untracked.PSet(
+            path = cms.untracked.string('Ecal/Trends/TriggerTowerTask Et sum of TPs in EB above 30 GeV'),
+            kind = cms.untracked.string('TProfile'),
+            otype = cms.untracked.string('Ecal2P'),
+            btype = cms.untracked.string('Trend'),
+            description = cms.untracked.string('Trend of Et sum of TPs in EB with Et > 30 GeV.')
+        ),
+        TrendEtSpikeMatchSum13 = cms.untracked.PSet(
+            path = cms.untracked.string('Ecal/Trends/TriggerTowerTask Et sum of TPs in EB above 13 GeV (Spike Matched)'),
+            kind = cms.untracked.string('TProfile'),
+            otype = cms.untracked.string('Ecal2P'),
+            btype = cms.untracked.string('Trend'),
+            description = cms.untracked.string('Trend of Et sum of TPs in EB (spike-matched) with Et > 13 GeV.')
+        ),
+        TrendEtSpikeMatchSum20 = cms.untracked.PSet(
+            path = cms.untracked.string('Ecal/Trends/TriggerTowerTask Et sum of TPs in EB above 20 GeV (Spike Matched)'),
+            kind = cms.untracked.string('TProfile'),
+            otype = cms.untracked.string('Ecal2P'),
+            btype = cms.untracked.string('Trend'),
+            description = cms.untracked.string('Trend of Et sum of TPs in EB (spike-matched) with Et > 20 GeV.')
+        ),
+        TrendEtSpikeMatchSum30 = cms.untracked.PSet(
+            path = cms.untracked.string('Ecal/Trends/TriggerTowerTask Et sum of TPs in EB above 30 GeV (Spike Matched)'),
+            kind = cms.untracked.string('TProfile'),
+            otype = cms.untracked.string('Ecal2P'),
+            btype = cms.untracked.string('Trend'),
+            description = cms.untracked.string('Trend of Et sum of TPs in EB (spike-matched) with Et > 30 GeV.')
         ),
         LHCStatusByLumi = cms.untracked.PSet(
             path = cms.untracked.string('Ecal/Trends/LHC status by lumi'),

--- a/DQM/EcalMonitorTasks/src/OccupancyTask.cc
+++ b/DQM/EcalMonitorTasks/src/OccupancyTask.cc
@@ -15,10 +15,6 @@ namespace ecaldqm {
     metadataTag = _params.getParameter<edm::InputTag>("metadata");
     lumiCheck_ = _params.getUntrackedParameter<bool>("lumiCheck", false);
     if (!onlineMode_) {
-      MEs_.erase(std::string("PU"));
-      MEs_.erase(std::string("NEvents"));
-      MEs_.erase(std::string("TrendEventsperLumi"));
-      MEs_.erase(std::string("TrendPUperLumi"));
       MEs_.erase(std::string("AELoss"));
       MEs_.erase(std::string("AEReco"));
     }
@@ -51,11 +47,9 @@ namespace ecaldqm {
       MEs_.at("TPDigiThrAllByLumi").reset(GetElectronicsMap());
       MEs_.at("RecHitThrAllByLumi").reset(GetElectronicsMap());
       nEv = 0;
-      if (onlineMode_) {
-        MEs_.at("PU").reset(GetElectronicsMap(), -1);
-        MEs_.at("NEvents").reset(GetElectronicsMap(), -1);
-        FindPUinLS = true;
-      }
+      MEs_.at("PU").reset(GetElectronicsMap(), -1);
+      MEs_.at("NEvents").reset(GetElectronicsMap(), -1);
+      FindPUinLS = true;
     }
     nEv++;
     MESet& meLaserCorrProjEta(MEs_.at("LaserCorrProjEta"));
@@ -103,15 +97,13 @@ namespace ecaldqm {
   }
 
   void OccupancyTask::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {
-    if (onlineMode_) {
-      MESet& meNEvents(static_cast<MESet&>(MEs_.at("NEvents")));
-      MESet& meTrendEventsperLumi(MEs_.at("TrendEventsperLumi"));
-      MESet& meTrendPUperLumi(MEs_.at("TrendPUperLumi"));
+    MESet& meNEvents(static_cast<MESet&>(MEs_.at("NEvents")));
+    MESet& meTrendEventsperLumi(MEs_.at("TrendEventsperLumi"));
+    MESet& meTrendPUperLumi(MEs_.at("TrendPUperLumi"));
 
-      meNEvents.fill(getEcalDQMSetupObjects(), double(nEv));
-      meTrendEventsperLumi.fill(getEcalDQMSetupObjects(), EcalBarrel, double(timestamp_.iLumi), double(nEv));
-      meTrendPUperLumi.fill(getEcalDQMSetupObjects(), EcalBarrel, double(timestamp_.iLumi), double(scal_pu));
-    }
+    meNEvents.fill(getEcalDQMSetupObjects(), double(nEv));
+    meTrendEventsperLumi.fill(getEcalDQMSetupObjects(), EcalBarrel, double(timestamp_.iLumi), double(nEv));
+    meTrendPUperLumi.fill(getEcalDQMSetupObjects(), EcalBarrel, double(timestamp_.iLumi), double(scal_pu));
   }
 
   template <typename DigiCollection>

--- a/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
+++ b/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
@@ -231,14 +231,28 @@ namespace ecaldqm {
       meEtSummary.fill(getEcalDQMSetupObjects(), ttid, et);
       meEtSummaryByLumi.fill(getEcalDQMSetupObjects(), ttid, et);
 
-      if (et > 60)
-        etSum_ += et;
-
       if (ttid.subDet() == EcalBarrel) {
+        if (et > 26) {
+          etSum_[0] += et;
+          if (et > 40) {
+            etSum_[1] += et;
+            if (et > 60) {
+              etSum_[2] += et;
+            }
+          }
+        }
+
         if (mapTowerOfflineSpikes_[ttid] == 1) {
           meEtRealSpikeMatched.fill(getEcalDQMSetupObjects(), ttid, et);
-          if (et > 60)
-            etSpikeMatchSum_ += et;
+          if (et > 26) {
+            etSpikeMatchSum_[0] += et;
+            if (et > 40) {
+              etSpikeMatchSum_[1] += et;
+              if (et > 60) {
+                etSpikeMatchSum_[2] += et;
+              }
+            }
+          }
         }
       }
 
@@ -433,14 +447,22 @@ namespace ecaldqm {
   }
 
   void TrigPrimTask::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {
-    MESet& meTrendEtSum(MEs_.at("TrendEtSum"));
-    MESet& meTrendEtSpikeMatchSum(MEs_.at("TrendEtSpikeMatchSum"));
+    MESet& meTrendEtSum13(MEs_.at("TrendEtSum13"));
+    MESet& meTrendEtSum20(MEs_.at("TrendEtSum20"));
+    MESet& meTrendEtSum30(MEs_.at("TrendEtSum30"));
+    MESet& meTrendEtSpikeMatchSum13(MEs_.at("TrendEtSpikeMatchSum13"));
+    MESet& meTrendEtSpikeMatchSum20(MEs_.at("TrendEtSpikeMatchSum20"));
+    MESet& meTrendEtSpikeMatchSum30(MEs_.at("TrendEtSpikeMatchSum30"));
 
-    meTrendEtSum.fill(getEcalDQMSetupObjects(), EcalBarrel, double(timestamp_.iLumi), etSum_);
-    meTrendEtSpikeMatchSum.fill(getEcalDQMSetupObjects(), EcalBarrel, double(timestamp_.iLumi), etSpikeMatchSum_);
+    meTrendEtSum13.fill(getEcalDQMSetupObjects(), EcalBarrel, double(timestamp_.iLumi), etSum_[0]);
+    meTrendEtSum20.fill(getEcalDQMSetupObjects(), EcalBarrel, double(timestamp_.iLumi), etSum_[1]);
+    meTrendEtSum30.fill(getEcalDQMSetupObjects(), EcalBarrel, double(timestamp_.iLumi), etSum_[2]);
+    meTrendEtSpikeMatchSum13.fill(getEcalDQMSetupObjects(), EcalBarrel, double(timestamp_.iLumi), etSpikeMatchSum_[0]);
+    meTrendEtSpikeMatchSum20.fill(getEcalDQMSetupObjects(), EcalBarrel, double(timestamp_.iLumi), etSpikeMatchSum_[1]);
+    meTrendEtSpikeMatchSum30.fill(getEcalDQMSetupObjects(), EcalBarrel, double(timestamp_.iLumi), etSpikeMatchSum_[2]);
 
-    etSum_ = 0.;
-    etSpikeMatchSum_ = 0.;
+    etSum_ = {0., 0., 0.};
+    etSpikeMatchSum_ = {0., 0., 0.};
   }
 
   DEFINE_ECALDQM_WORKER(TrigPrimTask);


### PR DESCRIPTION
#### PR description:

This PR adds a few plots in ECAL DQM workspace to help PU-related plots (e.g. transverse energy sum for trigger primitives (spike-matched) above some thresholds vs. LS). 

#### PR validation:

PR is validated by running the ECAL online DQM configuration and verifying the plots on a test DQM GUI.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is a master PR. Backports to `15_0_X` are made in #48507. 
