### PR TITLE
[TkAl] Add "extract" jobs for the PixelBarycentre validation in the All-in-One framework

### DIFF
--- a/Alignment/OfflineValidation/README.md
+++ b/Alignment/OfflineValidation/README.md
@@ -118,7 +118,7 @@ For details read [`README_JetHT.md`](https://github.com/cms-sw/cmssw/blob/master
 For details read [`README_MTS.md`](https://github.com/cms-sw/cmssw/blob/master/Alignment/OfflineValidation/README_MTS.md)
 
 ## Pixel BaryCenter
-For details read [`README_MTS.md`](https://github.com/cms-sw/cmssw/blob/master/Alignment/OfflineValidation/README_PixBary.md)
+For details read [`README_PixBary.md`](https://github.com/cms-sw/cmssw/blob/master/Alignment/OfflineValidation/README_PixBary.md)
 
 ## Generic validation (dataset validation)
 For details read [`README_Generic.md`](https://github.com/cms-sw/cmssw/blob/master/Alignment/OfflineValidation/README_Generic.md)

--- a/Alignment/OfflineValidation/README_PixBary.md
+++ b/Alignment/OfflineValidation/README_PixBary.md
@@ -7,11 +7,17 @@ The following parameters are expected/accepted in the json/yaml configuration fi
 ```
 validations:
     PixBary:
-        single:
+        <step_type>:
             <job_name>:
                 <options>
 ```
 
+The following steps are supported:
+- single (run the analyzer to compute the barycentre)
+- extract (retrieve the barycentre from the `single` output)
+
+### Single PixBary jobs
+Runs PixelBaryCentreAnalyzer_cfg.py.
 The following options are understood:
 
 Variable | Default value | Explanation/Options
@@ -20,3 +26,11 @@ firstRun | 290550 | The first run to process (inclusive)
 lastRun | 325175 | The last run to process (inclusive)
 lumisPerRun | 1 | The number of LumiSections tested for a change in the TrackerAlignmentRcd in each run
 alignments | None | List of alignments for which this validation is run
+
+### Extract PixBary jobs
+Runs extractBarycentre.py.
+The following options are understood:
+
+Variable | Default value | Explanation/Options
+-------- | ------------- | --------------------
+styles   | [csv, twiki]  | List of styles to be used; see `extractBarycentre.py -h`

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/PixBary.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/PixBary.py
@@ -28,7 +28,9 @@ def PixBary(config, validationDir, verbose=False):
         for runRange in IOV_list:
             IOV = '-'.join(str(i) for i in runRange)
 
-            for alignment, alignmentConfig in config["alignments"].items():
+            for alignment in jobConfig["alignments"]:
+                alignmentConfig = config["alignments"][alignment]
+
                 ##Work directory for each IOV
                 workDir = os.path.join(validationDir, _validationName, jobType, jobName, alignment, IOV)
 

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/PixelBaryCentreAnalyzer_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/PixelBaryCentreAnalyzer_cfg.py
@@ -126,7 +126,7 @@ bsLabels_ = cms.untracked.vstring("")
 alignments = configuration.get('alignments', None) # NOTE: aligments is plural
 if alignments is None:
     align = configuration['alignment'] # NOTE: alignment is singular
-    label = configuration['alignment'].get('label', align['title'].split()[0])
+    label = configuration['alignment'].get('label', 'alignment')
     alignments = {label: align}
 
 for label, align in alignments.items():

--- a/Alignment/OfflineValidation/scripts/extractBaryCentre.py
+++ b/Alignment/OfflineValidation/scripts/extractBaryCentre.py
@@ -2,6 +2,9 @@
 
 from argparse import ArgumentParser
 import logging
+import json
+import sys
+import os
 import ROOT
 
 class TFileContext(object):
@@ -12,7 +15,7 @@ class TFileContext(object):
     def __exit__(self, type, value, traceback):
         self.tfile.Close()
 
-def display_results(t_data, style='twiki'):
+def display_results(t_data, style='twiki', out=sys.stdout):
     before = after = None
     if  (style == 'twiki'):
         header_fmt = ' | '.join( ['{:^6s}'] + ['{:^9s}' ] * (len(t_data.keys())-1) )
@@ -30,30 +33,17 @@ def display_results(t_data, style='twiki'):
     else:
         raise RuntimeError('Unknown style "%s" for table'%(style))
 
-    if(before is not None): print(before)
-    print( header_fmt.format(*t_data.keys()) )
+    if(before is not None): out.write(before+'\n')
+    out.write( header_fmt.format(*t_data.keys())+'\n' )
     for i, run in enumerate(t_data['run']):
-        print(row_fmt.format(run, *[t_data[k][i] for k in t_data.keys() if not k == 'run']))
-    if(after is not None): print(after)
+        out.write(row_fmt.format(run, *[t_data[k][i] for k in t_data.keys() if not k == 'run'])+'\n')
+    if(after is not None): out.write(after+'\n')
+
+    return out
 
 
-def main():
-    parser = ArgumentParser()
-    parser.add_argument('fname'            , metavar='FILE')
-    parser.add_argument('-p', '--partition', default='BPIX', help='Tracker partition (e.g. BPIX, FPIX, BPIXLYR1, etc.). Default: %(default)s')
-    parser.add_argument('-l', '--list-content' , action='store_true', dest='list_content', help='List the contents of file and exit')
-    parser.add_argument(      '--list-branches', action='store_true', help='List the branches of the tree and exit')
-    parser.add_argument('-t', '--type'     , default='barycentre', choices=('barycentre', 'beamspot'), type=str.lower, help='Default: %(default)s')
-    parser.add_argument(      '--label'    , default=None, help='Additional label that is appended to the folder name (i.e. PixelBaryCentreAnalyzer by default)')
-    parser.add_argument(      '--quality'  , action='store_true', help='Read results with the WithPixelQuality flag (default: %(default)s)')
-    parser.add_argument('-s', '--style'    , default='twiki', choices=('twiki', 'latex', 'csv'), type=str.lower, help='Table style for the output (default: %(default)s)')
-    parser.add_argument(      '--loglevel' , metavar='LEVEL', default='WARNING', help='Level for the python logging module. Can be either a mnemonic string like DEBUG, INFO or WARNING or an integer (lower means more verbose).')
-
-    args = parser.parse_args()
-    loglevel = args.loglevel.upper() if not args.loglevel.isdigit() else int(args.loglevel)
-    logging.basicConfig(format='%(levelname)s:%(module)s:%(funcName)s: %(message)s', level=loglevel)
+def main(args):
     logging.debug('args: %s', args)
-
 
     folder    = 'PixelBaryCentreAnalyzer' if not args.quality          else 'PixelBaryCentreAnalyzerWithPixelQuality'
     tree_name = 'PixelBarycentre'         if args.type == 'barycentre' else 'BeamSpot'
@@ -85,7 +75,22 @@ def main():
         logging.info('Reading "%s"', tree_name)
         results = rdf.AsNumpy(columns)
 
-    display_results(results, style=args.style)
+    if(args.config is None):
+        display_results(results, style=args.style)
+    else:
+        # When this script is called from the validation framework, the output is
+        # written to a list of files, one for each style, with appropriate extensions
+        fname_base = '_'.join([args.type, args.partition] + (['quality'] if args.quality else []))
+        fname_path = os.path.join(args.config['output'], fname_base) # without the ext
+        for style in args.config["styles"]:
+            if  (style == 'twiki'): ext = 'txt'
+            elif(style == 'latex'): ext = 'tex'
+            else: ext = style
+            fname = '.'.join([fname_path, ext])
+            logging.info('output in "%s"', fname)
+
+            with open(fname, 'w') as fout:
+                display_results(results, style=style, out=fout)
 
     return 0
 
@@ -103,5 +108,36 @@ def list_branches(tree, folder_name=''):
     print('\n'.join(branches))
 
 
+def parse_args():
+    parser = ArgumentParser()
+    parser.add_argument('fname'            , metavar='FILE')
+    parser.add_argument('-p', '--partition', default='BPIX', help='Tracker partition (e.g. BPIX, FPIX, BPIXLYR1, etc.). Default: %(default)s')
+    parser.add_argument('-l', '--list-content' , action='store_true', dest='list_content', help='List the contents of file and exit')
+    parser.add_argument(      '--list-branches', action='store_true', help='List the branches of the tree and exit')
+    parser.add_argument('-t', '--type'     , default='barycentre', choices=('barycentre', 'beamspot'), type=str.lower, help='Default: %(default)s')
+    parser.add_argument(      '--label'    , default=None, help='Additional label that is appended to the folder name (i.e. PixelBaryCentreAnalyzer by default)')
+    parser.add_argument(      '--quality'  , action='store_true', help='Read results with the WithPixelQuality flag (default: %(default)s)')
+    parser.add_argument('-s', '--style'    , default='twiki', choices=('twiki', 'latex', 'csv'), type=str.lower, help='Table style for the output (default: %(default)s)')
+    parser.add_argument(      '--loglevel' , metavar='LEVEL', default='WARNING', help='Level for the python logging module. Can be either a mnemonic string like DEBUG, INFO or WARNING or an integer (lower means more verbose).')
+
+    args = parser.parse_args()
+
+    # If the script is called from the validation framework, the first argument
+    # will be a JSON file with the configuration, instead of a ROOT file
+    try:
+        with open(args.fname) as f:
+            config = json.load(f)
+        args.fname = config['input']
+        args.config = config
+    except (json.JSONDecodeError, UnicodeDecodeError) as e:
+        args.config = None
+
+    return args
+
+
 if __name__ == '__main__':
-    exit(main())
+    args = parse_args()
+    loglevel = args.loglevel.upper() if not args.loglevel.isdigit() else int(args.loglevel)
+    logging.basicConfig(format='%(levelname)s:%(module)s:%(funcName)s: %(message)s', level=loglevel)
+
+    exit(main(args))

--- a/Alignment/OfflineValidation/scripts/extractBaryCentre.py
+++ b/Alignment/OfflineValidation/scripts/extractBaryCentre.py
@@ -78,7 +78,7 @@ def main():
             raise KeyError(tree_name)
 
         if(args.list_branches):
-            list_branches(tree, folder=folder)
+            list_branches(tree, folder_name=folder)
             return 0
 
         rdf = ROOT.RDataFrame(tree)

--- a/Alignment/OfflineValidation/test/testingScripts/test_unitPixBary.sh
+++ b/Alignment/OfflineValidation/test/testingScripts/test_unitPixBary.sh
@@ -4,14 +4,26 @@ function die { echo $1: status $2 ; exit $2; }
 
 runrange=376370-379254
 
-thistest="Alignment/PixelBarycentre single yaml configuration unitTest (test 1/2)"
+thistest="Alignment/PixelBarycentre single yaml configuration unitTest (test 1/4)"
 echo "TESTING $thistest..."
 pushd test_yaml/PixBary/single/testSinglePixBary/unitTest/$runrange
 ./cmsRun validation_cfg.py config=validation.json || die "Failure running $thistest" $?
 popd
 
-thistest="Alignment/PixelBarycentre single yaml configuration mp3619 (test 2/2)"
+thistest="Alignment/PixelBarycentre single yaml configuration mp3619 (test 2/4)"
 echo "TESTING $thistest..."
 pushd test_yaml/PixBary/single/testSinglePixBary/mp3619/$runrange
 ./cmsRun validation_cfg.py config=validation.json || die "Failure running $thistest" $?
+popd
+
+thistest="Alignment/PixelBarycentre extract yaml configuration unitTest (test 3/4)"
+echo "TESTING $thistest..."
+pushd test_yaml/PixBary/extract/testExtractPixBary/testSinglePixBary/unitTest/$runrange
+./run.sh || die "Failure running $thistest" $?
+popd
+
+thistest="Alignment/PixelBarycentre extract yaml configuration mp3619 (test 4/4)"
+echo "TESTING $thistest..."
+pushd test_yaml/PixBary/extract/testExtractPixBary/testSinglePixBary/mp3619/$runrange
+./run.sh || die "Failure running $thistest" $?
 popd

--- a/Alignment/OfflineValidation/test/unit_test.json
+++ b/Alignment/OfflineValidation/test/unit_test.json
@@ -331,7 +331,13 @@
                         "mp3619"
                     ]
                 }
-            }
+            },
+	    "extract": {
+		"testExtractPixBary": {
+		    "singles": ["testSinglePixBary"],
+		    "styles": ["twiki", "csv"]
+		}
+	    }
 	}
     },
     "style":{

--- a/Alignment/OfflineValidation/test/unit_test.yaml
+++ b/Alignment/OfflineValidation/test/unit_test.yaml
@@ -330,6 +330,13 @@ validations:
                 alignments:
                 - unitTest
                 - mp3619
+        extract:
+            testExtractPixBary:
+                singles:
+                    - testSinglePixBary
+                styles:
+                    - twiki
+                    - csv
 style:
     DMR:
         averaged:


### PR DESCRIPTION
#### PR description:
The `extract` job uses the output ROOT file of the corresponding `PixBary` `single` job to generate text files in various formats.
Details in the git log.
FYI @TomasKello

#### PR validation:
Unit tests for the `OfflineValidation` package have been updated and run:
```sh
cd Alignment/OfflineValidation/test
./testingScripts/validateAlignments.sh
./testingScripts/test_unitPixBary.sh
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not applicable.
