### PR TITLE
HCAL DQM: Update laser monitoring tasks for new laser in hcal calibration events

### DIFF
--- a/DQM/HcalCommon/interface/Constants.h
+++ b/DQM/HcalCommon/interface/Constants.h
@@ -160,6 +160,9 @@ namespace hcaldqm {
  *	Detector Constants
  */
 
+    // HBLAS pin diode channel id
+    const HcalCalibDetId HBLasMon(HcalBarrel, 0, 31, 0);
+
     //	Hcal Subdetector
     int const HB = 1;
     int const HE = 2;

--- a/DQM/HcalCommon/interface/ValueQuantity.h
+++ b/DQM/HcalCommon/interface/ValueQuantity.h
@@ -72,6 +72,7 @@ namespace hcaldqm {
       fDiffRatio,  // (v2-v1)/v1
       fCPUenergy,
       fGPUenergy,
+      fNbins,
     };
     const std::map<ValueQuantityType, std::string> name_value = {
         {fN, "N"},
@@ -138,6 +139,7 @@ namespace hcaldqm {
         {fDiffRatio, "(GPU energy - CPU energy)/CPU energy"},
         {fCPUenergy, "CPU energy"},
         {fGPUenergy, "GPU energy"},
+        {fNbins, "Nbins"},
     };
     const std::map<ValueQuantityType, double> min_value = {
         {fN, -0.05},
@@ -204,6 +206,7 @@ namespace hcaldqm {
         {fDiffRatio, -2.5},
         {fCPUenergy, 0},
         {fGPUenergy, 0},
+        {fNbins, 0},
     };
     const std::map<ValueQuantityType, double> max_value = {
         {fN, 1000},
@@ -270,6 +273,7 @@ namespace hcaldqm {
         {fDiffRatio, 2.5},
         {fCPUenergy, 200},
         {fGPUenergy, 200},
+        {fNbins, 50},
     };
     const std::map<ValueQuantityType, int> nbins_value = {
         {fN, 200},
@@ -335,6 +339,7 @@ namespace hcaldqm {
         {fDiffRatio, 50},
         {fCPUenergy, 1000},
         {fGPUenergy, 1000},
+        {fNbins, 50},
     };
     class ValueQuantity : public Quantity {
     public:

--- a/DQM/HcalTasks/interface/HFRaddamTask.h
+++ b/DQM/HcalTasks/interface/HFRaddamTask.h
@@ -33,6 +33,11 @@ protected:
   edm::EDGetTokenT<QIE10DigiCollection> _tokHF;
   edm::EDGetTokenT<HcalUMNioDigi> _tokuMN;
 
+  edm::InputTag _tagFEDs;
+  edm::EDGetTokenT<FEDRawDataCollection> _tokFEDs;
+
+  uint32_t _laserType;
+
   //	vector of Detector Ids for RadDam
   std::vector<HcalDetId> _vDetIds;
 

--- a/DQM/HcalTasks/interface/LaserTask.h
+++ b/DQM/HcalTasks/interface/LaserTask.h
@@ -43,7 +43,7 @@ protected:
   void _resetMonitors(hcaldqm::UpdateFreq) override;
   bool _isApplicable(edm::Event const &) override;
   virtual void _dump();
-  void processLaserMon(edm::Handle<QIE10DigiCollection> &col, std::vector<int> &iLaserMonADC);
+  void processLaserMon(edm::Handle<QIE11DigiCollection> &col, std::vector<int> &iLaserMonADC);
 
   //	tags and tokens
   edm::InputTag _tagQIE11;
@@ -55,6 +55,8 @@ protected:
   edm::EDGetTokenT<QIE10DigiCollection> _tokQIE10;
   edm::EDGetTokenT<HcalUMNioDigi> _tokuMN;
   edm::ESGetToken<HcalDbService, HcalDbRecord> hcalDbServiceToken_;
+  edm::InputTag _tagFEDs;
+  edm::EDGetTokenT<FEDRawDataCollection> _tokFEDs;
 
   enum LaserFlag { fBadTiming = 0, fMissingLaserMon = 1, nLaserFlag = 2 };
   std::vector<hcaldqm::flag::Flag> _vflags;
@@ -106,6 +108,8 @@ protected:
   hcaldqm::ContainerProf1D _cSignalvsBXQIE1011_SubdetPM;
 
   //	2D timing/signals
+  hcaldqm::Container2D _cADCvsTS_SubdetPM;
+
   hcaldqm::ContainerProf2D _cSignalMean_depth;
   hcaldqm::ContainerProf2D _cSignalRMS_depth;
   hcaldqm::ContainerProf2D _cSignalMeanQIE1011_depth;

--- a/DQM/HcalTasks/interface/LaserTask.h
+++ b/DQM/HcalTasks/interface/LaserTask.h
@@ -43,7 +43,7 @@ protected:
   void _resetMonitors(hcaldqm::UpdateFreq) override;
   bool _isApplicable(edm::Event const &) override;
   virtual void _dump();
-  void processLaserMon(edm::Handle<QIE11DigiCollection> &col, std::vector<int> &iLaserMonADC);
+  void processLaserMon(edm::Handle<QIE11DigiCollection> &col, QIE11DataFrame &iLaserMonDigi);
 
   //	tags and tokens
   edm::InputTag _tagQIE11;

--- a/DQM/HcalTasks/interface/UMNioTask.h
+++ b/DQM/HcalTasks/interface/UMNioTask.h
@@ -56,6 +56,8 @@ protected:
   edm::EDGetTokenT<HcalUMNioDigi> tokuMN_;
   edm::ESGetToken<HcalDbService, HcalDbRecord> hcalDbServiceToken_;
 
+  edm::InputTag _tagFEDs;
+  edm::EDGetTokenT<FEDRawDataCollection> _tokFEDs;
   //	cuts
   double lowHBHE_, lowHO_, lowHF_;
 
@@ -68,5 +70,9 @@ protected:
   hcaldqm::ContainerSingle2D _cEventType;
   hcaldqm::ContainerSingle2D _cTotalCharge;
   hcaldqm::ContainerSingleProf2D _cTotalChargeProfile;
+
+  // 1D histograms for uHTR eventType and uMNio eventType
+  hcaldqm::ContainerSingle1D _cEventType_uMNio;
+  hcaldqm::ContainerSingle1D _cEventType_uHTR;
 };
 #endif

--- a/DQM/HcalTasks/plugins/LaserTask.cc
+++ b/DQM/HcalTasks/plugins/LaserTask.cc
@@ -18,6 +18,8 @@ LaserTask::LaserTask(edm::ParameterSet const& ps)
   _tokQIE10 = consumes<QIE10DigiCollection>(_tagQIE10);
   _tokuMN = consumes<HcalUMNioDigi>(_taguMN);
   _tokLaserMon = consumes<QIE10DigiCollection>(_tagLaserMon);
+  _tagFEDs = ps.getUntrackedParameter<edm::InputTag>("tagFEDs", edm::InputTag("hltHcalCalibrationRaw"));
+  _tokFEDs = consumes<FEDRawDataCollection>(_tagFEDs);
 
   _vflags.resize(nLaserFlag);
   _vflags[fBadTiming] = hcaldqm::flag::Flag("BadTiming");
@@ -223,6 +225,16 @@ LaserTask::LaserTask(edm::ParameterSet const& ps)
                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
                              0);
 
+  if (_ptype == fOnline || _ptype == fLocal) {
+    _cADCvsTS_SubdetPM.initialize(_name,
+                                  "ADCvsTS",
+                                  hcaldqm::hashfunctions::fSubdetPM,
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
+                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
+                                  0);
+  }
+
   //	initialize compact containers
   _xSignalSum.initialize(hcaldqm::hashfunctions::fDChannel);
   _xSignalSum2.initialize(hcaldqm::hashfunctions::fDChannel);
@@ -364,6 +376,7 @@ LaserTask::LaserTask(edm::ParameterSet const& ps)
   _xTimingSum2.book(_emap);
 
   if (_ptype == fOnline || _ptype == fLocal) {
+    _cADCvsTS_SubdetPM.book(ib, _emap, _subsystem);
     _cLaserMonSumQ.book(ib, _subsystem);
     _cLaserMonTiming.book(ib, _subsystem);
     if (_ptype == fOnline) {
@@ -532,7 +545,7 @@ LaserTask::LaserTask(edm::ParameterSet const& ps)
     _logger.dqmthrow("QIE10DigiCollection for laserMonDigis isn't available.");
   }
   std::vector<int> laserMonADC;
-  processLaserMon(cLaserMon, laserMonADC);
+  processLaserMon(c_QIE11, laserMonADC);
 
   // SumQ = peak +/- 3 TSes
   // Timing = fC-weighted average (TS-TS0) * 25 ns, also in peak +/- 3 TSes
@@ -625,6 +638,12 @@ LaserTask::LaserTask(edm::ParameterSet const& ps)
       _cSignalvsBX_SubdetPM.fill(did, bx, sumQ);
       _cTimingDiffLS_SubdetPM.fill(did, _currentLS, hcaldqm::utilities::getRBX(did.iphi()), deltaTiming);
     }
+
+    if (_ptype == fOnline || _ptype == fLocal) {
+      for (int iTS = 0; iTS < digi.samples(); ++iTS) {
+        _cADCvsTS_SubdetPM.fill(did, iTS, digi[iTS].adc());
+      }
+    }
   }
   for (HODigiCollection::const_iterator it = c_ho->begin(); it != c_ho->end(); ++it) {
     const HODataFrame digi = (const HODataFrame)(*it);
@@ -665,6 +684,12 @@ LaserTask::LaserTask(edm::ParameterSet const& ps)
       _cTimingvsBX_SubdetPM.fill(did, bx, aveTS);
       _cSignalvsBX_SubdetPM.fill(did, bx, sumQ);
       _cTimingDiffLS_SubdetPM.fill(did, _currentLS, hcaldqm::utilities::getRBX(did.iphi()), deltaTiming);
+    }
+
+    if (_ptype == fOnline || _ptype == fLocal) {
+      for (int iTS = 0; iTS < digi.size(); ++iTS) {
+        _cADCvsTS_SubdetPM.fill(did, iTS, digi.sample(iTS).adc());
+      }
     }
   }
   for (QIE10DigiCollection::const_iterator it = c_QIE10->begin(); it != c_QIE10->end(); ++it) {
@@ -716,35 +741,33 @@ LaserTask::LaserTask(edm::ParameterSet const& ps)
       _cSignalvsBX_SubdetPM.fill(did, bx, sumQ);
       _cTimingDiffLS_SubdetPM.fill(did, _currentLS, hcaldqm::utilities::getRBX(did.iphi()), deltaTiming);
     }
+    if (_ptype == fOnline || _ptype == fLocal) {
+      for (int iTS = 0; iTS < digi.samples(); ++iTS) {
+        _cADCvsTS_SubdetPM.fill(did, iTS, digi[iTS].adc());
+      }
+    }
   }
 }
 
