### PR TITLE
fix HLT TICL reconstruction sequences when `ticl_barrel` is invoked in presence of the `alpaka` modifier

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltMergeLayerClusters_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltMergeLayerClusters_cfi.py
@@ -1,28 +1,51 @@
 import FWCore.ParameterSet.Config as cms
 
+# Default lists
+default_layerClusters = [
+    "hltHgcalLayerClustersEE", 
+    "hltHgcalLayerClustersHSci", 
+    "hltHgcalLayerClustersHSi"
+]
+
+default_time_layerclusters = [
+    "hltHgcalLayerClustersEE:timeLayerCluster", 
+    "hltHgcalLayerClustersHSci:timeLayerCluster", 
+    "hltHgcalLayerClustersHSi:timeLayerCluster"
+]
+
+# Define the producer with default lists
 hltMergeLayerClusters = cms.EDProducer("MergeClusterProducer",
-    layerClusters = cms.VInputTag("hltHgcalLayerClustersEE", "hltHgcalLayerClustersHSci", "hltHgcalLayerClustersHSi"),
-    mightGet = cms.optional.untracked.vstring,
-    time_layerclusters = cms.VInputTag("hltHgcalLayerClustersEE:timeLayerCluster", "hltHgcalLayerClustersHSci:timeLayerCluster", "hltHgcalLayerClustersHSi:timeLayerCluster")
+    layerClusters = cms.VInputTag(*default_layerClusters),
+    time_layerclusters = cms.VInputTag(*default_time_layerclusters),
 )
 
+# Process modifier: alpaka
 from Configuration.ProcessModifiers.alpaka_cff import alpaka
 alpaka.toModify(hltMergeLayerClusters,
-                layerClustersEE = cms.InputTag("hltHgCalLayerClustersFromSoAProducer"),
-                time_layerclustersEE = cms.InputTag("hltHgCalLayerClustersFromSoAProducer", "timeLayerCluster"))
+    layerClusters = cms.VInputTag(
+        "hltHgCalLayerClustersFromSoAProducer",
+        "hltHgcalLayerClustersHSci",
+        "hltHgcalLayerClustersHSi"
+    ),
+    time_layerclusters = cms.VInputTag(
+        "hltHgCalLayerClustersFromSoAProducer:timeLayerCluster",
+        "hltHgcalLayerClustersHSci:timeLayerCluster",
+        "hltHgcalLayerClustersHSi:timeLayerCluster"
+    )
+)
 
+# Process modifier: ticl_barrel
 from Configuration.ProcessModifiers.ticl_barrel_cff import ticl_barrel
 
