### PR TITLE
 MTD reconstruction: updated MTD track quality BDT

### DIFF
--- a/RecoMTD/TimingIDTools/interface/MTDTrackQualityMVA.h
+++ b/RecoMTD/TimingIDTools/interface/MTDTrackQualityMVA.h
@@ -10,20 +10,23 @@
 #include "CommonTools/MVAUtils/interface/TMVAEvaluator.h"
 
 #define MTDTRACKQUALITYMVA_VARS(MTDBDTVAR) \
-  MTDBDTVAR(pt)                            \
-  MTDBDTVAR(eta)                           \
-  MTDBDTVAR(phi)                           \
-  MTDBDTVAR(chi2)                          \
-  MTDBDTVAR(ndof)                          \
-  MTDBDTVAR(numberOfValidHits)             \
-  MTDBDTVAR(numberOfValidPixelBarrelHits)  \
-  MTDBDTVAR(numberOfValidPixelEndcapHits)  \
-  MTDBDTVAR(btlMatchChi2)                  \
-  MTDBDTVAR(btlMatchTimeChi2)              \
-  MTDBDTVAR(etlMatchChi2)                  \
-  MTDBDTVAR(etlMatchTimeChi2)              \
-  MTDBDTVAR(mtdt)                          \
-  MTDBDTVAR(path_len)
+  MTDBDTVAR(Track_pt)                      \
+  MTDBDTVAR(Track_eta)                     \
+  MTDBDTVAR(Track_phi)                     \
+  MTDBDTVAR(Track_dz)                      \
+  MTDBDTVAR(Track_dxy)                     \
+  MTDBDTVAR(Track_chi2)                    \
+  MTDBDTVAR(Track_ndof)                    \
+  MTDBDTVAR(Track_npixBarrelValidHits)     \
+  MTDBDTVAR(Track_npixEndcapValidHits)     \
+  MTDBDTVAR(Track_BTLchi2)                 \
+  MTDBDTVAR(Track_BTLtime_chi2)            \
+  MTDBDTVAR(Track_ETLchi2)                 \
+  MTDBDTVAR(Track_ETLtime_chi2)            \
+  MTDBDTVAR(Track_Tmtd)                    \
+  MTDBDTVAR(Track_sigmaTmtd)               \
+  MTDBDTVAR(Track_length)                  \
+  MTDBDTVAR(Track_lHitPos)
 
 #define MTDBDTVAR_ENUM(ENUM) ENUM,
 #define MTDBDTVAR_STRING(STRING) #STRING,
@@ -38,6 +41,7 @@ public:
   //---getters---
   // 4D
   float operator()(const reco::TrackRef& trk,
+                   const reco::BeamSpot& beamspot,
                    const edm::ValueMap<int>& npixBarrels,
                    const edm::ValueMap<int>& npixEndcaps,
                    const edm::ValueMap<float>& btl_chi2s,
@@ -45,7 +49,9 @@ public:
                    const edm::ValueMap<float>& etl_chi2s,
                    const edm::ValueMap<float>& etl_time_chi2s,
                    const edm::ValueMap<float>& tmtds,
-                   const edm::ValueMap<float>& trk_lengths) const;
+                   const edm::ValueMap<float>& sigmatmtds,
+                   const edm::ValueMap<float>& trk_lengths,
+                   const edm::ValueMap<float>& trk_lhitpos) const;
 
 private:
   std::vector<std::string> vars_, spec_vars_;

--- a/RecoMTD/TimingIDTools/plugins/MTDTrackQualityMVAProducer.cc
+++ b/RecoMTD/TimingIDTools/plugins/MTDTrackQualityMVAProducer.cc
@@ -37,15 +37,17 @@ private:
 
   edm::EDGetTokenT<reco::TrackCollection> tracksToken_;
   edm::EDGetTokenT<reco::TrackCollection> tracksMTDToken_;
-
   edm::EDGetTokenT<edm::ValueMap<float>> btlMatchChi2Token_;
+  edm::EDGetTokenT<reco::BeamSpot> RecBeamSpotToken_;
   edm::EDGetTokenT<edm::ValueMap<float>> btlMatchTimeChi2Token_;
   edm::EDGetTokenT<edm::ValueMap<float>> etlMatchChi2Token_;
   edm::EDGetTokenT<edm::ValueMap<float>> etlMatchTimeChi2Token_;
   edm::EDGetTokenT<edm::ValueMap<float>> mtdTimeToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> sigmamtdTimeToken_;
   edm::EDGetTokenT<edm::ValueMap<float>> pathLengthToken_;
   edm::EDGetTokenT<edm::ValueMap<int>> npixBarrelToken_;
   edm::EDGetTokenT<edm::ValueMap<int>> npixEndcapToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> outermostHitPositionToken_;
 
   MTDTrackQualityMVA mva_;
 };
