### PR TITLE
HCAL DQM: Update laser monitoring tasks for new laser -- backport of #48510

### DIFF
--- a/DQM/HcalCommon/interface/Constants.h
+++ b/DQM/HcalCommon/interface/Constants.h
@@ -160,6 +160,9 @@ namespace hcaldqm {
  *	Detector Constants
  */
 
+    // HBLAS pin diode channel id
+    const HcalCalibDetId HBLasMon(HcalBarrel, 0, 31, 0);
+
     //	Hcal Subdetector
     int const HB = 1;
     int const HE = 2;

--- a/DQM/HcalCommon/interface/ValueQuantity.h
+++ b/DQM/HcalCommon/interface/ValueQuantity.h
@@ -72,6 +72,7 @@ namespace hcaldqm {
       fDiffRatio,  // (v2-v1)/v1
       fCPUenergy,
       fGPUenergy,
+      fNbins,
     };
     const std::map<ValueQuantityType, std::string> name_value = {
         {fN, "N"},
@@ -138,6 +139,7 @@ namespace hcaldqm {
         {fDiffRatio, "(GPU energy - CPU energy)/CPU energy"},
         {fCPUenergy, "CPU energy"},
         {fGPUenergy, "GPU energy"},
+        {fNbins, "Nbins"},
     };
     const std::map<ValueQuantityType, double> min_value = {
         {fN, -0.05},
@@ -204,6 +206,7 @@ namespace hcaldqm {
         {fDiffRatio, -2.5},
         {fCPUenergy, 0},
         {fGPUenergy, 0},
+        {fNbins, 0},
     };
     const std::map<ValueQuantityType, double> max_value = {
         {fN, 1000},
@@ -270,6 +273,7 @@ namespace hcaldqm {
         {fDiffRatio, 2.5},
         {fCPUenergy, 200},
         {fGPUenergy, 200},
+        {fNbins, 50},
     };
     const std::map<ValueQuantityType, int> nbins_value = {
         {fN, 200},
@@ -335,6 +339,7 @@ namespace hcaldqm {
         {fDiffRatio, 50},
         {fCPUenergy, 1000},
         {fGPUenergy, 1000},
+        {fNbins, 50},
     };
     class ValueQuantity : public Quantity {
     public:

--- a/DQM/HcalTasks/interface/HFRaddamTask.h
+++ b/DQM/HcalTasks/interface/HFRaddamTask.h
@@ -33,6 +33,11 @@ protected:
   edm::EDGetTokenT<QIE10DigiCollection> _tokHF;
   edm::EDGetTokenT<HcalUMNioDigi> _tokuMN;
 
+  edm::InputTag _tagFEDs;
+  edm::EDGetTokenT<FEDRawDataCollection> _tokFEDs;
+
+  uint32_t _laserType;
+
   //	vector of Detector Ids for RadDam
   std::vector<HcalDetId> _vDetIds;
 

--- a/DQM/HcalTasks/interface/LaserTask.h
+++ b/DQM/HcalTasks/interface/LaserTask.h
@@ -43,7 +43,7 @@ protected:
   void _resetMonitors(hcaldqm::UpdateFreq) override;
   bool _isApplicable(edm::Event const &) override;
   virtual void _dump();
-  void processLaserMon(edm::Handle<QIE10DigiCollection> &col, std::vector<int> &iLaserMonADC);
+  void processLaserMon(edm::Handle<QIE11DigiCollection> &col, QIE11DataFrame &iLaserMonDigi);
 
   //	tags and tokens
   edm::InputTag _tagQIE11;
@@ -55,6 +55,8 @@ protected:
   edm::EDGetTokenT<QIE10DigiCollection> _tokQIE10;
   edm::EDGetTokenT<HcalUMNioDigi> _tokuMN;
   edm::ESGetToken<HcalDbService, HcalDbRecord> hcalDbServiceToken_;
+  edm::InputTag _tagFEDs;
+  edm::EDGetTokenT<FEDRawDataCollection> _tokFEDs;
 
   enum LaserFlag { fBadTiming = 0, fMissingLaserMon = 1, nLaserFlag = 2 };
   std::vector<hcaldqm::flag::Flag> _vflags;
@@ -106,6 +108,8 @@ protected:
   hcaldqm::ContainerProf1D _cSignalvsBXQIE1011_SubdetPM;
 
   //	2D timing/signals
+  hcaldqm::Container2D _cADCvsTS_SubdetPM;
+
   hcaldqm::ContainerProf2D _cSignalMean_depth;
   hcaldqm::ContainerProf2D _cSignalRMS_depth;
   hcaldqm::ContainerProf2D _cSignalMeanQIE1011_depth;

--- a/DQM/HcalTasks/interface/UMNioTask.h
+++ b/DQM/HcalTasks/interface/UMNioTask.h
@@ -56,6 +56,8 @@ protected:
   edm::EDGetTokenT<HcalUMNioDigi> tokuMN_;
   edm::ESGetToken<HcalDbService, HcalDbRecord> hcalDbServiceToken_;
 
+  edm::InputTag _tagFEDs;
+  edm::EDGetTokenT<FEDRawDataCollection> _tokFEDs;
   //	cuts
   double lowHBHE_, lowHO_, lowHF_;
 
@@ -68,5 +70,9 @@ protected:
   hcaldqm::ContainerSingle2D _cEventType;
   hcaldqm::ContainerSingle2D _cTotalCharge;
   hcaldqm::ContainerSingleProf2D _cTotalChargeProfile;
+
+  // 1D histograms for uHTR eventType and uMNio eventType
+  hcaldqm::ContainerSingle1D _cEventType_uMNio;
+  hcaldqm::ContainerSingle1D _cEventType_uHTR;
 };
 #endif

--- a/DQM/HcalTasks/python/HFRaddamTask_cfi.py
+++ b/DQM/HcalTasks/python/HFRaddamTask_cfi.py
@@ -13,9 +13,12 @@ hfRaddamTask = DQMEDAnalyzer(
 	mtype = cms.untracked.bool(True),
 	subsystem = cms.untracked.string('HcalCalib'),
 
+    laserType = cms.untracked.uint32(0),
+
 	#	tags
 	tagHF = cms.untracked.InputTag("hcalDigis"),
-	tagRaw = cms.untracked.InputTag('hltHcalCalibrationRaw')
+	tagRaw = cms.untracked.InputTag('hltHcalCalibrationRaw'),
+    tagFEDs = cms.untracked.InputTag("hltHcalCalibrationRaw")
 )
 
 

--- a/DQM/HcalTasks/python/LaserTask_cfi.py
+++ b/DQM/HcalTasks/python/LaserTask_cfi.py
@@ -20,6 +20,7 @@ laserTask = DQMEDAnalyzer(
 	taguMN      = cms.untracked.InputTag("hcalDigis"),
 	tagRaw      = cms.untracked.InputTag('hltHcalCalibrationRaw'),
 	tagLaserMon = cms.untracked.InputTag("hcalDigis:LASERMON"),
+	tagFEDs = cms.untracked.InputTag("hltHcalCalibrationRaw"),
 
 	laserType = cms.untracked.uint32(0),
 

--- a/DQM/HcalTasks/python/UMNioTask_cfi.py
+++ b/DQM/HcalTasks/python/UMNioTask_cfi.py
@@ -5,7 +5,7 @@ umnioTask = DQMEDAnalyzer(
 	"UMNioTask",
 	
 	#	standard parameters
-	name = cms.untracked.string("UMNioTask"),
+	name = cms.untracked.string("EventTypeTask"),
 	debug = cms.untracked.int32(0),
 	runkeyVal = cms.untracked.int32(0),
 	runkeyName = cms.untracked.string("pp_run"),
@@ -15,7 +15,8 @@ umnioTask = DQMEDAnalyzer(
 
 	#	tags
     taguMN = cms.untracked.InputTag("hcalDigis"),
-	tagRaw = cms.untracked.InputTag('hltHcalCalibrationRaw')
+	tagRaw = cms.untracked.InputTag('hltHcalCalibrationRaw'),
+    tagFEDs = cms.untracked.InputTag("hltHcalCalibrationRaw")
 )
 
 

--- a/DQM/Integration/python/clients/hcalcalib_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcalcalib_dqm_sourceclient-live_cfg.py
@@ -21,6 +21,7 @@ errorstr     = "### HcalDQM::cfg::ERROR:"
 useOfflineGT = False
 useFileInput = False
 useMap       = False
+usetxtMap    = False
 
 #-------------------------------------
 #	Central DQM Stuff imports
@@ -125,6 +126,17 @@ if useMap:
                  #tag = cms.string("HcalElectronicsMap_v7.05_hlt"),
                  tag = cms.string("HcalElectronicsMap_v9.0_hlt"),
         ))
+if usetxtMap:
+    process.es_ascii = cms.ESSource(
+                'HcalTextCalibrations',
+                input = cms.VPSet(
+                        cms.PSet(
+                                object = cms.string('ElectronicsMap'),
+                                file = cms.FileInPath("ElectronicsMap_Run394200_new.txt")
+                        )
+                )
+        )
+    process.es_prefer = cms.ESPrefer('HcalTextCalibrations', 'es_ascii')
 
 #-------------------------------------
 #	Some Settings before Finishing up
@@ -199,6 +211,14 @@ process.qie11Task_pedestal = process.qie11Task.clone(
 
 process.ledTask.name = cms.untracked.string("LEDTask")
 
+process.hfRaddamTask.laserType = cms.untracked.uint32(24)
+
+process.megatileTask = process.laserTask.clone(
+    name = "MegatileTask",
+    laserType = 24
+)
+
+
 #-------------------------------------
 #	Hcal DQM Tasks Sequence Definition
 #-------------------------------------
@@ -206,17 +226,18 @@ process.tasksSequence = cms.Sequence(
 		process.pedestalTask
 		*process.hfRaddamTask
 		*process.rawTask
-		*process.hbhehpdTask
-		*process.hoTask
-		*process.hfTask
-		*process.hepmegaTask
-		*process.hemmegaTask
-		*process.hbpmegaTask
-		*process.hbmmegaTask
+		#*process.hbhehpdTask
+		#*process.hoTask
+		#*process.hfTask
+		#*process.hepmegaTask
+		#*process.hemmegaTask
+		#*process.hbpmegaTask
+		#*process.hbmmegaTask
 		*process.umnioTask
-		*process.qie11Task_laser
+		#*process.qie11Task_laser
 		*process.qie11Task_pedestal
 		*process.ledTask
+        *process.megatileTask
 )
 
 process.harvestingSequence = cms.Sequence(


### PR DESCRIPTION
Backport of PR#48510, meant for DQM at P5

#### PR description:
This PR updates the laser task monitoring in HCAL calibration workspace, and removed several unused tasks from running.

#### PR validation:
HCAL private test running DQM on run 393745 shows desired monitoring elements updated. 