-layerClusters = ["hltHgcalLayerClustersEE", 
-                 "hltHgcalLayerClustersHSci", 
-                 "hltHgcalLayerClustersHSi", 
-                 "hltBarrelLayerClustersEB", 
-                 "hltBarrelLayerClustersHB"]
-
-time_layerclusters = ["hltHgcalLayerClustersEE:timeLayerCluster", 
-                      "hltHgcalLayerClustersHSci:timeLayerCluster", 
-                      "hltHgcalLayerClustersHSi:timeLayerCluster", 
-                      "hltBarrelLayerClustersEB:timeLayerCluster", 
-                      "hltBarrelLayerClustersHB:timeLayerCluster"]
-
-ticl_barrel.toModify(hltMergeLayerClusters, layerClusters = layerClusters, time_layerclusters = time_layerclusters)
+ticl_barrel.toModify(hltMergeLayerClusters,
+    layerClusters = cms.VInputTag(
+        *default_layerClusters,
+        "hltBarrelLayerClustersEB",
+        "hltBarrelLayerClustersHB"
+    ),
+    time_layerclusters = cms.VInputTag(
+        *default_time_layerclusters,
+        "hltBarrelLayerClustersEB:timeLayerCluster",
+        "hltBarrelLayerClustersHB:timeLayerCluster"
+    )
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTHgcalTiclPFClusteringForEgammaL1SeededSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTHgcalTiclPFClusteringForEgammaL1SeededSequence_cfi.py
@@ -20,9 +20,25 @@ from ..modules.hltTiclTrackstersCLUE3DHighL1Seeded_cfi import *
 from ..modules.hltTiclTracksterLinksL1Seeded_cfi import *
 from ..modules.hltBarrelLayerClustersEBL1Seeded_cfi import *
 
-_HgcalLocalRecoL1SeededSequence = cms.Sequence(hltHgcalDigis+hltL1TEGammaHGCFilteredCollectionProducer+hltHgcalDigisL1Seeded+hltHGCalUncalibRecHitL1Seeded+hltHGCalRecHitL1Seeded+hltParticleFlowRecHitHGCL1Seeded+hltRechitInRegionsHGCAL+hltHgcalLayerClustersEEL1Seeded+hltHgcalLayerClustersHSciL1Seeded+hltHgcalLayerClustersHSiL1Seeded+hltMergeLayerClustersL1Seeded)
-_HgcalTICLPatternRecognitionL1SeededSequence = cms.Sequence(hltFilteredLayerClustersCLUE3DHighL1Seeded+hltTiclSeedingL1+hltTiclLayerTileProducerL1Seeded+hltTiclTrackstersCLUE3DHighL1Seeded)
-_SuperclusteringL1SeededSequence = cms.Sequence(hltParticleFlowClusterHGCalFromTICLL1Seeded+hltParticleFlowSuperClusterHGCalFromTICLL1Seeded)
+_HgcalLocalRecoL1SeededSequence = cms.Sequence(hltHgcalDigis+
+                                               hltL1TEGammaHGCFilteredCollectionProducer+
+                                               hltHgcalDigisL1Seeded+
+                                               hltHGCalUncalibRecHitL1Seeded+
+                                               hltHGCalRecHitL1Seeded+
+                                               hltParticleFlowRecHitHGCL1Seeded+
+                                               hltRechitInRegionsHGCAL+
+                                               hltHgcalLayerClustersEEL1Seeded+
+                                               hltHgcalLayerClustersHSciL1Seeded+
+                                               hltHgcalLayerClustersHSiL1Seeded+
+                                               hltMergeLayerClustersL1Seeded)
+
+_HgcalTICLPatternRecognitionL1SeededSequence = cms.Sequence(hltFilteredLayerClustersCLUE3DHighL1Seeded+
+                                                            hltTiclSeedingL1+
+                                                            hltTiclLayerTileProducerL1Seeded+
+                                                            hltTiclTrackstersCLUE3DHighL1Seeded)
+
+_SuperclusteringL1SeededSequence = cms.Sequence(hltParticleFlowClusterHGCalFromTICLL1Seeded+
+                                                hltParticleFlowSuperClusterHGCalFromTICLL1Seeded)
 
 # The baseline sequence
 HLTHgcalTiclPFClusteringForEgammaL1SeededSequence = cms.Sequence(_HgcalLocalRecoL1SeededSequence + _HgcalTICLPatternRecognitionL1SeededSequence + _SuperclusteringL1SeededSequence)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTHgcalTiclPFClusteringForEgammaUnseededSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTHgcalTiclPFClusteringForEgammaUnseededSequence_cfi.py
@@ -22,9 +22,19 @@ from ..modules.hltTiclTracksterLinks_cfi import *
 # Barrel layer clusters
 from ..modules.hltBarrelLayerClustersEB_cfi import *
 from ..modules.hltBarrelLayerClustersHB_cfi import *
-_HgcalLocalRecoUnseededSequence = cms.Sequence(hltHgcalDigis+hltHGCalUncalibRecHit+hltHGCalRecHit+hltParticleFlowRecHitHGC+hltHgcalLayerClustersEE+hltHgcalLayerClustersHSci+hltHgcalLayerClustersHSi+hltMergeLayerClusters)
-_HgcalTICLPatternRecognitionUnseededSequence = cms.Sequence(hltFilteredLayerClustersCLUE3DHigh+hltTiclSeedingGlobal+hltTiclLayerTileProducer+hltTiclTrackstersCLUE3DHigh)
-_SuperclusteringUnseededSequence = cms.Sequence(hltParticleFlowClusterHGCalFromTICLUnseeded+hltParticleFlowSuperClusterHGCalFromTICLUnseeded)
+_HgcalLocalRecoUnseededSequence = cms.Sequence(hltHgcalDigis+hltHGCalUncalibRecHit+
+                                               hltHGCalRecHit+hltParticleFlowRecHitHGC+
+                                               hltHgcalLayerClustersEE+
+                                               hltHgcalLayerClustersHSci+
+                                               hltHgcalLayerClustersHSi+
+                                               hltMergeLayerClusters)
+
+_HgcalTICLPatternRecognitionUnseededSequence = cms.Sequence(hltFilteredLayerClustersCLUE3DHigh+
+                                                            hltTiclSeedingGlobal+hltTiclLayerTileProducer+
+                                                            hltTiclTrackstersCLUE3DHigh)
+
+_SuperclusteringUnseededSequence = cms.Sequence(hltParticleFlowClusterHGCalFromTICLUnseeded+
+                                                hltParticleFlowSuperClusterHGCalFromTICLUnseeded)
 
 # The baseline sequence
 HLTHgcalTiclPFClusteringForEgammaUnseededSequence = cms.Sequence(_HgcalLocalRecoUnseededSequence + _HgcalTICLPatternRecognitionUnseededSequence + _SuperclusteringUnseededSequence)
@@ -103,30 +113,3 @@ _HgcalLocalRecoUnseededSequence_barrel += hltBarrelLayerClustersHB
 from Configuration.ProcessModifiers.ticl_barrel_cff import ticl_barrel
 ticl_barrel.toReplaceWith(_HgcalLocalRecoUnseededSequence, _HgcalLocalRecoUnseededSequence_barrel)
 
-layerClusters = ["hltHgcalLayerClustersEE", 
-                 "hltHgcalLayerClustersHSci", 
-                 "hltHgcalLayerClustersHSi", 
-                 "hltBarrelLayerClustersEB", 
-                 "hltBarrelLayerClustersHB"]
-
-time_layerClusters = ["hltHgcalLayerClustersEE:timeLayerCluster", 
-                      "hltHgcalLayerClustersHSci:timeLayerCluster", 
-                      "hltHgcalLayerClustersHSi:timeLayerCluster", 
-                      "hltBarrelLayerClustersEB:timeLayerCluster", 
-                      "hltBarrelLayerClustersHB:timeLayerCluster"]
-
-ticl_barrel.toModify(hltMergeLayerClusters, layerClusters=layerClusters, time_layerclusters=time_layerClusters)
-
-layerClusters = ["hltHgCalLayerClustersFromSoAProducer", 
-                 "hltHgcalLayerClustersHSci", 
-                 "hltHgcalLayerClustersHSi", 
-                 "hltBarrelLayerClustersEB", 
-                 "hltBarrelLayerClustersHB"]
-
-time_layerClusters = ["hltHgCalLayerClustersFromSoAProducer:timeLayerCluster", 
-                      "hltHgcalLayerClustersHSci:timeLayerCluster", 
-                      "hltHgcalLayerClustersHSi:timeLayerCluster", 
-                      "hltBarrelLayerClustersEB:timeLayerCluster", 
-                      "hltBarrelLayerClustersHB:timeLayerCluster"]
-
-(ticl_barrel & alpaka).toModify(hltMergeLayerClusters, layerClusters=layerClusters, time_layerclusters=time_layerClusters)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTTICLLocalRecoSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTTICLLocalRecoSequence_cfi.py
@@ -35,8 +35,6 @@ _HLTTICLLocalRecoSequence_heterogeneous = cms.Sequence(
         hltHgCalLayerClustersFromSoAProducer+
         hltHgcalLayerClustersHSci+
         hltHgcalLayerClustersHSi+
-        hltBarrelLayerClustersEB+
-        hltBarrelLayerClustersHB+
         hltMergeLayerClusters)
 
 from Configuration.ProcessModifiers.alpaka_cff import alpaka
@@ -54,24 +52,8 @@ _HLTTICLLocalRecoSequence_withBarrel = cms.Sequence(
         hltMergeLayerClusters
 )
 
-layerClusters = ["hltHgCalLayerClustersEE", 
-                 "hltHgcalLayerClustersHSci", 
-                 "hltHgcalLayerClustersHSi", 
-                 "hltBarrelLayerClustersEB", 
-                 "hltBarrelLayerClustersHB"]
-
-time_layerclusters = ["hltHgCalLayerClustersEE:timeLayerCluster", 
-                      "hltHgcalLayerClustersHSci:timeLayerCluster", 
-                      "hltHgcalLayerClustersHSi:timeLayerCluster", 
-                      "hltBarrelLayerClustersEB:timeLayerCluster", 
-                      "hltBarrelLayerClustersHB:timeLayerCluster"]
-
-
 from Configuration.ProcessModifiers.ticl_barrel_cff import ticl_barrel
 ticl_barrel.toReplaceWith(HLTTICLLocalRecoSequence, _HLTTICLLocalRecoSequence_withBarrel)
-ticl_barrel.toModify(hltMergeLayerClusters,
-                     layerClusters = layerClusters,
-                     time_layerclusters = time_layerclusters)
 
 _HLTTICLLocalRecoSequence_heterogeneous_withBarrel = cms.Sequence(
         hltHGCalUncalibRecHit+
@@ -88,20 +70,4 @@ _HLTTICLLocalRecoSequence_heterogeneous_withBarrel = cms.Sequence(
         hltMergeLayerClusters
 )
 
-layerClusters = ["hltHgCalLayerClustersFromSoAProducer", 
-                 "hltHgcalLayerClustersHSci", 
-                 "hltHgcalLayerClustersHSi", 
-                 "hltBarrelLayerClustersEB", 
-                 "hltBarrelLayerClustersHB"]
-
-time_layerclusters = ["hltHgCalLayerClustersFromSoAProducer:timeLayerCluster", 
-                      "hltHgcalLayerClustersHSci:timeLayerCluster", 
-                      "hltHgcalLayerClustersHSi:timeLayerCluster", 
-                      "hltBarrelLayerClustersEB:timeLayerCluster", 
-                      "hltBarrelLayerClustersHB:timeLayerCluster"]
-
 (ticl_barrel & alpaka).toReplaceWith(HLTTICLLocalRecoSequence, _HLTTICLLocalRecoSequence_heterogeneous_withBarrel)
-(ticl_barrel & alpaka).toModify(hltMergeLayerClusters,
-                                layerClusters = layerClusters,
-                                time_layerclusters = time_layerclusters
-)


### PR DESCRIPTION
#### PR description:

This PR is a follow-up to https://github.com/cms-sw/cmssw/pull/47859.
Title says it all, addressed the first part of the issue explained at https://github.com/cms-sw/cmssw/pull/47859#issuecomment-3051290758.

#### PR validation:

Run successfully:

```
runTheMatrix.py -l ph2_hlt -j 8 -i all --ibeos
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, not meant to be backported