@@ -53,15 +55,19 @@ private:
 MTDTrackQualityMVAProducer::MTDTrackQualityMVAProducer(const ParameterSet& iConfig)
     : tracksToken_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracksSrc"))),
       btlMatchChi2Token_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("btlMatchChi2Src"))),
+      RecBeamSpotToken_(consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("offlineBS"))),
       btlMatchTimeChi2Token_(
           consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("btlMatchTimeChi2Src"))),
       etlMatchChi2Token_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("etlMatchChi2Src"))),
       etlMatchTimeChi2Token_(
           consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("etlMatchTimeChi2Src"))),
       mtdTimeToken_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("mtdTimeSrc"))),
+      sigmamtdTimeToken_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("sigmamtdTimeSrc"))),
       pathLengthToken_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("pathLengthSrc"))),
       npixBarrelToken_(consumes<edm::ValueMap<int>>(iConfig.getParameter<edm::InputTag>("npixBarrelSrc"))),
       npixEndcapToken_(consumes<edm::ValueMap<int>>(iConfig.getParameter<edm::InputTag>("npixEndcapSrc"))),
+      outermostHitPositionToken_(
+          consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("outermostHitPositionSrc"))),
       mva_(iConfig.getParameter<edm::FileInPath>("qualityBDT_weights_file").fullPath()) {
   produces<edm::ValueMap<float>>(mvaName);
 }
@@ -79,15 +85,20 @@ void MTDTrackQualityMVAProducer::fillDescriptions(edm::ConfigurationDescriptions
   desc.add<edm::InputTag>("etlMatchTimeChi2Src", edm::InputTag("trackExtenderWithMTD", "etlMatchTimeChi2"))
       ->setComment("ETL Chi2 Matching value Map");
   desc.add<edm::InputTag>("mtdTimeSrc", edm::InputTag("trackExtenderWithMTD", "generalTracktmtd"))
-      ->setComment("MTD TIme value Map");
+      ->setComment("MTD Time value Map");
+  desc.add<edm::InputTag>("sigmamtdTimeSrc", edm::InputTag("trackExtenderWithMTD", "generalTracksigmatmtd"))
+      ->setComment("sigma MTD Time value Map");
   desc.add<edm::InputTag>("pathLengthSrc", edm::InputTag("trackExtenderWithMTD", "generalTrackPathLength"))
       ->setComment("MTD PathLength value Map");
   desc.add<edm::InputTag>("npixBarrelSrc", edm::InputTag("trackExtenderWithMTD", "npixBarrel"))
       ->setComment("# of Barrel pixel associated to refitted tracks");
   desc.add<edm::InputTag>("npixEndcapSrc", edm::InputTag("trackExtenderWithMTD", "npixEndcap"))
       ->setComment("# of Endcap pixel associated to refitted tracks");
+  desc.add<edm::InputTag>("outermostHitPositionSrc",
+                          edm::InputTag("trackExtenderWithMTD", "generalTrackOutermostHitPosition"));
+  desc.add<edm::InputTag>("offlineBS", edm::InputTag("offlineBeamSpot"));
   desc.add<edm::FileInPath>("qualityBDT_weights_file",
-                            edm::FileInPath("RecoMTD/TimingIDTools/data/clf4D_MTDquality_bo.xml"))
+                            edm::FileInPath("RecoMTD/TimingIDTools/data/BDT_nvars_17_d7.xml"))
       ->setComment("Track MTD quality BDT weights");
   descriptions.add("mtdTrackQualityMVAProducer", desc);
 }