-void LaserTask::processLaserMon(edm::Handle<QIE10DigiCollection>& col, std::vector<int>& iLaserMonADC) {
-  for (QIE10DigiCollection::const_iterator it = col->begin(); it != col->end(); ++it) {
-    const QIE10DataFrame digi = (const QIE10DataFrame)(*it);
+void LaserTask::processLaserMon(edm::Handle<QIE11DigiCollection>& col, std::vector<int>& iLaserMonADC) {
+  for (QIE11DigiCollection::const_iterator it = col->begin(); it != col->end(); ++it) {
+    const QIE11DataFrame digi = static_cast<const QIE11DataFrame>(*it);
     HcalCalibDetId hcdid(digi.id());
 
-    if ((hcdid.ieta() != _laserMonIEta) || (hcdid.cboxChannel() != _laserMonCBox)) {
+    if (!(hcdid.hcalSubdet() == constants::HBLasMon.hcalSubdet() && hcdid.ieta() == constants::HBLasMon.ieta() &&
+          hcdid.iphi() == constants::HBLasMon.iphi() && hcdid.cboxChannel() == constants::HBLasMon.cboxChannel()))
       continue;
-    }
 
-    unsigned int digiIndex =
-        std::find(_vLaserMonIPhi.begin(), _vLaserMonIPhi.end(), hcdid.iphi()) - _vLaserMonIPhi.begin();
-    if (digiIndex == _vLaserMonIPhi.size()) {
-      continue;
-    }
-
-    // First digi: initialize the vectors to -1 (need to know the length of the digi)
+    // First initialize the vectors to -1 (need to know the length of the digi)
     if (iLaserMonADC.empty()) {
-      int totalNSamples = (digi.samples() - _laserMonDigiOverlap) * _vLaserMonIPhi.size();
+      int totalNSamples = digi.samples();
       for (int i = 0; i < totalNSamples; ++i) {
         iLaserMonADC.push_back(-1);
       }
     }
 
-    for (int subindex = 0; subindex < digi.samples() - _laserMonDigiOverlap; ++subindex) {
-      int totalIndex = (digi.samples() - _laserMonDigiOverlap) * digiIndex + subindex;
-      iLaserMonADC[totalIndex] = (digi[subindex].ok() ? digi[subindex].adc() : -1);
+    for (int subindex = 0; subindex < digi.samples(); ++subindex) {
+      iLaserMonADC[subindex] = digi[subindex].adc();
     }
   }
 }
@@ -769,15 +792,42 @@ void LaserTask::processLaserMon(edm::Handle<QIE10DigiCollection>& col, std::vect
     if (!e.getByToken(_tokuMN, cumn))
       return false;
 
-    //	event type check first
-    uint8_t eventType = cumn->eventType();
-    if (eventType != constants::EVENTTYPE_LASER)
+    // Below we are requiring both laser type equals 24 and uHTR event type from crate:slot 25:11 equals 14 to confirm this is a megatile laser signal
+    //  laser type check
+    uint32_t laserType = cumn->valueUserWord(0);
+    if (laserType != _laserType)
       return false;
 
-    //	check if this analysis task is of the right laser type
-    uint32_t laserType = cumn->valueUserWord(0);
-    if (laserType == _laserType)
+    // uHTR event type check from crate:slot 25:11 for megatile
+    int eventflag_uHTR = -1;
+    edm::Handle<FEDRawDataCollection> craw;
+    if (!e.getByToken(_tokFEDs, craw))
+      _logger.dqmthrow("Collection FEDRawDataCollection isn't available " + _tagFEDs.label() + " " +
+                       _tagFEDs.instance());
+
+    for (int fed = FEDNumbering::MINHCALFEDID; fed <= FEDNumbering::MAXHCALuTCAFEDID && !(eventflag_uHTR >= 0); fed++) {
+      if ((fed > FEDNumbering::MAXHCALFEDID && fed < FEDNumbering::MINHCALuTCAFEDID) ||
+          fed > FEDNumbering::MAXHCALuTCAFEDID)
+        continue;
+      FEDRawData const& raw = craw->FEDData(fed);
+      if (raw.size() < constants::RAW_EMPTY)
+        continue;
+
+      hcal::AMC13Header const* hamc13 = (hcal::AMC13Header const*)raw.data();
+      if (!hamc13)
+        continue;
+
+      for (int iamc = 0; iamc < hamc13->NAMC(); iamc++) {
+        HcalUHTRData uhtr(hamc13->AMCPayload(iamc), hamc13->AMCSize(iamc));
+        if (static_cast<int>(uhtr.crateId()) == 25 && static_cast<int>(uhtr.slot()) == 11) {
+          eventflag_uHTR = uhtr.getEventType();
+          break;
+        }
+      }
+    }
+    if (eventflag_uHTR == constants::EVENTTYPE_LASER) {
       return true;
+    }
   }
 
   return false;

--- a/DQM/HcalTasks/python/HFRaddamTask_cfi.py
+++ b/DQM/HcalTasks/python/HFRaddamTask_cfi.py
@@ -13,9 +13,12 @@ hfRaddamTask = DQMEDAnalyzer(
 	mtype = cms.untracked.bool(True),
 	subsystem = cms.untracked.string('HcalCalib'),
 
+    laserType = cms.untracked.uint32(0),
+
 	#	tags
 	tagHF = cms.untracked.InputTag("hcalDigis"),
-	tagRaw = cms.untracked.InputTag('hltHcalCalibrationRaw')
+	tagRaw = cms.untracked.InputTag('hltHcalCalibrationRaw'),
+    tagFEDs = cms.untracked.InputTag("hltHcalCalibrationRaw")
 )
 
 

--- a/DQM/HcalTasks/python/LaserTask_cfi.py
+++ b/DQM/HcalTasks/python/LaserTask_cfi.py
@@ -20,6 +20,7 @@ laserTask = DQMEDAnalyzer(
 	taguMN      = cms.untracked.InputTag("hcalDigis"),
 	tagRaw      = cms.untracked.InputTag('hltHcalCalibrationRaw'),
 	tagLaserMon = cms.untracked.InputTag("hcalDigis:LASERMON"),
+	tagFEDs = cms.untracked.InputTag("hltHcalCalibrationRaw"),
 
 	laserType = cms.untracked.uint32(0),
 

--- a/DQM/HcalTasks/python/UMNioTask_cfi.py
+++ b/DQM/HcalTasks/python/UMNioTask_cfi.py
@@ -5,7 +5,7 @@ umnioTask = DQMEDAnalyzer(
 	"UMNioTask",
 	
 	#	standard parameters
-	name = cms.untracked.string("UMNioTask"),
+	name = cms.untracked.string("EventTypeTask"),
 	debug = cms.untracked.int32(0),
 	runkeyVal = cms.untracked.int32(0),
 	runkeyName = cms.untracked.string("pp_run"),
@@ -15,7 +15,8 @@ umnioTask = DQMEDAnalyzer(
 
 	#	tags
     taguMN = cms.untracked.InputTag("hcalDigis"),
-	tagRaw = cms.untracked.InputTag('hltHcalCalibrationRaw')
+	tagRaw = cms.untracked.InputTag('hltHcalCalibrationRaw'),
+    tagFEDs = cms.untracked.InputTag("hltHcalCalibrationRaw")
 )
 
 

--- a/DQM/Integration/python/clients/hcalcalib_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcalcalib_dqm_sourceclient-live_cfg.py
@@ -199,6 +199,14 @@ process.qie11Task_pedestal = process.qie11Task.clone(
 
 process.ledTask.name = cms.untracked.string("LEDTask")
 
+process.hfRaddamTask.laserType = cms.untracked.uint32(24)
+
+process.megatileTask = process.laserTask.clone(
+    name = "MegatileTask",
+    laserType = 24
+)
+
+
 #-------------------------------------
 #	Hcal DQM Tasks Sequence Definition
 #-------------------------------------
@@ -206,17 +214,18 @@ process.tasksSequence = cms.Sequence(
 		process.pedestalTask
 		*process.hfRaddamTask
 		*process.rawTask
-		*process.hbhehpdTask
-		*process.hoTask
-		*process.hfTask
-		*process.hepmegaTask
-		*process.hemmegaTask
-		*process.hbpmegaTask
-		*process.hbmmegaTask
+		#*process.hbhehpdTask
+		#*process.hoTask
+		#*process.hfTask
+		#*process.hepmegaTask
+		#*process.hemmegaTask
+		#*process.hbpmegaTask
+		#*process.hbmmegaTask
 		*process.umnioTask
-		*process.qie11Task_laser
+		#*process.qie11Task_laser
 		*process.qie11Task_pedestal
 		*process.ledTask
+        *process.megatileTask
 )
 
 process.harvestingSequence = cms.Sequence(

--- a/DQM/Integration/python/clients/hcalcalib_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcalcalib_dqm_sourceclient-live_cfg.py
@@ -21,6 +21,7 @@ errorstr     = "### HcalDQM::cfg::ERROR:"
 useOfflineGT = False
 useFileInput = False
 useMap       = False
+usetxtMap    = False
 
 #-------------------------------------
 #	Central DQM Stuff imports
@@ -125,6 +126,17 @@ if useMap:
                  #tag = cms.string("HcalElectronicsMap_v7.05_hlt"),
                  tag = cms.string("HcalElectronicsMap_v9.0_hlt"),
         ))
+if usetxtMap:
+    process.es_ascii = cms.ESSource(
+                'HcalTextCalibrations',
+                input = cms.VPSet(
+                        cms.PSet(
+                                object = cms.string('ElectronicsMap'),
+                                file = cms.FileInPath("ElectronicsMap_Run394200_new.txt")
+                        )
+                )
+        )
+    process.es_prefer = cms.ESPrefer('HcalTextCalibrations', 'es_ascii')
 
 #-------------------------------------
 #	Some Settings before Finishing up


### PR DESCRIPTION
#### PR description:

This PR updates the laser task monitoring in HCAL calibration workspace, and removed several unused tasks from running. 

#### PR validation:

HCAL private test running DQM on run 393745 shows desired monitoring elements updated. See: https://cmsweb.cern.ch/dqm/hcal-online/session/vhcmgbji