@@ -109,6 +120,11 @@ void MTDTrackQualityMVAProducer::produce(edm::Event& ev, const edm::EventSetup& 
   ev.getByToken(tracksToken_, tracksH);
   const auto& tracks = *tracksH;
 
+  reco::BeamSpot beamSpot;
+  edm::Handle<reco::BeamSpot> BeamSpotH;
+  ev.getByToken(RecBeamSpotToken_, BeamSpotH);
+  beamSpot = *BeamSpotH;
+
   const auto& btlMatchChi2 = ev.get(btlMatchChi2Token_);
   const auto& btlMatchTimeChi2 = ev.get(btlMatchTimeChi2Token_);
   const auto& etlMatchChi2 = ev.get(etlMatchChi2Token_);
@@ -117,6 +133,8 @@ void MTDTrackQualityMVAProducer::produce(edm::Event& ev, const edm::EventSetup& 
   const auto& npixBarrel = ev.get(npixBarrelToken_);
   const auto& npixEndcap = ev.get(npixEndcapToken_);
   const auto& mtdTime = ev.get(mtdTimeToken_);
+  const auto& sigmamtdTime = ev.get(sigmamtdTimeToken_);
+  const auto& lHitPos = ev.get(outermostHitPositionToken_);
 
   std::vector<float> mvaOutRaw;
 
@@ -127,6 +145,7 @@ void MTDTrackQualityMVAProducer::produce(edm::Event& ev, const edm::EventSetup& 
       mvaOutRaw.push_back(-1.);
     else {
       mvaOutRaw.push_back(mva_(trackref,
+                               beamSpot,
                                npixBarrel,
                                npixEndcap,
                                btlMatchChi2,
@@ -134,7 +153,9 @@ void MTDTrackQualityMVAProducer::produce(edm::Event& ev, const edm::EventSetup& 
                                etlMatchChi2,
                                etlMatchTimeChi2,
                                mtdTime,
-                               pathLength));
+                               sigmamtdTime,
+                               pathLength,
+                               lHitPos));
     }
   }
   fillValueMap(ev, tracksH, mvaOutRaw, mvaName);

--- a/RecoMTD/TimingIDTools/src/MTDTrackQualityMVA.cc
+++ b/RecoMTD/TimingIDTools/src/MTDTrackQualityMVA.cc
@@ -10,9 +10,11 @@ MTDTrackQualityMVA::MTDTrackQualityMVA(std::string weights_file) {
 
   mva_ = std::make_unique<TMVAEvaluator>();
   mva_->initialize(options, method, weights_file, vars_, spec_vars_, true, false);  //use GBR, GradBoost
-}
+  //mva_->initialize(options, method, weights_file, vars_, spec_vars_, false, false);  //use TMVA
+};
 
 float MTDTrackQualityMVA::operator()(const reco::TrackRef& trk,
+                                     const reco::BeamSpot& beamspot,
                                      const edm::ValueMap<int>& npixBarrels,
                                      const edm::ValueMap<int>& npixEndcaps,
                                      const edm::ValueMap<float>& btl_chi2s,
@@ -20,30 +22,44 @@ float MTDTrackQualityMVA::operator()(const reco::TrackRef& trk,
                                      const edm::ValueMap<float>& etl_chi2s,
                                      const edm::ValueMap<float>& etl_time_chi2s,
                                      const edm::ValueMap<float>& tmtds,
-                                     const edm::ValueMap<float>& trk_lengths) const {
+                                     const edm::ValueMap<float>& sigmatmtds,
+                                     const edm::ValueMap<float>& trk_lengths,
+                                     const edm::ValueMap<float>& trk_lhitpos) const {
   std::map<std::string, float> vars;
 
-  //---training performed only above 0.5 GeV
-  constexpr float minPtForMVA = 0.5;
-  if (trk->pt() < minPtForMVA)
+  static constexpr double etacutREC_ = 3.;   // |eta| < 3
+  static constexpr double etacutBTL_ = 1.5;  // |eta| < 1.5 for BTL
+  static constexpr double pTcutBTL_ = 0.7;   // PT > 0.7 GeV
+  static constexpr double pTcutETL_ = 0.2;   // PT > 0.2 GeV
+
+  //---training performed only for the specified cuts
+  if (std::abs(trk->eta()) > etacutREC_)  // max eta cut
+    return -1;
+  if (std::abs(trk->eta()) <= etacutBTL_ && trk->pt() < pTcutBTL_)  // min PT cut for BTL
+    return -1;
+  if (std::abs(trk->eta()) > etacutBTL_ && trk->pt() < pTcutETL_)  // min PT cut for ETL
     return -1;
 
   //---training performed only for tracks with MTD hits
   if (tmtds[trk] > 0) {
-    vars.emplace(vars_[int(VarID::pt)], trk->pt());
-    vars.emplace(vars_[int(VarID::eta)], trk->eta());
-    vars.emplace(vars_[int(VarID::phi)], trk->phi());
-    vars.emplace(vars_[int(VarID::chi2)], trk->chi2());
-    vars.emplace(vars_[int(VarID::ndof)], trk->ndof());
-    vars.emplace(vars_[int(VarID::numberOfValidHits)], trk->numberOfValidHits());
-    vars.emplace(vars_[int(VarID::numberOfValidPixelBarrelHits)], npixBarrels[trk]);
-    vars.emplace(vars_[int(VarID::numberOfValidPixelEndcapHits)], npixEndcaps[trk]);
-    vars.emplace(vars_[int(VarID::btlMatchChi2)], btl_chi2s.contains(trk.id()) ? btl_chi2s[trk] : -1);
-    vars.emplace(vars_[int(VarID::btlMatchTimeChi2)], btl_time_chi2s.contains(trk.id()) ? btl_time_chi2s[trk] : -1);
-    vars.emplace(vars_[int(VarID::etlMatchChi2)], etl_chi2s.contains(trk.id()) ? etl_chi2s[trk] : -1);
-    vars.emplace(vars_[int(VarID::etlMatchTimeChi2)], etl_time_chi2s.contains(trk.id()) ? etl_time_chi2s[trk] : -1);
-    vars.emplace(vars_[int(VarID::mtdt)], tmtds[trk]);
-    vars.emplace(vars_[int(VarID::path_len)], trk_lengths[trk]);
+    vars.emplace(vars_[int(VarID::Track_pt)], trk->pt());
+    vars.emplace(vars_[int(VarID::Track_eta)], trk->eta());
+    vars.emplace(vars_[int(VarID::Track_phi)], trk->phi());
+    vars.emplace(vars_[int(VarID::Track_dz)], trk->dz(beamspot.position()));
+    vars.emplace(vars_[int(VarID::Track_dxy)], trk->dxy(beamspot.position()));
+    vars.emplace(vars_[int(VarID::Track_chi2)], trk->chi2());
+    vars.emplace(vars_[int(VarID::Track_ndof)], trk->ndof());
+    vars.emplace(vars_[int(VarID::Track_npixBarrelValidHits)], npixBarrels[trk]);
+    vars.emplace(vars_[int(VarID::Track_npixEndcapValidHits)], npixEndcaps[trk]);
+    vars.emplace(vars_[int(VarID::Track_BTLchi2)], btl_chi2s.contains(trk.id()) ? btl_chi2s[trk] : -1);
+    vars.emplace(vars_[int(VarID::Track_BTLtime_chi2)], btl_time_chi2s.contains(trk.id()) ? btl_time_chi2s[trk] : -1);
+    vars.emplace(vars_[int(VarID::Track_ETLchi2)], etl_chi2s.contains(trk.id()) ? etl_chi2s[trk] : -1);
+    vars.emplace(vars_[int(VarID::Track_ETLtime_chi2)], etl_time_chi2s.contains(trk.id()) ? etl_time_chi2s[trk] : -1);
+    vars.emplace(vars_[int(VarID::Track_Tmtd)], tmtds[trk]);
+    vars.emplace(vars_[int(VarID::Track_sigmaTmtd)], sigmatmtds[trk]);
+    vars.emplace(vars_[int(VarID::Track_length)], trk_lengths[trk]);
+    vars.emplace(vars_[int(VarID::Track_lHitPos)], trk_lhitpos[trk]);
+
     return 1. / (1 + sqrt(2 / (1 + mva_->evaluate(vars, false)) - 1));  //return values between 0-1 (probability)
   } else
     return -1;


### PR DESCRIPTION
#### PR description:

Updated the MTDTrackQualityMVA code with a new and improved BDT model. The new BDT has a few extra input parameters and was trained on a dataset with updated pT cuts. The BDT part of `MVATrainingNtuple.cc` has been rewritten to be more similar to `Validation/MtdValidation/plugins/MtdTracksValidation.cc` and to output a few additional track parameters. The training and performance of the BDT is described in this [presentation](https://indico.cern.ch/event/1565764/#4-status-of-the-track-mtd-matc).

The updated BDT code uses a new [model file](https://github.com/cms-data/RecoMTD-TimingIDTools/pull/2) that is is expected to be located at `RecoMTD/TimingIDTools/data`.

#### PR validation:

This code has been tested using
`runTheMatrix.py -l limited -i all --ibeos`

There were no errors from the MTDTrackQualityMVA module, however some of the analysis workflows couldn't access some of the required root files. I'm not sure if that is an issue because it is caused by unavailable datasets and not the code itself. The file read errors contained `[3011] No servers are available to read the file`.

The BDT was also tested using the `29834.0_TTbar_14TeV+Run4D110PU` workflow where everything worked as expected.